### PR TITLE
refactor(topology): change continuous_at_within to continuous_within_at

### DIFF
--- a/src/analysis/normed_space/deriv.lean
+++ b/src/analysis/normed_space/deriv.lean
@@ -866,23 +866,23 @@ begin
   exact this.congr (by simp)
 end
 
-theorem has_fderiv_within_at.continuous_at_within
-  (h : has_fderiv_within_at f f' s x) : continuous_at_within f x s :=
+theorem has_fderiv_within_at.continuous_within_at
+  (h : has_fderiv_within_at f f' s x) : continuous_within_at f s x :=
 has_fderiv_at_filter.tendsto_nhds lattice.inf_le_left h
 
 theorem has_fderiv_at.continuous_at (h : has_fderiv_at f f' x) :
   continuous_at f x :=
 has_fderiv_at_filter.tendsto_nhds (le_refl _) h
 
-lemma differentiable_within_at.continuous_at_within (h : differentiable_within_at k f s x) :
-  continuous_at_within f x s :=
-let ⟨f', hf'⟩ := h in hf'.continuous_at_within
+lemma differentiable_within_at.continuous_within_at (h : differentiable_within_at k f s x) :
+  continuous_within_at f s x :=
+let ⟨f', hf'⟩ := h in hf'.continuous_within_at
 
 lemma differentiable_at.continuous_at (h : differentiable_at k f x) : continuous_at f x :=
 let ⟨f', hf'⟩ := h in hf'.continuous_at
 
 lemma differentiable_on.continuous_on (h : differentiable_on k f s) : continuous_on f s :=
-λx hx, (h x hx).continuous_at_within
+λx hx, (h x hx).continuous_within_at
 
 lemma differentiable.continuous (h : differentiable k f) : continuous f :=
 continuous_iff_continuous_at.2 $ λx, (h x).continuous_at
@@ -1071,7 +1071,7 @@ theorem has_fderiv_within_at.comp {g : F → G} {g' : F →L[k] G}
   (hg : has_fderiv_within_at g g' (f '' s) (f x)) :
   has_fderiv_within_at (g ∘ f) (g'.comp f') s x :=
 hf.comp (has_fderiv_at_filter.mono hg
-  hf.continuous_at_within.tendsto_nhds_within_image)
+  hf.continuous_within_at.tendsto_nhds_within_image)
 
 /-- The chain rule. -/
 theorem has_fderiv_at.comp {g : F → G} {g' : F →L[k] G}

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -646,10 +646,10 @@ def continuous (f : α → β) := ∀s, is_open s → is_open (f ⁻¹' s)
 
 def continuous_at (f : α → β) (x : α) := tendsto f (nhds x) (nhds (f x))
 
-def continuous_at_within (f : α → β) (x : α) (s : set α) : Prop :=
+def continuous_within_at (f : α → β) (s : set α) (x : α) : Prop :=
 tendsto f (nhds_within x s) (nhds (f x))
 
-def continuous_on (f : α → β) (s : set α) : Prop := ∀ x ∈ s, continuous_at_within f x s
+def continuous_on (f : α → β) (s : set α) : Prop := ∀ x ∈ s, continuous_within_at f s x
 
 lemma continuous_id : continuous (id : α → α) :=
 assume s h, h

--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -54,9 +54,9 @@ lemma tendsto_prod_mk_nhds {γ} {a : α} {b : β} {f : filter γ} {ma : γ → �
   tendsto (λc, (ma c, mb c)) f (nhds (a, b)) :=
 by rw [nhds_prod_eq]; exact filter.tendsto.prod_mk ha hb
 
-lemma continuous_at_within.prod {f : α → β} {g : α → γ} {s : set α} {x : α}
-  (hf : continuous_at_within f x s) (hg : continuous_at_within g x s) :
-  continuous_at_within (λx, (f x, g x)) x s :=
+lemma continuous_within_at.prod {f : α → β} {g : α → γ} {s : set α} {x : α}
+  (hf : continuous_within_at f s x) (hg : continuous_within_at g s x) :
+  continuous_within_at (λx, (f x, g x)) s x :=
 tendsto_prod_mk_nhds hf hg
 
 lemma continuous_at.prod {f : α → β} {g : α → γ} {x : α}
@@ -65,7 +65,7 @@ tendsto_prod_mk_nhds hf hg
 
 lemma continuous_on.prod {f : α → β} {g : α → γ} {s : set α}
   (hf : continuous_on f s) (hg : continuous_on g s) : continuous_on (λx, (f x, g x)) s :=
-λx hx, continuous_at_within.prod (hf x hx) (hg x hx)
+λx hx, continuous_within_at.prod (hf x hx) (hg x hx)
 
 lemma prod_generate_from_generate_from_eq {s : set (set α)} {t : set (set β)}
   (hs : ⋃₀ s = univ) (ht : ⋃₀ t = univ) :

--- a/src/topology/order.lean
+++ b/src/topology/order.lean
@@ -598,16 +598,16 @@ by rw [tendsto, tendsto, function.restrict, nhds_within_eq_map_subtype_val h,
 
 variables [tspace β] [tspace γ]
 
-theorem continuous_at_within_univ (f : α → β) (x : α) :
-   continuous_at_within f x set.univ ↔ continuous_at f x :=
-by rw [continuous_at, continuous_at_within, nhds_within_univ]
+theorem continuous_within_at_univ (f : α → β) (x : α) :
+   continuous_within_at f set.univ x ↔ continuous_at f x :=
+by rw [continuous_at, continuous_within_at, nhds_within_univ]
 
-theorem continuous_at_within_iff_continuous_at_restrict (f : α → β) {x : α} {s : set α} (h : x ∈ s) :
-  continuous_at_within f x s ↔ continuous_at (function.restrict f s) ⟨x, h⟩ :=
+theorem continuous_within_at_iff_continuous_at_restrict (f : α → β) {x : α} {s : set α} (h : x ∈ s) :
+  continuous_within_at f s x ↔ continuous_at (function.restrict f s) ⟨x, h⟩ :=
 tendsto_nhds_within_iff_subtype h f _
 
-theorem continuous_at_within.tendsto_nhds_within_image {f : α → β} {x : α} {s : set α}
-  (h : continuous_at_within f x s) :
+theorem continuous_within_at.tendsto_nhds_within_image {f : α → β} {x : α} {s : set α}
+  (h : continuous_within_at f s x) :
   tendsto f (nhds_within x s) (nhds_within (f x) (f '' s)) :=
 tendsto_inf.2 ⟨h, tendsto_principal.2 $
   mem_inf_sets_of_right $ mem_principal_sets.2 $
@@ -616,16 +616,16 @@ tendsto_inf.2 ⟨h, tendsto_principal.2 $
 theorem continuous_on_iff {f : α → β} {s : set α} :
   continuous_on f s ↔ ∀ x ∈ s, ∀ t : set β, is_open t → f x ∈ t → ∃ u, is_open u ∧ x ∈ u ∧
     u ∩ s ⊆ f ⁻¹' t :=
-by simp only [continuous_on, continuous_at_within, tendsto_nhds, mem_nhds_within]
+by simp only [continuous_on, continuous_within_at, tendsto_nhds, mem_nhds_within]
 
 theorem continuous_on_iff_continuous_restrict {f : α → β} {s : set α} :
   continuous_on f s ↔ continuous (function.restrict f s) :=
 begin
   rw [continuous_on, continuous_iff_continuous_at], split,
   { rintros h ⟨x, xs⟩,
-    exact (continuous_at_within_iff_continuous_at_restrict f xs).mp (h x xs) },
+    exact (continuous_within_at_iff_continuous_at_restrict f xs).mp (h x xs) },
   intros h x xs,
-  exact (continuous_at_within_iff_continuous_at_restrict f xs).mpr (h ⟨x, xs⟩)
+  exact (continuous_within_at_iff_continuous_at_restrict f xs).mpr (h ⟨x, xs⟩)
 end
 
 theorem continuous_on_iff' {f : α → β} {s : set α} :
@@ -639,29 +639,29 @@ have ∀ t, is_open (function.restrict f s ⁻¹' t) ↔ ∃ (u : set α), is_op
   end,
 by rw [continuous_on_iff_continuous_restrict, continuous]; simp only [this]
 
-theorem nhds_within_le_comap {x : α} {s : set α} {f : α → β} (ctsf : continuous_at_within f x s) :
+theorem nhds_within_le_comap {x : α} {s : set α} {f : α → β} (ctsf : continuous_within_at f s x) :
   nhds_within x s ≤ comap f (nhds_within (f x) (f '' s)) :=
 map_le_iff_le_comap.1 ctsf.tendsto_nhds_within_image
 
-theorem continuous_at_within_iff_ptendsto_res (f : α → β) {x : α} {s : set α} (xs : x ∈ s) :
-  continuous_at_within f x s ↔ ptendsto (pfun.res f s) (nhds x) (nhds (f x)) :=
+theorem continuous_within_at_iff_ptendsto_res (f : α → β) {x : α} {s : set α} (xs : x ∈ s) :
+  continuous_within_at f s x ↔ ptendsto (pfun.res f s) (nhds x) (nhds (f x)) :=
 tendsto_iff_ptendsto _ _ _ _
 
 def continuous_iff_continuous_on_univ {f : α → β} : continuous f ↔ continuous_on f univ :=
-by simp [continuous_iff_continuous_at, continuous_on, continuous_at, continuous_at_within,
+by simp [continuous_iff_continuous_at, continuous_on, continuous_at, continuous_within_at,
          nhds_within_univ]
 
-lemma continuous_at_within.mono {f : α → β} {s t : set α} {x : α} (h : continuous_at_within f x t)
-  (hs : s ⊆ t) : continuous_at_within f x s :=
+lemma continuous_within_at.mono {f : α → β} {s t : set α} {x : α} (h : continuous_within_at f t x)
+  (hs : s ⊆ t) : continuous_within_at f s x :=
 tendsto_le_left (nhds_within_mono x hs) h
 
 lemma continuous_on.congr_mono {f g : α → β} {s s₁ : set α} (h : continuous_on f s)
   (h' : ∀x ∈ s₁, g x = f x) (h₁ : s₁ ⊆ s) : continuous_on g s₁ :=
 begin
   assume x hx,
-  unfold continuous_at_within,
+  unfold continuous_within_at,
   have A := (h x (h₁ hx)).mono h₁,
-  unfold continuous_at_within at A,
+  unfold continuous_within_at at A,
   rw ← h' x hx at A,
   have : {x : α | g x = f x} ∈ nhds_within x s₁ := mem_inf_sets_of_right h',
   apply tendsto.congr' _ A,
@@ -670,9 +670,9 @@ begin
   finish
 end
 
-lemma continuous_at.continuous_at_within {f : α → β} {s : set α} {x : α} (h : continuous_at f x) :
-  continuous_at_within f x s :=
-continuous_at_within.mono ((continuous_at_within_univ f x).2 h) (subset_univ _)
+lemma continuous_at.continuous_within_at {f : α → β} {s : set α} {x : α} (h : continuous_at f x) :
+  continuous_within_at f s x :=
+continuous_within_at.mono ((continuous_within_at_univ f x).2 h) (subset_univ _)
 
 lemma continuous_on.comp {f : α → β} {g : β → γ} {s : set α} {t : set β}
   (hf : continuous_on f s) (hg : continuous_on g t) (h : f '' s ⊆ t) :
@@ -726,7 +726,7 @@ begin
   assume x xs,
   rcases h x xs with ⟨t, open_t, xt, ct⟩,
   have := ct x ⟨xs, xt⟩,
-  rwa [continuous_at_within, ← nhds_within_restrict _ xt open_t] at this
+  rwa [continuous_within_at, ← nhds_within_restrict _ xt open_t] at this
 end
 
 end topα


### PR DESCRIPTION
Change `continuous_at_within` to `continuous_within_at`, for coherence with the order of arguments for derivatives, i.e., `differentiable_within_at` and `fderiv_within` (where, for the last one, it is important that the point comes last, to be able to use it easily as a function).