### PR TITLE
feat(data/quot): quot.map: act on non-id maps

### DIFF
--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -825,15 +825,31 @@ def equiv_punit_of_unique [unique α] : α ≃ punit.{v} :=
 equiv_of_unique_of_unique
 
 namespace quot
+protected def congr {α β} {ra : α → α → Prop} {rb : β → β → Prop} (e : α ≃ β)
+  (eq : ∀a₁ a₂, ra a₁ a₂ ↔ rb (e a₁) (e a₂)) :
+  quot ra ≃ quot rb :=
+{ to_fun := quot.map e (assume a₁ a₂, (eq a₁ a₂).1),
+  inv_fun := quot.map e.symm
+    (assume b₁ b₂ h,
+     (eq (e.symm b₁) (e.symm b₂)).2
+       ((e.apply_symm_apply b₁).symm ▸ (e.apply_symm_apply b₂).symm ▸ h)),
+  left_inv := by rintros ⟨a⟩; dunfold quot.map; simp only [equiv.symm_apply_apply],
+  right_inv := by rintros ⟨a⟩; dunfold quot.map; simp only [equiv.apply_symm_apply] }
+
 /-- Quotients are congruent on equivalences under equality of their relation.
 An alternative is just to use rewriting with `eq`, but then computational proofs get stuck. -/
-protected def congr {α} {r r' : α → α → Prop} (eq : ∀a b, r a b ↔ r' a b) : quot r ≃ quot r' :=
-⟨quot.map r r' (assume a b, (eq a b).1), quot.map r' r (assume a b, (eq a b).2),
-  by rintros ⟨a⟩; refl, by rintros ⟨a⟩; refl⟩
+protected def congr_right {α} {r r' : α → α → Prop} (eq : ∀a₁ a₂, r a₁ a₂ ↔ r' a₁ a₂) :
+  quot r ≃ quot r' :=
+quot.congr (equiv.refl α) eq
 end quot
 
 namespace quotient
-protected def congr {α} {r r' : setoid α} (eq : ∀a b, @setoid.r α r a b ↔ @setoid.r α r' a b) :
-  quotient r ≃ quotient r' :=
-quot.congr eq
+protected def congr {α β} {ra : setoid α} {rb : setoid β} (e : α ≃ β)
+  (eq : ∀a₁ a₂, @setoid.r α ra a₁ a₂ ↔ @setoid.r β rb (e a₁) (e a₂)) :
+  quotient ra ≃ quotient rb :=
+quot.congr e eq
+
+protected def congr_right {α} {r r' : setoid α}
+  (eq : ∀a₁ a₂, @setoid.r α r a₁ a₂ ↔ @setoid.r α r' a₁ a₂) : quotient r ≃ quotient r' :=
+quot.congr_right eq
 end quotient

--- a/src/data/quot.lean
+++ b/src/data/quot.lean
@@ -31,8 +31,12 @@ quot.hrec_on qa (λ a, quot.hrec_on qb (f a) (λ b₁ b₂ pb, cb pb)) $ λ a₁
       ... == f a₂ b                                     : ca pa
       ... == @quot.hrec_on _ _ (φ _) ⟦b⟧ (f a₂) (@cb _) : by simp
 
-protected def map {α} (r r' : α → α → Prop) (h : ∀a b, r a b → r' a b) (a : quot r) : quot r' :=
-quot.hrec_on a (quot.mk r') $ assume a b hab, by rw [quot.sound (h a b hab)]
+protected def map (f : α → β) (h : ∀a₁ a₂, ra a₁ a₂ → rb (f a₁) (f a₂)) : quot ra → quot rb :=
+quot.lift (λ x, ⟦f x⟧) $ assume x y h₁, quot.sound $ h x y h₁
+
+protected def map_right {ra' : α → α → Prop} (h : ∀a₁ a₂, ra a₁ a₂ → ra' a₁ a₂) :
+  quot ra → quot ra' :=
+quot.map id h
 end quot
 
 namespace quotient

--- a/src/topology/algebra/uniform_ring.lean
+++ b/src/topology/algebra/uniform_ring.lean
@@ -115,7 +115,7 @@ by rw [@ring_sep_rel α r]; refl
 def sep_quot_equiv_ring_quot (α)
   [r : comm_ring α] [uniform_space α] [uniform_add_group α] [topological_ring α] :
   quotient (separation_setoid α) ≃ (⊥ : ideal α).closure.quotient :=
-quotient.congr $ assume x y, group_separation_rel x y
+quotient.congr_right $ assume x y, group_separation_rel x y
 
 /- TODO: use a form of transport a.k.a. lift definition a.k.a. transfer -/
 instance [comm_ring α] [uniform_space α] [uniform_add_group α] [topological_ring α] :


### PR DESCRIPTION
TO CONTRIBUTORS:

Another chunk from #1082 
Should I restore the original version of `quotient.congr` as `quotient.congr_right`?

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
