### PR TITLE
p-adic numbers

### DIFF
--- a/algebra/archimedean.lean
+++ b/algebra/archimedean.lean
@@ -98,13 +98,13 @@ eq.trans (by rw [int.cast_neg]; refl) (ceil_add_int _ _)
 theorem ceil_lt_add_one (x : α) : (⌈x⌉ : α) < x + 1 :=
 by rw [← lt_ceil, ← int.cast_one, ceil_add_int]; apply lt_add_one
 
-lemma ceil_pos {a : α} : 0 < ceil a ↔ 0 < a :=
+lemma ceil_pos {a : α} : 0 < ⌈a⌉ ↔ 0 < a :=
 ⟨ λ h, have ⌊-a⌋ < 0, from neg_of_neg_pos h, 
   pos_of_neg_neg $ lt_of_not_ge $ (not_iff_not_of_iff floor_nonneg).1 $ not_le_of_gt this,
  λ h, have -a < 0, from neg_neg_of_pos h,
   neg_pos_of_neg $ lt_of_not_ge $ (not_iff_not_of_iff floor_nonneg).2 $ not_le_of_gt this ⟩
 
-lemma ceil_nonneg {q : ℚ} (hq : q ≥ 0) : ceil q ≥ 0 :=
+lemma ceil_nonneg {q : ℚ} (hq : q ≥ 0) : ⌈q⌉ ≥ 0 :=
 if h : q > 0 then le_of_lt $ ceil_pos.2 h
 else 
   have h' : q = 0, from le_antisymm (le_of_not_lt h) hq,

--- a/algebra/archimedean.lean
+++ b/algebra/archimedean.lean
@@ -98,6 +98,18 @@ eq.trans (by rw [int.cast_neg]; refl) (ceil_add_int _ _)
 theorem ceil_lt_add_one (x : α) : (⌈x⌉ : α) < x + 1 :=
 by rw [← lt_ceil, ← int.cast_one, ceil_add_int]; apply lt_add_one
 
+lemma ceil_pos {a : α} : 0 < ceil a ↔ 0 < a :=
+⟨ λ h, have ⌊-a⌋ < 0, from neg_of_neg_pos h, 
+  pos_of_neg_neg $ lt_of_not_ge $ (not_iff_not_of_iff floor_nonneg).1 $ not_le_of_gt this,
+ λ h, have -a < 0, from neg_neg_of_pos h,
+  neg_pos_of_neg $ lt_of_not_ge $ (not_iff_not_of_iff floor_nonneg).2 $ not_le_of_gt this ⟩
+
+lemma ceil_nonneg {q : ℚ} (hq : q ≥ 0) : ceil q ≥ 0 :=
+if h : q > 0 then le_of_lt $ ceil_pos.2 h
+else 
+  have h' : q = 0, from le_antisymm (le_of_not_lt h) hq,
+  by simp [h']
+
 end
 
 class archimedean (α) [ordered_comm_monoid α] : Prop :=

--- a/algebra/field_power.lean
+++ b/algebra/field_power.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Y. Lewis
+
+Integer power operation on fields.
+-/
+
+import algebra.group_power tactic.wlog
+
+universe u
+
+section field_power
+open int nat 
+variables {α : Type u} [field α]
+
+@[simp] lemma zero_gpow : ∀ z : ℕ, z ≠ 0 → (0 : α)^z = 0
+| 0 h := absurd rfl h 
+| (k+1) h := zero_mul _ 
+
+def fpow (a : α) : ℤ → α 
+| (of_nat n) := a ^ n 
+| -[1+n] := 1/(a ^ (n+1))
+
+@[simp] lemma unit_pow {a : α} (ha : a ≠ 0) : ∀ n : ℕ, a ^ n = ↑((units.mk0 a ha)^n)
+| 0 := by simp; refl
+| (k+1) := by simp [_root_.pow_add]; congr; apply unit_pow 
+
+lemma fpow_eq_gpow {a : α} (h : a ≠ 0) : ∀ (z : ℤ), fpow a z = ↑(gpow (units.mk0 a h) z)
+| (of_nat k) := by simp only [fpow, gpow]; apply unit_pow 
+| -[1+k] := by simp [fpow, gpow]; congr; apply unit_pow 
+
+lemma fpow_inv (a : α) : fpow a (-1) = a⁻¹ := 
+begin change fpow a -[1+0] = a⁻¹, simp [fpow] end 
+
+lemma fpow_ne_zero_of_ne_zero {a : α} (ha : a ≠ 0) : ∀ (z : ℤ), fpow a z ≠ 0
+| (of_nat n) := pow_ne_zero _ ha
+| -[1+n] := one_div_ne_zero $ pow_ne_zero _ ha
+
+
+@[simp] lemma fpow_zero {a : α} : fpow a 0 = 1 :=
+pow_zero _ 
+
+end field_power
+
+section discrete_field_power
+open int nat 
+variables {α : Type u} [discrete_field α]
+
+lemma zero_fpow : ∀ z : ℤ, z ≠ 0 → fpow (0 : α) z = 0
+| (of_nat n) h :=
+  have h2 : n ≠ 0, from assume : n = 0, by simpa [this] using h,
+  by simp [h, h2, fpow]
+| -[1+n] h := 
+  have h1 : (0 : α) ^ (n+1) = 0, from zero_mul _,
+  by simp [fpow, h1]
+
+lemma fpow_add {a : α} (ha : a ≠ 0) (z1 z2 : ℤ) : fpow a (z1 + z2) = fpow a z1 * fpow a z2 := 
+begin simp only [fpow_eq_gpow ha], rw ←units.mul_coe, congr, apply gpow_add end 
+
+end discrete_field_power
+
+section ordered_field_power
+open int 
+
+variables {α : Type u} [discrete_linear_ordered_field α]
+
+lemma inv_le_one {a : α} (ha : 1 ≤ a) : a⁻¹ ≤ 1 :=
+if ha' : 1 < a then le_of_lt $ inv_lt_one ha' 
+else 
+  have 1 = a, from le_antisymm ha (le_of_not_lt ha'),
+  by simp [this.symm]
+
+lemma fpow_nonneg_of_nonneg {a : α} (ha : a ≥ 0) : ∀ (z : ℤ), fpow a z ≥ 0
+| (of_nat n) := pow_nonneg ha _
+| -[1+n] := div_nonneg' zero_le_one $ pow_nonneg ha _
+
+
+lemma fpow_le_of_le {x : α} (hx : 1 ≤ x) {a b : ℤ} (h : a ≤ b) : fpow x a ≤ fpow x b :=
+begin 
+  induction a with a a; induction b with b b,
+    { simp only [fpow], 
+      apply pow_le_pow hx, 
+      apply le_of_coe_nat_le_coe_nat h },
+    { apply absurd h, 
+      apply not_le_of_gt,
+      exact lt_of_lt_of_le (neg_succ_lt_zero _) (of_nat_nonneg _) },
+    { simp only [fpow, one_div_eq_inv], 
+      apply le_trans, 
+      apply inv_le_one, 
+      repeat { apply one_le_pow_of_one_le hx } },
+    { simp only [fpow],
+      apply (one_div_le_one_div _ _).2,
+        { apply pow_le_pow hx,
+          have : -(↑(a+1) : ℤ) ≤ -(↑(b+1) : ℤ), from h,
+          have h' := le_of_neg_le_neg this,
+          apply le_of_coe_nat_le_coe_nat h' },
+        repeat { apply pow_pos (lt_of_lt_of_le zero_lt_one hx) } }
+end
+
+lemma pow_le_max_of_min_le {x : α} (hx : x ≥ 1) {a b c : ℤ} (h : min a b ≤ c) : 
+      fpow x (-c) ≤ max (fpow x (-a)) (fpow x (-b)) :=
+begin 
+  wlog hle := le_total a b using a b,
+  have hnle : -b ≤ -a, from neg_le_neg hle,
+  have hfle : fpow x (-b) ≤ fpow x (-a), from fpow_le_of_le hx hnle,
+  have : fpow x (-c) ≤ fpow x (-a), 
+    { apply fpow_le_of_le hx,
+      simpa [hle, min_eq_left] using h },
+  simpa [hfle, max_eq_left] using this 
+end 
+
+end ordered_field_power 

--- a/algebra/order_functions.lean
+++ b/algebra/order_functions.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import algebra.ordered_group order.lattice tactic.wlog
+import algebra.ordered_group order.lattice 
 
 open lattice
 
@@ -83,15 +83,20 @@ le_trans (le_max_left _ _) h
 lemma le_of_max_le_right {a b c : α} (h : max a b ≤ c) : b ≤ c :=
 le_trans (le_max_right _ _) h 
 
-lemma min_add_eq_min_add_min {α : Type u} [decidable_linear_ordered_comm_group α] (a b c : α) : 
-      min a b - c = min (a-c) (b-c) := 
-begin
-  wlog hle : a ≤ b,
-  have : a - c ≤ b - c, from sub_le_sub hle (le_refl _),
-  simp [*, min_eq_left] at *
-end 
-
 end
+
+lemma min_add {α : Type u} [decidable_linear_ordered_comm_group α] (a b c : α) : 
+      min a b + c = min (a + c) (b + c) :=
+if hle : a ≤ b then 
+  have a - c ≤ b - c, from sub_le_sub hle (le_refl _),
+  by simp [*, min_eq_left] at *
+else 
+  have b - c ≤ a - c, from sub_le_sub (le_of_lt (lt_of_not_ge hle)) (le_refl _),
+  by simp [*, min_eq_right] at *
+
+lemma min_sub {α : Type u} [decidable_linear_ordered_comm_group α] (a b c : α) : 
+      min a b - c = min (a - c) (b - c) :=
+by simp [min_add, sub_eq_add_neg]
 
 section decidable_linear_ordered_comm_group
 variables [decidable_linear_ordered_comm_group α] {a b c : α}
@@ -150,12 +155,7 @@ calc
       ... ≤ a + b : le_add_of_nonneg_left ha
 
 lemma max_le_add_of_nonneg {a b : α} (ha : a ≥ 0) (hb : b ≥ 0) : max a b ≤ a + b :=
-begin 
-  wlog hle : a ≤ b,
-  rw max_eq_right hle,
-  apply le_add_of_nonneg_left',
-  assumption 
-end 
+max_le_iff.2 (by split; simpa)
 
 end decidable_linear_ordered_comm_group
 

--- a/algebra/order_functions.lean
+++ b/algebra/order_functions.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import algebra.ordered_group order.lattice
+import algebra.ordered_group order.lattice tactic.wlog
 
 open lattice
 
@@ -77,6 +77,20 @@ by by_cases h : a ≤ b; simp [min, h]
 theorem max_choice (a b : α) : max a b = a ∨ max a b = b :=
 by by_cases h : a ≤ b; simp [max, h]
 
+lemma le_of_max_le_left {a b c : α} (h : max a b ≤ c) : a ≤ c :=
+le_trans (le_max_left _ _) h 
+
+lemma le_of_max_le_right {a b c : α} (h : max a b ≤ c) : b ≤ c :=
+le_trans (le_max_right _ _) h 
+
+lemma min_add_eq_min_add_min {α : Type u} [decidable_linear_ordered_comm_group α] (a b c : α) : 
+      min a b - c = min (a-c) (b-c) := 
+begin
+  wlog hle : a ≤ b,
+  have : a - c ≤ b - c, from sub_le_sub hle (le_refl _),
+  simp [*, min_eq_left] at *
+end 
+
 end
 
 section decidable_linear_ordered_comm_group
@@ -124,6 +138,24 @@ lemma abs_le_max_abs_abs (hab : a ≤ b)  (hbc : b ≤ c) : abs b ≤ max (abs a
 abs_le_of_le_of_neg_le
   (by simp [le_max_iff, le_trans hbc (le_abs_self c)])
   (by simp [le_max_iff, le_trans (neg_le_neg hab) (neg_le_abs_self a)])
+
+lemma min_le_add_of_nonneg_right {a b : α} (hb : b ≥ 0) : min a b ≤ a + b :=
+calc 
+  min a b ≤ a     : by apply min_le_left
+      ... ≤ a + b : le_add_of_nonneg_right hb
+
+lemma min_le_add_of_nonneg_left {a b : α} (ha : a ≥ 0) : min a b ≤ a + b :=
+calc 
+  min a b ≤ b     : by apply min_le_right
+      ... ≤ a + b : le_add_of_nonneg_left ha
+
+lemma max_le_add_of_nonneg {a b : α} (ha : a ≥ 0) (hb : b ≥ 0) : max a b ≤ a + b :=
+begin 
+  wlog hle : a ≤ b,
+  rw max_eq_right hle,
+  apply le_add_of_nonneg_left',
+  assumption 
+end 
 
 end decidable_linear_ordered_comm_group
 

--- a/algebra/ordered_field.lean
+++ b/algebra/ordered_field.lean
@@ -159,6 +159,9 @@ by rw [inv_eq_one_div]; exact div_lt_of_mul_lt_of_pos (lt_trans zero_lt_one ha) 
 lemma one_lt_inv (h₁ : 0 < a) (h₂ : a < 1) : 1 < a⁻¹ :=
 by rw [inv_eq_one_div, lt_div_iff h₁]; simp [h₂]
 
+lemma inv_le_one {a : α} (ha : 1 ≤ a) : a⁻¹ ≤ 1 :=
+by rw [inv_eq_one_div]; exact div_le_of_le_mul (lt_of_lt_of_le zero_lt_one ha) (by simp *)
+
 lemma mul_self_inj_of_nonneg {a b : α} (a0 : 0 ≤ a) (b0 : 0 ≤ b) : a * a = b * b ↔ a = b :=
 (mul_self_eq_mul_self_iff a b).trans $ or_iff_left_of_imp $
 λ h, by subst a; rw [le_antisymm (neg_nonneg.1 a0) b0, neg_zero]

--- a/algebra/ordered_ring.lean
+++ b/algebra/ordered_ring.lean
@@ -109,6 +109,10 @@ le_iff_le_iff_lt_iff_lt.1 (mul_le_mul_right_of_neg h)
 lemma sub_one_lt (a : α) : a - 1 < a :=
 sub_lt_iff_lt_add.2 (lt_add_one a)
 
+lemma mul_le_one {α : Type*} [linear_ordered_semiring α] {a b : α} (ha : a ≤ 1) (hb' : 0 ≤ b) 
+      (hb : b ≤ 1) : a * b ≤ 1 :=
+begin rw ←one_mul (1 : α), apply mul_le_mul; {assumption <|> apply zero_le_one} end 
+
 end linear_ordered_ring
 
 set_option old_structure_cmd true

--- a/data/int/basic.lean
+++ b/data/int/basic.lean
@@ -527,6 +527,38 @@ eq_one_of_dvd_one H ⟨b, H'.symm⟩
 theorem eq_one_of_mul_eq_one_left {a b : ℤ} (H : b ≥ 0) (H' : a * b = 1) : b = 1 :=
 eq_one_of_mul_eq_one_right H (by rw [mul_comm, H'])
 
+lemma of_nat_dvd_of_dvd_nat_abs {a : ℕ} : ∀ {z : ℤ} (haz : a ∣ z.nat_abs), ↑a ∣ z
+| (int.of_nat _) haz := int.coe_nat_dvd.2 haz
+| -[1+k] haz :=
+  begin 
+    change ↑a ∣ -(k+1 : ℤ), 
+    apply dvd_neg_of_dvd, 
+    apply int.coe_nat_dvd.2,
+    exact haz 
+  end 
+
+lemma dvd_nat_abs_of_of_nat_dvd {a : ℕ} : ∀ {z : ℤ} (haz : ↑a ∣ z), a ∣ z.nat_abs 
+| (int.of_nat _) haz := int.coe_nat_dvd.1 (int.dvd_nat_abs.2 haz)
+| -[1+k] haz := 
+  have haz' : (↑a:ℤ) ∣ (↑(k+1):ℤ), from dvd_of_dvd_neg haz,
+  int.coe_nat_dvd.1 haz' 
+
+lemma pow_div_of_le_of_pow_div_int {p m n : ℕ} {k : ℤ} (hmn : m ≤ n) (hdiv : ↑(p ^ n) ∣ k) : 
+      ↑(p ^ m) ∣ k :=
+begin
+  induction k,
+    { apply int.coe_nat_dvd.2,
+      apply pow_div_of_le_of_pow_div hmn,
+      apply int.coe_nat_dvd.1 hdiv },
+    { change -[1+k] with -(↑(k+1) : ℤ),
+      apply dvd_neg_of_dvd,
+      apply int.coe_nat_dvd.2,
+      apply pow_div_of_le_of_pow_div hmn,
+      apply int.coe_nat_dvd.1,
+      apply dvd_of_dvd_neg,
+      exact hdiv } 
+end 
+
 /- / and ordering -/
 
 protected theorem div_mul_le (a : ℤ) {b : ℤ} (H : b ≠ 0) : a / b * b ≤ a :=
@@ -582,6 +614,16 @@ int.div_eq_of_eq_mul_right H3 $
 by rw [← int.mul_div_assoc _ H2]; exact
 (int.div_eq_of_eq_mul_left H4 H5.symm).symm
 
+theorem eq_mul_div_of_mul_eq_mul_of_dvd_left {a b c d : ℤ} (hb : b ≠ 0) (hd : d ≠ 0) (hbc : b ∣ c)
+      (h : b * a = c * d) : a = c / b * d :=
+begin 
+  cases hbc with k hk,
+  subst hk,
+  rw int.mul_div_cancel_left, rw mul_assoc at h,
+  apply _root_.eq_of_mul_eq_mul_left _ h,
+  repeat {assumption}
+end 
+
 theorem of_nat_add_neg_succ_of_nat_of_lt {m n : ℕ}
   (h : m < n.succ) : of_nat m + -[1+n] = -[1+ n - m] :=
 begin
@@ -630,6 +672,9 @@ by cases a; cases b; simp [(*), int.mul, nat_abs_neg_of_nat]
 
 theorem neg_succ_of_nat_eq' (m : ℕ) : -[1+ m] = -m - 1 :=
 by simp [neg_succ_of_nat_eq]
+
+lemma nat_abs_ne_zero_of_ne_zero {z : ℤ} (hz : z ≠ 0) : z.nat_abs ≠ 0 :=
+λ h, hz $ int.eq_zero_of_nat_abs_eq_zero h 
 
 /- to_nat -/
 

--- a/data/nat/basic.lean
+++ b/data/nat/basic.lean
@@ -578,50 +578,6 @@ le_of_dvd (fact_pos _) (fact_dvd_fact h)
 
 section find_greatest
 
-
-/-
-
-variables {P : ℕ → Prop} [decidable_pred P] {bound : ℕ}
-    (hall : ∀ m : ℕ, m > bound → ¬ P m) (hex : ∃ m, P m)
-    
-protected def nat.find_greatest_x : {n : ℕ // P n ∧ ∀ m : ℕ, m > n → ¬ P m} :=
-have ∃ v, P (bound - v), from 
-  let ⟨m, Hpm⟩ := hex in
-  have m ≤ bound, from le_of_not_gt (λ h, hall _ h Hpm),
-  ⟨bound - m, by rw nat.sub_sub_self; repeat {assumption}⟩,
-let minv := nat.find this,
-    minv_spec := nat.find_spec this,
-    minv_lt := @nat.find_min _ _ this in 
-⟨ bound - minv,
-  minv_spec,
-  assume (m : ℕ) (h : m > bound - minv),
-  if hmb : m > bound then
-    hall _ hmb
-  else
-    have hmb' : m ≤ bound, from le_of_not_gt hmb,
-    let minv' := @minv_lt (bound - m) in
-    have m + minv > bound, from nat.lt_add_of_sub_lt_right h,
-    have bound - m < minv, from (nat.sub_lt_left_iff_lt_add hmb').2 this,
-    begin rw nat.sub_sub_self at minv', exact minv' this, exact hmb' end ⟩ 
-
-protected def nat.find_greatest : ℕ := nat.find_greatest_x hall hex
-
-protected lemma nat.find_greatest_spec : P (nat.find_greatest hall hex) := 
-(nat.find_greatest_x hall hex).2.1
-
-protected lemma nat.find_greatest_is_greatest : ∀ (m : ℕ), m > nat.find_greatest hall hex → ¬ P m :=
-(nat.find_greatest_x hall hex).2.2
-
-protected lemma nat.find_greatest_unique {m : ℕ} (hp : P m) (hallm : ∀ k : ℕ, k > m → ¬ P k) :
-          m = nat.find_greatest hall hex :=
-nat.le_antisymm
-  (le_of_not_gt
-    (assume h : m > nat.find_greatest hall hex,
-     nat.find_greatest_is_greatest hall hex _ h hp)) 
-  (le_of_not_gt
-    (assume h : nat.find_greatest hall hex > m,
-     hallm _ h (nat.find_greatest_spec hall hex)))-/
-
 private def nat.find_greatest_core_aux (P : ℕ → Prop) [decidable_pred P] (bound : ℕ) : 
           Π m : ℕ, (∀ k, m < k ∧ k ≤ bound → ¬ P k) → 
             psum {n // P n ∧ ∀ k, n < k ∧ k ≤ bound → ¬ P k} (∀ k, k ≤ bound → ¬ P k)
@@ -634,9 +590,7 @@ private def nat.find_greatest_core_aux (P : ℕ → Prop) [decidable_pred P] (bo
       have m + 1 < k, from lt_of_le_of_ne (nat.succ_le_of_lt hmk) hm1k, 
       h _ ⟨this, hkb⟩
 
-/--
- Finds the largest n ≤ bound such that P n holds, or returns none if no such n exists
--/
+
 protected def nat.find_greatest_core (P : ℕ → Prop) [decidable_pred P] (bound : ℕ) : 
           psum {n // P n ∧ ∀ k, n < k ∧ k ≤ bound → ¬ P k} (∀ k, k ≤ bound → ¬ P k) :=
 nat.find_greatest_core_aux P bound bound $ λ _ ⟨hlt, hle⟩, false.elim $ not_le_of_gt hlt hle
@@ -646,6 +600,9 @@ protected def nat.find_greatest_aux {P : ℕ → Prop} [decidable_pred P] {bound
 | (psum.inl ⟨n, _⟩) := n
 | (psum.inr _) := 0
 
+/--
+  Finds the largest n ≤ bound such that P n holds, or returns 0 if no such n exists
+-/
 protected def nat.find_greatest (P : ℕ → Prop) [decidable_pred P] (bound : ℕ) : ℕ :=
 nat.find_greatest_aux $ nat.find_greatest_core P bound
 

--- a/data/nat/prime.lean
+++ b/data/nat/prime.lean
@@ -54,6 +54,11 @@ def decidable_prime_1 (p : ℕ) : decidable (prime p) :=
 decidable_of_iff' _ prime_def_lt'
 local attribute [instance] decidable_prime_1
 
+lemma prime.ne_zero {n : ℕ} (h : prime n) : n ≠ 0 :=
+assume hn : n = 0,
+have h2 : ¬ prime 0, from dec_trivial,
+h2 (hn ▸ h)
+
 theorem prime.pos {p : ℕ} (pp : prime p) : p > 0 :=
 lt_of_succ_lt pp.gt_one
 
@@ -355,5 +360,30 @@ end,
 perm_of_prod_eq_prod (by rwa prod_factors hn) h₂ (@mem_factors _)
 
 end
+
+lemma succ_dvd_or_succ_dvd_of_succ_sum_dvd_mul {p : ℕ} (p_prime : prime p) {m n k l : ℕ} 
+      (hpm : p ^ k ∣ m) (hpn : p ^ l ∣ n) (hpmn : p ^ (k+l+1) ∣ m*n) : 
+      p ^ (k+1) ∣ m ∨ p ^ (l+1) ∣ n :=
+have hpd : p^(k+l) * p ∣ m*n, from hpmn,
+have hpd2 : p ∣ (m*n) / p ^ (k+l), from dvd_div_of_mul_dvd hpd,
+have hpd3 : p ∣ (m*n) / (p^k * p^l), by simpa [nat.pow_add] using hpd2,
+have hpd4 : p ∣ (m / p^k) * (n / p^l), by simpa [nat.div_mul_div hpm hpn] using hpd3,
+have hpd5 : p ∣ (m / p^k) ∨ p ∣ (n / p^l), from (prime.dvd_mul p_prime).1 hpd4,
+show p^k*p ∣ m ∨ p^l*p ∣ n, from
+  hpd5.elim
+    (assume : p ∣ m / p ^ k, or.inl $ mul_dvd_of_dvd_div hpm this)
+    (assume : p ∣ n / p ^ l, or.inr $ mul_dvd_of_dvd_div hpn this)
+
+lemma succ_dvd_or_succ_dvd_of_succ_sum_dvd_mul_int {p : ℕ} (p_prime : prime p) {m n : ℤ} {k l : ℕ} 
+      (hpm : ↑(p ^ k) ∣ m) 
+      (hpn : ↑(p ^ l) ∣ n) (hpmn : ↑(p ^ (k+l+1)) ∣ m*n) : ↑(p ^ (k+1)) ∣ m ∨ ↑(p ^ (l+1)) ∣ n :=
+have hpm' : p ^ k ∣ m.nat_abs, from int.coe_nat_dvd.1 $ int.dvd_nat_abs.2 hpm,
+have hpn' : p ^ l ∣ n.nat_abs, from int.coe_nat_dvd.1 $ int.dvd_nat_abs.2 hpn,
+have hpmn' : (p ^ (k+l+1)) ∣ m.nat_abs*n.nat_abs, 
+  by rw ←int.nat_abs_mul; apply (int.coe_nat_dvd.1 $ int.dvd_nat_abs.2 hpmn),
+let hsd := succ_dvd_or_succ_dvd_of_succ_sum_dvd_mul p_prime hpm' hpn' hpmn' in
+hsd.elim
+  (λ hsd1, or.inl begin apply int.dvd_nat_abs.1, apply int.coe_nat_dvd.2 hsd1 end)
+  (λ hsd2, or.inr begin apply int.dvd_nat_abs.1, apply int.coe_nat_dvd.2 hsd2 end)
 
 end nat

--- a/data/padics/padic_integers.lean
+++ b/data/padics/padic_integers.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Y. Lewis
+
+Define the p-adic integers ℤ_p as a subtype of ℚ_p. Show ℤ_p is a ring.
+-/
+
+import data.padics.padic_rationals
+open nat padic
+noncomputable theory
+
+section padic_int
+variables {p : ℕ} (hp : prime p)
+
+def padic_int := {x : ℚ_[hp] // padic_norm_e x ≤ 1}
+notation `ℤ_[`hp`]` := padic_int hp
+end padic_int 
+
+namespace padic_int 
+variables {p : ℕ} {hp : prime p}
+
+def add : ℤ_[hp] → ℤ_[hp] → ℤ_[hp]
+| ⟨x, hx⟩ ⟨y, hy⟩ := ⟨x+y, 
+    le_trans (padic_norm_e.nonarchimedean _ _) (max_le_iff.2 ⟨hx,hy⟩)⟩
+
+def mul : ℤ_[hp] → ℤ_[hp] → ℤ_[hp]
+| ⟨x, hx⟩ ⟨y, hy⟩ := ⟨x*y, 
+    begin rw padic_norm_e.mul, apply mul_le_one; {assumption <|> apply padic_norm_e.nonneg} end⟩
+
+def neg : ℤ_[hp] → ℤ_[hp]
+| ⟨x, hx⟩ := ⟨-x, by simpa⟩
+
+instance : ring ℤ_[hp] :=
+begin 
+  refine { add := add,
+           mul := mul,
+           neg := neg,
+           zero := ⟨0, by simp⟩,
+           one := ⟨1, by simp⟩,
+           .. };
+  {repeat {rintro ⟨_, _⟩}, simp [mul_assoc, left_distrib, right_distrib, add, mul, neg]}
+end 
+
+end padic_int 

--- a/data/padics/padic_norm.lean
+++ b/data/padics/padic_norm.lean
@@ -156,14 +156,14 @@ else
     cases hn with kn hkn,
     have hmn : m + n = ↑(p ^ padic_val p m) * km + ↑(p ^ padic_val p n) * kn, by cc,
     have hmn' : m + n = ↑(p ^ padic_val p m) * (km + ↑(p ^ (padic_val p n - padic_val p m)) * kn), 
-      { rw [left_distrib, hmn, ←nat.pow_eq_mul_pow_sub _ hle], simp [mul_assoc] },
+    { rw [left_distrib, hmn, ←nat.pow_eq_mul_pow_sub _ hle], simp [mul_assoc] },
     have hpp : ↑(p ^ padic_val p m) ∣ (m + n),
-      { rw hmn', apply dvd_mul_of_dvd_left, apply dvd_refl },
+    { rw hmn', apply dvd_mul_of_dvd_left, apply dvd_refl },
     have hpvle : padic_val p m ≤ padic_val p (m+n), from 
       le_padic_val_of_pow_div hp hmnz hpp,
     transitivity,
-      { apply min_le_left },
-      { apply hpvle }
+    { apply min_le_left },
+    { apply hpvle }
   end 
 
 end
@@ -429,16 +429,16 @@ begin
                ... ≤ max (padic_norm hp (q + r)) (padic_norm hp (-r)) : padic_norm.nonarchimedean hp
                ... = max (padic_norm hp (q + r)) (padic_norm hp r) : by simpa,
   have hnge : padic_norm hp r ≤ padic_norm hp (q + r), 
-    { apply le_of_not_gt,
-      intro hgt,
-      rw max_eq_right_of_lt hgt at this,
-      apply not_lt_of_ge this,
-      assumption },
+  { apply le_of_not_gt,
+    intro hgt,
+    rw max_eq_right_of_lt hgt at this,
+    apply not_lt_of_ge this,
+    assumption },
   have : padic_norm hp q ≤ padic_norm hp (q + r), by rwa [max_eq_left hnge] at this,
   apply _root_.le_antisymm,
-    { apply padic_norm.nonarchimedean hp },
-    { rw max_eq_left_of_lt hlt,
-      assumption }
+  { apply padic_norm.nonarchimedean hp },
+  { rw max_eq_left_of_lt hlt,
+    assumption }
 end 
 
 protected theorem image {q : ℚ} (hq : q ≠ 0) : ∃ n : ℤ, padic_norm hp q = fpow p (-n) :=
@@ -450,8 +450,8 @@ instance : is_absolute_value (padic_norm hp) :=
     begin 
       intros, 
       constructor; intro, 
-        { apply zero_of_padic_norm_eq_zero hp, assumption }, 
-        { simp [*] } 
+      { apply zero_of_padic_norm_eq_zero hp, assumption }, 
+      { simp [*] } 
     end,
   abv_add := padic_norm.triangle_ineq hp,
   abv_mul := padic_norm.mul hp }

--- a/data/padics/padic_norm.lean
+++ b/data/padics/padic_norm.lean
@@ -1,0 +1,448 @@
+/-
+Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Y. Lewis
+
+Define the p-adic valuation on ℤ and ℚ, and the p-adic norm on ℚ
+-/
+
+import data.rat algebra.field_power
+import tactic.wlog tactic.ring
+
+universe u 
+open nat
+
+private lemma exi_div (p : ℕ) (n : ℤ) : ∃ k : ℕ, ↑(p ^ k) ∣ n := ⟨0, by simp⟩
+
+private lemma bound {p : ℕ} (hp : p > 1) {n : ℤ} (hn : n ≠ 0) : 
+        ∀ k : ℕ, k > n.nat_abs → ¬ (↑(p ^ k) ∣ n) := 
+assume k (hkn : k > n.nat_abs),
+have n.nat_abs < p^k, from lt.trans (le_pow_self hp _) (pow_lt_pow_of_lt_right hp hkn),
+assume hdvd : ↑(p ^ k) ∣ n,
+have hdvd' : (p ^ k) ∣ n.nat_abs, from int.dvd_nat_abs_of_of_nat_dvd hdvd,
+let hle := le_of_dvd (int.nat_abs_pos_of_ne_zero hn) hdvd' in 
+not_le_of_gt this hle 
+
+def padic_val {p : ℕ} (hp : p > 1) (n : ℤ) : ℕ := 
+if hn : n = 0 then
+  0
+else nat.find_greatest (bound hp hn) (exi_div p n)
+
+namespace padic_val 
+
+lemma spec {p : ℕ} (hp : p > 1) {n : ℤ} (hn : n ≠ 0) : ↑(p ^ padic_val hp n) ∣ n := 
+let ha := nat.find_greatest_spec (bound hp hn) (exi_div p n) in
+by simpa [padic_val, hn] using ha
+
+lemma is_greatest {p : ℕ} (hp : p > 1) {n : ℤ} (hn : n ≠ 0) : 
+      ∀ m : ℕ, m > padic_val hp n → ¬ ↑(p ^ m) ∣ n :=
+let ha := nat.find_greatest_is_greatest (bound hp hn) (exi_div p n) in 
+by simpa [padic_val, hn] using ha
+
+lemma unique {p : ℕ} (hp : p > 1) {n : ℤ} (hn : n ≠ 0) {k : ℕ} (hk : ↑(p^k) ∣ n) 
+      (hall : ∀ m : ℕ, m > k → ¬ ↑(p^m) ∣ n) : k = padic_val hp n :=
+let ha := nat.find_greatest_unique (bound hp hn) (exi_div p n) hk hall in 
+by simpa [padic_val, hn] using ha
+
+@[simp] protected lemma neg {p : ℕ} (hp : p > 1) (n : ℤ) : padic_val hp (-n) = padic_val hp n :=
+if hn : n = 0 then by simp [hn] else 
+have hnn : -n ≠ 0, by simp [hn],
+unique hp hn
+  (have ↑(p ^ padic_val hp (-n)) ∣ (-n), from spec hp hnn, dvd_of_dvd_neg this) 
+  (assume m hm (hdiv : (↑(p^m) ∣ n)), 
+   have ↑(p^m) ∣ (-n), from dvd_neg_of_dvd hdiv, 
+   is_greatest hp  hnn _ hm this)
+
+lemma le_padic_val_of_pow_div {p k : ℕ} (hp : p > 1) {n : ℤ} (hn : n ≠ 0) (h : ↑(p^k) ∣ n) : 
+      k ≤ padic_val hp n := 
+le_of_not_gt $
+  assume : k > padic_val hp n,
+  is_greatest hp hn _ this h
+
+section
+variables {p : ℕ} (hp : p > 1)
+
+@[simp] protected lemma zero : padic_val hp 0 = 0 := by simp [padic_val]
+
+@[simp] protected lemma one : padic_val hp 1 = 0 :=
+begin
+  symmetry,
+  apply nat.find_greatest_unique,
+    { norm_num },
+    { intros k hk,
+      have h1k : 1 ^ k < p ^ k, from pow_lt_pow_of_lt_left hp hk,
+      rw nat.one_pow at h1k,
+      intro hdvd,
+      apply not_le_of_gt h1k,
+      apply le_of_dvd zero_lt_one,
+      apply int.coe_nat_dvd.1 hdvd }
+end 
+
+@[simp] lemma padic_val_self : padic_val hp p = 1 :=
+have h : p ≠ 0, by intro h'; subst h'; exact absurd hp dec_trivial,
+begin 
+  unfold padic_val,
+  simp [h],
+  symmetry,
+  apply nat.find_greatest_unique,
+    { simp },
+    { intros k hk hdvd,
+      apply not_pos_pow_dvd hp hk,
+      rw ←int.coe_nat_dvd, simpa }
+end 
+
+end
+
+section padic_val 
+parameters {p : ℕ} (p_prime : prime p)
+
+private lemma hpp : p > 1 := prime.gt_one p_prime
+
+protected lemma mul {m n : ℤ} (hm : m ≠ 0) (hn : n ≠ 0) : 
+      padic_val hpp m + padic_val hpp n = padic_val hpp (m*n) :=
+have m*n ≠ 0, from mul_ne_zero hm hn,
+have hdivm : ↑(p ^ padic_val hpp m) ∣ m, from spec hpp hm,
+have hdivn : ↑(p ^ padic_val hpp n) ∣ n, from spec hpp hn,
+have hdiv : ↑(p ^ (padic_val hpp m + padic_val hpp n)) ∣ m*n, from
+  have hpoweq : (↑(p ^ (padic_val hpp m + padic_val hpp n)) : ℤ) = 
+                 (↑(p ^ padic_val hpp m * p ^ padic_val hpp n) : ℤ),
+    by simp [nat.pow_add],
+  begin
+    rw [hpoweq, int.coe_nat_mul],
+    apply mul_dvd_mul,
+    repeat {assumption}
+  end, 
+have hall : ∀ k : ℕ, k > padic_val hpp m + padic_val hpp n → ¬ ↑(p ^ k) ∣ m*n, from
+  assume (k : ℕ) (hkgt : k > padic_val hpp m + padic_val hpp n) (hdiv : ↑(p ^ k) ∣ m*n),
+  have hpsucc : ↑(p ^ (padic_val hpp m + padic_val hpp n + 1)) ∣ m*n, from
+    int.pow_div_of_le_of_pow_div_int hkgt hdiv,
+  let hsd := succ_dvd_or_succ_dvd_of_succ_sum_dvd_mul_int p_prime hdivm hdivn hpsucc in
+  or.elim hsd
+    (assume : ↑(p ^ (padic_val hpp m + 1)) ∣ m,
+      is_greatest hpp hm _ (lt_succ_self _) this)
+    (assume : ↑(p ^ (padic_val hpp n + 1)) ∣ n,
+      is_greatest hpp hn _ (lt_succ_self _) this), 
+have habs : m.nat_abs * n.nat_abs = (m*n).nat_abs, by simp [int.nat_abs_mul],
+begin 
+  simp only [habs] at *, 
+  apply unique, 
+  repeat {assumption}
+ end 
+
+end padic_val 
+
+section
+variables {p : ℕ} (hp : p > 1)
+
+lemma min_le_padic_val_add {m n : ℤ} (hmnz : m + n ≠ 0) : 
+      min (padic_val hp m) (padic_val hp n) ≤ padic_val hp (m + n) :=
+if hmz : m = 0 then by simp [hmz, nat.zero_le]
+else if hnz : n = 0 then by simp [hnz, nat.zero_le]
+else 
+  begin
+    wlog hle := le_total (padic_val hp m) (padic_val hp n) using [n m],
+    have hm : ∃ km, m = ↑(p ^ padic_val hp m) * km, from spec hp hmz,
+    have hn : ∃ kn, n = ↑(p ^ padic_val hp n) * kn, from spec hp hnz,
+    cases hm with km hkm,
+    cases hn with kn hkn,
+    have hmn : m + n = ↑(p ^ padic_val hp m) * km + ↑(p ^ padic_val hp n) * kn, by cc,
+    have hmn' : m + n = ↑(p ^ padic_val hp m) * (km + ↑(p ^ (padic_val hp n - padic_val hp m)) * kn), 
+      { rw [left_distrib, hmn, ←nat.pow_eq_mul_pow_sub _ hle], simp [mul_assoc] },
+    have hpp : ↑(p ^ padic_val hp m) ∣ (m + n),
+      { rw hmn', apply dvd_mul_of_dvd_left, apply dvd_refl },
+    have hpvle : padic_val hp m ≤ padic_val hp (m+n), from 
+      le_padic_val_of_pow_div _ hmnz hpp,
+    transitivity,
+      { apply min_le_left },
+      { apply hpvle }
+  end 
+
+end
+end padic_val 
+
+local infix `/.`:70 := rat.mk
+
+def padic_val_rat {p : ℕ} (hp : p > 1) (q : ℚ) : ℤ :=
+(padic_val hp q.num : ℤ) - (padic_val hp q.denom : ℤ)
+
+namespace padic_val_rat
+
+section padic_val_rat
+variables {p : ℕ} (hp : p > 1)
+
+@[simp] protected lemma neg (q : ℚ) : padic_val_rat hp (-q) = padic_val_rat hp q :=
+begin 
+  simp [padic_val_rat]
+end 
+
+@[simp] protected lemma one : padic_val_rat hp 1 = 0 :=
+have (1 : ℚ).num = 1, from rfl,
+have (1 : ℚ).denom = 1, from rfl,
+by simp [padic_val_rat, *]
+
+@[simp] lemma padic_val_rat_self : padic_val_rat hp p = 1 :=
+by simp [padic_val_rat]
+
+end padic_val_rat 
+
+section padic_val_rat
+open padic_val
+variables {p : ℕ} (p_prime : prime p)
+
+protected lemma defn {q : ℚ} {n d : ℤ} (hqz : q ≠ 0) (qdf : q = n /. d) : 
+      padic_val_rat (prime.gt_one p_prime) q = 
+        (padic_val (prime.gt_one p_prime) n : ℤ) - padic_val (prime.gt_one p_prime) d :=
+have hn : n ≠ 0, from rat.mk_num_ne_zero_of_ne_zero hqz qdf,
+have hd : d ≠ 0, from rat.mk_denom_ne_zero_of_ne_zero hqz qdf,
+have h : ∃ c : ℤ, n = c * q.num ∧ d = c * q.denom, from rat.num_denom_mk hn hd qdf,
+have hqn : q.num ≠ 0, from rat.num_ne_zero_of_ne_zero hqz,
+have hqd : (↑q.denom : ℤ) ≠ 0, by simp [rat.denom_ne_zero],
+begin 
+  rcases h with ⟨c, ⟨hc1, hc2⟩⟩,
+  have hcz : c ≠ 0,
+    { intro hc,
+      subst hc, 
+      apply hn, simpa using hc1 },
+  unfold padic_val_rat,
+  rw [hc1, hc2, ←padic_val.mul p_prime hcz hqn, ←padic_val.mul p_prime hcz hqd],
+  simp
+end
+
+protected lemma mul {q r : ℚ} (hq : q ≠ 0) (hr : r ≠ 0) : 
+        padic_val_rat (prime.gt_one p_prime) (q*r) = 
+          padic_val_rat (prime.gt_one p_prime) q + padic_val_rat (prime.gt_one p_prime) r :=
+have q*r = (q.num * r.num) /. (↑q.denom * ↑r.denom), by simp [rat.mul_num_denom],
+begin
+  rw padic_val_rat.defn p_prime (mul_ne_zero hq hr) this,
+  unfold padic_val_rat,
+  rw [←padic_val.mul p_prime, ←padic_val.mul p_prime],
+    {simp},
+    repeat {apply int.coe_nat_ne_zero.2, apply ne_of_gt, apply rat.pos},
+    repeat {apply rat.num_ne_zero_of_ne_zero, assumption}
+end  
+
+theorem min_le_padic_val_rat_add {q r : ℚ} (hq : q ≠ 0) (hr : r ≠ 0) (hqr : q + r ≠ 0) :
+        min (padic_val_rat (prime.gt_one p_prime) q) (padic_val_rat (prime.gt_one p_prime) r) ≤ 
+          padic_val_rat (prime.gt_one p_prime) (q + r) :=
+have hqn : q.num ≠ 0, from rat.num_ne_zero_of_ne_zero hq,
+have hqd : q.denom ≠ 0, from rat.denom_ne_zero _,
+have hrn : r.num ≠ 0, from rat.num_ne_zero_of_ne_zero hr,
+have hrd : r.denom ≠ 0, from rat.denom_ne_zero _,
+have hqdv : q.num /. q.denom ≠ 0, from rat.mk_ne_zero_of_ne_zero hqn (by simpa),
+have hrdv : r.num /. r.denom ≠ 0, from rat.mk_ne_zero_of_ne_zero hrn (by simpa),
+have hqreq : q + r = (((q.num * r.denom + q.denom * r.num : ℤ)) /. (↑q.denom * ↑r.denom : ℤ)),
+  from calc 
+  q + r = (q.num /. q.denom + r.num /. r.denom) : by rw [←rat.num_denom q, ←rat.num_denom r]
+    ... = (↑q.num : ℚ) / ↑q.denom + ((↑r.num : ℚ) / ↑r.denom) : by simp [rat.mk_eq_div]
+    ... = (q.num * r.denom + q.denom * r.num) / (↑q.denom * ↑r.denom) : 
+      by rw div_add_div _ _ (show (q.denom : ℚ) ≠ 0, by simpa) (show (r.denom : ℚ) ≠ 0, by simpa) 
+    ... = ((q.num * r.denom + q.denom * r.num : ℤ)) /. (↑q.denom * ↑r.denom : ℤ) : 
+      by simp [rat.mk_eq_div],
+have hsnz : q.num*r.denom + q.denom*r.num ≠ 0, from
+  assume heq,
+  have q + r = 0 /. (q.denom * r.denom), by rwa [heq] at hqreq,
+  hqr (by simpa),
+have hge  : (padic_val (prime.gt_one p_prime) (q.num * r.denom + q.denom * r.num) : ℤ) ≥ 
+       min ((padic_val (prime.gt_one p_prime) (q.num*r.denom)) : ℤ) 
+           (padic_val (prime.gt_one p_prime) (q.denom*r.num)),
+    from calc 
+    min ((padic_val (prime.gt_one p_prime) (q.num*r.denom)) : ℤ) 
+           (padic_val (prime.gt_one p_prime) (q.denom*r.num)) = 
+    (min (padic_val (prime.gt_one p_prime) (q.num*r.denom)) 
+           (padic_val (prime.gt_one p_prime) (q.denom*r.num)) : ℤ) :
+       by simp
+     ... ≤ (padic_val (prime.gt_one p_prime) (q.num * r.denom + q.denom * r.num) : ℤ) : 
+       begin 
+         apply min_le_iff.2, 
+         simp only [int.coe_nat_le], 
+         apply min_le_iff.1, 
+         apply min_le_padic_val_add, 
+         assumption 
+       end,  
+calc 
+  padic_val_rat (prime.gt_one p_prime) (q + r) 
+         = padic_val_rat (prime.gt_one p_prime) 
+                         (((q.num * r.denom + q.denom * r.num : ℤ)) /. (↑q.denom * ↑r.denom : ℤ)) :
+            by rw hqreq
+     ... = padic_val (prime.gt_one p_prime) 
+                     (q.num * r.denom + q.denom * r.num) - 
+            padic_val (prime.gt_one p_prime) (↑q.denom * ↑r.denom) :
+       begin apply padic_val_rat.defn, cc, reflexivity end 
+     ... ≥ min (padic_val (prime.gt_one p_prime) (q.num*r.denom)) 
+               (padic_val (prime.gt_one p_prime) (q.denom*r.num)) - 
+            padic_val (prime.gt_one p_prime) (↑q.denom * ↑r.denom) :
+       sub_le_sub hge (le_refl _)
+     ... = min (padic_val (prime.gt_one p_prime) q.num + 
+                 padic_val (prime.gt_one p_prime) r.denom) 
+               (padic_val (prime.gt_one p_prime) q.denom + 
+                 padic_val (prime.gt_one p_prime) r.num) - 
+            (padic_val (prime.gt_one p_prime) q.denom + 
+              padic_val (prime.gt_one p_prime) r.denom) :
+       begin rw [←padic_val.mul, ←padic_val.mul, ←padic_val.mul], reflexivity, repeat {simpa} end
+     ... = min (padic_val (prime.gt_one p_prime) q.num + 
+                 padic_val (prime.gt_one p_prime) r.denom - 
+                 (padic_val (prime.gt_one p_prime) q.denom + 
+                   padic_val (prime.gt_one p_prime) r.denom)) 
+               (padic_val (prime.gt_one p_prime) q.denom + 
+                 padic_val (prime.gt_one p_prime) r.num - 
+                 (padic_val (prime.gt_one p_prime) q.denom + 
+                   padic_val (prime.gt_one p_prime) r.denom)) :
+       by apply min_add_eq_min_add_min
+     ... = min (padic_val (prime.gt_one p_prime) q.num - 
+                 padic_val (prime.gt_one p_prime) q.denom) 
+               (padic_val (prime.gt_one p_prime) r.num - 
+                 padic_val (prime.gt_one p_prime) r.denom) :
+       by simp
+     ... = min (padic_val_rat (prime.gt_one p_prime) (q.num /. ↑q.denom)) 
+               (padic_val_rat (prime.gt_one p_prime) (r.num /. ↑r.denom)) : 
+       by rw [padic_val_rat.defn, padic_val_rat.defn]; simpa
+     ... = min (padic_val_rat (prime.gt_one p_prime) q) 
+               (padic_val_rat (prime.gt_one p_prime) r) : 
+       by rw [←rat.num_denom q, ←rat.num_denom r]
+end padic_val_rat 
+end padic_val_rat 
+
+def padic_norm {p : ℕ} (hp : prime p) (q : ℚ) : ℚ :=
+if q = 0 then 0 
+else fpow (↑p : ℚ) (-(padic_val_rat (prime.gt_one hp) q))
+
+namespace padic_norm
+
+section padic_norm
+open padic_val_rat
+variables {p : ℕ} (hp : prime p)
+
+@[simp] protected lemma zero : padic_norm hp 0 = 0 := by simp [padic_norm]
+
+@[simp] protected lemma nonzero {q : ℚ} (hq : q ≠ 0) : 
+        padic_norm hp q = fpow p (-(padic_val_rat (prime.gt_one hp) q)) :=
+by simp [hq, padic_norm]
+
+@[simp] protected lemma neg (q : ℚ) : padic_norm hp (-q) = padic_norm hp q :=
+if hq : q = 0 then by simp [hq] 
+else by simp [padic_norm, hq]
+
+lemma zero_of_padic_norm_eq_zero {q : ℚ} (h : padic_norm hp q = 0) : q = 0 :=
+by_contradiction $
+  assume hq : q ≠ 0,
+  have padic_norm hp q = fpow p (-(padic_val_rat (prime.gt_one hp) q)), by simp [hq],
+  fpow_ne_zero_of_ne_zero 
+    (show (↑p : ℚ) ≠ 0, by simp [prime.ne_zero hp]) 
+    (-(padic_val_rat (prime.gt_one hp) q)) (by rw [←this, h])
+
+protected lemma nonneg (q : ℚ) : padic_norm hp q ≥ 0 :=
+if hq : q = 0 then by simp [hq]
+else 
+  begin 
+    unfold padic_norm; split_ifs,
+    apply fpow_nonneg_of_nonneg,
+    apply nat.cast_nonneg 
+  end 
+
+protected theorem mul (q r : ℚ) : padic_norm hp (q*r) = padic_norm hp q * padic_norm hp r :=
+if hq : q = 0 then
+  by simp [hq]
+else if hr : r = 0 then
+  by simp [hr]
+else
+  have q*r ≠ 0, from mul_ne_zero hq hr,
+  have (↑p : ℚ) ≠ 0, by simpa [prime.ne_zero hp],
+  by simp [padic_norm, *, padic_val_rat.mul, fpow_add this]
+
+theorem triangle_ineq (q r : ℚ) : padic_norm hp (q + r) ≤ padic_norm hp q + padic_norm hp r :=
+if hq : q = 0 then 
+  by simp [hq]
+else if hr : r = 0 then
+  by simp [hr]
+else if hqr : q + r = 0 then
+  begin simp [hqr], apply add_nonneg; apply padic_norm.nonneg end 
+else 
+  have hminle : min (padic_val_rat (prime.gt_one hp) q) (padic_val_rat (prime.gt_one hp) r) ≤ 
+                 (padic_val_rat (prime.gt_one hp) (q + r)),
+    by apply min_le_padic_val_rat_add; assumption,
+  have hpge1 : (↑p : ℚ) ≥ ↑(1 : ℕ), from nat.cast_le.2 $ le_of_lt $ prime.gt_one hp,
+  calc 
+    padic_norm hp (q + r) = fpow p (-(padic_val_rat (prime.gt_one hp) (q + r))) : 
+                       by simp [padic_norm, *]
+                      ... ≤ max (fpow p (-(padic_val_rat (prime.gt_one hp) q))) 
+                                ((fpow p (-(padic_val_rat (prime.gt_one hp) r)))) : 
+                       pow_le_max_of_min_le hpge1 hminle
+                      ... = max (padic_norm hp q) (padic_norm hp r) : by simp [padic_norm, *] 
+                      ... ≤ padic_norm hp q + padic_norm hp r : 
+                       by apply max_le_add_of_nonneg; apply padic_norm.nonneg
+
+private lemma nonarchimedean_aux {q r : ℚ}
+        (h : padic_val_rat (prime.gt_one hp) q ≤ padic_val_rat (prime.gt_one hp) r) : 
+        padic_norm hp (q + r) ≤ max (padic_norm hp q) (padic_norm hp r) :=
+have hnqp : padic_norm hp q ≥ 0, from padic_norm.nonneg _ _,
+have hnrp : padic_norm hp r ≥ 0, from padic_norm.nonneg _ _,
+if hq : q = 0 then
+  by simp [hq, max_eq_right hnrp]
+else if hr : r = 0 then
+  by simp [hr, max_eq_left hnqp]
+else if hqr : q + r = 0 then
+  le_trans (by simpa [hqr] using padic_norm.nonneg hp) (le_max_left _ _)
+else
+  begin 
+    unfold padic_norm, split_ifs,
+    apply le_max_iff.2,
+    left,
+    have hpge1 : (↑p : ℚ) ≥ ↑(1 : ℕ), from (nat.cast_le.2 $ le_of_lt $ prime.gt_one hp),
+    apply fpow_le_of_le hpge1,
+    apply neg_le_neg,
+    have : padic_val_rat (prime.gt_one hp) q = 
+            min (padic_val_rat (prime.gt_one hp) q) (padic_val_rat (prime.gt_one hp) r),
+      from (min_eq_left h).symm,
+    rw this,
+    apply min_le_padic_val_rat_add; assumption
+  end 
+
+protected theorem nonarchimedean {q r : ℚ} : 
+        padic_norm hp (q + r) ≤ max (padic_norm hp q) (padic_norm hp r) :=
+if h : padic_val_rat (prime.gt_one hp) q ≤ padic_val_rat (prime.gt_one hp) r then
+  nonarchimedean_aux hp h
+else 
+  have h' : padic_val_rat (prime.gt_one hp) r ≤ padic_val_rat (prime.gt_one hp) q,
+    from le_of_lt $ lt_of_not_ge h,
+  let h'' := nonarchimedean_aux hp h' in
+  by rwa [add_comm, max_comm] at h''
+
+lemma add_eq_max_of_ne {q r : ℚ} (hne : padic_norm hp q ≠ padic_norm hp r) : 
+      padic_norm hp (q + r) = max (padic_norm hp q) (padic_norm hp r) :=
+begin
+  wlog hle := le_total (padic_norm hp r) (padic_norm hp q) using [q r],
+  have hlt : padic_norm hp r < padic_norm hp q, from lt_of_le_of_ne hle hne.symm,
+  have : padic_norm hp q ≤ max (padic_norm hp (q + r)) (padic_norm hp r), from calc
+   padic_norm hp q = padic_norm hp (q + r - r) : by congr; ring
+               ... ≤ max (padic_norm hp (q + r)) (padic_norm hp (-r)) : padic_norm.nonarchimedean hp
+               ... = max (padic_norm hp (q + r)) (padic_norm hp r) : by simpa,
+  have hnge : padic_norm hp r ≤ padic_norm hp (q + r), 
+    { apply le_of_not_gt,
+      intro hgt,
+      rw max_eq_right_of_lt hgt at this,
+      apply not_lt_of_ge this,
+      assumption },
+  have : padic_norm hp q ≤ padic_norm hp (q + r), by rwa [max_eq_left hnge] at this,
+  apply _root_.le_antisymm,
+    { apply padic_norm.nonarchimedean hp },
+    { rw max_eq_left_of_lt hlt,
+      assumption }
+end 
+
+protected theorem image {q : ℚ} (hq : q ≠ 0) : ∃ n : ℤ, padic_norm hp q = fpow p (-n) :=
+⟨ (padic_val_rat (prime.gt_one hp) q), by simp [padic_norm, hq] ⟩ 
+
+instance : is_absolute_value (padic_norm hp) :=
+{ abv_nonneg := padic_norm.nonneg hp,
+  abv_eq_zero := 
+    begin 
+      intros, 
+      constructor; intro, 
+        { apply zero_of_padic_norm_eq_zero hp, assumption }, 
+        { simp [*] } 
+    end,
+  abv_add := padic_norm.triangle_ineq hp,
+  abv_mul := padic_norm.mul hp }
+
+end padic_norm 
+end padic_norm

--- a/data/padics/padic_rationals.lean
+++ b/data/padics/padic_rationals.lean
@@ -47,7 +47,7 @@ let ⟨N2, hN2⟩ := this in
 def stationary_point {f : padic_seq hp} (hf : ¬ f ≈ 0) : ℕ :=
 classical.some $ stationary hf
 
-def stationary_point_spec {f : padic_seq hp} (hf : ¬ f ≈ 0) :
+lemma stationary_point_spec {f : padic_seq hp} (hf : ¬ f ≈ 0) :
       ∀ {m n}, m ≥ stationary_point hf → n ≥ stationary_point hf → 
                  padic_norm hp (f n) = padic_norm hp (f m) :=
 classical.some_spec $ stationary hf
@@ -159,7 +159,7 @@ by simpa [hk] using padic_norm.image hp hk'
 
 lemma norm_one : norm (1 : padic_seq hp) = 1 :=
 have h1 : ¬ (1 : padic_seq hp) ≈ 0, from one_not_equiv_zero _,
-by simp [h1, norm]
+by simp [h1, norm, hp.gt_one]
 
 private lemma norm_eq_of_equiv_aux {f g : padic_seq hp} (hf : ¬ f ≈ 0) (hg : ¬ g ≈ 0) (hfg : f ≈ g) 
         (h : padic_norm hp (f (stationary_point hf)) ≠ padic_norm hp (g (stationary_point hg))) 

--- a/data/padics/padic_rationals.lean
+++ b/data/padics/padic_rationals.lean
@@ -1,0 +1,568 @@
+/-
+Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Y. Lewis
+
+Define the p-adic numbers (rationals) ℚ_p as the completion of ℚ wrt the p-adic norm.
+Show that the p-adic norm extends to ℚ_p, that ℚ is embedded in ℚ_p, and that ℚ_p is complete
+-/
+
+import data.real.cau_seq_completion data.padics.padic_norm algebra.archimedean
+
+noncomputable theory 
+local attribute [instance] classical.prop_decidable
+
+open nat padic_val padic_norm cau_seq cau_seq.completion
+
+@[reducible] def padic_seq {p : ℕ} (hp : prime p) := cau_seq _ (padic_norm hp)
+
+namespace padic_seq
+
+section 
+variables {p : ℕ} {hp : prime p}
+
+lemma stationary {f : cau_seq ℚ (padic_norm hp)} (hf : ¬ f ≈ 0) : 
+      ∃ N, ∀ m n, m ≥ N → n ≥ N → padic_norm hp (f n) = padic_norm hp (f m) :=
+have ∃ ε > 0, ∃ N1, ∀ j ≥ N1, ε ≤ padic_norm hp (f j), 
+  from cau_seq.abv_pos_of_not_lim_zero $ not_lim_zero_of_not_congr_zero hf,
+let ⟨ε, hε, N1, hN1⟩ := this in 
+have ∃ N2, ∀ i j ≥ N2, padic_norm hp (f i - f j) < ε, from cau_seq.cauchy₂ f hε,
+let ⟨N2, hN2⟩ := this in
+⟨ max N1 N2,
+  λ n m hn hm, 
+  have padic_norm hp (f n - f m) < ε, from hN2 _ _ (max_le_iff.1 hn).2 (max_le_iff.1 hm).2,
+  have padic_norm hp (f n - f m) < padic_norm hp (f n), 
+    from lt_of_lt_of_le this $ hN1 _ (max_le_iff.1 hn).1,
+  have  padic_norm hp (f n - f m) < max (padic_norm hp (f n)) (padic_norm hp (f m)),
+    from lt_max_iff.2 (or.inl this),
+  begin 
+    by_contradiction hne,
+    rw ←padic_norm.neg hp (f m) at hne,
+    have hnam := add_eq_max_of_ne hp hne,
+    rw [padic_norm.neg, max_comm] at hnam,
+    rw ←hnam at this,
+    apply _root_.lt_irrefl _ (by simp at this; exact this)
+  end ⟩ 
+
+def stationary_point {f : padic_seq hp} (hf : ¬ f ≈ 0) : ℕ :=
+classical.some $ stationary hf
+
+def stationary_point_spec {f : padic_seq hp} (hf : ¬ f ≈ 0) :
+      ∀ {m n}, m ≥ stationary_point hf → n ≥ stationary_point hf → 
+                 padic_norm hp (f n) = padic_norm hp (f m) :=
+classical.some_spec $ stationary hf
+
+def norm (f : padic_seq hp) : ℚ :=
+if hf : f ≈ 0 then 0
+else padic_norm hp (f (stationary_point hf))
+
+lemma norm_zero_iff (f : padic_seq hp) : f.norm = 0 ↔ f ≈ 0 :=
+begin 
+  constructor,
+    { intro h,
+      by_contradiction hf,
+      unfold norm at h, split_ifs at h,
+      apply hf,
+      intros ε hε,
+      existsi stationary_point hf,
+      intros j hj,
+      have heq := stationary_point_spec hf (le_refl _) hj,
+      simpa [h, heq] },
+    { intro h,
+      simp [norm, h] }
+end 
+
+end 
+
+section embedding
+open cau_seq 
+variables {p : ℕ} {hp : prime p}
+
+lemma equiv_zero_of_val_eq_of_equiv_zero {f g : padic_seq hp}
+      (h : ∀ k, padic_norm hp (f k) = padic_norm hp (g k)) (hf : f ≈ 0) : g ≈ 0 :=
+λ ε hε, let ⟨i, hi⟩ := hf _ hε in
+⟨i, λ j hj, by simpa [h] using hi _ hj⟩
+
+lemma norm_nonzero_of_not_equiv_zero {f : padic_seq hp} (hf : ¬ f ≈ 0) : 
+      f.norm ≠ 0 :=
+hf ∘ f.norm_zero_iff.1
+
+lemma norm_eq_norm_app_of_nonzero {f : padic_seq hp} (hf : ¬ f ≈ 0) :
+      ∃ k, f.norm = padic_norm hp k ∧ k ≠ 0 :=
+have heq : f.norm = padic_norm hp (f $ stationary_point hf), by simp [norm, hf],
+⟨f $ stationary_point hf, heq,
+  λ h, norm_nonzero_of_not_equiv_zero hf (by simpa [h] using heq)⟩
+
+lemma not_lim_zero_const_of_nonzero {q : ℚ} (hq : q ≠ 0) : ¬ lim_zero (const (padic_norm hp) q) :=
+λ h', hq $ const_lim_zero.1 h' 
+
+lemma not_equiv_zero_const_of_nonzero {q : ℚ} (hq : q ≠ 0) : ¬ (const (padic_norm hp) q) ≈ 0 :=
+λ h : lim_zero (const (padic_norm hp) q - 0), not_lim_zero_const_of_nonzero hq $ by simpa using h
+
+lemma norm_nonneg (f : padic_seq hp) : f.norm ≥ 0 :=
+if hf : f ≈ 0 then by simp [hf, norm]
+else by simp [norm, hf, padic_norm.nonneg] 
+
+lemma norm_mul (f g : padic_seq hp) :
+      (f * g).norm = f.norm * g.norm :=
+if hf : f ≈ 0 then 
+  have hg : f * g ≈ 0, from mul_equiv_zero' _ hf,
+  by simp [hf, hg, norm]
+else if hg : g ≈ 0 then
+  have hf : f * g ≈ 0, from mul_equiv_zero _ hg,
+  by simp [hf, hg, norm]
+else 
+  have hfg : ¬ f * g ≈ 0, by apply mul_not_equiv_zero; assumption,
+  let i := max (stationary_point hfg) (max (stationary_point hf) (stationary_point hg)) in
+  have hpnfg : padic_norm hp ((f * g) (stationary_point hfg)) = padic_norm hp ((f * g) i),
+    { apply stationary_point_spec hfg,
+      apply le_max_left,
+      apply le_refl },
+  have hpnf : padic_norm hp (f (stationary_point hf)) = padic_norm hp (f i),
+    { apply stationary_point_spec hf,
+      apply ge_trans,
+      apply le_max_right,
+      apply le_max_left,
+      apply le_refl },
+  have hpng : padic_norm hp (g (stationary_point hg)) = padic_norm hp (g i),
+    { apply stationary_point_spec hg,
+      apply ge_trans,
+      apply le_max_right,
+      apply le_max_right,
+      apply le_refl },
+  begin 
+    unfold norm,
+    split_ifs,
+    rw [hpnfg, hpnf, hpng],
+    apply padic_norm.mul hp
+  end 
+
+lemma eq_zero_iff_equiv_zero (f : padic_seq hp) : mk f = 0 ↔ f ≈ 0 :=
+mk_eq
+
+lemma ne_zero_iff_nequiv_zero (f : padic_seq hp) : mk f ≠ 0 ↔ ¬ f ≈ 0 :=
+not_iff_not.2 (eq_zero_iff_equiv_zero _)
+
+lemma norm_const (q : ℚ) : norm (const (padic_norm hp) q) = padic_norm hp q :=
+if hq : q = 0 then 
+  have (const (padic_norm hp) q) ≈ 0, 
+    by simp [hq]; apply setoid.refl (const (padic_norm hp) 0),
+  by subst hq; simp [norm, this]
+else 
+  have ¬ (const (padic_norm hp) q) ≈ 0, from not_equiv_zero_const_of_nonzero hq,
+  by simp [norm, this] 
+
+lemma norm_image (a : padic_seq hp) (ha : ¬ a ≈ 0) :
+      (∃ (n : ℤ), a.norm = fpow ↑p (-n)) :=
+let ⟨k, hk, hk'⟩ := norm_eq_norm_app_of_nonzero ha in
+by simpa [hk] using padic_norm.image hp hk'
+
+lemma norm_one : norm (1 : padic_seq hp) = 1 :=
+have h1 : ¬ (1 : padic_seq hp) ≈ 0, from one_not_equiv_zero _,
+by simp [h1, norm]
+
+private lemma norm_eq_of_equiv_aux {f g : padic_seq hp} (hf : ¬ f ≈ 0) (hg : ¬ g ≈ 0) (hfg : f ≈ g) 
+        (h : padic_norm hp (f (stationary_point hf)) ≠ padic_norm hp (g (stationary_point hg))) 
+        (hgt : padic_norm hp (f (stationary_point hf)) > padic_norm hp (g (stationary_point hg))) :
+        false :=
+begin 
+  have hpn : padic_norm hp (f (stationary_point hf)) - padic_norm hp (g (stationary_point hg)) > 0,
+    from sub_pos_of_lt hgt,
+  cases hfg _ hpn with N hN,
+  let i := max N (max (stationary_point hf) (stationary_point hg)),
+  have hfi : padic_norm hp (f (stationary_point hf)) = padic_norm hp (f i), 
+    { apply stationary_point_spec hf,
+      { apply le_trans,
+        apply le_max_left,
+        tactic.rotate_left 1,
+        apply le_max_right },
+      { apply le_refl } },
+  have hgi : padic_norm hp (g (stationary_point hg)) = padic_norm hp (g i),
+    { apply stationary_point_spec hg,
+      { apply le_trans,
+        apply le_max_right,
+        tactic.rotate_left 1,
+        apply le_max_right },
+      { apply le_refl } },
+  have hi : i ≥ N, from le_max_left _ _,
+  have hN' := hN _ hi,
+  simp only [hfi, hgi] at hN',
+  have hpne : padic_norm hp (f i) ≠ padic_norm hp (-(g i)), 
+    by rwa [hfi, hgi, ←padic_norm.neg hp (g i)] at h,
+  let hpnem := add_eq_max_of_ne hp hpne,
+  have hpeq : padic_norm hp ((f - g) i) = max (padic_norm hp (f i)) (padic_norm hp (g i)), 
+    { rwa padic_norm.neg at hpnem },
+  have hfigi : padic_norm hp (g i) < padic_norm hp (f i),
+    { rwa [hfi, hgi] at hgt },
+  rw [hpeq, max_eq_left_of_lt hfigi] at hN',
+  have : padic_norm hp (f i) < padic_norm hp (f i),
+    { apply lt_of_lt_of_le hN', apply sub_le_self, apply padic_norm.nonneg },
+  exact lt_irrefl _ this
+end 
+
+private lemma norm_eq_of_equiv {f g : padic_seq hp} (hf : ¬ f ≈ 0) (hg : ¬ g ≈ 0) (hfg : f ≈ g) :
+      padic_norm hp (f (stationary_point hf)) = padic_norm hp (g (stationary_point hg)) :=
+begin 
+  by_contradiction h,
+  cases (decidable.em (padic_norm hp (f (stationary_point hf)) > 
+          padic_norm hp (g (stationary_point hg))))
+      with hgt hngt,
+    { exact norm_eq_of_equiv_aux hf hg hfg h hgt },
+    { apply norm_eq_of_equiv_aux hg hf (setoid.symm hfg) (ne.symm h),
+      apply lt_of_le_of_ne,
+      apply le_of_not_gt hngt,
+      apply h }
+end 
+
+theorem norm_equiv {f g : padic_seq hp} (hfg : f ≈ g) : 
+      f.norm = g.norm :=
+if hf : f ≈ 0 then 
+  have hg : g ≈ 0, from setoid.trans (setoid.symm hfg) hf,
+  by simp [norm, hf, hg]
+else have hg : ¬ g ≈ 0, from hf ∘ setoid.trans hfg,
+by unfold norm; split_ifs; exact norm_eq_of_equiv hf hg hfg
+
+private lemma norm_nonarchimedean_aux {f g : padic_seq hp} 
+        (hfg : ¬ f + g ≈ 0) (hf : ¬ f ≈ 0) (hg : ¬ g ≈ 0) :
+        (f + g).norm ≤ max (f.norm) (g.norm) :=
+let i := max (stationary_point hfg) (max (stationary_point hf) (stationary_point hg)) in
+have hpnfg : padic_norm hp ((f + g) (stationary_point hfg)) = padic_norm hp ((f + g) i),
+  { apply stationary_point_spec hfg,
+    apply le_max_left,
+    apply le_refl },
+have hpnf : padic_norm hp (f (stationary_point hf)) = padic_norm hp (f i),
+  { apply stationary_point_spec hf,
+    apply ge_trans,
+    apply le_max_right,
+    apply le_max_left,
+    apply le_refl },
+have hpng : padic_norm hp (g (stationary_point hg)) = padic_norm hp (g i),
+  { apply stationary_point_spec hg,
+    apply ge_trans,
+    apply le_max_right,
+    apply le_max_right,
+    apply le_refl },
+begin 
+  unfold norm, split_ifs,  
+  rw [hpnfg, hpnf, hpng],
+  apply padic_norm.nonarchimedean
+end 
+
+theorem norm_nonarchimedean (f g : padic_seq hp) :
+      (f + g).norm ≤ max (f.norm) (g.norm) :=
+if hfg : f + g ≈ 0 then 
+  have 0 ≤ max (f.norm) (g.norm), from le_max_left_of_le (norm_nonneg _),
+  by simpa [hfg, norm]
+else if hf : f ≈ 0 then 
+  have hfg' : f + g ≈ g,
+    { change lim_zero (f - 0) at hf,
+      show lim_zero (f + g - g), by simpa using hf },
+  have hcfg : (f + g).norm = g.norm, from norm_equiv hfg',
+  have hcl : f.norm = 0, from (norm_zero_iff f).2 hf,
+  have max (f.norm) (g.norm) = g.norm, 
+    by rw hcl; exact max_eq_right (norm_nonneg _),
+  by rw [this, hcfg]
+else if hg : g ≈ 0 then 
+  have hfg' : f + g ≈ f, 
+    { change lim_zero (g - 0) at hg,
+      show lim_zero (f + g - f), by  simpa [add_sub_cancel'] using hg },
+  have hcfg : (f + g).norm = f.norm, from norm_equiv hfg',
+  have hcl : g.norm = 0, from (norm_zero_iff g).2 hg,
+  have max (f.norm) (g.norm) = f.norm, 
+    by rw hcl; exact max_eq_left (norm_nonneg _),
+  by rw [this, hcfg]
+else norm_nonarchimedean_aux hfg hf hg
+
+lemma norm_eq {f g : padic_seq hp} (h : ∀ k, padic_norm hp (f k) = padic_norm hp (g k)) :
+      f.norm = g.norm :=
+if hf : f ≈ 0 then 
+  have hg : g ≈ 0, from equiv_zero_of_val_eq_of_equiv_zero h hf,
+  by simp [hf, hg, norm]
+else 
+  have hg : ¬ g ≈ 0, from λ hg, hf $ equiv_zero_of_val_eq_of_equiv_zero (by simp [h]) hg,
+  begin
+    simp [hg, hf, norm],
+    let i := max (stationary_point hf) (stationary_point hg),
+    have hpf : padic_norm hp (f (stationary_point hf)) = padic_norm hp (f i), 
+      { apply stationary_point_spec, apply le_max_left, apply le_refl },
+    have hpg : padic_norm hp (g (stationary_point hg)) = padic_norm hp (g i), 
+      { apply stationary_point_spec, apply le_max_right, apply le_refl },
+    rw [hpf, hpg, h]
+  end
+
+lemma norm_neg (a : padic_seq hp) : (-a).norm = a.norm :=
+norm_eq $ by simp
+
+end embedding
+end padic_seq
+
+def padic {p : ℕ} (hp : prime p) := @Cauchy _ _ _ _ (padic_norm hp) _
+notation `ℚ_[` hp `]` := padic hp
+
+namespace padic
+
+section completion
+variables {p : ℕ} {hp : prime p}
+
+instance discrete_field : discrete_field (padic hp) := 
+cau_seq.completion.discrete_field 
+
+def mk : padic_seq hp → ℚ_[hp] := quotient.mk 
+end completion
+
+section completion 
+variables {p : ℕ} (hp : prime p)
+
+lemma mk_eq {f g : padic_seq hp} : mk f = mk g ↔ f ≈ g := quotient.eq
+
+def of_rat : ℚ → ℚ_[hp] := cau_seq.completion.of_rat
+
+@[simp] lemma of_rat_add : ∀ (x y : ℚ), of_rat hp (x + y) = of_rat hp x + of_rat hp y :=
+cau_seq.completion.of_rat_add 
+
+@[simp] lemma of_rat_neg : ∀ (x : ℚ), of_rat hp (-x) = -of_rat hp x :=
+cau_seq.completion.of_rat_neg
+
+@[simp] lemma of_rat_mul : ∀ (x y : ℚ), of_rat hp (x * y) = of_rat hp x * of_rat hp y :=
+cau_seq.completion.of_rat_mul
+
+@[simp] lemma of_rat_sub : ∀ (x y : ℚ), of_rat hp (x - y) = of_rat hp x - of_rat hp y :=
+cau_seq.completion.of_rat_sub
+
+@[simp] lemma of_rat_div : ∀ (x y : ℚ), of_rat hp (x / y) = of_rat hp x / of_rat hp y :=
+cau_seq.completion.of_rat_div
+
+@[simp] lemma of_rat_one : of_rat hp 1 = 1 := rfl
+
+@[simp] lemma of_rat_zero : of_rat hp 0 = 0 := rfl
+
+@[simp] lemma cast_eq_of_rat_of_nat (n : ℕ) : (↑n : ℚ_[hp]) = of_rat hp n :=
+begin 
+  induction n with n ih,
+    { refl },
+    { simp, ring, congr, apply ih }
+end 
+
+@[simp] lemma cast_eq_of_rat_of_int (n : ℤ) : (↑n : ℚ_[hp]) = of_rat hp n :=
+by induction n; simp 
+
+lemma cast_eq_of_rat : ∀ (q : ℚ), (↑q : ℚ_[hp]) = of_rat hp q 
+| ⟨n, d, h1, h2⟩ := 
+  show ↑n / ↑d = _, from 
+    have (⟨n, d, h1, h2⟩ : ℚ) = rat.mk n d, from rat.num_denom _, 
+    by simp [this, rat.mk_eq_div, of_rat_div]
+
+lemma const_equiv {q r : ℚ} : const (padic_norm hp) q ≈ const (padic_norm hp) r ↔ q = r :=
+⟨ λ heq : lim_zero (const (padic_norm hp) (q - r)),
+    eq_of_sub_eq_zero $ const_lim_zero.1 heq,
+  λ heq, by rw heq; apply setoid.refl _ ⟩
+
+lemma of_rat_eq {q r : ℚ} : of_rat hp q = of_rat hp r ↔ q = r :=
+⟨(const_equiv hp).1 ∘ quotient.eq.1, λ h, by rw h⟩
+
+instance : char_zero ℚ_[hp] := 
+⟨ λ m n, suffices of_rat hp ↑m = of_rat hp ↑n ↔ m = n, by simpa,
+    by simp [of_rat_eq] ⟩
+
+end completion
+end padic 
+
+def padic_norm_e {p : ℕ} {hp : prime p} : ℚ_[hp] → ℚ := 
+quotient.lift padic_seq.norm $ @padic_seq.norm_equiv _ _ 
+
+namespace padic_norm_e 
+section embedding 
+open padic_seq
+variables {p : ℕ} {hp : prime p}
+
+lemma defn (f : padic_seq hp) {ε : ℚ} (hε : ε > 0) :
+      ∃ N, ∀ i ≥ N, padic_norm_e (⟦f⟧ - f i) < ε :=
+begin
+  simp only [padic.cast_eq_of_rat],
+  change ∃ N, ∀ i ≥ N, (f - const _ (f i)).norm < ε,
+  by_contradiction h,
+  cases cauchy₂ f hε with N hN,
+  have : ∀ N, ∃ i ≥ N, (f - const _ (f i)).norm ≥ ε, 
+    by simpa [not_forall] using h,
+  rcases this N with ⟨i, hi, hge⟩,
+  have hne : ¬ (f - const (padic_norm hp) (f i)) ≈ 0,
+    { intro h, unfold norm at hge; split_ifs at hge, exact not_lt_of_ge hge hε },
+  unfold norm at hge; split_ifs at hge,
+  apply not_le_of_gt _ hge,
+  cases decidable.em ((stationary_point hne) ≥ N) with hgen hngen,
+    { apply hN; assumption },
+    { have := stationary_point_spec hne (le_refl _) (le_of_not_le hngen),
+      rw ←this,
+      apply hN,
+      apply le_refl, assumption }
+end 
+
+protected lemma nonneg (q : ℚ_[hp]) : padic_norm_e q ≥ 0 :=
+quotient.induction_on q $ norm_nonneg
+
+lemma zero_def : (0 : ℚ_[hp]) = ⟦0⟧ := rfl 
+
+lemma zero_iff (q : ℚ_[hp]) : padic_norm_e q = 0 ↔ q = 0 :=
+quotient.induction_on q $ 
+  by simpa only [zero_def, quotient.eq] using norm_zero_iff
+
+@[simp] protected lemma zero : padic_norm_e (0 : ℚ_[hp]) = 0 :=
+(zero_iff _).2 rfl
+
+@[simp] protected lemma one : padic_norm_e (1 : ℚ_[hp]) = 1 :=
+norm_one 
+
+@[simp] protected lemma neg (q : ℚ_[hp]) : padic_norm_e (-q) = padic_norm_e q :=
+quotient.induction_on q $ norm_neg 
+
+theorem nonarchimedean (q r : ℚ_[hp]) : 
+      padic_norm_e (q + r) ≤ max (padic_norm_e q) (padic_norm_e r) :=
+quotient.induction_on₂ q r $ norm_nonarchimedean 
+
+protected lemma add (q r : ℚ_[hp]) : 
+      padic_norm_e (q + r) ≤ (padic_norm_e q) + (padic_norm_e r) :=
+calc 
+  padic_norm_e (q + r) ≤ max (padic_norm_e q) (padic_norm_e r) : nonarchimedean _ _ 
+                      ... ≤ (padic_norm_e q) + (padic_norm_e r) : 
+                              max_le_add_of_nonneg (padic_norm_e.nonneg _) (padic_norm_e.nonneg _)
+
+protected lemma mul (q r : ℚ_[hp]) : 
+      padic_norm_e (q * r) = (padic_norm_e q) * (padic_norm_e r) :=
+quotient.induction_on₂ q r $ norm_mul 
+
+instance : is_absolute_value (@padic_norm_e _ hp) :=
+{ abv_nonneg := padic_norm_e.nonneg,
+  abv_eq_zero := zero_iff,
+  abv_add := padic_norm_e.add,
+  abv_mul := padic_norm_e.mul }
+
+lemma eq_padic_norm (q : ℚ) : padic_norm_e (padic.of_rat hp q) = padic_norm hp q :=
+norm_const _
+
+protected theorem image {q : ℚ_[hp]} : q ≠ 0 → ∃ n : ℤ, padic_norm_e q = fpow p (-n) :=
+quotient.induction_on q $ λ f hf,
+  have ¬ f ≈ 0, from (ne_zero_iff_nequiv_zero f).1 hf,
+  norm_image f this
+
+lemma sub_rev (q r : ℚ_[hp]) : padic_norm_e (q - r) = padic_norm_e (r - q) := 
+by rw ←(padic_norm_e.neg); simp
+
+end embedding
+end padic_norm_e
+
+namespace padic
+
+section complete
+open padic_seq padic 
+
+theorem rat_dense {p : ℕ} {hp : prime p} (q : ℚ_[hp]) {ε : ℚ} (hε : ε > 0) : 
+        ∃ r : ℚ, padic_norm_e (q - r) < ε :=
+quotient.induction_on q $ λ q',
+  have ∃ N, ∀ m n ≥ N, padic_norm hp (q' m - q' n) < ε, from cauchy₂ _ hε,
+  let ⟨N, hN⟩ := this in 
+  ⟨q' N, 
+    begin
+      simp only [padic.cast_eq_of_rat],
+      change padic_seq.norm (q' - const _ (q' N)) < ε,
+      cases decidable.em ((q' - const (padic_norm hp) (q' N)) ≈ 0) with heq hne',
+        { simpa only [heq, norm, dif_pos] },
+        { simp only [norm, dif_neg hne'],
+          change padic_norm hp (q' _ - q' _) < ε,        
+          have := stationary_point_spec hne', 
+          cases decidable.em (N ≥ stationary_point hne') with hle hle,
+            { have := eq.symm (this (le_refl _) hle),
+              simp at this, simpa [this] },
+            { apply hN,
+              apply le_of_lt, apply lt_of_not_ge, apply hle, apply le_refl }}
+    end⟩
+
+variables {p : ℕ} {hp : prime p} (f : cau_seq _ (@padic_norm_e _ hp))
+open classical 
+
+private lemma cast_succ_nat_pos (n : ℕ) : (↑(n + 1) : ℚ) > 0 :=
+nat.cast_pos.2 $ succ_pos _
+
+private lemma div_nat_pos (n : ℕ) : (1 / ((n + 1): ℚ)) > 0 :=
+div_pos zero_lt_one (cast_succ_nat_pos _)
+
+def lim_seq : ℕ → ℚ := λ n, classical.some (rat_dense (f n) (div_nat_pos n))
+
+lemma exi_rat_seq_conv :
+      ∀ ε > 0, ∃ N, ∀ i ≥ N, padic_norm_e (f i - of_rat hp ((lim_seq f) i)) < ε :=
+begin 
+  intros ε hε,
+  existsi (ceil (1/ε)).nat_abs,
+  intros i hi,
+  let h := classical.some_spec (rat_dense (f i) (div_nat_pos i)),
+  rw ←cast_eq_of_rat,
+  apply lt_of_lt_of_le,
+  apply h,
+  apply div_le_of_le_mul,
+  apply cast_succ_nat_pos,
+  have hi' := int.of_nat_le_of_nat_of_le hi,
+  have : ceil (1/ε) ≥ 0, from ceil_nonneg (le_of_lt (one_div_pos_of_pos hε)),
+  rw int.of_nat_nat_abs_eq_of_nonneg (this) at hi',
+  have hi'' := le_mul_of_div_le hε (ceil_le.1 hi'),
+  rw right_distrib, 
+  apply le_add_of_le_of_nonneg,
+    { apply hi'' }, 
+    { apply le_of_lt, 
+      simpa }
+end  
+
+lemma exi_rat_seq_conv_cauchy : is_cau_seq (padic_norm hp) (lim_seq f) :=
+assume ε hε,
+have hε3 : ε / 3 > 0, from div_pos hε (by norm_num),
+let ⟨N, hN⟩ := exi_rat_seq_conv f _ hε3,
+    ⟨N2, hN2⟩ := f.cauchy₂ hε3 in 
+begin 
+  existsi max N N2,
+  intros j hj,
+  rw [←padic_norm_e.eq_padic_norm, padic.of_rat_sub],
+  suffices : padic_norm_e ((↑(lim_seq f j) - f (max N N2)) + (f (max N N2) - lim_seq f (max N N2))) < ε, 
+    { ring at this ⊢, simpa only [cast_eq_of_rat] },
+    { apply lt_of_le_of_lt,
+      { apply padic_norm_e.add },
+      { have : (3 : ℚ) ≠ 0, by norm_num,
+        have : ε = ε / 3 + ε / 3 + ε / 3,
+          { apply eq_of_mul_eq_mul_left this, simp [left_distrib, mul_div_cancel' _ this ], ring },
+        rw this,
+        apply add_lt_add, 
+          { suffices : padic_norm_e ((↑(lim_seq f j) - f j) + (f j - f (max N N2))) < ε / 3 + ε / 3,
+              by simpa,
+            apply lt_of_le_of_lt,
+              { apply padic_norm_e.add },
+              { apply add_lt_add,
+                { rw [padic_norm_e.sub_rev, cast_eq_of_rat], apply hN, apply le_of_max_le_left hj },
+                { apply hN2, apply le_of_max_le_right hj, apply le_max_right } } },
+          { rw cast_eq_of_rat, apply hN, apply le_max_left }} }
+end 
+
+private def lim' : padic_seq hp := ⟨_, exi_rat_seq_conv_cauchy f⟩
+
+private def lim : ℚ_[hp] := ⟦lim' f⟧
+
+theorem complete : 
+        ∃ q : ℚ_[hp], ∀ ε > 0, ∃ N, ∀ i ≥ N, padic_norm_e (q - f i) < ε :=
+⟨ lim f, 
+  λ ε hε,  
+  let ⟨N, hN⟩ := exi_rat_seq_conv f _ (show ε / 2 > 0, from div_pos hε (by norm_num)),
+      ⟨N2, hN2⟩ := padic_norm_e.defn (lim' f) (show ε / 2 > 0, from div_pos hε (by norm_num)) in 
+  begin
+    existsi max N N2,
+    intros i hi,
+    suffices : padic_norm_e ((lim f - lim' f i) + (lim' f i - f i)) < ε, 
+      { ring at this; exact this },
+      { apply lt_of_le_of_lt,
+        { apply padic_norm_e.add },
+        { have : (2 : ℚ) ≠ 0, by norm_num,
+          have : ε = ε / 2 + ε / 2, by rw ←(add_self_div_two ε); simp,
+          rw this,
+          apply add_lt_add,
+            { apply hN2, apply le_of_max_le_right hi },
+            { rw [padic_norm_e.sub_rev, cast_eq_of_rat], apply hN, apply le_of_max_le_left hi } } }
+  end ⟩
+
+end complete 
+
+end padic

--- a/data/padics/padic_rationals.lean
+++ b/data/padics/padic_rationals.lean
@@ -59,17 +59,17 @@ else padic_norm hp (f (stationary_point hf))
 lemma norm_zero_iff (f : padic_seq hp) : f.norm = 0 ↔ f ≈ 0 :=
 begin 
   constructor,
-    { intro h,
-      by_contradiction hf,
-      unfold norm at h, split_ifs at h,
-      apply hf,
-      intros ε hε,
-      existsi stationary_point hf,
-      intros j hj,
-      have heq := stationary_point_spec hf (le_refl _) hj,
-      simpa [h, heq] },
-    { intro h,
-      simp [norm, h] }
+  { intro h,
+    by_contradiction hf,
+    unfold norm at h, split_ifs at h,
+    apply hf,
+    intros ε hε,
+    existsi stationary_point hf,
+    intros j hj,
+    have heq := stationary_point_spec hf (le_refl _) hj,
+    simpa [h, heq] },
+  { intro h,
+    simp [norm, h] }
 end 
 
 end 
@@ -115,21 +115,21 @@ else
   have hfg : ¬ f * g ≈ 0, by apply mul_not_equiv_zero; assumption,
   let i := max (stationary_point hfg) (max (stationary_point hf) (stationary_point hg)) in
   have hpnfg : padic_norm hp ((f * g) (stationary_point hfg)) = padic_norm hp ((f * g) i),
-    { apply stationary_point_spec hfg,
-      apply le_max_left,
-      apply le_refl },
+  { apply stationary_point_spec hfg,
+    apply le_max_left,
+    apply le_refl },
   have hpnf : padic_norm hp (f (stationary_point hf)) = padic_norm hp (f i),
-    { apply stationary_point_spec hf,
-      apply ge_trans,
-      apply le_max_right,
-      apply le_max_left,
-      apply le_refl },
+  { apply stationary_point_spec hf,
+    apply ge_trans,
+    apply le_max_right,
+    apply le_max_left,
+    apply le_refl },
   have hpng : padic_norm hp (g (stationary_point hg)) = padic_norm hp (g i),
-    { apply stationary_point_spec hg,
-      apply ge_trans,
-      apply le_max_right,
-      apply le_max_right,
-      apply le_refl },
+  { apply stationary_point_spec hg,
+    apply ge_trans,
+    apply le_max_right,
+    apply le_max_right,
+    apply le_refl },
   begin 
     unfold norm,
     split_ifs,
@@ -171,19 +171,19 @@ begin
   cases hfg _ hpn with N hN,
   let i := max N (max (stationary_point hf) (stationary_point hg)),
   have hfi : padic_norm hp (f (stationary_point hf)) = padic_norm hp (f i), 
-    { apply stationary_point_spec hf,
-      { apply le_trans,
-        apply le_max_left,
-        tactic.rotate_left 1,
-        apply le_max_right },
-      { apply le_refl } },
+  { apply stationary_point_spec hf,
+    { apply le_trans,
+      apply le_max_left,
+      tactic.rotate_left 1,
+      apply le_max_right },
+    { apply le_refl } },
   have hgi : padic_norm hp (g (stationary_point hg)) = padic_norm hp (g i),
-    { apply stationary_point_spec hg,
-      { apply le_trans,
-        apply le_max_right,
-        tactic.rotate_left 1,
-        apply le_max_right },
-      { apply le_refl } },
+  { apply stationary_point_spec hg,
+    { apply le_trans,
+      apply le_max_right,
+      tactic.rotate_left 1,
+      apply le_max_right },
+    { apply le_refl } },
   have hi : i ≥ N, from le_max_left _ _,
   have hN' := hN _ hi,
   simp only [hfi, hgi] at hN',
@@ -191,12 +191,12 @@ begin
     by rwa [hfi, hgi, ←padic_norm.neg hp (g i)] at h,
   let hpnem := add_eq_max_of_ne hp hpne,
   have hpeq : padic_norm hp ((f - g) i) = max (padic_norm hp (f i)) (padic_norm hp (g i)), 
-    { rwa padic_norm.neg at hpnem },
+  { rwa padic_norm.neg at hpnem },
   have hfigi : padic_norm hp (g i) < padic_norm hp (f i),
-    { rwa [hfi, hgi] at hgt },
+  { rwa [hfi, hgi] at hgt },
   rw [hpeq, max_eq_left_of_lt hfigi] at hN',
   have : padic_norm hp (f i) < padic_norm hp (f i),
-    { apply lt_of_lt_of_le hN', apply sub_le_self, apply padic_norm.nonneg },
+  { apply lt_of_lt_of_le hN', apply sub_le_self, apply padic_norm.nonneg },
   exact lt_irrefl _ this
 end 
 
@@ -207,11 +207,11 @@ begin
   cases (decidable.em (padic_norm hp (f (stationary_point hf)) > 
           padic_norm hp (g (stationary_point hg))))
       with hgt hngt,
-    { exact norm_eq_of_equiv_aux hf hg hfg h hgt },
-    { apply norm_eq_of_equiv_aux hg hf (setoid.symm hfg) (ne.symm h),
-      apply lt_of_le_of_ne,
-      apply le_of_not_gt hngt,
-      apply h }
+  { exact norm_eq_of_equiv_aux hf hg hfg h hgt },
+  { apply norm_eq_of_equiv_aux hg hf (setoid.symm hfg) (ne.symm h),
+    apply lt_of_le_of_ne,
+    apply le_of_not_gt hngt,
+    apply h }
 end 
 
 theorem norm_equiv {f g : padic_seq hp} (hfg : f ≈ g) : 
@@ -227,21 +227,21 @@ private lemma norm_nonarchimedean_aux {f g : padic_seq hp}
         (f + g).norm ≤ max (f.norm) (g.norm) :=
 let i := max (stationary_point hfg) (max (stationary_point hf) (stationary_point hg)) in
 have hpnfg : padic_norm hp ((f + g) (stationary_point hfg)) = padic_norm hp ((f + g) i),
-  { apply stationary_point_spec hfg,
-    apply le_max_left,
-    apply le_refl },
+{ apply stationary_point_spec hfg,
+  apply le_max_left,
+  apply le_refl },
 have hpnf : padic_norm hp (f (stationary_point hf)) = padic_norm hp (f i),
-  { apply stationary_point_spec hf,
-    apply ge_trans,
-    apply le_max_right,
-    apply le_max_left,
-    apply le_refl },
+{ apply stationary_point_spec hf,
+  apply ge_trans,
+  apply le_max_right,
+  apply le_max_left,
+  apply le_refl },
 have hpng : padic_norm hp (g (stationary_point hg)) = padic_norm hp (g i),
-  { apply stationary_point_spec hg,
-    apply ge_trans,
-    apply le_max_right,
-    apply le_max_right,
-    apply le_refl },
+{ apply stationary_point_spec hg,
+  apply ge_trans,
+  apply le_max_right,
+  apply le_max_right,
+  apply le_refl },
 begin 
   unfold norm, split_ifs,  
   rw [hpnfg, hpnf, hpng],
@@ -255,8 +255,8 @@ if hfg : f + g ≈ 0 then
   by simpa [hfg, norm]
 else if hf : f ≈ 0 then 
   have hfg' : f + g ≈ g,
-    { change lim_zero (f - 0) at hf,
-      show lim_zero (f + g - g), by simpa using hf },
+  { change lim_zero (f - 0) at hf,
+    show lim_zero (f + g - g), by simpa using hf },
   have hcfg : (f + g).norm = g.norm, from norm_equiv hfg',
   have hcl : f.norm = 0, from (norm_zero_iff f).2 hf,
   have max (f.norm) (g.norm) = g.norm, 
@@ -264,8 +264,8 @@ else if hf : f ≈ 0 then
   by rw [this, hcfg]
 else if hg : g ≈ 0 then 
   have hfg' : f + g ≈ f, 
-    { change lim_zero (g - 0) at hg,
-      show lim_zero (f + g - f), by  simpa [add_sub_cancel'] using hg },
+  { change lim_zero (g - 0) at hg,
+    show lim_zero (f + g - f), by  simpa [add_sub_cancel'] using hg },
   have hcfg : (f + g).norm = f.norm, from norm_equiv hfg',
   have hcl : g.norm = 0, from (norm_zero_iff g).2 hg,
   have max (f.norm) (g.norm) = f.norm, 
@@ -284,9 +284,9 @@ else
     simp [hg, hf, norm],
     let i := max (stationary_point hf) (stationary_point hg),
     have hpf : padic_norm hp (f (stationary_point hf)) = padic_norm hp (f i), 
-      { apply stationary_point_spec, apply le_max_left, apply le_refl },
+    { apply stationary_point_spec, apply le_max_left, apply le_refl },
     have hpg : padic_norm hp (g (stationary_point hg)) = padic_norm hp (g i), 
-      { apply stationary_point_spec, apply le_max_right, apply le_refl },
+    { apply stationary_point_spec, apply le_max_right, apply le_refl },
     rw [hpf, hpg, h]
   end
 
@@ -339,8 +339,8 @@ cau_seq.completion.of_rat_div
 @[simp] lemma cast_eq_of_rat_of_nat (n : ℕ) : (↑n : ℚ_[hp]) = of_rat hp n :=
 begin 
   induction n with n ih,
-    { refl },
-    { simp, ring, congr, apply ih }
+  { refl },
+  { simp, ring, congr, apply ih }
 end 
 
 @[simp] lemma cast_eq_of_rat_of_int (n : ℤ) : (↑n : ℚ_[hp]) = of_rat hp n :=
@@ -386,15 +386,15 @@ begin
     by simpa [not_forall] using h,
   rcases this N with ⟨i, hi, hge⟩,
   have hne : ¬ (f - const (padic_norm hp) (f i)) ≈ 0,
-    { intro h, unfold norm at hge; split_ifs at hge, exact not_lt_of_ge hge hε },
+  { intro h, unfold norm at hge; split_ifs at hge, exact not_lt_of_ge hge hε },
   unfold norm at hge; split_ifs at hge,
   apply not_le_of_gt _ hge,
   cases decidable.em ((stationary_point hne) ≥ N) with hgen hngen,
-    { apply hN; assumption },
-    { have := stationary_point_spec hne (le_refl _) (le_of_not_le hngen),
-      rw ←this,
-      apply hN,
-      apply le_refl, assumption }
+  { apply hN; assumption },
+  { have := stationary_point_spec hne (le_refl _) (le_of_not_le hngen),
+    rw ←this,
+    apply hN,
+    apply le_refl, assumption }
 end 
 
 protected lemma nonneg (q : ℚ_[hp]) : padic_norm_e q ≥ 0 :=
@@ -465,15 +465,15 @@ quotient.induction_on q $ λ q',
       simp only [padic.cast_eq_of_rat],
       change padic_seq.norm (q' - const _ (q' N)) < ε,
       cases decidable.em ((q' - const (padic_norm hp) (q' N)) ≈ 0) with heq hne',
-        { simpa only [heq, norm, dif_pos] },
-        { simp only [norm, dif_neg hne'],
-          change padic_norm hp (q' _ - q' _) < ε,        
-          have := stationary_point_spec hne', 
-          cases decidable.em (N ≥ stationary_point hne') with hle hle,
-            { have := eq.symm (this (le_refl _) hle),
-              simp at this, simpa [this] },
-            { apply hN,
-              apply le_of_lt, apply lt_of_not_ge, apply hle, apply le_refl }}
+      { simpa only [heq, norm, dif_pos] },
+      { simp only [norm, dif_neg hne'],
+        change padic_norm hp (q' _ - q' _) < ε,        
+        have := stationary_point_spec hne', 
+        cases decidable.em (N ≥ stationary_point hne') with hle hle,
+        { have := eq.symm (this (le_refl _) hle),
+          simp at this, simpa [this] },
+        { apply hN,
+          apply le_of_lt, apply lt_of_not_ge, apply hle, apply le_refl }}
     end⟩
 
 variables {p : ℕ} {hp : prime p} (f : cau_seq _ (@padic_norm_e _ hp))
@@ -505,9 +505,9 @@ begin
   have hi'' := le_mul_of_div_le hε (ceil_le.1 hi'),
   rw right_distrib, 
   apply le_add_of_le_of_nonneg,
-    { apply hi'' }, 
-    { apply le_of_lt, 
-      simpa }
+  { apply hi'' }, 
+  { apply le_of_lt, 
+    simpa }
 end  
 
 lemma exi_rat_seq_conv_cauchy : is_cau_seq (padic_norm hp) (lim_seq f) :=
@@ -520,22 +520,22 @@ begin
   intros j hj,
   rw [←padic_norm_e.eq_padic_norm, padic.of_rat_sub],
   suffices : padic_norm_e ((↑(lim_seq f j) - f (max N N2)) + (f (max N N2) - lim_seq f (max N N2))) < ε, 
-    { ring at this ⊢, simpa only [cast_eq_of_rat] },
-    { apply lt_of_le_of_lt,
-      { apply padic_norm_e.add },
-      { have : (3 : ℚ) ≠ 0, by norm_num,
-        have : ε = ε / 3 + ε / 3 + ε / 3,
-          { apply eq_of_mul_eq_mul_left this, simp [left_distrib, mul_div_cancel' _ this ], ring },
-        rw this,
-        apply add_lt_add, 
-          { suffices : padic_norm_e ((↑(lim_seq f j) - f j) + (f j - f (max N N2))) < ε / 3 + ε / 3,
-              by simpa,
-            apply lt_of_le_of_lt,
-              { apply padic_norm_e.add },
-              { apply add_lt_add,
-                { rw [padic_norm_e.sub_rev, cast_eq_of_rat], apply hN, apply le_of_max_le_left hj },
-                { apply hN2, apply le_of_max_le_right hj, apply le_max_right } } },
-          { rw cast_eq_of_rat, apply hN, apply le_max_left }} }
+  { ring at this ⊢, simpa only [cast_eq_of_rat] },
+  { apply lt_of_le_of_lt,
+    { apply padic_norm_e.add },
+    { have : (3 : ℚ) ≠ 0, by norm_num,
+      have : ε = ε / 3 + ε / 3 + ε / 3,
+      { apply eq_of_mul_eq_mul_left this, simp [left_distrib, mul_div_cancel' _ this ], ring },
+      rw this,
+      apply add_lt_add, 
+      { suffices : padic_norm_e ((↑(lim_seq f j) - f j) + (f j - f (max N N2))) < ε / 3 + ε / 3,
+          by simpa,
+        apply lt_of_le_of_lt,
+        { apply padic_norm_e.add },
+        { apply add_lt_add,
+          { rw [padic_norm_e.sub_rev, cast_eq_of_rat], apply hN, apply le_of_max_le_left hj },
+          { apply hN2, apply le_of_max_le_right hj, apply le_max_right } } },
+      { rw cast_eq_of_rat, apply hN, apply le_max_left }}}
 end 
 
 private def lim' : padic_seq hp := ⟨_, exi_rat_seq_conv_cauchy f⟩
@@ -552,15 +552,15 @@ theorem complete :
     existsi max N N2,
     intros i hi,
     suffices : padic_norm_e ((lim f - lim' f i) + (lim' f i - f i)) < ε, 
-      { ring at this; exact this },
-      { apply lt_of_le_of_lt,
-        { apply padic_norm_e.add },
-        { have : (2 : ℚ) ≠ 0, by norm_num,
-          have : ε = ε / 2 + ε / 2, by rw ←(add_self_div_two ε); simp,
-          rw this,
-          apply add_lt_add,
-            { apply hN2, apply le_of_max_le_right hi },
-            { rw [padic_norm_e.sub_rev, cast_eq_of_rat], apply hN, apply le_of_max_le_left hi } } }
+    { ring at this; exact this },
+    { apply lt_of_le_of_lt,
+      { apply padic_norm_e.add },
+      { have : (2 : ℚ) ≠ 0, by norm_num,
+        have : ε = ε / 2 + ε / 2, by rw ←(add_self_div_two ε); simp,
+        rw this,
+        apply add_lt_add,
+        { apply hN2, apply le_of_max_le_right hi },
+        { rw [padic_norm_e.sub_rev, cast_eq_of_rat], apply hN, apply le_of_max_le_left hi } } }
   end ⟩
 
 end complete 

--- a/data/rat.lean
+++ b/data/rat.lean
@@ -202,10 +202,21 @@ theorem num_denom' (n d h c) : (⟨n, d, h, c⟩ : ℚ) = n /. d := num_denom _
 num_denom_cases_on a $ λ n d h c,
 H n d $ ne_of_gt h
 
-theorem num_dvd (a) {b} (b0 : b ≠ 0) : (a /. b).num ∣ a :=
+/-theorem num_dvd (a) {b} (b0 : b ≠ 0) : (a /. b).num ∣ a :=
 begin
   cases e : a /. b with n d h c,
   rw [num_denom', mk_eq (int.coe_nat_ne_zero.2 b0)
+    (ne_of_gt (int.coe_nat_pos.2 h))] at e,
+  refine (int.nat_abs_dvd.1 $ int.dvd_nat_abs.1 $ int.coe_nat_dvd.2 $
+    c.dvd_of_dvd_mul_right _),
+  have := congr_arg int.nat_abs e,
+  simp [int.nat_abs_mul, int.nat_abs_of_nat] at this, simp [this]
+end-/
+
+theorem rat.num_dvd (a) {b : ℤ} (b0 : b ≠ 0) : (a /. b).num ∣ a :=
+begin
+  cases e : a /. b with n d h c,
+  rw [rat.num_denom', rat.mk_eq b0
     (ne_of_gt (int.coe_nat_pos.2 h))] at e,
   refine (int.nat_abs_dvd.1 $ int.dvd_nat_abs.1 $ int.coe_nat_dvd.2 $
     c.dvd_of_dvd_mul_right _),
@@ -931,4 +942,59 @@ theorem nat_ceil_lt_add_one {q : ℚ} (hq : q ≥ 0) : ↑(nat_ceil q) < q + 1 :
 lt_nat_ceil.1 $ by rw [
   show nat_ceil (q+1) = nat_ceil q+1, from nat_ceil_add_nat hq 1]; apply nat.lt_succ_self
 
+@[simp] lemma denom_neg_eq_denom : ∀ q : ℚ, (-q).denom = q.denom 
+| ⟨_, d, _, _⟩ := rfl
+
+@[simp] lemma num_neg_eq_neg_num : ∀ q : ℚ, (-q).num = -(q.num)
+| ⟨n, _, _, _⟩ := rfl 
+
+@[simp] lemma num_zero : rat.num 0 = 0 := rfl 
+
+lemma zero_of_num_zero {q : ℚ} (hq : q.num = 0) : q = 0 :=
+have q = q.num /. q.denom, from num_denom _,
+by simpa [hq]
+
+lemma num_ne_zero_of_ne_zero {q : ℚ} (h : q ≠ 0) : q.num ≠ 0 :=
+assume : q.num = 0,
+h $ zero_of_num_zero this 
+
+lemma denom_ne_zero (q : ℚ) : q.denom ≠ 0 :=
+ne_of_gt q.pos
+
+lemma mk_num_ne_zero_of_ne_zero {q : ℚ} {n d : ℤ} (hq : q ≠ 0) (hqnd : q = n /. d) : n ≠ 0 :=
+assume : n = 0,
+hq $ by simpa [this] using hqnd 
+
+lemma mk_denom_ne_zero_of_ne_zero {q : ℚ} {n d : ℤ} (hq : q ≠ 0) (hqnd : q = n /. d) : d ≠ 0 :=
+assume : d = 0,
+hq $ by simpa [this] using hqnd 
+
+lemma mk_ne_zero_of_ne_zero {n d : ℤ} (h : n ≠ 0) (hd : d ≠ 0) : n /. d ≠ 0 :=
+assume : n /. d = 0,
+h $ (mk_eq_zero hd).1 this
+
+lemma mul_num_denom (q r : ℚ) : q * r = (q.num * r.num) /. ↑(q.denom * r.denom) :=
+have hq' : (↑q.denom : ℤ) ≠ 0, by have := denom_ne_zero q; simpa,
+have hr' : (↑r.denom : ℤ) ≠ 0, by have := denom_ne_zero r; simpa,
+suffices (q.num /. ↑q.denom) * (r.num /. ↑r.denom) = (q.num * r.num) /. ↑(q.denom * r.denom), 
+  by rwa [←num_denom q, ←num_denom r] at this,
+by simp [mul_def hq' hr'] 
+
+lemma rat.num_denom_mk {q : ℚ} {n d : ℤ} (hn : n ≠ 0) (hd : d ≠ 0) (qdf : q = n /. d) : 
+      ∃ c : ℤ, n = c * q.num ∧ d = c * q.denom :=
+have hq : q ≠ 0, from 
+  assume : q = 0,
+  hn $ (rat.mk_eq_zero hd).1 (by cc),
+have q.num /. q.denom = n /. d, by rwa [←rat.num_denom q],
+have q.num * d = n * ↑(q.denom), from (rat.mk_eq (by simpa [rat.denom_ne_zero]) hd).1 this,
+begin 
+  existsi n / q.num,
+  have hqdn : q.num ∣ n, begin rw qdf, apply rat.num_dvd, assumption end,
+  split,
+    { rw int.div_mul_cancel hqdn },
+    { apply int.eq_mul_div_of_mul_eq_mul_of_dvd_left,
+      {apply rat.num_ne_zero_of_ne_zero hq}, 
+      {simp [rat.denom_ne_zero]},
+      repeat {assumption} }
+end 
 end rat

--- a/data/rat.lean
+++ b/data/rat.lean
@@ -202,18 +202,7 @@ theorem num_denom' (n d h c) : (⟨n, d, h, c⟩ : ℚ) = n /. d := num_denom _
 num_denom_cases_on a $ λ n d h c,
 H n d $ ne_of_gt h
 
-/-theorem num_dvd (a) {b} (b0 : b ≠ 0) : (a /. b).num ∣ a :=
-begin
-  cases e : a /. b with n d h c,
-  rw [num_denom', mk_eq (int.coe_nat_ne_zero.2 b0)
-    (ne_of_gt (int.coe_nat_pos.2 h))] at e,
-  refine (int.nat_abs_dvd.1 $ int.dvd_nat_abs.1 $ int.coe_nat_dvd.2 $
-    c.dvd_of_dvd_mul_right _),
-  have := congr_arg int.nat_abs e,
-  simp [int.nat_abs_mul, int.nat_abs_of_nat] at this, simp [this]
-end-/
-
-theorem rat.num_dvd (a) {b : ℤ} (b0 : b ≠ 0) : (a /. b).num ∣ a :=
+theorem num_dvd (a) {b : ℤ} (b0 : b ≠ 0) : (a /. b).num ∣ a :=
 begin
   cases e : a /. b with n d h c,
   rw [rat.num_denom', rat.mk_eq b0

--- a/data/rat.lean
+++ b/data/rat.lean
@@ -980,7 +980,7 @@ suffices (q.num /. ↑q.denom) * (r.num /. ↑r.denom) = (q.num * r.num) /. ↑(
   by rwa [←num_denom q, ←num_denom r] at this,
 by simp [mul_def hq' hr'] 
 
-lemma rat.num_denom_mk {q : ℚ} {n d : ℤ} (hn : n ≠ 0) (hd : d ≠ 0) (qdf : q = n /. d) : 
+lemma num_denom_mk {q : ℚ} {n d : ℤ} (hn : n ≠ 0) (hd : d ≠ 0) (qdf : q = n /. d) : 
       ∃ c : ℤ, n = c * q.num ∧ d = c * q.denom :=
 have hq : q ≠ 0, from 
   assume : q = 0,

--- a/data/real/cau_seq.lean
+++ b/data/real/cau_seq.lean
@@ -379,7 +379,7 @@ end
 end ring
 
 section comm_ring 
-variables {β : Type*} [comm_ring β] (abv : β → α) [is_absolute_value abv]
+variables {β : Type*} [comm_ring β] {abv : β → α} [is_absolute_value abv]
 
 lemma mul_equiv_zero' (g : cau_seq _ abv) {f : cau_seq _ abv} (hf : f ≈ 0) : f * g ≈ 0 :=
 by rw mul_comm; apply mul_equiv_zero _ hf

--- a/data/real/cau_seq.lean
+++ b/data/real/cau_seq.lean
@@ -344,7 +344,64 @@ theorem of_near (f : ℕ → β) (g : cau_seq β abv)
          sub_add_sub_cancel, sub_add_sub_cancel] at this
   end⟩
 
+lemma not_lim_zero_of_not_congr_zero {f : cau_seq _ abv} (hf : ¬ f ≈ 0) : ¬ lim_zero f :=
+assume : lim_zero f,
+have lim_zero (f - 0), by simpa,
+hf this
+
+lemma mul_equiv_zero  (g : cau_seq _ abv) {f : cau_seq _ abv} (hf : f ≈ 0) : g * f ≈ 0 :=
+have lim_zero (f - 0), from hf,
+have lim_zero (g*f), from mul_lim_zero _ $ by simpa,
+show lim_zero (g*f - 0), by simpa
+
+lemma mul_not_equiv_zero {f g : cau_seq _ abv} (hf : ¬ f ≈ 0) (hg : ¬ g ≈ 0) : ¬ (f * g) ≈ 0 :=
+assume : lim_zero (f*g - 0),
+have hlz : lim_zero (f*g), by simpa,
+have hf' : ¬ lim_zero f, by simpa using (show ¬ lim_zero (f - 0), from hf),
+have hg' : ¬ lim_zero g, by simpa using (show ¬ lim_zero (g - 0), from hg),
+begin 
+  rcases abv_pos_of_not_lim_zero hf' with ⟨a1, ha1, N1, hN1⟩,
+  rcases abv_pos_of_not_lim_zero hg' with ⟨a2, ha2, N2, hN2⟩,
+  have : a1 * a2 > 0, from mul_pos ha1 ha2,
+  cases hlz _ this with N hN,
+  let i := max N (max N1 N2),
+  have hN' := hN i (le_max_left _ _),
+  have hN1' := hN1 i (le_trans (le_max_left _ _) (le_max_right _ _)),
+  have hN1' := hN2 i (le_trans (le_max_right _ _) (le_max_right _ _)),
+  apply not_le_of_lt hN',
+  change _ ≤ abv (_ * _),
+  rw is_absolute_value.abv_mul abv,
+  apply mul_le_mul; try { assumption },
+    { apply le_of_lt ha2 },
+    { apply is_absolute_value.abv_nonneg abv }
+end 
+
 end ring
+
+section comm_ring 
+variables {β : Type*} [comm_ring β] (abv : β → α) [is_absolute_value abv]
+
+lemma mul_equiv_zero' (g : cau_seq _ abv) {f : cau_seq _ abv} (hf : f ≈ 0) : f * g ≈ 0 :=
+by rw mul_comm; apply mul_equiv_zero _ hf
+
+end comm_ring 
+
+section integral_domain
+variables {β : Type*} [integral_domain β] (abv : β → α) [is_absolute_value abv]
+
+lemma one_not_equiv_zero : ¬ (const abv 1) ≈ (const abv 0) :=
+assume h,
+have ∀ ε > 0, ∃ i, ∀ k, k ≥ i → abv (1 - 0) < ε, from h,
+have h1 : abv 1 ≤ 0, from le_of_not_gt $
+  assume h2 : abv 1 > 0,
+  exists.elim (this _ h2) $ λ i hi,
+    lt_irrefl (abv 1) $ by simpa using hi _ (le_refl _),
+have h2 : abv 1 ≥ 0, from is_absolute_value.abv_nonneg _ _,
+have abv 1 = 0, from le_antisymm h1 h2,
+have (1 : β) = 0, from (is_absolute_value.abv_eq_zero abv).1 this,
+absurd this one_ne_zero
+
+end integral_domain
 
 section discrete_field
 variables {β : Type*} [discrete_field β] {abv : β → α} [is_absolute_value abv]

--- a/data/real/cau_seq_completion.lean
+++ b/data/real/cau_seq_completion.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Robert Y. Lewis
+
+Generalizes the Cauchy completion of (ℚ, abs) to the completion of a 
+commutative ring with absolute value. 
+-/
+
+import data.real.cau_seq
+
+namespace cau_seq.completion 
+open cau_seq
+
+section
+parameters {α : Type*} [discrete_linear_ordered_field α]
+parameters {β : Type*} [comm_ring β] {abv : β → α} [is_absolute_value abv]
+
+def Cauchy := @quotient (cau_seq _ abv) cau_seq.equiv 
+
+def mk : cau_seq _ abv → Cauchy := quotient.mk
+
+@[simp] theorem mk_eq_mk (f) : @eq Cauchy ⟦f⟧ (mk f) := rfl
+
+theorem mk_eq {f g} : mk f = mk g ↔ f ≈ g := quotient.eq
+
+def of_rat (x : β) : Cauchy := mk (const abv x)
+
+instance : has_zero Cauchy := ⟨of_rat 0⟩
+instance : has_one Cauchy := ⟨of_rat 1⟩
+instance : inhabited Cauchy := ⟨0⟩
+
+theorem of_rat_zero : of_rat 0 = 0 := rfl
+theorem of_rat_one : of_rat 1 = 1 := rfl
+
+@[simp] theorem mk_eq_zero {f} : mk f = 0 ↔ lim_zero f :=
+by have : mk f = 0 ↔ lim_zero (f - 0) := quotient.eq;
+   rwa sub_zero at this
+
+instance : has_add Cauchy :=
+⟨λ x y, quotient.lift_on₂ x y (λ f g, mk (f + g)) $
+  λ f₁ g₁ f₂ g₂ hf hg, quotient.sound $
+  by simpa [(≈), setoid.r] using add_lim_zero hf hg⟩
+
+@[simp] theorem mk_add (f g : cau_seq β abv) : mk f + mk g = mk (f + g) := rfl
+
+instance : has_neg Cauchy :=
+⟨λ x, quotient.lift_on x (λ f, mk (-f)) $
+  λ f₁ f₂ hf, quotient.sound $
+  by simpa [(≈), setoid.r] using neg_lim_zero hf⟩
+
+@[simp] theorem mk_neg (f : cau_seq β abv) : -mk f = mk (-f) := rfl
+
+instance : has_mul Cauchy :=
+⟨λ x y, quotient.lift_on₂ x y (λ f g, mk (f * g)) $
+  λ f₁ g₁ f₂ g₂ hf hg, quotient.sound $
+  by simpa [(≈), setoid.r, mul_add, mul_comm] using
+    add_lim_zero (mul_lim_zero g₁ hf) (mul_lim_zero f₂ hg)⟩
+
+@[simp] theorem mk_mul (f g : cau_seq β abv) : mk f * mk g = mk (f * g) := rfl
+
+theorem of_rat_add (x y : β) : of_rat (x + y) = of_rat x + of_rat y :=
+congr_arg mk (const_add _ _)
+
+theorem of_rat_neg (x : β) : of_rat (-x) = -of_rat x :=
+congr_arg mk (const_neg _)
+
+theorem of_rat_mul (x y : β) : of_rat (x * y) = of_rat x * of_rat y :=
+congr_arg mk (const_mul _ _)
+
+private lemma zero_def : 0 = mk 0 := rfl
+
+private lemma one_def : 1 = mk 1 := rfl
+
+instance : comm_ring Cauchy :=
+by refine { neg := has_neg.neg,
+    add := (+), zero := 0, mul := (*), one := 1, .. };
+  { repeat {refine λ a, quotient.induction_on a (λ _, _)},
+    simp [zero_def, one_def, mul_left_comm, mul_comm, mul_add] }
+
+theorem of_rat_sub (x y : β) : of_rat (x - y) = of_rat x - of_rat y :=
+congr_arg mk (const_sub _ _)
+
+end
+
+local attribute [instance] classical.prop_decidable
+section
+
+parameters {α : Type*} [discrete_linear_ordered_field α]
+parameters {β : Type*} [discrete_field β] {abv : β → α} [is_absolute_value abv]
+local notation `Cauchy` := @Cauchy _ _ _ _ abv _
+
+noncomputable instance : has_inv Cauchy :=
+⟨λ x, quotient.lift_on x
+  (λ f, mk $ if h : lim_zero f then 0 else inv f h) $
+λ f g fg, begin
+  have := lim_zero_congr fg,
+  by_cases hf : lim_zero f,
+  { simp [hf, this.1 hf, setoid.refl] },
+  { have hg := mt this.2 hf, simp [hf, hg],
+    have If : mk (inv f hf) * mk f = 1 := mk_eq.2 (inv_mul_cancel hf),
+    have Ig : mk (inv g hg) * mk g = 1 := mk_eq.2 (inv_mul_cancel hg),
+    rw [mk_eq.2 fg, ← Ig] at If,
+    rw mul_comm at Ig,
+    rw [← mul_one (mk (inv f hf)), ← Ig, ← mul_assoc, If,
+        mul_assoc, Ig, mul_one] }
+end⟩
+
+@[simp] theorem inv_zero : (0 : Cauchy)⁻¹ = 0 :=
+congr_arg mk $ by rw dif_pos; [refl, exact zero_lim_zero]
+
+@[simp] theorem inv_mk {f} (hf) : (@mk α _ β _ abv _ f)⁻¹ = mk (inv f hf) :=
+congr_arg mk $ by rw dif_neg
+
+lemma cau_seq_zero_ne_one : ¬ (0 : cau_seq _ abv) ≈ 1 := λ h, 
+have lim_zero (1 - 0), from setoid.symm h,
+have lim_zero 1, by simpa,
+one_ne_zero $ const_lim_zero.1 this 
+
+lemma zero_ne_one : (0 : Cauchy) ≠ 1 :=
+λ h, cau_seq_zero_ne_one $ mk_eq.1 h 
+
+
+protected theorem inv_mul_cancel {x : Cauchy} : x ≠ 0 → x⁻¹ * x = 1 :=
+quotient.induction_on x $ λ f hf, begin
+  simp at hf, simp [hf],
+  exact quotient.sound (cau_seq.inv_mul_cancel hf)
+end
+
+noncomputable def discrete_field : discrete_field Cauchy :=
+{ inv              := has_inv.inv,
+  inv_mul_cancel   := @cau_seq.completion.inv_mul_cancel,
+  mul_inv_cancel   := λ x x0, by rw [mul_comm, cau_seq.completion.inv_mul_cancel x0],
+  zero_ne_one      := zero_ne_one,
+  inv_zero         := inv_zero,
+  has_decidable_eq := by apply_instance,
+  ..cau_seq.completion.comm_ring }
+
+local attribute [instance] discrete_field
+
+theorem of_rat_inv (x : β) : of_rat (x⁻¹) = ((of_rat x)⁻¹ : Cauchy) :=
+congr_arg mk $ by split_ifs with h; try {simp [const_lim_zero.1 h]}; refl
+
+theorem of_rat_div (x y : β) : of_rat (x / y) = (of_rat x / of_rat y : Cauchy) :=
+by simp only [div_eq_inv_mul, of_rat_inv, of_rat_mul]
+
+end 
+end cau_seq.completion


### PR DESCRIPTION
This pull request defines the p-adic numbers as the Cauchy completion of `ℚ` with respect to the p-adic norm. As a side effect, I've generalized the construction of `ℝ`, since it shares some steps with this one. This isn't strictly necessary -- I can drop the third commit if you'd rather leave `real.lean` as it was. I've also added `field_power.lean`, since `gpow` doesn't extend to `ℚ`. There's more that could be filled out here, what I have is just sufficient for this project.

I've added various lemmas in various places along the way, in the first commit. I tried to find sensible names and places for most of them. Tell me if you think they should be moved, renamed, or just used locally.

Lifting the norm from `ℚ` to `ℚ_p` involves some explicit calculations with indices. @johoelzl suggested approaching this with the `at_top` filter. To be honest, I'm not immediately sure how that construction would go, and I'm a little skeptical that it would save much work in the end. (I suspect it might be prettier though!)

TO CONTRIBUTORS:

Make sure you have:

 * [ ] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
