### PR TITLE
Updates to p-adics and linarith

### DIFF
--- a/algebra/archimedean.lean
+++ b/algebra/archimedean.lean
@@ -104,7 +104,9 @@ lemma ceil_pos {a : α} : 0 < ⌈a⌉ ↔ 0 < a :=
  λ h, have -a < 0, from neg_neg_of_pos h,
   neg_pos_of_neg $ lt_of_not_ge $ (not_iff_not_of_iff floor_nonneg).2 $ not_le_of_gt this ⟩
 
-lemma ceil_nonneg {q : ℚ} (hq : q ≥ 0) : ⌈q⌉ ≥ 0 :=
+@[simp] theorem ceil_zero : ⌈(0 : α)⌉ = 0 := by simp [ceil]
+
+lemma ceil_nonneg [decidable_rel ((<) : α → α → Prop)] {q : α} (hq : q ≥ 0) : ⌈q⌉ ≥ 0 :=
 if h : q > 0 then le_of_lt $ ceil_pos.2 h
 else 
   have h' : q = 0, from le_antisymm (le_of_not_lt h) hq,

--- a/algebra/field_power.lean
+++ b/algebra/field_power.lean
@@ -6,7 +6,7 @@ Authors: Robert Y. Lewis
 Integer power operation on fields.
 -/
 
-import algebra.group_power tactic.wlog
+import algebra.group_power tactic.wlog 
 
 universe u
 
@@ -36,7 +36,6 @@ begin change fpow a -[1+0] = a⁻¹, simp [fpow] end
 lemma fpow_ne_zero_of_ne_zero {a : α} (ha : a ≠ 0) : ∀ (z : ℤ), fpow a z ≠ 0
 | (of_nat n) := pow_ne_zero _ ha
 | -[1+n] := one_div_ne_zero $ pow_ne_zero _ ha
-
 
 @[simp] lemma fpow_zero {a : α} : fpow a 0 = 1 :=
 pow_zero _ 

--- a/algebra/field_power.lean
+++ b/algebra/field_power.lean
@@ -6,61 +6,61 @@ Authors: Robert Y. Lewis
 Integer power operation on fields.
 -/
 
-import algebra.group_power tactic.wlog 
+import algebra.group_power tactic.wlog
 
 universe u
 
 section field_power
-open int nat 
+open int nat
 variables {α : Type u} [division_ring α]
 
 @[simp] lemma zero_gpow : ∀ z : ℕ, z ≠ 0 → (0 : α)^z = 0
-| 0 h := absurd rfl h 
-| (k+1) h := zero_mul _ 
+| 0 h := absurd rfl h
+| (k+1) h := zero_mul _
 
-def fpow (a : α) : ℤ → α 
-| (of_nat n) := a ^ n 
+def fpow (a : α) : ℤ → α
+| (of_nat n) := a ^ n
 | -[1+n] := 1/(a ^ (n+1))
 
 lemma unit_pow {a : α} (ha : a ≠ 0) : ∀ n : ℕ, a ^ n = ↑((units.mk0 a ha)^n)
 | 0 := by simp; refl
-| (k+1) := by simp [_root_.pow_add]; congr; apply unit_pow 
+| (k+1) := by simp [_root_.pow_add]; congr; apply unit_pow
 
 lemma fpow_eq_gpow {a : α} (h : a ≠ 0) : ∀ (z : ℤ), fpow a z = ↑(gpow (units.mk0 a h) z)
-| (of_nat k) := by simp only [fpow, gpow]; apply unit_pow 
-| -[1+k] := by simp [fpow, gpow]; congr; apply unit_pow 
+| (of_nat k) := by simp only [fpow, gpow]; apply unit_pow
+| -[1+k] := by simp [fpow, gpow]; congr; apply unit_pow
 
-lemma fpow_inv (a : α) : fpow a (-1) = a⁻¹ := 
-begin change fpow a -[1+0] = a⁻¹, simp [fpow] end 
+lemma fpow_inv (a : α) : fpow a (-1) = a⁻¹ :=
+begin change fpow a -[1+0] = a⁻¹, simp [fpow] end
 
 lemma fpow_ne_zero_of_ne_zero {a : α} (ha : a ≠ 0) : ∀ (z : ℤ), fpow a z ≠ 0
 | (of_nat n) := pow_ne_zero _ ha
 | -[1+n] := one_div_ne_zero $ pow_ne_zero _ ha
 
 @[simp] lemma fpow_zero {a : α} : fpow a 0 = 1 :=
-pow_zero _ 
+pow_zero _
 
-lemma fpow_add {a : α} (ha : a ≠ 0) (z1 z2 : ℤ) : fpow a (z1 + z2) = fpow a z1 * fpow a z2 := 
-begin simp only [fpow_eq_gpow ha], rw ←units.mul_coe, congr, apply gpow_add end 
+lemma fpow_add {a : α} (ha : a ≠ 0) (z1 z2 : ℤ) : fpow a (z1 + z2) = fpow a z1 * fpow a z2 :=
+begin simp only [fpow_eq_gpow ha], rw ←units.mul_coe, congr, apply gpow_add end
 
 end field_power
 
 section discrete_field_power
-open int nat 
+open int nat
 variables {α : Type u} [discrete_field α]
 
 lemma zero_fpow : ∀ z : ℤ, z ≠ 0 → fpow (0 : α) z = 0
 | (of_nat n) h :=
   have h2 : n ≠ 0, from assume : n = 0, by simpa [this] using h,
   by simp [h, h2, fpow]
-| -[1+n] h := 
+| -[1+n] h :=
   have h1 : (0 : α) ^ (n+1) = 0, from zero_mul _,
   by simp [fpow, h1]
 
 end discrete_field_power
 
 section ordered_field_power
-open int 
+open int
 
 variables {α : Type u} [discrete_linear_ordered_field α]
 
@@ -70,15 +70,15 @@ lemma fpow_nonneg_of_nonneg {a : α} (ha : a ≥ 0) : ∀ (z : ℤ), fpow a z �
 
 
 lemma fpow_le_of_le {x : α} (hx : 1 ≤ x) {a b : ℤ} (h : a ≤ b) : fpow x a ≤ fpow x b :=
-begin 
+begin
   induction a with a a; induction b with b b,
-  { simp only [fpow], 
-    apply pow_le_pow hx, 
+  { simp only [fpow],
+    apply pow_le_pow hx,
     apply le_of_coe_nat_le_coe_nat h },
-  { apply absurd h, 
+  { apply absurd h,
     apply not_le_of_gt,
     exact lt_of_lt_of_le (neg_succ_lt_zero _) (of_nat_nonneg _) },
-  { simp only [fpow, one_div_eq_inv], 
+  { simp only [fpow, one_div_eq_inv],
     apply le_trans (inv_le_one _); apply one_le_pow_of_one_le hx },
   { simp only [fpow],
     apply (one_div_le_one_div _ _).2,
@@ -89,16 +89,20 @@ begin
     repeat { apply pow_pos (lt_of_lt_of_le zero_lt_one hx) } }
 end
 
-lemma pow_le_max_of_min_le {x : α} (hx : x ≥ 1) {a b c : ℤ} (h : min a b ≤ c) : 
+lemma pow_le_max_of_min_le {x : α} (hx : x ≥ 1) {a b c : ℤ} (h : min a b ≤ c) :
       fpow x (-c) ≤ max (fpow x (-a)) (fpow x (-b)) :=
-begin 
+begin
   wlog hle : a ≤ b,
   have hnle : -b ≤ -a, from neg_le_neg hle,
   have hfle : fpow x (-b) ≤ fpow x (-a), from fpow_le_of_le hx hnle,
-  have : fpow x (-c) ≤ fpow x (-a), 
+  have : fpow x (-c) ≤ fpow x (-a),
   { apply fpow_le_of_le hx,
     simpa [hle, min_eq_left] using h },
-  simpa [hfle, max_eq_left] using this 
-end 
+  simpa [hfle, max_eq_left] using this
+end
 
-end ordered_field_power 
+lemma fpow_le_one_of_nonpos {p : α} (hp : p ≥ 1) {z : ℤ} (hz : z ≤ 0) : fpow p z ≤ 1 :=
+calc fpow p z ≤ fpow p 0 : fpow_le_of_le hp hz
+          ... = 1        : by simp
+
+end ordered_field_power

--- a/analysis/normed_space.lean
+++ b/analysis/normed_space.lean
@@ -84,6 +84,9 @@ abs_le.2 $ and.intro
 lemma dist_norm_norm_le (g h : α) : dist ∥g∥ ∥h∥ ≤ ∥g - h∥ :=
 abs_norm_sub_norm_le g h
 
+lemma norm_sub_rev (g h : α) : ∥g - h∥ = ∥h - g∥ :=
+by rw ←norm_neg; simp
+
 section nnnorm
 
 def nnnorm (a : α) : nnreal := ⟨norm a, norm_nonneg a⟩
@@ -212,6 +215,23 @@ class normed_field (α : Type*) extends has_norm α, discrete_field α, metric_s
 
 instance normed_field.to_normed_ring [i : normed_field α] : normed_ring α :=
 { norm_mul := by finish [i.norm_mul], ..i }
+
+@[simp] lemma norm_one {α : Type*} [normed_field α] : ∥(1 : α)∥ = 1 := 
+have  ∥(1 : α)∥ * ∥(1 : α)∥ = ∥(1 : α)∥ * 1, by calc
+ ∥(1 : α)∥ * ∥(1 : α)∥ = ∥(1 : α) * (1 : α)∥ : by rw normed_field.norm_mul
+                  ... = ∥(1 : α)∥ * 1 : by simp,
+eq_of_mul_eq_mul_left (ne_of_gt ((norm_pos_iff _).2 (by simp))) this
+
+@[simp] lemma norm_div {α : Type*} [normed_field α] (a b : α) : ∥a/b∥ = ∥a∥/∥b∥ := 
+if hb : b = 0 then by simp [hb] else 
+begin 
+  apply eq_div_of_mul_eq,
+  { apply ne_of_gt, apply (norm_pos_iff _).mpr hb },
+  { rw [←normed_field.norm_mul, div_mul_cancel _ hb] }
+end 
+
+@[simp] lemma norm_inv {α : Type*} [normed_field α] (a : α) : ∥a⁻¹∥ = ∥a∥⁻¹ := 
+by simp only [inv_eq_one_div, norm_div, norm_one] 
 
 instance : normed_field ℝ :=
 { norm := λ x, abs x,

--- a/data/int/basic.lean
+++ b/data/int/basic.lean
@@ -580,21 +580,24 @@ lemma dvd_nat_abs_of_of_nat_dvd {a : ℕ} : ∀ {z : ℤ} (haz : ↑a ∣ z), a 
   have haz' : (↑a:ℤ) ∣ (↑(k+1):ℤ), from dvd_of_dvd_neg haz,
   int.coe_nat_dvd.1 haz'
 
-lemma pow_div_of_le_of_pow_div_int {p m n : ℕ} {k : ℤ} (hmn : m ≤ n) (hdiv : ↑(p ^ n) ∣ k) :
+lemma pow_dvd_of_le_of_pow_dvd {p m n : ℕ} {k : ℤ} (hmn : m ≤ n) (hdiv : ↑(p ^ n) ∣ k) :
       ↑(p ^ m) ∣ k :=
 begin
   induction k,
     { apply int.coe_nat_dvd.2,
-      apply pow_div_of_le_of_pow_div hmn,
+      apply pow_dvd_of_le_of_pow_dvd hmn,
       apply int.coe_nat_dvd.1 hdiv },
     { change -[1+k] with -(↑(k+1) : ℤ),
       apply dvd_neg_of_dvd,
       apply int.coe_nat_dvd.2,
-      apply pow_div_of_le_of_pow_div hmn,
+      apply pow_dvd_of_le_of_pow_dvd hmn,
       apply int.coe_nat_dvd.1,
       apply dvd_of_dvd_neg,
       exact hdiv }
 end
+
+lemma dvd_of_pow_dvd {p k : ℕ} {m : ℤ} (hk : 1 ≤ k) (hpk : ↑(p^k) ∣ m) : ↑p ∣ m := 
+by rw ←nat.pow_one p; exact pow_dvd_of_le_of_pow_dvd hk hpk
 
 /- / and ordering -/
 

--- a/data/int/modeq.lean
+++ b/data/int/modeq.lean
@@ -75,5 +75,28 @@ by rw [mul_comm a, mul_comm b]; exact modeq_mul_left c h
 theorem modeq_mul (h₁ : a ≡ b [ZMOD n]) (h₂ : c ≡ d [ZMOD n]) : a * c ≡ b * d [ZMOD n] :=
 (modeq_mul_left _ h₂).trans (modeq_mul_right _ h₁)
 
+theorem modeq_add_fac {a b n : ℤ} (c : ℤ) (ha : a ≡ b [ZMOD n]) : a + n*c ≡ b [ZMOD n] :=
+calc a + n*c ≡ b + n*c [ZMOD n] : int.modeq.modeq_add ha (int.modeq.refl _) 
+         ... ≡ b + 0 [ZMOD n] : int.modeq.modeq_add (int.modeq.refl _) (int.modeq.modeq_zero_iff.2 (dvd_mul_right _ _))
+         ... ≡ b [ZMOD n] : by simp
+
+open nat 
+lemma mod_coprime {a b : ℕ} (hab : coprime a b) : ∃ y : ℤ, a * y ≡ 1 [ZMOD b] :=
+⟨ gcd_a a b, 
+  have hgcd : nat.gcd a b = 1, from coprime.gcd_eq_one hab,
+  calc
+   ↑a * gcd_a a b ≡ ↑a*gcd_a a b + ↑b*gcd_b a b [ZMOD ↑b] : int.modeq.symm $ modeq_add_fac _ $ int.modeq.refl _
+              ... ≡ 1 [ZMOD ↑b] : by rw [←gcd_eq_gcd_ab, hgcd]; reflexivity ⟩
+
+lemma exists_unique_equiv (a : ℤ) {b : ℤ} (hb : b > 0) : ∃ z : ℤ, 0 ≤ z ∧ z < b ∧ z ≡ a [ZMOD b] :=
+⟨ a % b, int.mod_nonneg _ (ne_of_gt hb), 
+  have a % b < abs b, from int.mod_lt _ (ne_of_gt hb),
+  by rwa abs_of_pos hb at this, 
+  by simp [int.modeq] ⟩
+
+lemma exists_unique_equiv_nat (a : ℤ) {b : ℤ} (hb : b > 0) : ∃ z : ℕ, ↑z < b ∧ ↑z ≡ a [ZMOD b] :=
+let ⟨z, hz1, hz2, hz3⟩ := exists_unique_equiv a hb in 
+⟨z.nat_abs, by split; rw [←int.of_nat_eq_coe, int.of_nat_nat_abs_eq_of_nonneg hz1]; assumption⟩
+
 end modeq
 end int

--- a/data/nat/basic.lean
+++ b/data/nat/basic.lean
@@ -656,7 +656,7 @@ have h3 : b = a * d * c, from
   nat.eq_mul_of_div_eq_left hab hd,
 show ∃ d, b = c * a * d, from ⟨d, by cc⟩
 
-lemma nat.div_mul_div {a b c d : ℕ} (hab : b ∣ a) (hcd : d ∣ c) :
+lemma div_mul_div {a b c d : ℕ} (hab : b ∣ a) (hcd : d ∣ c) :
       (a / b) * (c / d) = (a * c) / (b * d) :=
 have exi1 : ∃ x, a = b * x, from hab,
 have exi2 : ∃ y, c = d * y, from hcd,
@@ -674,9 +674,12 @@ begin
   cc
 end
 
-lemma pow_div_of_le_of_pow_div {p m n k : ℕ} (hmn : m ≤ n) (hdiv : p ^ n ∣ k) : p ^ m ∣ k :=
+lemma pow_dvd_of_le_of_pow_dvd {p m n k : ℕ} (hmn : m ≤ n) (hdiv : p ^ n ∣ k) : p ^ m ∣ k :=
 have p ^ m ∣ p ^ n, from pow_dvd_pow _ hmn,
 dvd_trans this hdiv
+
+lemma dvd_of_pow_dvd {p k m : ℕ} (hk : 1 ≤ k) (hpk : p^k ∣ m) : p ∣ m := 
+by rw ←nat.pow_one p; exact pow_dvd_of_le_of_pow_dvd hk hpk
 
 end div
 

--- a/data/padics/padic_integers.lean
+++ b/data/padics/padic_integers.lean
@@ -3,19 +3,16 @@ Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
 
-Define the p-adic integers ℤ_p as a subtype of ℚ_p. Show ℤ_p is a ring.
+Define the p-adic integers ℤ_p as a subtype of ℚ_p. Construct algebraic structures on ℤ_p.
 -/
 
-import data.padics.padic_rationals
+import data.padics.padic_rationals tactic.subtype_instance ring_theory.ideals
 open nat padic
 noncomputable theory
+local attribute [instance] classical.prop_decidable
 
-section padic_int
-variables {p : ℕ} (hp : prime p)
-
-def padic_int := {x : ℚ_[hp] // padic_norm_e x ≤ 1}
+def padic_int {p : ℕ} (hp : prime p) := {x : ℚ_[hp] // ∥x∥ ≤ 1}
 notation `ℤ_[`hp`]` := padic_int hp
-end padic_int 
 
 namespace padic_int 
 variables {p : ℕ} {hp : prime p}
@@ -26,7 +23,7 @@ def add : ℤ_[hp] → ℤ_[hp] → ℤ_[hp]
 
 def mul : ℤ_[hp] → ℤ_[hp] → ℤ_[hp]
 | ⟨x, hx⟩ ⟨y, hy⟩ := ⟨x*y, 
-    begin rw padic_norm_e.mul, apply mul_le_one; {assumption <|> apply padic_norm_e.nonneg} end⟩
+    begin rw padic_norm_e.mul, apply mul_le_one; {assumption <|> apply norm_nonneg} end⟩
 
 def neg : ℤ_[hp] → ℤ_[hp]
 | ⟨x, hx⟩ := ⟨-x, by simpa⟩
@@ -36,10 +33,209 @@ begin
   refine { add := add,
            mul := mul,
            neg := neg,
-           zero := ⟨0, by simp⟩,
+           zero := ⟨0, by simp [zero_le_one]⟩,
            one := ⟨1, by simp⟩,
            .. };
   {repeat {rintro ⟨_, _⟩}, simp [mul_assoc, left_distrib, right_distrib, add, mul, neg]}
 end 
 
+lemma zero_def : ∀ x : ℤ_[hp], x = 0 ↔ x.val = 0 
+| ⟨x, _⟩ := ⟨subtype.mk.inj, λ h, by simp at h; simp only [h]; refl⟩
+
+@[simp] lemma add_def : ∀ (x y : ℤ_[hp]), (x+y).val = x.val + y.val 
+| ⟨x, hx⟩ ⟨y, hy⟩ := rfl
+
+@[simp] lemma mul_def : ∀ (x y : ℤ_[hp]), (x*y).val = x.val * y.val 
+| ⟨x, hx⟩ ⟨y, hy⟩ := rfl
+
+@[simp] lemma mk_zero {h} : (⟨0, h⟩ : ℤ_[hp]) = (0 : ℤ_[hp]) := rfl
+
+instance : has_coe ℤ_[hp] ℚ_[hp] := ⟨subtype.val⟩
+
+@[simp] lemma val_eq_coe (z : ℤ_[hp]) : z.val = ↑z := rfl
+
+@[simp] lemma coe_add : ∀ (z1 z2 : ℤ_[hp]), (↑(z1 + z2) : ℚ_[hp]) = ↑z1 + ↑z2 
+| ⟨_, _⟩ ⟨_, _⟩ := rfl
+
+@[simp] lemma coe_mul : ∀ (z1 z2 : ℤ_[hp]), (↑(z1 * z2) : ℚ_[hp]) = ↑z1 * ↑z2 
+| ⟨_, _⟩ ⟨_, _⟩ := rfl
+
+@[simp] lemma coe_neg : ∀ (z1 : ℤ_[hp]), (↑(-z1) : ℚ_[hp]) = -↑z1
+| ⟨_, _⟩ := rfl
+
+@[simp] lemma coe_sub : ∀ (z1 z2 : ℤ_[hp]), (↑(z1 - z2) : ℚ_[hp]) = ↑z1 - ↑z2 
+| ⟨_, _⟩ ⟨_, _⟩ := rfl
+
+@[simp] lemma coe_coe : ∀ n : ℕ, (↑(↑n : ℤ_[hp]) : ℚ_[hp]) = (↑n : ℚ_[hp])
+| 0 := rfl
+| (k+1) := by simp [coe_coe]; refl
+
+@[simp] lemma coe_one : (↑(1 : ℤ_[hp]) : ℚ_[hp]) = 1 := rfl 
+
+lemma mk_coe : ∀ (k : ℤ_[hp]) /-{p : @padic_norm_e _ hp ↑k ≤ 1}-/, (⟨↑k, k.2⟩ : ℤ_[hp]) = k
+| ⟨_, _⟩ := rfl
+
+def inv : ℤ_[hp] → ℤ_[hp]
+| ⟨k, _⟩ := if h : ∥k∥ = 1 then ⟨1/k, by simp [h]⟩ else 0
+
 end padic_int 
+
+section instances
+variables {p : ℕ} {hp : p.prime}
+
+@[reducible] def padic_norm_z (z : ℤ_[hp]) : ℝ := ∥z.val∥
+
+instance : metric_space ℤ_[hp] := 
+subtype.metric_space
+ 
+instance : has_norm ℤ_[hp] := ⟨padic_norm_z⟩ 
+
+instance : normed_ring ℤ_[hp] :=
+{ dist_eq := λ ⟨_, _⟩ ⟨_, _⟩, rfl,
+  norm_mul := λ ⟨_, _⟩ ⟨_, _⟩, norm_mul _ _ }
+
+instance padic_norm_z.is_absolute_value {p} {hp : prime p} : is_absolute_value (λ z : ℤ_[hp], ∥z∥) := 
+{ abv_nonneg := norm_nonneg,
+  abv_eq_zero := λ ⟨_, _⟩, by simp [norm_eq_zero, padic_int.zero_def],
+  abv_add := λ ⟨_,_⟩ ⟨_, _⟩, norm_triangle _ _,
+  abv_mul := λ _ _, by unfold norm; simp [padic_norm_z] }
+
+protected lemma padic_int.pmul_comm : ∀ z1 z2 : ℤ_[hp], z1*z2 = z2*z1 
+| ⟨q1, h1⟩ ⟨q2, h2⟩ := show (⟨q1*q2, _⟩ : ℤ_[hp]) = ⟨q2*q1, _⟩, by simp [mul_comm]
+
+instance : comm_ring ℤ_[hp] :=
+{ mul_comm := padic_int.pmul_comm,
+  ..padic_int.ring }
+
+protected lemma padic_int.zero_ne_one : (0 : ℤ_[hp]) ≠ 1 := 
+show (⟨(0 : ℚ_[hp]), _⟩ : ℤ_[hp]) ≠ ⟨(1 : ℚ_[hp]), _⟩, from mt subtype.ext.1 zero_ne_one
+
+protected lemma padic_int.eq_zero_or_eq_zero_of_mul_eq_zero : ∀ (a b : ℤ_[hp]), a * b = 0 → a = 0 ∨ b = 0
+| ⟨a, ha⟩ ⟨b, hb⟩ := λ h : (⟨a * b, _⟩ : ℤ_[hp]) = ⟨0, _⟩, 
+have a * b = 0, from subtype.ext.1 h,
+(mul_eq_zero_iff_eq_zero_or_eq_zero.1 this).elim
+  (λ h1, or.inl (by simp [h1]; refl))
+  (λ h2, or.inr (by simp [h2]; refl)) 
+
+instance {p : ℕ} {hp : prime p} : integral_domain ℤ_[hp] :=
+{ eq_zero_or_eq_zero_of_mul_eq_zero := padic_int.eq_zero_or_eq_zero_of_mul_eq_zero,
+  zero_ne_one := padic_int.zero_ne_one,
+  ..padic_int.comm_ring }
+
+end instances
+
+namespace padic_norm_z
+
+variables {p : ℕ} {hp : p.prime}
+
+lemma le_one : ∀ z : ℤ_[hp], ∥z∥ ≤ 1 
+| ⟨_, h⟩ := h
+
+@[simp] lemma mul (z1 z2 : ℤ_[hp]) : ∥z1 * z2∥ = ∥z1∥ * ∥z2∥ :=
+by unfold norm; simp [padic_norm_z]
+
+theorem nonarchimedean : ∀ (q r : ℤ_[hp]), ∥q + r∥ ≤ max (∥q∥) (∥r∥)
+| ⟨_, _⟩ ⟨_, _⟩ := padic_norm_e.nonarchimedean _ _
+
+@[simp] lemma norm_one : ∥(1 : ℤ_[hp])∥ = 1 := norm_one 
+
+end padic_norm_z 
+
+namespace padic_int 
+variables {p : ℕ} {hp : p.prime}
+local attribute [reducible] padic_int 
+
+lemma mul_inv : ∀ {z : ℤ_[hp]}, ∥z∥ = 1 → z * z.inv = 1 
+| ⟨k, _⟩ h := 
+  begin
+    have hk : k ≠ 0, from λ h', @zero_ne_one ℚ_[hp] _ (by simpa [h'] using h),
+    unfold padic_int.inv, split_ifs, 
+    { change (⟨k * (1/k), _⟩ : ℤ_[hp]) = 1,
+      simp [hk], refl },
+    { apply subtype.ext.2, simp [mul_inv_cancel hk] }
+  end 
+
+lemma inv_mul {z : ℤ_[hp]} (hz : ∥z∥ = 1) : z.inv * z = 1 := 
+by rw [mul_comm, mul_inv hz]
+
+def maximal_ideal {p : ℕ} (hp : prime p) : set ℤ_[hp] := λ z, ∥z∥ < 1
+
+lemma maximal_ideal_add {z1 z2 : ℤ_[hp]} (hz1 : ∥z1∥ < 1) (hz2 : ∥z2∥ < 1) : ∥z1 + z2∥ < 1 := 
+lt_of_le_of_lt (padic_norm_z.nonarchimedean _ _) (max_lt hz1 hz2)
+
+private lemma mul_lt_one  {α} [decidable_linear_ordered_comm_ring α] {a b : α} (hbz : 0 < b)
+  (ha : a < 1) (hb : b < 1) : a * b < 1 :=
+suffices a*b < 1*1, by simpa,
+mul_lt_mul ha (le_of_lt hb) hbz zero_le_one
+
+private lemma mul_lt_one_of_le_of_lt {α} [decidable_linear_ordered_comm_ring α] {a b : α} (ha : a ≤ 1) 
+  (hbz : 0 ≤ b) (hb : b < 1) : a * b < 1 := 
+if hb' : b = 0 then by simpa [hb'] using zero_lt_one 
+else if ha' : a = 1 then by simpa [ha']
+else mul_lt_one (lt_of_le_of_ne hbz (ne.symm hb')) (lt_of_le_of_ne ha ha') hb
+
+lemma maximal_ideal_mul {z1 z2 : ℤ_[hp]} (hz2 : ∥z2∥ < 1) : ∥z1 * z2∥ < 1 := 
+calc  ∥z1 * z2∥ = ∥z1∥ * ∥z2∥ : by simp 
+           ... < 1 : mul_lt_one_of_le_of_lt (padic_norm_z.le_one _) (norm_nonneg _) hz2
+
+instance : is_submodule (maximal_ideal hp) :=
+{ zero_ := show ∥(0 : ℤ_[hp])∥ < 1, by simp [zero_lt_one],
+  add_ := @maximal_ideal_add _ _,
+  smul := @maximal_ideal_mul _ _ }
+
+lemma maximal_ideal_ne_univ : maximal_ideal hp ≠ set.univ := 
+mt set.eq_univ_iff_forall.mp 
+  begin
+    rw [not_forall],
+    existsi (1 : ℤ_[hp]),
+    change ¬ (_ < _),
+    apply not_lt_of_ge,
+    simp, apply le_refl 
+  end  
+
+lemma maximal_ideal_eq_nonunits : maximal_ideal hp = nonunits _ :=
+begin 
+  ext,
+  constructor,
+  { intros hx hex,
+    cases hex with y hy,
+    have hym : ∥(y*x)∥ < 1, from is_submodule.smul _ hx,
+    apply lt_irrefl (1 : ℝ),
+    rw hy at hym, simpa using hym },
+  { intro hx,
+    by_contradiction hnm,
+    apply hx,
+    have : ∥x∥ = 1, from le_antisymm (padic_norm_z.le_one _) (le_of_not_gt hnm),
+    existsi x.inv, apply inv_mul this }
+end  
+
+instance : is_proper_ideal (maximal_ideal hp) :=
+{ ne_univ := maximal_ideal_ne_univ }
+
+lemma maximal_ideal_eq_or_univ_of_subset (T : set ℤ_[hp]) [_inst_2 : is_ideal T]
+      (hss : maximal_ideal hp ⊆ T) : T = maximal_ideal hp ∨ T = set.univ :=
+have T ≠ maximal_ideal hp → T = set.univ, from
+  (assume h : T ≠ maximal_ideal hp,
+   let ⟨k, hkt, hknm⟩ := set.exists_of_ssubset ⟨hss, ne.symm h⟩ in 
+   set.eq_univ_of_forall $ λ z,
+     have hknm : ∥k∥ = 1, from le_antisymm (padic_norm_z.le_one _) (le_of_not_gt hknm),
+     have hkzt : z*k ∈ T, from is_submodule.smul _ hkt,
+     have hkzt' : (inv k)*(z*k) ∈ T, from is_submodule.smul _ hkzt,
+     by rw [mul_comm, mul_assoc, mul_inv] at hkzt'; simpa using hkzt'),
+if hT : T = maximal_ideal hp then or.inl hT else or.inr (this hT) 
+
+instance : is_maximal_ideal (maximal_ideal hp) := 
+{ eq_or_univ_of_subset := maximal_ideal_eq_or_univ_of_subset }
+
+lemma maximal_ideal_unique (T : set ℤ_[hp]) [_inst_2 : is_maximal_ideal T] : maximal_ideal hp = T :=
+let htmax := @is_maximal_ideal.eq_or_univ_of_subset _ _ T _ (maximal_ideal hp) _ in 
+have htsub : T ⊆ maximal_ideal hp, 
+  by rw maximal_ideal_eq_nonunits; apply not_unit_of_mem_proper_ideal,
+or.resolve_right (htmax htsub) maximal_ideal_ne_univ
+
+instance : local_ring ℤ_[hp] :=
+{ S := maximal_ideal hp,
+  max := by apply_instance,
+  unique := maximal_ideal_unique }
+
+end padic_int

--- a/data/padics/padic_integers.lean
+++ b/data/padics/padic_integers.lean
@@ -72,7 +72,7 @@ instance : has_coe ℤ_[hp] ℚ_[hp] := ⟨subtype.val⟩
 
 @[simp] lemma coe_one : (↑(1 : ℤ_[hp]) : ℚ_[hp]) = 1 := rfl 
 
-lemma mk_coe : ∀ (k : ℤ_[hp]) /-{p : @padic_norm_e _ hp ↑k ≤ 1}-/, (⟨↑k, k.2⟩ : ℤ_[hp]) = k
+lemma mk_coe : ∀ (k : ℤ_[hp]), (⟨↑k, k.2⟩ : ℤ_[hp]) = k
 | ⟨_, _⟩ := rfl
 
 def inv : ℤ_[hp] → ℤ_[hp]
@@ -110,7 +110,8 @@ instance : comm_ring ℤ_[hp] :=
 protected lemma padic_int.zero_ne_one : (0 : ℤ_[hp]) ≠ 1 := 
 show (⟨(0 : ℚ_[hp]), _⟩ : ℤ_[hp]) ≠ ⟨(1 : ℚ_[hp]), _⟩, from mt subtype.ext.1 zero_ne_one
 
-protected lemma padic_int.eq_zero_or_eq_zero_of_mul_eq_zero : ∀ (a b : ℤ_[hp]), a * b = 0 → a = 0 ∨ b = 0
+protected lemma padic_int.eq_zero_or_eq_zero_of_mul_eq_zero : 
+          ∀ (a b : ℤ_[hp]), a * b = 0 → a = 0 ∨ b = 0
 | ⟨a, ha⟩ ⟨b, hb⟩ := λ h : (⟨a * b, _⟩ : ℤ_[hp]) = ⟨0, _⟩, 
 have a * b = 0, from subtype.ext.1 h,
 (mul_eq_zero_iff_eq_zero_or_eq_zero.1 this).elim

--- a/data/padics/padic_integers.lean
+++ b/data/padics/padic_integers.lean
@@ -6,7 +6,7 @@ Authors: Robert Y. Lewis
 Define the p-adic integers ℤ_p as a subtype of ℚ_p. Construct algebraic structures on ℤ_p.
 -/
 
-import data.padics.padic_rationals tactic.subtype_instance ring_theory.ideals
+import data.padics.padic_rationals tactic.subtype_instance ring_theory.ideals data.int.modeq
 open nat padic
 noncomputable theory
 local attribute [instance] classical.prop_decidable
@@ -14,22 +14,22 @@ local attribute [instance] classical.prop_decidable
 def padic_int {p : ℕ} (hp : prime p) := {x : ℚ_[hp] // ∥x∥ ≤ 1}
 notation `ℤ_[`hp`]` := padic_int hp
 
-namespace padic_int 
+namespace padic_int
 variables {p : ℕ} {hp : prime p}
 
 def add : ℤ_[hp] → ℤ_[hp] → ℤ_[hp]
-| ⟨x, hx⟩ ⟨y, hy⟩ := ⟨x+y, 
+| ⟨x, hx⟩ ⟨y, hy⟩ := ⟨x+y,
     le_trans (padic_norm_e.nonarchimedean _ _) (max_le_iff.2 ⟨hx,hy⟩)⟩
 
 def mul : ℤ_[hp] → ℤ_[hp] → ℤ_[hp]
-| ⟨x, hx⟩ ⟨y, hy⟩ := ⟨x*y, 
+| ⟨x, hx⟩ ⟨y, hy⟩ := ⟨x*y,
     begin rw padic_norm_e.mul, apply mul_le_one; {assumption <|> apply norm_nonneg} end⟩
 
 def neg : ℤ_[hp] → ℤ_[hp]
 | ⟨x, hx⟩ := ⟨-x, by simpa⟩
 
 instance : ring ℤ_[hp] :=
-begin 
+begin
   refine { add := add,
            mul := mul,
            neg := neg,
@@ -37,15 +37,15 @@ begin
            one := ⟨1, by simp⟩,
            .. };
   {repeat {rintro ⟨_, _⟩}, simp [mul_assoc, left_distrib, right_distrib, add, mul, neg]}
-end 
+end
 
-lemma zero_def : ∀ x : ℤ_[hp], x = 0 ↔ x.val = 0 
+lemma zero_def : ∀ x : ℤ_[hp], x = 0 ↔ x.val = 0
 | ⟨x, _⟩ := ⟨subtype.mk.inj, λ h, by simp at h; simp only [h]; refl⟩
 
-@[simp] lemma add_def : ∀ (x y : ℤ_[hp]), (x+y).val = x.val + y.val 
+@[simp] lemma add_def : ∀ (x y : ℤ_[hp]), (x+y).val = x.val + y.val
 | ⟨x, hx⟩ ⟨y, hy⟩ := rfl
 
-@[simp] lemma mul_def : ∀ (x y : ℤ_[hp]), (x*y).val = x.val * y.val 
+@[simp] lemma mul_def : ∀ (x y : ℤ_[hp]), (x*y).val = x.val * y.val
 | ⟨x, hx⟩ ⟨y, hy⟩ := rfl
 
 @[simp] lemma mk_zero {h} : (⟨0, h⟩ : ℤ_[hp]) = (0 : ℤ_[hp]) := rfl
@@ -54,23 +54,23 @@ instance : has_coe ℤ_[hp] ℚ_[hp] := ⟨subtype.val⟩
 
 @[simp] lemma val_eq_coe (z : ℤ_[hp]) : z.val = ↑z := rfl
 
-@[simp] lemma coe_add : ∀ (z1 z2 : ℤ_[hp]), (↑(z1 + z2) : ℚ_[hp]) = ↑z1 + ↑z2 
+@[simp] lemma coe_add : ∀ (z1 z2 : ℤ_[hp]), (↑(z1 + z2) : ℚ_[hp]) = ↑z1 + ↑z2
 | ⟨_, _⟩ ⟨_, _⟩ := rfl
 
-@[simp] lemma coe_mul : ∀ (z1 z2 : ℤ_[hp]), (↑(z1 * z2) : ℚ_[hp]) = ↑z1 * ↑z2 
+@[simp] lemma coe_mul : ∀ (z1 z2 : ℤ_[hp]), (↑(z1 * z2) : ℚ_[hp]) = ↑z1 * ↑z2
 | ⟨_, _⟩ ⟨_, _⟩ := rfl
 
 @[simp] lemma coe_neg : ∀ (z1 : ℤ_[hp]), (↑(-z1) : ℚ_[hp]) = -↑z1
 | ⟨_, _⟩ := rfl
 
-@[simp] lemma coe_sub : ∀ (z1 z2 : ℤ_[hp]), (↑(z1 - z2) : ℚ_[hp]) = ↑z1 - ↑z2 
+@[simp] lemma coe_sub : ∀ (z1 z2 : ℤ_[hp]), (↑(z1 - z2) : ℚ_[hp]) = ↑z1 - ↑z2
 | ⟨_, _⟩ ⟨_, _⟩ := rfl
 
 @[simp] lemma coe_coe : ∀ n : ℕ, (↑(↑n : ℤ_[hp]) : ℚ_[hp]) = (↑n : ℚ_[hp])
 | 0 := rfl
 | (k+1) := by simp [coe_coe]; refl
 
-@[simp] lemma coe_one : (↑(1 : ℤ_[hp]) : ℚ_[hp]) = 1 := rfl 
+@[simp] lemma coe_one : (↑(1 : ℤ_[hp]) : ℚ_[hp]) = 1 := rfl
 
 lemma mk_coe : ∀ (k : ℤ_[hp]), (⟨↑k, k.2⟩ : ℤ_[hp]) = k
 | ⟨_, _⟩ := rfl
@@ -78,45 +78,45 @@ lemma mk_coe : ∀ (k : ℤ_[hp]), (⟨↑k, k.2⟩ : ℤ_[hp]) = k
 def inv : ℤ_[hp] → ℤ_[hp]
 | ⟨k, _⟩ := if h : ∥k∥ = 1 then ⟨1/k, by simp [h]⟩ else 0
 
-end padic_int 
+end padic_int
 
 section instances
 variables {p : ℕ} {hp : p.prime}
 
 @[reducible] def padic_norm_z (z : ℤ_[hp]) : ℝ := ∥z.val∥
 
-instance : metric_space ℤ_[hp] := 
+instance : metric_space ℤ_[hp] :=
 subtype.metric_space
- 
-instance : has_norm ℤ_[hp] := ⟨padic_norm_z⟩ 
+
+instance : has_norm ℤ_[hp] := ⟨padic_norm_z⟩
 
 instance : normed_ring ℤ_[hp] :=
 { dist_eq := λ ⟨_, _⟩ ⟨_, _⟩, rfl,
   norm_mul := λ ⟨_, _⟩ ⟨_, _⟩, norm_mul _ _ }
 
-instance padic_norm_z.is_absolute_value {p} {hp : prime p} : is_absolute_value (λ z : ℤ_[hp], ∥z∥) := 
+instance padic_norm_z.is_absolute_value {p} {hp : prime p} : is_absolute_value (λ z : ℤ_[hp], ∥z∥) :=
 { abv_nonneg := norm_nonneg,
   abv_eq_zero := λ ⟨_, _⟩, by simp [norm_eq_zero, padic_int.zero_def],
   abv_add := λ ⟨_,_⟩ ⟨_, _⟩, norm_triangle _ _,
   abv_mul := λ _ _, by unfold norm; simp [padic_norm_z] }
 
-protected lemma padic_int.pmul_comm : ∀ z1 z2 : ℤ_[hp], z1*z2 = z2*z1 
+protected lemma padic_int.pmul_comm : ∀ z1 z2 : ℤ_[hp], z1*z2 = z2*z1
 | ⟨q1, h1⟩ ⟨q2, h2⟩ := show (⟨q1*q2, _⟩ : ℤ_[hp]) = ⟨q2*q1, _⟩, by simp [mul_comm]
 
 instance : comm_ring ℤ_[hp] :=
 { mul_comm := padic_int.pmul_comm,
   ..padic_int.ring }
 
-protected lemma padic_int.zero_ne_one : (0 : ℤ_[hp]) ≠ 1 := 
+protected lemma padic_int.zero_ne_one : (0 : ℤ_[hp]) ≠ 1 :=
 show (⟨(0 : ℚ_[hp]), _⟩ : ℤ_[hp]) ≠ ⟨(1 : ℚ_[hp]), _⟩, from mt subtype.ext.1 zero_ne_one
 
-protected lemma padic_int.eq_zero_or_eq_zero_of_mul_eq_zero : 
+protected lemma padic_int.eq_zero_or_eq_zero_of_mul_eq_zero :
           ∀ (a b : ℤ_[hp]), a * b = 0 → a = 0 ∨ b = 0
-| ⟨a, ha⟩ ⟨b, hb⟩ := λ h : (⟨a * b, _⟩ : ℤ_[hp]) = ⟨0, _⟩, 
+| ⟨a, ha⟩ ⟨b, hb⟩ := λ h : (⟨a * b, _⟩ : ℤ_[hp]) = ⟨0, _⟩,
 have a * b = 0, from subtype.ext.1 h,
 (mul_eq_zero_iff_eq_zero_or_eq_zero.1 this).elim
   (λ h1, or.inl (by simp [h1]; refl))
-  (λ h2, or.inr (by simp [h2]; refl)) 
+  (λ h2, or.inr (by simp [h2]; refl))
 
 instance {p : ℕ} {hp : prime p} : integral_domain ℤ_[hp] :=
 { eq_zero_or_eq_zero_of_mul_eq_zero := padic_int.eq_zero_or_eq_zero_of_mul_eq_zero,
@@ -129,7 +129,7 @@ namespace padic_norm_z
 
 variables {p : ℕ} {hp : p.prime}
 
-lemma le_one : ∀ z : ℤ_[hp], ∥z∥ ≤ 1 
+lemma le_one : ∀ z : ℤ_[hp], ∥z∥ ≤ 1
 | ⟨_, h⟩ := h
 
 @[simp] lemma mul (z1 z2 : ℤ_[hp]) : ∥z1 * z2∥ = ∥z1∥ * ∥z2∥ :=
@@ -138,30 +138,30 @@ by unfold norm; simp [padic_norm_z]
 theorem nonarchimedean : ∀ (q r : ℤ_[hp]), ∥q + r∥ ≤ max (∥q∥) (∥r∥)
 | ⟨_, _⟩ ⟨_, _⟩ := padic_norm_e.nonarchimedean _ _
 
-@[simp] lemma norm_one : ∥(1 : ℤ_[hp])∥ = 1 := norm_one 
+@[simp] lemma norm_one : ∥(1 : ℤ_[hp])∥ = 1 := norm_one
 
-end padic_norm_z 
+end padic_norm_z
 
-namespace padic_int 
+namespace padic_int
 variables {p : ℕ} {hp : p.prime}
-local attribute [reducible] padic_int 
+local attribute [reducible] padic_int
 
-lemma mul_inv : ∀ {z : ℤ_[hp]}, ∥z∥ = 1 → z * z.inv = 1 
-| ⟨k, _⟩ h := 
+lemma mul_inv : ∀ {z : ℤ_[hp]}, ∥z∥ = 1 → z * z.inv = 1
+| ⟨k, _⟩ h :=
   begin
     have hk : k ≠ 0, from λ h', @zero_ne_one ℚ_[hp] _ (by simpa [h'] using h),
-    unfold padic_int.inv, split_ifs, 
+    unfold padic_int.inv, split_ifs,
     { change (⟨k * (1/k), _⟩ : ℤ_[hp]) = 1,
       simp [hk], refl },
     { apply subtype.ext.2, simp [mul_inv_cancel hk] }
-  end 
+  end
 
-lemma inv_mul {z : ℤ_[hp]} (hz : ∥z∥ = 1) : z.inv * z = 1 := 
+lemma inv_mul {z : ℤ_[hp]} (hz : ∥z∥ = 1) : z.inv * z = 1 :=
 by rw [mul_comm, mul_inv hz]
 
 def maximal_ideal {p : ℕ} (hp : prime p) : set ℤ_[hp] := λ z, ∥z∥ < 1
 
-lemma maximal_ideal_add {z1 z2 : ℤ_[hp]} (hz1 : ∥z1∥ < 1) (hz2 : ∥z2∥ < 1) : ∥z1 + z2∥ < 1 := 
+lemma maximal_ideal_add {z1 z2 : ℤ_[hp]} (hz1 : ∥z1∥ < 1) (hz2 : ∥z2∥ < 1) : ∥z1 + z2∥ < 1 :=
 lt_of_le_of_lt (padic_norm_z.nonarchimedean _ _) (max_lt hz1 hz2)
 
 private lemma mul_lt_one  {α} [decidable_linear_ordered_comm_ring α] {a b : α} (hbz : 0 < b)
@@ -169,14 +169,14 @@ private lemma mul_lt_one  {α} [decidable_linear_ordered_comm_ring α] {a b : α
 suffices a*b < 1*1, by simpa,
 mul_lt_mul ha (le_of_lt hb) hbz zero_le_one
 
-private lemma mul_lt_one_of_le_of_lt {α} [decidable_linear_ordered_comm_ring α] {a b : α} (ha : a ≤ 1) 
-  (hbz : 0 ≤ b) (hb : b < 1) : a * b < 1 := 
-if hb' : b = 0 then by simpa [hb'] using zero_lt_one 
+private lemma mul_lt_one_of_le_of_lt {α} [decidable_linear_ordered_comm_ring α] {a b : α} (ha : a ≤ 1)
+  (hbz : 0 ≤ b) (hb : b < 1) : a * b < 1 :=
+if hb' : b = 0 then by simpa [hb'] using zero_lt_one
 else if ha' : a = 1 then by simpa [ha']
 else mul_lt_one (lt_of_le_of_ne hbz (ne.symm hb')) (lt_of_le_of_ne ha ha') hb
 
-lemma maximal_ideal_mul {z1 z2 : ℤ_[hp]} (hz2 : ∥z2∥ < 1) : ∥z1 * z2∥ < 1 := 
-calc  ∥z1 * z2∥ = ∥z1∥ * ∥z2∥ : by simp 
+lemma maximal_ideal_mul {z1 z2 : ℤ_[hp]} (hz2 : ∥z2∥ < 1) : ∥z1 * z2∥ < 1 :=
+calc  ∥z1 * z2∥ = ∥z1∥ * ∥z2∥ : by simp
            ... < 1 : mul_lt_one_of_le_of_lt (padic_norm_z.le_one _) (norm_nonneg _) hz2
 
 instance : is_submodule (maximal_ideal hp) :=
@@ -184,18 +184,18 @@ instance : is_submodule (maximal_ideal hp) :=
   add_ := @maximal_ideal_add _ _,
   smul := @maximal_ideal_mul _ _ }
 
-lemma maximal_ideal_ne_univ : maximal_ideal hp ≠ set.univ := 
-mt set.eq_univ_iff_forall.mp 
+lemma maximal_ideal_ne_univ : maximal_ideal hp ≠ set.univ :=
+mt set.eq_univ_iff_forall.mp
   begin
     rw [not_forall],
     existsi (1 : ℤ_[hp]),
     change ¬ (_ < _),
     apply not_lt_of_ge,
-    simp, apply le_refl 
-  end  
+    simp, apply le_refl
+  end
 
 lemma maximal_ideal_eq_nonunits : maximal_ideal hp = nonunits _ :=
-begin 
+begin
   ext,
   constructor,
   { intros hx hex,
@@ -208,7 +208,7 @@ begin
     apply hx,
     have : ∥x∥ = 1, from le_antisymm (padic_norm_z.le_one _) (le_of_not_gt hnm),
     existsi x.inv, apply inv_mul this }
-end  
+end
 
 instance : is_proper_ideal (maximal_ideal hp) :=
 { ne_univ := maximal_ideal_ne_univ }
@@ -217,20 +217,20 @@ lemma maximal_ideal_eq_or_univ_of_subset (T : set ℤ_[hp]) [_inst_2 : is_ideal 
       (hss : maximal_ideal hp ⊆ T) : T = maximal_ideal hp ∨ T = set.univ :=
 have T ≠ maximal_ideal hp → T = set.univ, from
   (assume h : T ≠ maximal_ideal hp,
-   let ⟨k, hkt, hknm⟩ := set.exists_of_ssubset ⟨hss, ne.symm h⟩ in 
+   let ⟨k, hkt, hknm⟩ := set.exists_of_ssubset ⟨hss, ne.symm h⟩ in
    set.eq_univ_of_forall $ λ z,
      have hknm : ∥k∥ = 1, from le_antisymm (padic_norm_z.le_one _) (le_of_not_gt hknm),
      have hkzt : z*k ∈ T, from is_submodule.smul _ hkt,
      have hkzt' : (inv k)*(z*k) ∈ T, from is_submodule.smul _ hkzt,
      by rw [mul_comm, mul_assoc, mul_inv] at hkzt'; simpa using hkzt'),
-if hT : T = maximal_ideal hp then or.inl hT else or.inr (this hT) 
+if hT : T = maximal_ideal hp then or.inl hT else or.inr (this hT)
 
-instance : is_maximal_ideal (maximal_ideal hp) := 
+instance : is_maximal_ideal (maximal_ideal hp) :=
 { eq_or_univ_of_subset := maximal_ideal_eq_or_univ_of_subset }
 
 lemma maximal_ideal_unique (T : set ℤ_[hp]) [_inst_2 : is_maximal_ideal T] : maximal_ideal hp = T :=
-let htmax := @is_maximal_ideal.eq_or_univ_of_subset _ _ T _ (maximal_ideal hp) _ in 
-have htsub : T ⊆ maximal_ideal hp, 
+let htmax := @is_maximal_ideal.eq_or_univ_of_subset _ _ T _ (maximal_ideal hp) _ in
+have htsub : T ⊆ maximal_ideal hp,
   by rw maximal_ideal_eq_nonunits; apply not_unit_of_mem_proper_ideal,
 or.resolve_right (htmax htsub) maximal_ideal_ne_univ
 
@@ -239,4 +239,30 @@ instance : local_ring ℤ_[hp] :=
   max := by apply_instance,
   unique := maximal_ideal_unique }
 
+private def cau_seq_to_rat_cau_seq (f : cau_seq ℤ_[hp] (λ a, ∥a∥)) :
+  cau_seq ℚ_[hp] (λ a, ∥a∥) :=
+⟨ λ n, f n,
+  λ _ hε, by simpa [norm, padic_norm_z] using f.cauchy hε ⟩
+
+theorem padic_int.complete (f : cau_seq ℤ_[hp] (λ a, ∥a∥)) :
+  ∃ z : ℤ_[hp], ∀ ε > 0, ∃ N, ∀ i ≥ N, ∥z - f i∥ < ε :=
+have hqn : ∥padic.cau_seq_lim (cau_seq_to_rat_cau_seq f)∥ ≤ 1,
+  from padic_norm_e_lim_le zero_lt_one (λ _, padic_norm_z.le_one _),
+⟨ ⟨_, hqn⟩,
+  by simpa [norm, padic_norm_z] using padic.cau_seq_lim_spec (cau_seq_to_rat_cau_seq f) ⟩
+
 end padic_int
+
+namespace padic_norm_z
+variables {p : ℕ} {hp : p.prime}
+
+lemma padic_val_of_cong_pow_p {z1 z2 : ℤ} {n : ℕ} (hz : z1 ≡ z2 [ZMOD ↑(p^n)]) :
+      ∥(z1 - z2 : ℚ_[hp])∥ ≤ ↑(fpow ↑p (-n) : ℚ) :=
+have hdvd : ↑(p^n) ∣ z2 - z1, from int.modeq.modeq_iff_dvd.1 hz,
+have (↑(z2 - z1) : ℚ_[hp]) = padic.of_rat hp ↑(z2 - z1), by simp,
+begin
+  rw [norm_sub_rev, ←int.cast_sub, this, padic_norm_e.eq_padic_norm],
+  simpa using padic_norm.le_of_dvd hp hdvd
+end
+
+end padic_norm_z

--- a/data/padics/padic_integers.lean
+++ b/data/padics/padic_integers.lean
@@ -202,7 +202,7 @@ begin
     cases hex with y hy,
     have hym : ∥(y*x)∥ < 1, from is_submodule.smul _ hx,
     apply lt_irrefl (1 : ℝ),
-    rw hy at hym, simpa using hym },
+    simpa [hy] using hym },
   { intro hx,
     by_contradiction hnm,
     apply hx,
@@ -213,7 +213,7 @@ end
 instance : is_proper_ideal (maximal_ideal hp) :=
 { ne_univ := maximal_ideal_ne_univ }
 
-lemma maximal_ideal_eq_or_univ_of_subset (T : set ℤ_[hp]) [_inst_2 : is_ideal T]
+lemma maximal_ideal_eq_or_univ_of_subset (T : set ℤ_[hp]) [is_ideal T]
       (hss : maximal_ideal hp ⊆ T) : T = maximal_ideal hp ∨ T = set.univ :=
 have T ≠ maximal_ideal hp → T = set.univ, from
   (assume h : T ≠ maximal_ideal hp,
@@ -228,7 +228,7 @@ if hT : T = maximal_ideal hp then or.inl hT else or.inr (this hT)
 instance : is_maximal_ideal (maximal_ideal hp) :=
 { eq_or_univ_of_subset := maximal_ideal_eq_or_univ_of_subset }
 
-lemma maximal_ideal_unique (T : set ℤ_[hp]) [_inst_2 : is_maximal_ideal T] : maximal_ideal hp = T :=
+lemma maximal_ideal_unique (T : set ℤ_[hp]) [is_maximal_ideal T] : maximal_ideal hp = T :=
 let htmax := @is_maximal_ideal.eq_or_univ_of_subset _ _ T _ (maximal_ideal hp) _ in
 have htsub : T ⊆ maximal_ideal hp,
   by rw maximal_ideal_eq_nonunits; apply not_unit_of_mem_proper_ideal,

--- a/data/padics/padic_norm.lean
+++ b/data/padics/padic_norm.lean
@@ -219,6 +219,9 @@ by simp [padic_val_rat, *]
 @[simp] lemma padic_val_rat_self : padic_val_rat p p = 1 :=
 by simp [padic_val_rat, hp]
 
+lemma padic_val_rat_of_int (z : ℤ) : padic_val_rat p ↑z = padic_val p z := 
+by simp [padic_val_rat, rat.coe_int_denom, padic_val.one hp]
+
 end padic_val_rat
 
 section padic_val_rat
@@ -465,6 +468,21 @@ instance : is_absolute_value (padic_norm hp) :=
     end,
   abv_add := padic_norm.triangle_ineq hp,
   abv_mul := padic_norm.mul hp }
+
+lemma le_of_dvd {n : ℕ} {z : ℤ} (hd : ↑(p^n) ∣ z) : padic_norm hp z ≤ fpow ↑p (-n) := 
+have hp' : (↑p : ℚ) ≥ 1, from show ↑p ≥ ↑(1 : ℕ), from cast_le.2 (le_of_lt hp.gt_one),
+have hpn : (↑p : ℚ) ≥ 0, from le_trans zero_le_one hp',
+begin 
+  unfold padic_norm, split_ifs with hz hz,
+  { simpa [padic_norm, hz] using fpow_nonneg_of_nonneg hpn _ },
+  { apply fpow_le_of_le hp',
+    apply neg_le_neg,
+    rw padic_val_rat_of_int hp.gt_one _,
+    apply int.coe_nat_le.2,
+    apply padic_val.le_padic_val_of_pow_dvd hp.gt_one,
+    { simpa using hz },
+    { assumption }}
+end 
 
 end padic_norm
 end padic_norm

--- a/data/padics/padic_rationals.lean
+++ b/data/padics/padic_rationals.lean
@@ -8,7 +8,7 @@ Show that the p-adic norm extends to ℚ_p, that ℚ is embedded in ℚ_p, and t
 -/
 
 import data.real.cau_seq_completion data.padics.padic_norm algebra.archimedean analysis.normed_space
-noncomputable theory 
+noncomputable theory
 local attribute [instance] classical.prop_decidable
 
 open nat padic_val padic_norm cau_seq cau_seq.completion
@@ -17,36 +17,36 @@ open nat padic_val padic_norm cau_seq cau_seq.completion
 
 namespace padic_seq
 
-section 
+section
 variables {p : ℕ} {hp : prime p}
 
-lemma stationary {f : cau_seq ℚ (padic_norm hp)} (hf : ¬ f ≈ 0) : 
+lemma stationary {f : cau_seq ℚ (padic_norm hp)} (hf : ¬ f ≈ 0) :
       ∃ N, ∀ m n, m ≥ N → n ≥ N → padic_norm hp (f n) = padic_norm hp (f m) :=
-have ∃ ε > 0, ∃ N1, ∀ j ≥ N1, ε ≤ padic_norm hp (f j), 
+have ∃ ε > 0, ∃ N1, ∀ j ≥ N1, ε ≤ padic_norm hp (f j),
   from cau_seq.abv_pos_of_not_lim_zero $ not_lim_zero_of_not_congr_zero hf,
 let ⟨ε, hε, N1, hN1⟩ := this,
     ⟨N2, hN2⟩ := cau_seq.cauchy₂ f hε in
 ⟨ max N1 N2,
-  λ n m hn hm, 
+  λ n m hn hm,
   have padic_norm hp (f n - f m) < ε, from hN2 _ _ (max_le_iff.1 hn).2 (max_le_iff.1 hm).2,
-  have padic_norm hp (f n - f m) < padic_norm hp (f n), 
+  have padic_norm hp (f n - f m) < padic_norm hp (f n),
     from lt_of_lt_of_le this $ hN1 _ (max_le_iff.1 hn).1,
   have  padic_norm hp (f n - f m) < max (padic_norm hp (f n)) (padic_norm hp (f m)),
     from lt_max_iff.2 (or.inl this),
-  begin 
+  begin
     by_contradiction hne,
     rw ←padic_norm.neg hp (f m) at hne,
     have hnam := add_eq_max_of_ne hp hne,
     rw [padic_norm.neg, max_comm] at hnam,
     rw ←hnam at this,
     apply _root_.lt_irrefl _ (by simp at this; exact this)
-  end ⟩ 
+  end ⟩
 
 def stationary_point {f : padic_seq hp} (hf : ¬ f ≈ 0) : ℕ :=
 classical.some $ stationary hf
 
 lemma stationary_point_spec {f : padic_seq hp} (hf : ¬ f ≈ 0) :
-      ∀ {m n}, m ≥ stationary_point hf → n ≥ stationary_point hf → 
+      ∀ {m n}, m ≥ stationary_point hf → n ≥ stationary_point hf →
                  padic_norm hp (f n) = padic_norm hp (f m) :=
 classical.some_spec $ stationary hf
 
@@ -55,7 +55,7 @@ if hf : f ≈ 0 then 0
 else padic_norm hp (f (stationary_point hf))
 
 lemma norm_zero_iff (f : padic_seq hp) : f.norm = 0 ↔ f ≈ 0 :=
-begin 
+begin
   constructor,
   { intro h,
     by_contradiction hf,
@@ -68,12 +68,12 @@ begin
     simpa [h, heq] },
   { intro h,
     simp [norm, h] }
-end 
+end
 
-end 
+end
 
 section embedding
-open cau_seq 
+open cau_seq
 variables {p : ℕ} {hp : prime p}
 
 lemma equiv_zero_of_val_eq_of_equiv_zero {f g : padic_seq hp}
@@ -81,7 +81,7 @@ lemma equiv_zero_of_val_eq_of_equiv_zero {f g : padic_seq hp}
 λ ε hε, let ⟨i, hi⟩ := hf _ hε in
 ⟨i, λ j hj, by simpa [h] using hi _ hj⟩
 
-lemma norm_nonzero_of_not_equiv_zero {f : padic_seq hp} (hf : ¬ f ≈ 0) : 
+lemma norm_nonzero_of_not_equiv_zero {f : padic_seq hp} (hf : ¬ f ≈ 0) :
       f.norm ≠ 0 :=
 hf ∘ f.norm_zero_iff.1
 
@@ -92,23 +92,23 @@ have heq : f.norm = padic_norm hp (f $ stationary_point hf), by simp [norm, hf],
   λ h, norm_nonzero_of_not_equiv_zero hf (by simpa [h] using heq)⟩
 
 lemma not_lim_zero_const_of_nonzero {q : ℚ} (hq : q ≠ 0) : ¬ lim_zero (const (padic_norm hp) q) :=
-λ h', hq $ const_lim_zero.1 h' 
+λ h', hq $ const_lim_zero.1 h'
 
 lemma not_equiv_zero_const_of_nonzero {q : ℚ} (hq : q ≠ 0) : ¬ (const (padic_norm hp) q) ≈ 0 :=
 λ h : lim_zero (const (padic_norm hp) q - 0), not_lim_zero_const_of_nonzero hq $ by simpa using h
 
 lemma norm_nonneg (f : padic_seq hp) : f.norm ≥ 0 :=
 if hf : f ≈ 0 then by simp [hf, norm]
-else by simp [norm, hf, padic_norm.nonneg] 
+else by simp [norm, hf, padic_norm.nonneg]
 
 lemma norm_mul (f g : padic_seq hp) : (f * g).norm = f.norm * g.norm :=
-if hf : f ≈ 0 then 
+if hf : f ≈ 0 then
   have hg : f * g ≈ 0, from mul_equiv_zero' _ hf,
   by simp [hf, hg, norm]
 else if hg : g ≈ 0 then
   have hf : f * g ≈ 0, from mul_equiv_zero _ hg,
   by simp [hf, hg, norm]
-else 
+else
   have hfg : ¬ f * g ≈ 0, by apply mul_not_equiv_zero; assumption,
   let i := max (stationary_point hfg) (max (stationary_point hf) (stationary_point hg)) in
   have hpnfg : padic_norm hp ((f * g) (stationary_point hfg)) = padic_norm hp ((f * g) i),
@@ -127,12 +127,12 @@ else
     apply le_max_right,
     apply le_max_right,
     apply le_refl },
-  begin 
+  begin
     unfold norm,
     split_ifs,
     rw [hpnfg, hpnf, hpng],
     apply padic_norm.mul hp
-  end 
+  end
 
 lemma eq_zero_iff_equiv_zero (f : padic_seq hp) : mk f = 0 ↔ f ≈ 0 :=
 mk_eq
@@ -141,13 +141,13 @@ lemma ne_zero_iff_nequiv_zero (f : padic_seq hp) : mk f ≠ 0 ↔ ¬ f ≈ 0 :=
 not_iff_not.2 (eq_zero_iff_equiv_zero _)
 
 lemma norm_const (q : ℚ) : norm (const (padic_norm hp) q) = padic_norm hp q :=
-if hq : q = 0 then 
-  have (const (padic_norm hp) q) ≈ 0, 
+if hq : q = 0 then
+  have (const (padic_norm hp) q) ≈ 0,
     by simp [hq]; apply setoid.refl (const (padic_norm hp) 0),
   by subst hq; simp [norm, this]
-else 
+else
   have ¬ (const (padic_norm hp) q) ≈ 0, from not_equiv_zero_const_of_nonzero hq,
-  by simp [norm, this] 
+  by simp [norm, this]
 
 lemma norm_image (a : padic_seq hp) (ha : ¬ a ≈ 0) :
       (∃ (n : ℤ), a.norm = fpow ↑p (-n)) :=
@@ -158,16 +158,16 @@ lemma norm_one : norm (1 : padic_seq hp) = 1 :=
 have h1 : ¬ (1 : padic_seq hp) ≈ 0, from one_not_equiv_zero _,
 by simp [h1, norm, hp.gt_one]
 
-private lemma norm_eq_of_equiv_aux {f g : padic_seq hp} (hf : ¬ f ≈ 0) (hg : ¬ g ≈ 0) (hfg : f ≈ g) 
-        (h : padic_norm hp (f (stationary_point hf)) ≠ padic_norm hp (g (stationary_point hg))) 
+private lemma norm_eq_of_equiv_aux {f g : padic_seq hp} (hf : ¬ f ≈ 0) (hg : ¬ g ≈ 0) (hfg : f ≈ g)
+        (h : padic_norm hp (f (stationary_point hf)) ≠ padic_norm hp (g (stationary_point hg)))
         (hgt : padic_norm hp (f (stationary_point hf)) > padic_norm hp (g (stationary_point hg))) :
         false :=
-begin 
+begin
   have hpn : padic_norm hp (f (stationary_point hf)) - padic_norm hp (g (stationary_point hg)) > 0,
     from sub_pos_of_lt hgt,
   cases hfg _ hpn with N hN,
   let i := max N (max (stationary_point hf) (stationary_point hg)),
-  have hfi : padic_norm hp (f (stationary_point hf)) = padic_norm hp (f i), 
+  have hfi : padic_norm hp (f (stationary_point hf)) = padic_norm hp (f i),
   { apply stationary_point_spec hf,
     { apply le_trans,
       apply le_max_left,
@@ -184,10 +184,10 @@ begin
   have hi : i ≥ N, from le_max_left _ _,
   have hN' := hN _ hi,
   simp only [hfi, hgi] at hN',
-  have hpne : padic_norm hp (f i) ≠ padic_norm hp (-(g i)), 
+  have hpne : padic_norm hp (f i) ≠ padic_norm hp (-(g i)),
     by rwa [hfi, hgi, ←padic_norm.neg hp (g i)] at h,
   let hpnem := add_eq_max_of_ne hp hpne,
-  have hpeq : padic_norm hp ((f - g) i) = max (padic_norm hp (f i)) (padic_norm hp (g i)), 
+  have hpeq : padic_norm hp ((f - g) i) = max (padic_norm hp (f i)) (padic_norm hp (g i)),
   { rwa padic_norm.neg at hpnem },
   have hfigi : padic_norm hp (g i) < padic_norm hp (f i),
   { rwa [hfi, hgi] at hgt },
@@ -195,13 +195,13 @@ begin
   have : padic_norm hp (f i) < padic_norm hp (f i),
   { apply lt_of_lt_of_le hN', apply sub_le_self, apply padic_norm.nonneg },
   exact lt_irrefl _ this
-end 
+end
 
 private lemma norm_eq_of_equiv {f g : padic_seq hp} (hf : ¬ f ≈ 0) (hg : ¬ g ≈ 0) (hfg : f ≈ g) :
       padic_norm hp (f (stationary_point hf)) = padic_norm hp (g (stationary_point hg)) :=
-begin 
+begin
   by_contradiction h,
-  cases (decidable.em (padic_norm hp (f (stationary_point hf)) > 
+  cases (decidable.em (padic_norm hp (f (stationary_point hf)) >
           padic_norm hp (g (stationary_point hg))))
       with hgt hngt,
   { exact norm_eq_of_equiv_aux hf hg hfg h hgt },
@@ -209,16 +209,16 @@ begin
     apply lt_of_le_of_ne,
     apply le_of_not_gt hngt,
     apply h }
-end 
+end
 
 theorem norm_equiv {f g : padic_seq hp} (hfg : f ≈ g) : f.norm = g.norm :=
-if hf : f ≈ 0 then 
+if hf : f ≈ 0 then
   have hg : g ≈ 0, from setoid.trans (setoid.symm hfg) hf,
   by simp [norm, hf, hg]
 else have hg : ¬ g ≈ 0, from hf ∘ setoid.trans hfg,
 by unfold norm; split_ifs; exact norm_eq_of_equiv hf hg hfg
 
-private lemma norm_nonarchimedean_aux {f g : padic_seq hp} 
+private lemma norm_nonarchimedean_aux {f g : padic_seq hp}
         (hfg : ¬ f + g ≈ 0) (hf : ¬ f ≈ 0) (hg : ¬ g ≈ 0) :
         (f + g).norm ≤ max (f.norm) (g.norm) :=
 let i := max (stationary_point hfg) (max (stationary_point hf) (stationary_point hg)) in
@@ -238,50 +238,50 @@ have hpng : padic_norm hp (g (stationary_point hg)) = padic_norm hp (g i),
   apply le_max_right,
   apply le_max_right,
   apply le_refl },
-begin 
-  unfold norm, split_ifs,  
+begin
+  unfold norm, split_ifs,
   rw [hpnfg, hpnf, hpng],
   apply padic_norm.nonarchimedean
-end 
+end
 
 theorem norm_nonarchimedean (f g : padic_seq hp) :
       (f + g).norm ≤ max (f.norm) (g.norm) :=
-if hfg : f + g ≈ 0 then 
+if hfg : f + g ≈ 0 then
   have 0 ≤ max (f.norm) (g.norm), from le_max_left_of_le (norm_nonneg _),
   by simpa [hfg, norm]
-else if hf : f ≈ 0 then 
+else if hf : f ≈ 0 then
   have hfg' : f + g ≈ g,
   { change lim_zero (f - 0) at hf,
     show lim_zero (f + g - g), by simpa using hf },
   have hcfg : (f + g).norm = g.norm, from norm_equiv hfg',
   have hcl : f.norm = 0, from (norm_zero_iff f).2 hf,
-  have max (f.norm) (g.norm) = g.norm, 
+  have max (f.norm) (g.norm) = g.norm,
     by rw hcl; exact max_eq_right (norm_nonneg _),
   by rw [this, hcfg]
-else if hg : g ≈ 0 then 
-  have hfg' : f + g ≈ f, 
+else if hg : g ≈ 0 then
+  have hfg' : f + g ≈ f,
   { change lim_zero (g - 0) at hg,
     show lim_zero (f + g - f), by  simpa [add_sub_cancel'] using hg },
   have hcfg : (f + g).norm = f.norm, from norm_equiv hfg',
   have hcl : g.norm = 0, from (norm_zero_iff g).2 hg,
-  have max (f.norm) (g.norm) = f.norm, 
+  have max (f.norm) (g.norm) = f.norm,
     by rw hcl; exact max_eq_left (norm_nonneg _),
   by rw [this, hcfg]
 else norm_nonarchimedean_aux hfg hf hg
 
 lemma norm_eq {f g : padic_seq hp} (h : ∀ k, padic_norm hp (f k) = padic_norm hp (g k)) :
       f.norm = g.norm :=
-if hf : f ≈ 0 then 
+if hf : f ≈ 0 then
   have hg : g ≈ 0, from equiv_zero_of_val_eq_of_equiv_zero h hf,
   by simp [hf, hg, norm]
-else 
+else
   have hg : ¬ g ≈ 0, from λ hg, hf $ equiv_zero_of_val_eq_of_equiv_zero (by simp [h]) hg,
   begin
     simp [hg, hf, norm],
     let i := max (stationary_point hf) (stationary_point hg),
-    have hpf : padic_norm hp (f (stationary_point hf)) = padic_norm hp (f i), 
+    have hpf : padic_norm hp (f (stationary_point hf)) = padic_norm hp (f i),
     { apply stationary_point_spec, apply le_max_left, apply le_refl },
-    have hpg : padic_norm hp (g (stationary_point hg)) = padic_norm hp (g i), 
+    have hpg : padic_norm hp (g (stationary_point hg)) = padic_norm hp (g i),
     { apply stationary_point_spec, apply le_max_right, apply le_refl },
     rw [hpf, hpg, h]
   end
@@ -300,13 +300,13 @@ namespace padic
 section completion
 variables {p : ℕ} {hp : prime p}
 
-instance discrete_field : discrete_field (padic hp) := 
-cau_seq.completion.discrete_field 
+instance discrete_field : discrete_field (padic hp) :=
+cau_seq.completion.discrete_field
 
-def mk : padic_seq hp → ℚ_[hp] := quotient.mk 
+def mk : padic_seq hp → ℚ_[hp] := quotient.mk
 end completion
 
-section completion 
+section completion
 variables {p : ℕ} (hp : prime p)
 
 lemma mk_eq {f g : padic_seq hp} : mk f = mk g ↔ f ≈ g := quotient.eq
@@ -314,7 +314,7 @@ lemma mk_eq {f g : padic_seq hp} : mk f = mk g ↔ f ≈ g := quotient.eq
 def of_rat : ℚ → ℚ_[hp] := cau_seq.completion.of_rat
 
 @[simp] lemma of_rat_add : ∀ (x y : ℚ), of_rat hp (x + y) = of_rat hp x + of_rat hp y :=
-cau_seq.completion.of_rat_add 
+cau_seq.completion.of_rat_add
 
 @[simp] lemma of_rat_neg : ∀ (x : ℚ), of_rat hp (-x) = -of_rat hp x :=
 cau_seq.completion.of_rat_neg
@@ -333,19 +333,19 @@ cau_seq.completion.of_rat_div
 @[simp] lemma of_rat_zero : of_rat hp 0 = 0 := rfl
 
 @[simp] lemma cast_eq_of_rat_of_nat (n : ℕ) : (↑n : ℚ_[hp]) = of_rat hp n :=
-begin 
+begin
   induction n with n ih,
   { refl },
   { simp, ring, congr, apply ih }
-end 
+end
 
 @[simp] lemma cast_eq_of_rat_of_int (n : ℤ) : (↑n : ℚ_[hp]) = of_rat hp n :=
-by induction n; simp 
+by induction n; simp
 
-lemma cast_eq_of_rat : ∀ (q : ℚ), (↑q : ℚ_[hp]) = of_rat hp q 
-| ⟨n, d, h1, h2⟩ := 
-  show ↑n / ↑d = _, from 
-    have (⟨n, d, h1, h2⟩ : ℚ) = rat.mk n d, from rat.num_denom _, 
+lemma cast_eq_of_rat : ∀ (q : ℚ), (↑q : ℚ_[hp]) = of_rat hp q
+| ⟨n, d, h1, h2⟩ :=
+  show ↑n / ↑d = _, from
+    have (⟨n, d, h1, h2⟩ : ℚ) = rat.mk n d, from rat.num_denom _,
     by simp [this, rat.mk_eq_div, of_rat_div]
 
 lemma const_equiv {q r : ℚ} : const (padic_norm hp) q ≈ const (padic_norm hp) r ↔ q = r :=
@@ -356,18 +356,18 @@ lemma const_equiv {q r : ℚ} : const (padic_norm hp) q ≈ const (padic_norm hp
 lemma of_rat_eq {q r : ℚ} : of_rat hp q = of_rat hp r ↔ q = r :=
 ⟨(const_equiv hp).1 ∘ quotient.eq.1, λ h, by rw h⟩
 
-instance : char_zero ℚ_[hp] := 
+instance : char_zero ℚ_[hp] :=
 ⟨ λ m n, suffices of_rat hp ↑m = of_rat hp ↑n ↔ m = n, by simpa using this,
     by simp [of_rat_eq] ⟩
 
 end completion
-end padic 
+end padic
 
-def padic_norm_e {p : ℕ} {hp : prime p} : ℚ_[hp] → ℚ := 
-quotient.lift padic_seq.norm $ @padic_seq.norm_equiv _ _ 
+def padic_norm_e {p : ℕ} {hp : prime p} : ℚ_[hp] → ℚ :=
+quotient.lift padic_seq.norm $ @padic_seq.norm_equiv _ _
 
-namespace padic_norm_e 
-section embedding 
+namespace padic_norm_e
+section embedding
 open padic_seq
 variables {p : ℕ} {hp : prime p}
 
@@ -378,7 +378,7 @@ begin
   change ∃ N, ∀ i ≥ N, (f - const _ (f i)).norm < ε,
   by_contradiction h,
   cases cauchy₂ f hε with N hN,
-  have : ∀ N, ∃ i ≥ N, (f - const _ (f i)).norm ≥ ε, 
+  have : ∀ N, ∃ i ≥ N, (f - const _ (f i)).norm ≥ ε,
     by simpa [not_forall] using h,
   rcases this N with ⟨i, hi, hge⟩,
   have hne : ¬ (f - const (padic_norm hp) (f i)) ≈ 0,
@@ -391,47 +391,47 @@ begin
     rw ←this,
     apply hN,
     apply le_refl, assumption }
-end 
+end
 
 protected lemma nonneg (q : ℚ_[hp]) : padic_norm_e q ≥ 0 :=
 quotient.induction_on q $ norm_nonneg
 
-lemma zero_def : (0 : ℚ_[hp]) = ⟦0⟧ := rfl 
+lemma zero_def : (0 : ℚ_[hp]) = ⟦0⟧ := rfl
 
 lemma zero_iff (q : ℚ_[hp]) : padic_norm_e q = 0 ↔ q = 0 :=
-quotient.induction_on q $ 
+quotient.induction_on q $
   by simpa only [zero_def, quotient.eq] using norm_zero_iff
 
 @[simp] protected lemma zero : padic_norm_e (0 : ℚ_[hp]) = 0 :=
 (zero_iff _).2 rfl
 
 @[simp] protected lemma one' : padic_norm_e (1 : ℚ_[hp]) = 1 :=
-norm_one 
+norm_one
 
 @[simp] protected lemma neg (q : ℚ_[hp]) : padic_norm_e (-q) = padic_norm_e q :=
-quotient.induction_on q $ norm_neg 
+quotient.induction_on q $ norm_neg
 
-theorem nonarchimedean' (q r : ℚ_[hp]) : 
+theorem nonarchimedean' (q r : ℚ_[hp]) :
       padic_norm_e (q + r) ≤ max (padic_norm_e q) (padic_norm_e r) :=
-quotient.induction_on₂ q r $ norm_nonarchimedean 
+quotient.induction_on₂ q r $ norm_nonarchimedean
 
-lemma triangle_ineq (x y z : ℚ_[hp]) : 
+lemma triangle_ineq (x y z : ℚ_[hp]) :
   padic_norm_e (x - z) ≤ padic_norm_e (x - y) + padic_norm_e (y - z) :=
 calc padic_norm_e (x - z) = padic_norm_e ((x - y) + (y - z)) : by rw sub_add_sub_cancel
   ... ≤ max (padic_norm_e (x - y)) (padic_norm_e (y - z)) : padic_norm_e.nonarchimedean' _ _
-  ... ≤ padic_norm_e (x - y) + padic_norm_e (y - z) : 
+  ... ≤ padic_norm_e (x - y) + padic_norm_e (y - z) :
     max_le_add_of_nonneg (padic_norm_e.nonneg _) (padic_norm_e.nonneg _)
 
-protected lemma add (q r : ℚ_[hp]) : 
+protected lemma add (q r : ℚ_[hp]) :
       padic_norm_e (q + r) ≤ (padic_norm_e q) + (padic_norm_e r) :=
-calc 
-  padic_norm_e (q + r) ≤ max (padic_norm_e q) (padic_norm_e r) : nonarchimedean' _ _ 
-                      ... ≤ (padic_norm_e q) + (padic_norm_e r) : 
+calc
+  padic_norm_e (q + r) ≤ max (padic_norm_e q) (padic_norm_e r) : nonarchimedean' _ _
+                      ... ≤ (padic_norm_e q) + (padic_norm_e r) :
                               max_le_add_of_nonneg (padic_norm_e.nonneg _) (padic_norm_e.nonneg _)
 
-protected lemma mul' (q r : ℚ_[hp]) : 
+protected lemma mul' (q r : ℚ_[hp]) :
       padic_norm_e (q * r) = (padic_norm_e q) * (padic_norm_e r) :=
-quotient.induction_on₂ q r $ norm_mul 
+quotient.induction_on₂ q r $ norm_mul
 
 instance : is_absolute_value (@padic_norm_e _ hp) :=
 { abv_nonneg := padic_norm_e.nonneg,
@@ -447,7 +447,7 @@ quotient.induction_on q $ λ f hf,
   have ¬ f ≈ 0, from (ne_zero_iff_nequiv_zero f).1 hf,
   norm_image f this
 
-lemma sub_rev (q r : ℚ_[hp]) : padic_norm_e (q - r) = padic_norm_e (r - q) := 
+lemma sub_rev (q r : ℚ_[hp]) : padic_norm_e (q - r) = padic_norm_e (r - q) :=
 by rw ←(padic_norm_e.neg); simp
 
 end embedding
@@ -456,22 +456,22 @@ end padic_norm_e
 namespace padic
 
 section complete
-open padic_seq padic 
+open padic_seq padic
 
-theorem rat_dense' {p : ℕ} {hp : prime p} (q : ℚ_[hp]) {ε : ℚ} (hε : ε > 0) : 
+theorem rat_dense' {p : ℕ} {hp : prime p} (q : ℚ_[hp]) {ε : ℚ} (hε : ε > 0) :
         ∃ r : ℚ, padic_norm_e (q - r) < ε :=
 quotient.induction_on q $ λ q',
   have ∃ N, ∀ m n ≥ N, padic_norm hp (q' m - q' n) < ε, from cauchy₂ _ hε,
-  let ⟨N, hN⟩ := this in 
-  ⟨q' N, 
+  let ⟨N, hN⟩ := this in
+  ⟨q' N,
     begin
       simp only [padic.cast_eq_of_rat],
       change padic_seq.norm (q' - const _ (q' N)) < ε,
       cases decidable.em ((q' - const (padic_norm hp) (q' N)) ≈ 0) with heq hne',
       { simpa only [heq, padic_seq.norm, dif_pos] },
       { simp only [padic_seq.norm, dif_neg hne'],
-        change padic_norm hp (q' _ - q' _) < ε,        
-        have := stationary_point_spec hne', 
+        change padic_norm hp (q' _ - q' _) < ε,
+        have := stationary_point_spec hne',
         cases decidable.em (N ≥ stationary_point hne') with hle hle,
         { have := eq.symm (this (le_refl _) hle),
           simp at this, simpa [this] },
@@ -480,7 +480,7 @@ quotient.induction_on q $ λ q',
     end⟩
 
 variables {p : ℕ} {hp : prime p} (f : cau_seq _ (@padic_norm_e _ hp))
-open classical 
+open classical
 
 private lemma cast_succ_nat_pos (n : ℕ) : (↑(n + 1) : ℚ) > 0 :=
 nat.cast_pos.2 $ succ_pos _
@@ -492,7 +492,7 @@ def lim_seq : ℕ → ℚ := λ n, classical.some (rat_dense' (f n) (div_nat_pos
 
 lemma exi_rat_seq_conv :
       ∀ ε > 0, ∃ N, ∀ i ≥ N, padic_norm_e (f i - of_rat hp ((lim_seq f) i)) < ε :=
-begin 
+begin
   intros ε hε,
   existsi (ceil (1/ε)).nat_abs,
   intros i hi,
@@ -506,23 +506,23 @@ begin
   have : ceil (1/ε) ≥ 0, from ceil_nonneg (le_of_lt (one_div_pos_of_pos hε)),
   rw int.of_nat_nat_abs_eq_of_nonneg (this) at hi',
   have hi'' := le_mul_of_div_le hε (ceil_le.1 hi'),
-  rw right_distrib, 
+  rw right_distrib,
   apply le_add_of_le_of_nonneg,
-  { apply hi'' }, 
-  { apply le_of_lt, 
+  { apply hi'' },
+  { apply le_of_lt,
     simpa }
-end  
+end
 
 lemma exi_rat_seq_conv_cauchy : is_cau_seq (padic_norm hp) (lim_seq f) :=
 assume ε hε,
 have hε3 : ε / 3 > 0, from div_pos hε (by norm_num),
 let ⟨N, hN⟩ := exi_rat_seq_conv f _ hε3,
-    ⟨N2, hN2⟩ := f.cauchy₂ hε3 in 
-begin 
+    ⟨N2, hN2⟩ := f.cauchy₂ hε3 in
+begin
   existsi max N N2,
   intros j hj,
   rw [←padic_norm_e.eq_padic_norm', padic.of_rat_sub],
-  suffices : padic_norm_e ((↑(lim_seq f j) - f (max N N2)) + (f (max N N2) - lim_seq f (max N N2))) < ε, 
+  suffices : padic_norm_e ((↑(lim_seq f j) - f (max N N2)) + (f (max N N2) - lim_seq f (max N N2))) < ε,
   { ring at this ⊢, simpa only [cast_eq_of_rat] },
   { apply lt_of_le_of_lt,
     { apply padic_norm_e.add },
@@ -530,7 +530,7 @@ begin
       have : ε = ε / 3 + ε / 3 + ε / 3,
       { apply eq_of_mul_eq_mul_left this, simp [left_distrib, mul_div_cancel' _ this ], ring },
       rw this,
-      apply add_lt_add, 
+      apply add_lt_add,
       { suffices : padic_norm_e ((↑(lim_seq f j) - f j) + (f j - f (max N N2))) < ε / 3 + ε / 3,
           by simpa,
         apply lt_of_le_of_lt,
@@ -539,22 +539,22 @@ begin
           { rw [padic_norm_e.sub_rev, cast_eq_of_rat], apply hN, apply le_of_max_le_left hj },
           { apply hN2, apply le_of_max_le_right hj, apply le_max_right } } },
       { rw cast_eq_of_rat, apply hN, apply le_max_left }}}
-end 
+end
 
 private def lim' : padic_seq hp := ⟨_, exi_rat_seq_conv_cauchy f⟩
 
 private def lim : ℚ_[hp] := ⟦lim' f⟧
 
-theorem complete' : 
+theorem complete' :
         ∃ q : ℚ_[hp], ∀ ε > 0, ∃ N, ∀ i ≥ N, padic_norm_e (q - f i) < ε :=
-⟨ lim f, 
-  λ ε hε,  
+⟨ lim f,
+  λ ε hε,
   let ⟨N, hN⟩ := exi_rat_seq_conv f _ (show ε / 2 > 0, from div_pos hε (by norm_num)),
-      ⟨N2, hN2⟩ := padic_norm_e.defn (lim' f) (show ε / 2 > 0, from div_pos hε (by norm_num)) in 
+      ⟨N2, hN2⟩ := padic_norm_e.defn (lim' f) (show ε / 2 > 0, from div_pos hε (by norm_num)) in
   begin
     existsi max N N2,
     intros i hi,
-    suffices : padic_norm_e ((lim f - lim' f i) + (lim' f i - f i)) < ε, 
+    suffices : padic_norm_e ((lim f - lim' f i) + (lim' f i - f i)) < ε,
     { ring at this; exact this },
     { apply lt_of_le_of_lt,
       { apply padic_norm_e.add },
@@ -576,19 +576,19 @@ instance : has_dist ℚ_[hp] := ⟨λ x y, padic_norm_e (x - y)⟩
 instance : metric_space ℚ_[hp] :=
 { dist_self := by simp [dist],
   dist_comm := λ x y, by unfold dist; rw ←padic_norm_e.neg (x - y); simp,
-  dist_triangle := 
-    begin 
-      intros, unfold dist, 
-      rw ←rat.cast_add, 
-      apply rat.cast_le.2, 
-      apply padic_norm_e.triangle_ineq 
-    end, 
-  eq_of_dist_eq_zero := 
-    begin 
-      unfold dist, intros _ _ h, 
-      apply eq_of_sub_eq_zero, 
-      apply (padic_norm_e.zero_iff _).1, 
-      simpa using h 
+  dist_triangle :=
+    begin
+      intros, unfold dist,
+      rw ←rat.cast_add,
+      apply rat.cast_le.2,
+      apply padic_norm_e.triangle_ineq
+    end,
+  eq_of_dist_eq_zero :=
+    begin
+      unfold dist, intros _ _ h,
+      apply eq_of_sub_eq_zero,
+      apply (padic_norm_e.zero_iff _).1,
+      simpa using h
     end }
 
 instance : has_norm ℚ_[hp] := ⟨λ x, padic_norm_e x⟩
@@ -604,28 +604,28 @@ instance : is_absolute_value (λ a : ℚ_[hp], ∥a∥) :=
   abv_mul := by simp [has_norm.norm, padic_norm_e.mul'] }
 
 
-theorem rat_dense {p : ℕ} {hp : prime p} (q : ℚ_[hp]) {ε : ℝ} (hε : ε > 0) : 
+theorem rat_dense {p : ℕ} {hp : prime p} (q : ℚ_[hp]) {ε : ℝ} (hε : ε > 0) :
         ∃ r : ℚ, ∥q - r∥ < ε :=
 let ⟨ε', hε'l, hε'r⟩ := exists_rat_btwn hε,
-    ⟨r, hr⟩ := rat_dense' q (by simpa using hε'l)  in 
+    ⟨r, hr⟩ := rat_dense' q (by simpa using hε'l)  in
 ⟨r, lt.trans (by simpa [has_norm.norm] using hr) hε'r⟩
 
 end normed_space
-end padic 
+end padic
 
-namespace padic_norm_e 
-section normed_space 
+namespace padic_norm_e
+section normed_space
 variables {p : ℕ} {hp : p.prime}
 
 @[simp] protected lemma mul (q r : ℚ_[hp]) : ∥q * r∥ = ∥q∥ * ∥r∥ :=
 by simp [has_norm.norm, padic_norm_e.mul']
 
-@[simp] protected lemma is_norm (q : ℚ_[hp]) : ↑(padic_norm_e q) = ∥q∥ := rfl
+protected lemma is_norm (q : ℚ_[hp]) : ↑(padic_norm_e q) = ∥q∥ := rfl
 
-theorem nonarchimedean (q r : ℚ_[hp]) : ∥q + r∥ ≤ max (∥q∥) (∥r∥) := 
-begin 
+theorem nonarchimedean (q r : ℚ_[hp]) : ∥q + r∥ ≤ max (∥q∥) (∥r∥) :=
+begin
   unfold has_norm.norm, rw ←rat.cast_max, apply rat.cast_le.2, apply nonarchimedean'
-end 
+end
 
 @[simp] lemma eq_padic_norm (q : ℚ) : ∥padic.of_rat hp q∥ = padic_norm hp q :=
 by unfold has_norm.norm; congr; apply padic_seq.norm_const
@@ -633,7 +633,7 @@ by unfold has_norm.norm; congr; apply padic_seq.norm_const
 protected theorem image {q : ℚ_[hp]} : q ≠ 0 → ∃ n : ℤ, ∥q∥ = ↑(fpow (↑p : ℚ) (-n)) :=
 quotient.induction_on q $ λ f hf,
   have ¬ f ≈ 0, from (padic_seq.ne_zero_iff_nequiv_zero f).1 hf,
-  let ⟨n, hn⟩ := padic_seq.norm_image f this in 
+  let ⟨n, hn⟩ := padic_seq.norm_image f this in
   ⟨n, congr_arg rat.cast hn⟩
 
 protected lemma is_rat (q : ℚ_[hp]) : ∃ q' : ℚ, ∥q∥ = ↑q' :=
@@ -644,16 +644,51 @@ def rat_norm (q : ℚ_[hp]) : ℚ := classical.some (padic_norm_e.is_rat q)
 
 lemma eq_rat_norm (q : ℚ_[hp]) : ∥q∥ = rat_norm q := classical.some_spec (padic_norm_e.is_rat q)
 
-protected theorem complete (f : cau_seq ℚ_[hp] (λ a, ∥a∥)): 
+theorem norm_rat_le_one : ∀ {q : ℚ} (hq : ¬ p ∣ q.denom), ∥(q : ℚ_[hp])∥ ≤ 1
+| ⟨n, d, hn, hd⟩ := λ hq : ¬ p ∣ d,
+  if hnz : n = 0 then
+    have (⟨n, d, hn, hd⟩ : ℚ) = 0, from rat.zero_of_num_zero hnz,
+      by simp [this, padic.cast_eq_of_rat, zero_le_one]
+  else
+    have hnz' : {rat . num := n, denom := d, pos := hn, cop := hd} ≠ 0,
+      from mt rat.zero_iff_num_zero.1 hnz,
+    have fpow (p : ℚ) (-↑(padic_val p n)) ≤ 1,
+      from fpow_le_one_of_nonpos
+             (show (↑p : ℚ) ≥ ↑(1: ℕ), from le_of_lt (nat.cast_lt.2 hp.gt_one))
+             (neg_nonpos_of_nonneg (int.coe_nat_nonneg _)),
+    have (↑(fpow (p : ℚ) (-↑(padic_val p n))) : ℝ) ≤ (1 : ℚ), from rat.cast_le.2 this,
+    by simpa [padic.cast_eq_of_rat, hnz', padic_norm, padic_val_rat,
+              padic_val_eq_zero_of_not_dvd' hq] using this
+
+end normed_space
+end padic_norm_e
+
+namespace padic
+variables {p : ℕ} {hp : p.prime}
+
+protected theorem complete (f : cau_seq ℚ_[hp] (λ a, ∥a∥)):
         ∃ q : ℚ_[hp], ∀ ε > 0, ∃ N, ∀ i ≥ N, ∥q - f i∥ < ε :=
-let f' : cau_seq ℚ_[hp] padic_norm_e := 
-  ⟨λ n, f n, λ ε hε, 
+let f' : cau_seq ℚ_[hp] padic_norm_e :=
+  ⟨λ n, f n, λ ε hε,
     let ⟨N, hN⟩ := is_cau f ↑ε (rat.cast_pos.2 hε) in ⟨N, λ j hj, rat.cast_lt.1 (hN _ hj)⟩⟩ in
 let ⟨q, hq⟩ := padic.complete' f' in
-⟨ q, λ ε hε, 
+⟨ q, λ ε hε,
   let ⟨ε', hε'l, hε'r⟩ := exists_rat_btwn hε,
-      ⟨N, hN⟩ := hq _ (by simpa using hε'l) in  
+      ⟨N, hN⟩ := hq _ (by simpa using hε'l) in
   ⟨N, λ i hi, lt.trans (rat.cast_lt.2 (hN _ hi)) hε'r ⟩⟩
 
-end normed_space 
-end padic_norm_e
+def cau_seq_lim (f : cau_seq ℚ_[hp] (λ a, ∥a∥)) : ℚ_[hp] :=
+classical.some (padic.complete f)
+
+lemma cau_seq_lim_spec (f : cau_seq ℚ_[hp] (λ a, ∥a∥)) :
+      ∀ ε > 0, ∃ N, ∀ i ≥ N, ∥(cau_seq_lim f) - f i∥ < ε :=
+classical.some_spec (padic.complete f)
+
+lemma padic_norm_e_lim_le {f : cau_seq ℚ_[hp] (λ a, ∥a∥)} {a : ℝ} (ha : a > 0)
+      (hf : ∀ i, ∥f i∥ ≤ a) : ∥cau_seq_lim f∥ ≤ a :=
+let ⟨N, hN⟩ := cau_seq_lim_spec f _ ha in
+calc ∥cau_seq_lim f∥ = ∥cau_seq_lim f - f N + f N∥ : by simp
+                ... ≤ max (∥cau_seq_lim f - f N∥) (∥f N∥) : padic_norm_e.nonarchimedean _ _
+                ... ≤ a : max_le (le_of_lt (hN _ (le_refl _))) (hf _)
+
+end padic

--- a/data/rat.lean
+++ b/data/rat.lean
@@ -943,6 +943,9 @@ lemma zero_of_num_zero {q : ℚ} (hq : q.num = 0) : q = 0 :=
 have q = q.num /. q.denom, from num_denom _,
 by simpa [hq]
 
+lemma zero_iff_num_zero {q : ℚ} : q = 0 ↔ q.num = 0 :=
+⟨λ _, by simp *, zero_of_num_zero⟩
+
 lemma num_ne_zero_of_ne_zero {q : ℚ} (h : q ≠ 0) : q.num ≠ 0 :=
 assume : q.num = 0,
 h $ zero_of_num_zero this

--- a/tactic/linarith.lean
+++ b/tactic/linarith.lean
@@ -304,6 +304,7 @@ meta def map_of_expr : rb_map expr ℕ → ℕ → expr → option (rb_map expr 
 | m max `(-%%e) := do (m', max', comp) ← map_of_expr m max e, return (m', max', comp.scale (-1))
 | m max e := 
   match e.to_int, m.find e with
+  | some 0, _ := return ⟨m, max, mk_rb_map⟩
   | some z, _ := return ⟨m, max, mk_rb_map.insert 0 z⟩ 
   | none, some k := return (m, max, mk_rb_map.insert k 1) 
   | none, none := return (m.insert e max, max + 1, mk_rb_map.insert max 1)

--- a/tactic/linarith.lean
+++ b/tactic/linarith.lean
@@ -346,7 +346,7 @@ do pftps ← l.mmap infer_type,
    let vars : rb_set ℕ := rb_map.of_list $ (list.range (max)).map (λ k, (k, ())),
    let pc : rb_set pcomp := 
      rb_map.of_list $ (list.range lz.length).map (λ n, (⟨(lz.inth n).2, comp_source.assump n⟩, ())),
-   return ⟨vars, pc, prmap, none⟩ 
+   return ⟨vars, pc, prmap, find_contr_in_set pc⟩ 
 
 end parse 
 

--- a/tests/linarith_tests.lean
+++ b/tests/linarith_tests.lean
@@ -1,5 +1,9 @@
 import tactic.linarith
 
+example (e b c a v0 v1 : ℚ) (h1 : v0 = 5*a) (h2 : v1 = 3*b) (h3 : v0 + v1 + c = 10) : 
+  v0 + 5 + (v1 - 3) + (c - 2) = 10 :=
+by linarith
+
 example (ε : ℚ) (h1 : ε > 0) : ε / 2 + ε / 3 + ε / 7 < ε :=
  by linarith
 

--- a/tests/linarith_tests.lean
+++ b/tests/linarith_tests.lean
@@ -1,5 +1,8 @@
 import tactic.linarith
 
+example (h1 : (1 : ℚ) < 1) : false :=
+by linarith
+
 example (e b c a v0 v1 : ℚ) (h1 : v0 = 5*a) (h2 : v1 = 3*b) (h3 : v0 + v1 + c = 10) : 
   v0 + 5 + (v1 - 3) + (c - 2) = 10 :=
 by linarith


### PR DESCRIPTION
This PR does the following:
* Minor fixes to `linarith`, so that it correctly identifies contradictory hypotheses like `0 < 0`.
* Instantiates the p-adic numbers as a normed field and the p-adic integers as a normed ring.
* Adds some algebraic structure to the p-adic integers.
* Various naming corrections.

TO CONTRIBUTORS:

Make sure you have:

 * [ ] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
