### PR TITLE
Automate the deployment of nightly builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,29 @@
 language: c
 sudo: false
+go:
+- 1.11.x
 os:
     - linux
+addons:
+    packages:
+        - python3.4
 branches:
   except:
-    - /^bin-.*$/
-
+    - /^lean-.*$/
 
 cache:
   directories:
-    - $TRAVIS_BUILD_DIR/*/
+    - $TRAVIS_BUILD_DIR/test/
+    - $TRAVIS_BUILD_DIR/src/
     - $HOME/.elan
 
+before_install:
+  - python3.4 -m venv .venv --without-pip
+  - curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+  - .venv/bin/python get-pip.py
+
 install:
-  # - export TRAVIS_TAG=${TRAVIS_TAG:-bin-$(date +'%Y%m%d-%H%M%S')-$(git log --format=%h -1)}
+  - .venv/bin/python -m pip install toml
   - |
     if [ ! -d "$HOME/.elan/toolchains/" ]; then
       curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh -s -- --default-toolchain none -y
@@ -28,7 +38,6 @@ install:
   - git clean -d -f -q
   - ./purge_olean.sh
   - rm mathlib.txt || true
-  - travis_long lean -v
 
 jobs:
   include:
@@ -45,26 +54,7 @@ jobs:
         - leanpkg test
         - lean --recursive --export=mathlib.txt src/
         - leanchecker mathlib.txt
-      before_deploy:
-        - export RELEASE=$(date +'%Y%m%d-%H%M%S')-$(git log --format=%h -1)
-        - export TRAVIS_TAG=${TRAVIS_TAG:-bin-$RELEASE}
-        - export OLEAN_ARCHIVE=mathlib-olean-$RELEASE.tar.gz
-        - export SCRIPT_ARCHIVE=mathlib-scripts-$RELEASE.tar.gz
-        - tar -zcvf $OLEAN_ARCHIVE src
-        - mv scripts mathlib-scripts
-        - tar -zcvf $SCRIPT_ARCHIVE mathlib-scripts
-      deploy:
-        provider: releases
-        overwrite: true
-        skip_cleanup: true
-        api_key:
-          secure: HsAy78hjdJf+jg2yGqD7MWGCn+8K/EceaZ8sZ2U/95Kprmnetc1A5j1T0pgY531pQbjGm6XSbVdn0L0ymuunKo7gIfg3q4+ns6bMCucnxdCrXdJR9/DoUwSLVqJrdFjcigJ58ekMUh1l2g7jIfqJwCAM09FF+dMF09Wh9wVKGK1TYsr6RHZ7NqYlfme6hO+GwBw545NbSHxWEjvNT/8s+T8sMAwMWqjzXm/n/GNUn2TGoRwkwp/BdcQ9V7hKOHX0bbMQXc5RZniVqVnFpnZHx8zTIWJoKnx4HeS5beYN/OcPha6cShqpml3sGaGSUrkWBnQYOzcx28lA4jblYIc84g7lyryLhT2qYB02Fv4C97hyYIppDDdx4Op3NF4IdPqvHazji1pmctWH6muE0z/pJNw5fEX+eNY9djGnexRE8XnVUJigtvh0cUmYRPlb7+6Qza7K6lXzdXflK8TEDYcY9lTHoLw+h8ffFFxKq18yNzvwMoLk9VaA/h2gSCTTjOXrr8s3tLRBNJEjkFWvRAVPaJCbDep5DPf/eK9VEL497xZAfe8YLf1CKlw1ynV7nNb5VB4dPoQFxak/76gDQT/po1l2c/QC4EJe02Degx0+0FG+e2MlY7k/uJb4qndVXdJZQE9DQty0IquHPU0KNISp+VVb7xanh26UtulE/0YdChI=
-        file:
-          - "$OLEAN_ARCHIVE"
-          - "$SCRIPT_ARCHIVE"
-        on:
-          branch: master
-          repo: leanprover-community/mathlib
+        - sh scripts/deploy_nightly.sh
 
 notifications:
   webhooks:

--- a/scripts/deploy_nightly.sh
+++ b/scripts/deploy_nightly.sh
@@ -20,7 +20,6 @@ go get github.com/itchio/gothub
 HEAD=`git rev-parse --abbrev-ref HEAD`
 if [ $HEAD = "master" ] && git tag $MATHLIB_VERSION_STRING
 then
-    last_tag=$(git describe @^ --abbrev=0 --tags)
     export OLEAN_ARCHIVE=mathlib-olean-$MATHLIB_VERSION_STRING.tar.gz
     export SCRIPT_ARCHIVE=mathlib-scripts-$MATHLIB_VERSION_STRING.tar.gz
     tar -zcvf $OLEAN_ARCHIVE src > /dev/null
@@ -28,7 +27,7 @@ then
     cp scripts/* mathlib-scripts/
     tar -zcvf $SCRIPT_ARCHIVE mathlib-scripts > /dev/null
     ls *.tar.gz
-    gothub release -s $GITHUB_TOKEN -u leanprover-community -r mathlib-nightly -t $MATHLIB_VERSION_STRING -d "some description" --pre-release
+    gothub release -s $GITHUB_TOKEN -u leanprover-community -r mathlib-nightly -t $MATHLIB_VERSION_STRING -d "Mathlib's .olean files and scripts" --pre-release
     gothub upload -s $GITHUB_TOKEN -u leanprover-community -r mathlib-nightly -t $MATHLIB_VERSION_STRING -n "$(basename $OLEAN_ARCHIVE)" -f "$OLEAN_ARCHIVE"
     gothub upload -s $GITHUB_TOKEN -u leanprover-community -r mathlib-nightly -t $MATHLIB_VERSION_STRING -n "$(basename $SCRIPT_ARCHIVE)" -f "$SCRIPT_ARCHIVE"
 

--- a/scripts/deploy_nightly.sh
+++ b/scripts/deploy_nightly.sh
@@ -1,0 +1,38 @@
+
+git remote add mathlib "https://$GITHUB_TOKEN@github.com/leanprover-community/mathlib.git"
+git remote add nightly "https://$GITHUB_TOKEN@github.com/leanprover-community/mathlib-nightly.git"
+git fetch nightly --tags
+
+export MATHLIB_VERSION_STRING="nightly-$(date -u +%F)"
+
+if command -v greadlink >/dev/null 2>&1; then
+    # macOS readlink doesn't support -f option
+    READLINK=greadlink
+else
+    READLINK=readlink
+fi
+
+# Travis can't publish releases to other repos (or stop mucking with the markdown description), so push releases directly
+export GOPATH=$($READLINK -f go)
+PATH=$PATH:$GOPATH/bin
+go get github.com/itchio/gothub
+
+HEAD=`git rev-parse --abbrev-ref HEAD`
+if [ $HEAD = "master" ] && git tag $MATHLIB_VERSION_STRING
+then
+    last_tag=$(git describe @^ --abbrev=0 --tags)
+    export OLEAN_ARCHIVE=mathlib-olean-$MATHLIB_VERSION_STRING.tar.gz
+    export SCRIPT_ARCHIVE=mathlib-scripts-$MATHLIB_VERSION_STRING.tar.gz
+    tar -zcvf $OLEAN_ARCHIVE src > /dev/null
+    mkdir mathlib-scripts || true
+    cp scripts/* mathlib-scripts/
+    tar -zcvf $SCRIPT_ARCHIVE mathlib-scripts > /dev/null
+    ls *.tar.gz
+    gothub release -s $GITHUB_TOKEN -u leanprover-community -r mathlib-nightly -t $MATHLIB_VERSION_STRING -d "some description" --pre-release
+    gothub upload -s $GITHUB_TOKEN -u leanprover-community -r mathlib-nightly -t $MATHLIB_VERSION_STRING -n "$(basename $OLEAN_ARCHIVE)" -f "$OLEAN_ARCHIVE"
+    gothub upload -s $GITHUB_TOKEN -u leanprover-community -r mathlib-nightly -t $MATHLIB_VERSION_STRING -n "$(basename $SCRIPT_ARCHIVE)" -f "$SCRIPT_ARCHIVE"
+
+    LEAN_VERSION=`python3 lean_version.py`
+    git tag $LEAN_VERSION -f
+    git push mathlib -f $LEAN_VERSION
+fi

--- a/scripts/lean_version.py
+++ b/scripts/lean_version.py
@@ -1,0 +1,15 @@
+
+import toml
+import os.path
+import os
+
+# find root of project and leanpkg.toml
+cwd = os.getcwd()
+while not os.path.isfile('leanpkg.toml') and not os.getcwd() == '/':
+    os.chdir(os.path.dirname(os.getcwd()))
+if not os.path.isfile('leanpkg.toml'):
+    raise('no leanpkg.toml found')
+
+leanpkg = toml.load('leanpkg.toml')
+version = leanpkg['package']['lean_version']
+print(f'lean-{version}')

--- a/scripts/update-mathlib.py
+++ b/scripts/update-mathlib.py
@@ -30,14 +30,13 @@ if lib['git'] in ['https://github.com/leanprover/mathlib','https://github.com/le
     hash = rev[:7]
 
     g = Github()
-    repo = g.get_repo("leanprover-community/mathlib")
+    repo = g.get_repo("leanprover-community/mathlib-nightly")
     assets = (r.get_assets() for r in (repo.get_releases())
-                             if r.tag_name.endswith(hash) and
-                                  r.tag_name.startswith('bin') and
+                             if r.tag_name.startswith('nightly-') and
                                   r.target_commitish == rev )
     assets = next(assets,None)
     if assets:
-        a = next(x for x in assets if x.name.startswith('mathlib-bin'))
+        a = next(x for x in assets if x.name.startswith('mathlib-olean-nightly-'))
         cd = os.getcwd()
         os.chdir(mathlib_dir)
         if not os.path.isfile(a.name):


### PR DESCRIPTION
once a day, 
* push the `lean-3.4.2` tag
* upload the mathlib olean files to `leanprover-community/mathlib-nightly`

`update-mathlib` now fetches the binaries from `leanprover-community/mathlib-nightly`
