### PR TITLE
chore(CommRing/adjunctions): refactor proofs

### DIFF
--- a/src/category_theory/adjunction/basic.lean
+++ b/src/category_theory/adjunction/basic.lean
@@ -3,15 +3,11 @@ Copyright (c) 2019 Reid Barton. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Reid Barton, Johan Commelin
 -/
-
-import category_theory.limits.preserves
-import category_theory.whiskering
-
-open opposite
+import category_theory.equivalence
+import data.equiv.basic
 
 namespace category_theory
 open category
-open category_theory.limits
 
 universes v₁ v₂ v₃ u₁ u₂ u₃ -- declare the `v`'s first; see `category_theory.category` for an explanation
 
@@ -272,131 +268,3 @@ end equivalence
 end adjunction
 
 end category_theory
-
-namespace category_theory.adjunction
-open category_theory
-open category_theory.functor
-open category_theory.limits
-
-universes u₁ u₂ v
-
-variables {C : Sort u₁} [𝒞 : category.{v+1} C] {D : Sort u₂} [𝒟 : category.{v+1} D]
-include 𝒞 𝒟
-
-variables {F : C ⥤ D} {G : D ⥤ C} (adj : F ⊣ G)
-include adj
-
-section preservation_colimits
-variables {J : Type v} [small_category J] (K : J ⥤ C)
-
-def functoriality_is_left_adjoint :
-  is_left_adjoint (@cocones.functoriality _ _ _ _ K _ _ F) :=
-{ right := (cocones.functoriality G) ⋙ (cocones.precompose
-    (K.right_unitor.inv ≫ (whisker_left K adj.unit) ≫ (associator _ _ _).inv)),
-  adj := mk_of_unit_counit
-  { unit :=
-    { app := λ c,
-      { hom := adj.unit.app c.X,
-        w' := λ j, by have := adj.unit.naturality (c.ι.app j); tidy },
-      naturality' := λ _ _ f, by have := adj.unit.naturality (f.hom); tidy },
-    counit :=
-    { app := λ c,
-      { hom := adj.counit.app c.X,
-        w' :=
-        begin
-          intro j,
-          dsimp,
-          erw [category.comp_id, category.id_comp, F.map_comp, category.assoc,
-            adj.counit.naturality (c.ι.app j), ← category.assoc,
-            adj.left_triangle_components, category.id_comp],
-          refl,
-        end },
-      naturality' := λ _ _ f, by have := adj.counit.naturality (f.hom); tidy } } }
-
-/-- A left adjoint preserves colimits. -/
-def left_adjoint_preserves_colimits : preserves_colimits F :=
-{ preserves_colimits_of_shape := λ J 𝒥,
-  { preserves_colimit := λ F,
-    by resetI; exact
-    { preserves := λ c hc, is_colimit_iso_unique_cocone_morphism.inv
-        (λ s, (((adj.functoriality_is_left_adjoint _).adj).hom_equiv _ _).unique_of_equiv $
-          is_colimit_iso_unique_cocone_morphism.hom hc _ ) } } }
-
-end preservation_colimits
-
-section preservation_limits
-variables {J : Type v} [small_category J] (K : J ⥤ D)
-
-def functoriality_is_right_adjoint :
-  is_right_adjoint (@cones.functoriality _ _ _ _ K _ _ G) :=
-{ left := (cones.functoriality F) ⋙ (cones.postcompose
-    ((associator _ _ _).hom ≫ (whisker_left K adj.counit) ≫ K.right_unitor.hom)),
-  adj := mk_of_unit_counit
-  { unit :=
-    { app := λ c,
-      { hom := adj.unit.app c.X,
-        w' :=
-        begin
-          intro j,
-          dsimp,
-          erw [category.comp_id, category.id_comp, G.map_comp, ← category.assoc,
-            ← adj.unit.naturality (c.π.app j), category.assoc,
-            adj.right_triangle_components, category.comp_id],
-          refl,
-        end },
-      naturality' := λ _ _ f, by have := adj.unit.naturality (f.hom); tidy },
-    counit :=
-    { app := λ c,
-      { hom := adj.counit.app c.X,
-        w' := λ j, by have := adj.counit.naturality (c.π.app j); tidy },
-      naturality' := λ _ _ f, by have := adj.counit.naturality (f.hom); tidy } } }
-
-/-- A right adjoint preserves limits. -/
-def right_adjoint_preserves_limits : preserves_limits G :=
-{ preserves_limits_of_shape := λ J 𝒥,
-  { preserves_limit := λ K,
-    by resetI; exact
-    { preserves := λ c hc, is_limit_iso_unique_cone_morphism.inv
-        (λ s, (((adj.functoriality_is_right_adjoint _).adj).hom_equiv _ _).symm.unique_of_equiv $
-          is_limit_iso_unique_cone_morphism.hom hc _) } } }
-
-end preservation_limits
-
--- Note: this is natural in K, but we do not yet have the tools to formulate that.
-def cocones_iso {J : Type v} [small_category J] {K : J ⥤ C} :
-  (cocones J D).obj (op (K ⋙ F)) ≅ G ⋙ ((cocones J C).obj (op K)) :=
-nat_iso.of_components (λ Y,
-{ hom := λ t,
-    { app := λ j, (adj.hom_equiv (K.obj j) Y) (t.app j),
-      naturality' := λ j j' f, by erw [← adj.hom_equiv_naturality_left, t.naturality]; dsimp; simp },
-  inv := λ t,
-    { app := λ j, (adj.hom_equiv (K.obj j) Y).symm (t.app j),
-      naturality' := λ j j' f, begin
-        erw [← adj.hom_equiv_naturality_left_symm, ← adj.hom_equiv_naturality_right_symm, t.naturality],
-        dsimp, simp
-      end } } )
-begin
-  intros Y₁ Y₂ f,
-  ext1 t,
-  ext1 j,
-  apply adj.hom_equiv_naturality_right
-end
-
--- Note: this is natural in K, but we do not yet have the tools to formulate that.
-def cones_iso {J : Type v} [small_category J] {K : J ⥤ D} :
-  F.op ⋙ ((cones J D).obj K) ≅ (cones J C).obj (K ⋙ G) :=
-nat_iso.of_components (λ X,
-{ hom := λ t,
-  { app := λ j, (adj.hom_equiv (unop X) (K.obj j)) (t.app j),
-    naturality' := λ j j' f, begin
-      erw [← adj.hom_equiv_naturality_right, ← t.naturality, category.id_comp, category.id_comp],
-      refl
-    end },
-  inv := λ t,
-  { app := λ j, (adj.hom_equiv (unop X) (K.obj j)).symm (t.app j),
-    naturality' := λ j j' f, begin
-      erw [← adj.hom_equiv_naturality_right_symm, ← t.naturality, category.id_comp, category.id_comp]
-    end } } )
-(by tidy)
-
-end category_theory.adjunction

--- a/src/category_theory/adjunction/default.lean
+++ b/src/category_theory/adjunction/default.lean
@@ -1,0 +1,1 @@
+import category_theory.adjunction.limits

--- a/src/category_theory/adjunction/limits.lean
+++ b/src/category_theory/adjunction/limits.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2019 Reid Barton. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Reid Barton, Johan Commelin
+-/
+import category_theory.adjunction.basic
+import category_theory.limits.preserves
+
+open opposite
+
+namespace category_theory.adjunction
+open category_theory
+open category_theory.functor
+open category_theory.limits
+
+universes u₁ u₂ v
+
+variables {C : Sort u₁} [𝒞 : category.{v+1} C] {D : Sort u₂} [𝒟 : category.{v+1} D]
+include 𝒞 𝒟
+
+variables {F : C ⥤ D} {G : D ⥤ C} (adj : F ⊣ G)
+include adj
+
+section preservation_colimits
+variables {J : Type v} [small_category J] (K : J ⥤ C)
+
+def functoriality_is_left_adjoint :
+  is_left_adjoint (@cocones.functoriality _ _ _ _ K _ _ F) :=
+{ right := (cocones.functoriality G) ⋙ (cocones.precompose
+    (K.right_unitor.inv ≫ (whisker_left K adj.unit) ≫ (associator _ _ _).inv)),
+  adj := mk_of_unit_counit
+  { unit :=
+    { app := λ c,
+      { hom := adj.unit.app c.X,
+        w' := λ j, by have := adj.unit.naturality (c.ι.app j); tidy },
+      naturality' := λ _ _ f, by have := adj.unit.naturality (f.hom); tidy },
+    counit :=
+    { app := λ c,
+      { hom := adj.counit.app c.X,
+        w' :=
+        begin
+          intro j,
+          dsimp,
+          erw [category.comp_id, category.id_comp, F.map_comp, category.assoc,
+            adj.counit.naturality (c.ι.app j), ← category.assoc,
+            adj.left_triangle_components, category.id_comp],
+          refl,
+        end },
+      naturality' := λ _ _ f, by have := adj.counit.naturality (f.hom); tidy } } }
+
+/-- A left adjoint preserves colimits. -/
+def left_adjoint_preserves_colimits : preserves_colimits F :=
+{ preserves_colimits_of_shape := λ J 𝒥,
+  { preserves_colimit := λ F,
+    by resetI; exact
+    { preserves := λ c hc, is_colimit_iso_unique_cocone_morphism.inv
+        (λ s, (((adj.functoriality_is_left_adjoint _).adj).hom_equiv _ _).unique_of_equiv $
+          is_colimit_iso_unique_cocone_morphism.hom hc _ ) } } }
+
+end preservation_colimits
+
+section preservation_limits
+variables {J : Type v} [small_category J] (K : J ⥤ D)
+
+def functoriality_is_right_adjoint :
+  is_right_adjoint (@cones.functoriality _ _ _ _ K _ _ G) :=
+{ left := (cones.functoriality F) ⋙ (cones.postcompose
+    ((associator _ _ _).hom ≫ (whisker_left K adj.counit) ≫ K.right_unitor.hom)),
+  adj := mk_of_unit_counit
+  { unit :=
+    { app := λ c,
+      { hom := adj.unit.app c.X,
+        w' :=
+        begin
+          intro j,
+          dsimp,
+          erw [category.comp_id, category.id_comp, G.map_comp, ← category.assoc,
+            ← adj.unit.naturality (c.π.app j), category.assoc,
+            adj.right_triangle_components, category.comp_id],
+          refl,
+        end },
+      naturality' := λ _ _ f, by have := adj.unit.naturality (f.hom); tidy },
+    counit :=
+    { app := λ c,
+      { hom := adj.counit.app c.X,
+        w' := λ j, by have := adj.counit.naturality (c.π.app j); tidy },
+      naturality' := λ _ _ f, by have := adj.counit.naturality (f.hom); tidy } } }
+
+/-- A right adjoint preserves limits. -/
+def right_adjoint_preserves_limits : preserves_limits G :=
+{ preserves_limits_of_shape := λ J 𝒥,
+  { preserves_limit := λ K,
+    by resetI; exact
+    { preserves := λ c hc, is_limit_iso_unique_cone_morphism.inv
+        (λ s, (((adj.functoriality_is_right_adjoint _).adj).hom_equiv _ _).symm.unique_of_equiv $
+          is_limit_iso_unique_cone_morphism.hom hc _) } } }
+
+end preservation_limits
+
+-- Note: this is natural in K, but we do not yet have the tools to formulate that.
+def cocones_iso {J : Type v} [small_category J] {K : J ⥤ C} :
+  (cocones J D).obj (op (K ⋙ F)) ≅ G ⋙ ((cocones J C).obj (op K)) :=
+nat_iso.of_components (λ Y,
+{ hom := λ t,
+    { app := λ j, (adj.hom_equiv (K.obj j) Y) (t.app j),
+      naturality' := λ j j' f, by erw [← adj.hom_equiv_naturality_left, t.naturality]; dsimp; simp },
+  inv := λ t,
+    { app := λ j, (adj.hom_equiv (K.obj j) Y).symm (t.app j),
+      naturality' := λ j j' f, begin
+        erw [← adj.hom_equiv_naturality_left_symm, ← adj.hom_equiv_naturality_right_symm, t.naturality],
+        dsimp, simp
+      end } } )
+begin
+  intros Y₁ Y₂ f,
+  ext1 t,
+  ext1 j,
+  apply adj.hom_equiv_naturality_right
+end
+
+-- Note: this is natural in K, but we do not yet have the tools to formulate that.
+def cones_iso {J : Type v} [small_category J] {K : J ⥤ D} :
+  F.op ⋙ ((cones J D).obj K) ≅ (cones J C).obj (K ⋙ G) :=
+nat_iso.of_components (λ X,
+{ hom := λ t,
+  { app := λ j, (adj.hom_equiv (unop X) (K.obj j)) (t.app j),
+    naturality' := λ j j' f, begin
+      erw [← adj.hom_equiv_naturality_right, ← t.naturality, category.id_comp, category.id_comp],
+      refl
+    end },
+  inv := λ t,
+  { app := λ j, (adj.hom_equiv (unop X) (K.obj j)).symm (t.app j),
+    naturality' := λ j j' f, begin
+      erw [← adj.hom_equiv_naturality_right_symm, ← t.naturality, category.id_comp, category.id_comp]
+    end } } )
+(by tidy)
+
+end category_theory.adjunction

--- a/src/category_theory/epi_mono.lean
+++ b/src/category_theory/epi_mono.lean
@@ -9,7 +9,7 @@ The definitions of `epi` and `mono` are in `category_theory.category`,
 since they are used by some lemmas for `iso`, which is used everywhere.
 -/
 
-import category_theory.adjunction
+import category_theory.adjunction.basic
 import category_theory.fully_faithful
 
 universes v₁ v₂ u₁ u₂

--- a/src/category_theory/instances/CommRing/adjunctions.lean
+++ b/src/category_theory/instances/CommRing/adjunctions.lean
@@ -30,14 +30,15 @@ noncomputable def polynomial_ring : Type u ⥤ CommRing.{u} :=
 @[simp] lemma polynomial_ring_map_val {α β : Type u} {f : α → β} :
   (polynomial_ring.map f).val = rename f := rfl
 
-noncomputable def adj : polynomial_ring ⊣ (forget : CommRing ⥤ Type u) :=
+noncomputable def adj : polynomial_ring ⊣ (forget : CommRing.{u} ⥤ Type u) :=
 adjunction.mk_of_hom_equiv
 { hom_equiv := λ α R,
   { to_fun    := λ f, f ∘ X,
     inv_fun   := λ f, ⟨eval₂ (λ n : ℤ, (n : R)) f, by { unfold_coes, apply_instance }⟩,
-    left_inv  := λ f, CommRing.hom.ext (eval₂_hom_X f.val),
+    left_inv  := λ f, CommRing.hom.ext $ @eval₂_hom_X _ _ _ _ _ _ f _,
     right_inv := λ x, by { ext1, unfold_coes, simp only [function.comp_app, eval₂_X] } },
   hom_equiv_naturality_left_symm' :=
-  λ X X' Y f g, by { ext1, dsimp, apply eval₂_cast_comp } }.
+  λ X X' Y f g, by { ext1, dsimp, apply eval₂_cast_comp }
+}.
 
 end category_theory.instances.CommRing

--- a/src/category_theory/instances/CommRing/adjunctions.lean
+++ b/src/category_theory/instances/CommRing/adjunctions.lean
@@ -7,7 +7,7 @@ forgetful functor from commutative rings to types.
 -/
 
 import category_theory.instances.CommRing.basic
-import category_theory.adjunction
+import category_theory.adjunction.basic
 import data.mv_polynomial
 
 universe u
@@ -22,12 +22,12 @@ local attribute [instance, priority 0] subtype.fintype set_fintype classical.pro
 
 noncomputable def polynomial_ring : Type u ⥤ CommRing.{u} :=
 { obj := λ α, ⟨mv_polynomial α ℤ, by apply_instance⟩,
-  map := λ α β f, ⟨eval₂ C (X ∘ f), by apply_instance⟩,
+  map := λ α β f, ⟨eval₂ C (X ∘ f), by apply_instance⟩, -- TODO should use `rename f` here.
   map_id' := λ α, subtype.ext.mpr $ funext $ eval₂_eta,
   map_comp' := λ α β γ f g, subtype.ext.mpr $ funext $ λ p,
-  by apply mv_polynomial.induction_on p; intros;
+  by { apply mv_polynomial.induction_on p; intros;
     simp only [*, eval₂_add, eval₂_mul, eval₂_C, eval₂_X, comp_val,
-      eq_self_iff_true, function.comp_app, types_comp] at * }
+      function.comp_app, types_comp] at * } }
 
 @[simp] lemma polynomial_ring_obj_α {α : Type u} :
   (polynomial_ring.obj α).α = mv_polynomial α ℤ := rfl

--- a/src/category_theory/instances/CommRing/adjunctions.lean
+++ b/src/category_theory/instances/CommRing/adjunctions.lean
@@ -18,48 +18,26 @@ open category_theory.instances
 
 namespace category_theory.instances.CommRing
 
-local attribute [instance, priority 0] subtype.fintype set_fintype classical.prop_decidable
+local attribute [instance, priority 0] classical.prop_decidable
 
 noncomputable def polynomial_ring : Type u ⥤ CommRing.{u} :=
 { obj := λ α, ⟨mv_polynomial α ℤ, by apply_instance⟩,
-  map := λ α β f, ⟨eval₂ C (X ∘ f), by apply_instance⟩, -- TODO should use `rename f` here.
-  map_id' := λ α, subtype.ext.mpr $ funext $ eval₂_eta,
-  map_comp' := λ α β γ f g, subtype.ext.mpr $ funext $ λ p,
-  by { apply mv_polynomial.induction_on p; intros;
-    simp only [*, eval₂_add, eval₂_mul, eval₂_C, eval₂_X, comp_val,
-      function.comp_app, types_comp] at * } }
+  map := λ α β f, ⟨rename f, by apply_instance⟩ }
 
 @[simp] lemma polynomial_ring_obj_α {α : Type u} :
   (polynomial_ring.obj α).α = mv_polynomial α ℤ := rfl
 
 @[simp] lemma polynomial_ring_map_val {α β : Type u} {f : α → β} :
-  (polynomial_ring.map f).val = eval₂ C (X ∘ f) := rfl
-
-lemma hom_coe_app' {R S : CommRing} (f : R ⟶ S) (r : R) : f r = f.val r := rfl
--- this is usually a bad idea, as it forgets that `f` is ring homomorphism
-local attribute [simp] hom_coe_app'
+  (polynomial_ring.map f).val = rename f := rfl
 
 noncomputable def adj : polynomial_ring ⊣ (forget : CommRing ⥤ Type u) :=
 adjunction.mk_of_hom_equiv
 { hom_equiv := λ α R,
   { to_fun := λ f, f ∘ X,
     inv_fun := λ f, ⟨eval₂ int.cast f, by apply_instance⟩,
-    left_inv := λ f, subtype.ext.mpr $ funext $ λ p,
-    begin
-      have H0 := λ n, (congr (int.eq_cast' (f.val ∘ C)) (rfl : n = n)).symm,
-      have H1 := λ p₁ p₂, (@is_ring_hom.map_add _ _ _ _ f.val f.2 p₁ p₂).symm,
-      have H2 := λ p₁ p₂, (@is_ring_hom.map_mul _ _ _ _ f.val f.2 p₁ p₂).symm,
-      apply mv_polynomial.induction_on p; intros;
-      simp only [*, eval₂_add, eval₂_mul, eval₂_C, eval₂_X,
-        eq_self_iff_true, function.comp_app, hom_coe_app'] at *
-    end,
-    right_inv := by tidy },
-  hom_equiv_naturality_left_symm' := λ X' X Y f g, subtype.ext.mpr $ funext $ λ p,
-  begin
-    apply mv_polynomial.induction_on p; intros;
-    simp only [*, eval₂_mul, eval₂_add, eval₂_C, eval₂_X,
-      comp_val, equiv.coe_fn_symm_mk, hom_coe_app, polynomial_ring_map_val,
-      eq_self_iff_true, function.comp_app, add_right_inj, types_comp] at *
-  end }
+    left_inv := λ f, CommRing.hom.ext (eval₂_hom_X f.val),
+    right_inv := λ x, by { ext1, unfold_coes, simp only [function.comp_app, eval₂_X] } },
+  hom_equiv_naturality_left_symm' :=
+  λ X X' Y f g, by { ext1, dsimp, apply eval₂_cast_comp } }.
 
 end category_theory.instances.CommRing

--- a/src/category_theory/instances/CommRing/adjunctions.lean
+++ b/src/category_theory/instances/CommRing/adjunctions.lean
@@ -33,9 +33,9 @@ noncomputable def polynomial_ring : Type u ⥤ CommRing.{u} :=
 noncomputable def adj : polynomial_ring ⊣ (forget : CommRing ⥤ Type u) :=
 adjunction.mk_of_hom_equiv
 { hom_equiv := λ α R,
-  { to_fun := λ f, f ∘ X,
-    inv_fun := λ f, ⟨eval₂ int.cast f, by apply_instance⟩,
-    left_inv := λ f, CommRing.hom.ext (eval₂_hom_X f.val),
+  { to_fun    := λ f, f ∘ X,
+    inv_fun   := λ f, ⟨eval₂ (λ n : ℤ, (n : R)) f, by { unfold_coes, apply_instance }⟩,
+    left_inv  := λ f, CommRing.hom.ext (eval₂_hom_X f.val),
     right_inv := λ x, by { ext1, unfold_coes, simp only [function.comp_app, eval₂_X] } },
   hom_equiv_naturality_left_symm' :=
   λ X X' Y f g, by { ext1, dsimp, apply eval₂_cast_comp } }.

--- a/src/category_theory/instances/CommRing/basic.lean
+++ b/src/category_theory/instances/CommRing/basic.lean
@@ -63,9 +63,6 @@ def Int : CommRing := ⟨ℤ, infer_instance⟩
 
 def Int.cast {R : CommRing} : Int ⟶ R := { val := int.cast, property := by apply_instance }
 
-def int.eq_cast' {R : Type u} [ring R] (f : int → R) [is_ring_hom f] : f = int.cast :=
-funext $ int.eq_cast f (is_ring_hom.map_one f) (λ _ _, is_ring_hom.map_add f)
-
 def Int.hom_unique {R : CommRing} : unique (Int ⟶ R) :=
 { default := Int.cast,
   uniq := λ f, subtype.ext.mpr $ funext $ int.eq_cast f f.2.map_one f.2.map_add }

--- a/src/category_theory/instances/Top/adjunctions.lean
+++ b/src/category_theory/instances/Top/adjunctions.lean
@@ -3,7 +3,7 @@
 -- Authors: Patrick Massot, Mario Carneiro
 
 import category_theory.instances.Top.basic
-import category_theory.adjunction
+import category_theory.adjunction.basic
 
 universe u
 

--- a/src/category_theory/types.lean
+++ b/src/category_theory/types.lean
@@ -18,8 +18,6 @@ instance types : large_category (Sort u) :=
 @[simp] lemma types_hom {α β : Sort u} : (α ⟶ β) = (α → β) := rfl
 @[simp] lemma types_id (X : Sort u) : 𝟙 X = id := rfl
 @[simp] lemma types_comp {X Y Z : Sort u} (f : X ⟶ Y) (g : Y ⟶ Z) : f ≫ g = g ∘ f := rfl
--- @[simp] lemma types_id {α : Sort u} (a : α) : (𝟙 α : α → α) a = a := rfl
--- @[simp] lemma types_comp {α β γ : Sort u} (f : α → β) (g : β → γ) (a : α) : (((f : α ⟶ β) ≫ (g : β ⟶ γ)) : α ⟶ γ) a = g (f a) := rfl
 
 namespace functor_to_types
 variables {C : Sort u} [𝒞 : category.{v} C] (F G H : C ⥤ Sort w) {X Y Z : C}

--- a/src/category_theory/types.lean
+++ b/src/category_theory/types.lean
@@ -16,8 +16,10 @@ instance types : large_category (Sort u) :=
   comp    := λ _ _ _ f g, g ∘ f }
 
 @[simp] lemma types_hom {α β : Sort u} : (α ⟶ β) = (α → β) := rfl
-@[simp] lemma types_id {α : Sort u} (a : α) : (𝟙 α : α → α) a = a := rfl
-@[simp] lemma types_comp {α β γ : Sort u} (f : α → β) (g : β → γ) (a : α) : (((f : α ⟶ β) ≫ (g : β ⟶ γ)) : α ⟶ γ) a = g (f a) := rfl
+@[simp] lemma types_id (X : Sort u) : 𝟙 X = id := rfl
+@[simp] lemma types_comp {X Y Z : Sort u} (f : X ⟶ Y) (g : Y ⟶ Z) : f ≫ g = g ∘ f := rfl
+-- @[simp] lemma types_id {α : Sort u} (a : α) : (𝟙 α : α → α) a = a := rfl
+-- @[simp] lemma types_comp {α β γ : Sort u} (f : α → β) (g : β → γ) (a : α) : (((f : α ⟶ β) ≫ (g : β ⟶ γ)) : α ⟶ γ) a = g (f a) := rfl
 
 namespace functor_to_types
 variables {C : Sort u} [𝒞 : category.{v} C] (F G H : C ⥤ Sort w) {X Y Z : C}

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1165,6 +1165,9 @@ begin
       Hadd, show f (n+1) = n+1, from H (n+1)]
 end
 
+lemma eq_cast' [ring α] (f : ℤ → α) [is_ring_hom f] : f = int.cast :=
+funext $ int.eq_cast f (is_ring_hom.map_one f) (λ _ _, is_ring_hom.map_add f)
+
 @[simp, squash_cast] theorem cast_id (n : ℤ) : ↑n = n :=
 (eq_cast id rfl (λ _ _, rfl) n).symm
 

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1119,6 +1119,8 @@ instance cast.is_ring_hom [ring α] :
   is_ring_hom (int.cast : ℤ → α) :=
 ⟨cast_one, cast_mul, cast_add⟩
 
+instance coe.is_ring_hom [ring α] : is_ring_hom (coe : ℤ → α) := cast.is_ring_hom
+
 theorem mul_cast_comm [ring α] (a : α) (n : ℤ) : a * n = n * a :=
 by cases n; simp [nat.mul_cast_comm, left_distrib, right_distrib, *]
 

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -534,9 +534,9 @@ congr_fun (int.eq_cast' (f ∘ C)) n
 @[simp] lemma eval₂_hom_X {α : Type u} [decidable_eq α] (f : mv_polynomial α ℤ → β) [is_ring_hom f]
   (x : mv_polynomial α ℤ) : eval₂ (λ n : ℤ, (n : β)) (f ∘ X) x = f x :=
 mv_polynomial.induction_on x
-(λ n, by { rw [hom_C f], /- deterministic timeout: -/ rw [eval₂_C], })
-(λ p q hp hq, by { sorry /- rw [eval₂_add, hp, hq], exact (is_ring_hom.map_add f).symm }) -/})
-(λ p n hp, by { sorry /-rw [eval₂_mul, eval₂_X, hp], exact (is_ring_hom.map_mul f).symm }) -/})
+(λ n, by { unfold_coes, rw [hom_C f, eval₂_C], unfold_coes, })
+(λ p q hp hq, by { unfold_coes at *, rw [eval₂_add, hp, hq], exact (is_ring_hom.map_add f).symm })
+(λ p n hp, by { unfold_coes at *, rw [eval₂_mul, eval₂_X, hp], exact (is_ring_hom.map_mul f).symm })
 
 end eval₂
 

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -531,7 +531,7 @@ lemma hom_C (f : mv_polynomial σ ℤ → β) [is_ring_hom f] (n : ℤ) : f (C n
 congr_fun (int.eq_cast' (f ∘ C)) n
 
 /-- A ring homomorphism f : Z[X_1, X_2, ...] -> R is determined by the evaluations f(X_1), f(X_2), ... -/
-@[simp] lemma eval₂_hom_X {α : Type u} [decidable_eq α] (f : mv_polynomial α ℤ → β) [is_ring_hom f]
+@[simp] lemma eval₂_hom_X {α : Type u} [decidable_eq α] (c : ℤ → β) [is_ring_hom c] (f : mv_polynomial α ℤ → β) [is_ring_hom f]
   (x : mv_polynomial α ℤ) : eval₂ (λ n : ℤ, (n : β)) (f ∘ X) x = f x :=
 mv_polynomial.induction_on x
 (λ n, by { unfold_coes, rw [hom_C f, eval₂_C], unfold_coes, })

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -532,7 +532,7 @@ congr_fun (int.eq_cast' (f ∘ C)) n
 
 /-- A ring homomorphism f : Z[X_1, X_2, ...] -> R is determined by the evaluations f(X_1), f(X_2), ... -/
 @[simp] lemma eval₂_hom_X {α : Type u} [decidable_eq α] (c : ℤ → β) [is_ring_hom c] (f : mv_polynomial α ℤ → β) [is_ring_hom f]
-  (x : mv_polynomial α ℤ) : eval₂ (λ n : ℤ, (n : β)) (f ∘ X) x = f x :=
+  (x : mv_polynomial α ℤ) : eval₂ c (f ∘ X) x = f x :=
 mv_polynomial.induction_on x
 (λ n, by { unfold_coes, rw [hom_C f, eval₂_C], unfold_coes, })
 (λ p q hp hq, by { unfold_coes at *, rw [eval₂_add, hp, hq], exact (is_ring_hom.map_add f).symm })

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -531,8 +531,9 @@ lemma hom_C (f : mv_polynomial σ ℤ → β) [is_ring_hom f] (n : ℤ) : f (C n
 congr_fun (int.eq_cast' (f ∘ C)) n
 
 /-- A ring homomorphism f : Z[X_1, X_2, ...] -> R is determined by the evaluations f(X_1), f(X_2), ... -/
-@[simp] lemma eval₂_hom_X {α : Type u} [decidable_eq α] (c : ℤ → β) [is_ring_hom c] (f : mv_polynomial α ℤ → β) [is_ring_hom f]
-  (x : mv_polynomial α ℤ) : eval₂ c (f ∘ X) x = f x :=
+@[simp] lemma eval₂_hom_X {α : Type u} [decidable_eq α] (c : ℤ → β) [is_ring_hom c]
+  (f : mv_polynomial α ℤ → β) [is_ring_hom f] (x : mv_polynomial α ℤ) :
+  eval₂ c (f ∘ X) x = f x :=
 mv_polynomial.induction_on x
 (λ n, by { unfold_coes, rw [hom_C f, eval₂_C], unfold_coes, })
 (λ p q hp hq, by { unfold_coes at *, rw [eval₂_add, hp, hq], exact (is_ring_hom.map_add f).symm })

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -527,14 +527,14 @@ lemma eval₂_sub : (p - q).eval₂ f g = p.eval₂ f g - q.eval₂ f g := is_ri
 
 @[simp] lemma eval₂_neg : (-p).eval₂ f g = -(p.eval₂ f g) := is_ring_hom.map_neg _
 
-lemma hom_C (f : mv_polynomial σ ℤ → β) [is_ring_hom f] (n : ℤ) : f (C n) = int.cast n :=
+lemma hom_C (f : mv_polynomial σ ℤ → β) [is_ring_hom f] (n : ℤ) : f (C n) = n :=
 congr_fun (int.eq_cast' (f ∘ C)) n
 
 /-- A ring homomorphism f : Z[X_1, X_2, ...] -> R is determined by the evaluations f(X_1), f(X_2), ... -/
 @[simp] lemma eval₂_hom_X {α : Type u} [decidable_eq α] (f : mv_polynomial α ℤ → β) [is_ring_hom f]
   (x : mv_polynomial α ℤ) : eval₂ int.cast (f ∘ X) x = f x :=
 mv_polynomial.induction_on x
-(λ n, by rw [eval₂_C, hom_C f])
+(λ n, by { rw [eval₂_C, hom_C f] })
 (λ p q hp hq, by { rw [eval₂_add, hp, hq], exact (is_ring_hom.map_add f).symm })
 (λ p n hp, by { rw [eval₂_mul, eval₂_X, hp], exact (is_ring_hom.map_mul f).symm })
 

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -639,8 +639,8 @@ finset.sup_le $ assume b,
 end rename
 
 lemma eval₂_cast_comp {β : Type u} {γ : Type v} [decidable_eq β] [decidable_eq γ] (f : γ → β)
-  {α : Type w} [comm_ring α] (g : β → α) (x : mv_polynomial γ ℤ) :
-  eval₂ int.cast (g ∘ f) x = eval₂ int.cast g (rename f x) :=
+  {α : Type w} [comm_ring α] (c : ℤ → α) [is_ring_hom c] (g : β → α) (x : mv_polynomial γ ℤ) :
+  eval₂ c (g ∘ f) x = eval₂ c g (rename f x) :=
 mv_polynomial.induction_on x
 (λ n, by simp only [eval₂_C, rename_C])
 (λ p q hp hq, by simp only [hp, hq, rename, eval₂_add])

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -530,14 +530,15 @@ lemma eval₂_sub : (p - q).eval₂ f g = p.eval₂ f g - q.eval₂ f g := is_ri
 lemma hom_C (f : mv_polynomial σ ℤ → β) [is_ring_hom f] (n : ℤ) : f (C n) = (n : β) :=
 congr_fun (int.eq_cast' (f ∘ C)) n
 
-/-- A ring homomorphism f : Z[X_1, X_2, ...] -> R is determined by the evaluations f(X_1), f(X_2), ... -/
+/-- A ring homomorphism f : Z[X_1, X_2, ...] -> R
+is determined by the evaluations f(X_1), f(X_2), ... -/
 @[simp] lemma eval₂_hom_X {α : Type u} [decidable_eq α] (c : ℤ → β) [is_ring_hom c]
   (f : mv_polynomial α ℤ → β) [is_ring_hom f] (x : mv_polynomial α ℤ) :
   eval₂ c (f ∘ X) x = f x :=
 mv_polynomial.induction_on x
-(λ n, by { unfold_coes, rw [hom_C f, eval₂_C], unfold_coes, })
-(λ p q hp hq, by { unfold_coes at *, rw [eval₂_add, hp, hq], exact (is_ring_hom.map_add f).symm })
-(λ p n hp, by { unfold_coes at *, rw [eval₂_mul, eval₂_X, hp], exact (is_ring_hom.map_mul f).symm })
+(λ n, by { rw [hom_C f, eval₂_C, int.eq_cast' c], refl })
+(λ p q hp hq, by { rw [eval₂_add, hp, hq], exact (is_ring_hom.map_add f).symm })
+(λ p n hp, by { rw [eval₂_mul, eval₂_X, hp], exact (is_ring_hom.map_mul f).symm })
 
 end eval₂
 

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -530,6 +530,7 @@ lemma eval₂_sub : (p - q).eval₂ f g = p.eval₂ f g - q.eval₂ f g := is_ri
 lemma hom_C (f : mv_polynomial σ ℤ → α) [is_ring_hom f] (n : ℤ) : f (C n) = int.cast n :=
 congr_fun (int.eq_cast' (f ∘ C)) n
 
+/-- A ring homomorphism f : Z[X_1, X_2, ...] -> R is determined by the evaluations f(X_1), f(X_2), ... -/
 @[simp] lemma eval₂_hom_X {α : Type u} [decidable_eq α] [decidable_eq β] (f : mv_polynomial α ℤ → β) [is_ring_hom f]
   (x : mv_polynomial α ℤ) : eval₂ int.cast (f ∘ X) x = f x :=
 mv_polynomial.induction_on x

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -527,6 +527,16 @@ lemma eval₂_sub : (p - q).eval₂ f g = p.eval₂ f g - q.eval₂ f g := is_ri
 
 @[simp] lemma eval₂_neg : (-p).eval₂ f g = -(p.eval₂ f g) := is_ring_hom.map_neg _
 
+lemma hom_C (f : mv_polynomial σ ℤ → α) [is_ring_hom f] (n : ℤ) : f (C n) = int.cast n :=
+congr_fun (int.eq_cast' (f ∘ C)) n
+
+@[simp] lemma eval₂_hom_X {α : Type u} [decidable_eq α] [decidable_eq β] (f : mv_polynomial α ℤ → β) [is_ring_hom f]
+  (x : mv_polynomial α ℤ) : eval₂ int.cast (f ∘ X) x = f x :=
+mv_polynomial.induction_on x
+(λ n, by rw [eval₂_C, hom_C f])
+(λ p q hp hq, by { rw [eval₂_add, hp, hq], exact (is_ring_hom.map_add f).symm })
+(λ p n hp, by { rw [eval₂_mul, eval₂_X, hp], exact (is_ring_hom.map_mul f).symm })
+
 end eval₂
 
 section eval
@@ -573,12 +583,12 @@ eval₂_C _ _ _
 @[simp] lemma rename_X (f : β → γ) (b : β) : rename f (X b : mv_polynomial β α) = X (f b) :=
 eval₂_X _ _ _
 
-lemma rename_rename (f : β → γ) (g : γ → δ) (p : mv_polynomial β α) :
+@[simp] lemma rename_rename (f : β → γ) (g : γ → δ) (p : mv_polynomial β α) :
   rename g (rename f p) = rename (g ∘ f) p :=
 show rename g (eval₂ C (X ∘ f) p) = _,
   by simp only [eval₂_comp_left (rename g) C (X ∘ f) p, (∘), rename_C, rename_X]; refl
 
-lemma rename_id (p : mv_polynomial β α) : rename id p = p :=
+@[simp] lemma rename_id (p : mv_polynomial β α) : rename id p = p :=
 eval₂_eta p
 
 lemma rename_monomial (f : β → γ) (p : β →₀ ℕ) (a : α) :
@@ -626,6 +636,14 @@ finset.sup_le $ assume b,
   end
 
 end rename
+
+lemma eval₂_cast_comp {β : Type u} {γ : Type v} [decidable_eq β] [decidable_eq γ] (f : γ → β)
+  {α : Type w} [comm_ring α] (g : β → α) (x : mv_polynomial γ ℤ) :
+  eval₂ int.cast (g ∘ f) x = eval₂ int.cast g (rename f x) :=
+mv_polynomial.induction_on x
+(λ n, by simp only [eval₂_C, rename_C])
+(λ p q hp hq, by simp only [hp, hq, rename, eval₂_add])
+(λ p n hp, by simp only [hp, rename, eval₂_X, eval₂_mul])
 
 instance rename.is_ring_hom
   {α} [comm_ring α] [decidable_eq α] [decidable_eq β] [decidable_eq γ] (f : β → γ) :

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -527,16 +527,16 @@ lemma eval₂_sub : (p - q).eval₂ f g = p.eval₂ f g - q.eval₂ f g := is_ri
 
 @[simp] lemma eval₂_neg : (-p).eval₂ f g = -(p.eval₂ f g) := is_ring_hom.map_neg _
 
-lemma hom_C (f : mv_polynomial σ ℤ → β) [is_ring_hom f] (n : ℤ) : f (C n) = int.cast n :=
+lemma hom_C (f : mv_polynomial σ ℤ → β) [is_ring_hom f] (n : ℤ) : f (C n) = (n : β) :=
 congr_fun (int.eq_cast' (f ∘ C)) n
 
 /-- A ring homomorphism f : Z[X_1, X_2, ...] -> R is determined by the evaluations f(X_1), f(X_2), ... -/
 @[simp] lemma eval₂_hom_X {α : Type u} [decidable_eq α] (f : mv_polynomial α ℤ → β) [is_ring_hom f]
-  (x : mv_polynomial α ℤ) : eval₂ int.cast (f ∘ X) x = f x :=
+  (x : mv_polynomial α ℤ) : eval₂ (λ n : ℤ, (n : β)) (f ∘ X) x = f x :=
 mv_polynomial.induction_on x
-(λ n, by rw [eval₂_C, hom_C f])
-(λ p q hp hq, by { rw [eval₂_add, hp, hq], exact (is_ring_hom.map_add f).symm })
-(λ p n hp, by { rw [eval₂_mul, eval₂_X, hp], exact (is_ring_hom.map_mul f).symm })
+(λ n, by { rw [hom_C f], /- deterministic timeout: -/ rw [eval₂_C], })
+(λ p q hp hq, by { sorry /- rw [eval₂_add, hp, hq], exact (is_ring_hom.map_add f).symm }) -/})
+(λ p n hp, by { sorry /-rw [eval₂_mul, eval₂_X, hp], exact (is_ring_hom.map_mul f).symm }) -/})
 
 end eval₂
 

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -527,10 +527,10 @@ lemma eval₂_sub : (p - q).eval₂ f g = p.eval₂ f g - q.eval₂ f g := is_ri
 
 @[simp] lemma eval₂_neg : (-p).eval₂ f g = -(p.eval₂ f g) := is_ring_hom.map_neg _
 
-lemma hom_C (f : mv_polynomial σ ℤ → α) [is_ring_hom f] (n : ℤ) : f (C n) = int.cast n :=
+lemma hom_C (f : mv_polynomial σ ℤ → β) [is_ring_hom f] (n : ℤ) : f (C n) = int.cast n :=
 congr_fun (int.eq_cast' (f ∘ C)) n
 
-@[simp] lemma eval₂_hom_X {α : Type u} [decidable_eq α] [decidable_eq β] (f : mv_polynomial α ℤ → β) [is_ring_hom f]
+@[simp] lemma eval₂_hom_X {α : Type u} [decidable_eq α] (f : mv_polynomial α ℤ → β) [is_ring_hom f]
   (x : mv_polynomial α ℤ) : eval₂ int.cast (f ∘ X) x = f x :=
 mv_polynomial.induction_on x
 (λ n, by rw [eval₂_C, hom_C f])

--- a/src/tactic/tidy.lean
+++ b/src/tactic/tidy.lean
@@ -53,6 +53,7 @@ meta def default_tactics : list (tactic string) :=
   fsplit                                      >> pure "fsplit",
   injections_and_clear                        >> pure "injections_and_clear",
   propositional_goal >> (`[solve_by_elim])    >> pure "solve_by_elim",
+  `[unfold_coes]                              >> pure "unfold_coes",
   `[unfold_aux]                               >> pure "unfold_aux",
   tidy.run_tactics ]
 


### PR DESCRIPTION
This PR:

* splits `category_theory/adjunction.lean` into 
  * `category_theory/adjunction/default.lean`, 
  * `category_theory/adjunction/basic.lean`, 
  * `category_theory/adjunction/limits.lean`

  mostly for the sake of shortening the critical compile path
* refactors the proofs in `category_theory/instances/CommRing/adjunctions.lean`, moving the facts that are just about `mv_polynomial` to the relevant file.
* completes the `-T50000` challenge for `category_theory/instances/CommRing/adjunctions.lean`