### PR TITLE
fix(category_theory): make the `nat_trans` arrow `⟹` a synonym for the `hom` arrow

### DIFF
--- a/docs/theories/category_theory.md
+++ b/docs/theories/category_theory.md
@@ -93,4 +93,4 @@ We use `F ⟶ G` (`\hom` or `-->`) to denote the type of natural transformations
 We use `F ≅ G` (`\iso`) to denote the type of natural isomorphisms.
 
 For vertical composition of natural transformations we just use `≫`. For horizontal composition,
-use `vcomp`.
+use `hcomp`.

--- a/docs/theories/category_theory.md
+++ b/docs/theories/category_theory.md
@@ -84,9 +84,13 @@ We use `F.map f` to denote the action of a functor on a morphism`.
 Functor composition can be written as `F ⋙ G`.
 
 ### Natural transformations
-We use `⟹` (`\nattrans` or `\==>`) to denote the type of natural transformations, e.g. `F ⟹ G`.
-We use `⇔` (`\<=>`) to denote the type of natural isomorphisms.
-
 We use `τ.app X` for the components of a natural transformation.
 
-For vertical and horiztonal composition of natural transformations we "cutely" use `⊟` (`\boxminus`) and `◫` (currently untypeable, but we could ask for `\boxvert`).
+Otherwise, we mostly use the notation for morphisms in any category:
+
+We use `F ⟶ G` (`\hom` or `-->`) to denote the type of natural transformations, between functors
+`F` and `G`.
+We use `F ≅ G` (`\iso`) to denote the type of natural isomorphisms.
+
+For vertical composition of natural transformations we just use `≫`. For horizontal composition,
+use `vcomp`.

--- a/src/category_theory/adjunction.lean
+++ b/src/category_theory/adjunction.lean
@@ -27,7 +27,7 @@ structure adjunction (F : C ⥤ D) (G : D ⥤ C) :=
 (hom_equiv : Π (X Y), (F.obj X ⟶ Y) ≃ (X ⟶ G.obj Y))
 (unit : functor.id C ⟶ F.comp G)
 (counit : G.comp F ⟶ functor.id D)
-(hom_equiv_unit' : Π {X Y f}, (hom_equiv X Y) f = (unit : _ ⟹ _).app X ≫ G.map f . obviously)
+(hom_equiv_unit' : Π {X Y f}, (hom_equiv X Y) f = (unit : _ ⟶ _).app X ≫ G.map f . obviously)
 (hom_equiv_counit' : Π {X Y g}, (hom_equiv X Y).symm g = F.map g ≫ counit.app Y . obviously)
 
 namespace adjunction
@@ -57,7 +57,7 @@ by rw [hom_equiv_unit, G.map_comp, ← assoc, ←hom_equiv_unit]
 by rw [equiv.symm_apply_eq]; simp [-hom_equiv_counit]
 
 @[simp] lemma left_triangle :
-  (whisker_right adj.unit F).vcomp (whisker_left F adj.counit) = nat_trans.id _ :=
+  (whisker_right adj.unit F) ≫ (whisker_left F adj.counit) = nat_trans.id _ :=
 begin
   ext1 X, dsimp,
   erw [← adj.hom_equiv_counit, equiv.symm_apply_eq, adj.hom_equiv_unit],
@@ -65,7 +65,7 @@ begin
 end
 
 @[simp] lemma right_triangle :
-  (whisker_left G adj.unit).vcomp (whisker_right adj.counit G) = nat_trans.id _ :=
+  (whisker_left G adj.unit) ≫ (whisker_right adj.counit G) = nat_trans.id _ :=
 begin
   ext1 Y, dsimp,
   erw [← adj.hom_equiv_unit, ← equiv.eq_symm_apply, adj.hom_equiv_counit],
@@ -74,11 +74,11 @@ end
 
 @[simp] lemma left_triangle_components :
   F.map (adj.unit.app X) ≫ adj.counit.app (F.obj X) = 𝟙 _ :=
-congr_arg (λ (t : _ ⟹ functor.id C ⋙ F), t.app X) adj.left_triangle
+congr_arg (λ (t : nat_trans _ (functor.id C ⋙ F)), t.app X) adj.left_triangle
 
 @[simp] lemma right_triangle_components {Y : D} :
   adj.unit.app (G.obj Y) ≫ G.map (adj.counit.app Y) = 𝟙 _ :=
-congr_arg (λ (t : _ ⟹ G ⋙ functor.id C), t.app Y) adj.right_triangle
+congr_arg (λ (t : nat_trans _ (G ⋙ functor.id C)), t.app Y) adj.right_triangle
 
 end
 
@@ -110,8 +110,8 @@ end core_hom_equiv
 structure core_unit_counit (F : C ⥤ D) (G : D ⥤ C) :=
 (unit : functor.id C ⟶ F.comp G)
 (counit : G.comp F ⟶ functor.id D)
-(left_triangle' : (whisker_right unit F).vcomp (whisker_left F counit) = nat_trans.id _ . obviously)
-(right_triangle' : (whisker_left G unit).vcomp (whisker_right counit G) = nat_trans.id _ . obviously)
+(left_triangle' : (whisker_right unit F) ≫ (whisker_left F counit) = nat_trans.id _ . obviously)
+(right_triangle' : (whisker_left G unit) ≫ (whisker_right counit G) = nat_trans.id _ . obviously)
 
 namespace core_unit_counit
 
@@ -152,13 +152,13 @@ def mk_of_unit_counit (adj : core_unit_counit F G) : adjunction F G :=
       change F.map (_ ≫ _) ≫ _ = _,
       rw [F.map_comp, assoc, ←functor.comp_map, adj.counit.naturality, ←assoc],
       convert id_comp _ f,
-      exact congr_arg (λ t : _ ⟹ _, t.app _) adj.left_triangle
+      exact congr_arg (λ t : nat_trans _ _, t.app _) adj.left_triangle
     end,
     right_inv := λ g, begin
       change _ ≫ G.map (_ ≫ _) = _,
       rw [G.map_comp, ←assoc, ←functor.comp_map, ←adj.unit.naturality, assoc],
       convert comp_id _ g,
-      exact congr_arg (λ t : _ ⟹ _, t.app _) adj.right_triangle
+      exact congr_arg (λ t : nat_trans _ _, t.app _) adj.right_triangle
   end },
   .. adj }
 

--- a/src/category_theory/adjunction.lean
+++ b/src/category_theory/adjunction.lean
@@ -57,7 +57,7 @@ by rw [hom_equiv_unit, G.map_comp, ← assoc, ←hom_equiv_unit]
 by rw [equiv.symm_apply_eq]; simp [-hom_equiv_counit]
 
 @[simp] lemma left_triangle :
-  (whisker_right adj.unit F).vcomp (whisker_left F adj.counit) = nat_trans.id _ :=
+  (whisker_right adj.unit F) ≫ (whisker_left F adj.counit) = nat_trans.id _ :=
 begin
   ext1 X, dsimp,
   erw [← adj.hom_equiv_counit, equiv.symm_apply_eq, adj.hom_equiv_unit],
@@ -65,7 +65,7 @@ begin
 end
 
 @[simp] lemma right_triangle :
-  (whisker_left G adj.unit).vcomp (whisker_right adj.counit G) = nat_trans.id _ :=
+  (whisker_left G adj.unit) ≫ (whisker_right adj.counit G) = nat_trans.id _ :=
 begin
   ext1 Y, dsimp,
   erw [← adj.hom_equiv_unit, ← equiv.eq_symm_apply, adj.hom_equiv_counit],
@@ -110,8 +110,8 @@ end core_hom_equiv
 structure core_unit_counit (F : C ⥤ D) (G : D ⥤ C) :=
 (unit : functor.id C ⟶ F.comp G)
 (counit : G.comp F ⟶ functor.id D)
-(left_triangle' : (whisker_right unit F).vcomp (whisker_left F counit) = nat_trans.id _ . obviously)
-(right_triangle' : (whisker_left G unit).vcomp (whisker_right counit G) = nat_trans.id _ . obviously)
+(left_triangle' : (whisker_right unit F) ≫ (whisker_left F counit) = nat_trans.id _ . obviously)
+(right_triangle' : (whisker_left G unit) ≫ (whisker_right counit G) = nat_trans.id _ . obviously)
 
 namespace core_unit_counit
 

--- a/src/category_theory/adjunction.lean
+++ b/src/category_theory/adjunction.lean
@@ -74,11 +74,11 @@ end
 
 @[simp] lemma left_triangle_components :
   F.map (adj.unit.app X) ≫ adj.counit.app (F.obj X) = 𝟙 _ :=
-congr_arg (λ (t : _ ⟹ functor.id C ⋙ F), t.app X) adj.left_triangle
+congr_arg (λ (t : nat_trans _ (functor.id C ⋙ F)), t.app X) adj.left_triangle
 
 @[simp] lemma right_triangle_components {Y : D} :
   adj.unit.app (G.obj Y) ≫ G.map (adj.counit.app Y) = 𝟙 _ :=
-congr_arg (λ (t : _ ⟹ G ⋙ functor.id C), t.app Y) adj.right_triangle
+congr_arg (λ (t : nat_trans _ (G ⋙ functor.id C)), t.app Y) adj.right_triangle
 
 end
 
@@ -152,13 +152,13 @@ def mk_of_unit_counit (adj : core_unit_counit F G) : adjunction F G :=
       change F.map (_ ≫ _) ≫ _ = _,
       rw [F.map_comp, assoc, ←functor.comp_map, adj.counit.naturality, ←assoc],
       convert id_comp _ f,
-      exact congr_arg (λ t : _ ⟹ _, t.app _) adj.left_triangle
+      exact congr_arg (λ t : nat_trans _ _, t.app _) adj.left_triangle
     end,
     right_inv := λ g, begin
       change _ ≫ G.map (_ ≫ _) = _,
       rw [G.map_comp, ←assoc, ←functor.comp_map, ←adj.unit.naturality, assoc],
       convert comp_id _ g,
-      exact congr_arg (λ t : _ ⟹ _, t.app _) adj.right_triangle
+      exact congr_arg (λ t : nat_trans _ _, t.app _) adj.right_triangle
   end },
   .. adj }
 

--- a/src/category_theory/comma.lean
+++ b/src/category_theory/comma.lean
@@ -126,7 +126,7 @@ variables {X : comma L R}
 end
 
 def map_left_comp (l : L₁ ⟹ L₂) (l' : L₂ ⟹ L₃) :
-(map_left R (l ⊟ l')) ≅ (map_left R l') ⋙ (map_left R l) :=
+(map_left R (l ≫ l')) ≅ (map_left R l') ⋙ (map_left R l) :=
 { hom :=
   { app := λ X, { left := 𝟙 _, right := 𝟙 _ } },
   inv :=
@@ -173,7 +173,7 @@ variables {X : comma L R}
 @[simp] lemma map_right_id_inv_app_right : (((map_right_id L R).inv).app X).right = 𝟙 (X.right) := rfl
 end
 
-def map_right_comp (r : R₁ ⟹ R₂) (r' : R₂ ⟹ R₃) : (map_right L (r ⊟ r')) ≅ (map_right L r) ⋙ (map_right L r') :=
+def map_right_comp (r : R₁ ⟹ R₂) (r' : R₂ ⟹ R₃) : (map_right L (r ≫ r')) ≅ (map_right L r) ⋙ (map_right L r') :=
 { hom :=
   { app := λ X, { left := 𝟙 _, right := 𝟙 _ } },
   inv :=

--- a/src/category_theory/comma.lean
+++ b/src/category_theory/comma.lean
@@ -86,13 +86,13 @@ def snd : comma L R ⥤ B :=
 @[simp] lemma fst_map {X Y : comma L R} {f : X ⟶ Y} : (fst L R).map f = f.left := rfl
 @[simp] lemma snd_map {X Y : comma L R} {f : X ⟶ Y} : (snd L R).map f = f.right := rfl
 
-def nat_trans : fst L R ⋙ L ⟹ snd L R ⋙ R :=
+def nat_trans : fst L R ⋙ L ⟶ snd L R ⋙ R :=
 { app := λ X, X.hom }
 
 section
 variables {L₁ L₂ L₃ : A ⥤ T} {R₁ R₂ R₃ : B ⥤ T}
 
-def map_left (l : L₁ ⟹ L₂) : comma L₂ R ⥤ comma L₁ R :=
+def map_left (l : L₁ ⟶ L₂) : comma L₂ R ⥤ comma L₁ R :=
 { obj := λ X,
   { left  := X.left,
     right := X.right,
@@ -103,7 +103,7 @@ def map_left (l : L₁ ⟹ L₂) : comma L₂ R ⥤ comma L₁ R :=
     w' := by tidy; rw [←category.assoc, l.naturality f.left, category.assoc]; tidy } }
 
 section
-variables {X Y : comma L₂ R} {f : X ⟶ Y} {l : L₁ ⟹ L₂}
+variables {X Y : comma L₂ R} {f : X ⟶ Y} {l : L₁ ⟶ L₂}
 @[simp] lemma map_left_obj_left  : ((map_left R l).obj X).left  = X.left                := rfl
 @[simp] lemma map_left_obj_right : ((map_left R l).obj X).right = X.right               := rfl
 @[simp] lemma map_left_obj_hom   : ((map_left R l).obj X).hom   = l.app X.left ≫ X.hom := rfl
@@ -125,22 +125,22 @@ variables {X : comma L R}
 @[simp] lemma map_left_id_inv_app_right : (((map_left_id L R).inv).app X).right = 𝟙 (X.right) := rfl
 end
 
-def map_left_comp (l : L₁ ⟹ L₂) (l' : L₂ ⟹ L₃) :
-(map_left R (l ⊟ l')) ≅ (map_left R l') ⋙ (map_left R l) :=
+def map_left_comp (l : L₁ ⟶ L₂) (l' : L₂ ⟶ L₃) :
+(map_left R (l ≫ l')) ≅ (map_left R l') ⋙ (map_left R l) :=
 { hom :=
   { app := λ X, { left := 𝟙 _, right := 𝟙 _ } },
   inv :=
   { app := λ X, { left := 𝟙 _, right := 𝟙 _ } } }
 
 section
-variables {X : comma L₃ R} {l : L₁ ⟹ L₂} {l' : L₂ ⟹ L₃}
+variables {X : comma L₃ R} {l : L₁ ⟶ L₂} {l' : L₂ ⟶ L₃}
 @[simp] lemma map_left_comp_hom_app_left  : (((map_left_comp R l l').hom).app X).left  = 𝟙 (X.left)  := rfl
 @[simp] lemma map_left_comp_hom_app_right : (((map_left_comp R l l').hom).app X).right = 𝟙 (X.right) := rfl
 @[simp] lemma map_left_comp_inv_app_left  : (((map_left_comp R l l').inv).app X).left  = 𝟙 (X.left)  := rfl
 @[simp] lemma map_left_comp_inv_app_right : (((map_left_comp R l l').inv).app X).right = 𝟙 (X.right) := rfl
 end
 
-def map_right (r : R₁ ⟹ R₂) : comma L R₁ ⥤ comma L R₂ :=
+def map_right (r : R₁ ⟶ R₂) : comma L R₁ ⥤ comma L R₂ :=
 { obj := λ X,
   { left  := X.left,
     right := X.right,
@@ -151,7 +151,7 @@ def map_right (r : R₁ ⟹ R₂) : comma L R₁ ⥤ comma L R₂ :=
     w' := by tidy; rw [←r.naturality f.right, ←category.assoc]; tidy } }
 
 section
-variables {X Y : comma L R₁} {f : X ⟶ Y} {r : R₁ ⟹ R₂}
+variables {X Y : comma L R₁} {f : X ⟶ Y} {r : R₁ ⟶ R₂}
 @[simp] lemma map_right_obj_left  : ((map_right L r).obj X).left  = X.left                 := rfl
 @[simp] lemma map_right_obj_right : ((map_right L r).obj X).right = X.right                := rfl
 @[simp] lemma map_right_obj_hom   : ((map_right L r).obj X).hom   = X.hom ≫ r.app X.right  := rfl
@@ -173,14 +173,14 @@ variables {X : comma L R}
 @[simp] lemma map_right_id_inv_app_right : (((map_right_id L R).inv).app X).right = 𝟙 (X.right) := rfl
 end
 
-def map_right_comp (r : R₁ ⟹ R₂) (r' : R₂ ⟹ R₃) : (map_right L (r ⊟ r')) ≅ (map_right L r) ⋙ (map_right L r') :=
+def map_right_comp (r : R₁ ⟶ R₂) (r' : R₂ ⟶ R₃) : (map_right L (r ≫ r')) ≅ (map_right L r) ⋙ (map_right L r') :=
 { hom :=
   { app := λ X, { left := 𝟙 _, right := 𝟙 _ } },
   inv :=
   { app := λ X, { left := 𝟙 _, right := 𝟙 _ } } }
 
 section
-variables {X : comma L R₁} {r : R₁ ⟹ R₂} {r' : R₂ ⟹ R₃}
+variables {X : comma L R₁} {r : R₁ ⟶ R₂} {r' : R₂ ⟶ R₃}
 @[simp] lemma map_right_comp_hom_app_left  : (((map_right_comp L r r').hom).app X).left  = 𝟙 (X.left)  := rfl
 @[simp] lemma map_right_comp_hom_app_right : (((map_right_comp L r r').hom).app X).right = 𝟙 (X.right) := rfl
 @[simp] lemma map_right_comp_inv_app_left  : (((map_right_comp L r r').inv).app X).left  = 𝟙 (X.left)  := rfl

--- a/src/category_theory/discrete_category.lean
+++ b/src/category_theory/discrete_category.lean
@@ -33,7 +33,7 @@ end functor
 namespace nat_trans
 
 @[simp] def of_function {I : Type u₁} {F G : I → C} (f : Π i : I, F i ⟶ G i) :
-  (functor.of_function F) ⟹ (functor.of_function G) :=
+  (functor.of_function F) ⟶ (functor.of_function G) :=
 { app := λ i, f i,
   naturality' := λ X Y g,
   begin

--- a/src/category_theory/eq_to_hom.lean
+++ b/src/category_theory/eq_to_hom.lean
@@ -72,7 +72,7 @@ by cases p; simp
 by ext; cases p; simp
 
 @[simp] lemma eq_to_hom_app {F G : C ⥤ D} (h : F = G) (X : C) :
-  (eq_to_hom h : F ⟹ G).app X = eq_to_hom (functor.congr_obj h X) :=
+  (eq_to_hom h : F ⟶ G).app X = eq_to_hom (functor.congr_obj h X) :=
 by subst h; refl
 
 end category_theory

--- a/src/category_theory/functor_category.lean
+++ b/src/category_theory/functor_category.lean
@@ -23,9 +23,11 @@ However if `C` and `D` are both large categories at the same universe level,
 this is a small category at the next higher level.
 -/
 instance functor.category : category.{(max u₁ v₂ 1)} (C ⥤ D) :=
-{ hom     := λ F G, F ⟹ G,
+{ hom     := λ F G, nat_trans F G,
   id      := λ F, nat_trans.id F,
-  comp    := λ _ _ _ α β, α ⊟ β }
+  comp    := λ _ _ _ α β, vcomp α β }
+
+notation F `⟹` G := (F : functor _ _) ⟶ (G : functor _ _)
 
 variables {C D} {E : Sort u₃} [ℰ : category.{v₃} E]
 

--- a/src/category_theory/functor_category.lean
+++ b/src/category_theory/functor_category.lean
@@ -23,9 +23,9 @@ However if `C` and `D` are both large categories at the same universe level,
 this is a small category at the next higher level.
 -/
 instance functor.category : category.{(max u₁ v₂ 1)} (C ⥤ D) :=
-{ hom     := λ F G, F ⟹ G,
+{ hom     := λ F G, nat_trans F G,
   id      := λ F, nat_trans.id F,
-  comp    := λ _ _ _ α β, α ⊟ β }
+  comp    := λ _ _ _ α β, vcomp α β }
 
 variables {C D} {E : Sort u₃} [ℰ : category.{v₃} E]
 
@@ -33,7 +33,7 @@ namespace functor.category
 
 section
 
-@[simp] lemma id_app (F : C ⥤ D) (X : C) : (𝟙 F : F ⟹ F).app X = 𝟙 (F.obj X) := rfl
+@[simp] lemma id_app (F : C ⥤ D) (X : C) : (𝟙 F : F ⟶ F).app X = 𝟙 (F.obj X) := rfl
 @[simp] lemma comp_app {F G H : C ⥤ D} (α : F ⟶ G) (β : G ⟶ H) (X : C) :
   (α ≫ β).app X = α.app X ≫ β.app X := rfl
 end
@@ -45,11 +45,11 @@ namespace nat_trans
 
 include ℰ
 
-lemma app_naturality {F G : C ⥤ (D ⥤ E)} (T : F ⟹ G) (X : C) {Y Z : D} (f : Y ⟶ Z) :
+lemma app_naturality {F G : C ⥤ (D ⥤ E)} (T : F ⟶ G) (X : C) {Y Z : D} (f : Y ⟶ Z) :
   ((F.obj X).map f) ≫ ((T.app X).app Z) = ((T.app X).app Y) ≫ ((G.obj X).map f) :=
 (T.app X).naturality f
 
-lemma naturality_app {F G : C ⥤ (D ⥤ E)} (T : F ⟹ G) (Z : D) {X Y : C} (f : X ⟶ Y) :
+lemma naturality_app {F G : C ⥤ (D ⥤ E)} (T : F ⟶ G) (Z : D) {X Y : C} (f : X ⟶ Y) :
   ((F.map f).app Z) ≫ ((T.app Y).app Z) = ((T.app X).app Z) ≫ ((G.map f).app Z) :=
 congr_fun (congr_arg app (T.naturality f)) Z
 

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -49,7 +49,7 @@ An object corepresenting this functor is a colimit of `F`.
 -/
 def cocones : C ⥤ Type v := const J ⋙ coyoneda.obj (op F)
 
-lemma cocones_obj (X : C) : F.cocones.obj X = (F ⟹ (const J).obj X) := rfl
+lemma cocones_obj (X : C) : F.cocones.obj X = (F ⟶ (const J).obj X) := rfl
 
 @[simp] lemma cocones_map_app {X₁ X₂ : C} (f : X₁ ⟶ X₂) (t : F.cocones.obj X₁) (j : J) :
   (F.cocones.map f t).app j = t.app j ≫ f := rfl
@@ -84,13 +84,13 @@ namespace limits
 /--
 A `c : cone F` is:
 * an object `c.X` and
-* a natural transformation `c.π : c.X ⟹ F` from the constant `c.X` functor to `F`.
+* a natural transformation `c.π : c.X ⟶ F` from the constant `c.X` functor to `F`.
 
 `cone F` is equivalent, in the obvious way, to `Σ X, F.cones.obj X`.
 -/
 structure cone (F : J ⥤ C) :=
 (X : C)
-(π : (const J).obj X ⟹ F)
+(π : (const J).obj X ⟶ F)
 
 @[simp] lemma cone.w {F : J ⥤ C} (c : cone F) {j j' : J} (f : j ⟶ j') :
   c.π.app j ≫ F.map f = c.π.app j' :=
@@ -99,13 +99,13 @@ by convert ←(c.π.naturality f).symm; apply id_comp
 /--
 A `c : cocone F` is
 * an object `c.X` and
-* a natural transformation `c.ι : F ⟹ c.X` from `F` to the constant `c.X` functor.
+* a natural transformation `c.ι : F ⟶ c.X` from `F` to the constant `c.X` functor.
 
 `cocone F` is equivalent, in the obvious way, to `Σ X, F.cocones.obj X`.
 -/
 structure cocone (F : J ⥤ C) :=
 (X : C)
-(ι : F ⟹ (const J).obj X)
+(ι : F ⟶ (const J).obj X)
 
 @[simp] lemma cocone.w {F : J ⥤ C} (c : cocone F) {j j' : J} (f : j ⟶ j') :
   F.map f ≫ c.ι.app j' = c.ι.app j :=
@@ -189,7 +189,7 @@ namespace cones
   inv := { hom := φ.inv, w' := λ j, φ.inv_comp_eq.mpr (w j) } }
 
 def postcompose {G : J ⥤ C} (α : F ⟶ G) : cone F ⥤ cone G :=
-{ obj := λ c, { X := c.X, π := c.π ⊟ α },
+{ obj := λ c, { X := c.X, π := c.π ≫ α },
   map := λ c₁ c₂ f, { hom := f.hom, w' :=
   by intro; erw ← category.assoc; simp [-category.assoc] } }
 
@@ -197,7 +197,7 @@ def postcompose {G : J ⥤ C} (α : F ⟶ G) : cone F ⥤ cone G :=
   ((postcompose α).obj c).X = c.X := rfl
 
 @[simp] lemma postcompose_obj_π {G : J ⥤ C} (α : F ⟶ G) (c : cone F) :
-  ((postcompose α).obj c).π = c.π ⊟ α := rfl
+  ((postcompose α).obj c).π = c.π ≫ α := rfl
 
 @[simp] lemma postcompose_map_hom {G : J ⥤ C} (α : F ⟶ G) {c₁ c₂ : cone F} (f : c₁ ⟶ c₂):
   ((postcompose α).map f).hom = f.hom := rfl
@@ -255,14 +255,14 @@ namespace cocones
   inv := { hom := φ.inv, w' := λ j, φ.comp_inv_eq.mpr (w j).symm } }
 
 def precompose {G : J ⥤ C} (α : G ⟶ F) : cocone F ⥤ cocone G :=
-{ obj := λ c, { X := c.X, ι := α ⊟ c.ι },
+{ obj := λ c, { X := c.X, ι := α ≫ c.ι },
   map := λ c₁ c₂ f, { hom := f.hom } }
 
 @[simp] lemma precompose_obj_X {G : J ⥤ C} (α : G ⟶ F) (c : cocone F) :
   ((precompose α).obj c).X = c.X := rfl
 
 @[simp] lemma precompose_obj_ι {G : J ⥤ C} (α : G ⟶ F) (c : cocone F) :
-  ((precompose α).obj c).ι = α ⊟ c.ι := rfl
+  ((precompose α).obj c).ι = α ≫ c.ι := rfl
 
 @[simp] lemma precompose_map_hom {G : J ⥤ C} (α : G ⟶ F) {c₁ c₂ : cocone F} (f : c₁ ⟶ c₂) :
   ((precompose α).map f).hom = f.hom := rfl

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -189,7 +189,7 @@ namespace cones
   inv := { hom := φ.inv, w' := λ j, φ.inv_comp_eq.mpr (w j) } }
 
 def postcompose {G : J ⥤ C} (α : F ⟶ G) : cone F ⥤ cone G :=
-{ obj := λ c, { X := c.X, π := c.π ⊟ α },
+{ obj := λ c, { X := c.X, π := c.π ≫ α },
   map := λ c₁ c₂ f, { hom := f.hom, w' :=
   by intro; erw ← category.assoc; simp [-category.assoc] } }
 
@@ -197,7 +197,7 @@ def postcompose {G : J ⥤ C} (α : F ⟶ G) : cone F ⥤ cone G :=
   ((postcompose α).obj c).X = c.X := rfl
 
 @[simp] lemma postcompose_obj_π {G : J ⥤ C} (α : F ⟶ G) (c : cone F) :
-  ((postcompose α).obj c).π = c.π ⊟ α := rfl
+  ((postcompose α).obj c).π = c.π ≫ α := rfl
 
 @[simp] lemma postcompose_map_hom {G : J ⥤ C} (α : F ⟶ G) {c₁ c₂ : cone F} (f : c₁ ⟶ c₂):
   ((postcompose α).map f).hom = f.hom := rfl
@@ -255,14 +255,14 @@ namespace cocones
   inv := { hom := φ.inv, w' := λ j, φ.comp_inv_eq.mpr (w j).symm } }
 
 def precompose {G : J ⥤ C} (α : G ⟶ F) : cocone F ⥤ cocone G :=
-{ obj := λ c, { X := c.X, ι := α ⊟ c.ι },
+{ obj := λ c, { X := c.X, ι := α ≫ c.ι },
   map := λ c₁ c₂ f, { hom := f.hom } }
 
 @[simp] lemma precompose_obj_X {G : J ⥤ C} (α : G ⟶ F) (c : cocone F) :
   ((precompose α).obj c).X = c.X := rfl
 
 @[simp] lemma precompose_obj_ι {G : J ⥤ C} (α : G ⟶ F) (c : cocone F) :
-  ((precompose α).obj c).ι = α ⊟ c.ι := rfl
+  ((precompose α).obj c).ι = α ≫ c.ι := rfl
 
 @[simp] lemma precompose_map_hom {G : J ⥤ C} (α : G ⟶ F) {c₁ c₂ : cocone F} (f : c₁ ⟶ c₂) :
   ((precompose α).map f).hom = f.hom := rfl

--- a/src/category_theory/limits/limits.lean
+++ b/src/category_theory/limits/limits.lean
@@ -80,7 +80,7 @@ by rw [h.hom_lift f, h.hom_lift f']; congr; exact funext w
 
 /-- The universal property of a limit cone: a map `W ⟶ X` is the same as
   a cone on `F` with vertex `W`. -/
-def hom_iso (h : is_limit t) (W : C) : (W ⟶ t.X) ≅ ((const J).obj W ⟹ F) :=
+def hom_iso (h : is_limit t) (W : C) : (W ⟶ t.X) ≅ ((const J).obj W ⟶ F) :=
 { hom := λ f, (t.extend f).π,
   inv := λ π, h.lift { X := W, π := π },
   hom_inv_id' := by ext f; apply h.hom_ext; intro j; simp; dsimp; refl }
@@ -191,7 +191,7 @@ by rw [h.hom_desc f, h.hom_desc f']; congr; exact funext w
 
 /-- The universal property of a colimit cocone: a map `X ⟶ W` is the same as
   a cocone on `F` with vertex `W`. -/
-def hom_iso (h : is_colimit t) (W : C) : (t.X ⟶ W) ≅ (F ⟹ (const J).obj W) :=
+def hom_iso (h : is_colimit t) (W : C) : (t.X ⟶ W) ≅ (F ⟶ (const J).obj W) :=
 { hom := λ f, (t.extend f).ι,
   inv := λ ι, h.desc { X := W, ι := ι },
   hom_inv_id' := by ext f; apply h.hom_ext; intro j; simp; dsimp; refl }
@@ -403,7 +403,7 @@ def lim : (J ⥤ C) ⥤ C :=
   map_comp' := λ F G H α β,
     by ext; erw [assoc, is_limit.fac, is_limit.fac, ←assoc, is_limit.fac, assoc]; refl }
 
-variables {F} {G : J ⥤ C} (α : F ⟹ G)
+variables {F} {G : J ⥤ C} (α : F ⟶ G)
 
 @[simp] lemma lim.map_π (j : J) : lim.map α ≫ limit.π G j = limit.π F j ≫ α.app j :=
 by apply is_limit.fac
@@ -417,7 +417,7 @@ lemma limit.map_pre {K : Type v} [small_category K] [has_limits_of_shape K C] (E
 by ext; rw [assoc, limit.pre_π, lim.map_π, assoc, lim.map_π, ←assoc, limit.pre_π]; refl
 
 lemma limit.map_pre' {K : Type v} [small_category K] [has_limits_of_shape.{v} K C]
-  (F : J ⥤ C) {E₁ E₂ : K ⥤ J} (α : E₁ ⟹ E₂) :
+  (F : J ⥤ C) {E₁ E₂ : K ⥤ J} (α : E₁ ⟶ E₂) :
   limit.pre F E₂ = limit.pre F E₁ ≫ lim.map (whisker_right α F) :=
 by ext1; simp [(category.assoc _ _ _ _).symm]
 
@@ -644,7 +644,7 @@ def colim : (J ⥤ C) ⥤ C :=
   map_comp' := λ F G H α β,
     by ext; erw [←assoc, is_colimit.fac, is_colimit.fac, assoc, is_colimit.fac, ←assoc]; refl }
 
-variables {F} {G : J ⥤ C} (α : F ⟹ G)
+variables {F} {G : J ⥤ C} (α : F ⟶ G)
 
 @[simp] lemma colim.ι_map (j : J) : colimit.ι F j ≫ colim.map α = α.app j ≫ colimit.ι G j :=
 by apply is_colimit.fac
@@ -662,7 +662,7 @@ lemma colimit.pre_map {K : Type v} [small_category K] [has_colimits_of_shape K C
 by ext; rw [←assoc, colimit.ι_pre, colim.ι_map, ←assoc, colim.ι_map, assoc, colimit.ι_pre]; refl
 
 lemma colimit.pre_map' {K : Type v} [small_category K] [has_colimits_of_shape.{v} K C]
-  (F : J ⥤ C) {E₁ E₂ : K ⥤ J} (α : E₁ ⟹ E₂) :
+  (F : J ⥤ C) {E₁ E₂ : K ⥤ J} (α : E₁ ⟶ E₂) :
   colimit.pre F E₁ = colim.map (whisker_right α F) ≫ colimit.pre F E₂ :=
 by ext1; simp [(category.assoc _ _ _ _).symm]
 

--- a/src/category_theory/limits/types.lean
+++ b/src/category_theory/limits/types.lean
@@ -37,7 +37,7 @@ instance : has_limits.{u} (Type u) :=
 @[simp] lemma types_limit_pre
   (F : J ⥤ Type u) {K : Type u} [𝒦 : small_category K] (E : K ⥤ J) (g : (limit F).X) :
   limit.pre F E g = (⟨λ k, g.val (E.obj k), by obviously⟩ : (limit (E ⋙ F)).X) := rfl
-@[simp] lemma types_limit_map {F G : J ⥤ Type u} (α : F ⟹ G) (g : (limit F).X) :
+@[simp] lemma types_limit_map {F G : J ⥤ Type u} (α : F ⟶ G) (g : (limit F).X) :
   (lim.map α : (limit F).X → (limit G).X) g =
   (⟨λ j, (α.app j) (g.val j), λ j j' f,
     by rw [←functor_to_types.naturality, ←(g.property f)]⟩ : (limit G).X) := rfl
@@ -71,7 +71,7 @@ instance : has_colimits.{u} (Type u) :=
   (F : J ⥤ Type u) {K : Type u} [𝒦 : small_category K] (E : K ⥤ J) (g : (colimit (E ⋙ F)).X) :
   colimit.pre F E =
   quot.lift (λ p, quot.mk _ ⟨E.obj p.1, p.2⟩) (λ p p' ⟨f, h⟩, quot.sound ⟨E.map f, h⟩) := rfl
-@[simp] lemma types_colimit_map {F G : J ⥤ Type u} (α : F ⟹ G) :
+@[simp] lemma types_colimit_map {F G : J ⥤ Type u} (α : F ⟶ G) :
   (colim.map α : (colimit F).X → (colimit G).X) =
   quot.lift
     (λ p, quot.mk _ ⟨p.1, (α.app p.1) p.2⟩)

--- a/src/category_theory/natural_isomorphism.lean
+++ b/src/category_theory/natural_isomorphism.lean
@@ -37,29 +37,26 @@ instance inv_app_is_iso (α : F ≅ G) (X : C) : is_iso (α.inv.app X) :=
   hom_inv_id' := begin rw [←functor.category.comp_app, iso.inv_hom_id, ←functor.category.id_app] end,
   inv_hom_id' := begin rw [←functor.category.comp_app, iso.hom_inv_id, ←functor.category.id_app] end }
 
-@[simp] lemma hom_vcomp_inv (α : F ≅ G) : (α.hom ⊟ α.inv) = nat_trans.id _ :=
+-- TODO remove these
+@[simp] lemma hom_vcomp_inv (α : F ≅ G) : (α.hom ≫ α.inv) = nat_trans.id _ :=
 begin
-  have h : (α.hom ⊟ α.inv) = α.hom ≫ α.inv := rfl,
-  rw h,
   rw iso.hom_inv_id,
   refl
 end
-@[simp] lemma inv_vcomp_hom (α : F ≅ G) : (α.inv ⊟ α.hom) = nat_trans.id _ :=
+@[simp] lemma inv_vcomp_hom (α : F ≅ G) : (α.inv ≫ α.hom) = nat_trans.id _ :=
 begin
-  have h : (α.inv ⊟ α.hom) = α.inv ≫ α.hom := rfl,
-  rw h,
   rw iso.inv_hom_id,
   refl
 end
 
 @[simp] lemma hom_app_inv_app_id (α : F ≅ G) (X : C) : α.hom.app X ≫ α.inv.app X = 𝟙 _ :=
 begin
-  rw ←nat_trans.vcomp_app,
+  rw ←functor.category.comp_app,
   simp,
 end
 @[simp] lemma inv_app_hom_app_id (α : F ≅ G) (X : C) : α.inv.app X ≫ α.hom.app X = 𝟙 _ :=
 begin
-  rw ←nat_trans.vcomp_app,
+  rw ←functor.category.comp_app,
   simp,
 end
 

--- a/src/category_theory/natural_isomorphism.lean
+++ b/src/category_theory/natural_isomorphism.lean
@@ -37,29 +37,26 @@ instance inv_app_is_iso (α : F ≅ G) (X : C) : is_iso (α.inv.app X) :=
   hom_inv_id' := begin rw [←functor.category.comp_app, iso.inv_hom_id, ←functor.category.id_app] end,
   inv_hom_id' := begin rw [←functor.category.comp_app, iso.hom_inv_id, ←functor.category.id_app] end }
 
-@[simp] lemma hom_vcomp_inv (α : F ≅ G) : (α.hom ⊟ α.inv) = nat_trans.id _ :=
+-- TODO remove these
+@[simp] lemma hom_comp_inv (α : F ≅ G) : (α.hom ≫ α.inv) = nat_trans.id _ :=
 begin
-  have h : (α.hom ⊟ α.inv) = α.hom ≫ α.inv := rfl,
-  rw h,
   rw iso.hom_inv_id,
   refl
 end
-@[simp] lemma inv_vcomp_hom (α : F ≅ G) : (α.inv ⊟ α.hom) = nat_trans.id _ :=
+@[simp] lemma inv_comp_hom (α : F ≅ G) : (α.inv ≫ α.hom) = nat_trans.id _ :=
 begin
-  have h : (α.inv ⊟ α.hom) = α.inv ≫ α.hom := rfl,
-  rw h,
   rw iso.inv_hom_id,
   refl
 end
 
 @[simp] lemma hom_app_inv_app_id (α : F ≅ G) (X : C) : α.hom.app X ≫ α.inv.app X = 𝟙 _ :=
 begin
-  rw ←nat_trans.vcomp_app,
+  rw ←functor.category.comp_app,
   simp,
 end
 @[simp] lemma inv_app_hom_app_id (α : F ≅ G) (X : C) : α.inv.app X ≫ α.hom.app X = 𝟙 _ :=
 begin
-  rw ←nat_trans.vcomp_app,
+  rw ←functor.category.comp_app,
   simp,
 end
 

--- a/src/category_theory/natural_isomorphism.lean
+++ b/src/category_theory/natural_isomorphism.lean
@@ -37,18 +37,6 @@ instance inv_app_is_iso (α : F ≅ G) (X : C) : is_iso (α.inv.app X) :=
   hom_inv_id' := begin rw [←functor.category.comp_app, iso.inv_hom_id, ←functor.category.id_app] end,
   inv_hom_id' := begin rw [←functor.category.comp_app, iso.hom_inv_id, ←functor.category.id_app] end }
 
--- TODO remove these
-@[simp] lemma hom_vcomp_inv (α : F ≅ G) : (α.hom ≫ α.inv) = nat_trans.id _ :=
-begin
-  rw iso.hom_inv_id,
-  refl
-end
-@[simp] lemma inv_vcomp_hom (α : F ≅ G) : (α.inv ≫ α.hom) = nat_trans.id _ :=
-begin
-  rw iso.inv_hom_id,
-  refl
-end
-
 @[simp] lemma hom_app_inv_app_id (α : F ≅ G) (X : C) : α.hom.app X ≫ α.inv.app X = 𝟙 _ :=
 begin
   rw ←functor.category.comp_app,

--- a/src/category_theory/natural_transformation.lean
+++ b/src/category_theory/natural_transformation.lean
@@ -6,8 +6,8 @@ Authors: Tim Baumann, Stephen Morgan, Scott Morrison
 Defines natural transformations between functors.
 
 Introduces notations
-  `F ⟹ G` for the type of natural transformations between functors `F` and `G`,
   `τ.app X` for the components of natural transformations,
+  `F ⟶ G` for the type of natural transformations between functors `F` and `G`,
   `σ ≫ τ` for vertical compositions, and
   `σ ◫ τ` for horizontal compositions.
 -/

--- a/src/category_theory/natural_transformation.lean
+++ b/src/category_theory/natural_transformation.lean
@@ -8,7 +8,7 @@ Defines natural transformations between functors.
 Introduces notations
   `F ⟹ G` for the type of natural transformations between functors `F` and `G`,
   `τ.app X` for the components of natural transformations,
-  `σ ⊟ τ` for vertical compositions, and
+  `σ ≫ τ` for vertical compositions, and
   `σ ◫ τ` for horizontal compositions.
 -/
 
@@ -34,14 +34,12 @@ structure nat_trans (F G : C ⥤ D) : Sort (max u₁ v₂ 1) :=
 (app : Π X : C, (F.obj X) ⟶ (G.obj X))
 (naturality' : ∀ {X Y : C} (f : X ⟶ Y), (F.map f) ≫ (app Y) = (app X) ≫ (G.map f) . obviously)
 
-infixr ` ⟹ `:50  := nat_trans             -- type as \==> or ⟹
-
 restate_axiom nat_trans.naturality'
 
 namespace nat_trans
 
 /-- `nat_trans.id F` is the identity natural transformation on a functor `F`. -/
-protected def id (F : C ⥤ D) : F ⟹ F :=
+protected def id (F : C ⥤ D) : nat_trans F F :=
 { app := λ X, 𝟙 (F.obj X) }
 
 @[simp] lemma id_app (F : C ⥤ D) (X : C) : (nat_trans.id F).app X = 𝟙 (F.obj X) := rfl
@@ -53,7 +51,7 @@ section
 variables {F G H I : C ⥤ D}
 
 -- We'll want to be able to prove that two natural transformations are equal if they are componentwise equal.
-@[extensionality] lemma ext (α β : F ⟹ G) (w : ∀ X : C, α.app X = β.app X) : α = β :=
+@[extensionality] lemma ext (α β : nat_trans F G) (w : ∀ X : C, α.app X = β.app X) : α = β :=
 begin
   induction α with α_components α_naturality,
   induction β with β_components β_naturality,
@@ -61,24 +59,30 @@ begin
   subst hc
 end
 
-lemma congr_app {α β : F ⟹ G} (h : α = β) (X : C) : α.app X = β.app X := by rw h
+lemma congr_app {α β : nat_trans F G} (h : α = β) (X : C) : α.app X = β.app X := by rw h
 
 /-- `vcomp α β` is the vertical compositions of natural transformations. -/
-def vcomp (α : F ⟹ G) (β : G ⟹ H) : F ⟹ H :=
+def vcomp (α : nat_trans F G) (β : nat_trans G H) : nat_trans F H :=
 { app         := λ X, (α.app X) ≫ (β.app X),
-  naturality' := begin /- `obviously'` says: -/ intros, simp, rw [←assoc, naturality, assoc, ←naturality], end }
+  naturality' :=
+  begin
+    /- `obviously'` says: -/
+    intros, simp, rw [←assoc, naturality, assoc, ←naturality],
+  end }
 
-infixr ` ⊟ `:80 := vcomp
-
-@[simp] lemma vcomp_app (α : F ⟹ G) (β : G ⟹ H) (X : C) : (α ⊟ β).app X = (α.app X) ≫ (β.app X) := rfl
-@[simp] lemma vcomp_assoc (α : F ⟹ G) (β : G ⟹ H) (γ : H ⟹ I) : (α ⊟ β) ⊟ γ = α ⊟ (β ⊟ γ) := by tidy
+@[simp] lemma vcomp_app (α : nat_trans F G) (β : nat_trans G H) (X : C) :
+  (vcomp α β).app X = (α.app X) ≫ (β.app X) :=
+rfl
+@[simp] lemma vcomp_assoc (α : nat_trans F G) (β : nat_trans G H) (γ : nat_trans H I) :
+  vcomp (vcomp α β) γ = vcomp α (vcomp β γ) :=
+by tidy
 end
 
 variables {E : Sort u₃} [ℰ : category.{v₃} E]
 include ℰ
 
 /-- `hcomp α β` is the horizontal composition of natural transformations. -/
-def hcomp {F G : C ⥤ D} {H I : D ⥤ E} (α : F ⟹ G) (β : H ⟹ I) : (F ⋙ H) ⟹ (G ⋙ I) :=
+def hcomp {F G : C ⥤ D} {H I : D ⥤ E} (α : nat_trans F G) (β : nat_trans H I) : nat_trans (F ⋙ H) (G ⋙ I) :=
 { app         := λ X : C, (β.app (F.obj X)) ≫ (I.map (α.app X)),
   naturality' := begin
                    /- `obviously'` says: -/
@@ -92,13 +96,13 @@ def hcomp {F G : C ⥤ D} {H I : D ⥤ E} (α : F ⟹ G) (β : H ⟹ I) : (F ⋙
 
 infix ` ◫ `:80 := hcomp
 
-@[simp] lemma hcomp_app {F G : C ⥤ D} {H I : D ⥤ E} (α : F ⟹ G) (β : H ⟹ I) (X : C) :
+@[simp] lemma hcomp_app {F G : C ⥤ D} {H I : D ⥤ E} (α : nat_trans F G) (β : nat_trans H I) (X : C) :
   (α ◫ β).app X = (β.app (F.obj X)) ≫ (I.map (α.app X)) := rfl
 
 -- Note that we don't yet prove a `hcomp_assoc` lemma here: even stating it is painful, because we need to use associativity of functor composition
 
-lemma exchange {F G H : C ⥤ D} {I J K : D ⥤ E} (α : F ⟹ G) (β : G ⟹ H) (γ : I ⟹ J) (δ : J ⟹ K) :
-  ((α ⊟ β) ◫ (γ ⊟ δ)) = ((α ◫ γ) ⊟ (β ◫ δ)) :=
+lemma exchange {F G H : C ⥤ D} {I J K : D ⥤ E} (α : nat_trans F G) (β : nat_trans G H) (γ : nat_trans I J) (δ : nat_trans J K) :
+  ((vcomp α β) ◫ (vcomp γ δ)) = (vcomp (α ◫ γ) (β ◫ δ)) :=
 begin
   -- `obviously'` says:
   ext,

--- a/src/category_theory/products.lean
+++ b/src/category_theory/products.lean
@@ -112,7 +112,7 @@ include 𝒞 𝒟
   map := λ x y f, (x.2.map f.1) ≫ (f.2.app y.1),
   map_comp' := begin
     intros X Y Z f g, cases g, cases f, cases Z, cases Y, cases X, dsimp at *, simp at *,
-    erw [←nat_trans.vcomp_app, nat_trans.naturality, category.assoc, nat_trans.naturality]
+    erw [←functor.category.comp_app, nat_trans.naturality, category.assoc, nat_trans.naturality]
   end }
 
 end
@@ -139,13 +139,13 @@ end functor
 namespace nat_trans
 
 /-- The cartesian product of two natural transformations. -/
-def prod {F G : A ⥤ B} {H I : C ⥤ D} (α : F ⟹ G) (β : H ⟹ I) : F.prod H ⟹ G.prod I :=
+def prod {F G : A ⥤ B} {H I : C ⥤ D} (α : F ⟶ G) (β : H ⟶ I) : F.prod H ⟶ G.prod I :=
 { app         := λ X, (α.app X.1, β.app X.2),
   naturality' := begin /- `obviously'` says: -/ intros, cases f, cases Y, cases X, dsimp at *, simp, split, rw naturality, rw naturality end }
 
 /- Again, it is inadvisable in Lean 3 to setup a notation `α × β`; use instead `α.prod β` or `nat_trans.prod α β`. -/
 
-@[simp] lemma prod_app  {F G : A ⥤ B} {H I : C ⥤ D} (α : F ⟹ G) (β : H ⟹ I) (a : A) (c : C) :
+@[simp] lemma prod_app  {F G : A ⥤ B} {H I : C ⥤ D} (α : F ⟶ G) (β : H ⟶ I) (a : A) (c : C) :
   (nat_trans.prod α β).app (a, c) = (α.app a, β.app c) := rfl
 end nat_trans
 

--- a/src/category_theory/products.lean
+++ b/src/category_theory/products.lean
@@ -112,7 +112,7 @@ include 𝒞 𝒟
   map := λ x y f, (x.2.map f.1) ≫ (f.2.app y.1),
   map_comp' := begin
     intros X Y Z f g, cases g, cases f, cases Z, cases Y, cases X, dsimp at *, simp at *,
-    erw [←nat_trans.vcomp_app, nat_trans.naturality, category.assoc, nat_trans.naturality]
+    erw [←functor.category.comp_app, nat_trans.naturality, category.assoc, nat_trans.naturality]
   end }
 
 end

--- a/src/category_theory/types.lean
+++ b/src/category_theory/types.lean
@@ -32,7 +32,7 @@ by simp
 lemma naturality (f : X ⟶ Y) (x : F.obj X) : σ.app Y ((F.map f) x) = (G.map f) (σ.app X x) :=
 congr_fun (σ.naturality f) x
 
-@[simp] lemma vcomp (x : F.obj X) : (σ ⊟ τ).app X x = τ.app X (σ.app X x) := rfl
+@[simp] lemma comp (x : F.obj X) : (σ ≫ τ).app X x = τ.app X (σ.app X x) := rfl
 
 variables {D : Sort u'} [𝒟 : category.{u'} D] (I J : D ⥤ C) (ρ : I ⟹ J) {W : D}
 

--- a/src/category_theory/types.lean
+++ b/src/category_theory/types.lean
@@ -21,7 +21,7 @@ instance types : large_category (Sort u) :=
 namespace functor_to_types
 variables {C : Sort u} [𝒞 : category.{v} C] (F G H : C ⥤ Sort w) {X Y Z : C}
 include 𝒞
-variables (σ : F ⟹ G) (τ : G ⟹ H)
+variables (σ : F ⟶ G) (τ : G ⟶ H)
 
 @[simp] lemma map_comp (f : X ⟶ Y) (g : Y ⟶ Z) (a : F.obj X) : (F.map (f ≫ g)) a = (F.map g) ((F.map f) a) :=
 by simp
@@ -32,9 +32,9 @@ by simp
 lemma naturality (f : X ⟶ Y) (x : F.obj X) : σ.app Y ((F.map f) x) = (G.map f) (σ.app X x) :=
 congr_fun (σ.naturality f) x
 
-@[simp] lemma vcomp (x : F.obj X) : (σ ⊟ τ).app X x = τ.app X (σ.app X x) := rfl
+@[simp] lemma comp (x : F.obj X) : (σ ≫ τ).app X x = τ.app X (σ.app X x) := rfl
 
-variables {D : Sort u'} [𝒟 : category.{u'} D] (I J : D ⥤ C) (ρ : I ⟹ J) {W : D}
+variables {D : Sort u'} [𝒟 : category.{u'} D] (I J : D ⥤ C) (ρ : I ⟶ J) {W : D}
 
 @[simp] lemma hcomp (x : (I ⋙ F).obj W) : (ρ ◫ σ).app W x = (G.map (ρ.app W)) (σ.app (I.obj W) x) := rfl
 

--- a/src/category_theory/whiskering.lean
+++ b/src/category_theory/whiskering.lean
@@ -64,12 +64,12 @@ rfl
   whisker_right (nat_trans.id G) F = nat_trans.id (G.comp F) :=
 ((whiskering_right C D E).obj F).map_id _
 
-@[simp] lemma whisker_left_vcomp (F : C ⥤ D) {G H K : D ⥤ E} (α : G ⟹ H) (β : H ⟹ K) :
-  whisker_left F (α ⊟ β) = (whisker_left F α) ⊟ (whisker_left F β) :=
+@[simp] lemma whisker_left_comp (F : C ⥤ D) {G H K : D ⥤ E} (α : G ⟹ H) (β : H ⟹ K) :
+  whisker_left F (α ≫ β) = (whisker_left F α) ≫ (whisker_left F β) :=
 rfl
 
-@[simp] lemma whisker_right_vcomp {G H K : C ⥤ D} (α : G ⟹ H) (β : H ⟹ K) (F : D ⥤ E)  :
-  whisker_right (α ⊟ β) F = (whisker_right α F) ⊟ (whisker_right β F) :=
+@[simp] lemma whisker_right_comp {G H K : C ⥤ D} (α : G ⟹ H) (β : H ⟹ K) (F : D ⥤ E)  :
+  whisker_right (α ≫ β) F = (whisker_right α F) ≫ (whisker_right β F) :=
 ((whiskering_right C D E).obj F).map_comp α β
 
 variables {B : Sort u₄} [ℬ : category.{v₄} B]
@@ -128,7 +128,7 @@ def associator (F : A ⥤ B) (G : B ⥤ C) (H : C ⥤ D) : ((F ⋙ G) ⋙ H) ≅
 omit 𝒟
 
 lemma triangle (F : A ⥤ B) (G : B ⥤ C) :
-  (associator F (functor.id B) G).hom ⊟ (whisker_left F (left_unitor G).hom) =
+  (associator F (functor.id B) G).hom ≫ (whisker_left F (left_unitor G).hom) =
     (whisker_right (right_unitor F).hom G) :=
 begin
   ext1,
@@ -142,8 +142,8 @@ include 𝒟 ℰ
 variables (F : A ⥤ B) (G : B ⥤ C) (H : C ⥤ D) (K : D ⥤ E)
 
 lemma pentagon :
-  (whisker_right (associator F G H).hom K) ⊟ (associator F (G ⋙ H) K).hom ⊟ (whisker_left F (associator G H K).hom) =
-    ((associator (F ⋙ G) H K).hom ⊟ (associator F G (H ⋙ K)).hom) :=
+  (whisker_right (associator F G H).hom K) ≫ (associator F (G ⋙ H) K).hom ≫ (whisker_left F (associator G H K).hom) =
+    ((associator (F ⋙ G) H K).hom ≫ (associator F G (H ⋙ K)).hom) :=
 begin
   ext1,
   dsimp [associator],

--- a/src/category_theory/whiskering.lean
+++ b/src/category_theory/whiskering.lean
@@ -42,17 +42,17 @@ def whiskering_right : (D ⥤ E) ⥤ ((C ⥤ D) ⥤ (C ⥤ E)) :=
 
 variables {C} {D} {E}
 
-def whisker_left (F : C ⥤ D) {G H : D ⥤ E} (α : G ⟹ H) : (F ⋙ G) ⟹ (F ⋙ H) :=
+def whisker_left (F : C ⥤ D) {G H : D ⥤ E} (α : G ⟶ H) : (F ⋙ G) ⟶ (F ⋙ H) :=
 ((whiskering_left C D E).obj F).map α
 
-@[simp] lemma whisker_left.app (F : C ⥤ D) {G H : D ⥤ E} (α : G ⟹ H) (X : C) :
+@[simp] lemma whisker_left.app (F : C ⥤ D) {G H : D ⥤ E} (α : G ⟶ H) (X : C) :
   (whisker_left F α).app X = α.app (F.obj X) :=
 rfl
 
-def whisker_right {G H : C ⥤ D} (α : G ⟹ H) (F : D ⥤ E) : (G ⋙ F) ⟹ (H ⋙ F) :=
+def whisker_right {G H : C ⥤ D} (α : G ⟶ H) (F : D ⥤ E) : (G ⋙ F) ⟶ (H ⋙ F) :=
 ((whiskering_right C D E).obj F).map α
 
-@[simp] lemma whisker_right.app {G H : C ⥤ D} (α : G ⟹ H) (F : D ⥤ E) (X : C) :
+@[simp] lemma whisker_right.app {G H : C ⥤ D} (α : G ⟶ H) (F : D ⥤ E) (X : C) :
    (whisker_right α F).app X = F.map (α.app X) :=
 rfl
 
@@ -64,12 +64,12 @@ rfl
   whisker_right (nat_trans.id G) F = nat_trans.id (G.comp F) :=
 ((whiskering_right C D E).obj F).map_id _
 
-@[simp] lemma whisker_left_vcomp (F : C ⥤ D) {G H K : D ⥤ E} (α : G ⟹ H) (β : H ⟹ K) :
-  whisker_left F (α ⊟ β) = (whisker_left F α) ⊟ (whisker_left F β) :=
+@[simp] lemma whisker_left_comp (F : C ⥤ D) {G H K : D ⥤ E} (α : G ⟶ H) (β : H ⟶ K) :
+  whisker_left F (α ≫ β) = (whisker_left F α) ≫ (whisker_left F β) :=
 rfl
 
-@[simp] lemma whisker_right_vcomp {G H K : C ⥤ D} (α : G ⟹ H) (β : H ⟹ K) (F : D ⥤ E)  :
-  whisker_right (α ⊟ β) F = (whisker_right α F) ⊟ (whisker_right β F) :=
+@[simp] lemma whisker_right_comp {G H K : C ⥤ D} (α : G ⟶ H) (β : H ⟶ K) (F : D ⥤ E)  :
+  whisker_right (α ≫ β) F = (whisker_right α F) ≫ (whisker_right β F) :=
 ((whiskering_right C D E).obj F).map_comp α β
 
 variables {B : Sort u₄} [ℬ : category.{v₄} B]
@@ -77,15 +77,15 @@ include ℬ
 
 local attribute [elab_simple] whisker_left whisker_right
 
-@[simp] lemma whisker_left_twice (F : B ⥤ C) (G : C ⥤ D) {H K : D ⥤ E} (α : H ⟹ K) :
+@[simp] lemma whisker_left_twice (F : B ⥤ C) (G : C ⥤ D) {H K : D ⥤ E} (α : H ⟶ K) :
   whisker_left F (whisker_left G α) = whisker_left (F ⋙ G) α :=
 rfl
 
-@[simp] lemma whisker_right_twice {H K : B ⥤ C} (F : C ⥤ D) (G : D ⥤ E) (α : H ⟹ K) :
+@[simp] lemma whisker_right_twice {H K : B ⥤ C} (F : C ⥤ D) (G : D ⥤ E) (α : H ⟶ K) :
   whisker_right (whisker_right α F) G = whisker_right α (F ⋙ G) :=
 rfl
 
-lemma whisker_right_left (F : B ⥤ C) {G H : C ⥤ D} (α : G ⟹ H) (K : D ⥤ E) :
+lemma whisker_right_left (F : B ⥤ C) {G H : C ⥤ D} (α : G ⟶ H) (K : D ⥤ E) :
   whisker_right (whisker_left F α) K = whisker_left F (whisker_right α K) :=
 rfl
 end
@@ -128,7 +128,7 @@ def associator (F : A ⥤ B) (G : B ⥤ C) (H : C ⥤ D) : ((F ⋙ G) ⋙ H) ≅
 omit 𝒟
 
 lemma triangle (F : A ⥤ B) (G : B ⥤ C) :
-  (associator F (functor.id B) G).hom ⊟ (whisker_left F (left_unitor G).hom) =
+  (associator F (functor.id B) G).hom ≫ (whisker_left F (left_unitor G).hom) =
     (whisker_right (right_unitor F).hom G) :=
 begin
   ext1,
@@ -142,8 +142,8 @@ include 𝒟 ℰ
 variables (F : A ⥤ B) (G : B ⥤ C) (H : C ⥤ D) (K : D ⥤ E)
 
 lemma pentagon :
-  (whisker_right (associator F G H).hom K) ⊟ (associator F (G ⋙ H) K).hom ⊟ (whisker_left F (associator G H K).hom) =
-    ((associator (F ⋙ G) H K).hom ⊟ (associator F G (H ⋙ K)).hom) :=
+  (whisker_right (associator F G H).hom K) ≫ (associator F (G ⋙ H) K).hom ≫ (whisker_left F (associator G H K).hom) =
+    ((associator (F ⋙ G) H K).hom ≫ (associator F G (H ⋙ K)).hom) :=
 begin
   ext1,
   dsimp [associator],

--- a/src/category_theory/yoneda.lean
+++ b/src/category_theory/yoneda.lean
@@ -173,11 +173,11 @@ def yoneda_lemma : yoneda_pairing C ≅ yoneda_evaluation C :=
 
 variables {C}
 
-@[simp] def yoneda_sections (X : C) (F : Cᵒᵖ ⥤ Type v₁) : (yoneda.obj X ⟹ F) ≅ ulift.{u₁} (F.obj (op X)) :=
+@[simp] def yoneda_sections (X : C) (F : Cᵒᵖ ⥤ Type v₁) : (yoneda.obj X ⟶ F) ≅ ulift.{u₁} (F.obj (op X)) :=
 nat_iso.app (yoneda_lemma C) (op X, F)
 
 omit 𝒞
-@[simp] def yoneda_sections_small {C : Type u₁} [small_category C] (X : C) (F : Cᵒᵖ ⥤ Type u₁) : (yoneda.obj X ⟹ F) ≅ F.obj (op X) :=
+@[simp] def yoneda_sections_small {C : Type u₁} [small_category C] (X : C) (F : Cᵒᵖ ⥤ Type u₁) : (yoneda.obj X ⟶ F) ≅ F.obj (op X) :=
 yoneda_sections X F ≪≫ ulift_trivial _
 
 end category_theory


### PR DESCRIPTION
This removes some misfeatures of the category theory library.

~~Now when you write `F ⟹ G`, Lean recognises this as a morphism in the functor category.~~

Now you just write `F ⟶ G` (that is `F \hom G`) for the natural transformations between functors `F` and `G`.

In particular, you can always use `≫` for composing natural transformations now, and the stupid notation `⊟` for composing natural transformations has been removed.
