### PR TITLE
fix(tactic/basic): use `lean.parser.of_tactic'` instead of builtin

### DIFF
--- a/tactic/basic.lean
+++ b/tactic/basic.lean
@@ -149,6 +149,12 @@ match r with
 | (exception f pos _) := exception f pos
 end
 
+-- Override the builtin `lean.parser.of_tactic` coe, which is broken.
+-- (See tests/tactics.lean for a failure case.)
+@[priority 2000]
+meta instance has_coe' {α} : has_coe (tactic α) (parser α) :=
+⟨of_tactic'⟩
+
 end lean.parser
 
 namespace tactic

--- a/tactic/explode.lean
+++ b/tactic/explode.lean
@@ -132,8 +132,7 @@ open interactive lean lean.parser interaction_monad.result
 @[user_command]
 meta def explode_cmd (_ : parse $ tk "#explode") : parser unit :=
 do n ← ident,
-  -- explode n  -- TODO(Mario): seems to cause a VM exception
-  of_tactic' (explode n)
+  explode n
 .
 
 -- #explode iff_true_intro


### PR DESCRIPTION
The implementation of `lean.parser.of_tactic : tactic \alpha -> lean.parser \alpha` is broken; when an exception occurs in the underlying tactic, it fails to be passed up to the `lean.parser` monad and instead a `vm_check` abort is fired (there is a (probably small) mistake in `lean`, but I haven't checked the code).

This is really lame, since it means reporting errors in commands or `user_notation` has to be manually routed through---you can't use the coercion, and its a pain if you don't know what the problem is to begin with.

I was going to submit a new `of_tactic_safe` version, but discovered that mathlib already has `of_tactic'` which avoids the problem. We just increase the priority of the instance so the non-broken version is used instead.

I wrote a little test to make sure it's working as well.

<br>
<br>

Make sure you have:

 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
