### PR TITLE
feat(category_theory/limit): limits and colimits

### DIFF
--- a/algebra/pi_instances.lean
+++ b/algebra/pi_instances.lean
@@ -11,7 +11,7 @@ import data.finset
 import tactic.pi_instances
 
 namespace pi
-universes u v
+universes u v w
 variable {I : Type u}     -- The indexing type
 variable {f : I → Type v} -- The family of types already equiped with instances
 variables (x y : Π i, f i) (i : I)
@@ -105,6 +105,21 @@ lemma finset_prod_apply {α : Type*} {β γ} [comm_monoid β] (a : α) (s : fins
   s.prod g a = s.prod (λc, g c a) :=
 show (s.val.map g).prod a = (s.val.map (λc, g c a)).prod,
   by rw [multiset_prod_apply, multiset.map_map]
+
+def is_ring_hom_pi
+  {α : Type u} {β : α → Type v} [R : Π a : α, ring (β a)]
+  {γ : Type w} [ring γ]
+  (f : Π a : α, γ → β a) [Rh : Π a : α, is_ring_hom (f a)] :
+  is_ring_hom (λ x b, f b x) :=
+begin
+  dsimp at *,
+  split,
+  -- It's a pity that these can't be done using `simp` lemmas.
+  { ext, rw [is_ring_hom.map_one (f x)], refl, },
+  { intros x y, ext1 z, rw [is_ring_hom.map_mul (f z)], refl, },
+  { intros x y, ext1 z, rw [is_ring_hom.map_add (f z)], refl, }
+end
+
 
 end pi
 

--- a/category_theory/category.lean
+++ b/category_theory/category.lean
@@ -24,8 +24,9 @@ namespace category_theory
 universes u v
 
 /-
-The propositional fields of `category` are annotated with the auto_param `obviously`, which is
-defined here as a [`replacer` tactic](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md#def_replacer).
+The propositional fields of `category` are annotated with the auto_param `obviously`,
+which is defined here as a
+[`replacer` tactic](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md#def_replacer).
 We then immediately set up `obviously` to call `tidy`. Later, this can be replaced with more
 powerful tactics.
 -/
@@ -43,13 +44,15 @@ class category (obj : Type u) : Type (max u (v+1)) :=
 (comp     : Π {X Y Z : obj}, hom X Y → hom Y Z → hom X Z)
 (id_comp' : ∀ {X Y : obj} (f : hom X Y), comp (id X) f = f . obviously)
 (comp_id' : ∀ {X Y : obj} (f : hom X Y), comp f (id Y) = f . obviously)
-(assoc'   : ∀ {W X Y Z : obj} (f : hom W X) (g : hom X Y) (h : hom Y Z), comp (comp f g) h = comp f (comp g h) . obviously)
+(assoc'   : ∀ {W X Y Z : obj} (f : hom W X) (g : hom X Y) (h : hom Y Z),
+  comp (comp f g) h = comp f (comp g h) . obviously)
 
 notation `𝟙` := category.id -- type as \b1
 infixr ` ≫ `:80 := category.comp -- type as \gg
 infixr ` ⟶ `:10 := category.hom -- type as \h
 
--- `restate_axiom` is a command that creates a lemma from a structure field, discarding any auto_param wrappers from the type.
+-- `restate_axiom` is a command that creates a lemma from a structure field,
+-- discarding any auto_param wrappers from the type.
 -- (It removes a backtick from the name, if it finds one, and otherwise adds "_lemma".)
 restate_axiom category.id_comp'
 restate_axiom category.comp_id'
@@ -57,8 +60,9 @@ restate_axiom category.assoc'
 attribute [simp] category.id_comp category.comp_id category.assoc
 
 /--
-A `large_category` has objects in one universe level higher than the universe level of the morphisms.
-It is useful for examples such as the category of types, or the category of groups, etc.
+A `large_category` has objects in one universe level higher than the universe level of
+the morphisms. It is useful for examples such as the category of types, or the category
+of groups, etc.
 -/
 abbreviation large_category (C : Type (u+1)) : Type (u+1) := category.{u+1 u} C
 /--
@@ -66,13 +70,23 @@ A `small_category` has objects and morphisms in the same universe level.
 -/
 abbreviation small_category (C : Type u)     : Type (u+1) := category.{u u} C
 
+instance pempty_category : small_category pempty :=
+{ hom  := λ X Y, pempty,
+  id   := by obviously,
+  comp := by obviously }
+
+instance punit_category : small_category punit :=
+{ hom  := λ X Y, punit,
+  id   := by obviously,
+  comp := by obviously }
+
 structure bundled (c : Type u → Type v) :=
 (α : Type u)
 [str : c α]
 
 instance (c : Type u → Type v) : has_coe_to_sort (bundled c) :=
 { S := Type u, coe := bundled.α }
- 
+
 def mk_ob {c : Type u → Type v} (α : Type u) [str : c α] : bundled c :=
 @bundled.mk c α str
 
@@ -82,7 +96,8 @@ In a typical example, `c` is the type class `topological_space` and `hom` is `co
 structure concrete_category {c : Type u → Type v}
   (hom : out_param $ ∀{α β : Type u}, c α → c β → (α → β) → Prop) :=
 (hom_id : ∀{α} (ia : c α), hom ia ia id)
-(hom_comp : ∀{α β γ} (ia : c α) (ib : c β) (ic : c γ) {f g}, hom ia ib f → hom ib ic g → hom ia ic (g ∘ f))
+(hom_comp : ∀{α β γ} (ia : c α) (ib : c β) (ic : c γ) {f g},
+  hom ia ib f → hom ib ic g → hom ia ic (g ∘ f))
 attribute [class] concrete_category
 
 instance {c : Type u → Type v} (hom : ∀{α β : Type u}, c α → c β → (α → β) → Prop)
@@ -91,15 +106,23 @@ instance {c : Type u → Type v} (hom : ∀{α β : Type u}, c α → c β → (
   id    := λa, ⟨@id a.1, h.hom_id a.2⟩,
   comp  := λa b c f g, ⟨g.1 ∘ f.1, h.hom_comp a.2 b.2 c.2 f.2 g.2⟩ }
 
-@[simp] lemma concrete_category_id {c : Type u → Type v} (hom : ∀{α β : Type u}, c α → c β → (α → β) → Prop)
+@[simp] lemma concrete_category_id
+  {c : Type u → Type v} (hom : ∀{α β : Type u}, c α → c β → (α → β) → Prop)
   [h : concrete_category @hom] (X : bundled c) : subtype.val (𝟙 X) = id := rfl
-@[simp] lemma concrete_category_comp {c : Type u → Type v} (hom : ∀{α β : Type u}, c α → c β → (α → β) → Prop)
-  [h : concrete_category @hom] {X Y Z : bundled c} (f : X ⟶ Y) (g : Y ⟶ Z): subtype.val (f ≫ g) = g.val ∘ f.val := rfl
+@[simp] lemma concrete_category_comp
+  {c : Type u → Type v} (hom : ∀{α β : Type u}, c α → c β → (α → β) → Prop)
+  [h : concrete_category @hom] {X Y Z : bundled c} (f : X ⟶ Y) (g : Y ⟶ Z) :
+  subtype.val (f ≫ g) = g.val ∘ f.val := rfl
 
 instance {c : Type u → Type v} (hom : ∀{α β : Type u}, c α → c β → (α → β) → Prop)
   [h : concrete_category @hom] {R S : bundled c} : has_coe_to_fun (R ⟶ S) :=
 { F := λ f, R → S,
   coe := λ f, f.1 }
+
+@[simp] lemma bundled_hom_coe
+  {c : Type u → Type v} (hom : ∀{α β : Type u}, c α → c β → (α → β) → Prop)
+  [h : concrete_category @hom] {R S : bundled c} (val : R → S) (prop) (r : R) :
+  (⟨val, prop⟩ : R ⟶ S) r = val r := rfl
 
 section
 variables {C : Type u} [𝒞 : category.{u v} C] {X Y Z : C}
@@ -125,7 +148,7 @@ universe u'
 instance ulift_category : category.{(max u u') v} (ulift.{u'} C) :=
 { hom  := λ X Y, (X.down ⟶ Y.down),
   id   := λ X, 𝟙 X.down,
-  comp := λ _ _ _ f g, f ≫ g }  
+  comp := λ _ _ _ f g, f ≫ g }
 
 -- We verify that this previous instance can lift small categories to large categories.
 example (D : Type u) [small_category D] : large_category (ulift.{u+1} D) := by apply_instance

--- a/category_theory/commas.lean
+++ b/category_theory/commas.lean
@@ -1,0 +1,106 @@
+-- Copyright (c) 2018 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Scott Morrison
+
+import category_theory.types
+import category_theory.isomorphism
+import category_theory.whiskering
+
+namespace category_theory
+
+universes u₁ v₁ u₂ v₂ u₃ v₃
+variables {A : Type u₁} [𝒜 : category.{u₁ v₁} A]
+variables {B : Type u₂} [ℬ : category.{u₂ v₂} B]
+variables {T : Type u₃} [𝒯 : category.{u₃ v₃} T]
+include 𝒜 ℬ 𝒯
+
+structure comma (L : A ⥤ T) (R : B ⥤ T) :=
+(left : A . obviously)
+(right : B . obviously)
+(hom : L.obj left ⟶ R.obj right)
+
+variables {L : A ⥤ T} {R : B ⥤ T}
+
+structure comma_morphism (X Y : comma L R) :=
+(left : X.left ⟶ Y.left . obviously)
+(right : X.right ⟶ Y.right . obviously)
+(w' : L.map left ≫ Y.hom = X.hom ≫ R.map right . obviously)
+
+restate_axiom comma_morphism.w'
+attribute [simp] comma_morphism.w
+
+namespace comma_morphism
+@[extensionality] lemma ext
+  {X Y : comma L R} {f g : comma_morphism X Y}
+  (l : f.left = g.left) (r : f.right = g.right) : f = g :=
+begin
+  cases f, cases g,
+  congr; assumption
+end
+end comma_morphism
+
+instance comma_category : category (comma L R) :=
+{ hom := comma_morphism,
+  id := λ X,
+  { left := 𝟙 X.left,
+    right := 𝟙 X.right },
+  comp := λ X Y Z f g,
+  { left := f.left ≫ g.left,
+    right := f.right ≫ g.right,
+    w' :=
+    begin
+      rw [functor.map_comp,
+          category.assoc,
+          g.w,
+          ←category.assoc,
+          f.w,
+          functor.map_comp,
+          category.assoc],
+    end }}
+
+namespace comma
+
+variables (L) (R)
+
+def fst : comma L R ⥤ A :=
+{ obj := λ X, X.left,
+  map := λ _ _ f, f.left }
+
+def snd : comma L R ⥤ B :=
+{ obj := λ X, X.right,
+  map := λ _ _ f, f.right }
+
+@[simp] lemma fst_obj {X : comma L R} : (fst L R).obj X = X.left := rfl
+@[simp] lemma snd_obj {X : comma L R} : (snd L R).obj X = X.right := rfl
+@[simp] lemma fst_map {X Y : comma L R} {f : X ⟶ Y} : (fst L R).map f = f.left := rfl
+@[simp] lemma snd_map {X Y : comma L R} {f : X ⟶ Y} : (snd L R).map f = f.right := rfl
+
+def nat_trans : fst L R ⋙ L ⟹ snd L R ⋙ R :=
+{ app := λ X, X.hom }
+
+variables {L₁ : A ⥤ T} {L₂ : A ⥤ T}
+variables {R₁ : B ⥤ T} {R₂ : B ⥤ T}
+
+def map_left (l : L₁ ⟹ L₂) : comma L₂ R ⥤ comma L₁ R :=
+{ obj := λ X,
+  { left  := X.left,
+    right := X.right,
+    hom   := l.app X.left ≫ X.hom },
+  map := λ X Y f,
+  { left  := f.left,
+    right := f.right,
+    w' := by tidy; rw [←category.assoc, l.naturality f.left, category.assoc]; tidy } }
+
+def map_right (r : R₁ ⟹ R₂) : comma L R₁ ⥤ comma L R₂ :=
+{ obj := λ X,
+  { left  := X.left,
+    right := X.right,
+    hom   := X.hom ≫ r.app X.right },
+  map := λ X Y f,
+  { left  := f.left,
+    right := f.right,
+    w' := by tidy; rw [←r.naturality f.right, ←category.assoc]; tidy } }
+
+end comma
+
+end category_theory

--- a/category_theory/const.lean
+++ b/category_theory/const.lean
@@ -33,7 +33,7 @@ section
 variables {D : Type u'} [𝒟 : category.{u' v} D]
 include 𝒟
 
-@[simp] def const_compose (X : C) (F : C ⥤ D) : 
+@[simp] def const_compose (X : C) (F : C ⥤ D) :
   (const J).obj (F.obj X) ≅ (const J).obj X ⋙ F :=
 { hom := { app := λ _, 𝟙 _ },
   inv := { app := λ _, 𝟙 _ } }
@@ -53,5 +53,7 @@ natural transformations from the constant functor with value `X` to `F`.
 -/
 def cones (F : J ⥤ C) : (Cᵒᵖ) ⥤ (Type v) :=
   (const (Jᵒᵖ)) ⋙ (op_inv J C) ⋙ (yoneda.obj F)
+def cocones (F : J ⥤ C) : C ⥤ (Type v) :=
+  (const J) ⋙ (coyoneda.obj F)
 
 end category_theory.functor

--- a/category_theory/const.lean
+++ b/category_theory/const.lean
@@ -51,9 +51,7 @@ natural transformations from the constant functor with value `X` to `F`.
 
 `cone F` is equivalent, in the obvious way, to `Σ X, F.cones X`.
 -/
-def cones (F : J ⥤ C) : (Cᵒᵖ) ⥤ (Type v) :=
-  (const (Jᵒᵖ)) ⋙ (op_inv J C) ⋙ (yoneda.obj F)
-def cocones (F : J ⥤ C) : C ⥤ (Type v) :=
-  (const J) ⋙ (coyoneda.obj F)
+def cones (F : J ⥤ C) : (Cᵒᵖ) ⥤ (Type v) := (const (Jᵒᵖ)) ⋙ (op_inv J C) ⋙ (yoneda.obj F)
+def cocones (F : J ⥤ C) : C ⥤ (Type v) := (const J) ⋙ (coyoneda.obj F)
 
 end category_theory.functor

--- a/category_theory/const.lean
+++ b/category_theory/const.lean
@@ -1,0 +1,57 @@
+-- Copyright (c) 2018 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Scott Morrison
+
+import category_theory.functor_category
+import category_theory.yoneda
+
+universes u u' v
+
+open category_theory
+
+namespace category_theory.functor
+
+variables (J : Type v) [small_category J]
+variables {C : Type u} [𝒞 : category.{u v} C]
+include 𝒞
+
+def const : C ⥤ (J ⥤ C) :=
+{ obj := λ X,
+  { obj := λ j, X,
+    map := λ j j' f, 𝟙 X },
+  map := λ X Y f, { app := λ j, f } }
+
+namespace const
+@[simp] lemma obj_obj (X : C) (j : J) : ((const J).obj X).obj j = X := rfl
+@[simp] lemma obj_map (X : C) {j j' : J} (f : j ⟶ j') : ((const J).obj X).map f = 𝟙 X := rfl
+@[simp] lemma map_app {X Y : C} (f : X ⟶ Y) (j : J) : ((const J).map f).app j = f := rfl
+end const
+
+variables (J) {C}
+
+section
+variables {D : Type u'} [𝒟 : category.{u' v} D]
+include 𝒟
+
+@[simp] def const_compose (X : C) (F : C ⥤ D) : 
+  (const J).obj (F.obj X) ≅ (const J).obj X ⋙ F :=
+{ hom := { app := λ _, 𝟙 _ },
+  inv := { app := λ _, 𝟙 _ } }
+
+@[simp] lemma const_compose_symm_app (X : C) (F : C ⥤ D) (j : J) :
+  (const_compose J X F).inv.app j = 𝟙 _ := rfl
+
+end
+
+variables {J C}
+
+/--
+`F.cones` is the functor assigning to an object `X` the type of
+natural transformations from the constant functor with value `X` to `F`.
+
+`cone F` is equivalent, in the obvious way, to `Σ X, F.cones X`.
+-/
+def cones (F : J ⥤ C) : (Cᵒᵖ) ⥤ (Type v) :=
+  (const (Jᵒᵖ)) ⋙ (op_inv J C) ⋙ (yoneda.obj F)
+
+end category_theory.functor

--- a/category_theory/discrete_category.lean
+++ b/category_theory/discrete_category.lean
@@ -1,0 +1,81 @@
+-- Copyright (c) 2017 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Stephen Morgan, Scott Morrison
+
+import data.ulift
+import category_theory.natural_transformation
+import category_theory.isomorphism
+import category_theory.functor_category
+
+namespace category_theory
+
+universes u₁ v₁ u₂ v₂
+
+def discrete (α : Type u₁) := α
+
+@[extensionality] lemma plift.ext {P : Prop} (a b : plift P) : a = b :=
+begin
+  cases a, cases b, refl
+end
+
+instance discrete_category (α : Type u₁) : small_category (discrete α) :=
+{ hom  := λ X Y, ulift (plift (X = Y)),
+  id   := by obviously,
+  comp := by obviously }
+
+-- TODO this needs to wait for equivalences to arrive
+-- example : equivalence.{u₁ u₁ u₁ u₁} punit (discrete punit) := by obviously
+
+def discrete.lift {α : Type u₁} {β : Type u₂} (f : α → β) : (discrete α) ⥤ (discrete β) :=
+{ obj := f,
+  map := λ X Y g, begin cases g, cases g, cases g, exact 𝟙 (f X) end }
+
+variables (J : Type v₂) [small_category J]
+
+variables (C : Type u₂) [𝒞 : category.{u₂ v₂} C]
+include 𝒞
+
+section forget
+
+@[simp] def discrete.forget : (J ⥤ C) ⥤ (discrete J ⥤ C) :=
+{ obj := λ F,
+  { obj := F.obj,
+    map := λ X Y f, F.map (eq_to_hom f.down.down) },
+  map := λ F G α,
+  { app := α.app } }
+
+end forget
+
+@[simp] lemma discrete.functor_map_id
+  (F : discrete J ⥤ C) (j : discrete J) (f : j ⟶ j) : F.map f = 𝟙 (F.obj j) :=
+begin
+  have h : f = 𝟙 j, cases f, cases f, ext,
+  rw h,
+  simp,
+end
+
+variables {C}
+
+namespace functor
+
+@[simp] def of_function {I : Type u₁} (F : I → C) : (discrete I) ⥤ C :=
+{ obj := F,
+  map := λ X Y f, begin cases f, cases f, cases f, exact 𝟙 (F X) end }
+
+end functor
+
+namespace nat_trans
+
+@[simp] def of_function {I : Type u₁} {F G : I → C} (f : Π i : I, F i ⟶ G i) :
+  (functor.of_function F) ⟹ (functor.of_function G) :=
+{ app := λ i, f i,
+  naturality' := λ X Y g,
+  begin
+    cases g, cases g, cases g,
+    dsimp [functor.of_function],
+    simp,
+  end }
+
+end nat_trans
+
+end category_theory

--- a/category_theory/discrete_category.lean
+++ b/category_theory/discrete_category.lean
@@ -18,6 +18,9 @@ begin
   cases a, cases b, refl
 end
 
+instance plift_subsingleton (P : Prop) : subsingleton (plift P) :=
+subsingleton.intro (λ a b, begin cases a, cases b, refl end)
+
 instance discrete_category (α : Type u₁) : small_category (discrete α) :=
 { hom  := λ X Y, ulift (plift (X = Y)),
   id   := by obviously,
@@ -35,16 +38,9 @@ variables (J : Type v₂) [small_category J]
 variables (C : Type u₂) [𝒞 : category.{u₂ v₂} C]
 include 𝒞
 
-section forget
-
-@[simp] def discrete.forget : (J ⥤ C) ⥤ (discrete J ⥤ C) :=
-{ obj := λ F,
-  { obj := F.obj,
-    map := λ X Y f, F.map (eq_to_hom f.down.down) },
-  map := λ F G α,
-  { app := α.app } }
-
-end forget
+@[simp] def discrete.forget : discrete J ⥤ J :=
+{ obj := λ X, X,
+  map := λ X Y f, eq_to_hom f.down.down }
 
 @[simp] lemma discrete.functor_map_id
   (F : discrete J ⥤ C) (j : discrete J) (f : j ⟶ j) : F.map f = 𝟙 (F.obj j) :=

--- a/category_theory/examples/CommRing/products.lean
+++ b/category_theory/examples/CommRing/products.lean
@@ -1,0 +1,32 @@
+import algebra.pi_instances
+import category_theory.examples.rings
+import category_theory.limits
+
+universes u v w
+
+namespace category_theory.examples
+
+open category_theory
+open category_theory.limits
+
+def CommRing.pi {β : Type u} (f : β → CommRing.{u}) : CommRing :=
+{ α := Π b : β, (f b), str := by apply_instance }
+
+def CommRing.pi_π {β : Type u} (f : β → CommRing) (b : β): CommRing.pi f ⟶ f b :=
+{ val := λ g, g b, property := by tidy }
+
+@[simp] def CommRing.hom_pi
+  {α : Type u} {β : α → CommRing} {γ : CommRing}
+  (f : Π a : α, γ ⟶ β a) : γ ⟶ CommRing.pi β :=
+{ val := λ x b, f b x,
+  property := begin convert pi.is_ring_hom_pi (λ a, (f a).val) end }
+
+local attribute [extensionality] subtype.eq
+
+instance CommRing_has_products : has_products.{v+1 v} CommRing :=
+{ fan := λ β f, { X := CommRing.pi f,
+                  π := { app := CommRing.pi_π f } },
+  is_product := λ β f, { lift := λ s, CommRing.hom_pi (λ j, s.π.app j),
+                         uniq' := begin tidy, rw ←w, tidy, end } }.
+
+end category_theory.examples

--- a/category_theory/examples/Top/products.lean
+++ b/category_theory/examples/Top/products.lean
@@ -1,0 +1,30 @@
+import category_theory.examples.topological_spaces
+import category_theory.limits.products
+import analysis.topology.continuity
+
+universes u v w
+
+open category_theory.limits
+open category_theory.examples
+
+def Top.pi {β : Type u} (f : β → Top.{u}) : Top :=
+{ α := Π b : β, (f b), str := by apply_instance }
+
+def Top.pi_π {β : Type u} (f : β → Top) (b : β): Top.pi f ⟶ f b :=
+{ val := λ g, g b, property := continuous_apply _ }
+
+@[simp] def Top.hom_pi
+  {α : Type u} {β : α → Top} {γ : Top}
+  (f : Π a : α, γ ⟶ β a) : γ ⟶ Top.pi β :=
+{ val := λ x b, f b x,
+  property := continuous_pi (λ a, (f a).property) }
+
+local attribute [extensionality] subtype.eq
+
+instance : has_products.{u+1 u} Top :=
+{ fan := λ β f,
+  { X := Top.pi f,
+    π := { app := Top.pi_π f } },
+  is_product := λ β f,
+  { lift := λ s, Top.hom_pi (λ j, s.π.app j),
+    uniq' := λ s m w, begin tidy, rw ←w, tidy, end } }.

--- a/category_theory/examples/monoids.lean
+++ b/category_theory/examples/monoids.lean
@@ -7,7 +7,7 @@ Introduce Mon -- the category of monoids.
 Currently only the basic setup.
 -/
 
-import category_theory.embedding
+import category_theory.fully_faithful
 import algebra.ring
 
 universes u v
@@ -39,11 +39,12 @@ instance concrete_is_comm_monoid_hom : concrete_category @is_comm_monoid_hom :=
 ⟨by introsI α ia; apply_instance,
   by introsI α β γ ia ib ic f g hf hg; apply_instance⟩
 
-instance CommMon_hom_is_comm_monoid_hom {R S : CommMon} (f : R ⟶ S) : is_comm_monoid_hom (f : R → S) := f.2
+instance CommMon_hom_is_comm_monoid_hom {R S : CommMon} (f : R ⟶ S) : 
+  is_comm_monoid_hom (f : R → S) := f.2
 
 namespace CommMon
 /-- The forgetful functor from commutative monoids to monoids. -/
-def forget_to_Mon : CommMon ⥤ Mon := 
+def forget_to_Mon : CommMon ⥤ Mon :=
 concrete_functor
   (by intros _ c; exact { ..c })
   (by introsI _ _ _ _ f i;  exact { ..i })

--- a/category_theory/examples/rings.lean
+++ b/category_theory/examples/rings.lean
@@ -8,7 +8,7 @@ Currently only the basic setup.
 -/
 
 import category_theory.examples.monoids
-import category_theory.embedding
+import category_theory.fully_faithful
 import algebra.ring
 
 universes u v
@@ -33,21 +33,26 @@ instance Ring_hom_is_ring_hom {R S : Ring} (f : R ⟶ S) : is_ring_hom (f : R �
 
 instance (x : CommRing) : comm_ring x := x.str
 
-@[reducible] def is_comm_ring_hom {α β} [comm_ring α] [comm_ring β] (f : α → β) : Prop :=
-is_ring_hom f
+-- Here we don't use the `concrete` machinery,
+-- because it would require introducing a useless synonym for `is_ring_hom`.
+instance : category CommRing :=
+{ hom := λ R S, { f : R → S // is_ring_hom f },
+  id := λ R, ⟨ id, by resetI; apply_instance ⟩,
+  comp := λ R S T g h, ⟨ h.1 ∘ g.1, begin haveI := g.2, haveI := h.2, apply_instance end ⟩ }
 
-instance concrete_is_comm_ring_hom : concrete_category @is_comm_ring_hom :=
-⟨by introsI α ia; apply_instance,
-  by introsI α β γ ia ib ic f g hf hg; apply_instance⟩
+instance CommRing_hom_coe {R S : CommRing} : has_coe_to_fun (R ⟶ S) :=
+{ F := λ f, R → S,
+  coe := λ f, f.1 }
 
-instance CommRing_hom_is_comm_ring_hom {R S : CommRing} (f : R ⟶ S) : is_comm_ring_hom (f : R → S) := f.2
+@[simp] lemma CommRing_hom_coe_app {R S : CommRing} (f : R ⟶ S) (r : R) : f r = f.val r := rfl
+
+instance CommRing_hom_is_ring_hom {R S : CommRing} (f : R ⟶ S) : is_ring_hom (f : R → S) := f.2
 
 namespace CommRing
 /-- The forgetful functor from commutative rings to (multiplicative) commutative monoids. -/
-def forget_to_CommMon : CommRing ⥤ CommMon := 
-concrete_functor
-  (by intros _ c; exact { ..c })
-  (by introsI _ _ _ _ f i;  exact { ..i })
+def forget_to_CommMon : CommRing ⥤ CommMon :=
+{ obj := λ X, { α := X.1, str := by apply_instance },
+  map := λ X Y f, ⟨ f, by apply_instance ⟩ }
 
 instance : faithful (forget_to_CommMon) := {}
 

--- a/category_theory/examples/topological_spaces.lean
+++ b/category_theory/examples/topological_spaces.lean
@@ -36,6 +36,12 @@ instance : small_category (opens X) := by apply_instance
 def nbhd (x : X.α) := { U : opens X // x ∈ U }
 def nbhds (x : X.α) : small_category (nbhd x) := begin unfold nbhd, apply_instance end
 
+end category_theory.examples
+
+open category_theory.examples
+
+namespace topological_space.opens
+
 /-- `opens.map f` gives the functor from open sets in Y to open set in X,
     given by taking preimages under f. -/
 def map
@@ -49,10 +55,11 @@ def map
 { hom := { app := λ U, 𝟙 U },
   inv := { app := λ U, 𝟙 U } }
 
--- We could make f g implicit here, but it's nice to be able to see when they are the identity (often!)
+-- We could make f g implicit here, but it's nice to be able to see when
+-- they are the identity (often!)
 def map_iso {X Y : Top.{u}} (f g : X ⟶ Y) (h : f = g) : map f ≅ map g :=
 nat_iso.of_components (λ U, eq_to_iso (congr_fun (congr_arg _ (congr_arg _ h)) _) ) (by obviously)
 
 @[simp] def map_iso_id {X : Top.{u}} (h) : map_iso (𝟙 X) (𝟙 X) h = iso.refl (map _) := rfl
 
-end category_theory.examples
+end topological_space.opens

--- a/category_theory/full_subcategory.lean
+++ b/category_theory/full_subcategory.lean
@@ -1,7 +1,7 @@
 -- Copyright (c) 2017 Scott Morrison. All rights reserved.
 -- Released under Apache 2.0 license as described in the file LICENSE.
 -- Authors: Scott Morrison
-import category_theory.embedding
+import category_theory.fully_faithful
 
 namespace category_theory
 
@@ -16,12 +16,14 @@ instance full_subcategory (Z : C → Prop) : category.{u v} {X : C // Z X} :=
   id   := λ X, 𝟙 X.1,
   comp := λ _ _ _ f g, f ≫ g }
 
-def full_subcategory_embedding (Z : C → Prop) : {X : C // Z X} ⥤ C :=
+def full_subcategory_inclusion (Z : C → Prop) : {X : C // Z X} ⥤ C :=
 { obj := λ X, X.1,
   map := λ _ _ f, f }
 
-instance full_subcategory_full     (Z : C → Prop) : full     (full_subcategory_embedding Z) := by obviously
-instance full_subcategory_faithful (Z : C → Prop) : faithful (full_subcategory_embedding Z) := by obviously
+instance full_subcategory_full     (Z : C → Prop) : full     (full_subcategory_inclusion Z) := 
+by obviously
+instance full_subcategory_faithful (Z : C → Prop) : faithful (full_subcategory_inclusion Z) := 
+by obviously
 end
 
 end category_theory

--- a/category_theory/fully_faithful.lean
+++ b/category_theory/fully_faithful.lean
@@ -27,8 +27,11 @@ namespace functor
 def injectivity (F : C ⥤ D) [faithful F] {X Y : C} {f g : X ⟶ Y} (p : F.map f = F.map g) : f = g :=
 faithful.injectivity F p
 
-def preimage (F : C ⥤ D) [full F] {X Y : C} (f : F.obj X ⟶ F.obj Y) : X ⟶ Y := full.preimage.{u₁ v₁ u₂ v₂}  f
-@[simp] lemma image_preimage (F : C ⥤ D) [full F] {X Y : C} (f : F.obj X ⟶ F.obj Y) : F.map (preimage F f) = f := begin unfold preimage, obviously end
+def preimage (F : C ⥤ D) [full F] {X Y : C} (f : F.obj X ⟶ F.obj Y) : X ⟶ Y := 
+full.preimage.{u₁ v₁ u₂ v₂}  f
+@[simp] lemma image_preimage (F : C ⥤ D) [full F] {X Y : C} (f : F.obj X ⟶ F.obj Y) : 
+  F.map (preimage F f) = f := 
+by unfold preimage; obviously
 end functor
 
 
@@ -40,11 +43,13 @@ def preimage_iso (f : (F.obj X) ≅ (F.obj Y)) : X ≅ Y :=
   hom_inv_id' := begin apply @faithful.injectivity _ _ _ _ F, obviously, end,
   inv_hom_id' := begin apply @faithful.injectivity _ _ _ _ F, obviously, end, }
 
-@[simp] lemma preimage_iso_hom (f : (F.obj X) ≅ (F.obj Y)) : (preimage_iso f).hom = F.preimage f.hom := rfl
-@[simp] lemma preimage_iso_inv (f : (F.obj X) ≅ (F.obj Y)) : (preimage_iso f).inv = F.preimage (f.inv) := rfl
+@[simp] lemma preimage_iso_hom (f : (F.obj X) ≅ (F.obj Y)) : 
+  (preimage_iso f).hom = F.preimage f.hom := rfl
+@[simp] lemma preimage_iso_inv (f : (F.obj X) ≅ (F.obj Y)) : 
+  (preimage_iso f).inv = F.preimage (f.inv) := rfl
 end
 
-class embedding (F : C ⥤ D) extends (full F), (faithful F).
+class fully_faithful (F : C ⥤ D) extends (full F), (faithful F).
 end category_theory
 
 namespace category_theory
@@ -57,7 +62,7 @@ instance full.id : full (functor.id C) :=
 
 instance : faithful (functor.id C) := by obviously
 
-instance : embedding (functor.id C) := { ((by apply_instance) : full (functor.id C)) with }
+instance : fully_faithful (functor.id C) := { ((by apply_instance) : full (functor.id C)) with }
 
 variables {D : Type u₂} [𝒟 : category.{u₂ v₂} D] {E : Type u₃} [ℰ : category.{u₃ v₃} E]
 include 𝒟 ℰ

--- a/category_theory/functor.lean
+++ b/category_theory/functor.lean
@@ -28,7 +28,8 @@ To apply a functor `F` to an object use `F.obj X`, and to a morphism use `F.map 
 The axiom `map_id_lemma` expresses preservation of identities, and
 `map_comp_lemma` expresses functoriality.
 -/
-structure functor (C : Type u₁) [category.{u₁ v₁} C] (D : Type u₂) [category.{u₂ v₂} D] : Type (max u₁ v₁ u₂ v₂) :=
+structure functor (C : Type u₁) [category.{u₁ v₁} C] (D : Type u₂) [category.{u₂ v₂} D] :
+  Type (max u₁ v₁ u₂ v₂) :=
 (obj       : C → D)
 (map       : Π {X Y : C}, (X ⟶ Y) → ((obj X) ⟶ (obj Y)))
 (map_id'   : ∀ (X : C), map (𝟙 X) = 𝟙 (obj X) . obviously)
@@ -89,11 +90,23 @@ include 𝒞
 @[simp] def ulift_up : C ⥤ (ulift.{u₂} C) :=
 { obj := λ X, ⟨ X ⟩,
   map := λ X Y f, f }
+
+def empty : pempty ⥤ C := by obviously
+
+variables {C}
+
+-- punit.{u} : Sort u, so punit.{v₂+1} is a small_category.{v₂}.
+def of_obj (X : C) : punit.{v₂+1} ⥤ C :=
+{ obj := λ Y, X,
+  map := λ Y Z f, 𝟙 X }
+
+@[simp] lemma of_obj_obj (X : C) (a : punit) : ((of_obj X).obj a) = X := rfl
 end
 
 end functor
 
-def bundled.map {c : Type u → Type v} {d : Type u → Type v} (f : Π{a}, c a → d a) (s : bundled c) : bundled d :=
+def bundled.map {c : Type u → Type v} {d : Type u → Type v} (f : Π{a}, c a → d a) (s : bundled c) :
+  bundled d :=
 { α := s.α, str := f s.str }
 
 def concrete_functor

--- a/category_theory/functor_category.lean
+++ b/category_theory/functor_category.lean
@@ -6,17 +6,23 @@ import category_theory.natural_transformation
 
 namespace category_theory
 
-universes u₁ v₁ u₂ v₂ u₃ v₃
+universes u v u₁ v₁ u₂ v₂ u₃ v₃
 
 open nat_trans
 
-/--
-`functor.category C D` gives the category structure on functor and natural transformations between categories `C` and `D`.
+variables (C : Type u₁) [𝒞 : category.{u₁ v₁} C] (D : Type u₂) [𝒟 : category.{u₂ v₂} D]
+include 𝒞 𝒟
 
-Notice that if `C` and `D` are both small categories at the same universe level, this is another small category at that level.
-However if `C` and `D` are both large categories at the same universe level, this is a small category at the next higher level.
+/--
+`functor.category C D` gives the category structure on functors and natural transformations
+between categories `C` and `D`.
+
+Notice that if `C` and `D` are both small categories at the same universe level,
+this is another small category at that level.
+However if `C` and `D` are both large categories at the same universe level,
+this is a small category at the next higher level.
 -/
-instance functor.category (C : Type u₁) [category.{u₁ v₁} C] (D : Type u₂) [category.{u₂ v₂} D] :
+instance functor.category :
   category.{(max u₁ v₁ u₂ v₂) (max u₁ v₂)} (C ⥤ D) :=
 { hom     := λ F G, F ⟹ G,
   id      := λ F, nat_trans.id F,
@@ -25,8 +31,7 @@ instance functor.category (C : Type u₁) [category.{u₁ v₁} C] (D : Type u�
 namespace functor.category
 
 section
-variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C] {D : Type u₂} [𝒟 : category.{u₂ v₂} D]
-include 𝒞 𝒟
+variables {C D}
 
 @[simp] lemma id_app (F : C ⥤ D) (X : C) : (𝟙 F : F ⟹ F).app X = 𝟙 (F.obj X) := rfl
 @[simp] lemma comp_app {F G H : C ⥤ D} (α : F ⟶ G) (β : G ⟶ H) (X : C) :
@@ -34,22 +39,43 @@ include 𝒞 𝒟
 end
 
 namespace nat_trans
--- This section gives two lemmas about natural transformations between functors into functor categories,
+-- This section gives two lemmas about natural transformations
+-- between functors into functor categories,
 -- spelling them out in components.
 
-variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C]
-          {D : Type u₂} [𝒟 : category.{u₂ v₂} D]
-          {E : Type u₃} [ℰ : category.{u₃ v₃} E]
-include 𝒞 𝒟 ℰ
+variables {E : Type u₃} [ℰ : category.{u₃ v₃} E]
+include ℰ
 
 lemma app_naturality {F G : C ⥤ (D ⥤ E)} (T : F ⟹ G) (X : C) {Y Z : D} (f : Y ⟶ Z) :
-  ((F.obj X).map f) ≫ ((T.app X).app Z) = ((T.app X).app Y) ≫ ((G.obj X).map f) := (T.app X).naturality f
+  ((F.obj X).map f) ≫ ((T.app X).app Z) = ((T.app X).app Y) ≫ ((G.obj X).map f) :=
+(T.app X).naturality f
 
 lemma naturality_app {F G : C ⥤ (D ⥤ E)} (T : F ⟹ G) (Z : D) {X Y : C} (f : X ⟶ Y) :
-  ((F.map f).app Z) ≫ ((T.app Y).app Z) = ((T.app X).app Z) ≫ ((G.map f).app Z) := congr_fun (congr_arg app (T.naturality f)) Z
+  ((F.map f).app Z) ≫ ((T.app Y).app Z) = ((T.app X).app Z) ≫ ((G.map f).app Z) :=
+congr_fun (congr_arg app (T.naturality f)) Z
 
 end nat_trans
 
 end functor.category
+
+namespace functor
+
+omit 𝒟
+variables {C D} {J K : Type v} [small_category J] [small_category K]
+
+protected def flip (F : J ⥤ (K ⥤ C)) : K ⥤ (J ⥤ C) :=
+{ obj := λ k,
+  { obj := λ j, (F.obj j).obj k,
+    map := λ j j' f, (F.map f).app k,
+    map_id' := λ X, begin rw category_theory.functor.map_id, refl end,
+    map_comp' := λ X Y Z f g, by rw [functor.map_comp, ←functor.category.comp_app] },
+  map := λ c c' f,
+  { app := λ j, (F.obj j).map f,
+    naturality' := λ X Y g, by dsimp; rw ←nat_trans.naturality } }.
+
+@[simp] lemma flip_obj_map (F : J ⥤ (K ⥤ C)) {j j' : J} (f : j ⟶ j') (k : K) :
+  ((F.flip).obj k).map f = (F.map f).app k := rfl
+
+end functor
 
 end category_theory

--- a/category_theory/isomorphism.lean
+++ b/category_theory/isomorphism.lean
@@ -61,8 +61,20 @@ namespace iso
 @[trans] def trans (α : X ≅ Y) (β : Y ≅ Z) : X ≅ Z :=
 { hom := α.hom ≫ β.hom,
   inv := β.inv ≫ α.inv,
-  hom_inv_id' := begin /- `obviously'` says: -/ rw [category.assoc], conv { to_lhs, congr, skip, rw ← category.assoc }, rw iso.hom_inv_id, rw category.id_comp, rw iso.hom_inv_id end,
-  inv_hom_id' := begin /- `obviously'` says: -/ rw [category.assoc], conv { to_lhs, congr, skip, rw ← category.assoc }, rw iso.inv_hom_id, rw category.id_comp, rw iso.inv_hom_id end }
+  hom_inv_id' := 
+  begin 
+    /- `obviously'` says: -/ 
+    rw [category.assoc], 
+    conv { to_lhs, congr, skip, rw ← category.assoc }, 
+    rw [iso.hom_inv_id, category.id_comp, iso.hom_inv_id]
+  end,
+  inv_hom_id' := 
+  begin 
+    /- `obviously'` says: -/ 
+    rw [category.assoc], 
+    conv { to_lhs, congr, skip, rw ← category.assoc }, 
+    rw [iso.inv_hom_id, category.id_comp, iso.inv_hom_id]
+  end }
 
 infixr ` ≪≫ `:80 := iso.trans -- type as `\ll \gg`.
 
@@ -147,10 +159,20 @@ instance mono_of_iso (f : X ⟶ Y) [is_iso f] : mono f :=
                          rw [←category.assoc, w, ←category.assoc]
                        end }
 
+def eq_to_hom {X Y : C} (p : X = Y) : X ⟶ Y := begin rw p, exact 𝟙 _ end
 def eq_to_iso {X Y : C} (p : X = Y) : X ≅ Y := by rw p
 
+@[simp] lemma eq_to_iso.hom {X Y : C} (p : X = Y) : (eq_to_iso p).hom = eq_to_hom p :=
+begin
+  induction p,
+  refl,
+end
+
+@[simp] lemma eq_to_hom_refl (X : C) (p : X = X) : eq_to_hom p = 𝟙 X := rfl
 @[simp] lemma eq_to_iso_refl (X : C) (p : X = X) : eq_to_iso p = (iso.refl X) := rfl
 
+@[simp] lemma eq_to_hom_trans {X Y Z : C} (p : X = Y) (q : Y = Z) : (eq_to_hom p) ≫ (eq_to_hom q) = eq_to_hom (p.trans q) :=
+begin /- obviously' says: -/ induction q, induction p, dsimp, simp, end
 @[simp] lemma eq_to_iso_trans {X Y Z : C} (p : X = Y) (q : Y = Z) : (eq_to_iso p) ≪≫ (eq_to_iso q) = eq_to_iso (p.trans q) :=
 begin /- obviously' says: -/ ext, induction q, induction p, dsimp at *, simp at * end
 
@@ -161,6 +183,8 @@ universes u₁ v₁ u₂ v₂
 variables {D : Type u₂} [𝒟 : category.{u₂ v₂} D]
 include 𝒟
 
+@[simp] lemma eq_to_hom (F : C ⥤ D) {X Y : C} (p : X = Y) : F.map (eq_to_hom p) = eq_to_hom (congr_arg F.obj p) :=
+begin /- obviously says: -/ induction p, dsimp at *, simp at * end
 @[simp] lemma eq_to_iso (F : C ⥤ D) {X Y : C} (p : X = Y) : F.on_iso (eq_to_iso p) = eq_to_iso (congr_arg F.obj p) :=
 begin /- obviously says: -/ ext1, induction p, dsimp at *, simp at * end
 end functor

--- a/category_theory/limits/binary_products.lean
+++ b/category_theory/limits/binary_products.lean
@@ -105,6 +105,10 @@ by erw is_limit.fac; refl
   (w_snd : g ≫ prod.snd X Y = h ≫ prod.snd X Y) : g = h :=
 limit.hom_ext (λ j, two.cases_on j w_fst w_snd)
 
+def prod.hom_equiv {P : C} : (P ⟶ limits.prod X Y) ≅ (P ⟶ X) × (P ⟶ Y) :=
+{ hom := λ g, (g ≫ prod.fst X Y, g ≫ prod.snd X Y),
+  inv := λ p, prod.lift p.1 p.2 }
+
 end prod
 
 section sum
@@ -121,6 +125,35 @@ variables {X Y}
 
 def sum.desc {P : C} (left : X ⟶ P) (right : Y ⟶ P) : limits.sum X Y ⟶ P :=
 colimit.desc.{u v} _ (sum.mk.{u v} left right)
+
+@[simp] lemma sum.desc_inl {P : C} (inl : X ⟶ P) (inr : Y ⟶ P) : sum.inl _ _ ≫ sum.desc inl inr = inl :=
+colimit.ι_desc (sum.mk.{u v} inl inr) two.left
+@[simp] lemma sum.desc_inr {P : C} (inl : X ⟶ P) (inr : Y ⟶ P) : sum.inr _ _ ≫ sum.desc inl inr = inr :=
+colimit.ι_desc (sum.mk.{u v} inl inr) two.right
+
+def sum.map
+  {U V : C} [has_binary_coproduct.{u v} U V] (fst : X ⟶ U) (snd : Y ⟶ V) :
+  (limits.sum X Y) ⟶ (limits.sum U V) :=
+sigma.desc (λ b, two.cases_on b (fst ≫ sum.inl U V) (snd ≫ sum.inr U V))
+
+@[simp] lemma sum.map_inl
+  {U V : C} [has_binary_coproduct.{u v} U V] (fst : X ⟶ U) (snd : Y ⟶ V) :
+  sum.inl X Y ≫ sum.map fst snd = fst ≫ sum.inl U V :=
+by erw is_colimit.fac; refl
+@[simp] lemma sum.map_inr
+  {U V : C} [has_binary_coproduct.{u v} U V] (fst : X ⟶ U) (snd : Y ⟶ V) :
+  sum.inr X Y ≫ sum.map fst snd = snd ≫ sum.inr U V :=
+by erw is_colimit.fac; refl
+
+@[extensionality] lemma sum.hom_ext
+  {P : C} {g h : limits.sum.{u v} X Y ⟶ P}
+  (w_fst : sum.inl X Y ≫ g = sum.inl X Y ≫ h)
+  (w_snd : sum.inr X Y ≫ g = sum.inr X Y ≫ h) : g = h :=
+colimit.hom_ext (λ j, two.cases_on j w_fst w_snd)
+
+def sum.hom_equiv {P : C} : (limits.sum X Y ⟶ P) ≅ (X ⟶ P) × (Y ⟶ P) :=
+{ hom := λ g, (sum.inl X Y ≫ g, sum.inr X Y ≫ g),
+  inv := λ p, sum.desc p.1 p.2 }
 
 end sum
 

--- a/category_theory/limits/binary_products.lean
+++ b/category_theory/limits/binary_products.lean
@@ -1,0 +1,132 @@
+-- Copyright (c) 2018 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Scott Morrison
+
+import category_theory.limits.products
+
+universes u v
+
+open category_theory
+
+namespace category_theory.limits
+
+@[derive decidable_eq] inductive two : Type v
+| left | right
+
+def two.map {C : Type u} (X Y : C) : two → C
+| two.left := X
+| two.right := Y
+
+variables (C : Type u) [𝒞 : category.{u v} C]
+include 𝒞
+
+variables {C} {X Y : C}
+
+def prod.mk {P : C} (π₁ : P ⟶ X) (π₂ : P ⟶ Y) : fan (two.map X Y) :=
+{ X := P,
+  π :=
+  { app := λ j, begin cases j, exact π₁, exact π₂ end }}
+def sum.mk {P : C} (ι₁ : X ⟶ P) (ι₂ : Y ⟶ P) : cofan (two.map X Y) :=
+{ X := P,
+  ι :=
+  { app := λ j, begin cases j, exact ι₁, exact ι₂ end }}
+
+-- FIXME can we use `def` here? with a `class` attribute?
+
+variables (C)
+
+class has_binary_products extends has_products_of_shape.{u v} two.{v} C
+class has_binary_coproducts extends has_coproducts_of_shape.{u v} two.{v} C
+
+variables {C}
+
+class has_binary_product (X Y : C) extends has_product.{u v} (two.map X Y)
+class has_binary_coproduct (X Y : C) extends has_coproduct.{u v} (two.map X Y)
+
+instance has_binary_product_of_has_binary_products (X Y : C) [i : has_binary_products.{u v} C] :
+  has_binary_product.{u v} X Y :=
+{ fan := has_products_of_shape.fan (two.map X Y),
+  is_product := has_products_of_shape.is_product (two.map X Y) }
+instance has_binary_coproduct_of_has_binary_coproducts (X Y : C) [i : has_binary_coproducts.{u v} C] :
+  has_binary_coproduct.{u v} X Y :=
+{ cofan := has_coproducts_of_shape.cofan (two.map X Y),
+  is_coproduct := has_coproducts_of_shape.is_coproduct (two.map X Y) }
+
+-- These are defs because they do not necessarily give the nicest constructions.
+def has_binary_products_of_has_products [i : has_products_of_shape.{u v} two C] :
+  has_binary_products.{u v} C := { .. i }
+def has_binary_product_of_has_product (X Y : C) [i : has_product.{u v} (two.map X Y)] :
+  has_binary_product.{u v} X Y := { .. i }
+def has_binary_coproducts_of_has_coproducts [i : has_coproducts_of_shape.{u v} two C] :
+  has_binary_coproducts.{u v} C := { .. i }
+def has_binary_coproduct_of_has_coproduct (X Y : C) [i : has_coproduct.{u v} (two.map X Y)] :
+  has_binary_coproduct.{u v} X Y := { .. i }
+
+variables (X Y)
+
+section prod
+variable [has_binary_product.{u v} X Y]
+
+def prod.span : fan (two.map X Y) := has_product.fan.{u v} (two.map X Y)
+protected def prod : C := (prod.span.{u v} X Y).X
+def prod.fst : limits.prod X Y ⟶ X :=
+(prod.span.{u v} X Y).π.app two.left
+def prod.snd : limits.prod X Y ⟶ Y :=
+(prod.span.{u v} X Y).π.app two.right
+
+variables {X Y}
+
+def prod.lift {P : C} (fst : P ⟶ X) (snd : P ⟶ Y) : P ⟶ limits.prod X Y :=
+limit.lift.{u v} _ (prod.mk.{u v} fst snd)
+
+@[simp] lemma prod.lift_fst {P : C} (fst : P ⟶ X) (snd : P ⟶ Y) : prod.lift fst snd ≫ prod.fst _ _ = fst :=
+limit.lift_π (prod.mk.{u v} fst snd) two.left
+@[simp] lemma prod.lift_snd {P : C} (fst : P ⟶ X) (snd : P ⟶ Y) : prod.lift fst snd ≫ prod.snd _ _ = snd :=
+limit.lift_π (prod.mk.{u v} fst snd) two.right
+
+def prod.map
+  {U V : C} [has_binary_product.{u v} U V] (fst : X ⟶ U) (snd : Y ⟶ V) :
+  (limits.prod X Y) ⟶ (limits.prod U V) :=
+pi.lift (λ b, two.cases_on b (prod.fst X Y ≫ fst) (prod.snd X Y ≫ snd))
+
+@[simp] lemma prod.map_fst
+  {U V : C} [has_binary_product.{u v} U V] (fst : X ⟶ U) (snd : Y ⟶ V) :
+  prod.map fst snd ≫ prod.fst U V = prod.fst X Y ≫ fst :=
+by erw is_limit.fac; refl
+@[simp] lemma prod.map_snd
+  {U V : C} [has_binary_product.{u v} U V] (fst : X ⟶ U) (snd : Y ⟶ V) :
+  prod.map fst snd ≫ prod.snd U V = prod.snd X Y ≫ snd :=
+by erw is_limit.fac; refl
+
+
+@[extensionality] lemma prod.hom_ext
+  {P : C} {g h : P ⟶ limits.prod.{u v} X Y}
+  (w_fst : g ≫ prod.fst X Y = h ≫ prod.fst X Y)
+  (w_snd : g ≫ prod.snd X Y = h ≫ prod.snd X Y) : g = h :=
+limit.hom_ext (λ j, two.cases_on j w_fst w_snd)
+
+end prod
+
+section sum
+variable [has_binary_coproduct.{u v} X Y]
+
+def sum.cospan : cofan (two.map X Y) := has_coproduct.cofan.{u v} (two.map X Y)
+protected def sum : C := (sum.cospan.{u v} X Y).X
+def sum.inl : X ⟶ limits.sum X Y :=
+(sum.cospan.{u v} X Y).ι.app two.left
+def sum.inr : Y ⟶ limits.sum X Y :=
+(sum.cospan.{u v} X Y).ι.app two.right
+
+variables {X Y}
+
+def sum.desc {P : C} (left : X ⟶ P) (right : Y ⟶ P) : limits.sum X Y ⟶ P :=
+colimit.desc.{u v} _ (sum.mk.{u v} left right)
+
+end sum
+
+-- TODO many things
+
+-- pullbacks from binary_products and equalizers
+-- finite products from binary_products and terminal objects
+
+end category_theory.limits

--- a/category_theory/limits/cones.lean
+++ b/category_theory/limits/cones.lean
@@ -1,0 +1,264 @@
+-- Copyright (c) 2017 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Stephen Morgan, Scott Morrison
+
+import category_theory.natural_isomorphism
+import category_theory.whiskering
+import category_theory.discrete_category
+import category_theory.const
+
+universes u u' v
+
+open category_theory
+
+variables (J : Type v) [small_category J]
+variables (C : Type u) [𝒞 : category.{u v} C]
+include 𝒞
+
+variables {J C}
+open category_theory
+open category_theory.functor
+
+namespace category_theory.limits
+
+/--
+A `c : cone F` is:
+* an object `c.X` and
+* a natural transformation `c.π : c.X ⟹ F` from the constant `c.X` functor to `F`.
+-/
+structure cone (F : J ⥤ C) :=
+(X : C)
+(π : (const J).obj X ⟹ F)
+
+@[simp] lemma cone.w {F : J ⥤ C} (c : cone F) {j j' : J} (f : j ⟶ j') :
+  c.π.app j ≫ F.map f = c.π.app j' :=
+begin
+  have h := (c.π).naturality f,
+  simp at h,
+  erw category.id_comp at h,
+  exact eq.symm h
+end
+
+/--
+A `c : cocone F` is
+* an object `c.X` and
+* a natural transformation `c.ι : F ⟹ c.X` from `F` to the constant `c.X` functor.
+-/
+structure cocone (F : J ⥤ C) :=
+(X : C)
+(ι : F ⟹ (const J).obj X)
+
+@[simp] lemma cocone.w {F : J ⥤ C} (c : cocone F) {j j' : J} (f : j ⟶ j') :
+  F.map f ≫ c.ι.app j' = c.ι.app j :=
+begin
+  have h := (c.ι).naturality f,
+  simp at h,
+  erw category.comp_id at h,
+  exact h
+end
+
+variable {F : J ⥤ C}
+
+namespace functor
+-- These are not particularly important definitions; they're mostly here
+-- as reminders of the relationship between `F.cones` and `cone F`.
+
+def cones_of_cone (c : cone F) : F.cones.obj c.X := c.π
+def cone_of_cones {X : C} (π : F.cones.obj X) : cone F :=
+{ X := X,
+  π := π }
+end functor
+
+namespace cone
+@[simp] def extensions (c : cone F) : yoneda.obj c.X ⟶ F.cones :=
+{ app := λ X f, ((const J).map f) ⊟ c.π }
+
+@[simp] def extend (c : cone F) {X : C} (f : X ⟶ c.X) : cone F :=
+{ X := X,
+  π := c.extensions.app X f }
+
+def postcompose {G : J ⥤ C} (c : cone F) (α : F ⟹ G) : cone G :=
+{ X := c.X,
+  π := c.π ⊟ α }
+
+def whisker (c : cone F) {K : Type v} [small_category K] (E : K ⥤ J) : cone (E ⋙ F) :=
+{ X := c.X,
+  π := whisker_left E c.π }
+
+@[simp] lemma whisker_π_app (c : cone F) {K : Type v} [small_category K] (E : K ⥤ J) (k : K) :
+  (c.whisker E).π.app k = (c.π).app (E.obj k) := rfl
+end cone
+
+namespace cocone
+def extend (c : cocone F) {X : C} (f : c.X ⟶ X) : cocone F :=
+{ X := X,
+  ι := c.ι ⊟ (const J).map f }
+
+def precompose {G : J ⥤ C} (c : cocone F) (α : G ⟹ F) : cocone G :=
+{ X := c.X,
+  ι := α ⊟ c.ι }
+
+def whisker (c : cocone F) {K : Type v} [small_category K] (E : K ⥤ J) : cocone (E ⋙ F) :=
+{ X := c.X,
+  ι := whisker_left E c.ι }
+
+@[simp] lemma whisker_ι_app (c : cocone F) {K : Type v} [small_category K] (E : K ⥤ J) (k : K) :
+  (c.whisker E).ι.app k = (c.ι).app (E.obj k) := rfl
+end cocone
+
+structure cone_morphism (A B : cone F) :=
+(hom : A.X ⟶ B.X)
+(w'  : Π j : J, hom ≫ (B.π.app j) = (A.π.app j) . obviously)
+
+restate_axiom cone_morphism.w'
+attribute [simp] cone_morphism.w
+
+namespace cone_morphism
+
+@[extensionality] lemma ext {A B : cone F} {f g : cone_morphism A B} (w : f.hom = g.hom) : f = g :=
+begin
+  induction f,
+  induction g,
+  -- `obviously'` says:
+  dsimp at w,
+  induction w,
+  refl,
+end
+end cone_morphism
+
+instance cones (F : J ⥤ C) : category.{(max u v) v} (cone F) :=
+{ hom  := λ A B, cone_morphism A B,
+  comp := λ X Y Z f g,
+  { hom := f.hom ≫ g.hom,
+    w' := begin intros j, rw category.assoc, rw cone_morphism.w g, rw cone_morphism.w f j end },
+  id   := λ B, { hom := 𝟙 B.X } }
+
+namespace cones
+@[simp] lemma id.hom   {F : J ⥤ C} (c : cone F) : (𝟙 c : cone_morphism c c).hom = 𝟙 (c.X) := rfl
+@[simp] lemma comp.hom {F : J ⥤ C} {c d e : cone F} (f : c ⟶ d) (g : d ⟶ e) :
+  ((f ≫ g) : cone_morphism c e).hom = (f : cone_morphism c d).hom ≫ (g : cone_morphism d e).hom :=
+rfl
+
+@[extensionality] def ext
+  {F : J ⥤ C} (c c' : cone F) (φ : c.X ≅ c'.X) (w : ∀ j, c.π.app j = φ.hom ≫ c'.π.app j) :
+  c ≅ c' :=
+{ hom :=
+  { hom := φ.hom },
+  inv :=
+  { hom := φ.symm.hom,
+    w' := λ j,
+    begin
+      have h := congr_arg (λ p, φ.inv ≫ p) (w j),
+      dsimp at h,
+      erw h,
+      rw ←category.assoc,
+      simp,
+    end } }
+
+section
+variables {D : Type u'} [𝒟 : category.{u' v} D]
+include 𝒟
+
+@[simp] def functoriality (F : J ⥤ C) (G : C ⥤ D) : (cone F) ⥤ (cone (F ⋙ G)) :=
+{ obj := λ A,
+  { X := G.obj A.X,
+    π := (functor.const_compose _ _ _).hom ⊟ whisker_right A.π G },
+  map := λ X Y f,
+  { hom := G.map f.hom,
+    w' := begin intros, dsimp, simp, rw [←functor.map_comp, f.w], end } }
+end
+end cones
+
+structure cocone_morphism (A B : cocone F) :=
+(hom : A.X ⟶ B.X)
+(w'  : Π j : J, (A.ι.app j) ≫ hom = (B.ι.app j) . obviously)
+
+restate_axiom cocone_morphism.w'
+attribute [simp] cocone_morphism.w
+
+namespace cocone_morphism
+
+@[extensionality] lemma ext
+  {A B : cocone F} {f g : cocone_morphism A B} (w : f.hom = g.hom) : f = g :=
+begin
+  induction f,
+  induction g,
+  -- `obviously'` says:
+  dsimp at w,
+  induction w,
+  refl,
+end
+end cocone_morphism
+
+instance cocones (F : J ⥤ C) : category.{(max u v) v} (cocone F) :=
+{ hom  := λ A B, cocone_morphism A B,
+  comp := λ _ _ _ f g,
+  { hom := f.hom ≫ g.hom,
+    w' :=
+    begin
+      intros j, rw [←category.assoc, ←cocone_morphism.w g, ←cocone_morphism.w f j]
+    end },
+  id   := λ B, { hom := 𝟙 B.X } }
+
+namespace cocones
+@[simp] lemma id.hom   {F : J ⥤ C} (c : cocone F) :
+  (𝟙 c : cocone_morphism c c).hom = 𝟙 (c.X) := rfl
+@[simp] lemma comp.hom {F : J ⥤ C} {c d e : cocone F} (f : c ⟶ d) (g : d ⟶ e) : ((f ≫ g) :
+  cocone_morphism c e).hom = (f : cocone_morphism c d).hom ≫ (g : cocone_morphism d e).hom := rfl
+
+@[extensionality] def ext
+  {F : J ⥤ C} (c c' : cocone F) (φ : c.X ≅ c'.X) (w : ∀ j, c.ι.app j ≫ φ.hom = c'.ι.app j):
+  c ≅ c' :=
+{ hom :=
+  { hom := φ.hom },
+  inv :=
+  { hom := φ.symm.hom,
+    w' := λ j,
+    begin
+      have h := congr_arg (λ p, p ≫ φ.inv) (w j),
+      dsimp at h,
+      erw ←h,
+      rw category.assoc,
+      simp,
+    end } }
+
+section
+variables {D : Type u'} [𝒟 : category.{u' v} D]
+include 𝒟
+
+@[simp] def functoriality (F : J ⥤ C) (G : C ⥤ D) : (cocone F) ⥤ (cocone (F ⋙ G)) :=
+{ obj := λ A,
+  { X  := G.obj A.X,
+    ι  :=  whisker_right A.ι G ⊟ (functor.const_compose _ _ _).inv },
+  map := λ _ _ f,
+  { hom := G.map f.hom,
+    w'  :=
+    begin
+      intros, dsimp,
+      erw [category.comp_id, ←functor.map_comp, cocone_morphism.w, category.comp_id],
+    end } }
+end
+end cocones
+
+end category_theory.limits
+
+namespace category_theory.functor
+
+variables {D : Type u'} [category.{u' v} D]
+variables {F : J ⥤ C} {G : J ⥤ C}
+
+open category_theory.limits
+
+def map_cone   (H : C ⥤ D) (c : cone F)   : cone (F ⋙ H)   := (cones.functoriality F H).obj c
+def map_cocone (H : C ⥤ D) (c : cocone F) : cocone (F ⋙ H) := (cocones.functoriality F H).obj c
+def map_cone_morphism   (H : C ⥤ D) {c c' : cone F}   (f : cone_morphism c c')   :
+  cone_morphism   (H.map_cone c)   (H.map_cone c')   := (cones.functoriality F H).map f
+def map_cocone_morphism (H : C ⥤ D) {c c' : cocone F} (f : cocone_morphism c c') :
+  cocone_morphism (H.map_cocone c) (H.map_cocone c') := (cocones.functoriality F H).map f
+
+@[simp] lemma map_cone_π (H : C ⥤ D) (c : cone F) (j : J) :
+  (map_cone H c).π.app j = ((functor.const_compose _ _ _).hom ⊟ whisker_right c.π H).app j := rfl
+@[simp] lemma map_cocone_ι (H : C ⥤ D) (c : cocone F) (j : J) :
+  (map_cocone H c).ι.app j = (whisker_right c.ι H ⊟ (functor.const_compose _ _ _).inv).app j := rfl
+
+end category_theory.functor

--- a/category_theory/limits/cones.lean
+++ b/category_theory/limits/cones.lean
@@ -19,7 +19,8 @@ variables {J C}
 open category_theory
 open category_theory.functor
 
-namespace category_theory.limits
+namespace category_theory
+namespace limits
 
 /--
 A `c : cone F` is:
@@ -59,7 +60,6 @@ end
 
 variable {F : J ⥤ C}
 
-namespace functor
 -- These are not particularly important definitions; they're mostly here
 -- as reminders of the relationship between `F.cones` and `cone F`.
 
@@ -67,11 +67,26 @@ def cones_of_cone (c : cone F) : F.cones.obj c.X := c.π
 def cone_of_cones {X : C} (π : F.cones.obj X) : cone F :=
 { X := X,
   π := π }
-end functor
+
+@[simp] lemma cones_of_cone_app (c : cone F) (j : J) : (cones_of_cone c).app j = c.π.app j := rfl
+@[simp] lemma cone_of_cones_app {X : C} (π : F.cones.obj X) (j : J) :
+  (cone_of_cones π).π.app j = π.app j := rfl
+@[simp] lemma cones_cone {X : C} (π : F.cones.obj X) : cones_of_cone (cone_of_cones π) = π := rfl
+
+def cocones_of_cocone (c : cocone F) : F.cocones.obj c.X := c.ι
+def cocone_of_cocones {X : C} (ι : F.cocones.obj X) : cocone F :=
+{ X := X,
+  ι := ι }
+
+@[simp] lemma cocones_of_cocone_app (c : cocone F) (j : J) : (cocones_of_cocone c).app j = c.ι.app j := rfl
+@[simp] lemma cocone_of_cocones_app {X : C} (ι : F.cocones.obj X) (j : J) :
+  (cocone_of_cocones ι).ι.app j = ι.app j := rfl
+@[simp] lemma cocones_cocone {X : C} (ι : F.cones.obj X) : cones_of_cone (cone_of_cones ι) = ι := rfl
 
 namespace cone
+
 @[simp] def extensions (c : cone F) : yoneda.obj c.X ⟶ F.cones :=
-{ app := λ X f, ((const J).map f) ⊟ c.π }
+{ app := λ X f, ((const J).map f) ≫ c.π }
 
 @[simp] def extend (c : cone F) {X : C} (f : X ⟶ c.X) : cone F :=
 { X := X,
@@ -90,7 +105,10 @@ def whisker (c : cone F) {K : Type v} [small_category K] (E : K ⥤ J) : cone (E
 end cone
 
 namespace cocone
-def extend (c : cocone F) {X : C} (f : c.X ⟶ X) : cocone F :=
+-- @[simp] def extensions (c : cocone F) : coyoneda.obj c.X ⟶ F.cocones :=
+-- { app := λ X f, c.ι ≫ ((const J).map f) }
+
+@[simp] def extend (c : cocone F) {X : C} (f : c.X ⟶ X) : cocone F :=
 { X := X,
   ι := c.ι ⊟ (const J).map f }
 
@@ -119,7 +137,6 @@ namespace cone_morphism
 begin
   induction f,
   induction g,
-  -- `obviously'` says:
   dsimp at w,
   induction w,
   refl,
@@ -183,7 +200,6 @@ namespace cocone_morphism
 begin
   induction f,
   induction g,
-  -- `obviously'` says:
   dsimp at w,
   induction w,
   refl,
@@ -240,9 +256,9 @@ include 𝒟
 end
 end cocones
 
-end category_theory.limits
+end limits
 
-namespace category_theory.functor
+namespace functor
 
 variables {D : Type u'} [category.{u' v} D]
 variables {F : J ⥤ C} {G : J ⥤ C}
@@ -261,4 +277,5 @@ def map_cocone_morphism (H : C ⥤ D) {c c' : cocone F} (f : cocone_morphism c c
 @[simp] lemma map_cocone_ι (H : C ⥤ D) (c : cocone F) (j : J) :
   (map_cocone H c).ι.app j = (whisker_right c.ι H ⊟ (functor.const_compose _ _ _).inv).app j := rfl
 
-end category_theory.functor
+end functor
+end category_theory

--- a/category_theory/limits/default.lean
+++ b/category_theory/limits/default.lean
@@ -1,0 +1,10 @@
+-- Copyright (c) 2018 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Scott Morrison
+
+import category_theory.limits.limits
+import category_theory.limits.products
+import category_theory.limits.binary_products
+import category_theory.limits.pullbacks
+import category_theory.limits.equalizers
+import category_theory.limits.terminal

--- a/category_theory/limits/equalizers.lean
+++ b/category_theory/limits/equalizers.lean
@@ -270,6 +270,25 @@ instance [has_coequalizer f g] : epi (coequalizer.π f g) :=
   {h k : coequalizer f g ⟶ P}
   (w : coequalizer.π f g ≫ h = coequalizer.π f g ≫ k) : h = k := epi.left_cancellation h k w
 
+def equalizer.hom_equiv [has_equalizer f g] {P : C} :
+  (P ⟶ equalizer f g) ≅ { p : P ⟶ X // p ≫ f = p ≫ g } :=
+{ hom := λ k,
+  ⟨ k ≫ equalizer.ι f g,
+    begin
+      rw [category.assoc, category.assoc],
+      rw equalizer.w,
+    end ⟩,
+  inv := λ p, equalizer.lift f g p.val p.property }
+def coequalizer.hom_equiv [has_coequalizer f g] {P : C} :
+  (coequalizer f g ⟶ P) ≅ { p : Y ⟶ P // f ≫ p = g ≫ p } :=
+{ hom := λ k,
+  ⟨ coequalizer.π f g ≫ k,
+    begin
+      rw [←category.assoc, ←category.assoc],
+      rw coequalizer.w,
+    end ⟩,
+  inv := λ p, coequalizer.desc f g p.val p.property }
+
 instance has_limits_of_shape_of_has_equalizers [has_equalizers.{u v} C] :
   limits.has_limits_of_shape.{u v} walking_pair.{v} C :=
 { cone := λ F, cone.of_fork (equalizer.fork (F.map left) (F.map right)),

--- a/category_theory/limits/equalizers.lean
+++ b/category_theory/limits/equalizers.lean
@@ -1,0 +1,303 @@
+-- Copyright (c) 2018 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Scott Morrison
+
+import category_theory.limits.limits
+import category_theory.limits.pullbacks
+import tactic.squeeze
+
+open category_theory
+
+namespace category_theory.limits
+
+local attribute [tidy] tactic.case_bash
+
+universes u v w
+
+@[derive decidable_eq] inductive walking_pair : Type v
+| zero | one
+
+open walking_pair
+
+inductive walking_pair_hom : walking_pair → walking_pair → Type v
+| left : walking_pair_hom zero one
+| right : walking_pair_hom zero one
+| id : Π X : walking_pair.{v}, walking_pair_hom X X
+
+open walking_pair_hom
+
+instance walking_pair_category : small_category walking_pair :=
+{ hom := walking_pair_hom,
+  id := walking_pair_hom.id,
+  comp := λ X Y Z f g, match X, Y, Z, f, g with
+  | _, _ ,_, (id _), h := h
+  | _, _, _, left, (id one) := left
+  | _, _, _, right, (id one) := right
+  end }
+
+lemma walking_pair_hom_id (X : walking_pair.{v}) : walking_pair_hom.id X = 𝟙 X := rfl
+
+variables {C : Type u} [𝒞 : category.{u v} C]
+include 𝒞
+variables {X Y : C}
+
+def pair (f g : X ⟶ Y) : walking_pair.{v} ⥤ C :=
+{ obj := λ x, match x with
+  | zero := X
+  | one := Y
+  end,
+  map := λ x y h, match x, y, h with
+  | _, _, (id _) := 𝟙 _
+  | _, _, left := f
+  | _, _, right := g
+  end }.
+
+@[simp] lemma pair_map_left (f g : X ⟶ Y) : (pair f g).map left = f := rfl
+@[simp] lemma pair_map_right (f g : X ⟶ Y) : (pair f g).map right = g := rfl
+
+@[simp] lemma pair_functor_obj {F : walking_pair.{v} ⥤ C} (j : walking_pair.{v}) :
+  (pair (F.map left) (F.map right)).obj j = F.obj j :=
+begin
+  cases j; refl
+end
+
+def fork (f g : X ⟶ Y) := cone (pair f g)
+def cofork (f g : X ⟶ Y) := cocone (pair f g)
+
+variables {f g : X ⟶ Y}
+
+attribute [simp] walking_pair_hom_id
+
+def fork.of_ι {P : C} (ι : P ⟶ X) (w : ι ≫ f = ι ≫ g) : fork f g :=
+{ X := P,
+  π :=
+  { app := λ X, begin cases X, exact ι, exact ι ≫ f, end,
+    naturality' := λ X Y f,
+    begin
+      cases X; cases Y; cases f; dsimp; simp,
+      exact w
+    end }}
+def cofork.of_π {P : C} (π : Y ⟶ P) (w : f ≫ π = g ≫ π) : cofork f g :=
+{ X := P,
+  ι :=
+  { app := λ X, begin cases X, exact f ≫ π, exact π, end,
+    naturality' := λ X Y f,
+    begin
+      cases X; cases Y; cases f; dsimp; simp,
+      exact eq.symm w
+    end }}
+
+@[simp] lemma fork.of_ι_app_zero {P : C} (ι : P ⟶ X) (w : ι ≫ f = ι ≫ g) :
+  (fork.of_ι ι w).π.app zero = ι := rfl
+@[simp] lemma fork.of_ι_app_one {P : C} (ι : P ⟶ X) (w : ι ≫ f = ι ≫ g) :
+  (fork.of_ι ι w).π.app one = ι ≫ f := rfl
+
+def fork.ι (t : fork f g) := t.π.app zero
+def cofork.π (t : cofork f g) := t.ι.app one
+def fork.condition (t : fork f g) : (fork.ι t) ≫ f = (fork.ι t) ≫ g :=
+begin
+  erw [t.w left, ← t.w right], refl
+end
+def cofork.condition (t : cofork f g) : f ≫ (cofork.π t) = g ≫ (cofork.π t) :=
+begin
+  erw [t.w left, ← t.w right], refl
+end
+
+def is_equalizer (t : fork f g) := is_limit t
+def is_coequalizer (t : cofork f g) := is_colimit t
+
+lemma is_equalizer.mono {t : fork f g} (h : is_equalizer t) : mono t.ι :=
+⟨λ W (e₁ e₂ : W ⟶ t.X) H, begin
+   unfold fork.ι at H,
+   apply h.hom_ext,
+   rintro (_|_),
+   { exact H },
+   { rw [←t.w left, ←category.assoc, ←category.assoc, H] }
+ end⟩
+
+lemma is_coequalizer.epi {t : cofork f g} (h : is_coequalizer t) : epi t.π :=
+⟨λ W (e₁ e₂ : t.X ⟶ W) H, begin
+   unfold cofork.π at H,
+   apply h.hom_ext,
+   rintro (_|_),
+   { rw [←t.w left, category.assoc, category.assoc, H] },
+   { exact H }
+ end⟩
+
+variables {t : fork f g}
+variables {s : cofork f g}
+
+instance is_equalizer_subsingleton : subsingleton (is_equalizer t) :=
+by dsimp [is_equalizer]; apply_instance
+instance is_coequalizer_subsingleton : subsingleton (is_coequalizer s) :=
+by dsimp [is_coequalizer]; apply_instance
+
+class has_equalizer {X Y : C} (f g : X ⟶ Y) :=
+(fork : fork.{u v} f g)
+(is_equalizer : is_equalizer fork . obviously)
+class has_coequalizer {X Y : C} (f g : X ⟶ Y) :=
+(cofork : cofork.{u v} f g)
+(is_coequalizer : is_coequalizer cofork . obviously)
+
+variable (C)
+
+class has_equalizers :=
+(fork : Π {X Y : C} (f g : X ⟶ Y), fork.{u v} f g)
+(is_equalizer : Π {X Y : C} (f g : X ⟶ Y), is_equalizer (fork f g) . obviously)
+class has_coequalizers :=
+(cofork : Π {X Y : C} (f g : X ⟶ Y), cofork.{u v} f g)
+(is_coequalizer : Π {X Y : C} (f g : X ⟶ Y), is_coequalizer (cofork f g) . obviously)
+
+variable {C}
+
+instance has_equalizer_of_has_equalizers [has_equalizers.{u v} C] {X Y : C} (f g : X ⟶ Y) :
+  has_equalizer.{u v} f g :=
+{ fork := has_equalizers.fork f g,
+  is_equalizer := has_equalizers.is_equalizer C f g }
+instance has_coequalizer_of_has_coequalizers [has_coequalizers.{u v} C] {X Y : C} (f g : X ⟶ Y) :
+  has_coequalizer.{u v} f g :=
+{ cofork := has_coequalizers.cofork f g,
+  is_coequalizer := has_coequalizers.is_coequalizer C f g }
+
+-- Special cases of this may be marked with [instance] as desired.
+def has_equalizers_of_has_limits [limits.has_limits_of_shape.{u v} walking_pair C] :
+  has_equalizers.{u v} C :=
+{ fork := λ X Y f g, limit.cone (pair f g),
+  is_equalizer := λ X Y f g, limit.universal_property (pair f g) }
+def has_coequalizers_of_has_colimits [limits.has_colimits_of_shape.{u v} walking_pair C] :
+  has_coequalizers.{u v} C :=
+{ cofork := λ X Y f g, colimit.cocone (pair f g),
+  is_coequalizer := λ X Y f g, colimit.universal_property (pair f g) }
+
+def cone.of_fork
+  {F : walking_pair.{v} ⥤ C} (t : fork (F.map left) (F.map right)) : cone F :=
+{ X := t.X,
+  π :=
+  { app := λ X, t.π.app X ≫ eq_to_hom (by tidy),
+    naturality' := λ j j' g,
+    begin
+      cases j; cases j'; cases g; dsimp; simp,
+      erw ← t.w left, refl,
+      erw ← t.w right, refl,
+    end } }.
+def cocone.of_cofork
+  {F : walking_pair.{v} ⥤ C} (t : cofork (F.map left) (F.map right)) : cocone F :=
+{ X := t.X,
+  ι :=
+  { app := λ X, eq_to_hom (by tidy) ≫ t.ι.app X,
+    naturality' := λ j j' g,
+    begin
+      cases j; cases j'; cases g; dsimp; simp,
+      erw ← t.w left, refl,
+      erw ← t.w right, refl,
+    end } }.
+
+@[simp] lemma cone.of_fork_π
+  {F : walking_pair.{v} ⥤ C} (t : fork (F.map left) (F.map right)) (j):
+  (cone.of_fork t).π.app j = t.π.app j ≫ eq_to_hom (by tidy) := rfl
+
+@[simp] lemma cocone.of_cofork_ι
+  {F : walking_pair.{v} ⥤ C} (t : cofork (F.map left) (F.map right)) (j):
+  (cocone.of_cofork t).ι.app j = eq_to_hom (by tidy) ≫ t.ι.app j := rfl
+
+def fork.of_cone
+  {F : walking_pair.{v} ⥤ C} (t : cone F) : fork (F.map left) (F.map right) :=
+{ X := t.X,
+  π :=
+  { app := λ X, t.π.app X ≫ eq_to_hom (by tidy) } }
+def cofork.of_cocone
+  {F : walking_pair.{v} ⥤ C} (t : cocone F) : cofork (F.map left) (F.map right) :=
+{ X := t.X,
+  ι :=
+  { app := λ X, eq_to_hom (by tidy) ≫ t.ι.app X } }
+
+@[simp] lemma fork.of_cone_π {F : walking_pair.{v} ⥤ C} (t : cone F) (j) :
+  (fork.of_cone t).π.app j = t.π.app j ≫ eq_to_hom (by tidy) := rfl
+@[simp] lemma cofork.of_cocone_ι {F : walking_pair.{v} ⥤ C} (t : cocone F) (j) :
+  (cofork.of_cocone t).ι.app j = eq_to_hom (by tidy) ≫ t.ι.app j := rfl
+
+variable {C}
+
+section
+variables (f g)
+
+def equalizer.fork [has_equalizer f g] : fork f g := has_equalizer.fork.{u v} f g
+def coequalizer.cofork [has_coequalizer f g] : cofork f g := has_coequalizer.cofork.{u v} f g
+def equalizer [has_equalizer f g] := (equalizer.fork f g).X
+def coequalizer [has_coequalizer f g] := (coequalizer.cofork f g).X
+def equalizer.ι [has_equalizer f g] : equalizer f g ⟶ X := (equalizer.fork f g).π.app zero
+def coequalizer.π [has_coequalizer f g] : Y ⟶ coequalizer f g := (coequalizer.cofork f g).ι.app one
+@[simp] lemma equalizer.w [has_equalizer f g] : equalizer.ι f g ≫ f = equalizer.ι f g ≫ g :=
+begin
+  erw ((equalizer.fork f g).w left),
+  erw ((equalizer.fork f g).w right)
+end
+@[simp] lemma coequalizer.w
+  [has_coequalizer f g] : f ≫ coequalizer.π f g = g ≫ coequalizer.π f g :=
+begin
+  erw ((coequalizer.cofork f g).w left),
+  erw ((coequalizer.cofork f g).w right)
+end
+def equalizer.universal_property [has_equalizer f g] : is_equalizer (equalizer.fork f g) :=
+has_equalizer.is_equalizer f g
+def coequalizer.universal_property
+  [has_coequalizer f g] : is_coequalizer (coequalizer.cofork f g) :=
+has_coequalizer.is_coequalizer f g
+
+def equalizer.lift
+  [has_equalizer f g] {P : C} (h : P ⟶ X) (w : h ≫ f = h ≫ g) : P ⟶ equalizer f g :=
+(equalizer.universal_property f g).lift (fork.of_ι h w)
+def coequalizer.desc
+  [has_coequalizer f g] {P : C} (h : Y ⟶ P) (w : f ≫ h = g ≫ h) : coequalizer f g ⟶ P :=
+(coequalizer.universal_property f g).desc (cofork.of_π h w)
+
+@[simp] lemma equalizer.lift_ι [has_equalizer f g] {P : C} (h : P ⟶ X) (w : h ≫ f = h ≫ g) :
+  equalizer.lift f g h w ≫ equalizer.ι f g = h :=
+is_limit.fac _ _ _
+@[simp] lemma coequalizer.π_desc [has_coequalizer f g] {P : C} (h : Y ⟶ P) (w : f ≫ h = g ≫ h) :
+  coequalizer.π f g ≫ coequalizer.desc f g h w = h :=
+is_colimit.fac _ _ _
+
+instance [has_equalizer f g] : mono (equalizer.ι f g) :=
+(has_equalizer.is_equalizer f g).mono
+instance [has_coequalizer f g] : epi (coequalizer.π f g) :=
+(has_coequalizer.is_coequalizer f g).epi
+
+@[extensionality] lemma equalizer.hom_ext [has_equalizer f g] {P : C}
+  {h k : P ⟶ equalizer f g}
+  (w : h ≫ equalizer.ι f g = k ≫ equalizer.ι f g) : h = k := mono.right_cancellation h k w
+@[extensionality] lemma coequalizer.hom_ext [has_coequalizer f g] {P : C}
+  {h k : coequalizer f g ⟶ P}
+  (w : coequalizer.π f g ≫ h = coequalizer.π f g ≫ k) : h = k := epi.left_cancellation h k w
+
+instance has_limits_of_shape_of_has_equalizers [has_equalizers.{u v} C] :
+  limits.has_limits_of_shape.{u v} walking_pair.{v} C :=
+{ cone := λ F, cone.of_fork (equalizer.fork (F.map left) (F.map right)),
+  is_limit := λ F, let is_equalizer := equalizer.universal_property (F.map left) (F.map right) in
+  { lift := λ s, is_equalizer.lift (fork.of_cone s),
+    fac' := λ s j,
+    begin
+      dsimp at *,
+      cases j; simp,
+    end,
+    uniq' := λ s m w, is_equalizer.uniq (fork.of_cone s) m
+      (λ j, begin have h := w j, cases j; simp at *; exact h end) } }
+
+instance has_colimits_of_shape_of_has_coequalizers [has_coequalizers.{u v} C] :
+  limits.has_colimits_of_shape.{u v} walking_pair.{v} C :=
+{ cocone := λ F, cocone.of_cofork (coequalizer.cofork (F.map left) (F.map right)),
+  is_colimit := λ F,
+  let is_coequalizer := coequalizer.universal_property (F.map left) (F.map right) in
+  { desc := λ s, is_coequalizer.desc (cofork.of_cocone s),
+    fac' := λ s j,
+    begin
+      dsimp at *,
+      cases j; simp,
+    end,
+    uniq' := λ s m w, is_coequalizer.uniq (cofork.of_cocone s) m
+      (λ j, begin have h := w j, cases j; simp at *; exact h end) } }
+
+
+end
+
+end category_theory.limits

--- a/category_theory/limits/functor_category.lean
+++ b/category_theory/limits/functor_category.lean
@@ -1,0 +1,185 @@
+-- Copyright (c) 2018 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Scott Morrison
+
+import category_theory.products
+import category_theory.limits
+import category_theory.limits.preserves
+
+open category_theory
+
+namespace category_theory.limits
+
+universes u v
+
+variables {C : Type u} [𝒞 : category.{u v} C]
+include 𝒞
+
+variables {J K : Type v} [small_category J] [small_category K]
+
+@[simp] lemma cone.functor_w {F : J ⥤ (K ⥤ C)} (c : cone F) {j j' : J} (f : j ⟶ j') (k : K) :
+  (c.π.app j).app k ≫ (F.map f).app k = (c.π.app j').app k :=
+begin
+  have h := congr_fun (congr_arg (nat_trans.app) (eq.symm (c.π.naturality f))) k,
+  dsimp at h,
+  rw h,
+  simp,
+end
+@[simp] lemma cocone.functor_w {F : J ⥤ (K ⥤ C)} (c : cocone F) {j j' : J} (f : j ⟶ j') (k : K) :
+  (F.map f).app k ≫ (c.ι.app j').app k = (c.ι.app j).app k :=
+begin
+  have h := congr_fun (congr_arg (nat_trans.app) (eq.symm (c.ι.naturality f))) k,
+  dsimp at h,
+  simp at h,
+  rw h,
+end
+
+@[simp] def functor_category_limit_cone
+  [has_limits_of_shape.{u v} J C] (F : J ⥤ K ⥤ C) : cone F :=
+{ X := F.flip ⋙ lim,
+  π :=
+  { app := λ j,
+    { app := λ k, limit.π (F.flip.obj k) j },
+      naturality' := λ j j' f,
+        begin
+          dsimp, simp, ext k, dsimp,
+          erw limit.w (F.flip.obj k),
+        end } }
+@[simp] def functor_category_colimit_cocone
+  [has_colimits_of_shape.{u v} J C] (F : J ⥤ K ⥤ C) : cocone F :=
+{ X := F.flip ⋙ colim,
+  ι :=
+  { app := λ j,
+    { app := λ k , colimit.ι (F.flip.obj k) j },
+      naturality' := λ j j' f,
+        begin
+          dsimp, simp, ext k, dsimp,
+          erw colimit.w (F.flip.obj k),
+        end } }
+
+@[simp] def evaluate_functor_category_limit_cone
+  [has_limits_of_shape.{u v} J C] (F : J ⥤ K ⥤ C) (k : K) :
+  ((evaluation K C).obj k).map_cone (functor_category_limit_cone F) ≅
+    limit.cone (F.flip.obj k) :=
+by tidy
+@[simp] def evaluate_functor_category_colimit_cocone
+  [has_colimits_of_shape.{u v} J C] (F : J ⥤ K ⥤ C) (k : K) :
+  ((evaluation K C).obj k).map_cocone (functor_category_colimit_cocone F) ≅
+    colimit.cocone (F.flip.obj k) :=
+by tidy
+
+def functor_category_is_limit_cone [has_limits_of_shape.{u v} J C] (F : J ⥤ K ⥤ C) :
+  is_limit (functor_category_limit_cone F) :=
+{ lift := λ s,
+  { app := λ k, limit.lift (F.flip.obj k)
+    { X := s.X.obj k,
+      π := { app := λ j, (s.π.app j).app k } },
+    naturality' := λ k k' f,
+    begin
+      ext, dsimp, simp, rw nat_trans.naturality, refl,
+    end },
+  uniq' := λ s m w,
+  begin
+    ext k j, dsimp, simp,
+    rw ← w j,
+    refl
+  end }
+def functor_category_is_colimit_cocone [has_colimits_of_shape.{u v} J C] (F : J ⥤ K ⥤ C) :
+  is_colimit (functor_category_colimit_cocone F) :=
+{ desc := λ s,
+  { app := λ k, colimit.desc (F.flip.obj k)
+    { X := s.X.obj k,
+      ι := { app := λ j, (s.ι.app j).app k } },
+    naturality' := λ k k' f,
+    begin
+      ext, dsimp,
+      rw ←category.assoc, simp,
+      rw ←category.assoc, simp,
+      erw ← nat_trans.naturality, refl,
+    end },
+  uniq' := λ s m w,
+  begin
+    ext k j, dsimp, simp,
+    rw ← w j,
+    refl
+  end }
+
+instance functor_category_has_limits_of_shape
+  [has_limits_of_shape.{u v} J C] : has_limits_of_shape J (K ⥤ C) :=
+{ cone := λ F, functor_category_limit_cone F,
+  is_limit := λ F, functor_category_is_limit_cone F }
+instance functor_category_has_colimits_of_shape
+  [has_colimits_of_shape.{u v} J C] : has_colimits_of_shape J (K ⥤ C) :=
+{ cocone := λ F, functor_category_colimit_cocone F,
+  is_colimit := λ F, functor_category_is_colimit_cocone F }
+
+-- Perhaps we need hand-rolled versions of these? Let's see what people need.
+instance functor_category_has_products
+  [has_products.{u v} C] : has_products.{(max u v) v} (K ⥤ C) :=
+limits.has_products_of_has_limits
+instance functor_category_has_coproducts
+  [has_coproducts.{u v} C] : has_coproducts.{(max u v) v} (K ⥤ C) :=
+limits.has_coproducts_of_has_colimits
+instance functor_category_has_pullbacks
+  [has_pullbacks.{u v} C] : has_pullbacks.{(max u v) v} (K ⥤ C) :=
+limits.has_pullbacks_of_has_limits
+instance functor_category_has_pushouts
+  [has_pushouts.{u v} C] : has_pushouts.{(max u v) v} (K ⥤ C) :=
+limits.has_pushouts_of_has_colimits
+instance functor_category_has_equalizers
+  [has_equalizers.{u v} C] : has_equalizers.{(max u v) v} (K ⥤ C) :=
+limits.has_equalizers_of_has_limits
+instance functor_category_has_coequalizers
+  [has_coequalizers.{u v} C] : has_coequalizers.{(max u v) v} (K ⥤ C) :=
+limits.has_coequalizers_of_has_colimits
+
+instance functor_category_has_limits
+  [has_limits.{u v} C] : has_limits.{(max u v) v} (K ⥤ C) :=
+{ cone := λ J 𝒥 F, by resetI; exact functor_category_limit_cone F,
+  is_limit := λ J 𝒥 F, by resetI; exact functor_category_is_limit_cone F }
+instance functor_category_has_colimits
+  [has_colimits.{u v} C] : has_colimits.{(max u v) v} (K ⥤ C) :=
+{ cocone := λ J 𝒥 F, by resetI; exact functor_category_colimit_cocone F,
+  is_colimit := λ J 𝒥 F, by resetI; exact functor_category_is_colimit_cocone F }
+
+instance evaluation_preserves_limits_of_shape [has_limits_of_shape.{u v} J C] (k : K) :
+  preserves_limits_of_shape J ((evaluation.{v v u v} K C).obj k) :=
+{ preserves := λ F c h,
+  begin
+    have i : functor_category_limit_cone F ≅ c :=
+      limit_cone.ext (functor_category_is_limit_cone F) h,
+    apply is_limit_invariance _ _ (functor.on_iso _ i),
+
+    -- Next, we know exactly what the evaluation of the `product_cone F` is:
+    apply is_limit_invariance _ _ (evaluate_functor_category_limit_cone F k).symm,
+
+    -- Finally, it's just that the limit cone is a limit.
+    exact limit.universal_property _
+  end }
+instance evaluation_preserves_colimits_of_shape [has_colimits_of_shape.{u v} J C] (k : K) :
+  preserves_colimits_of_shape J ((evaluation.{v v u v} K C).obj k) :=
+{ preserves := λ F c h,
+  begin
+    have i : functor_category_colimit_cocone F ≅ c :=
+      colimit_cocone.ext (functor_category_is_colimit_cocone F) h,
+    apply is_colimit_invariance _ _ (functor.on_iso _ i),
+
+    -- Next, we know exactly what the evaluation of the `product_cocone F` is:
+    apply is_colimit_invariance _ _ (evaluate_functor_category_colimit_cocone F k).symm,
+
+    -- Finally, it's just that the colimit cocone is a colimit.
+    exact colimit.universal_property _
+  end }
+
+instance evaluation_preserves_limits [has_limits.{u v} C] (k : K) :
+  preserves_limits ((evaluation.{v v u v} K C).obj k) :=
+@preserves_limits_of_preserves_limits_of_all_shapes _ _ _ _
+  ((evaluation.{v v u v} K C).obj k)
+  (λ J 𝒥, by resetI; apply_instance)
+instance evaluation_preserves_colimits [has_colimits.{u v} C] (k : K) :
+  preserves_colimits ((evaluation.{v v u v} K C).obj k) :=
+@preserves_colimits_of_preserves_colimits_of_all_shapes _ _ _ _
+  ((evaluation.{v v u v} K C).obj k)
+  (λ J 𝒥, by resetI; apply_instance)
+
+end category_theory.limits

--- a/category_theory/limits/limits.lean
+++ b/category_theory/limits/limits.lean
@@ -1,0 +1,752 @@
+-- Copyright (c) 2018 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Scott Morrison, Reid Barton, Mario Carneiro
+
+import category_theory.whiskering
+import category_theory.yoneda
+import category_theory.limits.cones
+
+open category_theory
+
+namespace category_theory.limits
+
+universes u v w
+
+variables {J : Type v} [small_category J]
+variables {C : Type u} [𝒞 : category.{u v} C]
+include 𝒞
+
+section limit
+variables {F : J ⥤ C}
+
+structure is_limit (t : cone F) :=
+(lift : ∀ (s : cone F), s.X ⟶ t.X)
+(fac'  : ∀ (s : cone F) (j : J), (lift s ≫ t.π.app j) = s.π.app j . obviously)
+(uniq' : ∀ (s : cone F) (m : s.X ⟶ t.X) (w : ∀ j : J, (m ≫ t.π.app j) = s.π.app j), 
+  m = lift s . obviously)
+
+restate_axiom is_limit.fac'
+attribute [simp] is_limit.fac
+restate_axiom is_limit.uniq'
+
+@[simp] lemma is_limit.lift_self {t : cone F} (h : is_limit t) : h.lift t = 𝟙 t.X :=
+begin
+  symmetry,
+  apply h.uniq,
+  tidy,
+end
+
+def limit_cone.ext {s t : cone F} (P : is_limit s) (Q : is_limit t) : s ≅ t :=
+{ hom :=
+  { hom := Q.lift s,
+    w' := λ j, Q.fac s j },
+  inv := { hom := P.lift t },
+  hom_inv_id' :=
+  begin
+    ext, simp,
+    rw ← is_limit.lift_self P,
+    apply P.uniq,
+    tidy,
+  end,
+  inv_hom_id' :=
+  begin
+    ext, simp,
+    rw ← is_limit.lift_self Q,
+    apply Q.uniq,
+    tidy,
+  end }
+
+def is_limit_invariance (r t : cone F) (i : r ≅ t) (P : is_limit r) : is_limit t :=
+{ lift := λ s, P.lift s ≫ i.hom.hom,
+  uniq' :=
+  begin
+    tidy,
+    have h : m ≫ i.inv.hom = P.lift s,
+    { apply P.uniq,
+      intro j,
+      rw category.assoc,
+      rw i.inv.w,
+      exact w j },
+    replace h := congr_arg (λ p, p ≫ i.hom.hom) h,
+    dsimp at h,
+    rw category.assoc at h,
+    have p := congr_arg cone_morphism.hom i.inv_hom_id,
+    dsimp at p,
+    rw p at h,
+    simp at h,
+    exact h
+  end }
+
+variables {t : cone F}
+
+@[extensionality] lemma is_limit.ext (P Q : is_limit t) : P = Q :=
+begin
+  tactic.unfreeze_local_instances,
+  cases P, cases Q,
+  congr,
+  ext1,
+  solve_by_elim,
+ end
+
+instance is_limit_subsingleton : subsingleton (is_limit t) := by tidy
+
+lemma is_limit.universal (h : is_limit t) (s : cone F) (φ : s.X ⟶ t.X) :
+  (∀ j, φ ≫ t.π.app j = s.π.app j) ↔ (φ = is_limit.lift h s) :=
+/- obviously says: -/
+⟨ is_limit.uniq h s φ,
+  begin
+    intros a j,
+    rw a,
+    rw ←is_limit.fac h,
+    simp at *,
+  end ⟩
+
+lemma is_limit.hom_lift (h : is_limit t) {X' : C} (m : X' ⟶ t.X) :
+  m = h.lift { X := X', π := { app := λ b, m ≫ t.π.app b } } :=
+h.uniq { X := X', π := { app := λ b, m ≫ t.π.app b } } m (λ b, rfl)
+
+lemma is_limit.hom_ext (h : is_limit t) {W : C} {f g : W ⟶ t.X}
+  (w : ∀ j, f ≫ t.π.app j = g ≫ t.π.app j) : f = g :=
+by rw [h.hom_lift f, h.hom_lift g]; congr; exact funext w
+
+def is_limit.of_lift_universal
+  (lift : Π (s : cone F), s.X ⟶ t.X)
+  (universal : Π (s : cone F) (φ : s.X ⟶ t.X),
+    (∀ j : J, (φ ≫ t.π.app j) = s.π.app j) ↔ (φ = lift s)) : is_limit t :=
+{ lift := lift,
+  fac'  := λ s j, ((universal s (lift s)).mpr (eq.refl (lift s))) j,
+  uniq' := λ s φ, (universal s φ).mp }
+
+def is_limit.equiv (h : is_limit t) (X' : C) : (X' ⟶ t.X) ≅ ((functor.const J).obj X' ⟹ F) :=
+{ hom := λ f, (t.extend f).π,
+  inv := λ π, h.lift { X := X', π := π },
+  hom_inv_id' :=
+  begin
+    tidy, symmetry,
+    apply h.uniq {X := X', π := (limits.cone.extend t x).π} x,
+    tidy,
+  end }
+
+@[simp] lemma is_limit.equiv_hom (h : is_limit t) (X' : C) (f : X' ⟶ t.X) :
+  (is_limit.equiv h X').hom f = (t.extend f).π := rfl
+
+def is_limit.natural_equiv (h : is_limit t) : yoneda.obj t.X ≅ F.cones :=
+nat_iso.of_components (is_limit.equiv h) (by tidy)
+
+def is_limit.of_extensions_iso (h : is_iso t.extensions) : is_limit t :=
+{ lift := λ s, (inv t.extensions).app s.X s.π,
+  fac' := λ s j,
+    show ((inv t.extensions ≫ t.extensions).app s.X s.π).app j = _,
+    by erw @is_iso.inv_hom_id _ _ _ _ _ h; refl,
+  uniq' := λ s m hm, begin
+    have : m = (t.extensions ≫ inv t.extensions).app s.X m,
+      by erw @is_iso.hom_inv_id _ _ _ _ _ h; refl,
+    rw this,
+    have : s.π = (functor.const J).map m ≫ t.π, by ext j; exact (hm j).symm,
+    rw this,
+    refl
+  end }
+
+end limit
+
+variables (J C)
+
+class has_limits :=
+(cone : Π {J : Type v} [small_category J] (F : J ⥤ C), cone F)
+(is_limit : Π {J : Type v} [small_category J] (F : J ⥤ C), is_limit (cone F))
+
+class has_limits_of_shape :=
+(cone : Π F : J ⥤ C, cone F)
+(is_limit : Π F : J ⥤ C, is_limit (cone F))
+
+variables {J C}
+
+class has_limit {J : Type v} [small_category J] (F : J ⥤ C) :=
+(cone : cone F)
+(is_limit : is_limit cone)
+
+def cone.of_representable_cones (F : J ⥤ C) [r : representable F.cones] : cone F :=
+{ X := r.X,
+  π := r.w.hom.app r.X (𝟙 r.X) }
+
+lemma cone.of_representable_cones_extension (F : J ⥤ C) (r : representable F.cones) :
+  (cone.of_representable_cones F).extensions = r.w.hom :=
+begin
+  ext1 Z, ext1 f,
+  have : ((yoneda.obj r.X).map f ≫ r.w.hom.app  Z) (𝟙 _) = _, by rw [r.w.hom.naturality f],
+  simpa using this.symm
+end
+
+def extensions_iso_of_representable_cones (F : J ⥤ C) [r : representable F.cones] :
+  is_iso (cone.of_representable_cones F).extensions :=
+{ inv := r.w.inv,
+  hom_inv_id' := by rw cone.of_representable_cones_extension; exact r.w.hom_inv_id',
+  inv_hom_id' := by rw cone.of_representable_cones_extension; exact r.w.inv_hom_id' }
+
+def has_limit_of_cones_representable (F : J ⥤ C) [r : representable F.cones] : has_limit F :=
+{ cone := cone.of_representable_cones F,
+  is_limit := is_limit.of_extensions_iso (extensions_iso_of_representable_cones F) }
+
+def cones_representable_of_has_limit (F : J ⥤ C) [has_limit F] : representable F.cones :=
+{ X := (has_limit.cone F).X,
+  w := (has_limit.is_limit F).natural_equiv }
+
+instance has_limit_of_has_limits_of_shape
+  {J : Type v} [small_category J] [has_limits_of_shape.{u v} J C] (F : J ⥤ C) : has_limit F :=
+{ cone := has_limits_of_shape.cone F,
+  is_limit := has_limits_of_shape.is_limit F }
+
+instance has_limits_of_shape_of_has_limits
+  {J : Type v} [small_category J] [has_limits.{u v} C] : has_limits_of_shape.{u v} J C :=
+{ cone := λ F, has_limits.cone F,
+  is_limit := λ F, has_limits.is_limit F }
+
+section colimit
+variables {F : J ⥤ C}
+
+structure is_colimit (t : cocone F) :=
+(desc : ∀ (s : cocone F), t.X ⟶ s.X)
+(fac'  : ∀ (s : cocone F) (j : J), (t.ι.app j ≫ desc s) = s.ι.app j . obviously)
+(uniq' : ∀ (s : cocone F) (m : t.X ⟶ s.X) (w : ∀ j : J, (t.ι.app j ≫ m) = s.ι.app j),
+  m = desc s . obviously)
+
+restate_axiom is_colimit.fac'
+attribute [simp] is_colimit.fac
+restate_axiom is_colimit.uniq'
+
+@[simp] lemma is_colimit.desc_self {t : cocone F} (h : is_colimit t) : h.desc t = 𝟙 t.X :=
+begin
+  symmetry,
+  apply h.uniq,
+  tidy,
+end
+
+def colimit_cocone.ext {s t : cocone F} (P : is_colimit s) (Q : is_colimit t) : s ≅ t :=
+{ hom := { hom := P.desc t },
+  inv := { hom := Q.desc s,
+    w' := λ j, Q.fac s j },
+  hom_inv_id' :=
+  begin
+    ext, simp,
+    rw ← is_colimit.desc_self P,
+    apply P.uniq,
+    intro j,
+    rw ← category.assoc,
+    tidy,
+  end,
+  inv_hom_id' :=
+  begin
+    ext, simp,
+    rw ← is_colimit.desc_self Q,
+    apply Q.uniq,
+    intro j,
+    rw ← category.assoc,
+    tidy,
+  end }
+
+def is_colimit_invariance (r t : cocone F) (i : r ≅ t) (P : is_colimit r) : is_colimit t :=
+{ desc := λ s, i.inv.hom ≫ P.desc s,
+  fac' := λ s j, begin rw [←category.assoc, ←i.hom.w], simp, end,
+  uniq' :=
+  begin
+    tidy,
+    have h : i.hom.hom ≫ m = P.desc s,
+    { apply P.uniq,
+      intro j,
+      rw ← category.assoc,
+      rw i.hom.w,
+      exact w j },
+    replace h := congr_arg (λ p, i.inv.hom ≫ p) h,
+    dsimp at h,
+    rw ← category.assoc at h,
+    have p := congr_arg cocone_morphism.hom i.inv_hom_id,
+    dsimp at p,
+    rw p at h,
+    simp at h,
+    exact h
+  end }
+
+variables {t : cocone F}
+
+@[extensionality] lemma is_colimit.ext (P Q : is_colimit t) : P = Q :=
+begin
+  tactic.unfreeze_local_instances,
+  cases P, cases Q,
+  congr,
+  ext1,
+  solve_by_elim,
+end
+
+instance is_colimit_subsingleton : subsingleton (is_colimit t) := by tidy
+
+lemma is_colimit.universal (h : is_colimit t) (s : cocone F) (φ : t.X ⟶ s.X) :
+  (∀ j, t.ι.app j ≫ φ = s.ι.app j) ↔ (φ = is_colimit.desc h s) :=
+⟨ is_colimit.uniq h s φ,
+  begin
+    intros a j,
+    rw a,
+    rw ←is_colimit.fac h,
+    simp at *,
+  end ⟩
+
+lemma is_colimit.hom_desc (h : is_colimit t) {X' : C} (m : t.X ⟶ X') :
+  m = h.desc { X := X', ι := { app := λ b, t.ι.app b ≫ m,
+    naturality' := by intros X Y f; rw ←category.assoc; dsimp; simp } } :=
+h.uniq { X := X', ι := { app := λ b, t.ι.app b ≫ m, naturality' := _ } } m (λ b, rfl)
+
+lemma is_colimit.hom_ext (h : is_colimit t) {W : C} {f g : t.X ⟶ W}
+  (w : ∀ j, t.ι.app j ≫ f = t.ι.app j ≫ g) : f = g :=
+by rw [h.hom_desc f, h.hom_desc g]; congr; exact funext w
+
+def is_colimit.of_desc_universal
+  (desc : Π (s : cocone F), t.X ⟶ s.X)
+  (universal : Π (s : cocone F) (φ : t.X ⟶ s.X),
+    (∀ j : J, (t.ι.app j ≫ φ) = s.ι.app j) ↔ (φ = desc s)) : is_colimit t :=
+{ desc := desc,
+  fac'  := λ s j, ((universal s (desc s)).mpr (eq.refl (desc s))) j,
+  uniq' := λ s φ, (universal s φ).mp }
+
+end colimit
+
+variables (J C)
+
+class has_colimits :=
+(cocone : Π {J : Type v} [small_category J] (F : J ⥤ C), cocone F)
+(is_colimit : Π {J : Type v} [small_category J] (F : J ⥤ C), is_colimit (cocone F))
+
+class has_colimits_of_shape :=
+(cocone : Π F : J ⥤ C, cocone F)
+(is_colimit : Π F : J ⥤ C, is_colimit (cocone F))
+
+variables {J C}
+
+class has_colimit {J : Type v} [small_category J] (F : J ⥤ C) :=
+(cocone : cocone F)
+(is_colimit : is_colimit cocone)
+
+instance has_colimit_of_has_colimits_of_shape
+  {J : Type v} [small_category J] [has_colimits_of_shape.{u v} J C] (F : J ⥤ C) : has_colimit F :=
+{ cocone := has_colimits_of_shape.cocone F,
+  is_colimit := has_colimits_of_shape.is_colimit F }
+
+instance has_colimits_of_shape_of_has_colimits
+  {J : Type v} [small_category J] [has_colimits.{u v} C] : has_colimits_of_shape.{u v} J C :=
+{ cocone := λ F, has_colimits.cocone F,
+  is_colimit := λ F, has_colimits.is_colimit F }
+
+
+
+section
+
+def limit.cone (F : J ⥤ C) [has_limit F] : cone F := has_limit.cone.{u v} F
+def limit (F : J ⥤ C) [has_limit F] := (limit.cone F).X
+def limit.π (F : J ⥤ C) [has_limit F] (j : J) : limit F ⟶ F.obj j :=
+(limit.cone F).π.app j
+@[simp] lemma limit.w (F : J ⥤ C) [has_limit F] {j j' : J} (f : j ⟶ j') :
+  limit.π F j ≫ F.map f = limit.π F j' := (limit.cone F).w f
+def limit.universal_property (F : J ⥤ C) [has_limit F] : is_limit (limit.cone F) :=
+has_limit.is_limit.{u v} F
+
+-- We could make `F` an implicit argument here, but it seems to make usage more confusing.
+def limit.lift (F : J ⥤ C) [has_limit F] (c : cone F) : c.X ⟶ limit F :=
+(limit.universal_property F).lift c
+@[simp] lemma limit.universal_property_lift {F : J ⥤ C} [has_limit F] (c : cone F) :
+  (limit.universal_property F).lift c = limit.lift F c := rfl
+
+@[simp] lemma limit.lift_π {F : J ⥤ C} [has_limit F] (c : cone F) (j : J) :
+  limit.lift F c ≫ limit.π F j = c.π.app j :=
+is_limit.fac _ c j
+
+-- We need to be really explicit about the coercion we're simplifying here.
+@[simp] lemma limit.cone_π {F : J ⥤ C} [has_limit F] (j : J) :
+  (limit.cone F).π.app j = (@limit.π J _ C _ F _ j) := rfl
+
+def limit.cone_morphism {F : J ⥤ C} [has_limit F] (c : cone F) : cone_morphism c (limit.cone F) :=
+{ hom := (limit.lift F) c }
+
+@[simp] lemma limit.cone_morphism_hom {F : J ⥤ C} [has_limit F] (c : cone F) :
+  (limit.cone_morphism c).hom = limit.lift F c := rfl
+@[simp] lemma limit.cone_morphism_π {F : J ⥤ C} [has_limit F] (c : cone F) (j : J) :
+  (limit.cone_morphism c).hom ≫ (limit.π F j) = c.π.app j :=
+by erw is_limit.fac
+
+@[extensionality] lemma limit.hom_ext {F : J ⥤ C} [has_limit F] {X : C}
+  {f g : X ⟶ limit F}
+  (w : ∀ j, f ≫ limit.π F j = g ≫ limit.π F j) : f = g :=
+(limit.universal_property F).hom_ext w
+
+lemma limit.lift_extend {F : J ⥤ C} [has_limit F] (c : cone F) {X : C} (f : X ⟶ c.X) :
+  limit.lift F (c.extend f) = f ≫ limit.lift F c :=
+by obviously
+
+/-- `limit F` is functorial in `F`. -/
+def lim [has_limits_of_shape.{u v} J C] : (J ⥤ C) ⥤ C :=
+{ obj := λ F, limit F,
+  map := λ F F' t, limit.lift F' $
+  { X := limit F,
+    π :=
+    { app := λ j, limit.π F j ≫ t.app j,
+      naturality' :=
+      begin
+        /- `obviously` says -/
+        intros j j' f, simp,
+        erw [category.id_comp, ←t.naturality, ←category.assoc, limit.w],
+      end } },
+  map_comp' :=
+  begin
+    /- `obviously` says -/
+    intros X Y Z f g, ext1, simp,
+    conv { to_rhs, rw ←category.assoc },
+    simp
+  end }.
+
+@[simp] lemma lim_map_π [has_limits_of_shape.{u v} J C] {F G : J ⥤ C} (α : F ⟹ G) (j : J) :
+  lim.map α ≫ limit.π G j = limit.π F j ≫ α.app j :=
+by erw is_limit.fac
+
+@[simp] lemma limit.lift_map
+  [has_limits_of_shape.{u v} J C] {F G : J ⥤ C} (c : cone F) (α : F ⟹ G) :
+  limit.lift F c ≫ lim.map α = limit.lift G (c.postcompose α) :=
+begin
+  /- `obviously` says -/
+  ext1, simp,
+  erw ←category.assoc,
+  simp,
+  refl
+end
+
+section
+variables {K : Type v} [𝒦 : small_category K]
+include 𝒦
+
+def limit.pre (F : J ⥤ C)
+  [has_limit F] (E : K ⥤ J) [has_limit (E ⋙ F)] : limit F ⟶ limit (E ⋙ F) :=
+limit.lift (E ⋙ F)
+  { X := limit F,
+    π := { app := λ k, limit.π F (E.obj k) } }
+
+@[simp] lemma limit.pre_π (F : J ⥤ C) [has_limit F] (E : K ⥤ J) [has_limit (E ⋙ F)] (k : K) :
+  limit.pre F E ≫ limit.π (E ⋙ F) k = limit.π F (E.obj k) :=
+by erw is_limit.fac
+
+@[simp] lemma limit.lift_pre
+  {F : J ⥤ C} [has_limit F] (c : cone F) (E : K ⥤ J) [has_limit (E ⋙ F)] :
+  limit.lift F c ≫ limit.pre F E = limit.lift (E ⋙ F) (c.whisker E) :=
+by obviously
+
+lemma limit.map_pre
+  [has_limits_of_shape.{u v} J C] [has_limits_of_shape.{u v} K C]
+  {F G : J ⥤ C} (α : F ⟹ G) (E : K ⥤ J) :
+  lim.map α ≫ limit.pre G E = limit.pre F E ≫ lim.map (whisker_left E α) :=
+begin
+  /- `obviously` says -/
+  ext1, dsimp at *, simp at *,
+  erw [←category.assoc, is_limit.fac],
+end
+
+@[simp] lemma limit.pre_pre
+  {L : Type v} [small_category L]
+  (F : J ⥤ C) [has_limit F] (E : K ⥤ J) [has_limit (E ⋙ F)] (D : L ⥤ K) [has_limit (D ⋙ E ⋙ F)] :
+  limit.pre F E ≫ limit.pre (E ⋙ F) D = limit.pre F (D ⋙ E) :=
+begin
+  /- `obviously` says -/
+  ext1, dsimp, simp,
+  erw limit.pre_π, -- isn't it sad this simp lemma isn't applied by simp?
+  refl
+end
+end
+
+section
+variables {D : Type u} [𝒟 : category.{u v} D]
+include 𝒟
+
+def limit.post
+  (F : J ⥤ C) [has_limit F] (G : C ⥤ D) [has_limit (F ⋙ G)] : G.obj (limit F) ⟶ limit (F ⋙ G) :=
+limit.lift (F ⋙ G)
+{ X := _,
+  π :=
+  { app := λ j, G.map (limit.π F j),
+    naturality' :=
+    begin
+      /- `obviously` says -/
+      intros j j' f, dsimp at *,
+      erw [←functor.map_comp, limits.cone.w, category.id_comp],
+      refl
+    end } }
+
+@[simp] lemma limit.post_π (F : J ⥤ C) [has_limit F] (G : C ⥤ D) [has_limit (F ⋙ G)] (j : J) :
+  limit.post F G ≫ limit.π (F ⋙ G) j = G.map (limit.π F j) :=
+by erw is_limit.fac
+
+@[simp] lemma limit.lift_post
+  {F : J ⥤ C} [has_limit F] (c : cone F) (G : C ⥤ D) [has_limit (F ⋙ G)] :
+  G.map (limit.lift F c) ≫ limit.post F G = limit.lift (F ⋙ G) (G.map_cone c) :=
+begin
+  /- `obviously` says -/
+  ext1, dsimp at *, simp at *,
+  erw ←functor.map_comp,
+  simp,
+end
+
+lemma limit.map_post
+  [has_limits_of_shape.{u v} J C] [has_limits_of_shape.{u v} J D]
+  {F G : J ⥤ C} (α : F ⟹ G) (H : C ⥤ D) :
+/- H (limit F) ⟶ H (limit G) ⟶ limit (G ⋙ H) vs
+   H (limit F) ⟶ limit (F ⋙ H) ⟶ limit (G ⋙ H) -/
+  H.map (lim.map α) ≫ limit.post G H = limit.post F H ≫ lim.map (whisker_right α H) :=
+begin
+  /- `obviously` says -/
+  ext1, dsimp, simp, dsimp,
+  rw ← category.assoc,
+  simp,
+  rw ←functor.map_comp,
+  rw ←functor.map_comp,
+  simp,
+end.
+
+lemma limit.pre_post
+  {K : Type v} [small_category K]
+  (F : J ⥤ C) [has_limit F]
+  (E : K ⥤ J) [has_limit (E ⋙ F)]
+  (G : C ⥤ D) [has_limit (F ⋙ G)] [has_limit ((E ⋙ F) ⋙ G)]:
+/- G (limit F) ⟶ G (limit (E ⋙ F)) ⟶ limit ((E ⋙ F) ⋙ G) vs -/
+/- G (limit F) ⟶ limit F ⋙ G ⟶ limit (E ⋙ (F ⋙ G)) or -/
+  G.map (limit.pre F E) ≫ limit.post (E ⋙ F) G = limit.post F G ≫ limit.pre (F ⋙ G) E :=
+begin
+  /- `obviously` says -/
+  ext1, dsimp at *, simp at *, dsimp at *,
+  erw [←functor.map_comp, limit.pre_π F E j, limit.pre_π],
+  simp,
+end.
+
+@[simp] lemma limit.post_post
+  {E : Type u} [category.{u v} E]
+  (F : J ⥤ C) [has_limit F] (G : C ⥤ D) [has_limit (F ⋙ G)] (H : D ⥤ E) [has_limit ((F ⋙ G) ⋙ H)] :
+/- H G (limit F) ⟶ H (limit (F ⋙ G)) ⟶ limit ((F ⋙ G) ⋙ H) vs -/
+/- H G (limit F) ⟶ limit (F ⋙ (G ⋙ H)) or -/
+  H.map (limit.post F G) ≫ limit.post (F ⋙ G) H = limit.post F (G ⋙ H) :=
+begin
+  /- `obviously` says -/
+  ext1, dsimp at *, simp at *, dsimp at *,
+  erw [←functor.map_comp, limit.post_π],
+  conv { to_rhs, rw [limit.post_π] {md:=semireducible} },
+  refl,
+end
+end
+
+end
+
+section
+
+def colimit.cocone (F : J ⥤ C) [has_colimit F] : cocone F := has_colimit.cocone.{u v} F
+def colimit (F : J ⥤ C) [has_colimit F] := (colimit.cocone F).X
+def colimit.ι (F : J ⥤ C) [has_colimit F] (j : J) : F.obj j ⟶ colimit F :=
+(colimit.cocone F).ι.app j
+@[simp] lemma colimit.w
+  (F : J ⥤ C) [has_colimit F] {j j' : J} (f : j ⟶ j') : F.map f ≫ colimit.ι F j' = colimit.ι F j :=
+(colimit.cocone F).w f
+def colimit.universal_property (F : J ⥤ C) [has_colimit F] : is_colimit (colimit.cocone F) :=
+has_colimit.is_colimit.{u v} F
+
+def colimit.desc (F : J ⥤ C) [has_colimit F] (c : cocone F) : colimit F ⟶ c.X :=
+(colimit.universal_property F).desc c
+@[simp] lemma colimit.universal_property_desc (F : J ⥤ C) [has_colimit F] (c : cocone F) :
+  (colimit.universal_property F).desc c = colimit.desc F c := rfl
+
+@[simp] lemma colimit.ι_desc {F : J ⥤ C} [has_colimit F] (c : cocone F) (j : J) :
+  colimit.ι F j ≫ colimit.desc F c = c.ι.app j :=
+is_colimit.fac _ c j
+
+@[simp] lemma colimit.cone_ι {F : J ⥤ C} [has_colimit F] (j : J) :
+  (colimit.cocone F).ι.app j = (@colimit.ι J _ C _ F _ j) := rfl
+
+def colimit.cocone_morphism
+  {F : J ⥤ C} [has_colimit F] (c : cocone F) : cocone_morphism (colimit.cocone F) c :=
+{ hom := (colimit.desc F) c }
+
+@[simp] lemma colimit.cocone_morphism_hom {F : J ⥤ C} [has_colimit F] (c : cocone F) :
+  (colimit.cocone_morphism c).hom = colimit.desc F c := rfl
+@[simp] lemma colimit.ι_cocone_morphism {F : J ⥤ C} [has_colimit F] (c : cocone F) (j : J) :
+  (colimit.ι F j) ≫ (colimit.cocone_morphism c).hom = c.ι.app j :=
+by erw is_colimit.fac
+
+@[extensionality] lemma colimit.hom_ext {F : J ⥤ C} [has_colimit F] {X : C}
+  {f g : colimit F ⟶ X}
+  (w : ∀ j, colimit.ι F j ≫ f = colimit.ι F j ≫ g) : f = g :=
+(colimit.universal_property F).hom_ext w
+
+lemma colimit.desc_extend (F : J ⥤ C) [has_colimit F] (c : cocone F) {X : C} (f : c.X ⟶ X) :
+  colimit.desc F (c.extend f) = colimit.desc F c ≫ f :=
+begin
+  /- obviously says: -/
+  ext1, simp at *, erw ←category.assoc, simp, refl
+end
+
+/-- `colimit F` is functorial in `F`. -/
+def colim [has_colimits_of_shape.{u v} J C] : (J ⥤ C) ⥤ C :=
+{ obj := λ F, colimit F,
+  map := λ F F' t, colimit.desc F $
+  { X := colimit F',
+    ι :=
+    { app := λ j, t.app j ≫ colimit.ι F' j,
+      naturality' :=
+      begin
+        /- `obviously` says -/
+        intros j j' f,
+        erw [←category.assoc,
+              nat_trans.naturality,
+              category.assoc,
+              limits.cocone.w],
+        dsimp,
+        simp,
+      end } },
+  map_comp' :=
+  begin
+    /- `obviously` says -/
+    intros X Y Z f g, ext1, dsimp at *, simp at *,
+    conv { to_rhs, rw ←category.assoc },
+    simp
+  end }.
+
+@[simp] lemma colim_ι_map [has_colimits_of_shape.{u v} J C] {F G : J ⥤ C} (α : F ⟹ G) (j : J) :
+  colimit.ι F j ≫ colim.map α = α.app j ≫ colimit.ι G j :=
+by erw is_colimit.fac
+
+@[simp] lemma colimit.map_desc
+  [has_colimits_of_shape.{u v} J C] {F G : J ⥤ C} (c : cocone G) (α : F ⟹ G) :
+  colim.map α ≫ colimit.desc G c = colimit.desc F (c.precompose α) :=
+begin
+  /- `obviously` says -/
+  ext1, simp,
+  erw ←category.assoc,
+  simp,
+  refl
+end
+
+section
+variables {K : Type v} [𝒦 : small_category K]
+include 𝒦
+
+def colimit.pre
+  (F : J ⥤ C) [has_colimit F]
+  (E : K ⥤ J) [has_colimit (E ⋙ F)] : colimit (E ⋙ F) ⟶ colimit F :=
+colimit.desc (E ⋙ F)
+{ X := colimit F,
+  ι := { app := λ k, colimit.ι F (E.obj k) } }
+
+@[simp] lemma colimit.ι_pre (F : J ⥤ C) [has_colimit F] (E : K ⥤ J) [has_colimit (E ⋙ F)] (k : K) :
+  colimit.ι (E ⋙ F) k ≫ colimit.pre F E = colimit.ι F (E.obj k) :=
+by erw is_colimit.fac
+
+@[simp] lemma colimit.desc_pre
+  {F : J ⥤ C} [has_colimit F] (c : cocone F) (E : K ⥤ J) [has_colimit (E ⋙ F)] :
+  colimit.pre F E ≫ colimit.desc F c = colimit.desc (E ⋙ F) (c.whisker E) :=
+begin
+  /- `obviously` says -/
+  ext1, dsimp at *, simp at *,
+  rw ←category.assoc,
+  simp,
+end
+
+lemma colimit.map_pre
+  [has_colimits_of_shape.{u v} J C] [has_colimits_of_shape.{u v} K C]
+  {F G : J ⥤ C} (α : F ⟹ G) (E : K ⥤ J) :
+  colimit.pre F E ≫ colim.map α = colim.map (whisker_left E α) ≫ colimit.pre G E :=
+begin
+  /- `obviously` says -/
+  ext1, dsimp,
+  conv {to_rhs, rw ←category.assoc},
+  simp,
+  rw ←category.assoc,
+  simp
+end.
+
+@[simp] lemma colimit.pre_pre
+  {L : Type v} [small_category L]
+  (F : J ⥤ C) [has_colimit F]
+  (E : K ⥤ J) [has_colimit (E ⋙ F)]
+  (D : L ⥤ K) [has_colimit (D ⋙ E ⋙ F)]:
+  colimit.pre (E ⋙ F) D ≫ colimit.pre F E = colimit.pre F (D ⋙ E) :=
+begin
+  /- `obviously` says -/
+  ext1, dsimp at *,
+  conv { to_lhs, rw [←category.assoc, colimit.ι_pre, is_colimit.fac] {md:=semireducible} },
+  conv { to_rhs, rw [is_colimit.fac] {md:=semireducible} },
+refl
+end
+
+end
+
+section
+variables {D : Type u} [𝒟 : category.{u v} D]
+include 𝒟
+
+def colimit.post
+  (F : J ⥤ C) [has_colimit F]
+  (G : C ⥤ D) [has_colimit (F ⋙ G)] : colimit (F ⋙ G) ⟶ G.obj (colimit F) :=
+colimit.desc (F ⋙ G)
+{ X := _,
+  ι :=
+  { app := λ j, G.map (colimit.ι F j),
+    naturality' :=
+    begin
+      /- `obviously` says -/
+      intros j j' f, dsimp at *,
+      erw [←functor.map_comp, limits.cocone.w],
+      dsimp,
+      simp,
+    end } }
+
+@[simp] lemma colimit.ι_post
+  (F : J ⥤ C) [has_colimit F] (G : C ⥤ D) [has_colimit (F ⋙ G)] (j : J) :
+  colimit.ι (F ⋙ G) j ≫ colimit.post F G = G.map (colimit.ι F j) :=
+by erw is_colimit.fac
+
+@[simp] lemma colimit.desc_post
+  {F : J ⥤ C} [has_colimit F] (c : cocone F) (G : C ⥤ D) [has_colimit (F ⋙ G)] :
+  colimit.post F G ≫ G.map (colimit.desc F c) = colimit.desc (F ⋙ G) (G.map_cocone c) :=
+begin
+  /- `obviously` says -/
+  ext1, dsimp at *, simp at *,
+  rw ←category.assoc,
+  simp,
+  rw ←functor.map_comp,
+  simp,
+end
+
+lemma colimit.post_map [has_colimits_of_shape.{u v} J C] [has_colimits_of_shape.{u v} J D]
+  {F G : J ⥤ C} (α : F ⟹ G) (H : C ⥤ D) :
+  colimit.post F H ≫ H.map (colim.map α) = colim.map (whisker_right α H) ≫ colimit.post G H :=
+begin
+  /- `obviously` says -/
+  ext1, dsimp,
+  rw [←category.assoc],
+  erw [is_colimit.fac],
+  dsimp,
+  rw [←category.assoc],
+  simp,
+  rw ← functor.map_comp,
+  rw ← functor.map_comp,
+  simp,
+end
+
+-- TODO, later, as needed
+/-
+lemma colimit.pre_post {K : Type v} [small_category K]
+  (F : J ⥤ C) [has_colimit F] (E : K ⥤ J) [has_colimit (E ⋙ F)]
+  (G : C ⥤ D) [has_colimit (F ⋙ G)] [has_colimit (E ⋙ F ⋙ G)] :
+  colimit.pre (F ⋙ G) E ≫ colimit.post F G =
+    colimit.post (E ⋙ F) G ≫ G.map (colimit.pre F E) := ...
+
+@[simp] lemma colimit.post_post
+  {E : Type u} [category.{u v} E]
+  (F : J ⥤ C) [has_colimit F]
+  (G : C ⥤ D) [has_colimit (F ⋙ G)]
+  (H : D ⥤ E) [has_colimit ((F ⋙ G) ⋙ H)] :
+  colimit.post (F ⋙ G) H ≫ H.map (colimit.post F G) = colimit.post F (G ⋙ H) := ...
+-/
+
+end
+end
+
+end category_theory.limits

--- a/category_theory/limits/limits.lean
+++ b/category_theory/limits/limits.lean
@@ -22,7 +22,7 @@ variables {F : J ⥤ C}
 structure is_limit (t : cone F) :=
 (lift : ∀ (s : cone F), s.X ⟶ t.X)
 (fac'  : ∀ (s : cone F) (j : J), (lift s ≫ t.π.app j) = s.π.app j . obviously)
-(uniq' : ∀ (s : cone F) (m : s.X ⟶ t.X) (w : ∀ j : J, (m ≫ t.π.app j) = s.π.app j), 
+(uniq' : ∀ (s : cone F) (m : s.X ⟶ t.X) (w : ∀ j : J, (m ≫ t.π.app j) = s.π.app j),
   m = lift s . obviously)
 
 restate_axiom is_limit.fac'
@@ -375,6 +375,25 @@ by erw is_limit.fac
   (w : ∀ j, f ≫ limit.π F j = g ≫ limit.π F j) : f = g :=
 (limit.universal_property F).hom_ext w
 
+def limit.hom_equiv {F : J ⥤ C} [has_limit F] (P : C) : (P ⟶ limit F) ≅ (F.cones.obj P) :=
+{ hom := λ f, cones_of_cone ((limit.cone F).extend f),
+  inv := λ c, limit.lift F (cone_of_cones c) }
+
+def limit.hom_equiv' {F : J ⥤ C} [has_limit F] (P : C) :
+  (P ⟶ limit F) ≅ { p : Π j, P ⟶ F.obj j // ∀ {j j' : J} (f : j ⟶ j'), p j ≫ F.map f = p j' } :=
+limit.hom_equiv P ≪≫
+{ hom := λ π,
+  ⟨ λ j, π.app j, λ j j' f,
+    begin
+      let g := (π.naturality f).symm,
+      dsimp at g,
+      erw [category.id_comp] at g,
+      exact g,
+    end ⟩,
+  inv := λ p,
+  { app := λ j, p.1 j,
+    naturality' := λ j j' f, begin dsimp, erw [category.id_comp], exact (p.2 f).symm end } }
+
 lemma limit.lift_extend {F : J ⥤ C} [has_limit F] (c : cone F) {X : C} (f : X ⟶ c.X) :
   limit.lift F (c.extend f) = f ≫ limit.lift F c :=
 by obviously
@@ -574,6 +593,25 @@ by erw is_colimit.fac
   {f g : colimit F ⟶ X}
   (w : ∀ j, colimit.ι F j ≫ f = colimit.ι F j ≫ g) : f = g :=
 (colimit.universal_property F).hom_ext w
+
+def colimit.hom_equiv {F : J ⥤ C} [has_colimit F] (P : C) : (colimit F ⟶ P) ≅ (F.cocones.obj P) :=
+{ hom := λ f, cocones_of_cocone ((colimit.cocone F).extend f),
+  inv := λ c, colimit.desc F (cocone_of_cocones c) }
+
+def colimit.hom_equiv' {F : J ⥤ C} [has_colimit F] (P : C) :
+  (colimit F ⟶ P) ≅ { p : Π j, F.obj j ⟶ P // ∀ {j j' : J} (f : j ⟶ j'), F.map f ≫ p j' = p j } :=
+colimit.hom_equiv P ≪≫
+{ hom := λ ι,
+  ⟨ λ j, ι.app j, λ j j' f,
+    begin
+      let g := ι.naturality f,
+      dsimp at g,
+      erw [category.comp_id] at g,
+      exact g,
+    end ⟩,
+  inv := λ p,
+  { app := λ j, p.1 j,
+    naturality' := λ j j' f, begin dsimp, erw [category.comp_id], exact p.2 f end } }
 
 lemma colimit.desc_extend (F : J ⥤ C) [has_colimit F] (c : cocone F) {X : C} (f : c.X ⟶ X) :
   colimit.desc F (c.extend f) = colimit.desc F c ≫ f :=

--- a/category_theory/limits/limits_from_equalizers_and_products.lean
+++ b/category_theory/limits/limits_from_equalizers_and_products.lean
@@ -1,0 +1,54 @@
+-- Copyright (c) 2017 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Scott Morrison
+
+import category_theory.limits
+
+open category_theory
+
+namespace category_theory.limits
+
+universes u₁ v₁
+variables {C : Type u₁} [category.{u₁ v₁} C]
+
+def limits_from_equalizers_and_products
+  [has_products.{u₁ v₁} C] [has_equalizers.{u₁ v₁} C] : has_limits.{u₁ v₁} C :=
+{ cone := λ J 𝒥 F,
+  begin
+    resetI,
+    let β_obj := (λ j : J, F.obj j),
+    let β_hom := (λ f : (Σ p : J × J, p.1 ⟶ p.2), F.obj f.1.2),
+    let pi_obj := limits.pi β_obj,
+    let pi_hom := limits.pi β_hom,
+    let s : pi_obj ⟶ pi_hom :=
+      pi.lift (λ f : (Σ p : J × J, p.1 ⟶ p.2), pi.π β_obj f.1.1 ≫ F.map f.2),
+    let t : pi_obj ⟶ pi_hom :=
+      pi.lift (λ f : (Σ p : J × J, p.1 ⟶ p.2), pi.π β_obj f.1.2),
+    exact
+    { X := equalizer s t,
+      π :=
+      { app := λ j, equalizer.ι s t ≫ pi.π β_obj j,
+        naturality' := λ j j' f,
+        begin
+          rw category.assoc,
+          have p := congr_arg (λ φ, φ ≫ pi.π β_hom ⟨ ⟨ j, j' ⟩, f ⟩) (equalizer.w s t),
+          dsimp at p,
+          simp,
+          erw category.id_comp,
+          erw category.assoc at p,
+          simp at p,
+          dsimp at p,
+          exact (eq.symm p)
+        end } }
+  end,
+  is_limit := λ J 𝒥 F,
+  begin resetI, exact
+    { lift := λ c,
+        equalizer.lift _ _
+          (pi.lift (λ j : J, begin have r := c.π.app j, dsimp at r, exact r end))
+          begin ext1, simp, rw ←category.assoc, simp, end,
+      fac' := λ s j, begin dsimp, rw ←category.assoc, simp, end }
+  end
+}
+
+end category_theory.limits

--- a/category_theory/limits/opposites.lean
+++ b/category_theory/limits/opposites.lean
@@ -1,0 +1,6 @@
+-- Copyright (c) 2018 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Scott Morrison
+
+-- TODO
+-- limits in the opposite category are colimits, etc.

--- a/category_theory/limits/preserves.lean
+++ b/category_theory/limits/preserves.lean
@@ -1,0 +1,155 @@
+-- Copyright (c) 2018 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Scott Morrison
+
+import category_theory.whiskering
+import category_theory.limits.limits
+
+open category_theory
+
+namespace category_theory.limits
+
+universes u₁ u₂ v
+
+variables {C : Type u₁} [𝒞 : category.{u₁ v} C]
+variables {D : Type u₂} [𝒟 : category.{u₂ v} D]
+include 𝒞 𝒟
+
+variables {J : Type v} [small_category J] {K : J ⥤ C}
+
+-- FIXME Reid's suggestion using forall, also for all variants of has_limits
+-- TODO rename to `continuous`?
+-- TODO show `functor.id` preserves limits?
+
+class preserves_limit (K : J ⥤ C) (F : C ⥤ D) :=
+(preserves : Π {c : cone K}, is_limit c → is_limit (F.map_cone c))
+class preserves_colimit (K : J ⥤ C) (F : C ⥤ D) :=
+(preserves : Π {c : cocone K}, is_colimit c → is_colimit (F.map_cocone c))
+
+class preserves_limits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) :=
+(preserves : Π {K : J ⥤ C} {c : cone K}, is_limit c → is_limit (F.map_cone c))
+class preserves_colimits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) :=
+(preserves : Π {K : J ⥤ C} {c : cocone K}, is_colimit c → is_colimit (F.map_cocone c))
+
+class preserves_limits (F : C ⥤ D) :=
+(preserves : Π {J : Type v} [small_category J] {K : J ⥤ C} {c : cone K},
+  is_limit c → is_limit (F.map_cone c))
+class preserves_colimits (F : C ⥤ D) :=
+(preserves : Π {J : Type v} [small_category J] {K : J ⥤ C} {c : cocone K},
+  is_colimit c → is_colimit (F.map_cocone c))
+
+instance preserves_limit_of_preserves_limits_of_shape
+  (K : J ⥤ C) (F : C ⥤ D) [preserves_limits_of_shape J F] :
+  preserves_limit K F :=
+{ preserves := λ _, preserves_limits_of_shape.preserves F }
+
+instance preserves_limits_of_shape_of_preserves_limit (F : C ⥤ D) [preserves_limits F] :
+  preserves_limits_of_shape J F :=
+{ preserves := λ _ _, preserves_limits.preserves F }
+
+-- def preserves_limit.is_limit {F : C ⥤ D} [preserves_limit K F]
+--   {c : cone K} (h : is_limit c) : is_limit (F.map_cone c) :=
+-- preserves_limit.preserves F h
+
+class reflects_limit (K : J ⥤ C) (F : C ⥤ D) :=
+(reflects : Π {c : cone K}, is_limit (F.map_cone c) → is_limit c)
+
+class reflects_limits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) :=
+(reflects : Π {K : J ⥤ C} {c : cone K}, is_limit (F.map_cone c) → is_limit c)
+
+class reflects_limits (F : C ⥤ D) :=
+(reflects : Π {J : Type v} [small_category J] {K : J ⥤ C} {c : cone K},
+  is_limit (F.map_cone c) → is_limit c)
+
+instance reflects_limit_of_reflects_limits_of_shape
+  (K : J ⥤ C) (F : C ⥤ D) [reflects_limits_of_shape J F] :
+  reflects_limit K F :=
+{ reflects := λ _, reflects_limits_of_shape.reflects }
+
+instance reflects_limits_of_shape_of_reflects_limit (F : C ⥤ D) [reflects_limits F] :
+  reflects_limits_of_shape J F :=
+{ reflects := λ _ _, reflects_limits.reflects }
+
+class creates_limit (K : J ⥤ C) (F : C ⥤ D) extends reflects_limit K F :=
+(creates : Π {c : cone (K ⋙ F)}, is_limit c → cone K)
+(image_is_limit : Π {c : cone (K ⋙ F)} (h : is_limit c), is_limit (F.map_cone (creates h)))
+
+class creates_limits_of_shape
+  (J : Type v) [small_category J] (F : C ⥤ D) extends reflects_limits_of_shape J F :=
+(creates : Π {K : J ⥤ C} {c : cone (K ⋙ F)}, is_limit c → cone K)
+(image_is_limit : Π {K : J ⥤ C} {c : cone (K ⋙ F)} (h : is_limit c),
+  is_limit (F.map_cone (creates h)))
+
+class creates_limits (F : C ⥤ D) extends reflects_limits F :=
+(creates : Π {J : Type v} [small_category J] {K : J ⥤ C} {c : cone (K ⋙ F)}, is_limit c → cone K)
+(image_is_limit :
+  Π {J : Type v} [small_category J] {K : J ⥤ C} {c : cone (K ⋙ F)} (h : is_limit c),
+  is_limit (F.map_cone (creates h)))
+
+instance creates_limit_of_creates_limits_of_shape
+  (K : J ⥤ C) (F : C ⥤ D) [creates_limits_of_shape J F] :
+  creates_limit K F :=
+{ creates := λ _, creates_limits_of_shape.creates,
+  image_is_limit := λ _, creates_limits_of_shape.image_is_limit }
+
+instance creates_limits_of_shape_of_creates_limit (F : C ⥤ D) [creates_limits F] :
+  creates_limits_of_shape J F :=
+{ creates := λ _ _, creates_limits.creates,
+  image_is_limit := λ _ _, creates_limits.image_is_limit }
+
+def creates_limit.is_limit {F : C ⥤ D} [creates_limit K F]
+  {c : cone (K ⋙ F)} (h : is_limit c) : is_limit (creates_limit.creates h) :=
+reflects_limit.reflects (creates_limit.image_is_limit h)
+
+-- Specific instances of this may be turned into instances.
+def preserved_limit (F : C ⥤ D) [preserves_limit K F] [has_limit K] : has_limit (K ⋙ F) :=
+{ cone := F.map_cone (limit.cone K),
+  is_limit := preserves_limit.preserves F (limit.universal_property K) }
+
+-- Specific instances of this may be turned into instances.
+def created_limit (F : C ⥤ D) [creates_limit K F] [has_limit (K ⋙ F)] : has_limit K :=
+{ cone := creates_limit.creates (limit.universal_property (K ⋙ F)),
+  is_limit := creates_limit.is_limit (limit.universal_property (K ⋙ F)) }
+
+def created_limits_of_shape
+  (F : C ⥤ D) [creates_limits_of_shape J F] [has_limits_of_shape.{u₂ v} J D] :
+  has_limits_of_shape.{u₁ v} J C :=
+{ cone := λ G, creates_limit.creates (limit.universal_property (G ⋙ F)),
+  is_limit := λ G, creates_limit.is_limit (limit.universal_property (G ⋙ F)) }
+
+def created_limits (F : C ⥤ D) [creates_limits F] [has_limits.{u₂ v} D] : has_limits.{u₁ v} C :=
+{ cone := λ J 𝒥 G,
+  begin
+    resetI,
+    exact creates_limit.creates (limit.universal_property (G ⋙ F)),
+  end,
+  is_limit := λ J 𝒥 G,
+  begin
+    resetI,
+    exact creates_limit.is_limit (limit.universal_property (G ⋙ F)),
+  end }
+
+-- TODO
+-- instance preserves_created_limit
+--   (F : C ⥤ D) [creates_limit K F] [has_limit (K ⋙ F)] : preserves_limit K F :=
+-- { preserves := sorry } -- See second half of Proposition 3.3.3 of Category Theory in Context
+
+/-
+TODO: Any full and faithful functor reflects any limits and colimits that are present
+in its codomain.
+
+TODO: Any equivalence of categories preserves, reflects, and creates any limits and
+colimits that are present in its domain or codomain.
+-/
+
+def preserves_limits_of_preserves_limits_of_all_shapes
+  {F : C ⥤ D} [∀ (J : Type v) [small_category J], preserves_limits_of_shape J F] :
+  preserves_limits F :=
+{ preserves := λ J 𝒥, by resetI; exact λ K c, preserves_limits_of_shape.preserves F }
+def preserves_colimits_of_preserves_colimits_of_all_shapes
+  {F : C ⥤ D} [∀ (J : Type v) [small_category J], preserves_colimits_of_shape J F] :
+  preserves_colimits F :=
+{ preserves := λ J 𝒥, by resetI; exact λ K c, preserves_colimits_of_shape.preserves F }
+
+
+end category_theory.limits

--- a/category_theory/limits/products.lean
+++ b/category_theory/limits/products.lean
@@ -413,6 +413,10 @@ end
   g = h :=
 colimit.hom_ext w
 
+def sigma.hom_equiv {f : β → C} [has_coproduct f] {P : C} : (limits.sigma f ⟶ P) ≅ Π b, f b ⟶ P :=
+{ hom := λ g b, sigma.ι f b ≫ g,
+  inv := λ g, sigma.desc g }
+
 @[simp] lemma sigma.map_desc
   [has_coproducts_of_shape.{u v} β C]
   {f : β → C} {g : β → C} {P : C} (k : Π b, f b ⟶ g b) (p : Π b, g b ⟶ P) :

--- a/category_theory/limits/products.lean
+++ b/category_theory/limits/products.lean
@@ -177,6 +177,10 @@ end
   {X : C} {g h : X ⟶ limits.pi f} (w : ∀ b, g ≫ pi.π f b = h ≫ pi.π f b) : g = h :=
 limit.hom_ext w
 
+def pi.hom_equiv {f : β → C} [has_product f] {P : C} : (P ⟶ limits.pi f) ≅ Π b, P ⟶ f b :=
+{ hom := λ g b, g ≫ pi.π f b,
+  inv := λ g, pi.lift g }
+
 @[simp] def pi.lift_map
   [has_products_of_shape.{u v} β C] {f : β → C} {g : β → C}
   {P : C} (p : Π b, P ⟶ f b) (k : Π b, f b ⟶ g b) :

--- a/category_theory/limits/products.lean
+++ b/category_theory/limits/products.lean
@@ -1,0 +1,536 @@
+-- Copyright (c) 2018 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Scott Morrison
+
+import category_theory.limits.limits
+import category_theory.discrete_category
+
+open category_theory
+
+namespace category_theory.limits
+
+universes u v w
+
+variables {β : Type v}
+variables {C : Type u} [𝒞 : category.{u v} C]
+include 𝒞
+
+section products
+def fan (f : β → C) := cone (functor.of_function f)
+
+variables {f : β → C}
+
+def is_product (t : fan f) := is_limit t
+
+variables {t : fan f}
+
+instance is_product_subsingleton : subsingleton (is_product t) :=
+by dsimp [is_product]; apply_instance
+
+variable (C)
+
+class has_products :=
+(fan : Π {β : Type v} (f : β → C), fan.{u v} f)
+(is_product : Π {β : Type v} (f : β → C), is_product (fan f) . obviously)
+
+section
+omit 𝒞
+class has_products_of_shape (β : Type v) (C : Type u) [𝒞 : category.{u v} C] :=
+(fan : Π f : β → C, fan f)
+(is_product : Π f : β → C, is_product (fan f))
+end
+
+variable {C}
+
+class has_product {β : Type v} (f : β → C) :=
+(fan : fan.{u v} f)
+(is_product : is_product fan)
+
+instance has_product_of_has_products_of_shape
+  {β : Type v} [has_products_of_shape.{u v} β C] (f : β → C) : has_product f :=
+{ fan := has_products_of_shape.fan f,
+  is_product := has_products_of_shape.is_product f }
+
+instance has_products_of_shape_of_has_products
+  {β : Type v} [has_products.{u v} C] : has_products_of_shape.{u v} β C :=
+{ fan := λ f, has_products.fan f,
+  is_product := λ f, has_products.is_product C f }
+
+-- Special cases of this may be marked with [instance] as desired.
+def has_products_of_shape_of_has_limits_of_shape
+  [limits.has_limits_of_shape.{u v} (discrete β) C] : has_products_of_shape.{u v} β C :=
+{ fan := λ f, limit.cone (functor.of_function f),
+  is_product := λ f, limit.universal_property (functor.of_function f) }
+def has_products_of_has_limits
+  [∀ β : Type v, limits.has_limits_of_shape.{u v} (discrete β) C] : has_products.{u v} C :=
+{ fan := λ β f, limit.cone (functor.of_function f),
+  is_product := λ β f, limit.universal_property (functor.of_function f) }
+
+instance has_limit_of_has_product
+  {β : Type v} (f : β → C) [has_product f] : limits.has_limit (functor.of_function f) :=
+{ cone := has_product.fan f,
+  is_limit := has_product.is_product f }
+
+def cone.of_fan {β : Type v} {F : (discrete β) ⥤ C} (t : fan (F.obj)) : cone F :=
+{ X := t.X,
+  π :=
+  { app := t.π.app,
+    naturality' := λ j j' g,
+    begin
+      cases g, cases g, cases g,
+      have h : ({down := {down := g}} : j ⟶ j) = 𝟙 j, ext1, ext1,
+      rw h,
+      simp,
+      erw category.id_comp,
+    end } }
+
+def fan.of_cone {β : Type v} {F : (discrete β) ⥤ C} (t : cone F) : fan (F.obj) :=
+{ X := t.X,
+  π :=
+  { app := t.π.app,
+    naturality' := λ j j' g,
+    begin
+      cases g, cases g, cases g,
+      have h : ({down := {down := g}} : j ⟶ j) = 𝟙 j, ext1, ext1,
+      rw h,
+      simp,
+      erw category.id_comp,
+    end } }
+
+instance has_limits_of_shape_of_has_products_of_shape
+  {β : Type v} [has_products_of_shape.{u v} β C] :
+  limits.has_limits_of_shape.{u v} (discrete β) C :=
+begin
+  haveI : has_products_of_shape.{u v} (discrete β) C :=
+    (by apply_instance : has_products_of_shape.{u v} β C),
+  exact
+  { cone := λ F, cone.of_fan (has_products_of_shape.fan F.obj),
+    is_limit := λ F, let is_product := has_product.is_product F.obj in
+    { lift := λ s, is_product.lift (fan.of_cone s),
+      fac' := λ s j, is_product.fac (fan.of_cone s) j,
+      uniq' := λ s m j, is_product.uniq (fan.of_cone s) m j } }
+end
+
+section
+
+def pi.fan (f : β → C) [has_product f] : fan f := has_product.fan.{u v} f
+protected def pi (f : β → C) [has_product f] : C := (pi.fan f).X
+def pi.π (f : β → C) [has_product f] (b : β) : limits.pi f ⟶ f b :=
+(pi.fan f).π.app b
+def pi.universal_property (f : β → C) [has_product f] : is_product (pi.fan f) :=
+has_product.is_product.{u v} f
+
+@[simp] lemma pi.fan_π
+  (f : β → C) [has_product f] (b : β) :
+  (pi.fan f).π.app b = @pi.π _ C _ f _ b := rfl
+
+@[simp] def cone.of_function
+  {f : β → C} {P : C} (p : Π b, P ⟶ f b) : cone (functor.of_function f) :=
+{ X := P,
+  π := { app := p } }
+
+def pi.lift {f : β → C} [has_product f] {P : C} (p : Π b, P ⟶ f b) : P ⟶ limits.pi f :=
+limit.lift _ (cone.of_function p)
+
+@[simp] lemma pi.lift_π
+  {f : β → C} [has_product f] {P : C} (p : Π b, P ⟶ f b) (b : β) : pi.lift p ≫ pi.π f b = p b :=
+limit.lift_π (cone.of_function p) b
+
+def pi.map
+  {f : β → C} [has_product f] {g : β → C} [has_product g] (k : Π b, f b ⟶ g b) :
+  (limits.pi f) ⟶ (limits.pi g) :=
+pi.lift (λ b, pi.π f b ≫ k b)
+
+@[simp] lemma pi.map_π
+  {f : β → C} [has_product f] {g : β → C} [has_product g] (k : Π b, f b ⟶ g b) (b : β) :
+  pi.map k ≫ pi.π g b = pi.π f b ≫ k b :=
+by erw is_limit.fac; refl
+
+def pi.pre {α} (f : α → C) [has_product.{u v} f] (h : β → α) [has_product.{u v} (f ∘ h)] :
+  limits.pi f ⟶ limits.pi (f ∘ h) :=
+pi.lift (λ g, pi.π f (h g))
+
+@[simp] lemma pi.pre_π {α}
+  (f : α → C) [has_product.{u v} f] (h : β → α) [has_product.{u v} (f ∘ h)] (b : β) :
+  pi.pre f h ≫ pi.π (f ∘ h) b = pi.π f (h b) :=
+by erw is_limit.fac; refl
+
+section
+variables {D : Type u} [𝒟 : category.{u v} D]
+include 𝒟
+
+def pi.post (f : β → C) [has_product f] (G : C ⥤ D) [has_product (G.obj ∘ f)] :
+  G.obj (limits.pi f) ⟶ (limits.pi (G.obj ∘ f)) :=
+@is_limit.lift _ _ _ _ _
+  (pi.fan (G.obj ∘ f))
+  (pi.universal_property _)
+  { X := _,
+    π := { app := λ b, G.map (pi.π f b) } }
+
+@[simp] lemma pi.post_π (f : β → C) [has_product f] (G : C ⥤ D) [has_product (G.obj ∘ f)] (b : β) :
+  pi.post f G ≫ pi.π _ b = G.map (pi.π f b) :=
+by erw is_limit.fac; refl
+end
+
+@[extensionality] lemma pi.hom_ext
+  {f : β → C} [has_product f]
+  {X : C} {g h : X ⟶ limits.pi f} (w : ∀ b, g ≫ pi.π f b = h ≫ pi.π f b) : g = h :=
+limit.hom_ext w
+
+@[simp] def pi.lift_map
+  [has_products_of_shape.{u v} β C] {f : β → C} {g : β → C}
+  {P : C} (p : Π b, P ⟶ f b) (k : Π b, f b ⟶ g b) :
+  pi.lift p ≫ pi.map k = pi.lift (λ b, p b ≫ k b) :=
+limit.lift_map (cone.of_function p) (nat_trans.of_function k)
+
+@[simp] def pi.map_map [has_products_of_shape.{u v} β C] {f1 : β → C} {f2 : β → C} {f3 : β → C}
+  (k1 : Π b, f1 b ⟶ f2 b) (k2 : Π b, f2 b ⟶ f3 b) :
+  pi.map (λ b, k1 b ≫ k2 b) = pi.map k1 ≫ pi.map k2 :=
+lim.map_comp (nat_trans.of_function k1) (nat_trans.of_function k2)
+
+@[simp] def pi.lift_pre
+  {α : Type v} {f : β → C} [has_product f]
+  {P : C} (p : Π b, P ⟶ f b) (h : α → β) [has_product (f ∘ h)]:
+  pi.lift p ≫ pi.pre _ h = pi.lift (λ a, p (h a)) :=
+by ext1; simp.
+
+def pi.map_pre
+  {α : Type v} [has_products_of_shape.{u v} β C] [has_products_of_shape.{u v} α C]
+  {f g : β → C} (k : Π b : β, f b ⟶ g b)
+  (e : α → β) :
+  pi.map k ≫ pi.pre g e = pi.pre f e ≫ pi.map (λ a, k (e a)) :=
+limit.map_pre (nat_trans.of_function k) (discrete.lift e)
+
+@[simp] lemma pi.pre_pre
+  {γ δ : Type v}
+  [has_products_of_shape.{u v} β C]
+  [has_products_of_shape.{u v} γ C]
+  [has_products_of_shape.{u v} δ C]
+  (f : β → C) (g : γ → β) (h : δ → γ) :
+  pi.pre f g ≫ pi.pre (f ∘ g) h = pi.pre f (g ∘ h) :=
+by ext1; simp.
+
+section
+variables {D : Type u} [category.{u v} D] [has_products.{u v} D]
+
+@[simp] def pi.lift_post
+  [has_products_of_shape.{u v} β C] {f : β → C}
+  {P : C} (k : Π b : β, P ⟶ f b) (G : C ⥤ D) :
+  G.map (pi.lift k) ≫ pi.post f G = pi.lift (λ b, G.map (k b)) :=
+begin
+  /- `obviously` says -/
+  ext1, dsimp, simp,
+  erw ←functor.map_comp,
+  simp,
+end
+
+
+def pi.map_post
+  [has_products_of_shape.{u v} β C] {f g : β → C} (k : Π b : β, f b ⟶ g b) (H : C ⥤ D) :
+  H.map (pi.map k) ≫ pi.post g H = pi.post f H ≫ pi.map (λ b, H.map (k b)) :=
+limit.map_post (nat_trans.of_function k) H
+
+def pi.pre_post
+  {α} [has_products_of_shape.{u v} β C] [has_products_of_shape.{u v} α C]
+  (f : β → C) (g : α → β) (G : C ⥤ D) :
+  G.map (pi.pre f g) ≫ pi.post (f ∘ g) G = pi.post f G ≫ pi.pre (G.obj ∘ f) g :=
+limit.pre_post (functor.of_function f) (discrete.lift g) G
+
+@[simp] def pi.post_post
+  [has_products_of_shape.{u v} β C]
+  {E : Type u} [category.{u v} E] [has_products.{u v} E] (f : β → C) (G : C ⥤ D) (H : D ⥤ E) :
+  H.map (pi.post f G) ≫ pi.post (G.obj ∘ f) H = pi.post f (G ⋙ H) :=
+limit.post_post (functor.of_function f) G H
+end
+end
+end products
+
+section coproducts
+def cofan (f : β → C) := cocone (functor.of_function f)
+
+variables {f : β → C}
+
+def is_coproduct (t : cofan f) := is_colimit t
+
+variables {t : cofan f}
+
+instance is_coproduct_subsingleton : subsingleton (is_coproduct t) :=
+by dsimp [is_coproduct]; apply_instance
+
+variable (C)
+
+class has_coproducts :=
+(cofan : Π {β : Type v} (f : β → C), cofan.{u v} f)
+(is_coproduct : Π {β : Type v} (f : β → C), is_coproduct (cofan f) . obviously)
+
+section
+omit 𝒞
+class has_coproducts_of_shape (β : Type v) (C : Type u) [category.{u v} C]:=
+(cofan : Π f : β → C, cofan f)
+(is_coproduct : Π f : β → C, is_coproduct (cofan f))
+end
+
+variable {C}
+
+class has_coproduct {β : Type v} (f : β → C) :=
+(cofan : cofan.{u v} f)
+(is_coproduct : is_coproduct cofan)
+
+instance has_coproduct_of_has_coproducts_of_shape
+  {β : Type v} [has_coproducts_of_shape.{u v} β C] (f : β → C) : has_coproduct f :=
+{ cofan := has_coproducts_of_shape.cofan f,
+  is_coproduct := has_coproducts_of_shape.is_coproduct f }
+
+instance has_coproducts_of_shape_of_has_coproducts
+  {β : Type v} [has_coproducts.{u v} C] : has_coproducts_of_shape.{u v} β C :=
+{ cofan := λ f, has_coproducts.cofan f,
+  is_coproduct := λ f, has_coproducts.is_coproduct C f }
+
+-- Special cases of this may be marked with [instance] as desired.
+def has_coproducts_of_shape_of_has_colimits_of_shape
+  [limits.has_colimits_of_shape.{u v} (discrete β) C] : has_coproducts_of_shape.{u v} β C :=
+{ cofan := λ f, colimit.cocone (functor.of_function f),
+  is_coproduct := λ f, colimit.universal_property (functor.of_function f) }
+def has_coproducts_of_has_colimits
+  [∀ β : Type v, limits.has_colimits_of_shape.{u v} (discrete β) C] : has_coproducts.{u v} C :=
+{ cofan := λ β f, colimit.cocone (functor.of_function f),
+  is_coproduct := λ β f, colimit.universal_property (functor.of_function f) }
+
+instance has_colimit_of_has_coproduct {β : Type v} (f : β → C) [has_coproduct f] :
+  limits.has_colimit (functor.of_function f) :=
+{ cocone := has_coproduct.cofan f,
+  is_colimit := has_coproduct.is_coproduct f }
+
+def cocone.of_cofan {β : Type v} {F : (discrete β) ⥤ C} (t : cofan (F.obj)) : cocone F :=
+{ X := t.X,
+  ι :=
+  { app := t.ι.app,
+    naturality' := λ j j' g,
+    begin
+      cases g, cases g, cases g,
+      have h : ({down := {down := g}} : j ⟶ j) = 𝟙 j, ext1, ext1,
+      rw h,
+      simp,
+      erw category.comp_id,
+    end } }
+
+def cofan.of_cocone {β : Type v} {F : (discrete β) ⥤ C} (t : cocone F) : cofan (F.obj) :=
+{ X := t.X,
+  ι :=
+  { app := t.ι.app,
+    naturality' := λ j j' g,
+    begin
+      cases g, cases g, cases g,
+      have h : ({down := {down := g}} : j ⟶ j) = 𝟙 j, ext1, ext1,
+      rw h,
+      simp,
+      erw category.comp_id,
+    end } }
+
+instance has_colimits_of_shape_of_has_coproducts_of_shape
+  {β : Type v} [has_coproducts_of_shape.{u v} β C] :
+  limits.has_colimits_of_shape.{u v} (discrete β) C :=
+begin
+  haveI : has_coproducts_of_shape.{u v} (discrete β) C :=
+    (by apply_instance : has_coproducts_of_shape.{u v} β C),
+  exact
+  { cocone := λ F, cocone.of_cofan (has_coproducts_of_shape.cofan F.obj),
+    is_colimit := λ F, let is_coproduct := has_coproduct.is_coproduct F.obj in
+    { desc := λ s, is_coproduct.desc (cofan.of_cocone s),
+      fac' := λ s j, is_coproduct.fac (cofan.of_cocone s) j,
+      uniq' := λ s m j, is_coproduct.uniq (cofan.of_cocone s) m j } }
+end
+
+section
+
+def sigma.cofan (f : β → C) [has_coproduct f] := has_coproduct.cofan.{u v} f
+protected def sigma (f : β → C) [has_coproduct f] : C := (sigma.cofan f).X
+def sigma.ι (f : β → C) [has_coproduct f] (b : β) : f b ⟶ limits.sigma f :=
+(sigma.cofan f).ι.app b
+def sigma.universal_property (f : β → C) [has_coproduct f] : is_coproduct (sigma.cofan f) :=
+has_coproduct.is_coproduct.{u v} f
+
+@[simp] lemma sigma.cofan_ι
+  (f : β → C) [has_coproduct f] (b : β) :
+  (sigma.cofan f).ι.app b = @sigma.ι _ C _ f _ b := rfl
+
+@[simp] def cocone.of_function
+  {f : β → C} {P : C} (p : Π b, f b ⟶ P) : cocone (functor.of_function f) :=
+{ X := P,
+  ι := { app := p } }
+
+def sigma.desc {f : β → C} [has_coproduct f] {P : C} (p : Π b, f b ⟶ P) : limits.sigma f ⟶ P :=
+colimit.desc _ (cocone.of_function p)
+
+@[simp] lemma sigma.ι_desc {f : β → C} [has_coproduct f] {P : C} (p : Π b, f b ⟶ P) (b : β) :
+  sigma.ι f b ≫ sigma.desc p = p b :=
+colimit.ι_desc (cocone.of_function p) b
+
+def sigma.map
+  {f : β → C} [has_coproduct f] {g : β → C} [has_coproduct g] (k : Π b, f b ⟶ g b) :
+  (limits.sigma f) ⟶ (limits.sigma g) :=
+sigma.desc (λ b, k b ≫ sigma.ι g b)
+
+@[simp] lemma sigma.ι_map
+  {f : β → C} [has_coproduct f] {g : β → C} [has_coproduct g] (k : Π b, f b ⟶ g b) (b : β) :
+  sigma.ι f b ≫ sigma.map k = k b ≫ sigma.ι g b :=
+by erw is_colimit.fac; refl
+
+def sigma.pre {α} (f : α → C) [has_coproduct.{u v} f] (h : β → α) [has_coproduct (f ∘ h)] :
+  limits.sigma (f ∘ h) ⟶ limits.sigma f :=
+sigma.desc (λ g, sigma.ι f (h g))
+
+@[simp] lemma sigma.ι_pre
+  {α} (f : α → C) [has_coproduct.{u v} f] (h : β → α) [has_coproduct (f ∘ h)] (b : β) :
+  sigma.ι (f ∘ h) b ≫ sigma.pre f h = sigma.ι f (h b) :=
+by erw is_colimit.fac; refl
+
+section
+variables {D : Type u} [𝒟 : category.{u v} D]
+include 𝒟
+
+def sigma.post (f : β → C) [has_coproduct f] (G : C ⥤ D) [has_coproduct (G.obj ∘ f)] :
+  (limits.sigma (G.obj ∘ f)) ⟶ G.obj (limits.sigma f) :=
+@is_colimit.desc _ _ _ _ _
+  (sigma.cofan (G.obj ∘ f))
+  (sigma.universal_property _)
+  { X := _,
+    ι := { app := λ b, G.map (sigma.ι f b) } }
+
+@[simp] lemma sigma.ι_post
+  (f : β → C) [has_coproduct f] (G : C ⥤ D) [has_coproduct (G.obj ∘ f)] (b : β) :
+  sigma.ι _ b ≫ sigma.post f G = G.map (sigma.ι f b) :=
+by erw is_colimit.fac; refl
+end
+
+@[extensionality] lemma sigma.hom_ext
+  (f : β → C) [has_coproduct f]
+  {X : C} (g h : limits.sigma f ⟶ X) (w : ∀ b, sigma.ι f b ≫ g = sigma.ι f b ≫ h) :
+  g = h :=
+colimit.hom_ext w
+
+@[simp] lemma sigma.map_desc
+  [has_coproducts_of_shape.{u v} β C]
+  {f : β → C} {g : β → C} {P : C} (k : Π b, f b ⟶ g b) (p : Π b, g b ⟶ P) :
+  sigma.map k ≫ sigma.desc p = sigma.desc (λ b, k b ≫ p b) :=
+colimit.map_desc (cocone.of_function p) (nat_trans.of_function k)
+
+@[simp] lemma sigma.map_map
+  {f1 : β → C} [has_coproduct.{u v} f1]
+  {f2 : β → C} [has_coproduct.{u v} f2]
+  {f3 : β → C} [has_coproduct.{u v} f3]
+  (k1 : Π b, f1 b ⟶ f2 b) (k2 : Π b, f2 b ⟶ f3 b) :
+  sigma.map k1 ≫ sigma.map k2 = sigma.map (λ b, k1 b ≫ k2 b) :=
+begin
+  /- `obviously` says -/
+  ext1,
+  simp,
+  rw ←category.assoc,
+  simp,
+end.
+
+@[simp] lemma sigma.pre_desc
+  {α : Type v} {f : β → C} [has_coproduct.{u v} f]
+  {P : C} (p : Π b, f b ⟶ P)
+  (h : α → β) [has_coproduct.{u v} (f ∘ h)] :
+  sigma.pre _ h ≫ sigma.desc p = sigma.desc (λ a, p (h a)) :=
+begin
+  /- `obviously` says -/
+  ext1,
+  simp,
+  rw ←category.assoc,
+  simp,
+end
+
+def sigma.pre_map
+  {α : Type v} {f g : β → C} [has_coproduct.{u v} f] [has_coproduct.{u v} g]
+  (k : Π b : β, f b ⟶ g b) (e : α → β)
+  [has_coproduct.{u v} (f ∘ e)] [has_coproduct.{u v} (g ∘ e)] :
+  sigma.pre f e ≫ sigma.map k = sigma.map (λ a, k (e a)) ≫ sigma.pre g e :=
+begin
+  /- `obviously` says -/
+  ext1,
+  rw ←category.assoc,
+  erw sigma.ι_desc,
+  rw ←category.assoc,
+  simp,
+end.
+
+@[simp] lemma sigma.pre_pre
+  {γ δ : Type v}
+  (f : β → C) [has_coproduct.{u v} f]
+  (g : γ → β) [has_coproduct.{u v} (f ∘ g)]
+  (h : δ → γ) [has_coproduct.{u v} ((f ∘ g) ∘ h)]:
+  sigma.pre (f ∘ g) h ≫ sigma.pre f g = sigma.pre f (g ∘ h) :=
+begin
+  ext1,
+  rw ←category.assoc,
+  simp,
+  rw sigma.ι_pre f,
+end.
+
+section
+variables {D : Type u} [category.{u v} D]
+
+@[simp] def sigma.post_desc
+  {f : β → C} [has_coproduct.{u v} f]
+  {P : C} (k : Π b : β, f b ⟶ P)
+  (G : C ⥤ D) [has_coproduct.{u v} (G.obj ∘ f)] :
+  sigma.post f G ≫ G.map (sigma.desc k) = sigma.desc (λ b, G.map (k b)) :=
+begin
+  /- `obvously` says -/
+  ext1, simp,
+  rw ←category.assoc,
+  rw sigma.ι_post,
+  rw ←functor.map_comp,
+  rw sigma.ι_desc,
+end.
+
+def sigma.map_post
+  {f g : β → C} [has_coproduct.{u v} f] [has_coproduct.{u v} g]
+  (k : Π b : β, f b ⟶ g b)
+  (H : C ⥤ D) [has_coproduct.{u v} (H.obj ∘ f)] [has_coproduct.{u v} (H.obj ∘ g)] :
+  @sigma.map _ _ _ (H.obj ∘ f) _ (H.obj ∘ g) _ (λ b, H.map (k b)) ≫ sigma.post g H =
+    sigma.post f H ≫ H.map (sigma.map k) :=
+begin
+  /- `obviously` says -/
+  ext1,
+  dsimp at *,
+  rw ←category.assoc,
+  simp,
+  rw ←functor.map_comp,
+  rw ←category.assoc,
+  simp,
+  rw ←functor.map_comp,
+  rw ←functor.map_comp,
+  rw sigma.ι_map,
+end.
+
+def sigma.pre_post
+  {α} (f : β → C) [has_coproduct.{u v} f]
+  (g : α → β) [has_coproduct.{u v} (f ∘ g)]
+  (G : C ⥤ D) [has_coproduct.{u v} (G.obj ∘ f)] [has_coproduct.{u v} (G.obj ∘ f ∘ g)] :
+  sigma.pre (G.obj ∘ f) g ≫ sigma.post f G = sigma.post (f ∘ g) G ≫ G.map (sigma.pre f g) :=
+begin
+  /- `obviously` says -/
+  ext1,
+  dsimp at *,
+  rw [←category.assoc, sigma.ι_pre, sigma.ι_post, ←category.assoc,
+      sigma.ι_post, ←functor.map_comp, sigma.ι_pre]
+end
+
+-- TODO? As needed.
+/-
+@[simp] def sigma.post_post
+  {E : Type u} [category.{u v} E]
+  (f : β → C) [has_coproduct.{u v} f]
+  (G : C ⥤ D) [has_coproduct.{u v} (G.obj ∘ f)]
+  (H : D ⥤ E) [has_coproduct.{u v} (H.obj ∘ G.obj ∘ f)]:
+  sigma.post (G.obj ∘ f) H ≫ H.map (sigma.post f G) = sigma.post f (G ⋙ H) := ...
+-/
+
+end
+end
+end coproducts
+
+end category_theory.limits

--- a/category_theory/limits/pullbacks.lean
+++ b/category_theory/limits/pullbacks.lean
@@ -1,0 +1,413 @@
+-- Copyright (c) 2018 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Scott Morrison
+
+import category_theory.limits.limits
+
+open category_theory
+
+namespace tactic
+meta def case_bash : tactic unit :=
+do l ← local_context,
+   r ← successes (l.reverse.map (λ h, cases h >> skip)),
+   when (r.empty) failed
+end tactic
+
+namespace category_theory.limits
+
+universes u v w
+
+local attribute [tidy] tactic.case_bash
+
+@[derive decidable_eq] inductive walking_cospan : Type v
+| left | right | one
+@[derive decidable_eq] inductive walking_span : Type v
+| zero | left | right
+
+open walking_cospan
+open walking_span
+
+inductive walking_cospan_hom : walking_cospan → walking_cospan → Type v
+| inl : walking_cospan_hom left one
+| inr : walking_cospan_hom right one
+| id : Π X : walking_cospan.{v}, walking_cospan_hom X X
+inductive walking_span_hom : walking_span → walking_span → Type v
+| fst : walking_span_hom zero left
+| snd : walking_span_hom zero right
+| id : Π X : walking_span.{v}, walking_span_hom X X
+
+open walking_cospan_hom
+open walking_span_hom
+
+instance walking_cospan_category : small_category walking_cospan :=
+{ hom := walking_cospan_hom,
+  id := walking_cospan_hom.id,
+  comp := λ X Y Z f g, match X, Y, Z, f, g with
+  | _, _ ,_, (id _), h := h
+  | _, _, _, inl, (id one) := inl
+  | _, _, _, inr, (id one) := inr
+  end }
+instance walking_span_category : small_category walking_span :=
+{ hom := walking_span_hom,
+  id := walking_span_hom.id,
+  comp := λ X Y Z f g, match X, Y, Z, f, g with
+  | _, _ ,_, (id _), h := h
+  | _, _, _, fst, (id left) := fst
+  | _, _, _, snd, (id right) := snd
+  end }
+
+lemma walking_cospan_hom_id (X : walking_cospan.{v}) : walking_cospan_hom.id X = 𝟙 X := rfl
+lemma walking_span_hom_id (X : walking_span.{v}) : walking_span_hom.id X = 𝟙 X := rfl
+
+variables {C : Type u} [𝒞 : category.{u v} C]
+include 𝒞
+
+def cospan {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) : walking_cospan.{v} ⥤ C :=
+{ obj := λ x, match x with
+  | left := X
+  | right := Y
+  | one := Z
+  end,
+  map := λ x y h, match x, y, h with
+  | _, _, (id _) := 𝟙 _
+  | _, _, inl := f
+  | _, _, inr := g
+  end }
+def span {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) : walking_span.{v} ⥤ C :=
+{ obj := λ x, match x with
+  | zero := X
+  | left := Y
+  | right := Z
+  end,
+  map := λ x y h, match x, y, h with
+  | _, _, (id _) := 𝟙 _
+  | _, _, fst := f
+  | _, _, snd := g
+  end }
+
+@[simp] lemma cospan_left {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) :
+  (cospan f g).obj walking_cospan.left = X := rfl
+@[simp] lemma span_left {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) :
+  (span f g).obj walking_span.left = Y := rfl
+
+@[simp] lemma cospan_right {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) :
+  (cospan f g).obj walking_cospan.right = Y := rfl
+@[simp] lemma span_right {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) :
+  (span f g).obj walking_span.right = Z := rfl
+
+@[simp] lemma cospan_one {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) :
+  (cospan f g).obj walking_cospan.one = Z := rfl
+@[simp] lemma span_zero {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) :
+  (span f g).obj walking_span.zero = X := rfl
+
+@[simp] lemma cospan_map_inl {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) :
+  (cospan f g).map walking_cospan_hom.inl = f := rfl
+@[simp] lemma span_map_fst {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) :
+  (span f g).map walking_span_hom.fst = f := rfl
+
+@[simp] lemma cospan_map_inr {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) :
+  (cospan f g).map walking_cospan_hom.inr = g := rfl
+@[simp] lemma span_map_snd {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) :
+  (span f g).map walking_span_hom.snd = g := rfl
+
+@[simp] lemma cospan_map_id {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) (w : walking_cospan) :
+  (cospan f g).map (walking_cospan_hom.id w) = 𝟙 _ := rfl
+@[simp] lemma span_map_id {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) (w : walking_span) :
+  (span f g).map (walking_span_hom.id w) = 𝟙 _ := rfl
+
+
+variables {X Y Z : C}
+
+attribute [simp] walking_cospan_hom_id walking_span_hom_id
+
+section pullback
+def square (f : X ⟶ Z) (g : Y ⟶ Z) := cone (cospan f g)
+
+variables {f : X ⟶ Z} {g : Y ⟶ Z}
+
+def square.π₁ (t : square f g) : t.X ⟶ X := t.π.app left
+def square.π₂ (t : square f g) : t.X ⟶ Y := t.π.app right
+
+def square.mk {W : C} (π₁ : W ⟶ X) (π₂ : W ⟶ Y)
+  (eq : π₁ ≫ f = π₂ ≫ g) :
+  square f g :=
+{ X := W,
+  π :=
+  { app := λ j, walking_cospan.cases_on j π₁ π₂ (π₁ ≫ f),
+    naturality' := λ j j' f, by cases f; obviously } }
+
+def square.condition (t : square f g) : (square.π₁ t) ≫ f = (square.π₂ t) ≫ g :=
+begin
+  erw [t.w inl, ← t.w inr], refl
+end
+
+def is_pullback (t : square f g) := is_limit t
+
+variables {t : square f g}
+
+instance is_pullback_subsingleton : subsingleton (is_pullback t) :=
+by dsimp [is_pullback]; apply_instance
+
+lemma is_pullback.hom_ext (p : is_pullback t) {W : C} {k h : W ⟶ t.X}
+  (w_left : k ≫ t.π.app left = h ≫ t.π.app left)
+  (w_right : k ≫ t.π.app right = h ≫ t.π.app right) : k = h :=
+begin
+ rw [p.hom_lift k, p.hom_lift h]; congr,
+ ext j, cases j,
+ exact w_left,
+ exact w_right,
+ have v := t.π.naturality walking_cospan_hom.inl,
+ simp at v,
+ erw category.id_comp at v,
+ rw [v, ←category.assoc, w_left, category.assoc],
+end
+
+end pullback
+
+section pushout
+def cosquare (f : X ⟶ Y) (g : X ⟶ Z) := cocone (span f g)
+
+variables {f : X ⟶ Y} {g : X ⟶ Z}
+
+def cosquare.ι₁ (t : cosquare f g) : Y ⟶ t.X := t.ι.app left
+def cosquare.ι₂ (t : cosquare f g) : Z ⟶ t.X := t.ι.app right
+
+def cosquare.mk {W : C} (ι₁ : Y ⟶ W) (ι₂ : Z ⟶ W)
+  (eq : f ≫ ι₁ = g ≫ ι₂) :
+  cosquare f g :=
+{ X := W,
+  ι :=
+  { app := λ j, walking_span.cases_on j (f ≫ ι₁) ι₁ ι₂,
+    naturality' := λ j j' f, by cases f; obviously } }
+
+def cosquare.condition (t : cosquare f g) : f ≫ (cosquare.ι₁ t) = g ≫ (cosquare.ι₂ t) :=
+begin
+  erw [t.w fst, ← t.w snd], refl
+end
+
+def is_pushout (t : cosquare f g) := is_colimit t
+
+variables {t : cosquare f g}
+
+instance is_pushout_subsingleton : subsingleton (is_pushout t) :=
+by dsimp [is_pushout]; apply_instance
+
+lemma is_pushout.hom_ext (p : is_pushout t) {W : C} {k h : t.X ⟶ W}
+  (w_left : t.ι.app left ≫ k = t.ι.app left ≫ h)
+  (w_right : t.ι.app right ≫ k = t.ι.app right ≫ h) : k = h :=
+begin
+ rw [p.hom_desc k, p.hom_desc h]; congr,
+ ext j, cases j,
+ have v := t.ι.naturality walking_span_hom.fst,
+ simp at v,
+ erw category.comp_id at v,
+ rw [←v, category.assoc, w_left, ←category.assoc],
+ exact w_left,
+ exact w_right,
+end
+
+end pushout
+
+def cone.of_square
+  {F : walking_cospan.{v} ⥤ C} (t : square (F.map inl) (F.map inr)) : cone F :=
+{ X := t.X,
+  π :=
+  { app := λ X, t.π.app X ≫ eq_to_hom (by tidy),
+    naturality' := λ j j' g,
+    begin
+      cases j; cases j'; cases g; dsimp; simp,
+      erw ← t.w inl, refl,
+      erw ← t.w inr, refl,
+    end } }.
+
+@[simp] lemma cone.of_square_π
+  {F : walking_cospan.{v} ⥤ C} (t : square (F.map inl) (F.map inr)) (j):
+  (cone.of_square t).π.app j = t.π.app j ≫ eq_to_hom (by tidy) := rfl
+
+def cocone.of_cosquare
+  {F : walking_span.{v} ⥤ C} (t : cosquare (F.map fst) (F.map snd)) : cocone F :=
+{ X := t.X,
+  ι :=
+  { app := λ X, eq_to_hom (by tidy) ≫ t.ι.app X,
+    naturality' := λ j j' g,
+    begin
+      cases j; cases j'; cases g; dsimp; simp,
+      erw ← t.w fst, refl,
+      erw ← t.w snd, refl,
+    end } }.
+
+@[simp] lemma cocone.of_cosquare_ι
+  {F : walking_span.{v} ⥤ C} (t : cosquare (F.map fst) (F.map snd)) (j):
+  (cocone.of_cosquare t).ι.app j = eq_to_hom (by tidy) ≫ t.ι.app j := rfl
+
+def square.of_cone
+  {F : walking_cospan.{v} ⥤ C} (t : cone F) : square (F.map inl) (F.map inr) :=
+{ X := t.X,
+  π :=
+  { app := λ j, t.π.app j ≫ eq_to_hom (by tidy) } }
+
+@[simp] lemma square.of_cone_π {F : walking_cospan.{v} ⥤ C} (t : cone F) (j) :
+  (square.of_cone t).π.app j = t.π.app j ≫ eq_to_hom (by tidy) := rfl
+
+def cosquare.of_cocone
+  {F : walking_span.{v} ⥤ C} (t : cocone F) : cosquare (F.map fst) (F.map snd) :=
+{ X := t.X,
+  ι :=
+  { app := λ j, eq_to_hom (by tidy) ≫ t.ι.app j } }
+
+@[simp] lemma cosquare.of_cocone_ι {F : walking_span.{v} ⥤ C} (t : cocone F) (j) :
+  (cosquare.of_cocone t).ι.app j = eq_to_hom (by tidy) ≫ t.ι.app j := rfl
+
+variable (C)
+
+class has_pullbacks :=
+(square : Π {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z), square.{u v} f g)
+(is_pullback : Π {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z), is_pullback (square f g) . obviously)
+class has_pushouts :=
+(cosquare : Π {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z), cosquare.{u v} f g)
+(is_pushout : Π {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z), is_pushout (cosquare f g) . obviously)
+
+variable {C}
+
+-- Special cases of this may be marked with [instance] as desired.
+def has_pullbacks_of_has_limits
+  [limits.has_limits_of_shape.{u v} walking_cospan C] : has_pullbacks.{u v} C :=
+{ square := λ X Y Z f g, limit.cone (cospan f g),
+  is_pullback := λ X Y Z f g, limit.universal_property (cospan f g) }
+def has_pushouts_of_has_colimits
+  [limits.has_colimits_of_shape.{u v} walking_span C] : has_pushouts.{u v} C :=
+{ cosquare := λ X Y Z f g, colimit.cocone (span f g),
+  is_pushout := λ X Y Z f g, colimit.universal_property (span f g) }
+
+section pullback
+variable [has_pullbacks.{u v} C]
+variables (f : X ⟶ Z) (g : Y ⟶ Z)
+
+def pullback.square : square f g := has_pullbacks.square.{u v} f g
+def pullback := (pullback.square f g).X
+def pullback.π₁ : pullback f g ⟶ X := (pullback.square f g).π₁
+def pullback.π₂ : pullback f g ⟶ Y := (pullback.square f g).π₂
+@[simp] lemma pullback.w : pullback.π₁ f g ≫ f = pullback.π₂ f g ≫ g :=
+begin
+  erw ((pullback.square f g).w inl),
+  erw ((pullback.square f g).w inr)
+end
+def pullback.universal_property : is_pullback (pullback.square f g) :=
+has_pullbacks.is_pullback.{u v} C f g
+
+instance has_limits_of_shape_of_has_pullbacks [has_pullbacks.{u v} C] :
+  limits.has_limits_of_shape.{u v} walking_cospan.{v} C :=
+{ cone := λ F, cone.of_square (pullback.square (F.map inl) (F.map inr)),
+  is_limit := λ F, let is_pullback := pullback.universal_property (F.map inl) (F.map inr) in
+  { lift := λ s, is_pullback.lift (square.of_cone s),
+    fac' := λ s j,
+    begin
+      dsimp at *,
+      cases j; simp,
+    end,
+    uniq' := λ s m w, is_pullback.uniq (square.of_cone s) m
+      (λ j, begin have h := w j, cases j; simp at *; exact h end) } }.
+
+@[extensionality] lemma pullback.hom_ext [has_pullbacks.{u v} C] {W : C}
+  {k h : W ⟶ pullback f g}
+  (w_left : k ≫ pullback.π₁ f g = h ≫ pullback.π₁ f g)
+  (w_right : k ≫ pullback.π₂ f g = h ≫ pullback.π₂ f g) : k = h :=
+(pullback.universal_property f g).hom_ext w_left w_right
+
+def pullback.lift [has_pullbacks.{u v} C] {W : C}
+  (f' : W ⟶ X) (g' : W ⟶ Y) (eq : f' ≫ f = g' ≫ g) : W ⟶ pullback f g :=
+(pullback.universal_property f g).lift (square.mk f' g' eq)
+
+@[simp] lemma pullback.lift_π₁ [has_pullbacks.{u v} C] {W : C}
+  (f' : W ⟶ X) (g' : W ⟶ Y) (eq : f' ≫ f = g' ≫ g) :
+  pullback.lift f g f' g' eq ≫ pullback.π₁ f g = f' :=
+(pullback.universal_property f g).fac (square.mk f' g' eq) _
+
+@[simp] lemma pullback.lift_π₂ [has_pullbacks.{u v} C] {W : C}
+  (f' : W ⟶ X) (g' : W ⟶ Y) (eq : f' ≫ f = g' ≫ g) :
+  pullback.lift f g f' g' eq ≫ pullback.π₂ f g = g' :=
+(pullback.universal_property f g).fac (square.mk f' g' eq) _
+
+@[simp] lemma pullback.lift_id [has_pullbacks.{u v} C]
+  (eq : pullback.π₁ f g ≫ f = pullback.π₂ f g ≫ g) :
+  pullback.lift f g _ _ eq = 𝟙 _ :=
+begin
+  refine ((pullback.universal_property f g).uniq _ _ _).symm,
+  rintros (_ | _ | _),
+  { dsimp [square.mk], simp, refl },
+  { dsimp [square.mk], simp, refl },
+  { dsimp [square.mk], simp,
+    have := (pullback.square f g).π.naturality walking_cospan_hom.inr,
+    dsimp at this,
+    simpa }
+end
+
+end pullback
+
+section pushout
+variable [has_pushouts.{u v} C]
+variables (f : X ⟶ Y) (g : X ⟶ Z)
+
+def pushout.cosquare : cosquare f g := has_pushouts.cosquare.{u v} f g
+def pushout := (pushout.cosquare f g).X
+def pushout.ι₁ : Y ⟶ pushout f g := (pushout.cosquare f g).ι₁
+def pushout.ι₂ : Z ⟶ pushout f g := (pushout.cosquare f g).ι₂
+@[simp] lemma pushout.w : f ≫ pushout.ι₁ f g = g ≫ pushout.ι₂ f g :=
+begin
+  erw ((pushout.cosquare f g).w fst),
+  erw ((pushout.cosquare f g).w snd)
+end
+def pushout.universal_property : is_pushout (pushout.cosquare f g) :=
+has_pushouts.is_pushout.{u v} C f g
+
+instance has_colimits_of_shape_of_has_pushouts [has_pushouts.{u v} C] :
+  limits.has_colimits_of_shape.{u v} walking_span.{v} C :=
+{ cocone := λ F, cocone.of_cosquare (pushout.cosquare (F.map fst) (F.map snd)),
+  is_colimit := λ F, let is_pushout := pushout.universal_property (F.map fst) (F.map snd) in
+  { desc := λ s, is_pushout.desc (cosquare.of_cocone s),
+    fac' := λ s j,
+    begin
+      dsimp at *,
+      cases j; simp,
+    end,
+    uniq' := λ s m w, is_pushout.uniq (cosquare.of_cocone s) m
+      (λ j, begin have h := w j, cases j; simp at *; exact h end) } }.
+
+@[extensionality] lemma pushout.hom_ext [has_pushouts.{u v} C] {W : C}
+  {k h : pushout f g ⟶ W}
+  (w_left : pushout.ι₁ f g ≫ k = pushout.ι₁ f g ≫ h)
+  (w_right : pushout.ι₂ f g ≫ k = pushout.ι₂ f g ≫ h) : k = h :=
+(pushout.universal_property f g).hom_ext w_left w_right
+
+def pushout.desc [has_pushouts.{u v} C] {W : C}
+  (f' : Y ⟶ W) (g' : Z ⟶ W) (eq : f ≫ f' = g ≫ g') : pushout f g ⟶ W :=
+(pushout.universal_property f g).desc (cosquare.mk f' g' eq)
+
+@[simp] lemma pushout.lift_π₁ [has_pushouts.{u v} C] {W : C}
+  (f' : Y ⟶ W) (g' : Z ⟶ W) (eq : f ≫ f' = g ≫ g') :
+  pushout.ι₁ f g ≫ pushout.desc f g f' g' eq = f' :=
+(pushout.universal_property f g).fac (cosquare.mk f' g' eq) _
+
+@[simp] lemma pushout.lift_π₂ [has_pushouts.{u v} C] {W : C}
+  (f' : Y ⟶ W) (g' : Z ⟶ W) (eq : f ≫ f' = g ≫ g') :
+  pushout.ι₂ f g ≫ pushout.desc f g f' g' eq = g' :=
+(pushout.universal_property f g).fac (cosquare.mk f' g' eq) _
+
+@[simp] lemma pushout.lift_id [has_pushouts.{u v} C]
+  (eq : f ≫ pushout.ι₁ f g = g ≫ pushout.ι₂ f g) :
+  pushout.desc f g _ _ eq = 𝟙 _ :=
+begin
+  refine ((pushout.universal_property f g).uniq _ _ _).symm,
+  rintros (_ | _ | _),
+  { dsimp [cosquare.mk], simp,
+    have := (pushout.cosquare f g).ι.naturality walking_span_hom.snd,
+    dsimp at this,
+    erw ← this,
+    simpa },
+  { dsimp [cosquare.mk], erw category.comp_id, refl },
+  { dsimp [cosquare.mk], erw category.comp_id, refl },
+end
+
+end pushout
+
+end category_theory.limits

--- a/category_theory/limits/pullbacks.lean
+++ b/category_theory/limits/pullbacks.lean
@@ -342,6 +342,15 @@ begin
     simpa }
 end
 
+def pullback.hom_equiv {P : C} : (P ⟶ pullback f g) ≅ { p : (P ⟶ X) × (P ⟶ Y) // p.1 ≫ f = p.2 ≫ g } :=
+{ hom := λ k,
+  ⟨ (k ≫ pullback.π₁ f g, k ≫ pullback.π₂ f g),
+    begin
+      rw [category.assoc, category.assoc],
+      rw pullback.w,
+    end ⟩,
+  inv := λ p, pullback.lift f g p.val.1 p.val.2 p.property }
+
 end pullback
 
 section pushout
@@ -407,6 +416,15 @@ begin
   { dsimp [cosquare.mk], erw category.comp_id, refl },
   { dsimp [cosquare.mk], erw category.comp_id, refl },
 end
+
+def pushout.hom_equiv {P : C} : (pushout f g ⟶ P) ≅ { p : (Y ⟶ P) × (Z ⟶ P) // f ≫ p.1 = g ≫ p.2 } :=
+{ hom := λ k,
+  ⟨ (pushout.ι₁ f g ≫ k, pushout.ι₂ f g ≫ k),
+    begin
+      rw [←category.assoc, ←category.assoc],
+      rw pushout.w,
+    end ⟩,
+  inv := λ p, pushout.desc f g p.val.1 p.val.2 p.property }
 
 end pushout
 

--- a/category_theory/limits/terminal.lean
+++ b/category_theory/limits/terminal.lean
@@ -58,6 +58,10 @@ begin
   refl,
 end
 
+def terminal.hom_equiv {P : C} : (P ⟶ terminal C) ≅ punit :=
+{ hom := λ f, punit.star,
+  inv := λ s, terminal.from P }
+
 end terminal
 
 section initial
@@ -74,13 +78,18 @@ variables {C}
 def initial.to (X : C) : initial C ⟶ X :=
 (has_initial.is_initial.{u v} C).desc { X := X, ι := by tidy }.
 
-@[extensionality] def initial.hom_ext {X : C} (f g : initial C ⟶ X) : f = g := 
+@[extensionality] def initial.hom_ext {X : C} (f g : initial C ⟶ X) : f = g :=
 begin
   have h := has_initial.is_initial.{u v} C,
   rw h.uniq { X := X, ι := by tidy } f (by tidy),
   rw h.uniq { X := X, ι := by tidy } g (by tidy),
   refl,
 end
+
+def initial.hom_equiv {P : C} : (initial C ⟶ P) ≅ punit :=
+{ hom := λ f, punit.star,
+  inv := λ s, initial.to P }
+
 end initial
 
 -- Special cases of this may be marked with [instance] as desired.

--- a/category_theory/limits/terminal.lean
+++ b/category_theory/limits/terminal.lean
@@ -1,0 +1,122 @@
+-- Copyright (c) 2018 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Scott Morrison
+
+import category_theory.limits.limits
+import category_theory.limits.products
+import category_theory.discrete_category
+
+open category_theory
+
+namespace category_theory.limits
+
+universes u v
+
+variables {C : Type u} [𝒞 : category.{u v} C]
+include 𝒞
+
+def is_terminal (X : C) :=
+is_limit ({ X := X, π := { app := pempty.rec _ } } : cone (functor.empty C))
+def is_initial (X : C) :=
+is_colimit ({ X := X, ι := { app := pempty.rec _ } } : cocone (functor.empty C))
+
+variables {X : C}
+
+instance is_terminal_subsingleton : subsingleton (is_terminal X) :=
+by dsimp [is_terminal]; apply_instance
+instance is_initial_subsingleton : subsingleton (is_initial X) :=
+by dsimp [is_initial]; apply_instance
+
+variable (C)
+
+class has_terminal :=
+(terminal : C)
+(is_terminal : is_terminal terminal . obviously)
+class has_initial :=
+(initial : C)
+(is_initial : is_initial initial . obviously)
+
+section terminal
+variables [has_terminal.{u v} C]
+
+def terminal := has_terminal.terminal.{u v} C
+
+instance has_limit_of_has_terminal : has_limit (functor.empty C) :=
+{ cone := { X := terminal C, π := by tidy, },
+  is_limit := has_terminal.is_terminal C }
+
+variables {C}
+
+def terminal.from (X : C) : X ⟶ terminal C :=
+(has_terminal.is_terminal.{u v} C).lift { X := X, π := by tidy }.
+
+@[extensionality] def terminal.hom_ext {X : C} (f g : X ⟶ terminal C) : f = g :=
+begin
+  have h := has_terminal.is_terminal.{u v} C,
+  rw h.uniq { X := X, π := by tidy } f (by tidy),
+  rw h.uniq { X := X, π := by tidy } g (by tidy),
+  refl,
+end
+
+end terminal
+
+section initial
+variables [has_initial.{u v} C]
+
+def initial := has_initial.initial.{u v} C
+
+instance has_colimit_of_has_initial : has_colimit (functor.empty C) :=
+{ cocone := { X := initial C, ι := by tidy, },
+  is_colimit := has_initial.is_initial C }
+
+variables {C}
+
+def initial.to (X : C) : initial C ⟶ X :=
+(has_initial.is_initial.{u v} C).desc { X := X, ι := by tidy }.
+
+@[extensionality] def initial.hom_ext {X : C} (f g : initial C ⟶ X) : f = g := 
+begin
+  have h := has_initial.is_initial.{u v} C,
+  rw h.uniq { X := X, ι := by tidy } f (by tidy),
+  rw h.uniq { X := X, ι := by tidy } g (by tidy),
+  refl,
+end
+end initial
+
+-- Special cases of this may be marked with [instance] as desired.
+def has_terminal_of_has_limits [limits.has_limits.{u v} C] : has_terminal.{u v} C :=
+{ terminal := limit (functor.empty C),
+  is_terminal :=
+    is_limit_invariance _ _
+      (by tidy)
+      (limit.universal_property (functor.empty C)) }
+def has_initial_of_has_colimits [limits.has_colimits.{u v} C] : has_initial.{u v} C :=
+{ initial := colimit (functor.empty C),
+  is_initial :=
+    is_colimit_invariance _ _
+      (by tidy)
+      (colimit.universal_property (functor.empty C)) }
+
+def has_terminal_of_has_products [has_products.{u v} C] : has_terminal.{u v} C :=
+{ terminal := limits.pi (pempty.rec _),
+  is_terminal := begin tidy, apply pi.lift, tidy, end }
+def has_initial_of_has_coproducts [has_coproducts.{u v} C] : has_initial.{u v} C :=
+{ initial := limits.sigma (pempty.rec _),
+  is_initial := begin tidy, apply sigma.desc, tidy, end }
+
+-- TODO restore:
+-- def limit_cone_of_limit {t : cone F} (L : is_limit t) : is_terminal.{(max u v) v} t :=
+-- { lift := λ s, { hom := L.lift s, },
+--   uniq' := begin tidy, apply L.uniq, tidy, end } -- TODO uniq is marked @[back'], but the unifier fails to apply it
+
+-- def limit_of_limit_cone {t : cone F} (L : is_terminal.{(max u v) v} t) : is_limit t :=
+-- { lift := λ s, (L.lift s).hom,
+--   uniq' := begin tidy, have p := L.uniq s { hom := m }, rw ← p, end }
+
+-- def limits_are_limit_cones {t : cone F} : (is_limit t) ≅ (is_terminal.{(max u v) v} t) :=
+-- { hom := limit_cone_of_limit,
+--   inv := limit_of_limit_cone,
+--   hom_inv_id' := by obviously,
+--   inv_hom_id' := by obviously }
+
+end category_theory.limits

--- a/category_theory/limits/types.lean
+++ b/category_theory/limits/types.lean
@@ -1,0 +1,151 @@
+-- Copyright (c) 2018 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Scott Morrison, Reid Barton
+
+import category_theory.limits
+
+universes u v
+
+open category_theory
+open category_theory.limits
+
+namespace category_theory.limits.types
+
+variables {J : Type u} [small_category J]
+
+def limit (F : J ⥤ Type u) : cone F :=
+{ X := {u : Π j, F.obj j // ∀ (j j' : J) (f : j ⟶ j'), F.map f (u j) = u j'},
+  π := { app := λ j u, u.val j } }
+
+attribute [extensionality] subtype.eq
+
+def limit_is_limit (F : J ⥤ Type u) : is_limit (limit F) :=
+{ lift := λ s v, ⟨λ j, s.π.app j v, λ j j' f, congr_fun (@cone.w _ _ _ _ _ s j j' f) _⟩,
+  uniq' :=
+  begin
+    tidy,
+    have h := congr_fun (w x_1) x,
+    exact h
+  end }
+
+instance : has_limits.{u+1 u} (Type u) :=
+{ cone := @limit, is_limit := @limit_is_limit }
+
+@[simp] lemma types_limit (F : J ⥤ Type u) :
+  limits.limit F = {u : Π j, F.obj j // ∀ j j' f, F.map f (u j) = u j'} := rfl
+@[simp] lemma types_limit_π (F : J ⥤ Type u) (j : J) (g : (limit F).X) :
+  limit.π F j g = g.val j := rfl.
+@[simp] lemma types_limit_pre
+  (F : J ⥤ Type u) {K : Type u} [𝒦 : small_category K] (E : K ⥤ J) (g : (limit F).X) :
+  limit.pre F E g = (⟨ λ k, g.val (E.obj k), by obviously ⟩ : (limit (E ⋙ F)).X) := rfl
+@[simp] lemma types_limit_map {F G : J ⥤ Type u} (α : F ⟹ G) (g : (limit F).X) :
+  (lim.map α : (limit F).X → (limit G).X) g =
+  (⟨ λ j, (α.app j) (g.val j), λ j j' f,
+     by rw [←functor_to_types.naturality, ←(g.property j j' f)] ⟩ : (limit G).X) :=
+rfl
+
+@[simp] lemma types_limit_lift (F : J ⥤ Type u) (c : cone F) (x : c.X):
+  limit.lift F c x = (⟨ λ j, c.π.app j x, λ j j' f, congr_fun (cone.w c f) x ⟩ : (limit F).X) := 
+rfl
+
+def colimit (F : J ⥤ Type u) : cocone F :=
+{ X := @quot (Σ j, F.obj j) (λ p p', ∃ f : p.1 ⟶ p'.1, p'.2 = F.map f p.2),
+  ι :=
+  { app := λ j x, quot.mk _ ⟨j, x⟩,
+    naturality' := λ j j' f, funext $ λ x, eq.symm (quot.sound ⟨f, rfl⟩) } }
+
+local attribute [elab_with_expected_type] quot.lift
+
+def colimit_is_colimit (F : J ⥤ Type u) : is_colimit (colimit F) :=
+{ desc := λ s, quot.lift (λ (p : Σ j, F.obj j), s.ι.app p.1 p.2)
+  (assume ⟨j, x⟩ ⟨j', x'⟩ ⟨f, hf⟩, by rw hf; exact (congr_fun (cocone.w s f) x).symm),
+  fac' := begin tidy end,
+  uniq' := begin tidy end }
+
+instance : has_colimits.{u+1 u} (Type u) :=
+{ cocone := @colimit, is_colimit := @colimit_is_colimit }
+
+@[simp] lemma types_colimit (F : J ⥤ Type u) :
+  limits.colimit F = @quot (Σ j, F.obj j) (λ p p', ∃ f : p.1 ⟶ p'.1, p'.2 = F.map f p.2) := rfl
+@[simp] lemma types_colimit_ι
+  (F : J ⥤ Type u) (j : J) : colimit.ι F j = λ x, quot.mk _ (⟨j, x⟩ : (Σ j, F.obj j)) := rfl.
+
+local attribute [extensionality] quot.sound
+
+@[simp] lemma types_colimit_map {F G : J ⥤ Type u} (α : F ⟹ G) :
+  (colim.map α : (colimit F).X → (colimit G).X) =
+  (quot.lift
+    (λ p : Σ (j : J), F.obj j, quot.mk _ ⟨ p.1, (α.app p.1) p.2 ⟩ )
+    (λ p p' r, begin tidy, exact r_w, rw r_h, rw functor_to_types.naturality, end)) := 
+rfl
+
+lemma types_colimit_pre
+  (F : J ⥤ Type u) {K : Type u} [𝒦 : small_category K] (E : K ⥤ J) (g : (colimit (E ⋙ F)).X) :
+  (colimit.pre F E : (colimit (E ⋙ F)).X → (colimit F).X) = 
+  quot.lift 
+    (λ p : Σ (j : K), (E ⋙ F).obj j, quot.mk _ ⟨ E.obj p.1, p.2 ⟩)
+    (by tidy) := 
+rfl
+
+-- TODO finish stating this lemma!
+-- @[simp] lemma types_colimit_desc (F : J ⥤ Type u) (c : cocone F) :
+--   colimit.desc F c = λ x, begin sorry end := rfl
+
+instance : has_terminal.{u+1 u} (Type u) :=
+{ terminal := punit }
+instance : has_initial.{u+1 u} (Type u) :=
+{ initial := pempty }
+
+open category_theory.limits.walking_cospan
+open category_theory.limits.walking_cospan_hom
+
+def pullback {Y₁ Y₂ Z : Type u} (r₁ : Y₁ ⟶ Z) (r₂ : Y₂ ⟶ Z) : cone (cospan r₁ r₂) :=
+{ X := { z : Y₁ × Y₂ // r₁ z.1 = r₂ z.2 },
+  π :=
+  { app := λ j z,
+      match j with
+      | left  := z.val.1
+      | right := z.val.2
+      | one   := r₁ z.val.1
+      end,
+    naturality' := λ j j' f, funext $
+      match j, j', f with
+      | _, _, (id _) := by tidy
+      | _, _, inl := by tidy
+      | _, _, inr := λ x, begin dsimp [cospan], erw ← x.property, refl end
+      end } }
+
+instance : has_pullbacks.{u+1 u} (Type u) :=
+{ square := λ Y₁ Y₂ Z r₁ r₂, pullback r₁ r₂,
+  is_pullback := λ Y₁ Y₂ Z r₁ r₂,
+  { lift  := λ s x, ⟨ (s.π.app left x, s.π.app right x),
+    begin
+      have swl := congr_fun (@cone.w _ _ _ _ _ s left one inl) x,
+      have swr := congr_fun (@cone.w _ _ _ _ _ s right one inr) x,
+      exact eq.trans swl (eq.symm swr),
+    end ⟩,
+    fac' := λ s j, funext $ λ x,
+    begin
+      cases j, refl, refl,
+      exact congr_fun (s.w inl) x,
+    end,
+    uniq' := λ s m w,
+    begin
+      tidy,
+      exact congr_fun (w left) x,
+      exact congr_fun (w right) x,
+    end }, }
+
+-- We should eventually provide 'hand-rolled' instances, like those above,
+-- which will be cleaner to use.
+
+instance : has_products.{u+1 u} (Type u) := has_products_of_has_limits
+instance : has_binary_products.{u+1 u} (Type u) := has_binary_products_of_has_products
+instance : has_equalizers.{u+1 u} (Type u) := has_equalizers_of_has_limits
+
+instance : has_coproducts.{u+1 u} (Type u) := has_coproducts_of_has_colimits
+instance : has_binary_coproducts.{u+1 u} (Type u) := has_binary_coproducts_of_has_coproducts
+instance : has_coequalizers.{u+1 u} (Type u) := has_coequalizers_of_has_colimits
+instance : has_pushouts.{u+1 u} (Type u) := has_pushouts_of_has_colimits
+
+end category_theory.limits.types

--- a/category_theory/opposites.lean
+++ b/category_theory/opposites.lean
@@ -59,6 +59,8 @@ definition op_inv : (Cᵒᵖ ⥤ Dᵒᵖ) ⥤ (C ⥤ D)ᵒᵖ :=
     naturality' := λ X Y f, eq.symm (α.naturality f) } }
 
 namespace op_inv
+@[simp] lemma obj_obj (F : Cᵒᵖ ⥤ Dᵒᵖ) (X : C) : ((op_inv C D).obj F).obj X = F.obj X := rfl
+@[simp] lemma obj_map (F : Cᵒᵖ ⥤ Dᵒᵖ) {X Y : C} (f : X ⟶ Y) : ((op_inv C D).obj F).map f = F.map f := rfl
 @[simp] lemma map_app {F G : Cᵒᵖ ⥤ Dᵒᵖ} (α : F ⟶ G) (X : C) : ((op_inv C D).map α).app X = α.app X := rfl
 end op_inv
 

--- a/category_theory/opposites.lean
+++ b/category_theory/opposites.lean
@@ -11,7 +11,7 @@ universes u₁ v₁ u₂ v₂
 
 def op (C : Type u₁) : Type u₁ := C
 
-notation C `ᵒᵖ` := op C
+notation C `ᵒᵖ`:80 := op C
 
 variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C]
 include 𝒞
@@ -21,22 +21,59 @@ instance opposite : category.{u₁ v₁} (Cᵒᵖ) :=
   comp := λ _ _ _ f g, g ≫ f,
   id   := λ X, 𝟙 X }
 
+def op_op : (Cᵒᵖ)ᵒᵖ ⥤ C :=
+{ obj := λ X, X,
+  map := λ X Y f, f }
+
+-- TODO this is an equivalence
+
 namespace functor
 
-section
 variables {D : Type u₂} [𝒟 : category.{u₂ v₂} D]
 include 𝒟
 
-protected definition op (F : C ⥤ D) : (Cᵒᵖ) ⥤ (Dᵒᵖ) :=
-{ obj       := λ X, F.obj X,
-  map       := λ X Y f, F.map f,
-  map_id'   := begin /- `obviously'` says: -/ intros, erw [map_id], refl, end,
-  map_comp' := begin /- `obviously'` says: -/ intros, erw [map_comp], refl end }
+variables (C D)
+
+definition op_hom : (C ⥤ D)ᵒᵖ ⥤ (Cᵒᵖ ⥤ Dᵒᵖ) :=
+{ obj := λ F : C ⥤ D,
+  { obj       := λ X, F.obj X,
+    map       := λ X Y f, F.map f,
+    map_id'   := begin /- `obviously'` says: -/ intros, erw [map_id], refl, end,
+    map_comp' := begin /- `obviously'` says: -/ intros, erw [map_comp], refl end },
+  map := λ F G α,
+  { app := λ X, α.app X,
+    naturality' := λ X Y f, eq.symm (α.naturality f) } }
+
+namespace op_hom
+@[simp] lemma map_app {F G : (C ⥤ D)ᵒᵖ} (α : F ⟶ G) (X : C) : ((op_hom C D).map α).app X = α.app X := rfl
+end op_hom
+
+definition op_inv : (Cᵒᵖ ⥤ Dᵒᵖ) ⥤ (C ⥤ D)ᵒᵖ :=
+{ obj := λ F : Cᵒᵖ ⥤ Dᵒᵖ,
+  { obj       := λ X, F.obj X,
+    map       := λ X Y f, F.map f,
+    map_id'   := begin /- `obviously'` says: -/ intros, erw [map_id], refl, end,
+    map_comp' := begin /- `obviously'` says: -/ intros, erw [map_comp], refl end },
+  map := λ F G α,
+  { app := λ X : C, α.app X,
+    naturality' := λ X Y f, eq.symm (α.naturality f) } }
+
+namespace op_inv
+@[simp] lemma map_app {F G : Cᵒᵖ ⥤ Dᵒᵖ} (α : F ⟶ G) (X : C) : ((op_inv C D).map α).app X = α.app X := rfl
+end op_inv
+
+-- TODO show these form an equivalence
+
+variables {C D}
+
+protected definition op (F : C ⥤ D) : Cᵒᵖ ⥤ Dᵒᵖ := (@op_hom C _ D _).obj (F : (C ⥤ D)ᵒᵖ)
 
 @[simp] lemma opposite_obj (F : C ⥤ D) (X : C) : (F.op).obj X = F.obj X := rfl
 @[simp] lemma opposite_map (F : C ⥤ D) {X Y : C} (f : X ⟶ Y) : (F.op).map f = F.map f := rfl
-end
 
+end functor
+
+namespace functor
 variable (C)
 
 /-- `functor.hom` is the hom-pairing, sending (X,Y) to X → Y, contravariant in X and covariant in Y. -/

--- a/category_theory/products.lean
+++ b/category_theory/products.lean
@@ -80,17 +80,32 @@ section
 variables (C : Type u₁) [𝒞 : category.{u₁ v₁} C] (D : Type u₂) [𝒟 : category.{u₂ v₂} D]
 include 𝒞 𝒟
 
--- TODO, later this can be defined by uncurrying `functor.id (C ⥤ D)`
-def evaluation : ((C ⥤ D) × C) ⥤ D :=
-{ obj := λ p, p.1.obj p.2,
-  map := λ x y f, (x.1.map f.2) ≫ (f.1.app y.2),
-  map_comp' := begin
-                 intros X Y Z f g, cases g, cases f, cases Z, cases Y, cases X, dsimp at *, simp at *,
-                 erw [←nat_trans.vcomp_app, nat_trans.naturality, category.assoc, nat_trans.naturality]
-               end }
+@[simp] def evaluation : C ⥤ (C ⥤ D) ⥤ D :=
+{ obj := λ X,
+  { obj := λ F, F.obj X,
+    map := λ F G α, α.app X, },
+  map := λ X Y f,
+  { app := λ F, F.map f,
+    naturality' := λ F G α, eq.symm (α.naturality f) },
+  map_comp' := λ X Y Z f g,
+  begin
+    ext, dsimp, rw functor.map_comp,
+  end }
+
+@[simp] def evaluation_uncurried : (C × (C ⥤ D)) ⥤ D :=
+{ obj := λ p, p.2.obj p.1,
+  map := λ x y f, (x.2.map f.1) ≫ (f.2.app y.1),
+  map_comp' :=
+  begin
+    intros X Y Z f g, cases g, cases f, cases Z, cases Y, cases X, dsimp at *, simp at *,
+    erw [←nat_trans.vcomp_app, nat_trans.naturality, category.assoc, nat_trans.naturality]
+  end }
 end
 
-variables {A : Type u₁} [𝒜 : category.{u₁ v₁} A] {B : Type u₂} [ℬ : category.{u₂ v₂} B] {C : Type u₃} [𝒞 : category.{u₃ v₃} C] {D : Type u₄} [𝒟 : category.{u₄ v₄} D]
+variables {A : Type u₁} [𝒜 : category.{u₁ v₁} A]
+          {B : Type u₂} [ℬ : category.{u₂ v₂} B]
+          {C : Type u₃} [𝒞 : category.{u₃ v₃} C]
+          {D : Type u₄} [𝒟 : category.{u₄ v₄} D]
 include 𝒜 ℬ 𝒞 𝒟
 
 namespace functor

--- a/category_theory/types.lean
+++ b/category_theory/types.lean
@@ -2,7 +2,8 @@
 -- Released under Apache 2.0 license as described in the file LICENSE.
 -- Authors: Stephen Morgan, Scott Morrison, Johannes Hölzl
 
-import category_theory.functor_category category_theory.embedding
+import category_theory.functor_category
+import category_theory.fully_faithful
 
 namespace category_theory
 

--- a/category_theory/yoneda.lean
+++ b/category_theory/yoneda.lean
@@ -28,6 +28,16 @@ def yoneda : C ⥤ ((Cᵒᵖ) ⥤ (Type v₁)) :=
     map_id' := begin intros X_1, ext1, dsimp at *, erw [category.id_comp] end },
   map := λ X X' f, { app := λ Y g, g ≫ f } }
 
+def coyoneda : (Cᵒᵖ) ⥤ (C ⥤ (Type v₁)) :=
+{ obj := λ X : C,
+  { obj := λ Y, X ⟶ Y,
+    map := λ Y Y' f g, g ≫ f,
+    map_comp' := begin intros X_1 Y Z f g, ext1, dsimp at *, erw [category.assoc] end,
+    map_id' := begin intros X_1, ext1, dsimp at *, erw [category.comp_id] end },
+  map := λ X X' f, { app := λ Y g, f ≫ g },
+  map_comp' := begin intros X Y Z f g, ext1, ext1, dsimp at *, erw [category.assoc] end,
+  map_id' := begin intros X, ext1, ext1, dsimp at *, erw [category.id_comp] end }
+
 variables (C)
 
 namespace yoneda
@@ -76,6 +86,15 @@ instance prod_category_instance_2 : category ((Cᵒᵖ) × ((Cᵒᵖ) ⥤ Type v
 category_theory.prod.{u₁ v₁ (max u₁ (v₁+1)) (max u₁ v₁)} (Cᵒᵖ) (Cᵒᵖ ⥤ Type v₁)
 
 end yoneda
+
+namespace coyoneda
+@[simp] lemma obj_obj (X Y : C) : (coyoneda.obj X).obj Y = (X ⟶ Y) := rfl
+@[simp] lemma obj_map (X : C) {Y Y' : C} (f : Y ⟶ Y') : (coyoneda.obj X).map f = λ g, g ≫ f := rfl
+@[simp] lemma map_app {X X' : C} (f : X ⟶ X') (Y : C) : (coyoneda.map f).app Y = λ g, f ≫ g := rfl
+
+-- Does anyone need the coyoneda lemma as well?
+
+end coyoneda
 
 open yoneda
 

--- a/category_theory/yoneda.lean
+++ b/category_theory/yoneda.lean
@@ -10,14 +10,14 @@
 import category_theory.natural_transformation
 import category_theory.opposites
 import category_theory.types
-import category_theory.embedding
+import category_theory.fully_faithful
 import category_theory.natural_isomorphism
 
 namespace category_theory
 
 universes u₁ v₁ u₂
 
-variables (C : Type u₁) [𝒞 : category.{u₁ v₁} C]
+variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C]
 include 𝒞
 
 def yoneda : C ⥤ ((Cᵒᵖ) ⥤ (Type v₁)) :=
@@ -28,22 +28,24 @@ def yoneda : C ⥤ ((Cᵒᵖ) ⥤ (Type v₁)) :=
     map_id' := begin intros X_1, ext1, dsimp at *, erw [category.id_comp] end },
   map := λ X X' f, { app := λ Y g, g ≫ f } }
 
-namespace yoneda
-@[simp] lemma obj_obj (X Y : C) : ((yoneda C).obj X).obj Y = (Y ⟶ X) := rfl
-@[simp] lemma obj_map (X : C) {Y Y' : C} (f : Y ⟶ Y') : ((yoneda C).obj X).map f = λ g, f ≫ g := rfl
-@[simp] lemma map_app {X X' : C} (f : X ⟶ X') (Y : C) : ((yoneda C).map f).app Y = λ g, g ≫ f := rfl
+variables (C)
 
-lemma obj_map_id {X Y : Cᵒᵖ} (f : X ⟶ Y) : ((yoneda C).obj X).map f (𝟙 X) = ((yoneda C).map f).app Y (𝟙 Y) :=
+namespace yoneda
+@[simp] lemma obj_obj (X Y : C) : (yoneda.obj X).obj Y = (Y ⟶ X) := rfl
+@[simp] lemma obj_map (X : C) {Y Y' : C} (f : Y ⟶ Y') : (yoneda.obj X).map f = λ g, f ≫ g := rfl
+@[simp] lemma map_app {X X' : C} (f : X ⟶ X') (Y : C) : (yoneda.map f).app Y = λ g, g ≫ f := rfl
+
+lemma obj_map_id {X Y : Cᵒᵖ} (f : X ⟶ Y) : ((@yoneda C _).obj X).map f (𝟙 X) = ((@yoneda C _).map f).app Y (𝟙 Y) :=
 by obviously
 
-@[simp] lemma naturality {X Y : C} (α : (yoneda C).obj X ⟶ (yoneda C).obj Y)
+@[simp] lemma naturality {X Y : C} (α : yoneda.obj X ⟶ yoneda.obj Y)
   {Z Z' : C} (f : Z ⟶ Z') (h : Z' ⟶ X) : f ≫ α.app Z' h = α.app Z (f ≫ h) :=
 begin erw [functor_to_types.naturality], refl end
 
-instance full : full (yoneda C) :=
+instance yoneda_full : full (@yoneda C _) :=
 { preimage := λ X Y f, (f.app X) (𝟙 X) }.
 
-instance faithful : faithful (yoneda C) :=
+instance yoneda_faithful : faithful (@yoneda C _) :=
 begin
   fsplit,
   intros X Y f g p,
@@ -63,7 +65,7 @@ def ext (X Y : C)
   (p : Π {Z : C}, (Z ⟶ X) → (Z ⟶ Y)) (q : Π {Z : C}, (Z ⟶ Y) → (Z ⟶ X))
   (h₁ : Π {Z : C} (f : Z ⟶ X), q (p f) = f) (h₂ : Π {Z : C} (f : Z ⟶ Y), p (q f) = f)
   (n : Π {Z Z' : C} (f : Z' ⟶ Z) (g : Z ⟶ X), p (f ≫ g) = f ≫ p g) : X ≅ Y :=
-@preimage_iso _ _ _ _ (yoneda C) _ _ _ _
+@preimage_iso _ _ _ _ yoneda _ _ _ _
   (nat_iso.of_components (λ Z, { hom := p, inv := q, }) (by tidy))
 
 -- We need to help typeclass inference with some awkward universe levels here.
@@ -77,36 +79,71 @@ end yoneda
 
 open yoneda
 
-def yoneda_evaluation : (((Cᵒᵖ) ⥤ (Type v₁)) × (Cᵒᵖ)) ⥤ (Type (max u₁ v₁)) :=
-(evaluation (Cᵒᵖ) (Type v₁)) ⋙ ulift_functor.{v₁ u₁}
+def yoneda_evaluation : ((Cᵒᵖ) × ((Cᵒᵖ) ⥤ (Type v₁))) ⥤ (Type (max u₁ v₁)) :=
+(evaluation_uncurried (Cᵒᵖ) (Type v₁)) ⋙ ulift_functor.{v₁ u₁}
 
 @[simp] lemma yoneda_evaluation_map_down
-  (P Q : (Cᵒᵖ ⥤ Type v₁) × (Cᵒᵖ)) (α : P ⟶ Q) (x : (yoneda_evaluation C).obj P) :
-  ((yoneda_evaluation C).map α x).down = (α.1).app (Q.2) ((P.1).map (α.2) (x.down)) := rfl
+  (P Q : (Cᵒᵖ) × (Cᵒᵖ ⥤ Type v₁)) (α : P ⟶ Q) (x : (yoneda_evaluation C).obj P) :
+  ((yoneda_evaluation C).map α x).down = (α.2).app (Q.1) ((P.2).map (α.1) (x.down)) := rfl
 
-def yoneda_pairing : (((Cᵒᵖ) ⥤ (Type v₁)) × (Cᵒᵖ)) ⥤ (Type (max u₁ v₁)) :=
-let F := (category_theory.prod.swap ((Cᵒᵖ) ⥤ (Type v₁)) (Cᵒᵖ)) in
-let G := (functor.prod ((yoneda C).op) (functor.id ((Cᵒᵖ) ⥤ (Type v₁)))) in
-let H := (functor.hom ((Cᵒᵖ) ⥤ (Type v₁))) in
-  (F ⋙ G ⋙ H)
+def yoneda_pairing : ((Cᵒᵖ) × ((Cᵒᵖ) ⥤ (Type v₁))) ⥤ (Type (max u₁ v₁)) :=
+(functor.prod (yoneda.op) (functor.id ((Cᵒᵖ) ⥤ (Type v₁)))) ⋙
+  (functor.hom ((Cᵒᵖ) ⥤ (Type v₁)))
 
 @[simp] lemma yoneda_pairing_map
-  (P Q : (Cᵒᵖ ⥤ Type v₁) ×  (Cᵒᵖ)) (α : P ⟶ Q) (β : (yoneda_pairing C).obj (P.1, P.2)) :
-  (yoneda_pairing C).map α β = (yoneda C).map (α.snd) ≫ β ≫ α.fst := rfl
+  (P Q : (Cᵒᵖ) × (Cᵒᵖ ⥤ Type v₁)) (α : P ⟶ Q) (β : (yoneda_pairing C).obj P) :
+  (yoneda_pairing C).map α β = yoneda.map (α.1) ≫ β ≫ α.2 := rfl
 
 def yoneda_lemma : (yoneda_pairing C) ≅ (yoneda_evaluation C) :=
 { hom :=
-  { app := λ F x, ulift.up ((x.app F.2) (𝟙 F.2)),
-    naturality' := begin intros X Y f, ext1, ext1, cases f, cases Y, cases X, dsimp at *, simp at *,
-      erw [←functor_to_types.naturality, obj_map_id, functor_to_types.naturality, functor_to_types.map_id] end },
+  { app := λ F x, ulift.up ((x.app F.1) (𝟙 F.1)),
+    naturality' :=
+    begin
+      intros X Y f, ext1, ext1,
+      cases f, cases Y, cases X,
+      dsimp at *, simp at *,
+      erw [←functor_to_types.naturality,
+           obj_map_id,
+           functor_to_types.naturality,
+           functor_to_types.map_id]
+    end },
   inv :=
   { app := λ F x,
-    { app := λ X a, (F.1.map a) x.down,
-      naturality' := begin intros X Y f, ext1, cases x, cases F, dsimp at *, erw [functor_to_types.map_comp], refl end },
-    naturality' := begin intros X Y f, ext1, ext1, ext1, cases x, cases f, cases Y, cases X,
-      dsimp at *, erw [←functor_to_types.naturality, functor_to_types.map_comp] end },
-  hom_inv_id' := begin ext1, ext1, ext1, ext1, cases X, dsimp at *,
-    erw [←functor_to_types.naturality, obj_map_id, functor_to_types.naturality, functor_to_types.map_id] end,
-  inv_hom_id' := begin ext1, ext1, ext1, cases x, cases X, dsimp at *, erw [functor_to_types.map_id] end }.
+    { app := λ X a, (F.2.map a) x.down,
+      naturality' :=
+      begin
+        intros X Y f, ext1,
+        cases x, cases F,
+        dsimp at *,
+        erw [functor_to_types.map_comp]
+      end },
+    naturality' :=
+    begin
+      intros X Y f, ext1, ext1, ext1,
+      cases x, cases f, cases Y, cases X,
+      dsimp at *,
+      erw [←functor_to_types.naturality, functor_to_types.map_comp]
+    end },
+  hom_inv_id' :=
+  begin
+    ext1, ext1, ext1, ext1, cases X, dsimp at *,
+    erw [←functor_to_types.naturality,
+         obj_map_id,
+         functor_to_types.naturality,
+         functor_to_types.map_id]
+  end,
+  inv_hom_id' :=
+  begin
+    ext1, ext1, ext1,
+    cases x, cases X,
+    dsimp at *,
+    erw [functor_to_types.map_id]
+  end }.
+
+variables {C}
+
+class representable (F : Cᵒᵖ ⥤ Type v₁) :=
+(X : C)
+(w : yoneda.obj X ≅ F)
 
 end category_theory

--- a/data/ulift.lean
+++ b/data/ulift.lean
@@ -1,0 +1,15 @@
+/-
+Copyright (c) 2018 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+
+Transport through constant families.
+-/
+
+universes u₁ u₂
+
+@[simp] lemma plift.rec.constant {α : Sort u₁} {β : Sort u₂} (b : β) : @plift.rec α (λ _, β) (λ _, b) = λ _, b :=
+funext (λ x, plift.cases_on x (λ a, eq.refl (plift.rec (λ a', b) {down := a})))
+
+@[simp] lemma ulift.rec.constant {α : Type u₁} {β : Sort u₂} (b : β) : @ulift.rec α (λ _, β) (λ _, b) = λ _, b :=
+funext (λ x, ulift.cases_on x (λ a, eq.refl (ulift.rec (λ a', b) {down := a})))

--- a/docs/theories/category_theory.md
+++ b/docs/theories/category_theory.md
@@ -13,9 +13,11 @@ The category of functors and natural transformations between fixed categories `C
 is defined in [category_theory/functor_category.lean](https://github.com/leanprover/mathlib/blob/master/category_theory/functor_category.lean).
 
 Cartesian products of categories, functors, and natural transformations appear in
- [category_theory/products.lean](https://github.com/leanprover/mathlib/blob/master/category_theory/products.lean). (Product in the sense of limits will appear elsewhere soon!)
+[category_theory/products.lean](https://github.com/leanprover/mathlib/blob/master/category_theory/products.lean). (Product in the sense of limits will appear elsewhere soon!)
 
- The category of types, and the hom pairing functor, are defined in  [category_theory/types.lean](https://github.com/leanprover/mathlib/blob/master/category_theory/types.lean).
+The category of types, and the hom pairing functor, are defined in  [category_theory/types.lean](https://github.com/leanprover/mathlib/blob/master/category_theory/types.lean).
+
+
 
 ## Universes
 


### PR DESCRIPTION
Limits, products, equalizers, pullbacks, binary_products, terminal objects, and all the dual notions, too.

The basic design centres around:

```
/--
A `c : cone F` is:
* an object `c.X` and
* a natural transformation `c.π : c.X ⟹ F` from the constant `c.X` functor to `F`.
-/
structure cone (F : J ⥤ C) :=
(X : C)
(π : (const J C).obj X ⟹ F)
```

```
structure is_limit (t : cone F) :=
(lift : ∀ (s : cone F), s.X ⟶ t.X)
(fac'  : ∀ (s : cone F) (j : J), (lift s ≫ t.π.app j) = s.π.app j . obviously)
(uniq' : ∀ (s : cone F) (m : s.X ⟶ t.X) (w : ∀ j : J, (m ≫ t.π.app j) = s.π.app j), 
  m = lift s . obviously)
```

and a typeclass bundling these together:

```
class has_limit {J : Type v} [small_category J] (F : J ⥤ C) :=
(cone : cone F)
(is_limit : is_limit cone)
```

Theorems/constructions included so far:
* `Type u` has all limits and colimits.
* products, equalizers, pullbacks from limits
* limits from products and equalizers
* binary_products and terminal objects from products
* if `has_limits_of_shape J C`, then `has_limits_of_shape J (K \func C)`, and the evaluation function at `k` preserves limits
* `F.cones` is the category `C^op \func Type`, giving the collection of cones with a given cone point. We show `has_limit F` iff `representable F.cones`