### PR TITLE
refactor(analysis/normed_space/operator_norm): replace subspace with …

### DIFF
--- a/src/analysis/normed_space/bounded_linear_maps.lean
+++ b/src/analysis/normed_space/bounded_linear_maps.lean
@@ -6,8 +6,7 @@ Authors: Patrick Massot, Johannes Hölzl
 Continuous linear functions -- functions between normed vector spaces which are bounded and linear.
 -/
 import algebra.field
-import analysis.normed_space.basic
-import analysis.asymptotics
+import analysis.normed_space.operator_norm
 
 noncomputable theory
 local attribute [instance] classical.prop_decidable
@@ -35,10 +34,17 @@ lemma is_linear_map.with_bound
     le_trans (h x) $ mul_le_mul_of_nonneg_right (le_trans this zero_le_one) (norm_nonneg x)⟩)
   (assume : ¬ M ≤ 0, ⟨M, lt_of_not_ge this, h⟩)⟩
 
+/-- A bounded linear map satisfies `is_bounded_linear_map` -/
+lemma bounded_linear_map.is_bounded_linear_map (f : E →L[k] F) : is_bounded_linear_map k f := {..f}
+
 namespace is_bounded_linear_map
 
 def to_linear_map (f : E → F) (h : is_bounded_linear_map k f) : E →ₗ[k] F :=
 (is_linear_map.mk' _ h.to_is_linear_map)
+
+/-- Construct a bounded linear map from is_bounded_linear_map -/
+def to_bounded_linear_map {f : E → F} (hf : is_bounded_linear_map k f) : E →L[k] F :=
+{ bound := hf.bound, ..is_bounded_linear_map.to_linear_map f hf }
 
 lemma zero : is_bounded_linear_map k (λ (x:E), (0:F)) :=
 (0 : E →ₗ F).is_linear.with_bound 0 $ by simp [le_refl]

--- a/src/analysis/normed_space/bounded_linear_maps.lean
+++ b/src/analysis/normed_space/bounded_linear_maps.lean
@@ -9,11 +9,6 @@ import algebra.field
 import analysis.normed_space.basic
 import analysis.asymptotics
 
-@[simp] lemma mul_inv_eq' {α} [discrete_field α] (a b : α) : (a * b)⁻¹ = b⁻¹ * a⁻¹ :=
-classical.by_cases (assume : a = 0, by simp [this]) $ assume ha,
-classical.by_cases (assume : b = 0, by simp [this]) $ assume hb,
-mul_inv_eq hb ha
-
 noncomputable theory
 local attribute [instance] classical.prop_decidable
 


### PR DESCRIPTION
…structure

#927 was closed before a comment by @digama0 was properly taken into account, saying that he would prefer a self-contained implementation avoiding `is_bounded_linear_map` as much as possible, as is done with `is_linear_map` and `linear_map`.

This is done in this PR: `bounded_linear_map` is redefined as a structure extending `linear_map`, without reference to `is_bounded_linear_map`. In this way, we can shrink or even completely remove `is_bounded_linear_map` in the future if needed.

A motivation for this: when one wants to define `bounded_linear_equiv` extending `linear_equiv` and `bounded_linear_map`, then `bounded_linear_map` has to be a structure, contrary to the current implementation.

Most content in this file comes from the initial PR #726 by @jlpaca . 