### PR TITLE
norm_num fix and small refactor

### DIFF
--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -86,6 +86,19 @@ meta def is_mvar : expr → bool
 | (mvar _ _ _) := tt
 | _            := ff
 
+/--
+ is_num_eq n1 n2 returns true if n1 and n2 are both numerals with the same numeral structure,
+ ignoring differences in type and type class arguments.
+-/
+meta def is_num_eq : expr → expr → bool
+| `(@has_zero.zero _ _) `(@has_zero.zero _ _) := tt
+| `(@has_one.one _ _) `(@has_one.one _ _) := tt
+| `(bit0 %%a) `(bit0 %%b) := a.is_num_eq b
+| `(bit1 %%a) `(bit1 %%b) := a.is_num_eq b
+| `(-%%a) `(-%%b) := a.is_num_eq b
+| `(%%a/%%a') `(%%b/%%b') :=  a.is_num_eq b
+| _ _ := ff
+
 end expr
 
 

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2019 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Robert Y. Lewis
+Authors: Mario Carneiro, Simon Hudon, Scott Morrison, Keeley Hoek, Robert Y. Lewis
 
 Additional non-tactic operations on expr and related types
 -/

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2019 Robert Y. Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Robert Y. Lewis
+
+Additional non-tactic operations on expr and related types
+-/
+
+namespace name
+
+meta def deinternalize_field : name → name
+| (name.mk_string s name.anonymous) :=
+  let i := s.mk_iterator in
+  if i.curr = '_' then i.next.next_to_string else s
+| n := n
+
+meta def get_nth_prefix : name → ℕ → name
+| nm 0 := nm
+| nm (n + 1) := get_nth_prefix nm.get_prefix n
+
+private meta def pop_nth_prefix_aux : name → ℕ → name × ℕ
+| anonymous n := (anonymous, 1)
+| nm n := let (pfx, height) := pop_nth_prefix_aux nm.get_prefix n in
+          if height ≤ n then (anonymous, height + 1)
+          else (nm.update_prefix pfx, height + 1)
+
+-- Pops the top `n` prefixes from the given name.
+meta def pop_nth_prefix (nm : name) (n : ℕ) : name :=
+prod.fst $ pop_nth_prefix_aux nm n
+
+meta def pop_prefix (n : name) : name :=
+pop_nth_prefix n 1
+
+-- `name`s can contain numeral pieces, which are not legal names
+-- when typed/passed directly to the parser. We turn an arbitrary
+-- name into a legal identifier name.
+meta def sanitize_name : name → name
+| name.anonymous := name.anonymous
+| (name.mk_string s p) := name.mk_string s $ sanitize_name p
+| (name.mk_numeral s p) := name.mk_string sformat!"n{s}" $ sanitize_name p
+
+end name
+
+namespace expr
+open tactic
+
+protected meta def to_pos_nat : expr → option ℕ
+| `(has_one.one _) := some 1
+| `(bit0 %%e) := bit0 <$> e.to_pos_nat
+| `(bit1 %%e) := bit1 <$> e.to_pos_nat
+| _           := none
+
+protected meta def to_nat : expr → option ℕ
+| `(has_zero.zero _) := some 0
+| e                  := e.to_pos_nat
+
+protected meta def to_int : expr → option ℤ
+| `(has_neg.neg %%e) := do n ← e.to_nat, some (-n)
+| e                  := coe <$> e.to_nat
+
+meta def is_meta_var : expr → bool
+| (mvar _ _ _) := tt
+| e            := ff
+
+meta def is_sort : expr → bool
+| (sort _) := tt
+| e         := ff
+
+meta def list_local_consts (e : expr) : list expr :=
+e.fold [] (λ e' _ es, if e'.is_local_constant then insert e' es else es)
+
+meta def list_constant (e : expr) : name_set :=
+e.fold mk_name_set (λ e' _ es, if e'.is_constant then es.insert e'.const_name else es)
+
+meta def list_meta_vars (e : expr) : list expr :=
+e.fold [] (λ e' _ es, if e'.is_meta_var then insert e' es else es)
+
+meta def list_names_with_prefix (pre : name) (e : expr) : name_set :=
+e.fold mk_name_set $ λ e' _ l,
+  match e' with
+  | expr.const n _ := if n.get_prefix = pre then l.insert n else l
+  | _ := l
+  end
+
+meta def is_mvar : expr → bool
+| (mvar _ _ _) := tt
+| _            := ff
+
+end expr
+
+
+namespace environment
+
+meta def in_current_file' (env : environment) (n : name) : bool :=
+env.in_current_file n && (n ∉ [``quot, ``quot.mk, ``quot.lift, ``quot.ind])
+
+meta def is_structure_like (env : environment) (n : name) : option (nat × name) :=
+do guardb (env.is_inductive n),
+  d ← (env.get n).to_option,
+  [intro] ← pure (env.constructors_of n) | none,
+  guard (env.inductive_num_indices n = 0),
+  some (env.inductive_num_params n, intro)
+
+meta def is_structure (env : environment) (n : name) : bool :=
+option.is_some $ do
+  (nparams, intro) ← env.is_structure_like n,
+  di ← (env.get intro).to_option,
+  expr.pi x _ _ _ ← nparams.iterate
+    (λ e : option expr, do expr.pi _ _ _ body ← e | none, some body)
+    (some di.type) | none,
+  env.is_projection (n ++ x.deinternalize_field)
+
+end environment

--- a/src/meta/rb_map.lean
+++ b/src/meta/rb_map.lean
@@ -75,3 +75,17 @@ end
 
 end rb_map
 end native
+
+namespace name_set
+meta def filter (s : name_set) (P : name → bool) : name_set :=
+s.fold s (λ a m, if P a then m else m.erase a)
+
+meta def mfilter {m} [monad m] (s : name_set) (P : name → m bool) : m name_set :=
+s.fold (pure s) (λ a m,
+  do x ← m,
+     mcond (P a) (pure x) (pure $ x.erase a))
+
+meta def union (s t : name_set) : name_set :=
+s.fold t (λ a t, t.insert a)
+
+end name_set

--- a/src/tactic/basic.lean
+++ b/src/tactic/basic.lean
@@ -3,74 +3,12 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Simon Hudon, Scott Morrison, Keeley Hoek
 -/
-import data.dlist.basic category.basic
+import data.dlist.basic category.basic meta.expr meta.rb_map
 
-namespace name
-
-meta def deinternalize_field : name → name
-| (name.mk_string s name.anonymous) :=
-  let i := s.mk_iterator in
-  if i.curr = '_' then i.next.next_to_string else s
-| n := n
-
-meta def get_nth_prefix : name → ℕ → name
-| nm 0 := nm
-| nm (n + 1) := get_nth_prefix nm.get_prefix n
-
-private meta def pop_nth_prefix_aux : name → ℕ → name × ℕ
-| anonymous n := (anonymous, 1)
-| nm n := let (pfx, height) := pop_nth_prefix_aux nm.get_prefix n in
-          if height ≤ n then (anonymous, height + 1)
-          else (nm.update_prefix pfx, height + 1)
-
--- Pops the top `n` prefixes from the given name.
-meta def pop_nth_prefix (nm : name) (n : ℕ) : name :=
-prod.fst $ pop_nth_prefix_aux nm n
-
-meta def pop_prefix (n : name) : name :=
-pop_nth_prefix n 1
-
--- `name`s can contain numeral pieces, which are not legal names
--- when typed/passed directly to the parser. We turn an arbitrary
--- name into a legal identifier name.
-meta def sanitize_name : name → name
-| name.anonymous := name.anonymous
-| (name.mk_string s p) := name.mk_string s $ sanitize_name p
-| (name.mk_numeral s p) := name.mk_string sformat!"n{s}" $ sanitize_name p
-
-end name
-
-namespace name_set
-meta def filter (s : name_set) (P : name → bool) : name_set :=
-s.fold s (λ a m, if P a then m else m.erase a)
-
-meta def mfilter {m} [monad m] (s : name_set) (P : name → m bool) : m name_set :=
-s.fold (pure s) (λ a m,
-  do x ← m,
-     mcond (P a) (pure x) (pure $ x.erase a))
-
-meta def union (s t : name_set) : name_set :=
-s.fold t (λ a t, t.insert a)
-
-end name_set
 namespace expr
 open tactic
 
 attribute [derive has_reflect] binder_info
-
-protected meta def to_pos_nat : expr → option ℕ
-| `(has_one.one _) := some 1
-| `(bit0 %%e) := bit0 <$> e.to_pos_nat
-| `(bit1 %%e) := bit1 <$> e.to_pos_nat
-| _           := none
-
-protected meta def to_nat : expr → option ℕ
-| `(has_zero.zero _) := some 0
-| e                  := e.to_pos_nat
-
-protected meta def to_int : expr → option ℤ
-| `(has_neg.neg %%e) := do n ← e.to_nat, some (-n)
-| e                  := coe <$> e.to_nat
 
 protected meta def of_nat (α : expr) : ℕ → tactic expr :=
 nat.binary_rec
@@ -83,30 +21,6 @@ protected meta def of_int (α : expr) : ℤ → tactic expr
 | -[1+ n] := do
   e ← expr.of_nat α (n+1),
   tactic.mk_app ``has_neg.neg [e]
-
-meta def is_meta_var : expr → bool
-| (mvar _ _ _) := tt
-| e            := ff
-
-meta def is_sort : expr → bool
-| (sort _) := tt
-| e         := ff
-
-meta def list_local_consts (e : expr) : list expr :=
-e.fold [] (λ e' _ es, if e'.is_local_constant then insert e' es else es)
-
-meta def list_constant (e : expr) : name_set :=
-e.fold mk_name_set (λ e' _ es, if e'.is_constant then es.insert e'.const_name else es)
-
-meta def list_meta_vars (e : expr) : list expr :=
-e.fold [] (λ e' _ es, if e'.is_meta_var then insert e' es else es)
-
-meta def list_names_with_prefix (pre : name) (e : expr) : name_set :=
-e.fold mk_name_set $ λ e' _ l,
-  match e' with
-  | expr.const n _ := if n.get_prefix = pre then l.insert n else l
-  | _ := l
-  end
 
 /- only traverses the direct descendents -/
 meta def {u} traverse {m : Type → Type u} [applicative m]
@@ -127,34 +41,7 @@ meta def mfoldl {α : Type} {m} [monad m] (f : α → expr → m α) : α → ex
 | x e := prod.snd <$> (state_t.run (e.traverse $ λ e',
     (get >>= monad_lift ∘ flip f e' >>= put) $> e') x : m _)
 
-meta def is_mvar : expr → bool
-| (mvar _ _ _) := tt
-| _            := ff
-
 end expr
-
-namespace environment
-
-meta def in_current_file' (env : environment) (n : name) : bool :=
-env.in_current_file n && (n ∉ [``quot, ``quot.mk, ``quot.lift, ``quot.ind])
-
-meta def is_structure_like (env : environment) (n : name) : option (nat × name) :=
-do guardb (env.is_inductive n),
-  d ← (env.get n).to_option,
-  [intro] ← pure (env.constructors_of n) | none,
-  guard (env.inductive_num_indices n = 0),
-  some (env.inductive_num_params n, intro)
-
-meta def is_structure (env : environment) (n : name) : bool :=
-option.is_some $ do
-  (nparams, intro) ← env.is_structure_like n,
-  di ← (env.get intro).to_option,
-  expr.pi x _ _ _ ← nparams.iterate
-    (λ e : option expr, do expr.pi _ _ _ body ← e | none, some body)
-    (some di.type) | none,
-  env.is_projection (n ++ x.deinternalize_field)
-
-end environment
 
 namespace interaction_monad
 open result

--- a/src/tactic/norm_num.lean
+++ b/src/tactic/norm_num.lean
@@ -159,7 +159,7 @@ meta def prove_lt (simp : expr → tactic (expr × expr)) : instance_cache → e
   d ← expr.of_rat c.α (n₂ - n₁),
   (c, e₃) ← c.mk_app ``has_add.add [e₁, d],
   (e₂', p) ← norm_num e₃,
-  guard (e₂' =ₐ e₂),
+  guard (e₂'.is_num_eq e₂),
   (c, p') ← prove_pos c d,
   (c, p) ← c.mk_app ``norm_num.lt_add_of_pos_helper [e₁, d, e₂, p, p'],
   return (c, p)


### PR DESCRIPTION
This pr does two things.

First, it fixes a bug in `norm_num` reported by @kbuzzard at https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/norm_num.20weirdness . The assert on the changed line is mostly unnecessary, and could also just be removed. This is the second "bug" that's been noticed because of that line, but arguably, both were caused by it. In any case, the assert has twice pointed out differences between how `norm_num` runs and how we expect it to run, so I'm hesitant to remove it completely.

It also moves some stuff in `tactic.basic` to the `meta` folder where it really belongs. Sorry for the two changes at once. But they aren't completely independent, and the non-tactic stuff in `tactic.basic` has been bugging me.

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
