### PR TITLE
add ennreal.to_real

### DIFF
--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -38,25 +38,45 @@ protected def to_nnreal : ennreal → nnreal
 | (some r) := r
 | none := 0
 
+/-- `to_real x` returns `x` if it is real, `0` otherwise. -/
+protected def to_real (a : ennreal) : real := coe (a.to_nnreal)
+
+/-- `of_real x` returns `x` if it is nonnegative, `0` otherwise. -/
+protected def of_real (r : real) : ennreal := coe (nnreal.of_real r)
+
 @[simp] lemma to_nnreal_coe : (r : ennreal).to_nnreal = r := rfl
 
 @[simp] lemma coe_to_nnreal : ∀{a:ennreal}, a ≠ ∞ → ↑(a.to_nnreal) = a
 | (some r) h := rfl
 | none     h := (h rfl).elim
 
+@[simp] lemma of_real_to_real {a : ennreal} (h : a ≠ ∞) : ennreal.of_real (a.to_real) = a :=
+by simp [ennreal.to_real, ennreal.of_real, h]
+
+@[simp] lemma to_real_of_real {r : real} (h : 0 ≤ r) : ennreal.to_real (ennreal.of_real r) = r :=
+by simp [ennreal.to_real, ennreal.of_real, nnreal.coe_of_real _ h]
+
 lemma coe_to_nnreal_le_self : ∀{a:ennreal}, ↑(a.to_nnreal) ≤ a
 | (some r) := by rw [some_eq_coe, to_nnreal_coe]; exact le_refl _
 | none     := le_top
 
+@[simp] lemma coe_zero : ↑(0 : nnreal) = (0 : ennreal) := rfl
+@[simp] lemma coe_one : ↑(1 : nnreal) = (1 : ennreal) := rfl
+
+@[simp] lemma to_real_nonneg {a : ennreal} : 0 ≤ a.to_real := by simp [ennreal.to_real]
+
 @[simp] lemma top_to_nnreal : ∞.to_nnreal = 0 := rfl
+@[simp] lemma top_to_real : ∞.to_real = 0 := rfl
 @[simp] lemma zero_to_nnreal : (0 : ennreal).to_nnreal = 0 := rfl
+@[simp] lemma zero_to_real : (0 : ennreal).to_real = 0 := rfl
+@[simp] lemma of_real_zero : ennreal.of_real (0 : ℝ) = 0 :=
+by simp [ennreal.of_real]; refl
+@[simp] lemma of_real_one : ennreal.of_real (1 : ℝ) = (1 : ennreal) :=
+by simp [ennreal.of_real]
 
 lemma forall_ennreal {p : ennreal → Prop} : (∀a, p a) ↔ (∀r:nnreal, p r) ∧ p ∞ :=
 ⟨assume h, ⟨assume r, h _, h _⟩,
   assume ⟨h₁, h₂⟩ a, match a with some r := h₁ _ | none := h₂ end⟩
-
-@[simp] lemma coe_zero : ↑(0 : nnreal) = (0 : ennreal) := rfl
-@[simp] lemma coe_one : ↑(1 : nnreal) = (1 : ennreal) := rfl
 
 lemma to_nnreal_eq_zero_iff (x : ennreal) : x.to_nnreal = 0 ↔ x = 0 ∨ x = ⊤ :=
 ⟨begin
@@ -67,8 +87,13 @@ lemma to_nnreal_eq_zero_iff (x : ennreal) : x.to_nnreal = 0 ↔ x = 0 ∨ x = �
 end,
 by intro h; cases h; simp [h]⟩
 
+lemma to_real_eq_zero_iff (x : ennreal) : x.to_real = 0 ↔ x = 0 ∨ x = ⊤ :=
+by simp [ennreal.to_real, to_nnreal_eq_zero_iff]
+
 @[simp] lemma coe_ne_top : (r : ennreal) ≠ ∞ := with_top.coe_ne_top
 @[simp] lemma top_ne_coe : ∞ ≠ (r : ennreal) := with_top.top_ne_coe
+@[simp] lemma of_real_ne_top {r : ℝ} : ennreal.of_real r ≠ ∞ := by simp [ennreal.of_real]
+@[simp] lemma top_ne_of_real {r : ℝ} : ∞ ≠ ennreal.of_real r := by simp [ennreal.of_real]
 
 @[simp] lemma zero_ne_top : 0 ≠ ∞ := coe_ne_top
 @[simp] lemma top_ne_zero : ∞ ≠ 0 := top_ne_coe
@@ -176,7 +201,7 @@ lemma lt_iff_exists_rat_btwn :
 λ ⟨q, q0, qa, qb⟩, lt_trans qa qb⟩
 
 lemma lt_iff_exists_real_btwn :
-  a < b ↔ (∃r:ℝ, 0 ≤ r ∧ a < nnreal.of_real r ∧ (nnreal.of_real r:ennreal) < b) :=
+  a < b ↔ (∃r:ℝ, 0 ≤ r ∧ a < ennreal.of_real r ∧ (ennreal.of_real r:ennreal) < b) :=
 ⟨λ h, let ⟨q, q0, aq, qb⟩ := ennreal.lt_iff_exists_rat_btwn.1 h in
   ⟨q, rat.cast_nonneg.2 q0, aq, qb⟩,
 λ ⟨q, q0, qa, qb⟩, lt_trans qa qb⟩
@@ -517,6 +542,59 @@ begin
   exact ⟨n, lt_of_le_of_lt I ba⟩
 end
 end inv
+
+section real
+
+lemma to_real_add (ha : a ≠ ⊤) (hb : b ≠ ⊤) : (a+b).to_real = a.to_real + b.to_real :=
+begin
+  cases a,
+  { simpa [none_eq_top] using ha },
+  cases b,
+  { simpa [none_eq_top] using hb },
+  refl
+end
+
+lemma of_real_add {p q : ℝ} (hp : 0 ≤ p) (hq : 0 ≤ q) :
+  ennreal.of_real (p + q) = ennreal.of_real p + ennreal.of_real q :=
+by rw [ennreal.of_real, ennreal.of_real, ennreal.of_real, ← coe_add,
+       coe_eq_coe, nnreal.of_real_add hp hq]
+
+@[simp] lemma to_real_le_to_real (ha : a ≠ ⊤) (hb : b ≠ ⊤) : a.to_real ≤ b.to_real ↔ a ≤ b :=
+begin
+  cases a,
+  { simpa [none_eq_top] using ha },
+  cases b,
+  { simpa [none_eq_top] using hb },
+  simp only [ennreal.to_real, nnreal.coe_le.symm, with_top.some_le_some],
+  refl
+end
+
+@[simp] lemma to_real_lt_to_real (ha : a ≠ ⊤) (hb : b ≠ ⊤) : a.to_real < b.to_real ↔ a < b :=
+begin
+  cases a,
+  { simpa [none_eq_top] using ha },
+  cases b,
+  { simpa [none_eq_top] using hb },
+  rw [with_top.some_lt_some],
+  refl
+end
+
+lemma of_real_le_of_real {p q : ℝ} (h : p ≤ q) : ennreal.of_real p ≤ ennreal.of_real q :=
+by simp [ennreal.of_real, nnreal.of_real_le_of_real h]
+
+@[simp] lemma of_real_le_of_real_iff {p q : ℝ} (h : 0 ≤ q) : ennreal.of_real p ≤ ennreal.of_real q ↔ p ≤ q :=
+by rw [ennreal.of_real, ennreal.of_real, coe_le_coe, nnreal.of_real_le_of_real_iff h]
+
+@[simp] lemma of_real_lt_of_real_iff {p q : ℝ} (h : 0 < q) : ennreal.of_real p < ennreal.of_real q ↔ p < q :=
+by rw [ennreal.of_real, ennreal.of_real, coe_lt_coe, nnreal.of_real_lt_of_real_iff h]
+
+@[simp] lemma of_real_pos {p : ℝ} : 0 < ennreal.of_real p ↔ 0 < p :=
+by simp [ennreal.of_real]
+
+@[simp] lemma of_real_eq_zero {p : ℝ} : ennreal.of_real p = 0 ↔ p ≤ 0 :=
+by simp [ennreal.of_real]
+
+end real
 
 section infi
 variables {ι : Sort*} {f g : ι → ennreal}

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -240,6 +240,9 @@ section of_real
 @[simp] lemma of_real_zero : nnreal.of_real 0 = 0 :=
 by simp [nnreal.of_real]; refl
 
+@[simp] lemma of_real_one : nnreal.of_real 1 = 1 :=
+by simp [nnreal.of_real, max_eq_left (zero_le_one : (0 :ℝ) ≤ 1)]; refl
+
 @[simp] lemma of_real_pos {r : ℝ} : 0 < nnreal.of_real r ↔ 0 < r :=
 by simp [nnreal.of_real, nnreal.coe_lt, lt_irrefl]
 

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -88,6 +88,13 @@ begin
   exact prod_mem_nhds_sets coe_range_mem_nhds coe_range_mem_nhds
 end
 
+lemma continuous_of_real : continuous ennreal.of_real :=
+continuous.comp nnreal.continuous_of_real (continuous_coe.2 continuous_id)
+
+lemma tendsto_of_real {f : filter α} {m : α → ℝ} {a : ℝ} (h : tendsto m f (nhds a)) :
+  tendsto (λa, ennreal.of_real (m a)) f (nhds (ennreal.of_real a)) :=
+tendsto.comp h (continuous.tendsto continuous_of_real _)
+
 lemma tendsto_to_nnreal {a : ennreal} : a ≠ ⊤ →
   tendsto (ennreal.to_nnreal) (nhds a) (nhds a.to_nnreal) :=
 begin

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -60,8 +60,8 @@ class metric_space (α : Type u) extends has_dist α : Type u :=
 (eq_of_dist_eq_zero : ∀ {x y : α}, dist x y = 0 → x = y)
 (dist_comm : ∀ x y : α, dist x y = dist y x)
 (dist_triangle : ∀ x y z : α, dist x z ≤ dist x y + dist y z)
-(edist : α → α → ennreal := λx y, nnreal.of_real (dist x y))
-(edist_dist : ∀ x y : α, edist x y = ↑(nnreal.of_real (dist x y)) . control_laws_tac)
+(edist : α → α → ennreal := λx y, ennreal.of_real (dist x y))
+(edist_dist : ∀ x y : α, edist x y = ennreal.of_real (dist x y) . control_laws_tac)
 (to_uniform_space : uniform_space α := uniform_space_of_dist dist dist_self dist_comm dist_triangle)
 (uniformity_dist : uniformity = ⨅ ε>0, principal {p:α×α | dist p.1 p.2 < ε} . control_laws_tac)
 
@@ -79,7 +79,7 @@ metric_space.eq_of_dist_eq_zero
 
 theorem dist_comm (x y : α) : dist x y = dist y x := metric_space.dist_comm x y
 
-theorem edist_dist (x y : α) : edist x y = ↑(nnreal.of_real (dist x y)) :=
+theorem edist_dist (x y : α) : edist x y = ennreal.of_real (dist x y) :=
 metric_space.edist_dist _ x y
 
 @[simp] theorem dist_eq_zero {x y : α} : dist x y = 0 ↔ x = y :=
@@ -140,12 +140,12 @@ eq_of_dist_eq_zero (eq_of_le_of_forall_le_of_dense dist_nonneg h)
 def nndist (a b : α) : nnreal := ⟨dist a b, dist_nonneg⟩
 
 /--Express `nndist` in terms of `edist`-/
-@[simp] lemma edist_eq_nndist (x y : α) : (edist x y).to_nnreal = nndist x y :=
-by simp [nndist, edist_dist, nnreal.of_real, max_eq_left dist_nonneg]
+lemma nndist_edist (x y : α) : nndist x y = (edist x y).to_nnreal :=
+by simp [nndist, edist_dist, nnreal.of_real, max_eq_left dist_nonneg, ennreal.of_real]
 
 /--Express `edist` in terms of `nndist`-/
-@[simp] lemma nndist_eq_edist (x y : α) : ↑(nndist x y) = edist x y :=
-by simp [nndist, edist_dist, nnreal.of_real, max_eq_left dist_nonneg]
+lemma edist_nndist (x y : α) : edist x y = ↑(nndist x y) :=
+by simp [nndist, edist_dist, nnreal.of_real, max_eq_left dist_nonneg, ennreal.of_real]
 
 /--In a metric space, the extended distance is always finite-/
 lemma edist_ne_top (x y : α) : edist x y ≠ ⊤ :=
@@ -155,25 +155,25 @@ by rw [edist_dist x y]; apply ennreal.coe_ne_top
 @[simp] lemma nndist_self (a : α) : nndist a a = 0 := (nnreal.coe_eq_zero _).1 (dist_self a)
 
 /--Express `dist` in terms of `nndist`-/
-@[simp] lemma nndist_eq_dist (x y : α) : ↑(nndist x y) = dist x y := rfl
+lemma dist_nndist (x y : α) : dist x y = ↑(nndist x y) := rfl
 
 /--Express `nndist` in terms of `dist`-/
-@[simp] lemma dist_eq_nndist (x y : α) : nnreal.of_real (dist x y) = nndist x y :=
-by rw [← nndist_eq_dist, nnreal.of_real_coe]
+lemma nndist_dist (x y : α) : nndist x y = nnreal.of_real (dist x y) :=
+by rw [dist_nndist, nnreal.of_real_coe]
 
 /--Deduce the equality of points with the vanishing of the nonnegative distance-/
 theorem eq_of_nndist_eq_zero {x y : α} : nndist x y = 0 → x = y :=
-by simp [nnreal.eq_iff.symm]
+by simp only [nnreal.eq_iff.symm, (dist_nndist _ _).symm, imp_self, nnreal.coe_zero, dist_eq_zero]
 
 theorem nndist_comm (x y : α) : nndist x y = nndist y x :=
 by simpa [nnreal.eq_iff.symm] using dist_comm x y
 
 /--Characterize the equality of points with the vanishing of the nonnegative distance-/
 @[simp] theorem nndist_eq_zero {x y : α} : nndist x y = 0 ↔ x = y :=
-by simp [nnreal.eq_iff.symm]
+by simp only [nnreal.eq_iff.symm, (dist_nndist _ _).symm, imp_self, nnreal.coe_zero, dist_eq_zero]
 
 @[simp] theorem zero_eq_nndist {x y : α} : 0 = nndist x y ↔ x = y :=
-by simp [nnreal.eq_iff.symm]
+by simp only [nnreal.eq_iff.symm, (dist_nndist _ _).symm, imp_self, nnreal.coe_zero, zero_eq_dist]
 
 /--Triangle inequality for the nonnegative distance-/
 theorem nndist_triangle (x y z : α) : nndist x z ≤ nndist x y + nndist y z :=
@@ -185,13 +185,9 @@ by simpa [nnreal.coe_le] using dist_triangle_left x y z
 theorem nndist_triangle_right (x y z : α) : nndist x y ≤ nndist x z + nndist y z :=
 by simpa [nnreal.coe_le] using dist_triangle_right x y z
 
-/--Express `edist` in terms of `dist`-/
-@[simp] lemma dist_eq_edist (x y : α) : ↑(nnreal.of_real (dist x y)) = edist x y :=
-(edist_dist x y).symm
-
-/--Express `dist` in terms `edist`-/
-@[simp] lemma edist_eq_dist (x y : α) : ↑((edist x y).to_nnreal) = dist x y :=
-by rw [← dist_eq_edist]; simp; rw [nnreal.coe_of_real _ (metric_space.dist_nonneg x y)]
+/--Express `dist` in terms of `edist`-/
+lemma dist_edist (x y : α) : dist x y = (edist x y).to_real :=
+by rw [edist_dist, ennreal.to_real_of_real (dist_nonneg)]
 
 namespace metric
 
@@ -411,14 +407,14 @@ protected lemma metric.mem_uniformity_edist {s : set (α×α)} :
   s ∈ (@uniformity α _).sets ↔ (∃ε>0, ∀{a b:α}, edist a b < ε → (a, b) ∈ s) :=
 begin
   refine mem_uniformity_dist.trans ⟨_, _⟩; rintro ⟨ε, ε0, Hε⟩,
-  { refine ⟨nnreal.of_real ε, _, λ a b, _⟩,
-    { rwa [gt, ennreal.coe_pos, nnreal.of_real_pos] },
-    { rw [edist_dist, ennreal.coe_lt_coe, nnreal.of_real_lt_of_real_iff ε0],
+  { refine ⟨ennreal.of_real ε, _, λ a b, _⟩,
+    { rwa [gt, ennreal.of_real_pos] },
+    { rw [edist_dist, ennreal.of_real_lt_of_real_iff ε0],
       exact Hε } },
   { rcases ennreal.lt_iff_exists_real_btwn.1 ε0 with ⟨ε', _, ε0', hε⟩,
-    rw [ennreal.coe_pos, nnreal.of_real_pos] at ε0',
+    rw [ennreal.of_real_pos] at ε0',
     refine ⟨ε', ε0', λ a b h, Hε (lt_trans _ hε)⟩,
-    rwa [edist_dist, ennreal.coe_lt_coe, nnreal.of_real_lt_of_real_iff ε0'] }
+    rwa [edist_dist, ennreal.of_real_lt_of_real_iff ε0'] }
 end
 
 protected theorem metric.uniformity_edist' : uniformity = (⨅ε:{ε:ennreal // ε>0}, principal {p:α×α | edist p.1 p.2 < ε.val}) :=
@@ -434,20 +430,69 @@ theorem uniformity_edist : uniformity = (⨅ ε>0, principal {p:α×α | edist p
 by simpa [infi_subtype] using @metric.uniformity_edist' α _
 
 /-- A metric space induces an emetric space -/
-instance metric_space.to_emetric_space [a : metric_space α] : emetric_space α :=
+instance metric_space.to_emetric_space : emetric_space α :=
 { edist               := edist,
   edist_self          := by simp [edist_dist],
-  eq_of_edist_eq_zero := assume x y h,
-  by rw [edist_dist] at h; simpa [-dist_eq_edist, -dist_eq_nndist] using h,
+  eq_of_edist_eq_zero := assume x y h, by simpa [edist_dist] using h,
   edist_comm          := by simp only [edist_dist, dist_comm]; simp,
-  edist_triangle      := assume x y z,
-  begin
-    rw [← nndist_eq_edist, ← nndist_eq_edist, ← nndist_eq_edist,
-      ← ennreal.coe_add, ennreal.coe_le_coe],
-    exact nndist_triangle x y z
+  edist_triangle      := assume x y z, begin
+    simp only [edist_dist, (ennreal.of_real_add _ _).symm, dist_nonneg],
+    rw ennreal.of_real_le_of_real_iff _,
+    { exact dist_triangle _ _ _ },
+    { simpa using add_le_add (dist_nonneg : 0 ≤ dist x y) dist_nonneg }
   end,
   uniformity_edist    := uniformity_edist,
-  ..a }
+  ..‹metric_space α› }
+
+/-- Balls defined using the distance or the edistance coincide -/
+lemma metric.emetric_ball {x : α} {ε : ℝ} : emetric.ball x (ennreal.of_real ε) = ball x ε :=
+begin
+  classical, by_cases h : 0 < ε,
+  { ext y, by simp [edist_dist, ennreal.of_real_lt_of_real_iff h] },
+  { have h' : ε ≤ 0, by simpa using h,
+    have A : ball x ε = ∅, by simpa [ball_eq_empty_iff_nonpos.symm],
+    have B : emetric.ball x (ennreal.of_real ε) = ∅,
+      by simp [ennreal.of_real_eq_zero.2 h', emetric.ball_eq_empty_iff],
+    rwa [A, B] }
+end
+
+/-- Closed balls defined using the distance or the edistance coincide -/
+lemma metric.emetric_closed_ball {x : α} {ε : ℝ} (h : 0 ≤ ε) :
+  emetric.closed_ball x (ennreal.of_real ε) = closed_ball x ε :=
+by ext y; simp [edist_dist]; rw ennreal.of_real_le_of_real_iff h
+
+def metric_space.replace_uniformity {α} [U : uniform_space α] (m : metric_space α)
+  (H : @uniformity _ U = @uniformity _ (metric_space.to_uniform_space α)) :
+  metric_space α :=
+{ dist               := @dist _ m.to_has_dist,
+  dist_self          := dist_self,
+  eq_of_dist_eq_zero := @eq_of_dist_eq_zero _ _,
+  dist_comm          := dist_comm,
+  dist_triangle      := dist_triangle,
+  edist              := edist,
+  edist_dist         := edist_dist,
+  to_uniform_space   := U,
+  uniformity_dist    := H.trans (metric_space.uniformity_dist α) }
+
+/-- One gets a metric space from an emetric space if the edistance
+is everywhere finite. We set it up so that the edist and the uniformity are
+defeq in the metric space and the emetric space -/
+
+def emetric_space.to_metric_space {α : Type u} [e : emetric_space α] (h : ∀x y: α, edist x y ≠ ⊤) :
+  metric_space α :=
+let m : metric_space α :=
+{ dist               := λx y, ennreal.to_real (edist x y),
+  eq_of_dist_eq_zero := λx y hxy, by simpa [dist, ennreal.to_real_eq_zero_iff, h x y] using hxy,
+  dist_self          := λx, by simp,
+  dist_comm          := λx y, by simp [emetric_space.edist_comm],
+  dist_triangle      := λx y z, begin
+    rw [← ennreal.to_real_add (h _ _) (h _ _), ennreal.to_real_le_to_real (h _ _)],
+    { exact edist_triangle _ _ _ },
+    { simp [ennreal.add_eq_top, h] }
+  end,
+  edist              := λx y, edist x y,
+  edist_dist         := λx y, by simp [ennreal.of_real_to_real, h] } in
+metric_space.replace_uniformity m (by rw [uniformity_edist, uniformity_edist']; refl)
 
 section real
 
@@ -584,19 +629,6 @@ lemma cauchy_seq_iff_le_tendsto_0 {s : ℕ → α} : cauchy_seq s ↔ ∃ b : �
 
 end cauchy_seq
 
-def metric_space.replace_uniformity {α} [U : uniform_space α] (m : metric_space α)
-  (H : @uniformity _ U = @uniformity _ (metric_space.to_uniform_space α)) :
-  metric_space α :=
-{ dist               := @dist _ m.to_has_dist,
-  dist_self          := dist_self,
-  eq_of_dist_eq_zero := @eq_of_dist_eq_zero _ _,
-  dist_comm          := dist_comm,
-  dist_triangle      := dist_triangle,
-  edist              := edist,
-  edist_dist         := edist_dist,
-  to_uniform_space   := U,
-  uniformity_dist    := H.trans (metric_space.uniformity_dist α) }
-
 def metric_space.induced {α β} (f : α → β) (hf : function.injective f)
   (m : metric_space β) : metric_space α :=
 { dist               := λ x y, dist (f x) (f y),
@@ -639,11 +671,8 @@ instance prod.metric_space_max [metric_space β] : metric_space (α × β) :=
     (le_trans (dist_triangle _ _ _) (add_le_add (le_max_right _ _) (le_max_right _ _))),
   edist := λ x y, max (edist x.1 y.1) (edist x.2 y.2),
   edist_dist := assume x y, begin
-    have I : monotone (nnreal.of_real) := assume x y h, nnreal.of_real_le_of_real h,
-    have J : monotone (λ (t:nnreal), (t:ennreal)) := assume x y h, ennreal.coe_le_coe.2 h,
-    have A : monotone (λ (a:ℝ), ((nnreal.of_real a) : ennreal)) := monotone_comp I J,
-    have B := (max_distrib_of_monotone A).symm,
-    rw [← dist_eq_edist, ← dist_eq_edist, B]
+    have : monotone ennreal.of_real := assume x y h, ennreal.of_real_le_of_real h,
+    rw [edist_dist, edist_dist, (max_distrib_of_monotone this).symm]
   end,
   uniformity_dist := begin
     refine uniformity_prod.trans _,
@@ -744,6 +773,11 @@ def metric_space_sum : metric_space (α ⊕ β) :=
   eq_of_dist_eq_zero := sum.eq_of_dist_eq_zero,
   to_uniform_space := sum.uniform_space,
   uniformity_dist := uniformity_dist_of_mem_uniformity _ _ sum.mem_uniformity }
+
+local attribute [instance] metric_space_sum
+
+lemma sum.dist_eq {x y : α ⊕ β} :
+dist x y = sum.dist x y := rfl
 
 end sum
 
@@ -858,13 +892,12 @@ instance metric_space_pi : metric_space (Πb, π b) :=
       exact (funext $ assume b, eq_of_nndist_eq_zero $ bot_unique $ eq0 b $ mem_univ b),
     end,
   edist := λ f g, finset.sup univ (λb, edist (f b) (g b)),
-  edist_dist := assume x y,
-  have A : sup univ (λ (b : β), ((nndist (x b) (y b)) : ennreal)) = ↑(sup univ (λ (b : β), nndist (x b) (y b))) :=
-  begin
-    refine eq.symm (comp_sup_eq_sup_comp _ _ _),
-    exact (assume x y h, ennreal.coe_le_coe.2 h), refl
-  end,
-  by unfold dist; simp; simp only [(nndist_eq_edist _ _).symm, A] }
+  edist_dist := assume x y, begin
+    have A : sup univ (λ (b : β), ((nndist (x b) (y b)) : ennreal)) = ↑(sup univ (λ (b : β), nndist (x b) (y b))),
+    { refine eq.symm (comp_sup_eq_sup_comp _ _ _),
+      exact (assume x y h, ennreal.coe_le_coe.2 h), refl },
+    simp [dist, edist_nndist, ennreal.of_real, A]
+  end }
 
 end pi
 

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -320,6 +320,9 @@ lt_of_le_of_lt (zero_le _) hy
 theorem mem_ball_self (h : 0 < ε) : x ∈ ball x ε :=
 show edist x x < ε, by rw edist_self; assumption
 
+theorem mem_closed_ball_self : x ∈ closed_ball x ε :=
+show edist x x ≤ ε, by rw edist_self; exact bot_le
+
 theorem mem_ball_comm : x ∈ ball y ε ↔ y ∈ ball x ε :=
 by simp [edist_comm]
 
@@ -349,6 +352,11 @@ begin
   { rw ennreal.add_sub_cancel_of_le (le_of_lt h), apply le_refl _},
   { have : edist y x ≠ ⊤ := lattice.ne_top_of_lt h, apply lt_top_iff_ne_top.2 this }
 end
+
+theorem ball_eq_empty_iff : ball x ε = ∅ ↔ ε = 0 :=
+eq_empty_iff_forall_not_mem.trans
+⟨λh, le_bot_iff.1 (le_of_not_gt (λ ε0, h _ (mem_ball_self ε0))),
+λε0 y h, not_lt_of_le (le_of_eq ε0) (pos_of_mem_ball h)⟩
 
 theorem nhds_eq : nhds x = (⨅ε:{ε:ennreal // ε>0}, principal (ball x ε.val)) :=
 begin


### PR DESCRIPTION
Add maps `ennreal.to_real` and `ennreal.of_real` from ennreal to real (resp. real to ennreal), and use these to revamp emetric spaces and their relationships with metric spaces. They are the composition of the natural already defined maps between `real` and `nnreal`, and between `nnreal` and `ennreal`.

Motivation: in later developments, I introduce things on emetric spaces and then transfer them to metric spaces. After doing more than 20 rewrites going through `nnreal`, I got tired of this and decided that proving all the useful lemmas once and for all would be more efficient.

This should also be useful when defining real-valued probability measures starting from ennreal-valued measures taking only finite values.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
