### PR TITLE
Bounded continuous functions

### DIFF
--- a/algebra/group.lean
+++ b/algebra/group.lean
@@ -577,6 +577,8 @@ section add_comm_group
 
   theorem neg_add' (a b : α) : -(a + b) = -a - b := neg_add a b
 
+  lemma neg_sub_neg (a b : α) : -a - -b = b - a := by simp
+
   lemma eq_sub_iff_add_eq' : a = b - c ↔ c + a = b :=
   by rw [eq_sub_iff_add_eq, add_comm]
 

--- a/analysis/metric_space.lean
+++ b/analysis/metric_space.lean
@@ -97,6 +97,19 @@ by rw dist_comm z; apply dist_triangle
 theorem dist_triangle_right (x y z : α) : dist x y ≤ dist x z + dist y z :=
 by rw dist_comm y; apply dist_triangle
 
+lemma dist_triangle4 (x y z t : α) :
+  dist x t ≤ dist x y + dist y z + dist z t :=
+calc
+  dist x t ≤ dist x z + dist z t : dist_triangle x z t
+       ... ≤ (dist x y + dist y z) + dist z t : add_le_add_right (metric_space.dist_triangle x y z) _
+
+lemma dist_triangle5 (x y z t u : α) :
+  dist x u ≤ dist x y + dist y z + dist z t + dist t u :=
+calc
+  dist x u ≤ dist x t + dist t u : dist_triangle x t u
+       ... ≤ (dist x y + dist y z + dist z t) + dist t u : add_le_add_right (dist_triangle4 x y z t) _
+
+
 theorem swap_dist : function.swap (@dist α _) = dist :=
 by funext x y; exact dist_comm _ _
 

--- a/analysis/metric_space.lean
+++ b/analysis/metric_space.lean
@@ -97,19 +97,6 @@ by rw dist_comm z; apply dist_triangle
 theorem dist_triangle_right (x y z : α) : dist x y ≤ dist x z + dist y z :=
 by rw dist_comm y; apply dist_triangle
 
-lemma dist_triangle4 (x y z t : α) :
-  dist x t ≤ dist x y + dist y z + dist z t :=
-calc
-  dist x t ≤ dist x z + dist z t : dist_triangle x z t
-       ... ≤ (dist x y + dist y z) + dist z t : add_le_add_right (metric_space.dist_triangle x y z) _
-
-lemma dist_triangle5 (x y z t u : α) :
-  dist x u ≤ dist x y + dist y z + dist z t + dist t u :=
-calc
-  dist x u ≤ dist x t + dist t u : dist_triangle x t u
-       ... ≤ (dist x y + dist y z + dist z t) + dist t u : add_le_add_right (dist_triangle4 x y z t) _
-
-
 theorem swap_dist : function.swap (@dist α _) = dist :=
 by funext x y; exact dist_comm _ _
 

--- a/analysis/metric_space.lean
+++ b/analysis/metric_space.lean
@@ -406,13 +406,6 @@ begin
   exact ⟨λ ⟨s, ⟨N, hN⟩, hs⟩, ⟨N, λn hn, hs _ (hN _ hn)⟩, λ ⟨N, hN⟩, ⟨{n | n ≥ N}, ⟨⟨N, by simp⟩, hN⟩⟩⟩,
 end
 
-theorem eq_of_forall_dist_le {x y : α} (h : ∀ε, ε > 0 → dist x y ≤ ε) : x = y :=
-eq_of_dist_eq_zero (eq_of_le_of_forall_le_of_dense dist_nonneg h)
-
-instance metric_space.to_separated : separated α :=
-separated_def.2 $ λ x y h, eq_of_forall_dist_le $
-  λ ε ε0, le_of_lt (h _ (dist_mem_uniformity ε0))
-
 /-Instantiate a metric space as an emetric space. Before we can state the instance,
 we need to show that the uniform structure coming from the edistance and the
 distance coincide. -/
@@ -473,15 +466,15 @@ begin
 end
 
 theorem uniformity_edist : uniformity = (⨅ ε>0, principal {p:α×α | edist p.1 p.2 < ε}) :=
-by have h := @uniformity_edist' α _; simpa [infi_subtype] using h
+by simpa [infi_subtype] using @uniformity_edist' α _
 
 /--A metric space induces an emetric space-/
 instance emetric_space_of_metric_space [a : metric_space α] : emetric_space α :=
-{ edist_self := by simp [edist_dist],
+{ edist_self          := by simp [edist_dist],
   eq_of_edist_eq_zero := assume x y h,
-  by rw [edist_dist] at h; simpa [-dist_eq_edist, -dist_eq_nndist] using h,
-  edist_comm := by simp only [edist_dist, dist_comm]; simp,
-  edist_triangle := assume x y z,
+    by rw [edist_dist] at h; simpa [-dist_eq_edist, -dist_eq_nndist] using h,
+  edist_comm          := by simp only [edist_dist, dist_comm]; simp,
+  edist_triangle      := assume x y z,
   begin
     rw [edist_dist, edist_dist, edist_dist, ← ennreal.coe_add, ennreal.coe_le_coe,
         nnreal.of_real_add_of_real (@dist_nonneg _ _ x y) (@dist_nonneg _ _ y z),
@@ -489,7 +482,7 @@ instance emetric_space_of_metric_space [a : metric_space α] : emetric_space α 
           add_nonneg (@dist_nonneg _ _ x y) (@dist_nonneg _ _ y z)],
     apply dist_triangle x y z
   end,
-  uniformity_edist := uniformity_edist,
+  uniformity_edist    := uniformity_edist,
   ..a }
 
 /-- Instantiate the reals as a metric space. -/

--- a/analysis/metric_space.lean
+++ b/analysis/metric_space.lean
@@ -1377,7 +1377,7 @@ lemma bounded_singleton {x : α} : bounded ({x} : set α) :=
 bounded_of_finite (finite_singleton _)
 
 /--Characterization of the boundedness of the range of a function-/
-lemma bounded_range {f : β → α} : bounded (range f) ↔ ∃C, ∀x y, dist (f x) (f y) ≤ C :=
+lemma bounded_range_iff {f : β → α} : bounded (range f) ↔ ∃C, ∀x y, dist (f x) (f y) ≤ C :=
 ⟨λ⟨C, hC⟩, ⟨C, λx y, hC (f x) (f y) (mem_range_self _) (mem_range_self _)⟩,
   λ⟨C, hC⟩, ⟨C, λx y hx hy,
   begin

--- a/analysis/metric_space.lean
+++ b/analysis/metric_space.lean
@@ -9,7 +9,7 @@ Many definitions and theorems expected on metric spaces are already introduced o
 topological spaces. For example:
   open and closed sets, compactness, completeness, continuity and uniform continuity
 -/
-import data.real.nnreal analysis.topology.topological_structures analysis.emetric_space tactic.linarith
+import data.real.nnreal analysis.topology.topological_structures analysis.emetric_space
 open lattice set filter classical topological_space
 noncomputable theory
 
@@ -97,11 +97,19 @@ by rw dist_comm z; apply dist_triangle
 theorem dist_triangle_right (x y z : α) : dist x y ≤ dist x z + dist y z :=
 by rw dist_comm y; apply dist_triangle
 
-lemma dist_triangle4 (x y z t : α) :
-  dist x t ≤ dist x y + dist y z + dist z t :=
+lemma dist_triangle4 (x y z w : α) :
+  dist x w ≤ dist x y + dist y z + dist z w :=
 calc
-  dist x t ≤ dist x z + dist z t : dist_triangle x z t
-       ... ≤ (dist x y + dist y z) + dist z t : add_le_add_right (metric_space.dist_triangle x y z) _
+  dist x w ≤ dist x z + dist z w : dist_triangle x z w
+       ... ≤ (dist x y + dist y z) + dist z w : add_le_add_right (metric_space.dist_triangle x y z) _
+
+lemma dist_triangle4_left (x₁ y₁ x₂ y₂ : α) :
+  dist x₂ y₂ ≤ dist x₁ y₁ + (dist x₁ x₂ + dist y₁ y₂) :=
+by rw [add_left_comm, dist_comm x₁, ← add_assoc]; apply dist_triangle4
+
+lemma dist_triangle4_right (x₁ y₁ x₂ y₂ : α) :
+  dist x₁ y₁ ≤ dist x₁ x₂ + dist y₁ y₂ + dist x₂ y₂ :=
+by rw [add_right_comm, dist_comm y₁]; apply dist_triangle4
 
 theorem swap_dist : function.swap (@dist α _) = dist :=
 by funext x y; exact dist_comm _ _
@@ -287,38 +295,26 @@ theorem totally_bounded_of_metric {s : set α} :
                ⟨t, ft, h⟩ := H ε ε0 in
   ⟨t, ft, subset.trans h $ Union_subset_Union $ λ y, Union_subset_Union $ λ yt z, hε⟩⟩
 
-/--A metric space space is totally bounded if one can reconstruct up to any ε>0 any element of the
-space from finitely many data.-/
-lemma totally_bounded_of_finite_discretization {α : Type u} [metric_space α] (s : set α)
-  (H : ∀ε > (0 : real), ∃(β : Type*) (t : set β) (F : α → β),
-     finite t ∧ (∀x ∈ s, F x ∈ t) ∧ (∀x y ∈ s, F x = F y → dist x y < ε)) :
+/-- A metric space space is totally bounded if one can reconstruct up to any ε>0 any element of the
+space from finitely many data. -/
+lemma totally_bounded_of_finite_discretization {α : Type u} [metric_space α] {s : set α}
+  (H : ∀ε > (0 : ℝ), ∃ (β : Type u) [fintype β] (F : s → β),
+    ∀x y, F x = F y → dist (x:α) y < ε) :
   totally_bounded s :=
-have A : s = ∅ → totally_bounded s :=
 begin
-  assume hs,
-  rw totally_bounded_of_metric,
-  intros ε εpos,
-  exact ⟨∅, ⟨finite_empty, begin rw hs, by simp end⟩⟩
-end,
-have B : s ≠ ∅ → totally_bounded s :=
-begin
-  assume hs,
+  classical, by_cases hs : s = ∅,
+  { rw hs, exact totally_bounded_empty },
   rcases exists_mem_of_ne_empty hs with ⟨x0, hx0⟩,
-  haveI : inhabited α := ⟨x0⟩,
-  rw totally_bounded_of_metric,
-  intros ε εpos,
-  rcases H ε εpos with ⟨β, t, F, ⟨finite_t, hFt, hF⟩⟩,
-  let Finv := function.inv_fun_on F s,
-  let t' := Finv '' t,
-  refine  ⟨t', ⟨finite_image _ finite_t, λx x_in_s, _⟩⟩,
-  let x' := Finv (F x),
-  have : x' ∈ s := function.inv_fun_on_mem ⟨x, x_in_s, rfl⟩,
-  have : F x' = F x := function.inv_fun_on_eq ⟨x, x_in_s, rfl⟩,
-  have : dist x x' < ε := hF _ _ ‹x ∈ s› ‹x' ∈ s› (this.symm),
-  simp only [exists_prop, set.mem_Union, mem_ball, set.mem_image],
-  exact ⟨x', ⟨⟨F x, ⟨hFt _ x_in_s, by refl⟩⟩, by assumption⟩⟩
-end,
-classical.by_cases A B
+  haveI : inhabited s := ⟨⟨x0, hx0⟩⟩,
+  refine totally_bounded_of_metric.2 (λ ε ε0, _),
+  rcases H ε ε0 with ⟨β, fβ, F, hF⟩,
+  let Finv := function.inv_fun F,
+  refine ⟨range (subtype.val ∘ Finv), finite_range _, λ x xs, _⟩,
+  let x' := Finv (F ⟨x, xs⟩),
+  have : F x' = F ⟨x, xs⟩ := function.inv_fun_eq ⟨⟨x, xs⟩, rfl⟩,
+  simp only [set.mem_Union, set.mem_range],
+  exact ⟨_, ⟨F ⟨x, xs⟩, rfl⟩, hF _ _ this.symm⟩
+end
 
 lemma cauchy_of_metric {f : filter α} :
   cauchy f ↔ f ≠ ⊥ ∧ ∀ ε > 0, ∃ t ∈ f.sets, ∀ x y ∈ t, dist x y < ε :=
@@ -389,17 +385,12 @@ theorem continuous_topo_metric [topological_space β] {f : β → α} :
   continuous f ↔ ∀a (ε > 0), ∃ n ∈ (nhds a).sets, ∀b ∈ n, dist (f b) (f a) < ε :=
 continuous_iff_tendsto.trans $ forall_congr $ λ b, tendsto_nhds_topo_metric
 
-theorem tendsto_at_top_metric [inhabited β] [semilattice_sup β] (u : β → α) {a : α} :
+theorem tendsto_at_top_metric [inhabited β] [semilattice_sup β] {u : β → α} {a : α} :
   tendsto u at_top (nhds a) ↔ ∀ε>0, ∃N, ∀n≥N, dist (u n) a < ε :=
-begin
-  rw tendsto_nhds_topo_metric,
-  apply forall_congr,
-  intro ε,
-  apply forall_congr,
-  intro hε,
-  simp,
-  exact ⟨λ ⟨s, ⟨N, hN⟩, hs⟩, ⟨N, λn hn, hs _ (hN _ hn)⟩, λ ⟨N, hN⟩, ⟨{n | n ≥ N}, ⟨⟨N, by simp⟩, hN⟩⟩⟩,
-end
+tendsto_nhds_topo_metric.trans $ ball_congr $ λ ε ε0,
+by simp; exact ⟨
+  λ ⟨s, ⟨N, hN⟩, hs⟩, ⟨N, λn hn, hs _ (hN _ hn)⟩,
+  λ ⟨N, hN⟩, ⟨{n | n ≥ N}, ⟨⟨N, by simp⟩, hN⟩⟩⟩
 
 theorem eq_of_forall_dist_le {x y : α} (h : ∀ε, ε > 0 → dist x y ≤ ε) : x = y :=
 eq_of_dist_eq_zero (eq_of_le_of_forall_le_of_dense dist_nonneg h)
@@ -412,59 +403,28 @@ separated_def.2 $ λ x y h, eq_of_forall_dist_le $
 we need to show that the uniform structure coming from the edistance and the
 distance coincide. -/
 
-/--Expressing the uniformity in terms of `edist`-/
+/-- Expressing the uniformity in terms of `edist` -/
 lemma mem_uniformity_dist_edist {s : set (α×α)} :
   s ∈ (@uniformity α _).sets ↔ (∃ε>0, ∀{a b:α}, edist a b < ε → (a, b) ∈ s) :=
-suffices (∃ε>0, ∀a b, edist a b < ε → (a, b) ∈ s) ↔ (∃ε>0, ∀a b, dist a b < ε → (a, b) ∈ s), from
-  iff.trans (mem_uniformity_dist) this.symm,
-⟨show (∃ε>0, ∀a b, edist a b < ε → (a, b) ∈ s) → (∃ε>0, ∀a b, dist a b < ε → (a, b) ∈ s),
 begin
-  rintro ⟨ε, εpos, Hε⟩,
-  rcases ε with h,
-  { /- ε = ⊤, i.e., all points belong to `s` as the distance is finite.-/
-    have A : ∀ a b : α, edist a b < ⊤ := assume a b, lt_top_iff_ne_top.2 (edist_ne_top a b),
-    have B : ∀ a b : α, (a, b) ∈ s := assume a b, Hε _ _ (A a b),
-    exact ⟨1, zero_lt_one, assume a b _, B a b⟩ },
-  { /- ε < ⊤, and we can use the same value of ε as a real parameter-/
-    have A : ε > 0 := ennreal.coe_lt_coe.1 εpos,
-    have B : ∀ (a b : α), dist a b < ↑ε → (a, b) ∈ s := begin
-      assume a b Dab,
-      have I : nndist a b < ε := by rwa [← nndist_eq_dist, ← nnreal.coe_lt] at Dab,
-      have J : edist a b < ε := by rw [← nndist_eq_edist]; apply ennreal.coe_lt_coe.2 I,
-      exact Hε a b J
-    end,
-    exact ⟨ε, by simpa using A, B⟩ }
-end,
-show (∃ε>0, ∀a b, dist a b < ε → (a, b) ∈ s) → (∃ε>0, ∀a b, edist a b < ε → (a, b) ∈ s),
-begin
-  rintro ⟨ε, εpos, Hε⟩,
-  have A : ((nnreal.of_real ε) : ennreal) > (0:nnreal) :=
-  by apply ennreal.coe_lt_coe.2; simpa using εpos,
-  have B : ∀ (a b : α), edist a b < nnreal.of_real ε → (a, b) ∈ s :=
-  begin
-    assume a b Dab,
-    have I : nndist a b < nnreal.of_real ε :=
-    by rwa [← nndist_eq_edist, ennreal.coe_lt_coe] at Dab,
-    have J : dist a b < ε := begin
-      rw [← nndist_eq_dist],
-      have K := nnreal.coe_lt.1 I,
-      rwa [nnreal.coe_of_real _ (le_of_lt εpos)] at K
-    end,
-    exact Hε a b J
-  end,
-  exact ⟨nnreal.of_real ε, A, B⟩
-end⟩
+  refine mem_uniformity_dist.trans ⟨_, _⟩; rintro ⟨ε, ε0, Hε⟩,
+  { refine ⟨nnreal.of_real ε, _, λ a b, _⟩,
+    { rwa [gt, ennreal.coe_pos, nnreal.of_real_pos] },
+    { rw [edist_dist, ennreal.coe_lt_coe, nnreal.of_real_lt_of_real_iff ε0],
+      exact Hε } },
+  { rcases ennreal.lt_iff_exists_real_btwn.1 ε0 with ⟨ε', _, ε0', hε⟩,
+    rw [ennreal.coe_pos, nnreal.of_real_pos] at ε0',
+    refine ⟨ε', ε0', λ a b h, Hε (lt_trans _ hε)⟩,
+    rwa [edist_dist, ennreal.coe_lt_coe, nnreal.of_real_lt_of_real_iff ε0'] }
+end
 
 theorem uniformity_edist' : uniformity = (⨅ε:{ε:ennreal // ε>0}, principal {p:α×α | edist p.1 p.2 < ε.val}) :=
-suffices ∀s, s ∈ (⨅ε:{ε:ennreal // ε>0}, principal {p:α×α | edist p.1 p.2 < ε.val}).sets ↔
-    (∃ε>0, ∀{a b:α}, edist a b < ε → (a, b) ∈ s), from
-  filter.ext $ assume s, iff.trans (mem_uniformity_dist_edist) ((this s).symm),
 begin
-  assume s,
-  rw [infi_sets_eq],
-  simp [subset_def],
-  exact assume ⟨r, hr⟩ ⟨p, hp⟩, ⟨⟨min r p, lt_min hr hp⟩, by simp [lt_min_iff, (≥)] {contextual := tt}⟩,
-  exact ⟨⟨1, ennreal.zero_lt_one⟩⟩
+  ext s, rw infi_sets_eq,
+  { simp [mem_uniformity_dist_edist, subset_def] },
+  { rintro ⟨r, hr⟩ ⟨p, hp⟩, use ⟨min r p, lt_min hr hp⟩,
+    simp [lt_min_iff, (≥)] {contextual := tt} },
+  { exact ⟨⟨1, ennreal.zero_lt_one⟩⟩ }
 end
 
 theorem uniformity_edist : uniformity = (⨅ ε>0, principal {p:α×α | edist p.1 p.2 < ε}) :=
@@ -474,15 +434,13 @@ by simpa [infi_subtype] using @uniformity_edist' α _
 instance emetric_space_of_metric_space [a : metric_space α] : emetric_space α :=
 { edist_self          := by simp [edist_dist],
   eq_of_edist_eq_zero := assume x y h,
-    by rw [edist_dist] at h; simpa [-dist_eq_edist, -dist_eq_nndist] using h,
+  by rw [edist_dist] at h; simpa [-dist_eq_edist, -dist_eq_nndist] using h,
   edist_comm          := by simp only [edist_dist, dist_comm]; simp,
   edist_triangle      := assume x y z,
   begin
-    rw [edist_dist, edist_dist, edist_dist, ← ennreal.coe_add, ennreal.coe_le_coe,
-        nnreal.of_real_add_of_real (@dist_nonneg _ _ x y) (@dist_nonneg _ _ y z),
-        nnreal.of_real_le_of_real_iff $
-          add_nonneg (@dist_nonneg _ _ x y) (@dist_nonneg _ _ y z)],
-    apply dist_triangle x y z
+    rw [← nndist_eq_edist, ← nndist_eq_edist, ← nndist_eq_edist,
+      ← ennreal.coe_add, ennreal.coe_le_coe],
+    exact nndist_triangle x y z
   end,
   uniformity_edist    := uniformity_edist,
   ..a }
@@ -526,10 +484,10 @@ end real
 section cauchy_seq
 variables [inhabited β] [semilattice_sup β]
 
-/--In a metric space, Cauchy sequences are characterized by the fact that, eventually,
-the distance between its elements is arbitrarily small-/
+/-- In a metric space, Cauchy sequences are characterized by the fact that, eventually,
+the distance between its elements is arbitrarily small -/
 theorem cauchy_seq_metric {u : β → α} :
-  cauchy_seq u ↔ ∀ε>0, ∃N, ∀m n≥N, dist (u n) (u m) < ε :=
+  cauchy_seq u ↔ ∀ε>0, ∃N, ∀m n≥N, dist (u m) (u n) < ε :=
 begin
   unfold cauchy_seq,
   rw cauchy_of_metric,
@@ -538,19 +496,19 @@ begin
   split,
   { intros H ε εpos,
     rcases H ε εpos with ⟨t, ⟨N, hN⟩, ht⟩,
-    exact ⟨N, λm n hm hn, ht _ _ (hN _ hn) (hN _ hm)⟩ },
+    exact ⟨N, λm n hm hn, ht _ _ (hN _ hm) (hN _ hn)⟩ },
   { intros H ε εpos,
     rcases H (ε/2) (half_pos εpos) with ⟨N, hN⟩,
     existsi ball (u N) (ε/2),
     split,
-    { exact ⟨N, λx hx, hN _ _ (le_refl N) hx⟩ },
+    { exact ⟨N, λx hx, hN _ _ hx (le_refl N)⟩ },
     { exact λx y hx hy, calc
         dist x y ≤ dist x (u N) + dist y (u N) : dist_triangle_right _ _ _
         ... < ε/2 + ε/2 : add_lt_add hx hy
         ... = ε : add_halves _ } }
 end
 
-/--A variation around the metric characterization of Cauchy sequences-/
+/-- A variation around the metric characterization of Cauchy sequences -/
 theorem cauchy_seq_metric' {u : β → α} :
   cauchy_seq u ↔ ∀ε>0, ∃N, ∀n≥N, dist (u n) (u N) < ε :=
 begin
@@ -558,102 +516,70 @@ begin
   split,
   { intros H ε εpos,
     rcases H ε εpos with ⟨N, hN⟩,
-    exact ⟨N, λn hn, hN _ _ (le_refl N) hn⟩ },
+    exact ⟨N, λn hn, hN _ _ hn (le_refl N)⟩ },
   { intros H ε εpos,
     rcases H (ε/2) (half_pos εpos) with ⟨N, hN⟩,
     exact ⟨N, λ m n hm hn, calc
-       dist (u n) (u m) ≤ dist (u n) (u N) + dist (u m) (u N) : dist_triangle_right _ _ _
-                    ... < ε/2 + ε/2 : add_lt_add (hN _ hn) (hN _ hm)
+       dist (u m) (u n) ≤ dist (u m) (u N) + dist (u n) (u N) : dist_triangle_right _ _ _
+                    ... < ε/2 + ε/2 : add_lt_add (hN _ hm) (hN _ hn)
                     ... = ε : add_halves _⟩ }
 end
 
-/--Yet another metric characterization of Cauchy sequences on integers. This one is often the
-most efficient.-/
-lemma cauchy_seq_iff_le_tendsto_0 {s : ℕ → α} :
-  cauchy_seq s ↔ (∃ (b: ℕ → ℝ), (∀ n m N : ℕ, N ≤ n → N ≤ m → dist (s n) (s m) ≤ b N)
-                    ∧ (tendsto b at_top (nhds 0))) :=
-⟨begin
-  assume hs,
-  rw cauchy_seq_metric at hs,
-  /- `s` is Cauchy sequence. The sequence `b` will be constructed by taking
+/-- A Cauchy sequence on the natural numbers is bounded. -/
+theorem cauchy_seq_bdd {u : ℕ → α} (hu : cauchy_seq u) :
+  ∃ R > 0, ∀ m n, dist (u m) (u n) < R :=
+begin
+  rcases cauchy_seq_metric'.1 hu 1 zero_lt_one with ⟨N, hN⟩,
+  suffices : ∃ R > 0, ∀ n, dist (u n) (u N) < R,
+  { rcases this with ⟨R, R0, H⟩,
+    exact ⟨_, add_pos R0 R0, λ m n,
+      lt_of_le_of_lt (dist_triangle_right _ _ _) (add_lt_add (H m) (H n))⟩ },
+  let R := finset.sup (finset.range N) (λ n, nndist (u n) (u N)),
+  refine ⟨↑R + 1, add_pos_of_nonneg_of_pos R.2 zero_lt_one, λ n, _⟩,
+  cases le_or_lt N n,
+  { exact lt_of_lt_of_le (hN _ h) (le_add_of_nonneg_left R.2) },
+  { have : _ ≤ R := finset.le_sup (finset.mem_range.2 h),
+    exact lt_of_le_of_lt this (lt_add_of_pos_right _ zero_lt_one) }
+end
+
+/-- Yet another metric characterization of Cauchy sequences on integers. This one is often the
+most efficient. -/
+lemma cauchy_seq_iff_le_tendsto_0 {s : ℕ → α} : cauchy_seq s ↔ ∃ b : ℕ → ℝ,
+  (∀ n, 0 ≤ b n) ∧
+  (∀ n m N : ℕ, N ≤ n → N ≤ m → dist (s n) (s m) ≤ b N) ∧
+  tendsto b at_top (nhds 0) :=
+⟨λ hs, begin
+  /- `s` is a Cauchy sequence. The sequence `b` will be constructed by taking
   the supremum of the distances between `s n` and `s m` for `n m ≥ N`.
   First, we prove that all these distances are bounded, as otherwise the Sup
-  would not make sense.-/
-  rcases hs 1 (zero_lt_one) with ⟨N, hN⟩,
-  have A : bdd_above ((λn, dist (s n) (s N)) '' {n | n ≤ N}) :=
-    bdd_above_finite (finite_image _ (finite_le_nat N)),
-  rcases A with ⟨CA, hA⟩,
-  let M := max 1 CA,
-  have B : ∀n, dist (s n) (s N) ≤ M,
-  { intros n,
-    cases le_total n N with h,
-    { simp at hA,
-      calc dist (s n) (s N) ≤ CA : hA (dist (s n) (s N)) _ h rfl
-                        ... ≤ M : le_max_right _ _ },
-    { calc dist (s n) (s N) ≤ 1 : le_of_lt (hN _ _ (le_refl _) h)
-                        ... ≤ M : le_max_left _ _ }},
-  have bdd : bdd_above (range (λ(p : ℕ × ℕ), dist (s p.1) (s p.2))) :=
-    ⟨M + M, begin simp, intros y n m hy, calc
-      y = dist (s n) (s m) : hy.symm
-      ... ≤ dist (s n) (s N) + dist (s m) (s N) : dist_triangle_right _ _ _
-      ... ≤ M + M : add_le_add (B n) (B m)
-    end⟩,
-  --We define `b`
-  let b := λN, Sup ((λ(p : ℕ × ℕ), dist (s p.1) (s p.2))''{p | p.1 ≥ N ∧ p.2 ≥ N}),
-  --Prove that it bounds the distances of points in the Cauchy sequence
-  have C : ∀ n m N, N ≤ n → N ≤ m → dist (s n) (s m) ≤ b N,
-  { intros m n N hm hn,
-    apply le_cSup,
-    { apply bdd_above_subset _ bdd,
-      intros d hd,
-      simp at hd,
-      rcases hd with ⟨m, n, ⟨h1, h2⟩⟩,
-      rw ← h2,
-      simp only [set.mem_range, prod.exists],
-      exact ⟨m, n, rfl⟩ },
-    { existsi (prod.mk m n),
-      simp only [and_true, eq_self_iff_true, set.mem_set_of_eq],
-      exact ⟨hm, hn⟩}},
-  --Prove that it tends to `0`, by using the Cauchy property of `s`
-  have D : tendsto b at_top (nhds 0),
-  {  rw tendsto_at_top_metric,
-    intros ε εpos,
-    rcases hs (ε/2) (half_pos εpos) with ⟨N, hN⟩,
-    existsi N,
-    intros n hn,
-    have : b n ≤ ε/2,
-    {  apply cSup_le,
-      { have : {p : ℕ × ℕ | p.fst ≥ n ∧ p.snd ≥ n} ≠ ∅ :=
-          @ne_empty_of_mem _ _ (prod.mk n n) (by simp; apply le_refl),
-        simpa using this },
-      { simp only [and_imp, set.mem_image, set.mem_set_of_eq, exists_imp_distrib, prod.exists],
-        intros d p q hp hq hd,
-        rw ← hd,
-        apply le_of_lt (hN q p (le_trans hn hq) (le_trans hn hp)) }},
-    have : b n < ε := lt_of_le_of_lt this (half_lt_self εpos),
-    have : 0 ≤ b n := calc
-      0 = dist (s n) (s n) : by simp
-        ... ≤ b n : C n n n (le_refl n) (le_refl n),
-    rw real.dist_0_eq_abs,
-    exact abs_lt_of_lt_of_neg_lt ‹b n < ε› (by linarith) },
-  -- Conclude
-  exact ⟨b, ⟨C, D⟩⟩
-end,
-begin
-  rintros ⟨b, ⟨b_bound, b_lim⟩⟩,
-  /-b : ℕ → ℝ, b_bound : ∀ (n m N : ℕ), N ≤ n → N ≤ m → dist (s n) (s m) ≤ b N,
-    b_lim : tendsto b at_top (nhds 0)-/
-  rw cauchy_seq_metric,
-  intros ε εpos, /-ε : ℝ, εpos : ε > 0-/
-  rw tendsto_at_top_metric at b_lim,
-  rcases b_lim ε εpos with ⟨N, hN⟩,
-  existsi N,
-  intros m n hm hn,
-  calc dist (s n) (s m) ≤ b N : b_bound n m N hn hm
-                    ... ≤ abs(b N) : le_abs_self _
+  would not make sense. -/
+  let S := λ N, (λ(p : ℕ × ℕ), dist (s p.1) (s p.2)) '' {p | p.1 ≥ N ∧ p.2 ≥ N},
+  have hS : ∀ N, ∃ x, ∀ y ∈ S N, y ≤ x,
+  { rcases cauchy_seq_bdd hs with ⟨R, R0, hR⟩,
+    refine λ N, ⟨R, _⟩, rintro _ ⟨⟨m, n⟩, _, rfl⟩,
+    exact le_of_lt (hR m n) },
+  have bdd : bdd_above (range (λ(p : ℕ × ℕ), dist (s p.1) (s p.2))),
+  { rcases cauchy_seq_bdd hs with ⟨R, R0, hR⟩,
+    use R, rintro _ ⟨⟨m, n⟩, rfl⟩, exact le_of_lt (hR m n) },
+  -- Prove that it bounds the distances of points in the Cauchy sequence
+  have ub : ∀ m n N, N ≤ m → N ≤ n → dist (s m) (s n) ≤ real.Sup (S N) :=
+    λ m n N hm hn, real.le_Sup _ (hS N) ⟨⟨_, _⟩, ⟨hm, hn⟩, rfl⟩,
+  have S0m : ∀ n, (0:ℝ) ∈ S n := λ n, ⟨⟨n, n⟩, ⟨le_refl _, le_refl _⟩, dist_self _⟩,
+  have S0 := λ n, real.le_Sup _ (hS n) (S0m n),
+  -- Prove that it tends to `0`, by using the Cauchy property of `s`
+  refine ⟨λ N, real.Sup (S N), S0, ub, tendsto_at_top_metric.2 (λ ε ε0, _)⟩,
+  refine (cauchy_seq_metric.1 hs (ε/2) (half_pos ε0)).imp (λ N hN n hn, _),
+  rw [real.dist_0_eq_abs, abs_of_nonneg (S0 n)],
+  refine lt_of_le_of_lt (real.Sup_le_ub _ ⟨_, S0m _⟩ _) (half_lt_self ε0),
+  rintro _ ⟨⟨m', n'⟩, ⟨hm', hn'⟩, rfl⟩,
+  exact le_of_lt (hN _ _ (le_trans hn hm') (le_trans hn hn'))
+  end,
+λ ⟨b, _, b_bound, b_lim⟩, cauchy_seq_metric.2 $ λ ε ε0,
+  (tendsto_at_top_metric.1 b_lim ε ε0).imp $ λ N hN m n hm hn,
+  calc dist (s m) (s n) ≤ b N : b_bound m n N hm hn
+                    ... ≤ abs (b N) : le_abs_self _
                     ... = dist (b N) 0 : by rw real.dist_0_eq_abs; refl
-                    ... < ε : (hN _ (le_refl N))
-end⟩
+                    ... < ε : (hN _ (le_refl N)) ⟩
 
 end cauchy_seq
 
@@ -894,6 +820,10 @@ begin
   apply ne_empty_of_mem B
 end⟩
 
+theorem mem_of_closed' {α : Type u} [metric_space α] {s : set α} (hs : is_closed s)
+  {a : α} : a ∈ s ↔ ∀ε>0, ∃b ∈ s, dist a b < ε :=
+by simpa only [closure_eq_of_is_closed hs] using @mem_closure_iff' _ _ s a
+
 section pi
 open finset lattice
 variables {π : β → Type*} [fintype β] [∀b, metric_space (π b)]
@@ -959,7 +889,7 @@ section second_countable
 /-- A separable metric space is second countable: one obtains a countable basis by taking
 the balls centered at points in a dense subset, and with rational radii. We do not register
 this as an instance, as there is already an instance going in the other direction
-from second countable spaces to separable spaces, and we want to avoid loops.-/
+from second countable spaces to separable spaces, and we want to avoid loops. -/
 lemma second_countable_of_separable_metric_space (α : Type u) [metric_space α] [separable_space α] :
   second_countable_topology α :=
 let ⟨S, ⟨S_countable, S_dense⟩⟩ := separable_space.exists_countable_closure_eq_univ α in
@@ -1172,9 +1102,10 @@ lemma lebesgue_number_lemma_of_metric_sUnion
 by rw sUnion_eq_Union at hc₂;
    simpa using lebesgue_number_lemma_of_metric hs (by simpa) hc₂
 
-/--boundedness of a subset of a metric space. We formulate the definition to work
-even in the empty space.-/
-definition bounded [metric_space α] (s : set α) : Prop :=
+
+/-- Boundedness of a subset of a metric space. We formulate the definition to work
+even in the empty space. -/
+def bounded [metric_space α] (s : set α) : Prop :=
 ∃C, ∀x y ∈ s, dist x y ≤ C
 
 section bounded
@@ -1183,111 +1114,97 @@ variables {t : set α} {r : ℝ}
 @[simp] lemma bounded_empty : bounded (∅ : set α) :=
 ⟨0, by simp⟩
 
-/--Subsets of a bounded set are also bounded-/
-lemma bounded_of_subset_of_bounded (incl : s ⊆ t) (h : bounded t) :
-  bounded s :=
-let ⟨C, hC⟩ := h in ⟨C, λx y hx hy, hC x y (incl hx) (incl hy)⟩
+lemma bounded_iff_mem_bounded : bounded s ↔ ∀ x ∈ s, bounded s :=
+⟨λ h _ _, h, λ H, begin
+  classical, by_cases s = ∅,
+  { subst s, exact ⟨0, by simp⟩ },
+  { rcases exists_mem_of_ne_empty h with ⟨x, hx⟩,
+    exact H x hx }
+end⟩
 
-/--Closed balls are bounded-/
+/-- Subsets of a bounded set are also bounded -/
+lemma bounded.subset (incl : s ⊆ t) : bounded t → bounded s :=
+Exists.imp $ λ C hC x y hx hy, hC x y (incl hx) (incl hy)
+
+/-- Closed balls are bounded -/
 lemma bounded_closed_ball : bounded (closed_ball x r) :=
-begin
-  existsi r + r,
-  assume y z hy hz,
+⟨r + r, λ y z hy hz, begin
   simp only [mem_closed_ball] at *,
   calc dist y z ≤ dist y x + dist z x : dist_triangle_right _ _ _
             ... ≤ r + r : add_le_add hy hz
-end
+end⟩
 
-/--Open balls are bounded-/
+/-- Open balls are bounded -/
 lemma bounded_ball : bounded (ball x r) :=
-bounded_of_subset_of_bounded ball_subset_closed_ball bounded_closed_ball
+bounded_closed_ball.subset ball_subset_closed_ball
 
-/--Given a point, a bounded subset is included in some ball around this point-/
-lemma subset_ball_of_bounded (c : α) (h : bounded s) :
-  ∃r, s ⊆ closed_ball c r :=
-have A : s = ∅ → ∃r, s ⊆ closed_ball c r := λe, ⟨0, by rw e; simp⟩,
-have B : s ≠ ∅ → ∃r, s ⊆ closed_ball c r :=
+/-- Given a point, a bounded subset is included in some ball around this point -/
+lemma bounded_iff_subset_ball (c : α) : bounded s ↔ ∃r, s ⊆ closed_ball c r :=
 begin
-  assume ne,
-  rcases exists_mem_of_ne_empty ne with ⟨x, hx⟩,
-  rcases h with ⟨C, hC⟩,
-  existsi C + dist x c,
-  assume y hy,
-  simp only [mem_closed_ball],
-  calc dist y c ≤ dist y x + dist x c : dist_triangle _ _ _
-            ... ≤ C + dist x c : add_le_add_right (hC y x hy hx) _
-end,
-classical.by_cases A B
-
-/--The union of two bounded sets is bounded iff each of the sets is bounded-/
-@[simp] lemma bounded_union_iff_bounded :
-  bounded (s ∪ t) ↔ (bounded s ∧ bounded t) :=
-⟨λh, ⟨bounded_of_subset_of_bounded (by simp) h, bounded_of_subset_of_bounded (by simp) h⟩,
-assume ⟨hs, ht⟩,
-have A : s ∪ t = ∅ → bounded (s ∪ t) := by simp {contextual := tt},
-have B : s ∪ t ≠ ∅ → bounded (s ∪ t) :=
-begin
-  assume ne,
-  rcases exists_mem_of_ne_empty ne with ⟨c, hc⟩,
-  rcases subset_ball_of_bounded c hs with ⟨Cs, hCs⟩,
-  rcases subset_ball_of_bounded c ht with ⟨Ct, hCt⟩,
-  let C := max Cs Ct,
-  have Is : s ⊆ closed_ball c C :=
-    subset.trans hCs (closed_ball_subset_closed_ball (le_max_left _ _)),
-  have It : t ⊆ closed_ball c C :=
-    subset.trans hCt (closed_ball_subset_closed_ball (le_max_right _ _)),
-  apply bounded_of_subset_of_bounded (union_subset Is It) bounded_closed_ball,
-end,
-classical.by_cases A B⟩
-
-/--A finite union of bounded sets is bounded-/
-lemma bounded_bUnion_of_bounded {I : set β} {s : β → set α} (H : finite I) :
-  (∀i ∈ I, bounded (s i)) → bounded (⋃i∈I, s i) :=
-by apply finite.induction_on ‹finite I›; simp; finish
-
-/--A compact set is bounded-/
-lemma bounded_of_compact {s : set α} (h : compact s) : bounded s :=
-begin
-  --We cover the compact set by finitely many balls of radius 1,
-  --and then argue that a finite union of bounded sets is bounded
-  rcases finite_cover_balls_of_compact h zero_lt_one with ⟨t, ht, ⟨fint, subs⟩⟩,
-  exact bounded_of_subset_of_bounded subs (bounded_bUnion_of_bounded fint
-    (begin assume i hi, apply bounded_ball end))
+  split; rintro ⟨C, hC⟩,
+  { classical, by_cases s = ∅,
+    { subst s, exact ⟨0, by simp⟩ },
+    { rcases exists_mem_of_ne_empty h with ⟨x, hx⟩,
+      exact ⟨C + dist x c, λ y hy, calc
+        dist y c ≤ dist y x + dist x c : dist_triangle _ _ _
+            ... ≤ C + dist x c : add_le_add_right (hC y x hy hx) _⟩ } },
+  { exact bounded_closed_ball.subset hC }
 end
 
-/--A finite set is bounded-/
+/-- The union of two bounded sets is bounded iff each of the sets is bounded -/
+@[simp] lemma bounded_union :
+  bounded (s ∪ t) ↔ bounded s ∧ bounded t :=
+⟨λh, ⟨h.subset (by simp), h.subset (by simp)⟩,
+begin
+  rintro ⟨hs, ht⟩,
+  refine bounded_iff_mem_bounded.2 (λ x _, _),
+  rw bounded_iff_subset_ball x at hs ht ⊢,
+  rcases hs with ⟨Cs, hCs⟩, rcases ht with ⟨Ct, hCt⟩,
+  exact ⟨max Cs Ct, union_subset
+    (subset.trans hCs $ closed_ball_subset_closed_ball $ le_max_left _ _)
+    (subset.trans hCt $ closed_ball_subset_closed_ball $ le_max_right _ _)⟩,
+end⟩
+
+/-- A finite union of bounded sets is bounded -/
+lemma bounded_bUnion {I : set β} {s : β → set α} (H : finite I) :
+  bounded (⋃i∈I, s i) ↔ ∀i ∈ I, bounded (s i) :=
+finite.induction_on H (by simp) $ λ x I _ _ IH,
+by simp [or_imp_distrib, forall_and_distrib, IH]
+
+/-- A compact set is bounded -/
+lemma bounded_of_compact {s : set α} (h : compact s) : bounded s :=
+-- We cover the compact set by finitely many balls of radius 1,
+-- and then argue that a finite union of bounded sets is bounded
+let ⟨t, ht, fint, subs⟩ := finite_cover_balls_of_compact h zero_lt_one in
+bounded.subset subs $ (bounded_bUnion fint).2 $ λ i hi, bounded_ball
+
+/-- A finite set is bounded -/
 lemma bounded_of_finite {s : set α} (h : finite s) : bounded s :=
 bounded_of_compact $ compact_of_finite h
 
-/--A singleton is bounded-/
+/-- A singleton is bounded -/
 lemma bounded_singleton {x : α} : bounded ({x} : set α) :=
-bounded_of_finite (finite_singleton _)
+bounded_of_finite $ finite_singleton _
 
-/--Characterization of the boundedness of the range of a function-/
+/-- Characterization of the boundedness of the range of a function -/
 lemma bounded_range_iff {f : β → α} : bounded (range f) ↔ ∃C, ∀x y, dist (f x) (f y) ≤ C :=
-⟨λ⟨C, hC⟩, ⟨C, λx y, hC (f x) (f y) (mem_range_self _) (mem_range_self _)⟩,
-  λ⟨C, hC⟩, ⟨C, λx y hx hy,
-  begin
-    rcases mem_range.1 hx with ⟨x', fx⟩,
-    rcases mem_range.1 hy with ⟨y', fy⟩,
-    simpa [fx.symm, fy.symm] using hC x' y'
-  end⟩⟩
+exists_congr $ λ C, ⟨
+  λ H x y, H _ _ ⟨x, rfl⟩ ⟨y, rfl⟩,
+  by rintro H _ _ ⟨x, rfl⟩ ⟨y, rfl⟩; exact H x y⟩
 
-/--In a compact space, all sets are bounded-/
-lemma bounded_in_compact_space [compact_space α] : bounded s :=
-bounded_of_subset_of_bounded (subset_univ _) (bounded_of_compact compact_univ)
+/-- In a compact space, all sets are bounded -/
+lemma bounded_of_compact_space [compact_space α] : bounded s :=
+(bounded_of_compact compact_univ).subset (subset_univ _)
 
-/--In a proper space, a set is compact if and only if it is closed and bounded-/
+/-- In a proper space, a set is compact if and only if it is closed and bounded -/
 lemma compact_iff_closed_bounded [proper_space α] :
-  compact s ↔ (is_closed s ∧ bounded s) :=
-⟨λ h, ⟨closed_of_compact _ h, bounded_of_compact h⟩,
-assume ⟨hc, hb⟩,
-have A : s = ∅ → compact s := by simp [compact_empty] {contextual := tt},
-have B : s ≠ ∅ → compact s,
-{ assume ne,
-  rcases exists_mem_of_ne_empty ne with ⟨x, hx⟩,
-  rcases subset_ball_of_bounded x hb with ⟨r, hr⟩,
-  exact compact_of_is_closed_subset (proper_space.compact_ball x r) hc hr },
-classical.by_cases A B⟩
+  compact s ↔ is_closed s ∧ bounded s :=
+⟨λ h, ⟨closed_of_compact _ h, bounded_of_compact h⟩, begin
+  rintro ⟨hc, hb⟩,
+  classical, by_cases s = ∅, {simp [h, compact_empty]},
+  rcases exists_mem_of_ne_empty h with ⟨x, hx⟩,
+  rcases (bounded_iff_subset_ball x).1 hb with ⟨r, hr⟩,
+  exact compact_of_is_closed_subset (proper_space.compact_ball x r) hc hr
+end⟩
 
 end bounded

--- a/analysis/metric_space.lean
+++ b/analysis/metric_space.lean
@@ -318,7 +318,7 @@ begin
     have : x' ∈ s := function.inv_fun_on_mem ⟨x, x_in_s, rfl⟩,
     have : F x' = F x := function.inv_fun_on_eq ⟨x, x_in_s, rfl⟩,
     have : dist x x' < ε := hF _ _ ‹x ∈ s› ‹x' ∈ s› (this.symm),
-    simp,
+    simp only [exists_prop, set.mem_Union, mem_ball, set.mem_image],
     exact ⟨x', ⟨⟨F x, ⟨hFt _ x_in_s, by refl⟩⟩, by assumption⟩⟩
   end,
   exact ⟨t', ⟨‹finite t'›, this⟩⟩
@@ -523,7 +523,8 @@ theorem cauchy_seq_metric {u : β → α} :
 begin
   unfold cauchy_seq,
   rw cauchy_of_metric,
-  simp,
+  simp only [true_and, exists_prop, filter.mem_at_top_sets, filter.at_top_ne_bot,
+             filter.mem_map, ne.def, filter.map_eq_bot_iff, not_false_iff, set.mem_set_of_eq],
   split,
   { intros H ε εpos,
     rcases H ε εpos with ⟨t, ⟨N, hN⟩, ht⟩,
@@ -601,10 +602,10 @@ lemma cauchy_seq_iff_le_tendsto_0 {s : ℕ → α} :
       simp at hd,
       rcases hd with ⟨m, n, ⟨h1, h2⟩⟩,
       rw ← h2,
-      simp,
+      simp only [set.mem_range, prod.exists],
       exact ⟨m, n, rfl⟩ },
     { existsi (prod.mk m n),
-      simp,
+      simp only [and_true, eq_self_iff_true, set.mem_set_of_eq],
       exact ⟨hm, hn⟩}
   end,
   --Prove that it tends to `0`, by using the Cauchy property of `s`
@@ -621,7 +622,7 @@ lemma cauchy_seq_iff_le_tendsto_0 {s : ℕ → α} :
       { have : {p : ℕ × ℕ | p.fst ≥ n ∧ p.snd ≥ n} ≠ ∅ :=
           @ne_empty_of_mem _ _ (prod.mk n n) (by simp; apply le_refl),
         simpa using this },
-      { simp,
+      { simp only [and_imp, set.mem_image, set.mem_set_of_eq, exists_imp_distrib, prod.exists],
         intros d p q hp hq hd,
         rw ← hd,
         apply le_of_lt (hN q p (le_trans hn hq) (le_trans hn hp)) }
@@ -1305,7 +1306,7 @@ lemma bounded_closed_ball : bounded (closed_ball x r) :=
 begin
   existsi r + r,
   assume y z hy hz,
-  simp at *,
+  simp only [mem_closed_ball] at *,
   calc dist y z ≤ dist y x + dist z x : dist_triangle_right _ _ _
             ... ≤ r + r : add_le_add hy hz
 end
@@ -1325,7 +1326,7 @@ begin
   rcases h with ⟨C, hC⟩,
   existsi C + dist x c,
   assume y hy,
-  simp,
+  simp only [mem_closed_ball],
   calc dist y c ≤ dist y x + dist x c : dist_triangle _ _ _
             ... ≤ C + dist x c : add_le_add_right (hC y x hy hx) _
 end,
@@ -1383,8 +1384,7 @@ lemma bounded_range_iff {f : β → α} : bounded (range f) ↔ ∃C, ∀x y, di
   begin
     rcases mem_range.1 hx with ⟨x', fx⟩,
     rcases mem_range.1 hy with ⟨y', fy⟩,
-    simp [fx.symm, fy.symm],
-    exact hC x' y'
+    simpa [fx.symm, fy.symm] using hC x' y'
   end⟩⟩
 
 /--In a compact space, all sets are bounded-/

--- a/analysis/normed_space.lean
+++ b/analysis/normed_space.lean
@@ -31,6 +31,26 @@ notation `∥`:1024 e:1 `∥`:1 := norm e
 class normed_group (α : Type*) extends has_norm α, add_comm_group α, metric_space α :=
 (dist_eq : ∀ x y, dist x y = norm (x - y))
 
+/-- Construct a normed group from a translation invariant distance -/
+def normed_group.of_add_dist [has_norm α] [add_comm_group α] [metric_space α]
+  (H1 : ∀ x:α, ∥x∥ = dist x 0)
+  (H2 : ∀ x y z : α, dist x y ≤ dist (x + z) (y + z)) : normed_group α :=
+{ dist_eq := λ x y, begin
+    rw H1, apply le_antisymm,
+    { rw [sub_eq_add_neg, ← add_right_neg y], apply H2 },
+    { have := H2 (x-y) 0 y, rwa [sub_add_cancel, zero_add] at this }
+  end }
+
+/-- Construct a normed group from a translation invariant distance -/
+def normed_group.of_add_dist' [has_norm α] [add_comm_group α] [metric_space α]
+  (H1 : ∀ x:α, ∥x∥ = dist x 0)
+  (H2 : ∀ x y z : α, dist (x + z) (y + z) ≤ dist x y) : normed_group α :=
+{ dist_eq := λ x y, begin
+    rw H1, apply le_antisymm,
+    { have := H2 (x-y) 0 y, rwa [sub_add_cancel, zero_add] at this },
+    { rw [sub_eq_add_neg, ← add_right_neg y], apply H2 }
+  end }
+
 section normed_group
 variables [normed_group α] [normed_group β]
 

--- a/analysis/topology/bounded_continuous_function.lean
+++ b/analysis/topology/bounded_continuous_function.lean
@@ -82,18 +82,21 @@ section
 variables [topological_space α] [metric_space β] [metric_space γ]
 variables {f g : bounded_continuous_function α β} {x : α} {C : ℝ}
 
+instance : has_coe_to_fun (bounded_continuous_function α β) :=  ⟨_, subtype.val⟩
+
+lemma bounded_range : bounded (range f) :=
+bounded_range_iff.2 (f.property.2)
+
 /--If a function is continuous on a compact space, it is automatically bounded,
 and therefore gives rise to an element of the type of bounded continuous functions-/
 def mk_of_compact [compact_space α] (f : α → β) (hf : continuous f) : bounded_continuous_function α β :=
-⟨f, ⟨hf, by apply bounded_range.1; rw ← image_univ; apply bounded_of_compact (compact_image compact_univ hf)⟩⟩
+⟨f, ⟨hf, by apply bounded_range_iff.1; rw ← image_univ; apply bounded_of_compact (compact_image compact_univ hf)⟩⟩
 
 /--If a function is bounded on a discrete space, it is automatically continuous,
 and therefore gives rise to an element of the type of bounded continuous functions-/
 def mk_of_discrete [discrete_topology α] (f : α → β) (hf : ∃C, ∀x y, dist (f x) (f y) ≤ C) :
   bounded_continuous_function α β :=
 ⟨f, ⟨continuous_of_discrete_topology, hf⟩⟩
-
-instance : has_coe_to_fun (bounded_continuous_function α β) :=  ⟨_, subtype.val⟩
 
 /--The uniform distance between two bounded continuous functions-/
 instance : has_dist (bounded_continuous_function α β) :=
@@ -642,6 +645,19 @@ instance : normed_group (bounded_continuous_function α β) :=
   ..bounded_continuous_function.add_comm_group,
   ..bounded_continuous_function.has_norm
 }
+
+lemma abs_diff_coe_le_dist : norm (f x - g x) ≤ dist f g :=
+calc norm (f x - g x) = norm ((f - g) x) : by simp
+                  ... ≤ norm (f - g) : norm_coe_le_norm
+                  ... = dist f g : (normed_group.dist_eq _ _).symm
+
+lemma coe_le_coe_add_dist {f g : bounded_continuous_function α ℝ} : f x ≤ g x + dist f g :=
+begin
+  have : f x - g x ≤ abs (f x - g x) := le_abs_self _,
+  have : abs (f x - g x) ≤ dist f g :=
+    by rw ← real.norm_eq_abs; exact abs_diff_coe_le_dist,
+  by linarith
+end
 
 end normed_group --section
 end bounded_continuous_function --namespace

--- a/analysis/topology/bounded_continuous_function.lean
+++ b/analysis/topology/bounded_continuous_function.lean
@@ -35,11 +35,11 @@ begin
   intros y yrs,
   calc dist (f y) (f x) ≤ dist (f y) (F N y) + dist (F N y) (F N x) + dist (F N x) (f x) : dist_triangle4 _ _ _ _
       ... ≤ (ε/4) + (ε/4) + (ε/4) :
-        begin
-          apply_rules [add_le_add, le_of_lt (hs y yrs.2), hN x (mem_of_nhds r_set)],
-          rw dist_comm,
-          apply hN _ yrs.1,
-        end
+      begin
+        apply_rules [add_le_add, le_of_lt (hs y yrs.2), hN x (mem_of_nhds r_set)],
+        rw dist_comm,
+        apply hN _ yrs.1,
+      end
       ... < ε : by linarith
 end
 
@@ -62,7 +62,7 @@ begin
   intros x ε εpos,
   have : 0 < max C 1 := lt_of_lt_of_le zero_lt_one (le_max_right C 1),
   existsi (ε/max C 1),
-  simp,
+  simp only [exists_prop],
   split,
   { apply div_pos εpos ‹0 < max C 1› },
   { intros y hy, calc
@@ -167,7 +167,7 @@ instance : metric_space (bounded_continuous_function α β) :=
       intro H, /- H : univ ≠ ∅ -/
       rcases exists_mem_of_ne_empty H with ⟨x, _⟩, /- x : α -/
       have a : dist (f x) (f x) ≤ dist f f := dist_coe_le_dist,
-      simp at a,
+      simp only [dist_self] at a,
       have b : dist f f ≤ 0 := dist_le_of_forall_dist_le (by simp [le_refl]) (le_refl _),
       show dist f f = 0, from le_antisymm b a,
     end,
@@ -186,7 +186,7 @@ instance : metric_space (bounded_continuous_function α β) :=
       calc dist (f x) (h x) ≤ dist (f x) (g x) + dist (g x) (h x) : dist_triangle _ _ _
                         ... ≤ dist f g + dist g h : add_le_add dist_coe_le_dist dist_coe_le_dist,
     have b : 0 + 0 ≤ dist f g + dist g h := add_le_add dist_nonneg' dist_nonneg',
-    simp at b,
+    simp only [add_zero] at b,
     show dist f h ≤ dist f g + dist g h, from dist_le_of_forall_dist_le a b
   end }
 
@@ -212,7 +212,7 @@ begin
   /- The product set `set.prod (ball f (ε/2)) nx` is a set around `(f, x)` where the
   evaluation map varies by at most ε.-/
   existsi set.prod (ball f (ε/2)) nx,
-  simp,
+  simp only [and_imp, exists_prop, mem_ball, prod.forall, set.mem_prod],
   dsimp,
   exact ⟨B, A⟩,
 end
@@ -250,7 +250,7 @@ begin
       tendsto_dist tendsto_const_nhds (hF x),
     have b : tendsto (λn, b N) at_top (nhds (b N)) := tendsto_const_nhds,
     apply le_of_tendsto (by simp) a b _ ,
-    simp,
+    simp only [filter.mem_at_top_sets, set.mem_set_of_eq],
     exact ⟨N, λn hn, I x N n N (le_refl N) hn⟩,
   end,
   /- Check that `F` is continuous -/
@@ -397,7 +397,7 @@ begin
     have : ∀ y, ∃z∈tβ, dist y z < ε/8 :=
       λy, by simpa using htβ (mem_univ y),
     choose F hF using this,
-    simp at hF,
+    simp only [exists_prop] at hF,
     /- F : β → β, hF : ∀ (y : β), F y ∈ tβ ∧ dist y (F y) < ε/8-/
 
     /-Associate to every function a discrete approximation, mapping each point in `tα`
@@ -431,8 +431,7 @@ begin
     end,
     /-The discretization constructed above is good enough to conclude-/
     existsi [(tα → tβ), univ, approx],
-    simp [fin_univ],
-    exact main,
+    simpa [fin_univ] using main
   end
 end
 
@@ -602,7 +601,7 @@ instance : has_neg (bounded_continuous_function α β) :=
         rw [dist_eq_norm, dist_eq_norm, norm_sub_rev],
         simp,
       end,
-      simp [this],
+      simp only [this],
       exact f.property.2 }
   end⟩ }
 
@@ -643,8 +642,7 @@ instance : normed_group (bounded_continuous_function α β) :=
     exact le_antisymm A B
   end,
   ..bounded_continuous_function.add_comm_group,
-  ..bounded_continuous_function.has_norm
-}
+  ..bounded_continuous_function.has_norm }
 
 lemma abs_diff_coe_le_dist : norm (f x - g x) ≤ dist f g :=
 calc norm (f x - g x) = norm ((f - g) x) : by simp

--- a/analysis/topology/bounded_continuous_function.lean
+++ b/analysis/topology/bounded_continuous_function.lean
@@ -1,0 +1,560 @@
+/-
+Copyright (c) 2018 Sébastien Gouëzel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sébastien Gouëzel
+
+Type of bounded continuous functions taking values in a metric space, with
+the uniform distance.
+-/
+
+import analysis.normed_space data.real.cau_seq_filter tactic.tidy
+
+noncomputable theory
+local attribute [instance] classical.decidable_inhabited classical.prop_decidable
+
+open set lattice filter
+
+universes u v w
+variables {α : Type u} {β : Type v} {γ : Type w}
+
+/--A locally uniform limit of continuous functions is continuous-/
+lemma continuous_of_locally_uniform_limit_of_continuous [topological_space α] [metric_space β]
+  {F : ℕ → α → β} {f : α → β}
+  (L : ∀x:α, ∃s ∈ (nhds x).sets, ∀ε>(0:ℝ), ∃N, ∀y∈s, dist (F N y) (f y) ≤ ε)
+  (C : ∀(n : ℕ), continuous (F n)) :
+  continuous f :=
+begin
+  rw continuous_topo_metric,
+  intros x ε εpos,
+  have ε4pos : ε / 4 > 0 := by linarith,
+  rcases L x with ⟨r, r_set, hr⟩,
+  rcases hr (ε/4) ε4pos with ⟨N, hN⟩,
+  rcases continuous_topo_metric.1 (C N) x (ε/4) ε4pos with ⟨s, ⟨s_set, hs⟩⟩,
+  existsi r ∩ s,
+  existsi (nhds x).inter_sets r_set s_set,
+  intros y yrs,
+  calc dist (f y) (f x) ≤ dist (f y) (F N y) + dist (F N y) (F N x) + dist (F N x) (f x) : dist_triangle4 _ _ _ _
+      ... ≤ (ε/4) + (ε/4) + (ε/4) :
+        begin
+          apply_rules [add_le_add, le_of_lt (hs y yrs.2), hN x (mem_of_nhds r_set)],
+          rw dist_comm,
+          apply hN _ yrs.1,
+        end
+      ... < ε : by linarith
+end
+
+/--A uniform limit of continuous functions is continuous-/
+lemma continuous_of_uniform_limit_of_continuous {α : Type u} [topological_space α] {β : Type v} [metric_space β]
+  {F : ℕ → α → β} {f : α → β}
+  (L : ∀ε>(0:ℝ), ∃N, ∀y, dist (F N y) (f y) ≤ ε)
+  (C : ∀(n : ℕ), continuous (F n)) :
+  continuous f :=
+begin
+  apply @continuous_of_locally_uniform_limit_of_continuous _ _ _ _ F f _ C,
+  exact λx, ⟨univ, by simpa [filter.univ_mem_sets] using L⟩
+end
+
+/--A Lipschitz function is continuous-/
+lemma continuous_of_lipschitz {α : Type u} {β : Type v} [metric_space α] [metric_space β] {C : ℝ}
+  {f : α → β} (H : ∀x y, dist (f x) (f y) ≤ C * dist x y) : continuous f :=
+begin
+  rw continuous_of_metric,
+  intros x ε εpos,
+  have : 0 < max C 1 := lt_of_lt_of_le zero_lt_one (le_max_right C 1),
+  existsi (ε/max C 1),
+  simp,
+  split,
+  { apply div_pos εpos ‹0 < max C 1› },
+  { intros y hy, calc
+      dist (f y) (f x) ≤ C * dist y x : H y x
+      ... ≤ max C 1 * dist y x : mul_le_mul_of_nonneg_right (le_max_left C 1) (dist_nonneg)
+      ... < max C 1 * (ε/max C 1) : mul_lt_mul_of_pos_left hy ‹0 < max C 1›
+      ... = ε : mul_div_cancel' _ (ne_of_gt ‹0 < max C 1›) }
+end
+
+/--The type of bounded continuous functions from a topological space to a metric space-/
+def bounded_continuous_function (α : Type u) (β : Type v) [topological_space α] [metric_space β] : Type (max u v) :=
+  {f : α → β // continuous f ∧ ∃C, ∀x y:α, dist (f x) (f y) ≤ C}
+
+namespace bounded_continuous_function
+
+section
+
+variables [topological_space α] [metric_space β] [metric_space γ]
+variables {f g : bounded_continuous_function α β} {x : α} {C : ℝ}
+
+instance : has_coe_to_fun (bounded_continuous_function α β) :=  ⟨_, subtype.val⟩
+
+/--The uniform distance between two bounded continuous functions-/
+instance : has_dist (bounded_continuous_function α β) :=
+⟨λf g, Inf {C | C ≥ 0 ∧ ∀ x : α, dist (f x) (g x) ≤ C}⟩
+
+lemma dist_eq : dist f g = Inf {C | C ≥ 0 ∧ ∀ x : α, dist (f x) (g x) ≤ C} := rfl
+
+@[extensionality] lemma ext (H : ∀x, f x = g x) : f = g :=
+by apply subtype.eq; apply funext; assumption
+
+/--On an empty space, bounded continuous functions are at distance 0-/
+lemma dist_zero_of_empty (e : (univ : set α) = ∅) : dist f g = 0 :=
+have A : {C | C ≥ 0 ∧ ∀ x : α, dist (f x) (g x) ≤ C} = {C | C ≥ 0} :=
+begin
+  apply eq_of_subset_of_subset,
+  { exact λC h, h.1 },
+  { exact λC h, ⟨h, begin assume x, simpa using ne_empty_of_mem (mem_univ x) end⟩}
+end,
+by rw [dist_eq, A]; simp
+
+/--The pointwise distance is controlled by the distance between functions, by definition-/
+lemma dist_coe_le_dist : dist (f x) (g x) ≤ dist f g :=
+have A : ∃C, C ≥ 0 ∧ ∀ y : α, dist (f y) (g y) ≤ C :=
+begin
+  rcases f.2 with ⟨_, Cf, hCf⟩, /- hCf : ∀ (x y : α), dist (f.val x) (f.val y) ≤ Cf -/
+  rcases g.2 with ⟨_, Cg, hCg⟩, /- hCg : ∀ (x y : α), dist (g.val x) (g.val y) ≤ Cg -/
+  let C := max 0 (Cf + dist (f x) (g x) + Cg),
+  have : ∀ y, dist (f y) (g y) ≤ C := assume y, calc
+    dist (f y) (g y) ≤ dist (f y) (f x) + dist (f x) (g x) + dist (g x) (g y) : dist_triangle4 _ _ _ _
+                 ... ≤ Cf + dist (f x) (g x) + Cg : add_le_add (add_le_add_right (hCf _ _) _) (hCg _ _)
+                 ... ≤ C : le_max_right _ _,
+  exact ⟨C, ⟨le_max_left _ _, this⟩⟩
+end,
+le_cInf (ne_empty_iff_exists_mem.2 A) $ λb hb, hb.2 x
+
+/--The distance between two functions is controlled by the supremum of the pointwise distances-/
+lemma dist_le_of_forall_dist_le (H : ∀x:α, dist (f x) (g x) ≤ C) (Cnonneg : C ≥ (0 : ℝ)) :
+  dist f g ≤ C :=
+begin
+  have a : bdd_below {C | C ≥ 0 ∧ ∀x, dist (f x) (g x) ≤ C} :=
+    ⟨0, begin intros y hy, simp at hy, exact hy.1 end⟩,
+  have b : C ∈ {C | C ≥ 0 ∧ ∀x, dist (f x) (g x) ≤ C} :=
+    by simp; exact ⟨Cnonneg, H⟩,
+  show dist f g ≤ C, from cInf_le a b
+end
+
+/-This lemma will be needed in the proof of the metric space instance, but it will become
+useless afterwards as it will be superceded by the general result that the distance is nonnegative
+is metric spaces.-/
+lemma dist_nonneg' : 0 ≤ dist f g :=
+have A : (univ : set α) = ∅ → 0 ≤ dist f g := λh, by simp [dist_zero_of_empty h, le_refl],
+have B : (univ : set α) ≠ ∅ → 0 ≤ dist f g :=
+begin
+  intro H, /- H : univ ≠ ∅ -/
+  rcases exists_mem_of_ne_empty H with ⟨x, _⟩, /- x : α -/
+  calc 0 ≤ dist (f x) (g x) : dist_nonneg
+     ... ≤ dist f g : dist_coe_le_dist
+end,
+show 0 ≤ dist f g, from classical.by_cases A B
+
+/--The type of bounded continuous functions, with the uniform distance, is a metric space.-/
+instance : metric_space (bounded_continuous_function α β) :=
+{ dist_self := assume f,
+  begin
+    have A : (univ : set α) = ∅ → dist f f = 0 := λh, dist_zero_of_empty h,
+    have B : (univ : set α) ≠ ∅ → dist f f = 0 :=
+    begin
+      intro H, /- H : univ ≠ ∅ -/
+      rcases exists_mem_of_ne_empty H with ⟨x, _⟩, /- x : α -/
+      have a : dist (f x) (f x) ≤ dist f f := dist_coe_le_dist,
+      simp at a,
+      have b : dist f f ≤ 0 := dist_le_of_forall_dist_le (by simp [le_refl]) (le_refl _),
+      show dist f f = 0, from le_antisymm b a,
+    end,
+    show dist f f = 0, from classical.by_cases A B
+  end,
+  eq_of_dist_eq_zero := assume f g hfg, /- hfg : dist f g = 0 -/
+  begin
+    ext x, /- x : α, goal f x = g x -/
+    have a : dist (f x) (g x) ≤ 0 := by rw ← hfg; apply dist_coe_le_dist,
+    show f x = g x, by simpa using le_antisymm a dist_nonneg,
+  end,
+  dist_comm := assume f g, show dist f g = dist g f, by rw [dist_eq, dist_eq]; simp [dist_comm],
+  dist_triangle := assume f g h,
+  begin
+    have a : ∀x, dist (f x) (h x) ≤ dist f g + dist g h := λx,
+      calc dist (f x) (h x) ≤ dist (f x) (g x) + dist (g x) (h x) : dist_triangle _ _ _
+                        ... ≤ dist f g + dist g h : add_le_add dist_coe_le_dist dist_coe_le_dist,
+    have b : 0 + 0 ≤ dist f g + dist g h := add_le_add dist_nonneg' dist_nonneg',
+    simp at b,
+    show dist f h ≤ dist f g + dist g h, from dist_le_of_forall_dist_le a b
+  end }
+
+instance [inhabited β] : inhabited (bounded_continuous_function α β) :=
+{ default := ⟨λx, default β, ⟨continuous_const, ⟨0, by simp [le_refl]⟩⟩⟩ }
+
+/-- The evaluation map is continuous, as a joint function of `u` and `x`-/
+theorem continuous_eval : continuous (λ(p : (bounded_continuous_function α β) × α), p.1 p.2) :=
+begin
+  apply continuous_topo_metric.2,
+  rintros ⟨f, x⟩ ε εpos, /- f : bounded_continuous_function α β, x : α, ε : ℝ, εpos : ε > 0 -/
+  /- use the continuity of `f` to find a neighborhood of `x` where it varies at most by ε/2-/
+  rcases (continuous_topo_metric.1 (f.property.1)) x (ε/2) (half_pos εpos) with ⟨nx, nx_nbd, Hnx⟩,
+  /- nx : set α, nx_nbd : nx ∈ (nhds x).sets, Hnx : ∀ (b : α), b ∈ nx → dist (f.val b) (f.val x) < ε / 2-/
+  have A : ∀g y, dist g f < ε / 2 → y ∈ nx → dist (g y) (f x) < ε := λg y hg hy, calc
+    dist (g y) (f x) ≤ dist (g y) (f y) + dist (f y) (f x) : dist_triangle _ _ _
+                 ... ≤ dist g f + dist (f y) (f x) : add_le_add_right (dist_coe_le_dist) _
+                 ... < ε/2 + ε/2 : add_lt_add hg (Hnx _ hy)
+                 ... = ε : add_halves _,
+  have B : set.prod (ball f (ε/2)) nx ∈ (nhds (f, x)).sets :=
+    prod_mem_nhds_sets (ball_mem_nhds _ (half_pos εpos)) nx_nbd,
+  /- The product set `set.prod (ball f (ε/2)) nx` is a set around `(f, x)` where the
+  evaluation map varies by at most ε.-/
+  existsi set.prod (ball f (ε/2)) nx,
+  simp,
+  dsimp,
+  exact ⟨B, A⟩,
+end
+
+/-- In particular, when `x` is fixed, `f → f x` is continuous-/
+theorem continuous_evalx {x : α} : continuous (λ(f : (bounded_continuous_function α β)), f x) :=
+continuous.comp (continuous.prod_mk continuous_id continuous_const) continuous_eval
+
+/--When `f` is fixed, `x → f x` is also continuous, by definition-/
+theorem continuous_evalf {f : bounded_continuous_function α β} : continuous (λx, f x) :=
+f.property.1
+
+/--Bounded continuous functions taking values in a complete space form a complete space.-/
+instance [complete_space β] : complete_space (bounded_continuous_function α β) :=
+begin
+  refine complete_of_cauchy_seq_tendsto _,
+  intros f hf,
+  /- f : ℕ → bounded_continuous_function α β, hf : cauchy_seq f.
+  We have to show that `f n` converges to a bounded continuous function.
+  For this, we prove pointwise convergence to define the limit, then check
+  it is a continuous bounded function, and then check the norm convergence. -/
+  rcases cauchy_seq_iff_le_tendsto_0.1 hf with ⟨b, ⟨b_bound, b_lim⟩⟩,
+  have I : ∀ x n m N, N ≤ n → N ≤ m → dist (f n x) (f m x) ≤ b N := λx n m N hn hm,
+    calc dist (f n x) (f m x) ≤ dist (f n) (f m) : dist_coe_le_dist
+                          ... ≤ b N : b_bound n m N hn hm,
+  have A : ∀x, cauchy_seq (λn, f n x) := λx, cauchy_seq_iff_le_tendsto_0.2 ⟨b, ⟨I x, b_lim⟩⟩,
+  have B : ∀x, ∃y, tendsto (λn, f n x) at_top (nhds y) := λx, cauchy_seq_tendsto_of_complete (A x),
+  choose F hF using B,
+  /- F : α → β,  hF : ∀ (x : α), tendsto (λ (n : ℕ), f n x) at_top (nhds (F x))
+  `F` is the desired limit function. Check that it is uniformly approximated by `f N`-/
+  have b_bound_x : ∀x N, dist (f N x) (F x) ≤ b N :=
+  begin
+    intros x N,
+    have a : tendsto (λn, dist (f N x) (f n x)) at_top (nhds (dist (f N x) (F x))) :=
+      tendsto_dist tendsto_const_nhds (hF x),
+    have b : tendsto (λn, b N) at_top (nhds (b N)) := tendsto_const_nhds,
+    apply le_of_tendsto (by simp) a b _ ,
+    simp,
+    exact ⟨N, λn hn, I x N n N (le_refl N) hn⟩,
+  end,
+  /- Check that `F` is continuous -/
+  have F_cont : continuous F :=
+  begin
+    have : ∀ε>(0:ℝ), ∃N, ∀y, dist (f N y) (F y) ≤ ε :=
+    begin
+      assume ε εpos,
+      rw tendsto_at_top_metric at b_lim,
+      rcases b_lim ε εpos with ⟨N, hN⟩,
+      exact ⟨N, λy, calc
+        dist (f N y) (F y) ≤ b N : b_bound_x y N
+        ... ≤ dist (b N) 0 : begin simp, show b N ≤ abs(b N), from le_abs_self _ end
+        ... ≤ ε : le_of_lt (hN N (le_refl N))⟩
+    end,
+    exact continuous_of_uniform_limit_of_continuous this (λN, (f N).property.1)
+  end,
+  /- Check that `F` is bounded -/
+  have F_bound : ∃C, ∀x y, dist (F x) (F y) ≤ C :=
+  begin
+    rcases (f 0).property.2 with ⟨C, hC⟩,
+    existsi b 0 + C + b 0,
+    intros x y,
+    calc dist (F x) (F y) ≤ dist (F x) (f 0 x) + dist (f 0 x) (f 0 y) + dist (f 0 y) (F y) : dist_triangle4 _ _ _ _
+         ... = dist (f 0 x) (F x) + dist (f 0 x) (f 0 y) + dist (f 0 y) (F y) : by simp [dist_comm]
+         ... ≤ b 0 + C + b 0 : add_le_add (add_le_add (b_bound_x x 0) (hC x y)) (b_bound_x y 0)
+  end,
+  /- We can now define the bounded continuous function `flim` associated to `F`-/
+  let flim := (⟨F, ⟨F_cont, F_bound⟩⟩ : bounded_continuous_function α β),
+  /- Check that `flim` is close to `f N` in distance terms-/
+  have : ∀N, dist (f N) flim ≤ b N :=
+  begin
+    intros N,
+    apply dist_le_of_forall_dist_le,
+    { exact λx, b_bound_x x N },
+    { simpa using b_bound N N N (le_refl N) (le_refl N) }
+  end,
+  /- Deduce that `f N` tends to `flim`-/
+  have : tendsto f at_top (nhds flim) :=
+  begin
+    apply tendsto_iff_dist_tendsto_zero.2,
+    apply squeeze_zero _ ‹∀N, dist (f N) flim ≤ b N› ‹tendsto b at_top (nhds 0)›,
+    show ∀ (n : ℕ), 0 ≤ dist (f n) flim, from λn, dist_nonneg,
+  end,
+  exact ⟨flim, this⟩
+end
+
+/--Composition (in the target) of a bounded continuous function with a Lipschitz map again
+gives a bounded continuous function-/
+def comp {G : β → γ} (H : ∀x y, dist (G x) (G y) ≤ C * dist x y)
+  (f : bounded_continuous_function α β) : bounded_continuous_function α γ :=
+⟨λx, G (f x),
+begin
+  split,
+  { apply continuous.comp f.property.1 (continuous_of_lipschitz H) },
+  { rcases f.property.2 with ⟨D, hD⟩,
+    existsi max C 0 * D,
+    intros x y,
+    calc dist (G (f x)) (G (f y)) ≤ C * (dist (f x) (f y)) : H _ _
+      ... ≤ max C 0 * (dist (f x) (f y)) : mul_le_mul_of_nonneg_right (le_max_left C 0) (dist_nonneg)
+      ... ≤ max C 0 * D : mul_le_mul_of_nonneg_left (hD _ _) (le_max_right C 0) }
+end⟩
+
+/--The composition operator (in the target) with a Lipschitz map is continuous-/
+lemma continuous_comp {G : β → γ} (H : ∀x y, dist (G x) (G y) ≤ C * dist x y) :
+  continuous ((comp H) : bounded_continuous_function α β → bounded_continuous_function α γ) :=
+have A : ∀f g : bounded_continuous_function α β, dist (comp H f) (comp H g) ≤ max C 0 * dist f g :=
+begin
+  intros f g,
+  apply dist_le_of_forall_dist_le,
+  { assume x,
+    show dist (G (f x)) (G (g x)) ≤ max C 0 * dist f g, calc
+      dist (G (f x)) (G (g x)) ≤ C * dist (f x) (g x) : H _ _
+      ... ≤ max C 0 * dist (f x) (g x) : mul_le_mul_of_nonneg_right (le_max_left C 0) (dist_nonneg)
+      ... ≤ max C 0 * dist f g : mul_le_mul_of_nonneg_left dist_coe_le_dist (le_max_right C 0) },
+  { show max C 0 * dist f g ≥ 0, from mul_nonneg (le_max_right C 0) dist_nonneg }
+end,
+continuous_of_lipschitz A
+
+/--Restriction (in the target) of a bounded continuous function taking values in a subset-/
+def restr (s : set β) (f : bounded_continuous_function α β) (H : ∀x, f x ∈ s) : bounded_continuous_function α s :=
+⟨λx, ⟨f x, H x⟩, ⟨continuous_subtype_mk _ f.property.1, by cases f; cases f_property; assumption⟩⟩
+
+/--Arzelà–Ascoli theorem, saying that, on a compact space, a set of functions sharing
+a common modulus of continuity and taking values in a compact set forms a compact
+subset for the topology of uniform convergence. First version where the range is
+a compact space-/
+theorem compact_of_equicontinuous_of_compact_space {α : Type u} [metric_space α] [compact_space α] [compact_space β]
+  {b : ℝ → ℝ} (b_lim : tendsto b (nhds 0) (nhds 0)) :
+  compact {f : bounded_continuous_function α β | ∀x y, dist (f x) (f y) ≤ b (dist x y)} :=
+begin
+  apply compact_of_totally_bounded_is_closed,
+  /-We need to show that our set is closed and totally bounded (i.e., covered by finitely many
+  balls of radius ε, for any ε>0. Closedness is obvious from the expression of the set.-/
+  show is_closed {f : bounded_continuous_function α β | ∀ (x y : α), dist (f x) (f y) ≤ b (dist x y)},
+  begin
+    have a : is_closed (⋂x y, {f : bounded_continuous_function α β | dist (f x) (f y) ≤ b (dist x y)}) :=
+    begin
+      apply is_closed_Inter _,
+      assume x,
+      apply is_closed_Inter _,
+      assume y,
+      let D := (λf : bounded_continuous_function α β, dist (f x) (f y)),
+      have : continuous D := continuous_dist continuous_evalx continuous_evalx,
+      have A : {f : bounded_continuous_function α β | dist (f x) (f y) ≤ b (dist x y)}
+             = D⁻¹' {r | r ≤ b (dist x y)} := rfl,
+      rw A,
+      apply continuous_iff_is_closed.1 ‹continuous D› _ _,
+      simp [is_closed_le'],
+    end,
+    have : {f : bounded_continuous_function α β | ∀ (x y : α), dist (f x) (f y) ≤ b (dist x y)}
+      = (⋂x y, {f : bounded_continuous_function α β | dist (f x) (f y) ≤ b (dist x y)}) := by ext1; simp,
+    rw this,
+    exact a
+  end,
+  /- Let us now show that our set is totally bounded-/
+  show totally_bounded {f : bounded_continuous_function α β | ∀x y, dist (f x) (f y) ≤ b (dist x y)},
+  begin
+    apply totally_bounded_of_finite_discretization,
+    intros ε εpos,
+    /-We have to find a finite discretization of `u`, i.e., finite information
+    that is sufficient to reconstruct `u` up to ε. This information will be
+    provided by the values of `u` on a finite δ-dense set tα (where δ is suitably small),
+    slightly translated to fit in a finite (ε/8)-dense set tβ in the image. Such
+    sets exist by compactness of the source and range. Then, to check that these
+    data determine the function up to ε, one uses the control on the modulus of
+    continuity to extend the closeness on tα to closeness everywhere. -/
+    have εpos8 : ε/8 > 0 := by linarith,
+    rw [tendsto_nhds_of_metric] at b_lim,
+    rcases b_lim (ε/8) εpos8 with ⟨δ, δpos, hδ⟩,
+    have : ∃tα ⊆ (univ : set α), (finite tα ∧ univ ⊆ (⋃x∈tα, ball x δ)) :=
+      finite_cover_balls_of_compact compact_univ δpos,
+    rcases this with ⟨tα, _, ⟨finite_tα, htα⟩⟩,
+    /- tα : set α, finite_tα : finite tα, htα : univ ⊆ ⋃x ∈ tα, ball x δ-/
+    have : ∃tβ ⊆ (univ : set β), (finite tβ ∧ univ ⊆ (⋃y∈tβ, ball y (ε/8))) :=
+      finite_cover_balls_of_compact compact_univ εpos8,
+    rcases this with ⟨tβ, _, ⟨finite_tβ, htβ⟩⟩,
+    /-tβ : set β, finite_tβ : finite tβ, htβ : univ ⊆ ⋃y ∈ tβ, ball y (ε / 2)-/
+    have fin_univ : finite (univ : set (tα → tβ)) :=
+      finite_fun_of_finite_of_finite finite_tα finite_tβ,
+    /- Associate to every point `y` in the space a nearby point `F y` in tβ -/
+    have : ∀ y, ∃z∈tβ, dist y z < ε/8 :=
+      λy, by simpa using htβ (mem_univ y),
+    choose F hF using this,
+    simp at hF,
+    /- F : β → β, hF : ∀ (y : β), F y ∈ tβ ∧ dist y (F y) < ε/8-/
+
+    /-Associate to every function a discrete approximation, mapping each point in `tα`
+    to a point in `tβ` close to its true image by the function.-/
+    let approx : (bounded_continuous_function α β) → (tα → tβ) := λf a, ⟨F (f a), (hF (f a)).1⟩,
+    /-If two functions have the same approximation, then they are within distance ε-/
+    have main : ∀f g ∈ {f : bounded_continuous_function α β | ∀ (x y : α), dist (f x) (f y) ≤ b (dist x y)},
+      approx f = approx g → dist f g < ε :=
+    begin
+      assume f g hf hg f_eq_g,
+      simp at hf hg,
+      have : ∀x, dist (f x) (g x) ≤ ε/2 := λx,
+      begin
+        have : ∃x' ∈ tα, dist x x' < δ := by simpa using htα (mem_univ x),
+        rcases this with ⟨x', ⟨x'tα, hx'⟩⟩,
+        have F_f_g : F (f x') = F (g x') := calc
+          F (f x') = approx f ⟨x', x'tα⟩ : rfl
+          ... = approx g ⟨x', x'tα⟩ : by rw [f_eq_g]
+          ... = F (g x') : rfl,
+        have bxx' : b (dist x x') ≤ ε/8 := calc
+          b (dist x x') ≤ abs(b(dist x x')) : le_abs_self _
+            ... = dist (b(dist x x')) 0 : by simp [real.dist_eq]
+            ... ≤ ε/8 : le_of_lt (hδ (by simpa [real.dist_eq] using hx')),
+        have bx'x : b (dist x' x) ≤ ε/8 := by rwa [dist_comm],
+        have : dist (f x') (g x') ≤ ε/4 := calc
+          dist (f x') (g x') ≤ dist (f x') (F (f x')) + dist (g x') (F (f x')) : dist_triangle_right _ _ _
+            ... = dist (f x') (F (f x')) + dist (g x') (F (g x')) : by rw [← F_f_g]
+            ... ≤ ε/8 + ε/8 : add_le_add (le_of_lt (hF (f x')).2) (le_of_lt (hF (g x')).2)
+            ... = ε/4 : by ring,
+        calc dist (f x) (g x) ≤ dist (f x) (f x') + dist (f x') (g x') + dist (g x') (g x) : dist_triangle4 _ _ _ _
+                ... ≤ b(dist x x') + ε/4 + b(dist x' x) : add_le_add (add_le_add (hf x x') (this)) (hg x' x)
+                ... ≤ ε/8 + ε/4 + ε/8 : add_le_add (add_le_add bxx' (le_refl _)) bx'x
+                ... = ε/2 : by ring,
+      end,
+      calc dist f g ≤ ε/2 : dist_le_of_forall_dist_le this (le_of_lt (half_pos εpos))
+             ... < ε : half_lt_self εpos,
+    end,
+    /-The discretization constructed above is good enough to conclude-/
+    existsi [(tα → tβ), univ, approx],
+    simp at main,
+    simp [fin_univ],
+    exact main,
+  end
+end
+
+/-Arzelà–Ascoli theorem, saying that, on a compact space, a set of functions sharing
+a common modulus of continuity and taking values in a compact set forms a compact
+subset for the topology of uniform convergence. Second version where the range is
+contained in a given compact set. This version follows from the first one, by reformulating
+it from the compact subtype to the compact subset.-/
+theorem compact_of_equicontinuous_of_compact_range {α : Type u} [metric_space α] [compact_space α]
+  {b : ℝ → ℝ} (b_lim : tendsto b (nhds 0) (nhds 0))
+  (s : set β) (hs : compact s):
+  compact {f : bounded_continuous_function α β | (∀x y, dist (f x) (f y) ≤ b (dist x y)) ∧ range f ⊆ s} :=
+begin
+  have H : ∀x y : s, dist (x : β) y ≤ 1 * dist x y :=
+    begin intros x y, cases y, cases x, dsimp at *, simp at *, refl end,
+  let F : bounded_continuous_function α s → bounded_continuous_function α β := comp H,
+  have A : F '' {f : bounded_continuous_function α s | (∀x y, dist (f x) (f y) ≤ b (dist x y))}
+    = {f : bounded_continuous_function α β | (∀x y, dist (f x) (f y) ≤ b (dist x y)) ∧ range f ⊆ s} :=
+  begin
+    have : ∀f x, F f x ∈ s := λf x, subtype.mem _,
+    ext f,
+    split,
+    { simp [range_subset_iff], tidy },
+    { simp [range_subset_iff],
+      intros hdist hrange,
+      existsi (restr s f hrange),
+      tidy },
+  end,
+  rw ← A,
+  show compact (F '' {f : bounded_continuous_function α s | (∀x y, dist (f x) (f y) ≤ b (dist x y))}),
+  begin
+    apply compact_image _ (continuous_comp H),
+    haveI : compact_space s := ⟨compact_iff_compact_univ.1 hs⟩,
+    exact compact_of_equicontinuous_of_compact_space b_lim
+  end
+end
+
+end --section
+
+section normed_group
+/-In this section, if β is a normed group, then we show that the space of bounded
+continuous functions from α to β inherits a normed group structure, by using
+pointwise operations and checking that they are compatible with the uniform distance.-/
+
+variables [topological_space α] [normed_group β]
+variables {f g : bounded_continuous_function α β} {x : α} {C : ℝ}
+
+instance : has_zero (bounded_continuous_function α β) :=
+{ zero := ⟨λx, 0, ⟨continuous_const,  ⟨0, by simp [le_refl]⟩⟩⟩ }
+
+@[simp] lemma coe_zero : (0 : bounded_continuous_function α β) x = 0 := rfl
+
+instance : has_norm (bounded_continuous_function α β) :=
+{ norm := λu, dist u 0 }
+
+lemma norm_coe_le_norm : norm (f x) ≤ norm f := calc
+  norm (f x) = dist (f x) ((0 : bounded_continuous_function α β) x) : by simp [dist_zero_right]
+  ... ≤ dist f 0 : dist_coe_le_dist
+  ... = norm f : rfl
+
+/--The pointwise sum of two bounded continuous functions is again bounded continuous.-/
+instance : has_add (bounded_continuous_function α β) :=
+{ add := λf g, ⟨λx, f x + g x,
+  begin
+    split,
+    { apply continuous_add f.property.1 g.property.1 },
+    { existsi (norm f + norm g) + (norm f + norm g),
+      have A : ∀x, dist (f x + g x) 0 ≤ norm f + norm g := λx, calc
+        dist (f x + g x) 0 = norm (f x + g x) : by rw dist_zero_right
+        ... ≤ norm (f x) + norm (g x) : norm_triangle _ _
+        ... ≤ norm f + norm g : add_le_add norm_coe_le_norm norm_coe_le_norm,
+      intros x y,
+      calc dist (f x + g x) (f y + g y) ≤ dist (f x + g x) 0 + dist (f y + g y) 0 : dist_triangle_right _ _ _
+          ... ≤ (norm f + norm g) + (norm f + norm g) : add_le_add (A x) (A y) }
+  end⟩ }
+
+/--The pointwise opposite of a bounded continuous function is again bounded continuous.-/
+instance : has_neg (bounded_continuous_function α β) :=
+{ neg := λf, ⟨λx, -f x,
+  begin
+    split,
+    { apply continuous_neg f.property.1 },
+    { have : ∀a b : β, dist (-a) (-b) = dist a b :=
+      begin
+        intros a b,
+        rw [dist_eq_norm, dist_eq_norm, norm_sub_rev],
+        simp,
+      end,
+      simp [this],
+      exact f.property.2 }
+  end⟩ }
+
+@[simp] lemma coe_add : (f + g) x = f x + g x := rfl
+@[simp] lemma coe_neg : (-f) x = - (f x) := rfl
+lemma forall_coe_zero_iff_zero : (∀x, f x = 0) ↔ f = 0 :=
+⟨by intros Hf; apply ext; simpa, by intros Hf; rw [Hf]; simp⟩
+
+instance : add_comm_group (bounded_continuous_function α β) :=
+{ add_assoc    := assume f g h, by ext; simp,
+  zero_add     := assume f, by ext; simp,
+  add_zero     := assume f, by ext; simp,
+  add_left_neg := assume f, by ext; simp,
+  add_comm     := assume f g, by ext; simp,
+  ..bounded_continuous_function.has_add,
+  ..bounded_continuous_function.has_neg,
+  ..bounded_continuous_function.has_zero }
+
+@[simp] lemma coe_diff : (f-g) x = f x - g x := rfl
+
+instance : normed_group (bounded_continuous_function α β) :=
+{ dist_eq := assume f g,
+  begin
+    have A : dist f g ≤ norm (f - g) :=
+    begin
+      apply dist_le_of_forall_dist_le _ dist_nonneg,
+      assume x,
+      calc dist (f x) (g x) = dist ((f - g) x) ((0 : bounded_continuous_function α β) x) : by simp [dist_eq_norm]
+           ... ≤ dist (f - g) 0 : dist_coe_le_dist
+    end,
+    have B : norm (f - g) ≤ dist f g :=
+    begin
+      apply dist_le_of_forall_dist_le _ dist_nonneg,
+      assume x,
+      calc dist (f x - g x) 0 = dist (f x) (g x) : by simp [dist_eq_norm]
+           ... ≤ dist f g : dist_coe_le_dist
+    end,
+    exact le_antisymm A B
+  end,
+  ..bounded_continuous_function.add_comm_group,
+  ..bounded_continuous_function.has_norm
+}
+
+end normed_group --section
+end bounded_continuous_function --namespace

--- a/analysis/topology/bounded_continuous_function.lean
+++ b/analysis/topology/bounded_continuous_function.lean
@@ -1,13 +1,13 @@
 /-
 Copyright (c) 2018 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Sébastien Gouëzel
+Authors: Sébastien Gouëzel, Mario Carneiro
 
 Type of bounded continuous functions taking values in a metric space, with
 the uniform distance.
--/
+ -/
 
-import analysis.normed_space data.real.cau_seq_filter tactic.tidy
+import analysis.normed_space data.real.cau_seq_filter
 
 noncomputable theory
 local attribute [instance] classical.decidable_inhabited classical.prop_decidable
@@ -17,552 +17,406 @@ open set lattice filter
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
 
-/--A locally uniform limit of continuous functions is continuous-/
+/-- A locally uniform limit of continuous functions is continuous -/
 lemma continuous_of_locally_uniform_limit_of_continuous [topological_space α] [metric_space β]
   {F : ℕ → α → β} {f : α → β}
-  (L : ∀x:α, ∃s ∈ (nhds x).sets, ∀ε>(0:ℝ), ∃N, ∀y∈s, dist (F N y) (f y) ≤ ε)
-  (C : ∀(n : ℕ), continuous (F n)) :
-  continuous f :=
-begin
-  rw continuous_topo_metric,
-  intros x ε εpos,
-  have ε4pos : ε / 4 > 0 := by linarith,
-  rcases L x with ⟨r, r_set, hr⟩,
-  rcases hr (ε/4) ε4pos with ⟨N, hN⟩,
-  rcases continuous_topo_metric.1 (C N) x (ε/4) ε4pos with ⟨s, ⟨s_set, hs⟩⟩,
-  existsi r ∩ s,
-  existsi (nhds x).inter_sets r_set s_set,
-  intros y yrs,
-  calc dist (f y) (f x) ≤ dist (f y) (F N y) + dist (F N y) (F N x) + dist (F N x) (f x) : dist_triangle4 _ _ _ _
-      ... ≤ (ε/4) + (ε/4) + (ε/4) :
-      begin
-        apply_rules [add_le_add, le_of_lt (hs y yrs.2), hN x (mem_of_nhds r_set)],
-        rw dist_comm,
-        apply hN _ yrs.1,
-      end
-      ... < ε : by linarith
+  (L : ∀x:α, ∃s ∈ (nhds x).sets, ∀ε>(0:ℝ), ∃n, ∀y∈s, dist (F n y) (f y) ≤ ε)
+  (C : ∀ n, continuous (F n)) : continuous f :=
+continuous_topo_metric.2 $ λ x ε ε0, begin
+  rcases L x with ⟨r, rx, hr⟩,
+  rcases hr (ε/2/2) (half_pos $ half_pos ε0) with ⟨n, hn⟩,
+  rcases continuous_topo_metric.1 (C n) x (ε/2) (half_pos ε0) with ⟨s, sx, hs⟩,
+  refine ⟨_, (nhds x).inter_sets rx sx, _⟩,
+  rintro y ⟨yr, ys⟩,
+  calc dist (f y) (f x)
+        ≤ dist (F n y) (F n x) + (dist (F n y) (f y) + dist (F n x) (f x)) : dist_triangle4_left _ _ _ _
+    ... < ε/2 + (ε/2/2 + ε/2/2) :
+      add_lt_add_of_lt_of_le (hs _ ys) (add_le_add (hn _ yr) (hn _ (mem_of_nhds rx)))
+    ... = ε : by rw [add_halves, add_halves]
 end
 
-/--A uniform limit of continuous functions is continuous-/
+/-- A uniform limit of continuous functions is continuous -/
 lemma continuous_of_uniform_limit_of_continuous [topological_space α] {β : Type v} [metric_space β]
-  {F : ℕ → α → β} {f : α → β}
-  (L : ∀ε>(0:ℝ), ∃N, ∀y, dist (F N y) (f y) ≤ ε)
-  (C : ∀(n : ℕ), continuous (F n)) :
-  continuous f :=
-begin
-  apply @continuous_of_locally_uniform_limit_of_continuous _ _ _ _ F f _ C,
-  exact λx, ⟨univ, by simpa [filter.univ_mem_sets] using L⟩
-end
+  {F : ℕ → α → β} {f : α → β} (L : ∀ε>(0:ℝ), ∃N, ∀y, dist (F N y) (f y) ≤ ε) :
+  (∀ n, continuous (F n)) → continuous f :=
+continuous_of_locally_uniform_limit_of_continuous $ λx,
+  ⟨univ, by simpa [filter.univ_mem_sets] using L⟩
 
-/--A Lipschitz function is continuous-/
+/-- A Lipschitz function is continuous -/
 lemma continuous_of_lipschitz [metric_space α] [metric_space β] {C : ℝ}
   {f : α → β} (H : ∀x y, dist (f x) (f y) ≤ C * dist x y) : continuous f :=
-begin
-  rw continuous_of_metric,
-  intros x ε εpos,
-  have : 0 < max C 1 := lt_of_lt_of_le zero_lt_one (le_max_right C 1),
-  existsi (ε/max C 1),
-  simp only [exists_prop],
-  split,
-  { apply div_pos εpos ‹0 < max C 1› },
-  { intros y hy, calc
-      dist (f y) (f x) ≤ C * dist y x : H y x
-      ... ≤ max C 1 * dist y x : mul_le_mul_of_nonneg_right (le_max_left C 1) (dist_nonneg)
-      ... < max C 1 * (ε/max C 1) : mul_lt_mul_of_pos_left hy ‹0 < max C 1›
-      ... = ε : mul_div_cancel' _ (ne_of_gt ‹0 < max C 1›) }
-end
+continuous_of_metric.2 $ λ x ε ε0,
+have 0 < max C 1 := lt_of_lt_of_le zero_lt_one (le_max_right C 1),
+⟨ε/max C 1, div_pos ε0 this, λ y hy, calc
+  dist (f y) (f x) ≤ C * dist y x : H y x
+  ... ≤ max C 1 * dist y x : mul_le_mul_of_nonneg_right (le_max_left C 1) dist_nonneg
+  ... < ε : (lt_div_iff' this).1 hy⟩
 
-/--The type of bounded continuous functions from a topological space to a metric space-/
+/-- The type of bounded continuous functions from a topological space to a metric space -/
 def bounded_continuous_function (α : Type u) (β : Type v) [topological_space α] [metric_space β] : Type (max u v) :=
-  {f : α → β // continuous f ∧ ∃C, ∀x y:α, dist (f x) (f y) ≤ C}
+{f : α → β // continuous f ∧ ∃C, ∀x y:α, dist (f x) (f y) ≤ C}
+
+local infixr ` →ᵇ `:25 := bounded_continuous_function
 
 namespace bounded_continuous_function
-
-section
+section basics
 variables [topological_space α] [metric_space β] [metric_space γ]
-variables {f g : bounded_continuous_function α β} {x : α} {C : ℝ}
+variables {f g : α →ᵇ β} {x : α} {C : ℝ}
 
-instance : has_coe_to_fun (bounded_continuous_function α β) :=  ⟨_, subtype.val⟩
+instance : has_coe_to_fun (α →ᵇ β) :=  ⟨_, subtype.val⟩
 
 lemma bounded_range : bounded (range f) :=
-bounded_range_iff.2 (f.property.2)
+bounded_range_iff.2 f.2.2
 
-/--If a function is continuous on a compact space, it is automatically bounded,
-and therefore gives rise to an element of the type of bounded continuous functions-/
-def mk_of_compact [compact_space α] (f : α → β) (hf : continuous f) : bounded_continuous_function α β :=
-⟨f, ⟨hf, by apply bounded_range_iff.1; rw ← image_univ; apply bounded_of_compact (compact_image compact_univ hf)⟩⟩
+/-- If a function is continuous on a compact space, it is automatically bounded,
+and therefore gives rise to an element of the type of bounded continuous functions -/
+def mk_of_compact [compact_space α] (f : α → β) (hf : continuous f) : α →ᵇ β :=
+⟨f, hf, bounded_range_iff.1 $ by rw ← image_univ; exact
+  bounded_of_compact (compact_image compact_univ hf)⟩
 
-/--If a function is bounded on a discrete space, it is automatically continuous,
-and therefore gives rise to an element of the type of bounded continuous functions-/
+/-- If a function is bounded on a discrete space, it is automatically continuous,
+and therefore gives rise to an element of the type of bounded continuous functions -/
 def mk_of_discrete [discrete_topology α] (f : α → β) (hf : ∃C, ∀x y, dist (f x) (f y) ≤ C) :
-  bounded_continuous_function α β :=
-⟨f, ⟨continuous_of_discrete_topology, hf⟩⟩
+  α →ᵇ β :=
+⟨f, continuous_of_discrete_topology, hf⟩
 
-/--The uniform distance between two bounded continuous functions-/
-instance : has_dist (bounded_continuous_function α β) :=
+/-- The uniform distance between two bounded continuous functions -/
+instance : has_dist (α →ᵇ β) :=
 ⟨λf g, Inf {C | C ≥ 0 ∧ ∀ x : α, dist (f x) (g x) ≤ C}⟩
 
 lemma dist_eq : dist f g = Inf {C | C ≥ 0 ∧ ∀ x : α, dist (f x) (g x) ≤ C} := rfl
 
-@[extensionality] lemma ext (H : ∀x, f x = g x) : f = g :=
-by apply subtype.eq; apply funext; assumption
-
-/--On an empty space, bounded continuous functions are at distance 0-/
-lemma dist_zero_of_empty (e : (univ : set α) = ∅) : dist f g = 0 :=
-have A : {C | C ≥ 0 ∧ ∀ x : α, dist (f x) (g x) ≤ C} = {C | C ≥ 0} :=
+lemma dist_set_exists : ∃ C, C ≥ 0 ∧ ∀ x : α, dist (f x) (g x) ≤ C :=
 begin
-  apply eq_of_subset_of_subset,
-  { exact λC h, h.1 },
-  { exact λC h, ⟨h, λx, by simpa [e] using ne_empty_of_mem (mem_univ x)⟩}
-end,
-by rw [dist_eq, A]; simp
-
-/--The pointwise distance is controlled by the distance between functions, by definition-/
-lemma dist_coe_le_dist : dist (f x) (g x) ≤ dist f g :=
-have A : ∃C, C ≥ 0 ∧ ∀ y : α, dist (f y) (g y) ≤ C :=
-begin
+  refine if h : nonempty α then _ else ⟨0, le_refl _, λ x, h.elim ⟨x⟩⟩,
+  cases h with x,
   rcases f.2 with ⟨_, Cf, hCf⟩, /- hCf : ∀ (x y : α), dist (f.val x) (f.val y) ≤ Cf -/
   rcases g.2 with ⟨_, Cg, hCg⟩, /- hCg : ∀ (x y : α), dist (g.val x) (g.val y) ≤ Cg -/
-  let C := max 0 (Cf + dist (f x) (g x) + Cg),
-  have : ∀ y, dist (f y) (g y) ≤ C := assume y, calc
-    dist (f y) (g y) ≤ dist (f y) (f x) + dist (f x) (g x) + dist (g x) (g y) : dist_triangle4 _ _ _ _
-                 ... ≤ Cf + dist (f x) (g x) + Cg : add_le_add (add_le_add_right (hCf _ _) _) (hCg _ _)
-                 ... ≤ C : le_max_right _ _,
-  exact ⟨C, ⟨le_max_left _ _, this⟩⟩
-end,
-le_cInf (ne_empty_iff_exists_mem.2 A) $ λb hb, hb.2 x
-
-/--The distance between two functions is controlled by the supremum of the pointwise distances-/
-lemma dist_le_of_forall_dist_le (H : ∀x:α, dist (f x) (g x) ≤ C) (Cnonneg : C ≥ (0 : ℝ)) :
-  dist f g ≤ C :=
-begin
-  have a : bdd_below {C | C ≥ 0 ∧ ∀x, dist (f x) (g x) ≤ C} :=
-    ⟨0, begin intros y hy, simp at hy, exact hy.1 end⟩,
-  have b : C ∈ {C | C ≥ 0 ∧ ∀x, dist (f x) (g x) ≤ C} :=
-    by simp; exact ⟨Cnonneg, H⟩,
-  show dist f g ≤ C, from cInf_le a b
+  let C := max 0 (dist (f x) (g x) + (Cf + Cg)),
+  exact ⟨C, le_max_left _ _, λ y, calc
+    dist (f y) (g y) ≤ dist (f x) (g x) + (dist (f x) (f y) + dist (g x) (g y)) : dist_triangle4_left _ _ _ _
+                ... ≤ dist (f x) (g x) + (Cf + Cg) : add_le_add_left (add_le_add (hCf _ _) (hCg _ _)) _
+                ... ≤ C : le_max_right _ _⟩
 end
 
-/-This lemma will be needed in the proof of the metric space instance, but it will become
+/-- The pointwise distance is controlled by the distance between functions, by definition -/
+lemma dist_coe_le_dist (x : α) : dist (f x) (g x) ≤ dist f g :=
+le_cInf (ne_empty_iff_exists_mem.2 dist_set_exists) $ λb hb, hb.2 x
+
+@[extensionality] lemma ext (H : ∀x, f x = g x) : f = g :=
+subtype.eq $ by ext; apply H
+
+/- This lemma will be needed in the proof of the metric space instance, but it will become
 useless afterwards as it will be superceded by the general result that the distance is nonnegative
-is metric spaces.-/
+is metric spaces. -/
 private lemma dist_nonneg' : 0 ≤ dist f g :=
-have A : (univ : set α) = ∅ → 0 ≤ dist f g := λh, by simp [dist_zero_of_empty h, le_refl],
-have B : (univ : set α) ≠ ∅ → 0 ≤ dist f g :=
+le_cInf (ne_empty_iff_exists_mem.2 dist_set_exists) (λ C, and.left)
+
+/-- The distance between two functions is controlled by the supremum of the pointwise distances -/
+lemma dist_le (C0 : (0 : ℝ) ≤ C) : dist f g ≤ C ↔ ∀x:α, dist (f x) (g x) ≤ C :=
+⟨λ h x, le_trans (dist_coe_le_dist x) h, λ H, cInf_le ⟨0, λ C, and.left⟩ ⟨C0, H⟩⟩
+
+/-- On an empty space, bounded continuous functions are at distance 0 -/
+lemma dist_zero_of_empty (e : ¬ nonempty α) : dist f g = 0 :=
+le_antisymm ((dist_le (le_refl _)).2 $ λ x, e.elim ⟨x⟩) dist_nonneg'
+
+/-- The type of bounded continuous functions, with the uniform distance, is a metric space. -/
+instance : metric_space (α →ᵇ β) :=
+{ dist_self := λ f, le_antisymm ((dist_le (le_refl _)).2 $ λ x, by simp) dist_nonneg',
+  eq_of_dist_eq_zero := λ f g hfg, by ext x; exact
+    eq_of_dist_eq_zero (le_antisymm (hfg ▸ dist_coe_le_dist _) dist_nonneg),
+  dist_comm := λ f g, by simp [dist_eq, dist_comm],
+  dist_triangle := λ f g h,
+    (dist_le (add_nonneg dist_nonneg' dist_nonneg')).2 $ λ x,
+      le_trans (dist_triangle _ _ _) (add_le_add (dist_coe_le_dist _) (dist_coe_le_dist _)) }
+
+def const (b : β) : α →ᵇ β := ⟨λx, b, continuous_const, 0, by simp [le_refl]⟩
+
+/-- If the target space is inhabited, so is the space of bounded continuous functions -/
+instance [inhabited β] : inhabited (α →ᵇ β) := ⟨const (default β)⟩
+
+/-- The evaluation map is continuous, as a joint function of `u` and `x` -/
+theorem continuous_eval : continuous (λ p : (α →ᵇ β) × α, p.1 p.2) :=
+continuous_topo_metric.2 $ λ ⟨f, x⟩ ε ε0,
+/- use the continuity of `f` to find a neighborhood of `x` where it varies at most by ε/2 -/
+let ⟨s, sx, Hs⟩ := continuous_topo_metric.1 f.2.1 x (ε/2) (half_pos ε0) in
+/- s : set α, sx : s ∈ (nhds x).sets, Hs : ∀ (b : α), b ∈ s → dist (f.val b) (f.val x) < ε / 2 -/
+⟨set.prod (ball f (ε/2)) s, prod_mem_nhds_sets (ball_mem_nhds _ (half_pos ε0)) sx,
+λ ⟨g, y⟩ ⟨hg, hy⟩, calc dist (g y) (f x)
+      ≤ dist (g y) (f y) + dist (f y) (f x) : dist_triangle _ _ _
+  ... < ε/2 + ε/2 : add_lt_add (lt_of_le_of_lt (dist_coe_le_dist _) hg) (Hs _ hy)
+  ... = ε : add_halves _⟩
+
+/-- In particular, when `x` is fixed, `f → f x` is continuous -/
+theorem continuous_evalx {x : α} : continuous (λ f : α →ᵇ β, f x) :=
+(continuous_id.prod_mk continuous_const).comp continuous_eval
+
+/-- When `f` is fixed, `x → f x` is also continuous, by definition -/
+theorem continuous_evalf {f : α →ᵇ β} : continuous f := f.2.1
+
+/-- Bounded continuous functions taking values in a complete space form a complete space. -/
+instance [complete_space β] : complete_space (α →ᵇ β) :=
+complete_of_cauchy_seq_tendsto $ λ (f : ℕ → α →ᵇ β) (hf : cauchy_seq f),
 begin
-  intro H, /- H : univ ≠ ∅ -/
-  rcases exists_mem_of_ne_empty H with ⟨x, _⟩, /- x : α -/
-  calc 0 ≤ dist (f x) (g x) : dist_nonneg
-     ... ≤ dist f g : dist_coe_le_dist
-end,
-show 0 ≤ dist f g, from classical.by_cases A B
-
-/--The type of bounded continuous functions, with the uniform distance, is a metric space.-/
-instance : metric_space (bounded_continuous_function α β) :=
-{ dist_self := assume f,
-  begin
-    have A : (univ : set α) = ∅ → dist f f = 0 := λh, dist_zero_of_empty h,
-    have B : (univ : set α) ≠ ∅ → dist f f = 0,
-    { intro H, /- H : univ ≠ ∅ -/
-      rcases exists_mem_of_ne_empty H with ⟨x, _⟩, /- x : α -/
-      have a : dist (f x) (f x) ≤ dist f f := dist_coe_le_dist,
-      simp only [dist_self] at a,
-      have b : dist f f ≤ 0 := dist_le_of_forall_dist_le (by simp [le_refl]) (le_refl _),
-      show dist f f = 0, from le_antisymm b a },
-    show dist f f = 0, from classical.by_cases A B
-  end,
-  eq_of_dist_eq_zero := assume f g hfg, /- hfg : dist f g = 0 -/
-  begin
-    ext x, /- x : α, goal f x = g x -/
-    have a : dist (f x) (g x) ≤ 0 := by rw ← hfg; apply dist_coe_le_dist,
-    show f x = g x, by simpa using le_antisymm a dist_nonneg,
-  end,
-  dist_comm := assume f g, show dist f g = dist g f, by rw [dist_eq, dist_eq]; simp [dist_comm],
-  dist_triangle := assume f g h,
-  begin
-    have a : ∀x, dist (f x) (h x) ≤ dist f g + dist g h := λx,
-      calc dist (f x) (h x) ≤ dist (f x) (g x) + dist (g x) (h x) : dist_triangle _ _ _
-                        ... ≤ dist f g + dist g h : add_le_add dist_coe_le_dist dist_coe_le_dist,
-    have b : 0 + 0 ≤ dist f g + dist g h := add_le_add dist_nonneg' dist_nonneg',
-    simp only [add_zero] at b,
-    show dist f h ≤ dist f g + dist g h, from dist_le_of_forall_dist_le a b
-  end }
-
-/--If the target space is inhabited, so is the space of bounded continuous functions-/
-instance [inhabited β] : inhabited (bounded_continuous_function α β) :=
-{ default := ⟨λx, default β, ⟨continuous_const, ⟨0, by simp [le_refl]⟩⟩⟩ }
-
-/-- The evaluation map is continuous, as a joint function of `u` and `x`-/
-theorem continuous_eval : continuous (λ(p : (bounded_continuous_function α β) × α), p.1 p.2) :=
-begin
-  apply continuous_topo_metric.2,
-  rintros ⟨f, x⟩ ε εpos, /- f : bounded_continuous_function α β, x : α, ε : ℝ, εpos : ε > 0 -/
-  /- use the continuity of `f` to find a neighborhood of `x` where it varies at most by ε/2-/
-  rcases (continuous_topo_metric.1 (f.property.1)) x (ε/2) (half_pos εpos) with ⟨nx, nx_nbd, Hnx⟩,
-  /- nx : set α, nx_nbd : nx ∈ (nhds x).sets, Hnx : ∀ (b : α), b ∈ nx → dist (f.val b) (f.val x) < ε / 2-/
-  have A : ∀g y, dist g f < ε / 2 → y ∈ nx → dist (g y) (f x) < ε := λg y hg hy, calc
-    dist (g y) (f x) ≤ dist (g y) (f y) + dist (f y) (f x) : dist_triangle _ _ _
-                 ... ≤ dist g f + dist (f y) (f x) : add_le_add_right (dist_coe_le_dist) _
-                 ... < ε/2 + ε/2 : add_lt_add hg (Hnx _ hy)
-                 ... = ε : add_halves _,
-  have B : set.prod (ball f (ε/2)) nx ∈ (nhds (f, x)).sets :=
-    prod_mem_nhds_sets (ball_mem_nhds _ (half_pos εpos)) nx_nbd,
-  /- The product set `set.prod (ball f (ε/2)) nx` is a set around `(f, x)` where the
-  evaluation map varies by at most ε.-/
-  existsi set.prod (ball f (ε/2)) nx,
-  simp only [and_imp, exists_prop, mem_ball, prod.forall, set.mem_prod],
-  dsimp,
-  exact ⟨B, A⟩,
-end
-
-/-- In particular, when `x` is fixed, `f → f x` is continuous-/
-theorem continuous_evalx {x : α} : continuous (λ(f : (bounded_continuous_function α β)), f x) :=
-continuous.comp (continuous.prod_mk continuous_id continuous_const) continuous_eval
-
-/--When `f` is fixed, `x → f x` is also continuous, by definition-/
-theorem continuous_evalf {f : bounded_continuous_function α β} : continuous (λx, f x) :=
-f.property.1
-
-/--Bounded continuous functions taking values in a complete space form a complete space.-/
-instance [complete_space β] : complete_space (bounded_continuous_function α β) :=
-begin
-  refine complete_of_cauchy_seq_tendsto _,
-  intros f hf,
-  /- f : ℕ → bounded_continuous_function α β, hf : cauchy_seq f.
-  We have to show that `f n` converges to a bounded continuous function.
+  /- We have to show that `f n` converges to a bounded continuous function.
   For this, we prove pointwise convergence to define the limit, then check
   it is a continuous bounded function, and then check the norm convergence. -/
-  rcases cauchy_seq_iff_le_tendsto_0.1 hf with ⟨b, ⟨b_bound, b_lim⟩⟩,
-  have I : ∀ x n m N, N ≤ n → N ≤ m → dist (f n x) (f m x) ≤ b N := λx n m N hn hm,
-    calc dist (f n x) (f m x) ≤ dist (f n) (f m) : dist_coe_le_dist
-                          ... ≤ b N : b_bound n m N hn hm,
-  have A : ∀x, cauchy_seq (λn, f n x) := λx, cauchy_seq_iff_le_tendsto_0.2 ⟨b, ⟨I x, b_lim⟩⟩,
-  have B : ∀x, ∃y, tendsto (λn, f n x) at_top (nhds y) := λx, cauchy_seq_tendsto_of_complete (A x),
-  choose F hF using B,
+  rcases cauchy_seq_iff_le_tendsto_0.1 hf with ⟨b, b0, b_bound, b_lim⟩,
+  have f_bdd := λx n m N hn hm, le_trans (dist_coe_le_dist x) (b_bound n m N hn hm),
+  have fx_cau : ∀x, cauchy_seq (λn, f n x) :=
+    λx, cauchy_seq_iff_le_tendsto_0.2 ⟨b, b0, f_bdd x, b_lim⟩,
+  choose F hF using λx, cauchy_seq_tendsto_of_complete (fx_cau x),
   /- F : α → β,  hF : ∀ (x : α), tendsto (λ (n : ℕ), f n x) at_top (nhds (F x))
-  `F` is the desired limit function. Check that it is uniformly approximated by `f N`-/
-  have b_bound_x : ∀x N, dist (f N x) (F x) ≤ b N,
-  { intros x N,
-    have a : tendsto (λn, dist (f N x) (f n x)) at_top (nhds (dist (f N x) (F x))) :=
-      tendsto_dist tendsto_const_nhds (hF x),
-    have b : tendsto (λn, b N) at_top (nhds (b N)) := tendsto_const_nhds,
-    apply le_of_tendsto_of_tendsto (by simp) a b _ ,
-    simp only [filter.mem_at_top_sets, set.mem_set_of_eq],
-    exact ⟨N, λn hn, I x N n N (le_refl N) hn⟩ },
-  /- Check that `F` is continuous -/
-  have F_cont : continuous F,
-  { refine continuous_of_uniform_limit_of_continuous _ (λN, (f N).property.1),
-    assume ε εpos,
-    rw tendsto_at_top_metric at b_lim,
-    rcases b_lim ε εpos with ⟨N, hN⟩,
+  `F` is the desired limit function. Check that it is uniformly approximated by `f N` -/
+  have fF_bdd : ∀x N, dist (f N x) (F x) ≤ b N :=
+    λ x N, le_of_tendsto (by simp)
+      (tendsto_dist tendsto_const_nhds (hF x))
+      (filter.mem_at_top_sets.2 ⟨N, λn hn, f_bdd x N n N (le_refl N) hn⟩),
+  refine ⟨⟨F, _, _⟩, _⟩,
+  { /- Check that `F` is continuous -/
+    refine continuous_of_uniform_limit_of_continuous (λ ε ε0, _) (λN, (f N).2.1),
+    rcases tendsto_at_top_metric.1 b_lim ε ε0 with ⟨N, hN⟩,
     exact ⟨N, λy, calc
-      dist (f N y) (F y) ≤ b N : b_bound_x y N
+      dist (f N y) (F y) ≤ b N : fF_bdd y N
       ... ≤ dist (b N) 0 : begin simp, show b N ≤ abs(b N), from le_abs_self _ end
       ... ≤ ε : le_of_lt (hN N (le_refl N))⟩ },
-  /- Check that `F` is bounded -/
-  have F_bound : ∃C, ∀x y, dist (F x) (F y) ≤ C,
-  { rcases (f 0).property.2 with ⟨C, hC⟩,
-    existsi b 0 + C + b 0,
-    intros x y,
-    calc dist (F x) (F y) ≤ dist (F x) (f 0 x) + dist (f 0 x) (f 0 y) + dist (f 0 y) (F y) : dist_triangle4 _ _ _ _
-         ... = dist (f 0 x) (F x) + dist (f 0 x) (f 0 y) + dist (f 0 y) (F y) : by simp [dist_comm]
-         ... ≤ b 0 + C + b 0 : add_le_add (add_le_add (b_bound_x x 0) (hC x y)) (b_bound_x y 0) },
-  /- We can now define the bounded continuous function `flim` associated to `F`-/
-  let flim := (⟨F, ⟨F_cont, F_bound⟩⟩ : bounded_continuous_function α β),
-  /- Check that `flim` is close to `f N` in distance terms-/
-  have : ∀N, dist (f N) flim ≤ b N,
-  { intros N,
-    apply dist_le_of_forall_dist_le,
-    { exact λx, b_bound_x x N },
-    { simpa using b_bound N N N (le_refl N) (le_refl N) }},
-  /- Deduce that `f N` tends to `flim`-/
-  have : tendsto f at_top (nhds flim),
-  { apply tendsto_iff_dist_tendsto_zero.2,
-    apply squeeze_zero _ ‹∀N, dist (f N) flim ≤ b N› ‹tendsto b at_top (nhds 0)›,
-    exact λn, dist_nonneg },
-  exact ⟨flim, this⟩
+  { /- Check that `F` is bounded -/
+    rcases (f 0).2.2 with ⟨C, hC⟩,
+    exact ⟨C + (b 0 + b 0), λ x y, calc
+      dist (F x) (F y) ≤ dist (f 0 x) (f 0 y) + (dist (f 0 x) (F x) + dist (f 0 y) (F y)) : dist_triangle4_left _ _ _ _
+         ... ≤ C + (b 0 + b 0) : add_le_add (hC x y) (add_le_add (fF_bdd x 0) (fF_bdd y 0))⟩ },
+  { /- Check that `F` is close to `f N` in distance terms -/
+    refine tendsto_iff_dist_tendsto_zero.2 (squeeze_zero (λ _, dist_nonneg) _ b_lim),
+    exact λ N, (dist_le (b0 _)).2 (λx, fF_bdd x N) }
 end
 
-/--Composition (in the target) of a bounded continuous function with a Lipschitz map again
-gives a bounded continuous function-/
-def comp {G : β → γ} (H : ∀x y, dist (G x) (G y) ≤ C * dist x y)
-  (f : bounded_continuous_function α β) : bounded_continuous_function α γ :=
-⟨λx, G (f x),
-begin
-  split,
-  { apply continuous.comp f.property.1 (continuous_of_lipschitz H) },
-  { rcases f.property.2 with ⟨D, hD⟩,
-    existsi max C 0 * D,
-    intros x y,
-    calc dist (G (f x)) (G (f y)) ≤ C * (dist (f x) (f y)) : H _ _
-      ... ≤ max C 0 * (dist (f x) (f y)) : mul_le_mul_of_nonneg_right (le_max_left C 0) (dist_nonneg)
-      ... ≤ max C 0 * D : mul_le_mul_of_nonneg_left (hD _ _) (le_max_right C 0) }
-end⟩
+/-- Composition (in the target) of a bounded continuous function with a Lipschitz map again
+gives a bounded continuous function -/
+def comp (G : β → γ) (H : ∀x y, dist (G x) (G y) ≤ C * dist x y)
+  (f : α →ᵇ β) : α →ᵇ γ :=
+⟨λx, G (f x), f.2.1.comp (continuous_of_lipschitz H),
+  let ⟨D, hD⟩ := f.2.2 in
+  ⟨max C 0 * D, λ x y, calc
+    dist (G (f x)) (G (f y)) ≤ C * dist (f x) (f y) : H _ _
+    ... ≤ max C 0 * dist (f x) (f y) : mul_le_mul_of_nonneg_right (le_max_left C 0) dist_nonneg
+    ... ≤ max C 0 * D : mul_le_mul_of_nonneg_left (hD _ _) (le_max_right C 0)⟩⟩
 
-/--The composition operator (in the target) with a Lipschitz map is continuous-/
+/-- The composition operator (in the target) with a Lipschitz map is continuous -/
 lemma continuous_comp {G : β → γ} (H : ∀x y, dist (G x) (G y) ≤ C * dist x y) :
-  continuous ((comp H) : bounded_continuous_function α β → bounded_continuous_function α γ) :=
-have A : ∀f g : bounded_continuous_function α β, dist (comp H f) (comp H g) ≤ max C 0 * dist f g :=
-begin
-  intros f g,
-  apply dist_le_of_forall_dist_le,
-  { assume x,
-    show dist (G (f x)) (G (g x)) ≤ max C 0 * dist f g, calc
-      dist (G (f x)) (G (g x)) ≤ C * dist (f x) (g x) : H _ _
-      ... ≤ max C 0 * dist (f x) (g x) : mul_le_mul_of_nonneg_right (le_max_left C 0) (dist_nonneg)
-      ... ≤ max C 0 * dist f g : mul_le_mul_of_nonneg_left dist_coe_le_dist (le_max_right C 0) },
-  { show max C 0 * dist f g ≥ 0, from mul_nonneg (le_max_right C 0) dist_nonneg }
-end,
-continuous_of_lipschitz A
+  continuous (comp G H : (α →ᵇ β) → α →ᵇ γ) :=
+continuous_of_lipschitz $ λ f g,
+(dist_le (mul_nonneg (le_max_right C 0) dist_nonneg)).2 $ λ x,
+calc dist (G (f x)) (G (g x)) ≤ C * dist (f x) (g x) : H _ _
+  ... ≤ max C 0 * dist (f x) (g x) : mul_le_mul_of_nonneg_right (le_max_left C 0) (dist_nonneg)
+  ... ≤ max C 0 * dist f g : mul_le_mul_of_nonneg_left (dist_coe_le_dist _) (le_max_right C 0)
 
-/--Restriction (in the target) of a bounded continuous function taking values in a subset-/
-def restr (s : set β) (f : bounded_continuous_function α β) (H : ∀x, f x ∈ s) : bounded_continuous_function α s :=
-⟨λx, ⟨f x, H x⟩, ⟨continuous_subtype_mk _ f.property.1, by cases f; cases f_property; assumption⟩⟩
+/-- Restriction (in the target) of a bounded continuous function taking values in a subset -/
+def cod_restrict (s : set β) (f : α →ᵇ β) (H : ∀x, f x ∈ s) : α →ᵇ s :=
+⟨λx, ⟨f x, H x⟩, continuous_subtype_mk _ f.2.1, f.2.2⟩
 
-end --section
+end basics
 
-namespace Arzela_Ascoli
-section
+section arzela_ascoli
 variables [topological_space α] [compact_space α] [metric_space β]
-variables {f g : bounded_continuous_function α β} {x : α} {C : ℝ}
+variables {f g : α →ᵇ β} {x : α} {C : ℝ}
 
-/-Arzela-Ascoli theorem asserts that, on a compact space, a set of functions sharing
+/- Arzela-Ascoli theorem asserts that, on a compact space, a set of functions sharing
 a common modulus of continuity and taking values in a compact set forms a compact
 subset for the topology of uniform convergence. In this section, we prove this theorem
-and several useful variations around it.-/
+and several useful variations around it. -/
 
-/--First version, with pointwise equicontinuity and range in a compact space-/
-theorem compact_of_closed_of_compact_space_of_equicontinuous [compact_space β]
-  (A : set (bounded_continuous_function α β))
+/-- First version, with pointwise equicontinuity and range in a compact space -/
+theorem arzela_ascoli₁ [compact_space β]
+  (A : set (α →ᵇ β))
   (closed : is_closed A)
-  (H : ∀(x:α) (ε > 0), ∃U ∈ (nhds x).sets, ∀ (y z ∈ U) (f : bounded_continuous_function α β),
+  (H : ∀ (x:α) (ε > 0), ∃U ∈ (nhds x).sets, ∀ (y z ∈ U) (f : α →ᵇ β),
     f ∈ A → dist (f y) (f z) < ε) :
   compact A :=
 begin
-  apply compact_of_totally_bounded_is_closed _ closed,
-  show totally_bounded A,
-  { apply totally_bounded_of_finite_discretization,
-    intros ε εpos,
-    /-We have to find a finite discretization of `u`, i.e., finite information
-    that is sufficient to reconstruct `u` up to ε. This information will be
-    provided by the values of `u` on a sufficiently dense set tα,
-    slightly translated to fit in a finite (ε/8)-dense set tβ in the image. Such
-    sets exist by compactness of the source and range. Then, to check that these
-    data determine the function up to ε, one uses the control on the modulus of
-    continuity to extend the closeness on tα to closeness everywhere. -/
-    have εpos8 : ε/8 > 0 := by linarith,
-    have : ∀x:α, ∃U, x ∈ U ∧ is_open U ∧ (∀ (y z ∈ U) (f : bounded_continuous_function α β),
-      f ∈ A → dist (f y) (f z) < ε/8),
-    { assume x,
-      rcases H x _ εpos8 with ⟨U, nhdsU, hU⟩,
-      rcases mem_nhds_sets_iff.1 nhdsU with ⟨V, V_sub_U, openV, hV⟩,
-      exact ⟨V, hV, openV, λy z hy hz f hf, hU y z (V_sub_U hy) (V_sub_U hz) f hf⟩ },
-    choose U hU using this,
-    /-For all x, the set hU x is an open set containing x on which the elements of A
-    fluctuate by at most ε/8.
-    We extract finitely many of these sets that cover the whole space, by compactness-/
-    have : ∃tα ⊆ (univ : set α), finite tα ∧ univ ⊆ ⋃x∈tα, U x,
-    { refine compact_elim_finite_subcover_image compact_univ _ _,
-      show ∀ (x : α), x ∈ univ → is_open (U x), from λx hx, (hU x).2.1,
-      show univ ⊆ ⋃ (i : α) (H : i ∈ univ), U i, from λx hx, mem_bUnion (mem_univ _) (hU x).1 },
-    rcases this with ⟨tα, _, ⟨finite_tα, htα⟩⟩,
-    /- tα : set α, finite_tα : finite tα, htα : univ ⊆ ⋃x ∈ tα, U x-/
-    have : ∃tβ ⊆ (univ : set β), (finite tβ ∧ univ ⊆ (⋃y∈tβ, ball y (ε/8))) :=
-      finite_cover_balls_of_compact compact_univ εpos8,
-    rcases this with ⟨tβ, _, ⟨finite_tβ, htβ⟩⟩,
-    /-tβ : set β, finite_tβ : finite tβ, htβ : univ ⊆ ⋃y ∈ tβ, ball y (ε / 2)-/
-    have fin_univ : finite (univ : set (tα → tβ)) :=
-      finite_fun_of_finite_of_finite finite_tα finite_tβ,
-    /- Associate to every point `y` in the space a nearby point `F y` in tβ -/
-    have : ∀ y, ∃z∈tβ, dist y z < ε/8 :=
-      λy, by simpa using htβ (mem_univ y),
-    choose F hF using this,
-    simp only [exists_prop] at hF,
-    /- F : β → β, hF : ∀ (y : β), F y ∈ tβ ∧ dist y (F y) < ε/8-/
+  refine compact_of_totally_bounded_is_closed _ closed,
+  refine totally_bounded_of_finite_discretization (λ ε ε0, _),
+  rcases dense ε0 with ⟨ε₁, ε₁0, εε₁⟩,
+  let ε₂ := ε₁/2/2,
+  /- We have to find a finite discretization of `u`, i.e., finite information
+  that is sufficient to reconstruct `u` up to ε. This information will be
+  provided by the values of `u` on a sufficiently dense set tα,
+  slightly translated to fit in a finite ε₂-dense set tβ in the image. Such
+  sets exist by compactness of the source and range. Then, to check that these
+  data determine the function up to ε, one uses the control on the modulus of
+  continuity to extend the closeness on tα to closeness everywhere. -/
+  have ε₂0 : ε₂ > 0 := half_pos (half_pos ε₁0),
+  have : ∀x:α, ∃U, x ∈ U ∧ is_open U ∧ ∀ (y z ∈ U) {f : α →ᵇ β},
+    f ∈ A → dist (f y) (f z) < ε₂ := λ x,
+      let ⟨U, nhdsU, hU⟩ := H x _ ε₂0,
+          ⟨V, VU, openV, xV⟩ := mem_nhds_sets_iff.1 nhdsU in
+      ⟨V, xV, openV, λy z hy hz f hf, hU y z (VU hy) (VU hz) f hf⟩,
+  choose U hU using this,
+  /- For all x, the set hU x is an open set containing x on which the elements of A
+  fluctuate by at most ε₂.
+  We extract finitely many of these sets that cover the whole space, by compactness -/
+  rcases compact_elim_finite_subcover_image compact_univ
+    (λx _, (hU x).2.1) (λx hx, mem_bUnion (mem_univ _) (hU x).1)
+    with ⟨tα, _, ⟨_⟩, htα⟩,
+  /- tα : set α, htα : univ ⊆ ⋃x ∈ tα, U x -/
+  rcases @finite_cover_balls_of_compact β _ _ compact_univ _ ε₂0
+    with ⟨tβ, _, ⟨_⟩, htβ⟩, resetI,
+  /- tβ : set β, htβ : univ ⊆ ⋃y ∈ tβ, ball y ε₂ -/
+  /- Associate to every point `y` in the space a nearby point `F y` in tβ -/
+  choose F hF using λy, show ∃z∈tβ, dist y z < ε₂, by simpa using htβ (mem_univ y),
+  /- F : β → β, hF : ∀ (y : β), F y ∈ tβ ∧ dist y (F y) < ε₂ -/
 
-    /-Associate to every function a discrete approximation, mapping each point in `tα`
-    to a point in `tβ` close to its true image by the function.-/
-    let approx : (bounded_continuous_function α β) → (tα → tβ) := λf a, ⟨F (f a), (hF (f a)).1⟩,
-    /-If two functions have the same approximation, then they are within distance ε-/
-    have main : ∀f g ∈ A, approx f = approx g → dist f g < ε,
-    { assume f g hf hg f_eq_g,
-      have : ∀x, dist (f x) (g x) ≤ ε/2 := λx,
-      begin
-        have : ∃x', x' ∈ tα ∧ x ∈ U x' := mem_bUnion_iff.1 (htα (mem_univ x)),
-        rcases this with ⟨x', ⟨x'tα, hx'⟩⟩,
-        have F_f_g : F (f x') = F (g x') := calc
-          F (f x') = approx f ⟨x', x'tα⟩ : rfl
-          ... = approx g ⟨x', x'tα⟩ : by rw [f_eq_g]
-          ... = F (g x') : rfl,
-        have fxx' : dist (f x) (f x') ≤ ε/8 := le_of_lt ((hU x').2.2 _ _ hx' ((hU x').1) _ hf),
-        have gx'x : dist (g x') (g x) ≤ ε/8 := le_of_lt ((hU x').2.2 _ _ ((hU x').1) hx' _ hg),
-        have : dist (f x') (g x') ≤ ε/4 := calc
-          dist (f x') (g x') ≤ dist (f x') (F (f x')) + dist (g x') (F (f x')) : dist_triangle_right _ _ _
-            ... = dist (f x') (F (f x')) + dist (g x') (F (g x')) : by rw [← F_f_g]
-            ... ≤ ε/8 + ε/8 : add_le_add (le_of_lt (hF (f x')).2) (le_of_lt (hF (g x')).2)
-            ... = ε/4 : by ring,
-        calc dist (f x) (g x) ≤ dist (f x) (f x') + dist (f x') (g x') + dist (g x') (g x) : dist_triangle4 _ _ _ _
-                ... ≤ ε/8 + ε/4 + ε/8 : add_le_add (add_le_add (fxx') (this)) (gx'x)
-                ... = ε/2 : by ring,
-      end,
-      calc dist f g ≤ ε/2 : dist_le_of_forall_dist_le this (le_of_lt (half_pos εpos))
-             ... < ε : half_lt_self εpos },
-    /-The discretization constructed above is good enough to conclude-/
-    existsi [(tα → tβ), univ, approx],
-    simpa [fin_univ] using main }
+  /- Associate to every function a discrete approximation, mapping each point in `tα`
+  to a point in `tβ` close to its true image by the function. -/
+  refine ⟨tα → tβ, by apply_instance, λ f a, ⟨F (f a), (hF (f a)).fst⟩, _⟩,
+  rintro ⟨f, hf⟩ ⟨g, hg⟩ f_eq_g,
+  /- If two functions have the same approximation, then they are within distance ε -/
+  refine lt_of_le_of_lt ((dist_le $ le_of_lt ε₁0).2 (λ x, _)) εε₁,
+  have : ∃x', x' ∈ tα ∧ x ∈ U x' := mem_bUnion_iff.1 (htα (mem_univ x)),
+  rcases this with ⟨x', x'tα, hx'⟩,
+  refine calc dist (f x) (g x)
+      ≤ dist (f x) (f x') + dist (g x) (g x') + dist (f x') (g x') : dist_triangle4_right _ _ _ _
+  ... ≤ ε₂ + ε₂ + ε₁/2 : le_of_lt (add_lt_add (add_lt_add _ _) _)
+  ... = ε₁ : by rw [add_halves, add_halves],
+  { exact (hU x').2.2 _ _ hx' ((hU x').1) hf },
+  { exact (hU x').2.2 _ _ hx' ((hU x').1) hg },
+  { have F_f_g : F (f x') = F (g x') :=
+      (congr_arg (λ f:tα → tβ, (f ⟨x', x'tα⟩ : β)) f_eq_g : _),
+    calc dist (f x') (g x')
+          ≤ dist (f x') (F (f x')) + dist (g x') (F (f x')) : dist_triangle_right _ _ _
+      ... = dist (f x') (F (f x')) + dist (g x') (F (g x')) : by rw F_f_g
+      ... < ε₂ + ε₂ : add_lt_add (hF (f x')).snd (hF (g x')).snd
+      ... = ε₁/2 : add_halves _ }
 end
 
-/--Second version, with pointwise equicontinuity and range in a compact subset-/
-theorem compact_of_closed_of_compact_range_of_equicontinuous
+/-- Second version, with pointwise equicontinuity and range in a compact subset -/
+theorem arzela_ascoli₂
   (s : set β) (hs : compact s)
-  (A : set (bounded_continuous_function α β))
+  (A : set (α →ᵇ β))
   (closed : is_closed A)
-  (in_s : ∀(f : bounded_continuous_function α β) (x : α), f ∈ A → f x ∈ s)
-  (H : ∀(x:α) (ε > 0), ∃U ∈ (nhds x).sets, ∀ (y z ∈ U) (f : bounded_continuous_function α β),
+  (in_s : ∀(f : α →ᵇ β) (x : α), f ∈ A → f x ∈ s)
+  (H : ∀(x:α) (ε > 0), ∃U ∈ (nhds x).sets, ∀ (y z ∈ U) (f : α →ᵇ β),
     f ∈ A → dist (f y) (f z) < ε) :
   compact A :=
-/-This version is deduced from the previous one by restricting to the compact type in the target,
-using compactness there and then lifting everything to the original space.-/
+/- This version is deduced from the previous one by restricting to the compact type in the target,
+using compactness there and then lifting everything to the original space. -/
 begin
-  have M : ∀x y : s, dist (x : β) y ≤ 1 * dist x y :=
-    begin intros x y, cases y, cases x, dsimp at *, simp at *, refl end,
-  let F : bounded_continuous_function α s → bounded_continuous_function α β := comp M,
-  let B := F⁻¹' A,
-  have : compact B,
-  { haveI : compact_space s := ⟨compact_iff_compact_univ.1 hs⟩,
-    apply compact_of_closed_of_compact_space_of_equicontinuous,
-    show is_closed B, from continuous_iff_is_closed.1 (continuous_comp M) _ closed,
-    assume x ε εpos,
-    rcases H x ε εpos with ⟨U, U_nhds, hU⟩,
-    existsi [U, U_nhds],
-    assume y z hy hz f hf,
+  have M : ∀x y : s, dist (x : β) y ≤ 1 * dist x y := λ x y, ge_of_eq (one_mul _),
+  let F : (α →ᵇ s) → α →ᵇ β := comp coe M,
+  refine compact_of_is_closed_subset
+    (compact_image (_ : compact (F ⁻¹' A)) (continuous_comp M)) closed (λ f hf, _),
+  { haveI : compact_space s := compact_iff_compact_space.1 hs,
+    refine arzela_ascoli₁ _ (continuous_iff_is_closed.1 (continuous_comp M) _ closed)
+      (λ x ε ε0, bex.imp_right (λ U U_nhds hU y z hy hz f hf, _) (H x ε ε0)),
     calc dist (f y) (f z) = dist (F f y) (F f z) : rfl
                         ... < ε : hU y z hy hz (F f) hf },
-  have : A ⊆ F '' B,
-  { assume f hf,
-    let g := restr s f (λx, in_s f x hf),
-    have fg : f = F g := by ext; by refl,
-    have : g ∈ B := by simp [B, fg.symm, hf],
-    rw fg,
-    apply mem_image_of_mem F ‹g ∈ B› },
-  apply compact_of_is_closed_subset (compact_image ‹compact B› (continuous_comp M)) closed this
+  { let g := cod_restrict s f (λx, in_s f x hf),
+    rw [show f = F g, by ext; refl] at hf ⊢,
+    exact ⟨g, hf, rfl⟩ }
 end
 
-/--Third (main) version, with pointwise equicontinuity and range in a compact subset, but
-without closedness. The closure is then compact-/
-theorem compact_closure_of_equicontinuous_of_compact_range
+/-- Third (main) version, with pointwise equicontinuity and range in a compact subset, but
+without closedness. The closure is then compact -/
+theorem arzela_ascoli
   (s : set β) (hs : compact s)
-  (A : set (bounded_continuous_function α β))
-  (in_s : ∀(f : bounded_continuous_function α β) (x : α), f ∈ A → f x ∈ s)
-  (H : ∀(x:α) (ε > 0), ∃U ∈ (nhds x).sets, ∀ (y z ∈ U) (f : bounded_continuous_function α β),
+  (A : set (α →ᵇ β))
+  (in_s : ∀(f : α →ᵇ β) (x : α), f ∈ A → f x ∈ s)
+  (H : ∀(x:α) (ε > 0), ∃U ∈ (nhds x).sets, ∀ (y z ∈ U) (f : α →ᵇ β),
     f ∈ A → dist (f y) (f z) < ε) :
   compact (closure A) :=
-/-This version is deduced from the previous one by checking that the closure of A, in
-addition to being closed, still satisfies the properties of compact range and equicontinuity-/
-begin
-  apply compact_of_closed_of_compact_range_of_equicontinuous s hs (closure A) (is_closed_closure),
-  show ∀ (f : bounded_continuous_function α β) (x : α), f ∈ closure A → f x ∈ s,
-  { assume f x hf,
-    have : f x ∈ closure s,
-    { apply mem_closure_iff'.2,
-      assume ε εpos,
-      rcases mem_closure_iff'.1 hf ε εpos with ⟨g, gA, dist_fg⟩,
-      exact ⟨g x, in_s g x gA, lt_of_le_of_lt dist_coe_le_dist dist_fg⟩ },
-    rwa closure_eq_iff_is_closed.2 (closed_of_compact _ hs) at this },
-  show ∀ (x:α) (ε > 0), ∃ U ∈ (nhds x).sets,
-       ∀ y z ∈ U, ∀ (f : bounded_continuous_function α β), f ∈ closure A → dist (f y) (f z) < ε,
-  { assume x ε εpos,
-    have ε3pos : ε/3 > 0 := by linarith,
-    rcases H x (ε/3) ε3pos with ⟨U, U_set, hU⟩,
-    existsi [U, U_set],
-    assume y z hy hz f hf,
-    rcases mem_closure_iff'.1 hf (ε/3) ε3pos with ⟨g, gA, dist_fg⟩,
-    calc dist (f y) (f z) ≤ dist (f y) (g y) + dist (g y) (g z) + dist (g z) (f z) : dist_triangle4 _ _ _ _
-        ... ≤ dist f g + dist (g y) (g z) + dist g f :
-          add_le_add (add_le_add dist_coe_le_dist (le_refl _)) dist_coe_le_dist
-        ... < ε/3 + ε/3 + ε/3 :
-          by apply add_lt_add (add_lt_add dist_fg (hU y z hy hz g gA)); rwa dist_comm at dist_fg
-        ... = ε : by ring }
-end
+/- This version is deduced from the previous one by checking that the closure of A, in
+addition to being closed, still satisfies the properties of compact range and equicontinuity -/
+arzela_ascoli₂ s hs (closure A) is_closed_closure
+  (λ f x hf, (mem_of_closed' (closed_of_compact _ hs)).2 $ λ ε ε0,
+    let ⟨g, gA, dist_fg⟩ := mem_closure_iff'.1 hf ε ε0 in
+    ⟨g x, in_s g x gA, lt_of_le_of_lt (dist_coe_le_dist _) dist_fg⟩)
+  (λ x ε ε0, show ∃ U ∈ (nhds x).sets,
+      ∀ y z ∈ U, ∀ (f : α →ᵇ β), f ∈ closure A → dist (f y) (f z) < ε,
+    begin
+      refine bex.imp_right (λ U U_set hU y z hy hz f hf, _) (H x (ε/2) (half_pos ε0)),
+      rcases mem_closure_iff'.1 hf (ε/2/2) (half_pos (half_pos ε0)) with ⟨g, gA, dist_fg⟩,
+      replace dist_fg := λ x, lt_of_le_of_lt (dist_coe_le_dist x) dist_fg,
+      calc dist (f y) (f z) ≤ dist (f y) (g y) + dist (f z) (g z) + dist (g y) (g z) : dist_triangle4_right _ _ _ _
+          ... < ε/2/2 + ε/2/2 + ε/2 :
+            add_lt_add (add_lt_add (dist_fg y) (dist_fg z)) (hU y z hy hz g gA)
+          ... = ε : by rw [add_halves, add_halves]
+    end)
 
-/-To apply the previous theorems, one needs to check the equicontinuity. An important
+/- To apply the previous theorems, one needs to check the equicontinuity. An important
 instance is when the source space is a metric space, and there is a fixed modulus of continuity
-for all the functions in the set A-/
+for all the functions in the set A -/
 
 lemma equicontinuous_of_continuity_modulus {α : Type u} [metric_space α]
   (b : ℝ → ℝ) (b_lim : tendsto b (nhds 0) (nhds 0))
-  (A : set (bounded_continuous_function α β))
-  (H : ∀(x y:α) (f : bounded_continuous_function α β), f ∈ A → dist (f x) (f y) ≤ b (dist x y)) :
-  ∀(x:α) (ε > 0), ∃U ∈ (nhds x).sets, ∀ (y z ∈ U) (f : bounded_continuous_function α β),
+  (A : set (α →ᵇ β))
+  (H : ∀(x y:α) (f : α →ᵇ β), f ∈ A → dist (f x) (f y) ≤ b (dist x y))
+  (x:α) (ε : ℝ) (ε0 : ε > 0) : ∃U ∈ (nhds x).sets, ∀ (y z ∈ U) (f : α →ᵇ β),
     f ∈ A → dist (f y) (f z) < ε :=
 begin
-  assume x ε εpos,
-  rw [tendsto_nhds_of_metric] at b_lim,
-  rcases b_lim ε εpos with ⟨δ, δpos, hδ⟩,
-  existsi [ball x (δ/2), ball_mem_nhds x (half_pos δpos)],
-  assume y z hy hz f hf,
+  rcases tendsto_nhds_of_metric.1 b_lim ε ε0 with ⟨δ, δ0, hδ⟩,
+  refine ⟨ball x (δ/2), ball_mem_nhds x (half_pos δ0), λ y z hy hz f hf, _⟩,
   have : dist y z < δ := calc
     dist y z ≤ dist y x + dist z x : dist_triangle_right _ _ _
     ... < δ/2 + δ/2 : add_lt_add hy hz
     ... = δ : add_halves _,
   calc
     dist (f y) (f z) ≤ b (dist y z) : H y z f hf
-    ... ≤ abs(b(dist y z)) : le_abs_self _
-    ... = dist (b(dist y z)) 0 : by simp [real.dist_eq]
+    ... ≤ abs (b (dist y z)) : le_abs_self _
+    ... = dist (b (dist y z)) 0 : by simp [real.dist_eq]
     ... < ε : hδ (by simpa [real.dist_eq] using this),
 end
 
-end --section
-end Arzela_Ascoli --namespace
-
+end arzela_ascoli
 
 section normed_group
-/-In this section, if β is a normed group, then we show that the space of bounded
+/- In this section, if β is a normed group, then we show that the space of bounded
 continuous functions from α to β inherits a normed group structure, by using
-pointwise operations and checking that they are compatible with the uniform distance.-/
+pointwise operations and checking that they are compatible with the uniform distance. -/
 
 variables [topological_space α] [normed_group β]
-variables {f g : bounded_continuous_function α β} {x : α} {C : ℝ}
+variables {f g : α →ᵇ β} {x : α} {C : ℝ}
 
-instance : has_zero (bounded_continuous_function α β) :=
-{ zero := ⟨λx, 0, ⟨continuous_const,  ⟨0, by simp [le_refl]⟩⟩⟩ }
+instance : has_zero (α →ᵇ β) := ⟨const 0⟩
 
-@[simp] lemma coe_zero : (0 : bounded_continuous_function α β) x = 0 := rfl
+@[simp] lemma coe_zero : (0 : α →ᵇ β) x = 0 := rfl
 
-instance : has_norm (bounded_continuous_function α β) :=
-{ norm := λu, dist u 0 }
+instance : has_norm (α →ᵇ β) := ⟨λu, dist u 0⟩
 
-lemma norm_coe_le_norm : norm (f x) ≤ norm f := calc
-  norm (f x) = dist (f x) ((0 : bounded_continuous_function α β) x) : by simp [dist_zero_right]
-  ... ≤ dist f 0 : dist_coe_le_dist
-  ... = norm f : rfl
+lemma norm_def : ∥f∥ = dist f 0 := rfl
 
-/--The pointwise sum of two bounded continuous functions is again bounded continuous.-/
-instance : has_add (bounded_continuous_function α β) :=
-{ add := λf g, ⟨λx, f x + g x, ⟨continuous_add f.property.1 g.property.1,
-    ⟨(norm f + norm g) + (norm f + norm g), λx y,
-      have A : ∀x, dist (f x + g x) 0 ≤ norm f + norm g := λx, calc
-        dist (f x + g x) 0 = norm (f x + g x) : by rw dist_zero_right
-        ... ≤ norm (f x) + norm (g x) : norm_triangle _ _
-        ... ≤ norm f + norm g : add_le_add norm_coe_le_norm norm_coe_le_norm,
-      calc dist (f x + g x) (f y + g y) ≤ dist (f x + g x) 0 + dist (f y + g y) 0 : dist_triangle_right _ _ _
-          ... ≤ (norm f + norm g) + (norm f + norm g) : add_le_add (A x) (A y) ⟩⟩⟩ }
+lemma norm_coe_le_norm (x : α) : ∥f x∥ ≤ ∥f∥ := calc
+  ∥f x∥ = dist (f x) ((0 : α →ᵇ β) x) : by simp [dist_zero_right]
+  ... ≤ ∥f∥ : dist_coe_le_dist _
 
-/--The pointwise opposite of a bounded continuous function is again bounded continuous.-/
-instance : has_neg (bounded_continuous_function α β) :=
-{ neg := λf, ⟨λx, -f x, ⟨continuous_neg f.property.1, begin
-    have : ∀a b : β, dist (-a) (-b) = dist a b :=
-      λa b, by rw [dist_eq_norm, dist_eq_norm, norm_sub_rev]; simp,
-    simp only [this],
-    exact f.property.2
-  end⟩⟩ }
+/-- The norm of a function is controlled by the supremum of the pointwise norms -/
+lemma norm_le (C0 : (0 : ℝ) ≤ C) : ∥f∥ ≤ C ↔ ∀x:α, ∥f x∥ ≤ C :=
+by simpa only [coe_zero, dist_zero_right] using @dist_le _ _ _ _ f 0 _ C0
+
+/-- The pointwise sum of two bounded continuous functions is again bounded continuous. -/
+instance : has_add (α →ᵇ β) :=
+⟨λf g, ⟨λx, f x + g x, continuous_add f.2.1 g.2.1, (∥f∥ + ∥g∥) + (∥f∥ + ∥g∥),
+  λ x y,
+    have ∀x, dist (f x + g x) 0 ≤ ∥f∥ + ∥g∥ := λx, calc
+      dist (f x + g x) 0 = ∥f x + g x∥ : dist_zero_right _
+      ... ≤ ∥f x∥ + ∥g x∥ : norm_triangle _ _
+      ... ≤ ∥f∥ + ∥g∥ : add_le_add (norm_coe_le_norm _) (norm_coe_le_norm _),
+    calc dist (f x + g x) (f y + g y) ≤ dist (f x + g x) 0 + dist (f y + g y) 0 : dist_triangle_right _ _ _
+        ... ≤ (∥f∥ + ∥g∥) + (∥f∥ + ∥g∥) : add_le_add (this x) (this y) ⟩⟩
+
+/-- The pointwise opposite of a bounded continuous function is again bounded continuous. -/
+instance : has_neg (α →ᵇ β) :=
+⟨λf, ⟨λx, -f x, continuous_neg f.2.1,
+  begin
+    have dn : ∀a b : β, dist (-a) (-b) = dist a b := λ a b,
+      by rw [dist_eq_norm, neg_sub_neg, ← dist_eq_norm, dist_comm],
+    simpa only [dn] using f.2.2
+  end⟩⟩
 
 @[simp] lemma coe_add : (f + g) x = f x + g x := rfl
 @[simp] lemma coe_neg : (-f) x = - (f x) := rfl
 lemma forall_coe_zero_iff_zero : (∀x, f x = 0) ↔ f = 0 :=
-⟨by intros Hf; apply ext; simpa, by intros Hf; rw [Hf]; simp⟩
+⟨@ext _ _ _ _ f 0, by rintro rfl _; refl⟩
 
-instance : add_comm_group (bounded_continuous_function α β) :=
+instance : add_comm_group (α →ᵇ β) :=
 { add_assoc    := assume f g h, by ext; simp,
   zero_add     := assume f, by ext; simp,
   add_zero     := assume f, by ext; simp,
@@ -572,51 +426,19 @@ instance : add_comm_group (bounded_continuous_function α β) :=
   ..bounded_continuous_function.has_neg,
   ..bounded_continuous_function.has_zero }
 
-@[simp] lemma coe_diff : (f-g) x = f x - g x := rfl
+@[simp] lemma coe_diff : (f - g) x = f x - g x := rfl
 
-instance : normed_group (bounded_continuous_function α β) :=
-{ dist_eq := assume f g,
-  begin
-    have A : dist f g ≤ norm (f - g),
-    { refine dist_le_of_forall_dist_le (λx, _) dist_nonneg,
-      calc dist (f x) (g x) = dist ((f - g) x) ((0 : bounded_continuous_function α β) x) : by simp [dist_eq_norm]
-           ... ≤ dist (f - g) 0 : dist_coe_le_dist },
-    have B : norm (f - g) ≤ dist f g,
-    { refine dist_le_of_forall_dist_le (λx, _) dist_nonneg,
-      calc dist (f x - g x) 0 = dist (f x) (g x) : by simp [dist_eq_norm]
-           ... ≤ dist f g : dist_coe_le_dist },
-    exact le_antisymm A B
-  end,
-  ..bounded_continuous_function.add_comm_group,
-  ..bounded_continuous_function.has_norm }
+instance : normed_group (α →ᵇ β) :=
+normed_group.of_add_dist (λ _, rfl) $ λ f g h,
+(dist_le dist_nonneg).2 $ λ x,
+le_trans (by rw [dist_eq_norm, dist_eq_norm, coe_add, coe_add,
+  add_sub_add_right_eq_sub]) (dist_coe_le_dist x)
 
 lemma abs_diff_coe_le_dist : norm (f x - g x) ≤ dist f g :=
-calc norm (f x - g x) = norm ((f - g) x) : by simp
-                  ... ≤ norm (f - g) : norm_coe_le_norm
-                  ... = dist f g : (normed_group.dist_eq _ _).symm
+by rw normed_group.dist_eq; exact @norm_coe_le_norm _ _ _ _ (f-g) x
 
-lemma coe_le_coe_add_dist {f g : bounded_continuous_function α ℝ} : f x ≤ g x + dist f g :=
-begin
-  have : f x - g x ≤ abs (f x - g x) := le_abs_self _,
-  have : abs (f x - g x) ≤ dist f g :=
-    by rw ← real.norm_eq_abs; exact abs_diff_coe_le_dist,
-  by linarith
-end
+lemma coe_le_coe_add_dist {f g : α →ᵇ ℝ} : f x ≤ g x + dist f g :=
+sub_le_iff_le_add'.1 $ (abs_le.1 $ @dist_coe_le_dist _ _ _ _ f g x).2
 
-/-- Constructing a bounded continuous function from a continuous function taking values in a normed
-group, that is pointwise bounded-/
-def normed_group.mk (f : α  → β) (C : ℝ) (H : ∀x, norm (f x) ≤ C) (Hf : continuous f) :
-  bounded_continuous_function α β :=
-⟨λn, f n, ⟨Hf, ⟨C + C, λm n,
-  calc dist (f m) (f n) ≤ dist (f m) 0 + dist (f n) 0 : dist_triangle_right _ _ _
-       ... = norm (f m) + norm (f n) : by simp
-       ... ≤ C + C : add_le_add (H m) (H n) ⟩⟩⟩
-
-/-- Constructing a bounded continuous function from a function on a discrete space taking values
-in a normed group, that is pointwise bounded-/
-def normed_group.mk_of_discrete [discrete_topology α] (f : α  → β) (C : ℝ) (H : ∀x, norm (f x) ≤ C) :
-  bounded_continuous_function α β :=
-bounded_continuous_function.normed_group.mk f C H continuous_of_discrete_topology
-
-end normed_group --section
-end bounded_continuous_function --namespace
+end normed_group
+end bounded_continuous_function

--- a/analysis/topology/continuity.lean
+++ b/analysis/topology/continuity.lean
@@ -922,6 +922,9 @@ compact_iff_compact_image_of_embedding embedding_subtype_val
 lemma compact_iff_compact_univ {s : set α} : compact s ↔ compact (univ : set (subtype s)) :=
 by rw [compact_iff_compact_in_subtype, image_univ, subtype_val_range]; refl
 
+lemma compact_iff_compact_space {s : set α} : compact s ↔ compact_space s :=
+compact_iff_compact_univ.trans ⟨λ h, ⟨h⟩, @compact_space.compact_univ _ _⟩
+
 end subtype
 
 section quotient

--- a/analysis/topology/continuity.lean
+++ b/analysis/topology/continuity.lean
@@ -52,6 +52,9 @@ lemma continuous_iff_tendsto {f : α → β} :
 lemma continuous_const {b : β} : continuous (λa:α, b) :=
 continuous_iff_tendsto.mpr $ assume a, tendsto_const_nhds
 
+lemma continuous_of_discrete_topology [discrete_topology α] {f : α → β} : continuous f :=
+λs hs, is_open_discrete _
+
 lemma continuous_iff_is_closed {f : α → β} :
   continuous f ↔ (∀s, is_closed s → is_closed (f ⁻¹' s)) :=
 ⟨assume hf s hs, hf (-s) hs,

--- a/analysis/topology/uniform_space.lean
+++ b/analysis/topology/uniform_space.lean
@@ -779,6 +779,9 @@ lemma totally_bounded_subset [uniform_space α] {s₁ s₂ : set α} (hs : s₁ 
   (h : totally_bounded s₂) : totally_bounded s₁ :=
 assume d hd, let ⟨t, ht₁, ht₂⟩ := h d hd in ⟨t, ht₁, subset.trans hs ht₂⟩
 
+lemma totally_bounded_empty [uniform_space α] : totally_bounded (∅ : set α) :=
+λ d hd, ⟨∅, finite_empty, empty_subset _⟩
+
 lemma totally_bounded_closure [uniform_space α] {s : set α} (h : totally_bounded s) :
   totally_bounded (closure s) :=
 assume t ht,

--- a/data/real/ennreal.lean
+++ b/data/real/ennreal.lean
@@ -84,6 +84,8 @@ by intro h; cases h; simp [h]⟩
 @[simp] lemma zero_eq_coe : 0 = (↑r : ennreal) ↔ 0 = r := coe_eq_coe
 @[simp] lemma coe_eq_one : (↑r : ennreal) = 1 ↔ r = 1 := coe_eq_coe
 @[simp] lemma one_eq_coe : 1 = (↑r : ennreal) ↔ 1 = r := coe_eq_coe
+@[simp] lemma coe_nonneg : 0 ≤ (↑r : ennreal) ↔ 0 ≤ r := coe_le_coe
+@[simp] lemma coe_pos : 0 < (↑r : ennreal) ↔ 0 < r := coe_lt_coe
 
 @[simp] lemma coe_add : ↑(r + p) = (r + p : ennreal) := with_top.coe_add
 @[simp] lemma coe_mul : ↑(r * p) = (r * p : ennreal) := with_top.coe_mul
@@ -161,7 +163,7 @@ lemma le_of_forall_epsilon_le : ∀{a b : ennreal}, (∀ε:nnreal, ε > 0 → b 
     by simp only [none_eq_top, some_eq_coe, coe_add.symm, coe_le_coe, coe_lt_top, true_implies_iff] at *;
       exact nnreal.le_of_forall_epsilon_le h
 
-protected lemma lt_iff_exists_rat_btwn :
+lemma lt_iff_exists_rat_btwn :
   a < b ↔ (∃q:ℚ, 0 ≤ q ∧ a < nnreal.of_real q ∧ (nnreal.of_real q:ennreal) < b) :=
 ⟨λ h,
   begin
@@ -171,6 +173,12 @@ protected lemma lt_iff_exists_rat_btwn :
     rcases (nnreal.lt_iff_exists_rat_btwn _ _).1 (coe_lt_coe.1 pc) with ⟨q, hq0, pq, qr⟩,
     exact ⟨q, hq0, coe_lt_coe.2 pq, lt_trans (coe_lt_coe.2 qr) cb⟩
   end,
+λ ⟨q, q0, qa, qb⟩, lt_trans qa qb⟩
+
+lemma lt_iff_exists_real_btwn :
+  a < b ↔ (∃r:ℝ, 0 ≤ r ∧ a < nnreal.of_real r ∧ (nnreal.of_real r:ennreal) < b) :=
+⟨λ h, let ⟨q, q0, aq, qb⟩ := ennreal.lt_iff_exists_rat_btwn.1 h in
+  ⟨q, rat.cast_nonneg.2 q0, aq, qb⟩,
 λ ⟨q, q0, qa, qb⟩, lt_trans qa qb⟩
 
 protected lemma exists_nat_gt {r : ennreal} (h : r ≠ ⊤) : ∃n:ℕ, r < n :=

--- a/data/real/nnreal.lean
+++ b/data/real/nnreal.lean
@@ -98,6 +98,7 @@ instance : decidable_linear_order ℝ≥0 :=
 
 protected lemma coe_le {r₁ r₂ : ℝ≥0} : r₁ ≤ r₂ ↔ (r₁ : ℝ) ≤ r₂ := iff.rfl
 protected lemma coe_lt {r₁ r₂ : ℝ≥0} : r₁ < r₂ ↔ (r₁ : ℝ) < r₂ := iff.rfl
+protected lemma coe_pos {r : ℝ≥0} : 0 < r ↔ (0 : ℝ) < r := iff.rfl
 
 instance : canonically_ordered_monoid ℝ≥0 :=
 { add_le_add_left       := assume a b h c, @add_le_add_left ℝ _ a b h c,
@@ -239,11 +240,14 @@ section of_real
 @[simp] lemma of_real_zero : nnreal.of_real 0 = 0 :=
 by simp [nnreal.of_real]; refl
 
-@[simp] lemma zero_lt_of_real (r : ℝ) : 0 < nnreal.of_real r ↔ 0 < r :=
+@[simp] lemma of_real_pos {r : ℝ} : 0 < nnreal.of_real r ↔ 0 < r :=
 by simp [nnreal.of_real, nnreal.coe_lt, lt_irrefl]
 
-@[simp] lemma of_real_eq_zero (r : ℝ) : nnreal.of_real r = 0 ↔ r ≤ 0 :=
-by simpa [-zero_lt_of_real] using (not_iff_not.2 (zero_lt_of_real r))
+@[simp] lemma of_real_eq_zero {r : ℝ} : nnreal.of_real r = 0 ↔ r ≤ 0 :=
+by simpa [-of_real_pos] using (not_iff_not.2 (@of_real_pos r))
+
+lemma of_real_of_nonpos {r : ℝ} : r ≤ 0 → nnreal.of_real r = 0 :=
+of_real_eq_zero.2
 
 @[simp] lemma of_real_coe {r : nnreal} : nnreal.of_real r = r :=
 nnreal.eq $ by simp [nnreal.of_real]
@@ -252,16 +256,17 @@ nnreal.eq $ by simp [nnreal.of_real]
   nnreal.of_real r ≤ nnreal.of_real p ↔ r ≤ p :=
 by simp [nnreal.coe_le, nnreal.of_real, hp]
 
-@[simp] lemma of_real_lt_of_real_iff {r p : ℝ}  :
+@[simp] lemma of_real_lt_of_real_iff' {r p : ℝ} :
   nnreal.of_real r < nnreal.of_real p ↔ r < p ∧ 0 < p :=
 by simp [nnreal.coe_lt, nnreal.of_real, lt_irrefl]
 
-@[simp] lemma of_real_add_of_real {r p : ℝ} (hr : 0 ≤ r) (hp : 0 ≤ p) :
-  nnreal.of_real r + nnreal.of_real p = nnreal.of_real (r + p) :=
-nnreal.eq $ by simp [nnreal.of_real, hr, hp, add_nonneg]
+lemma of_real_lt_of_real_iff {r p : ℝ} (h : 0 < p) :
+  nnreal.of_real r < nnreal.of_real p ↔ r < p :=
+of_real_lt_of_real_iff'.trans (and_iff_left h)
 
-lemma of_real_of_nonpos {r : ℝ} (h : r ≤ 0) : nnreal.of_real r = 0 :=
-by simp [nnreal.of_real, h]; refl
+@[simp] lemma of_real_add {r p : ℝ} (hr : 0 ≤ r) (hp : 0 ≤ p) :
+  nnreal.of_real (r + p) = nnreal.of_real r + nnreal.of_real p :=
+nnreal.eq $ by simp [nnreal.of_real, hr, hp, add_nonneg]
 
 lemma of_real_le_of_real {r p : ℝ} (h : r ≤ p) : nnreal.of_real r ≤ nnreal.of_real p :=
 nnreal.coe_le.2 $ max_le_max h $ le_refl _

--- a/data/set/basic.lean
+++ b/data/set/basic.lean
@@ -1044,11 +1044,7 @@ range_iff_surjective.2 quot.exists_rep
 by rw ← image_univ; simp [-image_univ, subtype_val_image]
 
 lemma range_const_subset {c : β} : range (λx:α, c) ⊆ {c} :=
-begin
-  assume x hx,
-  rcases mem_range.1 hx with ⟨y, hy⟩,
-  simpa using hy.symm
-end
+range_subset_iff.2 $ λ x, or.inl rfl
 
 end range
 

--- a/data/set/basic.lean
+++ b/data/set/basic.lean
@@ -1047,8 +1047,7 @@ lemma range_const_subset {c : β} : range (λx:α, c) ⊆ {c} :=
 begin
   assume x hx,
   rcases mem_range.1 hx with ⟨y, hy⟩,
-  simp,
-  exact hy.symm
+  simpa using hy.symm
 end
 
 end range

--- a/data/set/basic.lean
+++ b/data/set/basic.lean
@@ -1043,6 +1043,14 @@ range_iff_surjective.2 quot.exists_rep
   range (@subtype.val _ p) = {x | p x} :=
 by rw ← image_univ; simp [-image_univ, subtype_val_image]
 
+lemma range_const_subset {c : β} : range (λx:α, c) ⊆ {c} :=
+begin
+  assume x hx,
+  rcases mem_range.1 hx with ⟨y, hy⟩,
+  simp,
+  exact hy.symm
+end
+
 end range
 
 /-- The set `s` is pairwise `r` if `r x y` for all *distinct* `x y ∈ s`. -/

--- a/data/set/finite.lean
+++ b/data/set/finite.lean
@@ -284,6 +284,17 @@ theorem finite_seq {α β : Type u} {f : set (α → β)} {s : set α} :
   finite f → finite s → finite (f <*> s)
 | ⟨hf⟩ ⟨hs⟩ := by haveI := classical.dec_eq β; exactI ⟨fintype_seq _ _⟩
 
+/--The set of functions from a finite set to a finite set is finite-/
+lemma finite_fun_of_finite_of_finite {α : Type u} {β : Type v} {a : set α} {b : set β}
+  (ha : finite a) (hb : finite b) : finite (univ : set (a → b)) :=
+begin
+  haveI : decidable_eq α := classical.dec_eq α,
+  haveI : fintype a := finite.fintype ha,
+  haveI : fintype b := finite.fintype hb,
+  haveI F : fintype (univ : set (a → b)) := by apply_instance,
+  exact ⟨F⟩
+end
+
 end set
 
 namespace finset

--- a/data/set/finite.lean
+++ b/data/set/finite.lean
@@ -66,6 +66,9 @@ let ⟨s', h⟩ := hs.exists_finset in ⟨s', set.ext h⟩
 theorem finite_mem_finset (s : finset α) : finite {a | a ∈ s} :=
 ⟨fintype_of_finset s (λ _, iff.rfl)⟩
 
+theorem finite.of_fintype [fintype α] (s : set α) : finite s :=
+by classical; exact ⟨set_fintype s⟩
+
 instance decidable_mem_of_fintype [decidable_eq α] (s : set α) [fintype s] (a) : decidable (a ∈ s) :=
 decidable_of_iff _ mem_to_finset
 
@@ -283,17 +286,6 @@ by rw seq_eq_bind_map; apply set.fintype_bind'
 theorem finite_seq {α β : Type u} {f : set (α → β)} {s : set α} :
   finite f → finite s → finite (f <*> s)
 | ⟨hf⟩ ⟨hs⟩ := by haveI := classical.dec_eq β; exactI ⟨fintype_seq _ _⟩
-
-/--The set of functions from a finite set to a finite set is finite-/
-lemma finite_fun_of_finite_of_finite {α : Type u} {β : Type v} {a : set α} {b : set β}
-  (ha : finite a) (hb : finite b) : finite (univ : set (a → b)) :=
-begin
-  haveI : decidable_eq α := classical.dec_eq α,
-  haveI : fintype a := finite.fintype ha,
-  haveI : fintype b := finite.fintype hb,
-  haveI F : fintype (univ : set (a → b)) := by apply_instance,
-  exact ⟨F⟩
-end
 
 end set
 


### PR DESCRIPTION
The type of bounded continuous functions from a topological space to a metric space, with the corresponding uniform distance. We prove basic statements such as the completeness of the space when the target is complete, and the Arzela-Ascoli theorem saying that a set of functions with a common modulus of continuity is compact. When the target space is a normed space, we also put the canonical normed space structure on the space of bounded continuous functions, working pointwise and checking that everything is compatible with the distance.

I have completed the change to a more general formulation of Arzela-Ascoli, so this is ready for review.

TO CONTRIBUTORS:

Make sure you have:

 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [x] make sure definitions and lemmas are put in the right files
 * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
