### PR TITLE
doc(elan.md): fix msys2 setup

### DIFF
--- a/docs/elan.md
+++ b/docs/elan.md
@@ -42,8 +42,9 @@ all users.
    On Linux and on macOS, this automatically appends a line to your `$HOME/.profile`
    which prepends `$HOME/.elan/bin` to your `$PATH`.
 
-   On Windows, this doesn't happen automatically, so you'll need to run
-   `echo 'PATH="$HOME/.elan/bin:$PATH"' >> $HOME/.profile` in the terminal.
+   On Windows, this doesn't happen automatically. 
+   * With Git for Windows you'll need to run `echo 'PATH="$HOME/.elan/bin:$PATH"' >> $HOME/.profile` in the terminal.
+   * With MSYS2 you'll need to run `echo 'PATH="/c/Users/$USERNAME/.elan/bin:$PATH"' >> $HOME/.bashrc`.
 
    It is recommended that you re-login,
    so that your environment knows about `elan`.


### PR DESCRIPTION
For me, adding the suggested line to .profile did not change my path, even after restarting the terminal.
Moreover, elan is installed in $USERPROFILE/.elan/bin, not in $HOME/.elan/bin.
Adding $USERPROFILE/.elan/bin to the path did not work for me, so I give the full path.
