### PR TITLE
refactor(field_theory/finite): generalize proofs

### DIFF
--- a/data/equiv/algebra.lean
+++ b/data/equiv/algebra.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
-import data.equiv.basic algebra.group
+import data.equiv.basic algebra.group algebra.field
 
 namespace equiv
 variables {α : Type*} [group α]

--- a/data/equiv/algebra.lean
+++ b/data/equiv/algebra.lean
@@ -38,4 +38,10 @@ attribute [to_additive equiv.neg._proof_1] equiv.inv._proof_1
 attribute [to_additive equiv.neg._proof_2] equiv.inv._proof_2
 attribute [to_additive equiv.neg] equiv.inv
 
+def units_equiv_ne_zero (α : Type*) [field α] : units α ≃ {a : α | a ≠ 0} :=
+⟨λ a, ⟨a.1, units.ne_zero _⟩, λ a, units.mk0 _ a.2, λ ⟨_, _, _, _⟩, units.ext rfl, λ ⟨_, _⟩, rfl⟩
+
+@[simp] lemma coe_units_equiv_ne_zero [field α] (a : units α) :
+  ((units_equiv_ne_zero α a) : α) = a := rfl
+
 end equiv

--- a/data/nat/gcd.lean
+++ b/data/nat/gcd.lean
@@ -94,6 +94,30 @@ dvd_antisymm (gcd_dvd_left _ _) (dvd_gcd (dvd_refl _) H)
 theorem gcd_eq_right {m n : ℕ} (H : n ∣ m) : gcd m n = n :=
 by rw [gcd_comm, gcd_eq_left H]
 
+@[simp] lemma gcd_mul_left_left (m n : ℕ) : gcd (m * n) n = n :=
+dvd_antisymm (gcd_dvd_right _ _) (dvd_gcd (dvd_mul_left _ _) (dvd_refl _))
+
+@[simp] lemma gcd_mul_left_right (m n : ℕ) : gcd n (m * n) = n :=
+by rw [gcd_comm, gcd_mul_left_left]
+
+@[simp] lemma gcd_mul_right_left (m n : ℕ) : gcd (n * m) n = n :=
+by rw [mul_comm, gcd_mul_left_left]
+
+@[simp] lemma gcd_mul_right_right (m n : ℕ) : gcd n (n * m) = n :=
+by rw [gcd_comm, gcd_mul_right_left]
+
+@[simp] lemma gcd_gcd_self_right_left (m n : ℕ) : gcd m (gcd m n) = gcd m n :=
+dvd_antisymm (gcd_dvd_right _ _) (dvd_gcd (gcd_dvd_left _ _) (dvd_refl _))
+
+@[simp] lemma gcd_gcd_self_right_right (m n : ℕ) : gcd m (gcd n m) = gcd n m :=
+by rw [gcd_comm n m, gcd_gcd_self_right_left]
+
+@[simp] lemma gcd_gcd_self_left_right (m n : ℕ) : gcd (gcd n m) m = gcd n m :=
+by rw [gcd_comm, gcd_gcd_self_right_right]
+
+@[simp] lemma gcd_gcd_self_left_left (m n : ℕ) : gcd (gcd m n) m = gcd m n :=
+by rw [gcd_comm m n, gcd_gcd_self_left_right]
+
 /- lcm -/
 
 theorem lcm_comm (m n : ℕ) : lcm m n = lcm n m :=

--- a/data/zmod/quadratic_reciprocity.lean
+++ b/data/zmod/quadratic_reciprocity.lean
@@ -27,7 +27,7 @@ hp.eq_two_or_odd.elim
     ⟨λ ⟨y, hy⟩, by rw [← hy, ← pow_mul, two_mul_odd_div_two hp1,
         ← card_units_zmodp hp, pow_card_eq_one],
     λ hx, have 2 * (p / 2) ∣ n * (p / 2),
-        by rw [two_mul_odd_div_two hp1, ← card_units_zmodp hp, ← order_of_eq_card_of_forall_mem_gppowers hg];
+        by rw [two_mul_odd_div_two hp1, ← card_units_zmodp hp, ← order_of_eq_card_of_forall_mem_gpowers hg];
         exact order_of_dvd_of_pow_eq_one (by rwa [pow_mul, hn]),
       let ⟨m, hm⟩ := dvd_of_mul_dvd_mul_right (nat.div_pos hp.ge_two dec_trivial) this in
       ⟨g ^ m, by rwa [← pow_mul, mul_comm, ← hm]⟩⟩)

--- a/field_theory/finite.lean
+++ b/field_theory/finite.lean
@@ -139,14 +139,14 @@ variables [field α] [fintype α]
 
 instance [decidable_eq α] : fintype (units α) :=
 by haveI := set_fintype {a : α | a ≠ 0}; exact
-fintype.of_equiv _ (units_equiv_ne_zero α).symm
+fintype.of_equiv _ (equiv.units_equiv_ne_zero α).symm
 
 lemma card_units [decidable_eq α] : fintype.card (units α) = fintype.card α - 1 :=
 begin
   rw [eq_comm, nat.sub_eq_iff_eq_add (fintype.card_pos_iff.2 ⟨(0 : α)⟩)],
   haveI := set_fintype {a : α | a ≠ 0},
   haveI := set_fintype (@set.univ α),
-  rw [fintype.card_congr (units_equiv_ne_zero _),
+  rw [fintype.card_congr (equiv.units_equiv_ne_zero _),
     ← @set.card_insert _ _ {a : α | a ≠ 0} _ (not_not.2 (eq.refl (0 : α)))
     (set.fintype_insert _ _), fintype.card_congr (equiv.set.univ α).symm],
   congr; simp [set.ext_iff, classical.em]

--- a/field_theory/finite.lean
+++ b/field_theory/finite.lean
@@ -10,126 +10,20 @@ variables {α : Type u} {β : Type v}
 
 open function finset polynomial nat
 
-lemma order_of_pow {α : Type*} [group α] [fintype α] [decidable_eq α] (a : α) (n : ℕ) :
-  order_of (a ^ n) = order_of a / gcd (order_of a) n :=
-dvd_antisymm
-(order_of_dvd_of_pow_eq_one
-  (by rw [← pow_mul, ← nat.mul_div_assoc _ (gcd_dvd_left _ _), mul_comm,
-    nat.mul_div_assoc _ (gcd_dvd_right _ _), pow_mul, pow_order_of_eq_one, _root_.one_pow]))
-(have gcd_pos : 0 < gcd (order_of a) n, from gcd_pos_of_pos_left n (order_of_pos a),
-  have hdvd : order_of a ∣ n * order_of (a ^ n),
-    from order_of_dvd_of_pow_eq_one (by rw [pow_mul, pow_order_of_eq_one]),
-  coprime.dvd_of_dvd_mul_right (coprime_div_gcd_div_gcd gcd_pos)
-    (dvd_of_mul_dvd_mul_right gcd_pos
-      (by rwa [nat.div_mul_cancel (gcd_dvd_left _ _), mul_assoc,
-          nat.div_mul_cancel (gcd_dvd_right _ _), mul_comm])))
-
 section
 
 variables [integral_domain α] [decidable_eq α] (S : set (units α)) [is_subgroup S] [fintype S]
 
-lemma card_nth_roots_units {n : ℕ} (hn : 0 < n) (a : S) :
+lemma card_nth_roots_subgroup_units {n : ℕ} (hn : 0 < n) (a : S) :
   (univ.filter (λ b : S, b ^ n = a)).card ≤ (nth_roots n ((a : units α) : α)).card :=
 card_le_card_of_inj_on (λ a, ((a : units α) : α))
   (by simp [mem_nth_roots hn, (units.coe_pow _ _).symm, -units.coe_pow, units.ext_iff.symm, subtype.coe_ext])
   (by simp [units.ext_iff.symm, subtype.coe_ext.symm])
 
-lemma card_pow_eq_one_eq_order_of (a : S) :
-  (univ.filter (λ b : S, b ^ order_of a = 1)).card = order_of a :=
-le_antisymm
-(le_trans (card_nth_roots_units S (order_of_pos a) _) (card_nth_roots _ _))
-(calc order_of a = @fintype.card (gpowers a) (id _) : order_eq_card_gpowers
-  ... ≤ @fintype.card (↑(univ.filter (λ b : S, b ^ order_of a = 1)) : set S)
-  (set.fintype_of_finset _ (λ _, iff.rfl)) :
-    @fintype.card_le_of_injective (gpowers a) (↑(univ.filter (λ b : S, b ^ order_of a = 1)) : set S)
-      (id _) (id _) (λ b, ⟨b.1, mem_filter.2 ⟨mem_univ _,
-        let ⟨i, hi⟩ := b.2 in
-        by rw [← hi, ← gpow_coe_nat, ← gpow_mul, mul_comm, gpow_mul, gpow_coe_nat,
-          pow_order_of_eq_one, one_gpow]⟩⟩) (λ _ _ h, subtype.eq (subtype.mk.inj h))
-  ... = (univ.filter (λ b : S, b ^ order_of a = 1)).card : set.card_fintype_of_finset _ _)
-
-local notation `φ` := totient
-
-private lemma card_order_of_eq_totient_aux :
-  ∀ {d : ℕ}, d ∣ fintype.card S → 0 < (univ.filter (λ a : S, order_of a = d)).card →
-  (univ.filter (λ a : S, order_of a = d)).card = φ d
-| 0     := λ hd hd0, absurd hd0 (mt card_pos.1
-  (by simp [finset.ext, nat.pos_iff_ne_zero.1 (order_of_pos _)]))
-| (d+1) := λ hd hd0,
-let ⟨a, ha⟩ := exists_mem_of_ne_empty (card_pos.1 hd0) in
-have ha : order_of a = d.succ, from (mem_filter.1 ha).2,
-have h : ((range d.succ).filter (∣ d.succ)).sum
-    (λ m, (univ.filter (λ a : S, order_of a = m)).card) =
-    ((range d.succ).filter (∣ d.succ)).sum φ, from
-  finset.sum_congr rfl
-    (λ m hm, have hmd : m < d.succ, from mem_range.1 (mem_filter.1 hm).1,
-      have hm : m ∣ d.succ, from (mem_filter.1 hm).2,
-      card_order_of_eq_totient_aux (dvd.trans hm hd) (finset.card_pos.2
-        (ne_empty_of_mem (show a ^ (d.succ / m) ∈ _,
-          from mem_filter.2 ⟨mem_univ _,
-          by rw [order_of_pow, ha, gcd_eq_right (div_dvd_of_dvd hm),
-            nat.div_div_self hm (succ_pos _)]⟩)))),
-have hinsert : insert d.succ ((range d.succ).filter (∣ d.succ))
-    = (range d.succ.succ).filter (∣ d.succ),
-  from (finset.ext.2 $ λ x, ⟨λ h, (mem_insert.1 h).elim (λ h, by simp [h])
-    (by clear _let_match; simp; tauto), by clear _let_match; simp {contextual := tt}; tauto⟩),
-have hinsert₁ : d.succ ∉ (range d.succ).filter (∣ d.succ),
-  by simp [-range_succ, mem_range, zero_le_one, le_succ],
-(add_right_inj (((range d.succ).filter (∣ d.succ)).sum
-  (λ m, (univ.filter (λ a : S, order_of a = m)).card))).1
-  (calc _ = (insert d.succ (filter (∣ d.succ) (range d.succ))).sum
-        (λ m, (univ.filter (λ a : S, order_of a = m)).card) :
-    eq.symm (finset.sum_insert (by simp [-range_succ, mem_range, zero_le_one, le_succ]))
-  ... = ((range d.succ.succ).filter (∣ d.succ)).sum (λ m,
-      (univ.filter (λ a : S, order_of a = m)).card) :
-    sum_congr hinsert (λ _ _, rfl)
-  ... = (univ.filter (λ a : S, a ^ d.succ = 1)).card :
-    sum_card_order_of_eq_card_pow_eq_one (succ_pos d)
-  ... = ((range d.succ.succ).filter (∣ d.succ)).sum φ :
-    ha ▸ (card_pow_eq_one_eq_order_of S a).symm ▸ (sum_totient _).symm
-  ... = _ : by rw [h, ← sum_insert hinsert₁];
-      exact finset.sum_congr hinsert.symm (λ _ _, rfl))
-
-lemma card_order_of_eq_totient {d : ℕ} (hd : d ∣ fintype.card S) :
-  (univ.filter (λ a : S, order_of a = d)).card = φ d :=
-by_contradiction $ λ h,
-have h0 : (univ.filter (λ a : S, order_of a = d)).card = 0 :=
-  not_not.1 (mt nat.pos_iff_ne_zero.2 (mt (card_order_of_eq_totient_aux S hd) h)),
-let c := fintype.card S in
-have hc0 : 0 < c, from fintype.card_pos_iff.2 ⟨1⟩,
-lt_irrefl c $
-  calc c = (univ.filter (λ a : S, a ^ c = 1)).card :
-    congr_arg card $ by simp [finset.ext]
-  ... = ((range c.succ).filter (∣ c)).sum
-      (λ m, (univ.filter (λ a : S, order_of a = m)).card) :
-    (sum_card_order_of_eq_card_pow_eq_one hc0).symm
-  ... = (((range c.succ).filter (∣ c)).erase d).sum
-      (λ m, (univ.filter (λ a : S, order_of a = m)).card) :
-    eq.symm (sum_subset (erase_subset _ _) (λ m hm₁ hm₂,
-      have m = d, by simp at *; cc,
-      by simp [*, finset.ext] at *; exact h0))
-  ... ≤ (((range c.succ).filter (∣ c)).erase d).sum φ :
-    sum_le_sum (λ m hm,
-      have hmc : m ∣ c, by simp at hm; tauto,
-      (imp_iff_not_or.1 (card_order_of_eq_totient_aux S hmc)).elim
-        (λ h, by simp [nat.le_zero_iff.1 (le_of_not_gt h), nat.zero_le])
-        (by simp [le_refl] {contextual := tt}))
-  ... < φ d + (((range c.succ).filter (∣ c)).erase d).sum φ :
-    lt_add_of_pos_left _ (totient_pos (nat.pos_of_ne_zero
-      (λ h, nat.pos_iff_ne_zero.1 hc0 (eq_zero_of_zero_dvd $ h ▸ hd))))
-  ... = (insert d (((range c.succ).filter (∣ c)).erase d)).sum φ : eq.symm (sum_insert (by simp))
-  ... = ((range c.succ).filter (∣ c)).sum φ : finset.sum_congr
-      (finset.insert_erase (mem_filter.2 ⟨mem_range.2 (lt_succ_of_le (le_of_dvd hc0 hd)), hd⟩)) (λ _ _, rfl)
-  ... = c : sum_totient _
-
 instance subgroup_units_cyclic : is_cyclic S :=
 by haveI := classical.dec_eq α; exact
-have ∃ x, x ∈ univ.filter (λ a : S, order_of a = fintype.card S),
-from exists_mem_of_ne_empty (card_pos.1 $
-  by rw [card_order_of_eq_totient S (dvd_refl _)];
-  exact totient_pos (fintype.card_pos_iff.2 ⟨1⟩)),
-let ⟨x, hx⟩ := this in
-is_cyclic_of_order_of_eq_card x (finset.mem_filter.1 hx).2
+is_cyclic_of_card_pow_eq_one_le
+  (λ n hn, le_trans (card_nth_roots_subgroup_units S hn 1) (card_nth_roots _ _))
 
 end
 

--- a/field_theory/finite.lean
+++ b/field_theory/finite.lean
@@ -6,7 +6,7 @@ Authors: Chris Hughes
 import group_theory.order_of_element data.nat.totient data.polynomial
 
 universes u v
-variables {α : Type u} {β : Type v} [field α]
+variables {α : Type u} {β : Type v}
 
 open function finset polynomial nat
 
@@ -24,65 +24,42 @@ dvd_antisymm
       (by rwa [nat.div_mul_cancel (gcd_dvd_left _ _), mul_assoc,
           nat.div_mul_cancel (gcd_dvd_right _ _), mul_comm])))
 
-def units_equiv_ne_zero (α : Type*) [field α] : units α ≃ {a : α | a ≠ 0} :=
-⟨λ a, ⟨a.1, units.ne_zero _⟩, λ a, units.mk0 _ a.2, λ ⟨_, _, _, _⟩, units.ext rfl, λ ⟨_, _⟩, rfl⟩
+section
 
-@[simp] lemma coe_units_equiv_ne_zero (a : units α) : ((units_equiv_ne_zero α a) : α) = a := rfl
+variables [integral_domain α] [decidable_eq α] (S : set (units α)) [is_subgroup S] [fintype S]
 
-namespace finite_field
+lemma card_nth_roots_units {n : ℕ} (hn : 0 < n) (a : S) :
+  (univ.filter (λ b : S, b ^ n = a)).card ≤ (nth_roots n ((a : units α) : α)).card :=
+card_le_card_of_inj_on (λ a, ((a : units α) : α))
+  (by simp [mem_nth_roots hn, (units.coe_pow _ _).symm, -units.coe_pow, units.ext_iff.symm, subtype.coe_ext])
+  (by simp [units.ext_iff.symm, subtype.coe_ext.symm])
 
-variables [fintype α] [decidable_eq α]
-
-instance : fintype (units α) :=
-by haveI := set_fintype {a : α | a ≠ 0}; exact
-fintype.of_equiv _ (units_equiv_ne_zero α).symm
-
-lemma card_units : fintype.card (units α) = fintype.card α - 1 :=
-begin
-  rw [eq_comm, nat.sub_eq_iff_eq_add (fintype.card_pos_iff.2 ⟨(0 : α)⟩)],
-  haveI := set_fintype {a : α | a ≠ 0},
-  haveI := set_fintype (@set.univ α),
-  rw [fintype.card_congr (units_equiv_ne_zero _),
-    ← @set.card_insert _ _ {a : α | a ≠ 0} _ (not_not.2 (eq.refl (0 : α)))
-    (set.fintype_insert _ _), fintype.card_congr (equiv.set.univ α).symm],
-  congr; simp [set.ext_iff, classical.em]
-end
-
-lemma card_nth_roots_units {n : ℕ} (hn : 0 < n)
-  (a : units α) : (univ.filter (λ b, b ^ n = a)).card = (nth_roots n (a : α)).card :=
-card_congr (λ a _, a)
-  (by simp [mem_nth_roots hn, (units.coe_pow _ _).symm, -units.coe_pow, units.ext_iff.symm])
-  (by simp [units.ext_iff.symm])
-  (λ b hb, have hb0 : b ≠ 0, from λ h,
-    units.coe_ne_zero a $ by rwa [mem_nth_roots hn, h, _root_.zero_pow hn, eq_comm] at hb,
-    ⟨units.mk0 _ hb0, by simp [units.ext_iff, (mem_nth_roots hn).1 hb]⟩)
-
-lemma card_pow_eq_one_eq_order_of (a : units α) :
-  (univ.filter (λ b : units α, b ^ order_of a = 1)).card = order_of a :=
+lemma card_pow_eq_one_eq_order_of (a : S) :
+  (univ.filter (λ b : S, b ^ order_of a = 1)).card = order_of a :=
 le_antisymm
-(by rw card_nth_roots_units (order_of_pos a) 1; exact card_nth_roots _ _)
+(le_trans (card_nth_roots_units S (order_of_pos a) _) (card_nth_roots _ _))
 (calc order_of a = @fintype.card (gpowers a) (id _) : order_eq_card_gpowers
-  ... ≤ @fintype.card (↑(univ.filter (λ b : units α, b ^ order_of a = 1)) : set (units α))
+  ... ≤ @fintype.card (↑(univ.filter (λ b : S, b ^ order_of a = 1)) : set S)
   (set.fintype_of_finset _ (λ _, iff.rfl)) :
-    @fintype.card_le_of_injective (gpowers a) (↑(univ.filter (λ b : units α, b ^ order_of a = 1)) : set (units α))
+    @fintype.card_le_of_injective (gpowers a) (↑(univ.filter (λ b : S, b ^ order_of a = 1)) : set S)
       (id _) (id _) (λ b, ⟨b.1, mem_filter.2 ⟨mem_univ _,
         let ⟨i, hi⟩ := b.2 in
         by rw [← hi, ← gpow_coe_nat, ← gpow_mul, mul_comm, gpow_mul, gpow_coe_nat,
           pow_order_of_eq_one, one_gpow]⟩⟩) (λ _ _ h, subtype.eq (subtype.mk.inj h))
-  ... = (univ.filter (λ b : units α, b ^ order_of a = 1)).card : set.card_fintype_of_finset _ _)
+  ... = (univ.filter (λ b : S, b ^ order_of a = 1)).card : set.card_fintype_of_finset _ _)
 
 local notation `φ` := totient
 
 private lemma card_order_of_eq_totient_aux :
-  ∀ {d : ℕ}, d ∣ fintype.card (units α) → 0 < (univ.filter (λ a : units α, order_of a = d)).card →
-  (univ.filter (λ a : units α, order_of a = d)).card = φ d
+  ∀ {d : ℕ}, d ∣ fintype.card S → 0 < (univ.filter (λ a : S, order_of a = d)).card →
+  (univ.filter (λ a : S, order_of a = d)).card = φ d
 | 0     := λ hd hd0, absurd hd0 (mt card_pos.1
   (by simp [finset.ext, nat.pos_iff_ne_zero.1 (order_of_pos _)]))
 | (d+1) := λ hd hd0,
 let ⟨a, ha⟩ := exists_mem_of_ne_empty (card_pos.1 hd0) in
 have ha : order_of a = d.succ, from (mem_filter.1 ha).2,
 have h : ((range d.succ).filter (∣ d.succ)).sum
-    (λ m, (univ.filter (λ a : units α, order_of a = m)).card) =
+    (λ m, (univ.filter (λ a : S, order_of a = m)).card) =
     ((range d.succ).filter (∣ d.succ)).sum φ, from
   finset.sum_congr rfl
     (λ m hm, have hmd : m < d.succ, from mem_range.1 (mem_filter.1 hm).1,
@@ -99,42 +76,42 @@ have hinsert : insert d.succ ((range d.succ).filter (∣ d.succ))
 have hinsert₁ : d.succ ∉ (range d.succ).filter (∣ d.succ),
   by simp [-range_succ, mem_range, zero_le_one, le_succ],
 (add_right_inj (((range d.succ).filter (∣ d.succ)).sum
-  (λ m, (univ.filter (λ a : units α, order_of a = m)).card))).1
+  (λ m, (univ.filter (λ a : S, order_of a = m)).card))).1
   (calc _ = (insert d.succ (filter (∣ d.succ) (range d.succ))).sum
-        (λ m, (univ.filter (λ (a : units α), order_of a = m)).card) :
+        (λ m, (univ.filter (λ a : S, order_of a = m)).card) :
     eq.symm (finset.sum_insert (by simp [-range_succ, mem_range, zero_le_one, le_succ]))
   ... = ((range d.succ.succ).filter (∣ d.succ)).sum (λ m,
-      (univ.filter (λ a : units α, order_of a = m)).card) :
+      (univ.filter (λ a : S, order_of a = m)).card) :
     sum_congr hinsert (λ _ _, rfl)
-  ... = (univ.filter (λ a : units α, a ^ d.succ = 1)).card :
+  ... = (univ.filter (λ a : S, a ^ d.succ = 1)).card :
     sum_card_order_of_eq_card_pow_eq_one (succ_pos d)
   ... = ((range d.succ.succ).filter (∣ d.succ)).sum φ :
-    ha ▸ (card_pow_eq_one_eq_order_of a).symm ▸ (sum_totient _).symm
+    ha ▸ (card_pow_eq_one_eq_order_of S a).symm ▸ (sum_totient _).symm
   ... = _ : by rw [h, ← sum_insert hinsert₁];
       exact finset.sum_congr hinsert.symm (λ _ _, rfl))
 
-lemma card_order_of_eq_totient {d : ℕ} (hd : d ∣ fintype.card (units α)) :
-  (univ.filter (λ a : units α, order_of a = d)).card = φ d :=
+lemma card_order_of_eq_totient {d : ℕ} (hd : d ∣ fintype.card S) :
+  (univ.filter (λ a : S, order_of a = d)).card = φ d :=
 by_contradiction $ λ h,
-have h0 : (univ.filter (λ a : units α, order_of a = d)).card = 0 :=
-  not_not.1 (mt nat.pos_iff_ne_zero.2 (mt (card_order_of_eq_totient_aux hd) h)),
-let c := fintype.card (units α) in
+have h0 : (univ.filter (λ a : S, order_of a = d)).card = 0 :=
+  not_not.1 (mt nat.pos_iff_ne_zero.2 (mt (card_order_of_eq_totient_aux S hd) h)),
+let c := fintype.card S in
 have hc0 : 0 < c, from fintype.card_pos_iff.2 ⟨1⟩,
 lt_irrefl c $
-  calc c = (univ.filter (λ a : units α, a ^ c = 1)).card :
+  calc c = (univ.filter (λ a : S, a ^ c = 1)).card :
     congr_arg card $ by simp [finset.ext]
   ... = ((range c.succ).filter (∣ c)).sum
-      (λ m, (univ.filter (λ a : units α, order_of a = m)).card) :
+      (λ m, (univ.filter (λ a : S, order_of a = m)).card) :
     (sum_card_order_of_eq_card_pow_eq_one hc0).symm
   ... = (((range c.succ).filter (∣ c)).erase d).sum
-      (λ m, (univ.filter (λ a : units α, order_of a = m)).card) :
+      (λ m, (univ.filter (λ a : S, order_of a = m)).card) :
     eq.symm (sum_subset (erase_subset _ _) (λ m hm₁ hm₂,
       have m = d, by simp at *; cc,
-      by simp [*, finset.ext] at *))
+      by simp [*, finset.ext] at *; exact h0))
   ... ≤ (((range c.succ).filter (∣ c)).erase d).sum φ :
     sum_le_sum (λ m hm,
       have hmc : m ∣ c, by simp at hm; tauto,
-      (imp_iff_not_or.1 (card_order_of_eq_totient_aux hmc)).elim
+      (imp_iff_not_or.1 (card_order_of_eq_totient_aux S hmc)).elim
         (λ h, by simp [nat.le_zero_iff.1 (le_of_not_gt h), nat.zero_le])
         (by simp [le_refl] {contextual := tt}))
   ... < φ d + (((range c.succ).filter (∣ c)).erase d).sum φ :
@@ -145,16 +122,49 @@ lt_irrefl c $
       (finset.insert_erase (mem_filter.2 ⟨mem_range.2 (lt_succ_of_le (le_of_dvd hc0 hd)), hd⟩)) (λ _ _, rfl)
   ... = c : sum_totient _
 
-instance {α : Type*} [fintype α] [field α] : is_cyclic (units α) :=
+instance subgroup_units_cyclic : is_cyclic S :=
 by haveI := classical.dec_eq α; exact
-have ∃ x, x ∈ univ.filter (λ a : units α, order_of a = fintype.card (units α)),
+have ∃ x, x ∈ univ.filter (λ a : S, order_of a = fintype.card S),
 from exists_mem_of_ne_empty (card_pos.1 $
-  by rw [card_order_of_eq_totient (dvd_refl _)];
+  by rw [card_order_of_eq_totient S (dvd_refl _)];
   exact totient_pos (fintype.card_pos_iff.2 ⟨1⟩)),
 let ⟨x, hx⟩ := this in
 is_cyclic_of_order_of_eq_card x (finset.mem_filter.1 hx).2
 
-lemma prod_univ_units_id_eq_neg_one : univ.prod (λ x, x) = (-1 : units α) :=
+end
+
+namespace finite_field
+
+def units_equiv_ne_zero (α : Type*) [field α] : units α ≃ {a : α | a ≠ 0} :=
+⟨λ a, ⟨a.1, units.ne_zero _⟩, λ a, units.mk0 _ a.2, λ ⟨_, _, _, _⟩, units.ext rfl, λ ⟨_, _⟩, rfl⟩
+
+@[simp] lemma coe_units_equiv_ne_zero [field α] (a : units α) : ((units_equiv_ne_zero α a) : α) = a := rfl
+
+variables [field α] [fintype α]
+
+instance [decidable_eq α] : fintype (units α) :=
+by haveI := set_fintype {a : α | a ≠ 0}; exact
+fintype.of_equiv _ (units_equiv_ne_zero α).symm
+
+lemma card_units [decidable_eq α] : fintype.card (units α) = fintype.card α - 1 :=
+begin
+  rw [eq_comm, nat.sub_eq_iff_eq_add (fintype.card_pos_iff.2 ⟨(0 : α)⟩)],
+  haveI := set_fintype {a : α | a ≠ 0},
+  haveI := set_fintype (@set.univ α),
+  rw [fintype.card_congr (units_equiv_ne_zero _),
+    ← @set.card_insert _ _ {a : α | a ≠ 0} _ (not_not.2 (eq.refl (0 : α)))
+    (set.fintype_insert _ _), fintype.card_congr (equiv.set.univ α).symm],
+  congr; simp [set.ext_iff, classical.em]
+end
+
+instance : is_cyclic (units α) :=
+by haveI := classical.dec_eq α;
+haveI := set_fintype (@set.univ (units α)); exact
+let ⟨g, hg⟩ := is_cyclic.exists_generator (@set.univ (units α)) in
+⟨⟨g, λ x, let ⟨n, hn⟩ := hg ⟨x, trivial⟩ in ⟨n, by rw [← is_subgroup.coe_gpow, hn]; refl⟩⟩⟩
+
+lemma prod_univ_units_id_eq_neg_one [decidable_eq α] :
+  univ.prod (λ x, x) = (-1 : units α) :=
 have ((@univ (units α) _).erase (-1)).prod (λ x, x) = 1,
 from prod_involution (λ x _, x⁻¹) (by simp)
   (λ a, by simp [units.inv_eq_self_iff] {contextual := tt})

--- a/field_theory/finite.lean
+++ b/field_theory/finite.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
-import group_theory.order_of_element data.nat.totient data.polynomial
+import group_theory.order_of_element data.nat.totient data.polynomial data.equiv.algebra
 
 universes u v
 variables {α : Type u} {β : Type v}
@@ -134,11 +134,6 @@ is_cyclic_of_order_of_eq_card x (finset.mem_filter.1 hx).2
 end
 
 namespace finite_field
-
-def units_equiv_ne_zero (α : Type*) [field α] : units α ≃ {a : α | a ≠ 0} :=
-⟨λ a, ⟨a.1, units.ne_zero _⟩, λ a, units.mk0 _ a.2, λ ⟨_, _, _, _⟩, units.ext rfl, λ ⟨_, _⟩, rfl⟩
-
-@[simp] lemma coe_units_equiv_ne_zero [field α] (a : units α) : ((units_equiv_ne_zero α a) : α) = a := rfl
 
 variables [field α] [fintype α]
 

--- a/group_theory/order_of_element.lean
+++ b/group_theory/order_of_element.lean
@@ -3,8 +3,8 @@ Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
-import data.set.finite group_theory.coset
-open set function
+import data.set.finite group_theory.coset data.nat.totient
+open function
 
 variables {α : Type*} {s : set α} {a a₁ a₂ b c: α}
 
@@ -29,6 +29,7 @@ end finset
 
 section order_of
 variables [group α] [fintype α] [decidable_eq α]
+open set
 
 lemma exists_gpow_eq_one (a : α) : ∃i≠0, a ^ (i:ℤ) = 1 :=
 have ¬ injective (λi, a ^ i),
@@ -180,6 +181,32 @@ set.ext (λ x, ⟨λ ⟨n, hn⟩, ⟨n, by simp * at *⟩,
     by rwa [← gpow_coe_nat, int.nat_abs_of_nonneg (int.mod_nonneg _
       (int.coe_nat_ne_zero_iff_pos.2 (order_of_pos _))), ← gpow_eq_mod_order_of]⟩⟩)
 
+open nat
+
+lemma order_of_pow (a : α) (n : ℕ) : order_of (a ^ n) = order_of a / gcd (order_of a) n :=
+dvd_antisymm
+  (order_of_dvd_of_pow_eq_one
+    (by rw [← pow_mul, ← nat.mul_div_assoc _ (gcd_dvd_left _ _), mul_comm,
+      nat.mul_div_assoc _ (gcd_dvd_right _ _), pow_mul, pow_order_of_eq_one, _root_.one_pow]))
+  (have gcd_pos : 0 < gcd (order_of a) n, from gcd_pos_of_pos_left n (order_of_pos a),
+    have hdvd : order_of a ∣ n * order_of (a ^ n),
+      from order_of_dvd_of_pow_eq_one (by rw [pow_mul, pow_order_of_eq_one]),
+    coprime.dvd_of_dvd_mul_right (coprime_div_gcd_div_gcd gcd_pos)
+      (dvd_of_mul_dvd_mul_right gcd_pos
+        (by rwa [nat.div_mul_cancel (gcd_dvd_left _ _), mul_assoc,
+            nat.div_mul_cancel (gcd_dvd_right _ _), mul_comm])))
+
+lemma pow_gcd_card_eq_one_iff {n : ℕ} {a : α} :
+  a ^ n = 1 ↔ a ^ (gcd n (fintype.card α)) = 1 :=
+⟨λ h, have hn : order_of a ∣ n, from dvd_of_mod_eq_zero $
+      by_contradiction (λ ha, by rw pow_eq_mod_order_of at h;
+        exact (not_le_of_gt (nat.mod_lt n (order_of_pos a)))
+          (order_of_le_of_pow_eq_one (nat.pos_of_ne_zero ha) h)),
+    let ⟨m, hm⟩ := dvd_gcd hn order_of_dvd_card_univ in
+    by rw [hm, pow_mul, pow_order_of_eq_one, _root_.one_pow],
+  λ h, let ⟨m, hm⟩ := gcd_dvd_left n (fintype.card α) in
+    by rw [hm, pow_mul, h, _root_.one_pow]⟩
+
 end
 
 end order_of
@@ -197,7 +224,7 @@ lemma is_cyclic_of_order_of_eq_card [group α] [fintype α] [decidable_eq α]
   (set.subset_univ _)
   (by rw [fintype.card_congr (equiv.set.univ α), ← hx, order_eq_card_gpowers])⟩⟩
 
-lemma order_of_eq_card_of_forall_mem_gppowers [group α] [fintype α] [decidable_eq α]
+lemma order_of_eq_card_of_forall_mem_gpowers [group α] [fintype α] [decidable_eq α]
   {g : α} (hx : ∀ x, x ∈ gpowers g) : order_of g = fintype.card α :=
 by rw [← fintype.card_congr (equiv.set.univ α), order_eq_card_gpowers];
   simp [hx]; congr
@@ -248,5 +275,141 @@ else
     from set.ext $ λ x, ⟨λ h, by simp at *; tauto,
       λ h, by rw [is_subgroup.mem_trivial.1 h]; exact is_submonoid.one_mem _⟩,
   by clear _let_match; subst this; apply_instance
+
+open finset nat
+
+lemma is_cyclic.card_pow_eq_one_le [group α] [fintype α] [decidable_eq α] [is_cyclic α] {n : ℕ}
+  (hn0 : 0 < n) : (univ.filter (λ a : α, a ^ n = 1)).card ≤ n :=
+let ⟨g, hg⟩ := is_cyclic.exists_generator α in
+calc (univ.filter (λ a : α, a ^ n = 1)).card ≤ (gpowers (g ^ (fintype.card α / (gcd n (fintype.card α))))).to_finset.card :
+  card_le_of_subset (λ x hx, let ⟨m, hm⟩ := show x ∈ powers g, from (powers_eq_gpowers g).symm ▸ hg x in
+    set.mem_to_finset.2 ⟨(m / (fintype.card α / (gcd n (fintype.card α))) : ℕ),
+      have hgmn : g ^ (m * gcd n (fintype.card α)) = 1,
+        by rw [pow_mul, hm, ← pow_gcd_card_eq_one_iff]; exact (mem_filter.1 hx).2,
+      begin
+        rw [gpow_coe_nat, ← pow_mul, nat.mul_div_cancel_left', hm],
+        refine dvd_of_mul_dvd_mul_right (gcd_pos_of_pos_left (fintype.card α) hn0) _,
+        conv {to_lhs, rw [nat.div_mul_cancel (gcd_dvd_right _ _), ← order_of_eq_card_of_forall_mem_gpowers hg]},
+        exact order_of_dvd_of_pow_eq_one hgmn
+      end⟩)
+... ≤ n :
+  let ⟨m, hm⟩ := gcd_dvd_right n (fintype.card α) in
+  have hm0 : 0 < m, from nat.pos_of_ne_zero
+    (λ hm0, (by rw [hm0, mul_zero, fintype.card_eq_zero_iff] at hm; exact hm 1)),
+  begin
+    rw [← set.card_fintype_of_finset' _ (λ _, set.mem_to_finset), ← order_eq_card_gpowers,
+      order_of_pow, order_of_eq_card_of_forall_mem_gpowers hg],
+    rw [hm] {occs := occurrences.pos [2,3]},
+    rw [nat.mul_div_cancel_left _  (gcd_pos_of_pos_left _ hn0), gcd_mul_left_left,
+      hm, nat.mul_div_cancel _ hm0],
+    exact le_of_dvd hn0 (gcd_dvd_left _ _)
+  end
+
+section totient
+
+variables [group α] [fintype α] [decidable_eq α] (hn : ∀ n : ℕ, 0 < n → (univ.filter (λ a : α, a ^ n = 1)).card ≤ n)
+include hn
+
+lemma card_pow_eq_one_eq_order_of_aux (a : α) :
+  (finset.univ.filter (λ b : α, b ^ order_of a = 1)).card = order_of a :=
+le_antisymm
+  (hn _ (order_of_pos _))
+  (calc order_of a = @fintype.card (gpowers a) (id _) : order_eq_card_gpowers
+    ... ≤ @fintype.card (↑(univ.filter (λ b : α, b ^ order_of a = 1)) : set α)
+    (set.fintype_of_finset _ (λ _, iff.rfl)) :
+      @fintype.card_le_of_injective (gpowers a) (↑(univ.filter (λ b : α, b ^ order_of a = 1)) : set α)
+        (id _) (id _) (λ b, ⟨b.1, mem_filter.2 ⟨mem_univ _,
+          let ⟨i, hi⟩ := b.2 in
+          by rw [← hi, ← gpow_coe_nat, ← gpow_mul, mul_comm, gpow_mul, gpow_coe_nat,
+            pow_order_of_eq_one, one_gpow]⟩⟩) (λ _ _ h, subtype.eq (subtype.mk.inj h))
+    ... = (univ.filter (λ b : α, b ^ order_of a = 1)).card : set.card_fintype_of_finset _ _)
+
+local notation `φ` := nat.totient
+
+private lemma card_order_of_eq_totient_aux₁ :
+  ∀ {d : ℕ}, d ∣ fintype.card α → 0 < (univ.filter (λ a : α, order_of a = d)).card →
+  (univ.filter (λ a : α, order_of a = d)).card = φ d
+| 0     := λ hd hd0, absurd hd0 (mt card_pos.1
+  (by simp [finset.ext, nat.pos_iff_ne_zero.1 (order_of_pos _)]))
+| (d+1) := λ hd hd0,
+let ⟨a, ha⟩ := exists_mem_of_ne_empty (card_pos.1 hd0) in
+have ha : order_of a = d.succ, from (mem_filter.1 ha).2,
+have h : ((range d.succ).filter (∣ d.succ)).sum
+    (λ m, (univ.filter (λ a : α, order_of a = m)).card) =
+    ((range d.succ).filter (∣ d.succ)).sum φ, from
+  finset.sum_congr rfl
+    (λ m hm, have hmd : m < d.succ, from mem_range.1 (mem_filter.1 hm).1,
+      have hm : m ∣ d.succ, from (mem_filter.1 hm).2,
+      card_order_of_eq_totient_aux₁ (dvd.trans hm hd) (finset.card_pos.2
+        (ne_empty_of_mem (show a ^ (d.succ / m) ∈ _,
+          from mem_filter.2 ⟨mem_univ _,
+          by rw [order_of_pow, ha, gcd_eq_right (div_dvd_of_dvd hm),
+            nat.div_div_self hm (succ_pos _)]⟩)))),
+have hinsert : insert d.succ ((range d.succ).filter (∣ d.succ))
+    = (range d.succ.succ).filter (∣ d.succ),
+  from (finset.ext.2 $ λ x, ⟨λ h, (mem_insert.1 h).elim (λ h, by simp [h])
+    (by clear _let_match; simp; tauto), by clear _let_match; simp {contextual := tt}; tauto⟩),
+have hinsert₁ : d.succ ∉ (range d.succ).filter (∣ d.succ),
+  by simp [-range_succ, mem_range, zero_le_one, le_succ],
+(add_right_inj (((range d.succ).filter (∣ d.succ)).sum
+  (λ m, (univ.filter (λ a : α, order_of a = m)).card))).1
+  (calc _ = (insert d.succ (filter (∣ d.succ) (range d.succ))).sum
+        (λ m, (univ.filter (λ a : α, order_of a = m)).card) :
+    eq.symm (finset.sum_insert (by simp [-range_succ, mem_range, zero_le_one, le_succ]))
+  ... = ((range d.succ.succ).filter (∣ d.succ)).sum (λ m,
+      (univ.filter (λ a : α, order_of a = m)).card) :
+    sum_congr hinsert (λ _ _, rfl)
+  ... = (univ.filter (λ a : α, a ^ d.succ = 1)).card :
+    sum_card_order_of_eq_card_pow_eq_one (succ_pos d)
+  ... = ((range d.succ.succ).filter (∣ d.succ)).sum φ :
+    ha ▸ (card_pow_eq_one_eq_order_of_aux hn a).symm ▸ (sum_totient _).symm
+  ... = _ : by rw [h, ← sum_insert hinsert₁];
+      exact finset.sum_congr hinsert.symm (λ _ _, rfl))
+
+lemma card_order_of_eq_totient_aux₂ {d : ℕ} (hd : d ∣ fintype.card α) :
+  (univ.filter (λ a : α, order_of a = d)).card = φ d :=
+by_contradiction $ λ h,
+have h0 : (univ.filter (λ a : α , order_of a = d)).card = 0 :=
+  not_not.1 (mt nat.pos_iff_ne_zero.2 (mt (card_order_of_eq_totient_aux₁ hn hd) h)),
+let c := fintype.card α in
+have hc0 : 0 < c, from fintype.card_pos_iff.2 ⟨1⟩,
+lt_irrefl c $
+  calc c = (univ.filter (λ a : α, a ^ c = 1)).card :
+    congr_arg card $ by simp [finset.ext, c]
+  ... = ((range c.succ).filter (∣ c)).sum
+      (λ m, (univ.filter (λ a : α, order_of a = m)).card) :
+    (sum_card_order_of_eq_card_pow_eq_one hc0).symm
+  ... = (((range c.succ).filter (∣ c)).erase d).sum
+      (λ m, (univ.filter (λ a : α, order_of a = m)).card) :
+    eq.symm (sum_subset (erase_subset _ _) (λ m hm₁ hm₂,
+      have m = d, by simp at *; cc,
+      by simp [*, finset.ext] at *; exact h0))
+  ... ≤ (((range c.succ).filter (∣ c)).erase d).sum φ :
+    sum_le_sum (λ m hm,
+      have hmc : m ∣ c, by simp at hm; tauto,
+      (imp_iff_not_or.1 (card_order_of_eq_totient_aux₁ hn hmc)).elim
+        (λ h, by simp [nat.le_zero_iff.1 (le_of_not_gt h), nat.zero_le])
+        (by simp [le_refl] {contextual := tt}))
+  ... < φ d + (((range c.succ).filter (∣ c)).erase d).sum φ :
+    lt_add_of_pos_left _ (totient_pos (nat.pos_of_ne_zero
+      (λ h, nat.pos_iff_ne_zero.1 hc0 (eq_zero_of_zero_dvd $ h ▸ hd))))
+  ... = (insert d (((range c.succ).filter (∣ c)).erase d)).sum φ : eq.symm (sum_insert (by simp))
+  ... = ((range c.succ).filter (∣ c)).sum φ : finset.sum_congr
+      (finset.insert_erase (mem_filter.2 ⟨mem_range.2 (lt_succ_of_le (le_of_dvd hc0 hd)), hd⟩)) (λ _ _, rfl)
+  ... = c : sum_totient _
+
+lemma is_cyclic_of_card_pow_eq_one_le : is_cyclic α :=
+have ∃ x, x ∈ univ.filter (λ a : α, order_of a = fintype.card α),
+from exists_mem_of_ne_empty (card_pos.1 $
+  by rw [card_order_of_eq_totient_aux₂ hn (dvd_refl _)];
+  exact totient_pos (fintype.card_pos_iff.2 ⟨1⟩)),
+let ⟨x, hx⟩ := this in
+is_cyclic_of_order_of_eq_card x (finset.mem_filter.1 hx).2
+
+end totient
+
+lemma is_cyclic.card_order_of_eq_totient [group α] [is_cyclic α] [fintype α] [decidable_eq α]
+  {d : ℕ} (hd : d ∣ fintype.card α) : (univ.filter (λ a : α, order_of a = d)).card = totient d :=
+card_order_of_eq_totient_aux₂ (λ n, is_cyclic.card_pow_eq_one_le) hd
 
 end cyclic

--- a/group_theory/order_of_element.lean
+++ b/group_theory/order_of_element.lean
@@ -218,6 +218,13 @@ local attribute [instance] set_fintype
 class is_cyclic (α : Type*) [group α] : Prop :=
 (exists_generator : ∃ g : α, ∀ x, x ∈ gpowers g)
 
+def is_cyclic.comm_group [hg : group α] [is_cyclic α] : comm_group α :=
+{ mul_comm := λ x y, show x * y = y * x,
+    from let ⟨g, hg⟩ := is_cyclic.exists_generator α in
+    let ⟨n, hn⟩ := hg x in let ⟨m, hm⟩ := hg y in
+    hm ▸ hn ▸ gpow_mul_comm _ _ _,
+  ..hg }
+
 lemma is_cyclic_of_order_of_eq_card [group α] [fintype α] [decidable_eq α]
   (x : α) (hx : order_of x = fintype.card α) : is_cyclic α :=
 ⟨⟨x, set.eq_univ_iff_forall.1 $ set.eq_of_subset_of_card_le


### PR DESCRIPTION
Generalize the proof that the units of a finite field are cyclic, to a proof that any subgroup of the units of an integral domain are cyclic.

TO CONTRIBUTORS:

Make sure you have:

 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
