### PR TITLE
feat(docs/tactic) document congr_n and unfold_coes

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -64,6 +64,18 @@ All accept an optional list of simplifier rules, typically definitions that shou
 Evaluate expressions in the language of (semi-)rings.
 Based on [Proving Equalities in a Commutative Ring Done Right in Coq](http://www.cs.ru.nl/~freek/courses/tt-2014/read/10.1.1.61.3041.pdf) by Benjamin Grégoire and Assia Mahboubi.
 
+### congr_n
+
+Same as the `congr` tactic, but only works up to depth `n`. This is
+useful when the `congr` tactic is too aggressive in breaking down the
+goal. For example, given `⊢ f (g (x + y)) = f (g (y + x))`, `congr`
+produces the goals `⊢ x = y` and `⊢ y = x`, while `congr_n 2` produces
+the intended `⊢ x + y = y + x`.
+
+### unfold_coes
+
+Unfold coercion-related definitions
+
 ### Instance cache tactics
 
 * `resetI`: Reset the instance cache. This allows any new instances


### PR DESCRIPTION
Two tactics I initially neglected when writing mathlib main tactic docs. I think `congr_n` is especially important, but also added `unfold_coes` for good measure.