### PR TITLE
feat(data/list) update_nth_eq_nil, append_eq_nil

### DIFF
--- a/data/list/basic.lean
+++ b/data/list/basic.lean
@@ -797,23 +797,23 @@ by rw [update_nth_eq_modify_nth, modify_nth_eq_take_cons_drop _ h]
 
 @[simp] lemma update_nth_eq_nil {β} (l : list β) (n : ℕ) (a : β) : l.update_nth n a = [] ↔ l = [] :=
 begin
-split,
-show list.update_nth l n a = list.nil → l = list.nil, 
-{
-  induction l,
-  case list.nil {
-    intros,
-    assumption
+  split,
+  show list.update_nth l n a = [] → l = [], 
+  {
+    induction l,
+    case list.nil {
+      intros,
+      assumption
+    },
+    case list.cons {
+      induction n,
+      all_goals { contradiction }
+    }
   },
-  case list.cons {
-    induction n,
-    all_goals { contradiction }
+  -- show l = [] → list.update_nth l n a = [], -- TODO this show mysteriously fails?
+  {
+    intros, simp *, refl
   }
-},
--- show l = list.nil → list.update_nth l n a = list.nil,
-{
-  intros, simp *, refl
-}
 end
 
 /- take_while -/
@@ -1493,20 +1493,16 @@ theorem infix_of_mem_join : ∀ {L : list (list α)} {l}, l ∈ L → l <:+: joi
 
 @[simp] lemma append_eq_nil {β} (p q : list β) : (p ++ q) = [] ↔ p = [] ∧ q = [] :=
 begin
-split,
-show (p ++ q) = [] → p = [] ∧ q = [],
-{
-  intro h,
   split,
-  apply eq_nil_of_prefix_nil, rw ← h, simp, 
-  apply eq_nil_of_suffix_nil, rw ← h, simp,
-},
-show p = [] ∧ q = [] → p ++ q = [],
-{
-  intros h,
-  rw [h.left, h.right],
-  refl,
-}
+  show (p ++ q) = [] → p = [] ∧ q = [],
+  {
+    intro h,
+    split, 
+    { apply eq_nil_of_prefix_nil, rw ← h, simp },
+    { apply eq_nil_of_suffix_nil, rw ← h, simp }
+  },
+  show p = [] ∧ q = [] → p ++ q = [],
+  simp {contextual:=tt}
 end
 
 /-- `inits l` is the list of initial segments of `l`.

--- a/data/list/basic.lean
+++ b/data/list/basic.lean
@@ -795,10 +795,10 @@ theorem update_nth_eq_take_cons_drop (a : α) {n l} (h : n < length l) :
   update_nth l n a = take n l ++ a :: drop (n+1) l :=
 by rw [update_nth_eq_modify_nth, modify_nth_eq_take_cons_drop _ h]
 
-@[simp] lemma update_nth_eq_nil {β} (l : list β) (n : ℕ) (a : β) : l.update_nth n a = [] ↔ l = [] :=
+@[simp] lemma update_nth_eq_nil {β} (l : list β) (n : ℕ) (b : β) : l.update_nth n b = [] ↔ l = [] :=
 begin
   split,
-  show list.update_nth l n a = [] → l = [], 
+  show list.update_nth l n b = [] → l = [], 
   {
     induction l,
     case list.nil {
@@ -810,7 +810,7 @@ begin
       all_goals { contradiction }
     }
   },
-  -- show l = [] → list.update_nth l n a = [], -- TODO this show mysteriously fails?
+  show l = [] → list.update_nth l n b = [],
   {
     intros, simp *, refl
   }

--- a/data/list/basic.lean
+++ b/data/list/basic.lean
@@ -795,6 +795,27 @@ theorem update_nth_eq_take_cons_drop (a : α) {n l} (h : n < length l) :
   update_nth l n a = take n l ++ a :: drop (n+1) l :=
 by rw [update_nth_eq_modify_nth, modify_nth_eq_take_cons_drop _ h]
 
+@[simp] lemma update_nth_eq_nil {β} (l : list β) (n : ℕ) (a : β) : l.update_nth n a = [] ↔ l = [] :=
+begin
+split,
+show list.update_nth l n a = list.nil → l = list.nil, 
+{
+  induction l,
+  case list.nil {
+    intros,
+    assumption
+  },
+  case list.cons {
+    induction n,
+    all_goals { contradiction }
+  }
+},
+-- show l = list.nil → list.update_nth l n a = list.nil,
+{
+  intros, simp *, refl
+}
+end
+
 /- take_while -/
 
 /-- Get the longest initial segment of the list whose members all satisfy `p`.
@@ -1469,6 +1490,24 @@ theorem infix_of_mem_join : ∀ {L : list (list α)} {l}, l ∈ L → l <:+: joi
 | (_  :: L) l (or.inl rfl) := infix_append [] _ _
 | (l' :: L) l (or.inr h)   :=
   is_infix.trans (infix_of_mem_join h) $ infix_of_suffix $ suffix_append _ _
+
+@[simp] lemma append_eq_nil {β} (p q : list β) : (p ++ q) = [] ↔ p = [] ∧ q = [] :=
+begin
+split,
+show (p ++ q) = [] → p = [] ∧ q = [],
+{
+  intro h,
+  split,
+  apply eq_nil_of_prefix_nil, rw ← h, simp, 
+  apply eq_nil_of_suffix_nil, rw ← h, simp,
+},
+show p = [] ∧ q = [] → p ++ q = [],
+{
+  intros h,
+  rw [h.left, h.right],
+  refl,
+}
+end
 
 /-- `inits l` is the list of initial segments of `l`.
   `inits [1, 2, 3] = [[], [1], [1, 2], [1, 2, 3]]` -/


### PR DESCRIPTION
Adding two lemmas I needed. Both are useful when one has to preserve the invariant of a list being non-empty.

(`append_eq_nil` belongs higher up in the file, but it was convenient to use `eq_nil_of_prefix_nil`.)