### PR TITLE
feat(tactic/linarith): option to prove arbitrary goals by exfalso

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -410,9 +410,10 @@ by linarith
 `linarith h1 h2 h3` will ohly use the local hypotheses `h1`, `h2`, `h3`.
 `linarith using [t1, t2, t3] will add `t1`, `t2`, `t3` to the local context and then run
 `linarith`.
-`linarith {discharger := tac, restrict_type := tp}` takes a config object with two optional
+`linarith {discharger := tac, restrict_type := tp, exfalso := ff}` takes a config object with three optional
 arguments. `discharger` specifies a tactic to be used for reducing an algebraic equation in the
 proof stage. The default is `ring`. Other options currently include `ring SOP` or `simp` for basic
 problems. `restrict_type` will only use hypotheses that are inequalities over `tp`. This is useful
 if you have e.g. both integer and rational valued inequalities in the local context, which can
 sometimes confuse the tactic.
+If `exfalso` is false, `linarith` will fail when the goal is neither an inequality nor `false`. (True by default.)

--- a/tests/linarith.lean
+++ b/tests/linarith.lean
@@ -59,7 +59,7 @@ example (a b c : ℚ) (h2 : b > 0) (h3 : b < 0) : false :=
 by linarith
 
 example (a b c : ℚ) (h2 : (2 : ℚ) > 3)  : a + b - c ≥ 3 :=
-by linarith
+by linarith {exfalso := ff}
 
 example (x : ℚ) (hx : x > 0) (h : x.num < 0) : false :=
 by linarith using [rat.num_pos_iff_pos.mpr hx]
@@ -71,6 +71,9 @@ example (x y z : ℕ) (hx : x ≤ 3*y) (h2 : y ≤ 2*z) (h3 : x ≥ 6*z) : x = 3
 by linarith
 
 example (h1 : (1 : ℕ) < 1) : false :=
+by linarith
+
+example (a b c : ℚ) (h2 : b > 0) (h3 : b < 0) : nat.prime 10 :=
 by linarith
 
 example (a b c : ℕ) : a + b ≥ a :=


### PR DESCRIPTION
If the target is not an inequality, `linarith` will apply `exfalso` and try to find a contradiction from the hypotheses. This can be disabled using `linarith {exfalso := ff}`.

TO CONTRIBUTORS:

Make sure you have:

 * [ ] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
