### PR TITLE
feat(data/equiv/basic): quot_equiv_of_quot(')

### DIFF
--- a/data/equiv/basic.lean
+++ b/data/equiv/basic.lean
@@ -477,6 +477,23 @@ def subtype_subtype_equiv_subtype {α : Type u} (p : α → Prop) (q : subtype p
 
 end
 
+section
+
+local attribute [elab_with_expected_type] quot.lift
+
+def quot_equiv_of_quot' {r : α → α → Prop} {s : β → β → Prop} (e : α ≃ β)
+  (h : ∀ a a', r a a' ↔ s (e a) (e a')) : quot r ≃ quot s :=
+⟨quot.lift (λ a, quot.mk _ (e a)) (λ a a' H, quot.sound ((h a a').mp H)),
+ quot.lift (λ b, quot.mk _ (e.symm b)) (λ b b' H, quot.sound ((h _ _).mpr (by convert H; simp))),
+ quot.ind $ by simp,
+ quot.ind $ by simp⟩
+
+def quot_equiv_of_quot {r : α → α → Prop} (e : α ≃ β) :
+  quot r ≃ quot (λ b b', r (e.symm b) (e.symm b')) :=
+quot_equiv_of_quot' e (by simp)
+
+end
+
 namespace set
 open set
 


### PR DESCRIPTION
quot_equiv_of_quot matches matches the existing subtype_equiv_of_subtype,
but quot_equiv_of_quot' is useful in practice and this definition is careful
to use eq.rec only in proofs.

TO CONTRIBUTORS:

Make sure you have:

 * [X] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
