### PR TITLE
fix(docs/naming): use names in use

### DIFF
--- a/docs/naming.md
+++ b/docs/naming.md
@@ -145,11 +145,11 @@ describing their conclusions.
 
 ### Names for symbols ###
 
-- `implies` : implication
+- `imp`: implication
 - `forall`
 - `exists`
-- `bforall` : bounded forall
-- `bexists` : bounded exists
+- `ball`: bounded forall
+- `bex`: bounded exists
 
 
 ## Identifiers and theorem names ##


### PR DESCRIPTION
Refer to names that are in use in the code: `bforall` and `bexists` are not used, and `imp` is used much more than `implies`.