### PR TITLE
Linarith fixes

### DIFF
--- a/tactic/linarith.lean
+++ b/tactic/linarith.lean
@@ -304,6 +304,7 @@ meta def map_of_expr : rb_map expr ℕ → ℕ → expr → option (rb_map expr 
 | m max `(-%%e) := do (m', max', comp) ← map_of_expr m max e, return (m', max', comp.scale (-1))
 | m max e := 
   match e.to_int, m.find e with
+  | some 0, _ := return ⟨m, max, mk_rb_map⟩
   | some z, _ := return ⟨m, max, mk_rb_map.insert 0 z⟩ 
   | none, some k := return (m, max, mk_rb_map.insert k 1) 
   | none, none := return (m.insert e max, max + 1, mk_rb_map.insert max 1)

--- a/tactic/linarith.lean
+++ b/tactic/linarith.lean
@@ -346,7 +346,7 @@ do pftps ← l.mmap infer_type,
    let vars : rb_set ℕ := rb_map.of_list $ (list.range (max)).map (λ k, (k, ())),
    let pc : rb_set pcomp := 
      rb_map.of_list $ (list.range lz.length).map (λ n, (⟨(lz.inth n).2, comp_source.assump n⟩, ())),
-   return ⟨vars, pc, prmap, none⟩ 
+   return ⟨vars, pc, prmap, find_contr_in_set pc⟩ 
 
 end parse 
 

--- a/tests/linarith_tests.lean
+++ b/tests/linarith_tests.lean
@@ -1,5 +1,9 @@
 import tactic.linarith
 
+example (e b c a v0 v1 : ℚ) (h1 : v0 = 5*a) (h2 : v1 = 3*b) (h3 : v0 + v1 + c = 10) : 
+  v0 + 5 + (v1 - 3) + (c - 2) = 10 :=
+by linarith
+
 example (ε : ℚ) (h1 : ε > 0) : ε / 2 + ε / 3 + ε / 7 < ε :=
  by linarith
 

--- a/tests/linarith_tests.lean
+++ b/tests/linarith_tests.lean
@@ -1,5 +1,8 @@
 import tactic.linarith
 
+example (h1 : (1 : ℚ) < 1) : false :=
+by linarith
+
 example (e b c a v0 v1 : ℚ) (h1 : v0 = 5*a) (h2 : v1 = 3*b) (h3 : v0 + v1 + c = 10) : 
   v0 + 5 + (v1 - 3) + (c - 2) = 10 :=
 by linarith


### PR DESCRIPTION
Factored out of #317 . This makes `linarith` properly use equality hypotheses and degenerate inequalities like `0 < 0`.

TO CONTRIBUTORS:

Make sure you have:

 * [ ] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
