### PR TITLE
fix(topology/algebra/group): fix binders for top group extensionality

### DIFF
--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -157,7 +157,7 @@ end
 
 @[to_additive topological_add_group.ext]
 lemma topological_group.ext {G : Type*} [group G] {t t' : topological_space G}
-  [tg : @topological_group G t _] [tg' : @topological_group G t' _]
+  (tg : @topological_group G t _) (tg' : @topological_group G t' _)
   (h : @nhds G t 1 = @nhds G t' 1) : t = t' :=
 eq_of_nhds_eq_nhds $ λ x, by
   rw [← @nhds_translation_mul_inv G t _ _ x , ← @nhds_translation_mul_inv G t' _ _ x , ← h]


### PR DESCRIPTION
This is in the code I was too quick to push a few days ago. The binders are stupid...