### PR TITLE
fix(category_theory): consistent use of coercions, consistent naming

### DIFF
--- a/category_theory/functor.lean
+++ b/category_theory/functor.lean
@@ -84,7 +84,7 @@ def comp (F : C ↝ D) (G : D ↝ E) : C ↝ E :=
 
 infixr ` ⋙ `:80 := comp
 
-@[simp] lemma comp_obj (F : C ↝ D) (G : D ↝ E) (X : C) : (F ⋙ G).obj X = G.obj (F.obj X) := rfl
+@[simp] lemma comp_obj (F : C ↝ D) (G : D ↝ E) (X : C) : (F ⋙ G) X = G (F X) := rfl
 @[simp] lemma comp_map (F : C ↝ D) (G : D ↝ E) (X Y : C) (f : X ⟶ Y) : (F ⋙ G).map f = G.map (F.map f) := rfl
 end
 

--- a/category_theory/products.lean
+++ b/category_theory/products.lean
@@ -7,7 +7,6 @@ namespace category_theory
 
 universes u₁ v₁ u₂ v₂ u₃ v₃ u₄ v₄
 
-namespace category
 section
 variables (C : Type u₁) [𝒞 : category.{u₁ v₁} C] (D : Type u₂) [𝒟 : category.{u₂ v₂} D]
 include 𝒞 𝒟
@@ -26,13 +25,19 @@ instance prod : category.{(max u₁ u₂) (max v₁ v₂)} (C × D) :=
 -- rfl lemmas for category.prod
 @[simp, ematch] lemma prod_id (X : C) (Y : D) : 𝟙 (X, Y) = (𝟙 X, 𝟙 Y) := rfl
 @[simp, ematch] lemma prod_comp {P Q R : C} {S T U : D} (f : (P, S) ⟶ (Q, T)) (g : (Q, T) ⟶ (R, U)) : f ≫ g = (f.1 ≫ g.1, f.2 ≫ g.2) := rfl
+end
 
+section
+variables (C : Type u₁) [𝒞 : category.{u₁ v₁} C] (D : Type u₁) [𝒟 : category.{u₁ v₁} D]
+include 𝒞 𝒟 
 /--
 `prod.category.uniform C D` is an additional instance specialised so both factors have the same universe levels. This helps typeclass resolution.
 -/
-instance uniform : category (C × D) := category.prod C D
+instance uniform_prod : category (C × D) := category_theory.prod C D
 end
 -- Next we define the natural functors into and out of product categories. For now this doesn't address the universal properties.
+
+namespace prod
 
 /-- `inl C Z` is the functor `X ↦ (X, Z)`. -/
 def inl (C : Type u₁) [category.{u₁ v₁} C] {D : Type u₁} [category.{u₁ v₁} D] (Z : D) : C ↝ (C × D) :=
@@ -62,7 +67,7 @@ def snd (C : Type u₁) [category.{u₁ v₁} C] (Z : C) (D : Type u₁) [catego
   map_id   := begin /- `obviously'` says: -/ intros, refl end,
   map_comp := begin /- `obviously'` says: -/ intros, refl end }
 
-end category
+end prod
 
 variables {A : Type u₁} [𝒜 : category.{u₁ v₁} A] {B : Type u₂} [ℬ : category.{u₂ v₂} B] {C : Type u₃} [𝒞 : category.{u₃ v₃} C] {D : Type u₄} [𝒟 : category.{u₄ v₄} D]
 include 𝒜 ℬ 𝒞 𝒟

--- a/category_theory/products.lean
+++ b/category_theory/products.lean
@@ -7,41 +7,31 @@ namespace category_theory
 
 universes u₁ v₁ u₂ v₂ u₃ v₃ u₄ v₄
 
+namespace category
 section
-variables (C : Type u₁) [category.{u₁ v₁} C] (D : Type u₂) [category.{u₂ v₂} D]
+variables (C : Type u₁) [𝒞 : category.{u₁ v₁} C] (D : Type u₂) [𝒟 : category.{u₂ v₂} D]
+include 𝒞 𝒟
 
 /--
 `prod.category C D` gives the cartesian product of two categories.
 -/
-instance prod.category : category.{(max u₁ u₂) (max v₁ v₂)} (C × D) :=
+instance prod : category.{(max u₁ u₂) (max v₁ v₂)} (C × D) :=
 { Hom     := λ X Y, ((X.1) ⟶ (Y.1)) × ((X.2) ⟶ (Y.2)),
   id      := λ X, ⟨ 𝟙 (X.1), 𝟙 (X.2) ⟩,
   comp    := λ _ _ _ f g, (f.1 ≫ g.1, f.2 ≫ g.2),
-  id_comp := begin  /- `obviously'` says: -/ intros, cases X, cases Y, cases f, dsimp at *, simp end,
+  id_comp := begin /- `obviously'` says: -/ intros, cases X, cases Y, cases f, dsimp at *, simp end,
   comp_id := begin /- `obviously'` says: -/ intros, cases X, cases Y, cases f, dsimp at *, simp end,
   assoc   := begin /- `obviously'` says: -/ intros, cases W, cases X, cases Y, cases Z, cases f, cases g, cases h, dsimp at *, simp end }
-end
 
-namespace prod.category
-
-section -- rfl lemmas for prod.category
-variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C] {D : Type u₂} [𝒟 : category.{u₂ v₂} D]
-include 𝒞 𝒟
-
-@[simp, ematch] lemma id (X : C) (Y : D) : 𝟙 (X, Y) = (𝟙 X, 𝟙 Y) := rfl
-@[simp, ematch] lemma comp {P Q R : C} {S T U : D} (f : (P, S) ⟶ (Q, T)) (g : (Q, T) ⟶ (R, U)) : f ≫ g = (f.1 ≫ g.1, f.2 ≫ g.2) := rfl
-end
-
-section
-variables (C : Type u₁) [𝒞 : category.{u₁ v₁} C] (D : Type u₁) [𝒟 : category.{u₁ v₁} D]
-include 𝒞 𝒟
+-- rfl lemmas for category.prod
+@[simp, ematch] lemma prod_id (X : C) (Y : D) : 𝟙 (X, Y) = (𝟙 X, 𝟙 Y) := rfl
+@[simp, ematch] lemma prod_comp {P Q R : C} {S T U : D} (f : (P, S) ⟶ (Q, T)) (g : (Q, T) ⟶ (R, U)) : f ≫ g = (f.1 ≫ g.1, f.2 ≫ g.2) := rfl
 
 /--
 `prod.category.uniform C D` is an additional instance specialised so both factors have the same universe levels. This helps typeclass resolution.
 -/
-instance uniform : category (C × D) := prod.category C D
+instance uniform : category (C × D) := category.prod C D
 end
-
 -- Next we define the natural functors into and out of product categories. For now this doesn't address the universal properties.
 
 /-- `inl C Z` is the functor `X ↦ (X, Z)`. -/
@@ -72,7 +62,7 @@ def snd (C : Type u₁) [category.{u₁ v₁} C] (Z : C) (D : Type u₁) [catego
   map_id   := begin /- `obviously'` says: -/ intros, refl end,
   map_comp := begin /- `obviously'` says: -/ intros, refl end }
 
-end prod.category
+end category
 
 variables {A : Type u₁} [𝒜 : category.{u₁ v₁} A] {B : Type u₂} [ℬ : category.{u₂ v₂} B] {C : Type u₃} [𝒞 : category.{u₃ v₃} C] {D : Type u₄} [𝒟 : category.{u₄ v₄} D]
 include 𝒜 ℬ 𝒞 𝒟


### PR DESCRIPTION
1) `functor.comp_obj` should have been using the coercion for functors acting on objects.

2) In products.lean, I've slightly changed the naming. The instance for a product of categories is now `category_theory.prod`, not `category_theory.prod.category`.

3) The associated `rfl` lemmas used to be `category_theory.prod.id` and `category_theory.prod.comp`, which was annoying if you had `category_theory.prod` open. Now they are `category_theory.prod_id` and `category_theory.prod_comp`, unlikely to get in the way.

4) `inl`, `inr`, `fst`, and `snd` are now in `category_theory.prod.`, rather than `category_theory.prod.category.`.