### PR TITLE
feat(tactic/conv): add `erw`, `conv_lhs`, and `conv_rhs`

### DIFF
--- a/docs/extras/conv.md
+++ b/docs/extras/conv.md
@@ -133,5 +133,7 @@ definitionally equal, rather like the `show` command in tactic mode.
 The `whnf` command means "reduces to weak head normal form" and will eventually
 be explained in [Programming in Lean](https://leanprover.github.io/programming_in_lean/#08_Writing_Tactics.html) section 8.4.
 
+Extensions to `conv` provided by mathlib can be found at [docs/tactics.md#conv](../tactics.md#conv).
+
 Soon, `norm_num` and `ring` will be available in conversion mode, but not
 yet.

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -551,3 +551,23 @@ Known limitation(s):
     `squeeze_simp` will produce as many suggestions as the number of goals it is applied to.
     It is likely that none of the suggestion is a good replacement but they can all be
     combined by concatenating their list of lemmas.
+
+## conv
+
+The `conv` tactic is built-in to lean. Currently mathlib additionally provides `erw`
+to be available inside a `conv` block. Also, as a shorthand `conv_lhs` and `conv_rhs`
+are provided, so that
+```
+example : 0 + 0 = 0 :=
+begin
+  conv_lhs {simp}
+end
+```
+just means
+```
+example : 0 + 0 = 0 :=
+begin
+  conv {to_lhs, simp}
+end
+```
+and likewise for `to_rhs`.

--- a/tactic/converter/interactive.lean
+++ b/tactic/converter/interactive.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Leonardo de Moura
+Authors: Leonardo de Moura, Keeley Hoek
 
 Converter monad for building simplifiers.
 -/
@@ -65,11 +65,24 @@ meta def find (p : parse lean.parser.pexpr) (c : itactic) : old_conv unit :=
 end interactive
 end old_conv
 
+namespace conv
+namespace interactive
+open interactive
+open tactic.interactive (rw_rules)
+open tactic (rewrite_cfg)
+
+meta def erw (q : parse rw_rules) (cfg : rewrite_cfg := {md := semireducible}) : conv unit :=
+rw q cfg
+
+end interactive
+end conv
+
 namespace tactic
 namespace interactive
+open lean
 open lean.parser
 open interactive
-open interactive.types
+local postfix `?`:9001 := optional
 
 meta def old_conv (c : old_conv.interactive.itactic) : tactic unit :=
 do t ← target,
@@ -78,6 +91,16 @@ do t ← target,
 
 meta def find (p : parse lean.parser.pexpr) (c : old_conv.interactive.itactic) : tactic unit :=
 old_conv $ old_conv.interactive.find p c
+
+meta def conv_lhs (loc : parse (tk "at" *> ident)?)
+              (p : parse (tk "in" *> parser.pexpr)?)
+              (c : conv.interactive.itactic) : tactic unit :=
+conv loc p (conv.interactive.to_lhs >> c)
+
+meta def conv_rhs (loc : parse (tk "at" *> ident)?)
+              (p : parse (tk "in" *> parser.pexpr)?)
+              (c : conv.interactive.itactic) : tactic unit :=
+conv loc p (conv.interactive.to_rhs >> c)
 
 end interactive
 end tactic

--- a/tests/tactics.lean
+++ b/tests/tactics.lean
@@ -5,7 +5,7 @@ Authors: Simon Hudon, Scott Morrison
 -/
 import tactic data.set.lattice data.prod data.vector
        tactic.rewrite data.stream.basic
-       tactic.tfae
+       tactic.tfae tactic.converter.interactive
 
 section tauto₀
 variables p q r : Prop
@@ -650,3 +650,18 @@ end assoc_rw
 -- end
 
 -- end tfae
+
+example : 0 + 0 = 0 :=
+begin
+  conv_lhs {erw [add_zero]}
+end
+
+example : 0 + 0 = 0 :=
+begin
+  conv_lhs {simp}
+end
+
+example : 0 = 0 + 0 :=
+begin
+  conv_rhs {simp}
+end


### PR DESCRIPTION
`rewrite_search` can now directly generate `conv` proofs (and soon `calc` output too), but the lack of `erw` is unfortunate (having to sprinkle a whole punch of `{md := semireducible}`s around the place is obviously very undesirable).

We add `erw` to `conv`, mirroring exactly the style in which `rw` and friends are defined in core lean.

In the same vein we also provide `conv_lhs` and `conv_rhs` as a shorthand for `conv { to_lhs, xxx }` and likewise for `to_rhs`, which are very convenient for constructing cleaner successive calls to `conv` (e.g. at the moment ugliness such as that in https://github.com/khoek/lean-category-theory/commit/8a60c5468cc5cd02f764b30257f338c4e2fff1e1#diff-38fc3086061cb2cd5e8ecbbd3acf7e1aR178 has to go on, and that's just total garbage).

We add a short explanation to the docs, trying not to be intrusive.

<br>

TO CONTRIBUTORS:

Make sure you have:

 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
