### PR TITLE
fix(tactic/tidy): fix interactive tidy ignoring cfg 

### DIFF
--- a/tactic/tidy.lean
+++ b/tactic/tidy.lean
@@ -67,7 +67,7 @@ end tidy
 meta def tidy (cfg : tidy.cfg := {}) := tactic.tidy.core cfg >> skip
 
 namespace interactive
-meta def tidy (cfg : tidy.cfg := {}) := tactic.tidy
+meta def tidy (cfg : tidy.cfg := {}) := tactic.tidy cfg
 end interactive
 
 @[hole_command] meta def tidy_hole_cmd : hole_command :=


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

 * [X] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)

Currently, the following example in VS Code does not print any output:
```lean
import tactic.tidy
example : true := by tidy {trace_result := tt}
```

This PR addresses the underlying bug: the "interactive" version of tidy was completely ignoring the `cfg` parameter.