### PR TITLE
feat(tactic/basic): utility functions for names

### DIFF
--- a/src/tactic/basic.lean
+++ b/src/tactic/basic.lean
@@ -83,6 +83,24 @@ meta def emit_code_here : string → lean.parser unit
 
 end lean.parser
 
+namespace name
+
+meta def head : name → string
+| (mk_string s anonymous) := s
+| (mk_string s p)         := head p
+| (mk_numeral n p)        := head p
+| anonymous               := "[anonymous]"
+
+meta def is_private (n : name) : bool :=
+n.head = "_private"
+
+meta def last : name → string
+| (mk_string s _)  := s
+| (mk_numeral n _) := repr n
+| anonymous        := "[anonymous]"
+
+end name
+
 namespace tactic
 
 meta def eval_expr' (α : Type*) [_inst_1 : reflected α] (e : expr) : tactic α :=


### PR DESCRIPTION
Adding `name.head`, `name.last`, and `name.is_private` to tactic/basic.lean.

I'll use these in the upcoming `back` and `library_search` tactics.