### PR TITLE
feat(data/alist,data/finmap): always insert key-value pair

### DIFF
--- a/src/data/finmap.lean
+++ b/src/data/finmap.lean
@@ -13,6 +13,14 @@ variables {α : Type u} {β : α → Type v}
 
 namespace multiset
 
+/-- Multiset of keys of an association multiset. -/
+def keys (s : multiset (sigma β)) : multiset α :=
+s.map sigma.fst
+
+@[simp] theorem coe_keys {l : list (sigma β)} :
+  keys (l : multiset (sigma β)) = (l.keys : multiset α) :=
+rfl
+
 /-- `nodupkeys s` means that `s` has no duplicate keys. -/
 def nodupkeys (s : multiset (sigma β)) : Prop :=
 quot.lift_on s list.nodupkeys (λ s t p, propext $ perm_nodupkeys p)
@@ -63,17 +71,17 @@ by rcases s with ⟨⟨a⟩, h⟩; exact H ⟨a, h⟩
 | ⟨l₁, h₁⟩ ⟨l₂, h₂⟩ H := by congr'
 
 /-- The predicate `a ∈ s` means that `s` has a value associated to the key `a`. -/
-instance : has_mem α (finmap β) := ⟨λ a s, ∃ b : β a, sigma.mk a b ∈ s.entries⟩
+instance : has_mem α (finmap β) := ⟨λ a s, a ∈ s.entries.keys⟩
 
 theorem mem_def {a : α} {s : finmap β} :
-  a ∈ s ↔ ∃ b : β a, sigma.mk a b ∈ s.entries := iff.rfl
+  a ∈ s ↔ a ∈ s.entries.keys := iff.rfl
 
 @[simp] theorem mem_to_finmap {a : α} {s : alist β} :
   a ∈ ⟦s⟧ ↔ a ∈ s := iff.rfl
 
 /-- The set of keys of a finite map. -/
 def keys (s : finmap β) : finset α :=
-⟨s.entries.map sigma.fst, induction_on s $ λ s, s.keys_nodup⟩
+⟨s.entries.keys, induction_on s keys_nodup⟩
 
 @[simp] theorem keys_val (s : alist β) : (keys ⟦s⟧).val = s.keys := rfl
 
@@ -82,7 +90,7 @@ def keys (s : finmap β) : finset α :=
 by simp [keys, alist.keys]
 
 theorem mem_keys {a : α} {s : finmap β} : a ∈ s.keys ↔ a ∈ s :=
-induction_on s $ λ s, mem_keys
+induction_on s $ λ s, alist.mem_keys
 
 /-- The empty map. -/
 instance : has_emptyc (finmap β) := ⟨⟨0, nodupkeys_nil⟩⟩
@@ -90,11 +98,8 @@ instance : has_emptyc (finmap β) := ⟨⟨0, nodupkeys_nil⟩⟩
 @[simp] theorem empty_to_finmap (s : alist β) :
   (⟦∅⟧ : finmap β) = ∅ := rfl
 
-theorem not_mem_empty_entries {s : sigma β} : s ∉ (∅ : finmap β).entries :=
-multiset.not_mem_zero _
-
 theorem not_mem_empty {a : α} : a ∉ (∅ : finmap β) :=
-λ ⟨b, h⟩, not_mem_empty_entries h
+multiset.not_mem_zero a
 
 @[simp] theorem keys_empty : (∅ : finmap β).keys = ∅ := rfl
 
@@ -118,31 +123,11 @@ theorem lookup_is_some {a : α} {s : finmap β} :
   (s.lookup a).is_some ↔ a ∈ s :=
 induction_on s $ λ s, alist.lookup_is_some
 
+theorem lookup_eq_none {a} {s : finmap β} : lookup a s = none ↔ a ∉ s :=
+induction_on s $ λ s, alist.lookup_eq_none
+
 instance (a : α) (s : finmap β) : decidable (a ∈ s) :=
 decidable_of_iff _ lookup_is_some
-
-/-- Insert a key-value pair into a finite map.
-  If the key is already present it does nothing. -/
-def insert (a : α) (b : β a) (s : finmap β) : finmap β :=
-lift_on s (λ t, ⟦insert a b t⟧) $
-λ s₁ s₂ p, to_finmap_eq.2 $ perm_insert p
-
-@[simp] theorem insert_to_finmap (a : α) (b : β a) (s : alist β) :
-  insert a b ⟦s⟧ = ⟦s.insert a b⟧ := by simp [insert]
-
-@[simp] theorem insert_of_pos {a : α} {b : β a} {s : finmap β} : a ∈ s →
-  insert a b s = s :=
-induction_on s $ λ ⟨s, nd⟩ h, congr_arg to_finmap $
-insert_of_pos (mem_to_finmap.2 h)
-
-theorem insert_entries_of_neg {a : α} {b : β a} {s : finmap β} : a ∉ s →
-  (insert a b s).entries = ⟨a, b⟩ :: s.entries :=
-induction_on s $ λ s h,
-by simp [insert_entries_of_neg (mt mem_to_finmap.1 h)]
-
-@[simp] theorem mem_insert {a a' : α} {b : β a} {s : finmap β} :
-  a' ∈ insert a b s ↔ a' = a ∨ a' ∈ s :=
-induction_on s $ by simp
 
 /-- Replace a key with a given value in a finite map.
   If the key is not present it does nothing. -/
@@ -177,7 +162,7 @@ lift_on s (λ t, ⟦erase a t⟧) $
 
 @[simp] theorem keys_erase_to_finset (a : α) (s : alist β) :
   keys ⟦s.erase a⟧ = (keys ⟦s⟧).erase a :=
-by simp [finset.erase, keys, alist.erase, list.kerase_map_fst]
+by simp [finset.erase, keys, alist.erase, keys_kerase]
 
 @[simp] theorem keys_erase (a : α) (s : finmap β) :
   (erase a s).keys = s.keys.erase a :=
@@ -185,6 +170,40 @@ induction_on s $ λ s, by simp
 
 @[simp] theorem mem_erase {a a' : α} {s : finmap β} : a' ∈ erase a s ↔ a' ≠ a ∧ a' ∈ s :=
 induction_on s $ λ s, by simp
+
+@[simp] theorem lookup_erase (a) (s : finmap β) : lookup a (erase a s) = none :=
+induction_on s $ lookup_erase a
+
+@[simp] theorem lookup_erase_ne {a a'} {s : finmap β} (h : a ≠ a') :
+  lookup a' (erase a s) = lookup a' s :=
+induction_on s $ λ s, lookup_erase_ne h
+
+/- insert -/
+
+/-- Insert a key-value pair into a finite map, replacing any existing pair with
+  the same key. -/
+def insert (a : α) (b : β a) (s : finmap β) : finmap β :=
+lift_on s (λ t, ⟦insert a b t⟧) $
+λ s₁ s₂ p, to_finmap_eq.2 $ perm_insert p
+
+@[simp] theorem insert_to_finmap (a : α) (b : β a) (s : alist β) :
+  insert a b ⟦s⟧ = ⟦s.insert a b⟧ := by simp [insert]
+
+theorem insert_entries_of_neg {a : α} {b : β a} {s : finmap β} : a ∉ s →
+  (insert a b s).entries = ⟨a, b⟩ :: s.entries :=
+induction_on s $ λ s h,
+by simp [insert_entries_of_neg (mt mem_to_finmap.1 h)]
+
+@[simp] theorem mem_insert {a a' : α} {b : β a} {s : finmap β} :
+  a' ∈ insert a b s ↔ a = a' ∨ a' ∈ s :=
+induction_on s mem_insert
+
+@[simp] theorem lookup_insert {a} {b : β a} (s : finmap β) :
+  lookup a (insert a b s) = some b :=
+induction_on s $ λ s,
+by simp only [insert_to_finmap, lookup_to_finmap, lookup_insert]
+
+/- extract -/
 
 /-- Erase a key from the map, and return the corresponding value, if found. -/
 def extract (a : α) (s : finmap β) : option (β a) × finmap β :=

--- a/src/data/list/alist.lean
+++ b/src/data/list/alist.lean
@@ -23,34 +23,34 @@ namespace alist
 @[extensionality] theorem ext : ∀ {s t : alist β}, s.entries = t.entries → s = t
 | ⟨l₁, h₁⟩ ⟨l₂, h₂⟩ H := by congr'
 
-/-- The predicate `a ∈ s` means that `s` has a value associated to the key `a`. -/
-instance : has_mem α (alist β) := ⟨λ a s, ∃ b : β a, sigma.mk a b ∈ s.entries⟩
-
-theorem mem_def {a : α} {s : alist β} :
-  a ∈ s ↔ ∃ b : β a, sigma.mk a b ∈ s.entries := iff.rfl
-
-theorem mem_of_perm {a : α} {s₁ s₂ : alist β} (p : s₁.entries ~ s₂.entries) : a ∈ s₁ ↔ a ∈ s₂ :=
-exists_congr $ λ b, mem_of_perm p
+/- keys -/
 
 /-- The list of keys of an association list. -/
-def keys (s : alist β) : list α := s.entries.map sigma.fst
-
-theorem mem_keys {a : α} {s : alist β} : a ∈ s.keys ↔ a ∈ s :=
-by rw [keys, mem_map]; exact
-⟨λ ⟨⟨_, b⟩, h, rfl⟩, ⟨b, h⟩, λ ⟨b, h⟩, ⟨_, h, rfl⟩⟩
+def keys (s : alist β) : list α := s.entries.keys
 
 theorem keys_nodup (s : alist β) : s.keys.nodup := s.nodupkeys
+
+/- mem -/
+
+/-- The predicate `a ∈ s` means that `s` has a value associated to the key `a`. -/
+instance : has_mem α (alist β) := ⟨λ a s, a ∈ s.keys⟩
+
+theorem mem_keys {a : α} {s : alist β} : a ∈ s ↔ a ∈ s.keys := iff.rfl
+
+theorem mem_of_perm {a : α} {s₁ s₂ : alist β} (p : s₁.entries ~ s₂.entries) : a ∈ s₁ ↔ a ∈ s₂ :=
+mem_of_perm $ perm_map sigma.fst p
+
+/- empty -/
 
 /-- The empty association list. -/
 instance : has_emptyc (alist β) := ⟨⟨[], nodupkeys_nil⟩⟩
 
-theorem not_mem_empty_entries {s : sigma β} : s ∉ (∅ : alist β).entries :=
-not_mem_nil _
-
-theorem not_mem_empty {a : α} : a ∉ (∅ : alist β) :=
-λ ⟨b, h⟩, not_mem_empty_entries h
+theorem not_mem_empty (a : α) : a ∉ (∅ : alist β) :=
+not_mem_nil a
 
 @[simp] theorem keys_empty : (∅ : alist β).keys = [] := rfl
+
+/- singleton -/
 
 /-- The singleton association list. -/
 def singleton (a : α) (b : β a) : alist β :=
@@ -60,12 +60,18 @@ def singleton (a : α) (b : β a) : alist β :=
 
 variables [decidable_eq α]
 
+/- lookup -/
+
 /-- Look up the value associated to a key in an association list. -/
 def lookup (a : α) (s : alist β) : option (β a) :=
 s.entries.lookup a
 
 theorem lookup_is_some {a : α} {s : alist β} :
   (s.lookup a).is_some ↔ a ∈ s := lookup_is_some
+
+theorem lookup_eq_none {a : α} {s : alist β} :
+  lookup a s = none ↔ a ∉ s :=
+lookup_eq_none
 
 theorem perm_lookup {a : α} {s₁ s₂ : alist β} (p : s₁.entries ~ s₂.entries) :
   s₁.lookup a = s₂.lookup a :=
@@ -74,39 +80,7 @@ perm_lookup _ s₁.nodupkeys s₂.nodupkeys p
 instance (a : α) (s : alist β) : decidable (a ∈ s) :=
 decidable_of_iff _ lookup_is_some
 
-/-- Insert a key-value pair into an association list.
-  If the key is already present it does nothing. -/
-def insert (a : α) (b : β a) (s : alist β) : alist β :=
-if h : a ∈ s then s else ⟨⟨a, b⟩ :: s.entries,
-  nodup_cons.2 ⟨mt mem_keys.1 h, s.nodupkeys⟩⟩
-
-@[simp] theorem insert_of_pos {a : α} {b : β a} {s : alist β} (h : a ∈ s) :
-  insert a b s = s := dif_pos h
-
-theorem insert_entries_of_neg {a : α} {b : β a} {s : alist β} (h : a ∉ s) :
-  (insert a b s).entries = ⟨a, b⟩ :: s.entries := by simp [insert, h]
-
-@[simp] theorem keys_insert (a : α) (b : β a) (s : alist β) :
-  (insert a b s).keys = _root_.insert a s.keys :=
-begin
-  by_cases a ∈ s,
-  { simp [h, mem_keys.2 h] },
-  { simp [keys, insert_entries_of_neg h],
-    exact (insert_of_not_mem (mt mem_keys.1 h)).symm }
-end
-
-@[simp] theorem mem_insert {a a' : α} {b : β a} {s : alist β} :
-  a' ∈ insert a b s ↔ a' = a ∨ a' ∈ s :=
-by rw [← mem_keys, ← mem_keys]; simp
-
-theorem perm_insert {a : α} {b : β a} {s₁ s₂ : alist β}
-  (p : s₁.entries ~ s₂.entries) : (insert a b s₁).entries ~ (insert a b s₂).entries :=
-begin
-  by_cases a ∈ s₁,
-  { simp [h, (mem_of_perm p).1 h, p] },
-  { simp [insert_entries_of_neg h, insert_entries_of_neg (mt (mem_of_perm p).2 h)],
-    exact p.skip _ }
-end
+/- replace -/
 
 /-- Replace a key with a given value in an association list.
   If the key is not present it does nothing. -/
@@ -115,11 +89,11 @@ def replace (a : α) (b : β a) (s : alist β) : alist β :=
 
 @[simp] theorem keys_replace (a : α) (b : β a) (s : alist β) :
   (replace a b s).keys = s.keys :=
-kreplace_map_fst _ _ _
+keys_kreplace _ _ _
 
 @[simp] theorem mem_replace {a a' : α} {b : β a} {s : alist β} :
   a' ∈ replace a b s ↔ a' ∈ s :=
-by rw [← mem_keys, keys_replace, mem_keys]
+by rw [mem_keys, keys_replace, ←mem_keys]
 
 theorem perm_replace {a : α} {b : β a} {s₁ s₂ : alist β} :
   s₁.entries ~ s₂.entries → (replace a b s₁).entries ~ (replace a b s₂).entries :=
@@ -129,20 +103,65 @@ perm_kreplace s₁.nodupkeys
 def foldl {δ : Type w} (f : δ → Π a, β a → δ) (d : δ) (m : alist β) : δ :=
 m.entries.foldl (λ r a, f r a.1 a.2) d
 
+/- erase -/
+
 /-- Erase a key from the map. If the key is not present it does nothing. -/
 def erase (a : α) (s : alist β) : alist β :=
 ⟨kerase a s.entries, kerase_nodupkeys _ s.nodupkeys⟩
 
 @[simp] theorem keys_erase (a : α) (s : alist β) :
   (erase a s).keys = s.keys.erase a :=
-by rw [erase_eq_erasep, keys, keys, erasep_map]; refl
+by simp only [erase, keys, keys_kerase]
 
 @[simp] theorem mem_erase {a a' : α} {s : alist β} : a' ∈ erase a s ↔ a' ≠ a ∧ a' ∈ s :=
-by rw [← mem_keys, keys_erase, mem_erase_iff_of_nodup s.keys_nodup, mem_keys]
+by rw [mem_keys, keys_erase, mem_erase_iff_of_nodup s.keys_nodup, ←mem_keys]
 
 theorem perm_erase {a : α} {s₁ s₂ : alist β} :
   s₁.entries ~ s₂.entries → (erase a s₁).entries ~ (erase a s₂).entries :=
 perm_kerase s₁.nodupkeys
+
+@[simp] theorem lookup_erase (a) (s : alist β) : lookup a (erase a s) = none :=
+lookup_kerase a s.nodupkeys
+
+@[simp] theorem lookup_erase_ne {a a'} {s : alist β} (h : a ≠ a') :
+  lookup a' (erase a s) = lookup a' s :=
+lookup_kerase_ne h
+
+/- insert -/
+
+/-- Insert a key-value pair into an association list and erase any existing pair
+  with the same key. -/
+def insert (a : α) (b : β a) (s : alist β) : alist β :=
+⟨kinsert a b s.entries, kinsert_nodupkeys a b s.nodupkeys⟩
+
+@[simp] theorem insert_entries {a} {b : β a} {s : alist β} :
+  (insert a b s).entries = sigma.mk a b :: kerase a s.entries :=
+rfl
+
+theorem insert_entries_of_neg {a} {b : β a} {s : alist β} (h : a ∉ s) :
+  (insert a b s).entries = ⟨a, b⟩ :: s.entries :=
+by rw [insert_entries, kerase_of_not_mem_keys h]
+
+@[simp] theorem mem_insert {a a'} {b : β a} (s : alist β) :
+  a' ∈ insert a b s ↔ a = a' ∨ a' ∈ s :=
+mem_keys_kinsert
+
+@[simp] theorem keys_insert {a} {b : β a} (s : alist β) :
+  (insert a b s).keys = a :: s.keys.erase a :=
+by simp [insert, keys, keys_kerase]
+
+theorem perm_insert {a} {b : β a} {s₁ s₂ : alist β} (p : s₁.entries ~ s₂.entries) :
+  (insert a b s₁).entries ~ (insert a b s₂).entries :=
+by simp only [insert_entries]; exact perm_kinsert s₁.nodupkeys p
+
+@[simp] theorem lookup_insert {a} {b : β a} (s : alist β) : lookup a (insert a b s) = some b :=
+by simp only [lookup, insert, lookup_kinsert]
+
+@[simp] theorem lookup_insert_ne {a a'} {b : β a} {s : alist β} (h : a ≠ a') :
+  lookup a' (insert a b s) = lookup a' s :=
+lookup_kinsert_ne h
+
+/- extract -/
 
 /-- Erase a key from the map, and return the corresponding value, if found. -/
 def extract (a : α) (s : alist β) : option (β a) × alist β :=


### PR DESCRIPTION
* Changed `{alist,finmap}.insert` to always insert the key-value pair instead of doing nothing if the inserted key is found. This allows for useful theorems such as `lookup_insert`.
* Added `list.keys` and used key membership instead of exists/forall. This makes proofs easier in some places.
* Added a few other useful theorems such as `lookup_eq_none`, `lookup_erase`, `lookup_erase_ne`.

---

* [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
* [x] make sure definitions and lemmas are put in the right files
* [x] make sure definitions and lemmas are not redundant