### PR TITLE
Add default setup for VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2,
+  "files.encoding": "utf8",
+  "files.eol": "\n",
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "files.trimTrailingWhitespace": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "editor.insertSpaces": true,
   "editor.tabSize": 2,
+  "editor.rulers" : [100],
   "files.encoding": "utf8",
   "files.eol": "\n",
   "files.insertFinalNewline": true,


### PR DESCRIPTION
This adds default setup for Visual Studio Code. 

Some files in the repository use CRLF line ending, lines with whitespace at the end, or whitespace at the end of the file. To normalize this I propose the settings setup in this file.

@gebner @Kha should we add something similar for Emacs?

Zulip reference: https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.23593.20Add.20default.20setup.20for.20VS.20Code