### PR TITLE
cleanup(*): removing uses of bare `have`

### DIFF
--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -108,8 +108,8 @@ attribute [simp] nat_abs nat_abs_of_nat nat_abs_zero nat_abs_one
 
 theorem nat_abs_add_le (a b : ℤ) : nat_abs (a + b) ≤ nat_abs a + nat_abs b :=
 begin
-  have, {
-    refine (λ a b : ℕ, sub_nat_nat_elim a b.succ
+  have : ∀ (a b : ℕ), nat_abs (sub_nat_nat a (nat.succ b)) ≤ nat.succ (a + b), 
+  { refine (λ a b : ℕ, sub_nat_nat_elim a b.succ
       (λ m n i, n = b.succ → nat_abs i ≤ (m + b).succ) _ _ rfl);
     intros i n e,
     { subst e, rw [add_comm _ i, add_assoc],

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -463,7 +463,8 @@ theorem mem_Sup_of_directed {s : set (submodule α β)}
   ∃ y ∈ s, z ∈ y :=
 begin
   haveI := classical.dec, rw Sup_eq_supr at hzs,
-  have, { refine (mem_supr_of_directed ⟨⊥⟩ _ (λ i j, _)).1 hzs,
+  have : ∃ (i : submodule α β), z ∈ ⨆ (H : i ∈ s), i,
+  { refine (mem_supr_of_directed ⟨⊥⟩ _ (λ i j, _)).1 hzs,
     by_cases his : i ∈ s; by_cases hjs : j ∈ s,
     { rcases hdir i his j hjs with ⟨k, hks, hik, hjk⟩,
         exact ⟨k, le_supr_of_le hks (supr_le $ λ _, hik),


### PR DESCRIPTION
Using a bare `have`, which creates a new goal of type `?m_1`, seems unnecessarily obfuscatory. There are only two instances in mathlib, so I've added the explicit type to the `have` statement.