### PR TITLE
fix(data/real,data/rat): make orders on real and rat irreducible

### DIFF
--- a/analysis/complex.lean
+++ b/analysis/complex.lean
@@ -97,6 +97,8 @@ tendsto_of_uniform_continuous_subtype
       (continuous_abs _ $ is_open_gt' _))
     ⟨lt_add_one (abs a₁), lt_add_one (abs a₂)⟩)
 
+local attribute [semireducible] real.le
+
 lemma uniform_continuous_re : uniform_continuous re :=
 uniform_continuous_of_metric.2 (λ ε ε0, ⟨ε, ε0, λ _ _, lt_of_le_of_lt (abs_re_le_abs _)⟩)
 

--- a/data/rat.lean
+++ b/data/rat.lean
@@ -579,6 +579,8 @@ instance : ordered_comm_group ℚ                  := by apply_instance
 instance : ordered_cancel_comm_monoid ℚ          := by apply_instance
 instance : ordered_comm_monoid ℚ                 := by apply_instance
 
+attribute [irreducible] rat.le
+
 theorem num_pos_iff_pos {a : ℚ} : 0 < a.num ↔ 0 < a :=
 lt_iff_lt_of_le_iff_le $
 by simpa [(by cases a; refl : (-a).num = -a.num)]

--- a/data/real/basic.lean
+++ b/data/real/basic.lean
@@ -52,7 +52,8 @@ instance : has_lt ℝ :=
 @[simp] theorem mk_pos {f : cau_seq ℚ abs} : 0 < mk f ↔ pos f :=
 iff_of_eq (congr_arg pos (sub_zero f))
 
-instance : has_le ℝ := ⟨λ x y, x < y ∨ x = y⟩
+protected def le (x y : ℝ) : Prop := x < y ∨ x = y
+instance : has_le ℝ := ⟨real.le⟩
 
 @[simp] theorem mk_le {f g : cau_seq ℚ abs} : mk f ≤ mk g ↔ f ≤ g :=
 or_congr iff.rfl quotient.eq
@@ -627,5 +628,7 @@ by rw [mul_comm, sqrt_mul' _ hx, mul_comm]
 
 @[simp] theorem sqrt_div {x : ℝ} (hx : 0 ≤ x) (y : ℝ) : sqrt (x / y) = sqrt x / sqrt y :=
 by rw [division_def, sqrt_mul hx, sqrt_inv]; refl
+
+attribute [irreducible] real.le
 
 end real


### PR DESCRIPTION
As per a conversation on Zulip (https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/performance.20of.20.60assumption.60), the following examples are extremely slow to succeed or fail, because inequalities on `rat` and `real` get reduced.

```lean
lemma foo {x y z ε : ℝ} (a : x ≤ ε/8) (b : y ≤ ε/8) (c : z ≤ ε/4) : z ≤ ε/4 := by assumption

lemma foo {x z ε : ℚ} (a : x ≤ ε/2) (b : z ≤ ε/100) : z ≤ ε/100 := by assumption

example {x z ε : ℝ} : (x ≤ ε / 8) = (z ≤ ε / 4) := by refl

example {x z ε : ℚ} : (x ≤ ε /2) = (z ≤ ε / 100) := by refl
```

TO CONTRIBUTORS:

Make sure you have:

 * [ ] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
