### PR TITLE
Adapt to changes in equation compiler:

### DIFF
--- a/data/seq/computation.lean
+++ b/data/seq/computation.lean
@@ -510,8 +510,8 @@ begin
          ∃ s, c1 = bind s (return ∘ f) ∧ c2 = map f s),
   { intros c1 c2 h,
     exact match c1, c2, h with
-    | c, ._, or.inl rfl := by cases destruct c with b cb; simp
-    | ._, ._, or.inr ⟨s, rfl, rfl⟩ := begin
+    | _, _, or.inl (eq.refl c) := begin cases destruct c with b cb; simp end
+    | _, _, or.inr ⟨s, rfl, rfl⟩ := begin
       apply cases_on s; intros s; simp,
       exact or.inr ⟨s, rfl, rfl⟩
     end end },
@@ -528,7 +528,7 @@ begin
          ∃ s, c1 = bind (bind s f) g ∧ c2 = bind s (λ (x : α), bind (f x) g)),
   { intros c1 c2 h,
     exact match c1, c2, h with
-    | c, ._, or.inl rfl := by cases destruct c with b cb; simp
+    | _, _, or.inl (eq.refl c) := by cases destruct c with b cb; simp
     | ._, ._, or.inr ⟨s, rfl, rfl⟩ := begin
       apply cases_on s; intros s; simp,
       { generalize : f s = fs,

--- a/data/seq/seq.lean
+++ b/data/seq/seq.lean
@@ -427,7 +427,7 @@ begin
       s2 = cons a (append s (join S))) _ (or.inr ⟨a, s, S, rfl, rfl⟩),
   intros s1 s2 h,
   exact match s1, s2, h with
-  | ._, s, (or.inl rfl) := begin
+  | _, _, (or.inl $ eq.refl s) := begin
       apply cases_on s, { trivial },
       { intros x s, rw [destruct_cons], exact ⟨rfl, or.inl rfl⟩ }
     end

--- a/data/seq/wseq.lean
+++ b/data/seq/wseq.lean
@@ -430,8 +430,8 @@ begin
   refine computation.eq_of_bisim (λc1 c2, c1 = c2 ∨
     ∃ c, c1 = destruct (flatten c) ∧ c2 = computation.bind c destruct) _ (or.inr ⟨c, rfl, rfl⟩),
   intros c1 c2 h, exact match c1, c2, h with
-  | c, ._, (or.inl rfl) := by cases c.destruct; simp
-  | ._, ._, (or.inr ⟨c, rfl, rfl⟩) := begin
+  | _, _, (or.inl $ eq.refl c) := by cases c.destruct; simp
+  | _, _, (or.inr ⟨c, rfl, rfl⟩) := begin
     apply c.cases_on (λa, _) (λc', _); repeat {simp},
     { cases (destruct a).destruct; simp },
     { exact or.inr ⟨c', rfl, rfl⟩ }
@@ -1042,8 +1042,8 @@ begin
   apply eq_of_bisim (λ c1 c2, c1 = c2 ∨ ∃ S, c1 = destruct (join S) ∧
     c2 = (destruct S).bind destruct_join.aux) _ (or.inr ⟨S, rfl, rfl⟩),
   intros c1 c2 h, exact match c1, c2, h with
-  | c, ._, or.inl rfl := by cases c.destruct; simp
-  | ._, ._, or.inr ⟨S, rfl, rfl⟩ := begin
+  | _, _, (or.inl $ eq.refl c) := by cases c.destruct; simp
+  | _, _, or.inr ⟨S, rfl, rfl⟩ := begin
     apply S.cases_on _ (λ s S, _) (λ S, _); simp; simp,
     { refine or.inr ⟨S, rfl, rfl⟩ }
   end end

--- a/order/filter.lean
+++ b/order/filter.lean
@@ -516,11 +516,11 @@ le_antisymm
 
 lemma le_map_vmap' {f : filter β} {m : α → β} {s : set β}
   (hs : s ∈ f.sets) (hm : ∀b∈s, ∃a, m a = b) : f ≤ map m (vmap m f) :=
-assume t' ⟨t, ht, (sub : ∀x, m x ∈ t → m x ∈ t')⟩,
+assume t' ⟨t, ht, (sub : m ⁻¹' t ⊆ m ⁻¹' t')⟩,
 f.upwards_sets (inter_mem_sets ht hs) $
   assume x ⟨hxt, hxs⟩,
   let ⟨y, (hy : m y = x)⟩ := hm x hxs in
-  hy ▸ sub _ (show m y ∈ t, from hy.symm ▸ hxt)
+  hy ▸ sub (show m y ∈ t, from hy.symm ▸ hxt)
 
 lemma le_map_vmap {f : filter β} {m : α → β} (hm : ∀x, ∃y, m y = x) : f ≤ map m (vmap m f) :=
 le_map_vmap' univ_mem_sets (assume b _, hm b)

--- a/theories/set_theory.lean
+++ b/theories/set_theory.lean
@@ -204,7 +204,7 @@ namespace classical
   noncomputable def all_definable : Π {n} (F : arity Set.{u} n), definable n F
   | 0     F := let p := @quotient.exists_rep pSet _ F in
                definable.eq_mk ⟨some p, equiv.refl _⟩ (some_spec p)
-  | (n+1) (F : Set → arity Set.{u} n) := begin
+  | (n+1) (F : arity Set.{u} (n + 1)) := begin
       have I := λx, (all_definable (F x)),
       refine definable.eq_mk ⟨λx:pSet, (@definable.resp _ _ (I ⟦x⟧)).1, _⟩ _,
       { dsimp[arity.equiv],
@@ -295,7 +295,7 @@ namespace Set
   show pSet.mem ∅ pSet.omega, from ⟨⟨0⟩, equiv.refl _⟩
 
   @[simp] theorem omega_succ {n : Set.{u}} : n ∈ omega.{u} → insert n n ∈ omega.{u} :=
-  quotient.induction_on n (λx ⟨⟨n⟩, (h : x ≈ of_nat n)⟩, ⟨⟨n+1⟩,
+  quotient.induction_on n (λx ⟨⟨n⟩, h⟩, ⟨⟨n+1⟩,
     have Set.insert ⟦x⟧ ⟦x⟧ = Set.insert ⟦of_nat n⟧ ⟦of_nat n⟧, by rw (@quotient.sound pSet _ _ _ h),
     quotient.exact this⟩)
 

--- a/topology/continuity.lean
+++ b/topology/continuity.lean
@@ -27,7 +27,7 @@ set.ext $ assume x, ⟨assume ⟨x, hx, heq⟩, heq ▸ ⟨hx, mem_image_of_mem 
 lemma subtype.val_image {p : α → Prop} {s : set (subtype p)} :
   subtype.val '' s = {x | ∃h : p x, (⟨x, h⟩ : subtype p) ∈ s} :=
 set.ext $ assume a,
-⟨assume ⟨⟨a', ha'⟩, in_s, (h_eq : a' = a)⟩, h_eq ▸ ⟨ha', in_s⟩,
+⟨assume ⟨⟨a', ha'⟩, in_s, h_eq⟩, h_eq ▸ ⟨ha', in_s⟩,
   assume ⟨ha, in_s⟩, ⟨⟨a, ha⟩, in_s, rfl⟩⟩
 
 @[simp] lemma univ_prod_univ : set.prod univ univ = (univ : set (α×β)) :=

--- a/topology/real.lean
+++ b/topology/real.lean
@@ -136,10 +136,10 @@ uniform_space.of_core { uniform_space.core .
       exact calc zero_nhd.lift' f ≤
           zero_nhd.lift' (image (λp:ℚ×ℚ, p.1 + p.2) ∘ (λs, set.prod s s)) :
             lift'_mono' $
-            assume s hs r ⟨⟨p₁, p₂⟩, ⟨q, (h₁ : p₁ - q ∈ s), (h₂ : q - p₂ ∈ s)⟩, (h : p₁ - p₂ = r)⟩,
+            assume s hs r ⟨⟨p₁, p₂⟩, ⟨q, h₁, h₂⟩, h⟩,
             ⟨⟨p₁ - q, q - p₂⟩, ⟨h₁, h₂⟩,
               calc (p₁ - q) + (q - p₂) = p₁ - p₂ + (q - q) : by simp [-add_right_neg]
-                ... = r : by simp [h]⟩
+                ... = r : by simp [*] at *⟩
         ... = map (λp:ℚ×ℚ, p.1 + p.2) (filter.prod zero_nhd zero_nhd) :
           by rw [←map_lift'_eq, prod_same_eq]; exact monotone_prod monotone_id monotone_id
         ... ≤ zero_nhd : tendsto_add_rat_zero,
@@ -935,7 +935,7 @@ have 0 < i / 2, from div_pos_of_pos_of_pos hi zero_lt_two,
 have u ∈ (nhds r).sets, from mem_nhds_sets hu hru,
 dense_embedding_of_rat.tendsto_ext $ (nhds r).upwards_sets this $
   assume r hr,
-  let ⟨a, (ha : closure (of_rat '' {a' : ℚ | abs (a - a') < i / 2}) ∈ (nhds r).sets)⟩ :=
+  let ⟨a, ha⟩ :=
     closure_image_mem_nhds_of_uniform_embedding r
       uniform_embedding_of_rat dense_embedding_of_rat $ mem_uniformity_rat ‹0 < i / 2› in
   have hia : i / 2 < abs a,

--- a/topology/uniform_space.lean
+++ b/topology/uniform_space.lean
@@ -58,7 +58,9 @@ lemma prod_mk_mem_comp_rel {a b c : α} {s t : set (α×α)} (h₁ : (a, c) ∈ 
 ⟨c, h₁, h₂⟩
 
 @[simp] lemma id_comp_rel {r : set (α×α)} : comp_rel id_rel r = r :=
-set.ext $ assume ⟨a, b⟩, ⟨assume ⟨a', (heq : a = a'), ha'⟩, heq.symm ▸ ha', assume ha, ⟨a, rfl, ha⟩⟩
+set.ext $ assume ⟨a, b⟩, ⟨assume ⟨a', heq, ha'⟩, 
+  (show a' = a, from heq.symm) ▸ ha',
+  assume ha, ⟨a, rfl, ha⟩⟩
 
 /-- This core description of a uniform space is outside of the type class hierarchy. It is useful
   for constructions of uniform spaces, when the topology is derived from the uniform space. -/
@@ -440,7 +442,8 @@ lemma closure_image_mem_nhds_of_uniform_embedding
 ∃a, closure (e '' {a' | (a, a') ∈ s}) ∈ (nhds b).sets :=
 have s ∈ (vmap (λp:α×α, (e p.1, e p.2)) $ uniformity).sets,
   from he₁.right.symm ▸ hs,
-let ⟨t₁, ht₁u, (ht₁ : ∀p:α×α, (e p.1, e p.2) ∈ t₁ → p ∈ s)⟩ := this in
+let ⟨t₁, ht₁u, ht₁⟩ := this in
+have ht₁ : ∀p:α×α, (e p.1, e p.2) ∈ t₁ → p ∈ s, from ht₁,
 let ⟨t₂, ht₂u, ht₂s, ht₂c⟩ := comp_symm_of_uniformity ht₁u in
 let ⟨t, htu, hts, htc⟩ := comp_symm_of_uniformity ht₂u in
 have preimage e {b' | (b, b') ∈ t₂} ∈ (vmap e $ nhds b).sets,
@@ -796,7 +799,7 @@ have cauchy g, from
   have hg : set.prod (p (preimage prod.swap s₁) t) (p s₂ t) ∈ (filter.prod g g).sets,
     from @prod_mem_prod α α _ _ g g hg₁ hg₂,
   (filter.prod g g).upwards_sets hg
-    (assume ⟨a, b⟩ ⟨⟨c₁, c₁t, (hc₁ : (a, c₁) ∈ s₁)⟩, ⟨c₂, c₂t, (hc₂ : (c₂, b) ∈ s₂)⟩⟩,
+    (assume ⟨a, b⟩ ⟨⟨c₁, c₁t, hc₁⟩, ⟨c₂, c₂t, hc₂⟩⟩,
       have (c₁, c₂) ∈ set.prod t t, from ⟨c₁t, c₂t⟩,
       comp_s₁ $ prod_mk_mem_comp_rel hc₁ $
       comp_s₂ $ prod_mk_mem_comp_rel (prod_t this) hc₂)⟩,
@@ -947,7 +950,7 @@ lim_spec $ uniformly_extend_exists h_e h_dense h_f
 lemma uniform_continuous_uniformly_extend [cγ : complete_space γ] [sγ : separated γ] :
   uniform_continuous ψ :=
 assume d hd,
-let ⟨s, hs, (hs_comp : comp_rel s (comp_rel s s) ⊆ d)⟩ := (mem_lift'_iff $
+let ⟨s, hs, hs_comp⟩ := (mem_lift'_iff $
   monotone_comp_rel monotone_id $ monotone_comp_rel monotone_id monotone_id).mp (comp_le_uniformity3 hd) in
 have h_pnt : ∀{a m}, m ∈ (nhds a).sets → ∃c, c ∈ f '' preimage e m ∧ (c, ψ a) ∈ s ∧ (ψ a, c) ∈ s,
   from assume a m hm,
@@ -961,7 +964,7 @@ have preimage (λp:β×β, (f p.1, f p.2)) s ∈ (@uniformity β _).sets,
   from h_f hs,
 have preimage (λp:β×β, (f p.1, f p.2)) s ∈ (vmap (λx:β×β, (e x.1, e x.2)) uniformity).sets,
   by rwa [h_e.right.symm] at this,
-let ⟨t, ht, (ts : ∀p:(β×β), (e p.1, e p.2) ∈ t → (f p.1, f p.2) ∈ s)⟩ := this in
+let ⟨t, ht, ts⟩ := this in
 show preimage (λp:(α×α), (ψ p.1, ψ p.2)) d ∈ uniformity.sets,
   from (@uniformity α _).upwards_sets (interior_mem_uniformity ht) $
   assume ⟨x₁, x₂⟩ hx_t,


### PR DESCRIPTION
* Names are not necessary propagated when `rfl` is eliminated on two
  variables. Replace `rfl` by `eq.refl n`.

* it looks like that delta, beta, eta conversion rules are applied later now,
  so some statements of the form `assume <x, (h : t), ...` do not work anymore.

* there is still a problem in `data/list/perm.lean`