### PR TITLE
feat(tactic/ext): add apply_cfg argument to ext1

### DIFF
--- a/tactic/ext.lean
+++ b/tactic/ext.lean
@@ -162,9 +162,9 @@ meta def ext1 (xs : ext_patt) : tactic ext_patt :=
 do subject ← target >>= get_ext_subject,
    m ← extensional_attribute.get_cache,
    do { rule ← m.find subject,
-        applyc rule } <|>
+        applyc rule {new_goals := new_goals.all} } <|>
      do { ls ← attribute.get_instances `extensionality,
-          ls.any_of applyc } <|>
+          ls.any_of (λ n, applyc n {new_goals := new_goals.all}) } <|>
      fail format!"no applicable extensionality rule found for {subject}",
    try_intros xs
 

--- a/tactic/ext.lean
+++ b/tactic/ext.lean
@@ -158,13 +158,13 @@ do tgt ← target >>= whnf,
      then rintro [x] >> try_intros xs
      else pure (x :: xs)
 
-meta def ext1 (xs : ext_patt) : tactic ext_patt :=
+meta def ext1 (xs : ext_patt) (cfg : apply_cfg := {}): tactic ext_patt :=
 do subject ← target >>= get_ext_subject,
    m ← extensional_attribute.get_cache,
    do { rule ← m.find subject,
-        applyc rule {new_goals := new_goals.all} } <|>
+        applyc rule cfg } <|>
      do { ls ← attribute.get_instances `extensionality,
-          ls.any_of (λ n, applyc n {new_goals := new_goals.all}) } <|>
+          ls.any_of (λ n, applyc n cfg) } <|>
      fail format!"no applicable extensionality rule found for {subject}",
    try_intros xs
 

--- a/tactic/tidy.lean
+++ b/tactic/tidy.lean
@@ -32,11 +32,19 @@ do names ← attribute.get_instances `tidy,
    tactics ← names.mmap name_to_tactic,
    first tactics <|> fail "no @[tidy] tactics succeeded"
 
+meta def ext1_wrapper : tactic string :=
+do ng ← num_goals,
+   ext1 [] {apply_cfg . new_goals := new_goals.all},
+   ng' ← num_goals,
+   return $ if ng' > ng then
+     "tactic.ext1 [] {new_goals := tactic.new_goals.all}"
+   else "ext1"
+
 meta def default_tactics : list (tactic string) :=
 [ reflexivity                                 >> pure "refl", 
   `[exact dec_trivial]                        >> pure "exact dec_trivial",
   propositional_goal >> assumption            >> pure "assumption",
-  `[ext1]                                     >> pure "ext1",
+  ext1_wrapper,
   intros1                                     >>= λ ns, pure ("intros " ++ (" ".intercalate (ns.map (λ e, e.to_string)))),
   auto_cases,
   `[apply_auto_param]                         >> pure "apply_auto_param",

--- a/tests/tactics.lean
+++ b/tests/tactics.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Scott Morrison
 -/
-import tactic data.set.lattice data.prod
+import tactic data.set.lattice data.prod data.vector
        tactic.rewrite data.stream.basic
 
 section solve_by_elim
@@ -476,6 +476,31 @@ begin
     guard_tags _field one_mul monoid, admit,
     guard_tags _field mul_one monoid, admit, },
   trivial
+end
+
+structure dependent_fields :=
+(a : bool)
+(v : if a then ℕ else ℤ)
+
+@[extensionality] lemma df.ext (s t : dependent_fields) (h : s.a = t.a)
+ (w : (@eq.rec _ s.a (λ b, if b then ℕ else ℤ) s.v t.a h) = t.v): s = t :=
+begin
+  cases s, cases t,
+  dsimp at *,
+  congr,
+  exact h,
+  subst h,
+  simp,
+  simp at w,
+  exact w,
+end
+
+example (s : dependent_fields) : s = s :=
+begin
+  ext,
+  guard_target s.a = s.a,
+  refl,
+  refl,
 end
 
 end ext

--- a/tests/tactics.lean
+++ b/tests/tactics.lean
@@ -497,7 +497,7 @@ end
 
 example (s : dependent_fields) : s = s :=
 begin
-  ext,
+  tactic.ext1 [] {tactic.apply_cfg . new_goals := tactic.new_goals.all},
   guard_target s.a = s.a,
   refl,
   refl,


### PR DESCRIPTION
This causes goals to appear in the same order they appear as hypotheses of the
`@[extensionality]` lemma, rather than being reordered to put dependent
goals first.

This doesn't appear to affect any uses of `ext` in mathlib,
but is occasionally helpful in the development of category theory.

(Indeed, I have been running into tactic mode proofs that fail to
typecheck, when using ext, and this avoids the problem. My
actual dependent ext lemma is at [here](https://github.com/semorrison/lean-category-theory/blob/64fb9063c2e72a056b2c2624d4f667a7e663f14e/src/category_theory/presheaves.lean#L32), and the place where I need 
to swap the goals back into order by hand is [here](https://github.com/semorrison/lean-category-theory/blob/64fb9063c2e72a056b2c2624d4f667a7e663f14e/src/category_theory/presheaves/map.lean#L29).)

TO CONTRIBUTORS:

Make sure you have:

 * [X] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [X] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)

For reviewers: [code review check list](./docs/code-review.md)
