### PR TITLE
refactor(tactic/interactive): remove dependencies of

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ install:
   - source ~/.elan/env
   - mkdir $HOME/scripts || echo ""
   - export PATH="$HOME/scripts:$PATH"
+  - export OLEAN_RS=https://github.com/cipher1024/olean-rs/releases
+  - export latest=$(curl -sSf "$OLEAN_RS/latest" | cut -d'"' -f2 | awk -F/ '{print $NF}')
+  - curl -sSfL "$OLEAN_RS/download/$latest/olean-rs-linux" -o "$HOME/scripts/olean-rs"
+  - chmod +x $HOME/scripts/olean-rs
   - cp travis_long.sh $HOME/scripts/travis_long
   - chmod +x $HOME/scripts/travis_long
   - (git status | grep  -e "Changes not staged for commit:"); RESULT=$?
@@ -50,6 +54,10 @@ jobs:
         - travis_long "leanpkg test"
         - lean --recursive --export=mathlib.txt src/
         - travis_long "leanchecker mathlib.txt"
+        - cd src
+        - olean-rs -m
+        - make unused
+        - cd ..
         - sh scripts/deploy_nightly.sh
 
     - env: TASK="check install scripts"

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl, Jens Wagemaker
 
 Associated and irreducible elements.
 -/
-import order.galois_connection algebra.group data.equiv.basic data.multiset
+import algebra.group data.multiset
 
 variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*}
 open lattice

--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl
 
 Some big operators for lists and finite sets.
 -/
-import data.list.basic data.list.perm data.finset
+import tactic.tauto data.list.basic data.finset
 import algebra.group algebra.ordered_group algebra.group_power
 
 universes u v w

--- a/src/algebra/char_p.lean
+++ b/src/algebra/char_p.lean
@@ -6,7 +6,7 @@ Author: Kenny Lau, Joey van Langen, Casper Putz
 Characteristic of semirings.
 -/
 
-import data.padics.padic_norm data.nat.choose data.fintype data.set
+import data.padics.padic_norm data.nat.choose data.fintype
 import data.zmod.basic algebra.module
 
 universes u v

--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -6,7 +6,7 @@ Authors: Robert Y. Lewis
 Integer power operation on fields.
 -/
 
-import algebra.group_power tactic.wlog
+import algebra.group_power algebra.ordered_field tactic.wlog
 
 universe u
 

--- a/src/algebra/free.lean
+++ b/src/algebra/free.lean
@@ -11,7 +11,7 @@ Authors: Kenny Lau
 And finally, magma.free_semigroup (free_magma α) ≃ free_semigroup α.
 -/
 
-import data.equiv.basic
+import data.equiv.basic category.traversable.basic
 
 universes u v
 

--- a/src/algebra/group_power.lean
+++ b/src/algebra/group_power.lean
@@ -11,7 +11,7 @@ a^n is used for the first, but users can locally redefine it to gpow when needed
 
 Note: power adopts the convention that 0^0=1.
 -/
-import algebra.char_zero algebra.group algebra.ordered_field
+import algebra.group
 import data.int.basic data.list.basic
 
 universes u v

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import order.basic algebra.order algebra.ordered_group algebra.ring data.nat.cast
+import tactic.split_ifs order.basic algebra.order algebra.ordered_group algebra.ring data.nat.cast
 
 universe u
 variable {α : Type u}

--- a/src/algebra/pointwise.lean
+++ b/src/algebra/pointwise.lean
@@ -9,7 +9,6 @@ Pointwise addition and multiplication of sets
 import data.set.finite
 import data.set.lattice
 import algebra.group
-import group_theory.subgroup
 
 namespace set
 open function

--- a/src/algebra/punit_instances.lean
+++ b/src/algebra/punit_instances.lean
@@ -6,7 +6,6 @@ Authors: Kenny Lau
 Instances on punit.
 -/
 
-import order.basic
 import algebra.module algebra.group
 
 universes u

--- a/src/algebra/ring.lean
+++ b/src/algebra/ring.lean
@@ -3,7 +3,7 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn
 -/
-import algebra.group data.set.basic
+import algebra.group
 
 universes u v
 variable {α : Type u}

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -7,7 +7,6 @@ Authors: Patrick Massot, Johannes Hölzl
 -/
 
 import algebra.pi_instances
-import linear_algebra.basic
 import topology.instances.nnreal topology.instances.complex
 variables {α : Type*} {β : Type*} {γ : Type*} {ι : Type*}
 

--- a/src/category/bitraversable/basic.lean
+++ b/src/category/bitraversable/basic.lean
@@ -6,8 +6,7 @@ Author: Simon Hudon
 Functors with two arguments
 -/
 
-import data.sum
-       category.basic category.functor
+import category.functor
        category.bifunctor
        category.traversable.basic
        tactic.basic

--- a/src/category/monad/cont.lean
+++ b/src/category/monad/cont.lean
@@ -8,7 +8,7 @@ Haskell's `Cont`, `ContT` and `MonadCont`:
 http://hackage.haskell.org/package/mtl-2.2.2/docs/Control-Monad-Cont.html
 -/
 
-import tactic.interactive
+import tactic.ext
 
 universes u v w
 

--- a/src/category/traversable/equiv.lean
+++ b/src/category/traversable/equiv.lean
@@ -100,7 +100,7 @@ by simp [equiv.traverse,comp_traverse] with functor_norm; congr; ext; simp
 
 protected lemma naturality (f : α → F β) (x : t' α) :
   η (equiv.traverse eqv f x) = equiv.traverse eqv (@η _ ∘ f) x :=
-by simp [equiv.traverse] with functor_norm
+by simp only [equiv.traverse] with functor_norm
 
 protected def is_lawful_traversable :
   @is_lawful_traversable t' (equiv.traversable eqv) :=

--- a/src/category_theory/adjunction.lean
+++ b/src/category_theory/adjunction.lean
@@ -6,7 +6,6 @@ Authors: Reid Barton, Johan Commelin
 
 import category_theory.limits.preserves
 import category_theory.whiskering
-import category_theory.equivalence
 
 namespace category_theory
 open category

--- a/src/category_theory/category.lean
+++ b/src/category_theory/category.lean
@@ -15,7 +15,6 @@ local notation f ` ⊚ `:80 g:80 := category.comp g f    -- type as \oo
 -/
 
 import tactic.restate_axiom
-import tactic.replacer
 import tactic.interactive
 import tactic.tidy
 

--- a/src/category_theory/comma.lean
+++ b/src/category_theory/comma.lean
@@ -2,12 +2,8 @@
 -- Released under Apache 2.0 license as described in the file LICENSE.
 -- Authors: Scott Morrison, Johan Commelin
 
-import category_theory.types
 import category_theory.isomorphism
-import category_theory.whiskering
-import category_theory.opposites
 import category_theory.punit
-import category_theory.equivalence
 
 namespace category_theory
 

--- a/src/category_theory/core.lean
+++ b/src/category_theory/core.lean
@@ -8,7 +8,6 @@ isomorphisms of C.
 -/
 
 import category_theory.groupoid
-import category_theory.equivalence
 import category_theory.whiskering
 
 namespace category_theory

--- a/src/category_theory/discrete_category.lean
+++ b/src/category_theory/discrete_category.lean
@@ -3,8 +3,6 @@
 -- Authors: Stephen Morgan, Scott Morrison
 
 import data.ulift
-import category_theory.natural_transformation
-import category_theory.isomorphism
 import category_theory.functor_category
 
 namespace category_theory

--- a/src/category_theory/instances/CommRing/basic.lean
+++ b/src/category_theory/instances/CommRing/basic.lean
@@ -6,7 +6,6 @@ Introduce CommRing -- the category of commutative rings.
 -/
 
 import category_theory.instances.monoids
-import category_theory.fully_faithful
 import algebra.ring
 import data.int.basic
 

--- a/src/category_theory/instances/Top/basic.lean
+++ b/src/category_theory/instances/Top/basic.lean
@@ -3,8 +3,7 @@
 -- Authors: Patrick Massot, Scott Morrison, Mario Carneiro
 
 import category_theory.concrete_category
-import category_theory.full_subcategory
-import topology.opens
+import topology.order
 
 open category_theory
 open topological_space

--- a/src/category_theory/instances/Top/open_nhds.lean
+++ b/src/category_theory/instances/Top/open_nhds.lean
@@ -1,4 +1,5 @@
 import category_theory.instances.Top.opens
+import category_theory.full_subcategory
 
 open category_theory
 open category_theory.instances

--- a/src/category_theory/instances/Top/opens.lean
+++ b/src/category_theory/instances/Top/opens.lean
@@ -2,6 +2,7 @@ import category_theory.instances.Top.basic
 import category_theory.natural_isomorphism
 import category_theory.opposites
 import category_theory.eq_to_hom
+import topology.opens
 
 open category_theory
 open category_theory.instances

--- a/src/category_theory/instances/groups.lean
+++ b/src/category_theory/instances/groups.lean
@@ -10,7 +10,6 @@ Copied from monoids.lean.
 
 import algebra.punit_instances
 import category_theory.concrete_category
-import category_theory.fully_faithful
 
 universes u v
 

--- a/src/category_theory/instances/measurable_space.lean
+++ b/src/category_theory/instances/measurable_space.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl
 Basic setup for measurable spaces.
 -/
 
-import category_theory.instances.Top
+import category_theory.instances.Top.basic
 import measure_theory.borel_space
 
 open category_theory

--- a/src/category_theory/instances/monoids.lean
+++ b/src/category_theory/instances/monoids.lean
@@ -7,8 +7,7 @@ Introduce Mon -- the category of monoids.
 Currently only the basic setup.
 -/
 
-import category_theory.concrete_category
-import category_theory.fully_faithful
+import category_theory.concrete_category algebra.group
 
 universes u v
 

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -2,7 +2,6 @@
 -- Released under Apache 2.0 license as described in the file LICENSE.
 -- Authors: Stephen Morgan, Scott Morrison
 
-import category_theory.natural_isomorphism
 import category_theory.whiskering
 import category_theory.const
 import category_theory.opposites

--- a/src/category_theory/limits/preserves.lean
+++ b/src/category_theory/limits/preserves.lean
@@ -4,7 +4,6 @@
 
 -- Preservation and reflection of (co)limits.
 
-import category_theory.whiskering
 import category_theory.limits.limits
 
 open category_theory

--- a/src/category_theory/natural_isomorphism.lean
+++ b/src/category_theory/natural_isomorphism.lean
@@ -3,7 +3,8 @@
 -- Authors: Tim Baumann, Stephen Morgan, Scott Morrison
 
 import category_theory.functor_category
-import category_theory.whiskering
+import category_theory.isomorphism
+import tactic.simpa
 
 open category_theory
 

--- a/src/category_theory/opposites.lean
+++ b/src/category_theory/opposites.lean
@@ -4,7 +4,6 @@
 
 import category_theory.products
 import category_theory.types
-import category_theory.natural_isomorphism
 
 namespace category_theory
 

--- a/src/category_theory/types.lean
+++ b/src/category_theory/types.lean
@@ -4,6 +4,7 @@
 
 import category_theory.functor_category
 import category_theory.fully_faithful
+import data.equiv.basic
 
 namespace category_theory
 

--- a/src/data/analysis/filter.lean
+++ b/src/data/analysis/filter.lean
@@ -5,7 +5,7 @@ Authors: Mario Carneiro
 
 Computational realization of filters (experimental).
 -/
-import order.filter
+import order.filter.basic
 open set filter
 
 /-- A `cfilter α σ` is a realization of a filter (base) on `α`,

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -8,7 +8,7 @@ We say two types are equivalent if they are isomorphic.
 
 Two equivalent types have the same cardinality.
 -/
-import logic.function logic.unique data.set.basic data.bool data.quot
+import tactic.split_ifs logic.function logic.unique data.set.basic data.bool data.quot
 
 open function
 

--- a/src/data/equiv/list.lean
+++ b/src/data/equiv/list.lean
@@ -6,7 +6,7 @@ Author: Mario Carneiro
 Additional equiv and encodable instances for lists and finsets.
 -/
 import data.equiv.denumerable data.nat.pairing order.order_iso
-  data.vector2 data.array.lemmas data.fintype
+  data.array.lemmas data.fintype
 
 open nat list
 

--- a/src/data/erased.lean
+++ b/src/data/erased.lean
@@ -6,7 +6,7 @@ Author: Mario Carneiro
 A type for VM-erased data.
 -/
 
-import data.set.basic data.equiv.basic
+import data.equiv.basic
 
 /-- `erased α` is the same as `α`, except that the elements
   of `erased α` are erased in the VM in the same way as types

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -5,7 +5,7 @@ Author: Leonardo de Moura, Jeremy Avigad, Minchao Wu, Mario Carneiro
 
 Finite sets.
 -/
-import logic.embedding order.boolean_algebra algebra.order_functions
+import logic.embedding algebra.order_functions
   data.multiset data.sigma.basic data.set.lattice
 
 open multiset subtype nat lattice

--- a/src/data/fintype.lean
+++ b/src/data/fintype.lean
@@ -5,7 +5,7 @@ Author: Mario Carneiro
 
 Finite types.
 -/
-import data.finset algebra.big_operators data.array.lemmas data.vector2 data.equiv.encodable
+import data.finset algebra.big_operators data.array.lemmas
 universes u v
 
 variables {α : Type*} {β : Type*} {γ : Type*}

--- a/src/data/hash_map.lean
+++ b/src/data/hash_map.lean
@@ -4,6 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
 -/
 import data.list.basic data.pnat data.array.lemmas
+   logic.basic algebra.group
+   data.list.defs data.nat.basic data.option.basic
+   data.bool data.prod
+import tactic.finish data.sigma.basic
 
 universes u v w
 

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -6,11 +6,11 @@ Authors: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn, M
 Basic properties of lists.
 -/
 import
-  tactic.interactive tactic.mk_iff_of_inductive_prop tactic.split_ifs
-  logic.basic logic.function logic.relation
+  tactic.interactive tactic.mk_iff_of_inductive_prop
+  logic.basic logic.function logic.relator
   algebra.group order.basic
   data.list.defs data.nat.basic data.option.basic
-  data.bool data.prod data.sigma data.fin
+  data.bool data.prod data.fin
 open function nat
 
 namespace list
@@ -2389,7 +2389,7 @@ end
 
 section forall₂
 variables {r : α → β → Prop} {p : γ → δ → Prop}
-open relator relation
+open relator
 
 run_cmd tactic.mk_iff_of_inductive_prop `list.forall₂ `list.forall₂_iff
 

--- a/src/data/list/defs.lean
+++ b/src/data/list/defs.lean
@@ -5,7 +5,7 @@ Authors: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn, M
 
 Extra definitions on lists.
 -/
-import data.option.defs logic.basic logic.relator
+import data.option.defs logic.basic
 
 namespace list
 
@@ -233,7 +233,6 @@ def sublists_aux₁ : list α → (list α → list β) → list β
 
 section forall₂
 variables {r : α → β → Prop} {p : γ → δ → Prop}
-open relator
 
 inductive forall₂ (R : α → β → Prop) : list α → list β → Prop
 | nil {} : forall₂ [] []

--- a/src/data/list/perm.lean
+++ b/src/data/list/perm.lean
@@ -5,7 +5,7 @@ Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 
 List permutations.
 -/
-import data.list.basic
+import data.list.basic logic.relation
 
 namespace list
 universe variables uu vv
@@ -264,8 +264,8 @@ def subperm (l₁ l₂ : list α) : Prop := ∃ l ~ l₁, l <+ l₂
 
 infix ` <+~ `:50 := subperm
 
-theorem nil_subperm {l : list α} : [] <+~ l := 
-⟨[], perm.nil, by simp⟩ 
+theorem nil_subperm {l : list α} : [] <+~ l :=
+⟨[], perm.nil, by simp⟩
 
 theorem perm.subperm_left {l l₁ l₂ : list α} (p : l₁ ~ l₂) : l <+~ l₁ ↔ l <+~ l₂ :=
 suffices ∀ {l₁ l₂ : list α}, l₁ ~ l₂ → l <+~ l₁ → l <+~ l₂,

--- a/src/data/list/sigma.lean
+++ b/src/data/list/sigma.lean
@@ -5,7 +5,7 @@ Authors: Mario Carneiro, Sean Leather
 
 Functions on lists of sigma types.
 -/
-import data.list.perm
+import data.list.perm data.sigma
 
 universes u v
 

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -5,7 +5,7 @@ Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 
 Prime numbers.
 -/
-import data.nat.sqrt data.nat.gcd data.list.basic data.list.perm
+import data.nat.sqrt data.nat.gcd data.list.basic data.list.perm tactic.wlog
 open bool subtype
 
 namespace nat

--- a/src/data/nat/sqrt.lean
+++ b/src/data/nat/sqrt.lean
@@ -7,7 +7,7 @@ An efficient binary implementation of a (sqrt n) function that
 returns s s.t.
     s*s ≤ n ≤ s*s + s + s
 -/
-import data.nat.basic algebra.ordered_group algebra.ring tactic
+import data.nat.basic algebra.ordered_group algebra.ring tactic.alias
 
 namespace nat
 

--- a/src/data/num/basic.lean
+++ b/src/data/num/basic.lean
@@ -11,7 +11,7 @@ in favor of the "Peano" natural numbers `nat`, and the purpose of this
 collection of theorems is to show the equivalence of the different approaches.
 -/
 
-import data.pnat data.bool data.vector data.bitvec
+import data.vector data.bitvec
 
 /-- The type of positive binary numbers.
 
@@ -396,13 +396,13 @@ namespace znum
 end znum
 
 namespace pos_num
-  
+
   def divmod_aux (d : pos_num) (q r : num) : num × num :=
   match num.of_znum' (num.sub' r (num.pos d)) with
   | some r' := (num.bit1 q, r')
   | none    := (num.bit0 q, r)
   end
-  
+
   def divmod (d : pos_num) : pos_num → num × num
   | (bit0 n) := let (q, r₁) := divmod n in
     divmod_aux d q (num.bit0 r₁)
@@ -419,7 +419,7 @@ namespace pos_num
   | some n' := (r.div2 + num.pos b, n')
   | none := (r.div2, n)
   end
-    
+
   def sqrt_aux : pos_num → num → num → num
   | b@(bit0 b') r n := let (r', n') := sqrt_aux1 b r n in sqrt_aux b' r' n'
   | b@(bit1 b') r n := let (r', n') := sqrt_aux1 b r n in sqrt_aux b' r' n'

--- a/src/data/option/basic.lean
+++ b/src/data/option/basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import logic.basic data.bool data.option.defs tactic.interactive
+import logic.basic data.bool data.option.defs tactic.ext tactic.simpa
 
 namespace option
 variables {α : Type*} {β : Type*}

--- a/src/data/padics/hensel.lean
+++ b/src/data/padics/hensel.lean
@@ -7,9 +7,9 @@ A proof of Hensel's lemma on ℤ_p, roughly following Keith Conrad's writeup:
 http://www.math.uconn.edu/~kconrad/blurbs/gradnumthy/hensel.pdf
 -/
 
-import data.padics.padic_integers data.polynomial data.nat.choose topology.metric_space.cau_seq_filter
+import data.padics.padic_integers data.polynomial topology.metric_space.cau_seq_filter
 import analysis.specific_limits topology.instances.polynomial
-import tactic.ring
+import tactic.simpa
 
 noncomputable theory
 

--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -8,6 +8,7 @@ Define the p-adic valuation on ℤ and ℚ, and the p-adic norm on ℚ
 
 import data.rat algebra.gcd_domain algebra.field_power
 import ring_theory.multiplicity tactic.ring
+import data.real.cau_seq
 
 universe u
 

--- a/src/data/pfun.lean
+++ b/src/data/pfun.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Mario Carneiro, Jeremy Avigad
 -/
-import data.set.basic data.equiv.basic data.rel
+import data.set.basic data.equiv.basic data.rel logic.relator
 
 /-- `roption α` is the type of "partial values" of type `α`. It
   is similar to `option α` except the domain condition can be an

--- a/src/data/rat.lean
+++ b/src/data/rat.lean
@@ -7,8 +7,9 @@ Introduces the rational numbers as discrete, linear ordered field.
 -/
 
 import
-  data.nat.gcd data.pnat data.int.sqrt data.equiv.encodable order.basic
-  algebra.ordered_field data.real.cau_seq
+  data.nat.gcd data.pnat data.int.sqrt data.equiv.encodable
+  algebra.group algebra.ordered_group algebra.group_power
+  algebra.ordered_field
 
 /- rational numbers -/
 

--- a/src/data/real/basic.lean
+++ b/src/data/real/basic.lean
@@ -7,7 +7,7 @@ The (classical) real numbers ℝ. This is a direct construction
 from Cauchy sequences.
 -/
 import order.conditionally_complete_lattice data.real.cau_seq_completion
-  algebra.big_operators algebra.archimedean order.bounds
+  algebra.archimedean order.bounds
 
 def real := @cau_seq.completion.Cauchy ℚ _ _ _ abs _
 notation `ℝ` := real

--- a/src/data/seq/computation.lean
+++ b/src/data/seq/computation.lean
@@ -5,7 +5,7 @@ Author: Mario Carneiro
 
 Coinductive formalization of unbounded computations.
 -/
-import data.stream data.nat.basic
+import data.stream logic.relator tactic.cache tactic.interactive
 universes u v w
 
 /-

--- a/src/data/seq/seq.lean
+++ b/src/data/seq/seq.lean
@@ -1,4 +1,5 @@
 import data.stream data.lazy_list data.seq.computation logic.basic tactic.interactive
+
 universes u v w
 
 /-
@@ -85,7 +86,7 @@ begin
   dsimp [destruct],
   induction f0 : nth s 0 with a'; intro h,
   { contradiction },
-  { unfold functor.map at h, dsimp at h,
+  { unfold functor.map at h,
     cases s with f al,
     injections with _ h1 h2,
     rw ←h2, apply subtype.eq, dsimp [tail, cons],

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Jeremy Avigad, Leonardo de Moura
 -/
-import tactic.ext tactic.finish data.subtype tactic.interactive
+import tactic.finish data.subtype tactic.interactive
 open function
 
 

--- a/src/data/set/enumerate.lean
+++ b/src/data/set/enumerate.lean
@@ -6,10 +6,10 @@ Author: Johannes Hölzl
 Enumerate elements of a set with a select function.
 -/
 
-import data.equiv.encodable data.set.finite data.set.lattice logic.function
+import data.set.lattice tactic.wlog
 noncomputable theory
 
-open function set encodable
+open function set
 
 namespace set
 

--- a/src/data/set/intervals.lean
+++ b/src/data/set/intervals.lean
@@ -14,7 +14,8 @@ Each interval has the name `I` + letter for left side + letter for right side
 
 TODO: This is just the beginning; a lot of rules are missing
 -/
-import data.set.lattice algebra.order algebra.order_functions
+import algebra.order algebra.order_functions
+import tactic.tauto
 
 namespace set
 

--- a/src/data/vector2.lean
+++ b/src/data/vector2.lean
@@ -5,8 +5,7 @@ Authors: Mario Carneiro
 
 Additional theorems about the `vector` type.
 -/
-import data.vector data.list.basic data.sigma data.equiv.basic
-       category.traversable
+import data.vector data.list.basic category.traversable.basic data.set.basic
 
 universes u
 variables {n : ℕ}

--- a/src/data/zsqrtd/gaussian_int.lean
+++ b/src/data/zsqrtd/gaussian_int.lean
@@ -6,7 +6,7 @@ Author: Chris Hughes
 The gaussian integers ℤ[i].
 -/
 
-import data.zsqrtd.basic data.complex.basic algebra.euclidean_domain algebra.associated
+import data.zsqrtd.basic data.complex.basic algebra.euclidean_domain
 open zsqrtd complex
 
 @[reducible] def gaussian_int : Type := zsqrtd (-1)

--- a/src/field_theory/finite.lean
+++ b/src/field_theory/finite.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
-import group_theory.order_of_element data.nat.totient data.polynomial data.equiv.algebra
+import group_theory.order_of_element data.polynomial data.equiv.algebra
 
 universes u v
 variables {α : Type u} {β : Type v}

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -6,7 +6,9 @@ Authors: Chris Hughes
 Definition of splitting fields, and definition of homomorphism into any field that splits
 -/
 
-import ring_theory.adjoin_root ring_theory.unique_factorization_domain
+import ring_theory.unique_factorization_domain
+import data.polynomial ring_theory.principal_ideal_domain
+       algebra.euclidean_domain
 
 universes u v w
 
@@ -17,7 +19,7 @@ namespace polynomial
 noncomputable theory
 local attribute [instance, priority 0] classical.prop_decidable
 variables [discrete_field α] [discrete_field β] [discrete_field γ]
-open polynomial adjoin_root
+open polynomial
 
 section splits
 

--- a/src/group_theory/eckmann_hilton.lean
+++ b/src/group_theory/eckmann_hilton.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Kenny Lau, Robert Y. Lewis
 -/
 
-import tactic.interactive
+import tactic.simpa
 
 universe u
 

--- a/src/group_theory/free_group.lean
+++ b/src/group_theory/free_group.lean
@@ -15,7 +15,7 @@ Then we introduce `free_group α` as a quotient over `free_group.red.step`.
 -/
 import logic.relation
 import algebra.group algebra.group_power
-import data.fintype data.list.basic data.quot
+import data.fintype data.list.basic
 import group_theory.subgroup
 open relation
 

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
 import group_theory.group_action group_theory.quotient_group
-import group_theory.order_of_element data.zmod.basic algebra.pi_instances
+import group_theory.order_of_element data.zmod.basic
 
 open equiv fintype finset mul_action function
 open equiv.perm is_subgroup list quotient_group

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Chris Hughes
 -/
 import data.matrix
-import group_theory.subgroup group_theory.perm.sign
+import group_theory.perm.sign
 
 universes u v
 open equiv equiv.perm finset function

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -9,7 +9,7 @@ Classical versions are in the namespace "classical".
 Note: in the presence of automation, this whole file may be unnecessary. On the other hand,
 maybe it is useful for writing automation.
 -/
-import data.prod tactic.cache
+import tactic.cache
 
 /-
     miscellany
@@ -542,9 +542,9 @@ protected lemma not_not {p : Prop} : ¬¬p ↔ p := not_not
 
 protected lemma not_and_distrib {p q : Prop}: ¬(p ∧ q) ↔ ¬p ∨ ¬q := not_and_distrib
 
-protected lemma imp_iff_not_or {a b : Prop} : a → b ↔ ¬a ∨ b := imp_iff_not_or 
+protected lemma imp_iff_not_or {a b : Prop} : a → b ↔ ¬a ∨ b := imp_iff_not_or
 
-lemma iff_iff_not_or_and_or_not {a b : Prop} : (a ↔ b) ↔ ((¬a ∨ b) ∧ (a ∨ ¬b)) := 
+lemma iff_iff_not_or_and_or_not {a b : Prop} : (a ↔ b) ↔ ((¬a ∨ b) ∧ (a ∨ ¬b)) :=
 begin
   rw [iff_iff_implies_and_implies a b],
   simp only [imp_iff_not_or, or.comm]

--- a/src/logic/relator.lean
+++ b/src/logic/relator.lean
@@ -6,9 +6,6 @@ Authors: Johannes Hölzl
 Relator for functions, pairs, sums, and lists.
 -/
 
-prelude
-import init.core init.data.basic
-
 namespace relator
 universe variables u₁ u₂ v₁ v₂
 

--- a/src/logic/unique.lean
+++ b/src/logic/unique.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
 
-import logic.basic
-
 universes u v w
 
 variables {α : Sort u} {β : Sort v} {γ : Sort w}
@@ -52,4 +50,3 @@ def of_surjective {f : α → β} (hf : surjective f) [unique α] : unique β :=
   end }
 
 end unique
-

--- a/src/measure_theory/giry_monad.lean
+++ b/src/measure_theory/giry_monad.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl
 
 Giry monad: `measure` is a monad in the category of `measurable_space` and `measurable` functions.
 -/
-import measure_theory.integration data.sum
+import measure_theory.integration
 noncomputable theory
 local attribute [instance, priority 0] classical.prop_decidable
 

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl, Mario Carneiro
 
 Measurable spaces -- σ-algberas
 -/
-import data.set.disjointed data.finset order.galois_connection data.set.countable
+import data.set.disjointed order.galois_connection data.set.countable
 open set lattice encodable
 local attribute [instance] classical.prop_decidable
 

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -16,7 +16,8 @@ somehow well-behaved on non-measurable sets.
 This allows us for the `lebesgue` measure space to have the `borel` measurable space, but still be
 a complete measure.
 -/
-import data.set order.galois_connection topology.instances.ennreal
+import data.set.lattice data.set.finite
+import topology.instances.ennreal
        measure_theory.outer_measure
 
 noncomputable theory

--- a/src/measure_theory/outer_measure.lean
+++ b/src/measure_theory/outer_measure.lean
@@ -6,7 +6,7 @@ Authors: Johannes Hölzl, Mario Carneiro
 Outer measures -- overapproximations of measures
 -/
 
-import order.galois_connection algebra.big_operators algebra.module
+import algebra.big_operators algebra.module
        topology.instances.ennreal analysis.specific_limits
        measure_theory.measurable_space
 

--- a/src/number_theory/dioph.lean
+++ b/src/number_theory/dioph.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import number_theory.pell data.set data.pfun
+import number_theory.pell data.pfun
 
 universe u
 

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import data.nat.prime data.nat.modeq data.zsqrtd.basic
+import data.nat.modeq data.zsqrtd.basic
 
 namespace pell
 open nat

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Mario Carneiro
 -/
-import tactic.interactive logic.basic data.sum data.set.basic algebra.order
+import logic.basic data.sum data.set.basic algebra.order
 open function
 
 /- TODO: automatic construction of dual definitions / theorems -/

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -24,7 +24,7 @@ bounded below.
 -/
 import
   order.lattice order.complete_lattice order.bounds
-  tactic.finish data.set.countable
+  tactic.finish data.set.finite
 
 set_option old_structure_cmd true
 

--- a/src/order/filter/default.lean
+++ b/src/order/filter/default.lean
@@ -1,1 +1,1 @@
-import .basic .partial
+import order.filter.basic order.filter.partial

--- a/src/order/lexicographic.lean
+++ b/src/order/lexicographic.lean
@@ -6,7 +6,7 @@ Author: Scott Morrison, Minchao Wu
 Lexicographic preorder / partial_order / linear_order / decidable_linear_order,
 for pairs and dependent pairs.
 -/
-import order.basic
+import algebra.order
 import tactic.interactive
 
 universes u v
@@ -24,8 +24,8 @@ instance lex_has_lt [preorder α] [preorder β] : has_lt (lex α β) :=
 
 /-- Dictionary / lexicographic preorder for pairs. -/
 instance lex_preorder [preorder α] [preorder β] : preorder (lex α β) :=
-{ le_refl := λ ⟨l, r⟩, by { right, apply le_refl }, 
-  le_trans := 
+{ le_refl := λ ⟨l, r⟩, by { right, apply le_refl },
+  le_trans :=
   begin
     rintros ⟨a₁, b₁⟩ ⟨a₂, b₂⟩ ⟨a₃, b₃⟩ ⟨h₁l, h₁r⟩ ⟨h₂l, h₂r⟩,
     { left, apply lt_trans, repeat { assumption } },
@@ -33,25 +33,25 @@ instance lex_preorder [preorder α] [preorder β] : preorder (lex α β) :=
     { left, assumption },
     { right, apply le_trans, repeat { assumption } }
   end,
-  lt_iff_le_not_le := 
+  lt_iff_le_not_le :=
   begin
-    rintros ⟨a₁, b₁⟩ ⟨a₂, b₂⟩, 
+    rintros ⟨a₁, b₁⟩ ⟨a₂, b₂⟩,
     split,
     { rintros (⟨_, _, _, _, hlt⟩ | ⟨_, _, _, hlt⟩),
-     { split, 
-       { left, assumption }, 
-       { rintro ⟨l,r⟩, 
-         { apply lt_asymm hlt, assumption }, 
+     { split,
+       { left, assumption },
+       { rintro ⟨l,r⟩,
+         { apply lt_asymm hlt, assumption },
          { apply lt_irrefl _ hlt } } },
-     { split, 
-       { right, rw lt_iff_le_not_le at hlt, exact hlt.1 }, 
-       { rintro ⟨l,r⟩, 
-         { apply lt_irrefl a₁, assumption }, 
+     { split,
+       { right, rw lt_iff_le_not_le at hlt, exact hlt.1 },
+       { rintro ⟨l,r⟩,
+         { apply lt_irrefl a₁, assumption },
          { rw lt_iff_le_not_le at hlt, apply hlt.2, assumption } } } },
-    { rintros ⟨⟨h₁ll, h₁lr⟩, h₂r⟩, 
-      { left, assumption }, 
-      { right, rw lt_iff_le_not_le, split, 
-        { assumption }, 
+    { rintros ⟨⟨h₁ll, h₁lr⟩, h₂r⟩,
+      { left, assumption },
+      { right, rw lt_iff_le_not_le, split,
+        { assumption },
         { intro h, apply h₂r, right, exact h } } }
   end,
   .. lex_has_le,
@@ -62,9 +62,9 @@ instance lex_partial_order [partial_order α] [partial_order β] : partial_order
 { le_antisymm :=
   begin
     rintros ⟨a₁, b₁⟩ ⟨a₂, b₂⟩ (⟨_, _, _, _, hlt₁⟩ | ⟨_, _, _, hlt₁⟩) (⟨_, _, _, _, hlt₂⟩ | ⟨_, _, _, hlt₂⟩),
-    { exfalso, exact lt_irrefl a₁ (lt_trans hlt₁ hlt₂) }, 
-    { exfalso, exact lt_irrefl a₁ hlt₁ }, 
-    { exfalso, exact lt_irrefl a₁ hlt₂ }, 
+    { exfalso, exact lt_irrefl a₁ (lt_trans hlt₁ hlt₂) },
+    { exfalso, exact lt_irrefl a₁ hlt₁ },
+    { exfalso, exact lt_irrefl a₁ hlt₂ },
     { have := le_antisymm hlt₁ hlt₂, simp [this] }
   end
   .. lex_preorder }
@@ -97,16 +97,16 @@ instance lex_decidable_linear_order [decidable_linear_order α] [decidable_linea
     rintros ⟨a₁, b₁⟩ ⟨a₂, b₂⟩,
     rcases decidable_linear_order.decidable_le α a₁ a₂ with a_lt | a_le,
     { -- a₂ < a₁
-      left, rw not_le at a_lt, rintro ⟨l, r⟩, 
-      { apply lt_irrefl a₂, apply lt_trans, repeat { assumption } }, 
+      left, rw not_le at a_lt, rintro ⟨l, r⟩,
+      { apply lt_irrefl a₂, apply lt_trans, repeat { assumption } },
       { apply lt_irrefl a₁, assumption } },
     { -- a₁ ≤ a₂
       by_cases h : a₁ = a₂,
-      { rw h, 
+      { rw h,
         rcases decidable_linear_order.decidable_le _ b₁ b₂ with b_lt | b_le,
         { -- b₂ < b₁
-          left, rw not_le at b_lt, rintro ⟨l, r⟩, 
-          { apply lt_irrefl a₂, assumption }, 
+          left, rw not_le at b_lt, rintro ⟨l, r⟩,
+          { apply lt_irrefl a₂, assumption },
           { apply lt_irrefl b₂, apply lt_of_lt_of_le, repeat { assumption } } },
           -- b₁ ≤ b₂
          { right, right, assumption } },
@@ -131,7 +131,7 @@ instance dlex_has_lt [preorder α] [∀ a, preorder (Z a)] : has_lt (Σ' a, Z a)
 
 /-- Dictionary / lexicographic preorder on dependent pairs. -/
 instance dlex_preorder [preorder α] [∀ a, preorder (Z a)] : preorder (Σ' a, Z a) :=
-{ le_refl := λ ⟨l, r⟩, by { right, apply le_refl }, 
+{ le_refl := λ ⟨l, r⟩, by { right, apply le_refl },
   le_trans :=
   begin
     rintros ⟨a₁, b₁⟩ ⟨a₂, b₂⟩ ⟨a₃, b₃⟩ ⟨h₁l, h₁r⟩ ⟨h₂l, h₂r⟩,
@@ -142,23 +142,23 @@ instance dlex_preorder [preorder α] [∀ a, preorder (Z a)] : preorder (Σ' a, 
   end,
   lt_iff_le_not_le :=
   begin
-    rintros ⟨a₁, b₁⟩ ⟨a₂, b₂⟩, 
+    rintros ⟨a₁, b₁⟩ ⟨a₂, b₂⟩,
     split,
     { rintros (⟨_, _, _, _, hlt⟩ | ⟨_, _, _, hlt⟩),
-     { split, 
-       { left, assumption }, 
-       { rintro ⟨l,r⟩, 
-         { apply lt_asymm hlt, assumption }, 
+     { split,
+       { left, assumption },
+       { rintro ⟨l,r⟩,
+         { apply lt_asymm hlt, assumption },
          { apply lt_irrefl _ hlt } } },
-     { split, 
-       { right, rw lt_iff_le_not_le at hlt, exact hlt.1 }, 
-       { rintro ⟨l,r⟩, 
-         { apply lt_irrefl a₁, assumption }, 
+     { split,
+       { right, rw lt_iff_le_not_le at hlt, exact hlt.1 },
+       { rintro ⟨l,r⟩,
+         { apply lt_irrefl a₁, assumption },
          { rw lt_iff_le_not_le at hlt, apply hlt.2, assumption } } } },
-    { rintros ⟨⟨h₁ll, h₁lr⟩, h₂r⟩, 
-      { left, assumption }, 
-      { right, rw lt_iff_le_not_le, split, 
-        { assumption }, 
+    { rintros ⟨⟨h₁ll, h₁lr⟩, h₂r⟩,
+      { left, assumption },
+      { right, rw lt_iff_le_not_le, split,
+        { assumption },
         { intro h, apply h₂r, right, exact h } } }
   end,
   .. dlex_has_le,
@@ -169,9 +169,9 @@ instance dlex_partial_order [partial_order α] [∀ a, partial_order (Z a)] : pa
 { le_antisymm :=
   begin
     rintros ⟨a₁, b₁⟩ ⟨a₂, b₂⟩ (⟨_, _, _, _, hlt₁⟩ | ⟨_, _, _, hlt₁⟩) (⟨_, _, _, _, hlt₂⟩ | ⟨_, _, _, hlt₂⟩),
-    { exfalso, exact lt_irrefl a₁ (lt_trans hlt₁ hlt₂) }, 
-    { exfalso, exact lt_irrefl a₁ hlt₁ }, 
-    { exfalso, exact lt_irrefl a₁ hlt₂ }, 
+    { exfalso, exact lt_irrefl a₁ (lt_trans hlt₁ hlt₂) },
+    { exfalso, exact lt_irrefl a₁ hlt₁ },
+    { exfalso, exact lt_irrefl a₁ hlt₂ },
     { have := le_antisymm hlt₁ hlt₂, simp [this] }
   end
   .. dlex_preorder }
@@ -204,16 +204,16 @@ instance dlex_decidable_linear_order [decidable_linear_order α] [∀ a, decidab
     rintros ⟨a₁, b₁⟩ ⟨a₂, b₂⟩,
     rcases decidable_linear_order.decidable_le α a₁ a₂ with a_lt | a_le,
     { -- a₂ < a₁
-      left, rw not_le at a_lt, rintro ⟨l, r⟩, 
-      { apply lt_irrefl a₂, apply lt_trans, repeat { assumption } }, 
+      left, rw not_le at a_lt, rintro ⟨l, r⟩,
+      { apply lt_irrefl a₂, apply lt_trans, repeat { assumption } },
       { apply lt_irrefl a₁, assumption } },
     { -- a₁ ≤ a₂
       by_cases h : a₁ = a₂,
-      { subst h, 
+      { subst h,
         rcases decidable_linear_order.decidable_le _ b₁ b₂ with b_lt | b_le,
         { -- b₂ < b₁
-          left, rw not_le at b_lt, rintro ⟨l, r⟩, 
-          { apply lt_irrefl a₁, assumption }, 
+          left, rw not_le at b_lt, rintro ⟨l, r⟩,
+          { apply lt_irrefl a₁, assumption },
           { apply lt_irrefl b₂, apply lt_of_lt_of_le, repeat { assumption } } },
           -- b₁ ≤ b₂
          { right, right, assumption } },

--- a/src/order/zorn.lean
+++ b/src/order/zorn.lean
@@ -7,7 +7,7 @@ Zorn's lemmas.
 
 Ported from Isabelle/HOL (written by Jacques D. Fleuriot, Tobias Nipkow, and Christian Sternagel).
 -/
-import data.set.lattice order.order_iso
+import data.set.lattice
 noncomputable theory
 
 universes u

--- a/src/ring_theory/algebra_operations.lean
+++ b/src/ring_theory/algebra_operations.lean
@@ -6,8 +6,9 @@ Authors: Kenny Lau
 Multiplication of submodules of an algebra.
 -/
 
-import ring_theory.algebra algebra.pointwise ring_theory.ideals
+import ring_theory.algebra algebra.pointwise
 import tactic.chain
+import tactic.monotonicity.basic
 
 universes u v
 

--- a/src/ring_theory/polynomial.lean
+++ b/src/ring_theory/polynomial.lean
@@ -9,8 +9,8 @@ Main result: Hilbert basis theorem, that if a ring is noetherian then so is its 
 -/
 
 import data.polynomial data.mv_polynomial
-import ring_theory.principal_ideal_domain
 import ring_theory.subring
+import ring_theory.ideals ring_theory.noetherian
 
 universes u v w
 

--- a/src/set_theory/lists.lean
+++ b/src/set_theory/lists.lean
@@ -7,7 +7,7 @@ A computable model of hereditarily finite sets with atoms
 (ZFA without infinity). This is useful for calculations in naive
 set theory.
 -/
-import tactic.interactive data.list.basic
+import tactic.interactive data.list.basic data.sigma
 
 variables {α : Type*}
 

--- a/src/tactic/basic.lean
+++ b/src/tactic/basic.lean
@@ -972,4 +972,17 @@ meta def clear_aux_decl_aux : list expr → tactic unit
 meta def clear_aux_decl : tactic unit :=
 local_context >>= clear_aux_decl_aux
 
+precedence `setup_tactic_parser`:0
+
+@[user_command]
+meta def setup_tactic_parser_cmd (_ : interactive.parse $ tk "setup_tactic_parser") : lean.parser unit :=
+emit_code_here "
+open lean
+open lean.parser
+open interactive interactive.types
+
+local postfix `?`:9001 := optional
+local postfix *:9001 := many .
+"
+
 end tactic

--- a/src/tactic/chain.lean
+++ b/src/tactic/chain.lean
@@ -2,7 +2,8 @@
 -- Released under Apache 2.0 license as described in the file LICENSE.
 -- Authors: Scott Morrison, Mario Carneiro
 
-import tactic
+import tactic.basic
+import tactic.ext
 import data.option.defs
 
 open interactive

--- a/src/tactic/default.lean
+++ b/src/tactic/default.lean
@@ -5,3 +5,8 @@ import
   tactic.mk_iff_of_inductive_prop
   tactic.wlog
   tactic.monotonicity.interactive
+  tactic.basic tactic.generalize_proofs
+  tactic.split_ifs tactic.ext tactic.tauto
+  tactic.where tactic.abel tactic.ring tactic.squeeze
+  tactic.tidy
+  tactic.linarith tactic.omega

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Simon Hudon, Sebastien Gouezel, Scott Morrison
 -/
-import data.dlist data.dlist.basic data.prod category.basic
+import data.list.defs tactic.rcases tactic.generalize_proofs tactic.tauto
   tactic.basic tactic.rcases tactic.generalize_proofs
   tactic.split_ifs logic.basic tactic.ext tactic.tauto
   tactic.replacer tactic.simpa tactic.squeeze tactic.library_search

--- a/src/tactic/omega/nat/dnf.lean
+++ b/src/tactic/omega/nat/dnf.lean
@@ -7,7 +7,7 @@ DNF transformation.
 -/
 
 import tactic.omega.clause
-import tactic.omega.nat.sub_elim
+import tactic.omega.nat.form
 
 namespace omega
 namespace nat

--- a/src/tactic/omega/nat/main.lean
+++ b/src/tactic/omega/nat/main.lean
@@ -9,6 +9,7 @@ Main procedure for linear natural number arithmetic.
 import tactic.omega.prove_unsats
 import tactic.omega.nat.dnf
 import tactic.omega.nat.neg_elim
+import tactic.omega.nat.sub_elim
 
 open tactic
 

--- a/src/tactic/rcases.lean
+++ b/src/tactic/rcases.lean
@@ -323,14 +323,10 @@ do l ← intros,
     set_goals gs,
     pure p
 
-section interactive
-open interactive interactive.types expr
+setup_tactic_parser
 
 local notation `listΣ` := list_Sigma
 local notation `listΠ` := list_Pi
-
-local postfix `?`:9001 := optional
-local postfix *:9001 := many
 
 meta def rcases_patt_parse_core
   (rcases_patt_parse_list : parser (listΣ rcases_patt_inverted)) :
@@ -374,5 +370,4 @@ meta def ext_parse : parser ext_patt :=
   (brackets "(" ")" rcases_patt_parse_list <|>
   (λ x, [x]) <$> rcases_patt_parse))*
 
-end interactive
 end tactic

--- a/src/tactic/tfae.lean
+++ b/src/tactic/tfae.lean
@@ -8,7 +8,7 @@ Tactic for proving the equivalence of a set of proposition
 using various implications between them.
 -/
 
-import tactic.basic tactic.interactive data.list.basic
+import tactic.interactive data.list.basic
 import tactic.scc
 
 open expr tactic lean lean.parser

--- a/src/tactic/tidy.lean
+++ b/src/tactic/tidy.lean
@@ -2,7 +2,7 @@
 -- Released under Apache 2.0 license as described in the file LICENSE.
 -- Authors: Scott Morrison
 
-import tactic
+import tactic.ext
 import tactic.auto_cases
 import tactic.chain
 import tactic.interactive

--- a/src/tactic/wlog.lean
+++ b/src/tactic/wlog.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl
 
 Without loss of generality tactic.
 -/
-import tactic.basic tactic.interactive data.list.perm
+import tactic.tauto tactic.basic data.list.perm
 
 open expr tactic lean lean.parser
 

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -16,7 +16,7 @@ Reference:
 * Bourbaki: General Topology (1995), Chapter 3 §5 (Infinite sums in commutative groups)
 
 -/
-import logic.function algebra.big_operators data.set data.finset
+import logic.function algebra.big_operators data.set.lattice data.finset
        topology.metric_space.basic topology.algebra.uniform_group topology.algebra.ring
        topology.algebra.ordered topology.instances.real
 

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -6,10 +6,9 @@ Authors: Johannes Hölzl, Mario Carneiro
 Theory of ordered topology.
 -/
 import order.liminf_limsup
-import algebra.big_operators algebra.group algebra.pi_instances
-import data.set.intervals data.equiv.algebra
+import data.set.intervals
 import topology.algebra.group
-import topology.constructions topology.uniform_space.uniform_embedding topology.uniform_space.separation
+import topology.constructions
 
 open classical set lattice filter topological_space
 local attribute [instance] classical.prop_decidable

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -6,7 +6,7 @@ Authors: Johannes Hölzl, Mario Carneiro
 Bases of topologies. Countability axioms.
 -/
 
-import topology.order
+import topology.order data.set.countable
 
 open set filter lattice classical
 

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -10,7 +10,7 @@ Parts of the formalization is based on the books:
   I. M. James: Topologies and Uniformities
 A major difference is that this formalization is heavily based on the filter library.
 -/
-import order.filter data.set.countable tactic
+import order.filter
 
 open set filter lattice classical
 local attribute [instance] prop_decidable

--- a/src/topology/bounded_continuous_function.lean
+++ b/src/topology/bounded_continuous_function.lean
@@ -8,7 +8,7 @@ the uniform distance.
  -/
 
 import analysis.normed_space.basic topology.metric_space.cau_seq_filter
-       topology.metric_space.lipschitz topology.instances.real
+       topology.metric_space.lipschitz
 
 noncomputable theory
 local attribute [instance] classical.decidable_inhabited classical.prop_decidable

--- a/src/topology/instances/polynomial.lean
+++ b/src/topology/instances/polynomial.lean
@@ -6,7 +6,7 @@ Author: Robert Y. Lewis
 Analytic facts about polynomials.
 -/
 
-import topology.algebra.ring data.polynomial
+import topology.algebra.ring data.polynomial data.real.cau_seq
 
 open polynomial is_absolute_value
 

--- a/src/topology/instances/real.lean
+++ b/src/topology/instances/real.lean
@@ -21,7 +21,7 @@ generalizations:
 * Archimedean fields
 
 -/
-import logic.function topology.metric_space.basic topology.algebra.uniform_group
+import topology.metric_space.basic topology.algebra.uniform_group
        topology.algebra.ring tactic.linarith
 
 noncomputable theory

--- a/src/topology/metric_space/completion.lean
+++ b/src/topology/metric_space/completion.lean
@@ -10,7 +10,7 @@ here that the uniform space completion of a metric space inherits a metric space
 by extending the distance to the completion and checking that it is indeed a distance, and that
 it defines the same uniformity as the already defined uniform structure on the completion
 -/
-import topology.uniform_space.completion topology.instances.real topology.metric_space.isometry
+import topology.uniform_space.completion topology.metric_space.isometry
 open lattice set filter uniform_space uniform_space.completion
 noncomputable theory
 

--- a/src/topology/metric_space/hausdorff_distance.lean
+++ b/src/topology/metric_space/hausdorff_distance.lean
@@ -14,7 +14,7 @@ This files introduces:
 `Hausdorff_dist`.
 -/
 
-import topology.metric_space.isometry topology.instances.ennreal topology.metric_space.cau_seq_filter
+import topology.metric_space.isometry topology.instances.ennreal
        topology.metric_space.lipschitz
 noncomputable theory
 local attribute [instance, priority 0] classical.prop_decidable

--- a/src/topology/metric_space/isometry.lean
+++ b/src/topology/metric_space/isometry.lean
@@ -8,7 +8,7 @@ the edistance (on metric spaces, these are exactly the maps that preserve distan
 and prove their basic properties. We also introduce isometric bijections.
 -/
 
-import topology.metric_space.basic topology.instances.real
+import topology.metric_space.basic
 topology.bounded_continuous_function analysis.normed_space.basic topology.opens
 
 noncomputable theory

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -24,7 +24,7 @@ The formalization is mostly based on the books:
   I. M. James: Topologies and Uniformities
 A major difference is that this formalization is heavily based on the filter library.
 -/
-import order.filter order.filter.lift data.quot topology.constructions
+import order.filter.basic order.filter.lift topology.constructions
 
 open set lattice filter classical
 local attribute [instance, priority 0] prop_decidable

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -34,7 +34,7 @@ This formalization is mostly based on
   I. M. James: Topologies and Uniformities
 From a slightly different perspective in order to reuse material in topology.uniform_space.basic.
 -/
-import data.set.basic data.set.function
+import data.set.basic
 import topology.uniform_space.uniform_embedding topology.uniform_space.separation
 
 


### PR DESCRIPTION
`tactic/interactive` on many theories

Right now `tactic/interactive` depends on `data.list.basic` and `logic.basic` which means that every file importing `tactic/interactive` also depends on both. By breaking down `tactic/interactive` around the various modules it depends on, I'm hoping to decrease coupling.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
