### PR TITLE
fix(algebra/archimedean): swap names of floor_add_fract and fract_add_floor

### DIFF
--- a/src/algebra/archimedean.lean
+++ b/src/algebra/archimedean.lean
@@ -88,9 +88,9 @@ def fract (r : α) : α := r - ⌊r⌋
 
 -- Mathematical notation is usually {r}. Let's not even go there.
 
-@[simp] lemma fract_add_floor (r : α) : (⌊r⌋ : α) + fract r = r := by unfold fract; simp
+@[simp] lemma floor_add_fract (r : α) : (⌊r⌋ : α) + fract r = r := by unfold fract; simp
 
-@[simp] lemma floor_add_fract (r : α) : fract r + ⌊r⌋ = r := sub_add_cancel _ _
+@[simp] lemma fract_add_floor (r : α) : fract r + ⌊r⌋ = r := sub_add_cancel _ _
 
 theorem fract_nonneg (r : α) : 0 ≤ fract r :=
 sub_nonneg.2 $ floor_le _


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
