### PR TITLE
chore(travis): disable the check for minimal imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,6 @@ jobs:
         - travis_long "leanpkg test"
         - lean --recursive --export=mathlib.txt src/
         - travis_long "leanchecker mathlib.txt"
-        - cd src
-        - olean-rs -m
-        - make unused
-        - cd ..
         - sh scripts/deploy_nightly.sh
 
     - env: TASK="check install scripts"


### PR DESCRIPTION
This test is causing lots of stress for PR authors.
Reportedly it also gives false advice...
