### PR TITLE
chore(*): provide some proof terms for `is_group_hom` explicitly

### DIFF
--- a/src/algebra/pi_instances.lean
+++ b/src/algebra/pi_instances.lean
@@ -236,10 +236,10 @@ lemma snd.is_monoid_hom [monoid α] [monoid β] : is_monoid_hom (prod.snd : α �
 
 @[to_additive fst.is_add_group_hom]
 lemma fst.is_group_hom [group α] [group β] : is_group_hom (prod.fst : α × β → α) :=
-by refine_struct {..}; simp
+{ map_mul := λ _ _, rfl }
 @[to_additive snd.is_add_group_hom]
 lemma snd.is_group_hom [group α] [group β] : is_group_hom (prod.snd : α × β → β) :=
-by refine_struct {..}; simp
+{ map_mul := λ _ _, rfl }
 
 attribute [instance] fst.is_monoid_hom fst.is_add_monoid_hom snd.is_monoid_hom snd.is_add_monoid_hom
 fst.is_group_hom fst.is_add_group_hom snd.is_group_hom snd.is_add_group_hom

--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -244,10 +244,10 @@ noncomputable instance : discrete_field ℂ :=
   ..complex.comm_ring }
 
 instance re.is_add_group_hom : is_add_group_hom complex.re :=
-by refine_struct {..}; simp
+{ map_add := complex.add_re }
 
 instance im.is_add_group_hom : is_add_group_hom complex.im :=
-by refine_struct {..}; simp
+{ map_add := complex.add_im }
 
 instance : is_ring_hom conj :=
 by refine_struct {..}; simp

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -86,11 +86,11 @@ by refine {zero := 0, add := (+), neg := has_neg.neg, ..};
    intros; ext; simp
 
 instance linear_map.is_add_group_hom : is_add_group_hom f :=
-by refine_struct {..}; simp
+{ map_add := f.add }
 
 instance linear_map_apply_is_add_group_hom (a : β) :
   is_add_group_hom (λ f : β →ₗ[α] γ, f a) :=
-by refine_struct {..}; simp
+{ map_add := λ f g, linear_map.add_apply f g a }
 
 lemma sum_apply [decidable_eq δ] (t : finset δ) (f : δ → β →ₗ[α] γ) (b : β) :
   t.sum f b = t.sum (λd, f d b) :=


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
