### PR TITLE
Proof by "the following are equivalent"

### DIFF
--- a/category/basic.lean
+++ b/category/basic.lean
@@ -6,7 +6,7 @@ Authors: Johannes Hölzl
 Extends the theory on functors, applicatives and monads.
 -/
 
-universes u v
+universes u v w
 variables {α β γ : Type u}
 
 notation a ` $< `:1 f:1 := f a
@@ -94,6 +94,23 @@ by rw [← bind_pure_comp_eq_map, bind_assoc]; simp [pure_bind]
 
 lemma seq_eq_bind_map {x : m α} {f : m (α → β)} : f <*> x = (f >>= (<$> x)) :=
 (bind_map_eq_seq m f x).symm
+
+variables {β' γ' : Type v}
+variables {m' : Type v → Type w} [monad m']
+
+def list.mmap_accumr (f : α → β' → m' (β' × γ')) : β' → list α → m' (β' × list γ')
+| a [] := pure (a,[])
+| a (x :: xs) :=
+  do (a',ys) ← list.mmap_accumr a xs,
+     (a'',y) ← f x a',
+     pure (a'',y::ys)
+
+def list.mmap_accuml (f : β' → α → m' (β' × γ')) : β' → list α → m' (β' × list γ')
+| a [] := pure (a,[])
+| a (x :: xs) :=
+  do (a',y) ← f a x,
+     (a'',ys) ← list.mmap_accuml a' xs,
+     pure (a'',y :: ys)
 
 end monad
 

--- a/data/list/basic.lean
+++ b/data/list/basic.lean
@@ -3879,6 +3879,13 @@ end⟩
 theorem tfae_cons_cons {a b} {l : list Prop} : tfae (a::b::l) ↔ (a ↔ b) ∧ tfae (b::l) :=
 tfae_cons_of_mem (or.inl rfl)
 
+theorem tfae_of_forall (b : Prop) (l : list Prop) (h : ∀ a ∈ l, a ↔ b) : tfae l :=
+show ∀ x ∈ l, ∀ y ∈ l, x ↔ y, from
+assume x (hx : x ∈ l) y (hy : y ∈ l),
+calc  x
+    ↔ b : h _ hx
+... ↔ y : (h _ hy).symm
+
 theorem tfae_of_cycle {a b} {l : list Prop} :
   list.chain (→) a (b::l) → (last' b l → a) → tfae (a::b::l) :=
 begin

--- a/data/list/basic.lean
+++ b/data/list/basic.lean
@@ -3849,9 +3849,6 @@ def map_last {α} (f : α → α) : list α → list α
 | [x] := [f x]
 | (x :: xs) := x :: map_last xs
 
-/- tfae: The Following (propositions) Are Equivalent -/
-section tfae
-
 @[simp] def last' {α} : α → list α → α
 | a []     := a
 | a (b::l) := last' b l
@@ -3860,6 +3857,9 @@ theorem last'_mem {α} : ∀ a l, @last' α a l ∈ a :: l
 | a []     := or.inl rfl
 | a (b::l) := or.inr (last'_mem b l)
 
+section tfae
+
+/-- tfae: The Following (propositions) Are Equivalent -/
 def tfae (l : list Prop) : Prop := ∀ x ∈ l, ∀ y ∈ l, x ↔ y
 
 theorem tfae_nil : tfae [] := forall_mem_nil _

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -23,9 +23,9 @@ tactics.  The first tactic is `tfae_have`.  As an argument it takes an
 expression of the form `i arrow j`, where `i` and `j` are two positive
 natural numbers, and `arrow` is an arrow such as `→`, `->`, `←`, `<-`,
 `↔`, or `<->`.  The tactic `tfae_have : i arrow j` sets up a subgoal in
-which the user
+which the user has to prove the equivalence (or implication) of `pi` and `pj`.
 
-The remaining tactics, `tfae_finish`, is a finishing tactic. It
+The remaining tactic, `tfae_finish`, is a finishing tactic. It
 collects all implications and equivalences from the local context and
 computes their transitive closure to close the
 main goal.

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -4,6 +4,56 @@ In addition to [core tactics](https://leanprover.github.io/reference/tactics.htm
 mathlib provides a number of specific interactive tactics and commands.
 Here we document the mostly commonly used ones.
 
+### tfae
+
+The `tfae` tactic suite is a set of tactics that help with proving that certain
+propositions are equivalent.
+In `data/list/basic.lean` there is a section devoted to propositions of the
+form
+```
+tfae [p1, p2, ..., pn]
+```
+where `p1`, `p2`, through, `pn` are terms of type `Prop`.
+This proposition asserts that all the `pi` are pairwise equivalent.
+There are results that allow to extract the equivalence
+of two propositions `pi` and `pj`.
+
+To prove a goal of the form `tfae [p1, p2, ..., pn]`, there are two
+tactics.  The first tactic is `tfae_have`.  As an argument it takes an
+expression of the form `i arrow j`, where `i` and `j` are two positive
+natural numbers, and `arrow` is an arrow such as `→`, `->`, `←`, `<-`,
+`↔`, or `<->`.  The tactic `tfae_have : i arrow j` sets up a subgoal in
+which the user
+
+The remaining tactics, `tfae_finish`, is a finishing tactic. It
+collects all implications and equivalences from the local context and
+computes their transitive closure to close the
+main goal.
+
+`tfae_have` and `tfae_finish` can be used together in a proof as
+follows:
+
+```lean
+example (a b c d : Prop) : tfae [a,b,c,d] :=
+begin
+  tfae_have : 3 → 1,
+  { /- prove c → a -/ },
+  tfae_have : 2 → 3,
+  { /- prove b → c -/ },
+  tfae_have : 2 ← 1,
+  { /- prove a → b -/ },
+  tfae_have : 4 ↔ 2,
+  { /- prove d ↔ b -/ },
+    -- a b c d : Prop,
+    -- tfae_3_to_1 : c → a,
+    -- tfae_2_to_3 : b → c,
+    -- tfae_1_to_2 : a → b,
+    -- tfae_4_iff_2 : d ↔ b
+    -- ⊢ tfae [a, b, c, d]
+  tfae_finish,
+end
+```
+
 ### rcases
 
 The `rcases` tactic is the same as `cases`, but with more flexibility in the
@@ -414,10 +464,10 @@ by linarith
 `linarith`.
 
 `linarith {discharger := tac, restrict_type := tp, exfalso := ff}` takes a config object with three optional
-arguments. 
+arguments.
 * `discharger` specifies a tactic to be used for reducing an algebraic equation in the
 proof stage. The default is `ring`. Other options currently include `ring SOP` or `simp` for basic
-problems. 
+problems.
 * `restrict_type` will only use hypotheses that are inequalities over `tp`. This is useful
 if you have e.g. both integer and rational valued inequalities in the local context, which can
 sometimes confuse the tactic.

--- a/tactic/scc.lean
+++ b/tactic/scc.lean
@@ -48,7 +48,6 @@ do `(%%e₀ ↔ %%e₁) ← infer_type p >>= instantiate_mvars,
      p₂ ← mk_app ``iff.symm [p₀],
      p ← mk_app ``iff.trans [p₂,p],
      p ← mk_app ``iff.trans [p,p₁],
-     m ← read_ref cl,
      modify_ref cl $ λ m, m.insert e₂ (e₃,p)
    else pure ()
 
@@ -63,8 +62,7 @@ do (r,p₀) ← root cl e₀,
 meta def is_eqv (cl : closure) (e₀ e₁ : expr) : tactic bool :=
 do (r,p₀) ← root cl e₀,
    (r',p₁) ← root cl e₁,
-   b ← try_core $ is_def_eq r r',
-   pure b.is_some
+   succeeds $ is_def_eq r r'
 
 end closure
 

--- a/tactic/scc.lean
+++ b/tactic/scc.lean
@@ -54,7 +54,6 @@ do `(%%e₀ ↔ %%e₁) ← infer_type p >>= instantiate_mvars,
 meta def prove_eqv (cl : closure) (e₀ e₁ : expr) : tactic expr :=
 do (r,p₀) ← root cl e₀,
    (r',p₁) ← root cl e₁,
-   m ← read_ref cl,
    is_def_eq r r',
    p₁ ← mk_app ``iff.symm [p₁],
    mk_app ``iff.trans [p₀,p₁]

--- a/tactic/scc.lean
+++ b/tactic/scc.lean
@@ -3,8 +3,12 @@ Copyright (c) 2018 Simon Hudon All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon
 
-Data structures and algorithms for finding the sets of equivalent
-proposition in a set of implications.
+Tactics based on the strongly connected components (SCC) of a graph where
+the vertices are propositions and the edges are implications found
+in the context.
+
+They are used for finding the sets of equivalent proposition in a set
+of implications.
 -/
 
 import tactic.basic
@@ -142,19 +146,17 @@ meta def prove_eqv_target (cl : closure) : tactic unit :=
 do `(%%p ↔ %%q) ← target >>= whnf,
    cl.prove_eqv p q >>= exact
 
-meta def interactive.check_eqv : tactic unit :=
-closure.mk_closure $ λ cl,
-do ls ← local_context,
-   ls.mmap' $ λ l, try (cl.merge l),
-   `(%%p ↔ %%q) ← target,
-   cl.prove_eqv p q >>= exact
-
+/-- Use the available equivalences and implications to prove
+a goal of the form `p ↔ q`. -/
 meta def interactive.scc : tactic unit :=
 closure.mk_closure $ λ cl,
 do impl_graph.mk_scc cl,
    `(%%p ↔ %%q) ← target,
    cl.prove_eqv p q >>= exact
 
+/-- Collect all the available equivalences and implications and
+add assumptions for every equivalence that can be proven using the
+strongly connected components technique. Mostly useful for testing. -/
 meta def interactive.scc' : tactic unit :=
 closure.mk_closure $ λ cl,
 do m ← impl_graph.mk_scc cl,

--- a/tactic/scc.lean
+++ b/tactic/scc.lean
@@ -1,0 +1,167 @@
+/-
+Copyright (c) 2018 Simon Hudon All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Simon Hudon
+
+Data structures and algorithms for finding the sets of equivalent
+proposition in a set of implications.
+-/
+
+import tactic.basic
+import tactic.tauto
+import category.basic
+
+namespace tactic
+
+meta def closure := ref (expr_map (expr × expr))
+
+namespace closure
+
+meta def mk_closure {α} : (closure → tactic α) → tactic α :=
+using_new_ref (expr_map.mk _)
+
+meta def root' (cl : closure) : expr → tactic (expr × expr) | e :=
+do m ← read_ref cl,
+   match m.find e with
+   | none :=
+     do p ← mk_app ``iff.refl [e],
+        pure (e,p)
+   | (some (e₀,p₀)) :=
+     do (e₁,p₁) ← root' e₀,
+        p ← mk_app ``iff.trans [p₀,p₁],
+        modify_ref cl $ λ m, m.insert e (e₁,p),
+        pure (e₁,p)
+   end
+
+meta def root (cl : closure) (p : expr) : tactic (expr × expr) :=
+instantiate_mvars p >>= root' cl
+
+meta def merge (cl : closure) (p : expr) : tactic unit :=
+do `(%%e₀ ↔ %%e₁) ← infer_type p >>= instantiate_mvars,
+   (e₂,p₀) ← root cl e₀,
+   (e₃,p₁) ← root cl e₁,
+   if e₂ ≠ e₃ then do
+     p₂ ← mk_app ``iff.symm [p₀],
+     p ← mk_app ``iff.trans [p₂,p],
+     p ← mk_app ``iff.trans [p,p₁],
+     m ← read_ref cl,
+     modify_ref cl $ λ m, m.insert e₂ (e₃,p)
+   else pure ()
+
+meta def prove_eqv (cl : closure) (e₀ e₁ : expr) : tactic expr :=
+do (r,p₀) ← root cl e₀,
+   (r',p₁) ← root cl e₁,
+   m ← read_ref cl,
+   is_def_eq r r',
+   p₁ ← mk_app ``iff.symm [p₁],
+   mk_app ``iff.trans [p₀,p₁]
+
+meta def is_eqv (cl : closure) (e₀ e₁ : expr) : tactic bool :=
+do (r,p₀) ← root cl e₀,
+   (r',p₁) ← root cl e₁,
+   b ← try_core $ is_def_eq r r',
+   pure b.is_some
+
+end closure
+
+@[reducible]
+meta def impl_graph := ref (expr_map (list $ expr × expr))
+
+meta def with_impl_graph {α} : (impl_graph → tactic α) → tactic α :=
+using_new_ref (expr_map.mk (list $ expr × expr))
+
+namespace impl_graph
+
+meta def add_edge (g : impl_graph) : expr → tactic unit | p :=
+do t ← infer_type p,
+   match t with
+   | `(%%v₀ → %%v₁) :=
+     do m ← read_ref g,
+        let xs := (m.find v₀).get_or_else [],
+        let xs' := (m.find v₁).get_or_else [],
+        modify_ref g $ λ m, (m.insert v₀ ((v₁,p) :: xs)).insert v₁ xs'
+   | `(%%v₀ ↔ %%v₁) :=
+     do p₀ ← mk_mapp ``iff.mp [none,none,p],
+        p₁ ← mk_mapp ``iff.mpr [none,none,p],
+        add_edge p₀, add_edge p₁
+   | _ := failed
+   end
+
+section scc
+open list
+parameter g : expr_map (list $ expr × expr)
+parameter visit : ref $ expr_map bool
+parameter cl : closure
+
+meta def dfs_at :
+  expr ⊕ list (expr × expr × expr) →
+  tactic (option $ list (expr × expr) × expr × list (expr × expr × expr))
+| (sum.inl v) :=
+do m ← read_ref visit,
+   match m.find v with
+   | (some tt) := pure none
+   | (some ff) :=
+     do es ← g.find v,
+        pure $ some ([],v,es.map (prod.mk v))
+   | none :=
+     do modify_ref visit $ λ m, m.insert v ff,
+        es ← g.find v,
+        x ← dfs_at (sum.inr $ es.map $ prod.mk v),
+        modify_ref visit $ λ m, m.insert v tt,
+        some (path,e,es') ← pure x | pure none,
+        if e = v then do
+          p₀ ← mk_mapp ``id [e],
+          (_,ls) ← path.mmap_accuml (λ p p',
+            prod.mk <$> mk_mapp ``implies.trans [none,p'.1,none,p,p'.2] <*> pure p) p₀,
+          (_,rs) ← path.mmap_accumr (λ p p',
+            prod.mk <$> mk_mapp ``implies.trans [none,none,none,p.2,p'] <*> pure p') p₀,
+          ps ← mzip_with (λ p₀ p₁, mk_app ``iff.intro [p₀,p₁]) ls.tail rs.init,
+          ps.mmap' cl.merge,
+          dfs_at $ sum.inr es'
+        else pure x
+   end
+| (sum.inr []) := pure none
+| (sum.inr ((v,v',p) :: es)) :=
+do some (path,e,es') ← dfs_at (sum.inl v') | dfs_at (sum.inr es),
+   pure $ some ((v,p)::path, e, es ++ es')
+
+end scc
+
+meta def mk_scc (cl : closure) : tactic (expr_map (list (expr × expr))) :=
+with_impl_graph $ λ g,
+using_new_ref (expr_map.mk bool) $ λ visit,
+do ls ← local_context,
+   ls.mmap' $ λ l, try (g.add_edge l),
+   m ← read_ref g,
+   m.to_list.mmap' $ λ ⟨v,_⟩, impl_graph.dfs_at m visit cl (sum.inl v),
+   pure m
+
+end impl_graph
+
+meta def prove_eqv_target (cl : closure) : tactic unit :=
+do `(%%p ↔ %%q) ← target >>= whnf,
+   cl.prove_eqv p q >>= exact
+
+meta def interactive.check_eqv : tactic unit :=
+closure.mk_closure $ λ cl,
+do ls ← local_context,
+   ls.mmap' $ λ l, try (cl.merge l),
+   `(%%p ↔ %%q) ← target,
+   cl.prove_eqv p q >>= exact
+
+meta def interactive.scc : tactic unit :=
+closure.mk_closure $ λ cl,
+do impl_graph.mk_scc cl,
+   `(%%p ↔ %%q) ← target,
+   cl.prove_eqv p q >>= exact
+
+meta def interactive.scc' : tactic unit :=
+closure.mk_closure $ λ cl,
+do m ← impl_graph.mk_scc cl,
+   let ls := m.to_list.map prod.fst,
+   let ls' := prod.mk <$> ls <*> ls,
+   ls'.mmap' $ λ x,
+     do { h ← get_unused_name `h,
+          try $ closure.prove_eqv cl x.1 x.2 >>= note h none }
+
+end tactic

--- a/tactic/tfae.lean
+++ b/tactic/tfae.lean
@@ -76,11 +76,16 @@ meta def tfae_finish : tactic unit :=
 applyc ``tfae_nil <|>
 closure.mk_closure (λ cl,
 do impl_graph.mk_scc cl,
-   tfae_cons ← mk_const ``tfae_cons_cons,
-   repeat $ do {
-     rewrite_target tfae_cons, split,
-     prove_eqv_target cl },
-   applyc ``tfae_singleton,
+   `(tfae %%l) ← target,
+   l ← parse_list l,
+   (r,_) ← cl.root l.head,
+   refine ``(tfae_of_forall %%r _ _),
+   thm ← mk_const ``forall_mem_cons,
+   l.mmap' (λ e,
+     do rewrite_target thm, split,
+        (r',p) ← cl.root e,
+        tactic.exact p ),
+   applyc ``forall_mem_nil,
    pure ())
 
 end interactive

--- a/tactic/tfae.lean
+++ b/tactic/tfae.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2018 Johan Commelin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johan Commelin, Reid Barton, Simon Hudon
+
+"The Following Are Equivalent" (tfae):
+Tactic for proving the equivalence of a set of proposition
+using various implications between them.
+-/
+
+import tactic.basic tactic.interactive data.list.basic
+import tactic.scc
+
+open expr tactic lean lean.parser
+
+namespace tactic
+open interactive interactive.types expr
+
+export list (tfae)
+
+namespace tfae
+
+@[derive has_reflect] inductive arrow : Type
+| right      : arrow
+| left_right : arrow
+| left       : arrow
+
+meta def mk_implication : Π (re : arrow) (e₁ e₂ : expr), pexpr
+| arrow.right      e₁ e₂ := ``(%%e₁ → %%e₂)
+| arrow.left_right e₁ e₂ := ``(%%e₁ ↔ %%e₂)
+| arrow.left       e₁ e₂ := ``(%%e₂ → %%e₁)
+
+meta def mk_name : Π (re : arrow) (i₁ i₂ : nat), name
+| arrow.right      i₁ i₂ := ("tfae_" ++ to_string i₁ ++ "_to_"  ++ to_string i₂ : string)
+| arrow.left_right i₁ i₂ := ("tfae_" ++ to_string i₁ ++ "_iff_" ++ to_string i₂ : string)
+| arrow.left       i₁ i₂ := ("tfae_" ++ to_string i₂ ++ "_to_"  ++ to_string i₁ : string)
+
+end tfae
+
+namespace interactive
+
+open tactic.tfae list
+
+meta def parse_list : expr → option (list expr )
+| `([]) := pure []
+| `(%%e :: %%es) := (::) e <$> parse_list es
+| _ := none
+
+/-- in a goal of the form `tfae [a₀,a₁,a₂]`,
+`tfae_have : i → j` creates the assertion `aᵢ → aⱼ`. The other possible
+notations are `tfae_have : i ← j` and `tfae_have : i ↔ j`. The user can
+also provide a label for the assertion, as with `have`: `tfae_have h : i ↔ j`
+-/
+meta def tfae_have
+  (h : parse $ optional ident <* tk ":")
+  (i₁ : parse small_nat)
+  (re : parse (((tk "→" <|> tk "->")  *> return arrow.right)      <|>
+               ((tk "↔" <|> tk "<->") *> return arrow.left_right) <|>
+               ((tk "←" <|> tk "<-")  *> return arrow.left)))
+  (i₂ : parse small_nat)
+  (discharger : tactic unit := (solve_by_elim)) :
+  tactic unit := do
+    `(tfae %%l) <- target,
+    l ← parse_list l,
+    e₁ ← list.nth l (i₁ - 1) <|> fail format!"index {i₁} is not between 1 and {l.length}",
+    e₂ ← list.nth l (i₂ - 1) <|> fail format!"index {i₂} is not between 1 and {l.length}",
+    type ← to_expr (tfae.mk_implication re e₁ e₂),
+    let h := h.get_or_else (mk_name re i₁ i₂),
+    tactic.assert h type,
+    return ()
+
+/-- find all implications and equivalences in to prove a goal of
+the form `tfae [...]`
+-/
+meta def tfae_finish : tactic unit :=
+applyc ``tfae_nil <|>
+closure.mk_closure (λ cl,
+do impl_graph.mk_scc cl,
+   tfae_cons ← mk_const ``tfae_cons_cons,
+   repeat $ do {
+     rewrite_target tfae_cons, split,
+     prove_eqv_target cl },
+   applyc ``tfae_singleton,
+   pure ())
+
+end interactive
+end tactic

--- a/tests/tactics.lean
+++ b/tests/tactics.lean
@@ -5,6 +5,7 @@ Authors: Simon Hudon, Scott Morrison
 -/
 import tactic data.set.lattice data.prod
        tactic.rewrite data.stream.basic
+       tactic.tfae
 
 section solve_by_elim
 example {a b : Prop} (h₀ : a → b) (h₁ : a) : b :=
@@ -603,3 +604,55 @@ by { assoc_rw [h₀,h₂] at *,
      exact h₁ }
 
 end assoc_rw
+
+section tfae
+
+example (p q r s : Prop)
+  (h₀ : p ↔ q)
+  (h₁ : q ↔ r)
+  (h₂ : r ↔ s) :
+  p ↔ s :=
+begin
+  check_eqv,
+end
+
+example (p' p q r r' s s' : Prop)
+  (h₀ : p' → p)
+  (h₀ : p → q)
+  (h₁ : q → r)
+  (h₁ : r' → r)
+  (h₂ : r ↔ s)
+  (h₂ : s → p)
+  (h₂ : s → s') :
+  p ↔ s :=
+begin
+  scc,
+end
+
+example (p' p q r r' s s' : Prop)
+  (h₀ : p' → p)
+  (h₀ : p → q)
+  (h₁ : q → r)
+  (h₁ : r' → r)
+  (h₂ : r ↔ s)
+  (h₂ : s → p)
+  (h₂ : s → s') :
+  p ↔ s :=
+begin
+  scc',
+  assumption
+end
+
+example : tfae [true, ∀ n : ℕ, 0 ≤ n * n, true, true] := begin
+  tfae_have : 3 → 1, { intro h, constructor },
+  tfae_have : 2 → 3, { intro h, constructor },
+  tfae_have : 2 ← 1, { intros h n, apply nat.zero_le },
+  tfae_have : 4 ↔ 2, { tauto },
+  tfae_finish,
+end
+
+example : tfae [] := begin
+  tfae_finish,
+end
+
+end tfae

--- a/tests/tactics.lean
+++ b/tests/tactics.lean
@@ -613,7 +613,7 @@ example (p q r s : Prop)
   (h₂ : r ↔ s) :
   p ↔ s :=
 begin
-  check_eqv,
+  scc,
 end
 
 example (p' p q r r' s s' : Prop)


### PR DESCRIPTION
tactic for decomposing a proof into a set of equivalent propositions which can be proved equivalent by cyclical implications

With @jcommelin @rwbarton and @digama0.

TO CONTRIBUTORS:

Make sure you have:

 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
