### PR TITLE
feat(tactic/tauto): add an option for `tauto` to work in classical logic

### DIFF
--- a/tactic/basic.lean
+++ b/tactic/basic.lean
@@ -461,7 +461,7 @@ meta def apply_assumption
   (asms : tactic (list expr) := local_context)
   (tac : tactic unit := skip) : tactic unit :=
 do { ctx ← asms,
-     ctx.any_of (λ H, symm_apply H >> tac) } <|> 
+     ctx.any_of (λ H, symm_apply H >> tac) } <|>
 do { exfalso,
      ctx ← asms,
      ctx.any_of (λ H, symm_apply H >> tac) }
@@ -632,5 +632,10 @@ instance : monad id :=
      let fs := list.intersperse (",\n  " : format) $ fs.map (λ fn, format!"{fn} := _"),
      let out := format.to_string format!"{{ {format.join fs} }",
      return [(out,"")] }
+
+meta def classical : tactic unit :=
+do h ← get_unused_name `_inst,
+   mk_const `classical.prop_decidable >>= note h none,
+   reset_instance_cache
 
 end tactic

--- a/tactic/interactive.lean
+++ b/tactic/interactive.lean
@@ -269,10 +269,13 @@ do asms ← mk_assumption_set no_dflt hs attr_names,
 and splits a goal of the form `_ ∧ _`, `_ ↔ _` or `∃ _, _` until it can be discharged
 using `reflexivity` or `solve_by_elim`
 -/
-meta def tautology := tactic.tautology
+meta def tautology (c : parse $ (tk "!")?) := tactic.tautology c.is_some
 
 /-- Shorter name for the tactic `tautology`. -/
-meta def tauto := tautology
+meta def tauto (c : parse $ (tk "!")?) := tautology c
+
+/-- Make every propositions in the context decidable -/
+meta def classical := tactic.classical
 
 private meta def generalize_arg_p_aux : pexpr → parser (pexpr × name)
 | (app (app (macro _ [const `eq _ ]) h) (local_const x _ _ _)) := pure (h, x)

--- a/tactic/tauto.lean
+++ b/tactic/tauto.lean
@@ -176,26 +176,27 @@ do { ctx ← local_context,
 meta def assumption_symm :=
 using_new_ref (native.rb_map.mk _ _) assumption_with
 
-meta def tautology : tactic unit :=
-using_new_ref (expr_map.mk _) $ λ r,
-do try (contradiction_with r);
-   try (assumption_with r);
-   repeat (do
-     gs ← get_goals,
-     () <$ tactic.intros;
-     distrib_not;
-     casesm (some ()) [``(_ ∧ _),``(_ ∨ _),``(Exists _),``(false)];
-     try (contradiction_with r);
-     try (target >>= match_or >> refine ``( or_iff_not_imp_left.mpr _));
-     try (target >>= match_or >> refine ``( or_iff_not_imp_right.mpr _));
-     () <$ tactic.intros;
-     constructor_matching (some ()) [``(_ ∧ _),``(_ ↔ _),``(true)];
-     try (assumption_with r),
-     gs' ← get_goals,
-     guard (gs ≠ gs') ) ;
-   repeat
-   (reflexivity <|> solve_by_elim <|>
-    constructor_matching none [``(_ ∧ _),``(_ ↔ _),``(Exists _),``(true)] ) ;
-   done
+meta def tautology (c : bool := ff) : tactic unit :=
+do when c classical,
+   using_new_ref (expr_map.mk _) $ λ r,
+   do try (contradiction_with r);
+      try (assumption_with r);
+      repeat (do
+        gs ← get_goals,
+        () <$ tactic.intros;
+        distrib_not;
+        casesm (some ()) [``(_ ∧ _),``(_ ∨ _),``(Exists _),``(false)];
+        try (contradiction_with r);
+        try (target >>= match_or >> refine ``( or_iff_not_imp_left.mpr _));
+        try (target >>= match_or >> refine ``( or_iff_not_imp_right.mpr _));
+        () <$ tactic.intros;
+        constructor_matching (some ()) [``(_ ∧ _),``(_ ↔ _),``(true)];
+        try (assumption_with r),
+        gs' ← get_goals,
+        guard (gs ≠ gs') ) ;
+      repeat
+      (reflexivity <|> solve_by_elim <|>
+       constructor_matching none [``(_ ∧ _),``(_ ↔ _),``(Exists _),``(true)] ) ;
+      done
 
 end tactic

--- a/tactic/wlog.lean
+++ b/tactic/wlog.lean
@@ -156,7 +156,7 @@ meta def wlog
   (cases : parse (tk ":=" *> texpr)?)
   (perms : parse (tk "using" *> (list_of (ident*) <|> (λx, [x]) <$> ident*))?)
   (discharger : tactic unit :=
-    (tactic.solve_by_elim <|> tauto <|> using_smt (smt_tactic.intros >> smt_tactic.solve_goals))) :
+    (tactic.solve_by_elim <|> tactic.tautology <|> using_smt (smt_tactic.intros >> smt_tactic.solve_goals))) :
   tactic unit := do
 perms ← parse_permutations perms,
 (pat, cases_pr, cases_goal, vars, perms) ← (match cases with

--- a/tests/tactics.lean
+++ b/tests/tactics.lean
@@ -53,13 +53,12 @@ example (p q : Prop) [decidable q] [decidable p] (h : ¬ (p ↔ q)) (h' : q) : �
 example (p q : Prop) [decidable q] [decidable p] (h : ¬ (p ↔ q)) (h' : ¬ q) : p := by tauto
 example (p q : Prop) [decidable q] [decidable p] (h : ¬ (p ↔ q)) (h' : ¬ q) (h'' : ¬ p) : false := by tauto
 example (p q r : Prop) [decidable q] [decidable p] (h : p ↔ q) (h' : r ↔ q) (h'' : ¬ r) : ¬ p := by tauto
-example (p q r : Prop) [decidable q] [decidable p] (h : p ↔ q) (h' : r ↔ q) : p ↔ r :=
-by tauto
-example (p q r : Prop) [decidable p] [decidable q] [decidable r] (h : ¬ p = q) (h' : r = q) : p ↔ ¬ r := by tauto
+example (p q r : Prop) (h : p ↔ q) (h' : r ↔ q) : p ↔ r :=
+by tauto!
+example (p q r : Prop) (h : ¬ p = q) (h' : r = q) : p ↔ ¬ r := by tauto!
 
 section modulo_symmetry
-variables {p q r : Prop} {α : Type} {x y : α} [decidable_eq α]
-variables [decidable p] [decidable q] [decidable r]
+variables {p q r : Prop} {α : Type} {x y : α}
 variables (h : x = y)
 variables (h'' : (p ∧ q ↔ q ∨ r) ↔ (r ∧ p ↔ r ∨ q))
 include h


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
