### PR TITLE
feat(data/equiv/algebra): instances for transporting algebra across an equiv

### DIFF
--- a/src/data/equiv/algebra.lean
+++ b/src/data/equiv/algebra.lean
@@ -55,72 +55,72 @@ section instances
 
 variables (e : α ≃ β)
 
-protected def has_zero [has_zero α] : has_zero β := ⟨e 0⟩
-lemma zero_def [has_zero α] : @has_zero.zero _ (equiv.has_zero e) = e 0 := rfl
+protected def has_zero [has_zero β] : has_zero α := ⟨e.symm 0⟩
+lemma zero_def [has_zero β] : @has_zero.zero _ (equiv.has_zero e) = e.symm 0 := rfl
 
-protected def has_one [has_one α] : has_one β := ⟨e 1⟩
-lemma one_def [has_one α] : @has_one.one _ (equiv.has_one e) = e 1 := rfl
+protected def has_one [has_one β] : has_one α := ⟨e.symm 1⟩
+lemma one_def [has_one β] : @has_one.one _ (equiv.has_one e) = e.symm 1 := rfl
 
-protected def has_mul [has_mul α] : has_mul β := ⟨λ x y, e (e.symm x * e.symm y)⟩
-lemma mul_def [has_mul α] (x y : β) :
-  @has_mul.mul _ (equiv.has_mul e) x y = e (e.symm x * e.symm y) := rfl
+protected def has_mul [has_mul β] : has_mul α := ⟨λ x y, e.symm (e x * e y)⟩
+lemma mul_def [has_mul β] (x y : α) :
+  @has_mul.mul _ (equiv.has_mul e) x y = e.symm (e x * e y) := rfl
 
-protected def has_add [has_add α] : has_add β := ⟨λ x y, e (e.symm x + e.symm y)⟩
-lemma add_def [has_add α] (x y : β) :
-  @has_add.add _ (equiv.has_add e) x y = e (e.symm x + e.symm y) := rfl
+protected def has_add [has_add β] : has_add α := ⟨λ x y, e.symm (e x + e y)⟩
+lemma add_def [has_add β] (x y : α) :
+  @has_add.add _ (equiv.has_add e) x y = e.symm (e x + e y) := rfl
 
-protected def has_inv [has_inv α] : has_inv β := ⟨λ x, e (e.symm x)⁻¹⟩
-lemma inv_def [has_inv α] (x : β) : @has_inv.inv _ (equiv.has_inv e) x = e (e.symm x)⁻¹ := rfl
+protected def has_inv [has_inv β] : has_inv α := ⟨λ x, e.symm (e x)⁻¹⟩
+lemma inv_def [has_inv β] (x : α) : @has_inv.inv _ (equiv.has_inv e) x = e.symm (e x)⁻¹ := rfl
 
-protected def has_neg [has_neg α] : has_neg β := ⟨λ x, e (- e.symm x)⟩
-lemma neg_def [has_neg α] (x : β) : @has_neg.neg _ (equiv.has_neg e) x = e (-e.symm x) := rfl
+protected def has_neg [has_neg β] : has_neg α := ⟨λ x, e.symm (-e x)⟩
+lemma neg_def [has_neg β] (x : α) : @has_neg.neg _ (equiv.has_neg e) x = e.symm (-e x) := rfl
 
-protected def semigroup [semigroup α] : semigroup β :=
+protected def semigroup [semigroup β] : semigroup α :=
 { mul_assoc := by simp [mul_def, mul_assoc],
   ..equiv.has_mul e }
 
-protected def comm_semigroup [comm_semigroup α] : comm_semigroup β :=
+protected def comm_semigroup [comm_semigroup β] : comm_semigroup α :=
 { mul_comm := by simp [mul_def, mul_comm],
   ..equiv.semigroup e }
 
-protected def monoid [monoid α] : monoid β :=
+protected def monoid [monoid β] : monoid α :=
 { one_mul := by simp [mul_def, one_def],
   mul_one := by simp [mul_def, one_def],
   ..equiv.semigroup e,
   ..equiv.has_one e }
 
-protected def comm_monoid [comm_monoid α] : comm_monoid β :=
+protected def comm_monoid [comm_monoid β] : comm_monoid α :=
 { ..equiv.comm_semigroup e,
   ..equiv.monoid e }
 
-protected def group [group α] : group β :=
+protected def group [group β] : group α :=
 { mul_left_inv := by simp [mul_def, inv_def, one_def],
   ..equiv.monoid e,
   ..equiv.has_inv e }
 
-protected def comm_group [comm_group α] : comm_group β :=
+protected def comm_group [comm_group β] : comm_group α :=
 { ..equiv.group e,
   ..equiv.comm_semigroup e }
 
-protected def add_semigroup [add_semigroup α] : add_semigroup β :=
+protected def add_semigroup [add_semigroup β] : add_semigroup α :=
 @additive.add_semigroup _ (@equiv.semigroup _ _ e multiplicative.semigroup)
 
-protected def add_comm_semigroup [add_comm_semigroup α] : add_comm_semigroup β :=
+protected def add_comm_semigroup [add_comm_semigroup β] : add_comm_semigroup α :=
 @additive.add_comm_semigroup _ (@equiv.comm_semigroup _ _ e multiplicative.comm_semigroup)
 
-protected def add_monoid [add_monoid α] : add_monoid β :=
+protected def add_monoid [add_monoid β] : add_monoid α :=
 @additive.add_monoid _ (@equiv.monoid _ _ e multiplicative.monoid)
 
-protected def add_comm_monoid [add_comm_monoid α] : add_comm_monoid β :=
+protected def add_comm_monoid [add_comm_monoid β] : add_comm_monoid α :=
 @additive.add_comm_monoid _ (@equiv.comm_monoid _ _ e multiplicative.comm_monoid)
 
-protected def add_group [add_group α] : add_group β :=
+protected def add_group [add_group β] : add_group α :=
 @additive.add_group _ (@equiv.group _ _ e multiplicative.group)
 
-protected def add_comm_group [add_comm_group α] : add_comm_group β :=
+protected def add_comm_group [add_comm_group β] : add_comm_group α :=
 @additive.add_comm_group _ (@equiv.comm_group _ _ e multiplicative.comm_group)
 
-protected def ring [ring α] : ring β :=
+protected def ring [ring β] : ring α :=
 { right_distrib := by simp [mul_def, add_def, add_mul],
   left_distrib := by simp [mul_def, add_def, mul_add],
   ..equiv.has_mul e,
@@ -128,23 +128,23 @@ protected def ring [ring α] : ring β :=
   ..equiv.monoid e,
   ..equiv.add_comm_group e }
 
-protected def comm_ring [comm_ring α] : comm_ring β :=
+protected def comm_ring [comm_ring β] : comm_ring α :=
 { ..equiv.comm_monoid e,
   ..equiv.ring e }
 
-protected def nonzero_comm_ring [nonzero_comm_ring α] : nonzero_comm_ring β :=
+protected def nonzero_comm_ring [nonzero_comm_ring β] : nonzero_comm_ring α :=
 { zero_ne_one := by simp [zero_def, one_def],
   ..equiv.has_zero e,
   ..equiv.has_one e,
   ..equiv.comm_ring e }
 
-protected def integral_domain [integral_domain α] : integral_domain β :=
-{ eq_zero_or_eq_zero_of_mul_eq_zero := by simp [mul_def, zero_def, equiv.symm_apply_eq],
+protected def integral_domain [integral_domain β] : integral_domain α :=
+{ eq_zero_or_eq_zero_of_mul_eq_zero := by simp [mul_def, zero_def, equiv.eq_symm_apply],
   ..equiv.has_zero e,
   ..equiv.has_mul e,
   ..equiv.nonzero_comm_ring e }
 
-protected def division_ring [division_ring α] : division_ring β :=
+protected def division_ring [division_ring β] : division_ring α :=
 { zero_ne_one := by simp [zero_def, one_def],
   inv_mul_cancel := λ _,
     by simp [mul_def, inv_def, zero_def, one_def, (equiv.symm_apply_eq _).symm];
@@ -157,12 +157,12 @@ protected def division_ring [division_ring α] : division_ring β :=
   ..equiv.ring e,
   ..equiv.has_inv e }
 
-protected def field [field α] : field β :=
+protected def field [field β] : field α :=
 { ..equiv.comm_ring e,
   ..equiv.division_ring e }
 
-protected def discrete_field [discrete_field α] : discrete_field β :=
-{ has_decidable_eq := equiv.decidable_eq e.symm,
+protected def discrete_field [discrete_field β] : discrete_field α :=
+{ has_decidable_eq := equiv.decidable_eq e,
   inv_zero := by simp [mul_def, inv_def, zero_def],
   ..equiv.has_mul e,
   ..equiv.has_inv e,

--- a/src/data/equiv/algebra.lean
+++ b/src/data/equiv/algebra.lean
@@ -143,21 +143,28 @@ protected def comm_ring [comm_ring β] : comm_ring α :=
 { ..equiv.comm_monoid e,
   ..equiv.ring e }
 
-protected def nonzero_comm_ring [nonzero_comm_ring β] : nonzero_comm_ring α :=
+protected def zero_ne_one_class [zero_ne_one_class β] : zero_ne_one_class α :=
 { zero_ne_one := by simp [zero_def, one_def],
   ..equiv.has_zero e,
-  ..equiv.has_one e,
+  ..equiv.has_one e }
+
+protected def nonzero_comm_ring [nonzero_comm_ring β] : nonzero_comm_ring α :=
+{ ..equiv.zero_ne_one_class e,
   ..equiv.comm_ring e }
 
-protected def integral_domain [integral_domain β] : integral_domain α :=
+protected def domain [domain β] : domain α :=
 { eq_zero_or_eq_zero_of_mul_eq_zero := by simp [mul_def, zero_def, equiv.eq_symm_apply],
   ..equiv.has_zero e,
+  ..equiv.zero_ne_one_class e,
   ..equiv.has_mul e,
+  ..equiv.ring e }
+
+protected def integral_domain [integral_domain β] : integral_domain α :=
+{ ..equiv.domain e,
   ..equiv.nonzero_comm_ring e }
 
 protected def division_ring [division_ring β] : division_ring α :=
-{ zero_ne_one := by simp [zero_def, one_def],
-  inv_mul_cancel := λ _,
+{ inv_mul_cancel := λ _,
     by simp [mul_def, inv_def, zero_def, one_def, (equiv.symm_apply_eq _).symm];
       exact inv_mul_cancel,
   mul_inv_cancel := λ _,
@@ -165,11 +172,11 @@ protected def division_ring [division_ring β] : division_ring α :=
       exact mul_inv_cancel,
   ..equiv.has_zero e,
   ..equiv.has_one e,
-  ..equiv.ring e,
+  ..equiv.domain e,
   ..equiv.has_inv e }
 
 protected def field [field β] : field α :=
-{ ..equiv.comm_ring e,
+{ ..equiv.integral_domain e,
   ..equiv.division_ring e }
 
 protected def discrete_field [discrete_field β] : discrete_field α :=

--- a/src/data/equiv/algebra.lean
+++ b/src/data/equiv/algebra.lean
@@ -120,12 +120,23 @@ protected def add_group [add_group β] : add_group α :=
 protected def add_comm_group [add_comm_group β] : add_comm_group α :=
 @additive.add_comm_group _ (@equiv.comm_group _ _ e multiplicative.comm_group)
 
-protected def ring [ring β] : ring α :=
+protected def semiring [semiring β] : semiring α :=
 { right_distrib := by simp [mul_def, add_def, add_mul],
   left_distrib := by simp [mul_def, add_def, mul_add],
+  zero_mul := by simp [mul_def, zero_def],
+  mul_zero := by simp [mul_def, zero_def],
+  ..equiv.has_zero e,
   ..equiv.has_mul e,
   ..equiv.has_add e,
   ..equiv.monoid e,
+  ..equiv.add_comm_monoid e }
+
+protected def comm_semiring [comm_semiring β] : comm_semiring α :=
+{ ..equiv.semiring e,
+  ..equiv.comm_monoid e }
+
+protected def ring [ring β] : ring α :=
+{ ..equiv.semiring e,
   ..equiv.add_comm_group e }
 
 protected def comm_ring [comm_ring β] : comm_ring α :=

--- a/src/data/equiv/algebra.lean
+++ b/src/data/equiv/algebra.lean
@@ -6,9 +6,12 @@ Authors: Johannes Hölzl
 import data.equiv.basic algebra.field
 
 universes u v w
+variables {α : Type u} {β : Type v}  {γ : Type w}
 
 namespace equiv
-variables {α : Type u} [group α]
+
+section group
+variables [group α]
 
 protected def mul_left (a : α) : α ≃ α :=
 { to_fun    := λx, a * x,
@@ -46,6 +49,127 @@ def units_equiv_ne_zero (α : Type*) [field α] : units α ≃ {a : α | a ≠ 0
 @[simp] lemma coe_units_equiv_ne_zero [field α] (a : units α) :
   ((units_equiv_ne_zero α a) : α) = a := rfl
 
+end group
+
+section instances
+
+variables (e : α ≃ β)
+
+protected def has_zero [has_zero α] : has_zero β := ⟨e 0⟩
+lemma zero_def [has_zero α] : @has_zero.zero _ (equiv.has_zero e) = e 0 := rfl
+
+protected def has_one [has_one α] : has_one β := ⟨e 1⟩
+lemma one_def [has_one α] : @has_one.one _ (equiv.has_one e) = e 1 := rfl
+
+protected def has_mul [has_mul α] : has_mul β := ⟨λ x y, e (e.symm x * e.symm y)⟩
+lemma mul_def [has_mul α] (x y : β) :
+  @has_mul.mul _ (equiv.has_mul e) x y = e (e.symm x * e.symm y) := rfl
+
+protected def has_add [has_add α] : has_add β := ⟨λ x y, e (e.symm x + e.symm y)⟩
+lemma add_def [has_add α] (x y : β) :
+  @has_add.add _ (equiv.has_add e) x y = e (e.symm x + e.symm y) := rfl
+
+protected def has_inv [has_inv α] : has_inv β := ⟨λ x, e (e.symm x)⁻¹⟩
+lemma inv_def [has_inv α] (x : β) : @has_inv.inv _ (equiv.has_inv e) x = e (e.symm x)⁻¹ := rfl
+
+protected def has_neg [has_neg α] : has_neg β := ⟨λ x, e (- e.symm x)⟩
+lemma neg_def [has_neg α] (x : β) : @has_neg.neg _ (equiv.has_neg e) x = e (-e.symm x) := rfl
+
+protected def semigroup [semigroup α] : semigroup β :=
+{ mul_assoc := by simp [mul_def, mul_assoc],
+  ..equiv.has_mul e }
+
+protected def comm_semigroup [comm_semigroup α] : comm_semigroup β :=
+{ mul_comm := by simp [mul_def, mul_comm],
+  ..equiv.semigroup e }
+
+protected def monoid [monoid α] : monoid β :=
+{ one_mul := by simp [mul_def, one_def],
+  mul_one := by simp [mul_def, one_def],
+  ..equiv.semigroup e,
+  ..equiv.has_one e }
+
+protected def comm_monoid [comm_monoid α] : comm_monoid β :=
+{ ..equiv.comm_semigroup e,
+  ..equiv.monoid e }
+
+protected def group [group α] : group β :=
+{ mul_left_inv := by simp [mul_def, inv_def, one_def],
+  ..equiv.monoid e,
+  ..equiv.has_inv e }
+
+protected def comm_group [comm_group α] : comm_group β :=
+{ ..equiv.group e,
+  ..equiv.comm_semigroup e }
+
+protected def add_semigroup [add_semigroup α] : add_semigroup β :=
+@additive.add_semigroup _ (@equiv.semigroup _ _ e multiplicative.semigroup)
+
+protected def add_comm_semigroup [add_comm_semigroup α] : add_comm_semigroup β :=
+@additive.add_comm_semigroup _ (@equiv.comm_semigroup _ _ e multiplicative.comm_semigroup)
+
+protected def add_monoid [add_monoid α] : add_monoid β :=
+@additive.add_monoid _ (@equiv.monoid _ _ e multiplicative.monoid)
+
+protected def add_comm_monoid [add_comm_monoid α] : add_comm_monoid β :=
+@additive.add_comm_monoid _ (@equiv.comm_monoid _ _ e multiplicative.comm_monoid)
+
+protected def add_group [add_group α] : add_group β :=
+@additive.add_group _ (@equiv.group _ _ e multiplicative.group)
+
+protected def add_comm_group [add_comm_group α] : add_comm_group β :=
+@additive.add_comm_group _ (@equiv.comm_group _ _ e multiplicative.comm_group)
+
+protected def ring [ring α] : ring β :=
+{ right_distrib := by simp [mul_def, add_def, add_mul],
+  left_distrib := by simp [mul_def, add_def, mul_add],
+  ..equiv.has_mul e,
+  ..equiv.has_add e,
+  ..equiv.monoid e,
+  ..equiv.add_comm_group e }
+
+protected def comm_ring [comm_ring α] : comm_ring β :=
+{ ..equiv.comm_monoid e,
+  ..equiv.ring e }
+
+protected def nonzero_comm_ring [nonzero_comm_ring α] : nonzero_comm_ring β :=
+{ zero_ne_one := by simp [zero_def, one_def],
+  ..equiv.has_zero e,
+  ..equiv.has_one e,
+  ..equiv.comm_ring e }
+
+protected def integral_domain [integral_domain α] : integral_domain β :=
+{ eq_zero_or_eq_zero_of_mul_eq_zero := by simp [mul_def, zero_def, equiv.symm_apply_eq],
+  ..equiv.has_zero e,
+  ..equiv.has_mul e,
+  ..equiv.nonzero_comm_ring e }
+
+protected def division_ring [division_ring α] : division_ring β :=
+{ zero_ne_one := by simp [zero_def, one_def],
+  inv_mul_cancel := λ _,
+    by simp [mul_def, inv_def, zero_def, one_def, (equiv.symm_apply_eq _).symm];
+      exact inv_mul_cancel,
+  mul_inv_cancel := λ _,
+    by simp [mul_def, inv_def, zero_def, one_def, (equiv.symm_apply_eq _).symm];
+      exact mul_inv_cancel,
+  ..equiv.has_zero e,
+  ..equiv.has_one e,
+  ..equiv.ring e,
+  ..equiv.has_inv e }
+
+protected def field [field α] : field β :=
+{ ..equiv.comm_ring e,
+  ..equiv.division_ring e }
+
+protected def discrete_field [discrete_field α] : discrete_field β :=
+{ has_decidable_eq := equiv.decidable_eq e.symm,
+  inv_zero := by simp [mul_def, inv_def, zero_def],
+  ..equiv.has_mul e,
+  ..equiv.has_inv e,
+  ..equiv.has_zero e,
+  ..equiv.field e }
+
+end instances
 end equiv
 
 structure ring_equiv (α β : Type*) [ring α] [ring β] extends α ≃ β :=
@@ -55,7 +179,6 @@ infix ` ≃r `:50 := ring_equiv
 
 namespace ring_equiv
 
-variables {α : Type u} {β : Type v} {γ : Type w}
 variables [ring α] [ring β] [ring γ]
 
 instance {e : α ≃r β} : is_ring_hom e.to_equiv := hom _


### PR DESCRIPTION
This was required for my construction of algebraic closure.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
