### PR TITLE
feat(topology/algebra/topological_structures): mem_image_of_is_glb_range

### DIFF
--- a/src/order/bounds.lean
+++ b/src/order/bounds.lean
@@ -42,6 +42,26 @@ by simp [is_lub, is_least, upper_bounds, lower_bounds] {contextual := tt}
 lemma is_glb_singleton {a : α} : is_glb {a} a :=
 by simp [is_glb, is_greatest, upper_bounds, lower_bounds] {contextual := tt}
 
+lemma lower_bounds_subset_eq {s t : set α} (hst : s ⊆ t)
+  (x : α) (hxs : x ∈ s) (hxst : x ∈ lower_bounds (t \ s)) :
+  lower_bounds s = lower_bounds t :=
+by letI := classical.dec; exact
+set.ext (λ y, ⟨λ hy a hat, if has : a ∈ s then hy _ has
+    else le_trans (hy x hxs) (hxst a ⟨hat, has⟩),
+  λ hy a ha, hy _ (hst ha)⟩)
+
+lemma upper_bounds_subset_eq : ∀ {s t : set α}, s ⊆ t → ∀ x ∈ s,
+  x ∈ upper_bounds (t \ s) → upper_bounds s = upper_bounds t :=
+@lower_bounds_subset_eq (order_dual α) _
+
+lemma is_glb_subset_iff {s t : set α} (hst : s ⊆ t) (x : α) (hxs : x ∈ s)
+  (hxst : x ∈ lower_bounds (t \ s)) {a : α} : is_glb s a ↔ is_glb t a :=
+by rw [is_glb, is_glb, is_greatest, is_greatest, lower_bounds_subset_eq hst x hxs hxst].
+
+lemma is_lub_subset_iff : ∀ {s t : set α}, s ⊆ t → ∀ x ∈ s, x ∈ upper_bounds (t \ s) →
+  ∀ {a}, is_lub s a ↔ is_lub t a :=
+@is_glb_subset_iff (order_dual α) _
+
 end preorder
 
 section partial_order

--- a/src/topology/algebra/topological_structures.lean
+++ b/src/topology/algebra/topological_structures.lean
@@ -1004,6 +1004,20 @@ lemma bdd_above_of_compact {α : Type u} [topological_space α] [linear_order α
   [orderable_topology α] : Π [nonempty α] {s : set α}, compact s → bdd_above s :=
 @bdd_below_of_compact (order_dual α) _ _ _
 
+lemma mem_image_of_is_glb_range (f : β → α) (hf : continuous f) (r b : α) (a : β)
+  (har : f a ≤ r) (s : set β) (hs : compact s) (h : ∀ z, z ∉ s → r < f z)
+  (hb : is_glb (range f) b) : b ∈ f '' s :=
+have has : a ∈ s, from classical.by_contradiction (λ has, (not_le_of_gt (h _ has) har)),
+mem_of_is_glb_of_is_closed
+  ((is_glb_subset_iff (image_subset_range _ _) (f a) ⟨a, has, rfl⟩
+    (λ y ⟨⟨c, hcy⟩, hc⟩, le_trans har $ hcy ▸ le_of_lt (h c $ by clear_aux_decl; finish))).2 hb)
+  (ne_empty_of_mem ⟨a, has, rfl⟩)
+  (closed_of_compact _ (compact_image hs hf))
+
+lemma mem_image_of_is_lub_range : ∀ f : β → α, continuous f → ∀ (r b : α) (a : β),
+  r ≤ f a → ∀ s : set β, compact s → (∀ z, z ∉ s → f z < r) → is_lub (range f) b → b ∈ f '' s :=
+@mem_image_of_is_glb_range (order_dual α) β _ _ _ _ _ _
+
 end order_topology
 
 


### PR DESCRIPTION
Not entirely sure whether the statement of `mem_image_of_is_glb_range` is the most useful.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
