### PR TITLE
fix(category_theory/yoneda): add componentwise lemma

### DIFF
--- a/category_theory/types.lean
+++ b/category_theory/types.lean
@@ -40,9 +40,26 @@ variables {D : Type u'} [𝒟 : category.{u' v'} D] (I J : D ⥤ C) (ρ : I ⟹ 
 
 end functor_to_types
 
+def ulift_trivial (V : Type u) : ulift.{u} V ≅ V := by tidy
+
 def ulift_functor : (Type u) ⥤ (Type (max u v)) :=
 { obj := λ X, ulift.{v} X,
   map := λ X Y f, λ x : ulift.{v} X, ulift.up (f x.down) }
+
+@[simp] lemma ulift_functor.map {X Y : Type u} (f : X ⟶ Y) (x : ulift.{v} X) :
+  ulift_functor.map f x = ulift.up (f x.down)
+:= rfl
+
+instance ulift_functor_faithful : faithful ulift_functor :=
+begin
+  tidy,
+  funext,
+  have px := congr_fun p {down := x},
+  dsimp at px,
+  exact congr_arg ulift.down px,
+end
+
+instance ulift_functor_full : full ulift_functor := by tidy
 
 section forget
 variables (C : Type u → Type v) {hom : ∀α β, C α → C β → (α → β) → Prop} [i : concrete_category hom]

--- a/category_theory/types.lean
+++ b/category_theory/types.lean
@@ -47,19 +47,12 @@ def ulift_functor : (Type u) ⥤ (Type (max u v)) :=
   map := λ X Y f, λ x : ulift.{v} X, ulift.up (f x.down) }
 
 @[simp] lemma ulift_functor.map {X Y : Type u} (f : X ⟶ Y) (x : ulift.{v} X) :
-  ulift_functor.map f x = ulift.up (f x.down)
-:= rfl
+  ulift_functor.map f x = ulift.up (f x.down) := rfl
 
-instance ulift_functor_faithful : faithful ulift_functor :=
-begin
-  tidy,
-  funext,
-  have px := congr_fun p {down := x},
-  dsimp at px,
-  exact congr_arg ulift.down px,
-end
-
-instance ulift_functor_full : full ulift_functor := by tidy
+instance ulift_functor_faithful : fully_faithful ulift_functor :=
+{ preimage := λ X Y f x, (f (ulift.up x)).down,
+  injectivity' := λ X Y f g p, funext $ λ x,
+    congr_arg ulift.down ((congr_fun p (ulift.up x)) : ((ulift.up (f x)) = (ulift.up (g x)))) }
 
 section forget
 variables (C : Type u → Type v) {hom : ∀α β, C α → C β → (α → β) → Prop} [i : concrete_category hom]

--- a/category_theory/yoneda.lean
+++ b/category_theory/yoneda.lean
@@ -28,7 +28,7 @@ def yoneda : C ⥤ ((Cᵒᵖ) ⥤ (Type v₁)) :=
     map_id' := begin intros X_1, ext1, dsimp at *, erw [category.id_comp] end },
   map := λ X X' f, { app := λ Y g, g ≫ f } }
 
-variables (C)
+variables {C}
 
 namespace yoneda
 @[simp] lemma obj_obj (X Y : C) : (yoneda.obj X).obj Y = (Y ⟶ X) := rfl
@@ -75,6 +75,11 @@ category_theory.prod.{u₁ v₁ (max u₁ (v₁+1)) (max u₁ v₁)} (Cᵒᵖ) (
 
 end yoneda
 
+class representable (F : Cᵒᵖ ⥤ Type v₁) :=
+(X : C)
+(w : yoneda.obj X ≅ F)
+
+variables (C)
 open yoneda
 
 def yoneda_evaluation : (Cᵒᵖ × (Cᵒᵖ ⥤ Type v₁)) ⥤ Type (max u₁ v₁) :=
@@ -139,8 +144,11 @@ def yoneda_lemma : yoneda_pairing C ≅ yoneda_evaluation C :=
 
 variables {C}
 
-class representable (F : Cᵒᵖ ⥤ Type v₁) :=
-(X : C)
-(w : yoneda.obj X ≅ F)
+@[simp] def yoneda_sections (X : C) (F : Cᵒᵖ ⥤ Type v₁) : (yoneda.obj X ⟹ F) ≅ ulift.{u₁} (F.obj X) :=
+nat_iso.app (yoneda_lemma C) (X, F)
+
+omit 𝒞
+@[simp] def yoneda_sections_small {C : Type u₁} [small_category C] (X : C) (F : Cᵒᵖ ⥤ Type u₁) : (yoneda.obj X ⟹ F) ≅ F.obj X :=
+yoneda_sections X F ≪≫ ulift_trivial _
 
 end category_theory


### PR DESCRIPTION
@jcommelin and @rwbarton noticed that `yoneda.lean` is missing a componentwise version of the yoneda lemma, making it a bit hard to use.

This adds
`@[simp] def yoneda_sections (X : C) (F : Cᵒᵖ ⥤ Type v₁) : (yoneda.obj X ⟹ F) ≅ ulift.{u₁} (F.obj X)`

and a corresponding version when `C` is a small category, without the `ulift`.