### PR TITLE
cleanup: replace `begin intros ...` with lambdas

### DIFF
--- a/src/category_theory/whiskering.lean
+++ b/src/category_theory/whiskering.lean
@@ -24,8 +24,8 @@ def whiskering_left : (C ⥤ D) ⥤ ((D ⥤ E) ⥤ (C ⥤ E)) :=
   map := λ F G τ,
   { app := λ H,
     { app := λ c, H.map (τ.app c),
-      naturality' := begin intros X Y f, dsimp at *, rw [←H.map_comp, ←H.map_comp, ←τ.naturality] end },
-    naturality' := begin intros X Y f, ext1, dsimp at *, rw [←nat_trans.naturality] end } }
+      naturality' := λ X Y f, begin dsimp at *, rw [←H.map_comp, ←H.map_comp, ←τ.naturality] end },
+    naturality' := λ X Y f, begin ext1, dsimp at *, rw [←nat_trans.naturality] end } }
 
 def whiskering_right : (D ⥤ E) ⥤ ((C ⥤ D) ⥤ (C ⥤ E)) :=
 { obj := λ H,
@@ -37,8 +37,8 @@ def whiskering_right : (D ⥤ E) ⥤ ((C ⥤ D) ⥤ (C ⥤ E)) :=
   map := λ G H τ,
   { app := λ F,
     { app := λ c, τ.app (F.obj c),
-      naturality' := begin intros X Y f, dsimp at *, rw [τ.naturality] end },
-    naturality' := begin intros X Y f, ext1, dsimp at *, rw [←nat_trans.naturality] end } }
+      naturality' := λ X Y f, begin dsimp at *, rw [τ.naturality] end },
+    naturality' := λ X Y f, begin ext1, dsimp at *, rw [←nat_trans.naturality] end } }
 
 variables {C} {D} {E}
 

--- a/src/category_theory/yoneda.lean
+++ b/src/category_theory/yoneda.lean
@@ -24,19 +24,19 @@ def yoneda : C ⥤ (Cᵒᵖ ⥤ Type v₁) :=
 { obj := λ X,
   { obj := λ Y, unop Y ⟶ X,
     map := λ Y Y' f g, f.unop ≫ g,
-    map_comp' := begin intros X_1 Y Z f g, ext1, dsimp at *, erw [category.assoc] end,
-    map_id' := begin intros X_1, ext1, dsimp at *, erw [category.id_comp] end },
+    map_comp' := λ _ _ _ f g, begin ext1, dsimp at *, erw [category.assoc] end,
+    map_id' := λ Y, begin ext1, dsimp at *, erw [category.id_comp] end },
   map := λ X X' f, { app := λ Y g, g ≫ f } }
 
 def coyoneda : Cᵒᵖ ⥤ (C ⥤ Type v₁) :=
 { obj := λ X,
   { obj := λ Y, unop X ⟶ Y,
     map := λ Y Y' f g, g ≫ f,
-    map_comp' := begin intros X_1 Y Z f g, ext1, dsimp at *, erw [category.assoc] end,
-    map_id' := begin intros X_1, ext1, dsimp at *, erw [category.comp_id] end },
+    map_comp' := λ _ _ _ f g, begin ext1, dsimp at *, erw [category.assoc] end,
+    map_id' := λ Y, begin ext1, dsimp at *, erw [category.comp_id] end },
   map := λ X X' f, { app := λ Y g, f.unop ≫ g },
-  map_comp' := begin intros X Y Z f g, ext1, ext1, dsimp at *, erw [category.assoc] end,
-  map_id' := begin intros X, ext1, ext1, dsimp at *, erw [category.id_comp] end }
+  map_comp' := λ _ _ _ f g, begin ext1, ext1, dsimp at *, erw [category.assoc] end,
+  map_id' := λ X, begin ext1, ext1, dsimp at *, erw [category.id_comp] end }
 
 namespace yoneda
 @[simp] lemma obj_obj (X : C) (Y : Cᵒᵖ) : (yoneda.obj X).obj Y = (unop Y ⟶ X) := rfl

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -51,7 +51,7 @@ theorem ext {a b : set α} (h : ∀ x, x ∈ a ↔ x ∈ b) : a = b :=
 funext (assume x, propext (h x))
 
 theorem ext_iff (s t : set α) : s = t ↔ ∀ x, x ∈ s ↔ x ∈ t :=
-⟨begin intros h x, rw h end, ext⟩
+⟨λ h x, by rw h, ext⟩
 
 @[trans] theorem mem_of_mem_of_subset {α : Type u} {x : α} {s t : set α} (hx : x ∈ s) (h : s ⊆ t) : x ∈ t :=
 h hx


### PR DESCRIPTION
`begin intros X Y, ... end` should just use a lambda. This is just a minor stylistic issue, and could be ignored.