### PR TITLE
feat(script/auth_github): improve messages [ci skip]

### DIFF
--- a/scripts/auth_github.py
+++ b/scripts/auth_github.py
@@ -7,17 +7,18 @@ def auth_github():
         repo = Repo('.', search_parent_directories=True)
         config = repo.config_reader()
     except:
-        print('This does not seem to be a git repository.')
+        print('Warning: This does not seem to be a git repository. Expect weird things...')
         return Github()
     try:
         return Github(config.get('github', 'user'), config.get('github', 'password'))
     except configparser.NoSectionError:
-        print('No github section found in \'git config\'')
+        print('Info: No github section found in \'git config\', we will use GitHub with no authentication')
         return Github()
     except configparser.NoOptionError:
         try:
             return Github(config.get('github', 'oauthtoken'))
         except configparser.NoOptionError:
-            print('No github \'user\'/\'password\' or \'oauthtoken\' keys found in \'git config\'.')
+            print("Info: No github 'user'/'password' or 'oauthtoken' keys found in git config, "
+                  "we will use GitHub with no authentication.")
             print('You can create an OAuth token at https://github.com/settings/tokens/new (no scopes are required).')
             return Github()


### PR DESCRIPTION
Try to make update-mathlib messages less confusing. I think the very first step towards non-confusing messages is to make sure users know whether a message is information, warning or error. Next step is to provide a bit of context. The message `No github section found in 'git config'` fails spectacularly on both sides.