### PR TITLE
feat(.travis.yml): export and run leanchecker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ install:
 
 script:
   - leanpkg test
+  - lean --recursive --export=mathlib.txt
+  - leanchecker mathlib.txt


### PR DESCRIPTION
This should detect multiple definitions with the same name as in #27.

Let's wait whether this actually works on Travis.