### PR TITLE
refactor(*): rename metric_space_subtype to subtype.metric_space

### DIFF
--- a/src/data/padics/padic_integers.lean
+++ b/src/data/padics/padic_integers.lean
@@ -93,7 +93,7 @@ variables {p : ℕ} [nat.prime p]
 
 @[reducible] def padic_norm_z (z : ℤ_[p]) : ℝ := ∥z.val∥
 
-instance : metric_space ℤ_[p] := metric_space_subtype
+instance : metric_space ℤ_[p] := subtype.metric_space
 
 instance : has_norm ℤ_[p] := ⟨padic_norm_z⟩
 

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -667,7 +667,7 @@ def metric_space.induced {α β} (f : α → β) (hf : function.injective f)
       exact ⟨_, dist_mem_uniformity ε0, λ ⟨a, b⟩, hε⟩ }
   end }
 
-instance metric_space_subtype {p : α → Prop} [t : metric_space α] : metric_space (subtype p) :=
+instance subtype.metric_space {p : α → Prop} [t : metric_space α] : metric_space (subtype p) :=
 metric_space.induced subtype.val (λ x y, subtype.eq) t
 
 theorem subtype.dist_eq {p : α → Prop} [t : metric_space α] (x y : subtype p) :


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
