### PR TITLE
chore(*): use `induction generalizing`

### DIFF
--- a/data/int/basic.lean
+++ b/data/int/basic.lean
@@ -487,16 +487,16 @@ end int
 
 namespace int
 
-theorem of_nat_add_neg_succ_of_nat_of_lt {m n : ℕ} (h : m < succ n) : of_nat m + -[1+n] = -[1+ n - m] := 
+theorem of_nat_add_neg_succ_of_nat_of_lt {m n : ℕ} (h : m < succ n) : of_nat m + -[1+n] = -[1+ n - m] :=
 begin
- change sub_nat_nat _ _ = _, 
- have h' : succ n - m = succ (n - m), 
+ change sub_nat_nat _ _ = _,
+ have h' : succ n - m = succ (n - m),
  apply succ_sub,
  apply le_of_lt_succ h,
  simp [*, sub_nat_nat]
 end
 
-theorem of_nat_add_neg_succ_of_nat_of_ge {m n : ℕ} (h : m ≥ succ n) : of_nat m + -[1+n] = of_nat (m - succ n) := 
+theorem of_nat_add_neg_succ_of_nat_of_ge {m n : ℕ} (h : m ≥ succ n) : of_nat m + -[1+n] = of_nat (m - succ n) :=
 begin
  change sub_nat_nat _ _ = _,
  have h' : succ n - m = 0,
@@ -697,7 +697,7 @@ by rw [← bitwise_xor, bitwise_bit]
 @[simp] lemma test_bit_bitwise (f : bool → bool → bool) (m n k) :
   test_bit (bitwise f m n) k = f (test_bit m k) (test_bit n k) :=
 begin
-  revert m n; induction k with k IH; intros m n;
+  induction k with k IH generalizing m n;
   apply bit_cases_on m; intros a m';
   apply bit_cases_on n; intros b n';
   rw bitwise_bit,

--- a/data/list/basic.lean
+++ b/data/list/basic.lean
@@ -34,10 +34,10 @@ theorem append_ne_nil_of_ne_nil_right (s t : list α) : t ≠ [] → s ++ t ≠ 
 by induction s; intros; contradiction
 
 theorem append_foldl (f : α → β → α) (a : α) (s t : list β) : foldl f a (s ++ t) = foldl f (foldl f a s) t :=
-by {revert a, induction s with b s H, exact λ_, rfl, intros, simp [foldl], rw H _}
+by {induction s with b s H generalizing a, refl, simp [foldl], rw H _}
 
 theorem append_foldr (f : α → β → β) (a : β) (s t : list α) : foldr f a (s ++ t) = foldr f (foldr f a t) s :=
-by {revert a, induction s with b s H, exact λ_, rfl, intros, simp [foldr], rw H _}
+by {induction s with b s H generalizing a, refl, simp [foldr], rw H _}
 
 /- repeat take drop -/
 

--- a/data/list/comb.lean
+++ b/data/list/comb.lean
@@ -341,7 +341,7 @@ theorem eq_of_mem_map_pair₁  {a₁ a : α} {b₁ : β} {l : list β} :
   (a₁, b₁) ∈ map (λ b, (a, b)) l → a₁ = a :=
 assume ain,
 have fst (a₁, b₁) ∈ map fst (map (λ b, (a, b)) l), from mem_map fst ain,
-have a₁ ∈ map (λb, a) l, begin revert this, rw [map_map], intro this, assumption end,
+have a₁ ∈ map (λb, a) l, begin rw map_map at this, assumption end,
 eq_of_map_const this
 
 theorem mem_of_mem_map_pair₁ {a₁ a : α} {b₁ : β} {l : list β} :

--- a/data/num/lemmas.lean
+++ b/data/num/lemmas.lean
@@ -380,10 +380,10 @@ namespace num
       rw [fn0, nat.binary_rec_eq, nat.binary_rec_zero, ←h],
       cases g tt ff; refl,
       apply nat.bitwise_bit_aux gff },
-    { rw fnn, revert n,
+    { rw fnn,
       have : ∀b (n : pos_num), cond b ↑n 0 = ↑(cond b n 0 : num) :=
         by intros; cases b; refl,
-      induction m with m IH m IH; intro n; cases n with n n,
+      induction m with m IH m IH generalizing n; cases n with n n,
       any_goals { change one with 1 },
       any_goals { change pos 1 with 1 },
       any_goals { change pos_num.bit0 with pos_num.bit ff },
@@ -421,7 +421,7 @@ namespace num
   @[simp] theorem shiftr_to_nat (m n) : (shiftr m n : ℕ) = nat.shiftr m n :=
   begin
     cases m with m; dunfold shiftr, {symmetry, apply nat.zero_shiftr},
-    revert m; induction n with n IH; intro m, {cases m; refl},
+    induction n with n IH generalizing m, {cases m; refl},
     cases m with m m; dunfold pos_num.shiftr,
     { rw [nat.shiftr_eq_div_pow], symmetry, apply nat.div_eq_of_lt,
       exact @nat.pow_lt_pow_of_lt_right 2 dec_trivial 0 (n+1) (nat.succ_pos _) },
@@ -443,7 +443,7 @@ namespace num
   begin
     cases m with m; unfold test_bit nat.test_bit,
     { change (zero : nat) with 0, rw nat.zero_shiftr, refl },
-    revert m; induction n with n IH; intro m;
+    induction n with n IH generalizing m;
     cases m; dunfold pos_num.test_bit, {refl},
     { exact (nat.bodd_bit _ _).symm },
     { exact (nat.bodd_bit _ _).symm },

--- a/data/seq/computation.lean
+++ b/data/seq/computation.lean
@@ -574,7 +574,7 @@ theorem of_results_bind {s : computation α} {f : α → computation β} {b k} :
   results (bind s f) b k →
   ∃ a m n, results s a m ∧ results (f a) b n ∧ k = n + m :=
 begin
-  revert s, induction k with n IH; intro s;
+  induction k with n IH generalizing s;
   apply cases_on s (λ a, _) (λ s', _); intro e,
   { simp [thinkN] at e, refine ⟨a, _, _, results_ret _, e, rfl⟩ },
   { have := congr_arg head (eq_thinkN e), contradiction },

--- a/data/seq/parallel.lean
+++ b/data/seq/parallel.lean
@@ -48,7 +48,7 @@ begin
   intros l S c m T, revert l S,
   apply @terminates_rec_on _ _ c T _ _,
   { intros a l S m, apply lem1,
-    revert m, induction l with c l IH; intro; simp at m, { contradiction },
+    induction l with c l IH generalizing m; simp at m, { contradiction },
     cases m with e m,
     { rw ←e, simp [parallel.aux2],
       cases list.foldr parallel.aux2._match_1 (sum.inr list.nil) l with a' ls,
@@ -58,8 +58,8 @@ begin
       rw e, exact ⟨a', rfl⟩ } },
   { intros s IH l S m,
     have H1 : ∀ l', parallel.aux2 l = sum.inr l' → s ∈ l',
-    { revert m, induction l with c l IH';
-      intros m l' e'; simp at m, { contradiction },
+    { induction l with c l IH' generalizing m;
+      intros l' e'; simp at m, { contradiction },
       cases m with e m; simp [parallel.aux2] at e',
       { rw ←e at e',
         cases list.foldr parallel.aux2._match_1 (sum.inr list.nil) l with a' ls;

--- a/data/seq/seq.lean
+++ b/data/seq/seq.lean
@@ -115,7 +115,7 @@ theorem mem_rec_on {C : seq α → Prop} {a s} (M : a ∈ s)
   (h1 : ∀ b s', (a = b ∨ C s') → C (cons b s')) : C s :=
 begin
   cases M with k e, unfold stream.nth at e,
-  revert s, induction k with k IH; intros s e,
+  induction k with k IH generalizing s,
   { have TH : s = cons a (tail s),
     { apply destruct_eq_cons,
       unfold destruct nth has_map.map, rw ←e, refl },
@@ -164,7 +164,7 @@ end
 
 def of_list (l : list α) : seq α :=
 ⟨list.nth l, λn h, begin
-  revert n, induction l with a l IH; intros, refl,
+  induction l with a l IH generalizing n, refl,
   dsimp [list.nth], cases n with n; dsimp [list.nth] at h,
   { contradiction },
   { apply IH _ h }
@@ -497,7 +497,7 @@ theorem nth_tail : ∀ (s : seq α) n, nth (tail s) n = nth s (n + 1)
 
 @[simp] theorem head_dropn (s : seq α) (n) : head (drop s n) = nth s n :=
 begin
-  revert s, induction n with n IH; intro, { refl },
+  induction n with n IH generalizing s, { refl },
   rw [nat.succ_eq_add_one, ←nth_tail, ←dropn_tail], apply IH
 end
 


### PR DESCRIPTION
I was looking through mathlib to replace the `revert h, dsimp` zeta-reduction workaround by `dsimp [h]`, but I didn't find any instances of the workaround.  🙁 

Instead, when grepping for `revert`, I found a few places where we can now use `induction foo generalizing bar`.