### PR TITLE
feat(tactic/linarith): don't reject nonlinear hypotheses

### DIFF
--- a/tactic/linarith.lean
+++ b/tactic/linarith.lean
@@ -27,6 +27,10 @@ section lemmas
 
 lemma int.coe_nat_bit0 (n : ℕ) : (↑(bit0 n : ℕ) : ℤ) = bit0 (↑n : ℤ) := by simp [bit0]
 lemma int.coe_nat_bit1 (n : ℕ) : (↑(bit1 n : ℕ) : ℤ) = bit1 (↑n : ℤ) := by simp [bit1, bit0]
+lemma int.coe_nat_bit0_mul (n : ℕ) (x : ℕ) : (↑(bit0 n * x) : ℤ) = (↑(bit0 n) : ℤ) * (↑x : ℤ) := by simp
+lemma int.coe_nat_bit1_mul (n : ℕ) (x : ℕ) : (↑(bit1 n * x) : ℤ) = (↑(bit1 n) : ℤ) * (↑x : ℤ) := by simp
+lemma int.coe_nat_one_mul (x : ℕ) : (↑(1 * x) : ℤ) = 1 * (↑x : ℤ) := by simp
+lemma int.coe_nat_zero_mul (x : ℕ) : (↑(0 * x) : ℤ) = 0 * (↑x : ℤ) := by simp
 
 lemma nat_eq_subst {n1 n2 : ℕ} {z1 z2 : ℤ} (hn : n1 = n2) (h1 : ↑n1 = z1) (h2 : ↑n2 = z2) : z1 = z2 :=
 by simpa [eq.symm h1, eq.symm h2, int.coe_nat_eq_coe_nat_iff]
@@ -280,11 +284,15 @@ end
     Returns a new map.
 -/
 meta def map_of_expr : expr_map ℕ → expr → option (expr_map ℕ × rb_map ℕ ℤ)
-| m `(%%e1 * %%e2) :=
-   do (m', comp1) ← map_of_expr m e1,
+| m e@`(%%e1 * %%e2) :=
+   (do (m', comp1) ← map_of_expr m e1,
       (m', comp2) ← map_of_expr m' e2,
       mp ← map_of_expr_mul_aux comp1 comp2,
-      return (m', mp)
+      return (m', mp)) <|>
+   (match m.find e with
+    | some k := return (m, mk_rb_map.insert k 1)
+    | none := let n := m.size + 1 in return (m.insert e n, mk_rb_map.insert n 1)
+    end)
 | m `(%%e1 + %%e2) :=
    do (m', comp1) ← map_of_expr m e1,
       (m', comp2) ← map_of_expr m' e2,
@@ -624,7 +632,8 @@ meta def get_contr_lemma_name : expr → option name
 
 -- assumes the input t is of type ℕ. Produces t' of type ℤ such that ↑t = t' and a proof of equality
 meta def cast_expr (e : expr) : tactic (expr × expr) :=
-do s ← [`int.coe_nat_add, `int.coe_nat_mul, `int.coe_nat_zero, `int.coe_nat_one,
+do s ← [`int.coe_nat_add, `int.coe_nat_zero, `int.coe_nat_one,
+        ``int.coe_nat_bit0_mul, ``int.coe_nat_bit1_mul, ``int.coe_nat_zero_mul, ``int.coe_nat_one_mul,
         ``int.coe_nat_bit0, ``int.coe_nat_bit1].mfoldl simp_lemmas.add_simp simp_lemmas.mk,
    ce ← to_expr ``(↑%%e : ℤ),
    simplify s [] ce {fail_if_unchanged := ff}

--- a/tactic/linarith.lean
+++ b/tactic/linarith.lean
@@ -31,6 +31,10 @@ lemma int.coe_nat_bit0_mul (n : ℕ) (x : ℕ) : (↑(bit0 n * x) : ℤ) = (↑(
 lemma int.coe_nat_bit1_mul (n : ℕ) (x : ℕ) : (↑(bit1 n * x) : ℤ) = (↑(bit1 n) : ℤ) * (↑x : ℤ) := by simp
 lemma int.coe_nat_one_mul (x : ℕ) : (↑(1 * x) : ℤ) = 1 * (↑x : ℤ) := by simp
 lemma int.coe_nat_zero_mul (x : ℕ) : (↑(0 * x) : ℤ) = 0 * (↑x : ℤ) := by simp
+lemma int.coe_nat_mul_bit0 (n : ℕ) (x : ℕ) : (↑(x * bit0 n) : ℤ) = (↑x : ℤ) * (↑(bit0 n) : ℤ) := by simp
+lemma int.coe_nat_mul_bit1 (n : ℕ) (x : ℕ) : (↑(x * bit1 n) : ℤ) = (↑x : ℤ) * (↑(bit1 n) : ℤ) := by simp
+lemma int.coe_nat_mul_one (x : ℕ) : (↑(x * 1) : ℤ) = (↑x : ℤ) * 1 := by simp
+lemma int.coe_nat_mul_zero (x : ℕ) : (↑(x * 0) : ℤ) = (↑x : ℤ) * 0 := by simp
 
 lemma nat_eq_subst {n1 n2 : ℕ} {z1 z2 : ℤ} (hn : n1 = n2) (h1 : ↑n1 = z1) (h2 : ↑n2 = z2) : z1 = z2 :=
 by simpa [eq.symm h1, eq.symm h2, int.coe_nat_eq_coe_nat_iff]
@@ -634,6 +638,7 @@ meta def get_contr_lemma_name : expr → option name
 meta def cast_expr (e : expr) : tactic (expr × expr) :=
 do s ← [`int.coe_nat_add, `int.coe_nat_zero, `int.coe_nat_one,
         ``int.coe_nat_bit0_mul, ``int.coe_nat_bit1_mul, ``int.coe_nat_zero_mul, ``int.coe_nat_one_mul,
+        ``int.coe_nat_mul_bit0, ``int.coe_nat_mul_bit1, ``int.coe_nat_mul_zero, ``int.coe_nat_mul_one,
         ``int.coe_nat_bit0, ``int.coe_nat_bit1].mfoldl simp_lemmas.add_simp simp_lemmas.mk,
    ce ← to_expr ``(↑%%e : ℤ),
    simplify s [] ce {fail_if_unchanged := ff}

--- a/tests/linarith.lean
+++ b/tests/linarith.lean
@@ -78,3 +78,10 @@ by linarith
 
 example (a b c : ℕ) : a + b ≥ a :=
 by linarith
+
+example (x y : ℚ) (h : 6 + ((x + 4) * x + (6 + 3 * y) * y) = 3) (h' : (x + 4) * x ≥ 0)
+  (h'' : (6 + 3 * y) * y ≥ 0)  : false :=
+by linarith
+
+example (x y : ℕ) (h : 6 + ((x + 4) * x + (6 + 3 * y) * y) = 3) : false :=
+by linarith


### PR DESCRIPTION
Previously, `linarith` was rejecting hypotheses when it saw products of variables. This is unnecessarily strict -- it should treat those products as atoms.

```lean
example (x y : ℕ) (h : 6 + ((x + 4) * x + (6 + 3 * y) * y) = 3) : false :=
by linarith
```

TO CONTRIBUTORS:

Make sure you have:

 * [ ] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
