### PR TITLE
refactor(integration.lean): changing `measure_space` to `measurable_s…

### DIFF
--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -80,7 +80,7 @@ def const (α) {β} [measurable_space α] (b : β) : α →ₛ β :=
 
 @[simp] theorem const_apply (a : α) (b : β) : (const α b) a = b := rfl
 
-lemma range_const (α) [measure_space α] [ne : nonempty α] (b : β) :
+lemma range_const (α) [measurable_space α] [ne : nonempty α] (b : β) :
   (const α b).range = {b} :=
 begin
   ext b',


### PR DESCRIPTION
…pace`

I've been using this file and `range_const` doesn't seem to require the spurious `measure_space` instance. `measurable_space` seems to suffice.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
