### PR TITLE
docs(resetI): minor rewrite of exactI, resetI etc

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -199,22 +199,22 @@ Unfold coercion-related definitions
 
 ### Instance cache tactics
 
-* `resetI`: Reset the instance cache. This allows any new instances
-  added to the context to be used in typeclass inference.
+* `resetI`: Reset the instance cache. This allows any instances
+  currently in the context to be used in typeclass inference.
 
 * `unfreezeI`: Unfreeze local instances, which allows us to revert
   instances in the context
 
-* `introI`/`introsI`: Like `intro`/`intros`, but uses the introduced variable
-  in typeclass inference.
+* `introI`/`introsI`: `intro`/`intros` followed by `resetI`. Like
+  `intro`/`intros`, but uses the introduced variable in typeclass inference.
 
-* `haveI`/`letI`: Used to add typeclasses to the context so that they can
-  be used in typeclass inference. The syntax is the same as
-  `have`/`letI`, but the proof-omitted version of `have` is not supported
-  (for this one must write `have : t, { <proof> }, resetI, <proof>`).
+* `haveI`/`letI`: `have`/`let` followed by `resetI`. Used to add typeclasses
+  to the context so that they can be used in typeclass inference. The syntax
+  is the same as `have`/`letI`, but the proof-omitted version of `have` is
+  not supported (for this one must write `have : t, { <proof> }, resetI, <proof>`).
 
-* `exactI`: Like `exact`, but uses all variables in the context
-  for typeclass inference.
+* `exactI`: `resetI` followed by `exact`. Like `exact`, but uses all
+  variables in the context for typeclass inference.
 
 ### find
 

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -210,8 +210,9 @@ Unfold coercion-related definitions
 
 * `haveI`/`letI`: `have`/`let` followed by `resetI`. Used to add typeclasses
   to the context so that they can be used in typeclass inference. The syntax
-  is the same as `have`/`letI`, but the proof-omitted version of `have` is
-  not supported (for this one must write `have : t, { <proof> }, resetI, <proof>`).
+  `haveI := <proof>` and `haveI : t := <proof>` is supported, but
+  `haveI : t, from _` and `haveI : t, { <proof> }` are not; in these cases
+  use `have : t, { <proof> }, resetI` directly).
 
 * `exactI`: `resetI` followed by `exact`. Like `exact`, but uses all
   variables in the context for typeclass inference.


### PR DESCRIPTION
I always found these tactics confusing, but I finally figured out what they do and so I rewrote the docs so that I understand them better.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
