### PR TITLE
fix(tactic/simpa): in `simpa using e`, only close goal with `e`

### DIFF
--- a/data/padics/padic_norm.lean
+++ b/data/padics/padic_norm.lean
@@ -456,7 +456,7 @@ if hq : q = 0 then
 else if hr : r = 0 then
   by simp [hr, max_eq_left hnqp]
 else if hqr : q + r = 0 then
-  le_trans (by simpa [hqr] using padic_norm.nonneg) (le_max_left _ _)
+  le_trans (by simpa [hqr] using hnqp) (le_max_left _ _)
 else
   begin
     unfold padic_norm, split_ifs,

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -99,11 +99,18 @@ depth of splitting; the default is 5.
 
 ### simpa
 
-This is a "finishing" tactic modification of `simp`. The tactic `simpa
-[rules, ...] using e` will simplify the hypothesis `e` using `rules`,
-then simplify the goal using `rules`, and try to close the goal using
-`assumption`. If `e` is a term instead of a local constant, it is first
-added to the local context using `have`.
+This is a "finishing" tactic modification of `simp`. It has two forms.
+
+* `simpa [rules, ...] using e` will simplify the goal and the type of
+  `e` using `rules`, then try to close the goal using `e`.
+
+  Simplifying the type of `e` makes it more likely to match the goal
+  (which has also been simplified). This construction also tends to be
+  more robust under changes to the simp lemma set.
+
+* `simpa [rules, ...]` will simplify the goal and the type of a
+  hypothesis `this` if present, then try to close the goal using
+  the `assumption` tactic.
 
 ### replace
 

--- a/tactic/simpa.lean
+++ b/tactic/simpa.lean
@@ -11,17 +11,21 @@ open interactive interactive.types expr lean.parser
 local postfix `?`:9001 := optional
 
 /--
-This is a "finishing" tactic modification of `simp`. The tactic `simpa [rules, ...] using e`
-will simplify the hypothesis `e` using `rules`, then simplify the goal using `rules`, and
-try to close the goal using `assumption`. If `e` is a term instead of a local constant,
-it is first added to the local context using `have`.
--/
+This is a "finishing" tactic modification of `simp`.
+
+* `simpa [rules, ...] using e` will simplify the goal and the type of
+  `e` using `rules`, then try to close the goal using `e`.
+
+* `simpa [rules, ...]` will simplify the goal using `rules`, then try
+  to close it using `assumption`. -/
 meta def simpa (use_iota_eqn : parse $ (tk "!")?) (no_dflt : parse only_flag)
   (hs : parse simp_arg_list) (attr_names : parse with_ident_list)
   (tgt : parse (tk "using" *> texpr)?) (cfg : simp_config_ext := {}) : tactic unit :=
-let simp_at (lc) := try (simp use_iota_eqn no_dflt hs attr_names (loc.ns lc) cfg) >> (assumption <|> trivial) in
+let simp_at lc close_tac :=
+  try (simp use_iota_eqn no_dflt hs attr_names (loc.ns lc) cfg) >>
+  (close_tac <|> trivial) in
 match tgt with
-| none := get_local `this >> simp_at [some `this, none] <|> simp_at [none]
+| none := get_local `this >> simp_at [some `this, none] assumption <|> simp_at [none] assumption
 | some e := do
   e ← i_to_expr e <|> do {
     ty ← target,
@@ -32,10 +36,10 @@ match tgt with
       "inferrable. Try:\n\nsimpa ... using\nshow " ++
       to_fmt pty ++ ",\nfrom " ++ ptgt : format) },
   match e with
-  | local_const _ lc _ _ := simp_at [some lc, none]
+  | local_const _ lc _ _ := simp_at [some lc, none] (get_local lc >>= tactic.exact)
   | e := do
     t ← infer_type e,
-    assertv `this t e >> simp_at [some `this, none]
+    assertv `this t e >> simp_at [some `this, none] (get_local `this >>= tactic.exact)
   end
 end
 


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

Related Zulip discussion:
https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.23568.20metric.20namespace/near/155045224

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
