### PR TITLE
feat(ring_theory/euclidean_domain): lemmas about ideals and euclidean domains

### DIFF
--- a/algebra/euclidean_domain.lean
+++ b/algebra/euclidean_domain.lean
@@ -101,6 +101,12 @@ by simpa only [zero_mul] using mul_div_cancel 0 a0
 @[simp] lemma div_self {a : α} (a0 : a ≠ 0) : a / a = 1 :=
 by simpa only [one_mul] using mul_div_cancel 1 a0
 
+lemma eq_div_of_mul_eq_left {a b c : α} (hb : b ≠ 0) (h : a * b = c) : a = c / b :=
+by rw [← h, mul_div_cancel _ hb]
+
+lemma eq_div_of_mul_eq_right {a b c : α} (ha : a ≠ 0) (h : a * b = c) : b = c / a :=
+by rw [← h, mul_div_cancel_left _ ha]
+
 section gcd
 variable [decidable_eq α]
 
@@ -140,6 +146,11 @@ gcd.induction a b
 theorem gcd_dvd_left (a b : α) : gcd a b ∣ a := (gcd_dvd a b).left
 
 theorem gcd_dvd_right (a b : α) : gcd a b ∣ b := (gcd_dvd a b).right
+
+protected theorem gcd_eq_zero_iff {a b : α} :
+  gcd a b = 0 ↔ a = 0 ∧ b = 0 :=
+⟨λ h, by simpa [h] using gcd_dvd a b,
+ by rintro ⟨rfl, rfl⟩; simp⟩
 
 theorem dvd_gcd {a b c : α} : c ∣ a → c ∣ b → c ∣ gcd a b :=
 gcd.induction a b
@@ -214,9 +225,9 @@ instance (α : Type*) [e : euclidean_domain α] : integral_domain α :=
 by haveI := classical.dec_eq α; exact
 { eq_zero_or_eq_zero_of_mul_eq_zero :=
     λ a b (h : a * b = 0), or_iff_not_and_not.2 $ λ h0 : a ≠ 0 ∧ b ≠ 0,
-      h0.1 $ by rw [← mul_div_cancel a h0.2, h, zero_div h0.2], 
+      h0.1 $ by rw [← mul_div_cancel a h0.2, h, zero_div h0.2],
   ..e }
-  
+
 end gcd
 
 instance : euclidean_domain ℤ :=

--- a/ring_theory/euclidean_domain.lean
+++ b/ring_theory/euclidean_domain.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Chris Hughes
+-/
+import algebra.euclidean_domain ring_theory.ideals ring_theory.associated
+noncomputable theory
+local attribute [instance] classical.dec
+open euclidean_domain set ideal
+
+theorem span_gcd {α} [euclidean_domain α] (x y : α) :
+  span ({gcd x y} : set α) = span ({x, y} : set α) :=
+begin
+  apply le_antisymm; refine span_le.1 _,
+  { simp [submodule.span_span, mem_span_pair, submodule.le_def', mem_span_singleton'],
+    assume a b ha,
+    exact ⟨b * gcd_a x y, b * gcd_b x y, by rw [← ha, gcd_eq_gcd_ab x y];
+      simp [mul_add, mul_comm, mul_left_comm]⟩ },
+  { assume z ,
+    simp [mem_span_singleton, euclidean_domain.gcd_dvd_left, mem_span_pair,
+      @eq_comm _ _ z] {contextual := tt},
+    assume a b h,
+    exact dvd_add (dvd_mul_of_dvd_right (gcd_dvd_left _ _) _)
+      (dvd_mul_of_dvd_right (gcd_dvd_right _ _) _) }
+end
+
+theorem gcd_is_unit_iff {α} [euclidean_domain α] {x y : α} :
+  is_unit (gcd x y) ↔ is_coprime x y :=
+by rw [← span_singleton_eq_top, span_gcd, is_coprime]
+
+theorem is_coprime_of_dvd {α} [euclidean_domain α] {x y : α}
+  (z : ¬ (x = 0 ∧ y = 0)) (H : ∀ z ∈ nonunits α, z ≠ 0 → z ∣ x → ¬ z ∣ y) :
+  is_coprime x y :=
+begin
+  rw [← gcd_is_unit_iff],
+  by_contra h,
+  refine H _ h _ (gcd_dvd_left _ _) (gcd_dvd_right _ _),
+  rwa [ne, euclidean_domain.gcd_eq_zero_iff]
+end
+
+theorem dvd_or_coprime {α} [euclidean_domain α] (x y : α)
+  (h : irreducible x) : x ∣ y ∨ is_coprime x y :=
+begin
+  refine or_iff_not_imp_left.2 (λ h', _),
+  unfreezeI, apply is_coprime_of_dvd,
+  { rintro ⟨rfl, rfl⟩, simpa using h },
+  { rintro z nu nz ⟨w, rfl⟩ dy,
+    refine h' (dvd.trans _ dy),
+    simpa using mul_dvd_mul_left z (is_unit_iff_dvd_one.1 $
+      (of_irreducible_mul h).resolve_left nu) }
+end

--- a/ring_theory/ideals.lean
+++ b/ring_theory/ideals.lean
@@ -14,6 +14,9 @@ local attribute [instance] classical.prop_decidable
 namespace ideal
 variable (I : ideal α)
 
+@[extensionality] lemma ext {I J : ideal α} (h : ∀ x, x ∈ I ↔ x ∈ J) : I = J :=
+submodule.ext h
+
 theorem eq_top_of_unit_mem
   (x y : α) (hx : x ∈ I) (h : y * x = 1) : I = ⊤ :=
 eq_top_iff.2 $ λ z _, calc
@@ -141,6 +144,27 @@ begin
     rcases submodule.mem_Sup_of_directed ((eq_top_iff_one _).1 H) I IS cC.directed_on with ⟨J, JS, J0⟩,
     exact SC JS ((eq_top_iff_one _).2 J0) }
 end
+
+def is_coprime (x y : α) : Prop :=
+span ({x, y} : set α) = ⊤
+
+theorem mem_span_pair {α} [comm_ring α] {x y z : α} :
+  z ∈ span (insert y {x} : set α) ↔ ∃ a b, a * x + b * y = z :=
+begin
+  simp only [mem_span_insert, mem_span_singleton', exists_prop],
+  split,
+  { rintros ⟨a, b, ⟨c, hc⟩, h⟩,
+    exact ⟨c, a, by simp [h, hc]⟩ },
+  { rintro ⟨b, c, e⟩, exact ⟨c, b * x, ⟨b, rfl⟩, by simp [e.symm]⟩ }
+end
+
+theorem is_coprime_def {α} [comm_ring α] {x y : α} :
+  is_coprime x y ↔ ∀ z, ∃ a b, a * x + b * y = z :=
+by simp [is_coprime, submodule.eq_top_iff', mem_span_pair]
+
+theorem is_coprime_self {α} [comm_ring α] (x y : α) :
+  is_coprime x x ↔ is_unit x :=
+by rw [← span_singleton_eq_top]; simp [is_coprime]
 
 end ideal
 


### PR DESCRIPTION
From the splitting fields branch. This stuff was not used in the definition of splitting fields in the end.

TO CONTRIBUTORS:

Make sure you have:

 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
