### PR TITLE
feat(tactic/local_cache): add tactic-block-local caching mechanism

### DIFF
--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -31,6 +31,13 @@ prod.fst $ pop_nth_prefix_aux nm n
 meta def pop_prefix (n : name) : name :=
 pop_nth_prefix n 1
 
+private def from_components_aux : name → list string → name
+| n [] := n
+| n (s :: rest) := from_components_aux (name.mk_string s n) rest
+
+def from_components (l : list string) : name :=
+from_components_aux name.anonymous l
+
 -- `name`s can contain numeral pieces, which are not legal names
 -- when typed/passed directly to the parser. We turn an arbitrary
 -- name into a legal identifier name.

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -35,8 +35,8 @@ private def from_components_aux : name → list string → name
 | n [] := n
 | n (s :: rest) := from_components_aux (name.mk_string s n) rest
 
-def from_components (l : list string) : name :=
-from_components_aux name.anonymous l
+def from_components : list string → name :=
+from_components_aux name.anonymous
 
 -- `name`s can contain numeral pieces, which are not legal names
 -- when typed/passed directly to the parser. We turn an arbitrary

--- a/src/tactic/basic.lean
+++ b/src/tactic/basic.lean
@@ -144,7 +144,7 @@ mk_app ``id [e] >>= eval_expr α
 -- useful source of random names provided by `mk_fresh_name` into
 -- names which are usable by tactic programs.
 --
--- The returned name has four components.
+-- The returned name has four components which are all strings.
 meta def mk_user_fresh_name : tactic name :=
 do nm ← mk_fresh_name,
    return $ `user__ ++ nm.pop_prefix.sanitize_name ++ `user__

--- a/src/tactic/local_cache.lean
+++ b/src/tactic/local_cache.lean
@@ -1,0 +1,65 @@
+import tactic.basic
+
+namespace tactic
+namespace local_cache
+
+section internal
+
+variables {α : Type} [reflected α] [has_reflect α]
+
+meta def mk_full_namespace (ns : name) : name := `local_cache ++ ns
+
+meta def get_data_name (ns : name) : tactic name :=
+do o ← tactic.get_options,
+   let opt := mk_full_namespace ns,
+   match o.get_string opt "" with
+   | "" := do n ← mk_user_fresh_name,
+              tactic.set_options $ o.set_string opt n.to_string,
+              return n
+   | s := return $ name.from_components $ s.split (λ c, c = '.')
+   end
+
+meta def save_data (dn : name) (a : α) [reflected a] : tactic unit :=
+tactic.add_decl $ mk_definition dn [] (reflect α) (reflect a)
+
+meta def load_data (dn : name) : tactic α :=
+do e ← tactic.get_env,
+   d ← e.get dn,
+   tactic.eval_expr α d.value
+
+end internal
+
+-- Asks whether the namespace `ns` currently has a value-in-cache
+meta def present (ns : name) : tactic bool :=
+do o ← tactic.get_options,
+   match o.get_string (mk_full_namespace ns) "" with
+   | "" := return ff
+   | s  := return tt
+   end
+
+-- Clear cache associated to namespace `ns`
+meta def clear (ns : name) : tactic unit :=
+do o ← tactic.get_options,
+   set_options $ o.set_string (mk_full_namespace ns) ""
+
+end local_cache
+
+open local_cache
+
+-- Using the namespace `ns` as its key, when called for the first
+-- time `calculate_once ns t` runs `t`, saves and returns the result.
+-- Upon subsequent invocations in the same `environment` (usually
+-- just in the same tactic block) return the cached result.
+--
+-- If `α` is just `unit`, this means we just run `t` once each tactic
+-- block.
+meta def run_once {α : Type} [reflected α] [has_reflect α] (ns : name) (t : tactic α) : tactic α :=
+do dn ← get_data_name ns,
+   load_data dn <|>
+   do {
+     a ← t,
+     save_data dn a,
+     return a
+   }
+
+end tactic

--- a/src/tactic/local_cache.lean
+++ b/src/tactic/local_cache.lean
@@ -1,5 +1,4 @@
-import tactic.basic
-import init.data.nat.bitwise
+import tactic.basic tactic.norm_num
 
 namespace tactic
 namespace local_cache
@@ -88,7 +87,7 @@ section fnv_a1
 
 def FNV_OFFSET_BASIS := 0xcbf29ce484222325
 def FNV_PRIME := 0x100000001b3
-def RADIX := 2^64
+def RADIX := by apply_normed 2^64
 
 def hash_byte (seed : ℕ) (c : char) : ℕ :=
 let n : ℕ := c.to_nat in ((seed.lxor n) * FNV_PRIME) % RADIX
@@ -101,7 +100,7 @@ end fnv_a1
 meta def hash_context : tactic string :=
 do ns ← open_namespaces,
    dn ← decl_name,
-   let flat := ((dn :: ns).map to_string).foldl string.append "",
+   let flat := ((list.cons dn ns).map to_string).foldl string.append "",
    return $ (to_string dn) ++ (to_string (hash_string flat))
 
 meta def get_root_name (ns : name) : tactic name :=

--- a/src/tactic/local_cache.lean
+++ b/src/tactic/local_cache.lean
@@ -9,15 +9,26 @@ variables {α : Type} [reflected α] [has_reflect α]
 
 meta def mk_full_namespace (ns : name) : name := `local_cache ++ ns
 
-meta def get_data_name (ns : name) : tactic name :=
+-- `mk_new` gives a way to generate a new name if no current one
+-- exists.
+meta def get_data_name_aux (ns : name) (mk_new : options → name → tactic name) : tactic name :=
 do o ← tactic.get_options,
    let opt := mk_full_namespace ns,
    match o.get_string opt "" with
-   | "" := do n ← mk_user_fresh_name,
-              tactic.set_options $ o.set_string opt n.to_string,
-              return n
+   | "" := mk_new o opt
    | s := return $ name.from_components $ s.split (λ c, c = '.')
    end
+
+meta def get_data_name (ns : name) : tactic name :=
+get_data_name_aux ns $ λ o opt,
+do n ← mk_user_fresh_name,
+   tactic.set_options $ o.set_string opt n.to_string,
+   return n
+
+-- Like `get_data_name`, but fail if `ns` does not have a cached
+-- decl name (we create a new one above).
+meta def try_get_data_name (ns : name) : tactic name :=
+get_data_name_aux ns $ λ o opt, fail format!"no cache for \"{ns}\""
 
 meta def save_data (dn : name) (a : α) [reflected a] : tactic unit :=
 tactic.add_decl $ mk_definition dn [] (reflect α) (reflect a)
@@ -42,15 +53,27 @@ meta def clear (ns : name) : tactic unit :=
 do o ← tactic.get_options,
    set_options $ o.set_string (mk_full_namespace ns) ""
 
+-- Gets the (optionally present) value-in-cache for `ns`
+meta def get (ns : name) (α : Type) [reflected α] [has_reflect α] : tactic (option α) :=
+do dn ← some <$> try_get_data_name ns <|> return none,
+   match dn with
+   | none := return none
+   | some dn := some <$> load_data dn
+   end
+-- Note: we can't just use `<|>` on `load_data` since it will fail
+-- when a cached value is not present *as well as* when the type of
+-- `α` is just wrong.
+
 end local_cache
 
 open local_cache
 
 -- Using the namespace `ns` as its key, when called for the first
 -- time `run_once ns t` runs `t`, then saves and returns the result.
--- Upon subsequent invocations in the same `environment` (usually
--- just in the same tactic block, with the scope of the caching being
--- inherited by child tactic blocks) we return the cached result directly.
+-- Upon subsequent invocations with the same `tactic.get_options` state
+-- (usually just in the same tactic block, with the scope of the caching
+-- being inherited by child tactic blocks) we return the cached result
+-- directly.
 --
 -- If `α` is just `unit`, this means we just run `t` once each tactic
 -- block.

--- a/src/tactic/local_cache.lean
+++ b/src/tactic/local_cache.lean
@@ -1,4 +1,5 @@
 import tactic.basic
+import init.data.nat.bitwise
 
 namespace tactic
 namespace local_cache
@@ -9,27 +10,6 @@ variables {α : Type} [reflected α] [has_reflect α]
 
 meta def mk_full_namespace (ns : name) : name := `local_cache ++ ns
 
--- `mk_new` gives a way to generate a new name if no current one
--- exists.
-meta def get_data_name_aux (ns : name) (mk_new : options → name → tactic name) : tactic name :=
-do o ← tactic.get_options,
-   let opt := mk_full_namespace ns,
-   match o.get_string opt "" with
-   | "" := mk_new o opt
-   | s := return $ name.from_components $ s.split (λ c, c = '.')
-   end
-
-meta def get_data_name (ns : name) : tactic name :=
-get_data_name_aux ns $ λ o opt,
-do n ← mk_user_fresh_name,
-   tactic.set_options $ o.set_string opt n.to_string,
-   return n
-
--- Like `get_data_name`, but fail if `ns` does not have a cached
--- decl name (we create a new one above).
-meta def try_get_data_name (ns : name) : tactic name :=
-get_data_name_aux ns $ λ o opt, fail format!"no cache for \"{ns}\""
-
 meta def save_data (dn : name) (a : α) [reflected a] : tactic unit :=
 tactic.add_decl $ mk_definition dn [] (reflect α) (reflect a)
 
@@ -38,9 +18,58 @@ do e ← tactic.get_env,
    d ← e.get dn,
    tactic.eval_expr α d.value
 
+meta def poke_data (dn : name) : tactic bool :=
+do e ← tactic.get_env,
+   return (e.get dn).to_bool
+
+meta def run_once_under_name {α : Type} [reflected α] [has_reflect α] (t : tactic α) (cache_name : name) : tactic α :=
+do load_data cache_name <|>
+   do {
+     a ← t,
+     save_data cache_name a,
+     return a
+   }
+
 end internal
 
+-- We maintain two separate caches with different scopes:
+-- one local to `begin ... end` or `by` blocks, and another
+-- for entire `def`/`lemma`s.
+meta structure cache_scope :=
+-- Returns the name of the def used to store the contents of is cache,
+-- making a new one and recording this in private state if neccesary.
+(get_name : name → tactic name)
+-- Same as above but fails instead of making a new name, and never
+-- mutates state.
+(try_get_name : name → tactic name)
 -- Asks whether the namespace `ns` currently has a value-in-cache
+(present : name → tactic bool)
+-- Clear cache associated to namespace `ns`
+(clear : name → tactic unit)
+
+namespace block_local
+
+-- `mk_new` gives a way to generate a new name if no current one
+-- exists.
+private meta def get_name_aux (ns : name) (mk_new : options → name → tactic name) : tactic name :=
+do o ← tactic.get_options,
+   let opt := mk_full_namespace ns,
+   match o.get_string opt "" with
+   | "" := mk_new o opt
+   | s := return $ name.from_components $ s.split (λ c, c = '.')
+   end
+
+meta def get_name (ns : name) : tactic name :=
+get_name_aux ns $ λ o opt,
+do n ← mk_user_fresh_name,
+   tactic.set_options $ o.set_string opt n.to_string,
+   return n
+
+-- Like `get_name`, but fail if `ns` does not have a cached
+-- decl name (we create a new one above).
+meta def try_get_name (ns : name) : tactic name :=
+get_name_aux ns $ λ o opt, fail format!"no cache for \"{ns}\""
+
 meta def present (ns : name) : tactic bool :=
 do o ← tactic.get_options,
    match o.get_string (mk_full_namespace ns) "" with
@@ -48,14 +77,110 @@ do o ← tactic.get_options,
    | s  := return tt
    end
 
--- Clear cache associated to namespace `ns`
 meta def clear (ns : name) : tactic unit :=
 do o ← tactic.get_options,
    set_options $ o.set_string (mk_full_namespace ns) ""
 
+end block_local
+
+namespace def_local
+
+-- Fowler–Noll–Vo hash function (FNV-1a)
+section fnv_a1
+
+def FNV_OFFSET_BASIS := 0xcbf29ce484222325
+def FNV_PRIME := 0x100000001b3
+def RADIX := 0xFFFFFFFFFFFFFFFF + 1 -- 64-bits
+
+def hash_byte (seed : ℕ) (c : char) : ℕ :=
+let n : ℕ := c.to_nat in ((seed.lxor n) * FNV_PRIME) % RADIX
+
+def hash_string (s : string) : ℕ :=
+s.to_list.foldl hash_byte FNV_OFFSET_BASIS
+
+end fnv_a1
+
+meta def hash_context : tactic string :=
+do ns ← open_namespaces,
+   dn ← decl_name,
+   let flat := ((dn :: ns).map to_string).foldl string.append "",
+   return $ (to_string dn) ++ (to_string (hash_string flat))
+
+meta def get_root_name (ns : name) : tactic name :=
+do hc ← hash_context,
+   return $ mk_full_namespace $ hc ++ ns
+
+meta def apply_tag (n : name) (tag : ℕ) : name := n ++ to_string format!"t{tag}"
+
+meta def mk_dead_name (n : name) : name := n ++ `dead
+
+meta def kill_name (n : name) : tactic unit :=
+save_data (mk_dead_name n) ()
+
+meta def is_name_dead (n : name) : tactic bool :=
+do { witness : unit ← load_data $ mk_dead_name n, return true }
+<|> return false
+
+-- `get_with_status_tag_aux rn n` fails exactly when `rn ++ to_string n` does
+-- not exist.
+private meta def get_with_status_tag_aux (rn : name) : ℕ → tactic (ℕ × bool)
+| tag := do let n := apply_tag rn tag,
+            present ← poke_data n,
+            if ¬present then fail format!"{rn} never seen in cache!"
+            else do is_dead ← is_name_dead n,
+                    if is_dead then get_with_status_tag_aux (tag + 1)
+                                    <|> return (tag, false)
+                    else return (tag, true)
+
+-- Find the latest tag for the name `rn` and report whether it is alive.
+meta def get_tag_with_status (rn : name) : tactic (ℕ × bool) :=
+get_with_status_tag_aux rn 0
+
+meta def get_name (ns : name) : tactic name :=
+do rn ← get_root_name ns,
+   (tag, alive) ← get_tag_with_status rn <|> return (0, true),
+   return $ apply_tag rn $ if alive then tag
+                           else tag + 1
+
+meta def try_get_name (ns : name) : tactic name :=
+do rn ← get_root_name ns,
+   (tag, alive) ← get_tag_with_status rn,
+   if alive then return $ apply_tag rn tag
+   else fail format!"no cache for \"{ns}\""
+
+meta def present (ns : name) : tactic bool :=
+do rn ← get_root_name ns,
+   (prod.snd <$> get_tag_with_status rn) <|> return false
+
+meta def clear (ns : name) : tactic unit :=
+do { n ← try_get_name ns, kill_name n }
+<|> skip
+
+end def_local
+
+meta def cache_scope.block_local : cache_scope :=
+⟨ block_local.get_name,
+  block_local.try_get_name,
+  block_local.present,
+  block_local.clear ⟩
+
+meta def cache_scope.def_local : cache_scope :=
+⟨ def_local.get_name,
+  def_local.try_get_name,
+  def_local.present,
+  def_local.clear ⟩
+
+open cache_scope
+
+meta def present (ns : name) (s : cache_scope := block_local) : tactic bool :=
+s.present ns
+
+meta def clear (ns : name) (s : cache_scope := block_local) : tactic unit :=
+s.clear ns
+
 -- Gets the (optionally present) value-in-cache for `ns`
-meta def get (ns : name) (α : Type) [reflected α] [has_reflect α] : tactic (option α) :=
-do dn ← some <$> try_get_data_name ns <|> return none,
+meta def get (ns : name) (α : Type) [reflected α] [has_reflect α] (s : cache_scope := block_local) : tactic (option α) :=
+do dn ← some <$> s.try_get_name ns <|> return none,
    match dn with
    | none := return none
    | some dn := some <$> load_data dn
@@ -70,20 +195,17 @@ open local_cache
 
 -- Using the namespace `ns` as its key, when called for the first
 -- time `run_once ns t` runs `t`, then saves and returns the result.
--- Upon subsequent invocations with the same `tactic.get_options` state
--- (usually just in the same tactic block, with the scope of the caching
--- being inherited by child tactic blocks) we return the cached result
--- directly.
+-- Upon subsequent invocations in the same tactic block, with the scope
+-- of the caching being inherited by child tactic blocks) we return the
+-- cached result directly.
+--
+-- You can configure the cached scope to be entire `def`/`lemma`s chaning
+-- the optional cache_scope argument to `cache_scope.def_local`.
+-- Note: the caches backing each scope are different.
 --
 -- If `α` is just `unit`, this means we just run `t` once each tactic
 -- block.
-meta def run_once {α : Type} [reflected α] [has_reflect α] (ns : name) (t : tactic α) : tactic α :=
-do dn ← get_data_name ns,
-   load_data dn <|>
-   do {
-     a ← t,
-     save_data dn a,
-     return a
-   }
+meta def run_once {α : Type} [reflected α] [has_reflect α] (ns : name) (t : tactic α) (s : cache_scope := cache_scope.block_local) : tactic α :=
+s.get_name ns >>= run_once_under_name t
 
 end tactic

--- a/src/tactic/local_cache.lean
+++ b/src/tactic/local_cache.lean
@@ -56,7 +56,7 @@ do o ← tactic.get_options,
    let opt := mk_full_namespace ns,
    match o.get_string opt "" with
    | "" := mk_new o opt
-   | s := return $ name.from_components $ s.split (λ c, c = '.')
+   | s := return $ name.from_components $ s.split (= '.')
    end
 
 meta def get_name (ns : name) : tactic name :=

--- a/src/tactic/local_cache.lean
+++ b/src/tactic/local_cache.lean
@@ -47,9 +47,10 @@ end local_cache
 open local_cache
 
 -- Using the namespace `ns` as its key, when called for the first
--- time `calculate_once ns t` runs `t`, saves and returns the result.
+-- time `run_once ns t` runs `t`, then saves and returns the result.
 -- Upon subsequent invocations in the same `environment` (usually
--- just in the same tactic block) return the cached result.
+-- just in the same tactic block, with the scope of the caching being
+-- inherited by child tactic blocks) we return the cached result directly.
 --
 -- If `α` is just `unit`, this means we just run `t` once each tactic
 -- block.

--- a/test/local_cache.lean
+++ b/test/local_cache.lean
@@ -1,0 +1,67 @@
+import tactic.local_cache
+
+open tactic
+
+section example_tactic
+
+def TEST_NS : name := `my_tactic
+
+-- Example "expensive" function
+meta def generate_some_data : tactic (list ℕ) :=
+do trace "cache regenerating",
+   return [1, 2, 3, 4]
+
+meta def my_tactic : tactic unit :=
+do my_cached_data ← run_once TEST_NS generate_some_data,
+   -- Do some stuff with `my_cached_data`
+   skip
+
+end example_tactic
+
+
+
+section example_usage
+
+-- Note only a single cache regeneration (only a single trace message),
+-- even upon descent to a sub-tactic-block.
+lemma my_lemma : true := begin
+    my_tactic,
+    my_tactic,
+    my_tactic,
+
+    have h : true,
+    { my_tactic,
+      trivial },
+
+    trivial
+end
+
+end example_usage
+
+section test
+
+meta def fail_if_cache_miss : tactic unit :=
+do p ← local_cache.present TEST_NS,
+   if p then skip else fail "cache miss"
+
+meta def clear_cache : tactic unit := local_cache.clear TEST_NS
+
+lemma my_test : true := begin
+    success_if_fail { fail_if_cache_miss },
+
+    my_tactic,
+
+    fail_if_cache_miss,
+    fail_if_cache_miss,
+
+    have h : true,
+    { fail_if_cache_miss,
+      trivial },
+
+    clear_cache,
+    success_if_fail { fail_if_cache_miss },
+
+    trivial
+end
+
+end test

--- a/test/local_cache.lean
+++ b/test/local_cache.lean
@@ -4,7 +4,8 @@ open tactic
 
 section example_tactic
 
-def TEST_NS : name := `my_tactic
+def TEST_NS_1 : name := `my_tactic
+def TEST_NS_2 : name := `my_other_tactic
 
 -- Example "expensive" function
 meta def generate_some_data : tactic (list ℕ) :=
@@ -12,9 +13,12 @@ do trace "cache regenerating",
    return [1, 2, 3, 4]
 
 meta def my_tactic : tactic unit :=
-do my_cached_data ← run_once TEST_NS generate_some_data,
+do my_cached_data ← run_once TEST_NS_1 generate_some_data,
    -- Do some stuff with `my_cached_data`
    skip
+
+meta def my_other_tactic : tactic unit :=
+run_once TEST_NS_2 (return [10, 20, 30, 40]) >> skip
 
 end example_tactic
 
@@ -40,28 +44,125 @@ end example_usage
 
 section test
 
-meta def fail_if_cache_miss : tactic unit :=
-do p ← local_cache.present TEST_NS,
+meta def fail_if_cache_miss (ns : name) : tactic unit :=
+do p ← local_cache.present ns,
    if p then skip else fail "cache miss"
 
-meta def clear_cache : tactic unit := local_cache.clear TEST_NS
+meta def fail_if_cache_miss_1 : tactic unit :=
+fail_if_cache_miss TEST_NS_1
 
-lemma my_test : true := begin
-    success_if_fail { fail_if_cache_miss },
-
-    my_tactic,
-
-    fail_if_cache_miss,
-    fail_if_cache_miss,
-
-    have h : true,
-    { fail_if_cache_miss,
-      trivial },
-
-    clear_cache,
-    success_if_fail { fail_if_cache_miss },
-
-    trivial
-end
+meta def fail_if_cache_miss_2 : tactic unit :=
+fail_if_cache_miss TEST_NS_2
 
 end test
+
+-- Test: the cache is reliably persistent, decends to sub-blocks,
+-- the api to inspect whether a cache entry is present works, and
+-- the cache can be manually cleared.
+section test_persistence
+
+lemma my_test_ps : true := begin
+  success_if_fail { fail_if_cache_miss_1 },
+
+  my_tactic,
+
+  fail_if_cache_miss_1,
+  fail_if_cache_miss_1,
+  success_if_fail { fail_if_cache_miss_2 },
+
+  have h : true,
+  { fail_if_cache_miss_1,
+    trivial },
+
+  -- Manually clear cache
+  local_cache.clear TEST_NS_1,
+  success_if_fail { fail_if_cache_miss_1 },
+
+  trivial
+end
+
+end test_persistence
+
+-- Test: caching under different namespaces doesn't share the
+-- cached state.
+section test_ns_collison
+
+lemma my_test_ns : true := begin
+  my_tactic,
+  fail_if_cache_miss_1,
+  success_if_fail { fail_if_cache_miss_2 },
+
+  my_other_tactic,
+  fail_if_cache_miss_1,
+  fail_if_cache_miss_2,
+
+  local_cache.clear TEST_NS_1,
+  success_if_fail { fail_if_cache_miss_1 },
+  fail_if_cache_miss_2,
+
+  my_other_tactic,
+  success_if_fail { fail_if_cache_miss_1 },
+  fail_if_cache_miss_2,
+
+  trivial
+end
+
+end test_ns_collison
+
+-- Test: cached results don't leak between `def`s or `lemma`s.
+section test_locality
+
+def my_def_1 : true := begin
+  success_if_fail { fail_if_cache_miss_1 },
+  my_tactic,
+  fail_if_cache_miss_1,
+
+  trivial
+end
+
+def my_def_2 : true := begin
+  success_if_fail { fail_if_cache_miss_1 },
+  my_tactic,
+  fail_if_cache_miss_1,
+
+  trivial
+end
+
+lemma my_lemma_1 : true := begin
+  success_if_fail { fail_if_cache_miss_1 },
+  my_tactic,
+  fail_if_cache_miss_1,
+
+  trivial
+end
+
+lemma my_lemma_2 : true := begin
+  success_if_fail { fail_if_cache_miss_1 },
+  my_tactic,
+  fail_if_cache_miss_1,
+
+  trivial
+end
+
+end test_locality
+
+-- Test: the `local_cache.get` function.
+section test_get
+
+meta def assert_equal {α : Type} [decidable_eq α] (a : α) (ta : tactic α) : tactic unit :=
+do a' ← ta,
+   if a = a' then skip
+             else fail "not equal!"
+
+lemma my_lemma_3 : true := begin
+  assert_equal none (local_cache.get TEST_NS_1 (list ℕ)),
+
+  my_tactic,
+  my_other_tactic,
+  assert_equal (some [1,2,3,4]) (local_cache.get TEST_NS_1 (list ℕ)),
+  assert_equal (some [10, 20, 30, 40]) (local_cache.get TEST_NS_2 (list ℕ)),
+
+  trivial
+end
+
+end test_get

--- a/test/local_cache.lean
+++ b/test/local_cache.lean
@@ -2,6 +2,8 @@ import tactic.local_cache
 
 open tactic
 
+namespace block_local
+
 section example_tactic
 
 def TEST_NS_1 : name := `my_tactic
@@ -55,6 +57,46 @@ meta def fail_if_cache_miss_2 : tactic unit :=
 fail_if_cache_miss TEST_NS_2
 
 end test
+
+-- Test: the cache persists only within a single tactic block
+section test_scope
+
+structure dummy :=
+(a b : ℕ)
+
+def my_definition : dummy :=
+ ⟨ begin
+     my_tactic,
+     fail_if_cache_miss_1,
+     exact 1
+   end,
+   begin
+     success_if_fail { fail_if_cache_miss_1 },
+     exact 1
+   end, ⟩
+
+def my_definition' : dummy :=
+ ⟨ begin
+     success_if_fail { fail_if_cache_miss_1 },
+     exact 1
+   end,
+   begin
+     success_if_fail { fail_if_cache_miss_1 },
+     exact 1
+   end, ⟩
+
+lemma my_lemma' : dummy :=
+ ⟨ begin
+     my_tactic,
+     fail_if_cache_miss_1,
+     exact 1
+   end,
+   begin
+     success_if_fail { fail_if_cache_miss_1 },
+     exact 1
+   end, ⟩
+
+end test_scope
 
 -- Test: the cache is reliably persistent, decends to sub-blocks,
 -- the api to inspect whether a cache entry is present works, and
@@ -166,3 +208,294 @@ lemma my_lemma_3 : true := begin
 end
 
 end test_get
+
+end block_local
+
+
+
+---------------------------
+-- Now test again with the `def_local` scope.
+---------------------------
+
+
+namespace def_local
+
+open tactic.local_cache.cache_scope
+
+section example_tactic
+
+def TEST_NS_1 : name := `my_tactic
+def TEST_NS_2 : name := `my_other_tactic
+
+-- Example "expensive" function
+meta def generate_some_data : tactic (list ℕ) :=
+do trace "cache regenerating",
+   return [1, 2, 3, 4]
+
+meta def my_tactic : tactic unit :=
+do my_cached_data ← run_once TEST_NS_1 generate_some_data def_local,
+   -- Do some stuff with `my_cached_data`
+   skip
+
+meta def my_other_tactic : tactic unit :=
+run_once TEST_NS_2 (return [10, 20, 30, 40]) def_local >> skip
+
+end example_tactic
+
+
+
+section example_usage
+
+-- Note only a single cache regeneration (only a single trace message),
+-- even upon descent to a sub-tactic-block.
+lemma my_lemma : true := begin
+    my_tactic,
+    my_tactic,
+    my_tactic,
+
+    have h : true,
+    { my_tactic,
+      trivial },
+
+    trivial
+end
+
+end example_usage
+
+section test
+
+meta def fail_if_cache_miss (ns : name) : tactic unit :=
+do p ← local_cache.present ns def_local,
+   if p then skip else fail "cache miss"
+
+meta def fail_if_cache_miss_1 : tactic unit :=
+fail_if_cache_miss TEST_NS_1
+
+meta def fail_if_cache_miss_2 : tactic unit :=
+fail_if_cache_miss TEST_NS_2
+
+end test
+
+-- Test: the cache really does persist over a whole definition
+section test_scope
+
+structure dummy :=
+(a b : ℕ)
+
+def my_definition : dummy :=
+ ⟨ begin
+     my_tactic,
+     fail_if_cache_miss_1,
+     exact 1
+   end,
+   begin
+     fail_if_cache_miss_1,
+     exact 1
+   end, ⟩
+
+def my_definition' : dummy :=
+ ⟨ begin
+     success_if_fail { fail_if_cache_miss_1 },
+     exact 1
+   end,
+   begin
+     success_if_fail { fail_if_cache_miss_1 },
+     exact 1
+   end, ⟩
+
+lemma my_lemma' : dummy :=
+ ⟨ begin
+     my_tactic,
+     fail_if_cache_miss_1,
+     exact 1
+   end,
+   begin
+     fail_if_cache_miss_1,
+     exact 1
+   end, ⟩
+
+end test_scope
+
+-- Test: the cache is reliably persistent, decends to sub-blocks,
+-- the api to inspect whether a cache entry is present works, and
+-- the cache can be manually cleared.
+section test_persistence
+
+lemma my_test_ps : true := begin
+  success_if_fail { fail_if_cache_miss_1 },
+
+  my_tactic,
+  my_tactic,
+
+  fail_if_cache_miss_1,
+  fail_if_cache_miss_1,
+  success_if_fail { fail_if_cache_miss_2 },
+
+  have h : true,
+  { fail_if_cache_miss_1,
+    trivial },
+
+  -- Manually clear cache
+  local_cache.clear TEST_NS_1 def_local,
+  success_if_fail { fail_if_cache_miss_1 },
+
+  trivial
+end
+
+end test_persistence
+
+-- Test: caching under different namespaces doesn't share the
+-- cached state.
+section test_ns_collison
+
+lemma my_test_ns : true := begin
+  my_tactic,
+  fail_if_cache_miss_1,
+  success_if_fail { fail_if_cache_miss_2 },
+
+  my_other_tactic,
+  fail_if_cache_miss_1,
+  fail_if_cache_miss_2,
+
+  local_cache.clear TEST_NS_1 def_local,
+  success_if_fail { fail_if_cache_miss_1 },
+  fail_if_cache_miss_2,
+
+  my_other_tactic,
+  success_if_fail { fail_if_cache_miss_1 },
+  fail_if_cache_miss_2,
+
+  trivial
+end
+
+end test_ns_collison
+
+-- Test: cached results don't leak between `def`s or `lemma`s.
+section test_locality
+
+def my_def_1 : true := begin
+  success_if_fail { fail_if_cache_miss_1 },
+  my_tactic,
+  fail_if_cache_miss_1,
+
+  trivial
+end
+
+def my_def_2 : true := begin
+  success_if_fail { fail_if_cache_miss_1 },
+  my_tactic,
+  fail_if_cache_miss_1,
+
+  trivial
+end
+
+lemma my_lemma_1 : true := begin
+  success_if_fail { fail_if_cache_miss_1 },
+  my_tactic,
+  fail_if_cache_miss_1,
+
+  trivial
+end
+
+lemma my_lemma_2 : true := begin
+  success_if_fail { fail_if_cache_miss_1 },
+  my_tactic,
+  fail_if_cache_miss_1,
+
+  trivial
+end
+
+end test_locality
+
+-- Test: the `local_cache.get` function.
+section test_get
+
+meta def assert_equal {α : Type} [decidable_eq α] (a : α) (ta : tactic α) : tactic unit :=
+do a' ← ta,
+   if a = a' then skip
+             else fail "not equal!"
+
+lemma my_lemma_3 : true := begin
+  assert_equal none (local_cache.get TEST_NS_1 (list ℕ)),
+
+  my_tactic,
+  my_other_tactic,
+  assert_equal (some [1,2,3,4]) (local_cache.get TEST_NS_1 (list ℕ) def_local),
+  assert_equal (some [10, 20, 30, 40]) (local_cache.get TEST_NS_2 (list ℕ) def_local),
+
+  trivial
+end
+
+end test_get
+
+end def_local
+
+-- Finally, make sure the `block_local` and `def_local` caches
+-- don't collide.
+
+namespace collision
+
+open tactic.local_cache.cache_scope
+
+def TEST_NS : name := `my_tactic
+
+-- Example "expensive" function
+meta def generate_some_data : tactic (list ℕ) :=
+do trace "cache regenerating",
+   return [1, 2, 3, 4]
+
+meta def tac_block : tactic unit :=
+do my_cached_data ← run_once TEST_NS generate_some_data block_local,
+   skip
+
+meta def tac_def : tactic unit :=
+do my_cached_data ← run_once TEST_NS generate_some_data def_local,
+   skip
+
+meta def fail_if_cache_miss_def : tactic unit :=
+do p ← local_cache.present TEST_NS def_local,
+   if p then skip else fail "cache miss"
+
+meta def fail_if_cache_miss_block : tactic unit :=
+do p ← local_cache.present TEST_NS block_local,
+   if p then skip else fail "cache miss"
+
+lemma my_lemma_1 : true := begin
+  tac_block,
+  fail_if_cache_miss_block,
+  success_if_fail { fail_if_cache_miss_def },
+
+  trivial
+end
+
+lemma my_lemma_2 : true := begin
+  tac_def,
+  fail_if_cache_miss_def,
+  success_if_fail { fail_if_cache_miss_block },
+
+  trivial
+end
+
+lemma my_lemma_3 : true := begin
+  tac_block,
+  tac_def,
+
+  local_cache.clear TEST_NS block_local,
+  fail_if_cache_miss_def,
+  success_if_fail { fail_if_cache_miss_block },
+
+  trivial
+end
+
+lemma my_lemma_4 : true := begin
+  tac_block,
+  tac_def,
+
+  local_cache.clear TEST_NS def_local,
+  fail_if_cache_miss_block,
+  success_if_fail { fail_if_cache_miss_def },
+
+  trivial
+end
+
+end collision

--- a/test/local_cache.lean
+++ b/test/local_cache.lean
@@ -430,7 +430,7 @@ end test_get
 
 end def_local
 
--- Finally, make sure the `block_local` and `def_local` caches
+-- Test: finally, make sure the `block_local` and `def_local` caches
 -- don't collide.
 
 namespace collision


### PR DESCRIPTION
Add tactic-block-local caching mechanism. The main function is `tactic.run_once`, which does what it says on the tin---it runs the passed tactic the first time it is called per-tactic-block. If the passed tactic returns a value it caches that value for subsequent invocations and returns the value in the cache directly instead.

<br><br>

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
