### PR TITLE
fix(algebra/ring): delete duplicate lemma zero_dvd_iff_eq_zero

### DIFF
--- a/algebra/ring.lean
+++ b/algebra/ring.lean
@@ -101,11 +101,6 @@ instance : is_monoid_hom f :=
 
 end is_semiring_hom
 
-@[simp] lemma zero_dvd_iff_eq_zero [comm_semiring α] (a : α) : 0 ∣ a ↔ a = 0 :=
-iff.intro
-  eq_zero_of_zero_dvd
-  (assume ha, ha ▸ dvd_refl a)
-
 section
   variables [ring α] (a b c d e : α)
 


### PR DESCRIPTION
`zero_dvd_iff_eq_zero` is a duplicate of `zero_dvd_iff`

TO CONTRIBUTORS:

Make sure you have:

 
* [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
* [x] make sure definitions and lemmas are put in the right files
* [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
