### PR TITLE
feat(Ico): initial implementation of intervals in nat [WIP]

### DIFF
--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -525,7 +525,7 @@ eq.symm (prod_bij (λ x _, nat.succ x)
   (λ b h,
     have b.pred.succ = b, from nat.succ_pred_eq_of_pos $
       by simp [nat.pos_iff_ne_zero] at *; tauto,
-    ⟨nat.pred b, mem_range.2 $ nat.lt_of_succ_lt_succ (by simp [*, - range_succ] at *), this.symm⟩))
+    ⟨nat.pred b, mem_range.2 $ nat.lt_of_succ_lt_succ (by simp [*] at *), this.symm⟩))
 ... = nat.fact n : by induction n; simp [*, range_succ]
 
 end finset

--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -525,7 +525,7 @@ eq.symm (prod_bij (λ x _, nat.succ x)
   (λ b h,
     have b.pred.succ = b, from nat.succ_pred_eq_of_pos $
       by simp [nat.pos_iff_ne_zero] at *; tauto,
-    ⟨nat.pred b, mem_range.2 $ nat.lt_of_succ_lt_succ (by simp [*] at *), this.symm⟩))
+    ⟨nat.pred b, mem_range.2 $ nat.lt_of_succ_lt_succ (by simp [*, - range_succ] at *), this.symm⟩))
 ... = nat.fact n : by induction n; simp [*, range_succ]
 
 end finset

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -643,7 +643,7 @@ by dsimp [Ico]; congr; dsimp [multiset.Ico, list.Ico, multiset.range]; rw list.r
 @[simp] theorem empty (n : ℕ) : Ico n n = ∅ :=
 by dsimp [Ico]; congr; simp
 
-@[simp] theorem succ_singleton (n : ℕ) : Ico n (n+1) = singleton n :=
+@[simp] theorem succ_singleton (n : ℕ) : Ico n (n+1) = {n} :=
 by dsimp [Ico]; congr; simp
 
 lemma pred_singleton {m : ℕ} (h : m > 0) : Ico (m-1) m = {m-1} :=

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -658,6 +658,14 @@ begin
   simp,
 end
 
+lemma interval_pred {m : ℕ} (h : m > 0) : interval (m-1) m = {m-1} :=
+begin
+  dsimp [interval],
+  congr,
+  rw multiset.interval_pred h,
+  refl,
+end
+
 end interval
 
 /- useful rules for calculations with quantifiers -/

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -649,6 +649,40 @@ by dsimp [Ico]; congr; simp
 lemma pred_singleton {m : ℕ} (h : m > 0) : Ico (m-1) m = {m-1} :=
 by dsimp [Ico]; congr; rw multiset.Ico.pred_singleton h; refl
 
+@[simp] lemma filter_lt (l n m : ℕ) : (Ico n m).filter (λ x, x < l) = (Ico n (min m l)) :=
+begin
+  /- `tidy` says -/
+  ext,
+  simp,
+  fsplit,
+  intros a_1, cases a_1, cases a_1_left, fsplit, assumption,
+  swap,
+  intros a_1, cases a_1, fsplit, fsplit, assumption,
+  swap 3,
+  -- and after that it's just chasing down inequalities...
+  apply lt_min; assumption,
+  apply lt_of_lt_of_le a_1_right,
+  apply min_le_left,
+  apply lt_of_lt_of_le a_1_right,
+  apply min_le_right,
+end
+
+@[simp] lemma diff (l n m : ℕ) : (Ico n m) \ (Ico n l) = Ico (max n l) m :=
+begin
+  /- `tidy` says -/
+  ext,
+  simp,
+  fsplit,
+  intros a_1, cases a_1, cases a_1_left, fsplit, swap, assumption,
+  swap,
+  intros a_1, cases a_1, fsplit,
+  fsplit, swap, assumption,
+  -- and then some more inequalities
+  swap 3,
+  apply max_le; solve_by_elim,
+  transitivity, swap, exact a_1_left, apply le_max_left,
+  intros, transitivity, swap, exact a_1_left, apply le_max_right,
+end
 end Ico
 
 /- useful rules for calculations with quantifiers -/

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -625,48 +625,31 @@ finset.induction_on s ⟨0, empty_subset _⟩ $ λ a s ha ⟨n, hn⟩,
 
 end range
 
-/- interval -/
-section interval
+/- Ico (a closed open interval) -/
 variables {n m l : ℕ}
 
-/-- `interval n m` is the set of natural numbers `n ≤ k < m`. -/
-def interval (n m : ℕ) : finset ℕ := ⟨_, nodup_interval n m⟩
+/-- `Ico n m` is the set of natural numbers `n ≤ k < m`. -/
+def Ico (n m : ℕ) : finset ℕ := ⟨_, nodup_Ico n m⟩
 
-@[simp] theorem interval_val (n m : ℕ) : (interval n m).1 = multiset.interval n m := rfl
+namespace Ico
 
-@[simp] theorem mem_interval : l ∈ interval n m ↔ n ≤ l ∧ l < m := mem_interval
+@[simp] theorem val (n m : ℕ) : (Ico n m).1 = multiset.Ico n m := rfl
 
-@[simp] theorem interval_range (n : ℕ) : interval 0 n = range n :=
-begin
-  dsimp [interval],
-  congr,
-  dsimp [multiset.interval, list.interval, multiset.range],
-  rw list.range_eq_range'
-end
+@[simp] theorem mem : l ∈ Ico n m ↔ n ≤ l ∧ l < m := multiset.Ico.mem
 
-@[simp] theorem interval_zero (n : ℕ) : interval n n = ∅ :=
-begin
-  dsimp [interval],
-  congr,
-  simp,
-end
+@[simp] theorem Ico_range (n : ℕ) : Ico 0 n = range n :=
+by dsimp [Ico]; congr; dsimp [multiset.Ico, list.Ico, multiset.range]; rw list.range_eq_range'
 
-@[simp] theorem interval_one (n : ℕ) : interval n (n+1) = singleton n :=
-begin
-  dsimp [interval],
-  congr,
-  simp,
-end
+@[simp] theorem empty (n : ℕ) : Ico n n = ∅ :=
+by dsimp [Ico]; congr; simp
 
-lemma interval_pred {m : ℕ} (h : m > 0) : interval (m-1) m = {m-1} :=
-begin
-  dsimp [interval],
-  congr,
-  rw multiset.interval_pred h,
-  refl,
-end
+@[simp] theorem succ_singleton (n : ℕ) : Ico n (n+1) = singleton n :=
+by dsimp [Ico]; congr; simp
 
-end interval
+lemma pred_singleton {m : ℕ} (h : m > 0) : Ico (m-1) m = {m-1} :=
+by dsimp [Ico]; congr; rw multiset.Ico.pred_singleton h; refl
+
+end Ico
 
 /- useful rules for calculations with quantifiers -/
 theorem exists_mem_empty_iff (p : α → Prop) : (∃ x, x ∈ (∅ : finset α) ∧ p x) ↔ false :=

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -625,6 +625,41 @@ finset.induction_on s ⟨0, empty_subset _⟩ $ λ a s ha ⟨n, hn⟩,
 
 end range
 
+/- interval -/
+section interval
+variables {n m l : ℕ}
+
+/-- `interval n m` is the set of natural numbers `n ≤ k < m`. -/
+def interval (n m : ℕ) : finset ℕ := ⟨_, nodup_interval n m⟩
+
+@[simp] theorem interval_val (n m : ℕ) : (interval n m).1 = multiset.interval n m := rfl
+
+@[simp] theorem mem_interval : l ∈ interval n m ↔ n ≤ l ∧ l < m := mem_interval
+
+@[simp] theorem interval_range (n : ℕ) : interval 0 n = range n :=
+begin
+  dsimp [interval],
+  congr,
+  dsimp [multiset.interval, list.interval, multiset.range],
+  rw list.range_eq_range'
+end
+
+@[simp] theorem interval_zero (n : ℕ) : interval n n = ∅ :=
+begin
+  dsimp [interval],
+  congr,
+  simp,
+end
+
+@[simp] theorem interval_one (n : ℕ) : interval n (n+1) = singleton n :=
+begin
+  dsimp [interval],
+  congr,
+  simp,
+end
+
+end interval
+
 /- useful rules for calculations with quantifiers -/
 theorem exists_mem_empty_iff (p : α → Prop) : (∃ x, x ∈ (∅ : finset α) ∧ p x) ↔ false :=
 by simp only [not_mem_empty, false_and, exists_false]

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -649,11 +649,18 @@ by dsimp [Ico]; congr; simp
 lemma pred_singleton {m : ℕ} (h : m > 0) : Ico (m-1) m = {m-1} :=
 by dsimp [Ico]; congr; rw multiset.Ico.pred_singleton h; refl
 
+theorem eq_empty_of_le {n m : ℕ} (h : n ≥ m) : Ico n m = ∅ :=
+by dsimp [Ico]; congr; rw multiset.Ico.eq_empty_of_le h; simp
+
 @[simp] lemma filter_lt (l n m : ℕ) : (Ico n l).filter (λ x, x < m) = Ico n (min m l) :=
 by dsimp [Ico, filter]; congr; simp
 
 @[simp] lemma filter_ge (l n m : ℕ) : (Ico n l).filter (λ x, x ≥ m) = Ico (max n m) l :=
 by dsimp [Ico, filter]; congr; simp
+
+-- Statements about `diff`. 
+-- (These are less useful on the `list` and `multiset` versions of `Ico`, so
+-- are proved here.)
 
 @[simp] lemma diff_left (l n m : ℕ) : (Ico n m) \ (Ico n l) = Ico (max n l) m :=
 begin
@@ -679,7 +686,7 @@ begin
   assumption
 end
 
-@[simp] lemma diff_right (l n m : ℕ) (h : l ≤ m): (Ico n m) \ (Ico l m) = Ico n l :=
+@[simp] lemma diff_right (l n m : ℕ) (h : l ≤ m) : (Ico n m) \ (Ico l m) = Ico n l :=
 begin
   /- `tidy` says -/
   ext1,
@@ -696,6 +703,9 @@ begin
   show a < m, sorry,
   show a < l, sorry
 end
+
+-- One could also prove
+-- lemma diff (k l n m : ℕ) : (Ico k l) \ (Ico n m) = (Ico k (min k n)) ∪ (Ico (max k m) l) := sorry
 
 end Ico
 

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -7,7 +7,7 @@ Finite sets.
 -/
 import logic.embedding order.boolean_algebra algebra.order_functions
   data.multiset data.sigma.basic data.set.lattice
-import tactic.tidy
+
 open multiset subtype nat lattice
 
 variables {α : Type*} {β : Type*} {γ : Type*}

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -629,7 +629,7 @@ end range
 variables {n m l : ℕ}
 
 /-- `Ico n m` is the set of natural numbers `n ≤ k < m`. -/
-def Ico (n m : ℕ) : finset ℕ := ⟨_, nodup_Ico n m⟩
+def Ico (n m : ℕ) : finset ℕ := ⟨_, Ico.nodup n m⟩
 
 namespace Ico
 
@@ -649,46 +649,11 @@ by dsimp [Ico]; congr; simp
 lemma pred_singleton {m : ℕ} (h : m > 0) : Ico (m-1) m = {m-1} :=
 by dsimp [Ico]; congr; rw multiset.Ico.pred_singleton h; refl
 
-@[simp] lemma filter_lt (l n m : ℕ) : (Ico n m).filter (λ x, x < l) = (Ico n (min m l)) :=
-begin
-  /- `tidy` says -/
-  ext1,
-  simp at *,
-  fsplit,
-  intros a_1,
-  cases a_1,
-  cases a_1_left,
-  fsplit, assumption,
-  fsplit, assumption,
-  assumption ,
-  intros a_1,
-  cases a_1,
-  cases a_1_right,
-  fsplit,
-  fsplit; assumption,
-  assumption
-end
+@[simp] lemma filter_lt (l n m : ℕ) : (Ico n l).filter (λ x, x < m) = Ico n (min m l) :=
+by dsimp [Ico, filter]; congr; simp
 
-@[simp] lemma filter_ge (l n m : ℕ) : (Ico n m).filter (λ x, x ≥ l) = (Ico (max n l) m) :=
-begin
-  /- `tidy` says -/
-  ext1,
-  dsimp at *,
-  simp at *,
-  fsplit,
-  intros a_1,
-  cases a_1,
-  cases a_1_left,
-  fsplit,
-  fsplit; assumption,
-  assumption,
-  intros a_1,
-  cases a_1,
-  cases a_1_left,
-  fsplit,
-  fsplit; assumption,
-  assumption
-end
+@[simp] lemma filter_ge (l n m : ℕ) : (Ico n l).filter (λ x, x ≥ m) = Ico (max n m) l :=
+by dsimp [Ico, filter]; congr; simp
 
 @[simp] lemma diff_left (l n m : ℕ) : (Ico n m) \ (Ico n l) = Ico (max n l) m :=
 begin

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -7,7 +7,7 @@ Finite sets.
 -/
 import logic.embedding order.boolean_algebra algebra.order_functions
   data.multiset data.sigma.basic data.set.lattice
-
+import tactic.tidy
 open multiset subtype nat lattice
 
 variables {α : Type*} {β : Type*} {γ : Type*}
@@ -652,37 +652,86 @@ by dsimp [Ico]; congr; rw multiset.Ico.pred_singleton h; refl
 @[simp] lemma filter_lt (l n m : ℕ) : (Ico n m).filter (λ x, x < l) = (Ico n (min m l)) :=
 begin
   /- `tidy` says -/
-  ext,
-  simp,
+  ext1,
+  simp at *,
+  fsplit,
+  intros a_1,
+  cases a_1,
+  cases a_1_left,
+  fsplit, assumption,
+  fsplit, assumption,
+  assumption ,
+  intros a_1,
+  cases a_1,
+  cases a_1_right,
+  fsplit,
+  fsplit; assumption,
+  assumption
+end
+
+@[simp] lemma filter_ge (l n m : ℕ) : (Ico n m).filter (λ x, x ≥ l) = (Ico (max n l) m) :=
+begin
+  /- `tidy` says -/
+  ext1,
+  dsimp at *,
+  simp at *,
+  fsplit,
+  intros a_1,
+  cases a_1,
+  cases a_1_left,
+  fsplit,
+  fsplit; assumption,
+  assumption,
+  intros a_1,
+  cases a_1,
+  cases a_1_left,
+  fsplit,
+  fsplit; assumption,
+  assumption
+end
+
+@[simp] lemma diff_left (l n m : ℕ) : (Ico n m) \ (Ico n l) = Ico (max n l) m :=
+begin
+  /- `tidy` says -/
+  ext1,
+  dsimp at *,
+  simp at *,
+  fsplit,
+  intros a_1,
+  cases a_1,
+  cases a_1_left,
+  fsplit,
+  fsplit,
+  assumption,
+  solve_by_elim,
+  assumption,
+  intros a_1,
+  cases a_1,
+  cases a_1_left,
+  fsplit,
+  fsplit; assumption,
+  intros a_1,
+  assumption
+end
+
+@[simp] lemma diff_right (l n m : ℕ) (h : l ≤ m): (Ico n m) \ (Ico l m) = Ico n l :=
+begin
+  /- `tidy` says -/
+  ext1,
+  dsimp at *,
+  simp at *,
   fsplit,
   intros a_1, cases a_1, cases a_1_left, fsplit, assumption,
   swap,
-  intros a_1, cases a_1, fsplit, fsplit, assumption,
-  swap 3,
-  -- and after that it's just chasing down inequalities...
-  apply lt_min; assumption,
-  apply lt_of_lt_of_le a_1_right,
-  apply min_le_left,
-  apply lt_of_lt_of_le a_1_right,
-  apply min_le_right,
+  intros a_1, cases a_1, fsplit, fsplit, assumption ,
+  swap 2,
+  intros a_1,
+  -- and then some easy logic puzzles, that should be automatic
+  show m ≤ a, sorry,
+  show a < m, sorry,
+  show a < l, sorry
 end
 
-@[simp] lemma diff (l n m : ℕ) : (Ico n m) \ (Ico n l) = Ico (max n l) m :=
-begin
-  /- `tidy` says -/
-  ext,
-  simp,
-  fsplit,
-  intros a_1, cases a_1, cases a_1_left, fsplit, swap, assumption,
-  swap,
-  intros a_1, cases a_1, fsplit,
-  fsplit, swap, assumption,
-  -- and then some more inequalities
-  swap 3,
-  apply max_le; solve_by_elim,
-  transitivity, swap, exact a_1_left, apply le_max_left,
-  intros, transitivity, swap, exact a_1_left, apply le_max_right,
-end
 end Ico
 
 /- useful rules for calculations with quantifiers -/

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -4062,7 +4062,7 @@ by dsimp [Ico]; simp [mem_condition]
 @[simp] theorem not_mem_top {n m : ℕ} : m ∉ Ico n m :=
 by simp; intros; refl
 
-@[simp] lemma append {n m l : ℕ} (h₁ : m ≥ n) (h₂ : l ≥ m) : Ico n m ++ Ico m l = Ico n l :=
+lemma append_consecutive {n m l : ℕ} (h₁ : m ≥ n) (h₂ : l ≥ m) : Ico n m ++ Ico m l = Ico n l :=
 begin
   dsimp [Ico],
   convert range'_append _ _ _,
@@ -4072,29 +4072,34 @@ begin
   exact h₂
 end
 
-@[simp] lemma filter_lt_top (n m : ℕ) : (Ico n m).filter (λ x, x < m) = Ico n m :=
+lemma filter_lt_eq_self_of_ge_top (k l m : ℕ) (h : m ≥ l): (Ico k l).filter (λ x, x < m) = Ico k l :=
 begin
   rw filter_eq_self.mpr,
   intros a H,
   simp at H,
-  exact H.right
-end
-@[simp] lemma filter_lt_bot (n m : ℕ) : (Ico n m).filter (λ x, x < n) = [] :=
-begin
-  rw filter_eq_nil.mpr,
-  intros a H,
-  simp at H,
-  simp,
-  exact H.left,
+  exact lt_of_lt_of_le H.right h,
 end
 
+@[simp] lemma filter_lt_top_eq_self (n m : ℕ) : (Ico n m).filter (λ x, x < m) = Ico n m :=
+filter_lt_eq_self_of_ge_top n m m (sorry)
+
+lemma filter_lt_eq_nil_of_le_bot (k l m : ℕ) (h : m ≤ k): (Ico k l).filter (λ x, x < m) = [] :=
+begin
+  sorry
+end
+
+@[simp] lemma filter_lt_bot_eq_nil (n m : ℕ) : (Ico n m).filter (λ x, x < n) = [] :=
+filter_lt_eq_nil_of_le_bot n m n sorry
+
+-- TODO fix ordering and naming of parameters
 @[simp] lemma filter_lt (l n m : ℕ) : (Ico n l).filter (λ x, x < m) = Ico n (min m l) :=
 begin
   by_cases h₁ : m ≥ n,
   { by_cases h₂ : l ≥ m,
-    { rw ← append h₁ h₂,
+    { rw ← append_consecutive h₁ h₂,
       simp [min_eq_left h₂] },
-    { rw filter_eq_self.mpr,
+    { 
+      rw filter_eq_self.mpr,
       simp at h₂,
       rw min_eq_right (le_of_lt h₂),
       intros a H,
@@ -4110,14 +4115,14 @@ begin
     exact le_trans (le_of_lt h₁) H.left }
 end
 
-@[simp] lemma filter_ge_top (n m : ℕ) : (Ico n m).filter (λ x, x ≥ n) = Ico n m :=
+@[simp] lemma filter_ge_top_eq_self (n m : ℕ) : (Ico n m).filter (λ x, x ≥ n) = Ico n m :=
 begin
   rw filter_eq_self.mpr,
   intros a H,
   simp at H,
   exact H.left
 end
-@[simp] lemma filter_ge_bot (n m : ℕ) : (Ico n m).filter (λ x, x ≥ m) = [] :=
+@[simp] lemma filter_ge_bot_eq_nil (n m : ℕ) : (Ico n m).filter (λ x, x ≥ m) = [] :=
 begin
   rw filter_eq_nil.mpr,
   intros a H,
@@ -4130,7 +4135,7 @@ end
 begin
   by_cases h₁ : m ≥ n,
   { by_cases h₂ : l ≥ m,
-    { rw ← append h₁ h₂,
+    { rw ← append_consecutive h₁ h₂,
       simp [max_eq_right h₁] },
     { simp at h₂,
       rw filter_eq_nil.mpr,

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -4039,7 +4039,7 @@ theorem pred_singleton {m : ℕ} (h : m > 0) : Ico (m-1) m = [m-1] :=
 by dsimp [Ico]; rw nat.sub_sub_self h; simp
 
 -- Someone put me out of my misery (no human suffering should be needed to prove this):
-@[simp] private lemma mem_condition {n m l : ℕ} : n ≤ l ∧ l < n + (m - n) ↔ n ≤ l ∧ l < m :=
+private lemma mem_condition {n m l : ℕ} : n ≤ l ∧ l < n + (m - n) ↔ n ≤ l ∧ l < m :=
 begin
   by_cases n ≤ m,
   { rw add_sub_of_le h },
@@ -4056,12 +4056,10 @@ begin
 end
 
 @[simp] theorem mem {n m l : ℕ} : l ∈ Ico n m ↔ n ≤ l ∧ l < m :=
-by dsimp [Ico]; simp
+by dsimp [Ico]; simp [mem_condition]
 
--- TODO implement these, amongst maybe many others!
--- theorem sublist {n m n' m' : ℕ} : Ico n m <+ Ico n' m' ↔ n' ≤ n ∧ m ≤ m' :=
--- theorem subset {n m n' m' : ℕ} : Ico n m ⊆ Ico n' m' ↔ n' ≤ n ∧ m ≤ m' :=
--- @[simp] theorem not_mem_top {n m : ℕ} : m ∉ Ico n m :=
+@[simp] theorem not_mem_top {n m : ℕ} : m ∉ Ico n m :=
+by simp; intros; refl
 end Ico
 
 @[simp] theorem enum_from_map_fst : ∀ n (l : list α),

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -4014,6 +4014,43 @@ theorem reverse_range' : ∀ s n : ℕ,
     nil_append, eq_self_iff_true, true_and, map_map]
   using reverse_range' s n
 
+def interval (n m : ℕ) : list ℕ := range' n (m - n)
+
+@[simp] theorem length_interval (n m : ℕ) : length (interval n m) = m - n :=
+by dsimp [interval]; simp only [length_range']
+
+theorem pairwise_lt_interval (n m : ℕ) : pairwise (<) (interval n m) :=
+by dsimp [interval]; simp only [pairwise_lt_range']
+
+theorem nodup_interval (n m : ℕ) : nodup (interval n m) :=
+by dsimp [interval]; simp only [nodup_range']
+
+theorem interval_sublist {n m n' m' : ℕ} : interval n m <+ interval n' m' ↔ n' ≤ n ∧ m ≤ m' :=
+by dsimp [interval]; sorry
+
+theorem interval_subset {n m n' m' : ℕ} : interval n m ⊆ interval n' m' ↔ n' ≤ n ∧ m ≤ m' :=
+by sorry
+
+@[simp] theorem mem_interval {n m l : ℕ} : l ∈ interval n m ↔ n ≤ l ∧ l < m :=
+by dsimp [interval]; simp; sorry
+
+local attribute [simp] nat.sub_self -- Why is this not alway `[simp]`??
+
+@[simp] theorem interval_zero {n : ℕ} : interval n n = [] :=
+begin
+  dsimp [interval],
+  simp,
+end
+
+@[simp] theorem interval_one {n : ℕ} : interval n (n+1) = [n] :=
+begin
+  dsimp [interval],
+  simp [nat.add_sub_cancel_left], -- Similarly, why isn't this `[simp]`?
+end
+
+@[simp] theorem not_mem_interval_top {n m : ℕ} : n ∉ interval n m :=
+mt mem_interval.1 $ sorry
+
 @[simp] theorem enum_from_map_fst : ∀ n (l : list α),
   map prod.fst (enum_from n l) = range' n l.length
 | n []       := rfl

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -4014,41 +4014,32 @@ theorem reverse_range' : ∀ s n : ℕ,
     nil_append, eq_self_iff_true, true_and, map_map]
   using reverse_range' s n
 
-def interval (n m : ℕ) : list ℕ := range' n (m - n)
+def Ico (n m : ℕ) : list ℕ := range' n (m - n)
 
-@[simp] theorem length_interval (n m : ℕ) : length (interval n m) = m - n :=
-by dsimp [interval]; simp only [length_range']
+namespace Ico
 
-theorem pairwise_lt_interval (n m : ℕ) : pairwise (<) (interval n m) :=
-by dsimp [interval]; simp only [pairwise_lt_range']
+@[simp] theorem length (n m : ℕ) : length (Ico n m) = m - n :=
+by dsimp [Ico]; simp only [length_range']
 
-theorem nodup_interval (n m : ℕ) : nodup (interval n m) :=
-by dsimp [interval]; simp only [nodup_range']
+theorem pairwise_lt (n m : ℕ) : pairwise (<) (Ico n m) :=
+by dsimp [Ico]; simp only [pairwise_lt_range']
 
-local attribute [simp] nat.sub_self -- Why is this not alway `[simp]`??
+theorem nodup (n m : ℕ) : nodup (Ico n m) :=
+by dsimp [Ico]; simp only [nodup_range']
 
-@[simp] theorem interval_zero {n : ℕ} : interval n n = [] :=
-begin
-  dsimp [interval],
-  simp,
-end
+local attribute [simp] nat.sub_self
 
-@[simp] theorem interval_one {n : ℕ} : interval n (n+1) = [n] :=
-begin
-  dsimp [interval],
-  simp [nat.add_sub_cancel_left], -- Similarly, why isn't this `[simp]`?
-end
+@[simp] theorem self_empty {n : ℕ} : Ico n n = [] :=
+by dsimp [Ico]; simp
 
-theorem interval_pred {m : ℕ} (h : m > 0) : interval (m-1) m = [m-1] :=
-begin
-  dsimp [interval],
-  rw nat.sub_sub_self,
-  { simp },
-  { assumption },
-end
+@[simp] theorem succ_singleton {n : ℕ} : Ico n (n+1) = [n] :=
+by dsimp [Ico]; simp [nat.add_sub_cancel_left]
+
+theorem pred_singleton {m : ℕ} (h : m > 0) : Ico (m-1) m = [m-1] :=
+by dsimp [Ico]; rw nat.sub_sub_self h; simp
 
 -- Someone put me out of my misery (no human suffering should be needed to prove this):
-@[simp] private lemma mem_interval_condition {n m l : ℕ} : n ≤ l ∧ l < n + (m - n) ↔ n ≤ l ∧ l < m :=
+@[simp] private lemma mem_condition {n m l : ℕ} : n ≤ l ∧ l < n + (m - n) ↔ n ≤ l ∧ l < m :=
 begin
   by_cases n ≤ m,
   { rw add_sub_of_le h },
@@ -4064,15 +4055,14 @@ begin
       split, assumption, transitivity; assumption } }
 end
 
-@[simp] theorem mem_interval {n m l : ℕ} : l ∈ interval n m ↔ n ≤ l ∧ l < m :=
-begin
-  dsimp [interval],
-  simp
-end
--- TODO implement these
--- theorem interval_sublist {n m n' m' : ℕ} : interval n m <+ interval n' m' ↔ n' ≤ n ∧ m ≤ m' :=
--- theorem interval_subset {n m n' m' : ℕ} : interval n m ⊆ interval n' m' ↔ n' ≤ n ∧ m ≤ m' :=
--- @[simp] theorem not_mem_interval_top {n m : ℕ} : n ∉ interval n m :=
+@[simp] theorem mem {n m l : ℕ} : l ∈ Ico n m ↔ n ≤ l ∧ l < m :=
+by dsimp [Ico]; simp
+
+-- TODO implement these, amongst maybe many others!
+-- theorem sublist {n m n' m' : ℕ} : Ico n m <+ Ico n' m' ↔ n' ≤ n ∧ m ≤ m' :=
+-- theorem subset {n m n' m' : ℕ} : Ico n m ⊆ Ico n' m' ↔ n' ≤ n ∧ m ≤ m' :=
+-- @[simp] theorem not_mem_top {n m : ℕ} : m ∉ Ico n m :=
+end Ico
 
 @[simp] theorem enum_from_map_fst : ∀ n (l : list α),
   map prod.fst (enum_from n l) = range' n l.length

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -3316,9 +3316,9 @@ end
 
 lemma forall_of_pairwise (H : symmetric R) {l : list α}
    (hl : pairwise R l) : (∀a∈l, ∀b∈l, a ≠ b → R a b) :=
-forall_of_forall_of_pairwise 
-  (λ a b h hne, H (h hne.symm)) 
-  (λ _ _ h, (h rfl).elim) 
+forall_of_forall_of_pairwise
+  (λ a b h hne, H (h hne.symm))
+  (λ _ _ h, (h rfl).elim)
   (pairwise.imp (λ _ _ h _, h) hl)
 
 theorem pairwise_singleton (R) (a : α) : pairwise R [a] :=
@@ -4041,18 +4041,12 @@ by dsimp [Ico]; rw nat.sub_sub_self h; simp
 -- Someone put me out of my misery (no human suffering should be needed to prove this):
 private lemma mem_condition {n m l : ℕ} : n ≤ l ∧ l < n + (m - n) ↔ n ≤ l ∧ l < m :=
 begin
-  by_cases n ≤ m,
-  { rw add_sub_of_le h },
-  { simp at h,
-    rw sub_eq_zero_of_le (le_of_lt h),
-    simp,
-    split,
-    { rintro ⟨a, b⟩,
-      exfalso,
-      have h := lt_of_lt_of_le b a,
-      exact lt_irrefl _ h, },
-    { rintro ⟨a, b⟩,
-      split, assumption, transitivity; assumption } }
+  cases le_total n m with hnm hmn,
+  { rw [nat.add_sub_of_le hnm] },
+  { rw [nat.sub_eq_zero_of_le hmn, add_zero],
+    exact and_congr_right (assume hnl, iff.intro
+      (assume hln, (not_le_of_gt hln hnl).elim)
+      (assume hlm, lt_of_lt_of_le hlm hmn)) }
 end
 
 @[simp] theorem mem {n m l : ℕ} : l ∈ Ico n m ↔ n ≤ l ∧ l < m :=
@@ -4060,6 +4054,16 @@ by dsimp [Ico]; simp [mem_condition]
 
 @[simp] theorem not_mem_top {n m : ℕ} : m ∉ Ico n m :=
 by simp; intros; refl
+
+-- @[simp] lemma filter_lt (l n m : ℕ) : (Ico n m).filter (λ x, x < l) = (Ico n (min m l)) :=
+-- -- This seems like a real pain in the neck.
+-- -- I want to first prove both lists are strictly ordered,
+-- -- and then have it be enough that they have the same elements (as finsets).
+-- sorry
+
+-- @[simp] lemma filter_ge (l n m : ℕ) : (Ico n m).filter (λ x, x ≥ l) = (Ico (max n l) m) :=
+-- sorry
+
 end Ico
 
 @[simp] theorem enum_from_map_fst : ∀ n (l : list α),

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -4025,15 +4025,6 @@ by dsimp [interval]; simp only [pairwise_lt_range']
 theorem nodup_interval (n m : ℕ) : nodup (interval n m) :=
 by dsimp [interval]; simp only [nodup_range']
 
-theorem interval_sublist {n m n' m' : ℕ} : interval n m <+ interval n' m' ↔ n' ≤ n ∧ m ≤ m' :=
-by dsimp [interval]; sorry
-
-theorem interval_subset {n m n' m' : ℕ} : interval n m ⊆ interval n' m' ↔ n' ≤ n ∧ m ≤ m' :=
-by sorry
-
-@[simp] theorem mem_interval {n m l : ℕ} : l ∈ interval n m ↔ n ≤ l ∧ l < m :=
-by dsimp [interval]; simp; sorry
-
 local attribute [simp] nat.sub_self -- Why is this not alway `[simp]`??
 
 @[simp] theorem interval_zero {n : ℕ} : interval n n = [] :=
@@ -4048,8 +4039,40 @@ begin
   simp [nat.add_sub_cancel_left], -- Similarly, why isn't this `[simp]`?
 end
 
-@[simp] theorem not_mem_interval_top {n m : ℕ} : n ∉ interval n m :=
-mt mem_interval.1 $ sorry
+theorem interval_pred {m : ℕ} (h : m > 0) : interval (m-1) m = [m-1] :=
+begin
+  dsimp [interval],
+  rw nat.sub_sub_self,
+  { simp },
+  { assumption },
+end
+
+-- Someone put me out of my misery (no human suffering should be needed to prove this):
+@[simp] private lemma mem_interval_condition {n m l : ℕ} : n ≤ l ∧ l < n + (m - n) ↔ n ≤ l ∧ l < m :=
+begin
+  by_cases n ≤ m,
+  { rw add_sub_of_le h },
+  { simp at h,
+    rw sub_eq_zero_of_le (le_of_lt h),
+    simp,
+    split,
+    { rintro ⟨a, b⟩,
+      exfalso,
+      have h := lt_of_lt_of_le b a,
+      exact lt_irrefl _ h, },
+    { rintro ⟨a, b⟩,
+      split, assumption, transitivity; assumption } }
+end
+
+@[simp] theorem mem_interval {n m l : ℕ} : l ∈ interval n m ↔ n ≤ l ∧ l < m :=
+begin
+  dsimp [interval],
+  simp
+end
+-- TODO implement these
+-- theorem interval_sublist {n m n' m' : ℕ} : interval n m <+ interval n' m' ↔ n' ≤ n ∧ m ≤ m' :=
+-- theorem interval_subset {n m n' m' : ℕ} : interval n m ⊆ interval n' m' ↔ n' ≤ n ∧ m ≤ m' :=
+-- @[simp] theorem not_mem_interval_top {n m : ℕ} : n ∉ interval n m :=
 
 @[simp] theorem enum_from_map_fst : ∀ n (l : list α),
   map prod.fst (enum_from n l) = range' n l.length

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -4038,10 +4038,10 @@ by dsimp [Ico]; simp [nat.add_sub_cancel_left]
 theorem pred_singleton {m : ℕ} (h : m > 0) : Ico (m-1) m = [m-1] :=
 by dsimp [Ico]; rw nat.sub_sub_self h; simp
 
-theorem gt_nil {n m : ℕ} (h : n > m) : Ico n m = [] :=
+theorem eq_nil_of_le {n m : ℕ} (h : n ≥ m) : Ico n m = [] :=
 begin
   dsimp [Ico],
-  rw nat.sub_eq_zero_of_le (le_of_lt h),
+  rw nat.sub_eq_zero_of_le h,
   simp,
 end
 
@@ -4102,9 +4102,9 @@ begin
       cases H,
       transitivity; assumption } },
   { rw filter_eq_nil.mpr,
-    rw gt_nil,
+    rw eq_nil_of_le,
     simp at h₁,
-    exact gt_of_gt_of_ge h₁ (min_le_left _ _),
+    exact le_of_lt (gt_of_gt_of_ge h₁ (min_le_left _ _)),
     intros a H,
     simp at *,
     exact le_trans (le_of_lt h₁) H.left }
@@ -4134,8 +4134,8 @@ begin
       simp [max_eq_right h₁] },
     { simp at h₂,
       rw filter_eq_nil.mpr,
-      rw gt_nil,
-      exact gt_of_ge_of_gt (le_max_right _ _) h₂,
+      rw eq_nil_of_le,
+      exact le_of_lt (gt_of_ge_of_gt (le_max_right _ _) h₂),
       intros a H,
       simp at *,
       cases H,

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -501,29 +501,6 @@ theorem range_subset {m n : ℕ} : range m ⊆ range n ↔ m ≤ n := range_subs
 
 @[simp] theorem not_mem_range_self {n : ℕ} : n ∉ range n := not_mem_range_self
 
-/- Ico -/
-
-/-- `Ico n m` is the multiset lifted from the list `Ico n m`,
-  that is, the set `{n, n+1, ..., m-1}`. -/
-def Ico (n m : ℕ) : multiset ℕ := Ico n m
-
-namespace Ico
-
-@[simp] theorem mem {n m l : ℕ} : l ∈ Ico n m ↔ n ≤ l ∧ l < m := list.Ico.mem
-
-@[simp] theorem Ico_range (n : ℕ) : Ico 0 n = range n :=
-by dsimp [Ico]; congr; dsimp [list.Ico]; rw list.range_eq_range'
-
-@[simp] theorem empty (n : ℕ) : Ico n n = ∅ :=
-by dsimp [Ico]; congr; simp
-
-@[simp] theorem succ_singleton (n : ℕ) : Ico n (n+1) = singleton n :=
-by dsimp [Ico]; congr; simp
-
-lemma pred_singleton {m : ℕ} (h : m > 0) : Ico (m-1) m = {m-1} :=
-by dsimp [Ico]; congr; rw list.Ico.pred_singleton h
-end Ico
-
 /- erase -/
 section erase
 variables [decidable_eq α] {s t : multiset α} {a b : α}
@@ -2228,8 +2205,6 @@ quot.induction_on s $ λ l, nodup_filter_map H
 
 theorem nodup_range (n : ℕ) : nodup (range n) := nodup_range _
 
-theorem nodup_Ico (n m : ℕ) : nodup (Ico n m) := Ico.nodup _ _
-
 theorem nodup_inter_left [decidable_eq α] {s : multiset α} (t) : nodup s → nodup (s ∩ t) :=
 nodup_of_le $ inter_le_left _ _
 
@@ -2980,5 +2955,37 @@ lemma choose_mem (hp : ∃! a, a ∈ l ∧ p a) : choose p l hp ∈ l := (choose
 lemma choose_property (hp : ∃! a, a ∈ l ∧ p a) : p (choose p l hp) := (choose_spec _ _ _).2
 
 end choose
+
+/- Ico -/
+
+/-- `Ico n m` is the multiset lifted from the list `Ico n m`,
+  that is, the set `{n, n+1, ..., m-1}`. -/
+def Ico (n m : ℕ) : multiset ℕ := Ico n m
+
+namespace Ico
+
+@[simp] theorem mem {n m l : ℕ} : l ∈ Ico n m ↔ n ≤ l ∧ l < m := list.Ico.mem
+
+@[simp] theorem Ico_range (n : ℕ) : Ico 0 n = range n :=
+by dsimp [Ico]; congr; dsimp [list.Ico]; rw list.range_eq_range'
+
+@[simp] theorem empty (n : ℕ) : Ico n n = ∅ :=
+by dsimp [Ico]; congr; simp
+
+@[simp] theorem succ_singleton (n : ℕ) : Ico n (n+1) = singleton n :=
+by dsimp [Ico]; congr; simp
+
+lemma pred_singleton {m : ℕ} (h : m > 0) : Ico (m-1) m = {m-1} :=
+by dsimp [Ico]; congr; rw list.Ico.pred_singleton h
+
+theorem nodup (n m : ℕ) : nodup (Ico n m) := Ico.nodup _ _
+
+@[simp] lemma filter_lt (l n m : ℕ) : (Ico n l).filter (λ x, x < m) = Ico n (min m l) :=
+by dsimp [Ico]; simp
+
+@[simp] lemma filter_ge (l n m : ℕ) : (Ico n l).filter (λ x, x ≥ m) = Ico (max n m) l :=
+by dsimp [Ico]; simp
+
+end Ico
 
 end multiset

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -2228,7 +2228,7 @@ quot.induction_on s $ λ l, nodup_filter_map H
 
 theorem nodup_range (n : ℕ) : nodup (range n) := nodup_range _
 
-theorem nodup_Ico (n m : ℕ) : nodup (Ico n m) := nodup_Ico _ _
+theorem nodup_Ico (n m : ℕ) : nodup (Ico n m) := Ico.nodup _ _
 
 theorem nodup_inter_left [decidable_eq α] {s : multiset α} (t) : nodup s → nodup (s ∩ t) :=
 nodup_of_le $ inter_le_left _ _

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -532,6 +532,13 @@ begin
   simp,
 end
 
+lemma interval_pred {m : ℕ} (h : m > 0) : interval (m-1) m = {m-1} :=
+begin
+  dsimp [interval],
+  congr,
+  rw list.interval_pred h,
+end
+
 /- erase -/
 section erase
 variables [decidable_eq α] {s t : multiset α} {a b : α}

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -501,43 +501,28 @@ theorem range_subset {m n : ℕ} : range m ⊆ range n ↔ m ≤ n := range_subs
 
 @[simp] theorem not_mem_range_self {n : ℕ} : n ∉ range n := not_mem_range_self
 
-/- interval -/
+/- Ico -/
 
-/-- `interval n m` is the multiset lifted from the list `interval n m`,
+/-- `Ico n m` is the multiset lifted from the list `Ico n m`,
   that is, the set `{n, n+1, ..., m-1}`. -/
-def interval (n m : ℕ) : multiset ℕ := interval n m
+def Ico (n m : ℕ) : multiset ℕ := Ico n m
 
--- TODO all the relevant lemmas
-@[simp] theorem mem_interval {n m l : ℕ} : l ∈ interval n m ↔ n ≤ l ∧ l < m := mem_interval
+namespace Ico
 
-@[simp] theorem interval_range (n : ℕ) : interval 0 n = range n :=
-begin
-  dsimp [interval],
-  congr,
-  dsimp [list.interval],
-  rw list.range_eq_range'
-end
+@[simp] theorem mem {n m l : ℕ} : l ∈ Ico n m ↔ n ≤ l ∧ l < m := list.Ico.mem
 
-@[simp] theorem interval_zero (n : ℕ) : interval n n = ∅ :=
-begin
-  dsimp [interval],
-  congr,
-  simp,
-end
+@[simp] theorem Ico_range (n : ℕ) : Ico 0 n = range n :=
+by dsimp [Ico]; congr; dsimp [list.Ico]; rw list.range_eq_range'
 
-@[simp] theorem interval_one (n : ℕ) : interval n (n+1) = singleton n :=
-begin
-  dsimp [interval],
-  congr,
-  simp,
-end
+@[simp] theorem empty (n : ℕ) : Ico n n = ∅ :=
+by dsimp [Ico]; congr; simp
 
-lemma interval_pred {m : ℕ} (h : m > 0) : interval (m-1) m = {m-1} :=
-begin
-  dsimp [interval],
-  congr,
-  rw list.interval_pred h,
-end
+@[simp] theorem succ_singleton (n : ℕ) : Ico n (n+1) = singleton n :=
+by dsimp [Ico]; congr; simp
+
+lemma pred_singleton {m : ℕ} (h : m > 0) : Ico (m-1) m = {m-1} :=
+by dsimp [Ico]; congr; rw list.Ico.pred_singleton h
+end Ico
 
 /- erase -/
 section erase
@@ -2243,7 +2228,7 @@ quot.induction_on s $ λ l, nodup_filter_map H
 
 theorem nodup_range (n : ℕ) : nodup (range n) := nodup_range _
 
-theorem nodup_interval (n m : ℕ) : nodup (interval n m) := nodup_interval _ _
+theorem nodup_Ico (n m : ℕ) : nodup (Ico n m) := nodup_Ico _ _
 
 theorem nodup_inter_left [decidable_eq α] {s : multiset α} (t) : nodup s → nodup (s ∩ t) :=
 nodup_of_le $ inter_le_left _ _

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -2972,7 +2972,7 @@ by dsimp [Ico]; congr; dsimp [list.Ico]; rw list.range_eq_range'
 @[simp] theorem empty (n : ℕ) : Ico n n = ∅ :=
 by dsimp [Ico]; congr; simp
 
-@[simp] theorem succ_singleton (n : ℕ) : Ico n (n+1) = singleton n :=
+@[simp] theorem succ_singleton (n : ℕ) : Ico n (n+1) = {n} :=
 by dsimp [Ico]; congr; simp
 
 lemma pred_singleton {m : ℕ} (h : m > 0) : Ico (m-1) m = {m-1} :=

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -501,6 +501,36 @@ theorem range_subset {m n : ℕ} : range m ⊆ range n ↔ m ≤ n := range_subs
 
 @[simp] theorem not_mem_range_self {n : ℕ} : n ∉ range n := not_mem_range_self
 
+/- interval -/
+
+/-- `interval n m` is the multiset lifted from the list `interval n m`,
+  that is, the set `{n, n+1, ..., m-1}`. -/
+def interval (n m : ℕ) : multiset ℕ := interval n m
+
+-- TODO all the relevant lemmas
+@[simp] theorem mem_interval {n m l : ℕ} : l ∈ interval n m ↔ n ≤ l ∧ l < m := mem_interval
+
+@[simp] theorem interval_range (n : ℕ) : interval 0 n = range n :=
+begin
+  dsimp [interval],
+  congr,
+  dsimp [list.interval],
+  rw list.range_eq_range'
+end
+
+@[simp] theorem interval_zero (n : ℕ) : interval n n = ∅ :=
+begin
+  dsimp [interval],
+  congr,
+  simp,
+end
+
+@[simp] theorem interval_one (n : ℕ) : interval n (n+1) = singleton n :=
+begin
+  dsimp [interval],
+  congr,
+  simp,
+end
 
 /- erase -/
 section erase
@@ -2205,6 +2235,8 @@ theorem nodup_filter_map (f : α → option β) {s : multiset α}
 quot.induction_on s $ λ l, nodup_filter_map H
 
 theorem nodup_range (n : ℕ) : nodup (range n) := nodup_range _
+
+theorem nodup_interval (n m : ℕ) : nodup (interval n m) := nodup_interval _ _
 
 theorem nodup_inter_left [decidable_eq α] {s : multiset α} (t) : nodup s → nodup (s ∩ t) :=
 nodup_of_le $ inter_le_left _ _

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -2978,7 +2978,13 @@ by dsimp [Ico]; congr; simp
 lemma pred_singleton {m : ℕ} (h : m > 0) : Ico (m-1) m = {m-1} :=
 by dsimp [Ico]; congr; rw list.Ico.pred_singleton h
 
+theorem eq_empty_of_le {n m : ℕ} (h : n ≥ m) : Ico n m = ∅ :=
+by dsimp [Ico]; congr; rw list.Ico.eq_nil_of_le h
+
 theorem nodup (n m : ℕ) : nodup (Ico n m) := Ico.nodup _ _
+
+lemma add_consecutive {n m l : ℕ} (h₁ : m ≥ n) (h₂ : l ≥ m) : Ico n m + Ico m l = Ico n l :=
+by dsimp [Ico]; congr; rw list.Ico.append h₁ h₂
 
 @[simp] lemma filter_lt (l n m : ℕ) : (Ico n l).filter (λ x, x < m) = Ico n (min m l) :=
 by dsimp [Ico]; simp


### PR DESCRIPTION
Some initial attempts at defining `Ico` (interval, closed-open), in `nat`, as a list, multiset, and finset.

There are many more lemmas to prove about these intervals (and the corresponding ones in `int`), but these are all I need so far for my "reindexing `finset.sum`" lemmas and tactics.

(And I think this stuff will be useful whatever our eventual design for big operators looks like.)

Please feel free to criticize, hack, or add to this branch!