### PR TITLE
feat(tactic/spass): interface with SPASS

### DIFF
--- a/src/tactic/spass/arifix.lean
+++ b/src/tactic/spass/arifix.lean
@@ -1,0 +1,175 @@
+/-
+  Copyright (c) 2019 Seul Baek. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Seul Baek
+
+  `arifix` is similar to `form₂.holds`, but fixes the
+  arity of each quantifier's domain. This is necessary
+  for unification with the initial goal from which the
+  reified formula was obtained.
+-/
+
+import tactic.spass.swap
+
+variable {α : Type}
+
+local notation f `₀↦` a := assign a f
+local notation `#`      := term₂.var
+local notation a `&` b  := term₂.app a b
+
+postfix  `ₑ` : 1000 := evaluate
+postfix  `ᵈ` : 1000 := denote
+local infix `⬝`     := value.app
+
+local notation `⟪` b `,` a `⟫` := form₂.lit b a
+local notation p `∨₂` q        := form₂.bin tt p q
+local notation p `∧₂` q        := form₂.bin ff p q
+local notation `∃₂`            := form₂.qua tt
+local notation `∀₂`            := form₂.qua ff
+
+open nat
+
+def nary (α : Type) : bool → nat → Type
+| ff 0       := α
+| tt 0       := Prop
+| b  (n + 1) := α → (nary b n)
+
+def nary.val [inhabited α] : ∀ {b : bool} {k : nat}, nary α b k → value α
+| ff 0       f []        := (f, false)
+| tt 0       f []        := (default α, f)
+| _  (k + 1) f []        := (default α, false)
+| _  0       f (_ :: _)  := (default α, false)
+| ff (k + 1) f (a :: as) := @nary.val ff k (f a) as
+| tt (k + 1) f (a :: as) := @nary.val tt k (f a) as
+
+def term₂.arity (k : nat) : term₂ → option (bool × nat)
+| (# m)   := if k = m then some (tt, 0) else none
+| (t & s) :=
+  (t.arity >>= λ x, some $ if x.fst then (x.fst, x.snd + 1) else x) <|>
+  (prod.map (λ _, ff) id <$> s.arity)
+
+def term₂.arity_app {k : nat} {t s : term₂} :
+  (t & s).arity k =
+  ((t.arity k >>= λ x, some $ if x.fst then (x.fst, x.snd + 1) else x) <|>
+   (prod.map (λ _, ff) id <$> s.arity k)) := rfl
+
+def form₂.arity_core : nat → form₂ → option (bool × nat)
+| k ⟪b, t⟫            := t.arity k
+| k (form₂.bin _ p q) := p.arity_core k <|> q.arity_core k
+| k (form₂.qua _ p)   := p.arity_core (k + 1)
+
+def form₂.arity (k : nat) (p : form₂) : bool × nat :=
+option.get_or_else (p.arity_core k) (ff, 0)
+
+def option.if_is_some (p : α → Prop) : option α → Prop
+| none     := true
+| (some a) := p a
+
+open option
+
+lemma term₂.arity_eq_const_of_fov (k : nat) :
+  ∀ (t : term₂), t.fov k → if_is_some ((=) (ff, 0)) (t.arity k)
+| (# m) h0 :=
+  by { unfold term₂.arity,
+       rw if_neg h0, trivial }
+| (t & (# m)) h0 :=
+  begin
+    have h1 := term₂.arity_eq_const_of_fov t h0.left,
+    unfold term₂.arity,
+    cases t.arity k with x,
+    { rw [none_bind, none_orelse],
+      by_cases h2 : k = m,
+      { rw if_pos h2,
+        simp only [if_is_some, id.def, map_some, prod.map] },
+      rw if_neg h2, trivial },
+    rw [some_bind, some_orelse],
+    cases x with b n,
+    have h2 : b = ff,
+    { cases h1, refl },
+    have h3 : n = 0,
+    { cases h1, refl },
+    simp only [if_is_some, h2, h3,
+      bool.coe_sort_ff, if_false]
+  end
+| (t & (s & r)) h0 :=
+  begin
+    have h1 := term₂.arity_eq_const_of_fov t h0.left,
+    have h2 := term₂.arity_eq_const_of_fov (s & r) h0.right,
+    rw term₂.arity_app,
+    cases t.arity k with x,
+    { rw [none_bind, none_orelse],
+      cases term₂.arity k (s&r) with x,
+      { trivial },
+      cases x with b n,
+      have h3 : n = 0,
+      { cases h2, refl },
+      simp only [if_is_some, h3,
+        id.def, map_some, prod.map] },
+    rw [some_bind, some_orelse],
+    cases x with b n,
+    have h3 : b = ff,
+    { cases h1, refl },
+    have h4 : n = 0,
+    { cases h1, refl },
+    simp only [if_is_some, h3, h4,
+      bool.coe_sort_ff, if_false]
+  end
+
+lemma form₂.arity_core_eq_const_of_fov :
+  ∀ (k : nat) (p : form₂), p.fov k →
+  if_is_some ((=) (ff, 0)) (p.arity_core k)
+| k ⟪b, t⟫ h0 := term₂.arity_eq_const_of_fov _ _ h0
+| k (form₂.bin b p q) h0 :=
+  begin
+    have hp := form₂.arity_core_eq_const_of_fov k p h0.left,
+    have hq := form₂.arity_core_eq_const_of_fov k q h0.right,
+    unfold form₂.arity_core,
+    cases (p.arity_core k) with x,
+    { rw [option.none_orelse], exact hq },
+    rw [option.some_orelse], exact hp
+  end
+| k (form₂.qua b p) h0 :=
+  form₂.arity_core_eq_const_of_fov (k + 1) _ h0
+
+lemma form₂.arity_eq_const_of_fov (k : nat) (p : form₂) :
+  p.fov k → p.arity k = (ff, 0) :=
+begin
+  intro h0, unfold form₂.arity,
+  have h1 := form₂.arity_core_eq_const_of_fov k p h0,
+  cases (p.arity_core k) with x, refl,
+  apply eq.symm, exact h1
+end
+
+def arifix [inhabited α] : model α → form₂ → Prop
+| M ⟪tt, a⟫  :=   (a.val M []).snd
+| M ⟪ff, a⟫  := ¬ (a.val M []).snd
+| M (p ∨₂ q) := arifix M p ∨ arifix M q
+| M (p ∧₂ q) := arifix M p ∧ arifix M q
+| M (∀₂ p)   := ∀ x : nary α (p.arity 0).fst (p.arity 0).snd, arifix (M ₀↦ x.val) p
+| M (∃₂ p)   := ∃ x : nary α (p.arity 0).fst (p.arity 0).snd, arifix (M ₀↦ x.val) p
+
+lemma arifix_of_holds [inhabited α] :
+  ∀ {M : model α} {p : form₂}, foq tt p → p.holds M → arifix M p
+| M ⟪tt, a⟫  h0 h1 := h1
+| M ⟪ff, a⟫  h0 h1 := h1
+| M (p ∨₂ q) h0 h1 :=
+  by { cases h0, cases h1; [`[left], `[right]];
+       apply arifix_of_holds; assumption }
+| M (p ∧₂ q) h0 h1 :=
+  by { cases h0, cases h1, constructor;
+       apply arifix_of_holds; assumption }
+| M (∀₂ p)   h0 h1 := λ _, arifix_of_holds h0.right (h1 _)
+| M (∃₂ p)   h0 h1 :=
+  begin
+    cases h1 with v h1,
+    have h2 := h0.left rfl,
+    have h3 : form₂.arity 0 p = (ff, 0),
+    { exact form₂.arity_eq_const_of_fov 0 p (h0.left rfl) },
+    have h4 : (M ₀↦ (nary.val (v ᵈ : nary α ff 0))) ⊨ p,
+    { apply (holds_iff_holds_of_eq_except p _ h2).elim_left h1,
+      refine ⟨_, rfl⟩,
+      { intros m hm, cases m,
+        { cases hm rfl }, refl } },
+    unfold arifix, rw h3,
+    refine ⟨(v []).fst, arifix_of_holds h0.right h4⟩
+  end

--- a/src/tactic/spass/cnf.lean
+++ b/src/tactic/spass/cnf.lean
@@ -1,0 +1,257 @@
+/-
+  Copyright (c) 2019 Seul Baek. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Seul Baek
+
+  CNF formulas.
+-/
+
+import data.list.min_max
+import tactic.spass.list
+import tactic.spass.folize
+import tactic.spass.misc
+
+universe u
+
+variable {α : Type u}
+
+open list
+
+local notation `&`     := term.sym
+local notation a `&` b := term.app a b
+local notation a `#` k := term.vpp a k
+
+local notation `⟪` b `,` a `⟫` := form.lit b a
+local notation p `∨₁` q        := form.bin tt p q
+local notation p `∧₁` q        := form.bin ff p q
+
+@[reducible] def cla : Type := list term × list term
+@[reducible] def mat : Type := list cla
+
+def cla.append : cla → cla → cla
+| (nts1, pts1) (nts2, pts2) := (nts1 ++ nts2, pts1 ++ pts2)
+
+def cnf : form → mat
+| ⟪ff, t⟫   := [([t],[])]
+| ⟪tt, t⟫   := [([],[t])]
+| (p ∨₁ q) :=
+  (list.product (cnf p) (cnf q)).map
+    (λ x, cla.append x.fst x.snd)
+| (p ∧₁ q) := (cnf p) ++ (cnf q)
+
+namespace cla
+
+def vars : cla → list nat
+| (nc, pc) := ((nc ∪ pc).map term.vars).foldl list.union []
+
+def fresh_var : cla → nat
+| (nc, pc) := ((nc ++ pc).map term.fresh_var).maximum
+
+def subst (π : smaps) : cla → cla
+| (nts, pts) := (nts.map (term.subst π), pts.map (term.subst π))
+
+def rename (f : nat → nat) : cla → cla
+| (nts, pts) := (nts.map (term.rename f), pts.map (term.rename f))
+
+def holds (M : model α) (v : vas α) : cla → Prop
+| (nts, pts) :=
+  (∃ t ∈ nts, ¬ term.holds M v t) ∨ (∃ t ∈ pts, term.holds M v t)
+
+def fav (M : model α) (c : cla) : Prop :=
+∀ v : vas α, holds M v c
+
+def satisfies (M : model α) (c : cla) : Prop :=
+∀ v : vas α, holds M v c
+
+lemma holds_rename (M : model α) (v : vas α) (f : nat → nat) (c : cla) :
+  holds M v (c.rename f) ↔ holds M (v ∘ f) c :=
+begin
+  cases c with nc pc,
+  simp only [cla.rename, cla.holds],
+  apply pred_mono_2; apply iff.symm;
+  apply @list.exists_mem_iff_exists_mem_map
+    term term _ _ (term.rename f) _ _;
+  intro t; rw term.holds_rename
+end
+
+lemma holds_subst (M : model α) (v : vas α) (μ : smaps) (c : cla) :
+  holds M v (c.subst μ) ↔ holds M (v.subst M μ) c :=
+begin
+  cases c with nc pc,
+  simp only [cla.subst, vas.subst, cla.holds],
+  apply pred_mono_2; apply iff.symm;
+  apply @list.exists_mem_iff_exists_mem_map
+    term term _ _ (term.subst μ) _ _;
+  intro t; rw term.holds_subst
+end
+
+def repr_aux : list term → string
+| []        := "⬝"
+| [t]       := t.repr
+| (t :: ts) := t.repr ++ "," ++ repr_aux ts
+
+def repr : cla → string
+| (nts, pts) :=
+  repr_aux nts ++ " ⊢ " ++ repr_aux pts
+
+instance has_repr : has_repr cla := ⟨repr⟩
+meta instance has_to_format : has_to_format cla := ⟨λ x, repr x⟩
+
+def get_ref : cla → nat → (bool × nat)
+| (nc, pc) k :=
+  if k < nc.length
+  then (ff, k)
+  else (tt, k - nc.length)
+
+def nth : cla → bool → nat → option term
+| (nc, pc) ff k := nc.nth k
+| (nc, pc) tt k := pc.nth k
+
+def length : cla → nat
+| (nc, pc) := nc.length + pc.length
+
+def permutations : cla → list cla
+| (nc, pc) := list.product nc.permutations pc.permutations
+
+def exteq : cla → cla → Prop
+| (nc, pc) (nd, pd) := list.exteq nc nd ∧ list.exteq pc pd
+
+lemma holds_of_exteq {M : model α} {v : vas α} {c d : cla} :
+  c.holds M v → cla.exteq c d → d.holds M v :=
+begin
+  cases c with nc pc,
+  cases d with nd pd,
+  rintros (⟨t, h0, h1⟩ | ⟨t, h0, h1⟩) ⟨hc, hd⟩,
+  { left, refine ⟨t, _, h1⟩,
+    apply list.subset_of_exteq _ _ hc h0 },
+  right, refine ⟨t, _, h1⟩,
+  apply list.subset_of_exteq _ _ hd h0
+end
+
+instance decidable_exteq :
+  ∀ c d : cla, decidable (cla.exteq c d)
+| (nc, pc) (nd, pd) := and.decidable
+end cla
+
+namespace mat
+
+def holds (M : model α) (v : nat → α) (m : mat) : Prop :=
+∀ c ∈ m, cla.holds M v c
+
+def fav (M : model α) (m : mat) : Prop :=
+∀ v : vas α, m.holds M v
+
+end mat
+
+lemma holds_cnf_of_holds {M : model α} {v : nat → α} :
+  ∀ p : form, p.holds M v → (cnf p).holds M v
+| ⟪b, a⟫ h0 :=
+  begin
+    intros c h1, cases b;
+    rw eq_of_mem_singleton h1;
+    [left, right];
+    refine ⟨_, or.inl rfl, _⟩;
+    apply h0
+  end
+| (p ∧₁ q) h0 :=
+  begin
+    cases h0 with hp hq,
+    replace hp := holds_cnf_of_holds _ hp,
+    replace hq := holds_cnf_of_holds _ hq,
+    simp only [mat.holds, cnf],
+    rw forall_mem_append, refine ⟨hp, hq⟩
+  end
+| (p ∨₁ q) h0 :=
+  begin
+    simp only [mat.holds, cnf, mem_map],
+    rintros c ⟨⟨c1, c2⟩, h1, h2⟩,
+    simp only [prod.fst, prod.snd] at h2, subst h2,
+    rw mem_product at h1, cases h1 with hc1 hc2,
+    cases c1 with nc1 pc1,
+    cases c2 with nc2 pc2,
+    simp only [cla.holds, cla.append, exists_mem_append],
+    cases h0,
+    { cases holds_cnf_of_holds _ h0 _ hc1 with h1 h1,
+      { left, left, assumption },
+      right, left, assumption },
+    cases holds_cnf_of_holds _ h0 _ hc2 with h1 h1,
+    { left, right, assumption },
+    right, right, assumption
+  end
+
+def term.print_core : term → list char
+| (& k) := ('s' :: k.repr.data).reverse
+| (t & s) :=
+  match term.print_core t with
+  | [] := []
+  | (')' :: cs) :=
+    ')' :: (term.print_core s ++ (',' :: cs))
+  | (c :: cs) :=
+    ')' :: (term.print_core s ++ ('(' :: c :: cs))
+  end
+| (t # k) :=
+  match term.print_core t with
+  | [] := []
+  | (')' :: cs) :=
+    ')' :: (('X' :: k.repr.data).reverse ++ (',' :: cs))
+  | (c :: cs) :=
+    ')' :: (('X' :: k.repr.data).reverse ++ ('(' :: c :: cs))
+  end
+
+def term.print (t : term) : string :=
+⟨(term.print_core t).reverse⟩
+
+def cla.print : nat → cla → string
+| k (nts, pts) :=
+  "cnf(c" ++ k.repr ++ ", negated_conjecture, (" ++
+   ( match nts.map (λ x, "~ " ++ term.print x)  ++ pts.map term.print with
+     | []        := ""
+     | (s :: ss) := ss.foldl (λ x y , x ++ " | " ++ y ) s
+     end )
+   ++ "))."
+
+def mat.print_core : nat → mat → string
+| _ []       := ""
+| k (c :: m) := cla.print k c ++ " " ++ mat.print_core (k + 1) m
+
+def mat.print (m : mat) : string := mat.print_core 1 m
+
+def mat.repr_core : nat → mat → string
+| _ [] := ""
+| k (c :: m) := k.repr ++ ". " ++ c.repr ++ "\n" ++ mat.repr_core (k + 1) m
+
+def mat.repr := mat.repr_core 1
+
+instance mat.has_repr : has_repr mat := ⟨mat.repr⟩
+
+def term.renumbering : term → smaps → smaps
+| (term.sym _) := id
+| (term.app t s) := s.renumbering ∘ t.renumbering
+| (term.vpp t k) :=
+  λ μ,
+  let μ' := t.renumbering μ in
+  if ∃ x ∈ μ', prod.fst x = k
+  then μ'
+  else (k, sum.inl μ'.length) :: μ'
+
+def cla.renumbering : cla → smaps
+| (nc, pc) := list.foldl (λ x y, term.renumbering y x) [] (nc ++ pc)
+
+def cla.renumber (c : cla) : cla :=
+c.subst c.renumbering
+
+def mat.renumber (m : mat) : mat :=
+m.map cla.renumber
+
+lemma fav_renumber_of_fav
+  (M : model α) (m : mat) :
+  m.fav M → m.renumber.fav M :=
+begin
+  intros h0 v c h1,
+  unfold mat.renumber at h1,
+  rw mem_map at h1,
+  rcases h1 with ⟨d, h2, h3⟩, subst h3,
+  unfold cla.renumber,
+  rw cla.holds_subst,
+  apply h0 _ _ h2
+end

--- a/src/tactic/spass/compile.lean
+++ b/src/tactic/spass/compile.lean
@@ -1,0 +1,282 @@
+/-
+  Copyright (c) 2019 Seul Baek. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Seul Baek
+
+  Compilation of parsed SPASS proof output into detailed proof recipes.
+-/
+
+import tactic.spass.parse
+
+open tactic
+
+def disjoiner (c d : cla) : smaps :=
+d.vars.map (λ k, (k, sum.inl $ k + c.fresh_var))
+
+meta def unifier : term → term → tactic smaps
+| (term.sym k) (term.sym m) :=
+  guard (k = m) >> return []
+| (term.app t1 t2) (term.app s1 s2) :=
+  do μ ← unifier t2 s2,
+     ν ← unifier (t1.subst μ) (s1.subst μ),
+     return (smaps.compose ν μ)
+| (term.app t1 t2) (term.vpp s k) :=
+  do guard (¬ k ∈ t2.vars),
+     μ ← unifier (t1.subst [(k, sum.inr t2)]) (s.subst [(k, sum.inr t2)]),
+     return (smaps.compose μ [(k, sum.inr t2)])
+| (term.vpp t k) (term.app s1 s2) :=
+  do guard (¬ k ∈ s2.vars),
+     μ ← unifier (t.subst [(k, sum.inr s2)]) (s1.subst [(k, sum.inr s2)]),
+     return (smaps.compose μ [(k, sum.inr s2)])
+| (term.vpp t k) (term.vpp s m) :=
+  do μ ← unifier (t.subst [(m, sum.inl k)]) (s.subst [(m, sum.inl k)]),
+     return (smaps.compose μ [(m, sum.inl k)])
+| t s := fail ("Nonunifiable terms : " ++ t.repr ++ " " ++ s.repr)
+
+meta def unifiers (δ : smaps) (t s : term) : tactic (smaps × smaps) :=
+do μ ← unifier t (s.subst δ),
+   return (μ, smaps.compose μ δ)
+
+meta def instantiator.merge_core : smaps → smaps → smaps → tactic smaps
+| [] μ ν             := return (μ ++ ν)
+| ((m, t) :: ξ) μ ν  :=
+  match ν.find (λ x, prod.fst x = m) with
+  | none := instantiator.merge_core ξ ((m, t) :: μ) ν
+  | some ns :=
+    if t = ns.snd
+    then instantiator.merge_core ξ μ ν
+    else failed
+  end
+
+meta def instantiator.merge : smaps → smaps → tactic smaps
+| μ ν := instantiator.merge_core μ [] ν
+
+meta def term.instantiator : term → term → tactic smaps
+| (term.sym k) (term.sym m) :=
+  guard (k = m) >> return []
+| (term.app t1 t2) (term.app s1 s2) :=
+  do μ ← term.instantiator t2 s2,
+     ν ← term.instantiator t1 s1,
+     instantiator.merge μ ν
+| (term.vpp t k) (term.app s1 s2) :=
+  do μ ← term.instantiator t s1,
+     instantiator.merge μ [(k, sum.inr s2)]
+| (term.vpp t k) (term.vpp s m) :=
+  do μ ← term.instantiator t s,
+     instantiator.merge μ [(k, sum.inl m)]
+| _ _ := fail "RHS is not an instance of LHS"
+
+meta def terms.instantiator : list term → list term → tactic smaps
+| [] [] := return []
+| (t :: ts) (s :: ss) :=
+  do μ ← term.instantiator t s,
+     ν ← terms.instantiator ts ss,
+     instantiator.merge μ ν
+| _ _ := failed
+
+meta def cla.instantiator : cla → cla → tactic smaps
+| (nc, pc) (nd, pd) :=
+  do μ ← terms.instantiator nc nd,
+     ν ← terms.instantiator pc pd,
+     instantiator.merge μ ν
+
+meta def find_line (k : nat) : list line → tactic line
+| []                := failed
+| (⟨m, r, c⟩ :: ls) :=
+  if k = m
+  then return ⟨m, r, c⟩
+  else find_line ls
+
+def ref_update (npad ppad nlen idx r : nat) : nat :=
+let r' := if idx < r then r - 1 else r in
+let padding := npad + (if r < nlen then 0 else ppad) in
+r' + padding
+
+meta def compare_return (s : string) (c d : cla) (ρx : expr) : tactic expr :=
+if c = d
+then return ρx
+else do trace (s ++ "Derived clause not equal to target."),
+        trace "Derived clause : ", trace c,
+        trace "Target clause : ", trace d,
+        failed
+
+meta def term.find_dup (t : term) : nat → list term → tactic (nat × smaps)
+| _ [] := failed
+| k (s :: ts) :=
+  ( do _ ← term.instantiator t s,
+       μ ← term.instantiator s t,
+       return (k, μ) ) <|> ( term.find_dup (k + 1) ts )
+
+meta def side.find_dup : nat → list term → tactic (nat × smaps)
+| k []        := failed
+| k (t :: ts) :=
+  ( do (m, μ) ← t.find_dup 1 ts, return (k + m, μ) ) <|>
+  ( side.find_dup (k + 1) ts )
+
+meta def cla.find_dup : cla → tactic (bool × nat × smaps)
+| (nc, pc) :=
+  (do (k, μ) ← side.find_dup 0 nc, return (ff, k, μ)) <|>
+  (do (k, μ) ← side.find_dup 0 pc, return (tt, k, μ))
+
+meta def extract_ems_refs_core (k : nat) :
+  list (nat × nat) → (list nat × list (nat × nat))
+| []            := ([], [])
+| ((m, n) :: l) :=
+  if k = m
+  then let (ns, nns) := extract_ems_refs_core l in
+       (n :: ns, nns)
+  else ([], ((m, n) :: l))
+
+meta def extract_ems_refs : list (nat × nat) → tactic (nat × list nat × list (nat × nat))
+| [] := trace "Invalid ems refs" >> failed
+| ((k, m) :: l) :=
+  let (ns, nns) := extract_ems_refs_core k l in
+  return (k, (m :: ns), nns)
+
+meta mutual def compile_core, compile_ems,
+  compile_sub, compile_psub, compile_res,
+  compile_con, compile_obv, compile_obvs
+
+with compile_core : mat → list line → nat → rule → cla → tactic expr
+| A ls k rule.inp c :=
+  ( do d ← A.nth (k - 1),
+           compile_psub `(recipe.hyp $ %%`(k) - 1) d d.permutations c )
+  <|> (trace "Inp fail" >> failed)
+| A ls k (rule.res ln1 rf1 ln2 rf2) c :=
+  ( do ⟨m, r, d⟩ ← find_line ln1 ls,
+     ⟨n, s, e⟩ ← find_line ln2 ls,
+     ρ ← compile_core A ls m r d,
+     σ ← compile_core A ls n s e,
+     (τ, f) ← compile_res ρ d (rf1 - d.fst.length) σ e rf2,
+     compile_psub τ f f.permutations c )
+  <|> (trace "Res fail" >> failed)
+| A ls k (rule.unc ln1 rf1 ln2 rf2) c :=
+  ( do ⟨m, r, d⟩ ← find_line ln1 ls,
+     ⟨n, s, e⟩ ← find_line ln2 ls,
+     ρ ← compile_core A ls m r d,
+     σ ← compile_core A ls n s e,
+     (τ, f) ← ( if rf1 < d.fst.length
+                then compile_res σ e rf2 ρ d rf1
+                else compile_res ρ d rf1 σ e rf2 ),
+    compare_return "[UnC]" f ([], []) τ )
+  <|> (trace "Unc fail" >> failed)
+| A ls k (rule.obv ln rf) c :=
+  ( do ⟨m, r, d⟩ ← find_line ln ls,
+       ρ ← compile_core A ls m r d,
+       let (b, rf') := if rf < d.fst.length
+                       then (ff, rf)
+                       else (tt, rf - d.fst.length),
+       (σ, e) ← compile_obv ρ d b rf',
+       compare_return "[Obv]" e c σ )
+  <|> (trace "Obv fail" >> failed)
+| A ls k (rule.fac ln rf1 rf2) c :=
+  ( do ⟨m, r, d⟩ ← find_line ln ls,
+     ρ ← compile_core A ls m r d,
+     let (b1, i) := d.get_ref rf1,
+     let (b2, j) := d.get_ref rf2,
+     t ← d.nth b1 i,
+     s ← d.nth b2 j,
+     μ ← unifier t s,
+     (σ, e) ← compile_obv `(recipe.sub %%`(μ) %%ρ) (d.subst μ) b1 i,
+     compare_return "[Fac]" e c σ )
+  <|> (trace "Fac fail" >> failed)
+| A ls k (rule.con ln rf) c :=
+  ( do ⟨m, r, (nd, pd)⟩ ← find_line ln ls,
+     ρ ← compile_core A ls m r (nd, pd),
+     if rf < nd.length
+     then let nd' := nd.remove_nth rf in
+          do t ← nd.nth rf,
+             compile_con ρ (nd', pd) c rf ff nd' t
+     else let rf' := rf - nd.length in
+          let pd' := pd.remove_nth rf' in
+          do t ← pd.nth rf',
+             compile_con ρ (nd, pd') c rf' tt pd' t )
+  <|> (trace "Con fail" >> failed)
+| A ls k (rule.ems l) c :=
+( do (m, ms, mms) ← extract_ems_refs l,
+     ⟨n, s, d⟩ ← find_line m ls,
+     ρ ← compile_core A ls n s d,
+     (σ, e) ← compile_ems A ls ρ d ms [] mms,
+     compile_obvs σ e c )
+  <|> (trace ("EmS fail, line " ++ k.repr) >> failed)
+
+with compile_ems : mat → list line → expr → cla →
+  list nat → list (nat × nat) → list (nat × nat) → tactic (expr × cla)
+| _ _ ρ c [] _ _ := return (ρ, c)
+| _ _ ρ c _ _ [] := return (ρ, c)
+| A ls ρ (nc, pc) (k :: ks) l ((m, n) :: mns) :=
+( do ⟨i, s, (nd, pd)⟩ ← find_line m ls,
+     σ ← compile_core A ls i s (nd, pd),
+  if nc.length ≤ k
+  then do (τ, e) ← compile_res ρ (nc, pc) (k - nc.length) σ (nd, pd) n,
+          compile_ems A ls τ e (ks.map (ref_update 0 0 nc.length k)) [] (l ++ mns)
+  else do (τ, e) ← compile_res σ (nd, pd) (n - nd.length) ρ (nc, pc) k,
+          compile_ems A ls τ e (ks.map (ref_update nd.length (pd.length - 1) nc.length k)) [] (l ++ mns) )
+<|> (compile_ems A ls ρ (nc, pc) (k :: ks) (l ++ [(m, n)]) mns)
+
+with compile_sub : expr → cla → cla → tactic expr
+| ρ c d :=
+( do μ ← cla.instantiator c d,
+     compare_return "[Instantiation]" (c.subst μ) d `(recipe.sub %%`(μ) %%ρ) )
+
+with compile_psub : expr → cla → list cla → cla → tactic expr
+| ρ c [] e := trace "No more permutations" >> failed
+| ρ c (d :: ds) e :=
+  (compile_sub `(recipe.prm %%`(d) %%ρ) d e) <|>
+  (compile_psub ρ c ds e) <|>
+  (trace "Fail C-psub-2" >> failed)
+
+with compile_res : expr → cla → nat →
+  expr → cla → nat → tactic (expr × cla)
+| ρx (nc, pc) k σx (nd, pd) m :=
+( do t ← pc.nth k | fail "Cannot retrieve positive term",
+     s ← nd.nth m | fail "Cannot retrieve negative term",
+     (μ, ν) ← unifiers (disjoiner (nc, pc) (nd, pd)) t s,
+     let (nc', pc') := cla.subst μ (nc, pc.remove_nth k),
+     let (nd', pd') := cla.subst ν (nd.remove_nth m, pd),
+     return (`(recipe.res %%`(k) %%`(m) (recipe.sub %%`(μ) %%ρx) (recipe.sub %%`(ν) %%σx)),
+       (nc' ++ nd', pc' ++ pd')) )
+    <|> (do trace "Fail C-res.",
+            trace ("Pos cla : " ++ cla.repr (nc, pc)),
+            trace ("Pos idx : " ++ k.repr),
+            trace ("Neg cla : " ++ cla.repr (nd, pd)),
+            trace ("Neg idx : " ++ m.repr),
+            failed)
+
+with compile_con : expr → cla → cla → nat →
+  bool → list term → term → tactic expr
+| ρ d c rf b [] t        :=
+  (trace "Fain C-con-1" >> failed)
+| ρ d c rf b (s :: ts) t :=
+  (do μ ← unifier s t,
+      compile_sub `(recipe.con %%`(b) %%`(rf) $
+      recipe.sub %%`(μ) %%ρ) (d.subst μ) c) <|>
+  (compile_con ρ d c rf b ts t)
+  <|> (trace "Fain C-con-2" >> failed)
+
+with compile_obv : expr → cla → bool → nat → tactic (expr × cla)
+| ρ (nc, pc) ff rf :=
+  let nc' := nc.remove_nth rf in
+( do t ← nc.nth rf,
+     guard (t ∈ nc'),
+     return (`(recipe.con ff %%`(rf) %%ρ), (nc', pc)) )
+<|> (trace "fail C-obv-1" >> failed)
+| ρ (nc, pc) tt rf :=
+  let pc' := pc.remove_nth rf in
+( do t ← pc.nth rf,
+     guard (t ∈ pc'),
+     return (`(recipe.con tt %%`(rf) %%ρ), (nc, pc')) )
+<|> (trace "fail C-obv-2" >> failed)
+
+with compile_obvs : expr → cla → cla → tactic expr
+| ρ c d :=
+( do
+  if c.length = d.length
+  then compile_psub ρ c c.permutations d
+  else do (b, k, μ) ← c.find_dup,
+          (σ, e) ← compile_obv `(recipe.sub %%`(μ) %%ρ) (c.subst μ) b k,
+          compile_obvs σ e d ) <|> (trace "Fail compile_obvs" >> failed)
+
+meta def compile (m : mat) (ls : list line) : tactic expr :=
+do ⟨k, r, ([], [])⟩ ← list.find (λ l, line.c l = ([], [])) ls,
+   compile_core m ls k r ([], [])

--- a/src/tactic/spass/debug.lean
+++ b/src/tactic/spass/debug.lean
@@ -1,0 +1,68 @@
+/-
+  Copyright (c) 2019 Seul Baek. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Seul Baek
+
+  Tactics for debugging the spass tacric.
+-/
+
+import tactic.spass.main
+
+open tactic
+
+meta def recipe.derives_debug (m : mat) : recipe → tactic cla
+| (recipe.hyp k)   :=
+  (do c ← m.nth k,
+      trace (k.repr ++ "-th clause retrieved : " ++ c.repr),
+      return c)
+  <|> (trace "Failed Hyp" >> failed)
+| (recipe.prm d ρ) :=
+   do c ← ρ.derives_debug,
+      if cla.exteq c d
+      then return d
+      else do trace "failed prm, cannot permutate ",
+              trace c,
+              trace " into ",
+              trace d,
+              failed
+| (recipe.sub μ ρ) :=
+  ( do trace "Enter sub",
+     c ← ρ.derives_debug,
+     trace "Returning sub : ",
+     trace (c.subst μ),
+     return (c.subst μ) ) <|> (trace "failed sub" >> failed)
+| (recipe.con ff k ρ) :=
+  ( do c ← ρ.derives_debug,
+     t ← c.fst.nth k,
+     guard (t ∈ c.fst.remove_nth k),
+     return (c.fst.remove_nth k, c.snd) ) <|> (trace "failed con" >> failed)
+| (recipe.con tt k ρ) :=
+  ( do c ← ρ.derives_debug,
+       t ← c.snd.nth k,
+       guard (t ∈ c.snd.remove_nth k),
+       return (c.fst, c.snd.remove_nth k) ) <|>
+  (trace "failed con" >> failed)
+| (recipe.res k n ρ σ) :=
+  ( do trace "Enter Res",
+     c ← ρ.derives_debug,
+     d ← σ.derives_debug,
+     t ← c.snd.nth k,
+     s ← d.fst.nth n,
+     trace "Test guard",
+     guard (t = s),
+     trace "Guard passed",
+     return (c.fst ++ d.fst.remove_nth n,
+      c.snd.remove_nth k ++ d.snd) )
+  <|> (trace "failed res" >> failed)
+
+meta def prove_arifix_debug (αx ix : expr) (p : form₂) : tactic recipe :=
+do s ← spass_output (mat.print $ clausify p),
+   ls ← parse.lines s,
+   ρx ← compile (clausify p) ls,
+   eval_expr recipe ρx
+
+meta def spass_debug : tactic unit :=
+do (dx, ix, p) ← reify,
+   yx ← prove_arifix_debug dx ix p,
+   c ← (yx.derives_debug $ clausify p),
+   skip

--- a/src/tactic/spass/examples.lean
+++ b/src/tactic/spass/examples.lean
@@ -1,0 +1,115 @@
+/-
+  Copyright (c) 2019 Seul Baek. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Seul Baek
+-/
+
+import tactic.spass.main
+
+section
+
+/- Examples from finish. -/
+
+variables {A B C D : Prop}
+
+  example : ¬ A → A → C := by spass
+  example : (A ∧ A ∧ B) → (A ∧ C ∧ B) → A := by spass
+  example : A → ¬ B → ¬ (A → B) := by spass
+  example : A ∨ B → B ∨ A := by spass
+  example : A ∧ B → B ∧ A := by spass
+  example : A → (A → B) → (B → C) → C := by spass
+  example : (A ∧ B) → (C ∧ B) → C := by spass
+  example : A → B → C → D → (A ∧ B) ∧ (C ∧ D) := by spass
+  example : (A ∧ B) → (B ∧ ¬ C) → A ∨ C := by spass
+  example : (A → B) ∧ (B → C) → A → C := by spass
+  example : (A → B) ∨ (B → A) := by spass
+  example : ((A → B) → A) → A := by spass
+  example : A → ¬ B → ¬ (A → B) := by spass
+  example : ¬ (A ↔ ¬ A) := by spass
+  example : (A ↔ B) → (A ∧ B → C) → (¬ A ∧ ¬ B → C) → C := by spass
+  example : (A ↔ B) → ((A ∧ ¬ B) ∨ (¬ A ∧ B)) → C := by spass
+  example : (A → B) → A → B := by spass
+  example : (A → B) → (B → C) → A → C := by spass
+  example : (A → B ∨ C) → (B → D) → (C → D) → A → D := by spass
+  example : A ∨ B → B ∨ A := by spass
+
+  variables (α : Type) [inhabited α]
+  variables (a b c : α) (p q : α → Prop) (r : α → α → Prop)
+  variables (P Q R : Prop)
+  variable  (g : bool → nat)
+
+  example : (∀ x, p x → q x) → (∀ x, p x) → q a := by spass
+  example : (p a) → ∃ x, p x := by spass
+  example : (p a) → (p b) → (q b) → ∃ x, p x ∧ q x := by spass
+  example : (∃ x, p x ∧ r x x) → (∀ x, r x x → q x) → ∃ x, p x ∧ q x := by spass
+  example : (∃ x, q x ∧ p x) → ∃ x, p x ∧ q x := by spass
+  example : (∀ x, q x → p x) → (q a) → ∃ x, p x := by spass
+  example : (∀ x, p x → q x → false) → (p a) → (p b) → (q b) → false := by spass
+  example : (∀ x, p x) → (∀ x, p x → q x) → ∀ x, q x := by spass
+  example : (∃ x, p x) → (∀ x, p x → q x) → ∃ x, q x := by spass
+  example : (¬ ∀ x, ¬ p x) → (∀ x, p x → q x) → (∀ x, ¬ q x) → false := by spass
+  example : (p a) → (p a → false) → false := by spass
+  example : (¬ (P → Q ∨ R)) → (¬ (Q ∨ ¬ R)) → false := by spass
+  example : (P → Q ∨ R) → (¬ Q) → P → R := by spass
+  example : (∃ x, p x → P) ↔ (∀ x, p x) → P := by spass
+  example : (∃ x, P → p x) ↔ (P → ∃ x, p x) := by spass
+
+end
+
+section
+
+  /- Examples from the Handbook of Practical Logic and Automated Reasoning. -/
+
+  variables (α : Type) [inhabited α]
+
+  lemma gilmore_1 {F G H : α → Prop} :
+    ∃ x, ∀ y z,
+        ((F y → G y) ↔ F x) ∧
+        ((F y → H y) ↔ G x) ∧
+        (((F y → G y) → H y) ↔ H x)
+        → F z ∧ G z ∧ H z := by spass
+
+  lemma gilmore_6 {F G : α → α → Prop} {H : α → α → α → Prop} :
+  ∀ x, ∃ y,
+    (∃ u, ∀ v, F u x → G v u ∧ G u x)
+     → (∃ u, ∀ v, F u y → G v u ∧ G u y) ∨
+         (∀ u v, ∃ w, G v u ∨ H w y u → G u w) := by spass
+
+  lemma gilmore_8 {G : α → Prop} {F : α → α → Prop} {H : α → α → α → Prop} :
+    ∃ x, ∀ y z,
+      ((F y z → (G y → (∀ u, ∃ v, H u v x))) → F x x) ∧
+      ((F z x → G x) → (∀ u, ∃ v, H u v z)) ∧
+      F x y → F z z := by spass
+
+  lemma Manthe_and_Bry (agatha butler charles : α)
+  (lives : α → Prop) (killed hates richer : α → α → Prop) :
+     lives agatha ∧ lives butler ∧ lives charles ∧
+     (killed agatha agatha ∨ killed butler agatha ∨
+      killed charles agatha) ∧
+     (∀ x y, killed x y → hates x y ∧ ¬ richer x y) ∧
+     (∀ x, hates agatha x → ¬ hates charles x) ∧
+     (hates agatha agatha ∧ hates agatha charles) ∧
+     (∀ x, lives(x) ∧ ¬ richer x agatha → hates butler x) ∧
+     (∀ x, hates agatha x → hates butler x) ∧
+     (∀ x, ¬ hates x agatha ∨ ¬ hates x butler ∨ ¬ hates x charles)
+     → killed agatha agatha ∧
+         ¬ killed butler agatha ∧
+         ¬ killed charles agatha := by spass
+
+  lemma Knights_and_Knaves (me : α) (knight knave rich poor : α → α)
+    (a_truth says : α → α → Prop) (and : α → α → α) :
+    ( (∀ X Y, ¬ a_truth (knight X) Y ∨ ¬ a_truth (knave X) Y ) ∧
+      (∀ X Y, a_truth (knight X) Y ∨ a_truth (knave X) Y ) ∧
+      (∀ X Y, ¬ a_truth (rich X) Y ∨ ¬ a_truth (poor X) Y ) ∧
+      (∀ X Y, a_truth (rich X) Y ∨ a_truth (poor X) Y ) ∧
+      (∀ X Y Z, ¬ a_truth (knight X) Z ∨ ¬ says X Y ∨ a_truth Y Z ) ∧
+      (∀ X Y Z, ¬ a_truth (knight X) Z ∨ says X Y ∨ ¬ a_truth Y Z ) ∧
+      (∀ X Y Z, ¬ a_truth (knave X) Z ∨ ¬ says X Y ∨ ¬ a_truth Y Z ) ∧
+      (∀ X Y Z, ¬ a_truth (knave X) Z ∨ says X Y ∨ a_truth Y Z ) ∧
+      (∀ X Y Z, ¬ a_truth (and X Y) Z ∨ a_truth X Z ) ∧
+      (∀ X Y Z, ¬ a_truth (and X Y) Z ∨ a_truth Y Z ) ∧
+      (∀ X Y Z, a_truth (and X Y) Z ∨ ¬ a_truth X Z ∨ ¬ a_truth Y Z ) ∧
+      (∀ X, ¬ says me X ∨ ¬ a_truth (and (knave me) (rich me)) X ) ∧
+      (∀ X, says me X ∨ a_truth (and (knave me) (rich me)) X ) ) → false := by spass
+
+end

--- a/src/tactic/spass/folize.lean
+++ b/src/tactic/spass/folize.lean
@@ -1,0 +1,241 @@
+/-
+  Copyright (c) 2019 Seul Baek. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Seul Baek
+
+  Translation of SOL formulas into FOL.
+-/
+
+import tactic.interactive
+import tactic.spass.swap
+import tactic.spass.form
+
+universe u
+
+variable {α : Type u}
+
+open nat list
+
+local notation f `₀↦` a := assign a f
+postfix  `ₑ` : 1000 := evaluate
+postfix  `ᵈ` : 1000 := denote
+local infix `⬝` := value.app
+
+local notation `&₁`     := term.sym
+local notation a `&₁` b := term.app a b
+local notation a `#₁` k := term.vpp a k
+
+local notation `⟪` b `,` a `⟫₁` := form.lit b a
+local notation p `∨₁` q        := form.bin tt p q
+local notation p `∧₁` q        := form.bin ff p q
+
+def term₂.folize (k : nat) : term₂ → term
+| (term₂.var m) := (&₁ (m - k))
+| (term₂.app a (term₂.var m)) :=
+  if m < k
+  then a.folize #₁ m
+  else a.folize &₁ (&₁ (m - k))
+| (term₂.app a (term₂.app b c)) :=
+  a.folize &₁ (term₂.app b c).folize
+
+def form₂.folize : nat → form₂ → form
+| k (form₂.lit b t)   := ⟪b, t.folize k⟫₁
+| k (form₂.bin b p q) := form.bin b (p.folize k) (q.folize k)
+| k (form₂.qua tt p)  := p.folize k.succ
+| k (form₂.qua ff p)  := p.folize k
+
+def term₂.fov_lt (k : nat) (a : term₂) : Prop :=
+∀ m < k, a.fov m
+
+lemma fov_lt_of_fov_lt_app_left {k : nat} {a b : term₂} :
+  (term₂.app a b).fov_lt k → a.fov_lt k :=
+λ h0 m h1, (h0 m h1).left
+
+lemma fov_lt_of_fov_lt_app_right {k : nat} {a b c : term₂} :
+  (term₂.app a (term₂.app b c)).fov_lt k → (term₂.app b c).fov_lt k :=
+λ h0 m h1, (h0 m h1).right
+
+def form₂.fov_lt (k : nat) (p : form₂) : Prop :=
+∀ m < k, p.fov m
+
+lemma fov_lt_of_fov_lt_bin_left {b : bool} {k : nat} {p q : form₂} :
+  (form₂.bin b p q).fov_lt k → p.fov_lt k :=
+λ h0 m h1, (h0 m h1).left
+
+lemma fov_lt_of_fov_lt_bin_right {b : bool} {k : nat} {p q : form₂} :
+  (form₂.bin b p q).fov_lt k → q.fov_lt k :=
+λ h0 m h1, (h0 m h1).right
+
+def exs : nat → form₂ → form₂
+| 0       p := p
+| (k + 1) p := form₂.qua tt (exs k p)
+
+lemma exs_ex :
+  ∀ k : nat, ∀ p : form₂,
+  exs k (form₂.qua tt p) = exs (k + 1) p
+| 0       p := rfl
+| (k + 1) p := by {unfold exs, rw exs_ex, refl}
+
+lemma sub_eq_succ_sub_succ {k m : nat} :
+  k + 1 ≤ m → m - k = succ (m - (k + 1)) :=
+begin
+  intro h0,
+  rw succ_le_iff at h0,
+  rw [← nat.sub_sub, ← pred_eq_sub_one, succ_pred_eq_of_pos _],
+  simpa only [gt, nat.lt_sub_left_iff_add_lt] using h0
+end
+
+lemma val_folize_succ {k : nat} (M : model α) (v : nat → α) :
+  ∀ {a : term₂}, a.fov_lt (k + 1) →
+  (a.folize $ k + 1).val M v = (a.folize k).val (M ₀↦ (v k)ₑ) v
+| (term₂.var m) h0 :=
+  begin
+    by_cases h1 : m < k + 1,
+    { cases h0 m h1 rfl },
+    rw not_lt at h1,
+    simp only [term₂.folize, term.val],
+    rw sub_eq_succ_sub_succ h1, refl,
+  end
+| (term₂.app a (term₂.var m)) h0 :=
+  begin
+    have h := val_folize_succ (fov_lt_of_fov_lt_app_left h0),
+    unfold term₂.folize,
+    by_cases h1 : m < k,
+    { rw if_pos h1,
+      rw if_pos (lt_trans h1 $ lt_succ_self _),
+      unfold term.val, rw h },
+    rw if_neg h1,
+    rw not_lt at h1,
+    by_cases h2 : m = k,
+    { rw h2, rw if_pos (lt_succ_self _),
+      unfold term.val,
+      rw [h, nat.sub_self k], refl },
+    have h3 : k + 1 ≤ m,
+    { rw le_iff_eq_or_lt at h1,
+      cases h1,
+      { cases h2 h1.symm },
+      rw succ_le_iff, exact h1 },
+    rw if_neg (not_lt.elim_right h3),
+    unfold term.val,
+    rw [h, sub_eq_succ_sub_succ h3], refl
+  end
+| (term₂.app a (term₂.app b c)) h0 :=
+  by simp only [term₂.folize, term.val,
+     val_folize_succ (fov_lt_of_fov_lt_app_left h0),
+     val_folize_succ (fov_lt_of_fov_lt_app_right h0)]
+
+lemma holds_folize_succ {k : nat} (M : model α) (v : nat → α) :
+  ∀ p : form₂, p.F → p.fov_lt (k + 1) →
+  ((p.folize $ k + 1).holds M v ↔ (p.folize k).holds (M ₀↦ (v k)ₑ) v)
+| (form₂.lit b a) h0 h1 :=
+  by { cases b; --;
+       simp only  [form₂.folize, term.val,
+         form.holds, val_folize_succ M v h1] }
+| (form₂.bin b p q) h0 h1 :=
+  begin
+    apply form.holds_bin_iff_holds_bin,
+    { exact holds_folize_succ _ h0.left (fov_lt_of_fov_lt_bin_left h1) },
+    exact holds_folize_succ _ h0.right (fov_lt_of_fov_lt_bin_right h1),
+  end
+
+lemma forall_lt_of_forall_lt_succ {k : nat} {p : nat → Prop} :
+  (∀ m < (k + 1), p m) → (∀ m < k, p m) :=
+λ h0 m h1, h0 _ (lt_trans h1 $ lt_succ_self _)
+
+lemma forall_lt_zero {p : nat → Prop} : (∀ m < 0, p m) :=
+λ m h, by cases h
+
+lemma val_folize_zero (M : model α) (v : nat → α) :
+  ∀ a : term₂, (a.folize 0).val M v = a.val M
+| (term₂.var k) := rfl
+| (term₂.app a (term₂.var k)) :=
+  begin
+    unfold term₂.folize,
+    have h0 : ¬ k < 0,
+    { rw not_lt, apply nat.zero_le },
+    rw if_neg h0,
+    simp only [term.val, term₂.val, nat.sub_zero,
+      val_folize_zero a, eq_self_iff_true]
+  end
+| (term₂.app a (term₂.app b c)) :=
+  by simp only [term.val, term₂.val, nat.sub_zero,
+    val_folize_zero a, val_folize_zero (term₂.app b c),
+    eq_self_iff_true, term₂.folize]
+
+lemma holds_folize_zero (M : model α) (v : nat → α) :
+  ∀ {p : form₂}, p.F → ((p.folize 0).holds M v ↔ p.holds M)
+| (form₂.lit b a) h0 :=
+  by cases b;
+     simp only [form₂.holds, form.holds,
+       form₂.folize, val_folize_zero]
+| (form₂.bin b p q) h0 :=
+  by { cases b; apply pred_mono_2;
+       simp only [ form₂.holds, form.holds,
+       form₂.folize, holds_folize_zero h0.left,
+       holds_folize_zero h0.right ] }
+
+lemma holds_exs_of_exv_folize :
+  ∀ {p : form₂} (k : nat) {M : model α},
+  foq tt p → p.QF tt → p.fov_lt k →
+  (∃ v : nat → α, (p.folize k).holds M v) →
+  (exs k p).holds M
+| (form₂.lit b a) 0  :=
+  by { intros M h0 h1 h2 h3,
+       cases h3 with v h3,
+       rwa holds_folize_zero _ _ h1 at h3 }
+| (form₂.lit b a) (k + 1) :=
+  begin
+    intros M h0 h1 h2 h3,
+    cases h3 with v h3,
+    rw holds_folize_succ _ _ (form₂.lit b a) trivial h2 at h3,
+    have h5 : (M ₀↦v k ₑ) ⊨exs k (form₂.lit b a) :=
+      @holds_exs_of_exv_folize (form₂.lit b a) k _ trivial
+        trivial (forall_lt_of_forall_lt_succ h2) ⟨v, h3⟩,
+    refine ⟨(v k)ₑ, h5⟩
+  end
+| (form₂.bin b p q) 0 :=
+  by { intros M h0 h1 h2 h3,
+       cases h3 with v h3,
+       rwa holds_folize_zero _ _ h1 at h3 }
+| (form₂.bin b p q) (k + 1) :=
+  begin
+intros M h0 h1 h2 h3,
+    cases h3 with v h3,
+    rw holds_folize_succ _ _ (form₂.bin b p q) h1 h2 at h3,
+    have h5 : (M ₀↦v k ₑ) ⊨ exs k (form₂.bin b p q) :=
+      @holds_exs_of_exv_folize (form₂.bin b p q) k _ h0
+        h1 (forall_lt_of_forall_lt_succ h2) ⟨v, h3⟩,
+    refine ⟨(v k)ₑ, h5⟩,
+  end
+| (form₂.qua tt p) k :=
+  begin
+    intros M h0 h1 h2 h3,
+    have h5 : p.fov_lt (k + 1),
+    { rintro ⟨m⟩; intro h4,
+      { exact h0.left rfl },
+      rw succ_lt_succ_iff at h4,
+      exact h2 _ h4 },
+    rw exs_ex,
+    exact @holds_exs_of_exv_folize p (k + 1)
+      M h0.right h1.right h5 h3,
+  end
+| (form₂.qua ff p) k := λ _ _  h, by cases h.left
+
+lemma fam_of_tas_folize_zero :
+  ∀ {p : form₂}, foq tt p → p.QF tt →
+  (p.folize 0).tas α → fam α p :=
+λ p h0 h1 h2 M, @holds_exs_of_exv_folize
+  α p 0 M h0 h1 forall_lt_zero (h2 M)
+
+lemma fam_of_tas_folize :
+  ∀ p : form₂, foq tt p → p.QDF ff →
+  (p.folize 0).tas α → fam α p
+| (form₂.lit b a)   := fam_of_tas_folize_zero
+| (form₂.bin b p q) := fam_of_tas_folize_zero
+| (form₂.qua tt p)  :=
+  by { intros h0 h1 h2,
+       apply fam_of_tas_folize_zero h0 _ h2,
+       refine ⟨rfl, h1.right (λ h3, by cases h3)⟩ }
+| (form₂.qua ff p)  :=
+  λ h0 h1 h2, (fam_fa _ _).elim_right
+    (fam_of_tas_folize p h0.right (h1.left rfl) h2)

--- a/src/tactic/spass/form.lean
+++ b/src/tactic/spass/form.lean
@@ -1,0 +1,68 @@
+/-
+  Copyright (c) 2019 Seul Baek. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Seul Baek
+
+  First-order formulas.
+-/
+
+import tactic.spass.term
+
+universe u
+
+variable {α : Type u}
+
+inductive form : Type
+| lit : bool → term → form
+| bin : bool → form → form → form
+
+local notation `⟪` b `,` a `⟫₁` := form.lit b a
+local notation p `∨₁` q         := form.bin tt p q
+local notation p `∧₁` q         := form.bin ff p q
+
+namespace form
+
+def holds (M : model α) (v : nat → α) : form → Prop
+| (form.lit tt a)   :=   (a.val M v []).snd
+| (form.lit ff a)   := ¬ (a.val M v []).snd
+| (form.bin tt p q) := p.holds ∨ q.holds
+| (form.bin ff p q) := p.holds ∧ q.holds
+
+lemma holds_bin_iff_holds_bin
+  {M N : model α} {v w : nat → α} {p q r s : form} {b : bool} :
+  (p.holds M v ↔ q.holds N w) → (r.holds M v ↔ s.holds N w) →
+  ((form.bin b p r).holds M v ↔ (form.bin b q s).holds N w) :=
+by { intros h0 h1,
+     cases b; unfold form.holds;
+     apply pred_mono_2; assumption }
+
+def neg : form → form
+| (form.lit b t)   := form.lit (bnot b) t
+| (form.bin b p q) := form.bin (bnot b) (neg p) (neg q)
+
+lemma holds_neg (M : model α) (v : vas α) :
+  ∀ p : form, (neg p).holds M v ↔ ¬ p.holds M v
+| (form.lit b t) :=
+  by { cases b; simp only [form.holds,
+       classical.not_not, term.val, neg, bnot] }
+| (p ∨₁ q) :=
+  begin
+    unfold form.holds,
+    rw not_or_distrib,
+    apply pred_mono_2;
+    apply holds_neg
+  end
+| (p ∧₁ q) :=
+  begin
+    unfold form.holds,
+    rw @not_and_distrib _ _ (classical.dec _),
+    apply pred_mono_2; apply holds_neg
+  end
+
+def tas (α : Type u) (p : form) : Prop :=
+∀ M : model α, ∃ v : nat → α, p.holds M v
+
+def sat (α : Type u) (p : form) : Prop :=
+∃ M : model α, ∀ v : nat → α, p.holds M v
+
+end form

--- a/src/tactic/spass/form2.lean
+++ b/src/tactic/spass/form2.lean
@@ -1,0 +1,347 @@
+/-
+  Copyright (c) 2019 Seul Baek. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Seul Baek
+
+  Second-order formulas.
+-/
+
+import tactic.spass.sub2
+import data.nat.basic
+
+universe u
+
+variables {α β : Type u}
+
+open nat
+
+local notation f `₀↦` a := assign a f
+local notation `#`      := term₂.var
+local notation a `&` b  := term₂.app a b
+
+postfix  `ₑ` : 1000 := evaluate
+postfix  `ᵈ` : 1000 := denote
+local infix `⬝` := value.app
+
+@[derive has_reflect]
+inductive form₂ : Type
+| lit : bool → term₂ → form₂
+| bin : bool → form₂ → form₂ → form₂
+| qua : bool → form₂ → form₂
+
+local notation `⟪` b `,` a `⟫` := form₂.lit b a
+local notation p `∨*` q        := form₂.bin tt p q
+local notation p `∧*` q        := form₂.bin ff p q
+local notation `∃*`            := form₂.qua tt
+local notation `∀*`            := form₂.qua ff
+
+namespace form₂
+
+meta def to_expr : form₂ → expr
+| ⟪b, t⟫ := `(⟪%%`(b), %%(t.to_expr)⟫)
+| (form₂.bin b p q) := `(form₂.bin %%`(b) %%p.to_expr %%q.to_expr)
+| (form₂.qua b p)   := `(form₂.qua %%`(b) %%p.to_expr)
+
+def repr : form₂ → string
+| ⟪tt, t⟫  := t.repr
+| ⟪ff, t⟫  := "¬" ++ t.repr
+| (p ∨* q) := "(" ++ p.repr ++ " ∨ " ++ q.repr ++ ")"
+| (p ∧* q) := "(" ++ p.repr ++ " ∧ " ++ q.repr ++ ")"
+| (∀* p)   := "(∀ " ++ p.repr ++ ")"
+| (∃* p)   := "(∃ " ++ p.repr ++ ")"
+
+instance has_repr : has_repr form₂ := ⟨repr⟩
+meta instance has_to_format : has_to_format form₂ := ⟨λ x, repr x⟩
+
+def holds : model α → form₂ → Prop
+| M ⟪tt, a⟫  :=   (a.val M []).snd
+| M ⟪ff, a⟫  := ¬ (a.val M []).snd
+| M (p ∨* q) := holds M p ∨ holds M q
+| M (p ∧* q) := holds M p ∧ holds M q
+| M (∀* p)   := ∀ x : value α, holds (M ₀↦ x) p
+| M (∃* p)   := ∃ x : value α, holds (M ₀↦ x) p
+
+infix `⊨` : 1000 := holds
+
+@[reducible] def size_of : form₂ → nat
+| ⟪_, _⟫           := 1
+| (form₂.bin _ p q) := p.size_of + q.size_of + 1
+| (form₂.qua _ p)   := p.size_of + 1
+
+instance has_sizeof : has_sizeof form₂ := ⟨size_of⟩
+
+/- Increment all variable indices equal to or greater than k by 1. -/
+def incr_ge : nat → form₂ → form₂
+| k ⟪b, a⟫           := ⟪b, a.incr_ge k⟫
+| k (form₂.bin b p q) := form₂.bin b (incr_ge k p) (incr_ge k q)
+| k (form₂.qua b p)   := form₂.qua b (incr_ge (k + 1) p)
+
+def incr : form₂ → form₂ := incr_ge 0
+
+def subst : sub₂ → form₂ → form₂
+| σ ⟪b, a⟫           := ⟪b, a.subst σ⟫
+| σ (form₂.bin b p q) := form₂.bin b (subst σ p) (subst σ q)
+| σ (form₂.qua b p)   := form₂.qua b (subst σ.incr p)
+
+lemma size_of_subst :
+  ∀ p : form₂, ∀ σ : sub₂, (p.subst σ).size_of = p.size_of
+| ⟪b, a⟫           σ := rfl
+| (form₂.bin b p q) σ :=
+  by simp only [size_of, subst, size_of_subst p, size_of_subst q]
+| (form₂.qua b p)   σ :=
+  by simp only [size_of, subst, size_of_subst p]
+
+@[simp] lemma size_of_incr_ge :
+  ∀ k : nat, ∀ p : form₂, (p.incr_ge k).size_of = p.size_of
+| k ⟪b, a⟫           := rfl
+| k (form₂.bin b p q) :=
+  by simp only [ size_of, size_of_incr_ge k p,
+     incr_ge, size_of_incr_ge k q ]
+| k (form₂.qua b p)   :=
+  by simp only [size_of, incr_ge, size_of_incr_ge _ p]
+
+@[simp] lemma size_of_incr :
+  ∀ p : form₂, p.incr.size_of = p.size_of :=
+size_of_incr_ge _
+
+def neg : form₂ → form₂
+| ⟪b, a⟫           := ⟪bnot b, a⟫
+| (form₂.bin b p q) := form₂.bin (bnot b) p.neg q.neg
+| (form₂.qua b p)   := form₂.qua (bnot b) p.neg
+
+def occ : nat → form₂ → Prop
+| k ⟪_, a⟫           := a.occ k
+| k (form₂.bin b p q) := p.occ k ∨ q.occ k
+| k (form₂.qua b p)   := p.occ (k + 1)
+
+lemma not_occ_incr_ge :
+  ∀ k : nat, ∀ p : form₂, ¬ (p.incr_ge k).occ k
+| k ⟪b, a⟫           := term₂.not_occ_incr_ge _ _
+| k (form₂.bin b p q) :=
+  by { intro h0, cases h0;
+       apply not_occ_incr_ge k _ h0 }
+| k (form₂.qua b p) := not_occ_incr_ge (k + 1) p
+
+lemma holds_bin_iff_holds_bin
+  {M N : model α} {p q r s : form₂} {b : bool} :
+  (M ⊨ p ↔ N ⊨ q) → (M ⊨ r ↔ N ⊨ s) →
+  (M ⊨ form₂.bin b p r ↔ N ⊨ form₂.bin b q s) :=
+by { intros h0 h1, cases b;
+     apply pred_mono_2; assumption }
+
+end form₂
+
+def fam (α : Type u) (p : form₂) : Prop :=
+  ∀ M : model α, M ⊨ p
+
+lemma fam_fa (α : Type u) (p : form₂) :
+  fam α (∀* p) ↔ fam α p :=
+begin
+  constructor; intros h0 M,
+  { have h1 := h0 M.decr_idxs (M 0),
+    rwa assign_decr_idxs at h1 },
+  intro v, apply h0
+end
+
+def eqv (α : Type u) (p q : form₂) : Prop :=
+∀ M : model α, (M ⊨ p ↔ M ⊨ q)
+
+notation p `<==` α `==>` q := eqv α p q
+
+lemma eqv_trans {α : Type u} {p q r : form₂} :
+  (p <==α==> q) → (q <==α==> r) → (p <==α==> r) :=
+λ h0 h1 M, by rw [h0 M, h1 M]
+
+lemma eqv_refl (α : Type u) (p : form₂) : p <==α==> p := λ M, by refl
+
+lemma bin_eqv_bin {p q r s : form₂} {b : bool} :
+  (p <==α==> q) → (r <==α==> s) →
+  (form₂.bin b p r <==α==> form₂.bin b q s) :=
+by { intros h0 h1 M,
+     apply form₂.holds_bin_iff_holds_bin (h0 _) (h1 _) }
+
+lemma bin_comm (b : bool) (p q : form₂) :
+  form₂.bin b p q <==α==> form₂.bin b q p :=
+by {intro M, cases b, apply and.comm, apply or.comm}
+
+lemma holds_qua_iff_holds_qua {M N : model α} {p q : form₂} {b : bool} :
+  (∀ v : value α, (M ₀↦ v) ⊨ p ↔ (N ₀↦ v) ⊨ q) →
+  (M ⊨ form₂.qua b p ↔ N ⊨ form₂.qua b q) :=
+begin
+  intro h0, cases b,
+  apply forall_congr h0,
+  apply exists_congr h0
+end
+
+lemma qua_eqv_qua {p q : form₂} {b : bool} :
+  (p <==α==> q) → (form₂.qua b p <==α==> form₂.qua b q) :=
+by { intros h0 M,
+     apply holds_qua_iff_holds_qua,
+     intro v, apply h0 }
+
+lemma holds_neg : ∀ {M : model α}, ∀ {p : form₂}, M ⊨ p.neg ↔ ¬ M ⊨ p
+| M ⟪b, a⟫ :=
+  by cases b;
+     simp only [classical.not_not, form₂.neg,
+     form₂.holds, bool.bnot_true, bool.bnot_false]
+| M (p ∨* q) :=
+  begin
+    unfold form₂.holds,
+    rw not_or_distrib,
+    apply pred_mono_2;
+    apply holds_neg
+  end
+| M (p ∧* q) :=
+  begin
+    unfold form₂.holds,
+    rw @not_and_distrib _ _ (classical.dec _),
+    apply pred_mono_2; apply holds_neg
+  end
+| M (∀* p)   :=
+  begin
+    unfold form₂.holds,
+    rw @not_forall _ _ (classical.dec _) (classical.dec_pred _),
+    apply exists_congr,
+    intro v, apply holds_neg
+  end
+| M (∃* p)   :=
+  begin
+    unfold form₂.holds,
+    rw @not_exists,
+    apply forall_congr,
+    intro v, apply holds_neg
+  end
+
+lemma holds_incr_ge :
+  ∀ M N : model α, ∀ k : nat,
+    (∀ m < k, M m = N m) →
+    (∀ m ≥ k, M (m + 1) = N m) →
+    ∀ p : form₂, M ⊨ p.incr_ge k ↔ N ⊨ p
+| M N k h0 h1 ⟪b, a⟫ :=
+  by cases b; simp [form₂.incr_ge,
+     form₂.holds, val_incr_ge h0 h1 a]
+| M N k h0 h1 (form₂.bin b p q) :=
+  by { apply form₂.holds_bin_iff_holds_bin;
+       apply holds_incr_ge _ _ _ h0 h1 }
+| M N k h0 h1 (form₂.qua b p) :=
+  begin
+    apply holds_qua_iff_holds_qua, intro v,
+    apply holds_incr_ge _ _ (k + 1);
+    intros m h2; cases m,
+    { refl },
+    { apply h0 _ (lt_of_succ_lt_succ h2) },
+    { cases (not_lt_zero _ (lt_of_succ_le h2)) },
+    apply h1 _ (succ_le_succ_iff.elim_left h2)
+  end
+
+lemma holds_assign_incr {M : model α} {d : value α} :
+  ∀ p : form₂, (M ₀↦ d) ⊨ p.incr ↔ M ⊨ p :=
+holds_incr_ge (M ₀↦ d) M 0 (λ _ h, by cases h) (λ _ _, rfl)
+
+lemma neg_subst :
+  ∀ p : form₂, ∀ σ : sub₂, (p.subst σ).neg <==α==> (p.neg.subst σ)
+| ⟪b, a⟫       σ := by apply eqv_refl
+| (form₂.bin b p q) σ :=
+  by { intro M, apply form₂.holds_bin_iff_holds_bin;
+       apply neg_subst }
+| (form₂.qua b p)   σ :=
+  by { intro M, apply holds_qua_iff_holds_qua,
+       intro v, apply neg_subst }
+
+lemma neg_eqv_neg (p q : form₂) :
+  (p.neg <==α==> q.neg) ↔ (p <==α==> q) :=
+begin
+  apply forall_congr, intro M,
+  rw [holds_neg, holds_neg, @not_iff_not _ _ _ _],
+  repeat {apply classical.dec _}
+end
+
+lemma neg_incr_ge :
+  ∀ k : nat, ∀ p : form₂, (p.incr_ge k).neg = p.neg.incr_ge k
+| k ⟪b, a⟫           := by cases b; refl
+| k (form₂.bin b p q) :=
+  by simp only [form₂.neg, form₂.incr_ge,
+     eq_self_iff_true, neg_incr_ge, and_self ]
+| k (form₂.qua b p) :=
+  by simp only [form₂.neg, form₂.incr_ge,
+     eq_self_iff_true, neg_incr_ge, and_self ]
+
+lemma neg_incr (p : form₂) :
+  p.incr.neg = p.neg.incr :=
+neg_incr_ge 0 p
+
+lemma holds_subst :
+  ∀ (M : model α) (p : form₂) (σ : sub₂),
+  M ⊨ (p.subst σ) ↔ M.subst σ ⊨ p
+| M ⟪b, a⟫ σ :=
+  by cases b; simp only [form₂.subst, form₂.holds, val_subst M σ a]
+| M (form₂.bin b p q) σ :=
+  by apply form₂.holds_bin_iff_holds_bin; apply holds_subst
+| M (form₂.qua b p)   σ :=
+  by { apply holds_qua_iff_holds_qua, intro v,
+       simp only [model.assign_subst, holds_subst] }
+
+namespace form₂
+
+def F : form₂ → Prop
+| ⟪_, _⟫           := true
+| (form₂.bin _ p q) := F p ∧ F q
+| (form₂.qua b p)   := false
+
+def N (b : bool) : form₂ → Prop
+| ⟪_, _⟫            := true
+| (form₂.bin _ p q) := N p ∧ N q
+| (form₂.qua c p)   := b ≠ c ∧ N p
+
+def QN (b : bool) : form₂ → Prop
+| (form₂.qua c p) := (b = c → QN p) ∧ (b ≠ c → N b p)
+| p              := N b p
+
+def QF (b : bool) : form₂ → Prop
+| (form₂.qua c p) := b = c ∧ QF p
+| p              := F p
+
+def QDF (b : bool) : form₂ → Prop
+| (form₂.qua c p) := (b = c → QDF p) ∧ (b ≠ c → QF (bnot b) p)
+| p              := F p
+
+lemma F_incr_ge :
+  ∀ k : nat, ∀ {p : form₂}, p.F → (p.incr_ge k).F
+| k (form₂.lit _ _)   _ := trivial
+| k (form₂.bin _ p q) h := ⟨F_incr_ge _ h.left, F_incr_ge _ h.right⟩
+| k (form₂.qua c p)   h := by cases h
+
+lemma N_incr_ge {b : bool} :
+  ∀ k : nat, ∀ {p : form₂}, p.N b → (p.incr_ge k).N b
+| k (form₂.lit _ _)   _ := trivial
+| k (form₂.bin _ p q) h := ⟨N_incr_ge _ h.left, N_incr_ge _ h.right⟩
+| k (form₂.qua c p)   h := ⟨h.left, N_incr_ge _ h.right⟩
+
+lemma QN_incr_ge {b : bool} :
+  ∀ k : nat, ∀ {p : form₂}, p.QN b → (p.incr_ge k).QN b
+| k (form₂.lit _ _)   _  := trivial
+| k (form₂.bin _ p q) h0 :=
+  ⟨ N_incr_ge _ h0.left,
+    N_incr_ge _ h0.right ⟩
+| k (form₂.qua c p)   h0 :=
+  ⟨ λ h1, QN_incr_ge _ (h0.left h1),
+    λ h1, N_incr_ge _ (h0.right h1) ⟩
+
+lemma QF_incr_ge {b : bool} :
+  ∀ k : nat, ∀ {p : form₂}, p.QF b → (p.incr_ge k).QF b
+| k (form₂.lit _ _)   _  := trivial
+| k (form₂.bin _ p q) h0 :=
+  ⟨ F_incr_ge _ h0.left,
+    F_incr_ge _ h0.right ⟩
+| k (form₂.qua c p)   h0 :=
+  ⟨ h0.left, QF_incr_ge _ h0.right ⟩
+
+lemma QDF_of_QF_bnot {b : bool} :
+  ∀ p : form₂, p.QF (bnot b) → p.QDF b
+| (form₂.lit _ _)   _  := trivial
+| (form₂.bin _ p q) h0 := h0
+| (form₂.qua c p)   h0 :=
+  ⟨ λ h1, absurd h1 (bnot_eq_iff_ne.elim_left h0.left),
+    λ _, h0.right⟩
+
+end form₂

--- a/src/tactic/spass/fov.lean
+++ b/src/tactic/spass/fov.lean
@@ -1,0 +1,199 @@
+/-
+  Copyright (c) 2019 Seul Baek. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Seul Baek
+
+  First-order constraint for variables.
+  `fov k x` asserts that variable k is only used
+  as a first-order variable in x. I.e., variable k
+  never occurs at the head of a complex term.
+-/
+
+import tactic.spass.form2
+
+open nat
+
+local notation `#` := term₂.var
+local notation a `&` b := term₂.app a b
+
+local notation `⟪` b `,` a `⟫` := form₂.lit b a
+local notation p `∨*` q        := form₂.bin tt p q
+local notation p `∧*` q        := form₂.bin ff p q
+local notation `∃*`            := form₂.qua tt
+local notation `∀*`            := form₂.qua ff
+
+namespace term₂
+
+def fov_on (k : nat) : bool → term₂ → Prop
+| ff (# m)   := k ≠ m
+| tt (# _)   := true
+| _  (a & b) := fov_on ff a ∧ fov_on tt b
+
+instance fov_on.decidable {k : nat} :
+  ∀ {b : bool} {t : term₂}, decidable (t.fov_on k b)
+| ff (# m)   := by {unfold fov_on, apply_instance}
+| tt (# m)   := decidable.true
+| tt (a & b) := @and.decidable _ _ fov_on.decidable fov_on.decidable
+| ff (a & b) := @and.decidable _ _ fov_on.decidable fov_on.decidable
+
+def fov (k : nat) : term₂ → Prop := fov_on k ff
+
+instance fov.decidable {k : nat} {p : term₂} : decidable (p.fov k) :=
+by {unfold fov, apply_instance}
+
+lemma fov_of_not_occ (k : nat) :
+  ∀ a : term₂, ¬ a.occ k → fov k a
+| (# m)   h0 := h0
+| (a & (# m)) h0 :=
+  ⟨fov_of_not_occ _ (λ h1, absurd (or.inl h1) h0), trivial⟩
+| (a & (b & c)) h0 :=
+  by { cases not_or_distrib.elim_left h0 with h1 h2,
+       refine ⟨fov_of_not_occ _ h1, fov_of_not_occ _ h2⟩ }
+
+lemma fov_app_var (k m : nat) (a : term₂) :
+  fov k (a & (# m)) ↔ fov k a :=
+by simp only [fov, fov_on, and_true]
+
+lemma fov_incr_ge :
+  ∀ {k m : nat} (a : term₂),
+  m ≤ k → (fov (k + 1) (a.incr_ge m) ↔ fov k a)
+| k m (# n) h0 :=
+  begin
+    unfold term₂.incr_ge,
+    by_cases h2 : m ≤ n,
+    { rw if_pos h2,
+      apply not_iff_not_of_iff (nat.succ_eq_succ_iff _ _) },
+    rw if_neg h2,
+    have h3 : n < k,
+    { rw not_le at h2,
+      exact lt_of_lt_of_le h2 h0 },
+    refine ⟨ λ _, ne_of_gt h3,
+             λ _, ne_of_gt (lt_trans h3 $ lt_succ_self _) ⟩
+  end
+| k m (a & (# n)) h0 :=
+  begin
+    unfold term₂.incr_ge,
+    by_cases h2 : m ≤ n;
+    (`[rw if_pos h2] <|> `[rw if_neg h2]);
+    `[ rw [fov_app_var, fov_app_var],
+       apply fov_incr_ge a h0 ]
+  end
+| k m (a & (b & c)) h0 :=
+  begin
+    apply pred_mono_2,
+    { apply fov_incr_ge a h0 },
+    apply fov_incr_ge (b & c) h0
+  end
+
+lemma fov_incr_ge_of_lt {k m : nat} (h0 : k < m) :
+  ∀ a : term₂, fov k a → fov k (a.incr_ge m)
+| (# n) h1 :=
+  begin
+    unfold incr_ge,
+    by_cases h2 : m ≤ n,
+    { rw if_pos h2,
+      apply ne_of_lt (lt_trans
+        (lt_of_lt_of_le h0 h2) $ lt_succ_self _) },
+    rw if_neg h2, exact h1
+  end
+| (a & (# n)) h1 :=
+  begin
+    unfold incr_ge,
+    by_cases h2 : m ≤ n;
+    (`[rw if_pos h2] <|> `[rw if_neg h2]);
+    `[refine ⟨fov_incr_ge_of_lt _ h1.left, trivial⟩]
+  end
+| (a & (b & c)) h1 :=
+  ⟨ fov_incr_ge_of_lt a h1.left,
+    fov_incr_ge_of_lt (b & c) h1.right ⟩
+
+end term₂
+
+namespace form₂
+
+def fov : nat → form₂ → Prop
+| k ⟪b, a⟫           := a.fov k
+| k (form₂.bin _ p q) := fov k p ∧ fov k q
+| k (form₂.qua b p)   := fov (k + 1) p
+
+lemma fov_of_not_occ :
+  ∀ k : nat, ∀ p : form₂, ¬ p.occ k → p.fov k
+| k (form₂.lit b a)   := term₂.fov_of_not_occ _ _
+| k (form₂.bin b p q) :=
+  by { intro h0,
+       cases not_or_distrib.elim_left h0 with h1 h2,
+       refine ⟨fov_of_not_occ _ _ h1, fov_of_not_occ _ _ h2⟩ }
+| k (form₂.qua b p) := fov_of_not_occ (k + 1) _
+
+lemma fov_incr_ge :
+  ∀ {k m : nat} {p : form₂},
+  m ≤ k → fov k p → fov (k + 1) (p.incr_ge m)
+| k m ⟪b, a⟫ h0 h1 :=
+  by { unfold fov at h1,
+       rwa ← term₂.fov_incr_ge a h0 at h1 }
+| k m (form₂.bin b p q) h0 h1 :=
+  by { cases h1, constructor;
+       apply fov_incr_ge h0;
+       assumption }
+| k m (form₂.qua b p) h0 h1 :=
+  by { apply @fov_incr_ge (k + 1),
+       exact succ_le_succ h0, exact h1 }
+
+lemma fov_incr_ge_of_lt :
+  ∀ {k m : nat} (h0 : k < m),
+  ∀ p : form₂, fov k p → fov k (p.incr_ge m)
+| k m h0 ⟪b, a⟫           := term₂.fov_incr_ge_of_lt h0 _
+| k m h0 (form₂.bin _ p q) :=
+  λ h1, ⟨ fov_incr_ge_of_lt h0 _ h1.left,
+          fov_incr_ge_of_lt h0 _ h1.right ⟩
+| k m h0 (form₂.qua b p)   :=
+  fov_incr_ge_of_lt (succ_lt_succ h0) _
+
+instance fov.decidable : ∀ {k : nat} {p : form₂}, decidable (p.fov k)
+| k ⟪b, a⟫ := by {unfold fov, apply_instance}
+| k (form₂.bin b p q):=
+  @and.decidable _ _ fov.decidable fov.decidable
+| k (form₂.qua b p) := @fov.decidable _ p
+
+end form₂
+
+def foq (ae : bool) : form₂ → Prop
+| ⟪b, a⟫            := true
+| (form₂.bin _ p q) := foq p ∧ foq q
+| (form₂.qua b p)   := (ae = b → p.fov 0) ∧ foq p
+
+instance foq.decidable (b : bool) : ∀ {p : form₂}, decidable (foq b p)
+| ⟪b, a⟫            := decidable.true
+| (form₂.bin _ p q) := @and.decidable _ _ foq.decidable foq.decidable
+| (form₂.qua c p)   :=
+  @and.decidable _ _
+    (@implies.decidable _ _ (by apply_instance)
+    form₂.fov.decidable) foq.decidable
+
+lemma foq_incr_ge {b : bool} :
+  ∀ {m : nat} {p : form₂},
+  foq b p → foq b (p.incr_ge m)
+| m ⟪b, a⟫           h0 := trivial
+| m (form₂.bin b p q) h0 :=
+  by { cases h0, constructor;
+       apply foq_incr_ge; assumption }
+| m (form₂.qua c p)   h0 :=
+  begin
+    constructor,
+    { intro h1,
+      apply form₂.fov_incr_ge_of_lt,
+      { apply zero_lt_succ },
+      apply h0.left h1 },
+    exact foq_incr_ge h0.right
+  end
+
+lemma fov_incr {k : nat} {p : form₂} :
+  p.fov k → p.incr.fov (k + 1):=
+form₂.fov_incr_ge (nat.zero_le _)
+
+lemma fov_neg : ∀ k : nat, ∀ p : form₂, p.neg.fov k ↔ p.fov k
+| k ⟪b, a⟫           := by refl
+| k (form₂.bin b p q) :=
+  by simp only [form₂.fov, form₂.neg, fov_neg]
+| k (form₂.qua b p)   :=
+  by simp only [form₂.fov, form₂.neg, fov_neg]

--- a/src/tactic/spass/list.lean
+++ b/src/tactic/spass/list.lean
@@ -1,0 +1,163 @@
+/-
+  Copyright (c) 2019 Seul Baek. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Seul Baek
+
+  List lemmas and definitions.
+-/
+
+import data.list.basic
+import tactic.spass.misc
+
+universes u v
+
+variables {α : Type u} {β : Type v}
+
+namespace list
+
+open option
+
+theorem exists_mem_append {p : α → Prop} {l₁ l₂ : list α} :
+  (∃ x ∈ l₁ ++ l₂, p x) ↔ (∃ x ∈ l₁, p x) ∨ (∃ x ∈ l₂, p x) :=
+begin
+  constructor; intro h0,
+  { rcases h0 with ⟨a, h1, h2⟩,
+    rw list.mem_append at h1, cases h1,
+    { left, refine ⟨_, h1, h2⟩ },
+    right, refine ⟨_, h1, h2⟩ },
+  cases h0; rcases h0 with ⟨a, h1, h2⟩;
+  refine ⟨a, _, h2⟩; rw list.mem_append;
+  [left, right]; assumption
+end
+
+lemma exists_mem_iff_exists_mem_map
+  {p : α → Prop} {q : β → Prop} {f : α → β} (h : ∀ a : α, p a ↔ q (f a)) :
+  ∀ as : list α, ((∃ a ∈ as, p a) ↔ (∃ b ∈ as.map f, q b))
+| []        := by constructor; rintro ⟨_, ⟨_⟩, _⟩
+| (a :: as) :=
+  begin
+    rw [map_cons],
+    simp only [exists_mem_cons_iff],
+    apply pred_mono_2 (h _),
+    apply exists_mem_iff_exists_mem_map
+  end
+
+lemma forall_mem_iff_forall_mem_map
+  {p : α → Prop} {q : β → Prop} {f : α → β} (h : ∀ a : α, p a ↔ q (f a)) :
+  ∀ as : list α, ((∀ a ∈ as, p a) ↔ (∀ b ∈ as.map f, q b))
+| []        := by constructor; intro; apply forall_mem_nil
+| (a :: as) :=
+  begin
+    rw [map_cons],
+    simp only [forall_mem_cons],
+    apply pred_mono_2 (h _),
+    apply forall_mem_iff_forall_mem_map
+  end
+
+
+lemma mem_remove_nth {a : α}  :
+  ∀ l : list α, ∀ k m : nat,
+  l.nth m = some a → k ≠ m → a ∈ l.remove_nth k
+| [] k m h0 h1 := by cases h0
+| (b :: l) 0 m h0 h1 :=
+  begin
+    cases m, {cases h1 rfl},
+    simp only [list.remove_nth],
+    rw list.mem_iff_nth, use m,
+    exact h0
+  end
+| (b :: l) (k + 1) m h0 h1 :=
+  begin
+    cases m,
+    { apply or.inl (option.some.inj h0.symm) },
+    have h2 : k ≠ m,
+    { intro h2, rw h2 at h1, cases h1 rfl },
+    apply or.inr (mem_remove_nth _ k m h0 h2)
+  end
+
+lemma mem_of_mem_remove_nth {a : α} :
+  ∀ l : list α, ∀ k : nat, a ∈ l.remove_nth k → a ∈ l
+| []       k h0 := by cases k; cases h0
+| (b :: l) 0 h0 := or.inr h0
+| (b :: l) (k + 1) h0 :=
+  by { cases h0, {exact or.inl h0},
+       apply or.inr (mem_of_mem_remove_nth l k h0) }
+
+lemma mem_iff_nth_eq_some_or_mem_remove_nth
+  {a : α} {l : list α} (k : nat) :
+  a ∈ l ↔ (a ∈ l.remove_nth k ∨ l.nth k = some a) :=
+begin
+  constructor; intro h0,
+  { rw @list.mem_iff_nth _ a l at h0,
+    rcases h0 with ⟨m, h1⟩,
+    by_cases h2 : k = m,
+    { right, rwa ← h2 at h1 },
+    left, apply mem_remove_nth _ _ _ h1 h2 },
+  cases h0,
+  { apply mem_of_mem_remove_nth _ _ h0 },
+  rw @list.mem_iff_nth _ a l,
+  refine ⟨k, h0⟩
+end
+
+def remove_one [decidable_eq α] (a : α) (as : list α) : option (list α) :=
+if as.index_of a < as.length
+then some (as.remove_nth $ as.index_of a)
+else none
+
+/- Equivalent to perm, but includes no axioms -/
+
+def exteq [decidable_eq α] : list α → list α → Prop
+| []        []       := true
+| []        (_ :: _) := false
+| (a :: l1) l2       :=
+  match l2.remove_one a with
+  | none       := false
+  | (some l2') := exteq l1 l2'
+  end
+
+lemma remove_one_subset [decidable_eq α] (a : α) (l1 l2 : list α) :
+  l1.remove_one a = some l2 → l2 ⊆ l1 :=
+begin
+  unfold list.remove_one,
+  by_cases l1.index_of a < l1.length,
+  { rw if_pos h, intro h1,
+    rw ← (option.some.inj h1),
+    intros x h2,
+    rw list.mem_iff_nth_eq_some_or_mem_remove_nth (l1.index_of a),
+    left, assumption },
+  rw if_neg h, rintro ⟨_⟩
+end
+
+lemma subset_of_exteq [decidable_eq α] :
+  ∀ l1 l2 : list α, list.exteq l1 l2 → l1 ⊆ l2
+| []        []       h0 x h1 := by cases h1
+| []        (_ :: _) h0 x h1 := by cases h0
+| (a :: l1) l2       h0 x h1 :=
+  begin
+    unfold list.exteq at h0,
+    cases h2 : (l2.remove_one a) with l2',
+    { rw h2 at h0, cases h0 },
+    cases h1,
+    { subst h1,
+      unfold list.remove_one at h2,
+      by_cases h3 : l2.index_of x < l2.length,
+      { rw list.index_of_lt_length at h3, exact h3 },
+      rw if_neg h3 at h2, cases h2 },
+    rw h2 at h0,
+    have h3 := subset_of_exteq _ _ h0,
+    apply list.remove_one_subset _ _ _ h2 (h3 h1)
+  end
+
+instance decidable_exteq [decidable_eq α] :
+  ∀ l1 l2 : list α, decidable (list.exteq l1 l2)
+| []        []       := by { right, trivial }
+| []        (_ :: _) := by { left, rintro ⟨_⟩ }
+| (a :: l1) l2       :=
+  begin
+    unfold list.exteq,
+    cases (l2.remove_one a),
+    { left, rintro ⟨_⟩ },
+    apply decidable_exteq,
+  end
+
+end list

--- a/src/tactic/spass/main.lean
+++ b/src/tactic/spass/main.lean
@@ -1,0 +1,82 @@
+/-
+  Copyright (c) 2019 Seul Baek. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Seul Baek
+
+ `spass` uses proof output from SPASS to discharge first-order goals.
+-/
+
+import system.io
+import tactic.spass.arifix
+import tactic.spass.reify
+import tactic.spass.compile
+
+open tactic list
+
+local notation `#`     := term₂.var
+local notation a `&` b := term₂.app a b
+
+def clausify (p : form₂) : mat :=
+mat.renumber $ cnf $ form.neg $ form₂.folize 0 $ prenexify $ swap_all ff p
+
+lemma arifix_of_run_eq_some_empty (α : Type) [inhabited α]
+  (p : form₂) (ρ : recipe) :
+  foq tt p → ρ.run (clausify p) = some ([], []) →
+  arifix (model.default α) p :=
+begin
+  intros h0 hρ,
+  apply arifix_of_holds h0,
+  apply (@id (fam α p) _),
+  apply (forall_congr (@swap_all_eqv α _ ff _ h0)).elim_left,
+  apply (forall_congr (@prenexify_eqv α _ _)).elim_left,
+  have h1 : foq tt (prenexify (swap_all ff p)),
+  { apply foq_prenexify,
+    apply foq_swap_all _ h0 },
+  have h2 : form₂.QDF ff (prenexify (swap_all ff p)),
+  { apply QDF_prenexify,
+    apply QN_swap_all },
+  apply fam_of_tas_folize _ h1 h2,
+  apply @tas_of_run_empty α _ _ _ hρ
+end
+
+/- Same as regular read_to_end and cmd,
+   except for configurable read length. -/
+
+def io.fs.read_to_end_cfg (h : io.handle) (k : nat) : io char_buffer :=
+io.iterate mk_buffer $ λ r,
+  do done ← io.fs.is_eof h,
+    if done
+    then return none
+    else do
+      c ← io.fs.read h k,
+      return $ some (r ++ c)
+
+def io.cmd_cfg (args : io.process.spawn_args) (k : nat) : io string :=
+do child ← io.proc.spawn { stdout := io.process.stdio.piped, ..args },
+  buf ← io.fs.read_to_end_cfg child.stdout k,
+  io.fs.close child.stdout,
+  exitv ← io.proc.wait child,
+  when (exitv ≠ 0) $ io.fail $ "process exited with status " ++ repr exitv,
+  return buf.to_string
+
+meta def spass_output (gs : string) : tactic string :=
+unsafe_run_io $ io.cmd_cfg {
+  cmd  := "./spass.sh",
+  /- Change this path to the desired location of temporary goal file -/
+  args := [gs, "/path/to/temp_goal_file"],
+  /- Change this path to the location of spass.sh -/
+  cwd  := "/path/to/spass.sh"
+} 65536
+
+/- Return ⌜π : arifix (model.default ⟦αx⟧) p⌝ -/
+meta def prove_arifix (αx ix : expr) (p : form₂) : tactic expr :=
+do s ← spass_output (mat.print $ clausify p),
+   ls ← parse.lines s,
+   ρx ← compile (clausify p) ls,
+   to_expr ``(@arifix_of_run_eq_some_empty %%αx %%ix %%p.to_expr %%ρx
+     dec_trivial (@eq.refl (option cla) (some ([], []))))
+
+meta def spass : tactic unit :=
+do (dx, ix, p) ← reify,
+   y ← prove_arifix dx ix p,
+   apply y, skip

--- a/src/tactic/spass/misc.lean
+++ b/src/tactic/spass/misc.lean
@@ -59,3 +59,29 @@ def digit_to_subs : char → char
 
 def nat.to_subs (n : nat) : string :=
 ⟨n.repr.data.map digit_to_subs⟩
+
+
+namespace nat
+
+  lemma succ_lt_succ_iff :
+    ∀ {a b : ℕ}, a.succ < b.succ ↔ a < b :=
+  begin
+    intros a b, apply iff.intro,
+    apply lt_of_succ_lt_succ,
+    apply succ_lt_succ
+  end
+
+  lemma succ_eq_succ_iff (k m : nat) :
+    k.succ = m.succ ↔ k = m :=
+  by { constructor; intro h0,
+       {cases h0, refl}, rw h0 }
+
+  lemma succ_ne_succ {k m : nat} :
+    k ≠ m → k.succ ≠ m.succ :=
+  by { intros h0 h1, apply h0,
+       rwa succ_eq_succ_iff at h1 }
+
+  lemma zero_ne_succ {k : nat} : 0 ≠ k.succ :=
+  λ h, by cases h
+
+end nat

--- a/src/tactic/spass/misc.lean
+++ b/src/tactic/spass/misc.lean
@@ -1,0 +1,61 @@
+/-
+  Copyright (c) 2019 Seul Baek. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Seul Baek
+
+  Miscellaneous.
+-/
+
+universe u
+
+variables {α β γ δ : Type u}
+
+def spaces (k : nat) : string := ⟨list.repeat ' ' k⟩
+
+def bool.repr : bool → string
+| tt := "tt"
+| ff := "ff"
+
+def list.write (f : α → string) (s : string) : list α → string
+| []        := ""
+| (a :: as) := f a ++ s ++ list.write as
+
+lemma bnot_eq_iff_ne {a b : bool} :
+  bnot a = b ↔ a ≠ b :=
+by cases a; cases b; simp only
+   [bnot, ne, not_false_iff, eq_self_iff_true, not_true]
+
+lemma eq_bnot_iff_ne {a b : bool} :
+  a = bnot b ↔ a ≠ b :=
+by cases a; cases b; simp only
+   [bnot, ne, not_false_iff, eq_self_iff_true, not_true]
+
+lemma ite_cases {r : α → Prop} {p : Prop} [decidable p] {a b : α} :
+  r a → r b → r (ite p a b) :=
+by { intros h0 h1, by_cases h2 : p,
+     { rw if_pos h2, exact h0 },
+     rw if_neg h2, exact h1 }
+
+lemma pred_mono_2 {c : Prop → Prop → Prop} {a1 a2 b1 b2 : Prop} :
+  (a1 ↔ a2) → (b1 ↔ b2) → (c a1 b1 ↔ c a2 b2) :=
+λ h1 h2, by rw [h1, h2]
+
+def assign (a : α) (f : nat → α) : nat → α
+| 0       := a
+| (k + 1) := f k
+
+def digit_to_subs : char → char
+| '0' := '₀'
+| '1' := '₁'
+| '2' := '₂'
+| '3' := '₃'
+| '4' := '₄'
+| '5' := '₅'
+| '6' := '₆'
+| '7' := '₇'
+| '8' := '₈'
+| '9' := '₉'
+| _ := ' '
+
+def nat.to_subs (n : nat) : string :=
+⟨n.repr.data.map digit_to_subs⟩

--- a/src/tactic/spass/model.lean
+++ b/src/tactic/spass/model.lean
@@ -1,0 +1,63 @@
+/-
+  Copyright (c) 2019 Seul Baek. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Seul Baek
+
+  Models and variable assignments.
+-/
+
+import logic.function tactic.basic tactic.interactive
+import tactic.spass.misc
+
+universe u
+
+variable {α : Type u}
+
+local notation f `₀↦` a := assign a f
+
+def value (α : Type u) : Type u := list α → (α × Prop)
+
+def value.default [inhabited α] : value α :=
+λ as, (default α, false)
+
+def evaluate (a : α) : value α :=
+λ _, (a, false)
+
+def denote (v : value α) : α := (v []).fst
+
+postfix  `ₑ` : 1000 := evaluate
+postfix  `ᵈ` : 1000 := denote
+
+lemma denote_evaluate (a : α) : (a ₑ)ᵈ = a := rfl
+
+@[reducible] def value.app (v w : value α) : value α :=
+λ as, v (wᵈ :: as)
+
+local infix `⬝` := value.app
+
+def model (α : Type u) : Type u := nat → value α
+
+def model.default (α : Type u) [inhabited α] : model α := λ _, value.default
+
+@[reducible] def vas (α : Type u) : Type u := nat → α
+
+def vas.default (α : Type u) [inhabited α] : vas α := λ _, default α
+
+lemma assign_app_evaluate_denote (M : model α) (v w : value α) :
+  (M ₀↦ v ⬝ wᵈₑ) = (M ₀↦ v ⬝ w) :=
+by ext k as; cases k; refl
+
+namespace model
+
+def decr_idxs (M : model α) : model α :=
+M ∘ nat.succ
+
+end model
+
+lemma assign_decr_idxs (M : model α) :
+  (M.decr_idxs ₀↦ (M 0)) = M :=
+begin
+  rw function.funext_iff,
+  rintro ⟨_⟩, { refl },
+  simp only [model.decr_idxs, assign]
+end

--- a/src/tactic/spass/parse.lean
+++ b/src/tactic/spass/parse.lean
@@ -1,0 +1,241 @@
+/-
+  Copyright (c) 2019 Seul Baek. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Seul Baek
+
+  Parse proof output from SPASS.
+-/
+
+import data.buffer.parser
+import tactic.spass.recipe
+
+universe u
+
+open list parser tactic
+
+inductive rule
+| inp : rule
+| obv (c l : nat) : rule
+| fac (k rf1 rf2 : nat) : rule
+| con (c l : nat) : rule
+| res (c1 l1 c2 l2 : nat) : rule
+| unc (c1 l1 c2 l2 : nat) : rule
+| ems : list (nat × nat) → rule
+
+namespace rule
+
+def repr : rule → string
+| rule.inp := "Inp"
+| (rule.obv k m) := "Obv:" ++ k.repr ++ "." ++ m.repr
+| (rule.con k m) := "Con:" ++ k.repr ++ "." ++ m.repr
+| (rule.fac ln rf1 rf2) := "Fac:" ++ ln.repr ++ "." ++
+  rf1.repr ++ "," ++
+  ln.repr ++ "." ++
+  rf2.repr
+| (rule.res c1 l1 c2 l2) := "Res:" ++ c1.repr ++ "." ++
+  l1.repr ++ "," ++
+  c2.repr ++ "." ++
+  l2.repr
+| (rule.unc c1 l1 c2 l2) := "UnC:" ++ c1.repr ++ "." ++
+  l1.repr ++ "," ++
+  c2.repr ++ "." ++
+  l2.repr
+| (rule.ems l) := "EmS:" ++ l.repr
+
+instance has_repr : has_repr rule := ⟨repr⟩
+meta instance has_to_format : has_to_format rule := ⟨λ x, repr x⟩
+
+end rule
+
+structure line :=
+(n : nat)
+(r : rule)
+(c : cla)
+
+namespace line
+
+def repr : line → string
+| ⟨n, r, c⟩ := n.repr ++ " " ++ r.repr ++ " " ++ c.repr
+
+instance has_repr : has_repr line := ⟨repr⟩
+meta instance has_to_format : has_to_format line := ⟨λ x, repr x⟩
+
+end line
+
+inductive preterm : Type
+| sym : nat  → preterm
+| var : nat  → preterm
+| app : preterm → preterm → preterm
+
+def digits : list char :=
+[ '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' ]
+
+def unpunctuate_core : list char → list char
+| []        := []
+| [c]       := if c = '.' then [] else [c]
+| (c :: cs) := c :: unpunctuate_core cs
+
+def unpunctuate (s : string) : string :=
+⟨unpunctuate_core s.data⟩
+
+def string.filter (p : char → Prop) [decidable_pred p] (s : string) : string :=
+⟨s.data.filter p⟩
+
+def lex_core : list char → bool → list (list char) → list (list char)
+| []        _ ts := (ts.map reverse).reverse
+| (c :: cs) _ [] :=
+  if c = ' '
+  then lex_core cs ff []
+  else lex_core cs tt [[c]]
+| (c :: cs) b (t :: ts) :=
+  if c = ' '
+  then lex_core cs ff (t :: ts)
+  else if b
+       then lex_core cs tt ((c :: t) :: ts)
+       else lex_core cs tt ([c] :: t :: ts)
+
+def lex (s : string) : list string :=
+(lex_core s.data ff []).map string_imp.mk
+
+namespace parse
+
+meta def to_tactic {α : Type u} : (string ⊕ α) → tactic α
+| (sum.inl s) := fail s
+| (sum.inr a) := return a
+
+def digits : parser string := many_char (one_of digits)
+
+def nat : parser nat :=
+digits >>= (return ∘ string.to_nat)
+
+def character : parser char := sat (λ x, x ≠ '\n')
+
+def linestring_core : parser string := many_char character <* many (ch '\n')
+
+meta def linestrings_core (s : string) : tactic (list string) :=
+to_tactic $ run_string (many linestring_core) (s ++ "\n")
+
+meta def is_linestring (s : string) : tactic bool :=
+match s.data with
+| []       := return ff
+| (c :: _) := return (c ∈ _root_.digits)
+end
+
+meta def linestrings (s : string) : tactic (list string) :=
+linestrings_core s >>= monad.filter is_linestring
+
+meta def reference : parser (_root_.nat × _root_.nat) :=
+do k ← nat,
+   ch '.',
+	 m ← nat,
+	 pure (k, m)
+
+meta def rule_core : parser _root_.rule :=
+(str "Inp" >> pure _root_.rule.inp) <|>
+(do str "Obv",
+    ch ':',
+    (k, m) ← reference,
+		pure (_root_.rule.obv k m)) <|>
+(do str "Con",
+    ch ':',
+    (k, m) ← reference,
+		pure (_root_.rule.con k m)) <|>
+(do (str "Fac"),
+    ch ':',
+    cn ← nat, ch '.',
+    rf1 ← nat, ch ',',
+    _ ← nat, ch '.',
+    rf2 ← nat,
+		pure (_root_.rule.fac cn rf1 rf2)) <|>
+(do (str "Res"),
+    ch ':',
+    c1 ← nat, ch '.',
+    l1 ← nat, ch ',',
+    c2 ← nat, ch '.',
+    l2 ← nat,
+		pure (_root_.rule.res c1 l1 c2 l2)) <|>
+(do (str "UnC"),
+    ch ':',
+    c1 ← nat, ch '.',
+    l1 ← nat, ch ',',
+    c2 ← nat, ch '.',
+    l2 ← nat,
+		pure (_root_.rule.unc c1 l1 c2 l2)) <|>
+(do (str "EmS" <|> str "MRR" <|> str "SSi" <|> str "SoR"),
+    ch ':',
+    l ← sep_by1 (ch ',') reference,
+		pure (_root_.rule.ems l))
+
+meta def rule : parser _root_.rule :=
+do ch '[', nat, ch ':',
+   r ← rule_core, ch ']', pure r
+
+meta def number_rule' : parser (_root_.nat × _root_.rule) :=
+do n ← nat,
+   r ← rule,
+	 pure (n, r)
+
+meta def number_rule (s : string) : tactic (_root_.nat × _root_.rule) :=
+to_tactic (run_string number_rule' s)
+
+def split_clastrings_core : list string → list string → list string × list string
+| ns []        := (ns, [])
+| ns (s :: ss) :=
+  if s = "->" then (ns, ss) else split_clastrings_core (ns ++ [s]) ss
+
+def split_clastrings (ss : list string) : list string × list string :=
+split_clastrings_core [] ss
+
+meta def var_index : parser _root_.nat :=
+(ch 'u' >> pure 0) <|>
+(ch 'v' >> pure 1) <|>
+(ch 'w' >> pure 2) <|>
+(ch 'y' >> pure 4) <|>
+(ch 'z' >> pure 5) <|>
+(do ch 'x',
+    ((eof >> pure 3) <|>
+		 (do n ← nat, pure (n + 5))))
+
+meta def preterm : parser preterm :=
+(do ch 's',
+    n ← nat,
+		((do ch '(',
+		     pts ← sep_by1 (ch ',') preterm,
+		     ch ')',
+			   pure (list.foldl _root_.preterm.app (_root_.preterm.sym n) pts)) <|>
+			(pure (_root_.preterm.sym n)))) <|>
+(do n ← var_index, pure $ _root_.preterm.var n)
+
+meta def preterm_to_term : _root_.preterm → tactic term
+| (_root_.preterm.sym k)   := return $ term.sym k
+| (_root_.preterm.app pt $ _root_.preterm.var k) :=
+  do t ← preterm_to_term pt,
+	   return (term.vpp t k)
+| (_root_.preterm.app pt $ ps) :=
+  do t ← preterm_to_term pt,
+     s ← preterm_to_term ps,
+		 return (term.app t s)
+| (_root_.preterm.var k) := fail "Ill-formed term"
+
+meta def term (s : string) : tactic term :=
+match run_string preterm s with
+| (sum.inl s)  := fail s
+| (sum.inr pt) := preterm_to_term pt
+end
+
+meta def line (s : string) : tactic line :=
+match lex ((unpunctuate s).filter (λ c, ¬ c ∈ ['*', '+', '|'])) with
+| []          := failed
+| (tk :: tks) :=
+  do (k, r) ← number_rule tk,
+	   let (ntks, ptks) := split_clastrings tks,
+	   nts ← monad.mapm term ntks,
+	   pts ← monad.mapm term ptks,
+		 return ⟨k, r, (nts, pts)⟩
+end
+
+meta def lines (s : string) : tactic (list $ _root_.line) :=
+do ss ← linestrings s,
+   monad.mapm line ss
+
+end parse

--- a/src/tactic/spass/pull.lean
+++ b/src/tactic/spass/pull.lean
@@ -1,0 +1,293 @@
+/-
+  Copyright (c) 2019 Seul Baek. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Seul Baek
+
+  Pulling quantifiers for Skolemization and prenex normalization.
+-/
+
+import tactic.spass.fov
+
+universe u
+
+variables {α β : Type u}
+
+open nat
+
+local notation f `₀↦` a := assign a f
+local notation `#` := term₂.var
+local notation a `&` b := term₂.app a b
+
+postfix  `ₑ` : 1000 := evaluate
+postfix  `ᵈ` : 1000 := denote
+local infix `⬝` := value.app
+
+local notation `⟪` b `,` a `⟫` := form₂.lit b a
+local notation p `∨*` q        := form₂.bin tt p q
+local notation p `∧*` q        := form₂.bin ff p q
+local notation `∃*`            := form₂.qua tt
+local notation `∀*`            := form₂.qua ff
+
+def pull_fa_left_eqv [inhabited α] (b : bool) (p q : form₂) :
+  ∀* (form₂.bin b p q.incr) <==α==> form₂.bin b (∀* p) q :=
+begin
+  intro M,
+  have v : value α := (default α)ₑ,
+  constructor; intro h0; cases b,
+  { constructor,
+    { intro w, exact (h0 w).left },
+    apply (holds_assign_incr _).elim_left (h0 v).right },
+  { cases classical.em ((M ₀↦ v) ⊨ q.incr) with h2 h2,
+    { rw holds_assign_incr at h2,
+      right, exact h2 },
+    left, intro w,
+    cases (h0 w) with h3 h3,
+    { exact h3 },
+    rw holds_assign_incr at h2,
+    rw holds_assign_incr at h3,
+    cases (h2 h3) },
+  { intro w,
+    refine ⟨h0.left _, _⟩,
+    rw holds_assign_incr,
+    exact h0.right },
+  { intro w,
+    cases classical.em ((M ₀↦ w) ⊨ q.incr) with h1 h1,
+    { right, exact h1 },
+    left, cases h0 with h2 h2,
+    { apply h2 },
+    rw holds_assign_incr at h1,
+    cases (h1 h2) }
+end
+
+def pull_ex_left_eqv [inhabited α] (b : bool) (p q : form₂) :
+  ∃* (form₂.bin b p q.incr) <==α==> form₂.bin b (∃* p) q :=
+by { rw ← neg_eqv_neg,
+     simp only [form₂.neg, neg_incr,
+     bnot, pull_fa_left_eqv] }
+
+def pull_left_eqv [inhabited α] (ae ao : bool) (p q : form₂) :
+  form₂.qua ae (form₂.bin ao p q.incr) <==α==>
+  form₂.bin ao (form₂.qua ae p) q :=
+by {cases ae, apply pull_fa_left_eqv, apply pull_ex_left_eqv }
+
+def pull_right_eqv [inhabited α] (ae ao : bool) (p q : form₂) :
+  form₂.qua ae (form₂.bin ao p.incr q) <==α==>
+  form₂.bin ao p (form₂.qua ae q) :=
+begin
+  have h0 : ( form₂.qua ae (form₂.bin ao (form₂.incr p) q) <==α==>
+              form₂.qua ae (form₂.bin ao q (form₂.incr p)) ) :=
+  qua_eqv_qua (bin_comm _ _ _),
+  intro M,
+  simp only [ h0 M, pull_left_eqv ae ao q p M,
+    bin_comm ao p (form₂.qua ae q) M ]
+end
+
+--def pull' (b : bool) : form₂ → form₂ → form₂
+--| p ⟪b, t⟫            := form₂.bin b p ⟪b, t⟫
+--| p (form₂.bin c q r) := form₂.bin b p (form₂.bin c q r)
+--| p (form₂.qua c q)   := form₂.qua c (pull' p.incr q)
+--
+--/- Pull all quantifiers over a binary connective.
+--   `b` specifies the binary connective. -/
+--def pull (b : bool) : form₂ → form₂ → form₂
+--| ⟪c, t⟫            q := pull' b ⟪c, t⟫ q
+--| (form₂.bin c p q) r := pull' b (form₂.bin c p q) r
+--| (form₂.qua c p)   q := form₂.qua c (pull p q.incr)
+
+def pull' (o : option bool) (a : bool) : form₂ → form₂ → form₂
+| p ⟪b, t⟫            := form₂.bin a p ⟪b, t⟫
+| p (form₂.bin c q r) := form₂.bin a p (form₂.bin c q r)
+| p (form₂.qua c q)   :=
+  if (some $ bnot c) = o
+  then form₂.bin a p (form₂.qua c q)
+  else form₂.qua c (pull' p.incr q)
+
+/- Pull quantifiers over a binary connective.
+   'o' specifies the polairy of quantifiers being
+   pulled, `b` specifies the binary connective. -/
+def pull (o : option bool) (b : bool) : form₂ → form₂ → form₂
+| ⟪c, t⟫            q := pull' o b ⟪c, t⟫ q
+| (form₂.bin c p q) r := pull' o b (form₂.bin c p q) r
+| (form₂.qua c p)   q :=
+  if (some $ bnot c) = o
+  then pull' o b (form₂.qua c p) q
+  else form₂.qua c (pull p q.incr)
+
+@[reducible] def form₂.size_of_ordered :
+  (Σ' (b : bool), (Σ' (a : form₂), form₂)) → nat
+| ⟨tt, p, q⟩ := p.size_of + q.size_of + 1
+| ⟨ff, p, q⟩ := p.size_of + q.size_of
+
+meta def form₂.show_size_lt : tactic unit :=
+`[ simp only [form₂.size_of_ordered, form₂.size_of,
+   nat.lt_succ_self, add_comm, add_lt_add_iff_left,
+   add_left_comm, form₂.size_of_incr ] ]
+
+lemma fov_pull' (o : option bool) (b : bool) :
+  ∀ {p q : form₂} {k : nat},
+  p.fov k → q.fov k → (pull' o b p q).fov k
+| p ⟪b, t⟫            k h0 h1 := ⟨h0, h1⟩
+| p (form₂.bin c q r) k h0 h1 := ⟨h0, h1⟩
+| p (form₂.qua c q)   k h0 h1 :=
+  by { apply ite_cases,
+       refine ⟨h0, h1⟩,
+       apply fov_pull' (fov_incr h0) h1 }
+
+lemma fov_pull (o : option bool) (b : bool) :
+  ∀ {p q : form₂} {k : nat},
+  p.fov k → q.fov k → (pull o b p q).fov k
+| ⟪c, t⟫            q k h0 h1 := fov_pull' _ _ h0 h1
+| (form₂.bin c p q) r k h0 h1 := fov_pull' _ _ h0 h1
+| (form₂.qua c p)   q k h0 h1 :=
+  by { apply ite_cases,
+       { apply fov_pull' _ _ h0 h1 },
+       apply fov_pull _ (fov_incr h1),
+       exact h0 }
+
+-- lemma fov_pull' (a : bool) :
+--   ∀ {p q : form₂} {k : nat},
+--   p.fov k → q.fov k → (pull' a p q).fov k
+-- | p ⟪b, t⟫            k h0 h1 := ⟨h0, h1⟩
+-- | p (form₂.bin b q r) k h0 h1 := ⟨h0, h1⟩
+-- | p (form₂.qua b q)   k h0 h1 :=
+--   @fov_pull' p.incr q (k + 1) (fov_incr h0) h1
+--
+-- lemma fov_pull (b : bool) :
+--   ∀ {p q : form₂} {k : nat},
+--   p.fov k → q.fov k → (pull b p q).fov k
+-- | ⟪c, t⟫            q k h0 h1 := fov_pull' _ h0 h1
+-- | (form₂.bin c p q) r k h0 h1 := fov_pull' _ h0 h1
+-- | (form₂.qua c p)   q k h0 h1 :=
+--   @fov_pull p q.incr (k + 1) h0 (fov_incr h1)
+
+lemma foq_pull' (o : option bool) (a b : bool) :
+  ∀ {p q : form₂}, foq a p → foq a q → foq a (pull' o b p q)
+| p ⟪b, t⟫            h0 h1 := ⟨h0, h1⟩
+| p (form₂.bin b q r) h0 h1 := ⟨h0, h1⟩
+| p (form₂.qua b q)   h0 h1 :=
+  begin
+    apply ite_cases,
+    { refine ⟨h0, h1⟩ },
+    constructor,
+    { intro h2,
+      apply fov_pull' _ _ _ (h1.left h2),
+      apply form₂.fov_of_not_occ,
+      apply form₂.not_occ_incr_ge },
+    apply foq_pull' _ h1.right,
+    apply foq_incr_ge h0,
+  end
+
+lemma foq_pull (o : option bool) (a b : bool) :
+  ∀ {p q : form₂}, foq a p → foq a q → foq a (pull o b p q)
+| ⟪c, t⟫            q h0 h1 := foq_pull' _ _ _ h0 h1
+| (form₂.bin c p q) r h0 h1 := foq_pull' _ _ _ h0 h1
+| (form₂.qua c p)   q h0 h1 :=
+  begin
+    apply ite_cases,
+    { apply foq_pull' _ _ _ h0 h1 },
+    constructor,
+    { intro h2,
+      apply fov_pull _ _  (h0.left h2),
+      apply form₂.fov_of_not_occ,
+      apply form₂.not_occ_incr_ge },
+    apply foq_pull h0.right (foq_incr_ge h1),
+  end
+
+def pull'_eqv [inhabited α] (o : option bool) (a : bool) :
+  ∀ p q : form₂, pull' o a p q <==α==> form₂.bin a p q
+| p ⟪c, t⟫            := eqv_refl α _
+| p (form₂.bin b q r) := eqv_refl α _
+| p (form₂.qua b q)   :=
+  begin
+    unfold pull',
+    apply @ite_cases _ (λ x, x <==α==> form₂.bin a p (form₂.qua b q)),
+    { apply eqv_refl },
+    apply eqv_trans
+      (qua_eqv_qua $ pull'_eqv p.incr q)
+      (pull_right_eqv _ _ _ _)
+  end
+
+def pull_eqv [inhabited α] (o : option bool) (a : bool) :
+  ∀ p q : form₂, pull o a p q <==α==> form₂.bin a p q
+| ⟪b, t⟫            q := pull'_eqv o a _ _
+| (form₂.bin b p q) r := pull'_eqv o a _ _
+| (form₂.qua b p)   q :=
+  begin
+    unfold pull,
+    apply @ite_cases _ (λ x, x <==α==> form₂.bin a (form₂.qua b p) q),
+    { apply pull'_eqv },
+    apply eqv_trans
+      (qua_eqv_qua $ pull_eqv p q.incr)
+      (pull_left_eqv _ _ _ _)
+  end
+
+open form₂
+
+lemma QN_pull' (a b : bool) :
+  ∀ {p q : form₂}, p.N a → q.QN a →
+  (pull' (some a) b p q).QN a
+| p ⟪c, t⟫ h0 h1      := ⟨h0, h1⟩
+| p (bin c q r) h0 h1 := ⟨h0, h1⟩
+| p (qua c q)  h0 h1 :=
+  begin
+    unfold pull',
+    by_cases h2 : a = bnot c,
+    { rw [← h2, if_pos rfl],
+      rw eq_bnot_iff_ne at h2,
+      refine ⟨h0, ⟨h2, h1.right h2⟩⟩ },
+    rw if_neg,
+    { have h3 : a = c,
+      { rw eq_bnot_iff_ne at h2,
+        apply not_not.elim_left h2 },
+      refine ⟨λ _, _, λ h4, absurd h3 h4⟩,
+      apply QN_pull' _ (h1.left h3),
+      apply N_incr_ge _ h0 },
+    rw option.some_inj,
+    intro h3, cases (h2 h3.symm)
+  end
+
+lemma QN_pull (a b : bool) :
+  ∀ {p q : form₂}, p.QN a → q.QN a →
+  (pull (some a) b p q).QN a
+| ⟪c, t⟫ q h0 h1      := QN_pull' _ _ h0 h1
+| (bin _ p q) r h0 h1 := QN_pull' _ _ h0 h1
+| (qua c p) q h0 h1 :=
+  begin
+    unfold pull,
+    by_cases h2 : a = bnot c,
+    { rw [← h2, if_pos rfl],
+      rw eq_bnot_iff_ne at h2,
+      apply QN_pull' _ _ _ h1,
+      refine ⟨h2, h0.right h2⟩ },
+    rw if_neg,
+    { rw [eq_bnot_iff_ne, not_not] at h2,
+      refine ⟨λ _, _, λ h3, absurd h2 h3⟩,
+      apply QN_pull (h0.left h2),
+      apply form₂.QN_incr_ge _ h1 },
+    rw option.some_inj,
+    intro h3, cases h2 h3.symm
+  end
+
+lemma QF_pull' (a b : bool) :
+  ∀ {p q : form₂}, p.F → q.QF a →
+  (pull' none b p q).QF a
+| p ⟪c, t⟫      h0 h1 := ⟨h0, h1⟩
+| p (bin c q r) h0 h1 := ⟨h0, h1⟩
+| p (qua c q)   h0 h1 :=
+  begin
+    unfold pull', rw if_neg,
+    { refine ⟨h1.left, QF_pull' (F_incr_ge _ h0) h1.right⟩ },
+    rintro ⟨_⟩
+  end
+
+lemma QF_pull {b : bool} (ao : bool) :
+  ∀ {p q : form₂}, p.QF b → q.QF b →
+  (pull none ao  p q).QF b
+| ⟪_, _⟫      q h0 h1 := QF_pull' _ _ h0 h1
+| (bin _ _ _) q h0 h1 := QF_pull' _ _ h0 h1
+| (qua c p) q h0 h1 :=
+  begin
+    unfold pull, rw if_neg,
+    { refine ⟨h0.left, QF_pull h0.right (form₂.QF_incr_ge _ h1)⟩ },
+    intro h2, cases h2
+  end

--- a/src/tactic/spass/readme.md
+++ b/src/tactic/spass/readme.md
@@ -1,0 +1,3 @@
+- The 'spass' tactic requires SPASS 3.9. Install SPASS 3.9 and and add SPASS to path. (https://www.mpi-inf.mpg.de/departments/automation-of-logic/software/spass-workbench/classic-spass-theorem-prover/download/)
+
+- The definition of the 'spass_output' tactic (in 'main.lean') includes two paths; one for the location of 'spass.sh' (a shell script used for communicating with SPASS), and one for the location of the temporary file in which goals are stored in TPTP format and subsequently read by SPASS. Modify the first path to the location of 'spass.sh', and set the second path to any suitable location.

--- a/src/tactic/spass/recipe.lean
+++ b/src/tactic/spass/recipe.lean
@@ -1,0 +1,183 @@
+/-
+  Copyright (c) 2019 Seul Baek. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Seul Baek
+
+  Detailed recipes for building resolution proofs.
+-/
+
+import tactic.spass.cnf
+import tactic.spass.list
+
+universes u v
+
+variable {α : Type u}
+
+local notation `&`     := term.sym
+local notation a `&` b := term.app a b
+local notation a `#` k := term.vpp a k
+
+@[derive has_reflect] inductive recipe : Type
+| hyp (k : nat)   : recipe
+| prm (c : cla)   : recipe → recipe
+| sub (μ : smaps) : recipe → recipe
+| con (b : bool) (k : nat) : recipe → recipe
+| res (k m : nat) : recipe → recipe → recipe
+
+namespace recipe
+
+def repr_core : nat → recipe → string
+| k (recipe.hyp m) := spaces k ++ "hyp " ++ m.repr ++ "\n"
+| k (recipe.prm c ρ) :=
+  spaces k ++ "prm " ++ c.repr ++ "\n" ++ (ρ.repr_core $ k + 2)
+| k (recipe.sub μ ρ) :=
+  spaces k ++ "sub " ++ μ.repr ++ "\n" ++ (ρ.repr_core $ k + 2)
+| k (recipe.res m n ρ σ) :=
+  spaces k ++ "res " ++ m.repr ++ " " ++ n.repr ++ "\n" ++
+  (ρ.repr_core $ k + 2) ++ (σ.repr_core $ k + 2)
+| k (recipe.con b m ρ) :=
+  spaces k ++ "con " ++ b.repr ++ " " ++ m.repr ++
+  "\n" ++ (ρ.repr_core $ k + 2)
+
+def repr : recipe → string := repr_core 0
+
+instance has_repr : has_repr recipe := ⟨repr⟩
+meta instance has_to_format : has_to_format recipe := ⟨λ x, repr x⟩
+
+def run (m : mat) : recipe → option cla
+| (recipe.hyp k)   := m.nth k
+| (recipe.prm d ρ) :=
+   do c ← ρ.run,
+      if cla.exteq c d
+      then some d
+      else none
+| (recipe.sub μ ρ) :=
+   do c ← ρ.run, some (c.subst μ)
+| (recipe.con ff k ρ) :=
+  do c ← ρ.run,
+     t ← c.fst.nth k,
+     option.guard (λ _, t ∈ c.fst.remove_nth k) (c.fst.remove_nth k, c.snd)
+| (recipe.con tt k ρ) :=
+  do c ← ρ.run,
+     t ← c.snd.nth k,
+     option.guard (λ _, t ∈ c.snd.remove_nth k) (c.fst, c.snd.remove_nth k)
+| (recipe.res k n ρ σ) :=
+  do c ← ρ.run,
+     d ← σ.run,
+     t ← c.snd.nth k,
+     s ← d.fst.nth n,
+     option.guard (λ _, t = s)
+     (c.fst ++ d.fst.remove_nth n,
+      c.snd.remove_nth k ++ d.snd)
+
+end recipe
+
+open tactic option list
+
+lemma fav_of_run_eq_some
+  (M : model α) (m : mat) (h0 : m.fav M) :
+  ∀ ρ : recipe, ∀ c : cla, ρ.run m = some c → c.fav M
+| (recipe.hyp k) c h1 v :=
+  by { simp only [recipe.run] at h1,
+       have h2 := list.mem_iff_nth.elim_right ⟨_, h1⟩,
+       apply h0 _ _ h2 }
+| (recipe.prm d ρ) c h0 v :=
+  begin
+    simp only [recipe.run, option.bind_eq_some] at h0,
+    rcases h0 with ⟨e, h1, h2⟩,
+    by_cases h3 : (cla.exteq e d),
+    { rw if_pos h3 at h2,
+      rw ← option.some.inj h2,
+      have h4 := fav_of_run_eq_some _ _ h1 v,
+      apply cla.holds_of_exteq h4 h3 },
+    rw if_neg h3 at h2, cases h2
+  end
+| (recipe.sub μ ρ) c h1 v :=
+  begin
+    simp only [recipe.run] at h1,
+    cases h2 : (ρ.run m) with d,
+    { rw [h2, option.none_bind] at h1, cases h1 },
+    rw [h2, option.some_bind] at h1,
+    have h3 := fav_of_run_eq_some ρ d h2,
+    rw [← option.some.inj h1, cla.holds_subst],
+    apply h3
+  end
+| (recipe.con ff k ρ) c h1 v :=
+  begin
+    simp only [recipe.run] at h1,
+    rw bind_eq_some at h1, rcases h1 with ⟨d, h1, h2⟩,
+    rw bind_eq_some at h2, rcases h2 with ⟨t, h2, h3⟩,
+    rw guard_eq_some at h3,
+    cases h3 with h3 h4, subst h3,
+    have h5 := fav_of_run_eq_some _ _ h1 v,
+    cases d with nd pd,
+    rcases h5 with ⟨s, h5, h6⟩ | h5,
+    { left, refine ⟨s, _, h6⟩,
+      rw mem_iff_nth_eq_some_or_mem_remove_nth k at h5,
+      cases h5, {exact h5},
+      have : s = t,
+      { apply some.inj (eq.trans h5.symm h2) },
+      rw this, assumption },
+    right, apply h5
+  end
+| (recipe.con tt k ρ) c h1 v :=
+  begin
+    simp only [recipe.run] at h1,
+    rw bind_eq_some at h1, rcases h1 with ⟨d, h1, h2⟩,
+    rw bind_eq_some at h2, rcases h2 with ⟨t, h2, h3⟩,
+    rw guard_eq_some at h3,
+    cases h3 with h3 h4, subst h3,
+    have h5 := fav_of_run_eq_some _ _ h1 v,
+    cases d with nd pd,
+    rcases h5 with h5 | ⟨s, h5, h6⟩,
+    { left, apply h5 },
+    right, refine ⟨s, _, h6⟩,
+    rw mem_iff_nth_eq_some_or_mem_remove_nth k at h5,
+    cases h5, {exact h5},
+    have : s = t,
+    { apply some.inj (eq.trans h5.symm h2) },
+    rw this, assumption
+  end
+| (recipe.res k n ρ σ) c h1 v :=
+  begin
+    simp only [recipe.run] at h1,
+    rw bind_eq_some at h1, rcases h1 with ⟨d, h1, h2⟩,
+    rw bind_eq_some at h2, rcases h2 with ⟨e, h2, h3⟩,
+    rw bind_eq_some at h3, rcases h3 with ⟨i, h3, h4⟩,
+    rw bind_eq_some at h4, rcases h4 with ⟨j, h4, h5⟩,
+    rw guard_eq_some at h5,
+    rcases h5 with ⟨h5, h6⟩,
+    subst h5, subst h6,
+    cases d with nd pd,
+    cases e with ne pe,
+    rcases (fav_of_run_eq_some ρ _ h1 v)
+      with ⟨t, ht1, ht2⟩ | ⟨t, ht1, ht2⟩,
+    { left, refine ⟨t, mem_append_left _ ht1, ht2⟩ },
+    rcases (fav_of_run_eq_some σ _ h2 v)
+      with ⟨s, hs1, hs2⟩ | ⟨s, hs1, hs2⟩,
+    { rw list.mem_iff_nth_eq_some_or_mem_remove_nth k at ht1,
+      rw list.mem_iff_nth_eq_some_or_mem_remove_nth n at hs1,
+      cases ht1,
+      { right, refine ⟨t, mem_append_left _ ht1, ht2⟩ },
+      cases hs1,
+      { left, refine ⟨s, mem_append_right _ hs1, hs2⟩ },
+      have ht3 : t = i,
+      { apply some.inj (eq.trans ht1.symm h3) },
+      have hs3 : s = i,
+      { apply some.inj (eq.trans hs1.symm h4) },
+      subst ht3, subst hs3, cases hs2 ht2 },
+    right, refine ⟨s, mem_append_right _ hs1, hs2⟩
+end
+
+lemma tas_of_run_empty [inhabited α] (p : form) (ρ : recipe) :
+  ρ.run (cnf p.neg).renumber = some ([], []) → p.tas α :=
+begin
+  rintros h0 M,
+  apply classical.by_contradiction,
+  rw not_exists, intro h3,
+  rcases (fav_of_run_eq_some M _ _ ρ _ h0
+    (vas.default α)) with ⟨_, ⟨_⟩, _⟩ | ⟨_, ⟨_⟩, _⟩,
+  apply fav_renumber_of_fav,
+  intro v, apply holds_cnf_of_holds,
+  rw form.holds_neg, apply h3
+end

--- a/src/tactic/spass/reify.lean
+++ b/src/tactic/spass/reify.lean
@@ -1,0 +1,135 @@
+/-
+  Copyright (c) 2019 Seul Baek. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Seul Baek
+
+  Reification of goals into deeply embedded SOL.
+-/
+
+import tactic.spass.form2 logic.basic
+
+open expr tactic
+
+meta def is_func_type (dx : expr) : expr → bool
+| `(%%x → %%y) := (x = dx) && (is_func_type y)
+| x            := x = dx
+
+meta def is_pred_type (dx : expr) : expr → bool
+| `(%%x → %%y) := (x = dx) && (is_pred_type y)
+| x            := x = `(Prop)
+
+meta def get_symb_aux (dx x : expr) : tactic expr :=
+do tx ← infer_type x,
+   if (is_pred_type dx tx || is_func_type dx tx)
+   then return x
+   else failed
+
+meta def get_symb (dx : expr) : expr → tactic expr
+| `(true)   := failed
+| `(false)  := failed
+| `(¬ %%px) := get_symb px
+| `(%%px ∨ %%qx) := get_symb px <|> get_symb qx
+| `(%%px ∧ %%qx) := get_symb px <|> get_symb qx
+| (pi _ _ _ px) := get_symb px
+| `(Exists %%(expr.lam _ _ _ px)) := get_symb px
+| `(Exists %%prx) := get_symb prx
+| x@(app x1 x2) :=
+       get_symb x1
+  <|>  get_symb x2
+  <|>  get_symb_aux dx x
+| x := get_symb_aux dx x
+
+meta def subst_symb (y : expr) : nat → expr → expr
+| k x@(app x1 x2) :=
+  if y = x
+  then var k
+  else app (subst_symb k x1) (subst_symb k x2)
+| k (lam n b tx x) := lam n b tx (subst_symb (k+1) x)
+| k (pi n b tx x)  := pi n b tx (subst_symb (k+1) x)
+| k x := if y = x then var k else x
+
+meta def abst (dx : expr) : expr → tactic expr
+| x :=
+  (do y ← get_symb dx x,
+      abst (pi name.anonymous binder_info.default dx (subst_symb y 0 x))) <|>
+  (return x)
+
+meta def get_domain_core : expr → tactic expr
+| `(¬ %%p)     := get_domain_core p
+| `(%%p ∨ %%q) := get_domain_core p <|> get_domain_core q
+| `(%%p ∧ %%q) := get_domain_core p <|> get_domain_core q
+| `(%%p ↔ %%q) := get_domain_core p <|> get_domain_core q
+| (pi _ _ p q) := mcond (is_prop p) (get_domain_core p <|> get_domain_core q) (return p)
+| `(@Exists %%t _) := return t
+| _ := failed
+
+meta def get_domain : tactic expr :=
+(target >>= get_domain_core) <|> return `(unit)
+
+local notation `#`     := term₂.var
+local notation t `&` s := term₂.app t s
+
+local notation `⟪` b `,` a `⟫` := form₂.lit b a
+local notation p `∨₂` q := form₂.bin tt p q
+local notation p `∧₂` q := form₂.bin ff p q
+local notation `∃₂` p := form₂.qua tt p
+local notation `∀₂` p := form₂.qua ff p
+
+meta def to_term (k : nat) : expr → tactic term₂
+| (app x y) :=
+  do a ← to_term x,
+     b ← to_term y,
+     return (a & b)
+| (var m) := return (# m)
+| _ := failed
+
+meta def to_form : nat → expr → tactic form₂
+| k `(%%px ∨ %%qx) :=
+  do φ ← to_form k px,
+     χ ← to_form k qx,
+     return (φ ∨₂ χ)
+| k `(%%px ∧ %%qx) :=
+  do φ ← to_form k px,
+     χ ← to_form k qx,
+     return (φ ∧₂ χ)
+| k (pi _ _ _ px) :=
+  do φ ← to_form (k+1) px, return (∀₂ φ)
+| k `(Exists %%(expr.lam _ _ _ px)) :=
+  do φ ← to_form (k+1) px, return (∃₂ φ)
+| k `(Exists %%prx) :=
+  do φ ← to_form (k+1) (app (prx.lift_vars 0 1) (var 0)),
+     return (∃₂ φ)
+| k `(¬ %%px) :=
+  do a ← to_term k px,
+     return ⟪ff, a⟫
+| k px :=
+  do a ← to_term k px,
+     return ⟪tt, a⟫
+
+run_cmd mk_simp_attr `sugar
+
+attribute [sugar]
+  -- logical constants
+  or_false  false_or
+  and_false false_and
+  or_true   true_or
+  and_true  true_and
+  -- implication elimination
+  classical.imp_iff_not_or
+  classical.iff_iff_not_or_and_or_not
+  -- NNF
+  classical.not_not
+  not_exists
+  not_or_distrib
+  classical.not_and_distrib
+  classical.not_forall
+
+meta def desugar := `[try {simp only with sugar}]
+
+meta def reify : tactic (expr × expr × form₂) :=
+do desugar,
+   dx ← get_domain,
+   ihx ← to_expr ``(inhabited),
+   ix ← mk_instance (app ihx dx),
+   p ← target >>= abst dx >>= to_form 0,
+   return (dx, ix, p)

--- a/src/tactic/spass/spass.sh
+++ b/src/tactic/spass/spass.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo $1 > $2
+
+SPASS -TPTP -PGiven=0 -PProblem=0 -Splits=0 -DocProof $2

--- a/src/tactic/spass/sub2.lean
+++ b/src/tactic/spass/sub2.lean
@@ -1,0 +1,156 @@
+/-
+  Copyright (c) 2019 Seul Baek. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Seul Baek
+
+  Second-order substitutions.
+-/
+
+import tactic.spass.term2
+import logic.basic logic.function
+
+universe u
+
+variable {α : Type u}
+
+local notation f `₀↦` a := assign a f
+local notation `#` := term₂.var
+local notation a `&` b := term₂.app a b
+
+@[reducible] def sub₂ : Type := list (nat × term₂)
+
+namespace sub₂
+
+open list
+
+@[reducible] def incr : sub₂ → sub₂ :=
+map (prod.map nat.succ (term₂.incr))
+
+def get (k : nat) : sub₂ → option term₂
+| []            := none
+| ((m, a) :: σ) := if k = m then a else get σ
+
+end sub₂
+
+lemma get_eq_of_ne {k m : nat} (a : term₂) (σ : sub₂) :
+  k ≠ m → sub₂.get k ((m, a) :: σ) = sub₂.get k σ :=
+by {intro h0, simp only [sub₂.get, if_neg h0]}
+
+lemma get_zero_incr :
+  ∀ σ : sub₂, σ.incr.get 0 = none
+| []            := rfl
+| ((m, a) :: σ) :=
+  begin
+    have h0 : sub₂.get 0 (sub₂.incr ((m, a) :: σ)) =
+              sub₂.get 0 (sub₂.incr σ),
+    { apply get_eq_of_ne,
+      apply (ne.symm $ nat.succ_ne_zero _) },
+    rw h0, apply get_zero_incr,
+  end
+
+lemma get_succ_incr (k : nat) :
+  ∀ σ : sub₂, σ.incr.get (k + 1) = term₂.incr <$> (σ.get k)
+| []            := rfl
+| ((m, a) :: σ) :=
+  begin
+    by_cases h0 : k = m,
+    { have h1 : sub₂.get (k + 1) (sub₂.incr ((m, a) :: σ)) =
+                some a.incr,
+      { simp only [sub₂.get, sub₂.incr, if_true,
+          prod.map, list.map, eq_self_iff_true, h0],
+        refl },
+     have h2 : term₂.incr <$> sub₂.get k ((m, a) :: σ) =
+               some a.incr,
+     { simp only [sub₂.get, sub₂.incr, if_true,
+       prod.map, list.map, eq_self_iff_true, h0], refl },
+     simp only [h1, h2] },
+    have h1 : sub₂.get (k + 1) (sub₂.incr ((m, a) :: σ)) =
+              sub₂.get (k + 1) (sub₂.incr σ),
+    { simp only [sub₂.get, sub₂.incr, if_false, prod.map,
+     list.map, eq_self_iff_true, not.imp h0 nat.succ_inj] },
+    have h2 : term₂.incr <$> sub₂.get k ((m, a) :: σ) =
+              term₂.incr <$> sub₂.get k σ,
+    { simp only [sub₂.get, sub₂.incr, if_false,
+      prod.map,list.map, eq_self_iff_true, h0] },
+    simp only [h1, h2, get_succ_incr σ]
+  end
+
+namespace term₂
+
+def subst (σ : sub₂) : term₂ → term₂
+| (# k)   := (σ.get k).get_or_else (# k)
+| (a & b) := a.subst & b.subst
+
+lemma subst_eq_of_get_eq_none {σ : sub₂} {k : nat} :
+  σ.get k = none → (# k).subst σ = # k :=
+by {intro h1, simp only [h1, option.get_or_else, subst]}
+
+lemma subst_eq_of_get_eq_some {σ : sub₂} {k : nat} {a : term₂} :
+  σ.get k = some a → (# k).subst σ = a :=
+by {intro h1, simp only [h1, option.get_or_else, subst]}
+
+end term₂
+
+namespace model
+
+def subst (M : model α) (σ : sub₂) : model α :=
+λ k : nat,
+match σ.get k with
+| none   := M k
+| some a := a.val M
+end
+
+lemma subst_eq_of_get_eq_none
+  (M : model α) {σ : sub₂} {k : nat} :
+  σ.get k = none → M.subst σ k = M k :=
+by {intro h1, simp only [h1, model.subst]}
+
+lemma subst_eq_of_get_eq_some
+  (M : model α) {σ : sub₂} {k : nat} {a : term₂} :
+  σ.get k = some a → M.subst σ k = a.val M :=
+by {intro h1, simp only [h1, model.subst]}
+
+lemma assign_subst (M : model α) (v : value α) (σ : sub₂) :
+  ((M.subst σ) ₀↦ v) = (subst (M ₀↦ v) σ.incr) :=
+begin
+  rw function.funext_iff,
+  intro k, cases k,
+  { have h0 := get_zero_incr σ,
+    simp only [subst, h0], refl },
+  have h0 := get_succ_incr k σ,
+  cases h1 : sub₂.get k σ with a,
+  { rw h1 at h0,
+    have h2 : (subst M σ ₀↦v) k.succ = M k,
+    { simp only [assign, model.subst_eq_of_get_eq_none _ h1] },
+    have h3 : subst (M ₀↦v) (sub₂.incr σ) k.succ = M k,
+    { simp only [assign, model.subst_eq_of_get_eq_none _ h0] },
+    simp only [h2, h3] },
+  rw h1 at h0,
+  have h2 : (subst M σ ₀↦v) k.succ = a.val M,
+  { simp only [assign, model.subst_eq_of_get_eq_some _ h1] },
+  have h3 : subst (M ₀↦v) (sub₂.incr σ) k.succ = a.val M,
+  { simp only [assign, subst_eq_of_get_eq_some _ h0,
+    term₂.val_assign_incr] },
+  simp only [h2, h3]
+end
+
+end model
+
+lemma val_subst (M : model α) (σ : sub₂) :
+  ∀ a : term₂, term₂.val M (a.subst σ) = term₂.val (M.subst σ) a
+| (# k) :=
+  begin
+    rw function.funext_iff, intro as,
+    cases h1 : σ.get k with s,
+    { simp only [term₂.val, term₂.subst_eq_of_get_eq_none h1,
+        model.subst_eq_of_get_eq_none M h1] },
+    simp only [term₂.val, term₂.subst_eq_of_get_eq_some h1,
+      model.subst_eq_of_get_eq_some M h1],
+  end
+| (a & b) :=
+  begin
+    rw function.funext_iff, intro as,
+    have h1 := val_subst a,
+    have h2 := val_subst b,
+    simp only [term₂.val, term₂.subst, h1, h2],
+  end

--- a/src/tactic/spass/swap.lean
+++ b/src/tactic/spass/swap.lean
@@ -1,0 +1,551 @@
+/-
+  Copyright (c) 2019 Seul Baek. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Seul Baek
+
+  Swapping adjacent quantifiers for Skolemization and Herbrandization.
+-/
+
+import tactic.spass.pull
+
+universe u
+
+variables {α β : Type u}
+
+open nat
+
+local notation f `₀↦` a := assign a f
+local infix `⬝` := value.app
+
+local notation `#` := term₂.var
+local notation a `&` b := term₂.app a b
+
+local notation `⟪` b `,` a `⟫` := form₂.lit b a
+local notation p `∨*` q        := form₂.bin tt p q
+local notation p `∧*` q        := form₂.bin ff p q
+local notation `∃*`            := form₂.qua tt
+local notation `∀*`            := form₂.qua ff
+
+@[reducible] def swap (k : nat) : sub₂ :=
+[(k, # (k + 1) & # k), (k + 1, # k)]
+
+lemma subst_swap_var (k m : nat) :
+(m = k ∧ (# m).subst (swap k) = (# (k + 1) & # k)) ∨
+(m = k + 1 ∧ (# m).subst (swap k) = # k) ∨
+(m ≠ k ∧ m ≠ k + 1 ∧ (# m).subst (swap k) = # m) :=
+begin
+  by_cases h0 : m = k,
+  { left, refine ⟨h0, _⟩,
+    simp only [ swap, term₂.subst, sub₂.get,
+      if_true, h0, eq_self_iff_true ], refl },
+  by_cases h1 : m = k + 1,
+  { right, left,
+    refine ⟨h1, _⟩,
+    simp only [ swap, term₂.subst, sub₂.get,
+      if_neg h0, if_pos h1 ], refl },
+  right, right,
+  refine ⟨h0, h1, _⟩,
+  simp only [ swap, term₂.subst, sub₂.get,
+    if_neg h0, if_neg h1 ], refl
+end
+
+namespace term₂
+
+lemma fov_swap_of_ne {k m : nat} (hO : k ≠ m) (hS : k ≠ m + 1) :
+  ∀ a : term₂, a.fov k → (a.subst $ swap m).fov k
+| (# n) h1 :=
+  begin
+    rcases subst_swap_var m n
+      with ⟨_, h2⟩ | ⟨_, h2⟩ | ⟨_, _, h2⟩; rw h2,
+    { refine ⟨hS, trivial⟩ },
+    { exact hO },
+    exact h1,
+  end
+| (a & (# n)) h1 :=
+  begin
+    refine ⟨fov_swap_of_ne _ h1.left, _⟩,
+    rcases subst_swap_var m n
+      with ⟨_, h2⟩ | ⟨_, h2⟩ | ⟨_, _, h2⟩;
+    rw h2; try {exact trivial},
+    refine ⟨hS, trivial⟩
+  end
+| (a & (b & c)) h1 :=
+  ⟨fov_swap_of_ne _ h1.left, fov_swap_of_ne (b &c) h1.right⟩
+
+lemma fov_swap (k : nat) :
+  ∀ a : term₂, a.fov (k + 1) → (a.subst $ swap k).fov k
+| (# m) h0 :=
+  begin
+    rcases subst_swap_var k m
+      with ⟨_, h1⟩ | ⟨h2, h1⟩ | ⟨h2, _, h1⟩;
+    rw h1,
+    { refine ⟨(succ_ne_self k).symm, trivial⟩ },
+    { cases h0 h2.symm },
+    exact h2.symm
+  end
+| (a & (# m)) h0 :=
+  begin
+    refine ⟨fov_swap _ h0.left, _⟩,
+    rcases subst_swap_var k m
+      with ⟨_, h1⟩ | ⟨h2, h1⟩ | ⟨h2, _, h1⟩;
+    rw h1; try {exact trivial},
+    refine ⟨(succ_ne_self _).symm, trivial⟩
+  end
+| (a & (b & c)) h0 :=
+  ⟨fov_swap a h0.left, fov_swap (b &c) h0.right⟩
+
+end term₂
+
+def form₂.swap (k : nat) (p : form₂) : form₂ :=
+p.subst (swap k)
+
+lemma holds_swap {M : model α} {v w : value α} {p : form₂} :
+  ((M ₀↦ v ₀↦ w) ⊨ p.swap 0) ↔ ((M ₀↦ w ₀↦ v ⬝ w) ⊨ p) :=
+begin
+  unfold form₂.swap,
+  rw holds_subst,
+  have h0 : model.subst (M ₀↦ v ₀↦ w) [(0, (# 1) & (# 0)), (1, # 0)] =
+            (M ₀↦ w ₀↦ v ⬝ w),
+  { rw function.funext_iff,
+    intro k, cases k, refl,
+    cases k; refl },
+  rw h0,
+end
+
+def swap_val [inhabited α] (f : value α → value α) : value α
+| []        := (default α, false)
+| (a :: as) := f (a ₑ) as
+
+lemma exists_swap_val [inhabited α] {M : model α} {p : form₂} :
+  (M ⊨ ∀* (∃* p)) → ∃ f : value α, ∀ a : α, (M ₀↦ (a ₑ) ₀↦ f ⬝ a ₑ) ⊨ p :=
+begin
+  intro h0,
+  cases classical.skolem.elim_left h0 with f h1,
+  refine ⟨swap_val f, λ a, h1 (a ₑ)⟩,
+end
+
+def eq_except (M N : model α) (k : nat) : Prop :=
+(∀ m : nat, m ≠ k → M m = N m) ∧ (M k)ᵈ = (N k)ᵈ
+
+lemma assign_eq_except_assign
+  {M N : model α} {k : nat} (v : value α) :
+  eq_except M N k → eq_except (M ₀↦ v) (N ₀↦ v) (k + 1) :=
+begin
+  intro h0, constructor,
+  { intros m h1, cases m, refl,
+    apply h0.left _ (λ h2, h1 _),
+    subst h2 },
+  exact h0.right
+end
+
+lemma val_eq_val_of_eq_except {M N : model α} {k : nat} (h0 : eq_except M N k) :
+  ∀ a : term₂, a.fov k → (a.val M = a.val N)
+| (# m)   h1 := by apply h0.left _ (ne.symm h1)
+| (a & (# m)) h1 :=
+  begin
+    have h2 : a.val M = a.val N,
+    { rw term₂.fov_app_var at h1,
+      apply val_eq_val_of_eq_except a h1 },
+    have h3 : (M m []).fst  = (N m []).fst,
+    { by_cases h4 : k = m,
+      { subst h4, apply h0.right },
+      rw h0.left _ (ne.symm h4) },
+    simp only [term₂.val, h2, h3]
+  end
+| (a & (b & c)) h1 :=
+  begin
+    have h2 : a.val M = a.val N,
+    { apply val_eq_val_of_eq_except a h1.left },
+    have h3 : (b & c).val M = (b & c).val N,
+    { apply val_eq_val_of_eq_except (b & c) h1.right },
+    simp only [term₂.val, h2, h3]
+  end
+
+lemma holds_iff_holds_of_eq_except :
+  ∀ {M N : model α} {k : nat} (p : form₂),
+  eq_except M N k → p.fov k → (M ⊨ p ↔ N ⊨ p)
+| M N k ⟪b, a⟫ h0 h1 :=
+  by cases b; simp [form₂.holds, val_eq_val_of_eq_except h0 a h1]
+| M N k (form₂.bin b p q) h0 h1 :=
+  begin
+    cases h1,
+    apply form₂.holds_bin_iff_holds_bin;
+    apply holds_iff_holds_of_eq_except;
+    assumption
+  end
+| M N k (form₂.qua b p)   h0 h1 :=
+  begin
+    apply holds_qua_iff_holds_qua, intro v,
+    apply holds_iff_holds_of_eq_except _
+      (assign_eq_except_assign _ h0) h1
+  end
+
+def ex_fa_swap_eqv [inhabited α] (p : form₂) :
+  p.fov 1 → (∃* (∀* $ p.swap 0) <==α==> ∀* (∃* p)) :=
+begin
+  intros h0 M,
+  constructor; intro h1,
+  { cases h1 with v h1,
+    intro w,
+    refine ⟨v ⬝ w, _⟩,
+    rw ← holds_swap, apply h1 },
+  cases exists_swap_val h1 with f h2,
+  refine ⟨f, λ v, _⟩,
+  rw holds_swap,
+  rw [ @holds_iff_holds_of_eq_except _
+         (M ₀↦ v ₀↦ f⬝v) (M ₀↦ vᵈₑ ₀↦ f ⬝ v) 1 p _ h0,
+       ← assign_app_evaluate_denote (M ₀↦vᵈₑ) f v ],
+  { apply h2 },
+  constructor,
+  { rintros ⟨n⟩ h3, refl,
+    cases m, cases (h3 rfl), refl },
+  apply (denote_evaluate (vᵈ))
+end
+
+lemma neg_swap {p : form₂} : (p.swap 0).neg <==α==> p.neg.swap 0 :=
+neg_subst _ _
+
+def fa_ex_swap_eqv [inhabited α] (p : form₂) :
+  p.fov 1 → (∀* (∃* $ p.swap 0) <==α==> ∃* (∀* p)) :=
+begin
+  intro h0,
+  replace h0 := (fov_neg _ _).elim_right h0,
+  have h1 : (∃* (∀* (p.swap 0).neg) <==α==> ∀* (∃* p.neg)) :=
+  eqv_trans
+    (qua_eqv_qua (qua_eqv_qua neg_swap))
+    (@ex_fa_swap_eqv α _ _ h0),
+  rw ← neg_eqv_neg,
+  simp only [holds_neg.symm, form₂.neg, bnot, h1]
+end
+
+def swap_eqv [inhabited α] (ae : bool) {p : form₂} :
+  p.fov 1 →
+  (form₂.qua ae (form₂.qua (bnot ae) $ p.swap 0)
+    <==α==> form₂.qua (bnot ae) (form₂.qua ae p)) :=
+by { intro h0, cases ae,
+     exact fa_ex_swap_eqv _ h0,
+     exact ex_fa_swap_eqv _ h0 }
+
+namespace form₂
+
+open nat
+
+lemma fov_swap :
+  ∀ {k : nat} {p : form₂}, p.fov (k + 1) → (p.swap k).fov k
+| k ⟪b, a⟫           h0 := term₂.fov_swap _ _ h0
+| k (form₂.bin b p q) h0 :=
+  by { cases h0, constructor;
+       apply fov_swap; assumption }
+| k (form₂.qua b p)   h0 := @fov_swap (k + 1) p h0
+
+lemma fov_swap_of_ne :
+  ∀ k m : nat, (k ≠ m) → (k ≠ m + 1) →
+  ∀ p : form₂, p.fov k → (p.swap m).fov k
+| k m hO hS ⟪b, a⟫ h1 := term₂.fov_swap_of_ne hO hS _ h1
+| k m hO hS (form₂.bin b p q) h1 :=
+  by { cases h1, constructor;
+       apply fov_swap_of_ne; assumption }
+| k m hO hS (form₂.qua b p)   h1 :=
+  fov_swap_of_ne (k + 1) (m + 1)
+    (succ_ne_succ hO) (succ_ne_succ hS) p h1
+
+end form₂
+
+lemma foq_swap (b : bool) :
+  ∀ (k : nat) {p : form₂}, foq b p → foq b (p.swap k)
+| k ⟪_, a⟫           h0 := trivial
+| k (form₂.bin _ p q) h0 := ⟨foq_swap _ h0.left, foq_swap _ h0.right⟩
+| k (form₂.qua c p)   h0 :=
+  begin
+    constructor,
+    { intro h1,
+      apply form₂.fov_swap_of_ne 0 (k + 1)
+        (@zero_ne_succ _) (@zero_ne_succ _) p (h0.left h1) },
+    apply foq_swap _ h0.right
+  end
+
+def swap_many (ae : bool) : form₂ → form₂
+| (form₂.qua b p) :=
+  have form₂.size_of (p.swap 0) < form₂.size_of (form₂.qua b p),
+  { unfold form₂.swap,
+    have h0 : form₂.size_of p < form₂.size_of (form₂.qua b p),
+    { unfold form₂.size_of, apply nat.lt_succ_self },
+    have h1 := form₂.size_of_subst p (swap 0),
+    apply @eq.rec _ _ (λ x, x < form₂.size_of (form₂.qua b p)) h0 _ h1.symm },
+  if ae = b
+  then form₂.qua ae (swap_many $ p.swap 0)
+  else form₂.qua (bnot ae) (form₂.qua b p)
+| p := form₂.qua (bnot ae) p
+
+lemma fov_swap_many (ae : bool) :
+  ∀ {p : form₂} {k : nat},
+  p.fov (k + 1) → (swap_many ae p).fov k
+| ⟪b, a⟫           := λ _, id
+| (form₂.bin b p q) := λ _, id
+| (form₂.qua b p)   :=
+  have form₂.size_of (p.swap 0) < form₂.size_of (form₂.qua b p),
+  by { unfold form₂.swap,
+       rw form₂.size_of_subst,
+       form₂.show_size_lt},
+  begin
+    intros k h0,
+    unfold swap_many,
+    by_cases h1 : ae = b,
+    { subst h1, rw if_pos rfl,
+      have h2 : (p.swap 0).fov (k + 2) :=
+      @form₂.fov_swap_of_ne (k + 2) 0 (ne.symm (@zero_ne_succ _))
+        (succ_ne_succ $ ne.symm (@zero_ne_succ _)) _ h0,
+    apply @fov_swap_many _ (k + 1) h2, },
+    rw if_neg h1, exact h0
+  end
+
+lemma bnot_ne_self (b : bool) :
+  bnot b ≠ b := by { cases b; rintro ⟨_⟩ }
+
+lemma foq_swap_many (b : bool) :
+  ∀ {p : form₂}, p.fov 0 → foq b p → foq b (swap_many (bnot b) p)
+| (form₂.lit b a)   h0 h1 := ⟨λ _, h0, h1⟩
+| (form₂.bin b p q) h0 h1 := ⟨λ _, h0, h1⟩
+| (form₂.qua c p)   h0 h1 :=
+  have form₂.size_of (form₂.swap 0 p) <
+       form₂.size_of (form₂.qua c p),
+  { unfold form₂.swap, rw form₂.size_of_subst, form₂.show_size_lt },
+  begin
+    unfold swap_many,
+    by_cases h2 : bnot b = c,
+    { rw if_pos h2,
+      refine ⟨λ h3, absurd h3.symm (bnot_ne_self b), _⟩,
+      apply @foq_swap_many (p.swap 0),
+      apply form₂.fov_swap h0,
+      apply foq_swap _ _ h1.right },
+    rw if_neg h2,
+    refine ⟨λ _, h0, h1⟩
+  end
+
+lemma swap_many_eqv (α : Type u) [inhabited α] (ae : bool) :
+  ∀ {p : form₂}, p.fov 0 →
+  (swap_many ae p <==α==> form₂.qua (bnot ae) p)
+| ⟪b, a⟫           := λ _, eqv_refl _ _
+| (form₂.bin b p q) := λ _, eqv_refl _ _
+| (form₂.qua b p)   :=
+  have form₂.size_of (p.swap 0) <
+       form₂.size_of (form₂.qua b p) :=
+  by { unfold form₂.swap,
+       rw form₂.size_of_subst,
+       form₂.show_size_lt },
+  begin
+    intro h0,
+    unfold swap_many,
+    by_cases h1 : ae = b,
+    { subst h1, rw if_pos rfl,
+      apply eqv_trans _ (@swap_eqv α _ ae _ h0),
+      apply qua_eqv_qua,
+      apply swap_many_eqv,
+      apply form₂.fov_swap,
+      apply h0 },
+    rw if_neg h1, apply eqv_refl _
+  end
+
+def swap_all (ae : bool) : form₂ → form₂
+| ⟪b, a⟫           := ⟪b, a⟫
+| (form₂.bin b p q) :=
+  pull (some ae) b (swap_all p) (swap_all q)
+| (form₂.qua b p)   :=
+  if ae = b
+  then form₂.qua ae (swap_all p)
+  else swap_many ae (swap_all p)
+
+lemma fov_swap_all (ae : bool) :
+  ∀ {k : nat} {p : form₂}, p.fov k → (swap_all ae p).fov k
+| k ⟪b, a⟫           h0 := h0
+| k (form₂.bin b p q) h0 :=
+  by { cases h0, apply fov_pull;
+       apply fov_swap_all; assumption }
+| k (form₂.qua b p)   h0 :=
+  begin
+    unfold swap_all,
+    by_cases h1 : ae = b,
+    { subst h1, rw if_pos rfl,
+      apply @fov_swap_all _ p h0 },
+    rw if_neg h1,
+    apply fov_swap_many,
+    apply fov_swap_all,
+    apply h0
+  end
+
+lemma foq_swap_all (b : bool) :
+  ∀ {p : form₂}, (foq b p) → foq b (swap_all (bnot b) p)
+| ⟪_, a⟫           h0 := trivial
+| (form₂.bin _ p q) h0 :=
+  begin
+    unfold swap_all,
+    have hp := foq_swap_all h0.left,
+    have hq := foq_swap_all h0.right,
+    apply foq_pull; assumption
+  end
+| (form₂.qua c p) h0 :=
+  begin
+    unfold swap_all,
+    by_cases h1 : (bnot b = c),
+    { rw if_pos h1,
+      refine ⟨ λ h2, absurd h2.symm (bnot_ne_self b),
+               foq_swap_all h0.right ⟩ },
+    rw if_neg h1,
+    have h2 : (swap_all (bnot b) p).fov 0,
+    { apply fov_swap_all,
+      apply h0.left _,
+      rwa [bnot_eq_iff_ne, not_not] at h1 },
+    apply foq_swap_many _ h2 (foq_swap_all h0.right)
+  end
+
+lemma swap_all_eqv [inhabited α] {ae : bool} :
+  ∀ {p : form₂}, foq (bnot ae) p → (swap_all ae p <==α==> p)
+| ⟪b, a⟫           h0 := eqv_refl _ _
+| (form₂.bin b p q) h0 :=
+  eqv_trans
+    (pull_eqv ae _ _ _)
+    (bin_eqv_bin
+      (swap_all_eqv h0.left)
+      (swap_all_eqv h0.right))
+| (form₂.qua b p)   h0 :=
+  begin
+    unfold swap_all,
+    by_cases h1 : ae = b,
+    { subst h1, rw if_pos rfl,
+      apply qua_eqv_qua (swap_all_eqv h0.right) },
+    have h2 := bnot_eq_iff_ne.elim_right h1,
+    rw [if_neg h1, ← h2],
+    apply eqv_trans (swap_many_eqv α _
+      (fov_swap_all _ (h0.left h2))),
+    apply qua_eqv_qua (swap_all_eqv h0.right)
+end
+
+def prenexify : form₂ → form₂
+| ⟪b, a⟫            := ⟪b, a⟫
+| (form₂.bin b p q) := pull none b (prenexify p) (prenexify q)
+| (form₂.qua b p)   := form₂.qua b (prenexify p)
+
+lemma fov_prenexify :
+  ∀ {k : nat} {p : form₂}, p.fov k → (prenexify p).fov k
+| k ⟪_, a⟫           h0 := h0
+| k (form₂.bin _ p q) h0 :=
+  by { cases h0, apply fov_pull;
+       apply fov_prenexify; assumption }
+| k (form₂.qua c p)   h0 := @fov_prenexify (k + 1) p h0
+
+lemma foq_prenexify (b : bool) :
+  ∀ {p : form₂}, (foq b p) → foq b (prenexify p)
+| ⟪_, a⟫           h0 := h0
+| (form₂.bin _ p q) h0 :=
+  by { cases h0, apply foq_pull;
+       apply foq_prenexify; assumption }
+| (form₂.qua c p)   h0 :=
+  ⟨ λ h1, fov_prenexify (h0.left h1),
+    foq_prenexify h0.right ⟩
+
+lemma prenexify_eqv [inhabited α] :
+  ∀ p : form₂, prenexify p <==α==> p
+| ⟪b, a⟫            := eqv_refl _ _
+| (form₂.bin b p q) :=
+  begin
+    apply eqv_trans (@pull_eqv α _ _ _ _ _),
+    apply bin_eqv_bin;
+    apply prenexify_eqv
+  end
+| (form₂.qua b p)   := qua_eqv_qua (prenexify_eqv _)
+
+def QDFy (b : bool) : form₂ → form₂ := prenexify ∘ swap_all b
+
+lemma N_subst {b : bool} :
+  ∀ {p : form₂} (σ : sub₂), p.N b → (p.subst σ).N b
+| ⟪_, a⟫           _ _ := trivial
+| (form₂.bin c p q) _ h := ⟨N_subst _ h.left, N_subst _ h.right⟩
+| (form₂.qua c p)   σ h := ⟨h.left, N_subst _ h.right⟩
+
+lemma QN_subst {b : bool} :
+  ∀ {p : form₂} (σ : sub₂), p.QN b → (p.subst σ).QN b
+| ⟪_, a⟫           _ h0 := trivial
+| (form₂.bin c p q) _ h0 :=
+  by { cases h0, constructor;
+       apply N_subst; assumption }
+| (form₂.qua c p)   σ h0 :=
+  ⟨ λ h1, QN_subst _ (h0.left h1),
+    λ h1, N_subst _ (h0.right h1) ⟩
+
+lemma QN_swap_many {b : bool} :
+  ∀ {p : form₂}, p.QN b → (swap_many b p).QN b
+| (form₂.lit c a) :=
+  λ h0, ⟨ λ h1, absurd h1 (bnot_ne_self b).symm, λ _, h0⟩
+| (form₂.bin c p q) :=
+  λ h0, ⟨ λ h1, absurd h1 (bnot_ne_self b).symm, λ _, h0⟩
+| (form₂.qua c p) :=
+  have form₂.size_of (form₂.swap 0 p) <
+       form₂.size_of (form₂.qua c p),
+  by { unfold form₂.swap,
+       rw form₂.size_of_subst,
+       form₂.show_size_lt },
+  begin
+    intro h0, unfold swap_many,
+    by_cases h1 : b = c,
+    { rw if_pos h1,
+      constructor; intro h2,
+      { apply QN_swap_many,
+        apply QN_subst _ (h0.left h1) },
+      cases h2 rfl },
+    rw if_neg h1,
+    constructor; intro h2,
+    { rw eq_bnot_iff_ne at h2,
+      cases h2 rfl },
+    refine ⟨h1, h0.right h1⟩
+  end
+
+lemma QN_swap_all (b : bool) :
+  ∀ p : form₂, (swap_all b p).QN b
+| ⟪_, a⟫           := trivial
+| (form₂.bin c p q) :=
+  by { unfold swap_all,
+       apply QN_pull;
+       apply QN_swap_all }
+| (form₂.qua c p)   :=
+  begin
+    unfold swap_all,
+    by_cases h0 : b = c,
+    { rw if_pos h0,
+      constructor; intro h1,
+      { apply QN_swap_all },
+      cases (h1 rfl) },
+    rw if_neg h0,
+    have h1 := QN_swap_all p,
+    apply QN_swap_many h1
+  end
+
+lemma QF_prenexify {b : bool} :
+  ∀ {p : form₂}, p.N b → (prenexify p).QF (bnot b)
+| (form₂.lit c a)   h0 := trivial
+| (form₂.bin c p q) h0 :=
+  by { cases h0, apply QF_pull;
+       apply QF_prenexify; assumption }
+| (form₂.qua c p)   h0 :=
+  by { constructor,
+       { rw bnot_eq_iff_ne, apply h0.left },
+       apply QF_prenexify h0.right }
+
+lemma QDF_prenexify (b : bool) :
+  ∀ p : form₂, p.QN b → (prenexify p).QDF b
+| (form₂.lit c a)   h0 := trivial
+| (form₂.qua c p)   h0 :=
+  begin
+    by_cases h1 : b = c,
+    { constructor; intro h2,
+      { apply QDF_prenexify _ (h0.left h1) },
+      cases h2 h1 },
+    constructor; intro h2,
+    { cases h1 h2 },
+    apply QF_prenexify (h0.right h2)
+  end
+| (form₂.bin c p q) h0 :=
+  by { cases h0, apply form₂.QDF_of_QF_bnot,
+       apply QF_pull; apply QF_prenexify; assumption }
+
+lemma QDF_QDFy (b : bool) (p : form₂) : (QDFy b p).QDF b :=
+by {apply QDF_prenexify, apply QN_swap_all}

--- a/src/tactic/spass/term.lean
+++ b/src/tactic/spass/term.lean
@@ -1,0 +1,158 @@
+/-
+  Copyright (c) 2019 Seul Baek. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Seul Baek
+
+  First-order terms and atoms.
+-/
+
+import tactic.spass.model
+
+universe u
+
+variable {α : Type u}
+
+@[derive has_reflect, derive decidable_eq]
+inductive term : Type
+| sym : nat  → term
+| app : term → term → term
+| vpp : term → nat  → term
+
+local notation `&`     := term.sym
+local notation a `&` b := term.app a b
+local notation a `#` k := term.vpp a k
+
+open sum
+
+namespace term
+
+def vars : term → list nat
+| (& _)   := []
+| (t & s) := t.vars ∪ s.vars
+| (t # k) := t.vars.insert k
+
+def fresh_var : term → nat
+| (& _)   := 0
+| (t & s) := max t.fresh_var s.fresh_var
+| (t # k) := max t.fresh_var (k + 1)
+
+def repr_core : bool → term → string
+| s (term.sym k)   := (if s then "P" else "F") ++ k.to_subs
+| s (term.app a b) := "(" ++ a.repr_core s ++ " " ++ b.repr_core ff ++ ")"
+| s (term.vpp a k) := "(" ++ a.repr_core s ++ " " ++ "X" ++ k.to_subs ++ ")"
+
+def write : term → string
+| (term.sym k)   := "S " ++ k.repr
+| (term.app t s) := "( " ++ t.write ++ " "   ++ s.write ++ " )"
+| (term.vpp t k) := "( " ++ t.write ++ " V " ++ k.repr  ++ " )"
+
+def repr : term → string := repr_core tt
+
+instance has_repr : has_repr term := ⟨repr⟩
+meta instance has_to_format : has_to_format term := ⟨λ x, repr x⟩
+
+def vdxs : term → list nat
+| (term.sym _)   := []
+| (term.app a b) := a.vdxs ∪ b.vdxs
+| (term.vpp a m) := a.vdxs.insert m
+
+def val (M : model α) (v : nat → α) : term → value α
+| (term.sym k)   := M k
+| (term.app a b) := a.val ∘ list.cons (b.val []).fst
+| (term.vpp a k) := a.val ∘ list.cons (v k)
+
+def holds (M : model α) (v : nat → α) (t : term) : Prop :=
+(t.val M v []).snd
+
+def rename (f : nat → nat) : term → term
+| (& k) := & k
+| (t & s) := t.rename & s.rename
+| (t # k) := t.rename # (f k)
+
+end term
+
+@[reducible] def smap : Type := nat × (nat ⊕ term)
+
+instance smap.decidable_eq : decidable_eq smap := by apply_instance
+
+@[reducible] def smaps : Type := list smap
+
+def smaps.get (k : nat) : smaps → (nat ⊕ term)
+| []            := sum.inl k
+| ((m, t) :: μ) := if k = m then t else smaps.get μ
+
+def term.subst (μ : smaps) : term → term
+| (& k)   := & k
+| (t & s) := t.subst & s.subst
+| (t # k) :=
+  match μ.get k with
+  | (sum.inl m) := t.subst # m
+  | (sum.inr s) := t.subst & s
+  end
+
+def smaps.compose (μ : smaps) : smaps → smaps
+| []                    := μ
+| ((k, sum.inr t) :: ν) := (k, sum.inr (t.subst μ)) :: smaps.compose ν
+| ((k, sum.inl m) :: ν) := (k, μ.get m) :: smaps.compose ν
+
+namespace vas
+
+def subst (M : model α) (v : vas α) (μ : smaps) (k : nat) : α :=
+match μ.get k with
+| (inl m) := v m
+| (inr t) := (t.val M v []).fst
+end
+
+lemma subst_eq_of_eq_inl (M : model α)
+  (v : vas α) {μ : smaps} {k m : nat} :
+μ.get k = inl m → v.subst M μ k = v m :=
+by { intro h1, simp only [h1, subst] }
+
+lemma subst_eq_of_eq_inr (M : model α)
+  (v : vas α) {μ : smaps} {k : nat} {t : term} :
+μ.get k = inr t → v.subst M μ k = (t.val M v []).fst :=
+by { intro h1, simp only [h1, subst] }
+
+end vas
+
+namespace term
+
+
+lemma subst_eq_of_eq_inl {μ : smaps} (t : term) {k m : nat} :
+μ.get k = inl m → (t # k).subst μ = t.subst μ # m :=
+by { intro h, simp only [h, subst, eq_self_iff_true, and_self] }
+
+lemma subst_eq_of_eq_inr {μ : smaps} (t s : term) {k : nat} :
+μ.get k = inr s → (t # k).subst μ = t.subst μ & s :=
+by { intro h, simp only [h, subst, eq_self_iff_true, and_self] }
+
+lemma val_rename (M : model α) (v : vas α) (f : nat → nat) :
+  ∀ t : term, (t.rename f).val M v = t.val M (v ∘ f)
+| (& k)   := rfl
+| (t & s) := by simp only [val, rename, val_rename]
+| (t # k) := by simp only [val, rename, val_rename]
+
+lemma val_subst (M : model α) (v : vas α) (μ : smaps) :
+  ∀ t : term, (t.subst μ).val M v = t.val M (v.subst M μ)
+| (& k)   := rfl
+| (t & s) := by simp only [val, subst, val_subst]
+| (t # k) :=
+  begin
+    cases h1 : μ.get k with m s,
+    { simp only [subst_eq_of_eq_inl t h1,
+        vas.subst_eq_of_eq_inl M v h1,
+        val_subst, val] },
+    simp only [subst_eq_of_eq_inr t s h1,
+      vas.subst_eq_of_eq_inr M v h1,
+      val_subst, val]
+  end
+
+lemma holds_subst (M : model α) (v : vas α) (μ : smaps) (t : term) :
+  (t.subst μ).holds M v ↔ t.holds M (v.subst M μ) :=
+by {unfold holds, rw val_subst}
+
+lemma holds_rename (M : model α) (v : vas α) (f : nat → nat) (t : term) :
+  (t.rename f).holds M v ↔ t.holds M (v ∘ f) :=
+by {unfold holds, rw val_rename}
+
+end term

--- a/src/tactic/spass/term2.lean
+++ b/src/tactic/spass/term2.lean
@@ -1,0 +1,114 @@
+/-
+  Copyright (c) 2019 Seul Baek. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Seul Baek
+
+  Second-order terms.
+-/
+
+import algebra.ordered_group
+import tactic.spass.model
+import tactic.spass.misc
+
+universe u
+
+variable {α : Type u}
+
+open nat
+
+local notation f `₀↦` a := assign a f
+
+@[derive has_reflect, derive decidable_eq]
+inductive term₂ : Type
+| var : nat → term₂
+| app : term₂ → term₂ → term₂
+
+local notation `#`     := term₂.var
+local notation a `&` b := term₂.app a b
+
+namespace term₂
+
+meta def to_expr : term₂ → expr
+| (# k)   := `(# %%`(k))
+| (t & s) := `(%%(t.to_expr) & %%(s.to_expr))
+
+local notation `#`     := term₂.var
+local notation a `&` b := term₂.app a b
+def repr : term₂ → string
+| (# k)   := "X" ++ k.to_subs
+| (t & s) := "(" ++ t.repr ++ " " ++ s.repr ++ ")"
+
+instance has_repr : has_repr term₂ := ⟨repr⟩
+
+def incr_ge (k : nat) : term₂ → term₂
+| (# m)   := if k ≤ m then # (m + 1) else # m
+| (a & b) := a.incr_ge & b.incr_ge
+
+def incr : term₂ → term₂ := incr_ge 0
+
+def val (M : model α) : term₂ → value α
+| (# k)   := M k
+| (a & b) := a.val ∘ list.cons (b.val []).fst
+
+end term₂
+
+lemma incr_app (a b : term₂) :
+  term₂.incr (a & b) = (a.incr & b.incr) :=
+by simp only [ term₂.incr, and_self,
+     term₂.incr_ge, eq_self_iff_true ]
+
+namespace term₂
+
+lemma val_assign_incr (M : model α) (v : value α) :
+  ∀ a : term₂, val (M ₀↦ v) a.incr = val M a
+| (# k)   := rfl
+| (a & b) :=
+  by simp only [val, val_assign_incr a,
+     val_assign_incr b, incr_app]
+
+def occ (k : nat) : term₂ → Prop
+| (# m)   := k = m
+| (a & b) := a.occ ∨ b.occ
+
+lemma not_occ_incr_ge (k : nat) :
+  ∀ a : term₂, ¬ (a.incr_ge k).occ k
+| (# m)  :=
+  begin
+    unfold term₂.incr_ge,
+    by_cases h1 : k ≤ m,
+    { rw if_pos h1,
+      unfold occ, intro h2,
+      rw [h2, ← not_lt] at h1,
+      exact (h1 $ lt_succ_self _) },
+    rw if_neg h1,
+    unfold occ, intro h2,
+    rw h2 at h1,
+    exact h1 (le_refl _)
+  end
+| (a & b) :=
+  begin
+    unfold term₂.incr_ge,
+    intro h0, cases h0;
+    apply not_occ_incr_ge _ h0
+  end
+
+end term₂
+
+lemma eq_of_var_eq_var {k m : nat} : (# k) = (# m) → k = m :=
+by {intro h0, cases h0, refl}
+
+lemma val_incr_ge {M N : model α} {k : nat}
+  (h0 : ∀ m < k, M m = N m) (h1 : ∀ m ≥ k, M (m + 1) = N m) :
+    ∀ a : term₂, (a.incr_ge k).val M = a.val N
+| (# m) :=
+  begin
+    unfold term₂.incr_ge,
+    by_cases h2 : k ≤ m,
+    { rw if_pos h2,
+      apply h1 _ h2 },
+    rw if_neg h2,
+    rw not_le at h2,
+    apply h0 _ h2
+  end
+| (a & b) :=
+  by simp only [term₂.incr_ge, term₂.val, val_incr_ge]


### PR DESCRIPTION
Still a minimally functional WIP. Hoping to get some feedback at this point.

The tactic currently works only for pure FOL. It reduces the input goal into a (deeply embedded) CNF, sends it to SPASS, parses the SPASS output and translates it into a Lean proof. You can look at examples.lean to get an idea of what it does.

The to do list from here includes:
- Add support for equality.
- Extension to other ATPs (Vampire is a strong candidate).
- Add interface with SystemOnTPTP; it would help a lot if the tactic doesn't require local ATP installations. 