### PR TITLE
feat(category_theory): replace bundled with sigma

### DIFF
--- a/category_theory/category.lean
+++ b/category_theory/category.lean
@@ -66,16 +66,6 @@ A `small_category` has objects and morphisms in the same universe level.
 -/
 abbreviation small_category (C : Type u)     : Type (u+1) := category.{u u} C
 
-structure bundled (c : Type u → Type v) :=
-(α : Type u)
-[str : c α]
-
-instance (c : Type u → Type v) : has_coe_to_sort (bundled c) :=
-{ S := Type u, coe := bundled.α }
- 
-def mk_ob {c : Type u → Type v} (α : Type u) [str : c α] : bundled c :=
-@bundled.mk c α str
-
 /-- `concrete_category hom` collects the evidence that a type constructor `c` and a morphism
 predicate `hom` can be thought of as a concrete category.
 In a typical example, `c` is the type class `topological_space` and `hom` is `continuous`. -/
@@ -86,18 +76,18 @@ structure concrete_category {c : Type u → Type v}
 attribute [class] concrete_category
 
 instance {c : Type u → Type v} (hom : ∀{α β : Type u}, c α → c β → (α → β) → Prop)
-  [h : concrete_category @hom] : category (bundled c) :=
+  [h : concrete_category @hom] : category (sigma c) :=
 { hom   := λa b, subtype (hom a.2 b.2),
   id    := λa, ⟨@id a.1, h.hom_id a.2⟩,
   comp  := λa b c f g, ⟨g.1 ∘ f.1, h.hom_comp a.2 b.2 c.2 f.2 g.2⟩ }
 
 @[simp] lemma concrete_category_id {c : Type u → Type v} (hom : ∀{α β : Type u}, c α → c β → (α → β) → Prop)
-  [h : concrete_category @hom] (X : bundled c) : subtype.val (𝟙 X) = id := rfl
+  [h : concrete_category @hom] (X : sigma c) : subtype.val (𝟙 X) = id := rfl
 @[simp] lemma concrete_category_comp {c : Type u → Type v} (hom : ∀{α β : Type u}, c α → c β → (α → β) → Prop)
-  [h : concrete_category @hom] {X Y Z : bundled c} (f : X ⟶ Y) (g : Y ⟶ Z): subtype.val (f ≫ g) = g.val ∘ f.val := rfl
+  [h : concrete_category @hom] {X Y Z : sigma c} (f : X ⟶ Y) (g : Y ⟶ Z): subtype.val (f ≫ g) = g.val ∘ f.val := rfl
 
 instance {c : Type u → Type v} (hom : ∀{α β : Type u}, c α → c β → (α → β) → Prop)
-  [h : concrete_category @hom] {R S : bundled c} : has_coe_to_fun (R ⟶ S) :=
+  [h : concrete_category @hom] {R S : sigma c} : has_coe_to_fun (R ⟶ S) :=
 { F := λ f, R → S,
   coe := λ f, f.1 }
 

--- a/category_theory/examples/measurable_space.lean
+++ b/category_theory/examples/measurable_space.lean
@@ -14,9 +14,9 @@ universes u v
 
 namespace category_theory.examples
 
-@[reducible] def Meas : Type (u+1) := bundled measurable_space
+@[reducible] def Meas : Type (u+1) := sigma measurable_space
 
-instance (x : Meas) : measurable_space x := x.str
+instance (x : Meas) : measurable_space x := x.snd
 
 namespace Meas
 

--- a/category_theory/examples/monoids.lean
+++ b/category_theory/examples/monoids.lean
@@ -17,9 +17,9 @@ open category_theory
 namespace category_theory.examples
 
 /-- The category of monoids and monoid morphisms. -/
-@[reducible] def Mon : Type (u+1) := bundled monoid
+@[reducible] def Mon : Type (u+1) := sigma monoid
 
-instance (x : Mon) : monoid x := x.str
+instance (x : Mon) : monoid x := x.snd
 
 instance concrete_is_monoid_hom : concrete_category @is_monoid_hom :=
 ⟨by introsI α ia; apply_instance,
@@ -28,9 +28,9 @@ instance concrete_is_monoid_hom : concrete_category @is_monoid_hom :=
 instance Mon_hom_is_monoid_hom {R S : Mon} (f : R ⟶ S) : is_monoid_hom (f : R → S) := f.2
 
 /-- The category of commutative monoids and monoid morphisms. -/
-@[reducible] def CommMon : Type (u+1) := bundled comm_monoid
+@[reducible] def CommMon : Type (u+1) := sigma comm_monoid
 
-instance (x : CommMon) : comm_monoid x := x.str
+instance (x : CommMon) : comm_monoid x := x.snd
 
 @[reducible] def is_comm_monoid_hom {α β} [comm_monoid α] [comm_monoid β] (f : α → β) : Prop :=
 is_monoid_hom f

--- a/category_theory/examples/rings.lean
+++ b/category_theory/examples/rings.lean
@@ -18,9 +18,9 @@ open category_theory
 namespace category_theory.examples
 
 /-- The category of rings. -/
-@[reducible] def Ring : Type (u+1) := bundled ring
+@[reducible] def Ring : Type (u+1) := sigma ring
 
-instance (x : Ring) : ring x := x.str
+instance (x : Ring) : ring x := x.snd
 
 instance concrete_is_ring_hom : concrete_category @is_ring_hom :=
 ⟨by introsI α ia; apply_instance,
@@ -29,9 +29,9 @@ instance concrete_is_ring_hom : concrete_category @is_ring_hom :=
 instance Ring_hom_is_ring_hom {R S : Ring} (f : R ⟶ S) : is_ring_hom (f : R → S) := f.2
 
 /-- The category of commutative rings. -/
-@[reducible] def CommRing : Type (u+1) := bundled comm_ring
+@[reducible] def CommRing : Type (u+1) := sigma comm_ring
 
-instance (x : CommRing) : comm_ring x := x.str
+instance (x : CommRing) : comm_ring x := x.snd
 
 @[reducible] def is_comm_ring_hom {α β} [comm_ring α] [comm_ring β] (f : α → β) : Prop :=
 is_ring_hom f

--- a/category_theory/examples/topological_spaces.lean
+++ b/category_theory/examples/topological_spaces.lean
@@ -16,9 +16,9 @@ universe u
 namespace category_theory.examples
 
 /-- The category of topological spaces and continuous maps. -/
-@[reducible] def Top : Type (u+1) := bundled topological_space
+@[reducible] def Top : Type (u+1) := sigma topological_space
 
-instance (x : Top) : topological_space x := x.str
+instance (x : Top) : topological_space x := x.snd
 
 namespace Top
 instance : concrete_category @continuous := ⟨@continuous_id, @continuous.comp⟩
@@ -29,7 +29,7 @@ end Top
 
 structure open_set (X : Top.{u}) : Type u :=
 (s : set X.α)
-(is_open : topological_space.is_open X.str s)
+(is_open : topological_space.is_open X.snd s)
 
 variables {X : Top.{u}}
 

--- a/category_theory/examples/topological_spaces.lean
+++ b/category_theory/examples/topological_spaces.lean
@@ -28,13 +28,13 @@ instance : concrete_category @continuous := ⟨@continuous_id, @continuous.comp�
 end Top
 
 structure open_set (X : Top.{u}) : Type u :=
-(s : set X.α)
+(s : set X.fst)
 (is_open : topological_space.is_open X.snd s)
 
 variables {X : Top.{u}}
 
 namespace open_set
-instance : has_coe (open_set X) (set X.α) := { coe := λ U, U.s }
+instance : has_coe (open_set X) (set X.fst) := { coe := λ U, U.s }
 
 instance : has_subset (open_set X) :=
 { subset := λ U V, U.s ⊆ V.s }
@@ -43,11 +43,11 @@ instance : preorder (open_set X) := by refine { le := (⊇), .. } ; tidy
 
 instance open_sets : small_category (open_set X) := by apply_instance
 
-instance : has_mem X.α (open_set X) :=
+instance : has_mem X.fst (open_set X) :=
 { mem := λ a V, a ∈ V.s }
 
-def nbhd (x : X.α) := { U : open_set X // x ∈ U }
-def nbhds (x : X.α) : small_category (nbhd x) := begin unfold nbhd, apply_instance end
+def nbhd (x : X.fst) := { U : open_set X // x ∈ U }
+def nbhds (x : X.fst) : small_category (nbhd x) := begin unfold nbhd, apply_instance end
 
 /-- `open_set.map f` gives the functor from open sets in Y to open set in X, 
     given by taking preimages under f. -/

--- a/category_theory/functor.lean
+++ b/category_theory/functor.lean
@@ -118,15 +118,12 @@ end
 
 end functor
 
-def bundled.map {c : Type u → Type v} {d : Type u → Type v} (f : Π{a}, c a → d a) (s : bundled c) : bundled d :=
-{ α := s.α, str := f s.str }
-
 def concrete_functor
   {C : Type u → Type v} {hC : ∀{α β}, C α → C β → (α → β) → Prop} [concrete_category @hC]
   {D : Type u → Type v} {hD : ∀{α β}, D α → D β → (α → β) → Prop} [concrete_category @hD]
   (m : ∀{α}, C α → D α) (h : ∀{α β} {ia : C α} {ib : C β} {f}, hC ia ib f → hD (m ia) (m ib) f) :
-  bundled C ⥤ bundled D :=
-{ obj := bundled.map @m,
+  sigma C ⥤ sigma D :=
+{ obj := sigma.map_snd @m,
   map' := λ X Y f, ⟨ f, h f.2 ⟩}
 
 end category_theory

--- a/category_theory/types.lean
+++ b/category_theory/types.lean
@@ -51,7 +51,7 @@ variables (C : Type u → Type v) {hom : ∀α β, C α → C β → (α → β)
 include i
 
 /-- The forgetful functor from a bundled category to `Type`. -/
-def forget : bundled C ⥤ Type u := { obj := bundled.α, map' := λa b h, h.1 }
+def forget : sigma C ⥤ Type u := { obj := sigma.fst, map' := λa b h, h.1 }
 
 instance forget.faithful : faithful (forget C) := {}
 

--- a/data/sigma/basic.lean
+++ b/data/sigma/basic.lean
@@ -7,6 +7,12 @@ Author: Johannes Hölzl
 section sigma
 variables {α : Type*} {β : α → Type*}
 
+section
+universes u v
+instance (c : Type u → Type v) : has_coe_to_sort (sigma c) :=
+{ S := Type u, coe := @sigma.fst (Type u) c }
+end
+
 instance [inhabited α] [inhabited (β (default α))] : inhabited (sigma β) :=
 ⟨⟨default α, default (β (default α))⟩⟩
 
@@ -34,9 +40,13 @@ instance [h₁ : decidable_eq α] [h₂ : ∀a, decidable_eq (β a)] : decidable
 
 variables {α₁ : Type*} {α₂ : Type*} {β₁ : α₁ → Type*} {β₂ : α₂ → Type*}
 
-/-- Map the left and right components of a sigma -/
+/-- Map the `fst` and `snd` components of a `sigma` -/
 def sigma.map (f₁ : α₁ → α₂) (f₂ : Πa, β₁ a → β₂ (f₁ a)) : sigma β₁ → sigma β₂
 | ⟨a, b⟩ := ⟨f₁ a, f₂ a b⟩
+
+/-- Map only the `snd` component of a `sigma` -/
+def sigma.map_snd {β₁ β₂ : α → Type*} (f : ∀ a, β₁ a → β₂ a) (s : sigma β₁) : sigma β₂ :=
+⟨s.fst, f _ s.snd⟩
 
 end sigma
 
@@ -63,8 +73,12 @@ iff.intro psigma.mk.inj $
 
 variables {α₁ : Sort*} {α₂ : Sort*} {β₁ : α₁ → Sort*} {β₂ : α₂ → Sort*}
 
-/-- Map the left and right components of a sigma -/
+/-- Map the `fst` and `snd` components of a `psigma` -/
 def psigma.map (f₁ : α₁ → α₂) (f₂ : Πa, β₁ a → β₂ (f₁ a)) : psigma β₁ → psigma β₂
 | ⟨a, b⟩ := ⟨f₁ a, f₂ a b⟩
+
+/-- Map only the `snd` component of a `psigma` -/
+def psigma.map_snd {β₁ β₂ : α → Type*} (f : ∀ a, β₁ a → β₂ a) (s : psigma β₁) : psigma β₂ :=
+⟨s.fst, f _ s.snd⟩
 
 end psigma


### PR DESCRIPTION
This is an alternative proposal to #390. Instead of extracting `bundled` from `category_theory`, it uses `sigma` as the bundled type.

The main (potentially controversial?) thing that it adds is the following instance:

```lean
instance (c : Type u → Type v) : has_coe_to_sort (sigma c) :=
{ S := Type u, coe := @sigma.fst (Type u) c }
```