### PR TITLE
feat(data/quot): quotient.ind'

### DIFF
--- a/src/data/quot.lean
+++ b/src/data/quot.lean
@@ -200,17 +200,13 @@ protected def lift_on₂' (q₁ : quotient s₁) (q₂ : quotient s₂) (f : α 
   (h : ∀ a₁ a₂ b₁ b₂, @setoid.r α s₁ a₁ b₁ → @setoid.r β s₂ a₂ b₂ → f a₁ a₂ = f b₁ b₂) : γ :=
 quotient.lift_on₂ q₁ q₂ f h
 
--- I (Buzzard) am reluctant to write "@[elab_as_eliminator, reducible]", not because I know
--- it's wrong, but because I don't really understand these elaborator tags
--- and don't want to write stuff which makes it look like I know what I'm doing;
--- also I note some of these functions below are [reducible] and others aren't.
--- Is `protected` correct?
-protected def ind' {p : quotient s₁ → Prop}
+@[elab_as_eliminator]
+protected lemma ind' {p : quotient s₁ → Prop}
   (h : ∀ a, p (quotient.mk' a)) (q : quotient s₁) : p q :=
 quotient.ind h q
 
--- @[elab_as_eliminator, reducible]? protected?
-protected def ind₂' {p : quotient s₁ → quotient s₂ → Prop}
+@[elab_as_eliminator]
+protected lemma ind₂' {p : quotient s₁ → quotient s₂ → Prop}
   (h : ∀ a₁ a₂, p (quotient.mk' a₁) (quotient.mk' a₂))
   (q₁ : quotient s₁) (q₂ : quotient s₂) : p q₁ q₂ :=
 quotient.ind₂ h q₁ q₂

--- a/src/data/quot.lean
+++ b/src/data/quot.lean
@@ -200,6 +200,21 @@ protected def lift_on₂' (q₁ : quotient s₁) (q₂ : quotient s₂) (f : α 
   (h : ∀ a₁ a₂ b₁ b₂, @setoid.r α s₁ a₁ b₁ → @setoid.r β s₂ a₂ b₂ → f a₁ a₂ = f b₁ b₂) : γ :=
 quotient.lift_on₂ q₁ q₂ f h
 
+-- I (Buzzard) am reluctant to write "@[elab_as_eliminator, reducible]", not because I know
+-- it's wrong, but because I don't really understand these elaborator tags
+-- and don't want to write stuff which makes it look like I know what I'm doing;
+-- also I note some of these functions below are [reducible] and others aren't.
+-- Is `protected` correct?
+protected def ind' {p : quotient s₁ → Prop}
+  (h : ∀ a, p (quotient.mk' a)) (q : quotient s₁) : p q :=
+quotient.ind h q
+
+-- @[elab_as_eliminator, reducible]? protected?
+protected def ind₂' {p : quotient s₁ → quotient s₂ → Prop}
+  (h : ∀ a₁ a₂, p (quotient.mk' a₁) (quotient.mk' a₂))
+  (q₁ : quotient s₁) (q₂ : quotient s₂) : p q₁ q₂ :=
+quotient.ind₂ h q₁ q₂
+
 @[elab_as_eliminator]
 protected lemma induction_on' {p : quotient s₁ → Prop} (q : quotient s₁)
   (h : ∀ a, p (quotient.mk' a)) : p q := quotient.induction_on q h


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)

*****

Zulip discussion: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/quotient.2Einduction_on.20order.20of.20variables

I don't know about the elaborator tags for these quotient.blah functions. Some are tagged reducible and others aren't; many are tagged `elab_as_eliminator`. Many are marked protected. I understand what protected means so I went with it; I do not really understand the practicalities of the elaborator tags so I left them, in order not to give the impression that I know what I'm doing there.