### PR TITLE
refactor(analysis/normed_space/basic) Remove outparam in normed space

### DIFF
--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -330,7 +330,7 @@ by rw [real.norm_eq_abs, abs_of_nonneg (norm_nonneg _)]
 
 section normed_space
 
-class normed_space (α : out_param $ Type*) (β : Type*) [out_param $ normed_field α]
+class normed_space (α : Type*) (β : Type*) [normed_field α]
   extends normed_group β, vector_space α β :=
 (norm_smul : ∀ (a:α) b, norm (a • b) = has_norm.norm a * norm b)
 
@@ -413,15 +413,17 @@ instance fintype.normed_space {ι : Type*} {E : ι → Type*} [fintype ι] [∀i
   ..metric_space_pi,
   ..pi.vector_space α }
 
-/-- A normed space can be build from a norm that satisfies algebraic properties. This is formalised in this structure. -/
+/-- A normed space can be built from a norm that satisfies algebraic properties. This is
+formalised in this structure. -/
 structure normed_space.core (α : Type*) (β : Type*)
-  [out_param $ discrete_field α] [normed_field α] [add_comm_group β] [has_scalar α β] [has_norm β]:=
+  [normed_field α] [add_comm_group β] [has_scalar α β] [has_norm β] :=
 (norm_eq_zero_iff : ∀ x : β, ∥x∥ = 0 ↔ x = 0)
 (norm_smul : ∀ c : α, ∀ x : β, ∥c • x∥ = ∥c∥ * ∥x∥)
 (triangle : ∀ x y : β, ∥x + y∥ ≤ ∥x∥ + ∥y∥)
 
 noncomputable def normed_space.of_core (α : Type*) (β : Type*)
-  [normed_field α] [add_comm_group β] [vector_space α β] [has_norm β] (C : normed_space.core α β) : normed_space α β :=
+  [normed_field α] [add_comm_group β] [vector_space α β] [has_norm β]
+  (C : normed_space.core α β) : normed_space α β :=
 { dist := λ x y, ∥x - y∥,
   dist_eq := assume x y, by refl,
   dist_self := assume x, (C.norm_eq_zero_iff (x - x)).mpr (show x - x = 0, by simp),
@@ -432,8 +434,7 @@ noncomputable def normed_space.of_core (α : Type*) (β : Type*)
   dist_comm := assume x y,
     calc ∥x - y∥ = ∥ -(1 : α) • (y - x)∥ : by simp
              ... = ∥y - x∥ : begin rw[C.norm_smul], simp end,
-  norm_smul := C.norm_smul
-}
+  norm_smul := C.norm_smul }
 
 end normed_space
 

--- a/src/analysis/normed_space/bounded_linear_maps.lean
+++ b/src/analysis/normed_space/bounded_linear_maps.lean
@@ -28,7 +28,7 @@ variables {E : Type*} [normed_space k E]
 variables {F : Type*} [normed_space k F]
 variables {G : Type*} [normed_space k G]
 
-structure is_bounded_linear_map {k : Type*}
+structure is_bounded_linear_map (k : Type*)
   [normed_field k] {E : Type*} [normed_space k E] {F : Type*} [normed_space k F] (L : E → F)
   extends is_linear_map k L : Prop :=
 (bound : ∃ M, M > 0 ∧ ∀ x : E, ∥ L x ∥ ≤ M * ∥ x ∥)
@@ -37,7 +37,7 @@ include k
 
 lemma is_linear_map.with_bound
   {L : E → F} (hf : is_linear_map k L) (M : ℝ) (h : ∀ x : E, ∥ L x ∥ ≤ M * ∥ x ∥) :
-  is_bounded_linear_map L :=
+  is_bounded_linear_map k L :=
 ⟨ hf, classical.by_cases
   (assume : M ≤ 0, ⟨1, zero_lt_one, assume x,
     le_trans (h x) $ mul_le_mul_of_nonneg_right (le_trans this zero_le_one) (norm_nonneg x)⟩)
@@ -45,45 +45,46 @@ lemma is_linear_map.with_bound
 
 namespace is_bounded_linear_map
 
-def to_linear_map (f : E → F) (h : is_bounded_linear_map f) : E →ₗ[k] F :=
+def to_linear_map (f : E → F) (h : is_bounded_linear_map k f) : E →ₗ[k] F :=
 (is_linear_map.mk' _ h.to_is_linear_map)
 
-lemma zero : is_bounded_linear_map (λ (x:E), (0:F)) :=
+lemma zero : is_bounded_linear_map k (λ (x:E), (0:F)) :=
 (0 : E →ₗ F).is_linear.with_bound 0 $ by simp [le_refl]
 
-lemma id : is_bounded_linear_map (λ (x:E), x) :=
+lemma id : is_bounded_linear_map k (λ (x:E), x) :=
 linear_map.id.is_linear.with_bound 1 $ by simp [le_refl]
 
-lemma smul {f : E → F} (c : k) : is_bounded_linear_map f → is_bounded_linear_map (λ e, c • f e)
+set_option class.instance_max_depth 40
+lemma smul {f : E → F} (c : k) : is_bounded_linear_map k f → is_bounded_linear_map k (λ e, c • f e)
 | ⟨hf, ⟨M, hM, h⟩⟩ := (c • hf.mk' f).is_linear.with_bound (∥c∥ * M) $ assume x,
   calc ∥c • f x∥ = ∥c∥ * ∥f x∥ : norm_smul c (f x)
     ... ≤ ∥c∥ * (M * ∥x∥) : mul_le_mul_of_nonneg_left (h x) (norm_nonneg c)
     ... = (∥c∥ * M) * ∥x∥ : (mul_assoc _ _ _).symm
 
-lemma neg {f : E → F} (hf : is_bounded_linear_map f) : is_bounded_linear_map (λ e, -f e) :=
+lemma neg {f : E → F} (hf : is_bounded_linear_map k f) : is_bounded_linear_map k (λ e, -f e) :=
 begin
   rw show (λ e, -f e) = (λ e, (-1 : k) • f e), { funext, simp },
   exact smul (-1) hf
 end
 
 lemma add {f : E → F} {g : E → F} :
-  is_bounded_linear_map f → is_bounded_linear_map g → is_bounded_linear_map (λ e, f e + g e)
+  is_bounded_linear_map k f → is_bounded_linear_map k g → is_bounded_linear_map k (λ e, f e + g e)
 | ⟨hlf, Mf, hMf, hf⟩  ⟨hlg, Mg, hMg, hg⟩ := (hlf.mk' _ + hlg.mk' _).is_linear.with_bound (Mf + Mg) $ assume x,
   calc ∥f x + g x∥ ≤ ∥f x∥ + ∥g x∥ : norm_triangle _ _
     ... ≤ Mf * ∥x∥ + Mg * ∥x∥ : add_le_add (hf x) (hg x)
     ... ≤ (Mf + Mg) * ∥x∥ : by rw add_mul
 
-lemma sub {f : E → F} {g : E → F} (hf : is_bounded_linear_map f) (hg : is_bounded_linear_map g) :
-  is_bounded_linear_map (λ e, f e - g e) := add hf (neg hg)
+lemma sub {f : E → F} {g : E → F} (hf : is_bounded_linear_map k f) (hg : is_bounded_linear_map k g) :
+  is_bounded_linear_map k (λ e, f e - g e) := add hf (neg hg)
 
 lemma comp {f : E → F} {g : F → G} :
-  is_bounded_linear_map g → is_bounded_linear_map f → is_bounded_linear_map (g ∘ f)
+  is_bounded_linear_map k g → is_bounded_linear_map k f → is_bounded_linear_map k (g ∘ f)
 | ⟨hlg, Mg, hMg, hg⟩ ⟨hlf, Mf, hMf, hf⟩ := ((hlg.mk' _).comp (hlf.mk' _)).is_linear.with_bound (Mg * Mf) $ assume x,
   calc ∥g (f x)∥ ≤ Mg * ∥f x∥ : hg _
     ... ≤ Mg * (Mf * ∥x∥) : mul_le_mul_of_nonneg_left (hf _) (le_of_lt hMg)
     ... = Mg * Mf * ∥x∥ : (mul_assoc _ _ _).symm
 
-lemma tendsto {L : E → F} (x : E) : is_bounded_linear_map L → L →_{x} (L x)
+lemma tendsto {L : E → F} (x : E) : is_bounded_linear_map k L → L →_{x} (L x)
 | ⟨hL, M, hM, h_ineq⟩ := tendsto_iff_norm_tendsto_zero.2 $
   squeeze_zero (assume e, norm_nonneg _)
     (assume e, calc ∥L e - L x∥ = ∥hL.mk' L (e - x)∥ : by rw (hL.mk' _).map_sub e x; refl
@@ -91,25 +92,25 @@ lemma tendsto {L : E → F} (x : E) : is_bounded_linear_map L → L →_{x} (L x
     (suffices (λ (e : E), M * ∥e - x∥) →_{x} (M * 0), by simpa,
       tendsto_mul tendsto_const_nhds (lim_norm _))
 
-lemma continuous {L : E → F} (hL : is_bounded_linear_map L) : continuous L :=
+lemma continuous {L : E → F} (hL : is_bounded_linear_map k L) : continuous L :=
 continuous_iff_continuous_at.2 $ assume x, hL.tendsto x
 
-lemma lim_zero_bounded_linear_map {L : E → F} (H : is_bounded_linear_map L) : (L →_{0} 0) :=
+lemma lim_zero_bounded_linear_map {L : E → F} (H : is_bounded_linear_map k L) : (L →_{0} 0) :=
 (H.1.mk' _).map_zero ▸ continuous_iff_continuous_at.1 H.continuous 0
 
 section
 open asymptotics filter
 
-theorem is_O_id {L : E → F} (h : is_bounded_linear_map L) (l : filter E) :
+theorem is_O_id {L : E → F} (h : is_bounded_linear_map k L) (l : filter E) :
   is_O L (λ x, x) l :=
 let ⟨M, Mpos, hM⟩ := h.bound in
 ⟨M, Mpos, mem_sets_of_superset univ_mem_sets (λ x _, hM x)⟩
 
-theorem is_O_comp {L : F → G} (h : is_bounded_linear_map L)
+theorem is_O_comp {L : F → G} (h : is_bounded_linear_map k L)
   {f : E → F} (l : filter E) : is_O (λ x', L (f x')) f l :=
 ((h.is_O_id ⊤).comp _).mono (map_le_iff_le_comap.mp lattice.le_top)
 
-theorem is_O_sub {L : E → F} (h : is_bounded_linear_map L) (l : filter E) (x : E) :
+theorem is_O_sub {L : E → F} (h : is_bounded_linear_map k L) (l : filter E) (x : E) :
   is_O (λ x', L (x' - x)) (λ x', x' - x) l :=
 is_O_comp h l
 
@@ -120,7 +121,7 @@ end is_bounded_linear_map
 -- Next lemma is stated for real normed space but it would work as soon as the base field is an extension of ℝ
 lemma bounded_continuous_linear_map
   {E : Type*} [normed_space ℝ E] {F : Type*} [normed_space ℝ F] {L : E → F}
-  (lin : is_linear_map ℝ L) (cont : continuous L) : is_bounded_linear_map L :=
+  (lin : is_linear_map ℝ L) (cont : continuous L) : is_bounded_linear_map ℝ L :=
 let ⟨δ, δ_pos, hδ⟩ := exists_delta_of_continuous cont zero_lt_one 0 in
 have HL0 : L 0 = 0, from (lin.mk' _).map_zero,
 have H : ∀{a}, ∥a∥ ≤ δ → ∥L a∥ < 1, by simpa only [HL0, dist_zero_right] using hδ,

--- a/src/analysis/normed_space/deriv.lean
+++ b/src/analysis/normed_space/deriv.lean
@@ -22,37 +22,39 @@ open filter asymptotics
 
 section
 
-variables {K : Type*} [normed_field K]
+variables (K : Type*) [normed_field K]
 variables {E : Type*} [normed_space K E]
 variables {F : Type*} [normed_space K F]
 variables {G : Type*} [normed_space K G]
 include K
 
 def has_fderiv_at_filter (f : E → F) (f' : E → F) (x : E) (L : filter E) :=
-is_bounded_linear_map f' ∧
+is_bounded_linear_map K f' ∧
   is_o (λ x', f x' - f x - f' (x' - x)) (λ x', x' - x) L
 
 def has_fderiv_at_within (f : E → F) (f' : E → F) (x : E) (s : set E) :=
-has_fderiv_at_filter f f' x (nhds_within x s)
+has_fderiv_at_filter K f f' x (nhds_within x s)
 
 def has_fderiv_at (f : E → F) (f' : E → F) (x : E) :=
-has_fderiv_at_filter f f' x (nhds x)
+has_fderiv_at_filter K f f' x (nhds x)
+
+variables {K}
 
 theorem has_fderiv_at_filter.is_o {f : E → F} {f' : E → F} {x L}
-  (h : has_fderiv_at_filter f f' x L) :
+  (h : has_fderiv_at_filter K f f' x L) :
   is_o (λ x', f x' - f x - f' (x' - x)) (λ x', x' - x) L :=
 h.right
 
-theorem has_fderiv_at.is_o {f : E → F} {f' : E → F} {x : E} (h : has_fderiv_at f f' x) :
+theorem has_fderiv_at.is_o {f : E → F} {f' : E → F} {x : E} (h : has_fderiv_at K f f' x) :
   is_o (λ x', f x' - f x - f' (x' - x)) (λ x', x' - x) (nhds x) :=
 h.is_o
 
 theorem has_fderiv_at_filter_iff_tendsto {f : E → F} {f' : E → F} {x : E} {L : filter E} :
-  has_fderiv_at_filter f f' x L ↔
-    is_bounded_linear_map f' ∧
+  has_fderiv_at_filter K f f' x L ↔
+    is_bounded_linear_map K f' ∧
       tendsto (λ x', ∥x' - x∥⁻¹ * ∥f x' - f x - f' (x' - x)∥) L (nhds 0) :=
 and.congr_right_iff.mpr $
-  assume bf' : is_bounded_linear_map f',
+  assume bf' : is_bounded_linear_map K f',
   have f'0 : f' 0 = 0 := (bf'.to_linear_map _).map_zero,
   have h : ∀ x', ∥x' - x∥ = 0 → ∥f x' - f x - f' (x' - x)∥ = 0, from
     assume x' hx',
@@ -64,36 +66,36 @@ and.congr_right_iff.mpr $
   end
 
 theorem has_fderiv_at_within_iff_tendsto {f : E → F} {f' : E → F} {x : E} {s : set E} :
-  has_fderiv_at_within f f' x s ↔
-    is_bounded_linear_map f' ∧
+  has_fderiv_at_within K f f' x s ↔
+    is_bounded_linear_map K f' ∧
       tendsto (λ x', ∥x' - x∥⁻¹ * ∥f x' - f x - f' (x' - x)∥) (nhds_within x s) (nhds 0) :=
 has_fderiv_at_filter_iff_tendsto
 
 theorem has_fderiv_at_iff_tendsto {f : E → F} {f' : E → F} {x : E} :
-  has_fderiv_at f f' x ↔
-    is_bounded_linear_map f' ∧
+  has_fderiv_at K f f' x ↔
+    is_bounded_linear_map K f' ∧
       tendsto (λ x', ∥x' - x∥⁻¹ * ∥f x' - f x - f' (x' - x)∥) (nhds x) (nhds 0) :=
 has_fderiv_at_filter_iff_tendsto
 
 theorem has_fderiv_at_filter.mono {f : E → F} {f' : E → F} {x : E} {L₁ L₂ : filter E}
-  (hst : L₁ ≤ L₂) : has_fderiv_at_filter f f' x L₂ → has_fderiv_at_filter f f' x L₁ :=
+  (hst : L₁ ≤ L₂) : has_fderiv_at_filter K f f' x L₂ → has_fderiv_at_filter K f f' x L₁ :=
 and.imp_right (is_o.mono hst)
 
 theorem has_fderiv_at_within.mono {f : E → F} {f' : E → F} {x : E} {s t : set E}
-  (hst : s ⊆ t) : has_fderiv_at_within f f' x t → has_fderiv_at_within f f' x s :=
+  (hst : s ⊆ t) : has_fderiv_at_within K f f' x t → has_fderiv_at_within K f f' x s :=
 has_fderiv_at_filter.mono (nhds_within_mono _ hst)
 
 theorem has_fderiv_at_filter_of_has_fderiv_at {f : E → F} {f' : E → F} {x : E}
-  {L : filter E} (hL : L ≤ nhds x) (h : has_fderiv_at f f' x) : has_fderiv_at_filter f f' x L :=
+  {L : filter E} (hL : L ≤ nhds x) (h : has_fderiv_at K f f' x) : has_fderiv_at_filter K f f' x L :=
 h.mono hL
 
 theorem has_fderiv_at_within_of_has_fderiv_at {f : E → F} {f' : E → F} {x : E} {s : set E} :
-  has_fderiv_at f f' x → has_fderiv_at_within f f' x s :=
+  has_fderiv_at K f f' x → has_fderiv_at_within K f f' x s :=
 has_fderiv_at_filter_of_has_fderiv_at lattice.inf_le_left
 
 theorem has_fderiv_at_filter_congr' {f₀ f₁ : E → F} {f₀' f₁' : E → F} {x : E} {L : filter E}
   (hx : f₀ x = f₁ x) (h₀ : {x | f₀ x = f₁ x} ∈ L) (h₁ : ∀ x, f₀' x = f₁' x) :
-  has_fderiv_at_filter f₀ f₀' x L ↔ has_fderiv_at_filter f₁ f₁' x L :=
+  has_fderiv_at_filter K f₀ f₀' x L ↔ has_fderiv_at_filter K f₁ f₁' x L :=
 by rw (funext h₁ : f₀' = f₁'); exact
 and_congr_right (λ _, is_o_congr
   (by filter_upwards [h₀] λ x' (h:_=_), by simp [h, hx])
@@ -101,122 +103,122 @@ and_congr_right (λ _, is_o_congr
 
 theorem has_fderiv_at_filter_congr {f₀ f₁ : E → F} {f₀' f₁' : E → F} {x : E} {L : filter E}
   (h₀ : ∀ x, f₀ x = f₁ x) (h₁ : ∀ x, f₀' x = f₁' x) :
-  has_fderiv_at_filter f₀ f₀' x L ↔ has_fderiv_at_filter f₁ f₁' x L :=
+  has_fderiv_at_filter K f₀ f₀' x L ↔ has_fderiv_at_filter K f₁ f₁' x L :=
 has_fderiv_at_filter_congr' (h₀ _) (univ_mem_sets' h₀) h₁
 
 theorem has_fderiv_at_filter.congr {f₀ f₁ : E → F} {f₀' f₁' : E → F} {x : E} {L : filter E}
   (h₀ : ∀ x, f₀ x = f₁ x) (h₁ : ∀ x, f₀' x = f₁' x) :
-  has_fderiv_at_filter f₀ f₀' x L → has_fderiv_at_filter f₁ f₁' x L :=
+  has_fderiv_at_filter K f₀ f₀' x L → has_fderiv_at_filter K f₁ f₁' x L :=
 (has_fderiv_at_filter_congr h₀ h₁).1
 
 theorem has_fderiv_at_within_congr {f₀ f₁ : E → F} {f₀' f₁' : E → F} {x : E} {s : set E}
   (h₀ : ∀ x, f₀ x = f₁ x) (h₁ : ∀ x, f₀' x = f₁' x) :
-  has_fderiv_at_within f₀ f₀' x s ↔ has_fderiv_at_within f₁ f₁' x s :=
+  has_fderiv_at_within K f₀ f₀' x s ↔ has_fderiv_at_within K f₁ f₁' x s :=
 has_fderiv_at_filter_congr h₀ h₁
 
 theorem has_fderiv_at_within.congr {f₀ f₁ : E → F} {f₀' f₁' : E → F} {x : E} {s : set E}
   (h₀ : ∀ x, f₀ x = f₁ x) (h₁ : ∀ x, f₀' x = f₁' x) :
-  has_fderiv_at_within f₀ f₀' x s → has_fderiv_at_within f₁ f₁' x s :=
+  has_fderiv_at_within K f₀ f₀' x s → has_fderiv_at_within K f₁ f₁' x s :=
 (has_fderiv_at_within_congr h₀ h₁).1
 
 theorem has_fderiv_at_congr {f₀ f₁ : E → F} {f₀' f₁' : E → F} {x : E}
   (h₀ : ∀ x, f₀ x = f₁ x) (h₁ : ∀ x, f₀' x = f₁' x) :
-  has_fderiv_at f₀ f₀' x ↔ has_fderiv_at f₁ f₁' x :=
+  has_fderiv_at K f₀ f₀' x ↔ has_fderiv_at K f₁ f₁' x :=
 has_fderiv_at_filter_congr h₀ h₁
 
 theorem has_fderiv_at.congr {f₀ f₁ : E → F} {f₀' f₁' : E → F} {x : E}
   (h₀ : ∀ x, f₀ x = f₁ x) (h₁ : ∀ x, f₀' x = f₁' x) :
-  has_fderiv_at f₀ f₀' x → has_fderiv_at f₁ f₁' x :=
+  has_fderiv_at K f₀ f₀' x → has_fderiv_at K f₁ f₁' x :=
 (has_fderiv_at_congr h₀ h₁).1
 
-theorem has_fderiv_at_filter_id (x : E) (L : filter E) : has_fderiv_at_filter id id x L :=
+theorem has_fderiv_at_filter_id (x : E) (L : filter E) : has_fderiv_at_filter K id id x L :=
 ⟨is_bounded_linear_map.id, (is_o_zero _ _).congr_left (by simp)⟩
 
-theorem has_fderiv_at_within_id (x : E) (s : set E) : has_fderiv_at_within id id x s :=
+theorem has_fderiv_at_within_id (x : E) (s : set E) : has_fderiv_at_within K id id x s :=
 has_fderiv_at_filter_id _ _
 
-theorem has_fderiv_at_id (x : E) : has_fderiv_at id id x :=
+theorem has_fderiv_at_id (x : E) : has_fderiv_at K id id x :=
 has_fderiv_at_filter_id _ _
 
 theorem has_fderiv_at_filter_const (c : F) (x : E) (L : filter E) :
-  has_fderiv_at_filter (λ x, c) (λ y, 0) x L :=
+  has_fderiv_at_filter K (λ x, c) (λ y, 0) x L :=
 ⟨is_bounded_linear_map.zero, (is_o_zero _ _).congr_left (by simp)⟩
 
 theorem has_fderiv_at_within_const (c : F) (x : E) (s : set E) :
-  has_fderiv_at_within (λ x, c) (λ y, 0) x s :=
+  has_fderiv_at_within K (λ x, c) (λ y, 0) x s :=
 has_fderiv_at_filter_const _ _ _
 
 theorem has_fderiv_at_const (c : F) (x : E) :
-  has_fderiv_at (λ x, c) (λ y, 0) x :=
+  has_fderiv_at K (λ x, c) (λ y, 0) x :=
 has_fderiv_at_filter_const _ _ _
 
 theorem has_fderiv_at_filter_smul {f : E → F} {f' : E → F} {x : E} {L : filter E}
-    (c : K) (h : has_fderiv_at_filter f f' x L) :
-  has_fderiv_at_filter (λ x, c • f x) (λ x, c • f' x) x L :=
+    (c : K) (h : has_fderiv_at_filter K f f' x L) :
+  has_fderiv_at_filter K (λ x, c • f x) (λ x, c • f' x) x L :=
 ⟨is_bounded_linear_map.smul c h.left,
   (is_o_const_smul_left h.right c).congr_left $
   λ x, by simp [smul_neg, smul_add]⟩
 
 theorem has_fderiv_at_within_smul {f : E → F} {f' : E → F} {x : E} {s : set E}
-    (c : K) : has_fderiv_at_within f f' x s →
-  has_fderiv_at_within (λ x, c • f x) (λ x, c • f' x) x s :=
+    (c : K) : has_fderiv_at_within K f f' x s →
+  has_fderiv_at_within K (λ x, c • f x) (λ x, c • f' x) x s :=
 has_fderiv_at_filter_smul _
 
 theorem has_fderiv_at_smul {f : E → F} {f' : E → F} {x : E}
-    (c : K) : has_fderiv_at f f' x →
-  has_fderiv_at (λ x, c • f x) (λ x, c • f' x) x :=
+    (c : K) : has_fderiv_at K f f' x →
+  has_fderiv_at K (λ x, c • f x) (λ x, c • f' x) x :=
 has_fderiv_at_filter_smul _
 
 theorem has_fderiv_at_filter_add {f g : E → F} {f' g' : E → F} {x : E} {L : filter E}
-  (hf : has_fderiv_at_filter f f' x L) (hg : has_fderiv_at_filter g g' x L) :
-  has_fderiv_at_filter (λ x, f x + g x) (λ x, f' x + g' x) x L :=
+  (hf : has_fderiv_at_filter K f f' x L) (hg : has_fderiv_at_filter K g g' x L) :
+  has_fderiv_at_filter K (λ x, f x + g x) (λ x, f' x + g' x) x L :=
 ⟨is_bounded_linear_map.add hf.left hg.left,
   (hf.right.add hg.right).congr_left (by simp)⟩
 
 theorem has_fderiv_at_within_add {f g : E → F} {f' g' : E → F} {x : E} {s : set E} :
-  has_fderiv_at_within f f' x s → has_fderiv_at_within g g' x s →
-  has_fderiv_at_within (λ x, f x + g x) (λ x, f' x + g' x) x s :=
+  has_fderiv_at_within K f f' x s → has_fderiv_at_within K g g' x s →
+  has_fderiv_at_within K (λ x, f x + g x) (λ x, f' x + g' x) x s :=
 has_fderiv_at_filter_add
 
 theorem has_fderiv_at_add {f g : E → F} {f' g' : E → F} {x : E} :
-  has_fderiv_at f f' x → has_fderiv_at g g' x →
-  has_fderiv_at (λ x, f x + g x) (λ x, f' x + g' x) x :=
+  has_fderiv_at K f f' x → has_fderiv_at K g g' x →
+  has_fderiv_at K (λ x, f x + g x) (λ x, f' x + g' x) x :=
 has_fderiv_at_filter_add
 
 theorem has_fderiv_at_filter_neg {f : E → F} {f' : E → F} {x : E} {L : filter E}
-  (h : has_fderiv_at_filter f f' x L) :
-  has_fderiv_at_filter (λ x, -f x) (λ x, -f' x) x L :=
+  (h : has_fderiv_at_filter K f f' x L) :
+  has_fderiv_at_filter K (λ x, -f x) (λ x, -f' x) x L :=
 (has_fderiv_at_filter_smul (-1 : K) h).congr (by simp) (by simp)
 
 theorem has_fderiv_at_within_neg {f : E → F} {f' : E → F} {x : E} {s : set E} :
-  has_fderiv_at_within f f' x s → has_fderiv_at_within (λ x, -f x) (λ x, -f' x) x s :=
+  has_fderiv_at_within K f f' x s → has_fderiv_at_within K (λ x, -f x) (λ x, -f' x) x s :=
 has_fderiv_at_filter_neg
 
 theorem has_fderiv_at_neg {f : E → F} {f' : E → F} {x : E} :
-  has_fderiv_at f f' x → has_fderiv_at (λ x, -f x) (λ x, -f' x) x :=
+  has_fderiv_at K f f' x → has_fderiv_at K (λ x, -f x) (λ x, -f' x) x :=
 has_fderiv_at_filter_neg
 
 theorem has_fderiv_at_filter_sub {f g : E → F} {f' g' : E → F} {x : E} {L : filter E}
-  (hf : has_fderiv_at_filter f f' x L) (hg : has_fderiv_at_filter g g' x L) :
-  has_fderiv_at_filter (λ x, f x - g x) (λ x, f' x - g' x) x L :=
+  (hf : has_fderiv_at_filter K f f' x L) (hg : has_fderiv_at_filter K g g' x L) :
+  has_fderiv_at_filter K (λ x, f x - g x) (λ x, f' x - g' x) x L :=
 has_fderiv_at_filter_add hf (has_fderiv_at_filter_neg hg)
 
 theorem has_fderiv_at_within_sub {f g : E → F} {f' g' : E → F} {x : E} {s : set E} :
-  has_fderiv_at_within f f' x s → has_fderiv_at_within g g' x s →
-  has_fderiv_at_within (λ x, f x - g x) (λ x, f' x - g' x) x s :=
+  has_fderiv_at_within K f f' x s → has_fderiv_at_within K g g' x s →
+  has_fderiv_at_within K (λ x, f x - g x) (λ x, f' x - g' x) x s :=
 has_fderiv_at_filter_sub
 
 theorem has_fderiv_at_sub {f g : E → F} {f' g' : E → F} {x : E} :
-  has_fderiv_at f f' x → has_fderiv_at g g' x →
-  has_fderiv_at (λ x, f x - g x) (λ x, f' x - g' x) x :=
+  has_fderiv_at K f f' x → has_fderiv_at K g g' x →
+  has_fderiv_at K (λ x, f x - g x) (λ x, f' x - g' x) x :=
 has_fderiv_at_filter_sub
 
 theorem has_fderiv_at_filter.is_O_sub {f : E → F} {f' : E → F} {x : E} {L : filter E}
-  (h : has_fderiv_at_filter f f' x L) : is_O (λ x', f x' - f x) (λ x', x' - x) L :=
+  (h : has_fderiv_at_filter K f f' x L) : is_O (λ x', f x' - f x) (λ x', x' - x) L :=
 h.2.to_is_O.congr_of_sub.2 (h.1.is_O_sub _ _)
 
 theorem has_fderiv_at_filter.tendsto_nhds {f : E → F} {f' : E → F} {x : E} {L : filter E}
-  (hL : L ≤ nhds x) (h : has_fderiv_at_filter f f' x L) : tendsto f L (nhds (f x)) :=
+  (hL : L ≤ nhds x) (h : has_fderiv_at_filter K f f' x L) : tendsto f L (nhds (f x)) :=
 begin
   have : tendsto (λ x', f x' - f x) L (nhds 0),
   { refine h.is_O_sub.trans_tendsto (tendsto_le_left hL _),
@@ -227,17 +229,17 @@ begin
 end
 
 theorem has_fderiv_at_within.continuous_at_within {f : E → F} {f' : E → F} {x : E} {s : set E} :
-  has_fderiv_at_within f f' x s → continuous_at_within f x s :=
+  has_fderiv_at_within K f f' x s → continuous_at_within f x s :=
 has_fderiv_at_filter.tendsto_nhds lattice.inf_le_left
 
 theorem has_fderiv_at.continuous_at {f : E → F} {f' : E → F} {x : E} :
-  has_fderiv_at f f' x → continuous_at f x :=
+  has_fderiv_at K f f' x → continuous_at f x :=
 has_fderiv_at_filter.tendsto_nhds (le_refl _)
 
 theorem has_fderiv_at_filter.comp {g g' : F → G} {f f' : E → F} {L : filter E} {x : E}
-  (hf : has_fderiv_at_filter f f' x L)
-  (hg : has_fderiv_at_filter g g' (f x) (L.map f)) :
-  has_fderiv_at_filter (g ∘ f) (g' ∘ f') x L :=
+  (hf : has_fderiv_at_filter K f f' x L)
+  (hg : has_fderiv_at_filter K g g' (f x) (L.map f)) :
+  has_fderiv_at_filter K (g ∘ f) (g' ∘ f') x L :=
 ⟨hg.1.comp hf.1, begin
   have eq₁ := (hg.1.is_O_comp _).trans_is_o hf.2,
   have eq₂ := ((hg.2.comp f).mono le_comap_map).trans_is_O hf.is_O_sub,
@@ -248,9 +250,9 @@ end⟩
 /- A readable version of the previous theorem, a general form of the chain rule. -/
 
 example {g g' : F → G} {f f' : E → F} {L : filter E} {x : E}
-  (hf : has_fderiv_at_filter f f' x L)
-  (hg : has_fderiv_at_filter g g' (f x) (L.map f)) :
-  has_fderiv_at_filter (g ∘ f) (g' ∘ f') x L :=
+  (hf : has_fderiv_at_filter K f f' x L)
+  (hg : has_fderiv_at_filter K g g' (f x) (L.map f)) :
+  has_fderiv_at_filter K (g ∘ f) (g' ∘ f') x L :=
 ⟨hg.1.comp hf.1,
 begin
   have : is_o (λ x', g (f x') - g (f x) - g' (f x' - f x)) (λ x', f x' - f x) L,
@@ -270,16 +272,16 @@ begin
 end⟩
 
 theorem has_fderiv_at_within.comp {g g' : F → G} {f f' : E → F} {s : set E} {x : E}
-  (hf : has_fderiv_at_within f f' x s)
-  (hg : has_fderiv_at_within g g' (f x) (f '' s)) :
-  has_fderiv_at_within (g ∘ f) (g' ∘ f') x s :=
+  (hf : has_fderiv_at_within K f f' x s)
+  (hg : has_fderiv_at_within K g g' (f x) (f '' s)) :
+  has_fderiv_at_within K (g ∘ f) (g' ∘ f') x s :=
 hf.comp (has_fderiv_at_filter.mono
   hf.continuous_at_within.tendsto_nhds_within_image hg)
 
 /-- The chain rule. -/
 theorem has_fderiv_at.comp {g g' : F → G} {f f' : E → F} {x : E}
-  (hf : has_fderiv_at f f' x) (hg : has_fderiv_at g g' (f x)) :
-  has_fderiv_at (g ∘ f) (g' ∘ f') x :=
+  (hf : has_fderiv_at K f f' x) (hg : has_fderiv_at K g g' (f x)) :
+  has_fderiv_at K (g ∘ f) (g' ∘ f') x :=
 hf.comp (hg.mono hf.continuous_at)
 
 end
@@ -296,7 +298,7 @@ variables {F : Type*} [normed_space ℝ F]
 variables {G : Type*} [normed_space ℝ G]
 
 theorem has_fderiv_at_filter_real_equiv {f : E → F} {f' : E → F} {x : E} {L : filter E}
-    (bf' : is_bounded_linear_map f') :
+    (bf' : is_bounded_linear_map ℝ f') :
   tendsto (λ x' : E, ∥x' - x∥⁻¹ * ∥f x' - f x - f' (x' - x)∥) L (nhds 0) ↔
   tendsto (λ x' : E, ∥x' - x∥⁻¹ • (f x' - f x - f' (x' - x))) L (nhds 0) :=
 begin

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -27,12 +27,12 @@ variables [hnfk : normed_field k] [normed_space k E] [normed_space k F]
 include hnfk
 
 def bounded_linear_maps : subspace k (E → F) :=
-{ carrier := {A : E → F | is_bounded_linear_map A},
+{ carrier := {A : E → F | is_bounded_linear_map k A},
   zero := is_bounded_linear_map.zero,
   add := assume A B, is_bounded_linear_map.add,
   smul := assume c A, is_bounded_linear_map.smul c }
 
-local notation `L(` E `,` F `)` := @bounded_linear_maps _ E F _ _ _
+local notation `L(` E `,` F `)` := @bounded_linear_maps k E F _ _ _
 
 /-- Coerce bounded linear maps to functions. -/
 instance bounded_linear_maps.to_fun : has_coe_to_fun $ L(E,F) :=
@@ -69,7 +69,7 @@ section operator_norm
 variables [normed_space ℝ E] [normed_space ℝ F]
 open lattice set
 
-local notation `L(` E `,` F `)` := @bounded_linear_maps _ E F _ _ _
+local notation `L(` E `,` F `)` := @bounded_linear_maps ℝ E F _ _ _
 
 noncomputable def to_linear_map (A : L(E, F)) : linear_map _ E F :=
 {to_fun := A.val, ..A.property}


### PR DESCRIPTION
There are still outparams in the definition of `normed_space`, probably forgotten in the module refactor. A consequence is that `is_bounded_linear_maps` and `has_fderiv` have been defined without mentioning explicitely the field of scalars. This makes it impossible to distinguish R-bounded linear maps and C-bounded linear maps on a complex vector space, or to distinguish between the real derivative and the complex derivative.

We remove the outparam in the definition, and add the field of scalars where necessary.

This PR conflicts with virtually all my recent PRs, I guess, but I think this one should be merged first (and if possible rapidly, otherwise conflicts will show up again quickly) and then I will rebase the other PRs.