### PR TITLE
fix(scripts/remote-install-update-mathlib): add GitPython dependency

### DIFF
--- a/scripts/remote-install-update-mathlib.sh
+++ b/scripts/remote-install-update-mathlib.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 echo "Installing python dependencies (at user level)"
-pip3 install --user toml PyGithub urllib3 certifi
+pip3 install --user toml PyGithub urllib3 certifi GitPython
 echo "Fetching the update-mathlib script"
 curl -o update-mathlib.py https://raw.githubusercontent.com/leanprover-community/mathlib/master/scripts/update-mathlib.py
 echo "installing it in \$HOME/.mathlib/bin"


### PR DESCRIPTION
Pointed out here:

https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/I*M.3DM.20for.20R-modules/near/162047000