### PR TITLE
refactor(analysis/normed_space/bounded_linear_maps): nondiscrete normed field

### DIFF
--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -46,6 +46,9 @@ lemma fpow_ne_zero_of_ne_zero {a : α} (ha : a ≠ 0) : ∀ (z : ℤ), a ^ z ≠
 @[simp] lemma fpow_zero {a : α} : a ^ (0 : ℤ) = 1 :=
 pow_zero a
 
+@[simp] lemma fpow_one {a : α} : a ^ (1 : ℤ) = a :=
+pow_one a
+
 lemma fpow_add {a : α} (ha : a ≠ 0) (z1 z2 : ℤ) : a ^ (z1 + z2) = a ^ z1 * a ^ z2 :=
 begin simp only [fpow_eq_gpow ha], rw ← units.coe_mul, congr, apply gpow_add end
 

--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -46,9 +46,6 @@ lemma fpow_ne_zero_of_ne_zero {a : α} (ha : a ≠ 0) : ∀ (z : ℤ), a ^ z ≠
 @[simp] lemma fpow_zero {a : α} : a ^ (0 : ℤ) = 1 :=
 pow_zero a
 
-@[simp] lemma fpow_one {a : α} : a ^ (1 : ℤ) = a :=
-pow_one a
-
 lemma fpow_add {a : α} (ha : a ≠ 0) (z1 z2 : ℤ) : a ^ (z1 + z2) = a ^ z1 * a ^ z2 :=
 begin simp only [fpow_eq_gpow ha], rw ← units.coe_mul, congr, apply gpow_add end
 

--- a/src/algebra/module.lean
+++ b/src/algebra/module.lean
@@ -179,6 +179,21 @@ def mk' (f : β → γ) (H : is_linear_map α f) : β →ₗ γ := {to_fun := f,
 @[simp] theorem mk'_apply {f : β → γ} (H : is_linear_map α f) (x : β) :
   mk' f H x = f x := rfl
 
+variables {f : β → γ} (lin : is_linear_map α f)
+include β γ lin
+
+@[simp] lemma map_zero : f (0 : β) = (0 : γ) :=
+by rw [← zero_smul α (0 : β), lin.smul, zero_smul]
+
+@[simp] lemma map_add (x y : β) : f (x + y) = f x + f y :=
+by rw [lin.add]
+
+@[simp] lemma map_neg (x : β) : f (- x) = - f x :=
+by rw [← neg_one_smul α, lin.smul, neg_one_smul]
+
+@[simp] lemma map_sub (x y : β) : f (x - y) = f x - f y :=
+by simp [lin.map_neg, lin.map_add]
+
 end is_linear_map
 
 /-- A submodule of a module is one which is closed under vector operations.

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -70,7 +70,7 @@ by { rw[←dist_zero_right], exact dist_eq_zero }
 lemma norm_triangle_sum {β} : ∀(s : finset β) (f : β → α), ∥s.sum f∥ ≤ s.sum (λa, ∥ f a ∥) :=
 finset.le_sum_of_subadditive norm norm_zero norm_triangle
 
-lemma norm_pos_iff (g : α) : ∥ g ∥ > 0 ↔ g ≠ 0 :=
+lemma norm_pos_iff (g : α) : 0 < ∥ g ∥ ↔ g ≠ 0 :=
 begin
   split ; intro h ; rw[←dist_zero_right] at *,
   { exact dist_pos.1 h },
@@ -283,6 +283,9 @@ class normed_field (α : Type*) extends has_norm α, discrete_field α, metric_s
 (dist_eq : ∀ x y, dist x y = norm (x - y))
 (norm_mul : ∀ a b, norm (a * b) = norm a * norm b)
 
+class nondiscrete_normed_field (α : Type*) extends normed_field α :=
+(non_trivial : ∃x:α, 1<∥x∥)
+
 instance normed_field.to_normed_ring [i : normed_field α] : normed_ring α :=
 { norm_mul := by finish [i.norm_mul], ..i }
 
@@ -316,10 +319,33 @@ end
 @[simp] lemma norm_inv {α : Type*} [normed_field α] (a : α) : ∥a⁻¹∥ = ∥a∥⁻¹ :=
 by simp only [inv_eq_one_div, norm_div, norm_one]
 
+@[simp] lemma norm_fpow {α : Type*} [normed_field α] (a : α) : ∀n : ℤ,
+  ∥a^n∥ = ∥a∥^n
+| (n : ℕ) := norm_pow a n
+| -[1+ n] := by simp [fpow_neg_succ_of_nat]
+
+lemma exists_one_lt_norm (α : Type*) [i : nondiscrete_normed_field α] : ∃x : α, 1 < ∥x∥ :=
+i.non_trivial
+
+lemma exists_norm_lt_one (α : Type*) [nondiscrete_normed_field α] : ∃x : α, 0 < ∥x∥ ∧ ∥x∥ < 1 :=
+begin
+  rcases exists_one_lt_norm α with ⟨y, hy⟩,
+  refine ⟨y⁻¹, _, _⟩,
+  { simp only [inv_eq_zero, ne.def, norm_pos_iff],
+    assume h,
+    rw ← norm_eq_zero at h,
+    rw h at hy,
+    exact lt_irrefl _ (lt_trans zero_lt_one hy) },
+  { simp [inv_lt_one hy] }
+end
+
 instance : normed_field ℝ :=
 { norm := λ x, abs x,
   dist_eq := assume x y, rfl,
   norm_mul := abs_mul }
+
+instance : nondiscrete_normed_field ℝ :=
+{ non_trivial := ⟨2, by { unfold norm, rw abs_of_nonneg; norm_num }⟩ }
 
 lemma real.norm_eq_abs (r : ℝ): norm r = abs r := rfl
 
@@ -385,6 +411,33 @@ lemma continuous_smul [topological_space γ] {f : γ → α} {g : γ → E}
   (hf : continuous f) (hg : continuous g) : continuous (λc, f c • g c) :=
 continuous_iff_continuous_at.2 $ assume c,
   tendsto_smul (continuous_iff_continuous_at.1 hf _) (continuous_iff_continuous_at.1 hg _)
+
+/-- If there is a scalar `c` with `∥c∥>1`, then any element can be moved by scalar multiplication to
+any shell of width `∥c∥`. Also recap information on the norm of the rescaling element that shows
+up in applications. -/
+lemma rescale_to_shell {c : α} (hc : 1 < ∥c∥) {ε : ℝ} (εpos : 0 < ε) {x : E} (hx : x ≠ 0) :
+  ∃d:α, d ≠ 0 ∧ ∥d • x∥ ≤ ε ∧ (ε/∥c∥ ≤ ∥d • x∥) ∧ (∥d∥⁻¹ ≤ ε⁻¹ * ∥c∥ * ∥x∥) :=
+begin
+  have xεpos : 0 < ∥x∥/ε := div_pos_of_pos_of_pos ((norm_pos_iff _).2 hx) εpos,
+  rcases exists_int_pow_near xεpos hc with ⟨n, hn⟩,
+  have cpos : 0 < ∥c∥ := lt_trans (zero_lt_one : (0 :ℝ) < 1) hc,
+  have cnpos : 0 < ∥c^(n+1)∥ := by { rw norm_fpow, exact lt_trans xεpos hn.2 },
+  refine ⟨(c^(n+1))⁻¹, _, _, _, _⟩,
+  show (c ^ (n + 1))⁻¹  ≠ 0,
+    by rwa [ne.def, inv_eq_zero, ← ne.def, ← norm_pos_iff],
+  show ∥(c ^ (n + 1))⁻¹ • x∥ ≤ ε,
+  { rw [norm_smul, norm_inv, ← div_eq_inv_mul, div_le_iff cnpos, mul_comm, norm_fpow],
+    exact (div_le_iff εpos).1 (le_of_lt (hn.2)) },
+  show ε / ∥c∥ ≤ ∥(c ^ (n + 1))⁻¹ • x∥,
+  { rw [div_le_iff cpos, norm_smul, norm_inv, norm_fpow, fpow_add (ne_of_gt cpos),
+        fpow_one, mul_inv', mul_comm, ← mul_assoc, ← mul_assoc, mul_inv_cancel (ne_of_gt cpos),
+        one_mul, ← div_eq_inv_mul, le_div_iff (fpow_pos_of_pos cpos _), mul_comm],
+    exact (le_div_iff εpos).1 hn.1 },
+  show ∥(c ^ (n + 1))⁻¹∥⁻¹ ≤ ε⁻¹ * ∥c∥ * ∥x∥,
+  { have : ε⁻¹ * ∥c∥ * ∥x∥ = ε⁻¹ * ∥x∥ * ∥c∥, by ring,
+    rw [norm_inv, inv_inv', norm_fpow, fpow_add (ne_of_gt cpos), fpow_one, this, ← div_eq_inv_mul],
+    exact mul_le_mul_of_nonneg_right hn.1 (norm_nonneg _) }
+end
 
 instance : normed_space α (E × F) :=
 { norm_smul :=
@@ -485,6 +538,9 @@ instance : normed_field ℂ :=
   dist_eq := λ _ _, rfl,
   norm_mul := complex.abs_mul,
   .. complex.discrete_field }
+
+instance : nondiscrete_normed_field ℂ :=
+{ non_trivial := ⟨2, by simp [norm]; norm_num⟩ }
 
 @[simp] lemma norm_real (r : ℝ) : ∥(r : ℂ)∥ = ∥r∥ := complex.abs_of_real _
 

--- a/src/analysis/normed_space/bounded_linear_maps.lean
+++ b/src/analysis/normed_space/bounded_linear_maps.lean
@@ -118,33 +118,37 @@ end
 
 end is_bounded_linear_map
 
--- Next lemma is stated for real normed space but it would work as soon as the base field is an extension of ℝ
-lemma bounded_continuous_linear_map
-  {E : Type*} [normed_space ℝ E] {F : Type*} [normed_space ℝ F] {L : E → F}
-  (lin : is_linear_map ℝ L) (cont : continuous L) : is_bounded_linear_map ℝ L :=
-let ⟨δ, δ_pos, hδ⟩ := exists_delta_of_continuous cont zero_lt_one 0 in
-have HL0 : L 0 = 0, from (lin.mk' _).map_zero,
-have H : ∀{a}, ∥a∥ ≤ δ → ∥L a∥ < 1, by simpa only [HL0, dist_zero_right] using hδ,
-lin.with_bound (δ⁻¹) $ assume x,
-classical.by_cases (assume : x = 0, by simp only [this, HL0, norm_zero, mul_zero]) $
-assume h : x ≠ 0,
-let p := ∥x∥ * δ⁻¹, q := p⁻¹ in
-have p_inv : p⁻¹ = δ*∥x∥⁻¹, by simp,
+set_option class.instance_max_depth 35
 
-have norm_x_pos : ∥x∥ > 0 := (norm_pos_iff x).2 h,
-have norm_x : ∥x∥ ≠ 0 := mt (norm_eq_zero x).1 h,
-
-have p_pos : p > 0 := mul_pos norm_x_pos (inv_pos δ_pos),
-have p0 : _ := ne_of_gt p_pos,
-have q_pos : q > 0 := inv_pos p_pos,
-have q0 : _ := ne_of_gt q_pos,
-
-have ∥p⁻¹ • x∥ = δ := calc
-  ∥p⁻¹ • x∥ = abs p⁻¹ * ∥x∥ : by rw norm_smul; refl
-  ... = p⁻¹ * ∥x∥ : by rw [abs_of_nonneg $ le_of_lt q_pos]
-  ... = δ : by simp [mul_assoc, inv_mul_cancel norm_x],
-
-calc ∥L x∥ = (p * q) * ∥L x∥ : begin dsimp [q], rw [mul_inv_cancel p0, one_mul] end
-  ... = p * ∥L (q • x)∥ : by simp [lin.smul, norm_smul, real.norm_eq_abs, abs_of_pos q_pos, mul_assoc]
-  ... ≤ p * 1 : mul_le_mul_of_nonneg_left (le_of_lt $ H $ le_of_eq $ this) (le_of_lt p_pos)
-  ... = δ⁻¹ * ∥x∥ : by rw [mul_one, mul_comm]
+/-- A continuous linear map between normed spaces is bounded when the field is nondiscrete.
+The continuity ensures boundedness on a ball of some radius δ. The nondiscreteness is then
+used to rescale any element into an element of norm in [δ/C, δ], whose image has a controlled norm.
+The norm control for the original element follows by rescaling. -/
+theorem is_linear_map.bounded_of_continuous_at {k : Type*} [nondiscrete_normed_field k]
+  {E : Type*} [normed_space k E] {F : Type*} [normed_space k F] {L : E → F} {x₀ : E}
+  (lin : is_linear_map k L) (cont : continuous_at L x₀) : is_bounded_linear_map k L :=
+begin
+  rcases tendsto_nhds_nhds.1 cont 1 zero_lt_one with ⟨ε, ε_pos, hε⟩,
+  let δ := ε/2,
+  have δ_pos : δ > 0 := half_pos ε_pos,
+  have H : ∀{a}, ∥a∥ ≤ δ → ∥L a∥ ≤ 1,
+  { assume a ha,
+    have : dist (L (x₀+a)) (L x₀) ≤ 1,
+    { apply le_of_lt (hε _),
+      have : dist x₀ (x₀ + a) = ∥a∥, by { rw dist_eq_norm, simp },
+      rw [dist_comm, this],
+      exact lt_of_le_of_lt ha (half_lt_self ε_pos) },
+    simpa [dist_eq_norm, lin.add] using this },
+  rcases exists_one_lt_norm k with ⟨c, hc⟩,
+  refine lin.with_bound (δ⁻¹ * ∥c∥) (λx, _),
+  by_cases h : x = 0,
+  { simp only [h, lin.map_zero, norm_zero, mul_zero] },
+  { rcases rescale_to_shell hc δ_pos h with ⟨d, hd, dxle, ledx, dinv⟩,
+    calc ∥L x∥
+      = ∥L ((d⁻¹ * d) • x)∥ : by rwa [inv_mul_cancel, one_smul]
+      ... = ∥d∥⁻¹ * ∥L (d • x)∥ :
+        by rw [mul_smul, lin.smul, norm_smul, norm_inv]
+      ... ≤ ∥d∥⁻¹ * 1 :
+        mul_le_mul_of_nonneg_left (H dxle) (by { rw ← norm_inv, exact norm_nonneg _ })
+      ... ≤ δ⁻¹ * ∥c∥ * ∥x∥ : by { rw mul_one, exact dinv } }
+end

--- a/src/data/padics/padic_numbers.lean
+++ b/src/data/padics/padic_numbers.lean
@@ -393,8 +393,6 @@ begin
   { simpa using ih }
 end
 
-example {α} [discrete_field α] (n : ℤ) : α := n
-
 -- without short circuits, this needs an increase of class.instance_max_depth
 @[simp] lemma cast_eq_of_rat_of_int (n : ℤ) : ↑n = of_rat p n :=
 by induction n; simp
@@ -689,6 +687,18 @@ end
 
 @[simp] lemma eq_padic_norm (q : ℚ) : ∥padic.of_rat p q∥ = padic_norm p q :=
 by unfold has_norm.norm; congr; apply padic_seq.norm_const
+
+instance : nondiscrete_normed_field ℚ_[p] :=
+{ non_trivial := ⟨padic.of_rat p (p⁻¹), begin
+    have : 1 < p := prime.gt_one hp,
+    have : p ≠ 0 := ne_of_gt (hp.pos),
+    simp only [padic_norm, padic_val_rat.inv, *, inv_eq_zero, if_false, ne.def, nat.cast_eq_zero,
+      not_false_iff, neg_neg, padic_norm_e.eq_padic_norm, padic_val_rat.padic_val_rat_self,
+      nat.cast_ne_zero],
+    erw _root_.pow_one,
+    simp only [rat.cast_coe_nat],
+    rwa [← cast_one, cast_lt]
+  end⟩ }
 
 protected theorem image {q : ℚ_[p]} : q ≠ 0 → ∃ n : ℤ, ∥q∥ = ↑((↑p : ℚ) ^ (-n)) :=
 quotient.induction_on q $ λ f hf,


### PR DESCRIPTION
The fact that a continuous linear map is bounded is currently only stated over the real numbers. The proper setting is that of a nondiscrete normed field, i.e., a normed field with an element of norm different from 1. This PR introduces this typeclass and proves the general boundedness statement for continuous linear map. It also adds some missing bits on normed fields (for instance, complex numbers were not registered as a normed field).

All the PRs this was depending on have been merged, so this should be ready for merging. I have streamlined the proof that continuity implies boundedness, extracting a lemma `rescale_to_shell` that is also useful to prove the Banach open mapping theorem.