### PR TITLE
fix(scripts/deploy_nightly): fix git push

### DIFF
--- a/scripts/deploy_nightly.sh
+++ b/scripts/deploy_nightly.sh
@@ -38,7 +38,7 @@ fi
 
 # Try to update the lean-x.y.z branch on mathlib. This could fail if
 # a subsequent commit has already pushed an update.
-git push mathlib HEAD:$LEAN_VERSION || \
+git push mathlib HEAD:refs/heads/$LEAN_VERSION || \
     echo "mathlib rejected push to branch $LEAN_VERSION; maybe it already has a later version?" >&2
 
 # Push the commits to a branch on nightly and push a tag.


### PR DESCRIPTION
The deploy_nightly script has been failing to push to the lean-3.4.2 branch recently: https://travis-ci.org/leanprover-community/mathlib/jobs/512774251#L540
```
+git push mathlib HEAD:lean-3.4.2
error: dst refspec lean-3.4.2 matches more than one.
```

The issue is that there is both a `lean-3.4.2` tag and a `lean-3.4.2` branch. This change disambiguates the `git push` command.

https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/setup-update-mathlib.2Esh/near/162007712