### PR TITLE
Module refactoring take 2: remove out_param

### DIFF
--- a/src/algebra/module.lean
+++ b/src/algebra/module.lean
@@ -13,7 +13,7 @@ universes u v w x
 variables {α : Type u} {β : Type v} {γ : Type w} {δ : Type x}
 
 /-- Typeclass for types with a scalar multiplication operation, denoted `•` (`\bu`) -/
-class has_scalar (α : out_param $ Type u) (γ : Type v) := (smul : α → γ → γ)
+class has_scalar (α : Type u) (γ : Type v) := (smul : α → γ → γ)
 
 infixr ` • `:73 := has_scalar.smul
 
@@ -22,25 +22,26 @@ infixr ` • `:73 := has_scalar.smul
   connected by a "scalar multiplication" operation `r • x : β`
   (where `r : α` and `x : β`) with some natural associativity and
   distributivity axioms similar to those on a ring. -/
-class semimodule (α : out_param $ Type u) (β : Type v) [out_param $ semiring α]
+class semimodule (α : Type u) (β : Type v) [semiring α]
   [add_comm_monoid β] extends has_scalar α β :=
-(smul_add : ∀r (x y : β), r • (x + y) = r • x + r • y)
-(add_smul : ∀r s (x : β), (r + s) • x = r • x + s • x)
-(mul_smul : ∀r s (x : β), (r * s) • x = r • s • x)
+(smul_add : ∀(r : α) (x y : β), r • (x + y) = r • x + r • y)
+(add_smul : ∀(r s : α) (x : β), (r + s) • x = r • x + s • x)
+(mul_smul : ∀(r s : α) (x : β), (r * s) • x = r • s • x)
 (one_smul : ∀x : β, (1 : α) • x = x)
 (zero_smul : ∀x : β, (0 : α) • x = 0)
-(smul_zero {} : ∀r, r • (0 : β) = 0)
+(smul_zero {} : ∀(r : α), r • (0 : β) = 0)
 
 section semimodule
-variables {R:semiring α} [add_comm_monoid β] [semimodule α β] (r s : α) (x y : β)
+variables [R:semiring α] [add_comm_monoid β] [semimodule α β] (r s : α) (x y : β)
 include R
 
 theorem smul_add : r • (x + y) = r • x + r • y := semimodule.smul_add r x y
 theorem add_smul : (r + s) • x = r • x + s • x := semimodule.add_smul r s x
 theorem mul_smul : (r * s) • x = r • s • x := semimodule.mul_smul r s x
-@[simp] theorem one_smul : (1 : α) • x = x := semimodule.one_smul x
-@[simp] theorem zero_smul : (0 : α) • x = 0 := semimodule.zero_smul x
 @[simp] theorem smul_zero : r • (0 : β) = 0 := semimodule.smul_zero r
+variables (α)
+@[simp] theorem one_smul : (1 : α) • x = x := semimodule.one_smul α x
+@[simp] theorem zero_smul : (0 : α) • x = 0 := semimodule.zero_smul α x
 
 lemma smul_smul : r • s • x = (r * s) • x := (mul_smul _ _ _).symm
 
@@ -54,19 +55,18 @@ end semimodule
   connected by a "scalar multiplication" operation `r • x : β`
   (where `r : α` and `x : β`) with some natural associativity and
   distributivity axioms similar to those on a ring. -/
-class module (α : out_param $ Type u) (β : Type v) [out_param $ ring α]
-  [add_comm_group β] extends semimodule α β
+class module (α : Type u) (β : Type v) [ring α] [add_comm_group β] extends semimodule α β
 
 structure module.core (α β) [ring α] [add_comm_group β] extends has_scalar α β :=
-(smul_add : ∀r (x y : β), r • (x + y) = r • x + r • y)
-(add_smul : ∀r s (x : β), (r + s) • x = r • x + s • x)
-(mul_smul : ∀r s (x : β), (r * s) • x = r • s • x)
+(smul_add : ∀(r : α) (x y : β), r • (x + y) = r • x + r • y)
+(add_smul : ∀(r s : α) (x : β), (r + s) • x = r • x + s • x)
+(mul_smul : ∀(r s : α) (x : β), (r * s) • x = r • s • x)
 (one_smul : ∀x : β, (1 : α) • x = x)
 
 def module.of_core {α β} [ring α] [add_comm_group β] (M : module.core α β) : module α β :=
 by letI := M.to_has_scalar; exact
 { zero_smul := λ x,
-    have (0 : α) • x + 0 • x = 0 • x + 0, by rw ← M.add_smul; simp,
+    have (0 : α) • x + (0 : α) • x = (0 : α) • x + 0, by rw ← M.add_smul; simp,
     add_left_cancel this,
   smul_zero := λ r,
     have r • (0:β) + r • 0 = r • 0 + 0, by rw ← M.smul_add; simp,
@@ -74,16 +74,17 @@ by letI := M.to_has_scalar; exact
   ..M }
 
 section module
-variables {R:ring α} [add_comm_group β] [module α β] {r s : α} {x y : β}
-include R
+variables [ring α] [add_comm_group β] [module α β] (r s : α) (x y : β)
 
 @[simp] theorem neg_smul : -r • x = - (r • x) :=
 eq_neg_of_add_eq_zero (by rw [← add_smul, add_left_neg, zero_smul])
 
+variables (α)
 theorem neg_one_smul (x : β) : (-1 : α) • x = -x := by simp
+variables {α}
 
 @[simp] theorem smul_neg : r • (-x) = -(r • x) :=
-by rw [← neg_one_smul x, ← mul_smul, mul_neg_one, neg_smul]
+by rw [← neg_one_smul α, ← mul_smul, mul_neg_one, neg_smul]
 
 theorem smul_sub (r : α) (x y : β) : r • (x - y) = r • x - r • y :=
 by simp [smul_add]; rw smul_neg
@@ -107,35 +108,36 @@ instance semiring.to_semimodule [r : semiring α] : semimodule α α :=
 instance ring.to_module [r : ring α] : module α α :=
 { ..semiring.to_semimodule }
 
-class is_linear_map {α : Type u} {β : Type v} {γ : Type w}
+class is_linear_map (α : Type u) {β : Type v} {γ : Type w}
   [ring α] [add_comm_group β] [add_comm_group γ] [module α β] [module α γ]
   (f : β → γ) : Prop :=
 (add  : ∀x y, f (x + y) = f x + f y)
-(smul : ∀c x, f (c • x) = c • f x)
+(smul : ∀(c : α) x, f (c • x) = c • f x)
 
-structure linear_map {α : Type u} (β : Type v) (γ : Type w)
+structure linear_map (α : Type u) (β : Type v) (γ : Type w)
   [ring α] [add_comm_group β] [add_comm_group γ] [module α β] [module α γ] :=
 (to_fun : β → γ)
 (add  : ∀x y, to_fun (x + y) = to_fun x + to_fun y)
-(smul : ∀c x, to_fun (c • x) = c • to_fun x)
+(smul : ∀(c : α) x, to_fun (c • x) = c • to_fun x)
 
-infixr ` →ₗ `:25 := linear_map
+infixr ` →ₗ `:25 := linear_map _
+notation β ` →ₗ[`:25 α `] ` γ := linear_map α β γ
 
 namespace linear_map
 
 variables [ring α] [add_comm_group β] [add_comm_group γ] [add_comm_group δ]
 variables [module α β] [module α γ] [module α δ]
-variables (f g : β →ₗ γ)
+variables (f g : β →ₗ[α] γ)
 include α
 
-instance : has_coe_to_fun (β →ₗ γ) := ⟨_, to_fun⟩
+instance : has_coe_to_fun (β →ₗ[α] γ) := ⟨_, to_fun⟩
 
-theorem is_linear : is_linear_map f := {..f}
+theorem is_linear : is_linear_map α f := {..f}
 
-@[extensionality] theorem ext {f g : β →ₗ γ} (H : ∀ x, f x = g x) : f = g :=
+@[extensionality] theorem ext {f g : β →ₗ[α] γ} (H : ∀ x, f x = g x) : f = g :=
 by cases f; cases g; congr'; exact funext H
 
-theorem ext_iff {f g : β →ₗ γ} : f = g ↔ ∀ x, f x = g x :=
+theorem ext_iff {f g : β →ₗ[α] γ} : f = g ↔ ∀ x, f x = g x :=
 ⟨by rintro rfl; simp, ext⟩
 
 @[simp] lemma map_add (x y : β) : f (x + y) = f x + f y := f.add x y
@@ -143,12 +145,12 @@ theorem ext_iff {f g : β →ₗ γ} : f = g ↔ ∀ x, f x = g x :=
 @[simp] lemma map_smul (c : α) (x : β) : f (c • x) = c • f x := f.smul c x
 
 @[simp] lemma map_zero : f 0 = 0 :=
-by rw [← zero_smul, map_smul f 0 0, zero_smul]
+by rw [← zero_smul α, map_smul f 0 0, zero_smul]
 
 instance : is_add_group_hom f := ⟨map_add f⟩
 
 @[simp] lemma map_neg (x : β) : f (- x) = - f x :=
-by rw [← neg_one_smul, map_smul, neg_one_smul]
+by rw [← neg_one_smul α, map_smul, neg_one_smul]
 
 @[simp] lemma map_sub (x y : β) : f (x - y) = f x - f y :=
 by simp [map_neg, map_add]
@@ -157,11 +159,11 @@ by simp [map_neg, map_add]
   f (t.sum g) = t.sum (λi, f (g i)) :=
 (finset.sum_hom f).symm
 
-def comp (f : γ →ₗ δ) (g : β →ₗ γ) : β →ₗ δ := ⟨f ∘ g, by simp, by simp⟩
+def comp (f : γ →ₗ[α] δ) (g : β →ₗ[α] γ) : β →ₗ[α] δ := ⟨f ∘ g, by simp, by simp⟩
 
-@[simp] lemma comp_apply (f : γ →ₗ δ) (g : β →ₗ γ) (x : β) : f.comp g x = f (g x) := rfl
+@[simp] lemma comp_apply (f : γ →ₗ[α] δ) (g : β →ₗ[α] γ) (x : β) : f.comp g x = f (g x) := rfl
 
-def id : linear_map β β := ⟨id, by simp, by simp⟩
+def id : β →ₗ[α] β := ⟨id, by simp, by simp⟩
 
 @[simp] lemma id_apply (x : β) : @id α β _ _ _ x = x := rfl
 
@@ -172,9 +174,9 @@ variables [ring α] [add_comm_group β] [add_comm_group γ]
 variables [module α β] [module α γ]
 include α
 
-def mk' (f : β → γ) (H : is_linear_map f) : β →ₗ γ := {to_fun := f, ..H}
+def mk' (f : β → γ) (H : is_linear_map α f) : β →ₗ γ := {to_fun := f, ..H}
 
-@[simp] theorem mk'_apply {f : β → γ} (H : is_linear_map f) (x : β) :
+@[simp] theorem mk'_apply {f : β → γ} (H : is_linear_map α f) (x : β) :
   mk' f H x = f x := rfl
 
 end is_linear_map
@@ -182,19 +184,18 @@ end is_linear_map
 /-- A submodule of a module is one which is closed under vector operations.
   This is a sufficient condition for the subset of vectors in the submodule
   to themselves form a module. -/
-structure submodule (α : Type u) (β : Type v) {R:ring α}
+structure submodule (α : Type u) (β : Type v) [ring α]
   [add_comm_group β] [module α β] : Type v :=
 (carrier : set β)
 (zero : (0:β) ∈ carrier)
 (add : ∀ {x y}, x ∈ carrier → y ∈ carrier → x + y ∈ carrier)
-(smul : ∀ c {x}, x ∈ carrier → c • x ∈ carrier)
+(smul : ∀ (c:α) {x}, x ∈ carrier → c • x ∈ carrier)
 
 namespace submodule
-variables {R:ring α} [add_comm_group β] [add_comm_group γ]
+variables [ring α] [add_comm_group β] [add_comm_group γ]
 variables [module α β] [module α γ]
 variables (p p' : submodule α β)
 variables {r : α} {x y : β}
-include R
 
 instance : has_coe (submodule α β) (set β) := ⟨submodule.carrier⟩
 instance : has_mem β (submodule α β) := ⟨λ x p, x ∈ (p : set β)⟩
@@ -215,7 +216,7 @@ lemma add_mem (h₁ : x ∈ p) (h₂ : y ∈ p) : x + y ∈ p := p.add h₁ h₂
 
 lemma smul_mem (r : α) (h : x ∈ p) : r • x ∈ p := p.smul r h
 
-lemma neg_mem (hx : x ∈ p) : -x ∈ p := by rw ← neg_one_smul x; exact p.smul_mem _ hx
+lemma neg_mem (hx : x ∈ p) : -x ∈ p := by rw ← neg_one_smul α; exact p.smul_mem _ hx
 
 lemma sub_mem (hx : x ∈ p) (hy : y ∈ p) : x - y ∈ p := p.add_mem hx (p.neg_mem hy)
 
@@ -252,7 +253,7 @@ instance : module α p :=
 by refine {smul := (•), ..};
    { intros, apply set_coe.ext, simp [smul_add, add_smul, mul_smul] }
 
-protected def subtype : p →ₗ β :=
+protected def subtype : p →ₗ[α] β :=
 by refine {to_fun := coe, ..}; simp [coe_smul]
 
 @[simp] theorem subtype_apply (x : p) : p.subtype x = x := rfl
@@ -287,8 +288,7 @@ end ideal
   This is the traditional generalization of spaces like `ℝ^n`, which have a natural
   addition operation and a way to multiply them by real numbers, but no multiplication
   operation between vectors. -/
-class vector_space (α : out_param $ Type u) (β : Type v)
-  [out_param $ discrete_field α] [add_comm_group β] extends module α β
+class vector_space (α : Type u) (β : Type v) [discrete_field α] [add_comm_group β] extends module α β
 
 /-- Subspace of a vector space. Defined to equal `submodule`. -/
 @[reducible] def subspace (α : Type u) (β : Type v)

--- a/src/algebra/pi_instances.lean
+++ b/src/algebra/pi_instances.lean
@@ -61,7 +61,14 @@ instance add_comm_group     [∀ i, add_comm_group     $ f i] : add_comm_group  
 instance ring               [∀ i, ring               $ f i] : ring               (Π i : I, f i) := by pi_instance
 instance comm_ring          [∀ i, comm_ring          $ f i] : comm_ring          (Π i : I, f i) := by pi_instance
 
-instance semimodule   (α) {r : semiring α}       [∀ i, add_comm_monoid $ f i] [∀ i, semimodule α $ f i]   : semimodule α (Π i : I, f i)   := by pi_instance
+instance semimodule   (α) {r : semiring α}       [∀ i, add_comm_monoid $ f i] [∀ i, semimodule α $ f i]   : semimodule α (Π i : I, f i)   :=
+{ smul := λ c f i, c • f i,
+  smul_add := λ c f g, funext $ λ i, smul_add _ _ _,
+  add_smul := λ c f g, funext $ λ i, add_smul _ _ _,
+  mul_smul := λ r s f, funext $ λ i, mul_smul _ _ _,
+  one_smul := λ f, funext $ λ i, one_smul α _,
+  zero_smul := λ f, funext $ λ i, zero_smul α _,
+  smul_zero := λ c, funext $ λ i, smul_zero _ }
 instance module       (α) {r : ring α}           [∀ i, add_comm_group $ f i]  [∀ i, module α $ f i]       : module α (Π i : I, f i)       := {..pi.semimodule α}
 instance vector_space (α) {r : discrete_field α} [∀ i, add_comm_group $ f i]  [∀ i, vector_space α $ f i] : vector_space α (Π i : I, f i) := {..pi.module α}
 
@@ -311,8 +318,8 @@ instance {r : semiring α} [add_comm_monoid β] [add_comm_monoid γ]
 { smul_add  := assume a p₁ p₂, mk.inj_iff.mpr ⟨smul_add _ _ _, smul_add _ _ _⟩,
   add_smul  := assume a p₁ p₂, mk.inj_iff.mpr ⟨add_smul _ _ _, add_smul _ _ _⟩,
   mul_smul  := assume a₁ a₂ p, mk.inj_iff.mpr ⟨mul_smul _ _ _, mul_smul _ _ _⟩,
-  one_smul  := assume ⟨b, c⟩, mk.inj_iff.mpr ⟨one_smul _, one_smul _⟩,
-  zero_smul := assume ⟨b, c⟩, mk.inj_iff.mpr ⟨zero_smul _, zero_smul _⟩,
+  one_smul  := assume ⟨b, c⟩, mk.inj_iff.mpr ⟨one_smul _ _, one_smul _ _⟩,
+  zero_smul := assume ⟨b, c⟩, mk.inj_iff.mpr ⟨zero_smul _ _, zero_smul _ _⟩,
   smul_zero := assume a, mk.inj_iff.mpr ⟨smul_zero _, smul_zero _⟩,
   .. prod.has_scalar }
 

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -299,7 +299,7 @@ section normed_space
 
 class normed_space (α : out_param $ Type*) (β : Type*) [out_param $ normed_field α]
   extends normed_group β, vector_space α β :=
-(norm_smul : ∀ a b, norm (a • b) = has_norm.norm a * norm b)
+(norm_smul : ∀ (a:α) b, norm (a • b) = has_norm.norm a * norm b)
 
 variables [normed_field α]
 
@@ -347,17 +347,12 @@ instance : normed_space α (E × F) :=
   begin
     intros s x,
     cases x with x₁ x₂,
-    exact calc
-      ∥s • (x₁, x₂)∥ = ∥ (s • x₁, s• x₂)∥ : rfl
-      ... = max (∥s • x₁∥) (∥ s• x₂∥) : rfl
-      ... = max (∥s∥ * ∥x₁∥) (∥s∥ * ∥x₂∥) : by simp [norm_smul s x₁, norm_smul s x₂]
-      ... = ∥s∥ * max (∥x₁∥) (∥x₂∥) : by simp [mul_max_of_nonneg]
+    change max (∥s • x₁∥) (∥s • x₂∥) = ∥s∥ * max (∥x₁∥) (∥x₂∥),
+    rw [norm_smul, norm_smul, ← mul_max_of_nonneg _ _ (norm_nonneg _)]
   end,
 
-  add_smul := by simp[add_smul],
-  -- I have no idea why by simp[smul_add] is not enough for the next goal
-  smul_add := assume r x y,  show (r•(x+y).fst, r•(x+y).snd)  = (r•x.fst+r•y.fst, r•x.snd+r•y.snd),
-               by simp[smul_add],
+  add_smul := λ r x y, prod.ext (add_smul _ _ _) (add_smul _ _ _),
+  smul_add := λ r x y, prod.ext (smul_add _ _ _) (smul_add _ _ _),
   ..prod.normed_group,
   ..prod.vector_space }
 

--- a/src/analysis/normed_space/bounded_linear_maps.lean
+++ b/src/analysis/normed_space/bounded_linear_maps.lean
@@ -29,13 +29,13 @@ variables {G : Type*} [normed_space k G]
 
 structure is_bounded_linear_map {k : Type*}
   [normed_field k] {E : Type*} [normed_space k E] {F : Type*} [normed_space k F] (L : E → F)
-  extends is_linear_map L : Prop :=
+  extends is_linear_map k L : Prop :=
 (bound : ∃ M, M > 0 ∧ ∀ x : E, ∥ L x ∥ ≤ M * ∥ x ∥)
 
 include k
 
 lemma is_linear_map.with_bound
-  {L : E → F} (hf : is_linear_map L) (M : ℝ) (h : ∀ x : E, ∥ L x ∥ ≤ M * ∥ x ∥) :
+  {L : E → F} (hf : is_linear_map k L) (M : ℝ) (h : ∀ x : E, ∥ L x ∥ ≤ M * ∥ x ∥) :
   is_bounded_linear_map L :=
 ⟨ hf, classical.by_cases
   (assume : M ≤ 0, ⟨1, zero_lt_one, assume x,
@@ -58,7 +58,7 @@ lemma smul {f : E → F} (c : k) : is_bounded_linear_map f → is_bounded_linear
 
 lemma neg {f : E → F} (hf : is_bounded_linear_map f) : is_bounded_linear_map (λ e, -f e) :=
 begin
-  rw show (λ e, -f e) = (λ e, (-1) • f e), { funext, simp },
+  rw show (λ e, -f e) = (λ e, (-1 : k) • f e), { funext, simp },
   exact smul (-1) hf
 end
 
@@ -98,7 +98,7 @@ end is_bounded_linear_map
 -- Next lemma is stated for real normed space but it would work as soon as the base field is an extension of ℝ
 lemma bounded_continuous_linear_map
   {E : Type*} [normed_space ℝ E] {F : Type*} [normed_space ℝ F] {L : E → F}
-  (lin : is_linear_map L) (cont : continuous L) : is_bounded_linear_map L :=
+  (lin : is_linear_map ℝ L) (cont : continuous L) : is_bounded_linear_map L :=
 let ⟨δ, δ_pos, hδ⟩ := exists_delta_of_continuous cont zero_lt_one 0 in
 have HL0 : L 0 = 0, from (lin.mk' _).map_zero,
 have H : ∀{a}, ∥a∥ ≤ δ → ∥L a∥ < 1, by simpa only [HL0, dist_zero_right] using hδ,

--- a/src/data/dfinsupp.lean
+++ b/src/data/dfinsupp.lean
@@ -387,9 +387,9 @@ instance [Π i, add_group (β i)] {s : finset ι} : is_add_group_hom (@mk ι β 
 
 section
 local attribute [instance] to_module
-variables {γ : Type w} [ring γ] [Π i, add_comm_group (β i)] [Π i, module γ (β i)]
+variables (γ : Type w) [ring γ] [Π i, add_comm_group (β i)] [Π i, module γ (β i)]
 include γ
-@[simp] lemma mk_smul {s : finset ι} {c : γ} {x : Π i : (↑s : set ι), β i.1} :
+@[simp] lemma mk_smul {s : finset ι} {c : γ} (x : Π i : (↑s : set ι), β i.1) :
   mk s (c • x) = c • mk s x :=
 ext $ λ i, by simp only [smul_apply, mk_apply]; split_ifs; [refl, rw smul_zero]
 
@@ -398,16 +398,16 @@ ext $ λ i, by simp only [smul_apply, mk_apply]; split_ifs; [refl, rw smul_zero]
 ext $ λ i, by simp only [smul_apply, single_apply]; split_ifs; [cases h, rw smul_zero]; refl
 
 variable β
-def lmk (s : finset ι) : (Π i : (↑s : set ι), β i.1) →ₗ Π₀ i, β i :=
-⟨mk s, λ _ _, mk_add, λ _ _, mk_smul⟩
+def lmk (s : finset ι) : (Π i : (↑s : set ι), β i.1) →ₗ[γ] Π₀ i, β i :=
+⟨mk s, λ _ _, mk_add, λ c x, by rw [mk_smul γ x]⟩
 
-def lsingle (i) : β i →ₗ Π₀ i, β i :=
-⟨single i, λ _ _, single_add, λ _ _, single_smul⟩
+def lsingle (i) : β i →ₗ[γ] Π₀ i, β i :=
+⟨single i, λ _ _, single_add, λ _ _, single_smul _⟩
 variable {β}
 
-@[simp] lemma lmk_apply {s : finset ι} {x} : lmk β s x = mk s x := rfl
+@[simp] lemma lmk_apply {s : finset ι} {x} : lmk β γ s x = mk s x := rfl
 
-@[simp] lemma lsingle_apply {i : ι} {x : β i} : lsingle β i x = single i x := rfl
+@[simp] lemma lsingle_apply {i : ι} {x : β i} : lsingle β γ i x = single i x := rfl
 end
 
 section support_basic

--- a/src/data/finsupp.lean
+++ b/src/data/finsupp.lean
@@ -889,7 +889,7 @@ finset.induction_on s rfl $ λ a s has ih, by rw [prod_insert has, ih,
 section
 variables (α β)
 
-def to_has_scalar' {R:semiring γ} [add_comm_monoid β] [semimodule γ β] : has_scalar γ (α →₀ β) := ⟨λa v, v.map_range ((•) a) (smul_zero _)⟩
+def to_has_scalar' [R:semiring γ] [add_comm_monoid β] [semimodule γ β] : has_scalar γ (α →₀ β) := ⟨λa v, v.map_range ((•) a) (smul_zero _)⟩
 local attribute [instance] to_has_scalar'
 
 @[simp] lemma smul_apply' {R:semiring γ} [add_comm_monoid β] [semimodule γ β] {a : α} {b : γ} {v : α →₀ β} :
@@ -899,9 +899,9 @@ def to_semimodule {R:semiring γ} [add_comm_monoid β] [semimodule γ β] : semi
 { smul      := (•),
   smul_add  := λ a x y, finsupp.ext $ λ _, smul_add _ _ _,
   add_smul  := λ a x y, finsupp.ext $ λ _, add_smul _ _ _,
-  one_smul  := λ x, finsupp.ext $ λ _, one_smul _,
+  one_smul  := λ x, finsupp.ext $ λ _, one_smul _ _,
   mul_smul  := λ r s x, finsupp.ext $ λ _, mul_smul _ _ _,
-  zero_smul := λ x, finsupp.ext $ λ _, zero_smul _,
+  zero_smul := λ x, finsupp.ext $ λ _, zero_smul _ _,
   smul_zero := λ x, finsupp.ext $ λ _, smul_zero _ }
 
 def to_module {R:ring γ} [add_comm_group β] [module γ β] : module γ (α →₀ β) :=

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -16,11 +16,6 @@ reserve infix `≃ₗ` : 50
 universes u v w x y
 variables {α : Type u} {β : Type v} {γ : Type w} {δ : Type y} {ι : Type x}
 
-@[elab_as_eliminator]
-lemma classical.some_spec3 {α : Type*} {p : α → Prop} {h : ∃a, p a}
-  (q : α → Prop) (hpq : ∀a, p a → q a) : q (classical.some h) :=
-hpq _ $ classical.some_spec _
-
 namespace finset
 
 lemma smul_sum [ring γ] [add_comm_group β] [module γ β]
@@ -43,39 +38,39 @@ namespace linear_map
 section
 variables [ring α] [add_comm_group β] [add_comm_group γ] [add_comm_group δ]
 variables [module α β] [module α γ] [module α δ]
-variables (f g : β →ₗ γ)
+variables (f g : β →ₗ[α] γ)
 include α
 
-theorem comp_id (f : β →ₗ γ) : f.comp id = f :=
+theorem comp_id (f : β →ₗ[α] γ) : f.comp id = f :=
 linear_map.ext $ λ x, rfl
 
-theorem id_comp (f : β →ₗ γ) : id.comp f = f :=
+theorem id_comp (f : β →ₗ[α] γ) : id.comp f = f :=
 linear_map.ext $ λ x, rfl
 
-def cod_restrict (p : submodule α β) (f : γ →ₗ β) (h : ∀c, f c ∈ p) : γ →ₗ p :=
+def cod_restrict (p : submodule α β) (f : γ →ₗ[α] β) (h : ∀c, f c ∈ p) : γ →ₗ[α] p :=
 by refine {to_fun := λc, ⟨f c, h c⟩, ..}; intros; apply set_coe.ext; simp
 
-@[simp] theorem cod_restrict_apply (p : submodule α β) (f : γ →ₗ β) {h} (x : γ) :
+@[simp] theorem cod_restrict_apply (p : submodule α β) (f : γ →ₗ[α] β) {h} (x : γ) :
   (cod_restrict p f h x : β) = f x := rfl
 
-def inverse (g : γ → β) (h₁ : left_inverse g f) (h₂ : right_inverse g f) : γ →ₗ β :=
+def inverse (g : γ → β) (h₁ : left_inverse g f) (h₂ : right_inverse g f) : γ →ₗ[α] β :=
 by dsimp [left_inverse, function.right_inverse] at h₁ h₂; exact
 ⟨g, λ x y, by rw [← h₁ (g (x + y)), ← h₁ (g x + g y)]; simp [h₂],
     λ a b, by rw [← h₁ (g (a • b)), ← h₁ (a • g b)]; simp [h₂]⟩
 
-instance : has_zero (β →ₗ γ) := ⟨⟨λ _, 0, by simp, by simp⟩⟩
+instance : has_zero (β →ₗ[α] γ) := ⟨⟨λ _, 0, by simp, by simp⟩⟩
 
-@[simp] lemma zero_apply (x : β) : (0 : β →ₗ γ) x = 0 := rfl
+@[simp] lemma zero_apply (x : β) : (0 : β →ₗ[α] γ) x = 0 := rfl
 
-instance : has_neg (β →ₗ γ) := ⟨λ f, ⟨λ b, - f b, by simp, by simp⟩⟩
+instance : has_neg (β →ₗ[α] γ) := ⟨λ f, ⟨λ b, - f b, by simp, by simp⟩⟩
 
 @[simp] lemma neg_apply (x : β) : (- f) x = - f x := rfl
 
-instance : has_add (β →ₗ γ) := ⟨λ f g, ⟨λ b, f b + g b, by simp, by simp [smul_add]⟩⟩
+instance : has_add (β →ₗ[α] γ) := ⟨λ f g, ⟨λ b, f b + g b, by simp, by simp [smul_add]⟩⟩
 
 @[simp] lemma add_apply (x : β) : (f + g) x = f x + g x := rfl
 
-instance : add_comm_group (β →ₗ γ) :=
+instance : add_comm_group (β →ₗ[α] γ) :=
 by refine {zero := 0, add := (+), neg := has_neg.neg, ..};
    intros; ext; simp
 
@@ -83,115 +78,115 @@ instance linear_map.is_add_group_hom : is_add_group_hom f :=
 by refine_struct {..}; simp
 
 instance linear_map_apply_is_add_group_hom (a : β) :
-  is_add_group_hom (λ f : β →ₗ γ, f a) :=
+  is_add_group_hom (λ f : β →ₗ[α] γ, f a) :=
 by refine_struct {..}; simp
 
-lemma sum_apply [decidable_eq δ] (t : finset δ) (f : δ → β →ₗ γ) (b : β) :
+lemma sum_apply [decidable_eq δ] (t : finset δ) (f : δ → β →ₗ[α] γ) (b : β) :
   t.sum f b = t.sum (λd, f d b) :=
-(@finset.sum_hom _ _ _ t f _ _ (λ g : β →ₗ γ, g b) _).symm
+(@finset.sum_hom _ _ _ t f _ _ (λ g : β →ₗ[α] γ, g b) _).symm
 
 @[simp] lemma sub_apply (x : β) : (f - g) x = f x - g x := rfl
 
-def smul_right (f : γ →ₗ α) (x : β) : γ →ₗ β :=
+def smul_right (f : γ →ₗ[α] α) (x : β) : γ →ₗ[α] β :=
 ⟨λb, f b • x, by simp [add_smul], by simp [smul_smul]⟩.
 
-@[simp] theorem smul_right_apply (f : γ →ₗ α) (x : β) (c : γ) :
+@[simp] theorem smul_right_apply (f : γ →ₗ[α] α) (x : β) (c : γ) :
   (smul_right f x : γ → β) c = f c • x := rfl
 
-instance : has_one (β →ₗ β) := ⟨linear_map.id⟩
-instance : has_mul (β →ₗ β) := ⟨linear_map.comp⟩
+instance : has_one (β →ₗ[α] β) := ⟨linear_map.id⟩
+instance : has_mul (β →ₗ[α] β) := ⟨linear_map.comp⟩
 
-@[simp] lemma one_app (x : β) : (1 : β →ₗ β) x = x := rfl
-@[simp] lemma mul_app (A B : β →ₗ β) (x : β) : (A * B) x = A (B x) := rfl
+@[simp] lemma one_app (x : β) : (1 : β →ₗ[α] β) x = x := rfl
+@[simp] lemma mul_app (A B : β →ₗ[α] β) (x : β) : (A * B) x = A (B x) := rfl
 
 section
 variables (α β)
 include β
 
 -- declaring this an instance breaks `real.lean` with reaching max. instance resolution depth
-def endomorphism_ring : ring (β →ₗ β) :=
+def endomorphism_ring : ring (β →ₗ[α] β) :=
 by refine {mul := (*), one := 1, ..linear_map.add_comm_group, ..};
   { intros, apply linear_map.ext, simp }
 
 /-- The group of invertible linear maps from `β` to itself -/
 def general_linear_group :=
-by haveI := endomorphism_ring α β; exact units (β →ₗ β)
+by haveI := endomorphism_ring α β; exact units (β →ₗ[α] β)
 end
 
 section
-variables (β γ)
-def fst : β × γ →ₗ β := ⟨prod.fst, λ x y, rfl, λ x y, rfl⟩
-def snd : β × γ →ₗ γ := ⟨prod.snd, λ x y, rfl, λ x y, rfl⟩
+variables (α β γ)
+def fst : β × γ →ₗ[α] β := ⟨prod.fst, λ x y, rfl, λ x y, rfl⟩
+def snd : β × γ →ₗ[α] γ := ⟨prod.snd, λ x y, rfl, λ x y, rfl⟩
 end
 
-@[simp] theorem fst_apply (x : β × γ) : fst β γ x = x.1 := rfl
-@[simp] theorem snd_apply (x : β × γ) : snd β γ x = x.2 := rfl
+@[simp] theorem fst_apply (x : β × γ) : fst α β γ x = x.1 := rfl
+@[simp] theorem snd_apply (x : β × γ) : snd α β γ x = x.2 := rfl
 
-def pair (f : β →ₗ γ) (g : β →ₗ δ) : β →ₗ γ × δ :=
+def pair (f : β →ₗ[α] γ) (g : β →ₗ[α] δ) : β →ₗ[α] γ × δ :=
 ⟨λ x, (f x, g x), λ x y, by simp, λ x y, by simp⟩
 
-@[simp] theorem pair_apply (f : β →ₗ γ) (g : β →ₗ δ) (x : β) :
+@[simp] theorem pair_apply (f : β →ₗ[α] γ) (g : β →ₗ[α] δ) (x : β) :
   pair f g x = (f x, g x) := rfl
 
-@[simp] theorem fst_pair (f : β →ₗ γ) (g : β →ₗ δ) :
-  (fst γ δ).comp (pair f g) = f := by ext; refl
+@[simp] theorem fst_pair (f : β →ₗ[α] γ) (g : β →ₗ[α] δ) :
+  (fst α γ δ).comp (pair f g) = f := by ext; refl
 
-@[simp] theorem snd_pair (f : β →ₗ γ) (g : β →ₗ δ) :
-  (snd γ δ).comp (pair f g) = g := by ext; refl
+@[simp] theorem snd_pair (f : β →ₗ[α] γ) (g : β →ₗ[α] δ) :
+  (snd α γ δ).comp (pair f g) = g := by ext; refl
 
-@[simp] theorem pair_fst_snd : pair (fst β γ) (snd β γ) = linear_map.id :=
+@[simp] theorem pair_fst_snd : pair (fst α β γ) (snd α β γ) = linear_map.id :=
 by ext; refl
 
 section
-variables (β γ)
-def inl : β →ₗ β × γ := by refine ⟨prod.inl, _, _⟩; intros; simp [prod.inl]
-def inr : γ →ₗ β × γ := by refine ⟨prod.inr, _, _⟩; intros; simp [prod.inr]
+variables (α β γ)
+def inl : β →ₗ[α] β × γ := by refine ⟨prod.inl, _, _⟩; intros; simp [prod.inl]
+def inr : γ →ₗ[α] β × γ := by refine ⟨prod.inr, _, _⟩; intros; simp [prod.inr]
 end
 
-@[simp] theorem inl_apply (x : β) : inl β γ x = (x, 0) := rfl
-@[simp] theorem inr_apply (x : γ) : inr β γ x = (0, x) := rfl
+@[simp] theorem inl_apply (x : β) : inl α β γ x = (x, 0) := rfl
+@[simp] theorem inr_apply (x : γ) : inr α β γ x = (0, x) := rfl
 
-def copair (f : β →ₗ δ) (g : γ →ₗ δ) : β × γ →ₗ δ :=
+def copair (f : β →ₗ[α] δ) (g : γ →ₗ[α] δ) : β × γ →ₗ[α] δ :=
 ⟨λ x, f x.1 + g x.2, λ x y, by simp, λ x y, by simp [smul_add]⟩
 
-@[simp] theorem copair_apply (f : β →ₗ δ) (g : γ →ₗ δ) (x : β) (y : γ) :
+@[simp] theorem copair_apply (f : β →ₗ[α] δ) (g : γ →ₗ[α] δ) (x : β) (y : γ) :
   copair f g (x, y) = f x + g y := rfl
 
-@[simp] theorem copair_inl (f : β →ₗ δ) (g : γ →ₗ δ) :
-  (copair f g).comp (inl β γ) = f := by ext; simp
+@[simp] theorem copair_inl (f : β →ₗ[α] δ) (g : γ →ₗ[α] δ) :
+  (copair f g).comp (inl α β γ) = f := by ext; simp
 
-@[simp] theorem copair_inr (f : β →ₗ δ) (g : γ →ₗ δ) :
-  (copair f g).comp (inr β γ) = g := by ext; simp
+@[simp] theorem copair_inr (f : β →ₗ[α] δ) (g : γ →ₗ[α] δ) :
+  (copair f g).comp (inr α β γ) = g := by ext; simp
 
-@[simp] theorem copair_inl_inr : copair (inl β γ) (inr β γ) = linear_map.id :=
+@[simp] theorem copair_inl_inr : copair (inl α β γ) (inr α β γ) = linear_map.id :=
 by ext ⟨x, y⟩; simp
 
-theorem fst_eq_copair : fst β γ = copair linear_map.id 0 := by ext ⟨x, y⟩; simp
+theorem fst_eq_copair : fst α β γ = copair linear_map.id 0 := by ext ⟨x, y⟩; simp
 
-theorem snd_eq_copair : snd β γ = copair 0 linear_map.id := by ext ⟨x, y⟩; simp
+theorem snd_eq_copair : snd α β γ = copair 0 linear_map.id := by ext ⟨x, y⟩; simp
 
-theorem inl_eq_pair : inl β γ = pair linear_map.id 0 := rfl
+theorem inl_eq_pair : inl α β γ = pair linear_map.id 0 := rfl
 
-theorem inr_eq_pair : inr β γ = pair 0 linear_map.id := rfl
+theorem inr_eq_pair : inr α β γ = pair 0 linear_map.id := rfl
 
 end
 
 section comm_ring
 variables [comm_ring α] [add_comm_group β] [add_comm_group γ] [add_comm_group δ]
 variables [module α β] [module α γ] [module α δ]
-variables (f g : β →ₗ γ)
+variables (f g : β →ₗ[α] γ)
 include α
 
-instance : has_scalar α (β →ₗ γ) := ⟨λ a f,
+instance : has_scalar α (β →ₗ[α] γ) := ⟨λ a f,
   ⟨λ b, a • f b, by simp [smul_add], by simp [smul_smul, mul_comm]⟩⟩
 
 @[simp] lemma smul_apply (a : α) (x : β) : (a • f) x = a • f x := rfl
 
-instance : module α (β →ₗ γ) :=
+instance : module α (β →ₗ[α] γ) :=
 module.of_core $ by refine { smul := (•), ..};
   intros; ext; simp [smul_add, add_smul, smul_smul]
 
-def congr_right (f : γ →ₗ δ) : (β →ₗ γ) →ₗ (β →ₗ δ) :=
+def congr_right (f : γ →ₗ[α] δ) : (β →ₗ[α] γ) →ₗ[α] (β →ₗ[α] δ) :=
 ⟨linear_map.comp f,
 λ _ _, linear_map.ext $ λ _, f.2 _ _,
 λ _ _, linear_map.ext $ λ _, f.3 _ _⟩
@@ -200,11 +195,10 @@ end comm_ring
 end linear_map
 
 namespace submodule
-variables {R:ring α} [add_comm_group β] [add_comm_group γ] [add_comm_group δ]
+variables [ring α] [add_comm_group β] [add_comm_group γ] [add_comm_group δ]
 variables [module α β] [module α γ] [module α δ]
 variables (p p' : submodule α β) (q q' : submodule α γ)
 variables {r : α} {x y : β}
-include R
 open set lattice
 
 instance : partial_order (submodule α β) :=
@@ -214,7 +208,7 @@ lemma le_def {p p' : submodule α β} : p ≤ p' ↔ (p : set β) ⊆ p' := iff.
 
 lemma le_def' {p p' : submodule α β} : p ≤ p' ↔ ∀ x ∈ p, x ∈ p' := iff.rfl
 
-def of_le {p p' : submodule α β} (h : p ≤ p') : p →ₗ p' :=
+def of_le {p p' : submodule α β} (h : p ≤ p') : p →ₗ[α] p' :=
 linear_map.cod_restrict _ p.subtype $ λ ⟨x, hx⟩, h hx
 
 @[simp] theorem of_le_apply {p p' : submodule α β} (h : p ≤ p')
@@ -225,7 +219,10 @@ instance : has_bot (submodule α β) :=
 
 @[simp] lemma bot_coe : ((⊥ : submodule α β) : set β) = {0} := rfl
 
+section
+variables (α)
 @[simp] lemma mem_bot : x ∈ (⊥ : submodule α β) ↔ x = 0 := mem_singleton_iff
+end
 
 instance : order_bot (submodule α β) :=
 { bot := ⊥,
@@ -306,7 +303,7 @@ theorem disjoint_def {p p' : submodule α β} :
 show (∀ x, x ∈ p ∧ x ∈ p' → x ∈ ({0} : set β)) ↔ _, by simp
 
 /-- The pushforward -/
-def map (f : β →ₗ γ) (p : submodule α β) : submodule α γ :=
+def map (f : β →ₗ[α] γ) (p : submodule α β) : submodule α γ :=
 { carrier := f '' p,
   zero  := ⟨0, p.zero_mem, f.map_zero⟩,
   add   := by rintro _ _ ⟨b₁, hb₁, rfl⟩ ⟨b₂, hb₂, rfl⟩;
@@ -314,63 +311,63 @@ def map (f : β →ₗ γ) (p : submodule α β) : submodule α γ :=
   smul  := by rintro a _ ⟨b, hb, rfl⟩;
               exact ⟨_, p.smul_mem _ hb, f.map_smul _ _⟩ }
 
-lemma map_coe (f : β →ₗ γ) (p : submodule α β) :
+lemma map_coe (f : β →ₗ[α] γ) (p : submodule α β) :
   (map f p : set γ) = f '' p := rfl
 
-@[simp] lemma mem_map {f : β →ₗ γ} {p : submodule α β} {x : γ} :
+@[simp] lemma mem_map {f : β →ₗ[α] γ} {p : submodule α β} {x : γ} :
   x ∈ map f p ↔ ∃ y, y ∈ p ∧ f y = x := iff.rfl
 
-theorem mem_map_of_mem {f : β →ₗ γ} {p : submodule α β} {r} (h : r ∈ p) : f r ∈ map f p :=
+theorem mem_map_of_mem {f : β →ₗ[α] γ} {p : submodule α β} {r} (h : r ∈ p) : f r ∈ map f p :=
 set.mem_image_of_mem _ h
 
 lemma map_id : map linear_map.id p = p :=
 submodule.ext $ λ a, by simp
 
-lemma map_comp (f : β →ₗ γ) (g : γ →ₗ δ) (p : submodule α β) :
+lemma map_comp (f : β →ₗ[α] γ) (g : γ →ₗ[α] δ) (p : submodule α β) :
   map (g.comp f) p = map g (map f p) :=
 submodule.ext' $ by simp [map_coe]; rw ← image_comp
 
-lemma map_mono {f : β →ₗ γ} {p p' : submodule α β} : p ≤ p' → map f p ≤ map f p' :=
+lemma map_mono {f : β →ₗ[α] γ} {p p' : submodule α β} : p ≤ p' → map f p ≤ map f p' :=
 image_subset _
 
 /-- The pullback -/
-def comap (f : β →ₗ γ) (p : submodule α γ) : submodule α β :=
+def comap (f : β →ₗ[α] γ) (p : submodule α γ) : submodule α β :=
 { carrier := f ⁻¹' p,
   zero  := by simp,
   add   := λ x y h₁ h₂, by simp [p.add_mem h₁ h₂],
   smul  := λ a x h, by simp [p.smul_mem _ h] }
 
-@[simp] lemma comap_coe (f : β →ₗ γ) (p : submodule α γ) :
+@[simp] lemma comap_coe (f : β →ₗ[α] γ) (p : submodule α γ) :
   (comap f p : set β) = f ⁻¹' p := rfl
 
-@[simp] lemma mem_comap {f : β →ₗ γ} {p : submodule α γ} :
+@[simp] lemma mem_comap {f : β →ₗ[α] γ} {p : submodule α γ} :
   x ∈ comap f p ↔ f x ∈ p := iff.rfl
 
 lemma comap_id : comap linear_map.id p = p :=
 submodule.ext' rfl
 
-lemma comap_comp (f : β →ₗ γ) (g : γ →ₗ δ) (p : submodule α δ) :
+lemma comap_comp (f : β →ₗ[α] γ) (g : γ →ₗ[α] δ) (p : submodule α δ) :
   comap (g.comp f) p = comap f (comap g p) := rfl
 
-lemma comap_mono {f : β →ₗ γ} {q q' : submodule α γ} : q ≤ q' → comap f q ≤ comap f q' :=
+lemma comap_mono {f : β →ₗ[α] γ} {q q' : submodule α γ} : q ≤ q' → comap f q ≤ comap f q' :=
 preimage_mono
 
-@[simp] lemma comap_top (f : β →ₗ γ) : comap f ⊤ = ⊤ := rfl
+@[simp] lemma comap_top (f : β →ₗ[α] γ) : comap f ⊤ = ⊤ := rfl
 
-lemma map_le_iff_le_comap {f : β →ₗ γ} {p : submodule α β} {q : submodule α γ} :
+lemma map_le_iff_le_comap {f : β →ₗ[α] γ} {p : submodule α β} {q : submodule α γ} :
   map f p ≤ q ↔ p ≤ comap f q := image_subset_iff
 
-lemma map_comap_le (f : β →ₗ γ) (q : submodule α γ) : map f (comap f q) ≤ q :=
+lemma map_comap_le (f : β →ₗ[α] γ) (q : submodule α γ) : map f (comap f q) ≤ q :=
 map_le_iff_le_comap.2 $ le_refl _
 
-lemma le_comap_map (f : β →ₗ γ) (p : submodule α β) : p ≤ comap f (map f p) :=
+lemma le_comap_map (f : β →ₗ[α] γ) (p : submodule α β) : p ≤ comap f (map f p) :=
 map_le_iff_le_comap.1 $ le_refl _
 
-@[simp] lemma map_bot (f : β →ₗ γ) : map f ⊥ = ⊥ :=
+@[simp] lemma map_bot (f : β →ₗ[α] γ) : map f ⊥ = ⊥ :=
 eq_bot_iff.2 $ map_le_iff_le_comap.2 bot_le
 
 --TODO(Mario): is there a way to prove this from order properties?
-lemma map_inf_eq_map_inf_comap {f : β →ₗ γ}
+lemma map_inf_eq_map_inf_comap {f : β →ₗ[α] γ}
   {p : submodule α β} {p' : submodule α γ} :
   map f p ⊓ p' = map f (p ⊓ comap f p') :=
 le_antisymm
@@ -380,49 +377,52 @@ le_antisymm
 lemma map_comap_subtype : map p.subtype (comap p.subtype p') = p ⊓ p' :=
 ext $ λ x, ⟨by rintro ⟨⟨_, h₁⟩, h₂, rfl⟩; exact ⟨h₁, h₂⟩, λ ⟨h₁, h₂⟩, ⟨⟨_, h₁⟩, h₂, rfl⟩⟩
 
+section
+variables (α)
 def span (s : set β) : submodule α β := Inf {p | s ⊆ p}
+end
 
 variables {s t : set β}
-lemma mem_span : x ∈ span s ↔ ∀ p : submodule α β, s ⊆ p → x ∈ p :=
+lemma mem_span : x ∈ span α s ↔ ∀ p : submodule α β, s ⊆ p → x ∈ p :=
 mem_bInter_iff
 
-lemma subset_span : s ⊆ span s :=
+lemma subset_span : s ⊆ span α s :=
 λ x h, mem_span.2 $ λ p hp, hp h
 
-lemma span_le {p} : span s ≤ p ↔ s ⊆ p :=
+lemma span_le {p} : span α s ≤ p ↔ s ⊆ p :=
 ⟨subset.trans subset_span, λ ss x h, mem_span.1 h _ ss⟩
 
-lemma span_mono (h : s ⊆ t) : span s ≤ span t :=
+lemma span_mono (h : s ⊆ t) : span α s ≤ span α t :=
 span_le.2 $ subset.trans h subset_span
 
-lemma span_eq_of_le (h₁ : s ⊆ p) (h₂ : p ≤ span s) : span s = p :=
+lemma span_eq_of_le (h₁ : s ⊆ p) (h₂ : p ≤ span α s) : span α s = p :=
 le_antisymm (span_le.2 h₁) h₂
 
-@[simp] lemma span_eq : span (p : set β) = p :=
+@[simp] lemma span_eq : span α (p : set β) = p :=
 span_eq_of_le _ (subset.refl _) subset_span
 
-@[elab_as_eliminator] lemma span_induction {p : β → Prop} (h : x ∈ span s)
+@[elab_as_eliminator] lemma span_induction {p : β → Prop} (h : x ∈ span α s)
   (Hs : ∀ x ∈ s, p x) (H0 : p 0)
   (H1 : ∀ x y, p x → p y → p (x + y))
-  (H2 : ∀ a x, p x → p (a • x)) : p x :=
+  (H2 : ∀ (a:α) x, p x → p (a • x)) : p x :=
 (@span_le _ _ _ _ _ _ ⟨p, H0, H1, H2⟩).2 Hs h
 
-variables (β)
+variables (α β)
 protected def gi : galois_insertion (@span α β _ _ _) coe :=
-{ choice := λ s _, span s,
+{ choice := λ s _, span α s,
   gc := λ s t, span_le,
   le_l_u := λ s, subset_span,
   choice_eq := λ s h, rfl }
-variables {β}
+variables {α β}
 
-@[simp] lemma span_empty : span (∅ : set β) = ⊥ :=
-(submodule.gi β).gc.l_bot
+@[simp] lemma span_empty : span α (∅ : set β) = ⊥ :=
+(submodule.gi α β).gc.l_bot
 
-lemma span_union (s t : set β) : span (s ∪ t) = span s ⊔ span t :=
-(submodule.gi β).gc.l_sup
+lemma span_union (s t : set β) : span α (s ∪ t) = span α s ⊔ span α t :=
+(submodule.gi α β).gc.l_sup
 
-lemma span_Union {ι} (s : ι → set β) : span (⋃ i, s i) = ⨆ i, span (s i) :=
-(submodule.gi β).gc.l_supr
+lemma span_Union {ι} (s : ι → set β) : span α (⋃ i, s i) = ⨆ i, span α (s i) :=
+(submodule.gi α β).gc.l_supr
 
 @[simp] theorem Union_coe_of_directed {ι} (hι : nonempty ι)
   (S : ι → submodule α β)
@@ -430,7 +430,7 @@ lemma span_Union {ι} (s : ι → set β) : span (⋃ i, s i) = ⨆ i, span (s i
   ((supr S : submodule α β) : set β) = ⋃ i, S i :=
 begin
   refine subset.antisymm _ (Union_subset $ le_supr S),
-  rw [show supr S = ⨆ i, span (S i), by simp, ← span_Union],
+  rw [show supr S = ⨆ i, span α (S i), by simp, ← span_Union],
   unfreezeI,
   refine λ x hx, span_induction hx (λ _, id) _ _ _,
   { cases hι with i, exact mem_Union.2 ⟨i, by simp⟩ },
@@ -464,7 +464,7 @@ begin
   { have : (⨆ (H : N ∈ s), N) ≤ N := supr_le (λ _, le_refl _),
     exact ⟨N, hns, this hzn⟩ },
   { have : (⨆ (H : N ∈ s), N) ≤ ⊥ := supr_le hns.elim,
-    cases mem_bot.1 (this hzn), exact ⟨x, H, x.zero_mem⟩ }
+    cases (mem_bot α).1 (this hzn), exact ⟨x, H, x.zero_mem⟩ }
 end
 
 variables {p p'}
@@ -486,7 +486,7 @@ by rintro ⟨y, hy, z, hz, rfl⟩; exact add_mem _
   ((le_sup_right : p' ≤ p ⊔ p') hz)⟩
 variables (p p')
 
-lemma mem_span_singleton {y : β} : x ∈ span ({y} : set β) ↔ ∃ a, a • y = x :=
+lemma mem_span_singleton {y : β} : x ∈ span α ({y} : set β) ↔ ∃ a:α, a • y = x :=
 ⟨λ h, begin
   apply span_induction h,
   { rintro y (rfl|⟨⟨⟩⟩), exact ⟨1, by simp⟩ },
@@ -499,10 +499,10 @@ end,
 by rintro ⟨a, y, rfl⟩; exact
   smul_mem _ _ (subset_span $ by simp)⟩
 
-lemma span_singleton_eq_range (y : β) : (span ({y} : set β) : set β) = range (• y) :=
+lemma span_singleton_eq_range (y : β) : (span α ({y} : set β) : set β) = range ((• y) : α → β) :=
 set.ext $ λ x, mem_span_singleton
 
-lemma mem_span_insert {y} : x ∈ span (insert y s) ↔ ∃ a (z ∈ span s), x = a • y + z :=
+lemma mem_span_insert {y} : x ∈ span α (insert y s) ↔ ∃ (a:α) (z ∈ span α s), x = a • y + z :=
 begin
   rw [← union_singleton, span_union, mem_sup],
   simp [mem_span_singleton], split,
@@ -510,27 +510,27 @@ begin
   { rintro ⟨a, z, hz, rfl⟩, exact ⟨z, hz, _, ⟨a, rfl⟩, rfl⟩ }
 end
 
-lemma mem_span_insert' {y} : x ∈ span (insert y s) ↔ ∃a, x + a • y ∈ span s :=
+lemma mem_span_insert' {y} : x ∈ span α (insert y s) ↔ ∃(a:α), x + a • y ∈ span α s :=
 begin
   rw mem_span_insert, split,
   { rintro ⟨a, z, hz, rfl⟩, exact ⟨-a, by simp [hz]⟩ },
   { rintro ⟨a, h⟩, exact ⟨-a, _, h, by simp⟩ }
 end
 
-lemma span_insert_eq_span (h : x ∈ span s) : span (insert x s) = span s :=
+lemma span_insert_eq_span (h : x ∈ span α s) : span α (insert x s) = span α s :=
 span_eq_of_le _ (set.insert_subset.mpr ⟨h, subset_span⟩) (span_mono $ subset_insert _ _)
 
-lemma span_span : span (span s : set β) = span s := span_eq _
+lemma span_span : span α (span α s : set β) = span α s := span_eq _
 
-lemma span_eq_bot : span (s : set β) = ⊥ ↔ ∀ x ∈ s, (x:β) = 0 :=
+lemma span_eq_bot : span α (s : set β) = ⊥ ↔ ∀ x ∈ s, (x:β) = 0 :=
 eq_bot_iff.trans ⟨
-  λ H x h, mem_bot.1 $ H $ subset_span h,
-  λ H, span_le.2 (λ x h, mem_bot.2 (H x h))⟩
+  λ H x h, (mem_bot α).1 $ H $ subset_span h,
+  λ H, span_le.2 (λ x h, (mem_bot α).2 $ H x h)⟩
 
-lemma span_singleton_eq_bot : span ({x} : set β) = ⊥ ↔ x = 0 :=
+lemma span_singleton_eq_bot : span α ({x} : set β) = ⊥ ↔ x = 0 :=
 span_eq_bot.trans $ by simp
 
-@[simp] lemma span_image (f : β →ₗ γ) : span (f '' s) = map f (span s) :=
+@[simp] lemma span_image (f : β →ₗ[α] γ) : span α (f '' s) = map f (span α s) :=
 span_eq_of_le _ (image_subset _ subset_span) $ map_le_iff_le_comap.2 $
 span_le.2 $ image_subset_iff.1 subset_span
 
@@ -549,7 +549,7 @@ def prod : submodule α (β × γ) :=
   x ∈ prod p q ↔ x.1 ∈ p ∧ x.2 ∈ q := set.mem_prod
 
 lemma span_prod_le (s : set β) (t : set γ) :
-  span (set.prod s t) ≤ prod (span s) (span t) :=
+  span α (set.prod s t) ≤ prod (span α s) (span α t) :=
 span_le.2 $ set.prod_mono subset_span subset_span
 
 @[simp] lemma prod_top : (prod ⊤ ⊤ : submodule α (β × γ)) = ⊤ :=
@@ -643,83 +643,83 @@ open submodule
 
 @[simp] lemma finsupp_sum {α β γ δ} [ring α] [add_comm_group β] [module α β]
    [add_comm_group γ] [module α γ] [has_zero δ]
-  (f : β →ₗ γ) {t : ι →₀ δ} {g : ι → δ → β} :
+  (f : β →ₗ[α] γ) {t : ι →₀ δ} {g : ι → δ → β} :
   f (t.sum g) = t.sum (λi d, f (g i d)) := f.map_sum
 
-theorem map_cod_restrict (p : submodule α β) (f : γ →ₗ β) (h p') :
+theorem map_cod_restrict (p : submodule α β) (f : γ →ₗ[α] β) (h p') :
   submodule.map (cod_restrict p f h) p' = comap p.subtype (p'.map f) :=
 submodule.ext $ λ ⟨x, hx⟩, by simp [subtype.coe_ext]
 
-theorem comap_cod_restrict (p : submodule α β) (f : γ →ₗ β) (hf p') :
+theorem comap_cod_restrict (p : submodule α β) (f : γ →ₗ[α] β) (hf p') :
   submodule.comap (cod_restrict p f hf) p' = submodule.comap f (map p.subtype p') :=
 submodule.ext $ λ x, ⟨λ h, ⟨⟨_, hf x⟩, h, rfl⟩, by rintro ⟨⟨_, _⟩, h, ⟨⟩⟩; exact h⟩
 
-def range (f : β →ₗ γ) : submodule α γ := map f ⊤
+def range (f : β →ₗ[α] γ) : submodule α γ := map f ⊤
 
-theorem range_coe (f : β →ₗ γ) : (range f : set γ) = set.range f := set.image_univ
+theorem range_coe (f : β →ₗ[α] γ) : (range f : set γ) = set.range f := set.image_univ
 
-@[simp] theorem mem_range {f : β →ₗ γ} : ∀ {x}, x ∈ range f ↔ ∃ y, f y = x :=
+@[simp] theorem mem_range {f : β →ₗ[α] γ} : ∀ {x}, x ∈ range f ↔ ∃ y, f y = x :=
 (set.ext_iff _ _).1 (range_coe f).
 
-@[simp] theorem range_id : range (linear_map.id : β →ₗ β) = ⊤ := map_id _
+@[simp] theorem range_id : range (linear_map.id : β →ₗ[α] β) = ⊤ := map_id _
 
-theorem range_comp (f : β →ₗ γ) (g : γ →ₗ δ) : range (g.comp f) = map g (range f) :=
+theorem range_comp (f : β →ₗ[α] γ) (g : γ →ₗ[α] δ) : range (g.comp f) = map g (range f) :=
 map_comp _ _ _
 
-theorem range_comp_le_range (f : β →ₗ γ) (g : γ →ₗ δ) : range (g.comp f) ≤ range g :=
+theorem range_comp_le_range (f : β →ₗ[α] γ) (g : γ →ₗ[α] δ) : range (g.comp f) ≤ range g :=
 by rw range_comp; exact map_mono le_top
 
-theorem range_eq_top {f : β →ₗ γ} : range f = ⊤ ↔ surjective f :=
+theorem range_eq_top {f : β →ₗ[α] γ} : range f = ⊤ ↔ surjective f :=
 by rw [← submodule.ext'_iff, range_coe, top_coe, set.range_iff_surjective]
 
-lemma range_le_iff_comap {f : β →ₗ γ} {p : submodule α γ} : range f ≤ p ↔ comap f p = ⊤ :=
+lemma range_le_iff_comap {f : β →ₗ[α] γ} {p : submodule α γ} : range f ≤ p ↔ comap f p = ⊤ :=
 by rw [range, map_le_iff_le_comap, eq_top_iff]
 
-def ker (f : β →ₗ γ) : submodule α β := comap f ⊥
+def ker (f : β →ₗ[α] γ) : submodule α β := comap f ⊥
 
-@[simp] theorem mem_ker {f : β →ₗ γ} {y} : y ∈ ker f ↔ f y = 0 := mem_bot
+@[simp] theorem mem_ker {f : β →ₗ[α] γ} {y} : y ∈ ker f ↔ f y = 0 := mem_bot α
 
-@[simp] theorem ker_id : ker (linear_map.id : β →ₗ β) = ⊥ := rfl
+@[simp] theorem ker_id : ker (linear_map.id : β →ₗ[α] β) = ⊥ := rfl
 
-theorem ker_comp (f : β →ₗ γ) (g : γ →ₗ δ) : ker (g.comp f) = comap f (ker g) := rfl
+theorem ker_comp (f : β →ₗ[α] γ) (g : γ →ₗ[α] δ) : ker (g.comp f) = comap f (ker g) := rfl
 
-theorem ker_le_ker_comp (f : β →ₗ γ) (g : γ →ₗ δ) : ker f ≤ ker (g.comp f) :=
+theorem ker_le_ker_comp (f : β →ₗ[α] γ) (g : γ →ₗ[α] δ) : ker f ≤ ker (g.comp f) :=
 by rw ker_comp; exact comap_mono bot_le
 
-theorem sub_mem_ker_iff {f : β →ₗ γ} {x y} : x - y ∈ f.ker ↔ f x = f y :=
+theorem sub_mem_ker_iff {f : β →ₗ[α] γ} {x y} : x - y ∈ f.ker ↔ f x = f y :=
 by rw [mem_ker, map_sub, sub_eq_zero]
 
-theorem disjoint_ker {f : β →ₗ γ} {p : submodule α β} :
+theorem disjoint_ker {f : β →ₗ[α] γ} {p : submodule α β} :
   disjoint p (ker f) ↔ ∀ x ∈ p, f x = 0 → x = 0 :=
 by simp [disjoint_def]
 
-theorem disjoint_ker' {f : β →ₗ γ} {p : submodule α β} :
+theorem disjoint_ker' {f : β →ₗ[α] γ} {p : submodule α β} :
   disjoint p (ker f) ↔ ∀ x y ∈ p, f x = f y → x = y :=
 disjoint_ker.trans
 ⟨λ H x y hx hy h, eq_of_sub_eq_zero $ H _ (sub_mem _ hx hy) (by simp [h]),
  λ H x h₁ h₂, H x 0 h₁ (zero_mem _) (by simpa using h₂)⟩
 
-theorem inj_of_disjoint_ker {f : β →ₗ γ} {p : submodule α β}
+theorem inj_of_disjoint_ker {f : β →ₗ[α] γ} {p : submodule α β}
   {s : set β} (h : s ⊆ p) (hd : disjoint p (ker f)) :
   ∀ x y ∈ s, f x = f y → x = y :=
 λ x y hx hy, disjoint_ker'.1 hd _ _ (h hx) (h hy)
 
-theorem ker_eq_bot {f : β →ₗ γ} : ker f = ⊥ ↔ injective f :=
+theorem ker_eq_bot {f : β →ₗ[α] γ} : ker f = ⊥ ↔ injective f :=
 by simpa [disjoint] using @disjoint_ker' _ _ _ _ _ _ _ _ f ⊤
 
-lemma le_ker_iff_map {f : β →ₗ γ} {p : submodule α β} : p ≤ ker f ↔ map f p = ⊥ :=
+lemma le_ker_iff_map {f : β →ₗ[α] γ} {p : submodule α β} : p ≤ ker f ↔ map f p = ⊥ :=
 by rw [ker, eq_bot_iff, map_le_iff_le_comap]
 
-lemma map_comap_eq (f : β →ₗ γ) (q : submodule α γ) :
+lemma map_comap_eq (f : β →ₗ[α] γ) (q : submodule α γ) :
   map f (comap f q) = range f ⊓ q :=
 le_antisymm (le_inf (map_mono le_top) (map_comap_le _ _)) $
 by rintro _ ⟨⟨x, _, rfl⟩, hx⟩; exact ⟨x, hx, rfl⟩
 
-lemma map_comap_eq_self {f : β →ₗ γ} {q : submodule α γ} (h : q ≤ range f) :
+lemma map_comap_eq_self {f : β →ₗ[α] γ} {q : submodule α γ} (h : q ≤ range f) :
   map f (comap f q) = q :=
 by rw [map_comap_eq, inf_of_le_right h]
 
-lemma comap_map_eq (f : β →ₗ γ) (p : submodule α β) :
+lemma comap_map_eq (f : β →ₗ[α] γ) (p : submodule α β) :
   comap f (map f p) = p ⊔ ker f :=
 begin
   refine le_antisymm _ (sup_le (le_comap_map _ _) (comap_mono bot_le)),
@@ -727,29 +727,29 @@ begin
   exact mem_sup.2 ⟨y, hy, x - y, by simpa using sub_eq_zero.2 e.symm, by simp⟩
 end
 
-lemma comap_map_eq_self {f : β →ₗ γ} {p : submodule α β} (h : ker f ≤ p) :
+lemma comap_map_eq_self {f : β →ₗ[α] γ} {p : submodule α β} (h : ker f ≤ p) :
   comap f (map f p) = p :=
 by rw [comap_map_eq, sup_of_le_left h]
 
-@[simp] theorem ker_zero : ker (0 : β →ₗ γ) = ⊤ :=
+@[simp] theorem ker_zero : ker (0 : β →ₗ[α] γ) = ⊤ :=
 eq_top_iff'.2 $ λ x, by simp
 
-theorem ker_eq_top {f : β →ₗ γ} : ker f = ⊤ ↔ f = 0 :=
+theorem ker_eq_top {f : β →ₗ[α] γ} : ker f = ⊤ ↔ f = 0 :=
 ⟨λ h, ext $ λ x, mem_ker.1 $ h.symm ▸ trivial, λ h, h.symm ▸ ker_zero⟩
 
-theorem map_le_map_iff {f : β →ₗ γ} (hf : ker f = ⊥) {p p'} : map f p ≤ map f p' ↔ p ≤ p' :=
+theorem map_le_map_iff {f : β →ₗ[α] γ} (hf : ker f = ⊥) {p p'} : map f p ≤ map f p' ↔ p ≤ p' :=
 ⟨λ H x hx, let ⟨y, hy, e⟩ := H ⟨x, hx, rfl⟩ in ker_eq_bot.1 hf e ▸ hy, map_mono⟩
 
-theorem map_injective {f : β →ₗ γ} (hf : ker f = ⊥) : injective (map f) :=
+theorem map_injective {f : β →ₗ[α] γ} (hf : ker f = ⊥) : injective (map f) :=
 λ p p' h, le_antisymm ((map_le_map_iff hf).1 (le_of_eq h)) ((map_le_map_iff hf).1 (ge_of_eq h))
 
-theorem comap_le_comap_iff {f : β →ₗ γ} (hf : range f = ⊤) {p p'} : comap f p ≤ comap f p' ↔ p ≤ p' :=
+theorem comap_le_comap_iff {f : β →ₗ[α] γ} (hf : range f = ⊤) {p p'} : comap f p ≤ comap f p' ↔ p ≤ p' :=
 ⟨λ H x hx, by rcases range_eq_top.1 hf x with ⟨y, hy, rfl⟩; exact H hx, comap_mono⟩
 
-theorem comap_injective {f : β →ₗ γ} (hf : range f = ⊤) : injective (comap f) :=
+theorem comap_injective {f : β →ₗ[α] γ} (hf : range f = ⊤) : injective (comap f) :=
 λ p p' h, le_antisymm ((comap_le_comap_iff hf).1 (le_of_eq h)) ((comap_le_comap_iff hf).1 (ge_of_eq h))
 
-theorem map_copair_prod (f : β →ₗ δ) (g : γ →ₗ δ) (p : submodule α β) (q : submodule α γ) :
+theorem map_copair_prod (f : β →ₗ[α] δ) (g : γ →ₗ[α] δ) (p : submodule α β) (q : submodule α γ) :
   map (copair f g) (p.prod q) = map f p ⊔ map g q :=
 begin
   refine le_antisymm _ (sup_le (map_le_iff_le_comap.2 _) (map_le_iff_le_comap.2 _)),
@@ -759,20 +759,20 @@ begin
   { exact λ x hx, ⟨(0, x), by simp [hx]⟩ }
 end
 
-theorem comap_pair_prod (f : β →ₗ γ) (g : β →ₗ δ) (p : submodule α γ) (q : submodule α δ) :
+theorem comap_pair_prod (f : β →ₗ[α] γ) (g : β →ₗ[α] δ) (p : submodule α γ) (q : submodule α δ) :
   comap (pair f g) (p.prod q) = comap f p ⊓ comap g q :=
 submodule.ext $ λ x, iff.rfl
 
 theorem prod_eq_inf_comap (p : submodule α β) (q : submodule α γ) :
-  p.prod q = p.comap (linear_map.fst β γ) ⊓ q.comap (linear_map.snd β γ) :=
+  p.prod q = p.comap (linear_map.fst α β γ) ⊓ q.comap (linear_map.snd α β γ) :=
 submodule.ext $ λ x, iff.rfl
 
 theorem prod_eq_sup_map (p : submodule α β) (q : submodule α γ) :
-  p.prod q = p.map (linear_map.inl β γ) ⊔ q.map (linear_map.inr β γ) :=
+  p.prod q = p.map (linear_map.inl α β γ) ⊔ q.map (linear_map.inr α β γ) :=
 by rw [← map_copair_prod, copair_inl_inr, map_id]
 
 lemma span_inl_union_inr {s : set β} {t : set γ} :
-  span (prod.inl '' s ∪ prod.inr '' t) = (span s).prod (span t) :=
+  span α (prod.inl '' s ∪ prod.inr '' t) = (span α s).prod (span α t) :=
 by rw [span_union, prod_eq_sup_map, ← span_image, ← span_image]; refl
 
 end linear_map
@@ -783,9 +783,9 @@ variables (p p' : submodule α β) (q : submodule α γ)
 include R
 open linear_map
 
-@[simp] theorem map_top (f : β →ₗ γ) : map f ⊤ = range f := rfl
+@[simp] theorem map_top (f : β →ₗ[α] γ) : map f ⊤ = range f := rfl
 
-@[simp] theorem comap_bot (f : β →ₗ γ) : comap f ⊥ = ker f := rfl
+@[simp] theorem comap_bot (f : β →ₗ[α] γ) : comap f ⊥ = ker f := rfl
 
 @[simp] theorem ker_subtype : p.subtype.ker = ⊥ :=
 ker_eq_bot.2 $ λ x y, subtype.eq'
@@ -817,54 +817,54 @@ def map_subtype.lt_order_embedding :
   ((<) : submodule α p → submodule α p → Prop) ≼o ((<) : submodule α β → submodule α β → Prop) :=
 (map_subtype.le_order_embedding p).lt_embedding_of_le_embedding
 
-@[simp] theorem map_inl : p.map (inl β γ) = prod p ⊥ :=
+@[simp] theorem map_inl : p.map (inl α β γ) = prod p ⊥ :=
 by ext ⟨x, y⟩; simp [and.left_comm, eq_comm]
 
-@[simp] theorem map_inr : q.map (inr β γ) = prod ⊥ q :=
+@[simp] theorem map_inr : q.map (inr α β γ) = prod ⊥ q :=
 by ext ⟨x, y⟩; simp [and.left_comm, eq_comm]
 
-@[simp] theorem comap_fst : p.comap (fst β γ) = prod p ⊤ :=
+@[simp] theorem comap_fst : p.comap (fst α β γ) = prod p ⊤ :=
 by ext ⟨x, y⟩; simp
 
-@[simp] theorem comap_snd : q.comap (snd β γ) = prod ⊤ q :=
+@[simp] theorem comap_snd : q.comap (snd α β γ) = prod ⊤ q :=
 by ext ⟨x, y⟩; simp
 
-@[simp] theorem prod_comap_inl : (prod p q).comap (inl β γ) = p := by ext; simp
+@[simp] theorem prod_comap_inl : (prod p q).comap (inl α β γ) = p := by ext; simp
 
-@[simp] theorem prod_comap_inr : (prod p q).comap (inr β γ) = q := by ext; simp
+@[simp] theorem prod_comap_inr : (prod p q).comap (inr α β γ) = q := by ext; simp
 
-@[simp] theorem prod_map_fst : (prod p q).map (fst β γ) = p :=
+@[simp] theorem prod_map_fst : (prod p q).map (fst α β γ) = p :=
 by ext x; simp [(⟨0, zero_mem _⟩ : ∃ x, x ∈ q)]
 
-@[simp] theorem prod_map_snd : (prod p q).map (snd β γ) = q :=
+@[simp] theorem prod_map_snd : (prod p q).map (snd α β γ) = q :=
 by ext x; simp [(⟨0, zero_mem _⟩ : ∃ x, x ∈ p)]
 
-@[simp] theorem ker_inl : (inl β γ).ker = ⊥ :=
+@[simp] theorem ker_inl : (inl α β γ).ker = ⊥ :=
 by rw [ker, ← prod_bot, prod_comap_inl]
 
-@[simp] theorem ker_inr : (inr β γ).ker = ⊥ :=
+@[simp] theorem ker_inr : (inr α β γ).ker = ⊥ :=
 by rw [ker, ← prod_bot, prod_comap_inr]
 
-@[simp] theorem range_fst : (fst β γ).range = ⊤ :=
+@[simp] theorem range_fst : (fst α β γ).range = ⊤ :=
 by rw [range, ← prod_top, prod_map_fst]
 
-@[simp] theorem range_snd : (snd β γ).range = ⊤ :=
+@[simp] theorem range_snd : (snd α β γ).range = ⊤ :=
 by rw [range, ← prod_top, prod_map_snd]
 
-def mkq : β →ₗ p.quotient := ⟨quotient.mk, by simp, by simp⟩
+def mkq : β →ₗ[α] p.quotient := ⟨quotient.mk, by simp, by simp⟩
 
 @[simp] theorem mkq_apply (x : β) : p.mkq x = quotient.mk x := rfl
 
-def liftq (f : β →ₗ γ) (h : p ≤ f.ker) : p.quotient →ₗ γ :=
+def liftq (f : β →ₗ[α] γ) (h : p ≤ f.ker) : p.quotient →ₗ[α] γ :=
 ⟨λ x, _root_.quotient.lift_on' x f $
    λ a b (ab : a - b ∈ p), eq_of_sub_eq_zero $ by simpa using h ab,
  by rintro ⟨x⟩ ⟨y⟩; exact map_add f x y,
  by rintro a ⟨x⟩; exact map_smul f a x⟩
 
-@[simp] theorem liftq_apply (f : β →ₗ γ) {h} (x : β) :
+@[simp] theorem liftq_apply (f : β →ₗ[α] γ) {h} (x : β) :
   p.liftq f h (quotient.mk x) = f x := rfl
 
-@[simp] theorem liftq_mkq (f : β →ₗ γ) (h) : (p.liftq f h).comp p.mkq = f :=
+@[simp] theorem liftq_mkq (f : β →ₗ[α] γ) (h) : (p.liftq f h).comp p.mkq = f :=
 by ext; refl
 
 @[simp] theorem range_mkq : p.mkq.range = ⊤ :=
@@ -882,26 +882,35 @@ by rw [eq_bot_iff, map_le_iff_le_comap, comap_bot, ker_mkq]; exact le_refl _
 @[simp] theorem comap_map_mkq : comap p.mkq (map p.mkq p') = p ⊔ p' :=
 by simp [comap_map_eq, sup_comm]
 
-def mapq (f : β →ₗ γ) (h : p ≤ comap f q) : p.quotient →ₗ q.quotient :=
+def mapq (f : β →ₗ[α] γ) (h : p ≤ comap f q) : p.quotient →ₗ[α] q.quotient :=
 p.liftq (q.mkq.comp f) $ by simpa [ker_comp] using h
 
-@[simp] theorem mapq_apply (f : β →ₗ γ) {h} (x : β) :
+@[simp] theorem mapq_apply (f : β →ₗ[α] γ) {h} (x : β) :
   mapq p q f h (quotient.mk x) = quotient.mk (f x) := rfl
 
-theorem mapq_mkq (f : β →ₗ γ) {h} : (mapq p q f h).comp p.mkq = q.mkq.comp f :=
+theorem mapq_mkq (f : β →ₗ[α] γ) {h} : (mapq p q f h).comp p.mkq = q.mkq.comp f :=
 by ext x; refl
 
-theorem comap_liftq (f : β →ₗ γ) (h) :
+theorem comap_liftq (f : β →ₗ[α] γ) (h) :
   q.comap (p.liftq f h) = (q.comap f).map (mkq p) :=
 le_antisymm
   (by rintro ⟨x⟩ hx; exact ⟨_, hx, rfl⟩)
   (by rw [map_le_iff_le_comap, ← comap_comp, liftq_mkq]; exact le_refl _)
 
-theorem ker_liftq (f : β →ₗ γ) (h) :
+theorem map_liftq (f : β →ₗ[α] γ) (h) (q : submodule α (quotient p)) :
+  q.map (p.liftq f h) = (q.comap p.mkq).map f :=
+le_antisymm
+  (by rintro _ ⟨⟨x⟩, hxq, rfl⟩; exact ⟨x, hxq, rfl⟩)
+  (by rintro _ ⟨x, hxq, rfl⟩; exact ⟨quotient.mk x, hxq, rfl⟩)
+
+theorem ker_liftq (f : β →ₗ[α] γ) (h) :
   ker (p.liftq f h) = (ker f).map (mkq p) := comap_liftq _ _ _ _
 
-theorem ker_liftq_eq_bot (f : β →ₗ γ) (h) (h' : ker f = p) : ker (p.liftq f h) = ⊥ :=
-by rw [ker_liftq, h', mkq_map_self]
+theorem range_liftq (f : β →ₗ[α] γ) (h) :
+  range (p.liftq f h) = range f := map_liftq _ _ _ _
+
+theorem ker_liftq_eq_bot (f : β →ₗ[α] γ) (h) (h' : ker f ≤ p) : ker (p.liftq f h) = ⊥ :=
+by rw [ker_liftq, le_antisymm h h', mkq_map_self]
 
 /-- Correspondence Theorem -/
 def comap_mkq.order_iso :
@@ -928,12 +937,13 @@ end submodule
 
 section
 set_option old_structure_cmd true
-structure linear_equiv {α : Type u} (β : Type v) (γ : Type w)
+structure linear_equiv (α : Type u) (β : Type v) (γ : Type w)
   [ring α] [add_comm_group β] [add_comm_group γ] [module α β] [module α γ]
-  extends β →ₗ γ, β ≃ γ
+  extends β →ₗ[α] γ, β ≃ γ
 end
 
-infix ` ≃ₗ ` := linear_equiv
+infix ` ≃ₗ ` := linear_equiv _
+notation β ` ≃ₗ[`:50 α `] ` γ := linear_equiv α β γ
 
 namespace linear_equiv
 section ring
@@ -943,52 +953,52 @@ include α
 
 section
 variable (β)
-def refl : β ≃ₗ β := { .. linear_map.id, .. equiv.refl β }
+def refl : β ≃ₗ[α] β := { .. linear_map.id, .. equiv.refl β }
 end
 
-def symm (e : β ≃ₗ γ) : γ ≃ₗ β :=
+def symm (e : β ≃ₗ[α] γ) : γ ≃ₗ[α] β :=
 { .. e.to_linear_map.inverse e.inv_fun e.left_inv e.right_inv,
   .. e.to_equiv.symm }
 
-def trans (e₁ : β ≃ₗ γ) (e₂ : γ ≃ₗ δ) : β ≃ₗ δ :=
+def trans (e₁ : β ≃ₗ[α] γ) (e₂ : γ ≃ₗ[α] δ) : β ≃ₗ[α] δ :=
 { .. e₂.to_linear_map.comp e₁.to_linear_map,
   .. e₁.to_equiv.trans e₂.to_equiv }
 
-instance : has_coe (β ≃ₗ γ) (β →ₗ γ) := ⟨to_linear_map⟩
+instance : has_coe (β ≃ₗ[α] γ) (β →ₗ[α] γ) := ⟨to_linear_map⟩
 
-@[simp] theorem apply_symm_apply (e : β ≃ₗ γ) (c : γ) : e (e.symm c) = c := e.6 c
-@[simp] theorem symm_apply_apply (e : β ≃ₗ γ) (b : β) : e.symm (e b) = b := e.5 b
+@[simp] theorem apply_symm_apply (e : β ≃ₗ[α] γ) (c : γ) : e (e.symm c) = c := e.6 c
+@[simp] theorem symm_apply_apply (e : β ≃ₗ[α] γ) (b : β) : e.symm (e b) = b := e.5 b
 
-@[simp] theorem coe_apply (e : β ≃ₗ γ) (b : β) : (e : β →ₗ γ) b = e b := rfl
+@[simp] theorem coe_apply (e : β ≃ₗ[α] γ) (b : β) : (e : β →ₗ[α] γ) b = e b := rfl
 
 noncomputable def of_bijective
-  (f : β →ₗ γ) (hf₁ : f.ker = ⊥) (hf₂ : f.range = ⊤) : β ≃ₗ γ :=
+  (f : β →ₗ[α] γ) (hf₁ : f.ker = ⊥) (hf₂ : f.range = ⊤) : β ≃ₗ[α] γ :=
 { ..f, ..@equiv.of_bijective _ _ f
   ⟨linear_map.ker_eq_bot.1 hf₁, linear_map.range_eq_top.1 hf₂⟩ }
 
-@[simp] theorem of_bijective_apply (f : β →ₗ γ) {hf₁ hf₂} (x : β) :
+@[simp] theorem of_bijective_apply (f : β →ₗ[α] γ) {hf₁ hf₂} (x : β) :
   of_bijective f hf₁ hf₂ x = f x := rfl
 
-def of_linear (f : β →ₗ γ) (g : γ →ₗ β)
-  (h₁ : f.comp g = linear_map.id) (h₂ : g.comp f = linear_map.id) : β ≃ₗ γ :=
+def of_linear (f : β →ₗ[α] γ) (g : γ →ₗ[α] β)
+  (h₁ : f.comp g = linear_map.id) (h₂ : g.comp f = linear_map.id) : β ≃ₗ[α] γ :=
 { inv_fun   := g,
   left_inv  := linear_map.ext_iff.1 h₂,
   right_inv := linear_map.ext_iff.1 h₁,
   ..f }
 
-@[simp] theorem of_linear_apply (f : β →ₗ γ) (g : γ →ₗ β) {h₁ h₂}
+@[simp] theorem of_linear_apply (f : β →ₗ[α] γ) (g : γ →ₗ[α] β) {h₁ h₂}
   (x : β) : of_linear f g h₁ h₂ x = f x := rfl
 
-@[simp] theorem of_linear_symm_apply (f : β →ₗ γ) (g : γ →ₗ β) {h₁ h₂}
+@[simp] theorem of_linear_symm_apply (f : β →ₗ[α] γ) (g : γ →ₗ[α] β) {h₁ h₂}
   (x : γ) : (of_linear f g h₁ h₂).symm x = g x := rfl
 
-@[simp] protected theorem ker (f : β ≃ₗ γ) : (f : β →ₗ γ).ker = ⊥ :=
+@[simp] protected theorem ker (f : β ≃ₗ[α] γ) : (f : β →ₗ[α] γ).ker = ⊥ :=
 linear_map.ker_eq_bot.2 f.to_equiv.bijective.1
 
-@[simp] protected theorem range (f : β ≃ₗ γ) : (f : β →ₗ γ).range = ⊤ :=
+@[simp] protected theorem range (f : β ≃ₗ[α] γ) : (f : β →ₗ[α] γ).range = ⊤ :=
 linear_map.range_eq_top.2 f.to_equiv.bijective.2
 
-def of_top (p : submodule α β) (h : p = ⊤) : p ≃ₗ β :=
+def of_top (p : submodule α β) (h : p = ⊤) : p ≃ₗ[α] β :=
 { inv_fun   := λ x, ⟨x, h.symm ▸ trivial⟩,
   left_inv  := λ ⟨x, h⟩, rfl,
   right_inv := λ x, rfl,
@@ -1007,7 +1017,7 @@ variables [comm_ring α] [add_comm_group β] [add_comm_group γ] [add_comm_group
 variables [module α β] [module α γ] [module α δ]
 include α
 
-def congr_right (f : γ ≃ₗ δ) : (β →ₗ γ) ≃ₗ (β →ₗ δ) :=
+def congr_right (f : γ ≃ₗ[α] δ) : (β →ₗ[α] γ) ≃ₗ (β →ₗ δ) :=
 of_linear
   f.to_linear_map.congr_right
   f.symm.to_linear_map.congr_right
@@ -1021,12 +1031,12 @@ end linear_equiv
 namespace linear_map
 variables [ring α] [add_comm_group β] [add_comm_group γ] [add_comm_group δ]
 variables [module α β] [module α γ] [module α δ]
-variables (f : β →ₗ γ)
+variables (f : β →ₗ[α] γ)
 
 /-- First Isomorphism Law -/
-noncomputable def quot_ker_equiv_range : f.ker.quotient ≃ₗ f.range :=
+noncomputable def quot_ker_equiv_range : f.ker.quotient ≃ₗ[α] f.range :=
 have hr : ∀ x : f.range, ∃ y, f y = ↑x := λ x, x.2.imp $ λ _, and.right,
-let F : f.ker.quotient →ₗ f.range :=
+let F : f.ker.quotient →ₗ[α] f.range :=
   f.ker.liftq (cod_restrict f.range f $ λ x, ⟨x, trivial, rfl⟩)
     (λ x hx, by simp; apply subtype.coe_ext.2; simpa using hx) in
 { inv_fun    := λx, submodule.quotient.mk (classical.some (hr x)),
@@ -1037,35 +1047,30 @@ let F : f.ker.quotient →ₗ f.range :=
   .. F }
 
 open submodule
+
+def sup_quotient_to_quotient_inf (p p' : submodule α β) :
+  (comap p.subtype (p ⊓ p')).quotient →ₗ[α] (comap (p ⊔ p').subtype p').quotient :=
+(comap p.subtype (p ⊓ p')).liftq
+  ((comap (p ⊔ p').subtype p').mkq.comp (of_le le_sup_left)) begin
+rw [ker_comp, of_le, comap_cod_restrict, ker_mkq, map_comap_subtype],
+exact comap_mono (inf_le_inf le_sup_left (le_refl _)) end
+
+set_option class.instance_max_depth 41
+
 /-- Second Isomorphism Law -/
 noncomputable def sup_quotient_equiv_quotient_inf (p p' : submodule α β) :
-  (comap p.subtype (p ⊓ p')).quotient ≃ₗ
-  (comap (p ⊔ p').subtype p').quotient :=
-begin
-  let F : (comap p.subtype (p ⊓ p')).quotient →ₗ
-          (comap (p ⊔ p').subtype p').quotient :=
-    (comap p.subtype (p ⊓ p')).liftq
-      ((comap (p ⊔ p').subtype p').mkq.comp (of_le le_sup_left)) begin
-    rw [ker_comp, of_le, comap_cod_restrict, ker_mkq, map_comap_subtype],
-    exact comap_mono (inf_le_inf le_sup_left (le_refl _)),
-  end,
-  have hsup : ∀ x : p ⊔ p', ∃ y : p, ↑x - ↑y ∈ p',
-  { rintro ⟨x, hx⟩,
-    rcases mem_sup.1 hx with ⟨y, hy, z, hz, rfl⟩,
-    exact ⟨⟨y, hy⟩, by simp [hz]⟩ },
-  let G := λ x, classical.some (hsup x),
-  have hG : ∀ x : p ⊔ p', ↑x - ↑(G x) ∈ p' :=
-    λ x, classical.some_spec (hsup x),
-  refine {
-    to_fun := F,
-    inv_fun := λ q, quotient.lift_on' q (λ x, submodule.quotient.mk (G x)) _,
-    ..F, .. },
-  { refine λ x y h, (submodule.quotient.eq _).2 ⟨(G x - G y : p).2, _⟩,
-    simpa using add_mem _ (sub_mem p' h (hG x)) (hG y) },
-  { rintro ⟨x⟩,
-    refine ((submodule.quotient.eq _).2 _).symm,
-    exact ⟨(x - G _ : p).2, hG ⟨↑x, _⟩⟩ },
-  { rintro ⟨x⟩, refine (quot.sound _).symm, exact hG x }
-end
+  (comap p.subtype (p ⊓ p')).quotient ≃ₗ[α] (comap (p ⊔ p').subtype p').quotient :=
+{ .. sup_quotient_to_quotient_inf p p',
+  .. show (comap p.subtype (p ⊓ p')).quotient ≃ (comap (p ⊔ p').subtype p').quotient, from
+    @equiv.of_bijective _ _ (sup_quotient_to_quotient_inf p p') begin
+      constructor,
+      { rw [← ker_eq_bot, sup_quotient_to_quotient_inf, ker_liftq_eq_bot],
+        rw [ker_comp, ker_mkq],
+        rintros ⟨x, hx1⟩ hx2, exact ⟨hx1, hx2⟩ },
+      rw [← range_eq_top, sup_quotient_to_quotient_inf, range_liftq, eq_top_iff'],
+      rintros ⟨x, hx⟩, rcases mem_sup.1 hx with ⟨y, hy, z, hz, rfl⟩,
+      use [⟨y, hy⟩, trivial], apply (submodule.quotient.eq _).2,
+      change y - (y + z) ∈ p', rwa [sub_add_eq_sub_sub, sub_self, zero_sub, neg_mem_iff]
+    end }
 
 end linear_map

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -9,12 +9,12 @@ This file is inspired by Isabelle/HOL's linear algebra, and hence indirectly by 
 
 We define the following concepts:
 
-* `linear_independent s`: states that `s` are linear independent
+* `linear_independent α s`: states that `s` are linear independent
 
 * `linear_independent.repr s b`: choose the linear combination representing `b` on the linear
-  independent vectors `s`. `b` should be in `span b` (uses classical choice)
+  independent vectors `s`. `b` should be in `span α b` (uses classical choice)
 
-* `is_basis s`: if `s` is a basis, i.e. linear independent and spans the entire space
+* `is_basis α s`: if `s` is a basis, i.e. linear independent and spans the entire space
 
 * `is_basis.repr s b`: like `linear_independent.repr` but as a `linear_map`
 
@@ -34,31 +34,33 @@ variables [module α β] [module α γ] [module α δ]
 variables {a b : α} {s t : set β} {x y : β}
 include α
 
+variables (α)
 /-- Linearly independent set of vectors -/
 def linear_independent (s : set β) : Prop :=
-disjoint (lc.supported s) (lc.total β).ker
+disjoint (lc.supported α s) (lc.total α β).ker
+variables {α}
 
-theorem linear_independent_iff : linear_independent s ↔
-  ∀l ∈ lc.supported s, lc.total β l = 0 → l = 0 :=
+theorem linear_independent_iff : linear_independent α s ↔
+  ∀l ∈ lc.supported α s, lc.total α β l = 0 → l = 0 :=
 by simp [linear_independent, linear_map.disjoint_ker]
 
-theorem linear_independent_iff_total_on : linear_independent s ↔ (lc.total_on s).ker = ⊥ :=
+theorem linear_independent_iff_total_on : linear_independent α s ↔ (lc.total_on α s).ker = ⊥ :=
 by rw [lc.total_on, linear_map.ker, linear_map.comap_cod_restrict, map_bot, comap_bot,
   linear_map.ker_comp, linear_independent, disjoint, ← map_comap_subtype, map_le_iff_le_comap,
   comap_bot, ker_subtype, le_bot_iff]
 
-lemma linear_independent_empty : linear_independent (∅ : set β) :=
+lemma linear_independent_empty : linear_independent α (∅ : set β) :=
 by simp [linear_independent]
 
-lemma linear_independent.mono (h : t ⊆ s) : linear_independent s → linear_independent t :=
+lemma linear_independent.mono (h : t ⊆ s) : linear_independent α s → linear_independent α t :=
 disjoint_mono_left (lc.supported_mono h)
 
-lemma linear_independent.unique (hs : linear_independent s) {l₁ l₂ : lc α β} :
-  l₁ ∈ lc.supported s → l₂ ∈ lc.supported s →
-  lc.total β l₁ = lc.total β l₂ → l₁ = l₂ :=
+lemma linear_independent.unique (hs : linear_independent α s) {l₁ l₂ : lc α β} :
+  l₁ ∈ lc.supported α s → l₂ ∈ lc.supported α s →
+  lc.total α β l₁ = lc.total α β l₂ → l₁ = l₂ :=
 linear_map.disjoint_ker'.1 hs _ _
 
-lemma zero_not_mem_of_linear_independent (ne : 0 ≠ (1:α)) (hs : linear_independent s) : (0:β) ∉ s :=
+lemma zero_not_mem_of_linear_independent (ne : 0 ≠ (1:α)) (hs : linear_independent α s) : (0:β) ∉ s :=
 λ h, ne $ eq.symm begin
   suffices : (finsupp.single 0 1 : lc α β) 0 = 0, {simpa},
   rw disjoint_def.1 hs _ (lc.single_mem_supported 1 h),
@@ -66,14 +68,14 @@ lemma zero_not_mem_of_linear_independent (ne : 0 ≠ (1:α)) (hs : linear_indepe
 end
 
 lemma linear_independent_union {s t : set β}
-  (hs : linear_independent s) (ht : linear_independent t)
-  (hst : disjoint (span s) (span t)) : linear_independent (s ∪ t) :=
+  (hs : linear_independent α s) (ht : linear_independent α t)
+  (hst : disjoint (span α s) (span α t)) : linear_independent α (s ∪ t) :=
 begin
   rw [linear_independent, disjoint_def, lc.supported_union],
   intros l h₁ h₂, rw mem_sup at h₁,
   rcases h₁ with ⟨ls, hls, lt, hlt, rfl⟩,
   rw [span_eq_map_lc, span_eq_map_lc] at hst,
-  have : lc.total β ls ∈ map (lc.total β) (lc.supported t),
+  have : lc.total α β ls ∈ map (lc.total α β) (lc.supported α t),
   { apply (add_mem_iff_left (map _ _) (mem_image_of_mem _ hlt)).1,
     rw [← linear_map.map_add, linear_map.mem_ker.1 h₂],
     apply zero_mem },
@@ -84,14 +86,14 @@ begin
 end
 
 lemma linear_independent_of_finite
-  (H : ∀ t ⊆ s, finite t → linear_independent t) :
-  linear_independent s :=
+  (H : ∀ t ⊆ s, finite t → linear_independent α t) :
+  linear_independent α s :=
 linear_independent_iff.2 $ λ l hl,
 linear_independent_iff.1 (H _ hl (finset.finite_to_set _)) l (subset.refl _)
 
 lemma linear_independent_Union_of_directed {ι : Type*}
   {s : ι → set β} (hs : directed (⊆) s)
-  (h : ∀ i, linear_independent (s i)) : linear_independent (⋃ i, s i) :=
+  (h : ∀ i, linear_independent α (s i)) : linear_independent α (⋃ i, s i) :=
 begin
   by_cases hι : nonempty ι,
   { refine linear_independent_of_finite (λ t ht ft, _),
@@ -105,52 +107,52 @@ end
 
 lemma linear_independent_sUnion_of_directed {s : set (set β)}
   (hs : directed_on (⊆) s)
-  (h : ∀ a ∈ s, linear_independent a) : linear_independent (⋃₀ s) :=
+  (h : ∀ a ∈ s, linear_independent α a) : linear_independent α (⋃₀ s) :=
 by rw sUnion_eq_Union; exact
 linear_independent_Union_of_directed
   ((directed_on_iff_directed _).1 hs) (by simpa using h)
 
 lemma linear_independent_bUnion_of_directed {ι} {s : set ι} {t : ι → set β}
-  (hs : directed_on (t ⁻¹'o (⊆)) s) (h : ∀a∈s, linear_independent (t a)) :
-  linear_independent (⋃a∈s, t a) :=
+  (hs : directed_on (t ⁻¹'o (⊆)) s) (h : ∀a∈s, linear_independent α (t a)) :
+  linear_independent α (⋃a∈s, t a) :=
 by rw bUnion_eq_Union; exact
 linear_independent_Union_of_directed
   ((directed_comp _ _ _).2 $ (directed_on_iff_directed _).1 hs)
   (by simpa using h)
 
 section repr
-variables (hs : linear_independent s)
+variables (hs : linear_independent α s)
 
-def linear_independent.total_equiv : lc.supported s ≃ₗ span s :=
-linear_equiv.of_bijective (lc.total_on s)
+def linear_independent.total_equiv : lc.supported α s ≃ₗ span α s :=
+linear_equiv.of_bijective (lc.total_on α s)
   (linear_independent_iff_total_on.1 hs) (lc.total_on_range _)
 
-def linear_independent.repr : span s →ₗ lc α β :=
-(submodule.subtype _).comp (hs.total_equiv.symm : span s →ₗ lc.supported s)
+def linear_independent.repr : span α s →ₗ[α] lc α β :=
+(submodule.subtype _).comp (hs.total_equiv.symm : span α s →ₗ[α] lc.supported α s)
 
-lemma linear_independent.total_repr (x) : lc.total β (hs.repr x) = x :=
+lemma linear_independent.total_repr (x) : lc.total α β (hs.repr x) = x :=
 subtype.ext.1 $ hs.total_equiv.right_inv x
 
-lemma linear_independent.total_comp_repr : (lc.total β).comp hs.repr = submodule.subtype _ :=
+lemma linear_independent.total_comp_repr : (lc.total α β).comp hs.repr = submodule.subtype _ :=
 linear_map.ext $ hs.total_repr
 
 lemma linear_independent.repr_ker : hs.repr.ker = ⊥ :=
 by rw [linear_independent.repr, linear_map.ker_comp, ker_subtype, comap_bot,
        linear_equiv.ker]
 
-lemma linear_independent.repr_range : hs.repr.range = lc.supported s :=
+lemma linear_independent.repr_range : hs.repr.range = lc.supported α s :=
 by rw [linear_independent.repr, linear_map.range_comp,
        linear_equiv.range, map_top, range_subtype]
 
-lemma linear_independent.repr_eq {l : lc α β} (h : l ∈ lc.supported s) {x} (eq : lc.total β l = ↑x) : hs.repr x = l :=
-by rw ← (subtype.eq' eq : (lc.total_on s : lc.supported s →ₗ span s) ⟨l, h⟩ = x);
+lemma linear_independent.repr_eq {l : lc α β} (h : l ∈ lc.supported α s) {x} (eq : lc.total α β l = ↑x) : hs.repr x = l :=
+by rw ← (subtype.eq' eq : (lc.total_on α s : lc.supported α s →ₗ span α s) ⟨l, h⟩ = x);
    exact subtype.ext.1 (hs.total_equiv.left_inv ⟨l, h⟩)
 
 lemma linear_independent.repr_eq_single (x) (hx : ↑x ∈ s) : hs.repr x = finsupp.single x 1 :=
 hs.repr_eq (lc.single_mem_supported _ hx) (by simp)
 
-lemma linear_independent.repr_supported (x) : hs.repr x ∈ lc.supported s :=
-((hs.total_equiv.symm : span s →ₗ lc.supported s) x).2
+lemma linear_independent.repr_supported (x) : hs.repr x ∈ lc.supported α s :=
+((hs.total_equiv.symm : span α s →ₗ[α] lc.supported α s) x).2
 
 lemma linear_independent.repr_eq_repr_of_subset
   (h : t ⊆ s) (x y) (e : (↑x:β) = ↑y) :
@@ -159,11 +161,11 @@ eq.symm $ hs.repr_eq (lc.supported_mono h $ (hs.mono h).repr_supported _)
   (by rw [← e, (hs.mono h).total_repr]).
 
 lemma linear_independent_iff_not_smul_mem_span :
-  linear_independent s ↔ (∀ (x ∈ s) (a : α), a • x ∈ span (s \ {x}) → a = 0) :=
+  linear_independent α s ↔ (∀ (x ∈ s) (a : α), a • x ∈ span α (s \ {x}) → a = 0) :=
 ⟨λ hs x hx a ha, begin
   rw [span_eq_map_lc, mem_map] at ha,
   rcases ha with ⟨l, hl, e⟩,
-  have := (lc.supported s).sub_mem
+  have := (lc.supported α s).sub_mem
     (lc.supported_mono (diff_subset _ _) hl) (lc.single_mem_supported a hx),
   rw [sub_eq_zero.1 (linear_independent_iff.1 hs _ this $ by simp [e])] at hl,
   by_contra hn,
@@ -174,7 +176,7 @@ end, λ H, linear_independent_iff.2 $ λ l ls l0, begin
   have xs : x ∈ s := ls (finsupp.mem_support_iff.2 hn),
   refine hn (H _ xs _ _),
   refine mem_span_iff_lc.2 ⟨finsupp.single x (l x) - l, _, _⟩,
-  { have : finsupp.single x (l x) - l ∈ lc.supported s :=
+  { have : finsupp.single x (l x) - l ∈ lc.supported α s :=
       sub_mem _ (lc.single_mem_supported _ xs) ls,
     refine λ y hy, ⟨this hy, λ e, _⟩,
     simp at e hy, apply hy, simp [e] },
@@ -184,7 +186,7 @@ end⟩
 end repr
 
 lemma eq_of_linear_independent_of_span (nz : (1 : α) ≠ 0)
-  (hs : linear_independent s) (h : t ⊆ s) (hst : s ⊆ span t) : s = t :=
+  (hs : linear_independent α s) (h : t ⊆ s) (hst : s ⊆ span α t) : s = t :=
 begin
   refine subset.antisymm (λ b hb, _) h,
   have : (hs.mono h).repr ⟨b, hst hb⟩ = finsupp.single b 1 :=
@@ -195,14 +197,14 @@ begin
 end
 
 section
-variables {f : β →ₗ γ}
-  (hs : linear_independent (f '' s))
+variables {f : β →ₗ[α] γ}
+  (hs : linear_independent α (f '' s))
   (hf_inj : ∀ a b ∈ s, f a = f b → a = b)
 include hs hf_inj
 open linear_map
 
 lemma linear_independent.supported_disjoint_ker :
-  disjoint (lc.supported s) (ker (f.comp (lc.total β))) :=
+  disjoint (lc.supported α s) (ker (f.comp (lc.total α β))) :=
 begin
   refine le_trans (le_inf inf_le_left _) (lc.map_disjoint_ker f hf_inj),
   rw [linear_independent, disjoint_iff, ← lc.map_supported f] at hs,
@@ -211,23 +213,23 @@ begin
   rw [map_le_iff_le_comap, ← ker_comp], exact inf_le_right
 end
 
-lemma linear_independent.of_image : linear_independent s :=
+lemma linear_independent.of_image : linear_independent α s :=
 disjoint_mono_right (ker_le_ker_comp _ _) (hs.supported_disjoint_ker hf_inj)
 
-lemma linear_independent.disjoint_ker : disjoint (span s) f.ker :=
+lemma linear_independent.disjoint_ker : disjoint (span α s) f.ker :=
 by rw [span_eq_map_lc, disjoint_iff, map_inf_eq_map_inf_comap,
   ← ker_comp, disjoint_iff.1 (hs.supported_disjoint_ker hf_inj), map_bot]
 
 end
 
-lemma linear_independent.inj_span_iff_inj {s : set β} {f : β →ₗ γ}
-  (hfs : linear_independent (f '' s)) :
-  disjoint (span s) f.ker ↔ (∀a b ∈ s, f a = f b → a = b) :=
+lemma linear_independent.inj_span_iff_inj {s : set β} {f : β →ₗ[α] γ}
+  (hfs : linear_independent α (f '' s)) :
+  disjoint (span α s) f.ker ↔ (∀a b ∈ s, f a = f b → a = b) :=
 ⟨linear_map.inj_of_disjoint_ker subset_span, hfs.disjoint_ker⟩
 
 open linear_map
-lemma linear_independent.image {s : set β} {f : β →ₗ γ} (hs : linear_independent s)
-  (hf_inj : disjoint (span s) f.ker) : linear_independent (f '' s) :=
+lemma linear_independent.image {s : set β} {f : β →ₗ γ} (hs : linear_independent α s)
+  (hf_inj : disjoint (span α s) f.ker) : linear_independent α (f '' s) :=
 by rw [disjoint, span_eq_map_lc, map_inf_eq_map_inf_comap,
     map_le_iff_le_comap, comap_bot] at hf_inj;
   rw [linear_independent, disjoint, ← lc.map_supported f, map_inf_eq_map_inf_comap,
@@ -235,42 +237,44 @@ by rw [disjoint, span_eq_map_lc, map_inf_eq_map_inf_comap,
   exact le_trans (le_inf inf_le_left hf_inj) (le_trans hs bot_le)
 
 lemma linear_map.linear_independent_image_iff {s : set β} {f : β →ₗ γ}
-  (hf_inj : disjoint (span s) f.ker) :
-  linear_independent (f '' s) ↔ linear_independent s :=
+  (hf_inj : disjoint (span α s) f.ker) :
+  linear_independent α (f '' s) ↔ linear_independent α s :=
 ⟨λ hs, hs.of_image (linear_map.inj_of_disjoint_ker subset_span hf_inj),
  λ hs, hs.image hf_inj⟩
 
 lemma linear_independent_inl_union_inr {s : set β} {t : set γ}
-  (hs : linear_independent s) (ht : linear_independent t) :
-  linear_independent (inl β γ '' s ∪ inr β γ '' t) :=
+  (hs : linear_independent α s) (ht : linear_independent α t) :
+  linear_independent α (inl α β γ '' s ∪ inr α β γ '' t) :=
 linear_independent_union (hs.image $ by simp) (ht.image $ by simp) $
 by rw [span_image, span_image]; simp [disjoint_iff, prod_inf_prod]
 
-/-- A set of vectors is a basis if it is linearly independent and all vectors are in the span -/
-def is_basis (s : set β) := linear_independent s ∧ span s = ⊤
+variables (α)
+/-- A set of vectors is a basis if it is linearly independent and all vectors are in the span α -/
+def is_basis (s : set β) := linear_independent α s ∧ span α s = ⊤
+variables {α}
 
 section is_basis
-variables (hs : is_basis s)
+variables (hs : is_basis α s)
 
-lemma is_basis.mem_span (hs : is_basis s) : ∀ x, x ∈ span s := eq_top_iff'.1 hs.2
+lemma is_basis.mem_span (hs : is_basis α s) : ∀ x, x ∈ span α s := eq_top_iff'.1 hs.2
 
 def is_basis.repr : β →ₗ lc α β :=
 (hs.1.repr).comp (linear_map.id.cod_restrict _ hs.mem_span)
 
-lemma is_basis.total_repr (x) : lc.total β (hs.repr x) = x :=
+lemma is_basis.total_repr (x) : lc.total α β (hs.repr x) = x :=
 hs.1.total_repr ⟨x, _⟩
 
-lemma is_basis.total_comp_repr : (lc.total β).comp hs.repr = linear_map.id :=
+lemma is_basis.total_comp_repr : (lc.total α β).comp hs.repr = linear_map.id :=
 linear_map.ext hs.total_repr
 
 lemma is_basis.repr_ker : hs.repr.ker = ⊥ :=
 linear_map.ker_eq_bot.2 $ injective_of_left_inverse hs.total_repr
 
-lemma is_basis.repr_range : hs.repr.range = lc.supported s :=
+lemma is_basis.repr_range : hs.repr.range = lc.supported α s :=
 by  rw [is_basis.repr, linear_map.range, submodule.map_comp,
   linear_map.map_cod_restrict, submodule.map_id, comap_top, map_top, hs.1.repr_range]
 
-lemma is_basis.repr_supported (x) : hs.repr x ∈ lc.supported s :=
+lemma is_basis.repr_supported (x) : hs.repr x ∈ lc.supported α s :=
 hs.1.repr_supported ⟨x, _⟩
 
 lemma is_basis.repr_eq_single {x} : x ∈ s → hs.repr x = finsupp.single x 1 :=
@@ -278,93 +282,93 @@ hs.1.repr_eq_single ⟨x, _⟩
 
 /-- Construct a linear map given the value at the basis. -/
 def is_basis.constr (f : β → γ) : β →ₗ γ :=
-(lc.total γ).comp $ (lc.map f).comp hs.repr
+(lc.total α γ).comp $ (lc.map α f).comp hs.repr
 
 theorem is_basis.constr_apply (f : β → γ) (x : β) :
   (hs.constr f : β → γ) x = (hs.repr x).sum (λb a, a • f b) :=
 by dsimp [is_basis.constr];
    rw [lc.total_apply, finsupp.sum_map_domain_index]; simp [add_smul]
 
-lemma is_basis.ext {f g : β →ₗ γ} (hs : is_basis s) (h : ∀x∈s, f x = g x) : f = g :=
+lemma is_basis.ext {f g : β →ₗ[α] γ} (hs : is_basis α s) (h : ∀x∈s, f x = g x) : f = g :=
 linear_map.ext $ λ x, linear_eq_on h (hs.mem_span x)
 
-lemma constr_congr {f g : β → γ} {x : β} (hs : is_basis s) (h : ∀x∈s, f x = g x) :
+lemma constr_congr {f g : β → γ} {x : β} (hs : is_basis α s) (h : ∀x∈s, f x = g x) :
   hs.constr f = hs.constr g :=
 by ext y; simp [is_basis.constr_apply]; exact
 finset.sum_congr rfl (λ x hx, by simp [h x (hs.repr_supported _ hx)])
 
-lemma constr_basis {f : β → γ} {b : β} (hs : is_basis s) (hb : b ∈ s) :
+lemma constr_basis {f : β → γ} {b : β} (hs : is_basis α s) (hb : b ∈ s) :
   (hs.constr f : β → γ) b = f b :=
 by simp [is_basis.constr_apply, hs.repr_eq_single hb, finsupp.sum_single_index]
 
-lemma constr_eq {g : β → γ} {f : β →ₗ γ} (hs : is_basis s)
+lemma constr_eq {g : β → γ} {f : β →ₗ[α] γ} (hs : is_basis α s)
   (h : ∀x∈s, g x = f x) : hs.constr g = f :=
 hs.ext $ λ x hx, (constr_basis hs hx).trans (h _ hx)
 
-lemma constr_self (f : β →ₗ γ) : hs.constr f = f :=
+lemma constr_self (f : β →ₗ[α] γ) : hs.constr f = f :=
 constr_eq hs $ λ x hx, rfl
 
-lemma constr_zero (hs : is_basis s) : hs.constr (λb, (0 : γ)) = 0 :=
+lemma constr_zero (hs : is_basis α s) : hs.constr (λb, (0 : γ)) = 0 :=
 constr_eq hs $ λ x hx, rfl
 
-lemma constr_add {g f : β → γ} (hs : is_basis s) :
+lemma constr_add {g f : β → γ} (hs : is_basis α s) :
   hs.constr (λb, f b + g b) = hs.constr f + hs.constr g :=
 constr_eq hs $ by simp [constr_basis hs] {contextual := tt}
 
-lemma constr_neg {f : β → γ} (hs : is_basis s) : hs.constr (λb, - f b) = - hs.constr f :=
+lemma constr_neg {f : β → γ} (hs : is_basis α s) : hs.constr (λb, - f b) = - hs.constr f :=
 constr_eq hs $ by simp [constr_basis hs] {contextual := tt}
 
-lemma constr_sub {g f : β → γ} (hs : is_basis s) :
+lemma constr_sub {g f : β → γ} (hs : is_basis α s) :
   hs.constr (λb, f b - g b) = hs.constr f - hs.constr g :=
 by simp [constr_add, constr_neg]
 
 -- this only works on functions if `α` is a commutative ring
 lemma constr_smul {α β γ} [comm_ring α]
   [add_comm_group β] [add_comm_group γ] [module α β] [module α γ]
-  {f : β → γ} {a : α} {s : set β} (hs : is_basis s) {b : β} :
+  {f : β → γ} {a : α} {s : set β} (hs : is_basis α s) {b : β} :
   hs.constr (λb, a • f b) = a • hs.constr f :=
 constr_eq hs $ by simp [constr_basis hs] {contextual := tt}
 
-lemma constr_range (hs : is_basis s) {f : β → γ} : (hs.constr f).range = span (f '' s) :=
+lemma constr_range (hs : is_basis α s) {f : β → γ} : (hs.constr f).range = span α (f '' s) :=
 by rw [is_basis.constr, linear_map.range_comp, linear_map.range_comp,
        is_basis.repr_range, lc.map_supported, span_eq_map_lc]
 
-def module_equiv_lc (hs : is_basis s) : β ≃ₗ lc.supported s :=
+def module_equiv_lc (hs : is_basis α s) : β ≃ₗ lc.supported α s :=
 (hs.1.total_equiv.trans (linear_equiv.of_top _ hs.2)).symm
 
 def equiv_of_is_basis {s : set β} {t : set γ} {f : β → γ} {g : γ → β}
-  (hs : is_basis s) (ht : is_basis t) (hf : ∀b∈s, f b ∈ t) (hg : ∀c∈t, g c ∈ s)
+  (hs : is_basis α s) (ht : is_basis α t) (hf : ∀b∈s, f b ∈ t) (hg : ∀c∈t, g c ∈ s)
   (hgf : ∀b∈s, g (f b) = b) (hfg : ∀c∈t, f (g c) = c) :
   β ≃ₗ γ :=
 { inv_fun := ht.constr g,
   left_inv :=
     have (ht.constr g).comp (hs.constr f) = linear_map.id,
     from hs.ext $ by simp [constr_basis, hs, ht, hf, hgf, (∘)] {contextual := tt},
-    λ x, congr_arg (λ h:β →ₗ β, h x) this,
+    λ x, congr_arg (λ h:β →ₗ[α] β, h x) this,
   right_inv :=
     have (hs.constr f).comp (ht.constr g) = linear_map.id,
     from ht.ext $ by simp [constr_basis, hs, ht, hg, hfg, (∘)] {contextual := tt},
-    λ y, congr_arg (λ h:γ →ₗ γ, h y) this,
+    λ y, congr_arg (λ h:γ →ₗ[α] γ, h y) this,
   ..hs.constr f }
 
 lemma is_basis_inl_union_inr {s : set β} {t : set γ}
-  (hs : is_basis s) (ht : is_basis t) : is_basis (inl β γ '' s ∪ inr β γ '' t) :=
+  (hs : is_basis α s) (ht : is_basis α t) : is_basis α (inl α β γ '' s ∪ inr α β γ '' t) :=
 ⟨linear_independent_inl_union_inr hs.1 ht.1,
   by rw [span_union, span_image, span_image]; simp [hs.2, ht.2]⟩
 
 end is_basis
 
-lemma linear_equiv.is_basis {s : set β} (hs : is_basis s)
-  (f : β ≃ₗ γ) : is_basis (f '' s) :=
-show is_basis ((f : β →ₗ γ) '' s), from
+lemma linear_equiv.is_basis {s : set β} (hs : is_basis α s)
+  (f : β ≃ₗ[α] γ) : is_basis α (f '' s) :=
+show is_basis α ((f : β →ₗ[α] γ) '' s), from
 ⟨hs.1.image $ by simp, by rw [span_image, hs.2, map_top, f.range]⟩
 
-lemma is_basis_injective {s : set γ} {f : β →ₗ γ}
-  (hs : linear_independent s) (h : function.injective f) (hfs : span s = f.range) :
-  is_basis (f ⁻¹' s) :=
+lemma is_basis_injective {s : set γ} {f : β →ₗ[α] γ}
+  (hs : linear_independent α s) (h : function.injective f) (hfs : span α s = f.range) :
+  is_basis α (f ⁻¹' s) :=
 have s_eq : f '' (f ⁻¹' s) = s :=
   image_preimage_eq_of_subset $ by rw [← linear_map.range_coe, ← hfs]; exact subset_span,
-have linear_independent (f '' (f ⁻¹' s)), from hs.mono (image_preimage_subset _ _),
+have linear_independent α (f '' (f ⁻¹' s)), from hs.mono (image_preimage_subset _ _),
 begin
   split,
   exact (this.of_image $ assume a ha b hb eq, h eq),
@@ -373,13 +377,13 @@ begin
   exact le_refl _
 end
 
-lemma is_basis_span {s : set β} (hs : linear_independent s) : is_basis ((span s).subtype ⁻¹' s) :=
+lemma is_basis_span {s : set β} (hs : linear_independent α s) : is_basis α ((span α s).subtype ⁻¹' s) :=
 is_basis_injective hs subtype.val_injective (range_subtype _).symm
 
-lemma is_basis_empty (h : ∀x:β, x = 0) : is_basis (∅ : set β) :=
+lemma is_basis_empty (h : ∀x:β, x = 0) : is_basis α (∅ : set β) :=
 ⟨linear_independent_empty, eq_top_iff'.2 $ assume x, (h x).symm ▸ submodule.zero_mem _⟩
 
-lemma is_basis_empty_bot : is_basis ({x | false } : set (⊥ : submodule α β)) :=
+lemma is_basis_empty_bot : is_basis α ({x | false } : set (⊥ : submodule α β)) :=
 is_basis_empty $ assume ⟨x, hx⟩,
   by change x ∈ (⊥ : submodule α β) at hx; simpa [subtype.ext] using hx
 
@@ -394,7 +398,7 @@ open submodule
 /- TODO: some of the following proofs can generalized with a zero_ne_one predicate type class
    (instead of a data containing type classs) -/
 
-lemma mem_span_insert_exchange : x ∈ span (insert y s) → x ∉ span s → y ∈ span (insert x s) :=
+lemma mem_span_insert_exchange : x ∈ span α (insert y s) → x ∉ span α s → y ∈ span α (insert x s) :=
 begin
   simp [mem_span_insert],
   rintro a z hz rfl h,
@@ -403,17 +407,17 @@ begin
   simp [a0, smul_add, smul_smul]
 end
 
-lemma linear_independent_iff_not_mem_span : linear_independent s ↔ (∀x∈s, x ∉ span (s \ {x})) :=
+lemma linear_independent_iff_not_mem_span : linear_independent α s ↔ (∀x∈s, x ∉ span α (s \ {x})) :=
 linear_independent_iff_not_smul_mem_span.trans
 ⟨λ H x xs hx, one_ne_zero (H x xs 1 $ by simpa),
  λ H x xs a hx, classical.by_contradiction $ λ a0,
    H x xs ((smul_mem_iff _ a0).1 hx)⟩
 
-lemma linear_independent_singleton {x : β} (hx : x ≠ 0) : linear_independent ({x} : set β) :=
+lemma linear_independent_singleton {x : β} (hx : x ≠ 0) : linear_independent α ({x} : set β) :=
 linear_independent_iff_not_mem_span.mpr $ by simp [hx] {contextual := tt}
 
 lemma disjoint_span_singleton {p : submodule α β} {x : β} (x0 : x ≠ 0) :
-  disjoint p (span {x}) ↔ x ∉ p :=
+  disjoint p (span α {x}) ↔ x ∉ p :=
 ⟨λ H xp, x0 (disjoint_def.1 H _ xp (singleton_subset_iff.1 subset_span:_)),
 begin
   simp [disjoint_def, mem_span_singleton],
@@ -422,8 +426,8 @@ begin
   exact xp.elim ((smul_mem_iff p a0).1 yp),
 end⟩
 
-lemma linear_independent.insert (hs : linear_independent s) (hx : x ∉ span s) :
-  linear_independent (insert x s) :=
+lemma linear_independent.insert (hs : linear_independent α s) (hx : x ∉ span α s) :
+  linear_independent α (insert x s) :=
 begin
   rw ← union_singleton,
   have x0 : x ≠ 0 := mt (by rintro rfl; apply zero_mem _) hx,
@@ -431,10 +435,10 @@ begin
     ((disjoint_span_singleton x0).2 hx)
 end
 
-lemma exists_linear_independent (hs : linear_independent s) (hst : s ⊆ t) :
-  ∃b⊆t, s ⊆ b ∧ t ⊆ span b ∧ linear_independent b :=
+lemma exists_linear_independent (hs : linear_independent α s) (hst : s ⊆ t) :
+  ∃b⊆t, s ⊆ b ∧ t ⊆ span α b ∧ linear_independent α b :=
 begin
-  rcases zorn.zorn_subset₀ {b | b ⊆ t ∧ linear_independent b} _ _
+  rcases zorn.zorn_subset₀ {b | b ⊆ t ∧ linear_independent α b} _ _
     ⟨hst, hs⟩ with ⟨b, ⟨bt, bi⟩, sb, h⟩,
   { refine ⟨b, bt, sb, λ x xt, _, bi⟩,
     by_contra hn,
@@ -447,24 +451,24 @@ begin
     { exact subset_sUnion_of_mem } }
 end
 
-lemma exists_subset_is_basis (hs : linear_independent s) : ∃b, s ⊆ b ∧ is_basis b :=
+lemma exists_subset_is_basis (hs : linear_independent α s) : ∃b, s ⊆ b ∧ is_basis α b :=
 let ⟨b, hb₀, hx, hb₂, hb₃⟩ := exists_linear_independent hs (@subset_univ _ _) in
 ⟨b, hx, hb₃, eq_top_iff.2 hb₂⟩
 
-variable (β)
-lemma exists_is_basis : ∃b : set β, is_basis b :=
+variables (α β)
+lemma exists_is_basis : ∃b : set β, is_basis α b :=
 let ⟨b, _, hb⟩ := exists_subset_is_basis linear_independent_empty in ⟨b, hb⟩
-variable {β}
+variables {α β}
 
 -- TODO(Mario): rewrite?
 lemma exists_of_linear_independent_of_finite_span {t : finset β}
-  (hs : linear_independent s) (hst : s ⊆ (span ↑t : submodule α β)) :
+  (hs : linear_independent α s) (hst : s ⊆ (span α ↑t : submodule α β)) :
   ∃t':finset β, ↑t' ⊆ s ∪ ↑t ∧ s ⊆ ↑t' ∧ t'.card = t.card :=
-have ∀t, ∀(s' : finset β), ↑s' ⊆ s → s ∩ ↑t = ∅ → s ⊆ (span ↑(s' ∪ t) : submodule α β) →
+have ∀t, ∀(s' : finset β), ↑s' ⊆ s → s ∩ ↑t = ∅ → s ⊆ (span α ↑(s' ∪ t) : submodule α β) →
   ∃t':finset β, ↑t' ⊆ s ∪ ↑t ∧ s ⊆ ↑t' ∧ t'.card = (s' ∪ t).card :=
 assume t, finset.induction_on t
   (assume s' hs' _ hss',
-    have s = ↑s', from eq_of_linear_independent_of_span one_ne_zero hs hs' $ by simpa using hss',
+    have s = ↑s', from eq_of_linear_independent_of_span (@one_ne_zero α _) hs hs' $ by simpa using hss',
     ⟨s', by simp [this]⟩)
   (assume b₁ t hb₁t ih s' hs' hst hss',
     have hb₁s : b₁ ∉ s,
@@ -476,23 +480,23 @@ assume t, finset.induction_on t
       from eq_empty_of_subset_empty $ subset.trans
         (by simp [inter_subset_inter, subset.refl]) (le_of_eq hst),
     classical.by_cases
-      (assume : s ⊆ (span ↑(s' ∪ t) : submodule α β),
+      (assume : s ⊆ (span α ↑(s' ∪ t) : submodule α β),
         let ⟨u, hust, hsu, eq⟩ := ih _ hs' hst this in
         have hb₁u : b₁ ∉ u, from assume h, (hust h).elim hb₁s hb₁t,
         ⟨insert b₁ u, by simp [insert_subset_insert hust],
           subset.trans hsu (by simp), by simp [eq, hb₁t, hb₁s', hb₁u]⟩)
-      (assume : ¬ s ⊆ (span ↑(s' ∪ t) : submodule α β),
+      (assume : ¬ s ⊆ (span α ↑(s' ∪ t) : submodule α β),
         let ⟨b₂, hb₂s, hb₂t⟩ := not_subset.mp this in
         have hb₂t' : b₂ ∉ s' ∪ t, from assume h, hb₂t $ subset_span h,
-        have s ⊆ (span ↑(insert b₂ s' ∪ t) : submodule α β), from
+        have s ⊆ (span α ↑(insert b₂ s' ∪ t) : submodule α β), from
           assume b₃ hb₃,
           have ↑(s' ∪ insert b₁ t) ⊆ insert b₁ (insert b₂ ↑(s' ∪ t) : set β),
             by simp [insert_eq, -singleton_union, -union_singleton, union_subset_union, subset.refl, subset_union_right],
-          have hb₃ : b₃ ∈ span (insert b₁ (insert b₂ ↑(s' ∪ t) : set β)),
+          have hb₃ : b₃ ∈ span α (insert b₁ (insert b₂ ↑(s' ∪ t) : set β)),
             from span_mono this (hss' hb₃),
-          have s ⊆ (span (insert b₁ ↑(s' ∪ t)) : submodule α β),
+          have s ⊆ (span α (insert b₁ ↑(s' ∪ t)) : submodule α β),
             by simpa [insert_eq, -singleton_union, -union_singleton] using hss',
-          have hb₁ : b₁ ∈ span (insert b₂ ↑(s' ∪ t)),
+          have hb₁ : b₁ ∈ span α (insert b₂ ↑(s' ∪ t)),
             from mem_span_insert_exchange (this hb₂s) hb₂t,
           by rw [span_insert_eq_span hb₁] at hb₃; simpa using hb₃,
         let ⟨u, hust, hsu, eq⟩ := ih _ (by simp [insert_subset, hb₂s, hs']) hst this in
@@ -506,18 +510,18 @@ let ⟨u, h₁, h₂, h⟩ := this (t.filter (λx, x ∉ s)) (t.filter (λx, x �
   h₂, by rwa [eq] at h⟩
 
 lemma exists_finite_card_le_of_finite_of_linear_independent_of_span
-  (ht : finite t) (hs : linear_independent s) (hst : s ⊆ span t) :
+  (ht : finite t) (hs : linear_independent α s) (hst : s ⊆ span α t) :
   ∃h : finite s, h.to_finset.card ≤ ht.to_finset.card :=
-have s ⊆ (span ↑(ht.to_finset) : submodule α β), by simp; assumption,
+have s ⊆ (span α ↑(ht.to_finset) : submodule α β), by simp; assumption,
 let ⟨u, hust, hsu, eq⟩ := exists_of_linear_independent_of_finite_span hs this in
 have finite s, from finite_subset u.finite_to_set hsu,
 ⟨this, by rw [←eq]; exact (finset.card_le_of_subset $ finset.coe_subset.mp $ by simp [hsu])⟩
 
-lemma exists_left_inverse_linear_map_of_injective {f : β →ₗ γ}
+lemma exists_left_inverse_linear_map_of_injective {f : β →ₗ[α] γ}
   (hf_inj : f.ker = ⊥) : ∃g:γ →ₗ β, g.comp f = linear_map.id :=
 begin
-  rcases exists_is_basis β with ⟨B, hB⟩,
-  have : linear_independent (f '' B) :=
+  rcases exists_is_basis α β with ⟨B, hB⟩,
+  have : linear_independent α (f '' B) :=
     hB.1.image (by simp [hf_inj]),
   rcases exists_subset_is_basis this with ⟨C, BC, hC⟩,
   haveI : inhabited β := ⟨0⟩,
@@ -527,19 +531,20 @@ begin
   exact left_inverse_inv_fun (linear_map.ker_eq_bot.1 hf_inj) _
 end
 
-lemma exists_right_inverse_linear_map_of_surjective {f : β →ₗ γ}
+lemma exists_right_inverse_linear_map_of_surjective {f : β →ₗ[α] γ}
   (hf_surj : f.range = ⊤) : ∃g:γ →ₗ β, f.comp g = linear_map.id :=
 begin
-  rcases exists_is_basis γ with ⟨C, hC⟩,
+  rcases exists_is_basis α γ with ⟨C, hC⟩,
   haveI : inhabited β := ⟨0⟩,
   refine ⟨hC.constr (inv_fun f), hC.ext $ λ c cC, _⟩,
   simp [constr_basis hC cC],
   exact right_inverse_inv_fun (linear_map.range_eq_top.1 hf_surj) _
 end
 
+set_option class.instance_max_depth 49
 open submodule linear_map
 theorem quotient_prod_linear_equiv (p : submodule α β) :
-  nonempty ((p.quotient × p) ≃ₗ β) :=
+  nonempty ((p.quotient × p) ≃ₗ[α] β) :=
 begin
   rcases exists_right_inverse_linear_map_of_surjective p.range_mkq with ⟨f, hf⟩,
   have mkf : ∀ x, submodule.quotient.mk (f x) = x := linear_map.ext_iff.1 hf,

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -22,19 +22,19 @@ open submodule lattice function set
 variables (α β)
 def vector_space.dim : cardinal :=
 cardinal.min
-  (nonempty_subtype.2 (exists_is_basis β))
+  (nonempty_subtype.2 (exists_is_basis α β))
   (λ b, cardinal.mk b.1)
 variables {α β}
 open vector_space
 
-theorem is_basis.le_span {I J : set β} (hI : is_basis I) (hJ : span J = ⊤) : cardinal.mk I ≤ cardinal.mk J :=
+theorem is_basis.le_span {I J : set β} (hI : is_basis α I) (hJ : span α J = ⊤) : cardinal.mk I ≤ cardinal.mk J :=
 begin
   cases le_or_lt cardinal.omega (cardinal.mk J) with oJ oJ,
   { refine le_of_not_lt (λ IJ, _),
     let S : J → set β := λ j, ↑(hI.repr j).support,
     have hs : I ⊆ ⋃ j, S j,
     { intros i hi,
-      have : span J ≤ comap hI.repr (lc.supported (⋃ j, S j)) :=
+      have : span α J ≤ comap hI.repr (lc.supported α (⋃ j, S j)) :=
         span_le.2 (λ j hj x hx, ⟨_, ⟨⟨j, hj⟩, rfl⟩, hx⟩),
       rw hJ at this, replace : hI.repr i ∈ _ := this trivial,
       rw hI.repr_eq_single hi at this,
@@ -53,17 +53,17 @@ begin
 end
 
 /-- dimension theorem -/
-theorem mk_eq_mk_of_basis {I J : set β} (hI : is_basis I) (hJ : is_basis J) : cardinal.mk I = cardinal.mk J :=
+theorem mk_eq_mk_of_basis {I J : set β} (hI : is_basis α I) (hJ : is_basis α J) : cardinal.mk I = cardinal.mk J :=
 le_antisymm (hI.le_span hJ.2) (hJ.le_span hI.2)
 
-theorem is_basis.mk_eq_dim {b : set β} (h : is_basis b) : cardinal.mk b = dim α β :=
+theorem is_basis.mk_eq_dim {b : set β} (h : is_basis α b) : cardinal.mk b = dim α β :=
 let ⟨b', e⟩ := show ∃ b', dim α β = _, from cardinal.min_eq _ _ in
 mk_eq_mk_of_basis h (subtype.property _)
 
 variables [add_comm_group γ] [vector_space α γ]
 
-theorem linear_equiv.dim_eq (f : β ≃ₗ γ) : dim α β = dim α γ :=
-let ⟨b, hb⟩ := exists_is_basis β in
+theorem linear_equiv.dim_eq (f : β ≃ₗ[α] γ) : dim α β = dim α γ :=
+let ⟨b, hb⟩ := exists_is_basis α β in
 hb.mk_eq_dim.symm.trans $
   (cardinal.mk_eq_of_injective f.to_equiv.bijective.1).symm.trans $
 (f.is_basis hb).mk_eq_dim
@@ -74,22 +74,24 @@ begin
   exact cardinal.mk_emptyc (⊥ : submodule α β)
 end
 
-lemma dim_span {s : set β} (hs : linear_independent s) : dim α ↥(span s) = cardinal.mk s :=
-have (span s).subtype '' ((span s).subtype ⁻¹' s) = s :=
+set_option class.instance_max_depth 37
+lemma dim_span {s : set β} (hs : linear_independent α s) : dim α ↥(span α s) = cardinal.mk s :=
+have (span α s).subtype '' ((span α s).subtype ⁻¹' s) = s :=
   image_preimage_eq_of_subset $ by rw [← linear_map.range_coe, range_subtype]; exact subset_span,
 begin
   rw [← (is_basis_span hs).mk_eq_dim],
-  calc cardinal.mk ↥(⇑(submodule.subtype (span s)) ⁻¹' s) =
-      cardinal.mk ↥((submodule.subtype (span s)) '' ((submodule.subtype (span s)) ⁻¹' s)) :
+  calc cardinal.mk ↥(⇑(submodule.subtype (span α s)) ⁻¹' s) =
+      cardinal.mk ↥((submodule.subtype (span α s)) '' ((submodule.subtype (span α s)) ⁻¹' s)) :
       (cardinal.mk_eq_of_injective subtype.val_injective).symm
     ... = cardinal.mk ↥s : by rw this
 end
+set_option class.instance_max_depth 32
 
 theorem dim_prod : dim α (β × γ) = dim α β + dim α γ :=
 begin
-  rcases exists_is_basis β with ⟨b, hb⟩,
-  rcases exists_is_basis γ with ⟨c, hc⟩,
-  rw [← @is_basis.mk_eq_dim _ (β × γ) _ _ _ _ (is_basis_inl_union_inr hb hc),
+  rcases exists_is_basis α β with ⟨b, hb⟩,
+  rcases exists_is_basis α γ with ⟨c, hc⟩,
+  rw [← @is_basis.mk_eq_dim α (β × γ) _ _ _ _ (is_basis_inl_union_inr hb hc),
     ← hb.mk_eq_dim, ← hc.mk_eq_dim, cardinal.mk_union_of_disjoint,
     cardinal.mk_eq_of_injective, cardinal.mk_eq_of_injective],
   { exact prod.injective_inr },
@@ -102,10 +104,10 @@ theorem dim_quotient (p : submodule α β) : dim α p.quotient + dim α p = dim 
 let ⟨f⟩ := quotient_prod_linear_equiv p in dim_prod.symm.trans f.dim_eq
 
 /-- rank-nullity theorem -/
-theorem dim_range_add_dim_ker (f : linear_map β γ) : dim α f.range + dim α f.ker = dim α β :=
+theorem dim_range_add_dim_ker (f : β →ₗ[α] γ) : dim α f.range + dim α f.ker = dim α β :=
 by rw [← f.quot_ker_equiv_range.dim_eq, dim_quotient]
 
-lemma dim_range_le (f : β →ₗ γ) : dim α f.range ≤ dim α β :=
+lemma dim_range_le (f : β →ₗ[α] γ) : dim α f.range ≤ dim α β :=
 by rw ← dim_range_add_dim_ker f; exact le_add_right (le_refl _)
 
 lemma dim_map_le (f : β →ₗ γ) (p : submodule α β): dim α (p.map f) ≤ dim α p :=
@@ -114,7 +116,7 @@ begin
   rwa [linear_map.range_comp, range_subtype] at h,
 end
 
-lemma dim_range_of_surjective (f : β →ₗ γ) (h : surjective f) :
+lemma dim_range_of_surjective (f : β →ₗ[α] γ) (h : surjective f) :
   dim α f.range = dim α γ :=
 begin
   refine linear_equiv.dim_eq (linear_equiv.of_bijective (submodule.subtype _) _ _),
@@ -122,21 +124,22 @@ begin
   rwa [range_subtype, linear_map.range_eq_top]
 end
 
-lemma dim_eq_surjective (f : β →ₗ γ) (h : surjective f) : dim α β = dim α γ + dim α f.ker :=
+lemma dim_eq_surjective (f : β →ₗ[α] γ) (h : surjective f) : dim α β = dim α γ + dim α f.ker :=
 by rw [← dim_range_add_dim_ker f, ← dim_range_of_surjective f h]
 
-lemma dim_le_surjective (f : β →ₗ γ) (h : surjective f) : dim α γ ≤ dim α β :=
+lemma dim_le_surjective (f : β →ₗ[α] γ) (h : surjective f) : dim α γ ≤ dim α β :=
 by rw [dim_eq_surjective f h]; refine le_add_right (le_refl _)
 
-lemma dim_eq_injective (f : β →ₗ γ) (h : injective f) : dim α β = dim α f.range :=
+lemma dim_eq_injective (f : β →ₗ[α] γ) (h : injective f) : dim α β = dim α f.range :=
 by rw [← dim_range_add_dim_ker f, linear_map.ker_eq_bot.2 h]; simp [dim_bot]
 
+set_option class.instance_max_depth 37
 lemma dim_submodule_le (s : submodule α β) : dim α s ≤ dim α β :=
 begin
-  rcases exists_is_basis s with ⟨bs, hbs⟩,
-  have : linear_independent (submodule.subtype s '' bs) :=
+  rcases exists_is_basis α s with ⟨bs, hbs⟩,
+  have : linear_independent α (submodule.subtype s '' bs) :=
     hbs.1.image (linear_map.disjoint_ker'.2 $ assume x y _ _ eq, subtype.val_injective eq),
-  have : linear_independent ((coe : s → β) '' bs) := this,
+  have : linear_independent α ((coe : s → β) '' bs) := this,
   rcases exists_subset_is_basis this with ⟨b, hbs_b, hb⟩,
   rw [← is_basis.mk_eq_dim hbs, ← is_basis.mk_eq_dim hb],
   calc cardinal.mk ↥bs = cardinal.mk ((coe : s → β) '' bs) :
@@ -144,14 +147,16 @@ begin
     ... ≤ cardinal.mk ↥b :
       nonempty.intro (embedding_of_subset hbs_b)
 end
+set_option class.instance_max_depth 32
 
-lemma dim_le_injective (f : β →ₗ γ) (h : injective f) : dim α β ≤ dim α γ :=
+lemma dim_le_injective (f : β →ₗ[α] γ) (h : injective f) : dim α β ≤ dim α γ :=
 by rw [dim_eq_injective f h]; exact dim_submodule_le _
 
 lemma dim_le_of_submodule (s t : submodule α β) (h : s ≤ t) : dim α s ≤ dim α t :=
 dim_le_injective (of_le h) $ assume ⟨x, hx⟩ ⟨y, hy⟩ eq,
   subtype.eq $ show x = y, from subtype.ext.1 eq
 
+set_option class.instance_max_depth 37
 lemma dim_add_le_dim_add_dim (s t : submodule α β) :
   dim α (s ⊔ t : submodule α β) ≤ dim α s + dim α t :=
 calc dim α (s ⊔ t : submodule α β) ≤ dim α (s × t) :
@@ -162,15 +167,15 @@ calc dim α (s ⊔ t : submodule α β) ≤ dim α (s × t) :
       ⟨⟨⟨x, hx⟩, ⟨y, hy⟩⟩, subtype.eq $ by simp [eq.symm]; refl⟩)
   ... = dim α s + dim α t : dim_prod
 
-def rank (f : β →ₗ γ) : cardinal := dim α f.range
+def rank (f : β →ₗ[α] γ) : cardinal := dim α f.range
 
-lemma rank_le_domain (f : β →ₗ γ) : rank f ≤ dim α β :=
+lemma rank_le_domain (f : β →ₗ[α] γ) : rank f ≤ dim α β :=
 by rw [← dim_range_add_dim_ker f]; exact le_add_right (le_refl _)
 
-lemma rank_le_range (f : β →ₗ γ) : rank f ≤ dim α γ :=
+lemma rank_le_range (f : β →ₗ[α] γ) : rank f ≤ dim α γ :=
 dim_submodule_le _
 
-lemma rank_add_le (f g : β →ₗ γ) : rank (f + g) ≤ rank f + rank g :=
+lemma rank_add_le (f g : β →ₗ[α] γ) : rank (f + g) ≤ rank f + rank g :=
 calc rank (f + g) ≤ dim α (f.range ⊔ g.range : submodule α γ) :
   begin
     refine dim_le_of_submodule _ _ _,
@@ -182,14 +187,14 @@ calc rank (f + g) ≤ dim α (f.range ⊔ g.range : submodule α γ) :
 
 variables [add_comm_group δ] [vector_space α δ]
 
-lemma rank_comp_le1 (g : β →ₗ γ) (f : γ →ₗ δ) : rank (f.comp g) ≤ rank f :=
+lemma rank_comp_le1 (g : β →ₗ[α] γ) (f : γ →ₗ[α] δ) : rank (f.comp g) ≤ rank f :=
 begin
   refine dim_le_of_submodule _ _ _,
   rw [linear_map.range_comp],
   exact image_subset _ (subset_univ _)
 end
 
-lemma rank_comp_le2 (g : β →ₗ γ) (f : γ →ₗ δ) : rank (f.comp g) ≤ rank g :=
+lemma rank_comp_le2 (g : β →ₗ[α] γ) (f : γ →ₗ δ) : rank (f.comp g) ≤ rank g :=
 by rw [rank, rank, linear_map.range_comp]; exact dim_map_le _ _
 
 end vector_space

--- a/src/linear_algebra/direct_sum_module.lean
+++ b/src/linear_algebra/direct_sum_module.lean
@@ -22,54 +22,54 @@ variables {R ι β}
 
 instance : module R (direct_sum ι β) := dfinsupp.to_module
 
-variables ι β
-def lmk : Π s : finset ι, (Π i : (↑s : set ι), β i.1) →ₗ direct_sum ι β :=
-dfinsupp.lmk β
+variables R ι β
+def lmk : Π s : finset ι, (Π i : (↑s : set ι), β i.1) →ₗ[R] direct_sum ι β :=
+dfinsupp.lmk β R
 
-def lof : Π i : ι, β i →ₗ direct_sum ι β :=
-dfinsupp.lsingle β
-variables {ι β}
+def lof : Π i : ι, β i →ₗ[R] direct_sum ι β :=
+dfinsupp.lsingle β R
+variables {R ι β}
 
-theorem mk_smul (s : finset ι) (c x) : mk β s (c • x) = c • mk β s x :=
-(lmk ι β s).map_smul c x
+theorem mk_smul (s : finset ι) (c : R) (x) : mk β s (c • x) = c • mk β s x :=
+(lmk R ι β s).map_smul c x
 
-theorem of_smul (i : ι) (c x) : of β i (c • x) = c • of β i x :=
-(lof ι β i).map_smul c x
+theorem of_smul (i : ι) (c : R) (x) : of β i (c • x) = c • of β i x :=
+(lof R ι β i).map_smul c x
 
 variables {γ : Type u₁} [add_comm_group γ] [module R γ]
-variables (φ : Π i, β i →ₗ γ)
+variables (φ : Π i, β i →ₗ[R] γ)
 
-variables (ι γ φ)
-def to_module : direct_sum ι β →ₗ γ :=
+variables (R ι γ φ)
+def to_module : direct_sum ι β →ₗ[R] γ :=
 { to_fun := to_group (λ i, φ i),
   add := to_group_add _,
   smul := λ c x, direct_sum.induction_on x
     (by rw [smul_zero, to_group_zero, smul_zero])
     (λ i x, by rw [← of_smul, to_group_of, to_group_of, (φ i).map_smul c x])
     (λ x y ihx ihy, by rw [smul_add, to_group_add, ihx, ihy, to_group_add, smul_add]) }
-variables {ι γ φ}
+variables {R ι γ φ}
 
-@[simp] lemma to_module_lof (i) (x : β i) : to_module ι γ φ (lof ι β i x) = φ i x :=
+@[simp] lemma to_module_lof (i) (x : β i) : to_module R ι γ φ (lof R ι β i x) = φ i x :=
 to_group_of (λ i, φ i) i x
 
-variables (ψ : direct_sum ι β →ₗ γ)
+variables (ψ : direct_sum ι β →ₗ[R] γ)
 
-theorem to_module.unique (f : direct_sum ι β) : ψ f = to_module ι γ (λ i, ψ.comp $ lof ι β i) f :=
+theorem to_module.unique (f : direct_sum ι β) : ψ f = to_module R ι γ (λ i, ψ.comp $ lof R ι β i) f :=
 to_group.unique ψ f
 
-variables {ψ} {ψ' : direct_sum ι β →ₗ γ}
+variables {ψ} {ψ' : direct_sum ι β →ₗ[R] γ}
 
-theorem to_module.ext (H : ∀ i, ψ.comp (lof ι β i) = ψ'.comp (lof ι β i)) (f : direct_sum ι β) :
+theorem to_module.ext (H : ∀ i, ψ.comp (lof R ι β i) = ψ'.comp (lof R ι β i)) (f : direct_sum ι β) :
   ψ f = ψ' f :=
 by rw [to_module.unique ψ, to_module.unique ψ', funext H]
 
 def lset_to_set (S T : set ι) (H : S ⊆ T) :
   direct_sum S (β ∘ subtype.val) →ₗ direct_sum T (β ∘ subtype.val) :=
-to_module _ _ $ λ i, lof T (β ∘ @subtype.val _ T) ⟨i.1, H i.2⟩
+to_module R _ _ $ λ i, lof R T (β ∘ @subtype.val _ T) ⟨i.1, H i.2⟩
 
 protected def lid (M : Type v) [add_comm_group M] [module R M] :
   direct_sum punit (λ _, M) ≃ₗ M :=
 { .. direct_sum.id M,
-  .. to_module punit M (λ i, linear_map.id) }
+  .. to_module R punit M (λ i, linear_map.id) }
 
 end direct_sum

--- a/src/linear_algebra/linear_combination.lean
+++ b/src/linear_algebra/linear_combination.lean
@@ -18,9 +18,8 @@ from the module `β` to the scalar ring `α`. -/
 @[reducible] def lc (α β) [ring α] [add_comm_group β] [module α β] : Type* := β →₀ α
 
 namespace lc
-variables {R:ring α} [add_comm_group β] [add_comm_group γ] [add_comm_group δ]
+variables [ring α] [add_comm_group β] [add_comm_group γ] [add_comm_group δ]
 variables [module α β] [module α γ] [module α δ]
-include R
 open submodule linear_map
 
 instance : add_comm_group (lc α β) := finsupp.add_comm_group
@@ -29,6 +28,7 @@ instance : has_scalar α (lc α β) := finsupp.to_has_scalar
 
 instance : module α (lc α β) := finsupp.to_module β α
 
+variables (α)
 def supported (s : set β) : submodule α (lc α β) :=
 { carrier := {l | ↑l.support ⊆ s},
   zero := by simp,
@@ -36,20 +36,21 @@ def supported (s : set β) : submodule α (lc α β) :=
     (by simpa using set.union_subset h₁ h₂),
   smul := λ a l h, set.subset.trans (finset.coe_subset.2 finsupp.support_smul)
     (by simpa using h) }
+variables {α}
 
 theorem mem_supported {s : set β} {l : lc α β} :
-  l ∈ supported s ↔ ↑l.support ⊆ s := iff.rfl
+  l ∈ supported α s ↔ ↑l.support ⊆ s := iff.rfl
 
 theorem mem_supported' {s : set β} {l : lc α β} :
-  l ∈ supported s ↔ ∀ x ∉ s, l x = 0 :=
+  l ∈ supported α s ↔ ∀ x ∉ s, l x = 0 :=
 by simp [mem_supported, set.subset_def, not_imp_comm]
 
 theorem single_mem_supported {s : set β} (a : α) {b : β} (h : b ∈ s) :
-  finsupp.single b a ∈ supported s :=
+  finsupp.single b a ∈ supported α s :=
 set.subset.trans finsupp.support_single_subset (set.singleton_subset_iff.2 h)
 
 theorem supported_eq_span_single (s : set β) :
-  lc.supported s = span ((λ x, finsupp.single x (1:α)) '' s) :=
+  lc.supported α s = span α ((λ x, finsupp.single x (1:α)) '' s) :=
 begin
   refine (span_eq_of_le _ _ (le_def'.2 $ λ l hl, _)).symm,
   { rintro _ ⟨l, hl, rfl⟩, exact single_mem_supported _ hl },
@@ -59,44 +60,46 @@ begin
     exact smul_mem _ _ (subset_span ⟨_, hl xl, rfl⟩) }
 end
 
-def restrict_dom (s : set β) : lc α β →ₗ supported s :=
+variables (α)
+def restrict_dom (s : set β) : lc α β →ₗ supported α s :=
 linear_map.cod_restrict _
   { to_fun := finsupp.filter (∈ s),
     add := λ l₁ l₂, finsupp.filter_add,
     smul := λ a l, finsupp.filter_smul }
   (λ l, mem_supported'.2 $ λ x, finsupp.filter_apply_neg (∈ s) l)
+variables {α}
 
 @[simp] theorem restrict_dom_apply (s : set β) (l : lc α β) :
-  ↑((restrict_dom s : lc α β →ₗ supported s) l) = finsupp.filter (∈ s) l := rfl
+  ↑((restrict_dom α s : lc α β →ₗ supported α s) l) = finsupp.filter (∈ s) l := rfl
 
 theorem restrict_dom_comp_subtype (s : set β) :
-  (restrict_dom s).comp (submodule.subtype _) = linear_map.id :=
+  (restrict_dom α s).comp (submodule.subtype _) = linear_map.id :=
 by ext l; apply subtype.coe_ext.2; simp; ext a;
    by_cases a ∈ s; simp [h]; exact (mem_supported'.1 l.2 _ h).symm
 
-theorem range_restrict_dom (s : set β) : (restrict_dom s).range = ⊤ :=
+theorem range_restrict_dom (s : set β) : (restrict_dom α s).range = ⊤ :=
 begin
-  have := linear_map.range_comp (submodule.subtype _) (restrict_dom s),
+  have := linear_map.range_comp (submodule.subtype _) (restrict_dom α s),
   rw [restrict_dom_comp_subtype, linear_map.range_id] at this,
   exact eq_top_mono (submodule.map_mono le_top) this.symm
 end
 
 theorem supported_mono {s t : set β} (st : s ⊆ t) :
-  supported s ≤ supported t :=
+  supported α s ≤ supported α t :=
 λ l h, set.subset.trans h st
 
-@[simp] theorem supported_empty : supported (∅ : set β) = ⊥ :=
-eq_bot_iff.2 $ λ l h, submodule.mem_bot.2 $
+@[simp] theorem supported_empty : supported α (∅ : set β) = ⊥ :=
+eq_bot_iff.2 $ λ l h, (submodule.mem_bot α).2 $
 by ext; simp [*, mem_supported'] at *
 
-@[simp] theorem supported_univ : supported (set.univ : set β) = ⊤ :=
+@[simp] theorem supported_univ : supported α (set.univ : set β) = ⊤ :=
 eq_top_iff.2 $ λ l _, set.subset_univ _
 
 theorem supported_Union {ι : Type*} (s : ι → set β) :
-  supported (⋃ i, s i) = ⨆ i, supported (s i) :=
+  supported α (⋃ i, s i) = ⨆ i, supported α (s i) :=
 begin
   refine le_antisymm _ (supr_le $ λ i, supported_mono $ set.subset_Union _ _),
-  suffices : ((submodule.subtype _).comp (restrict_dom (⋃ i, s i))).range ≤ ⨆ i, supported (s i),
+  suffices : ((submodule.subtype _).comp (restrict_dom α (⋃ i, s i))).range ≤ ⨆ i, supported α (s i),
   { rwa [range_comp, range_restrict_dom, map_top, range_subtype] at this },
   rw [range_le_iff_comap, eq_top_iff],
   rintro l ⟨⟩, rw mem_coe,
@@ -104,15 +107,15 @@ begin
   refine λ x a l hl a0, add_mem _ _,
   by_cases (∃ i, x ∈ s i); simp [h],
   cases h with i hi,
-  exact le_supr (λ i, supported (s i)) i (single_mem_supported _ hi)
+  exact le_supr (λ i, supported α (s i)) i (single_mem_supported _ hi)
 end
 
 theorem supported_union (s t : set β) :
-  supported (s ∪ t) = supported s ⊔ supported t :=
+  supported α (s ∪ t) = supported α s ⊔ supported α t :=
 by erw [set.union_eq_Union, supported_Union, supr_bool_eq]; refl
 
 theorem supported_Inter {ι : Type*} (s : ι → set β) :
-  supported (⋂ i, s i) = ⨅ i, supported (s i) :=
+  supported α (⋂ i, s i) = ⨅ i, supported α (s i) :=
 begin
   refine le_antisymm (le_infi $ λ i, supported_mono $ set.Inter_subset _ _) _,
   simp [le_def, infi_coe, set.subset_def],
@@ -125,7 +128,7 @@ def apply (x : β) : lc α β →ₗ α :=
 @[simp] theorem apply_apply (x : β) (l : lc α β) :
   (lc.apply x : lc α β →ₗ α) l = l x := rfl
 
-protected def lsum (f : β → α →ₗ γ) : lc α β →ₗ γ :=
+protected def lsum (f : β → α →ₗ[α] γ) : lc α β →ₗ[α] γ :=
 ⟨λ d, d.sum (λ b, f b),
   assume d₁ d₂, by simp [finsupp.sum_add_index],
   assume a d, by simp [finsupp.sum_smul_index, finsupp.smul_sum,
@@ -135,37 +138,39 @@ protected def lsum (f : β → α →ₗ γ) : lc α β →ₗ γ :=
   (lc.lsum f : lc α β →ₗ γ) l = l.sum (λ b, f b) := rfl
 
 section
-variable (β)
+variables (α β)
 protected def total : lc α β →ₗ β := lc.lsum linear_map.id.smul_right
 end
 
 theorem total_apply (l : lc α β) :
-  lc.total β l = l.sum (λ b a, a • b) := rfl
+  lc.total α β l = l.sum (λ b a, a • b) := rfl
 
 @[simp] theorem total_single (a : α) (x : β) :
-  lc.total β (finsupp.single x a) = a • x :=
+  lc.total α β (finsupp.single x a) = a • x :=
 by simp [total_apply, finsupp.sum_single_index]
 
-@[simp] theorem total_range : (lc.total β).range = ⊤ :=
+@[simp] theorem total_range : (lc.total α β).range = ⊤ :=
 range_eq_top.2 $ λ x, ⟨finsupp.single x 1, by simp⟩
 
-protected def map (f : β → γ) : lc α β →ₗ lc α γ :=
+variables (α)
+protected def map (f : β → γ) : lc α β →ₗ[α] lc α γ :=
 { to_fun := finsupp.map_domain f,
   add := λ l₁ l₂, finsupp.map_domain_add,
   smul := λ a l, finsupp.map_domain_smul _ _ }
+variables {α}
 
 @[simp] theorem map_apply (f : β → γ) (l : lc α β) :
-  (lc.map f : lc α β →ₗ lc α γ) l = finsupp.map_domain f l := rfl
+  (lc.map α f : _ →ₗ _) l = finsupp.map_domain f l := rfl
 
-@[simp] theorem map_id : (lc.map id : lc α β →ₗ lc α β) = linear_map.id :=
+@[simp] theorem map_id : (lc.map α id : lc α β →ₗ[α] lc α β) = linear_map.id :=
 linear_map.ext $ λ l, finsupp.map_domain_id
 
 theorem map_comp (f : β → γ) (g : γ → δ) :
-  lc.map (g ∘ f) = (lc.map g).comp (lc.map f) :=
+  lc.map α (g ∘ f) = (lc.map α g).comp (lc.map α f) :=
 linear_map.ext $ λ l, finsupp.map_domain_comp
 
 theorem supported_comap_map (f : β → γ) (s : set γ) :
-  supported (f ⁻¹' s) ≤ (supported s).comap (lc.map f) :=
+  supported α (f ⁻¹' s) ≤ (supported α s).comap (lc.map α f) :=
 λ l (hl : ↑l.support ⊆ f ⁻¹' s),
 show ↑(finsupp.map_domain f l).support ⊆ s, begin
   rw [← set.image_subset_iff, ← finset.coe_image] at hl,
@@ -173,13 +178,13 @@ show ↑(finsupp.map_domain f l).support ⊆ s, begin
 end
 
 theorem map_supported (f : β → γ) (s : set β) :
-  (supported s).map (lc.map f) = supported (f '' s) :=
+  (supported α s).map (lc.map α f) = supported α (f '' s) :=
 begin
   refine le_antisymm (map_le_iff_le_comap.2 $
     le_trans (supported_mono $ set.subset_preimage_image _ _)
        (supported_comap_map _ _)) _,
   intros l hl, haveI : inhabited β := ⟨0⟩,
-  refine ⟨(lc.map (inv_fun_on f s) : lc α γ →ₗ lc α β) l, λ x hx, _, _⟩,
+  refine ⟨(lc.map α (inv_fun_on f s) : lc α γ →ₗ lc α β) l, λ x hx, _, _⟩,
   { rcases finset.mem_image.1 (finsupp.map_domain_support hx) with ⟨c, hc, rfl⟩,
     exact inv_fun_on_mem (by simpa using hl hc) },
   { rw [← linear_map.comp_apply, ← map_comp],
@@ -189,7 +194,7 @@ end
 
 theorem map_disjoint_ker (f : β → γ) {s : set β}
   (H : ∀ a b ∈ s, f a = f b → a = b) :
-  disjoint (supported s) (lc.map f).ker :=
+  disjoint (supported α s) (lc.map α f).ker :=
 begin
   rintro l ⟨h₁, h₂⟩,
   rw [mem_coe, mem_ker, map_apply, finsupp.map_domain] at h₂,
@@ -203,8 +208,8 @@ begin
   { by_contra h, exact xs (h₁ $ finsupp.mem_support_iff.2 h) }
 end
 
-theorem map_total (f : β →ₗ γ) :
-  (lc.total γ).comp (lc.map f) = f.comp (lc.total β) :=
+theorem map_total (f : β →ₗ[α] γ) :
+  (lc.total α γ).comp (lc.map α f) = f.comp (lc.total α β) :=
 by ext; simp [total_apply, finsupp.sum_map_domain_index, add_smul]
 
 end lc
@@ -223,30 +228,32 @@ variables {a b : α} {s t : set β} {x y : β}
 include α
 open submodule
 
-theorem span_eq_map_lc : span s = (lc.supported s).map (lc.total β) :=
+theorem span_eq_map_lc : span α s = (lc.supported α s).map (lc.total α β) :=
 begin
   apply span_eq_of_le,
   { exact λ x hx, ⟨_, lc.single_mem_supported 1 hx, by simp⟩ },
   { refine map_le_iff_le_comap.2 (λ v hv, _),
-    have : ∀c, v c • c ∈ span s,
+    have : ∀c, v c • c ∈ span α s,
     { intro c, by_cases c ∈ s,
       { exact smul_mem _ _ (subset_span h) },
       { simp [lc.mem_supported'.1 hv _ h] } },
     refine sum_mem _ _, simp [this] }
 end
 
-theorem mem_span_iff_lc : x ∈ span s ↔ ∃ l ∈ lc.supported s, lc.total β l = x :=
+theorem mem_span_iff_lc : x ∈ span α s ↔ ∃ l ∈ lc.supported α s, lc.total α β l = x :=
 by rw span_eq_map_lc; simp
 
-def lc.total_on (s : set β) : lc.supported s →ₗ span s :=
-linear_map.cod_restrict _ ((lc.total _).comp (submodule.subtype _)) $
+variables (α)
+def lc.total_on (s : set β) : lc.supported α s →ₗ span α s :=
+linear_map.cod_restrict _ ((lc.total α _).comp (submodule.subtype _)) $
   λ ⟨l, hl⟩, mem_span_iff_lc.2 ⟨l, hl, rfl⟩
+variables {α}
 
-theorem lc.total_on_range (s : set β) : (lc.total_on s).range = ⊤ :=
+theorem lc.total_on_range (s : set β) : (lc.total_on α s).range = ⊤ :=
 by rw [lc.total_on, linear_map.range, linear_map.map_cod_restrict, ← linear_map.range_le_iff_comap,
   range_subtype, map_top, linear_map.range_comp, range_subtype]; exact le_of_eq span_eq_map_lc
 
-lemma linear_eq_on {f g : β →ₗ γ} (H : ∀x∈s, f x = g x) {x} (h : x ∈ span s) : f x = g x :=
+lemma linear_eq_on {f g : β →ₗ[α] γ} (H : ∀x∈s, f x = g x) {x} (h : x ∈ span α s) : f x = g x :=
 by apply span_induction h H; simp {contextual := tt}
 
 end module

--- a/src/linear_algebra/tensor_product.lean
+++ b/src/linear_algebra/tensor_product.lean
@@ -20,27 +20,29 @@ set_option class.instance_max_depth 100
 
 namespace linear_map
 
+variables (R)
 def mk₂ (f : M → N → P)
   (H1 : ∀ m₁ m₂ n, f (m₁ + m₂) n = f m₁ n + f m₂ n)
-  (H2 : ∀ c m n, f (c • m) n = c • f m n)
+  (H2 : ∀ (c:R) m n, f (c • m) n = c • f m n)
   (H3 : ∀ m n₁ n₂, f m (n₁ + n₂) = f m n₁ + f m n₂)
-  (H4 : ∀ c m n, f m (c • n) = c • f m n) : M →ₗ N →ₗ P :=
+  (H4 : ∀ (c:R) m n, f m (c • n) = c • f m n) : M →ₗ N →ₗ P :=
 ⟨λ m, ⟨f m, H3 m, λ c, H4 c m⟩,
 λ m₁ m₂, linear_map.ext $ H1 m₁ m₂,
 λ c m, linear_map.ext $ H2 c m⟩
+variables {R}
 
 @[simp] theorem mk₂_apply
   (f : M → N → P) {H1 H2 H3 H4} (m : M) (n : N) :
-  (mk₂ f H1 H2 H3 H4 : M →ₗ N →ₗ P) m n = f m n := rfl
+  (mk₂ R f H1 H2 H3 H4 : M →ₗ[R] N →ₗ P) m n = f m n := rfl
 
-variables (f : M →ₗ N →ₗ P)
+variables (f : M →ₗ[R] N →ₗ[R] P)
 
-theorem ext₂ {f g : M →ₗ N →ₗ P}
+theorem ext₂ {f g : M →ₗ[R] N →ₗ[R] P}
   (H : ∀ m n, f m n = g m n) : f = g :=
 linear_map.ext (λ m, linear_map.ext $ λ n, H m n)
 
 def flip : N →ₗ M →ₗ P :=
-mk₂ (λ n m, f m n)
+mk₂ R (λ n m, f m n)
   (λ n₁ n₂ m, (f m).map_add _ _)
   (λ c n m, (f m).map_smul _ _)
   (λ n m₁ m₂, by rw f.map_add; refl)
@@ -48,11 +50,12 @@ mk₂ (λ n m, f m n)
 
 @[simp] theorem flip_apply (m : M) (n : N) : flip f n m = f m n := rfl
 
-theorem flip_inj {f g : M →ₗ N →ₗ P} (H : flip f = flip g) : f = g :=
+variables {R}
+theorem flip_inj {f g : M →ₗ[R] N →ₗ P} (H : flip f = flip g) : f = g :=
 ext₂ $ λ m n, show flip f n m = flip g n m, by rw H
 
 variables (R M N P)
-def lflip : (M →ₗ N →ₗ P) →ₗ N →ₗ M →ₗ P :=
+def lflip : (M →ₗ[R] N →ₗ P) →ₗ[R] N →ₗ M →ₗ P :=
 ⟨flip, λ _ _, rfl, λ _ _, rfl⟩
 variables {R M N P}
 
@@ -64,42 +67,42 @@ theorem map_neg₂ (x y) : f (-x) y = -f x y := (flip f y).map_neg _
 
 theorem map_add₂ (x₁ x₂ y) : f (x₁ + x₂) y = f x₁ y + f x₂ y := (flip f y).map_add _ _
 
-theorem map_smul₂ (r x y) : f (r • x) y = r • f x y := (flip f y).map_smul _ _
+theorem map_smul₂ (r:R) (x y) : f (r • x) y = r • f x y := (flip f y).map_smul _ _
 
-variables (P)
-def lcomp (f : M →ₗ N) : (N →ₗ P) →ₗ M →ₗ P :=
+variables (R P)
+def lcomp (f : M →ₗ[R] N) : (N →ₗ P) →ₗ M →ₗ P :=
 flip $ (flip id).comp f
-variables {P}
+variables {R P}
 
-@[simp] theorem lcomp_apply (f : M →ₗ N) (g : N →ₗ P) (x : M) :
-  lcomp P f g x = g (f x) := rfl
+@[simp] theorem lcomp_apply (f : M →ₗ[R] N) (g : N →ₗ P) (x : M) :
+  lcomp R P f g x = g (f x) := rfl
 
-variables (M N P)
-def llcomp : (N →ₗ P) →ₗ (M →ₗ N) →ₗ M →ₗ P :=
-flip ⟨lcomp P,
+variables (R M N P)
+def llcomp : (N →ₗ[R] P) →ₗ[R] (M →ₗ[R] N) →ₗ M →ₗ P :=
+flip ⟨lcomp R P,
   λ f f', ext₂ $ λ g x, g.map_add _ _,
   λ c f, ext₂ $ λ g x, g.map_smul _ _⟩
-variables {M N P}
+variables {R M N P}
 
 section
-@[simp] theorem llcomp_apply (f : N →ₗ P) (g : M →ₗ N) (x : M) :
-  llcomp M N P f g x = f (g x) := rfl
+@[simp] theorem llcomp_apply (f : N →ₗ[R] P) (g : M →ₗ[R] N) (x : M) :
+  llcomp R M N P f g x = f (g x) := rfl
 end
 
-def compl₂ (g : Q →ₗ N) : M →ₗ Q →ₗ P := (lcomp _ g).comp f
+def compl₂ (g : Q →ₗ N) : M →ₗ Q →ₗ P := (lcomp R _ g).comp f
 
-@[simp] theorem compl₂_apply (g : Q →ₗ N) (m : M) (q : Q) :
+@[simp] theorem compl₂_apply (g : Q →ₗ[R] N) (m : M) (q : Q) :
   f.compl₂ g m q = f m (g q) := rfl
 
 def compr₂ (g : P →ₗ Q) : M →ₗ N →ₗ Q :=
-linear_map.comp (llcomp N P Q g) f
+linear_map.comp (llcomp R N P Q g) f
 
-@[simp] theorem compr₂_apply (g : P →ₗ Q) (m : M) (n : N) :
+@[simp] theorem compr₂_apply (g : P →ₗ[R] Q) (m : M) (n : N) :
   f.compr₂ g m n = g (f m n) := rfl
 
 variables (R M)
 def lsmul : R →ₗ M →ₗ M :=
-mk₂ (•) add_smul (λ _ _ _, eq.symm $ smul_smul _ _ _) smul_add
+mk₂ R (•) add_smul (λ _ _ _, eq.symm $ smul_smul _ _ _ _) smul_add
 (λ r s m, by simp only [smul_smul, smul_eq_mul, mul_comm])
 variables {R M}
 
@@ -113,6 +116,7 @@ namespace tensor_product
 
 section
 open free_abelian_group
+variables (R)
 def relators : set (free_abelian_group (M × N)) :=
 add_group.closure { x : free_abelian_group (M × N) |
   (∃ (m₁ m₂ : M) (n : N), x = of (m₁, n) + of (m₂, n) - of (m₁ + m₂, n)) ∨
@@ -122,17 +126,20 @@ end
 
 namespace relators
 
-instance : normal_add_subgroup (relators M N) :=
+instance : normal_add_subgroup (relators R M N) :=
 by unfold relators; apply normal_add_subgroup_of_add_comm_group
 
 end relators
 
 end tensor_product
 
+variables (R)
 def tensor_product : Type* :=
-quotient_add_group.quotient (tensor_product.relators M N)
+quotient_add_group.quotient (tensor_product.relators R M N)
+variables {R}
 
-local infix ` ⊗ `:100 := tensor_product
+local infix ` ⊗ `:100 := tensor_product _
+local notation M ` ⊗[`:100 R `] ` N:100 := tensor_product R M N
 
 namespace tensor_product
 
@@ -140,33 +147,34 @@ section module
 
 local attribute [instance] quotient_add_group.left_rel normal_add_subgroup.to_is_add_subgroup
 
-instance : add_comm_group (M ⊗ N) := quotient_add_group.add_comm_group _
+instance : add_comm_group (M ⊗[R] N) := quotient_add_group.add_comm_group _
 
 instance quotient.mk.is_add_group_hom :
   is_add_group_hom (quotient.mk : free_abelian_group (M × N) → M ⊗ N) :=
 quotient_add_group.is_add_group_hom _
 
-variables {M N}
+variables (R) {M N}
+def tmul (m : M) (n : N) : M ⊗[R] N := quotient_add_group.mk $ free_abelian_group.of (m, n)
+variables {R}
 
-def tmul (m : M) (n : N) : M ⊗ N := quotient_add_group.mk $ free_abelian_group.of (m, n)
+infix ` ⊗ₜ `:100 := tmul _
+notation x ` ⊗ₜ[`:100 R `] ` y := tmul R x y
 
-infix ` ⊗ₜ `:100 := tmul
-
-lemma add_tmul (m₁ m₂ : M) (n : N) : (m₁ + m₂) ⊗ₜ n = m₁ ⊗ₜ n + m₂ ⊗ₜ n :=
+lemma add_tmul (m₁ m₂ : M) (n : N) : (m₁ + m₂) ⊗ₜ n = m₁ ⊗ₜ n + m₂ ⊗ₜ[R] n :=
 eq.symm $ sub_eq_zero.1 $ eq.symm $ quotient.sound $
   group.in_closure.basic $ or.inl $ ⟨m₁, m₂, n, rfl⟩
 
-lemma tmul_add (m : M) (n₁ n₂ : N) : m ⊗ₜ (n₁ + n₂) = m ⊗ₜ n₁ + m ⊗ₜ n₂ :=
+lemma tmul_add (m : M) (n₁ n₂ : N) : m ⊗ₜ (n₁ + n₂) = m ⊗ₜ n₁ + m ⊗ₜ[R] n₂ :=
 eq.symm $ sub_eq_zero.1 $ eq.symm $ quotient.sound $
   group.in_closure.basic $ or.inr $ or.inl $ ⟨m, n₁, n₂, rfl⟩
 
-lemma smul_tmul (r : R) (m : M) (n : N) : (r • m) ⊗ₜ n = m ⊗ₜ (r • n) :=
+lemma smul_tmul (r : R) (m : M) (n : N) : (r • m) ⊗ₜ n = m ⊗ₜ[R] (r • n) :=
 sub_eq_zero.1 $ eq.symm $ quotient.sound $
   group.in_closure.basic $ or.inr $ or.inr $ ⟨r, m, n, rfl⟩
 
 local attribute [instance] quotient_add_group.is_add_group_hom_quotient_lift
 
-def smul.aux (r : R) : free_abelian_group (M × N) → M ⊗ N :=
+def smul.aux (r : R) : free_abelian_group (M × N) → M ⊗[R] N :=
 free_abelian_group.lift (λ (y : M × N), (r • y.1) ⊗ₜ y.2)
 
 instance (r : R) : is_add_group_hom (smul.aux r : _ → M ⊗ N) :=
@@ -183,10 +191,10 @@ instance : has_scalar R (M ⊗ N) :=
     free_abelian_group.lift.add, free_abelian_group.lift.sub]
 end⟩
 
-instance smul.is_add_group_hom (r : R) : is_add_group_hom ((•) r : M ⊗ N → M ⊗ N) :=
+instance smul.is_add_group_hom (r : R) : is_add_group_hom ((•) r : M ⊗[R] N → M ⊗[R] N) :=
 by unfold has_scalar.smul; apply_instance
 
-protected theorem smul_add (r : R) (x y : M ⊗ N) :
+protected theorem smul_add (r : R) (x y : M ⊗[R] N) :
   r • (x + y) = r • x + r • y :=
 is_add_group_hom.add _ _ _
 
@@ -220,20 +228,20 @@ instance : module R (M ⊗ N) := module.of_core
     eq.symm $ free_abelian_group.lift.unique _ _ $ λ ⟨p, q⟩,
     by rw one_smul; refl }
 
-@[simp] lemma tmul_smul (r : R) (x : M) (y : N) : x ⊗ₜ (r • y) = r • (x ⊗ₜ y) :=
+@[simp] lemma tmul_smul (r : R) (x : M) (y : N) : x ⊗ₜ (r • y) = r • (x ⊗ₜ[R] y) :=
 (smul_tmul _ _ _).symm
 
 variables (R M N)
 def mk : M →ₗ N →ₗ M ⊗ N :=
-linear_map.mk₂ (⊗ₜ) add_tmul (λ c m n, by rw [smul_tmul, tmul_smul]) tmul_add tmul_smul
+linear_map.mk₂ R (⊗ₜ) add_tmul (λ c m n, by rw [smul_tmul, tmul_smul]) tmul_add tmul_smul
 variables {R M N}
 
 @[simp] lemma mk_apply (m : M) (n : N) : mk R M N m n = m ⊗ₜ n := rfl
 
-lemma zero_tmul (n : N) : (0 ⊗ₜ n : M ⊗ N) = 0 := (mk R M N).map_zero₂ _
-lemma tmul_zero (m : M) : (m ⊗ₜ 0 : M ⊗ N) = 0 := (mk R M N _).map_zero
-lemma neg_tmul (m : M) (n : N) : (-m) ⊗ₜ n = -(m ⊗ₜ n) := (mk R M N).map_neg₂ _ _
-lemma tmul_neg (m : M) (n : N) : m ⊗ₜ (-n) = -(m ⊗ₜ n) := (mk R M N _).map_neg _
+lemma zero_tmul (n : N) : (0 ⊗ₜ[R] n : M ⊗ N) = 0 := (mk R M N).map_zero₂ _
+lemma tmul_zero (m : M) : (m ⊗ₜ[R] 0 : M ⊗ N) = 0 := (mk R M N _).map_zero
+lemma neg_tmul (m : M) (n : N) : (-m) ⊗ₜ n = -(m ⊗ₜ[R] n) := (mk R M N).map_neg₂ _ _
+lemma tmul_neg (m : M) (n : N) : m ⊗ₜ (-n) = -(m ⊗ₜ[R] n) := (mk R M N _).map_neg _
 
 end module
 
@@ -241,10 +249,10 @@ local attribute [instance] quotient_add_group.left_rel normal_add_subgroup.to_is
 
 @[elab_as_eliminator]
 protected theorem induction_on
-  {C : M ⊗ N → Prop}
-  (z : M ⊗ N)
+  {C : (M ⊗[R] N) → Prop}
+  (z : M ⊗[R] N)
   (C0 : C 0)
-  (C1 : ∀ x y, C $ x ⊗ₜ y)
+  (C1 : ∀ x y, C $ x ⊗ₜ[R] y)
   (Cp : ∀ x y, C x → C y → C (x + y)) : C z :=
 quotient.induction_on z $ λ x, free_abelian_group.induction_on x
   C0 (λ ⟨p, q⟩, C1 p q)
@@ -254,11 +262,11 @@ quotient.induction_on z $ λ x, free_abelian_group.induction_on x
 section UMP
 
 variables {M N P Q}
-variables (f : M →ₗ N →ₗ P)
+variables (f : M →ₗ[R] N →ₗ[R] P)
 
 local attribute [instance] free_abelian_group.lift.is_add_group_hom
 
-def lift_aux : M ⊗ N → P :=
+def lift_aux : (M ⊗[R] N) → P :=
 quotient_add_group.lift _
   (free_abelian_group.lift $ λ z, f z.1 z.2) $ λ x hx,
 begin
@@ -274,7 +282,7 @@ local attribute [instance] quotient_add_group.left_rel normal_add_subgroup.to_is
 @[simp] lemma lift_aux.add (x y) : lift_aux f (x + y) = lift_aux f x + lift_aux f y :=
 quotient.induction_on₂ x y $ λ m n, free_abelian_group.lift.add _ _ _
 
-@[simp] lemma lift_aux.smul (r x) : lift_aux f (r • x) = r • lift_aux f x :=
+@[simp] lemma lift_aux.smul (r:R) (x) : lift_aux f (r • x) = r • lift_aux f x :=
 tensor_product.induction_on _ _ x (smul_zero _).symm
   (λ p q, by rw [← tmul_smul]; simp [lift_aux, tmul])
   (λ p q ih1 ih2, by simp [@smul_add _ _ _ _ _ _ p _,
@@ -293,7 +301,7 @@ zero_add _
 @[simp] lemma lift.tmul' (x y) : (lift f).1 (x ⊗ₜ y) = f x y :=
 lift.tmul _ _
 
-theorem lift.unique {g : linear_map (M ⊗ N) P} (H : ∀ x y, g (x ⊗ₜ y) = f x y) :
+theorem lift.unique {g : (M ⊗[R] N) →ₗ[R] P} (H : ∀ x y, g (x ⊗ₜ y) = f x y) :
   g = lift f :=
 linear_map.ext $ λ z, begin
   apply quotient_add_group.induction_on' z,
@@ -312,7 +320,7 @@ eq.symm $ lift.unique $ λ x y, by simp
 theorem lift_mk_compr₂ (f : M ⊗ N →ₗ P) : lift ((mk R M N).compr₂ f) = f :=
 by rw [lift_compr₂, lift_mk, linear_map.comp_id]
 
-theorem ext {g h : M ⊗ N →ₗ P}
+theorem ext {g h : (M ⊗[R] N) →ₗ[R] P}
   (H : ∀ x y, g (x ⊗ₜ y) = h (x ⊗ₜ y)) : g = h :=
 by rw ← lift_mk_compr₂ h; exact lift.unique H
 
@@ -323,32 +331,32 @@ by rw [← lift_mk_compr₂ g, H, lift_mk_compr₂]
 example : M → N → (M → N → P) → P :=
 λ m, flip $ λ f, f m
 
-variables (M N P)
-def uncurry : (M →ₗ N →ₗ P) →ₗ M ⊗ N →ₗ P :=
+variables (R M N P)
+def uncurry : (M →ₗ N →ₗ[R] P) →ₗ M ⊗ N →ₗ P :=
 linear_map.flip $ lift $ (linear_map.lflip _ _ _ _).comp linear_map.id.flip
-variables {M N P}
+variables {R M N P}
 
-@[simp] theorem uncurry_apply (f : M →ₗ N →ₗ P) (m : M) (n : N) :
-  uncurry M N P f (m ⊗ₜ n) = f m n :=
+@[simp] theorem uncurry_apply (f : M →ₗ[R] N →ₗ[R] P) (m : M) (n : N) :
+  uncurry R M N P f (m ⊗ₜ n) = f m n :=
 by rw [uncurry, linear_map.flip_apply, lift.tmul]; refl
 
-variables (M N P)
+variables (R M N P)
 def lift.equiv : (M →ₗ N →ₗ P) ≃ₗ (M ⊗ N →ₗ P) :=
 { inv_fun := λ f, (mk R M N).compr₂ f,
   left_inv := λ f, linear_map.ext₂ $ λ m n, lift.tmul _ _,
   right_inv := λ f, ext $ λ m n, lift.tmul _ _,
-  .. uncurry M N P }
+  .. uncurry R M N P }
 
-def lcurry : (M ⊗ N →ₗ P) →ₗ M →ₗ N →ₗ P :=
-(lift.equiv M N P).symm
-variables {M N P}
+def lcurry : (M ⊗[R] N →ₗ[R] P) →ₗ[R] M →ₗ[R] N →ₗ[R] P :=
+(lift.equiv R M N P).symm
+variables {R M N P}
 
-@[simp] theorem lcurry_apply (f : M ⊗ N →ₗ P) (m : M) (n : N) :
-  lcurry M N P f m n = f (m ⊗ₜ n) := rfl
+@[simp] theorem lcurry_apply (f : M ⊗[R] N →ₗ[R] P) (m : M) (n : N) :
+  lcurry R M N P f m n = f (m ⊗ₜ n) := rfl
 
-def curry (f : M ⊗ N →ₗ P) : M →ₗ N →ₗ P := lcurry M N P f
+def curry (f : M ⊗ N →ₗ P) : M →ₗ N →ₗ P := lcurry R M N P f
 
-@[simp] theorem curry_apply (f : M ⊗ N →ₗ P) (m : M) (n : N) :
+@[simp] theorem curry_apply (f : M ⊗ N →ₗ[R] P) (m : M) (n : N) :
   curry f m n = f (m ⊗ₜ n) := rfl
 
 end UMP
@@ -365,11 +373,11 @@ linear_equiv.of_linear (lift (mk R N M).flip) (lift (mk R M N).flip)
   (ext $ λ m n, rfl)
 
 open linear_map
-protected def assoc : (M ⊗ N) ⊗ P ≃ₗ M ⊗ (N ⊗ P) :=
+protected def assoc : (M ⊗[R] N) ⊗[R] P ≃ₗ[R] M ⊗[R] (N ⊗[R] P) :=
 begin
   refine linear_equiv.of_linear
-    (lift $ lift $ comp (lcurry _ _ _) $ mk _ _ _)
-    (lift $ comp (uncurry _ _ _) $ curry $ mk _ _ _)
+    (lift $ lift $ comp (lcurry R _ _ _) $ mk _ _ _)
+    (lift $ comp (uncurry R _ _ _) $ curry $ mk _ _ _)
     (mk_compr₂_inj $ linear_map.ext $ λ m, ext $ λ n p, _)
     (mk_compr₂_inj $ flip_inj $ linear_map.ext $ λ p, ext $ λ m n, _);
   repeat { rw lift.tmul <|> rw compr₂_apply <|> rw comp_apply <|>
@@ -377,14 +385,14 @@ begin
     rw uncurry_apply <|> rw curry_apply <|> rw id_apply }
 end
 
-def map (f : M →ₗ P) (g : N →ₗ Q) : M ⊗ N →ₗ P ⊗ Q :=
+def map (f : M →ₗ[R] P) (g : N →ₗ Q) : M ⊗ N →ₗ P ⊗ Q :=
 lift $ comp (compl₂ (mk _ _ _) g) f
 
-@[simp] theorem map_tmul (f : M →ₗ P) (g : N →ₗ Q) (m : M) (n : N) :
+@[simp] theorem map_tmul (f : M →ₗ[R] P) (g : N →ₗ[R] Q) (m : M) (n : N) :
   map f g (m ⊗ₜ n) = f m ⊗ₜ g n :=
 rfl
 
-def congr (f : M ≃ₗ P) (g : N ≃ₗ Q) : M ⊗ N ≃ₗ P ⊗ Q :=
+def congr (f : M ≃ₗ[R] P) (g : N ≃ₗ[R] Q) : M ⊗ N ≃ₗ[R] P ⊗ Q :=
 linear_equiv.of_linear (map f g) (map f.symm g.symm)
   (ext $ λ m n, by simp; simp only [linear_equiv.apply_symm_apply])
   (ext $ λ m n, by simp; simp only [linear_equiv.symm_apply_apply])
@@ -395,13 +403,13 @@ variables (β₁ : ι₁ → Type*) (β₂ : ι₂ → Type*)
 variables [Π i₁, add_comm_group (β₁ i₁)] [Π i₂, add_comm_group (β₂ i₂)]
 variables [Π i₁, module R (β₁ i₁)] [Π i₂, module R (β₂ i₂)]
 
-def direct_sum : direct_sum ι₁ β₁ ⊗ direct_sum ι₂ β₂
-  ≃ₗ direct_sum (ι₁ × ι₂) (λ i, β₁ i.1 ⊗ β₂ i.2) :=
+def direct_sum : direct_sum ι₁ β₁ ⊗[R] direct_sum ι₂ β₂
+  ≃ₗ[R] direct_sum (ι₁ × ι₂) (λ i, β₁ i.1 ⊗[R] β₂ i.2) :=
 begin
   refine linear_equiv.of_linear
-    (lift $ direct_sum.to_module _ _ $ λ i₁, flip $ direct_sum.to_module _ _ $ λ i₂,
-      flip $ curry $ direct_sum.lof (ι₁ × ι₂) (λ i, β₁ i.1 ⊗ β₂ i.2) (i₁, i₂))
-    (direct_sum.to_module _ _ $ λ i, map (direct_sum.lof _ _ _) (direct_sum.lof _ _ _))
+    (lift $ direct_sum.to_module R _ _ $ λ i₁, flip $ direct_sum.to_module R _ _ $ λ i₂,
+      flip $ curry $ direct_sum.lof R (ι₁ × ι₂) (λ i, β₁ i.1 ⊗[R] β₂ i.2) (i₁, i₂))
+    (direct_sum.to_module R _ _ $ λ i, map (direct_sum.lof R _ _ _) (direct_sum.lof R _ _ _))
     (linear_map.ext $ direct_sum.to_module.ext $ λ i, mk_compr₂_inj $
       linear_map.ext $ λ x₁, linear_map.ext $ λ x₂, _)
     (mk_compr₂_inj $ linear_map.ext $ direct_sum.to_module.ext $ λ i₁, linear_map.ext $ λ x₁,

--- a/src/measure_theory/outer_measure.lean
+++ b/src/measure_theory/outer_measure.lean
@@ -255,7 +255,7 @@ by by_cases b ∈ s; simp [h]
 
 theorem top_apply {s : set α} (h : s ≠ ∅) : (⊤ : outer_measure α) s = ⊤ :=
 let ⟨a, as⟩ := set.exists_mem_of_ne_empty h in
-top_unique $ le_supr_of_le ⟨⊤ • dirac a, trivial⟩ $
+top_unique $ le_supr_of_le ⟨(⊤ : ennreal) • dirac a, trivial⟩ $
 by simp [smul_dirac_apply, as]
 
 end basic

--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -122,7 +122,7 @@ of_ring_hom subtype.val ⟨rfl, λ _ _, rfl, λ _ _, rfl⟩
 variables (R A)
 /-- The multiplication in an algebra is a bilinear map. -/
 def lmul : A →ₗ A →ₗ A :=
-linear_map.mk₂ (*)
+linear_map.mk₂ R (*)
   (λ x y z, add_mul x y z)
   (λ c x y, by rw [smul_def, smul_def, mul_assoc _ x y])
   (λ x y z, mul_add x y z)
@@ -249,8 +249,8 @@ instance comap.algebra : algebra R (comap R S A) :=
   smul_add := λ _ _ _, smul_add _ _ _,
   add_smul := λ _ _ _, by simp only [algebra.map_add]; from add_smul _ _ _,
   mul_smul := λ _ _ _, by simp only [algebra.map_mul]; from mul_smul _ _ _,
-  one_smul := λ _, by simp only [algebra.map_one]; from one_smul _,
-  zero_smul := λ _, by simp only [algebra.map_zero]; from zero_smul _,
+  one_smul := λ _, by simp only [algebra.map_one]; from one_smul _ _,
+  zero_smul := λ _, by simp only [algebra.map_zero]; from zero_smul _ _,
   smul_zero := λ _, smul_zero _,
   to_fun := (algebra_map A : S → A) ∘ algebra_map S,
   hom := by letI : is_ring_hom (algebra_map A) := _inst_5.hom; apply_instance,

--- a/src/ring_theory/ideal_operations.lean
+++ b/src/ring_theory/ideal_operations.lean
@@ -34,13 +34,13 @@ theorem mem_annihilator {r} : r ∈ N.annihilator ↔ ∀ n ∈ N, r • n = (0:
 λ h, linear_map.mem_ker.2 $ linear_map.ext $ λ n, subtype.eq $ h n.1 n.2⟩
 
 theorem mem_annihilator' {r} : r ∈ N.annihilator ↔ N ≤ comap (r • linear_map.id) ⊥ :=
-mem_annihilator.trans ⟨λ H n hn, mem_bot.2 $ H n hn, λ H n hn, mem_bot.1 $ H hn⟩
+mem_annihilator.trans ⟨λ H n hn, (mem_bot R).2 $ H n hn, λ H n hn, (mem_bot R).1 $ H hn⟩
 
 theorem annihilator_bot : (⊥ : submodule R M).annihilator = ⊤ :=
 (ideal.eq_top_iff_one _).2 $ mem_annihilator'.2 bot_le
 
 theorem annihilator_eq_top_iff : N.annihilator = ⊤ ↔ N = ⊥ :=
-⟨λ H, eq_bot_iff.2 $ λ n hn, mem_bot.2 $ one_smul n ▸ mem_annihilator.1 ((ideal.eq_top_iff_one _).1 H) n hn,
+⟨λ H, eq_bot_iff.2 $ λ (n:M) hn, (mem_bot R).2 $ one_smul R n ▸ mem_annihilator.1 ((ideal.eq_top_iff_one _).1 H) n hn,
 λ H, H.symm ▸ annihilator_bot⟩
 
 theorem annihilator_mono (h : N ≤ P) : P.annihilator ≤ N.annihilator :=
@@ -81,7 +81,7 @@ theorem smul_le {P : submodule R M} : I • N ≤ P ↔ ∀ (r ∈ I) (n ∈ N),
 theorem smul_induction_on {p : M → Prop} {x} (H : x ∈ I • N)
   (Hb : ∀ (r ∈ I) (n ∈ N), p (r • n)) (H0 : p 0)
   (H1 : ∀ x y, p x → p y → p (x + y))
-  (H2 : ∀ c n, p n → p (c • n)) : p x :=
+  (H2 : ∀ (c:R) n, p n → p (c • n)) : p x :=
 (@smul_le _ _ _ _ _ _ _ ⟨p, H0, H1, H2⟩).2 Hb H
 
 theorem smul_le_right : I • N ≤ N :=
@@ -99,14 +99,14 @@ smul_mono (le_refl I) h
 variables (I J N P)
 theorem smul_bot : I • (⊥ : submodule R M) = ⊥ :=
 eq_bot_iff.2 $ smul_le.2 $ λ r hri s hsb,
-submodule.mem_bot.2 $ (submodule.mem_bot.1 hsb).symm ▸ smul_zero r
+(submodule.mem_bot R).2 $ ((submodule.mem_bot R).1 hsb).symm ▸ smul_zero r
 
-theorem bot_smul : ⊥ • N = ⊥ :=
+theorem bot_smul : (⊥ : ideal R) • N = ⊥ :=
 eq_bot_iff.2 $ smul_le.2 $ λ r hrb s hsi,
-submodule.mem_bot.2 $ (submodule.mem_bot.1 hrb).symm ▸ zero_smul s
+(submodule.mem_bot R).2 $ ((submodule.mem_bot R).1 hrb).symm ▸ zero_smul _ s
 
-theorem top_smul : ⊤ • N = N :=
-le_antisymm smul_le_right $ λ r hri, one_smul r ▸ smul_mem_smul mem_top hri
+theorem top_smul : (⊤ : ideal R) • N = N :=
+le_antisymm smul_le_right $ λ r hri, one_smul R r ▸ smul_mem_smul mem_top hri
 
 theorem smul_sup : I • (N ⊔ P) = I • N ⊔ I • P :=
 le_antisymm (smul_le.2 $ λ r hri m hmnp, let ⟨n, hn, p, hp, hnpm⟩ := mem_sup.1 hmnp in
@@ -123,17 +123,17 @@ le_antisymm (smul_le.2 $ λ r hrij n hn, let ⟨ri, hri, rj, hrj, hrijr⟩ := me
 theorem smul_assoc : (I • J) • N = I • (J • N) :=
 le_antisymm (smul_le.2 $ λ rs hrsij t htn,
   smul_induction_on hrsij
-  (λ r hr s hs, (@smul_eq_mul R _ r s).symm ▸ smul_smul r s t ▸ smul_mem_smul hr (smul_mem_smul hs htn))
-  ((zero_smul t).symm ▸ submodule.zero_mem _)
+  (λ r hr s hs, (@smul_eq_mul R _ r s).symm ▸ smul_smul _ r s t ▸ smul_mem_smul hr (smul_mem_smul hs htn))
+  ((zero_smul R t).symm ▸ submodule.zero_mem _)
   (λ x y, (add_smul x y t).symm ▸ submodule.add_mem _)
-  (λ r s h, (@smul_eq_mul R _ r s).symm ▸ smul_smul r s t ▸ submodule.smul_mem _ _ h))
+  (λ r s h, (@smul_eq_mul R _ r s).symm ▸ smul_smul _ r s t ▸ submodule.smul_mem _ _ h))
 (smul_le.2 $ λ r hr sn hsn, suffices J • N ≤ submodule.comap (r • linear_map.id) ((I • J) • N), from this hsn,
 smul_le.2 $ λ s hs n hn, show r • (s • n) ∈ (I • J) • N, from mul_smul r s n ▸ smul_mem_smul (smul_mem_smul hr hs) hn)
 
 variables (S : set R) (T : set M)
 
-theorem span_smul_span : (ideal.span S) • (span T) =
-  span (⋃ (s ∈ S) (t ∈ T), {s • t}) :=
+theorem span_smul_span : (ideal.span S) • (span R T) =
+  span R (⋃ (s ∈ S) (t ∈ T), {s • t}) :=
 le_antisymm (smul_le.2 $ λ r hrS n hnT, span_induction hrS
   (λ r hrS, span_induction hnT
     (λ n hnT, subset_span $ set.mem_bUnion hrS $
@@ -141,7 +141,7 @@ le_antisymm (smul_le.2 $ λ r hrS n hnT, span_induction hrS
     ((smul_zero r : r • 0 = (0:M)).symm ▸ submodule.zero_mem _)
     (λ x y, (smul_add r x y).symm ▸ submodule.add_mem _)
     (λ c m, by rw [smul_smul, mul_comm, mul_smul]; exact submodule.smul_mem _ _))
-  ((zero_smul n).symm ▸ submodule.zero_mem _)
+  ((zero_smul R n).symm ▸ submodule.zero_mem _)
   (λ r s, (add_smul r s n).symm ▸ submodule.add_mem _)
   (λ c r, by rw [smul_eq_mul, mul_smul]; exact submodule.smul_mem _ _)) $
 span_le.2 $ set.bUnion_subset $ λ r hrS, set.bUnion_subset $ λ n hnT, set.singleton_subset_iff.2 $
@@ -435,7 +435,7 @@ submodule.span_induction H (λ _, id) ⟨0, I.zero_mem, is_ring_hom.map_zero f�
 theorem comap_map_of_surjective (I : ideal R) :
   comap f (map f I) = I ⊔ comap f ⊥ :=
 le_antisymm (assume r h, let ⟨s, hsi, hfsr⟩ := mem_image_of_mem_map_of_surjective f hf h in
-  submodule.mem_sup.2 ⟨s, hsi, r - s, submodule.mem_bot.2 $ by rw [is_ring_hom.map_sub f, hfsr, sub_self],
+  submodule.mem_sup.2 ⟨s, hsi, r - s, (submodule.mem_bot S).2 $ by rw [is_ring_hom.map_sub f, hfsr, sub_self],
   add_sub_cancel'_right s r⟩)
 (sup_le (map_le_iff_le_comap.1 (le_refl _)) (comap_mono bot_le))
 

--- a/src/ring_theory/ideals.lean
+++ b/src/ring_theory/ideals.lean
@@ -34,7 +34,7 @@ theorem eq_top_iff_one : I = ⊤ ↔ (1:α) ∈ I :=
 theorem ne_top_iff_one : I ≠ ⊤ ↔ (1:α) ∉ I :=
 not_congr I.eq_top_iff_one
 
-def span (s : set α) : ideal α := submodule.span s
+def span (s : set α) : ideal α := submodule.span α s
 
 lemma subset_span {s : set α} : s ⊆ span s := submodule.subset_span
 

--- a/src/ring_theory/principal_ideal_domain.lean
+++ b/src/ring_theory/principal_ideal_domain.lean
@@ -71,7 +71,7 @@ lemma mod_mem_iff {S : ideal α} {x y : α} (hy : y ∈ S) : x % y ∈ S ↔ x �
 instance euclidean_domain.to_principal_ideal_domain : principal_ideal_domain α :=
 { principal := λ S, by exactI
     ⟨if h : {x : α | x ∈ S ∧ x ≠ 0} = ∅
-    then ⟨0, submodule.ext $ λ a, by rw [← submodule.bot_coe, span_eq, submodule.mem_bot]; exact
+    then ⟨0, submodule.ext $ λ a, by rw [← @submodule.bot_coe α α _ _ ring.to_module, span_eq, submodule.mem_bot]; exact
       ⟨λ haS, by_contradiction $ λ ha0, eq_empty_iff_forall_not_mem.1 h a ⟨haS, ha0⟩,
       λ h₁, h₁.symm ▸ S.zero_mem⟩⟩
     else
@@ -107,7 +107,7 @@ local attribute [instance] classical.prop_decidable
 open submodule
 
 lemma factors_decreasing (b₁ b₂ : α) (h₁ : b₁ ≠ 0) (h₂ : ¬ is_unit b₂) :
-  submodule.span ({b₁ * b₂} : set α) < submodule.span {b₁} :=
+  submodule.span α ({b₁ * b₂} : set α) < submodule.span α {b₁} :=
 lt_of_le_not_le (ideal.span_le.2 $ singleton_subset_iff.2 $
   ideal.mem_span_singleton.2 ⟨b₂, rfl⟩) $ λ h,
 h₂ $ is_unit_of_dvd_one _ $ (mul_dvd_mul_iff_left h₁).1 $


### PR DESCRIPTION
* The first parameters of `has_scalar`, `semimodule`, `module`, and `vector_space` are no longer `out_param`s. The implication is that the base ring will have to be inferred either from being provided explicitly or from context.
* The base ring of linear maps are now specified via `β →ₗ[α] γ`, alongside the original notation `β →ₗ γ`. A similar notation has been introduced for tensor products.
* The base ring in some definitions/theorems are made explicit.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
