### PR TITLE
fix(scripts/hooks): fix PATH in git hooks

### DIFF
--- a/scripts/post-checkout
+++ b/scripts/post-checkout
@@ -1,16 +1,17 @@
 #!/bin/sh
 export PATH=$HOME/.mathlib/bin:$PATH
+# SourceTree on OS X provides a defective path that doesn't contain pythong
+# https://jira.atlassian.com/browse/SRCTREE-6540
+export PATH=$PATH:/usr/local/bin
 
 OLD_HEAD=$1
 NEW_HEAD=$2
 CHANGED_BRANCH=$3
 
 if [ "$CHANGED_BRANCH" -eq "1" ]; then
-    # hooks are sometimes run from git GUIs with a limited environment
-    # if python3 isn't available, we don't generate an error; just a message
     if /usr/bin/env python3 -c ""; then
-	echo "Trying to fetch cached olean"
-	cache-olean --fetch
+		echo "Trying to fetch cached olean"
+		cache-olean --fetch
     else
         echo "'env python3' failed; not running post-checkout hook"
     fi

--- a/scripts/post-commit
+++ b/scripts/post-commit
@@ -1,9 +1,14 @@
 #!/bin/sh
+export PATH=$HOME/.mathlib/bin:$PATH
+# SourceTree on OS X provides a defective path that doesn't contain pythong
+# https://jira.atlassian.com/browse/SRCTREE-6540
+export PATH=$PATH:/usr/local/bin
+
 # hooks are sometimes run from git GUIs with a limited environment
 # if python3 isn't available, we don't generate an error; just a message
 if /usr/bin/env python3 -c ""; then
 	echo "Caching olean..."
-	$HOME/.mathlib/bin/cache-olean
+	cache-olean
 else
     echo "'env python3' failed; not running post-checkout hook"
 fi


### PR DESCRIPTION
I use sourcetree as a git GUI sometimes. For some reason when it runs hooks it doesn't put `/usr/local/bin/` on the PATH, and some we can't find python3 in our hooks, when running on macOS. This PR explicitly pushes `/usr/local/bin/` onto the PATH in each of the two hooks.