### PR TITLE
feat(ring_theory/ideal_operations): inj_iff_trivial_ker for ring homomorphisms

### DIFF
--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -555,6 +555,17 @@ lemma inj_iff_trivial_ker (f : α → β) [is_group_hom f] :
   function.injective f ↔ ker f = trivial α :=
 ⟨trivial_ker_of_inj f, inj_of_trivial_ker f⟩
 
+@[to_additive is_add_group_hom.trivial_ker_iff_eq_zero]
+lemma trivial_ker_iff_eq_one (f : α → β) [is_group_hom f] :
+  ker f = trivial α ↔ ∀ x, f x = 1 → x = 1 :=
+by rw set.ext_iff; simp [ker]; exact
+⟨λ h x hx, (h x).1 hx, λ h x, ⟨h x, λ hx, by rw [hx, map_one f]⟩⟩
+
+@[to_additive is_add_group_hom.inj_iff_eq_zero]
+lemma inj_iff_eq_one (f : α → β) [is_group_hom f] :
+  function.injective f ↔ ∀ x, f x = 1 → x = 1 :=
+iff.trans (inj_iff_trivial_ker f) (trivial_ker_iff_eq_one f)
+
 end is_group_hom
 
 instance subtype_val.is_group_hom [group α] {s : set α} [is_subgroup s] :

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -561,11 +561,6 @@ lemma trivial_ker_iff_eq_one (f : α → β) [is_group_hom f] :
 by rw set.ext_iff; simp [ker]; exact
 ⟨λ h x hx, (h x).1 hx, λ h x, ⟨h x, λ hx, by rw [hx, map_one f]⟩⟩
 
-@[to_additive is_add_group_hom.inj_iff_eq_zero]
-lemma inj_iff_eq_one (f : α → β) [is_group_hom f] :
-  function.injective f ↔ ∀ x, f x = 1 → x = 1 :=
-iff.trans (inj_iff_trivial_ker f) (trivial_ker_iff_eq_one f)
-
 end is_group_hom
 
 instance subtype_val.is_group_hom [group α] {s : set α} [is_subgroup s] :

--- a/src/ring_theory/ideal_operations.lean
+++ b/src/ring_theory/ideal_operations.lean
@@ -553,8 +553,8 @@ by rw [←submodule.ext'_iff, ker_eq]; exact is_add_group_hom.inj_iff_trivial_ke
 lemma ker_eq_bot_iff_eq_zero : ker f = ⊥ ↔ ∀ x, f x = 0 → x = 0 :=
 by rw [←submodule.ext'_iff, ker_eq]; exact is_add_group_hom.trivial_ker_iff_eq_zero f
 
-lemma inj_iff_eq_zero : function.injective f ↔ ∀ x, f x = 0 → x = 0 :=
-is_add_group_hom.inj_iff_eq_zero f
+lemma injective_iff : function.injective f ↔ ∀ x, f x = 0 → x = 0 :=
+is_add_group_hom.injective_iff f
 
 end is_ring_hom
 

--- a/src/ring_theory/ideal_operations.lean
+++ b/src/ring_theory/ideal_operations.lean
@@ -538,6 +538,26 @@ end map_and_comap
 
 end ideal
 
+namespace is_ring_hom
+
+variables {R : Type u} {S : Type v} [comm_ring R] [comm_ring S]
+variables (f : R → S) [is_ring_hom f]
+
+def ker : ideal R := ideal.comap f ⊥
+
+lemma ker_eq : ((ker f) : set R) = is_add_group_hom.ker f := rfl
+
+lemma inj_iff_ker_eq_bot : function.injective f ↔ ker f = ⊥ :=
+by rw [←submodule.ext'_iff, ker_eq]; exact is_add_group_hom.inj_iff_trivial_ker f
+
+lemma ker_eq_bot_iff_eq_zero : ker f = ⊥ ↔ ∀ x, f x = 0 → x = 0 :=
+by rw [←submodule.ext'_iff, ker_eq]; exact is_add_group_hom.trivial_ker_iff_eq_zero f
+
+lemma inj_iff_eq_zero : function.injective f ↔ ∀ x, f x = 0 → x = 0 :=
+is_add_group_hom.inj_iff_eq_zero f
+
+end is_ring_hom
+
 namespace submodule
 
 variables {R : Type u} {M : Type v}


### PR DESCRIPTION
Using [#947](https://github.com/leanprover-community/mathlib/pull/947) to prove the same result for ring homomorphisms including the definition of the kernel of a ring homomorphism.