### PR TITLE
refactor: coherent composition order

### DIFF
--- a/src/analysis/asymptotics.lean
+++ b/src/analysis/asymptotics.lean
@@ -588,7 +588,7 @@ begin
   refine ⟨∥y∥ + 1, lt_of_le_of_lt (norm_nonneg _) Iy, _⟩,
   simp only [mul_one, norm_one],
   have : tendsto (λx, ∥f x∥) l (nhds ∥y∥) :=
-    h.comp (continuous_norm.tendsto _),
+    (continuous_norm.tendsto _).comp h,
   exact this (ge_mem_nhds Iy)
 end
 

--- a/src/analysis/complex/exponential.lean
+++ b/src/analysis/complex/exponential.lean
@@ -31,7 +31,7 @@ continuous_iff_continuous_at.2 (λ x,
       (λ y, id y - (λ z, x) y)) (nhds x) (nhds (exp x)),
     by simp only [function.comp, add_sub_cancel'_right, id.def] at this;
       exact this,
-  tendsto.comp (by rw [sub_self] at H2; exact H2) H1)
+  tendsto.comp H1 (by rw [sub_self] at H2; exact H2))
 
 lemma continuous_sin : continuous sin :=
 continuous_mul

--- a/src/analysis/normed_space/banach.lean
+++ b/src/analysis/normed_space/banach.lean
@@ -157,7 +157,7 @@ begin
   have : tendsto (λn, (range n).sum u) at_top (nhds x) :=
     tendsto_sum_nat_of_has_sum (has_sum_tsum su),
   have L₁ : tendsto (λn, f((range n).sum u)) at_top (nhds (f x)) :=
-    tendsto.comp this (hf.continuous.tendsto _),
+    tendsto.comp (hf.continuous.tendsto _) this,
   simp only [fsumeq] at L₁,
   have L₂ : tendsto (λn, y - (h^[n]) y) at_top (nhds (y - 0)),
   { refine tendsto_sub tendsto_const_nhds _,

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -397,7 +397,7 @@ begin
   { clear ineq,
 
     have limf': tendsto (λ x, ∥f x - s∥) e (nhds 0) := tendsto_iff_norm_tendsto_zero.1 limf,
-    have limg' : tendsto (λ x, ∥g x∥) e (nhds ∥b∥) := filter.tendsto.comp limg (continuous_iff_continuous_at.1 continuous_norm _),
+    have limg' : tendsto (λ x, ∥g x∥) e (nhds ∥b∥) := filter.tendsto.comp (continuous_iff_continuous_at.1 continuous_norm _) limg,
 
     have lim1 := tendsto_mul limf' limg',
     simp only [zero_mul, sub_eq_add_neg] at lim1,
@@ -532,7 +532,7 @@ summable_of_norm_bounded _ hf (assume i, le_refl _)
 
 lemma norm_tsum_le_tsum_norm {f : ι → α} (hf : summable (λi, ∥f i∥)) : ∥(∑i, f i)∥ ≤ (∑ i, ∥f i∥) :=
 have h₁ : tendsto (λs:finset ι, ∥s.sum f∥) at_top (nhds ∥(∑ i, f i)∥) :=
-  (has_sum_tsum $ summable_of_summable_norm hf).comp (continuous_norm.tendsto _),
+  (continuous_norm.tendsto _).comp (has_sum_tsum $ summable_of_summable_norm hf),
 have h₂ : tendsto (λs:finset ι, s.sum (λi, ∥f i∥)) at_top (nhds (∑ i, ∥f i∥)) :=
   has_sum_tsum hf,
 le_of_tendsto_of_tendsto at_top_ne_bot h₁ h₂ $ univ_mem_sets' $ assume s, norm_triangle_sum _ _

--- a/src/analysis/normed_space/deriv.lean
+++ b/src/analysis/normed_space/deriv.lean
@@ -164,9 +164,9 @@ lemma tangent_cone_at.lim_zero {y : E} {c : ℕ → k} {d : ℕ → E}
   tendsto d at_top (nhds 0) :=
 begin
   have A : tendsto (λn, ∥c n∥⁻¹) at_top (nhds 0) :=
-    hc.comp tendsto_inverse_at_top_nhds_0,
+    tendsto_inverse_at_top_nhds_0.comp hc,
   have B : tendsto (λn, ∥c n • d n∥) at_top (nhds ∥y∥) :=
-    hd.comp (continuous_norm.tendsto _),
+    (continuous_norm.tendsto _).comp hd,
   have C : tendsto (λn, ∥c n∥⁻¹ * ∥c n • d n∥) at_top (nhds (0 * ∥y∥)) :=
     tendsto_mul A B,
   rw zero_mul at C,
@@ -227,7 +227,7 @@ begin
       is_o_one_iff.1 L4,
     have L' : tendsto (λ (n : ℕ), c n • (f₁' (d n) - f' (d n))) at_top (nhds (f₁' y - f' y)),
     { simp only [smul_sub, (bounded_linear_map.map_smul _ _ _).symm],
-      apply tendsto_sub (ylim.comp (f₁'.continuous.tendsto _)) (ylim.comp (f'.continuous.tendsto _)) },
+      apply tendsto_sub ((f₁'.continuous.tendsto _).comp ylim) ((f'.continuous.tendsto _).comp ylim) },
     have : f₁' y - f' y = 0 := tendsto_nhds_unique (by simp) L' L,
     exact (sub_eq_zero_iff_eq.1 this).symm },
   have B : ∀y ∈ submodule.span k (tangent_cone_at k s x), f' y = f₁' y,
@@ -1033,6 +1033,12 @@ end cartesian_product
 /- Composition -/
 section composition
 
+
+/- For composition lemmas, we put x explicit to help the elaborator, as otherwise Lean tends to
+get confused since there are too many possibilities for composition -/
+
+variable (x)
+
 theorem has_fderiv_at_filter.comp {g : F → G} {g' : F →L[k] G}
   (hg : has_fderiv_at_filter g g' (f x) (L.map f))
   (hf : has_fderiv_at_filter f f' x L) :
@@ -1071,20 +1077,20 @@ theorem has_fderiv_within_at.comp {g : F → G} {g' : F →L[k] G}
   (hf : has_fderiv_within_at f f' s x) :
   has_fderiv_within_at (g ∘ f) (g'.comp f') s x :=
 (has_fderiv_at_filter.mono hg
-  hf.continuous_within_at.tendsto_nhds_within_image).comp hf
+  hf.continuous_within_at.tendsto_nhds_within_image).comp x hf
 
 /-- The chain rule. -/
 theorem has_fderiv_at.comp {g : F → G} {g' : F →L[k] G}
   (hg : has_fderiv_at g g' (f x)) (hf : has_fderiv_at f f' x) :
   has_fderiv_at (g ∘ f) (g'.comp f') x :=
-(hg.mono hf.continuous_at).comp hf
+(hg.mono hf.continuous_at).comp x hf
 
 theorem has_fderiv_at.comp_has_fderiv_within_at {g : F → G} {g' : F →L[k] G}
   (hg : has_fderiv_at g g' (f x)) (hf : has_fderiv_within_at f f' s x) :
   has_fderiv_within_at (g ∘ f) (g'.comp f') s x :=
 begin
   rw ← has_fderiv_within_univ_at at hg,
-  exact has_fderiv_within_at.comp (hg.mono (subset_univ _)) hf
+  exact has_fderiv_within_at.comp x (hg.mono (subset_univ _)) hf
 end
 
 lemma differentiable_within_at.comp {g : F → G} {t : set F}
@@ -1093,13 +1099,13 @@ lemma differentiable_within_at.comp {g : F → G} {t : set F}
 begin
   rcases hf with ⟨f', hf'⟩,
   rcases hg with ⟨g', hg'⟩,
-  exact ⟨bounded_linear_map.comp g' f', (hg'.mono h).comp hf'⟩
+  exact ⟨bounded_linear_map.comp g' f', (hg'.mono h).comp x hf'⟩
 end
 
 lemma differentiable_at.comp {g : F → G}
   (hg : differentiable_at k g (f x)) (hf : differentiable_at k f x) :
   differentiable_at k (g ∘ f) x :=
-(hg.has_fderiv_at.comp hf.has_fderiv_at).differentiable_at
+(hg.has_fderiv_at.comp x hf.has_fderiv_at).differentiable_at
 
 lemma fderiv_within.comp {g : F → G} {t : set F}
   (hg : differentiable_within_at k g t (f x)) (hf : differentiable_within_at k f s x)
@@ -1108,7 +1114,7 @@ lemma fderiv_within.comp {g : F → G} {t : set F}
     bounded_linear_map.comp (fderiv_within k g t (f x)) (fderiv_within k f s x) :=
 begin
   apply has_fderiv_within_at.fderiv_within _ hxs,
-  apply has_fderiv_within_at.comp _ (hf.has_fderiv_within_at),
+  apply has_fderiv_within_at.comp x _ (hf.has_fderiv_within_at),
   apply hg.has_fderiv_within_at.mono h
 end
 
@@ -1117,13 +1123,13 @@ lemma fderiv.comp {g : F → G}
   fderiv k (g ∘ f) x = bounded_linear_map.comp (fderiv k g (f x)) (fderiv k f x) :=
 begin
   apply has_fderiv_at.fderiv,
-  exact has_fderiv_at.comp hg.has_fderiv_at hf.has_fderiv_at
+  exact has_fderiv_at.comp x hg.has_fderiv_at hf.has_fderiv_at
 end
 
 lemma differentiable_on.comp {g : F → G} {t : set F}
   (hg : differentiable_on k g t) (hf : differentiable_on k f s) (st : f '' s ⊆ t) :
   differentiable_on k (g ∘ f) s :=
-λx hx, differentiable_within_at.comp (hg (f x) (st (mem_image_of_mem _ hx))) (hf x hx) st
+λx hx, differentiable_within_at.comp x (hg (f x) (st (mem_image_of_mem _ hx))) (hf x hx) st
 
 end composition
 
@@ -1136,15 +1142,14 @@ theorem has_fderiv_within_at.smul'
   has_fderiv_within_at (λ y, c y • f y) (c x • f' + c'.scalar_prod_space_iso (f x)) s x :=
 begin
   have : is_bounded_bilinear_map k (λ (p : k × F), p.1 • p.2) := is_bounded_bilinear_map_smul,
-  exact @has_fderiv_at.comp_has_fderiv_within_at _ _ _ _ _ _ _ _ _ _ x _ _ _
-    (this.has_fderiv_at (c x, f x)) (hc.prod hf),
-  end
+  exact has_fderiv_at.comp_has_fderiv_within_at x (this.has_fderiv_at (c x, f x)) (hc.prod hf)
+end
 
 theorem has_fderiv_at.smul' (hc : has_fderiv_at c c' x) (hf : has_fderiv_at f f' x) :
   has_fderiv_at (λ y, c y • f y) (c x • f' + c'.scalar_prod_space_iso (f x)) x :=
 begin
   have : is_bounded_bilinear_map k (λ (p : k × F), p.1 • p.2) := is_bounded_bilinear_map_smul,
-  exact @has_fderiv_at.comp _ _ _ _ _ _ _ _ _ _ x _ _ (this.has_fderiv_at (c x, f x)) (hc.prod hf)
+  exact has_fderiv_at.comp x (this.has_fderiv_at (c x, f x)) (hc.prod hf)
 end
 
 lemma differentiable_within_at.smul'
@@ -1188,8 +1193,7 @@ theorem has_fderiv_within_at.mul
   has_fderiv_within_at (λ y, c y * d y) (c x • d' + d x • c') s x :=
 begin
   have : is_bounded_bilinear_map k (λ (p : k × k), p.1 * p.2) := is_bounded_bilinear_map_mul,
-  convert @has_fderiv_at.comp_has_fderiv_within_at _ _ _ _ _ _ _ _ _ _ x _ _ _
-    (this.has_fderiv_at (c x, d x)) (hc.prod hd),
+  convert has_fderiv_at.comp_has_fderiv_within_at x (this.has_fderiv_at (c x, d x)) (hc.prod hd),
   ext z,
   change c x * d' z + d x * c' z = c x * d' z + c' z * d x,
   ring
@@ -1199,8 +1203,7 @@ theorem has_fderiv_at.mul (hc : has_fderiv_at c c' x) (hd : has_fderiv_at d d' x
   has_fderiv_at (λ y, c y * d y) (c x • d' + d x • c') x :=
 begin
   have : is_bounded_bilinear_map k (λ (p : k × k), p.1 * p.2) := is_bounded_bilinear_map_mul,
-  convert @has_fderiv_at.comp _ _ _ _ _ _ _ _ _ _ x _ _
-    (this.has_fderiv_at (c x, d x)) (hc.prod hd),
+  convert has_fderiv_at.comp x (this.has_fderiv_at (c x, d x)) (hc.prod hd),
   ext z,
   change c x * d' z + d x * c' z = c x * d' z + c' z * d x,
   ring

--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -57,8 +57,8 @@ by_cases
   (assume : r = 0, (tendsto_add_at_top_iff_nat 1).mp $ by simp [pow_succ, this, tendsto_const_nhds])
   (assume : r ≠ 0,
     have tendsto (λn, (r⁻¹ ^ n)⁻¹) at_top (nhds 0),
-      from (tendsto_pow_at_top_at_top_of_gt_1 $ one_lt_inv (lt_of_le_of_ne h₁ this.symm) h₂).comp
-        tendsto_inverse_at_top_nhds_0,
+      from tendsto.comp tendsto_inverse_at_top_nhds_0
+        (tendsto_pow_at_top_at_top_of_gt_1 $ one_lt_inv (lt_of_le_of_ne h₁ this.symm) h₂),
     tendsto.congr' (univ_mem_sets' $ by simp *) this)
 
 lemma tendsto_pow_at_top_nhds_0_of_lt_1_normed_field {K : Type*} [normed_field K] {ξ : K}
@@ -77,7 +77,7 @@ tendsto_coe_nat_real_at_top_iff.1 $
   by simpa using tendsto_pow_at_top_at_top_of_gt_1 hr
 
 lemma tendsto_inverse_at_top_nhds_0_nat : tendsto (λ n : ℕ, (n : ℝ)⁻¹) at_top (nhds 0) :=
-tendsto.comp (tendsto_coe_nat_real_at_top_iff.2 tendsto_id) tendsto_inverse_at_top_nhds_0
+tendsto.comp tendsto_inverse_at_top_nhds_0 (tendsto_coe_nat_real_at_top_iff.2 tendsto_id)
 
 lemma tendsto_one_div_at_top_nhds_0_nat : tendsto (λ n : ℕ, 1/(n : ℝ)) at_top (nhds 0) :=
 by simpa only [inv_eq_one_div] using tendsto_inverse_at_top_nhds_0_nat

--- a/src/data/padics/hensel.lean
+++ b/src/data/padics/hensel.lean
@@ -29,8 +29,7 @@ private lemma comp_tendsto_lim {p : ℕ} [p.prime] {F : polynomial ℤ_[p]} (ncs
 @tendsto.comp _ _ _ ncs
   (λ k, F.eval k)
   _ _ _
-  (tendsto_limit ncs)
-  (continuous_iff_continuous_at.1 F.continuous_eval _)
+  (continuous_iff_continuous_at.1 F.continuous_eval _) (tendsto_limit ncs)
 
 section
 parameters {p : ℕ} [nat.prime p] {ncs : cau_seq ℤ_[p] norm} {F : polynomial ℤ_[p]} {a : ℤ_[p]}
@@ -43,7 +42,7 @@ by convert tendsto_const_nhds; ext; rw ncs_der_val
 
 private lemma ncs_tendsto_lim :
   tendsto (λ i, ∥F.derivative.eval (ncs i)∥) at_top (nhds (∥F.derivative.eval ncs.lim∥)) :=
-tendsto.comp (comp_tendsto_lim _) (continuous_iff_continuous_at.1 continuous_norm _)
+tendsto.comp (continuous_iff_continuous_at.1 continuous_norm _) (comp_tendsto_lim _)
 
 private lemma norm_deriv_eq : ∥F.derivative.eval ncs.lim∥ = ∥F.derivative.eval a∥ :=
 tendsto_nhds_unique at_top_ne_bot ncs_tendsto_lim ncs_tendsto_const
@@ -282,9 +281,9 @@ private lemma bound' : tendsto (λ n : ℕ, ∥F.derivative.eval a∥ * T^(2^n))
 begin
   rw ←mul_zero (∥F.derivative.eval a∥),
   exact tendsto_mul (tendsto_const_nhds)
-                    (tendsto.comp (tendsto_pow_at_top_at_top_of_gt_1_nat (by norm_num))
-                                   (tendsto_pow_at_top_nhds_0_of_lt_1 (norm_nonneg _)
-                                                                      (T_lt_one hnorm)))
+                    (tendsto.comp
+                      (tendsto_pow_at_top_nhds_0_of_lt_1 (norm_nonneg _) (T_lt_one hnorm))
+                      (tendsto_pow_at_top_at_top_of_gt_1_nat (by norm_num)))
 end
 
 private lemma bound : ∀ {ε}, ε > 0 → ∃ N : ℕ, ∀ {n}, n ≥ N → ∥F.derivative.eval a∥ * T^(2^n) < ε :=
@@ -342,8 +341,9 @@ tendsto.congr'
 
 private lemma newton_seq_dist_tendsto' :
   tendsto (λ n, ∥newton_cau_seq n - a∥) at_top (nhds ∥soln - a∥) :=
-tendsto.comp (tendsto_sub (tendsto_limit _) tendsto_const_nhds)
-             (continuous_iff_continuous_at.1 continuous_norm _)
+tendsto.comp (continuous_iff_continuous_at.1 continuous_norm _)
+             (tendsto_sub (tendsto_limit _) tendsto_const_nhds)
+
 
 private lemma soln_dist_to_a : ∥soln - a∥ = ∥F.eval a∥ / ∥F.derivative.eval a∥ :=
 tendsto_nhds_unique at_top_ne_bot newton_seq_dist_tendsto' newton_seq_dist_tendsto

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -352,7 +352,7 @@ def ennreal_equiv_nnreal : measurable_equiv {r : ennreal | r < ⊤} nnreal :=
     refine measurable_of_continuous (continuous_iff_continuous_at.2 _),
     rintros ⟨r, hr⟩,
     simp [continuous_at, nhds_subtype_eq_comap],
-    refine tendsto.comp tendsto_comap (tendsto_to_nnreal (ne_of_lt hr))
+    refine tendsto.comp (tendsto_to_nnreal (ne_of_lt hr)) tendsto_comap
   end,
   measurable_inv_fun := measurable_subtype_mk measurable_coe }
 

--- a/src/measure_theory/decomposition.lean
+++ b/src/measure_theory/decomposition.lean
@@ -56,7 +56,7 @@ begin
   { assume s hs hm,
     refine tendsto_sub _ _;
       refine (nnreal.tendsto_coe.2 $
-        (tendsto_measure_Union hs hm).comp $ ennreal.tendsto_to_nnreal $ @ne_top_of_lt _ _ _ ⊤ _),
+        (ennreal.tendsto_to_nnreal $ @ne_top_of_lt _ _ _ ⊤ _).comp $ tendsto_measure_Union hs hm),
     exact hμ _,
     exact hν _ },
 
@@ -65,11 +65,11 @@ begin
   { assume s hs hm,
     refine tendsto_sub _ _;
       refine (nnreal.tendsto_coe.2 $
-        (tendsto_measure_Inter hs hm _).comp $ ennreal.tendsto_to_nnreal $ @ne_top_of_lt _ _ _ ⊤ _),
-    exact ⟨0, hμ _⟩,
+        (ennreal.tendsto_to_nnreal $ @ne_top_of_lt _ _ _ ⊤ _).comp $ tendsto_measure_Inter hs hm _),
     exact hμ _,
-    exact ⟨0, hν _⟩,
-    exact hν _ },
+    exact ⟨0, hμ _⟩,
+    exact hν _,
+    exact ⟨0, hν _⟩ },
 
   have bdd_c : bdd_above c,
   { use (μ univ).to_nnreal,

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -1143,7 +1143,7 @@ by simp only [tendsto, map_id, forall_true_iff] {contextual := tt}
 lemma tendsto_id {x : filter α} : tendsto id x x := tendsto_id' $ le_refl x
 
 lemma tendsto.comp {f : α → β} {g : β → γ} {x : filter α} {y : filter β} {z : filter γ}
-  (hf : tendsto f x y) (hg : tendsto g y z) : tendsto (g ∘ f) x z :=
+  (hg : tendsto g y z) (hf : tendsto f x y) : tendsto (g ∘ f) x z :=
 calc map (g ∘ f) x = map g (map f x) : by rw [map_map]
   ... ≤ map g y : map_mono hf
   ... ≤ z : hg
@@ -1171,7 +1171,7 @@ map_comap_le
 
 lemma tendsto_comap_iff {f : α → β} {g : β → γ} {a : filter α} {c : filter γ} :
   tendsto f a (c.comap g) ↔ tendsto (g ∘ f) a c :=
-⟨assume h, h.comp tendsto_comap, assume h, map_le_iff_le_comap.mp $ by rwa [map_map]⟩
+⟨assume h, tendsto_comap.comp h, assume h, map_le_iff_le_comap.mp $ by rwa [map_map]⟩
 
 lemma tendsto_comap'_iff {m : α → β} {f : filter α} {g : filter β} {i : γ → α}
   (h : range i ∈ f) : tendsto (m ∘ i) (comap i f) g ↔ tendsto m f g :=
@@ -1326,7 +1326,7 @@ le_antisymm
       calc set.prod (m₁ '' s₁) (m₂ '' s₂) = (λp:α₁×α₂, (m₁ p.1, m₂ p.2)) '' set.prod s₁ s₂ :
           set.prod_image_image_eq
         ... ⊆ _ : by rwa [image_subset_iff])
-  ((tendsto_fst.comp (le_refl _)).prod_mk (tendsto_snd.comp (le_refl _)))
+  ((tendsto.comp (le_refl _) tendsto_fst).prod_mk (tendsto.comp (le_refl _) tendsto_snd))
 
 lemma map_prod (m : α × β → γ) (f : filter α) (g : filter β) :
   map m (f.prod g) = (f.map (λa b, m (a, b))).seq g :=

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -49,7 +49,7 @@ continuous_inv'.comp hf
 @[to_additive tendsto_neg]
 lemma tendsto_inv [topological_group α] {f : β → α} {x : filter β} {a : α}
   (hf : tendsto f x (nhds a)) : tendsto (λx, (f x)⁻¹) x (nhds a⁻¹) :=
-hf.comp (continuous_iff_continuous_at.mp (topological_group.continuous_inv α) a)
+tendsto.comp (continuous_iff_continuous_at.mp (topological_group.continuous_inv α) a) hf
 
 @[to_additive prod.topological_add_group]
 instance [topological_group α] [topological_space β] [group β] [topological_group β] :
@@ -266,13 +266,13 @@ lemma neg_Z : tendsto (λa:α, - a) (Z α) (Z α) :=
 have tendsto (λa, (0:α)) (Z α) (Z α),
   by refine le_trans (assume h, _) zero_Z; simp [univ_mem_sets'] {contextual := tt},
 have tendsto (λa:α, 0 - a) (Z α) (Z α), from
-  (tendsto.prod_mk this tendsto_id).comp sub_Z,
+  sub_Z.comp (tendsto.prod_mk this tendsto_id),
 by simpa
 
 lemma add_Z : tendsto (λp:α×α, p.1 + p.2) ((Z α).prod (Z α)) (Z α) :=
 suffices tendsto (λp:α×α, p.1 - -p.2) ((Z α).prod (Z α)) (Z α),
   by simpa,
-(tendsto.prod_mk tendsto_fst (tendsto_snd.comp neg_Z)).comp sub_Z
+sub_Z.comp (tendsto.prod_mk tendsto_fst (neg_Z.comp tendsto_snd))
 
 lemma exists_Z_half {s : set α} (hs : s ∈ Z α) : ∃ V ∈ Z α, ∀ v w ∈ V, v + w ∈ s :=
 begin
@@ -307,7 +307,7 @@ instance : topological_add_monoid α :=
     suffices :  tendsto ((λx:α, (a + b) + x) ∘ (λp:α×α,p.1 + p.2)) (filter.prod (Z α) (Z α))
       (map (λx:α, (a + b) + x) (Z α)),
     { simpa [(∘)] },
-    exact add_Z.comp tendsto_map
+    exact tendsto_map.comp add_Z
   end⟩
 
 instance : topological_add_group α :=
@@ -316,7 +316,7 @@ instance : topological_add_group α :=
     rw [continuous_at, nhds_eq, nhds_eq, tendsto_map'_iff],
     suffices : tendsto ((λx:α, x - a) ∘ (λx:α, -x)) (Z α) (map (λx:α, x - a) (Z α)),
     { simpa [(∘)] },
-    exact neg_Z.comp tendsto_map
+    exact tendsto_map.comp neg_Z
   end⟩
 
 end add_group_with_zero_nhd

--- a/src/topology/algebra/group_completion.lean
+++ b/src/topology/algebra/group_completion.lean
@@ -51,8 +51,8 @@ instance : add_group (completion α) :=
   .. completion.has_zero, .. completion.has_neg, ..completion.has_add }
 
 instance : uniform_add_group (completion α) :=
-⟨ (uniform_continuous.prod_mk uniform_continuous_fst
-  (uniform_continuous_snd.comp uniform_continuous_map)).comp (uniform_continuous_map₂' (+))  ⟩
+⟨ (uniform_continuous_map₂' (+)).comp (uniform_continuous.prod_mk uniform_continuous_fst
+    (uniform_continuous_map.comp uniform_continuous_snd)) ⟩
 
 instance is_add_group_hom_coe : is_add_group_hom (coe : α → completion α) :=
 ⟨ coe_add ⟩

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -101,7 +101,7 @@ have ∀x y, j x = j y → x = y,
 have (λs:finset γ, s.sum (f ∘ j)) = (λs:finset β, s.sum f) ∘ (λs:finset γ, s.image j),
   from funext $ assume s, (sum_image $ assume x _ y _, this x y).symm,
 show tendsto (λs:finset γ, s.sum (f ∘ j)) at_top (nhds a),
-   by rw [this]; apply (tendsto_finset_image_at_top_at_top h₂).comp hf
+   by rw [this]; apply hf.comp (tendsto_finset_image_at_top_at_top h₂)
 
 lemma has_sum_iff_has_sum_of_iso {j : γ → β} (i : β → γ)
   (h₁ : ∀x, i (j x) = x) (h₂ : ∀x, j (i x) = x) :
@@ -118,7 +118,7 @@ lemma has_sum_hom (g : α → γ) [add_comm_monoid γ] [topological_space γ] [t
 have (λs:finset β, s.sum (g ∘ f)) = g ∘ (λs:finset β, s.sum f),
   from funext $ assume s, sum_hom g,
 show tendsto (λs:finset β, s.sum (g ∘ f)) at_top (nhds (g a)),
-  by rw [this]; exact hf.comp (continuous_iff_continuous_at.mp h₃ a)
+  by rw [this]; exact tendsto.comp (continuous_iff_continuous_at.mp h₃ a) hf
 
 lemma tendsto_sum_nat_of_has_sum {f : ℕ → α} (h : has_sum f a) :
   tendsto (λn:ℕ, (range n).sum f) at_top (nhds a) :=
@@ -158,7 +158,7 @@ mem_at_top_sets.mpr $ exists.intro fsts $ assume bs (hbs : fsts ⊆ bs),
   have tendsto (λp:(Πb:β, finset (γ b)), bs.sum (λb, (p b).sum (λc, f ⟨b, c⟩)))
       (⨅b (h : b ∈ bs), at_top.comap (λp, p b)) (nhds (bs.sum g)),
     from tendsto_finset_sum bs $
-      assume c hc, tendsto_infi' c $ tendsto_infi' hc $ tendsto_comap.comp (hf c),
+      assume c hc, tendsto_infi' c $ tendsto_infi' hc $ by apply tendsto.comp (hf c) tendsto_comap,
   have bs.sum g ∈ s,
     from mem_of_closed_of_tendsto' this hsc $ forall_sets_neq_empty_iff_neq_bot.mp $
       by simp [mem_inf_sets, exists_imp_distrib, and_imp, forall_and_distrib,

--- a/src/topology/algebra/monoid.lean
+++ b/src/topology/algebra/monoid.lean
@@ -59,7 +59,7 @@ continuous_iff_continuous_at.mp (topological_monoid.continuous_mul α) (a, b)
 lemma tendsto_mul {f : β → α} {g : β → α} {x : filter β} {a b : α}
   (hf : tendsto f x (nhds a)) (hg : tendsto g x (nhds b)) :
   tendsto (λx, f x * g x) x (nhds (a * b)) :=
-(hf.prod_mk hg).comp (by rw [←nhds_prod_eq]; exact tendsto_mul')
+tendsto.comp (by rw [←nhds_prod_eq]; exact tendsto_mul') (hf.prod_mk hg)
 
 @[to_additive tendsto_list_sum]
 lemma tendsto_list_prod {f : γ → β → α} {x : filter β} {a : γ → α} :

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -143,20 +143,22 @@ end
 lemma tendsto_max {b : filter β} {a₁ a₂ : α} (hf : tendsto f b (nhds a₁)) (hg : tendsto g b (nhds a₂)) :
   tendsto (λb, max (f b) (g b)) b (nhds (max a₁ a₂)) :=
 show tendsto ((λp:α×α, max p.1 p.2) ∘ (λb, (f b, g b))) b (nhds (max a₁ a₂)),
-  from (hf.prod_mk hg).comp
+  from tendsto.comp
     begin
       rw [←nhds_prod_eq],
       from continuous_iff_continuous_at.mp (continuous_max continuous_fst continuous_snd) _
     end
+    (hf.prod_mk hg)
 
 lemma tendsto_min {b : filter β} {a₁ a₂ : α} (hf : tendsto f b (nhds a₁)) (hg : tendsto g b (nhds a₂)) :
   tendsto (λb, min (f b) (g b)) b (nhds (min a₁ a₂)) :=
 show tendsto ((λp:α×α, min p.1 p.2) ∘ (λb, (f b, g b))) b (nhds (min a₁ a₂)),
-  from (hf.prod_mk hg).comp
+  from tendsto.comp
     begin
       rw [←nhds_prod_eq],
       from continuous_iff_continuous_at.mp (continuous_min continuous_fst continuous_snd) _
     end
+    (hf.prod_mk hg)
 
 end decidable_linear_order
 

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -33,7 +33,7 @@ class uniform_add_group (α : Type*) [uniform_space α] [add_group α] : Prop :=
 theorem uniform_add_group.mk' {α} [uniform_space α] [add_group α]
   (h₁ : uniform_continuous (λp:α×α, p.1 + p.2))
   (h₂ : uniform_continuous (λp:α, -p)) : uniform_add_group α :=
-⟨(uniform_continuous_fst.prod_mk (uniform_continuous_snd.comp h₂)).comp h₁⟩
+⟨h₁.comp (uniform_continuous_fst.prod_mk (h₂.comp uniform_continuous_snd))⟩
 
 variables [uniform_space α] [add_group α] [uniform_add_group α]
 
@@ -42,7 +42,7 @@ uniform_add_group.uniform_continuous_sub α
 
 lemma uniform_continuous_sub [uniform_space β] {f : β → α} {g : β → α}
   (hf : uniform_continuous f) (hg : uniform_continuous g) : uniform_continuous (λx, f x - g x) :=
-(hf.prod_mk hg).comp uniform_continuous_sub'
+uniform_continuous_sub'.comp (hf.prod_mk hg)
 
 lemma uniform_continuous_neg [uniform_space β] {f : β → α}
   (hf : uniform_continuous f) : uniform_continuous (λx, - f x) :=
@@ -70,9 +70,9 @@ instance [uniform_space β] [add_group β] [uniform_add_group β] : uniform_add_
 ⟨uniform_continuous.prod_mk
   (uniform_continuous_sub
     (uniform_continuous_fst.comp uniform_continuous_fst)
-    (uniform_continuous_snd.comp uniform_continuous_fst))
+    (uniform_continuous_fst.comp uniform_continuous_snd))
   (uniform_continuous_sub
-    (uniform_continuous_fst.comp uniform_continuous_snd)
+    (uniform_continuous_snd.comp uniform_continuous_fst)
     (uniform_continuous_snd.comp uniform_continuous_snd)) ⟩
 
 lemma uniformity_translate (a : α) : (𝓤 α).map (λx:α×α, (x.1 + a, x.2 + a)) = 𝓤 α :=
@@ -126,7 +126,7 @@ begin
   { simp only [is_add_group_hom.map_sub f] },
   rw [uniform_continuous, uniformity_eq_comap_nhds_zero α, uniformity_eq_comap_nhds_zero β,
     tendsto_comap_iff, this],
-  exact tendsto.comp tendsto_comap h
+  exact tendsto.comp h tendsto_comap
 end
 
 lemma uniform_continuous_of_continuous [uniform_space β] [add_group β] [uniform_add_group β]
@@ -154,7 +154,7 @@ def topological_add_group.to_uniform_space : uniform_space G :=
   begin
     suffices : tendsto ((λp, -p) ∘ (λp:G×G, p.2 - p.1)) (comap (λp:G×G, p.2 - p.1) (nhds 0)) (nhds (-0)),
     { simpa [(∘), tendsto_comap_iff] },
-    exact tendsto.comp tendsto_comap (tendsto_neg tendsto_id)
+    exact tendsto.comp (tendsto_neg tendsto_id) tendsto_comap
   end,
   comp                :=
   begin
@@ -201,7 +201,7 @@ have tendsto
     ((λp:(G×G), p.1 - p.2) ∘ (λp:(G×G)×(G×G), (p.1.2 - p.1.1, p.2.2 - p.2.1)))
     (comap (λp:(G×G)×(G×G), (p.1.2 - p.1.1, p.2.2 - p.2.1)) ((nhds 0).prod (nhds 0)))
     (nhds (0 - 0)) :=
-  tendsto_comap.comp (tendsto_sub tendsto_fst tendsto_snd),
+  (tendsto_sub tendsto_fst tendsto_snd).comp tendsto_comap,
 begin
   constructor,
   rw [uniform_continuous, uniformity_prod_eq_prod, tendsto_map'_iff,
@@ -374,7 +374,7 @@ begin
     rw [nhds_prod_eq, prod_comap_comap_eq, ←nhds_prod_eq],
     exact (this : _) },
 
-  have lim := tendsto.comp lim1 (is_Z_bilin.tendsto_zero_right hφ y₁),
+  have lim := tendsto.comp (is_Z_bilin.tendsto_zero_right hφ y₁) lim1,
   rw tendsto_prod_self_iff at lim,
   exact lim W' W'_nhd,
 end
@@ -400,7 +400,7 @@ begin
     { have := filter.prod_mono (tendsto_sub_comap_self de x₀) (tendsto_sub_comap_self df y₀),
       rwa prod_map_map_eq at this },
     rw ← nhds_prod_eq at lim_sub_sub,
-    exact tendsto.comp lim_sub_sub lim_φ },
+    exact tendsto.comp lim_φ lim_sub_sub },
 
   rcases exists_nhds_quarter W'_nhd with ⟨W, W_nhd, W4⟩,
 

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -526,17 +526,22 @@ begin
   exact ⟨u, λ x xu xs, hu ⟨xu, xs⟩, openu, au⟩
 end
 
+theorem inter_mem_nhds_within (s : set α) {t : set α} {a : α} (h : t ∈ nhds a) :
+  s ∩ t ∈ nhds_within a s :=
+inter_mem_sets (mem_inf_sets_of_right (mem_principal_self s)) (mem_inf_sets_of_left h)
+
 theorem nhds_within_mono (a : α) {s t : set α} (h : s ⊆ t) : nhds_within a s ≤ nhds_within a t :=
 lattice.inf_le_inf (le_refl _) (principal_mono.mpr h)
 
+theorem nhds_within_restrict' {a : α} (s : set α) {t : set α} (h : t ∈ nhds a) :
+  nhds_within a s = nhds_within a (s ∩ t) :=
+le_antisymm
+  (lattice.le_inf lattice.inf_le_left (le_principal_iff.mpr (inter_mem_nhds_within s h)))
+  (lattice.inf_le_inf (le_refl _) (principal_mono.mpr (set.inter_subset_left _ _)))
+
 theorem nhds_within_restrict {a : α} (s : set α) {t : set α} (h₀ : a ∈ t) (h₁ : is_open t) :
   nhds_within a s = nhds_within a (s ∩ t) :=
-have s ∩ t ∈ nhds_within a s,
-  from inter_mem_sets (mem_inf_sets_of_right (mem_principal_self s))
-         (mem_inf_sets_of_left (mem_nhds_sets h₁ h₀)),
-le_antisymm
-  (lattice.le_inf lattice.inf_le_left (le_principal_iff.mpr this))
-  (lattice.inf_le_inf (le_refl _) (principal_mono.mpr (set.inter_subset_left _ _)))
+nhds_within_restrict' s (mem_nhds_sets h₁ h₀)
 
 theorem nhds_within_eq_nhds_within {a : α} {s t u : set α}
     (h₀ : a ∈ s) (h₁ : is_open s) (h₂ : t ∩ s = u ∩ s) :

--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -756,7 +756,7 @@ by rw [nhds_cons, tendsto, map_prod]; exact le_refl _
 lemma tendsto_cons {f : α → β} {g : α → list β}
   {a : _root_.filter α} {b : β} {l : list β} (hf : tendsto f a (nhds b)) (hg : tendsto g a (nhds l)):
   tendsto (λa, list.cons (f a) (g a)) a (nhds (b :: l)) :=
-(tendsto.prod_mk hf hg).comp tendsto_cons'
+tendsto_cons'.comp (tendsto.prod_mk hf hg)
 
 lemma tendsto_cons_iff [topological_space β]
   {f : list α → β} {b : _root_.filter β} {a : α} {l : list α} :
@@ -785,8 +785,8 @@ begin
   { exact tendsto_pure_pure _ _ },
   { assume l a ih,
     dsimp only [list.length],
-    refine tendsto.comp _ (tendsto_pure_pure (λx, x + 1) _),
-    refine tendsto.comp tendsto_snd ih }
+    refine tendsto.comp (tendsto_pure_pure (λx, x + 1) _) _,
+    refine tendsto.comp ih tendsto_snd }
 end
 
 lemma tendsto_insert_nth' {a : α} : ∀{n : ℕ} {l : list α},
@@ -807,14 +807,14 @@ lemma tendsto_insert_nth' {a : α} : ∀{n : ℕ} {l : list α},
   begin
     rw [this, tendsto_map'_iff],
     exact tendsto_cons
-      (tendsto_snd.comp tendsto_fst)
-      ((tendsto.prod_mk tendsto_fst (tendsto_snd.comp tendsto_snd)).comp (@tendsto_insert_nth' n l))
+      (tendsto_fst.comp tendsto_snd)
+      ((@tendsto_insert_nth' n l).comp (tendsto.prod_mk tendsto_fst (tendsto_snd.comp tendsto_snd)))
   end
 
 lemma tendsto_insert_nth {n : ℕ} {a : α} {l : list α} {f : β → α} {g : β → list α}
   {b : _root_.filter β} (hf : tendsto f b (nhds a)) (hg : tendsto g b (nhds l)) :
   tendsto (λb:β, insert_nth n (f b) (g b)) b (nhds (insert_nth n a l)) :=
-(tendsto.prod_mk hf hg).comp tendsto_insert_nth'
+tendsto_insert_nth'.comp (tendsto.prod_mk hf hg)
 
 lemma continuous_insert_nth {n : ℕ} : continuous (λp:α×list α, insert_nth n p.1 p.2) :=
 continuous_iff_continuous_at.mpr $
@@ -828,7 +828,7 @@ lemma tendsto_remove_nth : ∀{n : ℕ} {l : list α},
   begin
     rw [tendsto_cons_iff],
     dsimp [remove_nth],
-    exact tendsto_cons tendsto_fst (tendsto_snd.comp (@tendsto_remove_nth n l))
+    exact tendsto_cons tendsto_fst ((@tendsto_remove_nth n l).comp tendsto_snd)
   end
 
 lemma continuous_remove_nth {n : ℕ} : continuous (λl : list α, remove_nth l n) :=
@@ -849,7 +849,7 @@ lemma tendsto_cons [topological_space α] {n : ℕ} {a : α} {l : vector α n}:
   tendsto (λp:α×vector α n, vector.cons p.1 p.2) ((nhds a).prod (nhds l)) (nhds (a :: l)) :=
 by
   simp [tendsto_subtype_rng, cons_val];
-  exact tendsto_cons tendsto_fst (tendsto.comp tendsto_snd continuous_at_subtype_val)
+  exact tendsto_cons tendsto_fst (tendsto.comp continuous_at_subtype_val tendsto_snd)
 
 lemma tendsto_insert_nth
   [topological_space α] {n : ℕ} {i : fin (n+1)} {a:α} :
@@ -859,7 +859,7 @@ lemma tendsto_insert_nth
 begin
   rw [insert_nth, tendsto_subtype_rng],
   simp [insert_nth_val],
-  exact list.tendsto_insert_nth tendsto_fst (tendsto.comp tendsto_snd continuous_at_subtype_val)
+  exact list.tendsto_insert_nth tendsto_fst (tendsto.comp continuous_at_subtype_val tendsto_snd : _)
 end
 
 lemma continuous_insert_nth' [topological_space α] {n : ℕ} {i : fin (n+1)} :
@@ -880,7 +880,7 @@ lemma continuous_at_remove_nth [topological_space α] {n : ℕ} {i : fin (n+1)} 
 begin
   rw [continuous_at, remove_nth, tendsto_subtype_rng],
   simp [remove_nth_val],
-  exact continuous_at_subtype_val.comp list.tendsto_remove_nth
+  exact tendsto.comp list.tendsto_remove_nth continuous_at_subtype_val
 end
 
 lemma continuous_remove_nth [topological_space α] {n : ℕ} {i : fin (n+1)} :

--- a/src/topology/instances/complex.lean
+++ b/src/topology/instances/complex.lean
@@ -58,7 +58,7 @@ tendsto_of_uniform_continuous_subtype
 
 lemma continuous_inv' : continuous (λa:{r:ℂ // r ≠ 0}, a.val⁻¹) :=
 continuous_iff_continuous_at.mpr $ assume ⟨r, hr⟩,
-  (continuous_iff_continuous_at.mp continuous_subtype_val _).comp (tendsto_inv hr)
+  tendsto.comp (tendsto_inv hr) (continuous_iff_continuous_at.mp continuous_subtype_val _)
 
 lemma continuous_inv {α} [topological_space α] {f : α → ℂ} (h : ∀a, f a ≠ 0) (hf : continuous f) :
   continuous (λa, (f a)⁻¹) :=

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -97,7 +97,7 @@ lemma continuous_of_real : continuous ennreal.of_real :=
 
 lemma tendsto_of_real {f : filter α} {m : α → ℝ} {a : ℝ} (h : tendsto m f (nhds a)) :
   tendsto (λa, ennreal.of_real (m a)) f (nhds (ennreal.of_real a)) :=
-tendsto.comp h (continuous.tendsto continuous_of_real _)
+tendsto.comp (continuous.tendsto continuous_of_real _) h
 
 lemma tendsto_to_nnreal {a : ennreal} : a ≠ ⊤ →
   tendsto (ennreal.to_nnreal) (nhds a) (nhds a.to_nnreal) :=
@@ -183,7 +183,7 @@ protected lemma tendsto_mul {f : filter α} {ma : α → ennreal} {mb : α → e
   (hma : tendsto ma f (nhds a)) (ha : a ≠ 0 ∨ b ≠ ⊤) (hmb : tendsto mb f (nhds b)) (hb : b ≠ 0 ∨ a ≠ ⊤) :
   tendsto (λa, ma a * mb a) f (nhds (a * b)) :=
 show tendsto ((λp:ennreal×ennreal, p.1 * p.2) ∘ (λa, (ma a, mb a))) f (nhds (a * b)), from
-tendsto.comp (tendsto_prod_mk_nhds hma hmb) (ennreal.tendsto_mul' ha hb)
+tendsto.comp (ennreal.tendsto_mul' ha hb) (tendsto_prod_mk_nhds hma hmb)
 
 protected lemma tendsto_mul_right {f : filter α} {m : α → ennreal} {a b : ennreal}
   (hm : tendsto m f (nhds b)) (hb : b ≠ 0 ∨ a ≠ ⊤) : tendsto (λb, a * m b) f (nhds (a * b)) :=
@@ -287,7 +287,7 @@ have Inf ((λb, ↑r - b) '' range b) = ↑r - (⨆i, b i),
     (assume x _ y _, sub_le_sub (le_refl _))
     is_lub_supr
     (ne_empty_of_mem ⟨i, rfl⟩)
-    (tendsto.comp (tendsto_id' inf_le_left) ennreal.tendsto_coe_sub),
+    (tendsto.comp ennreal.tendsto_coe_sub (tendsto_id' inf_le_left)),
 by rw [eq, ←this]; simp [Inf_image, infi_range, -mem_range]; exact le_refl _
 
 end topological_space
@@ -608,6 +608,6 @@ theorem tendsto_edist {f g : β → α} {x : filter β} {a b : α}
   tendsto (λx, edist (f x) (g x)) x (nhds (edist a b)) :=
 have tendsto (λp:α×α, edist p.1 p.2) (nhds (a, b)) (nhds (edist a b)),
   from continuous_iff_continuous_at.mp continuous_edist' (a, b),
-(hf.prod_mk hg).comp (by rw [nhds_prod_eq] at this; exact this)
+tendsto.comp (by rw [nhds_prod_eq] at this; exact this) (hf.prod_mk hg)
 
 end --section

--- a/src/topology/instances/nnreal.lean
+++ b/src/topology/instances/nnreal.lean
@@ -74,7 +74,7 @@ lemma tendsto_coe {f : filter α} {m : α → nnreal} :
 
 lemma tendsto_of_real {f : filter α} {m : α → ℝ} {x : ℝ} (h : tendsto m f (nhds x)):
   tendsto (λa, nnreal.of_real (m a)) f (nhds (nnreal.of_real x)) :=
-h.comp (continuous_iff_continuous_at.1 continuous_of_real _)
+tendsto.comp (continuous_iff_continuous_at.1 continuous_of_real _) h
 
 lemma tendsto_sub {f : filter α} {m n : α → nnreal} {r p : nnreal}
   (hm : tendsto m f (nhds r)) (hn : tendsto n f (nhds p)) :

--- a/src/topology/instances/real.lean
+++ b/src/topology/instances/real.lean
@@ -72,8 +72,8 @@ let ⟨δ, δ0, Hδ⟩ := rat_add_continuous_lemma abs ε0 in
 -- TODO(Mario): Find a way to use rat_add_continuous_lemma
 theorem rat.uniform_continuous_add : uniform_continuous (λp : ℚ × ℚ, p.1 + p.2) :=
 uniform_embedding_of_rat.uniform_continuous_iff.2 $ by simp [(∘)]; exact
-((uniform_continuous_fst.comp uniform_continuous_of_rat).prod_mk
-  (uniform_continuous_snd.comp uniform_continuous_of_rat)).comp real.uniform_continuous_add
+real.uniform_continuous_add.comp ((uniform_continuous_of_rat.comp uniform_continuous_fst).prod_mk
+  (uniform_continuous_of_rat.comp uniform_continuous_snd))
 
 theorem real.uniform_continuous_neg : uniform_continuous (@has_neg.neg ℝ _) :=
 metric.uniform_continuous_iff.2 $ λ ε ε0, ⟨_, ε0, λ a b h,
@@ -148,7 +148,7 @@ tendsto_of_uniform_continuous_subtype
 
 lemma real.continuous_inv' : continuous (λa:{r:ℝ // r ≠ 0}, a.val⁻¹) :=
 continuous_iff_continuous_at.mpr $ assume ⟨r, hr⟩,
-  (continuous_iff_continuous_at.mp continuous_subtype_val _).comp (real.tendsto_inv hr)
+  tendsto.comp (real.tendsto_inv hr) (continuous_iff_continuous_at.mp continuous_subtype_val _)
 
 lemma real.continuous_inv [topological_space α] {f : α → ℝ} (h : ∀a, f a ≠ 0) (hf : continuous f) :
   continuous (λa, (f a)⁻¹) :=

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -737,7 +737,7 @@ end⟩)
 theorem uniform_continuous_dist [uniform_space β] {f g : β → α}
   (hf : uniform_continuous f) (hg : uniform_continuous g) :
   uniform_continuous (λb, dist (f b) (g b)) :=
-(hf.prod_mk hg).comp uniform_continuous_dist'
+uniform_continuous_dist'.comp (hf.prod_mk hg)
 
 theorem continuous_dist' : continuous (λp:α×α, dist p.1 p.2) :=
 uniform_continuous_dist'.continuous
@@ -751,7 +751,7 @@ theorem tendsto_dist {f g : β → α} {x : filter β} {a b : α}
   tendsto (λx, dist (f x) (g x)) x (nhds (dist a b)) :=
 have tendsto (λp:α×α, dist p.1 p.2) (nhds (a, b)) (nhds (dist a b)),
   from continuous_iff_continuous_at.mp continuous_dist' (a, b),
-(hf.prod_mk hg).comp (by rw [nhds_prod_eq] at this; exact this)
+tendsto.comp (by rw [nhds_prod_eq] at this; exact this) (hf.prod_mk hg)
 
 lemma nhds_comap_dist (a : α) : (nhds (0 : ℝ)).comap (λa', dist a' a) = nhds a :=
 have h₁ : ∀ε, (λa', dist a' a) ⁻¹' ball 0 ε ⊆ ball a ε,

--- a/src/topology/metric_space/completion.lean
+++ b/src/topology/metric_space/completion.lean
@@ -27,7 +27,7 @@ instance : has_dist (completion α) :=
 /-- The new distance is uniformly continuous. -/
 protected lemma completion.uniform_continuous_dist :
   uniform_continuous (λp:completion α × completion α, dist p.1 p.2) :=
-uniform_continuous.comp uniform_continuous_prod uniform_continuous_extension
+uniform_continuous.comp uniform_continuous_extension uniform_continuous_prod
 
 /-- The new distance is an extension of the original distance. -/
 protected lemma completion.dist_eq (x y : α) : dist (x : completion α) y = dist x y :=

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -999,7 +999,7 @@ begin
   rcases cauchy_seq_tendsto_of_complete this with ⟨L, hL⟩,
   -- the images of `X3 n` in the Gromov-Hausdorff space converge to the image of `L`
   have M : tendsto (λn, (X3 n).to_GH_space) at_top (nhds L.to_GH_space) :=
-    tendsto.comp hL (to_GH_space_continuous.tendsto _),
+    tendsto.comp (to_GH_space_continuous.tendsto _) hL,
   -- By construction, the image of `X3 n` in the Gromov-Hausdorff space is `u n`.
   have : ∀n, (X3 n).to_GH_space = u n,
   { assume n,

--- a/src/topology/metric_space/lipschitz.lean
+++ b/src/topology/metric_space/lipschitz.lean
@@ -17,7 +17,7 @@ begin
   rcases hx with ⟨x₀, hx⟩,
   refine tendsto_nhds_unique at_top_ne_bot _ hx,
   rw [← tendsto_add_at_top_iff_nat 1, funext (assume n, nat.iterate_succ' f n x₀)],
-  exact hx.comp hf
+  exact hf.comp hx
 end
 
 /-- A Lipschitz function is uniformly continuous -/

--- a/src/topology/order.lean
+++ b/src/topology/order.lean
@@ -670,19 +670,31 @@ lemma continuous_at.continuous_within_at {f : α → β} {s : set α} {x : α} (
   continuous_within_at f s x :=
 continuous_within_at.mono ((continuous_within_at_univ f x).2 h) (subset_univ _)
 
-lemma continuous_on.comp {f : α → β} {g : β → γ} {s : set α} {t : set β}
-  (hf : continuous_on f s) (hg : continuous_on g t) (h : f '' s ⊆ t) :
-  continuous_on (g ∘ f) s :=
+lemma continuous_within_at.comp {g : β → γ} {f : α → β} {s : set α} {t : set β} {x : α}
+  (hg : continuous_within_at g t (f x)) (hf : continuous_within_at f s x) (h : f '' s ⊆ t) :
+  continuous_within_at (g ∘ f) s x :=
 begin
-  assume x hx,
   have : tendsto f (principal s) (principal t),
     by { rw tendsto_principal_principal, exact λx hx, h (mem_image_of_mem _ hx) },
   have : tendsto f (nhds_within x s) (principal t) :=
     tendsto_le_left lattice.inf_le_right this,
   have : tendsto f (nhds_within x s) (nhds_within (f x) t) :=
-    tendsto_inf.2 ⟨hf x hx, this⟩,
-  exact tendsto.comp this (hg _ (h (mem_image_of_mem _ hx)))
+    tendsto_inf.2 ⟨hf, this⟩,
+  exact tendsto.comp hg this
 end
+
+lemma continuous_at.comp {g : β → γ} {f : α → β} {x : α}
+  (hg : continuous_at g (f x)) (hf : continuous_at f x) :
+  continuous_at (g ∘ f) x :=
+begin
+  rw ← continuous_within_at_univ at *,
+  exact continuous_within_at.comp hg hf (subset_univ _)
+end
+
+lemma continuous_on.comp {g : β → γ} {f : α → β} {s : set α} {t : set β}
+  (hg : continuous_on g t) (hf : continuous_on f s) (h : f '' s ⊆ t) :
+  continuous_on (g ∘ f) s :=
+λx hx, continuous_within_at.comp (hg _ (h (mem_image_of_mem _ hx))) (hf x hx) h
 
 lemma continuous_on.mono {f : α → β} {s t : set α} (hf : continuous_on f s) (h : t ⊆ s)  :
   continuous_on f t :=

--- a/src/topology/sequences.lean
+++ b/src/topology/sequences.lean
@@ -133,7 +133,7 @@ lemma continuous.to_sequentially_continuous {f : α → β} (_ : continuous f) :
   sequentially_continuous f :=
 assume x limit (_ : x ⟶ limit),
 have tendsto f (nhds limit) (nhds (f limit)), from continuous.tendsto ‹continuous f› limit,
-show (f ∘ x) ⟶ (f limit), from tendsto.comp ‹(x ⟶ limit)› this
+show (f ∘ x) ⟶ (f limit), from tendsto.comp this ‹(x ⟶ limit)›
 
 /-- In a sequential space, continuity and sequential continuity coincide. -/
 lemma continuous_iff_sequentially_continuous {f : α → β} [sequential_space α] :

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -443,8 +443,8 @@ lemma uniform_continuous_const [uniform_space β] {b : β} : uniform_continuous 
 @tendsto_const_uniformity _ _ _ b (𝓤 α)
 
 lemma uniform_continuous.comp [uniform_space β] [uniform_space γ] {f : α → β} {g : β → γ}
-  (hf : uniform_continuous f) (hg : uniform_continuous g) : uniform_continuous (g ∘ f) :=
-hf.comp hg
+  (hg : uniform_continuous g) (hf : uniform_continuous f) : uniform_continuous (g ∘ f) :=
+hg.comp hf
 
 lemma uniform_continuous.continuous [uniform_space β] {f : α → β}
   (hf : uniform_continuous f) : continuous f :=
@@ -552,7 +552,7 @@ def uniform_space.comap (f : α → β) (u : uniform_space β) : uniform_space �
 { uniformity := u.uniformity.comap (λp:α×α, (f p.1, f p.2)),
   to_topological_space := u.to_topological_space.induced f,
   refl := le_trans (by simp; exact assume ⟨a, b⟩ (h : a = b), h ▸ rfl) (comap_mono u.refl),
-  symm := by simp [tendsto_comap_iff, prod.swap, (∘)]; exact tendsto_comap.comp tendsto_swap_uniformity,
+  symm := by simp [tendsto_comap_iff, prod.swap, (∘)]; exact tendsto_swap_uniformity.comp tendsto_comap,
   comp := le_trans
     begin
       rw [comap_lift'_eq, comap_lift'_eq2],
@@ -755,11 +755,11 @@ tendsto_inf.2 ⟨tendsto_comap_iff.2 h₁, tendsto_comap_iff.2 h₂⟩
 
 lemma uniform_continuous.prod_mk_left {f : α × β → γ} (h : uniform_continuous f) (b) :
   uniform_continuous (λ a, f (a,b)) :=
-(uniform_continuous_id.prod_mk uniform_continuous_const).comp h
+h.comp (uniform_continuous_id.prod_mk uniform_continuous_const)
 
 lemma uniform_continuous.prod_mk_right {f : α × β → γ} (h : uniform_continuous f) (a) :
   uniform_continuous (λ b, f (a,b)) :=
-(uniform_continuous_const.prod_mk  uniform_continuous_id).comp h
+h.comp (uniform_continuous_const.prod_mk  uniform_continuous_id)
 
 lemma to_topological_space_prod [u : uniform_space α] [v : uniform_space β] :
   @uniform_space.to_topological_space (α × β) prod.uniform_space =

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -360,8 +360,8 @@ instance : has_coe α (completion α) := ⟨quotient.mk ∘ pure_cauchy⟩
 protected lemma coe_eq : (coe : α → completion α) = quotient.mk ∘ pure_cauchy := rfl
 
 lemma uniform_continuous_coe : uniform_continuous (coe : α → completion α) :=
-uniform_continuous.comp uniform_embedding_pure_cauchy.uniform_continuous
-  uniform_continuous_quotient_mk
+uniform_continuous.comp
+  uniform_continuous_quotient_mk uniform_embedding_pure_cauchy.uniform_continuous
 
 lemma continuous_coe : continuous (coe : α → completion α) :=
 uniform_continuous.continuous (uniform_continuous_coe α)
@@ -485,7 +485,7 @@ lemma continuous_map : continuous (completion.map f) :=
 uniform_continuous_extension.continuous
 
 @[simp] lemma map_coe (hf : uniform_continuous f) (a : α) : (completion.map f) a = f a :=
-by rw [completion.map, extension_coe]; from hf.comp (uniform_continuous_coe β)
+by rw [completion.map, extension_coe]; from (uniform_continuous_coe β).comp hf
 
 lemma map_unique {f : α → β} {g : completion α → completion β}
   (hg : uniform_continuous g) (h : ∀a:α, ↑(f a) = g a) : completion.map f = g :=
@@ -493,7 +493,7 @@ completion.ext continuous_map hg.continuous $
 begin
   intro a,
   simp only [completion.map, (∘), h],
-  rw [extension_coe ((uniform_continuous_coe α).comp hg)]
+  rw [extension_coe (hg.comp (uniform_continuous_coe α))]
 end
 
 lemma map_id : completion.map (@id α) = id :=
@@ -503,11 +503,11 @@ lemma extension_map [complete_space γ] [separated γ] {f : β → γ} {g : α �
   (hf : uniform_continuous f) (hg : uniform_continuous g) :
   completion.extension f ∘ completion.map g = completion.extension (f ∘ g) :=
 completion.ext (continuous_extension.comp continuous_map) continuous_extension $
-  by intro a; simp only [hg, hf, hg.comp hf, (∘), map_coe, extension_coe]
+  by intro a; simp only [hg, hf, hf.comp hg, (∘), map_coe, extension_coe]
 
 lemma map_comp {g : β → γ} {f : α → β} (hg : uniform_continuous g) (hf : uniform_continuous f) :
   completion.map g ∘ completion.map f = completion.map (g ∘ f) :=
-extension_map (hg.comp (uniform_continuous_coe _)) hf
+extension_map ((uniform_continuous_coe _).comp hg) hf
 
 end map
 
@@ -556,7 +556,7 @@ lemma uniform_continuous_prod : uniform_continuous (@completion.prod α β _ _) 
 uniform_continuous_quotient_lift₂ $
   suffices uniform_continuous (quotient.mk ∘ Cauchy.prod),
   { convert this, ext ⟨a, b⟩, refl },
-  Cauchy.uniform_continuous_prod.comp uniform_continuous_quotient_mk
+  uniform_continuous_quotient_mk.comp Cauchy.uniform_continuous_prod
 
 lemma prod_coe_coe (a : α) (b : β) :
   completion.prod ((a : completion α), (b : completion β)) = (a, b) :=
@@ -571,7 +571,7 @@ completion.map (λp:α×β, f p.1 p.2) (completion.prod (a, b))
 
 lemma uniform_continuous_map₂' (f : α → β → γ) :
   uniform_continuous (λp:completion α×completion β, completion.map₂ f p.1 p.2) :=
-uniform_continuous.comp uniform_continuous_prod completion.uniform_continuous_map
+uniform_continuous.comp completion.uniform_continuous_map uniform_continuous_prod
 
 lemma continuous_map₂ {δ} [topological_space δ] {f : α → β → γ}
   {a : δ → completion α} {b : δ → completion β} (ha : continuous a) (hb : continuous b) :

--- a/src/topology/uniform_space/separation.lean
+++ b/src/topology/uniform_space/separation.lean
@@ -108,7 +108,7 @@ instance {α : Type u} [u : uniform_space α] : uniform_space (quotient (separat
   uniformity := map (λp:(α×α), (⟦p.1⟧, ⟦p.2⟧)) u.uniformity,
   refl := le_trans (by simp [quotient.exists_rep]) (filter.map_mono refl_le_uniformity),
   symm := tendsto_map' $
-    by simp [prod.swap, (∘)]; exact tendsto_swap_uniformity.comp tendsto_map,
+    by simp [prod.swap, (∘)]; exact tendsto_map.comp tendsto_swap_uniformity,
   comp := calc (map (λ (p : α × α), (⟦p.fst⟧, ⟦p.snd⟧)) u.uniformity).lift' (λs, comp_rel s s) =
           u.uniformity.lift' ((λs, comp_rel s s) ∘ image (λ (p : α × α), (⟦p.fst⟧, ⟦p.snd⟧))) :
       map_lift'_eq2 $ monotone_comp_rel monotone_id monotone_id
@@ -239,7 +239,7 @@ def map (f : α → β) : separation_quotient α → separation_quotient β :=
 lift (quotient.mk ∘ f)
 
 lemma map_mk {f : α → β} (h : uniform_continuous f) (a : α) : map f ⟦a⟧ = ⟦f a⟧ :=
-by rw [map, lift_mk (h.comp uniform_continuous_quotient_mk)]
+by rw [map, lift_mk (uniform_continuous_quotient_mk.comp h)]
 
 lemma uniform_continuous_map (f : α → β): uniform_continuous (map f) :=
 uniform_continuous_lift (quotient.mk ∘ f)
@@ -256,7 +256,7 @@ map_unique uniform_continuous_id rfl
 
 lemma map_comp {f : α → β} {g : β → γ} (hf : uniform_continuous f) (hg : uniform_continuous g) :
   map g ∘ map f = map (g ∘ f) :=
-(map_unique (hf.comp hg) $ by simp only [(∘), map_mk, hf, hg]).symm
+(map_unique (hg.comp hf) $ by simp only [(∘), map_mk, hf, hg]).symm
 
 end separation_quotient
 


### PR DESCRIPTION
Followup to #1035 : I has forgotten `tendsto.comp` and `uniform_continuous.comp` and `continuous_on.comp`.