### PR TITLE
feat(group_theory/sylow): Sylow theorems

### DIFF
--- a/data/equiv/basic.lean
+++ b/data/equiv/basic.lean
@@ -159,6 +159,9 @@ def equiv_empty (h : α → false) : α ≃ empty :=
 def false_equiv_empty : false ≃ empty :=
 equiv_empty _root_.id
 
+def equiv_univ (α : Type u) : α ≃ (set.univ : set α) :=
+⟨λ a, ⟨a, set.mem_univ _⟩, λ a, a.1, λ a, rfl, λ ⟨a, ha⟩, rfl⟩
+
 def empty_of_not_nonempty {α : Sort*} (h : ¬ nonempty α) : α ≃ empty :=
 ⟨assume a, (h ⟨a⟩).elim, assume e, e.rec_on _, assume a, (h ⟨a⟩).elim, assume e, e.rec_on _⟩
 

--- a/data/equiv/basic.lean
+++ b/data/equiv/basic.lean
@@ -159,9 +159,6 @@ def equiv_empty (h : α → false) : α ≃ empty :=
 def false_equiv_empty : false ≃ empty :=
 equiv_empty _root_.id
 
-def equiv_univ (α : Type u) : α ≃ (set.univ : set α) :=
-⟨λ a, ⟨a, set.mem_univ _⟩, λ a, a.1, λ a, rfl, λ ⟨a, ha⟩, rfl⟩
-
 def empty_of_not_nonempty {α : Sort*} (h : ¬ nonempty α) : α ≃ empty :=
 ⟨assume a, (h ⟨a⟩).elim, assume e, e.rec_on _, assume a, (h ⟨a⟩).elim, assume e, e.rec_on _⟩
 
@@ -524,6 +521,18 @@ begin
     (bijective_comp hf equiv.plift.bijective),
   simp [set.set_coe_cast, (∘), set.range_iff_surjective.2 hg.2],
 end
+
+lemma subtype_quotient_equiv_quotient_subtype (p₁ : α → Prop) [s₁ : setoid α]
+  [s₂ : setoid (subtype p₁)] (p₂ : quotient s₁ → Prop) (hp₂ :  ∀ a, p₁ a ↔ p₂ ⟦a⟧)
+  (h : ∀ x y : subtype p₁, @setoid.r _ s₂ x y ↔ (x : α) ≈ y) :
+  {x // p₂ x} ≃ quotient s₂ :=
+{ to_fun := λ a, quotient.hrec_on a.1 (λ a h, ⟦⟨a, (hp₂ _).2 h⟩⟧)
+    (λ a b hab, hfunext (by rw quotient.sound hab)
+    (λ h₁ h₂ _, heq_of_eq (quotient.sound ((h _ _).2 hab)))) a.2,
+  inv_fun := λ a, quotient.lift_on a (λ a, (⟨⟦a.1⟧, (hp₂ _).1 a.2⟩ : {x // p₂ x}))
+    (λ a b hab, subtype.eq' (quotient.sound ((h _ _).1 hab))),
+  left_inv := λ ⟨a, ha⟩, quotient.induction_on a (λ a ha, rfl) ha,
+  right_inv := λ a, quotient.induction_on a (λ ⟨a, ha⟩, rfl) }
 
 section swap
 variable [decidable_eq α]

--- a/data/fintype.lean
+++ b/data/fintype.lean
@@ -282,6 +282,13 @@ match n, hn with
     (λ _ _ _, h _ _))⟩
 end
 
+lemma fintype.exists_ne_of_card_gt_one [fintype α] (h : fintype.card α > 1) (a : α) :
+  ∃ b : α, b ≠ a :=
+let ⟨b, hb⟩ := classical.not_forall.1 (mt fintype.card_le_one_iff.2 (not_le_of_gt h)) in
+let ⟨c, hc⟩ := classical.not_forall.1 hb in
+by haveI := classical.dec_eq α; exact
+if hba : b = a then ⟨c, by cc⟩ else ⟨b, hba⟩
+
 lemma fintype.injective_iff_surjective [fintype α] {f : α → α} : injective f ↔ surjective f :=
 by haveI := classical.prop_decidable; exact
 have ∀ {f : α → α}, injective f → surjective f,

--- a/data/fintype.lean
+++ b/data/fintype.lean
@@ -182,6 +182,10 @@ instance : fintype bool := ⟨⟨tt::ff::0, by simp⟩, λ x, by cases x; simp�
 instance units_int.fintype : fintype (units ℤ) :=
 ⟨{1, -1}, λ x, by cases int.units_eq_one_or x; simp *⟩
 
+instance additive.fintype : Π [fintype α], fintype (additive α) := id
+
+instance multiplicative.fintype : Π [fintype α], fintype (multiplicative α) := id
+
 @[simp] theorem fintype.card_units_int : fintype.card (units ℤ) = 2 := rfl
 
 @[simp] theorem fintype.card_bool : fintype.card bool = 2 := rfl
@@ -360,6 +364,10 @@ d_array.fintype
 
 instance vector.fintype {α : Type*} [fintype α] {n : ℕ} : fintype (vector α n) :=
 fintype.of_equiv _ (equiv.vector_equiv_fin _ _).symm
+
+@[simp] lemma card_vector [fintype α] (n : ℕ) :
+  fintype.card (vector α n) = fintype.card α ^ n :=
+by rw fintype.of_equiv_card; simp
 
 instance quotient.fintype [fintype α] (s : setoid α)
   [decidable_rel ((≈) : α → α → Prop)] : fintype (quotient s) :=

--- a/data/list/basic.lean
+++ b/data/list/basic.lean
@@ -755,6 +755,32 @@ option.some.inj $ by rw [← nth_le_nth, nth_map, nth_le_nth]; refl
   nth_le (map f l) n H = f (nth_le l n (length_map f l ▸ H)) :=
 nth_le_map f _ _
 
+@[simp] lemma nth_le_singleton (a : α) {n : ℕ} (hn : n < 1) :
+  nth_le [a] n hn = a :=
+have hn0 : n = 0 := le_zero_iff.1 (le_of_lt_succ hn),
+by subst hn0; refl
+
+lemma nth_le_append : ∀ {l₁ l₂ : list α} {n : ℕ} (hn₁) (hn₂),
+  (l₁ ++ l₂).nth_le n hn₁ = l₁.nth_le n hn₂
+| []     _ n     hn₁ hn₂  := (not_lt_zero _ hn₂).elim
+| (a::l) _ 0     hn₁ hn₂ := rfl
+| (a::l) _ (n+1) hn₁ hn₂ := by simp only [nth_le, cons_append];
+                         exact nth_le_append _ _
+
+@[simp] lemma nth_le_repeat (a : α) {n m : ℕ} (h : m < n) :
+  (list.repeat a n).nth_le m (by rwa list.length_repeat) = a :=
+eq_of_mem_repeat (nth_le_mem _ _ _)
+
+lemma nth_append  {l₁ l₂ : list α} {n : ℕ} (hn : n < l₁.length) :
+  (l₁ ++ l₂).nth n = l₁.nth n :=
+have hn' : n < (l₁ ++ l₂).length := lt_of_lt_of_le hn
+  (by rw length_append; exact le_add_right _ _),
+by rw [nth_le_nth hn, nth_le_nth hn', nth_le_append]
+
+@[simp] lemma nth_concat_length: ∀ (l : list α) (a : α), (l ++ [a]).nth l.length = a
+| []     a := rfl
+| (b::l) a := by rw [cons_append, length_cons, nth, nth_concat_length]
+
 @[extensionality]
 theorem ext : ∀ {l₁ l₂ : list α}, (∀n, nth l₁ n = nth l₂ n) → l₁ = l₂
 | []      []       h := rfl
@@ -896,7 +922,7 @@ begin intros, reflexivity end
 
 theorem take_cons (n) (a : α) (l : list α) : take (succ n) (a::l) = a :: take n l := rfl
 
-theorem take_all : ∀ (l : list α), take (length l) l = l
+@[simp] theorem take_all : ∀ (l : list α), take (length l) l = l
 | []     := rfl
 | (a::l) := begin change a :: (take (length l) l) = a :: l, rw take_all end
 
@@ -949,6 +975,24 @@ theorem drop_eq_nth_le_cons : ∀ {n} {l : list α} h,
   drop n l = nth_le l n h :: drop (n+1) l
 | 0     (a::l) h := rfl
 | (n+1) (a::l) h := @drop_eq_nth_le_cons n _ _
+
+@[simp] lemma drop_all (l : list α) : l.drop l.length = [] :=
+calc l.drop l.length = (l ++ []).drop l.length : by simp
+                 ... = [] : drop_left _ _
+
+lemma drop_append_of_le_length : ∀ {l₁ l₂ : list α} {n : ℕ}, n ≤ l₁.length →
+  (l₁ ++ l₂).drop n = l₁.drop n ++ l₂
+| l₁      l₂ 0     hn := by simp
+| []      l₂ (n+1) hn := absurd hn dec_trivial
+| (a::l₁) l₂ (n+1) hn :=
+by rw [drop, cons_append, drop, drop_append_of_le_length (le_of_succ_le_succ hn)]
+
+lemma take_append_of_le_length : ∀ {l₁ l₂ : list α} {n : ℕ},
+  n ≤ l₁.length → (l₁ ++ l₂).take n = l₁.take n
+| l₁      l₂ 0     hn := by simp
+| []      l₂ (n+1) hn := absurd hn dec_trivial
+| (a::l₁) l₂ (n+1) hn :=
+by rw [list.take, list.cons_append, list.take, take_append_of_le_length (le_of_succ_le_succ hn)]
 
 theorem modify_nth_tail_eq_take_drop (f : list α → list α) (H : f [] = []) :
   ∀ n l, modify_nth_tail f n l = take n l ++ f (drop n l)
@@ -3786,6 +3830,59 @@ theorem reverse_range' : ∀ s n : ℕ,
 @[simp] theorem enum_map_fst (l : list α) :
   map prod.fst (enum l) = range l.length :=
 by simp [enum, range_eq_range']
+
+/-- `rotate l n` rotates the elements of `l` to the left by `n`
+  `rotate [0, 1, 2, 3, 4, 5] 2 = [2, 3, 4, 5, 0, 1] -/
+def rotate : list α → ℕ → list α
+| []     n     := []
+| l      0     := l
+| (a::l) (n+1) := rotate (l ++ [a]) n
+
+@[simp] lemma rotate_nil (n : ℕ) : ([] : list α).rotate n = [] := by cases n; refl
+
+@[simp] lemma rotate_zero (l : list α) : l.rotate 0 = l := by cases l; refl
+
+lemma rotate_succ_cons (l : list α) (a : α) (n : ℕ) :
+  (a :: l : list α).rotate n.succ = (l ++ [a]).rotate n := rfl
+
+@[simp] lemma length_rotate : ∀ (l : list α) (n : ℕ), (l.rotate n).length = l.length
+| []     n     := rfl
+| (a::l) 0     := rfl
+| (a::l) (n+1) := by rw [list.rotate, length_rotate (l ++ [a]) n]; simp
+
+lemma rotate_eq_take_append_drop : ∀ {l : list α} {n : ℕ}, n ≤ l.length →
+  l.rotate n = l.drop n ++ l.take n
+| []     n     h := by simp [drop_append_of_le_length h]
+| l      0     h := by simp [take_append_of_le_length h]
+| (a::l) (n+1) h :=
+have hnl : n ≤ l.length, from le_of_succ_le_succ h,
+have hnl' : n ≤ (l ++ [a]).length,
+  by rw [length_append, length_cons, list.length, zero_add];
+    exact (le_of_succ_le h),
+by rw [rotate_succ_cons, rotate_eq_take_append_drop hnl', drop, take,
+     drop_append_of_le_length hnl, take_append_of_le_length hnl];
+   simp
+
+lemma rotate_rotate : ∀ (l : list α) (n m : ℕ), (l.rotate n).rotate m = l.rotate (n + m)
+| (a::l) 0     m := by simp
+| []     n     m := by simp
+| (a::l) (n+1) m := by rw [rotate_succ_cons, rotate_rotate, add_right_comm, rotate_succ_cons]
+
+@[simp] lemma rotate_length (l : list α) : rotate l l.length = l :=
+by rw rotate_eq_take_append_drop (le_refl _); simp
+
+@[simp] lemma rotate_length_mul (l : list α) : ∀ n : ℕ, l.rotate (l.length * n) = l
+| 0     := by simp
+| (n+1) :=
+calc l.rotate (l.length * (n + 1)) =
+  (l.rotate (l.length * n)).rotate (l.rotate (l.length * n)).length :
+    by simp [-rotate_length, nat.mul_succ, rotate_rotate]
+... = l : by rw [rotate_length, rotate_length_mul]
+
+lemma rotate_mod (l : list α) (n : ℕ) : l.rotate (n % l.length) = l.rotate n :=
+calc l.rotate (n % l.length) = (l.rotate (n % l.length)).rotate
+    ((l.rotate (n % l.length)).length * (n / l.length)) : by rw rotate_length_mul
+... = l.rotate n : by rw [rotate_rotate, length_rotate, nat.mod_add_div]
 
 end list
 

--- a/data/set/finite.lean
+++ b/data/set/finite.lean
@@ -272,4 +272,21 @@ begin
   exact finset.card_lt_card h,
 end
 
+lemma card_le_of_subset {s t : set α} [fintype s] [fintype t] (hsub : s ⊆ t) :
+  fintype.card s ≤ fintype.card t :=
+calc fintype.card s = s.to_finset.card : card_fintype_of_finset' _ (by simp)
+... ≤ t.to_finset.card : finset.card_le_of_subset (λ x hx, by simp [set.subset_def, *] at *)
+... = fintype.card t : eq.symm (card_fintype_of_finset' _ (by simp))
+
+lemma eq_of_card_le_of_subset {s t : set α} [fintype s] [fintype t]
+  (hcard : fintype.card t ≤ fintype.card s) (hsub : s ⊆ t) : s = t :=
+classical.by_contradiction (λ h, lt_irrefl (fintype.card t)
+  (have fintype.card s < fintype.card t := set.card_lt_card ⟨hsub, h⟩,
+    by rwa [le_antisymm (card_le_of_subset hsub) hcard] at this))
+
+lemma card_range_of_injective [fintype α] {f : α → β} (hf : injective f)
+  [fintype (range f)] : fintype.card (range f) = fintype.card α :=
+eq.symm $ fintype.card_congr (@equiv.of_bijective  _ _ (λ a : α, show range f, from ⟨f a, a, rfl⟩)
+  ⟨λ x y h, hf $ subtype.mk.inj h, λ b, let ⟨a, ha⟩ := b.2 in ⟨a, by simp *⟩⟩)
+
 end set

--- a/data/vector2.lean
+++ b/data/vector2.lean
@@ -100,6 +100,9 @@ def {u} mmap {m} [monad m] {α} {β : Type u} (f : α → m β) :
 | ⟨v, hv⟩ ⟨w, hw⟩ h := subtype.eq (list.ext_le (by rw [hv, hw])
   (λ m hm hn, h ⟨m, hv ▸ hm⟩))
 
+instance zero_subsingleton : subsingleton (vector α 0) :=
+⟨λ _ _, vector.ext (λ m, fin.elim0 m)⟩
+
 end vector
 
 namespace vector

--- a/group_theory/coset.lean
+++ b/group_theory/coset.lean
@@ -172,6 +172,21 @@ calc α ≃ Σ L : left_cosets s, {x : α // (x : left_cosets s)= L} :
     ... ≃ (left_cosets s × s) :
   equiv.sigma_equiv_prod _ _
 
+noncomputable lemma preimage_left_cosets_mk_equiv_subgroup_times_set
+  (s : set α) [is_subgroup s] (t : set (left_cosets s)) : left_cosets.mk ⁻¹' t ≃ (s × t) :=
+have h : ∀ {x : left_cosets s} {a : α}, x ∈ t → a ∈ s →
+  (quotient.mk' (quotient.out' x * a) : left_cosets s) = quotient.mk' (quotient.out' x) :=
+    λ x a hx ha, quotient.sound' (show (quotient.out' x * a)⁻¹ * quotient.out' x ∈ s,
+      from (is_subgroup.inv_mem_iff _).1 $
+        by rwa [mul_inv_rev, inv_inv, ← mul_assoc, inv_mul_self, one_mul]),
+{ to_fun := λ ⟨a, ha⟩, ⟨⟨(quotient.out' (quotient.mk' a))⁻¹ * a,
+    @quotient.exact' _ (left_rel s) _ _ $ (quotient.out_eq' _)⟩,
+      ⟨quotient.mk' a, ha⟩⟩,
+  inv_fun := λ ⟨⟨a, ha⟩, ⟨x, hx⟩⟩, ⟨quotient.out' x * a, show quotient.mk' _ ∈ t,
+    by simp [h hx ha, hx]⟩,
+  left_inv := λ ⟨a, ha⟩, by simp,
+  right_inv := λ ⟨⟨a, ha⟩, ⟨x, hx⟩⟩, by simp [h hx ha] }
+
 end is_subgroup
 
 namespace left_cosets

--- a/group_theory/coset.lean
+++ b/group_theory/coset.lean
@@ -140,7 +140,7 @@ instance [group α] (s : set α) [is_subgroup s] : inhabited (left_cosets s) :=
 @[simp] protected lemma eq {a b : α} : (a : left_cosets s) = b ↔ a⁻¹ * b ∈ s :=
 quotient.eq'
 
-lemma eq_class_eq_left_coset [group α] (s : set α) [is_subgroup s] (g : α) : 
+lemma eq_class_eq_left_coset [group α] (s : set α) [is_subgroup s] (g : α) :
   {x : α | (x : left_cosets s) = g} = left_coset g s :=
 set.ext $ λ z, by simp [eq_comm, mem_left_coset_iff]; refl
 
@@ -162,8 +162,8 @@ noncomputable def group_equiv_left_cosets_times_subgroup (hs : is_subgroup s) :
 calc α ≃ Σ L : left_cosets s, {x : α // (x : left_cosets s)= L} :
   equiv.equiv_fib left_cosets.mk
     ... ≃ Σ L : left_cosets s, left_coset (quotient.out' L) s :
-  equiv.sigma_congr_right (λ L, 
-    begin rw ← left_cosets.eq_class_eq_left_coset, 
+  equiv.sigma_congr_right (λ L,
+    begin rw ← left_cosets.eq_class_eq_left_coset,
       show {x // quotient.mk' x = L} ≃ {x : α // quotient.mk' x = quotient.mk' _},
       simp [-quotient.eq']
     end)
@@ -186,8 +186,8 @@ instance [group α] (s : set α) [normal_subgroup s] : group (left_cosets s) :=
         (by rw [mul_inv_rev, mul_inv_rev, ← mul_assoc (a₂⁻¹ * a₁⁻¹),
           mul_assoc _ b₂, ← mul_assoc b₂, mul_inv_self, one_mul, mul_assoc (a₂⁻¹)];
           exact normal_subgroup.normal _ hab₁ _))),
-  mul_assoc := λ a b c, quotient.induction_on₃' a b c 
-    (λ a b c, congr_arg mk (mul_assoc a b c)), 
+  mul_assoc := λ a b c, quotient.induction_on₃' a b c
+    (λ a b c, congr_arg mk (mul_assoc a b c)),
   one_mul := λ a, quotient.induction_on' a
     (λ a, congr_arg mk (one_mul a)),
   mul_one := λ a, quotient.induction_on' a
@@ -205,11 +205,11 @@ instance [group α] (s : set α) [normal_subgroup s] :
   is_group_hom (mk : α → left_cosets s) := ⟨λ _ _, rfl⟩
 
 instance [comm_group α] (s : set α) [normal_subgroup s] : comm_group (left_cosets s) :=
-{ mul_comm := λ a b, quotient.induction_on₂' a b 
+{ mul_comm := λ a b, quotient.induction_on₂' a b
     (λ a b, congr_arg mk (mul_comm a b)),
   ..left_cosets.group s }
 
-@[simp] lemma coe_one [group α] (s : set α) [normal_subgroup s] : 
+@[simp] lemma coe_one [group α] (s : set α) [normal_subgroup s] :
   ((1 : α) : left_cosets s) = 1 := rfl
 
 @[simp] lemma coe_mul [group α] (s : set α) [normal_subgroup s] (a b : α) :

--- a/group_theory/group_action.lean
+++ b/group_theory/group_action.lean
@@ -14,7 +14,7 @@ class is_monoid_action [monoid α] (f : α → β → β) : Prop :=
 
 namespace is_monoid_action
 
-variables [monoid α] (f : α → β → β) [is_monoid_action f] 
+variables [monoid α] (f : α → β → β) [is_monoid_action f]
 
 def orbit (a : β) := set.range (λ x : α, f x a)
 
@@ -70,7 +70,7 @@ instance : is_group_hom (to_perm f) :=
 lemma bijective (g : α) : function.bijective (f g) :=
 (to_perm f g).bijective
 
-lemma orbit_eq_iff {f : α → β → β} [is_monoid_action f] {a b : β} : 
+lemma orbit_eq_iff {f : α → β → β} [is_monoid_action f] {a b : β} :
    orbit f a = orbit f b ↔ a ∈ orbit f b:=
 ⟨λ h, h ▸ mem_orbit_self _ _,
 λ ⟨x, (hx : f x b = a)⟩, set.ext (λ c, ⟨λ ⟨y, (hy : f y a = c)⟩, ⟨y * x,
@@ -87,18 +87,23 @@ instance (a : β) : is_subgroup (stabilizer f a) :=
   inv_mem := λ x (hx : f x a = a), show f x⁻¹ a = a,
     by rw [← hx, ← is_monoid_action.mul f, inv_mul_self, is_monoid_action.one f, hx] }
 
+def orbit_rel : setoid β :=
+{ r := λ a b, a ∈ orbit f b,
+  iseqv := ⟨mem_orbit_self f, λ a b, by simp [orbit_eq_iff.symm, eq_comm],
+    λ a b, by simp [orbit_eq_iff.symm, eq_comm] {contextual := tt}⟩ }
+
 noncomputable lemma orbit_equiv_left_cosets (a : β) :
   orbit f a ≃ left_cosets (stabilizer f a) :=
 by letI := left_rel (stabilizer f a); exact
-equiv.symm (@equiv.of_bijective _ _ 
-  (λ x : left_cosets (stabilizer f a), quotient.lift_on x 
-    (λ x, (⟨f x a, mem_orbit _ _ _⟩ : orbit f a)) 
+equiv.symm (@equiv.of_bijective _ _
+  (λ x : left_cosets (stabilizer f a), quotient.lift_on x
+    (λ x, (⟨f x a, mem_orbit _ _ _⟩ : orbit f a))
     (λ g h (H : _ = _), subtype.eq $ (is_group_action.bijective f (g⁻¹)).1
       $ show f g⁻¹ (f g a) = f g⁻¹ (f h a),
-      by rw [← is_monoid_action.mul f, ← is_monoid_action.mul f, 
-        H, inv_mul_self, is_monoid_action.one f])) 
+      by rw [← is_monoid_action.mul f, ← is_monoid_action.mul f,
+        H, inv_mul_self, is_monoid_action.one f]))
 ⟨λ g h, quotient.induction_on₂ g h (λ g h H, quotient.sound $
-  have H : f g a = f h a := subtype.mk.inj H, 
+  have H : f g a = f h a := subtype.mk.inj H,
   show f (g⁻¹ * h) a = a,
   by rw [is_monoid_action.mul f, ← H, ← is_monoid_action.mul f, inv_mul_self,
     is_monoid_action.one f]),

--- a/group_theory/subgroup.lean
+++ b/group_theory/subgroup.lean
@@ -259,6 +259,28 @@ instance center_normal : normal_subgroup (center α) :=
       ...               = g * g⁻¹ * n * h : by rw ha h; simp
       ...               = g * n * g⁻¹ * h : by rw [mul_assoc g, ha g⁻¹, ←mul_assoc] }
 
+def normalizer (s : set α) : set α :=
+{g : α | ∀ n, n ∈ s ↔ g * n * g⁻¹ ∈ s}
+
+instance (s : set α) [is_subgroup s] : is_subgroup (normalizer s) :=
+{ one_mem := by simp [normalizer],
+  mul_mem := λ a b (ha : ∀ n, n ∈ s ↔ a * n * a⁻¹ ∈ s)
+    (hb : ∀ n, n ∈ s ↔ b * n * b⁻¹ ∈ s) n,
+    by rw [mul_inv_rev, ← mul_assoc, mul_assoc a, mul_assoc a, ← ha, ← hb],
+  inv_mem := λ a (ha : ∀ n, n ∈ s ↔ a * n * a⁻¹ ∈ s) n,
+    by rw [ha (a⁻¹ * n * a⁻¹⁻¹)];
+    simp [mul_assoc] }
+
+lemma subset_normalizer (s : set α) [is_subgroup s] : s ⊆ normalizer s :=
+λ g hg n, by rw [is_subgroup.mul_mem_cancel_left _ ((is_subgroup.inv_mem_iff _).2 hg),
+  is_subgroup.mul_mem_cancel_right _ hg]
+
+instance (s : set α) [is_subgroup s] : normal_subgroup {x : normalizer s | ↑x ∈ s} :=
+{ one_mem := show (1 : α) ∈ s, from is_submonoid.one_mem _,
+  mul_mem := λ a b ha hb, show (a * b : α) ∈ s, from is_submonoid.mul_mem ha hb,
+  inv_mem := λ a ha, show (a⁻¹ : α) ∈ s, from is_subgroup.inv_mem ha,
+  normal := λ a ha ⟨m, hm⟩, (hm a).1 ha }
+
 end is_subgroup
 
 namespace is_add_subgroup
@@ -362,5 +384,8 @@ set.ext $ assume x, iff.intro
 lemma inj_iff_trivial_ker (f : α → β) [is_group_hom f] :
   function.injective f ↔ ker f = trivial α :=
 ⟨trivial_ker_of_inj f, inj_of_trivial_ker f⟩
+
+instance (s : set α) [is_subgroup s] : is_group_hom (subtype.val : s → α) :=
+⟨λ _ _, rfl⟩
 
 end is_group_hom

--- a/group_theory/subgroup.lean
+++ b/group_theory/subgroup.lean
@@ -77,8 +77,8 @@ theorem is_add_subgroup.of_sub (s : set β)
 multiplicative.is_subgroup_iff.1 $
 @is_subgroup.of_div (multiplicative β) _ _ zero_mem @sub_mem
 
-def gpowers (x : α) : set α := {y | ∃i:ℤ, x^i = y}
-def gmultiples (x : β) : set β := {y | ∃i:ℤ, gsmul i x = y}
+def gpowers (x : α) : set α := set.range ((^) x : ℤ → α)
+def gmultiples (x : β) : set β := set.range (λ i, gsmul i x)
 attribute [to_additive gmultiples] gpowers
 
 instance gpowers.is_subgroup (x : α) : is_subgroup (gpowers x) :=
@@ -106,6 +106,10 @@ end group
 namespace is_subgroup
 open is_submonoid
 variables [group α] (s : set α) [is_subgroup s]
+
+@[to_additive is_add_subgroup.coe_neg, simp]
+lemma coe_inv {s : set α} [is_subgroup s] (a : s) : ((a⁻¹ : s) : α) = a⁻¹ := rfl
+attribute [simp] is_add_subgroup.coe_neg
 
 @[to_additive is_add_subgroup.neg_mem_iff]
 lemma inv_mem_iff : a⁻¹ ∈ s ↔ a ∈ s :=

--- a/group_theory/submonoid.lean
+++ b/group_theory/submonoid.lean
@@ -92,6 +92,18 @@ attribute [to_additive subtype.add_monoid._proof_3] subtype.monoid._proof_3
 attribute [to_additive subtype.add_monoid._proof_4] subtype.monoid._proof_4
 attribute [to_additive subtype.add_monoid] subtype.monoid
 
+namespace is_submonoid
+
+@[to_additive is_add_submonoid.coe_zero, simp]
+lemma coe_one (s : set α) [is_submonoid s] : ((1 : s) : α) = 1 := rfl
+
+@[to_additive is_add_submonoid.coe_add, simp]
+lemma coe_add {s : set α} [is_submonoid s] (a b : s) : ((a * b : s) : α) = a * b := rfl
+
+attribute [simp] is_add_submonoid.coe_zero is_add_submonoid.coe_add
+
+end is_submonoid
+
 namespace monoid
 
 inductive in_closure (s : set α) : α → Prop

--- a/group_theory/sylow.lean
+++ b/group_theory/sylow.lean
@@ -1,0 +1,674 @@
+import group_theory.order_of_element data.zmod algebra.pi_instances group_theory.group_action
+
+open equiv fintype finset is_group_action is_monoid_action function equiv.perm
+universes u v w
+variables {G : Type u} {α : Type v} {β : Type w} [group G]
+
+lemma subtype_quotient_equiv_quotient_subtype (p₁ : α → Prop) [s₁ : setoid α]
+  [s₂ : setoid (subtype p₁)] (p₂ : quotient s₁ → Prop) (hp₂ :  ∀ a : α, p₁ a ↔ p₂ ⟦a⟧)
+  (h : ∀ x y : subtype p₁, @setoid.r _ s₂ x y ↔ (x : α) ≈ y) :
+  { x : quotient s₁ // p₂ x } ≃ quotient s₂ :=
+{ to_fun := λ a, quotient.hrec_on a.1 (λ a h, ⟦⟨a, (hp₂ _).2 h⟩⟧)
+    (λ a b hab, hfunext (by rw quotient.sound hab)
+    (λ h₁ h₂ _, heq_of_eq (quotient.sound ((h _ _).2 hab)))) a.2,
+  inv_fun := λ a, quotient.lift_on a (λ a, (⟨⟦a.1⟧, (hp₂ _).1 a.2⟩ : {x // p₂ x}))
+    (λ a b hab, subtype.eq (quotient.sound ((h _ _).1 hab))),
+  left_inv := λ ⟨a, ha⟩, quotient.induction_on a (λ a ha, rfl) ha,
+  right_inv := λ a, quotient.induction_on a (λ ⟨a, ha⟩, rfl) }
+
+local attribute [instance, priority 0] subtype.fintype set_fintype classical.prop_decidable
+
+section should_be_in_group_theory
+
+@[simp] lemma card_trivial [fintype (is_subgroup.trivial G)] :
+  fintype.card (is_subgroup.trivial G) = 1 :=
+fintype.card_eq_one_iff.2
+  ⟨⟨(1 : G), by simp⟩, λ ⟨y, hy⟩, subtype.eq $ is_subgroup.mem_trivial.1 hy⟩
+
+local attribute [instance] left_rel normal_subgroup.to_is_subgroup
+
+instance subtype.val.is_group_hom (H : set G) [is_subgroup H] : is_group_hom (subtype.val : H → G) :=
+⟨λ _ _, rfl⟩
+
+def normalizer (H : set G) : set G :=
+{ g : G | ∀ n, n ∈ H ↔ g * n * g⁻¹ ∈ H }
+
+instance (H : set G) [is_subgroup H] : is_subgroup (normalizer H) :=
+{ one_mem := by simp [normalizer],
+  mul_mem := λ a b (ha : ∀ n, n ∈ H ↔ a * n * a⁻¹ ∈ H)
+    (hb : ∀ n, n ∈ H ↔ b * n * b⁻¹ ∈ H) n,
+    by rw [mul_inv_rev, ← mul_assoc, mul_assoc a, mul_assoc a, ← ha, ← hb],
+  inv_mem := λ a (ha : ∀ n, n ∈ H ↔ a * n * a⁻¹ ∈ H) n,
+    by rw [ha (a⁻¹ * n * a⁻¹⁻¹)];
+    simp [mul_assoc] }
+
+lemma subset_normalizer (H : set G) [is_subgroup H] : H ⊆ normalizer H :=
+λ g hg n, by rw [is_subgroup.mul_mem_cancel_left _ ((is_subgroup.inv_mem_iff _).2 hg),
+  is_subgroup.mul_mem_cancel_right _ hg]
+
+instance (H : set G) [is_subgroup H] : normal_subgroup { x : normalizer H | ↑x ∈ H } :=
+{ one_mem := show (1 : G) ∈ H, from is_submonoid.one_mem _,
+  mul_mem := λ a b ha hb, show (a * b : G) ∈ H, from is_submonoid.mul_mem ha hb,
+  inv_mem := λ a ha, show (a⁻¹ : G) ∈ H, from is_subgroup.inv_mem ha,
+  normal := λ a ha ⟨m, hm⟩, (hm a).1 ha }
+
+lemma conj_inj_left {x : G} : function.injective (λ (n : G), x * n * x⁻¹) :=
+λ a b h, by simpa [mul_left_inj, mul_right_inj] using h
+
+lemma mem_normalizer_fintype {H : set G} [fintype H] {x : G} :
+  (∀ n, n ∈ H → x * n * x⁻¹ ∈ H) → x ∈ normalizer H :=
+λ h n, ⟨h n, λ h₁,
+have heq : (λ n, x * n * x⁻¹) '' H = H := set.eq_of_card_le_of_subset
+  (by rw set.card_image_of_injective H conj_inj_left) (λ n ⟨y, hy⟩, hy.2 ▸ h y hy.1),
+have x * n * x⁻¹ ∈ (λ n, x * n * x⁻¹) '' H := heq.symm ▸ h₁,
+let ⟨y, hy⟩ := this in conj_inj_left hy.2 ▸ hy.1⟩
+
+noncomputable lemma preimage_left_cosets_mk_equiv_subgroup_times_set
+  (H : set G) [is_subgroup H] (s : set (left_cosets H)) : left_cosets.mk ⁻¹' s ≃ (H × s) :=
+have h : ∀ {x : left_cosets H} {a : G}, x ∈ s → a ∈ H →
+  (quotient.mk' (quotient.out' x * a) : left_cosets H) = quotient.mk' (quotient.out' x) :=
+    λ x a hx ha, quotient.sound (show (quotient.out x * a)⁻¹ * quotient.out x ∈ H,
+      from (is_subgroup.inv_mem_iff _).1 $
+        by rwa [mul_inv_rev, inv_inv, ← mul_assoc, inv_mul_self, one_mul]),
+{ to_fun := λ ⟨a, ha⟩, ⟨⟨(quotient.out' (quotient.mk' a))⁻¹ * a,
+    @quotient.exact' _ (left_rel H) _ _ $ (quotient.out_eq' _)⟩,
+      ⟨quotient.mk' a, ha⟩⟩,
+  inv_fun := λ ⟨⟨a, ha⟩, ⟨x, hx⟩⟩, ⟨(quotient.out' x) * a, show quotient.mk' _ ∈ s,
+    by simp [h hx ha, hx]⟩,
+  left_inv := λ ⟨a, ha⟩, by simp,
+  right_inv := λ ⟨⟨a, ha⟩, ⟨x, hx⟩⟩, by simp [h hx ha] }
+
+end should_be_in_group_theory
+
+section group_action
+variables (f : G → α → α) [is_group_action f]
+
+lemma mem_fixed_points_iff_card_orbit {f : G → α → α} [is_group_action f] {a : α} [fintype (orbit f a)] :
+  a ∈ fixed_points f ↔ card (orbit f a) = 1 :=
+begin
+  rw [fintype.card_eq_one_iff, mem_fixed_points],
+  split,
+  { exact λ h, ⟨⟨a, mem_orbit_self _ _⟩, λ ⟨b, ⟨x, hx⟩⟩, subtype.eq $ by simp [h x, hx.symm]⟩ },
+  { assume h x,
+    rcases h with ⟨⟨z, hz⟩, hz₁⟩,
+    exact calc f x a = z : subtype.mk.inj (hz₁ ⟨f x a, mem_orbit _ _ _⟩)
+      ... = a : (subtype.mk.inj (hz₁ ⟨a, mem_orbit_self _ _⟩)).symm }
+end
+
+def orbit_rel : setoid α :=
+{ r := λ a b, a ∈ orbit f b,
+  iseqv := ⟨mem_orbit_self f, λ a b, by simp [orbit_eq_iff.symm, eq_comm],
+    λ a b, by simp [orbit_eq_iff.symm, eq_comm] {contextual := tt}⟩ }
+
+lemma card_modeq_card_fixed_points [fintype α] [fintype G] [fintype (fixed_points f)]
+  {p n : ℕ} (hp : nat.prime p) (h : card G = p ^ n) : card α ≡ card (fixed_points f) [MOD p] :=
+calc card α = card (Σ y : quotient (orbit_rel f), {x // quotient.mk' x = y}) :
+  card_congr (equiv_fib (@quotient.mk' _ (orbit_rel f)))
+... = univ.sum (λ a : quotient (orbit_rel f), card {x // quotient.mk' x = a}) : card_sigma _
+... ≡ (@univ (fixed_points f) _).sum (λ _, 1) [MOD p] :
+begin
+  rw [← zmodp.eq_iff_modeq_nat hp, sum_nat_cast, sum_nat_cast],
+  refine eq.symm (sum_bij_ne_zero (λ a _ _, quotient.mk' a.1)
+    (λ _ _ _, mem_univ _)
+    (λ a₁ a₂ _ _ _ _ h,
+      subtype.eq (mem_fixed_points'.1 a₂.2 a₁.1 (quotient.exact' h)))
+      (λ b, _)
+      (λ a ha _, by rw [← mem_fixed_points_iff_card_orbit.1 a.2];
+        simp only [quotient.eq']; congr)),
+  { refine quotient.induction_on' b (λ b _ hb, _),
+    have : card (orbit f b) ∣ p ^ n,
+    { rw [← h, card_congr (orbit_equiv_left_cosets f b)];
+      exact card_left_cosets_dvd_card _ },
+    rcases (nat.dvd_prime_pow hp).1 this with ⟨k, _, hk⟩,
+    have hb' :¬ p ^ 1 ∣ p ^ k,
+    { rw [nat.pow_one, ← hk, ← nat.modeq.modeq_zero_iff, ← zmodp.eq_iff_modeq_nat hp,
+        nat.cast_zero, ← ne.def],
+      exact eq.mpr (by simp only [quotient.eq']; congr) hb },
+    have : k = 0 := nat.le_zero_iff.1 (nat.le_of_lt_succ (lt_of_not_ge (mt (nat.pow_dvd_pow p) hb'))),
+    refine ⟨⟨b, mem_fixed_points_iff_card_orbit.2 $ by rw [hk, this, nat.pow_zero]⟩, mem_univ _,
+      by simp [zero_ne_one], rfl⟩ }
+end
+... = _ : by simp; refl
+
+end group_action
+
+def mk_vector_prod_eq_one (n : ℕ) (v : vector G n) : vector G (n+1) :=
+v.to_list.prod⁻¹ :: v
+
+lemma mk_vector_prod_eq_one_inj (n : ℕ) : injective (@mk_vector_prod_eq_one G _ n) :=
+λ ⟨v, _⟩ ⟨w, _⟩ h, subtype.eq (show v = w, by injection h with h; injection h)
+
+lemma card_vector [fintype α] (n : ℕ) :
+  fintype.card (vector α n) = fintype.card α ^ n :=
+by rw fintype.of_equiv_card; simp
+
+def vectors_prod_eq_one (G : Type*) [group G] (n : ℕ) : set (vector G n) :=
+{v | v.to_list.prod = 1}
+
+lemma mem_vectors_prod_eq_one {n : ℕ} (v : vector G n) :
+  v ∈ vectors_prod_eq_one G n ↔ v.to_list.prod = 1 := iff.rfl
+
+lemma mem_vectors_prod_eq_one_iff {n : ℕ} (v : vector G (n + 1)) :
+  v ∈ vectors_prod_eq_one G (n + 1) ↔ v ∈ set.range (@mk_vector_prod_eq_one G _ n) :=
+⟨λ (h : v.to_list.prod = 1), ⟨v.tail,
+  begin
+    unfold mk_vector_prod_eq_one,
+    conv {to_rhs, rw ← vector.cons_head_tail v},
+    suffices : (v.tail.to_list.prod)⁻¹ = v.head,
+    { rw this },
+    rw [← mul_right_inj v.tail.to_list.prod, inv_mul_self, ← list.prod_cons,
+      ← vector.to_list_cons, vector.cons_head_tail, h]
+  end⟩,
+  λ ⟨w, hw⟩, by rw [mem_vectors_prod_eq_one, ← hw, mk_vector_prod_eq_one,
+    vector.to_list_cons, list.prod_cons, inv_mul_self]⟩
+
+def list.rotate : list α → ℕ → list α
+| []     n     := []
+| l      0     := l
+| (a::l) (n+1) := (l ++ [a]).rotate n
+
+@[simp] lemma rotate_nil (n : ℕ) : ([] : list α).rotate n = [] := by cases n; refl
+
+@[simp] lemma rotate_zero (l : list α) : l.rotate 0 = l := by cases l; refl
+
+lemma rotate_succ_cons (l : list α) (a : α ) (n : ℕ) :
+  (a :: l : list α).rotate n.succ = (l ++ [a]).rotate n := rfl
+
+@[simp] lemma length_rotate : ∀ (l : list α) (n : ℕ), (l.rotate n).length = l.length
+| []     n     := rfl
+| (a::l) 0     := rfl
+| (a::l) (n+1) := by rw [list.rotate, length_rotate (l ++ [a]) n]; simp
+
+lemma drop_append : ∀ {l₁ l₂ : list α} {n : ℕ}, n ≤ l₁.length →
+  (l₁ ++ l₂).drop n = l₁.drop n ++ l₂
+| l₁      l₂ 0     hn := by simp
+| []      l₂ (n+1) hn := absurd hn dec_trivial
+| (a::l₁) l₂ (n+1) hn :=
+by rw [list.drop, list.cons_append, list.drop, drop_append (nat.le_of_succ_le_succ hn)]
+
+lemma take_append : ∀ {l₁ l₂ : list α} {n : ℕ}, n ≤ l₁.length → (l₁ ++ l₂).take n = l₁.take n
+| l₁      l₂ 0     hn := by simp
+| []      l₂ (n+1) hn := absurd hn dec_trivial
+| (a::l₁) l₂ (n+1) hn :=
+by rw [list.take, list.cons_append, list.take, take_append (nat.le_of_succ_le_succ hn)]
+
+lemma rotate_eq_take_append_drop : ∀ {l : list α} {n : ℕ}, n < l.length → l.rotate n = l.drop n ++ l.take n
+| []     n     h := by simp [drop_append h]
+| l      0     h := by simp [take_append h]
+| (a::l) (n+1) h :=
+have hnl : n ≤ l.length := le_of_lt (nat.lt_of_succ_lt_succ h),
+have hnl' : n < (l ++ [a]).length, by rw [list.length_append, list.length_cons, list.length, zero_add];
+  exact (nat.lt_succ_of_le hnl),
+by rw [rotate_succ_cons, rotate_eq_take_append_drop hnl', list.drop, list.take, drop_append hnl,
+  take_append hnl]; simp
+
+@[simp] lemma list.nth_le_singleton (a : α) {n : ℕ} (hn : n < 1) :
+  list.nth_le [a] n hn = a :=
+have hn0 : n = 0 := nat.le_zero_iff.1 (nat.le_of_lt_succ hn),
+by subst hn0; refl
+
+lemma list.nth_le_append : ∀ {l₁ l₂ : list α} {n : ℕ} (hn : n < l₁.length),
+  (l₁ ++ l₂).nth_le n (lt_of_lt_of_le hn (by rw [list.length_append]; exact nat.le_add_right _ _)) =
+  l₁.nth_le n hn
+| []     _ n     hn := (nat.not_lt_zero _ hn).elim
+| (a::l) _ 0     hn := rfl
+| (a::l) _ (n+1) hn := by simp only [list.nth_le, list.cons_append];
+                         exact list.nth_le_append _
+
+lemma list.nth_append  {l₁ l₂ : list α} {n : ℕ} (hn : n < l₁.length) :
+  (l₁ ++ l₂).nth n = l₁.nth n :=
+have hn' : n < (l₁ ++ l₂).length := lt_of_lt_of_le hn
+  (by rw [list.length_append]; exact nat.le_add_right _ _),
+by rw [list.nth_le_nth hn, list.nth_le_nth hn', list.nth_le_append]
+
+@[simp] lemma list.nth_concat_length: ∀ (l : list α) (a : α), (l ++ [a]).nth l.length = a
+| []     a := rfl
+| (b::l) a := by rw [list.cons_append, list.length_cons, list.nth, list.nth_concat_length]
+
+lemma nth_rotate : ∀ {l : list α} {n m : ℕ} (hml : m < l.length),
+  (l.rotate n).nth m = l.nth ((m + n) % l.length)
+| []     n     m hml := (nat.not_lt_zero _ hml).elim
+| l      0     m hml := by simp [nat.mod_eq_of_lt hml]
+| (a::l) (n+1) m hml :=
+have h₃ : m < list.length (l ++ [a]), by simpa using hml,
+(lt_or_eq_of_le (nat.le_of_lt_succ $ nat.mod_lt (m + n)
+  (lt_of_le_of_lt (nat.zero_le _) hml))).elim
+(λ hml',
+  have h₁ : (m + (n + 1)) % ((a :: l : list α).length) =
+      (m + n) % ((a :: l : list α).length) + 1,
+    from calc (m + (n + 1)) % (l.length + 1) =
+      ((m + n) % (l.length + 1) + 1) % (l.length + 1) :
+      add_assoc m n 1 ▸ nat.modeq.modeq_add (nat.mod_mod _ _).symm rfl
+    ... = (m + n) % (l.length + 1) + 1 : nat.mod_eq_of_lt (nat.succ_lt_succ hml'),
+  have h₂ : (m + n) % (l ++ [a]).length < l.length, by simpa [nat.add_one] using hml',
+  by rw [list.rotate, nth_rotate h₃, list.nth_append h₂, h₁, list.nth]; simp)
+(λ hml',
+  have h₁ : (m + (n + 1)) % (l.length + 1) = 0,
+    from calc (m + (n + 1)) % (l.length + 1) = (l.length + 1) % (l.length + 1) :
+      add_assoc m n 1 ▸ nat.modeq.modeq_add
+        (hml'.trans (nat.mod_eq_of_lt (nat.lt_succ_self _)).symm) rfl
+    ... = 0 : by simp,
+  have h₂ : l.length < (l ++ [a]).length, by simp [nat.lt_succ_self],
+  by rw [list.length, list.rotate, nth_rotate h₃, list.length_append,
+    list.length_cons, list.length, zero_add, hml', h₁, list.nth_concat_length]; refl)
+
+lemma rotate_rotate : ∀ (l : list α) (n m : ℕ), (l.rotate n).rotate m = l.rotate (n + m)
+| (a::l) 0     m := by simp
+| []     n     m := by simp
+| (a::l) (n+1) m := by rw [rotate_succ_cons, rotate_rotate, add_right_comm, rotate_succ_cons]
+
+@[simp] lemma nth_le_repeat (a : α) {n m : ℕ} (h : m < n) :
+  (list.repeat a n).nth_le m (by rwa list.length_repeat) = a :=
+list.eq_of_mem_repeat (list.nth_le_mem _ _ _)
+
+lemma rotate_eq_self_iff_eq_repeat [hα : nonempty α] : ∀ {l : list α},
+  (∀ n, l.rotate n = l) ↔ ∃ a, l = list.repeat a l.length
+| []     := ⟨λ h, nonempty.elim hα (λ a, ⟨a, by simp⟩), by simp⟩
+| (a::l) :=
+⟨λ h, ⟨a, list.ext_le (by simp) $ λ n hn h₁,
+  begin
+    rw [← option.some_inj, ← list.nth_le_nth],
+    conv {to_lhs, rw ← h ((list.length (a :: l)) - n)},
+    rw [nth_rotate hn, nat.add_sub_cancel' (le_of_lt hn),
+      nat.mod_self, nth_le_repeat _ hn], refl
+  end⟩,
+  λ ⟨a, ha⟩ n, ha.symm ▸ list.ext_le (by simp)
+    (λ m hm h,
+      have hm' : (m + n) % (list.repeat a (list.length (a :: l))).length < list.length (a :: l),
+        by rw list.length_repeat; exact nat.mod_lt _ (nat.succ_pos _),
+      by rw [nth_le_repeat, ← option.some_inj, ← list.nth_le_nth, nth_rotate h, list.nth_le_nth,
+        nth_le_repeat]; simp * at *)⟩
+
+lemma rotate_mod (l : list α) (m : ℕ) : l.rotate (m % l.length) = l.rotate m :=
+list.ext_le (by simp) $ λ n hn h,
+have h₁ : (n + m % list.length l) % list.length l = (n + m) % l.length :=
+  nat.modeq.modeq_add rfl (nat.mod_mod _ _),
+have h₂ : n < l.length, by rwa length_rotate at h,
+by rw [← option.some_inj, ← list.nth_le_nth, nth_rotate h₂, ← list.nth_le_nth,
+    nth_rotate h₂, h₁]
+
+def vector.rotate {n : ℕ} (v : vector α n) (m : ℕ) : vector α n :=
+⟨v.to_list.rotate m, by simp⟩
+
+lemma prod_rotate_eq_one_of_prod_eq_one : ∀ {l : list G} (hl : l.prod = 1) (n : ℕ),
+  (l.rotate n).prod = 1
+| []     _  _ := by simp
+| (a::l) hl n :=
+have n % list.length (a :: l) < list.length (a :: l), from nat.mod_lt _ dec_trivial,
+by rw ← list.take_append_drop (n % list.length (a :: l)) (a :: l) at hl;
+  rw [← rotate_mod, rotate_eq_take_append_drop this, list.prod_append, mul_eq_one_iff_inv_eq,
+    ← one_mul (list.prod _)⁻¹, ← hl, list.prod_append, mul_assoc, mul_inv_self, mul_one]
+
+def rotate_vectors_prod_eq_one (G : Type*) [group G] (n : ℕ+) (m : multiplicative (zmod n))
+  (v : vectors_prod_eq_one G n) : vectors_prod_eq_one G n :=
+⟨⟨v.1.to_list.rotate m.1, by simp⟩, prod_rotate_eq_one_of_prod_eq_one v.2 _⟩
+
+instance rotate_vectors_prod_eq_one.is_group_action (n : ℕ+) :
+  is_group_action (rotate_vectors_prod_eq_one G n) :=
+{to_is_monoid_action := ⟨λ v, subtype.eq $ vector.eq _ _ $ rotate_zero v.1.to_list,
+  λ a b ⟨⟨v, hv₁⟩, hv₂⟩, subtype.eq $ vector.eq _ _ $
+    show v.rotate ((a + b : zmod n).val) = list.rotate (list.rotate v (b.val)) (a.val),
+    by rw [zmod.add_val, rotate_rotate, ← rotate_mod _ (b.1 + a.1), add_comm, hv₁]⟩}
+
+lemma one_mem_vectors_prod_eq_one (n : ℕ) : vector.repeat (1 : G) n ∈ vectors_prod_eq_one G n :=
+by simp [vector.repeat, vectors_prod_eq_one]
+
+lemma one_mem_fixed_points_rotate (n : ℕ+) :
+  (⟨vector.repeat (1 : G) n, one_mem_vectors_prod_eq_one n⟩ : vectors_prod_eq_one G n) ∈
+  fixed_points (rotate_vectors_prod_eq_one G n) :=
+λ m, subtype.eq $ vector.eq _ _ $
+by haveI : nonempty G := ⟨1⟩; exact
+rotate_eq_self_iff_eq_repeat.2 ⟨(1 : G),
+  show list.repeat (1 : G) n = list.repeat 1 (list.repeat (1 : G) n).length, by simp⟩ _
+
+instance multiplicative.fintype : Π [fintype α], fintype (multiplicative α) := id
+
+instance group.nonempty : nonempty G := ⟨1⟩
+
+lemma exists_prime_order_of_dvd_card [fintype G] {p : ℕ} (hp : nat.prime p)
+  (hdvd : p ∣ card G) : ∃ x : G, order_of x = p :=
+let n : ℕ+ := ⟨p - 1, nat.sub_pos_of_lt hp.gt_one⟩ in
+let p' : ℕ+ := ⟨p, hp.pos⟩ in
+have hn : p' = n + 1 := subtype.eq (nat.succ_sub hp.pos),
+have hcard : card (vectors_prod_eq_one G (n + 1)) = card G ^ (n : ℕ),
+  by rw [set.ext mem_vectors_prod_eq_one_iff,
+    set.card_range_of_injective (mk_vector_prod_eq_one_inj _), card_vector],
+have hzmod : fintype.card (multiplicative (zmod p')) =
+  (p' : ℕ) ^ 1 := (nat.pow_one p').symm ▸ card_fin _,
+have hmodeq : _ = _ := @card_modeq_card_fixed_points _ _ _
+  (rotate_vectors_prod_eq_one G p') _ _ _ _ _ 1 hp hzmod,
+have hdvdcard : p ∣ fintype.card (vectors_prod_eq_one G (n + 1)) :=
+  calc p ∣ card G ^ 1 : by rwa nat.pow_one
+  ... ∣ card G ^ (n : ℕ) : nat.pow_dvd_pow _ n.2
+  ... = card (vectors_prod_eq_one G (n + 1)) : hcard.symm,
+have hdvdcard₂ : p ∣ card (fixed_points (rotate_vectors_prod_eq_one G p')) :=
+  nat.dvd_of_mod_eq_zero (hmodeq ▸ hn.symm ▸ nat.mod_eq_zero_of_dvd hdvdcard),
+have hcard_pos : 0 < card (fixed_points (rotate_vectors_prod_eq_one G p')) :=
+  fintype.card_pos_iff.2 ⟨⟨⟨vector.repeat 1 p', one_mem_vectors_prod_eq_one _⟩,
+    one_mem_fixed_points_rotate _⟩⟩,
+have hle : 1 < card (fixed_points (rotate_vectors_prod_eq_one G p')) :=
+  calc (1 : ℕ) < p' : hp.gt_one
+  ... ≤ _ : nat.le_of_dvd hcard_pos hdvdcard₂,
+let ⟨⟨⟨⟨x, hx₁⟩, hx₂⟩, hx₃⟩, hx₄⟩ := fintype.exists_ne_of_card_gt_one hle
+  ⟨_, one_mem_fixed_points_rotate p'⟩ in
+have hx : x ≠ list.repeat (1 : G) p', from λ h, by simpa [h, vector.repeat] using hx₄,
+have ∃ a, x = list.repeat a x.length := rotate_eq_self_iff_eq_repeat.1 (λ n,
+  have list.rotate x (n : zmod p').val = x :=
+    subtype.mk.inj (subtype.mk.inj (hx₃ (n : zmod p'))),
+  by rwa [zmod.val_cast_nat, ← hx₁, rotate_mod] at this),
+let ⟨a, ha⟩ := this in
+⟨a, have hx1 : x.prod = 1 := hx₂,
+  have ha1: a ≠ 1, from λ h, hx (ha.symm ▸ h ▸ hx₁ ▸ rfl),
+  have a ^ p = 1, by rwa [ha, list.prod_repeat, hx₁] at hx1,
+  (hp.2 _ (order_of_dvd_of_pow_eq_one this)).resolve_left
+    (λ h, ha1 (order_of_eq_one_iff.1 h))⟩
+
+open is_subgroup is_submonoid is_group_hom
+
+def mul_left_cosets (L₁ L₂ : set G) [is_subgroup L₂] [is_subgroup L₁]
+  (x : L₂) (y : left_cosets L₁) : left_cosets L₁ :=
+quotient.lift_on' y (λ y, left_cosets.mk ((x : G) * y))
+  (λ a b (hab : _ ∈ L₁), left_cosets.eq.2
+    (by rwa [mul_inv_rev, ← mul_assoc, mul_assoc (a⁻¹), inv_mul_self, mul_one]))
+
+instance mul_left_cosets.is_group_action (L₁ L₂ : set G) [is_subgroup L₂] [is_subgroup L₁] :
+  is_group_action (mul_left_cosets L₁ L₂) :=
+{ one := λ a, quotient.induction_on' a (λ a, left_cosets.eq.2
+    (by simp [is_submonoid.one_mem])),
+  mul := λ x y a, quotient.induction_on' a (λ a, left_cosets.eq.2
+    (by simp [mul_inv_rev, is_submonoid.one_mem, mul_assoc])) }
+
+lemma mem_fixed_points_mul_left_cosets_iff_mem_normalizer {H : set G} [is_subgroup H] [fintype H]
+  {x : G} : (x : left_cosets H) ∈ fixed_points (mul_left_cosets H H) ↔ x ∈ normalizer H :=
+⟨λ hx, have ha : ∀ {y : left_cosets H}, y ∈ orbit (mul_left_cosets H H) x → y = x := λ _,
+    (mem_fixed_points'.1 hx _),
+  (inv_mem_iff _).1 (mem_normalizer_fintype (λ n hn,
+    have (n⁻¹ * x)⁻¹ * x ∈ H := left_cosets.eq.1 (ha (mem_orbit (mul_left_cosets H H) _
+      ⟨n⁻¹, inv_mem hn⟩)),
+    by simpa only [mul_inv_rev, inv_inv] using this)),
+λ (hx : ∀ (n : G), n ∈ H ↔ x * n * x⁻¹ ∈ H),
+mem_fixed_points'.2 $ λ y, quotient.induction_on' y $ λ y hy, left_cosets.eq.2
+  (let ⟨⟨b, hb₁⟩, hb₂⟩ := hy in
+  have hb₂ : (b * x)⁻¹ * y ∈ H := left_cosets.eq.1 hb₂,
+  (inv_mem_iff H).1 $ (hx _).2 $ (mul_mem_cancel_right H (inv_mem hb₁)).1
+  $ by rw hx at hb₂;
+    simpa [mul_inv_rev, mul_assoc] using hb₂)⟩
+
+lemma fixed_points_mul_left_cosets_equiv_cosets (H : set G) [is_subgroup H] [fintype H] :
+  fixed_points (mul_left_cosets H H) ≃ left_cosets {x : normalizer H | ↑x ∈ H} := sorry
+
+local attribute [instance] set_fintype
+
+lemma exists_subgroup_card_pow_prime [fintype G] {p : ℕ} : ∀ {n : ℕ} (hp : nat.prime p)
+  (hdvd : p ^ n ∣ card G), ∃ H : set G, is_subgroup H ∧ card H = p ^ n
+| 0 := λ _ _, ⟨trivial G, by apply_instance, by simp [-set.set_coe_eq_subtype]⟩
+| (n+1) := λ hp hdvd,
+let ⟨H, ⟨hH1, hH2⟩⟩ := exists_subgroup_card_pow_prime hp
+  (dvd.trans (nat.pow_dvd_pow _ (nat.le_succ _)) hdvd) in
+let ⟨s, hs⟩ := exists_eq_mul_left_of_dvd hdvd in
+by exactI
+have hcard : card (left_cosets H) = s * p :=
+  (nat.mul_right_inj (show card H > 0, from fintype.card_pos_iff.2 ⟨⟨1, is_submonoid.one_mem H⟩⟩)).1
+    (by rwa [← card_eq_card_cosets_mul_card_subgroup, hH2, hs, nat.pow_succ, mul_assoc, mul_comm p]),
+have hm : s * p % p = card (left_cosets {x : normalizer H | ↑x ∈ H}) % p :=
+  card_congr (fixed_points_mul_left_cosets_equiv_cosets H) ▸ hcard ▸
+    card_modeq_card_fixed_points _ hp hH2,
+have hm' : p ∣ card (left_cosets {x : normalizer H | ↑x ∈ H}) :=
+  nat.dvd_of_mod_eq_zero
+    (by rwa [nat.mod_eq_zero_of_dvd (dvd_mul_left _ _), eq_comm] at hm),
+let ⟨x, hx⟩ := exists_prime_order_of_dvd_card hp hm' in
+have hxcard : ∀ {f : fintype (gpowers x)}, card (gpowers x) = p,
+  from λ f, by rw [← hx, order_eq_card_gpowers]; congr,
+let S : set ↥(normalizer H) := set.preimage left_cosets.mk
+      (@gpowers (left_cosets {x : ↥(normalizer H) | ↑x ∈ H}) _ x) in
+have is_subgroup S := @is_group_hom.preimage _
+  (left_cosets {x : ↥(normalizer H) | ↑x ∈ H}) _ _ _ _ _ _,
+let fS : fintype S := by apply_instance in
+let hequiv : {x : ↥(normalizer H) | ↑x ∈ H} ≃ H :=
+  { to_fun := λ ⟨x, hx⟩, ⟨x, hx⟩,
+    inv_fun := λ ⟨x, hx⟩, ⟨⟨x, subset_normalizer _ hx⟩, hx⟩,
+    left_inv := λ ⟨⟨_, _⟩, _⟩, rfl,
+    right_inv := λ ⟨_, _⟩, rfl } in
+⟨subtype.val '' S, by apply_instance,
+begin
+  dsimp only [S],
+  rw [set.card_image_of_injective _ subtype.val_injective, nat.pow_succ,
+    @card_congr _ _ fS _ (preimage_left_cosets_mk_equiv_subgroup_times_set _ _),
+    card_prod, hxcard, ← hH2, card_congr hequiv]
+end⟩
+
+def conjugate_set (x : G) (H : set G) : set G :=
+(λ n, x⁻¹ * n * x) ⁻¹' H
+
+lemma conjugate_set_eq_image (H : set G) (x : G) :
+  conjugate_set x H = (λ n, x * n * x⁻¹) '' H :=
+eq.symm (congr_fun (set.image_eq_preimage_of_inverse
+  (λ _, by simp [mul_assoc]) (λ _, by simp [mul_assoc])) _)
+
+lemma conjugate_set_eq_preimage (H : set G) (x : G) :
+  conjugate_set x H = (λ n, x⁻¹ * n * x) ⁻¹' H := rfl
+
+instance conjugate_set.is_group_action : is_group_action (@conjugate_set G _) :=
+{ one := λ H, by simp [conjugate_set_eq_image, set.image],
+  mul := λ x y H, by simp [mul_inv_rev, mul_assoc, function.comp, conjugate_set_eq_preimage,
+    set.preimage] }
+
+@[simp] lemma conjugate_set_normal_subgroup (H : set G) [normal_subgroup H] (x : G) :
+  conjugate_set x H = H :=
+set.ext (λ n, ⟨λ h : _ ∈ H, by have := normal_subgroup.normal _ h x; simpa [mul_assoc] using this,
+λ h, show _ ∈ H, by have := normal_subgroup.normal _ h (x⁻¹); by simpa using this⟩)
+
+instance is_group_action.subgroup (H : set G) [is_subgroup H] (f : G → α → α) [is_group_action f] :
+  is_group_action (λ x : H, f x) :=
+{ one := λ a, is_monoid_action.one f a,
+  mul := λ ⟨x, hx⟩ ⟨y, hy⟩ a, is_monoid_action.mul f x y a }
+
+instance is_group_hom_conj (x : G) : is_group_hom (λ (n : G), x * n * x⁻¹) :=
+⟨by simp [mul_assoc]⟩
+
+instance is_subgroup_conj (x : G) (H : set G) [is_subgroup H] :
+  is_subgroup (conjugate_set x H) :=
+by rw conjugate_set_eq_image; apply_instance
+
+/-- `dlogn p a` gives the maximum value of `n` such that `p ^ n ∣ a` -/
+def dlogn (p : ℕ) : ℕ → ℕ
+| 0     := 0
+| (a+1) := if h : p > 1 then
+  have (a + 1) / p < a + 1, from nat.div_lt_self dec_trivial h,
+    if p ∣ (a + 1) then dlogn ((a + 1) / p) + 1 else 0
+  else 0
+
+lemma dlogn_dvd {p : ℕ} : ∀ a, p > 1 → p ^ dlogn p a ∣ a
+| 0     := λ _, dvd_zero _
+| (a+1) := λ h,
+have (a + 1) / p < a + 1, from nat.div_lt_self dec_trivial h,
+begin
+  rw [dlogn, if_pos h],
+  split_ifs with hd,
+  { rw nat.pow_succ,
+    conv { to_rhs, rw ← nat.div_mul_cancel hd },
+    exact mul_dvd_mul (dlogn_dvd _ h) (dvd_refl _) },
+  { simp }
+end
+
+lemma not_dvd_of_gt_dlogn {p : ℕ} : ∀ {a m}, a > 0 → p > 1 → m > dlogn p a → ¬p ^ m ∣ a
+| 0     := λ m h, (lt_irrefl _ h).elim
+| (a+1) := λ m h hp hm ,
+have (a + 1) / p < a + 1, from nat.div_lt_self dec_trivial hp,
+begin
+  rw [dlogn, if_pos hp] at hm,
+  split_ifs at hm with hd,
+  { have hmsub : (m - 1).succ = m :=
+      nat.succ_sub (show 1 ≤ m, from (lt_of_le_of_lt (nat.zero_le _) hm)) ▸
+      (nat.succ_sub_one m).symm,
+    have := @not_dvd_of_gt_dlogn ((a + 1) / p) (m - 1)
+      (pos_of_mul_pos_left (by rw nat.mul_div_cancel' hd; exact nat.succ_pos _) (nat.zero_le p))
+      hp (nat.lt_of_succ_lt_succ (hmsub.symm ▸ hm)),
+    rwa [← nat.mul_dvd_mul_iff_right (lt_trans dec_trivial hp), nat.div_mul_cancel hd,
+      ← nat.pow_succ, hmsub] at this },
+  { assume h,
+    exact hd (calc p = p ^ 1 : (nat.pow_one _).symm
+      ... ∣ p ^ m : nat.pow_dvd_pow p hm
+      ... ∣ a + 1 : h) }
+end
+
+lemma pow_dvd_of_dvd_mul {p : ℕ} : ∀ {m n k : ℕ} (hp : nat.prime p)
+  (hd : p ^ m ∣ n * k) (hk : ¬p ∣ k), p ^ m ∣ n
+| 0     := by simp
+| (m+1) := λ n k hp hd hk,
+have hpnk : p ∣ n * k := calc p = p ^ 1 : by rw nat.pow_one
+  ... ∣ p ^ (m + 1) : nat.pow_dvd_pow _ (nat.succ_pos _)
+  ... ∣ n * k : by assumption,
+have hpn : p ∣ n := or.resolve_right (hp.dvd_mul.1 hpnk) hk,
+have p ^ m ∣ (n / p) * k := nat.dvd_of_mul_dvd_mul_right hp.pos $
+  by rwa [mul_right_comm, nat.div_mul_cancel hpn, ← nat.pow_succ],
+by rw [nat.pow_succ, ← nat.div_mul_cancel hpn];
+  exact mul_dvd_mul_right (pow_dvd_of_dvd_mul hp this hk) _
+
+lemma eq_dlogn_of_dvd_of_succ_not_dvd {a p n : ℕ} (hp : 1 < p) (h₁ : p ^ n ∣ a)
+  (h₂ : ¬p ^ n.succ ∣ a) : n = dlogn p a :=
+have ha : 0 < a := nat.pos_of_ne_zero (λ h, by simpa [h] using h₂),
+le_antisymm (le_of_not_gt $ λ h, not_dvd_of_gt_dlogn ha hp h h₁)
+  (le_of_not_gt $ λ h, h₂ $ calc p ^ n.succ ∣ p ^ dlogn p a : nat.pow_dvd_pow _ h
+    ... ∣ _ : dlogn_dvd _ hp)
+
+lemma dlogn_eq_of_not_dvd {a b p  : ℕ} (hp : nat.prime p) (hpb : ¬p ∣ b) :
+  dlogn p a = dlogn p (a * b) :=
+if ha : a = 0 then by simp [ha, dlogn] else
+eq_dlogn_of_dvd_of_succ_not_dvd hp.gt_one (dvd.trans (dlogn_dvd _ hp.gt_one) (dvd_mul_right _ _))
+  (λ h, not_dvd_of_gt_dlogn (nat.pos_of_ne_zero ha)
+  hp.gt_one (nat.lt_succ_self _) (pow_dvd_of_dvd_mul hp h hpb))
+
+lemma not_dvd_div_dlogn {p a : ℕ} (ha : a > 0) (hp : p > 1) : ¬p ∣ a / (p ^ dlogn p a) :=
+by rw [← nat.mul_dvd_mul_iff_left (nat.pos_pow_of_pos (dlogn p a) (lt_trans dec_trivial hp)),
+    nat.mul_div_cancel' (dlogn_dvd _ hp), ← nat.pow_succ];
+  exact not_dvd_of_gt_dlogn ha hp (nat.lt_succ_self _)
+
+class is_sylow [fintype G] (H : set G) {p : ℕ} (hp : nat.prime p) extends is_subgroup H : Prop :=
+(card_eq : card H = p ^ dlogn p (card G))
+
+instance is_subgroup_in_subgroup (H K : set G) [is_subgroup H] [is_subgroup K] :
+  is_subgroup {x : K | (x : G) ∈ H} :=
+{ one_mem := show _ ∈ H, from one_mem _,
+  mul_mem := λ x y hx hy, show x.1 * y.1 ∈ H, from mul_mem hx hy,
+  inv_mem := λ x hx, show x.1⁻¹ ∈ H, from inv_mem hx }
+
+lemma exists_sylow_subgroup (G : Type u) [group G] [fintype G] {p : ℕ} (hp : nat.prime p) :
+  ∃ H : set G, is_sylow H hp :=
+let ⟨H, ⟨hH₁, hH₂⟩⟩ := exists_subgroup_card_pow_prime hp (dlogn_dvd (card G) hp.gt_one) in
+by exactI ⟨H, by split; assumption⟩
+
+lemma card_sylow [fintype G] (H : set G) [f : fintype H] {p : ℕ} (hp : nat.prime p) [is_sylow H hp] :
+  card H = p ^ dlogn p (card G) :=
+by rw ← is_sylow.card_eq H hp; congr
+
+lemma is_sylow_in_subgroup [fintype G] (H K : set G) {p : ℕ} (hp : nat.prime p)
+  [is_sylow H hp] (hsub : H ⊆ K) [is_subgroup K] : is_sylow {x : K | (x : G) ∈ H} hp :=
+{ card_eq :=
+  have h₁ : H = subtype.val '' {x : K | (x : G) ∈ H},
+    from set.ext $ λ x, ⟨λ h, ⟨⟨x, hsub h⟩, ⟨h, rfl⟩⟩, λ ⟨y, hy⟩, hy.2 ▸ hy.1⟩,
+  have h₂ : card K * (card G / card K) = card G := nat.mul_div_cancel'
+    ((card_eq_card_cosets_mul_card_subgroup K).symm ▸ dvd_mul_left _ _),
+  have h₃ : ∀ {f : fintype {x : K | (x : G) ∈ H}}, @fintype.card {x : K | (x : G) ∈ H} f
+    = card H := λ f, by exactI
+    calc @fintype.card {x : K | (x : G) ∈ H} f = card (subtype.val '' {x : K | (x : G) ∈ H}) :
+      by exact (set.card_image_of_injective _ subtype.val_injective).symm
+    ... = card H : by rw ← h₁,
+  calc _ = _ : h₃
+  ... = p ^ dlogn p (card G) : card_sylow H hp
+  ... = p ^ dlogn p (card K) : congr_arg _ (h₂ ▸ eq.symm begin
+    refine dlogn_eq_of_not_dvd hp (λ h, _),
+    have h₄ := mul_dvd_mul_left (card K) h,
+    rw [h₂, card_eq_card_cosets_mul_card_subgroup {x : K | (x : G) ∈ H}, h₃, card_sylow H hp,
+      mul_assoc, ← nat.pow_succ] at h₄,
+    exact not_dvd_of_gt_dlogn (fintype.card_pos_iff.2 ⟨(1 : G)⟩) hp.gt_one (nat.lt_succ_self _)
+      (dvd_of_mul_left_dvd h₄),
+  end),
+  ..is_subgroup_in_subgroup H K }
+
+lemma sylow_conjugate [fintype G] {p : ℕ} (hp : nat.prime p)
+  (H K : set G) [is_sylow H hp] [is_sylow K hp] :
+  ∃ g : G, H = conjugate_set g K :=
+have hs : card (left_cosets K) = card G / (p ^ dlogn p (card G)) :=
+  (nat.mul_right_inj (nat.pos_pow_of_pos (dlogn p (card G)) hp.pos)).1
+  $ by rw [← card_sylow K hp, ← card_eq_card_cosets_mul_card_subgroup, card_sylow K hp,
+    nat.div_mul_cancel (dlogn_dvd _ hp.gt_one)],
+have hmodeq : card G / (p ^ dlogn p (card G)) ≡ card (fixed_points (mul_left_cosets K H)) [MOD p] :=
+  hs ▸ card_modeq_card_fixed_points (mul_left_cosets K H) hp (card_sylow H hp),
+have hfixed : 0 < card (fixed_points (mul_left_cosets K H)) := nat.pos_of_ne_zero
+  (λ h, (not_dvd_div_dlogn (fintype.card_pos_iff.2 ⟨(1 : G)⟩) hp.gt_one)
+    $ by rwa [h, nat.modeq.modeq_zero_iff] at hmodeq),
+let ⟨⟨x, hx⟩⟩ := fintype.card_pos_iff.1 hfixed in
+begin
+  haveI : is_subgroup K := by apply_instance,
+  revert hx,
+  refine quotient.induction_on' x
+    (λ x hx, ⟨x, set.eq_of_card_le_of_subset _ _⟩),
+  { rw [conjugate_set_eq_image, set.card_image_of_injective _ conj_inj_left,
+    card_sylow K hp, card_sylow H hp] },
+  { assume y hy,
+    have : (y⁻¹ * x)⁻¹ * x ∈ K := quotient.exact'
+      (mem_fixed_points'.1 hx ((y⁻¹ * x : G) : left_cosets K) ⟨⟨y⁻¹, inv_mem hy⟩, rfl⟩),
+    simp [conjugate_set_eq_preimage, set.preimage, mul_inv_rev, *, mul_assoc] at * }
+end
+
+def conj_on_sylow [fintype G] {p : ℕ} (hp : nat.prime p)
+  : Π (x : G) (H : {H : set G // is_sylow H hp}), {H : set G // is_sylow H hp} :=
+λ x ⟨H, hH⟩, ⟨conjugate_set x H, by exactI
+have h : is_subgroup (conjugate_set x H) := @is_subgroup_conj _ _ _ _ _,
+{ card_eq := by exactI by
+  rw [← card_sylow H hp, conjugate_set_eq_image, set.card_image_of_injective _ conj_inj_left],
+  ..h }⟩
+
+instance conj_on_sylow.is_group_action [fintype G] {p : ℕ} (hp : nat.prime p) :
+  is_group_action (@conj_on_sylow G _ _ _ hp) :=
+{ one := λ ⟨H, hH⟩, by simp [conj_on_sylow, conjugate_set_eq_preimage, set.preimage],
+  mul := λ x y ⟨H, hH⟩, by simp! [mul_inv_rev, mul_assoc, function.comp,
+      conjugate_set_eq_image, (set.image_comp _ _ _).symm, conj_on_sylow] }
+
+lemma card_sylow_dvd [fintype G] {p : ℕ} (hp : nat.prime p) :
+  card {H : set G // is_sylow H hp} ∣ card G :=
+let ⟨H, hH⟩ := exists_sylow_subgroup G hp in
+have h : orbit (conj_on_sylow hp) ⟨H, hH⟩ = set.univ :=
+  set.eq_univ_iff_forall.2 (λ S, mem_orbit_iff.2 $
+  let ⟨x, (hx : S.val = _)⟩ := @sylow_conjugate _ _ _ _ hp S.1 H S.2 hH in
+  ⟨x, subtype.eq (hx.symm ▸ rfl)⟩),
+have is_subgroup (stabilizer (conj_on_sylow hp) ⟨H, hH⟩) := by apply_instance,
+by exactI
+have orbit_equiv : card (orbit (conj_on_sylow hp) ⟨H, hH⟩) =
+  fintype.card (left_cosets (stabilizer (conj_on_sylow hp) ⟨H, hH⟩)) :=
+   card_congr (orbit_equiv_left_cosets (conj_on_sylow hp) (⟨H, hH⟩ : {H : set G // is_sylow H hp})),
+by exactI begin
+  rw [h, ← card_congr (equiv_univ _)] at orbit_equiv,
+  rw [orbit_equiv, card_congr (@group_equiv_left_cosets_times_subgroup _ _
+    (stabilizer (conj_on_sylow hp) ⟨H, hH⟩) (by apply_instance)), card_prod],
+  exact dvd_mul_right _ _
+end
+
+lemma card_sylow_modeq_one [fintype G] {p : ℕ} (hp : nat.prime p) :
+  card {H : set G // is_sylow H hp} ≡ 1 [MOD p] :=
+let ⟨H, hH⟩ := exists_sylow_subgroup G hp in
+by exactI
+eq.trans
+(card_modeq_card_fixed_points (λ x : H, conj_on_sylow hp (x : G)) hp (card_sylow H hp))
+begin
+  refine congr_fun (show (%) _ = (%) 1,
+    from congr_arg _ (fintype.card_eq_one_iff.2 _)) p,
+  refine ⟨(⟨(⟨H, hH⟩ :  {H // is_sylow H hp}), λ ⟨x, hx⟩, subtype.eq $
+    set.ext (λ i, by simp [conj_on_sylow, conjugate_set_eq_preimage, mul_mem_cancel_left _ hx,
+      mul_mem_cancel_right _ (inv_mem hx)])⟩ :
+        subtype (fixed_points (λ (x : ↥H), conj_on_sylow hp ↑x))), _⟩,
+  refine λ L, subtype.eq (subtype.eq _),
+  rcases L with ⟨⟨L, hL₁⟩, hL₂⟩,
+  have Hsub : H ⊆ normalizer L,
+  { assume x hx n,
+    conv {to_rhs, rw ← subtype.mk.inj (hL₂ ⟨x, hx⟩)},
+    simp [conjugate_set, mul_assoc] },
+  suffices : ∀ x, x ∈ {x : normalizer L | (x : G) ∈ L} ↔ x ∈ {x : normalizer L | (x : G) ∈ H},
+  { exact set.ext (λ x, ⟨λ h, (this ⟨x, subset_normalizer _ h⟩).1 h, λ h, (this ⟨x, Hsub h⟩).2 h⟩) },
+  assume x,
+  haveI := is_sylow_in_subgroup L (normalizer L) hp (subset_normalizer L),
+  haveI := is_sylow_in_subgroup H (normalizer L) hp Hsub,
+  cases sylow_conjugate hp {x : normalizer L | (x : G) ∈ H} {x | (x : G) ∈ L} with x hx,
+  simp [hx]
+end

--- a/group_theory/sylow.lean
+++ b/group_theory/sylow.lean
@@ -399,8 +399,10 @@ lemma fixed_points_mul_left_cosets_equiv_cosets (H : set G) [is_subgroup H] [fin
 
 local attribute [instance] set_fintype
 
+set_option class.instance_max_depth 2000
+
 lemma exists_subgroup_card_pow_prime [fintype G] {p : ℕ} : ∀ {n : ℕ} (hp : nat.prime p)
-  (hdvd : p ^ n ∣ card G), ∃ H : set G, is_subgroup H ∧ card H = p ^ n
+  (hdvd : p ^ n ∣ card G), ∃ H : set G, is_subgroup H ∧ fintype.card H = p ^ n
 | 0 := λ _ _, ⟨trivial G, by apply_instance, by simp [-set.set_coe_eq_subtype]⟩
 | (n+1) := λ hp hdvd,
 let ⟨H, ⟨hH1, hH2⟩⟩ := exists_subgroup_card_pow_prime hp
@@ -419,23 +421,15 @@ have hm' : p ∣ card (left_cosets {x : normalizer H | ↑x ∈ H}) :=
 let ⟨x, hx⟩ := exists_prime_order_of_dvd_card hp hm' in
 have hxcard : ∀ {f : fintype (gpowers x)}, card (gpowers x) = p,
   from λ f, by rw [← hx, order_eq_card_gpowers]; congr,
-let S : set ↥(normalizer H) := set.preimage left_cosets.mk
-      (@gpowers (left_cosets {x : ↥(normalizer H) | ↑x ∈ H}) _ x) in
-have is_subgroup S := @is_group_hom.preimage _
-  (left_cosets {x : ↥(normalizer H) | ↑x ∈ H}) _ _ _ _ _ _,
-let fS : fintype S := by apply_instance in
-let hequiv : {x : ↥(normalizer H) | ↑x ∈ H} ≃ H :=
-  { to_fun := λ ⟨x, hx⟩, ⟨x, hx⟩,
-    inv_fun := λ ⟨x, hx⟩, ⟨⟨x, subset_normalizer _ hx⟩, hx⟩,
-    left_inv := λ ⟨⟨_, _⟩, _⟩, rfl,
-    right_inv := λ ⟨_, _⟩, rfl } in
-⟨subtype.val '' S, by apply_instance,
-begin
-  dsimp only [S],
-  rw [set.card_image_of_injective _ subtype.val_injective, nat.pow_succ,
-    @card_congr _ _ fS _ (preimage_left_cosets_mk_equiv_subgroup_times_set _ _),
-    card_prod, hxcard, ← hH2, card_congr hequiv]
-end⟩
+have is_subgroup (left_cosets.mk ⁻¹' gpowers x),
+  from is_group_hom.preimage _ _,
+have hequiv : H ≃ {x : normalizer H | ↑x ∈ H }:=
+  ⟨λ a, ⟨⟨a.1, subset_normalizer _ a.2⟩, a.2⟩, λ a, ⟨a.1.1, a.2⟩,
+    λ ⟨_, _⟩, rfl, λ ⟨⟨_, _⟩, _⟩, rfl⟩,
+⟨subtype.val '' (left_cosets.mk ⁻¹' gpowers x), by apply_instance,
+  by rw [set.card_image_of_injective _ subtype.val_injective, nat.pow_succ,
+    card_congr (preimage_left_cosets_mk_equiv_subgroup_times_set _ _),
+      card_prod, hxcard, ← hH2, card_congr hequiv]; apply_instance⟩
 
 def conjugate_set (x : G) (H : set G) : set G :=
 (λ n, x⁻¹ * n * x) ⁻¹' H

--- a/logic/basic.lean
+++ b/logic/basic.lean
@@ -37,6 +37,10 @@ instance : decidable_eq empty := λa, a.elim
 @[simp] theorem coe_coe {α β γ} [has_coe α β] [has_coe_t β γ]
   (a : α) : (a : γ) = (a : β) := rfl
 
+instance has_zero.to_nonempty [has_zero α] : nonempty α := ⟨0⟩
+
+instance has_one.to_nonempty [has_one α] : nonempty α := ⟨1⟩
+
 end miscellany
 
 /-


### PR DESCRIPTION
This proof compiles, but aspects of it are not pretty. There were issues with type class inference for `fintype`. I noticed this comment `/- TODO: use cardinal theory, introduce `card : set α → ℕ`, or setup decidability for cosets -/` in `group_theory/order_of_element`. Are there any plans to change the setup for cardinals of finite sets, as they are a little bit difficult to work with at the moment?

TO CONTRIBUTORS:

Make sure you have:

 * [ ] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] make sure definitions and lemmas are put in the right files
 * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
