### PR TITLE
Deploy olean

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
   - git clean -d -f -q
   - ./purge_olean.sh
   - rm mathlib.txt || true
+  - travis_long lean -v
 
 jobs:
   include:
@@ -41,18 +42,22 @@ jobs:
         - lean --recursive --export=mathlib.txt src/
         - leanchecker mathlib.txt
       before_deploy:
-        - export TRAVIS_TAG=${TRAVIS_TAG:-bin-$(date +'%Y%m%d-%H%M%S')-$(git log --format=%h -1)}
-        - export ARCHIVE=mathlib-$TRAVIS_TAG.tar.gz
-        - tar -zcvf $ARCHIVE src
+        - export TRAVIS_TAG=${TRAVIS_TAG:$(date +'%Y%m%d-%H%M%S')-$(git log --format=%h -1)}
+        - export OLEAN_ARCHIVE=mathlib-olean-$TRAVIS_TAG.tar.gz
+        - export SCRIPT_ARCHIVE=mathlib-scripts-$TRAVIS_TAG.tar.gz
+        - tar -zcvf $OLEAN_ARCHIVE src
+        - mv scripts mathlib-scripts
+        - tar -zcvf $SCRIPT_ARCHIVE mathlib-scripts
       deploy:
         provider: releases
         overwrite: true
         skip_cleanup: true
         api_key:
           secure: HsAy78hjdJf+jg2yGqD7MWGCn+8K/EceaZ8sZ2U/95Kprmnetc1A5j1T0pgY531pQbjGm6XSbVdn0L0ymuunKo7gIfg3q4+ns6bMCucnxdCrXdJR9/DoUwSLVqJrdFjcigJ58ekMUh1l2g7jIfqJwCAM09FF+dMF09Wh9wVKGK1TYsr6RHZ7NqYlfme6hO+GwBw545NbSHxWEjvNT/8s+T8sMAwMWqjzXm/n/GNUn2TGoRwkwp/BdcQ9V7hKOHX0bbMQXc5RZniVqVnFpnZHx8zTIWJoKnx4HeS5beYN/OcPha6cShqpml3sGaGSUrkWBnQYOzcx28lA4jblYIc84g7lyryLhT2qYB02Fv4C97hyYIppDDdx4Op3NF4IdPqvHazji1pmctWH6muE0z/pJNw5fEX+eNY9djGnexRE8XnVUJigtvh0cUmYRPlb7+6Qza7K6lXzdXflK8TEDYcY9lTHoLw+h8ffFFxKq18yNzvwMoLk9VaA/h2gSCTTjOXrr8s3tLRBNJEjkFWvRAVPaJCbDep5DPf/eK9VEL497xZAfe8YLf1CKlw1ynV7nNb5VB4dPoQFxak/76gDQT/po1l2c/QC4EJe02Degx0+0FG+e2MlY7k/uJb4qndVXdJZQE9DQty0IquHPU0KNISp+VVb7xanh26UtulE/0YdChI=
-        file: "$ARCHIVE"
+        file:
+          - "$OLEAN_ARCHIVE"
+          - "$SCRIPT_ARCHIVE"
         on:
-          # tags: true
           branch: deploy-olean
           repo: leanprover-community/mathlib
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
     - $HOME/.elan
 
 install:
-  - export TRAVIS_TAG=${TRAVIS_TAG:-bin-$(date +'%Y%m%d-%H%M%S')-$(git log --format=%h -1)}
+  # - export TRAVIS_TAG=${TRAVIS_TAG:-bin-$(date +'%Y%m%d-%H%M%S')-$(git log --format=%h -1)}
   - |
     if [ ! -d "$HOME/.elan/toolchains/" ]; then
       curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh -s -- --default-toolchain none -y
@@ -42,9 +42,10 @@ jobs:
         - lean --recursive --export=mathlib.txt src/
         - leanchecker mathlib.txt
       before_deploy:
-        - export TRAVIS_TAG=${TRAVIS_TAG:$(date +'%Y%m%d-%H%M%S')-$(git log --format=%h -1)}
-        - export OLEAN_ARCHIVE=mathlib-olean-$TRAVIS_TAG.tar.gz
-        - export SCRIPT_ARCHIVE=mathlib-scripts-$TRAVIS_TAG.tar.gz
+        - export RELEASE=$(date +'%Y%m%d-%H%M%S')-$(git log --format=%h -1)
+        - export TRAVIS_TAG=${TRAVIS_TAG:-bin-$RELEASE}
+        - export OLEAN_ARCHIVE=mathlib-olean-$RELEASE.tar.gz
+        - export SCRIPT_ARCHIVE=mathlib-scripts-$RELEASE.tar.gz
         - tar -zcvf $OLEAN_ARCHIVE src
         - mv scripts mathlib-scripts
         - tar -zcvf $SCRIPT_ARCHIVE mathlib-scripts
@@ -58,7 +59,7 @@ jobs:
           - "$OLEAN_ARCHIVE"
           - "$SCRIPT_ARCHIVE"
         on:
-          branch: deploy-olean
+          branch: master
           repo: leanprover-community/mathlib
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
     - $HOME/.elan
 
 install:
+  - export TRAVIS_TAG=${TRAVIS_TAG:-bin-$(date +'%Y%m%d-%H%M%S')-$(git log --format=%h -1)}
   - |
     if [ ! -d "$HOME/.elan/toolchains/" ]; then
       curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh -s -- --default-toolchain none -y
@@ -39,6 +40,21 @@ jobs:
         - leanpkg test
         - lean --recursive --export=mathlib.txt src/
         - leanchecker mathlib.txt
+      before_deploy:
+        - export TRAVIS_TAG=${TRAVIS_TAG:-bin-$(date +'%Y%m%d-%H%M%S')-$(git log --format=%h -1)}
+        - export ARCHIVE=mathlib-$TRAVIS_TAG.tar.gz
+        - tar -zcvf $ARCHIVE src
+      deploy:
+        provider: releases
+        overwrite: true
+        skip_cleanup: true
+        api_key:
+          secure: HsAy78hjdJf+jg2yGqD7MWGCn+8K/EceaZ8sZ2U/95Kprmnetc1A5j1T0pgY531pQbjGm6XSbVdn0L0ymuunKo7gIfg3q4+ns6bMCucnxdCrXdJR9/DoUwSLVqJrdFjcigJ58ekMUh1l2g7jIfqJwCAM09FF+dMF09Wh9wVKGK1TYsr6RHZ7NqYlfme6hO+GwBw545NbSHxWEjvNT/8s+T8sMAwMWqjzXm/n/GNUn2TGoRwkwp/BdcQ9V7hKOHX0bbMQXc5RZniVqVnFpnZHx8zTIWJoKnx4HeS5beYN/OcPha6cShqpml3sGaGSUrkWBnQYOzcx28lA4jblYIc84g7lyryLhT2qYB02Fv4C97hyYIppDDdx4Op3NF4IdPqvHazji1pmctWH6muE0z/pJNw5fEX+eNY9djGnexRE8XnVUJigtvh0cUmYRPlb7+6Qza7K6lXzdXflK8TEDYcY9lTHoLw+h8ffFFxKq18yNzvwMoLk9VaA/h2gSCTTjOXrr8s3tLRBNJEjkFWvRAVPaJCbDep5DPf/eK9VEL497xZAfe8YLf1CKlw1ynV7nNb5VB4dPoQFxak/76gDQT/po1l2c/QC4EJe02Degx0+0FG+e2MlY7k/uJb4qndVXdJZQE9DQty0IquHPU0KNISp+VVb7xanh26UtulE/0YdChI=
+        file: "$ARCHIVE"
+        on:
+          # tags: true
+          branch: deploy-olean
+          repo: leanprover-community/mathlib
 
 notifications:
   webhooks:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/leanprover-community/mathlib.svg?branch=master)](https://travis-ci.org/leanprover-community/mathlib)
 
-Lean standard library
+## Lean standard library
 
 Besides [Lean's general documentation](https://leanprover.github.io/documentation/), the documentation of mathlib consists of:
 
@@ -21,7 +21,32 @@ Besides [Lean's general documentation](https://leanprover.github.io/documentatio
 This repository also contains [extra Lean documentation](docs/extras.md)
 not specific to mathlib.
 
-Maintainers (topics):
+## Obtaining binaries
+
+### Install the `update-mathlib`
+
+*Linux/OS X/Cygwin/MSYS2/git bash*: run the following command in a terminal:
+
+``` shell
+curl https://raw.githubusercontent.com/leanprover-community/mathlib/master/remote-install-update-mathlib.sh -sSf | sh
+```
+
+*Any platform*: in the release section of this page, download
+`mathlib-scripts-###-###-###.tar.gz`, expand it and run `setup-update-mathlib.sh`.
+
+### Fetch mathlib binaries
+
+In a terminal, in the directory of a project depending on mathlib, run
+the following:
+
+``` shell
+update-mathlib
+```
+
+The existing `_target/deps/mathlib` will be rewritten with a compiled
+version of mathlib.
+
+## Maintainers (topics):
 
 * Jeremy Avigad (@avigad): analysis
 * Reid Barton (@rwbarton): category theory, topology

--- a/scripts/setup-update-mathlib.sh
+++ b/scripts/setup-update-mathlib.sh
@@ -1,0 +1,3 @@
+#! /bin/sh
+pip3 install toml PyGithub urllib3 certifi
+cp update-mathlib.py /usr/local/bin/update-mathlib

--- a/scripts/update-mathlib.py
+++ b/scripts/update-mathlib.py
@@ -1,0 +1,51 @@
+#! /usr/local/bin/python3
+
+from github import Github
+import toml
+import urllib3
+import certifi
+import os.path
+import os
+import tarfile
+
+
+# find root of project and leanpkg.toml
+cwd = os.getcwd()
+while not os.path.isfile('leanpkg.toml') and not os.getcwd() == '/':
+    os.chdir(os.path.dirname(os.getcwd()))
+if not os.path.isfile('leanpkg.toml'):
+    raise('no leanpkg.toml found')
+
+mathlib_dir = os.path.join( os.environ['HOME'], '.mathlib' )
+if not os.path.isdir(mathlib_dir):
+    os.mkdir(mathlib_dir)
+
+# parse leanpkg.toml
+leanpkg = toml.load('leanpkg.toml')
+lib = leanpkg['dependencies']['mathlib']
+
+# download archive
+if lib['git'] in ['https://github.com/leanprover/mathlib','https://github.com/leanprover-community/mathlib']:
+    rev = lib['rev']
+    hash = rev[:7]
+
+    g = Github()
+    repo = g.get_repo("leanprover-community/mathlib")
+    assets = [r.get_assets() for r in (repo.get_releases())
+                             if r.tag_name.split('-')[3] == hash and r.tag_name.split('-')[0] == 'bin']
+    a = assets[0][0]
+    cd = os.getcwd()
+    os.chdir(mathlib_dir)
+    if not os.path.isfile(a.name):
+        http = urllib3.PoolManager(
+            cert_reqs='CERT_REQUIRED',
+            ca_certs=certifi.where())
+        r = http.request('GET', a.browser_download_url)
+        f = open(a.name,'wb')
+        f.write(r.data)
+        f.close()
+    os.chdir(cd)
+
+    # extract archive
+    ar = tarfile.open(os.path.join(mathlib_dir, a.name))
+    ar.extractall('_target/deps/mathlib')

--- a/scripts/update-mathlib.py
+++ b/scripts/update-mathlib.py
@@ -32,8 +32,10 @@ if lib['git'] in ['https://github.com/leanprover/mathlib','https://github.com/le
     g = Github()
     repo = g.get_repo("leanprover-community/mathlib")
     assets = [r.get_assets() for r in (repo.get_releases())
-                             if r.tag_name.split('-')[3] == hash and r.tag_name.split('-')[0] == 'bin']
-    a = assets[0][0]
+                             if r.tag_name.split('-')[3] == hash and
+                                  r.tag_name.split('-')[0] == 'bin' and
+                                  r.target_commitish == rev ]
+    a = next(x for x in assets[0] if x.name.startswith('mathlib-scripts'))
     cd = os.getcwd()
     os.chdir(mathlib_dir)
     if not os.path.isfile(a.name):


### PR DESCRIPTION
I'm playing with the idea of deploying `olean` files using Travis. Once the Travis config work, I'd like to write a `mathlib.sh` script that one can install so that to fetch the `olean` files for a project depending on mathlib.

I'd like to hear people's thoughts on this.