### PR TITLE
refactor(data/finset): change structure to subtype

### DIFF
--- a/algebra/big_operators.lean
+++ b/algebra/big_operators.lean
@@ -247,26 +247,26 @@ lemma prod_sum {δ : α → Type*} [∀a, decidable_eq (δ a)]
   {s : finset α} {t : Πa, finset (δ a)} {f : Πa, δ a → β} :
   s.prod (λa, (t a).sum (λb, f a b)) =
     (s.pi t).sum (λp, s.attach.prod (λx, f x.1 (p x.1 x.2))) :=
+finset.induction_on s (by simp)
 begin
-  induction s using finset.induction with a s ha ih,
-  { simp },
-  { have h₁ : ∀x ∈ t a, ∀y∈t a, ∀h : x ≠ y,
-        image (pi.cons s a x) (pi s t) ∩ image (pi.cons s a y) (pi s t) = ∅,
-    { assume x hx y hy h,
-      apply eq_empty_of_forall_not_mem,
-      simp,
-      assume p₁ p₂ hp eq p₃ hp₃ eq', subst eq',
-      have : pi.cons s a x p₂ a (mem_insert_self _ _) = pi.cons s a y p₃ a (mem_insert_self _ _),
-      { rw [eq] },
-      rw [pi.cons_same, pi.cons_same] at this,
-      exact h this },
-    have h₂ : ∀b:δ a, ∀p₁∈pi s t, ∀p₂∈pi s t, pi.cons s a b p₁ = pi.cons s a b p₂ → p₁ = p₂, from
-      assume b p₁ h₁ p₂ h₂ eq, injective_pi_cons ha eq,
-    have h₃ : ∀(v:{x // x ∈ s}) (b:δ a) (h : v.1 ∈ insert a s) (p : Πa, a ∈ s → δ a),
-        pi.cons s a b p v.1 h = p v.1 v.2, from
-      assume v b h p, pi.cons_ne $ assume eq, ha $ eq.symm ▸ v.2,
-    simp [ha, ih, sum_bind h₁, sum_image (h₂ _), sum_mul, h₃],
-    simp [mul_sum] }
+  intros a s ha ih,
+  have h₁ : ∀x ∈ t a, ∀y∈t a, ∀h : x ≠ y,
+      image (pi.cons s a x) (pi s t) ∩ image (pi.cons s a y) (pi s t) = ∅,
+  { assume x hx y hy h,
+    apply eq_empty_of_forall_not_mem,
+    simp,
+    assume p₁ p₂ hp eq p₃ hp₃ eq', subst eq',
+    have : pi.cons s a x p₂ a (mem_insert_self _ _) = pi.cons s a y p₃ a (mem_insert_self _ _),
+    { rw [eq] },
+    rw [pi.cons_same, pi.cons_same] at this,
+    exact h this },
+  have h₂ : ∀b:δ a, ∀p₁∈pi s t, ∀p₂∈pi s t, pi.cons s a b p₁ = pi.cons s a b p₂ → p₁ = p₂, from
+    assume b p₁ h₁ p₂ h₂ eq, injective_pi_cons ha eq,
+  have h₃ : ∀(v:{x // x ∈ s}) (b:δ a) (h : v.1 ∈ insert a s) (p : Πa, a ∈ s → δ a),
+      pi.cons s a b p v.1 h = p v.1 v.2, from
+    assume v b h p, pi.cons_ne $ assume eq, ha $ eq.symm ▸ v.2,
+  simp [ha, ih, sum_bind h₁, sum_image (h₂ _), sum_mul, h₃],
+  simp [mul_sum]
 end
 
 end comm_semiring


### PR DESCRIPTION
This PR redefines `finset` as a `subtype` of `multiset`. In terms of an immediate benefit, there may not be much. It does have a bit of elegance in reusing `subtype` instead of defining one as a `structure`. It does allow the reuse of some `subtype` theorems. Some `finset` theorems might even be better restated using `subtype` as the underlying type, though I didn't do more of that than necessary. The real benefit may be in sharing structure with a future `finmap`, which is also a `subtype` of `multiset` (see #174 for discussion). In particular, there are a number of things that do not depend on the subtype property, which can be shared.

I did run into one strange problem with this change:

```lean
home/travis/build/spl/mathlib/algebra/big_operators.lean:252:11:
state:
α : Type u,
β : Type v,
_inst_1 : decidable_eq α,
_inst_2 : comm_semiring β,
δ : α → Type u_1,
_inst_3 : Π (a : α), decidable_eq (δ a),
t : Π (a : α), finset (δ a),
f : Π (a : α), δ a → β,
s : finset α
⊢ decidable_eq (multiset α)
```

After trying an explicit instance for `decidable_eq (multiset α)`, I learned that

```lean
term has has type
  decidable_eq.{u+1} (multiset.{u} α) : Type u
but is expected to have type
  decidable_eq.{u+2} (multiset.{u} α) : Type (u+1)
```

This occurred at the use of `induction s using finset.induction`. When I changed that to `finset.induction_on s`, the problem went away. I believe this was the only place using `induction s using finset.induction`.