### PR TITLE
fix(category_theory/*): several minor fixes, preparatory to presheaves

### DIFF
--- a/category_theory/category.lean
+++ b/category_theory/category.lean
@@ -125,8 +125,8 @@ variables (α : Type u)
 
 instance [preorder α] : small_category α :=
 { hom  := λ U V, ulift (plift (U ≤ V)),
-  id   := by tidy,
-  comp := begin tidy, transitivity Y; assumption end }
+  id   := λ X, ⟨ ⟨ le_refl X ⟩ ⟩,
+  comp := λ X Y Z f g, ⟨ ⟨ le_trans f.down.down g.down.down ⟩ ⟩ }
 
 section
 variables {C : Type u} [𝒞 : category.{u v} C]

--- a/category_theory/category.lean
+++ b/category_theory/category.lean
@@ -91,6 +91,11 @@ instance {c : Type u → Type v} (hom : ∀{α β : Type u}, c α → c β → (
   id    := λa, ⟨@id a.1, h.hom_id a.2⟩,
   comp  := λa b c f g, ⟨g.1 ∘ f.1, h.hom_comp a.2 b.2 c.2 f.2 g.2⟩ }
 
+@[simp] lemma concrete_category_id {c : Type u → Type v} (hom : ∀{α β : Type u}, c α → c β → (α → β) → Prop)
+  [h : concrete_category @hom] (X : bundled c) : subtype.val (𝟙 X) = id := rfl
+@[simp] lemma concrete_category_comp {c : Type u → Type v} (hom : ∀{α β : Type u}, c α → c β → (α → β) → Prop)
+  [h : concrete_category @hom] {X Y Z : bundled c} (f : X ⟶ Y) (g : Y ⟶ Z): subtype.val (f ≫ g) = g.val ∘ f.val := rfl
+
 instance {c : Type u → Type v} (hom : ∀{α β : Type u}, c α → c β → (α → β) → Prop)
   [h : concrete_category @hom] {R S : bundled c} : has_coe_to_fun (R ⟶ S) :=
 { F := λ f, R → S,

--- a/category_theory/examples/topological_spaces.lean
+++ b/category_theory/examples/topological_spaces.lean
@@ -1,8 +1,10 @@
 -- Copyright (c) 2017 Scott Morrison. All rights reserved.
 -- Released under Apache 2.0 license as described in the file LICENSE.
--- Authors: Patrick Massot, Scott Morrison
+-- Authors: Patrick Massot, Scott Morrison, Mario Carneiro
 
 import category_theory.full_subcategory
+import category_theory.functor_category
+import category_theory.natural_isomorphism
 import analysis.topology.topological_space
 import analysis.topology.continuity
 
@@ -23,27 +25,41 @@ instance : concrete_category @continuous := ⟨@continuous_id, @continuous.comp�
 -- instance {R S : Top} (f : R ⟶ S) : continuous (f : R → S) := f.2
 end Top
 
-structure open_set (α : Type u) [X : topological_space α] : Type u :=
-(s : set α)
-(is_open : topological_space.is_open X s)
+structure open_set (X : Top.{u}) : Type u :=
+(s : set X.α)
+(is_open : topological_space.is_open X.str s)
 
-variables {α : Type*} [topological_space α]
+variables {X : Top.{u}}
 
 namespace open_set
-instance : has_coe (open_set α) (set α) := { coe := λ U, U.s }
+instance : has_coe (open_set X) (set X.α) := { coe := λ U, U.s }
 
-instance : has_subset (open_set α) :=
+instance : has_subset (open_set X) :=
 { subset := λ U V, U.s ⊆ V.s }
 
-instance : preorder (open_set α) := by refine { le := (⊆), .. } ; tidy
+instance : preorder (open_set X) := by refine { le := (⊇), .. } ; tidy
 
-instance open_sets : small_category (open_set α) := by apply_instance
+instance open_sets : small_category (open_set X) := by apply_instance
 
-instance : has_mem α (open_set α) :=
+instance : has_mem X.α (open_set X) :=
 { mem := λ a V, a ∈ V.s }
 
-def nbhd (x : α) := { U : open_set α // x ∈ U }
-def nbhds (x : α) : small_category (nbhd x) := begin unfold nbhd, apply_instance end
+def nbhd (x : X.α) := { U : open_set X // x ∈ U }
+def nbhds (x : X.α) : small_category (nbhd x) := begin unfold nbhd, apply_instance end
+
+/-- `open_set.map f` gives the functor from open sets in Y to open set in X, 
+    given by taking preimages under f. -/
+def map
+  {X Y : Top} (f : X ⟶ Y) : open_set Y ⥤ open_set X :=
+{ obj := λ U, ⟨ f.val ⁻¹' U.s, f.property _ U.is_open ⟩,
+  map' := λ U V i, ⟨ ⟨ λ a b, i.down.down b ⟩ ⟩ }.
+
+@[simp] def map_id (X : Top) : map (𝟙 X) ≅ functor.id (open_set X) := 
+{ hom := { app := λ U, 𝟙 U },
+  inv := { app := λ U, 𝟙 U } }
+
+def map_iso {X Y : Top} {f g : X ⟶ Y} (h : f = g) : map f ≅ map g := 
+nat_iso.of_components (λ U, eq_to_iso (congr_fun (congr_arg _ (congr_arg _ h)) _) ) (by obviously)
 
 end open_set
 

--- a/category_theory/examples/topological_spaces.lean
+++ b/category_theory/examples/topological_spaces.lean
@@ -9,6 +9,8 @@ import analysis.topology.topological_space
 import analysis.topology.continuity
 
 open category_theory
+open category_theory.nat_iso
+
 universe u
 
 namespace category_theory.examples
@@ -50,16 +52,24 @@ def nbhds (x : X.α) : small_category (nbhd x) := begin unfold nbhd, apply_insta
 /-- `open_set.map f` gives the functor from open sets in Y to open set in X, 
     given by taking preimages under f. -/
 def map
-  {X Y : Top} (f : X ⟶ Y) : open_set Y ⥤ open_set X :=
+  {X Y : Top.{u}} (f : X ⟶ Y) : open_set Y ⥤ open_set X :=
 { obj := λ U, ⟨ f.val ⁻¹' U.s, f.property _ U.is_open ⟩,
   map' := λ U V i, ⟨ ⟨ λ a b, i.down.down b ⟩ ⟩ }.
 
-@[simp] def map_id (X : Top) : map (𝟙 X) ≅ functor.id (open_set X) := 
+@[simp] lemma map_id_obj (X : Top.{u}) (U : open_set X) : map (𝟙 X) U = U :=
+begin
+  cases U, tidy
+end
+
+@[simp] def map_id (X : Top.{u}) : map (𝟙 X) ≅ functor.id (open_set X) := 
 { hom := { app := λ U, 𝟙 U },
   inv := { app := λ U, 𝟙 U } }
 
-def map_iso {X Y : Top} {f g : X ⟶ Y} (h : f = g) : map f ≅ map g := 
+-- We could make f g implicit here, but it's nice to be able to see when they are the identity (often!)
+def map_iso {X Y : Top.{u}} (f g : X ⟶ Y) (h : f = g) : map f ≅ map g := 
 nat_iso.of_components (λ U, eq_to_iso (congr_fun (congr_arg _ (congr_arg _ h)) _) ) (by obviously)
+
+@[simp] def map_iso_id {X : Top.{u}} (h) : map_iso (𝟙 X) (𝟙 X) h = iso.refl (map _) := rfl
 
 end open_set
 

--- a/category_theory/natural_isomorphism.lean
+++ b/category_theory/natural_isomorphism.lean
@@ -24,6 +24,16 @@ instance {F G : C ⥤ D} : has_coe_to_fun (F ≅ G) :=
 { F   := λ α, Π X : C, (F X) ≅ (G X),
   coe := λ α, app α }
 
+@[simp] lemma mk_app {F G : C ⥤ D} (hom : F ⟹ G) (inv) (hom_inv_id') (inv_hom_id') (X : C) :
+  ({ hom := hom, inv := inv, hom_inv_id' := hom_inv_id', inv_hom_id' := inv_hom_id' } : F ≅ G) X = 
+  { hom := hom X, inv := inv X, 
+    hom_inv_id' := congr_fun (congr_arg nat_trans.app hom_inv_id') X,
+    inv_hom_id' := congr_fun (congr_arg nat_trans.app inv_hom_id') X } :=
+rfl
+@[simp] lemma mk_app' {F G : C ⥤ D} (hom : F ⟹ G) (inv) (hom_inv_id') (inv_hom_id') (X : C) :
+  (({ hom := hom, inv := inv, hom_inv_id' := hom_inv_id', inv_hom_id' := inv_hom_id' } : F ≅ G) : F ⟹ G) X = hom X := 
+rfl
+
 @[simp] lemma comp_app {F G H : C ⥤ D} (α : F ≅ G) (β : G ≅ H) (X : C) : 
   ((α ≪≫ β) : F ⟹ H) X = α X ≪≫ β X := rfl
 
@@ -42,21 +52,73 @@ instance inv_app_is_iso (α : F ≅ G) (X : C) : is_iso ((α.symm : G ⟶ F) X) 
   inv_hom_id' := begin dsimp at *, erw [is_iso.hom_inv_id] end }
 
 variables {X Y : C}
-@[simp] lemma naturality_1 (α : F ≅ G) (f : X ⟶ Y) : ((α.symm : G ⟶ F) X) ≫ (F.map f) ≫ ((α : F ⟶ G) Y) = G.map f :=
+@[simp] lemma naturality_1 (α : F ≅ G) (f : X ⟶ Y) : 
+  ((α.symm : G ⟶ F) X) ≫ (F.map f) ≫ ((α : F ⟶ G) Y) = G.map f :=
 begin erw [nat_trans.naturality, ←category.assoc, is_iso.hom_inv_id, category.id_comp] end
-@[simp] lemma naturality_2 (α : F ≅ G) (f : X ⟶ Y) : ((α : F ⟶ G) X) ≫ (G.map f) ≫ ((α.symm : G ⟶ F) Y) = F.map f :=
+@[simp] lemma naturality_2 (α : F ≅ G) (f : X ⟶ Y) : 
+  ((α : F ⟶ G) X) ≫ (G.map f) ≫ ((α.symm : G ⟶ F) Y) = F.map f :=
 begin erw [nat_trans.naturality, ←category.assoc, is_iso.hom_inv_id, category.id_comp] end
 
-def of_components
-  (app : ∀ X : C, (F X) ≅ (G X))
-  (naturality : ∀ {X Y : C} (f : X ⟶ Y), (F.map f) ≫ ((app Y) : F Y ⟶ G Y) = ((app X) : F X ⟶ G X) ≫ (G.map f)) : F ≅ G :=
+def of_components (app : ∀ X : C, (F X) ≅ (G X))
+  (naturality : ∀ {X Y : C} (f : X ⟶ Y), (F.map f) ≫ ((app Y) : F Y ⟶ G Y) = ((app X) : F X ⟶ G X) ≫ (G.map f)) : 
+  F ≅ G :=
 { hom  := { app := λ X, ((app X) : F X ⟶ G X), },
-  inv  := { app := λ X, ((app X).symm : G X ⟶ F X),
-            naturality' := λ X Y f, begin 
-                                      let p := congr_arg (λ f, (app X).inv ≫ (f ≫ (app Y).inv)) (eq.symm (naturality f)),
-                                      dsimp at *, 
-                                      simp at *, 
-                                      erw [←p, ←category.assoc, is_iso.hom_inv_id, category.id_comp],
-                                    end } }
+  inv  := 
+  { app := λ X, ((app X).symm : G X ⟶ F X),
+    naturality' := λ X Y f, 
+    begin 
+      let p := congr_arg (λ f, (app X).inv ≫ (f ≫ (app Y).inv)) (eq.symm (naturality f)),
+      dsimp at *, 
+      simp at *, 
+      erw [←p, ←category.assoc, is_iso.hom_inv_id, category.id_comp],
+    end } }.
+
+@[simp] def of_components.app (app' : ∀ X : C, (F X) ≅ (G X)) (naturality) (X) : 
+  app (of_components app' naturality) X = app' X :=
+by tidy
+@[simp] def of_components.hom_app (app : ∀ X : C, (F X) ≅ (G X)) (naturality) (X) : 
+  ((of_components app naturality) : F ⟹ G) X = app X := rfl
+@[simp] def of_components.inv_app (app : ∀ X : C, (F X) ≅ (G X)) (naturality) (X) : 
+  ((of_components app naturality).symm : G ⟹ F) X = (app X).symm := rfl
 
 end category_theory.nat_iso
+
+namespace category_theory.functor
+
+universes u₁ u₂ v₁ v₂
+
+variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C] 
+          {D : Type u₂} [𝒟 : category.{u₂ v₂} D] 
+include 𝒞 𝒟
+
+@[simp] def id_comp (F : C ⥤ D) : functor.id C ⋙ F ≅ F := 
+{ hom :=
+  { app := λ X, 𝟙 (F X) },
+  inv :=
+  { app := λ X, 𝟙 (F X) }
+}
+@[simp] def comp_id (F : C ⥤ D) : F ⋙ functor.id D ≅ F := 
+{ hom :=
+  { app := λ X, 𝟙 (F X) },
+  inv :=
+  { app := λ X, 𝟙 (F X) }
+}
+
+universes u₃ v₃ u₄ v₄ 
+
+variables {A : Type u₃} [𝒜 : category.{u₃ v₃} A] 
+          {B : Type u₄} [ℬ : category.{u₄ v₄} B] 
+include 𝒜 ℬ
+variables (F : A ⥤ B) (G : B ⥤ C) (H : C ⥤ D)
+
+@[simp] def assoc : (F ⋙ G) ⋙ H ≅ F ⋙ (G ⋙ H ):= 
+{ hom :=
+  { app := λ X, 𝟙 (H (G (F X))) },
+  inv :=
+  { app := λ X, 𝟙 (H (G (F X))) }
+}
+
+-- When it's time to define monoidal categories and 2-categories,
+-- we'll need to add lemmas relating these natural isomorphisms,
+-- in particular the pentagon for the associator.
+end category_theory.functor


### PR DESCRIPTION
- In category.lean, better proofs in `instance [preorder α] : small_category α := …`.
- In natural_isomorphism.lean, some rfl lemmas, natural isomorphisms describing functor composition, and formatting
- In examples/topological_spaces.lean, deciding to reverse the arrows in `open_set X` (the category of open sets, with restrictions), to reduce using opposites later, as well as describing the functoriality of `open_set`.

TO CONTRIBUTORS:

Make sure you have:

 * [X] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
