### PR TITLE
feat(tactic/convert): tactic similar to `refine` but which generates

### DIFF
--- a/tactic/interactive.lean
+++ b/tactic/interactive.lean
@@ -389,6 +389,10 @@ meta def ext : parse ident_ * → tactic unit
  | [] := repeat (ext1 none)
  | xs := xs.mmap' (ext1 ∘ some)
 
+/--
+  Similar to `refine` but generates equality proof obligations
+  for every discrepancy between the goal and the type of the rule.
+  -/
 meta def convert (sym : parse (with_desc "←" (tk "<-")?)) (r : parse texpr) (n : parse (tk "using" *> small_nat)?) : tactic unit :=
 do v ← mk_mvar,
    if sym.is_some

--- a/tactic/interactive.lean
+++ b/tactic/interactive.lean
@@ -389,5 +389,16 @@ meta def ext : parse ident_ * → tactic unit
  | [] := repeat (ext1 none)
  | xs := xs.mmap' (ext1 ∘ some)
 
+meta def convert (sym : parse (with_desc "←" (tk "<-")?)) (r : parse texpr) (n : parse (tk "using" *> small_nat)?) : tactic unit :=
+do v ← mk_mvar,
+   if sym.is_some
+     then refine ``(eq.mp %%v %%r)
+     else refine ``(eq.mpr %%v %%r),
+   gs ← get_goals,
+   set_goals [v],
+   (option.cases_on n congr congr_n : tactic unit),
+   gs' ← get_goals,
+   set_goals $ gs' ++ gs
+
 end interactive
 end tactic

--- a/tests/tactics.lean
+++ b/tests/tactics.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon
 -/
 import tactic
-import data.set.basic
+import data.set
 
 example {a b : Prop} (h₀ : a → b) (h₁ : a) : b :=
 begin
@@ -110,4 +110,19 @@ begin
   { guard_hyp h  := x ∈ S₀ ∪ S₁,
     guard_hyp h' := x ∈ S₀,
     admit }
+end
+
+open set
+
+variables {α β : Type}
+local attribute [simp]
+private lemma singleton_inter_singleton_eq_empty {x y : α} :
+  ({x} ∩ {y} = (∅ : set α)) ↔ x ≠ y :=
+by simp [singleton_inter_eq_empty]
+
+example {f : β → α} {x y : α} (h : x ≠ y) : f ⁻¹' {x} ∩ f ⁻¹' {y} = ∅ :=
+begin
+  have : {x} ∩ {y} = (∅ : set α) := by simpa using h,
+  convert preimage_empty,
+  rw [←preimage_inter,this],
 end


### PR DESCRIPTION
equality proof obligations for every discrepancy between the goal and
the type of the rule