### PR TITLE
feat(data/polynomial): has_repr for polynomials

### DIFF
--- a/data/polynomial.lean
+++ b/data/polynomial.lean
@@ -31,6 +31,17 @@ instance : has_mul (polynomial α) := finsupp.has_mul
 instance : comm_semiring (polynomial α) := finsupp.to_comm_semiring
 instance : decidable_eq (polynomial α) := finsupp.decidable_eq
 
+instance [has_repr α] : has_repr (polynomial α) :=
+⟨λ p, if p = 0 then "0" 
+  else (p.support.sort (≤)).foldr 
+    (λ n a, a ++ (if a = "" then "" else " + ") ++ 
+      if n = 0 
+        then repr (p n)
+        else if n = 1
+          then if (p n) = 1 then "X" else repr (p n) ++ " * X"
+          else if (p n) = 1 then "X ^ " ++ repr n 
+            else repr (p n) ++ " * X ^ " ++ repr n) ""⟩
+
 local attribute [instance] finsupp.to_comm_semiring
 
 @[simp] lemma support_zero : (0 : polynomial α).support = ∅ := rfl

--- a/data/polynomial.lean
+++ b/data/polynomial.lean
@@ -32,15 +32,15 @@ instance : comm_semiring (polynomial α) := finsupp.to_comm_semiring
 instance : decidable_eq (polynomial α) := finsupp.decidable_eq
 
 instance [has_repr α] : has_repr (polynomial α) :=
-⟨λ p, if p = 0 then "0" 
-  else (p.support.sort (≤)).foldr 
-    (λ n a, a ++ (if a = "" then "" else " + ") ++ 
-      if n = 0 
-        then repr (p n)
+⟨λ p, if p = 0 then "0"
+  else (p.support.sort (≤)).foldr
+    (λ n a, a ++ (if a = "" then "" else " + ") ++
+      if n = 0
+        then "C (" ++ repr (p n) ++ ")"
         else if n = 1
-          then if (p n) = 1 then "X" else repr (p n) ++ " * X"
-          else if (p n) = 1 then "X ^ " ++ repr n 
-            else repr (p n) ++ " * X ^ " ++ repr n) ""⟩
+          then if (p n) = 1 then "X" else "C (" ++ repr (p n) ++ ") * X"
+          else if (p n) = 1 then "X ^ " ++ repr n
+            else "C (" ++ repr (p n) ++ ") * X ^ " ++ repr n) ""⟩
 
 local attribute [instance] finsupp.to_comm_semiring
 


### PR DESCRIPTION
Not sure if I should change this so that it will always return a string that will not cause any problems if copied and pasted into a lemma. It does this for rationals and integers, although for rationals, it returns something equal to the polynomial you would like, but probably not the polynomial you actually want, i.e. `(2 / 3 : polynomial ℚ)` more or less gives you `(C 2 / C 3)`, rather than `C (2 / 3)`. These expressions are def eq, but not in any reasonable amount of time as soon as the size gets slightly larger.

TO CONTRIBUTORS:

Make sure you have:

 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
