### PR TITLE
fix(scripts/remote-install-update-mathlib): missing dependency

### DIFF
--- a/scripts/remote-install-update-mathlib.sh
+++ b/scripts/remote-install-update-mathlib.sh
@@ -2,7 +2,7 @@
 BRANCH=master
 USER="--user"
 USER_MSG="(at user level)"
-PYTHON_DEPS="toml PyGithub urllib3 certifi gitpython"
+PYTHON_DEPS="setuptools toml PyGithub urllib3 certifi gitpython"
 
 for i in "$@"
 do
@@ -54,7 +54,7 @@ if ! which pip3; then
     fi
 fi
 
-pip3 install $USER $PYTHON_DEPS || exit -1
+pip3 install --upgrade $USER $PYTHON_DEPS || exit -1
 echo "Fetching the update-mathlib script"
 curl -o update-mathlib.py https://raw.githubusercontent.com/leanprover-community/mathlib/$BRANCH/scripts/update-mathlib.py
 curl -o cache-olean.py https://raw.githubusercontent.com/leanprover-community/mathlib/$BRANCH/scripts/cache-olean.py


### PR DESCRIPTION
Also add a `--upgrade` option to `pip install` in case something is
already there but outdated

See https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Jose.20Balado/near/164386878 and also what we needed to do in https://github.com/leanprover-community/lean-perfectoid-spaces/commit/851fe725f04f224d9f5ceb893ce1981801c3e9bc