### PR TITLE
feat(analysis/norms) Adds various normed stuff

### DIFF
--- a/analysis/metric_space_fintype_pi.lean
+++ b/analysis/metric_space_fintype_pi.lean
@@ -1,0 +1,74 @@
+import analysis.metric_space
+
+variables {α : Type*} {β : Type*}
+noncomputable theory
+
+namespace finset
+
+lemma image_const [decidable_eq β] {s : finset α} (h : s ≠ ∅) (b : β) : s.image (λa, b) = singleton b :=
+ext.2 $ assume b', by simp [exists_mem_of_ne_empty h, eq_comm]
+
+@[simp] theorem max_singleton' [decidable_linear_order α] {a : α} : finset.max (singleton a) = some a :=
+max_singleton
+
+section Max
+open option
+
+variables [decidable_linear_order β] [inhabited β] {s : finset α} {f : α → β}
+
+def maxi [decidable_linear_order β] [inhabited β] (s : finset α) (f : α → β) : β :=
+(s.image f).max.iget
+
+@[simp] lemma maxi_empty : (∅ : finset α).maxi f = default β := rfl
+
+lemma maxi_mem (f : α → β) (h : s ≠ ∅) : s.maxi f ∈ s.image f :=
+let ⟨a, ha⟩ := exists_mem_of_ne_empty h in
+mem_of_max $ (iget_mem $ is_some_iff_exists.2 $ max_of_mem (mem_image_of_mem f ha))
+
+lemma maxi_le {b : β} (hf : ∀a∈s, f a ≤ b) (hd : s = ∅ → default β ≤ b) : s.maxi f ≤ b :=
+classical.by_cases
+  (assume h : s = ∅, by simp * at * )
+  (assume h : s ≠ ∅,
+    let ⟨a, ha, eq⟩ := mem_image.1 $ maxi_mem f h in
+    eq ▸ hf a ha)
+
+lemma le_maxi {a : α} (h : a ∈ s) : f a ≤ s.maxi f :=
+le_max_of_mem (mem_image_of_mem f h) (iget_mem $ is_some_iff_exists.2 $ max_of_mem (mem_image_of_mem f h))
+
+lemma le_maxi_of_forall {b : β} (hb : ∀a∈s, b ≤ f a) (hd : s = ∅ → b ≤ default β) : b ≤ s.maxi f :=
+classical.by_cases
+  (assume h : s = ∅, by simp * at * )
+  (assume h : s ≠ ∅,
+    let ⟨a, ha, eq⟩ := mem_image.1 $ maxi_mem f h in
+    eq ▸ hb a ha)
+
+@[simp] lemma maxi_const {b : β} (h : s = ∅ → b = default β) : s.maxi (λa, b) = b :=
+classical.by_cases
+  (assume h : s = ∅, by simp * at * )
+  (assume h, by simp [maxi, image_const h])
+
+end Max
+
+end finset
+
+@[simp] lemma real.default_eq : default ℝ = 0 :=
+rfl
+
+namespace metric_space
+open finset
+
+instance fintype_function {α : β → Type*} [fintype β] [∀b, metric_space (α b)] :
+  metric_space (Πb, α b) :=
+{ dist := λf g, maxi univ (λb, _root_.dist (f b) (g b)),
+  dist_self := assume f, by simp,
+  dist_comm := assume f g, by congr; funext b; exact dist_comm _ _,
+  dist_triangle := assume f g h, maxi_le
+    (assume b hb,
+      calc dist (f b) (h b) ≤ dist (f b) (g b) + dist (g b) (h b) : dist_triangle _ _ _
+        ... ≤ maxi univ (λb, _root_.dist (f b) (g b)) + maxi univ (λb, _root_.dist (g b) (h b)) :
+          add_le_add (le_maxi hb) (le_maxi hb))
+    (by simp [le_refl] {contextual := tt}),
+  eq_of_dist_eq_zero := assume f g eq0, funext $ assume b, dist_le_zero.1 $ eq0 ▸
+    show dist (f b) (g b) ≤ maxi univ (λb, dist (f b) (g b)), from le_maxi (mem_univ b) }
+
+end metric_space

--- a/analysis/norms.lean
+++ b/analysis/norms.lean
@@ -1,0 +1,292 @@
+import analysis.real
+import linear_algebra.prod_module
+import algebra.pi_instances
+import analysis.metric_space_fintype_pi
+
+noncomputable theory
+
+local notation f `→_{`:50 a `}`:0 b := filter.tendsto f (nhds a) (nhds b)
+
+class normed_group (α : Type*) extends add_comm_group α, metric_space α :=
+(norm : α → ℝ)
+(dist_eq : ∀ x y, dist x y = norm (x - y))
+
+
+def norm {G : Type*} [normed_group G] : G → ℝ := normed_group.norm 
+notation `∥` e `∥` := norm e
+
+section normed_group
+variables {G : Type*} [normed_group G] {H : Type*} [normed_group H]
+
+
+lemma norm_dist' { g h : G} : dist g h = ∥g - h∥ :=
+normed_group.dist_eq _ _
+
+@[simp]
+lemma norm_dist { g : G} : dist g 0 = ∥g∥ :=
+by { rw[norm_dist'], simp }
+
+lemma norm_triangle (g h : G) : ∥g + h∥ ≤ ∥g∥ + ∥h∥ :=
+calc ∥g + h∥ = ∥g - (-h)∥             : by simp
+         ... = dist g (-h)            : by simp[norm_dist']
+         ... ≤ dist g 0 + dist 0 (-h) : by apply dist_triangle
+         ... = ∥g∥ + ∥h∥               : by simp[norm_dist']
+
+@[simp]
+lemma norm_nonneg {g : G} : 0 ≤ ∥g∥ :=
+by { rw[←norm_dist], exact dist_nonneg }
+
+lemma norm_zero_iff_zero {g : G} : ∥g∥ = 0 ↔ g = 0 :=
+by { rw[←norm_dist], exact dist_eq_zero }
+
+@[simp]
+lemma zero_norm_zero : ∥(0:G)∥ = 0 :=
+norm_zero_iff_zero.2 (by simp)
+
+lemma norm_pos_iff {g : G} : ∥ g ∥  > 0 ↔ g ≠ 0 :=
+begin
+  split ; intro h ; rw[←norm_dist] at *,
+  { exact dist_pos.1 h },
+  { exact dist_pos.2 h }
+end
+
+lemma norm_le_zero_iff {g : G} : ∥g∥ ≤ 0 ↔ g = 0 :=
+by { rw[←norm_dist], exact dist_le_zero }
+
+
+@[simp]
+lemma norm_neg {g : G} : ∥-g∥ = ∥g∥ :=
+calc ∥-g∥ = ∥0 - g∥ : by simp
+      ... = dist 0 g : norm_dist'.symm
+      ... = dist g 0 : dist_comm _ _
+      ... = ∥g - 0∥ : norm_dist'
+      ... = ∥g∥ : by simp
+
+lemma norm_triangle' (g h : G) : abs(∥g∥ - ∥h∥) ≤ ∥g - h∥ := 
+begin
+  have ng := calc ∥g∥ = ∥g - h + h∥ : by simp
+  ... ≤ ∥g-h∥ + ∥h∥ : norm_triangle _ _,
+  replace ng := sub_right_le_of_le_add ng,
+  have nh := calc ∥h∥ = ∥h - g + g∥ : by simp
+  ... ≤ ∥h - g∥ + ∥g∥ : norm_triangle _ _
+  ... = ∥-(g - h)∥ + ∥g∥ : by simp
+  ... = ∥g - h∥ + ∥g∥ : by { rw [show ∥-(g - h)∥ = ∥g-h∥, from norm_neg] },
+  replace nh := sub_right_le_of_le_add nh,
+  replace nh : -(∥g∥ - ∥h∥) ≤ ∥g - h∥ := by simpa using nh,
+  replace nh : -∥g - h∥ ≤ ∥g∥ - ∥h∥ := by simpa using neg_le_neg nh,
+  exact abs_le.2 ⟨nh, ng⟩
+end
+
+instance prod.normed_group {F : Type*} [normed_group F] : normed_group (G × F) :=
+{ norm := λ x, max ∥x.1∥ ∥x.2∥,
+  dist_eq := assume x y, by { simp, repeat {rw norm_dist'}, simp } }
+  
+
+lemma norm_proj1_le (x : G × H) : ∥x.1∥ ≤ ∥x∥ :=
+begin  have : ∥x∥ = max  (∥x.fst∥) ( ∥x.snd∥) := rfl, rw this, simp[le_max_left], end
+
+lemma norm_proj2_le (x : G × H) : ∥x.2∥ ≤ ∥x∥ :=
+begin  have : ∥x∥ = max  (∥x.fst∥) ( ∥x.snd∥) := rfl, rw this, simp[le_max_right], end
+
+instance fintype.normed_group {ι : Type*} {α : ι → Type*} [fintype ι] [∀i, normed_group (α i)] :
+  normed_group (Πb, α b) :=
+{ norm := λf, finset.maxi finset.univ (λ b, ∥f b∥),
+  dist_eq := assume x y, by finish [norm_dist'] }
+
+lemma tendsto_iff_norm_tendsto_zero {f : G → H} {a : G} {b : H} : (f →_{a} b) ↔ ((λ e, ∥ f e - b ∥) →_{a} 0) :=
+by rw tendsto_iff_dist_tendsto_zero ; simp only [norm_dist'.symm]  
+
+lemma lim_norm (x: G) : ((λ g, ∥g-x∥) : G → ℝ) →_{x} 0 :=
+  tendsto_iff_norm_tendsto_zero.1 (continuous_iff_tendsto.1 continuous_id x)
+
+lemma lim_norm_zero  : ((λ g, ∥g∥) : G → ℝ) →_{0} 0 :=
+by simpa using lim_norm (0:G)
+
+lemma squeeze_zero {T : Type*} [metric_space T] {f g : T → ℝ} {t₀ : T} : 
+(∀ t : T, 0 ≤ f t) → (∀ t : T, f t ≤ g t) → (g →_{t₀} 0) → (f →_{t₀} 0) :=
+begin
+  intros _ _ g0,
+  apply tendsto_of_tendsto_of_tendsto_of_le_of_le (tendsto_const_nhds) g0;
+  simp [*]; exact filter.univ_mem_sets
+end
+
+lemma norm_continuous {G : Type*} [normed_group G]: continuous ((λ g, ∥g∥) : G → ℝ) := 
+begin
+  apply continuous_iff_tendsto.2,
+  intro x,
+  have : (λ (g : G), dist ∥g∥ ∥x∥) →_{x} 0 := 
+    squeeze_zero (λ t, abs_nonneg _) (λ t, norm_triangle' _ _) (lim_norm x),
+  exact tendsto_iff_dist_tendsto_zero.2 this
+end
+
+
+instance normed_top_monoid  : topological_add_monoid G  := 
+⟨begin 
+  apply continuous_iff_tendsto.2 _,
+  intro x,
+  apply tendsto_iff_norm_tendsto_zero.2,
+  
+  have ineq := λ e: G × G, calc
+  ∥e.fst + e.snd - (x.fst + x.snd)∥ = ∥(e.fst-x.fst) + (e.snd - x.snd)∥ : by simp
+  ... ≤ ∥e.fst - x.fst∥ + ∥ e.snd - x.snd ∥  : norm_triangle (e.fst-x.fst) (e.snd - x.snd),
+
+  apply squeeze_zero (by simp) ineq,
+  
+  have ineq1 : ∀ e : G × G, ∥ e.fst - x.fst∥ ≤ ∥e - x∥ := assume e, norm_proj1_le (e-x),
+  have lim1 : (λ e : G × G, ∥ e.fst - x.fst∥) →_{x} 0 := squeeze_zero (by simp) ineq1 (lim_norm x), 
+  
+  have ineq2 : ∀ e : G × G, ∥ e.snd - x.snd∥ ≤ ∥e - x∥ := assume e, norm_proj2_le (e-x),
+  have lim2 : (λ e : G × G, ∥ e.snd - x.snd∥) →_{x} 0 := squeeze_zero (by simp) ineq2 (lim_norm x), 
+  
+  simpa using tendsto_add lim1 lim2
+end⟩
+
+instance normed_top_group  : topological_add_group G  := 
+{ continuous_neg := begin
+    apply continuous_iff_tendsto.2,
+    intro x,
+    apply tendsto_iff_norm_tendsto_zero.2,
+
+    have lim_negx : (λ (e : G), -x ) →_{x} -x := tendsto_const_nhds,
+    have lim_e : (λ (e : G), e) →_{x} x := continuous_iff_tendsto.1 continuous_id x,
+    have lim : (λ (y : G), y - x) →_{x} 0, by simpa using tendsto_add lim_negx lim_e,
+
+    have key : ∀ e, ∥-e - -x∥ = ∥e - x∥ := λ e, calc 
+      ∥-e - -x∥ = ∥-(e - x)∥ : by simp
+            ... = ∥e - x∥ : by rw norm_neg,
+    
+    simpa only [key] using filter.tendsto.comp lim lim_norm_zero
+  end }
+
+end normed_group
+
+section normed_ring
+class normed_ring (α : Type*) extends ring α, metric_space α :=
+(norm : α → ℝ)
+(dist_eq : ∀ x y, dist x y = norm (x - y))
+(norm_mul : ∀ a b, norm (a * b) ≤ norm a * norm b)
+
+variables {α : Type*} {β : Type*}
+
+instance normed_ring.to_normed_group [H : normed_ring α] : normed_group α := { ..H }
+
+lemma norm_mul {α : Type*} [normed_ring α] (a b : α) : (∥a*b∥) ≤ (∥a∥) * (∥b∥) :=
+normed_ring.norm_mul _ _
+
+
+instance prod.ring [ring α] [ring β] : ring (α × β) :=
+{ left_distrib := assume x y z, calc
+    x*(y+z) = (x.1, x.2) * (y.1 + z.1, y.2 + z.2) : rfl
+    ... = (x.1*(y.1 + z.1), x.2*(y.2 + z.2)) : rfl
+    ... = (x.1*y.1 + x.1*z.1, x.2*y.2 + x.2*z.2) : by simp[left_distrib],
+  right_distrib := assume x y z, calc
+    (x+y)*z = (x.1 + y.1, x.2 + y.2)*(z.1, z.2) : rfl
+    ... = ((x.1 + y.1)*z.1, (x.2 + y.2)*z.2) : rfl
+    ... = (x.1*z.1 + y.1*z.1, x.2*z.2 + y.2*z.2) : by simp[right_distrib],
+  ..prod.monoid,
+  ..prod.add_comm_group}
+
+instance prod.normed_ring [normed_ring α] [normed_ring β] : normed_ring (α × β) :=
+{ norm_mul := assume x y, 
+  calc
+    ∥x * y∥ = ∥(x.1*y.1, x.2*y.2)∥ : rfl 
+        ... = (max ∥x.1*y.1∥  ∥x.2*y.2∥) : rfl
+        ... ≤ (max (∥x.1∥*∥y.1∥) (∥x.2∥*∥y.2∥)) : max_le_max (norm_mul (x.1) (y.1)) (norm_mul (x.2) (y.2))
+        ... = (max (∥x.1∥*∥y.1∥) (∥y.2∥*∥x.2∥)) : by simp[mul_comm]
+        ... ≤ (max (∥x.1∥) (∥x.2∥)) * (max (∥y.2∥) (∥y.1∥)) : by { apply max_mul_mul_le_max_mul_max; simp [norm_nonneg] }
+        ... = (max (∥x.1∥) (∥x.2∥)) * (max (∥y.1∥) (∥y.2∥)) : by simp[max_comm]
+        ... = (∥x∥*∥y∥) : rfl,
+  ..prod.normed_group }
+end normed_ring
+
+section normed_field
+variables {α : Type*}
+
+class normed_field (α : Type*) extends discrete_field α, metric_space α :=
+(norm : α → ℝ)
+(dist_eq : ∀ x y, dist x y = norm (x - y))
+(norm_mul : ∀ a b, norm (a * b) = norm a * norm b)
+
+instance normed_field.to_normed_ring [H : normed_field α] : normed_ring α :=
+{ norm_mul := by finish[H.norm_mul], ..H }
+
+instance : normed_field ℝ :=
+{ norm := λ x, abs x, 
+  dist_eq := assume x y, rfl,
+  norm_mul := abs_mul}
+
+end normed_field
+
+section normed_space
+
+class normed_space (α : out_param $ Type*) (β : Type*) [out_param $ normed_field α] extends vector_space α β, metric_space β :=
+(norm : β → ℝ)
+(dist_eq : ∀ x y, dist x y = norm (x - y))
+(norm_smul : ∀ a b, norm (a • b) = normed_field.norm a * norm b)
+
+variables {α : Type*} [normed_field α]  {β : Type*}
+
+instance normed_space.to_normed_group [H : normed_space α β] : normed_group β :=
+by refine { add := (+),
+            dist_eq := normed_space.dist_eq,
+            zero := 0,
+            neg := λ x, -x,
+            ..H, .. }; simp
+
+variable [normed_space α β] 
+
+lemma norm_smul (s : α) (x : β) : ∥s • x∥ = ∥s∥ * ∥x∥ :=
+normed_space.norm_smul _ _
+
+variables {E : Type*} {F : Type*} [normed_space α E] [normed_space α F]
+
+lemma tendsto_smul {f : E → α} { g : E → F} {e : E} {s : α} {b : F} :
+(f →_{e} s) → (g →_{e} b) → ((λ e, (f e) • (g e)) →_{e} s • b) := 
+begin
+  intros limf limg,
+  apply tendsto_iff_norm_tendsto_zero.2,
+  have ineq := λ x : E, calc 
+      ∥f x • g x - s • b∥ = ∥(f x • g x - s • g x) + (s • g x - s • b)∥ : by simp[add_assoc]
+                      ... ≤ ∥f x • g x - s • g x∥ + ∥s • g x - s • b∥ : norm_triangle (f x • g x - s • g x) (s • g x - s • b)
+                      ... ≤ ∥f x - s∥*∥g x∥ + ∥s∥*∥g x - b∥ : by { rw [←smul_sub, ←sub_smul, norm_smul, norm_smul] },
+  apply squeeze_zero,
+  { intro t, exact norm_nonneg },
+  { exact ineq },
+  { clear ineq,
+    
+    have limf': (λ (x : E), ∥f x - s∥)→_{e}0 := tendsto_iff_norm_tendsto_zero.1 limf,
+    have limg' : (λ (x : E), ∥g x∥) →_{e} ∥b∥ := filter.tendsto.comp limg (continuous_iff_tendsto.1 norm_continuous _),
+    
+    have lim1 : (λ (x : E), ∥f x - s∥ * ∥g x∥)→_{e}0, 
+      by simpa using tendsto_mul limf' limg',
+    have limg3 := tendsto_iff_norm_tendsto_zero.1 limg,
+    have lim2 : (λ (x : E), ∥s∥ * ∥g x - b∥) →_{e} 0, 
+      by simpa using tendsto_mul tendsto_const_nhds limg3,
+        
+    rw [show (0:ℝ) = 0 + 0, by simp],
+    exact tendsto_add lim1 lim2  }
+end
+
+instance product_normed_space : normed_space α (E × F) := 
+{ norm_smul := 
+  begin 
+    intros s x,
+    cases x with x₁ x₂,
+    exact calc 
+      ∥s • (x₁, x₂)∥ = ∥ (s • x₁, s• x₂)∥ : rfl
+      ... = max (∥s • x₁∥) (∥ s• x₂∥) : rfl
+      ... = max (∥s∥ * ∥x₁∥) (∥s∥ * ∥x₂∥) : by simp[norm_smul s x₁, norm_smul s x₂]
+      ... = ∥s∥ * max (∥x₁∥) (∥x₂∥) : by simp[mul_max_of_nonneg]
+  end,
+  
+  add_smul := by simp[add_smul], 
+  -- I have no idea why by simp[smul_add] is not enough for the next goal
+  smul_add := assume r x y,  show (r•(x+y).fst, r•(x+y).snd)  = (r•x.fst+r•y.fst, r•x.snd+r•y.snd), 
+               by simp[smul_add],             
+  ..prod.normed_group, 
+  ..prod.vector_space }
+
+instance fintype.normed_space {ι : Type*} {E : ι → Type*} [fintype ι] [∀i, normed_space α (E i)] :
+  normed_space α (Πi, E i) := 
+sorry
+end normed_space


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [x] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

This is my old work on normed spaces. I got stuck because of the last instance where I try to build norms on finite products of normed spaces, and run into instance loop issues (with `module` of course).

I cannot say I'm super happy about how computations work in this file, and some proof take a long time to compile. The main trouble is that we cannot use lemmas about addition and multiplication of limits as mathematicians would do, in a calc block. Also those lemmas frequently don't quite match the goal because you need to use simp lemmas aferwards (typically 0 + 0 = 0 or its multiplicative lemmas). The proof can be made still somewhat nice to see using `simpa` but this is slow. See for instance the proof of `tendsto_smul`.

I also tried to use the new `apply_rules` but with very random and slow success.


For reviewers: [code review check list](./docs/code-review.md)
