### PR TITLE
feat(nightlies) adds a nightly lean working with mathlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,12 @@ Besides [Lean's general documentation](https://leanprover.github.io/documentatio
 * a [style guide](docs/style.md) for contributors
 * a tentative list of [work in progress](docs/wip.md) to make sure
   efforts are not duplicated without collaboration
+
+Development of this library very closely follows the development of Lean
+itself. Hence this library will almost never be usable with stable
+releases of Lean. On the other hand, there can be some short delay
+between nightly releases of Lean and adaptations of mathlib. In such
+cases, mathlib works with no release available from the main
+[download page](https://leanprover.github.io/download/). However, the
+[nightlies directory](nightlies/) should always contain releases working
+with current mathlib.


### PR DESCRIPTION
This is my attempt to fix the nightly issue. Of course at least two things are missing:
* windows and MacOS nightlies
* something for people who want to stick to stable releases of Lean.

I noticed there is a Lean-3.3.0 branch of mathlib. I hesitated to add a sentence mentioning this. But I wanted to ask first why this is not a tag (and github release) instead of a branch. It seems to me the branch option makes sense only if some new commits are added to this branch. But I don't think anyone wants to invest any time maintaining that lean-3.3.0 branch. So I think you should make it a tag and a github release (and then mention it in the readme if you want).