### PR TITLE
feat(tactic/interactive): try reflexivity after substs

### DIFF
--- a/set_theory/ordinal_notation.lean
+++ b/set_theory/ordinal_notation.lean
@@ -537,7 +537,7 @@ instance : has_pow onote onote := ⟨power⟩
 theorem power_def (o₁ o₂ : onote) : o₁ ^ o₂ = power._match_1 o₂ (split o₁) := rfl
 
 theorem split_eq_scale_split' : ∀ {o o' m} [NF o], split' o = (o', m) → split o = (scale 1 o', m)
-| 0            o' m h p := by injection p; substs o' m
+| 0            o' m h p := by injection p; substs o' m; refl
 | (oadd e n a) o' m h p := begin
   by_cases e0 : e = 0; simp [e0, split, split'] at p ⊢,
   { rcases p with ⟨rfl, rfl⟩, exact ⟨rfl, rfl⟩ },

--- a/set_theory/ordinal_notation.lean
+++ b/set_theory/ordinal_notation.lean
@@ -537,7 +537,7 @@ instance : has_pow onote onote := ⟨power⟩
 theorem power_def (o₁ o₂ : onote) : o₁ ^ o₂ = power._match_1 o₂ (split o₁) := rfl
 
 theorem split_eq_scale_split' : ∀ {o o' m} [NF o], split' o = (o', m) → split o = (scale 1 o', m)
-| 0            o' m h p := by injection p; substs o' m; refl
+| 0            o' m h p := by injection p; substs o' m
 | (oadd e n a) o' m h p := begin
   by_cases e0 : e = 0; simp [e0, split, split'] at p ⊢,
   { rcases p with ⟨rfl, rfl⟩, exact ⟨rfl, rfl⟩ },

--- a/tactic/interactive.lean
+++ b/tactic/interactive.lean
@@ -150,7 +150,7 @@ do max ← i_to_expr_strict max >>= tactic.eval_expr nat,
 
 /-- Multiple subst. `substs x y z` is the same as `subst x, subst y, subst z`. -/
 meta def substs (l : parse ident*) : tactic unit :=
-l.mmap' (λ h, get_local h >>= tactic.subst)
+l.mmap' (λ h, get_local h >>= tactic.subst) >> try (tactic.reflexivity reducible)
 
 /-- Unfold coercion-related definitions -/
 meta def unfold_coes (loc : parse location) : tactic unit :=


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

* [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
* [ ] for tactics:
  * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
  * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
* [x] make sure definitions and lemmas are put in the right files
* [x] make sure definitions and lemmas are not redundant

This brings `substs` closer to being equivalent to a sequence of `subst`s.