### PR TITLE
induction from start

### DIFF
--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -859,5 +859,10 @@ lemma with_bot.add_eq_one_iff : ∀ {n m : with_bot ℕ}, n + m = 1 ↔ (n = 0 �
 | (some n) (some (m + 1)) := by erw [with_bot.coe_eq_coe, with_bot.coe_eq_coe, with_bot.coe_eq_coe,
     with_bot.coe_eq_coe, with_bot.coe_eq_coe]; simp [nat.add_succ, nat.succ_inj', nat.succ_ne_zero]
 
+-- induction
+
+@[elab_as_eliminator] lemma le_induction {P : nat → Prop} {m} (h0 : P m) (h1 : ∀ n ≥ m, P n → P (n + 1)) : 
+  ∀ n ≥ m, P n :=
+by apply nat.less_than_or_equal.rec h0; exact h1
 
 end nat


### PR DESCRIPTION
Induction on nat, from a starting point which may be different from 0. Contributed by Mario on Zulip. I needed it for my developments and I am sure it will be useful to others also. Not sure about the name of the lemma, though.

