### PR TITLE
define supr and infi with range

### DIFF
--- a/analysis/measure_theory/outer_measure.lean
+++ b/analysis/measure_theory/outer_measure.lean
@@ -174,7 +174,7 @@ instance : complete_lattice (outer_measure α) :=
 le_antisymm
   (supr_le $ λ ⟨_, i, rfl⟩, le_supr _ i)
   (supr_le $ λ i, le_supr
-    (λ (m : {a : outer_measure α // ∃ i, a = f i}), m.1 s)
+    (λ (m : {a : outer_measure α // ∃ i, f i = a}), m.1 s)
     ⟨f i, i, rfl⟩)
 
 @[simp] theorem sup_apply (m₁ m₂ : outer_measure α) (s : set α) :

--- a/analysis/topology/continuity.lean
+++ b/analysis/topology/continuity.lean
@@ -190,7 +190,7 @@ continuous_iff_le_coinduced.2 $ Inf_le_of_le h₁ $ continuous_iff_le_coinduced.
 
 lemma continuous_infi_dom {t₁ : ι → tspace α} {t₂ : tspace β}
   (h : ∀i, cont (t₁ i) t₂ f) : cont (infi t₁) t₂ f :=
-continuous_Inf_dom $ assume t ⟨i, (t_eq : t = t₁ i)⟩, t_eq.symm ▸ h i
+continuous_Inf_dom $ assume t ⟨i, (t_eq : t₁ i = t)⟩, t_eq ▸ h i
 
 lemma continuous_infi_rng {t₁ : tspace α} {t₂ : ι → tspace β} {i : ι}
   (h : cont t₁ (t₂ i) f) : cont t₁ (infi t₂) f :=

--- a/analysis/topology/topological_space.lean
+++ b/analysis/topology/topological_space.lean
@@ -105,7 +105,7 @@ lemma is_closed_sInter {s : set (set α)} : (∀t ∈ s, is_closed t) → is_clo
 by simp only [is_closed, compl_sInter, sUnion_image]; exact assume h, is_open_Union $ assume t, is_open_Union $ assume ht, h t ht
 
 lemma is_closed_Inter {f : ι → set α} (h : ∀i, is_closed (f i)) : is_closed (⋂i, f i ) :=
-is_closed_sInter $ assume t ⟨i, (heq : t = f i)⟩, heq.symm ▸ h i
+is_closed_sInter $ assume t ⟨i, (heq : f i = t)⟩, heq ▸ h i
 
 @[simp] lemma is_open_compl_iff {s : set α} : is_open (-s) ↔ is_closed s := iff.rfl
 

--- a/analysis/topology/uniform_space.lean
+++ b/analysis/topology/uniform_space.lean
@@ -1101,10 +1101,10 @@ instance : complete_lattice (uniform_space α) :=
 
 lemma supr_uniformity {ι : Sort*} {u : ι → uniform_space α} :
   (supr u).uniformity = (⨅i, (u i).uniformity) :=
-show (⨅a (h : ∃i:ι, a = u i), a.uniformity) = _, from
+show (⨅a (h : ∃i:ι, u i = a), a.uniformity) = _, from
 le_antisymm
   (le_infi $ assume i, infi_le_of_le (u i) $ infi_le _ ⟨i, rfl⟩)
-  (le_infi $ assume a, le_infi $ assume ⟨i, (ha : a = u i)⟩, ha.symm ▸ infi_le _ _)
+  (le_infi $ assume a, le_infi $ assume ⟨i, (ha : u i = a)⟩, ha ▸ infi_le _ _)
 
 lemma sup_uniformity {u v : uniform_space α} :
   (u ⊔ v).uniformity = u.uniformity ⊓ v.uniformity :=

--- a/data/set/lattice.lean
+++ b/data/set/lattice.lean
@@ -83,15 +83,15 @@ notation `⋃` binders `, ` r:(scoped f, Union f) := r
 notation `⋂` binders `, ` r:(scoped f, Inter f) := r
 
 @[simp] theorem mem_Union {x : β} {s : ι → set β} : x ∈ Union s ↔ ∃ i, x ∈ s i :=
-⟨assume ⟨t, ⟨⟨a, (t_eq : t = s a)⟩, (h : x ∈ t)⟩⟩, ⟨a, t_eq ▸ h⟩,
+⟨assume ⟨t, ⟨⟨a, (t_eq : s a = t)⟩, (h : x ∈ t)⟩⟩, ⟨a, t_eq.symm ▸ h⟩,
   assume ⟨a, h⟩, ⟨s a, ⟨⟨a, rfl⟩, h⟩⟩⟩
 /- alternative proof: dsimp [Union, supr, Sup]; simp -/
   -- TODO: more rewrite rules wrt forall / existentials and logical connectives
   -- TODO: also eliminate ∃i, ... ∧ i = t ∧ ...
 
 @[simp] theorem mem_Inter {x : β} {s : ι → set β} : x ∈ Inter s ↔ ∀ i, x ∈ s i :=
-⟨assume (h : ∀a ∈ {a : set β | ∃i, a = s i}, x ∈ a) a, h (s a) ⟨a, rfl⟩,
-  assume h t ⟨a, (eq : t = s a)⟩, eq.symm ▸ h a⟩
+⟨assume (h : ∀a ∈ {a : set β | ∃i, s i = a}, x ∈ a) a, h (s a) ⟨a, rfl⟩,
+  assume h t ⟨a, (eq : s a = t)⟩, eq ▸ h a⟩
 
 theorem Union_subset {s : ι → set β} {t : set β} (h : ∀ i, s i ⊆ t) : (⋃ i, s i) ⊆ t :=
 -- TODO: should be simpler when sets' order is based on lattices
@@ -101,7 +101,7 @@ theorem Union_subset_iff {α : Sort u} {s : α → set β} {t : set β} : (⋃ i
 ⟨assume h i, subset.trans (le_supr s _) h, Union_subset⟩
 
 theorem mem_Inter_of_mem {α : Sort u} {x : β} {s : α → set β} : (∀ i, x ∈ s i) → (x ∈ ⋂ i, s i) :=
-assume h t ⟨a, (eq : t = s a)⟩, eq.symm ▸ h a
+assume h t ⟨a, (eq : s a = t)⟩, eq ▸ h a
 
 theorem subset_Inter {t : set β} {s : α → set β} (h : ∀ i, t ⊆ s i) : t ⊆ ⋂ i, s i :=
 -- TODO: should be simpler when sets' order is based on lattices

--- a/linear_algebra/basic.lean
+++ b/linear_algebra/basic.lean
@@ -288,7 +288,7 @@ eq_top_iff.trans ⟨λ h x, @h x trivial, λ h x _, h x⟩
 @[simp] theorem infi_coe {ι} (p : ι → submodule α β) :
   (↑⨅ i, p i : set β) = ⋂ i, ↑(p i) :=
 by rw [infi, Inf_coe]; ext a; simp; exact
-⟨λ h i, h _ i rfl, λ h i x e, e.symm ▸ h _⟩
+⟨λ h i, h _ i rfl, λ h i x e, e ▸ h _⟩
 
 @[simp] theorem mem_infi {ι} (p : ι → submodule α β) :
   x ∈ (⨅ i, p i) ↔ ∀ i, x ∈ p i :=

--- a/order/complete_lattice.lean
+++ b/order/complete_lattice.lean
@@ -482,7 +482,7 @@ le_antisymm
     (supr_le_supr2 $ assume i, ⟨or.inl i, le_refl _⟩)
     (supr_le_supr2 $ assume j, ⟨or.inr j, le_refl _⟩))
 
-theorem Inf_eq_infi {s : set α} : Inf s = (⨅a ∈ s, a) := -- TODO
+theorem Inf_eq_infi {s : set α} : Inf s = (⨅a ∈ s, a) :=
 le_antisymm
   (le_infi $ assume b, le_infi $ assume h, Inf_le h)
   (le_Inf $ assume b h, infi_le_of_le b $ infi_le _ h)

--- a/order/filter.lean
+++ b/order/filter.lean
@@ -1090,7 +1090,7 @@ lemma infi_sets_induct {f : ι → filter α} {s : set α} (hs : s ∈ (infi f).
   (ins : ∀{i s₁ s₂}, s₁ ∈ (f i).sets → p s₂ → p (s₁ ∩ s₂))
   (upw : ∀{s₁ s₂}, s₁ ⊆ s₂ → p s₁ → p s₂) : p s :=
 begin
-  have hs' : s ∈ (Inf {a : filter α | ∃ (i : ι), a = f i}).sets := hs,
+  have hs' : s ∈ (Inf {a : filter α | ∃ (i : ι), f i = a}).sets := hs,
   rw [Inf_sets_eq_finite] at hs',
   simp only [mem_Union] at hs',
   rcases hs' with ⟨is, ⟨fin_is, his⟩, hs⟩, revert his s,
@@ -1098,9 +1098,9 @@ begin
   { rw [Inf_empty, mem_top_sets] at hs, simpa only [hs] },
   { rw [Inf_insert] at hs,
     rcases hs with ⟨s₁, hs₁, s₂, hs₂, hs⟩,
-    rcases (his (mem_insert _ _) : ∃i, fi = f i) with ⟨i, rfl⟩,
+    rcases (his (mem_insert _ _)) with ⟨i, rfl⟩,
     have hs₂ : p s₂, from
-      have his : is ⊆ {x | ∃i, x = f i}, from assume i hi, his $ mem_insert_of_mem _ hi,
+      have his : is ⊆ {x | ∃i, f i = x}, from assume i hi, his $ mem_insert_of_mem _ hi,
       have infi f ≤ Inf is, from Inf_le_Inf his,
       ih his (this hs₂) hs₂,
     exact upw hs (ins hs₁ hs₂) }


### PR DESCRIPTION
Make the orders of variables the same in `supr` and `range`, ensuring that `supr f = Sup (range f)` is `rfl`.

TO CONTRIBUTORS:

Make sure you have:

 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [x] make sure definitions and lemmas are put in the right files
 * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
