### PR TITLE
[WIP] `traversable` type class

### DIFF
--- a/category/applicative.lean
+++ b/category/applicative.lean
@@ -32,6 +32,9 @@ instance : applicative id :=
 instance : is_lawful_applicative id :=
 by refine { .. }; intros; refl
 
+instance : is_comm_applicative id :=
+by refine { .. }; intros; refl
+
 namespace comp
 
 open function (hiding comp)
@@ -100,6 +103,17 @@ instance {f : Type u → Type u'} {g : Type v → Type u}
   map_pure := @comp.map_pure f g _ _ _ _,
   seq_pure := @comp.seq_pure f g _ _ _ _,
   seq_assoc := @comp.seq_assoc f g _ _ _ _ }
+
+open is_comm_applicative
+
+instance {f : Type u → Type u'} {g : Type v → Type u}
+  [applicative f] [applicative g]
+  [is_comm_applicative f] [is_comm_applicative g] :
+  is_comm_applicative (comp f g) :=
+by { refine { .. @comp.is_lawful_applicative f g _ _ _ _, .. },
+     intros, casesm* comp _ _ _, simp! [map,has_seq.seq] with norm,
+     rw [commutative_map,function.comp], congr, funext,
+     rw [commutative_map], congr }
 
 end comp
 open functor

--- a/category/applicative.lean
+++ b/category/applicative.lean
@@ -1,0 +1,112 @@
+/-
+Copyright (c) 2017 Simon Hudon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Simon Hudon
+
+Instances for identity and composition functors
+-/
+
+import category.functor
+
+universe variables u v w u' v' w'
+
+section lemmas
+
+open function
+
+variables {f : Type u → Type v}
+variables [applicative f] [is_lawful_applicative f]
+
+attribute [norm] seq_assoc pure_seq_eq_map map_pure seq_map_assoc map_seq
+
+lemma applicative.map_seq_map {α β γ σ : Type u} (g : α → β → γ) (h : σ → β) (x : f α) (y : f σ) :
+  (g <$> x) <*> (h <$> y) = (flip comp h ∘ g) <$> x <*> y :=
+by simp [flip] with norm
+
+end lemmas
+
+instance : applicative id :=
+{ pure := @id,
+  seq := λ α β f, f }
+
+instance : is_lawful_applicative id :=
+by refine { .. }; intros; refl
+
+namespace comp
+
+open function (hiding comp)
+open functor
+
+variables {f : Type u → Type u'} {g : Type v → Type u}
+
+variables [applicative f] [applicative g]
+
+def seq  {α β : Type v} : comp f g (α → β) → comp f g α → comp f g β
+| ⟨h⟩ ⟨x⟩ := ⟨has_seq.seq <$> h <*> x⟩
+
+instance : has_pure (comp f g) :=
+⟨λ _ x, ⟨pure $ pure x⟩⟩
+
+local infix ` <$> ` := comp.map
+local infix ` <*> ` := seq
+
+variables [is_lawful_applicative f] [is_lawful_applicative g]
+variables {α β γ : Type v}
+
+lemma map_pure (h : α → β) (x : α) : (h <$> pure x : comp f g β) = pure (h x) :=
+begin
+  unfold has_pure.pure function.comp comp.map,
+  apply congr_arg,
+  rw [map_pure, map_pure],
+end
+
+lemma seq_pure (h : comp f g (α → β)) (x : α) :
+  h <*> pure x = (λ g : α → β, g x) <$> h :=
+begin
+  cases h with h,
+  unfold comp.map has_pure.pure comp.seq function.comp,
+  apply congr_arg,
+  rw [seq_pure, ← comp_map],
+  apply congr_fun, apply congr_arg,
+  apply funext, intro y,
+  unfold function.comp,
+  apply seq_pure
+end
+
+lemma seq_assoc : ∀ (x : comp f g α) (h₀ : comp f g (α → β)) (h₁ : comp f g (β → γ)),
+   h₁ <*> (h₀ <*> x) = (@function.comp α β γ <$> h₁) <*> h₀ <*> x
+| ⟨x⟩ ⟨h₀⟩ ⟨h₁⟩ :=
+by simp! [(∘),flip] with norm
+
+lemma pure_seq_eq_map (h : α → β) : ∀ (x : comp f g α), pure h <*> x = h <$> x
+| ⟨x⟩ :=
+begin
+  simp! with norm,
+  congr, funext, simp with norm,
+end
+
+instance {f : Type u → Type u'} {g : Type v → Type u}
+  [applicative f] [applicative g] :
+  applicative (comp f g) :=
+{ map := @comp.map f g _ _,
+  seq := @comp.seq f g _ _,
+  ..comp.has_pure }
+
+instance {f : Type u → Type u'} {g : Type v → Type u}
+  [applicative f] [applicative g]
+  [is_lawful_applicative f] [is_lawful_applicative g] :
+  is_lawful_applicative (comp f g) :=
+{ pure_seq_eq_map := @comp.pure_seq_eq_map f g _ _ _ _,
+  map_pure := @comp.map_pure f g _ _ _ _,
+  seq_pure := @comp.seq_pure f g _ _ _ _,
+  seq_assoc := @comp.seq_assoc f g _ _ _ _ }
+
+end comp
+open functor
+
+@[norm]
+lemma comp.seq_mk {α β : Type u'}
+  {f : Type u → Type v} {g : Type u' → Type u}
+  [applicative f] [applicative g]
+  (h : f (g (α → β))) (x : f (g α)) :
+  comp.mk h <*> comp.mk x = comp.mk (has_seq.seq <$> h <*> x) := rfl

--- a/category/functor.lean
+++ b/category/functor.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2017 Simon Hudon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Simon Hudon
+
+Standard identity and composition functors
+-/
+import tactic.ext
+import category.basic
+
+universe variables u v w u' v' w'
+
+section functor
+
+variables {F : Type u → Type v}
+variables {α β γ : Type u}
+variables [functor F] [is_lawful_functor F]
+
+lemma functor.map_id : functor.map id = (id : F α → F α) :=
+by apply funext; apply id_map
+
+lemma functor.map_comp_map (f : α → β) (g : β → γ) :
+  (functor.map g ∘ functor.map f : F α → F γ) = functor.map (g ∘ f) :=
+by apply funext; intro; rw comp_map
+
+@[norm]
+lemma functor.map_map (f : α → β) (g : β → γ) (x : F α) :
+  g <$> f <$> x = (g ∘ f) <$> x :=
+by rw ← comp_map
+
+end functor
+
+def id.mk {α : Sort u} : α → id α := id
+
+namespace functor
+
+structure comp (f : Type u → Type u') (g : Type v → Type u) (α : Type v) : Type u' :=
+(run : f $ g α)
+
+@[extensionality]
+lemma comp.ext {f : Type u → Type u'} {g : Type v → Type u} {α : Type v}
+  {x y : comp f g α}
+  (h : x.run = y.run) :
+  x = y := by cases x; cases y; cases h; refl
+
+instance : functor id :=
+{ map := λ α β f, f }
+instance : is_lawful_functor id :=
+{ id_map := λ α x, rfl,
+  comp_map := λ α β γ f g x, rfl }
+
+namespace comp
+
+variables {f : Type u → Type u'} {g : Type v → Type u}
+
+variables [functor f] [functor g]
+
+protected def map {α β : Type v} (h : α → β) : comp f g α → comp f g β
+| ⟨x⟩ := ⟨functor.map h <$> x⟩
+
+variables [is_lawful_functor f] [is_lawful_functor g]
+variables {α β γ : Type v}
+
+local infix ` <$> ` := comp.map
+
+lemma id_map : ∀ (x : comp f g α), comp.map id x = x
+| ⟨x⟩ :=
+by simp [comp.map,functor.map_id]
+
+protected lemma comp_map (g_1 : α → β) (h : β → γ) : ∀ (x : comp f g α),
+           comp.map (h ∘ g_1) x = comp.map h (comp.map g_1 x)
+| ⟨x⟩ :=
+by simp [comp.map,functor.map_comp_map g_1 h] with norm
+
+instance {f : Type u → Type u'} {g : Type v → Type u}
+  [functor f] [functor g] :
+  functor (comp f g) :=
+{ map := @comp.map f g _ _ }
+
+instance {f : Type u → Type u'} {g : Type v → Type u}
+  [functor f] [functor g]
+  [is_lawful_functor f] [is_lawful_functor g] :
+  is_lawful_functor (comp f g) :=
+{ id_map := @comp.id_map f g _ _ _ _,
+  comp_map := @comp.comp_map f g _ _ _ _ }
+
+end comp
+
+@[norm]
+lemma comp.map_mk {α β : Type u'}
+  {f : Type u → Type v} {g : Type u' → Type u}
+  [functor f] [functor g]
+  (h : α → β) (x : f (g α)) :
+  h <$> comp.mk x = comp.mk (functor.map h <$> x) := rfl
+
+end functor
+
+namespace ulift
+
+instance : functor ulift :=
+{ map := λ α β f, up ∘ f ∘ down }
+
+end ulift
+
+namespace sum
+
+variables {γ α β : Type v}
+
+protected def mapr (f : α → β) : γ ⊕ α → γ ⊕ β
+| (inl x) := inl x
+| (inr x) := inr (f x)
+
+instance : functor (sum γ) :=
+{ map := @sum.mapr γ }
+
+instance : is_lawful_functor.{v} (sum γ) :=
+{ id_map := by intros; casesm _ ⊕ _; refl,
+  comp_map := by intros; casesm _ ⊕ _; refl }
+
+end sum

--- a/category/traversable/basic.lean
+++ b/category/traversable/basic.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2017 Simon Hudon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Simon Hudon
+
+Type class for traversing collections
+-/
+
+import tactic.cache
+import category.applicative
+
+open function (hiding comp)
+
+universe variables w u v w' u' v'
+
+section applicative_transformation
+
+variables (f : Type u → Type v) [applicative f] [is_lawful_applicative f]
+variables (g : Type u → Type w) [applicative g] [is_lawful_applicative g]
+
+structure applicative_transformation : Type (max (u+1) v w) :=
+(F : ∀ {α : Type u}, f α → g α)
+(preserves_pure' : ∀ {α : Type u} (x : α), F (pure x) = pure x)
+(preserves_seq' : ∀ {α β : Type u} (x : f (α → β)) (y : f α), F (x <*> y) = F x <*> F y)
+
+instance : has_coe_to_fun (applicative_transformation f g) :=
+{ F := λ _, ∀ {α}, f α → g α,
+  coe := λ m, m.F }
+
+variables {f g}
+variables (F : applicative_transformation f g)
+
+@[norm]
+lemma applicative_transformation.preserves_pure :
+  ∀ {α : Type u} (x : α), F (pure x) = pure x :=
+by apply applicative_transformation.preserves_pure'
+@[norm]
+lemma applicative_transformation.preserves_seq :
+  ∀ {α β : Type u} (x : f (α → β)) (y : f α), F (x <*> y) = F x <*> F y :=
+by apply applicative_transformation.preserves_seq'
+
+@[norm]
+lemma applicative_transformation.preserves_map {α β : Type u} (x : α → β)  (y : f α) :
+  F (x <$> y) = x <$> F y :=
+by rw [← pure_seq_eq_map,F.preserves_seq]; simp with norm
+
+end applicative_transformation
+
+class traversable (t : Type u → Type u)
+extends functor t :=
+(traverse : Π {m : Type u → Type u} [applicative m]
+   {α β : Type u},
+   (α → m β) → t α → m (t β))
+
+open functor
+
+export traversable (traverse)
+
+section functions
+
+variables {t : Type u → Type u}
+variables {m : Type u → Type v} [applicative m]
+variables {α β : Type u}
+
+
+variables {f : Type u → Type u} [applicative f]
+
+def sequence [traversable t] :
+  t (f α) → f (t α) :=
+traverse id
+
+end functions
+
+class is_lawful_traversable (t : Type u → Type u) [traversable t]
+extends is_lawful_functor t :
+  Type (u+1) :=
+(id_traverse : ∀ {α : Type u} (x : t α), traverse id.mk x = x )
+(comp_traverse : ∀ {G H : Type u → Type u}
+               [applicative G] [applicative H]
+               [is_lawful_applicative G] [is_lawful_applicative H]
+               {α β γ : Type u}
+               (g : α → G β) (h : β → H γ) (x : t α),
+   traverse (comp.mk ∘ map h ∘ g) x =
+   comp.mk (map (traverse h) (traverse g x)))
+(map_traverse : ∀ {G : Type u → Type u}
+               [applicative G] [is_lawful_applicative G]
+               {α β γ : Type u}
+               (g : α → G β) (h : β → γ)
+               (x : t α),
+               map (map h) (traverse g x) =
+               traverse (map h ∘ g) x)
+(traverse_map : ∀ {G : Type u → Type u}
+               [applicative G] [is_lawful_applicative G]
+               {α β γ : Type u}
+               (g : α → β) (h : β → G γ)
+               (x : t α),
+               traverse h (map g x) =
+               traverse (h ∘ g) x)
+(naturality : ∀ {G H : Type u → Type u}
+                [applicative G] [applicative H]
+                [is_lawful_applicative G] [is_lawful_applicative H]
+                (eta : applicative_transformation G H),
+                ∀ {α β : Type u} (f : α → G β) (x : t α),
+                  eta (traverse f x) = traverse (@eta _ ∘ f) x)

--- a/category/traversable/default.lean
+++ b/category/traversable/default.lean
@@ -1,0 +1,4 @@
+import category.traversable.basic
+       category.traversable.instances
+       category.traversable.lemmas
+       category.traversable.derive

--- a/category/traversable/derive.lean
+++ b/category/traversable/derive.lean
@@ -1,0 +1,213 @@
+/-
+Copyright (c) 2018 Simon Hudon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Simon Hudon
+
+Automation to construct `traversable` instances
+-/
+
+import category.traversable.basic category.traversable.instances
+import category.basic
+import tactic.basic tactic.cache
+
+namespace tactic.interactive
+
+open tactic list monad functor
+
+def succeeds {m : Type* → Type*} [alternative m] {α} (cmd : m α) : m bool :=
+(tt <$ cmd) <|> pure ff
+
+meta def nested_map (f v : expr) : expr → tactic expr
+| t :=
+do t ← instantiate_mvars t,
+   mcond (succeeds $ is_def_eq t v)
+      (pure f)
+      (if ¬ v.occurs (t.app_fn)
+          then do
+            cl ← mk_app ``functor [t.app_fn],
+            _inst ← mk_instance cl,
+            f' ← nested_map t.app_arg,
+            mk_mapp ``functor.map [t.app_fn,_inst,none,none,f']
+          else fail format!"type {t} is not a functor with respect to variable {v}")
+
+meta def map_field (n : name) (cl f v e : expr) : tactic expr :=
+do t ← infer_type e >>= whnf,
+   if t.get_app_fn.const_name = n
+   then fail "recursive types not supported"
+   else if v.occurs t
+   then do f' ← nested_map f v t,
+           pure $ f' e
+   else
+         (is_def_eq t.app_fn cl >> to_expr ``(comp.mk %%e))
+     <|> pure e
+
+meta def nested_traverse (f v : expr) : expr → tactic expr
+| t :=
+do t ← instantiate_mvars t,
+   mcond (succeeds $ is_def_eq t v)
+      (pure f)
+      (if ¬ v.occurs (t.app_fn)
+          then do
+            cl ← mk_app ``traversable [t.app_fn],
+            _inst ← mk_instance cl,
+            f' ← nested_traverse t.app_arg,
+            mk_mapp ``traversable.traverse [t.app_fn,_inst,none,none,none,none,f']
+          else fail format!"type {t} is not traversable with respect to variable {v}")
+
+meta def traverse_field (n : name) (_inst cl f v e : expr) : tactic expr :=
+do t ← infer_type e >>= whnf,
+   if t.get_app_fn.const_name = n
+   then fail "recursive types not supported"
+   else if v.occurs t
+   then do f' ← nested_traverse f v t,
+           pure $ f' e
+   else
+         (is_def_eq t.app_fn cl >> to_expr ``(comp.mk %%e))
+     <|> to_expr ``(@pure _ (%%_inst).to_has_pure _ (ulift.up %%e))
+
+meta def seq_apply_constructor : list expr → expr → tactic expr
+| (x :: xs) e := to_expr ``(%%e <*> %%x) >>= seq_apply_constructor xs
+| [] e := return e
+
+meta def fill_implicit_arg' : expr → expr → tactic expr
+| f (expr.pi n bi d b) :=
+if b.has_var then
+do v ← mk_meta_var d,
+   fill_implicit_arg' (expr.app f v) (b.instantiate_var v)
+else return f
+| e _ := return e
+
+meta def fill_implicit_arg (n : name) : tactic expr :=
+do c ← mk_const n,
+   t ← infer_type c,
+   fill_implicit_arg' c t
+
+meta def mk_down (e : expr) : tactic expr :=
+to_expr ``(ulift.down %%e) <|> pure e
+
+meta def map_constructor (c n : name) (f v : expr) (args : list expr) : tactic unit :=
+do g ← target,
+   args' ← mmap (map_field n g.app_fn f v) args,
+   constr ← fill_implicit_arg c,
+   let r := constr.mk_app args',
+   () <$ tactic.exact r
+
+meta def mk_map (type : name) (cs : list name) := do
+   `[intros α β f x],
+   reset_instance_cache,
+   x ← get_local `x,
+   xs ← tactic.induction x,
+   f ← get_local `f,
+   α ← get_local `α,
+   β ← get_local `β,
+   () <$ mmap₂'
+      (λ (c : name) (x : name × list expr × list (name × expr)),
+      solve1 (map_constructor c type f α x.2.1))
+      cs xs
+
+meta def traverse_constructor (c n : name) (_inst f v : expr) (args : list expr) : tactic unit :=
+do g ← target,
+   args' ← mmap (traverse_field n _inst g.app_fn f v) args,
+   constr ← fill_implicit_arg c,
+   v ← mk_mvar,
+   constr' ← to_expr ``(@pure %%(g.app_fn) (%%_inst).to_has_pure _ %%v),
+   r ← seq_apply_constructor args' constr',
+   gs ← get_goals,
+   set_goals [v],
+   vs ← tactic.intros >>= mmap mk_down,
+   tactic.exact (constr.mk_app vs),
+   done,
+   set_goals gs,
+   () <$ tactic.exact r
+
+meta def mk_traverse (type : name) (cs : list name) := do
+   `[intros m _inst α β f x],
+   reset_instance_cache,
+   x ← get_local `x,
+   xs ← tactic.induction x,
+   f ← get_local `f,
+   _inst ← get_local `_inst,
+   α ← get_local `α,
+   β ← get_local `β,
+   m ← get_local `m,
+   () <$ mmap₂'
+      (λ (c : name) (x : name × list expr × list (name × expr)),
+      solve1 (traverse_constructor c type _inst f α x.2.1))
+      cs xs
+
+open applicative
+
+meta def derive_functor : tactic unit :=
+do `(functor %%f) ← target | failed,
+   env ← get_env,
+   let n := f.get_app_fn.const_name,
+   let cs := env.constructors_of n,
+   refine ``( { functor . map := _ , .. } ),
+   mk_map n cs
+
+meta def derive_traverse : tactic unit :=
+do `(traversable %%f) ← target | failed,
+   env ← get_env,
+   let n := f.get_app_fn.const_name,
+   let cs := env.constructors_of n,
+   constructor,
+   mk_traverse n cs
+
+meta def mk_one_instance
+  (n : name)
+  (cls : name)
+  (tac : tactic unit) : tactic unit :=
+do decl ← get_decl n,
+   cls_decl ← get_decl cls,
+   env ← get_env,
+   guard (env.is_inductive n) <|> fail format!"failed to derive '{cls}', '{n}' is not an inductive type",
+   let ls := decl.univ_params.map $ λ n, level.param n,
+   -- incrementally build up target expression `Π (hp : p) [cls hp] ..., cls (n.{ls} hp ...)`
+   -- where `p ...` are the inductive parameter types of `n`
+   let tgt : expr := expr.const n ls,
+   ⟨params, _⟩ ← mk_local_pis (decl.type.instantiate_univ_params (decl.univ_params.zip ls)),
+   let params := params.init,
+   let tgt := tgt.mk_app params,
+   tgt ← mk_app cls [tgt] <|> fail "fish a",
+   tgt ← params.enum.mfoldr (λ ⟨i, param⟩ tgt,
+   do -- add typeclass hypothesis for each inductive parameter
+      tgt ← do {
+        guard $ i < env.inductive_num_params n,
+        param_cls ← mk_app cls [param] <|> fail "fish b",
+        -- TODO(sullrich): omit some typeclass parameters based on usage of `param`?
+        pure $ expr.pi `a binder_info.inst_implicit param_cls tgt
+      } <|> pure tgt,
+      pure $ tgt.bind_pi param
+   ) tgt,
+   () <$ mk_instance tgt <|> do
+     (_, val) ← tactic.solve_aux tgt (do
+       tactic.intros >> tac),
+     val ← instantiate_mvars val,
+     let trusted := decl.is_trusted ∧ cls_decl.is_trusted,
+     add_decl (declaration.defn (n ++ cls)
+               decl.univ_params
+               tgt val reducibility_hints.abbrev trusted),
+     set_basic_attribute `instance (n ++ cls) tt
+
+open function
+meta def higher_order_derive_handler
+  (cls : name)
+  (tac : tactic unit)
+  (deps : list (name × tactic unit) := []) :
+  derive_handler :=
+λ p n,
+if p.is_constant_of cls then
+do mmap' (uncurry $ mk_one_instance n) deps,
+   mk_one_instance n cls tac,
+   pure true
+else pure false
+
+@[derive_handler]
+meta def functor_derive_handler :=
+higher_order_derive_handler ``functor derive_functor
+
+@[derive_handler]
+meta def traversable_derive_handler :=
+higher_order_derive_handler ``traversable derive_traverse [(``functor,derive_functor)]
+
+end tactic.interactive

--- a/category/traversable/equiv.lean
+++ b/category/traversable/equiv.lean
@@ -1,0 +1,156 @@
+/-
+Copyright (c) 2018 Simon Hudon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Simon Hudon
+
+Transferring `traversable` instances using isomorphisms.
+-/
+import data.equiv.basic category.traversable.lemmas
+
+universes u
+
+namespace equiv
+
+section functor
+parameters {t t' : Type u → Type u}
+parameters (eqv : Π α, t α ≃ t' α)
+variables [functor t]
+
+open functor
+
+protected def map {α β : Type u} (f : α → β) (x : t' α) : t' β :=
+eqv β $ map f ((eqv α).symm x)
+
+protected def functor : functor t' :=
+{ map := @equiv.map _ }
+
+variables [is_lawful_functor t]
+
+protected lemma id_map {α : Type u} (x : t' α) :
+  equiv.map id x = x :=
+by simp [equiv.map,id_map]
+
+protected lemma comp_map {α β γ : Type u} (g : α → β) (h : β → γ) (x : t' α) :
+  equiv.map (h ∘ g) x = equiv.map h (equiv.map g x) :=
+by dsimp [equiv.map]; simp; apply comp_map
+
+protected def is_lawful_functor : @is_lawful_functor _ equiv.functor :=
+{ id_map := @equiv.id_map _ _,
+  comp_map := @equiv.comp_map _ _ }
+
+protected def is_lawful_functor' [_i : _root_.functor t']
+  (h₀ : ∀ {α β} (f : α → β),
+         _root_.functor.map f = equiv.map f)
+  (h₁ : ∀ {α β} (f : β),
+         _root_.functor.map_const f = (equiv.map ∘ function.const α) f) :
+  _root_.is_lawful_functor t' :=
+begin
+  have : _i = equiv.functor,
+  { unfreezeI, cases _i, dsimp [equiv.functor],
+    congr; ext, rw [← h₀],rw [← h₁] },
+  constructor ; intros;
+  haveI _i' := equiv.is_lawful_functor; resetI,
+  { simp, intros, ext,
+    rw [h₁], rw ← this at _i',
+    have k := @map_const_eq t' _ _ α β, rw this at ⊢ k, rw ← k, refl },
+  { rw [h₀], rw ← this at _i',
+    have k := id_map x, rw this at k, apply k },
+  { rw [h₀], rw ← this at _i',
+    have k := comp_map g h x, revert k, rw this, exact id },
+end
+
+end functor
+
+section traversable
+parameters {t t' : Type u → Type u}
+parameters (eqv : Π α, t α ≃ t' α)
+variables [traversable t]
+variables {m : Type u → Type u} [applicative m]
+variables {α β : Type u}
+
+protected def traverse (f : α → m β) (x : t' α) : m (t' β) :=
+eqv β <$> traverse f ((eqv α).symm x)
+
+protected def traversable : traversable t' :=
+{ to_functor := equiv.functor eqv,
+  traverse := @equiv.traverse _ }
+
+end traversable
+
+section equiv
+parameters {t t' : Type u → Type u}
+parameters (eqv : Π α, t α ≃ t' α)
+variables [traversable t]
+variables [is_lawful_traversable t]
+variables {G H : Type u → Type u}
+          [applicative G] [applicative H]
+          [is_lawful_applicative G]
+          [is_lawful_applicative H]
+variables (eta : applicative_transformation G H)
+variables {α β γ : Type u}
+
+open is_lawful_traversable functor
+
+protected lemma id_traverse (x : t' α) :
+  equiv.traverse eqv id.mk x = x :=
+by simp! [equiv.traverse,id_traverse,functor.map] with norm
+
+protected lemma map_traverse (g : α → G β) (f : β → γ) (x : t' α) :
+  equiv.map eqv f <$> equiv.traverse eqv g x = equiv.traverse eqv (functor.map f ∘ g) x :=
+by simp [equiv.traverse] with norm;
+   rw ← map_traverse; simp [equiv.map] with norm;
+   congr' 1; ext; simp [equiv.map]
+
+protected lemma traverse_map (g : α → β) (f : β → G γ) (x : t' α) :
+  equiv.traverse eqv f (equiv.map eqv g x) = equiv.traverse eqv (f ∘ g) x :=
+by simp [equiv.traverse] with norm; rw ← traverse_map g f;
+   [ simp [equiv.map,function.comp] with norm,
+     apply_instance ]
+
+protected lemma comp_traverse (g : α → G β) (h : β → H γ) (x : t' α) :
+  equiv.traverse eqv (comp.mk ∘ functor.map h ∘ g) x =
+  ⟨ equiv.traverse eqv h <$> equiv.traverse eqv g x ⟩ :=
+by simp [equiv.traverse,comp_traverse] with norm; congr; ext; simp
+
+protected lemma naturality  (f : α → G β) (x : t' α) :
+  eta (equiv.traverse eqv f x) = equiv.traverse eqv (@eta _ ∘ f) x :=
+by simp [equiv.traverse] with norm
+
+protected def is_lawful_traversable :
+  @is_lawful_traversable t' (equiv.traversable eqv) :=
+{ to_is_lawful_functor := @equiv.is_lawful_functor _ _ eqv _ _,
+  map_traverse := @equiv.map_traverse _ _,
+  traverse_map := @equiv.traverse_map _ _,
+  id_traverse := @equiv.id_traverse _ _,
+  comp_traverse := @equiv.comp_traverse _ _,
+  naturality := @equiv.naturality _ _ }
+
+protected def is_lawful_traversable' [_i : traversable t']
+  (h₀ : ∀ {α β} (f : α → β),
+         map f = equiv.map eqv f)
+  (h₁ : ∀ {α β} (f : β),
+         map_const f = (equiv.map eqv ∘ function.const α) f)
+  (h₂ : ∀ {F : Type u → Type u} [applicative F] [is_lawful_applicative F]
+          {α β} (f : α → F β),
+         traverse f = equiv.traverse eqv f) :
+  _root_.is_lawful_traversable t' :=
+begin
+    -- we can't use the same approach as for `is_lawful_functor'` because
+    -- h₂ needs a `is_lawful_applicative` assumption
+  refine { to_is_lawful_functor := equiv.is_lawful_functor' eqv @h₀ @h₁,
+           map_traverse := _,
+           traverse_map :=  _,
+           id_traverse := _,
+           comp_traverse := _,
+           naturality := _ };
+  intros; resetI,
+  { rw [h₂,equiv.id_traverse], apply_instance },
+  { rw [h₂,equiv.comp_traverse g h x,h₂], congr,
+    rw [h₂], all_goals { apply_instance }, },
+  { rw [h₂,h₀,equiv.map_traverse,h₂] ; apply_instance },
+  { rw [h₂,h₂,h₀,equiv.traverse_map] ; apply_instance },
+  { rw [h₂,equiv.naturality,h₂] ; apply_instance }
+end
+
+end equiv
+end equiv

--- a/category/traversable/instances.lean
+++ b/category/traversable/instances.lean
@@ -1,0 +1,249 @@
+/-
+Copyright (c) 2018 Simon Hudon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Simon Hudon
+
+Instances of `traversable` for types from the core library
+-/
+
+import category.traversable.basic
+import category.basic
+import category.functor
+import category.applicative
+
+universe variables w u v w' u' v'
+
+open function
+
+section identity
+
+open function functor
+
+variables {f f' : Type u → Type u}
+variables [applicative f] [applicative f']
+
+def id.traverse {α β : Type u} (g : α → f β) : id α → f (id β) := g
+
+instance : traversable id :=
+⟨ @id.traverse ⟩
+
+variables [is_lawful_applicative f] [is_lawful_applicative f']
+variables {α β γ : Type u}
+
+lemma id.id_traverse (x : id α) :
+  id.traverse id.mk x = x :=
+by refl
+lemma id.comp_traverse (g : α → f β) (h : β → f' γ) (x : id α) :
+  id.traverse (comp.mk ∘ map h ∘ g) x =
+  comp.mk (id.traverse h <$> id.traverse g x) :=
+by simp! [id.traverse,functor.map_id] with norm
+
+lemma id.map_traverse
+   (g : α → f' β) (f : β → γ)
+   (x : id α) :
+  map f <$> id.traverse g x = id.traverse (map f ∘ g) x :=
+by simp [map,id.traverse,id_map] with norm
+
+lemma id.traverse_map
+   (g : α → β) (f : β → f' γ)
+   (x : id α) :
+  id.traverse f (g <$> x) = id.traverse (f ∘ g) x :=
+by simp [map,id.traverse,id_map] with norm
+
+variable (eta : applicative_transformation f f')
+
+lemma id.naturality {α β : Type u}
+  (F : α → f β) (x : id α) :
+  eta (id.traverse F x) = id.traverse (@eta _ ∘ F) x :=
+by simp! [id.traverse] with norm; refl
+
+end identity
+
+instance : is_lawful_traversable id :=
+{ id_traverse := λ α x, @id.id_traverse α x,
+  comp_traverse := @id.comp_traverse,
+  map_traverse := @id.map_traverse,
+  traverse_map := @id.traverse_map,
+  naturality := @id.naturality }
+
+section option
+
+open function functor
+
+variables {f f' : Type u → Type u}
+variables [applicative f] [applicative f']
+
+protected def option.traverse {α β : Type u} (g : α → f β) : option α → f (option β)
+| none := pure none
+| (some x) := some <$> g x
+
+instance : traversable option :=
+{ traverse := @option.traverse }
+
+variables [is_lawful_applicative f] [is_lawful_applicative f']
+variables {α β γ : Type u}
+
+lemma option.id_traverse (x : option α) :
+  option.traverse id.mk x = x :=
+by cases x; unfold option.traverse; refl
+
+lemma option.comp_traverse (g : α → f β) (h : β → f' γ) :
+  ∀ (x : option α),
+        option.traverse (comp.mk ∘ map h ∘ g) x =
+        comp.mk (option.traverse h <$> option.traverse g x) :=
+by intro x; cases x; simp! with norm; refl
+
+lemma option.map_traverse (g : α -> f' β) (f : β → γ)
+  (x : option α) :
+  map f <$> option.traverse g x = option.traverse (map f ∘ g) x :=
+by cases x; simp! with norm; refl
+
+lemma option.traverse_map (g : α -> β) (f : β → f' γ)
+  (x : option α) :
+  option.traverse f (g <$> x) = option.traverse (f ∘ g) x :=
+by cases x; simp! with norm; refl
+
+variable (eta : applicative_transformation f f')
+
+lemma option.naturality {α β : Type u} (g : α → f β) (x : option α) :
+  eta (option.traverse g x) = option.traverse (@eta _ ∘ g) x :=
+by cases x with x; simp! [*] with norm
+
+end option
+
+instance : is_lawful_traversable option :=
+{ id_traverse := @option.id_traverse,
+  comp_traverse := @option.comp_traverse,
+  map_traverse := @option.map_traverse,
+  traverse_map := @option.traverse_map,
+  naturality := @option.naturality }
+
+section list
+
+variables {f : Type u → Type v}
+variables [applicative f]
+variables {α β : Type u}
+
+open applicative functor
+open list (cons)
+
+protected def list.traverse (g : α → f β) : list α → f (list β)
+| [] := pure []
+| (x :: xs) := cons <$> g x <*> list.traverse xs
+
+end list
+
+section list
+
+variables {f f' : Type u → Type u}
+variables [applicative f] [applicative f']
+variables [is_lawful_applicative f] [is_lawful_applicative f']
+variables {α β γ : Type u}
+
+open applicative functor
+open list (cons)
+
+lemma list.id_traverse (xs : list α) :
+  list.traverse id.mk xs = xs :=
+by induction xs; simp! [*] with norm; refl
+
+lemma list.comp_traverse (g : α → f β) (h : β → f' γ) (x : list α) :
+  list.traverse (comp.mk ∘ map h ∘ g) x =
+  comp.mk (list.traverse h <$> list.traverse g x) :=
+by induction x; simp! [*] with norm; refl
+
+lemma list.map_traverse {α β γ : Type u} (g : α → f' β) (f : β → γ)
+  (x : list α) :
+  map f <$> list.traverse g x = list.traverse (map f ∘ g) x :=
+begin
+  symmetry,
+  induction x with x xs ih;
+  simp! [*] with norm; refl
+end
+
+lemma list.traverse_map {α β γ : Type u} (g : α → β) (f : β → f' γ)
+  (x : list α) :
+  list.traverse f (g <$> x) = list.traverse (f ∘ g) x :=
+begin
+  symmetry,
+  induction x with x xs ih;
+  simp! [*] with norm; refl
+end
+
+variable (eta : applicative_transformation f f')
+
+lemma list.naturality {α β : Type u} (g : α → f β) (x : list α) :
+  eta (list.traverse g x) = list.traverse (@eta _ ∘ g) x :=
+by induction x; simp! [*] with norm
+open nat
+
+end list
+
+instance : traversable list :=
+{ traverse := @list.traverse }
+
+instance : is_lawful_traversable list :=
+{ id_traverse := @list.id_traverse,
+  comp_traverse := @list.comp_traverse,
+  map_traverse := @list.map_traverse,
+  traverse_map := @list.traverse_map,
+  naturality := @list.naturality }
+
+namespace sum
+
+section traverse
+variables {γ : Type u}
+variables {f f' : Type u → Type u}
+variables [applicative f] [applicative f']
+
+open applicative functor
+open list (cons)
+
+protected def traverse {α β : Type u} (g : α → f β) : γ ⊕ α → f (γ ⊕ β)
+| (sum.inl x) := pure (sum.inl x)
+| (sum.inr x) := sum.inr <$> g x
+
+variables [is_lawful_applicative f] [is_lawful_applicative f']
+variables {α β η : Type u}
+
+protected lemma id_traverse (x : γ ⊕ α) :
+  sum.traverse id.mk x = x :=
+by cases x; refl
+
+protected lemma comp_traverse (g : α → f β) (h : β → f' η) (x : γ ⊕ α) :
+        sum.traverse (comp.mk ∘ map h ∘ g) x =
+        comp.mk (sum.traverse h <$> sum.traverse g x) :=
+by casesm _ ⊕ _; simp! [sum.traverse,map_id] with norm; refl
+
+protected lemma map_traverse
+   (g : α → f' β) (f : β → η)
+   (x : γ ⊕ α) :
+  map f <$> sum.traverse g x = sum.traverse (map f ∘ g) x :=
+by casesm _ ⊕ _; simp [map,sum.mapr,sum.traverse,id_map] with norm; congr
+
+protected lemma traverse_map
+   (g : α → β) (f : β → f' η)
+   (x : γ ⊕ α) :
+  sum.traverse f (g <$> x) = sum.traverse (f ∘ g) x :=
+by casesm _ ⊕ _; simp [map,sum.mapr,sum.traverse,id_map] with norm
+
+variable (eta : applicative_transformation f f')
+
+protected lemma naturality {α β : Type u}
+  (F : α → f β) (x : γ ⊕ α) :
+  eta (sum.traverse F x) = sum.traverse (@eta _ ∘ F) x :=
+by cases x; simp! [sum.traverse] with norm; refl
+
+end traverse
+
+instance {γ : Type u} : traversable.{u} (sum γ) :=
+{ traverse := @sum.traverse.{u} γ }
+
+instance {γ : Type u} : is_lawful_traversable.{u} (sum γ) :=
+{ id_traverse := @sum.id_traverse γ,
+  comp_traverse := @sum.comp_traverse γ,
+  map_traverse := @sum.map_traverse γ,
+  traverse_map := @sum.traverse_map γ,
+  naturality := @sum.naturality γ }
+
+end sum

--- a/category/traversable/instances.lean
+++ b/category/traversable/instances.lean
@@ -7,9 +7,9 @@ Instances of `traversable` for types from the core library
 -/
 
 import category.traversable.basic
-import category.basic
-import category.functor
-import category.applicative
+       category.basic
+       category.functor
+       category.applicative
 
 universe variables w u v w' u' v'
 
@@ -177,8 +177,6 @@ lemma list.naturality {α β : Type u} (g : α → f β) (x : list α) :
 by induction x; simp! [*] with norm
 open nat
 
-end list
-
 instance : traversable list :=
 { traverse := @list.traverse }
 
@@ -188,6 +186,19 @@ instance : is_lawful_traversable list :=
   map_traverse := @list.map_traverse,
   traverse_map := @list.traverse_map,
   naturality := @list.naturality }
+
+lemma traverse_append (g : α → f β) (xs ys : list α) :
+  traverse g (xs ++ ys) = (++) <$> traverse g xs <*> traverse g ys :=
+begin
+  simp! [traverse],
+  induction xs,
+  { have : append (@list.nil β) = id,
+    { funext, simp },
+    simp! [this] },
+  { simp! [traverse,xs_ih] with norm, refl }
+end
+
+end list
 
 namespace sum
 

--- a/category/traversable/lemmas.lean
+++ b/category/traversable/lemmas.lean
@@ -1,0 +1,70 @@
+
+import tactic.cache
+import category.traversable.basic
+
+universe variables w u v w' u' v'
+
+open is_lawful_traversable
+open function (hiding comp)
+open functor
+
+lemma map_id_mk {α β : Type u}
+  (f : α → β) :
+  map f ∘ @id.mk α = @id.mk β ∘ f :=
+rfl
+
+attribute [norm] is_lawful_traversable.naturality
+
+section traversable
+
+variable {t : Type u → Type u}
+variables [traversable t] [is_lawful_traversable t]
+variables {G H : Type u → Type u}
+
+variables [applicative G] [is_lawful_applicative G]
+variables [applicative H] [is_lawful_applicative H]
+variables {α β γ : Type u}
+variables g : α → G β
+variables h : β → H γ
+variables f : β → γ
+
+variables G H
+
+def pure_transformation : applicative_transformation id G :=
+begin
+  refine { F := @pure G _, .. } ;
+  intros, { refl }, { simp with norm, refl }
+end
+
+variables {G H}
+
+lemma traverse_eq_map_ident (x : t β) :
+  traverse (id.mk ∘ f) x = id.mk (f <$> x) :=
+calc
+      traverse (id.mk ∘ f) x
+    = traverse id.mk (map f x) : by rw [← traverse_map]
+... = map f <$> x              : by simp [id_traverse]; refl
+
+lemma purity (x : t α) :
+  traverse pure x = (pure x : G (t α)) :=
+let eta := pure_transformation G in
+calc   traverse (@pure G _ _) x
+     = traverse (pure ∘ id.mk) x   : rfl
+ ... = traverse (@eta _ ∘ id.mk) x : rfl
+ ... = eta (traverse id.mk x)      : by rw [naturality]
+ ... = eta x                       : by rw [id_traverse]
+ ... = pure x                      : rfl
+
+lemma id_sequence (x : t α) :
+  sequence (id.mk <$> x) = id.mk x :=
+by simp [sequence,traverse_map,id_traverse]; refl
+
+lemma comp_sequennce (x : t (G (H α))) :
+  sequence (comp.mk <$> x) = comp.mk (sequence <$> sequence x) :=
+by simp [sequence,traverse_map]; rw ← comp_traverse; simp [map_id]
+
+lemma naturality' (eta : applicative_transformation G H) (x : t (G α)) :
+  eta (sequence x) = sequence (@eta _ <$> x) :=
+by simp [sequence,naturality,traverse_map]
+
+end traversable

--- a/data/array/lemmas.lean
+++ b/data/array/lemmas.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
 -/
-import data.list.basic data.buffer data.equiv.basic
+import data.list.basic data.buffer category.traversable.equiv data.vector2
 
 universes u w
 
@@ -16,7 +16,7 @@ instance [∀ i, inhabited (α i)] : inhabited (d_array n α) :=
 end d_array
 
 namespace array
-variables {n : nat} {α : Type u} {β : Type w}
+variables {n m : nat} {α : Type u} {β : Type w}
 
 instance [inhabited α] : inhabited (array n α) := d_array.inhabited
 
@@ -130,6 +130,12 @@ heq_of_heq_of_eq
 @[simp] theorem to_array_to_list (l : list α) : l.to_array.to_list = l :=
 list.ext_le (to_list_length _) $ λn h1 h2, to_list_nth_le _ _ _ _
 
+theorem to_list_of_heq {a₀ : array n α} {a₁ : array m α}
+  (h  : n = m)
+  (h' : a₀ == a₁) :
+  a₀.to_list = a₁.to_list :=
+by congr; assumption
+
 lemma push_back_rev_list_core (a : array n α) (v : α) :
   ∀ i h h',
     d_array.iterate_aux (a.push_back v) (λ_, list.cons) i h [] =
@@ -195,4 +201,23 @@ def d_array_equiv_fin {n : ℕ} (α : fin n → Type*) : d_array n α ≃ (Π i,
 def array_equiv_fin (n : ℕ) (α : Type*) : array n α ≃ (fin n → α) :=
 d_array_equiv_fin _
 
+def vector_equiv_fin (α : Type*) (n : ℕ) : vector α n ≃ (fin n → α) :=
+⟨vector.nth, vector.of_fn, vector.of_fn_nth, λ f, funext $ vector.nth_of_fn f⟩
+
+def vector_equiv_array (α : Type*) (n : ℕ) : vector α n ≃ array n α :=
+(vector_equiv_fin _ _).trans (array_equiv_fin _ _).symm
+
 end equiv
+
+namespace array
+open function
+
+variable {n : ℕ}
+
+instance : traversable.{u} (array n) :=
+@equiv.traversable (flip vector n) _ (λ α, equiv.vector_equiv_array α n) _
+
+instance : is_lawful_traversable.{u} (array n) :=
+@equiv.is_lawful_traversable (flip vector n) _ (λ α, equiv.vector_equiv_array α n) _ _
+
+end array

--- a/data/buffer/basic.lean
+++ b/data/buffer/basic.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2018 Simon Hudon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Simon Hudon
+
+Traversable instance for buffers.
+-/
+
+import data.buffer data.array.lemmas
+import category.traversable.instances data.equiv.basic
+       tactic.ext
+
+namespace buffer
+
+open function
+
+variables {α : Type*}
+variables {buf buf' : buffer α}
+variables {xs : list α}
+
+@[extensionality]
+lemma ext
+  (h : to_list buf = to_list buf') :
+  buf = buf' :=
+begin
+  cases buf with n buf, cases buf' with n' buf', simp [to_list,to_array] at h,
+  have : n = n',
+  { rw [← array.to_list_length buf,← array.to_list_length buf',h] },
+  subst n',
+  have := array.to_list_to_array buf,
+  have := array.to_list_to_array buf',
+  rw h at *, congr, apply eq_of_heq, transitivity;
+  [ symmetry, skip ]; assumption,
+end
+
+@[simp]
+lemma to_list_append_list  :
+  to_list (append_list buf xs) = to_list buf ++ xs :=
+by induction xs generalizing buf; simp! [*];
+   cases buf; simp! [to_list,to_array]
+
+@[simp]
+lemma append_list_mk_buffer  :
+  append_list mk_buffer xs = array.to_buffer (list.to_array xs) :=
+by ext 1 with x; simp [array.to_buffer,to_list,to_list_append_list];
+   induction xs; [refl,skip]; simp [to_array]; refl
+
+def list_equiv_buffer (α : Type*) : list α ≃ buffer α :=
+begin
+  refine { to_fun := list.to_buffer, inv_fun := buffer.to_list, .. };
+  simp [left_inverse,function.right_inverse],
+  { intro x, induction x, refl,
+    simp [list.to_buffer,append_list],
+    rw ← x_ih, refl },
+  { intro x, cases x,
+    simp [to_list,to_array,list.to_buffer],
+    congr, simp, refl, apply array.to_list_to_array }
+end
+
+instance : traversable buffer :=
+equiv.traversable list_equiv_buffer
+
+instance : is_lawful_traversable buffer :=
+equiv.is_lawful_traversable list_equiv_buffer
+
+end buffer

--- a/data/dlist/instances.lean
+++ b/data/dlist/instances.lean
@@ -1,0 +1,26 @@
+/-
+Copyright (c) 2018 Simon Hudon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Simon Hudon
+
+Traversable instance for dlists.
+-/
+import data.dlist category.traversable.equiv category.traversable.instances
+
+namespace dlist
+
+variables (α : Type*)
+
+open function equiv
+
+def list_equiv_dlist : list α ≃ dlist α :=
+by refine { to_fun := dlist.of_list, inv_fun := dlist.to_list, .. };
+   simp [function.right_inverse,left_inverse,to_list_of_list,of_list_to_list]
+
+instance : traversable dlist :=
+equiv.traversable list_equiv_dlist
+
+instance : is_lawful_traversable dlist :=
+equiv.is_lawful_traversable list_equiv_dlist
+
+end dlist

--- a/data/equiv/basic.lean
+++ b/data/equiv/basic.lean
@@ -23,6 +23,7 @@ structure equiv (α : Sort*) (β : Sort*) :=
 (right_inv : right_inverse inv_fun to_fun)
 
 namespace equiv
+
 /-- `perm α` is the type of bijections from `α` to itself. -/
 @[reducible] def perm (α : Sort*) := equiv α α
 
@@ -98,7 +99,7 @@ theorem left_inverse_symm (f : equiv α β) : left_inverse f.symm f := f.left_in
 
 theorem right_inverse_symm (f : equiv α β) : function.right_inverse f.symm f := f.right_inv
 
-protected lemma image_eq_preimage {α β} (e : α ≃ β) (s : set α) : e '' s = e.symm ⁻¹' s := 
+protected lemma image_eq_preimage {α β} (e : α ≃ β) (s : set α) : e '' s = e.symm ⁻¹' s :=
 set.ext $ assume x, set.mem_image_iff_of_inverse e.left_inv e.right_inv
 
 protected lemma subset_image {α β} (e : α ≃ β) (s : set α) (t : set β) : t ⊆ e '' s ↔ e.symm '' t ⊆ s :=

--- a/data/lazy_list/basic.lean
+++ b/data/lazy_list/basic.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2018 Simon Hudon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Simon Hudon
+
+Traversable instance for lazy_lists.
+-/
+
+import category.traversable.equiv category.traversable.instances data.lazy_list
+
+namespace lazy_list
+
+open function
+
+def list_equiv_lazy_list (α : Type*) : list α ≃ lazy_list α :=
+{ to_fun := lazy_list.of_list,
+  inv_fun := lazy_list.to_list,
+  right_inv := by { intro, induction x, refl, simp! [*],
+                    ext, cases x, refl },
+  left_inv := by { intro, induction x, refl, simp! [*] } }
+
+universes u
+def thunk.mk {α} (x : α) : thunk α := λ _, x
+
+protected def traverse {m : Type u → Type u} [applicative m] {α β : Type u}
+    (f : α → m β) : lazy_list α → m (lazy_list β)
+| lazy_list.nil := pure lazy_list.nil
+| (lazy_list.cons x xs):= lazy_list.cons <$> f x <*> (thunk.mk <$> traverse (xs ()))
+
+instance : traversable lazy_list :=
+{ map := @lazy_list.traverse id _,
+  traverse := @lazy_list.traverse }
+
+instance : is_lawful_traversable lazy_list :=
+begin
+  apply equiv.is_lawful_traversable' list_equiv_lazy_list;
+  intros ; resetI; ext,
+  { induction x, refl,
+    simp! [equiv.map,functor.map] at *,
+    simp [*], refl, },
+  { induction x, refl,
+    simp! [equiv.map,functor.map_const] at *,
+    simp [*], refl, },
+  { induction x,
+    { simp! [traversable.traverse,equiv.traverse] with norm, refl },
+    simp! [equiv.map,functor.map_const,traversable.traverse] at *, rw x_ih,
+    dsimp [list_equiv_lazy_list,equiv.traverse,to_list,traversable.traverse,list.traverse],
+    simp! with norm, refl },
+end
+
+end lazy_list

--- a/data/multiset.lean
+++ b/data/multiset.lean
@@ -8,6 +8,7 @@ Multisets.
 import logic.function order.boolean_algebra
   data.list.basic data.list.perm data.list.sort data.quot data.string
   algebra.order_functions algebra.group_power algebra.ordered_group
+  tactic.interactive
 
 open list subtype nat lattice
 

--- a/data/prod.lean
+++ b/data/prod.lean
@@ -6,6 +6,8 @@ Authors: Johannes Hölzl
 Extends theory on products
 -/
 
+import tactic.ext
+
 universes u v
 variables {α : Type u} {β : Type v}
 
@@ -23,6 +25,7 @@ namespace prod
 lemma ext_iff {p q : α × β} : p = q ↔ p.1 = q.1 ∧ p.2 = q.2 :=
 by rw [← @mk.eta _ _ p, ← @mk.eta _ _ q, mk.inj_iff]
 
+@[extensionality]
 lemma ext {α β} {p q : α × β} : p.1 = q.1 → p.2 = q.2 → p = q :=
 by rw [ext_iff] ; intros ; split ; assumption
 
@@ -60,4 +63,3 @@ theorem lex_def (r : α → α → Prop) (s : β → β → Prop)
  end⟩
 
 end prod
-

--- a/data/vector2.lean
+++ b/data/vector2.lean
@@ -5,7 +5,10 @@ Authors: Mario Carneiro
 
 Additional theorems about the `vector` type.
 -/
-import data.vector data.list.basic data.array.lemmas
+import data.vector data.list.basic data.sigma data.equiv.basic
+       category.traversable
+
+attribute [extensionality] vector.eq
 
 namespace vector
 variables {α : Type*} {n : ℕ}
@@ -96,12 +99,128 @@ def {u} mmap {m} [monad m] {α} {β : Type u} (f : α → m β) :
 
 end vector
 
-namespace equiv
+namespace vector
 
-def vector_equiv_fin (α : Type*) (n : ℕ) : vector α n ≃ (fin n → α) :=
-⟨vector.nth, vector.of_fn, vector.of_fn_nth, λ f, funext $ vector.nth_of_fn f⟩
+universes u
+variables {n : ℕ}
 
-def vector_equiv_array (α : Type*) (n : ℕ) : vector α n ≃ array n α :=
-(vector_equiv_fin _ _).trans (array_equiv_fin _ _).symm
+section traverse
 
-end equiv
+variables {f f' : Type u → Type u}
+variables [applicative f] [applicative f']
+
+open applicative functor
+open list (cons) nat
+
+def traverse_aux {α β : Type u} (g : α → f β) :
+  Π (x : list α), f (vector β x.length)
+| [] := pure vector.nil
+| (x::xs) := vector.cons <$> g x <*> traverse_aux xs
+
+protected def traverse {α β : Type u} (g : α → f β) :
+  vector α n → f (vector β n)
+ | ⟨v,Hv⟩ := cast (by rw Hv) $ traverse_aux g v
+
+protected def to_array {α : Type u} {n} : vector α n → array n α
+ | ⟨xs,h⟩ := cast (by rw h) xs.to_array
+
+variables [is_lawful_applicative f] [is_lawful_applicative f']
+variables {α β η : Type u}
+
+@[simp]
+protected lemma traverse_def (g : α → f β) (x : α) (xs : vector α n) :
+  vector.traverse g (x :: xs) = cons <$> g x <*> vector.traverse g xs :=
+begin
+  cases xs, simp!,
+  elim_cast _ with i,
+  elim_cast _ with j, subst n,
+  simp at *, subst i, subst j
+end
+
+protected lemma id_traverse (x : vector α n) :
+  vector.traverse id.mk x = x :=
+begin
+  cases x with x, subst n,
+  dsimp [vector.traverse,cast],
+  induction x with x xs, refl,
+  simp! [x_ih], refl
+end
+
+open function
+
+protected lemma comp_traverse (g : α → f β) (h : β → f' η) (x : vector α n) :
+  vector.traverse (comp.mk ∘ functor.map h ∘ g) x =
+  comp.mk (vector.traverse h <$> vector.traverse g x) :=
+begin
+  cases x with x,
+  dunfold vector.traverse, subst n, dsimp [cast],
+  induction x with x xs; simp! [cast,*] with norm, refl,
+  congr' 2, ext, simp [function.comp,flip]
+end
+
+protected lemma map_traverse
+   (g : α → f' β) (f : β → η)
+   (x : vector α n) :
+  map f <$> vector.traverse g x = vector.traverse (functor.map f ∘ g) x :=
+begin
+  symmetry,
+  cases x with x, subst n, unfold vector.traverse cast,
+  induction x; simp! [*,cast,map,flip,function.comp,vector.map] with norm, refl,
+  congr' 2, ext, cases x_1, refl
+end
+
+protected lemma traverse_map
+   (g : α → β) (f : β → f' η)
+   (x : vector α n) :
+  vector.traverse f (map g x) = vector.traverse (f ∘ g) x :=
+begin
+  symmetry,
+  cases x with x, subst n,
+  induction x; simp! [*,map,flip,vector.map] with norm, refl,
+  congr' 1, simp, simp,
+  congr' 1, simp, simp,
+  { dsimp [list.length],
+    rw list.length_map },
+  simp [vector.traverse,map] at x_ih,
+  transitivity, apply heq_of_eq, apply x_ih,
+  apply cast_heq,
+end
+
+variable (eta : applicative_transformation f f')
+
+protected lemma naturality {α β : Type*}
+  (F : α → f β) (x : vector α n) :
+  eta (vector.traverse F x) = vector.traverse (@eta _ ∘ F) x :=
+begin
+  cases x;
+  simp! [vector.traverse] with norm,
+  induction x_val with x xs generalizing n,
+  { elim_cast _ with i,
+    elim_cast _ with j,
+    simp! at Hi Hj; subst n; cases Hi; cases Hj,
+    simp [*] with norm },
+  { specialize x_val_ih rfl, subst n,
+    revert x_val_ih,
+    elim_cast _ with i, elim_cast _ with j,
+    elim_cast _ with k, elim_cast _ with h,
+    intros, simp! at *,
+    subst k, subst h, simp with norm,
+    subst i, subst j, rw [x_val_ih] }
+end
+
+end traverse
+
+instance : traversable.{u} (flip vector n) :=
+{ traverse := @vector.traverse n
+, map := λ α β, @vector.map.{u u} α β n }
+
+instance : is_lawful_traversable.{u} (flip vector n) :=
+{ id_traverse := @vector.id_traverse n,
+  comp_traverse := @vector.comp_traverse n,
+  map_traverse := @vector.map_traverse.{u} n,
+  traverse_map := @vector.traverse_map n,
+  naturality := @vector.naturality.{u} n,
+  id_map := by intros; cases x; simp! [functor.map],
+  comp_map := by intros; cases x; simp! [functor.map] }
+
+end vector

--- a/logic/basic.lean
+++ b/logic/basic.lean
@@ -631,3 +631,15 @@ lemma classical.nonempty_pi {α : Sort u} {β : α → Sort v} :
 iff.intro (assume ⟨f⟩ a, ⟨f a⟩) (assume f, ⟨assume a, classical.choice $ f a⟩)
 
 end nonempty
+
+lemma cast_eq_of_heq  {α : Sort*} {β : Sort*} {x : α} {y : β}
+  (h : α = β)
+  (h' : x == y) :
+  cast h x = y :=
+by cc
+
+lemma heq_of_cast_eq {α β} {x : α} {y : β}
+  (h : α = β)
+  (h' : cast h x = y) :
+  x == y :=
+by cc

--- a/tactic/cache.lean
+++ b/tactic/cache.lean
@@ -1,6 +1,7 @@
 
 import tactic.basic
 
+open lean
 open lean.parser
 
 local postfix `?`:9001 := optional
@@ -8,7 +9,7 @@ local postfix *:9001 := many
 
 namespace tactic
 namespace interactive
-open interactive interactive.types
+open interactive interactive.types expr
 
 /-- Unfreeze local instances, which allows us to revert
   instances in the context. -/

--- a/tactic/ext.lean
+++ b/tactic/ext.lean
@@ -1,0 +1,15 @@
+/--
+ Tag lemmas of the form:
+
+ ```
+ lemma my_collection.ext (a b : my_collection)
+   (h : ∀ x, a.lookup x = b.lookup y) :
+   a = b := ...
+ ```
+ -/
+@[user_attribute]
+meta def extensional_attribute : user_attribute :=
+{ name := `extensionality,
+  descr := "lemmas usable by `ext` tactic" }
+
+attribute [extensionality] _root_.funext array.ext

--- a/tests/tactics.lean
+++ b/tests/tactics.lean
@@ -317,12 +317,12 @@ end
 
 example (X Y : ℕ × ℕ)  (h : X.1 = Y.1) (h : X.2 = Y.2) : X = Y :=
 begin
-  ext ; assumption
+  ext; assumption
 end
 
 example (X Y : (ℕ → ℕ) × ℕ)  (h : ∀ i, X.1 i = Y.1 i) (h : X.2 = Y.2) : X = Y :=
 begin
-  ext x ; solve_by_elim,
+  ext x; solve_by_elim,
 end
 
 example (X Y : ℕ → ℕ × ℕ)  (h : ∀ i, X i = Y i) : true :=


### PR DESCRIPTION
Goal: 
* [x] add instances for more collections and 
  * [x] dlist
  * [x] lazy_list
  * [x] buffer
  * [x] array
  * [x] sum
  * [x] vector
  * [x] equiv
* [ ] hook into `derive` attribute
   * [x] derive `functor` and `traversable` (separate PR)
   * [ ] derive `is_lawful_functor` and `is_lawful_traversable`
* [x] in equiv instances, allow for custom `traverse` implementations