### PR TITLE
adding two lemmas about division

### DIFF
--- a/algebra/ring.lean
+++ b/algebra/ring.lean
@@ -146,6 +146,13 @@ section comm_ring
 
   @[simp] lemma neg_dvd (a b : α) : (-a ∣ b) ↔ (a ∣ b) :=
   ⟨dvd_of_neg_dvd, neg_dvd_of_dvd⟩
+
+  theorem dvd_add_left {a b c : α} (h : a ∣ c) : a ∣ b + c ↔ a ∣ b :=
+  (dvd_add_iff_left h).symm
+
+  theorem dvd_add_right {a b c : α} (h : a ∣ b) : a ∣ b + c ↔ a ∣ c :=
+  (dvd_add_iff_right h).symm
+
 end comm_ring
 
 class is_ring_hom {α : Type u} {β : Type v} [ring α] [ring β] (f : α → β) : Prop :=

--- a/data/nat/basic.lean
+++ b/data/nat/basic.lean
@@ -250,6 +250,12 @@ by rw [mul_comm c, mod_mul_right_div_self]
 @[simp] protected theorem dvd_one {n : ℕ} : n ∣ 1 ↔ n = 1 :=
 ⟨eq_one_of_dvd_one, λ e, e.symm ▸ dvd_refl _⟩
 
+lemma dvd_add_right {k m n : ℕ} (h₁ : k ∣ m) (h₂ : k ∣ m + n) : k ∣ n := 
+(nat.dvd_add_iff_right h₁).2 h₂
+
+lemma dvd_add_left {k m n : ℕ} (h₁ : k ∣ n) (h₂ : k ∣ m + n) : k ∣ m :=
+(nat.dvd_add_iff_left h₁).2 h₂
+
 protected theorem mul_dvd_mul_iff_left {a b c : ℕ} (ha : a > 0) : a * b ∣ a * c ↔ b ∣ c :=
 exists_congr $ λ d, by rw [mul_assoc, nat.mul_left_inj ha]
 

--- a/data/nat/basic.lean
+++ b/data/nat/basic.lean
@@ -250,11 +250,11 @@ by rw [mul_comm c, mod_mul_right_div_self]
 @[simp] protected theorem dvd_one {n : ℕ} : n ∣ 1 ↔ n = 1 :=
 ⟨eq_one_of_dvd_one, λ e, e.symm ▸ dvd_refl _⟩
 
-lemma dvd_add_right {k m n : ℕ} (h₁ : k ∣ m) (h₂ : k ∣ m + n) : k ∣ n := 
-(nat.dvd_add_iff_right h₁).2 h₂
+protected theorem dvd_add_left {k m n : ℕ} (h : k ∣ n) : k ∣ m + n ↔ k ∣ m :=
+(nat.dvd_add_iff_left h).symm
 
-lemma dvd_add_left {k m n : ℕ} (h₁ : k ∣ n) (h₂ : k ∣ m + n) : k ∣ m :=
-(nat.dvd_add_iff_left h₁).2 h₂
+protected theorem dvd_add_right {k m n : ℕ} (h : k ∣ m) : k ∣ m + n ↔ k ∣ n := 
+(nat.dvd_add_iff_right h).symm
 
 protected theorem mul_dvd_mul_iff_left {a b c : ℕ} (ha : a > 0) : a * b ∣ a * c ↔ b ∣ c :=
 exists_congr $ λ d, by rw [mul_assoc, nat.mul_left_inj ha]


### PR DESCRIPTION
These are very minor lemmas, and I don't know how they should be named, but I think they should be in.

These came up when I was trying to record a video demonstrating proving the infinitude of primes in Lean. (Essentially following the mathlib proof.)

It comes to the step where you know `p | fact N` and `p | fact N + 1`, and you're trying to deduce `p | 1`. Without magically knowing that the relevant lemma is `nat.dvd_add_iff_right` in core, I challenge you to explain to somehow to find that lemma!

If we add these two lemmas, at least one can do the obvious thing:

`#find _ ∣ _ → _ ∣ _ →  _ ∣ _`