### PR TITLE
feat(tactic/split_ifs): add if-splitter

### DIFF
--- a/algebra/euclidean_domain.lean
+++ b/algebra/euclidean_domain.lean
@@ -225,10 +225,8 @@ gcd.induction a b
 
 @[simp] theorem gcd_zero_right (a : α) : gcd a 0 = a :=
 begin
-  by_cases (a=0),
-  { simp[h] },
-  { rw gcd,
-    simp [h] }
+  unfold1 gcd,
+  split_ifs; simp *
 end
 
 @[simp] theorem gcd_one_left (a : α) : gcd 1 a = 1 :=

--- a/data/equiv.lean
+++ b/data/equiv.lean
@@ -568,33 +568,13 @@ else if r = b then a
 else r
 
 theorem swap_core_self (r a : α) : swap_core a a r = r :=
-by by_cases r = a; simp [swap_core, *]
+by unfold swap_core; split_ifs; cc
 
 theorem swap_core_swap_core (r a b : α) : swap_core a b (swap_core a b r) = r :=
-begin
-  by_cases hb : r = b,
-  { by_cases ha : r = a,
-    { simp [hb.symm, ha.symm, swap_core_self] },
-    { have : b ≠ a, by rwa [hb] at ha,
-      simp [swap_core, *] } },
-  { by_cases ha : r = a,
-    { have : b ≠ a, begin rw [ha] at hb, exact ne.symm hb end,
-      simp [swap_core, *] },
-    simp [swap_core, *] }
-end
+by unfold swap_core; split_ifs; cc
 
 theorem swap_core_comm (r a b : α) : swap_core a b r = swap_core b a r :=
-begin
-  by_cases hb : r = b,
-  { by_cases ha : r = a,
-    { simp [hb.symm, ha.symm, swap_core_self] },
-    { have : b ≠ a, by rwa [hb] at ha,
-      simp [swap_core, *] } },
-  { by_cases ha : r = a,
-    { have : a ≠ b, by rwa [ha] at hb,
-      simp [swap_core, *] },
-    simp [swap_core, *] }
-end
+by unfold swap_core; split_ifs; cc
 
 /-- `swap a b` is the permutation that swaps `a` and `b` and
   leaves other values as is. -/

--- a/data/list/basic.lean
+++ b/data/list/basic.lean
@@ -5,7 +5,7 @@ Authors: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn, M
 
 Basic properties of lists.
 -/
-import tactic.interactive tactic.mk_iff_of_inductive_prop
+import tactic.interactive tactic.mk_iff_of_inductive_prop tactic.split_ifs
   logic.basic logic.function
   algebra.group
   data.nat.basic data.option data.bool data.prod data.sigma
@@ -1448,10 +1448,7 @@ theorem count_cons (a b : α) (l : list α) :
 
 theorem count_cons' (a b : α) (l : list α) :
   count a (b :: l) = count a l + (if a = b then 1 else 0) :=
-decidable.by_cases
-  (assume : a = b, begin rw [count_cons, if_pos this, if_pos this] end)
-  (assume : a ≠ b, begin rw [count_cons, if_neg this, if_neg this], reflexivity end)
-
+begin rw count_cons, split_ifs; refl end
 
 @[simp] theorem count_cons_self (a : α) (l : list α) : count a (a::l) = succ (count a l) :=
 if_pos rfl

--- a/tactic/default.lean
+++ b/tactic/default.lean
@@ -4,4 +4,5 @@ import
   tactic.finish
   tactic.mk_iff_of_inductive_prop
   tactic.wlog
+  tactic.split_ifs
 

--- a/tactic/default.lean
+++ b/tactic/default.lean
@@ -4,5 +4,4 @@ import
   tactic.finish
   tactic.mk_iff_of_inductive_prop
   tactic.wlog
-  tactic.split_ifs
 

--- a/tactic/interactive.lean
+++ b/tactic/interactive.lean
@@ -3,7 +3,8 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import data.dlist tactic.basic tactic.rcases tactic.generalize_proofs meta.expr
+import data.dlist tactic.basic tactic.rcases tactic.generalize_proofs
+  tactic.split_ifs meta.expr
 
 open lean
 open lean.parser

--- a/tactic/split_ifs.lean
+++ b/tactic/split_ifs.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2018 Gabriel Ebner. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gabriel Ebner.
+
+Tactic to split if-then-else-expressions.
+-/
+open expr tactic
+
+namespace tactic
+open interactive
+
+meta def find_if_cond : expr → option expr | e :=
+e.fold none $ λ e _ acc, acc <|> do
+c ← match e with
+| `(@ite %%c %%_ _ _ _) := some c
+| `(@dite %%c %%_ _ _ _) := some c
+| _ := none
+end,
+guard ¬c.has_var,
+find_if_cond c <|> return c
+
+meta def find_if_cond_at (at_ : loc) : tactic (option expr) := do
+lctx ← at_.get_locals, lctx ← lctx.mmap infer_type, tgt ← target,
+let es := if at_.include_goal then tgt::lctx else lctx,
+return $ find_if_cond $ es.foldr app (default expr)
+
+run_cmd mk_simp_attr `split_if_reduction
+attribute [split_if_reduction] if_pos if_neg dif_pos dif_neg
+
+meta def reduce_ifs_at (at_ : loc) : tactic unit := do
+sls ← get_user_simp_lemmas `split_if_reduction,
+let cfg : simp_config := { fail_if_unchanged := ff },
+let discharger := assumption <|> (applyc `not_not_intro >> assumption),
+hs ← at_.get_locals, hs.mmap' (λ h, simp_hyp sls [] h cfg discharger >> skip),
+when at_.include_goal (simp_target sls [] cfg discharger)
+
+meta def split_if1 (c : expr) (n : name) (at_ : loc) : tactic unit :=
+by_cases c n; reduce_ifs_at at_
+
+private meta def get_next_name (names : ref (list name)) : tactic name := do
+ns ← read_ref names,
+match ns with
+| [] := get_unused_name `h
+| n::ns := do write_ref names ns, return n
+end
+
+private meta def value_known (c : expr) : tactic bool := do
+lctx ← local_context, lctx ← lctx.mmap infer_type,
+return $ c ∈ lctx ∨ `(¬%%c) ∈ lctx
+
+private meta def split_ifs_core (at_ : loc) (names : ref (list name)) : tactic unit := do
+some cond ← find_if_cond_at at_ | skip,
+let cond := match cond with `(¬%%p) := p | p := p end,
+no_split ← value_known cond,
+if no_split then
+    reduce_ifs_at at_; split_ifs_core
+else do
+    n ← get_next_name names,
+    split_if1 cond n at_; split_ifs_core
+
+meta def split_ifs (names : list name) (at_ : loc := loc.ns [none]) :=
+using_new_ref names (split_ifs_core at_)
+
+namespace interactive
+open interactive interactive.types expr lean.parser
+
+/-- Split if-then-else-expressions into multiple goals.
+
+Given a goal of the form `g (if p then x else y)`, `split_ifs` will produce
+two goals: `p ⊢ g x` and `¬p ⊢ g y`.
+
+If there are multiple ite-expressions, then `split_ifs` picks a top-most
+one whose condition does not contain another ite-expression.
+
+`split_ifs at *` splits all ite-expressions in all hypotheses as well as the goal.
+
+`split_ifs with h₁ h₂ h₃` overrides the default names for the hypotheses.
+-/
+meta def split_ifs (at_ : parse location) (names : parse with_ident_list) : tactic unit :=
+tactic.split_ifs names at_
+
+end interactive
+
+end tactic

--- a/tactic/split_ifs.lean
+++ b/tactic/split_ifs.lean
@@ -65,13 +65,14 @@ using_new_ref names (split_ifs_core at_)
 namespace interactive
 open interactive interactive.types expr lean.parser
 
-/-- Split if-then-else-expressions into multiple goals.
+/-- Splits all if-then-else-expressions into multiple goals.
 
 Given a goal of the form `g (if p then x else y)`, `split_ifs` will produce
 two goals: `p ⊢ g x` and `¬p ⊢ g y`.
 
-If there are multiple ite-expressions, then `split_ifs` picks a top-most
-one whose condition does not contain another ite-expression.
+If there are multiple ite-expressions, then `split_ifs` will split them all,
+starting with a top-most one whose condition does not contain another
+ite-expression.
 
 `split_ifs at *` splits all ite-expressions in all hypotheses as well as the goal.
 

--- a/tests/split_ifs.lean
+++ b/tests/split_ifs.lean
@@ -1,0 +1,15 @@
+import tactic.split_ifs
+
+example (p : Prop) [decidable p] (h : (if p then 1 else 2) > 3) : false :=
+by split_ifs at h; repeat {cases h with h h}
+
+example (p : Prop) [decidable p] (x : ℕ) (h : (if p then 1 else 2) > x) :
+    x < (if ¬p then 1 else 0) + 1 :=
+by split_ifs at *; assumption
+
+example (p : Prop) [decidable p] : if if ¬p then p else true then p else ¬p :=
+by split_ifs; assumption
+
+example (p q : Prop) [decidable p] [decidable q] :
+    if if if p then ¬p else q then p else q then q else ¬p ∨ ¬q :=
+by split_ifs; simp *


### PR DESCRIPTION
Adds a tactic that performs case splits on all ite and dite expressions.
```lean
example (p q : Prop) [decidable p] [decidable q] :
    if if if p then ¬p else q then p else q then q else ¬p ∨ ¬q :=
by split_ifs; simp *
```

I did not find many proofs in mathlib that can be simplified using this tactic.  This is probably due to the fact that most simp lemmas do not rewrite to if-then-else, but use conditions instead.  The most impressive usage so far is in `swap_core_swap_core`, which previously had a 10-line proof:
```lean
def swap_core (a b r : α) : α :=
if r = a then b
else if r = b then a
else r

theorem swap_core_swap_core (r a b : α) : swap_core a b (swap_core a b r) = r :=
by unfold swap_core; split_ifs; cc
```