### PR TITLE
(co)limits, and (co)limits in Type

### DIFF
--- a/category_theory/const.lean
+++ b/category_theory/const.lean
@@ -1,0 +1,50 @@
+-- Copyright (c) 2018 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Scott Morrison
+
+import category_theory.functor_category
+import category_theory.isomorphism
+
+universes u₁ v₁ u₂ v₂ u₃ v₃
+
+open category_theory
+
+namespace category_theory.functor
+
+variables (J : Type u₁) [𝒥 : category.{u₁ v₁} J]
+variables {C : Type u₂} [𝒞 : category.{u₂ v₂} C]
+include 𝒥 𝒞
+
+def const : C ⥤ (J ⥤ C) :=
+{ obj := λ X,
+  { obj := λ j, X,
+    map := λ j j' f, 𝟙 X },
+  map := λ X Y f, { app := λ j, f } }
+
+namespace const
+@[simp] lemma obj_obj (X : C) (j : J) : ((const J).obj X).obj j = X := rfl
+@[simp] lemma obj_map (X : C) {j j' : J} (f : j ⟶ j') : ((const J).obj X).map f = 𝟙 X := rfl
+@[simp] lemma map_app {X Y : C} (f : X ⟶ Y) (j : J) : ((const J).map f).app j = f := rfl
+end const
+
+section
+variables {D : Type u₃} [𝒟 : category.{u₃ v₃} D]
+include 𝒟
+
+/-- These are actually equal, of course, but not definitionally equal
+  (the equality requires F.map (𝟙 _) = 𝟙 _). A natural isomorphism is
+  more convenient than an equality between functors (compare id_to_iso). -/
+@[simp] def const_comp (X : C) (F : C ⥤ D) :
+  (const J).obj X ⋙ F ≅ (const J).obj (F.obj X) :=
+{ hom := { app := λ _, 𝟙 _ },
+  inv := { app := λ _, 𝟙 _ } }
+
+@[simp] lemma const_comp_hom_app (X : C) (F : C ⥤ D) (j : J) :
+  (const_comp J X F).hom.app j = 𝟙 _ := rfl
+
+@[simp] lemma const_comp_inv_app (X : C) (F : C ⥤ D) (j : J) :
+  (const_comp J X F).inv.app j = 𝟙 _ := rfl
+
+end
+
+end category_theory.functor

--- a/category_theory/equivalence.lean
+++ b/category_theory/equivalence.lean
@@ -239,14 +239,7 @@ section
 { obj  := λ X, F.obj_preimage X,
   map := λ X Y f, F.preimage ((F.fun_obj_preimage_iso X).hom ≫ f ≫ (F.fun_obj_preimage_iso Y).inv),
   map_id' := λ X, begin apply F.injectivity, tidy, end,
-  map_comp' := λ X Y Z f g,
-  begin
-    apply F.injectivity,
-    /- obviously can finish from here... -/
-    simp,
-    slice_rhs 2 3 { erw [is_iso.hom_inv_id] },
-    simp,
-  end }.
+  map_comp' := λ X Y Z f g, by apply F.injectivity; simp }.
 
 def equivalence_of_fully_faithfully_ess_surj
   (F : C ⥤ D) [full F] [faithful : faithful F] [ess_surj F] : is_equivalence F :=

--- a/category_theory/isomorphism.lean
+++ b/category_theory/isomorphism.lean
@@ -26,6 +26,12 @@ variables {X Y Z : C}
 
 namespace iso
 
+@[simp] lemma hom_inv_id_assoc (α : X ≅ Y) (f : X ⟶ Z) : α.hom ≫ α.inv ≫ f = f :=
+by rw [←category.assoc, α.hom_inv_id, category.id_comp]
+
+@[simp] lemma inv_hom_id_assoc (α : X ≅ Y) (f : Y ⟶ Z) : α.inv ≫ α.hom ≫ f = f :=
+by rw [←category.assoc, α.inv_hom_id, category.id_comp]
+
 @[extensionality] lemma ext
   (α β : X ≅ Y)
   (w : α.hom = β.hom) : α = β :=
@@ -81,6 +87,18 @@ infixr ` ≪≫ `:80 := iso.trans -- type as `\ll \gg`.
 
 @[simp] lemma refl_symm (X : C) : (iso.refl X).hom = 𝟙 X := rfl
 @[simp] lemma trans_symm (α : X ≅ Y) (β : Y ≅ Z) : (α ≪≫ β).inv = β.inv ≫ α.inv := rfl
+
+lemma inv_comp_eq (α : X ≅ Y) {f : X ⟶ Z} {g : Y ⟶ Z} : α.inv ≫ f = g ↔ f = α.hom ≫ g :=
+⟨λ H, by simp [H.symm], λ H, by simp [H]⟩
+
+lemma eq_inv_comp (α : X ≅ Y) {f : X ⟶ Z} {g : Y ⟶ Z} : g = α.inv ≫ f ↔ α.hom ≫ g = f :=
+(inv_comp_eq α.symm).symm
+
+lemma comp_inv_eq (α : X ≅ Y) {f : Z ⟶ Y} {g : Z ⟶ X} : f ≫ α.inv = g ↔ f = g ≫ α.hom :=
+⟨λ H, by simp [H.symm], λ H, by simp [H]⟩
+
+lemma eq_comp_inv (α : X ≅ Y) {f : Z ⟶ Y} {g : Z ⟶ X} : g = f ≫ α.inv ↔ g ≫ α.hom = f :=
+(comp_inv_eq α.symm).symm
 
 end iso
 

--- a/category_theory/limits/cones.lean
+++ b/category_theory/limits/cones.lean
@@ -124,7 +124,6 @@ def whisker (c : cocone F) {K : Type v} [small_category K] (E : K ⥤ J) : cocon
   (c.whisker E).ι.app k = (c.ι).app (E.obj k) := rfl
 end cocone
 
-
 structure cone_morphism (A B : cone F) :=
 (hom : A.X ⟶ B.X)
 (w'  : ∀ j : J, hom ≫ B.π.app j = A.π.app j . obviously)

--- a/category_theory/limits/cones.lean
+++ b/category_theory/limits/cones.lean
@@ -1,0 +1,246 @@
+-- Copyright (c) 2017 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Stephen Morgan, Scott Morrison
+
+import category_theory.natural_isomorphism
+import category_theory.whiskering
+import category_theory.const
+import category_theory.opposites
+import category_theory.yoneda
+
+universes u u' v
+
+open category_theory
+
+variables {J : Type v} [small_category J]
+variables {C : Type u} [𝒞 : category.{u v} C]
+include 𝒞
+
+open category_theory
+open category_theory.category
+open category_theory.functor
+
+namespace category_theory
+
+namespace functor
+variables {J C} (F : J ⥤ C)
+
+/--
+`F.cones` is the functor assigning to an object `X` the type of
+natural transformations from the constant functor with value `X` to `F`.
+An object representing this functor is a limit of `F`.
+-/
+def cones : Cᵒᵖ ⥤ Type _ := (const (Jᵒᵖ)) ⋙ (op_inv J C) ⋙ (yoneda.obj F)
+
+lemma cones_obj (X : C) : F.cones.obj X = ((const J).obj X ⟹ F) := rfl
+
+/--
+`F.cocones` is the functor assigning to an object `X` the type of
+natural transformations from `F` to the constant functor with value `X`.
+An object corepresenting this functor is a colimit of `F`.
+-/
+def cocones : C ⥤ Type _ := (const J) ⋙ (coyoneda.obj F)
+
+lemma cocones_obj (X : C) : F.cocones.obj X = (F ⟹ (const J).obj X) := rfl
+
+end functor
+
+
+namespace limits
+
+/--
+A `c : cone F` is:
+* an object `c.X` and
+* a natural transformation `c.π : c.X ⟹ F` from the constant `c.X` functor to `F`.
+
+`cone F` is equivalent, in the obvious way, to `Σ X, F.cones.obj X`.
+-/
+structure cone (F : J ⥤ C) :=
+(X : C)
+(π : (const J).obj X ⟹ F)
+
+@[simp] lemma cone.w {F : J ⥤ C} (c : cone F) {j j' : J} (f : j ⟶ j') :
+  c.π.app j ≫ F.map f = c.π.app j' :=
+by convert ←(c.π.naturality f).symm; apply id_comp
+
+/--
+A `c : cocone F` is
+* an object `c.X` and
+* a natural transformation `c.ι : F ⟹ c.X` from `F` to the constant `c.X` functor.
+
+`cocone F` is equivalent, in the obvious way, to `Σ X, F.cocones.obj X`.
+-/
+structure cocone (F : J ⥤ C) :=
+(X : C)
+(ι : F ⟹ (const J).obj X)
+
+@[simp] lemma cocone.w {F : J ⥤ C} (c : cocone F) {j j' : J} (f : j ⟶ j') :
+  F.map f ≫ c.ι.app j' = c.ι.app j :=
+by convert ←(c.ι.naturality f); apply comp_id
+
+
+variables {F : J ⥤ C}
+
+namespace cone
+@[simp] def extensions (c : cone F) : yoneda.obj c.X ⟶ F.cones :=
+{ app := λ X f, ((const J).map f) ≫ c.π }
+
+/-- A map to the vertex of a cone induces a cone by composition. -/
+@[simp] def extend (c : cone F) {X : C} (f : X ⟶ c.X) : cone F :=
+{ X := X,
+  π := c.extensions.app X f }
+
+def postcompose {G : J ⥤ C} (c : cone F) (α : F ⟹ G) : cone G :=
+{ X := c.X,
+  π := c.π ⊟ α }
+
+def whisker (c : cone F) {K : Type v} [small_category K] (E : K ⥤ J) : cone (E ⋙ F) :=
+{ X := c.X,
+  π := whisker_left E c.π }
+
+@[simp] lemma whisker_π_app (c : cone F) {K : Type v} [small_category K] (E : K ⥤ J) (k : K) :
+  (c.whisker E).π.app k = (c.π).app (E.obj k) := rfl
+end cone
+
+namespace cocone
+@[simp] def extensions (c : cocone F) : coyoneda.obj c.X ⟶ F.cocones :=
+{ app := λ X f, c.ι ≫ ((const J).map f),
+  naturality' := by intros X Y f; ext g j; dsimp; rw ←assoc; refl }
+
+/-- A map from the vertex of a cocone induces a cocone by composition. -/
+@[simp] def extend (c : cocone F) {X : C} (f : c.X ⟶ X) : cocone F :=
+{ X := X,
+  ι := c.extensions.app X f }
+
+def precompose {G : J ⥤ C} (c : cocone F) (α : G ⟹ F) : cocone G :=
+{ X := c.X,
+  ι := α ⊟ c.ι }
+
+def whisker (c : cocone F) {K : Type v} [small_category K] (E : K ⥤ J) : cocone (E ⋙ F) :=
+{ X := c.X,
+  ι := whisker_left E c.ι }
+
+@[simp] lemma whisker_ι_app (c : cocone F) {K : Type v} [small_category K] (E : K ⥤ J) (k : K) :
+  (c.whisker E).ι.app k = (c.ι).app (E.obj k) := rfl
+end cocone
+
+
+structure cone_morphism (A B : cone F) :=
+(hom : A.X ⟶ B.X)
+(w'  : ∀ j : J, hom ≫ B.π.app j = A.π.app j . obviously)
+
+restate_axiom cone_morphism.w'
+attribute [simp] cone_morphism.w
+
+@[extensionality] lemma cone_morphism.ext {A B : cone F} {f g : cone_morphism A B}
+  (w : f.hom = g.hom) : f = g :=
+by cases f; cases g; simpa using w
+
+instance cone.category : category.{(max u v) v} (cone F) :=
+{ hom  := λ A B, cone_morphism A B,
+  comp := λ X Y Z f g,
+  { hom := f.hom ≫ g.hom,
+    w' := by intro j; rw [assoc, g.w, f.w] },
+  id   := λ B, { hom := 𝟙 B.X } }
+
+namespace cones
+@[simp] lemma id.hom   (c : cone F) : (𝟙 c : cone_morphism c c).hom = 𝟙 (c.X) := rfl
+@[simp] lemma comp.hom {c d e : cone F} (f : c ⟶ d) (g : d ⟶ e) :
+  (f ≫ g).hom = f.hom ≫ g.hom := rfl
+
+/-- To give an isomorphism between cones, it suffices to give an
+  isomorphism between their vertices which commutes with the cone
+  maps. -/
+@[extensionality] def ext {c c' : cone F}
+  (φ : c.X ≅ c'.X) (w : ∀ j, c.π.app j = φ.hom ≫ c'.π.app j) : c ≅ c' :=
+{ hom := { hom := φ.hom },
+  inv := { hom := φ.inv, w' := λ j, φ.inv_comp_eq.mpr (w j) } }
+
+section
+variables {D : Type u'} [𝒟 : category.{u' v} D]
+include 𝒟
+
+@[simp] def functoriality (G : C ⥤ D) : cone F ⥤ cone (F ⋙ G) :=
+{ obj := λ A,
+  { X := G.obj A.X,
+    π := { app := λ j, G.map (A.π.app j), naturality' := by intros; erw ←G.map_comp; tidy } },
+  map := λ X Y f,
+  { hom := G.map f.hom,
+    w'  := by intros; rw [←functor.map_comp, f.w] } }
+end
+end cones
+
+
+structure cocone_morphism (A B : cocone F) :=
+(hom : A.X ⟶ B.X)
+(w'  : ∀ j : J, A.ι.app j ≫ hom = B.ι.app j . obviously)
+
+restate_axiom cocone_morphism.w'
+attribute [simp] cocone_morphism.w
+
+@[extensionality] lemma cocone_morphism.ext
+  {A B : cocone F} {f g : cocone_morphism A B} (w : f.hom = g.hom) : f = g :=
+by cases f; cases g; simpa using w
+
+instance cocone.category : category.{(max u v) v} (cocone F) :=
+{ hom  := λ A B, cocone_morphism A B,
+  comp := λ _ _ _ f g,
+  { hom := f.hom ≫ g.hom,
+    w' := by intro j; rw [←assoc, f.w, g.w] },
+  id   := λ B, { hom := 𝟙 B.X } }
+
+namespace cocones
+@[simp] lemma id.hom   (c : cocone F) : (𝟙 c : cocone_morphism c c).hom = 𝟙 (c.X) := rfl
+@[simp] lemma comp.hom {c d e : cocone F} (f : c ⟶ d) (g : d ⟶ e) :
+  (f ≫ g).hom = f.hom ≫ g.hom := rfl
+
+/-- To give an isomorphism between cocones, it suffices to give an
+  isomorphism between their vertices which commutes with the cocone
+  maps. -/
+@[extensionality] def ext {c c' : cocone F}
+  (φ : c.X ≅ c'.X) (w : ∀ j, c.ι.app j ≫ φ.hom = c'.ι.app j) : c ≅ c' :=
+{ hom := { hom := φ.hom },
+  inv := { hom := φ.inv, w' := λ j, φ.comp_inv_eq.mpr (w j).symm } }
+
+section
+variables {D : Type u'} [𝒟 : category.{u' v} D]
+include 𝒟
+
+@[simp] def functoriality (G : C ⥤ D) : cocone F ⥤ cocone (F ⋙ G) :=
+{ obj := λ A,
+  { X := G.obj A.X,
+    ι := { app := λ j, G.map (A.ι.app j), naturality' := by intros; erw ←G.map_comp; tidy } },
+  map := λ _ _ f,
+  { hom := G.map f.hom,
+    w'  := by intros; rw [←functor.map_comp, cocone_morphism.w] } }
+end
+end cocones
+
+end limits
+
+
+namespace functor
+
+variables {D : Type u'} [category.{u' v} D]
+variables {F : J ⥤ C} {G : J ⥤ C} (H : C ⥤ D)
+
+open category_theory.limits
+
+/-- The image of a cone in C under a functor G : C ⥤ D is a cone in D. -/
+def map_cone   (c : cone F)   : cone (F ⋙ H)   := (cones.functoriality H).obj c
+/-- The image of a cocone in C under a functor G : C ⥤ D is a cocone in D. -/
+def map_cocone (c : cocone F) : cocone (F ⋙ H) := (cocones.functoriality H).obj c
+
+def map_cone_morphism   {c c' : cone F}   (f : cone_morphism c c')   :
+  cone_morphism   (H.map_cone c)   (H.map_cone c')   := (cones.functoriality H).map f
+def map_cocone_morphism {c c' : cocone F} (f : cocone_morphism c c') :
+  cocone_morphism (H.map_cocone c) (H.map_cocone c') := (cocones.functoriality H).map f
+
+@[simp] lemma map_cone_π (c : cone F) (j : J) :
+  (map_cone H c).π.app j = H.map (c.π.app j) := rfl
+@[simp] lemma map_cocone_ι (c : cocone F) (j : J) :
+  (map_cocone H c).ι.app j = H.map (c.ι.app j) := rfl
+
+end functor
+
+end category_theory

--- a/category_theory/limits/cones.lean
+++ b/category_theory/limits/cones.lean
@@ -90,11 +90,11 @@ namespace cone
 { X := X,
   π := c.extensions.app X f }
 
-def postcompose {G : J ⥤ C} (c : cone F) (α : F ⟹ G) : cone G :=
+def postcompose {G : J ⥤ C} (α : F ⟹ G) (c : cone F) : cone G :=
 { X := c.X,
   π := c.π ⊟ α }
 
-def whisker (c : cone F) {K : Type v} [small_category K] (E : K ⥤ J) : cone (E ⋙ F) :=
+def whisker {K : Type v} [small_category K] (E : K ⥤ J) (c : cone F) : cone (E ⋙ F) :=
 { X := c.X,
   π := whisker_left E c.π }
 
@@ -112,11 +112,11 @@ namespace cocone
 { X := X,
   ι := c.extensions.app X f }
 
-def precompose {G : J ⥤ C} (c : cocone F) (α : G ⟹ F) : cocone G :=
+def precompose {G : J ⥤ C} (α : G ⟹ F) (c : cocone F) : cocone G :=
 { X := c.X,
   ι := α ⊟ c.ι }
 
-def whisker (c : cocone F) {K : Type v} [small_category K] (E : K ⥤ J) : cocone (E ⋙ F) :=
+def whisker {K : Type v} [small_category K] (E : K ⥤ J) (c : cocone F) : cocone (E ⋙ F) :=
 { X := c.X,
   ι := whisker_left E c.ι }
 

--- a/category_theory/limits/functor_category.lean
+++ b/category_theory/limits/functor_category.lean
@@ -1,0 +1,126 @@
+-- Copyright (c) 2018 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Scott Morrison
+
+import category_theory.products
+import category_theory.limits.preserves
+
+open category_theory category_theory.category
+
+namespace category_theory.limits
+
+universes u v
+
+variables {C : Type u} [𝒞 : category.{u v} C]
+include 𝒞
+
+variables {J K : Type v} [small_category J] [small_category K]
+
+@[simp] lemma cone.functor_w {F : J ⥤ (K ⥤ C)} (c : cone F) {j j' : J} (f : j ⟶ j') (k : K) :
+  (c.π.app j).app k ≫ (F.map f).app k = (c.π.app j').app k :=
+by convert ←nat_trans.congr_app (c.π.naturality f).symm k; apply id_comp
+
+@[simp] lemma cocone.functor_w {F : J ⥤ (K ⥤ C)} (c : cocone F) {j j' : J} (f : j ⟶ j') (k : K) :
+  (F.map f).app k ≫ (c.ι.app j').app k = (c.ι.app j).app k :=
+by convert ←nat_trans.congr_app (c.ι.naturality f) k; apply comp_id
+
+@[simp] def functor_category_limit_cone [has_limits_of_shape J C] (F : J ⥤ K ⥤ C) :
+  cone F :=
+{ X := F.flip ⋙ lim,
+  π :=
+  { app := λ j,
+    { app := λ k, limit.π (F.flip.obj k) j },
+      naturality' := λ j j' f,
+        by ext k; convert (limit.w (F.flip.obj k) _).symm using 1; apply id_comp } }
+
+@[simp] def functor_category_colimit_cocone [has_colimits_of_shape J C] (F : J ⥤ K ⥤ C) :
+  cocone F :=
+{ X := F.flip ⋙ colim,
+  ι :=
+  { app := λ j,
+    { app := λ k, colimit.ι (F.flip.obj k) j },
+      naturality' := λ j j' f,
+        by ext k; convert (colimit.w (F.flip.obj k) _) using 1; apply comp_id } }
+
+@[simp] def evaluate_functor_category_limit_cone
+  [has_limits_of_shape J C] (F : J ⥤ K ⥤ C) (k : K) :
+  ((evaluation K C).obj k).map_cone (functor_category_limit_cone F) ≅
+    limit.cone (F.flip.obj k) :=
+cones.ext (iso.refl _) (by tidy)
+
+@[simp] def evaluate_functor_category_colimit_cocone
+  [has_colimits_of_shape J C] (F : J ⥤ K ⥤ C) (k : K) :
+  ((evaluation K C).obj k).map_cocone (functor_category_colimit_cocone F) ≅
+    colimit.cocone (F.flip.obj k) :=
+cocones.ext (iso.refl _) (by tidy)
+
+def functor_category_is_limit_cone [has_limits_of_shape J C] (F : J ⥤ K ⥤ C) :
+  is_limit (functor_category_limit_cone F) :=
+{ lift := λ s,
+  { app := λ k, limit.lift (F.flip.obj k) (((evaluation K C).obj k).map_cone s),
+    naturality' := λ k k' f,
+      by ext; dsimp; simpa using (s.π.app j).naturality f },
+  uniq' := λ s m w,
+  begin
+    ext1 k,
+    exact is_limit.uniq _
+      (((evaluation K C).obj k).map_cone s) (m.app k) (λ j, nat_trans.congr_app (w j) k)
+  end }
+
+def functor_category_is_colimit_cocone [has_colimits_of_shape.{u v} J C] (F : J ⥤ K ⥤ C) :
+  is_colimit (functor_category_colimit_cocone F) :=
+{ desc := λ s,
+  { app := λ k, colimit.desc (F.flip.obj k) (((evaluation K C).obj k).map_cocone s),
+    naturality' := λ k k' f,
+    begin
+      ext,
+      rw [←assoc, ←assoc],
+      dsimp [functor.flip],
+      simpa using (s.ι.app j).naturality f
+    end },
+  uniq' := λ s m w,
+  begin
+    ext1 k,
+    exact is_colimit.uniq _
+      (((evaluation K C).obj k).map_cocone s) (m.app k) (λ j, nat_trans.congr_app (w j) k)
+  end }
+
+instance functor_category_has_limits_of_shape
+  [has_limits_of_shape J C] : has_limits_of_shape J (K ⥤ C) :=
+λ F,
+{ cone := functor_category_limit_cone F,
+  is_limit := functor_category_is_limit_cone F }
+
+instance functor_category_has_colimits_of_shape
+  [has_colimits_of_shape J C] : has_colimits_of_shape J (K ⥤ C) :=
+λ F,
+{ cocone := functor_category_colimit_cocone F,
+  is_colimit := functor_category_is_colimit_cocone F }
+
+instance functor_category_has_limits [has_limits C] : has_limits (K ⥤ C) :=
+λ J 𝒥, by resetI; apply_instance
+
+instance functor_category_has_colimits [has_colimits C] : has_colimits (K ⥤ C) :=
+λ J 𝒥, by resetI; apply_instance
+
+instance evaluation_preserves_limits_of_shape [has_limits_of_shape J C] (k : K) :
+  preserves_limits_of_shape J ((evaluation K C).obj k) :=
+λ F, preserves_limit_of_preserves_limit_cone (limit.is_limit _) $
+  is_limit.of_iso_limit (limit.is_limit _)
+    (evaluate_functor_category_limit_cone F k).symm
+
+instance evaluation_preserves_colimits_of_shape [has_colimits_of_shape J C] (k : K) :
+  preserves_colimits_of_shape J ((evaluation K C).obj k) :=
+λ F, preserves_colimit_of_preserves_colimit_cocone (colimit.is_colimit _) $
+  is_colimit.of_iso_colimit (colimit.is_colimit _)
+    (evaluate_functor_category_colimit_cocone F k).symm
+
+instance evaluation_preserves_limits [has_limits C] (k : K) :
+  preserves_limits ((evaluation K C).obj k) :=
+λ J 𝒥, by resetI; apply_instance
+
+instance evaluation_preserves_colimits [has_colimits C] (k : K) :
+  preserves_colimits ((evaluation K C).obj k) :=
+λ J 𝒥, by resetI; apply_instance
+
+end category_theory.limits

--- a/category_theory/limits/limits.lean
+++ b/category_theory/limits/limits.lean
@@ -1,0 +1,584 @@
+-- Copyright (c) 2018 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Scott Morrison, Reid Barton, Mario Carneiro
+
+import category_theory.whiskering
+import category_theory.yoneda
+import category_theory.limits.cones
+
+open category_theory category_theory.category category_theory.functor
+
+namespace category_theory.limits
+
+universes u u' u'' v w
+
+variables {J : Type v} [small_category J]
+variables {C : Type u} [𝒞 : category.{u v} C]
+include 𝒞
+
+section is_limit
+variables {F : J ⥤ C}
+
+/-- A cone `t` on `F` is a limit cone if each cone on `F` admits a unique
+  cone morphism to `t`. -/
+structure is_limit (t : cone F) :=
+(lift  : Π (s : cone F), s.X ⟶ t.X)
+(fac'  : ∀ (s : cone F) (j : J), lift s ≫ t.π.app j = s.π.app j . obviously)
+(uniq' : ∀ (s : cone F) (m : s.X ⟶ t.X) (w : ∀ j : J, m ≫ t.π.app j = s.π.app j),
+  m = lift s . obviously)
+
+restate_axiom is_limit.fac'
+attribute [simp] is_limit.fac
+restate_axiom is_limit.uniq'
+
+instance is_limit_subsingleton {t : cone F} : subsingleton (is_limit t) :=
+⟨by intros P Q; cases P; cases Q; congr; ext; solve_by_elim⟩
+
+/- Repackaging the definition in terms of cone morphisms. -/
+
+def is_limit.lift_cone_morphism {t : cone F} (h : is_limit t) (s : cone F) : s ⟶ t :=
+{ hom := h.lift s }
+
+lemma is_limit.uniq_cone_morphism {s t : cone F} (h : is_limit t) {f f' : s ⟶ t} :
+  f = f' :=
+have ∀ {g : s ⟶ t}, g = h.lift_cone_morphism s, by intro g; ext; exact h.uniq _ _ g.w,
+this.trans this.symm
+
+def is_limit.mk_cone_morphism {t : cone F}
+  (lift : Π (s : cone F), s ⟶ t)
+  (uniq' : ∀ (s : cone F) (m : s ⟶ t), m = lift s) : is_limit t :=
+{ lift := λ s, (lift s).hom,
+  uniq' := λ s m w,
+    have cone_morphism.mk m w = lift s, by apply uniq',
+    congr_arg cone_morphism.hom this }
+
+/-- Limit cones on `F` are unique up to isomorphism. -/
+def is_limit.unique {s t : cone F} (P : is_limit s) (Q : is_limit t) : s ≅ t :=
+{ hom := Q.lift_cone_morphism s,
+  inv := P.lift_cone_morphism t,
+  hom_inv_id' := P.uniq_cone_morphism,
+  inv_hom_id' := Q.uniq_cone_morphism }
+
+def is_limit.of_iso_limit {r t : cone F} (P : is_limit r) (i : r ≅ t) : is_limit t :=
+is_limit.mk_cone_morphism
+  (λ s, P.lift_cone_morphism s ≫ i.hom)
+  (λ s m, by rw ←i.comp_inv_eq; apply P.uniq_cone_morphism)
+
+variables {t : cone F}
+
+lemma is_limit.hom_lift (h : is_limit t) {W : C} (m : W ⟶ t.X) :
+  m = h.lift { X := W, π := { app := λ b, m ≫ t.π.app b } } :=
+h.uniq { X := W, π := { app := λ b, m ≫ t.π.app b } } m (λ b, rfl)
+
+/-- Two morphisms into a limit are equal if their compositions with
+  each cone morphism are equal. -/
+lemma is_limit.hom_ext (h : is_limit t) {W : C} {f f' : W ⟶ t.X}
+  (w : ∀ j, f ≫ t.π.app j = f' ≫ t.π.app j) : f = f' :=
+by rw [h.hom_lift f, h.hom_lift f']; congr; exact funext w
+
+/-- The universal property of a limit cone: a map `W ⟶ X` is the same as
+  a cone on `F` with vertex `W`. -/
+def is_limit.hom_iso (h : is_limit t) (W : C) : (W ⟶ t.X) ≅ ((const J).obj W ⟹ F) :=
+{ hom := λ f, (t.extend f).π,
+  inv := λ π, h.lift { X := W, π := π },
+  hom_inv_id' := by ext f; apply h.hom_ext; intro j; simp; dsimp; refl }
+
+@[simp] lemma is_limit.hom_iso_hom (h : is_limit t) {W : C} (f : W ⟶ t.X) :
+  (is_limit.hom_iso h W).hom f = (t.extend f).π := rfl
+
+/-- The limit of `F` represents the functor taking `W` to
+  the set of cones on `F` with vertex `W`. -/
+def is_limit.nat_iso (h : is_limit t) : yoneda.obj t.X ≅ F.cones :=
+nat_iso.of_components (is_limit.hom_iso h) (by tidy)
+
+def is_limit.hom_iso' (h : is_limit t) (W : C) :
+  (W ⟶ t.X) ≅ { p : Π j, W ⟶ F.obj j // ∀ {j j'} (f : j ⟶ j'), p j ≫ F.map f = p j' } :=
+h.hom_iso W ≪≫
+{ hom := λ π,
+  ⟨λ j, π.app j, λ j j' f,
+   by convert ←(π.naturality f).symm; apply id_comp⟩,
+  inv := λ p,
+  { app := λ j, p.1 j,
+    naturality' := λ j j' f, begin dsimp, erw [id_comp], exact (p.2 f).symm end } }
+
+end is_limit
+
+
+section is_colimit
+variables {F : J ⥤ C}
+
+/-- A cocone `t` on `F` is a colimit cocone if each cocone on `F` admits a unique
+  cocone morphism from `t`. -/
+structure is_colimit (t : cocone F) :=
+(desc  : Π (s : cocone F), t.X ⟶ s.X)
+(fac'  : ∀ (s : cocone F) (j : J), t.ι.app j ≫ desc s = s.ι.app j . obviously)
+(uniq' : ∀ (s : cocone F) (m : t.X ⟶ s.X) (w : ∀ j : J, t.ι.app j ≫ m = s.ι.app j),
+  m = desc s . obviously)
+
+restate_axiom is_colimit.fac'
+attribute [simp] is_colimit.fac
+restate_axiom is_colimit.uniq'
+
+instance is_colimit_subsingleton {t : cocone F} : subsingleton (is_colimit t) :=
+⟨by intros P Q; cases P; cases Q; congr; ext; solve_by_elim⟩
+
+/- Repackaging the definition in terms of cone morphisms. -/
+
+def is_colimit.desc_cocone_morphism {t : cocone F} (h : is_colimit t) (s : cocone F) : t ⟶ s :=
+{ hom := h.desc s }
+
+lemma is_colimit.uniq_cocone_morphism {s t : cocone F} (h : is_colimit t) {f f' : t ⟶ s} :
+  f = f' :=
+have ∀ {g : t ⟶ s}, g = h.desc_cocone_morphism s, by intro g; ext; exact h.uniq _ _ g.w,
+this.trans this.symm
+
+def is_colimit.mk_cocone_morphism {t : cocone F}
+  (desc : Π (s : cocone F), t ⟶ s)
+  (uniq' : ∀ (s : cocone F) (m : t ⟶ s), m = desc s) : is_colimit t :=
+{ desc := λ s, (desc s).hom,
+  uniq' := λ s m w,
+    have cocone_morphism.mk m w = desc s, by apply uniq',
+    congr_arg cocone_morphism.hom this }
+
+/-- Limit cones on `F` are unique up to isomorphism. -/
+def is_colimit.unique {s t : cocone F} (P : is_colimit s) (Q : is_colimit t) : s ≅ t :=
+{ hom := P.desc_cocone_morphism t,
+  inv := Q.desc_cocone_morphism s,
+  hom_inv_id' := P.uniq_cocone_morphism,
+  inv_hom_id' := Q.uniq_cocone_morphism }
+
+def is_colimit.of_iso_colimit {r t : cocone F} (P : is_colimit r) (i : r ≅ t) : is_colimit t :=
+is_colimit.mk_cocone_morphism
+  (λ s, i.inv ≫ P.desc_cocone_morphism s)
+  (λ s m, by rw i.eq_inv_comp; apply P.uniq_cocone_morphism)
+
+variables {t : cocone F}
+
+lemma is_colimit.hom_desc (h : is_colimit t) {W : C} (m : t.X ⟶ W) :
+  m = h.desc { X := W, ι := { app := λ b, t.ι.app b ≫ m,
+    naturality' := by intros; erw [←assoc, t.ι.naturality, comp_id, comp_id] } } :=
+h.uniq { X := W, ι := { app := λ b, t.ι.app b ≫ m, naturality' := _ } } m (λ b, rfl)
+
+/-- Two morphisms out of a colimit are equal if their compositions with
+  each cocone morphism are equal. -/
+lemma is_colimit.hom_ext (h : is_colimit t) {W : C} {f f' : t.X ⟶ W}
+  (w : ∀ j, t.ι.app j ≫ f = t.ι.app j ≫ f') : f = f' :=
+by rw [h.hom_desc f, h.hom_desc f']; congr; exact funext w
+
+/-- The universal property of a colimit cocone: a map `X ⟶ W` is the same as
+  a cocone on `F` with vertex `W`. -/
+def is_colimit.hom_iso (h : is_colimit t) (W : C) : (t.X ⟶ W) ≅ (F ⟹ (const J).obj W) :=
+{ hom := λ f, (t.extend f).ι,
+  inv := λ ι, h.desc { X := W, ι := ι },
+  hom_inv_id' := by ext f; apply h.hom_ext; intro j; simp; dsimp; refl }
+
+@[simp] lemma is_colimit.hom_iso_hom (h : is_colimit t) {W : C} (f : t.X ⟶ W) :
+  (is_colimit.hom_iso h W).hom f = (t.extend f).ι := rfl
+
+/-- The colimit of `F` represents the functor taking `W` to
+  the set of cocones on `F` with vertex `W`. -/
+def is_colimit.nat_iso (h : is_colimit t) : coyoneda.obj t.X ≅ F.cocones :=
+nat_iso.of_components (is_colimit.hom_iso h) (by intros; ext; dsimp; rw ←assoc; refl)
+
+def is_colimit.hom_iso' (h : is_colimit t) (W : C) :
+  (t.X ⟶ W) ≅ { p : Π j, F.obj j ⟶ W // ∀ {j j' : J} (f : j ⟶ j'), F.map f ≫ p j' = p j } :=
+h.hom_iso W ≪≫
+{ hom := λ ι,
+  ⟨λ j, ι.app j, λ j j' f,
+   by convert ←(ι.naturality f); apply comp_id⟩,
+  inv := λ p,
+  { app := λ j, p.1 j,
+    naturality' := λ j j' f, begin dsimp, erw [comp_id], exact (p.2 f) end } }
+
+end is_colimit
+
+
+section limit
+
+/-- `has_limit F` represents a particular chosen limit of the diagram `F`. -/
+class has_limit (F : J ⥤ C) :=
+(cone : cone F)
+(is_limit : is_limit cone)
+
+variables (J C)
+
+/-- `C` has limits of shape `J` if we have chosen a particular limit of
+  every functor `F : J ⥤ C`. -/
+@[class] def has_limits_of_shape := Π F : J ⥤ C, has_limit F
+
+/-- `C` has all (small) limits if it has limits of every shape. -/
+@[class] def has_limits :=
+Π {J : Type v} {𝒥 : small_category J}, by exactI has_limits_of_shape J C
+
+variables {J C}
+
+instance has_limit_of_has_limits_of_shape
+  {J : Type v} [small_category J] [H : has_limits_of_shape J C] (F : J ⥤ C) : has_limit F :=
+H F
+
+instance has_limits_of_shape_of_has_limits
+  {J : Type v} [small_category J] [H : has_limits.{u v} C] : has_limits_of_shape J C :=
+H
+
+/- Interface to the `has_limit` class. -/
+
+def limit.cone (F : J ⥤ C) [has_limit F] : cone F := has_limit.cone F
+
+def limit (F : J ⥤ C) [has_limit F] := (limit.cone F).X
+
+def limit.π (F : J ⥤ C) [has_limit F] (j : J) : limit F ⟶ F.obj j :=
+(limit.cone F).π.app j
+
+@[simp] lemma limit.cone_π {F : J ⥤ C} [has_limit F] (j : J) :
+  (limit.cone F).π.app j = limit.π _ j := rfl
+
+@[simp] lemma limit.w (F : J ⥤ C) [has_limit F] {j j' : J} (f : j ⟶ j') :
+  limit.π F j ≫ F.map f = limit.π F j' := (limit.cone F).w f
+
+def limit.is_limit (F : J ⥤ C) [has_limit F] : is_limit (limit.cone F) :=
+has_limit.is_limit.{u v} F
+
+def limit.lift (F : J ⥤ C) [has_limit F] (c : cone F) : c.X ⟶ limit F :=
+(limit.is_limit F).lift c
+
+@[simp] lemma limit.is_limit_lift {F : J ⥤ C} [has_limit F] (c : cone F) :
+  (limit.is_limit F).lift c = limit.lift F c := rfl
+
+@[simp] lemma limit.lift_π {F : J ⥤ C} [has_limit F] (c : cone F) (j : J) :
+  limit.lift F c ≫ limit.π F j = c.π.app j :=
+is_limit.fac _ c j
+
+def limit.cone_morphism {F : J ⥤ C} [has_limit F] (c : cone F) :
+  cone_morphism c (limit.cone F) :=
+(limit.is_limit F).lift_cone_morphism c
+
+@[simp] lemma limit.cone_morphism_hom {F : J ⥤ C} [has_limit F] (c : cone F) :
+  (limit.cone_morphism c).hom = limit.lift F c := rfl
+@[simp] lemma limit.cone_morphism_π {F : J ⥤ C} [has_limit F] (c : cone F) (j : J) :
+  (limit.cone_morphism c).hom ≫ limit.π F j = c.π.app j :=
+by erw is_limit.fac
+
+@[extensionality] lemma limit.hom_ext {F : J ⥤ C} [has_limit F] {X : C} {f f' : X ⟶ limit F}
+  (w : ∀ j, f ≫ limit.π F j = f' ≫ limit.π F j) : f = f' :=
+(limit.is_limit F).hom_ext w
+
+def limit.hom_iso (F : J ⥤ C) [has_limit F] (W : C) : (W ⟶ limit F) ≅ (F.cones.obj W) :=
+(limit.is_limit F).hom_iso W
+
+@[simp] lemma limit.hom_iso_hom (F : J ⥤ C) [has_limit F] {W : C} (f : W ⟶ limit F):
+  (limit.hom_iso F W).hom f = (const J).map f ≫ (limit.cone F).π :=
+(limit.is_limit F).hom_iso_hom f
+
+def limit.hom_iso' (F : J ⥤ C) [has_limit F] (W : C) :
+  (W ⟶ limit F) ≅ { p : Π j, W ⟶ F.obj j // ∀ {j j' : J} (f : j ⟶ j'), p j ≫ F.map f = p j' } :=
+(limit.is_limit F).hom_iso' W
+
+section pre
+variables {K : Type v} [small_category K]
+variables (F : J ⥤ C) [has_limit F] (E : K ⥤ J) [has_limit (E ⋙ F)]
+
+def limit.pre : limit F ⟶ limit (E ⋙ F) :=
+limit.lift (E ⋙ F)
+  { X := limit F,
+    π := { app := λ k, limit.π F (E.obj k) } }
+
+@[simp] lemma limit.pre_π (k : K) : limit.pre F E ≫ limit.π (E ⋙ F) k = limit.π F (E.obj k) :=
+by erw is_limit.fac
+
+@[simp] lemma limit.lift_pre (c : cone F) :
+  limit.lift F c ≫ limit.pre F E = limit.lift (E ⋙ F) (c.whisker E) :=
+by ext; simp
+
+variables {L : Type v} [small_category L]
+variables (D : L ⥤ K) [has_limit (D ⋙ E ⋙ F)]
+
+@[simp] lemma limit.pre_pre : limit.pre F E ≫ limit.pre (E ⋙ F) D = limit.pre F (D ⋙ E) :=
+by ext j; erw [assoc, limit.pre_π, limit.pre_π, limit.pre_π]; refl
+
+end pre
+
+section post
+variables {D : Type u'} [𝒟 : category.{u' v} D]
+include 𝒟
+
+variables (F : J ⥤ C) [has_limit F] (G : C ⥤ D) [has_limit (F ⋙ G)]
+
+def limit.post : G.obj (limit F) ⟶ limit (F ⋙ G) :=
+limit.lift (F ⋙ G)
+{ X := G.obj (limit F),
+  π :=
+  { app := λ j, G.map (limit.π F j),
+    naturality' :=
+      by intros j j' f; erw [←G.map_comp, limits.cone.w, id_comp]; refl } }
+
+@[simp] lemma limit.post_π (j : J) : limit.post F G ≫ limit.π (F ⋙ G) j = G.map (limit.π F j) :=
+by erw is_limit.fac
+
+@[simp] lemma limit.lift_post (c : cone F) :
+  G.map (limit.lift F c) ≫ limit.post F G = limit.lift (F ⋙ G) (G.map_cone c) :=
+by ext; rw [assoc, limit.post_π, ←G.map_comp, limit.lift_π, limit.lift_π]; refl
+
+@[simp] lemma limit.post_post
+  {E : Type u''} [category.{u'' v} E] (H : D ⥤ E) [has_limit ((F ⋙ G) ⋙ H)] :
+/- H G (limit F) ⟶ H (limit (F ⋙ G)) ⟶ limit ((F ⋙ G) ⋙ H) equals -/
+/- H G (limit F) ⟶ limit (F ⋙ (G ⋙ H)) -/
+  H.map (limit.post F G) ≫ limit.post (F ⋙ G) H = limit.post F (G ⋙ H) :=
+by ext; erw [assoc, limit.post_π, ←H.map_comp, limit.post_π, limit.post_π]; refl
+
+end post
+
+lemma limit.pre_post {K : Type v} [small_category K] {D : Type u'} [category.{u' v} D]
+  (E : K ⥤ J) (F : J ⥤ C) (G : C ⥤ D)
+  [has_limit F] [has_limit (E ⋙ F)] [has_limit (F ⋙ G)] [has_limit ((E ⋙ F) ⋙ G)] :
+/- G (limit F) ⟶ G (limit (E ⋙ F)) ⟶ limit ((E ⋙ F) ⋙ G) vs -/
+/- G (limit F) ⟶ limit F ⋙ G ⟶ limit (E ⋙ (F ⋙ G)) or -/
+  G.map (limit.pre F E) ≫ limit.post (E ⋙ F) G = limit.post F G ≫ limit.pre (F ⋙ G) E :=
+by ext; erw [assoc, limit.post_π, ←G.map_comp, limit.pre_π, assoc, limit.pre_π, limit.post_π]; refl
+
+section lim_functor
+
+variables [has_limits_of_shape J C]
+
+/-- `limit F` is functorial in `F`, when `C` has all limits of shape `J`. -/
+def lim : (J ⥤ C) ⥤ C :=
+{ obj := λ F, limit F,
+  map := λ F G α, limit.lift G
+    { X := limit F,
+      π :=
+      { app := λ j, limit.π F j ≫ α.app j,
+        naturality' := λ j j' f,
+          by erw [id_comp, assoc, ←α.naturality, ←assoc, limit.w] } },
+  map_comp' := λ F G H α β,
+    by ext; erw [assoc, is_limit.fac, is_limit.fac, ←assoc, is_limit.fac, assoc]; refl }
+
+variables {F G : J ⥤ C} (α : F ⟹ G)
+
+@[simp] lemma lim.map_π (j : J) : lim.map α ≫ limit.π G j = limit.π F j ≫ α.app j :=
+by apply is_limit.fac
+
+@[simp] lemma limit.lift_map (c : cone F) :
+  limit.lift F c ≫ lim.map α = limit.lift G (c.postcompose α) :=
+by ext; rw [assoc, lim.map_π, ←assoc, limit.lift_π, limit.lift_π]; refl
+
+lemma limit.map_pre {K : Type v} [small_category K] [has_limits_of_shape K C] (E : K ⥤ J) :
+  lim.map α ≫ limit.pre G E = limit.pre F E ≫ lim.map (whisker_left E α) :=
+by ext; rw [assoc, limit.pre_π, lim.map_π, assoc, lim.map_π, ←assoc, limit.pre_π]; refl
+
+lemma limit.map_post {D : Type u'} [category.{u' v} D] [has_limits_of_shape J D] (H : C ⥤ D) :
+/- H (limit F) ⟶ H (limit G) ⟶ limit (G ⋙ H) vs
+   H (limit F) ⟶ limit (F ⋙ H) ⟶ limit (G ⋙ H) -/
+  H.map (lim.map α) ≫ limit.post G H = limit.post F H ≫ lim.map (whisker_right α H) :=
+begin
+  ext,
+  rw [assoc, limit.post_π, ←H.map_comp, lim.map_π, H.map_comp],
+  rw [assoc, lim.map_π, ←assoc, limit.post_π],
+  refl
+end
+
+end lim_functor
+
+end limit
+
+
+section colimit
+
+/-- `has_colimit F` represents a particular chosen colimit of the diagram `F`. -/
+class has_colimit (F : J ⥤ C) :=
+(cocone : cocone F)
+(is_colimit : is_colimit cocone)
+
+variables (J C)
+
+/-- `C` has colimits of shape `J` if we have chosen a particular colimit of
+  every functor `F : J ⥤ C`. -/
+@[class] def has_colimits_of_shape := Π F : J ⥤ C, has_colimit F
+
+/-- `C` has all (small) colimits if it has limits of every shape. -/
+@[class] def has_colimits :=
+Π {J : Type v} {𝒥 : small_category J}, by exactI has_colimits_of_shape J C
+
+variables {J C}
+
+instance has_colimit_of_has_colimits_of_shape
+  {J : Type v} [small_category J] [H : has_colimits_of_shape J C] (F : J ⥤ C) : has_colimit F :=
+H F
+
+instance has_colimits_of_shape_of_has_colimits
+  {J : Type v} [small_category J] [H : has_colimits.{u v} C] : has_colimits_of_shape J C :=
+H
+
+/- Interface to the `has_colimit` class. -/
+
+def colimit.cocone (F : J ⥤ C) [has_colimit F] : cocone F := has_colimit.cocone F
+
+def colimit (F : J ⥤ C) [has_colimit F] := (colimit.cocone F).X
+
+def colimit.ι (F : J ⥤ C) [has_colimit F] (j : J) : F.obj j ⟶ colimit F :=
+(colimit.cocone F).ι.app j
+
+@[simp] lemma colimit.cocone_ι {F : J ⥤ C} [has_colimit F] (j : J) :
+  (colimit.cocone F).ι.app j = colimit.ι _ j := rfl
+
+@[simp] lemma colimit.w (F : J ⥤ C) [has_colimit F] {j j' : J} (f : j ⟶ j') :
+  F.map f ≫ colimit.ι F j' = colimit.ι F j := (colimit.cocone F).w f
+
+def colimit.is_colimit (F : J ⥤ C) [has_colimit F] : is_colimit (colimit.cocone F) :=
+has_colimit.is_colimit.{u v} F
+
+def colimit.desc (F : J ⥤ C) [has_colimit F] (c : cocone F) : colimit F ⟶ c.X :=
+(colimit.is_colimit F).desc c
+
+@[simp] lemma colimit.is_colimit_desc {F : J ⥤ C} [has_colimit F] (c : cocone F) :
+  (colimit.is_colimit F).desc c = colimit.desc F c := rfl
+
+@[simp] lemma colimit.ι_desc {F : J ⥤ C} [has_colimit F] (c : cocone F) (j : J) :
+  colimit.ι F j ≫ colimit.desc F c = c.ι.app j :=
+is_colimit.fac _ c j
+
+def colimit.cocone_morphism {F : J ⥤ C} [has_colimit F] (c : cocone F) :
+  cocone_morphism (colimit.cocone F) c :=
+(colimit.is_colimit F).desc_cocone_morphism c
+
+@[simp] lemma colimit.cocone_morphism_hom {F : J ⥤ C} [has_colimit F] (c : cocone F) :
+  (colimit.cocone_morphism c).hom = colimit.desc F c := rfl
+@[simp] lemma colimit.ι_cocone_morphism {F : J ⥤ C} [has_colimit F] (c : cocone F) (j : J) :
+  colimit.ι F j ≫ (colimit.cocone_morphism c).hom = c.ι.app j :=
+by erw is_colimit.fac
+
+@[extensionality] lemma colimit.hom_ext {F : J ⥤ C} [has_colimit F] {X : C} {f f' : colimit F ⟶ X}
+  (w : ∀ j, colimit.ι F j ≫ f = colimit.ι F j ≫ f') : f = f' :=
+(colimit.is_colimit F).hom_ext w
+
+def colimit.hom_iso (F : J ⥤ C) [has_colimit F] (W : C) : (colimit F ⟶ W) ≅ (F.cocones.obj W) :=
+(colimit.is_colimit F).hom_iso W
+
+@[simp] lemma colimit.hom_iso_hom (F : J ⥤ C) [has_colimit F] {W : C} (f : colimit F ⟶ W):
+  (colimit.hom_iso F W).hom f = (colimit.cocone F).ι ≫ (const J).map f :=
+(colimit.is_colimit F).hom_iso_hom f
+
+def colimit.hom_iso' (F : J ⥤ C) [has_colimit F] (W : C) :
+  (colimit F ⟶ W) ≅ { p : Π j, F.obj j ⟶ W // ∀ {j j'} (f : j ⟶ j'), F.map f ≫ p j' = p j } :=
+(colimit.is_colimit F).hom_iso' W
+
+section pre
+variables {K : Type v} [small_category K]
+variables (F : J ⥤ C) [has_colimit F] (E : K ⥤ J) [has_colimit (E ⋙ F)]
+
+def colimit.pre : colimit (E ⋙ F) ⟶ colimit F :=
+colimit.desc (E ⋙ F)
+  { X := colimit F,
+    ι := { app := λ k, colimit.ι F (E.obj k) } }
+
+@[simp] lemma colimit.ι_pre (k : K) : colimit.ι (E ⋙ F) k ≫ colimit.pre F E = colimit.ι F (E.obj k) :=
+by erw is_colimit.fac
+
+@[simp] lemma colimit.pre_desc (c : cocone F) :
+  colimit.pre F E ≫ colimit.desc F c = colimit.desc (E ⋙ F) (c.whisker E) :=
+by ext; rw [←assoc, colimit.ι_pre]; simp
+
+variables {L : Type v} [small_category L]
+variables (D : L ⥤ K) [has_colimit (D ⋙ E ⋙ F)]
+
+@[simp] lemma colimit.pre_pre : colimit.pre (E ⋙ F) D ≫ colimit.pre F E = colimit.pre F (D ⋙ E) :=
+begin
+  ext j,
+  erw [←assoc, colimit.ι_pre, colimit.ι_pre],
+  -- Why doesn't another erw [colimit.ι_pre] work here, like it did in limit.pre_pre?
+  letI : has_colimit ((D ⋙ E) ⋙ F) := show has_colimit (D ⋙ E ⋙ F), by apply_instance,
+  exact (colimit.ι_pre F (D ⋙ E) j).symm
+end
+
+end pre
+
+section post
+variables {D : Type u'} [𝒟 : category.{u' v} D]
+include 𝒟
+
+variables (F : J ⥤ C) [has_colimit F] (G : C ⥤ D) [has_colimit (F ⋙ G)]
+
+def colimit.post : colimit (F ⋙ G) ⟶ G.obj (colimit F) :=
+colimit.desc (F ⋙ G)
+{ X := G.obj (colimit F),
+  ι :=
+  { app := λ j, G.map (colimit.ι F j),
+    naturality' :=
+      by intros j j' f; erw [←G.map_comp, limits.cocone.w, comp_id]; refl } }
+
+@[simp] lemma colimit.ι_post (j : J) : colimit.ι (F ⋙ G) j ≫ colimit.post F G  = G.map (colimit.ι F j) :=
+by erw is_colimit.fac
+
+@[simp] lemma colimit.post_desc (c : cocone F) :
+  colimit.post F G ≫ G.map (colimit.desc F c) = colimit.desc (F ⋙ G) (G.map_cocone c) :=
+by ext; rw [←assoc, colimit.ι_post, ←G.map_comp, colimit.ι_desc, colimit.ι_desc]; refl
+
+@[simp] lemma colimit.post_post
+  {E : Type u''} [category.{u'' v} E] (H : D ⥤ E) [has_colimit ((F ⋙ G) ⋙ H)] :
+/- H G (colimit F) ⟶ H (colimit (F ⋙ G)) ⟶ colimit ((F ⋙ G) ⋙ H) equals -/
+/- H G (colimit F) ⟶ colimit (F ⋙ (G ⋙ H)) -/
+  colimit.post (F ⋙ G) H ≫ H.map (colimit.post F G) = colimit.post F (G ⋙ H) :=
+begin
+  ext,
+  erw [←assoc, colimit.ι_post, ←H.map_comp, colimit.ι_post],
+  exact (colimit.ι_post F (G ⋙ H) j).symm
+end
+
+end post
+
+lemma colimit.pre_post {K : Type v} [small_category K] {D : Type u'} [category.{u' v} D]
+  (E : K ⥤ J) (F : J ⥤ C) (G : C ⥤ D)
+  [has_colimit F] [has_colimit (E ⋙ F)] [has_colimit (F ⋙ G)] [has_colimit ((E ⋙ F) ⋙ G)] :
+/- G (colimit F) ⟶ G (colimit (E ⋙ F)) ⟶ colimit ((E ⋙ F) ⋙ G) vs -/
+/- G (colimit F) ⟶ colimit F ⋙ G ⟶ colimit (E ⋙ (F ⋙ G)) or -/
+  colimit.post (E ⋙ F) G ≫ G.map (colimit.pre F E) = colimit.pre (F ⋙ G) E ≫ colimit.post F G :=
+begin
+  ext,
+  erw [←assoc, colimit.ι_post, ←G.map_comp, colimit.ι_pre, ←assoc],
+  letI : has_colimit (E ⋙ F ⋙ G) := show has_colimit ((E ⋙ F) ⋙ G), by apply_instance,
+  erw [colimit.ι_pre (F ⋙ G) E j, colimit.ι_post]
+end
+
+section colim_functor
+
+variables [has_colimits_of_shape J C]
+
+/-- `colimit F` is functorial in `F`, when `C` has all colimits of shape `J`. -/
+def colim : (J ⥤ C) ⥤ C :=
+{ obj := λ F, colimit F,
+  map := λ F G α, colimit.desc F
+    { X := colimit G,
+      ι :=
+      { app := λ j, α.app j ≫ colimit.ι G j,
+        naturality' := λ j j' f,
+          by erw [comp_id, ←assoc, α.naturality, assoc, colimit.w] } },
+  map_comp' := λ F G H α β,
+    by ext; erw [←assoc, is_colimit.fac, is_colimit.fac, assoc, is_colimit.fac, ←assoc]; refl }
+
+variables {F G : J ⥤ C} (α : F ⟹ G)
+
+@[simp] lemma colim.ι_map (j : J) : colimit.ι F j ≫ colim.map α = α.app j ≫ colimit.ι G j :=
+by apply is_colimit.fac
+
+@[simp] lemma colimit.map_desc (c : cocone G) :
+  colim.map α ≫ colimit.desc G c = colimit.desc F (c.precompose α) :=
+by ext; rw [←assoc, colim.ι_map, assoc, colimit.ι_desc, colimit.ι_desc]; refl
+
+lemma colimit.pre_map {K : Type v} [small_category K] [has_colimits_of_shape K C] (E : K ⥤ J) :
+  colimit.pre F E ≫ colim.map α = colim.map (whisker_left E α) ≫ colimit.pre G E :=
+by ext; rw [←assoc, colimit.ι_pre, colim.ι_map, ←assoc, colim.ι_map, assoc, colimit.ι_pre]; refl
+
+lemma colimit.map_post {D : Type u'} [category.{u' v} D] [has_colimits_of_shape J D] (H : C ⥤ D) :
+/- H (colimit F) ⟶ H (colimit G) ⟶ colimit (G ⋙ H) vs
+   H (colimit F) ⟶ colimit (F ⋙ H) ⟶ colimit (G ⋙ H) -/
+  colimit.post F H ≫ H.map (colim.map α) = colim.map (whisker_right α H) ≫ colimit.post G H:=
+begin
+  ext,
+  rw [←assoc, colimit.ι_post, ←H.map_comp, colim.ι_map, H.map_comp],
+  rw [←assoc, colim.ι_map, assoc, colimit.ι_post],
+  refl
+end
+
+end colim_functor
+
+end colimit
+
+end category_theory.limits

--- a/category_theory/limits/limits.lean
+++ b/category_theory/limits/limits.lean
@@ -16,7 +16,6 @@ variables {J : Type v} [small_category J]
 variables {C : Type u} [𝒞 : category.{u v} C]
 include 𝒞
 
-section is_limit
 variables {F : J ⥤ C}
 
 /-- A cone `t` on `F` is a limit cone if each cone on `F` admits a unique
@@ -31,20 +30,22 @@ restate_axiom is_limit.fac'
 attribute [simp] is_limit.fac
 restate_axiom is_limit.uniq'
 
-instance is_limit_subsingleton {t : cone F} : subsingleton (is_limit t) :=
+namespace is_limit
+
+instance subsingleton {t : cone F} : subsingleton (is_limit t) :=
 ⟨by intros P Q; cases P; cases Q; congr; ext; solve_by_elim⟩
 
 /- Repackaging the definition in terms of cone morphisms. -/
 
-def is_limit.lift_cone_morphism {t : cone F} (h : is_limit t) (s : cone F) : s ⟶ t :=
+def lift_cone_morphism {t : cone F} (h : is_limit t) (s : cone F) : s ⟶ t :=
 { hom := h.lift s }
 
-lemma is_limit.uniq_cone_morphism {s t : cone F} (h : is_limit t) {f f' : s ⟶ t} :
+lemma uniq_cone_morphism {s t : cone F} (h : is_limit t) {f f' : s ⟶ t} :
   f = f' :=
 have ∀ {g : s ⟶ t}, g = h.lift_cone_morphism s, by intro g; ext; exact h.uniq _ _ g.w,
 this.trans this.symm
 
-def is_limit.mk_cone_morphism {t : cone F}
+def mk_cone_morphism {t : cone F}
   (lift : Π (s : cone F), s ⟶ t)
   (uniq' : ∀ (s : cone F) (m : s ⟶ t), m = lift s) : is_limit t :=
 { lift := λ s, (lift s).hom,
@@ -53,45 +54,45 @@ def is_limit.mk_cone_morphism {t : cone F}
     congr_arg cone_morphism.hom this }
 
 /-- Limit cones on `F` are unique up to isomorphism. -/
-def is_limit.unique {s t : cone F} (P : is_limit s) (Q : is_limit t) : s ≅ t :=
+def unique {s t : cone F} (P : is_limit s) (Q : is_limit t) : s ≅ t :=
 { hom := Q.lift_cone_morphism s,
   inv := P.lift_cone_morphism t,
   hom_inv_id' := P.uniq_cone_morphism,
   inv_hom_id' := Q.uniq_cone_morphism }
 
-def is_limit.of_iso_limit {r t : cone F} (P : is_limit r) (i : r ≅ t) : is_limit t :=
+def of_iso_limit {r t : cone F} (P : is_limit r) (i : r ≅ t) : is_limit t :=
 is_limit.mk_cone_morphism
   (λ s, P.lift_cone_morphism s ≫ i.hom)
   (λ s m, by rw ←i.comp_inv_eq; apply P.uniq_cone_morphism)
 
 variables {t : cone F}
 
-lemma is_limit.hom_lift (h : is_limit t) {W : C} (m : W ⟶ t.X) :
+lemma hom_lift (h : is_limit t) {W : C} (m : W ⟶ t.X) :
   m = h.lift { X := W, π := { app := λ b, m ≫ t.π.app b } } :=
 h.uniq { X := W, π := { app := λ b, m ≫ t.π.app b } } m (λ b, rfl)
 
 /-- Two morphisms into a limit are equal if their compositions with
   each cone morphism are equal. -/
-lemma is_limit.hom_ext (h : is_limit t) {W : C} {f f' : W ⟶ t.X}
+lemma hom_ext (h : is_limit t) {W : C} {f f' : W ⟶ t.X}
   (w : ∀ j, f ≫ t.π.app j = f' ≫ t.π.app j) : f = f' :=
 by rw [h.hom_lift f, h.hom_lift f']; congr; exact funext w
 
 /-- The universal property of a limit cone: a map `W ⟶ X` is the same as
   a cone on `F` with vertex `W`. -/
-def is_limit.hom_iso (h : is_limit t) (W : C) : (W ⟶ t.X) ≅ ((const J).obj W ⟹ F) :=
+def hom_iso (h : is_limit t) (W : C) : (W ⟶ t.X) ≅ ((const J).obj W ⟹ F) :=
 { hom := λ f, (t.extend f).π,
   inv := λ π, h.lift { X := W, π := π },
   hom_inv_id' := by ext f; apply h.hom_ext; intro j; simp; dsimp; refl }
 
-@[simp] lemma is_limit.hom_iso_hom (h : is_limit t) {W : C} (f : W ⟶ t.X) :
+@[simp] lemma hom_iso_hom (h : is_limit t) {W : C} (f : W ⟶ t.X) :
   (is_limit.hom_iso h W).hom f = (t.extend f).π := rfl
 
 /-- The limit of `F` represents the functor taking `W` to
   the set of cones on `F` with vertex `W`. -/
-def is_limit.nat_iso (h : is_limit t) : yoneda.obj t.X ≅ F.cones :=
+def nat_iso (h : is_limit t) : yoneda.obj t.X ≅ F.cones :=
 nat_iso.of_components (is_limit.hom_iso h) (by tidy)
 
-def is_limit.hom_iso' (h : is_limit t) (W : C) :
+def hom_iso' (h : is_limit t) (W : C) :
   (W ⟶ t.X) ≅ { p : Π j, W ⟶ F.obj j // ∀ {j j'} (f : j ⟶ j'), p j ≫ F.map f = p j' } :=
 h.hom_iso W ≪≫
 { hom := λ π,
@@ -102,10 +103,6 @@ h.hom_iso W ≪≫
     naturality' := λ j j' f, begin dsimp, erw [id_comp], exact (p.2 f).symm end } }
 
 end is_limit
-
-
-section is_colimit
-variables {F : J ⥤ C}
 
 /-- A cocone `t` on `F` is a colimit cocone if each cocone on `F` admits a unique
   cocone morphism from `t`. -/
@@ -119,20 +116,22 @@ restate_axiom is_colimit.fac'
 attribute [simp] is_colimit.fac
 restate_axiom is_colimit.uniq'
 
-instance is_colimit_subsingleton {t : cocone F} : subsingleton (is_colimit t) :=
+namespace is_colimit
+
+instance subsingleton {t : cocone F} : subsingleton (is_colimit t) :=
 ⟨by intros P Q; cases P; cases Q; congr; ext; solve_by_elim⟩
 
 /- Repackaging the definition in terms of cone morphisms. -/
 
-def is_colimit.desc_cocone_morphism {t : cocone F} (h : is_colimit t) (s : cocone F) : t ⟶ s :=
+def desc_cocone_morphism {t : cocone F} (h : is_colimit t) (s : cocone F) : t ⟶ s :=
 { hom := h.desc s }
 
-lemma is_colimit.uniq_cocone_morphism {s t : cocone F} (h : is_colimit t) {f f' : t ⟶ s} :
+lemma uniq_cocone_morphism {s t : cocone F} (h : is_colimit t) {f f' : t ⟶ s} :
   f = f' :=
 have ∀ {g : t ⟶ s}, g = h.desc_cocone_morphism s, by intro g; ext; exact h.uniq _ _ g.w,
 this.trans this.symm
 
-def is_colimit.mk_cocone_morphism {t : cocone F}
+def mk_cocone_morphism {t : cocone F}
   (desc : Π (s : cocone F), t ⟶ s)
   (uniq' : ∀ (s : cocone F) (m : t ⟶ s), m = desc s) : is_colimit t :=
 { desc := λ s, (desc s).hom,
@@ -141,46 +140,46 @@ def is_colimit.mk_cocone_morphism {t : cocone F}
     congr_arg cocone_morphism.hom this }
 
 /-- Limit cones on `F` are unique up to isomorphism. -/
-def is_colimit.unique {s t : cocone F} (P : is_colimit s) (Q : is_colimit t) : s ≅ t :=
+def unique {s t : cocone F} (P : is_colimit s) (Q : is_colimit t) : s ≅ t :=
 { hom := P.desc_cocone_morphism t,
   inv := Q.desc_cocone_morphism s,
   hom_inv_id' := P.uniq_cocone_morphism,
   inv_hom_id' := Q.uniq_cocone_morphism }
 
-def is_colimit.of_iso_colimit {r t : cocone F} (P : is_colimit r) (i : r ≅ t) : is_colimit t :=
+def of_iso_colimit {r t : cocone F} (P : is_colimit r) (i : r ≅ t) : is_colimit t :=
 is_colimit.mk_cocone_morphism
   (λ s, i.inv ≫ P.desc_cocone_morphism s)
   (λ s m, by rw i.eq_inv_comp; apply P.uniq_cocone_morphism)
 
 variables {t : cocone F}
 
-lemma is_colimit.hom_desc (h : is_colimit t) {W : C} (m : t.X ⟶ W) :
+lemma hom_desc (h : is_colimit t) {W : C} (m : t.X ⟶ W) :
   m = h.desc { X := W, ι := { app := λ b, t.ι.app b ≫ m,
     naturality' := by intros; erw [←assoc, t.ι.naturality, comp_id, comp_id] } } :=
 h.uniq { X := W, ι := { app := λ b, t.ι.app b ≫ m, naturality' := _ } } m (λ b, rfl)
 
 /-- Two morphisms out of a colimit are equal if their compositions with
   each cocone morphism are equal. -/
-lemma is_colimit.hom_ext (h : is_colimit t) {W : C} {f f' : t.X ⟶ W}
+lemma hom_ext (h : is_colimit t) {W : C} {f f' : t.X ⟶ W}
   (w : ∀ j, t.ι.app j ≫ f = t.ι.app j ≫ f') : f = f' :=
 by rw [h.hom_desc f, h.hom_desc f']; congr; exact funext w
 
 /-- The universal property of a colimit cocone: a map `X ⟶ W` is the same as
   a cocone on `F` with vertex `W`. -/
-def is_colimit.hom_iso (h : is_colimit t) (W : C) : (t.X ⟶ W) ≅ (F ⟹ (const J).obj W) :=
+def hom_iso (h : is_colimit t) (W : C) : (t.X ⟶ W) ≅ (F ⟹ (const J).obj W) :=
 { hom := λ f, (t.extend f).ι,
   inv := λ ι, h.desc { X := W, ι := ι },
   hom_inv_id' := by ext f; apply h.hom_ext; intro j; simp; dsimp; refl }
 
-@[simp] lemma is_colimit.hom_iso_hom (h : is_colimit t) {W : C} (f : t.X ⟶ W) :
+@[simp] lemma hom_iso_hom (h : is_colimit t) {W : C} (f : t.X ⟶ W) :
   (is_colimit.hom_iso h W).hom f = (t.extend f).ι := rfl
 
 /-- The colimit of `F` represents the functor taking `W` to
   the set of cocones on `F` with vertex `W`. -/
-def is_colimit.nat_iso (h : is_colimit t) : coyoneda.obj t.X ≅ F.cocones :=
+def nat_iso (h : is_colimit t) : coyoneda.obj t.X ≅ F.cocones :=
 nat_iso.of_components (is_colimit.hom_iso h) (by intros; ext; dsimp; rw ←assoc; refl)
 
-def is_colimit.hom_iso' (h : is_colimit t) (W : C) :
+def hom_iso' (h : is_colimit t) (W : C) :
   (t.X ⟶ W) ≅ { p : Π j, F.obj j ⟶ W // ∀ {j j' : J} (f : j ⟶ j'), F.map f ≫ p j' = p j } :=
 h.hom_iso W ≪≫
 { hom := λ ι,
@@ -191,7 +190,6 @@ h.hom_iso W ≪≫
     naturality' := λ j j' f, begin dsimp, erw [comp_id], exact (p.2 f) end } }
 
 end is_colimit
-
 
 section limit
 
@@ -275,7 +273,7 @@ def limit.hom_iso' (F : J ⥤ C) [has_limit F] (W : C) :
 
 section pre
 variables {K : Type v} [small_category K]
-variables (F : J ⥤ C) [has_limit F] (E : K ⥤ J) [has_limit (E ⋙ F)]
+variables (F) [has_limit F] (E : K ⥤ J) [has_limit (E ⋙ F)]
 
 def limit.pre : limit F ⟶ limit (E ⋙ F) :=
 limit.lift (E ⋙ F)
@@ -301,7 +299,7 @@ section post
 variables {D : Type u'} [𝒟 : category.{u' v} D]
 include 𝒟
 
-variables (F : J ⥤ C) [has_limit F] (G : C ⥤ D) [has_limit (F ⋙ G)]
+variables (F) [has_limit F] (G : C ⥤ D) [has_limit (F ⋙ G)]
 
 def limit.post : G.obj (limit F) ⟶ limit (F ⋙ G) :=
 limit.lift (F ⋙ G)
@@ -351,7 +349,7 @@ def lim : (J ⥤ C) ⥤ C :=
   map_comp' := λ F G H α β,
     by ext; erw [assoc, is_limit.fac, is_limit.fac, ←assoc, is_limit.fac, assoc]; refl }
 
-variables {F G : J ⥤ C} (α : F ⟹ G)
+variables {F} {G : J ⥤ C} (α : F ⟹ G)
 
 @[simp] lemma lim.map_π (j : J) : lim.map α ≫ limit.π G j = limit.π F j ≫ α.app j :=
 by apply is_limit.fac
@@ -462,7 +460,7 @@ def colimit.hom_iso' (F : J ⥤ C) [has_colimit F] (W : C) :
 
 section pre
 variables {K : Type v} [small_category K]
-variables (F : J ⥤ C) [has_colimit F] (E : K ⥤ J) [has_colimit (E ⋙ F)]
+variables (F) [has_colimit F] (E : K ⥤ J) [has_colimit (E ⋙ F)]
 
 def colimit.pre : colimit (E ⋙ F) ⟶ colimit F :=
 colimit.desc (E ⋙ F)
@@ -494,7 +492,7 @@ section post
 variables {D : Type u'} [𝒟 : category.{u' v} D]
 include 𝒟
 
-variables (F : J ⥤ C) [has_colimit F] (G : C ⥤ D) [has_colimit (F ⋙ G)]
+variables (F) [has_colimit F] (G : C ⥤ D) [has_colimit (F ⋙ G)]
 
 def colimit.post : colimit (F ⋙ G) ⟶ G.obj (colimit F) :=
 colimit.desc (F ⋙ G)
@@ -553,7 +551,7 @@ def colim : (J ⥤ C) ⥤ C :=
   map_comp' := λ F G H α β,
     by ext; erw [←assoc, is_colimit.fac, is_colimit.fac, assoc, is_colimit.fac, ←assoc]; refl }
 
-variables {F G : J ⥤ C} (α : F ⟹ G)
+variables {F} {G : J ⥤ C} (α : F ⟹ G)
 
 @[simp] lemma colim.ι_map (j : J) : colimit.ι F j ≫ colim.map α = α.app j ≫ colimit.ι G j :=
 by apply is_colimit.fac

--- a/category_theory/limits/preserves.lean
+++ b/category_theory/limits/preserves.lean
@@ -1,0 +1,180 @@
+-- Copyright (c) 2018 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Scott Morrison, Reid Barton
+
+-- Preservation and reflection of (co)limits.
+
+import category_theory.whiskering
+import category_theory.limits.limits
+
+open category_theory
+
+namespace category_theory.limits
+
+universes u₁ u₂ u₃ v
+
+variables {C : Type u₁} [𝒞 : category.{u₁ v} C]
+variables {D : Type u₂} [𝒟 : category.{u₂ v} D]
+include 𝒞 𝒟
+
+variables {J : Type v} [small_category J] {K : J ⥤ C}
+
+/- Note on "preservation of (co)limits"
+
+There are various distinct notions of "preserving limits". The one we
+aim to capture here is: A functor F : C → D "preserves limits" if it
+sends every limit cone in C to a limit cone in D. Informally, F
+preserves all the limits which exist in C.
+
+Note that:
+
+* Of course, we do not want to require F to *strictly* take chosen
+  limit cones of C to chosen limit cones of D. Indeed, the above
+  definition makes no reference to a choice of limit cones so it makes
+  sense without any conditions on C or D.
+
+* Some diagrams in C may have no limit. In this case, there is no
+  condition on the behavior of F on such diagrams. There are other
+  notions (such as "flat functor") which impose conditions also on
+  diagrams in C with no limits, but these are not considered here.
+
+In order to be able to express the property of preserving limits of a
+certain form, we say that a functor F preserves the limit of a
+diagram K if F sends every limit cone on K to a limit cone. This is
+vacuously satisfied when K does not admit a limit, which is consistent
+with the above definition of "preserves limits".
+
+-/
+
+class preserves_limit (K : J ⥤ C) (F : C ⥤ D) :=
+(preserves : Π {c : cone K}, is_limit c → is_limit (F.map_cone c))
+class preserves_colimit (K : J ⥤ C) (F : C ⥤ D) :=
+(preserves : Π {c : cocone K}, is_colimit c → is_colimit (F.map_cocone c))
+
+@[class] def preserves_limits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) :=
+Π {K : J ⥤ C}, preserves_limit K F
+@[class] def preserves_colimits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) :=
+Π {K : J ⥤ C}, preserves_colimit K F
+
+@[class] def preserves_limits (F : C ⥤ D) :=
+Π {J : Type v} {𝒥 : small_category J}, by exactI preserves_limits_of_shape J F
+@[class] def preserves_colimits (F : C ⥤ D) :=
+Π {J : Type v} {𝒥 : small_category J}, by exactI preserves_colimits_of_shape J F
+
+instance preserves_limit_of_preserves_limits_of_shape (F : C ⥤ D)
+  [H : preserves_limits_of_shape J F] : preserves_limit K F :=
+H
+instance preserves_colimit_of_preserves_colimits_of_shape (F : C ⥤ D)
+  [H : preserves_colimits_of_shape J F] : preserves_colimit K F :=
+H
+
+instance preserves_limits_of_shape_of_preserves_limits (F : C ⥤ D)
+  [H : preserves_limits F] : preserves_limits_of_shape J F :=
+@H J _
+instance preserves_colimits_of_shape_of_preserves_colimits (F : C ⥤ D)
+  [H : preserves_colimits F] : preserves_colimits_of_shape J F :=
+@H J _
+
+instance id_preserves_limits : preserves_limits (functor.id C) :=
+λ J 𝒥 K, by exactI ⟨λ c h,
+  ⟨λ s, h.lift ⟨s.X, λ j, s.π.app j, λ j j' f, s.π.naturality f⟩,
+   by cases K; rcases c with ⟨_, _, _⟩; intros s j; cases s; exact h.fac _ j,
+   by cases K; rcases c with ⟨_, _, _⟩; intros s m w; rcases s with ⟨_, _, _⟩; exact h.uniq _ m w⟩⟩
+
+instance id_preserves_colimits : preserves_colimits (functor.id C) :=
+λ J 𝒥 K, by exactI ⟨λ c h,
+  ⟨λ s, h.desc ⟨s.X, λ j, s.ι.app j, λ j j' f, s.ι.naturality f⟩,
+   by cases K; rcases c with ⟨_, _, _⟩; intros s j; cases s; exact h.fac _ j,
+   by cases K; rcases c with ⟨_, _, _⟩; intros s m w; rcases s with ⟨_, _, _⟩; exact h.uniq _ m w⟩⟩
+
+section
+variables {E : Type u₃} [ℰ : category.{u₃ v} E]
+variables (F : C ⥤ D) (G : D ⥤ E)
+
+local attribute [elab_simple] preserves_limit.preserves preserves_colimit.preserves
+
+instance comp_preserves_limit [preserves_limit K F] [preserves_limit (K ⋙ F) G] :
+  preserves_limit K (F ⋙ G) :=
+⟨λ c h, preserves_limit.preserves G (preserves_limit.preserves F h)⟩
+
+instance comp_preserves_colimit [preserves_colimit K F] [preserves_colimit (K ⋙ F) G] :
+  preserves_colimit K (F ⋙ G) :=
+⟨λ c h, preserves_colimit.preserves G (preserves_colimit.preserves F h)⟩
+
+end
+
+/-- If F preserves one limit cone for the diagram K,
+  then it preserves any limit cone for K. -/
+def preserves_limit_of_preserves_limit_cone {F : C ⥤ D} {t : cone K}
+  (h : is_limit t) (hF : is_limit (F.map_cone t)) : preserves_limit K F :=
+⟨λ t' h', is_limit.of_iso_limit hF (functor.on_iso _ (is_limit.unique h h'))⟩
+
+/-- If F preserves one colimit cocone for the diagram K,
+  then it preserves any colimit cocone for K. -/
+def preserves_colimit_of_preserves_colimit_cocone {F : C ⥤ D} {t : cocone K}
+  (h : is_colimit t) (hF : is_colimit (F.map_cocone t)) : preserves_colimit K F :=
+⟨λ t' h', is_colimit.of_iso_colimit hF (functor.on_iso _ (is_colimit.unique h h'))⟩
+
+/-
+A functor F : C → D reflects limits if whenever the image of a cone
+under F is a limit cone in D, the cone was already a limit cone in C.
+Note that again we do not assume a priori that D actually has any
+limits.
+-/
+
+class reflects_limit (K : J ⥤ C) (F : C ⥤ D) :=
+(reflects : Π {c : cone K}, is_limit (F.map_cone c) → is_limit c)
+class reflects_colimit (K : J ⥤ C) (F : C ⥤ D) :=
+(reflects : Π {c : cocone K}, is_colimit (F.map_cocone c) → is_colimit c)
+
+@[class] def reflects_limits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) :=
+Π {K : J ⥤ C}, reflects_limit K F
+@[class] def reflects_colimits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) :=
+Π {K : J ⥤ C}, reflects_colimit K F
+
+@[class] def reflects_limits (F : C ⥤ D) :=
+Π {J : Type v} {𝒥 : small_category J}, by exactI reflects_limits_of_shape J F
+@[class] def reflects_colimits (F : C ⥤ D) :=
+Π {J : Type v} {𝒥 : small_category J}, by exactI reflects_colimits_of_shape J F
+
+instance reflects_limit_of_reflects_limits_of_shape (K : J ⥤ C) (F : C ⥤ D)
+  [H : reflects_limits_of_shape J F] : reflects_limit K F :=
+H
+instance reflects_colimit_of_reflects_colimits_of_shape (K : J ⥤ C) (F : C ⥤ D)
+  [H : reflects_colimits_of_shape J F] : reflects_colimit K F :=
+H
+
+instance reflects_limits_of_shape_of_reflects_limits (F : C ⥤ D)
+  [H : reflects_limits F] : reflects_limits_of_shape J F :=
+@H J _
+instance reflects_colimits_of_shape_of_reflects_colimits (F : C ⥤ D)
+  [H : reflects_colimits F] : reflects_colimits_of_shape J F :=
+@H J _
+
+instance id_reflects_limits : reflects_limits (functor.id C) :=
+λ J 𝒥 K, by exactI ⟨λ c h,
+  ⟨λ s, h.lift ⟨s.X, λ j, s.π.app j, λ j j' f, s.π.naturality f⟩,
+   by cases K; rcases c with ⟨_, _, _⟩; intros s j; cases s; exact h.fac _ j,
+   by cases K; rcases c with ⟨_, _, _⟩; intros s m w; rcases s with ⟨_, _, _⟩; exact h.uniq _ m w⟩⟩
+
+instance id_reflects_colimits : reflects_colimits (functor.id C) :=
+λ J 𝒥 K, by exactI ⟨λ c h,
+  ⟨λ s, h.desc ⟨s.X, λ j, s.ι.app j, λ j j' f, s.ι.naturality f⟩,
+   by cases K; rcases c with ⟨_, _, _⟩; intros s j; cases s; exact h.fac _ j,
+   by cases K; rcases c with ⟨_, _, _⟩; intros s m w; rcases s with ⟨_, _, _⟩; exact h.uniq _ m w⟩⟩
+
+section
+variables {E : Type u₃} [ℰ : category.{u₃ v} E]
+variables (F : C ⥤ D) (G : D ⥤ E)
+
+instance comp_reflects_limit [reflects_limit K F] [reflects_limit (K ⋙ F) G] :
+  reflects_limit K (F ⋙ G) :=
+⟨λ c h, reflects_limit.reflects (reflects_limit.reflects h)⟩
+
+instance comp_reflects_colimit [reflects_colimit K F] [reflects_colimit (K ⋙ F) G] :
+  reflects_colimit K (F ⋙ G) :=
+⟨λ c h, reflects_colimit.reflects (reflects_colimit.reflects h)⟩
+
+end
+
+end category_theory.limits

--- a/category_theory/limits/preserves.lean
+++ b/category_theory/limits/preserves.lean
@@ -46,19 +46,19 @@ with the above definition of "preserves limits".
 
 -/
 
-class preserves_limit (K : J ⥤ C) (F : C ⥤ D) :=
+class preserves_limit (K : J ⥤ C) (F : C ⥤ D) : Type (max u₁ u₂ v) :=
 (preserves : Π {c : cone K}, is_limit c → is_limit (F.map_cone c))
-class preserves_colimit (K : J ⥤ C) (F : C ⥤ D) :=
+class preserves_colimit (K : J ⥤ C) (F : C ⥤ D) : Type (max u₁ u₂ v) :=
 (preserves : Π {c : cocone K}, is_colimit c → is_colimit (F.map_cocone c))
 
-@[class] def preserves_limits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) :=
+@[class] def preserves_limits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) : Type (max u₁ u₂ v) :=
 Π {K : J ⥤ C}, preserves_limit K F
-@[class] def preserves_colimits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) :=
+@[class] def preserves_colimits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) : Type (max u₁ u₂ v) :=
 Π {K : J ⥤ C}, preserves_colimit K F
 
-@[class] def preserves_limits (F : C ⥤ D) :=
+@[class] def preserves_limits (F : C ⥤ D) : Type (max u₁ u₂ (v+1)) :=
 Π {J : Type v} {𝒥 : small_category J}, by exactI preserves_limits_of_shape J F
-@[class] def preserves_colimits (F : C ⥤ D) :=
+@[class] def preserves_colimits (F : C ⥤ D) : Type (max u₁ u₂ (v+1)) :=
 Π {J : Type v} {𝒥 : small_category J}, by exactI preserves_colimits_of_shape J F
 
 instance preserves_limit_of_preserves_limits_of_shape (F : C ⥤ D)
@@ -122,19 +122,19 @@ Note that again we do not assume a priori that D actually has any
 limits.
 -/
 
-class reflects_limit (K : J ⥤ C) (F : C ⥤ D) :=
+class reflects_limit (K : J ⥤ C) (F : C ⥤ D) : Type (max u₁ u₂ v) :=
 (reflects : Π {c : cone K}, is_limit (F.map_cone c) → is_limit c)
-class reflects_colimit (K : J ⥤ C) (F : C ⥤ D) :=
+class reflects_colimit (K : J ⥤ C) (F : C ⥤ D) : Type (max u₁ u₂ v) :=
 (reflects : Π {c : cocone K}, is_colimit (F.map_cocone c) → is_colimit c)
 
-@[class] def reflects_limits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) :=
+@[class] def reflects_limits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) : Type (max u₁ u₂ v) :=
 Π {K : J ⥤ C}, reflects_limit K F
-@[class] def reflects_colimits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) :=
+@[class] def reflects_colimits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) : Type (max u₁ u₂ v) :=
 Π {K : J ⥤ C}, reflects_colimit K F
 
-@[class] def reflects_limits (F : C ⥤ D) :=
+@[class] def reflects_limits (F : C ⥤ D) : Type (max u₁ u₂ (v+1)) :=
 Π {J : Type v} {𝒥 : small_category J}, by exactI reflects_limits_of_shape J F
-@[class] def reflects_colimits (F : C ⥤ D) :=
+@[class] def reflects_colimits (F : C ⥤ D) : Type (max u₁ u₂ (v+1)) :=
 Π {J : Type v} {𝒥 : small_category J}, by exactI reflects_colimits_of_shape J F
 
 instance reflects_limit_of_reflects_limits_of_shape (K : J ⥤ C) (F : C ⥤ D)

--- a/category_theory/limits/preserves.lean
+++ b/category_theory/limits/preserves.lean
@@ -61,6 +61,23 @@ class preserves_colimit (K : J ⥤ C) (F : C ⥤ D) : Type (max u₁ u₂ v) :=
 @[class] def preserves_colimits (F : C ⥤ D) : Type (max u₁ u₂ (v+1)) :=
 Π {J : Type v} {𝒥 : small_category J}, by exactI preserves_colimits_of_shape J F
 
+instance preserves_limit_subsingleton (K : J ⥤ C) (F : C ⥤ D) : subsingleton (preserves_limit K F) :=
+by split; rintros ⟨a⟩ ⟨b⟩; congr
+instance preserves_colimit_subsingleton (K : J ⥤ C) (F : C ⥤ D) : subsingleton (preserves_colimit K F) :=
+by split; rintros ⟨a⟩ ⟨b⟩; congr
+
+instance preserves_limits_of_shape_subsingleton (J : Type v) [small_category J] (F : C ⥤ D) :
+  subsingleton (preserves_limits_of_shape J F) :=
+by split; intros; funext; apply subsingleton.elim
+instance preserves_colimits_of_shape_subsingleton (J : Type v) [small_category J] (F : C ⥤ D) :
+  subsingleton (preserves_colimits_of_shape J F) :=
+by split; intros; funext; apply subsingleton.elim
+
+instance preserves_limits_subsingleton (F : C ⥤ D) : subsingleton (preserves_limits F) :=
+by split; intros; funext; resetI; apply subsingleton.elim
+instance preserves_colimits_subsingleton (F : C ⥤ D) : subsingleton (preserves_colimits F) :=
+by split; intros; funext; resetI; apply subsingleton.elim
+
 instance preserves_limit_of_preserves_limits_of_shape (F : C ⥤ D)
   [H : preserves_limits_of_shape J F] : preserves_limit K F :=
 H
@@ -136,6 +153,23 @@ class reflects_colimit (K : J ⥤ C) (F : C ⥤ D) : Type (max u₁ u₂ v) :=
 Π {J : Type v} {𝒥 : small_category J}, by exactI reflects_limits_of_shape J F
 @[class] def reflects_colimits (F : C ⥤ D) : Type (max u₁ u₂ (v+1)) :=
 Π {J : Type v} {𝒥 : small_category J}, by exactI reflects_colimits_of_shape J F
+
+instance reflects_limit_subsingleton (K : J ⥤ C) (F : C ⥤ D) : subsingleton (reflects_limit K F) :=
+by split; rintros ⟨a⟩ ⟨b⟩; congr
+instance reflects_colimit_subsingleton (K : J ⥤ C) (F : C ⥤ D) : subsingleton (reflects_colimit K F) :=
+by split; rintros ⟨a⟩ ⟨b⟩; congr
+
+instance reflects_limits_of_shape_subsingleton (J : Type v) [small_category J] (F : C ⥤ D) :
+  subsingleton (reflects_limits_of_shape J F) :=
+by split; intros; funext; apply subsingleton.elim
+instance reflects_colimits_of_shape_subsingleton (J : Type v) [small_category J] (F : C ⥤ D) :
+  subsingleton (reflects_colimits_of_shape J F) :=
+by split; intros; funext; apply subsingleton.elim
+
+instance reflects_limits_subsingleton (F : C ⥤ D) : subsingleton (reflects_limits F) :=
+by split; intros; funext; resetI; apply subsingleton.elim
+instance reflects_colimits_subsingleton (F : C ⥤ D) : subsingleton (reflects_colimits F) :=
+by split; intros; funext; resetI; apply subsingleton.elim
 
 instance reflects_limit_of_reflects_limits_of_shape (K : J ⥤ C) (F : C ⥤ D)
   [H : reflects_limits_of_shape J F] : reflects_limit K F :=

--- a/category_theory/limits/types.lean
+++ b/category_theory/limits/types.lean
@@ -1,0 +1,84 @@
+-- Copyright (c) 2018 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Scott Morrison, Reid Barton
+
+import category_theory.limits.limits
+
+universes u v
+
+open category_theory
+open category_theory.limits
+
+namespace category_theory.limits.types
+
+variables {J : Type u} [small_category J]
+
+def limit (F : J ⥤ Type u) : cone F :=
+{ X := {u : Π j, F.obj j // ∀ {j j'} (f : j ⟶ j'), F.map f (u j) = u j'},
+  π := { app := λ j u, u.val j } }
+
+local attribute [elab_simple] congr_fun
+def limit_is_limit (F : J ⥤ Type u) : is_limit (limit F) :=
+{ lift := λ s v, ⟨λ j, s.π.app j v, λ j j' f, congr_fun (cone.w s f) _⟩,
+  uniq' :=
+  begin
+    intros, ext x, apply subtype.eq, ext j,
+    exact congr_fun (w j) x
+  end }
+
+instance : has_limits.{u+1 u} (Type u) :=
+λ J 𝒥 F, by exactI { cone := limit F, is_limit := limit_is_limit F }
+
+@[simp] lemma types_limit (F : J ⥤ Type u) :
+  limits.limit F = {u : Π j, F.obj j // ∀ {j j'} f, F.map f (u j) = u j'} := rfl
+@[simp] lemma types_limit_π (F : J ⥤ Type u) (j : J) (g : (limit F).X) :
+  limit.π F j g = g.val j := rfl
+@[simp] lemma types_limit_pre
+  (F : J ⥤ Type u) {K : Type u} [𝒦 : small_category K] (E : K ⥤ J) (g : (limit F).X) :
+  limit.pre F E g = (⟨λ k, g.val (E.obj k), by obviously⟩ : (limit (E ⋙ F)).X) := rfl
+@[simp] lemma types_limit_map {F G : J ⥤ Type u} (α : F ⟹ G) (g : (limit F).X) :
+  (lim.map α : (limit F).X → (limit G).X) g =
+  (⟨λ j, (α.app j) (g.val j), λ j j' f,
+    by rw [←functor_to_types.naturality, ←(g.property f)]⟩ : (limit G).X) := rfl
+
+@[simp] lemma types_limit_lift (F : J ⥤ Type u) (c : cone F) (x : c.X):
+  limit.lift F c x = (⟨λ j, c.π.app j x, λ j j' f, congr_fun (cone.w c f) x⟩ : (limit F).X) :=
+rfl
+
+
+def colimit (F : J ⥤ Type u) : cocone F :=
+{ X := @quot (Σ j, F.obj j) (λ p p', ∃ f : p.1 ⟶ p'.1, p'.2 = F.map f p.2),
+  ι :=
+  { app := λ j x, quot.mk _ ⟨j, x⟩,
+    naturality' := λ j j' f, funext $ λ x, eq.symm (quot.sound ⟨f, rfl⟩) } }
+
+local attribute [elab_with_expected_type] quot.lift
+
+def colimit_is_colimit (F : J ⥤ Type u) : is_colimit (colimit F) :=
+{ desc := λ s, quot.lift (λ (p : Σ j, F.obj j), s.ι.app p.1 p.2)
+    (assume ⟨j, x⟩ ⟨j', x'⟩ ⟨f, hf⟩, by rw hf; exact (congr_fun (cocone.w s f) x).symm) }
+
+instance : has_colimits.{u+1 u} (Type u) :=
+λ J 𝒥 F, by exactI { cocone := colimit F, is_colimit := colimit_is_colimit F }
+
+@[simp] lemma types_colimit (F : J ⥤ Type u) :
+  limits.colimit F = @quot (Σ j, F.obj j) (λ p p', ∃ f : p.1 ⟶ p'.1, p'.2 = F.map f p.2) := rfl
+@[simp] lemma types_colimit_ι (F : J ⥤ Type u) (j : J) :
+  colimit.ι F j = λ x, quot.mk _ ⟨j, x⟩ := rfl
+@[simp] lemma types_colimit_pre
+  (F : J ⥤ Type u) {K : Type u} [𝒦 : small_category K] (E : K ⥤ J) (g : (colimit (E ⋙ F)).X) :
+  colimit.pre F E =
+  quot.lift (λ p, quot.mk _ ⟨E.obj p.1, p.2⟩) (λ p p' ⟨f, h⟩, quot.sound ⟨E.map f, h⟩) := rfl
+@[simp] lemma types_colimit_map {F G : J ⥤ Type u} (α : F ⟹ G) :
+  (colim.map α : (colimit F).X → (colimit G).X) =
+  quot.lift
+    (λ p, quot.mk _ ⟨p.1, (α.app p.1) p.2⟩)
+    (λ p p' ⟨f, h⟩, quot.sound ⟨f, by rw h; exact functor_to_types.naturality _ _ α f _⟩) := rfl
+
+@[simp] lemma types_colimit_desc (F : J ⥤ Type u) (c : cocone F) :
+  colimit.desc F c =
+  quot.lift
+    (λ p, c.ι.app p.1 p.2)
+    (λ p p' ⟨f, h⟩, by rw h; exact (functor_to_types.naturality _ _ c.ι f _).symm) := rfl
+
+end category_theory.limits.types

--- a/category_theory/natural_isomorphism.lean
+++ b/category_theory/natural_isomorphism.lean
@@ -78,12 +78,7 @@ def of_components (app : ∀ X : C, (F.obj X) ≅ (G.obj X))
   inv  :=
   { app := λ X, ((app X).inv),
     naturality' := λ X Y f,
-    begin
-      let p := congr_arg (λ f, (app X).inv ≫ (f ≫ (app Y).inv)) (eq.symm (naturality f)),
-      dsimp at *,
-      simp at *,
-      erw [←p, ←category.assoc, is_iso.hom_inv_id, category.id_comp],
-    end } }.
+    by simpa using congr_arg (λ f, (app X).inv ≫ (f ≫ (app Y).inv)) (eq.symm (naturality f)) } }
 
 @[simp] def of_components.app (app' : ∀ X : C, (F.obj X) ≅ (G.obj X)) (naturality) (X) :
   app (of_components app' naturality) X = app' X :=

--- a/category_theory/natural_isomorphism.lean
+++ b/category_theory/natural_isomorphism.lean
@@ -78,7 +78,7 @@ def of_components (app : ∀ X : C, (F.obj X) ≅ (G.obj X))
   inv  :=
   { app := λ X, ((app X).inv),
     naturality' := λ X Y f,
-    by simpa using congr_arg (λ f, (app X).inv ≫ (f ≫ (app Y).inv)) (eq.symm (naturality f)) } }
+    by simpa using congr_arg (λ f, (app X).inv ≫ (f ≫ (app Y).inv)) (naturality f).symm } }
 
 @[simp] def of_components.app (app' : ∀ X : C, (F.obj X) ≅ (G.obj X)) (naturality) (X) :
   app (of_components app' naturality) X = app' X :=
@@ -99,10 +99,10 @@ variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C]
           {D : Type u₂} [𝒟 : category.{u₂ v₂} D]
 include 𝒞 𝒟
 
-@[simp] def id_comp (F : C ⥤ D) : functor.id C ⋙ F ≅ F :=
+@[simp] protected def id_comp (F : C ⥤ D) : functor.id C ⋙ F ≅ F :=
 { hom := { app := λ X, 𝟙 (F.obj X) },
   inv := { app := λ X, 𝟙 (F.obj X) } }
-@[simp] def comp_id (F : C ⥤ D) : F ⋙ functor.id D ≅ F :=
+@[simp] protected def comp_id (F : C ⥤ D) : F ⋙ functor.id D ≅ F :=
 { hom := { app := λ X, 𝟙 (F.obj X) },
   inv := { app := λ X, 𝟙 (F.obj X) } }
 
@@ -113,7 +113,7 @@ variables {A : Type u₃} [𝒜 : category.{u₃ v₃} A]
 include 𝒜 ℬ
 variables (F : A ⥤ B) (G : B ⥤ C) (H : C ⥤ D)
 
-@[simp] def assoc : (F ⋙ G) ⋙ H ≅ F ⋙ (G ⋙ H ):=
+@[simp] protected def assoc : (F ⋙ G) ⋙ H ≅ F ⋙ (G ⋙ H ):=
 { hom := { app := λ X, 𝟙 (H.obj (G.obj (F.obj X))) },
   inv := { app := λ X, 𝟙 (H.obj (G.obj (F.obj X))) } }
 

--- a/category_theory/natural_transformation.lean
+++ b/category_theory/natural_transformation.lean
@@ -59,6 +59,8 @@ begin
   subst hc
 end
 
+lemma congr_app {α β : F ⟹ G} (h : α = β) (X : C) : α.app X = β.app X := by rw h
+
 /-- `vcomp α β` is the vertical compositions of natural transformations. -/
 def vcomp (α : F ⟹ G) (β : G ⟹ H) : F ⟹ H :=
 { app         := λ X, (α.app X) ≫ (β.app X),

--- a/category_theory/yoneda.lean
+++ b/category_theory/yoneda.lean
@@ -20,7 +20,7 @@ universes u₁ v₁ u₂
 variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C]
 include 𝒞
 
-def yoneda : C ⥤ ((Cᵒᵖ) ⥤ (Type v₁)) :=
+def yoneda : C ⥤ (Cᵒᵖ ⥤ Type v₁) :=
 { obj := λ X,
   { obj := λ Y : C, Y ⟶ X,
     map := λ Y Y' f g, f ≫ g,
@@ -28,7 +28,15 @@ def yoneda : C ⥤ ((Cᵒᵖ) ⥤ (Type v₁)) :=
     map_id' := begin intros X_1, ext1, dsimp at *, erw [category.id_comp] end },
   map := λ X X' f, { app := λ Y g, g ≫ f } }
 
-variables {C}
+def coyoneda : Cᵒᵖ ⥤ (C ⥤ Type v₁) :=
+{ obj := λ X : C,
+  { obj := λ Y, X ⟶ Y,
+    map := λ Y Y' f g, g ≫ f,
+    map_comp' := begin intros X_1 Y Z f g, ext1, dsimp at *, erw [category.assoc] end,
+    map_id' := begin intros X_1, ext1, dsimp at *, erw [category.comp_id] end },
+  map := λ X X' f, { app := λ Y g, f ≫ g },
+  map_comp' := begin intros X Y Z f g, ext1, ext1, dsimp at *, erw [category.assoc] end,
+  map_id' := begin intros X, ext1, ext1, dsimp at *, erw [category.id_comp] end }
 
 namespace yoneda
 @[simp] lemma obj_obj (X Y : C) : (yoneda.obj X).obj Y = (Y ⟶ X) := rfl
@@ -74,6 +82,12 @@ instance prod_category_instance_2 : category ((Cᵒᵖ) × ((Cᵒᵖ) ⥤ Type v
 category_theory.prod.{u₁ v₁ (max u₁ (v₁+1)) (max u₁ v₁)} (Cᵒᵖ) (Cᵒᵖ ⥤ Type v₁)
 
 end yoneda
+
+namespace coyoneda
+@[simp] lemma obj_obj (X Y : C) : (coyoneda.obj X).obj Y = (X ⟶ Y) := rfl
+@[simp] lemma obj_map {X' X : C} (f : X' ⟶ X) (Y : C) : (coyoneda.obj Y).map f = λ g, g ≫ f := rfl
+@[simp] lemma map_app (X : C) {Y Y' : C} (f : Y ⟶ Y') : (coyoneda.map f).app X = λ g, f ≫ g := rfl
+end coyoneda
 
 class representable (F : Cᵒᵖ ⥤ Type v₁) :=
 (X : C)


### PR DESCRIPTION
I was planning on including slightly more in this PR, but this is already pretty big so I'll cut it off here for now.

This is a heavily edited version of `limits/limits.lean` and `limits/types.lean` from Scott's #473. I took the liberty of removing some things which seemed to be unimportant and not used by anyone so far. The rest of #473 still builds against this version with minor changes (mostly renaming and reordering arguments).