### PR TITLE
metric namespace

### DIFF
--- a/analysis/bounded_linear_maps.lean
+++ b/analysis/bounded_linear_maps.lean
@@ -20,6 +20,7 @@ local attribute [instance] classical.prop_decidable
 local notation f ` →_{`:50 a `} `:0 b := filter.tendsto f (nhds a) (nhds b)
 
 open filter (tendsto)
+open metric
 
 variables {k : Type*} [normed_field k]
 variables {E : Type*} [normed_space k E]

--- a/analysis/complex.lean
+++ b/analysis/complex.lean
@@ -8,7 +8,7 @@ Topology of the complex numbers.
 import data.complex.basic analysis.metric_space analysis.real
 
 noncomputable theory
-open filter
+open filter metric
 
 namespace complex
 

--- a/analysis/complex.lean
+++ b/analysis/complex.lean
@@ -24,12 +24,12 @@ instance : metric_space ℂ :=
 theorem dist_eq (x y : ℂ) : dist x y = (x - y).abs := rfl
 
 theorem uniform_continuous_add : uniform_continuous (λp : ℂ × ℂ, p.1 + p.2) :=
-uniform_continuous_of_metric.2 $ λ ε ε0,
+metric.uniform_continuous_iff.2 $ λ ε ε0,
 let ⟨δ, δ0, Hδ⟩ := rat_add_continuous_lemma abs ε0 in
 ⟨δ, δ0, λ a b h, let ⟨h₁, h₂⟩ := max_lt_iff.1 h in Hδ h₁ h₂⟩
 
 theorem uniform_continuous_neg : uniform_continuous (@has_neg.neg ℂ _) :=
-uniform_continuous_of_metric.2 $ λ ε ε0, ⟨_, ε0, λ a b h,
+metric.uniform_continuous_iff.2 $ λ ε ε0, ⟨_, ε0, λ a b h,
   by rw dist_comm at h; simpa [dist_eq] using h⟩
 
 instance : uniform_add_group ℂ :=
@@ -39,12 +39,12 @@ instance : topological_add_group ℂ := by apply_instance
 
 lemma uniform_continuous_inv (s : set ℂ) {r : ℝ} (r0 : 0 < r) (H : ∀ x ∈ s, r ≤ abs x) :
   uniform_continuous (λp:s, p.1⁻¹) :=
-uniform_continuous_of_metric.2 $ λ ε ε0,
+metric.uniform_continuous_iff.2 $ λ ε ε0,
 let ⟨δ, δ0, Hδ⟩ := rat_inv_continuous_lemma abs ε0 r0 in
 ⟨δ, δ0, λ a b h, Hδ (H _ a.2) (H _ b.2) h⟩
 
 lemma uniform_continuous_abs : uniform_continuous (abs : ℂ → ℝ) :=
-uniform_continuous_of_metric.2 $ λ ε ε0,
+metric.uniform_continuous_iff.2 $ λ ε ε0,
   ⟨ε, ε0, λ a b, lt_of_le_of_lt (abs_abs_sub_le_abs_sub _ _)⟩
 
 lemma continuous_abs : continuous (abs : ℂ → ℝ) :=
@@ -66,7 +66,7 @@ show continuous ((has_inv.inv ∘ @subtype.val ℂ (λr, r ≠ 0)) ∘ λa, ⟨f
   from (continuous_subtype_mk _ hf).comp continuous_inv'
 
 lemma uniform_continuous_mul_const {x : ℂ} : uniform_continuous ((*) x) :=
-uniform_continuous_of_metric.2 $ λ ε ε0, begin
+metric.uniform_continuous_iff.2 $ λ ε ε0, begin
   cases no_top (abs x) with y xy,
   have y0 := lt_of_le_of_lt (abs_nonneg _) xy,
   refine ⟨_, div_pos ε0 y0, λ a b h, _⟩,
@@ -78,7 +78,7 @@ lemma uniform_continuous_mul (s : set (ℂ × ℂ))
   {r₁ r₂ : ℝ} (r₁0 : 0 < r₁) (r₂0 : 0 < r₂)
   (H : ∀ x ∈ s, abs (x : ℂ × ℂ).1 < r₁ ∧ abs x.2 < r₂) :
   uniform_continuous (λp:s, p.1.1 * p.1.2) :=
-uniform_continuous_of_metric.2 $ λ ε ε0,
+metric.uniform_continuous_iff.2 $ λ ε ε0,
 let ⟨δ, δ0, Hδ⟩ := rat_mul_continuous_lemma abs ε0 r₁0 r₂0 in
 ⟨δ, δ0, λ a b h,
   let ⟨h₁, h₂⟩ := max_lt_iff.1 h in Hδ (H _ a.2).1 (H _ b.2).2 h₁ h₂⟩
@@ -100,17 +100,17 @@ tendsto_of_uniform_continuous_subtype
 local attribute [semireducible] real.le
 
 lemma uniform_continuous_re : uniform_continuous re :=
-uniform_continuous_of_metric.2 (λ ε ε0, ⟨ε, ε0, λ _ _, lt_of_le_of_lt (abs_re_le_abs _)⟩)
+metric.uniform_continuous_iff.2 (λ ε ε0, ⟨ε, ε0, λ _ _, lt_of_le_of_lt (abs_re_le_abs _)⟩)
 
 lemma continuous_re : continuous re := uniform_continuous_re.continuous
 
 lemma uniform_continuous_im : uniform_continuous im :=
-uniform_continuous_of_metric.2 (λ ε ε0, ⟨ε, ε0, λ _ _, lt_of_le_of_lt (abs_im_le_abs _)⟩)
+metric.uniform_continuous_iff.2 (λ ε ε0, ⟨ε, ε0, λ _ _, lt_of_le_of_lt (abs_im_le_abs _)⟩)
 
 lemma continuous_im : continuous im := uniform_continuous_im.continuous
 
 lemma uniform_continuous_of_real : uniform_continuous of_real :=
-uniform_continuous_of_metric.2 (λ ε ε0, ⟨ε, ε0, λ _ _,
+metric.uniform_continuous_iff.2 (λ ε ε0, ⟨ε, ε0, λ _ _,
   by rw [real.dist_eq, complex.dist_eq, of_real_eq_coe, of_real_eq_coe, ← of_real_sub, abs_of_real];
     exact id⟩)
 

--- a/analysis/emetric_space.lean
+++ b/analysis/emetric_space.lean
@@ -23,10 +23,8 @@ noncomputable theory
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
 
-namespace metric
-
-/--Characterizing uniformities associated to a (generalized) distance function `D`
-in terms of the elements of the uniformity.-/
+/-- Characterizing uniformities associated to a (generalized) distance function `D`
+in terms of the elements of the uniformity. -/
 theorem uniformity_dist_of_mem_uniformity [linear_order β] {U : filter (α × α)} (z : β) (D : α → α → β)
   (H : ∀ s, s ∈ U.sets ↔ ∃ε>z, ∀{a b:α}, D a b < ε → (a, b) ∈ s) :
   U = ⨅ ε>z, principal {p:α×α | D p.1 p.2 < ε} :=
@@ -38,7 +36,7 @@ le_antisymm
 class has_edist (α : Type*) := (edist : α → α → ennreal)
 export has_edist (edist)
 
-/-Design note: one could define an `emetric_space` just by giving `edist`, and then
+/- Design note: one could define an `emetric_space` just by giving `edist`, and then
 derive an instance of `uniform_space` by taking the natural uniform structure
 associated to the distance. This creates diamonds problem for products, as the
 uniform structure on the product of two emetric spaces could be obtained first
@@ -56,12 +54,9 @@ proof obligation, that this product uniformity is equal to the uniformity corres
 to the product metric. But the diamond problem disappears.
 
 The same trick is used in the definition of a metric space, where one stores as well
-a uniform structure and an edistance.
- -/
+a uniform structure and an edistance. -/
 
-namespace emetric
-
-/--Creating a uniform space from an extended distance.-/
+/-- Creating a uniform space from an extended distance. -/
 def uniform_space_of_edist
   (edist : α → α → ennreal)
   (edist_self : ∀ x : α, edist x x = 0)
@@ -86,7 +81,7 @@ uniform_space.of_core {
   symm       := tendsto_infi.2 $ assume ε, tendsto_infi.2 $ assume h,
     tendsto_infi' ε $ tendsto_infi' h $ tendsto_principal_principal.2 $ by simp [edist_comm] }
 
-/--Extended metric spaces, with an extended distance `edist` possibly taking the
+/-- Extended metric spaces, with an extended distance `edist` possibly taking the
 value ∞
 
 Each emetric space induces a canonical `uniform_space` and hence a canonical `topological_space`.
@@ -94,7 +89,7 @@ This is enforced in the type class definition, by extending the `uniform_space` 
 instantiating an `emetric_space` structure, the uniformity fields are not necessary, they will be
 filled in by default. There is a default value for the uniformity, that can be substituted
 in cases of interest, for instance when instantiating an `emetric_space` structure
-on a product.-/
+on a product. -/
 class emetric_space (α : Type u) extends has_edist α : Type u :=
 (edist_self : ∀ x : α, edist x x = 0)
 (eq_of_edist_eq_zero : ∀ {x y : α}, edist x y = 0 → x = y)
@@ -103,8 +98,8 @@ class emetric_space (α : Type u) extends has_edist α : Type u :=
 (to_uniform_space : uniform_space α := uniform_space_of_edist edist edist_self edist_comm edist_triangle)
 (uniformity_edist : uniformity = ⨅ ε>0, principal {p:α×α | edist p.1 p.2 < ε} . control_laws_tac)
 
-/-emetric spaces are less common than metric spaces. Therefore, we work in a dedicated
-namespace, while notions associated to metric spaces are mostly in the root namespace.-/
+/- emetric spaces are less common than metric spaces. Therefore, we work in a dedicated
+namespace, while notions associated to metric spaces are mostly in the root namespace. -/
 variables [emetric_space α]
 
 instance emetric_space.to_uniform_space' : uniform_space α :=
@@ -114,7 +109,7 @@ export emetric_space (edist_self eq_of_edist_eq_zero edist_comm edist_triangle)
 
 attribute [simp] edist_self
 
-/--Characterize the equality of points by the vanishing of their extended distance-/
+/-- Characterize the equality of points by the vanishing of their extended distance -/
 @[simp] theorem edist_eq_zero {x y : α} : edist x y = 0 ↔ x = y :=
 iff.intro eq_of_edist_eq_zero (assume : x = y, this ▸ edist_self _)
 
@@ -122,22 +117,26 @@ iff.intro eq_of_edist_eq_zero (assume : x = y, this ▸ edist_self _)
 iff.intro (assume h, eq_of_edist_eq_zero (h.symm))
           (assume : x = y, this ▸ (edist_self _).symm)
 
-/--Triangle inequality for the extended distance-/
+/-- Triangle inequality for the extended distance -/
 theorem edist_triangle_left (x y z : α) : edist x y ≤ edist z x + edist z y :=
 by rw edist_comm z; apply edist_triangle
 
 theorem edist_triangle_right (x y z : α) : edist x y ≤ edist x z + edist y z :=
 by rw edist_comm y; apply edist_triangle
 
-/--Reformulation of the uniform structure in terms of the extended distance-/
+/-- Two points coincide if their distance is `< ε` for all positive ε -/
+theorem eq_of_forall_edist_le {x y : α} (h : ∀ε, ε > 0 → edist x y ≤ ε) : x = y :=
+eq_of_edist_eq_zero (eq_of_le_of_forall_le_of_dense (by simp) h)
+
+/-- Reformulation of the uniform structure in terms of the extended distance -/
 theorem uniformity_edist' : uniformity = (⨅ ε>0, principal {p:α×α | edist p.1 p.2 < ε}) :=
 emetric_space.uniformity_edist _
 
-/--Reformulation of the uniform structure in terms of the extended distance on a subtype-/
+/-- Reformulation of the uniform structure in terms of the extended distance on a subtype -/
 theorem uniformity_edist'' : uniformity = (⨅ε:{ε:ennreal // ε>0}, principal {p:α×α | edist p.1 p.2 < ε.val}) :=
 by simp [infi_subtype]; exact uniformity_edist'
 
-/--Characterization of the elements of the uniformity in terms of the extended distance-/
+/-- Characterization of the elements of the uniformity in terms of the extended distance -/
 theorem mem_uniformity_edist {s : set (α×α)} :
   s ∈ (@uniformity α _).sets ↔ (∃ε>0, ∀{a b:α}, edist a b < ε → (a, b) ∈ s) :=
 begin
@@ -147,13 +146,15 @@ begin
   exact ⟨⟨1, ennreal.zero_lt_one⟩⟩
 end
 
-/--Fixed size neighborhoods of the diagonal belong to the uniform structure-/
+/-- Fixed size neighborhoods of the diagonal belong to the uniform structure -/
 theorem edist_mem_uniformity {ε:ennreal} (ε0 : 0 < ε) :
   {p:α×α | edist p.1 p.2 < ε} ∈ (@uniformity α _).sets :=
 mem_uniformity_edist.2 ⟨ε, ε0, λ a b, id⟩
 
-/-- ε-δ characterization of uniform continuity on emetric spaces-/
-theorem uniform_continuous_of_emetric [emetric_space β] {f : α → β} :
+namespace emetric
+
+/-- ε-δ characterization of uniform continuity on emetric spaces -/
+theorem uniform_continuous_iff [emetric_space β] {f : α → β} :
   uniform_continuous f ↔ ∀ ε > 0, ∃ δ > 0,
     ∀{a b:α}, edist a b < δ → edist (f a) (f b) < ε :=
 uniform_continuous_def.trans
@@ -162,8 +163,8 @@ uniform_continuous_def.trans
   let ⟨ε, ε0, hε⟩ := mem_uniformity_edist.1 ru, ⟨δ, δ0, hδ⟩ := H _ ε0 in
   mem_uniformity_edist.2 ⟨δ, δ0, λ a b h, hε (hδ h)⟩⟩
 
-/-- ε-δ characterization of uniform embeddings on emetric spaces-/
-theorem uniform_embedding_of_emetric [emetric_space β] {f : α → β} :
+/-- ε-δ characterization of uniform embeddings on emetric spaces -/
+theorem uniform_embedding_iff [emetric_space β] {f : α → β} :
   uniform_embedding f ↔ function.injective f ∧ uniform_continuous f ∧
     ∀ δ > 0, ∃ ε > 0, ∀ {a b : α}, edist (f a) (f b) < ε → edist a b < δ :=
 uniform_embedding_def'.trans $ and_congr iff.rfl $ and_congr iff.rfl
@@ -173,8 +174,8 @@ uniform_embedding_def'.trans $ and_congr iff.rfl $ and_congr iff.rfl
  λ H s su, let ⟨δ, δ0, hδ⟩ := mem_uniformity_edist.1 su, ⟨ε, ε0, hε⟩ := H _ δ0 in
   ⟨_, edist_mem_uniformity ε0, λ a b h, hδ (hε h)⟩⟩
 
-/-- ε-δ characterization of Cauchy sequences on emetric spaces-/
-lemma cauchy_of_emetric {f : filter α} :
+/-- ε-δ characterization of Cauchy sequences on emetric spaces -/
+lemma cauchy_iff {f : filter α} :
   cauchy f ↔ f ≠ ⊥ ∧ ∀ ε > 0, ∃ t ∈ f.sets, ∀ x y ∈ t, edist x y < ε :=
 cauchy_iff.trans $ and_congr iff.rfl
 ⟨λ H ε ε0, let ⟨t, tf, ts⟩ := H _ (edist_mem_uniformity ε0) in
@@ -183,11 +184,11 @@ cauchy_iff.trans $ and_congr iff.rfl
                ⟨t, tf, h⟩ := H ε ε0 in
    ⟨t, tf, λ ⟨x, y⟩ ⟨hx, hy⟩, hε (h x y hx hy)⟩⟩
 
-/--Two points coincide if their distance is `< ε` for all positive ε-/
-theorem eq_of_forall_edist_le {x y : α} (h : ∀ε, ε > 0 → edist x y ≤ ε) : x = y :=
-eq_of_edist_eq_zero (eq_of_le_of_forall_le_of_dense (by simp) h)
+end emetric
 
-/--An emetric space is separated-/
+open emetric
+
+/-- An emetric space is separated -/
 instance to_separated : separated α :=
 separated_def.2 $ λ x y h, eq_of_forall_edist_le $
 λ ε ε0, le_of_lt (h _ (edist_mem_uniformity ε0))
@@ -195,8 +196,8 @@ separated_def.2 $ λ x y h, eq_of_forall_edist_le $
 /-- Auxiliary function to replace the uniformity on an emetric space with
 a uniformity which is equal to the original one, but maybe not defeq.
 This is useful if one wants to construct an emetric space with a
-specified uniformity.-/
-def replace_uniformity {α} [U : uniform_space α] (m : emetric_space α)
+specified uniformity. -/
+def emetric_space.replace_uniformity {α} [U : uniform_space α] (m : emetric_space α)
   (H : @uniformity _ U = @uniformity _ (emetric_space.to_uniform_space α)) :
   emetric_space α :=
 { edist               := @edist _ m.to_has_edist,
@@ -207,8 +208,8 @@ def replace_uniformity {α} [U : uniform_space α] (m : emetric_space α)
   to_uniform_space    := U,
   uniformity_edist    := H.trans (@emetric_space.uniformity_edist α _) }
 
-/--The extended metric induced by an injective function taking values in an emetric space.-/
-def induced {α β} (f : α → β) (hf : function.injective f)
+/-- The extended metric induced by an injective function taking values in an emetric space. -/
+def emetric_space.induced {α β} (f : α → β) (hf : function.injective f)
   (m : emetric_space β) : emetric_space α :=
 { edist               := λ x y, edist (f x) (f y),
   edist_self          := λ x, edist_self _,
@@ -227,18 +228,18 @@ def induced {α β} (f : α → β) (hf : function.injective f)
       exact ⟨_, edist_mem_uniformity ε0, λ ⟨a, b⟩, hε⟩ }
   end }
 
-/--Emetric space instance on subsets of emetric spaces-/
+/-- Emetric space instance on subsets of emetric spaces -/
 instance {p : α → Prop} [t : emetric_space α] : emetric_space (subtype p) :=
-induced subtype.val (λ x y, subtype.eq) t
+t.induced subtype.val (λ x y, subtype.eq)
 
-/--The extended distance on a subset of an emetric space is the restriction of
-the original distance, by definition-/
+/-- The extended distance on a subset of an emetric space is the restriction of
+the original distance, by definition -/
 theorem subtype.edist_eq {p : α → Prop} [t : emetric_space α] (x y : subtype p) :
   edist x y = edist x.1 y.1 := rfl
 
-/--The product of two emetric spaces, with the max distance, is an extended
+/-- The product of two emetric spaces, with the max distance, is an extended
 metric spaces. We make sure that the uniform structure thus constructed is the one
-corresponding to the product of uniform spaces, to avoid diamond problems.-/
+corresponding to the product of uniform spaces, to avoid diamond problems. -/
 instance prod.emetric_space_max [emetric_space β] : emetric_space (α × β) :=
 { edist := λ x y, max (edist x.1 y.1) (edist x.2 y.2),
   edist_self := λ x, by simp,
@@ -265,11 +266,11 @@ section pi
 open finset
 variables {π : β → Type*} [fintype β]
 
-/--The product of a finite number of emetric spaces, with the max distance, is still
+/-- The product of a finite number of emetric spaces, with the max distance, is still
 an emetric space.
 This construction would also work for infinite products, but it would not give rise
 to the product topology. Hence, we only formalize it in the good situation of finitely many
-spaces.-/
+spaces. -/
 instance emetric_space_pi [∀b, emetric_space (π b)] : emetric_space (Πb, π b) :=
 { edist := λ f g, finset.sup univ (λb, edist (f b) (g b)),
   edist_self := assume f, bot_unique $ finset.sup_le $ by simp,
@@ -288,6 +289,3 @@ instance emetric_space_pi [∀b, emetric_space (π b)] : emetric_space (Πb, π 
     end }
 
 end pi
-
-end emetric
-end metric

--- a/analysis/ennreal.lean
+++ b/analysis/ennreal.lean
@@ -7,7 +7,7 @@ Extended non-negative reals
 -/
 import analysis.nnreal data.real.ennreal
 noncomputable theory
-open classical set lattice filter
+open classical set lattice filter metric
 local attribute [instance] prop_decidable
 variables {α : Type*} {β : Type*} {γ : Type*}
 

--- a/analysis/exponential.lean
+++ b/analysis/exponential.lean
@@ -10,7 +10,7 @@ open finset filter metric
 namespace complex
 
 lemma tendsto_exp_zero_one : tendsto exp (nhds 0) (nhds 1) :=
-tendsto_nhds_of_metric.2 $ λ ε ε0,
+tendsto_nhds_nhds.2 $ λ ε ε0,
   ⟨min (ε / 2) 1, lt_min (div_pos ε0 (by norm_num)) (by norm_num),
     λ x h, have h : abs x < min (ε / 2) 1, by simpa [dist_eq] using h,
       calc abs (exp x - 1) ≤ 2 * abs x : abs_exp_sub_one_le

--- a/analysis/exponential.lean
+++ b/analysis/exponential.lean
@@ -5,7 +5,7 @@ Authors: Chris Hughes
 -/
 import analysis.real analysis.complex tactic.linarith data.complex.exponential
 
-open finset filter
+open finset filter metric
 
 namespace complex
 

--- a/analysis/limits.lean
+++ b/analysis/limits.lean
@@ -8,7 +8,7 @@ A collection of limit properties.
 import algebra.big_operators algebra.group_power tactic.norm_num
   analysis.ennreal analysis.topology.infinite_sum
 noncomputable theory
-open classical finset function filter
+open classical finset function filter metric
 local attribute [instance] prop_decidable
 
 section real

--- a/analysis/metric_space.lean
+++ b/analysis/metric_space.lean
@@ -318,7 +318,7 @@ begin
   exact ⟨_, ⟨F ⟨x, xs⟩, rfl⟩, hF _ _ this.symm⟩
 end
 
-lemma cauchy_iff {f : filter α} :
+protected lemma cauchy_iff {f : filter α} :
   cauchy f ↔ f ≠ ⊥ ∧ ∀ ε > 0, ∃ t ∈ f.sets, ∀ x y ∈ t, dist x y < ε :=
 cauchy_iff.trans $ and_congr iff.rfl
 ⟨λ H ε ε0, let ⟨t, tf, ts⟩ := H _ (dist_mem_uniformity ε0) in
@@ -407,7 +407,7 @@ we need to show that the uniform structure coming from the edistance and the
 distance coincide. -/
 
 /-- Expressing the uniformity in terms of `edist` -/
-lemma mem_uniformity_edist {s : set (α×α)} :
+protected lemma metric.mem_uniformity_edist {s : set (α×α)} :
   s ∈ (@uniformity α _).sets ↔ (∃ε>0, ∀{a b:α}, edist a b < ε → (a, b) ∈ s) :=
 begin
   refine mem_uniformity_dist.trans ⟨_, _⟩; rintro ⟨ε, ε0, Hε⟩,
@@ -421,17 +421,17 @@ begin
     rwa [edist_dist, ennreal.coe_lt_coe, nnreal.of_real_lt_of_real_iff ε0'] }
 end
 
-theorem uniformity_edist' : uniformity = (⨅ε:{ε:ennreal // ε>0}, principal {p:α×α | edist p.1 p.2 < ε.val}) :=
+protected theorem metric.uniformity_edist' : uniformity = (⨅ε:{ε:ennreal // ε>0}, principal {p:α×α | edist p.1 p.2 < ε.val}) :=
 begin
   ext s, rw infi_sets_eq,
-  { simp [mem_uniformity_edist, subset_def] },
+  { simp [metric.mem_uniformity_edist, subset_def] },
   { rintro ⟨r, hr⟩ ⟨p, hp⟩, use ⟨min r p, lt_min hr hp⟩,
     simp [lt_min_iff, (≥)] {contextual := tt} },
   { exact ⟨⟨1, ennreal.zero_lt_one⟩⟩ }
 end
 
 theorem uniformity_edist : uniformity = (⨅ ε>0, principal {p:α×α | edist p.1 p.2 < ε}) :=
-by simpa [infi_subtype] using @uniformity_edist' α _
+by simpa [infi_subtype] using @metric.uniformity_edist' α _
 
 open emetric
 /-- A metric space induces an emetric space -/

--- a/analysis/metric_space.lean
+++ b/analysis/metric_space.lean
@@ -16,8 +16,6 @@ noncomputable theory
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
 
-namespace metric
-
 /-- Construct a uniform structure from a distance function and metric space axioms -/
 def uniform_space_of_dist
   (dist : α → α → ℝ)
@@ -133,9 +131,11 @@ by simpa [le_antisymm_iff, dist_nonneg] using @dist_eq_zero _ _ x y
 @[simp] theorem dist_pos {x y : α} : 0 < dist x y ↔ x ≠ y :=
 by simpa [-dist_le_zero] using not_congr (@dist_le_zero _ _ x y)
 
+@[simp] theorem abs_dist {a b : α} : abs (dist a b) = dist a b :=
+abs_of_nonneg dist_nonneg
 
-section
-variables [metric_space α]
+theorem eq_of_forall_dist_le {x y : α} (h : ∀ε, ε > 0 → dist x y ≤ ε) : x = y :=
+eq_of_dist_eq_zero (eq_of_le_of_forall_le_of_dense dist_nonneg h)
 
 def nndist (a b : α) : nnreal := ⟨dist a b, dist_nonneg⟩
 
@@ -193,7 +193,7 @@ by simpa [nnreal.coe_le] using dist_triangle_right x y z
 @[simp] lemma edist_eq_dist (x y : α) : ↑((edist x y).to_nnreal) = dist x y :=
 by rw [← dist_eq_edist]; simp; rw [nnreal.coe_of_real _ (metric_space.dist_nonneg x y)]
 
-end
+namespace metric
 
 /- instantiate metric space as a topology -/
 variables {x y z : α} {ε ε₁ ε₂ : ℝ} {s : set α}
@@ -271,7 +271,7 @@ theorem dist_mem_uniformity {ε:ℝ} (ε0 : 0 < ε) :
   {p:α×α | dist p.1 p.2 < ε} ∈ (@uniformity α _).sets :=
 mem_uniformity_dist.2 ⟨ε, ε0, λ a b, id⟩
 
-theorem uniform_continuous_of_metric [metric_space β] {f : α → β} :
+theorem uniform_continuous_iff [metric_space β] {f : α → β} :
   uniform_continuous f ↔ ∀ ε > 0, ∃ δ > 0,
     ∀{a b:α}, dist a b < δ → dist (f a) (f b) < ε :=
 uniform_continuous_def.trans
@@ -280,7 +280,7 @@ uniform_continuous_def.trans
   let ⟨ε, ε0, hε⟩ := mem_uniformity_dist.1 ru, ⟨δ, δ0, hδ⟩ := H _ ε0 in
   mem_uniformity_dist.2 ⟨δ, δ0, λ a b h, hε (hδ h)⟩⟩
 
-theorem uniform_embedding_of_metric [metric_space β] {f : α → β} :
+theorem uniform_embedding_iff [metric_space β] {f : α → β} :
   uniform_embedding f ↔ function.injective f ∧ uniform_continuous f ∧
     ∀ δ > 0, ∃ ε > 0, ∀ {a b : α}, dist (f a) (f b) < ε → dist a b < δ :=
 uniform_embedding_def'.trans $ and_congr iff.rfl $ and_congr iff.rfl
@@ -290,7 +290,7 @@ uniform_embedding_def'.trans $ and_congr iff.rfl $ and_congr iff.rfl
  λ H s su, let ⟨δ, δ0, hδ⟩ := mem_uniformity_dist.1 su, ⟨ε, ε0, hε⟩ := H _ δ0 in
   ⟨_, dist_mem_uniformity ε0, λ a b h, hδ (hε h)⟩⟩
 
-theorem totally_bounded_of_metric {s : set α} :
+theorem totally_bounded_iff {s : set α} :
   totally_bounded s ↔ ∀ ε > 0, ∃t : set α, finite t ∧ s ⊆ ⋃y∈t, ball y ε :=
 ⟨λ H ε ε0, H _ (dist_mem_uniformity ε0),
  λ H r ru, let ⟨ε, ε0, hε⟩ := mem_uniformity_dist.1 ru,
@@ -308,7 +308,7 @@ begin
   { rw hs, exact totally_bounded_empty },
   rcases exists_mem_of_ne_empty hs with ⟨x0, hx0⟩,
   haveI : inhabited s := ⟨⟨x0, hx0⟩⟩,
-  refine totally_bounded_of_metric.2 (λ ε ε0, _),
+  refine totally_bounded_iff.2 (λ ε ε0, _),
   rcases H ε ε0 with ⟨β, fβ, F, hF⟩,
   let Finv := function.inv_fun F,
   refine ⟨range (subtype.val ∘ Finv), finite_range _, λ x xs, _⟩,
@@ -318,7 +318,7 @@ begin
   exact ⟨_, ⟨F ⟨x, xs⟩, rfl⟩, hF _ _ this.symm⟩
 end
 
-lemma cauchy_of_metric {f : filter α} :
+lemma cauchy_iff {f : filter α} :
   cauchy f ↔ f ≠ ⊥ ∧ ∀ ε > 0, ∃ t ∈ f.sets, ∀ x y ∈ t, dist x y < ε :=
 cauchy_iff.trans $ and_congr iff.rfl
 ⟨λ H ε ε0, let ⟨t, tf, ts⟩ := H _ (dist_mem_uniformity ε0) in
@@ -327,7 +327,7 @@ cauchy_iff.trans $ and_congr iff.rfl
                ⟨t, tf, h⟩ := H ε ε0 in
    ⟨t, tf, λ ⟨x, y⟩ ⟨hx, hy⟩, hε (h x y hx hy)⟩⟩
 
-theorem nhds_eq_metric : nhds x = (⨅ε:{ε:ℝ // ε>0}, principal (ball x ε.val)) :=
+theorem nhds_eq : nhds x = (⨅ε:{ε:ℝ // ε>0}, principal (ball x ε.val)) :=
 begin
   rw [nhds_eq_uniformity, uniformity_dist', lift'_infi],
   { apply congr_arg, funext ε,
@@ -338,9 +338,9 @@ begin
   { intros, refl }
 end
 
-theorem mem_nhds_iff_metric : s ∈ (nhds x).sets ↔ ∃ε>0, ball x ε ⊆ s :=
+theorem mem_nhds_iff : s ∈ (nhds x).sets ↔ ∃ε>0, ball x ε ⊆ s :=
 begin
-  rw [nhds_eq_metric, infi_sets_eq],
+  rw [nhds_eq, infi_sets_eq],
   { simp },
   { intros y z, cases y with y hy, cases z with z hz,
     refine ⟨⟨min y z, lt_min hy hz⟩, _⟩,
@@ -348,54 +348,55 @@ begin
   { exact ⟨⟨1, zero_lt_one⟩⟩ }
 end
 
-theorem is_open_metric : is_open s ↔ ∀x∈s, ∃ε>0, ball x ε ⊆ s :=
-by simp [is_open_iff_nhds, mem_nhds_iff_metric]
+theorem is_open_iff : is_open s ↔ ∀x∈s, ∃ε>0, ball x ε ⊆ s :=
+by simp [is_open_iff_nhds, mem_nhds_iff]
 
 theorem is_open_ball : is_open (ball x ε) :=
-is_open_metric.2 $ λ y, exists_ball_subset_ball
+is_open_iff.2 $ λ y, exists_ball_subset_ball
 
 theorem ball_mem_nhds (x : α) {ε : ℝ} (ε0 : 0 < ε) : ball x ε ∈ (nhds x).sets :=
 mem_nhds_sets is_open_ball (mem_ball_self ε0)
 
-theorem tendsto_nhds_of_metric [metric_space β] {f : α → β} {a b} :
+theorem tendsto_nhds_nhds [metric_space β] {f : α → β} {a b} :
   tendsto f (nhds a) (nhds b) ↔
     ∀ ε > 0, ∃ δ > 0, ∀{x:α}, dist x a < δ → dist (f x) b < ε :=
-⟨λ H ε ε0, mem_nhds_iff_metric.1 (H (ball_mem_nhds _ ε0)),
+⟨λ H ε ε0, mem_nhds_iff.1 (H (ball_mem_nhds _ ε0)),
  λ H s hs,
-  let ⟨ε, ε0, hε⟩ := mem_nhds_iff_metric.1 hs, ⟨δ, δ0, hδ⟩ := H _ ε0 in
-  mem_nhds_iff_metric.2 ⟨δ, δ0, λ x h, hε (hδ h)⟩⟩
+  let ⟨ε, ε0, hε⟩ := mem_nhds_iff.1 hs, ⟨δ, δ0, hδ⟩ := H _ ε0 in
+  mem_nhds_iff.2 ⟨δ, δ0, λ x h, hε (hδ h)⟩⟩
 
-theorem continuous_of_metric [metric_space β] {f : α → β} :
+theorem continuous_iff [metric_space β] {f : α → β} :
   continuous f ↔
     ∀b (ε > 0), ∃ δ > 0, ∀a, dist a b < δ → dist (f a) (f b) < ε :=
-continuous_iff_tendsto.trans $ forall_congr $ λ b, tendsto_nhds_of_metric
+continuous_iff_tendsto.trans $ forall_congr $ λ b, tendsto_nhds_nhds
 
 theorem exists_delta_of_continuous [metric_space β] {f : α → β} {ε : ℝ}
   (hf : continuous f) (hε : ε > 0) (b : α) :
   ∃ δ > 0, ∀a, dist a b ≤ δ → dist (f a) (f b) < ε :=
-let ⟨δ, δ_pos, hδ⟩ := continuous_of_metric.1 hf b ε hε in
+let ⟨δ, δ_pos, hδ⟩ := continuous_iff.1 hf b ε hε in
 ⟨δ / 2, half_pos δ_pos, assume a ha, hδ a $ lt_of_le_of_lt ha $ div_two_lt_of_pos δ_pos⟩
 
-theorem tendsto_nhds_topo_metric {f : filter β} {u : β → α} {a : α} :
+theorem tendsto_nhds {f : filter β} {u : β → α} {a : α} :
   tendsto u f (nhds a) ↔ ∀ ε > 0, ∃ n ∈ f.sets, ∀x ∈ n,  dist (u x) a < ε :=
 ⟨λ H ε ε0, ⟨u⁻¹' (ball a ε), H (ball_mem_nhds _ ε0), by simp⟩,
  λ H s hs,
-  let ⟨ε, ε0, hε⟩ := mem_nhds_iff_metric.1 hs, ⟨δ, δ0, hδ⟩ := H _ ε0 in
+  let ⟨ε, ε0, hε⟩ := mem_nhds_iff.1 hs, ⟨δ, δ0, hδ⟩ := H _ ε0 in
   f.sets_of_superset δ0 (λx xδ, hε (hδ x xδ))⟩
 
-theorem continuous_topo_metric [topological_space β] {f : β → α} :
+theorem continuous_iff' [topological_space β] {f : β → α} :
   continuous f ↔ ∀a (ε > 0), ∃ n ∈ (nhds a).sets, ∀b ∈ n, dist (f b) (f a) < ε :=
-continuous_iff_tendsto.trans $ forall_congr $ λ b, tendsto_nhds_topo_metric
+continuous_iff_tendsto.trans $ forall_congr $ λ b, tendsto_nhds
 
-theorem tendsto_at_top_metric [inhabited β] [semilattice_sup β] {u : β → α} {a : α} :
+theorem tendsto_at_top [inhabited β] [semilattice_sup β] {u : β → α} {a : α} :
   tendsto u at_top (nhds a) ↔ ∀ε>0, ∃N, ∀n≥N, dist (u n) a < ε :=
-tendsto_nhds_topo_metric.trans $ ball_congr $ λ ε ε0,
+tendsto_nhds.trans $ ball_congr $ λ ε ε0,
 by simp; exact ⟨
   λ ⟨s, ⟨N, hN⟩, hs⟩, ⟨N, λn hn, hs _ (hN _ hn)⟩,
   λ ⟨N, hN⟩, ⟨{n | n ≥ N}, ⟨⟨N, by simp⟩, hN⟩⟩⟩
 
-theorem eq_of_forall_dist_le {x y : α} (h : ∀ε, ε > 0 → dist x y ≤ ε) : x = y :=
-eq_of_dist_eq_zero (eq_of_le_of_forall_le_of_dense dist_nonneg h)
+end metric
+
+open metric
 
 instance metric_space.to_separated : separated α :=
 separated_def.2 $ λ x y h, eq_of_forall_dist_le $
@@ -406,7 +407,7 @@ we need to show that the uniform structure coming from the edistance and the
 distance coincide. -/
 
 /-- Expressing the uniformity in terms of `edist` -/
-lemma mem_uniformity_dist_edist {s : set (α×α)} :
+lemma mem_uniformity_edist {s : set (α×α)} :
   s ∈ (@uniformity α _).sets ↔ (∃ε>0, ∀{a b:α}, edist a b < ε → (a, b) ∈ s) :=
 begin
   refine mem_uniformity_dist.trans ⟨_, _⟩; rintro ⟨ε, ε0, Hε⟩,
@@ -423,7 +424,7 @@ end
 theorem uniformity_edist' : uniformity = (⨅ε:{ε:ennreal // ε>0}, principal {p:α×α | edist p.1 p.2 < ε.val}) :=
 begin
   ext s, rw infi_sets_eq,
-  { simp [mem_uniformity_dist_edist, subset_def] },
+  { simp [mem_uniformity_edist, subset_def] },
   { rintro ⟨r, hr⟩ ⟨p, hp⟩, use ⟨min r p, lt_min hr hp⟩,
     simp [lt_min_iff, (≥)] {contextual := tt} },
   { exact ⟨⟨1, ennreal.zero_lt_one⟩⟩ }
@@ -433,8 +434,8 @@ theorem uniformity_edist : uniformity = (⨅ ε>0, principal {p:α×α | edist p
 by simpa [infi_subtype] using @uniformity_edist' α _
 
 open emetric
-/--A metric space induces an emetric space-/
-instance emetric_space_of_metric_space [a : metric_space α] : emetric_space α :=
+/-- A metric space induces an emetric space -/
+instance metric_space.to_emetric_space [a : metric_space α] : emetric_space α :=
 { edist               := edist,
   edist_self          := by simp [edist_dist],
   eq_of_edist_eq_zero := assume x y h,
@@ -464,9 +465,6 @@ theorem real.dist_eq (x y : ℝ) : dist x y = abs (x - y) := rfl
 theorem real.dist_0_eq_abs (x : ℝ) : dist x 0 = abs x :=
 by simp [real.dist_eq]
 
-@[simp] theorem abs_dist {a b : α} : abs (dist a b) = dist a b :=
-abs_of_nonneg dist_nonneg
-
 instance : orderable_topology ℝ :=
 orderable_topology_of_nhds_abs $ λ x, begin
   simp only [show ∀ r, {b : ℝ | abs (x - b) < r} = ball x r,
@@ -475,7 +473,7 @@ orderable_topology_of_nhds_abs $ λ x, begin
   { simp [le_infi_iff],
     exact λ ε ε0, mem_nhds_sets (is_open_ball) (mem_ball_self ε0) },
   { intros s h,
-    rcases mem_nhds_iff_metric.1 h with ⟨ε, ε0, ss⟩,
+    rcases mem_nhds_iff.1 h with ⟨ε, ε0, ss⟩,
     exact mem_infi_sets _ (mem_infi_sets ε0 (mem_principal_sets.2 ss)) },
 end
 
@@ -490,11 +488,11 @@ variables [inhabited β] [semilattice_sup β]
 
 /-- In a metric space, Cauchy sequences are characterized by the fact that, eventually,
 the distance between its elements is arbitrarily small -/
-theorem cauchy_seq_metric {u : β → α} :
+theorem metric.cauchy_seq_iff {u : β → α} :
   cauchy_seq u ↔ ∀ε>0, ∃N, ∀m n≥N, dist (u m) (u n) < ε :=
 begin
   unfold cauchy_seq,
-  rw cauchy_of_metric,
+  rw metric.cauchy_iff,
   simp only [true_and, exists_prop, filter.mem_at_top_sets, filter.at_top_ne_bot,
              filter.mem_map, ne.def, filter.map_eq_bot_iff, not_false_iff, set.mem_set_of_eq],
   split,
@@ -513,10 +511,10 @@ begin
 end
 
 /-- A variation around the metric characterization of Cauchy sequences -/
-theorem cauchy_seq_metric' {u : β → α} :
+theorem metric.cauchy_seq_iff' {u : β → α} :
   cauchy_seq u ↔ ∀ε>0, ∃N, ∀n≥N, dist (u n) (u N) < ε :=
 begin
-  rw cauchy_seq_metric,
+  rw metric.cauchy_seq_iff,
   split,
   { intros H ε εpos,
     rcases H ε εpos with ⟨N, hN⟩,
@@ -533,7 +531,7 @@ end
 theorem cauchy_seq_bdd {u : ℕ → α} (hu : cauchy_seq u) :
   ∃ R > 0, ∀ m n, dist (u m) (u n) < R :=
 begin
-  rcases cauchy_seq_metric'.1 hu 1 zero_lt_one with ⟨N, hN⟩,
+  rcases metric.cauchy_seq_iff'.1 hu 1 zero_lt_one with ⟨N, hN⟩,
   suffices : ∃ R > 0, ∀ n, dist (u n) (u N) < R,
   { rcases this with ⟨R, R0, H⟩,
     exact ⟨_, add_pos R0 R0, λ m n,
@@ -571,15 +569,15 @@ lemma cauchy_seq_iff_le_tendsto_0 {s : ℕ → α} : cauchy_seq s ↔ ∃ b : �
   have S0m : ∀ n, (0:ℝ) ∈ S n := λ n, ⟨⟨n, n⟩, ⟨le_refl _, le_refl _⟩, dist_self _⟩,
   have S0 := λ n, real.le_Sup _ (hS n) (S0m n),
   -- Prove that it tends to `0`, by using the Cauchy property of `s`
-  refine ⟨λ N, real.Sup (S N), S0, ub, tendsto_at_top_metric.2 (λ ε ε0, _)⟩,
-  refine (cauchy_seq_metric.1 hs (ε/2) (half_pos ε0)).imp (λ N hN n hn, _),
+  refine ⟨λ N, real.Sup (S N), S0, ub, metric.tendsto_at_top.2 (λ ε ε0, _)⟩,
+  refine (metric.cauchy_seq_iff.1 hs (ε/2) (half_pos ε0)).imp (λ N hN n hn, _),
   rw [real.dist_0_eq_abs, abs_of_nonneg (S0 n)],
   refine lt_of_le_of_lt (real.Sup_le_ub _ ⟨_, S0m _⟩ _) (half_lt_self ε0),
   rintro _ ⟨⟨m', n'⟩, ⟨hm', hn'⟩, rfl⟩,
   exact le_of_lt (hN _ _ (le_trans hn hm') (le_trans hn hn'))
   end,
-λ ⟨b, _, b_bound, b_lim⟩, cauchy_seq_metric.2 $ λ ε ε0,
-  (tendsto_at_top_metric.1 b_lim ε ε0).imp $ λ N hN m n hm hn,
+λ ⟨b, _, b_bound, b_lim⟩, metric.cauchy_seq_iff.2 $ λ ε ε0,
+  (metric.tendsto_at_top.1 b_lim ε ε0).imp $ λ N hN m n hm hn,
   calc dist (s m) (s n) ≤ b N : b_bound m n N hm hn
                     ... ≤ abs (b N) : le_abs_self _
                     ... = dist (b N) 0 : by rw real.dist_0_eq_abs; refl
@@ -598,7 +596,7 @@ def metric_space.replace_uniformity {α} [U : uniform_space α] (m : metric_spac
   edist              := edist,
   edist_dist         := edist_dist,
   to_uniform_space   := U,
-  uniformity_dist    := H.trans (@uniformity_dist α _) }
+  uniformity_dist    := H.trans (metric_space.uniformity_dist α) }
 
 def metric_space.induced {α β} (f : α → β) (hf : function.injective f)
   (m : metric_space β) : metric_space α :=
@@ -751,7 +749,7 @@ def metric_space_sum : metric_space (α ⊕ β) :=
 end sum
 
 theorem uniform_continuous_dist' : uniform_continuous (λp:α×α, dist p.1 p.2) :=
-uniform_continuous_of_metric.2 (λ ε ε0, ⟨ε/2, half_pos ε0,
+metric.uniform_continuous_iff.2 (λ ε ε0, ⟨ε/2, half_pos ε0,
 begin
   suffices,
   { intros p q h, cases p with p₁ p₂, cases q with q₁ q₂,
@@ -793,13 +791,16 @@ have h₁ : ∀ε, (λa', dist a' a) ⁻¹' ball 0 ε ⊆ ball a ε,
 have h₂ : tendsto (λa', dist a' a) (nhds a) (nhds (dist a a)),
   from tendsto_dist tendsto_id tendsto_const_nhds,
 le_antisymm
-  (by simp [h₁, nhds_eq_metric, infi_le_infi, principal_mono,
+  (by simp [h₁, nhds_eq, infi_le_infi, principal_mono,
       -le_principal_iff, -le_infi_iff])
   (by simpa [map_le_iff_le_comap.symm, tendsto] using h₂)
 
 lemma tendsto_iff_dist_tendsto_zero {f : β → α} {x : filter β} {a : α} :
   (tendsto f x (nhds a)) ↔ (tendsto (λb, dist (f b) a) x (nhds 0)) :=
 by rw [← nhds_comap_dist a, tendsto_comap_iff]
+
+namespace metric
+variables {x y z : α} {ε ε₁ ε₂ : ℝ} {s : set α}
 
 theorem is_closed_ball : is_closed (closed_ball x ε) :=
 is_closed_le (continuous_dist continuous_id continuous_const) continuous_const
@@ -818,7 +819,7 @@ begin
   intros H,
   apply mem_closure_iff.2,
   intros o ho ao,
-  rcases is_open_metric.1 ho a ao with ⟨ε, ⟨εpos, hε⟩⟩,
+  rcases is_open_iff.1 ho a ao with ⟨ε, ⟨εpos, hε⟩⟩,
   rcases H ε εpos with ⟨b, ⟨bs, bdist⟩⟩,
   have B : b ∈ o ∩ s := ⟨hε (by simpa [dist_comm]), bs⟩,
   apply ne_empty_of_mem B
@@ -827,6 +828,8 @@ end⟩
 theorem mem_of_closed' {α : Type u} [metric_space α] {s : set α} (hs : is_closed s)
   {a : α} : a ∈ s ↔ ∀ε>0, ∃b ∈ s, dist a b < ε :=
 by simpa only [closure_eq_of_is_closed hs] using @mem_closure_iff' _ _ s a
+
+end metric
 
 section pi
 open finset lattice
@@ -873,7 +876,7 @@ instance metric_space.first_countable_topology (α : Type u) [metric_space α] :
 ⟨assume a, ⟨⋃ i:ℕ, {ball a (i + 1 : ℝ)⁻¹},
   countable_Union $ assume n, countable_singleton _,
   suffices (⨅ i:{ i : ℝ // i > 0}, principal (ball a i)) = ⨅ (n : ℕ), principal (ball a (↑n + 1)⁻¹),
-    by simpa [nhds_eq_metric, @infi_comm _ _ ℕ],
+    by simpa [nhds_eq, @infi_comm _ _ ℕ],
   begin
     apply le_antisymm,
     { refine le_infi (assume n, infi_le_of_le _ _),
@@ -918,7 +921,7 @@ begin
   begin
     apply is_topological_basis_of_open_of_nhds A,
     intros a u au open_u,
-    rcases is_open_metric.1 open_u a au with ⟨ε, εpos, εball⟩,
+    rcases is_open_iff.1 open_u a au with ⟨ε, εpos, εball⟩,
     have : ε / 2 > 0 := half_pos εpos,
     /- The ball `ball a ε` is included in `u`. We need to find one of our balls `ball x (n⁻¹)`
     containing `a` and contained in `ball a ε`. For this, we take `n` larger than `2/ε`, and
@@ -928,7 +931,7 @@ begin
     have : 0 < (n : ℝ)⁻¹ := inv_pos this,
     have : (n : ℝ)⁻¹ < ε/2 := (inv_lt ‹ε/2 > 0› ‹(n : ℝ) > 0›).1 εn,
     have : (a : α) ∈ closure (S : set α) := by rw [S_dense]; simp,
-    rcases mem_closure_iff'.1 this _ ‹0 < (n : ℝ)⁻¹› with ⟨x, xS, xdist⟩,
+    rcases metric.mem_closure_iff'.1 this _ ‹0 < (n : ℝ)⁻¹› with ⟨x, xS, xdist⟩,
     have : a ∈ ball x (n⁻¹) := by simpa,
     have : ball x (n⁻¹) ⊆ ball a ε :=
     begin
@@ -944,7 +947,7 @@ begin
     have : ball x (n⁻¹) ⊆ u := subset.trans this εball,
     existsi ball x (↑n)⁻¹,
     simp,
-    exact ⟨⟨x, ⟨xS, ⟨n, rfl⟩⟩⟩, ⟨by assumption, by assumption⟩⟩,
+    exact ⟨⟨x, xS, n, rfl⟩, by assumption, by assumption⟩,
   end,
   exact B.2.2,
 end⟩⟩⟩
@@ -957,7 +960,7 @@ section compact
 radius -/
 lemma finite_cover_balls_of_compact {α : Type u} [metric_space α] {s : set α}
   (hs : compact s) {e : ℝ} (he : e > 0) :
-  ∃t ⊆ s, (finite t ∧ s ⊆ (⋃x∈t, ball x e)) :=
+  ∃t ⊆ s, finite t ∧ s ⊆ ⋃x∈t, ball x e :=
 begin
   apply compact_elim_finite_subcover_image hs,
   { simp [is_open_ball] },
@@ -968,7 +971,7 @@ end
 
 /-- A compact set in a metric space is separable, i.e., it is the closure of a countable set -/
 lemma countable_closure_of_compact {α : Type u} [metric_space α] {s : set α} (hs : compact s) :
-  ∃ t ⊆ s, (countable t ∧ s = closure t) :=
+  ∃ t ⊆ s, countable t ∧ s = closure t :=
 begin
   have A : ∀ (e:ℝ), e > 0 → ∃ t ⊆ s, (finite t ∧ s ⊆ (⋃x∈t, ball x e)) :=
     assume e, finite_cover_balls_of_compact hs,
@@ -988,7 +991,7 @@ begin
   have T₃ : s ⊆ closure t :=
   begin
     intros x x_in_s,
-    apply mem_closure_iff'.2,
+    apply metric.mem_closure_iff'.2,
     intros ε εpos,
     rcases exists_nat_gt ε⁻¹ with ⟨n, εn⟩,
     have : (n : ℝ) > 0 := lt_trans (inv_pos εpos) εn,
@@ -1009,6 +1012,7 @@ end
 end compact
 
 section proper_space
+open metric
 
 /-- A metric space is proper if all closed balls are compact. -/
 class proper_space (α : Type u) [metric_space α] : Prop :=
@@ -1026,7 +1030,7 @@ begin
   intros x,
   existsi closed_ball x 1,
   split,
-  { apply mem_nhds_iff_metric.2,
+  { apply mem_nhds_iff.2,
     existsi (1 : ℝ),
     simp,
     exact ⟨zero_lt_one, ball_subset_closed_ball⟩ },
@@ -1039,7 +1043,7 @@ instance complete_of_proper {α : Type u} [metric_space α] [proper_space α] : 
   intros f hf,
   /- We want to show that the Cauchy filter `f` is converging. It suffices to find a closed
   ball (therefore compact by properness) where it is nontrivial. -/
-  have A : ∃ t ∈ f.sets, ∀ x y ∈ t, dist x y < 1 := (cauchy_of_metric.1 hf).2 1 zero_lt_one,
+  have A : ∃ t ∈ f.sets, ∀ x y ∈ t, dist x y < 1 := (metric.cauchy_iff.1 hf).2 1 zero_lt_one,
   rcases A with ⟨t, ⟨t_fset, ht⟩⟩,
   rcases inhabited_of_mem_sets hf.1 t_fset with ⟨x, xt⟩,
   have : t ⊆ closed_ball x 1 := by intros y yt; simp [dist_comm]; apply le_of_lt (ht x y xt yt),
@@ -1106,14 +1110,15 @@ lemma lebesgue_number_lemma_of_metric_sUnion
 by rw sUnion_eq_Union at hc₂;
    simpa using lebesgue_number_lemma_of_metric hs (by simpa) hc₂
 
+namespace metric
 
 /-- Boundedness of a subset of a metric space. We formulate the definition to work
 even in the empty space. -/
-def bounded [metric_space α] (s : set α) : Prop :=
+def bounded (s : set α) : Prop :=
 ∃C, ∀x y ∈ s, dist x y ≤ C
 
 section bounded
-variables {t : set α} {r : ℝ}
+variables {x : α} {s t : set α} {r : ℝ}
 
 @[simp] lemma bounded_empty : bounded (∅ : set α) :=
 ⟨0, by simp⟩
@@ -1212,3 +1217,4 @@ lemma compact_iff_closed_bounded [proper_space α] :
 end⟩
 
 end bounded
+end metric

--- a/analysis/nnreal.lean
+++ b/analysis/nnreal.lean
@@ -7,7 +7,7 @@ Nonnegative real numbers.
 -/
 import data.real.nnreal analysis.real analysis.topology.infinite_sum
 noncomputable theory
-open set topological_space
+open set topological_space metric
 
 namespace nnreal
 local notation ` ℝ≥0 ` := nnreal

--- a/analysis/normed_space.lean
+++ b/analysis/normed_space.lean
@@ -339,15 +339,11 @@ begin
     have limf': tendsto (λ x, ∥f x - s∥) e (nhds 0) := tendsto_iff_norm_tendsto_zero.1 limf,
     have limg' : tendsto (λ x, ∥g x∥) e (nhds ∥b∥) := filter.tendsto.comp limg (continuous_iff_tendsto.1 continuous_norm _),
 
-    have lim1 : tendsto (λ x, ∥f x - s∥ * ∥g x∥) e (nhds 0),
-    { have := tendsto_mul limf' limg',
-      simp at this,
-      exact this },
+    have lim1 : tendsto (λ x, ∥f x - s∥ * ∥g x∥) e (nhds 0) :=
+      (zero_mul ∥b∥) ▸ tendsto_mul limf' limg',
     have limg3 := tendsto_iff_norm_tendsto_zero.1 limg,
-    have lim2 : tendsto (λ x, ∥s∥ * ∥g x - b∥) e (nhds 0),
-    { have := tendsto_mul tendsto_const_nhds limg3,
-      simp at this,
-      exact this },
+    have lim2 : tendsto (λ x, ∥s∥ * ∥g x - b∥) e (nhds 0) :=
+      (mul_zero ∥s∥) ▸ tendsto_mul tendsto_const_nhds limg3,
     rw [show (0:ℝ) = 0 + 0, by simp],
     exact tendsto_add lim1 lim2  }
 end

--- a/analysis/normed_space.lean
+++ b/analysis/normed_space.lean
@@ -340,11 +340,14 @@ begin
     have limg' : tendsto (λ x, ∥g x∥) e (nhds ∥b∥) := filter.tendsto.comp limg (continuous_iff_tendsto.1 continuous_norm _),
 
     have lim1 : tendsto (λ x, ∥f x - s∥ * ∥g x∥) e (nhds 0),
-      by simpa using tendsto_mul limf' limg',
+    { have := tendsto_mul limf' limg',
+      simp at this,
+      exact this },
     have limg3 := tendsto_iff_norm_tendsto_zero.1 limg,
     have lim2 : tendsto (λ x, ∥s∥ * ∥g x - b∥) e (nhds 0),
-      by simpa using tendsto_mul tendsto_const_nhds limg3,
-
+    { have := tendsto_mul tendsto_const_nhds limg3,
+      simp at this,
+      exact this },
     rw [show (0:ℝ) = 0 + 0, by simp],
     exact tendsto_add lim1 lim2  }
 end
@@ -378,7 +381,7 @@ instance fintype.normed_space {ι : Type*} {E : ι → Type*} [fintype ι] [∀i
     show (↑(finset.sup finset.univ (λ (b : ι), nnnorm (a • f b))) : ℝ) =
       nnnorm a * ↑(finset.sup finset.univ (λ (b : ι), nnnorm (f b))),
     by simp only [(nnreal.coe_mul _ _).symm, nnreal.mul_finset_sup, nnnorm_smul],
-  ..metric.metric_space_pi,
+  ..metric_space_pi,
   ..pi.vector_space α }
 
 end normed_space

--- a/analysis/normed_space.lean
+++ b/analysis/normed_space.lean
@@ -12,7 +12,7 @@ import analysis.nnreal
 variables {α : Type*} {β : Type*} {γ : Type*} {ι : Type*}
 
 noncomputable theory
-open filter
+open filter metric
 local notation f `→_{`:50 a `}`:0 b := tendsto f (nhds a) (nhds b)
 
 lemma squeeze_zero {α} {f g : α → ℝ} {t₀ : filter α} (hf : ∀t, 0 ≤ f t) (hft : ∀t, f t ≤ g t)
@@ -378,7 +378,7 @@ instance fintype.normed_space {ι : Type*} {E : ι → Type*} [fintype ι] [∀i
     show (↑(finset.sup finset.univ (λ (b : ι), nnnorm (a • f b))) : ℝ) =
       nnnorm a * ↑(finset.sup finset.univ (λ (b : ι), nnnorm (f b))),
     by simp only [(nnreal.coe_mul _ _).symm, nnreal.mul_finset_sup, nnnorm_smul],
-  ..metric_space_pi,
+  ..metric.metric_space_pi,
   ..pi.vector_space α }
 
 end normed_space

--- a/analysis/real.lean
+++ b/analysis/real.lean
@@ -24,7 +24,7 @@ generalizations:
 import logic.function analysis.metric_space tactic.linarith
 
 noncomputable theory
-open classical set lattice filter topological_space metric metric.real
+open classical set lattice filter topological_space metric
 local attribute [instance] prop_decidable
 
 universes u v w
@@ -55,7 +55,7 @@ uniform_embedding_comap rat.cast_injective
 theorem dense_embedding_of_rat : dense_embedding (coe : ℚ → ℝ) :=
 uniform_embedding_of_rat.dense_embedding $
 λ x, mem_closure_iff_nhds.2 $ λ t ht,
-let ⟨ε,ε0, hε⟩ := mem_nhds_iff_metric.1 ht in
+let ⟨ε,ε0, hε⟩ := mem_nhds_iff.1 ht in
 let ⟨q, h⟩ := exists_rat_near x ε0 in
 ne_empty_iff_exists_mem.2 ⟨_, hε (mem_ball'.2 h), q, rfl⟩
 
@@ -64,7 +64,7 @@ theorem embedding_of_rat : embedding (coe : ℚ → ℝ) := dense_embedding_of_r
 theorem continuous_of_rat : continuous (coe : ℚ → ℝ) := uniform_continuous_of_rat.continuous
 
 theorem real.uniform_continuous_add : uniform_continuous (λp : ℝ × ℝ, p.1 + p.2) :=
-uniform_continuous_of_metric.2 $ λ ε ε0,
+metric.uniform_continuous_iff.2 $ λ ε ε0,
 let ⟨δ, δ0, Hδ⟩ := rat_add_continuous_lemma abs ε0 in
 ⟨δ, δ0, λ a b h, let ⟨h₁, h₂⟩ := max_lt_iff.1 h in Hδ h₁ h₂⟩
 
@@ -75,11 +75,11 @@ uniform_embedding_of_rat.uniform_continuous_iff.2 $ by simp [(∘)]; exact
   (uniform_continuous_snd.comp uniform_continuous_of_rat)).comp real.uniform_continuous_add
 
 theorem real.uniform_continuous_neg : uniform_continuous (@has_neg.neg ℝ _) :=
-uniform_continuous_of_metric.2 $ λ ε ε0, ⟨_, ε0, λ a b h,
+metric.uniform_continuous_iff.2 $ λ ε ε0, ⟨_, ε0, λ a b h,
   by rw dist_comm at h; simpa [real.dist_eq] using h⟩
 
 theorem rat.uniform_continuous_neg : uniform_continuous (@has_neg.neg ℚ _) :=
-uniform_continuous_of_metric.2 $ λ ε ε0, ⟨_, ε0, λ a b h,
+metric.uniform_continuous_iff.2 $ λ ε ε0, ⟨_, ε0, λ a b h,
   by rw dist_comm at h; simpa [rat.dist_eq] using h⟩
 
 instance : uniform_add_group ℝ :=
@@ -120,19 +120,19 @@ _ -/
 
 lemma real.uniform_continuous_inv (s : set ℝ) {r : ℝ} (r0 : 0 < r) (H : ∀ x ∈ s, r ≤ abs x) :
   uniform_continuous (λp:s, p.1⁻¹) :=
-uniform_continuous_of_metric.2 $ λ ε ε0,
+metric.uniform_continuous_iff.2 $ λ ε ε0,
 let ⟨δ, δ0, Hδ⟩ := rat_inv_continuous_lemma abs ε0 r0 in
 ⟨δ, δ0, λ a b h, Hδ (H _ a.2) (H _ b.2) h⟩
 
 lemma real.uniform_continuous_abs : uniform_continuous (abs : ℝ → ℝ) :=
-uniform_continuous_of_metric.2 $ λ ε ε0,
+metric.uniform_continuous_iff.2 $ λ ε ε0,
   ⟨ε, ε0, λ a b, lt_of_le_of_lt (abs_abs_sub_abs_le_abs_sub _ _)⟩
 
 lemma real.continuous_abs : continuous (abs : ℝ → ℝ) :=
 real.uniform_continuous_abs.continuous
 
 lemma rat.uniform_continuous_abs : uniform_continuous (abs : ℚ → ℚ) :=
-uniform_continuous_of_metric.2 $ λ ε ε0,
+metric.uniform_continuous_iff.2 $ λ ε ε0,
   ⟨ε, ε0, λ a b h, lt_of_le_of_lt
     (by simpa [rat.dist_eq] using abs_abs_sub_abs_le_abs_sub _ _) h⟩
 
@@ -155,7 +155,7 @@ show continuous ((has_inv.inv ∘ @subtype.val ℝ (λr, r ≠ 0)) ∘ λa, ⟨f
   from (continuous_subtype_mk _ hf).comp real.continuous_inv'
 
 lemma real.uniform_continuous_mul_const {x : ℝ} : uniform_continuous ((*) x) :=
-uniform_continuous_of_metric.2 $ λ ε ε0, begin
+metric.uniform_continuous_iff.2 $ λ ε ε0, begin
   cases no_top (abs x) with y xy,
   have y0 := lt_of_le_of_lt (abs_nonneg _) xy,
   refine ⟨_, div_pos ε0 y0, λ a b h, _⟩,
@@ -167,7 +167,7 @@ lemma real.uniform_continuous_mul (s : set (ℝ × ℝ))
   {r₁ r₂ : ℝ} (r₁0 : 0 < r₁) (r₂0 : 0 < r₂)
   (H : ∀ x ∈ s, abs (x : ℝ × ℝ).1 < r₁ ∧ abs x.2 < r₂) :
   uniform_continuous (λp:s, p.1.1 * p.1.2) :=
-uniform_continuous_of_metric.2 $ λ ε ε0,
+metric.uniform_continuous_iff.2 $ λ ε ε0,
 let ⟨δ, δ0, Hδ⟩ := rat_mul_continuous_lemma abs ε0 r₁0 r₂0 in
 ⟨δ, δ0, λ a b h,
   let ⟨h₁, h₂⟩ := max_lt_iff.1 h in Hδ (H _ a.2).1 (H _ b.2).2 h₁ h₂⟩
@@ -209,7 +209,7 @@ by rw [real.ball_eq_Ioo, ← sub_div, add_comm, ← sub_add,
   add_assoc, add_sub_cancel'_right, add_self_div_two]
 
 lemma real.totally_bounded_Ioo (a b : ℝ) : totally_bounded (Ioo a b) :=
-totally_bounded_of_metric.2 $ λ ε ε0, begin
+metric.totally_bounded_iff.2 $ λ ε ε0, begin
   rcases exists_nat_gt ((b - a) / ε) with ⟨n, ba⟩,
   rw [div_lt_iff' ε0, sub_lt_iff_lt_add'] at ba,
   let s := (λ i:ℕ, a + ε * i) '' {i:ℕ | i < n},
@@ -255,7 +255,7 @@ instance : complete_space ℝ :=
 ⟨λ f cf, begin
   let g : ℕ → {ε:ℝ//ε>0} := λ n, ⟨n.to_pnat'⁻¹, inv_pos (nat.cast_pos.2 n.to_pnat'.pos)⟩,
   choose S hS hS_dist using show ∀n:ℕ, ∃t ∈ f.sets, ∀ x y ∈ t, dist x y < g n, from
-    assume n, let ⟨t, tf, h⟩ := (cauchy_of_metric.1 cf).2 (g n).1 (g n).2 in ⟨t, tf, h⟩,
+    assume n, let ⟨t, tf, h⟩ := (metric.cauchy_iff.1 cf).2 (g n).1 (g n).2 in ⟨t, tf, h⟩,
   let F : ℕ → set ℝ := λn, ⋂i≤n, S i,
   have hF : ∀n, F n ∈ f.sets := assume n, Inter_mem_sets (finite_le_nat n) (λ i _, hS i),
   have hF_dist : ∀n, ∀ x y ∈ F n, dist x y < g n :=
@@ -279,7 +279,7 @@ instance : complete_space ℝ :=
       bInter_subset_bInter_left (λ i h, @le_trans _ _ i n j h jn),
     exact lt_trans (hF_dist n _ _ (this (hG j)) (hG n)) (hn _ $ le_refl _) },
   refine ⟨cau_seq.lim c, λ s h, _⟩,
-  rcases mem_nhds_iff_metric.1 h with ⟨ε, ε0, hε⟩,
+  rcases metric.mem_nhds_iff.1 h with ⟨ε, ε0, hε⟩,
   cases exists_forall_ge_and (hg _ $ half_pos ε0)
     (cau_seq.equiv_lim c _ $ half_pos ε0) with n hn,
   cases hn _ (le_refl _) with h₁ h₂,
@@ -300,7 +300,7 @@ subset.antisymm
   ((closure_subset_iff_subset_of_is_closed (is_closed_ge' _)).2
     (image_subset_iff.2 $ λ p h, le_of_lt $ (@rat.cast_lt ℝ _ _ _).2 h)) $
 λ x hx, mem_closure_iff_nhds.2 $ λ t ht,
-let ⟨ε, ε0, hε⟩ := mem_nhds_iff_metric.1 ht in
+let ⟨ε, ε0, hε⟩ := metric.mem_nhds_iff.1 ht in
 let ⟨p, h₁, h₂⟩ := exists_rat_btwn ((lt_add_iff_pos_right x).2 ε0) in
 ne_empty_iff_exists_mem.2 ⟨_, hε (show abs _ < _,
     by rwa [abs_of_nonneg (le_of_lt $ sub_pos.2 h₁), sub_lt_iff_lt_add']),
@@ -334,7 +334,7 @@ have hax : a ≤ x, from le_Sup _ hx₁ ⟨ha, le_refl _, hab⟩,
 have hxb : x ≤ b, from (Sup_le _ hx₂ hx₁).2 (λ _ h, h.2.2),
 ⟨x, hax, hxb,
   eq_of_forall_dist_le $ λ ε ε0,
-    let ⟨δ, hδ0, hδ⟩ := tendsto_nhds_of_metric.1 (hf _ hax hxb) ε ε0 in
+    let ⟨δ, hδ0, hδ⟩ := metric.tendsto_nhds_nhds.1 (hf _ hax hxb) ε ε0 in
     (le_total t (f x)).elim
       (λ h, le_of_not_gt $ λ hfε, begin
         rw [dist_eq, abs_of_nonneg (sub_nonneg.2 h)] at hfε,

--- a/analysis/real.lean
+++ b/analysis/real.lean
@@ -24,7 +24,7 @@ generalizations:
 import logic.function analysis.metric_space tactic.linarith
 
 noncomputable theory
-open classical set lattice filter topological_space
+open classical set lattice filter topological_space metric metric.real
 local attribute [instance] prop_decidable
 
 universes u v w

--- a/analysis/topology/bounded_continuous_function.lean
+++ b/analysis/topology/bounded_continuous_function.lean
@@ -22,10 +22,10 @@ lemma continuous_of_locally_uniform_limit_of_continuous [topological_space α] [
   {F : ℕ → α → β} {f : α → β}
   (L : ∀x:α, ∃s ∈ (nhds x).sets, ∀ε>(0:ℝ), ∃n, ∀y∈s, dist (F n y) (f y) ≤ ε)
   (C : ∀ n, continuous (F n)) : continuous f :=
-continuous_topo_metric.2 $ λ x ε ε0, begin
+continuous_iff'.2 $ λ x ε ε0, begin
   rcases L x with ⟨r, rx, hr⟩,
   rcases hr (ε/2/2) (half_pos $ half_pos ε0) with ⟨n, hn⟩,
-  rcases continuous_topo_metric.1 (C n) x (ε/2) (half_pos ε0) with ⟨s, sx, hs⟩,
+  rcases continuous_iff'.1 (C n) x (ε/2) (half_pos ε0) with ⟨s, sx, hs⟩,
   refine ⟨_, (nhds x).inter_sets rx sx, _⟩,
   rintro y ⟨yr, ys⟩,
   calc dist (f y) (f x)
@@ -45,7 +45,7 @@ continuous_of_locally_uniform_limit_of_continuous $ λx,
 /-- A Lipschitz function is continuous -/
 lemma continuous_of_lipschitz [metric_space α] [metric_space β] {C : ℝ}
   {f : α → β} (H : ∀x y, dist (f x) (f y) ≤ C * dist x y) : continuous f :=
-continuous_of_metric.2 $ λ x ε ε0,
+continuous_iff.2 $ λ x ε ε0,
 have 0 < max C 1 := lt_of_lt_of_le zero_lt_one (le_max_right C 1),
 ⟨ε/max C 1, div_pos ε0 this, λ y hy, calc
   dist (f y) (f x) ≤ C * dist y x : H y x
@@ -137,9 +137,9 @@ instance [inhabited β] : inhabited (α →ᵇ β) := ⟨const (default β)⟩
 
 /-- The evaluation map is continuous, as a joint function of `u` and `x` -/
 theorem continuous_eval : continuous (λ p : (α →ᵇ β) × α, p.1 p.2) :=
-continuous_topo_metric.2 $ λ ⟨f, x⟩ ε ε0,
+continuous_iff'.2 $ λ ⟨f, x⟩ ε ε0,
 /- use the continuity of `f` to find a neighborhood of `x` where it varies at most by ε/2 -/
-let ⟨s, sx, Hs⟩ := continuous_topo_metric.1 f.2.1 x (ε/2) (half_pos ε0) in
+let ⟨s, sx, Hs⟩ := continuous_iff'.1 f.2.1 x (ε/2) (half_pos ε0) in
 /- s : set α, sx : s ∈ (nhds x).sets, Hs : ∀ (b : α), b ∈ s → dist (f.val b) (f.val x) < ε / 2 -/
 ⟨set.prod (ball f (ε/2)) s, prod_mem_nhds_sets (ball_mem_nhds _ (half_pos ε0)) sx,
 λ ⟨g, y⟩ ⟨hg, hy⟩, calc dist (g y) (f x)
@@ -175,7 +175,7 @@ begin
   refine ⟨⟨F, _, _⟩, _⟩,
   { /- Check that `F` is continuous -/
     refine continuous_of_uniform_limit_of_continuous (λ ε ε0, _) (λN, (f N).2.1),
-    rcases tendsto_at_top_metric.1 b_lim ε ε0 with ⟨N, hN⟩,
+    rcases metric.tendsto_at_top.1 b_lim ε ε0 with ⟨N, hN⟩,
     exact ⟨N, λy, calc
       dist (f N y) (F y) ≤ b N : fF_bdd y N
       ... ≤ dist (b N) 0 : begin simp, show b N ≤ abs(b N), from le_abs_self _ end
@@ -352,7 +352,7 @@ lemma equicontinuous_of_continuity_modulus {α : Type u} [metric_space α]
   (x:α) (ε : ℝ) (ε0 : ε > 0) : ∃U ∈ (nhds x).sets, ∀ (y z ∈ U) (f : α →ᵇ β),
     f ∈ A → dist (f y) (f z) < ε :=
 begin
-  rcases tendsto_nhds_of_metric.1 b_lim ε ε0 with ⟨δ, δ0, hδ⟩,
+  rcases tendsto_nhds_nhds.1 b_lim ε ε0 with ⟨δ, δ0, hδ⟩,
   refine ⟨ball x (δ/2), ball_mem_nhds x (half_pos δ0), λ y z hy hz f hf, _⟩,
   have : dist y z < δ := calc
     dist y z ≤ dist y x + dist z x : dist_triangle_right _ _ _

--- a/analysis/topology/bounded_continuous_function.lean
+++ b/analysis/topology/bounded_continuous_function.lean
@@ -12,7 +12,7 @@ import analysis.normed_space data.real.cau_seq_filter
 noncomputable theory
 local attribute [instance] classical.decidable_inhabited classical.prop_decidable
 
-open set lattice filter
+open set lattice filter metric
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}

--- a/data/padics/hensel.lean
+++ b/data/padics/hensel.lean
@@ -22,7 +22,7 @@ let ⟨z, hz⟩ := F.eval_sub_factor x y in calc
     ... ≤ 1 * ∥x - y∥ : mul_le_mul_of_nonneg_right (padic_norm_z.le_one _) (norm_nonneg _)
     ... = ∥x - y∥ : by simp
 
-open filter
+open filter metric
 
 private lemma comp_tendsto_lim {p : ℕ} [p.prime] {F : polynomial ℤ_[p]} (ncs : cau_seq ℤ_[p] norm) :
   tendsto (λ i, F.eval (ncs i)) at_top (nhds (F.eval ncs.lim)) :=

--- a/data/padics/padic_integers.lean
+++ b/data/padics/padic_integers.lean
@@ -93,7 +93,7 @@ variables {p : ℕ} [nat.prime p]
 
 @[reducible] def padic_norm_z (z : ℤ_[p]) : ℝ := ∥z.val∥
 
-instance : metric_space ℤ_[p] := metric.metric_space_subtype
+instance : metric_space ℤ_[p] := metric_space_subtype
 
 instance : has_norm ℤ_[p] := ⟨padic_norm_z⟩
 

--- a/data/padics/padic_integers.lean
+++ b/data/padics/padic_integers.lean
@@ -9,7 +9,7 @@ Define the p-adic integers ℤ_p as a subtype of ℚ_p. Construct algebraic stru
 import data.padics.padic_numbers ring_theory.ideals data.int.modeq
 import tactic.linarith
 
-open nat padic
+open nat padic metric
 noncomputable theory
 local attribute [instance] classical.prop_decidable
 
@@ -93,8 +93,7 @@ variables {p : ℕ} [nat.prime p]
 
 @[reducible] def padic_norm_z (z : ℤ_[p]) : ℝ := ∥z.val∥
 
-instance : metric_space ℤ_[p] :=
-subtype.metric_space
+instance : metric_space ℤ_[p] := metric.metric_space_subtype
 
 instance : has_norm ℤ_[p] := ⟨padic_norm_z⟩
 

--- a/data/padics/padic_numbers.lean
+++ b/data/padics/padic_numbers.lean
@@ -12,7 +12,7 @@ import data.padics.padic_norm algebra.archimedean analysis.normed_space
 noncomputable theory
 local attribute [instance, priority 1] classical.prop_decidable
 
-open nat padic_val padic_norm cau_seq cau_seq.completion
+open nat padic_val padic_norm cau_seq cau_seq.completion metric
 
 @[reducible] def padic_seq (p : ℕ) [p.prime] := cau_seq _ (padic_norm p)
 

--- a/data/real/cau_seq_filter.lean
+++ b/data/real/cau_seq_filter.lean
@@ -11,7 +11,7 @@ import analysis.topology.uniform_space analysis.normed_space data.real.cau_seq a
 import tactic.linarith
 
 universes u v
-open set filter classical
+open set filter classical metric
 
 variable {β : Type v}
 

--- a/data/real/cau_seq_filter.lean
+++ b/data/real/cau_seq_filter.lean
@@ -27,22 +27,22 @@ private lemma one_div_succ (n : ℕ) : 1 / ((n : ℝ) + 1) > 0 :=
 one_div_pos_of_pos (by linarith using [show (↑n : ℝ) ≥ 0, from nat.cast_nonneg _])
 
 def set_seq_of_cau_filter : ℕ → set β
-| 0 := some ((cauchy_of_metric.1 hf).2 _ (one_div_succ 0))
-| (n+1) := (set_seq_of_cau_filter n) ∩ some ((cauchy_of_metric.1 hf).2 _ (one_div_succ (n + 1)))
+| 0 := some ((metric.cauchy_iff.1 hf).2 _ (one_div_succ 0))
+| (n+1) := (set_seq_of_cau_filter n) ∩ some ((metric.cauchy_iff.1 hf).2 _ (one_div_succ (n + 1)))
 
 lemma set_seq_of_cau_filter_mem_sets : ∀ n, set_seq_of_cau_filter hf n ∈ f.sets
-| 0 := some (some_spec ((cauchy_of_metric.1 hf).2 _ (one_div_succ 0)))
+| 0 := some (some_spec ((metric.cauchy_iff.1 hf).2 _ (one_div_succ 0)))
 | (n+1) := inter_mem_sets (set_seq_of_cau_filter_mem_sets n)
-             (some (some_spec ((cauchy_of_metric.1 hf).2 _ (one_div_succ (n + 1)))))
+             (some (some_spec ((metric.cauchy_iff.1 hf).2 _ (one_div_succ (n + 1)))))
 
 lemma set_seq_of_cau_filter_inhabited (n : ℕ) : ∃ x, x ∈ set_seq_of_cau_filter hf n :=
-inhabited_of_mem_sets (cauchy_of_metric.1 hf).1 (set_seq_of_cau_filter_mem_sets hf n)
+inhabited_of_mem_sets (metric.cauchy_iff.1 hf).1 (set_seq_of_cau_filter_mem_sets hf n)
 
 lemma set_seq_of_cau_filter_spec : ∀ n, ∀ {x y},
   x ∈ set_seq_of_cau_filter hf n → y ∈ set_seq_of_cau_filter hf n → dist x y < 1/((n : ℝ) + 1)
-| 0 := some_spec (some_spec ((cauchy_of_metric.1 hf).2 _ (one_div_succ 0)))
+| 0 := some_spec (some_spec ((metric.cauchy_iff.1 hf).2 _ (one_div_succ 0)))
 | (n+1) := λ x y hx hy,
-  some_spec (some_spec ((cauchy_of_metric.1 hf).2 _ (one_div_succ (n+1)))) x y
+  some_spec (some_spec ((metric.cauchy_iff.1 hf).2 _ (one_div_succ (n+1)))) x y
     (mem_of_mem_inter_right hx) (mem_of_mem_inter_right hy)
 
 -- this must exist somewhere, no?
@@ -80,7 +80,7 @@ set_seq_of_cau_filter_spec hf _
 lemma cauchy_seq_of_dist_tendsto_0 {s : ℕ → β} {b : ℕ → ℝ} (h : ∀ {n k : ℕ}, n ≤ k → dist (s n) (s k) < b n)
   (hb : tendsto b at_top (nhds 0)) : cauchy_seq s :=
 begin
-  rw cauchy_seq_metric',
+  rw metric.cauchy_seq_iff',
   assume ε hε,
   have hb : ∀ (i : set ℝ), (0:ℝ) ∈ i → is_open i → (∃ (a : ℕ), ∀ (c : ℕ), c ≥ a → b c ∈ i),
   { simpa [tendsto, nhds] using hb },
@@ -126,12 +126,12 @@ begin
   simp at hs,
   rcases hs with ⟨t1, ht1, t2, ht2, ht1t2⟩,
   apply ne_empty_iff_exists_mem.2,
-  rcases mem_nhds_iff_metric.1 ht2 with ⟨ε, hε, ht2'⟩,
-  cases cauchy_of_metric.1 hf with hfb _,
+  rcases metric.mem_nhds_iff.1 ht2 with ⟨ε, hε, ht2'⟩,
+  cases metric.cauchy_iff.1 hf with hfb _,
   have : ε / 2 > 0, from div_pos hε (by norm_num),
   have : ∃ n : ℕ, 1 / (↑n + 1) < ε / 2, from exists_nat_one_div_lt this,
   cases this with n hnε,
-  cases tendsto_at_top_metric.1 H _ this with n2 hn2,
+  cases metric.tendsto_at_top.1 H _ this with n2 hn2,
   let N := max n n2,
   have hNε : 1 / (↑N+1) < ε / 2,
   { apply lt_of_le_of_lt _ hnε,
@@ -190,7 +190,7 @@ tendsto_nhds
 begin
   intros s lfs os,
   suffices : ∃ (a : ℕ), ∀ (b : ℕ), b ≥ a → f b ∈ s, by simpa using this,
-  rcases is_open_metric.1 os _ lfs with ⟨ε, ⟨hε, hεs⟩⟩,
+  rcases metric.is_open_iff.1 os _ lfs with ⟨ε, ⟨hε, hεs⟩⟩,
   cases setoid.symm (cau_seq.equiv_lim f) _ hε with N hN,
   existsi N,
   intros b hb,
@@ -264,7 +264,7 @@ begin
   assume u hu,
   have C : is_cau_seq norm u := cau_seq_iff_cauchy_seq.2 hu,
   existsi cau_seq.lim ⟨u, C⟩,
-  rw tendsto_at_top_metric,
+  rw metric.tendsto_at_top,
   assume ε εpos,
   cases (cau_seq.equiv_lim ⟨u, C⟩) _ εpos with N hN,
   existsi N,


### PR DESCRIPTION
Currently, all the notions about metric spaces are in the root namespace, contrary to essentially everything else in mathlib. This PR adds a metric namespace, puts the notions related to metric spaces in it, and opens it where necessary.

TO CONTRIBUTORS:

Make sure you have:

 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
