### PR TITLE
feat(tactic/explode): improve readability & support proofs using 'suffices'

### DIFF
--- a/tactic/explode.lean
+++ b/tactic/explode.lean
@@ -94,8 +94,8 @@ with explode.core : expr → bool → nat → entries → tactic entries
   else do
     let en : entry := ⟨l, es.size, depth, status.intro, to_string n, []⟩,
     es' ← explode.core b' si (depth + 1) (es.add en),
-    deps' ← explode.append_dep filter es' b' [], -- conclusion
-    deps' ← explode.append_dep filter es' l deps', -- assumption
+    deps' ← explode.append_dep filter es' b' [],
+    deps' ← explode.append_dep filter es' l deps',
     return $ es'.add ⟨e, es'.size, depth, status.lam, "∀I", deps'⟩
 | e@(macro _ l) si depth es := explode.core l.head si depth es
 | e si depth es := filter e >>

--- a/tactic/explode.lean
+++ b/tactic/explode.lean
@@ -75,6 +75,10 @@ do { ei ← es.find e,
   return (ei.line :: deps) }
 <|> return deps
 
+meta def may_be_proof (e : expr) : tactic bool :=
+is_proof e >>= λ b, return $ 
+b || is_app e || is_local_constant e || is_pi e || is_lambda e
+
 end explode
 open explode
 
@@ -90,7 +94,10 @@ with explode.core : expr → bool → nat → entries → tactic entries
   else do
     let en : entry := ⟨l, es.size, depth, status.intro, to_string n, []⟩,
     es' ← explode.core b' si (depth + 1) (es.add en),
-    return $ es'.add ⟨e, es'.size, depth, status.lam, "∀I", [es'.size - 1]⟩
+    deps' ← explode.append_dep filter es' b' [], -- conclusion
+    deps' ← explode.append_dep filter es' l deps', -- assumption
+    return $ es'.add ⟨e, es'.size, depth, status.lam, "∀I", deps'⟩
+| e@(macro _ l) si depth es := explode.core l.head si depth es
 | e si depth es := filter e >>
   match get_app_fn_args e with
   | (const n _, args) :=
@@ -113,7 +120,7 @@ with explode.args : expr → list expr → nat → entries → string → list n
   return (es.add ⟨e, es.size, depth, status.reg, thm, deps.reverse⟩)
 
 meta def explode_expr (e : expr) (hide_non_prop := tt) : tactic entries :=
-let filter := if hide_non_prop then λ e, is_proof e >>= guardb else λ _, skip in
+let filter := if hide_non_prop then λ e, may_be_proof e >>= guardb else λ _, skip in
 tactic.explode.core filter e tt 0 (default _)
 
 meta def explode (n : name) : tactic unit :=
@@ -136,5 +143,6 @@ do n ← ident,
 .
 
 -- #explode iff_true_intro
+-- #explode nat.strong_rec_on
 
 end tactic


### PR DESCRIPTION
This adds the following features:
- For forall intro, it now explicitly refers to the lines where the conclusion is constructed and the assumption is introduced. For example, in the following exploded proof, line 6 also refers to line 1 now.
1│   │ h         ├ a
...
5│   │ hr        │ ┌ true
6│5  │ ∀I        │ true → a

- Proofs using ‘suffices’ can now be displayed, e.g., ‘nat.strong_rec_on’. 

TO CONTRIBUTORS:

Make sure you have:

 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)