### PR TITLE
chore(topology/*): @uniformity α _ becomes 𝓤 α

### DIFF
--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -452,7 +452,7 @@ lemma has_sum_iff_cauchy : has_sum f ↔ cauchy (map (λ (s : finset β), sum s 
 (cauchy_map_iff_exists_tendsto at_top_ne_bot).symm
 
 lemma has_sum_iff_vanishing :
-  has_sum f ↔ ∀e∈(nhds (0:α)).sets, (∃s:finset β, ∀t, disjoint t s → t.sum f ∈ e) :=
+  has_sum f ↔ ∀ e ∈ nhds (0:α), (∃s:finset β, ∀t, disjoint t s → t.sum f ∈ e) :=
 begin
   simp only [has_sum_iff_cauchy, cauchy_map_iff, and_iff_right at_top_ne_bot,
     prod_at_top_at_top_eq, uniformity_eq_comap_nhds_zero α, tendsto_comap_iff, (∘)],

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -18,6 +18,7 @@ import topology.uniform_space.uniform_embedding topology.uniform_space.separatio
 noncomputable theory
 local attribute [instance, priority 0] classical.prop_decidable
 
+local notation `𝓤` := uniformity
 
 section uniform_add_group
 open filter set
@@ -74,13 +75,13 @@ instance [uniform_space β] [add_group β] [uniform_add_group β] : uniform_add_
     (uniform_continuous_fst.comp uniform_continuous_snd)
     (uniform_continuous_snd.comp uniform_continuous_snd)) ⟩
 
-lemma uniformity_translate (a : α) : uniformity.map (λx:α×α, (x.1 + a, x.2 + a)) = uniformity :=
+lemma uniformity_translate (a : α) : (𝓤 α).map (λx:α×α, (x.1 + a, x.2 + a)) = 𝓤 α :=
 le_antisymm
   (uniform_continuous_add uniform_continuous_id uniform_continuous_const)
-  (calc uniformity =
-    (uniformity.map (λx:α×α, (x.1 + -a, x.2 + -a))).map (λx:α×α, (x.1 + a, x.2 + a)) :
+  (calc 𝓤 α =
+    ((𝓤 α).map (λx:α×α, (x.1 + -a, x.2 + -a))).map (λx:α×α, (x.1 + a, x.2 + a)) :
       by simp [filter.map_map, (∘)]; exact filter.map_id.symm
-    ... ≤ uniformity.map (λx:α×α, (x.1 + a, x.2 + a)) :
+    ... ≤ (𝓤 α).map (λx:α×α, (x.1 + a, x.2 + a)) :
       filter.map_mono (uniform_continuous_add uniform_continuous_id uniform_continuous_const))
 
 lemma uniform_embedding_translate (a : α) : uniform_embedding (λx:α, x + a) :=
@@ -93,7 +94,7 @@ end
 
 section
 variables (α)
-lemma uniformity_eq_comap_nhds_zero : uniformity = comap (λx:α×α, x.2 - x.1) (nhds (0:α)) :=
+lemma uniformity_eq_comap_nhds_zero : 𝓤 α = comap (λx:α×α, x.2 - x.1) (nhds (0:α)) :=
 begin
   rw [nhds_eq_comap_uniformity, filter.comap_comap_comp],
   refine le_antisymm (filter.map_le_iff_le_comap.1 _) _,
@@ -111,7 +112,7 @@ end
 
 lemma group_separation_rel (x y : α) : (x, y) ∈ separation_rel α ↔ x - y ∈ closure ({0} : set α) :=
 have embedding (λa, a + (y - x)), from (uniform_embedding_translate (y - x)).embedding,
-show (x, y) ∈ ⋂₀ uniformity.sets ↔ x - y ∈ closure ({0} : set α),
+show (x, y) ∈ ⋂₀ (𝓤 α).sets ↔ x - y ∈ closure ({0} : set α),
 begin
   rw [this.closure_eq_preimage_closure_image, uniformity_eq_comap_nhds_zero α, sInter_comap_sets],
   simp [mem_closure_iff_nhds, inter_singleton_eq_empty]
@@ -192,7 +193,7 @@ def topological_add_group.to_uniform_space : uniform_space G :=
 section
 local attribute [instance] topological_add_group.to_uniform_space
 
-lemma uniformity_eq_comap_nhds_zero' : uniformity = comap (λp:G×G, p.2 - p.1) (nhds (0 : G)) := rfl
+lemma uniformity_eq_comap_nhds_zero' : 𝓤 G = comap (λp:G×G, p.2 - p.1) (nhds (0 : G)) := rfl
 
 variable {G}
 lemma topological_add_group_is_uniform : uniform_add_group G :=
@@ -213,7 +214,7 @@ lemma to_uniform_space_eq {α : Type*} [u : uniform_space α] [add_comm_group α
   topological_add_group.to_uniform_space α = u :=
 begin
   ext : 1,
-  show @uniformity α (topological_add_group.to_uniform_space α) = uniformity,
+  show @uniformity α (topological_add_group.to_uniform_space α) = 𝓤 α,
   rw [uniformity_eq_comap_nhds_zero' α, uniformity_eq_comap_nhds_zero α]
 end
 

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -13,6 +13,8 @@ import data.real.nnreal topology.metric_space.emetric_space topology.algebra.ord
 open lattice set filter classical topological_space
 noncomputable theory
 
+local notation `𝓤` := uniformity
+
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
 
@@ -63,7 +65,7 @@ class metric_space (α : Type u) extends has_dist α : Type u :=
 (edist : α → α → ennreal := λx y, ennreal.of_real (dist x y))
 (edist_dist : ∀ x y : α, edist x y = ennreal.of_real (dist x y) . control_laws_tac)
 (to_uniform_space : uniform_space α := uniform_space_of_dist dist dist_self dist_comm dist_triangle)
-(uniformity_dist : uniformity = ⨅ ε>0, principal {p:α×α | dist p.1 p.2 < ε} . control_laws_tac)
+(uniformity_dist : 𝓤 α = ⨅ ε>0, principal {p:α×α | dist p.1 p.2 < ε} . control_laws_tac)
 
 variables [metric_space α]
 
@@ -248,14 +250,14 @@ theorem ball_eq_empty_iff_nonpos : ε ≤ 0 ↔ ball x ε = ∅ :=
 ⟨λ h, le_of_not_gt $ λ ε0, h _ $ mem_ball_self ε0,
  λ ε0 y h, not_lt_of_le ε0 $ pos_of_mem_ball h⟩).symm
 
-theorem uniformity_dist : uniformity = (⨅ ε>0, principal {p:α×α | dist p.1 p.2 < ε}) :=
+theorem uniformity_dist : 𝓤 α = (⨅ ε>0, principal {p:α×α | dist p.1 p.2 < ε}) :=
 metric_space.uniformity_dist _
 
-theorem uniformity_dist' : uniformity = (⨅ε:{ε:ℝ // ε>0}, principal {p:α×α | dist p.1 p.2 < ε.val}) :=
+theorem uniformity_dist' : 𝓤 α = (⨅ε:{ε:ℝ // ε>0}, principal {p:α×α | dist p.1 p.2 < ε.val}) :=
 by simp [infi_subtype]; exact uniformity_dist
 
 theorem mem_uniformity_dist {s : set (α×α)} :
-  s ∈ @uniformity α _ ↔ (∃ε>0, ∀{a b:α}, dist a b < ε → (a, b) ∈ s) :=
+  s ∈ 𝓤 α ↔ (∃ε>0, ∀{a b:α}, dist a b < ε → (a, b) ∈ s) :=
 begin
   rw [uniformity_dist', mem_infi],
   simp [subset_def],
@@ -264,7 +266,7 @@ begin
 end
 
 theorem dist_mem_uniformity {ε:ℝ} (ε0 : 0 < ε) :
-  {p:α×α | dist p.1 p.2 < ε} ∈ @uniformity α _ :=
+  {p:α×α | dist p.1 p.2 < ε} ∈ 𝓤 α :=
 mem_uniformity_dist.2 ⟨ε, ε0, λ a b, id⟩
 
 theorem uniform_continuous_iff [metric_space β] {f : α → β} :
@@ -399,7 +401,7 @@ distance coincide. -/
 
 /-- Expressing the uniformity in terms of `edist` -/
 protected lemma metric.mem_uniformity_edist {s : set (α×α)} :
-  s ∈ @uniformity α _ ↔ (∃ε>0, ∀{a b:α}, edist a b < ε → (a, b) ∈ s) :=
+  s ∈ 𝓤 α ↔ (∃ε>0, ∀{a b:α}, edist a b < ε → (a, b) ∈ s) :=
 begin
   refine mem_uniformity_dist.trans ⟨_, _⟩; rintro ⟨ε, ε0, Hε⟩,
   { refine ⟨ennreal.of_real ε, _, λ a b, _⟩,
@@ -412,7 +414,7 @@ begin
     rwa [edist_dist, ennreal.of_real_lt_of_real_iff ε0'] }
 end
 
-protected theorem metric.uniformity_edist' : uniformity = (⨅ε:{ε:ennreal // ε>0}, principal {p:α×α | edist p.1 p.2 < ε.val}) :=
+protected theorem metric.uniformity_edist' : 𝓤 α = (⨅ε:{ε:ennreal // ε>0}, principal {p:α×α | edist p.1 p.2 < ε.val}) :=
 begin
   ext s, rw mem_infi,
   { simp [metric.mem_uniformity_edist, subset_def] },
@@ -421,7 +423,7 @@ begin
   { exact ⟨⟨1, ennreal.zero_lt_one⟩⟩ }
 end
 
-theorem uniformity_edist : uniformity = (⨅ ε>0, principal {p:α×α | edist p.1 p.2 < ε}) :=
+theorem uniformity_edist : 𝓤 α = (⨅ ε>0, principal {p:α×α | edist p.1 p.2 < ε}) :=
 by simpa [infi_subtype] using @metric.uniformity_edist' α _
 
 /-- A metric space induces an emetric space -/
@@ -528,7 +530,7 @@ begin
 end
 
 theorem metric.uniformity_eq_comap_nhds_zero :
-  uniformity = comap (λp:α×α, dist p.1 p.2) (nhds (0 : ℝ)) :=
+  𝓤 α = comap (λp:α×α, dist p.1 p.2) (nhds (0 : ℝ)) :=
 begin
   simp only [uniformity_dist', nhds_eq, comap_infi, comap_principal],
   congr, funext ε,

--- a/src/topology/metric_space/cau_seq_filter.lean
+++ b/src/topology/metric_space/cau_seq_filter.lean
@@ -394,7 +394,6 @@ begin
       apply hεs,
       rw dist_eq_norm,
       apply hN; assumption }},
-  { apply_instance }
 end
 
 /-- In a normed field, `cau_seq` coincides with the usual notion of Cauchy sequences. -/

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -21,6 +21,8 @@ import topology.uniform_space.separation topology.uniform_space.uniform_embeddin
 open lattice set filter classical
 noncomputable theory
 
+local notation `𝓤` := uniformity
+
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
 
@@ -100,7 +102,7 @@ class emetric_space (α : Type u) extends has_edist α : Type u :=
 (edist_comm : ∀ x y : α, edist x y = edist y x)
 (edist_triangle : ∀ x y z : α, edist x z ≤ edist x y + edist y z)
 (to_uniform_space : uniform_space α := uniform_space_of_edist edist edist_self edist_comm edist_triangle)
-(uniformity_edist : uniformity = ⨅ ε>0, principal {p:α×α | edist p.1 p.2 < ε} . control_laws_tac)
+(uniformity_edist : 𝓤 α = ⨅ ε>0, principal {p:α×α | edist p.1 p.2 < ε} . control_laws_tac)
 
 /- emetric spaces are less common than metric spaces. Therefore, we work in a dedicated
 namespace, while notions associated to metric spaces are mostly in the root namespace. -/
@@ -139,15 +141,15 @@ theorem eq_of_forall_edist_le {x y : α} (h : ∀ε, ε > 0 → edist x y ≤ ε
 eq_of_edist_eq_zero (eq_of_le_of_forall_le_of_dense (by simp) h)
 
 /-- Reformulation of the uniform structure in terms of the extended distance -/
-theorem uniformity_edist' : uniformity = (⨅ ε>0, principal {p:α×α | edist p.1 p.2 < ε}) :=
+theorem uniformity_edist' : 𝓤 α = (⨅ ε>0, principal {p:α×α | edist p.1 p.2 < ε}) :=
 emetric_space.uniformity_edist _
 
 /-- Reformulation of the uniform structure in terms of the extended distance on a subtype -/
-theorem uniformity_edist'' : uniformity = (⨅ε:{ε:ennreal // ε>0}, principal {p:α×α | edist p.1 p.2 < ε.val}) :=
+theorem uniformity_edist'' : 𝓤 α = (⨅ε:{ε:ennreal // ε>0}, principal {p:α×α | edist p.1 p.2 < ε.val}) :=
 by simp [infi_subtype]; exact uniformity_edist'
 
 theorem uniformity_edist_nnreal :
-  uniformity = (⨅(ε:nnreal) (h : ε > 0), principal {p:α×α | edist p.1 p.2 < ε}) :=
+  𝓤 α = (⨅(ε:nnreal) (h : ε > 0), principal {p:α×α | edist p.1 p.2 < ε}) :=
 begin
   rw [uniformity_edist', ennreal.infi_ennreal, inf_of_le_left],
   { congr, funext ε, refine infi_congr_Prop ennreal.coe_pos _, assume h, refl },
@@ -157,7 +159,7 @@ end
 
 /-- Characterization of the elements of the uniformity in terms of the extended distance -/
 theorem mem_uniformity_edist {s : set (α×α)} :
-  s ∈ @uniformity α _ ↔ (∃ε>0, ∀{a b:α}, edist a b < ε → (a, b) ∈ s) :=
+  s ∈ 𝓤 α ↔ (∃ε>0, ∀{a b:α}, edist a b < ε → (a, b) ∈ s) :=
 begin
   rw [uniformity_edist'', mem_infi],
   simp [subset_def],
@@ -167,7 +169,7 @@ end
 
 /-- Fixed size neighborhoods of the diagonal belong to the uniform structure -/
 theorem edist_mem_uniformity {ε:ennreal} (ε0 : 0 < ε) :
-  {p:α×α | edist p.1 p.2 < ε} ∈ @uniformity α _ :=
+  {p:α×α | edist p.1 p.2 < ε} ∈ 𝓤 α :=
 mem_uniformity_edist.2 ⟨ε, ε0, λ a b, id⟩
 
 namespace emetric

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -149,102 +149,105 @@ variables [uniform_space α]
 
 /-- The uniformity is a filter on α × α (inferred from an ambient uniform space
   structure on α). -/
-def uniformity : filter (α × α) := (@uniform_space.to_core α _).uniformity
+def uniformity (α : Type u) [uniform_space α] : filter (α × α) :=
+  (@uniform_space.to_core α _).uniformity
+
+local notation `𝓤` := uniformity
 
 lemma is_open_uniformity {s : set α} :
-  is_open s ↔ (∀x∈s, { p : α × α | p.1 = x → p.2 ∈ s } ∈ @uniformity α _) :=
+  is_open s ↔ (∀x∈s, { p : α × α | p.1 = x → p.2 ∈ s } ∈ 𝓤 α) :=
 uniform_space.is_open_uniformity s
 
-lemma refl_le_uniformity : principal id_rel ≤ @uniformity α _ :=
+lemma refl_le_uniformity : principal id_rel ≤ 𝓤 α :=
 (@uniform_space.to_core α _).refl
 
-lemma refl_mem_uniformity {x : α} {s : set (α × α)} (h : s ∈ @uniformity α _) :
+lemma refl_mem_uniformity {x : α} {s : set (α × α)} (h : s ∈ 𝓤 α) :
   (x, x) ∈ s :=
 refl_le_uniformity h rfl
 
-lemma symm_le_uniformity : map (@prod.swap α α) uniformity ≤ uniformity :=
+lemma symm_le_uniformity : map (@prod.swap α α) (𝓤 _) ≤ (𝓤 _) :=
 (@uniform_space.to_core α _).symm
 
-lemma comp_le_uniformity : uniformity.lift' (λs:set (α×α), comp_rel s s) ≤ uniformity :=
+lemma comp_le_uniformity : (𝓤 α).lift' (λs:set (α×α), comp_rel s s) ≤ 𝓤 α :=
 (@uniform_space.to_core α _).comp
 
-lemma tendsto_swap_uniformity : tendsto prod.swap (@uniformity α _) uniformity :=
+lemma tendsto_swap_uniformity : tendsto (@prod.swap α α) (𝓤 α) (𝓤 α) :=
 symm_le_uniformity
 
-lemma tendsto_const_uniformity {a : α} {f : filter β} : tendsto (λ_, (a, a)) f uniformity :=
+lemma tendsto_const_uniformity {a : α} {f : filter β} : tendsto (λ _, (a, a)) f (𝓤 α) :=
 assume s hs,
 show {x | (a, a) ∈ s} ∈ f,
   from univ_mem_sets' $ assume b, refl_mem_uniformity hs
 
-lemma comp_mem_uniformity_sets {s : set (α × α)} (hs : s ∈ @uniformity α _) :
-  ∃t∈(@uniformity α _).sets, comp_rel t t ⊆ s :=
-have s ∈ uniformity.lift' (λt:set (α×α), comp_rel t t),
+lemma comp_mem_uniformity_sets {s : set (α × α)} (hs : s ∈ 𝓤 α) :
+  ∃ t ∈ 𝓤 α, comp_rel t t ⊆ s :=
+have s ∈ (𝓤 α).lift' (λt:set (α×α), comp_rel t t),
   from comp_le_uniformity hs,
 (mem_lift'_sets $ monotone_comp_rel monotone_id monotone_id).mp this
 
-lemma symm_of_uniformity {s : set (α × α)} (hs : s ∈ @uniformity α _) :
-  ∃t∈(@uniformity α _).sets, (∀a b, (a, b) ∈ t → (b, a) ∈ t) ∧ t ⊆ s :=
-have preimage prod.swap s ∈ @uniformity α _, from symm_le_uniformity hs,
+lemma symm_of_uniformity {s : set (α × α)} (hs : s ∈ 𝓤 α) :
+  ∃ t ∈ 𝓤 α, (∀a b, (a, b) ∈ t → (b, a) ∈ t) ∧ t ⊆ s :=
+have preimage prod.swap s ∈ 𝓤 α, from symm_le_uniformity hs,
 ⟨s ∩ preimage prod.swap s, inter_mem_sets hs this, assume a b ⟨h₁, h₂⟩, ⟨h₂, h₁⟩, inter_subset_left _ _⟩
 
-lemma comp_symm_of_uniformity {s : set (α × α)} (hs : s ∈ @uniformity α _) :
-  ∃t∈(@uniformity α _).sets, (∀{a b}, (a, b) ∈ t → (b, a) ∈ t) ∧ comp_rel t t ⊆ s :=
+lemma comp_symm_of_uniformity {s : set (α × α)} (hs : s ∈ 𝓤 α) :
+  ∃ t ∈ 𝓤 α, (∀{a b}, (a, b) ∈ t → (b, a) ∈ t) ∧ comp_rel t t ⊆ s :=
 let ⟨t, ht₁, ht₂⟩ := comp_mem_uniformity_sets hs in
 let ⟨t', ht', ht'₁, ht'₂⟩ := symm_of_uniformity ht₁ in
 ⟨t', ht', ht'₁, subset.trans (monotone_comp_rel monotone_id monotone_id ht'₂) ht₂⟩
 
-lemma uniformity_le_symm : uniformity ≤ (@prod.swap α α) <$> uniformity :=
+lemma uniformity_le_symm : 𝓤 α ≤ (@prod.swap α α) <$> 𝓤 α :=
 by rw [map_swap_eq_comap_swap];
 from map_le_iff_le_comap.1 tendsto_swap_uniformity
 
-lemma uniformity_eq_symm : uniformity = (@prod.swap α α) <$> uniformity :=
+lemma uniformity_eq_symm : 𝓤 α = (@prod.swap α α) <$> 𝓤 α :=
 le_antisymm uniformity_le_symm symm_le_uniformity
 
 theorem uniformity_lift_le_swap {g : set (α×α) → filter β} {f : filter β} (hg : monotone g)
-  (h : uniformity.lift (λs, g (preimage prod.swap s)) ≤ f) : uniformity.lift g ≤ f :=
-calc uniformity.lift g ≤ (filter.map prod.swap (@uniformity α _)).lift g :
+  (h : (𝓤 α).lift (λs, g (preimage prod.swap s)) ≤ f) : (𝓤 α).lift g ≤ f :=
+calc (𝓤 α).lift g ≤ (filter.map (@prod.swap α α) $ 𝓤 α).lift g :
     lift_mono uniformity_le_symm (le_refl _)
   ... ≤ _ :
     by rw [map_lift_eq2 hg, image_swap_eq_preimage_swap]; exact h
 
 lemma uniformity_lift_le_comp {f : set (α×α) → filter β} (h : monotone f):
-  uniformity.lift (λs, f (comp_rel s s)) ≤ uniformity.lift f :=
-calc uniformity.lift (λs, f (comp_rel s s)) =
-    (uniformity.lift' (λs:set (α×α), comp_rel s s)).lift f :
+  (𝓤 α).lift (λs, f (comp_rel s s)) ≤ (𝓤 α).lift f :=
+calc (𝓤 α).lift (λs, f (comp_rel s s)) =
+    ((𝓤 α).lift' (λs:set (α×α), comp_rel s s)).lift f :
   begin
     rw [lift_lift'_assoc],
     exact monotone_comp_rel monotone_id monotone_id,
     exact h
   end
-  ... ≤ uniformity.lift f : lift_mono comp_le_uniformity (le_refl _)
+  ... ≤ (𝓤 α).lift f : lift_mono comp_le_uniformity (le_refl _)
 
 lemma comp_le_uniformity3 :
-  uniformity.lift' (λs:set (α×α), comp_rel s (comp_rel s s)) ≤ uniformity :=
-calc uniformity.lift' (λd, comp_rel d (comp_rel d d)) =
-  uniformity.lift (λs, uniformity.lift' (λt:set(α×α), comp_rel s (comp_rel t t))) :
+  (𝓤 α).lift' (λs:set (α×α), comp_rel s (comp_rel s s)) ≤ (𝓤 α) :=
+calc (𝓤 α).lift' (λd, comp_rel d (comp_rel d d)) =
+  (𝓤 α).lift (λs, (𝓤 α).lift' (λt:set(α×α), comp_rel s (comp_rel t t))) :
   begin
     rw [lift_lift'_same_eq_lift'],
     exact (assume x, monotone_comp_rel monotone_const $ monotone_comp_rel monotone_id monotone_id),
     exact (assume x, monotone_comp_rel monotone_id monotone_const),
   end
-  ... ≤ uniformity.lift (λs, uniformity.lift' (λt:set(α×α), comp_rel s t)) :
+  ... ≤ (𝓤 α).lift (λs, (𝓤 α).lift' (λt:set(α×α), comp_rel s t)) :
     lift_mono' $ assume s hs, @uniformity_lift_le_comp α _ _ (principal ∘ comp_rel s) $
       monotone_comp (monotone_comp_rel monotone_const monotone_id) monotone_principal
-  ... = uniformity.lift' (λs:set(α×α), comp_rel s s) :
+  ... = (𝓤 α).lift' (λs:set(α×α), comp_rel s s) :
     lift_lift'_same_eq_lift'
       (assume s, monotone_comp_rel monotone_const monotone_id)
       (assume s, monotone_comp_rel monotone_id monotone_const)
-  ... ≤ uniformity : comp_le_uniformity
+  ... ≤ (𝓤 α) : comp_le_uniformity
 
 lemma mem_nhds_uniformity_iff {x : α} {s : set α} :
-  s ∈ nhds x ↔ {p : α × α | p.1 = x → p.2 ∈ s} ∈ @uniformity α _ :=
+  s ∈ nhds x ↔ {p : α × α | p.1 = x → p.2 ∈ s} ∈ 𝓤 α :=
 ⟨ begin
     simp only [mem_nhds_sets_iff, is_open_uniformity, and_imp, exists_imp_distrib],
     exact assume t ts ht xt, by filter_upwards [ht x xt] assume ⟨x', y⟩ h eq, ts $ h eq
   end,
 
   assume hs,
-  mem_nhds_sets_iff.mpr ⟨{x | {p : α × α | p.1 = x → p.2 ∈ s} ∈ @uniformity α _},
+  mem_nhds_sets_iff.mpr ⟨{x | {p : α × α | p.1 = x → p.2 ∈ s} ∈ 𝓤 α},
     assume x' hx', refl_mem_uniformity hx' rfl,
     is_open_uniformity.mpr $ assume x' hx',
       let ⟨t, ht, tr⟩ := comp_mem_uniformity_sets hx' in
@@ -257,42 +260,42 @@ lemma mem_nhds_uniformity_iff {x : α} {s : set α} :
         from tr this rfl,
     hs⟩⟩
 
-lemma nhds_eq_comap_uniformity {x : α} : nhds x = uniformity.comap (prod.mk x) :=
+lemma nhds_eq_comap_uniformity {x : α} : nhds x = (𝓤 α).comap (prod.mk x) :=
 by ext s; rw [mem_nhds_uniformity_iff, mem_comap_sets]; from iff.intro
   (assume hs, ⟨_, hs, assume x hx, hx rfl⟩)
-  (assume ⟨t, h, ht⟩, uniformity.sets_of_superset h $
+  (assume ⟨t, h, ht⟩, (𝓤 α).sets_of_superset h $
     assume ⟨p₁, p₂⟩ hp (h : p₁ = x), ht $ by simp [h.symm, hp])
 
-lemma nhds_eq_uniformity {x : α} : nhds x = uniformity.lift' (λs:set (α×α), {y | (x, y) ∈ s}) :=
+lemma nhds_eq_uniformity {x : α} : nhds x = (𝓤 α).lift' (λs:set (α×α), {y | (x, y) ∈ s}) :=
 begin
   ext s,
   rw [mem_lift'_sets], tactic.swap, apply monotone_preimage,
   simp [mem_nhds_uniformity_iff],
   exact ⟨assume h, ⟨_, h, assume y h, h rfl⟩,
     assume ⟨t, h₁, h₂⟩,
-    uniformity.sets_of_superset h₁ $
+    (𝓤 α).sets_of_superset h₁ $
     assume ⟨x', y⟩ hp (eq : x' = x), h₂ $
     show (x, y) ∈ t, from eq ▸ hp⟩
 end
 
-lemma mem_nhds_left (x : α) {s : set (α×α)} (h : s ∈ (uniformity.sets : set (set (α×α)))) :
+lemma mem_nhds_left (x : α) {s : set (α×α)} (h : s ∈ 𝓤 α) :
   {y : α | (x, y) ∈ s} ∈ nhds x :=
 have nhds x ≤ principal {y : α | (x, y) ∈ s},
   by rw [nhds_eq_uniformity]; exact infi_le_of_le s (infi_le _ h),
 by simp at this; assumption
 
-lemma mem_nhds_right (y : α) {s : set (α×α)} (h : s ∈ (uniformity.sets : set (set (α×α)))) :
+lemma mem_nhds_right (y : α) {s : set (α×α)} (h : s ∈ 𝓤 α) :
   {x : α | (x, y) ∈ s} ∈ nhds y :=
 mem_nhds_left _ (symm_le_uniformity h)
 
-lemma tendsto_right_nhds_uniformity {a : α} : tendsto (λa', (a', a)) (nhds a) uniformity :=
+lemma tendsto_right_nhds_uniformity {a : α} : tendsto (λa', (a', a)) (nhds a) (𝓤 α) :=
 assume s, mem_nhds_right a
 
-lemma tendsto_left_nhds_uniformity {a : α} : tendsto (λa', (a, a')) (nhds a) uniformity :=
+lemma tendsto_left_nhds_uniformity {a : α} : tendsto (λa', (a, a')) (nhds a) (𝓤 α) :=
 assume s, mem_nhds_left a
 
 lemma lift_nhds_left {x : α} {g : set α → filter β} (hg : monotone g) :
-  (nhds x).lift g = uniformity.lift (λs:set (α×α), g {y | (x, y) ∈ s}) :=
+  (nhds x).lift g = (𝓤 α).lift (λs:set (α×α), g {y | (x, y) ∈ s}) :=
 eq.trans
   begin
     rw [nhds_eq_uniformity],
@@ -301,16 +304,16 @@ eq.trans
   (congr_arg _ $ funext $ assume s, filter.lift_principal hg)
 
 lemma lift_nhds_right {x : α} {g : set α → filter β} (hg : monotone g) :
-  (nhds x).lift g = uniformity.lift (λs:set (α×α), g {y | (y, x) ∈ s}) :=
-calc (nhds x).lift g = uniformity.lift (λs:set (α×α), g {y | (x, y) ∈ s}) : lift_nhds_left hg
-  ... = ((@prod.swap α α) <$> uniformity).lift (λs:set (α×α), g {y | (x, y) ∈ s}) : by rw [←uniformity_eq_symm]
-  ... = uniformity.lift (λs:set (α×α), g {y | (x, y) ∈ image prod.swap s}) :
+  (nhds x).lift g = (𝓤 α).lift (λs:set (α×α), g {y | (y, x) ∈ s}) :=
+calc (nhds x).lift g = (𝓤 α).lift (λs:set (α×α), g {y | (x, y) ∈ s}) : lift_nhds_left hg
+  ... = ((@prod.swap α α) <$> (𝓤 α)).lift (λs:set (α×α), g {y | (x, y) ∈ s}) : by rw [←uniformity_eq_symm]
+  ... = (𝓤 α).lift (λs:set (α×α), g {y | (x, y) ∈ image prod.swap s}) :
     map_lift_eq2 $ monotone_comp monotone_preimage hg
   ... = _ : by simp [image_swap_eq_preimage_swap]
 
 lemma nhds_nhds_eq_uniformity_uniformity_prod {a b : α} :
   filter.prod (nhds a) (nhds b) =
-  uniformity.lift (λs:set (α×α), uniformity.lift' (λt:set (α×α),
+  (𝓤 α).lift (λs:set (α×α), (𝓤 α).lift' (λt:set (α×α),
     set.prod {y : α | (y, a) ∈ s} {y : α | (b, y) ∈ t})) :=
 begin
   rw [prod_def],
@@ -326,14 +329,14 @@ end
 
 lemma nhds_eq_uniformity_prod {a b : α} :
   nhds (a, b) =
-  uniformity.lift' (λs:set (α×α), set.prod {y : α | (y, a) ∈ s} {y : α | (b, y) ∈ s}) :=
+  (𝓤 α).lift' (λs:set (α×α), set.prod {y : α | (y, a) ∈ s} {y : α | (b, y) ∈ s}) :=
 begin
   rw [nhds_prod_eq, nhds_nhds_eq_uniformity_uniformity_prod, lift_lift'_same_eq_lift'],
   { intro s, exact monotone_prod monotone_const monotone_preimage },
   { intro t, exact monotone_prod monotone_preimage monotone_const }
 end
 
-lemma nhdset_of_mem_uniformity {d : set (α×α)} (s : set (α×α)) (hd : d ∈ @uniformity α _) :
+lemma nhdset_of_mem_uniformity {d : set (α×α)} (s : set (α×α)) (hd : d ∈ 𝓤 α) :
   ∃(t : set (α×α)), is_open t ∧ s ⊆ t ∧ t ⊆ {p | ∃x y, (p.1, x) ∈ d ∧ (x, y) ∈ s ∧ (y, p.2) ∈ d} :=
 let cl_d := {p:α×α | ∃x y, (p.1, x) ∈ d ∧ (x, y) ∈ s ∧ (y, p.2) ∈ d} in
 have ∀p ∈ s, ∃t ⊆ cl_d, is_open t ∧ p ∈ t, from
@@ -356,42 +359,42 @@ match this with
 end
 
 lemma closure_eq_inter_uniformity {t : set (α×α)} :
-  closure t = (⋂ d∈(@uniformity α _).sets, comp_rel d (comp_rel t d)) :=
+  closure t = (⋂ d ∈ 𝓤 α, comp_rel d (comp_rel t d)) :=
 set.ext $ assume ⟨a, b⟩,
 calc (a, b) ∈ closure t ↔ (nhds (a, b) ⊓ principal t ≠ ⊥) : by simp [closure_eq_nhds]
-  ... ↔ (((@prod.swap α α) <$> uniformity).lift'
+  ... ↔ (((@prod.swap α α) <$> 𝓤 α).lift'
       (λ (s : set (α × α)), set.prod {x : α | (x, a) ∈ s} {y : α | (b, y) ∈ s}) ⊓ principal t ≠ ⊥) :
     by rw [←uniformity_eq_symm, nhds_eq_uniformity_prod]
-  ... ↔ ((map (@prod.swap α α) uniformity).lift'
+  ... ↔ ((map (@prod.swap α α) (𝓤 α)).lift'
       (λ (s : set (α × α)), set.prod {x : α | (x, a) ∈ s} {y : α | (b, y) ∈ s}) ⊓ principal t ≠ ⊥) :
     by refl
-  ... ↔ (uniformity.lift'
+  ... ↔ ((𝓤 α).lift'
       (λ (s : set (α × α)), set.prod {y : α | (a, y) ∈ s} {x : α | (x, b) ∈ s}) ⊓ principal t ≠ ⊥) :
   begin
     rw [map_lift'_eq2],
     simp [image_swap_eq_preimage_swap, function.comp],
     exact monotone_prod monotone_preimage monotone_preimage
   end
-  ... ↔ (∀s∈(@uniformity α _).sets, ∃x, x ∈ set.prod {y : α | (a, y) ∈ s} {x : α | (x, b) ∈ s} ∩ t) :
+  ... ↔ (∀s ∈ 𝓤 α, ∃x, x ∈ set.prod {y : α | (a, y) ∈ s} {x : α | (x, b) ∈ s} ∩ t) :
   begin
     rw [lift'_inf_principal_eq, lift'_neq_bot_iff],
     apply forall_congr, intro s, rw [ne_empty_iff_exists_mem],
     exact monotone_inter (monotone_prod monotone_preimage monotone_preimage) monotone_const
   end
-  ... ↔ (∀s∈(@uniformity α _).sets, (a, b) ∈ comp_rel s (comp_rel t s)) :
+  ... ↔ (∀ s ∈ 𝓤 α, (a, b) ∈ comp_rel s (comp_rel t s)) :
     forall_congr $ assume s, forall_congr $ assume hs,
     ⟨assume ⟨⟨x, y⟩, ⟨⟨hx, hy⟩, hxyt⟩⟩, ⟨x, hx, y, hxyt, hy⟩,
       assume ⟨x, hx, y, hxyt, hy⟩, ⟨⟨x, y⟩, ⟨⟨hx, hy⟩, hxyt⟩⟩⟩
   ... ↔ _ : by simp
 
-lemma uniformity_eq_uniformity_closure : (@uniformity α _) = uniformity.lift' closure :=
+lemma uniformity_eq_uniformity_closure : 𝓤 α = (𝓤 α).lift' closure :=
 le_antisymm
   (le_infi $ assume s, le_infi $ assume hs, by simp; filter_upwards [hs] subset_closure)
-  (calc uniformity.lift' closure ≤ uniformity.lift' (λd, comp_rel d (comp_rel d d)) :
+  (calc (𝓤 α).lift' closure ≤ (𝓤 α).lift' (λd, comp_rel d (comp_rel d d)) :
       lift'_mono' (by intros s hs; rw [closure_eq_inter_uniformity]; exact bInter_subset_of_mem hs)
-    ... ≤ uniformity : comp_le_uniformity3)
+    ... ≤ (𝓤 α) : comp_le_uniformity3)
 
-lemma uniformity_eq_uniformity_interior : (@uniformity α _) = uniformity.lift' interior :=
+lemma uniformity_eq_uniformity_interior : 𝓤 α = (𝓤 α).lift' interior :=
 le_antisymm
   (le_infi $ assume d, le_infi $ assume hd,
     let ⟨s, hs, hs_comp⟩ := (mem_lift'_sets $
@@ -401,30 +404,30 @@ le_antisymm
       calc s ⊆ t : hst
        ... ⊆ interior d : (subset_interior_iff_subset_of_open ht).mpr $
         assume x, assume : x ∈ t, let ⟨x, y, h₁, h₂, h₃⟩ := ht_comp this in hs_comp ⟨x, h₁, y, h₂, h₃⟩,
-    have interior d ∈ @uniformity α _, by filter_upwards [hs] this,
+    have interior d ∈ 𝓤 α, by filter_upwards [hs] this,
     by simp [this])
-  (assume s hs, (uniformity.lift' interior).sets_of_superset (mem_lift' hs) interior_subset)
+  (assume s hs, ((𝓤 α).lift' interior).sets_of_superset (mem_lift' hs) interior_subset)
 
-lemma interior_mem_uniformity {s : set (α × α)} (hs : s ∈ @uniformity α _) :
-  interior s ∈ @uniformity α _ :=
+lemma interior_mem_uniformity {s : set (α × α)} (hs : s ∈ 𝓤 α) :
+  interior s ∈ 𝓤 α :=
 by rw [uniformity_eq_uniformity_interior]; exact mem_lift' hs
 
-lemma mem_uniformity_is_closed [uniform_space α] {s : set (α×α)} (h : s ∈ @uniformity α _) :
-  ∃t∈(@uniformity α _).sets, is_closed t ∧ t ⊆ s :=
-have s ∈ (@uniformity α _).lift' closure, by rwa [uniformity_eq_uniformity_closure] at h,
-have ∃t∈(@uniformity α _).sets, closure t ⊆ s,
+lemma mem_uniformity_is_closed [uniform_space α] {s : set (α×α)} (h : s ∈ 𝓤 α) :
+  ∃t ∈ 𝓤 α, is_closed t ∧ t ⊆ s :=
+have s ∈ (𝓤 α).lift' closure, by rwa [uniformity_eq_uniformity_closure] at h,
+have ∃ t ∈ 𝓤 α, closure t ⊆ s,
   by rwa [mem_lift'_sets] at this; apply closure_mono,
 let ⟨t, ht, hst⟩ := this in
-⟨closure t, uniformity.sets_of_superset ht subset_closure, is_closed_closure, hst⟩
+⟨closure t, (𝓤 α).sets_of_superset ht subset_closure, is_closed_closure, hst⟩
 
 /- uniform continuity -/
 
 def uniform_continuous [uniform_space β] (f : α → β) :=
-tendsto (λx:α×α, (f x.1, f x.2)) uniformity uniformity
+tendsto (λx:α×α, (f x.1, f x.2)) (𝓤 α) (𝓤 β)
 
 theorem uniform_continuous_def [uniform_space β] {f : α → β} :
-  uniform_continuous f ↔ ∀ r ∈ @uniformity β _,
-    {x : α × α | (f x.1, f x.2) ∈ r} ∈ @uniformity α _ :=
+  uniform_continuous f ↔ ∀ r ∈ 𝓤 β,
+    {x : α × α | (f x.1, f x.2) ∈ r} ∈ 𝓤 α :=
 iff.rfl
 
 lemma uniform_continuous_of_const [uniform_space β] {c : α → β} (h : ∀a b, c a = c b) :
@@ -437,7 +440,7 @@ lemma uniform_continuous_id : uniform_continuous (@id α) :=
 by simp [uniform_continuous]; exact tendsto_id
 
 lemma uniform_continuous_const [uniform_space β] {b : β} : uniform_continuous (λa:α, b) :=
-@tendsto_const_uniformity _ _ _ b uniformity
+@tendsto_const_uniformity _ _ _ b (𝓤 α)
 
 lemma uniform_continuous.comp [uniform_space β] [uniform_space γ] {f : α → β} {g : β → γ}
   (hf : uniform_continuous f) (hg : uniform_continuous g) : uniform_continuous (g ∘ f) :=
@@ -447,7 +450,7 @@ lemma uniform_continuous.continuous [uniform_space β] {f : α → β}
   (hf : uniform_continuous f) : continuous f :=
 continuous_iff_continuous_at.mpr $ assume a,
 calc map f (nhds a) ≤
-    (map (λp:α×α, (f p.1, f p.2)) uniformity).lift' (λs:set (β×β), {y | (f a, y) ∈ s}) :
+    (map (λp:α×α, (f p.1, f p.2)) (𝓤 α)).lift' (λs:set (β×β), {y | (f a, y) ∈ s}) :
   begin
     rw [nhds_eq_uniformity, map_lift'_eq, map_lift'_eq2],
     exact (lift'_mono' $ assume s hs b ⟨a', (ha' : (_, a') ∈ s), a'_eq⟩,
@@ -459,6 +462,8 @@ calc map f (nhds a) ≤
     by rw [nhds_eq_uniformity]; exact lift'_mono hf (le_refl _)
 end uniform_space
 end
+
+local notation `𝓤` := uniformity
 
 section constructions
 variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*} {ι : Sort*}
@@ -587,7 +592,7 @@ theorem to_topological_space_comap {f : α → β} {u : uniform_space β} :
 eq_of_nhds_eq_nhds $ assume a,
 begin
   simp [nhds_induced_eq_comap, nhds_eq_uniformity, nhds_eq_uniformity],
-  change comap f (uniformity.lift' (preimage (λb, (f a, b)))) =
+  change comap f ((𝓤 β).lift' (preimage (λb, (f a, b)))) =
       (u.uniformity.comap (λp:α×α, (f p.1, f p.2))).lift' (preimage (λa', (a, a'))),
   rw [comap_lift'_eq monotone_preimage, comap_lift'_eq2 monotone_preimage],
   exact rfl
@@ -659,7 +664,7 @@ instance {p : α → Prop} [t : uniform_space α] : uniform_space (subtype p) :=
 uniform_space.comap subtype.val t
 
 lemma uniformity_subtype {p : α → Prop} [t : uniform_space α] :
-  (@uniformity (subtype p) _) = comap (λq:subtype p × subtype p, (q.1.1, q.2.1)) uniformity :=
+  𝓤 (subtype p) = comap (λq:subtype p × subtype p, (q.1.1, q.2.1)) (𝓤 α) :=
 rfl
 
 lemma uniform_continuous_subtype_val {p : α → Prop} [uniform_space α] :
@@ -692,13 +697,13 @@ uniform_space.of_core_eq
     ... = _ : by rw [uniform_space.to_core_to_topological_space])
 
 theorem uniformity_prod [uniform_space α] [uniform_space β] : @uniformity (α × β) _ =
-  uniformity.comap (λp:(α × β) × α × β, (p.1.1, p.2.1)) ⊓
-  uniformity.comap (λp:(α × β) × α × β, (p.1.2, p.2.2)) :=
+  (𝓤 α).comap (λp:(α × β) × α × β, (p.1.1, p.2.1)) ⊓
+  (𝓤 β).comap (λp:(α × β) × α × β, (p.1.2, p.2.2)) :=
 sup_uniformity
 
 lemma uniformity_prod_eq_prod [uniform_space α] [uniform_space β] :
-  @uniformity (α×β) _ =
-    map (λp:(α×α)×(β×β), ((p.1.1, p.2.1), (p.1.2, p.2.2))) (filter.prod uniformity uniformity) :=
+  𝓤 (α×β) =
+    map (λp:(α×α)×(β×β), ((p.1.1, p.2.1), (p.1.2, p.2.2))) (filter.prod (𝓤 α) (𝓤 β)) :=
 have map (λp:(α×α)×(β×β), ((p.1.1, p.2.1), (p.1.2, p.2.2))) =
   comap (λp:(α×β)×(α×β), ((p.1.1, p.2.1), (p.1.2, p.2.2))),
   from funext $ assume f, map_eq_comap_of_inverse
@@ -710,8 +715,8 @@ lemma mem_map_sets_iff' {α : Type*} {β : Type*} {f : filter α} {m : α → β
 mem_map_sets_iff
 
 lemma mem_uniformity_of_uniform_continuous_invarant [uniform_space α] {s:set (α×α)} {f : α → α → α}
-  (hf : uniform_continuous (λp:α×α, f p.1 p.2)) (hs : s ∈ (@uniformity α _)) :
-  ∃u∈(@uniformity α _), ∀a b c, (a, b) ∈ u → (f a c, f b c) ∈ s :=
+  (hf : uniform_continuous (λp:α×α, f p.1 p.2)) (hs : s ∈ 𝓤 α) :
+  ∃u∈𝓤 α, ∀a b c, (a, b) ∈ u → (f a c, f b c) ∈ s :=
 begin
   rw [uniform_continuous, uniformity_prod_eq_prod, tendsto_map'_iff, (∘)] at hf,
   rcases mem_map_sets_iff'.1 (hf hs) with ⟨t, ht, hts⟩, clear hf,
@@ -723,16 +728,16 @@ begin
 end
 
 lemma mem_uniform_prod [t₁ : uniform_space α] [t₂ : uniform_space β] {a : set (α × α)} {b : set (β × β)}
-  (ha : a ∈ (@uniformity α _)) (hb : b ∈ (@uniformity β _)) :
+  (ha : a ∈ 𝓤 α) (hb : b ∈ 𝓤 β) :
   {p:(α×β)×(α×β) | (p.1.1, p.2.1) ∈ a ∧ (p.1.2, p.2.2) ∈ b } ∈ (@uniformity (α × β) _) :=
 by rw [uniformity_prod]; exact inter_mem_inf_sets (preimage_mem_comap ha) (preimage_mem_comap hb)
 
 lemma tendsto_prod_uniformity_fst [uniform_space α] [uniform_space β] :
-  tendsto (λp:(α×β)×(α×β), (p.1.1, p.2.1)) uniformity uniformity :=
+  tendsto (λp:(α×β)×(α×β), (p.1.1, p.2.1)) (𝓤 (α × β)) (𝓤 α) :=
 le_trans (map_mono (@le_sup_left (uniform_space (α×β)) _ _ _)) map_comap_le
 
 lemma tendsto_prod_uniformity_snd [uniform_space α] [uniform_space β] :
-  tendsto (λp:(α×β)×(α×β), (p.1.2, p.2.2)) uniformity uniformity :=
+  tendsto (λp:(α×β)×(α×β), (p.1.2, p.2.2)) (𝓤 (α × β)) (𝓤 β) :=
 le_trans (map_mono (@le_sup_right (uniform_space (α×β)) _ _ _)) map_comap_le
 
 lemma uniform_continuous_fst [uniform_space α] [uniform_space β] : uniform_continuous (λp:α×β, p.1) :=
@@ -750,11 +755,11 @@ tendsto_inf.2 ⟨tendsto_comap_iff.2 h₁, tendsto_comap_iff.2 h₂⟩
 
 lemma uniform_continuous.prod_mk_left {f : α × β → γ} (h : uniform_continuous f) (b) :
   uniform_continuous (λ a, f (a,b)) :=
-uniform_continuous.comp (uniform_continuous.prod_mk uniform_continuous_id uniform_continuous_const) h
+(uniform_continuous_id.prod_mk uniform_continuous_const).comp h
 
 lemma uniform_continuous.prod_mk_right {f : α × β → γ} (h : uniform_continuous f) (a) :
   uniform_continuous (λ b, f (a,b)) :=
-uniform_continuous.comp (uniform_continuous.prod_mk uniform_continuous_const uniform_continuous_id) h
+(uniform_continuous_const.prod_mk  uniform_continuous_id).comp h
 
 lemma to_topological_space_prod [u : uniform_space α] [v : uniform_space β] :
   @uniform_space.to_topological_space (α × β) prod.uniform_space =
@@ -775,7 +780,7 @@ by taking independently an entourage of the diagonal in the first part, and an e
 the diagonal in the second part. -/
 def uniform_space.core.sum : uniform_space.core (α ⊕ β) :=
 uniform_space.core.mk'
-  (map (λ p : α × α, (inl p.1, inl p.2)) uniformity ⊔ map (λ p : β × β, (inr p.1, inr p.2)) uniformity)
+  (map (λ p : α × α, (inl p.1, inl p.2)) (𝓤 α) ⊔ map (λ p : β × β, (inr p.1, inr p.2)) (𝓤 β))
   (λ r ⟨H₁, H₂⟩ x, by cases x; [apply refl_mem_uniformity H₁, apply refl_mem_uniformity H₂])
   (λ r ⟨H₁, H₂⟩, ⟨symm_le_uniformity H₁, symm_le_uniformity H₂⟩)
   (λ r ⟨Hrα, Hrβ⟩, begin
@@ -794,7 +799,7 @@ uniform_space.core.mk'
 
 /-- The union of an entourage of the diagonal in each set of a disjoint union is again an entourage of the diagonal. -/
 lemma union_mem_uniformity_sum
-  {a : set (α × α)} (ha : a ∈ @uniformity α _) {b : set (β × β)} (hb : b ∈ @uniformity β _) :
+  {a : set (α × α)} (ha : a ∈ 𝓤 α) {b : set (β × β)} (hb : b ∈ 𝓤 β) :
   ((λ p : (α × α), (inl p.1, inl p.2)) '' a ∪ (λ p : (β × β), (inr p.1, inr p.2)) '' b) ∈ (@uniform_space.core.sum α β _ _).uniformity :=
 ⟨mem_map_sets_iff.2 ⟨_, ha, subset_union_left _ _⟩, mem_map_sets_iff.2 ⟨_, hb, subset_union_right _ _⟩⟩
 
@@ -838,9 +843,9 @@ instance sum.uniform_space [u₁ : uniform_space α] [u₂ : uniform_space β] :
   is_open_uniformity := λ s, ⟨uniformity_sum_of_open_aux, open_of_uniformity_sum_aux⟩ }
 
 lemma sum.uniformity [uniform_space α] [uniform_space β] :
-  @uniformity (α ⊕ β) _ =
-    map (λ p : α × α, (inl p.1, inl p.2)) uniformity ⊔
-    map (λ p : β × β, (inr p.1, inr p.2)) uniformity := rfl
+  𝓤 (α ⊕ β) =
+    map (λ p : α × α, (inl p.1, inl p.2)) (𝓤 α) ⊔
+    map (λ p : β × β, (inr p.1, inr p.2)) (𝓤 β) := rfl
 
 end sum
 
@@ -848,19 +853,19 @@ end constructions
 
 lemma lebesgue_number_lemma {α : Type u} [uniform_space α] {s : set α} {ι} {c : ι → set α}
   (hs : compact s) (hc₁ : ∀ i, is_open (c i)) (hc₂ : s ⊆ ⋃ i, c i) :
-  ∃ n ∈ @uniformity α _, ∀ x ∈ s, ∃ i, {y | (x, y) ∈ n} ⊆ c i :=
+  ∃ n ∈ 𝓤 α, ∀ x ∈ s, ∃ i, {y | (x, y) ∈ n} ⊆ c i :=
 begin
-  let u := λ n, {x | ∃ i (m ∈ @uniformity α _), {y | (x, y) ∈ comp_rel m n} ⊆ c i},
-  have hu₁ : ∀ n ∈ @uniformity α _, is_open (u n),
+  let u := λ n, {x | ∃ i (m ∈ 𝓤 α), {y | (x, y) ∈ comp_rel m n} ⊆ c i},
+  have hu₁ : ∀ n ∈ 𝓤 α, is_open (u n),
   { refine λ n hn, is_open_uniformity.2 _,
     rintro x ⟨i, m, hm, h⟩,
     rcases comp_mem_uniformity_sets hm with ⟨m', hm', mm'⟩,
-    apply uniformity.sets_of_superset hm',
+    apply (𝓤 α).sets_of_superset hm',
     rintros ⟨x, y⟩ hp rfl,
     refine ⟨i, m', hm', λ z hz, h (monotone_comp_rel monotone_id monotone_const mm' _)⟩,
     dsimp at hz ⊢, rw comp_rel_assoc,
     exact ⟨y, hp, hz⟩ },
-  have hu₂ : s ⊆ ⋃ n ∈ @uniformity α _, u n,
+  have hu₂ : s ⊆ ⋃ n ∈ 𝓤 α, u n,
   { intros x hx,
     rcases mem_Union.1 (hc₂ hx) with ⟨i, h⟩,
     rcases comp_mem_uniformity_sets (is_open_uniformity.1 (hc₁ i) x h) with ⟨m', hm', mm'⟩,
@@ -874,6 +879,6 @@ end
 
 lemma lebesgue_number_lemma_sUnion {α : Type u} [uniform_space α] {s : set α} {c : set (set α)}
   (hs : compact s) (hc₁ : ∀ t ∈ c, is_open t) (hc₂ : s ⊆ ⋃₀ c) :
-  ∃ n ∈ @uniformity α _, ∀ x ∈ s, ∃ t ∈ c, ∀ y, (x, y) ∈ n → y ∈ t :=
+  ∃ n ∈ 𝓤 α, ∀ x ∈ s, ∃ t ∈ c, ∀ y, (x, y) ∈ n → y ∈ t :=
 by rw sUnion_eq_Union at hc₂;
    simpa using lebesgue_number_lemma hs (by simpa) hc₂

--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -13,20 +13,22 @@ local attribute [instance, priority 0] prop_decidable
 variables {α : Type*} {β : Type*} [uniform_space α]
 universe u
 
+local notation `𝓤` := uniformity
+
 /-- A filter `f` is Cauchy if for every entourage `r`, there exists an
   `s ∈ f` such that `s × s ⊆ r`. This is a generalization of Cauchy
   sequences, because if `a : ℕ → α` then the filter of sets containing
   cofinitely many of the `a n` is Cauchy iff `a` is a Cauchy sequence. -/
-def cauchy (f : filter α) := f ≠ ⊥ ∧ filter.prod f f ≤ uniformity
+def cauchy (f : filter α) := f ≠ ⊥ ∧ filter.prod f f ≤ (𝓤 α)
 
 def is_complete (s : set α) := ∀f, cauchy f → f ≤ principal s → ∃x∈s, f ≤ nhds x
 
-lemma cauchy_iff [uniform_space α] {f : filter α} :
-  cauchy f ↔ (f ≠ ⊥ ∧ (∀s∈(@uniformity α _).sets, ∃t∈f.sets, set.prod t t ⊆ s)) :=
+lemma cauchy_iff {f : filter α} :
+  cauchy f ↔ (f ≠ ⊥ ∧ (∀ s ∈ 𝓤 α, ∃t∈f.sets, set.prod t t ⊆ s)) :=
 and_congr (iff.refl _) $ forall_congr $ assume s, forall_congr $ assume hs, mem_prod_same_iff
 
-lemma cauchy_map_iff [uniform_space α] {l : filter β} {f : β → α} :
-  cauchy (l.map f) ↔ (l ≠ ⊥ ∧ tendsto (λp:β×β, (f p.1, f p.2)) (l.prod l) uniformity) :=
+lemma cauchy_map_iff {l : filter β} {f : β → α} :
+  cauchy (l.map f) ↔ (l ≠ ⊥ ∧ tendsto (λp:β×β, (f p.1, f p.2)) (l.prod l) (𝓤 α)) :=
 by rw [cauchy, (≠), map_eq_bot_iff, prod_map_map_eq]; refl
 
 lemma cauchy_downwards {f g : filter α} (h_c : cauchy f) (hg : g ≠ ⊥) (h_le : g ≤ f) : cauchy g :=
@@ -35,14 +37,14 @@ lemma cauchy_downwards {f g : filter α} (h_c : cauchy f) (hg : g ≠ ⊥) (h_le
 lemma cauchy_nhds {a : α} : cauchy (nhds a) :=
 ⟨nhds_neq_bot,
   calc filter.prod (nhds a) (nhds a) =
-    uniformity.lift (λs:set (α×α), uniformity.lift' (λt:set(α×α),
+    (𝓤 α).lift (λs:set (α×α), (𝓤 α).lift' (λt:set(α×α),
       set.prod {y : α | (y, a) ∈ s} {y : α | (a, y) ∈ t})) : nhds_nhds_eq_uniformity_uniformity_prod
-    ... ≤ uniformity.lift' (λs:set (α×α), comp_rel s s) :
+    ... ≤ (𝓤 α).lift' (λs:set (α×α), comp_rel s s) :
       le_infi $ assume s, le_infi $ assume hs,
       infi_le_of_le s $ infi_le_of_le hs $ infi_le_of_le s $ infi_le_of_le hs $
       principal_mono.mpr $
       assume ⟨x, y⟩ ⟨(hx : (x, a) ∈ s), (hy : (a, y) ∈ s)⟩, ⟨a, hx, hy⟩
-    ... ≤ uniformity : comp_le_uniformity⟩
+    ... ≤ 𝓤 α : comp_le_uniformity⟩
 
 lemma cauchy_pure {a : α} : cauchy (pure a) :=
 cauchy_downwards cauchy_nhds
@@ -73,14 +75,14 @@ calc f ≤ f.lift' (λs:set α, {y | x ∈ closure s ∧ y ∈ closure s}) :
     exact monotone_prod monotone_id monotone_id,
     exact monotone_comp (assume s t h x h', closure_mono h h') monotone_preimage
   end
-  ... ≤ uniformity.lift' (λs:set (α×α), {y | (x, y) ∈ closure s}) : lift'_mono hf.right (le_refl _)
-  ... = (uniformity.lift' closure).lift' (λs:set (α×α), {y | (x, y) ∈ s}) :
+  ... ≤ (𝓤 α).lift' (λs:set (α×α), {y | (x, y) ∈ closure s}) : lift'_mono hf.right (le_refl _)
+  ... = ((𝓤 α).lift' closure).lift' (λs:set (α×α), {y | (x, y) ∈ s}) :
   begin
     rw [lift'_lift'_assoc],
     exact assume s t h, closure_mono h,
     exact monotone_preimage
   end
-  ... = uniformity.lift' (λs:set (α×α), {y | (x, y) ∈ s}) :
+  ... = (𝓤 α).lift' (λs:set (α×α), {y | (x, y) ∈ s}) :
     by rw [←uniformity_eq_uniformity_closure]
   ... = nhds x :
     by rw [nhds_eq_uniformity]
@@ -95,17 +97,17 @@ lemma cauchy_map [uniform_space β] {f : filter α} {m : α → β}
 ⟨have f ≠ ⊥, from hf.left, by simp; assumption,
   calc filter.prod (map m f) (map m f) =
           map (λp:α×α, (m p.1, m p.2)) (filter.prod f f) : filter.prod_map_map_eq
-    ... ≤ map (λp:α×α, (m p.1, m p.2)) uniformity : map_mono hf.right
-    ... ≤ uniformity : hm⟩
+    ... ≤ map (λp:α×α, (m p.1, m p.2)) (𝓤 α) : map_mono hf.right
+    ... ≤ 𝓤 β : hm⟩
 
 lemma cauchy_comap [uniform_space β] {f : filter β} {m : α → β}
-  (hm : comap (λp:α×α, (m p.1, m p.2)) uniformity ≤ uniformity)
+  (hm : comap (λp:α×α, (m p.1, m p.2)) (𝓤 β) ≤ 𝓤 α)
   (hf : cauchy f) (hb : comap m f ≠ ⊥) : cauchy (comap m f) :=
 ⟨hb,
   calc filter.prod (comap m f) (comap m f) =
           comap (λp:α×α, (m p.1, m p.2)) (filter.prod f f) : filter.prod_comap_comap_eq
-    ... ≤ comap (λp:α×α, (m p.1, m p.2)) uniformity : comap_mono hf.right
-    ... ≤ uniformity : hm⟩
+    ... ≤ comap (λp:α×α, (m p.1, m p.2)) (𝓤 β) : comap_mono hf.right
+    ... ≤ 𝓤 α : hm⟩
 
 /-- Cauchy sequences. Usually defined on ℕ, but often it is also useful to say that a function
 defined on ℝ is Cauchy at +∞ to deduce convergence. Therefore, we define it in a type class that
@@ -113,7 +115,7 @@ is general enough to cover both ℕ and ℝ, which are the main motivating examp
 def cauchy_seq [inhabited β] [semilattice_sup β] (u : β → α) := cauchy (at_top.map u)
 
 lemma cauchy_seq_iff_prod_map [inhabited β] [semilattice_sup β] {u : β → α} :
-  cauchy_seq u ↔ map (prod.map u u) at_top ≤ uniformity :=
+  cauchy_seq u ↔ map (prod.map u u) at_top ≤ 𝓤 α :=
 iff.trans (and_iff_right (map_ne_bot at_top_ne_bot)) (prod_map_at_top_eq u u ▸ iff.rfl)
 
 /-- A complete space is defined here using uniformities. A uniform space
@@ -133,7 +135,7 @@ lemma cauchy_prod [uniform_space β] {f : filter α} {g : filter β} :
   cauchy f → cauchy g → cauchy (filter.prod f g)
 | ⟨f_proper, hf⟩ ⟨g_proper, hg⟩ := ⟨filter.prod_neq_bot.2 ⟨f_proper, g_proper⟩,
   let p_α := λp:(α×β)×(α×β), (p.1.1, p.2.1), p_β := λp:(α×β)×(α×β), (p.1.2, p.2.2) in
-  suffices (f.prod f).comap p_α ⊓ (g.prod g).comap p_β ≤ uniformity.comap p_α ⊓ uniformity.comap p_β,
+  suffices (f.prod f).comap p_α ⊓ (g.prod g).comap p_β ≤ (𝓤 α).comap p_α ⊓ (𝓤 β).comap p_β,
     by simpa [uniformity_prod, filter.prod, filter.comap_inf, filter.comap_comap_comp, (∘),
         lattice.inf_assoc, lattice.inf_comm, lattice.inf_left_comm],
   lattice.inf_le_inf (filter.comap_mono hf) (filter.comap_mono hg)⟩
@@ -178,10 +180,10 @@ lemma is_complete_of_is_closed [complete_space α] {s : set α}
 /-- A set `s` is totally bounded if for every entourage `d` there is a finite
   set of points `t` such that every element of `s` is `d`-near to some element of `t`. -/
 def totally_bounded (s : set α) : Prop :=
-∀d ∈ (@uniformity α _).sets, ∃t : set α, finite t ∧ s ⊆ (⋃y∈t, {x | (x,y) ∈ d})
+∀d ∈ 𝓤 α, ∃t : set α, finite t ∧ s ⊆ (⋃y∈t, {x | (x,y) ∈ d})
 
 theorem totally_bounded_iff_subset {s : set α} : totally_bounded s ↔
-  ∀d ∈ (@uniformity α _).sets, ∃t ⊆ s, finite t ∧ s ⊆ (⋃y∈t, {x | (x,y) ∈ d}) :=
+  ∀d ∈ 𝓤 α, ∃t ⊆ s, finite t ∧ s ⊆ (⋃y∈t, {x | (x,y) ∈ d}) :=
 ⟨λ H d hd, begin
   rcases comp_symm_of_uniformity hd with ⟨r, hr, rs, rd⟩,
   rcases H r hr with ⟨k, fk, ks⟩,
@@ -221,7 +223,7 @@ let ⟨t', ht', hct', htt'⟩ := mem_uniformity_is_closed ht, ⟨c, hcf, hc⟩ :
 lemma totally_bounded_image [uniform_space α] [uniform_space β] {f : α → β} {s : set α}
   (hf : uniform_continuous f) (hs : totally_bounded s) : totally_bounded (f '' s) :=
 assume t ht,
-have {p:α×α | (f p.1, f p.2) ∈ t} ∈ (@uniformity α _).sets,
+have {p:α×α | (f p.1, f p.2) ∈ t} ∈ 𝓤 α,
   from hf ht,
 let ⟨c, hfc, hct⟩ := hs _ this in
 ⟨f '' c, finite_image f hfc,

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -43,6 +43,7 @@ local attribute [instance] classical.prop_decidable
 open filter set
 universes u v w x
 
+local notation `𝓤` := uniformity
 
 /-- Space of Cauchy filters
 
@@ -65,15 +66,15 @@ def gen (s : set (α × α)) : set (Cauchy α × Cauchy α) :=
 lemma monotone_gen : monotone gen :=
 monotone_set_of $ assume p, @monotone_mem_sets (α×α) (filter.prod (p.1.val) (p.2.val))
 
-private lemma symm_gen : map prod.swap (uniformity.lift' gen) ≤ uniformity.lift' gen :=
-calc map prod.swap (uniformity.lift' gen) =
-  uniformity.lift' (λs:set (α×α), {p | s ∈ filter.prod (p.2.val) (p.1.val) }) :
+private lemma symm_gen : map prod.swap ((𝓤 α).lift' gen) ≤ (𝓤 α).lift' gen :=
+calc map prod.swap ((𝓤 α).lift' gen) =
+  (𝓤 α).lift' (λs:set (α×α), {p | s ∈ filter.prod (p.2.val) (p.1.val) }) :
   begin
     delta gen,
     simp [map_lift'_eq, monotone_set_of, monotone_mem_sets,
           function.comp, image_swap_eq_preimage_swap]
   end
-  ... ≤ uniformity.lift' gen :
+  ... ≤ (𝓤 α).lift' gen :
     uniformity_lift_le_swap
       (monotone_comp (monotone_set_of $ assume p,
         @monotone_mem_sets (α×α) ((filter.prod ((p.2).val) ((p.1).val)))) monotone_principal)
@@ -102,38 +103,38 @@ let ⟨x, xt₂, xt₃⟩ :=
       h₂ (show (x, b) ∈ set.prod t₃ t₄, from ⟨xt₃, hb⟩)⟩)
 
 private lemma comp_gen :
-  (uniformity.lift' gen).lift' (λs, comp_rel s s) ≤ uniformity.lift' gen :=
-calc (uniformity.lift' gen).lift' (λs, comp_rel s s) =
-    uniformity.lift' (λs, comp_rel (gen s) (gen s)) :
+  ((𝓤 α).lift' gen).lift' (λs, comp_rel s s) ≤ (𝓤 α).lift' gen :=
+calc ((𝓤 α).lift' gen).lift' (λs, comp_rel s s) =
+    (𝓤 α).lift' (λs, comp_rel (gen s) (gen s)) :
   begin
     rw [lift'_lift'_assoc],
     exact monotone_gen,
     exact (monotone_comp_rel monotone_id monotone_id)
   end
-  ... ≤ uniformity.lift' (λs, gen $ comp_rel s s) :
+  ... ≤ (𝓤 α).lift' (λs, gen $ comp_rel s s) :
     lift'_mono' $ assume s hs, comp_rel_gen_gen_subset_gen_comp_rel
-  ... = (uniformity.lift' $ λs:set(α×α), comp_rel s s).lift' gen :
+  ... = ((𝓤 α).lift' $ λs:set(α×α), comp_rel s s).lift' gen :
   begin
     rw [lift'_lift'_assoc],
     exact (monotone_comp_rel monotone_id monotone_id),
     exact monotone_gen
   end
-  ... ≤ uniformity.lift' gen : lift'_mono comp_le_uniformity (le_refl _)
+  ... ≤ (𝓤 α).lift' gen : lift'_mono comp_le_uniformity (le_refl _)
 
 instance : uniform_space (Cauchy α) :=
 uniform_space.of_core
-{ uniformity  := uniformity.lift' gen,
+{ uniformity  := (𝓤 α).lift' gen,
   refl        := principal_le_lift' $ assume s hs ⟨a, b⟩ (a_eq_b : a = b),
     a_eq_b ▸ a.property.right hs,
   symm        := symm_gen,
   comp        := comp_gen }
 
 theorem mem_uniformity {s : set (Cauchy α × Cauchy α)} :
-  s ∈ @uniformity (Cauchy α) _ ↔ ∃ t ∈ @uniformity α _, gen t ⊆ s :=
+  s ∈ 𝓤 (Cauchy α) ↔ ∃ t ∈ 𝓤 α, gen t ⊆ s :=
 mem_lift'_sets monotone_gen
 
 theorem mem_uniformity' {s : set (Cauchy α × Cauchy α)} :
-  s ∈ @uniformity (Cauchy α) _ ↔ ∃ t ∈ @uniformity α _,
+  s ∈ 𝓤 (Cauchy α) ↔ ∃ t ∈ 𝓤 α,
     ∀ f g : Cauchy α, t ∈ filter.prod f.1 g.1 → (f, g) ∈ s :=
 mem_uniformity.trans $ bex_congr $ λ t h, prod.forall
 
@@ -151,14 +152,14 @@ lemma uniform_embedding_pure_cauchy : uniform_embedding (pure_cauchy : α → Ca
   have (preimage (λ (x : α × α), (pure_cauchy (x.fst), pure_cauchy (x.snd))) ∘ gen) = id,
     from funext $ assume s, set.ext $ assume ⟨a₁, a₂⟩,
       by simp [preimage, gen, pure_cauchy, prod_principal_principal],
-  calc comap (λ (x : α × α), (pure_cauchy (x.fst), pure_cauchy (x.snd))) (uniformity.lift' gen)
-        = uniformity.lift' (preimage (λ (x : α × α), (pure_cauchy (x.fst), pure_cauchy (x.snd))) ∘ gen) :
+  calc comap (λ (x : α × α), (pure_cauchy (x.fst), pure_cauchy (x.snd))) ((𝓤 α).lift' gen)
+        = (𝓤 α).lift' (preimage (λ (x : α × α), (pure_cauchy (x.fst), pure_cauchy (x.snd))) ∘ gen) :
       comap_lift'_eq monotone_gen
-    ... = uniformity : by simp [this]⟩
+    ... = 𝓤 α : by simp [this]⟩
 
 lemma pure_cauchy_dense : ∀x, x ∈ closure (range pure_cauchy) :=
 assume f,
-have h_ex : ∀s∈(@uniformity (Cauchy α) _).sets, ∃y:α, (f, pure_cauchy y) ∈ s, from
+have h_ex : ∀ s ∈ 𝓤 (Cauchy α), ∃y:α, (f, pure_cauchy y) ∈ s, from
   assume s hs,
   let ⟨t'', ht''₁, (ht''₂ : gen t'' ⊆ s)⟩ := (mem_lift'_sets monotone_gen).mp hs in
   let ⟨t', ht'₁, ht'₂⟩ := comp_mem_uniformity_sets ht''₁ in
@@ -203,7 +204,7 @@ complete_space_extension
   pure_cauchy_dense $
   assume f hf,
   let f' : Cauchy α := ⟨f, hf⟩ in
-  have map pure_cauchy f ≤ uniformity.lift' (preimage (prod.mk f')),
+  have map pure_cauchy f ≤ (𝓤 $ Cauchy α).lift' (preimage (prod.mk f')),
     from le_lift' $ assume s hs,
     let ⟨t, ht₁, (ht₂ : gen t ⊆ s)⟩ := (mem_lift'_sets monotone_gen).mp hs in
     let ⟨t', ht', (h : set.prod t' t' ⊆ t)⟩ := mem_prod_same_iff.mp (hf.right ht₁) in
@@ -366,12 +367,14 @@ lemma continuous_coe : continuous (coe : α → completion α) :=
 uniform_continuous.continuous (uniform_continuous_coe α)
 
 lemma comap_coe_eq_uniformity :
-  uniformity.comap (λ(p:α×α), ((p.1 : completion α), (p.2 : completion α))) = uniformity :=
+  (𝓤 _).comap (λ(p:α×α), ((p.1 : completion α), (p.2 : completion α))) = 𝓤 α :=
 begin
   have : (λx:α×α, ((x.1 : completion α), (x.2 : completion α))) =
     (λx:(Cauchy α)×(Cauchy α), (⟦x.1⟧, ⟦x.2⟧)) ∘ (λx:α×α, (pure_cauchy x.1, pure_cauchy x.2)),
   { ext ⟨a, b⟩; simp; refl },
-  rw [this, ← filter.comap_comap_comp, comap_quotient_eq_uniformity, uniform_embedding_pure_cauchy.2]
+  rw [this, ← filter.comap_comap_comp],
+  change filter.comap _ (filter.comap _ (𝓤 $ quotient $ separation_setoid $ Cauchy α)) = 𝓤 α,
+  rw [comap_quotient_eq_uniformity, uniform_embedding_pure_cauchy.2]
 end
 
 lemma uniform_embedding_coe [separated α] : uniform_embedding  (coe : α → completion α) :=

--- a/src/topology/uniform_space/separation.lean
+++ b/src/topology/uniform_space/separation.lean
@@ -17,6 +17,7 @@ universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
 variables [uniform_space α] [uniform_space β] [uniform_space γ]
 
+local notation `𝓤` := uniformity
 
 /- separated uniformity -/
 
@@ -24,16 +25,16 @@ variables [uniform_space α] [uniform_space β] [uniform_space γ]
   Two points which are related by the separation relation are "indistinguishable"
   according to the uniform structure. -/
 protected def separation_rel (α : Type u) [u : uniform_space α] :=
-⋂₀ (@uniformity α _).sets
+⋂₀ (𝓤 α).sets
 
 lemma separated_equiv : equivalence (λx y, (x, y) ∈ separation_rel α) :=
 ⟨assume x, assume s, refl_mem_uniformity,
   assume x y, assume h (s : set (α×α)) hs,
-    have preimage prod.swap s ∈ @uniformity α _,
+    have preimage prod.swap s ∈ 𝓤 α,
       from symm_le_uniformity hs,
     h _ this,
   assume x y z (hxy : (x, y) ∈ separation_rel α) (hyz : (y, z) ∈ separation_rel α)
-      s (hs : s ∈ @uniformity α _),
+      s (hs : s ∈ 𝓤 α),
     let ⟨t, ht, (h_ts : comp_rel t t ⊆ s)⟩ := comp_mem_uniformity_sets hs in
     h_ts $ show (x, z) ∈ comp_rel t t,
       from ⟨y, hxy t ht, hyz t ht⟩⟩
@@ -42,12 +43,12 @@ lemma separated_equiv : equivalence (λx y, (x, y) ∈ separation_rel α) :=
 separation_rel α = id_rel
 
 theorem separated_def {α : Type u} [uniform_space α] :
-  separated α ↔ ∀ x y, (∀ r ∈ @uniformity α _, (x, y) ∈ r) → x = y :=
+  separated α ↔ ∀ x y, (∀ r ∈ 𝓤 α, (x, y) ∈ r) → x = y :=
 by simp [separated, id_rel_subset.2 separated_equiv.1, subset.antisymm_iff];
    simp [subset_def, separation_rel]
 
 theorem separated_def' {α : Type u} [uniform_space α] :
-  separated α ↔ ∀ x y, x ≠ y → ∃ r ∈ @uniformity α _, (x, y) ∉ r :=
+  separated α ↔ ∀ x y, x ≠ y → ∃ r ∈ 𝓤 α, (x, y) ∉ r :=
 separated_def.trans $ forall_congr $ λ x, forall_congr $ λ y,
 by rw ← not_imp_not; simp [classical.not_forall]
 
@@ -72,7 +73,7 @@ instance separated_regular [separated α] : regular_space α :=
 { regular := λs a hs ha,
     have -s ∈ nhds a,
       from mem_nhds_sets hs ha,
-    have {p : α × α | p.1 = a → p.2 ∈ -s} ∈ uniformity,
+    have {p : α × α | p.1 = a → p.2 ∈ -s} ∈ 𝓤 α,
       from mem_nhds_uniformity_iff.mp this,
     let ⟨d, hd, h⟩ := comp_mem_uniformity_sets this in
     let e := {y:α| (a, y) ∈ d} in
@@ -80,7 +81,7 @@ instance separated_regular [separated α] : regular_space α :=
     have set.prod (closure e) (closure e) ⊆ comp_rel d (comp_rel (set.prod e e) d),
     begin
       rw [←closure_prod_eq, closure_eq_inter_uniformity],
-      change (⨅d' ∈ uniformity.sets, _) ≤ comp_rel d (comp_rel _ d),
+      change (⨅d' ∈ 𝓤 α, _) ≤ comp_rel d (comp_rel _ d),
       exact (infi_le_of_le d $ infi_le_of_le hd $ le_refl _)
     end,
     have e_subset : closure e ⊆ -s,
@@ -104,14 +105,14 @@ local attribute [instance] separation_setoid
 
 instance {α : Type u} [u : uniform_space α] : uniform_space (quotient (separation_setoid α)) :=
 { to_topological_space := u.to_topological_space.coinduced (λx, ⟦x⟧),
-  uniformity := map (λp:(α×α), (⟦p.1⟧, ⟦p.2⟧)) uniformity,
+  uniformity := map (λp:(α×α), (⟦p.1⟧, ⟦p.2⟧)) u.uniformity,
   refl := le_trans (by simp [quotient.exists_rep]) (filter.map_mono refl_le_uniformity),
   symm := tendsto_map' $
     by simp [prod.swap, (∘)]; exact tendsto_swap_uniformity.comp tendsto_map,
-  comp := calc (map (λ (p : α × α), (⟦p.fst⟧, ⟦p.snd⟧)) uniformity).lift' (λs, comp_rel s s) =
-          uniformity.lift' ((λs, comp_rel s s) ∘ image (λ (p : α × α), (⟦p.fst⟧, ⟦p.snd⟧))) :
+  comp := calc (map (λ (p : α × α), (⟦p.fst⟧, ⟦p.snd⟧)) u.uniformity).lift' (λs, comp_rel s s) =
+          u.uniformity.lift' ((λs, comp_rel s s) ∘ image (λ (p : α × α), (⟦p.fst⟧, ⟦p.snd⟧))) :
       map_lift'_eq2 $ monotone_comp_rel monotone_id monotone_id
-    ... ≤ uniformity.lift' (image (λ (p : α × α), (⟦p.fst⟧, ⟦p.snd⟧)) ∘ (λs:set (α×α), comp_rel s (comp_rel s s))) :
+    ... ≤ u.uniformity.lift' (image (λ (p : α × α), (⟦p.fst⟧, ⟦p.snd⟧)) ∘ (λs:set (α×α), comp_rel s (comp_rel s s))) :
       lift'_mono' $ assume s hs ⟨a, b⟩ ⟨c, ⟨⟨a₁, a₂⟩, ha, a_eq⟩, ⟨⟨b₁, b₂⟩, hb, b_eq⟩⟩,
       begin
         simp at a_eq,
@@ -121,15 +122,15 @@ instance {α : Type u} [u : uniform_space α] : uniform_space (quotient (separat
         simp [function.comp, set.image, comp_rel, and.comm, and.left_comm, and.assoc],
         exact ⟨a₁, a_eq.left, b₂, b_eq.right, a₂, ha, b₁, h s hs, hb⟩
       end
-    ... = map (λp:(α×α), (⟦p.1⟧, ⟦p.2⟧)) (uniformity.lift' (λs:set (α×α), comp_rel s (comp_rel s s))) :
+    ... = map (λp:(α×α), (⟦p.1⟧, ⟦p.2⟧)) (u.uniformity.lift' (λs:set (α×α), comp_rel s (comp_rel s s))) :
       by rw [map_lift'_eq];
         exact monotone_comp_rel monotone_id (monotone_comp_rel monotone_id monotone_id)
-    ... ≤ map (λp:(α×α), (⟦p.1⟧, ⟦p.2⟧)) uniformity :
+    ... ≤ map (λp:(α×α), (⟦p.1⟧, ⟦p.2⟧)) u.uniformity :
       map_mono comp_le_uniformity3,
   is_open_uniformity := assume s,
     have ∀a, ⟦a⟧ ∈ s →
-        ({p:α×α | p.1 = a → ⟦p.2⟧ ∈ s} ∈ @uniformity α _ ↔
-          {p:α×α | p.1 ≈ a → ⟦p.2⟧ ∈ s} ∈ @uniformity α _),
+        ({p:α×α | p.1 = a → ⟦p.2⟧ ∈ s} ∈ 𝓤 α ↔
+          {p:α×α | p.1 ≈ a → ⟦p.2⟧ ∈ s} ∈ 𝓤 α),
       from assume a ha,
       ⟨assume h,
         let ⟨t, ht, hts⟩ := comp_mem_uniformity_sets h in
@@ -137,15 +138,15 @@ instance {α : Type u} [u : uniform_space α] : uniform_space (quotient (separat
           from assume a₁ a₂ ha₁ ha₂, @hts (a, a₂) ⟨a₁, ha₁, ha₂⟩ rfl,
         have ht' : ∀{a₁ a₂}, a₁ ≈ a₂ → (a₁, a₂) ∈ t,
           from assume a₁ a₂ h, sInter_subset_of_mem ht h,
-        uniformity.sets_of_superset ht $ assume ⟨a₁, a₂⟩ h₁ h₂, hts (ht' $ setoid.symm h₂) h₁,
-        assume h, uniformity.sets_of_superset h $ by simp {contextual := tt}⟩,
+        u.uniformity.sets_of_superset ht $ assume ⟨a₁, a₂⟩ h₁ h₂, hts (ht' $ setoid.symm h₂) h₁,
+        assume h, u.uniformity.sets_of_superset h $ by simp {contextual := tt}⟩,
     begin
       simp [topological_space.coinduced, u.is_open_uniformity, uniformity, forall_quotient_iff],
       exact ⟨λh a ha, (this a ha).mp $ h a ha, λh a ha, (this a ha).mpr $ h a ha⟩
     end }
 
 lemma uniformity_quotient :
-  @uniformity (quotient (separation_setoid α)) _ = uniformity.map (λp:(α×α), (⟦p.1⟧, ⟦p.2⟧)) :=
+  𝓤 (quotient (separation_setoid α)) = (𝓤 α).map (λp:(α×α), (⟦p.1⟧, ⟦p.2⟧)) :=
 rfl
 
 lemma uniform_continuous_quotient_mk :
@@ -172,12 +173,12 @@ begin
 end
 
 lemma comap_quotient_le_uniformity :
-  uniformity.comap (λ (p : α × α), (⟦p.fst⟧, ⟦p.snd⟧)) ≤ uniformity :=
+  (𝓤 $ quotient $ separation_setoid α).comap (λ (p : α × α), (⟦p.fst⟧, ⟦p.snd⟧)) ≤ (𝓤 α) :=
 assume t' ht',
 let ⟨t, ht, tt_t'⟩ := comp_mem_uniformity_sets ht' in
 let ⟨s, hs, ss_t⟩ := comp_mem_uniformity_sets ht in
 ⟨(λp:α×α, (⟦p.1⟧, ⟦p.2⟧)) '' s,
-  (@uniformity α _).sets_of_superset hs $ assume x hx, ⟨x, hx, rfl⟩,
+  (𝓤 α).sets_of_superset hs $ assume x hx, ⟨x, hx, rfl⟩,
   assume ⟨a₁, a₂⟩ ⟨⟨b₁, b₂⟩, hb, ab_eq⟩,
   have ⟦b₁⟧ = ⟦a₁⟧ ∧ ⟦b₂⟧ = ⟦a₂⟧, from prod.mk.inj ab_eq,
   have b₁ ≈ a₁ ∧ b₂ ≈ a₂, from and.imp quotient.exact quotient.exact this,
@@ -187,7 +188,7 @@ let ⟨s, hs, ss_t⟩ := comp_mem_uniformity_sets ht in
     ss_t ⟨b₂, show ((b₁, a₂).1, b₂) ∈ s, from hb, ba₂⟩⟩⟩
 
 lemma comap_quotient_eq_uniformity :
-  uniformity.comap (λ (p : α × α), (⟦p.fst⟧, ⟦p.snd⟧)) = uniformity :=
+  (𝓤 $ quotient $ separation_setoid α).comap (λ (p : α × α), (⟦p.fst⟧, ⟦p.snd⟧)) = 𝓤 α :=
 le_antisymm comap_quotient_le_uniformity le_comap_map
 
 
@@ -195,7 +196,7 @@ instance separated_separation : separated (quotient (separation_setoid α)) :=
 set.ext $ assume ⟨a, b⟩, quotient.induction_on₂ a b $ assume a b,
   ⟨assume h,
     have a ≈ b, from assume s hs,
-      have s ∈ uniformity.comap (λp:(α×α), (⟦p.1⟧, ⟦p.2⟧)),
+      have s ∈ (𝓤 $ quotient $ separation_setoid α).comap (λp:(α×α), (⟦p.1⟧, ⟦p.2⟧)),
         from comap_quotient_le_uniformity hs,
       let ⟨t, ht, hts⟩ := this in
       hts begin dsimp, exact h t ht end,

--- a/src/topology/uniform_space/uniform_embedding.lean
+++ b/src/topology/uniform_space/uniform_embedding.lean
@@ -12,19 +12,21 @@ local attribute [instance, priority 0] prop_decidable
 variables {α : Type*} {β : Type*} {γ : Type*} [uniform_space α]
 universe u
 
+local notation `𝓤` := uniformity
+
 def uniform_embedding [uniform_space β] (f : α → β) :=
 function.injective f ∧
-comap (λx:α×α, (f x.1, f x.2)) uniformity = uniformity
+comap (λx:α×α, (f x.1, f x.2)) (𝓤 β) = 𝓤 α
 
 theorem uniform_embedding_def [uniform_space β] {f : α → β} :
-  uniform_embedding f ↔ function.injective f ∧ ∀ s, s ∈ @uniformity α _ ↔
-    ∃ t ∈ @uniformity β _, ∀ x y : α, (f x, f y) ∈ t → (x, y) ∈ s :=
+  uniform_embedding f ↔ function.injective f ∧ ∀ s, s ∈ 𝓤 α ↔
+    ∃ t ∈ 𝓤 β, ∀ x y : α, (f x, f y) ∈ t → (x, y) ∈ s :=
 by rw [uniform_embedding, eq_comm, filter.ext_iff]; simp [subset_def]
 
 theorem uniform_embedding_def' [uniform_space β] {f : α → β} :
   uniform_embedding f ↔ function.injective f ∧ uniform_continuous f ∧
-    ∀ s, s ∈ @uniformity α _ →
-      ∃ t ∈ @uniformity β _, ∀ x y : α, (f x, f y) ∈ t → (x, y) ∈ s :=
+    ∀ s, s ∈ 𝓤 α →
+      ∃ t ∈ 𝓤 β, ∀ x y : α, (f x, f y) ∈ t → (x, y) ∈ s :=
 by simp [uniform_embedding_def, uniform_continuous_def]; exact
 ⟨λ ⟨I, H⟩, ⟨I, λ s su, (H _).2 ⟨s, su, λ x y, id⟩, λ s, (H s).1⟩,
  λ ⟨I, H₁, H₂⟩, ⟨I, λ s, ⟨H₂ s,
@@ -55,9 +57,9 @@ lemma uniform_embedding.dense_embedding [uniform_space β] {f : α → β}
 
 lemma closure_image_mem_nhds_of_uniform_embedding
   [uniform_space α] [uniform_space β] {s : set (α×α)} {e : α → β} (b : β)
-  (he₁ : uniform_embedding e) (he₂ : dense_embedding e) (hs : s ∈ @uniformity α _) :
+  (he₁ : uniform_embedding e) (he₂ : dense_embedding e) (hs : s ∈ 𝓤 α) :
   ∃a, closure (e '' {a' | (a, a') ∈ s}) ∈ nhds b :=
-have s ∈ comap (λp:α×α, (e p.1, e p.2)) uniformity,
+have s ∈ comap (λp:α×α, (e p.1, e p.2)) (𝓤 β),
   from he₁.right.symm ▸ hs,
 let ⟨t₁, ht₁u, ht₁⟩ := this in
 have ht₁ : ∀p:α×α, (e p.1, e p.2) ∈ t₁ → p ∈ s, from ht₁,
@@ -66,7 +68,7 @@ let ⟨t, htu, hts, htc⟩ := comp_symm_of_uniformity ht₂u in
 have preimage e {b' | (b, b') ∈ t₂} ∈ comap e (nhds b),
   from preimage_mem_comap $ mem_nhds_left b ht₂u,
 let ⟨a, (ha : (b, e a) ∈ t₂)⟩ := inhabited_of_mem_sets (he₂.comap_nhds_neq_bot) this in
-have ∀b' (s' : set (β × β)), (b, b') ∈ t → s' ∈ @uniformity β _ →
+have ∀b' (s' : set (β × β)), (b, b') ∈ t → s' ∈ 𝓤 β →
   {y : β | (b', y) ∈ s'} ∩ e '' {a' : α | (a, a') ∈ s} ≠ ∅,
   from assume b' s' hb' hs',
   have preimage e {b'' | (b', b'') ∈ s' ∩ t} ∈ comap e (nhds b'),
@@ -154,7 +156,7 @@ lemma complete_space_extension [uniform_space β] {m : β → α}
 ⟨assume (f : filter α), assume hf : cauchy f,
 let
   p : set (α × α) → set α → set α := λs t, {y : α| ∃x:α, x ∈ t ∧ (x, y) ∈ s},
-  g := uniformity.lift (λs, f.lift' (p s))
+  g := (𝓤 α).lift (λs, f.lift' (p s))
 in
 have mp₀ : monotone p,
   from assume a b h t s ⟨x, xs, xa⟩, ⟨x, xs, h xa⟩,
@@ -278,13 +280,13 @@ have h_pnt : ∀{a m}, m ∈ nhds a → ∃c, c ∈ f '' preimage e m ∧ (c, ψ
     from inter_mem_sets (image_mem_map $ preimage_mem_comap $ hm)
       (uniformly_extend_spec h_e h_dense h_f _ (inter_mem_sets (mem_nhds_right _ hs) (mem_nhds_left _ hs))),
   inhabited_of_mem_sets nb this,
-have preimage (λp:β×β, (f p.1, f p.2)) s ∈ @uniformity β _,
+have preimage (λp:β×β, (f p.1, f p.2)) s ∈ 𝓤 β,
   from h_f hs,
-have preimage (λp:β×β, (f p.1, f p.2)) s ∈ comap (λx:β×β, (e x.1, e x.2)) uniformity,
+have preimage (λp:β×β, (f p.1, f p.2)) s ∈ comap (λx:β×β, (e x.1, e x.2)) (𝓤 α),
   by rwa [h_e.right.symm] at this,
 let ⟨t, ht, ts⟩ := this in
-show preimage (λp:(α×α), (ψ p.1, ψ p.2)) d ∈ uniformity.sets,
-  from (@uniformity α _).sets_of_superset (interior_mem_uniformity ht) $
+show preimage (λp:(α×α), (ψ p.1, ψ p.2)) d ∈ 𝓤 α,
+  from (𝓤 α).sets_of_superset (interior_mem_uniformity ht) $
   assume ⟨x₁, x₂⟩ hx_t,
   have nhds (x₁, x₂) ≤ principal (interior t),
     from is_open_iff_nhds.mp is_open_interior (x₁, x₂) hx_t,


### PR DESCRIPTION
This is a binder type change and a local notation

see https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/uniformity