### PR TITLE
feat(algebra/archimedean): add fractional parts of reals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
     - $HOME/.elan
 
 install:
+  # - export TRAVIS_TAG=${TRAVIS_TAG:-bin-$(date +'%Y%m%d-%H%M%S')-$(git log --format=%h -1)}
   - |
     if [ ! -d "$HOME/.elan/toolchains/" ]; then
       curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh -s -- --default-toolchain none -y
@@ -23,6 +24,7 @@ install:
   - git clean -d -f -q
   - ./purge_olean.sh
   - rm mathlib.txt || true
+  - travis_long lean -v
 
 jobs:
   include:
@@ -39,6 +41,26 @@ jobs:
         - leanpkg test
         - lean --recursive --export=mathlib.txt src/
         - leanchecker mathlib.txt
+      before_deploy:
+        - export RELEASE=$(date +'%Y%m%d-%H%M%S')-$(git log --format=%h -1)
+        - export TRAVIS_TAG=${TRAVIS_TAG:-bin-$RELEASE}
+        - export OLEAN_ARCHIVE=mathlib-olean-$RELEASE.tar.gz
+        - export SCRIPT_ARCHIVE=mathlib-scripts-$RELEASE.tar.gz
+        - tar -zcvf $OLEAN_ARCHIVE src
+        - mv scripts mathlib-scripts
+        - tar -zcvf $SCRIPT_ARCHIVE mathlib-scripts
+      deploy:
+        provider: releases
+        overwrite: true
+        skip_cleanup: true
+        api_key:
+          secure: HsAy78hjdJf+jg2yGqD7MWGCn+8K/EceaZ8sZ2U/95Kprmnetc1A5j1T0pgY531pQbjGm6XSbVdn0L0ymuunKo7gIfg3q4+ns6bMCucnxdCrXdJR9/DoUwSLVqJrdFjcigJ58ekMUh1l2g7jIfqJwCAM09FF+dMF09Wh9wVKGK1TYsr6RHZ7NqYlfme6hO+GwBw545NbSHxWEjvNT/8s+T8sMAwMWqjzXm/n/GNUn2TGoRwkwp/BdcQ9V7hKOHX0bbMQXc5RZniVqVnFpnZHx8zTIWJoKnx4HeS5beYN/OcPha6cShqpml3sGaGSUrkWBnQYOzcx28lA4jblYIc84g7lyryLhT2qYB02Fv4C97hyYIppDDdx4Op3NF4IdPqvHazji1pmctWH6muE0z/pJNw5fEX+eNY9djGnexRE8XnVUJigtvh0cUmYRPlb7+6Qza7K6lXzdXflK8TEDYcY9lTHoLw+h8ffFFxKq18yNzvwMoLk9VaA/h2gSCTTjOXrr8s3tLRBNJEjkFWvRAVPaJCbDep5DPf/eK9VEL497xZAfe8YLf1CKlw1ynV7nNb5VB4dPoQFxak/76gDQT/po1l2c/QC4EJe02Degx0+0FG+e2MlY7k/uJb4qndVXdJZQE9DQty0IquHPU0KNISp+VVb7xanh26UtulE/0YdChI=
+        file:
+          - "$OLEAN_ARCHIVE"
+          - "$SCRIPT_ARCHIVE"
+        on:
+          branch: master
+          repo: leanprover-community/mathlib
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: c
 sudo: false
 os:
     - linux
+branches:
+  except:
+    - /^bin-.*$/
+
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ not specific to mathlib.
 
 ## Obtaining binaries
 
-### Install the `update-mathlib`
+### Install the `update-mathlib` script
 
 *Linux/OS X/Cygwin/MSYS2/git bash*: run the following command in a terminal:
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ not specific to mathlib.
 *Linux/OS X/Cygwin/MSYS2/git bash*: run the following command in a terminal:
 
 ``` shell
-curl https://raw.githubusercontent.com/leanprover-community/mathlib/master/remote-install-update-mathlib.sh -sSf | sh
+curl https://raw.githubusercontent.com/leanprover-community/mathlib/master/scripts/remote-install-update-mathlib.sh -sSf | sh
 ```
 
 *Any platform*: in the release section of this page, download
@@ -45,6 +45,17 @@ update-mathlib
 
 The existing `_target/deps/mathlib` will be rewritten with a compiled
 version of mathlib.
+
+### Automatic update of the binaries
+
+The following command, run on each project, sets up an automatic
+update of the mathlib binaries after every `git checkout`.
+
+``` shell
+echo \#! /bin/sh > .git/hooks/post-checkout
+echo update-mathlib >> .git/hooks/post-checkout
+chmod +x .git/hooks/post-checkout
+```
 
 ## Maintainers (topics):
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/leanprover-community/mathlib.svg?branch=master)](https://travis-ci.org/leanprover-community/mathlib)
 
-Lean standard library
+## Lean standard library
 
 Besides [Lean's general documentation](https://leanprover.github.io/documentation/), the documentation of mathlib consists of:
 
@@ -21,7 +21,32 @@ Besides [Lean's general documentation](https://leanprover.github.io/documentatio
 This repository also contains [extra Lean documentation](docs/extras.md)
 not specific to mathlib.
 
-Maintainers (topics):
+## Obtaining binaries
+
+### Install the `update-mathlib`
+
+*Linux/OS X/Cygwin/MSYS2/git bash*: run the following command in a terminal:
+
+``` shell
+curl https://raw.githubusercontent.com/leanprover-community/mathlib/master/remote-install-update-mathlib.sh -sSf | sh
+```
+
+*Any platform*: in the release section of this page, download
+`mathlib-scripts-###-###-###.tar.gz`, expand it and run `setup-update-mathlib.sh`.
+
+### Fetch mathlib binaries
+
+In a terminal, in the directory of a project depending on mathlib, run
+the following:
+
+``` shell
+update-mathlib
+```
+
+The existing `_target/deps/mathlib` will be rewritten with a compiled
+version of mathlib.
+
+## Maintainers (topics):
 
 * Jeremy Avigad (@avigad): analysis
 * Reid Barton (@rwbarton): category theory, topology

--- a/scripts/remote-install-update-mathlib.sh
+++ b/scripts/remote-install-update-mathlib.sh
@@ -2,6 +2,6 @@
 pip3 install toml PyGithub urllib3 certifi
 curl -o update-mathlib.py https://raw.githubusercontent.com/leanprover-community/mathlib/master/scripts/update-mathlib.py
 chmod +x update-mathlib.py
-mkdir $HOME/.mathlib/bin || true
+mkdir -p $HOME/.mathlib/bin || true
 cp update-mathlib.py $HOME/.mathlib/bin/update-mathlib
 echo "export PATH=\"\$HOME/.mathlib/bin:\$PATH\" " >> .profile

--- a/scripts/remote-install-update-mathlib.sh
+++ b/scripts/remote-install-update-mathlib.sh
@@ -2,4 +2,6 @@
 pip3 install toml PyGithub urllib3 certifi
 curl -o update-mathlib.py https://raw.githubusercontent.com/leanprover-community/mathlib/master/scripts/update-mathlib.py
 chmod +x update-mathlib.py
-mv update-mathlib.py /usr/local/bin/update-mathlib
+mkdir $HOME/.mathlib/bin || true
+cp update-mathlib.py $HOME/.mathlib/bin/update-mathlib
+echo "export PATH=\"\$HOME/.mathlib/bin:\$PATH\" " >> .profile

--- a/scripts/remote-install-update-mathlib.sh
+++ b/scripts/remote-install-update-mathlib.sh
@@ -1,0 +1,5 @@
+#! /bin/sh
+pip3 install toml PyGithub urllib3 certifi
+curl -o update-mathlib.py https://raw.githubusercontent.com/leanprover-community/mathlib/master/scripts/update-mathlib.py
+chmod +x update-mathlib.py
+mv update-mathlib.py /usr/local/bin/update-mathlib

--- a/scripts/setup-update-mathlib.sh
+++ b/scripts/setup-update-mathlib.sh
@@ -1,0 +1,3 @@
+#! /bin/sh
+pip3 install toml PyGithub urllib3 certifi
+cp update-mathlib.py /usr/local/bin/update-mathlib

--- a/scripts/setup-update-mathlib.sh
+++ b/scripts/setup-update-mathlib.sh
@@ -1,3 +1,5 @@
 #! /bin/sh
 pip3 install toml PyGithub urllib3 certifi
-cp update-mathlib.py /usr/local/bin/update-mathlib
+mkdir $HOME/.mathlib/bin || true
+cp update-mathlib.py $HOME/.mathlib/bin/update-mathlib
+echo "export PATH=\"\$HOME/.mathlib/bin:\$PATH\" " >> .profile

--- a/scripts/setup-update-mathlib.sh
+++ b/scripts/setup-update-mathlib.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
 pip3 install toml PyGithub urllib3 certifi
-mkdir $HOME/.mathlib/bin || true
+mkdir -p $HOME/.mathlib/bin || true
 cp update-mathlib.py $HOME/.mathlib/bin/update-mathlib
 echo "export PATH=\"\$HOME/.mathlib/bin:\$PATH\" " >> .profile

--- a/scripts/update-mathlib.py
+++ b/scripts/update-mathlib.py
@@ -1,4 +1,4 @@
-#! /usr/local/bin/python3
+#!/usr/bin/env python3
 
 from github import Github
 import toml

--- a/scripts/update-mathlib.py
+++ b/scripts/update-mathlib.py
@@ -31,23 +31,27 @@ if lib['git'] in ['https://github.com/leanprover/mathlib','https://github.com/le
 
     g = Github()
     repo = g.get_repo("leanprover-community/mathlib")
-    assets = [r.get_assets() for r in (repo.get_releases())
+    assets = (r.get_assets() for r in (repo.get_releases())
                              if r.tag_name.endswith(hash) and
                                   r.tag_name.startswith('bin') and
-                                  r.target_commitish == rev ]
-    a = next(x for x in assets[0] if x.name.startswith('mathlib-scripts'))
-    cd = os.getcwd()
-    os.chdir(mathlib_dir)
-    if not os.path.isfile(a.name):
-        http = urllib3.PoolManager(
-            cert_reqs='CERT_REQUIRED',
-            ca_certs=certifi.where())
-        r = http.request('GET', a.browser_download_url)
-        f = open(a.name,'wb')
-        f.write(r.data)
-        f.close()
-    os.chdir(cd)
+                                  r.target_commitish == rev )
+    assets = next(assets,None)
+    if assets:
+        a = next(x for x in assets if x.name.startswith('mathlib-bin'))
+        cd = os.getcwd()
+        os.chdir(mathlib_dir)
+        if not os.path.isfile(a.name):
+            http = urllib3.PoolManager(
+                cert_reqs='CERT_REQUIRED',
+                ca_certs=certifi.where())
+            r = http.request('GET', a.browser_download_url)
+            f = open(a.name,'wb')
+            f.write(r.data)
+            f.close()
+            os.chdir(cd)
 
-    # extract archive
-    ar = tarfile.open(os.path.join(mathlib_dir, a.name))
-    ar.extractall('_target/deps/mathlib')
+            # extract archive
+            ar = tarfile.open(os.path.join(mathlib_dir, a.name))
+            ar.extractall('_target/deps/mathlib')
+    else:
+        print('no olean archive available')

--- a/scripts/update-mathlib.py
+++ b/scripts/update-mathlib.py
@@ -1,0 +1,53 @@
+#! /usr/local/bin/python3
+
+from github import Github
+import toml
+import urllib3
+import certifi
+import os.path
+import os
+import tarfile
+
+
+# find root of project and leanpkg.toml
+cwd = os.getcwd()
+while not os.path.isfile('leanpkg.toml') and not os.getcwd() == '/':
+    os.chdir(os.path.dirname(os.getcwd()))
+if not os.path.isfile('leanpkg.toml'):
+    raise('no leanpkg.toml found')
+
+mathlib_dir = os.path.join( os.environ['HOME'], '.mathlib' )
+if not os.path.isdir(mathlib_dir):
+    os.mkdir(mathlib_dir)
+
+# parse leanpkg.toml
+leanpkg = toml.load('leanpkg.toml')
+lib = leanpkg['dependencies']['mathlib']
+
+# download archive
+if lib['git'] in ['https://github.com/leanprover/mathlib','https://github.com/leanprover-community/mathlib']:
+    rev = lib['rev']
+    hash = rev[:7]
+
+    g = Github()
+    repo = g.get_repo("leanprover-community/mathlib")
+    assets = [r.get_assets() for r in (repo.get_releases())
+                             if r.tag_name.split('-')[3] == hash and
+                                  r.tag_name.split('-')[0] == 'bin' and
+                                  r.target_commitish == rev ]
+    a = next(x for x in assets[0] if x.name.startswith('mathlib-scripts'))
+    cd = os.getcwd()
+    os.chdir(mathlib_dir)
+    if not os.path.isfile(a.name):
+        http = urllib3.PoolManager(
+            cert_reqs='CERT_REQUIRED',
+            ca_certs=certifi.where())
+        r = http.request('GET', a.browser_download_url)
+        f = open(a.name,'wb')
+        f.write(r.data)
+        f.close()
+    os.chdir(cd)
+
+    # extract archive
+    ar = tarfile.open(os.path.join(mathlib_dir, a.name))
+    ar.extractall('_target/deps/mathlib')

--- a/scripts/update-mathlib.py
+++ b/scripts/update-mathlib.py
@@ -32,8 +32,8 @@ if lib['git'] in ['https://github.com/leanprover/mathlib','https://github.com/le
     g = Github()
     repo = g.get_repo("leanprover-community/mathlib")
     assets = [r.get_assets() for r in (repo.get_releases())
-                             if r.tag_name.split('-')[3] == hash and
-                                  r.tag_name.split('-')[0] == 'bin' and
+                             if r.tag_name.endswith(hash) and
+                                  r.tag_name.startswith('bin') and
                                   r.target_commitish == rev ]
     a = next(x for x in assets[0] if x.name.startswith('mathlib-scripts'))
     cd = os.getcwd()

--- a/src/algebra/archimedean.lean
+++ b/src/algebra/archimedean.lean
@@ -5,7 +5,7 @@ Authors: Mario Carneiro
 
 Archimedean groups and fields.
 -/
-import algebra.group_power data.rat tactic.linarith
+import algebra.group_power data.rat tactic.linarith tactic.abel
 
 local infix ` • ` := add_monoid.smul
 
@@ -76,6 +76,79 @@ begin
   have : ((floor x) : α) ≤ x       := floor_le x,
   have : ((floor y) : α) ≤ y       := floor_le y,
   exact abs_sub_lt_iff.2 ⟨by linarith, by linarith⟩
+end
+
+lemma floor_eq_iff {r : α} {z : ℤ} :
+  ⌊r⌋ = z ↔ ↑z ≤ r ∧ r < (z + 1) :=
+by rw [←le_floor, ←int.cast_one, ←int.cast_add, ←floor_lt,
+int.lt_add_one_iff, le_antisymm_iff, and.comm]
+
+/-- The fractional part fract r of r is just r - ⌊r⌋ -/
+def fract (r : α) : α := r - ⌊r⌋
+
+-- Mathematical notation is usually {r}. Let's not even go there.
+-- I have no notation currently.
+
+@[simp] theorem fract_add_floor (r : α) : (⌊r⌋ : α) + fract r = r := by unfold fract;simp
+
+theorem fract_nonneg (r : α) : 0 ≤ fract r :=
+sub_nonneg.2 $ floor_le _
+
+theorem fract_lt_one (r : α) : fract r < 1 :=
+sub_lt.1 $ sub_one_lt_floor _
+
+@[simp] lemma fract_zero : fract (0 : α) = 0 := by unfold fract; simp
+
+@[simp] lemma fract_coe (z : ℤ) : fract (z : α) = 0 :=
+by unfold fract; rw floor_coe; exact sub_self _
+
+@[simp] lemma fract_floor (r : α) : fract (⌊r⌋ : α) = 0 := fract_coe _
+
+@[simp] lemma floor_fract (r : α) : ⌊fract r⌋ = 0 :=
+by rw floor_eq_iff; exact ⟨fract_nonneg _,
+  by rw [int.cast_zero, zero_add]; exact fract_lt_one r⟩
+
+theorem fract_eq_iff {r s : α} : fract r = s ↔ 0 ≤ s ∧ s < 1 ∧ ∃ z : ℤ, r - s = z :=
+⟨λ h, by rw ←h; exact ⟨fract_nonneg _, fract_lt_one _,
+  ⟨⌊r⌋, sub_sub_cancel _ _⟩⟩, begin
+    intro h,
+    show r - ⌊r⌋ = s, apply eq.symm,
+    rw [eq_sub_iff_add_eq, add_comm, ←eq_sub_iff_add_eq],
+    rcases h with ⟨hge, hlt, ⟨z, hz⟩⟩,
+    rw [hz, int.cast_inj, floor_eq_iff, ←hz],
+    clear hz, split; linarith {discharger := `[simp]}
+  end⟩
+
+theorem fract_eq_fract {r s : α} : fract r = fract s ↔ ∃ z : ℤ, r - s = z :=
+⟨λ h, ⟨⌊r⌋ - ⌊s⌋, begin
+  unfold fract at h, rw [int.cast_sub, sub_eq_sub_iff_sub_eq_sub.1 h],
+ end⟩,
+λ h, begin
+  rcases h with ⟨z, hz⟩,
+  rw fract_eq_iff,
+  split, exact fract_nonneg _,
+  split, exact fract_lt_one _,
+  use z + ⌊s⌋,
+  rw [eq_add_of_sub_eq hz, int.cast_add],
+  unfold fract, simp
+end⟩
+
+@[simp] lemma fract_fract (r : α) : fract (fract r) = fract r :=
+by rw fract_eq_fract; exact ⟨-⌊r⌋, by unfold fract;simp⟩
+
+theorem fract_add (r s : α) : ∃ z : ℤ, fract (r + s) - fract r - fract s = z :=
+⟨⌊r⌋ + ⌊s⌋ - ⌊r + s⌋, by unfold fract; simp⟩
+
+theorem fract_mul_nat (r : α) (b : ℕ) : ∃ z : ℤ, fract r * b - fract (r * b) = z :=
+begin
+  induction b with c hc,
+    use 0, simp,
+  rcases hc with ⟨z, hz⟩,
+  rw [nat.succ_eq_add_one, nat.cast_add, mul_add, mul_add, nat.cast_one, mul_one, mul_one],
+  rcases fract_add (r * c) r with ⟨y, hy⟩,
+  use z - y,
+  rw [int.cast_sub, ←hz, ←hy],
+  abel
 end
 
 /-- `ceil x` is the smallest integer `z` such that `x ≤ z` -/

--- a/src/algebra/archimedean.lean
+++ b/src/algebra/archimedean.lean
@@ -89,7 +89,9 @@ def fract (r : α) : α := r - ⌊r⌋
 -- Mathematical notation is usually {r}. Let's not even go there.
 -- I have no notation currently.
 
-@[simp] theorem fract_add_floor (r : α) : (⌊r⌋ : α) + fract r = r := by unfold fract;simp
+@[simp] lemma fract_add_floor (r : α) : (⌊r⌋ : α) + fract r = r := by unfold fract; simp
+
+@[simp] lemma floor_add_fract (r : α) : fract r + ⌊r⌋ = r := sub_add_cancel _ _
 
 theorem fract_nonneg (r : α) : 0 ≤ fract r :=
 sub_nonneg.2 $ floor_le _

--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -530,6 +530,32 @@ eq.symm (prod_bij (λ x _, nat.succ x)
 
 end finset
 
+section geom_sum
+open finset
+
+theorem geom_sum_mul_add [semiring α] (x : α) :
+  ∀ (n : ℕ), ((range n).sum (λ i, (x+1)^i)) * x + 1 = (x+1)^n
+| 0     := by simp
+| (n+1) := calc (range (n + 1)).sum (λi, (x + 1) ^ i) * x + 1 =
+        (x + 1)^n * x + (((range n).sum (λ i, (x+1)^i)) * x + 1) :
+    by simp [range_add_one, add_mul]
+  ... = (x + 1)^n * x + (x + 1)^n :
+    by rw geom_sum_mul_add n
+  ... = (x + 1) ^ (n + 1) :
+    by simp [pow_add, mul_add]
+
+theorem geom_sum_mul [ring α] (x : α) (n : ℕ) :
+  ((range n).sum (λ i, x^i)) * (x-1) = x^n-1 :=
+have _ := geom_sum_mul_add (x-1) n,
+by rw [sub_add_cancel] at this; rw [← this, add_sub_cancel]
+
+theorem geom_sum [division_ring α] (x : α) (h : x ≠ 1) (n : ℕ) :
+  (range n).sum (λ i, x^i) = (x^n-1)/(x-1) :=
+have x - 1 ≠ 0, by simp [*, -sub_eq_add_neg, sub_eq_iff_eq_add] at *,
+by rw [← geom_sum_mul, mul_div_cancel _ this]
+
+end geom_sum
+
 section group
 
 open list

--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -549,10 +549,23 @@ theorem geom_sum_mul [ring α] (x : α) (n : ℕ) :
 have _ := geom_sum_mul_add (x-1) n,
 by rw [sub_add_cancel] at this; rw [← this, add_sub_cancel]
 
-theorem geom_sum [division_ring α] (x : α) (h : x ≠ 1) (n : ℕ) :
+theorem geom_sum [division_ring α] {x : α} (h : x ≠ 1) (n : ℕ) :
   (range n).sum (λ i, x^i) = (x^n-1)/(x-1) :=
 have x - 1 ≠ 0, by simp [*, -sub_eq_add_neg, sub_eq_iff_eq_add] at *,
 by rw [← geom_sum_mul, mul_div_cancel _ this]
+
+lemma geom_sum_inv [division_ring α] {x : α} (hx1 : x ≠ 1) (hx0 : x ≠ 0) (n : ℕ) :
+  (range n).sum (λ m, x⁻¹ ^ m) = (x - 1)⁻¹ * (x - x⁻¹ ^ n * x) :=
+have h₁ : x⁻¹ ≠ 1, by rwa [inv_eq_one_div, ne.def, div_eq_iff_mul_eq hx0, one_mul],
+have h₂ : x⁻¹ - 1 ≠ 0, from mt sub_eq_zero.1 h₁,
+have h₃ : x - 1 ≠ 0, from mt sub_eq_zero.1 hx1,
+have h₄ : x * x⁻¹ ^ n = x⁻¹ ^ n * x,
+  from nat.cases_on n (by simp)
+  (λ _, by conv { to_rhs, rw [pow_succ', mul_assoc, inv_mul_cancel hx0, mul_one] };
+    rw [pow_succ, ← mul_assoc, mul_inv_cancel hx0, one_mul]),
+by rw [geom_sum h₁, div_eq_iff_mul_eq h₂, ← domain.mul_left_inj h₃,
+    ← mul_assoc, ← mul_assoc, mul_inv_cancel h₃];
+  simp [mul_add, add_mul, mul_inv_cancel hx0, mul_assoc, h₄]
 
 end geom_sum
 

--- a/src/algebra/group.lean
+++ b/src/algebra/group.lean
@@ -626,6 +626,10 @@ section add_comm_group
   lemma sub_sub_sub_cancel_left (a b c : α) : (c - a) - (c - b) = b - a :=
   by rw [← neg_sub b c, sub_neg_eq_add, add_comm, sub_add_sub_cancel]
 
+  lemma sub_eq_sub_iff_sub_eq_sub {d : α} :
+  a - b = c - d ↔ a - c = b - d :=
+  ⟨λ h, by rw eq_add_of_sub_eq h; simp, λ h, by rw eq_add_of_sub_eq h; simp⟩
+
 end add_comm_group
 
 section is_conj

--- a/src/algebra/ring.lean
+++ b/src/algebra/ring.lean
@@ -201,6 +201,12 @@ instance integral_domain.to_nonzero_comm_ring (α : Type*) [id : integral_domain
 lemma units.coe_ne_zero [nonzero_comm_ring α] (u : units α) : (u : α) ≠ 0 :=
 λ h : u.1 = 0, by simpa [h, zero_ne_one] using u.3
 
+def nonzero_comm_ring.of_ne [comm_ring α] {x y : α} (h : x ≠ y) : nonzero_comm_ring α :=
+{ one := 1,
+  zero := 0,
+  zero_ne_one := λ h01, h $ by rw [← one_mul x, ← one_mul y, ← h01, zero_mul, zero_mul],
+  ..show comm_ring α, by apply_instance }
+
 /-- A domain is a ring with no zero divisors, i.e. satisfying
   the condition `a * b = 0 ↔ a = 0 ∨ b = 0`. Alternatively, a domain
   is an integral domain without assuming commutativity of multiplication. -/

--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -154,21 +154,6 @@ lemma tendsto_one_div_add_at_top_nhds_0_nat : tendsto (λ n : ℕ, 1 / ((n : ℝ
 suffices tendsto (λ n : ℕ, 1 / (↑(n + 1) : ℝ)) at_top (nhds 0), by simpa,
 tendsto_comp_succ_at_top_iff.2 tendsto_one_div_at_top_nhds_0_nat
 
-lemma sum_geometric' {r : ℝ} (h : r ≠ 0) :
-  ∀{n}, (finset.range n).sum (λi, (r + 1) ^ i) = ((r + 1) ^ n - 1) / r
-| 0     := by simp [zero_div]
-| (n+1) :=
-  by simp [@sum_geometric' n, h, pow_succ, range_succ, add_div_eq_mul_add_div, add_mul, mul_comm, mul_assoc]
-
-lemma sum_geometric {r : ℝ} {n : ℕ} (h : r ≠ 1) :
-  (range n).sum (λi, r ^ i) = (r ^ n - 1) / (r - 1) :=
-calc (range n).sum (λi, r ^ i) = (range n).sum (λi, ((r - 1) + 1) ^ i) :
-    by simp
-  ... = (((r - 1) + 1) ^ n - 1) / (r - 1) :
-    sum_geometric' $ by simp [sub_eq_iff_eq_add, -sub_eq_add_neg, h]
-  ... = (r ^ n - 1) / (r - 1) :
-    by simp
-
 lemma is_sum_geometric {r : ℝ} (h₁ : 0 ≤ r) (h₂ : r < 1) :
   is_sum (λn:ℕ, r ^ n) (1 / (1 - r)) :=
 have r ≠ 1, from ne_of_lt h₂,
@@ -178,7 +163,7 @@ have tendsto (λn, (r ^ n - 1) * (r - 1)⁻¹) at_top (nhds ((0 - 1) * (r - 1)�
   from tendsto_mul
     (tendsto_sub (tendsto_pow_at_top_nhds_0_of_lt_1 h₁ h₂) tendsto_const_nhds) tendsto_const_nhds,
 (is_sum_iff_tendsto_nat_of_nonneg $ pow_nonneg h₁).mpr $
-  by simp [neg_inv, sum_geometric, div_eq_mul_inv, *] at *
+  by simp [neg_inv, geom_sum, div_eq_mul_inv, *] at *
 
 lemma is_sum_geometric_two (a : ℝ) : is_sum (λn:ℕ, (a / 2) / 2 ^ n) a :=
 begin

--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -218,19 +218,19 @@ ext_iff.2 $ begin
   rw [← div_div_eq_div_mul, div_self h, one_div_eq_inv]
 end
 
-lemma inv_zero : (0⁻¹ : ℂ) = 0 :=
+protected lemma inv_zero : (0⁻¹ : ℂ) = 0 :=
 by rw [← of_real_zero, ← of_real_inv, inv_zero]
 
-theorem mul_inv_cancel {z : ℂ} (h : z ≠ 0) : z * z⁻¹ = 1 :=
+protected theorem mul_inv_cancel {z : ℂ} (h : z ≠ 0) : z * z⁻¹ = 1 :=
 by rw [inv_def, ← mul_assoc, mul_conj, ← of_real_mul,
   mul_inv_cancel (mt norm_sq_eq_zero.1 h), of_real_one]
 
 noncomputable instance : discrete_field ℂ :=
 { inv := has_inv.inv,
   zero_ne_one := mt (congr_arg re) zero_ne_one,
-  mul_inv_cancel := @mul_inv_cancel,
-  inv_mul_cancel := λ z h, by rw [mul_comm, mul_inv_cancel h],
-  inv_zero := inv_zero,
+  mul_inv_cancel := @complex.mul_inv_cancel,
+  inv_mul_cancel := λ z h, by rw [mul_comm, complex.mul_inv_cancel h],
+  inv_zero := complex.inv_zero,
   has_decidable_eq := classical.dec_eq _,
   ..complex.comm_ring }
 

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -14,22 +14,6 @@ open is_absolute_value
 section
 open real is_absolute_value finset
 
-lemma geo_sum_eq {α : Type*} [field α] {x : α} : ∀ (n : ℕ) (hx1 : x ≠ 1),
-  (range n).sum (λ m, x ^ m) = (1 - x ^ n) / (1 - x)
-| 0     hx1 := by simp
-| (n+1) hx1 := have 1 - x ≠ 0 := mt sub_eq_zero_iff_eq.1 hx1.symm,
-by rw [sum_range_succ, ← mul_div_cancel (x ^ n) this, geo_sum_eq n hx1, ← add_div, _root_.pow_succ];
-    simp [mul_add, add_mul, mul_comm]
-
-lemma geo_sum_inv_eq {α : Type*} [discrete_field α] {x : α} (n : ℕ) (hx1 : x ≠ 1) (hx0 : x ≠ 0) :
-  (range n).sum (λ m, x⁻¹ ^ m) = (x - x * x⁻¹ ^ n) / (x - 1) :=
-have hx1' : x⁻¹ ≠ 1, from λ h, by rw [← @inv_inv' _ _ x, h] at hx1; simpa using hx1,
-have h1x' : 1 - x⁻¹ ≠ 0, from sub_ne_zero.2 hx1'.symm,
-have h1x : x - 1 ≠ 0, from sub_ne_zero.2 hx1,
-by rw [geo_sum_eq _ hx1', div_eq_div_iff h1x' h1x];
-  simp [mul_add, add_mul, mul_inv_cancel hx0, mul_comm x, mul_left_comm x,
-    mul_assoc, inv_mul_cancel hx0]
-
 lemma forall_ge_le_of_forall_le_succ {α : Type*} [preorder α] (f : ℕ → α) {m : ℕ}
   (h : ∀ n ≥ m, f n.succ ≤ f n) : ∀ {l}, ∀ k ≥ m, k ≤ l → f l ≤ f k :=
 begin
@@ -122,10 +106,11 @@ lemma is_cau_geo_series {β : Type*} [field β] {abv : β → α} [is_absolute_v
 have hx1' : abv x ≠ 1 := λ h, by simpa [h, lt_irrefl] using hx1,
 is_cau_series_of_abv_cau
 begin
-  simp only [abv_pow abv, geo_sum_eq _ hx1'] {eta := ff},
+  simp only [abv_pow abv, geom_sum hx1'] {eta := ff},
+  conv in (_ / _) { rw [← neg_div_neg_eq, neg_sub, neg_sub] },
   refine @is_cau_of_mono_bounded _ _ _ _ ((1 : α) / (1 - abv x)) 0 _ _,
   { assume n hn,
-    rw abs_of_nonneg ,
+    rw abs_of_nonneg,
     refine div_le_div_of_le_of_pos (sub_le_self _ (abv_pow abv x n ▸ abv_nonneg _ _))
       (sub_pos.2 hx1),
     refine div_nonneg (sub_nonneg.2 _) (sub_pos.2 hx1),
@@ -877,12 +862,11 @@ calc (filter (λ k, n ≤ k) (range j)).sum (λ m : ℕ, (1 / m.fact : α))
   have h₂ : (n.succ : α) ≠ 0, from nat.cast_ne_zero.2 (nat.succ_ne_zero _),
   have h₃ : (n.fact * n : α) ≠ 0, from mul_ne_zero (nat.cast_ne_zero.2 (nat.pos_iff_ne_zero.1 (nat.fact_pos _)))
     (nat.cast_ne_zero.2 (nat.pos_iff_ne_zero.1 hn)),
-  have h₄ : (n.succ - 1 : α) * (n.fact : ℕ) ≠ 0,
-    from mul_ne_zero (sub_ne_zero.2 h₁)
-      (nat.cast_ne_zero.2 (nat.pos_iff_ne_zero.1 (nat.fact_pos _))),
-  by rw [geo_sum_inv_eq _ h₁ h₂, mul_comm, ← div_eq_mul_inv, div_div_eq_div_mul,
-      div_eq_div_iff h₄ h₃];
-    simp [mul_add, add_mul, mul_comm, mul_assoc, mul_left_comm]
+  have h₄ : (n.succ - 1 : α) = n, by simp,
+  by rw [geom_sum_inv h₁ h₂, eq_div_iff_mul_eq _ _ h₃, mul_comm _ (n.fact * n : α),
+      ← mul_assoc (n.fact⁻¹ : α), ← mul_inv', h₄, ← mul_assoc (n.fact * n : α),
+      mul_comm (n : α) n.fact, mul_inv_cancel h₃];
+    simp [mul_add, add_mul, mul_assoc, mul_comm]
 ... ≤ n.succ / (n.fact * n) :
   begin
     refine (div_le_div_right (mul_pos _ _)).2 _,

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -616,6 +616,9 @@ def range (n : ℕ) : finset ℕ := ⟨_, nodup_range n⟩
 theorem range_succ : range (succ n) = insert n (range n) :=
 eq_of_veq $ (range_succ n).trans $ (ndinsert_of_not_mem not_mem_range_self).symm
 
+theorem range_add_one : range (n + 1) = insert n (range n) :=
+range_succ
+
 @[simp] theorem not_mem_range_self : n ∉ range n := not_mem_range_self
 
 @[simp] theorem range_subset {n m} : range n ⊆ range m ↔ n ≤ m := range_subset

--- a/src/data/polynomial.lean
+++ b/src/data/polynomial.lean
@@ -891,6 +891,44 @@ decidable.by_cases
     by rw [leading_coeff_mul', leading_coeff_X_pow, mul_one];
       rwa [leading_coeff_X_pow, mul_one])
 
+lemma monic_mul (hp : monic p) (hq : monic q) : monic (p * q) :=
+if h0 : (0 : α) = 1 then by haveI := subsingleton_of_zero_eq_one _ h0;
+  exact subsingleton.elim _ _
+else
+  have leading_coeff p * leading_coeff q ≠ 0, by simp [monic.def.1 hp, monic.def.1 hq, ne.symm h0],
+  by rw [monic.def, leading_coeff_mul' this, monic.def.1 hp, monic.def.1 hq, one_mul]
+
+lemma monic_pow (hp : monic p) : ∀ (n : ℕ), monic (p ^ n)
+| 0     := monic_one
+| (n+1) := monic_mul hp (monic_pow n)
+
+lemma multiplicity_finite_of_degree_pos_of_monic (hp : (0 : with_bot ℕ) < degree p)
+  (hmp : monic p) (hq : q ≠ 0) : multiplicity.finite p q :=
+have zn0 : (0 : α) ≠ 1, from λ h, by haveI := subsingleton_of_zero_eq_one _ h;
+  exact hq (subsingleton.elim _ _),
+⟨nat_degree q, λ ⟨r, hr⟩,
+  have hp0 : p ≠ 0, from λ hp0, by simp [hp0] at hp; contradiction,
+  have hr0 : r ≠ 0, from λ hr0, by simp * at *,
+  have hpn1 : leading_coeff p ^ (nat_degree q + 1) = 1,
+    by simp [show _ = _, from hmp],
+  have hpn0' : leading_coeff p ^ (nat_degree q + 1) ≠ 0,
+    from hpn1.symm ▸ zn0.symm,
+  have hpnr0 : leading_coeff (p ^ (nat_degree q + 1)) * leading_coeff r ≠ 0,
+    by simp only [leading_coeff_pow' hpn0', leading_coeff_eq_zero, hpn1,
+      one_pow, one_mul, ne.def, hr0]; simp,
+  have hpn0 : p ^ (nat_degree q + 1) ≠ 0,
+    from mt leading_coeff_eq_zero.2 $
+      by rw [leading_coeff_pow' hpn0', show _ = _, from hmp, one_pow]; exact zn0.symm,
+  have hnp : 0 < nat_degree p,
+    by rw [← with_bot.coe_lt_coe, ← degree_eq_nat_degree hp0];
+    exact hp,
+  begin
+    have := congr_arg nat_degree hr,
+    rw [nat_degree_mul_eq' hpnr0,  nat_degree_pow_eq' hpn0', add_mul, add_assoc] at this,
+    exact ne_of_lt (lt_add_of_le_of_pos (le_mul_of_ge_one_right' (nat.zero_le _) hnp)
+      (add_pos_of_pos_of_nonneg (by rwa one_mul) (nat.zero_le _))) this
+  end⟩
+
 end comm_semiring
 
 section comm_ring
@@ -1263,6 +1301,13 @@ decidable.by_cases
 lemma root_X_sub_C : is_root (X - C a) b ↔ a = b :=
 by rw [is_root.def, eval_sub, eval_X, eval_C, sub_eq_zero_iff_eq, eq_comm]
 
+def nonzero_comm_ring.of_polynomial_ne (h : p ≠ q) : nonzero_comm_ring α :=
+{ zero := 0,
+  one := 1,
+  zero_ne_one := λ h01, h $
+    by rw [← one_mul p, ← one_mul q, ← C_1, ← h01, C_0, zero_mul, zero_mul],
+  ..show comm_ring α, by apply_instance }
+
 end comm_ring
 
 section nonzero_comm_ring
@@ -1333,7 +1378,7 @@ variables [comm_ring α] [decidable_eq α] {p q : polynomial α}
 @[simp] lemma mod_by_monic_X_sub_C_eq_C_eval (p : polynomial α) (a : α) : p %ₘ (X - C a) = C (p.eval a) :=
 if h0 : (0 : α) = 1 then by letI := subsingleton_of_zero_eq_one α h0; exact subsingleton.elim _ _
 else
-by letI : nonzero_comm_ring α := {zero_ne_one := h0, ..show comm_ring α, from infer_instance}; exact
+by letI : nonzero_comm_ring α := nonzero_comm_ring.of_ne h0; exact
 have h : (p %ₘ (X - C a)).eval a = p.eval a :=
   by rw [mod_by_monic_eq_sub_mul_div _ (monic_X_sub_C a), eval_sub, eval_mul,
     eval_sub, eval_X, eval_C, sub_self, zero_mul, sub_zero],
@@ -1364,6 +1409,69 @@ lemma dvd_iff_is_root : (X - C a) ∣ p ↔ is_root p a :=
 
 lemma mod_by_monic_X (p : polynomial α) : p %ₘ X = C (p.eval 0) :=
 by rw [← mod_by_monic_X_sub_C_eq_C_eval, C_0, sub_zero]
+
+section multiplicity
+
+def decidable_dvd_monic (p : polynomial α) (hq : monic q): decidable (q ∣ p) :=
+decidable_of_iff (p %ₘ q = 0) (dvd_iff_mod_by_monic_eq_zero hq)
+
+local attribute [instance, priority 0] classical.dec
+
+lemma multiplicity_X_sub_C_finite (a : α) (h0 : p ≠ 0) :
+  multiplicity.finite (X - C a) p :=
+multiplicity_finite_of_degree_pos_of_monic
+  (have (0 : α) ≠ 1, from (λ h, by haveI := subsingleton_of_zero_eq_one _ h;
+      exact h0 (subsingleton.elim _ _)),
+    by letI : nonzero_comm_ring α := { zero_ne_one := this, ..show comm_ring α, by apply_instance };
+      rw degree_X_sub_C; exact dec_trivial)
+    (monic_X_sub_C _) h0
+
+def root_multiplicity (a : α) (p : polynomial α) : ℕ :=
+if h0 : p = 0 then 0
+else let I : decidable_pred (λ n : ℕ, ¬(X - C a) ^ (n + 1) ∣ p) :=
+  λ n, @not.decidable _ (decidable_dvd_monic p (monic_pow (monic_X_sub_C a) (n + 1))) in
+by exactI nat.find (multiplicity_X_sub_C_finite a h0)
+
+lemma root_multiplicity_eq_multiplicity (p : polynomial α) (a : α) :
+  root_multiplicity a p = if h0 : p = 0 then 0 else
+  (multiplicity (X - C a) p).get (multiplicity_X_sub_C_finite a h0) :=
+by simp [multiplicity, root_multiplicity, roption.dom];
+  congr; funext; congr
+
+lemma pow_root_multiplicity_dvd (p : polynomial α) (a : α) :
+  (X - C a) ^ root_multiplicity a p ∣ p :=
+if h : p = 0 then by simp [h]
+else by rw [root_multiplicity_eq_multiplicity, dif_neg h];
+  exact multiplicity.pow_multiplicity_dvd _
+
+lemma div_by_monic_mul_pow_root_multiplicity_eq
+  (p : polynomial α) (a : α) :
+  p /ₘ ((X - C a) ^ root_multiplicity a p) *
+  (X - C a) ^ root_multiplicity a p = p :=
+have monic ((X - C a) ^ root_multiplicity a p),
+  from monic_pow (monic_X_sub_C _) _,
+by conv_rhs { rw [← mod_by_monic_add_div p this,
+    (dvd_iff_mod_by_monic_eq_zero this).2 (pow_root_multiplicity_dvd _ _)] };
+  simp [mul_comm]
+
+lemma eval_div_by_monic_pow_root_multiplicity_ne_zero
+  {p : polynomial α} (a : α) (hp : p ≠ 0) :
+  (p /ₘ ((X - C a) ^ root_multiplicity a p)).eval a ≠ 0 :=
+begin
+  letI : nonzero_comm_ring α := nonzero_comm_ring.of_polynomial_ne hp,
+  rw [ne.def, ← is_root.def, ← dvd_iff_is_root],
+  rintros ⟨q, hq⟩,
+  have := div_by_monic_mul_pow_root_multiplicity_eq p a,
+  rw [mul_comm, hq, ← mul_assoc, ← pow_succ',
+    root_multiplicity_eq_multiplicity, dif_neg hp] at this,
+  exact multiplicity.is_greatest'
+    (multiplicity_finite_of_degree_pos_of_monic
+    (show (0 : with_bot ℕ) < degree (X - C a),
+      by rw degree_X_sub_C; exact dec_trivial) _ hp)
+    (nat.lt_succ_self _) (dvd_of_mul_right_eq _ this)
+end
+
+end multiplicity
 
 end comm_ring
 


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)

***********************************

My PR #684 conflicted with another recent PR and I must have got the merge/rebase thing all wrong. I closed that PR, and this is a second attempt. I made all changes requested at that PR.

************************************

This is a theory of fractional parts of reals and more general floor_rings, i.e. fract r := r - floor r. 

Note that I've added another import, `abel`, to algebra/archimedean.lean; `linarith` imports `ring` but I can't use `ring` because a `floor_ring` is not necessarily commutative. Without this import I would have to directly prove something of the form a+(b+c)-(b-a)=c, that sort of thing, which I could do but didn't.