### PR TITLE
feat(category_theory/equivalence): make definition of adjointify_η easier to elaborate

### DIFF
--- a/src/category_theory/equivalence.lean
+++ b/src/category_theory/equivalence.lean
@@ -120,8 +120,14 @@ section
 variables {F : C ⥤ D} {G : D ⥤ C} (η : 𝟭 C ≅ F ⋙ G) (ε : G ⋙ F ≅ 𝟭 D)
 
 def adjointify_η : 𝟭 C ≅ F ⋙ G :=
-η ≪≫ iso_whisker_left F ((left_unitor G).symm ≪≫
-  iso_whisker_right ε.symm G) ≪≫ iso_whisker_right η.symm (F ⋙ G)
+calc
+  𝟭 C ≅ F ⋙ G               : η
+  ... ≅ F ⋙ (𝟭 D ⋙ G)      : iso_whisker_left F (left_unitor G).symm
+  ... ≅ F ⋙ ((G ⋙ F) ⋙ G) : iso_whisker_left F (iso_whisker_right ε.symm G)
+  ... ≅ F ⋙ (G ⋙ (F ⋙ G)) : iso_whisker_left F (associator G F G)
+  ... ≅ (F ⋙ G) ⋙ (F ⋙ G) : (associator F G (F ⋙ G)).symm
+  ... ≅ 𝟭 C ⋙ (F ⋙ G)      : iso_whisker_right η.symm (F ⋙ G)
+  ... ≅ F ⋙ G               : left_unitor (F ⋙ G)
 
 lemma adjointify_η_ε (X : C) :
   F.map ((adjointify_η η ε).hom.app X) ≫ ε.hom.app (F.obj X) = 𝟙 (F.obj X) :=


### PR DESCRIPTION
Make the definition `adjointify_η` T50000-challenge-compliant (it's also T10000-compliant).

There were enough simp lemmas that this didn't even break the proof of `adjointify_η_ε`.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
