### PR TITLE
fix(algebra/ordered_group): make instances defeq

### DIFF
--- a/algebra/ordered_group.lean
+++ b/algebra/ordered_group.lean
@@ -230,10 +230,13 @@ instance [add_comm_semigroup α] : add_comm_semigroup (with_top α) :=
 
 instance [add_monoid α] : add_monoid (with_top α) :=
 { zero := some 0,
+  add := (+),
   ..@additive.add_monoid _ $ @with_zero.monoid (multiplicative α) _ }
 
 instance [add_comm_monoid α] : add_comm_monoid (with_top α) :=
-{ ..@additive.add_comm_monoid _ $
+{ zero := 0,
+  add := (+),
+  ..@additive.add_comm_monoid _ $
     @with_zero.comm_monoid (multiplicative α) _ }
 
 instance [ordered_comm_monoid α] : ordered_comm_monoid (with_top α) :=


### PR DESCRIPTION
The following definitional equality didn't hold before this changes. Now it does.
`example : @with_bot.add_monoid ℕ _ = add_comm_monoid.to_add_monoid (with_bot ℕ) := rfl`

TO CONTRIBUTORS:

Make sure you have:

 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [x] make sure definitions and lemmas are put in the right files
 * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
