### PR TITLE
feat(data/polynomial): create nonzero_comm_semiring class and generalize theorems from nonzero_comm_ring

### DIFF
--- a/src/algebra/ring.lean
+++ b/src/algebra/ring.lean
@@ -192,13 +192,20 @@ end is_ring_hom
 
 set_option old_structure_cmd true
 
-class nonzero_comm_ring (α : Type*) extends zero_ne_one_class α, comm_ring α
+class nonzero_comm_semiring (α : Type*) extends comm_semiring α, zero_ne_one_class α
+
+class nonzero_comm_ring (α : Type*) extends comm_ring α, zero_ne_one_class α
+
+instance nonzero_comm_ring.to_nonzero_comm_semiring {α : Type*} [I : nonzero_comm_ring α] :
+  nonzero_comm_semiring α :=
+{ zero_ne_one := by convert zero_ne_one,
+  ..show comm_semiring α, by apply_instance }
 
 instance integral_domain.to_nonzero_comm_ring (α : Type*) [id : integral_domain α] :
   nonzero_comm_ring α :=
 { ..id }
 
-lemma units.coe_ne_zero [nonzero_comm_ring α] (u : units α) : (u : α) ≠ 0 :=
+lemma units.coe_ne_zero [nonzero_comm_semiring α] (u : units α) : (u : α) ≠ 0 :=
 λ h : u.1 = 0, by simpa [h, zero_ne_one] using u.3
 
 def nonzero_comm_ring.of_ne [comm_ring α] {x y : α} (h : x ≠ y) : nonzero_comm_ring α :=
@@ -206,6 +213,12 @@ def nonzero_comm_ring.of_ne [comm_ring α] {x y : α} (h : x ≠ y) : nonzero_co
   zero := 0,
   zero_ne_one := λ h01, h $ by rw [← one_mul x, ← one_mul y, ← h01, zero_mul, zero_mul],
   ..show comm_ring α, by apply_instance }
+
+def nonzero_comm_semiring.of_ne [comm_semiring α] {x y : α} (h : x ≠ y) : nonzero_comm_semiring α :=
+{ one := 1,
+  zero := 0,
+  zero_ne_one := λ h01, h $ by rw [← one_mul x, ← one_mul y, ← h01, zero_mul, zero_mul],
+  ..show comm_semiring α, by apply_instance }
 
 /-- A domain is a ring with no zero divisors, i.e. satisfying
   the condition `a * b = 0 ↔ a = 0 ∨ b = 0`. Alternatively, a domain

--- a/src/data/polynomial.lean
+++ b/src/data/polynomial.lean
@@ -931,6 +931,46 @@ have zn0 : (0 : α) ≠ 1, from λ h, by haveI := subsingleton_of_zero_eq_one _ 
 
 end comm_semiring
 
+section nonzero_comm_semiring
+variables [nonzero_comm_semiring α] [decidable_eq α] {p q : polynomial α}
+
+instance : nonzero_comm_semiring (polynomial α) :=
+{ zero_ne_one := λ (h : (0 : polynomial α) = 1),
+    @zero_ne_one α _ $
+    calc (0 : α) = eval 0 0 : eval_zero.symm
+      ... = eval 0 1 : congr_arg _ h
+      ... = 1 : eval_C,
+  ..polynomial.comm_semiring }
+
+@[simp] lemma degree_one : degree (1 : polynomial α) = (0 : with_bot ℕ) :=
+degree_C (show (1 : α) ≠ 0, from zero_ne_one.symm)
+
+@[simp] lemma degree_X : degree (X : polynomial α) = 1 :=
+begin
+  unfold X degree single finsupp.support,
+  rw if_neg (zero_ne_one).symm,
+  refl
+end
+
+lemma X_ne_zero : (X : polynomial α) ≠ 0 :=
+mt (congr_arg (λ p, coeff p 1)) (by simp)
+
+@[simp] lemma degree_X_pow : ∀ (n : ℕ), degree ((X : polynomial α) ^ n) = n
+| 0 := by simp only [pow_zero, degree_one]; refl
+| (n+1) :=
+have h : leading_coeff (X : polynomial α) * leading_coeff (X ^ n) ≠ 0,
+  by rw [leading_coeff_X, leading_coeff_X_pow n, one_mul];
+    exact zero_ne_one.symm,
+by rw [pow_succ, degree_mul_eq' h, degree_X, degree_X_pow, add_comm]; refl
+
+@[simp] lemma not_monic_zero : ¬monic (0 : polynomial α) :=
+by simpa only [monic, leading_coeff_zero] using zero_ne_one
+
+lemma ne_zero_of_monic (h : monic p) : p ≠ 0 :=
+λ h₁, @not_monic_zero α _ _ (h₁ ▸ h)
+
+end nonzero_comm_semiring
+
 section comm_ring
 variables [comm_ring α] [decidable_eq α] {p q : polynomial α}
 instance : comm_ring (polynomial α) := finsupp.to_comm_ring
@@ -1314,25 +1354,8 @@ section nonzero_comm_ring
 variables [nonzero_comm_ring α] [decidable_eq α] {p q : polynomial α}
 
 instance : nonzero_comm_ring (polynomial α) :=
-{ zero_ne_one := λ (h : (0 : polynomial α) = 1),
-    @zero_ne_one α _ $
-    calc (0 : α) = eval 0 0 : eval_zero.symm
-      ... = eval 0 1 : congr_arg _ h
-      ... = 1 : eval_C,
+{ ..polynomial.nonzero_comm_semiring,
   ..polynomial.comm_ring }
-
-@[simp] lemma degree_one : degree (1 : polynomial α) = (0 : with_bot ℕ) :=
-degree_C (show (1 : α) ≠ 0, from zero_ne_one.symm)
-
-@[simp] lemma degree_X : degree (X : polynomial α) = 1 :=
-begin
-  unfold X degree single finsupp.support,
-  rw if_neg (zero_ne_one).symm,
-  refl
-end
-
-lemma X_ne_zero : (X : polynomial α) ≠ 0 :=
-mt (congr_arg (λ p, coeff p 1)) (by simp)
 
 @[simp] lemma degree_X_sub_C (a : α) : degree (X - C a) = 1 :=
 begin
@@ -1341,14 +1364,6 @@ begin
   { simp only [ha, C_0, neg_zero, zero_add] },
   exact degree_add_eq_of_degree_lt (by rw [degree_X, degree_neg, degree_C ha]; exact dec_trivial)
 end
-
-@[simp] lemma degree_X_pow : ∀ (n : ℕ), degree ((X : polynomial α) ^ n) = n
-| 0 := by simp only [pow_zero, degree_one]; refl
-| (n+1) :=
-have h : leading_coeff (X : polynomial α) * leading_coeff (X ^ n) ≠ 0,
-  by rw [leading_coeff_X, leading_coeff_X_pow n, one_mul];
-    exact zero_ne_one.symm,
-by rw [pow_succ, degree_mul_eq' h, degree_X, degree_X_pow, add_comm]; refl
 
 lemma degree_X_pow_sub_C {n : ℕ} (hn : 0 < n) (a : α) :
   degree ((X : polynomial α) ^ n - C a) = n :=
@@ -1362,12 +1377,6 @@ lemma X_pow_sub_C_ne_zero {n : ℕ} (hn : 0 < n) (a : α) :
   (X : polynomial α) ^ n - C a ≠ 0 :=
 mt degree_eq_bot.2 (show degree ((X : polynomial α) ^ n - C a) ≠ ⊥,
   by rw degree_X_pow_sub_C hn; exact dec_trivial)
-
-@[simp] lemma not_monic_zero : ¬monic (0 : polynomial α) :=
-by simpa only [monic, leading_coeff_zero] using zero_ne_one
-
-lemma ne_zero_of_monic (h : monic p) : p ≠ 0 :=
-λ h₁, @not_monic_zero α _ _ (h₁ ▸ h)
 
 end nonzero_comm_ring
 


### PR DESCRIPTION
I was hoping to just create
```lean
class zero_ne_one_class' (α : Type*) [has_zero α] [has_one α] : Prop :=
(zero_ne_one : (0 : α) ≠ 1)
```
but this gave me issues, so I defined `nonzero_comm_semiring` instead

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
