### PR TITLE
fix(algebra/big_operators): in finset.prod_map, remove spurious [comm_monoid β]

### DIFF
--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -57,7 +57,7 @@ lemma prod_image [decidable_eq α] {s : finset γ} {g : γ → α} :
 fold_image
 
 @[simp, to_additive sum_map]
-lemma prod_map [comm_monoid γ] (s : finset α) (e : α ↪ β) (f : β → γ):
+lemma prod_map (s : finset α) (e : α ↪ γ) (f : γ → β):
   (s.map e).prod f = s.prod (λa, f (e a)) :=
 by rw [finset.prod, finset.map_val, multiset.map_map]; refl
 


### PR DESCRIPTION
The old version involved maps α → β → γ and an instance [comm_monoid γ], but there was also a section variable [comm_monoid β].  In applications of this lemma it is not necessary, and not usually true, that β is a monoid.  Change the statement to involve maps α → γ → β so that we already have a monoid structure on the last variable and we do not make spurious assumptions about the second one.  This does not make any difference to how the lemma is invoked, it just means that the lemma now works if the second variable does not happen to have a monoid structure.

This is my first attempt to deal with the whole fork-and-branch/pull request thing.  Please let me know if I should be doing anything differently.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
