### PR TITLE
fix(category_theory): turn `has_limits` classes into structures

### DIFF
--- a/src/category_theory/adjunction.lean
+++ b/src/category_theory/adjunction.lean
@@ -310,10 +310,12 @@ def functoriality_is_left_adjoint :
 
 /-- A left adjoint preserves colimits. -/
 def left_adjoint_preserves_colimits : preserves_colimits F :=
-λ J 𝒥 K, by resetI; exact
-{ preserves := λ c hc, is_colimit_iso_unique_cocone_morphism.inv
-    (λ s, (((adj.functoriality_is_left_adjoint _).adj).hom_equiv _ _).unique_of_equiv $
-      is_colimit_iso_unique_cocone_morphism.hom hc _ ) }
+{ preserves_colimits_of_shape := λ J 𝒥,
+  { preserves_colimit := λ F,
+    by resetI; exact
+    { preserves := λ c hc, is_colimit_iso_unique_cocone_morphism.inv
+        (λ s, (((adj.functoriality_is_left_adjoint _).adj).hom_equiv _ _).unique_of_equiv $
+          is_colimit_iso_unique_cocone_morphism.hom hc _ ) } } }
 
 end preservation_colimits
 
@@ -346,10 +348,12 @@ def functoriality_is_right_adjoint :
 
 /-- A right adjoint preserves limits. -/
 def right_adjoint_preserves_limits : preserves_limits G :=
-λ J 𝒥 K, by resetI; exact
-{ preserves := λ c hc, is_limit_iso_unique_cone_morphism.inv
-    (λ s, (((adj.functoriality_is_right_adjoint _).adj).hom_equiv _ _).symm.unique_of_equiv $
-      is_limit_iso_unique_cone_morphism.hom hc _) }
+{ preserves_colimits_of_shape := λ J 𝒥,
+  { preserves_colimit := λ K,
+    by resetI; exact
+    { preserves := λ c hc, is_limit_iso_unique_cone_morphism.inv
+        (λ s, (((adj.functoriality_is_right_adjoint _).adj).hom_equiv _ _).symm.unique_of_equiv $
+          is_limit_iso_unique_cone_morphism.hom hc _) }
 
 end preservation_limits
 

--- a/src/category_theory/adjunction.lean
+++ b/src/category_theory/adjunction.lean
@@ -348,12 +348,12 @@ def functoriality_is_right_adjoint :
 
 /-- A right adjoint preserves limits. -/
 def right_adjoint_preserves_limits : preserves_limits G :=
-{ preserves_colimits_of_shape := λ J 𝒥,
-  { preserves_colimit := λ K,
+{ preserves_limits_of_shape := λ J 𝒥,
+  { preserves_limit := λ K,
     by resetI; exact
     { preserves := λ c hc, is_limit_iso_unique_cone_morphism.inv
         (λ s, (((adj.functoriality_is_right_adjoint _).adj).hom_equiv _ _).symm.unique_of_equiv $
-          is_limit_iso_unique_cone_morphism.hom hc _) }
+          is_limit_iso_unique_cone_morphism.hom hc _) } } }
 
 end preservation_limits
 

--- a/src/category_theory/instances/topological_spaces.lean
+++ b/src/category_theory/instances/topological_spaces.lean
@@ -49,11 +49,14 @@ by refine is_limit.of_faithful forget (limit.is_limit _) (λ s, ⟨_, _⟩) (λ 
      induced_le_iff_le_coinduced.mpr $ continuous_iff_le_coinduced.mp (s.π.app j).property)
 
 instance : has_limits.{u} Top.{u} :=
-λ J 𝒥 F, by exactI { cone := limit F, is_limit := limit_is_limit F }
+{ has_limits_of_shape := λ J 𝒥,
+  { has_limit := λ F, by exactI { cone := limit F, is_limit := limit_is_limit F } } }
 
 instance : preserves_limits (forget : Top.{u} ⥤ Type u) :=
-λ J 𝒥 F, by exactI preserves_limit_of_preserves_limit_cone
-  (limit.is_limit F) (limit.is_limit (F ⋙ forget))
+{ preserves_limits_of_shape := λ J 𝒥,
+  { preserves_limit := λ F,
+    by exactI preserves_limit_of_preserves_limit_cone
+       (limit.is_limit F) (limit.is_limit (F ⋙ forget)) } }
 
 def colimit (F : J ⥤ Top.{u}) : cocone F :=
 { X := ⟨colimit (F ⋙ forget), ⨅ j, (F.obj j).str.coinduced (colimit.ι (F ⋙ forget) j)⟩,
@@ -67,11 +70,14 @@ by refine is_colimit.of_faithful forget (colimit.is_colimit _) (λ s, ⟨_, _⟩
      induced_le_iff_le_coinduced.mpr $ continuous_iff_le_coinduced.mp (s.ι.app j).property)
 
 instance : has_colimits.{u} Top.{u} :=
-λ J 𝒥 F, by exactI { cocone := colimit F, is_colimit := colimit_is_colimit F }
+{ has_colimits_of_shape := λ J 𝒥,
+  { has_colimit := λ F, by exactI { cocone := colimit F, is_colimit := colimit_is_colimit F } } }
 
 instance : preserves_colimits (forget : Top.{u} ⥤ Type u) :=
-λ J 𝒥 F, by exactI preserves_colimit_of_preserves_colimit_cocone
-  (colimit.is_colimit F) (colimit.is_colimit (F ⋙ forget))
+{ preserves_colimits_of_shape := λ J 𝒥,
+  { preserves_colimit := λ F,
+    by exactI preserves_colimit_of_preserves_colimit_cocone
+      (colimit.is_colimit F) (colimit.is_colimit (F ⋙ forget)) } }
 
 end
 

--- a/src/category_theory/limits/functor_category.lean
+++ b/src/category_theory/limits/functor_category.lean
@@ -87,40 +87,42 @@ def functor_category_is_colimit_cocone [has_colimits_of_shape.{v} J C] (F : J �
 
 instance functor_category_has_limits_of_shape
   [has_limits_of_shape J C] : has_limits_of_shape J (K ⥤ C) :=
-λ F,
-{ cone := functor_category_limit_cone F,
-  is_limit := functor_category_is_limit_cone F }
+{ has_limit := λ F,
+  { cone := functor_category_limit_cone F,
+    is_limit := functor_category_is_limit_cone F } }
 
 instance functor_category_has_colimits_of_shape
   [has_colimits_of_shape J C] : has_colimits_of_shape J (K ⥤ C) :=
-λ F,
-{ cocone := functor_category_colimit_cocone F,
-  is_colimit := functor_category_is_colimit_cocone F }
+{ has_colimit := λ F,
+  { cocone := functor_category_colimit_cocone F,
+    is_colimit := functor_category_is_colimit_cocone F } }
 
-instance functor_category_has_limits [has_limits C] : has_limits (K ⥤ C) :=
-λ J 𝒥, by resetI; apply_instance
+instance functor_category_has_limits [has_limits.{v} C] : has_limits.{v} (K ⥤ C) :=
+{ has_limits_of_shape := λ J 𝒥, by resetI; apply_instance }
 
-instance functor_category_has_colimits [has_colimits C] : has_colimits (K ⥤ C) :=
-λ J 𝒥, by resetI; apply_instance
+instance functor_category_has_colimits [has_colimits.{v} C] : has_colimits.{v} (K ⥤ C) :=
+{ has_colimits_of_shape := λ J 𝒥, by resetI; apply_instance }
 
 instance evaluation_preserves_limits_of_shape [has_limits_of_shape J C] (k : K) :
   preserves_limits_of_shape J ((evaluation K C).obj k) :=
-λ F, preserves_limit_of_preserves_limit_cone (limit.is_limit _) $
-  is_limit.of_iso_limit (limit.is_limit _)
-    (evaluate_functor_category_limit_cone F k).symm
+{ preserves_limit :=
+  λ F, preserves_limit_of_preserves_limit_cone (limit.is_limit _) $
+    is_limit.of_iso_limit (limit.is_limit _)
+      (evaluate_functor_category_limit_cone F k).symm }
 
 instance evaluation_preserves_colimits_of_shape [has_colimits_of_shape J C] (k : K) :
   preserves_colimits_of_shape J ((evaluation K C).obj k) :=
-λ F, preserves_colimit_of_preserves_colimit_cocone (colimit.is_colimit _) $
-  is_colimit.of_iso_colimit (colimit.is_colimit _)
-    (evaluate_functor_category_colimit_cocone F k).symm
+{ preserves_colimit :=
+  λ F, preserves_colimit_of_preserves_colimit_cocone (colimit.is_colimit _) $
+    is_colimit.of_iso_colimit (colimit.is_colimit _)
+      (evaluate_functor_category_colimit_cocone F k).symm }
 
-instance evaluation_preserves_limits [has_limits C] (k : K) :
+instance evaluation_preserves_limits [has_limits.{v} C] (k : K) :
   preserves_limits ((evaluation K C).obj k) :=
-λ J 𝒥, by resetI; apply_instance
+{ preserves_limits_of_shape := λ J 𝒥, by resetI; apply_instance }
 
-instance evaluation_preserves_colimits [has_colimits C] (k : K) :
+instance evaluation_preserves_colimits [has_colimits.{v} C] (k : K) :
   preserves_colimits ((evaluation K C).obj k) :=
-λ J 𝒥, by resetI; apply_instance
+{ preserves_colimits_of_shape := λ J 𝒥, by resetI; apply_instance }
 
 end category_theory.limits

--- a/src/category_theory/limits/limits.lean
+++ b/src/category_theory/limits/limits.lean
@@ -251,21 +251,22 @@ variables (J C)
 
 /-- `C` has limits of shape `J` if we have chosen a particular limit of
   every functor `F : J ⥤ C`. -/
-@[class] def has_limits_of_shape := Π F : J ⥤ C, has_limit F
+class has_limits_of_shape :=
+(has_limit : Π F : J ⥤ C, has_limit F)
 
 /-- `C` has all (small) limits if it has limits of every shape. -/
-@[class] def has_limits :=
-Π {J : Type v} {𝒥 : small_category J}, by exactI has_limits_of_shape J C
+class has_limits :=
+(has_limits_of_shape : Π (J : Type v) [𝒥 : small_category J], has_limits_of_shape J C)
 
 variables {J C}
 
 instance has_limit_of_has_limits_of_shape
   {J : Type v} [small_category J] [H : has_limits_of_shape J C] (F : J ⥤ C) : has_limit F :=
-H F
+has_limits_of_shape.has_limit F
 
 instance has_limits_of_shape_of_has_limits
   {J : Type v} [small_category J] [H : has_limits.{v} C] : has_limits_of_shape J C :=
-H
+has_limits.has_limits_of_shape C J
 
 /- Interface to the `has_limit` class. -/
 
@@ -454,21 +455,22 @@ variables (J C)
 
 /-- `C` has colimits of shape `J` if we have chosen a particular colimit of
   every functor `F : J ⥤ C`. -/
-@[class] def has_colimits_of_shape := Π F : J ⥤ C, has_colimit F
+class has_colimits_of_shape :=
+(has_colimit : Π F : J ⥤ C, has_colimit F)
 
-/-- `C` has all (small) colimits if it has limits of every shape. -/
-@[class] def has_colimits :=
-Π {J : Type v} {𝒥 : small_category J}, by exactI has_colimits_of_shape J C
+/-- `C` has all (small) colimits if it has colimits of every shape. -/
+class has_colimits :=
+(has_colimits_of_shape : Π (J : Type v) [𝒥 : small_category J], has_colimits_of_shape J C)
 
 variables {J C}
 
 instance has_colimit_of_has_colimits_of_shape
   {J : Type v} [small_category J] [H : has_colimits_of_shape J C] (F : J ⥤ C) : has_colimit F :=
-H F
+has_colimits_of_shape.has_colimit F
 
 instance has_colimits_of_shape_of_has_colimits
   {J : Type v} [small_category J] [H : has_colimits.{v} C] : has_colimits_of_shape J C :=
-H
+has_colimits.has_colimits_of_shape C J
 
 /- Interface to the `has_colimit` class. -/
 

--- a/src/category_theory/limits/over.lean
+++ b/src/category_theory/limits/over.lean
@@ -55,25 +55,27 @@ def forget_colimit_is_colimit (F : J ⥤ over X) [has_colimit (F ⋙ forget)] :
 is_colimit.of_iso_colimit (colimit.is_colimit (F ⋙ forget)) (cocones.ext (iso.refl _) (by tidy))
 
 instance : reflects_colimits (forget : over X ⥤ C) :=
-λ J 𝒥 F, by constructor; exactI λ t ht,
-{ desc := λ s, hom_mk (ht.desc (forget.map_cocone s))
-    begin
-      apply ht.hom_ext, intro j,
-      rw [←category.assoc, ht.fac],
-      transitivity (F.obj j).hom,
-      exact w (s.ι.app j), -- TODO: How to write (s.ι.app j).w?
-      exact (w (t.ι.app j)).symm,
-    end,
-  fac' := begin
-    intros s j, ext, exact ht.fac (forget.map_cocone s) j
-    -- TODO: Ask Simon about multiple ext lemmas for defeq types (comma_morphism & over.category.hom)
-  end,
-  uniq' :=
-  begin
-    intros s m w,
-    ext1 j,
-    exact ht.uniq (forget.map_cocone s) m.left (λ j, congr_arg comma_morphism.left (w j))
-  end }
+{ reflects_colimits_of_shape := λ J 𝒥,
+  { reflects_colimit := λ F,
+    by constructor; exactI λ t ht,
+    { desc := λ s, hom_mk (ht.desc (forget.map_cocone s))
+        begin
+          apply ht.hom_ext, intro j,
+          rw [←category.assoc, ht.fac],
+          transitivity (F.obj j).hom,
+          exact w (s.ι.app j), -- TODO: How to write (s.ι.app j).w?
+          exact (w (t.ι.app j)).symm,
+        end,
+      fac' := begin
+        intros s j, ext, exact ht.fac (forget.map_cocone s) j
+        -- TODO: Ask Simon about multiple ext lemmas for defeq types (comma_morphism & over.category.hom)
+      end,
+      uniq' :=
+      begin
+        intros s m w,
+        ext1 j,
+        exact ht.uniq (forget.map_cocone s) m.left (λ j, congr_arg comma_morphism.left (w j))
+      end } } }
 
 instance has_colimit {F : J ⥤ over X} [has_colimit (F ⋙ forget)] : has_colimit F :=
 { cocone := colimit F,
@@ -81,15 +83,16 @@ instance has_colimit {F : J ⥤ over X} [has_colimit (F ⋙ forget)] : has_colim
 
 instance has_colimits_of_shape [has_colimits_of_shape J C] :
   has_colimits_of_shape J (over X) :=
-λ F, by apply_instance
+{ has_colimit := λ F, by apply_instance }
 
-instance has_colimits [has_colimits C] : has_colimits (over X) :=
-λ J 𝒥, by resetI; apply_instance
+instance has_colimits [has_colimits.{v} C] : has_colimits.{v} (over X) :=
+{ has_colimits_of_shape := λ J 𝒥, by resetI; apply_instance }
 
-instance forget_preserves_colimits [has_colimits C] {X : C} :
+instance forget_preserves_colimits [has_colimits.{v} C] {X : C} :
   preserves_colimits (forget : over X ⥤ C) :=
-λ J 𝒥 F, by exactI
-preserves_colimit_of_preserves_colimit_cocone (colimit.is_colimit F) (forget_colimit_is_colimit F)
+{ preserves_colimits_of_shape := λ J 𝒥,
+  { preserves_colimit := λ F, by exactI
+    preserves_colimit_of_preserves_colimit_cocone (colimit.is_colimit F) (forget_colimit_is_colimit F) } }
 
 end category_theory.over
 
@@ -116,24 +119,26 @@ def forget_limit_is_limit (F : J ⥤ under X) [has_limit (F ⋙ forget)] :
 is_limit.of_iso_limit (limit.is_limit (F ⋙ forget)) (cones.ext (iso.refl _) (by tidy))
 
 instance : reflects_limits (forget : under X ⥤ C) :=
-λ J 𝒥 F, by constructor; exactI λ t ht,
-{ lift := λ s, hom_mk (ht.lift (forget.map_cone s))
-    begin
-      apply ht.hom_ext, intro j,
-      rw [category.assoc, ht.fac],
-      transitivity (F.obj j).hom,
-      exact w (s.π.app j),
-      exact (w (t.π.app j)).symm,
-    end,
-  fac' := begin
-    intros s j, ext, exact ht.fac (forget.map_cone s) j
-  end,
-  uniq' :=
-  begin
-    intros s m w,
-    ext1 j,
-    exact ht.uniq (forget.map_cone s) m.right (λ j, congr_arg comma_morphism.right (w j))
-  end }
+{ reflects_limits_of_shape := λ J 𝒥,
+  { reflects_limit := λ F,
+    by constructor; exactI λ t ht,
+    { lift := λ s, hom_mk (ht.lift (forget.map_cone s))
+        begin
+          apply ht.hom_ext, intro j,
+          rw [category.assoc, ht.fac],
+          transitivity (F.obj j).hom,
+          exact w (s.π.app j),
+          exact (w (t.π.app j)).symm,
+        end,
+      fac' := begin
+        intros s j, ext, exact ht.fac (forget.map_cone s) j
+      end,
+      uniq' :=
+      begin
+        intros s m w,
+        ext1 j,
+        exact ht.uniq (forget.map_cone s) m.right (λ j, congr_arg comma_morphism.right (w j))
+      end } } }
 
 instance has_limit {F : J ⥤ under X} [has_limit (F ⋙ forget)] : has_limit F :=
 { cone := limit F,
@@ -141,14 +146,15 @@ instance has_limit {F : J ⥤ under X} [has_limit (F ⋙ forget)] : has_limit F 
 
 instance has_limits_of_shape [has_limits_of_shape J C] :
   has_limits_of_shape J (under X) :=
-λ F, by apply_instance
+{ has_limit := λ F, by apply_instance }
 
-instance has_limits [has_limits C] : has_limits (under X) :=
-λ J 𝒥, by resetI; apply_instance
+instance has_limits [has_limits.{v} C] : has_limits.{v} (under X) :=
+{ has_limits_of_shape := λ J 𝒥, by resetI; apply_instance }
 
-instance forget_preserves_limits [has_limits C] {X : C} :
+instance forget_preserves_limits [has_limits.{v} C] {X : C} :
   preserves_limits (forget : under X ⥤ C) :=
-λ J 𝒥 F, by exactI
-preserves_limit_of_preserves_limit_cone (limit.is_limit F) (forget_limit_is_limit F)
+{ preserves_limits_of_shape := λ J 𝒥,
+  { preserves_limit := λ F, by exactI
+    preserves_limit_of_preserves_limit_cone (limit.is_limit F) (forget_limit_is_limit F) } }
 
 end category_theory.under

--- a/src/category_theory/limits/preserves.lean
+++ b/src/category_theory/limits/preserves.lean
@@ -51,15 +51,15 @@ class preserves_limit (K : J ⥤ C) (F : C ⥤ D) : Type (max u₁ u₂ v) :=
 class preserves_colimit (K : J ⥤ C) (F : C ⥤ D) : Type (max u₁ u₂ v) :=
 (preserves : Π {c : cocone K}, is_colimit c → is_colimit (F.map_cocone c))
 
-@[class] def preserves_limits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) : Type (max u₁ u₂ v) :=
-Π {K : J ⥤ C}, preserves_limit K F
-@[class] def preserves_colimits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) : Type (max u₁ u₂ v) :=
-Π {K : J ⥤ C}, preserves_colimit K F
+class preserves_limits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) : Type (max u₁ u₂ v) :=
+(preserves_limit : Π {K : J ⥤ C}, preserves_limit K F)
+class preserves_colimits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) : Type (max u₁ u₂ v) :=
+(preserves_colimit : Π {K : J ⥤ C}, preserves_colimit K F)
 
-@[class] def preserves_limits (F : C ⥤ D) : Type (max u₁ u₂ (v+1)) :=
-Π {J : Type v} {𝒥 : small_category J}, by exactI preserves_limits_of_shape J F
-@[class] def preserves_colimits (F : C ⥤ D) : Type (max u₁ u₂ (v+1)) :=
-Π {J : Type v} {𝒥 : small_category J}, by exactI preserves_colimits_of_shape J F
+class preserves_limits (F : C ⥤ D) : Type (max u₁ u₂ (v+1)) :=
+(preserves_limits_of_shape : Π {J : Type v} {𝒥 : small_category J}, by exactI preserves_limits_of_shape J F)
+class preserves_colimits (F : C ⥤ D) : Type (max u₁ u₂ (v+1)) :=
+(preserves_colimits_of_shape : Π {J : Type v} {𝒥 : small_category J}, by exactI preserves_colimits_of_shape J F)
 
 instance preserves_limit_subsingleton (K : J ⥤ C) (F : C ⥤ D) : subsingleton (preserves_limit K F) :=
 by split; rintros ⟨a⟩ ⟨b⟩; congr
@@ -68,41 +68,43 @@ by split; rintros ⟨a⟩ ⟨b⟩; congr
 
 instance preserves_limits_of_shape_subsingleton (J : Type v) [small_category J] (F : C ⥤ D) :
   subsingleton (preserves_limits_of_shape J F) :=
-by split; intros; funext; apply subsingleton.elim
+by { split, intros, cases a, cases b, congr }
 instance preserves_colimits_of_shape_subsingleton (J : Type v) [small_category J] (F : C ⥤ D) :
   subsingleton (preserves_colimits_of_shape J F) :=
-by split; intros; funext; apply subsingleton.elim
+by { split, intros, cases a, cases b, congr }
 
 instance preserves_limits_subsingleton (F : C ⥤ D) : subsingleton (preserves_limits F) :=
-by split; intros; funext; resetI; apply subsingleton.elim
+by { split, intros, cases a, cases b, congr, funext J 𝒥, resetI, apply subsingleton.elim }
 instance preserves_colimits_subsingleton (F : C ⥤ D) : subsingleton (preserves_colimits F) :=
-by split; intros; funext; resetI; apply subsingleton.elim
+by { split, intros, cases a, cases b, congr, funext J 𝒥, resetI, apply subsingleton.elim }
 
 instance preserves_limit_of_preserves_limits_of_shape (F : C ⥤ D)
   [H : preserves_limits_of_shape J F] : preserves_limit K F :=
-H
+preserves_limits_of_shape.preserves_limit J F
 instance preserves_colimit_of_preserves_colimits_of_shape (F : C ⥤ D)
   [H : preserves_colimits_of_shape J F] : preserves_colimit K F :=
-H
+preserves_colimits_of_shape.preserves_colimit J F
 
 instance preserves_limits_of_shape_of_preserves_limits (F : C ⥤ D)
   [H : preserves_limits F] : preserves_limits_of_shape J F :=
-@H J _
+preserves_limits.preserves_limits_of_shape F
 instance preserves_colimits_of_shape_of_preserves_colimits (F : C ⥤ D)
   [H : preserves_colimits F] : preserves_colimits_of_shape J F :=
-@H J _
+preserves_colimits.preserves_colimits_of_shape F
 
 instance id_preserves_limits : preserves_limits (functor.id C) :=
-λ J 𝒥 K, by exactI ⟨λ c h,
+{ preserves_limits_of_shape := λ J 𝒥,
+  { preserves_limit := λ K, by exactI ⟨λ c h,
   ⟨λ s, h.lift ⟨s.X, λ j, s.π.app j, λ j j' f, s.π.naturality f⟩,
    by cases K; rcases c with ⟨_, _, _⟩; intros s j; cases s; exact h.fac _ j,
-   by cases K; rcases c with ⟨_, _, _⟩; intros s m w; rcases s with ⟨_, _, _⟩; exact h.uniq _ m w⟩⟩
+   by cases K; rcases c with ⟨_, _, _⟩; intros s m w; rcases s with ⟨_, _, _⟩; exact h.uniq _ m w⟩⟩ } }
 
 instance id_preserves_colimits : preserves_colimits (functor.id C) :=
-λ J 𝒥 K, by exactI ⟨λ c h,
+{ preserves_colimits_of_shape := λ J 𝒥,
+  { preserves_colimit := λ K, by exactI ⟨λ c h,
   ⟨λ s, h.desc ⟨s.X, λ j, s.ι.app j, λ j j' f, s.ι.naturality f⟩,
    by cases K; rcases c with ⟨_, _, _⟩; intros s j; cases s; exact h.fac _ j,
-   by cases K; rcases c with ⟨_, _, _⟩; intros s m w; rcases s with ⟨_, _, _⟩; exact h.uniq _ m w⟩⟩
+   by cases K; rcases c with ⟨_, _, _⟩; intros s m w; rcases s with ⟨_, _, _⟩; exact h.uniq _ m w⟩⟩ } }
 
 section
 variables {E : Sort u₃} [ℰ : category.{v+1} E]
@@ -144,15 +146,15 @@ class reflects_limit (K : J ⥤ C) (F : C ⥤ D) : Type (max u₁ u₂ v) :=
 class reflects_colimit (K : J ⥤ C) (F : C ⥤ D) : Type (max u₁ u₂ v) :=
 (reflects : Π {c : cocone K}, is_colimit (F.map_cocone c) → is_colimit c)
 
-@[class] def reflects_limits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) : Type (max u₁ u₂ v) :=
-Π {K : J ⥤ C}, reflects_limit K F
-@[class] def reflects_colimits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) : Type (max u₁ u₂ v) :=
-Π {K : J ⥤ C}, reflects_colimit K F
+class reflects_limits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) : Type (max u₁ u₂ v) :=
+(reflects_limit : Π {K : J ⥤ C}, reflects_limit K F)
+class reflects_colimits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) : Type (max u₁ u₂ v) :=
+(reflects_colimit : Π {K : J ⥤ C}, reflects_colimit K F)
 
-@[class] def reflects_limits (F : C ⥤ D) : Type (max u₁ u₂ (v+1)) :=
-Π {J : Type v} {𝒥 : small_category J}, by exactI reflects_limits_of_shape J F
-@[class] def reflects_colimits (F : C ⥤ D) : Type (max u₁ u₂ (v+1)) :=
-Π {J : Type v} {𝒥 : small_category J}, by exactI reflects_colimits_of_shape J F
+class reflects_limits (F : C ⥤ D) : Type (max u₁ u₂ (v+1)) :=
+(reflects_limits_of_shape : Π {J : Type v} {𝒥 : small_category J}, by exactI reflects_limits_of_shape J F)
+class reflects_colimits (F : C ⥤ D) : Type (max u₁ u₂ (v+1)) :=
+(reflects_colimits_of_shape : Π {J : Type v} {𝒥 : small_category J}, by exactI reflects_colimits_of_shape J F)
 
 instance reflects_limit_subsingleton (K : J ⥤ C) (F : C ⥤ D) : subsingleton (reflects_limit K F) :=
 by split; rintros ⟨a⟩ ⟨b⟩; congr
@@ -161,41 +163,43 @@ by split; rintros ⟨a⟩ ⟨b⟩; congr
 
 instance reflects_limits_of_shape_subsingleton (J : Type v) [small_category J] (F : C ⥤ D) :
   subsingleton (reflects_limits_of_shape J F) :=
-by split; intros; funext; apply subsingleton.elim
+by { split, intros, cases a, cases b, congr }
 instance reflects_colimits_of_shape_subsingleton (J : Type v) [small_category J] (F : C ⥤ D) :
   subsingleton (reflects_colimits_of_shape J F) :=
-by split; intros; funext; apply subsingleton.elim
+by { split, intros, cases a, cases b, congr }
 
 instance reflects_limits_subsingleton (F : C ⥤ D) : subsingleton (reflects_limits F) :=
-by split; intros; funext; resetI; apply subsingleton.elim
+by { split, intros, cases a, cases b, congr, funext J 𝒥, resetI, apply subsingleton.elim }
 instance reflects_colimits_subsingleton (F : C ⥤ D) : subsingleton (reflects_colimits F) :=
-by split; intros; funext; resetI; apply subsingleton.elim
+by { split, intros, cases a, cases b, congr, funext J 𝒥, resetI, apply subsingleton.elim }
 
 instance reflects_limit_of_reflects_limits_of_shape (K : J ⥤ C) (F : C ⥤ D)
   [H : reflects_limits_of_shape J F] : reflects_limit K F :=
-H
+reflects_limits_of_shape.reflects_limit J F
 instance reflects_colimit_of_reflects_colimits_of_shape (K : J ⥤ C) (F : C ⥤ D)
   [H : reflects_colimits_of_shape J F] : reflects_colimit K F :=
-H
+reflects_colimits_of_shape.reflects_colimit J F
 
 instance reflects_limits_of_shape_of_reflects_limits (F : C ⥤ D)
   [H : reflects_limits F] : reflects_limits_of_shape J F :=
-@H J _
+reflects_limits.reflects_limits_of_shape F
 instance reflects_colimits_of_shape_of_reflects_colimits (F : C ⥤ D)
   [H : reflects_colimits F] : reflects_colimits_of_shape J F :=
-@H J _
+reflects_colimits.reflects_colimits_of_shape F
 
 instance id_reflects_limits : reflects_limits (functor.id C) :=
-λ J 𝒥 K, by exactI ⟨λ c h,
+{ reflects_limits_of_shape := λ J 𝒥,
+  { reflects_limit := λ K, by exactI ⟨λ c h,
   ⟨λ s, h.lift ⟨s.X, λ j, s.π.app j, λ j j' f, s.π.naturality f⟩,
    by cases K; rcases c with ⟨_, _, _⟩; intros s j; cases s; exact h.fac _ j,
-   by cases K; rcases c with ⟨_, _, _⟩; intros s m w; rcases s with ⟨_, _, _⟩; exact h.uniq _ m w⟩⟩
+   by cases K; rcases c with ⟨_, _, _⟩; intros s m w; rcases s with ⟨_, _, _⟩; exact h.uniq _ m w⟩⟩ } }
 
 instance id_reflects_colimits : reflects_colimits (functor.id C) :=
-λ J 𝒥 K, by exactI ⟨λ c h,
+{ reflects_colimits_of_shape := λ J 𝒥,
+  { reflects_colimit := λ K, by exactI ⟨λ c h,
   ⟨λ s, h.desc ⟨s.X, λ j, s.ι.app j, λ j j' f, s.ι.naturality f⟩,
    by cases K; rcases c with ⟨_, _, _⟩; intros s j; cases s; exact h.fac _ j,
-   by cases K; rcases c with ⟨_, _, _⟩; intros s m w; rcases s with ⟨_, _, _⟩; exact h.uniq _ m w⟩⟩
+   by cases K; rcases c with ⟨_, _, _⟩; intros s m w; rcases s with ⟨_, _, _⟩; exact h.uniq _ m w⟩⟩ } }
 
 section
 variables {E : Sort u₃} [ℰ : category.{v+1} E]

--- a/src/category_theory/limits/types.lean
+++ b/src/category_theory/limits/types.lean
@@ -27,7 +27,8 @@ def limit_is_limit (F : J ⥤ Type u) : is_limit (limit F) :=
   end }
 
 instance : has_limits.{u} (Type u) :=
-λ J 𝒥 F, by exactI { cone := limit F, is_limit := limit_is_limit F }
+{ has_limits_of_shape := λ J 𝒥,
+  { has_limit := λ F, by exactI { cone := limit F, is_limit := limit_is_limit F } } }
 
 @[simp] lemma types_limit (F : J ⥤ Type u) :
   limits.limit F = {u : Π j, F.obj j // ∀ {j j'} f, F.map f (u j) = u j'} := rfl
@@ -59,7 +60,8 @@ def colimit_is_colimit (F : J ⥤ Type u) : is_colimit (colimit F) :=
     (assume ⟨j, x⟩ ⟨j', x'⟩ ⟨f, hf⟩, by rw hf; exact (congr_fun (cocone.w s f) x).symm) }
 
 instance : has_colimits.{u} (Type u) :=
-λ J 𝒥 F, by exactI { cocone := colimit F, is_colimit := colimit_is_colimit F }
+{ has_colimits_of_shape := λ J 𝒥,
+  { has_colimit := λ F, by exactI { cocone := colimit F, is_colimit := colimit_is_colimit F } } }
 
 @[simp] lemma types_colimit (F : J ⥤ Type u) :
   limits.colimit F = @quot (Σ j, F.obj j) (λ p p', ∃ f : p.1 ⟶ p'.1, p'.2 = F.map f p.2) := rfl


### PR DESCRIPTION
As discussed on [zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/typeclass.20inference.20problems.20for.20.60has_colimits.60). Both Reid and I have been having trouble with typeclass inference for `has_colimits`, which was defined as a pi-type. Neither of us had got to the bottom of it, but this should solve the problem.