### PR TITLE
feat(algebra/module): every abelian group is a Z-module

### DIFF
--- a/src/algebra/module.lean
+++ b/src/algebra/module.lean
@@ -320,3 +320,34 @@ theorem smul_mem_iff (r0 : r ≠ 0) : r • x ∈ p ↔ x ∈ p :=
  p.smul_mem r⟩
 
 end submodule
+
+namespace add_comm_monoid
+open add_monoid
+
+variables {M : Type*} [add_comm_monoid M]
+
+instance : semimodule ℕ M :=
+{ smul := smul,
+  smul_add := λ _ _ _, smul_add _ _ _,
+  add_smul := λ _ _ _, add_smul _ _ _,
+  mul_smul := λ _ _ _, mul_smul _ _ _,
+  one_smul := one_smul,
+  zero_smul := zero_smul,
+  smul_zero := smul_zero }
+
+end add_comm_monoid
+
+namespace add_comm_group
+
+variables {M : Type*} [add_comm_group M]
+
+instance : module ℤ M :=
+{ smul := gsmul,
+  smul_add := λ _ _ _, gsmul_add _ _ _,
+  add_smul := λ _ _ _, add_gsmul _ _ _,
+  mul_smul := λ _ _ _, gsmul_mul _ _ _,
+  one_smul := one_gsmul,
+  zero_smul := zero_gsmul,
+  smul_zero := gsmul_zero }
+
+end add_comm_group


### PR DESCRIPTION
This doesn't seem to create any problems. I think it's quite a useful thing to have, and I hope it makes @kckennylau happy (-;

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
