### PR TITLE
docs(tactic/monotonicity/interactive): fix `mono` documentation [ci-skip]

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -638,7 +638,7 @@ and likewise for `to_rhs`.
 
 - `mono` applies a monotonicity rule.
 - `mono*` applies monotonicity rules repetitively.
-- `mono using x ≤ y` or `mono using [0 ≤ x,0 ≤ y]` creates an assertion for the listed
+- `mono with x ≤ y` or `mono with [0 ≤ x,0 ≤ y]` creates an assertion for the listed
   propositions. Those help to select the right monotonicity rule.
 - `mono left` or `mono right` is useful when proving strict orderings:
    for `x + y < w + z` could be broken down into either

--- a/src/tactic/monotonicity/interactive.lean
+++ b/src/tactic/monotonicity/interactive.lean
@@ -478,7 +478,7 @@ do t ← target >>= instantiate_mvars,
 /--
 - `mono` applies a monotonicity rule.
 - `mono*` applies monotonicity rules repetitively.
-- `mono using x ≤ y` or `mono using [0 ≤ x,0 ≤ y]` creates an assertion for the listed
+- `mono with x ≤ y` or `mono with [0 ≤ x,0 ≤ y]` creates an assertion for the listed
   propositions. Those help to select the right monotonicity rule.
 - `mono left` or `mono right` is useful when proving strict orderings:
    for `x + y < w + z` could be broken down into either


### PR DESCRIPTION
For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
