### PR TITLE
feat(tactic/basic,tactic/interactive): improvements to set tactic

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -781,16 +781,16 @@ end
 ```
 ### set
 
-`set a := t with h` is a variant of `let a := t` that adds the hypothesis `h : a = t` to the local context.
+`set a := t with h` is a variant of `let a := t`. It adds the hypothesis `h : a = t` to the local context and replaces `t` with `a` everywhere it can.
 
-`set a := t with h⁻¹` will add `h : t = a` instead.
+`set a := t with ←h` will add `h : t = a` instead.
 
-`set! a := t with h` will try to replace `t` with `a` in the goal and all hypotheses.
+`set! a := t with h` does not do any replacing.
 
 ```lean
 example (x : ℕ) (h : x = 3)  : x + x + x = 9 :=
 begin
-  set! y := x with h_xy⁻¹,
+  set y := x with ←h_xy,
 /-
 x : ℕ,
 y : ℕ := x,

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -653,14 +653,53 @@ auxiliary declarations, and produce an error saying the recursion is not well fo
 -/
 meta def clear_aux_decl : tactic unit := tactic.clear_aux_decl
 
+meta def loc.get_local_pp_names : loc → tactic (list name)
+| loc.wildcard := list.map expr.local_pp_name <$> local_context
+| (loc.ns l) := return l.reduce_option
+
+meta def loc.get_local_uniq_names (l : loc) : tactic (list name) :=
+list.map expr.local_uniq_name <$> l.get_locals
+
 /--
-`set a := t with h` is a variant of `let a := t` that adds the hypothesis `h : a = t` to the local context.
-`set a := t with h⁻¹` will add `h : t = a` instead.
-`set! a := t with h` will try to replace `t` with `a` in the goal and all hypotheses.
+The logic of `change x with y at l` fails when there are dependencies.
+`change'` mimics the behavior of `change`, except in the case of `change x with y at l`.
+In this case, it will correctly replace occurences of `x` with `y` at all possible hypotheses in `l`.
+As long as `x` and `y` are defeq, it should never fail.
 -/
-meta def set (h_simp : parse (tk "!")?) (a : parse ident) (_ : parse (tk ":=")) (v : parse texpr)
-  (h : parse (tk "with" >> ident)) (h_symm : parse (tk "⁻¹")?) :=
-do e ← i_to_expr v, tactic.set a h e h_simp.is_some h_symm.is_some
+meta def change' (q : parse texpr) : parse (tk "with" *> texpr)? → parse location → tactic unit
+| none (loc.ns [none]) := do e ← i_to_expr q, change_core e none
+| none (loc.ns [some h]) := do eq ← i_to_expr q, eh ← get_local h, change_core eq (some eh)
+| none _ := fail "change-at does not support multiple locations"
+| (some w) l :=
+  do l' ← loc.get_local_pp_names l,
+     l'.mmap' (λ e, try (change_with_at q w e)),
+     when l.include_goal $ change q w (loc.ns [none])
+
+private meta def opt_dir_with : parser (option (bool × name)) :=
+(do tk "with",
+   arrow ← (tk "<-")?,
+   h ← ident,
+   return (arrow.is_some, h)) <|> return none
+
+/--
+`set a := t with h` is a variant of `let a := t`.
+It adds the hypothesis `h : a = t` to the local context and replaces `t` with `a` everywhere it can.
+`set a := t with ←h` will add `h : t = a` instead.
+`set! a := t with h` does not do any replacing.
+-/
+meta def set (h_simp : parse (tk "!")?) (a : parse ident) (_ : parse (tk ":=")) (pv : parse texpr)
+  (rev_name : parse opt_dir_with) :=
+do v ← to_expr pv,
+   tp ← infer_type v,
+   definev a tp v,
+   when h_simp.is_none $ change' pv (some (expr.const a [])) loc.wildcard,
+   match rev_name with
+   | some (flip, id) :=
+     do nv ← get_local a,
+        pf ← to_expr (cond flip ``(%%pv = %%nv) ``(%%nv = %%pv)) >>= assert id,
+        reflexivity
+   | none := skip
+   end
 
 end interactive
 end tactic

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -687,9 +687,11 @@ It adds the hypothesis `h : a = t` to the local context and replaces `t` with `a
 `set a := t with ←h` will add `h : t = a` instead.
 `set! a := t with h` does not do any replacing.
 -/
-meta def set (h_simp : parse (tk "!")?) (a : parse ident) (_ : parse (tk ":=")) (pv : parse texpr)
+meta def set (h_simp : parse (tk "!")?) (a : parse ident) (tp : parse ((tk ":") >> texpr)?) (_ : parse (tk ":=")) (pv : parse texpr)
   (rev_name : parse opt_dir_with) :=
-do v ← to_expr pv,
+do let vt := match tp with | some t := t | none := pexpr.mk_placeholder end,
+   let pv := ``(%%pv : %%vt),
+   v ← to_expr pv,
    tp ← infer_type v,
    definev a tp v,
    when h_simp.is_none $ change' pv (some (expr.const a [])) loc.wildcard,

--- a/src/tactic/linarith.lean
+++ b/src/tactic/linarith.lean
@@ -346,7 +346,6 @@ do pftps ← l.mmap infer_type,
   let vars : rb_set ℕ := rb_map.set_of_list $ list.range map.size.succ,
   let pc : rb_set pcomp := rb_map.set_of_list $
     lz.map (λ ⟨n, x⟩, ⟨x.2, comp_source.assump n⟩),
-  --trace pc, trace prmap,
   return (⟨vars, pc⟩, prmap)
 
 meta def linarith_monad.run {α} (tac : linarith_monad α) (l : list expr) : tactic ((pcomp ⊕ α) × rb_map ℕ (expr × expr)) :=
@@ -477,7 +476,6 @@ meta def prove_false_by_linarith1 (cfg : linarith_config) : list expr → tactic
 | l@(h::t) :=
   do l' ← add_neg_eq_pfs l,
      hz ← ineq_pf_tp h >>= mk_neg_one_lt_zero_pf,
-     --list.mmap' (λ e, infer_type e >>= trace) (hz::l') ,
      (sum.inl contr, inputs) ← elim_all_vars.run (hz::l')
        | fail "linarith failed to find a contradiction",
      let coeffs := inputs.keys.map (λ k, (contr.src.flatten.ifind k)),


### PR DESCRIPTION
Some changes to the `set` tactic discussed a while back on Zulip.

* uses `←` instead of `⁻¹` to reverse the direction of the inequality
* defaults to replacing the old value with the new variable everywhere it can
* does these replacements definitionally

This last one was sort of a pain. Changing the types of hypotheses is subtle and the current `change` tactic doesn't do it right. Compare the behavior here when you change `*` to `h`.
```lean
example (a : ℕ) (h : a = 0) : true :=
begin 
  change a with a + 0 at *,
end 
```

Finding a list of `local_const`s at the beginning and mapping over it doesn't work, because in the process of changing earlier ones, you can change the unique names of later ones. So this PR adds an interactive tactic `change'` which I believe has the correct behavior in the `change' x with y at l` case.

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
