### PR TITLE
refactor (data/finset): explicit arguments for subset_union_* and inter_subset_*

### DIFF
--- a/analysis/topology/infinite_sum.lean
+++ b/analysis/topology/infinite_sum.lean
@@ -202,7 +202,7 @@ have j_inj : ∀x y (hx : f x ≠ 0) (hy : f y ≠ 0), (j hx = j hy ↔ x = y),
 let ii : finset γ → finset β := λu, u.bind $ λc, if h : g c = 0 then ∅ else {i h} in
 let jj : finset β → finset γ := λv, v.bind $ λb, if h : f b = 0 then ∅ else {j h} in
 is_sum_of_is_sum $ assume u, exists.intro (ii u) $
-  assume v hv, exists.intro (u ∪ jj v) $ and.intro subset_union_left $
+  assume v hv, exists.intro (u ∪ jj v) $ and.intro (subset_union_left _ _) $
   have ∀c:γ, c ∈ u ∪ jj v → c ∉ jj v → g c = 0,
     from assume c hc hnc, classical.by_contradiction $ assume h : g c ≠ 0,
     have c ∈ u,
@@ -212,7 +212,7 @@ is_sum_of_is_sum $ assume u, exists.intro (ii u) $
     have j (hi h) ∈ jj v,
       by simp [mem_bind]; existsi i h; simp [h, hi, this],
     by rw [hji h] at this; exact hnc this,
-  calc (u ∪ jj v).sum g = (jj v).sum g : (sum_subset subset_union_right this).symm
+  calc (u ∪ jj v).sum g = (jj v).sum g : (sum_subset (subset_union_right _ _) this).symm
     ... = v.sum _ : sum_bind $ by intros x hx y hy hxy; by_cases f x = 0; by_cases f y = 0; simp [*]
     ... = v.sum f : sum_congr rfl $ by intros x hx; by_cases f x = 0; simp [*]
 
@@ -433,7 +433,7 @@ suffices cauchy (at_top.map (λs:finset β, s.sum f')),
   have ∀{u₁ u₂}, t ⊆ u₁ → t ⊆ u₂ → (u₁.sum f', u₂.sum f') ∈ s',
     from assume u₁ u₂ h₁ h₂,
     have ((t ∪ u₁.filter (λb, f' b ≠ 0)).sum f, (t ∪ u₂.filter (λb, f' b ≠ 0)).sum f) ∈ s,
-      from ht _ _ subset_union_left subset_union_left,
+      from ht _ _ (subset_union_left _ _) (subset_union_left _ _),
     have ((t ∪ u₁.filter (λb, f' b ≠ 0)).sum f - d, (t ∪ u₂.filter (λb, f' b ≠ 0)).sum f - d) ∈ s',
       from hss' this $ refl_mem_uniformity hs,
     by rwa [eq h₁, eq h₂] at this,

--- a/data/finset.lean
+++ b/data/finset.lean
@@ -269,9 +269,9 @@ by rw [mem_union, not_or_distrib]
 theorem union_subset {s₁ s₂ s₃ : finset α} (h₁ : s₁ ⊆ s₃) (h₂ : s₂ ⊆ s₃) : s₁ ∪ s₂ ⊆ s₃ :=
 val_le_iff.1 (ndunion_le.2 ⟨h₁, val_le_iff.2 h₂⟩)
 
-theorem subset_union_left {s₁ s₂ : finset α} : s₁ ⊆ s₁ ∪ s₂ := λ x, mem_union_left _
+theorem subset_union_left (s₁ s₂ : finset α) : s₁ ⊆ s₁ ∪ s₂ := λ x, mem_union_left _
 
-theorem subset_union_right {s₁ s₂ : finset α} : s₂ ⊆ s₁ ∪ s₂ := λ x, mem_union_right _
+theorem subset_union_right (s₁ s₂ : finset α) : s₂ ⊆ s₁ ∪ s₂ := λ x, mem_union_right _
 
 @[simp] theorem union_comm (s₁ s₂ : finset α) : s₁ ∪ s₂ = s₂ ∪ s₁ :=
 ext.2 $ λ x, by simp only [mem_union, or_comm]
@@ -333,9 +333,9 @@ theorem mem_of_mem_inter_right {a : α} {s₁ s₂ : finset α} (h : a ∈ s₁ 
 theorem mem_inter_of_mem {a : α} {s₁ s₂ : finset α} : a ∈ s₁ → a ∈ s₂ → a ∈ s₁ ∩ s₂ :=
 and_imp.1 mem_inter.2
 
-theorem inter_subset_left {s₁ s₂ : finset α} : s₁ ∩ s₂ ⊆ s₁ := λ a, mem_of_mem_inter_left
+theorem inter_subset_left (s₁ s₂ : finset α) : s₁ ∩ s₂ ⊆ s₁ := λ a, mem_of_mem_inter_left
 
-theorem inter_subset_right {s₁ s₂ : finset α} : s₁ ∩ s₂ ⊆ s₂ := λ a, mem_of_mem_inter_right
+theorem inter_subset_right (s₁ s₂ : finset α) : s₁ ∩ s₂ ⊆ s₂ := λ a, mem_of_mem_inter_right
 
 theorem subset_inter {s₁ s₂ s₃ : finset α} : s₁ ⊆ s₂ → s₁ ⊆ s₃ → s₁ ⊆ s₂ ∩ s₃ :=
 by simp only [subset_iff, mem_inter] {contextual:=tt}; intros; split; trivial
@@ -398,12 +398,12 @@ by rw [inter_comm, singleton_inter_of_not_mem h]
 instance : lattice (finset α) :=
 { sup          := (∪),
   sup_le       := assume a b c, union_subset,
-  le_sup_left  := assume a b, subset_union_left,
-  le_sup_right := assume a b, subset_union_right,
+  le_sup_left  := subset_union_left,
+  le_sup_right := subset_union_right,
   inf          := (∩),
   le_inf       := assume a b c, subset_inter,
-  inf_le_left  := assume a b, inter_subset_left,
-  inf_le_right := assume a b, inter_subset_right,
+  inf_le_left  := inter_subset_left,
+  inf_le_right := inter_subset_right,
   ..finset.partial_order }
 
 @[simp] theorem sup_eq_union (s t : finset α) : s ⊔ t = s ∪ t := rfl

--- a/data/finsupp.lean
+++ b/data/finsupp.lean
@@ -436,10 +436,10 @@ lemma prod_add_index [add_comm_monoid β] [comm_monoid γ] {f g : α →₀ β}
   {h : α → β → γ} (h_zero : ∀a, h a 0 = 1) (h_add : ∀a b₁ b₂, h a (b₁ + b₂) = h a b₁ * h a b₂) :
   (f + g).prod h = f.prod h * g.prod h :=
 have f_eq : (f.support ∪ g.support).prod (λa, h a (f a)) = f.prod h,
-  from (finset.prod_subset finset.subset_union_left $
+  from (finset.prod_subset (finset.subset_union_left _ _) $
     by intros _ _ H; rw [not_mem_support_iff.1 H, h_zero]).symm,
 have g_eq : (f.support ∪ g.support).prod (λa, h a (g a)) = g.prod h,
-  from (finset.prod_subset finset.subset_union_right $
+  from (finset.prod_subset (finset.subset_union_right _ _) $
     by intros _ _ H; rw [not_mem_support_iff.1 H, h_zero]).symm,
 calc (f + g).support.prod (λa, h a ((f + g) a)) =
       (f.support ∪ g.support).prod (λa, h a ((f + g) a)) :


### PR DESCRIPTION
This change makes them a little easier to apply, and also makes them consistent with their analogues in set.basic.

[One comment on zulip here](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/subject/finset.2Esubset_union_*/near/134045517).

TO CONTRIBUTORS:

Make sure you have:

 * [X] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
