### PR TITLE
feat(nat/basic): add some basic nat inequality lemmas

### DIFF
--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -260,16 +260,16 @@ iff.intro eq_zero_of_mul_eq_zero (by simp [or_imp_distrib] {contextual := tt})
 @[simp] protected theorem zero_eq_mul {a b : ℕ} : 0 = a * b ↔ a = 0 ∨ b = 0 :=
 by rw [eq_comm, nat.mul_eq_zero]
 
-lemma le_mul_pos_left {m n : ℕ} (h : n > 0) : m ≤ n * m :=
+lemma le_mul_of_pos_left {m n : ℕ} (h : n > 0) : m ≤ n * m :=
 begin
-conv {to_lhs, rw [← one_mul(m)]},
-exact mul_le_mul_of_nonneg_right (nat.succ_le_of_lt h) dec_trivial,
+  conv {to_lhs, rw [← one_mul(m)]},
+  exact mul_le_mul_of_nonneg_right (nat.succ_le_of_lt h) dec_trivial,
 end
 
-lemma le_mul_pos_right {m n : ℕ} (h : n > 0) : m ≤ m * n :=
+lemma le_mul_of_pos_right {m n : ℕ} (h : n > 0) : m ≤ m * n :=
 begin
-conv {to_lhs, rw [← mul_one(m)]},
-exact mul_le_mul_of_nonneg_left (nat.succ_le_of_lt h) dec_trivial,
+  conv {to_lhs, rw [← mul_one(m)]},
+  exact mul_le_mul_of_nonneg_left (nat.succ_le_of_lt h) dec_trivial,
 end
 
 @[elab_as_eliminator]
@@ -323,8 +323,8 @@ protected theorem div_le_div_right {n m : ℕ} (h : n ≤ m) {k : ℕ} : n / k �
 (nat.eq_zero_or_pos k).elim (λ k0, by simp [k0]) $ λ hk,
 (le_div_iff_mul_le' hk).2 $ le_trans (nat.div_mul_le_self' _ _) h
 
-lemma lt_of_div_lt_div (m n k : ℕ) : m / k < n / k → m < n :=
-λ h₁, by_contradiction $ λ h₂, absurd h₁ (not_lt_of_ge (nat.div_le_div_right (not_lt.1 h₂)))
+lemma lt_of_div_lt_div (m n k : ℕ) (h : m / k < n / k) : m < n :=
+by_contradiction $ λ h₁, absurd h (not_lt_of_ge (nat.div_le_div_right (not_lt.1 h₁)))
 
 protected theorem eq_mul_of_div_eq_right {a b c : ℕ} (H1 : b ∣ a) (H2 : a / b = c) :
   a = b * c :=

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -323,7 +323,7 @@ protected theorem div_le_div_right {n m : ℕ} (h : n ≤ m) {k : ℕ} : n / k �
 (nat.eq_zero_or_pos k).elim (λ k0, by simp [k0]) $ λ hk,
 (le_div_iff_mul_le' hk).2 $ le_trans (nat.div_mul_le_self' _ _) h
 
-lemma lt_of_div_lt_div (m n k : ℕ) (h : m / k < n / k) : m < n :=
+lemma lt_of_div_lt_div {m n k : ℕ} (h : m / k < n / k) : m < n :=
 by_contradiction $ λ h₁, absurd h (not_lt_of_ge (nat.div_le_div_right (not_lt.1 h₁)))
 
 protected theorem eq_mul_of_div_eq_right {a b c : ℕ} (H1 : b ∣ a) (H2 : a / b = c) :

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -260,6 +260,18 @@ iff.intro eq_zero_of_mul_eq_zero (by simp [or_imp_distrib] {contextual := tt})
 @[simp] protected theorem zero_eq_mul {a b : ℕ} : 0 = a * b ↔ a = 0 ∨ b = 0 :=
 by rw [eq_comm, nat.mul_eq_zero]
 
+lemma le_mul_pos_left {m n : ℕ} (h : n > 0) : m ≤ n * m :=
+begin
+conv {to_lhs, rw [← one_mul(m)]},
+exact mul_le_mul_of_nonneg_right (nat.succ_le_of_lt h) dec_trivial,
+end
+
+lemma le_mul_pos_right {m n : ℕ} (h : n > 0) : m ≤ m * n :=
+begin
+conv {to_lhs, rw [← mul_one(m)]},
+exact mul_le_mul_of_nonneg_left (nat.succ_le_of_lt h) dec_trivial,
+end
+
 @[elab_as_eliminator]
 protected def strong_rec' {p : ℕ → Sort u} (H : ∀ n, (∀ m, m < n → p m) → p n) : ∀ (n : ℕ), p n
 | n := H n (λ m hm, strong_rec' m)
@@ -310,6 +322,9 @@ lt_iff_lt_of_le_iff_le $ le_div_iff_mul_le' k0
 protected theorem div_le_div_right {n m : ℕ} (h : n ≤ m) {k : ℕ} : n / k ≤ m / k :=
 (nat.eq_zero_or_pos k).elim (λ k0, by simp [k0]) $ λ hk,
 (le_div_iff_mul_le' hk).2 $ le_trans (nat.div_mul_le_self' _ _) h
+
+lemma lt_of_div_lt_div (m n k : ℕ) : m / k < n / k → m < n :=
+λ h₁, by_contradiction $ λ h₂, absurd h₁ (not_lt_of_ge (nat.div_le_div_right (not_lt.1 h₂)))
 
 protected theorem eq_mul_of_div_eq_right {a b c : ℕ} (H1 : b ∣ a) (H2 : a / b = c) :
   a = b * c :=


### PR DESCRIPTION
Multiplication by a positive numbers gives a result larger or equal (Useful as specific cases of existing ordered ring lemmas since one less hypothesis is needed for natural numbers)

Ordering of numbers after division imposes order on the numbers (Just another missing order lemma unique to the natural numbers by the properties of natural number division).