### PR TITLE
feat(library_search): a simple library_search function

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -216,6 +216,21 @@ Unfold coercion-related definitions
 * `exactI`: Like `exact`, but uses all variables in the context
   for typeclass inference.
 
+### library_search
+
+`library_search` is a tactic to identify existing lemmas in the library. It tries to close the
+current goal by applying a lemma from the library, then discharging any new goals using
+`solve_by_elim`.
+
+Typical usage is:
+```
+example (n m k : ℕ) : n * (m - k) = n * m - n * k :=
+by library_search -- exact nat.mul_sub_left_distrib n m k
+```
+
+`library_search` prints a trace message showing the proof it found, shown above as a comment.
+Typically you will then copy and paste this proof, replacing the call to `library_search`.
+
 ### find
 
 The `find` command from `tactic.find` allows to find lemmas using

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -6,7 +6,7 @@ Authors: Mario Carneiro, Simon Hudon, Sebastien Gouezel, Scott Morrison
 import data.dlist data.dlist.basic data.prod category.basic
   tactic.basic tactic.rcases tactic.generalize_proofs
   tactic.split_ifs logic.basic tactic.ext tactic.tauto
-  tactic.replacer tactic.simpa tactic.squeeze
+  tactic.replacer tactic.simpa tactic.squeeze tactic.library_search
 
 open lean
 open lean.parser

--- a/src/tactic/library_search.lean
+++ b/src/tactic/library_search.lean
@@ -1,0 +1,147 @@
+-- Copyright (c) 2019 Scott Morrison. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Scott Morrison
+
+import tactic.basic
+import data.list.defs
+import data.option.basic
+
+/-
+A basic `library_search` tactic.
+-/
+
+namespace tactic
+open native
+
+namespace library_search
+
+meta def head_symbol : expr → name
+| (expr.pi _ _ _ t) := head_symbol t
+| (expr.app f _) := head_symbol f
+| (expr.const n _) :=
+  -- TODO this is a hack; if you suspect more cases here would help, please report them
+  match n with
+  | `gt := `has_lt.lt
+  | `ge := `has_le.le
+  | _   := n
+  end
+| _ := `_
+
+inductive head_symbol_match
+| ex | mp | mpr | both
+
+open head_symbol_match
+
+def head_symbol_match.to_string : head_symbol_match → string
+| ex   := "exact"
+| mp   := "iff.mp"
+| mpr  := "iff.mpr"
+| both := "iff.mp and iff.mpr"
+
+meta def unfold_head_symbol : name → list name
+| `false := [`not, `false]
+| n      := [n]
+
+meta def match_head_symbol (hs : name) : expr → option head_symbol_match
+| (expr.pi _ _ _ t) := match_head_symbol t
+| `(%%a ↔ %%b)      := if `iff = hs then some ex else
+                       match (match_head_symbol a, match_head_symbol b) with
+                       | (some ex, some ex) :=
+                           some both
+                       | (some ex, _) := some mpr
+                       | (_, some ex) := some mp
+                       | _ := none
+                       end
+| (expr.app f _)    := match_head_symbol f
+| (expr.const n _)  := if list.mem hs (unfold_head_symbol n) then some ex else none
+| _ := none
+
+meta structure decl_data :=
+(d : declaration)
+(n : name)
+(m : head_symbol_match)
+(l : ℕ) -- cached length of name
+
+-- We used to check here for private declarations, or declarations with certain suffixes.
+-- It turns out `apply` is so fast, it's better to just try them all.
+meta def process_declaration (hs : name) (d : declaration) : option decl_data :=
+let n := d.to_name in
+if ¬ d.is_trusted ∨ n.is_internal then
+  none
+else
+  (λ m, ⟨d, n, m, n.length⟩) <$> match_head_symbol hs d.type
+
+/-- Retrieve all library definitions with a given head symbol. -/
+meta def library_defs (hs : name) : tactic (list decl_data) :=
+do env ← get_env,
+   return $ env.decl_filter_map (process_declaration hs)
+
+meta def apply_and_solve (e : expr) :=
+apply e >> (done <|> solve_by_elim { all_goals := tt })
+
+meta def apply_declaration (d : decl_data) : tactic unit :=
+do e ← mk_const d.n,
+   let t := d.d.type,
+   match d.m with
+   | ex := apply_and_solve e
+   | mp :=
+      do l ← iff_mp_core e t,
+         apply_and_solve l
+   | mpr :=
+      do l ← iff_mpr_core e t,
+         apply_and_solve l
+   | both :=
+      do l ← iff_mp_core e t,
+         apply_and_solve l <|>
+         do l ← iff_mpr_core e t,
+            apply_and_solve l
+   end
+
+end library_search
+
+open library_search
+open library_search.head_symbol_match
+
+declare_trace silence_library_search -- Turn off `exact ...` trace message
+declare_trace library_search         -- Trace a list of all relevant lemmas
+
+meta def library_search : tactic string :=
+do [g] ← get_goals | fail "`library_search` should be called with exactly one goal",
+   t ← infer_type g,
+
+   -- Collect all definitions with the correct head symbol
+   defs ← library_defs (head_symbol t),
+   -- Sort by length; people like short proofs
+   let defs := defs.qsort(λ d₁ d₂, d₁.l ≤ d₂.l),
+   when (is_trace_enabled_for `library_search) $ (do
+     trace format!"Found {defs.length} relevant lemmas:",
+     trace $ defs.map (λ ⟨d, n, m, l⟩, (n, m.to_string))),
+   -- Try `apply` followed by `solve_by_elim`, for each definition.
+   defs.mfirst apply_declaration,
+
+   -- If something worked, prepare a string to print.
+   p ← instantiate_mvars g >>= head_beta >>= pp,
+   let r := format!"exact {p}",
+   when (¬ is_trace_enabled_for `silence_library_search) $ tactic.trace r,
+   return $ to_string r
+
+namespace interactive
+/--
+`library_search` attempts to apply every definition in the library whose head symbol
+matches the goal, and then discharge any new goals using `solve_by_elim`.
+
+If it succeeds, it prints a trace message `exact ...` which can replace the invocation
+of `library_search`.
+-/
+meta def library_search := tactic.library_search
+end interactive
+
+@[hole_command] meta def library_search_hole_cmd : hole_command :=
+{ name := "library_search",
+  descr := "Use `library_search` to complete the goal.",
+  action := λ _, do
+    script ← library_search,
+    -- Is there a better API for dropping the 'exact ' prefix on this string?
+    return [((script.mk_iterator.remove 6).to_string, "by library_search")] }
+
+end tactic

--- a/src/tactic/library_search.lean
+++ b/src/tactic/library_search.lean
@@ -4,7 +4,6 @@
 
 import tactic.basic
 import data.list.defs
-import data.option.basic
 
 /-
 A basic `library_search` tactic.

--- a/test/library_search/basic.lean
+++ b/test/library_search/basic.lean
@@ -49,6 +49,5 @@ by library_search -- says: `λ (a : Prop), (iff_not_self a).mp`
 example {a b c : ℕ} (h₁ : a ∣ c) (h₂ : a ∣ b + c) : a ∣ b :=
 by library_search -- says `exact (nat.dvd_add_left h₁).mp h₂`
 
-set_option trace.silence_library_search false
 example {a b c : ℕ} (h₁ : a ∣ b) (h₂ : a ∣ b + c) : a ∣ c :=
 by library_search -- says `exact (nat.dvd_add_left h₁).mp h₂`

--- a/test/library_search/basic.lean
+++ b/test/library_search/basic.lean
@@ -1,8 +1,10 @@
 import data.nat.basic
 import tactic.library_search
 
+-- Turn off trace messages so they don't pollute the test build:
 set_option trace.silence_library_search true
--- set_option trace.library_search true -- display the list of lemmas
+-- For debugging purposes, we can display the list of lemmas:
+-- set_option trace.library_search true
 
 -- Check that `library_search` fails if there are no goals.
 example : true :=
@@ -35,13 +37,18 @@ by library_search -- says: `exact add_pos`
 example (a b : ℕ) (h : a ∣ b) (w : b > 0) : a ≤ b :=
 by library_search -- says: `exact nat.le_of_dvd w h`
 
-example {b : ℕ} (w : b > 0) : b ≥ 1 :=
-by library_search -- says: `exact nat.succ_le_iff.mp w`
 
 -- We even find `iff` results:
+
+example {b : ℕ} (w : b > 0) : b ≥ 1 :=
+by library_search -- says: `exact nat.succ_le_iff.mpr w`
 
 example : ∀ P : Prop, ¬(P ↔ ¬P) :=
 by library_search -- says: `λ (a : Prop), (iff_not_self a).mp`
 
 example {a b c : ℕ} (h₁ : a ∣ c) (h₂ : a ∣ b + c) : a ∣ b :=
+by library_search -- says `exact (nat.dvd_add_left h₁).mp h₂`
+
+set_option trace.silence_library_search false
+example {a b c : ℕ} (h₁ : a ∣ b) (h₂ : a ∣ b + c) : a ∣ c :=
 by library_search -- says `exact (nat.dvd_add_left h₁).mp h₂`

--- a/test/library_search/basic.lean
+++ b/test/library_search/basic.lean
@@ -1,0 +1,47 @@
+import data.nat.basic
+import tactic.library_search
+
+set_option trace.silence_library_search true
+-- set_option trace.library_search true -- display the list of lemmas
+
+-- Check that `library_search` fails if there are no goals.
+example : true :=
+begin
+  trivial,
+  success_if_fail { library_search },
+end
+
+example (a b : ℕ) : a + b = b + a :=
+by library_search -- says: `exact add_comm a b`
+
+example {a b : ℕ} : a ≤ a + b :=
+by library_search -- says: `exact le_add_right a b`
+
+example (n m k : ℕ) : n * (m - k) = n * m - n * k :=
+by library_search -- says: `exact nat.mul_sub_left_distrib n m k`
+
+example {n m : ℕ} (h : m < n) : m ≤ n - 1 :=
+by library_search -- says: `exact nat.le_pred_of_lt h`
+
+example {α : Type} (x y : α) : x = y ↔ y = x :=
+by library_search -- says: `exact eq_comm`
+
+example (a b : ℕ) (ha : 0 < a) (hb : 0 < b) : 0 < a + b :=
+by library_search -- says: `exact add_pos ha hb`
+
+example (a b : ℕ) : 0 < a → 0 < b → 0 < a + b :=
+by library_search -- says: `exact add_pos`
+
+example (a b : ℕ) (h : a ∣ b) (w : b > 0) : a ≤ b :=
+by library_search -- says: `exact nat.le_of_dvd w h`
+
+example {b : ℕ} (w : b > 0) : b ≥ 1 :=
+by library_search -- says: `exact nat.succ_le_iff.mp w`
+
+-- We even find `iff` results:
+
+example : ∀ P : Prop, ¬(P ↔ ¬P) :=
+by library_search -- says: `λ (a : Prop), (iff_not_self a).mp`
+
+example {a b c : ℕ} (h₁ : a ∣ c) (h₂ : a ∣ b + c) : a ∣ b :=
+by library_search -- says `exact (nat.dvd_add_left h₁).mp h₂`

--- a/test/library_search/ring_theory.lean
+++ b/test/library_search/ring_theory.lean
@@ -1,0 +1,19 @@
+import tactic.library_search
+import ring_theory.principal_ideal_domain
+import ring_theory.polynomial
+
+set_option trace.silence_library_search true
+
+example {α : Type} [euclidean_domain α] {S : ideal α} {x y : α} (hy : y ∈ S) : x % y ∈ S ↔ x ∈ S :=
+by library_search -- exact mod_mem_iff hy
+
+variables {R : Type} [comm_ring R] [decidable_eq R]
+variables {I : ideal (polynomial R)}
+
+example {m n : ℕ} (H : m ≤ n) : I.leading_coeff_nth m ≤ I.leading_coeff_nth n :=
+by library_search -- exact ideal.leading_coeff_nth_mono I H
+
+open polynomial
+
+example (n : ℕ) (x) (h : ∃ p ∈ I, degree p ≤ n ∧ leading_coeff p = x) : x ∈ I.leading_coeff_nth n :=
+by library_search -- exact (ideal.mem_leading_coeff_nth I n x).mpr h

--- a/test/library_search/ring_theory.lean
+++ b/test/library_search/ring_theory.lean
@@ -12,8 +12,3 @@ variables {I : ideal (polynomial R)}
 
 example {m n : ℕ} (H : m ≤ n) : I.leading_coeff_nth m ≤ I.leading_coeff_nth n :=
 by library_search -- exact ideal.leading_coeff_nth_mono I H
-
-open polynomial
-
-example (n : ℕ) (x) (h : ∃ p ∈ I, degree p ≤ n ∧ leading_coeff p = x) : x ∈ I.leading_coeff_nth n :=
-by library_search -- exact (ideal.mem_leading_coeff_nth I n x).mpr h


### PR DESCRIPTION
I realised that one could write a very simple and straightforward `library_search`, that is already
useful enough to cover many cases. I hope this tactic will be helpful to newcomers, and everyone who
struggles to find lemmas.

Typical usage is:
```
example (n m k : ℕ) : n * (m - k) = n * m - n * k :=
by library_search -- exact nat.mul_sub_left_distrib n m k
```
(`library_search` prints a trace message showing the proof it found, shown here as a comment.)

This version simply goes through every lemma in the library that has the same 'head symbol' as the
goal, tries to apply it, and if that succeeds, checks that it can discharge all new goals using
`solve_by_elim`.

(There's one tweak: for `iff` lemmas, we also try applying the forwards and backwards directions.)
