### PR TITLE
feat(tactic): add `convert_to` and `ac_change`

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -964,4 +964,20 @@ nat.cast_sub : ∀ {α : Type*} [add_group α] [has_one α] {m n : ℕ}, m ≤ n
 int.cast_coe_nat : ∀ (n : ℕ), ↑↑n = ↑n
 
 int.cats_id : int.cast_id : ∀ (n : ℤ), ↑n = n
+
+### convert_to
+
+`convert_to g using n` attempts to change the current goal to `g`, but unlike `change`,
+it will generate equality proof obligations using `congr' n` to resolve discrepancies.
+`convert_to g` defaults to using `congr' 1`.
+
+`ac_change` is `convert_to` followed by `ac_refl`. It is useful for rearranging/reassociating
+e.g. sums:
+
+```lean
+example (a b c d e f g N : ℕ) : (a + b) + (c + d) + (e + f) + g ≤ N :=
+begin
+  ac_change a + d + e + f + c + g + b ≤ _,
+-- ⊢ a + d + e + f + c + g + b ≤ N
+end
 ```

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -576,8 +576,8 @@ meta def change' (q : parse texpr) : parse (tk "with" *> texpr)? → parse locat
      when l.include_goal $ change q w (loc.ns [none])
 
 meta def convert_to_core (r : pexpr) : tactic unit :=
-do tgt <- target,
-   h   <- to_expr ``(_ : %%tgt = %%r),
+do tgt ← target,
+   h   ← to_expr ``(_ : %%tgt = %%r),
    rewrite_target h,
    swap
 
@@ -587,14 +587,14 @@ using `congr' n` to resolve discrepancies.
 
 `convert_to g` defaults to using `congr' 1`.
 -/
-meta def convert_to (r : parse texpr) (n : parse (tk "using" *> small_nat)?):  tactic unit :=
+meta def convert_to (r : parse texpr) (n : parse (tk "using" *> small_nat)?) : tactic unit :=
 match n with
   | none     := convert_to_core r >> `[congr' 1]
   | (some 0) := convert_to_core r
   | (some o) := convert_to_core r >> congr' o
 end
 
-/-- `ac_change g using n` is `convert_to g using n; try{ac_refl}` -/
+/-- `ac_change g using n` is `convert_to g using n; try {ac_refl}` -/
 meta def ac_change (r : parse texpr) (n : parse (tk "using" *> small_nat)?) : tactic unit :=
 convert_to r n; try ac_refl
 

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -1,3 +1,4 @@
+
 /-
 Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
@@ -573,6 +574,29 @@ meta def change' (q : parse texpr) : parse (tk "with" *> texpr)? → parse locat
   do l' ← loc.get_local_pp_names l,
      l'.mmap' (λ e, try (change_with_at q w e)),
      when l.include_goal $ change q w (loc.ns [none])
+
+meta def convert_to_core (r : pexpr) : tactic unit :=
+do tgt <- target,
+   h   <- to_expr ``(_ : %%tgt = %%r),
+   rewrite_target h,
+   swap
+
+/--
+`convert_to g using n` attempts to change the current goal to `g`,
+using `congr' n` to resolve discrepancies.
+
+`convert_to g` defaults to using `congr' 1`.
+-/
+meta def convert_to (r : parse texpr) (n : parse (tk "using" *> small_nat)?):  tactic unit :=
+match n with
+  | none     := convert_to_core r >> `[congr' 1]
+  | (some 0) := convert_to_core r
+  | (some o) := convert_to_core r >> congr' o
+end
+
+/-- `ac_change g using n` is `convert_to g using n; try{ac_refl}` -/
+meta def ac_change (r : parse texpr) (n : parse (tk "using" *> small_nat)?) : tactic unit :=
+convert_to r n; try ac_refl
 
 private meta def opt_dir_with : parser (option (bool × name)) :=
 (do tk "with",

--- a/test/tactics.lean
+++ b/test/tactics.lean
@@ -201,6 +201,19 @@ end
 
 end congr
 
+section convert_to
+
+example {a b c d : ℕ} (H : a = c) (H' : b = d) : a + b = d + c :=
+by {convert_to c + d = _ using 2, from H, from H', rw[add_comm]}
+
+example {a b c d : ℕ} (H : a = c) (H' : b = d) : a + b = d + c :=
+by {convert_to c + d = _ using 0, congr' 2, from H, from H', rw[add_comm]}
+
+example (a b c d e f g N : ℕ) : (a + b) + (c + d) + (e + f) + g ≤ a + d + e + f + c + g + b :=
+by {ac_change a + d + e + f + c + g + b ≤ _, refl}
+
+end convert_to
+
 private meta def get_exception_message (t : lean.parser unit) : lean.parser string
 | s := match t s with
        | result.success a s' := result.success "No exception" s


### PR DESCRIPTION
`change'' g using n` attempts to change the current goal to `g`, using
`congr' n` to resolve discrepancies. `ac_change` is `change''`
followed by `ac_refl`.

TO CONTRIBUTORS:

Make sure you have:

  * [✓] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [✓] for tactics:
     * [✓] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [✓] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [✓] make sure definitions and lemmas are put in the right files
  * [✓] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
