### PR TITLE
fix(tactic/linarith): don't reject expressions with division by variables

### DIFF
--- a/src/tactic/linarith.lean
+++ b/src/tactic/linarith.lean
@@ -564,7 +564,7 @@ meta def find_cancel_factor : expr → ℕ × tree ℕ
 | `(%%e1 * %%e2) :=
   let (v1, t1) := find_cancel_factor e1, (v2, t2) := find_cancel_factor e2, pd := v1*v2 in
   (pd, tree.node pd t1 t2)
-| `(%%e1 / %%e2) := --do q ← is_numeric e2, return q.num.nat_abs
+| `(%%e1 / %%e2) :=
   match is_numeric e2 with
   | some q := let (v1, t1) := find_cancel_factor e1, n := v1.lcm q.num.nat_abs in
     (n, tree.node n t1 (tree.node q.num.nat_abs tree.nil tree.nil))
@@ -622,6 +622,7 @@ by rwa he at hl
 
 meta def norm_hyp_aux (h' lhs : expr) : tactic expr :=
 do (v, lhs') ← kill_factors lhs,
+   if v = 1 then return h' else do 
    (ih, h'') ← mk_single_comp_zero_pf v h',
    (_, nep, _) ← infer_type h'' >>= rewrite_core lhs',
    mk_eq_mp nep h''

--- a/tests/linarith.lean
+++ b/tests/linarith.lean
@@ -98,3 +98,6 @@ by linarith
 
 example (a b i : ℕ) (h1 :  ¬ a < i) (h2 : b < i) (h3 : a ≤ b) : false :=
 by linarith
+
+example (a b c : ℚ) (h1 : 1 / a < b) (h2 : b < c) : 1 / a < c := 
+by linarith


### PR DESCRIPTION
This was an unfortunate special case in the denominator normalization routine. Fixes the example reported by @kbuzzard on Zulip: https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/linarith.20failure

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
