### PR TITLE
fix(dev-scripts): restore ctrl-c protection

### DIFF
--- a/scripts/cache-olean.py
+++ b/scripts/cache-olean.py
@@ -9,7 +9,7 @@ import certifi
 import signal
 from git import Repo, InvalidGitRepositoryError
 from github import Github
-# from delayed_interrupt import DelayedInterrupt
+from delayed_interrupt import DelayedInterrupt
 from auth_github import auth_github
 
 
@@ -17,12 +17,12 @@ def make_cache(fn):
     if os.path.exists(fn):
         os.remove(fn)
 
-    # with DelayedInterrupt([signal.SIGTERM, signal.SIGINT]):
-    ar = tarfile.open(fn, 'w|bz2')
-    if os.path.exists('src/'): ar.add('src/')
-    if os.path.exists('test/'): ar.add('test/')
-    ar.close()
-    print('... successfully made olean cache.')
+    with DelayedInterrupt([signal.SIGTERM, signal.SIGINT]):
+        ar = tarfile.open(fn, 'w|bz2')
+        if os.path.exists('src/'): ar.add('src/')
+        if os.path.exists('test/'): ar.add('test/')
+        ar.close()
+        print('... successfully made olean cache.')
 
 def mathlib_asset(repo, rev):
     if not any(['leanprover' in r.url and 'mathlib' in r.url
@@ -63,17 +63,17 @@ def fetch_mathlib(asset):
             cert_reqs='CERT_REQUIRED',
             ca_certs=certifi.where())
         req = http.request('GET', asset.browser_download_url)
-        # with DelayedInterrupt([signal.SIGTERM, signal.SIGINT]):
-        with open(asset.name, 'wb') as f:
-            f.write(req.data)
+        with DelayedInterrupt([signal.SIGTERM, signal.SIGINT]):
+            with open(asset.name, 'wb') as f:
+                f.write(req.data)
         os.chdir(cd)
     else:
         print("Reusing cached olean archive")
 
-    # with DelayedInterrupt([signal.SIGTERM, signal.SIGINT]):
-    ar = tarfile.open(os.path.join(mathlib_dir, asset.name))
-    ar.extractall('.')
-    print("... successfully extracted olean archive.")
+    with DelayedInterrupt([signal.SIGTERM, signal.SIGINT]):
+        ar = tarfile.open(os.path.join(mathlib_dir, asset.name))
+        ar.extractall('.')
+        print("... successfully extracted olean archive.")
 
 
 if __name__ == "__main__":

--- a/scripts/setup-dev-scripts.sh
+++ b/scripts/setup-dev-scripts.sh
@@ -8,7 +8,7 @@ if [[ $1 = "--global" ]]; then
     USER_MSG="(globally)"
 fi
 
-if ! which pip3; then
+if ! which pip3 > /dev/null; then
     if which apt-get; then
         read -p "update-mathlib needs to install python3 and pip3. Proceed?" -n 1 -r
         echo

--- a/scripts/update-mathlib.py
+++ b/scripts/update-mathlib.py
@@ -11,7 +11,7 @@ import certifi
 import configparser
 import tarfile
 import signal
-# from delayed_interrupt import DelayedInterrupt
+from delayed_interrupt import DelayedInterrupt
 from auth_github import auth_github
 
 self_update = '--self-update' in sys.argv
@@ -96,6 +96,6 @@ else:
 
     # Extract archive
     print("Extracting nightly...")
-    # with DelayedInterrupt([signal.SIGTERM, signal.SIGINT]):
-    ar = tarfile.open(os.path.join(mathlib_dir, asset.name))
-    ar.extractall('_target/deps/mathlib')
+    with DelayedInterrupt([signal.SIGTERM, signal.SIGINT]):
+        ar = tarfile.open(os.path.join(mathlib_dir, asset.name))
+        ar.extractall('_target/deps/mathlib')


### PR DESCRIPTION
Restoring functionality to protect file operations involving the olean cache from ctrl-c.

I've been unable to reproduce the problem @cipher1024 saw, and travis seems to agree that everything is working.