### PR TITLE
`use` tactic

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -681,3 +681,26 @@ by ac_mono* h₁.
 
 By giving `ac_mono` the assumption `h₁`, we are asking `ac_refl` to
 stop earlier than it would normally would.
+
+### use
+Similar to `existsi`. `use x` will instantiate the first term of an `∃` or `Σ` goal with `x`.
+Unlike `existsi`, `x` is elaborated with respect to the expected type.
+Equivalent to `refine ⟨x, _⟩`.
+
+`use` will alternatively take a list of terms `[x0, ..., xn]`.
+
+Examples:
+
+```lean
+example (α : Type) : ∃ S : set α, S = S :=
+by use ∅
+
+example : ∃ x : ℤ, x = x :=
+by use 42
+
+example : ∃ a b c : ℤ, a + b + c = 6 :=
+by use [1, 2, 3]
+
+example : ∃ p : ℤ × ℤ, p.1 = 1 :=
+by use ⟨1, 42⟩
+```

--- a/tactic/basic.lean
+++ b/tactic/basic.lean
@@ -557,6 +557,7 @@ meta def note_anon (e : expr) : tactic unit :=
 do n ← get_unused_name "lh",
    note n none e, skip
 
+/-- `find_local t` returns a local constant with type t, or fails if none exists. -/
 meta def find_local (t : pexpr) : tactic expr :=
 do t' ← to_expr t,
    prod.snd <$> solve_aux t' assumption

--- a/tactic/interactive.lean
+++ b/tactic/interactive.lean
@@ -632,6 +632,28 @@ We use this tactic for writing tests.
 meta def guard_target' (p : parse texpr) : tactic unit :=
 do t ← target, guard_expr_eq' t p
 
+/--
+Similar to `existsi`. `use x` will instantiate the first term of an `∃` or `Σ` goal with `x`.
+Unlike `existsi`, `x` is elaborated with respect to the expected type.
+Equivalent to `refine ⟨x, _⟩`.
+`use` will alternatively take a list of terms `[x0, ..., xn]`.
+Examples:
+
+example (α : Type) : ∃ S : set α, S = S :=
+by use ∅
+
+example : ∃ x : ℤ, x = x :=
+by use 42
+
+example : ∃ a b c : ℤ, a + b + c = 6 :=
+by use [1, 2, 3]
+
+example : ∃ p : ℤ × ℤ, p.1 = 1 :=
+by use ⟨1, 42⟩
+-/
+meta def use (l : parse pexpr_list_or_texpr) : tactic unit :=
+do refine $ l.foldr (λ t p, ``(⟨%%t, %%p⟩)) pexpr.mk_placeholder,
+   try refl
 
 end interactive
 end tactic


### PR DESCRIPTION
As requested on Zulip, a synonym for `refine ⟨x, _⟩`.

TO CONTRIBUTORS:

Make sure you have:

 * [ ] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
