### PR TITLE
feat(tactic/fin_cases): a tactic to case bash on `fin n`

### DIFF
--- a/data/fin.lean
+++ b/data/fin.lean
@@ -27,6 +27,8 @@ lemma eq_iff_veq (a b : fin n) : a = b ↔ a.1 = b.1 :=
 
 instance fin_to_nat (n : ℕ) : has_coe (fin n) nat := ⟨fin.val⟩
 
+@[simp] def mk_val {m n : ℕ} (h : m < n) : (⟨m, h⟩ : fin n).val = m := rfl
+
 instance {n : ℕ} : decidable_linear_order (fin n) :=
 { le_refl := λ a, @le_refl ℕ _ _,
   le_trans := λ a b c, @le_trans ℕ _ _ _ _,

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -551,3 +551,14 @@ Known limitation(s):
     `squeeze_simp` will produce as many suggestions as the number of goals it is applied to.
     It is likely that none of the suggestion is a good replacement but they can all be
     combined by concatenating their list of lemmas.
+
+## fin_cases
+Performs cases analysis on a `fin n` hypothesis. As an example, in
+```
+example (f : ℕ → Prop) (p : fin 3) (h0 : f 0) (h1 : f 1) (h2 : f 2) : f p.val :=
+begin
+  fin_cases p,
+  all_goals { assumption }
+end
+```
+after `fin_cases p`, there are three goals, `f 0`, `f 1`, and `f 2`.

--- a/tactic/fin_cases.lean
+++ b/tactic/fin_cases.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2018 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Scott Morrison
+
+Case bashing on `fin n`, for explicit numerals `n`.
+-/
+import tactic.linarith
+
+namespace tactic
+
+meta def is_numeral : expr → bool
+| `(bit0 _) := tt
+| `(bit1 _) := tt
+| _ := ff
+
+meta def fin_cases_at (e : expr) : tactic unit :=
+do `(fin %%n) ← infer_type e,
+   guard (is_numeral n),
+   [(_, [val, bd], _)] ← cases_core e [`val, `bd],
+   n ← eval_expr ℕ n,
+   -- We now call `cases val` n times, rotating the generated goals out of the way.
+   iterate_at_most n (do val ← get_local `val, cases val, rotate 1),
+   -- We've got an absurd hypothesis, but it is messy: it looks like
+   -- `nat.succ (... (nat.succ val)) < n`
+   -- So we rewrite it as `val + 1 + ... + 1 < n`, and call `linarith` to kill it.
+   ss ← mk_const `nat.succ_eq_add_one,
+   bd ← get_local `bd,
+   (list.range n).mfoldl (λ bd _, do rewrite_hyp ss bd) bd,
+   exfalso >> `[linarith],
+   -- Finally we put the goals back in order.
+   rotate_right n
+
+meta def fin_cases : tactic unit :=
+do ctx ← local_context,
+   ctx.mfirst fin_cases_at <|> fail "No explicit `fin n` hypotheses."
+
+run_cmd add_interactive [`fin_cases]
+
+-- TODO would it be valuable to have an interactive tactic with a parser, so we can aim this
+-- at individual hypotheses, rather than just the first that matches?
+end tactic

--- a/tactic/fin_cases.lean
+++ b/tactic/fin_cases.lean
@@ -11,9 +11,8 @@ namespace tactic
 
 meta def fin_cases_at (e : expr) : tactic unit :=
 do `(fin %%n) ← infer_type e,
-   guard n.is_numeral,
-   [(_, [val, bd], _)] ← cases_core e [`val, `bd],
    n ← eval_expr ℕ n,
+   [(_, [val, bd], _)] ← cases_core e [`val, `bd],
    -- We now call `cases val` n times, rotating the generated goals out of the way.
    iterate_at_most n (do val ← get_local `val, cases val, rotate 1),
    -- We've got an absurd hypothesis, but it is messy: it looks like

--- a/tactic/fin_cases.lean
+++ b/tactic/fin_cases.lean
@@ -9,14 +9,9 @@ import tactic.linarith
 
 namespace tactic
 
-meta def is_numeral : expr → bool
-| `(bit0 _) := tt
-| `(bit1 _) := tt
-| _ := ff
-
 meta def fin_cases_at (e : expr) : tactic unit :=
 do `(fin %%n) ← infer_type e,
-   guard (is_numeral n),
+   guard n.is_numeral,
    [(_, [val, bd], _)] ← cases_core e [`val, `bd],
    n ← eval_expr ℕ n,
    -- We now call `cases val` n times, rotating the generated goals out of the way.

--- a/tactic/fin_cases.lean
+++ b/tactic/fin_cases.lean
@@ -5,9 +5,7 @@ Author: Scott Morrison
 
 Case bashing on `fin n`, for explicit numerals `n`.
 -/
-import tactic.linarith
-
-def fin_val {m n : ℕ} (h : m < n) : (⟨m, h⟩ : fin n).val = m := rfl
+import data.fin
 
 namespace tactic
 open lean.parser
@@ -19,21 +17,35 @@ do `(fin %%n) ← infer_type e,
    [(_, [val, bd], _)] ← cases_core e [`val, `bd],
    -- We now call `cases val` n times, rotating the generated goals out of the way.
    iterate_at_most n (do val ← get_local `val, cases val, rotate 1),
-   -- We've got an absurd hypothesis, but it is messy: it looks like
+   -- We've got an absurd hypothesis `bd`, but it is messy: it looks like
    -- `nat.succ (... (nat.succ val)) < n`
-   -- So we rewrite it as `val + 1 + ... + 1 < n`, and call `linarith` to kill it.
+   -- So we rewrite it as `bd : val + 1 + ... + 1 < n`, and use `dec_trivial` to kill it.
    ss ← mk_const `nat.succ_eq_add_one,
    bd ← get_local `bd,
    (list.range n).mfoldl (λ bd _, do rewrite_hyp ss bd) bd,
-   exfalso >> `[linarith],
+   to_expr ``(absurd %%bd dec_trivial) >>= exact,
    -- We put the goals back in order, and clear the `bd` hypotheses.
    iterate_exactly n (do rotate_right 1,
-                         try `[rw [fin_val]],
+                         try `[rw [fin.mk_val]],
                          try (get_local `bd >>= clear))
 
 namespace interactive
 private meta def hyp := tk "*" *> return none <|> some <$> ident
 
+/--
+`fin_cases h` performs case analysis on a hypothesis `h : fin n`, where `n` is an explicit natural
+number. `fin_cases *` performs case analysis on all suitable hypotheses.
+
+As an example, in
+```
+example (f : ℕ → Prop) (p : fin 3) (h0 : f 0) (h1 : f 1) (h2 : f 2) : f p.val :=
+begin
+  fin_cases p,
+  all_goals { assumption }
+end
+```
+after `fin_cases p`, there are three goals, `f 0`, `f 1`, and `f 2`.
+-/
 meta def fin_cases : parse hyp → tactic unit
 | none := do ctx ← local_context,
              ctx.mfirst fin_cases_at <|> fail "No explicit `fin n` hypotheses."

--- a/tactic/fin_cases.lean
+++ b/tactic/fin_cases.lean
@@ -7,7 +7,7 @@ Case bashing on `fin n`, for explicit numerals `n`.
 -/
 import tactic.linarith
 
-def fin_val {m n : ℕ} (h : m < n) : (⟨m, h⟩ : fin n).val = m := rfl 
+def fin_val {m n : ℕ} (h : m < n) : (⟨m, h⟩ : fin n).val = m := rfl
 
 namespace tactic
 open lean.parser
@@ -27,8 +27,8 @@ do `(fin %%n) ← infer_type e,
    (list.range n).mfoldl (λ bd _, do rewrite_hyp ss bd) bd,
    exfalso >> `[linarith],
    -- We put the goals back in order, and clear the `bd` hypotheses.
-   iterate_exactly n (do rotate_right 1, 
-                         `[rw [fin_val]], 
+   iterate_exactly n (do rotate_right 1,
+                         try `[rw [fin_val]],
                          try (get_local `bd >>= clear))
 
 namespace interactive

--- a/tests/fin_cases.lean
+++ b/tests/fin_cases.lean
@@ -1,0 +1,8 @@
+import tactic.fin_cases
+
+example (x2 : fin 2) (x3 : fin 3) (n : nat) (y : fin n) : x2.val * x3.val = x3.val * x2.val :=
+begin
+  fin_cases ; fin_cases,
+  success_if_fail { fin_cases },
+  all_goals { simp },
+end

--- a/tests/fin_cases.lean
+++ b/tests/fin_cases.lean
@@ -1,8 +1,17 @@
 import tactic.fin_cases
 
+
+example (f : ℕ → Prop) (p : fin 3) (h0 : f 0) (h1 : f 1) (h2 : f 2) : f p.val :=
+begin
+  fin_cases *,
+  all_goals { assumption }
+end
+
 example (x2 : fin 2) (x3 : fin 3) (n : nat) (y : fin n) : x2.val * x3.val = x3.val * x2.val :=
 begin
-  fin_cases ; fin_cases,
-  success_if_fail { fin_cases },
+  fin_cases x2;
+  fin_cases x3,
+  success_if_fail { fin_cases * },
+  success_if_fail { fin_cases y },
   all_goals { simp },
 end


### PR DESCRIPTION
No documentation yet. If we want to merge this, perhaps should add an interactive mode with a parser to aim at particular hypotheses.

Make sure you have:

 * [X] for tactics:
     * [X] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [X] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
