### PR TITLE
feat(tactic/linarith): better input syntax linarith only [...]

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -553,9 +553,9 @@ example (x y z : ℚ) (h1 : 2*x  < 3*y) (h2 : -4*x + 2*z < 0)
 by linarith
 ```
 
-`linarith` will use all relevant hypotheses in the local context.
+`linarith` will use all appropriate hypotheses and the negation of the goal, if applicable.
 
-`linarith [t1, t2, t3]` will add proof terms t1, t2, t3 to the local context.
+`linarith [t1, t2, t3]` will additionally use proof terms `t1, t2, t3`.
 
 `linarith only [h1, h2, h3, t1, t2, t3]` will use only the goal (if relevant), local hypotheses
 h1, h2, h3, and proofs t1, t2, t3. It will ignore the rest of the local context.

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -553,12 +553,12 @@ example (x y z : ℚ) (h1 : 2*x  < 3*y) (h2 : -4*x + 2*z < 0)
 by linarith
 ```
 
-`linarith` will use all appropriate hypotheses and the negation of the goal, if applicable.
+`linarith` will use all relevant hypotheses in the local context.
 
-`linarith h1 h2 h3` will ohly use the local hypotheses `h1`, `h2`, `h3`.
+`linarith [t1, t2, t3]` will add proof terms t1, t2, t3 to the local context.
 
-`linarith using [t1, t2, t3]` will add `t1`, `t2`, `t3` to the local context and then run
-`linarith`.
+`linarith only [h1, h2, h3, t1, t2, t3]` will use only the goal (if relevant), local hypotheses
+h1, h2, h3, and proofs t1, t2, t3. It will ignore the rest of the local context.
 
 `linarith!` will use a stronger reducibility setting to try to identify atoms. For example,
 ```lean

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -560,6 +560,14 @@ by linarith
 `linarith using [t1, t2, t3]` will add `t1`, `t2`, `t3` to the local context and then run
 `linarith`.
 
+`linarith!` will use a stronger reducibility setting to try to identify atoms. For example,
+```lean
+example (x : ℚ) : id x ≥ x :=
+by linarith
+```
+will fail, because `linarith` will not identify `x` and `id x`. `linarith!` will.
+This can sometimes be expensive.
+
 `linarith {discharger := tac, restrict_type := tp, exfalso := ff}` takes a config object with three optional
 arguments.
 * `discharger` specifies a tactic to be used for reducing an algebraic equation in the

--- a/src/analysis/complex/exponential.lean
+++ b/src/analysis/complex/exponential.lean
@@ -175,7 +175,7 @@ lemma pi_div_two_pos : 0 < π / 2 :=
 half_pos pi_pos
 
 lemma two_pi_pos : 0 < 2 * π :=
-by linarith using [pi_pos]
+by linarith [pi_pos]
 
 @[simp] lemma sin_pi : sin π = 0 :=
 by rw [← mul_div_cancel_left pi (@two_ne_zero ℝ _), two_mul, add_div,
@@ -385,9 +385,9 @@ lemma cos_lt_cos_of_nonneg_of_le_pi {x y : ℝ} (hx₁ : 0 ≤ x) (hx₂ : x ≤
 match (le_total x (π / 2) : x ≤ π / 2 ∨ π / 2 ≤ x), le_total y (π / 2) with
 | or.inl hx, or.inl hy := cos_lt_cos_of_nonneg_of_le_pi_div_two hx₁ hx hy₁ hy hxy
 | or.inl hx, or.inr hy := (lt_or_eq_of_le hx).elim
-  (λ hx, calc cos y ≤ 0 : cos_nonpos_of_pi_div_two_le_of_le hy (by linarith using [pi_pos])
+  (λ hx, calc cos y ≤ 0 : cos_nonpos_of_pi_div_two_le_of_le hy (by linarith [pi_pos])
     ... < cos x : cos_pos_of_neg_pi_div_two_lt_of_lt_pi_div_two (by linarith) hx)
-  (λ hx, calc cos y < 0 : cos_neg_of_pi_div_two_lt_of_lt (by linarith) (by linarith using [pi_pos])
+  (λ hx, calc cos y < 0 : cos_neg_of_pi_div_two_lt_of_lt (by linarith) (by linarith [pi_pos])
     ... = cos x : by rw [hx, cos_pi_div_two])
 | or.inr hx, or.inl hy := by linarith
 | or.inr hx, or.inr hy := neg_lt_neg_iff.1 (by rw [← cos_pi_sub, ← cos_pi_sub];
@@ -590,7 +590,7 @@ sin_inj_of_le_of_le_pi_div_two
 sin_inj_of_le_of_le_pi_div_two
   (neg_pi_div_two_le_arcsin _)
   (arcsin_le_pi_div_two _)
-  (by linarith using [pi_pos])
+  (by linarith [pi_pos])
   (le_refl _)
   (by rw [sin_arcsin, sin_pi_div_two]; norm_num)
 
@@ -641,10 +641,10 @@ lemma arccos_eq_pi_div_two_sub_arcsin (x : ℝ) : arccos x = π / 2 - arcsin x :
 lemma arcsin_eq_pi_div_two_sub_arccos (x : ℝ) : arcsin x = π / 2 - arccos x := by simp [arccos]
 
 lemma arccos_le_pi (x : ℝ) : arccos x ≤ π :=
-by unfold arccos; linarith using [neg_pi_div_two_le_arcsin x]
+by unfold arccos; linarith [neg_pi_div_two_le_arcsin x]
 
 lemma arccos_nonneg (x : ℝ) : 0 ≤ arccos x :=
-by unfold arccos; linarith using [arcsin_le_pi_div_two x]
+by unfold arccos; linarith [arcsin_le_pi_div_two x]
 
 lemma cos_arccos {x : ℝ} (hx₁ : -1 ≤ x) (hx₂ : x ≤ 1) : cos (arccos x) = x :=
 by rw [arccos, cos_pi_div_two_sub, sin_arcsin hx₁ hx₂]
@@ -707,10 +707,10 @@ match lt_or_eq_of_le h0x, lt_or_eq_of_le hxp with
 end
 
 lemma tan_neg_of_neg_of_pi_div_two_lt {x : ℝ} (hx0 : x < 0) (hpx : -(π / 2) < x) : tan x < 0 :=
-neg_pos.1 (tan_neg x ▸ tan_pos_of_pos_of_lt_pi_div_two (by linarith) (by linarith using [pi_pos]))
+neg_pos.1 (tan_neg x ▸ tan_pos_of_pos_of_lt_pi_div_two (by linarith) (by linarith [pi_pos]))
 
 lemma tan_nonpos_of_nonpos_of_neg_pi_div_two_le {x : ℝ} (hx0 : x ≤ 0) (hpx : -(π / 2) ≤ x) : tan x ≤ 0 :=
-neg_nonneg.1 (tan_neg x ▸ tan_nonneg_of_nonneg_of_le_pi_div_two (by linarith) (by linarith using [pi_pos]))
+neg_nonneg.1 (tan_neg x ▸ tan_nonneg_of_nonneg_of_le_pi_div_two (by linarith) (by linarith [pi_pos]))
 
 lemma tan_lt_tan_of_nonneg_of_lt_pi_div_two {x y : ℝ} (hx₁ : 0 ≤ x) (hx₂ : x < π / 2) (hy₁ : 0 ≤ y)
   (hy₂ : y < π / 2) (hxy : x < y) : tan x < tan y :=
@@ -827,7 +827,7 @@ else
       exact real.arcsin_nonpos (by rw [neg_im, neg_div, neg_nonpos]; exact div_nonneg hx₂ (abs_pos.2 hx)))
   else by rw [arg, if_neg hx₁, if_neg hx₂];
       exact sub_le_iff_le_add.2 (le_trans (real.arcsin_le_pi_div_two _)
-        (by linarith using [real.pi_pos]))
+        (by linarith [real.pi_pos]))
 
 lemma neg_pi_lt_arg (x : ℂ) : -π < arg x :=
 if hx₁ : 0 ≤ x.re
@@ -838,7 +838,7 @@ else
   if hx₂ : 0 ≤ x.im
   then by rw [arg, if_neg hx₁, if_pos hx₂];
     exact sub_lt_iff_lt_add.1
-      (lt_of_lt_of_le (by linarith using [real.pi_pos]) (real.neg_pi_div_two_le_arcsin _))
+      (lt_of_lt_of_le (by linarith [real.pi_pos]) (real.neg_pi_div_two_le_arcsin _))
   else by rw [arg, if_neg hx₁, if_neg hx₂];
     exact lt_sub_iff_add_lt.2 (by rw neg_add_self;
       exact real.arcsin_pos (by rw [neg_im]; exact div_pos (neg_pos.2 (lt_of_not_ge hx₂))

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -836,7 +836,7 @@ calc x + 1 ≤ lim (⟨(λ n : ℕ, ((exp' x) n).re), is_cau_seq_re (exp' x)⟩ 
 ... = exp x : by rw [exp, complex.exp, ← cau_seq_re, lim_re]
 
 lemma one_le_exp {x : ℝ} (hx : 0 ≤ x) : 1 ≤ exp x :=
-by linarith using [add_one_le_exp_of_nonneg hx]
+by linarith [add_one_le_exp_of_nonneg hx]
 
 lemma exp_pos (x : ℝ) : 0 < exp x :=
 (le_total 0 x).elim (lt_of_lt_of_le zero_lt_one ∘ one_le_exp)

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -626,9 +626,9 @@ do l ← local_context,
    r ← successes (l.reverse.map (λ h, cases h >> skip)),
    when (r.empty) failed
 
-meta def note_anon (e : expr) : tactic unit :=
+meta def note_anon (e : expr) : tactic expr :=
 do n ← get_unused_name "lh",
-   note n none e, skip
+   note n none e
 
 /-- `find_local t` returns a local constant with type t, or fails if none exists. -/
 meta def find_local (t : pexpr) : tactic expr :=

--- a/src/tactic/ring.lean
+++ b/src/tactic/ring.lean
@@ -18,6 +18,7 @@ meta structure cache :=
 (α : expr)
 (univ : level)
 (comm_semiring_inst : expr)
+(red : transparency)
 
 meta def ring_m (α : Type) : Type :=
 reader_t cache (state_t (buffer expr) tactic) α
@@ -30,21 +31,25 @@ meta def get_cache : ring_m cache := reader_t.read
 meta def get_atom (n : ℕ) : ring_m expr :=
 reader_t.lift $ (λ es : buffer expr, es.read' n) <$> state_t.get
 
+meta def get_transparency : ring_m transparency :=
+cache.red <$> get_cache
+
 meta def add_atom (e : expr) : ring_m ℕ :=
+do red ← get_transparency,
 reader_t.lift ⟨λ es, (do
-  n ← es.iterate failed (λ n e' t, t <|> (is_def_eq e e' $> n)),
+  n ← es.iterate failed (λ n e' t, t <|> (is_def_eq e e' red $> n)),
   return (n, es)) <|> return (es.size, es.push_back e)⟩
 
 meta def lift {α} (m : tactic α) : ring_m α :=
 reader_t.lift (state_t.lift m)
 
-meta def ring_m.run (e : expr) {α} (m : ring_m α) : tactic α :=
+meta def ring_m.run (red : transparency) (e : expr) {α} (m : ring_m α) : tactic α :=
 do α ← infer_type e,
    c ← mk_app ``comm_semiring [α] >>= mk_instance,
    u ← mk_meta_univ,
    infer_type α >>= unify (expr.sort (level.succ u)),
    u ← get_univ_assignment u,
-   prod.fst <$> state_t.run (reader_t.run m ⟨α, u, c⟩) mk_buffer
+   prod.fst <$> state_t.run (reader_t.run m ⟨α, u, c, red⟩) mk_buffer
 
 meta def cache.cs_app (c : cache) (n : name) : list expr → expr :=
 (@expr.const tt n [c.univ] c.α c.comm_semiring_inst).mk_app
@@ -409,8 +414,8 @@ meta def eval : expr → ring_m (horner_expr × expr)
   | none := eval_atom e
   end
 
-meta def eval' (e : expr) : tactic (expr × expr) :=
-ring_m.run e $ do (e', p) ← eval e, return (e', p)
+meta def eval' (red : transparency) (e : expr) : tactic (expr × expr) :=
+ring_m.run red e $ do (e', p) ← eval e, return (e', p)
 
 theorem horner_def' {α} [comm_semiring α] (a x n b) : @horner α _ a x n b = x ^ n * a + b :=
 by simp [horner, mul_comm]
@@ -429,7 +434,7 @@ theorem add_neg_eq_sub {α} [add_group α] (a b : α) : a + -b = a - b := rfl
 @[derive has_reflect]
 inductive normalize_mode | raw | SOP | horner
 
-meta def normalize (mode := normalize_mode.horner) (e : expr) : tactic (expr × expr) := do
+meta def normalize (red : transparency) (mode := normalize_mode.horner) (e : expr) : tactic (expr × expr) := do
 pow_lemma ← simp_lemmas.mk.add_simp ``pow_one,
 let lemmas := match mode with
 | normalize_mode.SOP :=
@@ -445,10 +450,10 @@ lemmas ← lemmas.mfoldl simp_lemmas.add_simp simp_lemmas.mk,
 (_, e', pr) ← ext_simplify_core () {}
   simp_lemmas.mk (λ _, failed) (λ _ _ _ _ e, do
     (new_e, pr) ← match mode with
-    | normalize_mode.raw := eval'
-    | normalize_mode.horner := trans_conv eval' (simplify lemmas [])
+    | normalize_mode.raw := eval' red
+    | normalize_mode.horner := trans_conv (eval' red) (simplify lemmas [])
     | normalize_mode.SOP :=
-      trans_conv eval' $
+      trans_conv (eval' red) $
       trans_conv (simplify lemmas []) $
       simp_bottom_up' (λ e, norm_num e <|> pow_lemma.rewrite e)
     end e,
@@ -468,9 +473,9 @@ local postfix `?`:9001 := optional
 /-- Tactic for solving equations in the language of rings.
   This version of `ring` fails if the target is not an equality
   that is provable by the axioms of commutative (semi)rings. -/
-meta def ring1 : tactic unit :=
+meta def ring1 (red : transparency) : tactic unit :=
 do `(%%e₁ = %%e₂) ← target,
-  ((e₁', p₁), (e₂', p₂)) ← ring_m.run e₁ $
+  ((e₁', p₁), (e₂', p₂)) ← ring_m.run red e₁ $
     prod.mk <$> eval e₁ <*> eval e₂,
   is_def_eq e₁' e₂',
   p ← mk_eq_symm p₂ >>= mk_eq_trans p₁,
@@ -491,14 +496,16 @@ end
   specifier and the target is an equality, but if this
   fails it falls back to rewriting all ring expressions
   into a normal form. When writing a normal form,
-  `ring SOP` will use sum-of-products form instead of horner form. -/
-meta def ring (SOP : parse ring.mode) (loc : parse location) : tactic unit :=
+  `ring SOP` will use sum-of-products form instead of horner form.
+  `ring!` will use a more aggressive reducibility setting to identify atoms. -/
+meta def ring (red : parse (tk "!")?) (SOP : parse ring.mode) (loc : parse location) : tactic unit :=
+let transp := if red.is_some then semireducible else reducible in
 match loc with
-| interactive.loc.ns [none] := ring1
+| interactive.loc.ns [none] := ring1 transp
 | _ := failed
 end <|>
 do ns ← loc.get_locals,
-   tt ← tactic.replace_at (normalize SOP) ns loc.include_goal
+   tt ← tactic.replace_at (normalize transp SOP) ns loc.include_goal
       | fail "ring failed to simplify",
    when loc.include_goal $ try tactic.reflexivity
 
@@ -510,9 +517,12 @@ open conv interactive
 open tactic tactic.interactive (ring.mode ring1)
 open tactic.ring (normalize)
 
-meta def ring (SOP : parse ring.mode) : conv unit :=
-discharge_eq_lhs ring1
-<|> replace_lhs (normalize SOP)
+local postfix `?`:9001 := optional
+
+meta def ring (red : parse (lean.parser.tk "!")?) (SOP : parse ring.mode) : conv unit :=
+let transp := if red.is_some then semireducible else reducible in
+discharge_eq_lhs (ring1 transp)
+<|> replace_lhs (normalize transp SOP)
 <|> fail "ring failed to simplify"
 
 end conv.interactive

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -66,7 +66,7 @@ example (a b c : ℚ) (h2 : (2 : ℚ) > 3)  : a + b - c ≥ 3 :=
 by linarith {exfalso := ff}
 
 example (x : ℚ) (hx : x > 0) (h : x.num < 0) : false :=
-by linarith using [rat.num_pos_iff_pos.mpr hx]
+by linarith [rat.num_pos_iff_pos.mpr hx, h]
 
 example (x y z : ℚ) (hx : x ≤ 3*y) (h2 : y ≤ 2*z) (h3 : x ≥ 6*z) : x = 3*y :=
 by linarith
@@ -115,7 +115,8 @@ example
 (A : ℚ) (l : ℚ) (h : A - l ≤ -(A - l)) (h_1 : ¬A ≤ -A) (h_2 : ¬l ≤ -l)
 (h_3 : -(A - l) < 1) :  A < l + 1 := by linarith
 
-example (d : ℚ) (q n : ℕ) (h1 : ((q : ℚ) - 1)*n ≥ 0) (h2 : d = 2/3*(((q : ℚ) - 1)*n)) : d ≤ ((q : ℚ) - 1)*n :=
+example (d : ℚ) (q n : ℕ) (h1 : ((q : ℚ) - 1)*n ≥ 0) (h2 : d = 2/3*(((q : ℚ) - 1)*n)) :
+  d ≤ ((q : ℚ) - 1)*n :=
 by linarith
 
 example (d : ℚ) (q n : ℕ) (h1 : ((q : ℚ) - 1)*n ≥ 0) (h2 : d = 2/3*(((q : ℚ) - 1)*n)) :
@@ -127,3 +128,9 @@ by linarith
 
 example (x : ℚ) : id x ≥ x :=
 by success_if_fail {linarith}; linarith!
+
+example (x y z : ℚ) (hx : x < 5) (hx2 : x > 5) (hy : y < 5000000000) (hz : z > 34*y) : false :=
+by linarith only [hx, hx2]
+
+example (x y z : ℚ) (hx : x < 5) (hy : y < 5000000000) (hz : z > 34*y) : x ≤ 5 :=
+by linarith only [hx]

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -126,4 +126,4 @@ example (a : ℚ) (ha : 0 ≤ a): 0 * 0 ≤ 2 * a :=
 by linarith
 
 example (x : ℚ) : id x ≥ x :=
-by linarith
+by success_if_fail {linarith}; linarith!

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -68,6 +68,9 @@ by linarith {exfalso := ff}
 example (x : ℚ) (hx : x > 0) (h : x.num < 0) : false :=
 by linarith [rat.num_pos_iff_pos.mpr hx, h]
 
+example (x : ℚ) (hx : x > 0) (h : x.num < 0) : false :=
+by linarith only [rat.num_pos_iff_pos.mpr hx, h]
+
 example (x y z : ℚ) (hx : x ≤ 3*y) (h2 : y ≤ 2*z) (h3 : x ≥ 6*z) : x = 3*y :=
 by linarith
 

--- a/test/ring.lean
+++ b/test/ring.lean
@@ -2,7 +2,7 @@ import tactic.ring data.real.basic
 
 example (x y : ℕ) : x + y = y + x := by ring
 example (x y : ℕ) : x + y + y = 2 * y + x := by ring
-example (x y : ℕ) : x + id y = y + id x := by ring
+example (x y : ℕ) : x + id y = y + id x := by ring!
 example {α} [comm_ring α] (x y : α) : x + y + y - x = 2 * y := by ring
 example (x y : ℚ) : x / 2 + x / 2 = x := by ring
 example (x y : ℚ) : (x + y) ^ 3 = x ^ 3 + y ^ 3 + 3 * (x * y ^ 2 + x ^ 2 * y) := by ring


### PR DESCRIPTION
This builds on #1053 .

`linarith` supports the option to restrict which hypotheses it uses. This used to have the syntax `linarith h1 h2 h3`. The interaction with adding extra hypotheses was buggy: `linarith h1 h2 h3 using [t1, t2, t3]` wouldn't actually use `t1, t2, t3`.

Rather than just fix the interaction, this PR changes the input syntax.
* `linarith using [t1, t2, t3]` becomes `linarith [t1, t2, t3]`
* `linarith h1 h2 h3` becomes `linarith only [h1, h2, h3]`
* `linarith h1 h2 h3 using [t1, t2, t3]` becomes `linarith only [h1, h2, h3, t1, t2, t3]`

There's a slight change to the behavior of `linarith only`. Before, this would not include the (negation of) the goal, and there was no convenient way to include it. Now the goal is included by default. The most convenient way to omit it is `exfalso; linarith only [...]`. This is not relevant anywhere in mathlib right now and including the goal will generally not have much of a negative effect.

 TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
