### PR TITLE
Add GCD domains

### DIFF
--- a/algebra/gcd_domain.lean
+++ b/algebra/gcd_domain.lean
@@ -1,0 +1,311 @@
+/-
+Copyright (c) 2018 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Jens Wagemaker
+
+GCD domain and integral domains with normalization functions
+
+TODO: abstract the domains to to semi domains (i.e. domains on semirings) to include ℕ and ℕ[X] etc.
+-/
+import algebra.ring
+
+variables {α : Type*}
+
+set_option old_structure_cmd true
+
+/-- Normalization domain: multiplying with `norm_unit` gives a normal form for associated elements. -/
+class normalization_domain (α : Type*) extends integral_domain α :=
+(norm_unit : α → units α)
+(norm_unit_zero      : norm_unit 0 = 1)
+(norm_unit_mul       : ∀a b, a ≠ 0 → b ≠ 0 → norm_unit (a * b) = norm_unit a * norm_unit b)
+(norm_unit_coe_units : ∀(u : units α), norm_unit u = u⁻¹)
+
+export normalization_domain (norm_unit norm_unit_zero norm_unit_mul norm_unit_coe_units)
+
+attribute [simp] norm_unit_coe_units norm_unit_zero norm_unit_mul
+
+section normalization_domain
+variable [normalization_domain α]
+
+@[simp] theorem norm_unit_one : norm_unit (1:α) = 1 :=
+norm_unit_coe_units 1
+
+theorem norm_unit_mul_norm_unit (a : α) : norm_unit (a * norm_unit a) = 1 :=
+classical.by_cases (assume : a = 0, by simp [this]) $
+  assume h, by rw [norm_unit_mul _ _ h (units.ne_zero _), norm_unit_coe_units, mul_inv_eq_one]
+
+theorem associated_of_dvd_of_dvd : ∀{a b : α}, a ∣ b → b ∣ a → ∃u:units α, a * u = b
+| a b ⟨c, rfl⟩ ⟨d, hd⟩ :=
+  classical.by_cases (assume : c = 0, ⟨1, by simp * at *⟩) $ assume hc : c ≠ 0,
+  classical.by_cases (assume : a = 0, ⟨1, by simp * at *⟩) $ assume ha : a ≠ 0,
+  have a * 1 = a * (c * d), by simpa [mul_assoc] using hd,
+  have 1 = c * d, from eq_of_mul_eq_mul_left ha this,
+  ⟨units.mk_of_mul_eq_one c d this.symm, rfl⟩
+
+theorem mul_norm_unit_eq_mul_norm_unit {a b : α}
+  (hab : a ∣ b) (hba : b ∣ a) : a * norm_unit a = b * norm_unit b :=
+begin
+  rcases associated_of_dvd_of_dvd hab hba with ⟨u, rfl⟩,
+  refine classical.by_cases (assume : a = 0, by simp [this] at *) (assume ha : a ≠ 0, _),
+  suffices : a * ↑(norm_unit a) = a * ↑u * ↑(norm_unit a) * ↑u⁻¹, by simpa [ha, mul_assoc],
+  calc a * ↑(norm_unit a) = a * ↑(norm_unit a) * ↑ u * ↑u⁻¹: by simp
+    ... = a * ↑u * ↑(norm_unit a) * ↑u⁻¹ : by ac_refl
+end
+
+theorem dvd_antisymm_of_norm {a b : α}
+  (ha : norm_unit a = 1) (hb : norm_unit b = 1) (hab : a ∣ b) (hba : b ∣ a) :
+  a = b :=
+have a * norm_unit a = b * norm_unit b, from mul_norm_unit_eq_mul_norm_unit hab hba,
+by simpa [ha, hb]
+
+end normalization_domain
+
+/-- GCD domain: an integral domain with normalization and `gcd` (greatest common divisor) and
+`lcm` (least common multiple) operations. In this setting `gcd` and `lcm` form a bounded lattice on
+the associated elements where `gcd` is the infimum, `lcm` is the supremum, `1` is bottom, and
+`0` is top. The type class focuses on `gcd` and we derive the correpsonding `lcm` facts from `gcd`.
+-/
+class gcd_domain (α : Type*) extends normalization_domain α :=
+(gcd : α → α → α)
+(lcm : α → α → α)
+(gcd_dvd_left   : ∀a b, gcd a b ∣ a)
+(gcd_dvd_right  : ∀a b, gcd a b ∣ b)
+(dvd_gcd        : ∀{a b c}, a ∣ c → a ∣ b → a ∣ gcd c b)
+(norm_unit_gcd  : ∀a b, norm_unit (gcd a b) = 1)
+(gcd_mul_lcm    : ∀a b, gcd a b * lcm a b = a * b * norm_unit (a * b))
+(lcm_zero_left  : ∀a, lcm 0 a = 0)
+(lcm_zero_right : ∀a, lcm a 0 = 0)
+
+export gcd_domain (gcd lcm gcd_dvd_left gcd_dvd_right dvd_gcd  lcm_zero_left lcm_zero_right)
+
+attribute [simp] lcm_zero_left lcm_zero_right
+
+section gcd_domain
+variables [gcd_domain α]
+
+@[simp] theorem norm_unit_gcd : ∀a b:α, norm_unit (gcd a b) = 1 :=
+gcd_domain.norm_unit_gcd
+
+@[simp] theorem gcd_mul_lcm : ∀a b:α, gcd a b * lcm a b = a * b * norm_unit (a * b) :=
+gcd_domain.gcd_mul_lcm
+
+section gcd
+
+theorem dvd_gcd_iff (a b c : α) : a ∣ gcd b c ↔ (a ∣ b ∧ a ∣ c) :=
+iff.intro
+  (assume h, ⟨dvd_trans h (gcd_dvd_left _ _), dvd_trans h (gcd_dvd_right _ _)⟩)
+  (assume ⟨hab, hac⟩, dvd_gcd hab hac)
+
+theorem gcd_comm (a b : α) : gcd a b = gcd b a :=
+dvd_antisymm_of_norm (norm_unit_gcd _ _) (norm_unit_gcd _ _)
+  (dvd_gcd (gcd_dvd_right _ _) (gcd_dvd_left _ _))
+  (dvd_gcd (gcd_dvd_right _ _) (gcd_dvd_left _ _))
+
+theorem gcd_assoc (m n k : α) : gcd (gcd m n) k = gcd m (gcd n k) :=
+dvd_antisymm_of_norm (norm_unit_gcd _ _) (norm_unit_gcd _ _)
+  (dvd_gcd
+    (dvd.trans (gcd_dvd_left (gcd m n) k) (gcd_dvd_left m n))
+    (dvd_gcd (dvd.trans (gcd_dvd_left (gcd m n) k) (gcd_dvd_right m n)) (gcd_dvd_right (gcd m n) k)))
+  (dvd_gcd
+    (dvd_gcd (gcd_dvd_left m (gcd n k)) (dvd.trans (gcd_dvd_right m (gcd n k)) (gcd_dvd_left n k)))
+    (dvd.trans (gcd_dvd_right m (gcd n k)) (gcd_dvd_right n k)))
+
+instance : is_commutative α gcd := ⟨gcd_comm⟩
+instance : is_associative α gcd := ⟨gcd_assoc⟩
+
+theorem gcd_eq_mul_norm_unit {a b c : α} (habc : gcd a b ∣ c) (hcab : c ∣ gcd a b) :
+  gcd a b = c * norm_unit c :=
+suffices gcd a b * norm_unit (gcd a b) = c * norm_unit c, by simpa,
+mul_norm_unit_eq_mul_norm_unit habc hcab
+
+@[simp] theorem gcd_zero_left (a : α) : gcd 0 a = a * norm_unit a :=
+gcd_eq_mul_norm_unit (gcd_dvd_right 0 a) (dvd_gcd (dvd_zero _) (dvd_refl a))
+
+@[simp] theorem gcd_zero_right (a : α) : gcd a 0 = a * norm_unit a :=
+gcd_eq_mul_norm_unit (gcd_dvd_left a 0) (dvd_gcd (dvd_refl a) (dvd_zero _))
+
+@[simp] theorem gcd_eq_zero_iff (a b : α) : gcd a b = 0 ↔ a = 0 ∧ b = 0 :=
+iff.intro
+  (assume h, let ⟨ca, ha⟩ := gcd_dvd_left a b, ⟨cb, hb⟩ := gcd_dvd_right a b in
+    by simp [h] at ha hb; exact ⟨ha, hb⟩)
+  (assume ⟨ha, hb⟩, by simp [ha, hb])
+
+@[simp] theorem gcd_one_left (a : α) : gcd 1 a = 1 :=
+dvd_antisymm_of_norm (norm_unit_gcd _ _) norm_unit_one (gcd_dvd_left _ _)
+  (dvd_gcd (dvd_refl 1) (one_dvd _))
+
+@[simp] theorem gcd_one_right (a : α) : gcd a 1 = 1 :=
+dvd_antisymm_of_norm (norm_unit_gcd _ _) norm_unit_one (gcd_dvd_right _ _)
+  (dvd_gcd (one_dvd _) (dvd_refl 1))
+
+theorem gcd_dvd_gcd {a b c d: α} (hab : a ∣ b) (hcd : c ∣ d) : gcd a c ∣ gcd b d :=
+dvd_gcd (dvd.trans (gcd_dvd_left _ _) hab) (dvd.trans (gcd_dvd_right _ _) hcd)
+
+@[simp] theorem gcd_same (a : α) : gcd a a = a * norm_unit a :=
+gcd_eq_mul_norm_unit (gcd_dvd_left _ _) (dvd_gcd (dvd_refl a) (dvd_refl a))
+
+@[simp] theorem gcd_mul_left (a b c : α) : gcd (a * b) (a * c) = (a * norm_unit a) * gcd b c :=
+classical.by_cases (assume h : a = 0, by simp [h]) $ assume ha : a ≠ 0,
+classical.by_cases (assume h : gcd b c = 0, by simp * at *) $ assume hbc : gcd b c ≠ 0,
+  suffices gcd (a * b) (a * c) = a * gcd b c * norm_unit (a * gcd b c),
+    by simpa [mul_comm, mul_assoc, mul_left_comm, norm_unit_mul a _ ha hbc],
+  let ⟨d, eq⟩ := dvd_gcd (dvd_mul_right a b) (dvd_mul_right a c) in
+  gcd_eq_mul_norm_unit
+    (eq.symm ▸ mul_dvd_mul_left a $ show d ∣ gcd b c, from
+      dvd_gcd
+        ((mul_dvd_mul_iff_left ha).1 $ eq ▸ gcd_dvd_left _ _)
+        ((mul_dvd_mul_iff_left ha).1 $ eq ▸ gcd_dvd_right _ _))
+    (dvd_gcd
+      (mul_dvd_mul_left a $ gcd_dvd_left _ _)
+      (mul_dvd_mul_left a $ gcd_dvd_right _ _))
+
+@[simp] theorem gcd_mul_right (a b c : α) : gcd (b * a) (c * a) = gcd b c * (a * norm_unit a) :=
+by simpa [mul_comm] using gcd_mul_left a b c
+
+theorem gcd_eq_left_iff (a b : α) (h : norm_unit a = 1) : gcd a b = a ↔ a ∣ b :=
+iff.intro (assume eq, eq ▸ gcd_dvd_right _ _) $
+  assume hab, dvd_antisymm_of_norm (norm_unit_gcd _ _) h (gcd_dvd_left _ _) (dvd_gcd (dvd_refl a) hab)
+
+theorem gcd_eq_right_iff (a b : α) (h : norm_unit b = 1) : gcd a b = b ↔ b ∣ a :=
+by simpa [gcd_comm a b] using gcd_eq_left_iff b a h
+
+theorem gcd_dvd_gcd_mul_left (m n k : α) : gcd m n ∣ gcd (k * m) n :=
+gcd_dvd_gcd (dvd_mul_left _ _) (dvd_refl _)
+
+theorem gcd_dvd_gcd_mul_right (m n k : α) : gcd m n ∣ gcd (m * k) n :=
+gcd_dvd_gcd (dvd_mul_right _ _) (dvd_refl _)
+
+theorem gcd_dvd_gcd_mul_left_right (m n k : α) : gcd m n ∣ gcd m (k * n) :=
+gcd_dvd_gcd (dvd_refl _) (dvd_mul_left _ _)
+
+theorem gcd_dvd_gcd_mul_right_right (m n k : α) : gcd m n ∣ gcd m (n * k) :=
+gcd_dvd_gcd (dvd_refl _) (dvd_mul_right _ _)
+
+end gcd
+
+section lcm
+
+lemma lcm_dvd_iff (a b c : α) : lcm a b ∣ c ↔ a ∣ c ∧ b ∣ c :=
+classical.by_cases
+  (assume : a = 0 ∨ b = 0, by cases this with h h; simp [h, iff_def] {contextual := tt})
+  (assume this : ¬ (a = 0 ∨ b = 0),
+    have a ≠ 0 ∧ b ≠ 0, by simpa [not_or_distrib] using this,
+    have h : gcd a b ≠ 0, by simp [gcd_eq_zero_iff, this],
+    by rw [← mul_dvd_mul_iff_left h, gcd_mul_lcm, units.coe_mul_dvd,
+        ← units.dvd_coe_mul _ _ (norm_unit c), mul_assoc, mul_comm (gcd a b),
+        ← gcd_mul_left, dvd_gcd_iff, mul_comm c a, mul_dvd_mul_iff_left this.1,
+        mul_dvd_mul_iff_right this.2, and_comm])
+
+lemma dvd_lcm_left (a b : α) : a ∣ lcm a b :=
+have a ∣ lcm a b ∧ b ∣ lcm a b, from (lcm_dvd_iff _ _ _).1 (dvd_refl _),
+this.1
+
+lemma dvd_lcm_right (a b : α) : b ∣ lcm a b :=
+have a ∣ lcm a b ∧ b ∣ lcm a b, from (lcm_dvd_iff _ _ _).1 (dvd_refl _),
+this.2
+
+lemma lcm_dvd {a b c : α} (hab : a ∣ b) (hcb : c ∣ b) : lcm a c ∣ b :=
+(lcm_dvd_iff _ _ _).2 ⟨hab, hcb⟩
+
+@[simp] theorem lcm_eq_zero_iff (a b : α) : lcm a b = 0 ↔ a = 0 ∨ b = 0 :=
+iff.intro
+  (assume h : lcm a b = 0,
+    have a * b * norm_unit (a * b) = 0,
+      by rw [← gcd_mul_lcm _ _, h, mul_zero],
+    by simpa [mul_eq_zero])
+  (by simp [or_imp_distrib] {contextual := tt})
+
+@[simp] lemma norm_unit_lcm (a b : α) : norm_unit (lcm a b) = 1 :=
+classical.by_cases (assume : lcm a b = 0, by simp [this]) $
+  assume h_lcm : lcm a b ≠ 0,
+  have gcd a b ≠ 0, by simp [*, not_or_distrib] at *,
+  have norm_unit (gcd a b * lcm a b) = 1,
+    by rw [gcd_mul_lcm, norm_unit_mul_norm_unit],
+  by simp [norm_unit_mul, *, -gcd_mul_lcm] at *
+
+theorem lcm_comm (a b : α) : lcm a b = lcm b a :=
+dvd_antisymm_of_norm (norm_unit_lcm _ _) (norm_unit_lcm _ _)
+  (lcm_dvd (dvd_lcm_right _ _) (dvd_lcm_left _ _))
+  (lcm_dvd (dvd_lcm_right _ _) (dvd_lcm_left _ _))
+
+theorem lcm_assoc (m n k : α) : lcm (lcm m n) k = lcm m (lcm n k) :=
+dvd_antisymm_of_norm (norm_unit_lcm _ _) (norm_unit_lcm _ _)
+  (lcm_dvd
+    (lcm_dvd (dvd_lcm_left _ _) (dvd.trans (dvd_lcm_left _ _) (dvd_lcm_right _ _)))
+    (dvd.trans (dvd_lcm_right _ _) (dvd_lcm_right _ _)))
+  (lcm_dvd
+    (dvd.trans (dvd_lcm_left _ _) (dvd_lcm_left _ _))
+    (lcm_dvd (dvd.trans (dvd_lcm_right _ _) (dvd_lcm_left _ _)) (dvd_lcm_right _ _)))
+
+instance : is_commutative α lcm := ⟨lcm_comm⟩
+instance : is_associative α lcm := ⟨lcm_assoc⟩
+
+lemma lcm_eq_mul_norm_unit {a b c : α} (habc : lcm a b ∣ c) (hcab : c ∣ lcm a b) :
+  lcm a b = c * norm_unit c :=
+dvd_antisymm_of_norm (norm_unit_lcm _ _) (norm_unit_mul_norm_unit _)
+  ((units.dvd_coe_mul _ _ _).2 $ habc)
+  ((units.coe_mul_dvd _ _ _).2 $ hcab)
+
+theorem lcm_dvd_lcm {a b c d : α} (hab : a ∣ b) (hcd : c ∣ d) : lcm a c ∣ lcm b d :=
+lcm_dvd (dvd.trans hab (dvd_lcm_left _ _)) (dvd.trans hcd (dvd_lcm_right _ _))
+
+@[simp] theorem lcm_units_coe_left (u : units α) (a : α) : lcm ↑u a = a * norm_unit a :=
+lcm_eq_mul_norm_unit (lcm_dvd (units.coe_dvd _ _) (dvd_refl _)) (dvd_lcm_right _ _)
+
+@[simp] theorem lcm_units_coe_right (a : α) (u : units α) : lcm a ↑u = a * norm_unit a :=
+by rw [lcm_comm a, lcm_units_coe_left]
+
+@[simp] theorem lcm_one_left (a : α) : lcm 1 a = a * norm_unit a :=
+lcm_units_coe_left 1 a
+
+@[simp] theorem lcm_one_right (a : α) : lcm a 1 = a * norm_unit a :=
+lcm_units_coe_right a 1
+
+@[simp] theorem lcm_same (a : α) : lcm a a = a * norm_unit a :=
+lcm_eq_mul_norm_unit (lcm_dvd (dvd_refl _) (dvd_refl _)) (dvd_lcm_left _ _)
+
+@[simp] theorem lcm_eq_one_iff (a b : α) : lcm a b = 1 ↔ a ∣ 1 ∧ b ∣ 1 :=
+iff.intro
+  (assume eq, eq ▸ ⟨dvd_lcm_left _ _, dvd_lcm_right _ _⟩)
+  (assume ⟨⟨c, hc⟩, ⟨d, hd⟩⟩,
+    show lcm (units.mk_of_mul_eq_one a c hc.symm : α) (units.mk_of_mul_eq_one b d hd.symm) = 1,
+      by simp)
+
+@[simp] theorem lcm_mul_left (a b c : α) : lcm (a * b) (a * c) = (a * norm_unit a) * lcm b c :=
+classical.by_cases (assume : a = 0, by simp * at *) $ assume ha : a ≠ 0,
+classical.by_cases (assume : lcm b c = 0, by simp [*, mul_eq_zero] at *) $ assume hbc : lcm b c ≠ 0,
+  suffices lcm (a * b) (a * c) = a * lcm b c * norm_unit (a * lcm b c),
+    by simpa [ha, hbc, norm_unit_mul, mul_assoc, mul_comm, mul_left_comm],
+  have a ∣ lcm (a * b) (a * c), from dvd.trans (dvd_mul_right _ _) (dvd_lcm_left _ _),
+  let ⟨d, eq⟩ := this in
+  lcm_eq_mul_norm_unit
+    (lcm_dvd (mul_dvd_mul_left a (dvd_lcm_left _ _)) (mul_dvd_mul_left a (dvd_lcm_right _ _)))
+    (eq.symm ▸ (mul_dvd_mul_left a $ lcm_dvd
+      ((mul_dvd_mul_iff_left ha).1 $ eq ▸ dvd_lcm_left _ _)
+      ((mul_dvd_mul_iff_left ha).1 $ eq ▸ dvd_lcm_right _ _)))
+
+@[simp] theorem lcm_mul_right (a b c : α) : lcm (b * a) (c * a) = lcm b c * (a * norm_unit a) :=
+by simpa [mul_comm] using lcm_mul_left a b c
+
+theorem lcm_eq_left_iff (a b : α) (h : norm_unit a = 1) : lcm a b = a ↔ b ∣ a :=
+iff.intro (assume eq, eq ▸ dvd_lcm_right _ _) $
+  assume hab, dvd_antisymm_of_norm (norm_unit_lcm _ _) h (lcm_dvd (dvd_refl a) hab) (dvd_lcm_left _ _)
+
+theorem lcm_eq_right_iff (a b : α) (h : norm_unit b = 1) : lcm a b = b ↔ a ∣ b :=
+by simpa [lcm_comm b a] using lcm_eq_left_iff b a h
+
+theorem lcm_dvd_lcm_mul_left (m n k : α) : lcm m n ∣ lcm (k * m) n :=
+lcm_dvd_lcm (dvd_mul_left _ _) (dvd_refl _)
+
+theorem lcm_dvd_lcm_mul_right (m n k : α) : lcm m n ∣ lcm (m * k) n :=
+lcm_dvd_lcm (dvd_mul_right _ _) (dvd_refl _)
+
+theorem lcm_dvd_lcm_mul_left_right (m n k : α) : lcm m n ∣ lcm m (k * n) :=
+lcm_dvd_lcm (dvd_refl _) (dvd_mul_left _ _)
+
+theorem lcm_dvd_lcm_mul_right_right (m n k : α) : lcm m n ∣ lcm m (n * k) :=
+lcm_dvd_lcm (dvd_refl _) (dvd_mul_right _ _)
+
+end lcm
+
+end gcd_domain

--- a/data/int/basic.lean
+++ b/data/int/basic.lean
@@ -119,11 +119,28 @@ begin
   try {refl}; [skip, rw add_comm a b]; apply this
 end
 
-theorem nat_abs_neg_of_nat (n : nat) : nat_abs (neg_of_nat n) = n :=
+theorem nat_abs_neg_of_nat (n : ℕ) : nat_abs (neg_of_nat n) = n :=
 by cases n; refl
 
 theorem nat_abs_mul (a b : ℤ) : nat_abs (a * b) = (nat_abs a) * (nat_abs b) :=
 by cases a; cases b; simp [(*), int.mul, nat_abs_neg_of_nat]
+
+theorem nat_abs_div (a b : ℤ) (H : b ∣ a) : nat_abs (a / b) = (nat_abs a) / (nat_abs b) :=
+begin
+  cases (nat.eq_zero_or_pos (nat_abs b)),
+  rw eq_zero_of_nat_abs_eq_zero h,
+  simp,
+  calc 
+  nat_abs (a / b) = nat_abs (a / b) * 1 : by rw mul_one
+    ... = nat_abs (a / b) * (nat_abs b / nat_abs b) : by rw nat.div_self h
+    ... = nat_abs (a / b) * nat_abs b / nat_abs b : by rw (nat.mul_div_assoc _ (dvd_refl _))
+    ... = nat_abs (a / b * b) / nat_abs b : by rw (nat_abs_mul (a / b) b)
+    ... = nat_abs a / nat_abs b : by rw int.div_mul_cancel H,
+end
+
+theorem nat_abs_dvd_abs_iff {i j : ℤ} : i.nat_abs ∣ j.nat_abs ↔ i ∣ j :=
+⟨assume (H : i.nat_abs ∣ j.nat_abs), dvd_nat_abs.mp (nat_abs_dvd.mp (coe_nat_dvd.mpr H)), 
+assume H : (i ∣ j), coe_nat_dvd.mp (dvd_nat_abs.mpr (nat_abs_dvd.mpr H))⟩
 
 theorem neg_succ_of_nat_eq' (m : ℕ) : -[1+ m] = -m - 1 :=
 by simp [neg_succ_of_nat_eq]

--- a/data/int/basic.lean
+++ b/data/int/basic.lean
@@ -5,7 +5,7 @@ Authors: Jeremy Avigad
 
 The integers, with addition, multiplication, and subtraction.
 -/
-import data.nat.prime algebra.char_zero algebra.order_functions
+import data.nat.basic algebra.char_zero algebra.order_functions
 open nat
 
 namespace int
@@ -124,23 +124,6 @@ by cases n; refl
 
 theorem nat_abs_mul (a b : ℤ) : nat_abs (a * b) = (nat_abs a) * (nat_abs b) :=
 by cases a; cases b; simp [(*), int.mul, nat_abs_neg_of_nat]
-
-theorem nat_abs_div (a b : ℤ) (H : b ∣ a) : nat_abs (a / b) = (nat_abs a) / (nat_abs b) :=
-begin
-  cases (nat.eq_zero_or_pos (nat_abs b)),
-  rw eq_zero_of_nat_abs_eq_zero h,
-  simp,
-  calc 
-  nat_abs (a / b) = nat_abs (a / b) * 1 : by rw mul_one
-    ... = nat_abs (a / b) * (nat_abs b / nat_abs b) : by rw nat.div_self h
-    ... = nat_abs (a / b) * nat_abs b / nat_abs b : by rw (nat.mul_div_assoc _ (dvd_refl _))
-    ... = nat_abs (a / b * b) / nat_abs b : by rw (nat_abs_mul (a / b) b)
-    ... = nat_abs a / nat_abs b : by rw int.div_mul_cancel H,
-end
-
-theorem nat_abs_dvd_abs_iff {i j : ℤ} : i.nat_abs ∣ j.nat_abs ↔ i ∣ j :=
-⟨assume (H : i.nat_abs ∣ j.nat_abs), dvd_nat_abs.mp (nat_abs_dvd.mp (coe_nat_dvd.mpr H)), 
-assume H : (i ∣ j), coe_nat_dvd.mp (dvd_nat_abs.mpr (nat_abs_dvd.mpr H))⟩
 
 theorem neg_succ_of_nat_eq' (m : ℕ) : -[1+ m] = -m - 1 :=
 by simp [neg_succ_of_nat_eq]
@@ -612,18 +595,6 @@ begin
       apply dvd_of_dvd_neg,
       exact hdiv }
 end
-
-lemma succ_dvd_or_succ_dvd_of_succ_sum_dvd_mul {p : ℕ} (p_prime : nat.prime p) {m n : ℤ} {k l : ℕ}
-      (hpm : ↑(p ^ k) ∣ m)
-      (hpn : ↑(p ^ l) ∣ n) (hpmn : ↑(p ^ (k+l+1)) ∣ m*n) : ↑(p ^ (k+1)) ∣ m ∨ ↑(p ^ (l+1)) ∣ n :=
-have hpm' : p ^ k ∣ m.nat_abs, from int.coe_nat_dvd.1 $ int.dvd_nat_abs.2 hpm,
-have hpn' : p ^ l ∣ n.nat_abs, from int.coe_nat_dvd.1 $ int.dvd_nat_abs.2 hpn,
-have hpmn' : (p ^ (k+l+1)) ∣ m.nat_abs*n.nat_abs,
-  by rw ←int.nat_abs_mul; apply (int.coe_nat_dvd.1 $ int.dvd_nat_abs.2 hpmn),
-let hsd := nat.succ_dvd_or_succ_dvd_of_succ_sum_dvd_mul p_prime hpm' hpn' hpmn' in
-hsd.elim
-  (λ hsd1, or.inl begin apply int.dvd_nat_abs.1, apply int.coe_nat_dvd.2 hsd1 end)
-  (λ hsd2, or.inr begin apply int.dvd_nat_abs.1, apply int.coe_nat_dvd.2 hsd2 end)
 
 /- / and ordering -/
 
@@ -1136,57 +1107,3 @@ by simp [abs]
 end cast
 
 end int
-
-/- extended euclidean algorithm -/
-namespace nat
-
-def xgcd_aux : ℕ → ℤ → ℤ → ℕ → ℤ → ℤ → ℕ × ℤ × ℤ
-| 0          s t r' s' t' := (r', s', t')
-| r@(succ _) s t r' s' t' :=
-  have r' % r < r, from mod_lt _ $ succ_pos _,
-  let q := r' / r in xgcd_aux (r' % r) (s' - q * s) (t' - q * t) r s t
-
-@[simp] theorem xgcd_zero_left {s t r' s' t'} : xgcd_aux 0 s t r' s' t' = (r', s', t') :=
-by simp [xgcd_aux]
-
-@[simp] theorem xgcd_aux_rec {r s t r' s' t'} (h : 0 < r) : xgcd_aux r s t r' s' t' = xgcd_aux (r' % r) (s' - (r' / r) * s) (t' - (r' / r) * t) r s t :=
-by cases r; [exact absurd h (lt_irrefl _), {simp only [xgcd_aux], refl}]
-
-/-- Use the extended GCD algorithm to generate the `a` and `b` values
-  satisfying `gcd x y = x * a + y * b`. -/
-def xgcd (x y : ℕ) : ℤ × ℤ := (xgcd_aux x 1 0 y 0 1).2
-
-/-- The extended GCD `a` value in the equation `gcd x y = x * a + y * b`. -/
-def gcd_a (x y : ℕ) : ℤ := (xgcd x y).1
-
-/-- The extended GCD `b` value in the equation `gcd x y = x * a + y * b`. -/
-def gcd_b (x y : ℕ) : ℤ := (xgcd x y).2
-
-@[simp] theorem xgcd_aux_fst (x y) : ∀ s t s' t',
-  (xgcd_aux x s t y s' t').1 = gcd x y :=
-gcd.induction x y (by simp) (λ x y h IH s t s' t', by simp [h, IH]; rw ← gcd_rec)
-
-theorem xgcd_aux_val (x y) : xgcd_aux x 1 0 y 0 1 = (gcd x y, xgcd x y) :=
-by rw [xgcd, ← xgcd_aux_fst x y 1 0 0 1]; cases xgcd_aux x 1 0 y 0 1; refl
-
-theorem xgcd_val (x y) : xgcd x y = (gcd_a x y, gcd_b x y) :=
-by unfold gcd_a gcd_b; cases xgcd x y; refl
-
-section
-parameters (a b : ℕ)
-
-private def P : ℕ × ℤ × ℤ → Prop | (r, s, t) := (r : ℤ) = a * s + b * t
-
-theorem xgcd_aux_P {r r'} : ∀ {s t s' t'}, P (r, s, t) → P (r', s', t') → P (xgcd_aux r s t r' s' t') :=
-gcd.induction r r' (by simp) $ λ x y h IH s t s' t' p p', begin
-  rw [xgcd_aux_rec h], refine IH _ p, dsimp [P] at *,
-  rw [int.mod_def], generalize : (y / x : ℤ) = k,
-  rw [p, p'], simp [mul_add, mul_comm, mul_left_comm]
-end
-
-theorem gcd_eq_gcd_ab : (gcd a b : ℤ) = a * gcd_a a b + b * gcd_b a b :=
-by have := @xgcd_aux_P a b a b 1 0 0 1 (by simp [P]) (by simp [P]);
-   rwa [xgcd_aux_val, xgcd_val] at this
-end
-
-end nat

--- a/data/int/gcd.lean
+++ b/data/int/gcd.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2018 Guy Leroy. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sangwoo Jo (aka Jason), Guy Leroy
+
+Lemmas and extended definitions and properties of gcd and lcm for integers.
+-/
+
+import data.int.basic data.nat.basic data.nat.gcd
+
+namespace int
+
+/- gcd -/
+
+@[simp] theorem gcd_self (i : ℤ) : gcd i i = nat_abs i :=
+by cases i; simp [gcd, mod_self]
+
+@[simp] theorem gcd_zero_left (i : ℤ) : gcd 0 i = nat_abs i := by simp [gcd]
+
+@[simp] theorem gcd_zero_right (i : ℤ) : gcd i 0 = nat_abs i :=
+by cases i; simp [gcd]
+
+theorem gcd_dvd_left (i j : ℤ) : (gcd i j : ℤ) ∣ i := 
+dvd_nat_abs.mp (coe_nat_dvd.mpr (nat.gcd_dvd_left (nat_abs i) (nat_abs j)))
+
+theorem gcd_dvd_right (i j : ℤ) : (gcd i j : ℤ) ∣ j :=
+dvd_nat_abs.mp (coe_nat_dvd.mpr (nat.gcd_dvd_right (nat_abs i) (nat_abs j)))
+
+theorem gcd_dvd (i j : ℤ) : ((gcd i j : ℤ) ∣ i) ∧ ((gcd i j : ℤ) ∣ j) := 
+⟨gcd_dvd_left i j, gcd_dvd_right i j⟩
+
+theorem dvd_gcd {i j k : ℤ} : k ∣ i → k ∣ j → k ∣ gcd i j :=
+by intros H1 H2; 
+exact nat_abs_dvd.mp (coe_nat_dvd.mpr (nat.dvd_gcd (nat_abs_dvd_abs_iff.mpr H1) 
+                                                   (nat_abs_dvd_abs_iff.mpr H2)))
+
+theorem gcd_comm (i j : ℤ) : gcd i j = gcd j i := 
+nat.gcd_comm (nat_abs i) (nat_abs j)
+
+theorem gcd_assoc (i j k : ℤ) : gcd (gcd i j) k = gcd i (gcd j k) :=
+nat.gcd_assoc (nat_abs i) (nat_abs j) (nat_abs k)
+
+@[simp] theorem gcd_one_left (i : ℤ) : gcd 1 i = 1 := nat.gcd_one_left _
+
+@[simp] theorem gcd_one_right (i : ℤ) : gcd i 1 = 1 :=
+eq.trans (gcd_comm i 1) $ gcd_one_left i
+
+theorem gcd_mul_left (i j k : ℤ) : gcd (i * j) (i * k) = nat_abs i * gcd j k :=
+by rw [gcd, nat_abs_mul, nat_abs_mul]; 
+exact nat.gcd_mul_left (nat_abs i) (nat_abs j) (nat_abs k)
+
+theorem gcd_mul_right (i j k : ℤ) : gcd (i * j) (k * j) = gcd i k * nat_abs j := 
+by rw [gcd, nat_abs_mul, nat_abs_mul]; 
+exact nat.gcd_mul_right (nat_abs i) (nat_abs j) (nat_abs k)
+
+theorem gcd_pos_of_non_zero_left {i : ℤ} (j : ℤ) (i_non_zero : i ≠ 0) : gcd i j > 0 :=
+nat.gcd_pos_of_pos_left (nat_abs j) (nat_abs_pos_of_ne_zero i_non_zero)
+
+theorem gcd_pos_of_non_zero_right (i : ℤ) {j : ℤ} (j_non_zero : j ≠ 0) : gcd i j > 0 :=
+nat.gcd_pos_of_pos_right (nat_abs i) (nat_abs_pos_of_ne_zero j_non_zero)
+
+theorem eq_zero_of_gcd_eq_zero_left {i j : ℤ} (H : gcd i j = 0) : i = 0 :=
+eq_zero_of_nat_abs_eq_zero (nat.eq_zero_of_gcd_eq_zero_left H)
+
+theorem eq_zero_of_gcd_eq_zero_right {i j : ℤ} (H : gcd i j = 0) : j = 0 :=
+eq_zero_of_nat_abs_eq_zero (nat.eq_zero_of_gcd_eq_zero_right H)
+
+theorem gcd_div {i j k : ℤ} (H1 : k ∣ i) (H2 : k ∣ j) :
+  gcd (i / k) (j / k) = gcd i j / nat_abs k :=
+by rw [gcd, nat_abs_div i k H1, nat_abs_div j k H2];
+exact nat.gcd_div (nat_abs_dvd_abs_iff.mpr H1) (nat_abs_dvd_abs_iff.mpr H2)
+
+theorem gcd_dvd_gcd_of_dvd_left {i k : ℤ} (j : ℤ) (H : i ∣ k) : gcd i j ∣ gcd k j :=
+int.coe_nat_dvd.1 $ dvd_gcd (dvd.trans (gcd_dvd_left i j) H) (gcd_dvd_right i j)
+
+theorem gcd_dvd_gcd_of_dvd_right {i k : ℤ} (j : ℤ) (H : i ∣ k) : gcd j i ∣ gcd j k :=
+int.coe_nat_dvd.1 $ dvd_gcd (gcd_dvd_left j i) (dvd.trans (gcd_dvd_right j i) H)
+
+theorem gcd_dvd_gcd_mul_left (i j k : ℤ) : gcd i j ∣ gcd (k * i) j :=
+gcd_dvd_gcd_of_dvd_left _ (dvd_mul_left _ _)
+
+theorem gcd_dvd_gcd_mul_right (i j k : ℤ) : gcd i j ∣ gcd (i * k) j :=
+gcd_dvd_gcd_of_dvd_left _ (dvd_mul_right _ _)
+
+theorem gcd_dvd_gcd_mul_left_right (i j k : ℤ) : gcd i j ∣ gcd i (k * j) :=
+gcd_dvd_gcd_of_dvd_right _ (dvd_mul_left _ _)
+
+theorem gcd_dvd_gcd_mul_right_right (i j k : ℤ) : gcd i j ∣ gcd i (j * k) :=
+gcd_dvd_gcd_of_dvd_right _ (dvd_mul_right _ _)
+
+theorem gcd_eq_left {i j : ℤ} (H : i ∣ j) : gcd i j = nat_abs i :=
+nat.dvd_antisymm (by unfold gcd; exact nat.gcd_dvd_left _ _)
+                 (by unfold gcd; exact nat.dvd_gcd (dvd_refl _) (nat_abs_dvd_abs_iff.mpr H))
+
+theorem gcd_eq_right {i j : ℤ} (H : j ∣ i) : gcd i j = nat_abs j :=
+by rw [gcd_comm, gcd_eq_left H]
+
+/- lcm -/
+
+def lcm (i j : ℤ) : ℕ := nat_abs(i * j) / (gcd i j)
+
+theorem lcm_def (i j : ℤ) : lcm i j = nat.lcm (nat_abs i) (nat_abs j) :=
+by rw [lcm, nat.lcm, gcd, nat_abs_mul]
+
+theorem lcm_comm (i j : ℤ) : lcm i j = lcm j i :=
+by delta lcm; rw [mul_comm, gcd_comm]
+
+theorem lcm_zero_left (i : ℤ) : lcm 0 i = 0 :=
+by rw [lcm, zero_mul, gcd_zero_left]; by simp
+
+theorem lcm_zero_right (i : ℤ) : lcm i 0 = 0 := lcm_comm 0 i ▸ lcm_zero_left i
+
+theorem lcm_one_left (i : ℤ) : lcm 1 i = nat_abs i :=
+by rw [lcm, one_mul, gcd_one_left, nat.div_one]
+
+theorem lcm_one_right (i : ℤ) : lcm i 1 = nat_abs i := 
+by unfold lcm; simp
+
+theorem lcm_self (i : ℤ) : lcm i i = nat_abs i :=
+by rw [lcm, gcd_self, nat_abs_mul, nat.mul_div_assoc, mul_comm, nat.div_mul_cancel]; 
+simp; simp
+
+theorem dvd_lcm_left (i j : ℤ) : i ∣ lcm i j :=
+nat_abs_dvd.mp (coe_nat_dvd.mpr (eq.subst (eq.symm (lcm_def i j)) 
+                                          (nat.dvd_lcm_left (nat_abs i) (nat_abs j))))
+
+theorem dvd_lcm_right (i j : ℤ) : j ∣ lcm i j :=
+lcm_comm j i ▸ dvd_lcm_left j i
+
+theorem gcd_mul_lcm (i j : ℤ) : gcd i j * lcm i j = nat_abs (i * j) :=
+begin
+  rw [lcm, mul_comm, nat.div_mul_cancel],
+  exact eq.subst (eq.symm (nat_abs_mul i j)) 
+                 (dvd_mul_of_dvd_left (coe_nat_dvd.mp (dvd_nat_abs.mpr (gcd_dvd_left i j))) _),
+end
+
+theorem lcm_dvd {i j k : ℤ} (H1 : i ∣ k) (H2 : j ∣ k) : (lcm i j : ℤ) ∣ k :=
+dvd_nat_abs.mp (coe_nat_dvd.mpr (eq.subst (eq.symm (lcm_def i j)) 
+                                          (nat.lcm_dvd (nat_abs_dvd_abs_iff.mpr H1)
+                                                       (nat_abs_dvd_abs_iff.mpr H2))))
+
+theorem lcm_assoc (i j k : ℤ) : lcm (lcm i j) k = lcm i (lcm j k) :=
+by rw [lcm_def, lcm_def, lcm_def, lcm_def];
+exact nat.lcm_assoc (nat_abs i) (nat_abs j) (nat_abs k)
+
+/- lemmas -/
+
+theorem dvd_of_mul_dvd_mul_left {i j k : ℤ} (k_non_zero : k ≠ 0) (H : k * i ∣ k * j) : i ∣ j :=
+dvd.elim H (λl H1, by rw mul_assoc at H1; exact ⟨_, eq_of_mul_eq_mul_left k_non_zero H1⟩)
+
+theorem dvd_of_mul_dvd_mul_right {i j k : ℤ} (k_non_zero : k ≠ 0) (H : i * k ∣ j * k) : i ∣ j :=
+by rw [mul_comm i k, mul_comm j k] at H; exact dvd_of_mul_dvd_mul_left k_non_zero H
+
+
+end int

--- a/data/int/gcd.lean
+++ b/data/int/gcd.lean
@@ -1,13 +1,17 @@
 /-
 Copyright (c) 2018 Guy Leroy. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Sangwoo Jo (aka Jason), Guy Leroy
+Authors: Sangwoo Jo (aka Jason), Guy Leroy, Johannes Hölzl
 
 Greatest common divisor (gcd) and least common multiple (lcm) for integers.
--/
-import data.int.basic data.nat.prime
 
-/- extended euclidean algorithm -/
+This sets up ℤ to be a GCD domain, and introduces rules about `int.gcd`, as well as `int.lcm`.
+NOTE: If you add rules to this theory, check that the corresponding rules are available for
+`gcd_domain`.
+-/
+import data.int.basic data.nat.prime algebra.gcd_domain
+
+/- Extended Euclidean algorithm -/
 namespace nat
 
 def xgcd_aux : ℕ → ℤ → ℤ → ℕ → ℤ → ℤ → ℕ × ℤ × ℤ
@@ -98,48 +102,100 @@ dvd.elim H (λl H1, by rw mul_assoc at H1; exact ⟨_, eq_of_mul_eq_mul_left k_n
 theorem dvd_of_mul_dvd_mul_right {i j k : ℤ} (k_non_zero : k ≠ 0) (H : i * k ∣ j * k) : i ∣ j :=
 by rw [mul_comm i k, mul_comm j k] at H; exact dvd_of_mul_dvd_mul_left k_non_zero H
 
-/- gcd -/
+section normalization_domain
 
-@[simp] theorem gcd_self (i : ℤ) : gcd i i = nat_abs i :=
-by cases i; simp [gcd, mod_self]
+instance : normalization_domain ℤ :=
+{ norm_unit      := λa:ℤ, if 0 ≤ a then 1 else -1,
+  norm_unit_zero := if_pos (le_refl _),
+  norm_unit_mul  := assume a b hna hnb,
+  begin
+    by_cases ha : 0 ≤ a; by_cases hb : 0 ≤ b; simp [ha, hb],
+    exact if_pos (mul_nonneg ha hb),
+    exact if_neg (assume h, hb $ nonneg_of_mul_nonneg_left h $ lt_of_le_of_ne ha hna.symm),
+    exact if_neg (assume h, ha $ nonneg_of_mul_nonneg_right h $ lt_of_le_of_ne hb hnb.symm),
+    exact if_pos (mul_nonneg_of_nonpos_of_nonpos (le_of_not_ge ha) (le_of_not_ge hb))
+  end,
+  norm_unit_coe_units := assume u, (units_eq_one_or u).elim
+    (assume eq, eq.symm ▸ if_pos zero_le_one)
+    (assume eq, eq.symm ▸ if_neg (not_le_of_gt $ show (-1:ℤ) < 0, by simpa [@neg_lt ℤ _ 1 0])),
+  .. (infer_instance : integral_domain ℤ) }
+
+lemma norm_unit_of_nonneg {z : ℤ} (h : 0 ≤ z) : norm_unit z = 1 :=
+by unfold norm_unit; exact if_pos h
+
+lemma norm_unit_of_neg {z : ℤ} (h : z < 0) : norm_unit z = -1 :=
+by unfold norm_unit; exact if_neg (not_le_of_gt h)
+
+lemma norm_unit_nat_coe (n : ℕ) : norm_unit (n : ℤ) = 1 :=
+norm_unit_of_nonneg (coe_nat_le_coe_nat_of_le $ nat.zero_le n)
+
+theorem coe_nat_abs_eq_mul_norm_unit {z : ℤ} : (z.nat_abs : ℤ) = z * norm_unit z :=
+begin
+  by_cases 0 ≤ z,
+  { simp [nat_abs_of_nonneg h, norm_unit_of_nonneg h] },
+  { simp [of_nat_nat_abs_of_nonpos (le_of_not_ge h), norm_unit_of_neg (lt_of_not_ge h)] }
+end
+
+end normalization_domain
+
+/-- ℤ specific version of least common multiple. -/
+def lcm (i j : ℤ) : ℕ := nat.lcm (nat_abs i) (nat_abs j)
+
+theorem lcm_def (i j : ℤ) : lcm i j = nat.lcm (nat_abs i) (nat_abs j) := rfl
+
+section gcd_domain
+
+theorem gcd_dvd_left (i j : ℤ) : (gcd i j : ℤ) ∣ i :=
+dvd_nat_abs.mp $ coe_nat_dvd.mpr $ nat.gcd_dvd_left _ _
+
+theorem gcd_dvd_right (i j : ℤ) : (gcd i j : ℤ) ∣ j :=
+dvd_nat_abs.mp $ coe_nat_dvd.mpr $ nat.gcd_dvd_right _ _
+
+theorem dvd_gcd {i j k : ℤ} (h1 : k ∣ i) (h2 : k ∣ j) : k ∣ gcd i j :=
+nat_abs_dvd.1 $ coe_nat_dvd.2 $ nat.dvd_gcd (nat_abs_dvd_abs_iff.2 h1) (nat_abs_dvd_abs_iff.2 h2)
+
+theorem gcd_mul_lcm (i j : ℤ) : gcd i j * lcm i j = nat_abs (i * j) :=
+by rw [int.gcd, int.lcm, nat.gcd_mul_lcm, nat_abs_mul]
+
+instance : gcd_domain ℤ :=
+{ gcd            := λa b, int.gcd a b,
+  lcm            := λa b, int.lcm a b,
+  gcd_dvd_left   := assume a b, int.gcd_dvd_left _ _,
+  gcd_dvd_right  := assume a b, int.gcd_dvd_right _ _,
+  dvd_gcd        := assume a b c, dvd_gcd,
+  norm_unit_gcd  := assume a b, norm_unit_nat_coe _,
+  gcd_mul_lcm    := by intros; rw [← int.coe_nat_mul, gcd_mul_lcm, coe_nat_abs_eq_mul_norm_unit],
+  lcm_zero_left  := assume a, coe_nat_eq_zero.2 $ nat.lcm_zero_left _,
+  lcm_zero_right := assume a, coe_nat_eq_zero.2 $ nat.lcm_zero_right _,
+  .. int.normalization_domain }
+
+lemma coe_gcd (i j : ℤ) : ↑(int.gcd i j) = gcd_domain.gcd i j := rfl
+lemma coe_lcm (i j : ℤ) : ↑(int.lcm i j) = gcd_domain.lcm i j := rfl
+
+lemma nat_abs_gcd (i j : ℤ) : nat_abs (gcd_domain.gcd i j) = int.gcd i j := rfl
+lemma nat_abs_lcm (i j : ℤ) : nat_abs (gcd_domain.lcm i j) = int.lcm i j := rfl
+
+end gcd_domain
+
+theorem gcd_comm (i j : ℤ) : gcd i j = gcd j i := nat.gcd_comm _ _
+
+theorem gcd_assoc (i j k : ℤ) : gcd (gcd i j) k = gcd i (gcd j k) := nat.gcd_assoc _ _ _
+
+@[simp] theorem gcd_self (i : ℤ) : gcd i i = nat_abs i := by simp [gcd]
 
 @[simp] theorem gcd_zero_left (i : ℤ) : gcd 0 i = nat_abs i := by simp [gcd]
 
-@[simp] theorem gcd_zero_right (i : ℤ) : gcd i 0 = nat_abs i :=
-by cases i; simp [gcd]
-
-theorem gcd_dvd_left (i j : ℤ) : (gcd i j : ℤ) ∣ i :=
-dvd_nat_abs.mp (coe_nat_dvd.mpr (nat.gcd_dvd_left (nat_abs i) (nat_abs j)))
-
-theorem gcd_dvd_right (i j : ℤ) : (gcd i j : ℤ) ∣ j :=
-dvd_nat_abs.mp (coe_nat_dvd.mpr (nat.gcd_dvd_right (nat_abs i) (nat_abs j)))
-
-theorem gcd_dvd (i j : ℤ) : ((gcd i j : ℤ) ∣ i) ∧ ((gcd i j : ℤ) ∣ j) :=
-⟨gcd_dvd_left i j, gcd_dvd_right i j⟩
-
-theorem dvd_gcd {i j k : ℤ} : k ∣ i → k ∣ j → k ∣ gcd i j :=
-by intros H1 H2;
-exact nat_abs_dvd.mp (coe_nat_dvd.mpr (nat.dvd_gcd (nat_abs_dvd_abs_iff.mpr H1)
-                                                   (nat_abs_dvd_abs_iff.mpr H2)))
-
-theorem gcd_comm (i j : ℤ) : gcd i j = gcd j i :=
-nat.gcd_comm (nat_abs i) (nat_abs j)
-
-theorem gcd_assoc (i j k : ℤ) : gcd (gcd i j) k = gcd i (gcd j k) :=
-nat.gcd_assoc (nat_abs i) (nat_abs j) (nat_abs k)
+@[simp] theorem gcd_zero_right (i : ℤ) : gcd i 0 = nat_abs i := by simp [gcd]
 
 @[simp] theorem gcd_one_left (i : ℤ) : gcd 1 i = 1 := nat.gcd_one_left _
 
-@[simp] theorem gcd_one_right (i : ℤ) : gcd i 1 = 1 :=
-eq.trans (gcd_comm i 1) $ gcd_one_left i
+@[simp] theorem gcd_one_right (i : ℤ) : gcd i 1 = 1 := nat.gcd_one_right _
 
 theorem gcd_mul_left (i j k : ℤ) : gcd (i * j) (i * k) = nat_abs i * gcd j k :=
-by rw [gcd, nat_abs_mul, nat_abs_mul];
-exact nat.gcd_mul_left (nat_abs i) (nat_abs j) (nat_abs k)
+by simp [(int.coe_nat_eq_coe_nat_iff _ _).symm, coe_gcd, coe_nat_abs_eq_mul_norm_unit]
 
 theorem gcd_mul_right (i j k : ℤ) : gcd (i * j) (k * j) = gcd i k * nat_abs j :=
-by rw [gcd, nat_abs_mul, nat_abs_mul];
-exact nat.gcd_mul_right (nat_abs i) (nat_abs j) (nat_abs k)
+by simp [(int.coe_nat_eq_coe_nat_iff _ _).symm, coe_gcd, coe_nat_abs_eq_mul_norm_unit]
 
 theorem gcd_pos_of_non_zero_left {i : ℤ} (j : ℤ) (i_non_zero : i ≠ 0) : gcd i j > 0 :=
 nat.gcd_pos_of_pos_left (nat_abs j) (nat_abs_pos_of_ne_zero i_non_zero)
@@ -147,11 +203,8 @@ nat.gcd_pos_of_pos_left (nat_abs j) (nat_abs_pos_of_ne_zero i_non_zero)
 theorem gcd_pos_of_non_zero_right (i : ℤ) {j : ℤ} (j_non_zero : j ≠ 0) : gcd i j > 0 :=
 nat.gcd_pos_of_pos_right (nat_abs i) (nat_abs_pos_of_ne_zero j_non_zero)
 
-theorem eq_zero_of_gcd_eq_zero_left {i j : ℤ} (H : gcd i j = 0) : i = 0 :=
-eq_zero_of_nat_abs_eq_zero (nat.eq_zero_of_gcd_eq_zero_left H)
-
-theorem eq_zero_of_gcd_eq_zero_right {i j : ℤ} (H : gcd i j = 0) : j = 0 :=
-eq_zero_of_nat_abs_eq_zero (nat.eq_zero_of_gcd_eq_zero_right H)
+theorem gcd_eq_zero_iff {i j : ℤ} : gcd i j = 0 ↔ i = 0 ∧ j = 0 :=
+by rw [← int.coe_nat_eq_coe_nat_iff, int.coe_nat_zero, coe_gcd, gcd_eq_zero_iff]
 
 theorem gcd_div {i j k : ℤ} (H1 : k ∣ i) (H2 : k ∣ j) :
   gcd (i / k) (j / k) = gcd i j / nat_abs k :=
@@ -185,50 +238,34 @@ by rw [gcd_comm, gcd_eq_left H]
 
 /- lcm -/
 
-def lcm (i j : ℤ) : ℕ := nat_abs(i * j) / (gcd i j)
-
-theorem lcm_def (i j : ℤ) : lcm i j = nat.lcm (nat_abs i) (nat_abs j) :=
-by rw [lcm, nat.lcm, gcd, nat_abs_mul]
-
 theorem lcm_comm (i j : ℤ) : lcm i j = lcm j i :=
-by delta lcm; rw [mul_comm, gcd_comm]
-
-theorem lcm_zero_left (i : ℤ) : lcm 0 i = 0 :=
-by rw [lcm, zero_mul, gcd_zero_left]; by simp
-
-theorem lcm_zero_right (i : ℤ) : lcm i 0 = 0 := lcm_comm 0 i ▸ lcm_zero_left i
-
-theorem lcm_one_left (i : ℤ) : lcm 1 i = nat_abs i :=
-by rw [lcm, one_mul, gcd_one_left, nat.div_one]
-
-theorem lcm_one_right (i : ℤ) : lcm i 1 = nat_abs i :=
-by unfold lcm; simp
-
-theorem lcm_self (i : ℤ) : lcm i i = nat_abs i :=
-by rw [lcm, gcd_self, nat_abs_mul, nat.mul_div_assoc, mul_comm, nat.div_mul_cancel];
-simp; simp
-
-theorem dvd_lcm_left (i j : ℤ) : i ∣ lcm i j :=
-nat_abs_dvd.mp (coe_nat_dvd.mpr (eq.subst (eq.symm (lcm_def i j))
-                                          (nat.dvd_lcm_left (nat_abs i) (nat_abs j))))
-
-theorem dvd_lcm_right (i j : ℤ) : j ∣ lcm i j :=
-lcm_comm j i ▸ dvd_lcm_left j i
-
-theorem gcd_mul_lcm (i j : ℤ) : gcd i j * lcm i j = nat_abs (i * j) :=
-begin
-  rw [lcm, mul_comm, nat.div_mul_cancel],
-  exact eq.subst (eq.symm (nat_abs_mul i j))
-                 (dvd_mul_of_dvd_left (coe_nat_dvd.mp (dvd_nat_abs.mpr (gcd_dvd_left i j))) _),
-end
-
-theorem lcm_dvd {i j k : ℤ} (H1 : i ∣ k) (H2 : j ∣ k) : (lcm i j : ℤ) ∣ k :=
-dvd_nat_abs.mp (coe_nat_dvd.mpr (eq.subst (eq.symm (lcm_def i j))
-                                          (nat.lcm_dvd (nat_abs_dvd_abs_iff.mpr H1)
-                                                       (nat_abs_dvd_abs_iff.mpr H2))))
+by simp [(int.coe_nat_eq_coe_nat_iff _ _).symm, coe_lcm, lcm_comm]
 
 theorem lcm_assoc (i j k : ℤ) : lcm (lcm i j) k = lcm i (lcm j k) :=
-by rw [lcm_def, lcm_def, lcm_def, lcm_def];
-exact nat.lcm_assoc (nat_abs i) (nat_abs j) (nat_abs k)
+by simp [(int.coe_nat_eq_coe_nat_iff _ _).symm, coe_lcm, lcm_assoc]
+
+@[simp] theorem lcm_zero_left (i : ℤ) : lcm 0 i = 0 :=
+by simp [(int.coe_nat_eq_coe_nat_iff _ _).symm, coe_lcm]
+
+@[simp] theorem lcm_zero_right (i : ℤ) : lcm i 0 = 0 :=
+by simp [(int.coe_nat_eq_coe_nat_iff _ _).symm, coe_lcm]
+
+@[simp] theorem lcm_one_left (i : ℤ) : lcm 1 i = nat_abs i :=
+by simp [(int.coe_nat_eq_coe_nat_iff _ _).symm, coe_lcm, coe_nat_abs_eq_mul_norm_unit]
+
+@[simp] theorem lcm_one_right (i : ℤ) : lcm i 1 = nat_abs i :=
+by simp [(int.coe_nat_eq_coe_nat_iff _ _).symm, coe_lcm, coe_nat_abs_eq_mul_norm_unit]
+
+@[simp] theorem lcm_self (i : ℤ) : lcm i i = nat_abs i :=
+by simp [(int.coe_nat_eq_coe_nat_iff _ _).symm, coe_lcm, coe_nat_abs_eq_mul_norm_unit]
+
+theorem dvd_lcm_left (i j : ℤ) : i ∣ lcm i j :=
+by rw [coe_lcm]; exact dvd_lcm_left _ _
+
+theorem dvd_lcm_right (i j : ℤ) : j ∣ lcm i j :=
+by rw [coe_lcm]; exact dvd_lcm_right _ _
+
+theorem lcm_dvd {i j k : ℤ}  : i ∣ k → j ∣ k → (lcm i j : ℤ) ∣ k :=
+by rw [coe_lcm]; exact lcm_dvd
 
 end int

--- a/data/nat/modeq.lean
+++ b/data/nat/modeq.lean
@@ -5,7 +5,7 @@ Authors: Mario Carneiro
 
 Modular equality relation.
 -/
-import data.int.basic data.nat.gcd
+import data.int.gcd
 
 namespace nat
 

--- a/data/padics/padic_norm.lean
+++ b/data/padics/padic_norm.lean
@@ -6,7 +6,7 @@ Authors: Robert Y. Lewis
 Define the p-adic valuation on ℤ and ℚ, and the p-adic norm on ℚ
 -/
 
-import data.rat data.int.basic algebra.field_power
+import data.rat data.int.gcd algebra.field_power
 import tactic.wlog tactic.ring
 
 universe u

--- a/data/zmod.lean
+++ b/data/zmod.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Chris Hughes
 -/
-import data.int.modeq data.fintype data.nat.prime data.nat.gcd data.pnat
+import data.int.modeq data.int.gcd data.fintype data.pnat
 
 open nat nat.modeq int
 


### PR DESCRIPTION
Add GCD domains and normalization domains. A "normalization domain" is a integral domain which has a function mapping each value to a unit, s.t. the value multiplied with the unit is a canonical value. 

One thing which is not yet clear is how to merge this with `euclidean_domain`. The current definition of `gcd` in `euclidean_domain` is not normalizing and I guess there is no way to define a normalizing function for a `euclidean_domain`.

My idea would be to change `euclidean_domain` to be based on `normalization_domain` and then define an instance from a `gcd_domain` from `euclidean_domain.`

Any comments?

--

Make sure you have:

 * [X] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [X] make sure definitions and lemmas are put in the right files
 * [X] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)