### PR TITLE
inhabited_of_nonempty with instance parameter

### DIFF
--- a/logic/basic.lean
+++ b/logic/basic.lean
@@ -694,4 +694,9 @@ lemma classical.nonempty_pi {α : Sort u} {β : α → Sort v} :
   nonempty (Πa:α, β a) ↔ (∀a:α, nonempty (β a)) :=
 iff.intro (assume ⟨f⟩ a, ⟨f a⟩) (assume f, ⟨assume a, classical.choice $ f a⟩)
 
+-- inhabited_of_nonempty already exists, in core/init/classical.lean, but the
+-- assumption is not [...], which makes it unsuitable for some applications
+noncomputable def classical.inhabited_of_nonempty' {α : Sort u} [h : nonempty α] : inhabited α :=
+⟨classical.choice h⟩
+
 end nonempty


### PR DESCRIPTION
inhabited_of_nonempty already exists, in core/init/classical.lean, but the
assumption is not [...], which makes it unsuitable for some applications