### PR TITLE
chore(.travis.yml): use git clean to clean out untracked files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
   - (git status | grep  -e "Changes not staged for commit:"); RESULT=$?
   - if [ $RESULT -eq 0 ]; then git checkout -f HEAD ; fi
   - git clean -d -f -q
+  - ./purge_olean.sh
   - rm mathlib.txt || true
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,7 @@ install:
   - chmod +x $HOME/scripts/travis_long
   - (git status | grep  -e "Changes not staged for commit:"); RESULT=$?
   - if [ $RESULT -eq 0 ]; then git checkout -f HEAD ; fi
-  - rm `git status | grep "\.lean" | sed "s/\.lean/.olean/"` ||  true
-  - rm `git status | grep "\.lean"` || true
+  - git clean -d -f -q
   - rm mathlib.txt || true
 
 jobs:

--- a/purge_olean.sh
+++ b/purge_olean.sh
@@ -1,0 +1,13 @@
+#! /bin/sh
+# olean=./src/tactic/ring.olean
+# lean_file=`echo $$olean_file | sed "s/\\.olean/.lean/"`
+
+for olean_file in `find . -name "*.olean"`;
+do
+    echo olean file: $olean_file
+    lean_file=`echo $olean_file | sed "s/\.olean/.lean/"`
+    if [ ! -e $lean_file ]; then
+        echo "absent " $lean_file;
+        rm $olean_file
+    fi
+done


### PR DESCRIPTION
PR #641 involved renaming a directory. The old directory was still
present in the cache, and in this situation `git status` lists the
directory as a whole as untracked, so the grep did not find any
`.lean` files.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
