### PR TITLE
Remove useless decidability assumption

### DIFF
--- a/analysis/topology/topological_structures.lean
+++ b/analysis/topology/topological_structures.lean
@@ -850,7 +850,7 @@ end topological_add_group
 section order_topology
 
 variables [topological_space α] [topological_space β]
-  [decidable_linear_order α] [decidable_linear_order β] [orderable_topology α] [orderable_topology β]
+  [linear_order α] [linear_order β] [orderable_topology α] [orderable_topology β]
 
 lemma nhds_principal_ne_bot_of_is_lub {a : α} {s : set α} (ha : is_lub s a) (hs : s ≠ ∅) :
   nhds a ⊓ principal s ≠ ⊥ :=


### PR DESCRIPTION
I need this to apply the results to a complete linear order (another solution would be to create a `complete_decidable_linear_order` class, but the patch in this PR seems minimal).

TO CONTRIBUTORS:

Make sure you have:

 * [ ] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
