### PR TITLE
add geometric sum

### DIFF
--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -530,6 +530,32 @@ eq.symm (prod_bij (λ x _, nat.succ x)
 
 end finset
 
+section geom_sum
+open finset
+
+theorem geom_sum_mul_add [semiring α] (x : α) :
+  ∀ (n : ℕ), ((range n).sum (λ i, (x+1)^i)) * x + 1 = (x+1)^n
+| 0     := by simp
+| (n+1) := calc (range (n + 1)).sum (λi, (x + 1) ^ i) * x + 1 =
+        (x + 1)^n * x + (((range n).sum (λ i, (x+1)^i)) * x + 1) :
+    by simp [range_add_one, add_mul]
+  ... = (x + 1)^n * x + (x + 1)^n :
+    by rw geom_sum_mul_add n
+  ... = (x + 1) ^ (n + 1) :
+    by simp [pow_add, mul_add]
+
+theorem geom_sum_mul [ring α] (x : α) (n : ℕ) :
+  ((range n).sum (λ i, x^i)) * (x-1) = x^n-1 :=
+have _ := geom_sum_mul_add (x-1) n,
+by rw [sub_add_cancel] at this; rw [← this, add_sub_cancel]
+
+theorem geom_sum [division_ring α] (x : α) (h : x ≠ 1) (n : ℕ) :
+  (range n).sum (λ i, x^i) = (x^n-1)/(x-1) :=
+have x - 1 ≠ 0, by simp [*, -sub_eq_add_neg, sub_eq_iff_eq_add] at *,
+by rw [← geom_sum_mul, mul_div_cancel _ this]
+
+end geom_sum
+
 section group
 
 open list

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -616,6 +616,9 @@ def range (n : ℕ) : finset ℕ := ⟨_, nodup_range n⟩
 theorem range_succ : range (succ n) = insert n (range n) :=
 eq_of_veq $ (range_succ n).trans $ (ndinsert_of_not_mem not_mem_range_self).symm
 
+theorem range_add_one : range (n + 1) = insert n (range n) :=
+range_succ
+
 @[simp] theorem not_mem_range_self : n ∉ range n := not_mem_range_self
 
 @[simp] theorem range_subset {n m} : range n ⊆ range m ↔ n ≤ m := range_subset


### PR DESCRIPTION
This adds the geometric sum for semiring, ring, and division ring.

It also adds finset.range_add_one as a convenient rewrite rule.

There is a specific version in `specific_limits.lean` (and maybe somewhere else too by @ChrisHughes24 )

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [X] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
