### PR TITLE
 refactor(unique_factorization_domain): simplify definition of UFD

### DIFF
--- a/data/multiset.lean
+++ b/data/multiset.lean
@@ -774,6 +774,9 @@ lemma prod_hom [comm_monoid α] [comm_monoid β] (f : α → β) [is_monoid_hom 
 multiset.induction_on s (by simp [is_monoid_hom.map_one f])
   (by simp [is_monoid_hom.map_mul f] {contextual := tt})
 
+lemma dvd_prod [comm_semiring α] {a : α} {s : multiset α} : a ∈ s → a ∣ s.prod :=
+quotient.induction_on s (λ l a h, by simpa using list.dvd_prod h) a
+
 lemma sum_hom [add_comm_monoid α] [add_comm_monoid β] (f : α → β) [is_add_monoid_hom f] (s : multiset α) :
   (s.map f).sum = f s.sum :=
 multiset.induction_on s (by simp [is_add_monoid_hom.map_zero f])

--- a/ring_theory/noetherian.lean
+++ b/ring_theory/noetherian.lean
@@ -348,4 +348,15 @@ well_founded.fix (well_founded_dvd_not_unit hα)
         hii.1, by rw [hb, mul_comm]⟩))
   a
 
+lemma exists_factors (a : α) : a ≠ 0 →
+  ∃f:multiset α, (∀b∈f, irreducible b) ∧ associated a f.prod :=
+is_noetherian_ring.irreducible_induction_on hα a
+  (λ h, (h rfl).elim)
+  (λ u hu _, ⟨0, by simp [associated_one_iff_is_unit, hu]⟩)
+  (λ a i ha0 hii ih hia0,
+    let ⟨s, hs⟩ := ih ha0 in
+    ⟨i::s, ⟨by clear _let_match; finish,
+      by rw multiset.prod_cons;
+        exact associated_mul_mul (by refl) hs.2⟩⟩)
+
 end is_noetherian_ring

--- a/ring_theory/principal_ideal_domain.lean
+++ b/ring_theory/principal_ideal_domain.lean
@@ -218,6 +218,7 @@ This is not added as type class instance, since the `factors` might be computed 
 E.g. factors could return normalized values.
 -/
 noncomputable def to_unique_factorization_domain : unique_factorization_domain α :=
+unique_factorization_domain.of_unique_irreducible_factorization
 { factors := factors,
   factors_prod := assume a ha, associated.symm (factors_spec a ha).2,
   irreducible_factors := assume a ha, (factors_spec a ha).1,

--- a/ring_theory/unique_factorization_domain.lean
+++ b/ring_theory/unique_factorization_domain.lean
@@ -19,11 +19,11 @@ represented as a multiset of irreducible factors.
 Uniqueness is only up to associated elements.
 
 This is equivalent to defining a unique factorization domain as a domain in
-which each element (except zero) is represented as a multiset of prime factors.
-This definition is used.
+which each element (except zero) is non-uniquely represented as a multiset
+of prime factors. This definition is used.
 
-To define a UFD using the traditional definition in terms of multisets of irreducible
-factors, use the definition `of_unique_irreducible_factorization
+To define a UFD using the traditional definition in terms of multisets
+of irreducible factors, use the definition `of_unique_irreducible_factorization`
 
 -/
 class unique_factorization_domain (α : Type*) [integral_domain α] :=
@@ -42,7 +42,7 @@ by haveI := classical.dec_eq α; exact
 if ha0 : a = 0 then ha0.symm ▸ h₁
 else @multiset.induction_on _
   (λ s : multiset α, ∀ (a : α), a ≠ 0 → s.prod ~ᵤ a → (∀ p ∈ s, prime p) →  P a)
-    (factors a)
+  (factors a)
   (λ _ _ h _, h₂ _ ((is_unit_iff_of_associated h.symm).2 is_unit_one))
   (λ p s ih a ha0 ⟨u, hu⟩ hsp,
     have ha : a = (p * u) * s.prod, by simp [hu.symm, mul_comm, mul_assoc],
@@ -84,7 +84,7 @@ else
       hq.2.symm ▸ by simp [this],
     irreducible_of_prime⟩
 
-lemma irreducible_factors :  ∀{a : α}, a ≠ 0 → ∀x∈factors a, irreducible x :=
+lemma irreducible_factors : ∀{a : α}, a ≠ 0 → ∀x∈factors a, irreducible x :=
 by simp only [irreducible_iff_prime]; exact @prime_factors _ _ _
 
 lemma unique : ∀{f g : multiset α},


### PR DESCRIPTION
UFD can be equivalently defined as an integral domain in which every non zero element is a non-uniquely represented as a product of a multiset of prime elements, as opposed to uniquely represented as a multiset of irreducible elements.

This PR redefines UFD, as well as proving equivalence to the traditional definition.

I also simplify the proof that PID -> UFD.

TO CONTRIBUTORS:

Make sure you have:

 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
