### PR TITLE
fix(scripts/update-mathlib): use git config, and handle interrupts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /_target
 /leanpkg.path
 _cache
+__pycache__

--- a/scripts/auth_github.py
+++ b/scripts/auth_github.py
@@ -1,0 +1,23 @@
+from git import Repo, InvalidGitRepositoryError
+from github import Github
+import configparser
+
+def auth_github():
+    try:
+        repo = Repo('.', search_parent_directories=True)
+        config = repo.config_reader()
+    except:
+        print('This does not seem to be a git repository.')
+        return Github()
+    try:
+        return Github(config.get('github', 'user'), config.get('github', 'password'))
+    except configparser.NoSectionError:
+        print('No github section found in \'git config\'')
+        return Github()
+    except configparser.NoOptionError:
+        try:
+            return Github(config.get('github', 'oauthtoken'))
+        except configparser.NoOptionError:
+            print('No github \'user\'/\'password\' or \'oauthtoken\' keys found in \'git config\'.')
+            print('You can create an OAuth token at https://github.com/settings/tokens/new (no scopes are required).')
+            return Github()

--- a/scripts/delayed_interrupt.py
+++ b/scripts/delayed_interrupt.py
@@ -1,0 +1,30 @@
+import signal
+import logging
+
+# DelayedInterrupt class based on: 
+# http://stackoverflow.com/a/21919644/487556 and 
+# https://gist.github.com/tcwalther/ae058c64d5d9078a9f333913718bba95
+class DelayedInterrupt(object):
+    def __init__(self, signals):
+        if not isinstance(signals, list) and not isinstance(signals, tuple):
+            signals = [signals]
+        self.sigs = signals        
+
+    def __enter__(self):
+        self.signal_received = {}
+        self.old_handlers = {}
+        for sig in self.sigs:
+            self.signal_received[sig] = False
+            self.old_handlers[sig] = signal.getsignal(sig)
+            def handler(s, frame):
+                self.signal_received[sig] = (s, frame)
+                # Note: in Python 3.5, you can use signal.Signals(sig).name
+                logging.info('Signal %s received. Delaying KeyboardInterrupt.' % sig)
+            self.old_handlers[sig] = signal.getsignal(sig)
+            signal.signal(sig, handler)
+
+    def __exit__(self, type, value, traceback):
+        for sig in self.sigs:
+            signal.signal(sig, self.old_handlers[sig])
+            if self.signal_received[sig] and self.old_handlers[sig]:
+                self.old_handlers[sig](*self.signal_received[sig])

--- a/scripts/setup-dev-scripts.sh
+++ b/scripts/setup-dev-scripts.sh
@@ -17,10 +17,12 @@ then
 	cd $BASEDIR
 	mkdir -p $HOME/.mathlib/bin || true
 	mkdir -p $HOME/.mathlib/hooks || true
-	cp update-mathlib.py $HOME/.mathlib/bin/update-mathlib
-	cp cache-olean.py $HOME/.mathlib/bin/cache-olean
+	cp auth_github.py          $HOME/.mathlib/bin/
+	cp delayed_interrupt.py    $HOME/.mathlib/bin/
+	cp update-mathlib.py       $HOME/.mathlib/bin/update-mathlib
+	cp cache-olean.py          $HOME/.mathlib/bin/cache-olean
 	cp setup-lean-git-hooks.sh $HOME/.mathlib/bin/setup-lean-git-hooks
-	cp post-commit $HOME/.mathlib/hooks/
+	cp post-commit   $HOME/.mathlib/hooks/
 	cp post-checkout $HOME/.mathlib/hooks/
 	if grep -q ".mathlib/bin" $HOME/.profile
 	then

--- a/scripts/update-mathlib.py
+++ b/scripts/update-mathlib.py
@@ -10,26 +10,8 @@ import urllib3
 import certifi
 import configparser
 import tarfile
-
-def auth_github():
-    try:
-        repo = Repo('.', search_parent_directories=True)
-        config = repo.config_reader()
-    except:
-        print('This does not seem to be a git repository.')
-        return Github()
-    try:
-        return Github(config.get('github', 'user'), config.get('github', 'password'))
-    except configparser.NoSectionError:
-        print('No github section found in \'git config\'')
-        return Github()
-    except configparser.NoOptionError:
-        try:
-            return Github(config.get('github', 'oauthtoken'))
-        except configparser.NoOptionError:
-            print('No github \'user\'/\'password\' or \'oauthtoken\' keys found in \'git config\'.')
-            print('You can create an OAuth token at https://github.com/settings/tokens/new (no scopes are required).')
-            return Github()
+from delayed_interrupt import DelayedInterrupt
+from auth_github import auth_github
 
 # find root of project and leanpkg.toml
 cwd = os.getcwd()
@@ -105,5 +87,6 @@ else:
 
 # Extract archive
 print("Extracting nightly...")
-ar = tarfile.open(os.path.join(mathlib_dir, asset.name))
-ar.extractall('_target/deps/mathlib')
+with DelayedInterrupt([signal.SIGTERM, signal.SIGINT]):
+	ar = tarfile.open(os.path.join(mathlib_dir, asset.name))
+	ar.extractall('_target/deps/mathlib')


### PR DESCRIPTION
This PR factors out the code in `cache-olean` that reads the git configuration, and handles `ctrl-C` duing file operations, and then uses both features in `update-mathlib`.