### PR TITLE
fix(data/list/basic): typo in pariwise_iff

### DIFF
--- a/data/list/basic.lean
+++ b/data/list/basic.lean
@@ -2935,7 +2935,7 @@ inductive pairwise : list α → Prop
 | cons : ∀ {a : α} {l : list α}, (∀ a' ∈ l, R a a') → pairwise l → pairwise (a::l)
 attribute [simp] pairwise.nil
 
-run_cmd tactic.mk_iff_of_inductive_prop `list.pairwise `list.pariwise_iff
+run_cmd tactic.mk_iff_of_inductive_prop `list.pairwise `list.pairwise_iff
 
 variable {R}
 @[simp] theorem pairwise_cons {a : α} {l : list α} :


### PR DESCRIPTION
 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [x] make sure definitions and lemmas are put in the right files
 * [x] make sure definitions and lemmas are not redundant