### PR TITLE
feat(linear_algebra/basic): general_linear_group basics

### DIFF
--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1126,10 +1126,17 @@ variables [ring α] [add_comm_group β] [add_comm_group γ] [add_comm_group δ]
 variables [module α β] [module α γ] [module α δ]
 include α
 
+instance : has_coe (β ≃ₗ[α] γ) (β →ₗ[α] γ) := ⟨to_linear_map⟩
+
+@[simp] theorem apply_symm_apply (e : β ≃ₗ[α] γ) (c : γ) : e (e.symm c) = c := e.6 c
+@[simp] theorem symm_apply_apply (e : β ≃ₗ[α] γ) (b : β) : e.symm (e b) = b := e.5 b
+
+@[simp] theorem coe_apply (e : β ≃ₗ[α] γ) (b : β) : (e : β →ₗ[α] γ) b = e b := rfl
+
 lemma to_equiv_injective : function.injective (to_equiv : (β ≃ₗ[α] γ) → β ≃ γ) :=
 λ ⟨_, _, _, _, _, _⟩ ⟨_, _, _, _, _, _⟩ h, linear_equiv.mk.inj_eq.mpr (equiv.mk.inj h)
 
-@[extensionality] lemma ext {f g : β ≃ₗ[α] γ} (h : f.to_fun = g.to_fun) : f = g :=
+@[extensionality] lemma ext {f g : β ≃ₗ[α] γ} (h : (f : β → γ) = g) : f = g :=
 to_equiv_injective (equiv.eq_of_to_fun_eq h)
 
 section
@@ -1144,13 +1151,6 @@ def symm (e : β ≃ₗ[α] γ) : γ ≃ₗ[α] β :=
 def trans (e₁ : β ≃ₗ[α] γ) (e₂ : γ ≃ₗ[α] δ) : β ≃ₗ[α] δ :=
 { .. e₂.to_linear_map.comp e₁.to_linear_map,
   .. e₁.to_equiv.trans e₂.to_equiv }
-
-instance : has_coe (β ≃ₗ[α] γ) (β →ₗ[α] γ) := ⟨to_linear_map⟩
-
-@[simp] theorem apply_symm_apply (e : β ≃ₗ[α] γ) (c : γ) : e (e.symm c) = c := e.6 c
-@[simp] theorem symm_apply_apply (e : β ≃ₗ[α] γ) (b : β) : e.symm (e b) = b := e.5 b
-
-@[simp] theorem coe_apply (e : β ≃ₗ[α] γ) (b : β) : (e : β →ₗ[α] γ) b = e b := rfl
 
 noncomputable def of_bijective
   (f : β →ₗ[α] γ) (hf₁ : f.ker = ⊥) (hf₂ : f.range = ⊤) : β ≃ₗ[α] γ :=

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1126,19 +1126,11 @@ variables [ring α] [add_comm_group β] [add_comm_group γ] [add_comm_group δ]
 variables [module α β] [module α γ] [module α δ]
 include α
 
-@[extensionality] lemma ext {f g : β ≃ₗ[α] γ} (h : f.to_fun = g.to_fun) :
-  f = g :=
-begin
-  cases f, cases g, congr, {exact h},
-  { funext x,
-    change f_to_fun = g_to_fun at h,
-    dsimp only [function.left_inverse, function.right_inverse] at *,
-    rw h at f_left_inv,
-    have : function.surjective g_to_fun :=
-      function.surjective_of_has_right_inverse ⟨g_inv_fun, g_right_inv⟩,
-    rcases this x with ⟨x, rfl⟩,
-    simp * }
-end
+lemma to_equiv_injective : function.injective (@to_equiv α β γ _ _ _ _ _) :=
+λ ⟨_, _, _, _, _, _⟩ ⟨_, _, _, _, _, _⟩ h, linear_equiv.mk.inj_eq.mpr (equiv.mk.inj h)
+
+@[extensionality] lemma ext {f g : β ≃ₗ[α] γ} (h : f.to_fun = g.to_fun) : f = g :=
+to_equiv_injective (equiv.eq_of_to_fun_eq h)
 
 section
 variable (β)

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -7,7 +7,7 @@ Basics of linear algebra. This sets up the "categorical/lattice structure" of
 modules, submodules, and linear maps.
 -/
 
-import algebra.pi_instances data.finsupp order.order_iso
+import algebra.pi_instances data.finsupp data.equiv.algebra order.order_iso
 
 open function lattice
 
@@ -1126,7 +1126,7 @@ variables [ring α] [add_comm_group β] [add_comm_group γ] [add_comm_group δ]
 variables [module α β] [module α γ] [module α δ]
 include α
 
-lemma to_equiv_injective : function.injective (@to_equiv α β γ _ _ _ _ _) :=
+lemma to_equiv_injective : function.injective (to_equiv : (β ≃ₗ[α] γ) → β ≃ γ) :=
 λ ⟨_, _, _, _, _, _⟩ ⟨_, _, _, _, _, _⟩ h, linear_equiv.mk.inj_eq.mpr (equiv.mk.inj h)
 
 @[extensionality] lemma ext {f g : β ≃ₗ[α] γ} (h : f.to_fun = g.to_fun) : f = g :=
@@ -1546,7 +1546,7 @@ def of_linear_equiv (f : (β ≃ₗ[α] β)) : general_linear_group α β :=
 
 variables (α β)
 
-def general_linear_equiv : general_linear_group α β ≃ (β ≃ₗ[α] β) :=
+def general_linear_equiv : general_linear_group α β ≃* (β ≃ₗ[α] β) :=
 { to_fun := to_linear_equiv,
   inv_fun := of_linear_equiv,
   left_inv := λ f,
@@ -1560,14 +1560,11 @@ def general_linear_equiv : general_linear_group α β ≃ (β ≃ₗ[α] β) :=
     delta to_linear_equiv of_linear_equiv,
     cases f,
     congr
-  end }
-
-instance general_linear_equiv.is_group_hom :
-  is_group_hom (general_linear_equiv α β) :=
-⟨λ g₁ g₂, by {ext, refl}⟩
+  end,
+  hom := ⟨λ x y, by {ext, refl}⟩ }
 
 @[simp] lemma general_linear_equiv_to_linear_map (f : general_linear_group α β) :
-  (general_linear_equiv α β f).to_linear_map = f.val :=
+  ((general_linear_equiv α β).to_equiv f).to_linear_map = f.val :=
 by {ext, refl}
 
 end general_linear_group

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1128,9 +1128,6 @@ include α
 
 instance : has_coe (β ≃ₗ[α] γ) (β →ₗ[α] γ) := ⟨to_linear_map⟩
 
-@[simp] theorem apply_symm_apply (e : β ≃ₗ[α] γ) (c : γ) : e (e.symm c) = c := e.6 c
-@[simp] theorem symm_apply_apply (e : β ≃ₗ[α] γ) (b : β) : e.symm (e b) = b := e.5 b
-
 @[simp] theorem coe_apply (e : β ≃ₗ[α] γ) (b : β) : (e : β →ₗ[α] γ) b = e b := rfl
 
 lemma to_equiv_injective : function.injective (to_equiv : (β ≃ₗ[α] γ) → β ≃ γ) :=
@@ -1151,6 +1148,9 @@ def symm (e : β ≃ₗ[α] γ) : γ ≃ₗ[α] β :=
 def trans (e₁ : β ≃ₗ[α] γ) (e₂ : γ ≃ₗ[α] δ) : β ≃ₗ[α] δ :=
 { .. e₂.to_linear_map.comp e₁.to_linear_map,
   .. e₁.to_equiv.trans e₂.to_equiv }
+
+@[simp] theorem apply_symm_apply (e : β ≃ₗ[α] γ) (c : γ) : e (e.symm c) = c := e.6 c
+@[simp] theorem symm_apply_apply (e : β ≃ₗ[α] γ) (b : β) : e.symm (e b) = b := e.5 b
 
 noncomputable def of_bijective
   (f : β →ₗ[α] γ) (hf₁ : f.ker = ⊥) (hf₂ : f.range = ⊤) : β ≃ₗ[α] γ :=


### PR DESCRIPTION
This patch proves that the general_linear_group (defined as units in the
endomorphism ring) are equivalent to the group of linear equivalences.

Inspired by the perfectoid project.