### PR TITLE
feat(tactic/basic,tactic/interactive): generalize use tactic

### DIFF
--- a/tactic/basic.lean
+++ b/tactic/basic.lean
@@ -507,6 +507,8 @@ do goals ← get_goals,
    p ← is_proof goals.head,
    guard p
 
+meta def triv' : tactic unit := do c ← mk_const `trivial, exact c reducible
+
 variable {α : Type}
 
 private meta def iterate_aux (t : tactic α) : list α → tactic (list α)
@@ -720,5 +722,11 @@ form `f ∘ g = h` for reasoning about higher-order functions.",
        copy_attribute `functor_norm lmm tt lmm' }
 
 attribute [higher_order map_comp_pure] map_pure
+
+private meta def tactic.use_aux (h : pexpr) : tactic unit :=
+(focus1 (refine h >> done)) <|> (fconstructor >> tactic.use_aux)
+
+meta def tactic.use (l : list pexpr) : tactic unit :=
+focus1 $ l.mmap' $ λ h, tactic.use_aux h <|> fail format!"failed to instantiate goal with {h}"
 
 end tactic

--- a/tactic/interactive.lean
+++ b/tactic/interactive.lean
@@ -660,13 +660,13 @@ example : ∃ p : ℤ × ℤ, p.1 = 1 :=
 by use ⟨1, 42⟩
 
 example : Σ x y : ℤ, (ℤ × ℤ) × ℤ :=
-by use' [1, 2, 3, 4, 5]
+by use [1, 2, 3, 4, 5]
 
 inductive foo
 | mk : ℕ → bool × ℕ → ℕ → foo
 
 example : foo :=
-by use' [100, tt, 4, 3]
+by use [100, tt, 4, 3]
 -/
 meta def use (l : parse pexpr_list_or_texpr) : tactic unit :=
 tactic.use l >> try triv

--- a/tactic/interactive.lean
+++ b/tactic/interactive.lean
@@ -633,10 +633,18 @@ meta def guard_target' (p : parse texpr) : tactic unit :=
 do t ← target, guard_expr_eq' t p
 
 /--
+a weaker version of `trivial` that tries to solve the goal by reflexivity or by reducing it to true,
+unfolding only `reducible` constants. -/
+meta def triv : tactic unit :=
+tactic.triv' <|> tactic.reflexivity reducible <|> tactic.contradiction <|> fail "triv tactic failed"
+
+/--
 Similar to `existsi`. `use x` will instantiate the first term of an `∃` or `Σ` goal with `x`.
 Unlike `existsi`, `x` is elaborated with respect to the expected type.
-Equivalent to `refine ⟨x, _⟩`.
 `use` will alternatively take a list of terms `[x0, ..., xn]`.
+
+`use` will work with constructors of arbitrary inductive types.
+
 Examples:
 
 example (α : Type) : ∃ S : set α, S = S :=
@@ -650,10 +658,18 @@ by use [1, 2, 3]
 
 example : ∃ p : ℤ × ℤ, p.1 = 1 :=
 by use ⟨1, 42⟩
+
+example : Σ x y : ℤ, (ℤ × ℤ) × ℤ :=
+by use' [1, 2, 3, 4, 5]
+
+inductive foo
+| mk : ℕ → bool × ℕ → ℕ → foo
+
+example : foo :=
+by use' [100, tt, 4, 3]
 -/
 meta def use (l : parse pexpr_list_or_texpr) : tactic unit :=
-do refine $ l.foldr (λ t p, ``(⟨%%t, %%p⟩)) pexpr.mk_placeholder,
-   try refl
+tactic.use l >> try triv
 
 end interactive
 end tactic


### PR DESCRIPTION
Implements the generalizations requested in #486 . `use` will now deal with nested constructors of inductive types with multiple arguments.

This also adds `triv`, a cheap version of `trivial` that does less unfolding. Alternatively, `triv` could take a reducibility parameter.

TO CONTRIBUTORS:

Make sure you have:

 * [ ] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
