### PR TITLE
fix(restate_axiom)

### DIFF
--- a/category_theory/category.lean
+++ b/category_theory/category.lean
@@ -35,23 +35,23 @@ The typeclass `category C` describes morphisms associated to objects of type `C`
 The universe levels of the objects and morphisms are unconstrained, and will often need to be specified explicitly, as `category.{u v} C`. (See also `large_category` and `small_category`.)
 -/
 class category (obj : Type u) : Type (max u (v+1)) :=
-(hom     : obj → obj → Type v)
-(id      : Π X : obj, hom X X)
-(comp    : Π {X Y Z : obj}, hom X Y → hom Y Z → hom X Z)
-(id_comp : ∀ {X Y : obj} (f : hom X Y), comp (id X) f = f . obviously)
-(comp_id : ∀ {X Y : obj} (f : hom X Y), comp f (id Y) = f . obviously)
-(assoc   : ∀ {W X Y Z : obj} (f : hom W X) (g : hom X Y) (h : hom Y Z), comp (comp f g) h = comp f (comp g h) . obviously)
+(hom      : obj → obj → Type v)
+(id       : Π X : obj, hom X X)
+(comp     : Π {X Y Z : obj}, hom X Y → hom Y Z → hom X Z)
+(id_comp' : ∀ {X Y : obj} (f : hom X Y), comp (id X) f = f . obviously)
+(comp_id' : ∀ {X Y : obj} (f : hom X Y), comp f (id Y) = f . obviously)
+(assoc'   : ∀ {W X Y Z : obj} (f : hom W X) (g : hom X Y) (h : hom Y Z), comp (comp f g) h = comp f (comp g h) . obviously)
 
 notation `𝟙` := category.id -- type as \b1
 infixr ` ≫ `:80 := category.comp -- type as \gg
 infixr ` ⟶ `:10 := category.hom -- type as \h
 
--- restate_axiom is a command that creates a lemma from a structure field, discarding any auto_param wrappers from the type.
-restate_axiom category.id_comp
-restate_axiom category.comp_id
-restate_axiom category.assoc
--- We tag some lemmas with the attribute `@[ematch]`, for later automation. (I'd be happy to change this to e.g. `@[search]`.)
-attribute [simp,ematch] category.id_comp_lemma category.comp_id_lemma category.assoc_lemma 
+-- `restate_axiom` is a command that creates a lemma from a structure field, discarding any auto_param wrappers from the type.
+-- (It removes a backtick from the name, if it finds one, and otherwise adds "_lemma".)
+restate_axiom category.id_comp'
+restate_axiom category.comp_id'
+restate_axiom category.assoc'
+attribute [simp] category.id_comp category.comp_id category.assoc
 
 /--
 A `large_category` has objects in one universe level higher than the universe level of the morphisms. 

--- a/category_theory/functor.lean
+++ b/category_theory/functor.lean
@@ -33,10 +33,10 @@ Implementation note: when constructing a `functor`, you need to define the
 When using a `functor`, use the `map` field (which makes use of the coercion).
 -/
 structure functor (C : Type u₁) [category.{u₁ v₁} C] (D : Type u₂) [category.{u₂ v₂} D] : Type (max u₁ v₁ u₂ v₂) :=
-(obj      : C → D)
-(map'     : Π {X Y : C}, (X ⟶ Y) → ((obj X) ⟶ (obj Y)))
-(map_id   : ∀ (X : C), map' (𝟙 X) = 𝟙 (obj X) . obviously)
-(map_comp : ∀ {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z), map' (f ≫ g) = (map' f) ≫ (map' g) . obviously)
+(obj       : C → D)
+(map'      : Π {X Y : C}, (X ⟶ Y) → ((obj X) ⟶ (obj Y)))
+(map_id'   : ∀ (X : C), map' (𝟙 X) = 𝟙 (obj X) . obviously)
+(map_comp' : ∀ {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z), map' (f ≫ g) = (map' f) ≫ (map' g) . obviously)
 
 infixr ` ↝ `:70 := functor       -- type as \lea --
 
@@ -52,18 +52,18 @@ instance : has_coe_to_fun (C ↝ D) :=
 
 def map (F : C ↝ D) {X Y : C} (f : X ⟶ Y) : (F X) ⟶ (F Y) := F.map' f
 
-@[simp,ematch] lemma map_id_lemma (F : C ↝ D) (X : C) : F.map (𝟙 X) = 𝟙 (F X) := 
-begin unfold functor.map, erw F.map_id, refl end
-@[simp,ematch] lemma map_comp_lemma (F : C ↝ D) {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) : 
+@[simp,ematch] lemma map_id (F : C ↝ D) (X : C) : F.map (𝟙 X) = 𝟙 (F X) := 
+begin unfold functor.map, erw F.map_id', refl end
+@[simp,ematch] lemma map_comp (F : C ↝ D) {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) : 
   F.map (f ≫ g) = F.map f ≫ F.map g := 
-begin unfold functor.map, erw F.map_comp end
+begin unfold functor.map, erw F.map_comp' end
 
 -- We do not define a refl lemma unfolding the coercion.
 -- However we do provide lemmas for the coercion applied to an explicit structure.
 @[simp] lemma mk_obj (o : C → D) (m mi mc) (X : C) : 
-  ({ functor . obj := o, map' := m, map_id := mi, map_comp := mc } : C ↝ D) X = o X := rfl
+  ({ functor . obj := o, map' := m, map_id' := mi, map_comp' := mc } : C ↝ D) X = o X := rfl
 @[simp] lemma mk_map (o : C → D) (m mi mc) {X Y : C} (f : X ⟶ Y) : 
-  functor.map { functor . obj := o, map' := m, map_id := mi, map_comp := mc } f = m f := rfl
+  functor.map { functor . obj := o, map' := m, map_id' := mi, map_comp' := mc } f = m f := rfl
 end
 
 section
@@ -72,10 +72,10 @@ include 𝒞
 
 /-- `functor.id C` is the identity functor on a category `C`. -/
 protected def id : C ↝ C :=
-{ obj      := λ X, X,
-  map'     := λ _ _ f, f,
-  map_id   := begin /- `obviously'` says: -/ intros, refl end,
-  map_comp := begin /- `obviously'` says: -/ intros, refl end }
+{ obj       := λ X, X,
+  map'      := λ _ _ f, f,
+  map_id'   := begin /- `obviously'` says: -/ intros, refl end,
+  map_comp' := begin /- `obviously'` says: -/ intros, refl end }
 
 variable {C}
 
@@ -93,10 +93,10 @@ include 𝒞 𝒟 ℰ
 `F ⋙ G` is the composition of a functor `F` and a functor `G` (`F` first, then `G`).
 -/
 def comp (F : C ↝ D) (G : D ↝ E) : C ↝ E :=
-{ obj      := λ X, G (F X),
+{ obj       := λ X, G (F X),
   map'      := λ _ _ f, G.map (F.map f),
-  map_id   := begin /- `obviously'` says: -/ intros, simp end,
-  map_comp := begin /- `obviously'` says: -/ intros, simp end }
+  map_id'   := begin /- `obviously'` says: -/ intros, simp end,
+  map_comp' := begin /- `obviously'` says: -/ intros, simp end }
 
 infixr ` ⋙ `:80 := comp
 

--- a/category_theory/functor.lean
+++ b/category_theory/functor.lean
@@ -52,9 +52,9 @@ instance : has_coe_to_fun (C ↝ D) :=
 
 def map (F : C ↝ D) {X Y : C} (f : X ⟶ Y) : (F X) ⟶ (F Y) := F.map' f
 
-@[simp,ematch] lemma map_id (F : C ↝ D) (X : C) : F.map (𝟙 X) = 𝟙 (F X) := 
+@[simp] lemma map_id (F : C ↝ D) (X : C) : F.map (𝟙 X) = 𝟙 (F X) := 
 begin unfold functor.map, erw F.map_id', refl end
-@[simp,ematch] lemma map_comp (F : C ↝ D) {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) : 
+@[simp] lemma map_comp (F : C ↝ D) {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) : 
   F.map (f ≫ g) = F.map f ≫ F.map g := 
 begin unfold functor.map, erw F.map_comp' end
 

--- a/category_theory/functor_category.lean
+++ b/category_theory/functor_category.lean
@@ -18,12 +18,12 @@ However if `C` and `D` are both large categories at the same universe level, thi
 -/
 instance functor.category (C : Type u₁) [category.{u₁ v₁} C] (D : Type u₂) [category.{u₂ v₂} D] : 
   category.{(max u₁ v₁ u₂ v₂) (max u₁ v₂)} (C ↝ D) :=
-{ hom     := λ F G, F ⟹ G,
-  id      := λ F, nat_trans.id F,
-  comp    := λ _ _ _ α β, α ⊟ β,
-  id_comp := begin /- `obviously'` says: -/ intros, ext, intros, dsimp, simp end,
-  comp_id := begin /- `obviously'` says: -/ intros, ext, intros, dsimp, simp end,
-  assoc   := begin /- `obviously'` says: -/ intros, ext, intros, simp end }
+{ hom      := λ F G, F ⟹ G,
+  id       := λ F, nat_trans.id F,
+  comp     := λ _ _ _ α β, α ⊟ β,
+  id_comp' := begin /- `obviously'` says: -/ intros, ext, intros, dsimp, simp end,
+  comp_id' := begin /- `obviously'` says: -/ intros, ext, intros, dsimp, simp end,
+  assoc'   := begin /- `obviously'` says: -/ intros, ext, intros, simp end }
 
 namespace functor.category
 

--- a/category_theory/functor_category.lean
+++ b/category_theory/functor_category.lean
@@ -31,8 +31,8 @@ section
 variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C] {D : Type u₂} [𝒟 : category.{u₂ v₂} D]
 include 𝒞 𝒟
 
-@[simp, ematch] lemma id_app (F : C ↝ D) (X : C) : (𝟙 F : F ⟹ F) X = 𝟙 (F X) := rfl
-@[simp, ematch] lemma comp_app {F G H : C ↝ D} (α : F ⟶ G) (β : G ⟶ H) (X : C) : 
+@[simp] lemma id_app (F : C ↝ D) (X : C) : (𝟙 F : F ⟹ F) X = 𝟙 (F X) := rfl
+@[simp] lemma comp_app {F G H : C ↝ D} (α : F ⟶ G) (β : G ⟶ H) (X : C) : 
   ((α ≫ β) : F ⟹ H) X = (α : F ⟹ G) X ≫ (β : G ⟹ H) X := rfl
 end
 
@@ -45,10 +45,10 @@ variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C]
           {E : Type u₃} [ℰ : category.{u₃ v₃} E]
 include 𝒞 𝒟 ℰ
 
-@[ematch] lemma app_naturality {F G : C ↝ (D ↝ E)} (T : F ⟹ G) (X : C) {Y Z : D} (f : Y ⟶ Z) : 
+lemma app_naturality {F G : C ↝ (D ↝ E)} (T : F ⟹ G) (X : C) {Y Z : D} (f : Y ⟶ Z) : 
   ((F X).map f) ≫ ((T X) Z) = ((T X) Y) ≫ ((G X).map f) := (T X).naturality f
 
-@[ematch] lemma naturality_app {F G : C ↝ (D ↝ E)} (T : F ⟹ G) (Z : D) {X Y : C} (f : X ⟶ Y) : 
+lemma naturality_app {F G : C ↝ (D ↝ E)} (T : F ⟹ G) (Z : D) {X Y : C} (f : X ⟶ Y) : 
   ((F.map f) Z) ≫ ((T Y) Z) = ((T X) Z) ≫ ((G.map f) Z) := congr_fun (congr_arg app (T.naturality f)) Z
 
 end nat_trans

--- a/category_theory/natural_transformation.lean
+++ b/category_theory/natural_transformation.lean
@@ -31,7 +31,7 @@ Naturality is expressed by `α.naturality_lemma`.
 -/
 structure nat_trans (F G : C ↝ D) : Type (max u₁ v₂) :=
 (app : Π X : C, (F X) ⟶ (G X))
-(naturality : ∀ {X Y : C} (f : X ⟶ Y), (F.map f) ≫ (app Y) = (app X) ≫ (G.map f) . obviously)
+(naturality' : ∀ {X Y : C} (f : X ⟶ Y), (F.map f) ≫ (app Y) = (app X) ≫ (G.map f) . obviously)
 
 infixr ` ⟹ `:50  := nat_trans             -- type as \==> or ⟹
 
@@ -42,19 +42,19 @@ instance {F G : C ↝ D} : has_coe_to_fun (F ⟹ G) :=
   coe := λ α, α.app }
 
 @[simp] lemma mk_app {F G : C ↝ D} (app : Π X : C, (F X) ⟶ (G X)) (naturality) (X : C) : 
-  { nat_trans . app := app, naturality := naturality } X = app X := rfl 
+  { nat_trans . app := app, naturality' := naturality } X = app X := rfl 
 
-@[ematch] lemma naturality_lemma {F G : C ↝ D} (α : F ⟹ G) {X Y : C} (f : X ⟶ Y) : 
+@[ematch] lemma naturality {F G : C ↝ D} (α : F ⟹ G) {X Y : C} (f : X ⟶ Y) : 
   (F.map f) ≫ (α Y) = (α X) ≫ (G.map f) := 
 begin 
   /- `obviously'` says: -/ 
-  erw nat_trans.naturality, refl
+  erw nat_trans.naturality', refl
 end
 
 /-- `nat_trans.id F` is the identity natural transformation on a functor `F`. -/
 protected def id (F : C ↝ D) : F ⟹ F :=
-{ app        := λ X, 𝟙 (F X),
-  naturality := begin /- `obviously'` says: -/ intros, simp end }
+{ app         := λ X, 𝟙 (F X),
+  naturality' := begin /- `obviously'` says: -/ intros, simp end }
 
 @[simp] lemma id_app (F : C ↝ D) (X : C) : (nat_trans.id F) X = 𝟙 (F X) := rfl
 
@@ -75,8 +75,8 @@ end
 
 /-- `vcomp α β` is the vertical compositions of natural transformations. -/
 def vcomp (α : F ⟹ G) (β : G ⟹ H) : F ⟹ H :=
-{ app        := λ X, (α X) ≫ (β X),
-  naturality := begin /- `obviously'` says: -/ intros, simp, rw [←assoc_lemma, naturality_lemma, assoc_lemma, ←naturality_lemma], end }
+{ app         := λ X, (α X) ≫ (β X),
+  naturality' := begin /- `obviously'` says: -/ intros, simp, rw [←assoc_lemma, naturality, assoc_lemma, ←naturality], end }
 
 notation α `⊟` β:80 := vcomp α β
 
@@ -90,16 +90,16 @@ include ℰ
 
 /-- `hcomp α β` is the horizontal composition of natural transformations. -/
 def hcomp {F G : C ↝ D} {H I : D ↝ E} (α : F ⟹ G) (β : H ⟹ I) : (F ⋙ H) ⟹ (G ⋙ I) :=
-{ app        := λ X : C, (β (F X)) ≫ (I.map (α X)),
-  naturality := begin
-                  /- `obviously'` says: -/
-                  intros,
-                  dsimp,
-                  simp,
-                  -- Actually, obviously doesn't use exactly this sequence of rewrites, but achieves the same result
-                  rw [← assoc_lemma, naturality_lemma, assoc_lemma],
-                  conv { to_rhs, rw [← map_comp_lemma, ← α.naturality_lemma, map_comp_lemma] }
-                end }
+{ app         := λ X : C, (β (F X)) ≫ (I.map (α X)),
+  naturality' := begin
+                   /- `obviously'` says: -/
+                   intros,
+                   dsimp,
+                   simp,
+                   -- Actually, obviously doesn't use exactly this sequence of rewrites, but achieves the same result
+                   rw [← assoc_lemma, naturality, assoc_lemma],
+                   conv { to_rhs, rw [← map_comp, ← α.naturality, map_comp] }
+                 end }
 
 notation α `◫` β:80 := hcomp α β
 
@@ -117,7 +117,7 @@ begin
   dsimp,
   simp,
   -- again, this isn't actually what obviously says, but it achieves the same effect.
-  conv { to_lhs, congr, skip, rw [←assoc_lemma, ←naturality_lemma, assoc_lemma] }
+  conv { to_lhs, congr, skip, rw [←assoc_lemma, ←naturality, assoc_lemma] }
 end
 
 end nat_trans

--- a/category_theory/natural_transformation.lean
+++ b/category_theory/natural_transformation.lean
@@ -44,7 +44,7 @@ instance {F G : C ↝ D} : has_coe_to_fun (F ⟹ G) :=
 @[simp] lemma mk_app {F G : C ↝ D} (app : Π X : C, (F X) ⟶ (G X)) (naturality) (X : C) : 
   { nat_trans . app := app, naturality' := naturality } X = app X := rfl 
 
-@[ematch] lemma naturality {F G : C ↝ D} (α : F ⟹ G) {X Y : C} (f : X ⟶ Y) : 
+lemma naturality {F G : C ↝ D} (α : F ⟹ G) {X Y : C} (f : X ⟶ Y) : 
   (F.map f) ≫ (α Y) = (α X) ≫ (G.map f) := 
 begin 
   /- `obviously'` says: -/ 
@@ -76,12 +76,12 @@ end
 /-- `vcomp α β` is the vertical compositions of natural transformations. -/
 def vcomp (α : F ⟹ G) (β : G ⟹ H) : F ⟹ H :=
 { app         := λ X, (α X) ≫ (β X),
-  naturality' := begin /- `obviously'` says: -/ intros, simp, rw [←assoc_lemma, naturality, assoc_lemma, ←naturality], end }
+  naturality' := begin /- `obviously'` says: -/ intros, simp, rw [←assoc, naturality, assoc, ←naturality], end }
 
 notation α `⊟` β:80 := vcomp α β
 
 @[simp] lemma vcomp_app (α : F ⟹ G) (β : G ⟹ H) (X : C) : (α ⊟ β) X = (α X) ≫ (β X) := rfl
-@[ematch] lemma vcomp_assoc (α : F ⟹ G) (β : G ⟹ H) (γ : H ⟹ I) : (α ⊟ β) ⊟ γ = (α ⊟ (β ⊟ γ)) := 
+lemma vcomp_assoc (α : F ⟹ G) (β : G ⟹ H) (γ : H ⟹ I) : (α ⊟ β) ⊟ γ = (α ⊟ (β ⊟ γ)) := 
 begin ext, intros, dsimp, rw [assoc] end
 end
 
@@ -97,7 +97,7 @@ def hcomp {F G : C ↝ D} {H I : D ↝ E} (α : F ⟹ G) (β : H ⟹ I) : (F ⋙
                    dsimp,
                    simp,
                    -- Actually, obviously doesn't use exactly this sequence of rewrites, but achieves the same result
-                   rw [← assoc_lemma, naturality, assoc_lemma],
+                   rw [← assoc, naturality, assoc],
                    conv { to_rhs, rw [← map_comp, ← α.naturality, map_comp] }
                  end }
 
@@ -108,7 +108,7 @@ notation α `◫` β:80 := hcomp α β
 
 -- Note that we don't yet prove a `hcomp_assoc` lemma here: even stating it is painful, because we need to use associativity of functor composition
 
-@[ematch] lemma exchange {F G H : C ↝ D} {I J K : D ↝ E} (α : F ⟹ G) (β : G ⟹ H) (γ : I ⟹ J) (δ : J ⟹ K) : 
+lemma exchange {F G H : C ↝ D} {I J K : D ↝ E} (α : F ⟹ G) (β : G ⟹ H) (γ : I ⟹ J) (δ : J ⟹ K) : 
   ((α ⊟ β) ◫ (γ ⊟ δ)) = ((α ◫ γ) ⊟ (β ◫ δ)) :=
 begin
   -- `obviously'` says:
@@ -117,7 +117,7 @@ begin
   dsimp,
   simp,
   -- again, this isn't actually what obviously says, but it achieves the same effect.
-  conv { to_lhs, congr, skip, rw [←assoc_lemma, ←naturality, assoc_lemma] }
+  conv { to_lhs, congr, skip, rw [←assoc, ←naturality, assoc] }
 end
 
 end nat_trans

--- a/category_theory/opposites.lean
+++ b/category_theory/opposites.lean
@@ -18,12 +18,12 @@ variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C]
 include 𝒞
 
 instance opposite : category.{u₁ v₁} (Cᵒᵖ) := 
-{ hom     := λ X Y : C, Y ⟶ X,
-  comp    := λ _ _ _ f g, g ≫ f,
-  id      := λ X, 𝟙 X,
-  id_comp := begin /- `obviously'` says: -/ intros, simp end,
-  comp_id := begin /- `obviously'` says: -/ intros, simp end,
-  assoc   := begin /- `obviously'` says: -/ intros, simp end }
+{ hom      := λ X Y : C, Y ⟶ X,
+  comp     := λ _ _ _ f g, g ≫ f,
+  id       := λ X, 𝟙 X,
+  id_comp' := begin /- `obviously'` says: -/ intros, simp end,
+  comp_id' := begin /- `obviously'` says: -/ intros, simp end,
+  assoc'   := begin /- `obviously'` says: -/ intros, simp end }
 
 namespace functor
 
@@ -47,7 +47,7 @@ variable (C)
 definition hom : (Cᵒᵖ × C) ↝ (Type v₁) := 
 { obj       := λ p, @category.hom C _ p.1 p.2,
   map'      := λ X Y f, λ h, f.1 ≫ h ≫ f.2,
-  map_id'   := begin /- `obviously'` says: -/ intros, ext, intros, cases X, dsimp at *, simp, erw [category.id_comp_lemma] end,
+  map_id'   := begin /- `obviously'` says: -/ intros, ext, intros, cases X, dsimp at *, simp, erw [category.id_comp] end,
   map_comp' := begin /- `obviously'` says: -/ intros, ext, intros, cases f, cases g, cases X, cases Y, cases Z, dsimp at *, simp, erw [category.assoc] end }
 
 @[simp] lemma hom_obj (X : Cᵒᵖ × C) : (functor.hom C) X = @category.hom C _ X.1 X.2 := rfl

--- a/category_theory/opposites.lean
+++ b/category_theory/opposites.lean
@@ -32,10 +32,10 @@ variables {D : Type u₂} [𝒟 : category.{u₂ v₂} D]
 include 𝒟
 
 protected definition op (F : C ↝ D) : (Cᵒᵖ) ↝ (Dᵒᵖ) := 
-{ obj      := λ X, F X,
-  map'     := λ X Y f, F.map f,
-  map_id   := begin /- `obviously'` says: -/ intros, erw [map_id_lemma], refl, end,
-  map_comp := begin /- `obviously'` says: -/ intros, erw [map_comp_lemma], refl end }
+{ obj       := λ X, F X,
+  map'      := λ X Y f, F.map f,
+  map_id'   := begin /- `obviously'` says: -/ intros, erw [map_id], refl, end,
+  map_comp' := begin /- `obviously'` says: -/ intros, erw [map_comp], refl end }
 
 @[simp] lemma opposite_obj (F : C ↝ D) (X : C) : (F.op) X = F X := rfl
 @[simp] lemma opposite_map (F : C ↝ D) {X Y : C} (f : X ⟶ Y) : (F.op).map f = F.map f := rfl
@@ -45,10 +45,10 @@ variable (C)
 
 /-- `functor.hom` is the hom-pairing, sending (X,Y) to X → Y, contravariant in X and covariant in Y. -/
 definition hom : (Cᵒᵖ × C) ↝ (Type v₁) := 
-{ obj      := λ p, @category.hom C _ p.1 p.2,
-  map'     := λ X Y f, λ h, f.1 ≫ h ≫ f.2,
-  map_id   := begin /- `obviously'` says: -/ intros, ext, intros, cases X, dsimp at *, simp, erw [category.id_comp_lemma] end,
-  map_comp := begin /- `obviously'` says: -/ intros, ext, intros, cases f, cases g, cases X, cases Y, cases Z, dsimp at *, simp, erw [category.assoc] end }
+{ obj       := λ p, @category.hom C _ p.1 p.2,
+  map'      := λ X Y f, λ h, f.1 ≫ h ≫ f.2,
+  map_id'   := begin /- `obviously'` says: -/ intros, ext, intros, cases X, dsimp at *, simp, erw [category.id_comp_lemma] end,
+  map_comp' := begin /- `obviously'` says: -/ intros, ext, intros, cases f, cases g, cases X, cases Y, cases Z, dsimp at *, simp, erw [category.assoc] end }
 
 @[simp] lemma hom_obj (X : Cᵒᵖ × C) : (functor.hom C) X = @category.hom C _ X.1 X.2 := rfl
 @[simp] lemma hom_pairing_map {X Y : Cᵒᵖ × C} (f : X ⟶ Y) : (functor.hom C).map f = λ h, f.1 ≫ h ≫ f.2 := rfl

--- a/category_theory/products.lean
+++ b/category_theory/products.lean
@@ -42,31 +42,31 @@ namespace prod
 
 /-- `inl C Z` is the functor `X ↦ (X, Z)`. -/
 def inl (C : Type u₁) [category.{u₁ v₁} C] {D : Type u₁} [category.{u₁ v₁} D] (Z : D) : C ↝ (C × D) :=
-{ obj      := λ X, (X, Z),
-  map'     := λ X Y f, (f, 𝟙 Z),
-  map_id   := begin /- `obviously'` says: -/ intros, refl end,
-  map_comp := begin /- `obviously'` says: -/ intros, dsimp, simp end }
+{ obj       := λ X, (X, Z),
+  map'      := λ X Y f, (f, 𝟙 Z),
+  map_id'   := begin /- `obviously'` says: -/ intros, refl end,
+  map_comp' := begin /- `obviously'` says: -/ intros, dsimp, simp end }
 
 /-- `inr D Z` is the functor `X ↦ (Z, X)`. -/
 def inr {C : Type u₁} [category.{u₁ v₁} C] (D : Type u₁) [category.{u₁ v₁} D] (Z : C) : D ↝ (C × D) :=
-{ obj      := λ X, (Z, X),
-  map'     := λ X Y f, (𝟙 Z, f),
-  map_id   := begin /- `obviously'` says: -/ intros, refl end,
-  map_comp := begin /- `obviously'` says: -/ intros, dsimp, simp end }
+{ obj       := λ X, (Z, X),
+  map'      := λ X Y f, (𝟙 Z, f),
+  map_id'   := begin /- `obviously'` says: -/ intros, refl end,
+  map_comp' := begin /- `obviously'` says: -/ intros, dsimp, simp end }
 
 /-- `fst` is the functor `(X, Y) ↦ X`. -/
 def fst (C : Type u₁) [category.{u₁ v₁} C] (Z : C) (D : Type u₁) [category.{u₁ v₁} D] : (C × D) ↝ C :=
-{ obj      := λ X, X.1,
-  map'     := λ X Y f, f.1,
-  map_id   := begin /- `obviously'` says: -/ intros, refl end,
-  map_comp := begin /- `obviously'` says: -/ intros, refl end }
+{ obj       := λ X, X.1,
+  map'      := λ X Y f, f.1,
+  map_id'   := begin /- `obviously'` says: -/ intros, refl end,
+  map_comp' := begin /- `obviously'` says: -/ intros, refl end }
 
 /-- `snd` is the functor `(X, Y) ↦ Y`. -/
 def snd (C : Type u₁) [category.{u₁ v₁} C] (Z : C) (D : Type u₁) [category.{u₁ v₁} D] : (C × D) ↝ D :=
-{ obj      := λ X, X.2,
-  map'     := λ X Y f, f.2,
-  map_id   := begin /- `obviously'` says: -/ intros, refl end,
-  map_comp := begin /- `obviously'` says: -/ intros, refl end }
+{ obj       := λ X, X.2,
+  map'      := λ X Y f, f.2,
+  map_id'   := begin /- `obviously'` says: -/ intros, refl end,
+  map_comp' := begin /- `obviously'` says: -/ intros, refl end }
 
 end prod
 
@@ -76,10 +76,10 @@ include 𝒜 ℬ 𝒞 𝒟
 namespace functor
 /-- The cartesian product of two functors. -/
 def prod (F : A ↝ B) (G : C ↝ D) : (A × C) ↝ (B × D) :=
-{ obj  := λ X, (F X.1, G X.2),
-  map' := λ _ _ f, (F.map f.1, G.map f.2),
-  map_id   := begin /- `obviously'` says: -/ intros, cases X, dsimp, rw map_id_lemma, rw map_id_lemma end,
-  map_comp := begin /- `obviously'` says: -/ intros, cases Z, cases Y, cases X, cases f, cases g, dsimp at *, rw map_comp_lemma, rw map_comp_lemma end }
+{ obj       := λ X, (F X.1, G X.2),
+  map'      := λ _ _ f, (F.map f.1, G.map f.2),
+  map_id'   := begin /- `obviously'` says: -/ intros, cases X, dsimp, rw map_id, rw map_id end,
+  map_comp' := begin /- `obviously'` says: -/ intros, cases Z, cases Y, cases X, cases f, cases g, dsimp at *, rw map_comp, rw map_comp end }
 
 /- Because of limitations in Lean 3's handling of notations, we do not setup a notation `F × G`. 
    You can use `F.prod G` as a "poor man's infix", or just write `functor.prod F G`. -/
@@ -92,12 +92,12 @@ namespace nat_trans
 
 /-- The cartesian product of two natural transformations. -/
 def prod {F G : A ↝ B} {H I : C ↝ D} (α : F ⟹ G) (β : H ⟹ I) : F.prod H ⟹ G.prod I :=
-{ app        := λ X, (α X.1, β X.2),
-  naturality := begin /- `obviously'` says: -/ intros, cases f, cases Y, cases X, dsimp at *, simp, split, rw naturality_lemma, rw naturality_lemma end }
+{ app         := λ X, (α X.1, β X.2),
+  naturality' := begin /- `obviously'` says: -/ intros, cases f, cases Y, cases X, dsimp at *, simp, split, rw naturality, rw naturality end }
 
 /- Again, it is inadvisable in Lean 3 to setup a notation `α × β`; use instead `α.prod β` or `nat_trans.prod α β`. -/
 
-@[simp, ematch] lemma prod_app  {F G : A ↝ B} {H I : C ↝ D} (α : F ⟹ G) (β : H ⟹ I) (a : A) (c : C) : (nat_trans.prod α β)     (a, c) = (α a, β c) := rfl
+@[simp, ematch] lemma prod_app  {F G : A ↝ B} {H I : C ↝ D} (α : F ⟹ G) (β : H ⟹ I) (a : A) (c : C) : (nat_trans.prod α β) (a, c) = (α a, β c) := rfl
 end nat_trans
 
 end category_theory

--- a/category_theory/products.lean
+++ b/category_theory/products.lean
@@ -16,16 +16,16 @@ include 𝒞 𝒟
 `prod.category C D` gives the cartesian product of two categories.
 -/
 instance prod : category.{(max u₁ u₂) (max v₁ v₂)} (C × D) :=
-{ hom     := λ X Y, ((X.1) ⟶ (Y.1)) × ((X.2) ⟶ (Y.2)),
-  id      := λ X, ⟨ 𝟙 (X.1), 𝟙 (X.2) ⟩,
-  comp    := λ _ _ _ f g, (f.1 ≫ g.1, f.2 ≫ g.2),
-  id_comp := begin /- `obviously'` says: -/ intros, cases X, cases Y, cases f, dsimp at *, simp end,
-  comp_id := begin /- `obviously'` says: -/ intros, cases X, cases Y, cases f, dsimp at *, simp end,
-  assoc   := begin /- `obviously'` says: -/ intros, cases W, cases X, cases Y, cases Z, cases f, cases g, cases h, dsimp at *, simp end }
+{ hom      := λ X Y, ((X.1) ⟶ (Y.1)) × ((X.2) ⟶ (Y.2)),
+  id       := λ X, ⟨ 𝟙 (X.1), 𝟙 (X.2) ⟩,
+  comp     := λ _ _ _ f g, (f.1 ≫ g.1, f.2 ≫ g.2),
+  id_comp' := begin /- `obviously'` says: -/ intros, cases X, cases Y, cases f, dsimp at *, simp end,
+  comp_id' := begin /- `obviously'` says: -/ intros, cases X, cases Y, cases f, dsimp at *, simp end,
+  assoc'   := begin /- `obviously'` says: -/ intros, cases W, cases X, cases Y, cases Z, cases f, cases g, cases h, dsimp at *, simp end }
 
 -- rfl lemmas for category.prod
-@[simp, ematch] lemma prod_id (X : C) (Y : D) : 𝟙 (X, Y) = (𝟙 X, 𝟙 Y) := rfl
-@[simp, ematch] lemma prod_comp {P Q R : C} {S T U : D} (f : (P, S) ⟶ (Q, T)) (g : (Q, T) ⟶ (R, U)) : f ≫ g = (f.1 ≫ g.1, f.2 ≫ g.2) := rfl
+@[simp] lemma prod_id (X : C) (Y : D) : 𝟙 (X, Y) = (𝟙 X, 𝟙 Y) := rfl
+@[simp] lemma prod_comp {P Q R : C} {S T U : D} (f : (P, S) ⟶ (Q, T)) (g : (Q, T) ⟶ (R, U)) : f ≫ g = (f.1 ≫ g.1, f.2 ≫ g.2) := rfl
 end
 
 section
@@ -84,8 +84,8 @@ def prod (F : A ↝ B) (G : C ↝ D) : (A × C) ↝ (B × D) :=
 /- Because of limitations in Lean 3's handling of notations, we do not setup a notation `F × G`. 
    You can use `F.prod G` as a "poor man's infix", or just write `functor.prod F G`. -/
 
-@[simp, ematch] lemma prod_obj  (F : A ↝ B) (G : C ↝ D) (a : A) (c : C) : (F.prod G) (a, c) = (F a, G c) := rfl
-@[simp, ematch] lemma prod_map  (F : A ↝ B) (G : C ↝ D) {a a' : A} {c c' : C} (f : (a, c) ⟶ (a', c')) : (F.prod G).map f = (F.map f.1, G.map f.2) := rfl
+@[simp] lemma prod_obj  (F : A ↝ B) (G : C ↝ D) (a : A) (c : C) : (F.prod G) (a, c) = (F a, G c) := rfl
+@[simp] lemma prod_map  (F : A ↝ B) (G : C ↝ D) {a a' : A} {c c' : C} (f : (a, c) ⟶ (a', c')) : (F.prod G).map f = (F.map f.1, G.map f.2) := rfl
 end functor
 
 namespace nat_trans
@@ -97,7 +97,7 @@ def prod {F G : A ↝ B} {H I : C ↝ D} (α : F ⟹ G) (β : H ⟹ I) : F.prod 
 
 /- Again, it is inadvisable in Lean 3 to setup a notation `α × β`; use instead `α.prod β` or `nat_trans.prod α β`. -/
 
-@[simp, ematch] lemma prod_app  {F G : A ↝ B} {H I : C ↝ D} (α : F ⟹ G) (β : H ⟹ I) (a : A) (c : C) : (nat_trans.prod α β) (a, c) = (α a, β c) := rfl
+@[simp] lemma prod_app  {F G : A ↝ B} {H I : C ↝ D} (α : F ⟹ G) (β : H ⟹ I) (a : A) (c : C) : (nat_trans.prod α β) (a, c) = (α a, β c) := rfl
 end nat_trans
 
 end category_theory

--- a/category_theory/types.lean
+++ b/category_theory/types.lean
@@ -9,12 +9,12 @@ namespace category_theory
 universes u v u' v' w
 
 instance types : large_category (Type u) :=
-{ hom     := λ a b, (a → b),
-  id      := λ a, id,
-  comp    := λ _ _ _ f g, g ∘ f,
-  id_comp := begin /- `obviously'` says: -/ intros, refl  end,
-  comp_id := begin /- `obviously'` says: -/ intros, refl end,
-  assoc   := begin /- `obviously'` says: -/ intros, refl end }
+{ hom      := λ a b, (a → b),
+  id       := λ a, id,
+  comp     := λ _ _ _ f g, g ∘ f,
+  id_comp' := begin /- `obviously'` says: -/ intros, refl  end,
+  comp_id' := begin /- `obviously'` says: -/ intros, refl end,
+  assoc'   := begin /- `obviously'` says: -/ intros, refl end }
 
 @[simp] lemma types_hom {α β : Type u} : (α ⟶ β) = (α → β) := rfl  
 @[simp] lemma types_id {α : Type u} (a : α) : (𝟙 α : α → α) a = a := rfl

--- a/category_theory/types.lean
+++ b/category_theory/types.lean
@@ -32,7 +32,7 @@ begin /- `obviously'` says: -/ simp end
 begin /- `obviously'` says: -/ simp end
 
 @[ematch] lemma naturality (f : X ⟶ Y) (x : F X) : σ Y ((F.map f) x) = (G.map f) (σ X x) := 
-congr_fun (σ.naturality_lemma f) x
+congr_fun (σ.naturality f) x
 
 @[simp] lemma vcomp (x : F X) : (σ ⊟ τ) X x = τ X (σ X x) := rfl
 
@@ -43,9 +43,9 @@ variables {D : Type u'} [𝒟 : category.{u' v'} D] (I J : D ↝ C) (ρ : I ⟹ 
 end functor_to_types
 
 definition ulift : (Type u) ↝ (Type (max u v)) := 
-{ obj      := λ X, ulift.{v} X,
-  map'     := λ X Y f, λ x : ulift.{v} X, ulift.up (f x.down),
-  map_id   := begin /- `obviously'` says: -/ intros, ext, refl end,
-  map_comp := begin /- `obviously'` says: -/ intros, refl end }
+{ obj       := λ X, ulift.{v} X,
+  map'      := λ X Y f, λ x : ulift.{v} X, ulift.up (f x.down),
+  map_id'   := begin /- `obviously'` says: -/ intros, ext, refl end,
+  map_comp' := begin /- `obviously'` says: -/ intros, refl end }
 
 end category_theory

--- a/category_theory/types.lean
+++ b/category_theory/types.lean
@@ -25,13 +25,13 @@ variables {C : Type u} [𝒞 : category.{u v} C] (F G H : C ↝ (Type w)) {X Y Z
 include 𝒞
 variables (σ : F ⟹ G) (τ : G ⟹ H) 
 
-@[simp,ematch] lemma map_comp (f : X ⟶ Y) (g : Y ⟶ Z) (a : F X) : (F.map (f ≫ g)) a = (F.map g) ((F.map f) a) :=
+@[simp] lemma map_comp (f : X ⟶ Y) (g : Y ⟶ Z) (a : F X) : (F.map (f ≫ g)) a = (F.map g) ((F.map f) a) :=
 begin /- `obviously'` says: -/ simp end
 
-@[simp,ematch] lemma map_id (a : F X) : (F.map (𝟙 X)) a = a := 
+@[simp] lemma map_id (a : F X) : (F.map (𝟙 X)) a = a := 
 begin /- `obviously'` says: -/ simp end
 
-@[ematch] lemma naturality (f : X ⟶ Y) (x : F X) : σ Y ((F.map f) x) = (G.map f) (σ X x) := 
+lemma naturality (f : X ⟶ Y) (x : F X) : σ Y ((F.map f) x) = (G.map f) (σ X x) := 
 congr_fun (σ.naturality f) x
 
 @[simp] lemma vcomp (x : F X) : (σ ⊟ τ) X x = τ X (σ X x) := rfl

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -259,6 +259,31 @@ new goal.
 `rewrite [h₀, ← h₁] at ⊢ h₂` with the exception that associativity is
 used implicitly to make rewriting possible.
 
+## restate_axiom
+
+`restate_axiom` makes a new copy of a structure field, first definitionally simplifying the type.
+This is useful to remove `auto_param` or `opt_param` from the statement.
+
+As an example, we have:
+```
+structure A :=
+(x : ℕ)
+(a' : x = 1 . skip)
+
+example (z : A) : z.x = 1 := by rw A.a' -- rewrite tactic failed, lemma is not an equality nor a iff
+
+restate_axiom A.a'
+example (z : A) : z.x = 1 := by rw A.a 
+```
+
+By default, `restate_axiom` names the new lemma by removing a trailing `'`, or otherwise appending
+`_lemma` if there is no trailing `'`. You can also give `restate_axiom` a second argument to
+specify the new name, as in
+```
+restate_axiom A.a f
+example (z : A) : z.x = 1 := by rw A.f
+```
+
 ## def_replacer
 
 `def_replacer foo` sets up a stub definition `foo : tactic unit`, which can

--- a/tactic/restate_axiom.lean
+++ b/tactic/restate_axiom.lean
@@ -24,7 +24,11 @@ do (levels, type, value, reducibility, trusted) ← pure (match d.to_definition 
 
 private meta def name_lemma (n : name) :=
 match n.components.reverse with
-| last :: most := mk_str_name n.get_prefix (last.to_string ++ "_lemma")
+| last :: most := let last := last.to_string in
+                  let last := if last.to_list.ilast = ''' then 
+                                 (last.to_list.reverse.drop 1).reverse.as_string
+                              else last ++ "_lemma" in
+                  mk_str_name n.get_prefix last
 | nil          := undefined
 end
 

--- a/tactic/restate_axiom.lean
+++ b/tactic/restate_axiom.lean
@@ -22,23 +22,29 @@ do (levels, type, value, reducibility, trusted) ← pure (match d.to_definition 
   new_type ← (s.dsimplify [] type) <|> pure (type),
   updateex_env $ λ env, env.add (declaration.defn new_name levels new_type value reducibility trusted)
 
-private meta def name_lemma (n : name) :=
-match n.components.reverse with
-| last :: most := let last := last.to_string in
-                  let last := if last.to_list.ilast = ''' then 
-                                 (last.to_list.reverse.drop 1).reverse.as_string
-                              else last ++ "_lemma" in
-                  mk_str_name n.get_prefix last
-| nil          := undefined
+private meta def name_lemma (old : name) (new : option name := none) : tactic name :=
+match new with
+| none :=
+  match old.components.reverse with
+  | last :: most := (do let last := last.to_string,
+                       let last := if last.to_list.ilast = ''' then
+                                     (last.to_list.reverse.drop 1).reverse.as_string
+                                   else last ++ "_lemma",
+                       return (mk_str_name old.get_prefix last)) <|> failed
+  | nil          := undefined
+  end
+| (some new) := return (mk_str_name old.get_prefix new.to_string)
 end
 
 @[user_command] meta def restate_axiom_cmd (meta_info : decl_meta_info)
   (_ : parse $ tk "restate_axiom") : lean.parser unit :=
 do from_lemma ← ident,
+   new_name ← optional ident,
    from_lemma_fully_qualified ← resolve_constant from_lemma,
   d ← get_decl from_lemma_fully_qualified <|>
     fail ("declaration " ++ to_string from_lemma ++ " not found"),
   do {
-    restate_axiom d (name_lemma from_lemma_fully_qualified)
-  }.
+    new_name ← name_lemma from_lemma_fully_qualified new_name,
+    restate_axiom d new_name
+  }
 

--- a/tests/restate_axiom.lean
+++ b/tests/restate_axiom.lean
@@ -1,0 +1,17 @@
+import tactic.restate_axiom
+
+open tactic
+
+structure A :=
+(x : ℕ)
+(a' : x = 1 . skip)
+(b : x = 2 . skip)
+
+restate_axiom A.a'
+example (z : A) : z.x = 1 := begin success_if_fail { rw A.a' }, rw A.a end
+
+restate_axiom A.b f
+example (z : A) : z.x = 2 := by rw A.f
+
+restate_axiom A.b
+example (z : A) : z.x = 2 := by rw A.b_lemma


### PR DESCRIPTION
This changes the behaviour of the command `restate_axiom`, to give better names:
* if a second argument is provided, use that as the new name, otherwise
* if the field end with a `'`, the new lemma has the same name without the `'`, otherwise
* the new lemma has the field name with `_lemma` appended

This PR also removes all the inappropriate `[ematch]` attributes on lemmas in the `category_theory` library. To use `rewrite_search` we'll have to add `[search]` attributes later.

Closes #282 and #283.