### PR TITLE
More about rpow and fpow

### DIFF
--- a/src/algebra/field.lean
+++ b/src/algebra/field.lean
@@ -32,6 +32,9 @@ def mk0 (a : α) (ha : a ≠ 0) : units α :=
 
 @[simp] theorem mk0_inv (ha : a ≠ 0) : ((mk0 a ha)⁻¹ : α) = a⁻¹ := rfl
 
+@[simp] lemma mk0_coe (u : units α) (h : (u : α) ≠ 0) : mk0 (u : α) h = u :=
+units.ext rfl
+
 @[simp] lemma units.mk0_inj [field α] {a b : α} (ha : a ≠ 0) (hb : b ≠ 0) :
   units.mk0 a ha = units.mk0 b hb ↔ a = b :=
 ⟨λ h, by injection h, λ h, units.ext h⟩
@@ -172,8 +175,15 @@ lemma div_div_cancel (ha : a ≠ 0) : a / (a / b) = b :=
 if b0 : b = 0 then by simp only [b0, div_zero] else
 field.div_div_cancel ha b0
 
-@[simp] lemma inv_eq_zero {α} [discrete_field α] (a : α) : a⁻¹ = 0 ↔ a = 0 :=
+@[simp] lemma inv_eq_zero (a : α) : a⁻¹ = 0 ↔ a = 0 :=
 classical.by_cases (assume : a = 0, by simp [*])(assume : a ≠ 0, by simp [*, inv_ne_zero])
+
+lemma neg_inv' (a : α) : (-a)⁻¹ = - a⁻¹ :=
+begin
+  by_cases a = 0,
+  { rw [h, neg_zero, inv_zero, neg_zero] },
+  { rw [neg_inv h] }
+end
 
 end
 

--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -49,6 +49,13 @@ pow_zero a
 lemma fpow_add {a : α} (ha : a ≠ 0) (z1 z2 : ℤ) : a ^ (z1 + z2) = a ^ z1 * a ^ z2 :=
 begin simp only [fpow_eq_gpow ha], rw ← units.coe_mul, congr, apply gpow_add end
 
+@[simp] lemma one_fpow : ∀(i : ℤ), (1 : α) ^ i = 1
+| (int.of_nat n) := _root_.one_pow n
+| -[1+n]         := show 1/(1 ^ (n+1) : α) = 1, by simp
+
+@[simp] lemma fpow_one (a : α) : a^(1:ℤ) = a :=
+pow_one a
+
 end field_power
 
 namespace is_field_hom
@@ -61,7 +68,7 @@ lemma map_fpow {α β : Type*} [discrete_field α] [discrete_field β] (f : α �
 end is_field_hom
 
 section discrete_field_power
-open int nat
+open int
 variables {α : Type u} [discrete_field α]
 
 lemma zero_fpow : ∀ z : ℤ, z ≠ 0 → (0 : α) ^ z = 0
@@ -75,6 +82,24 @@ lemma fpow_neg (a : α) : ∀ n : ℤ, a ^ (-n) = 1 / a ^ n
 
 lemma fpow_sub {a : α} (ha : a ≠ 0) (z1 z2 : ℤ) : a ^ (z1 - z2) = a ^ z1 / a ^ z2 :=
 by rw [sub_eq_add_neg, fpow_add ha, fpow_neg, ←div_eq_mul_one_div]
+
+lemma fpow_mul (a : α) (i j : ℤ) : a ^ (i * j) = (a ^ i) ^ j :=
+begin
+  by_cases a = 0,
+  { subst h,
+    have : ¬ i = 0 → ¬ j = 0 → ¬ i * j = 0, begin rw [mul_eq_zero, not_or_distrib], exact and.intro end,
+    by_cases hi : i = 0; by_cases hj : j = 0;
+      simp [hi, hj, zero_fpow i, zero_fpow j, zero_fpow _ (this _ _), one_fpow] },
+  rw [fpow_eq_gpow h, fpow_eq_gpow h, fpow_eq_gpow (units.ne_zero _), units.mk0_coe],
+  fapply congr_arg coe _, -- TODO: uh oh
+  exact gpow_mul (units.mk0 a h) i j
+end
+
+lemma mul_fpow (a b : α) : ∀(i : ℤ), (a * b) ^ i = (a ^ i) * (b ^ i)
+| (int.of_nat n) := _root_.mul_pow a b n
+| -[1+n] :=
+  by rw [fpow_neg_succ_of_nat, fpow_neg_succ_of_nat, fpow_neg_succ_of_nat,
+      mul_pow, div_mul_div, one_mul]
 
 end discrete_field_power
 

--- a/src/analysis/exponential.lean
+++ b/src/analysis/exponential.lean
@@ -1319,7 +1319,7 @@ begin
       exact (le_mul_of_ge_one_left (rpow_nonneg_of_nonneg (le_of_lt h) z) one_le_pow) } }
 end
 
-lemma rpow_le_one {x e : ℝ} (he : e ≥ 0) (hx : 0 ≤ x) (hx2 : x ≤ 1) : x^e ≤ 1 :=
+lemma rpow_le_one {x e : ℝ} (he : 0 ≤ e) (hx : 0 ≤ x) (hx2 : x ≤ 1) : x^e ≤ 1 :=
 by rw ←one_rpow e; apply rpow_le_rpow; assumption
 
 lemma pow_nat_rpow_nat_inv {x : ℝ} (hx : 0 ≤ x) {n : ℕ} (hn : 0 < n) :

--- a/src/analysis/exponential.lean
+++ b/src/analysis/exponential.lean
@@ -1316,8 +1316,11 @@ begin
       have one_le_pow : 1 ≤ (y / x)^z, exact one_le_rpow one_le (le_of_lt h₂),
       rw [←mul_div_cancel y (ne.symm (ne_of_lt h)), mul_comm, mul_div_assoc],
       rw [mul_rpow (le_of_lt h) (le_trans zero_le_one one_le), mul_comm],
-      exact (le_mul_of_ge_one_left (rpow_nonneg_of_nonneg (le_of_lt h) z) one_le_pow)}},
+      exact (le_mul_of_ge_one_left (rpow_nonneg_of_nonneg (le_of_lt h) z) one_le_pow) } }
 end
+
+lemma rpow_le_one {x e : ℝ} (he : e ≥ 0) (hx : 0 ≤ x) (hx2 : x ≤ 1) : x^e ≤ 1 :=
+by rw ←one_rpow e; apply rpow_le_rpow; assumption
 
 lemma pow_nat_rpow_nat_inv {x : ℝ} (hx : 0 ≤ x) {n : ℕ} (hn : 0 < n) :
   (x ^ n) ^ (n⁻¹ : ℝ) = x :=

--- a/src/analysis/exponential.lean
+++ b/src/analysis/exponential.lean
@@ -1214,6 +1214,14 @@ by simp only [rpow_def, complex.cpow_def];
   simp [*, (complex.of_real_log hx).symm, -complex.of_real_mul,
     (complex.of_real_mul _ _).symm, complex.exp_of_real_re] at *
 
+lemma rpow_pos_of_pos {x : ℝ} (hx : 0 < x) (y : ℝ) : 0 < x ^ y :=
+begin
+  rw [rpow_def_of_nonneg (le_of_lt hx)]; split_ifs,
+  { exact zero_lt_one },
+  { rwa h at hx },
+  { apply exp_pos }
+end
+
 end real
 
 namespace complex


### PR DESCRIPTION
Some theorems about `rpow` and `fpow`

```lean
lemma neg_inv' (a : α) : (-a)⁻¹ = - a⁻¹ 
@[simp] lemma mk0_coe (u : units α) (h : (u : α) ≠ 0) : mk0 (u : α) h = u
@[simp] lemma one_fpow : ∀(i : ℤ), (1 : α) ^ i = 1
@[simp] lemma fpow_one (a : α) : a^(1:ℤ) = a
lemma fpow_mul (a : α) (i j : ℤ) : a ^ (i * j) = (a ^ i) ^ j
lemma mul_fpow (a b : α) : ∀(i : ℤ), (a * b) ^ i = (a ^ i) * (b ^ i)
lemma rpow_le_one {x e : ℝ} (he : e ≥ 0) (hx : 0 ≤ x) (hx2 : x ≤ 1) : x^e ≤ 1
lemma rpow_pos_of_pos {x : ℝ} (hx : 0 < x) (y : ℝ) : 0 < x ^ y
```

Make sure you have:
  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant
