### PR TITLE
fix(tactic/norm_num): uninstantiated mvars can confuse things

### DIFF
--- a/tactic/norm_num.lean
+++ b/tactic/norm_num.lean
@@ -465,7 +465,8 @@ norm_num e <|> eval_div_ext simp e <|>
 eval_pow simp e <|> eval_ineq simp e <|> eval_prime simp e
 
 meta def derive : expr → tactic (expr × expr) | e :=
-do (_, e', pr) ←
+do e ← instantiate_mvars e,
+   (_, e', pr) ←
     ext_simplify_core () {} simp_lemmas.mk (λ _, failed) (λ _ _ _ _ _, failed)
       (λ _ _ _ _ e,
         do (new_e, pr) ← derive1 derive e,


### PR DESCRIPTION
As reported on Zulip.
```lean
lemma crazy (k l : ℕ) (h : l ≤ k): ((2:real)⁻¹)^k ≤ (2⁻¹)^l :=
begin
  apply pow_le_pow_of_le_one _ _ h,
  norm_num,
  -- goal is 2⁻¹ ≤ 1
  norm_num1
end
```
`norm_num1` fails to kill the goal because of an interplay between uninstantiated mvars and the behavior of `tactic.norm_num`.

(This shouldn't break anything else, but I haven't tested it, let Travis run if you want.)

TO CONTRIBUTORS:

Make sure you have:

 * [ ] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
