### PR TITLE
refactor(set_theory/ordinal): shorten proof of well_ordering_thm

### DIFF
--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -347,8 +347,7 @@ classical.choice $ embedding.total.resolve_left $ λ ⟨⟨f, hf⟩⟩,
 protected def r : σ → σ → Prop :=
 λ a b, embedding_to_cardinal a < embedding_to_cardinal b
 
-noncomputable def order_embedding_to_cardinal :
-  r ≼o ((<) : Π {a b : cardinal.{u}}, Prop) :=
+noncomputable def order_embedding_to_cardinal : r ≼o ((<) : Π {a b : cardinal.{u}}, Prop) :=
 { to_fun := embedding_to_cardinal.1,
   inj := embedding_to_cardinal.2,
   ord := λ _ _, iff.rfl }

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -344,7 +344,7 @@ classical.choice $ embedding.total.resolve_left $ λ ⟨⟨f, hf⟩⟩,
   have e : set T ↪ T, from ⟨λ s, ⟨x, hT s⟩, λ _, by simp⟩,
   cantor_injective e.1 e.2
 
-protected def r : σ → σ → Prop :=
+private def well_ordering_thm_r : σ → σ → Prop :=
 λ a b, embedding_to_cardinal a < embedding_to_cardinal b
 
 noncomputable def order_embedding_to_cardinal : r ≼o ((<) : Π {a b : cardinal.{u}}, Prop) :=

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -344,10 +344,10 @@ classical.choice $ embedding.total.resolve_left $ λ ⟨⟨f, hf⟩⟩,
   have e : set T ↪ T, from ⟨λ s, ⟨x, hT s⟩, λ _, by simp⟩,
   cantor_injective e.1 e.2
 
-private def well_ordering_thm_r : σ → σ → Prop :=
+private def well_order_r : σ → σ → Prop :=
 λ a b, embedding_to_cardinal a < embedding_to_cardinal b
 
-noncomputable def order_embedding_to_cardinal : r ≼o ((<) : Π {a b : cardinal.{u}}, Prop) :=
+noncomputable def order_embedding_to_cardinal : well_order_r ≼o ((<) : Π {a b : cardinal.{u}}, Prop) :=
 { to_fun := embedding_to_cardinal.1,
   inj := embedding_to_cardinal.2,
   ord := λ _ _, iff.rfl }

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -331,134 +331,30 @@ theorem collapse_apply [is_well_order β s] (f : r ≼o s)
 end order_embedding
 
 section well_ordering_thm
-parameter {σ : Type*}
+parameter {σ : Type u}
+open function
 
-private def partial_wo := Σ p : set σ, {r // is_well_order p r}
+noncomputable lemma embedding_to_cardinal : σ ↪ cardinal.{u} :=
+classical.choice $ embedding.total.resolve_left $ λ ⟨⟨f, hf⟩⟩,
+  let T : Type u := Σ a : σ, quotient.out (@inv_fun _ ⟨0⟩ _ f a) in
+  let ⟨x, hx⟩ := inv_fun_surjective hf (cardinal.mk (set T)) in
+  have hT : set T ≃ (@quotient.out (Type u) _ (@inv_fun _ ⟨0⟩ _ f x)),
+    by simp only [T, hx, cardinal.mk];
+      exact (classical.choice (@quotient.mk_out (Type u) _ _)).symm,
+  have e : set T ↪ T, from ⟨λ s, ⟨x, hT s⟩, λ _, by simp⟩,
+  cantor_injective e.1 e.2
 
-private def partial_wo.le (x y : partial_wo) := ∃ f : x.2.1 ≼i y.2.1, ∀ x, (f x).1 = x.1
+protected def r : σ → σ → Prop :=
+λ a b, embedding_to_cardinal a < embedding_to_cardinal b
 
-local infix ` ≤ `:50 := partial_wo.le
+noncomputable def order_embedding_to_cardinal :
+  r ≼o ((<) : Π {a b : cardinal.{u}}, Prop) :=
+{ to_fun := embedding_to_cardinal.1,
+  inj := embedding_to_cardinal.2,
+  ord := λ _ _, iff.rfl }
 
-private def partial_wo.is_refl : is_refl _ (≤) :=
-⟨λ a, ⟨initial_seg.refl _, λ x, rfl⟩⟩
-local attribute [instance] partial_wo.is_refl
-
-private def partial_wo.trans {a b c} : a ≤ b → b ≤ c → a ≤ c
-| ⟨f, hf⟩ ⟨g, hg⟩ := ⟨f.trans g, λ a, by rw [initial_seg.trans_apply, hg, hf]⟩
-
-private def sub_of_le {s t} : s ≤ t → s.1 ⊆ t.1
-| ⟨f, hf⟩ x h := by have := (f ⟨x, h⟩).2; rwa [hf ⟨x, h⟩] at this
-
-private def agree_of_le {s t} : s ≤ t → ∀ {a b} sa sb ta tb,
-  s.2.1 ⟨a, sa⟩ ⟨b, sb⟩ ↔ t.2.1 ⟨a, ta⟩ ⟨b, tb⟩
-| ⟨f, hf⟩ a b sa sb ta tb := by rw [f.to_order_embedding.ord',
-  show f.to_order_embedding ⟨a, sa⟩ = ⟨a, ta⟩, from subtype.eq (hf ⟨a, sa⟩),
-  show f.to_order_embedding ⟨b, sb⟩ = ⟨b, tb⟩, from subtype.eq (hf ⟨b, sb⟩)]
-
-section
-parameters {c : set partial_wo} (hc : zorn.chain (≤) c)
-
-private def U := ⋃₀ ((λ x:partial_wo, x.1) '' c)
-
-private def R (x y : U) := ∃ a : partial_wo, a ∈ c ∧
-  ∃ (hx : x.1 ∈ a.1) (hy : y.1 ∈ a.1), a.2.1 ⟨_, hx⟩ ⟨_, hy⟩
-
-private lemma mem_U {a} : a ∈ U ↔ ∃ s : partial_wo, s ∈ c ∧ a ∈ s.1 :=
-by simp only [U, set.sUnion_image, set.mem_Union, exists_prop]
-
-private lemma mem_U2 {a b} (au : a ∈ U) (bu : b ∈ U) :
-  ∃ s : partial_wo, s ∈ c ∧ a ∈ s.1 ∧ b ∈ s.1 :=
-let ⟨s, sc, as⟩ := mem_U.1 au, ⟨t, tc, bt⟩ := mem_U.1 bu,
-    ⟨k, kc, ks, kt⟩ := hc.directed sc tc in
-⟨k, kc, sub_of_le ks as, sub_of_le kt bt⟩
-
-private lemma R_ex {s : partial_wo} (sc : s ∈ c)
-  {a b : σ} (hb : b ∈ s.1) {au bu} :
-  R ⟨a, au⟩ ⟨b, bu⟩ → ∃ ha, s.2.1 ⟨a, ha⟩ ⟨b, hb⟩
-| ⟨t, tc, at', bt, h⟩ :=
-  match hc.total_of_refl sc tc with
-  | or.inr hr := ⟨sub_of_le hr at', (agree_of_le hr _ _ _ _).1 h⟩
-  | or.inl hr@⟨f, hf⟩ := begin
-      rw [← show (f ⟨b, hb⟩) = ⟨(subtype.mk b bu).val, bt⟩, from
-        subtype.eq (hf _)] at h,
-      rcases f.init_iff.1 h with ⟨⟨a', ha⟩, e, h'⟩,
-      have : a' = a,
-      { have := congr_arg subtype.val e, rwa hf at this },
-      subst a', exact ⟨_, h'⟩
-    end
-  end
-
-private lemma R_iff {s : partial_wo} (sc : s ∈ c)
-  {a b : σ} (ha hb) {au bu} :
-  R ⟨a, au⟩ ⟨b, bu⟩ ↔ s.2.1 ⟨a, ha⟩ ⟨b, hb⟩ :=
-⟨λ h, let ⟨_, h⟩ := R_ex sc hb h in h,
- λ h, ⟨s, sc, ha, hb, h⟩⟩
-
-private theorem wo : is_well_order U R :=
-{ trichotomous := λ ⟨a, au⟩ ⟨b, bu⟩,
-    let ⟨s, sc, ha, hb⟩ := mem_U2 au bu in
-    (@trichotomous _ s.2.1 s.2.2.1.1 ⟨a, ha⟩ ⟨b, hb⟩).imp
-      (R_iff sc _ _).2
-      (λ o, o.imp (subtype.eq ∘ subtype.mk.inj)
-      (R_iff sc _ _).2),
-  irrefl :=  λ ⟨a, au⟩ h, let ⟨s, sc, ha⟩ := mem_U.1 au in
-    -- by haveI := s.2.2; exact irrefl _ ((R_iff hc sc _ ha).1 h),
-    @irrefl _ s.2.1 s.2.2.1.2.1 _ ((R_iff sc _ ha).1 h),
-  trans := λ ⟨a, au⟩ ⟨b, bu⟩ ⟨d, du⟩ ab bd,
-    let ⟨s, sc, as, bs⟩ := mem_U2 au bu, ⟨t, tc, dt⟩ := mem_U.1 du,
-        ⟨k, kc, ks, kt⟩ := hc.directed sc tc in begin
-      simp only [R_iff hc kc, sub_of_le ks as, sub_of_le ks bs, sub_of_le kt dt] at ab bd ⊢,
-      -- haveI := k.2.2, exact trans ab bd
-      exact @trans _ k.2.1 k.2.2.1.2.2 _ _ _ ab bd
-    end,
-  wf := ⟨λ ⟨a, au⟩, let ⟨s, sc, ha⟩ := mem_U.1 au in
-    suffices ∀ (a : s.1) (au : a.1 ∈ U), acc R ⟨a.1, au⟩, from this ⟨a, ha⟩ au,
-    λ a, acc.rec_on ((@is_well_order.wf _ _ s.2.2).apply a) $
-    λ ⟨a, ha⟩ H IH au, ⟨_, λ ⟨b, hb⟩ h,
-      let ⟨hb, h⟩ := R_ex sc ha h in IH ⟨b, hb⟩ h _⟩⟩ }
-
-theorem chain_ub : ∃ ub, ∀ a ∈ c, a ≤ ub :=
-⟨⟨U, R, wo⟩, λ s sc, ⟨⟨⟨⟨
-  λ a, ⟨a.1, mem_U.2 ⟨s, sc, a.2⟩⟩,
-  λ a b h, subtype.eq $ subtype.mk.inj h⟩,
-  λ a b, by cases a with a ha; cases b with b hb; exact
-     (R_iff hc sc _ _).symm⟩,
-  λ ⟨a, ha⟩ ⟨b, hb⟩ h,
-    let ⟨bs, h'⟩ := R_ex sc ha h in ⟨⟨_, bs⟩, rfl⟩⟩,
-  λ a, rfl⟩⟩
-
-end
-
-theorem well_ordering_thm : ∃ r, is_well_order σ r :=
-let ⟨m, MM⟩ := zorn.zorn (λ c, chain_ub) (λ a b c, partial_wo.trans) in
-suffices hf : ∀ a, a ∈ m.1, from
-  let f : σ ≃ m.1 := ⟨λ a, ⟨a, hf a⟩, λ a, a.1, λ a, rfl, λ ⟨a, ha⟩, rfl⟩ in
-  ⟨order.preimage f m.2.1,
-    @order_embedding.is_well_order _ _ _ _ (order_iso.preimage f m.2.1 : f ⁻¹'o m.2.1 ≼o m.2.1) m.2.2⟩,
-λ a, classical.by_contradiction $ λ ha,
-let f : (insert a m.1 : set σ) ≃ (m.1 ⊕ unit) :=
- ⟨λ x, if h : x.1 ∈ m.1 then sum.inl ⟨_, h⟩ else sum.inr ⟨⟩,
-  λ x, sum.cases_on x (λ x, ⟨x.1, or.inr x.2⟩) (λ _, ⟨a, or.inl rfl⟩),
-  λ x, match x with
-    | ⟨_, or.inl rfl⟩ := by dsimp only; rw dif_neg ha
-    | ⟨x, or.inr h⟩ := by dsimp only; rw dif_pos h
-    end,
-  λ x, by rcases x with ⟨x, h⟩ | ⟨⟨⟩⟩; dsimp only;
-    [rw [dif_pos h], rw [dif_neg ha]]⟩ in
-let r' := sum.lex m.2.1 (@empty_relation unit) in
-have r'wo : is_well_order _ r' := @sum.lex.is_well_order _ _ _ _ m.2.2 _,
-let m' : partial_wo := ⟨insert a m.1, order.preimage f r',
-  @order_embedding.is_well_order _ _ _ _ ↑(order_iso.preimage f r') r'wo⟩ in
-let g : m.2.1 ≼i r' := ⟨⟨⟨sum.inl, λ a b, sum.inl.inj⟩,
-  λ a b, sum.lex_inl_inl.symm⟩,
-  λ a b h, begin
-    rcases b with b | ⟨⟨⟩⟩,
-    { exact ⟨_, rfl⟩ },
-    { cases sum.lex_inr_inl h }
-  end⟩ in
-ha (sub_of_le (MM m' ⟨g.trans
-  (initial_seg.of_iso (order_iso.preimage f r').symm),
-  λ x, rfl⟩) (or.inl rfl))
+theorem well_ordering_thm : ∃ (r : σ → σ → Prop), is_well_order σ r :=
+⟨_, order_embedding.is_well_order order_embedding_to_cardinal⟩
 
 end well_ordering_thm
 

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -341,17 +341,8 @@ classical.choice $ embedding.total.resolve_left $ λ ⟨⟨f, hf⟩⟩,
   have g x ≤ sum g, from le_sum.{u u} g x,
   not_le_of_gt (by rw hx; exact cantor _) this
 
-private def well_ordering_r : σ → σ → Prop :=
-λ a b, embedding_to_cardinal a < embedding_to_cardinal b
-
-noncomputable def order_embedding_to_cardinal :
-  well_ordering_r ≼o ((<) : Π {a b : cardinal.{u}}, Prop) :=
-{ to_fun := embedding_to_cardinal.1,
-  inj := embedding_to_cardinal.2,
-  ord := λ _ _, iff.rfl }
-
 theorem well_ordering_thm : ∃ (r : σ → σ → Prop), is_well_order σ r :=
-⟨_, order_embedding.is_well_order order_embedding_to_cardinal⟩
+⟨_, (order_embedding.preimage embedding_to_cardinal (<)).is_well_order⟩
 
 end well_ordering_thm
 

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -336,18 +336,17 @@ open function
 
 noncomputable lemma embedding_to_cardinal : σ ↪ cardinal.{u} :=
 classical.choice $ embedding.total.resolve_left $ λ ⟨⟨f, hf⟩⟩,
-  let T : Type u := Σ a : σ, quotient.out (@inv_fun _ ⟨0⟩ _ f a) in
-  let ⟨x, hx⟩ := inv_fun_surjective hf (cardinal.mk (set T)) in
-  have hT : set T ≃ (@quotient.out (Type u) _ (@inv_fun _ ⟨0⟩ _ f x)),
-    by simp only [T, hx, cardinal.mk];
-      exact (classical.choice (@quotient.mk_out (Type u) _ _)).symm,
-  have e : set T ↪ T, from ⟨λ s, ⟨x, hT s⟩, λ _, by simp⟩,
-  cantor_injective e.1 e.2
+  let g : σ → cardinal.{u} := @inv_fun _ ⟨0⟩ _ f in
+  let K : cardinal.{u} := sum g in
+  let ⟨x, (hx : g x = 2 ^ sum g)⟩ := @inv_fun_surjective _ _ _ _ hf (2 ^ sum g) in
+  have g x ≤ sum g, from le_sum.{u u} g x,
+  not_le_of_gt (by rw hx; exact cantor _) this
 
-private def well_order_r : σ → σ → Prop :=
+private def well_ordering_r : σ → σ → Prop :=
 λ a b, embedding_to_cardinal a < embedding_to_cardinal b
 
-noncomputable def order_embedding_to_cardinal : well_order_r ≼o ((<) : Π {a b : cardinal.{u}}, Prop) :=
+noncomputable def order_embedding_to_cardinal :
+  well_ordering_r ≼o ((<) : Π {a b : cardinal.{u}}, Prop) :=
 { to_fun := embedding_to_cardinal.1,
   inj := embedding_to_cardinal.2,
   ord := λ _ _, iff.rfl }

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -336,9 +336,8 @@ open function
 
 noncomputable lemma embedding_to_cardinal : σ ↪ cardinal.{u} :=
 classical.choice $ embedding.total.resolve_left $ λ ⟨⟨f, hf⟩⟩,
-  let g : σ → cardinal.{u} := @inv_fun _ ⟨0⟩ _ f in
-  let K : cardinal.{u} := sum g in
-  let ⟨x, (hx : g x = 2 ^ sum g)⟩ := @inv_fun_surjective _ _ _ _ hf (2 ^ sum g) in
+  let g : σ → cardinal.{u} := inv_fun f in
+  let ⟨x, (hx : g x = 2 ^ sum g)⟩ := inv_fun_surjective hf (2 ^ sum g) in
   have g x ≤ sum g, from le_sum.{u u} g x,
   not_le_of_gt (by rw hx; exact cantor _) this
 


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
