### PR TITLE
feat(ring_theory/noetherian): zero ring (and finite rings) are Noethe…

### DIFF
--- a/algebra/ring.lean
+++ b/algebra/ring.lean
@@ -184,6 +184,17 @@ instance integral_domain.to_nonzero_comm_ring (α : Type*) [id : integral_domain
   nonzero_comm_ring α :=
 { ..id }
 
+lemma semiring.zero_of_zero_eq_one {α} [semiring α] (h01 : (0 : α) = 1) (a : α) : a = 0 :=
+by rw [←one_mul a,←h01,zero_mul]
+
+theorem semiring.subsingleton_of_zero_eq_one {α} [semiring α] (h01 : (0 : α) = 1) : subsingleton α :=
+⟨λ b c,begin rw [←mul_one b,←mul_one c,←h01,mul_zero,mul_zero] end⟩
+
+definition comm_ring.non_zero_of_zero_ne_one {α} [h : comm_ring α] (h01 : (0 : α) ≠ 1) : nonzero_comm_ring α :=
+{ zero_ne_one := by exact h01,
+  ..h
+}
+
 /-- A domain is a ring with no zero divisors, i.e. satisfying
   the condition `a * b = 0 ↔ a = 0 ∨ b = 0`. Alternatively, a domain
   is an integral domain without assuming commutativity of multiplication. -/

--- a/algebra/ring.lean
+++ b/algebra/ring.lean
@@ -190,7 +190,7 @@ by rw [←one_mul a,←h01,zero_mul]
 theorem semiring.subsingleton_of_zero_eq_one {α} [semiring α] (h01 : (0 : α) = 1) : subsingleton α :=
 ⟨λ b c,begin rw [←mul_one b,←mul_one c,←h01,mul_zero,mul_zero] end⟩
 
-definition comm_ring.non_zero_of_zero_ne_one {α} [h : comm_ring α] (h01 : (0 : α) ≠ 1) : nonzero_comm_ring α :=
+definition comm_ring.nonzero_of_zero_ne_one {α} [h : comm_ring α] (h01 : (0 : α) ≠ 1) : nonzero_comm_ring α :=
 { zero_ne_one := by exact h01,
   ..h
 }

--- a/data/polynomial.lean
+++ b/data/polynomial.lean
@@ -347,6 +347,9 @@ calc degree (p + q) = ((p + q).support).sup some : rfl
   (not_not.2 h) (mem_of_max (degree_eq_nat_degree hp)),
 by simp {contextual := tt}⟩
 
+lemma leading_coeff_eq_zero_iff_deg_eq_bot : leading_coeff p = 0 ↔ degree p = ⊥ :=
+by rw [leading_coeff_eq_zero, degree_eq_bot]
+
 lemma degree_add_eq_of_degree_lt (h : degree p < degree q) : degree (p + q) = degree q :=
 le_antisymm (max_eq_right_of_lt h ▸ degree_add_le _ _) $ degree_le_degree $
   begin

--- a/ring_theory/noetherian.lean
+++ b/ring_theory/noetherian.lean
@@ -89,6 +89,26 @@ theorem is_noetherian_iff_well_founded
 
 def is_noetherian_ring (α) [ring α] : Prop := is_noetherian α α
 
+theorem ring.is_noetherian_of_fintype (R M) [ring R] [module R M] [fintype M] : is_noetherian R M :=
+begin
+  intro N,
+  existsi (to_finset N : finset M),
+  suffices : span (N : set M) = N,
+    simpa,
+  exact span_eq_of_is_submodule N.to_is_submodule,
+end
+
+noncomputable instance fintype.of_subsingleton_ring {α} [ring α] [h : subsingleton α] : fintype α :=
+{ elems := {0},
+  complete := λ x, begin
+    suffices: x = 0, by simpa,
+    exact subsingleton.elim x 0,
+  end
+}
+
+theorem ring.is_noetherian_of_zero_eq_one {R} [ring R] (h01 : (0 : R) = 1) : is_noetherian_ring R :=
+by haveI := semiring.subsingleton_of_zero_eq_one h01; exact ring.is_noetherian_of_fintype R R
+
 theorem is_noetherian_of_submodule_of_noetherian (R M) [ring R] [module R M] (N : set M) [is_submodule N]
   (h : is_noetherian R M) : is_noetherian R N :=
 begin


### PR DESCRIPTION
…rian

TO CONTRIBUTORS:

Make sure you have:

 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)

The zero ring is an annoying special case for any work with polynomials (e.g. X does not have degree 1) and I was finding that in several proofs I had to deal with the zero ring as a special case (i.e. the proof I had actually didn't work for the zero ring). I am now doing cases on 0 = 1 to deal with the zero ring, and these are the sorts of lemmas I need.