### PR TITLE
feat(tactic/interactive) adds `choice` tactic

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -414,11 +414,19 @@ by linarith
 `linarith`.
 
 `linarith {discharger := tac, restrict_type := tp, exfalso := ff}` takes a config object with three optional
-arguments. 
+arguments.
 * `discharger` specifies a tactic to be used for reducing an algebraic equation in the
 proof stage. The default is `ring`. Other options currently include `ring SOP` or `simp` for basic
-problems. 
+problems.
 * `restrict_type` will only use hypotheses that are inequalities over `tp`. This is useful
 if you have e.g. both integer and rational valued inequalities in the local context, which can
 sometimes confuse the tactic.
 * If `exfalso` is false, `linarith` will fail when the goal is neither an inequality nor `false`. (True by default.)
+
+## choice
+
+`choice hyp with g H` takes an hypothesis `hyp` of the form
+`∀ (y : Y), ∃ (x : X), P x y` for some `P : X → Y → Prop` and outputs into
+context a function `g : Y → X` and a proposition `H` stating
+`∀ (y : Y), P (g y) y`. It presumably also works with dependent versions
+(see the actual type of `classical.axiom_of_choice`).

--- a/tactic/interactive.lean
+++ b/tactic/interactive.lean
@@ -561,5 +561,14 @@ do let (e,n) := arg,
    tactic.clear asm,
    when rev.is_some (interactive.revert [n])
 
+/--
+  `choice hyp with g H` takes an hypothesis `hyp` of the form
+  `∀ (y : Y), ∃ (x : X), P x y` for some `P : X → Y → Prop` and outputs into
+  context a function `g : Y → X` and a proposition `H` stating
+  `∀ (y : Y), P (g y) y`. It presumably also works with dependent versions
+  (see the actual type of `classical.axiom_of_choice`)
+-/
+meta def choice (e : parse cases_arg_p) (ids : parse with_ident_list) :=
+do cases (e.1,``(classical.axiom_of_choice %%(e.2))) ids
 end interactive
 end tactic

--- a/tests/tactics.lean
+++ b/tests/tactics.lean
@@ -628,3 +628,13 @@ by { assoc_rw [h₀,h₂] at *,
      exact h₁ }
 
 end assoc_rw
+
+section choice
+example (X Y : Type) (f : X → Y) (hyp : ∀ y : Y, ∃ x : X, f(x) = y) :
+  (∃ g : Y → X, f ∘ g = id) :=
+begin
+  choice hyp with g H,
+  existsi g,
+  exact funext H
+end
+end choice


### PR DESCRIPTION
This is a tactic for mathematicians who want to use the axiom of choice.
```lean
example (X Y : Type) (f : X → Y) (hyp : ∀ y : Y, ∃ x : X, f(x) = y) :
  (∃ g : Y → X, f ∘ g = id) :=
begin
  choice hyp with g H,
  existsi g,
  exact funext H
end
```