### PR TITLE
[WIP] Categories, unbundled

### DIFF
--- a/categories/category.lean
+++ b/categories/category.lean
@@ -1,0 +1,35 @@
+-- Copyright (c) 2017 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Stephen Morgan, Scott Morrison
+
+namespace categories
+
+meta def obviously : tactic unit := `[all_goals { sorry }]  -- This is a placeholder for automation.
+
+universes u
+
+class category (Obj : Type u) :=
+  (Hom : Obj → Obj → Type u)
+  (identity : Π X : Obj, Hom X X)
+  (compose  : Π {X Y Z : Obj}, Hom X Y → Hom Y Z → Hom X Z)
+  (left_identity  : ∀ {X Y : Obj} (f : Hom X Y), compose (identity X) f = f . obviously)
+  (right_identity : ∀ {X Y : Obj} (f : Hom X Y), compose f (identity Y) = f . obviously)
+  (associativity  : ∀ {W X Y Z : Obj} (f : Hom W X) (g : Hom X Y) (h : Hom Y Z),
+    compose (compose f g) h = compose f (compose g h) . obviously)
+
+variable {C : Type u}
+variables {W X Y Z : C}
+variable [category C]
+
+def Hom : C → C → Type u := category.Hom
+
+notation `𝟙` := category.identity
+infixr ` >> `:80 := category.compose
+
+@[simp] def category.left_identity_lemma (f : Hom X Y) : 𝟙 X >> f = f := by rw category.left_identity
+@[simp] def category.right_identity_lemma (f : Hom X Y) : f >> 𝟙 Y = f := by rw category.right_identity
+@[simp,ematch] def category.associativity_lemma (f : Hom W X) (g : Hom X Y) (h : Hom Y Z) : (f >> g) >> h = f >> (g >> h) := by rw category.associativity
+
+@[ematch] lemma category.identity_idempotent (X : C) : 𝟙 X >> 𝟙 X = 𝟙 X := by simp
+
+end categories

--- a/categories/examples/groups/default.lean
+++ b/categories/examples/groups/default.lean
@@ -1,0 +1,86 @@
+-- Copyright (c) 2018 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Scott Morrison
+import ...functor
+import ...types
+import tactic.finish
+import algebra.group
+
+namespace categories.examples.groups
+
+
+open categories
+
+universe u₁
+
+definition Group := Σ α : Type u₁, group α
+
+instance group_from_Group (G : Group) : group G.1 := G.2
+
+meta def is_group_hom_obviously := `[unfold is_group_hom, obviously]
+
+structure GroupHomomorphism (G H : Group.{u₁}) : Type (u₁+1) := -- Notice that we push this up one universe level, because our categories expect Obj and Hom at the same universe level.
+  (map: G.1 → H.1)
+  (is_group_hom : by exactI is_group_hom map . is_group_hom_obviously) -- we need `by exactI` here to get the group instances.
+
+instance GroupHomomorphism_to_map {G H : Group} : has_coe_to_fun (GroupHomomorphism G H) :=
+{F   := λ f, Π x : G.1, H.1,
+  coe := GroupHomomorphism.map}
+
+@[simp] lemma GroupHomomorphism.is_group_hom_lemma (G H : Group) (f : GroupHomomorphism G H) (x y : G.1) : by exactI f(x * y) = f(x) * f(y) := -- again, we need to get the group instances.
+begin
+  dsimp {unfold_reducible := tt, md := semireducible},
+  erw f.is_group_hom,
+  refl,
+end
+
+#print GroupHomomorphism.is_group_hom_lemma -- yuck, the type is
+-- ∀ (G H : Group) (f : GroupHomomorphism G H) (x y : G.fst),
+--  id (λ (G H : Group) (f : GroupHomomorphism G H) (x y : G.fst), ⇑f (x * y) = ⇑f x * ⇑f y) G H f x y
+
+definition GroupHomomorphism.identity (G : Group) : GroupHomomorphism G G := ⟨ id ⟩
+
+definition GroupHomomorphism.composition
+  {G H K : Group}
+  (f: GroupHomomorphism G H) (g: GroupHomomorphism H K) : GroupHomomorphism G K :=
+{
+  map := λ x, g (f x),
+  is_group_hom := begin
+                    unfold is_group_hom, 
+                    dsimp, 
+                    intros, 
+                    -- we can't just say `simp`, and have GroupHomomorphism.is_group_hom_lemma finish, because its type is gross because of the exactI.
+                    have h := GroupHomomorphism.is_group_hom_lemma, 
+                    dsimp at h, 
+                    rw h, 
+                    rw h,
+                  end
+}
+
+lemma GroupHomomorphism_pointwise_equality
+  {G H : Group}
+  (f g : GroupHomomorphism G H)
+  (w : ∀ x : G.1, f x = g x) : f = g :=
+begin
+    induction f with fc,
+    induction g with gc,
+    have hc : fc = gc := funext w,
+    subst hc
+end
+
+instance CategoryOfGroups : category Group := {
+    Hom := GroupHomomorphism,
+    identity := GroupHomomorphism.identity,
+    compose  := @GroupHomomorphism.composition
+}
+
+open categories.functor
+open categories.types
+
+definition ForgetfulFunctor_Semigroups_to_Types : Functor Group (Type u₁) :=
+{
+  onObjects     := λ s, s.1,
+  onMorphisms   := λ s t, λ f, ulift.up f.map,
+}
+
+end categories.examples.groups

--- a/categories/examples/groups/default.lean
+++ b/categories/examples/groups/default.lean
@@ -77,10 +77,10 @@ instance CategoryOfGroups : category Group := {
 open categories.functor
 open categories.types
 
-definition ForgetfulFunctor_Semigroups_to_Types : Functor Group (Type u₁) :=
+definition ForgetfulFunctor_Groups_to_Types : Functor Group (Type u₁) :=
 {
   onObjects     := λ s, s.1,
-  onMorphisms   := λ s t, λ f, ulift.up f.map,
+  onMorphisms   := λ s t, λ f, ulift.up f.map, -- we need this ulift because there's only one universe level in the category of types.
 }
 
 end categories.examples.groups

--- a/categories/functor.lean
+++ b/categories/functor.lean
@@ -1,0 +1,60 @@
+-- Copyright (c) 2017 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Tim Baumann, Stephen Morgan, Scott Morrison
+
+import .category
+import .isomorphism
+
+open categories
+open categories.isomorphism
+
+namespace categories.functor
+
+universes u₁ u₂ u₃ 
+
+structure Functor (C : Type u₁) [category C] (D : Type u₂) [category D] :=
+  (onObjects   : C → D)
+  (onMorphisms : Π {X Y : C},
+                Hom X Y → Hom (onObjects X) (onObjects Y))
+  (identities : ∀ (X : C),
+    onMorphisms (𝟙 X) = 𝟙 (onObjects X) . obviously)
+  (functoriality : ∀ {X Y Z : C} (f : Hom X Y) (g : Hom Y Z),
+    onMorphisms (f >> g) = (onMorphisms f) >> (onMorphisms g) . obviously)
+
+definition IdentityFunctor (C) [category C] : Functor C C :=
+{
+  onObjects     := id,
+  onMorphisms   := λ _ _ f, f
+}
+
+variable {C : Type u₁}
+variable [category C]
+variable {D : Type u₂}
+variable [category D]
+variable {E : Type u₃}
+variable [category E]
+variables {X Y : C}
+
+-- We define a coercion so that we can write `F X` for the functor `F` applied to the object `X`.
+-- One can still write out `onObjects F X` when needed.
+instance Functor_to_onObjects : has_coe_to_fun (Functor C D) :=
+{F   := λ f, C → D,
+  coe := Functor.onObjects}
+
+definition FunctorComposition (F : Functor C D) (G : Functor D E) : Functor C E :=
+{
+  onObjects     := λ X, G.onObjects (F.onObjects X),
+  onMorphisms   := λ _ _ f, G.onMorphisms (F.onMorphisms f)
+}
+
+-- Functors preserve isomorphisms
+definition Functor.onIsomorphisms (F : Functor C D) (g : Isomorphism X Y) : Isomorphism (F.onObjects X) (F.onObjects Y) :=
+{
+    morphism := F.onMorphisms g.morphism,
+    inverse := F.onMorphisms g.inverse,
+}
+
+class ReflectsIsomorphisms (F : Functor C D) :=
+  (reflects : Π (f : Hom X Y) (w : is_Isomorphism (F.onMorphisms f)), is_Isomorphism f)
+
+end categories.functor

--- a/categories/functor_categories/default.lean
+++ b/categories/functor_categories/default.lean
@@ -1,0 +1,92 @@
+-- Copyright (c) 2017 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Tim Baumann, Stephen Morgan, Scott Morrison
+
+import ..natural_transformation
+
+open categories
+open categories.isomorphism
+open categories.functor
+open categories.natural_transformation
+
+namespace categories.functor_categories
+
+universes u₁ u₂ u₃
+
+instance FunctorCategory (C : Type u₁) [category C] (D : Type u₂) [category D] : category (Functor C D):=
+{
+  Hom := λ F G, NaturalTransformation F G,
+  identity := λ F, IdentityNaturalTransformation F,
+  compose  := @vertical_composition_of_NaturalTransformations C _ D _
+}
+
+definition whiskering_on_left (C : Type u₁) [category C] (D : Type u₂) [category D] (E : Type u₃) [category E] : Functor (Functor C D) (Functor (Functor D E) (Functor C E)) :=
+{
+  onObjects     := λ F, {
+    onObjects     := λ G, FunctorComposition F G,
+    onMorphisms   := λ _ _ α, whisker_on_left F α
+ },
+  onMorphisms   := λ F G τ, {
+    components := λ H, {
+      components := λ c, H.onMorphisms (τ.components c)
+   }
+ }
+}
+
+definition whisker_on_left_functor
+  {C : Type u₁} [category C] {D : Type u₂} [category D] (F : Functor C D) (E : Type u₃) [category E] :
+  Functor (Functor D E) (Functor C E) :=
+  (whiskering_on_left C D E).onObjects F
+
+definition whiskering_on_right (C : Type u₁) [category C] (D : Type u₂) [category D] (E : Type u₃) [category E] :
+    Functor (Functor D E) (Functor (Functor C D) (Functor C E)) :=
+{
+  onObjects     := λ H, {
+    onObjects     := λ F, FunctorComposition F H,
+    onMorphisms   := λ _ _ α, whisker_on_right α H,
+ },
+  onMorphisms   := λ G H τ, {
+    components := λ F, {
+      components := λ c, τ.components (F.onObjects c)
+   }
+ }
+}
+
+definition whisker_on_right_functor (C : Type u₁) [category C] {D : Type u₂} [category D] {E : Type u₃} [category E] (H : Functor D E) :
+  Functor (Functor C D) (Functor C E) :=
+(whiskering_on_right C D E).onObjects H
+
+variable {C : Type u₁}
+variable [category C]
+variable {D : Type u₂}
+variable [category D]
+variable {E : Type u₃}
+variable [category E]
+
+@[ematch] lemma NaturalTransformation_to_FunctorCategory.components_naturality
+  {F G : Functor C (Functor D E)}
+  (T : NaturalTransformation F G) 
+  (X : C)
+  {Y Z : D}
+  (f : Hom Y Z)
+    : ((F.onObjects X).onMorphisms f) >> ((T.components X).components Z) =
+    ((T.components X).components Y) >> ((G.onObjects X).onMorphisms f) :=
+begin
+  exact (T.components _).naturality _
+end
+
+@[ematch] lemma NaturalTransformation_to_FunctorCategory.naturality_components
+  {F G : Functor C (Functor D E)}
+  (T : NaturalTransformation F G) 
+  (Z : D)
+  {X Y : C}
+  (f : Hom X Y)
+  : ((F.onMorphisms f).components Z) >> ((T.components Y).components Z) =
+    ((T.components X).components Z) >> ((G.onMorphisms f).components Z) :=
+begin
+  have p := T.naturality _,
+  have q := congr_arg NaturalTransformation.components p,
+  obviously,
+end
+
+end categories.functor_categories

--- a/categories/isomorphism.lean
+++ b/categories/isomorphism.lean
@@ -19,9 +19,6 @@ structure Isomorphism (X Y : C) :=
 (witness_1 : morphism >> inverse = 𝟙 X . obviously)
 (witness_2 : inverse >> morphism = 𝟙 Y . obviously)
 
-make_lemma Isomorphism.witness_1
-make_lemma Isomorphism.witness_2
-attribute [simp,ematch] Isomorphism.witness_1_lemma Isomorphism.witness_2_lemma
 
 instance Isomorphism_coercion_to_morphism : has_coe (Isomorphism X Y) (Hom X Y) :=
   {coe := Isomorphism.morphism}
@@ -32,7 +29,7 @@ definition IsomorphismComposition (α : Isomorphism X Y) (β : Isomorphism Y Z) 
   inverse := β.inverse >> α.inverse
 }
 
-@[applicable] lemma Isomorphism_pointwise_equal
+lemma Isomorphism_pointwise_equal
   (α β : Isomorphism X Y)
   (w : α.morphism = β.morphism) : α = β :=
   begin
@@ -40,16 +37,8 @@ definition IsomorphismComposition (α : Isomorphism X Y) (β : Isomorphism Y Z) 
     induction β with h k wβ1 wβ2,
     simp at w,    
     have p : g = k,
-      begin
-        -- PROJECT why can't we automate this?
-        tidy,
-        resetI,
-        rewrite ← @category.left_identity C _ _ _ k,
-        rewrite ← wα2,
-        rewrite category.associativity,
-        simp *,
-      end,
-    smt_eblast
+      sorry,
+    begin[smt] eblast end
   end
 
 definition Isomorphism.reverse (I : Isomorphism X Y) : Isomorphism Y X := {
@@ -61,10 +50,6 @@ structure is_Isomorphism (morphism : Hom X Y) :=
 (inverse : Hom Y X)
 (witness_1 : morphism >> inverse = 𝟙 X . obviously)
 (witness_2 : inverse >> morphism = 𝟙 Y . obviously)
-
-make_lemma is_Isomorphism.witness_1
-make_lemma is_Isomorphism.witness_2
-attribute [simp,ematch] is_Isomorphism.witness_1_lemma is_Isomorphism.witness_2_lemma
 
 instance is_Isomorphism_coercion_to_morphism (f : Hom X Y): has_coe (is_Isomorphism f) (Hom X Y) :=
   {coe := λ _, f}

--- a/categories/isomorphism.lean
+++ b/categories/isomorphism.lean
@@ -1,0 +1,75 @@
+-- Copyright (c) 2017 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Tim Baumann, Stephen Morgan, Scott Morrison
+
+import .category
+
+open categories
+
+namespace categories.isomorphism
+universes u
+
+variable {C : Type u}
+variable [category C]
+variables {X Y Z : C}
+
+structure Isomorphism (X Y : C) :=
+(morphism : Hom X Y)
+(inverse : Hom Y X)
+(witness_1 : morphism >> inverse = 𝟙 X . obviously)
+(witness_2 : inverse >> morphism = 𝟙 Y . obviously)
+
+make_lemma Isomorphism.witness_1
+make_lemma Isomorphism.witness_2
+attribute [simp,ematch] Isomorphism.witness_1_lemma Isomorphism.witness_2_lemma
+
+instance Isomorphism_coercion_to_morphism : has_coe (Isomorphism X Y) (Hom X Y) :=
+  {coe := Isomorphism.morphism}
+
+definition IsomorphismComposition (α : Isomorphism X Y) (β : Isomorphism Y Z) : Isomorphism X Z :=
+{
+  morphism := α.morphism >> β.morphism,
+  inverse := β.inverse >> α.inverse
+}
+
+@[applicable] lemma Isomorphism_pointwise_equal
+  (α β : Isomorphism X Y)
+  (w : α.morphism = β.morphism) : α = β :=
+  begin
+    induction α with f g wα1 wα2,
+    induction β with h k wβ1 wβ2,
+    simp at w,    
+    have p : g = k,
+      begin
+        -- PROJECT why can't we automate this?
+        tidy,
+        resetI,
+        rewrite ← @category.left_identity C _ _ _ k,
+        rewrite ← wα2,
+        rewrite category.associativity,
+        simp *,
+      end,
+    smt_eblast
+  end
+
+definition Isomorphism.reverse (I : Isomorphism X Y) : Isomorphism Y X := {
+  morphism  := I.inverse,
+  inverse   := I.morphism
+}
+
+structure is_Isomorphism (morphism : Hom X Y) :=
+(inverse : Hom Y X)
+(witness_1 : morphism >> inverse = 𝟙 X . obviously)
+(witness_2 : inverse >> morphism = 𝟙 Y . obviously)
+
+make_lemma is_Isomorphism.witness_1
+make_lemma is_Isomorphism.witness_2
+attribute [simp,ematch] is_Isomorphism.witness_1_lemma is_Isomorphism.witness_2_lemma
+
+instance is_Isomorphism_coercion_to_morphism (f : Hom X Y): has_coe (is_Isomorphism f) (Hom X Y) :=
+  {coe := λ _, f}
+
+definition Epimorphism (f : Hom X Y) := Π (g h : Hom Y Z) (w : f >> g = f >> h), g = h
+definition Monomorphism (f : Hom X Y) := Π (g h : Hom Z X) (w : g >> f = h >> f), g = h
+
+end categories.isomorphism

--- a/categories/natural_transformation.lean
+++ b/categories/natural_transformation.lean
@@ -1,0 +1,86 @@
+-- Copyright (c) 2017 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Tim Baumann, Stephen Morgan, Scott Morrison
+
+import .functor
+
+open categories
+open categories.functor
+
+namespace categories.natural_transformation
+
+universes u v w
+variable {C : Type u}
+variable [category C]
+variable {D : Type v}
+variable [category D]
+variable {E : Type w}
+variable [category E]
+
+structure NaturalTransformation (F G : Functor C D) :=
+  (components: Π X : C, Hom (F.onObjects X) (G.onObjects X))
+  (naturality: ∀ {X Y : C} (f : Hom X Y),
+     (F.onMorphisms f) >> (components Y) = (components X) >> (G.onMorphisms f) . obviously)
+
+variables {F G H: Functor C D}
+
+-- This defines a coercion so we can write `α X` for `components α X`.
+instance NaturalTransformation_to_components : has_coe_to_fun (NaturalTransformation F G) :=
+{F   := λ f, Π X : C, Hom (F.onObjects X) (G.onObjects X),
+  coe := NaturalTransformation.components}
+
+-- We'll want to be able to prove that two natural transformations are equal if they are componentwise equal.
+lemma NaturalTransformations_componentwise_equal
+  (α β : NaturalTransformation F G)
+  (w : ∀ X : C, α.components X = β.components X) : α = β :=
+  begin
+    induction α with α_components α_naturality,
+    induction β with β_components β_naturality,
+    have hc : α_components = β_components := funext w,
+    subst hc
+  end
+
+definition IdentityNaturalTransformation (F : Functor C D) : NaturalTransformation F F :=
+{
+    components := λ X, 𝟙 (F.onObjects X)
+}
+
+definition vertical_composition_of_NaturalTransformations
+  (α : NaturalTransformation F G)
+  (β : NaturalTransformation G H) : NaturalTransformation F H :=
+{
+    components := λ X, (α.components X) >> (β.components X)
+}
+
+notation α `∘̬` β := vertical_composition_of_NaturalTransformations α β
+
+open categories.functor
+
+@[simp] lemma FunctorComposition.onObjects (F : Functor C D) (G : Functor D E) (X : C) : (FunctorComposition F G).onObjects X = G.onObjects (F.onObjects X) := by obviously
+
+definition horizontal_composition_of_NaturalTransformations
+  {F G : Functor C D}
+  {H I : Functor D E}
+  (α : NaturalTransformation F G)
+  (β : NaturalTransformation H I) : NaturalTransformation (FunctorComposition F H) (FunctorComposition G I) :=
+{
+    components := λ X : C, (β.components (F.onObjects X)) >> (I.onMorphisms (α.components X))
+}
+
+notation α `∘ₕ` β := horizontal_composition_of_NaturalTransformations α β
+
+definition whisker_on_left
+  (F : Functor C D)
+  {G H : Functor D E}
+  (α : NaturalTransformation G H) :
+  NaturalTransformation (FunctorComposition F G) (FunctorComposition F H) :=
+  (IdentityNaturalTransformation F) ∘ₕ α
+
+definition whisker_on_right
+  {F G : Functor C D}
+  (α : NaturalTransformation F G)
+  (H : Functor D E) :
+  NaturalTransformation (FunctorComposition F H) (FunctorComposition G H) :=
+  α ∘ₕ (IdentityNaturalTransformation H)
+
+end categories.natural_transformation

--- a/categories/opposites.lean
+++ b/categories/opposites.lean
@@ -1,0 +1,53 @@
+-- Copyright (c) 2017 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Stephen Morgan, Scott Morrison
+
+import .functor
+import .products
+import .types
+
+open categories
+open categories.functor
+open categories.products
+open categories.types
+
+namespace categories.opposites
+
+universes u₁ u₂
+
+variable {C : Type u₁}
+variable [category C]
+variable {D : Type u₂}
+variable [category D]
+
+def op (C : Type u₁) : Type u₁ := C
+
+notation C `ᵒᵖ` := op C
+
+instance Opposite : category (Cᵒᵖ) :=
+{ Hom := λ X Y : C, Hom Y X,
+  compose  := λ _ _ _ f g, g >> f,
+  identity := λ X, 𝟙 X }
+
+definition OppositeFunctor (F : Functor C D) : Functor (Cᵒᵖ) (Dᵒᵖ) :=  {
+  onObjects     := λ X, F.onObjects X,
+  onMorphisms   := λ X Y f, F.onMorphisms f
+}
+
+definition HomPairing {C : Type u₁} [category C]: Functor (Cᵒᵖ × C) (Type u₁) := { 
+  onObjects     := λ p, @Hom C _ p.1 p.2,
+  onMorphisms   := λ X Y f, ⟨λ h, f.1 >> h >> f.2⟩
+}
+
+@[simp,ematch] lemma ContravariantFunctor.functoriality
+  (F : Functor (Cᵒᵖ) D)
+  (X Y Z : C)
+  (f : Hom X Y) (g : Hom Y Z) :
+    F.onMorphisms ((f >> g) : Hom X Z) = (F.onMorphisms g) >> (F.onMorphisms f) := begin erw F.functoriality, end
+
+@[simp,ematch] lemma ContravariantFunctor.identities
+  (F : Functor (Cᵒᵖ) D)
+  (X : C) :
+    F.onMorphisms (𝟙 X) = 𝟙 (F.onObjects X) := by obviously
+
+end categories.opposites

--- a/categories/products/default.lean
+++ b/categories/products/default.lean
@@ -1,0 +1,75 @@
+-- Copyright (c) 2017 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Stephen Morgan, Scott Morrison
+import ..functor_categories
+
+open categories
+open categories.functor
+open categories.natural_transformation
+open categories.functor_categories
+
+namespace categories.products
+
+universes u₁ u₂ u₃ u₄
+
+variable {A : Type u₁}
+variable [category A]
+variable {B : Type u₂}
+variable [category B]
+variable {C : Type u₃}
+variable [category C]
+variable {D : Type u₄}
+variable [category D]
+
+instance ProductCategory : category (C × D) := {
+    Hom      := (λ X Y : C × D, Hom (X.1) (Y.1) × Hom (X.2) (Y.2)),
+    identity := λ X, ⟨ 𝟙 (X.1), 𝟙 (X.2) ⟩,
+    compose  := λ _ _ _ f g, (f.1 >> g.1, f.2 >> g.2)
+ }
+
+definition RightInjectionAt (Z : D) : Functor C (C × D) := {
+  onObjects     := λ X, (X, Z),
+  onMorphisms   := λ X Y f, (f, 𝟙 Z)
+}
+
+definition LeftInjectionAt (Z : C) : Functor D (C × D) := {
+  onObjects     := λ X, (Z, X),
+  onMorphisms   := λ X Y f, (𝟙 Z, f)
+}
+
+definition LeftProjection : Functor (C × D) C := 
+{
+  onObjects     := λ X, X.1,
+  onMorphisms   := λ X Y f, f.1
+}
+
+definition RightProjection : Functor (C × D) D := 
+{
+  onObjects     := λ X, X.2,
+  onMorphisms   := λ X Y f, f.2
+}
+
+definition ProductFunctor (F : Functor A B) (G : Functor C D) : Functor (A × C) (B × D) :=
+{
+  onObjects     := λ X, (F.onObjects X.1, G.onObjects X.2),
+  onMorphisms   := λ _ _ f, (F.onMorphisms f.1, G.onMorphisms f.2)
+}
+
+namespace ProductFunctor
+  notation F `×` G := ProductFunctor F G
+end ProductFunctor
+
+definition ProductNaturalTransformation
+  {F G : Functor A B} {H I : Functor C D} 
+  (α : NaturalTransformation F G) (β : NaturalTransformation H I) : 
+    NaturalTransformation (F × H) (G × I) :=
+{
+  components := λ X, (α.components X.1, β.components X.2)
+}
+
+namespace ProductNaturalTransformation
+  notation α `×` β := ProductNaturalTransformation α β
+end ProductNaturalTransformation
+
+
+end categories.products

--- a/categories/types/default.lean
+++ b/categories/types/default.lean
@@ -12,8 +12,7 @@ open categories.isomorphism
 
 universes u v
 
-@[reducible] instance CategoryOfTypes : category.{u+1} (Type u) :=
-{
+instance CategoryOfTypes : category.{u+1} (Type u) := {
     Hom := λ a b, ulift.{u+1} (a → b),
     identity := λ a, ulift.up id,
     compose  := λ _ _ _ f g, ulift.up (g.down ∘ f.down)

--- a/categories/types/default.lean
+++ b/categories/types/default.lean
@@ -1,0 +1,61 @@
+-- Copyright (c) 2017 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Stephen Morgan, Scott Morrison
+
+import ..category
+import ..isomorphism
+
+namespace categories.types
+
+open categories
+open categories.isomorphism
+
+universes u v
+
+@[reducible] instance CategoryOfTypes : category.{u+1} (Type u) :=
+{
+    Hom := λ a b, ulift.{u+1} (a → b),
+    identity := λ a, ulift.up id,
+    compose  := λ _ _ _ f g, ulift.up (g.down ∘ f.down)
+}
+
+lemma ulift_equal {α : Type v}
+  (X Y : ulift.{u v} α)
+  (w : X.down = Y.down) : X = Y :=
+  begin
+    induction X,
+    induction Y,
+    obviously
+  end
+
+definition Bijection (α β : Type u) := Isomorphism α β 
+
+@[simp] definition Bijection.witness_1 {α β : Type u} (iso : Bijection α β) (x : α) : iso.inverse.down (iso.morphism.down x) = x :=
+begin
+  have p := iso.witness_1, 
+  have p' := congr_arg ulift.down p,
+  obviously,
+end
+@[simp] definition Bijection.witness_2 {α β : Type u} (iso : Bijection α β) (x : β) : iso.morphism.down (iso.inverse.down x) = x :=
+begin
+  have p := iso.witness_2,
+  have p' := congr_arg ulift.down p,
+  obviously,
+end
+
+-- TODO the @s are unpleasant here
+@[simp] definition is_Isomorphism_in_Types.witness_1 {α β : Type u} (f : α → β) (h : @is_Isomorphism _ _ α β (ulift.up f)) (x : α) : h.inverse.down (f x) = x :=
+begin
+  have p := h.witness_1, 
+  have p' := congr_arg ulift.down p,
+  obviously,
+end
+@[simp] definition is_Isomorphism_in_Types.witness_2 {α β : Type u} (f : α → β) (h : @is_Isomorphism _ _ α β (ulift.up f)) (x : β) : f (h.inverse.down x) = x :=
+begin
+  have p := h.witness_2,
+  have p' := congr_arg ulift.down p,
+  obviously,
+end
+
+
+end categories.types


### PR DESCRIPTION
This is another preliminary PR for the category theory library. Again, I'd like some help!

This PR uses unbundled objects in the definition of a category, and allows only one universe level for the objects and morphisms.

I would like some help with some rough edges this is causing, as well as some help cleanly defining categories of algebraic objects controlled by type classes.

Before I begin, note that this PR includes a tactic `meta def obviously : tactic unit := '[all_goals { sorry }]`. In my development, every invocation of this tactic actually works, but for now this PR has lots of sorries, so we can concentrate on the constructions, not the proofs.

### Universe levels
In `categories/types/default.lean`, the definition of `CatgoryOfTypes` is
````
instance CategoryOfTypes : category.{u+1} (Type u) := {
    Hom := λ a b, ulift.{u+1} (a → b),
    identity := λ a, ulift.up id,
    compose  := λ _ _ _ f g, ulift.up (g.down ∘ f.down)
}
````
We need the `ulift` here, because if we only allow a single level for objects and morphisms, whenever the objects are a collection of types (or e.g. `definition Group := Σ α : Type u₁, group α`, as you can find in `categories/examples/groups/default.lean`), the morphisms will naturally be one level lower.

> Is this okay? I don't think this is going to be super painful, but I'm happy to take advice.

The only work-around I can think of at the moment is that we could define categories so the objects were _always_ one universe level higher than the morphisms. This would make all this algebraic examples much cleaner, at the expense of having to write a lot of `+1`s in universe levels when we're talking about categories in the abstract.

### Categories of objects described by typeclasses (update: these problems have been solved)
I'm struggling to cleanly construct categories of typeclass-based algebraic objects, because the typeclasses are never available. I attempt to use the `exactI` tactic to introduce bundled typeclasses into the typeclass inference mechanism at the correct moments, but it is still pretty unpleasant. There is an example of this defining `CategoryOfGroups : category Group` in `categories/examples/groups/default.lean`, and I would very much appreciate input on how to handle this better.

I begin here by defining:
````
definition Group := Σ α : Type u₁, group α

instance group_from_Group (G : Group) : group G.1 := G.2

structure GroupHomomorphism (G H : Group.{u₁}) : Type (u₁+1) :=
  (map: G.1 → H.1)
  (is_group_hom : by exactI is_group_hom map) -- we need `by exactI` here to get the group instances.
````
Notice first we have to artificially push GroupHomomorphism up one universe level.
In the field `is_group_hom`, I have to use `exactI` so that `is_group_hom map` can find the instances `G.2` and `H.2`. However this results in a terrible signature:
`categories.examples.groups.GroupHomomorphism.is_group_hom : ∀ {G H : Group} (c : GroupHomomorphism G H),
  id (λ (G H : Group) (map : G.fst → H.fst), is_group_hom map) G H (c.map)`
We're really like that `id` and the function application to definitionally simplify away.

In order to make this field more usable, I tried to define a `simp` lemma based on it, after defining a coercion from GroupHomomorphism to its map field:
````
instance GroupHomomorphism_to_map {G H : Group} : has_coe_to_fun (GroupHomomorphism G H) :=
{F   := λ f, Π x : G.1, H.1,
  coe := GroupHomomorphism.map}

@[simp] lemma GroupHomomorphism.is_group_hom_lemma (G H : Group) (f : GroupHomomorphism G H) (x y : G.1) : by exactI f(x * y) = f(x) * f(y) := -- again, we need to get the group instances.
begin
  dsimp {unfold_reducible := tt, md := semireducible},
  erw f.is_group_hom,
  refl,
end
````
but again the `exactI` ruins the signature of the lemma. As an example, rather than just being able to use `simp`, to use this lemma one needs to `have` it, `dsimp` it, and then `rw` using it:
````
definition GroupHomomorphism.composition
  {G H K : Group}
  (f: GroupHomomorphism G H) (g: GroupHomomorphism H K) : GroupHomomorphism G K :=
{
  map := λ x, g (f x),
  is_group_hom := begin
                    unfold is_group_hom, 
                    dsimp, 
                    intros, 
                    -- we can't just say `simp`, and have GroupHomomorphism.is_group_hom_lemma finish, because its type is gross because of the exactI.
                    have h := GroupHomomorphism.is_group_hom_lemma, 
                    dsimp at h, 
                    rw h, 
                    rw h,
                  end
}
````

Advice on any of these issues very much appreciated!

