### PR TITLE
feat(big_operators): reindexing products/sums over Ico

### DIFF
--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -713,6 +713,10 @@ finset.ext' $ by simp
         finset.union_idempotent] }
   end
 
+@[simp] lemma to_finset_inter (s t : multiset α) :
+  to_finset (s ∩ t) = to_finset s ∩ to_finset t :=
+finset.ext' $ by simp
+
 end multiset
 
 namespace list
@@ -1247,6 +1251,10 @@ by unfold fold; rw [insert_val, ndinsert_of_not_mem h, map_cons, fold_cons_left]
 
 @[simp] theorem fold_singleton : (singleton a).fold op b f = f a * b := rfl
 
+@[simp] theorem fold_map [decidable_eq α] {g : γ ↪ α} {s : finset γ} :
+  (s.map g).fold op b f = s.fold op b (f ∘ g) :=
+by simp only [fold, map, multiset.map_map]
+
 @[simp] theorem fold_image [decidable_eq α] {g : γ → α} {s : finset γ}
   (H : ∀ (x ∈ s) (y ∈ s), g x = g y → x = y) : (s.image g).fold op b f = s.fold op b (f ∘ g) :=
 by simp only [fold, image_val_of_inj_on H, multiset.map_map]
@@ -1716,8 +1724,15 @@ namespace Ico
 @[simp] theorem to_finset (n m : ℕ) : (multiset.Ico n m).to_finset = Ico n m :=
 (multiset.to_finset_eq _).symm
 
-theorem map_add (n m k : ℕ) : (Ico n m).image ((+) k) = Ico (n + k) (m + k) :=
+theorem image_add (n m k : ℕ) : (Ico n m).image ((+) k) = Ico (n + k) (m + k) :=
 by simp [image, multiset.Ico.map_add]
+
+theorem image_sub (n m k : ℕ) (h : k ≤ n): (Ico n m).image (λ x, x - k) = Ico (n - k) (m - k) :=
+begin
+  dsimp [image],
+  rw [multiset.Ico.map_sub _ _ _ h, ←multiset.to_finset_eq],
+  refl,
+end
 
 theorem zero_bot (n : ℕ) : Ico 0 n = range n :=
 eq_of_veq $ multiset.Ico.zero_bot _
@@ -1742,16 +1757,30 @@ lemma union_consecutive {n m l : ℕ} (hnm : n ≤ m) (hml : m ≤ l) :
 by rw [← to_finset, ← to_finset, ← multiset.to_finset_add,
   multiset.Ico.add_consecutive hnm hml, to_finset]
 
+@[simp] lemma inter_consecutive {n m l : ℕ} : Ico n m ∩ Ico m l = ∅ :=
+begin
+  rw [← to_finset, ← to_finset, ← multiset.to_finset_inter, multiset.Ico.inter_consecutive],
+  simp,
+end
+
 @[simp] theorem succ_singleton {n : ℕ} : Ico n (n+1) = {n} :=
 eq_of_veq $ multiset.Ico.succ_singleton
 
 theorem succ_top {n m : ℕ} (h : n ≤ m) : Ico n (m + 1) = insert m (Ico n m) :=
 by rw [← to_finset, multiset.Ico.succ_top h, multiset.to_finset_cons, to_finset]
 
+theorem succ_top' {n m : ℕ} (h : n < m) : Ico n m = insert (m - 1) (Ico n (m - 1)) :=
+begin
+  have w : m = m - 1 + 1 := (nat.sub_add_cancel (nat.one_le_of_lt h)).symm,
+  conv { to_lhs, rw w },
+  rw succ_top,
+  exact nat.le_pred_of_lt h
+end
+
 theorem eq_cons {n m : ℕ} (h : n < m) : Ico n m = insert n (Ico (n + 1) m) :=
 by rw [← to_finset, multiset.Ico.eq_cons h, multiset.to_finset_cons, to_finset]
 
-theorem pred_singleton {m : ℕ} (h : m > 0) : Ico (m - 1) m = {m - 1} :=
+@[simp] theorem pred_singleton {m : ℕ} (h : m > 0) : Ico (m - 1) m = {m - 1} :=
 eq_of_veq $ multiset.Ico.pred_singleton h
 
 @[simp] theorem not_mem_top {n m : ℕ} : m ∉ Ico n m :=

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -1823,6 +1823,9 @@ quotient.induction_on₂ s t $ λ l₁ l₂, quotient.eq.trans perm_iff_count
 theorem ext' {s t : multiset α} : (∀ a, count a s = count a t) → s = t :=
 ext.2
 
+@[simp] theorem coe_inter (s t : list α) : (s ∩ t : multiset α) = (s.bag_inter t : list α) :=
+by ext; simp
+
 theorem le_iff_count {s t : multiset α} : s ≤ t ↔ ∀ a, count a s ≤ count a t :=
 ⟨λ h a, count_le_of_le a h, λ al,
  by rw ← (ext.2 (λ a, by simp [max_eq_right (al a)]) : s ∪ t = t);
@@ -2988,6 +2991,9 @@ namespace Ico
 theorem map_add (n m k : ℕ) : (Ico n m).map ((+) k) = Ico (n + k) (m + k) :=
 congr_arg coe $ list.Ico.map_add _ _ _
 
+theorem map_sub (n m k : ℕ) (h : k ≤ n) : (Ico n m).map (λ x, x - k) = Ico (n - k) (m - k) :=
+congr_arg coe $ list.Ico.map_sub _ _ _ h
+
 theorem zero_bot (n : ℕ) : Ico 0 n = range n :=
 congr_arg coe $ list.Ico.zero_bot _
 
@@ -3012,6 +3018,9 @@ lemma add_consecutive {n m l : ℕ} (hnm : n ≤ m) (hml : m ≤ l) :
   Ico n m + Ico m l = Ico n l :=
 congr_arg coe $ list.Ico.append_consecutive hnm hml
 
+@[simp] lemma inter_consecutive (n m l : ℕ) : Ico n m ∩ Ico m l = 0 :=
+congr_arg coe $ list.Ico.bag_inter_consecutive n m l
+
 @[simp] theorem succ_singleton {n : ℕ} : Ico n (n+1) = {n} :=
 congr_arg coe $ list.Ico.succ_singleton
 
@@ -3021,7 +3030,7 @@ by rw [Ico, list.Ico.succ_top h, ← coe_add, add_comm]; refl
 theorem eq_cons {n m : ℕ} (h : n < m) : Ico n m = n :: Ico (n + 1) m :=
 congr_arg coe $ list.Ico.eq_cons h
 
-theorem pred_singleton {m : ℕ} (h : m > 0) : Ico (m - 1) m = {m - 1} :=
+@[simp] theorem pred_singleton {m : ℕ} (h : m > 0) : Ico (m - 1) m = {m - 1} :=
 congr_arg coe $ list.Ico.pred_singleton h
 
 @[simp] theorem not_mem_top {n m : ℕ} : m ∉ Ico n m :=

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -40,6 +40,19 @@ by rw [← sub_one, nat.sub_sub, one_add]; refl
 
 lemma pred_eq_sub_one (n : ℕ) : pred n = n - 1 := rfl
 
+lemma sub_sub_sub_cancel_right {a b c : ℕ} (h₂ : c ≤ b) : (a - c) - (b - c) = a - b :=
+by rw [nat.sub_sub, ←nat.add_sub_assoc h₂, nat.add_sub_cancel_left]
+
+lemma one_le_of_lt {n m : ℕ} (h : n < m) : 1 ≤ m :=
+lt_of_le_of_lt (nat.zero_le _) h
+
+lemma le_pred_of_lt {n m : ℕ} (h : m < n) : m ≤ n - 1 :=
+nat.sub_le_sub_right h 1
+
+/-- This ensures that `simp` succeeds on `pred (n + 1) = n`. -/
+@[simp] lemma nat.pred_one_add (n : ℕ) : pred (1 + n) = n :=
+by rw [add_comm, add_one, pred_succ]
+
 theorem pos_iff_ne_zero : n > 0 ↔ n ≠ 0 :=
 ⟨ne_of_gt, nat.pos_of_ne_zero⟩
 

--- a/test/reindex_finset_sum.lean
+++ b/test/reindex_finset_sum.lean
@@ -1,0 +1,45 @@
+import algebra.big_operators
+import data.nat.choose
+import tactic.linarith
+
+open finset
+
+lemma choose_sum : Π (n : ℕ), (range (n + 1)).sum (λ m, choose n m) = 2^n
+| 0 := by simp
+| (n+1) :=
+begin
+  have h : ∀ x ∈ Ico 1 (n + 1), choose n ((x - 1) + 1) = choose n x,
+  { intros x w,
+    simp at w,
+    replace w := w.left,
+    congr,
+    cases x, linarith, simp [add_comm], },
+
+  calc
+    (range (n + 2)).sum (λ m, choose (n + 1) m)
+        = sum (Ico 0 (n + 2)) (λ (m : ℕ), choose (n + 1) m) : by rw ←Ico.zero_bot
+    ... = choose (n + 1) 0 + sum (Ico 1 (n + 2)) (λ (m : ℕ), choose (n + 1) m) :
+            by rw Ico_sum_split_first; linarith
+    ... = choose (n + 1) 0 + sum (Ico 0 (n + 2 - 1)) (λ (x : ℕ), choose (n + 1) (x + 1)) :
+            by rw Ico_sum_reindex_left 1; linarith
+    ... = 1 + sum (Ico 0 (n + 1)) (λ (x : ℕ), choose n (x + 1) + choose n x) :
+            by simp [choose_succ_succ]
+    ... = 1 + (sum (Ico 0 (n + 1)) (λ (x : ℕ), choose n (x + 1))
+            + sum (Ico 0 (n + 1)) (λ (x : ℕ), choose n x)) :
+            by rw sum_add_distrib
+    ... = 1 + (sum (Ico 1 (n + 2)) (λ (x : ℕ), choose n (x - 1 + 1))
+            + sum (Ico 0 (n + 1)) (λ (x : ℕ), choose n x)) :
+            by rw Ico_sum_reindex_right 1
+    ... = 1 + (sum (Ico 1 (n + 1)) (λ (x : ℕ), choose n (x - 1 + 1))
+            + sum (Ico 0 (n + 1)) (choose n)) :
+            begin rw Ico_sum_split_last, simp, linarith end
+    ... = 1 + (sum (Ico 1 (n + 1)) (λ (x : ℕ), choose n x)
+            + sum (Ico 0 (n + 1)) (choose n)) :
+            by rw sum_congr (eq.refl _) h
+    ... = choose n 0 + (sum (Ico 1 (n + 1)) (λ (x : ℕ), choose n x)
+            + sum (Ico 0 (n + 1)) (choose n)) :
+            by conv { to_lhs, congr, rw ← choose_zero_right n }
+    ... = sum (Ico 0 (n + 1)) (λ (x : ℕ), choose n x) + sum (Ico 0 (n + 1)) (λ (x : ℕ), choose n x) :
+            by rw [←add_assoc, ←Ico_sum_split_first]; linarith; simp
+    ... = 2^(n + 1) : by rw [Ico.zero_bot, choose_sum, nat.pow_succ]; ring
+end


### PR DESCRIPTION
Some lemmas that allow reindexing and splitting sums over `Ico` (closed-open intervals in nat).