### PR TITLE
feat(topology/basic): is_open_Inter and others

### DIFF
--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -81,6 +81,15 @@ finite.induction_on hs
   (λ a s has hs ih h, by rw bInter_insert; exact
     is_open_inter (h a (mem_insert _ _)) (ih (λ i hi, h i (mem_insert_of_mem _ hi))))
 
+lemma is_open_Inter [fintype β] {s : β → set α}
+  (h : ∀ i, is_open (s i)) : is_open (⋂ i, s i) :=
+suffices is_open (⋂ (i : β) (hi : i ∈ @univ β), s i), by simpa,
+is_open_bInter finite_univ (λ i _, h i)
+
+lemma is_open_Inter_prop {p : Prop} {s : p → set α}
+  (h : ∀ h : p, is_open (s h)) : is_open (Inter s) :=
+by by_cases p; simp *
+
 lemma is_open_const {p : Prop} : is_open {a : α | p} :=
 by_cases
   (assume : p, begin simp only [this]; exact is_open_univ end)
@@ -118,12 +127,22 @@ is_open_inter h₁ $ is_open_compl_iff.mpr h₂
 lemma is_closed_inter (h₁ : is_closed s₁) (h₂ : is_closed s₂) : is_closed (s₁ ∩ s₂) :=
 by rw [is_closed, compl_inter]; exact is_open_union h₁ h₂
 
-lemma is_closed_Union {s : set β} {f : β → set α} (hs : finite s) :
+lemma is_closed_bUnion {s : set β} {f : β → set α} (hs : finite s) :
   (∀i∈s, is_closed (f i)) → is_closed (⋃i∈s, f i) :=
 finite.induction_on hs
   (λ _, by rw bUnion_empty; exact is_closed_empty)
   (λ a s has hs ih h, by rw bUnion_insert; exact
     is_closed_union (h a (mem_insert _ _)) (ih (λ i hi, h i (mem_insert_of_mem _ hi))))
+
+lemma is_closed_Union [fintype β] {s : β → set α}
+  (h : ∀ i, is_closed (s i)) : is_closed (Union s) :=
+suffices is_closed (⋃ (i : β) (hi : i ∈ @univ β), s i),
+  by convert this; simp [set.ext_iff],
+is_closed_bUnion finite_univ (λ i _, h i)
+
+lemma is_closed_Union_prop {p : Prop} {s : p → set α}
+  (h : ∀ h : p, is_closed (s h)) : is_closed (Union s) :=
+by by_cases p; simp *
 
 lemma is_closed_imp {p q : α → Prop} (hp : is_open {x | p x})
   (hq : is_closed {x | q x}) : is_closed {x | p x → q x} :=

--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -215,7 +215,7 @@ assume t ht,
 let ⟨t', ht', hct', htt'⟩ := mem_uniformity_is_closed ht, ⟨c, hcf, hc⟩ := h t' ht' in
 ⟨c, hcf,
   calc closure s ⊆ closure (⋃ (y : α) (H : y ∈ c), {x : α | (x, y) ∈ t'}) : closure_mono hc
-    ... = _ : closure_eq_of_is_closed $ is_closed_Union hcf $ assume i hi,
+    ... = _ : closure_eq_of_is_closed $ is_closed_bUnion hcf $ assume i hi,
       continuous_iff_is_closed.mp (continuous_id.prod_mk continuous_const) _ hct'
     ... ⊆ _ : bUnion_subset $ assume i hi, subset.trans (assume x, @htt' (x, i))
       (subset_bUnion_of_mem hi)⟩


### PR DESCRIPTION
Also renaming the old `is_closed_Union` to `is_closed_bUnion` to be consistent with `is_open_bInter`. 
Also lemmas on Unions indexed by propositions, necessary since `fintype` only takes a `Type` not a `Sort`. It would be cuter to generalise `fintype`, but this is fairly major.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
