### PR TITLE
feat(tactic/fin_cases): case bashing on finset, list, and fintype hypotheses.

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -603,7 +603,13 @@ Known limitation(s):
     combined by concatenating their list of lemmas.
 
 ## fin_cases
-Performs cases analysis on a `fin n` hypothesis. As an example, in
+`fin_cases h` performs case analysis on a hypothesis of the form
+1) `h : A`, where `[fintype A]` is available, or
+2) `h ∈ A`, where `A : finset X` or `A : list X`.
+
+`fin_cases *` performs case analysis on all suitable hypotheses.
+
+As an example, in
 ```
 example (f : ℕ → Prop) (p : fin 3) (h0 : f 0) (h1 : f 1) (h2 : f 2) : f p.val :=
 begin
@@ -612,7 +618,6 @@ begin
 end
 ```
 after `fin_cases p`, there are three goals, `f 0`, `f 1`, and `f 2`.
-
 ## conv
 The `conv` tactic is built-in to lean. Currently mathlib additionally provides
    * `erw`,

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -15,6 +15,9 @@ meta instance : has_to_format ℤ := ⟨λ z, int.rec_on z (λ k, ↑k) (λ k, "
 
 attribute [simp] int.coe_nat_add int.coe_nat_mul int.coe_nat_zero int.coe_nat_one int.coe_nat_succ
 
+@[simp] theorem add_eq_plus {a b : ℤ} : int.add a b = a + b := rfl
+@[simp] theorem mul_eq_times {a b : ℤ} : int.mul a b = a * b := rfl
+
 @[simp] theorem coe_nat_mul_neg_succ (m n : ℕ) : (m : ℤ) * -[1+ n] = -(m * succ n) := rfl
 @[simp] theorem neg_succ_mul_coe_nat (m n : ℕ) : -[1+ m] * n = -(succ m * n) := rfl
 @[simp] theorem neg_succ_mul_neg_succ (m n : ℕ) : -[1+ m] * -[1+ n] = succ m * succ n := rfl
@@ -128,7 +131,7 @@ theorem nat_abs_neg_of_nat (n : ℕ) : nat_abs (neg_of_nat n) = n :=
 by cases n; refl
 
 theorem nat_abs_mul (a b : ℤ) : nat_abs (a * b) = (nat_abs a) * (nat_abs b) :=
-by cases a; cases b; simp [(*), int.mul, nat_abs_neg_of_nat]
+by cases a; cases b; simp only [has_mul.mul, int.mul, nat_abs_neg_of_nat, eq_self_iff_true, int.nat_abs]
 
 theorem neg_succ_of_nat_eq' (m : ℕ) : -[1+ m] = -m - 1 :=
 by simp [neg_succ_of_nat_eq]

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -12,6 +12,12 @@ universes u v
 namespace nat
 variables {m n k : ℕ}
 
+-- Sometimes a bare `nat.add` or similar appears as a consequence of unfolding
+-- during pattern matching. These lemmas package them back up as typeclass
+-- mediated operations.
+@[simp] theorem add_eq_plus {a b : ℕ} : nat.add a b = a + b := rfl
+@[simp] theorem mul_eq_times {a b : ℕ} : nat.mul a b = a * b := rfl
+
 attribute [simp] nat.add_sub_cancel nat.add_sub_cancel_left
 attribute [simp] nat.sub_self
 
@@ -861,7 +867,7 @@ lemma with_bot.add_eq_one_iff : ∀ {n m : with_bot ℕ}, n + m = 1 ↔ (n = 0 �
 
 -- induction
 
-@[elab_as_eliminator] lemma le_induction {P : nat → Prop} {m} (h0 : P m) (h1 : ∀ n ≥ m, P n → P (n + 1)) : 
+@[elab_as_eliminator] lemma le_induction {P : nat → Prop} {m} (h0 : P m) (h1 : ∀ n ≥ m, P n → P (n + 1)) :
   ∀ n ≥ m, P n :=
 by apply nat.less_than_or_equal.rec h0; exact h1
 

--- a/src/tactic/fin_cases.lean
+++ b/src/tactic/fin_cases.lean
@@ -19,23 +19,14 @@ open conv.interactive
     and returns the type α. -/
 meta def guard_mem_fin (e : expr) : tactic expr :=
 do t ← infer_type e,
-   match t with
-   | `(%%x ∈ %%A) :=
-      do t ← infer_type A,
-         α ← mk_mvar,
-          -- `to_expr _ tt ff` prevents the creation of new goals:
-         to_expr ``(finset %%α)   tt ff >>= unify t <|>
-         to_expr ``(multiset %%α) tt ff >>= unify t <|>
-         to_expr ``(list %%α)     tt ff >>= unify t,
-         α ← instantiate_mvars α,
-         return α
-   -- after we start case bashing, the hypothesis may look like `list.mem x A` rather than `x ∈ A`
-   | `(@list.mem %%α %%x %%A) := return α
-   | _ := failed
-   end
+   α ← mk_mvar,
+   to_expr ``(_ ∈ (_ : finset %%α))   tt ff >>= unify t <|>
+   to_expr ``(_ ∈ (_ : multiset %%α)) tt ff >>= unify t <|>
+   to_expr ``(_ ∈ (_ : list %%α))     tt ff >>= unify t,
+   instantiate_mvars α
 
 meta def expr_list_to_list_expr : Π (e : expr), tactic (list expr)
-| `(list.cons %%h %%t) := do t ← expr_list_to_list_expr t, return (h :: t)
+| `(list.cons %%h %%t) := list.cons h <$> expr_list_to_list_expr t
 | `([]) := return []
 | _ := failed
 

--- a/src/tactic/fin_cases.lean
+++ b/src/tactic/fin_cases.lean
@@ -23,8 +23,9 @@ do t ← infer_type e,
    | `(%%x ∈ %%A) :=
       do t ← infer_type A,
         match t with
-        | `(finset %%α) := return α
-        | `(list %%α)   := return α
+        | `(finset %%α)   := return α
+        | `(multiset %%α) := return α
+        | `(list %%α)     := return α
         | _ := failed
         end
    | `(@list.mem %%α %%x %%A) := return α
@@ -42,10 +43,9 @@ focus1 $
    -- We have a goal with an equation `s`, and a second goal with a smaller `e : x ∈ _`.
    | [(_, [s], _), (_, [e], _)] :=
      do let sn := local_pp_name s,
-        if numeric then
+        when numeric
           -- tidy up with norm_num
-          tactic.interactive.conv (some sn) none (to_rhs >> `[try { norm_num }])
-        else skip,
+          (tactic.interactive.conv (some sn) none (to_rhs >> `[try { norm_num }])),
         s ← get_local sn,
         try `[subst %%s],
         rotate_left 1,

--- a/src/tactic/fin_cases.lean
+++ b/src/tactic/fin_cases.lean
@@ -15,11 +15,6 @@ open lean.parser
 open interactive interactive.types expr
 open conv.interactive
 
--- Maybe this is controversial.
--- When we do `cases h`, for `h : x ∈ range n`, a wild `nat.add` appears.
--- This simp lemma wraps it up again...
-@[simp] lemma nat.add_plus (a b : ℕ) : nat.add a b = a + b := rfl
-
 /-- Checks that the expression looks like `x ∈ A` for `A : finset α` or `A : list α`,
     and returns the type α. -/
 meta def guard_mem_fin (e : expr) : tactic expr :=

--- a/src/tactic/fin_cases.lean
+++ b/src/tactic/fin_cases.lean
@@ -85,7 +85,7 @@ after `fin_cases p`, there are three goals, `f 0`, `f 1`, and `f 2`.
 -/
 meta def fin_cases : parse hyp → tactic unit
 | none := do ctx ← local_context,
-             ctx.mfirst fin_cases_at <|> fail "No hypothesis of the forms `x ∈ A`, where `A : finset ℕ`, or `x : A`, with `[fintype A]`."
+             ctx.mfirst fin_cases_at <|> fail "No hypothesis of the forms `x ∈ A`, where `A : finset X`, `A : list X`, or `A : multiset X`, or `x : A`, with `[fintype A]`."
 | (some n) := do h ← get_local n, fin_cases_at h
 
 end interactive

--- a/src/tactic/fin_cases.lean
+++ b/src/tactic/fin_cases.lean
@@ -87,9 +87,6 @@ do ty ← try_core $ guard_mem_fin e,
         fin_cases_at_aux with_list e ty_numeric)
     end
 
-meta def fin_cases_at' (with_list : option pexpr) (e : expr) : tactic unit :=
-focus1 $ fin_cases_at with_list e
-
 namespace interactive
 private meta def hyp := tk "*" *> return none <|> some <$> ident
 local postfix `?`:9001 := optional
@@ -112,13 +109,14 @@ end
 after `fin_cases p; simp`, there are three goals, `f 0`, `f 1`, and `f 2`.
 -/
 meta def fin_cases : parse hyp → parse (tk "with" *> texpr)? → tactic unit
-| none none := do ctx ← local_context,
-                  ctx.mfirst (fin_cases_at' none) <|> fail "No hypothesis of the forms `x ∈ A`, where `A : finset X`, `A : list X`, or `A : multiset X`, or `x : A`, with `[fintype A]`."
+| none none := focus1 $
+               do ctx ← local_context,
+                  ctx.mfirst (fin_cases_at none) <|> fail "No hypothesis of the forms `x ∈ A`, where `A : finset X`, `A : list X`, or `A : multiset X`, or `x : A`, with `[fintype A]`."
 | none (some _) := fail "Specify a single hypothesis when using a `with` argument."
 | (some n) with_list :=
   do
     h ← get_local n,
-    fin_cases_at' with_list h
+    focus1 $ fin_cases_at with_list h
 
 end interactive
 

--- a/src/tactic/fin_cases.lean
+++ b/src/tactic/fin_cases.lean
@@ -3,49 +3,80 @@ Copyright (c) 2018 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Scott Morrison
 
-Case bashing on `fin n`, for explicit numerals `n`.
+Case bashing:
+* on `x ∈ A`, for `A : finset α` or `A : list α`, or
+* on `x : A`, with `[fintype A]`.
 -/
-import data.fin
-import data.finset
+import data.fintype
+import tactic.norm_num
 
 namespace tactic
 open lean.parser
 open interactive interactive.types expr
+open conv.interactive
 
-meta def finset_cases_at (e : expr) : tactic unit :=
-do `(%%x ∈ %%A) ← infer_type e,
-   `(finset %%α) ← infer_type A,
-   eval_expr (list ℕ) `(@finset.sort ℕ (<) _ _ _ _ %%A) >>= trace
+-- Maybe this is controversial.
+-- When we do `cases h`, for `h : x ∈ range n`, a wild `nat.add` appears.
+-- This simp lemma wraps it up again...
+@[simp] lemma nat.add_plus (a b : ℕ) : nat.add a b = a + b := rfl
 
-meta def fin_cases_at (e : expr) : tactic unit :=
-do `(fin %%n) ← infer_type e,
-   n ← eval_expr ℕ n,
-   [(_, [val, bd], _)] ← cases_core e [`val, `bd],
-   -- We now call `cases val` n times, rotating the generated goals out of the way.
-   iterate_at_most n (do val ← get_local `val, cases val, rotate 1),
-   -- We've got an absurd hypothesis `bd`, but it is messy: it looks like
-   -- `nat.succ (... (nat.succ val)) < n`
-   -- So we rewrite it as `bd : val + 1 + ... + 1 < n`, and use `dec_trivial` to kill it.
-   ss ← mk_const `nat.succ_eq_add_one,
-   bd ← get_local `bd,
-   (list.range n).mfoldl (λ bd _, do rewrite_hyp ss bd) bd,
-   to_expr ``(absurd %%bd dec_trivial) >>= exact,
-   -- We put the goals back in order, and clear the `bd` hypotheses.
-   iterate_exactly n (do rotate_right 1,
-                         try `[rw [fin.mk_val]],
-                         try (get_local `bd >>= clear))
+/-- Checks that the expression looks like `x ∈ A` for `A : finset α` or `A : list α`,
+    and returns the type α. -/
+meta def guard_mem_fin (e : expr) : tactic expr :=
+do t ← infer_type e,
+   match t with
+   | `(%%x ∈ %%A) :=
+      do t ← infer_type A,
+        match t with
+        | `(finset %%α) := return α
+        | `(list %%α)   := return α
+        | _ := failed
+        end
+   | `(@list.mem %%α %%x %%A) := return α
+   | _ := failed
+   end
+
+meta def fin_cases_at : expr → tactic unit
+| e :=
+focus1 $
+-- Deal with `x ∈ A` hypotheses first:
+(do ty ← guard_mem_fin e,
+   numeric ← option.is_some <$> try_core (unify ty `(ℕ) <|> unify ty `(ℤ) <|> unify ty `(ℚ)),
+   result ← cases_core e,
+   match result with
+   -- We have a goal with an equation `s`, and a second goal with a smaller `e : x ∈ _`.
+   | [(_, [s], _), (_, [e], _)] :=
+     do let sn := local_pp_name s,
+        if numeric then
+          -- tidy up with norm_num
+          tactic.interactive.conv (some sn) none (to_rhs >> `[try { norm_num }])
+        else skip,
+        s ← get_local sn,
+        try `[subst %%s],
+        rotate_left 1,
+        fin_cases_at e
+   -- No cases; we're done.
+   | [] := skip
+   | _ := failed
+   end) <|>
+-- Otherwise deal with `x : A`, where `[fintype A]` is available:
+(do
+   ty ← infer_type e,
+   i ← to_expr ``(fintype %%ty) >>= mk_instance,
+   t ← to_expr ``(%%e ∈ @fintype.elems %%ty %%i),
+   v ← to_expr ``(@fintype.complete %%ty %%i %%e),
+   h ← assertv `h t v,
+   fin_cases_at h)
 
 namespace interactive
 private meta def hyp := tk "*" *> return none <|> some <$> ident
 
-meta def finset_cases : parse hyp → tactic unit
-| none := do ctx ← local_context,
-             ctx.mfirst finset_cases_at <|> fail "No explicit `x ∈ A`, where `A : finset ℕ` hypotheses."
-| (some n) := do h ← get_local n, finset_cases_at h
-
 /--
-`fin_cases h` performs case analysis on a hypothesis `h : fin n`, where `n` is an explicit natural
-number. `fin_cases *` performs case analysis on all suitable hypotheses.
+`fin_cases h` performs case analysis on a hypothesis of the form
+1) `h : A`, where `[fintype A]` is available, or
+2) `h ∈ A`, where `A : finset X` or `A : list X`.
+
+`fin_cases *` performs case analysis on all suitable hypotheses.
 
 As an example, in
 ```
@@ -59,14 +90,9 @@ after `fin_cases p`, there are three goals, `f 0`, `f 1`, and `f 2`.
 -/
 meta def fin_cases : parse hyp → tactic unit
 | none := do ctx ← local_context,
-             ctx.mfirst fin_cases_at <|> fail "No explicit `fin n` hypotheses."
+             ctx.mfirst fin_cases_at <|> fail "No hypothesis of the forms `x ∈ A`, where `A : finset ℕ`, or `x : A`, with `[fintype A]`."
 | (some n) := do h ← get_local n, fin_cases_at h
+
 end interactive
 
 end tactic
-
-open finset
-example (x : ℕ) (h : x ∈ Ico 2 4) : x = 2 ∨ x = 3 :=
-begin
-  finset_cases h,
-end

--- a/src/tactic/fin_cases.lean
+++ b/src/tactic/fin_cases.lean
@@ -22,12 +22,22 @@ do t ← infer_type e,
    match t with
    | `(%%x ∈ %%A) :=
       do t ← infer_type A,
+        /- I'd thought this commented out block would work as a slightly
+        -- more general replacement for the match block.
+        -- Instead it causes a mysterious problem, re-ordering goals?! -/
+        --  α ← mk_mvar,
+        --  to_expr ``(finset %%α)   >>= unify t <|>
+        --  to_expr ``(multiset %%α) >>= unify t <|>
+        --  to_expr ``(list %%α)     >>= unify t,
+        --  α ← instantiate_mvars α,
+        --  return α
         match t with
         | `(finset %%α)   := return α
         | `(multiset %%α) := return α
         | `(list %%α)     := return α
         | _ := failed
         end
+   -- after we start case bashing, the hypothesis may look like `list.mem x A` rather than `x ∈ A`
    | `(@list.mem %%α %%x %%A) := return α
    | _ := failed
    end

--- a/src/tactic/fin_cases.lean
+++ b/src/tactic/fin_cases.lean
@@ -22,21 +22,13 @@ do t ← infer_type e,
    match t with
    | `(%%x ∈ %%A) :=
       do t ← infer_type A,
-        /- I'd thought this commented out block would work as a slightly
-        -- more general replacement for the match block.
-        -- Instead it causes a mysterious problem, re-ordering goals?! -/
-        --  α ← mk_mvar,
-        --  to_expr ``(finset %%α)   >>= unify t <|>
-        --  to_expr ``(multiset %%α) >>= unify t <|>
-        --  to_expr ``(list %%α)     >>= unify t,
-        --  α ← instantiate_mvars α,
-        --  return α
-        match t with
-        | `(finset %%α)   := return α
-        | `(multiset %%α) := return α
-        | `(list %%α)     := return α
-        | _ := failed
-        end
+         α ← mk_mvar,
+          -- `to_expr _ tt ff` prevents the creation of new goals:
+         to_expr ``(finset %%α)   tt ff >>= unify t <|>
+         to_expr ``(multiset %%α) tt ff >>= unify t <|>
+         to_expr ``(list %%α)     tt ff >>= unify t,
+         α ← instantiate_mvars α,
+         return α
    -- after we start case bashing, the hypothesis may look like `list.mem x A` rather than `x ∈ A`
    | `(@list.mem %%α %%x %%A) := return α
    | _ := failed

--- a/test/fin_cases.lean
+++ b/test/fin_cases.lean
@@ -3,18 +3,9 @@ import data.nat.prime
 import group_theory.perm
 import tactic.norm_num
 
-example (p : ℕ) (h : p ∈ list.range 2) : true :=
-begin
-  cases h,
-  trivial,
-  cases h,
-  trivial,
-  cases h,
-end
-
 example (f : ℕ → Prop) (p : fin 3) (h0 : f 0) (h1 : f 1) (h2 : f 2) : f p.val :=
 begin
-  fin_cases *,
+  fin_cases *; simp,
   all_goals { assumption }
 end
 

--- a/test/fin_cases.lean
+++ b/test/fin_cases.lean
@@ -5,8 +5,10 @@ import tactic.norm_num
 
 example (f : ℕ → Prop) (p : fin 3) (h0 : f 0) (h1 : f 1) (h2 : f 2) : f p.val :=
 begin
-  fin_cases *; simp,
-  all_goals { assumption }
+  fin_cases *,
+  simp, assumption,
+  simp, assumption,
+  simp, assumption,
 end
 
 example (x2 : fin 2) (x3 : fin 3) (n : nat) (y : fin n) : x2.val * x3.val = x3.val * x2.val :=
@@ -21,13 +23,15 @@ end
 open finset
 example (x : ℕ) (h : x ∈ Ico 2 5) : x = 2 ∨ x = 3 ∨ x = 4 :=
 begin
-  fin_cases h; simp
+  fin_cases h,
+  all_goals { simp }
 end
 
 open nat
 example (x : ℕ) (h : x ∈ [2,3,5,7]) : x = 2 ∨ x = 3 ∨ x = 5 ∨ x = 7 :=
 begin
-  fin_cases h; simp
+  fin_cases h,
+  all_goals { simp }
 end
 
 example (x : ℕ) (h : x ∈ [2,3,5,7]) : true :=

--- a/test/fin_cases.lean
+++ b/test/fin_cases.lean
@@ -1,5 +1,16 @@
 import tactic.fin_cases
+import data.nat.prime
+import group_theory.perm
+import tactic.norm_num
 
+example (p : ℕ) (h : p ∈ list.range 2) : true :=
+begin
+  cases h,
+  trivial,
+  cases h,
+  trivial,
+  cases h,
+end
 
 example (f : ℕ → Prop) (p : fin 3) (h0 : f 0) (h1 : f 1) (h2 : f 2) : f p.val :=
 begin
@@ -14,4 +25,40 @@ begin
   success_if_fail { fin_cases * },
   success_if_fail { fin_cases y },
   all_goals { simp },
+end
+
+open finset
+example (x : ℕ) (h : x ∈ Ico 2 5) : x = 2 ∨ x = 3 ∨ x = 4 :=
+begin
+  fin_cases h; simp
+end
+
+open nat
+example (x : ℕ) (h : x ∈ [2,3,5,7]) : x = 2 ∨ x = 3 ∨ x = 5 ∨ x = 7 :=
+begin
+  fin_cases h; simp
+end
+
+instance (n : ℕ) : decidable (prime n) := decidable_prime_1 n
+example (x : ℕ) (h : x ∈ (range 10).filter prime) : x = 2 ∨ x = 3 ∨ x = 5 ∨ x = 7 :=
+begin
+  fin_cases h; exact dec_trivial
+end
+
+open equiv.perm
+example (x : (Σ (a : fin 4), fin 4)) (h : x ∈ fin_pairs_lt 4) : x.1.val < 4 :=
+begin
+  fin_cases h; simp,
+  any_goals { exact dec_trivial },
+end
+
+example (x : fin 3) : x.val < 5 :=
+begin
+  fin_cases x; exact dec_trivial
+end
+
+example (f : ℕ → Prop) (p : fin 3) (h0 : f 0) (h1 : f 1) (h2 : f 2) : f p.val :=
+begin
+  fin_cases *,
+  all_goals { assumption }
 end

--- a/test/fin_cases.lean
+++ b/test/fin_cases.lean
@@ -48,6 +48,14 @@ begin
   simp
 end
 
+ -- testing that `with` arguments are elaborated with respect to the expected type:
+example (x : ℤ) (h : x ∈ ([2,3] : list ℤ)) : x = 2 ∨ x = 3:=
+begin
+  fin_cases h with [2,3],
+  all_goals { simp }
+end
+
+
 instance (n : ℕ) : decidable (prime n) := decidable_prime_1 n
 example (x : ℕ) (h : x ∈ (range 10).filter prime) : x = 2 ∨ x = 3 ∨ x = 5 ∨ x = 7 :=
 begin


### PR DESCRIPTION
`fin_cases h` will case bash a hypothesis `h : x \mem A`, for `A` a list or a finset, or a hypothesis `h : x : A`, if `[fintype A]` is available.

The @[simp] lemma `lemma nat.add_plus : nat.add a b = a + b := rfl` should be moved to an appropriate home if it is acceptable, or we should work out otherwise how to deal with the annoying `nat.add`s that `list.range` somehow produces.