### PR TITLE
feat(category_theory): propose removing coercions from category_theory/

### DIFF
--- a/category_theory/embedding.lean
+++ b/category_theory/embedding.lean
@@ -35,13 +35,13 @@ end functor
 section
 variables {F : C ⥤ D} [full F] [faithful F] {X Y : C}
 def preimage_iso (f : (F.obj X) ≅ (F.obj Y)) : X ≅ Y :=
-{ hom := F.preimage (f : F.obj X ⟶ F.obj Y),
-  inv := F.preimage (f.symm : F.obj Y ⟶ F.obj X),
+{ hom := F.preimage f.hom,
+  inv := F.preimage f.inv,
   hom_inv_id' := begin apply @faithful.injectivity _ _ _ _ F, obviously, end,
   inv_hom_id' := begin apply @faithful.injectivity _ _ _ _ F, obviously, end, }
 
-@[simp] lemma preimage_iso_coe (f : (F.obj X) ≅ (F.obj Y)) : ((preimage_iso f) : X ⟶ Y) = F.preimage (f : F.obj X ⟶ F.obj Y) := rfl
-@[simp] lemma preimage_iso_symm_coe (f : (F.obj X) ≅ (F.obj Y)) : ((preimage_iso f).symm : Y ⟶ X) = F.preimage (f.symm : F.obj Y ⟶ F.obj X) := rfl
+@[simp] lemma preimage_iso_hom (f : (F.obj X) ≅ (F.obj Y)) : (preimage_iso f).hom = F.preimage f.hom := rfl
+@[simp] lemma preimage_iso_inv (f : (F.obj X) ≅ (F.obj Y)) : (preimage_iso f).inv = F.preimage (f.inv) := rfl
 end
 
 class embedding (F : C ⥤ D) extends (full F), (faithful F).

--- a/category_theory/embedding.lean
+++ b/category_theory/embedding.lean
@@ -12,8 +12,8 @@ variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C] {D : Type u₂} [𝒟 
 include 𝒞 𝒟
 
 class full (F : C ⥤ D) :=
-(preimage : ∀ {X Y : C} (f : (F X) ⟶ (F Y)), X ⟶ Y)
-(witness'  : ∀ {X Y : C} (f : (F X) ⟶ (F Y)), F.map (preimage f) = f . obviously)
+(preimage : ∀ {X Y : C} (f : (F.obj X) ⟶ (F.obj Y)), X ⟶ Y)
+(witness'  : ∀ {X Y : C} (f : (F.obj X) ⟶ (F.obj Y)), F.map (preimage f) = f . obviously)
 
 restate_axiom full.witness'
 attribute [simp] full.witness
@@ -27,21 +27,21 @@ namespace functor
 def injectivity (F : C ⥤ D) [faithful F] {X Y : C} {f g : X ⟶ Y} (p : F.map f = F.map g) : f = g :=
 faithful.injectivity F p
 
-def preimage (F : C ⥤ D) [full F] {X Y : C} (f : F X ⟶ F Y) : X ⟶ Y := full.preimage.{u₁ v₁ u₂ v₂}  f
-@[simp] lemma image_preimage (F : C ⥤ D) [full F] {X Y : C} (f : F X ⟶ F Y) : F.map (preimage F f) = f := begin unfold preimage, obviously end
+def preimage (F : C ⥤ D) [full F] {X Y : C} (f : F.obj X ⟶ F.obj Y) : X ⟶ Y := full.preimage.{u₁ v₁ u₂ v₂}  f
+@[simp] lemma image_preimage (F : C ⥤ D) [full F] {X Y : C} (f : F.obj X ⟶ F.obj Y) : F.map (preimage F f) = f := begin unfold preimage, obviously end
 end functor
 
 
 section
 variables {F : C ⥤ D} [full F] [faithful F] {X Y : C}
-def preimage_iso (f : (F X) ≅ (F Y)) : X ≅ Y := 
-{ hom := F.preimage (f : F X ⟶ F Y),
-  inv := F.preimage (f.symm : F Y ⟶ F X),
+def preimage_iso (f : (F.obj X) ≅ (F.obj Y)) : X ≅ Y :=
+{ hom := F.preimage (f : F.obj X ⟶ F.obj Y),
+  inv := F.preimage (f.symm : F.obj Y ⟶ F.obj X),
   hom_inv_id' := begin apply @faithful.injectivity _ _ _ _ F, obviously, end,
   inv_hom_id' := begin apply @faithful.injectivity _ _ _ _ F, obviously, end, }
 
-@[simp] lemma preimage_iso_coe (f : (F X) ≅ (F Y)) : ((preimage_iso f) : X ⟶ Y) = F.preimage (f : F X ⟶ F Y) := rfl
-@[simp] lemma preimage_iso_symm_coe (f : (F X) ≅ (F Y)) : ((preimage_iso f).symm : Y ⟶ X) = F.preimage (f.symm : F Y ⟶ F X) := rfl
+@[simp] lemma preimage_iso_coe (f : (F.obj X) ≅ (F.obj Y)) : ((preimage_iso f) : X ⟶ Y) = F.preimage (f : F.obj X ⟶ F.obj Y) := rfl
+@[simp] lemma preimage_iso_symm_coe (f : (F.obj X) ≅ (F.obj Y)) : ((preimage_iso f).symm : Y ⟶ X) = F.preimage (f.symm : F.obj Y ⟶ F.obj X) := rfl
 end
 
 class embedding (F : C ⥤ D) extends (full F), (faithful F).
@@ -63,7 +63,7 @@ variables {D : Type u₂} [𝒟 : category.{u₂ v₂} D] {E : Type u₃} [ℰ :
 include 𝒟 ℰ
 variables (F : C ⥤ D) (G : D ⥤ E)
 
-instance faithful.comp [faithful F] [faithful G] : faithful (F ⋙ G) := 
+instance faithful.comp [faithful F] [faithful G] : faithful (F ⋙ G) :=
 { injectivity' := λ _ _ _ _ p, F.injectivity (G.injectivity p) }
 instance full.comp [full F] [full G] : full (F ⋙ G) :=
 { preimage := λ _ _ f, F.preimage (G.preimage f) }

--- a/category_theory/examples/topological_spaces.lean
+++ b/category_theory/examples/topological_spaces.lean
@@ -41,9 +41,9 @@ def nbhds (x : X.α) : small_category (nbhd x) := begin unfold nbhd, apply_insta
 def map
   {X Y : Top.{u}} (f : X ⟶ Y) : opens Y ⥤ opens X :=
 { obj := λ U, ⟨ f.val ⁻¹' U, f.property _ U.property ⟩,
-  map' := λ U V i, ⟨ ⟨ λ a b, i.down.down b ⟩ ⟩ }.
+  map := λ U V i, ⟨ ⟨ λ a b, i.down.down b ⟩ ⟩ }.
 
-@[simp] lemma map_id_obj (X : Top.{u}) (U : opens X) : map (𝟙 X) U = U := by tidy
+@[simp] lemma map_id_obj (X : Top.{u}) (U : opens X) : (map (𝟙 X)).obj U = U := by tidy
 
 @[simp] def map_id (X : Top.{u}) : map (𝟙 X) ≅ functor.id (opens X) :=
 { hom := { app := λ U, 𝟙 U },

--- a/category_theory/full_subcategory.lean
+++ b/category_theory/full_subcategory.lean
@@ -9,16 +9,16 @@ universes u v
 
 section
 variables {C : Type u} [𝒞 : category.{u v} C]
-include 𝒞 
+include 𝒞
 
-instance full_subcategory (Z : C → Prop) : category.{u v} {X : C // Z X} := 
+instance full_subcategory (Z : C → Prop) : category.{u v} {X : C // Z X} :=
 { hom  := λ X Y, X.1 ⟶ Y.1,
   id   := λ X, 𝟙 X.1,
   comp := λ _ _ _ f g, f ≫ g }
 
-def full_subcategory_embedding (Z : C → Prop) : {X : C // Z X} ⥤ C := 
+def full_subcategory_embedding (Z : C → Prop) : {X : C // Z X} ⥤ C :=
 { obj := λ X, X.1,
-  map' := λ _ _ f, f }
+  map := λ _ _ f, f }
 
 instance full_subcategory_full     (Z : C → Prop) : full     (full_subcategory_embedding Z) := by obviously
 instance full_subcategory_faithful (Z : C → Prop) : faithful (full_subcategory_embedding Z) := by obviously

--- a/category_theory/functor.lean
+++ b/category_theory/functor.lean
@@ -35,38 +35,18 @@ When using a `functor`, use the `map` field (which makes use of the coercion).
 -/
 structure functor (C : Type u₁) [category.{u₁ v₁} C] (D : Type u₂) [category.{u₂ v₂} D] : Type (max u₁ v₁ u₂ v₂) :=
 (obj       : C → D)
-(map'      : Π {X Y : C}, (X ⟶ Y) → ((obj X) ⟶ (obj Y)))
-(map_id'   : ∀ (X : C), map' (𝟙 X) = 𝟙 (obj X) . obviously)
-(map_comp' : ∀ {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z), map' (f ≫ g) = (map' f) ≫ (map' g) . obviously)
+(map       : Π {X Y : C}, (X ⟶ Y) → ((obj X) ⟶ (obj Y)))
+(map_id'   : ∀ (X : C), map (𝟙 X) = 𝟙 (obj X) . obviously)
+(map_comp' : ∀ {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z), map (f ≫ g) = (map f) ≫ (map g) . obviously)
 
 infixr ` ⥤ `:70 := functor       -- type as \func --
 
+restate_axiom functor.map_id'
+attribute [simp] functor.map_id
+restate_axiom functor.map_comp'
+attribute [simp] functor.map_comp
+
 namespace functor
-
-section
-variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C] {D : Type u₂} [𝒟 : category.{u₂ v₂} D]
-include 𝒞 𝒟
-
-instance : has_coe_to_fun (C ⥤ D) :=
-{ F   := λ F, C → D,
-  coe := λ F, F.obj }
-
-def map (F : C ⥤ D) {X Y : C} (f : X ⟶ Y) : (F X) ⟶ (F Y) := F.map' f
-
-@[simp] lemma map_id (F : C ⥤ D) (X : C) : F.map (𝟙 X) = 𝟙 (F X) :=
-begin unfold functor.map, erw F.map_id', refl end
-@[simp] lemma map_comp (F : C ⥤ D) {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) :
-  F.map (f ≫ g) = F.map f ≫ F.map g :=
-begin unfold functor.map, erw F.map_comp' end
-
--- We define a refl lemma 'refolding' the coercion,
--- and two lemmas for the coercion applied to an explicit structure.
-@[simp] lemma obj_eq_coe {F : C ⥤ D} (X : C) : F.obj X = F X := rfl
-@[simp] lemma mk_obj (o : C → D) (m mi mc) (X : C) :
-  ({ functor . obj := o, map' := m, map_id' := mi, map_comp' := mc } : C ⥤ D) X = o X := rfl
-@[simp] lemma mk_map (o : C → D) (m mi mc) {X Y : C} (f : X ⟶ Y) :
-  functor.map { functor . obj := o, map' := m, map_id' := mi, map_comp' := mc } f = m f := rfl
-end
 
 section
 variables (C : Type u₁) [𝒞 : category.{u₁ v₁} C]
@@ -74,12 +54,12 @@ include 𝒞
 
 /-- `functor.id C` is the identity functor on a category `C`. -/
 protected def id : C ⥤ C :=
-{ obj      := λ X, X,
-  map'     := λ _ _ f, f }
+{ obj := λ X, X,
+  map := λ _ _ f, f }
 
 variable {C}
 
-@[simp] lemma id_obj (X : C) : (functor.id C) X = X := rfl
+@[simp] lemma id_obj (X : C) : (functor.id C).obj X = X := rfl
 @[simp] lemma id_map {X Y : C} (f : X ⟶ Y) : (functor.id C).map f = f := rfl
 end
 
@@ -93,12 +73,12 @@ include 𝒞 𝒟 ℰ
 `F ⋙ G` is the composition of a functor `F` and a functor `G` (`F` first, then `G`).
 -/
 def comp (F : C ⥤ D) (G : D ⥤ E) : C ⥤ E :=
-{ obj      := λ X, G (F X),
-  map'      := λ _ _ f, G.map (F.map f) }
+{ obj := λ X, G.obj (F.obj X),
+  map := λ _ _ f, G.map (F.map f) }
 
 infixr ` ⋙ `:80 := comp
 
-@[simp] lemma comp_obj (F : C ⥤ D) (G : D ⥤ E) (X : C) : (F ⋙ G) X = G (F X) := rfl
+@[simp] lemma comp_obj (F : C ⥤ D) (G : D ⥤ E) (X : C) : (F ⋙ G).obj X = G.obj (F.obj X) := rfl
 @[simp] lemma comp_map (F : C ⥤ D) (G : D ⥤ E) (X Y : C) (f : X ⟶ Y) :
   (F ⋙ G).map f = G.map (F.map f) := rfl
 end
@@ -109,11 +89,11 @@ include 𝒞
 
 @[simp] def ulift_down : (ulift.{u₂} C) ⥤ C :=
 { obj := λ X, X.down,
-  map' := λ X Y f, f }
+  map := λ X Y f, f }
 
 @[simp] def ulift_up : C ⥤ (ulift.{u₂} C) :=
 { obj := λ X, ⟨ X ⟩,
-  map' := λ X Y f, f }
+  map := λ X Y f, f }
 end
 
 end functor
@@ -127,6 +107,6 @@ def concrete_functor
   (m : ∀{α}, C α → D α) (h : ∀{α β} {ia : C α} {ib : C β} {f}, hC ia ib f → hD (m ia) (m ib) f) :
   bundled C ⥤ bundled D :=
 { obj := bundled.map @m,
-  map' := λ X Y f, ⟨ f, h f.2 ⟩}
+  map := λ X Y f, ⟨ f, h f.2 ⟩}
 
 end category_theory

--- a/category_theory/functor.lean
+++ b/category_theory/functor.lean
@@ -11,7 +11,6 @@ by the underlying function on objects, the name is capitalised.)
 Introduces notations
   `C ⥤ D` for the type of all functors from `C` to `D`.
     (I would like a better arrow here, unfortunately ⇒ (`\functor`) is taken by core.)
-  `F X` (a coercion) for a functor `F` acting on an object `X`.
 -/
 
 import category_theory.category
@@ -24,14 +23,10 @@ universes u v u₁ v₁ u₂ v₂ u₃ v₃
 /--
 `functor C D` represents a functor between categories `C` and `D`.
 
-To apply a functor `F` to an object use `F X` (which uses a coercion), and to a morphism use `F.map f`.
+To apply a functor `F` to an object use `F.obj X`, and to a morphism use `F.map f`.
 
 The axiom `map_id_lemma` expresses preservation of identities, and
 `map_comp_lemma` expresses functoriality.
-
-Implementation note: when constructing a `functor`, you need to define the
-`map'` field (which does not know about the coercion).
-When using a `functor`, use the `map` field (which makes use of the coercion).
 -/
 structure functor (C : Type u₁) [category.{u₁ v₁} C] (D : Type u₂) [category.{u₂ v₂} D] : Type (max u₁ v₁ u₂ v₂) :=
 (obj       : C → D)

--- a/category_theory/functor_category.lean
+++ b/category_theory/functor_category.lean
@@ -16,7 +16,7 @@ open nat_trans
 Notice that if `C` and `D` are both small categories at the same universe level, this is another small category at that level.
 However if `C` and `D` are both large categories at the same universe level, this is a small category at the next higher level.
 -/
-instance functor.category (C : Type u₁) [category.{u₁ v₁} C] (D : Type u₂) [category.{u₂ v₂} D] : 
+instance functor.category (C : Type u₁) [category.{u₁ v₁} C] (D : Type u₂) [category.{u₂ v₂} D] :
   category.{(max u₁ v₁ u₂ v₂) (max u₁ v₂)} (C ⥤ D) :=
 { hom     := λ F G, F ⟹ G,
   id      := λ F, nat_trans.id F,
@@ -28,25 +28,25 @@ section
 variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C] {D : Type u₂} [𝒟 : category.{u₂ v₂} D]
 include 𝒞 𝒟
 
-@[simp] lemma id_app (F : C ⥤ D) (X : C) : (𝟙 F : F ⟹ F) X = 𝟙 (F X) := rfl
-@[simp] lemma comp_app {F G H : C ⥤ D} (α : F ⟶ G) (β : G ⟶ H) (X : C) : 
-  ((α ≫ β) : F ⟹ H) X = (α : F ⟹ G) X ≫ (β : G ⟹ H) X := rfl
+@[simp] lemma id_app (F : C ⥤ D) (X : C) : (𝟙 F : F ⟹ F).app X = 𝟙 (F.obj X) := rfl
+@[simp] lemma comp_app {F G H : C ⥤ D} (α : F ⟶ G) (β : G ⟶ H) (X : C) :
+  ((α ≫ β) : F ⟹ H).app X = (α : F ⟹ G).app X ≫ (β : G ⟹ H).app X := rfl
 end
 
 namespace nat_trans
 -- This section gives two lemmas about natural transformations between functors into functor categories,
 -- spelling them out in components.
 
-variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C] 
-          {D : Type u₂} [𝒟 : category.{u₂ v₂} D] 
+variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C]
+          {D : Type u₂} [𝒟 : category.{u₂ v₂} D]
           {E : Type u₃} [ℰ : category.{u₃ v₃} E]
 include 𝒞 𝒟 ℰ
 
-lemma app_naturality {F G : C ⥤ (D ⥤ E)} (T : F ⟹ G) (X : C) {Y Z : D} (f : Y ⟶ Z) : 
-  ((F X).map f) ≫ ((T X) Z) = ((T X) Y) ≫ ((G X).map f) := (T X).naturality f
+lemma app_naturality {F G : C ⥤ (D ⥤ E)} (T : F ⟹ G) (X : C) {Y Z : D} (f : Y ⟶ Z) :
+  ((F.obj X).map f) ≫ ((T.app X).app Z) = ((T.app X).app Y) ≫ ((G.obj X).map f) := (T.app X).naturality f
 
-lemma naturality_app {F G : C ⥤ (D ⥤ E)} (T : F ⟹ G) (Z : D) {X Y : C} (f : X ⟶ Y) : 
-  ((F.map f) Z) ≫ ((T Y) Z) = ((T X) Z) ≫ ((G.map f) Z) := congr_fun (congr_arg app (T.naturality f)) Z
+lemma naturality_app {F G : C ⥤ (D ⥤ E)} (T : F ⟹ G) (Z : D) {X Y : C} (f : X ⟶ Y) :
+  ((F.map f).app Z) ≫ ((T.app Y).app Z) = ((T.app X).app Z) ≫ ((G.map f).app Z) := congr_fun (congr_arg app (T.naturality f)) Z
 
 end nat_trans
 

--- a/category_theory/isomorphism.lean
+++ b/category_theory/isomorphism.lean
@@ -14,7 +14,9 @@ structure iso {C : Type u} [category.{u v} C] (X Y : C) :=
 (hom_inv_id' : hom ≫ inv = 𝟙 X . obviously)
 (inv_hom_id' : inv ≫ hom = 𝟙 Y . obviously)
 
--- We restate the hom_inv_id' and inv_hom_id' lemmas below.
+restate_axiom iso.hom_inv_id'
+restate_axiom iso.inv_hom_id'
+attribute [simp] iso.hom_inv_id iso.inv_hom_id
 
 infixr ` ≅ `:10  := iso             -- type as \cong or \iso
 
@@ -23,9 +25,6 @@ include 𝒞
 variables {X Y Z : C}
 
 namespace iso
-
-instance : has_coe (iso.{u v} X Y) (X ⟶ Y) :=
-{ coe := iso.hom }
 
 @[extensionality] lemma ext
   (α β : X ≅ Y)
@@ -49,36 +48,29 @@ instance : has_coe (iso.{u v} X Y) (X ⟶ Y) :=
   hom_inv_id' := I.inv_hom_id',
   inv_hom_id' := I.hom_inv_id' }
 
--- These are the restated lemmas for iso.hom_inv_id' and iso.inv_hom_id'
-@[simp] lemma hom_inv_id (α : X ≅ Y) : (α : X ⟶ Y) ≫ (α.symm : Y ⟶ X) = 𝟙 X :=
-begin unfold_coes, unfold symm, have p := α.hom_inv_id', dsimp at p, rw p end
-@[simp] lemma inv_hom_id (α : X ≅ Y) : (α.symm : Y ⟶ X) ≫ (α : X ⟶ Y) = 𝟙 Y :=
-begin unfold_coes, unfold symm, have p := iso.inv_hom_id', dsimp at p, rw p end
-
--- We rewrite the projections `.hom` and `.inv` into coercions.
-@[simp] lemma hom_eq_coe (α : X ≅ Y) : α.hom = (α : X ⟶ Y) := rfl
-@[simp] lemma inv_eq_coe (α : X ≅ Y) : α.inv = (α.symm : Y ⟶ X) := rfl
+@[simp] lemma symm_hom (α : X ≅ Y) : α.symm.hom = α.inv := rfl
+@[simp] lemma symm_inv (α : X ≅ Y) : α.symm.inv = α.hom := rfl
 
 @[refl] def refl (X : C) : X ≅ X :=
 { hom := 𝟙 X,
   inv := 𝟙 X }
 
-@[simp] lemma refl_coe (X : C) : ((iso.refl X) : X ⟶ X) = 𝟙 X := rfl
-@[simp] lemma refl_symm_coe  (X : C) : ((iso.refl X).symm : X ⟶ X)  = 𝟙 X := rfl
+@[simp] lemma refl_hom (X : C) : (iso.refl X).hom = 𝟙 X := rfl
+@[simp] lemma refl_inv (X : C) : (iso.refl X).inv = 𝟙 X := rfl
 
 @[trans] def trans (α : X ≅ Y) (β : Y ≅ Z) : X ≅ Z :=
-{ hom := (α : X ⟶ Y) ≫ (β : Y ⟶ Z),
-  inv := (β.symm : Z ⟶ Y) ≫ (α.symm : Y ⟶ X),
+{ hom := α.hom ≫ β.hom,
+  inv := β.inv ≫ α.inv,
   hom_inv_id' := begin /- `obviously'` says: -/ rw [category.assoc], conv { to_lhs, congr, skip, rw ← category.assoc }, rw iso.hom_inv_id, rw category.id_comp, rw iso.hom_inv_id end,
   inv_hom_id' := begin /- `obviously'` says: -/ rw [category.assoc], conv { to_lhs, congr, skip, rw ← category.assoc }, rw iso.inv_hom_id, rw category.id_comp, rw iso.inv_hom_id end }
 
 infixr ` ≪≫ `:80 := iso.trans -- type as `\ll \gg`.
 
-@[simp] lemma trans_coe (α : X ≅ Y) (β : Y ≅ Z) : ((α ≪≫ β) : X ⟶ Z) = (α : X ⟶ Y) ≫ (β : Y ⟶ Z) := rfl
-@[simp] lemma trans_symm_coe (α : X ≅ Y) (β : Y ≅ Z) : ((α ≪≫ β).symm : Z ⟶ X)  = (β.symm : Z ⟶ Y) ≫ (α.symm : Y ⟶ X) := rfl
+@[simp] lemma trans_hom (α : X ≅ Y) (β : Y ≅ Z) : (α ≪≫ β).hom = α.hom ≫ β.hom := rfl
+@[simp] lemma trans_inv (α : X ≅ Y) (β : Y ≅ Z) : (α ≪≫ β).inv = β.inv ≫ α.inv := rfl
 
-@[simp] lemma refl_symm (X : C) : ((iso.refl X).symm : X ⟶ X)  = 𝟙 X := rfl
-@[simp] lemma trans_symm (α : X ≅ Y) (β : Y ≅ Z) : ((α ≪≫ β).symm : Z ⟶ X) = (β.symm : Z ⟶ Y) ≫ (α.symm : Y ⟶ X) := rfl
+@[simp] lemma refl_symm (X : C) : (iso.refl X).hom = 𝟙 X := rfl
+@[simp] lemma trans_symm (α : X ≅ Y) (β : Y ≅ Z) : (α ≪≫ β).inv = β.inv ≫ α.inv := rfl
 
 end iso
 
@@ -108,10 +100,10 @@ is_iso.inv_hom_id' f
 instance (X : C) : is_iso (𝟙 X) :=
 { inv := 𝟙 X }
 
-instance of_iso         (f : X ≅ Y) : is_iso (f : X ⟶ Y) :=
-{ inv := (f.symm : Y ⟶ X) }
-instance of_iso_inverse (f : X ≅ Y) : is_iso (f.symm : Y ⟶ X)  :=
-{ inv := (f : X ⟶ Y) }
+instance of_iso (f : X ≅ Y) : is_iso f.hom :=
+{ inv := f.inv }
+instance of_iso_inverse (f : X ≅ Y) : is_iso f.inv :=
+{ inv := f.hom }
 
 end is_iso
 
@@ -129,8 +121,8 @@ def on_iso (F : C ⥤ D) {X Y : C} (i : X ≅ Y) : (F.obj X) ≅ (F.obj Y) :=
   hom_inv_id' := by erw [←map_comp, iso.hom_inv_id, ←map_id],
   inv_hom_id' := by erw [←map_comp, iso.inv_hom_id, ←map_id] }
 
-@[simp] lemma on_iso_hom (F : C ⥤ D) {X Y : C} (i : X ≅ Y) : ((F.on_iso i) : F.obj X ⟶ F.obj Y) = F.map (i : X ⟶ Y) := rfl
-@[simp] lemma on_iso_inv (F : C ⥤ D) {X Y : C} (i : X ≅ Y) : ((F.on_iso i).symm : F.obj Y ⟶ F.obj X) = F.map (i.symm : Y ⟶ X) := rfl
+@[simp] lemma on_iso_hom (F : C ⥤ D) {X Y : C} (i : X ≅ Y) : (F.on_iso i).hom = F.map i.hom := rfl
+@[simp] lemma on_iso_inv (F : C ⥤ D) {X Y : C} (i : X ≅ Y) : (F.on_iso i).inv = F.map i.inv := rfl
 
 instance (F : C ⥤ D) (f : X ⟶ Y) [is_iso f] : is_iso (F.map f) :=
 { inv := F.map (inv f),

--- a/category_theory/isomorphism.lean
+++ b/category_theory/isomorphism.lean
@@ -69,8 +69,8 @@ begin unfold_coes, unfold symm, have p := iso.inv_hom_id', dsimp at p, rw p end
 @[trans] def trans (α : X ≅ Y) (β : Y ≅ Z) : X ≅ Z :=
 { hom := (α : X ⟶ Y) ≫ (β : Y ⟶ Z),
   inv := (β.symm : Z ⟶ Y) ≫ (α.symm : Y ⟶ X),
-  hom_inv_id' := begin /- `obviously'` says: -/ erw [category.assoc], conv { to_lhs, congr, skip, rw ← category.assoc }, rw iso.hom_inv_id, rw category.id_comp, rw iso.hom_inv_id end,
-  inv_hom_id' := begin /- `obviously'` says: -/ erw [category.assoc], conv { to_lhs, congr, skip, rw ← category.assoc }, rw iso.inv_hom_id, rw category.id_comp, rw iso.inv_hom_id end }
+  hom_inv_id' := begin /- `obviously'` says: -/ rw [category.assoc], conv { to_lhs, congr, skip, rw ← category.assoc }, rw iso.hom_inv_id, rw category.id_comp, rw iso.hom_inv_id end,
+  inv_hom_id' := begin /- `obviously'` says: -/ rw [category.assoc], conv { to_lhs, congr, skip, rw ← category.assoc }, rw iso.inv_hom_id, rw category.id_comp, rw iso.inv_hom_id end }
 
 infixr ` ≪≫ `:80 := iso.trans -- type as `\ll \gg`.
 
@@ -134,8 +134,8 @@ def on_iso (F : C ⥤ D) {X Y : C} (i : X ≅ Y) : (F.obj X) ≅ (F.obj Y) :=
 
 instance (F : C ⥤ D) (f : X ⟶ Y) [is_iso f] : is_iso (F.map f) :=
 { inv := F.map (inv f),
-  hom_inv_id' := begin rw ← F.map_comp, erw is_iso.hom_inv_id, rw map_id, end,
-  inv_hom_id' := begin rw ← F.map_comp, erw is_iso.inv_hom_id, rw map_id, end }
+  hom_inv_id' := begin rw ← F.map_comp, rw is_iso.hom_inv_id, rw map_id, end,
+  inv_hom_id' := begin rw ← F.map_comp, rw is_iso.inv_hom_id, rw map_id, end }
 
 end functor
 
@@ -145,14 +145,14 @@ instance epi_of_iso  (f : X ⟶ Y) [is_iso f] : epi f  :=
                          intros,
                          rw [←category.id_comp C g, ←category.id_comp C h],
                          rw [← is_iso.inv_hom_id f],
-                         erw [category.assoc, w, category.assoc],
+                         rw [category.assoc, w, category.assoc],
                        end }
 instance mono_of_iso (f : X ⟶ Y) [is_iso f] : mono f :=
 { right_cancellation := begin
                          intros,
                          rw [←category.comp_id C g, ←category.comp_id C h],
                          rw [← is_iso.hom_inv_id f],
-                         erw [←category.assoc, w, ←category.assoc]
+                         rw [←category.assoc, w, ←category.assoc]
                        end }
 
 def eq_to_iso {X Y : C} (p : X = Y) : X ≅ Y := by rw p

--- a/category_theory/isomorphism.lean
+++ b/category_theory/isomorphism.lean
@@ -123,14 +123,14 @@ variables {D : Type u₂}
 variables [𝒟 : category.{u₂ v₂} D]
 include 𝒟
 
-def on_iso (F : C ⥤ D) {X Y : C} (i : X ≅ Y) : (F X) ≅ (F Y) :=
+def on_iso (F : C ⥤ D) {X Y : C} (i : X ≅ Y) : (F.obj X) ≅ (F.obj Y) :=
 { hom := F.map i.hom,
   inv := F.map i.inv,
   hom_inv_id' := by erw [←map_comp, iso.hom_inv_id, ←map_id],
   inv_hom_id' := by erw [←map_comp, iso.inv_hom_id, ←map_id] }
 
-@[simp] lemma on_iso_hom (F : C ⥤ D) {X Y : C} (i : X ≅ Y) : ((F.on_iso i) : F X ⟶ F Y) = F.map (i : X ⟶ Y) := rfl
-@[simp] lemma on_iso_inv (F : C ⥤ D) {X Y : C} (i : X ≅ Y) : ((F.on_iso i).symm : F Y ⟶ F X) = F.map (i.symm : Y ⟶ X) := rfl
+@[simp] lemma on_iso_hom (F : C ⥤ D) {X Y : C} (i : X ≅ Y) : ((F.on_iso i) : F.obj X ⟶ F.obj Y) = F.map (i : X ⟶ Y) := rfl
+@[simp] lemma on_iso_inv (F : C ⥤ D) {X Y : C} (i : X ≅ Y) : ((F.on_iso i).symm : F.obj Y ⟶ F.obj X) = F.map (i.symm : Y ⟶ X) := rfl
 
 instance (F : C ⥤ D) (f : X ⟶ Y) [is_iso f] : is_iso (F.map f) :=
 { inv := F.map (inv f),

--- a/category_theory/natural_isomorphism.lean
+++ b/category_theory/natural_isomorphism.lean
@@ -15,57 +15,42 @@ variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C] {D : Type u₂} [𝒟 
 include 𝒞 𝒟
 
 def app {F G : C ⥤ D} (α : F ≅ G) (X : C) : F.obj X ≅ G.obj X :=
-{ hom := (α : F ⟶ G).app X,
-  inv := (α.symm : G ⟶ F).app X,
+{ hom := α.hom.app X,
+  inv := α.inv.app X,
   hom_inv_id' := begin rw [← functor.category.comp_app, iso.hom_inv_id], refl, end,
   inv_hom_id' := begin rw [← functor.category.comp_app, iso.inv_hom_id], refl, end }
 
--- TODO remove this too
-instance {F G : C ⥤ D} : has_coe_to_fun (F ≅ G) :=
-{ F   := λ α, Π X : C, (F.obj X) ≅ (G.obj X),
-  coe := λ α, app α }
-
-@[simp] lemma mk_app {F G : C ⥤ D} (hom : F ⟹ G) (inv) (hom_inv_id') (inv_hom_id') (X : C) :
-  ({ hom := hom, inv := inv, hom_inv_id' := hom_inv_id', inv_hom_id' := inv_hom_id' } : F ≅ G) X =
-  { hom := hom.app X, inv := inv.app X,
-    hom_inv_id' := congr_fun (congr_arg nat_trans.app hom_inv_id') X,
-    inv_hom_id' := congr_fun (congr_arg nat_trans.app inv_hom_id') X } :=
-rfl
-@[simp] lemma mk_app' {F G : C ⥤ D} (hom : F ⟹ G) (inv) (hom_inv_id') (inv_hom_id') (X : C) :
-  (({ hom := hom, inv := inv, hom_inv_id' := hom_inv_id', inv_hom_id' := inv_hom_id' } : F ≅ G) : F ⟹ G).app X = hom.app X :=
-rfl
-
 @[simp] lemma comp_app {F G H : C ⥤ D} (α : F ≅ G) (β : G ≅ H) (X : C) :
-  ((α ≪≫ β) : F ⟹ H).app X = α X ≪≫ β X := rfl
+  app (α ≪≫ β) X = app α X ≪≫ app β X := rfl
 
-@[simp] lemma hom_eq_coe {F G : C ⥤ D} (α : F ≅ G) (X : C) : α.hom.app X = (α : F ⟶ G).app X := rfl
-@[simp] lemma inv_eq_symm_coe {F G : C ⥤ D} (α : F ≅ G) (X : C) : α.inv.app X = (α.symm : G ⟶ F).app X := rfl
+@[simp] lemma app_hom {F G : C ⥤ D} (α : F ≅ G) (X : C) : (app α X).hom = α.hom.app X := rfl
+@[simp] lemma app_inv {F G : C ⥤ D} (α : F ≅ G) (X : C) : (app α X).inv = α.inv.app X := rfl
 
 variables {F G : C ⥤ D}
 
-instance hom_app_is_iso (α : F ≅ G) (X : C) : is_iso ((α : F ⟶ G).app X) :=
+instance hom_app_is_iso (α : F ≅ G) (X : C) : is_iso (α.hom.app X) :=
 { inv := α.inv.app X,
-  hom_inv_id' := begin dsimp at *, rw [←functor.category.comp_app, iso.hom_inv_id, ←functor.category.id_app] end,
-  inv_hom_id' := begin dsimp at *, rw [←functor.category.comp_app, iso.inv_hom_id, ←functor.category.id_app] end }
-instance inv_app_is_iso (α : F ≅ G) (X : C) : is_iso ((α.symm : G ⟶ F).app X) :=
+  hom_inv_id' := begin rw [←functor.category.comp_app, iso.hom_inv_id, ←functor.category.id_app] end,
+  inv_hom_id' := begin rw [←functor.category.comp_app, iso.inv_hom_id, ←functor.category.id_app] end }
+instance inv_app_is_iso (α : F ≅ G) (X : C) : is_iso (α.inv.app X) :=
 { inv := α.hom.app X,
-  hom_inv_id' := begin dsimp at *, erw [is_iso.hom_inv_id] end,
-  inv_hom_id' := begin dsimp at *, erw [is_iso.hom_inv_id] end }
+  hom_inv_id' := begin rw [←functor.category.comp_app, iso.inv_hom_id, ←functor.category.id_app] end,
+  inv_hom_id' := begin rw [←functor.category.comp_app, iso.hom_inv_id, ←functor.category.id_app] end }
 
 variables {X Y : C}
 @[simp] lemma naturality_1 (α : F ≅ G) (f : X ⟶ Y) :
-  ((α.symm : G ⟶ F).app X) ≫ (F.map f) ≫ ((α : F ⟶ G).app Y) = G.map f :=
+  (α.inv.app X) ≫ (F.map f) ≫ (α.hom.app Y) = G.map f :=
 begin erw [nat_trans.naturality, ←category.assoc, is_iso.hom_inv_id, category.id_comp] end
 @[simp] lemma naturality_2 (α : F ≅ G) (f : X ⟶ Y) :
-  ((α : F ⟶ G).app X) ≫ (G.map f) ≫ ((α.symm : G ⟶ F).app Y) = F.map f :=
+  (α.hom.app X) ≫ (G.map f) ≫ (α.inv.app Y) = F.map f :=
 begin erw [nat_trans.naturality, ←category.assoc, is_iso.hom_inv_id, category.id_comp] end
 
 def of_components (app : ∀ X : C, (F.obj X) ≅ (G.obj X))
-  (naturality : ∀ {X Y : C} (f : X ⟶ Y), (F.map f) ≫ ((app Y) : F.obj Y ⟶ G.obj Y) = ((app X) : F.obj X ⟶ G.obj X) ≫ (G.map f)) :
+  (naturality : ∀ {X Y : C} (f : X ⟶ Y), (F.map f) ≫ ((app Y).hom) = ((app X).hom) ≫ (G.map f)) :
   F ≅ G :=
-{ hom  := { app := λ X, ((app X) : F.obj X ⟶ G.obj X), },
+{ hom  := { app := λ X, ((app X).hom), },
   inv  :=
-  { app := λ X, ((app X).symm : G.obj X ⟶ F.obj X),
+  { app := λ X, ((app X).inv),
     naturality' := λ X Y f,
     begin
       let p := congr_arg (λ f, (app X).inv ≫ (f ≫ (app Y).inv)) (eq.symm (naturality f)),
@@ -78,9 +63,9 @@ def of_components (app : ∀ X : C, (F.obj X) ≅ (G.obj X))
   app (of_components app' naturality) X = app' X :=
 by tidy
 @[simp] def of_components.hom_app (app : ∀ X : C, (F.obj X) ≅ (G.obj X)) (naturality) (X) :
-  ((of_components app naturality) : F ⟹ G).app X = app X := rfl
+  (of_components app naturality).hom.app X = (app X).hom := rfl
 @[simp] def of_components.inv_app (app : ∀ X : C, (F.obj X) ≅ (G.obj X)) (naturality) (X) :
-  ((of_components app naturality).symm : G ⟹ F).app X = (app X).symm := rfl
+  (of_components app naturality).inv.app X = (app X).inv := rfl
 
 end category_theory.nat_iso
 
@@ -94,17 +79,11 @@ variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C]
 include 𝒞 𝒟
 
 @[simp] def id_comp (F : C ⥤ D) : functor.id C ⋙ F ≅ F :=
-{ hom :=
-  { app := λ X, 𝟙 (F.obj X) },
-  inv :=
-  { app := λ X, 𝟙 (F.obj X) }
-}
+{ hom := { app := λ X, 𝟙 (F.obj X) },
+  inv := { app := λ X, 𝟙 (F.obj X) } }
 @[simp] def comp_id (F : C ⥤ D) : F ⋙ functor.id D ≅ F :=
-{ hom :=
-  { app := λ X, 𝟙 (F.obj X) },
-  inv :=
-  { app := λ X, 𝟙 (F.obj X) }
-}
+{ hom := { app := λ X, 𝟙 (F.obj X) },
+  inv := { app := λ X, 𝟙 (F.obj X) } }
 
 universes u₃ v₃ u₄ v₄
 
@@ -114,11 +93,8 @@ include 𝒜 ℬ
 variables (F : A ⥤ B) (G : B ⥤ C) (H : C ⥤ D)
 
 @[simp] def assoc : (F ⋙ G) ⋙ H ≅ F ⋙ (G ⋙ H ):=
-{ hom :=
-  { app := λ X, 𝟙 (H.obj (G.obj (F.obj X))) },
-  inv :=
-  { app := λ X, 𝟙 (H.obj (G.obj (F.obj X))) }
-}
+{ hom := { app := λ X, 𝟙 (H.obj (G.obj (F.obj X))) },
+  inv := { app := λ X, 𝟙 (H.obj (G.obj (F.obj X))) } }
 
 -- When it's time to define monoidal categories and 2-categories,
 -- we'll need to add lemmas relating these natural isomorphisms,

--- a/category_theory/natural_isomorphism.lean
+++ b/category_theory/natural_isomorphism.lean
@@ -45,8 +45,8 @@ variables {F G : C ⥤ D}
 
 instance hom_app_is_iso (α : F ≅ G) (X : C) : is_iso ((α : F ⟶ G).app X) :=
 { inv := α.inv.app X,
-  hom_inv_id' := begin dsimp at *, erw [←functor.category.comp_app, iso.hom_inv_id, ←functor.category.id_app] end,
-  inv_hom_id' := begin dsimp at *, erw [←functor.category.comp_app, iso.inv_hom_id, ←functor.category.id_app] end }
+  hom_inv_id' := begin dsimp at *, rw [←functor.category.comp_app, iso.hom_inv_id, ←functor.category.id_app] end,
+  inv_hom_id' := begin dsimp at *, rw [←functor.category.comp_app, iso.inv_hom_id, ←functor.category.id_app] end }
 instance inv_app_is_iso (α : F ≅ G) (X : C) : is_iso ((α.symm : G ⟶ F).app X) :=
 { inv := α.hom.app X,
   hom_inv_id' := begin dsimp at *, erw [is_iso.hom_inv_id] end,

--- a/category_theory/natural_isomorphism.lean
+++ b/category_theory/natural_isomorphism.lean
@@ -14,72 +14,73 @@ universes u₁ u₂ v₁ v₂
 variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C] {D : Type u₂} [𝒟 : category.{u₂ v₂} D]
 include 𝒞 𝒟
 
-def app {F G : C ⥤ D} (α : F ≅ G) (X : C) : F X ≅ G X :=
-{ hom := (α : F ⟶ G) X,
-  inv := (α.symm : G ⟶ F) X,
+def app {F G : C ⥤ D} (α : F ≅ G) (X : C) : F.obj X ≅ G.obj X :=
+{ hom := (α : F ⟶ G).app X,
+  inv := (α.symm : G ⟶ F).app X,
   hom_inv_id' := begin rw [← functor.category.comp_app, iso.hom_inv_id], refl, end,
   inv_hom_id' := begin rw [← functor.category.comp_app, iso.inv_hom_id], refl, end }
 
+-- TODO remove this too
 instance {F G : C ⥤ D} : has_coe_to_fun (F ≅ G) :=
-{ F   := λ α, Π X : C, (F X) ≅ (G X),
+{ F   := λ α, Π X : C, (F.obj X) ≅ (G.obj X),
   coe := λ α, app α }
 
 @[simp] lemma mk_app {F G : C ⥤ D} (hom : F ⟹ G) (inv) (hom_inv_id') (inv_hom_id') (X : C) :
-  ({ hom := hom, inv := inv, hom_inv_id' := hom_inv_id', inv_hom_id' := inv_hom_id' } : F ≅ G) X = 
-  { hom := hom X, inv := inv X, 
+  ({ hom := hom, inv := inv, hom_inv_id' := hom_inv_id', inv_hom_id' := inv_hom_id' } : F ≅ G) X =
+  { hom := hom.app X, inv := inv.app X,
     hom_inv_id' := congr_fun (congr_arg nat_trans.app hom_inv_id') X,
     inv_hom_id' := congr_fun (congr_arg nat_trans.app inv_hom_id') X } :=
 rfl
 @[simp] lemma mk_app' {F G : C ⥤ D} (hom : F ⟹ G) (inv) (hom_inv_id') (inv_hom_id') (X : C) :
-  (({ hom := hom, inv := inv, hom_inv_id' := hom_inv_id', inv_hom_id' := inv_hom_id' } : F ≅ G) : F ⟹ G) X = hom X := 
+  (({ hom := hom, inv := inv, hom_inv_id' := hom_inv_id', inv_hom_id' := inv_hom_id' } : F ≅ G) : F ⟹ G).app X = hom.app X :=
 rfl
 
-@[simp] lemma comp_app {F G H : C ⥤ D} (α : F ≅ G) (β : G ≅ H) (X : C) : 
-  ((α ≪≫ β) : F ⟹ H) X = α X ≪≫ β X := rfl
+@[simp] lemma comp_app {F G H : C ⥤ D} (α : F ≅ G) (β : G ≅ H) (X : C) :
+  ((α ≪≫ β) : F ⟹ H).app X = α X ≪≫ β X := rfl
 
-@[simp] lemma hom_eq_coe {F G : C ⥤ D} (α : F ≅ G) (X : C) : α.hom X = (α : F ⟶ G) X := rfl
-@[simp] lemma inv_eq_symm_coe {F G : C ⥤ D} (α : F ≅ G) (X : C) : α.inv X = (α.symm : G ⟶ F) X := rfl
+@[simp] lemma hom_eq_coe {F G : C ⥤ D} (α : F ≅ G) (X : C) : α.hom.app X = (α : F ⟶ G).app X := rfl
+@[simp] lemma inv_eq_symm_coe {F G : C ⥤ D} (α : F ≅ G) (X : C) : α.inv.app X = (α.symm : G ⟶ F).app X := rfl
 
-variables {F G : C ⥤ D} 
+variables {F G : C ⥤ D}
 
-instance hom_app_is_iso (α : F ≅ G) (X : C) : is_iso ((α : F ⟶ G) X) := 
-{ inv := α.inv X,
+instance hom_app_is_iso (α : F ≅ G) (X : C) : is_iso ((α : F ⟶ G).app X) :=
+{ inv := α.inv.app X,
   hom_inv_id' := begin dsimp at *, erw [←functor.category.comp_app, iso.hom_inv_id, ←functor.category.id_app] end,
   inv_hom_id' := begin dsimp at *, erw [←functor.category.comp_app, iso.inv_hom_id, ←functor.category.id_app] end }
-instance inv_app_is_iso (α : F ≅ G) (X : C) : is_iso ((α.symm : G ⟶ F) X) := 
-{ inv := α.hom X,
+instance inv_app_is_iso (α : F ≅ G) (X : C) : is_iso ((α.symm : G ⟶ F).app X) :=
+{ inv := α.hom.app X,
   hom_inv_id' := begin dsimp at *, erw [is_iso.hom_inv_id] end,
   inv_hom_id' := begin dsimp at *, erw [is_iso.hom_inv_id] end }
 
 variables {X Y : C}
-@[simp] lemma naturality_1 (α : F ≅ G) (f : X ⟶ Y) : 
-  ((α.symm : G ⟶ F) X) ≫ (F.map f) ≫ ((α : F ⟶ G) Y) = G.map f :=
+@[simp] lemma naturality_1 (α : F ≅ G) (f : X ⟶ Y) :
+  ((α.symm : G ⟶ F).app X) ≫ (F.map f) ≫ ((α : F ⟶ G).app Y) = G.map f :=
 begin erw [nat_trans.naturality, ←category.assoc, is_iso.hom_inv_id, category.id_comp] end
-@[simp] lemma naturality_2 (α : F ≅ G) (f : X ⟶ Y) : 
-  ((α : F ⟶ G) X) ≫ (G.map f) ≫ ((α.symm : G ⟶ F) Y) = F.map f :=
+@[simp] lemma naturality_2 (α : F ≅ G) (f : X ⟶ Y) :
+  ((α : F ⟶ G).app X) ≫ (G.map f) ≫ ((α.symm : G ⟶ F).app Y) = F.map f :=
 begin erw [nat_trans.naturality, ←category.assoc, is_iso.hom_inv_id, category.id_comp] end
 
-def of_components (app : ∀ X : C, (F X) ≅ (G X))
-  (naturality : ∀ {X Y : C} (f : X ⟶ Y), (F.map f) ≫ ((app Y) : F Y ⟶ G Y) = ((app X) : F X ⟶ G X) ≫ (G.map f)) : 
+def of_components (app : ∀ X : C, (F.obj X) ≅ (G.obj X))
+  (naturality : ∀ {X Y : C} (f : X ⟶ Y), (F.map f) ≫ ((app Y) : F.obj Y ⟶ G.obj Y) = ((app X) : F.obj X ⟶ G.obj X) ≫ (G.map f)) :
   F ≅ G :=
-{ hom  := { app := λ X, ((app X) : F X ⟶ G X), },
-  inv  := 
-  { app := λ X, ((app X).symm : G X ⟶ F X),
-    naturality' := λ X Y f, 
-    begin 
+{ hom  := { app := λ X, ((app X) : F.obj X ⟶ G.obj X), },
+  inv  :=
+  { app := λ X, ((app X).symm : G.obj X ⟶ F.obj X),
+    naturality' := λ X Y f,
+    begin
       let p := congr_arg (λ f, (app X).inv ≫ (f ≫ (app Y).inv)) (eq.symm (naturality f)),
-      dsimp at *, 
-      simp at *, 
+      dsimp at *,
+      simp at *,
       erw [←p, ←category.assoc, is_iso.hom_inv_id, category.id_comp],
     end } }.
 
-@[simp] def of_components.app (app' : ∀ X : C, (F X) ≅ (G X)) (naturality) (X) : 
+@[simp] def of_components.app (app' : ∀ X : C, (F.obj X) ≅ (G.obj X)) (naturality) (X) :
   app (of_components app' naturality) X = app' X :=
 by tidy
-@[simp] def of_components.hom_app (app : ∀ X : C, (F X) ≅ (G X)) (naturality) (X) : 
-  ((of_components app naturality) : F ⟹ G) X = app X := rfl
-@[simp] def of_components.inv_app (app : ∀ X : C, (F X) ≅ (G X)) (naturality) (X) : 
-  ((of_components app naturality).symm : G ⟹ F) X = (app X).symm := rfl
+@[simp] def of_components.hom_app (app : ∀ X : C, (F.obj X) ≅ (G.obj X)) (naturality) (X) :
+  ((of_components app naturality) : F ⟹ G).app X = app X := rfl
+@[simp] def of_components.inv_app (app : ∀ X : C, (F.obj X) ≅ (G.obj X)) (naturality) (X) :
+  ((of_components app naturality).symm : G ⟹ F).app X = (app X).symm := rfl
 
 end category_theory.nat_iso
 
@@ -88,35 +89,35 @@ namespace category_theory.functor
 universes u₁ u₂ v₁ v₂
 
 section
-variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C] 
-          {D : Type u₂} [𝒟 : category.{u₂ v₂} D] 
+variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C]
+          {D : Type u₂} [𝒟 : category.{u₂ v₂} D]
 include 𝒞 𝒟
 
-@[simp] def id_comp (F : C ⥤ D) : functor.id C ⋙ F ≅ F := 
+@[simp] def id_comp (F : C ⥤ D) : functor.id C ⋙ F ≅ F :=
 { hom :=
-  { app := λ X, 𝟙 (F X) },
+  { app := λ X, 𝟙 (F.obj X) },
   inv :=
-  { app := λ X, 𝟙 (F X) }
+  { app := λ X, 𝟙 (F.obj X) }
 }
-@[simp] def comp_id (F : C ⥤ D) : F ⋙ functor.id D ≅ F := 
+@[simp] def comp_id (F : C ⥤ D) : F ⋙ functor.id D ≅ F :=
 { hom :=
-  { app := λ X, 𝟙 (F X) },
+  { app := λ X, 𝟙 (F.obj X) },
   inv :=
-  { app := λ X, 𝟙 (F X) }
+  { app := λ X, 𝟙 (F.obj X) }
 }
 
-universes u₃ v₃ u₄ v₄ 
+universes u₃ v₃ u₄ v₄
 
-variables {A : Type u₃} [𝒜 : category.{u₃ v₃} A] 
-          {B : Type u₄} [ℬ : category.{u₄ v₄} B] 
+variables {A : Type u₃} [𝒜 : category.{u₃ v₃} A]
+          {B : Type u₄} [ℬ : category.{u₄ v₄} B]
 include 𝒜 ℬ
 variables (F : A ⥤ B) (G : B ⥤ C) (H : C ⥤ D)
 
-@[simp] def assoc : (F ⋙ G) ⋙ H ≅ F ⋙ (G ⋙ H ):= 
+@[simp] def assoc : (F ⋙ G) ⋙ H ≅ F ⋙ (G ⋙ H ):=
 { hom :=
-  { app := λ X, 𝟙 (H (G (F X))) },
+  { app := λ X, 𝟙 (H.obj (G.obj (F.obj X))) },
   inv :=
-  { app := λ X, 𝟙 (H (G (F X))) }
+  { app := λ X, 𝟙 (H.obj (G.obj (F.obj X))) }
 }
 
 -- When it's time to define monoidal categories and 2-categories,
@@ -125,7 +126,7 @@ variables (F : A ⥤ B) (G : B ⥤ C) (H : C ⥤ D)
 end
 
 section
-variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C] 
+variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C]
 include 𝒞
 
 def ulift_down_up : ulift_down.{u₁ v₁ u₂} C ⋙ ulift_up C ≅ functor.id (ulift.{u₂} C) :=

--- a/category_theory/natural_transformation.lean
+++ b/category_theory/natural_transformation.lean
@@ -30,33 +30,20 @@ coercion available so you can write `α X` for the component of a transformation
 Naturality is expressed by `α.naturality_lemma`.
 -/
 structure nat_trans (F G : C ⥤ D) : Type (max u₁ v₂) :=
-(app : Π X : C, (F X) ⟶ (G X))
+(app : Π X : C, (F.obj X) ⟶ (G.obj X))
 (naturality' : ∀ {X Y : C} (f : X ⟶ Y), (F.map f) ≫ (app Y) = (app X) ≫ (G.map f) . obviously)
 
 infixr ` ⟹ `:50  := nat_trans             -- type as \==> or ⟹
 
+restate_axiom nat_trans.naturality'
+
 namespace nat_trans
-
-instance {F G : C ⥤ D} : has_coe_to_fun (F ⟹ G) :=
-{ F   := λ α, Π X : C, (F X) ⟶ (G X),
-  coe := λ α, α.app }
-
-@[simp] lemma app_eq_coe {F G : C ⥤ D} (α : F ⟹ G) (X : C) : α.app X = α X := by unfold_coes
-@[simp] lemma mk_app {F G : C ⥤ D} (app : Π X : C, (F X) ⟶ (G X)) (naturality) (X : C) : 
-  { nat_trans . app := app, naturality' := naturality } X = app X := rfl 
-
-lemma naturality {F G : C ⥤ D} (α : F ⟹ G) {X Y : C} (f : X ⟶ Y) : 
-  (F.map f) ≫ (α Y) = (α X) ≫ (G.map f) := 
-begin 
-  /- `obviously'` says: -/ 
-  erw nat_trans.naturality', refl
-end
 
 /-- `nat_trans.id F` is the identity natural transformation on a functor `F`. -/
 protected def id (F : C ⥤ D) : F ⟹ F :=
-{ app := λ X, 𝟙 (F X) }
+{ app := λ X, 𝟙 (F.obj X) }
 
-@[simp] lemma id_app (F : C ⥤ D) (X : C) : (nat_trans.id F) X = 𝟙 (F X) := rfl
+@[simp] lemma id_app (F : C ⥤ D) (X : C) : (nat_trans.id F).app X = 𝟙 (F.obj X) := rfl
 
 open category
 open category_theory.functor
@@ -65,7 +52,7 @@ section
 variables {F G H I : C ⥤ D}
 
 -- We'll want to be able to prove that two natural transformations are equal if they are componentwise equal.
-@[extensionality] lemma ext (α β : F ⟹ G) (w : ∀ X : C, α X = β X) : α = β :=
+@[extensionality] lemma ext (α β : F ⟹ G) (w : ∀ X : C, α.app X = β.app X) : α = β :=
 begin
   induction α with α_components α_naturality,
   induction β with β_components β_naturality,
@@ -75,12 +62,12 @@ end
 
 /-- `vcomp α β` is the vertical compositions of natural transformations. -/
 def vcomp (α : F ⟹ G) (β : G ⟹ H) : F ⟹ H :=
-{ app         := λ X, (α X) ≫ (β X),
+{ app         := λ X, (α.app X) ≫ (β.app X),
   naturality' := begin /- `obviously'` says: -/ intros, simp, rw [←assoc, naturality, assoc, ←naturality], end }
 
 notation α `⊟` β:80 := vcomp α β
 
-@[simp] lemma vcomp_app (α : F ⟹ G) (β : G ⟹ H) (X : C) : (α ⊟ β) X = (α X) ≫ (β X) := rfl
+@[simp] lemma vcomp_app (α : F ⟹ G) (β : G ⟹ H) (X : C) : (α ⊟ β).app X = (α.app X) ≫ (β.app X) := rfl
 @[simp] lemma vcomp_assoc (α : F ⟹ G) (β : G ⟹ H) (γ : H ⟹ I) : (α ⊟ β) ⊟ γ = (α ⊟ (β ⊟ γ)) := by tidy
 end
 
@@ -89,7 +76,7 @@ include ℰ
 
 /-- `hcomp α β` is the horizontal composition of natural transformations. -/
 def hcomp {F G : C ⥤ D} {H I : D ⥤ E} (α : F ⟹ G) (β : H ⟹ I) : (F ⋙ H) ⟹ (G ⋙ I) :=
-{ app         := λ X : C, (β (F X)) ≫ (I.map (α X)),
+{ app         := λ X : C, (β.app (F.obj X)) ≫ (I.map (α.app X)),
   naturality' := begin
                    /- `obviously'` says: -/
                    intros,
@@ -102,12 +89,12 @@ def hcomp {F G : C ⥤ D} {H I : D ⥤ E} (α : F ⟹ G) (β : H ⟹ I) : (F ⋙
 
 notation α `◫` β:80 := hcomp α β
 
-@[simp] lemma hcomp_app {F G : C ⥤ D} {H I : D ⥤ E} (α : F ⟹ G) (β : H ⟹ I) (X : C) : 
-  (α ◫ β) X = (β (F X)) ≫ (I.map (α X)) := rfl
+@[simp] lemma hcomp_app {F G : C ⥤ D} {H I : D ⥤ E} (α : F ⟹ G) (β : H ⟹ I) (X : C) :
+  (α ◫ β).app X = (β.app (F.obj X)) ≫ (I.map (α.app X)) := rfl
 
 -- Note that we don't yet prove a `hcomp_assoc` lemma here: even stating it is painful, because we need to use associativity of functor composition
 
-lemma exchange {F G H : C ⥤ D} {I J K : D ⥤ E} (α : F ⟹ G) (β : G ⟹ H) (γ : I ⟹ J) (δ : J ⟹ K) : 
+lemma exchange {F G H : C ⥤ D} {I J K : D ⥤ E} (α : F ⟹ G) (β : G ⟹ H) (γ : I ⟹ J) (δ : J ⟹ K) :
   ((α ⊟ β) ◫ (γ ⊟ δ)) = ((α ◫ γ) ⊟ (β ◫ δ)) :=
 begin
   -- `obviously'` says:

--- a/category_theory/natural_transformation.lean
+++ b/category_theory/natural_transformation.lean
@@ -7,7 +7,7 @@ Defines natural transformations between functors.
 
 Introduces notations
   `F ⟹ G` for the type of natural transformations between functors `F` and `G`,
-  `τ X` (a coercion) for the components of natural transformations,
+  `τ.app X` for the components of natural transformations,
   `σ ⊟ τ` for vertical compositions, and
   `σ ◫ τ` for horizontal compositions.
 -/
@@ -24,8 +24,7 @@ include 𝒞 𝒟
 /--
 `nat_trans F G` represents a natural transformation between functors `F` and `G`.
 
-The field `app` provides the components of the natural transformation, and there is a
-coercion available so you can write `α X` for the component of a transformation `α` at an object `X`.
+The field `app` provides the components of the natural transformation.
 
 Naturality is expressed by `α.naturality_lemma`.
 -/

--- a/category_theory/opposites.lean
+++ b/category_theory/opposites.lean
@@ -16,10 +16,10 @@ notation C `ᵒᵖ` := op C
 variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C]
 include 𝒞
 
-instance opposite : category.{u₁ v₁} (Cᵒᵖ) := 
-{ hom     := λ X Y : C, Y ⟶ X,
-  comp    := λ _ _ _ f g, g ≫ f,
-  id      := λ X, 𝟙 X }
+instance opposite : category.{u₁ v₁} (Cᵒᵖ) :=
+{ hom  := λ X Y : C, Y ⟶ X,
+  comp := λ _ _ _ f g, g ≫ f,
+  id   := λ X, 𝟙 X }
 
 namespace functor
 
@@ -27,26 +27,26 @@ section
 variables {D : Type u₂} [𝒟 : category.{u₂ v₂} D]
 include 𝒟
 
-protected definition op (F : C ⥤ D) : (Cᵒᵖ) ⥤ (Dᵒᵖ) := 
-{ obj       := λ X, F X,
-  map'      := λ X Y f, F.map f,
+protected definition op (F : C ⥤ D) : (Cᵒᵖ) ⥤ (Dᵒᵖ) :=
+{ obj       := λ X, F.obj X,
+  map       := λ X Y f, F.map f,
   map_id'   := begin /- `obviously'` says: -/ intros, erw [map_id], refl, end,
   map_comp' := begin /- `obviously'` says: -/ intros, erw [map_comp], refl end }
 
-@[simp] lemma opposite_obj (F : C ⥤ D) (X : C) : (F.op) X = F X := rfl
+@[simp] lemma opposite_obj (F : C ⥤ D) (X : C) : (F.op).obj X = F.obj X := rfl
 @[simp] lemma opposite_map (F : C ⥤ D) {X Y : C} (f : X ⟶ Y) : (F.op).map f = F.map f := rfl
 end
 
 variable (C)
 
 /-- `functor.hom` is the hom-pairing, sending (X,Y) to X → Y, contravariant in X and covariant in Y. -/
-definition hom : (Cᵒᵖ × C) ⥤ (Type v₁) := 
+definition hom : (Cᵒᵖ × C) ⥤ (Type v₁) :=
 { obj       := λ p, @category.hom C _ p.1 p.2,
-  map'      := λ X Y f, λ h, f.1 ≫ h ≫ f.2,
+  map       := λ X Y f, λ h, f.1 ≫ h ≫ f.2,
   map_id'   := begin /- `obviously'` says: -/ intros, ext, intros, cases X, dsimp at *, simp, erw [category.id_comp] end,
   map_comp' := begin /- `obviously'` says: -/ intros, ext, intros, cases f, cases g, cases X, cases Y, cases Z, dsimp at *, simp, erw [category.assoc] end }
 
-@[simp] lemma hom_obj (X : Cᵒᵖ × C) : (functor.hom C) X = @category.hom C _ X.1 X.2 := rfl
+@[simp] lemma hom_obj (X : Cᵒᵖ × C) : (functor.hom C).obj X = @category.hom C _ X.1 X.2 := rfl
 @[simp] lemma hom_pairing_map {X Y : Cᵒᵖ × C} (f : X ⟶ Y) : (functor.hom C).map f = λ h, f.1 ≫ h ≫ f.2 := rfl
 
 end functor

--- a/category_theory/products.lean
+++ b/category_theory/products.lean
@@ -29,7 +29,7 @@ end
 
 section
 variables (C : Type u₁) [𝒞 : category.{u₁ v₁} C] (D : Type u₁) [𝒟 : category.{u₁ v₁} D]
-include 𝒞 𝒟 
+include 𝒞 𝒟
 /--
 `prod.category.uniform C D` is an additional instance specialised so both factors have the same universe levels. This helps typeclass resolution.
 -/
@@ -44,47 +44,49 @@ include 𝒞 𝒟
 
 /-- `inl C Z` is the functor `X ↦ (X, Z)`. -/
 def inl (Z : D) : C ⥤ (C × D) :=
-{ obj      := λ X, (X, Z),
-  map'     := λ X Y f, (f, 𝟙 Z) }
+{ obj := λ X, (X, Z),
+  map := λ X Y f, (f, 𝟙 Z) }
 
 /-- `inr D Z` is the functor `X ↦ (Z, X)`. -/
 def inr (Z : C) : D ⥤ (C × D) :=
-{ obj      := λ X, (Z, X),
-  map'     := λ X Y f, (𝟙 Z, f) }
+{ obj := λ X, (Z, X),
+  map := λ X Y f, (𝟙 Z, f) }
 
 /-- `fst` is the functor `(X, Y) ↦ X`. -/
 def fst : (C × D) ⥤ C :=
-{ obj      := λ X, X.1,
-  map'     := λ X Y f, f.1 }
+{ obj := λ X, X.1,
+  map := λ X Y f, f.1 }
 
 /-- `snd` is the functor `(X, Y) ↦ Y`. -/
 def snd : (C × D) ⥤ D :=
-{ obj      := λ X, X.2,
-  map'     := λ X Y f, f.2 }
+{ obj := λ X, X.2,
+  map := λ X Y f, f.2 }
 
 def swap : (C × D) ⥤ (D × C) :=
 { obj := λ X, (X.2, X.1),
-  map' := λ _ _ f, (f.2, f.1) }
+  map := λ _ _ f, (f.2, f.1) }
 
 def symmetry : ((swap C D) ⋙ (swap D C)) ≅ (functor.id (C × D)) :=
-{ hom := { app := λ X, 𝟙 X, 
-           naturality' := begin intros, erw [category.comp_id (C × D), category.id_comp (C × D)], dsimp [swap], simp, end },
-  inv := { app := λ X, 𝟙 X, 
-           naturality' := begin intros, erw [category.comp_id (C × D), category.id_comp (C × D)], dsimp [swap], simp, end } }
+{ hom :=
+  { app := λ X, 𝟙 X,
+    naturality' := begin intros, erw [category.comp_id (C × D), category.id_comp (C × D)], dsimp [swap], simp, end },
+  inv :=
+  { app := λ X, 𝟙 X,
+    naturality' := begin intros, erw [category.comp_id (C × D), category.id_comp (C × D)], dsimp [swap], simp, end } }
 
 end prod
 
 section
 variables (C : Type u₁) [𝒞 : category.{u₁ v₁} C] (D : Type u₂) [𝒟 : category.{u₂ v₂} D]
-include 𝒞 𝒟 
+include 𝒞 𝒟
 
 -- TODO, later this can be defined by uncurrying `functor.id (C ⥤ D)`
-def evaluation : ((C ⥤ D) × C) ⥤ D := 
-{ obj := λ p, p.1 p.2,
-  map' := λ x y f, (x.1.map f.2) ≫ (f.1 y.2),
-  map_comp' := begin 
-                 intros X Y Z f g, cases g, cases f, cases Z, cases Y, cases X, dsimp at *, simp at *, 
-                 erw [←nat_trans.vcomp_app, nat_trans.naturality, category.assoc, nat_trans.naturality] 
+def evaluation : ((C ⥤ D) × C) ⥤ D :=
+{ obj := λ p, p.1.obj p.2,
+  map := λ x y f, (x.1.map f.2) ≫ (f.1.app y.2),
+  map_comp' := begin
+                 intros X Y Z f g, cases g, cases f, cases Z, cases Y, cases X, dsimp at *, simp at *,
+                 erw [←nat_trans.vcomp_app, nat_trans.naturality, category.assoc, nat_trans.naturality]
                end }
 end
 
@@ -94,26 +96,27 @@ include 𝒜 ℬ 𝒞 𝒟
 namespace functor
 /-- The cartesian product of two functors. -/
 def prod (F : A ⥤ B) (G : C ⥤ D) : (A × C) ⥤ (B × D) :=
-{ obj  := λ X, (F X.1, G X.2),
-  map' := λ _ _ f, (F.map f.1, G.map f.2) }
-  
-/- Because of limitations in Lean 3's handling of notations, we do not setup a notation `F × G`. 
+{ obj := λ X, (F.obj X.1, G.obj X.2),
+  map := λ _ _ f, (F.map f.1, G.map f.2) }
+
+/- Because of limitations in Lean 3's handling of notations, we do not setup a notation `F × G`.
    You can use `F.prod G` as a "poor man's infix", or just write `functor.prod F G`. -/
 
-@[simp] lemma prod_obj  (F : A ⥤ B) (G : C ⥤ D) (a : A) (c : C) : (F.prod G) (a, c) = (F a, G c) := rfl
-@[simp] lemma prod_map  (F : A ⥤ B) (G : C ⥤ D) {a a' : A} {c c' : C} (f : (a, c) ⟶ (a', c')) : (F.prod G).map f = (F.map f.1, G.map f.2) := rfl
+@[simp] lemma prod_obj (F : A ⥤ B) (G : C ⥤ D) (a : A) (c : C) : (F.prod G).obj (a, c) = (F.obj a, G.obj c) := rfl
+@[simp] lemma prod_map (F : A ⥤ B) (G : C ⥤ D) {a a' : A} {c c' : C} (f : (a, c) ⟶ (a', c')) : (F.prod G).map f = (F.map f.1, G.map f.2) := rfl
 end functor
 
 namespace nat_trans
 
 /-- The cartesian product of two natural transformations. -/
 def prod {F G : A ⥤ B} {H I : C ⥤ D} (α : F ⟹ G) (β : H ⟹ I) : F.prod H ⟹ G.prod I :=
-{ app         := λ X, (α X.1, β X.2),
+{ app         := λ X, (α.app X.1, β.app X.2),
   naturality' := begin /- `obviously'` says: -/ intros, cases f, cases Y, cases X, dsimp at *, simp, split, rw naturality, rw naturality end }
 
 /- Again, it is inadvisable in Lean 3 to setup a notation `α × β`; use instead `α.prod β` or `nat_trans.prod α β`. -/
 
-@[simp] lemma prod_app  {F G : A ⥤ B} {H I : C ⥤ D} (α : F ⟹ G) (β : H ⟹ I) (a : A) (c : C) : (nat_trans.prod α β) (a, c) = (α a, β c) := rfl
+@[simp] lemma prod_app  {F G : A ⥤ B} {H I : C ⥤ D} (α : F ⟹ G) (β : H ⟹ I) (a : A) (c : C) :
+  (nat_trans.prod α β).app (a, c) = (α.app a, β.app c) := rfl
 end nat_trans
 
 end category_theory

--- a/category_theory/types.lean
+++ b/category_theory/types.lean
@@ -25,33 +25,33 @@ variables {C : Type u} [𝒞 : category.{u v} C] (F G H : C ⥤ (Type w)) {X Y Z
 include 𝒞
 variables (σ : F ⟹ G) (τ : G ⟹ H)
 
-@[simp] lemma map_comp (f : X ⟶ Y) (g : Y ⟶ Z) (a : F X) : (F.map (f ≫ g)) a = (F.map g) ((F.map f) a) :=
+@[simp] lemma map_comp (f : X ⟶ Y) (g : Y ⟶ Z) (a : F.obj X) : (F.map (f ≫ g)) a = (F.map g) ((F.map f) a) :=
 by simp
 
-@[simp] lemma map_id (a : F X) : (F.map (𝟙 X)) a = a :=
+@[simp] lemma map_id (a : F.obj X) : (F.map (𝟙 X)) a = a :=
 by simp
 
-lemma naturality (f : X ⟶ Y) (x : F X) : σ Y ((F.map f) x) = (G.map f) (σ X x) :=
+lemma naturality (f : X ⟶ Y) (x : F.obj X) : σ.app Y ((F.map f) x) = (G.map f) (σ.app X x) :=
 congr_fun (σ.naturality f) x
 
-@[simp] lemma vcomp (x : F X) : (σ ⊟ τ) X x = τ X (σ X x) := rfl
+@[simp] lemma vcomp (x : F.obj X) : (σ ⊟ τ).app X x = τ.app X (σ.app X x) := rfl
 
 variables {D : Type u'} [𝒟 : category.{u' v'} D] (I J : D ⥤ C) (ρ : I ⟹ J) {W : D}
 
-@[simp] lemma hcomp (x : (I ⋙ F) W) : (ρ ◫ σ) W x = (G.map (ρ W)) (σ (I W) x) := rfl
+@[simp] lemma hcomp (x : (I ⋙ F).obj W) : (ρ ◫ σ).app W x = (G.map (ρ.app W)) (σ.app (I.obj W) x) := rfl
 
 end functor_to_types
 
 def ulift_functor : (Type u) ⥤ (Type (max u v)) :=
-{ obj      := λ X, ulift.{v} X,
-  map'     := λ X Y f, λ x : ulift.{v} X, ulift.up (f x.down) }
+{ obj := λ X, ulift.{v} X,
+  map := λ X Y f, λ x : ulift.{v} X, ulift.up (f x.down) }
 
 section forget
 variables (C : Type u → Type v) {hom : ∀α β, C α → C β → (α → β) → Prop} [i : concrete_category hom]
 include i
 
 /-- The forgetful functor from a bundled category to `Type`. -/
-def forget : bundled C ⥤ Type u := { obj := bundled.α, map' := λa b h, h.1 }
+def forget : bundled C ⥤ Type u := { obj := bundled.α, map := λa b h, h.1 }
 
 instance forget.faithful : faithful (forget C) := {}
 

--- a/category_theory/types.lean
+++ b/category_theory/types.lean
@@ -17,9 +17,6 @@ instance types : large_category (Type u) :=
 @[simp] lemma types_id {α : Type u} (a : α) : (𝟙 α : α → α) a = a := rfl
 @[simp] lemma types_comp {α β γ : Type u} (f : α → β) (g : β → γ) (a : α) : (((f : α ⟶ β) ≫ (g : β ⟶ γ)) : α ⟶ γ) a = g (f a) := rfl
 
-@[simp] lemma types.iso_mk_coe (α β : Type u) (f : α → β) (g : β → α) (hom_inv_id) (inv_hom_id) (a : α) :
-(({ iso . hom := f, inv := g, hom_inv_id' := hom_inv_id, inv_hom_id' := inv_hom_id } : α ≅ β) : α ⟶ β) a = f a := rfl
-
 namespace functor_to_types
 variables {C : Type u} [𝒞 : category.{u v} C] (F G H : C ⥤ (Type w)) {X Y Z : C}
 include 𝒞

--- a/category_theory/whiskering.lean
+++ b/category_theory/whiskering.lean
@@ -8,62 +8,62 @@ namespace category_theory
 
 universes u₁ v₁ u₂ v₂ u₃ v₃ u₄ v₄
 
-variables (C : Type u₁) [𝒞 : category.{u₁ v₁} C] 
-          (D : Type u₂) [𝒟 : category.{u₂ v₂} D] 
+variables (C : Type u₁) [𝒞 : category.{u₁ v₁} C]
+          (D : Type u₂) [𝒟 : category.{u₂ v₂} D]
           (E : Type u₃) [ℰ : category.{u₃ v₃} E]
 include 𝒞 𝒟 ℰ
 
-def whiskering_left : (C ⥤ D) ⥤ ((D ⥤ E) ⥤ (C ⥤ E)) := 
+def whiskering_left : (C ⥤ D) ⥤ ((D ⥤ E) ⥤ (C ⥤ E)) :=
 { obj := λ F,
   { obj := λ G, F ⋙ G,
-    map' := λ G H α,
-    { app := λ c, α (F c),
+    map := λ G H α,
+    { app := λ c, α.app (F.obj c),
       naturality' := by intros X Y f; rw [functor.comp_map, functor.comp_map, α.naturality] } },
-  map' := λ F G τ, 
+  map := λ F G τ,
   { app := λ H,
-    { app := λ c, H.map (τ c), 
+    { app := λ c, H.map (τ.app c),
       naturality' := begin intros X Y f, dsimp at *, rw [←H.map_comp, ←H.map_comp, ←τ.naturality] end },
     naturality' := begin intros X Y f, ext1, dsimp at *, rw [←nat_trans.naturality] end } }
 
 def whiskering_right : (D ⥤ E) ⥤ ((C ⥤ D) ⥤ (C ⥤ E)) :=
 { obj := λ H,
   { obj := λ F, F ⋙ H,
-    map' := λ _ _ α,
-    { app := λ c, H.map (α c),
+    map := λ _ _ α,
+    { app := λ c, H.map (α.app c),
       naturality' := by intros X Y f;
         rw [functor.comp_map, functor.comp_map, ←H.map_comp, ←H.map_comp, α.naturality] } },
-  map' := λ G H τ, 
-  { app := λ F, 
-    { app := λ c, τ (F c),
+  map := λ G H τ,
+  { app := λ F,
+    { app := λ c, τ.app (F.obj c),
       naturality' := begin intros X Y f, dsimp at *, rw [τ.naturality] end },
     naturality' := begin intros X Y f, ext1, dsimp at *, rw [←nat_trans.naturality] end } }
 
 variables {C} {D} {E}
 
 def whisker_left (F : C ⥤ D) {G H : D ⥤ E} (α : G ⟹ H) : (F ⋙ G) ⟹ (F ⋙ H) :=
-((whiskering_left C D E) F).map α
+((whiskering_left C D E).obj F).map α
 
-@[simp] lemma whisker_left.app (F : C ⥤ D) {G H : D ⥤ E} (α : G ⟹ H) (X : C) : 
-  (whisker_left F α) X = α (F X) := 
+@[simp] lemma whisker_left.app (F : C ⥤ D) {G H : D ⥤ E} (α : G ⟹ H) (X : C) :
+  (whisker_left F α).app X = α.app (F.obj X) :=
 rfl
 
-def whisker_right {G H : C ⥤ D} (α : G ⟹ H) (F : D ⥤ E) : (G ⋙ F) ⟹ (H ⋙ F) := 
-((whiskering_right C D E) F).map α
+def whisker_right {G H : C ⥤ D} (α : G ⟹ H) (F : D ⥤ E) : (G ⋙ F) ⟹ (H ⋙ F) :=
+((whiskering_right C D E).obj F).map α
 
 @[simp] lemma whisker_right.app {G H : C ⥤ D} (α : G ⟹ H) (F : D ⥤ E) (X : C) :
-   (whisker_right α F) X = F.map (α X) := 
+   (whisker_right α F).app X = F.map (α.app X) :=
 rfl
 
-@[simp] lemma whisker_left_vcomp (F : C ⥤ D) {G H K : D ⥤ E} (α : G ⟹ H) (β : H ⟹ K) : 
+@[simp] lemma whisker_left_vcomp (F : C ⥤ D) {G H K : D ⥤ E} (α : G ⟹ H) (β : H ⟹ K) :
   whisker_left F (α ⊟ β) = ((whisker_left F α) ⊟ (whisker_left F β)) :=
-((whiskering_left C D E) F).map_comp α β
+((whiskering_left C D E).obj F).map_comp α β
 
-@[simp] lemma whisker_right_vcomp {G H K : C ⥤ D} (α : G ⟹ H) (β : H ⟹ K) (F : D ⥤ E)  : 
+@[simp] lemma whisker_right_vcomp {G H K : C ⥤ D} (α : G ⟹ H) (β : H ⟹ K) (F : D ⥤ E)  :
   whisker_right (α ⊟ β) F = ((whisker_right α F) ⊟ (whisker_right β F)) :=
-((whiskering_right C D E) F).map_comp α β
+((whiskering_right C D E).obj F).map_comp α β
 
 variables {B : Type u₄} [ℬ : category.{u₄ v₄} B]
-include ℬ 
+include ℬ
 
 local attribute [elab_simple] whisker_left whisker_right
 

--- a/category_theory/yoneda.lean
+++ b/category_theory/yoneda.lean
@@ -4,7 +4,7 @@
 
 /- The Yoneda embedding, as a functor `yoneda : C ⥤ ((Cᵒᵖ) ⥤ (Type v₁))`,
    along with instances that it is `full` and `faithful`.
-   
+
    Also the Yoneda lemma, `yoneda_lemma : (yoneda_pairing C) ≅ (yoneda_evaluation C)`. -/
 
 import category_theory.natural_transformation
@@ -20,33 +20,33 @@ universes u₁ v₁ u₂
 variables (C : Type u₁) [𝒞 : category.{u₁ v₁} C]
 include 𝒞
 
-def yoneda : C ⥤ ((Cᵒᵖ) ⥤ (Type v₁)) := 
+def yoneda : C ⥤ ((Cᵒᵖ) ⥤ (Type v₁)) :=
 { obj := λ X,
   { obj := λ Y : C, Y ⟶ X,
-    map' := λ Y Y' f g, f ≫ g,
+    map := λ Y Y' f g, f ≫ g,
     map_comp' := begin intros X_1 Y Z f g, ext1, dsimp at *, erw [category.assoc] end,
     map_id' := begin intros X_1, ext1, dsimp at *, erw [category.id_comp] end },
-  map' := λ X X' f, { app := λ Y g, g ≫ f } }
+  map := λ X X' f, { app := λ Y g, g ≫ f } }
 
 namespace yoneda
-@[simp] lemma obj_obj (X Y : C) : ((yoneda C) X) Y = (Y ⟶ X) := rfl
-@[simp] lemma obj_map (X : C) {Y Y' : C} (f : Y ⟶ Y') : ((yoneda C) X).map f = λ g, f ≫ g := rfl
-@[simp] lemma map_app {X X' : C} (f : X ⟶ X') (Y : C) : ((yoneda C).map f) Y = λ g, g ≫ f := rfl
+@[simp] lemma obj_obj (X Y : C) : ((yoneda C).obj X).obj Y = (Y ⟶ X) := rfl
+@[simp] lemma obj_map (X : C) {Y Y' : C} (f : Y ⟶ Y') : ((yoneda C).obj X).map f = λ g, f ≫ g := rfl
+@[simp] lemma map_app {X X' : C} (f : X ⟶ X') (Y : C) : ((yoneda C).map f).app Y = λ g, g ≫ f := rfl
 
-lemma obj_map_id {X Y : Cᵒᵖ} (f : X ⟶ Y) : ((yoneda C) X).map f (𝟙 X) = ((yoneda C).map f) Y (𝟙 Y) := 
+lemma obj_map_id {X Y : Cᵒᵖ} (f : X ⟶ Y) : ((yoneda C).obj X).map f (𝟙 X) = ((yoneda C).map f).app Y (𝟙 Y) :=
 by obviously
 
-@[simp] lemma naturality {X Y : C} (α : (yoneda C) X ⟶ (yoneda C) Y) 
-  {Z Z' : C} (f : Z ⟶ Z') (h : Z' ⟶ X) : f ≫ α Z' h = α Z (f ≫ h) :=
+@[simp] lemma naturality {X Y : C} (α : (yoneda C).obj X ⟶ (yoneda C).obj Y)
+  {Z Z' : C} (f : Z ⟶ Z') (h : Z' ⟶ X) : f ≫ α.app Z' h = α.app Z (f ≫ h) :=
 begin erw [functor_to_types.naturality], refl end
 
-instance full : full (yoneda C) := 
-{ preimage := λ X Y f, (f X) (𝟙 X) }.
+instance full : full (yoneda C) :=
+{ preimage := λ X Y f, (f.app X) (𝟙 X) }.
 
-instance faithful : faithful (yoneda C) := 
+instance faithful : faithful (yoneda C) :=
 begin
-  fsplit, 
-  intros X Y f g p, 
+  fsplit,
+  intros X Y f g p,
   injection p with h,
   convert (congr_fun (congr_fun h X) (𝟙 X)) ; simp
 end
@@ -61,51 +61,51 @@ functions are inverses and natural in `Z`.
 -/
 def ext (X Y : C)
   (p : Π {Z : C}, (Z ⟶ X) → (Z ⟶ Y)) (q : Π {Z : C}, (Z ⟶ Y) → (Z ⟶ X))
-  (h₁ : Π {Z : C} (f : Z ⟶ X), q (p f) = f) (h₂ : Π {Z : C} (f : Z ⟶ Y), p (q f) = f) 
-  (n : Π {Z Z' : C} (f : Z' ⟶ Z) (g : Z ⟶ X), p (f ≫ g) = f ≫ p g) : X ≅ Y := 
-@preimage_iso _ _ _ _ (yoneda C) _ _ _ _ 
+  (h₁ : Π {Z : C} (f : Z ⟶ X), q (p f) = f) (h₂ : Π {Z : C} (f : Z ⟶ Y), p (q f) = f)
+  (n : Π {Z Z' : C} (f : Z' ⟶ Z) (g : Z ⟶ X), p (f ≫ g) = f ≫ p g) : X ≅ Y :=
+@preimage_iso _ _ _ _ (yoneda C) _ _ _ _
   (nat_iso.of_components (λ Z, { hom := p, inv := q, }) (by tidy))
 
 -- We need to help typeclass inference with some awkward universe levels here.
-instance prod_category_instance_1 : category (((Cᵒᵖ) ⥤ Type v₁) × (Cᵒᵖ)) := 
+instance prod_category_instance_1 : category (((Cᵒᵖ) ⥤ Type v₁) × (Cᵒᵖ)) :=
 category_theory.prod.{(max u₁ (v₁+1)) (max u₁ v₁) u₁ v₁} (Cᵒᵖ ⥤ Type v₁) (Cᵒᵖ)
 
-instance prod_category_instance_2 : category ((Cᵒᵖ) × ((Cᵒᵖ) ⥤ Type v₁)) := 
-category_theory.prod.{u₁ v₁ (max u₁ (v₁+1)) (max u₁ v₁)} (Cᵒᵖ) (Cᵒᵖ ⥤ Type v₁) 
+instance prod_category_instance_2 : category ((Cᵒᵖ) × ((Cᵒᵖ) ⥤ Type v₁)) :=
+category_theory.prod.{u₁ v₁ (max u₁ (v₁+1)) (max u₁ v₁)} (Cᵒᵖ) (Cᵒᵖ ⥤ Type v₁)
 
 end yoneda
 
 open yoneda
 
-def yoneda_evaluation : (((Cᵒᵖ) ⥤ (Type v₁)) × (Cᵒᵖ)) ⥤ (Type (max u₁ v₁)) := 
+def yoneda_evaluation : (((Cᵒᵖ) ⥤ (Type v₁)) × (Cᵒᵖ)) ⥤ (Type (max u₁ v₁)) :=
 (evaluation (Cᵒᵖ) (Type v₁)) ⋙ ulift_functor.{v₁ u₁}
 
 @[simp] lemma yoneda_evaluation_map_down
-  (P Q : (Cᵒᵖ ⥤ Type v₁) ×  (Cᵒᵖ)) (α : P ⟶ Q) (x : (yoneda_evaluation C) P) : 
-  ((yoneda_evaluation C).map α x).down = (α.1) (Q.2) ((P.1).map (α.2) (x.down)) := rfl
+  (P Q : (Cᵒᵖ ⥤ Type v₁) × (Cᵒᵖ)) (α : P ⟶ Q) (x : (yoneda_evaluation C).obj P) :
+  ((yoneda_evaluation C).map α x).down = (α.1).app (Q.2) ((P.1).map (α.2) (x.down)) := rfl
 
-def yoneda_pairing : (((Cᵒᵖ) ⥤ (Type v₁)) × (Cᵒᵖ)) ⥤ (Type (max u₁ v₁)) := 
+def yoneda_pairing : (((Cᵒᵖ) ⥤ (Type v₁)) × (Cᵒᵖ)) ⥤ (Type (max u₁ v₁)) :=
 let F := (category_theory.prod.swap ((Cᵒᵖ) ⥤ (Type v₁)) (Cᵒᵖ)) in
 let G := (functor.prod ((yoneda C).op) (functor.id ((Cᵒᵖ) ⥤ (Type v₁)))) in
 let H := (functor.hom ((Cᵒᵖ) ⥤ (Type v₁))) in
-  (F ⋙ G ⋙ H)      
+  (F ⋙ G ⋙ H)
 
 @[simp] lemma yoneda_pairing_map
-  (P Q : (Cᵒᵖ ⥤ Type v₁) ×  (Cᵒᵖ)) (α : P ⟶ Q) (β : (yoneda_pairing C) (P.1, P.2)) : 
+  (P Q : (Cᵒᵖ ⥤ Type v₁) ×  (Cᵒᵖ)) (α : P ⟶ Q) (β : (yoneda_pairing C).obj (P.1, P.2)) :
   (yoneda_pairing C).map α β = (yoneda C).map (α.snd) ≫ β ≫ α.fst := rfl
 
-def yoneda_lemma : (yoneda_pairing C) ≅ (yoneda_evaluation C) := 
-{ hom := 
+def yoneda_lemma : (yoneda_pairing C) ≅ (yoneda_evaluation C) :=
+{ hom :=
   { app := λ F x, ulift.up ((x.app F.2) (𝟙 F.2)),
-    naturality' := begin intros X Y f, ext1, ext1, cases f, cases Y, cases X, dsimp at *, simp at *, 
+    naturality' := begin intros X Y f, ext1, ext1, cases f, cases Y, cases X, dsimp at *, simp at *,
       erw [←functor_to_types.naturality, obj_map_id, functor_to_types.naturality, functor_to_types.map_id] end },
-  inv := 
-  { app := λ F x, 
+  inv :=
+  { app := λ F x,
     { app := λ X a, (F.1.map a) x.down,
       naturality' := begin intros X Y f, ext1, cases x, cases F, dsimp at *, erw [functor_to_types.map_comp], refl end },
-    naturality' := begin intros X Y f, ext1, ext1, ext1, cases x, cases f, cases Y, cases X, 
-      dsimp at *, simp at *, erw [←functor_to_types.naturality, functor_to_types.map_comp] end },
-  hom_inv_id' := begin ext1, ext1, ext1, ext1, cases X, dsimp at *, simp at *, 
+    naturality' := begin intros X Y f, ext1, ext1, ext1, cases x, cases f, cases Y, cases X,
+      dsimp at *, erw [←functor_to_types.naturality, functor_to_types.map_comp] end },
+  hom_inv_id' := begin ext1, ext1, ext1, ext1, cases X, dsimp at *,
     erw [←functor_to_types.naturality, obj_map_id, functor_to_types.naturality, functor_to_types.map_id] end,
   inv_hom_id' := begin ext1, ext1, ext1, cases x, cases X, dsimp at *, erw [functor_to_types.map_id] end }.
 

--- a/docs/theories/category_theory.md
+++ b/docs/theories/category_theory.md
@@ -31,15 +31,15 @@ nat_trans F G        : Type (max u₁ v₂)
 functor.category C D : category.{(max u₁ u₂ v₁ v₂) (max u₁ v₂)}
 ````
 
-Note then that if we specialise to small categories, where `uᵢ = vᵢ`, then 
-`functor.category C D : category.{(max u₁ u₂) (max u₁ u₂)}`, and so is again 
-a small category. If `C` is a small category and `D` is a large category 
-(i.e. `u₂ = v₂+1`), and `v₂ = v₁` then we have 
+Note then that if we specialise to small categories, where `uᵢ = vᵢ`, then
+`functor.category C D : category.{(max u₁ u₂) (max u₁ u₂)}`, and so is again
+a small category. If `C` is a small category and `D` is a large category
+(i.e. `u₂ = v₂+1`), and `v₂ = v₁` then we have
 `functor.category C D : category.{v₁+1 v₁}` so is again a large category.
 
-Whenever you want to write code uniformly for small and large categories 
-(which you do by talking about categories whose universe levels `u` and `v` 
-are unrelated), you will find that Lean's `variable` mechanism doesn't always 
+Whenever you want to write code uniformly for small and large categories
+(which you do by talking about categories whose universe levels `u` and `v`
+are unrelated), you will find that Lean's `variable` mechanism doesn't always
 work, and the following trick is often helpful:
 
 ````
@@ -48,7 +48,7 @@ variables {D : Type u₂} [𝒟 : category.{u₂ v₂} D]
 include 𝒞 𝒟
 ````
 
-Some care with using `section ... end` can be required to make sure these 
+Some care with using `section ... end` can be required to make sure these
 included variables don't end up where they aren't wanted.
 
 ## Notation
@@ -61,7 +61,7 @@ This leaves the actual category implicit; it is inferred from the type of `X` an
 We use `𝟙` (`\b1`) to denote identity morphisms, as in `𝟙 X`.
 
 We use `≫` (`\gg`) to denote composition of morphisms, as in `f ≫ g`, which means "`f` followed by `g`".
-You may prefer write composition in the usual convention, using `⊚` (`\oo` or `\circledcirc`), as in `f ⊚ g` which means "`g` followed by `f`". To do so you'll need to add this notation locally, via 
+You may prefer write composition in the usual convention, using `⊚` (`\oo` or `\circledcirc`), as in `f ⊚ g` which means "`g` followed by `f`". To do so you'll need to add this notation locally, via
 ```
 local notation f ` ⊚ `:80 g:80 := category.comp g f
 ```
@@ -73,7 +73,7 @@ We use `≅` for isomorphisms.
 We use `⥤` (`\func`) to denote functors, as in `C ⥤ D` for the type of functors from `C` to `D`.
 (Unfortunately `⇒` is reserved in core: https://github.com/leanprover/lean/blob/master/library/init/relator.lean, so we can't use that here.)
 
-We use `F X` to denote the action of a functor on an object.
+We use `F.obj X` to denote the action of a functor on an object.
 We use `F.map f` to denote the action of a functor on a morphism`.
 
 Functor composition can be written as `F ⋙ G`.
@@ -82,6 +82,6 @@ Functor composition can be written as `F ⋙ G`.
 We use `⟹` (`\nattrans` or `\==>`) to denote the type of natural transformations, e.g. `F ⟹ G`.
 We use `⇔` (`\<=>`) to denote the type of natural isomorphisms.
 
-We prefer the of use `τ X` over `τ.app X`.
+We use `τ.app X` for the components of a natural transformation.
 
 For vertical and horiztonal composition of natural transformations we "cutely" use `⊟` (`\boxminus`) and `◫` (currently untypeable, but we could ask for `\boxvert`).


### PR DESCRIPTION
This PR removes `F X` in favour of `F.obj X`, for functors acting on objects, and removes `a X` in favour of `a.app X` for components of natural transformation.

The upsides ... have been discussed at length on zulip:
* https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/monoidal.20categories
* https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/limits.202.2E0
* https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/deeply.20unhappy.20with.20coercions

I don't think it's particularly gross, and indeed if you look at the changes, overall it's removing code.