### PR TITLE
feat(nat/basic): add some basic nat inequality lemmas

### DIFF
--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -260,6 +260,14 @@ iff.intro eq_zero_of_mul_eq_zero (by simp [or_imp_distrib] {contextual := tt})
 @[simp] protected theorem zero_eq_mul {a b : ℕ} : 0 = a * b ↔ a = 0 ∨ b = 0 :=
 by rw [eq_comm, nat.mul_eq_zero]
 
+lemma le_mul_pos_right {a b : ℕ} (h : b > 0) : a ≤ a * b :=
+by {rw [← mul_one(a),mul_assoc,one_mul], exact mul_le_mul_of_nonneg_left (nat.succ_le_of_lt h) dec_trivial,}
+
+lemma le_mul_pos_left {a b : ℕ} (h : b > 0) : a ≤ b * a :=
+by {rw [← one_mul(a),←mul_assoc,mul_one], exact mul_le_mul_of_nonneg_right (nat.succ_le_of_lt h) dec_trivial,}
+
+lemma le_mul_ge_one (m n : ℕ) (h : n ≥ 1) : m ≤ m * n := le_mul_pos_right (lt_of_lt_of_le dec_trivial h)
+
 @[elab_as_eliminator]
 protected def strong_rec' {p : ℕ → Sort u} (H : ∀ n, (∀ m, m < n → p m) → p n) : ∀ (n : ℕ), p n
 | n := H n (λ m hm, strong_rec' m)
@@ -310,6 +318,15 @@ lt_iff_lt_of_le_iff_le $ le_div_iff_mul_le' k0
 protected theorem div_le_div_right {n m : ℕ} (h : n ≤ m) {k : ℕ} : n / k ≤ m / k :=
 (nat.eq_zero_or_pos k).elim (λ k0, by simp [k0]) $ λ hk,
 (le_div_iff_mul_le' hk).2 $ le_trans (nat.div_mul_le_self' _ _) h
+
+def le_half_of_double_le (m n : ℕ) (h : 2*m ≤ n) : m ≤ n/2 :=
+begin
+  convert nat.div_le_div_right h,
+  exact (nat.mul_div_cancel_left m dec_trivial).symm,
+end
+
+lemma div_lt_div_to_lt (a b c : ℕ) (h : c > 0) : a / c < b / c → a < b:=
+λ j, by_contradiction $ λ k, absurd j (not_lt_of_ge (nat.div_le_div_right (not_lt.1 k)))
 
 protected theorem eq_mul_of_div_eq_right {a b c : ℕ} (H1 : b ∣ a) (H2 : a / b = c) :
   a = b * c :=

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -262,18 +262,15 @@ by rw [eq_comm, nat.mul_eq_zero]
 
 lemma le_mul_pos_right {m n : ℕ} (h : n > 0) : m ≤ m * n :=
 begin
-rw [← mul_one(m),mul_assoc,one_mul],
+conv {to_lhs, rw [← mul_one(m)]},
 exact mul_le_mul_of_nonneg_left (nat.succ_le_of_lt h) dec_trivial,
 end
 
 lemma le_mul_pos_left {m n : ℕ} (h : n > 0) : m ≤ n * m :=
 begin
-rw [← one_mul(m),←mul_assoc,mul_one],
+conv {to_lhs, rw [← one_mul(m)]},
 exact mul_le_mul_of_nonneg_right (nat.succ_le_of_lt h) dec_trivial,
 end
-
-lemma le_mul_ge_one (m n : ℕ) (h : n ≥ 1) : m ≤ m * n :=
-le_mul_pos_right (lt_of_lt_of_le dec_trivial h)
 
 @[elab_as_eliminator]
 protected def strong_rec' {p : ℕ → Sort u} (H : ∀ n, (∀ m, m < n → p m) → p n) : ∀ (n : ℕ), p n
@@ -332,7 +329,7 @@ begin
   exact (nat.mul_div_cancel_left m dec_trivial).symm,
 end
 
-lemma div_lt_div_to_lt (m n k : ℕ) (h : k > 0) : m / k < n / k → m < n :=
+lemma lt_of_div_lt_div (m n k : ℕ) : m / k < n / k → m < n :=
 λ h₁, by_contradiction $ λ h₂, absurd h₁ (not_lt_of_ge (nat.div_le_div_right (not_lt.1 h₂)))
 
 protected theorem eq_mul_of_div_eq_right {a b c : ℕ} (H1 : b ∣ a) (H2 : a / b = c) :

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -260,13 +260,20 @@ iff.intro eq_zero_of_mul_eq_zero (by simp [or_imp_distrib] {contextual := tt})
 @[simp] protected theorem zero_eq_mul {a b : ℕ} : 0 = a * b ↔ a = 0 ∨ b = 0 :=
 by rw [eq_comm, nat.mul_eq_zero]
 
-lemma le_mul_pos_right {a b : ℕ} (h : b > 0) : a ≤ a * b :=
-by {rw [← mul_one(a),mul_assoc,one_mul], exact mul_le_mul_of_nonneg_left (nat.succ_le_of_lt h) dec_trivial,}
+lemma le_mul_pos_right {m n : ℕ} (h : n > 0) : m ≤ m * n :=
+begin
+rw [← mul_one(m),mul_assoc,one_mul],
+exact mul_le_mul_of_nonneg_left (nat.succ_le_of_lt h) dec_trivial,
+end
 
-lemma le_mul_pos_left {a b : ℕ} (h : b > 0) : a ≤ b * a :=
-by {rw [← one_mul(a),←mul_assoc,mul_one], exact mul_le_mul_of_nonneg_right (nat.succ_le_of_lt h) dec_trivial,}
+lemma le_mul_pos_left {m n : ℕ} (h : n > 0) : m ≤ n * m :=
+begin
+rw [← one_mul(m),←mul_assoc,mul_one],
+exact mul_le_mul_of_nonneg_right (nat.succ_le_of_lt h) dec_trivial,
+end
 
-lemma le_mul_ge_one (m n : ℕ) (h : n ≥ 1) : m ≤ m * n := le_mul_pos_right (lt_of_lt_of_le dec_trivial h)
+lemma le_mul_ge_one (m n : ℕ) (h : n ≥ 1) : m ≤ m * n :=
+le_mul_pos_right (lt_of_lt_of_le dec_trivial h)
 
 @[elab_as_eliminator]
 protected def strong_rec' {p : ℕ → Sort u} (H : ∀ n, (∀ m, m < n → p m) → p n) : ∀ (n : ℕ), p n
@@ -325,8 +332,8 @@ begin
   exact (nat.mul_div_cancel_left m dec_trivial).symm,
 end
 
-lemma div_lt_div_to_lt (a b c : ℕ) (h : c > 0) : a / c < b / c → a < b:=
-λ j, by_contradiction $ λ k, absurd j (not_lt_of_ge (nat.div_le_div_right (not_lt.1 k)))
+lemma div_lt_div_to_lt (m n k : ℕ) (h : k > 0) : m / k < n / k → m < n :=
+λ h₁, by_contradiction $ λ h₂, absurd h₁ (not_lt_of_ge (nat.div_le_div_right (not_lt.1 h₂)))
 
 protected theorem eq_mul_of_div_eq_right {a b c : ℕ} (H1 : b ∣ a) (H2 : a / b = c) :
   a = b * c :=


### PR DESCRIPTION
Adding some basic inequality lemmas about the natural numbers.

3 forms of multiplication by a positive numbers gives a result larger or equal

The case that having a number less than half implies twice that number is less than.

Ordering of numbers after division imposes order on the numbers.