### PR TITLE
refactor(linear_algebra/quotient_module): avoid using type class inference for setoids

### DIFF
--- a/linear_algebra/linear_map_module.lean
+++ b/linear_algebra/linear_map_module.lean
@@ -86,11 +86,11 @@ instance im.is_submodule : is_submodule A.im :=
 
 /- equivalences -/
 section
-open is_submodule
+open is_submodule quotient_module
 
 /-- first isomorphism law -/
 def quot_ker_equiv_im (f : linear_map β γ) : (quotient β f.ker) ≃ₗ f.im :=
-{ to_fun     := is_submodule.quotient.lift _
+{ to_fun     := quotient_module.quotient.lift _
     (is_linear_map_subtype_mk f.1 f.2 $ assume b, ⟨b, rfl⟩) (assume b eq, subtype.eq eq),
   inv_fun    := λb, @quotient.mk _ (quotient_rel _) (classical.some b.2),
   left_inv   := assume b', @quotient.induction_on _ (quotient_rel _) _ b' $
@@ -133,36 +133,39 @@ have sel₂_spec : ∀b':span (s ∪ t), ∃y∈t, b'.1 = (sel₂ b').1 + y,
 { to_fun :=
   begin
     intro b,
-    fapply @quotient.lift_on _ _ (quotient_rel _) b,
-    { intro b', apply quotient.mk, exact (sel₁ b') },
-    { intros b₁ b₂ h, apply quotient.sound, simp [quotient_rel_eq, *] at * }
+    fapply quotient.lift_on' b,
+    { intro b', exact sel₁ b' },
+    { assume b₁ b₂ h,
+      change b₁ - b₂ ∈ subtype.val ⁻¹' (s ∩ t) at h,
+      apply quotient_module.eq.2, simp * at * }
   end,
   inv_fun :=
   begin
     intro b,
-    fapply @quotient.lift_on _ _ (quotient_rel _) b,
-    { intro b', apply quotient.mk, exact sel₂ b' },
+    fapply quotient.lift_on' b,
+    { intro b', exact sel₂ b' },
     { intros b₁ b₂ h,
+      change b₁ - b₂ ∈ _ at h,
       rcases (sel₂_spec b₁) with ⟨c₁, hc₁, eq_c₁⟩,
       rcases (sel₂_spec b₂) with ⟨c₂, hc₂, eq_c₂⟩,
       have : ((sel₂ b₁).1 - (sel₂ b₂).1) + (c₁ - c₂) ∈ t,
-      { simpa [quotient_rel_eq, eq_c₁, eq_c₂, add_comm, add_left_comm, add_assoc] using h },
+      { simpa [eq_c₁, eq_c₂, add_comm, add_left_comm, add_assoc] using h, },
       have ht : (sel₂ b₁).1 - (sel₂ b₂).1 ∈ t,
       { rwa [is_submodule.add_left_iff (is_submodule.sub hc₁ hc₂)] at this },
       have hs : (sel₂ b₁).1 - (sel₂ b₂).1 ∈ s,
       { from is_submodule.sub (sel₂ b₁).2 (sel₂ b₂).2 },
-      apply quotient.sound,
-      simp [quotient_rel_eq, *] at * }
+      apply quotient_module.eq.2,
+      simp * at * }
   end,
-  right_inv := assume b', @quotient.induction_on _ (quotient_rel _) _ b'
+  right_inv := assume b', quotient.induction_on' b'
   begin
-    intro b, apply quotient.sound,
+    intro b, apply quotient_module.eq.2,
     rcases (sel₂_spec b) with ⟨c, hc, eq_c⟩,
-    simp [quotient_rel_eq, eq_c, hc, is_submodule.neg_iff]
+    simp [eq_c, hc, is_submodule.neg_iff]
   end,
   left_inv := assume b', @quotient.induction_on _ (quotient_rel _) _ b'
   begin
-    intro b, apply quotient.sound,
+    intro b, apply quotient_module.eq.2,
     rcases (sel₂_spec (sel₁ b)) with ⟨c, hc, eq⟩,
     have b_eq : b.1 = c + (sel₂ (sel₁ b)).1,
     { simpa [sel₁_val] using eq },

--- a/linear_algebra/quotient_module.lean
+++ b/linear_algebra/quotient_module.lean
@@ -95,6 +95,10 @@ instance quotient.module : module α Q :=
   add_smul     := assume a b c, quotient.induction_on' c $
     assume c, quotient_module.eq.2 $ by simp [is_submodule.zero, add_smul], }
 
+@[simp] lemma coe_zero : ((0 : β) : Q) = 0 := rfl
+@[simp] lemma coe_smul (a : α) (b : β) : ((a • b : β) : Q) = a • b := rfl
+@[simp] lemma coe_add (a b : β) : ((a + b : β) : Q) = a + b := rfl
+
 instance quotient.inhabited : inhabited Q := ⟨0⟩
 
 lemma is_linear_map_quotient_mk : @is_linear_map _ _ Q _ _ _ (λb, mk b : β → Q) :=
@@ -116,7 +120,7 @@ lemma is_linear_map_quotient_lift {f : β → γ} {h : ∀x y, x - y ∈ s → f
 
 lemma quotient.injective_lift [is_submodule s] {f : β → γ} (hf : is_linear_map f)
   (hs : s = {x | f x = 0}) : injective (quotient.lift s hf $ le_of_eq hs) :=
-assume a b, quotient.induction_on₂ a b $ assume a b (h : f a = f b), quotient.sound $
+assume a b, quotient.induction_on₂' a b $ assume a b (h : f a = f b), quotient.sound' $
   have f (a - b) = 0, by rw [hf.sub]; simp [h],
   show a - b ∈ s, from hs.symm ▸ this
 

--- a/linear_algebra/quotient_module.lean
+++ b/linear_algebra/quotient_module.lean
@@ -8,14 +8,14 @@ Quotient construction on modules
 
 import linear_algebra.basic
 
-namespace is_submodule
-
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
-variables [ring α] [module α β] [module α γ] (s : set β) [hs : is_submodule s]
-include α s hs
+variables [ring α] [module α β] [module α γ] (s : set β) [is_submodule s]
+include α
 
 open function
+
+namespace is_submodule
 
 def quotient_rel : setoid β :=
 ⟨λb₁ b₂, b₁ - b₂ ∈ s,
@@ -27,30 +27,38 @@ def quotient_rel : setoid β :=
   have (b₁ - b₂) + (b₂ - b₃) ∈ s, from add hb₁₂ hb₂₃,
   by simpa using this⟩
 
-local attribute [instance] quotient_rel
+end is_submodule
 
-lemma quotient_rel_eq {b₁ b₂ : β} : (b₁ ≈ b₂) = (b₁ - b₂ ∈ s) := rfl
+namespace quotient_module
+open is_submodule
 
 section
 variable (β)
 /-- Quotient module. `quotient β s` is the quotient of the module `β` by the submodule `s`. -/
-def quotient : Type v := quotient (quotient_rel s)
+def quotient (s : set β) [is_submodule s] : Type v := quotient (quotient_rel s)
 end
 
 local notation ` Q ` := quotient β s
 
-instance quotient.has_zero : has_zero Q := ⟨⟦ 0 ⟧⟩
+def mk {s : set β} [is_submodule s] : β → quotient β s := quotient.mk'
+
+instance : has_coe β Q := ⟨mk⟩
+
+protected def eq {s : set β} [is_submodule s] {a b : β} : (a : quotient β s) = b ↔ a - b ∈ s :=
+quotient.eq'
+
+instance quotient.has_zero : has_zero Q := ⟨mk 0⟩
 
 instance quotient.has_add : has_add Q :=
-⟨λa b, quotient.lift_on₂ a b (λa b, ⟦a + b⟧) $
+⟨λa b, quotient.lift_on₂' a b (λa b, ((a + b : β ) : Q)) $
   assume a₁ a₂ b₁ b₂ (h₁ : a₁ - b₁ ∈ s) (h₂ : a₂ - b₂ ∈ s),
-  quotient.sound $
+  quotient.sound' $
   have (a₁ - b₁) + (a₂ - b₂) ∈ s, from add h₁ h₂,
   show (a₁ + a₂) - (b₁ + b₂) ∈ s, by simpa⟩
 
 instance quotient.has_neg : has_neg Q :=
-⟨λa, quotient.lift_on a (λa, ⟦- a⟧) $ assume a b (h : a - b ∈ s),
-  quotient.sound $
+⟨λa, quotient.lift_on' a (λa, mk (- a)) $ assume a b (h : a - b ∈ s),
+  quotient.sound' $
   have - (a - b) ∈ s, from neg h,
   show (-a) - (-b) ∈ s, by simpa⟩
 
@@ -58,52 +66,53 @@ instance quotient.add_comm_group : add_comm_group Q :=
 { zero := 0,
   add  := (+),
   neg  := has_neg.neg,
-  add_assoc    := assume a b c, quotient.induction_on₃ a b c $ assume a b c, quotient.sound $
-    by simp,
-  add_comm     := assume a b, quotient.induction_on₂ a b $ assume a b, quotient.sound $
-    by simp,
-  add_zero     := assume a, quotient.induction_on a $ assume a, quotient.sound $
-    by simp,
-  zero_add     := assume a, quotient.induction_on a $ assume a, quotient.sound $
-    by simp,
-  add_left_neg := assume a, quotient.induction_on a $ assume a, quotient.sound $
-    by simp }
+  add_assoc    := assume a b c, quotient.induction_on₃' a b c $
+    assume a b c, quotient_module.eq.2 $
+    by simp [is_submodule.zero],
+  add_comm     := assume a b, quotient.induction_on₂' a b $
+    assume a b, quotient_module.eq.2 $ by simp [is_submodule.zero],
+  add_zero     := assume a, quotient.induction_on' a $
+    assume a, quotient_module.eq.2 $ by simp [is_submodule.zero],
+  zero_add     := assume a, quotient.induction_on' a $
+    assume a, quotient_module.eq.2 $ by simp [is_submodule.zero],
+  add_left_neg := assume a, quotient.induction_on' a $
+    assume a, quotient_module.eq.2 $ by simp [is_submodule.zero] }
 
 instance quotient.has_scalar : has_scalar α Q :=
-⟨λa b, quotient.lift_on b (λb, ⟦a • b⟧) $ assume b₁ b₂ (h : b₁ - b₂ ∈ s),
-  quotient.sound $
+⟨λa b, quotient.lift_on' b (λb, ((a • b : β) : Q)) $ assume b₁ b₂ (h : b₁ - b₂ ∈ s),
+  quotient.sound' $
   have a • (b₁ - b₂) ∈ s, from is_submodule.smul a h,
   show a • b₁ - a • b₂ ∈ s, by simpa [smul_add]⟩
 
 instance quotient.module : module α Q :=
 { smul := (•),
-  one_smul     := assume a, quotient.induction_on a $ assume a, quotient.sound $
-    by simp,
-  mul_smul     := assume a b c, quotient.induction_on c $ assume c, quotient.sound $
-    by simp [mul_smul],
-  smul_add     := assume a b c, quotient.induction_on₂ b c $ assume b c, quotient.sound $
-    by simp [smul_add],
-  add_smul     := assume a b c, quotient.induction_on c $ assume c, quotient.sound $
-    by simp [add_smul] }
+  one_smul     := assume a, quotient.induction_on' a $
+    assume a, quotient_module.eq.2 $ by simp [is_submodule.zero],
+  mul_smul     := assume a b c, quotient.induction_on' c $
+    assume c, quotient_module.eq.2 $ by simp [is_submodule.zero, mul_smul],
+  smul_add     := assume a b c, quotient.induction_on₂' b c $
+    assume b c, quotient_module.eq.2 $ by simp [is_submodule.zero, smul_add],
+  add_smul     := assume a b c, quotient.induction_on' c $
+    assume c, quotient_module.eq.2 $ by simp [is_submodule.zero, add_smul], }
 
 instance quotient.inhabited : inhabited Q := ⟨0⟩
 
-lemma is_linear_map_quotient_mk : @is_linear_map _ _ Q _ _ _ (λb, ⟦b⟧ : β → Q) :=
+lemma is_linear_map_quotient_mk : @is_linear_map _ _ Q _ _ _ (λb, mk b : β → Q) :=
 by refine {..}; intros; refl
 
 def quotient.lift {f : β → γ} (hf : is_linear_map f) (h : ∀x∈s, f x = 0) (b : Q) : γ :=
-b.lift_on f $ assume a b (hab : a - b ∈ s),
+b.lift_on' f $ assume a b (hab : a - b ∈ s),
   have f a - f b = 0, by rw [←hf.sub]; exact h _ hab,
   show f a = f b, from eq_of_sub_eq_zero this
 
 @[simp] lemma quotient.lift_mk {f : β → γ} (hf : is_linear_map f) (h : ∀x∈s, f x = 0) (b : β) :
-  quotient.lift s hf h ⟦b⟧ = f b :=
+  quotient.lift s hf h (b : Q) = f b :=
 rfl
 
 lemma is_linear_map_quotient_lift {f : β → γ} {h : ∀x y, x - y ∈ s → f x = f y}
-  (hf : is_linear_map f) : is_linear_map (λq:Q, quotient.lift_on q f h) :=
-⟨assume b₁ b₂, quotient.induction_on₂ b₁ b₂ $ assume b₁ b₂, hf.add b₁ b₂,
-  assume a b, quotient.induction_on b $ assume b, hf.smul a b⟩
+  (hf : is_linear_map f) : is_linear_map (λq:Q, quotient.lift_on' q f h) :=
+⟨assume b₁ b₂, quotient.induction_on₂' b₁ b₂ $ assume b₁ b₂, hf.add b₁ b₂,
+  assume a b, quotient.induction_on' b $ assume b, hf.smul a b⟩
 
 lemma quotient.injective_lift [is_submodule s] {f : β → γ} (hf : is_linear_map f)
   (hs : s = {x | f x = 0}) : injective (quotient.lift s hf $ le_of_eq hs) :=
@@ -111,4 +120,4 @@ assume a b, quotient.induction_on₂ a b $ assume a b (h : f a = f b), quotient.
   have f (a - b) = 0, by rw [hf.sub]; simp [h],
   show a - b ∈ s, from hs.symm ▸ this
 
-end is_submodule
+end quotient_module

--- a/ring_theory/ideals.lean
+++ b/ring_theory/ideals.lean
@@ -161,7 +161,7 @@ instance (S : set α) [is_ideal S] : comm_ring (quotient S) :=
     λ a b c, congr_arg mk (left_distrib a b c),
   right_distrib := λ a b c, quotient.induction_on₃' a b c $
     λ a b c, congr_arg mk (right_distrib a b c),
-  ..is_submodule.quotient.add_comm_group S }
+  ..quotient_module.quotient.add_comm_group S }
 
 instance is_ring_hom_mk (S : set α) [is_ideal S] :
   @is_ring_hom _ (quotient S) _ _ mk :=


### PR DESCRIPTION
Continuation of #212 . Avoid using type class inference for quotient modules, and introduce a version of `quotient.mk` specifically for quotient modules, whose output type is `quotient β s` rather than `quotient (quotient_rel s)`, which should help type class inference
TO CONTRIBUTORS:

Make sure you have:

 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
