### PR TITLE
feat(tactic): generalize wlog to support multiple variables and cases…

### DIFF
--- a/data/set/enumerate.lean
+++ b/data/set/enumerate.lean
@@ -54,30 +54,21 @@ lemma enumerate_mem (h_sel : ∀s a, sel s = some a → a ∈ s) :
         this.left }
   end
 
-lemma enumerate_inj {n₁ n₂ : ℕ} {a : α} {s : set α} (h_sel : ∀s a, sel s = some a → a ∈ s) :
-  enumerate s n₁ = some a → enumerate s n₂ = some a → n₁ = n₂ :=
-have ∀{n m s}, enumerate s n = some a → enumerate s (n + m) = some a → m = 0,
+lemma enumerate_inj {n₁ n₂ : ℕ} {a : α} {s : set α} (h_sel : ∀s a, sel s = some a → a ∈ s)
+  (h₁ : enumerate s n₁ = some a) (h₂ : enumerate s n₂ = some a) : n₁ = n₂ :=
 begin
-  intros n m, induction n,
-  case nat.zero {
-    cases m,
-    case nat.zero { simp [enumerate] },
-    case nat.succ : m {
-      simp [enumerate] {contextual := tt},
-      exact assume s _ h,
-        have a ∈ s \ {a}, from enumerate_mem _ h_sel h,
+  wlog hn : n₁ ≤ n₂,
+  { rcases nat.le.dest hn with ⟨m, rfl⟩, clear hn,
+    induction n₁ generalizing s,
+    case nat.zero {
+      cases m,
+      case nat.zero { refl },
+      case nat.succ : m {
+        have : enumerate sel (s - {a}) m = some a, { simp [enumerate, *] at * },
+        have : a ∈ s \ {a}, from enumerate_mem _ h_sel this,
         by simpa } },
-  case nat.succ : n ih {
-    intro s,
-    cases h : sel s,
-    case none { simp [enumerate, h] },
-    case some : a' {
-      simp [enumerate, h, nat.add_succ] {contextual := tt},
-      simpa using ih } }
-end,
-match le_total n₁ n₂ with
-| or.inl h := let ⟨m, hm⟩ := nat.le.dest h in hm ▸ assume h₁ h₂, by simp [this h₁ h₂]
-| or.inr h := let ⟨m, hm⟩ := nat.le.dest h in hm ▸ assume h₁ h₂, by simp [this h₂ h₁]
+    case nat.succ { cases h : sel s; simp [enumerate, nat.add_succ, *] at *; tauto } },
+  { intros, simp * at * }
 end
 
 end enumerate

--- a/tactic/default.lean
+++ b/tactic/default.lean
@@ -1,1 +1,7 @@
-import tactic.interactive tactic.alias tactic.finish tactic.mk_iff_of_inductive_prop
+import
+  tactic.interactive
+  tactic.alias
+  tactic.finish
+  tactic.mk_iff_of_inductive_prop
+  tactic.wlog
+

--- a/tactic/interactive.lean
+++ b/tactic/interactive.lean
@@ -289,59 +289,6 @@ done
 meta def tauto := tautology
 
 /--
-  `wlog h : i ≤ j using i j`: without loss of generality, let us assume `h : i ≤ j`
-  If `using i j` is omitted, the last two free variables found in `i ≤ j` will be used.
-
-  `wlog : R x y` (synonymous with `wlog : R x y using x y`) adds `R x y` to the
-  assumptions and the goal `⊢ R x y ∨ R y x`.
-
-  A special case is made for total order relations `≤` where `⊢ R x y ∨ R y x`
-  is discharged automatically.
-
-  TODO(Simon): Generalize to multiple pairs of variables
--/
-meta def wlog (h : parse ident?)
-              (p : parse (tk ":" *> texpr))
-              (xy : parse (tk "using" *> monad.sequence [ident,ident])?) :
-  tactic unit :=
-do p' ← to_expr p,
-   h_asm ← get_unused_name (h.get_or_else `a),
-   (x :: y :: _) ← xy.to_monad >>= mmap get_local <|> pure p'.list_local_const,
-   n ← tactic.revert_lst [x,y],
-   x ← intro1, y ← intro1,
-   p ← to_expr p,
-   when (¬ x.occurs p ∧ ¬ x.occurs p) (do
-     p ← pp p,
-     fail format!"{p} should reference {x} and {y}"),
-   let p' := subst_locals [(x,y),(y,x)] p,
-   t ← target,
-   asm ← mk_local_def h_asm p,
-   g ← tactic.pis [x,y,asm] t,
-
-   h_this₀ ← get_unused_name `this,
-   (this,gs) ← local_proof h_this₀ (set_binder g [binder_info.default,binder_info.default])
-         (do tactic.clear x, tactic.clear y,
-             intron 2,
-             intro $ h_asm,
-             intron (n-2)),
-   intron (n-2),
-
-   p_or_p' ← to_expr ``(%%p ∨ %%p'),
-   h_this ← get_unused_name `this,
-   (h',gs') ← local_proof h_this p_or_p'
-     (do tactic.clear this,
-         try $ assumption <|> `[exact le_total _ _]),
-   (() <$ tactic.cases h' [h_asm,h_asm])
-     ; [ (do h ← get_local h_asm,
-            specialize ```(%%this %%x %%y %%h) <|> fail "spec A"),
-         do h ← get_local h_asm,
-            specialize ```(%%this %%y %%x %%h) <|> fail "spec B" ]
-     ; try (solve_by_elim <|> tauto <|> (tactic.intros >> cc)),
-   gs'' ← get_goals,
-   set_goals $ gs' ++ gs'' ++ gs,
-   return ()
-
-/--
  Tag lemmas of the form:
 
  ```

--- a/tactic/wlog.lean
+++ b/tactic/wlog.lean
@@ -1,0 +1,248 @@
+/-
+Copyright (c) 2018 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl
+
+Without loss of generality tactic.
+-/
+import tactic.basic tactic.interactive
+
+open expr tactic lean lean.parser
+
+local postfix `?`:9001 := optional
+local postfix *:9001 := many
+
+namespace tactic
+
+private meta def update_pp_name : expr → name → expr
+| (local_const n _ bi d) pp := local_const n pp bi d
+| e n := e
+
+private meta def elim_cases (pat : pattern) : expr → tactic (list expr) | h := do
+  t ← infer_type h,
+  ((match_pattern pat t >> return [h]) <|>
+  (do
+    `(_ ∨ _) ← infer_type h | fail "cases is not a disjunction of the same pattern",
+    [(_, [hl], []), (_, [hr], [])] ← induction h, -- there should be no dependent terms
+    [gl, gr] ← get_goals,
+
+    set_goals [gl],
+    hsl ← elim_cases hl,
+    gsl ← get_goals,
+
+    set_goals [gr],
+    hsr ← elim_cases hr,
+    gsr ← get_goals,
+
+    set_goals (gsl ++ gsr),
+    return (hsl ++ hsr)))
+
+private meta def update_type : expr → expr → expr
+| (local_const n pp bi d) t := local_const n pp bi t
+| e t := e
+
+private meta def intron' : ℕ → tactic (list expr)
+| 0       := return []
+| (i + 1) := do
+  n ← intro1,
+  ls ← intron' i,
+  return (n :: ls)
+
+private meta def dest_or : expr → list expr
+| `(%%a ∨ %%b) := dest_or a ++ dest_or b
+| e            := [e]
+
+private meta def match_perms (pat : pattern) : expr → tactic (list $ list expr) | t :=
+  (do m ← match_pattern pat t, return [m.2]) <|>
+  (do
+    `(%%l ∨ %%r) ← return t,
+    ls ← match_perms l,
+    rs ← match_perms r,
+    return (ls ++ rs))
+
+
+meta def wlog (vars' : list expr) (h_cases fst_case : expr) (perms : list (list expr)) :
+  tactic unit := do
+  case_pat ← mk_pattern [] (vars'.filter $ λv, v.occurs fst_case) fst_case [] [],
+  guard h_cases.is_local_constant,
+
+  -- reorder s.t. context is Γ ⬝ vars ⬝ cases ⊢ ∀deps, …
+  nr ← revert_lst (vars' ++ [h_cases]),
+  vars ← intron' vars'.length,
+  h_cases ← intro h_cases.local_pp_name,
+
+  cases ← infer_type h_cases,
+  h_fst_case ←
+    mk_local_def h_cases.local_pp_name
+      (fst_case.instantiate_locals $ (vars'.zip vars).map $ λ⟨o, n⟩, (o.local_uniq_name, n)),
+  ((), pr) ← solve_aux cases (repeat $ exact h_fst_case <|> left >> skip),
+
+  t ← target,
+  fixed_vars ← vars.mmap (λv, do t ← infer_type v, return (update_type v t) ),
+  let t' := (instantiate_local h_cases.local_uniq_name pr t).pis (fixed_vars ++ [h_fst_case]),
+
+  (h, [g]) ← local_proof `this t' (do
+    clear h_cases,
+    vars.mmap clear,
+    intron nr),
+
+  h₀ :: hs ← elim_cases case_pat h_cases,
+
+  solve1 (do
+    ctxt ← local_context,
+    exact (h.mk_app $ vars ++ [h₀])),
+
+  focus ((hs.zip perms.tail).map $ λ⟨h_case, perm⟩, do
+    let p_v := (vars'.zip vars).map (λ⟨p, v⟩, (p.local_uniq_name, v)),
+    let p := perm.map (λp, p.instantiate_locals p_v),
+    note `this none (h.mk_app $ p ++ [h_case]),
+    clear h,
+    return ()),
+  gs ← get_goals,
+  set_goals (g :: gs)
+
+namespace interactive
+open interactive interactive.types expr
+
+/-- Without loss of generality: reduces to one goal under variables permutations.
+
+Given a goal of the form `g xs`, a predicate `p` over a set of variables, as well as variable
+permutations `xs_i`. Then `wlog` produces goals of the form
+
+The case goal, i.e. the permutation `xs_i` covers all possible cases:
+  `⊢ p xs_0 ∨ ⋯ ∨ p xs_n`
+The main goal, i.e. the goal reduced to `xs_0`:
+  `(h : p xs_0) ⊢ g xs_0`
+The invariant goals, i.e. `g` is invariant under `xs_i`:
+  `(h : p xs_i) (this : g xs_0) ⊢ gs xs_i`
+
+Either the permutation is provided, or a proof of the disjunction is provided to compute the
+permtation. In many cases the invariant goals can be solved by AC rewriting using `cc` etc.
+
+Example:
+  On a state `(n m : ℕ) ⊢ p n m` the tactic `wlog h : n ≤ m using [n m, m n]` produces the following
+  states:
+    `(n m : ℕ) ⊢ n ≤ m ∨ m ≤ n`
+    `(n m : ℕ) (h : n ≤ m) ⊢ p n m`
+    `(n m : ℕ) (h : m ≤ n) (this : p n m) ⊢ p m n`
+
+`wlog` supports different calling conventions. The name `h` is used to give a name to the introduced
+case hypothesis. If the name is avoided, the default will be `case`.
+
+(1) `wlog : p xs0 using [xs0, …, xsn]`
+  Results in the case goal `p xs0 ∨ ⋯ ∨ ps xsn`, the main goal `(case : p xs0) ⊢ g xs0` and the
+  invariance goals `(case : p xsi) (this : g xs0) ⊢ g xsi`.
+
+(2) `wlog : p xs0 := r using xs0`
+  The expression `r` is a proof of the shape `p xs0 ∨ ⋯ ∨ p xsi`, it is also used to compute the
+  variable permutations.
+
+(3) `wlog := r using xs0`
+  The expression `r` is a proof of the shape `p xs0 ∨ ⋯ ∨ p xsi`, it is also used to compute the
+  variable permutations. This is not as stable as (2), for example `p` cannot be a disjunction.
+
+(4) `wlog : R x y using x y` and `wlog : R x y`
+  Produces the case `R x y ∨ R y x`. If `R` is ≤, then the disjunction discharged using linearity.
+  If `using x y` is avoided then `x` and `y` are the last two variables appearing in the
+  expression `R x y`. -/
+meta def wlog
+  (h : parse ident?)
+  (pat : parse (tk ":" *> texpr)?)
+  (cases : parse (tk ":=" *> texpr)?)
+  (perms : parse (tk "using" *> (list_of (ident*) <|> (λx, [x]) <$> ident*))?)
+  (discharger : tactic unit :=
+    (solve_by_elim <|> tauto <|> using_smt smt_tactic.solve_goals)) :
+  tactic unit := do
+  perms ← (perms.get_or_else []).mmap (λp, p.mmap get_local),
+  match perms with
+  | [] := skip
+  | p₀ :: perms := guard (perms.all $ λp, p.length = p₀.length) <|>
+    fail "The permutations `xs_i` in `using [xs_1, …, xs_n]` must have same number of variables."
+  end,
+  (pat, cases_pr, cases_goal, vars, perms) ← (match cases with
+  | some r := do
+    vars::_ ← return perms |
+      fail "At least one set of variables expected, i.e. `using x y` or `using [x y, y x]`.",
+    cases_pr ← to_expr r,
+    cases_pr ← (if cases_pr.is_local_constant
+      then return $ match h with some n := update_pp_name cases_pr n | none := cases_pr end
+      else do
+        note (h.get_or_else `case) none cases_pr),
+    cases ← infer_type cases_pr,
+    (pat, perms') ← match pat with
+    | some pat := do
+      pat ← to_expr pat,
+      let vars' := vars.filter $ λv, v.occurs pat,
+      case_pat ← mk_pattern [] vars' pat [] vars',
+      perms' ← match_perms case_pat cases,
+      return (pat, perms')
+    | none := do
+      (p :: ps) ← return $ dest_or cases,
+      let vars' := vars.filter $ λv, v.occurs p,
+      case_pat ← mk_pattern [] vars' p [] vars',
+      perms' ← (p :: ps).mmap (λp, do m ← match_pattern case_pat p, return m.2),
+      return (p, perms')
+    end,
+    let vars_name := vars.map local_uniq_name,
+    guard (perms'.all $ λp, p.all $ λv, v.is_local_constant ∧ v.local_uniq_name ∈ vars_name) <|>
+      fail "Cases contains variables not declared in `using x y z`",
+    perms ← (if perms.length = 1
+      then do
+        return (perms'.map $ λp, p ++ vars.filter (λv, p.all (λv', v'.local_uniq_name ≠ v.local_uniq_name)))
+      else do
+        guard (perms.length = perms'.length) <|>
+          fail "The provided permutation list has a different length then the provided cases.",
+        return perms),
+    return (pat, cases_pr, @none expr, vars, perms)
+
+  | none   := do
+    let name_h := h.get_or_else `case,
+    some pat ← return pat | fail "Either specify cases or a pattern with permutations",
+    pat ← to_expr pat,
+    (do
+      (x, y) ← match perms with
+      | []       := do
+        (x :: y :: _) ← return pat.list_local_const,
+        return (x, y)
+      | [[x, y]] := return (x, y)
+      | _        := fail ""
+      end,
+      let cases := mk_or_lst [pat, pat.instantiate_locals [(x.local_uniq_name, y), (y.local_uniq_name, x)]],
+      (do
+        `(%%x ≤ %%y) ← return pat,
+        (cases_pr, []) ← local_proof name_h cases (exact ``(le_total %%x %%y)),
+        return (pat, cases_pr, none, [x, y], [[x, y], [y, x]]))
+      <|>
+      (do
+        (cases_pr, [g]) ← local_proof name_h cases skip,
+        return (pat, cases_pr, some g, [x, y], [[x, y], [y, x]]))) <|>
+    (do
+      guard (perms.length ≥ 2) <|>
+        fail ("To generate cases at least two permutations are required, i.e. `using [x y, y x]`" ++
+          " or exactly 0 or 2 variables"),
+      (vars :: perms') ← return perms,
+      let names := vars.map local_uniq_name,
+      let cases := mk_or_lst (pat :: perms'.map (λp, pat.instantiate_locals (names.zip p))),
+      (cases_pr, [g]) ← local_proof name_h cases skip,
+      return (pat, cases_pr, some g, vars, perms))
+  end),
+  let name_fn :=
+    (if perms.length = 2 then λi, `invariant else λi, mk_simple_name ("invariant_" ++ to_string (i + 1))),
+  with_enable_tags $ tactic.focus1 $ do
+    t ← get_main_tag,
+    tactic.wlog vars cases_pr pat perms,
+    tactic.focus (set_main_tag (mk_num_name `_case 0 :: `main :: t) ::
+      (list.range (perms.length - 1)).map (λi, do
+        set_main_tag (mk_num_name `_case 0 :: name_fn i :: t),
+        try discharger)),
+    match cases_goal with
+    | some g := do
+      set_tag g (mk_num_name `_case 0 :: `cases :: t),
+      gs ← get_goals,
+      set_goals (g :: gs)
+    | none := skip
+    end
+
+end interactive
+
+end tactic

--- a/tests/tactics.lean
+++ b/tests/tactics.lean
@@ -52,6 +52,8 @@ by tauto
 
 end tauto₂
 
+section wlog
+
 example {x y : ℕ} (a : x = 1) : true :=
 begin
   suffices : false, trivial,
@@ -60,7 +62,7 @@ begin
     admit },
   { guard_hyp h := x = y,
     guard_hyp a := x = 1,
-    admit },
+    admit }
 end
 
 example {x y : ℕ} : true :=
@@ -69,7 +71,7 @@ begin
   wlog h : x ≤ y,
   { guard_hyp h := x ≤ y,
     guard_target false,
-    admit },
+    admit }
 end
 
 example {x y z : ℕ} : true :=
@@ -80,7 +82,7 @@ begin
     admit },
   { guard_hyp h := x ≤ y + z,
     guard_target false,
-    admit },
+    admit }
 end
 
 example {x y z : ℕ} : true :=
@@ -89,7 +91,7 @@ begin
   wlog : x ≤ y + z using x y,
   { guard_target x ≤ y + z ∨ y ≤ x + z,
     admit },
-  { guard_hyp a := x ≤ y + z,
+  { guard_hyp case := x ≤ y + z,
     guard_target false,
     admit },
 end
@@ -99,10 +101,52 @@ example {x : ℕ} (S₀ S₁ : set ℕ) (P : ℕ → Prop)
 begin
   suffices : false, trivial,
   wlog h' : x ∈ S₀ using S₀ S₁,
+  { guard_target x ∈ S₀ ∨ x ∈ S₁,
+    admit },
   { guard_hyp h  := x ∈ S₀ ∪ S₁,
     guard_hyp h' := x ∈ S₀,
     admit }
 end
+
+example {n m i : ℕ} {p : ℕ → ℕ → ℕ → Prop} : true :=
+begin
+  suffices : false, trivial,
+  wlog : p n m i using [n m i, n i m, i n m],
+  { guard_target p n m i ∨ p n i m ∨ p i n m,
+    admit },
+  { guard_hyp case := p n m i,
+    admit }
+end
+
+example {n m i : ℕ} {p : ℕ → Prop} : true :=
+begin
+  suffices : false, trivial,
+  wlog : p n using [n m i, m n i, i n m],
+  { guard_target p n ∨ p m ∨ p i,
+    admit },
+  { guard_hyp case := p n,
+    admit }
+end
+
+example {n m i : ℕ} {p : ℕ → ℕ → Prop} {q : ℕ → ℕ → ℕ → Prop} : true :=
+begin
+  suffices : q n m i, trivial,
+  have h : p n i ∨ p i m ∨ p m i, from sorry,
+  wlog : p n i := h using n m i,
+  { guard_hyp h := p n i,
+    guard_target q n m i,
+    admit },
+  { guard_hyp h := p i m,
+    guard_hyp this := q i m n,
+    guard_target q n m i,
+    admit },
+  { guard_hyp h := p m i,
+    guard_hyp this := q m i n,
+    guard_target q n m i,
+    admit },
+end
+
+end wlog
 
 example (m n p q : nat) (h : m + n = p) : true :=
 begin


### PR DESCRIPTION
This generalizes `wlog` to allow more than two variables, and hence also more then two permutations.

The user can now provide a explicit rule which shows that all permutation are covered. 

Another change is that `wlog` doesn't run the default discharger for the main goal or for the cases.

@cipher1024 @PatrickMassot there are only tests in `mathlib`. Do you want to test this version if it works with our applications?
I have at least one applications from Mason-Stother which might go into mathlib and require more than one variable. I will merge this if there are no problems.