### PR TITLE
feat(tactic/auto_cases): split `iff`s into two implications

### DIFF
--- a/tactic/auto_cases.lean
+++ b/tactic/auto_cases.lean
@@ -26,6 +26,7 @@ do t' ← infer_type h,
   | `(fin 0)     := tt
   | `(sum _ _)   := tt -- This is perhaps dangerous!
   | `(or _ _)    := tt -- This is perhaps dangerous!
+  | `(iff _ _)   := tt -- This is perhaps dangerous!
   | _            := ff
   end,
   if use_cases then
@@ -34,7 +35,7 @@ do t' ← infer_type h,
     match t' with
     -- `cases` can be dangerous on `eq` and `quot`, producing mysterious errors during type checking.
     -- instead we attempt `induction`
-    | `(eq _ _)        := (do induction h, pp ← pp h, return ("induction " ++ pp.to_string))
+    | `(eq _ _)        := do induction h, pp ← pp h, return ("induction " ++ pp.to_string)
     | `(quot _)        := do induction h, pp ← pp h, return ("induction " ++ pp.to_string)
     | _                := failed
     end

--- a/tests/tidy.lean
+++ b/tests/tidy.lean
@@ -49,4 +49,6 @@ end.
 
 def f : unit → unit → unit := by tidy -- intros a a_1, cases a_1, cases a, fsplit
 
+def g (P Q : Prop) (p : P) (h : P ↔ Q) : Q := by tidy
+
 end tidy.test


### PR DESCRIPTION
The tactic `auto_cases` should break `iff`s into two implication hypotheses. Right, @semorrison? Perhaps it is too dangerous.

Also remove random brackets.

TO CONTRIBUTORS:

Make sure you have:

 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [x] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
