### PR TITLE
chore(opposites): merge two definitions of `opposite`

### DIFF
--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -5,22 +5,12 @@ Authors: Kenny Lau
 
 Opposites.
 -/
+import data.opposite
 
+namespace opposite
 universes u
 
 variables (α : Type u)
-
-def opposite : Type u := α
-
-namespace opposite
-variables {α}
-def op : α → opposite α := id
-def unop : opposite α → α := id
-theorem op_inj : function.injective (op : α → opposite α) := λ _ _, id
-theorem unop_inj : function.injective (unop : opposite α → α) := λ _ _, id
-theorem op_unop (x : opposite α) : op (unop x) = x := rfl
-theorem unop_op (x : α) : unop (op x) = x := rfl
-variables (α)
 
 instance [has_add α] : has_add (opposite α) :=
 { add := λ x y, op (unop x + unop y) }

--- a/src/category_theory/adjunction.lean
+++ b/src/category_theory/adjunction.lean
@@ -7,6 +7,8 @@ Authors: Reid Barton, Johan Commelin
 import category_theory.limits.preserves
 import category_theory.whiskering
 
+open opposite
+
 namespace category_theory
 open category
 open category_theory.limits

--- a/src/category_theory/const.lean
+++ b/src/category_theory/const.lean
@@ -22,6 +22,8 @@ def const : C ⥤ (J ⥤ C) :=
   map := λ X Y f, { app := λ j, f } }
 
 namespace const
+open opposite
+
 variables {J}
 
 @[simp] lemma obj_obj (X : C) (j : J) : ((const J).obj X).obj j = X := rfl

--- a/src/category_theory/discrete_category.lean
+++ b/src/category_theory/discrete_category.lean
@@ -63,6 +63,8 @@ omit 𝒞
 def lift {α : Type u₁} {β : Type u₂} (f : α → β) : (discrete α) ⥤ (discrete β) :=
 functor.of_function f
 
+open opposite
+
 protected def opposite (α : Type u₁) : (discrete α)ᵒᵖ ≌ discrete α :=
 let F : discrete α ⥤ (discrete α)ᵒᵖ := functor.of_function (λ x, op x) in
 begin

--- a/src/category_theory/eq_to_hom.lean
+++ b/src/category_theory/eq_to_hom.lean
@@ -9,6 +9,7 @@ import category_theory.opposites
 universes v v' u u' -- declare the `v`'s first; see `category_theory.category` for an explanation
 
 namespace category_theory
+open opposite
 
 variables {C : Sort u} [𝒞 : category.{v} C]
 include 𝒞

--- a/src/category_theory/instances/Top/open_nhds.lean
+++ b/src/category_theory/instances/Top/open_nhds.lean
@@ -8,6 +8,7 @@ import category_theory.full_subcategory
 open category_theory
 open category_theory.instances
 open topological_space
+open opposite
 
 universe u
 

--- a/src/category_theory/instances/Top/opens.lean
+++ b/src/category_theory/instances/Top/opens.lean
@@ -14,7 +14,7 @@ open topological_space
 
 universe u
 
-open category_theory.instances
+open category_theory.instances opposite
 
 namespace topological_space.opens
 

--- a/src/category_theory/instances/Top/presheaf.lean
+++ b/src/category_theory/instances/Top/presheaf.lean
@@ -10,6 +10,7 @@ universes v u
 open category_theory
 open category_theory.instances
 open topological_space
+open opposite
 
 variables (C : Type u) [𝒞 : category.{v+1} C]
 include 𝒞

--- a/src/category_theory/instances/Top/presheaf_of_functions.lean
+++ b/src/category_theory/instances/Top/presheaf_of_functions.lean
@@ -9,6 +9,7 @@ universes v u
 open category_theory
 open category_theory.instances
 open topological_space
+open opposite
 
 namespace category_theory.instances.Top
 

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -23,6 +23,7 @@ include 𝒞
 open category_theory
 open category_theory.category
 open category_theory.functor
+open opposite
 
 namespace category_theory
 

--- a/src/category_theory/limits/limits.lean
+++ b/src/category_theory/limits/limits.lean
@@ -7,7 +7,7 @@ import category_theory.yoneda
 import category_theory.limits.cones
 import category_theory.eq_to_hom
 
-open category_theory category_theory.category category_theory.functor
+open category_theory category_theory.category category_theory.functor opposite
 
 namespace category_theory.limits
 

--- a/src/category_theory/limits/opposites.lean
+++ b/src/category_theory/limits/opposites.lean
@@ -8,6 +8,7 @@ universes v u
 
 open category_theory
 open category_theory.functor
+open opposite
 
 namespace category_theory.limits
 

--- a/src/category_theory/opposites.lean
+++ b/src/category_theory/opposites.lean
@@ -5,73 +5,12 @@
 import category_theory.products
 import category_theory.types
 import category_theory.natural_isomorphism
+import data.opposite
 
 universes v₁ v₂ u₁ u₂ -- declare the `v`'s first; see `category_theory.category` for an explanation
 
 namespace category_theory
-
-/-- The type of objects of the opposite of C (which should be a category).
-
-  In order to avoid confusion between C and its opposite category, we
-  set up the type of objects `opposite C` using the following pattern,
-  which will be repeated later for the morphisms.
-
-  1. Define `opposite C := C`.
-  2. Define the isomorphisms `op : C → opposite C`, `unop : opposite C → C`.
-  3. Make the definition `opposite` irreducible.
-
-  This has the following consequences.
-
-  * `opposite C` and `C` are distinct types in the elaborator, so you
-    must use `op` and `unop` explicitly to convert between them.
-  * Both `unop (op X) = X` and `op (unop X) = X` are definitional
-    equalities. Notably, every object of the opposite category is
-    definitionally of the form `op X`, which greatly simplifies the
-    definition of the structure of the opposite category, for example.
-
-  (If Lean supported definitional eta equality for records, we could
-  achieve the same goals using a structure with one field.)
--/
-def opposite (C : Sort u₁) : Sort u₁ := C
-
--- Use a high right binding power (like that of postfix ⁻¹) so that, for example,
--- `presheaf Cᵒᵖ` parses as `presheaf (Cᵒᵖ)` and not `(presheaf C)ᵒᵖ`.
-notation C `ᵒᵖ`:std.prec.max_plus := opposite C
-
-variables {C : Sort u₁}
-
-def op (X : C) : Cᵒᵖ := X
-def unop (X : Cᵒᵖ) : C := X
-
-attribute [irreducible] opposite
-
-@[simp] lemma unop_op (X : C) : unop (op X) = X := rfl
-@[simp] lemma op_unop (X : Cᵒᵖ) : op (unop X) = X := rfl
-
-lemma op_inj : function.injective (@op C) :=
-by { rintros _ _ ⟨ ⟩, refl }
-lemma unop_inj : function.injective (@unop C) :=
-by { rintros _ _ ⟨ ⟩, refl }
-
-def op_induction {F : Π (X : Cᵒᵖ), Sort v₁} (h : Π X, F (op X)) : Π X, F X :=
-λ X, h (unop X)
-
-end category_theory
-
-namespace tactic.interactive
-
-open interactive interactive.types lean.parser tactic
-
-meta def op_induction (h : parse ident) : tactic unit :=
-do h' ← tactic.get_local h,
-   revert_lst [h'],
-   applyc `category_theory.op_induction,
-   tactic.intro h,
-   skip
-
-end tactic.interactive
-
-namespace category_theory
+open opposite
 
 variables {C : Sort u₁}
 

--- a/src/category_theory/yoneda.lean
+++ b/src/category_theory/yoneda.lean
@@ -14,6 +14,7 @@ import category_theory.fully_faithful
 import category_theory.natural_isomorphism
 
 namespace category_theory
+open opposite
 
 universes v₁ u₁ u₂ -- declare the `v`'s first; see `category_theory.category` for an explanation
 
@@ -98,6 +99,8 @@ namespace category_theory
 -- for both objects and morphisms
 
 universes v₁ u₁ u₂ -- declare the `v`'s first; see `category_theory.category` for an explanation
+
+open opposite
 
 variables (C : Type u₁) [𝒞 : category.{v₁+1} C]
 include 𝒞

--- a/src/data/opposite.lean
+++ b/src/data/opposite.lean
@@ -67,5 +67,3 @@ do h' ← tactic.get_local h,
    skip
 
 end tactic.interactive
-
-

--- a/src/data/opposite.lean
+++ b/src/data/opposite.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2018 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison, Reid Barton, Simon Hudon, Kenny Lau
+
+Opposites.
+-/
+
+namespace opposite
+universes v u -- declare the `v` first; see `category_theory.category` for an explanation
+variable (α : Sort u)
+
+/-- The type of objects of the opposite of `α`; used to defined opposite category/group/...
+
+  In order to avoid confusion between `α` and its opposite type, we
+  set up the type of objects `opposite α` using the following pattern,
+  which will be repeated later for the morphisms.
+
+  1. Define `opposite α := α`.
+  2. Define the isomorphisms `op : α → opposite α`, `unop : opposite α → α`.
+  3. Make the definition `opposite` irreducible.
+
+  This has the following consequences.
+
+  * `opposite α` and `α` are distinct types in the elaborator, so you
+    must use `op` and `unop` explicitly to convert between them.
+  * Both `unop (op X) = X` and `op (unop X) = X` are definitional
+    equalities. Notably, every object of the opposite category is
+    definitionally of the form `op X`, which greatly simplifies the
+    definition of the structure of the opposite category, for example.
+
+  (If Lean supported definitional eta equality for records, we could
+  achieve the same goals using a structure with one field.)
+-/
+def opposite : Sort u := α
+
+-- Use a high right binding power (like that of postfix ⁻¹) so that, for example,
+-- `presheaf Cᵒᵖ` parses as `presheaf (Cᵒᵖ)` and not `(presheaf C)ᵒᵖ`.
+notation α `ᵒᵖ`:std.prec.max_plus := opposite α
+
+variables {α}
+
+def op : α → αᵒᵖ := id
+def unop : αᵒᵖ → α := id
+
+lemma op_inj : function.injective (op : α → αᵒᵖ) := λ _ _, id
+lemma unop_inj : function.injective (unop : αᵒᵖ → α) := λ _ _, id
+
+@[simp] lemma op_unop (x : αᵒᵖ) : op (unop x) = x := rfl
+@[simp] lemma unop_op (x : α) : unop (op x) = x := rfl
+
+attribute [irreducible] opposite
+
+def op_induction {F : Π (X : αᵒᵖ), Sort v} (h : Π X, F (op X)) : Π X, F X :=
+λ X, h (unop X)
+end opposite
+
+namespace tactic.interactive
+
+open interactive interactive.types lean.parser tactic
+
+meta def op_induction (h : parse ident) : tactic unit :=
+do h' ← tactic.get_local h,
+   revert_lst [h'],
+   applyc `opposite.op_induction,
+   tactic.intro h,
+   skip
+
+end tactic.interactive
+
+


### PR DESCRIPTION
 merge `opposite.opposite` from `algebra/opposites` with
  `category_theory.opposite` from `category_theory/opposites`, and put
  it into `data/opposite`

* main reasons: DRY, avoid confusion (especially for new users like me) if both namespaces are open;

* see #538, comment https://github.com/leanprover-community/mathlib/pull/538#issuecomment-459488227

* Authors merged from `git blame` output on both original files;
  I assume my contribution to be trivial

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
