### PR TITLE
fix(data/polynomial): change instance order in polynomial.subsingleton

### DIFF
--- a/src/data/polynomial.lean
+++ b/src/data/polynomial.lean
@@ -825,8 +825,14 @@ by rw [ne.def, ← degree_eq_bot];
 @[simp] lemma coeff_mul_X_zero (p : polynomial α) : coeff (p * X) 0 = 0 :=
 by rw [coeff_mul_left, sum_range_succ]; simp
 
-instance [subsingleton α] : subsingleton (polynomial α) :=
+end comm_semiring
+
+instance subsingleton [subsingleton α] [comm_semiring α] : subsingleton (polynomial α) :=
 ⟨λ _ _, polynomial.ext.2 (λ _, subsingleton.elim _ _)⟩
+
+section comm_semiring
+
+variables [decidable_eq α] [comm_semiring α] {p q r : polynomial α}
 
 lemma ne_zero_of_monic_of_zero_ne_one (hp : monic p) (h : (0 : α) ≠ 1) :
   p ≠ 0 := mt (congr_arg leading_coeff) $ by rw [monic.def.1 hp, leading_coeff_zero]; cc
@@ -988,7 +994,7 @@ lemma ne_zero_of_monic (h : monic p) : p ≠ 0 :=
 end nonzero_comm_semiring
 
 section comm_semiring
-variables [comm_semiring α] [decidable_eq α] {p q : polynomial α}
+variables [decidable_eq α] [comm_semiring α] {p q : polynomial α}
 
 /-- `dix_X p` return a polynomial `q` such that `q * X + C (p.coeff 0) = p`.
   It can be used in a semiring where the usual division algorithm is not possible -/
@@ -2200,7 +2206,7 @@ def pow_add_expansion {α : Type*} [comm_semiring α] (x y : α) : ∀ (n : ℕ)
     rw [_root_.pow_succ, hz],
     existsi (x*z + (n+1)*x^n+z*y),
     simp [_root_.pow_succ],
-    ring -- expensive!
+    ring
   end
 
 variables [comm_ring α] [decidable_eq α]
@@ -2238,7 +2244,7 @@ begin
 end
 
 def pow_sub_pow_factor (x y : α) : Π {i : ℕ},{z : α // x^i - y^i = z*(x - y)}
-| 0 := ⟨0, by simp⟩ --sorry --false.elim $ not_lt_of_ge h zero_lt_one
+| 0 := ⟨0, by simp⟩
 | 1 := ⟨1, by simp⟩
 | (k+2) :=
   begin


### PR DESCRIPTION
As per https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/.60ring.60.20might.20be.20worse.20now.3F

This is another case of a bad instance order, as @johoelzl describes here: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Problem.20with.20type.20class.20search

With this change, we can finally do
```lean
example : (X : polynomial ℤ) ^ 2 = X * X :=
by simp [pow_two]
```

Before, even `simp only []` would time out from `congr` checking for subsingleton instances.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
