### PR TITLE
fix(tactic/linarith): nat preprocessing was rejecting negated hypotheses

### DIFF
--- a/tests/linarith.lean
+++ b/tests/linarith.lean
@@ -95,3 +95,6 @@ by linarith
 
 example (x y : ℕ) (h : 6 + ((x + 4) * x + (6 + 3 * y) * y) = 3) : false :=
 by linarith
+
+example (a b i : ℕ) (h1 :  ¬ a < i) (h2 : b < i) (h3 : a ≤ b) : false :=
+by linarith


### PR DESCRIPTION
Fixes a bug in `linarith` reported by @jcommelin on Zulip.

TO CONTRIBUTORS:

Make sure you have:

 * [ ] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
