### PR TITLE
feat(tactic/ring(2)): add `ring` and `ring2` to `conv`

### DIFF
--- a/docs/extras/conv.md
+++ b/docs/extras/conv.md
@@ -135,5 +135,4 @@ be explained in [Programming in Lean](https://leanprover.github.io/programming_i
 
 Extensions to `conv` provided by mathlib can be found at [docs/tactics.md#conv](../tactics.md#conv).
 
-Soon, `norm_num` and `ring` will be available in conversion mode, but not
-yet.
+Soon, `norm_num` will be available in conversion mode, but not yet.

--- a/docs/extras/conv.md
+++ b/docs/extras/conv.md
@@ -133,5 +133,7 @@ definitionally equal, rather like the `show` command in tactic mode.
 The `whnf` command means "reduces to weak head normal form" and will eventually
 be explained in [Programming in Lean](https://leanprover.github.io/programming_in_lean/#08_Writing_Tactics.html) section 8.4.
 
+Extensions to `conv` provided by mathlib can be found at [docs/tactics.md#conv](../tactics.md#conv).
+
 Soon, `norm_num` and `ring` will be available in conversion mode, but not
 yet.

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -554,8 +554,10 @@ Known limitation(s):
 
 ## conv
 
-The `conv` tactic is built-in to lean. Currently mathlib additionally provides `erw`
-to be available inside a `conv` block. Also, as a shorthand `conv_lhs` and `conv_rhs`
+The `conv` tactic is built-in to lean. Currently mathlib additionally provides
+   * `erw`, and
+   * `ring` and `ring2`
+inside `conv` blocks. Also, as a shorthand `conv_lhs` and `conv_rhs`
 are provided, so that
 ```
 example : 0 + 0 = 0 :=

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -551,3 +551,23 @@ Known limitation(s):
     `squeeze_simp` will produce as many suggestions as the number of goals it is applied to.
     It is likely that none of the suggestion is a good replacement but they can all be
     combined by concatenating their list of lemmas.
+
+## conv
+
+The `conv` tactic is built-in to lean. Currently mathlib additionally provides `erw`
+to be available inside a `conv` block. Also, as a shorthand `conv_lhs` and `conv_rhs`
+are provided, so that
+```
+example : 0 + 0 = 0 :=
+begin
+  conv_lhs {simp}
+end
+```
+just means
+```
+example : 0 + 0 = 0 :=
+begin
+  conv {to_lhs, simp}
+end
+```
+and likewise for `to_rhs`.

--- a/tactic/basic.lean
+++ b/tactic/basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Mario Carneiro, Simon Hudon, Scott Morrison
+Authors: Mario Carneiro, Simon Hudon, Scott Morrison, Keeley Hoek
 -/
 import data.dlist.basic category.basic
 
@@ -461,7 +461,7 @@ meta def apply_assumption
   (asms : tactic (list expr) := local_context)
   (tac : tactic unit := skip) : tactic unit :=
 do { ctx ← asms,
-     ctx.any_of (λ H, symm_apply H >> tac) } <|> 
+     ctx.any_of (λ H, symm_apply H >> tac) } <|>
 do { exfalso,
      ctx ← asms,
      ctx.any_of (λ H, symm_apply H >> tac) }
@@ -596,6 +596,14 @@ meta def choose : expr → list name → tactic unit
   v ← get_unused_name >>= choose1 h n,
   choose v ns
 
+/-- This makes sure that the execution of the tactic does not change the tactic state.
+    This can be helpful while using rewrite, apply, or expr munging.
+    Remember to instantiate your metavariables before you're done! -/
+meta def lock_tactic_state {α} (t : tactic α) : tactic α
+| s := match t s with
+       | result.success a s' := result.success a s
+       | result.exception msg pos s' := result.exception msg pos s
+end
 
 /--
 Hole command used to fill in a structure's field when specifying an instance.

--- a/tactic/converter/interactive.lean
+++ b/tactic/converter/interactive.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Leonardo de Moura
+Authors: Leonardo de Moura, Keeley Hoek
 
 Converter monad for building simplifiers.
 -/
@@ -65,11 +65,24 @@ meta def find (p : parse lean.parser.pexpr) (c : itactic) : old_conv unit :=
 end interactive
 end old_conv
 
+namespace conv
+namespace interactive
+open interactive
+open tactic.interactive (rw_rules)
+open tactic (rewrite_cfg)
+
+meta def erw (q : parse rw_rules) (cfg : rewrite_cfg := {md := semireducible}) : conv unit :=
+rw q cfg
+
+end interactive
+end conv
+
 namespace tactic
 namespace interactive
+open lean
 open lean.parser
 open interactive
-open interactive.types
+local postfix `?`:9001 := optional
 
 meta def old_conv (c : old_conv.interactive.itactic) : tactic unit :=
 do t ← target,
@@ -78,6 +91,16 @@ do t ← target,
 
 meta def find (p : parse lean.parser.pexpr) (c : old_conv.interactive.itactic) : tactic unit :=
 old_conv $ old_conv.interactive.find p c
+
+meta def conv_lhs (loc : parse (tk "at" *> ident)?)
+              (p : parse (tk "in" *> parser.pexpr)?)
+              (c : conv.interactive.itactic) : tactic unit :=
+conv loc p (conv.interactive.to_lhs >> c)
+
+meta def conv_rhs (loc : parse (tk "at" *> ident)?)
+              (p : parse (tk "in" *> parser.pexpr)?)
+              (c : conv.interactive.itactic) : tactic unit :=
+conv loc p (conv.interactive.to_rhs >> c)
 
 end interactive
 end tactic

--- a/tactic/ring.lean
+++ b/tactic/ring.lean
@@ -7,6 +7,7 @@ Evaluate expressions in the language of (semi-)rings.
 Based on http://www.cs.ru.nl/~freek/courses/tt-2014/read/10.1.1.61.3041.pdf .
 -/
 import algebra.group_power tactic.norm_num
+import tactic.converter.interactive
 
 namespace tactic
 namespace ring
@@ -469,3 +470,15 @@ do ns ← loc.get_locals,
 
 end interactive
 end tactic
+
+namespace conv.interactive
+open conv interactive
+open tactic tactic.interactive (ring.mode ring1)
+open tactic.ring (normalize)
+
+meta def ring (SOP : parse ring.mode) : conv unit :=
+discharge_eq_lhs ring1
+<|> replace_lhs (normalize SOP)
+<|> fail "ring failed to simplify"
+
+end conv.interactive

--- a/tactic/ring2.lean
+++ b/tactic/ring2.lean
@@ -7,6 +7,7 @@ An experimental variant on the `ring` tactic that uses computational
 reflection instead of proof generation. Useful for kernel benchmarking.
 -/
 import tactic.ring data.num.lemmas
+import tactic.converter.interactive
 
 namespace tactic.ring2
 
@@ -468,3 +469,10 @@ do `[repeat {rw ← nat.pow_eq_pow}],
 
 end interactive
 end tactic
+
+namespace conv.interactive
+open conv
+
+meta def ring2 : conv unit := discharge_eq_lhs tactic.interactive.ring2
+
+end conv.interactive

--- a/tests/tactics.lean
+++ b/tests/tactics.lean
@@ -6,6 +6,7 @@ Authors: Simon Hudon, Scott Morrison
 import tactic data.set.lattice data.prod data.vector
        tactic.rewrite data.stream.basic
        tactic.tfae tactic.converter.interactive
+       tactic.ring tactic.ring2
 
 section tauto₀
 variables p q r : Prop
@@ -227,7 +228,7 @@ begin
       change list.nil = L₃ at H,
       admit },
     case list.cons
-    { change hd :: tl = L₃ at H,
+    { change list.cons hd tl = L₃ at H,
       admit } },
   trivial
 end
@@ -664,4 +665,29 @@ end
 example : 0 = 0 + 0 :=
 begin
   conv_rhs {simp}
+end
+
+-- Example with ring discharging the goal
+example : 22 + 7 * 4 + 3 * 8 = 0 + 7 * 4 + 46 :=
+begin
+  conv { ring, },
+end
+
+-- Example with ring failing to discharge, to normalizing the goal
+example : (22 + 7 * 4 + 3 * 8 = 0 + 7 * 4 + 47) = (74 = 75) :=
+begin
+  conv { ring, },
+end
+
+-- Example with ring discharging the goal
+example (x : ℕ) : 22 + 7 * x + 3 * 8 = 0 + 7 * x + 46 :=
+begin
+  conv { ring, },
+end
+
+-- Example with ring failing to discharge, to normalizing the goal
+example (x : ℕ) : (22 + 7 * x + 3 * 8 = 0 + 7 * x + 46 + 1)
+                    = (7 * x + 46 = 7 * x + 47) :=
+begin
+  conv { ring, },
 end

--- a/tests/tactics.lean
+++ b/tests/tactics.lean
@@ -5,7 +5,7 @@ Authors: Simon Hudon, Scott Morrison
 -/
 import tactic data.set.lattice data.prod data.vector
        tactic.rewrite data.stream.basic
-       tactic.tfae
+       tactic.tfae tactic.converter.interactive
 
 section tauto₀
 variables p q r : Prop
@@ -650,3 +650,18 @@ end assoc_rw
 -- end
 
 -- end tfae
+
+example : 0 + 0 = 0 :=
+begin
+  conv_lhs {erw [add_zero]}
+end
+
+example : 0 + 0 = 0 :=
+begin
+  conv_lhs {simp}
+end
+
+example : 0 = 0 + 0 :=
+begin
+  conv_rhs {simp}
+end


### PR DESCRIPTION
We permit `ring` and `ring2` to be used inside `conv`.

To try to be convenient in order to prevent merge conflicts, this branch sits on top of #436.

<br>

TO CONTRIBUTORS:

Make sure you have:

 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
