### PR TITLE
refactor(category_theory/opposites): Make `opposite` irreducible

### DIFF
--- a/src/category_theory/adjunction.lean
+++ b/src/category_theory/adjunction.lean
@@ -355,7 +355,7 @@ end preservation_limits
 
 -- Note: this is natural in K, but we do not yet have the tools to formulate that.
 def cocones_iso {J : Type v} [small_category J] {K : J ⥤ C} :
-  (cocones J D).obj (K ⋙ F) ≅ G ⋙ ((cocones J C).obj K) :=
+  (cocones J D).obj (op (K ⋙ F)) ≅ G ⋙ ((cocones J C).obj (op K)) :=
 nat_iso.of_components (λ Y,
 { hom := λ t,
     { app := λ j, (adj.hom_equiv (K.obj j) Y) (t.app j),
@@ -378,13 +378,13 @@ def cones_iso {J : Type v} [small_category J] {K : J ⥤ D} :
   F.op ⋙ ((cones J D).obj K) ≅ (cones J C).obj (K ⋙ G) :=
 nat_iso.of_components (λ X,
 { hom := λ t,
-  { app := λ j, (adj.hom_equiv X (K.obj j)) (t.app j),
+  { app := λ j, (adj.hom_equiv (unop X) (K.obj j)) (t.app j),
     naturality' := λ j j' f, begin
       erw [← adj.hom_equiv_naturality_right, ← t.naturality, category.id_comp, category.id_comp],
       refl
     end },
   inv := λ t,
-  { app := λ j, (adj.hom_equiv X (K.obj j)).symm (t.app j),
+  { app := λ j, (adj.hom_equiv (unop X) (K.obj j)).symm (t.app j),
     naturality' := λ j j' f, begin
       erw [← adj.hom_equiv_naturality_right_symm, ← t.naturality, category.id_comp, category.id_comp]
     end } } )

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -32,22 +32,22 @@ An object representing this functor is a limit of `F`.
 -/
 def cones : Cᵒᵖ ⥤ Type v := (const Jᵒᵖ ⋙ op_inv J C) ⋙ (yoneda.obj F)
 
-lemma cones_obj (X : C) : F.cones.obj X = ((const J).obj X ⟹ F) := rfl
+lemma cones_obj (X : C) : F.cones.obj (op X) = ((const J).obj X ⟹ F) := rfl
 
-@[simp] lemma cones_map_app {X₁ X₂ : C} (f : X₁ ⟶ X₂) (t : F.cones.obj X₂) (j : J) :
-(F.cones.map f t).app j = f ≫ t.app j := rfl
+@[simp] lemma cones_map_app {X₁ X₂ : Cᵒᵖ} (f : X₁ ⟶ X₂) (t : F.cones.obj X₁) (j : J) :
+  (F.cones.map f t).app j = f.unop ≫ t.app j := rfl
 
 /--
 `F.cocones` is the functor assigning to an object `X` the type of
 natural transformations from `F` to the constant functor with value `X`.
 An object corepresenting this functor is a colimit of `F`.
 -/
-def cocones : C ⥤ Type v := (const J) ⋙ (coyoneda.obj F)
+def cocones : C ⥤ Type v := const J ⋙ coyoneda.obj (op F)
 
 lemma cocones_obj (X : C) : F.cocones.obj X = (F ⟹ (const J).obj X) := rfl
 
 @[simp] lemma cocones_map_app {X₁ X₂ : C} (f : X₁ ⟶ X₂) (t : F.cocones.obj X₁) (j : J) :
-(F.cocones.map f t).app j = t.app j ≫ f := rfl
+  (F.cocones.map f t).app j = t.app j ≫ f := rfl
 
 end functor
 
@@ -59,7 +59,7 @@ def cones : (J ⥤ C) ⥤ (Cᵒᵖ ⥤ Type v) :=
   map := λ F G f, whisker_left _ (yoneda.map f) }
 
 def cocones : (J ⥤ C)ᵒᵖ ⥤ (C ⥤ Type v) :=
-{ obj := functor.cocones,
+{ obj := λ F, functor.cocones (unop F),
   map := λ F G f, whisker_left _ (coyoneda.map f) }
 
 variables {J C}
@@ -68,8 +68,8 @@ variables {J C}
 @[simp] lemma cones_map  {F G : J ⥤ C} {f : F ⟶ G} :
 (cones J C).map f = (whisker_left _ (yoneda.map f)) := rfl
 
-@[simp] lemma cocones_obj (F : J ⥤ C) : (cocones J C).obj F = F.cocones := rfl
-@[simp] lemma cocones_map  {F G : J ⥤ C} {f : F ⟶ G} :
+@[simp] lemma cocones_obj (F : (J ⥤ C)ᵒᵖ) : (cocones J C).obj F = (unop F).cocones := rfl
+@[simp] lemma cocones_map  {F G : (J ⥤ C)ᵒᵖ} {f : F ⟶ G} :
 (cocones J C).map f = (whisker_left _ (coyoneda.map f)) := rfl
 
 end
@@ -117,7 +117,7 @@ namespace cone
 /-- A map to the vertex of a cone induces a cone by composition. -/
 @[simp] def extend (c : cone F) {X : C} (f : X ⟶ c.X) : cone F :=
 { X := X,
-  π := c.extensions.app X f }
+  π := c.extensions.app (op X) f }
 
 def whisker {K : Type v} [small_category K] (E : K ⥤ J) (c : cone F) : cone (E ⋙ F) :=
 { X := c.X,
@@ -128,7 +128,7 @@ def whisker {K : Type v} [small_category K] (E : K ⥤ J) (c : cone F) : cone (E
 end cone
 
 namespace cocone
-@[simp] def extensions (c : cocone F) : coyoneda.obj c.X ⟶ F.cocones :=
+@[simp] def extensions (c : cocone F) : coyoneda.obj (op c.X) ⟶ F.cocones :=
 { app := λ X f, c.ι ≫ ((const J).map f),
   naturality' := by intros X Y f; ext g j; dsimp; rw ←assoc; refl }
 

--- a/src/category_theory/limits/limits.lean
+++ b/src/category_theory/limits/limits.lean
@@ -90,7 +90,7 @@ def hom_iso (h : is_limit t) (W : C) : (W ⟶ t.X) ≅ ((const J).obj W ⟹ F) :
 /-- The limit of `F` represents the functor taking `W` to
   the set of cones on `F` with vertex `W`. -/
 def nat_iso (h : is_limit t) : yoneda.obj t.X ≅ F.cones :=
-nat_iso.of_components (is_limit.hom_iso h) (by tidy)
+nat_iso.of_components (λ W, is_limit.hom_iso h (unop W)) (by tidy)
 
 def hom_iso' (h : is_limit t) (W : C) :
   (W ⟶ t.X) ≅ { p : Π j, W ⟶ F.obj j // ∀ {j j'} (f : j ⟶ j'), p j ≫ F.map f = p j' } :=
@@ -200,7 +200,7 @@ def hom_iso (h : is_colimit t) (W : C) : (t.X ⟶ W) ≅ (F ⟹ (const J).obj W)
 
 /-- The colimit of `F` represents the functor taking `W` to
   the set of cocones on `F` with vertex `W`. -/
-def nat_iso (h : is_colimit t) : coyoneda.obj t.X ≅ F.cocones :=
+def nat_iso (h : is_colimit t) : coyoneda.obj (op t.X) ≅ F.cocones :=
 nat_iso.of_components (is_colimit.hom_iso h) (by intros; ext; dsimp; rw ←assoc; refl)
 
 def hom_iso' (h : is_colimit t) (W : C) :
@@ -308,7 +308,7 @@ by erw is_limit.fac
   (w : ∀ j, f ≫ limit.π F j = f' ≫ limit.π F j) : f = f' :=
 (limit.is_limit F).hom_ext w
 
-def limit.hom_iso (F : J ⥤ C) [has_limit F] (W : C) : (W ⟶ limit F) ≅ (F.cones.obj W) :=
+def limit.hom_iso (F : J ⥤ C) [has_limit F] (W : C) : (W ⟶ limit F) ≅ (F.cones.obj (op W)) :=
 (limit.is_limit F).hom_iso W
 
 @[simp] lemma limit.hom_iso_hom (F : J ⥤ C) [has_limit F] {W : C} (f : W ⟶ limit F):
@@ -434,7 +434,8 @@ begin
 end
 
 def lim_yoneda : lim ⋙ yoneda ≅ category_theory.cones J C :=
-nat_iso.of_components (λ F, nat_iso.of_components (limit.hom_iso F) (by tidy)) (by tidy)
+nat_iso.of_components (λ F, nat_iso.of_components (λ W, limit.hom_iso F (unop W)) (by tidy))
+  (by tidy)
 
 end lim_functor
 
@@ -652,7 +653,7 @@ begin
 end
 
 def colim_coyoneda : colim.op ⋙ coyoneda ≅ category_theory.cocones J C :=
-nat_iso.of_components (λ F, nat_iso.of_components (colimit.hom_iso F) (by tidy))
+nat_iso.of_components (λ F, nat_iso.of_components (colimit.hom_iso (unop F)) (by tidy))
   (by {tidy, rw [← category.assoc,← category.assoc], tidy})
 
 end colim_functor

--- a/src/category_theory/opposites.lean
+++ b/src/category_theory/opposites.lean
@@ -9,23 +9,94 @@ namespace category_theory
 
 universes v₁ v₂ u₁ u₂ -- declare the `v`'s first; see `category_theory.category` for an explanation
 
-def op (C : Type u₁) : Type u₁ := C
+/-- The type of objects of the opposite of C (which should be a category).
+
+  In order to avoid confusion between C and its opposite category, we
+  set up the type of objects `opposite C` using the following pattern,
+  which will be repeated later for the morphisms.
+
+  1. Define `opposite C := C`.
+  2. Define the isomorphisms `op : C → opposite C`, `unop : opposite C → C`.
+  3. Make the definition `opposite` irreducible.
+
+  This has the following consequences.
+
+  * `opposite C` and `C` are distinct types in the elaborator, so you
+    must use `op` and `unop` explicitly to convert between them.
+  * Both `unop (op X) = X` and `op (unop X) = X` are definitional
+    equalities. Notably, every object of the opposite category is
+    definitionally of the form `op X`, which greatly simplifies the
+    definition of the structure of the opposite category, for example.
+
+  (If Lean supported definitional eta equality for records, we could
+  achieve the same goals using a structure with one field.)
+-/
+def opposite (C : Type u₁) : Type u₁ := C
 
 -- Use a high right binding power (like that of postfix ⁻¹) so that, for example,
 -- `presheaf Cᵒᵖ` parses as `presheaf (Cᵒᵖ)` and not `(presheaf C)ᵒᵖ`.
-notation C `ᵒᵖ`:std.prec.max_plus := op C
+notation C `ᵒᵖ`:std.prec.max_plus := opposite C
 
-variables {C : Type u₁} [𝒞 : category.{v₁} C]
+variables {C : Type u₁}
+
+def op (X : C) : Cᵒᵖ := X
+def unop (X : Cᵒᵖ) : C := X
+
+attribute [irreducible] opposite
+
+@[simp] lemma unop_op (X : C) : unop (op X) = X := rfl
+@[simp] lemma op_unop (X : Cᵒᵖ) : op (unop X) = X := rfl
+
+section has_hom
+
+variables [𝒞 : has_hom.{v₁} C]
 include 𝒞
 
-instance opposite : category.{v₁} Cᵒᵖ :=
-{ hom  := λ X Y : C, Y ⟶ X,
-  comp := λ _ _ _ f g, g ≫ f,
-  id   := λ X, 𝟙 X }
+/-- The hom types of the opposite of a category (or graph).
+
+  As with the objects, we'll make this irreducible below.
+  Use `f.op` and `f.unop` to convert between morphisms of C
+  and morphisms of Cᵒᵖ.
+-/
+instance has_hom.opposite : has_hom Cᵒᵖ :=
+{ hom := λ X Y, unop Y ⟶ unop X }
+
+def has_hom.hom.op {X Y : C} (f : X ⟶ Y) : op Y ⟶ op X := f
+def has_hom.hom.unop {X Y : Cᵒᵖ} (f : X ⟶ Y) : unop Y ⟶ unop X := f
+
+attribute [irreducible] has_hom.opposite
+
+lemma has_hom.hom.op_inj {X Y : C} :
+  function.injective (has_hom.hom.op : (X ⟶ Y) → (op Y ⟶ op X)) :=
+λ _ _ H, congr_arg has_hom.hom.unop H
+
+lemma has_hom.hom.unop_inj {X Y : Cᵒᵖ} :
+  function.injective (has_hom.hom.unop : (X ⟶ Y) → (unop Y ⟶ unop X)) :=
+λ _ _ H, congr_arg has_hom.hom.op H
+
+@[simp] lemma has_hom.hom.unop_op {X Y : C} {f : X ⟶ Y} : f.op.unop = f := rfl
+@[simp] lemma has_hom.hom.op_unop {X Y : Cᵒᵖ} {f : X ⟶ Y} : f.unop.op = f := rfl
+
+end has_hom
+
+variables [𝒞 : category.{v₁} C]
+include 𝒞
+
+instance category.opposite : category.{v₁} Cᵒᵖ :=
+{ comp := λ _ _ _ f g, (g.unop ≫ f.unop).op,
+  id   := λ X, (𝟙 (unop X)).op }
+
+@[simp] lemma op_comp {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} :
+  (f ≫ g).op = g.op ≫ f.op := rfl
+@[simp] lemma op_id {X : C} : (𝟙 X).op = 𝟙 (op X) := rfl
+
+@[simp] lemma unop_comp {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : Y ⟶ Z} :
+  (f ≫ g).unop = g.unop ≫ f.unop := rfl
+@[simp] lemma unop_id {X : Cᵒᵖ} : (𝟙 X).unop = 𝟙 (unop X) := rfl
 
 def op_op : (Cᵒᵖ)ᵒᵖ ⥤ C :=
-{ obj := λ X, X,
-  map := λ X Y f, f }
+{ obj := λ X, unop (unop X),
+  map := λ X Y f, f.unop.unop }
 
 -- TODO this is an equivalence
 
@@ -39,63 +110,51 @@ include 𝒟
 variables {C D}
 
 protected definition op (F : C ⥤ D) : Cᵒᵖ ⥤ Dᵒᵖ :=
-{ obj       := λ X, F.obj X,
-  map       := λ X Y f, F.map f,
-  map_id'   := begin /- `obviously'` says: -/ intros, erw [map_id], refl, end,
-  map_comp' := begin /- `obviously'` says: -/ intros, erw [map_comp], refl end }
+{ obj := λ X, op (F.obj (unop X)),
+  map := λ X Y f, (F.map f.unop).op }
 
-@[simp] lemma op_obj (F : C ⥤ D) (X : C) : (F.op).obj X = F.obj X := rfl
-@[simp] lemma op_map (F : C ⥤ D) {X Y : C} (f : X ⟶ Y) : (F.op).map f = F.map f := rfl
+@[simp] lemma op_obj (F : C ⥤ D) (X : Cᵒᵖ) : (F.op).obj X = op (F.obj (unop X)) := rfl
+@[simp] lemma op_map (F : C ⥤ D) {X Y : Cᵒᵖ} (f : X ⟶ Y) : (F.op).map f = (F.map f.unop).op := rfl
 
 protected definition unop (F : Cᵒᵖ ⥤ Dᵒᵖ) : C ⥤ D :=
-{ obj       := λ X, F.obj X,
-  map       := λ X Y f, F.map f,
-  map_id'   := F.map_id,
-  map_comp' := by intros; apply F.map_comp }
+{ obj := λ X, unop (F.obj (op X)),
+  map := λ X Y f, (F.map f.op).unop }
 
-@[simp] lemma unop_obj (F : Cᵒᵖ ⥤ Dᵒᵖ) (X : C) : (F.unop).obj X = F.obj X := rfl
-@[simp] lemma unop_map (F : Cᵒᵖ ⥤ Dᵒᵖ) {X Y : C} (f : X ⟶ Y) : (F.unop).map f = F.map f := rfl
+@[simp] lemma unop_obj (F : Cᵒᵖ ⥤ Dᵒᵖ) (X : C) : (F.unop).obj X = unop (F.obj (op X)) := rfl
+@[simp] lemma unop_map (F : Cᵒᵖ ⥤ Dᵒᵖ) {X Y : C} (f : X ⟶ Y) : (F.unop).map f = (F.map f.op).unop := rfl
 
 variables (C D)
 
 definition op_hom : (C ⥤ D)ᵒᵖ ⥤ (Cᵒᵖ ⥤ Dᵒᵖ) :=
-{ obj := λ F, F.op,
+{ obj := λ F, (unop F).op,
   map := λ F G α,
-  { app := λ X, α.app X,
-    naturality' := λ X Y f, eq.symm (α.naturality f) } }
+  { app := λ X, (α.unop.app (unop X)).op,
+    naturality' := λ X Y f, has_hom.hom.unop_inj $ eq.symm (α.unop.naturality f.unop) } }
 
-@[simp] lemma op_hom.obj (F : (C ⥤ D)ᵒᵖ) : (op_hom C D).obj F = F.op := rfl
-@[simp] lemma op_hom.map_app {F G : (C ⥤ D)ᵒᵖ} (α : F ⟶ G) (X : C) :
-  ((op_hom C D).map α).app X = α.app X := rfl
+@[simp] lemma op_hom.obj (F : (C ⥤ D)ᵒᵖ) : (op_hom C D).obj F = (unop F).op := rfl
+@[simp] lemma op_hom.map_app {F G : (C ⥤ D)ᵒᵖ} (α : F ⟶ G) (X : Cᵒᵖ) :
+  ((op_hom C D).map α).app X = (α.unop.app (unop X)).op := rfl
 
 definition op_inv : (Cᵒᵖ ⥤ Dᵒᵖ) ⥤ (C ⥤ D)ᵒᵖ :=
-{ obj := λ F : Cᵒᵖ ⥤ Dᵒᵖ, F.unop,
-  map := λ F G α,
-  { app := λ X : C, α.app X,
-    naturality' := λ X Y f, eq.symm (α.naturality f) } }
+{ obj := λ F, op F.unop,
+  map := λ F G α, has_hom.hom.op
+  { app := λ X, (α.app (op X)).unop,
+    naturality' := λ X Y f, has_hom.hom.op_inj $ eq.symm (α.naturality f.op) } }
 
-@[simp] lemma op_inv.obj (F : Cᵒᵖ ⥤ Dᵒᵖ) : (op_inv C D).obj F = F.unop := rfl
+@[simp] lemma op_inv.obj (F : Cᵒᵖ ⥤ Dᵒᵖ) : (op_inv C D).obj F = op F.unop := rfl
 @[simp] lemma op_inv.map_app {F G : Cᵒᵖ ⥤ Dᵒᵖ} (α : F ⟶ G) (X : C) :
-  ((op_inv C D).map α).app X = α.app X := rfl
+  (((op_inv C D).map α).unop).app X = (α.app (op X)).unop := rfl
 
 -- TODO show these form an equivalence
 
 instance {F : C ⥤ D} [full F] : full F.op :=
-{ preimage := λ X Y f, F.preimage f }
+{ preimage := λ X Y f, (F.preimage f.unop).op }
 
 instance {F : C ⥤ D} [faithful F] : faithful F.op :=
-{ injectivity' := λ X Y f g h, by simpa using injectivity F h }
+{ injectivity' := λ X Y f g h,
+    has_hom.hom.unop_inj $ by simpa using injectivity F (has_hom.hom.op_inj h) }
 
 end
-
-namespace category
-variables {C} {D : Type u₂} [𝒟 : category.{v₂} D]
-include 𝒟
-
-@[simp] lemma op_id_app (F : (C ⥤ D)ᵒᵖ) (X : C) : (𝟙 F : F ⟹ F).app X = 𝟙 (F.obj X) := rfl
-@[simp] lemma op_comp_app {F G H : (C ⥤ D)ᵒᵖ} (α : F ⟶ G) (β : G ⟶ H) (X : C) :
-  ((α ≫ β) : H ⟹ F).app X = (β : H ⟹ G).app X ≫ (α : G ⟹ F).app X := rfl
-end category
 
 section
 
@@ -103,14 +162,12 @@ variable (C)
 
 /-- `functor.hom` is the hom-pairing, sending (X,Y) to X → Y, contravariant in X and covariant in Y. -/
 definition hom : Cᵒᵖ × C ⥤ Type v₁ :=
-{ obj       := λ p, @has_hom.hom C _ p.1 p.2,
-  map       := λ X Y f, λ h, f.1 ≫ h ≫ f.2,
-  map_id'   := by intros; ext; dsimp [category_theory.opposite]; simp,
-  map_comp' := by intros; ext; dsimp [category_theory.opposite]; simp }
+{ obj       := λ p, unop p.1 ⟶ p.2,
+  map       := λ X Y f, λ h, f.1.unop ≫ h ≫ f.2 }
 
-@[simp] lemma hom_obj (X : Cᵒᵖ × C) : (functor.hom C).obj X = @has_hom.hom C _ X.1 X.2 := rfl
+@[simp] lemma hom_obj (X : Cᵒᵖ × C) : (functor.hom C).obj X = (unop X.1 ⟶ X.2) := rfl
 @[simp] lemma hom_pairing_map {X Y : Cᵒᵖ × C} (f : X ⟶ Y) :
-  (functor.hom C).map f = λ h, f.1 ≫ h ≫ f.2 := rfl
+  (functor.hom C).map f = λ h, f.1.unop ≫ h ≫ f.2 := rfl
 
 end
 

--- a/src/category_theory/yoneda.lean
+++ b/src/category_theory/yoneda.lean
@@ -22,41 +22,43 @@ include 𝒞
 
 def yoneda : C ⥤ (Cᵒᵖ ⥤ Type v₁) :=
 { obj := λ X,
-  { obj := λ Y : C, Y ⟶ X,
-    map := λ Y Y' f g, f ≫ g,
+  { obj := λ Y, unop Y ⟶ X,
+    map := λ Y Y' f g, f.unop ≫ g,
     map_comp' := begin intros X_1 Y Z f g, ext1, dsimp at *, erw [category.assoc] end,
     map_id' := begin intros X_1, ext1, dsimp at *, erw [category.id_comp] end },
   map := λ X X' f, { app := λ Y g, g ≫ f } }
 
 def coyoneda : Cᵒᵖ ⥤ (C ⥤ Type v₁) :=
-{ obj := λ X : C,
-  { obj := λ Y, X ⟶ Y,
+{ obj := λ X,
+  { obj := λ Y, unop X ⟶ Y,
     map := λ Y Y' f g, g ≫ f,
     map_comp' := begin intros X_1 Y Z f g, ext1, dsimp at *, erw [category.assoc] end,
     map_id' := begin intros X_1, ext1, dsimp at *, erw [category.comp_id] end },
-  map := λ X X' f, { app := λ Y g, f ≫ g },
+  map := λ X X' f, { app := λ Y g, f.unop ≫ g },
   map_comp' := begin intros X Y Z f g, ext1, ext1, dsimp at *, erw [category.assoc] end,
   map_id' := begin intros X, ext1, ext1, dsimp at *, erw [category.id_comp] end }
 
 namespace yoneda
-@[simp] lemma obj_obj (X Y : C) : (yoneda.obj X).obj Y = (Y ⟶ X) := rfl
-@[simp] lemma obj_map (X : C) {Y Y' : C} (f : Y ⟶ Y') : (yoneda.obj X).map f = λ g, f ≫ g := rfl
-@[simp] lemma map_app {X X' : C} (f : X ⟶ X') (Y : C) : (yoneda.map f).app Y = λ g, g ≫ f := rfl
+@[simp] lemma obj_obj (X : C) (Y : Cᵒᵖ) : (yoneda.obj X).obj Y = (unop Y ⟶ X) := rfl
+@[simp] lemma obj_map (X : C) {Y Y' : Cᵒᵖ} (f : Y ⟶ Y') :
+  (yoneda.obj X).map f = λ g, f.unop ≫ g := rfl
+@[simp] lemma map_app {X X' : C} (f : X ⟶ X') (Y : Cᵒᵖ) :
+  (yoneda.map f).app Y = λ g, g ≫ f := rfl
 
-lemma obj_map_id {X Y : Cᵒᵖ} (f : X ⟶ Y) :
-  ((@yoneda C _).obj X).map f (𝟙 X) = ((@yoneda C _).map f).app Y (𝟙 Y) :=
+lemma obj_map_id {X Y : C} (f : op X ⟶ op Y) :
+  ((@yoneda C _).obj X).map f (𝟙 X) = ((@yoneda C _).map f.unop).app (op Y) (𝟙 Y) :=
 by obviously
 
 @[simp] lemma naturality {X Y : C} (α : yoneda.obj X ⟶ yoneda.obj Y)
-  {Z Z' : C} (f : Z ⟶ Z') (h : Z' ⟶ X) : f ≫ α.app Z' h = α.app Z (f ≫ h) :=
+  {Z Z' : C} (f : Z ⟶ Z') (h : Z' ⟶ X) : f ≫ α.app (op Z') h = α.app (op Z) (f ≫ h) :=
 begin erw [functor_to_types.naturality], refl end
 
 instance yoneda_fully_faithful : fully_faithful (@yoneda C _) :=
-{ preimage := λ X Y f, (f.app X) (𝟙 X),
+{ preimage := λ X Y f, (f.app (op X)) (𝟙 X),
   injectivity' := λ X Y f g p,
   begin
     injection p with h,
-    convert (congr_fun (congr_fun h X) (𝟙 X)) ; simp
+    convert (congr_fun (congr_fun h (op X)) (𝟙 X)); dsimp; simp,
   end }
 
 /-- Extensionality via Yoneda. The typical usage would be
@@ -84,9 +86,11 @@ category_theory.prod.{v₁ (max u₁ v₁)} Cᵒᵖ (Cᵒᵖ ⥤ Type v₁)
 end yoneda
 
 namespace coyoneda
-@[simp] lemma obj_obj (X Y : C) : (coyoneda.obj X).obj Y = (X ⟶ Y) := rfl
-@[simp] lemma obj_map {X' X : C} (f : X' ⟶ X) (Y : C) : (coyoneda.obj Y).map f = λ g, g ≫ f := rfl
-@[simp] lemma map_app (X : C) {Y Y' : C} (f : Y ⟶ Y') : (coyoneda.map f).app X = λ g, f ≫ g := rfl
+@[simp] lemma obj_obj (X : Cᵒᵖ) (Y : C) : (coyoneda.obj X).obj Y = (unop X ⟶ Y) := rfl
+@[simp] lemma obj_map {X' X : C} (f : X' ⟶ X) (Y : Cᵒᵖ) :
+  (coyoneda.obj Y).map f = λ g, g ≫ f := rfl
+@[simp] lemma map_app (X : C) {Y Y' : Cᵒᵖ} (f : Y ⟶ Y') :
+  (coyoneda.map f).app X = λ g, f.unop ≫ g := rfl
 end coyoneda
 
 class representable (F : Cᵒᵖ ⥤ Type v₁) :=
@@ -108,11 +112,11 @@ functor.prod yoneda.op (functor.id (Cᵒᵖ ⥤ Type v₁)) ⋙ functor.hom (C�
 
 @[simp] lemma yoneda_pairing_map
   (P Q : Cᵒᵖ × (Cᵒᵖ ⥤ Type v₁)) (α : P ⟶ Q) (β : (yoneda_pairing C).obj P) :
-  (yoneda_pairing C).map α β = yoneda.map α.1 ≫ β ≫ α.2 := rfl
+  (yoneda_pairing C).map α β = yoneda.map α.1.unop ≫ β ≫ α.2 := rfl
 
 def yoneda_lemma : yoneda_pairing C ≅ yoneda_evaluation C :=
 { hom :=
-  { app := λ F x, ulift.up ((x.app F.1) (𝟙 F.1)),
+  { app := λ F x, ulift.up ((x.app F.1) (𝟙 (unop F.1))),
     naturality' :=
     begin
       intros X Y f, ext1, ext1,
@@ -125,7 +129,7 @@ def yoneda_lemma : yoneda_pairing C ≅ yoneda_evaluation C :=
     end },
   inv :=
   { app := λ F x,
-    { app := λ X a, (F.2.map a) x.down,
+    { app := λ X a, (F.2.map a.op) x.down,
       naturality' :=
       begin
         intros X Y f, ext1,
@@ -146,7 +150,7 @@ def yoneda_lemma : yoneda_pairing C ≅ yoneda_evaluation C :=
     erw [←functor_to_types.naturality,
          obj_map_id,
          functor_to_types.naturality,
-         functor_to_types.map_id]
+         functor_to_types.map_id], refl,
   end,
   inv_hom_id' :=
   begin
@@ -158,11 +162,11 @@ def yoneda_lemma : yoneda_pairing C ≅ yoneda_evaluation C :=
 
 variables {C}
 
-@[simp] def yoneda_sections (X : C) (F : Cᵒᵖ ⥤ Type v₁) : (yoneda.obj X ⟹ F) ≅ ulift.{u₁} (F.obj X) :=
-nat_iso.app (yoneda_lemma C) (X, F)
+@[simp] def yoneda_sections (X : C) (F : Cᵒᵖ ⥤ Type v₁) : (yoneda.obj X ⟹ F) ≅ ulift.{u₁} (F.obj (op X)) :=
+nat_iso.app (yoneda_lemma C) (op X, F)
 
 omit 𝒞
-@[simp] def yoneda_sections_small {C : Type u₁} [small_category C] (X : C) (F : Cᵒᵖ ⥤ Type u₁) : (yoneda.obj X ⟹ F) ≅ F.obj X :=
+@[simp] def yoneda_sections_small {C : Type u₁} [small_category C] (X : C) (F : Cᵒᵖ ⥤ Type u₁) : (yoneda.obj X ⟹ F) ≅ F.obj (op X) :=
 yoneda_sections X F ≪≫ ulift_trivial _
 
 end category_theory


### PR DESCRIPTION
See discussion at #510.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
