### PR TITLE
fix(finsupp): remove superfluous typeclass argument

### DIFF
--- a/data/finsupp.lean
+++ b/data/finsupp.lean
@@ -622,8 +622,7 @@ end
 
 end has_zero
 
-lemma filter_pos_add_filter_neg [add_monoid β] (f : α →₀ β) (p : α → Prop)
-  [decidable_pred p] :
+lemma filter_pos_add_filter_neg [add_monoid β] (f : α →₀ β) (p : α → Prop) [decidable_pred p] :
   f.filter p + f.filter (λa, ¬ p a) = f :=
 finsupp.ext $ assume a, if H : p a
 then by simp only [add_apply, filter_apply_pos, filter_apply_neg, H, not_not, add_zero]

--- a/data/finsupp.lean
+++ b/data/finsupp.lean
@@ -623,7 +623,7 @@ end
 end has_zero
 
 lemma filter_pos_add_filter_neg [add_monoid β] (f : α →₀ β) (p : α → Prop)
-  [decidable_pred p] [decidable_pred (λa, ¬ p a)] :
+  [decidable_pred p] :
   f.filter p + f.filter (λa, ¬ p a) = f :=
 finsupp.ext $ assume a, if H : p a
 then by simp only [add_apply, filter_apply_pos, filter_apply_neg, H, not_not, add_zero]


### PR DESCRIPTION
@rwbarton points out that in principle one could call this function, explicitly providing different algorithms for the decidability of `P` and of `not P`.

If preserving this is a concern, obviously drop this PR. I think this is too much of a corner case to worry about.