### PR TITLE
feat(algebra/group_power): adding various cast power lemmas for nat and int

### DIFF
--- a/algebra/group_power.lean
+++ b/algebra/group_power.lean
@@ -308,7 +308,7 @@ by rw [add_monoid.smul_eq_mul', add_monoid.smul_eq_mul', mul_assoc]
 theorem add_monoid.mul_smul_assoc [semiring α] (a b : α) (n : ℕ) : n • (a * b) = n • a * b :=
 by rw [add_monoid.smul_eq_mul, add_monoid.smul_eq_mul, mul_assoc]
 
-theorem nat.cast_pow [semiring α] (n m : ℕ) : (n : α) ^ m = (n ^ m : ℕ) :=
+@[simp] theorem nat.cast_pow [semiring α] (n m : ℕ) : (↑(n ^ m) : α) = ↑n ^ m :=
 by induction m; simp [*, nat.succ_eq_add_one, nat.pow_add, pow_add]
 
 @[simp] theorem int.coe_nat_pow (n m : ℕ) : ((n ^ m : ℕ) : ℤ)  = n ^ m := 
@@ -331,7 +331,7 @@ by rw [gsmul_eq_mul', gsmul_eq_mul', mul_assoc]
 theorem mul_gsmul_assoc [ring α] (a b : α) (n : ℤ) : n •ℤ (a * b) = n •ℤ a * b :=
 by rw [gsmul_eq_mul, gsmul_eq_mul, mul_assoc]
 
-theorem int.cast_pow [ring α] (n : ℤ) (m : ℕ) : (n : α) ^ m = (n ^ m : ℤ) :=
+@[simp] theorem int.cast_pow [ring α] (n : ℤ) (m : ℕ) : (↑(n ^ m) : α) = ↑n ^ m :=
 by induction m; simp [*, nat.succ_eq_add_one,pow_add]
 
 theorem pow_ne_zero [domain α] {a : α} (n : ℕ) (h : a ≠ 0) : a ^ n ≠ 0 :=

--- a/algebra/group_power.lean
+++ b/algebra/group_power.lean
@@ -308,6 +308,10 @@ by rw [add_monoid.smul_eq_mul', add_monoid.smul_eq_mul', mul_assoc]
 theorem add_monoid.mul_smul_assoc [semiring α] (a b : α) (n : ℕ) : n • (a * b) = n • a * b :=
 by rw [add_monoid.smul_eq_mul, add_monoid.smul_eq_mul, mul_assoc]
 
+theorem nat.cast_pow [semiring α] (n : ℕ) : ∀ m : ℕ, (n : α) ^ m = (n ^ m : ℕ)
+| 0 := nat.cast_one.symm 
+| (d+1) := show ↑n * ↑n ^ d = ↑(n ^ d * n), by rw [nat.cast_pow d,mul_comm,nat.cast_mul]
+
 theorem neg_one_pow_eq_or {R} [ring R] : ∀ n : ℕ, (-1 : R)^n = 1 ∨ (-1 : R)^n = -1
 | 0     := by simp
 | (n+1) := by cases neg_one_pow_eq_or n; simp [pow_succ, h]

--- a/algebra/group_power.lean
+++ b/algebra/group_power.lean
@@ -308,9 +308,11 @@ by rw [add_monoid.smul_eq_mul', add_monoid.smul_eq_mul', mul_assoc]
 theorem add_monoid.mul_smul_assoc [semiring α] (a b : α) (n : ℕ) : n • (a * b) = n • a * b :=
 by rw [add_monoid.smul_eq_mul, add_monoid.smul_eq_mul, mul_assoc]
 
-theorem nat.cast_pow [semiring α] (n : ℕ) : ∀ m : ℕ, (n : α) ^ m = (n ^ m : ℕ)
-| 0 := nat.cast_one.symm 
-| (d+1) := show ↑n * ↑n ^ d = ↑(n ^ d * n), by rw [nat.cast_pow d,mul_comm,nat.cast_mul]
+theorem nat.cast_pow [semiring α] (n m : ℕ) : (n : α) ^ m = (n ^ m : ℕ) :=
+by induction m; simp [*, nat.succ_eq_add_one, nat.pow_add, pow_add]
+
+@[simp] theorem int.coe_nat_pow (n m : ℕ) : ((n ^ m : ℕ) : ℤ)  = n ^ m := 
+by induction m; simp [*, pow_succ', nat.pow_succ]
 
 theorem neg_one_pow_eq_or {R} [ring R] : ∀ n : ℕ, (-1 : R)^n = 1 ∨ (-1 : R)^n = -1
 | 0     := by simp
@@ -328,6 +330,9 @@ by rw [gsmul_eq_mul', gsmul_eq_mul', mul_assoc]
 
 theorem mul_gsmul_assoc [ring α] (a b : α) (n : ℤ) : n •ℤ (a * b) = n •ℤ a * b :=
 by rw [gsmul_eq_mul, gsmul_eq_mul, mul_assoc]
+
+theorem int.cast_pow [ring α] (n : ℤ) (m : ℕ) : (n : α) ^ m = (n ^ m : ℤ) :=
+by induction m; simp [*, nat.succ_eq_add_one,pow_add]
 
 theorem pow_ne_zero [domain α] {a : α} (n : ℕ) (h : a ≠ 0) : a ^ n ≠ 0 :=
 by induction n with n ih; simp [pow_succ, mul_eq_zero, *]

--- a/data/nat/basic.lean
+++ b/data/nat/basic.lean
@@ -372,6 +372,8 @@ by induction k; simp [*, add_succ, bind_assoc]
 theorem pow_add (a m n : ℕ) : a^(m + n) = a^m * a^n :=
 by induction n; simp [*, pow_succ, mul_assoc]
 
+theorem pow_two (a : ℕ) : a ^ 2 = a * a := show (1 * a) * a = _, by rw one_mul
+
 theorem pow_dvd_pow (a : ℕ) {m n : ℕ} (h : m ≤ n) : a^m ∣ a^n :=
 by rw [← nat.add_sub_cancel' h, pow_add]; apply dvd_mul_right
 

--- a/data/nat/basic.lean
+++ b/data/nat/basic.lean
@@ -180,6 +180,9 @@ protected theorem eq_mul_of_div_eq_left {a b c : ℕ} (H1 : b ∣ a) (H2 : a / b
   a = c * b :=
 by rw [mul_comm, nat.eq_mul_of_div_eq_right H1 H2]
 
+protected theorem mul_div_cancel_left' {a b : ℕ} (Hd :  a ∣ b) : a * (b / a) = b :=
+by rw [mul_comm,nat.div_mul_cancel Hd] 
+
 protected theorem div_mod_unique {n k m d : ℕ} (h : 0 < k) :
   n / k = d ∧ n % k = m ↔ m + k * d = n ∧ m < k :=
 ⟨λ ⟨e₁, e₂⟩, e₁ ▸ e₂ ▸ ⟨mod_add_div _ _, mod_lt _ h⟩,
@@ -383,6 +386,9 @@ theorem pow_dvd_pow_of_dvd {a b : ℕ} (h : a ∣ b) : ∀ n:ℕ, a^n ∣ b^n
 
 theorem mul_pow (a b n : ℕ) : (a * b) ^ n = a ^ n * b ^ n := 
 by induction n; simp [*, nat.pow_succ, mul_comm, mul_assoc, mul_left_comm]
+
+protected theorem pow_mul (a b n : ℕ) : n ^ (a * b) = (n ^ a) ^ b :=
+by induction b; simp [*, nat.succ_eq_add_one, nat.pow_add, mul_add, mul_comm]
 
 @[simp] theorem bodd_div2_eq (n : ℕ) : bodd_div2 n = (bodd n, div2 n) :=
 by unfold bodd div2; cases bodd_div2 n; refl


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)

***

My users are switching between naturals and other types such as integers and integers mod n, and these two lemmas (relationship between nat.pow and monoid.pow, and the nat version of monoid.pow_two) keep showing up. 