### PR TITLE
feat(.vscode): add copyright snippet

### DIFF
--- a/.vscode/copyright.code-snippets
+++ b/.vscode/copyright.code-snippets
@@ -1,0 +1,13 @@
+{
+	"Copyright header for mathlib": {
+		"scope": "lean",
+		"prefix": "copyright",
+		"body": [
+			"/-",
+			"Copyright (c) ${CURRENT_YEAR} $1. All rights reserved.",
+			"Released under Apache 2.0 license as described in the file LICENSE.",
+			"Authors: $1",
+			"-/"
+		]
+	}
+}


### PR DESCRIPTION
This PR adds a vscode snippet to add the copyright header.  (To use, just type `copyright`).  Suggested by @jcommelin.

TO CONTRIBUTORS:

Make sure you have:

 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

See https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Vscode.20Translations.20file/near/155075387

For reviewers: [code review check list](./docs/code-review.md)
