### PR TITLE
feat(*): has_mem (set α) (filter α)

### DIFF
--- a/src/analysis/asymptotics.lean
+++ b/src/analysis/asymptotics.lean
@@ -41,10 +41,10 @@ section
 variables [has_norm β] [has_norm γ] [has_norm δ]
 
 def is_O (f : α → β) (g : α → γ) (l : filter α) : Prop :=
-∃ c > 0, { x | ∥ f x ∥ ≤ c * ∥ g x ∥ } ∈ l.sets
+∃ c > 0, { x | ∥ f x ∥ ≤ c * ∥ g x ∥ } ∈ l
 
 def is_o (f : α → β) (g : α → γ) (l : filter α) : Prop :=
-∀ c > 0, { x | ∥ f x ∥ ≤  c * ∥ g x ∥ } ∈ l.sets
+∀ c > 0, { x | ∥ f x ∥ ≤  c * ∥ g x ∥ } ∈ l
 
 theorem is_O_refl (f : α → β) (l : filter α) : is_O f f l :=
 ⟨1, zero_lt_one, by { filter_upwards [univ_mem_sets], intros x _, simp }⟩
@@ -124,14 +124,14 @@ begin
 end
 
 theorem is_O_congr {f₁ f₂ : α → β} {g₁ g₂ : α → γ} {l : filter α}
-    (hf : {x | f₁ x = f₂ x} ∈ l.sets) (hg : {x | g₁ x = g₂ x} ∈ l.sets) :
+    (hf : {x | f₁ x = f₂ x} ∈ l) (hg : {x | g₁ x = g₂ x} ∈ l) :
   is_O f₁ g₁ l ↔ is_O f₂ g₂ l :=
 bex_congr $ λ c _, filter.congr_sets $
 by filter_upwards [hf, hg] λ x e₁ e₂,
   by dsimp at e₁ e₂ ⊢; rw [e₁, e₂]
 
 theorem is_o_congr {f₁ f₂ : α → β} {g₁ g₂ : α → γ} {l : filter α}
-    (hf : {x | f₁ x = f₂ x} ∈ l.sets) (hg : {x | g₁ x = g₂ x} ∈ l.sets) :
+    (hf : {x | f₁ x = f₂ x} ∈ l) (hg : {x | g₁ x = g₂ x} ∈ l) :
   is_o f₁ g₁ l ↔ is_o f₂ g₂ l :=
 ball_congr $ λ c _, filter.congr_sets $
 by filter_upwards [hf, hg] λ x e₁ e₂,
@@ -148,12 +148,12 @@ theorem is_o.congr {f₁ f₂ : α → β} {g₁ g₂ : α → γ} {l : filter �
 (is_o_congr (univ_mem_sets' hf) (univ_mem_sets' hg)).1
 
 theorem is_O_congr_left {f₁ f₂ : α → β} {g : α → γ} {l : filter α}
-    (h : {x | f₁ x = f₂ x} ∈ l.sets) :
+    (h : {x | f₁ x = f₂ x} ∈ l) :
   is_O f₁ g l ↔ is_O f₂ g l :=
 is_O_congr h (univ_mem_sets' $ λ _, rfl)
 
 theorem is_o_congr_left {f₁ f₂ : α → β} {g : α → γ} {l : filter α}
-    (h : {x | f₁ x = f₂ x} ∈ l.sets) :
+    (h : {x | f₁ x = f₂ x} ∈ l) :
   is_o f₁ g l ↔ is_o f₂ g l :=
 is_o_congr h (univ_mem_sets' $ λ _, rfl)
 
@@ -166,12 +166,12 @@ theorem is_o.congr_left {f₁ f₂ : α → β} {g : α → γ} {l : filter α}
 is_o.congr hf (λ _, rfl)
 
 theorem is_O_congr_right {f : α → β} {g₁ g₂ : α → γ} {l : filter α}
-    (h : {x | g₁ x = g₂ x} ∈ l.sets) :
+    (h : {x | g₁ x = g₂ x} ∈ l) :
   is_O f g₁ l ↔ is_O f g₂ l :=
 is_O_congr (univ_mem_sets' $ λ _, rfl) h
 
 theorem is_o_congr_right {f : α → β} {g₁ g₂ : α → γ} {l : filter α}
-    (h : {x | g₁ x = g₂ x} ∈ l.sets) :
+    (h : {x | g₁ x = g₂ x} ∈ l) :
   is_o f g₁ l ↔ is_o f g₂ l :=
 is_o_congr (univ_mem_sets' $ λ _, rfl) h
 
@@ -209,14 +209,14 @@ theorem is_o_neg_right {f : α → β} {g : α → γ} {l : filter α} :
 by { rw ←is_o_norm_right, simp only [norm_neg], rw is_o_norm_right }
 
 theorem is_O_iff {f : α → β} {g : α → γ} {l : filter α} :
-  is_O f g l ↔ ∃ c, { x | ∥f x∥ ≤ c * ∥g x∥ } ∈ l.sets :=
-suffices (∃ c, { x | ∥f x∥ ≤ c * ∥g x∥ } ∈ l.sets) → is_O f g l,
+  is_O f g l ↔ ∃ c, { x | ∥f x∥ ≤ c * ∥g x∥ } ∈ l :=
+suffices (∃ c, { x | ∥f x∥ ≤ c * ∥g x∥ } ∈ l) → is_O f g l,
   from ⟨λ ⟨c, cpos, hc⟩, ⟨c, hc⟩, this⟩,
 assume ⟨c, hc⟩,
 or.elim (lt_or_ge 0 c)
   (assume : c > 0, ⟨c, this, hc⟩)
   (assume h'c : c ≤ 0,
-    have {x : α | ∥f x∥ ≤ 1 * ∥g x∥} ∈ l.sets,
+    have {x : α | ∥f x∥ ≤ 1 * ∥g x∥} ∈ l,
       begin
         filter_upwards [hc], intros x,
         show ∥f x∥ ≤ c * ∥g x∥ → ∥f x∥ ≤ 1 * ∥g x∥,
@@ -349,7 +349,7 @@ theorem is_O_refl_left {f : α → β} {g : α → γ} {l : filter α} :
 by simpa using is_O_zero g l
 
 theorem is_O_zero_right_iff {f : α → β} {l : filter α} :
-  is_O f (λ x, (0 : γ)) l ↔ {x | f x = 0} ∈ l.sets :=
+  is_O f (λ x, (0 : γ)) l ↔ {x | f x = 0} ∈ l :=
 begin
   rw [is_O_iff], split,
   { rintros ⟨c, hc⟩,
@@ -374,7 +374,7 @@ theorem is_o_refl_left {f : α → β} {g : α → γ} {l : filter α} :
 by simpa using is_o_zero g l
 
 theorem is_o_zero_right_iff {f : α → β} (l : filter α) :
-  is_o f (λ x, (0 : γ)) l ↔ {x | f x = 0} ∈ l.sets :=
+  is_o f (λ x, (0 : γ)) l ↔ {x | f x = 0} ∈ l :=
 begin
   split,
   { intro h, exact is_O_zero_right_iff.mp h.to_is_O },
@@ -393,8 +393,10 @@ theorem is_O_const_one (c : β) (l : filter α) :
   is_O (λ x : α, c) (λ x, (1 : γ)) l :=
 begin
   rw is_O_iff,
-  use ∥c∥, simp only [norm_one, mul_one],
-  convert univ_mem_sets, simp only [le_refl]
+  refine ⟨∥c∥, _⟩,
+  simp only [norm_one, mul_one],
+  apply univ_mem_sets',
+  simp [le_refl],
 end
 
 end
@@ -404,13 +406,13 @@ variables [normed_field β] [normed_group γ]
 
 theorem is_O_const_mul_left {f : α → β} {g : α → γ} {l : filter α} (h : is_O f g l) (c : β) :
   is_O (λ x, c * f x) g l :=
-begin
+ begin
   cases classical.em (c = 0) with h'' h'',
   { simp [h''], apply is_O_zero },
   rcases h with ⟨c', c'pos, h'⟩,
   have cne0 : ∥c∥ ≠ 0, from mt (norm_eq_zero _).mp h'',
   have cpos : ∥c∥ > 0, from lt_of_le_of_ne (norm_nonneg _) (ne.symm cne0),
-  use [∥c∥ * c', mul_pos cpos c'pos],
+  refine ⟨∥c∥ * c', mul_pos cpos c'pos, _⟩,
   filter_upwards [h'], dsimp,
   intros x h₀,
   rw [normed_field.norm_mul, mul_assoc],
@@ -467,7 +469,7 @@ begin
   have cne0 : ∥c∥ ≠ 0, from mt (norm_eq_zero _).mp h',
   have cpos : ∥c∥ > 0, from lt_of_le_of_ne (norm_nonneg _) (ne.symm cne0),
   rcases h with ⟨c', c'pos, h''⟩,
-  use [c' * ∥c∥, mul_pos c'pos cpos],
+  refine ⟨c' * ∥c∥, mul_pos c'pos cpos, _⟩,
   convert h'', ext x, dsimp,
   rw [normed_field.norm_mul, mul_assoc]
 end
@@ -546,7 +548,7 @@ theorem is_O_mul {f₁ f₂ : α → β} {g₁ g₂ : α → γ} {l : filter α}
 begin
   rcases h₁ with ⟨c₁, c₁pos, hc₁⟩,
   rcases h₂ with ⟨c₂, c₂pos, hc₂⟩,
-  use [c₁ * c₂, mul_pos c₁pos c₂pos],
+  refine ⟨c₁ * c₂, mul_pos c₁pos c₂pos, _⟩,
   filter_upwards [hc₁, hc₂], dsimp,
   intros x hx₁ hx₂,
   rw [normed_field.norm_mul, normed_field.norm_mul, mul_assoc, mul_left_comm c₂, ←mul_assoc],

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -118,7 +118,7 @@ lemma ball_0_eq (ε : ℝ) : ball (0:α) ε = {x | ∥x∥ < ε} :=
 set.ext $ assume a, by simp
 
 theorem normed_space.tendsto_nhds_zero {f : γ → α} {l : filter γ} :
-  tendsto f l (nhds 0) ↔ ∀ ε > 0, { x | ∥ f x ∥ < ε } ∈ l.sets :=
+  tendsto f l (nhds 0) ↔ ∀ ε > 0, { x | ∥ f x ∥ < ε } ∈ l :=
 begin
   rw [metric.tendsto_nhds], simp only [normed_group.dist_eq, sub_zero],
   split,

--- a/src/analysis/normed_space/deriv.lean
+++ b/src/analysis/normed_space/deriv.lean
@@ -92,7 +92,7 @@ theorem has_fderiv_at_within_of_has_fderiv_at {f : E → F} {f' : E → F} {x : 
 has_fderiv_at_filter_of_has_fderiv_at lattice.inf_le_left
 
 theorem has_fderiv_at_filter_congr' {f₀ f₁ : E → F} {f₀' f₁' : E → F} {x : E} {L : filter E}
-  (hx : f₀ x = f₁ x) (h₀ : {x | f₀ x = f₁ x} ∈ L.sets) (h₁ : ∀ x, f₀' x = f₁' x) :
+  (hx : f₀ x = f₁ x) (h₀ : {x | f₀ x = f₁ x} ∈ L) (h₁ : ∀ x, f₀' x = f₁' x) :
   has_fderiv_at_filter f₀ f₀' x L ↔ has_fderiv_at_filter f₁ f₁' x L :=
 by rw (funext h₁ : f₀' = f₁'); exact
 and_congr_right (λ _, is_o_congr

--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -36,7 +36,7 @@ tendsto_infi.2 $ assume p, tendsto_principal.2 $
       ... = 1 + add_monoid.smul n (r - 1) : by rw [add_monoid.smul_eq_mul]
       ... ≤ (1 + (r - 1)) ^ n : pow_ge_one_add_mul (le_of_lt this) _
       ... ≤ r ^ n : by simp; exact le_refl _,
-  show {n | p ≤ r ^ n} ∈ at_top.sets,
+  show {n | p ≤ r ^ n} ∈ at_top,
     from mem_at_top_sets.mpr ⟨n, assume m hnm, le_trans this (pow_le_pow (le_of_lt h) hnm)⟩
 
 lemma tendsto_inverse_at_top_nhds_0 : tendsto (λr:ℝ, r⁻¹) at_top (nhds 0) :=

--- a/src/data/analysis/filter.lean
+++ b/src/data/analysis/filter.lean
@@ -52,7 +52,7 @@ def to_filter (F : cfilter (set α) σ) : filter α :=
     subset_inter (subset.trans (F.inf_le_left _ _) h₁) (subset.trans (F.inf_le_right _ _) h₂)⟩ }
 
 @[simp] theorem mem_to_filter_sets (F : cfilter (set α) σ) {a : set α} :
-  a ∈ F.to_filter.sets ↔ ∃ b, F b ⊆ a := iff.rfl
+  a ∈ F.to_filter ↔ ∃ b, F b ⊆ a := iff.rfl
 
 end cfilter
 
@@ -66,7 +66,7 @@ protected def cfilter.to_realizer (F : cfilter (set α) σ) : F.to_filter.realiz
 
 namespace filter.realizer
 
-theorem mem_sets {f : filter α} (F : f.realizer) {a : set α} : a ∈ f.sets ↔ ∃ b, F.F b ⊆ a :=
+theorem mem_sets {f : filter α} (F : f.realizer) {a : set α} : a ∈ f ↔ ∃ b, F.F b ⊆ a :=
 by cases F; subst f; simp
 
 -- Used because it has better definitional equalities than the eq.rec proof

--- a/src/data/analysis/topology.lean
+++ b/src/data/analysis/topology.lean
@@ -55,7 +55,7 @@ theorem to_topsp_is_topological_basis (F : ctop α σ) :
 eq_univ_iff_forall.2 $ λ x, ⟨_, ⟨_, rfl⟩, F.top_mem x⟩, rfl⟩
 
 @[simp] theorem mem_nhds_to_topsp (F : ctop α σ) {s : set α} {a : α} :
-  s ∈ (@nhds _ F.to_topsp a).sets ↔ ∃ b, a ∈ F b ∧ F b ⊆ s :=
+  s ∈ @nhds _ F.to_topsp a ↔ ∃ b, a ∈ F b ∧ F b ⊆ s :=
 (@topological_space.mem_nhds_of_is_topological_basis
   _ F.to_topsp _ _ _ F.to_topsp_is_topological_basis).trans $
 ⟨λ ⟨_, ⟨x, rfl⟩, h⟩, ⟨x, h⟩, λ ⟨x, h⟩, ⟨_, ⟨x, rfl⟩, h⟩⟩
@@ -80,7 +80,7 @@ protected theorem is_basis [T : topological_space α] (F : realizer α) :
 by have := to_topsp_is_topological_basis F.F; rwa F.eq at this
 
 protected theorem mem_nhds [T : topological_space α] (F : realizer α) {s : set α} {a : α} :
-  s ∈ (nhds a).sets ↔ ∃ b, a ∈ F.F b ∧ F.F b ⊆ s :=
+  s ∈ nhds a ↔ ∃ b, a ∈ F.F b ∧ F.F b ⊆ s :=
 by have := mem_nhds_to_topsp F.F; rwa F.eq at this
 
 theorem is_open_iff [topological_space α] (F : realizer α) {s : set α} :
@@ -102,19 +102,19 @@ protected theorem is_open [topological_space α] (F : realizer α) (s : F.σ) : 
 is_open_iff_nhds.2 $ λ a m, by simpa using F.mem_nhds.2 ⟨s, m, subset.refl _⟩
 
 theorem ext' [T : topological_space α] {σ : Type*} {F : ctop α σ}
-  (H : ∀ a s, s ∈ (nhds a).sets ↔ ∃ b, a ∈ F b ∧ F b ⊆ s) :
+  (H : ∀ a s, s ∈ nhds a ↔ ∃ b, a ∈ F b ∧ F b ⊆ s) :
   F.to_topsp = T :=
 topological_space_eq $ funext $ λ s, begin
   have : ∀ T s, @topological_space.is_open _ T s ↔ _ := @is_open_iff_mem_nhds α,
   rw [this, this],
-  apply congr_arg (λ f : α → filter α, ∀ a ∈ s, s ∈ (f a).sets),
+  apply congr_arg (λ f : α → filter α, ∀ a ∈ s, s ∈ f a),
   funext a, apply filter_eq, apply set.ext, intro x,
   rw [mem_nhds_to_topsp, H]
 end
 
 theorem ext [T : topological_space α] {σ : Type*} {F : ctop α σ}
   (H₁ : ∀ a, is_open (F a))
-  (H₂ : ∀ a s, s ∈ (nhds a).sets → ∃ b, a ∈ F b ∧ F b ⊆ s) :
+  (H₂ : ∀ a s, s ∈ nhds a → ∃ b, a ∈ F b ∧ F b ⊆ s) :
   F.to_topsp = T :=
 ext' $ λ a s, ⟨H₂ a s, λ ⟨b, h₁, h₂⟩, mem_nhds_sets_iff.2 ⟨_, h₂, H₁ _, h₁⟩⟩
 

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -481,7 +481,7 @@ calc f.integral ≤ f.integral ⊔ g.integral : le_sup_left
   ... ≤ (f ⊔ g).integral : integral_sup_le _ _
   ... = g.integral : by rw [sup_of_le_right h]
 
-lemma integral_congr (f g : α →ₛ ennreal) (h : {a | f a = g a} ∈ (@measure_space.μ α _).a_e.sets) :
+lemma integral_congr (f g : α →ₛ ennreal) (h : {a | f a = g a} ∈ (@measure_space.μ α _).a_e) :
   f.integral = g.integral :=
 show ((pair f g).map prod.fst).integral = ((pair f g).map prod.snd).integral, from
 begin
@@ -546,7 +546,7 @@ begin
   refine le_antisymm
     (supr_le $ assume s, supr_le $ assume hs, _)
     (supr_le $ assume s, supr_le $ assume hs, le_supr_of_le (s.map c) $ le_supr _ hs),
-  by_cases {a | s a ≠ ⊤} ∈ ((@measure_space.μ α _).a_e).sets,
+  by_cases {a | s a ≠ ⊤} ∈ (@measure_space.μ α _).a_e,
   { have : f ≥ (s.map ennreal.to_nnreal).map c :=
       le_trans (assume a, ennreal.coe_to_nnreal_le_self) hs,
     refine le_supr_of_le (s.map ennreal.to_nnreal) (le_supr_of_le this (le_of_eq $ integral_congr _ _ _)),
@@ -736,7 +736,7 @@ lemma lintegral_le_lintegral_ae {f g : α → ennreal} (h : ∀ₘ a, f a ≤ g 
   (∫⁻ a, f a) ≤ (∫⁻ a, g a) :=
 begin
   rcases exists_is_measurable_superset_of_measure_eq_zero h with ⟨t, hts, ht, ht0⟩,
-  have : - t ∈ (@measure_space.μ α _).a_e.sets,
+  have : - t ∈ (@measure_space.μ α _).a_e,
   { rw [measure.mem_a_e_iff, lattice.neg_neg, ht0] },
   refine (supr_le $ assume s, supr_le $ assume hfs,
     le_supr_of_le (s.restrict (- t)) $ le_supr_of_le _ _),

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -861,7 +861,7 @@ associated with `α`. This means that the measure of the complementary of `p` is
 
 In a probability measure, the measure of `p` is `1`, when `p` is measurable.
 -/
-def all_ae (p : α → Prop) : Prop := { a | p a } ∈ (@measure_space.μ α _).a_e.sets
+def all_ae (p : α → Prop) : Prop := { a | p a } ∈ (@measure_space.μ α _).a_e
 
 notation `∀ₘ` binders `, ` r:(scoped P, all_ae P) := r
 

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -81,6 +81,10 @@ structure filter (α : Type*) :=
 (sets_of_superset {x y} : x ∈ sets → x ⊆ y → y ∈ sets)
 (inter_sets {x y}       : x ∈ sets → y ∈ sets → x ∩ y ∈ sets)
 
+/-- If `F` is a filter on `α`, and `U` a subset of `α` then we can write `U ∈ F` as on paper. -/
+@[reducible]
+instance {α : Type*}: has_mem (set α) (filter α) := ⟨λ U F, U ∈ F.sets⟩
+
 namespace filter
 variables {α : Type u} {f g : filter α} {s t : set α}
 
@@ -90,45 +94,45 @@ lemma filter_eq : ∀{f g : filter α}, f.sets = g.sets → f = g
 lemma filter_eq_iff : f = g ↔ f.sets = g.sets :=
 ⟨congr_arg _, filter_eq⟩
 
-protected lemma ext_iff : f = g ↔ ∀ s, s ∈ f.sets ↔ s ∈ g.sets :=
+protected lemma ext_iff : f = g ↔ ∀ s, s ∈ f ↔ s ∈ g :=
 by rw [filter_eq_iff, ext_iff]
 
 @[extensionality]
-protected lemma ext : (∀ s, s ∈ f.sets ↔ s ∈ g.sets) → f = g :=
+protected lemma ext : (∀ s, s ∈ f ↔ s ∈ g) → f = g :=
 filter.ext_iff.2
 
-lemma univ_mem_sets : univ ∈ f.sets :=
+lemma univ_mem_sets : univ ∈ f :=
 f.univ_sets
 
-lemma mem_sets_of_superset : ∀{x y : set α}, x ∈ f.sets → x ⊆ y → y ∈ f.sets :=
+lemma mem_sets_of_superset : ∀{x y : set α}, x ∈ f → x ⊆ y → y ∈ f :=
 f.sets_of_superset
 
-lemma inter_mem_sets : ∀{s t}, s ∈ f.sets → t ∈ f.sets → s ∩ t ∈ f.sets :=
+lemma inter_mem_sets : ∀{s t}, s ∈ f → t ∈ f → s ∩ t ∈ f :=
 f.inter_sets
 
-lemma univ_mem_sets' (h : ∀ a, a ∈ s): s ∈ f.sets :=
+lemma univ_mem_sets' (h : ∀ a, a ∈ s): s ∈ f :=
 mem_sets_of_superset univ_mem_sets (assume x _, h x)
 
-lemma mp_sets (hs : s ∈ f.sets) (h : {x | x ∈ s → x ∈ t} ∈ f.sets) : t ∈ f.sets :=
+lemma mp_sets (hs : s ∈ f) (h : {x | x ∈ s → x ∈ t} ∈ f) : t ∈ f :=
 mem_sets_of_superset (inter_mem_sets hs h) $ assume x ⟨h₁, h₂⟩, h₂ h₁
 
-lemma congr_sets (h : {x | x ∈ s ↔ x ∈ t} ∈ f.sets) : s ∈ f.sets ↔ t ∈ f.sets :=
+lemma congr_sets (h : {x | x ∈ s ↔ x ∈ t} ∈ f) : s ∈ f ↔ t ∈ f :=
 ⟨λ hs, mp_sets hs (mem_sets_of_superset h (λ x, iff.mp)),
  λ hs, mp_sets hs (mem_sets_of_superset h (λ x, iff.mpr))⟩
 
 lemma Inter_mem_sets {β : Type v} {s : β → set α} {is : set β} (hf : finite is) :
-  (∀i∈is, s i ∈ f.sets) → (⋂i∈is, s i) ∈ f.sets :=
+  (∀i∈is, s i ∈ f) → (⋂i∈is, s i) ∈ f :=
 finite.induction_on hf
   (assume hs, by simp only [univ_mem_sets, mem_empty_eq, Inter_neg, Inter_univ, not_false_iff])
   (assume i is _ hf hi hs,
-    have h₁ : s i ∈ f.sets, from hs i (by simp),
-    have h₂ : (⋂x∈is, s x) ∈ f.sets, from hi $ assume a ha, hs _ $ by simp only [ha, mem_insert_iff, or_true],
+    have h₁ : s i ∈ f, from hs i (by simp),
+    have h₂ : (⋂x∈is, s x) ∈ f, from hi $ assume a ha, hs _ $ by simp only [ha, mem_insert_iff, or_true],
     by simp [inter_mem_sets h₁ h₂])
 
-lemma exists_sets_subset_iff : (∃t∈f.sets, t ⊆ s) ↔ s ∈ f.sets :=
+lemma exists_sets_subset_iff : (∃t ∈ f, t ⊆ s) ↔ s ∈ f :=
 ⟨assume ⟨t, ht, ts⟩, mem_sets_of_superset ht ts, assume hs, ⟨s, hs, subset.refl _⟩⟩
 
-lemma monotone_mem_sets {f : filter α} : monotone (λs, s ∈ f.sets) :=
+lemma monotone_mem_sets {f : filter α} : monotone (λs, s ∈ f) :=
 assume s t hst h, mem_sets_of_superset h hst
 
 end filter
@@ -136,8 +140,8 @@ end filter
 namespace tactic.interactive
 open tactic interactive
 
-/-- `filter_upwards [h1, ⋯, hn]` replaces a goal of the form `s ∈ f.sets`
-and terms `h1 : t1 ∈ f.sets, ⋯, hn : tn ∈ f.sets` with `∀x, x ∈ t1 → ⋯ → x ∈ tn → x ∈ s`.
+/-- `filter_upwards [h1, ⋯, hn]` replaces a goal of the form `s ∈ f`
+and terms `h1 : t1 ∈ f, ⋯, hn : tn ∈ f` with `∀x, x ∈ t1 → ⋯ → x ∈ tn → x ∈ s`.
 
 `filter_upwards [h1, ⋯, hn] e` is a short form for `{ filter_upwards [h1, ⋯, hn], exact e }`.
 -/
@@ -169,9 +173,9 @@ def principal (s : set α) : filter α :=
 instance : inhabited (filter α) :=
 ⟨principal ∅⟩
 
-@[simp] lemma mem_principal_sets {s t : set α} : s ∈ (principal t).sets ↔ t ⊆ s := iff.rfl
+@[simp] lemma mem_principal_sets {s t : set α} : s ∈ principal t ↔ t ⊆ s := iff.rfl
 
-lemma mem_principal_self (s : set α) : s ∈ (principal s).sets := subset.refl _
+lemma mem_principal_self (s : set α) : s ∈ principal s := subset.refl _
 
 end principal
 
@@ -179,7 +183,7 @@ section join
 
 /-- The join of a filter of filters is defined by the relation `s ∈ join f ↔ {t | s ∈ t} ∈ f`. -/
 def join (f : filter (filter α)) : filter α :=
-{ sets             := {s | {t : filter α | s ∈ t.sets} ∈ f.sets},
+{ sets             := {s | {t : filter α | s ∈ t} ∈ f},
   univ_sets        := by simp only [univ_mem_sets, mem_set_of_eq]; exact univ_mem_sets,
   sets_of_superset := assume x y hx xy,
     mem_sets_of_superset hx $ assume f h, mem_sets_of_superset h xy,
@@ -187,7 +191,7 @@ def join (f : filter (filter α)) : filter α :=
     mem_sets_of_superset (inter_mem_sets hx hy) $ assume f ⟨h₁, h₂⟩, inter_mem_sets h₁ h₂ }
 
 @[simp] lemma mem_join_sets {s : set α} {f : filter (filter α)} :
-  s ∈ (join f).sets ↔ {t | s ∈ filter.sets t} ∈ f.sets := iff.rfl
+  s ∈ join f ↔ {t | s ∈ filter.sets t} ∈ f := iff.rfl
 
 end join
 
@@ -199,7 +203,7 @@ instance : partial_order (filter α) :=
   le_refl       := assume a, subset.refl _,
   le_trans      := assume a b c h₁ h₂, subset.trans h₂ h₁ }
 
-theorem le_def {f g : filter α} : f ≤ g ↔ ∀ x ∈ g.sets, x ∈ f.sets := iff.rfl
+theorem le_def {f g : filter α} : f ≤ g ↔ ∀ x ∈ g, x ∈ f := iff.rfl
 
 /-- `generate_sets g s`: `s` is in the filter closure of `g`. -/
 inductive generate_sets (g : set (set α)) : set α → Prop
@@ -224,13 +228,14 @@ iff.intro
 
 protected def mk_of_closure (s : set (set α)) (hs : (generate s).sets = s) : filter α :=
 { sets             := s,
-  univ_sets        := hs ▸ univ_mem_sets,
-  sets_of_superset := assume x y, hs ▸ mem_sets_of_superset,
-  inter_sets       := assume x y, hs ▸ inter_mem_sets }
+  univ_sets        := hs ▸ (univ_mem_sets : univ ∈ generate s),
+  sets_of_superset := assume x y, hs ▸ (mem_sets_of_superset : x ∈ generate s → x ⊆ y → y ∈ generate s),
+  inter_sets       := assume x y, hs ▸ (inter_mem_sets : x ∈ generate s → y ∈ generate s → x ∩ y ∈ generate s) }
 
 lemma mk_of_closure_sets {s : set (set α)} {hs : (generate s).sets = s} :
   filter.mk_of_closure s hs = generate s :=
-filter.ext $ assume u, hs.symm ▸ iff.refl _
+filter.ext $ assume u,
+show u ∈ (filter.mk_of_closure s hs).sets ↔ u ∈ (generate s).sets, from hs.symm ▸ iff.refl _
 
 /- Galois insertion from sets of sets into a filters. -/
 def gi_generate (α : Type*) :
@@ -243,7 +248,7 @@ def gi_generate (α : Type*) :
 /-- The infimum of filters is the filter generated by intersections
   of elements of the two filters. -/
 instance : has_inf (filter α) := ⟨λf g : filter α,
-{ sets             := {s | ∃ (a ∈ f.sets) (b ∈ g.sets), a ∩ b ⊆ s },
+{ sets             := {s | ∃ (a ∈ f) (b ∈ g), a ∩ b ⊆ s },
   univ_sets        := ⟨_, univ_mem_sets, _, univ_mem_sets, inter_subset_left _ _⟩,
   sets_of_superset := assume x y ⟨a, ha, b, hb, h⟩ xy, ⟨a, ha, b, hb, subset.trans h xy⟩,
   inter_sets       := assume x y ⟨a, ha, b, hb, hx⟩ ⟨c, hc, d, hd, hy⟩,
@@ -252,16 +257,16 @@ instance : has_inf (filter α) := ⟨λf g : filter α,
         ... ⊆ x ∩ y : inter_subset_inter hx hy⟩ }⟩
 
 @[simp] lemma mem_inf_sets {f g : filter α} {s : set α} :
-  s ∈ (f ⊓ g).sets ↔ ∃t₁∈f.sets, ∃t₂∈g.sets, t₁ ∩ t₂ ⊆ s := iff.rfl
+  s ∈ f ⊓ g ↔ ∃t₁∈f.sets, ∃t₂∈g.sets, t₁ ∩ t₂ ⊆ s := iff.rfl
 
-lemma mem_inf_sets_of_left {f g : filter α} {s : set α} (h : s ∈ f.sets) : s ∈ (f ⊓ g).sets :=
+lemma mem_inf_sets_of_left {f g : filter α} {s : set α} (h : s ∈ f) : s ∈ f ⊓ g :=
 ⟨s, h, univ, univ_mem_sets, inter_subset_left _ _⟩
 
-lemma mem_inf_sets_of_right {f g : filter α} {s : set α} (h : s ∈ g.sets) : s ∈ (f ⊓ g).sets :=
+lemma mem_inf_sets_of_right {f g : filter α} {s : set α} (h : s ∈ g) : s ∈ f ⊓ g :=
 ⟨univ, univ_mem_sets, s, h, inter_subset_right _ _⟩
 
 lemma inter_mem_inf_sets {α : Type u} {f g : filter α} {s t : set α}
-  (hs : s ∈ f.sets) (ht : t ∈ g.sets) : s ∩ t ∈ (f ⊓ g).sets :=
+  (hs : s ∈ f) (ht : t ∈ g) : s ∩ t ∈ f ⊓ g :=
 inter_mem_sets (mem_inf_sets_of_left hs) (mem_inf_sets_of_right ht)
 
 instance : has_top (filter α) :=
@@ -270,10 +275,10 @@ instance : has_top (filter α) :=
   sets_of_superset := assume x y hx hxy a, hxy (hx a),
   inter_sets       := assume x y hx hy a, mem_inter (hx _) (hy _) }⟩
 
-lemma mem_top_sets_iff_forall {s : set α} : s ∈ (⊤ : filter α).sets ↔ (∀x, x ∈ s) :=
+lemma mem_top_sets_iff_forall {s : set α} : s ∈ (⊤ : filter α) ↔ (∀x, x ∈ s) :=
 iff.refl _
 
-@[simp] lemma mem_top_sets {s : set α} : s ∈ (⊤ : filter α).sets ↔ s = univ :=
+@[simp] lemma mem_top_sets {s : set α} : s ∈ (⊤ : filter α) ↔ s = univ :=
 by rw [mem_top_sets_iff_forall, eq_univ_iff_forall]
 
 section complete_lattice
@@ -290,7 +295,7 @@ local attribute [instance] original_complete_lattice
 instance : complete_lattice (filter α) := original_complete_lattice.copy
   /- le  -/ filter.partial_order.le rfl
   /- top -/ (filter.lattice.has_top).1
-  (top_unique $ assume s hs, (eq_univ_of_forall hs).symm ▸ univ_mem_sets)
+  (top_unique $ assume s hs, by have := univ_mem_sets ; finish)
   /- bot -/ _ rfl
   /- sup -/ _ rfl
   /- inf -/ (filter.lattice.has_inf).1
@@ -298,7 +303,8 @@ instance : complete_lattice (filter α) := original_complete_lattice.copy
     ext f g : 2,
     exact le_antisymm
       (le_inf (assume s, mem_inf_sets_of_left) (assume s, mem_inf_sets_of_right))
-      (assume s ⟨a, ha, b, hb, hs⟩, mem_sets_of_superset (inter_mem_sets
+      (assume s ⟨a, ha, b, hb, hs⟩, show s ∈ complete_lattice.inf f g, from
+      mem_sets_of_superset (inter_mem_sets
         (@inf_le_left (filter α) _ _ _ _ ha)
         (@inf_le_right (filter α) _ _ _ _ hb)) hs)
   end
@@ -332,23 +338,23 @@ lemma generate_Union {s : ι → set (set α)} :
   filter.generate (⋃ i, s i) = (⨅ i, filter.generate (s i)) :=
 (gi_generate α).gc.l_supr
 
-@[simp] lemma mem_bot_sets {s : set α} : s ∈ (⊥ : filter α).sets :=
+@[simp] lemma mem_bot_sets {s : set α} : s ∈ (⊥ : filter α) :=
 trivial
 
 @[simp] lemma mem_sup_sets {f g : filter α} {s : set α} :
-  s ∈ (f ⊔ g).sets ↔ s ∈ f.sets ∧ s ∈ g.sets :=
+  s ∈ f ⊔ g ↔ s ∈ f ∧ s ∈ g :=
 iff.rfl
 
 @[simp] lemma mem_Sup_sets {x : set α} {s : set (filter α)} :
-  x ∈ (Sup s).sets ↔ (∀f∈s, x ∈ (f:filter α).sets) :=
+  x ∈ Sup s ↔ (∀f∈s, x ∈ (f:filter α)) :=
 iff.rfl
 
 @[simp] lemma mem_supr_sets {x : set α} {f : ι → filter α} :
-  x ∈ (supr f).sets ↔ (∀i, x ∈ (f i).sets) :=
+  x ∈ supr f ↔ (∀i, x ∈ f i) :=
 by simp only [supr_sets_eq, iff_self, mem_Inter]
 
-@[simp] lemma le_principal_iff {s : set α} {f : filter α} : f ≤ principal s ↔ s ∈ f.sets :=
-show (∀{t}, s ⊆ t → t ∈ f.sets) ↔ s ∈ f.sets,
+@[simp] lemma le_principal_iff {s : set α} {f : filter α} : f ≤ principal s ↔ s ∈ f :=
+show (∀{t}, s ⊆ t → t ∈ f) ↔ s ∈ f,
   from ⟨assume h, h (subset.refl s), assume hs t ht, mem_sets_of_superset hs ht⟩
 
 lemma principal_mono {s t : set α} : principal s ≤ principal t ↔ s ⊆ t :=
@@ -364,11 +370,11 @@ by simp only [le_antisymm_iff, le_principal_iff, mem_principal_sets]; refl
 
 /- lattice equations -/
 
-lemma empty_in_sets_eq_bot {f : filter α} : ∅ ∈ f.sets ↔ f = ⊥ :=
+lemma empty_in_sets_eq_bot {f : filter α} : ∅ ∈ f ↔ f = ⊥ :=
 ⟨assume h, bot_unique $ assume s _, mem_sets_of_superset h (empty_subset s),
   assume : f = ⊥, this.symm ▸ mem_bot_sets⟩
 
-lemma inhabited_of_mem_sets {f : filter α} {s : set α} (hf : f ≠ ⊥) (hs : s ∈ f.sets) :
+lemma inhabited_of_mem_sets {f : filter α} {s : set α} (hf : f ≠ ⊥) (hs : s ∈ f) :
   ∃x, x ∈ s :=
 have ∅ ∉ f.sets, from assume h, hf $ empty_in_sets_eq_bot.mp h,
 have s ≠ ∅, from assume h, this (h ▸ hs),
@@ -378,13 +384,13 @@ lemma filter_eq_bot_of_not_nonempty {f : filter α} (ne : ¬ nonempty α) : f = 
 empty_in_sets_eq_bot.mp $ univ_mem_sets' $ assume x, false.elim (ne ⟨x⟩)
 
 lemma forall_sets_neq_empty_iff_neq_bot {f : filter α} :
-  (∀ (s : set α), s ∈ f.sets → s ≠ ∅) ↔ f ≠ ⊥ :=
+  (∀ (s : set α), s ∈ f → s ≠ ∅) ↔ f ≠ ⊥ :=
 by
   simp only [(@empty_in_sets_eq_bot α f).symm, ne.def];
   exact ⟨assume h hs, h _ hs rfl, assume h s hs eq, h $ eq ▸ hs⟩
 
-lemma mem_sets_of_neq_bot {f : filter α} {s : set α} (h : f ⊓ principal (-s) = ⊥) : s ∈ f.sets :=
-have ∅ ∈ (f ⊓ principal (- s)).sets, from h.symm ▸ mem_bot_sets,
+lemma mem_sets_of_neq_bot {f : filter α} {s : set α} (h : f ⊓ principal (-s) = ⊥) : s ∈ f :=
+have ∅ ∈ f ⊓ principal (- s), from h.symm ▸ mem_bot_sets,
 let ⟨s₁, hs₁, s₂, (hs₂ : -s ⊆ s₂), (hs : s₁ ∩ s₂ ⊆ ∅)⟩ := this in
 by filter_upwards [hs₁] assume a ha, classical.by_contradiction $ assume ha', hs ⟨ha, hs₂ ha'⟩
 
@@ -406,6 +412,10 @@ subset.antisymm
   (show u ≤ infi f, from le_infi $ assume i, le_supr (λi, (f i).sets) i)
   (Union_subset $ assume i, infi_le f i)
 
+lemma mem_infi {f : ι → filter α} (h : directed (≥) f) (ne : nonempty ι) (s):
+  s ∈ infi f ↔ s ∈ ⋃ i, (f i).sets :=
+show  s  ∈ (infi f).sets ↔ s ∈ ⋃ i, (f i).sets, by rw infi_sets_eq h ne
+
 lemma infi_sets_eq' {f : β → filter α} {s : set β}
   (h : directed_on (f ⁻¹'o (≥)) s) (ne : ∃i, i ∈ s) :
   (⨅ i∈s, f i).sets = (⋃ i ∈ s, (f i).sets) :=
@@ -423,6 +433,11 @@ begin
   exact (directed_of_sup $ λs₁ s₂ hs, infi_le_infi $ λi, infi_le_infi_const $ λh, hs h),
   apply_instance
 end
+
+lemma mem_infi_finite {f : ι → filter α} (s):
+  s ∈ infi f ↔ s ∈ ⋃t:finset (plift ι), (⨅i∈t, f (plift.down i)).sets :=
+show  s ∈ (infi f).sets ↔ s ∈ ⋃t:finset (plift ι), (⨅i∈t, f (plift.down i)).sets,
+by rw infi_sets_eq_finite
 
 @[simp] lemma sup_join {f₁ f₂ : filter (filter α)} : (join f₁ ⊔ join f₂) = join (f₁ ⊔ f₂) :=
 filter_eq $ set.ext $ assume x,
@@ -466,8 +481,8 @@ begin
 end
 
 lemma mem_infi_sets_finset {s : finset α} {f : α → filter β} :
-  ∀t, t ∈ (⨅a∈s, f a).sets ↔ (∃p:α → set β, (∀a∈s, p a ∈ (f a).sets) ∧ (⋂a∈s, p a) ⊆ t) :=
-show ∀t, t ∈ (⨅a∈s, f a).sets ↔ (∃p:α → set β, (∀a∈s, p a ∈ (f a).sets) ∧ (⨅a∈s, p a) ≤ t),
+  ∀t, t ∈ (⨅a∈s, f a) ↔ (∃p:α → set β, (∀a∈s, p a ∈ f a) ∧ (⋂a∈s, p a) ⊆ t) :=
+show ∀t, t ∈ (⨅a∈s, f a) ↔ (∃p:α → set β, (∀a∈s, p a ∈ f a) ∧ (⨅a∈s, p a) ≤ t),
 begin
   simp only [(finset.inf_eq_infi _ _).symm],
   refine finset.induction_on s _ _,
@@ -517,11 +532,11 @@ bot_unique $ assume s _, empty_subset _
 ⟨assume h, principal_eq_iff_eq.mp $ by simp only [principal_empty, h, eq_self_iff_true],
   assume h, by simp only [h, principal_empty, eq_self_iff_true]⟩
 
-lemma inf_principal_eq_bot {f : filter α} {s : set α} (hs : -s ∈ f.sets) : f ⊓ principal s = ⊥ :=
+lemma inf_principal_eq_bot {f : filter α} {s : set α} (hs : -s ∈ f) : f ⊓ principal s = ⊥ :=
 empty_in_sets_eq_bot.mp ⟨_, hs, s, mem_principal_self s, assume x ⟨h₁, h₂⟩, h₁ h₂⟩
 
 theorem mem_inf_principal (f : filter α) (s t : set α) :
-  s ∈ (f ⊓ principal t).sets ↔ { x | x ∈ t → x ∈ s } ∈ f.sets :=
+  s ∈ f ⊓ principal t ↔ { x | x ∈ t → x ∈ s } ∈ f :=
 begin
   simp only [mem_inf_sets, mem_principal_sets, exists_prop], split,
   { rintros ⟨u, ul, v, tsubv, uvinter⟩,
@@ -549,15 +564,15 @@ filter_eq $ set.ext $ assume a, image_subset_iff.symm
 
 variables {f : filter α} {m : α → β} {m' : β → γ} {s : set α} {t : set β}
 
-@[simp] lemma mem_map : t ∈ (map m f).sets ↔ {x | m x ∈ t} ∈ f.sets := iff.rfl
+@[simp] lemma mem_map : t ∈ map m f ↔ {x | m x ∈ t} ∈ f := iff.rfl
 
-lemma image_mem_map (hs : s ∈ f.sets) : m '' s ∈ (map m f).sets :=
+lemma image_mem_map (hs : s ∈ f) : m '' s ∈ map m f :=
 f.sets_of_superset hs $ subset_preimage_image m s
 
-lemma range_mem_map : range m ∈ (map m f).sets :=
+lemma range_mem_map : range m ∈ map m f :=
 by rw ←image_univ; exact image_mem_map univ_mem_sets
 
-lemma mem_map_sets_iff : t ∈ (map m f).sets ↔ (∃s∈f.sets, m '' s ⊆ t) :=
+lemma mem_map_sets_iff : t ∈ map m f ↔ (∃s∈f, m '' s ⊆ t) :=
 iff.intro
   (assume ht, ⟨set.preimage m t, ht, image_preimage_subset _ _⟩)
   (assume ⟨s, hs, ht⟩, mem_sets_of_superset (image_mem_map hs) ht)
@@ -577,7 +592,7 @@ section comap
 
 /-- The inverse map of a filter -/
 def comap (m : α → β) (f : filter β) : filter α :=
-{ sets             := { s | ∃t∈f.sets, m ⁻¹' t ⊆ s },
+{ sets             := { s | ∃t∈ f, m ⁻¹' t ⊆ s },
   univ_sets        := ⟨univ, univ_mem_sets, by simp only [subset_univ, preimage_univ]⟩,
   sets_of_superset := assume a b ⟨a', ha', ma'a⟩ ab,
     ⟨a', ha', subset.trans ma'a ab⟩,
@@ -603,7 +618,7 @@ def bind (f : filter α) (m : α → filter β) : filter β := join (map m f)
 
 /-- The applicative sequentiation operation. This is not induced by the bind operation. -/
 def seq (f : filter (α → β)) (g : filter α) : filter β :=
-⟨{ s | ∃u∈f.sets, ∃t∈g.sets, (∀m∈u, ∀x∈t, (m : α → β) x ∈ s) },
+⟨{ s | ∃u∈ f, ∃t∈ g, (∀m∈u, ∀x∈t, (m : α → β) x ∈ s) },
   ⟨univ, univ_mem_sets, univ, univ_mem_sets, by simp only [forall_prop_of_true, mem_univ, forall_true_iff]⟩,
   assume s₀ s₁ ⟨t₀, t₁, h₀, h₁, h⟩ hst, ⟨t₀, t₁, h₀, h₁, assume x hx y hy, hst $ h _ hx _ hy⟩,
   assume s₀ s₁ ⟨t₀, ht₀, t₁, ht₁, ht⟩ ⟨u₀, hu₀, u₁, hu₁, hu⟩,
@@ -641,10 +656,10 @@ instance : alternative filter :=
 
 @[simp] lemma pure_def (x : α) : pure x = principal {x} := rfl
 
-@[simp] lemma mem_pure {a : α} {s : set α} : a ∈ s → s ∈ (pure a : filter α).sets :=
+@[simp] lemma mem_pure {a : α} {s : set α} : a ∈ s → s ∈ (pure a : filter α) :=
 by simp only [imp_self, pure_def, mem_principal_sets, singleton_subset_iff]; exact id
 
-@[simp] lemma mem_pure_iff {a : α} {s : set α} : s ∈ (pure a : filter α).sets ↔ a ∈ s :=
+@[simp] lemma mem_pure_iff {a : α} {s : set α} : s ∈ (pure a : filter α) ↔ a ∈ s :=
 by rw [pure_def, mem_principal_sets, set.singleton_subset_iff]
 
 @[simp] lemma map_def {α β} (m : α → β) (f : filter α) : m <$> f = map m f := rfl
@@ -655,9 +670,9 @@ by rw [pure_def, mem_principal_sets, set.singleton_subset_iff]
 section map
 variables {f f₁ f₂ : filter α} {g g₁ g₂ : filter β} {m : α → β} {m' : β → γ} {s : set α} {t : set β}
 
-@[simp] theorem mem_comap_sets : s ∈ (comap m g).sets ↔ ∃t∈g.sets, m ⁻¹' t ⊆ s := iff.rfl
+@[simp] theorem mem_comap_sets : s ∈ comap m g ↔ ∃t∈ g, m ⁻¹' t ⊆ s := iff.rfl
 
-theorem preimage_mem_comap (ht : t ∈ g.sets) : m ⁻¹' t ∈ (comap m g).sets :=
+theorem preimage_mem_comap (ht : t ∈ g) : m ⁻¹' t ∈ comap m g :=
 ⟨t, ht, subset.refl _⟩
 
 lemma comap_id : comap id f = f :=
@@ -708,7 +723,7 @@ lemma comap_supr {ι} {f : ι → filter β} {m : α → β} :
   comap m (supr f) = (⨆i, comap m (f i)) :=
 le_antisymm
   (assume s hs,
-    have ∀i, ∃t, t ∈ (f i).sets ∧ m ⁻¹' t ⊆ s, by simpa only [mem_comap_sets, exists_prop, mem_supr_sets] using mem_supr_sets.1 hs,
+    have ∀i, ∃t, t ∈ f i ∧ m ⁻¹' t ⊆ s, by simpa only [mem_comap_sets, exists_prop, mem_supr_sets] using mem_supr_sets.1 hs,
     let ⟨t, ht⟩ := classical.axiom_of_choice this in
     ⟨⋃i, t i, mem_supr_sets.2 $ assume i, (f i).sets_of_superset (ht i).1 (subset_Union _ _),
       begin
@@ -729,7 +744,7 @@ le_antisymm
       union_subset hs₁ hs₂⟩)
   (sup_le (comap_mono le_sup_left) (comap_mono le_sup_right))
 
-lemma map_comap {f : filter β} {m : α → β} (hf : range m ∈ f.sets) : (f.comap m).map m = f :=
+lemma map_comap {f : filter β} {m : α → β} (hf : range m ∈ f) : (f.comap m).map m = f :=
 le_antisymm
   map_comap_le
   (assume t' ⟨t, ht, sub⟩, by filter_upwards [ht, hf]; rintros x hxt ⟨y, rfl⟩; exact sub hxt)
@@ -746,7 +761,7 @@ le_antisymm
   le_comap_map
 
 lemma le_of_map_le_map_inj' {f g : filter α} {m : α → β} {s : set α}
-  (hsf : s ∈ f.sets) (hsg : s ∈ g.sets) (hm : ∀x∈s, ∀y∈s, m x = m y → x = y)
+  (hsf : s ∈ f) (hsg : s ∈ g) (hm : ∀x∈s, ∀y∈s, m x = m y → x = y)
   (h : map m f ≤ map m g) : f ≤ g :=
 assume t ht, by filter_upwards [hsf, h $ image_mem_map (inter_mem_sets hsg ht)]
 assume a has ⟨b, ⟨hbs, hb⟩, h⟩,
@@ -754,12 +769,12 @@ have b = a, from hm _ hbs _ has h,
 this ▸ hb
 
 lemma le_of_map_le_map_inj_iff {f g : filter α} {m : α → β} {s : set α}
-  (hsf : s ∈ f.sets) (hsg : s ∈ g.sets) (hm : ∀x∈s, ∀y∈s, m x = m y → x = y) :
+  (hsf : s ∈ f) (hsg : s ∈ g) (hm : ∀x∈s, ∀y∈s, m x = m y → x = y) :
   map m f ≤ map m g ↔ f ≤ g :=
 iff.intro (le_of_map_le_map_inj' hsf hsg hm) map_mono
 
 lemma eq_of_map_eq_map_inj' {f g : filter α} {m : α → β} {s : set α}
-  (hsf : s ∈ f.sets) (hsg : s ∈ g.sets) (hm : ∀x∈s, ∀y∈s, m x = m y → x = y)
+  (hsf : s ∈ f) (hsg : s ∈ g) (hm : ∀x∈s, ∀y∈s, m x = m y → x = y)
   (h : map m f = map m g) : f = g :=
 le_antisymm
   (le_of_map_le_map_inj' hsf hsg hm $ le_of_eq h)
@@ -770,7 +785,7 @@ lemma map_inj {f g : filter α} {m : α → β} (hm : ∀ x y, m x = m y → x =
 have comap m (map m f) = comap m (map m g), by rw h,
 by rwa [comap_map hm, comap_map hm] at this
 
-theorem le_map_comap_of_surjective' {f : α → β} {l : filter β} {u : set β} (ul : u ∈ l.sets)
+theorem le_map_comap_of_surjective' {f : α → β} {l : filter β} {u : set β} (ul : u ∈ l)
     (hf : ∀ y ∈ u, ∃ x, f x = y) :
   l ≤ map f (comap f l) :=
 assume s ⟨t, tl, ht⟩,
@@ -780,7 +795,7 @@ have t ∩ u ⊆ s, from
   by { rw ←faeq, apply ht, change f a ∈ t, rw faeq, exact xt },
 mem_sets_of_superset (inter_mem_sets tl ul) this
 
-theorem map_comap_of_surjective' {f : α → β} {l : filter β} {u : set β} (ul : u ∈ l.sets)
+theorem map_comap_of_surjective' {f : α → β} {l : filter β} {u : set β} (ul : u ∈ l)
     (hf : ∀ y ∈ u, ∃ x, f x = y)  :
   map f (comap f l) = l :=
 le_antisymm map_comap_le (le_map_comap_of_surjective' ul hf)
@@ -794,7 +809,7 @@ theorem map_comap_of_surjective {f : α → β} (hf : function.surjective f) (l 
 le_antisymm map_comap_le (le_map_comap_of_surjective hf l)
 
 lemma comap_neq_bot {f : filter β} {m : α → β}
-  (hm : ∀t∈f.sets, ∃a, m a ∈ t) : comap m f ≠ ⊥ :=
+  (hm : ∀t∈ f, ∃a, m a ∈ t) : comap m f ≠ ⊥ :=
 forall_sets_neq_empty_iff_neq_bot.mp $ assume s ⟨t, ht, t_s⟩,
   let ⟨a, (ha : a ∈ preimage m t)⟩ := hm t ht in
   neq_bot_of_le_neq_bot (ne_empty_of_mem ha) t_s
@@ -815,11 +830,11 @@ lemma map_ne_bot (hf : f ≠ ⊥) : map m f ≠ ⊥ :=
 assume h, hf $ by rwa [map_eq_bot_iff] at h
 
 lemma sInter_comap_sets (f : α → β) (F : filter β) :
-  ⋂₀(comap f F).sets = ⋂ U ∈ F.sets, f ⁻¹' U :=
+  ⋂₀(comap f F).sets = ⋂ U ∈ F, f ⁻¹' U :=
 begin
   ext x,
-  suffices : (∀ (A : set α) (B : set β), B ∈ F.sets → f ⁻¹' B ⊆ A → x ∈ A) ↔
-    ∀ (B : set β), B ∈ F.sets → f x ∈ B,
+  suffices : (∀ (A : set α) (B : set β), B ∈ F → f ⁻¹' B ⊆ A → x ∈ A) ↔
+    ∀ (B : set β), B ∈ F → f x ∈ B,
   by simp only [mem_sInter, mem_Inter, mem_comap_sets, this, and_imp, mem_comap_sets, exists_prop, mem_sInter,
     iff_self, mem_Inter, mem_preimage_eq, exists_imp_distrib],
   split,
@@ -830,12 +845,12 @@ begin
 end
 end map
 
-lemma map_cong {m₁ m₂ : α → β} {f : filter α} (h : {x | m₁ x = m₂ x} ∈ f.sets) :
+lemma map_cong {m₁ m₂ : α → β} {f : filter α} (h : {x | m₁ x = m₂ x} ∈ f) :
   map m₁ f = map m₂ f :=
-have ∀(m₁ m₂ : α → β) (h : {x | m₁ x = m₂ x} ∈ f.sets), map m₁ f ≤ map m₂ f,
+have ∀(m₁ m₂ : α → β) (h : {x | m₁ x = m₂ x} ∈ f), map m₁ f ≤ map m₂ f,
 begin
   intros  m₁ m₂ h s hs,
-  show {x | m₁ x ∈ s} ∈ f.sets,
+  show {x | m₁ x ∈ s} ∈ f,
   filter_upwards [h, hs],
   simp only [subset_def, mem_preimage_eq, mem_set_of_eq, forall_true_iff] {contextual := tt}
 end,
@@ -850,8 +865,8 @@ lemma map_infi_eq {f : ι → filter α} {m : α → β} (hf : directed (≥) f)
   map m (infi f) = (⨅ i, map m (f i)) :=
 le_antisymm
   map_infi_le
-  (assume s (hs : preimage m s ∈ (infi f).sets),
-    have ∃i, preimage m s ∈ (f i).sets,
+  (assume s (hs : preimage m s ∈ infi f),
+    have ∃i, preimage m s ∈ f i,
       by simp only [infi_sets_eq hf hι, mem_Union] at hs; assumption,
     let ⟨i, hi⟩ := this in
     have (⨅ i, map m (f i)) ≤ principal s, from
@@ -868,7 +883,7 @@ calc map m (⨅i (h : p i), f i) = map m (⨅i:subtype p, f i.val) : by simp onl
     ⟨⟨i, hi⟩⟩
   ... = (⨅i (h : p i), map m (f i)) : by simp only [infi_subtype, eq_self_iff_true]
 
-lemma map_inf' {f g : filter α} {m : α → β} {t : set α} (htf : t ∈ f.sets) (htg : t ∈ g.sets)
+lemma map_inf' {f g : filter α} {m : α → β} {t : set α} (htf : t ∈ f) (htg : t ∈ g)
   (h : ∀x∈t, ∀y∈t, m x = m y → x = y) : map m (f ⊓ g) = map m f ⊓ map m g :=
 begin
   refine le_antisymm
@@ -895,48 +910,48 @@ le_antisymm
   (assume b ⟨a, ha, (h : preimage n a ⊆ b)⟩, f.sets_of_superset ha $
     calc a = preimage (n ∘ m) a : by simp only [h₂, preimage_id, eq_self_iff_true]
       ... ⊆ preimage m b : preimage_mono h)
-  (assume b (hb : preimage m b ∈ f.sets),
+  (assume b (hb : preimage m b ∈ f),
     ⟨preimage m b, hb, show preimage (m ∘ n) b ⊆ b, by simp only [h₁]; apply subset.refl⟩)
 
 lemma map_swap_eq_comap_swap {f : filter (α × β)} : prod.swap <$> f = comap prod.swap f :=
 map_eq_comap_of_inverse prod.swap_swap_eq prod.swap_swap_eq
 
-lemma le_map {f : filter α} {m : α → β} {g : filter β} (h : ∀s∈f.sets, m '' s ∈ g.sets) :
+lemma le_map {f : filter α} {m : α → β} {g : filter β} (h : ∀s∈ f, m '' s ∈ g) :
   g ≤ f.map m :=
 assume s hs, mem_sets_of_superset (h _ hs) $ image_preimage_subset _ _
 
 section applicative
 
 @[simp] lemma mem_pure_sets {a : α} {s : set α} :
-  s ∈ (pure a : filter α).sets ↔ a ∈ s :=
+  s ∈ (pure a : filter α) ↔ a ∈ s :=
 by simp only [iff_self, pure_def, mem_principal_sets, singleton_subset_iff]
 
-lemma singleton_mem_pure_sets {a : α} : {a} ∈ (pure a : filter α).sets :=
+lemma singleton_mem_pure_sets {a : α} : {a} ∈ (pure a : filter α) :=
 by simp only [mem_singleton, pure_def, mem_principal_sets, singleton_subset_iff]
 
 @[simp] lemma pure_neq_bot {α : Type u} {a : α} : pure a ≠ (⊥ : filter α) :=
 by simp only [pure, has_pure.pure, ne.def, not_false_iff, singleton_ne_empty, principal_eq_bot_iff]
 
 lemma mem_seq_sets_def {f : filter (α → β)} {g : filter α} {s : set β} :
-  s ∈ (f.seq g).sets ↔ (∃u∈f.sets, ∃t∈g.sets, ∀x∈u, ∀y∈t, (x : α → β) y ∈ s) :=
+  s ∈ f.seq g ↔ (∃u ∈ f, ∃t ∈ g, ∀x∈u, ∀y∈t, (x : α → β) y ∈ s) :=
 iff.refl _
 
 lemma mem_seq_sets_iff {f : filter (α → β)} {g : filter α} {s : set β} :
-  s ∈ (f.seq g).sets ↔ (∃u∈f.sets, ∃t∈g.sets, set.seq u t ⊆ s) :=
+  s ∈ f.seq g ↔ (∃u ∈ f, ∃t ∈ g, set.seq u t ⊆ s) :=
 by simp only [mem_seq_sets_def, seq_subset, exists_prop, iff_self]
 
 lemma mem_map_seq_iff {f : filter α} {g : filter β} {m : α → β → γ} {s : set γ} :
-  s ∈ ((f.map m).seq g).sets ↔ (∃t u, t ∈ g.sets ∧ u ∈ f.sets ∧ ∀x∈u, ∀y∈t, m x y ∈ s) :=
+  s ∈ (f.map m).seq g ↔ (∃t u, t ∈ g ∧ u ∈ f ∧ ∀x∈u, ∀y∈t, m x y ∈ s) :=
 iff.intro
   (assume ⟨t, ht, s, hs, hts⟩, ⟨s, m ⁻¹' t, hs, ht, assume a, hts _⟩)
   (assume ⟨t, s, ht, hs, hts⟩, ⟨m '' s, image_mem_map hs, t, ht, assume f ⟨a, has, eq⟩, eq ▸ hts _ has⟩)
 
 lemma seq_mem_seq_sets {f : filter (α → β)} {g : filter α} {s : set (α → β)} {t : set α}
-  (hs : s ∈ f.sets) (ht : t ∈ g.sets): s.seq t ∈ (f.seq g).sets :=
+  (hs : s ∈ f) (ht : t ∈ g): s.seq t ∈ f.seq g :=
 ⟨s, hs, t, ht, assume f hf a ha, ⟨f, hf, a, ha, rfl⟩⟩
 
 lemma le_seq {f : filter (α → β)} {g : filter α} {h : filter β}
-  (hh : ∀t∈f.sets, ∀u∈g.sets, set.seq t u ∈ h.sets) : h ≤ seq f g :=
+  (hh : ∀t ∈ f, ∀u ∈ g, set.seq t u ∈ h) : h ≤ seq f g :=
 assume s ⟨t, ht, u, hu, hs⟩, mem_sets_of_superset (hh _ ht _ hu) $
   assume b ⟨m, hm, a, ha, eq⟩, eq ▸ hs _ hm _ ha
 
@@ -1024,14 +1039,14 @@ end applicative
 /- bind equations -/
 section bind
 @[simp] lemma mem_bind_sets {s : set β} {f : filter α} {m : α → filter β} :
-  s ∈ (bind f m).sets ↔ ∃t ∈ f.sets, ∀x ∈ t, s ∈ (m x).sets :=
-calc s ∈ (bind f m).sets ↔ {a | s ∈ (m a).sets} ∈ f.sets : by simp only [bind, mem_map, iff_self, mem_join_sets, mem_set_of_eq]
-                     ... ↔ (∃t ∈ f.sets, t ⊆ {a | s ∈ (m a).sets}) : exists_sets_subset_iff.symm
-                     ... ↔ (∃t ∈ f.sets, ∀x ∈ t, s ∈ (m x).sets) : iff.refl _
+  s ∈ bind f m ↔ ∃t ∈ f, ∀x ∈ t, s ∈ m x :=
+calc s ∈ bind f m ↔ {a | s ∈ m a} ∈ f : by simp only [bind, mem_map, iff_self, mem_join_sets, mem_set_of_eq]
+                     ... ↔ (∃t ∈ f, t ⊆ {a | s ∈ m a}) : exists_sets_subset_iff.symm
+                     ... ↔ (∃t ∈ f, ∀x ∈ t, s ∈ m x) : iff.refl _
 
-lemma bind_mono {f : filter α} {g h : α → filter β} (h₁ : {a | g a ≤ h a} ∈ f.sets) :
+lemma bind_mono {f : filter α} {g h : α → filter β} (h₁ : {a | g a ≤ h a} ∈ f) :
   bind f g ≤ bind f h :=
-assume x h₂, show (_ ∈ f.sets), by filter_upwards [h₁, h₂] assume s gh' h', gh' h'
+assume x h₂, show (_ ∈ f), by filter_upwards [h₁, h₂] assume s gh' h', gh' h'
 
 lemma bind_sup {f g : filter α} {h : α → filter β} :
   bind (f ⊔ g) h = bind f h ⊔ bind g h :=
@@ -1051,11 +1066,11 @@ end bind
 lemma infi_neq_bot_of_directed {f : ι → filter α}
   (hn : nonempty α) (hd : directed (≥) f) (hb : ∀i, f i ≠ ⊥) : (infi f) ≠ ⊥ :=
 let ⟨x⟩ := hn in
-assume h, have he: ∅ ∈ (infi f).sets, from h.symm ▸ mem_bot_sets,
+assume h, have he: ∅  ∈ (infi f), from h.symm ▸ (mem_bot_sets : ∅ ∈ (⊥ : filter α)),
 classical.by_cases
   (assume : nonempty ι,
-    have ∃i, ∅ ∈ (f i).sets,
-      by rw [infi_sets_eq hd this] at he; simp only [mem_Union] at he; assumption,
+    have ∃i, ∅ ∈ f i,
+      by rw [mem_infi hd this] at he; simp only [mem_Union] at he; assumption,
     let ⟨i, hi⟩ := this in
     hb i $ bot_unique $
     assume s _, (f i).sets_of_superset hi $ empty_subset _)
@@ -1072,16 +1087,16 @@ lemma infi_neq_bot_iff_of_directed {f : ι → filter α}
 ⟨assume neq_bot i eq_bot, neq_bot $ bot_unique $ infi_le_of_le i $ eq_bot ▸ le_refl _,
   infi_neq_bot_of_directed hn hd⟩
 
-lemma mem_infi_sets {f : ι → filter α} (i : ι) : ∀{s}, s ∈ (f i).sets → s ∈ (⨅i, f i).sets :=
+lemma mem_infi_sets {f : ι → filter α} (i : ι) : ∀{s}, s ∈ f i → s ∈ ⨅i, f i :=
 show (⨅i, f i) ≤ f i, from infi_le _ _
 
 @[elab_as_eliminator]
-lemma infi_sets_induct {f : ι → filter α} {s : set α} (hs : s ∈ (infi f).sets) {p : set α → Prop}
+lemma infi_sets_induct {f : ι → filter α} {s : set α} (hs : s ∈ infi f) {p : set α → Prop}
   (uni : p univ)
-  (ins : ∀{i s₁ s₂}, s₁ ∈ (f i).sets → p s₂ → p (s₁ ∩ s₂))
+  (ins : ∀{i s₁ s₂}, s₁ ∈ f i → p s₂ → p (s₁ ∩ s₂))
   (upw : ∀{s₁ s₂}, s₁ ⊆ s₂ → p s₁ → p s₂) : p s :=
 begin
-  rw [infi_sets_eq_finite] at hs,
+  rw [mem_infi_finite] at hs,
   simp only [mem_Union, (finset.inf_eq_infi _ _).symm] at hs,
   rcases hs with ⟨is, his⟩,
   revert s,
@@ -1101,14 +1116,14 @@ end
 def tendsto (f : α → β) (l₁ : filter α) (l₂ : filter β) := l₁.map f ≤ l₂
 
 lemma tendsto_def {f : α → β} {l₁ : filter α} {l₂ : filter β} :
-  tendsto f l₁ l₂ ↔ ∀ s ∈ l₂.sets, f ⁻¹' s ∈ l₁.sets := iff.rfl
+  tendsto f l₁ l₂ ↔ ∀ s ∈ l₂, f ⁻¹' s ∈ l₁ := iff.rfl
 
 lemma tendsto_iff_comap {f : α → β} {l₁ : filter α} {l₂ : filter β} :
   tendsto f l₁ l₂ ↔ l₁ ≤ l₂.comap f :=
 map_le_iff_le_comap
 
 lemma tendsto.congr' {f₁ f₂ : α → β} {l₁ : filter α} {l₂ : filter β}
-  (hl : {x | f₁ x = f₂ x} ∈ l₁.sets) (h : tendsto f₁ l₁ l₂) : tendsto f₂ l₁ l₂ :=
+  (hl : {x | f₁ x = f₂ x} ∈ l₁) (h : tendsto f₁ l₁ l₂) : tendsto f₂ l₁ l₂ :=
 by rwa [tendsto, ←map_cong hl]
 
 theorem tendsto.congr'r {f₁ f₂ : α → β} {l₁ : filter α} {l₂ : filter β}
@@ -1156,7 +1171,7 @@ lemma tendsto_comap_iff {f : α → β} {g : β → γ} {a : filter α} {c : fil
 ⟨assume h, h.comp tendsto_comap, assume h, map_le_iff_le_comap.mp $ by rwa [map_map]⟩
 
 lemma tendsto_comap'_iff {m : α → β} {f : filter α} {g : filter β} {i : γ → α}
-  (h : range i ∈ f.sets) : tendsto (m ∘ i) (comap i f) g ↔ tendsto m f g :=
+  (h : range i ∈ f) : tendsto (m ∘ i) (comap i f) g ↔ tendsto m f g :=
 by rw [tendsto, ← map_compose]; simp only [(∘), map_comap h, tendsto]
 
 lemma comap_eq_of_inverse {f : filter α} {g : filter β} {φ : α → β} (ψ : β → α)
@@ -1196,7 +1211,7 @@ lemma tendsto_infi' {f : α → β} {x : ι → filter α} {y : filter β} (i : 
 tendsto_le_left (infi_le _ _)
 
 lemma tendsto_principal {f : α → β} {a : filter α} {s : set β} :
-  tendsto f a (principal s) ↔ {a | f a ∈ s} ∈ a.sets :=
+  tendsto f a (principal s) ↔ {a | f a ∈ s} ∈ a :=
 by simp only [tendsto, le_principal_iff, mem_map, iff_self]
 
 lemma tendsto_principal_principal {f : α → β} {s : set α} {t : set β} :
@@ -1250,11 +1265,11 @@ protected def prod (f : filter α) (g : filter β) : filter (α × β) :=
 f.comap prod.fst ⊓ g.comap prod.snd
 
 lemma prod_mem_prod {s : set α} {t : set β} {f : filter α} {g : filter β}
-  (hs : s ∈ f.sets) (ht : t ∈ g.sets) : set.prod s t ∈ (filter.prod f g).sets :=
+  (hs : s ∈ f) (ht : t ∈ g) : set.prod s t ∈ filter.prod f g :=
 inter_mem_inf_sets (preimage_mem_comap hs) (preimage_mem_comap ht)
 
 lemma mem_prod_iff {s : set (α×β)} {f : filter α} {g : filter β} :
-  s ∈ (filter.prod f g).sets ↔ (∃t₁∈f.sets, ∃t₂∈g.sets, set.prod t₁ t₂ ⊆ s) :=
+  s ∈ filter.prod f g ↔ (∃ t₁ ∈ f, ∃ t₂ ∈ g, set.prod t₁ t₂ ⊆ s) :=
 begin
   simp only [filter.prod],
   split,
@@ -1356,7 +1371,7 @@ by rw [(≠), prod_eq_bot, not_or_distrib]
 
 lemma tendsto_prod_iff {f : α × β → γ} {x : filter α} {y : filter β} {z : filter γ} :
   filter.tendsto f (filter.prod x y) z ↔
-  ∀ W ∈ z.sets, ∃ U ∈ x.sets,  ∃ V ∈ y.sets, ∀ x y, x ∈ U → y ∈ V → f (x, y) ∈ W :=
+  ∀ W ∈ z, ∃ U ∈ x,  ∃ V ∈ y, ∀ x y, x ∈ U → y ∈ V → f (x, y) ∈ W :=
 by simp only [tendsto_def, mem_prod_iff, prod_sub_preimage_iff, exists_prop, iff_self]
 
 end prod
@@ -1375,7 +1390,7 @@ def at_top [preorder α] : filter α := ⨅ a, principal {b | a ≤ b}
   and indeed is trivial when a bottom element exists.) -/
 def at_bot [preorder α] : filter α := ⨅ a, principal {b | b ≤ a}
 
-lemma mem_at_top [preorder α] (a : α) : {b : α | a ≤ b} ∈ (@at_top α _).sets :=
+lemma mem_at_top [preorder α] (a : α) : {b : α | a ≤ b} ∈ @at_top α _ :=
 mem_infi_sets a $ subset.refl _
 
 @[simp] lemma at_top_ne_bot [nonempty α] [semilattice_sup α] : (at_top : filter α) ≠ ⊥ :=
@@ -1385,7 +1400,7 @@ infi_neq_bot_of_directed (by apply_instance)
   (assume a, by simp only [principal_eq_bot_iff, ne.def, principal_eq_bot_iff]; exact ne_empty_of_mem (le_refl a))
 
 @[simp] lemma mem_at_top_sets [nonempty α] [semilattice_sup α] {s : set α} :
-  s ∈ (at_top : filter α).sets ↔ ∃a:α, ∀b≥a, b ∈ s :=
+  s ∈ (at_top : filter α) ↔ ∃a:α, ∀b≥a, b ∈ s :=
 let ⟨a⟩ := ‹nonempty α› in
 iff.intro
   (assume h, infi_sets_induct h ⟨a, by simp only [forall_const, mem_univ, forall_true_iff]⟩
@@ -1403,11 +1418,11 @@ calc map f (⨅a, principal {a' | a ≤ a'}) = (⨅a, map f $ principal {a' | a 
   ... = (⨅a, principal $ f '' {a' | a ≤ a'}) : by simp only [map_principal, eq_self_iff_true]
 
 lemma tendsto_at_top [preorder β] (m : α → β) (f : filter α) :
-  tendsto m f at_top ↔ (∀b, {a | b ≤ m a} ∈ f.sets) :=
+  tendsto m f at_top ↔ (∀b, {a | b ≤ m a} ∈ f) :=
 by simp only [at_top, tendsto_infi, tendsto_principal]; refl
 
 lemma tendsto_at_top' [nonempty α] [semilattice_sup α] (f : α → β) (l : filter β) :
-  tendsto f at_top l ↔ (∀s∈l.sets, ∃a, ∀b≥a, f b ∈ s) :=
+  tendsto f at_top l ↔ (∀s ∈ l, ∃a, ∀b≥a, f b ∈ s) :=
 by simp only [tendsto_def, mem_at_top_sets]; refl
 
 theorem tendsto_at_top_principal [nonempty β] [semilattice_sup β] {f : β → α} {s : set α} :
@@ -1528,7 +1543,7 @@ le_of_inf_eq $ ultrafilter_unique hf h inf_le_left
   A filter f is an ultrafilter if and only if for each set s,
   -s belongs to f if and only if s does not belong to f. -/
 lemma ultrafilter_iff_compl_mem_iff_not_mem :
-  is_ultrafilter f ↔ (∀ s, -s ∈ f.sets ↔ s ∉ f.sets) :=
+  is_ultrafilter f ↔ (∀ s, -s ∈ f ↔ s ∉ f) :=
 ⟨assume hf s,
    ⟨assume hns hs,
       hf.1 $ empty_in_sets_eq_bot.mp $ by convert f.inter_sets hs hns; rw [inter_compl_self],
@@ -1540,33 +1555,33 @@ lemma ultrafilter_iff_compl_mem_iff_not_mem :
  assume hf,
    ⟨mt empty_in_sets_eq_bot.mpr ((hf ∅).mp (by convert f.univ_sets; rw [compl_empty])),
     assume g hg g_le s hs, classical.by_contradiction $ mt (hf s).mpr $
-      assume : - s ∈ f.sets,
-        have s ∩ -s ∈ g.sets, from inter_mem_sets hs (g_le this),
+      assume : - s ∈ f,
+        have s ∩ -s ∈ g, from inter_mem_sets hs (g_le this),
         by simp only [empty_in_sets_eq_bot, hg, inter_compl_self] at this; contradiction⟩⟩
 
 lemma mem_or_compl_mem_of_ultrafilter (hf : is_ultrafilter f) (s : set α) :
-  s ∈ f.sets ∨ - s ∈ f.sets :=
+  s ∈ f ∨ - s ∈ f :=
 classical.or_iff_not_imp_left.2 (ultrafilter_iff_compl_mem_iff_not_mem.mp hf s).mpr
 
-lemma mem_or_mem_of_ultrafilter {s t : set α} (hf : is_ultrafilter f) (h : s ∪ t ∈ f.sets) :
-  s ∈ f.sets ∨ t ∈ f.sets :=
+lemma mem_or_mem_of_ultrafilter {s t : set α} (hf : is_ultrafilter f) (h : s ∪ t ∈ f) :
+  s ∈ f ∨ t ∈ f :=
 (mem_or_compl_mem_of_ultrafilter hf s).imp_right
-  (assume : -s ∈ f.sets, by filter_upwards [this, h] assume x hnx hx, hx.resolve_left hnx)
+  (assume : -s ∈ f, by filter_upwards [this, h] assume x hnx hx, hx.resolve_left hnx)
 
 lemma mem_of_finite_sUnion_ultrafilter {s : set (set α)} (hf : is_ultrafilter f) (hs : finite s)
-  : ⋃₀ s ∈ f.sets → ∃t∈s, t ∈ f.sets :=
+  : ⋃₀ s ∈ f → ∃t∈s, t ∈ f :=
 finite.induction_on hs (by simp only [empty_in_sets_eq_bot, hf.left, mem_empty_eq, sUnion_empty,
   forall_prop_of_false, exists_false, not_false_iff, exists_prop_of_false]) $
 λ t s' ht' hs' ih, by simp only [exists_prop, mem_insert_iff, set.sUnion_insert]; exact
 assume h, (mem_or_mem_of_ultrafilter hf h).elim
-  (assume : t ∈ f.sets, ⟨t, or.inl rfl, this⟩)
+  (assume : t ∈ f, ⟨t, or.inl rfl, this⟩)
   (assume h, let ⟨t, hts', ht⟩ := ih h in ⟨t, or.inr hts', ht⟩)
 
 lemma mem_of_finite_Union_ultrafilter {is : set β} {s : β → set α}
-  (hf : is_ultrafilter f) (his : finite is) (h : (⋃i∈is, s i) ∈ f.sets) : ∃i∈is, s i ∈ f.sets :=
+  (hf : is_ultrafilter f) (his : finite is) (h : (⋃i∈is, s i) ∈ f) : ∃i∈is, s i ∈ f :=
 have his : finite (image s is), from finite_image s his,
-have h : (⋃₀ image s is) ∈ f.sets, from by simp only [sUnion_image, set.sUnion_image]; assumption,
-let ⟨t, ⟨i, hi, h_eq⟩, (ht : t ∈ f.sets)⟩ := mem_of_finite_sUnion_ultrafilter hf his h in
+have h : (⋃₀ image s is) ∈ f, from by simp only [sUnion_image, set.sUnion_image]; assumption,
+let ⟨t, ⟨i, hi, h_eq⟩, (ht : t ∈ f)⟩ := mem_of_finite_sUnion_ultrafilter hf his h in
 ⟨i, hi, h_eq.symm ▸ ht⟩
 
 lemma ultrafilter_map {f : filter α} {m : α → β} (h : is_ultrafilter f) : is_ultrafilter (map m f) :=
@@ -1714,13 +1729,13 @@ open list
 
 lemma mem_traverse_sets :
   ∀(fs : list β) (us : list γ),
-    forall₂ (λb c, s c ∈ (f b).sets) fs us → traverse s us ∈ (traverse f fs).sets
+    forall₂ (λb c, s c ∈ f b) fs us → traverse s us ∈ traverse f fs
 | []      []      forall₂.nil         := mem_pure_sets.2 $ mem_singleton _
 | (f::fs) (u::us) (forall₂.cons h hs) := seq_mem_seq_sets (image_mem_map h) (mem_traverse_sets fs us hs)
 
 lemma mem_traverse_sets_iff (fs : list β) (t : set (list α)) :
-  t ∈ (traverse f fs).sets ↔
-    (∃us:list (set α), forall₂ (λb (s : set α), s ∈ (f b).sets) fs us ∧ sequence us ⊆ t) :=
+  t ∈ traverse f fs ↔
+    (∃us:list (set α), forall₂ (λb (s : set α), s ∈ f b) fs us ∧ sequence us ⊆ t) :=
 begin
   split,
   { induction fs generalizing t,

--- a/src/order/filter/partial.lean
+++ b/src/order/filter/partial.lean
@@ -25,7 +25,7 @@ theorem rmap_sets (r : rel α β) (f : filter α) : (rmap r f).sets = r.core ⁻
 
 @[simp]
 theorem mem_rmap (r : rel α β) (l : filter α) (s : set β) :
-  s ∈ (l.rmap r).sets ↔ r.core s ∈ l.sets :=
+  s ∈ l.rmap r ↔ r.core s ∈ l :=
 iff.refl _
 
 @[simp]
@@ -41,7 +41,7 @@ funext $ rmap_rmap _ _
 def rtendsto (r : rel α β) (l₁ : filter α) (l₂ : filter β) := l₁.rmap r ≤ l₂
 
 theorem rtendsto_def (r : rel α β) (l₁ : filter α) (l₂ : filter β) :
-  rtendsto r l₁ l₂ ↔ ∀ s ∈ l₂.sets, r.core s ∈ l₁.sets :=
+  rtendsto r l₁ l₂ ↔ ∀ s ∈ l₂, r.core s ∈ l₁ :=
 iff.refl _
 
 def rcomap (r : rel α β) (f : filter β) : filter α :=
@@ -75,7 +75,9 @@ funext $ rcomap_rcomap _ _
 theorem rtendsto_iff_le_comap (r : rel α β) (l₁ : filter α) (l₂ : filter β) :
   rtendsto r l₁ l₂ ↔ l₁ ≤ l₂.rcomap r :=
 begin
-  rw rtendsto_def, simp [filter.le_def, rcomap, rel.mem_image], split,
+  rw rtendsto_def,
+  change (∀ (s : set β), s ∈ l₂.sets → rel.core r s ∈ l₁) ↔ l₁ ≤ rcomap r l₂,
+  simp [filter.le_def, rcomap, rel.mem_image], split,
   intros h s t tl₂ h',
   { exact mem_sets_of_superset (h t tl₂) h' },
   intros h t tl₂,
@@ -83,7 +85,7 @@ begin
 end
 
 -- Interestingly, there does not seem to be a way to express this relation using a forward map.
--- Given a filter `f` on `α`, we want a filter `f'` on `β` such that `r.preimage s ∈ f.sets` if
+-- Given a filter `f` on `α`, we want a filter `f'` on `β` such that `r.preimage s ∈ f` if
 -- and only if `s ∈ f'`. But the intersection of two sets satsifying the lhs may be empty.
 
 def rcomap' (r : rel α β) (f : filter β) : filter α :=
@@ -97,7 +99,7 @@ def rcomap' (r : rel α β) (f : filter β) : filter α :=
 
 @[simp]
 def mem_rcomap' (r : rel α β) (l : filter β) (s : set α) :
-  s ∈ (l.rcomap' r).sets ↔ ∃ t ∈ l.sets, rel.preimage r t ⊆ s :=
+  s ∈ l.rcomap' r ↔ ∃ t ∈ l, rel.preimage r t ⊆ s :=
 iff.refl _
 
 theorem rcomap'_sets (r : rel α β) (f : filter β) :
@@ -122,7 +124,7 @@ funext $ rcomap'_rcomap' _ _
 def rtendsto' (r : rel α β) (l₁ : filter α) (l₂ : filter β) := l₁ ≤ l₂.rcomap' r
 
 theorem rtendsto'_def (r : rel α β) (l₁ : filter α) (l₂ : filter β) :
-  rtendsto' r l₁ l₂ ↔ ∀ s ∈ l₂.sets, r.preimage s ∈ l₁.sets :=
+  rtendsto' r l₁ l₂ ↔ ∀ s ∈ l₂, r.preimage s ∈ l₁ :=
 begin
   unfold rtendsto', unfold rcomap', simp [le_def, rel.mem_image], split,
   { intros h s hs, apply (h _ _ hs (set.subset.refl _)) },
@@ -145,13 +147,13 @@ def pmap (f : α →. β) (l : filter α) : filter β :=
 filter.rmap f.graph' l
 
 @[simp]
-def mem_pmap (f : α →. β) (l : filter α) (s : set β) : s ∈ (l.pmap f).sets ↔ f.core s ∈ l.sets :=
+def mem_pmap (f : α →. β) (l : filter α) (s : set β) : s ∈ l.pmap f ↔ f.core s ∈ l :=
 iff.refl _
 
 def ptendsto (f : α →. β) (l₁ : filter α) (l₂ : filter β) := l₁.pmap f ≤ l₂
 
 theorem ptendsto_def (f : α →. β) (l₁ : filter α) (l₂ : filter β) :
-  ptendsto f l₁ l₂ ↔ ∀ s ∈ l₂.sets, f.core s ∈ l₁.sets :=
+  ptendsto f l₁ l₂ ↔ ∀ s ∈ l₂, f.core s ∈ l₁ :=
 iff.refl _
 
 theorem ptendsto_iff_rtendsto (l₁ : filter α) (l₂ : filter β) (f : α →. β) :
@@ -184,7 +186,7 @@ filter.rcomap' f.graph' l
 def ptendsto' (f : α →. β) (l₁ : filter α) (l₂ : filter β) := l₁ ≤ l₂.rcomap' f.graph'
 
 theorem ptendsto'_def (f : α →. β) (l₁ : filter α) (l₂ : filter β) :
-  ptendsto' f l₁ l₂ ↔ ∀ s ∈ l₂.sets, f.preimage s ∈ l₁.sets :=
+  ptendsto' f l₁ l₂ ↔ ∀ s ∈ l₂, f.preimage s ∈ l₁ :=
 rtendsto'_def _ _ _
 
 theorem ptendsto_of_ptendsto' {f : α →. β} {l₁ : filter α} {l₂ : filter β} :
@@ -195,13 +197,13 @@ begin
   exacts mem_sets_of_superset (h s sl₂) (pfun.preimage_subset_core _ _),
 end
 
-theorem ptendsto'_of_ptendsto {f : α →. β} {l₁ : filter α} {l₂ : filter β} (h : f.dom ∈ l₁.sets) :
+theorem ptendsto'_of_ptendsto {f : α →. β} {l₁ : filter α} {l₂ : filter β} (h : f.dom ∈ l₁) :
   ptendsto f l₁ l₂ → ptendsto' f l₁ l₂ :=
 begin
   rw [ptendsto_def, ptendsto'_def],
   assume h' s sl₂,
   rw pfun.preimage_eq,
-  show pfun.core f s ∩ pfun.dom f ∈ l₁.sets,
+  show pfun.core f s ∩ pfun.dom f ∈ l₁,
   exact inter_mem_sets (h' s sl₂) h
 end
 

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -98,10 +98,10 @@ attribute [to_additive homeomorph.neg._proof_2] homeomorph.inv._proof_2
 attribute [to_additive homeomorph.neg] homeomorph.inv
 
 @[to_additive exists_nhds_half]
-lemma exists_nhds_split [topological_group α] {s : set α} (hs : s ∈ (nhds (1 : α)).sets) :
-  ∃ V ∈ (nhds (1 : α)).sets, ∀ v w ∈ V, v * w ∈ s :=
+lemma exists_nhds_split [topological_group α] {s : set α} (hs : s ∈ nhds (1 : α)) :
+  ∃ V ∈ nhds (1 : α), ∀ v w ∈ V, v * w ∈ s :=
 begin
-  have : ((λa:α×α, a.1 * a.2) ⁻¹' s) ∈ (nhds ((1, 1) : α × α)).sets :=
+  have : ((λa:α×α, a.1 * a.2) ⁻¹' s) ∈ nhds ((1, 1) : α × α) :=
     tendsto_mul' (by simpa using hs),
   rw nhds_prod_eq at this,
   rcases mem_prod_iff.1 this with ⟨V₁, H₁, V₂, H₂, H⟩,
@@ -109,20 +109,20 @@ begin
 end
 
 @[to_additive exists_nhds_half_neg]
-lemma exists_nhds_split_inv [topological_group α] {s : set α} (hs : s ∈ (nhds (1 : α)).sets) :
-  ∃ V ∈ (nhds (1 : α)).sets, ∀ v w ∈ V, v * w⁻¹ ∈ s :=
+lemma exists_nhds_split_inv [topological_group α] {s : set α} (hs : s ∈ nhds (1 : α)) :
+  ∃ V ∈ nhds (1 : α), ∀ v w ∈ V, v * w⁻¹ ∈ s :=
 begin
   have : tendsto (λa:α×α, a.1 * (a.2)⁻¹) ((nhds (1:α)).prod (nhds (1:α))) (nhds 1),
   { simpa using tendsto_mul (@tendsto_fst α α (nhds 1) (nhds 1)) (tendsto_inv tendsto_snd) },
-  have : ((λa:α×α, a.1 * (a.2)⁻¹) ⁻¹' s) ∈ ((nhds (1:α)).prod (nhds (1:α))).sets :=
+  have : ((λa:α×α, a.1 * (a.2)⁻¹) ⁻¹' s) ∈ (nhds (1:α)).prod (nhds (1:α)) :=
     this (by simpa using hs),
   rcases mem_prod_iff.1 this with ⟨V₁, H₁, V₂, H₂, H⟩,
   exact ⟨V₁ ∩ V₂, inter_mem_sets H₁ H₂, assume v w ⟨hv, _⟩ ⟨_, hw⟩, @H (v, w) ⟨hv, hw⟩⟩
 end
 
 @[to_additive exists_nhds_quarter]
-lemma exists_nhds_split4 [topological_group α] {u : set α} (hu : u ∈ (nhds (1 : α)).sets) :
-  ∃ V ∈ (nhds (1 : α)).sets, ∀ {v w s t}, v ∈ V → w ∈ V → s ∈ V → t ∈ V → v * w * s * t ∈ u :=
+lemma exists_nhds_split4 [topological_group α] {u : set α} (hu : u ∈ nhds (1 : α)) :
+  ∃ V ∈ nhds (1 : α), ∀ {v w s t}, v ∈ V → w ∈ V → s ∈ V → t ∈ V → v * w * s * t ∈ u :=
 begin
   rcases exists_nhds_split hu with ⟨W, W_nhd, h⟩,
   rcases exists_nhds_split W_nhd with ⟨V, V_nhd, h'⟩,
@@ -268,9 +268,9 @@ suffices tendsto (λp:α×α, p.1 - -p.2) ((Z α).prod (Z α)) (Z α),
   by simpa,
 (tendsto.prod_mk tendsto_fst (tendsto_snd.comp neg_Z)).comp sub_Z
 
-lemma exists_Z_half {s : set α} (hs : s ∈ (Z α).sets) : ∃ V ∈ (Z α).sets, ∀ v w ∈ V, v + w ∈ s :=
+lemma exists_Z_half {s : set α} (hs : s ∈ Z α) : ∃ V ∈ Z α, ∀ v w ∈ V, v + w ∈ s :=
 begin
-  have : ((λa:α×α, a.1 + a.2) ⁻¹' s) ∈ ((Z α).prod (Z α)).sets := add_Z (by simpa using hs),
+  have : ((λa:α×α, a.1 + a.2) ⁻¹' s) ∈ (Z α).prod (Z α) := add_Z (by simpa using hs),
   rcases mem_prod_iff.1 this with ⟨V₁, H₁, V₂, H₂, H⟩,
   exact ⟨V₁ ∩ V₂, inter_mem_sets H₁ H₂, assume v w ⟨hv, _⟩ ⟨_, hw⟩, @H (v, w) ⟨hv, hw⟩⟩
 end

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -124,7 +124,7 @@ lemma tendsto_sum_nat_of_is_sum {f : ℕ → α} (h : is_sum f a) :
   tendsto (λn:ℕ, (range n).sum f) at_top (nhds a) :=
 suffices map (λ (n : ℕ), sum (range n) f) at_top ≤ map (λ (s : finset ℕ), sum s f) at_top,
   from le_trans this h,
-assume s (hs : {t : finset ℕ | t.sum f ∈ s} ∈ at_top.sets),
+assume s (hs : {t : finset ℕ | t.sum f ∈ s} ∈ at_top),
 let ⟨t, ht⟩ := mem_at_top_sets.mp hs, ⟨n, hn⟩ := @exists_nat_subset_range t in
 mem_at_top_sets.mpr ⟨n, assume n' hn', ht _ $ finset.subset.trans hn $ range_subset.mpr hn'⟩
 

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -52,7 +52,7 @@ lemma is_closed_Icc {a b : α} : is_closed (Icc a b) :=
 is_closed_inter (is_closed_ge' a) (is_closed_le' b)
 
 lemma le_of_tendsto_of_tendsto {f g : β → α} {b : filter β} {a₁ a₂ : α} (hb : b ≠ ⊥)
-  (hf : tendsto f b (nhds a₁)) (hg : tendsto g b (nhds a₂)) (h : {b | f b ≤ g b} ∈ b.sets) :
+  (hf : tendsto f b (nhds a₁)) (hg : tendsto g b (nhds a₂)) (h : {b | f b ≤ g b} ∈ b) :
   a₁ ≤ a₂ :=
 have tendsto (λb, (f b, g b)) b (nhds (a₁, a₂)),
   by rw [nhds_prod_eq]; exact hf.prod_mk hg,
@@ -60,11 +60,11 @@ show (a₁, a₂) ∈ {p:α×α | p.1 ≤ p.2},
   from mem_of_closed_of_tendsto hb this t.is_closed_le' h
 
 lemma le_of_tendsto {f : β → α} {a b : α} {x : filter β}
-  (nt : x ≠ ⊥) (lim : tendsto f x (nhds a)) (h : f ⁻¹' {c | c ≤ b} ∈ x.sets) : a ≤ b :=
+  (nt : x ≠ ⊥) (lim : tendsto f x (nhds a)) (h : f ⁻¹' {c | c ≤ b} ∈ x) : a ≤ b :=
 le_of_tendsto_of_tendsto nt lim tendsto_const_nhds h
 
 lemma ge_of_tendsto {f : β → α} {a b : α} {x : filter β}
-  (nt : x ≠ ⊥) (lim : tendsto f x (nhds a)) (h : f ⁻¹' {c | b ≤ c} ∈ x.sets) : b ≤ a :=
+  (nt : x ≠ ⊥) (lim : tendsto f x (nhds a)) (h : f ⁻¹' {c | b ≤ c} ∈ x) : b ≤ a :=
 le_of_tendsto_of_tendsto nt tendsto_const_nhds lim h
 
 @[simp] lemma closure_le_eq [topological_space β] {f g : β → α} (hf : continuous f) (hg : continuous g) :
@@ -192,16 +192,16 @@ by rw [@is_open_iff_generate_intervals α _ _ t]; exact generate_open.basic _ �
 lemma is_open_gt' (a : α) : is_open {b:α | b < a} :=
 by rw [@is_open_iff_generate_intervals α _ _ t]; exact generate_open.basic _ ⟨a, or.inr rfl⟩
 
-lemma lt_mem_nhds {a b : α} (h : a < b) : {b | a < b} ∈ (nhds b).sets :=
+lemma lt_mem_nhds {a b : α} (h : a < b) : {b | a < b} ∈ nhds b :=
 mem_nhds_sets (is_open_lt' _) h
 
-lemma le_mem_nhds {a b : α} (h : a < b) : {b | a ≤ b} ∈ (nhds b).sets :=
+lemma le_mem_nhds {a b : α} (h : a < b) : {b | a ≤ b} ∈ nhds b :=
 (nhds b).sets_of_superset (lt_mem_nhds h) $ assume b hb, le_of_lt hb
 
-lemma gt_mem_nhds {a b : α} (h : a < b) : {a | a < b} ∈ (nhds a).sets :=
+lemma gt_mem_nhds {a b : α} (h : a < b) : {a | a < b} ∈ nhds a :=
 mem_nhds_sets (is_open_gt' _) h
 
-lemma ge_mem_nhds {a b : α} (h : a < b) : {a | a ≤ b} ∈ (nhds a).sets :=
+lemma ge_mem_nhds {a b : α} (h : a < b) : {a | a ≤ b} ∈ nhds a :=
 (nhds a).sets_of_superset (gt_mem_nhds h) $ assume b hb, le_of_lt hb
 
 lemma nhds_eq_orderable {a : α} :
@@ -220,20 +220,20 @@ from le_antisymm
     end)
 
 lemma tendsto_orderable {f : β → α} {a : α} {x : filter β} :
-  tendsto f x (nhds a) ↔ (∀a'<a, {b | a' < f b} ∈ x.sets) ∧ (∀a'>a, {b | a' > f b} ∈ x.sets) :=
+  tendsto f x (nhds a) ↔ (∀a'<a, {b | a' < f b} ∈ x) ∧ (∀a'>a, {b | a' > f b} ∈ x) :=
 by simp [@nhds_eq_orderable α _ _, tendsto_inf, tendsto_infi, tendsto_principal]
 
 /-- Also known as squeeze or sandwich theorem. -/
 lemma tendsto_of_tendsto_of_tendsto_of_le_of_le {f g h : β → α} {b : filter β} {a : α}
   (hg : tendsto g b (nhds a)) (hh : tendsto h b (nhds a))
-  (hgf : {b | g b ≤ f b} ∈ b.sets) (hfh : {b | f b ≤ h b} ∈ b.sets) :
+  (hgf : {b | g b ≤ f b} ∈ b) (hfh : {b | f b ≤ h b} ∈ b) :
   tendsto f b (nhds a) :=
 tendsto_orderable.2
   ⟨assume a' h',
-    have {b : β | a' < g b} ∈ b.sets, from (tendsto_orderable.1 hg).left a' h',
+    have {b : β | a' < g b} ∈ b, from (tendsto_orderable.1 hg).left a' h',
     by filter_upwards [this, hgf] assume a, lt_of_lt_of_le,
     assume a' h',
-    have {b : β | h b < a'} ∈ b.sets, from (tendsto_orderable.1 hh).right a' h',
+    have {b : β | h b < a'} ∈ b, from (tendsto_orderable.1 hh).right a' h',
     by filter_upwards [this, hfh] assume a h₁ h₂, lt_of_le_of_lt h₂ h₁⟩
 
 lemma nhds_orderable_unbounded {a : α} (hu : ∃u, a < u) (hl : ∃l, l < a) :
@@ -252,7 +252,7 @@ calc nhds a = (⨅b<a, principal {c | b < c}) ⊓ (⨅b>a, principal {c | c < b}
   ... = _ : by simp [inter_comm]; refl
 
 lemma tendsto_orderable_unbounded {f : β → α} {a : α} {x : filter β}
-  (hu : ∃u, a < u) (hl : ∃l, l < a) (h : ∀l u, l < a → a < u → {b | l < f b ∧ f b < u } ∈ x.sets) :
+  (hu : ∃u, a < u) (hl : ∃l, l < a) (h : ∀l u, l < a → a < u → {b | l < f b ∧ f b < u } ∈ x) :
   tendsto f x (nhds a) :=
 by rw [nhds_orderable_unbounded hu hl];
 from (tendsto_infi.2 $ assume l, tendsto_infi.2 $ assume hl,
@@ -310,7 +310,7 @@ section linear_order
 variables [topological_space α] [linear_order α] [t : orderable_topology α]
 include t
 
-lemma mem_nhds_orderable_dest {a : α} {s : set α} (hs : s ∈ (nhds a).sets) :
+lemma mem_nhds_orderable_dest {a : α} {s : set α} (hs : s ∈ nhds a) :
   ((∃u, u>a) → ∃u, a < u ∧ ∀b, a ≤ b → b < u → b ∈ s) ∧
   ((∃l, l<a) → ∃l, l < a ∧ ∀b, l < b → b ≤ a → b ∈ s) :=
 let ⟨t₁, ht₁, t₂, ht₂, hts⟩ :=
@@ -358,7 +358,7 @@ and.intro
   (assume hx, let ⟨l, hl, h⟩ := ht₁.left hx in ⟨l, hl, assume b hbl hb, hts ⟨h _ hbl, ht₂.right b hb⟩⟩)
 
 lemma mem_nhds_unbounded {a : α} {s : set α} (hu : ∃u, a < u) (hl : ∃l, l < a) :
-  s ∈ (nhds a).sets ↔ (∃l u, l < a ∧ a < u ∧ ∀b, l < b → b < u → b ∈ s) :=
+  s ∈ nhds a ↔ (∃l u, l < a ∧ a < u ∧ ∀b, l < b → b < u → b ∈ s) :=
 let ⟨l, hl'⟩ := hl, ⟨u, hu'⟩ := hu in
 have nhds a = (⨅p : {l // l < a} × {u // a < u}, principal {x | p.1.val < x ∧ x < p.2.val }),
   by simp [nhds_orderable_unbounded hu hl, infi_subtype, infi_prod],
@@ -400,7 +400,7 @@ instance orderable_topology.t2_space : t2_space α := by apply_instance
 
 instance orderable_topology.regular_space : regular_space α :=
 { regular := assume s a hs ha,
-    have -s ∈ (nhds a).sets, from mem_nhds_sets hs ha,
+    have -s ∈ nhds a, from mem_nhds_sets hs ha,
     let ⟨h₁, h₂⟩ := mem_nhds_orderable_dest this in
     have ∃t:set α, is_open t ∧ (∀l∈ s, l < a → l ∈ t) ∧ nhds a ⊓ principal t = ⊥,
       from by_cases
@@ -500,17 +500,17 @@ lemma nhds_principal_ne_bot_of_is_glb : ∀ {a : α} {s : set α}, is_glb s a �
 @nhds_principal_ne_bot_of_is_lub (order_dual α) _ _ _
 
 lemma is_lub_of_mem_nhds {s : set α} {a : α} {f : filter α}
-  (hsa : a ∈ upper_bounds s) (hsf : s ∈ f.sets) (hfa : f ⊓ nhds a ≠ ⊥) : is_lub s a :=
+  (hsa : a ∈ upper_bounds s) (hsf : s ∈ f) (hfa : f ⊓ nhds a ≠ ⊥) : is_lub s a :=
 ⟨hsa, assume b hb,
   not_lt.1 $ assume hba,
-  have s ∩ {a | b < a} ∈ (f ⊓ nhds a).sets,
+  have s ∩ {a | b < a} ∈ f ⊓ nhds a,
     from inter_mem_inf_sets hsf (mem_nhds_sets (is_open_lt' _) hba),
   let ⟨x, ⟨hxs, hxb⟩⟩ := inhabited_of_mem_sets hfa this in
   have b < b, from lt_of_lt_of_le hxb $ hb _ hxs,
   lt_irrefl b this⟩
 
 lemma is_glb_of_mem_nhds : ∀ {s : set α} {a : α} {f : filter α},
-  a ∈ lower_bounds s → s ∈ f.sets → f ⊓ nhds a ≠ ⊥ → is_glb s a :=
+  a ∈ lower_bounds s → s ∈ f → f ⊓ nhds a ≠ ⊥ → is_glb s a :=
 @is_lub_of_mem_nhds (order_dual α) _ _ _
 
 lemma is_lub_of_is_lub_of_tendsto {f : α → β} {s : set α} {a : α} {b : β}
@@ -519,7 +519,7 @@ lemma is_lub_of_is_lub_of_tendsto {f : α → β} {s : set α} {a : α} {b : β}
 have hnbot : (nhds a ⊓ principal s) ≠ ⊥, from nhds_principal_ne_bot_of_is_lub ha hs,
 have ∀a'∈s, ¬ b < f a',
   from assume a' ha' h,
-  have {x | x < f a'} ∈ (nhds b).sets, from mem_nhds_sets (is_open_gt' _) h,
+  have {x | x < f a'} ∈ nhds b, from mem_nhds_sets (is_open_gt' _) h,
   let ⟨t₁, ht₁, t₂, ht₂, hs⟩ := mem_inf_sets.mp (hb this) in
   by_cases
     (assume h : a = a',
@@ -528,9 +528,9 @@ have ∀a'∈s, ¬ b < f a',
       lt_irrefl (f a') $ by rwa [h] at this)
     (assume h : a ≠ a',
       have a' < a, from lt_of_le_of_ne (ha.left _ ha') h.symm,
-      have {x | a' < x} ∈ (nhds a).sets, from mem_nhds_sets (is_open_lt' _) this,
-      have {x | a' < x} ∩ t₁ ∈ (nhds a).sets, from inter_mem_sets this ht₁,
-      have ({x | a' < x} ∩ t₁) ∩ s ∈ (nhds a ⊓ principal s).sets,
+      have {x | a' < x} ∈ nhds a, from mem_nhds_sets (is_open_lt' _) this,
+      have {x | a' < x} ∩ t₁ ∈ nhds a, from inter_mem_sets this ht₁,
+      have ({x | a' < x} ∩ t₁) ∩ s ∈ nhds a ⊓ principal s,
         from inter_mem_inf_sets this (subset.refl s),
       let ⟨x, ⟨hx₁, hx₂⟩, hx₃⟩ := inhabited_of_mem_sets hnbot this in
       have hxa' : f x < f a', from hs ⟨hx₂, ht₂ hx₃⟩,
@@ -748,7 +748,7 @@ variables [semilattice_sup α] [topological_space α] [orderable_topology α]
 
 lemma is_bounded_le_nhds (a : α) : (nhds a).is_bounded (≤) :=
 match forall_le_or_exists_lt_sup a with
-| or.inl h := ⟨a, univ_mem_sets' h⟩
+| or.inl h := ⟨a, show {x : α | x ≤ a} ∈ nhds a, from univ_mem_sets' h⟩
 | or.inr ⟨b, hb⟩ := ⟨b, ge_mem_nhds hb⟩
 end
 
@@ -770,7 +770,7 @@ variables [semilattice_inf α] [topological_space α] [orderable_topology α]
 
 lemma is_bounded_ge_nhds (a : α) : (nhds a).is_bounded (≥) :=
 match forall_le_or_exists_lt_inf a with
-| or.inl h := ⟨a, univ_mem_sets' h⟩
+| or.inl h := ⟨a, show {x : α | a ≤ x} ∈ nhds a, from univ_mem_sets' h⟩
 | or.inr ⟨b, hb⟩ := ⟨b, le_mem_nhds hb⟩
 end
 
@@ -791,13 +791,13 @@ section conditionally_complete_linear_order
 variables [conditionally_complete_linear_order α] [topological_space α] [orderable_topology α]
 
 theorem lt_mem_sets_of_Limsup_lt {f : filter α} {b} (h : f.is_bounded (≤)) (l : f.Limsup < b) :
-  {a | a < b} ∈ f.sets :=
-let ⟨c, (h : {a : α | a ≤ c} ∈ f.sets), hcb⟩ :=
+  {a | a < b} ∈ f :=
+let ⟨c, (h : {a : α | a ≤ c} ∈ f), hcb⟩ :=
   exists_lt_of_cInf_lt (ne_empty_iff_exists_mem.2 h) l in
 mem_sets_of_superset h $ assume a hac, lt_of_le_of_lt hac hcb
 
 theorem gt_mem_sets_of_Liminf_gt : ∀ {f : filter α} {b}, f.is_bounded (≥) → f.Liminf > b →
-  {a | a > b} ∈ f.sets :=
+  {a | a > b} ∈ f :=
 @lt_mem_sets_of_Limsup_lt (order_dual α) _ _ _
 
 /-- If the liminf and the limsup of a filter coincide, then this filter converges to
@@ -811,8 +811,8 @@ tendsto_orderable.2 $ and.intro
 
 theorem Limsup_nhds (a : α) : Limsup (nhds a) = a :=
 cInf_intro (ne_empty_iff_exists_mem.2 $ is_bounded_le_nhds a)
-  (assume a' (h : {n : α | n ≤ a'} ∈ (nhds a).sets), show a ≤ a', from @mem_of_nhds α _ a _ h)
-  (assume b (hba : a < b), show ∃c (h : {n : α | n ≤ c} ∈ (nhds a).sets), c < b, from
+  (assume a' (h : {n : α | n ≤ a'} ∈ nhds a), show a ≤ a', from @mem_of_nhds α _ a _ h)
+  (assume b (hba : a < b), show ∃c (h : {n : α | n ≤ c} ∈ nhds a), c < b, from
     match dense_or_discrete hba with
     | or.inl ⟨c, hac, hcb⟩ := ⟨c, ge_mem_nhds hac, hcb⟩
     | or.inr ⟨_, h⟩        := ⟨a, (nhds a).sets_of_superset (gt_mem_nhds hba) h, hba⟩

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -162,7 +162,7 @@ def topological_add_group.to_uniform_space : uniform_space G :=
     { rcases H with ⟨U, U_nhds, U_sub⟩,
       rcases exists_nhds_half U_nhds with ⟨V, ⟨V_nhds, V_sum⟩⟩,
       existsi ((λp:G×G, p.2 - p.1) ⁻¹' V),
-      have H : (λp:G×G, p.2 - p.1) ⁻¹' V ∈ (comap (λp:G×G, p.2 - p.1) (nhds (0 : G))).sets,
+      have H : (λp:G×G, p.2 - p.1) ⁻¹' V ∈ comap (λp:G×G, p.2 - p.1) (nhds (0 : G)),
         by existsi [V, V_nhds] ; refl,
       existsi H,
       have comp_rel_sub : comp_rel ((λp:G×G, p.2 - p.1) ⁻¹' V) ((λp:G×G, p.2 - p.1) ⁻¹' V) ⊆ (λp:G×G, p.2 - p.1) ⁻¹' U,
@@ -178,7 +178,7 @@ def topological_add_group.to_uniform_space : uniform_space G :=
   begin
     intro S,
     let S' := λ x, {p : G × G | p.1 = x → p.2 ∈ S},
-    show is_open S ↔ ∀ (x : G), x ∈ S → S' x ∈ (comap (λp:G×G, p.2 - p.1) (nhds (0 : G))).sets,
+    show is_open S ↔ ∀ (x : G), x ∈ S → S' x ∈ comap (λp:G×G, p.2 - p.1) (nhds (0 : G)),
     rw [is_open_iff_mem_nhds],
     refine forall_congr (assume a, forall_congr (assume ha, _)),
     rw [← nhds_translation a, mem_comap_sets, mem_comap_sets],
@@ -359,11 +359,11 @@ variables {φ : β × δ → G} (hφ : continuous φ) [bilin : is_Z_bilin φ]
 
 include de df hφ bilin
 
-variables {W' : set G} (W'_nhd : W' ∈ (nhds (0 : G)).sets)
+variables {W' : set G} (W'_nhd : W' ∈ nhds (0 : G))
 include W'_nhd
 
 private lemma extend_Z_bilin_aux (x₀ : α) (y₁ : δ) :
-  ∃ U₂ ∈ (comap e (nhds x₀)).sets, ∀ x x' ∈ U₂, φ (x' - x, y₁) ∈ W' :=
+  ∃ U₂ ∈ comap e (nhds x₀), ∀ x x' ∈ U₂, φ (x' - x, y₁) ∈ W' :=
 begin
   let Nx := nhds x₀,
   let ee := λ u : β × β, (e u.1, e u.2),
@@ -379,7 +379,7 @@ begin
 end
 
 private lemma extend_Z_bilin_key (x₀ : α) (y₀ : γ) :
-  ∃ U ∈ (comap e (nhds x₀)).sets, ∃ V ∈ (comap f (nhds y₀)).sets,
+  ∃ U ∈ comap e (nhds x₀), ∃ V ∈ comap f (nhds y₀),
     ∀ x x' ∈ U, ∀ y y' ∈ V, φ (x', y') - φ (x, y) ∈ W' :=
 begin
   let Nx := nhds x₀,
@@ -403,7 +403,7 @@ begin
 
   rcases exists_nhds_quarter W'_nhd with ⟨W, W_nhd, W4⟩,
 
-  have : ∃ U₁ ∈ (comap e (nhds x₀)).sets, ∃ V₁ ∈ (comap f (nhds y₀)).sets,
+  have : ∃ U₁ ∈ comap e (nhds x₀), ∃ V₁ ∈ comap f (nhds y₀),
     ∀ x x' ∈ U₁, ∀ y y' ∈ V₁,  φ (x'-x, y'-y) ∈ W,
   { have := tendsto_prod_iff.1 lim_φ_sub_sub W W_nhd,
     repeat { rw [nhds_prod_eq, ←prod_comap_comap_eq] at this },
@@ -484,7 +484,9 @@ begin
 
     simp only [exists_prop],
     split,
-    { have := prod_mem_prod U'_nhd V'_nhd,
+    { change U' ∈ nhds x₀ at U'_nhd,
+      change V' ∈ nhds y₀ at V'_nhd,
+      have := prod_mem_prod U'_nhd V'_nhd,
       tauto },
     { intros p h',
       simp only [set.mem_preimage_eq, set.prod_mk_mem_set_prod_eq] at h',

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -67,10 +67,11 @@ lemma is_topological_basis_of_open_of_nhds {s : set (set α)}
     (generate_from_le h_open)⟩
 
 lemma mem_nhds_of_is_topological_basis {a : α} {s : set α} {b : set (set α)}
-  (hb : is_topological_basis b) : s ∈ (nhds a).sets ↔ ∃t∈b, a ∈ t ∧ t ⊆ s :=
+  (hb : is_topological_basis b) : s ∈ nhds a ↔ ∃t∈b, a ∈ t ∧ t ⊆ s :=
 begin
+  change s ∈ (nhds a).sets ↔ ∃t∈b, a ∈ t ∧ t ⊆ s,
   rw [hb.2.2, nhds_generate_from, infi_sets_eq'],
-  { simp only [mem_bUnion_iff, exists_prop, mem_set_of_eq, and_assoc, and.left_comm]; refl },
+  { simp only [mem_bUnion_iff, exists_prop, mem_set_of_eq, and_assoc, and.left_comm], refl },
   { exact assume s ⟨hs₁, hs₂⟩ t ⟨ht₁, ht₂⟩,
       have a ∈ s ∩ t, from ⟨hs₁, ht₁⟩,
       let ⟨u, hu₁, hu₂, hu₃⟩ := hb.1 _ hs₂ _ ht₂ _ this in

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -321,22 +321,23 @@ calc map f (nhds a) = (⨅ s ∈ {s : set α | a ∈ s ∧ is_open s}, map f (pr
   ... = _ : by simp only [map_principal]
 
 lemma mem_nhds_sets_iff {a : α} {s : set α} :
- s ∈ (nhds a).sets ↔ ∃t⊆s, is_open t ∧ a ∈ t :=
+ s ∈ nhds a ↔ ∃t⊆s, is_open t ∧ a ∈ t :=
 by simp only [nhds_sets, mem_set_of_eq, exists_prop]
 
-lemma mem_of_nhds {a : α} {s : set α} : s ∈ (nhds a).sets → a ∈ s :=
+lemma mem_of_nhds {a : α} {s : set α} : s ∈ nhds a → a ∈ s :=
 λ H, let ⟨t, ht, _, hs⟩ := mem_nhds_sets_iff.1 H in ht hs
 
 lemma mem_nhds_sets {a : α} {s : set α} (hs : is_open s) (ha : a ∈ s) :
- s ∈ (nhds a).sets :=
+ s ∈ nhds a :=
 mem_nhds_sets_iff.2 ⟨s, subset.refl _, hs, ha⟩
 
 theorem all_mem_nhds (x : α) (P : set α → Prop) (hP : ∀ s t, s ⊆ t → P s → P t) :
-  (∀ s ∈ (nhds x).sets, P s) ↔ (∀ s, is_open s → x ∈ s → P s) :=
+  (∀ s ∈ nhds x, P s) ↔ (∀ s, is_open s → x ∈ s → P s) :=
 iff.intro
   (λ h s os xs, h s (mem_nhds_sets os xs))
   (λ h t,
     begin
+      change t ∈ (nhds x).sets → P t,
       rw nhds_sets,
       rintros ⟨s, hs, opens, xs⟩,
       exact hP _ _ hs (h s opens xs),
@@ -344,28 +345,28 @@ iff.intro
 
 theorem all_mem_nhds_filter (x : α) (f : set α → set β) (hf : ∀ s t, s ⊆ t → f s ⊆ f t)
     (l : filter β) :
-  (∀ s ∈ (nhds x).sets, f s ∈ l.sets) ↔ (∀ s, is_open s → x ∈ s → f s ∈ l.sets) :=
+  (∀ s ∈ nhds x, f s ∈ l) ↔ (∀ s, is_open s → x ∈ s → f s ∈ l) :=
 all_mem_nhds _ _ (λ s t ssubt h, mem_sets_of_superset h (hf s t ssubt))
 
 theorem rtendsto_nhds {r : rel β α} {l : filter β} {a : α} :
-  rtendsto r l (nhds a) ↔ (∀ s, is_open s → a ∈ s → r.core s ∈ l.sets) :=
-all_mem_nhds_filter _ _ (λ s t h, h) _
+  rtendsto r l (nhds a) ↔ (∀ s, is_open s → a ∈ s → r.core s ∈ l) :=
+all_mem_nhds_filter _ _ (λ s t h, λ x hx, λ y hy, h (hx y hy)) _
 
 theorem rtendsto'_nhds {r : rel β α} {l : filter β} {a : α} :
-  rtendsto' r l (nhds a) ↔ (∀ s, is_open s → a ∈ s → r.preimage s ∈ l.sets) :=
+  rtendsto' r l (nhds a) ↔ (∀ s, is_open s → a ∈ s → r.preimage s ∈ l) :=
 by { rw [rtendsto'_def], apply all_mem_nhds_filter, apply rel.preimage_mono }
 
 theorem ptendsto_nhds {f : β →. α} {l : filter β} {a : α} :
-  ptendsto f l (nhds a) ↔ (∀ s, is_open s → a ∈ s → f.core s ∈ l.sets) :=
+  ptendsto f l (nhds a) ↔ (∀ s, is_open s → a ∈ s → f.core s ∈ l) :=
 rtendsto_nhds
 
 theorem ptendsto'_nhds {f : β →. α} {l : filter β} {a : α} :
-  ptendsto' f l (nhds a) ↔ (∀ s, is_open s → a ∈ s → f.preimage s ∈ l.sets) :=
+  ptendsto' f l (nhds a) ↔ (∀ s, is_open s → a ∈ s → f.preimage s ∈ l) :=
 rtendsto'_nhds
 
 theorem tendsto_nhds {f : β → α} {l : filter β} {a : α} :
-  tendsto f l (nhds a) ↔ (∀ s, is_open s → a ∈ s → f ⁻¹' s ∈ l.sets) :=
-all_mem_nhds_filter _ _ (λ s t h, h) _
+  tendsto f l (nhds a) ↔ (∀ s, is_open s → a ∈ s → f ⁻¹' s ∈ l) :=
+all_mem_nhds_filter _ _ (λ s t h, preimage_mono h) _
 
 lemma tendsto_const_nhds {a : α} {f : filter β} : tendsto (λb:β, a) f (nhds a) :=
 tendsto_nhds.mpr $ assume s hs ha, univ_mem_sets' $ assume _, ha
@@ -392,14 +393,14 @@ lemma interior_eq_nhds {s : set α} : interior s = {a | nhds a ≤ principal s} 
 set.ext $ λ x, by simp only [mem_interior, le_principal_iff, mem_nhds_sets_iff]; refl
 
 lemma mem_interior_iff_mem_nhds {s : set α} {a : α} :
-  a ∈ interior s ↔ s ∈ (nhds a).sets :=
+  a ∈ interior s ↔ s ∈ nhds a :=
 by simp only [interior_eq_nhds, le_principal_iff]; refl
 
 lemma is_open_iff_nhds {s : set α} : is_open s ↔ ∀a∈s, nhds a ≤ principal s :=
 calc is_open s ↔ s ⊆ interior s : subset_interior_iff_open.symm
   ... ↔ (∀a∈s, nhds a ≤ principal s) : by rw [interior_eq_nhds]; refl
 
-lemma is_open_iff_mem_nhds {s : set α} : is_open s ↔ ∀a∈s, s ∈ (nhds a).sets :=
+lemma is_open_iff_mem_nhds {s : set α} : is_open s ↔ ∀a∈s, s ∈ nhds a :=
 is_open_iff_nhds.trans $ forall_congr $ λ _, imp_congr_right $ λ _, le_principal_iff
 
 lemma closure_eq_nhds {s : set α} : closure s = {a | nhds a ⊓ principal s ≠ ⊥} :=
@@ -410,7 +411,7 @@ calc closure s = - interior (- s) : closure_eq_compl_interior_compl
       (show principal s ⊔ principal (-s) = ⊤, by simp only [sup_principal, union_compl_self, principal_univ])
       (by simp only [inf_principal, inter_compl_self, principal_empty])).symm
 
-theorem mem_closure_iff_nhds {s : set α} {a : α} : a ∈ closure s ↔ ∀ t ∈ (nhds a).sets, t ∩ s ≠ ∅ :=
+theorem mem_closure_iff_nhds {s : set α} {a : α} : a ∈ closure s ↔ ∀ t ∈ nhds a, t ∩ s ≠ ∅ :=
 mem_closure_iff.trans
 ⟨λ H t ht, subset_ne_empty
   (inter_subset_inter_left _ interior_subset)
@@ -420,7 +421,7 @@ mem_closure_iff.trans
 /-- `x` belongs to the closure of `s` if and only if some ultrafilter
   supported on `s` converges to `x`. -/
 lemma mem_closure_iff_ultrafilter {s : set α} {x : α} :
-  x ∈ closure s ↔ ∃ (u : ultrafilter α), s ∈ u.val.sets ∧ u.val ≤ nhds x :=
+  x ∈ closure s ↔ ∃ (u : ultrafilter α), s ∈ u.val ∧ u.val ≤ nhds x :=
 begin
   rw closure_eq_nhds, change nhds x ⊓ principal s ≠ ⊥ ↔ _, symmetry,
   convert exists_ultrafilter_iff _, ext u,
@@ -434,7 +435,7 @@ calc is_closed s ↔ closure s = s : by rw [closure_eq_iff_is_closed]
 
 lemma closure_inter_open {s t : set α} (h : is_open s) : s ∩ closure t ⊆ closure (s ∩ t) :=
 assume a ⟨hs, ht⟩,
-have s ∈ (nhds a).sets, from mem_nhds_sets h hs,
+have s ∈ nhds a, from mem_nhds_sets h hs,
 have nhds a ⊓ principal s = nhds a, from inf_of_le_left $ by rwa le_principal_iff,
 have nhds a ⊓ principal (s ∩ t) ≠ ⊥,
   from calc nhds a ⊓ principal (s ∩ t) = nhds a ⊓ (principal s ⊓ principal t) : by rw inf_principal
@@ -449,7 +450,7 @@ calc closure s \ closure t = (- closure t) ∩ closure s : by simp only [diff_eq
   ... ⊆ closure (s \ t) : closure_mono $ diff_subset_diff (subset.refl s) subset_closure
 
 lemma mem_of_closed_of_tendsto {f : β → α} {b : filter β} {a : α} {s : set α}
-  (hb : b ≠ ⊥) (hf : tendsto f b (nhds a)) (hs : is_closed s) (h : f ⁻¹' s ∈ b.sets) : a ∈ s :=
+  (hb : b ≠ ⊥) (hf : tendsto f b (nhds a)) (hs : is_closed s) (h : f ⁻¹' s ∈ b) : a ∈ s :=
 have b.map f ≤ nhds a ⊓ principal s,
   from le_trans (le_inf (le_refl _) (le_principal_iff.mpr h)) (inf_le_inf hf (le_refl _)),
 is_closed_iff_nhds.mp hs a $ neq_bot_of_le_neq_bot (map_ne_bot hb) this
@@ -461,7 +462,7 @@ is_closed_iff_nhds.mp hs _ $ neq_bot_of_le_neq_bot (@map_ne_bot _ _ _ f h) $
     le_trans (map_mono $ inf_le_right_of_le $ by simp only [comap_principal, le_principal_iff]; exact subset.refl _) (@map_comap_le _ _ _ f)
 
 lemma mem_closure_of_tendsto {f : β → α} {b : filter β} {a : α} {s : set α}
-  (hb : b ≠ ⊥) (hf : tendsto f b (nhds a)) (h : f ⁻¹' s ∈ b.sets) : a ∈ closure s :=
+  (hb : b ≠ ⊥) (hf : tendsto f b (nhds a)) (h : f ⁻¹' s ∈ b) : a ∈ closure s :=
 mem_of_closed_of_tendsto hb hf (is_closed_closure) $
   filter.mem_sets_of_superset h (preimage_mono subset_closure)
 
@@ -493,7 +494,7 @@ theorem nhds_within_univ (a : α) : nhds_within a set.univ = nhds a :=
 by rw [nhds_within, principal_univ, lattice.inf_top_eq]
 
 theorem mem_nhds_within (t : set α) (a : α) (s : set α) :
-  t ∈ (nhds_within a s).sets ↔ ∃ u, is_open u ∧ a ∈ u ∧ u ∩ s ⊆ t  :=
+  t ∈ nhds_within a s ↔ ∃ u, is_open u ∧ a ∈ u ∧ u ∩ s ⊆ t  :=
 begin
   rw [nhds_within, mem_inf_principal, mem_nhds_sets_iff], split,
   { rintros ⟨u, hu, openu, au⟩,
@@ -507,7 +508,7 @@ lattice.inf_le_inf (le_refl _) (principal_mono.mpr h)
 
 theorem nhds_within_restrict {a : α} (s : set α) {t : set α} (h₀ : a ∈ t) (h₁ : is_open t) :
   nhds_within a s = nhds_within a (s ∩ t) :=
-have s ∩ t ∈ (nhds_within a s).sets,
+have s ∩ t ∈ nhds_within a s,
   from inter_mem_sets (mem_inf_sets_of_right (mem_principal_self s))
          (mem_inf_sets_of_left (mem_nhds_sets h₁ h₀)),
 le_antisymm
@@ -582,7 +583,7 @@ section locally_finite
 /-- A family of sets in `set α` is locally finite if at every point `x:α`,
   there is a neighborhood of `x` which meets only finitely many sets in the family -/
 def locally_finite (f : β → set α) :=
-∀x:α, ∃t∈(nhds x).sets, finite {i | f i ∩ t ≠ ∅ }
+∀x:α, ∃t ∈ nhds x, finite {i | f i ∩ t ≠ ∅ }
 
 lemma locally_finite_of_finite {f : β → set α} (h : finite (univ : set β)) : locally_finite f :=
 assume x, ⟨univ, univ_mem_sets, finite_subset h $ subset_univ _⟩
@@ -646,7 +647,7 @@ assume s h, hf _ (hg s h)
 
 lemma continuous.tendsto {f : α → β} (hf : continuous f) (x) :
   tendsto f (nhds x) (nhds (f x)) | s :=
-show s ∈ (nhds (f x)).sets → s ∈ (map f (nhds x)).sets,
+show s ∈ nhds (f x) → s ∈ map f (nhds x),
 by simp [nhds_sets]; exact
 assume t t_subset t_open fx_in_t,
   ⟨f ⁻¹' t, preimage_mono t_subset, hf t t_open, fx_in_t⟩
@@ -655,7 +656,7 @@ lemma continuous_iff_continuous_at {f : α → β} : continuous f ↔ ∀ x, con
 ⟨continuous.tendsto,
   assume hf : ∀x, tendsto f (nhds x) (nhds (f x)),
   assume s, assume hs : is_open s,
-  have ∀a, f a ∈ s → s ∈ (nhds (f a)).sets,
+  have ∀a, f a ∈ s → s ∈ nhds (f a),
     by simp [nhds_sets]; exact assume a ha, ⟨s, subset.refl s, hs, ha⟩,
   show is_open (f ⁻¹' s),
     by simp [is_open_iff_nhds]; exact assume a ha, hf a (this a ha)⟩
@@ -723,7 +724,9 @@ lemma pcontinuous_iff' {f : α →. β} :
 begin
   split,
   { intros h x y h',
-    rw [ptendsto'_def, nhds_sets, nhds_sets],
+    rw [ptendsto'_def],
+    change ∀ (s : set β), s ∈ (nhds y).sets → pfun.preimage f s ∈ (nhds x).sets,
+    rw [nhds_sets, nhds_sets],
     rintros s ⟨t, tsubs, opent, yt⟩,
     exact ⟨f.preimage t, pfun.preimage_mono _ tsubs, h _ opent, ⟨y, yt, h'⟩⟩
   },
@@ -732,14 +735,15 @@ begin
   rintros x ⟨y, ys, fxy⟩ t,
   rw [mem_principal_sets],
   assume h : f.preimage s ⊆ t,
+  change t ∈ nhds x,
   apply mem_sets_of_superset _ h,
-  have h' : ∀ s ∈ (nhds y).sets, f.preimage s ∈ (nhds x).sets,
+  have h' : ∀ s ∈ nhds y, f.preimage s ∈ nhds x,
   { intros s hs,
      have : ptendsto' f (nhds x) (nhds y) := hf fxy,
      rw ptendsto'_def at this,
      exact this s hs },
-  show f.preimage s ∈ (nhds x).sets,
-  apply h', rw nhds_sets, exact ⟨s, set.subset.refl _, os, ys⟩
+  show f.preimage s ∈ nhds x,
+  apply h', rw mem_nhds_sets_iff, exact ⟨s, set.subset.refl _, os, ys⟩
 end
 
 

--- a/src/topology/bounded_continuous_function.lean
+++ b/src/topology/bounded_continuous_function.lean
@@ -21,7 +21,7 @@ variables {α : Type u} {β : Type v} {γ : Type w}
 /-- A locally uniform limit of continuous functions is continuous -/
 lemma continuous_of_locally_uniform_limit_of_continuous [topological_space α] [metric_space β]
   {F : ℕ → α → β} {f : α → β}
-  (L : ∀x:α, ∃s ∈ (nhds x).sets, ∀ε>(0:ℝ), ∃n, ∀y∈s, dist (F n y) (f y) ≤ ε)
+  (L : ∀x:α, ∃s ∈ nhds x, ∀ε>(0:ℝ), ∃n, ∀y∈s, dist (F n y) (f y) ≤ ε)
   (C : ∀ n, continuous (F n)) : continuous f :=
 continuous_iff'.2 $ λ x ε ε0, begin
   rcases L x with ⟨r, rx, hr⟩,
@@ -131,7 +131,7 @@ theorem continuous_eval : continuous (λ p : (α →ᵇ β) × α, p.1 p.2) :=
 continuous_iff'.2 $ λ ⟨f, x⟩ ε ε0,
 /- use the continuity of `f` to find a neighborhood of `x` where it varies at most by ε/2 -/
 let ⟨s, sx, Hs⟩ := continuous_iff'.1 f.2.1 x (ε/2) (half_pos ε0) in
-/- s : set α, sx : s ∈ (nhds x).sets, Hs : ∀ (b : α), b ∈ s → dist (f.val b) (f.val x) < ε / 2 -/
+/- s : set α, sx : s ∈ nhds x, Hs : ∀ (b : α), b ∈ s → dist (f.val b) (f.val x) < ε / 2 -/
 ⟨set.prod (ball f (ε/2)) s, prod_mem_nhds_sets (ball_mem_nhds _ (half_pos ε0)) sx,
 λ ⟨g, y⟩ ⟨hg, hy⟩, calc dist (g y) (f x)
       ≤ dist (g y) (f y) + dist (f y) (f x) : dist_triangle _ _ _
@@ -220,7 +220,7 @@ and several useful variations around it. -/
 theorem arzela_ascoli₁ [compact_space β]
   (A : set (α →ᵇ β))
   (closed : is_closed A)
-  (H : ∀ (x:α) (ε > 0), ∃U ∈ (nhds x).sets, ∀ (y z ∈ U) (f : α →ᵇ β),
+  (H : ∀ (x:α) (ε > 0), ∃U ∈ nhds x, ∀ (y z ∈ U) (f : α →ᵇ β),
     f ∈ A → dist (f y) (f z) < ε) :
   compact A :=
 begin
@@ -285,7 +285,7 @@ theorem arzela_ascoli₂
   (A : set (α →ᵇ β))
   (closed : is_closed A)
   (in_s : ∀(f : α →ᵇ β) (x : α), f ∈ A → f x ∈ s)
-  (H : ∀(x:α) (ε > 0), ∃U ∈ (nhds x).sets, ∀ (y z ∈ U) (f : α →ᵇ β),
+  (H : ∀(x:α) (ε > 0), ∃U ∈ nhds x, ∀ (y z ∈ U) (f : α →ᵇ β),
     f ∈ A → dist (f y) (f z) < ε) :
   compact A :=
 /- This version is deduced from the previous one by restricting to the compact type in the target,
@@ -311,7 +311,7 @@ theorem arzela_ascoli
   (s : set β) (hs : compact s)
   (A : set (α →ᵇ β))
   (in_s : ∀(f : α →ᵇ β) (x : α), f ∈ A → f x ∈ s)
-  (H : ∀(x:α) (ε > 0), ∃U ∈ (nhds x).sets, ∀ (y z ∈ U) (f : α →ᵇ β),
+  (H : ∀(x:α) (ε > 0), ∃U ∈ nhds x, ∀ (y z ∈ U) (f : α →ᵇ β),
     f ∈ A → dist (f y) (f z) < ε) :
   compact (closure A) :=
 /- This version is deduced from the previous one by checking that the closure of A, in
@@ -320,7 +320,7 @@ arzela_ascoli₂ s hs (closure A) is_closed_closure
   (λ f x hf, (mem_of_closed' (closed_of_compact _ hs)).2 $ λ ε ε0,
     let ⟨g, gA, dist_fg⟩ := mem_closure_iff'.1 hf ε ε0 in
     ⟨g x, in_s g x gA, lt_of_le_of_lt (dist_coe_le_dist _) dist_fg⟩)
-  (λ x ε ε0, show ∃ U ∈ (nhds x).sets,
+  (λ x ε ε0, show ∃ U ∈ nhds x,
       ∀ y z ∈ U, ∀ (f : α →ᵇ β), f ∈ closure A → dist (f y) (f z) < ε,
     begin
       refine bex.imp_right (λ U U_set hU y z hy hz f hf, _) (H x (ε/2) (half_pos ε0)),
@@ -340,7 +340,7 @@ lemma equicontinuous_of_continuity_modulus {α : Type u} [metric_space α]
   (b : ℝ → ℝ) (b_lim : tendsto b (nhds 0) (nhds 0))
   (A : set (α →ᵇ β))
   (H : ∀(x y:α) (f : α →ᵇ β), f ∈ A → dist (f x) (f y) ≤ b (dist x y))
-  (x:α) (ε : ℝ) (ε0 : ε > 0) : ∃U ∈ (nhds x).sets, ∀ (y z ∈ U) (f : α →ᵇ β),
+  (x:α) (ε : ℝ) (ε0 : ε > 0) : ∃U ∈ nhds x, ∀ (y z ∈ U) (f : α →ᵇ β),
     f ∈ A → dist (f y) (f z) < ε :=
 begin
   rcases tendsto_nhds_nhds.1 b_lim ε ε0 with ⟨δ, δ0, hδ⟩,

--- a/src/topology/compact_open.lean
+++ b/src/topology/compact_open.lean
@@ -69,12 +69,12 @@ variables {α β}
 lemma continuous_ev [locally_compact_space α] : continuous (ev α β) :=
 continuous_iff_continuous_at.mpr $ assume ⟨f, x⟩ n hn,
   let ⟨v, vn, vo, fxv⟩ := mem_nhds_sets_iff.mp hn in
-  have v ∈ (nhds (f.val x)).sets, from mem_nhds_sets vo fxv,
+  have v ∈ nhds (f.val x), from mem_nhds_sets vo fxv,
   let ⟨s, hs, sv, sc⟩ :=
     locally_compact_space.local_compact_nhds x (f.val ⁻¹' v)
       (f.property.tendsto x this) in
   let ⟨u, us, uo, xu⟩ := mem_nhds_sets_iff.mp hs in
-  show (ev α β) ⁻¹' n ∈ (nhds (f, x)).sets, from
+  show (ev α β) ⁻¹' n ∈ nhds (f, x), from
   let w := set.prod (compact_open.gen s v) u in
   have w ⊆ ev α β ⁻¹' n, from assume ⟨f', x'⟩ ⟨hf', hx'⟩, calc
     f'.val x' ∈ f'.val '' s  : mem_image_of_mem f'.val (us hx')

--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -43,7 +43,7 @@ instance [topological_space α] [discrete_topology α] [topological_space β] [d
   by rw [nhds_prod_eq, nhds_discrete α, nhds_discrete β, nhds_top, filter.prod_pure_pure]⟩
 
 lemma prod_mem_nhds_sets {s : set α} {t : set β} {a : α} {b : β}
-  (ha : s ∈ (nhds a).sets) (hb : t ∈ (nhds b).sets) : set.prod s t ∈ (nhds (a, b)).sets :=
+  (ha : s ∈ nhds a) (hb : t ∈ nhds b) : set.prod s t ∈ nhds (a, b) :=
 by rw [nhds_prod_eq]; exact prod_mem_prod ha hb
 
 lemma nhds_swap (a : α) (b : β) : nhds (a, b) = (nhds (b, a)).map prod.swap :=
@@ -203,6 +203,8 @@ is_closed_iff_nhds.mpr $ assume ⟨a₁, a₂⟩ h, eq_of_nhds_neq_bot $ assume 
   let ⟨t₁, ht₁, t₂, ht₂, (h' : t₁ ∩ t₂ ⊆ ∅)⟩ :=
     by rw [←empty_in_sets_eq_bot, mem_inf_sets] at this; exact this in
   begin
+    change t₁ ∈ nhds a₁ at ht₁,
+    change t₂ ∈ nhds a₂ at ht₂,
     rw [nhds_prod_eq, ←empty_in_sets_eq_bot],
     apply filter.sets_of_superset,
     apply inter_mem_inf_sets (prod_mem_prod ht₁ ht₂) (mem_principal_sets.mpr (subset.refl _)),
@@ -240,7 +242,7 @@ is_open_compl_iff.mpr $ is_open_iff_forall_mem_open.mpr $ assume x hx,
 ⟨v, this, vo, by simpa using xv⟩
 
 lemma locally_compact_of_compact_nhds [topological_space α] [t2_space α]
-  (h : ∀ x : α, ∃ s, s ∈ (nhds x).sets ∧ compact s) :
+  (h : ∀ x : α, ∃ s, s ∈ nhds x ∧ compact s) :
   locally_compact_space α :=
 ⟨assume x n hn,
   let ⟨u, un, uo, xu⟩ := mem_nhds_sets_iff.mp hn in
@@ -252,7 +254,7 @@ lemma locally_compact_of_compact_nhds [topological_space α] [t2_space α]
   let ⟨v, w, vo, wo, xv, kuw, vw⟩ :=
     compact_compact_separated compact_singleton (compact_diff kc uo)
       (by rw [singleton_inter_eq_empty]; exact λ h, h.2 xu) in
-  have wn : -w ∈ (nhds x).sets, from
+  have wn : -w ∈ nhds x, from
    mem_nhds_sets_iff.mpr
      ⟨v, subset_compl_iff_disjoint.mpr vw, vo, singleton_subset_iff.mp xv⟩,
   ⟨k - w,
@@ -390,7 +392,7 @@ lemma continuous_at_subtype_val [topological_space α] {p : α → Prop} {a : su
   continuous_at subtype.val a :=
 continuous_iff_continuous_at.mp continuous_subtype_val _
 
-lemma map_nhds_subtype_val_eq {a : α} (ha : p a) (h : {a | p a} ∈ (nhds a).sets) :
+lemma map_nhds_subtype_val_eq {a : α} (ha : p a) (h : {a | p a} ∈ nhds a) :
   map (@subtype.val α p) (nhds ⟨a, ha⟩) = nhds a :=
 map_nhds_induced_eq (by simp [subtype.val_image, h])
 
@@ -403,11 +405,11 @@ lemma tendsto_subtype_rng [topological_space α] {p : α → Prop} {b : filter �
 | ⟨a, ha⟩ := by rw [nhds_subtype_eq_comap, tendsto_comap_iff]
 
 lemma continuous_subtype_nhds_cover {ι : Sort*} {f : α → β} {c : ι → α → Prop}
-  (c_cover : ∀x:α, ∃i, {x | c i x} ∈ (nhds x).sets)
+  (c_cover : ∀x:α, ∃i, {x | c i x} ∈ nhds x)
   (f_cont  : ∀i, continuous (λ(x : subtype (c i)), f x.val)) :
   continuous f :=
 continuous_iff_continuous_at.mpr $ assume x,
-  let ⟨i, (c_sets : {x | c i x} ∈ (nhds x).sets)⟩ := c_cover x in
+  let ⟨i, (c_sets : {x | c i x} ∈ nhds x)⟩ := c_cover x in
   let x' : subtype (c i) := ⟨x, mem_of_nhds c_sets⟩ in
   calc map f (nhds x) = map f (map subtype.val (nhds x')) :
       congr_arg (map f) (map_nhds_subtype_val_eq _ $ c_sets).symm

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -68,7 +68,7 @@ end
 lemma is_open_ne_top : is_open {a : ennreal | a ≠ ⊤} :=
 is_open_neg (is_closed_eq continuous_id continuous_const)
 
-lemma coe_range_mem_nhds : range (coe : nnreal → ennreal) ∈ (nhds (r : ennreal)).sets :=
+lemma coe_range_mem_nhds : range (coe : nnreal → ennreal) ∈ nhds (r : ennreal) :=
 have {a : ennreal | a ≠ ⊤} = range (coe : nnreal → ennreal),
   from set.ext $ assume a, by cases a; simp [none_eq_top, some_eq_coe],
 this ▸ mem_nhds_sets is_open_ne_top coe_ne_top
@@ -107,7 +107,7 @@ begin
 end
 
 lemma tendsto_nhds_top {m : α → ennreal} {f : filter α}
-  (h : ∀n:ℕ, {a | ↑n < m a} ∈ f.sets) : tendsto m f (nhds ⊤) :=
+  (h : ∀n:ℕ, {a | ↑n < m a} ∈ f) : tendsto m f (nhds ⊤) :=
 tendsto_nhds_generate_from $ assume s hs,
 match s, hs with
 | _, ⟨none,   or.inl rfl⟩, hr := (lt_irrefl ⊤ hr).elim
@@ -121,7 +121,7 @@ end
 lemma tendsto_coe_nnreal_nhds_top {α} {l : filter α} {f : α → nnreal} (h : tendsto f l at_top) :
   tendsto (λa, (f a : ennreal)) l (nhds (⊤:ennreal)) :=
 tendsto_nhds_top $ assume n,
-have {a : α | ↑(n+1) ≤ f a} ∈ l.sets := h $ mem_at_top _,
+have {a : α | ↑(n+1) ≤ f a} ∈ l := h $ mem_at_top _,
 mem_sets_of_superset this $ assume a (ha : ↑(n+1) ≤ f a),
 begin
   rw [← coe_nat],
@@ -133,8 +133,9 @@ instance : topological_add_monoid ennreal :=
 ⟨ continuous_iff_continuous_at.2 $
   have hl : ∀a:ennreal, tendsto (λ (p : ennreal × ennreal), p.fst + p.snd) (nhds (⊤, a)) (nhds ⊤), from
     assume a, tendsto_nhds_top $ assume n,
-    have set.prod {a | ↑n < a } univ ∈ (nhds ((⊤:ennreal), a)).sets, from
+    have set.prod {a | ↑n < a } univ ∈ nhds ((⊤:ennreal), a), from
       prod_mem_nhds_sets (lt_mem_nhds $ coe_nat n ▸ coe_lt_top) univ_mem_sets,
+    show {a : ennreal × ennreal | ↑n < a.fst + a.snd} ∈ nhds (⊤, a),
     begin filter_upwards [this] assume ⟨a₁, a₂⟩ ⟨h₁, h₂⟩, lt_of_lt_of_le h₁ (le_add_right $ le_refl _) end,
   begin
     rintro ⟨a₁, a₂⟩,
@@ -523,7 +524,7 @@ begin
   /-b : ℕ → ℝ, b_bound : ∀ (n m N : ℕ), N ≤ n → N ≤ m → edist (s n) (s m) ≤ b N,
     b_lim : tendsto b at_top (nhds 0)-/
   refine emetric.cauchy_seq_iff.2 (λε εpos, _),
-  have : {n | b n < ε} ∈ at_top.sets := (tendsto_orderable.1 b_lim ).2 _ εpos,
+  have : {n | b n < ε} ∈ at_top := (tendsto_orderable.1 b_lim ).2 _ εpos,
   rcases filter.mem_at_top_sets.1 this with ⟨N, hN⟩,
   exact ⟨N, λm n hm hn, calc
     edist (s n) (s m) ≤ b N : b_bound n m N hn hm
@@ -534,7 +535,7 @@ lemma continuous_of_le_add_edist {f : α → ennreal} (C : ennreal)
   (hC : C ≠ ⊤) (h : ∀x y, f x ≤ f y + C * edist x y) : continuous f :=
 begin
   refine continuous_iff_continuous_at.2 (λx, tendsto_orderable.2 ⟨_, _⟩),
-  show ∀e, e < f x → {y : α | e < f y} ∈ (nhds x).sets,
+  show ∀e, e < f x → {y : α | e < f y} ∈ nhds x,
   { assume e he,
     let ε := min (f x - e) 1,
     have : ε < ⊤ := lt_of_le_of_lt (min_le_right _ _) (by simp [lt_top_iff_ne_top]),
@@ -562,7 +563,7 @@ begin
         show e < f y, from
           (ennreal.add_lt_add_iff_right ‹ε < ⊤›).1 this }},
     apply filter.mem_sets_of_superset (ball_mem_nhds _ (‹0 < C⁻¹ * (ε/2)›)) this },
-  show ∀e, f x < e → {y : α | f y < e} ∈ (nhds x).sets,
+  show ∀e, f x < e → {y : α | f y < e} ∈ nhds x,
   { assume e he,
     let ε := min (e - f x) 1,
     have : ε < ⊤ := lt_of_le_of_lt (min_le_right _ _) (by simp [lt_top_iff_ne_top]),

--- a/src/topology/maps.lean
+++ b/src/topology/maps.lean
@@ -56,7 +56,7 @@ have is_closed (t ∩ range f), from is_closed_inter ht h,
 h_eq.symm ▸ by rwa [image_preimage_eq_inter_range]
 
 lemma embedding.map_nhds_eq [topological_space α] [topological_space β] {f : α → β}
-  (hf : embedding f) (a : α) (h : range f ∈ (nhds (f a)).sets) : (nhds a).map f = nhds (f a) :=
+  (hf : embedding f) (a : α) (h : range f ∈ nhds (f a)) : (nhds a).map f = nhds (f a) :=
 by rw [hf.2]; exact map_nhds_induced_eq h
 
 lemma embedding.tendsto_nhds_iff {ι : Type*}
@@ -89,8 +89,8 @@ theorem dense_embedding.mk'
   (c     : continuous e)
   (dense : ∀x, x ∈ closure (range e))
   (inj   : function.injective e)
-  (H     : ∀ (a:α) s ∈ (nhds a).sets,
-    ∃t ∈ (nhds (e a)).sets, ∀ b, e b ∈ t → b ∈ s) :
+  (H     : ∀ (a:α) s ∈ nhds a,
+    ∃t ∈ nhds (e a), ∀ b, e b ∈ t → b ∈ s) :
   dense_embedding e :=
 ⟨dense, inj, λ a, le_antisymm
   (by simpa [le_def] using H a)
@@ -127,7 +127,7 @@ begin
 end
 
 lemma closure_image_nhds_of_nhds {s : set α} {a : α} (de : dense_embedding e) :
-  s ∈ (nhds a).sets → closure (e '' s) ∈ (nhds (e a)).sets :=
+  s ∈ nhds a → closure (e '' s) ∈ nhds (e a) :=
 begin
   rw [← de.induced a, mem_comap_sets],
   intro h,
@@ -138,7 +138,7 @@ begin
                    ... ⊆ s      : sub,
   have := calc U ⊆ closure (e '' (e ⁻¹' U)) : self_sub_closure_image_preimage_of_open de U_op
              ... ⊆ closure (e '' s)         : closure_mono (image_subset e this),
-  have U_nhd : U ∈ (nhds (e a)).sets := mem_nhds_sets U_op e_a_in_U,
+  have U_nhd : U ∈ nhds (e a) := mem_nhds_sets U_op e_a_in_U,
   exact (nhds (e a)).sets_of_superset U_nhd this
 end
 
@@ -169,7 +169,7 @@ end
 lemma comap_nhds_neq_bot (de : dense_embedding e) {b : β} : comap e (nhds b) ≠ ⊥ :=
 forall_sets_neq_empty_iff_neq_bot.mp $
 assume s ⟨t, ht, (hs : e ⁻¹' t ⊆ s)⟩,
-have t ∩ range e ∈ (nhds b ⊓ principal (range e)).sets,
+have t ∩ range e ∈ nhds b ⊓ principal (range e),
   from inter_mem_inf_sets ht (subset.refl _),
 let ⟨_, ⟨hx₁, y, rfl⟩⟩ := inhabited_of_mem_sets de.nhds_inf_neq_bot this in
 subset_ne_empty hs $ ne_empty_of_mem hx₁
@@ -213,10 +213,10 @@ begin
 end
 
 lemma tendsto_extend [regular_space γ] {b : β} {f : α → γ} (de : dense_embedding e)
-  (hf : {b | ∃c, tendsto f (comap e $ nhds b) (nhds c)} ∈ (nhds b).sets) :
+  (hf : {b | ∃c, tendsto f (comap e $ nhds b) (nhds c)} ∈ nhds b) :
   tendsto (de.extend f) (nhds b) (nhds (de.extend f b)) :=
 let φ := {b | tendsto f (comap e $ nhds b) (nhds $ de.extend f b)} in
-have hφ : φ ∈ (nhds b).sets,
+have hφ : φ ∈ nhds b,
   from (nhds b).sets_of_superset hf $ assume b ⟨c, hc⟩,
     show tendsto f (comap e (nhds b)) (nhds (de.extend f b)), from (de.extend_eq hc).symm ▸ hc,
 assume s hs,
@@ -242,7 +242,7 @@ have h₂ : t ⊆ de.extend f ⁻¹' closure (f '' (e ⁻¹' t)), from
     exact de.comap_nhds_neq_bot
   end,
 (nhds b).sets_of_superset
-  (show t ∈ (nhds b).sets, from mem_nhds_sets ht₂ ht₃)
+  (show t ∈ nhds b, from mem_nhds_sets ht₂ ht₃)
   (calc t ⊆ de.extend f ⁻¹' closure (f '' (e ⁻¹' t)) : h₂
     ... ⊆ de.extend f ⁻¹' closure (f '' (e ⁻¹' s')) :
       preimage_mono $ closure_mono $ image_subset f $ preimage_mono $ subset.trans ht₁ $ inter_subset_right _ _

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -255,16 +255,16 @@ theorem uniformity_dist' : uniformity = (⨅ε:{ε:ℝ // ε>0}, principal {p:α
 by simp [infi_subtype]; exact uniformity_dist
 
 theorem mem_uniformity_dist {s : set (α×α)} :
-  s ∈ (@uniformity α _).sets ↔ (∃ε>0, ∀{a b:α}, dist a b < ε → (a, b) ∈ s) :=
+  s ∈ @uniformity α _ ↔ (∃ε>0, ∀{a b:α}, dist a b < ε → (a, b) ∈ s) :=
 begin
-  rw [uniformity_dist', infi_sets_eq],
+  rw [uniformity_dist', mem_infi],
   simp [subset_def],
   exact assume ⟨r, hr⟩ ⟨p, hp⟩, ⟨⟨min r p, lt_min hr hp⟩, by simp [lt_min_iff, (≥)] {contextual := tt}⟩,
   exact ⟨⟨1, zero_lt_one⟩⟩
 end
 
 theorem dist_mem_uniformity {ε:ℝ} (ε0 : 0 < ε) :
-  {p:α×α | dist p.1 p.2 < ε} ∈ (@uniformity α _).sets :=
+  {p:α×α | dist p.1 p.2 < ε} ∈ @uniformity α _ :=
 mem_uniformity_dist.2 ⟨ε, ε0, λ a b, id⟩
 
 theorem uniform_continuous_iff [metric_space β] {f : α → β} :
@@ -315,7 +315,7 @@ begin
 end
 
 protected lemma cauchy_iff {f : filter α} :
-  cauchy f ↔ f ≠ ⊥ ∧ ∀ ε > 0, ∃ t ∈ f.sets, ∀ x y ∈ t, dist x y < ε :=
+  cauchy f ↔ f ≠ ⊥ ∧ ∀ ε > 0, ∃ t ∈ f, ∀ x y ∈ t, dist x y < ε :=
 cauchy_iff.trans $ and_congr iff.rfl
 ⟨λ H ε ε0, let ⟨t, tf, ts⟩ := H _ (dist_mem_uniformity ε0) in
    ⟨t, tf, λ x y xt yt, @ts (x, y) ⟨xt, yt⟩⟩,
@@ -334,9 +334,9 @@ begin
   { intros, refl }
 end
 
-theorem mem_nhds_iff : s ∈ (nhds x).sets ↔ ∃ε>0, ball x ε ⊆ s :=
+theorem mem_nhds_iff : s ∈ nhds x ↔ ∃ε>0, ball x ε ⊆ s :=
 begin
-  rw [nhds_eq, infi_sets_eq],
+  rw [nhds_eq, mem_infi],
   { simp },
   { intros y z, cases y with y hy, cases z with z hz,
     refine ⟨⟨min y z, lt_min hy hz⟩, _⟩,
@@ -350,7 +350,7 @@ by simp [is_open_iff_nhds, mem_nhds_iff]
 theorem is_open_ball : is_open (ball x ε) :=
 is_open_iff.2 $ λ y, exists_ball_subset_ball
 
-theorem ball_mem_nhds (x : α) {ε : ℝ} (ε0 : 0 < ε) : ball x ε ∈ (nhds x).sets :=
+theorem ball_mem_nhds (x : α) {ε : ℝ} (ε0 : 0 < ε) : ball x ε ∈ nhds x :=
 mem_nhds_sets is_open_ball (mem_ball_self ε0)
 
 theorem tendsto_nhds_nhds [metric_space β] {f : α → β} {a b} :
@@ -373,12 +373,12 @@ let ⟨δ, δ_pos, hδ⟩ := continuous_iff.1 hf b ε hε in
 ⟨δ / 2, half_pos δ_pos, assume a ha, hδ a $ lt_of_le_of_lt ha $ div_two_lt_of_pos δ_pos⟩
 
 theorem tendsto_nhds {f : filter β} {u : β → α} {a : α} :
-  tendsto u f (nhds a) ↔ ∀ ε > 0, ∃ n ∈ f.sets, ∀x ∈ n,  dist (u x) a < ε :=
+  tendsto u f (nhds a) ↔ ∀ ε > 0, ∃ n ∈ f, ∀x ∈ n,  dist (u x) a < ε :=
 by simp only [metric.nhds_eq, tendsto_infi, subtype.forall, tendsto_principal, mem_ball];
   exact forall_congr (assume ε, forall_congr (assume hε, exists_sets_subset_iff.symm))
 
 theorem continuous_iff' [topological_space β] {f : β → α} :
-  continuous f ↔ ∀a (ε > 0), ∃ n ∈ (nhds a).sets, ∀b ∈ n, dist (f b) (f a) < ε :=
+  continuous f ↔ ∀a (ε > 0), ∃ n ∈ nhds a, ∀b ∈ n, dist (f b) (f a) < ε :=
 continuous_iff_continuous_at.trans $ forall_congr $ λ b, tendsto_nhds
 
 theorem tendsto_at_top [nonempty β] [semilattice_sup β] {u : β → α} {a : α} :
@@ -399,7 +399,7 @@ distance coincide. -/
 
 /-- Expressing the uniformity in terms of `edist` -/
 protected lemma metric.mem_uniformity_edist {s : set (α×α)} :
-  s ∈ (@uniformity α _).sets ↔ (∃ε>0, ∀{a b:α}, edist a b < ε → (a, b) ∈ s) :=
+  s ∈ @uniformity α _ ↔ (∃ε>0, ∀{a b:α}, edist a b < ε → (a, b) ∈ s) :=
 begin
   refine mem_uniformity_dist.trans ⟨_, _⟩; rintro ⟨ε, ε0, Hε⟩,
   { refine ⟨ennreal.of_real ε, _, λ a b, _⟩,
@@ -414,7 +414,7 @@ end
 
 protected theorem metric.uniformity_edist' : uniformity = (⨅ε:{ε:ennreal // ε>0}, principal {p:α×α | edist p.1 p.2 < ε.val}) :=
 begin
-  ext s, rw infi_sets_eq,
+  ext s, rw mem_infi,
   { simp [metric.mem_uniformity_edist, subset_def] },
   { rintro ⟨r, hr⟩ ⟨p, hp⟩, use ⟨min r p, lt_min hr hp⟩,
     simp [lt_min_iff, (≥)] {contextual := tt} },
@@ -890,11 +890,11 @@ instance complete_of_proper {α : Type u} [metric_space α] [proper_space α] : 
   intros f hf,
   /- We want to show that the Cauchy filter `f` is converging. It suffices to find a closed
   ball (therefore compact by properness) where it is nontrivial. -/
-  have A : ∃ t ∈ f.sets, ∀ x y ∈ t, dist x y < 1 := (metric.cauchy_iff.1 hf).2 1 zero_lt_one,
+  have A : ∃ t ∈ f, ∀ x y ∈ t, dist x y < 1 := (metric.cauchy_iff.1 hf).2 1 zero_lt_one,
   rcases A with ⟨t, ⟨t_fset, ht⟩⟩,
   rcases inhabited_of_mem_sets hf.1 t_fset with ⟨x, xt⟩,
   have : t ⊆ closed_ball x 1 := by intros y yt; simp [dist_comm]; apply le_of_lt (ht x y xt yt),
-  have : closed_ball x 1 ∈ f.sets := f.sets_of_superset t_fset this,
+  have : closed_ball x 1 ∈ f := f.sets_of_superset t_fset this,
   rcases (compact_iff_totally_bounded_complete.1 (proper_space.compact_ball x 1)).2 f hf (le_principal_iff.2 this)
     with ⟨y, _, hy⟩,
   exact ⟨y, hy⟩

--- a/src/topology/metric_space/cau_seq_filter.lean
+++ b/src/topology/metric_space/cau_seq_filter.lean
@@ -147,7 +147,7 @@ def set_seq_of_cau_filter : ℕ → set β
 | (n+1) := (set_seq_of_cau_filter n) ∩ some ((emetric.cauchy_iff.1 hf).2 _ (B2_pos B hB (n + 1)))
 
 /-- These sets are in the filter. -/
-lemma set_seq_of_cau_filter_mem_sets : ∀ n, set_seq_of_cau_filter hf B hB n ∈ f.sets
+lemma set_seq_of_cau_filter_mem_sets : ∀ n, set_seq_of_cau_filter hf B hB n ∈ f
 | 0 := some (some_spec ((emetric.cauchy_iff.1 hf).2 _ (B2_pos B hB 0)))
 | (n+1) := inter_mem_sets (set_seq_of_cau_filter_mem_sets n)
              (some (some_spec ((emetric.cauchy_iff.1 hf).2 _ (B2_pos B hB (n + 1)))))
@@ -231,7 +231,7 @@ begin
   simp only [set.mem_set_of_eq] at hnε, -- hnε : ε / 2 > B2 B hB n
   cases (emetric.tendsto_at_top _).1 H _ this with n2 hn2,
   let N := max n n2,
-  have ht1sn : t1 ∩ set_seq_of_cau_filter hf B hB N ∈ f.sets,
+  have ht1sn : t1 ∩ set_seq_of_cau_filter hf B hB N ∈ f,
     from inter_mem_sets ht1 (set_seq_of_cau_filter_mem_sets hf B hB _),
   have hts1n_ne : t1 ∩ set_seq_of_cau_filter hf B hB N ≠ ∅,
     from forall_sets_neq_empty_iff_neq_bot.2 hfb _ ht1sn,

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -27,7 +27,7 @@ variables {α : Type u} {β : Type v} {γ : Type w}
 /-- Characterizing uniformities associated to a (generalized) distance function `D`
 in terms of the elements of the uniformity. -/
 theorem uniformity_dist_of_mem_uniformity [linear_order β] {U : filter (α × α)} (z : β) (D : α → α → β)
-  (H : ∀ s, s ∈ U.sets ↔ ∃ε>z, ∀{a b:α}, D a b < ε → (a, b) ∈ s) :
+  (H : ∀ s, s ∈ U ↔ ∃ε>z, ∀{a b:α}, D a b < ε → (a, b) ∈ s) :
   U = ⨅ ε>z, principal {p:α×α | D p.1 p.2 < ε} :=
 le_antisymm
   (le_infi $ λ ε, le_infi $ λ ε0, le_principal_iff.2 $ (H _).2 ⟨ε, ε0, λ a b, id⟩)
@@ -157,9 +157,9 @@ end
 
 /-- Characterization of the elements of the uniformity in terms of the extended distance -/
 theorem mem_uniformity_edist {s : set (α×α)} :
-  s ∈ (@uniformity α _).sets ↔ (∃ε>0, ∀{a b:α}, edist a b < ε → (a, b) ∈ s) :=
+  s ∈ @uniformity α _ ↔ (∃ε>0, ∀{a b:α}, edist a b < ε → (a, b) ∈ s) :=
 begin
-  rw [uniformity_edist'', infi_sets_eq],
+  rw [uniformity_edist'', mem_infi],
   simp [subset_def],
   exact assume ⟨r, hr⟩ ⟨p, hp⟩, ⟨⟨min r p, lt_min hr hp⟩, by simp [lt_min_iff, (≥)] {contextual := tt}⟩,
   exact ⟨⟨1, ennreal.zero_lt_one⟩⟩
@@ -167,7 +167,7 @@ end
 
 /-- Fixed size neighborhoods of the diagonal belong to the uniform structure -/
 theorem edist_mem_uniformity {ε:ennreal} (ε0 : 0 < ε) :
-  {p:α×α | edist p.1 p.2 < ε} ∈ (@uniformity α _).sets :=
+  {p:α×α | edist p.1 p.2 < ε} ∈ @uniformity α _ :=
 mem_uniformity_edist.2 ⟨ε, ε0, λ a b, id⟩
 
 namespace emetric
@@ -195,7 +195,7 @@ uniform_embedding_def'.trans $ and_congr iff.rfl $ and_congr iff.rfl
 
 /-- ε-δ characterization of Cauchy sequences on emetric spaces -/
 protected lemma cauchy_iff {f : filter α} :
-  cauchy f ↔ f ≠ ⊥ ∧ ∀ ε > 0, ∃ t ∈ f.sets, ∀ x y ∈ t, edist x y < ε :=
+  cauchy f ↔ f ≠ ⊥ ∧ ∀ ε > 0, ∃ t ∈ f, ∀ x y ∈ t, edist x y < ε :=
 cauchy_iff.trans $ and_congr iff.rfl
 ⟨λ H ε ε0, let ⟨t, tf, ts⟩ := H _ (edist_mem_uniformity ε0) in
    ⟨t, tf, λ x y xt yt, @ts (x, y) ⟨xt, yt⟩⟩,
@@ -382,9 +382,9 @@ begin
   { intros, refl }
 end
 
-theorem mem_nhds_iff : s ∈ (nhds x).sets ↔ ∃ε>0, ball x ε ⊆ s :=
+theorem mem_nhds_iff : s ∈ nhds x ↔ ∃ε>0, ball x ε ⊆ s :=
 begin
-  rw [nhds_eq, infi_sets_eq],
+  rw [nhds_eq, mem_infi],
   { simp },
   { intros y z, cases y with y hy, cases z with z hz,
     refine ⟨⟨min y z, lt_min hy hz⟩, _⟩,
@@ -398,7 +398,7 @@ by simp [is_open_iff_nhds, mem_nhds_iff]
 theorem is_open_ball : is_open (ball x ε) :=
 is_open_iff.2 $ λ y, exists_ball_subset_ball
 
-theorem ball_mem_nhds (x : α) {ε : ennreal} (ε0 : 0 < ε) : ball x ε ∈ (nhds x).sets :=
+theorem ball_mem_nhds (x : α) {ε : ennreal} (ε0 : 0 < ε) : ball x ε ∈ nhds x :=
 mem_nhds_sets is_open_ball (mem_ball_self ε0)
 
 /-- ε-characterization of the closure in emetric spaces -/
@@ -422,7 +422,7 @@ begin
 end⟩
 
 theorem tendsto_nhds {f : filter β} {u : β → α} {a : α} :
-  tendsto u f (nhds a) ↔ ∀ ε > 0, ∃ n ∈ f.sets, ∀x ∈ n, edist (u x) a < ε :=
+  tendsto u f (nhds a) ↔ ∀ ε > 0, ∃ n ∈ f, ∀x ∈ n, edist (u x) a < ε :=
 ⟨λ H ε ε0, ⟨u⁻¹' (ball a ε), H (ball_mem_nhds _ ε0), by simp⟩,
  λ H s hs,
   let ⟨ε, ε0, hε⟩ := mem_nhds_iff.1 hs, ⟨δ, δ0, hδ⟩ := H _ ε0 in

--- a/src/topology/order.lean
+++ b/src/topology/order.lean
@@ -53,25 +53,25 @@ le_antisymm
     this s hs as)
 
 lemma tendsto_nhds_generate_from {β : Type*} {m : α → β} {f : filter α} {g : set (set β)} {b : β}
-  (h : ∀s∈g, b ∈ s → m ⁻¹' s ∈ f.sets) : tendsto m f (@nhds β (generate_from g) b) :=
+  (h : ∀s∈g, b ∈ s → m ⁻¹' s ∈ f) : tendsto m f (@nhds β (generate_from g) b) :=
 by rw [nhds_generate_from]; exact
   (tendsto_infi.2 $ assume s, tendsto_infi.2 $ assume ⟨hbs, hsg⟩, tendsto_principal.2 $ h s hsg hbs)
 
 protected def mk_of_nhds (n : α → filter α) : topological_space α :=
-{ is_open        := λs, ∀a∈s, s ∈ (n a).sets,
+{ is_open        := λs, ∀a∈s, s ∈ n a,
   is_open_univ   := assume x h, univ_mem_sets,
   is_open_inter  := assume s t hs ht x ⟨hxs, hxt⟩, inter_mem_sets (hs x hxs) (ht x hxt),
   is_open_sUnion := assume s hs a ⟨x, hx, hxa⟩, mem_sets_of_superset (hs x hx _ hxa) (set.subset_sUnion_of_mem hx) }
 
 lemma nhds_mk_of_nhds (n : α → filter α) (a : α)
-  (h₀ : pure ≤ n) (h₁ : ∀{a s}, s ∈ (n a).sets → ∃t∈(n a).sets, t ⊆ s ∧ ∀a'∈t, s ∈ (n a').sets) :
+  (h₀ : pure ≤ n) (h₁ : ∀{a s}, s ∈ n a → ∃ t ∈ n a, t ⊆ s ∧ ∀a' ∈ t, s ∈ n a') :
   @nhds α (topological_space.mk_of_nhds n) a = n a :=
 begin
   letI := topological_space.mk_of_nhds n,
   refine le_antisymm (assume s hs, _) (assume s hs, _),
-  { have h₀ : {b | s ∈ (n b).sets} ⊆ s := assume b hb, mem_pure_sets.1 $ h₀ b hb,
-    have h₁ : {b | s ∈ (n b).sets} ∈ (nhds a).sets,
-    { refine mem_nhds_sets (assume b (hb : s ∈ (n b).sets), _) hs,
+  { have h₀ : {b | s ∈ n b} ⊆ s := assume b hb, mem_pure_sets.1 $ h₀ b hb,
+    have h₁ : {b | s ∈ n b} ∈ nhds a,
+    { refine mem_nhds_sets (assume b (hb : s ∈ n b), _) hs,
       rcases h₁ hb with ⟨t, ht, hts, h⟩,
       exact mem_sets_of_superset ht h },
     exact mem_sets_of_superset h₁ h₀ },
@@ -385,7 +385,7 @@ le_antisymm
   (generate_from_le $ ball_image_iff.2 $ assume s hs, ⟨s, generate_open.basic _ hs, rfl⟩)
 
 protected def topological_space.nhds_adjoint (a : α) (f : filter α) : topological_space α :=
-{ is_open        := λs, a ∈ s → s ∈ f.sets,
+{ is_open        := λs, a ∈ s → s ∈ f,
   is_open_univ   := assume s, univ_mem_sets,
   is_open_inter  := assume s t hs ht ⟨has, hat⟩, inter_mem_sets (hs has) (ht hat),
   is_open_sUnion := assume k hk ⟨u, hu, hau⟩, mem_sets_of_superset (hk u hu hau) (subset_sUnion_of_mem hu) }
@@ -528,7 +528,7 @@ continuous_iff_le_coinduced.2 $ bot_le
 /- nhds in the induced topology -/
 
 theorem mem_nhds_induced [T : topological_space α] (f : β → α) (a : β) (s : set β) :
-  s ∈ (@nhds β (topological_space.induced f T) a).sets ↔ ∃ u ∈ (nhds (f a)).sets, f ⁻¹' u ⊆ s :=
+  s ∈ @nhds β (topological_space.induced f T) a ↔ ∃ u ∈ nhds (f a), f ⁻¹' u ⊆ s :=
 begin
   simp only [nhds_sets, is_open_induced_iff, exists_prop, set.mem_set_of_eq],
   split,
@@ -556,7 +556,7 @@ The nhds filter and the subspace topology.
 -/
 
 theorem mem_nhds_subtype (s : set α) (a : {x // x ∈ s}) (t : set {x // x ∈ s}) :
-  t ∈ (nhds a).sets ↔ ∃ u ∈ (nhds a.val).sets, (@subtype.val α s) ⁻¹' u ⊆ t :=
+  t ∈ nhds a ↔ ∃ u ∈ nhds a.val, (@subtype.val α s) ⁻¹' u ⊆ t :=
 by rw mem_nhds_induced
 
 theorem nhds_subtype (s : set α) (a : {x // x ∈ s}) :
@@ -572,8 +572,8 @@ nhds_within and subtypes
 -/
 
 theorem mem_nhds_within_subtype (s : set α) (a : {x // x ∈ s}) (t u : set {x // x ∈ s}) :
-  t ∈ (nhds_within a u).sets ↔
-    t ∈ (comap (@subtype.val _ s) (nhds_within a.val (subtype.val '' u))).sets :=
+  t ∈ nhds_within a u ↔
+    t ∈ comap (@subtype.val _ s) (nhds_within a.val (subtype.val '' u)) :=
 by rw [nhds_within, nhds_subtype, principal_subtype, ←comap_inf, ←nhds_within]
 
 theorem nhds_within_subtype (s : set α) (a : {x // x ∈ s}) (t : set {x // x ∈ s}) :
@@ -582,7 +582,7 @@ filter_eq $ by ext u; rw mem_nhds_within_subtype
 
 theorem nhds_within_eq_map_subtype_val {s : set α} {a : α} (h : a ∈ s) :
   nhds_within a s = map subtype.val (nhds ⟨a, h⟩) :=
-have h₀ : s ∈ (nhds_within a s).sets,
+have h₀ : s ∈ nhds_within a s,
   by { rw [mem_nhds_within], existsi set.univ, simp [set.diff_eq] },
 have h₁ : ∀ y ∈ s, ∃ x, @subtype.val _ s x = y,
   from λ y h, ⟨⟨y, h⟩, rfl⟩,
@@ -669,7 +669,7 @@ calc @nhds α (induced f t) a = (⨅ s (x : s ∈ preimage f '' set_of is_open �
     by simp only [infi_and, infi_image]; refl
   ... = _ : by simp [nhds, comap_infi, and_comm]
 
-lemma map_nhds_induced_eq {a : α} (h : range f ∈ (nhds (f a)).sets) :
+lemma map_nhds_induced_eq {a : α} (h : range f ∈ nhds (f a)) :
   map f (@nhds α (induced f t) a) = nhds (f a) :=
 by rw [nhds_induced_eq_comap, filter.map_comap h]
 
@@ -681,9 +681,9 @@ have comap f (nhds (f a) ⊓ principal (f '' s)) ≠ ⊥ ↔ nhds (f a) ⊓ prin
     assume h,
     forall_sets_neq_empty_iff_neq_bot.mp $
       assume s₁ ⟨s₂, hs₂, (hs : f ⁻¹' s₂ ⊆ s₁)⟩,
-      have f '' s ∈ (nhds (f a) ⊓ principal (f '' s)).sets,
+      have f '' s ∈ nhds (f a) ⊓ principal (f '' s),
         from mem_inf_sets_of_right $ by simp [subset.refl],
-      have s₂ ∩ f '' s ∈ (nhds (f a) ⊓ principal (f '' s)).sets,
+      have s₂ ∩ f '' s ∈ nhds (f a) ⊓ principal (f '' s),
         from inter_mem_sets hs₂ this,
       let ⟨b, hb₁, ⟨a, ha, ha₂⟩⟩ := inhabited_of_mem_sets h this in
       ne_empty_of_mem $ hs $ by rwa [←ha₂] at hb₁⟩,

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -124,7 +124,7 @@ instance t1_space.t0_space [t1_space α] : t0_space α :=
 ⟨λ x y h, ⟨-{x}, is_open_compl_iff.2 is_closed_singleton,
   or.inr ⟨λ hyx, or.cases_on hyx h.symm id, λ hx, hx $ or.inl rfl⟩⟩⟩
 
-lemma compl_singleton_mem_nhds [t1_space α] {x y : α} (h : y ≠ x) : - {x} ∈ (nhds y).sets :=
+lemma compl_singleton_mem_nhds [t1_space α] {x y : α} (h : y ≠ x) : - {x} ∈ nhds y :=
 mem_nhds_sets is_closed_singleton $ by rwa [mem_compl_eq, mem_singleton_iff]
 
 @[simp] lemma closure_singleton [t1_space α] {a : α} :
@@ -149,7 +149,7 @@ let ⟨u, v, hu, hv, hyu, hxv, huv⟩ := t2_separation (mt mem_singleton_of_eq h
 lemma eq_of_nhds_neq_bot [ht : t2_space α] {x y : α} (h : nhds x ⊓ nhds y ≠ ⊥) : x = y :=
 classical.by_contradiction $ assume : x ≠ y,
 let ⟨u, v, hu, hv, hx, hy, huv⟩ := t2_space.t2 x y this in
-have u ∩ v ∈ (nhds x ⊓ nhds y).sets,
+have u ∩ v ∈ nhds x ⊓ nhds y,
   from inter_mem_inf_sets (mem_nhds_sets hu hx) (mem_nhds_sets hv hy),
 h $ empty_in_sets_eq_bot.mp $ huv ▸ this
 
@@ -234,8 +234,8 @@ section regularity
 class regular_space (α : Type u) [topological_space α] extends t1_space α : Prop :=
 (regular : ∀{s:set α} {a}, is_closed s → a ∉ s → ∃t, is_open t ∧ s ⊆ t ∧ nhds a ⊓ principal t = ⊥)
 
-lemma nhds_is_closed [regular_space α] {a : α} {s : set α} (h : s ∈ (nhds a).sets) :
-  ∃t∈(nhds a).sets, t ⊆ s ∧ is_closed t :=
+lemma nhds_is_closed [regular_space α] {a : α} {s : set α} (h : s ∈ nhds a) :
+  ∃t∈(nhds a), t ⊆ s ∧ is_closed t :=
 let ⟨s', h₁, h₂, h₃⟩ := mem_nhds_sets_iff.mp h in
 have ∃t, is_open t ∧ -s' ⊆ t ∧ nhds a ⊓ principal t = ⊥,
   from regular_space.regular (is_closed_compl_iff.mpr h₂) (not_not_intro h₃),

--- a/src/topology/sequences.lean
+++ b/src/topology/sequences.lean
@@ -40,11 +40,11 @@ iff.intro
   (assume ttol : tendsto x at_top (nhds limit),
     show ∀ U : set α, limit ∈ U → is_open U → ∃ n0 : ℕ, ∀ n ≥ n0, (x n) ∈ U, from
       assume U limitInU isOpenU,
-      have {n | (x n) ∈ U} ∈ at_top.sets :=
+      have {n | (x n) ∈ U} ∈ at_top :=
         mem_map.mp $ le_def.mp ttol U $ mem_nhds_sets isOpenU limitInU,
       show ∃ n0 : ℕ, ∀ n ≥ n0, (x n) ∈ U, from mem_at_top_sets.mp this)
   (assume xtol : ∀ U : set α, limit ∈ U → is_open U → ∃ n0 : ℕ, ∀ n ≥ n0, (x n) ∈ U,
-    suffices ∀ U, is_open U → limit ∈ U → x ⁻¹' U ∈ at_top.sets,
+    suffices ∀ U, is_open U → limit ∈ U → x ⁻¹' U ∈ at_top,
       from tendsto_nhds.mpr this,
     assume U isOpenU limitInU,
     suffices ∃ n0 : ℕ, ∀ n ≥ n0, (x n) ∈ U, by simp [this],

--- a/src/topology/stone_cech.lean
+++ b/src/topology/stone_cech.lean
@@ -23,7 +23,7 @@ section ultrafilter
 
 /-- Basis for the topology on `ultrafilter α`. -/
 def ultrafilter_basis (α : Type u) : set (set (ultrafilter α)) :=
-{t | ∃ (s : set α), t = {u | s ∈ u.val.sets}}
+{t | ∃ (s : set α), t = {u | s ∈ u.val}}
 
 variables {α : Type u}
 
@@ -43,12 +43,12 @@ lemma ultrafilter_basis_is_basis :
 
 /-- The basic open sets for the topology on ultrafilters are open. -/
 lemma ultrafilter_is_open_basic (s : set α) :
-  is_open {u : ultrafilter α | s ∈ u.val.sets} :=
+  is_open {u : ultrafilter α | s ∈ u.val} :=
 topological_space.is_open_of_is_topological_basis ultrafilter_basis_is_basis ⟨s, rfl⟩
 
 /-- The basic open sets for the topology on ultrafilters are also closed. -/
 lemma ultrafilter_is_closed_basic (s : set α) :
-  is_closed {u : ultrafilter α | s ∈ u.val.sets} :=
+  is_closed {u : ultrafilter α | s ∈ u.val} :=
 begin
   change is_open (- _),
   convert ultrafilter_is_open_basic (-s),
@@ -62,7 +62,7 @@ lemma ultrafilter_converges_iff {u : ultrafilter (ultrafilter α)} {x : ultrafil
   u.val ≤ nhds x ↔ x = mjoin u :=
 begin
   rw [eq_comm, ultrafilter.eq_iff_val_le_val],
-  change u.val ≤ nhds x ↔ x.val.sets ⊆ {a | {v : ultrafilter α | a ∈ v.val.sets} ∈ u.val.sets},
+  change u.val ≤ nhds x ↔ x.val.sets ⊆ {a | {v : ultrafilter α | a ∈ v.val} ∈ u.val},
   simp only [topological_space.nhds_generate_from, lattice.le_infi_iff, ultrafilter_basis,
     le_principal_iff],
   split; intro h,
@@ -86,7 +86,7 @@ begin
   simp only [comap_infi, comap_principal],
   intros s hs,
   rw ←le_principal_iff,
-  refine lattice.infi_le_of_le {u | s ∈ u.val.sets} _,
+  refine lattice.infi_le_of_le {u | s ∈ u.val} _,
   refine lattice.infi_le_of_le ⟨hs, ⟨s, rfl⟩⟩ _,
   rw principal_mono,
   intros a ha,
@@ -98,7 +98,7 @@ section embedding
 lemma ultrafilter_pure_injective : function.injective (pure : α → ultrafilter α) :=
 begin
   intros x y h,
-  have : {x} ∈ (pure x : ultrafilter α).val.sets := singleton_mem_pure_sets,
+  have : {x} ∈ (pure x : ultrafilter α).val := singleton_mem_pure_sets,
   rw h at this,
   exact (mem_singleton_iff.mp (mem_pure_sets.mp this)).symm
 end
@@ -114,7 +114,7 @@ dense_embedding.mk' pure continuous_top
       ultrafilter_converges_iff.mpr (bind_pure x).symm⟩)
   ultrafilter_pure_injective
   (assume a s as,
-     ⟨{u | s ∈ u.val.sets},
+     ⟨{u | s ∈ u.val},
       mem_nhds_sets (ultrafilter_is_open_basic s) (mem_pure_sets.mpr (mem_of_nhds as)),
       assume b hb, mem_pure_sets.mp hb⟩)
 

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -40,7 +40,7 @@ by convert ← compact_inter hs ht; exact inter_eq_self_of_subset_right h
 
 lemma compact_adherence_nhdset {s t : set α} {f : filter α}
   (hs : compact s) (hf₂ : f ≤ principal s) (ht₁ : is_open t) (ht₂ : ∀a∈s, nhds a ⊓ f ≠ ⊥ → a ∈ t) :
-  t ∈ f.sets :=
+  t ∈ f :=
 classical.by_cases mem_sets_of_neq_bot $
   assume : f ⊓ principal (- t) ≠ ⊥,
   let ⟨a, ha, (hfa : f ⊓ principal (-t) ⊓ nhds a ≠ ⊥)⟩ := hs _ this $ inf_le_left_of_le hf₂ in
@@ -125,9 +125,9 @@ assume f hfn hfs, classical.by_contradiction $ assume : ¬ (∃x∈s, f ⊓ nhds
     by simpa only [not_exists, not_not, inf_comm],
   have ¬ ∃x∈s, ∀t∈f.sets, x ∈ closure t,
     from assume ⟨x, hxs, hx⟩,
-    have ∅ ∈ (nhds x ⊓ f).sets, by rw [empty_in_sets_eq_bot, hf x hxs],
+    have ∅ ∈ nhds x ⊓ f, by rw [empty_in_sets_eq_bot, hf x hxs],
     let ⟨t₁, ht₁, t₂, ht₂, ht⟩ := by rw [mem_inf_sets] at this; exact this in
-    have ∅ ∈ (nhds x ⊓ principal t₂).sets,
+    have ∅ ∈ nhds x ⊓ principal t₂,
       from (nhds x ⊓ principal t₂).sets_of_superset (inter_mem_inf_sets ht₁ (subset.refl t₂)) ht,
     have nhds x ⊓ principal t₂ = ⊥,
       by rwa [empty_in_sets_eq_bot] at this,
@@ -136,13 +136,13 @@ assume f hfn hfs, classical.by_contradiction $ assume : ¬ (∃x∈s, f ⊓ nhds
   let c := (λt, - closure t) '' f.sets, ⟨c', hcc', hcf, hsc'⟩ := h c
     (assume t ⟨s, hs, h⟩, h ▸ is_closed_closure) (by simpa only [subset_def, sUnion_image, mem_Union]) in
   let ⟨b, hb⟩ := axiom_of_choice $
-    show ∀s:c', ∃t, t ∈ f.sets ∧ - closure t = s,
+    show ∀s:c', ∃t, t ∈ f ∧ - closure t = s,
       from assume ⟨x, hx⟩, hcc' hx in
-  have (⋂s∈c', if h : s ∈ c' then b ⟨s, h⟩ else univ) ∈ f.sets,
+  have (⋂s∈c', if h : s ∈ c' then b ⟨s, h⟩ else univ) ∈ f,
     from Inter_mem_sets hcf $ assume t ht, by rw [dif_pos ht]; exact (hb ⟨t, ht⟩).left,
-  have s ∩ (⋂s∈c', if h : s ∈ c' then b ⟨s, h⟩ else univ) ∈ f.sets,
+  have s ∩ (⋂s∈c', if h : s ∈ c' then b ⟨s, h⟩ else univ) ∈ f,
     from inter_mem_sets (le_principal_iff.1 hfs) this,
-  have ∅ ∈ f.sets,
+  have ∅ ∈ f,
     from mem_sets_of_superset this $ assume x ⟨hxs, hxi⟩,
     let ⟨t, htc', hxt⟩ := (show ∃t ∈ c', x ∈ t, from hsc' hxs) in
     have -closure (b ⟨t, htc'⟩) = t, from (hb _).right,
@@ -222,7 +222,7 @@ Hausdorff spaces but not in general. This one is the precise condition on X need
 evaluation `map C(X, Y) × X → Y` to be continuous for all `Y` when `C(X, Y)` is given the
 compact-open topology. -/
 class locally_compact_space (α : Type*) [topological_space α] : Prop :=
-(local_compact_nhds : ∀ (x : α) (n ∈ (nhds x).sets), ∃ s ∈ (nhds x).sets, s ⊆ n ∧ compact s)
+(local_compact_nhds : ∀ (x : α) (n ∈ nhds x), ∃ s ∈ nhds x, s ⊆ n ∧ compact s)
 
 end compact
 

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -76,9 +76,9 @@ structure uniform_space.core (α : Type u) :=
 (comp       : uniformity.lift' (λs, comp_rel s s) ≤ uniformity)
 
 def uniform_space.core.mk' {α : Type u} (U : filter (α × α))
-  (refl : ∀ (r ∈ U.sets) x, (x, x) ∈ r)
-  (symm : ∀ r ∈ U.sets, {p | prod.swap p ∈ r} ∈ U.sets)
-  (comp : ∀ r ∈ U.sets, ∃ t ∈ U.sets, comp_rel t t ⊆ r) : uniform_space.core α :=
+  (refl : ∀ (r ∈ U) x, (x, x) ∈ r)
+  (symm : ∀ r ∈ U, {p | prod.swap p ∈ r} ∈ U)
+  (comp : ∀ r ∈ U, ∃ t ∈ U, comp_rel t t ⊆ r) : uniform_space.core α :=
 ⟨U, λ r ru, id_rel_subset.2 (refl _ ru), symm,
   begin
     intros r ru,
@@ -90,7 +90,7 @@ def uniform_space.core.mk' {α : Type u} (U : filter (α × α))
 /-- A uniform space generates a topological space -/
 def uniform_space.core.to_topological_space {α : Type u} (u : uniform_space.core α) :
   topological_space α :=
-{ is_open        := λs, ∀x∈s, { p : α × α | p.1 = x → p.2 ∈ s } ∈ u.uniformity.sets,
+{ is_open        := λs, ∀x∈s, { p : α × α | p.1 = x → p.2 ∈ s } ∈ u.uniformity,
   is_open_univ   := by simp; intro; exact univ_mem_sets,
   is_open_inter  :=
     assume s t hs ht x ⟨xs, xt⟩, by filter_upwards [hs x xs, ht x xt]; simp {contextual := tt},
@@ -108,12 +108,12 @@ lemma uniform_space.core_eq : ∀{u₁ u₂ : uniform_space.core α}, u₁.unifo
   A metric space has a natural uniformity, and a uniform space has a natural topology.
   A topological group also has a natural uniformity, even when it is not metrizable. -/
 class uniform_space (α : Type u) extends topological_space α, uniform_space.core α :=
-(is_open_uniformity : ∀s, is_open s ↔ (∀x∈s, { p : α × α | p.1 = x → p.2 ∈ s } ∈ uniformity.sets))
+(is_open_uniformity : ∀s, is_open s ↔ (∀x∈s, { p : α × α | p.1 = x → p.2 ∈ s } ∈ uniformity))
 
 @[pattern] def uniform_space.mk' {α} (t : topological_space α)
   (c : uniform_space.core α)
   (is_open_uniformity : ∀s:set α, t.is_open s ↔
-    (∀x∈s, { p : α × α | p.1 = x → p.2 ∈ s } ∈ c.uniformity.sets)) :
+    (∀x∈s, { p : α × α | p.1 = x → p.2 ∈ s } ∈ c.uniformity)) :
   uniform_space α := ⟨c, is_open_uniformity⟩
 
 def uniform_space.of_core {α : Type u} (u : uniform_space.core α) : uniform_space α :=
@@ -152,13 +152,13 @@ variables [uniform_space α]
 def uniformity : filter (α × α) := (@uniform_space.to_core α _).uniformity
 
 lemma is_open_uniformity {s : set α} :
-  is_open s ↔ (∀x∈s, { p : α × α | p.1 = x → p.2 ∈ s } ∈ (@uniformity α _).sets) :=
+  is_open s ↔ (∀x∈s, { p : α × α | p.1 = x → p.2 ∈ s } ∈ @uniformity α _) :=
 uniform_space.is_open_uniformity s
 
 lemma refl_le_uniformity : principal id_rel ≤ @uniformity α _ :=
 (@uniform_space.to_core α _).refl
 
-lemma refl_mem_uniformity {x : α} {s : set (α × α)} (h : s ∈ (@uniformity α _).sets) :
+lemma refl_mem_uniformity {x : α} {s : set (α × α)} (h : s ∈ @uniformity α _) :
   (x, x) ∈ s :=
 refl_le_uniformity h rfl
 
@@ -173,21 +173,21 @@ symm_le_uniformity
 
 lemma tendsto_const_uniformity {a : α} {f : filter β} : tendsto (λ_, (a, a)) f uniformity :=
 assume s hs,
-show {x | (a, a) ∈ s} ∈ f.sets,
+show {x | (a, a) ∈ s} ∈ f,
   from univ_mem_sets' $ assume b, refl_mem_uniformity hs
 
-lemma comp_mem_uniformity_sets {s : set (α × α)} (hs : s ∈ (@uniformity α _).sets) :
+lemma comp_mem_uniformity_sets {s : set (α × α)} (hs : s ∈ @uniformity α _) :
   ∃t∈(@uniformity α _).sets, comp_rel t t ⊆ s :=
-have s ∈ (uniformity.lift' (λt:set (α×α), comp_rel t t)).sets,
+have s ∈ uniformity.lift' (λt:set (α×α), comp_rel t t),
   from comp_le_uniformity hs,
 (mem_lift'_sets $ monotone_comp_rel monotone_id monotone_id).mp this
 
-lemma symm_of_uniformity {s : set (α × α)} (hs : s ∈ (@uniformity α _).sets) :
+lemma symm_of_uniformity {s : set (α × α)} (hs : s ∈ @uniformity α _) :
   ∃t∈(@uniformity α _).sets, (∀a b, (a, b) ∈ t → (b, a) ∈ t) ∧ t ⊆ s :=
-have preimage prod.swap s ∈ (@uniformity α _).sets, from symm_le_uniformity hs,
+have preimage prod.swap s ∈ @uniformity α _, from symm_le_uniformity hs,
 ⟨s ∩ preimage prod.swap s, inter_mem_sets hs this, assume a b ⟨h₁, h₂⟩, ⟨h₂, h₁⟩, inter_subset_left _ _⟩
 
-lemma comp_symm_of_uniformity {s : set (α × α)} (hs : s ∈ (@uniformity α _).sets) :
+lemma comp_symm_of_uniformity {s : set (α × α)} (hs : s ∈ @uniformity α _) :
   ∃t∈(@uniformity α _).sets, (∀{a b}, (a, b) ∈ t → (b, a) ∈ t) ∧ comp_rel t t ⊆ s :=
 let ⟨t, ht₁, ht₂⟩ := comp_mem_uniformity_sets hs in
 let ⟨t', ht', ht'₁, ht'₂⟩ := symm_of_uniformity ht₁ in
@@ -237,14 +237,14 @@ calc uniformity.lift' (λd, comp_rel d (comp_rel d d)) =
   ... ≤ uniformity : comp_le_uniformity
 
 lemma mem_nhds_uniformity_iff {x : α} {s : set α} :
-  s ∈ (nhds x).sets ↔ {p : α × α | p.1 = x → p.2 ∈ s} ∈ (@uniformity α _).sets :=
+  s ∈ nhds x ↔ {p : α × α | p.1 = x → p.2 ∈ s} ∈ @uniformity α _ :=
 ⟨ begin
     simp only [mem_nhds_sets_iff, is_open_uniformity, and_imp, exists_imp_distrib],
     exact assume t ts ht xt, by filter_upwards [ht x xt] assume ⟨x', y⟩ h eq, ts $ h eq
   end,
 
   assume hs,
-  mem_nhds_sets_iff.mpr ⟨{x | {p : α × α | p.1 = x → p.2 ∈ s} ∈ (@uniformity α _).sets},
+  mem_nhds_sets_iff.mpr ⟨{x | {p : α × α | p.1 = x → p.2 ∈ s} ∈ @uniformity α _},
     assume x' hx', refl_mem_uniformity hx' rfl,
     is_open_uniformity.mpr $ assume x' hx',
       let ⟨t, ht, tr⟩ := comp_mem_uniformity_sets hx' in
@@ -276,13 +276,13 @@ begin
 end
 
 lemma mem_nhds_left (x : α) {s : set (α×α)} (h : s ∈ (uniformity.sets : set (set (α×α)))) :
-  {y : α | (x, y) ∈ s} ∈ (nhds x).sets :=
+  {y : α | (x, y) ∈ s} ∈ nhds x :=
 have nhds x ≤ principal {y : α | (x, y) ∈ s},
   by rw [nhds_eq_uniformity]; exact infi_le_of_le s (infi_le _ h),
 by simp at this; assumption
 
 lemma mem_nhds_right (y : α) {s : set (α×α)} (h : s ∈ (uniformity.sets : set (set (α×α)))) :
-  {x : α | (x, y) ∈ s} ∈ (nhds y).sets :=
+  {x : α | (x, y) ∈ s} ∈ nhds y :=
 mem_nhds_left _ (symm_le_uniformity h)
 
 lemma tendsto_right_nhds_uniformity {a : α} : tendsto (λa', (a', a)) (nhds a) uniformity :=
@@ -333,12 +333,12 @@ begin
   { intro t, exact monotone_prod monotone_preimage monotone_const }
 end
 
-lemma nhdset_of_mem_uniformity {d : set (α×α)} (s : set (α×α)) (hd : d ∈ (@uniformity α _).sets) :
+lemma nhdset_of_mem_uniformity {d : set (α×α)} (s : set (α×α)) (hd : d ∈ @uniformity α _) :
   ∃(t : set (α×α)), is_open t ∧ s ⊆ t ∧ t ⊆ {p | ∃x y, (p.1, x) ∈ d ∧ (x, y) ∈ s ∧ (y, p.2) ∈ d} :=
 let cl_d := {p:α×α | ∃x y, (p.1, x) ∈ d ∧ (x, y) ∈ s ∧ (y, p.2) ∈ d} in
 have ∀p ∈ s, ∃t ⊆ cl_d, is_open t ∧ p ∈ t, from
   assume ⟨x, y⟩ hp, mem_nhds_sets_iff.mp $
-  show cl_d ∈ (nhds (x, y)).sets,
+  show cl_d ∈ nhds (x, y),
   begin
     rw [nhds_eq_uniformity_prod, mem_lift'_sets],
     exact ⟨d, hd, assume ⟨a, b⟩ ⟨ha, hb⟩, ⟨x, y, ha, hp, hb⟩⟩,
@@ -401,17 +401,17 @@ le_antisymm
       calc s ⊆ t : hst
        ... ⊆ interior d : (subset_interior_iff_subset_of_open ht).mpr $
         assume x, assume : x ∈ t, let ⟨x, y, h₁, h₂, h₃⟩ := ht_comp this in hs_comp ⟨x, h₁, y, h₂, h₃⟩,
-    have interior d ∈ (@uniformity α _).sets, by filter_upwards [hs] this,
+    have interior d ∈ @uniformity α _, by filter_upwards [hs] this,
     by simp [this])
   (assume s hs, (uniformity.lift' interior).sets_of_superset (mem_lift' hs) interior_subset)
 
-lemma interior_mem_uniformity {s : set (α × α)} (hs : s ∈ (@uniformity α _).sets) :
-  interior s ∈ (@uniformity α _).sets :=
+lemma interior_mem_uniformity {s : set (α × α)} (hs : s ∈ @uniformity α _) :
+  interior s ∈ @uniformity α _ :=
 by rw [uniformity_eq_uniformity_interior]; exact mem_lift' hs
 
-lemma mem_uniformity_is_closed [uniform_space α] {s : set (α×α)} (h : s ∈ (@uniformity α _).sets) :
+lemma mem_uniformity_is_closed [uniform_space α] {s : set (α×α)} (h : s ∈ @uniformity α _) :
   ∃t∈(@uniformity α _).sets, is_closed t ∧ t ⊆ s :=
-have s ∈ ((@uniformity α _).lift' closure).sets, by rwa [uniformity_eq_uniformity_closure] at h,
+have s ∈ (@uniformity α _).lift' closure, by rwa [uniformity_eq_uniformity_closure] at h,
 have ∃t∈(@uniformity α _).sets, closure t ⊆ s,
   by rwa [mem_lift'_sets] at this; apply closure_mono,
 let ⟨t, ht, hst⟩ := this in
@@ -423,8 +423,8 @@ def uniform_continuous [uniform_space β] (f : α → β) :=
 tendsto (λx:α×α, (f x.1, f x.2)) uniformity uniformity
 
 theorem uniform_continuous_def [uniform_space β] {f : α → β} :
-  uniform_continuous f ↔ ∀ r ∈ (@uniformity β _).sets,
-    {x : α × α | (f x.1, f x.2) ∈ r} ∈ (@uniformity α _).sets :=
+  uniform_continuous f ↔ ∀ r ∈ @uniformity β _,
+    {x : α × α | (f x.1, f x.2) ∈ r} ∈ @uniformity α _ :=
 iff.rfl
 
 lemma uniform_continuous_of_const [uniform_space β] {c : α → β} (h : ∀a b, c a = c b) :
@@ -673,7 +673,7 @@ uniform_continuous_comap' hf
 
 lemma tendsto_of_uniform_continuous_subtype
   [uniform_space α] [uniform_space β] {f : α → β} {s : set α} {a : α}
-  (hf : uniform_continuous (λx:s, f x.val)) (ha : s ∈ (nhds a).sets) :
+  (hf : uniform_continuous (λx:s, f x.val)) (ha : s ∈ nhds a) :
   tendsto f (nhds a) (nhds (f a)) :=
 by rw [(@map_nhds_subtype_val_eq α _ s a (mem_of_nhds ha) ha).symm]; exact
 tendsto_map' (continuous_iff_continuous_at.mp hf.continuous _)
@@ -705,12 +705,16 @@ have map (λp:(α×α)×(β×β), ((p.1.1, p.2.1), (p.1.2, p.2.2))) =
     (funext $ assume ⟨⟨_, _⟩, ⟨_, _⟩⟩, rfl) (funext $ assume ⟨⟨_, _⟩, ⟨_, _⟩⟩, rfl),
 by rw [this, uniformity_prod, filter.prod, comap_inf, comap_comap_comp, comap_comap_comp]
 
+lemma mem_map_sets_iff' {α : Type*} {β : Type*} {f : filter α} {m : α → β} {t : set β} :
+  t ∈ (map m f).sets ↔ (∃s∈f, m '' s ⊆ t) :=
+mem_map_sets_iff
+
 lemma mem_uniformity_of_uniform_continuous_invarant [uniform_space α] {s:set (α×α)} {f : α → α → α}
-  (hf : uniform_continuous (λp:α×α, f p.1 p.2)) (hs : s ∈ (@uniformity α _).sets) :
-  ∃u∈(@uniformity α _).sets, ∀a b c, (a, b) ∈ u → (f a c, f b c) ∈ s :=
+  (hf : uniform_continuous (λp:α×α, f p.1 p.2)) (hs : s ∈ (@uniformity α _)) :
+  ∃u∈(@uniformity α _), ∀a b c, (a, b) ∈ u → (f a c, f b c) ∈ s :=
 begin
   rw [uniform_continuous, uniformity_prod_eq_prod, tendsto_map'_iff, (∘)] at hf,
-  rcases mem_map_sets_iff.1 (hf hs) with ⟨t, ht, hts⟩, clear hf,
+  rcases mem_map_sets_iff'.1 (hf hs) with ⟨t, ht, hts⟩, clear hf,
   rcases mem_prod_iff.1 ht with ⟨u, hu, v, hv, huvt⟩, clear ht,
   refine ⟨u, hu, assume a b c hab, hts $ (mem_image _ _ _).2 ⟨⟨⟨a, b⟩, ⟨c, c⟩⟩, huvt ⟨_, _⟩, _⟩⟩,
   exact hab,
@@ -719,8 +723,8 @@ begin
 end
 
 lemma mem_uniform_prod [t₁ : uniform_space α] [t₂ : uniform_space β] {a : set (α × α)} {b : set (β × β)}
-  (ha : a ∈ (@uniformity α _).sets) (hb : b ∈ (@uniformity β _).sets) :
-  {p:(α×β)×(α×β) | (p.1.1, p.2.1) ∈ a ∧ (p.1.2, p.2.2) ∈ b } ∈ (@uniformity (α × β) _).sets :=
+  (ha : a ∈ (@uniformity α _)) (hb : b ∈ (@uniformity β _)) :
+  {p:(α×β)×(α×β) | (p.1.1, p.2.1) ∈ a ∧ (p.1.2, p.2.2) ∈ b } ∈ (@uniformity (α × β) _) :=
 by rw [uniformity_prod]; exact inter_mem_inf_sets (preimage_mem_comap ha) (preimage_mem_comap hb)
 
 lemma tendsto_prod_uniformity_fst [uniform_space α] [uniform_space β] :
@@ -790,15 +794,15 @@ uniform_space.core.mk'
 
 /-- The union of an entourage of the diagonal in each set of a disjoint union is again an entourage of the diagonal. -/
 lemma union_mem_uniformity_sum
-  {a : set (α × α)} (ha : a ∈ (@uniformity α _).sets) {b : set (β × β)} (hb : b ∈ (@uniformity β _).sets) :
-  ((λ p : (α × α), (inl p.1, inl p.2)) '' a ∪ (λ p : (β × β), (inr p.1, inr p.2)) '' b) ∈ (@uniform_space.core.sum α β _ _).uniformity.sets :=
+  {a : set (α × α)} (ha : a ∈ @uniformity α _) {b : set (β × β)} (hb : b ∈ @uniformity β _) :
+  ((λ p : (α × α), (inl p.1, inl p.2)) '' a ∪ (λ p : (β × β), (inr p.1, inr p.2)) '' b) ∈ (@uniform_space.core.sum α β _ _).uniformity :=
 ⟨mem_map_sets_iff.2 ⟨_, ha, subset_union_left _ _⟩, mem_map_sets_iff.2 ⟨_, hb, subset_union_right _ _⟩⟩
 
 /- To prove that the topology defined by the uniform structure on the disjoint union coincides with
 the disjoint union topology, we need two lemmas saying that open sets can be characterized by
 the uniform structure -/
 lemma uniformity_sum_of_open_aux {s : set (α ⊕ β)} (hs : is_open s) {x : α ⊕ β} (xs : x ∈ s) :
-  { p : ((α ⊕ β) × (α ⊕ β)) | p.1 = x → p.2 ∈ s } ∈ (@uniform_space.core.sum α β _ _).uniformity.sets :=
+  { p : ((α ⊕ β) × (α ⊕ β)) | p.1 = x → p.2 ∈ s } ∈ (@uniform_space.core.sum α β _ _).uniformity :=
 begin
   cases x,
   { refine mem_sets_of_superset
@@ -814,7 +818,7 @@ begin
 end
 
 lemma open_of_uniformity_sum_aux {s : set (α ⊕ β)}
-  (hs : ∀x ∈ s, { p : ((α ⊕ β) × (α ⊕ β)) | p.1 = x → p.2 ∈ s } ∈ (@uniform_space.core.sum α β _ _).uniformity.sets) :
+  (hs : ∀x ∈ s, { p : ((α ⊕ β) × (α ⊕ β)) | p.1 = x → p.2 ∈ s } ∈ (@uniform_space.core.sum α β _ _).uniformity) :
   is_open s :=
 begin
   split,
@@ -844,10 +848,10 @@ end constructions
 
 lemma lebesgue_number_lemma {α : Type u} [uniform_space α] {s : set α} {ι} {c : ι → set α}
   (hs : compact s) (hc₁ : ∀ i, is_open (c i)) (hc₂ : s ⊆ ⋃ i, c i) :
-  ∃ n ∈ (@uniformity α _).sets, ∀ x ∈ s, ∃ i, {y | (x, y) ∈ n} ⊆ c i :=
+  ∃ n ∈ @uniformity α _, ∀ x ∈ s, ∃ i, {y | (x, y) ∈ n} ⊆ c i :=
 begin
-  let u := λ n, {x | ∃ i (m ∈ (@uniformity α _).sets), {y | (x, y) ∈ comp_rel m n} ⊆ c i},
-  have hu₁ : ∀ n ∈ (@uniformity α _).sets, is_open (u n),
+  let u := λ n, {x | ∃ i (m ∈ @uniformity α _), {y | (x, y) ∈ comp_rel m n} ⊆ c i},
+  have hu₁ : ∀ n ∈ @uniformity α _, is_open (u n),
   { refine λ n hn, is_open_uniformity.2 _,
     rintro x ⟨i, m, hm, h⟩,
     rcases comp_mem_uniformity_sets hm with ⟨m', hm', mm'⟩,
@@ -856,7 +860,7 @@ begin
     refine ⟨i, m', hm', λ z hz, h (monotone_comp_rel monotone_id monotone_const mm' _)⟩,
     dsimp at hz ⊢, rw comp_rel_assoc,
     exact ⟨y, hp, hz⟩ },
-  have hu₂ : s ⊆ ⋃ n ∈ (@uniformity α _).sets, u n,
+  have hu₂ : s ⊆ ⋃ n ∈ @uniformity α _, u n,
   { intros x hx,
     rcases mem_Union.1 (hc₂ hx) with ⟨i, h⟩,
     rcases comp_mem_uniformity_sets (is_open_uniformity.1 (hc₁ i) x h) with ⟨m', hm', mm'⟩,
@@ -870,6 +874,6 @@ end
 
 lemma lebesgue_number_lemma_sUnion {α : Type u} [uniform_space α] {s : set α} {c : set (set α)}
   (hs : compact s) (hc₁ : ∀ t ∈ c, is_open t) (hc₂ : s ⊆ ⋃₀ c) :
-  ∃ n ∈ (@uniformity α _).sets, ∀ x ∈ s, ∃ t ∈ c, ∀ y, (x, y) ∈ n → y ∈ t :=
+  ∃ n ∈ @uniformity α _, ∀ x ∈ s, ∃ t ∈ c, ∀ y, (x, y) ∈ n → y ∈ t :=
 by rw sUnion_eq_Union at hc₂;
    simpa using lebesgue_number_lemma hs (by simpa) hc₂

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -60,14 +60,14 @@ variables {β : Type v} {γ : Type w}
 variables [uniform_space β] [uniform_space γ]
 
 def gen (s : set (α × α)) : set (Cauchy α × Cauchy α) :=
-{p | s ∈ (filter.prod (p.1.val) (p.2.val)).sets }
+{p | s ∈ filter.prod (p.1.val) (p.2.val) }
 
 lemma monotone_gen : monotone gen :=
 monotone_set_of $ assume p, @monotone_mem_sets (α×α) (filter.prod (p.1.val) (p.2.val))
 
 private lemma symm_gen : map prod.swap (uniformity.lift' gen) ≤ uniformity.lift' gen :=
 calc map prod.swap (uniformity.lift' gen) =
-  uniformity.lift' (λs:set (α×α), {p | s ∈ (filter.prod (p.2.val) (p.1.val)).sets }) :
+  uniformity.lift' (λs:set (α×α), {p | s ∈ filter.prod (p.2.val) (p.1.val) }) :
   begin
     delta gen,
     simp [map_lift'_eq, monotone_set_of, monotone_mem_sets,
@@ -86,11 +86,11 @@ calc map prod.swap (uniformity.lift' gen) =
 private lemma comp_rel_gen_gen_subset_gen_comp_rel {s t : set (α×α)} : comp_rel (gen s) (gen t) ⊆
   (gen (comp_rel s t) : set (Cauchy α × Cauchy α)) :=
 assume ⟨f, g⟩ ⟨h, h₁, h₂⟩,
-let ⟨t₁, (ht₁ : t₁ ∈ f.val.sets), t₂, (ht₂ : t₂ ∈ h.val.sets), (h₁ : set.prod t₁ t₂ ⊆ s)⟩ :=
+let ⟨t₁, (ht₁ : t₁ ∈ f.val), t₂, (ht₂ : t₂ ∈ h.val), (h₁ : set.prod t₁ t₂ ⊆ s)⟩ :=
   mem_prod_iff.mp h₁ in
-let ⟨t₃, (ht₃ : t₃ ∈ h.val.sets), t₄, (ht₄ : t₄ ∈ g.val.sets), (h₂ : set.prod t₃ t₄ ⊆ t)⟩ :=
+let ⟨t₃, (ht₃ : t₃ ∈ h.val), t₄, (ht₄ : t₄ ∈ g.val), (h₂ : set.prod t₃ t₄ ⊆ t)⟩ :=
   mem_prod_iff.mp h₂ in
-have t₂ ∩ t₃ ∈ h.val.sets,
+have t₂ ∩ t₃ ∈ h.val,
   from inter_mem_sets ht₂ ht₃,
 let ⟨x, xt₂, xt₃⟩ :=
   inhabited_of_mem_sets (h.property.left) this in
@@ -129,12 +129,12 @@ uniform_space.of_core
   comp        := comp_gen }
 
 theorem mem_uniformity {s : set (Cauchy α × Cauchy α)} :
-  s ∈ (@uniformity (Cauchy α) _).sets ↔ ∃ t ∈ (@uniformity α _).sets, gen t ⊆ s :=
+  s ∈ @uniformity (Cauchy α) _ ↔ ∃ t ∈ @uniformity α _, gen t ⊆ s :=
 mem_lift'_sets monotone_gen
 
 theorem mem_uniformity' {s : set (Cauchy α × Cauchy α)} :
-  s ∈ (@uniformity (Cauchy α) _).sets ↔ ∃ t ∈ (@uniformity α _).sets,
-    ∀ f g : Cauchy α, t ∈ (filter.prod f.1 g.1).sets → (f, g) ∈ s :=
+  s ∈ @uniformity (Cauchy α) _ ↔ ∃ t ∈ @uniformity α _,
+    ∀ f g : Cauchy α, t ∈ filter.prod f.1 g.1 → (f, g) ∈ s :=
 mem_uniformity.trans $ bex_congr $ λ t h, prod.forall
 
 /-- Embedding of `α` into its completion -/
@@ -162,11 +162,11 @@ have h_ex : ∀s∈(@uniformity (Cauchy α) _).sets, ∃y:α, (f, pure_cauchy y)
   assume s hs,
   let ⟨t'', ht''₁, (ht''₂ : gen t'' ⊆ s)⟩ := (mem_lift'_sets monotone_gen).mp hs in
   let ⟨t', ht'₁, ht'₂⟩ := comp_mem_uniformity_sets ht''₁ in
-  have t' ∈ (filter.prod (f.val) (f.val)).sets,
+  have t' ∈ filter.prod (f.val) (f.val),
     from f.property.right ht'₁,
   let ⟨t, ht, (h : set.prod t t ⊆ t')⟩ := mem_prod_same_iff.mp this in
   let ⟨x, (hx : x ∈ t)⟩ := inhabited_of_mem_sets f.property.left ht in
-  have t'' ∈ (filter.prod f.val (pure x)).sets,
+  have t'' ∈ filter.prod f.val (pure x),
     from mem_prod_iff.mpr ⟨t, ht, {y:α | (x, y) ∈ t'},
       assume y, begin simp, intro h, simp [h], exact refl_mem_uniformity ht'₁ end,
       assume ⟨a, b⟩ ⟨(h₁ : a ∈ t), (h₂ : (x, b) ∈ t')⟩,
@@ -269,7 +269,7 @@ begin
     refine H {p | (lim p.1.1, lim p.2.1) ∈ t}
       (Cauchy.mem_uniformity'.2 ⟨d, du, λ f g h, _⟩),
     rcases mem_prod_iff.1 h with ⟨x, xf, y, yg, h⟩,
-    have limc : ∀ (f : Cauchy α) (x ∈ f.1.sets), lim f.1 ∈ closure x,
+    have limc : ∀ (f : Cauchy α) (x ∈ f.1), lim f.1 ∈ closure x,
     { intros f x xf,
       rw closure_eq_nhds,
       exact lattice.neq_bot_of_le_neq_bot f.2.1

--- a/src/topology/uniform_space/separation.lean
+++ b/src/topology/uniform_space/separation.lean
@@ -29,11 +29,11 @@ protected def separation_rel (α : Type u) [u : uniform_space α] :=
 lemma separated_equiv : equivalence (λx y, (x, y) ∈ separation_rel α) :=
 ⟨assume x, assume s, refl_mem_uniformity,
   assume x y, assume h (s : set (α×α)) hs,
-    have preimage prod.swap s ∈ (@uniformity α _).sets,
+    have preimage prod.swap s ∈ @uniformity α _,
       from symm_le_uniformity hs,
     h _ this,
   assume x y z (hxy : (x, y) ∈ separation_rel α) (hyz : (y, z) ∈ separation_rel α)
-      s (hs : s ∈ (@uniformity α _).sets),
+      s (hs : s ∈ @uniformity α _),
     let ⟨t, ht, (h_ts : comp_rel t t ⊆ s)⟩ := comp_mem_uniformity_sets hs in
     h_ts $ show (x, z) ∈ comp_rel t t,
       from ⟨y, hxy t ht, hyz t ht⟩⟩
@@ -42,12 +42,12 @@ lemma separated_equiv : equivalence (λx y, (x, y) ∈ separation_rel α) :=
 separation_rel α = id_rel
 
 theorem separated_def {α : Type u} [uniform_space α] :
-  separated α ↔ ∀ x y, (∀ r ∈ (@uniformity α _).sets, (x, y) ∈ r) → x = y :=
+  separated α ↔ ∀ x y, (∀ r ∈ @uniformity α _, (x, y) ∈ r) → x = y :=
 by simp [separated, id_rel_subset.2 separated_equiv.1, subset.antisymm_iff];
    simp [subset_def, separation_rel]
 
 theorem separated_def' {α : Type u} [uniform_space α] :
-  separated α ↔ ∀ x y, x ≠ y → ∃ r ∈ (@uniformity α _).sets, (x, y) ∉ r :=
+  separated α ↔ ∀ x y, x ≠ y → ∃ r ∈ @uniformity α _, (x, y) ∉ r :=
 separated_def.trans $ forall_congr $ λ x, forall_congr $ λ y,
 by rw ← not_imp_not; simp [classical.not_forall]
 
@@ -55,10 +55,10 @@ instance separated_t2 [s : separated α] : t2_space α :=
 ⟨assume x y, assume h : x ≠ y,
 let ⟨d, hd, (hxy : (x, y) ∉ d)⟩ := separated_def'.1 s x y h in
 let ⟨d', hd', (hd'd' : comp_rel d' d' ⊆ d)⟩ := comp_mem_uniformity_sets hd in
-have {y | (x, y) ∈ d'} ∈ (nhds x).sets,
+have {y | (x, y) ∈ d'} ∈ nhds x,
   from mem_nhds_left x hd',
 let ⟨u, hu₁, hu₂, hu₃⟩ := mem_nhds_sets_iff.mp this in
-have {x | (x, y) ∈ d'} ∈ (nhds y).sets,
+have {x | (x, y) ∈ d'} ∈ nhds y,
   from mem_nhds_right y hd',
 let ⟨v, hv₁, hv₂, hv₃⟩ := mem_nhds_sets_iff.mp this in
 have u ∩ v = ∅, from
@@ -70,9 +70,9 @@ have u ∩ v = ∅, from
 
 instance separated_regular [separated α] : regular_space α :=
 { regular := λs a hs ha,
-    have -s ∈ (nhds a).sets,
+    have -s ∈ nhds a,
       from mem_nhds_sets hs ha,
-    have {p : α × α | p.1 = a → p.2 ∈ -s} ∈ uniformity.sets,
+    have {p : α × α | p.1 = a → p.2 ∈ -s} ∈ uniformity,
       from mem_nhds_uniformity_iff.mp this,
     let ⟨d, hd, h⟩ := comp_mem_uniformity_sets this in
     let e := {y:α| (a, y) ∈ d} in
@@ -88,7 +88,7 @@ instance separated_regular [separated α] : regular_space α :=
         let ⟨x, (hx : (a, x) ∈ d), y, ⟨hx₁, hx₂⟩, (hy : (y, _) ∈ d)⟩ := @this ⟨a, a'⟩ ⟨hae, ha'⟩ in
         have (a, a') ∈ comp_rel d d, from ⟨y, hx₂, hy⟩,
         h this rfl,
-    have closure e ∈ (nhds a).sets, from (nhds a).sets_of_superset (mem_nhds_left a hd) subset_closure,
+    have closure e ∈ nhds a, from (nhds a).sets_of_superset (mem_nhds_left a hd) subset_closure,
     have nhds a ⊓ principal (-closure e) = ⊥,
       from (@inf_eq_bot_iff_le_compl _ _ _ (principal (- closure e)) (principal (closure e))
         (by simp [principal_univ, union_comm]) (by simp)).mpr (by simp [this]),
@@ -128,8 +128,8 @@ instance {α : Type u} [u : uniform_space α] : uniform_space (quotient (separat
       map_mono comp_le_uniformity3,
   is_open_uniformity := assume s,
     have ∀a, ⟦a⟧ ∈ s →
-        ({p:α×α | p.1 = a → ⟦p.2⟧ ∈ s} ∈ (@uniformity α _).sets ↔
-          {p:α×α | p.1 ≈ a → ⟦p.2⟧ ∈ s} ∈ (@uniformity α _).sets),
+        ({p:α×α | p.1 = a → ⟦p.2⟧ ∈ s} ∈ @uniformity α _ ↔
+          {p:α×α | p.1 ≈ a → ⟦p.2⟧ ∈ s} ∈ @uniformity α _),
       from assume a ha,
       ⟨assume h,
         let ⟨t, ht, hts⟩ := comp_mem_uniformity_sets h in
@@ -195,7 +195,7 @@ instance separated_separation : separated (quotient (separation_setoid α)) :=
 set.ext $ assume ⟨a, b⟩, quotient.induction_on₂ a b $ assume a b,
   ⟨assume h,
     have a ≈ b, from assume s hs,
-      have s ∈ (uniformity.comap (λp:(α×α), (⟦p.1⟧, ⟦p.2⟧))).sets,
+      have s ∈ uniformity.comap (λp:(α×α), (⟦p.1⟧, ⟦p.2⟧)),
         from comap_quotient_le_uniformity hs,
       let ⟨t, ht, hts⟩ := this in
       hts begin dsimp, exact h t ht end,

--- a/src/topology/uniform_space/uniform_embedding.lean
+++ b/src/topology/uniform_space/uniform_embedding.lean
@@ -17,14 +17,14 @@ function.injective f ∧
 comap (λx:α×α, (f x.1, f x.2)) uniformity = uniformity
 
 theorem uniform_embedding_def [uniform_space β] {f : α → β} :
-  uniform_embedding f ↔ function.injective f ∧ ∀ s, s ∈ (@uniformity α _).sets ↔
-    ∃ t ∈ (@uniformity β _).sets, ∀ x y : α, (f x, f y) ∈ t → (x, y) ∈ s :=
+  uniform_embedding f ↔ function.injective f ∧ ∀ s, s ∈ @uniformity α _ ↔
+    ∃ t ∈ @uniformity β _, ∀ x y : α, (f x, f y) ∈ t → (x, y) ∈ s :=
 by rw [uniform_embedding, eq_comm, filter.ext_iff]; simp [subset_def]
 
 theorem uniform_embedding_def' [uniform_space β] {f : α → β} :
   uniform_embedding f ↔ function.injective f ∧ uniform_continuous f ∧
-    ∀ s, s ∈ (@uniformity α _).sets →
-      ∃ t ∈ (@uniformity β _).sets, ∀ x y : α, (f x, f y) ∈ t → (x, y) ∈ s :=
+    ∀ s, s ∈ @uniformity α _ →
+      ∃ t ∈ @uniformity β _, ∀ x y : α, (f x, f y) ∈ t → (x, y) ∈ s :=
 by simp [uniform_embedding_def, uniform_continuous_def]; exact
 ⟨λ ⟨I, H⟩, ⟨I, λ s su, (H _).2 ⟨s, su, λ x y, id⟩, λ s, (H s).1⟩,
  λ ⟨I, H₁, H₂⟩, ⟨I, λ s, ⟨H₂ s,
@@ -55,21 +55,21 @@ lemma uniform_embedding.dense_embedding [uniform_space β] {f : α → β}
 
 lemma closure_image_mem_nhds_of_uniform_embedding
   [uniform_space α] [uniform_space β] {s : set (α×α)} {e : α → β} (b : β)
-  (he₁ : uniform_embedding e) (he₂ : dense_embedding e) (hs : s ∈ (@uniformity α _).sets) :
-  ∃a, closure (e '' {a' | (a, a') ∈ s}) ∈ (nhds b).sets :=
-have s ∈ (comap (λp:α×α, (e p.1, e p.2)) $ uniformity).sets,
+  (he₁ : uniform_embedding e) (he₂ : dense_embedding e) (hs : s ∈ @uniformity α _) :
+  ∃a, closure (e '' {a' | (a, a') ∈ s}) ∈ nhds b :=
+have s ∈ comap (λp:α×α, (e p.1, e p.2)) uniformity,
   from he₁.right.symm ▸ hs,
 let ⟨t₁, ht₁u, ht₁⟩ := this in
 have ht₁ : ∀p:α×α, (e p.1, e p.2) ∈ t₁ → p ∈ s, from ht₁,
 let ⟨t₂, ht₂u, ht₂s, ht₂c⟩ := comp_symm_of_uniformity ht₁u in
 let ⟨t, htu, hts, htc⟩ := comp_symm_of_uniformity ht₂u in
-have preimage e {b' | (b, b') ∈ t₂} ∈ (comap e $ nhds b).sets,
+have preimage e {b' | (b, b') ∈ t₂} ∈ comap e (nhds b),
   from preimage_mem_comap $ mem_nhds_left b ht₂u,
 let ⟨a, (ha : (b, e a) ∈ t₂)⟩ := inhabited_of_mem_sets (he₂.comap_nhds_neq_bot) this in
-have ∀b' (s' : set (β × β)), (b, b') ∈ t → s' ∈ (@uniformity β _).sets →
+have ∀b' (s' : set (β × β)), (b, b') ∈ t → s' ∈ @uniformity β _ →
   {y : β | (b', y) ∈ s'} ∩ e '' {a' : α | (a, a') ∈ s} ≠ ∅,
   from assume b' s' hb' hs',
-  have preimage e {b'' | (b', b'') ∈ s' ∩ t} ∈ (comap e $ nhds b').sets,
+  have preimage e {b'' | (b', b'') ∈ s' ∩ t} ∈ comap e (nhds b'),
     from preimage_mem_comap $ mem_nhds_left b' $ inter_mem_sets hs' htu,
   let ⟨a₂, ha₂s', ha₂t⟩ := inhabited_of_mem_sets (he₂.comap_nhds_neq_bot) this in
   have (e a, e a₂) ∈ t₁,
@@ -125,7 +125,7 @@ begin
     have cf' : cauchy f',
     { have : comap m f ≠ ⊥,
       { refine comap_neq_bot (λt ht, _),
-        have A : t ∩ m '' s ∈ f.sets := filter.inter_mem_sets ht fs,
+        have A : t ∩ m '' s ∈ f := filter.inter_mem_sets ht fs,
         have : t ∩ m '' s ≠ ∅,
         { by_contradiction h,
           simp only [not_not, ne.def] at h,
@@ -174,11 +174,11 @@ have comap m g ≠ ⊥, from comap_neq_bot $ assume t ht,
   let ⟨x, (hx : x ∈ t'')⟩ := inhabited_of_mem_sets hf.left ht'' in
   have h₀ : nhds x ⊓ principal (range m) ≠ ⊥,
     by simp [closure_eq_nhds] at dense; exact dense x,
-  have h₁ : {y | (x, y) ∈ t'} ∈ (nhds x ⊓ principal (range m)).sets,
+  have h₁ : {y | (x, y) ∈ t'} ∈ nhds x ⊓ principal (range m),
     from @mem_inf_sets_of_left α (nhds x) (principal (range m)) _ $ mem_nhds_left x ht',
-  have h₂ : range m ∈ (nhds x ⊓ principal (range m)).sets,
+  have h₂ : range m ∈ nhds x ⊓ principal (range m),
     from @mem_inf_sets_of_right α (nhds x) (principal (range m)) _ $ subset.refl _,
-  have {y | (x, y) ∈ t'} ∩ range m ∈ (nhds x ⊓ principal (range m)).sets,
+  have {y | (x, y) ∈ t'} ∩ range m ∈ nhds x ⊓ principal (range m),
     from @inter_mem_sets α (nhds x ⊓ principal (range m)) _ _ h₁ h₂,
   let ⟨y, xyt', b, b_eq⟩ := inhabited_of_mem_sets h₀ this in
   ⟨b, b_eq.symm ▸ ht'_sub ⟨x, hx, xyt'⟩⟩,
@@ -190,11 +190,11 @@ have cauchy g, from
     ⟨s₂, hs₂, (comp_s₂ : comp_rel s₂ s₂ ⊆ s₁)⟩ := comp_mem_uniformity_sets hs₁,
     ⟨t, ht, (prod_t : set.prod t t ⊆ s₂)⟩ := mem_prod_same_iff.mp (hf.right hs₂)
   in
-  have hg₁ : p (preimage prod.swap s₁) t ∈ g.sets,
+  have hg₁ : p (preimage prod.swap s₁) t ∈ g,
     from mem_lift (symm_le_uniformity hs₁) $ @mem_lift' α α f _ t ht,
-  have hg₂ : p s₂ t ∈ g.sets,
+  have hg₂ : p s₂ t ∈ g,
     from mem_lift hs₂ $ @mem_lift' α α f _ t ht,
-  have hg : set.prod (p (preimage prod.swap s₁) t) (p s₂ t) ∈ (filter.prod g g).sets,
+  have hg : set.prod (p (preimage prod.swap s₁) t) (p s₂ t) ∈ filter.prod g g,
     from @prod_mem_prod α α _ _ g g hg₁ hg₂,
   (filter.prod g g).sets_of_superset hg
     (assume ⟨a, b⟩ ⟨⟨c₁, c₁t, hc₁⟩, ⟨c₂, c₂t, hc₂⟩⟩,
@@ -270,17 +270,17 @@ lemma uniform_continuous_uniformly_extend [cγ : complete_space γ] : uniform_co
 assume d hd,
 let ⟨s, hs, hs_comp⟩ := (mem_lift'_sets $
   monotone_comp_rel monotone_id $ monotone_comp_rel monotone_id monotone_id).mp (comp_le_uniformity3 hd) in
-have h_pnt : ∀{a m}, m ∈ (nhds a).sets → ∃c, c ∈ f '' preimage e m ∧ (c, ψ a) ∈ s ∧ (ψ a, c) ∈ s,
+have h_pnt : ∀{a m}, m ∈ nhds a → ∃c, c ∈ f '' preimage e m ∧ (c, ψ a) ∈ s ∧ (ψ a, c) ∈ s,
   from assume a m hm,
   have nb : map f (comap e (nhds a)) ≠ ⊥,
     from map_ne_bot (h_e.dense_embedding h_dense).comap_nhds_neq_bot,
-  have (f '' preimage e m) ∩ ({c | (c, ψ a) ∈ s } ∩ {c | (ψ a, c) ∈ s }) ∈ (map f (comap e (nhds a))).sets,
+  have (f '' preimage e m) ∩ ({c | (c, ψ a) ∈ s } ∩ {c | (ψ a, c) ∈ s }) ∈ map f (comap e (nhds a)),
     from inter_mem_sets (image_mem_map $ preimage_mem_comap $ hm)
       (uniformly_extend_spec h_e h_dense h_f _ (inter_mem_sets (mem_nhds_right _ hs) (mem_nhds_left _ hs))),
   inhabited_of_mem_sets nb this,
-have preimage (λp:β×β, (f p.1, f p.2)) s ∈ (@uniformity β _).sets,
+have preimage (λp:β×β, (f p.1, f p.2)) s ∈ @uniformity β _,
   from h_f hs,
-have preimage (λp:β×β, (f p.1, f p.2)) s ∈ (comap (λx:β×β, (e x.1, e x.2)) uniformity).sets,
+have preimage (λp:β×β, (f p.1, f p.2)) s ∈ comap (λx:β×β, (e x.1, e x.2)) uniformity,
   by rwa [h_e.right.symm] at this,
 let ⟨t, ht, ts⟩ := this in
 show preimage (λp:(α×α), (ψ p.1, ψ p.2)) d ∈ uniformity.sets,
@@ -288,7 +288,7 @@ show preimage (λp:(α×α), (ψ p.1, ψ p.2)) d ∈ uniformity.sets,
   assume ⟨x₁, x₂⟩ hx_t,
   have nhds (x₁, x₂) ≤ principal (interior t),
     from is_open_iff_nhds.mp is_open_interior (x₁, x₂) hx_t,
-  have interior t ∈ (filter.prod (nhds x₁) (nhds x₂)).sets,
+  have interior t ∈ filter.prod (nhds x₁) (nhds x₂),
     by rwa [nhds_prod_eq, le_principal_iff] at this,
   let ⟨m₁, hm₁, m₂, hm₂, (hm : set.prod m₁ m₂ ⊆ interior t)⟩ := mem_prod_iff.mp this in
   let ⟨a, ha₁, _, ha₂⟩ := h_pnt hm₁ in
@@ -311,7 +311,7 @@ lemma uniform_extend_subtype {α : Type*} {β : Type*} {γ : Type*}
   {p : α → Prop} {e : α → β} {f : α → γ} {b : β} {s : set α}
   (hf : uniform_continuous (λx:subtype p, f x.val))
   (he : uniform_embedding e) (hd : ∀x:β, x ∈ closure (range e))
-  (hb : closure (e '' s) ∈ (nhds b).sets) (hs : is_closed s) (hp : ∀x∈s, p x) :
+  (hb : closure (e '' s) ∈ nhds b) (hs : is_closed s) (hp : ∀x∈s, p x) :
   ∃c, tendsto f (comap e (nhds b)) (nhds c) :=
 have de : dense_embedding e,
   from he.dense_embedding hd,


### PR DESCRIPTION
This is the long overdue instance `has_mem (set α) (filter α)`. It gets rid of countless `.sets` and parentheses, and make every filter use closer to the real world thing. There are still a couple of inconveniences: of course we still have a couple of lemmas about the sets of a filter, and rewriting using them is not always possible, even though the instance is reducible. The workaround is to add a couple of `show` or `change`, or type ascriptions when using the funny triangle. I also added `mem_infi` to replace many uses of `infi_sets_eq`.

A weirder thing is in `asymptotics.lean` where `use` times out. I replaced those bby `refine` and everything works smoothly.