### PR TITLE
fix(tactic/linarith): properly handle problems with inequalities in m…

### DIFF
--- a/src/tactic/linarith.lean
+++ b/src/tactic/linarith.lean
@@ -449,10 +449,6 @@ meta def ineq_pf_tp (pf : expr) : tactic expr :=
 do (_, z) ← infer_type pf >>= get_rel_sides,
    infer_type z
 
-meta def ineq_pf_tp_eq (pf1 pf2 : expr) : tactic bool :=
-do tp1 ← ineq_pf_tp pf1, tp2 ← ineq_pf_tp pf2,
-   succeeds $ is_def_eq tp1 tp2
-
 meta def mk_neg_one_lt_zero_pf (tp : expr) : tactic expr :=
 to_expr ``((neg_neg_of_pos zero_lt_one : -1 < (0 : %%tp)))
 

--- a/tests/linarith.lean
+++ b/tests/linarith.lean
@@ -1,5 +1,7 @@
 import tactic.linarith
 
+set_option trace.app_builder true
+
 example (e b c a v0 v1 : ℚ) (h1 : v0 = 5*a) (h2 : v1 = 3*b) (h3 : v0 + v1 + c = 10) :
   v0 + 5 + (v1 - 3) + (c - 2) = 10 :=
 by linarith
@@ -99,5 +101,10 @@ by linarith
 example (a b i : ℕ) (h1 :  ¬ a < i) (h2 : b < i) (h3 : a ≤ b) : false :=
 by linarith
 
-example (a b c : ℚ) (h1 : 1 / a < b) (h2 : b < c) : 1 / a < c := 
+example (a b c : ℚ) (h1 : 1 / a < b) (h2 : b < c) : 1 / a < c :=
 by linarith
+
+example
+(N : ℕ) (n : ℕ) (Hirrelevant : n > N)
+(A : ℚ) (l : ℚ) (h : A - l ≤ -(A - l)) (h_1 : ¬A ≤ -A) (h_2 : ¬l ≤ -l)
+(h_3 : -(A - l) < 1) :  A < l + 1 := by linarith

--- a/tests/linarith.lean
+++ b/tests/linarith.lean
@@ -1,7 +1,5 @@
 import tactic.linarith
 
-set_option trace.app_builder true
-
 example (e b c a v0 v1 : ℚ) (h1 : v0 = 5*a) (h2 : v1 = 3*b) (h3 : v0 + v1 + c = 10) :
   v0 + 5 + (v1 - 3) + (c - 2) = 10 :=
 by linarith


### PR DESCRIPTION
…ultiple types

When problems have inequalities over multiple types, it's almost safe to process everything at once, since none of the variables overlap. But linarith deals with constants by homogenizing them and the "constant" variables do overlap.

This fix creates one call to linarith for each type that appears in a hypothesis.

As a side effect, failure reporting in problems with multiple types will be worse. (Which failure do you report on?) Eventually we probably want trace output for linarith.

(Reported by @kbuzzard : https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/linarith.20failure)

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
