### PR TITLE
refactor(data/int/basic): weaken hypotheses for int.induction_on

### DIFF
--- a/src/algebra/group_power.lean
+++ b/src/algebra/group_power.lean
@@ -370,7 +370,7 @@ theorem map_smul (a : α) (n : ℕ) : f (n • a) = n • f a :=
 is_add_monoid_hom.map_smul f a n
 
 theorem map_gsmul (a : α) (n : ℤ) : f (gsmul n a) = gsmul n (f a) :=
-@is_group_hom.gpow (multiplicative α) (multiplicative β) _ _ f _ a n
+@is_group_hom.map_gpow (multiplicative α) (multiplicative β) _ _ f _ a n
 
 end is_add_group_hom
 

--- a/src/algebra/group_power.lean
+++ b/src/algebra/group_power.lean
@@ -370,12 +370,7 @@ theorem smul (a : α) (n : ℕ) : f (n • a) = n • f a :=
 is_add_monoid_hom.map_smul f a n
 
 theorem gsmul (a : α) (n : ℤ) : f (gsmul n a) = gsmul n (f a) :=
-begin
-  induction n using int.induction_on with z ih z ih,
-  { simp [is_add_group_hom.zero f] },
-  { simp [is_add_group_hom.add f, add_gsmul, ih] },
-  { simp [is_add_group_hom.add f, is_add_group_hom.neg f, add_gsmul, ih] }
-end
+@is_group_hom.gpow (multiplicative α) (multiplicative β) _ _ f _ a n
 
 end is_add_group_hom
 

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -95,7 +95,7 @@ theorem le_sub_one_iff {a b : ℤ} : a ≤ b - 1 ↔ a < b :=
 le_sub_iff_add_le
 
 @[elab_as_eliminator] protected lemma induction_on {p : ℤ → Prop}
-  (i : ℤ) (hz : p 0) (hp : ∀i, p i → p (i + 1)) (hn : ∀i, p i → p (i - 1)) : p i :=
+  (i : ℤ) (hz : p 0) (hp : ∀i : ℕ, p i → p (i + 1)) (hn : ∀i : ℕ, p (-i) → p (-i - 1)) : p i :=
 begin
   induction i,
   { induction i,


### PR DESCRIPTION
`i` in the hypothesis is now a `nat` rather than an `int`.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
