### PR TITLE
refactor(topology/metric/gromov_hausdorff): make Hausdorff_edist irreducible

### DIFF
--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -536,7 +536,7 @@ begin
   rcases hs xα with ⟨xs, hxs, Dxs⟩,
   have sne : s ≠ ∅ := ne_empty_of_mem hxs,
   letI : nonempty (subtype s) := ⟨⟨xs, hxs⟩⟩,
-  have ε2_0 : 0 ≤ ε2 := le_trans (abs_nonneg _) (H ⟨xs, hxs⟩ ⟨xs, hxs⟩),
+  have : 0 ≤ ε2 := le_trans (abs_nonneg _) (H ⟨xs, hxs⟩ ⟨xs, hxs⟩),
   have : ∀ p q : s, abs (dist p q - dist (Φ p) (Φ q)) ≤ 2 * (ε2/2 + δ) := λp q, calc
     abs (dist p q - dist (Φ p) (Φ q)) ≤ ε2 : H p q
     ... ≤ 2 * (ε2/2 + δ) : by linarith,
@@ -554,27 +554,25 @@ begin
   coupling the points x and Φ x are at distance ε2/2 by construction of the coupling (in fact
   ε2/2 + δ where δ is an arbitrarily small positive constant where positivity is used to ensure
   that the coupling is really a metric space and not a premetric space on α ⊕ β). -/
-  have I1 : GH_dist α β ≤ Hausdorff_dist (range Fl) (range Fr) :=
+  have : GH_dist α β ≤ Hausdorff_dist (range Fl) (range Fr) :=
     GH_dist_le_Hausdorff_dist Il Ir,
-  have I2 : Hausdorff_dist (range Fl) (range Fr) ≤ Hausdorff_dist (range Fl) (Fl '' s)
+  have : Hausdorff_dist (range Fl) (range Fr) ≤ Hausdorff_dist (range Fl) (Fl '' s)
                                               + Hausdorff_dist (Fl '' s) (range Fr),
   { have B : bounded (range Fl) := bounded_of_compact (compact_range Il.continuous),
-    exact Hausdorff_dist_triangle (Hausdorff_edist_ne_top_of_ne_empty_of_bounded
-      (by simpa only [set.range_eq_empty, not_not, ne.def]) (by simpa)
+    exact Hausdorff_dist_triangle (Hausdorff_edist_ne_top_of_ne_empty_of_bounded (by simpa) (by simpa)
       B (bounded.subset (image_subset_range _ _) B)) },
-  have I3 : Hausdorff_dist (Fl '' s) (range Fr) ≤ Hausdorff_dist (Fl '' s) (Fr '' (range Φ))
+  have : Hausdorff_dist (Fl '' s) (range Fr) ≤ Hausdorff_dist (Fl '' s) (Fr '' (range Φ))
                                              + Hausdorff_dist (Fr '' (range Φ)) (range Fr),
   { have B : bounded (range Fr) := bounded_of_compact (compact_range Ir.continuous),
     exact Hausdorff_dist_triangle' (Hausdorff_edist_ne_top_of_ne_empty_of_bounded
       (by simpa [-nonempty_subtype]) (by simpa) (bounded.subset (image_subset_range _ _) B) B) },
-  have I4 : Hausdorff_dist (range Fl) (Fl '' s) ≤ ε1,
+  have : Hausdorff_dist (range Fl) (Fl '' s) ≤ ε1,
   { rw [← image_univ, Hausdorff_dist_image Il],
     have : 0 ≤ ε1 := le_trans dist_nonneg Dxs,
     refine Hausdorff_dist_le_of_mem_dist this (λx hx, hs x)
       (λx hx, ⟨x, mem_univ _, by simpa⟩) },
-  have I5 : Hausdorff_dist (Fl '' s) (Fr '' (range Φ)) ≤ ε2/2 + δ,
-  { refine Hausdorff_dist_le_of_mem_dist _ _ _,
-    exact add_nonneg (div_nonneg (ε2_0) (by norm_num)) (le_of_lt δ0),
+  have : Hausdorff_dist (Fl '' s) (Fr '' (range Φ)) ≤ ε2/2 + δ,
+  { refine Hausdorff_dist_le_of_mem_dist (by linarith) _ _,
     { assume x' hx',
       rcases (set.mem_image _ _ _).1 hx' with ⟨x, ⟨x_in_s, xx'⟩⟩,
       rw ← xx',
@@ -586,7 +584,7 @@ begin
       use [Fl x, mem_image_of_mem _ x.2],
       rw [← yx', ← xy, dist_comm],
       exact le_of_eq (glue_dist_glued_points (@subtype.val α s) Φ (ε2/2 + δ) x) } },
-  have I6 : Hausdorff_dist (Fr '' (range Φ)) (range Fr) ≤ ε3,
+  have : Hausdorff_dist (Fr '' (range Φ)) (range Fr) ≤ ε3,
   { rw [← @image_univ _ _ Fr, Hausdorff_dist_image Ir],
     rcases exists_mem_of_nonempty β with ⟨xβ, _⟩,
     rcases hs' xβ with ⟨xs', Dxs'⟩,
@@ -594,9 +592,7 @@ begin
     refine Hausdorff_dist_le_of_mem_dist this (λx hx, ⟨x, mem_univ _, by simpa⟩) (λx _, _),
     rcases hs' x with ⟨y, Dy⟩,
     exact ⟨Φ y, mem_range_self _, Dy⟩ },
-  have I := le_trans (le_trans I1 I2) (add_le_add I4 (le_trans I3 (add_le_add I5 I6))),
-  have : ε1 + (ε2 / 2 + δ + ε3) = ε1 + ε2 / 2 + ε3 + δ, by ring,
-  rwa this at I
+  linarith
 end
 end --section
 

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -536,7 +536,7 @@ begin
   rcases hs xα with ⟨xs, hxs, Dxs⟩,
   have sne : s ≠ ∅ := ne_empty_of_mem hxs,
   letI : nonempty (subtype s) := ⟨⟨xs, hxs⟩⟩,
-  have : 0 ≤ ε2 := le_trans (abs_nonneg _) (H ⟨xs, hxs⟩ ⟨xs, hxs⟩),
+  have ε2_0 : 0 ≤ ε2 := le_trans (abs_nonneg _) (H ⟨xs, hxs⟩ ⟨xs, hxs⟩),
   have : ∀ p q : s, abs (dist p q - dist (Φ p) (Φ q)) ≤ 2 * (ε2/2 + δ) := λp q, calc
     abs (dist p q - dist (Φ p) (Φ q)) ≤ ε2 : H p q
     ... ≤ 2 * (ε2/2 + δ) : by linarith,
@@ -554,25 +554,27 @@ begin
   coupling the points x and Φ x are at distance ε2/2 by construction of the coupling (in fact
   ε2/2 + δ where δ is an arbitrarily small positive constant where positivity is used to ensure
   that the coupling is really a metric space and not a premetric space on α ⊕ β). -/
-  have : GH_dist α β ≤ Hausdorff_dist (range Fl) (range Fr) :=
+  have I1 : GH_dist α β ≤ Hausdorff_dist (range Fl) (range Fr) :=
     GH_dist_le_Hausdorff_dist Il Ir,
-  have : Hausdorff_dist (range Fl) (range Fr) ≤ Hausdorff_dist (range Fl) (Fl '' s)
+  have I2 : Hausdorff_dist (range Fl) (range Fr) ≤ Hausdorff_dist (range Fl) (Fl '' s)
                                               + Hausdorff_dist (Fl '' s) (range Fr),
   { have B : bounded (range Fl) := bounded_of_compact (compact_range Il.continuous),
-    exact Hausdorff_dist_triangle (Hausdorff_edist_ne_top_of_ne_empty_of_bounded (by simpa) (by simpa)
+    exact Hausdorff_dist_triangle (Hausdorff_edist_ne_top_of_ne_empty_of_bounded
+      (by simpa only [set.range_eq_empty, not_not, ne.def]) (by simpa)
       B (bounded.subset (image_subset_range _ _) B)) },
-  have : Hausdorff_dist (Fl '' s) (range Fr) ≤ Hausdorff_dist (Fl '' s) (Fr '' (range Φ))
+  have I3 : Hausdorff_dist (Fl '' s) (range Fr) ≤ Hausdorff_dist (Fl '' s) (Fr '' (range Φ))
                                              + Hausdorff_dist (Fr '' (range Φ)) (range Fr),
   { have B : bounded (range Fr) := bounded_of_compact (compact_range Ir.continuous),
     exact Hausdorff_dist_triangle' (Hausdorff_edist_ne_top_of_ne_empty_of_bounded
       (by simpa [-nonempty_subtype]) (by simpa) (bounded.subset (image_subset_range _ _) B) B) },
-  have : Hausdorff_dist (range Fl) (Fl '' s) ≤ ε1,
+  have I4 : Hausdorff_dist (range Fl) (Fl '' s) ≤ ε1,
   { rw [← image_univ, Hausdorff_dist_image Il],
     have : 0 ≤ ε1 := le_trans dist_nonneg Dxs,
     refine Hausdorff_dist_le_of_mem_dist this (λx hx, hs x)
       (λx hx, ⟨x, mem_univ _, by simpa⟩) },
-  have : Hausdorff_dist (Fl '' s) (Fr '' (range Φ)) ≤ ε2/2 + δ,
-  { refine Hausdorff_dist_le_of_mem_dist (by linarith) _ _,
+  have I5 : Hausdorff_dist (Fl '' s) (Fr '' (range Φ)) ≤ ε2/2 + δ,
+  { refine Hausdorff_dist_le_of_mem_dist _ _ _,
+    exact add_nonneg (div_nonneg (ε2_0) (by norm_num)) (le_of_lt δ0),
     { assume x' hx',
       rcases (set.mem_image _ _ _).1 hx' with ⟨x, ⟨x_in_s, xx'⟩⟩,
       rw ← xx',
@@ -584,7 +586,7 @@ begin
       use [Fl x, mem_image_of_mem _ x.2],
       rw [← yx', ← xy, dist_comm],
       exact le_of_eq (glue_dist_glued_points (@subtype.val α s) Φ (ε2/2 + δ) x) } },
-  have : Hausdorff_dist (Fr '' (range Φ)) (range Fr) ≤ ε3,
+  have I6 : Hausdorff_dist (Fr '' (range Φ)) (range Fr) ≤ ε3,
   { rw [← @image_univ _ _ Fr, Hausdorff_dist_image Ir],
     rcases exists_mem_of_nonempty β with ⟨xβ, _⟩,
     rcases hs' xβ with ⟨xs', Dxs'⟩,
@@ -592,7 +594,9 @@ begin
     refine Hausdorff_dist_le_of_mem_dist this (λx hx, ⟨x, mem_univ _, by simpa⟩) (λx _, _),
     rcases hs' x with ⟨y, Dy⟩,
     exact ⟨Φ y, mem_range_self _, Dy⟩ },
-  linarith
+  have I := le_trans (le_trans I1 I2) (add_le_add I4 (le_trans I3 (add_le_add I5 I6))),
+  have : ε1 + (ε2 / 2 + δ + ε3) = ε1 + ε2 / 2 + ε3 + δ, by ring,
+  rwa this at I
 end
 end --section
 

--- a/src/topology/metric_space/hausdorff_distance.lean
+++ b/src/topology/metric_space/hausdorff_distance.lean
@@ -139,6 +139,11 @@ is contained in the `r`-neighborhood of the other one -/
 def Hausdorff_edist {α : Type u} [emetric_space α] (s t : set α) : ennreal :=
   Sup ((λx, inf_edist x t) '' s) ⊔ Sup ((λx, inf_edist x s) '' t)
 
+lemma Hausdorff_edist_def {α : Type u} [emetric_space α] (s t : set α) :
+  Hausdorff_edist s t = Sup ((λx, inf_edist x t) '' s) ⊔ Sup ((λx, inf_edist x s) '' t) := rfl
+
+attribute [irreducible] Hausdorff_edist
+
 section Hausdorff_edist
 local notation `∞` := (⊤ : ennreal)
 variables {α : Type u} {β : Type v} [emetric_space α] [emetric_space β]
@@ -147,8 +152,7 @@ variables {α : Type u} {β : Type v} [emetric_space α] [emetric_space β]
 /-- The Hausdorff edistance of a set to itself vanishes -/
 @[simp] lemma Hausdorff_edist_self : Hausdorff_edist s s = 0 :=
 begin
-  unfold Hausdorff_edist,
-  erw [lattice.sup_idem, ← le_bot_iff],
+  erw [Hausdorff_edist_def, lattice.sup_idem, ← le_bot_iff],
   apply Sup_le _,
   simp [le_bot_iff, inf_edist_zero_of_mem] {contextual := tt},
 end
@@ -185,6 +189,7 @@ end
 /-- The distance to a set is controlled by the Hausdorff distance -/
 lemma inf_edist_le_Hausdorff_edist_of_mem (h : x ∈ s) : inf_edist x t ≤ Hausdorff_edist s t :=
 begin
+  rw Hausdorff_edist_def,
   refine le_trans (le_Sup _) le_sup_left,
   exact mem_image_of_mem _ h
 end
@@ -196,7 +201,7 @@ lemma exists_edist_lt_of_Hausdorff_edist_lt {r : ennreal} (h : x ∈ s) (H : Hau
 exists_edist_lt_of_inf_edist_lt $ calc
   inf_edist x t ≤ Sup ((λx, inf_edist x t) '' s) : le_Sup (mem_image_of_mem _ h)
   ... ≤ Sup ((λx, inf_edist x t) '' s) ⊔ Sup ((λx, inf_edist x s) '' t) : le_sup_left
-  ... < r : H
+  ... < r : by rwa Hausdorff_edist_def at H
 
 /-- The distance from `x` to `s`or `t` is controlled in terms of the Hausdorff distance
 between `s` and `t` -/
@@ -261,7 +266,7 @@ end
 /-- The Hausdorff distance satisfies the triangular inequality -/
 lemma Hausdorff_edist_triangle : Hausdorff_edist s u ≤ Hausdorff_edist s t + Hausdorff_edist t u :=
 begin
-  change Sup ((λx, inf_edist x u) '' s) ⊔ Sup ((λx, inf_edist x s) '' u) ≤ Hausdorff_edist s t + Hausdorff_edist t u,
+  rw Hausdorff_edist_def,
   simp only [and_imp, set.mem_image, lattice.Sup_le_iff, exists_imp_distrib,
              lattice.sup_le_iff, -mem_image, set.ball_image_iff],
   split,


### PR DESCRIPTION
Making `Hausdorff_edist` irreducible makes the proof of `GH_dist_le_of_approx_subsets` 10 times faster, from 53s to 5.74s on my computer. This proof wasn't slow before, so I guess it is related to the recent modification of `linarith` by which it tries to check if atoms are defeq.

