### PR TITLE
refactor(*): rename is_group_hom.mul to map_mul

### DIFF
--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -615,18 +615,18 @@ section group
 open list
 variables [group α] [group β]
 
-@[to_additive is_add_group_hom.sum]
-theorem is_group_hom.prod (f : α → β) [is_group_hom f] (l : list α) :
+@[to_additive is_add_group_hom.map_sum]
+theorem is_group_hom.map_prod (f : α → β) [is_group_hom f] (l : list α) :
   f (prod l) = prod (map f l) :=
-by induction l; simp only [*, is_group_hom.mul f, is_group_hom.one f, prod_nil, prod_cons, map]
+by induction l; simp only [*, is_group_hom.map_mul f, is_group_hom.map_one f, prod_nil, prod_cons, map]
 
-theorem is_group_anti_hom.prod (f : α → β) [is_group_anti_hom f] (l : list α) :
+theorem is_group_anti_hom.map_prod (f : α → β) [is_group_anti_hom f] (l : list α) :
   f (prod l) = prod (map f (reverse l)) :=
-by induction l with hd tl ih; [exact is_group_anti_hom.one f,
-  simp only [prod_cons, is_group_anti_hom.mul f, ih, reverse_cons, map_append, prod_append, map_singleton, prod_cons, prod_nil, mul_one]]
+by induction l with hd tl ih; [exact is_group_anti_hom.map_one f,
+  simp only [prod_cons, is_group_anti_hom.map_mul f, ih, reverse_cons, map_append, prod_append, map_singleton, prod_cons, prod_nil, mul_one]]
 
 theorem inv_prod : ∀ l : list α, (prod l)⁻¹ = prod (map (λ x, x⁻¹) (reverse l)) :=
-λ l, @is_group_anti_hom.prod _ _ _ _ _ inv_is_group_anti_hom l -- TODO there is probably a cleaner proof of this
+λ l, @is_group_anti_hom.map_prod _ _ _ _ _ inv_is_group_anti_hom l -- TODO there is probably a cleaner proof of this
 
 end group
 
@@ -634,19 +634,19 @@ section comm_group
 variables [comm_group α] [comm_group β] (f : α → β) [is_group_hom f]
 
 @[to_additive is_add_group_hom.multiset_sum]
-lemma is_group_hom.multiset_prod (m : multiset α) : f m.prod = (m.map f).prod :=
-quotient.induction_on m $ assume l, by simp [is_group_hom.prod f l]
+lemma is_group_hom.map_multiset_prod (m : multiset α) : f m.prod = (m.map f).prod :=
+quotient.induction_on m $ assume l, by simp [is_group_hom.map_prod f l]
 
 @[to_additive is_add_group_hom.finset_sum]
 lemma is_group_hom.finset_prod (g : γ → α) (s : finset γ) : f (s.prod g) = s.prod (f ∘ g) :=
-show f (s.val.map g).prod = (s.val.map (f ∘ g)).prod, by rw [is_group_hom.multiset_prod f]; simp
+show f (s.val.map g).prod = (s.val.map (f ∘ g)).prod, by rw [is_group_hom.map_multiset_prod f]; simp
 
 end comm_group
 
 @[to_additive is_add_group_hom_finset_sum]
 lemma is_group_hom_finset_prod {α β γ} [group α] [comm_group β] (s : finset γ)
   (f : γ → α → β) [∀c, is_group_hom (f c)] : is_group_hom (λa, s.prod (λc, f c a)) :=
-⟨assume a b, by simp only [λc, is_group_hom.mul (f c), finset.prod_mul_distrib]⟩
+⟨assume a b, by simp only [λc, is_group_hom.map_mul (f c), finset.prod_mul_distrib]⟩
 
 attribute [instance] is_group_hom_finset_prod is_add_group_hom_finset_sum
 

--- a/src/algebra/direct_sum.lean
+++ b/src/algebra/direct_sum.lean
@@ -33,31 +33,31 @@ instance mk.is_add_group_hom (s : finset ι) : is_add_group_hom (mk β s) :=
 ⟨λ _ _, dfinsupp.mk_add⟩
 
 @[simp] lemma mk_zero (s : finset ι) : mk β s 0 = 0 :=
-is_add_group_hom.zero _
+is_add_group_hom.map_zero _
 
 @[simp] lemma mk_add (s : finset ι) (x y) : mk β s (x + y) = mk β s x + mk β s y :=
-is_add_group_hom.add _ x y
+is_add_group_hom.map_add _ x y
 
 @[simp] lemma mk_neg (s : finset ι) (x) : mk β s (-x) = -mk β s x :=
-is_add_group_hom.neg _ x
+is_add_group_hom.map_neg _ x
 
 @[simp] lemma mk_sub (s : finset ι) (x y) : mk β s (x - y) = mk β s x - mk β s y :=
-is_add_group_hom.sub _ x y
+is_add_group_hom.map_sub _ x y
 
 instance of.is_add_group_hom (i : ι) : is_add_group_hom (of β i) :=
 ⟨λ _ _, dfinsupp.single_add⟩
 
 @[simp] lemma of_zero (i : ι) : of β i 0 = 0 :=
-is_add_group_hom.zero _
+is_add_group_hom.map_zero _
 
 @[simp] lemma of_add (i : ι) (x y) : of β i (x + y) = of β i x + of β i y :=
-is_add_group_hom.add _ x y
+is_add_group_hom.map_add _ x y
 
 @[simp] lemma of_neg (i : ι) (x) : of β i (-x) = -of β i x :=
-is_add_group_hom.neg _ x
+is_add_group_hom.map_neg _ x
 
 @[simp] lemma of_sub (i : ι) (x y) : of β i (x - y) = of β i x - of β i y :=
-is_add_group_hom.sub _ x y
+is_add_group_hom.map_sub _ x y
 
 theorem mk_inj (s : finset ι) : function.injective (mk β s) :=
 dfinsupp.mk_inj s
@@ -88,11 +88,11 @@ begin
   refine (finset.sum_subset H1 _).symm.trans ((finset.sum_congr rfl _).trans (finset.sum_subset H2 _)),
   { intros i H1 H2, rw finset.mem_inter at H2, rw H i,
     simp only [multiset.mem_to_finset] at H1 H2,
-    rw [(y.3 i).resolve_left (mt (and.intro H1) H2), is_add_group_hom.zero (φ i)] },
+    rw [(y.3 i).resolve_left (mt (and.intro H1) H2), is_add_group_hom.map_zero (φ i)] },
   { intros i H1, rw H i },
   { intros i H1 H2, rw finset.mem_inter at H2, rw ← H i,
     simp only [multiset.mem_to_finset] at H1 H2,
-    rw [(x.3 i).resolve_left (mt (λ H3, and.intro H3 H1) H2), is_add_group_hom.zero (φ i)] }
+    rw [(x.3 i).resolve_left (mt (λ H3, and.intro H3 H1) H2), is_add_group_hom.map_zero (φ i)] }
 end
 variables {φ}
 
@@ -102,31 +102,31 @@ begin
   refine quotient.induction_on f (λ x, _),
   refine quotient.induction_on g (λ y, _),
   change finset.sum _ _ = finset.sum _ _ + finset.sum _ _,
-  simp only, conv { to_lhs, congr, skip, funext, rw is_add_group_hom.add (φ i) },
+  simp only, conv { to_lhs, congr, skip, funext, rw is_add_group_hom.map_add (φ i) },
   simp only [finset.sum_add_distrib],
   congr' 1,
   { refine (finset.sum_subset _ _).symm,
     { intro i, simp only [multiset.mem_to_finset, multiset.mem_add], exact or.inl },
     { intros i H1 H2, simp only [multiset.mem_to_finset, multiset.mem_add] at H2,
-      rw [(x.3 i).resolve_left H2, is_add_group_hom.zero (φ i)] } },
+      rw [(x.3 i).resolve_left H2, is_add_group_hom.map_zero (φ i)] } },
   { refine (finset.sum_subset _ _).symm,
     { intro i, simp only [multiset.mem_to_finset, multiset.mem_add], exact or.inr },
     { intros i H1 H2, simp only [multiset.mem_to_finset, multiset.mem_add] at H2,
-      rw [(y.3 i).resolve_left H2, is_add_group_hom.zero (φ i)] } }
+      rw [(y.3 i).resolve_left H2, is_add_group_hom.map_zero (φ i)] } }
 end
 
 variables (φ)
 @[simp] lemma to_group_zero : to_group φ 0 = 0 :=
-is_add_group_hom.zero _
+is_add_group_hom.map_zero _
 
 @[simp] lemma to_group_add (x y) : to_group φ (x + y) = to_group φ x + to_group φ y :=
-is_add_group_hom.add _ x y
+is_add_group_hom.map_add _ x y
 
 @[simp] lemma to_group_neg (x) : to_group φ (-x) = -to_group φ x :=
-is_add_group_hom.neg _ x
+is_add_group_hom.map_neg _ x
 
 @[simp] lemma to_group_sub (x y) : to_group φ (x - y) = to_group φ x - to_group φ y :=
-is_add_group_hom.sub _ x y
+is_add_group_hom.map_sub _ x y
 
 @[simp] lemma to_group_of (i) (x : β i) : to_group φ (of β i x) = φ i x :=
 (add_zero _).trans $ congr_arg (φ i) $ show (if H : i ∈ finset.singleton i then x else 0) = x,
@@ -136,9 +136,9 @@ variables (ψ : direct_sum ι β → γ) [is_add_group_hom ψ]
 
 theorem to_group.unique (f : direct_sum ι β) : ψ f = to_group (λ i, ψ ∘ of β i) f :=
 direct_sum.induction_on f
-  (by rw [is_add_group_hom.zero ψ, is_add_group_hom.zero (to_group (λ i, ψ ∘ of β i))])
+  (by rw [is_add_group_hom.map_zero ψ, is_add_group_hom.map_zero (to_group (λ i, ψ ∘ of β i))])
   (λ i x, by rw [to_group_of])
-  (λ x y ihx ihy, by rw [is_add_group_hom.add ψ, is_add_group_hom.add (to_group (λ i, ψ ∘ of β i)), ihx, ihy])
+  (λ x y ihx ihy, by rw [is_add_group_hom.map_add ψ, is_add_group_hom.map_add (to_group (λ i, ψ ∘ of β i)), ihx, ihy])
 
 variables (β)
 def set_to_set (S T : set ι) (H : S ⊆ T) :

--- a/src/algebra/group.lean
+++ b/src/algebra/group.lean
@@ -664,14 +664,12 @@ by refine_struct {..}; simp [add_mul]
 
 end is_monoid_hom
 
--- TODO rename fields of is_group_hom: mul ↝ map_mul?
-
 /-- Predicate for group homomorphism. -/
 class is_group_hom [group α] [group β] (f : α → β) : Prop :=
-(mul : ∀ a b : α, f (a * b) = f a * f b)
+(map_mul : ∀ a b : α, f (a * b) = f a * f b)
 
 class is_add_group_hom [add_group α] [add_group β] (f : α → β) : Prop :=
-(add : ∀ a b, f (a + b) = f a + f b)
+(map_add : ∀ a b, f (a + b) = f a + f b)
 
 attribute [to_additive is_add_group_hom] is_group_hom
 attribute [to_additive is_add_group_hom.cases_on] is_group_hom.cases_on
@@ -680,29 +678,29 @@ attribute [to_additive is_add_group_hom.rec] is_group_hom.rec
 attribute [to_additive is_add_group_hom.drec] is_group_hom.drec
 attribute [to_additive is_add_group_hom.rec_on] is_group_hom.rec_on
 attribute [to_additive is_add_group_hom.drec_on] is_group_hom.drec_on
-attribute [to_additive is_add_group_hom.add] is_group_hom.mul
+attribute [to_additive is_add_group_hom.map_add] is_group_hom.map_mul
 attribute [to_additive is_add_group_hom.mk] is_group_hom.mk
 
 instance additive.is_add_group_hom [group α] [group β] (f : α → β) [is_group_hom f] :
   @is_add_group_hom (additive α) (additive β) _ _ f :=
-⟨@is_group_hom.mul α β _ _ f _⟩
+⟨@is_group_hom.map_mul α β _ _ f _⟩
 
 instance multiplicative.is_group_hom [add_group α] [add_group β] (f : α → β) [is_add_group_hom f] :
   @is_group_hom (multiplicative α) (multiplicative β) _ _ f :=
-⟨@is_add_group_hom.add α β _ _ f _⟩
+⟨@is_add_group_hom.map_add α β _ _ f _⟩
 
 attribute [to_additive additive.is_add_group_hom] multiplicative.is_group_hom
 
 namespace is_group_hom
 variables [group α] [group β] (f : α → β) [is_group_hom f]
 
-@[to_additive is_add_group_hom.zero]
-theorem one : f 1 = 1 :=
-mul_self_iff_eq_one.1 $ by rw [← mul f, one_mul]
+@[to_additive is_add_group_hom.map_zero]
+theorem map_one : f 1 = 1 :=
+mul_self_iff_eq_one.1 $ by rw [← map_mul f, one_mul]
 
-@[to_additive is_add_group_hom.neg]
-theorem inv (a : α) : f a⁻¹ = (f a)⁻¹ :=
-eq_inv_of_mul_eq_one $ by rw [← mul f, inv_mul_self, one f]
+@[to_additive is_add_group_hom.map_neg]
+theorem map_inv (a : α) : f a⁻¹ = (f a)⁻¹ :=
+eq_inv_of_mul_eq_one $ by rw [← map_mul f, inv_mul_self, map_one f]
 
 @[to_additive is_add_group_hom.id]
 instance id : is_group_hom (@id α) :=
@@ -711,21 +709,21 @@ instance id : is_group_hom (@id α) :=
 @[to_additive is_add_group_hom.comp]
 instance comp {γ} [group γ] (g : β → γ) [is_group_hom g] :
   is_group_hom (g ∘ f) :=
-⟨λ x y, show g _ = g _ * g _, by rw [mul f, mul g]⟩
+⟨λ x y, show g _ = g _ * g _, by rw [map_mul f, map_mul g]⟩
 
 protected lemma is_conj (f : α → β) [is_group_hom f] {a b : α} : is_conj a b → is_conj (f a) (f b)
-| ⟨c, hc⟩ := ⟨f c, by rw [← is_group_hom.mul f, ← is_group_hom.inv f, ← is_group_hom.mul f, hc]⟩
+| ⟨c, hc⟩ := ⟨f c, by rw [← is_group_hom.map_mul f, ← is_group_hom.map_inv f, ← is_group_hom.map_mul f, hc]⟩
 
 @[to_additive is_add_group_hom.to_is_add_monoid_hom]
 lemma to_is_monoid_hom (f : α → β) [is_group_hom f] : is_monoid_hom f :=
-⟨is_group_hom.one f, is_group_hom.mul f⟩
+⟨is_group_hom.map_one f, is_group_hom.map_mul f⟩
 
 @[to_additive is_add_group_hom.injective_iff]
 lemma injective_iff (f : α → β) [is_group_hom f] :
   function.injective f ↔ (∀ a, f a = 1 → a = 1) :=
-⟨λ h _, by rw ← is_group_hom.one f; exact @h _ _,
-  λ h x y hxy, by rw [← inv_inv (f x), inv_eq_iff_mul_eq_one, ← is_group_hom.inv f,
-      ← is_group_hom.mul f] at hxy;
+⟨λ h _, by rw ← is_group_hom.map_one f; exact @h _ _,
+  λ h x y hxy, by rw [← inv_inv (f x), inv_eq_iff_mul_eq_one, ← is_group_hom.map_inv f,
+      ← is_group_hom.map_mul f] at hxy;
     simpa using inv_eq_of_mul_eq_one (h _ hxy)⟩
 
 attribute [instance] is_group_hom.to_is_monoid_hom
@@ -733,20 +731,20 @@ attribute [instance] is_group_hom.to_is_monoid_hom
 
 end is_group_hom
 
-@[to_additive is_add_group_hom_add]
-lemma is_group_hom_mul {α β} [group α] [comm_group β]
+@[to_additive is_add_group_hom.add]
+lemma is_group_hom.mul {α β} [group α] [comm_group β]
   (f g : α → β) [is_group_hom f] [is_group_hom g] :
   is_group_hom (λa, f a * g a) :=
-⟨assume a b, by simp only [is_group_hom.mul f, is_group_hom.mul g, mul_comm, mul_assoc, mul_left_comm]⟩
+⟨assume a b, by simp only [is_group_hom.map_mul f, is_group_hom.map_mul g, mul_comm, mul_assoc, mul_left_comm]⟩
 
-attribute [instance] is_group_hom_mul is_add_group_hom_add
+attribute [instance] is_group_hom.mul is_add_group_hom.add
 
-@[to_additive is_add_group_hom_neg]
-lemma is_group_hom_inv {α β} [group α] [comm_group β] (f : α → β) [is_group_hom f] :
+@[to_additive is_add_group_hom.neg]
+lemma is_group_hom.inv {α β} [group α] [comm_group β] (f : α → β) [is_group_hom f] :
   is_group_hom (λa, (f a)⁻¹) :=
-⟨assume a b, by rw [is_group_hom.mul f, mul_inv]⟩
+⟨assume a b, by rw [is_group_hom.map_mul f, mul_inv]⟩
 
-attribute [instance] is_group_hom_inv is_add_group_hom_neg
+attribute [instance] is_group_hom.inv is_add_group_hom.neg
 
 @[to_additive neg.is_add_group_hom]
 lemma inv.is_group_hom [comm_group α] : is_group_hom (has_inv.inv : α → α) :=
@@ -757,17 +755,17 @@ attribute [instance] inv.is_group_hom neg.is_add_group_hom
 /-- Predicate for group anti-homomorphism, or a homomorphism
   into the opposite group. -/
 class is_group_anti_hom {β : Type*} [group α] [group β] (f : α → β) : Prop :=
-(mul : ∀ a b : α, f (a * b) = f b * f a)
+(map_mul : ∀ a b : α, f (a * b) = f b * f a)
 
 namespace is_group_anti_hom
 variables [group α] [group β] (f : α → β) [w : is_group_anti_hom f]
 include w
 
-theorem one : f 1 = 1 :=
-mul_self_iff_eq_one.1 $ by rw [← mul f, one_mul]
+theorem map_one : f 1 = 1 :=
+mul_self_iff_eq_one.1 $ by rw [← map_mul f, one_mul]
 
-theorem inv (a : α) : f a⁻¹ = (f a)⁻¹ :=
-eq_inv_of_mul_eq_one $ by rw [← mul f, mul_inv_self, one f]
+theorem map_inv (a : α) : f a⁻¹ = (f a)⁻¹ :=
+eq_inv_of_mul_eq_one $ by rw [← map_mul f, mul_inv_self, map_one f]
 
 end is_group_anti_hom
 
@@ -777,19 +775,19 @@ theorem inv_is_group_anti_hom [group α] : is_group_anti_hom (λ x : α, x⁻¹)
 namespace is_add_group_hom
 variables [add_group α] [add_group β] (f : α → β) [is_add_group_hom f]
 
-lemma sub (a b) : f (a - b) = f a - f b :=
+lemma map_sub (a b) : f (a - b) = f a - f b :=
 calc f (a - b) = f (a + -b)   : rfl
-           ... = f a + f (-b) : add f _ _
-           ... = f a - f b    : by  simp[neg f]
+           ... = f a + f (-b) : map_add f _ _
+           ... = f a - f b    : by  simp[map_neg f]
 
 end is_add_group_hom
 
-lemma is_add_group_hom_sub {α β} [add_group α] [add_comm_group β]
+lemma is_add_group_hom.sub {α β} [add_group α] [add_comm_group β]
   (f g : α → β) [is_add_group_hom f] [is_add_group_hom g] :
   is_add_group_hom (λa, f a - g a) :=
-is_add_group_hom_add f (λa, - g a)
+is_add_group_hom.add f (λa, - g a)
 
-attribute [instance] is_add_group_hom_sub
+attribute [instance] is_add_group_hom.sub
 
 namespace units
 

--- a/src/algebra/group_power.lean
+++ b/src/algebra/group_power.lean
@@ -354,27 +354,27 @@ end group
 namespace is_group_hom
 variables {β : Type v} [group α] [group β] (f : α → β) [is_group_hom f]
 
-theorem pow (a : α) (n : ℕ) : f (a ^ n) = f a ^ n :=
+theorem map_pow (a : α) (n : ℕ) : f (a ^ n) = f a ^ n :=
 is_monoid_hom.map_pow f a n
 
-theorem gpow (a : α) (n : ℤ) : f (a ^ n) = f a ^ n :=
-by cases n; [exact is_group_hom.pow f _ _,
-  exact (is_group_hom.inv f _).trans (congr_arg _ $ is_group_hom.pow f _ _)]
+theorem map_gpow (a : α) (n : ℤ) : f (a ^ n) = f a ^ n :=
+by cases n; [exact is_group_hom.map_pow f _ _,
+  exact (is_group_hom.map_inv f _).trans (congr_arg _ $ is_group_hom.map_pow f _ _)]
 
 end is_group_hom
 
 namespace is_add_group_hom
 variables {β : Type v} [add_group α] [add_group β] (f : α → β) [is_add_group_hom f]
 
-theorem smul (a : α) (n : ℕ) : f (n • a) = n • f a :=
+theorem map_smul (a : α) (n : ℕ) : f (n • a) = n • f a :=
 is_add_monoid_hom.map_smul f a n
 
-theorem gsmul (a : α) (n : ℤ) : f (gsmul n a) = gsmul n (f a) :=
+theorem map_gsmul (a : α) (n : ℤ) : f (gsmul n a) = gsmul n (f a) :=
 begin
   induction n using int.induction_on with z ih z ih,
-  { simp [is_add_group_hom.zero f] },
-  { simp [is_add_group_hom.add f, add_gsmul, ih] },
-  { simp [is_add_group_hom.add f, is_add_group_hom.neg f, add_gsmul, ih] }
+  { simp [is_add_group_hom.map_zero f] },
+  { simp [is_add_group_hom.map_add f, add_gsmul, ih] },
+  { simp [is_add_group_hom.map_add f, is_add_group_hom.map_neg f, add_gsmul, ih] }
 end
 
 end is_add_group_hom
@@ -407,10 +407,10 @@ end comm_monoid
 section group
 
 @[instance]
-theorem is_add_group_hom_gsmul
+theorem is_add_group_hom.gsmul
   {α β} [add_group α] [add_comm_group β] (f : α → β) [is_add_group_hom f] (z : ℤ) :
   is_add_group_hom (λa, gsmul z (f a)) :=
-⟨assume a b, by rw [is_add_group_hom.add f, gsmul_add]⟩
+⟨assume a b, by rw [is_add_group_hom.map_add f, gsmul_add]⟩
 
 end group
 

--- a/src/analysis/complex/exponential.lean
+++ b/src/analysis/complex/exponential.lean
@@ -484,7 +484,7 @@ instance angle.is_add_group_hom : is_add_group_hom (coe : ℝ → angle) :=
 @[simp] lemma coe_add (x y : ℝ) : ↑(x + y : ℝ) = (↑x + ↑y : angle) := rfl
 @[simp] lemma coe_neg (x : ℝ) : ↑(-x : ℝ) = -(↑x : angle) := rfl
 @[simp] lemma coe_sub (x y : ℝ) : ↑(x - y : ℝ) = (↑x - ↑y : angle) := rfl
-@[simp] lemma coe_gsmul (x : ℝ) (n : ℤ) : ↑(gsmul n x : ℝ) = gsmul n (↑x : angle) := is_add_group_hom.gsmul _ _ _
+@[simp] lemma coe_gsmul (x : ℝ) (n : ℤ) : ↑(gsmul n x : ℝ) = gsmul n (↑x : angle) := is_add_group_hom.map_gsmul _ _ _
 @[simp] lemma coe_two_pi : ↑(2 * π : ℝ) = (0 : angle) :=
 quotient.sound' ⟨-1, by dsimp only; rw [neg_one_gsmul, add_zero]⟩
 

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -62,7 +62,7 @@ end
 lemma splits_mul {f g : polynomial α} (hf : splits i f) (hg : splits i g) : splits i (f * g) :=
 if h : f * g = 0 then by simp [h]
 else or.inr $ λ p hp hpf, ((principal_ideal_domain.irreducible_iff_prime.1 hp).2.2 _ _
-    (show p ∣ map i f * map i g, by convert hpf; rw map_mul)).elim
+    (show p ∣ map i f * map i g, by convert hpf; rw polynomial.map_mul)).elim
   (hf.resolve_left (λ hf, by simpa [hf] using h) hp)
   (hg.resolve_left (λ hg, by simpa [hg] using h) hp)
 

--- a/src/group_theory/abelianization.lean
+++ b/src/group_theory/abelianization.lean
@@ -63,11 +63,11 @@ variables {β : Type v} [comm_group β] (f : α → β) [is_group_hom f]
 
 def lift : abelianization α → β :=
 quotient_group.lift _ f $ λ x ⟨L, HL, hx⟩,
-hx ▸ list.rec_on L (λ _, is_group_hom.one f) (λ hd tl HL ih,
+hx ▸ list.rec_on L (λ _, is_group_hom.map_one f) (λ hd tl HL ih,
   by rw [list.forall_mem_cons] at ih;
     rcases ih with ⟨⟨p, q, hpq⟩, ih⟩;
-    specialize HL ih; rw [list.prod_cons, is_group_hom.mul f, ← hpq, HL];
-    simp [is_group_hom.mul f, is_group_hom.inv f, mul_comm]) HL
+    specialize HL ih; rw [list.prod_cons, is_group_hom.map_mul f, ← hpq, HL];
+    simp [is_group_hom.map_mul f, is_group_hom.map_inv f, mul_comm]) HL
 
 instance lift.is_group_hom : is_group_hom (lift f) :=
 quotient_group.is_group_hom_quotient_lift _ _ _

--- a/src/group_theory/free_abelian_group.lean
+++ b/src/group_theory/free_abelian_group.lean
@@ -34,21 +34,21 @@ variables {β : Type v} [add_comm_group β] (f : α → β)
 open free_abelian_group
 
 instance is_add_group_hom : is_add_group_hom (lift f) :=
-⟨λ x y, @is_group_hom.mul _ (multiplicative β) _ _ _ (abelianization.lift.is_group_hom _) x y⟩
+⟨λ x y, @is_group_hom.map_mul _ (multiplicative β) _ _ _ (abelianization.lift.is_group_hom _) x y⟩
 
 @[simp] protected lemma add (x y : free_abelian_group α) :
   lift f (x + y) = lift f x + lift f y :=
-is_add_group_hom.add _ _ _
+is_add_group_hom.map_add _ _ _
 
 @[simp] protected lemma neg (x : free_abelian_group α) : lift f (-x) = -lift f x :=
-is_add_group_hom.neg _ _
+is_add_group_hom.map_neg _ _
 
 @[simp] protected lemma sub (x y : free_abelian_group α) :
   lift f (x - y) = lift f x - lift f y :=
 by simp
 
 @[simp] protected lemma zero : lift f 0 = 0 :=
-is_add_group_hom.zero _
+is_add_group_hom.map_zero _
 
 @[simp] protected lemma of (x : α) : lift f (of x) = f x :=
 by unfold of; unfold lift; simp
@@ -57,9 +57,9 @@ protected theorem unique (g : free_abelian_group α → β) [is_add_group_hom g]
   (hg : ∀ x, g (of x) = f x) {x} :
   g x = lift f x :=
 @abelianization.lift.unique (free_group α) _ (multiplicative β) _ _ _ g
-  ⟨λ x y, @is_add_group_hom.add (additive $ abelianization (free_group α)) _ _ _ _ _ x y⟩ (λ x,
+  ⟨λ x y, @is_add_group_hom.map_add (additive $ abelianization (free_group α)) _ _ _ _ _ x y⟩ (λ x,
   @free_group.to_group.unique α (multiplicative β) _ _ (g ∘ abelianization.of)
-    ⟨λ m n, is_add_group_hom.add g (abelianization.of m) (abelianization.of n)⟩ hg _) _
+    ⟨λ m n, is_add_group_hom.map_add g (abelianization.of m) (abelianization.of n)⟩ hg _) _
 
 protected theorem ext (g h : free_abelian_group α → β)
   [is_add_group_hom g] [is_add_group_hom h]
@@ -105,11 +105,11 @@ instance is_add_group_hom_lift' {α} (β) [add_comm_group β] (a : free_abelian_
   is_add_group_hom (λf, (a.lift f : β)) :=
 begin
   refine ⟨assume f g, free_abelian_group.induction_on a _ _ _ _⟩,
-  { simp [is_add_group_hom.zero (free_abelian_group.lift f)] },
+  { simp [is_add_group_hom.map_zero (free_abelian_group.lift f)] },
   { simp [lift.of], assume x, refl },
-  { simp [is_add_group_hom.neg (free_abelian_group.lift f)],
+  { simp [is_add_group_hom.map_neg (free_abelian_group.lift f)],
     assume x h, show - (f x + g x) = -f x + - g x, exact neg_add _ _ },
-  { simp [is_add_group_hom.add (free_abelian_group.lift f)],
+  { simp [is_add_group_hom.map_add (free_abelian_group.lift f)],
     assume x y hx hy,
     rw [hx, hy],
     ac_refl }
@@ -178,19 +178,19 @@ sub_bind _ _ _
 
 instance is_add_group_hom_seq (f : free_abelian_group (α → β)) : is_add_group_hom ((<*>) f) :=
 ⟨λ x y, show lift (<$> (x+y)) _ = _, by simp only [map_add]; exact
-@@is_add_group_hom.add _ _ _ (@@free_abelian_group.is_add_group_hom_lift' (free_abelian_group β) _ _) _ _⟩
+@@is_add_group_hom.map_add _ _ _ (@@free_abelian_group.is_add_group_hom_lift' (free_abelian_group β) _ _) _ _⟩
 
 @[simp] lemma seq_zero (f : free_abelian_group (α → β)) : f <*> 0 = 0 :=
-is_add_group_hom.zero _
+is_add_group_hom.map_zero _
 
 @[simp] lemma seq_add (f : free_abelian_group (α → β)) (x y : free_abelian_group α) : f <*> (x + y) = (f <*> x) + (f <*> y) :=
-is_add_group_hom.add _ _ _
+is_add_group_hom.map_add _ _ _
 
 @[simp] lemma seq_neg (f : free_abelian_group (α → β)) (x : free_abelian_group α) : f <*> (-x) = -(f <*> x) :=
-is_add_group_hom.neg _ _
+is_add_group_hom.map_neg _ _
 
 @[simp] lemma seq_sub (f : free_abelian_group (α → β)) (x y : free_abelian_group α) : f <*> (x - y) = (f <*> x) - (f <*> y) :=
-is_add_group_hom.sub _ _ _
+is_add_group_hom.map_sub _ _ _
 
 instance : is_lawful_monad free_abelian_group.{u} :=
 { id_map := λ α x, free_abelian_group.induction_on' x (map_zero id) (λ x, map_pure id x)

--- a/src/group_theory/free_group.lean
+++ b/src/group_theory/free_group.lean
@@ -394,22 +394,22 @@ instance to_group.is_group_hom : is_group_hom (to_group f) :=
 ⟨by rintros ⟨L₁⟩ ⟨L₂⟩; simp⟩
 
 @[simp] lemma to_group.mul : to_group f (x * y) = to_group f x * to_group f y :=
-is_group_hom.mul _ _ _
+is_group_hom.map_mul _ _ _
 
 @[simp] lemma to_group.one : to_group f 1 = 1 :=
-is_group_hom.one _
+is_group_hom.map_one _
 
 @[simp] lemma to_group.inv : to_group f x⁻¹ = (to_group f x)⁻¹ :=
-is_group_hom.inv _ _
+is_group_hom.map_inv _ _
 
 theorem to_group.unique (g : free_group α → β) [is_group_hom g]
   (hg : ∀ x, g (of x) = f x) : ∀{x}, g x = to_group f x :=
-by rintros ⟨L⟩; exact list.rec_on L (is_group_hom.one g)
+by rintros ⟨L⟩; exact list.rec_on L (is_group_hom.map_one g)
 (λ ⟨x, b⟩ t (ih : g (mk t) = _), bool.rec_on b
   (show g ((of x)⁻¹ * mk t) = to_group f (mk ((x, ff) :: t)),
-     by simp [is_group_hom.mul g, is_group_hom.inv g, hg, ih, to_group, to_group.aux])
+     by simp [is_group_hom.map_mul g, is_group_hom.map_inv g, hg, ih, to_group, to_group.aux])
   (show g (of x * mk t) = to_group f (mk ((x, tt) :: t)),
-     by simp [is_group_hom.mul g, is_group_hom.inv g, hg, ih, to_group, to_group.aux]))
+     by simp [is_group_hom.map_mul g, is_group_hom.map_inv g, hg, ih, to_group, to_group.aux]))
 
 
 theorem to_group.of_eq (x : free_group α) : to_group of x = x :=
@@ -466,22 +466,22 @@ by rcases x with ⟨L⟩; simp
 @[simp] lemma map.of {x} : map f (of x) = of (f x) := rfl
 
 @[simp] lemma map.mul : map f (x * y) = map f x * map f y :=
-is_group_hom.mul _ x y
+is_group_hom.map_mul _ x y
 
 @[simp] lemma map.one : map f 1 = 1 :=
-is_group_hom.one _
+is_group_hom.map_one _
 
 @[simp] lemma map.inv : map f x⁻¹ = (map f x)⁻¹ :=
-is_group_hom.inv _ x
+is_group_hom.map_inv _ x
 
 theorem map.unique (g : free_group α → free_group β) [is_group_hom g]
   (hg : ∀ x, g (of x) = of (f x)) : ∀{x}, g x = map f x :=
-by rintros ⟨L⟩; exact list.rec_on L (is_group_hom.one g)
+by rintros ⟨L⟩; exact list.rec_on L (is_group_hom.map_one g)
 (λ ⟨x, b⟩ t (ih : g (mk t) = map f (mk t)), bool.rec_on b
   (show g ((of x)⁻¹ * mk t) = map f ((of x)⁻¹ * mk t),
-     by simp [is_group_hom.mul g, is_group_hom.inv g, hg, ih])
+     by simp [is_group_hom.map_mul g, is_group_hom.map_inv g, hg, ih])
   (show g (of x * mk t) = map f (of x * mk t),
-     by simp [is_group_hom.mul g, hg, ih]))
+     by simp [is_group_hom.map_mul g, hg, ih]))
 
 /-- Equivalent types give rise to equivalent free groups. -/
 def free_group_congr {α β} (e : α ≃ β) : free_group α ≃ free_group β :=

--- a/src/group_theory/group_action.lean
+++ b/src/group_theory/group_action.lean
@@ -97,7 +97,7 @@ def to_perm (g : α) : equiv.perm β :=
 variables {α} {β}
 
 instance : is_group_hom (to_perm α β) :=
-{ mul := λ x y, equiv.ext _ _ (λ a, mul_action.mul_smul x y a) }
+{ map_mul := λ x y, equiv.ext _ _ (λ a, mul_action.mul_smul x y a) }
 
 lemma bijective (g : α) : function.bijective (λ b : β, g • b) :=
 (to_perm α β g).bijective

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -36,7 +36,7 @@ instance of_subtype.is_group_hom {p : α → Prop} [decidable_pred p] : is_group
 end⟩
 
 @[simp] lemma of_subtype_one (p : α → Prop) [decidable_pred p] : @of_subtype α p _ 1 = 1 :=
-is_group_hom.one of_subtype
+is_group_hom.map_one of_subtype
 
 lemma eq_inv_iff_eq {f : perm α} {x y : α} : x = f⁻¹ y ↔ f x = y :=
 by conv {to_lhs, rw [← injective.eq_iff f.injective, apply_inv_self]}
@@ -458,16 +458,16 @@ section sign
 variable [fintype α]
 
 @[simp] lemma sign_mul (f g : perm α) : sign (f * g) = sign f * sign g :=
-is_group_hom.mul sign _ _
+is_group_hom.map_mul sign _ _
 
 @[simp] lemma sign_one : (sign (1 : perm α)) = 1 :=
-is_group_hom.one sign
+is_group_hom.map_one sign
 
 @[simp] lemma sign_refl : sign (equiv.refl α) = 1 :=
-is_group_hom.one sign
+is_group_hom.map_one sign
 
 @[simp] lemma sign_inv (f : perm α) : sign f⁻¹ = sign f :=
-by rw [is_group_hom.inv sign, int.units_inv_eq_self]; apply_instance
+by rw [is_group_hom.map_inv sign, int.units_inv_eq_self]; apply_instance
 
 lemma sign_swap {x y : α} (h : x ≠ y) : sign (swap x y) = -1 :=
 (sign_aux3_mul_and_swap 1 1 _ mem_univ).2 x y h
@@ -501,7 +501,7 @@ have h₁ : l.map sign = list.repeat (-1) l.length :=
   list.eq_repeat.2 ⟨by simp, λ u hu,
   let ⟨g, hg⟩ := list.mem_map.1 hu in
   hg.2 ▸ sign_eq_of_is_swap (hl _ hg.1)⟩,
-by rw [← list.prod_repeat, ← h₁, ← is_group_hom.prod (@sign α _ _)]
+by rw [← list.prod_repeat, ← h₁, ← is_group_hom.map_prod (@sign α _ _)]
 
 lemma sign_surjective (hα : 1 < fintype.card α) : function.surjective (sign : perm α → units ℤ) :=
 λ a, (int.units_eq_one_or a).elim
@@ -522,14 +522,14 @@ have ∀ {f}, is_swap f → s f = -1 :=
   have ∀ a ∈ l.map s, a = (1 : units ℤ) := λ a ha,
     let ⟨g, hg⟩ := list.mem_map.1 ha in hg.2 ▸ this _ (hl.2 _ hg.1),
   have s l.prod = 1,
-    by rw [is_group_hom.prod s, list.eq_repeat'.2 this, list.prod_repeat, one_pow],
+    by rw [is_group_hom.map_prod s, list.eq_repeat'.2 this, list.prod_repeat, one_pow],
   by rw [hl.1, hg] at this;
     exact absurd this dec_trivial),
 funext $ λ f,
 let ⟨l, hl₁, hl₂⟩ := trunc.out (trunc_swap_factors f) in
 have hsl : ∀ a ∈ l.map s, a = (-1 : units ℤ) := λ a ha,
   let ⟨g, hg⟩ := list.mem_map.1 ha in hg.2 ▸  this (hl₂ _ hg.1),
-by rw [← hl₁, is_group_hom.prod s, list.eq_repeat'.2 hsl, list.length_map,
+by rw [← hl₁, is_group_hom.map_prod s, list.eq_repeat'.2 hsl, list.length_map,
      list.prod_repeat, sign_prod_list_swap hl₂]
 
 lemma sign_subtype_perm (f : perm α) {p : α → Prop} [decidable_pred p]
@@ -540,7 +540,7 @@ have hl' : ∀ g' ∈ l.1.map of_subtype, is_swap g' :=
   let ⟨g, hg⟩ := list.mem_map.1 hg' in
   hg.2 ▸ is_swap_of_subtype (l.2.2 _ hg.1),
 have hl'₂ : (l.1.map of_subtype).prod = f,
-  by rw [← is_group_hom.prod of_subtype l.1, l.2.1, of_subtype_subtype_perm _ h₂],
+  by rw [← is_group_hom.map_prod of_subtype l.1, l.2.1, of_subtype_subtype_perm _ h₂],
 by conv {congr, rw ← l.2.1, skip, rw ← hl'₂};
   rw [sign_prod_list_swap l.2.2, sign_prod_list_swap hl', list.length_map]
 

--- a/src/group_theory/quotient_group.lean
+++ b/src/group_theory/quotient_group.lean
@@ -78,14 +78,14 @@ attribute [to_additive quotient_add_group.add_comm_group.equations._eqn_1] quoti
 @[simp] lemma coe_mul (a b : G) : ((a * b : G) : quotient N) = a * b := rfl
 @[simp] lemma coe_inv (a : G) : ((a⁻¹ : G) : quotient N) = a⁻¹ := rfl
 @[simp] lemma coe_pow (a : G) (n : ℕ) : ((a ^ n : G) : quotient N) = a ^ n :=
-@is_group_hom.pow _ _ _ _ mk _ a n
+@is_group_hom.map_pow _ _ _ _ mk _ a n
 
 attribute [to_additive quotient_add_group.coe_zero] coe_one
 attribute [to_additive quotient_add_group.coe_add] coe_mul
 attribute [to_additive quotient_add_group.coe_neg] coe_inv
 
 @[simp] lemma coe_gpow (a : G) (n : ℤ) : ((a ^ n : G) : quotient N) = a ^ n :=
-@is_group_hom.gpow _ _ _ _ mk _ a n
+@is_group_hom.map_gpow _ _ _ _ mk _ a n
 
 local notation ` Q ` := quotient N
 
@@ -93,7 +93,7 @@ def lift (φ : G → H) [is_group_hom φ] (HN : ∀x∈N, φ x = 1) (q : Q) : H 
 q.lift_on' φ $ assume a b (hab : a⁻¹ * b ∈ N),
 (calc φ a = φ a * 1           : by simp
 ...       = φ a * φ (a⁻¹ * b) : by rw HN (a⁻¹ * b) hab
-...       = φ (a * (a⁻¹ * b)) : by rw is_group_hom.mul φ a (a⁻¹ * b)
+...       = φ (a * (a⁻¹ * b)) : by rw is_group_hom.map_mul φ a (a⁻¹ * b)
 ...       = φ b               : by simp)
 attribute [to_additive quotient_add_group.lift._proof_1] lift._proof_1
 attribute [to_additive quotient_add_group.lift] lift
@@ -127,7 +127,7 @@ variables (φ : G → H) [is_group_hom φ] (HN : ∀x∈N, φ x = 1)
 instance is_group_hom_quotient_lift  :
   is_group_hom (lift N φ HN) :=
 ⟨λ q r, quotient.induction_on₂' q r $ λ a b,
-  show φ (a * b) = φ a * φ b, from is_group_hom.mul φ a b⟩
+  show φ (a * b) = φ a * φ b, from is_group_hom.map_mul φ a b⟩
 attribute [to_additive quotient_add_group.is_add_group_hom_quotient_lift] quotient_group.is_group_hom_quotient_lift
 attribute [to_additive quotient_add_group.is_add_group_hom_quotient_lift.equations._eqn_1] quotient_group.is_group_hom_quotient_lift.equations._eqn_1
 
@@ -163,7 +163,7 @@ quotient_group.is_group_hom_quotient_lift _ _ _
 lemma injective_ker_lift : injective (ker_lift φ) :=
 assume a b, quotient.induction_on₂' a b $ assume a b (h : φ a = φ b), quotient.sound' $
 show a⁻¹ * b ∈ ker φ, by rw [mem_ker φ,
-  is_group_hom.mul φ, ← h, is_group_hom.inv φ, inv_mul_self]
+  is_group_hom.map_mul φ, ← h, is_group_hom.map_inv φ, inv_mul_self]
 
 --@[to_additive quotient_add_group.quotient_ker_equiv_range]
 noncomputable def quotient_ker_equiv_range : (quotient (ker φ)) ≃ set.range φ :=

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -437,53 +437,53 @@ attribute [to_additive is_add_group_hom.ker.equations._eqn_1] ker.equations._eqn
 lemma mem_ker (f : α → β) [is_group_hom f] {x : α} : x ∈ ker f ↔ f x = 1 :=
 mem_trivial
 
-@[to_additive is_add_group_hom.zero_ker_neg]
+@[to_additive is_add_group_hom.map_zero_ker_neg]
 lemma one_ker_inv (f : α → β) [is_group_hom f] {a b : α} (h : f (a * b⁻¹) = 1) : f a = f b :=
 begin
-  rw [mul f, inv f] at h,
+  rw [map_mul f, map_inv f] at h,
   rw [←inv_inv (f b), eq_inv_of_mul_eq_one h]
 end
 
-@[to_additive is_add_group_hom.zero_ker_neg']
+@[to_additive is_add_group_hom.map_zero_ker_neg']
 lemma one_ker_inv' (f : α → β) [is_group_hom f] {a b : α} (h : f (a⁻¹ * b) = 1) : f a = f b :=
 begin
-  rw [mul f, inv f] at h,
+  rw [map_mul f, map_inv f] at h,
   apply eq_of_inv_eq_inv,
   rw eq_inv_of_mul_eq_one h
 end
 
-@[to_additive is_add_group_hom.neg_ker_zero]
+@[to_additive is_add_group_hom.map_neg_ker_zero]
 lemma inv_ker_one (f : α → β) [is_group_hom f] {a b : α} (h : f a = f b) : f (a * b⁻¹) = 1 :=
 have f a * (f b)⁻¹ = 1, by rw [h, mul_right_inv],
-by rwa [←inv f, ←mul f] at this
+by rwa [←map_inv f, ←map_mul f] at this
 
-@[to_additive is_add_group_hom.neg_ker_zero']
+@[to_additive is_add_group_hom.map_neg_ker_zero']
 lemma inv_ker_one' (f : α → β) [is_group_hom f] {a b : α} (h : f a = f b) : f (a⁻¹ * b) = 1 :=
 have (f a)⁻¹ * f b = 1, by rw [h, mul_left_inv],
-by rwa [←inv f, ←mul f] at this
+by rwa [←map_inv f, ←map_mul f] at this
 
-@[to_additive is_add_group_hom.zero_iff_ker_neg]
+@[to_additive is_add_group_hom.map_zero_iff_ker_neg]
 lemma one_iff_ker_inv (f : α → β) [is_group_hom f] (a b : α) : f a = f b ↔ f (a * b⁻¹) = 1 :=
 ⟨inv_ker_one f, one_ker_inv f⟩
 
-@[to_additive is_add_group_hom.zero_iff_ker_neg']
+@[to_additive is_add_group_hom.map_zero_iff_ker_neg']
 lemma one_iff_ker_inv' (f : α → β) [is_group_hom f] (a b : α) : f a = f b ↔ f (a⁻¹ * b) = 1 :=
 ⟨inv_ker_one' f, one_ker_inv' f⟩
 
-@[to_additive is_add_group_hom.neg_iff_ker]
+@[to_additive is_add_group_hom.map_neg_iff_ker]
 lemma inv_iff_ker (f : α → β) [w : is_group_hom f] (a b : α) : f a = f b ↔ a * b⁻¹ ∈ ker f :=
 by rw [mem_ker]; exact one_iff_ker_inv _ _ _
 
-@[to_additive is_add_group_hom.neg_iff_ker']
+@[to_additive is_add_group_hom.map_neg_iff_ker']
 lemma inv_iff_ker' (f : α → β) [w : is_group_hom f] (a b : α) : f a = f b ↔ a⁻¹ * b ∈ ker f :=
 by rw [mem_ker]; exact one_iff_ker_inv' _ _ _
 
 instance image_subgroup (f : α → β) [is_group_hom f] (s : set α) [is_subgroup s] :
   is_subgroup (f '' s) :=
 { mul_mem := assume a₁ a₂ ⟨b₁, hb₁, eq₁⟩ ⟨b₂, hb₂, eq₂⟩,
-             ⟨b₁ * b₂, mul_mem hb₁ hb₂, by simp [eq₁, eq₂, mul f]⟩,
-  one_mem := ⟨1, one_mem s, one f⟩,
-  inv_mem := assume a ⟨b, hb, eq⟩, ⟨b⁻¹, inv_mem hb, by rw inv f; simp *⟩ }
+             ⟨b₁ * b₂, mul_mem hb₁ hb₂, by simp [eq₁, eq₂, map_mul f]⟩,
+  one_mem := ⟨1, one_mem s, map_one f⟩,
+  inv_mem := assume a ⟨b, hb, eq⟩, ⟨b⁻¹, inv_mem hb, by rw map_inv f; simp *⟩ }
 attribute [to_additive is_add_group_hom.image_add_subgroup._match_1] is_group_hom.image_subgroup._match_1
 attribute [to_additive is_add_group_hom.image_add_subgroup._match_2] is_group_hom.image_subgroup._match_2
 attribute [to_additive is_add_group_hom.image_add_subgroup._match_3] is_group_hom.image_subgroup._match_3
@@ -502,13 +502,13 @@ local attribute [simp] one_mem inv_mem mul_mem normal_subgroup.normal
 
 instance preimage (f : α → β) [is_group_hom f] (s : set β) [is_subgroup s] :
   is_subgroup (f ⁻¹' s) :=
-by refine {..}; simp [mul f, one f, inv f, @inv_mem β _ s] {contextual:=tt}
+by refine {..}; simp [map_mul f, map_one f, map_inv f, @inv_mem β _ s] {contextual:=tt}
 attribute [to_additive is_add_group_hom.preimage] is_group_hom.preimage
 attribute [to_additive is_add_group_hom.preimage.equations._eqn_1] is_group_hom.preimage.equations._eqn_1
 
 instance preimage_normal (f : α → β) [is_group_hom f] (s : set β) [normal_subgroup s] :
   normal_subgroup (f ⁻¹' s) :=
-⟨by simp [mul f, inv f] {contextual:=tt}⟩
+⟨by simp [map_mul f, map_inv f] {contextual:=tt}⟩
 attribute [to_additive is_add_group_hom.preimage_normal] is_group_hom.preimage_normal
 attribute [to_additive is_add_group_hom.preimage_normal.equations._eqn_1] is_group_hom.preimage_normal.equations._eqn_1
 
@@ -531,8 +531,8 @@ lemma trivial_ker_of_inj (f : α → β) [is_group_hom f] (h : function.injectiv
 set.ext $ assume x, iff.intro
   (assume hx,
     suffices f x = f 1, by simpa using h this,
-    by simp [one f]; rwa [mem_ker] at hx)
-  (by simp [mem_ker, is_group_hom.one f] {contextual := tt})
+    by simp [map_one f]; rwa [mem_ker] at hx)
+  (by simp [mem_ker, is_group_hom.map_one f] {contextual := tt})
 
 lemma inj_iff_trivial_ker (f : α → β) [is_group_hom f] :
   function.injective f ↔ ker f = trivial α :=
@@ -578,7 +578,7 @@ lemma simple_group_of_surjective [group α] [group β] [simple_group α] (f : α
     { refine or.inl (is_subgroup.eq_trivial_iff.2 (λ x hx, _)),
       cases hf x with y hy,
       rw ← hy at hx,
-      rw [← hy, is_subgroup.eq_trivial_iff.1 h y hx, is_group_hom.one f] },
+      rw [← hy, is_subgroup.eq_trivial_iff.1 h y hx, is_group_hom.map_one f] },
     { refine or.inr (set.eq_univ_of_forall (λ x, _)),
       cases hf x with y hy,
       rw set.eq_univ_iff_forall at h,

--- a/src/linear_algebra/tensor_product.lean
+++ b/src/linear_algebra/tensor_product.lean
@@ -196,7 +196,7 @@ by unfold has_scalar.smul; apply_instance
 
 protected theorem smul_add (r : R) (x y : M ⊗[R] N) :
   r • (x + y) = r • x + r • y :=
-is_add_group_hom.add _ _ _
+is_add_group_hom.map_add _ _ _
 
 instance : module R (M ⊗ N) := module.of_core
 { smul := (•),

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -285,7 +285,7 @@ by simp [lift', quotient.lift_on_beta, of, mk, this]
 have g = (λ s, units.map f (to_units s)),
   from funext $ λ x, units.ext_iff.2 $ (hg x).symm ▸ rfl,
 funext $ λ x, localization.induction_on x
-  (λ r s, by subst this; rw [lift'_mk, ← is_group_hom.inv (units.map f), units.coe_map];
+  (λ r s, by subst this; rw [lift'_mk, ← is_group_hom.map_inv (units.map f), units.coe_map];
     simp [is_ring_hom.map_mul f])
 
 @[simp] lemma lift_apply_coe (f : localization α S → β) [is_ring_hom f] :

--- a/src/topology/algebra/group_completion.lean
+++ b/src/topology/algebra/group_completion.lean
@@ -66,7 +66,7 @@ have hf : uniform_continuous f, from uniform_continuous_of_continuous hf,
   (is_closed_eq
     (continuous_add'.comp continuous_extension)
     (continuous_add (continuous_fst.comp continuous_extension) (continuous_snd.comp continuous_extension)))
-  (assume a b, by rw [← coe_add, extension_coe hf, extension_coe hf, extension_coe hf, is_add_group_hom.add f])⟩
+  (assume a b, by rw [← coe_add, extension_coe hf, extension_coe hf, extension_coe hf, is_add_group_hom.map_add f])⟩
 
 lemma is_add_group_hom_map [add_group β] [uniform_add_group β]
   {f : α → β} [is_add_group_hom f] (hf : continuous f) : is_add_group_hom (completion.map f) :=

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -123,7 +123,7 @@ lemma uniform_continuous_of_tendsto_zero [uniform_space β] [add_group β] [unif
   uniform_continuous f :=
 begin
   have : ((λx:β×β, x.2 - x.1) ∘ (λx:α×α, (f x.1, f x.2))) = (λx:α×α, f (x.2 - x.1)),
-  { simp only [is_add_group_hom.sub f] },
+  { simp only [is_add_group_hom.map_sub f] },
   rw [uniform_continuous, uniformity_eq_comap_nhds_zero α, uniformity_eq_comap_nhds_zero β,
     tendsto_comap_iff, this],
   exact tendsto.comp tendsto_comap h
@@ -133,7 +133,7 @@ lemma uniform_continuous_of_continuous [uniform_space β] [add_group β] [unifor
   {f : α → β} [is_add_group_hom f] (h : continuous f) :
   uniform_continuous f :=
 uniform_continuous_of_tendsto_zero $
-  suffices tendsto f (nhds 0) (nhds (f 0)), by rwa [is_add_group_hom.zero f] at this,
+  suffices tendsto f (nhds 0) (nhds (f 0)), by rwa [is_add_group_hom.map_zero f] at this,
   h.tendsto 0
 
 end uniform_add_group
@@ -236,7 +236,7 @@ variables (f : α × β → γ) [is_Z_bilin f]
 
 instance is_Z_bilin.comp_hom {g : γ → δ} [add_comm_group δ] [is_add_group_hom g] :
   is_Z_bilin (g ∘ f) :=
-by constructor; simp [(∘), is_Z_bilin.add_left f, is_Z_bilin.add_right f, is_add_group_hom.add g]
+by constructor; simp [(∘), is_Z_bilin.add_left f, is_Z_bilin.add_right f, is_add_group_hom.map_add g]
 
 instance is_Z_bilin.comp_swap : is_Z_bilin (f ∘ prod.swap) :=
 ⟨λ a a' b, is_Z_bilin.add_right f b a a',
@@ -321,10 +321,10 @@ begin
   have comm : (λx:α×α, x.2-x.1) ∘ (λt:β×β, (e t.1, e t.2)) = e ∘ (λt:β×β, t.2 - t.1),
   { ext t,
     change e t.2 - e t.1 = e (t.2 - t.1),
-    rwa ← is_add_group_hom.sub e t.2 t.1 },
+    rwa ← is_add_group_hom.map_sub e t.2 t.1 },
   have lim : tendsto (λ x : α × α, x.2-x.1) (nhds (x₀, x₀)) (nhds (e 0)),
     { have := continuous.tendsto (continuous.comp continuous_swap continuous_sub') (x₀, x₀),
-      simpa [-sub_eq_add_neg, sub_self, eq.symm (is_add_group_hom.zero e)] using this },
+      simpa [-sub_eq_add_neg, sub_self, eq.symm (is_add_group_hom.map_zero e)] using this },
   have := de.tendsto_comap_nhds_nhds lim comm,
   simp [-sub_eq_add_neg, this]
 end

--- a/src/topology/algebra/uniform_ring.lean
+++ b/src/topology/algebra/uniform_ring.lean
@@ -91,7 +91,7 @@ have hf : uniform_continuous f, from uniform_continuous_of_continuous hf,
       (continuous_add'.comp continuous_extension)
       (continuous_add (continuous_fst.comp continuous_extension) (continuous_snd.comp continuous_extension)))
     (assume a b,
-      by rw [← coe_add, extension_coe hf, extension_coe hf, extension_coe hf, is_add_group_hom.add f]),
+      by rw [← coe_add, extension_coe hf, extension_coe hf, extension_coe hf, is_add_group_hom.map_add f]),
   map_mul := assume a b, completion.induction_on₂ a b
     (is_closed_eq
       ((continuous_mul' α).comp continuous_extension)


### PR DESCRIPTION
This PR renames `is_group_hom.mul` to `map_mul` and all the analogous changes:
`one` → `map_one`; `inv` → `map_inv`; `prod` → `map_prod`; `pow` → `map_pow`; `gpow` → `map_gpow`.
Similarly for `is_add_group_hom` the "fields" `add`, `zero`, `neg`, `sub`, `sum`, `smul`, and `gsmul` have been renamed. Idem dito for `is_anti_group_hom`. (N.b.: `is_anti_add_group_hom` does not exist.)

Vice versa, the existing `map_mul` has been renamed to `mul`. (This is the`is_group_hom` instance for the pointwise multiplication of homomorphisms. Idem dito for pointwise inverse, pointwise addition, pointwise negation, and pointwise difference.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
