### PR TITLE
chore(build): make travis build fail quicker when errors are found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,23 +14,27 @@ install:
       curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh -s -- --default-toolchain none -y
     fi
   - source ~/.elan/env
+  - mkdir $HOME/scripts || echo ""
+  - export PATH="$HOME/scripts:$PATH"
+  - cp travis_long.sh $HOME/scripts/travis_long
+  - chmod +x $HOME/scripts/travis_long
 
 jobs:
   include:
     - stage: Pre-build
       script:
-        - git status | grep  -e "Changes not staged for commit:"; [ $? -ne 0 ] || git checkout -f HEAD
+        - (git status | grep  -e "Changes not staged for commit:"); RESULT=$?
+        - if [ $RESULT -eq 0 ]; then git checkout -f HEAD ; fi
         - rm mathlib.txt || true
-        - timeout 2400 leanpkg test || echo timed out
+        - travis_long "timeout 2400 leanpkg test" | awk 'BEGIN{e=0;c=-1}c&&--c;/error/{if (!e) {c=30;e=1}};{if (!c) {exit 1}}'
+
 
     - stage: Test
       script:
-        - git status | grep  -e "Changes not staged for commit:"; [ $? -ne 0 ]
+        - (git status | grep  -e "Changes not staged for commit:"); test $? -ne 0
         - leanpkg test
         - lean --recursive --export=mathlib.txt
         - leanchecker mathlib.txt
-        - find . -name "*.lean" -delete
-
 
 notifications:
   webhooks:

--- a/travis_long.sh
+++ b/travis_long.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+
+# 
+# This script is taken from:
+# 
+# https://docs.haskellstack.org/en/stable/travis_ci/
+# https://github.com/futurice/fum2github/blob/master/travis_long
+
+# The following explains the 50min hard timeout on macs
+# https://github.com/travis-ci/travis-ci/issues/3810
+
+$* &
+pidA=$!
+minutes=0
+
+while true; do sleep 60; ((minutes++)); echo -e "\033[0;32m$minutes minute(s) elapsed.\033[0m"; done &
+    pidB=$!
+
+    wait $pidA
+    exitCode=$?
+
+    echo -e "\033[0;32m$* finished.\033[0m"
+
+    kill -9 $pidB
+    exit $exitCode


### PR DESCRIPTION
Make first stage fail when errors are found. Side effect: error reports are limited to one line.