### PR TITLE
fix(analysis/topology/continuity): remove unused code

### DIFF
--- a/analysis/topology/continuity.lean
+++ b/analysis/topology/continuity.lean
@@ -587,7 +587,7 @@ lemma continuous_pi [topological_space α] [∀i, topological_space (π i)] {f :
   (h : ∀i, continuous (λa, f a i)) : continuous f :=
 continuous_supr_rng $ assume i, continuous_induced_rng $ h i
 
-lemma continuous_apply [topological_space α] [∀i, topological_space (π i)] (i : ι) :
+lemma continuous_apply [∀i, topological_space (π i)] (i : ι) :
   continuous (λp:Πi, π i, p i) :=
 continuous_supr_dom continuous_induced_dom
 


### PR DESCRIPTION
Removing unused alpha in continuous_apply. This function is not used anywhere in mathlib -- would a better name for it be continuous_proj or something (proj for projection)?