### PR TITLE
Refactor operator norm

### DIFF
--- a/src/analysis/normed_space/bounded_linear_maps.lean
+++ b/src/analysis/normed_space/bounded_linear_maps.lean
@@ -6,7 +6,6 @@ Authors: Patrick Massot, Johannes Hölzl
 Continuous linear functions -- functions between normed vector spaces which are bounded and linear.
 -/
 import algebra.field
-import tactic.norm_num
 import analysis.normed_space.basic
 import analysis.asymptotics
 
@@ -28,16 +27,14 @@ variables {E : Type*} [normed_space k E]
 variables {F : Type*} [normed_space k F]
 variables {G : Type*} [normed_space k G]
 
-structure is_bounded_linear_map (k : Type*)
-  [normed_field k] {E : Type*} [normed_space k E] {F : Type*} [normed_space k F] (L : E → F)
+structure is_bounded_linear_map (k : Type*) [normed_field k] {E : Type*}
+  [normed_space k E] {F : Type*} [normed_space k F] (L : E → F)
   extends is_linear_map k L : Prop :=
-(bound : ∃ M, M > 0 ∧ ∀ x : E, ∥ L x ∥ ≤ M * ∥ x ∥)
-
-include k
+(bound : ∃ M > 0, ∀ x : E, ∥ L x ∥ ≤ M * ∥ x ∥)
 
 lemma is_linear_map.with_bound
-  {L : E → F} (hf : is_linear_map k L) (M : ℝ) (h : ∀ x : E, ∥ L x ∥ ≤ M * ∥ x ∥) :
-  is_bounded_linear_map k L :=
+  {f : E → F} (hf : is_linear_map k f) (M : ℝ) (h : ∀ x : E, ∥ f x ∥ ≤ M * ∥ x ∥) :
+  is_bounded_linear_map k f :=
 ⟨ hf, classical.by_cases
   (assume : M ≤ 0, ⟨1, zero_lt_one, assume x,
     le_trans (h x) $ mul_le_mul_of_nonneg_right (le_trans this zero_le_one) (norm_nonneg x)⟩)
@@ -55,63 +52,76 @@ lemma id : is_bounded_linear_map k (λ (x:E), x) :=
 linear_map.id.is_linear.with_bound 1 $ by simp [le_refl]
 
 set_option class.instance_max_depth 43
-lemma smul {f : E → F} (c : k) : is_bounded_linear_map k f → is_bounded_linear_map k (λ e, c • f e)
-| ⟨hf, ⟨M, hM, h⟩⟩ := (c • hf.mk' f).is_linear.with_bound (∥c∥ * M) $ assume x,
-  calc ∥c • f x∥ = ∥c∥ * ∥f x∥ : norm_smul c (f x)
-    ... ≤ ∥c∥ * (M * ∥x∥) : mul_le_mul_of_nonneg_left (h x) (norm_nonneg c)
-    ... = (∥c∥ * M) * ∥x∥ : (mul_assoc _ _ _).symm
+variables { f g : E → F }
 
-lemma neg {f : E → F} (hf : is_bounded_linear_map k f) : is_bounded_linear_map k (λ e, -f e) :=
+lemma smul (c : k) (hf : is_bounded_linear_map k f) :
+  is_bounded_linear_map k (λ e, c • f e) :=
+let ⟨hlf, M, hMp, hM⟩ := hf in
+(c • hlf.mk' f).is_linear.with_bound (∥c∥ * M) $ assume x,
+  calc ∥c • f x∥ = ∥c∥ * ∥f x∥ : norm_smul c (f x)
+  ... ≤ ∥c∥ * (M * ∥x∥)        : mul_le_mul_of_nonneg_left (hM _) (norm_nonneg _)
+  ... = (∥c∥ * M) * ∥x∥        : (mul_assoc _ _ _).symm
+
+lemma neg (hf : is_bounded_linear_map k f) :
+  is_bounded_linear_map k (λ e, -f e) :=
 begin
   rw show (λ e, -f e) = (λ e, (-1 : k) • f e), { funext, simp },
   exact smul (-1) hf
 end
 
-lemma add {f : E → F} {g : E → F} :
-  is_bounded_linear_map k f → is_bounded_linear_map k g → is_bounded_linear_map k (λ e, f e + g e)
-| ⟨hlf, Mf, hMf, hf⟩  ⟨hlg, Mg, hMg, hg⟩ := (hlf.mk' _ + hlg.mk' _).is_linear.with_bound (Mf + Mg) $ assume x,
+lemma add (hf : is_bounded_linear_map k f) (hg : is_bounded_linear_map k g) :
+  is_bounded_linear_map k (λ e, f e + g e) :=
+let ⟨hlf, Mf, hMfp, hMf⟩ := hf in
+let ⟨hlg, Mg, hMgp, hMg⟩ := hg in
+(hlf.mk' _ + hlg.mk' _).is_linear.with_bound (Mf + Mg) $ assume x,
   calc ∥f x + g x∥ ≤ ∥f x∥ + ∥g x∥ : norm_triangle _ _
-    ... ≤ Mf * ∥x∥ + Mg * ∥x∥ : add_le_add (hf x) (hg x)
-    ... ≤ (Mf + Mg) * ∥x∥ : by rw add_mul
+  ... ≤ Mf * ∥x∥ + Mg * ∥x∥        : add_le_add (hMf x) (hMg x)
+  ... ≤ (Mf + Mg) * ∥x∥            : by rw add_mul
 
-lemma sub {f : E → F} {g : E → F} (hf : is_bounded_linear_map k f) (hg : is_bounded_linear_map k g) :
+lemma sub (hf : is_bounded_linear_map k f) (hg : is_bounded_linear_map k g) :
   is_bounded_linear_map k (λ e, f e - g e) := add hf (neg hg)
 
-lemma comp {f : E → F} {g : F → G} :
-  is_bounded_linear_map k g → is_bounded_linear_map k f → is_bounded_linear_map k (g ∘ f)
-| ⟨hlg, Mg, hMg, hg⟩ ⟨hlf, Mf, hMf, hf⟩ := ((hlg.mk' _).comp (hlf.mk' _)).is_linear.with_bound (Mg * Mf) $ assume x,
-  calc ∥g (f x)∥ ≤ Mg * ∥f x∥ : hg _
-    ... ≤ Mg * (Mf * ∥x∥) : mul_le_mul_of_nonneg_left (hf _) (le_of_lt hMg)
+lemma comp {g : F → G}
+  (hg : is_bounded_linear_map k g) (hf : is_bounded_linear_map k f) :
+  is_bounded_linear_map k (g ∘ f) :=
+let ⟨hlg, Mg, hMgp, hMg⟩ := hg in
+let ⟨hlf, Mf, hMfp, hMf⟩ := hf in
+((hlg.mk' _).comp (hlf.mk' _)).is_linear.with_bound (Mg * Mf) $ assume x,
+  calc ∥g (f x)∥ ≤ Mg * ∥f x∥ : hMg _
+    ... ≤ Mg * (Mf * ∥x∥) : mul_le_mul_of_nonneg_left (hMf _) (le_of_lt hMgp)
     ... = Mg * Mf * ∥x∥ : (mul_assoc _ _ _).symm
 
-lemma tendsto {L : E → F} (x : E) : is_bounded_linear_map k L → L →_{x} (L x)
-| ⟨hL, M, hM, h_ineq⟩ := tendsto_iff_norm_tendsto_zero.2 $
+lemma tendsto (x : E) (hf : is_bounded_linear_map k f) : f →_{x} (f x) :=
+let ⟨hf, M, hMp, hM⟩ := hf in
+tendsto_iff_norm_tendsto_zero.2 $
   squeeze_zero (assume e, norm_nonneg _)
-    (assume e, calc ∥L e - L x∥ = ∥hL.mk' L (e - x)∥ : by rw (hL.mk' _).map_sub e x; refl
-      ... ≤ M*∥e-x∥ : h_ineq (e-x))
+    (assume e,
+      calc ∥f e - f x∥ = ∥hf.mk' f (e - x)∥ : by rw (hf.mk' _).map_sub e x; refl
+                   ... ≤ M * ∥e - x∥        : hM (e - x))
     (suffices (λ (e : E), M * ∥e - x∥) →_{x} (M * 0), by simpa,
       tendsto_mul tendsto_const_nhds (lim_norm _))
 
-lemma continuous {L : E → F} (hL : is_bounded_linear_map k L) : continuous L :=
-continuous_iff_continuous_at.2 $ assume x, hL.tendsto x
+lemma continuous (hf : is_bounded_linear_map k f) : continuous f :=
+continuous_iff_continuous_at.2 $ λ _, hf.tendsto _
 
-lemma lim_zero_bounded_linear_map {L : E → F} (H : is_bounded_linear_map k L) : (L →_{0} 0) :=
-(H.1.mk' _).map_zero ▸ continuous_iff_continuous_at.1 H.continuous 0
+lemma lim_zero_bounded_linear_map (hf : is_bounded_linear_map k f) :
+  (f →_{0} 0) :=
+(hf.1.mk' _).map_zero ▸ continuous_iff_continuous_at.1 hf.continuous 0
 
 section
 open asymptotics filter
 
-theorem is_O_id {L : E → F} (h : is_bounded_linear_map k L) (l : filter E) :
-  is_O L (λ x, x) l :=
-let ⟨M, Mpos, hM⟩ := h.bound in
-⟨M, Mpos, mem_sets_of_superset univ_mem_sets (λ x _, hM x)⟩
+theorem is_O_id {f : E → F} (h : is_bounded_linear_map k f) (l : filter E) :
+  is_O f (λ x, x) l :=
+let ⟨M, hMp, hM⟩ := h.bound in
+⟨M, hMp, mem_sets_of_superset univ_mem_sets (λ x _, hM x)⟩
 
-theorem is_O_comp {L : F → G} (h : is_bounded_linear_map k L)
-  {f : E → F} (l : filter E) : is_O (λ x', L (f x')) f l :=
-((h.is_O_id ⊤).comp _).mono (map_le_iff_le_comap.mp lattice.le_top)
+theorem is_O_comp {g : F → G} (hg : is_bounded_linear_map k g)
+  {f : E → F} (l : filter E) : is_O (λ x', g (f x')) f l :=
+((hg.is_O_id ⊤).comp _).mono (map_le_iff_le_comap.mp lattice.le_top)
 
-theorem is_O_sub {L : E → F} (h : is_bounded_linear_map k L) (l : filter E) (x : E) :
-  is_O (λ x', L (x' - x)) (λ x', x' - x) l :=
+theorem is_O_sub {f : E → F} (h : is_bounded_linear_map k f)
+  (l : filter E) (x : E) : is_O (λ x', f (x' - x)) (λ x', x' - x) l :=
 is_O_comp h l
 
 end

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2019 Jan-David Salchow. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jan-David Salchow, Sébastien Gouëzel
+Authors: Jan-David Salchow, Sébastien Gouëzel, Jean Lo
 
 The space of bounded linear maps
 

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -16,8 +16,7 @@ import algebra.module
 import analysis.normed_space.bounded_linear_maps
 import topology.metric_space.lipschitz
 
-variables {k : Type*}
-variables {E : Type*} {F : Type*} {G : Type*}
+variables (k : Type*) (E : Type*) (F : Type*) (G : Type*)
 
 variables [normed_field k]
 variables [normed_space k E] [normed_space k F] [normed_space k G]
@@ -31,9 +30,11 @@ def bounded_linear_map : subspace k (E → F) :=
   add := λ _ _, is_bounded_linear_map.add,
   smul := λ _ _, is_bounded_linear_map.smul _ }
 
+variables {k E F G}
+
 namespace bounded_linear_map
 
-notation β ` →L[`:25 α `] ` γ := @bounded_linear_map α β γ _ _ _
+notation E ` →L[`:25 k `] ` F := bounded_linear_map k E F
 
 /-- Coerce bounded linear maps to functions. -/
 instance to_fun : has_coe_to_fun $ E →L[k] F :=
@@ -57,14 +58,14 @@ def to_linear_map : linear_map _ E F :=
 @[simp] lemma map_smul : f (c • u) = c • f u := (to_linear_map _).map_smul _ _
 @[simp] lemma map_neg  : f (-u) = - (f u) := (to_linear_map _).map_neg _
 
-@[simp] lemma coe_zero : (0 : E →L[k] F) = 0 := rfl
+lemma coe_zero : ((0 : E →L[k] F) : E → F) = 0 := rfl
 
 @[simp] lemma zero_apply : (0 : E →L[k] F) u = 0 := rfl
 @[simp] lemma smul_apply : (c • f) u = c • (f u) := rfl
 @[simp] lemma neg_apply  : (-f) u = - (f u) := rfl
 
-@[simp] lemma zero_smul : (0 : k) • f = 0  := by ext; simp
-@[simp] lemma one_smul  : (1 : k) • f = f  := by ext; simp
+@[simp] lemma zero_smul : (0 : k) • f = 0  := by { ext, simp }
+@[simp] lemma one_smul  : (1 : k) • f = f  := by { ext, simp }
 
 /-- Composition of bounded linear maps. -/
 def comp (g : F →L[k] G) (f : E →L[k] F) : E →L[k] G :=
@@ -85,45 +86,47 @@ instance has_op_norm: has_norm (E →L[k] F) := ⟨op_norm⟩
 -- bounds is nonempty and bounded below.
 lemma bounds_nonempty {f : E →L[k] F} :
   ∃ c, c ∈ { c | c ≥ 0 ∧ ∀ x, ∥f x∥ ≤ c * ∥x∥ } :=
-  let ⟨M, hMp, hMb⟩ := f.property.bound in ⟨M, le_of_lt hMp, hMb⟩
+let ⟨M, hMp, hMb⟩ := f.property.bound in ⟨M, le_of_lt hMp, hMb⟩
 
 lemma bounds_bdd_below {f : E →L[k] F} :
   bdd_below { c | c ≥ 0 ∧ ∀ x, ∥f x∥ ≤ c * ∥x∥ } :=
-  ⟨0, λ _ ⟨hn, _⟩, hn⟩
+⟨0, λ _ ⟨hn, _⟩, hn⟩
 
 lemma op_norm_nonneg : 0 ≤ ∥f∥ :=
-  real.lb_le_Inf _ bounds_nonempty (λ _ ⟨hx, _⟩, hx)
+real.lb_le_Inf _ bounds_nonempty (λ _ ⟨hx, _⟩, hx)
 
 /-- This is the fundamental property of the operator norm: ∥f x∥ ≤ ∥f∥ * ∥x∥. -/
 theorem le_op_norm : ∥f x∥ ≤ ∥f∥ * ∥x∥ :=
-  classical.by_cases
-    (λ heq : x = 0, by rw heq; simp)
-    (λ hne, have hlt : 0 < ∥x∥, from (norm_pos_iff _).2 hne,
-      le_mul_of_div_le hlt ((real.le_Inf _ bounds_nonempty bounds_bdd_below).2
-      (λ c ⟨_, hc⟩, div_le_of_le_mul hlt (by rw mul_comm; exact hc _))))
+classical.by_cases
+  (λ heq : x = 0, by { rw heq, simp })
+  (λ hne, have hlt : 0 < ∥x∥, from (norm_pos_iff _).2 hne,
+    le_mul_of_div_le hlt ((real.le_Inf _ bounds_nonempty bounds_bdd_below).2
+    (λ c ⟨_, hc⟩, div_le_of_le_mul hlt (by { rw mul_comm, apply hc }))))
 
 lemma ratio_le_op_norm : ∥f x∥ / ∥x∥ ≤ ∥f∥ :=
-  (or.elim (lt_or_eq_of_le (norm_nonneg _))
-  (λ hlt, div_le_of_le_mul hlt (by rw mul_comm; exact le_op_norm _ _))
-  (λ heq, by rw [←heq, div_zero]; exact op_norm_nonneg _))
+(or.elim (lt_or_eq_of_le (norm_nonneg _))
+  (λ hlt, div_le_of_le_mul hlt (by { rw mul_comm, apply le_op_norm }))
+  (λ heq, by { rw [←heq, div_zero], apply op_norm_nonneg }))
 
 /-- The image of the unit ball under a bounded linear map is bounded. -/
 lemma unit_le_op_norm : ∥x∥ ≤ 1 → ∥f x∥ ≤ ∥f∥ :=
-  λ hx, by rw [←(mul_one ∥f∥)];
+λ hx, begin
+  rw [←(mul_one ∥f∥)],
   calc _ ≤ ∥f∥ * ∥x∥ : le_op_norm _ _
   ...    ≤ _ : mul_le_mul_of_nonneg_left hx (op_norm_nonneg _)
+end
 
 /-- If one controls the norm of every A x, then one controls the norm of A. -/
 lemma bound_le_op_norm {M : ℝ} (hMp: 0 ≤ M) (hM : ∀ x, ∥f x∥ ≤ M * ∥x∥) :
-  ∥f∥ ≤ M := real.Inf_le _ bounds_bdd_below ⟨hMp, hM⟩
+  ∥f∥ ≤ M :=
+real.Inf_le _ bounds_bdd_below ⟨hMp, hM⟩
 
 /-- The operator norm satisfies the triangle inequality. -/
 theorem op_norm_triangle : ∥f + g∥ ≤ ∥f∥ + ∥g∥ :=
-  real.Inf_le _ bounds_bdd_below
-  ⟨add_nonneg (op_norm_nonneg _) (op_norm_nonneg _),
-    λ x, by rw add_mul;
+real.Inf_le _ bounds_bdd_below
+  ⟨add_nonneg (op_norm_nonneg _) (op_norm_nonneg _), λ x, by { rw add_mul,
     calc _ ≤ ∥f x∥ + ∥g x∥ : norm_triangle _ _
-    ...    ≤ _ : add_le_add (le_op_norm _ _) (le_op_norm _ _)⟩
+    ...    ≤ _             : add_le_add (le_op_norm _ _) (le_op_norm _ _) }⟩
 
 /-- An operator is zero iff its norm vanishes. -/
 theorem op_norm_zero_iff : ∥f∥ = 0 ↔ f = 0 :=
@@ -132,43 +135,51 @@ iff.intro
     (calc _ ≤ ∥f∥ * ∥x∥ : le_op_norm _ _
      ...     = _ : by rw [hn, zero_mul])))
   (λ hf, le_antisymm (real.Inf_le _ bounds_bdd_below
-    ⟨ge_of_eq rfl, λ _, le_of_eq (by rw [zero_mul, hf]; exact norm_zero)⟩)
+    ⟨ge_of_eq rfl, λ _, le_of_eq (by { rw [zero_mul, hf], exact norm_zero })⟩)
     (op_norm_nonneg _))
 
 /-- The operator norm is homogeneous. -/
 lemma op_norm_smul : ∥c • f∥ = ∥c∥ * ∥f∥ :=
-  le_antisymm
-    (real.Inf_le _ bounds_bdd_below
-      ⟨mul_nonneg (norm_nonneg _) (op_norm_nonneg _),
-      λ _, by erw [norm_smul, mul_assoc]; exact
-      mul_le_mul_of_nonneg_left (le_op_norm _ _) (norm_nonneg _)⟩)
-    (real.lb_le_Inf _ bounds_nonempty (λ _ ⟨hn, hc⟩,
-      (or.elim (lt_or_eq_of_le (norm_nonneg c))
-        (λ hlt, by rw mul_comm; exact
-          mul_le_of_le_div hlt (real.Inf_le _ bounds_bdd_below
+le_antisymm
+  (real.Inf_le _ bounds_bdd_below
+    ⟨mul_nonneg (norm_nonneg _) (op_norm_nonneg _), λ _,
+    begin
+      erw [norm_smul, mul_assoc],
+      exact mul_le_mul_of_nonneg_left (le_op_norm _ _) (norm_nonneg _)
+    end⟩)
+  (real.lb_le_Inf _ bounds_nonempty (λ _ ⟨hn, hc⟩,
+    (or.elim (lt_or_eq_of_le (norm_nonneg c))
+      (λ hlt,
+        begin
+          rw mul_comm,
+          exact mul_le_of_le_div hlt (real.Inf_le _ bounds_bdd_below
           ⟨div_nonneg hn hlt, λ _,
-            (by rw div_mul_eq_mul_div; exact le_div_of_mul_le hlt
-            (by rw [ mul_comm, ←norm_smul ]; exact hc _))⟩))
-        (λ heq, by rw [←heq, zero_mul]; exact hn))))
+          (by { rw div_mul_eq_mul_div, exact le_div_of_mul_le hlt
+          (by { rw [ mul_comm, ←norm_smul ], exact hc _ }) })⟩)
+        end)
+      (λ heq, by { rw [←heq, zero_mul], exact hn }))))
 
 /-- Bounded linear maps themselves form a normed space with respect to
     the operator norm. -/
 noncomputable instance bounded_linear_map.to_normed_space :
   normed_space k (E →L[k] F) :=
-  normed_space.of_core _ _
+normed_space.of_core _ _
   ⟨op_norm_zero_iff, op_norm_smul, op_norm_triangle⟩
 
 /-- The operator norm is submultiplicative. -/
 lemma op_norm_comp_le : ∥comp h f∥ ≤ ∥h∥ * ∥f∥ :=
-  (real.Inf_le _ bounds_bdd_below
-  ⟨mul_nonneg (op_norm_nonneg _) (op_norm_nonneg _),
-  λ x, by rw mul_assoc; calc _ ≤ ∥h∥ * ∥f x∥: le_op_norm _ _
-  ... ≤ _ : mul_le_mul_of_nonneg_left
-            (le_op_norm _ _) (op_norm_nonneg _)⟩)
+(real.Inf_le _ bounds_bdd_below
+  ⟨mul_nonneg (op_norm_nonneg _) (op_norm_nonneg _), λ x,
+  begin
+    rw mul_assoc,
+    calc _ ≤ ∥h∥ * ∥f x∥: le_op_norm _ _
+    ... ≤ _ : mul_le_mul_of_nonneg_left
+              (le_op_norm _ _) (op_norm_nonneg _)
+  end⟩)
 
 /-- bounded linear maps are lipschitz continuous. -/
 theorem lipschitz : lipschitz_with ∥f∥ f :=
-  ⟨op_norm_nonneg _, λ x y, by rw [dist_eq_norm, dist_eq_norm, ←map_sub];
-  exact le_op_norm _ _⟩
+⟨op_norm_nonneg _, λ x y,
+  by { rw [dist_eq_norm, dist_eq_norm, ←map_sub], apply le_op_norm }⟩
 
 end op_norm

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -46,7 +46,7 @@ set_coe.ext $ funext h
 theorem ext_iff {f g : E →L[k] F} : f = g ↔ ∀ x, f x = g x :=
 ⟨λ h x, by rintro; rw h, ext⟩
 
-variables (c : k) (f g: E →L[k] F) (u v: E)
+variables (c : k) (f g: E →L[k] F) (h : F →L[k] G) (x u v: E)
 
 def to_linear_map : linear_map _ E F :=
 {to_fun := f.val, ..f.property}
@@ -71,12 +71,8 @@ lemma coe_zero : ((0 : E →L[k] F) : E → F) = 0 := rfl
 def comp (g : F →L[k] G) (f : E →L[k] F) : E →L[k] G :=
 ⟨_, is_bounded_linear_map.comp g.property f.property⟩
 
-end bounded_linear_map
-
 section op_norm
 open lattice set bounded_linear_map
-
-variables (c : k) (f g : E →L[k] F) (h : F →L[k] G) (x : E)
 
 /-- The operator norm of a bounded linear map is the inf of all its bounds. -/
 def op_norm := real.Inf { c | c ≥ 0 ∧ ∀ x, ∥f x∥ ≤ c * ∥x∥ }
@@ -161,8 +157,7 @@ le_antisymm
 
 /-- Bounded linear maps themselves form a normed space with respect to
     the operator norm. -/
-noncomputable instance bounded_linear_map.to_normed_space :
-  normed_space k (E →L[k] F) :=
+instance to_normed_space : normed_space k (E →L[k] F) :=
 normed_space.of_core _ _
   ⟨op_norm_zero_iff, op_norm_smul, op_norm_triangle⟩
 
@@ -183,3 +178,6 @@ theorem lipschitz : lipschitz_with ∥f∥ f :=
   by { rw [dist_eq_norm, dist_eq_norm, ←map_sub], apply le_op_norm }⟩
 
 end op_norm
+
+end bounded_linear_map
+

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -72,14 +72,14 @@ def comp (g : F →L[k] G) (f : E →L[k] F) : E →L[k] G :=
 
 end bounded_linear_map
 
-section operator_norm
+section op_norm
 open lattice set bounded_linear_map
 
 variables (c : k) (f g : E →L[k] F) (h : F →L[k] G) (x : E)
 
 /-- The operator norm of a bounded linear map is the inf of all its bounds. -/
-def operator_norm := real.Inf { c | c ≥ 0 ∧ ∀ x, ∥f x∥ ≤ c * ∥x∥ }
-instance has_operator_norm: has_norm (E →L[k] F) := ⟨operator_norm⟩
+def op_norm := real.Inf { c | c ≥ 0 ∧ ∀ x, ∥f x∥ ≤ c * ∥x∥ }
+instance has_op_norm: has_norm (E →L[k] F) := ⟨op_norm⟩
 
 -- So that invocations of real.Inf_le make sense: we show that the set of
 -- bounds is nonempty and bounded below.
@@ -91,57 +91,57 @@ lemma bounds_bdd_below {f : E →L[k] F} :
   bdd_below { c | c ≥ 0 ∧ ∀ x, ∥f x∥ ≤ c * ∥x∥ } :=
   ⟨0, λ _ ⟨hn, _⟩, hn⟩
 
-lemma operator_norm_nonneg : 0 ≤ ∥f∥ :=
+lemma op_norm_nonneg : 0 ≤ ∥f∥ :=
   real.lb_le_Inf _ bounds_nonempty (λ _ ⟨hx, _⟩, hx)
 
 /-- This is the fundamental property of the operator norm: ∥f x∥ ≤ ∥f∥ * ∥x∥. -/
-theorem le_operator_norm : ∥f x∥ ≤ ∥f∥ * ∥x∥ :=
+theorem le_op_norm : ∥f x∥ ≤ ∥f∥ * ∥x∥ :=
   classical.by_cases
     (λ heq : x = 0, by rw heq; simp)
     (λ hne, have hlt : 0 < ∥x∥, from (norm_pos_iff _).2 hne,
       le_mul_of_div_le hlt ((real.le_Inf _ bounds_nonempty bounds_bdd_below).2
       (λ c ⟨_, hc⟩, div_le_of_le_mul hlt (by rw mul_comm; exact hc _))))
 
-lemma ratio_le_operator_norm : ∥f x∥ / ∥x∥ ≤ ∥f∥ :=
+lemma ratio_le_op_norm : ∥f x∥ / ∥x∥ ≤ ∥f∥ :=
   (or.elim (lt_or_eq_of_le (norm_nonneg _))
-  (λ hlt, div_le_of_le_mul hlt (by rw mul_comm; exact le_operator_norm _ _))
-  (λ heq, by rw [←heq, div_zero]; exact operator_norm_nonneg _))
+  (λ hlt, div_le_of_le_mul hlt (by rw mul_comm; exact le_op_norm _ _))
+  (λ heq, by rw [←heq, div_zero]; exact op_norm_nonneg _))
 
 /-- The image of the unit ball under a bounded linear map is bounded. -/
-lemma unit_le_operator_norm : ∥x∥ ≤ 1 → ∥f x∥ ≤ ∥f∥ :=
+lemma unit_le_op_norm : ∥x∥ ≤ 1 → ∥f x∥ ≤ ∥f∥ :=
   λ hx, by rw [←(mul_one ∥f∥)];
-  calc _ ≤ ∥f∥ * ∥x∥ : le_operator_norm _ _
-  ...    ≤ _ : mul_le_mul_of_nonneg_left hx (operator_norm_nonneg _)
+  calc _ ≤ ∥f∥ * ∥x∥ : le_op_norm _ _
+  ...    ≤ _ : mul_le_mul_of_nonneg_left hx (op_norm_nonneg _)
 
 /-- If one controls the norm of every A x, then one controls the norm of A. -/
-lemma bound_le_operator_norm {M : ℝ} (hMp: 0 ≤ M) (hM : ∀ x, ∥f x∥ ≤ M * ∥x∥) :
+lemma bound_le_op_norm {M : ℝ} (hMp: 0 ≤ M) (hM : ∀ x, ∥f x∥ ≤ M * ∥x∥) :
   ∥f∥ ≤ M := real.Inf_le _ bounds_bdd_below ⟨hMp, hM⟩
 
 /-- The operator norm satisfies the triangle inequality. -/
-theorem operator_norm_triangle : ∥f + g∥ ≤ ∥f∥ + ∥g∥ :=
+theorem op_norm_triangle : ∥f + g∥ ≤ ∥f∥ + ∥g∥ :=
   real.Inf_le _ bounds_bdd_below
-  ⟨add_nonneg (operator_norm_nonneg _) (operator_norm_nonneg _),
+  ⟨add_nonneg (op_norm_nonneg _) (op_norm_nonneg _),
     λ x, by rw add_mul;
     calc _ ≤ ∥f x∥ + ∥g x∥ : norm_triangle _ _
-    ...    ≤ _ : add_le_add (le_operator_norm _ _) (le_operator_norm _ _)⟩
+    ...    ≤ _ : add_le_add (le_op_norm _ _) (le_op_norm _ _)⟩
 
 /-- An operator is zero iff its norm vanishes. -/
-theorem operator_norm_zero_iff : ∥f∥ = 0 ↔ f = 0 :=
+theorem op_norm_zero_iff : ∥f∥ = 0 ↔ f = 0 :=
 iff.intro
   (λ hn, bounded_linear_map.ext (λ x, (norm_le_zero_iff _).1
-    (calc _ ≤ ∥f∥ * ∥x∥ : le_operator_norm _ _
+    (calc _ ≤ ∥f∥ * ∥x∥ : le_op_norm _ _
      ...     = _ : by rw [hn, zero_mul])))
   (λ hf, le_antisymm (real.Inf_le _ bounds_bdd_below
     ⟨ge_of_eq rfl, λ _, le_of_eq (by rw [zero_mul, hf]; exact norm_zero)⟩)
-    (operator_norm_nonneg _))
+    (op_norm_nonneg _))
 
 /-- The operator norm is homogeneous. -/
-lemma operator_norm_smul : ∥c • f∥ = ∥c∥ * ∥f∥ :=
+lemma op_norm_smul : ∥c • f∥ = ∥c∥ * ∥f∥ :=
   le_antisymm
     (real.Inf_le _ bounds_bdd_below
-      ⟨mul_nonneg (norm_nonneg _) (operator_norm_nonneg _),
+      ⟨mul_nonneg (norm_nonneg _) (op_norm_nonneg _),
       λ _, by erw [norm_smul, mul_assoc]; exact
-      mul_le_mul_of_nonneg_left (le_operator_norm _ _) (norm_nonneg _)⟩)
+      mul_le_mul_of_nonneg_left (le_op_norm _ _) (norm_nonneg _)⟩)
     (real.lb_le_Inf _ bounds_nonempty (λ _ ⟨hn, hc⟩,
       (or.elim (lt_or_eq_of_le (norm_nonneg c))
         (λ hlt, by rw mul_comm; exact
@@ -156,19 +156,19 @@ lemma operator_norm_smul : ∥c • f∥ = ∥c∥ * ∥f∥ :=
 noncomputable instance bounded_linear_map.to_normed_space :
   normed_space k (E →L[k] F) :=
   normed_space.of_core _ _
-  ⟨operator_norm_zero_iff, operator_norm_smul, operator_norm_triangle⟩
+  ⟨op_norm_zero_iff, op_norm_smul, op_norm_triangle⟩
 
 /-- The operator norm is submultiplicative. -/
 lemma op_norm_comp_le : ∥comp h f∥ ≤ ∥h∥ * ∥f∥ :=
   (real.Inf_le _ bounds_bdd_below
-  ⟨mul_nonneg (operator_norm_nonneg _) (operator_norm_nonneg _),
-  λ x, by rw mul_assoc; calc _ ≤ ∥h∥ * ∥f x∥: le_operator_norm _ _
+  ⟨mul_nonneg (op_norm_nonneg _) (op_norm_nonneg _),
+  λ x, by rw mul_assoc; calc _ ≤ ∥h∥ * ∥f x∥: le_op_norm _ _
   ... ≤ _ : mul_le_mul_of_nonneg_left
-            (le_operator_norm _ _) (operator_norm_nonneg _)⟩)
+            (le_op_norm _ _) (op_norm_nonneg _)⟩)
 
 /-- bounded linear maps are lipschitz continuous. -/
 theorem lipschitz : lipschitz_with ∥f∥ f :=
-  ⟨operator_norm_nonneg _, λ x y, by rw [dist_eq_norm, dist_eq_norm, ←map_sub];
-  exact le_operator_norm _ _⟩
+  ⟨op_norm_nonneg _, λ x y, by rw [dist_eq_norm, dist_eq_norm, ←map_sub];
+  exact le_op_norm _ _⟩
 
-end operator_norm
+end op_norm

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -8,186 +8,167 @@ The space of bounded linear maps
 Define the set of bounded linear maps between normed spaces and show basic facts about it. In
 particular
 
-(*) define a set L(E,F) of bounded linear maps between k normed spaces,
-(*) show that L(E,F) is a vector subspace of E → F,
-(*) define the 'operator norm' on L(E,F) and show that it induces the structure of a normed space
-    on L(E,F).
+(*) show that bounded linear maps are a vector subspace of E → F,
+(*) define the operator norm and show that it induces the structure of a normed space
+    on bounded linear maps.
 -/
 import algebra.module
 import analysis.normed_space.bounded_linear_maps
+import topology.metric_space.lipschitz
 
 variables {k : Type*}
-variables {E : Type*} {F : Type*}
+variables {E : Type*} {F : Type*} {G : Type*}
 
+variables [normed_field k]
+variables [normed_space k E] [normed_space k F] [normed_space k G]
 
--- Define the subspace of bounded linear maps.
-section bounded_linear_maps
+noncomputable theory
 set_option class.instance_max_depth 50
 
-
-variables [hnfk : normed_field k] [normed_space k E] [normed_space k F]
-include hnfk
-
-def bounded_linear_maps : subspace k (E → F) :=
-{ carrier := {A : E → F | is_bounded_linear_map k A},
+def bounded_linear_map : subspace k (E → F) :=
+{ carrier := {f : E → F | is_bounded_linear_map k f},
   zero := is_bounded_linear_map.zero,
-  add := assume A B, is_bounded_linear_map.add,
-  smul := assume c A, is_bounded_linear_map.smul c }
+  add := λ _ _, is_bounded_linear_map.add,
+  smul := λ _ _, is_bounded_linear_map.smul _ }
 
--- introduce the local notation L(E,F) for the set of bounded linear maps.
-local notation `L(` E `,` F `)` := @bounded_linear_maps k E F _ _ _
+namespace bounded_linear_map
+
+notation β ` →L[`:25 α `] ` γ := @bounded_linear_map α β γ _ _ _
 
 /-- Coerce bounded linear maps to functions. -/
-instance bounded_linear_maps.to_fun : has_coe_to_fun $ L(E,F) :=
+instance to_fun : has_coe_to_fun $ E →L[k] F :=
 {F :=  λ _, (E → F), coe := (λ f, f.val)}
 
-@[extensionality] theorem ext {A B : L(E,F)} (H : ∀ x, A x = B x) : A = B :=
-set_coe.ext $ funext H
+@[extensionality] theorem ext {f g : E →L[k] F} (h : ∀ x, f x = g x) : f = g :=
+set_coe.ext $ funext h
 
-def to_linear_map (A : L(E, F)) : linear_map _ E F :=
-{to_fun := A.val, ..A.property}
+theorem ext_iff {f g : E →L[k] F} : f = g ↔ ∀ x, f x = g x :=
+⟨λ h x, by rintro; rw h, ext⟩
 
-@[simp] lemma bounded_linear_maps.map_zero {A : L(E, F)} : A (0 : E) = 0 :=
-(to_linear_map A).map_zero
+variables (c : k) (f g: E →L[k] F) (u v: E)
 
-@[simp] lemma bounded_linear_maps.coe_zero {x : E} : (0 : L(E, F)) x = 0 := rfl
+def to_linear_map : linear_map _ E F :=
+{to_fun := f.val, ..f.property}
 
-@[simp] lemma bounded_linear_maps.smul_coe {A : L(E, F)} {x : E} {c : k} :
-  (c • A) x = c • (A x) := rfl
+-- make some straightforward lemmas available to `simp`.
+@[simp] lemma map_zero : f (0 : E) = 0 := (to_linear_map _).map_zero
+@[simp] lemma map_add  : f (u + v) = f u + f v := (to_linear_map _).map_add _ _
+@[simp] lemma map_sub  : f (u - v) = f u - f v := (to_linear_map _).map_sub _ _
+@[simp] lemma map_smul : f (c • u) = c • f u := (to_linear_map _).map_smul _ _
+@[simp] lemma map_neg  : f (-u) = - (f u) := (to_linear_map _).map_neg _
 
-@[simp] lemma bounded_linear_maps.zero_smul {A : L(E, F)} : (0 : k) • A = 0 :=
-by ext; simp
+@[simp] lemma coe_zero : (0 : E →L[k] F) = 0 := rfl
 
-@[simp] lemma bounded_linear_maps.one_smul {A : L(E, F)} : (1 : k) • A = A :=
-by ext; simp
+@[simp] lemma zero_apply : (0 : E →L[k] F) u = 0 := rfl
+@[simp] lemma smul_apply : (c • f) u = c • (f u) := rfl
+@[simp] lemma neg_apply  : (-f) u = - (f u) := rfl
 
-/-- Bounded linear maps are ... bounded -/
-lemma exists_bound (A : L(E,F)) : ∃ c, 0 < c ∧ ∀ x : E, ∥A x∥ ≤ c * ∥x∥ := A.property.bound
+@[simp] lemma zero_smul : (0 : k) • f = 0  := by ext; simp
+@[simp] lemma one_smul  : (1 : k) • f = f  := by ext; simp
 
-end bounded_linear_maps
+/-- Composition of bounded linear maps. -/
+def comp (g : F →L[k] G) (f : E →L[k] F) : E →L[k] G :=
+⟨_, is_bounded_linear_map.comp g.property f.property⟩
 
-/-
-Now define the operator norm.
+end bounded_linear_map
 
-The main task is to show that the operator norm is definite, homogeneous, and satisfies the
-triangle inequality. This is done after a few preliminary lemmas necessary to deal with csupr.
--/
 section operator_norm
+open lattice set bounded_linear_map
 
-variables [normed_field k] [normed_space k E] [normed_space k F]
-open lattice set
+variables (c : k) (f g : E →L[k] F) (h : F →L[k] G) (x : E)
 
-local notation `L(` E `,` F `)` := @bounded_linear_maps k E F _ _ _
+/-- The operator norm of a bounded linear map is the inf of all its bounds. -/
+def operator_norm := real.Inf { c | c ≥ 0 ∧ ∀ x, ∥f x∥ ≤ c * ∥x∥ }
+instance has_operator_norm: has_norm (E →L[k] F) := ⟨operator_norm⟩
 
-/-- The operator norm of a bounded linear map A : E → F is the sup of ∥A x∥/∥x∥. -/
-noncomputable def operator_norm (A : L(E, F)) : ℝ :=
-supr (λ x, ∥A x∥/∥x∥)
+-- So that invocations of real.Inf_le make sense: we show that the set of
+-- bounds is nonempty and bounded below.
+lemma bounds_nonempty {f : E →L[k] F} :
+  ∃ c, c ∈ { c | c ≥ 0 ∧ ∀ x, ∥f x∥ ≤ c * ∥x∥ } :=
+  let ⟨M, hMp, hMb⟩ := f.property.bound in ⟨M, le_of_lt hMp, hMb⟩
 
-noncomputable instance bounded_linear_maps.to_has_norm : has_norm L(E,F) :=
-{norm := operator_norm}
+lemma bounds_bdd_below {f : E →L[k] F} :
+  bdd_below { c | c ≥ 0 ∧ ∀ x, ∥f x∥ ≤ c * ∥x∥ } :=
+  ⟨0, λ _ ⟨hn, _⟩, hn⟩
 
-lemma bdd_above_range_norm_image_div_norm (A : L(E,F)) : bdd_above (range (λ x, ∥A x∥/∥x∥)) :=
-let ⟨c, _, H⟩ := (exists_bound A : ∃ c, 0 < c ∧ ∀ x : E, ∥A x∥ ≤ c * ∥x∥) in
-bdd_above.mk c $ forall_range_iff.2 $ λx, begin
-  by_cases h : ∥x∥ = 0,
-  { simp [h, le_of_lt ‹0 < c›] },
-  { refine (div_le_iff _).2 (H x),
-    simpa [ne.symm h] using le_iff_eq_or_lt.1 (norm_nonneg x) }
-end
+lemma operator_norm_nonneg : 0 ≤ ∥f∥ :=
+  real.lb_le_Inf _ bounds_nonempty (λ _ ⟨hx, _⟩, hx)
 
-lemma operator_norm_nonneg (A : L(E,F)) : 0 ≤ ∥A∥ :=
-begin
-  have : (0 : ℝ) = (λ x, ∥A x∥/∥x∥) 0, by simp,
-  rw this,
-  exact le_csupr (bdd_above_range_norm_image_div_norm A),
-end
+/-- This is the fundamental property of the operator norm: ∥f x∥ ≤ ∥f∥ * ∥x∥. -/
+theorem le_operator_norm : ∥f x∥ ≤ ∥f∥ * ∥x∥ :=
+  classical.by_cases
+    (λ heq : x = 0, by rw heq; simp)
+    (λ hne, have hlt : 0 < ∥x∥, from (norm_pos_iff _).2 hne,
+      le_mul_of_div_le hlt ((real.le_Inf _ bounds_nonempty bounds_bdd_below).2
+      (λ c ⟨_, hc⟩, div_le_of_le_mul hlt (by rw mul_comm; exact hc _))))
 
-set_option class.instance_max_depth 34
+lemma ratio_le_operator_norm : ∥f x∥ / ∥x∥ ≤ ∥f∥ :=
+  (or.elim (lt_or_eq_of_le (norm_nonneg _))
+  (λ hlt, div_le_of_le_mul hlt (by rw mul_comm; exact le_operator_norm _ _))
+  (λ heq, by rw [←heq, div_zero]; exact operator_norm_nonneg _))
 
-/-- This is the fundamental property of the operator norm: ∥A x∥ ≤ ∥A∥ * ∥x∥. -/
-theorem bounded_by_operator_norm {A : L(E,F)} {x : E} : ∥A x∥ ≤ ∥A∥ * ∥x∥ :=
-begin
-  classical, by_cases h : x = 0,
-  { simp [h] },
-  { have : ∥A x∥/∥x∥ ≤ ∥A∥, from le_csupr (bdd_above_range_norm_image_div_norm A),
-    rwa (div_le_iff _) at this,
-    have : ∥x∥ ≠ 0, from ne_of_gt ((norm_pos_iff x).mpr h),
-    have I := le_iff_eq_or_lt.1 (norm_nonneg x),
-    simpa [ne.symm this] using I }
-end
+/-- The image of the unit ball under a bounded linear map is bounded. -/
+lemma unit_le_operator_norm : ∥x∥ ≤ 1 → ∥f x∥ ≤ ∥f∥ :=
+  λ hx, by rw [←(mul_one ∥f∥)];
+  calc _ ≤ ∥f∥ * ∥x∥ : le_operator_norm _ _
+  ...    ≤ _ : mul_le_mul_of_nonneg_left hx (operator_norm_nonneg _)
 
 /-- If one controls the norm of every A x, then one controls the norm of A. -/
-lemma operator_norm_bounded_by {A : L(E,F)} {c : ℝ} (hc : 0 ≤ c) (H : ∀ x, ∥A x∥ ≤ c * ∥x∥) :
-  ∥A∥ ≤ c :=
-begin
-  haveI : nonempty E := ⟨0⟩,
-  refine csupr_le (λx, _),
-  by_cases h : ∥x∥ = 0,
-  { simp [h, hc] },
-  { refine (div_le_iff _).2 (H x),
-    simpa [ne.symm h] using le_iff_eq_or_lt.1 (norm_nonneg x) }
-end
+lemma bound_le_operator_norm {M : ℝ} (hMp: 0 ≤ M) (hM : ∀ x, ∥f x∥ ≤ M * ∥x∥) :
+  ∥f∥ ≤ M := real.Inf_le _ bounds_bdd_below ⟨hMp, hM⟩
 
 /-- The operator norm satisfies the triangle inequality. -/
-theorem operator_norm_triangle (A B : L(E,F)) : ∥A + B∥ ≤ ∥A∥ + ∥B∥ :=
-operator_norm_bounded_by (add_nonneg (operator_norm_nonneg A) (operator_norm_nonneg B))
-  (assume x,
-    calc ∥(A + B) x∥ = ∥A x + B x∥ : by refl
-                ... ≤ ∥A x∥ + ∥B x∥ : by exact norm_triangle _ _
-                ... ≤ ∥A∥ * ∥x∥ + ∥B∥ * ∥x∥ :
-                  add_le_add bounded_by_operator_norm bounded_by_operator_norm
-                ... = (∥A∥ + ∥B∥) * ∥x∥ : by ring)
+theorem operator_norm_triangle : ∥f + g∥ ≤ ∥f∥ + ∥g∥ :=
+  real.Inf_le _ bounds_bdd_below
+  ⟨add_nonneg (operator_norm_nonneg _) (operator_norm_nonneg _),
+    λ x, by rw add_mul;
+    calc _ ≤ ∥f x∥ + ∥g x∥ : norm_triangle _ _
+    ...    ≤ _ : add_le_add (le_operator_norm _ _) (le_operator_norm _ _)⟩
 
 /-- An operator is zero iff its norm vanishes. -/
-theorem operator_norm_zero_iff (A : L(E,F)) : ∥A∥ = 0 ↔ A = 0 :=
+theorem operator_norm_zero_iff : ∥f∥ = 0 ↔ f = 0 :=
 iff.intro
-  (assume : ∥A∥ = 0,
-    suffices ∀ x, A x = 0, from ext this,
-    assume x,
-      have ∥A x∥ ≤ 0, from
-        calc ∥A x∥ ≤ ∥A∥ * ∥x∥ : bounded_by_operator_norm
-              ... = 0 : by rw[‹∥A∥ = 0›]; ring,
-      (norm_le_zero_iff (A x)).mp this)
-  (assume : A = 0,
-    have ∥A∥ ≤ 0, from operator_norm_bounded_by (le_refl 0) $ by rw this; simp [le_refl],
-    le_antisymm this (operator_norm_nonneg A))
+  (λ hn, bounded_linear_map.ext (λ x, (norm_le_zero_iff _).1
+    (calc _ ≤ ∥f∥ * ∥x∥ : le_operator_norm _ _
+     ...     = _ : by rw [hn, zero_mul])))
+  (λ hf, le_antisymm (real.Inf_le _ bounds_bdd_below
+    ⟨ge_of_eq rfl, λ _, le_of_eq (by rw [zero_mul, hf]; exact norm_zero)⟩)
+    (operator_norm_nonneg _))
 
-section instance_70
--- one needs to increase the max_depth for the following proof
-set_option class.instance_max_depth 70
+/-- The operator norm is homogeneous. -/
+lemma operator_norm_smul : ∥c • f∥ = ∥c∥ * ∥f∥ :=
+  le_antisymm
+    (real.Inf_le _ bounds_bdd_below
+      ⟨mul_nonneg (norm_nonneg _) (operator_norm_nonneg _),
+      λ _, by erw [norm_smul, mul_assoc]; exact
+      mul_le_mul_of_nonneg_left (le_operator_norm _ _) (norm_nonneg _)⟩)
+    (real.lb_le_Inf _ bounds_nonempty (λ _ ⟨hn, hc⟩,
+      (or.elim (lt_or_eq_of_le (norm_nonneg c))
+        (λ hlt, by rw mul_comm; exact
+          mul_le_of_le_div hlt (real.Inf_le _ bounds_bdd_below
+          ⟨div_nonneg hn hlt, λ _,
+            (by rw div_mul_eq_mul_div; exact le_div_of_mul_le hlt
+            (by rw [ mul_comm, ←norm_smul ]; exact hc _))⟩))
+        (λ heq, by rw [←heq, zero_mul]; exact hn))))
 
-/-- Auxiliary lemma to prove that the operator norm is homogeneous. -/
-lemma operator_norm_homogeneous_le (c : k) (A : L(E, F)) : ∥c • A∥ ≤ ∥c∥ * ∥A∥ :=
-begin
-  apply operator_norm_bounded_by (mul_nonneg (norm_nonneg _) (operator_norm_nonneg _)) (λx, _),
-  erw [norm_smul _ _, mul_assoc],
-  exact mul_le_mul_of_nonneg_left bounded_by_operator_norm (norm_nonneg _)
-end
+/-- Bounded linear maps themselves form a normed space with respect to
+    the operator norm. -/
+noncomputable instance bounded_linear_map.to_normed_space :
+  normed_space k (E →L[k] F) :=
+  normed_space.of_core _ _
+  ⟨operator_norm_zero_iff, operator_norm_smul, operator_norm_triangle⟩
 
-theorem operator_norm_homogeneous (c : k) (A : L(E, F)) : ∥c • A∥ = ∥c∥ * ∥A∥ :=
-begin
-  refine le_antisymm (operator_norm_homogeneous_le c A) _,
-  by_cases h : ∥c∥ = 0,
-  { have : c = 0, from (norm_eq_zero _).1 h,
-    have I : ∥(0 : L(E, F))∥ = 0, by rw operator_norm_zero_iff,
-    simp only [h],
-    simp [this, I] },
-  { have h' : c ≠ 0, by simpa [norm_eq_zero] using h,
-    have : ∥A∥ ≤ ∥c • A∥ / ∥c∥, from calc
-      ∥A∥ = ∥(1 : k) • A∥ : by rw bounded_linear_maps.one_smul
-      ... = ∥c⁻¹ • c • A∥ : by rw [smul_smul, inv_mul_cancel h']
-      ... ≤ ∥c⁻¹∥ * ∥c • A∥ : operator_norm_homogeneous_le _ _
-      ... = ∥c • A∥ / ∥c∥ : by rw [norm_inv, div_eq_inv_mul],
-    rwa [le_div_iff, mul_comm] at this,
-    simpa [ne.symm h] using le_iff_eq_or_lt.1 (norm_nonneg c) }
-end
-end instance_70
+/-- The operator norm is submultiplicative. -/
+lemma op_norm_comp_le : ∥comp h f∥ ≤ ∥h∥ * ∥f∥ :=
+  (real.Inf_le _ bounds_bdd_below
+  ⟨mul_nonneg (operator_norm_nonneg _) (operator_norm_nonneg _),
+  λ x, by rw mul_assoc; calc _ ≤ ∥h∥ * ∥f x∥: le_operator_norm _ _
+  ... ≤ _ : mul_le_mul_of_nonneg_left
+            (le_operator_norm _ _) (operator_norm_nonneg _)⟩)
 
-/-- Expose L(E,F) equipped with the operator norm as normed space. -/
-noncomputable instance bounded_linear_maps.to_normed_space : normed_space k L(E,F) :=
-normed_space.of_core k L(E,F) {
-  norm_eq_zero_iff := operator_norm_zero_iff,
-  norm_smul := operator_norm_homogeneous,
-  triangle := operator_norm_triangle }
+/-- bounded linear maps are lipschitz continuous. -/
+theorem lipschitz : lipschitz_with ∥f∥ f :=
+  ⟨operator_norm_nonneg _, λ x y, by rw [dist_eq_norm, dist_eq_norm, ←map_sub];
+  exact le_operator_norm _ _⟩
 
 end operator_norm


### PR DESCRIPTION
First part of a process towards restating `deriv.lean` in terms of bundled bounded linear maps. Supersedes #726 : @sgouezel has kindly pointed out that much of the work there has become outdated and/or duplicated; this is an attempt at cleaning up the mess I made.

Some names for theorems and definitions have been altered for adherence to conventions, or for brevity. Please see comments on #726 and commit messages in this PR for detailed accounts of changes.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
