### PR TITLE
docs(elan): remove reference to nightly Lean

### DIFF
--- a/docs/elan.md
+++ b/docs/elan.md
@@ -79,7 +79,7 @@ When you installed `elan`, it downloaded the latest stable release of Lean.
 That may be too recent or too old for mathlib, and you really want mathlib.
 
 1. Decide on a name for your package. We will use `my_playground`.
-2. Run `leanpkg +nightly new my_playground`.
+2. Run `leanpkg new my_playground`.
    This will create a `my_playground` directory with a Lean project layout.
 3. Run `cd my_playground`.
 4. Run `leanpkg add leanprover/mathlib`.

--- a/docs/elan.md
+++ b/docs/elan.md
@@ -79,7 +79,7 @@ When you installed `elan`, it downloaded the latest stable release of Lean.
 That may be too recent or too old for mathlib, and you really want mathlib.
 
 1. Decide on a name for your package. We will use `my_playground`.
-2. Run `leanpkg new my_playground`.
+2. Run `leanpkg +3.4.2 new my_playground`.
    This will create a `my_playground` directory with a Lean project layout.
 3. Run `cd my_playground`.
 4. Run `leanpkg add leanprover/mathlib`.


### PR DESCRIPTION
See also issue: #643 

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
