### PR TITLE
fix(solve_by_elim): improve backtracking when apply creates multiple goals

### DIFF
--- a/data/real/cau_seq_filter.lean
+++ b/data/real/cau_seq_filter.lean
@@ -53,7 +53,7 @@ begin
   intros j hj,
   rw ←dist_eq_norm,
   apply @htsub (f j, f N),
-  apply set.mk_mem_prod; solve_by_elim {discharger := `[apply le_refl]}
+  apply set.mk_mem_prod; solve_by_elim [le_refl]
 end
 
 lemma filter_cauchy_of_cauchy (f : cau_seq β norm) : cauchy (at_top.map f) :=

--- a/tactic/basic.lean
+++ b/tactic/basic.lean
@@ -461,10 +461,10 @@ meta def apply_assumption
   (asms : tactic (list expr) := local_context)
   (tac : tactic unit := skip) : tactic unit :=
 do { ctx ← asms,
-     ctx.any_of (λ H, () <$ symm_apply H; tac) } <|>
+     ctx.any_of (λ H, symm_apply H >> tac) } <|> 
 do { exfalso,
      ctx ← asms,
-     ctx.any_of (λ H, () <$ symm_apply H; tac) }
+     ctx.any_of (λ H, symm_apply H >> tac) }
 <|> fail "assumption tactic failed"
 
 open nat
@@ -481,7 +481,8 @@ meta structure by_elim_opt :=
 meta def solve_by_elim (opt : by_elim_opt := { }) : tactic unit :=
 do
   tactic.fail_if_no_goals,
-  solve_by_elim_aux opt.discharger opt.assumptions opt.max_rep
+  focus1 $
+    solve_by_elim_aux opt.discharger opt.assumptions opt.max_rep
 
 meta def metavariables : tactic (list expr) :=
 do r ← result,

--- a/tests/solve_by_elim.lean
+++ b/tests/solve_by_elim.lean
@@ -77,3 +77,17 @@ begin
   trivial
 end
 
+example {α : Type} (r : α → α → Prop) (f : α → α → α)
+  (l : ∀ a b c : α, r a b → r a (f b c) → r a c)
+  (a b c : α) (h₁ : r a b) (h₂ : r a (f b c)) : r a c :=
+begin
+  solve_by_elim,
+end
+
+-- Verifying that solve_by_elim behaves as expected in the presence of multiple goals.
+example (n : ℕ) : ℕ × ℕ :=
+begin
+  split,
+  solve_by_elim,
+  solve_by_elim
+end


### PR DESCRIPTION
This depends on the as-yet-unmerged https://github.com/leanprover/mathlib/pull/382.