### PR TITLE
Break build process into two parts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,32 @@
-language: generic
+language: c
+
+sudo: false
+
+os:
+    - linux
+
+cache:
+  directories:
+    - $TRAVIS_BUILD_DIR/*/
 
 install:
   - curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh -s -- --default-toolchain none -y
   - source ~/.elan/env
 
-script:
-  - leanpkg test
-  - lean --recursive --export=mathlib.txt
-  - leanchecker mathlib.txt
+jobs:
+  include:
+    - stage: Pre-build
+      script:
+        - rm mathlib.txt || true
+        - timeout 2400 leanpkg test || echo timed out
+        - find . -name "*.lean" -delete
+
+    - stage: Test
+      script:
+        - leanpkg test
+        - lean --recursive --export=mathlib.txt
+        - leanchecker mathlib.txt
+        - find . -name "*.lean" -delete
 
 notifications:
   webhooks:


### PR DESCRIPTION
Tweaked the travis build to cache the binaries and automatically retry once while preserving the binaries if the build times out.