### PR TITLE
feat(tactic/linarith): basic support for nat

### DIFF
--- a/tactic/linarith.lean
+++ b/tactic/linarith.lean
@@ -8,7 +8,7 @@ A tactic for discharging linear arithmetic goals using Fourier-Motzkin eliminati
 `linarith` is (in principle) complete for ℚ and ℝ. It is not complete for non-dense orders, i.e. ℤ.
 
 @TODO: investigate storing comparisons in a list instead of a set, for possible efficiency gains
-@TODO: perform slightly better on ℤ by strengthening t < 0 hyps to t - 1 ≤ 0
+@TODO: perform slightly better on ℤ by strengthening t < 0 hyps to t + 1 ≤ 0
 @TODO: alternative discharger to `ring`
 @TODO: delay proofs of denominator normalization and nat casting until after contradiction is found
 -/

--- a/tactic/linarith.lean
+++ b/tactic/linarith.lean
@@ -8,9 +8,9 @@ A tactic for discharging linear arithmetic goals using Fourier-Motzkin eliminati
 `linarith` is (in principle) complete for ℚ and ℝ. It is not complete for non-dense orders, i.e. ℤ.
 
 @TODO: investigate storing comparisons in a list instead of a set, for possible efficiency gains
-@TODO: (partial) support for ℕ by casting to ℤ
+@TODO: perform slightly better on ℤ by strengthening t < 0 hyps to t - 1 ≤ 0
 @TODO: alternative discharger to `ring`
-@TODO: delay proofs of denominator normalization until after contradiction is found
+@TODO: delay proofs of denominator normalization and nat casting until after contradiction is found
 -/
 
 import tactic.ring data.nat.gcd data.list.basic meta.rb_map
@@ -24,6 +24,18 @@ open native
 namespace linarith
 
 section lemmas
+
+lemma int.coe_nat_bit0 (n : ℕ) : (↑(bit0 n : ℕ) : ℤ) = bit0 (↑n : ℤ) := by simp [bit0]
+lemma int.coe_nat_bit1 (n : ℕ) : (↑(bit1 n : ℕ) : ℤ) = bit1 (↑n : ℤ) := by simp [bit1, bit0]
+
+lemma nat_eq_subst {n1 n2 : ℕ} {z1 z2 : ℤ} (hn : n1 = n2) (h1 : ↑n1 = z1) (h2 : ↑n2 = z2) : z1 = z2 :=
+by simpa [eq.symm h1, eq.symm h2, int.coe_nat_eq_coe_nat_iff]
+
+lemma nat_le_subst {n1 n2 : ℕ} {z1 z2 : ℤ} (hn : n1 ≤ n2) (h1 : ↑n1 = z1) (h2 : ↑n2 = z2) : z1 ≤ z2 :=
+by simpa [eq.symm h1, eq.symm h2, int.coe_nat_le]
+
+lemma nat_lt_subst {n1 n2 : ℕ} {z1 z2 : ℤ} (hn : n1 < n2) (h1 : ↑n1 = z1) (h2 : ↑n2 = z2) : z1 < z2 :=
+by simpa [eq.symm h1, eq.symm h2, int.coe_nat_lt]
 
 lemma eq_of_eq_of_eq {α} [ordered_semiring α] {a b : α} (ha : a = 0) (hb : b = 0) : a + b = 0 :=
 by simp *
@@ -340,6 +352,8 @@ meta def get_rel_sides : expr → tactic (expr × expr)
 | `(%%a < %%b) := return (a, b)
 | `(%%a ≤ %%b) := return (a, b)
 | `(%%a = %%b) := return (a, b)
+| `(%%a ≥ %%b) := return (a, b)
+| `(%%a > %%b) := return (a, b)
 | _ := failed
 
 meta def mul_expr (n : ℕ) (e : expr) : pexpr :=
@@ -480,12 +494,19 @@ end prove
 section normalize
 open tactic
 
+set_option eqn_compiler.max_steps 50000
+
 meta def rearr_comp (prf : expr) : expr → tactic expr
 | `(%%a ≤ 0) := return prf
 | `(%%a < 0) := return prf
 | `(%%a = 0) := return prf
 | `(%%a ≥ 0) := to_expr ``(neg_nonpos.mpr %%prf)
 | `(%%a > 0) := to_expr ``(neg_neg_of_pos %%prf) --mk_app ``neg_neg_of_pos [prf]
+| `(0 ≥ %%a) := to_expr ``(show %%a ≤ 0, from %%prf)
+| `(0 > %%a) := to_expr ``(show %%a < 0, from %%prf)
+| `(0 = %%a) := to_expr ``(eq.symm %%prf)
+| `(0 ≤ %%a) := to_expr ``(neg_nonpos.mpr %%prf)
+| `(0 < %%a) := to_expr ``(neg_neg_of_pos %%prf)
 | `(%%a ≤ %%b) := to_expr ``(sub_nonpos.mpr %%prf)
 | `(%%a < %%b) := to_expr ``(sub_neg_of_lt %%prf) -- mk_app ``sub_neg_of_lt [prf]
 | `(%%a = %%b) := to_expr ``(sub_eq_zero.mpr %%prf)
@@ -599,13 +620,67 @@ meta def get_contr_lemma_name : expr → tactic name
 | `(%%a > %%b) := return `lt_of_not_ge
 | _ := fail "target type not supported by linarith"
 
+
+-- assumes the input t is of type ℕ. Produces t' of type ℤ such that ↑t = t' and a proof of equality
+meta def cast_expr (e : expr) : tactic (expr × expr) :=
+do s ← [`int.coe_nat_add, `int.coe_nat_mul, `int.coe_nat_zero, `int.coe_nat_one,
+        ``int.coe_nat_bit0, ``int.coe_nat_bit1].mfoldl simp_lemmas.add_simp simp_lemmas.mk,
+   ce ← to_expr ``(↑%%e : ℤ),
+   simplify s [] ce {fail_if_unchanged := ff}
+
+meta def is_nat_int_coe : expr → option expr
+| `((↑(%%n : ℕ) : ℤ)) := some n
+| _ := none
+
+meta def mk_coe_nat_nonneg_prf (e : expr) : tactic expr :=
+mk_app `int.coe_nat_nonneg [e]
+
+meta def get_nat_comps : expr → list expr
+| `(%%a + %%b) := (get_nat_comps a).append (get_nat_comps b)
+| `(%%a * %%b) := (get_nat_comps a).append (get_nat_comps b)
+| e := match is_nat_int_coe e with
+  | some e' := [e']
+  | none := []
+  end
+
+meta def mk_coe_nat_nonneg_prfs (e : expr) : tactic (list expr) :=
+(get_nat_comps e).mmap mk_coe_nat_nonneg_prf
+
+meta def mk_cast_eq_and_nonneg_prfs (pf a b : expr) (ln : name) : tactic (list expr) :=
+do (a', prfa) ← cast_expr a,
+   (b', prfb) ← cast_expr b,
+   la ← mk_coe_nat_nonneg_prfs a',
+   lb ← mk_coe_nat_nonneg_prfs b',
+   pf' ← mk_app ln [pf, prfa, prfb],
+   return $ pf'::(la.append lb)
+
+meta def mk_int_pfs_of_nat_pf (pf : expr) : tactic (list expr) :=
+do tp ← infer_type pf,
+match tp with
+| `(%%a = %%b) := mk_cast_eq_and_nonneg_prfs pf a b ``nat_eq_subst
+| `(%%a ≤ %%b) := mk_cast_eq_and_nonneg_prfs pf a b ``nat_le_subst
+| `(%%a < %%b) := mk_cast_eq_and_nonneg_prfs pf a b ``nat_lt_subst
+| `(%%a ≥ %%b) := mk_cast_eq_and_nonneg_prfs pf b a ``nat_le_subst
+| `(%%a > %%b) := mk_cast_eq_and_nonneg_prfs pf b a ``nat_lt_subst
+| _ := fail "mk_coe_comp_prf failed: proof is not an inequality"
+end
+
+meta def replace_nat_pfs : list expr → tactic (list expr)
+| [] := return []
+| (h::t) :=
+  (do (a, _) ← infer_type h >>= get_rel_sides,
+     infer_type a >>= unify `(ℕ),
+     ls ← mk_int_pfs_of_nat_pf h,
+     list.append ls <$> replace_nat_pfs t) <|> list.cons h <$> replace_nat_pfs t
+
 /--
   Takes a list of proofs of propositions.
   Filters out the proofs of linear (in)equalities,
   and tries to use them to prove `false`.
 -/
 meta def prove_false_by_linarith (cfg : linarith_config) (l : list expr) : tactic unit :=
-do ls ← l.mmap (λ h, (do s ← norm_hyp h, return (some s)) <|> return none),
+do l' ← replace_nat_pfs l,
+   ls ← l'.mmap (λ h, (do s ← norm_hyp h, return (some s)) <|> return none),
    prove_false_by_linarith1 cfg ls.reduce_option
 
 end normalize

--- a/tests/linarith.lean
+++ b/tests/linarith.lean
@@ -1,16 +1,13 @@
 import tactic.linarith
 
-example (h1 : (1 : ℚ) < 1) : false :=
-by linarith
-
-example (e b c a v0 v1 : ℚ) (h1 : v0 = 5*a) (h2 : v1 = 3*b) (h3 : v0 + v1 + c = 10) : 
+example (e b c a v0 v1 : ℚ) (h1 : v0 = 5*a) (h2 : v1 = 3*b) (h3 : v0 + v1 + c = 10) :
   v0 + 5 + (v1 - 3) + (c - 2) = 10 :=
 by linarith
 
 example (ε : ℚ) (h1 : ε > 0) : ε / 2 + ε / 3 + ε / 7 < ε :=
  by linarith
 
-example (x y z : ℚ) (h1 : 2*x  < 3*y) (h2 : -4*x + z/2 < 0) 
+example (x y z : ℚ) (h1 : 2*x  < 3*y) (h2 : -4*x + z/2 < 0)
         (h3 : 12*y - z < 0)  : false :=
 by linarith
 
@@ -24,7 +21,7 @@ example (a b c : ℚ)  (h2 : b + 2 > 3 + b) : false :=
 by linarith {discharger := `[ring SOP]}
 
 example (a b c : ℚ)  (h2 : b + 2 > 3 + b) : false :=
-by linarith 
+by linarith
 
 example (a b c : ℚ) (x y : ℤ) (h1 : x ≤ 3*y) (h2 : b + 2 > 3 + b) : false :=
 by linarith {restrict_type := ℚ}
@@ -42,19 +39,19 @@ example (x y z : ℚ) (h1 : 2*1*x + (3)*(y*(-1)) < 0) (h2 : (-2)*x*2 < -(z + z))
        (h3 : 12*y + (-4)* z < 0) (h4 : nat.prime 7) : false :=
 by linarith
 
-example (x y z : ℤ) (h1 : 2*x  < 3*y) (h2 : -4*x + 2*z < 0) 
+example (x y z : ℤ) (h1 : 2*x  < 3*y) (h2 : -4*x + 2*z < 0)
         (h3 : 12*y - 4* z < 0)  : false :=
 by linarith
 
-example (x y z : ℤ) (h1 : 2*x  < 3*y) (h2 : -4*x + 2*z < 0) (h3 : x*y < 5) 
+example (x y z : ℤ) (h1 : 2*x  < 3*y) (h2 : -4*x + 2*z < 0) (h3 : x*y < 5)
         (h3 : 12*y - 4* z < 0)  : false :=
 by linarith
 
-example (w x y z : ℤ) (h1 : 4*x + (-3)*y + 6*w ≤ 0) (h2 : (-1)*x < 0) 
+example (w x y z : ℤ) (h1 : 4*x + (-3)*y + 6*w ≤ 0) (h2 : (-1)*x < 0)
         (h3 : y < 0) (h4 : w ≥ 0) (h5 : nat.prime x.nat_abs) : false :=
 by linarith
 
-example (a b c : ℚ) (h1 : a > 0) (h2 : b > 5) (h3 : c < -10) 
+example (a b c : ℚ) (h1 : a > 0) (h2 : b > 5) (h3 : c < -10)
         (h4 : a + b - c < 3)  : false :=
 by linarith
 
@@ -68,4 +65,13 @@ example (x : ℚ) (hx : x > 0) (h : x.num < 0) : false :=
 by linarith using [rat.num_pos_iff_pos.mpr hx]
 
 example (x y z : ℚ) (hx : x ≤ 3*y) (h2 : y ≤ 2*z) (h3 : x ≥ 6*z) : x = 3*y :=
+by linarith
+
+example (x y z : ℕ) (hx : x ≤ 3*y) (h2 : y ≤ 2*z) (h3 : x ≥ 6*z) : x = 3*y :=
+by linarith
+
+example (h1 : (1 : ℕ) < 1) : false :=
+by linarith
+
+example (a b c : ℕ) : a + b ≥ a :=
 by linarith


### PR DESCRIPTION
`linarith` can deal with (some) `nat`-valued inequalities by casting to `int`-valued inequalities and adding proofs that the cast terms are nonnegative. It won't try very hard to make sense of nat subtraction.

TO CONTRIBUTORS:

Make sure you have:

 * [ ] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
