### PR TITLE
 fix(doc/extra/tactic_writing): rename mul_left

### DIFF
--- a/docs/extras/tactic_writing.md
+++ b/docs/extras/tactic_writing.md
@@ -381,7 +381,7 @@ for using the second optional argument of `«have»` which is the expected type
 ```lean
 open interactive (loc.ns)
 open interactive.types (texpr location)
-meta def mul_left (q : parse texpr) : parse location → tactic unit
+meta def tactic.interactive.mul_left (q : parse texpr) : parse location → tactic unit
 | (loc.ns [some h]) := do
    e ← tactic.i_to_expr q,
    H ← get_local h,

--- a/docs/extras/tactic_writing.md
+++ b/docs/extras/tactic_writing.md
@@ -403,7 +403,7 @@ one if the tactic name is followed by `!`. This is the opportunity to use
 `when` which is the monadic version of `ite` (with else branch doing nothing).
 See [category/combinators.lean](https://github.com/leanprover/lean/blob/master/library/init/category/combinators.lean) in core library for other variations on this idea.
 ```lean
-meta def mul_left_bis (clear_hyp : parse (optional $ tk "!")) (q : parse texpr) :
+meta def tactic.interactive.mul_left_bis (clear_hyp : parse (optional $ tk "!")) (q : parse texpr) :
 parse location → tactic unit
 | (loc.ns [some h]) := do
    e ← tactic.i_to_expr q,


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
