### PR TITLE
fix(category_theory/opposites): make `op` irreducible

### DIFF
--- a/src/category_theory/equivalence.lean
+++ b/src/category_theory/equivalence.lean
@@ -5,6 +5,7 @@
 import category_theory.fully_faithful
 import category_theory.functor_category
 import category_theory.natural_isomorphism
+import category_theory.opposites
 import tactic.slice
 import tactic.converter.interactive
 
@@ -187,6 +188,36 @@ end
 
 end is_equivalence
 
+section -- opposites
+
+@[simp] private def fun_inv_id_hom : functor.op_hom C D ⋙ functor.op_inv C D ⟶ functor.id ((C ⥤ D)ᵒᵖ) :=
+{ app := λ F, { app := λ X, 𝟙 _ },
+  naturality' := λ F G α, begin ext, repeat { erw functor.category.comp_app }, dsimp, simp, end }
+@[simp] private def fun_inv_id_inv : functor.id ((C ⥤ D)ᵒᵖ) ⟶ functor.op_hom C D ⋙ functor.op_inv C D :=
+{ app := λ F, { app := λ X, 𝟙 _ },
+  naturality' := λ F G α, begin ext, repeat { erw functor.category.comp_app }, dsimp, simp, end }
+
+instance op_hom_is_equivalence : is_equivalence (functor.op_hom C D) :=
+{ inverse := functor.op_inv C D,
+  inv_fun_id' := nat_iso.of_components (λ F, as_iso { app := λ X, 𝟙 _ }) (by tidy),
+  -- unfortunately we have to be grungier for the other direction
+  fun_inv_id' :=
+  { hom := fun_inv_id_hom,
+    inv := fun_inv_id_inv,
+    hom_inv_id' := begin ext, erw functor.category.comp_app, simp, refl end,
+    inv_hom_id' := begin ext, erw functor.category.comp_app, simp, refl end } }
+
+instance op_inv_is_equivalence : is_equivalence (functor.op_inv C D) := functor.is_equivalence_symm (functor.op_hom C D)
+
+omit 𝒟
+
+instance op_op_is_equivalence : is_equivalence (op_op C) :=
+{ inverse :=
+  { obj := λ X, op (op X),
+    map := λ X Y f, f } }
+
+end
+
 class ess_surj (F : C ⥤ D) :=
 (obj_preimage (d : D) : C)
 (iso' (d : D) : F.obj (obj_preimage d) ≅ d . obviously)
@@ -199,7 +230,7 @@ def fun_obj_preimage_iso (F : C ⥤ D) [ess_surj F] (d : D) : F.obj (F.obj_preim
 ess_surj.iso F d
 end functor
 
-namespace category_theory.equivalence
+namespace equivalence
 
 def ess_surj_of_equivalence (F : C ⥤ D) [is_equivalence F] : ess_surj F :=
 ⟨ λ Y : D, F.inv.obj Y, λ Y : D, (nat_iso.app F.inv_fun_id Y) ⟩
@@ -252,6 +283,6 @@ def equivalence_of_fully_faithfully_ess_surj
     (by obviously) }
 end
 
-end category_theory.equivalence
+end equivalence
 
 end category_theory

--- a/src/category_theory/functor_category.lean
+++ b/src/category_theory/functor_category.lean
@@ -35,7 +35,7 @@ section
 
 @[simp] lemma id_app (F : C ⥤ D) (X : C) : (𝟙 F : F ⟹ F).app X = 𝟙 (F.obj X) := rfl
 @[simp] lemma comp_app {F G H : C ⥤ D} (α : F ⟶ G) (β : G ⟶ H) (X : C) :
-  ((α ≫ β) : F ⟹ H).app X = (α : F ⟹ G).app X ≫ (β : G ⟹ H).app X := rfl
+  (α ≫ β).app X = α.app X ≫ β.app X := rfl
 end
 
 namespace nat_trans

--- a/src/category_theory/isomorphism.lean
+++ b/src/category_theory/isomorphism.lean
@@ -135,6 +135,12 @@ instance of_iso_inverse (f : X ≅ Y) : is_iso f.inv :=
 
 end is_iso
 
+def as_iso (f : X ⟶ Y) [is_iso f] : X ≅ Y :=
+{ hom := f,
+  inv := inv f }
+@[simp] lemma as_iso_hom (f : X ⟶ Y) [is_iso f] : (as_iso f).hom = f := rfl
+@[simp] lemma as_iso_inv (f : X ⟶ Y) [is_iso f] : (as_iso f).inv = inv f := rfl
+
 namespace functor
 
 universes u₁ v₁ u₂ v₂

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -30,41 +30,55 @@ variables {J C} (F : J ⥤ C)
 natural transformations from the constant functor with value `X` to `F`.
 An object representing this functor is a limit of `F`.
 -/
-def cones : Cᵒᵖ ⥤ Type v := (const Jᵒᵖ ⋙ op_inv J C) ⋙ (yoneda.obj F)
+def cones : Cᵒᵖ ⥤ Type v := (const J).op ⋙ (yoneda.obj F)
 
-lemma cones_obj (X : C) : F.cones.obj X = ((const J).obj X ⟹ F) := rfl
+section
+lemma cones_obj (X : Cᵒᵖ) : F.cones.obj X = ((const J).obj (unop X) ⟶ F) := rfl
+
+local attribute [semireducible] category.hom.op category.hom.unop
+@[simp] lemma cones_map {X Y : Cᵒᵖ} (f : X ⟶ Y) (g : (cones F).obj X) (j : J) :
+  ((cones F).map f g).app j = f ≫ g.app j := rfl
+end
 
 /--
 `F.cocones` is the functor assigning to an object `X` the type of
 natural transformations from `F` to the constant functor with value `X`.
 An object corepresenting this functor is a colimit of `F`.
 -/
-def cocones : C ⥤ Type v := (const J) ⋙ (coyoneda.obj F)
 
+def cocones : C ⥤ Type v := (const J) ⋙ (coyoneda.obj (op F))
+
+section
 lemma cocones_obj (X : C) : F.cocones.obj X = (F ⟹ (const J).obj X) := rfl
 
+local attribute [semireducible] category.hom.op category.hom.unop
+@[simp] lemma cocones_map {X Y : C} (f : X ⟶ Y) (g : (cocones F).obj X) (j : J) :
+  ((cocones F).map f g).app j = g.app j ≫ f := rfl
+end
 end functor
 
 section
 variables (J C)
 
 def cones : (J ⥤ C) ⥤ (Cᵒᵖ ⥤ Type v) :=
-{ obj := functor.cones,
-  map := λ F G f, whisker_left _ (yoneda.map f) }
+{ obj := λ F, F.cones,
+  map := λ F G f, whisker_left (const J).op (yoneda.map f) }
+
+-- set_option pp.all true
 
 def cocones : (J ⥤ C)ᵒᵖ ⥤ (C ⥤ Type v) :=
-{ obj := functor.cocones,
-  map := λ F G f, whisker_left _ (coyoneda.map f) }
+{ obj := λ F, (unop F).cocones,
+  map := λ F G f, whisker_left (const J) (coyoneda.map f.unop) }
 
 variables {J C}
 
 @[simp] lemma cones_obj (F : J ⥤ C) : (cones J C).obj F = F.cones := rfl
-@[simp] lemma cones_map  {F G : J ⥤ C} {f : F ⟶ G} :
-(cones J C).map f = (whisker_left _ (yoneda.map f)) := rfl
+@[simp] lemma cones_map {F G : J ⥤ C} {f : F ⟶ G} :
+(cones J C).map f = (whisker_left (const J).op (yoneda.map f)) := rfl
 
-@[simp] lemma cocones_obj (F : J ⥤ C) : (cocones J C).obj F = F.cocones := rfl
-@[simp] lemma cocones_map  {F G : J ⥤ C} {f : F ⟶ G} :
-(cocones J C).map f = (whisker_left _ (coyoneda.map f)) := rfl
+@[simp] lemma cocones_obj (F : (J ⥤ C)ᵒᵖ) : (cocones J C).obj F = (unop F).cocones := rfl
+@[simp] lemma cocones_map {F G : (J ⥤ C)ᵒᵖ} {f : F ⟶ G} :
+(cocones J C).map f = (whisker_left (const J) (coyoneda.map f.unop)) := rfl
 
 end
 
@@ -111,7 +125,7 @@ namespace cone
 /-- A map to the vertex of a cone induces a cone by composition. -/
 @[simp] def extend (c : cone F) {X : C} (f : X ⟶ c.X) : cone F :=
 { X := X,
-  π := c.extensions.app X f }
+  π := c.extensions.app (op X) f }
 
 def postcompose {G : J ⥤ C} (α : F ⟹ G) (c : cone F) : cone G :=
 { X := c.X,
@@ -126,9 +140,8 @@ def whisker {K : Type v} [small_category K] (E : K ⥤ J) (c : cone F) : cone (E
 end cone
 
 namespace cocone
-@[simp] def extensions (c : cocone F) : coyoneda.obj c.X ⟶ F.cocones :=
-{ app := λ X f, c.ι ≫ ((const J).map f),
-  naturality' := by intros X Y f; ext g j; dsimp; rw ←assoc; refl }
+@[simp] def extensions (c : cocone F) : coyoneda.obj (op c.X) ⟶ F.cocones :=
+{ app := λ X f, c.ι ≫ ((const J).map f) }
 
 /-- A map from the vertex of a cocone induces a cocone by composition. -/
 @[simp] def extend (c : cocone F) {X : C} (f : c.X ⟶ X) : cocone F :=

--- a/src/category_theory/limits/limits.lean
+++ b/src/category_theory/limits/limits.lean
@@ -86,11 +86,13 @@ def hom_iso (h : is_limit t) (W : C) : (W ⟶ t.X) ≅ ((const J).obj W ⟹ F) :
 
 @[simp] lemma hom_iso_hom (h : is_limit t) {W : C} (f : W ⟶ t.X) :
   (is_limit.hom_iso h W).hom f = (t.extend f).π := rfl
+@[simp] lemma hom_iso_inv (h : is_limit t) {W : C} (π : (const J).obj W ⟹ F) :
+  (is_limit.hom_iso h W).inv π = h.lift { X := W, π := π } := rfl
 
 /-- The limit of `F` represents the functor taking `W` to
   the set of cones on `F` with vertex `W`. -/
 def nat_iso (h : is_limit t) : yoneda.obj t.X ≅ F.cones :=
-nat_iso.of_components (is_limit.hom_iso h) (by tidy)
+nat_iso.of_components (λ W, is_limit.hom_iso h (unop W)) (by tidy)
 
 def hom_iso' (h : is_limit t) (W : C) :
   (W ⟶ t.X) ≅ { p : Π j, W ⟶ F.obj j // ∀ {j j'} (f : j ⟶ j'), p j ≫ F.map f = p j' } :=
@@ -188,10 +190,12 @@ def hom_iso (h : is_colimit t) (W : C) : (t.X ⟶ W) ≅ (F ⟹ (const J).obj W)
 
 @[simp] lemma hom_iso_hom (h : is_colimit t) {W : C} (f : t.X ⟶ W) :
   (is_colimit.hom_iso h W).hom f = (t.extend f).ι := rfl
+@[simp] lemma hom_iso_inv (h : is_colimit t) {W : C} (ι : F ⟹ (const J).obj W) :
+  (is_colimit.hom_iso h W).inv ι = h.desc { X := W, ι := ι } := rfl
 
 /-- The colimit of `F` represents the functor taking `W` to
   the set of cocones on `F` with vertex `W`. -/
-def nat_iso (h : is_colimit t) : coyoneda.obj t.X ≅ F.cocones :=
+def nat_iso (h : is_colimit t) : coyoneda.obj (op t.X) ≅ F.cocones :=
 nat_iso.of_components (is_colimit.hom_iso h) (by intros; ext; dsimp; rw ←assoc; refl)
 
 def hom_iso' (h : is_colimit t) (W : C) :
@@ -290,12 +294,15 @@ by erw is_limit.fac
   (w : ∀ j, f ≫ limit.π F j = f' ≫ limit.π F j) : f = f' :=
 (limit.is_limit F).hom_ext w
 
-def limit.hom_iso (F : J ⥤ C) [has_limit F] (W : C) : (W ⟶ limit F) ≅ (F.cones.obj W) :=
+def limit.hom_iso (F : J ⥤ C) [has_limit F] (W : C) : (W ⟶ limit F) ≅ (F.cones.obj (op W)) :=
 (limit.is_limit F).hom_iso W
 
 @[simp] lemma limit.hom_iso_hom (F : J ⥤ C) [has_limit F] {W : C} (f : W ⟶ limit F):
   (limit.hom_iso F W).hom f = (const J).map f ≫ (limit.cone F).π :=
 (limit.is_limit F).hom_iso_hom f
+@[simp] lemma limit.hom_iso_inv (F : J ⥤ C) [has_limit F] {W : C} (π : F.cones.obj (op W)):
+  (limit.hom_iso F W).inv π = limit.lift F { X := W, π := π } :=
+(limit.is_limit F).hom_iso_inv π
 
 def limit.hom_iso' (F : J ⥤ C) [has_limit F] (W : C) :
   (W ⟶ limit F) ≅ { p : Π j, W ⟶ F.obj j // ∀ {j j' : J} (f : j ⟶ j'), p j ≫ F.map f = p j' } :=
@@ -416,7 +423,9 @@ begin
 end
 
 def lim_yoneda : lim ⋙ yoneda ≅ category_theory.cones J C :=
-nat_iso.of_components (λ F, nat_iso.of_components (limit.hom_iso F) (by tidy)) (by tidy)
+nat_iso.of_components
+  (λ F, nat_iso.of_components (λ W, limit.hom_iso F (unop W)) (by tidy))
+  (by tidy)
 
 end lim_functor
 
@@ -498,6 +507,9 @@ def colimit.hom_iso (F : J ⥤ C) [has_colimit F] (W : C) : (colimit F ⟶ W) �
 @[simp] lemma colimit.hom_iso_hom (F : J ⥤ C) [has_colimit F] {W : C} (f : colimit F ⟶ W):
   (colimit.hom_iso F W).hom f = (colimit.cocone F).ι ≫ (const J).map f :=
 (colimit.is_colimit F).hom_iso_hom f
+@[simp] lemma colimit.hom_iso_inv (F : J ⥤ C) [has_colimit F] {W : C} (ι : F.cocones.obj W):
+  (colimit.hom_iso F W).inv ι = colimit.desc F { X := W, ι := ι } :=
+(colimit.is_colimit F).hom_iso_inv ι
 
 def colimit.hom_iso' (F : J ⥤ C) [has_colimit F] (W : C) :
   (colimit F ⟶ W) ≅ { p : Π j, F.obj j ⟶ W // ∀ {j j'} (f : j ⟶ j'), F.map f ≫ p j' = p j } :=
@@ -634,9 +646,16 @@ begin
 end
 
 def colim_coyoneda : colim.op ⋙ coyoneda ≅ category_theory.cocones J C :=
-nat_iso.of_components (λ F, nat_iso.of_components (colimit.hom_iso F)
-  (by {tidy, dsimp [functor.cocones], rw category.assoc }))
-  (by {tidy, rw [← category.assoc,← category.assoc], tidy })
+nat_iso.of_components
+  (λ F, nat_iso.of_components (colimit.hom_iso (unop F)) (by tidy))
+  begin
+     intros X Y f, ext1, ext1, ext1,
+     dsimp, simp,
+     dsimp [category.hom.op, category.hom.unop],
+     rw [←category.assoc],
+     simp,
+     refl
+   end
 
 end colim_functor
 

--- a/src/category_theory/natural_isomorphism.lean
+++ b/src/category_theory/natural_isomorphism.lean
@@ -74,8 +74,8 @@ begin erw [nat_trans.naturality, ←category.assoc, is_iso.hom_inv_id, category.
 def of_components (app : ∀ X : C, (F.obj X) ≅ (G.obj X))
   (naturality : ∀ {X Y : C} (f : X ⟶ Y), (F.map f) ≫ ((app Y).hom) = ((app X).hom) ≫ (G.map f)) :
   F ≅ G :=
-{ hom  := { app := λ X, ((app X).hom), },
-  inv  :=
+{ hom := { app := λ X, ((app X).hom), },
+  inv :=
   { app := λ X, ((app X).inv),
     naturality' := λ X Y f,
     by simpa using congr_arg (λ f, (app X).inv ≫ (f ≫ (app Y).inv)) (naturality f).symm } }
@@ -87,6 +87,12 @@ by tidy
   (of_components app naturality).hom.app X = (app X).hom := rfl
 @[simp] def of_components.inv_app (app : ∀ X : C, (F.obj X) ≅ (G.obj X)) (naturality) (X) :
   (of_components app naturality).inv.app X = (app X).inv := rfl
+
+instance is_iso_of_is_iso_app (α : F ⟶ G) [∀ X : C, is_iso (α.app X)] : is_iso α :=
+begin
+  convert is_iso.of_iso (of_components (λ X, as_iso (α.app X)) (λ X Y f, α.naturality f)),
+  ext, refl
+end
 
 end category_theory.nat_iso
 

--- a/src/category_theory/opposites.lean
+++ b/src/category_theory/opposites.lean
@@ -9,79 +9,114 @@ namespace category_theory
 
 universes v₁ v₂ u₁ u₂ -- declare the `v`'s first; see `category_theory.category` for an explanation
 
-def op (C : Type u₁) : Type u₁ := C
+-- Without marking this as irreducible, Lean is just too helpful for its own good,
+-- passing back and forth between a category and its opposite.
+-- Broken proofs become very difficult to debug.
+def opposite (C : Type u₁) : Type u₁ := C
 
 -- Use a high right binding power (like that of postfix ⁻¹) so that, for example,
 -- `presheaf Cᵒᵖ` parses as `presheaf (Cᵒᵖ)` and not `(presheaf C)ᵒᵖ`.
-notation C `ᵒᵖ`:std.prec.max_plus := op C
+notation C `ᵒᵖ`:std.prec.max_plus := opposite C
 
-variables {C : Type u₁} [𝒞 : category.{v₁} C]
+variables {C : Type u₁}
+
+def op (X : C) : Cᵒᵖ := X
+def unop (X : Cᵒᵖ) : C := X
+@[simp] lemma unop_op (X : C) : unop (op X) = X := rfl
+@[simp] lemma op_unop (X : Cᵒᵖ) : op (unop X) = X := rfl
+
+attribute [irreducible] opposite
+
+variables (C) [𝒞 : category.{v₁} C]
 include 𝒞
 
-instance opposite : category.{v₁} Cᵒᵖ :=
-{ hom  := λ X Y : C, Y ⟶ X,
+instance opposite_category : category.{v₁} (Cᵒᵖ) :=
+{ hom  := λ X Y : Cᵒᵖ, (unop Y) ⟶ (unop X),
   comp := λ _ _ _ f g, g ≫ f,
-  id   := λ X, 𝟙 X }
+  id   := λ X, 𝟙 (unop X) }
 
+namespace category.hom
+variables {C}
+def op {X Y : C} (f : X ⟶ Y) : (op Y) ⟶ (op X) := f
+def unop {X Y : Cᵒᵖ} (f : X ⟶ Y) : (unop Y) ⟶ (unop X) := f
+
+@[simp] lemma op_id (X : C) : op (𝟙 X) = 𝟙 (category_theory.op X) := rfl
+@[simp] lemma unop_id (X : Cᵒᵖ) : unop (𝟙 X) = 𝟙 (category_theory.unop X) := rfl
+@[simp] lemma comp_op_op {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) :
+  (op g) ≫ (op f) = op (f ≫ g) := rfl
+@[simp] lemma comp_unop {X Y Z : Cᵒᵖ} (f : X ⟶ Y) (g : Y ⟶ Z) :
+  unop (f ≫ g) = (unop g) ≫ (unop f) := rfl
+
+@[simp] lemma op_unop {X Y : C} (f : X ⟶ Y) : f.op.unop = f := rfl
+@[simp] lemma unop_op {X Y : Cᵒᵖ} (f : X ⟶ Y) : f.unop.op = f := rfl
+
+attribute [irreducible] op unop
+end category.hom
+
+section
 def op_op : (Cᵒᵖ)ᵒᵖ ⥤ C :=
-{ obj := λ X, X,
+{ obj := λ X, unop (unop X),
   map := λ X Y f, f }
+end
 
--- TODO this is an equivalence
+variables {C}
 
 namespace functor
 
 section
+local attribute [semireducible] category.hom.op category.hom.unop
 
 variables {D : Type u₂} [𝒟 : category.{v₂} D]
 include 𝒟
 
 variables {C D}
 
-protected definition op (F : C ⥤ D) : Cᵒᵖ ⥤ Dᵒᵖ :=
-{ obj       := λ X, F.obj X,
-  map       := λ X Y f, F.map f,
-  map_id'   := begin /- `obviously'` says: -/ intros, erw [map_id], refl, end,
-  map_comp' := begin /- `obviously'` says: -/ intros, erw [map_comp], refl end }
+protected def op (F : C ⥤ D) : Cᵒᵖ ⥤ Dᵒᵖ :=
+{ obj       := λ X, op (F.obj (unop X)),
+  map       := λ X Y f, (F.map f.unop).op,
+  map_id'   := by intros; erw [map_id]; refl,
+  map_comp' := by intros; erw [map_comp]; refl }
 
-@[simp] lemma op_obj (F : C ⥤ D) (X : C) : (F.op).obj X = F.obj X := rfl
-@[simp] lemma op_map (F : C ⥤ D) {X Y : C} (f : X ⟶ Y) : (F.op).map f = F.map f := rfl
+@[simp] lemma op' (F : C ⥤ D) (X : Cᵒᵖ) :
+  (F.op).obj X = op (F.obj (unop X)) := rfl
+@[simp] lemma op_map' (F : C ⥤ D) {X Y : C} (f : X ⟶ Y) :
+  (F.op).map f = (F.map f.unop).op := rfl
 
-protected definition unop (F : Cᵒᵖ ⥤ Dᵒᵖ) : C ⥤ D :=
-{ obj       := λ X, F.obj X,
-  map       := λ X Y f, F.map f,
-  map_id'   := F.map_id,
-  map_comp' := by intros; apply F.map_comp }
+protected def unop (F : Cᵒᵖ ⥤ Dᵒᵖ) : C ⥤ D :=
+{ obj       := λ X, unop (F.obj (op X)),
+  map       := λ X Y f, (F.map f.op).unop,
+  map_id'   := by intros; erw [map_id]; refl,
+  map_comp' := by intros; erw [map_comp]; refl }
 
-@[simp] lemma unop_obj (F : Cᵒᵖ ⥤ Dᵒᵖ) (X : C) : (F.unop).obj X = F.obj X := rfl
-@[simp] lemma unop_map (F : Cᵒᵖ ⥤ Dᵒᵖ) {X Y : C} (f : X ⟶ Y) : (F.unop).map f = F.map f := rfl
+@[simp] lemma unop' (F : Cᵒᵖ ⥤ Dᵒᵖ) (X : C) :
+  (F.unop).obj X = unop (F.obj (op X)) := rfl
+@[simp] lemma unop_map' (F : Cᵒᵖ ⥤ Dᵒᵖ) {X Y : C} (f : X ⟶ Y) :
+  (F.unop).map f = (F.map f.op).unop := rfl
 
 variables (C D)
 
-definition op_hom : (C ⥤ D)ᵒᵖ ⥤ (Cᵒᵖ ⥤ Dᵒᵖ) :=
-{ obj := λ F, F.op,
+def op_hom : (C ⥤ D)ᵒᵖ ⥤ (Cᵒᵖ ⥤ Dᵒᵖ) :=
+{ obj := λ F, (unop F).op,
   map := λ F G α,
-  { app := λ X, α.app X,
+  { app := λ X, α.app (unop X),
     naturality' := λ X Y f, eq.symm (α.naturality f) } }
 
-@[simp] lemma op_hom.obj (F : (C ⥤ D)ᵒᵖ) : (op_hom C D).obj F = F.op := rfl
-@[simp] lemma op_hom.map_app {F G : (C ⥤ D)ᵒᵖ} (α : F ⟶ G) (X : C) :
-  ((op_hom C D).map α).app X = α.app X := rfl
+@[simp] lemma op_hom.obj (F : (C ⥤ D)ᵒᵖ) : (op_hom C D).obj F = (unop F).op := rfl
+@[simp] lemma op_hom.map_app {F G : (C ⥤ D)ᵒᵖ} (α : F ⟶ G) (X : Cᵒᵖ) :
+  ((op_hom C D).map α).app X = α.app (unop X) := rfl
 
-definition op_inv : (Cᵒᵖ ⥤ Dᵒᵖ) ⥤ (C ⥤ D)ᵒᵖ :=
-{ obj := λ F : Cᵒᵖ ⥤ Dᵒᵖ, F.unop,
+def op_inv : (Cᵒᵖ ⥤ Dᵒᵖ) ⥤ (C ⥤ D)ᵒᵖ :=
+{ obj := λ F, op F.unop,
   map := λ F G α,
-  { app := λ X : C, α.app X,
+  { app := λ X, α.app (op X),
     naturality' := λ X Y f, eq.symm (α.naturality f) } }
 
-@[simp] lemma op_inv.obj (F : Cᵒᵖ ⥤ Dᵒᵖ) : (op_inv C D).obj F = F.unop := rfl
+@[simp] lemma op_inv.obj (F : Cᵒᵖ ⥤ Dᵒᵖ) : (op_inv C D).obj F = op F.unop := rfl
 @[simp] lemma op_inv.map_app {F G : Cᵒᵖ ⥤ Dᵒᵖ} (α : F ⟶ G) (X : C) :
-  ((op_inv C D).map α).app X = α.app X := rfl
-
--- TODO show these form an equivalence
+  ((op_inv C D).map α).app X = α.app (op X) := rfl
 
 instance {F : C ⥤ D} [full F] : full F.op :=
-{ preimage := λ X Y f, F.preimage f }
+{ preimage := λ X Y f, (F.preimage f.unop).op }
 
 instance {F : C ⥤ D} [faithful F] : faithful F.op :=
 { injectivity' := λ X Y f g h, by simpa using injectivity F h }
@@ -91,27 +126,27 @@ injectivity F (by simp)
 
 end
 
-namespace category
-variables {C} {D : Type u₂} [𝒟 : category.{v₂} D]
-include 𝒟
+section
+def op_iso {X Y : C} (f : X ≅ Y) : (op X) ≅ (op Y) :=
+{ hom := f.inv.op,
+  inv := f.hom.op }
 
-@[simp] lemma op_id_app (F : (C ⥤ D)ᵒᵖ) (X : C) : (𝟙 F : F ⟹ F).app X = 𝟙 (F.obj X) := rfl
-@[simp] lemma op_comp_app {F G H : (C ⥤ D)ᵒᵖ} (α : F ⟶ G) (β : G ⟶ H) (X : C) :
-  ((α ≫ β) : H ⟹ F).app X = (β : H ⟹ G).app X ≫ (α : G ⟹ F).app X := rfl
-end category
+@[simp] lemma op_iso_hom {X Y : C} (f : X ≅ Y) : (op_iso f).hom = f.inv.op := rfl
+@[simp] lemma op_iso_inv {X Y : C} (f : X ≅ Y) : (op_iso f).inv = f.hom.op := rfl
+end
 
 section
 
 variable (C)
 
 /-- `functor.hom` is the hom-pairing, sending (X,Y) to X → Y, contravariant in X and covariant in Y. -/
-definition hom : (Cᵒᵖ × C) ⥤ (Type v₁) :=
-{ obj       := λ p, @category.hom C _ p.1 p.2,
+def hom : (Cᵒᵖ × C) ⥤ (Type v₁) :=
+{ obj       := λ X, (unop X.1) ⟶ X.2,
   map       := λ X Y f, λ h, f.1 ≫ h ≫ f.2,
-  map_id'   := by intros; ext; dsimp [category_theory.opposite]; simp,
-  map_comp' := by intros; ext; dsimp [category_theory.opposite]; simp }
+  map_id'   := begin intros, ext, dsimp [category_theory.opposite_category], simp end,
+  map_comp' := begin intros, ext, dsimp [category_theory.opposite_category], simp end }
 
-@[simp] lemma hom_obj (X : Cᵒᵖ × C) : (functor.hom C).obj X = @category.hom C _ X.1 X.2 := rfl
+@[simp] lemma hom_obj (X : Cᵒᵖ × C) : (functor.hom C).obj X = ((unop X.1) ⟶ X.2) := rfl
 @[simp] lemma hom_pairing_map {X Y : Cᵒᵖ × C} (f : X ⟶ Y) :
   (functor.hom C).map f = λ h, f.1 ≫ h ≫ f.2 := rfl
 

--- a/src/category_theory/opposites.lean
+++ b/src/category_theory/opposites.lean
@@ -9,9 +9,6 @@ namespace category_theory
 
 universes v₁ v₂ u₁ u₂ -- declare the `v`'s first; see `category_theory.category` for an explanation
 
--- Without marking this as irreducible, Lean is just too helpful for its own good,
--- passing back and forth between a category and its opposite.
--- Broken proofs become very difficult to debug.
 def opposite (C : Type u₁) : Type u₁ := C
 
 -- Use a high right binding power (like that of postfix ⁻¹) so that, for example,
@@ -24,8 +21,6 @@ def op (X : C) : Cᵒᵖ := X
 def unop (X : Cᵒᵖ) : C := X
 @[simp] lemma unop_op (X : C) : unop (op X) = X := rfl
 @[simp] lemma op_unop (X : Cᵒᵖ) : op (unop X) = X := rfl
-
-attribute [irreducible] opposite
 
 variables (C) [𝒞 : category.{v₁} C]
 include 𝒞

--- a/src/category_theory/yoneda.lean
+++ b/src/category_theory/yoneda.lean
@@ -7,7 +7,6 @@
 
    Also the Yoneda lemma, `yoneda_lemma : (yoneda_pairing C) ≅ (yoneda_evaluation C)`. -/
 
-import category_theory.natural_transformation
 import category_theory.opposites
 import category_theory.types
 import category_theory.fully_faithful
@@ -22,15 +21,15 @@ include 𝒞
 
 def yoneda : C ⥤ (Cᵒᵖ ⥤ Type v₁) :=
 { obj := λ X,
-  { obj := λ Y : C, Y ⟶ X,
+  { obj := λ Y, (unop Y) ⟶ X,
     map := λ Y Y' f g, f ≫ g,
-    map_comp' := begin intros X_1 Y Z f g, ext1, dsimp at *, erw [category.assoc] end,
-    map_id' := begin intros X_1, ext1, dsimp at *, erw [category.id_comp] end },
+    map_comp' := λ X' Y' Z' f g, begin ext h, dsimp, erw [category.assoc] end,
+    map_id' := λ X', begin ext h, dsimp, erw [category.id_comp] end },
   map := λ X X' f, { app := λ Y g, g ≫ f } }
 
 def coyoneda : Cᵒᵖ ⥤ (C ⥤ Type v₁) :=
-{ obj := λ X : C,
-  { obj := λ Y, X ⟶ Y,
+{ obj := λ X,
+  { obj := λ Y, (unop X) ⟶ Y,
     map := λ Y Y' f g, g ≫ f,
     map_comp' := begin intros X_1 Y Z f g, ext1, dsimp at *, erw [category.assoc] end,
     map_id' := begin intros X_1, ext1, dsimp at *, erw [category.comp_id] end },
@@ -39,24 +38,25 @@ def coyoneda : Cᵒᵖ ⥤ (C ⥤ Type v₁) :=
   map_id' := begin intros X, ext1, ext1, dsimp at *, erw [category.id_comp] end }
 
 namespace yoneda
-@[simp] lemma obj_obj (X Y : C) : (yoneda.obj X).obj Y = (Y ⟶ X) := rfl
+@[simp] lemma obj_obj (X : C) (Y : Cᵒᵖ) : (yoneda.obj X).obj Y = ((unop Y) ⟶ X) := rfl
 @[simp] lemma obj_map (X : C) {Y Y' : C} (f : Y ⟶ Y') : (yoneda.obj X).map f = λ g, f ≫ g := rfl
-@[simp] lemma map_app {X X' : C} (f : X ⟶ X') (Y : C) : (yoneda.map f).app Y = λ g, g ≫ f := rfl
+@[simp] lemma map_app {X X' : C} (f : X ⟶ X') (Y : Cᵒᵖ) : (yoneda.map f).app Y = λ g, g ≫ f := rfl
 
 lemma obj_map_id {X Y : Cᵒᵖ} (f : X ⟶ Y) :
-  ((@yoneda C _).obj X).map f (𝟙 X) = ((@yoneda C _).map f).app Y (𝟙 Y) :=
-by obviously
+  ((@yoneda C _).obj (unop X)).map f (𝟙 (unop X)) = ((@yoneda C _).map f).app Y (𝟙 (unop Y)) :=
+by dsimp; simp; erw category.comp_id
 
 @[simp] lemma naturality {X Y : C} (α : yoneda.obj X ⟶ yoneda.obj Y)
-  {Z Z' : C} (f : Z ⟶ Z') (h : Z' ⟶ X) : f ≫ α.app Z' h = α.app Z (f ≫ h) :=
-begin erw [functor_to_types.naturality], refl end
+  {Z Z' : C} (f : Z ⟶ Z') (h : Z' ⟶ X) : f ≫ α.app (op Z') h = α.app (op Z) (f ≫ h) :=
+by erw [functor_to_types.naturality]; refl
 
 instance yoneda_fully_faithful : fully_faithful (@yoneda C _) :=
-{ preimage := λ X Y f, (f.app X) (𝟙 X),
+{ preimage := λ X Y f, (f.app (op X)) (𝟙 X),
   injectivity' := λ X Y f g p,
   begin
     injection p with h,
-    convert (congr_fun (congr_fun h X) (𝟙 X)) ; simp
+    convert (congr_fun (congr_fun h (op X)) (𝟙 X));
+    erw category.id_comp
   end }
 
 /-- Extensionality via Yoneda. The typical usage would be
@@ -84,8 +84,8 @@ category_theory.prod.{v₁ (max u₁ v₁)} Cᵒᵖ (Cᵒᵖ ⥤ Type v₁)
 end yoneda
 
 namespace coyoneda
-@[simp] lemma obj_obj (X Y : C) : (coyoneda.obj X).obj Y = (X ⟶ Y) := rfl
-@[simp] lemma obj_map {X' X : C} (f : X' ⟶ X) (Y : C) : (coyoneda.obj Y).map f = λ g, g ≫ f := rfl
+@[simp] lemma obj_obj (X : Cᵒᵖ) (Y : C) : (coyoneda.obj X).obj Y = ((unop X) ⟶ Y) := rfl
+@[simp] lemma obj_map {X' X : C} (f : X' ⟶ X) (Y : Cᵒᵖ) : (coyoneda.obj Y).map f = λ g, g ≫ f := rfl
 @[simp] lemma map_app (X : C) {Y Y' : C} (f : Y ⟶ Y') : (coyoneda.map f).app X = λ g, f ≫ g := rfl
 end coyoneda
 
@@ -106,13 +106,14 @@ def yoneda_evaluation : (Cᵒᵖ × (Cᵒᵖ ⥤ Type v₁)) ⥤ Type (max u₁ 
 def yoneda_pairing : (Cᵒᵖ × (Cᵒᵖ ⥤ Type v₁)) ⥤ Type (max u₁ v₁) :=
 (functor.prod yoneda.op (functor.id (Cᵒᵖ ⥤ Type v₁))) ⋙ functor.hom (Cᵒᵖ ⥤ Type v₁)
 
+local attribute [semireducible] category.hom.op category.hom.unop
 @[simp] lemma yoneda_pairing_map
   (P Q : Cᵒᵖ × (Cᵒᵖ ⥤ Type v₁)) (α : P ⟶ Q) (β : (yoneda_pairing C).obj P) :
   (yoneda_pairing C).map α β = yoneda.map α.1 ≫ β ≫ α.2 := rfl
 
 def yoneda_lemma : yoneda_pairing C ≅ yoneda_evaluation C :=
 { hom :=
-  { app := λ F x, ulift.up ((x.app F.1) (𝟙 F.1)),
+  { app := λ F x, ulift.up ((x.app F.1) (𝟙 (unop F.1))),
     naturality' :=
     begin
       intros X Y f, ext1, ext1,
@@ -158,11 +159,11 @@ def yoneda_lemma : yoneda_pairing C ≅ yoneda_evaluation C :=
 
 variables {C}
 
-@[simp] def yoneda_sections (X : C) (F : Cᵒᵖ ⥤ Type v₁) : (yoneda.obj X ⟹ F) ≅ ulift.{u₁} (F.obj X) :=
-nat_iso.app (yoneda_lemma C) (X, F)
+@[simp] def yoneda_sections (X : C) (F : Cᵒᵖ ⥤ Type v₁) : (yoneda.obj X ⟹ F) ≅ ulift.{u₁} (F.obj (op X)) :=
+nat_iso.app (yoneda_lemma C) (op X, F)
 
 omit 𝒞
-@[simp] def yoneda_sections_small {C : Type u₁} [small_category C] (X : C) (F : Cᵒᵖ ⥤ Type u₁) : (yoneda.obj X ⟹ F) ≅ F.obj X :=
+@[simp] def yoneda_sections_small {C : Type u₁} [small_category C] (X : C) (F : Cᵒᵖ ⥤ Type u₁) : (yoneda.obj X ⟹ F) ≅ F.obj (op X) :=
 yoneda_sections X F ≪≫ ulift_trivial _
 
 end category_theory


### PR DESCRIPTION
This makes it harder to accidentally (... or intentionally!) move back and forth between a category and its opposite.

Unfortunately, broken proofs were too hard to diagnose, when the wrong (opposite) category was inferred.

This commit also adds constructions in `equivalence.lean` showing that the functors `op_hom : (C ⥤ D)ᵒᵖ ⥤ (Cᵒᵖ ⥤ Dᵒᵖ)` and `op_inv : (Cᵒᵖ ⥤ Dᵒᵖ) ⥤ (C ⥤ D)ᵒᵖ` form an equivalence.