### PR TITLE
feat(data/set): simple lemmas, renaming

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -782,7 +782,7 @@ assume x hx, h hx
 @[simp] theorem preimage_set_of_eq {p : α → Prop} {f : β → α} : f ⁻¹' {a | p a} = {a | p (f a)} :=
 rfl
 
-theorem preimage_id {s : set α} : id ⁻¹' s = s := rfl
+@[simp] theorem preimage_id {s : set α} : id ⁻¹' s = s := rfl
 
 theorem preimage_comp {s : set γ} : (g ∘ f) ⁻¹' s = f ⁻¹' (g ⁻¹' s) := rfl
 
@@ -1337,6 +1337,23 @@ ext $ assume ⟨a, b⟩, by simp
 lemma prod_sub_preimage_iff {W : set γ} {f : α × β → γ} :
   set.prod s t ⊆ f ⁻¹' W ↔ ∀ a b, a ∈ s → b ∈ t → f (a, b) ∈ W :=
 by simp [subset_def]
+
+lemma fst_image_prod_subset {s : set α} {t : set β} :
+  prod.fst '' (set.prod s t) ⊆ s :=
+begin
+  assume x hx,
+  simp only [set.mem_image, exists_and_distrib_right, exists_eq_right, set.mem_prod,
+             exists_and_distrib_left, prod.exists] at hx,
+  exact hx.1
+end
+
+lemma snd_image_prod_subset {s : set α} {t : set β} :
+  prod.snd '' (set.prod s t) ⊆ t :=
+begin
+  assume x hx,
+  simp only [set.mem_image, exists_and_distrib_right, exists_eq_right, set.mem_prod, prod.exists] at hx,
+  exact hx.2
+end
 
 end prod
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1338,22 +1338,25 @@ lemma prod_sub_preimage_iff {W : set γ} {f : α × β → γ} :
   set.prod s t ⊆ f ⁻¹' W ↔ ∀ a b, a ∈ s → b ∈ t → f (a, b) ∈ W :=
 by simp [subset_def]
 
-lemma fst_image_prod_subset {s : set α} {t : set β} :
+lemma fst_image_prod_subset (s : set α) (t : set β) :
   prod.fst '' (set.prod s t) ⊆ s :=
-begin
-  assume x hx,
-  simp only [set.mem_image, exists_and_distrib_right, exists_eq_right, set.mem_prod,
-             exists_and_distrib_left, prod.exists] at hx,
-  exact hx.1
-end
+λ _ h, let ⟨_, ⟨h₂, _⟩, h₁⟩ := (set.mem_image _ _ _).1 h in h₁ ▸ h₂
 
-lemma snd_image_prod_subset {s : set α} {t : set β} :
+lemma fst_image_prod {s : set α} (hs : s ≠ ∅) (t : set β) :
+  prod.fst '' (set.prod t s) = t :=
+set.subset.antisymm (fst_image_prod_subset _ _)
+  $ λ y y_in, let (⟨x, x_in⟩ : ∃ (x : α), x ∈ s) := set.exists_mem_of_ne_empty hs in
+    ⟨(y, x), ⟨y_in, x_in⟩, rfl⟩
+
+lemma snd_image_prod_subset (s : set α) (t : set β) :
   prod.snd '' (set.prod s t) ⊆ t :=
-begin
-  assume x hx,
-  simp only [set.mem_image, exists_and_distrib_right, exists_eq_right, set.mem_prod, prod.exists] at hx,
-  exact hx.2
-end
+λ _ h, let ⟨_, ⟨_, h₂⟩, h₁⟩ := (set.mem_image _ _ _).1 h in h₁ ▸ h₂
+
+lemma snd_image_prod {s : set α} (hs : s ≠ ∅) (t : set β) :
+  prod.snd '' (set.prod s t) = t :=
+set.subset.antisymm (snd_image_prod_subset _ _)
+  $ λ y y_in, let (⟨x, x_in⟩ : ∃ (x : α), x ∈ s) := set.exists_mem_of_ne_empty hs in
+    ⟨(x, y), ⟨x_in, y_in⟩, rfl⟩
 
 end prod
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1342,10 +1342,10 @@ lemma fst_image_prod_subset (s : set α) (t : set β) :
   prod.fst '' (set.prod s t) ⊆ s :=
 λ _ h, let ⟨_, ⟨h₂, _⟩, h₁⟩ := (set.mem_image _ _ _).1 h in h₁ ▸ h₂
 
-lemma fst_image_prod {s : set α} (hs : s ≠ ∅) (t : set β) :
-  prod.fst '' (set.prod t s) = t :=
+lemma fst_image_prod (s : set β) {t : set α} (ht : t ≠ ∅) :
+  prod.fst '' (set.prod s t) = s :=
 set.subset.antisymm (fst_image_prod_subset _ _)
-  $ λ y y_in, let (⟨x, x_in⟩ : ∃ (x : α), x ∈ s) := set.exists_mem_of_ne_empty hs in
+  $ λ y y_in, let (⟨x, x_in⟩ : ∃ (x : α), x ∈ t) := set.exists_mem_of_ne_empty ht in
     ⟨(y, x), ⟨y_in, x_in⟩, rfl⟩
 
 lemma snd_image_prod_subset (s : set α) (t : set β) :

--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -145,11 +145,11 @@ by simp [compl_Inter, compl_compl]
 theorem Inter_eq_comp_Union_comp (s : ι → set β) : (⋂ i, s i) = - (⋃ i, -s i) :=
 by simp [compl_compl]
 
-theorem inter_Union_left (s : set β) (t : ι → set β) :
+theorem inter_Union (s : set β) (t : ι → set β) :
   s ∩ (⋃ i, t i) = ⋃ i, s ∩ t i :=
 ext $ by simp
 
-theorem inter_Union_right (s : set β) (t : ι → set β) :
+theorem Union_inter (s : set β) (t : ι → set β) :
   (⋃ i, t i) ∩ s = ⋃ i, t i ∩ s :=
 ext $ by simp
 
@@ -161,38 +161,38 @@ theorem Inter_inter_distrib (s : ι → set β) (t : ι → set β) :
   (⋂ i, s i ∩ t i) = (⋂ i, s i) ∩ (⋂ i, t i) :=
 ext $ by simp [forall_and_distrib]
 
-theorem union_Union_left [inhabited ι] (s : set β) (t : ι → set β) :
+theorem union_Union [inhabited ι] (s : set β) (t : ι → set β) :
   s ∪ (⋃ i, t i) = ⋃ i, s ∪ t i :=
 by rw [Union_union_distrib, Union_const]
 
-theorem union_Union_right [inhabited ι] (s : set β) (t : ι → set β) :
+theorem Union_union [inhabited ι] (s : set β) (t : ι → set β) :
   (⋃ i, t i) ∪ s = ⋃ i, t i ∪ s :=
 by rw [Union_union_distrib, Union_const]
 
-theorem inter_Inter_left [inhabited ι] (s : set β) (t : ι → set β) :
+theorem inter_Inter [inhabited ι] (s : set β) (t : ι → set β) :
   s ∩ (⋂ i, t i) = ⋂ i, s ∩ t i :=
 by rw [Inter_inter_distrib, Inter_const]
 
-theorem inter_Inter_right [inhabited ι] (s : set β) (t : ι → set β) :
+theorem Inter_inter [inhabited ι] (s : set β) (t : ι → set β) :
   (⋂ i, t i) ∩ s = ⋂ i, t i ∩ s :=
 by rw [Inter_inter_distrib, Inter_const]
 
 -- classical
-theorem union_Inter_left (s : set β) (t : ι → set β) :
+theorem union_Inter (s : set β) (t : ι → set β) :
   s ∪ (⋂ i, t i) = ⋂ i, s ∪ t i :=
 ext $ assume x, by simp [classical.forall_or_distrib_left]
 
-theorem diff_Union_right (s : set β) (t : ι → set β) :
+theorem Union_diff (s : set β) (t : ι → set β) :
   (⋃ i, t i) \ s = ⋃ i, t i \ s :=
-inter_Union_right _ _
+Union_inter _ _
 
-theorem diff_Union_left [inhabited ι] (s : set β) (t : ι → set β) :
+theorem diff_Union [inhabited ι] (s : set β) (t : ι → set β) :
   s \ (⋃ i, t i) = ⋂ i, s \ t i :=
-by rw [diff_eq, compl_Union, inter_Inter_left]; refl
+by rw [diff_eq, compl_Union, inter_Inter]; refl
 
-theorem diff_Inter_left (s : set β) (t : ι → set β) :
+theorem diff_Inter (s : set β) (t : ι → set β) :
   s \ (⋂ i, t i) = ⋃ i, s \ t i :=
-by rw [diff_eq, compl_Inter, inter_Union_left]; refl
+by rw [diff_eq, compl_Inter, inter_Union]; refl
 
 /- bounded unions and intersections -/
 
@@ -316,6 +316,18 @@ ext (λ x, by simp)
 -- classical -- complete_boolean_algebra
 theorem compl_bInter (s : set α) (t : α → set β) : -(⋂ i ∈ s, t i) = (⋃ i ∈ s, - t i) :=
 ext (λ x, by simp [classical.not_forall])
+
+theorem inter_bUnion (s : set α) (t : α → set β) (u : set β) :
+  u ∩ (⋃ i ∈ s, t i) = ⋃ i ∈ s, u ∩ t i :=
+begin
+  ext x,
+  simp only [exists_prop, mem_Union, mem_inter_eq],
+  exact ⟨λ ⟨hx, ⟨i, is, xi⟩⟩, ⟨i, is, hx, xi⟩, λ ⟨i, is, hx, xi⟩, ⟨hx, ⟨i, is, xi⟩⟩⟩
+end
+
+theorem bUnion_inter (s : set α) (t : α → set β) (u : set β) :
+  (⋃ i ∈ s, t i) ∩ u = (⋃ i ∈ s, t i ∩ u) :=
+by simp [@inter_comm _ _ u, inter_bUnion]
 
 /-- Intersection of a set of sets. -/
 @[reducible] def sInter (S : set (set α)) : set α := Inf S

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -600,7 +600,7 @@ begin
     { ext1 a, exact ennreal.coe_mul.symm },
     have eq : ∀p, (rs.map c) ⁻¹' {p} = (⋃n, (rs.map c) ⁻¹' {p} ∩ {a | p ≤ f n a}),
     { assume p,
-      rw [← inter_Union_left, ← inter_univ ((map c rs) ⁻¹' {p})] {occs := occurrences.pos [1]},
+      rw [← inter_Union, ← inter_univ ((map c rs) ⁻¹' {p})] {occs := occurrences.pos [1]},
       refine set.ext (assume x, and_congr_right $ assume hx, (true_iff _).2 _),
       by_cases p_eq : p = 0, { simp [p_eq] },
       simp at hx, subst hx,
@@ -783,177 +783,177 @@ begin
 end
 
 /-- Weaker version of the monotone convergence theorem-/
-lemma lintegral_supr_ae {f : ℕ → α → ennreal} (hf : ∀n, measurable (f n)) 
+lemma lintegral_supr_ae {f : ℕ → α → ennreal} (hf : ∀n, measurable (f n))
   (h_mono : ∀n, ∀ₘ a, f n a ≤ f n.succ a) :
   (∫⁻ a, ⨆n, f n a) = (⨆n, ∫⁻ a, f n a) :=
 let ⟨s, hs⟩ := exists_is_measurable_superset_of_measure_eq_zero
                        (all_ae_iff.1 (all_ae_all_iff.2 h_mono)) in
 let g := λ n a, if a ∈ s then 0 else f n a in
-have g_eq_f : ∀ₘ a, ∀n, g n a = f n a, 
-  begin 
-    have := hs.2.2, rw [← compl_compl s] at this, 
+have g_eq_f : ∀ₘ a, ∀n, g n a = f n a,
+  begin
+    have := hs.2.2, rw [← compl_compl s] at this,
     filter_upwards [(measure.mem_a_e_iff (-s)).2 this] assume a ha n, if_neg ha
   end,
-calc 
-  (∫⁻ a, ⨆n, f n a) = (∫⁻ a, ⨆n, g n a) : 
-  lintegral_congr_ae 
-    begin 
+calc
+  (∫⁻ a, ⨆n, f n a) = (∫⁻ a, ⨆n, g n a) :
+  lintegral_congr_ae
+    begin
       filter_upwards [g_eq_f], assume a ha, congr, funext, exact (ha n).symm
     end
-  ... = ⨆n, (∫⁻ a, g n a) : 
-  lintegral_supr 
-    (assume n, measurable.if hs.2.1 measurable_const (hf n)) 
+  ... = ⨆n, (∫⁻ a, g n a) :
+  lintegral_supr
+    (assume n, measurable.if hs.2.1 measurable_const (hf n))
     (monotone_of_monotone_nat $ assume n a,  classical.by_cases
       (assume h : a ∈ s, by simp [g, if_pos h])
-      (assume h : a ∉ s, 
-      begin 
-        simp only [g, if_neg h], have := hs.1, rw subset_def at this, have := mt (this a) h, 
-        simp only [not_not, mem_set_of_eq] at this, exact this n  
+      (assume h : a ∉ s,
+      begin
+        simp only [g, if_neg h], have := hs.1, rw subset_def at this, have := mt (this a) h,
+        simp only [not_not, mem_set_of_eq] at this, exact this n
       end))
-  ... = ⨆n, (∫⁻ a, f n a) : 
-  begin 
+  ... = ⨆n, (∫⁻ a, f n a) :
+  begin
     congr, funext, apply lintegral_congr_ae, filter_upwards [g_eq_f] assume a ha, ha n
-  end 
+  end
 
 lemma lintegral_sub {f g : α → ennreal} (hf : measurable f) (hg : measurable g)
-  (hg_fin : lintegral g < ⊤) (h_le : ∀ₘ a, g a ≤ f a) : 
-  (∫⁻ a, f a - g a) = (∫⁻ a, f a) - (∫⁻ a, g a) := 
+  (hg_fin : lintegral g < ⊤) (h_le : ∀ₘ a, g a ≤ f a) :
+  (∫⁻ a, f a - g a) = (∫⁻ a, f a) - (∫⁻ a, g a) :=
 begin
-  rw [← ennreal.add_right_inj hg_fin, 
+  rw [← ennreal.add_right_inj hg_fin,
         ennreal.sub_add_cancel_of_le (lintegral_le_lintegral_ae h_le),
-      ← lintegral_add (ennreal.measurable_sub hf hg) hg], 
-  show  (∫⁻ (a : α), f a - g a + g a) = ∫⁻ (a : α), f a, 
-  apply lintegral_congr_ae, filter_upwards [h_le], simp only [add_comm, mem_set_of_eq], 
+      ← lintegral_add (ennreal.measurable_sub hf hg) hg],
+  show  (∫⁻ (a : α), f a - g a + g a) = ∫⁻ (a : α), f a,
+  apply lintegral_congr_ae, filter_upwards [h_le], simp only [add_comm, mem_set_of_eq],
   assume a ha, exact ennreal.add_sub_cancel_of_le ha
 end
 
 /-- Monotone convergence theorem for nonincreasing sequences of functions -/
 lemma lintegral_infi_ae
-  {f : ℕ → α → ennreal} (h_meas : ∀n, measurable (f n)) 
+  {f : ℕ → α → ennreal} (h_meas : ∀n, measurable (f n))
   (h_mono : ∀n:ℕ, ∀ₘ a, f n.succ a ≤ f n a) (h_fin : lintegral (f 0) < ⊤):
   (∫⁻ a, ⨅n, f n a) = (⨅n, ∫⁻ a, f n a) :=
-have fn_le_f0 : (∫⁻ a, ⨅n, f n a) ≤ lintegral (f 0), from 
-  lintegral_le_lintegral _ _ (assume a, infi_le_of_le 0 (le_refl _)), 
+have fn_le_f0 : (∫⁻ a, ⨅n, f n a) ≤ lintegral (f 0), from
+  lintegral_le_lintegral _ _ (assume a, infi_le_of_le 0 (le_refl _)),
 have fn_le_f0' : (⨅n, ∫⁻ a, f n a) ≤ lintegral (f 0), from infi_le_of_le 0 (le_refl _),
-(ennreal.sub_left_inj h_fin fn_le_f0 fn_le_f0').1 $ 
+(ennreal.sub_left_inj h_fin fn_le_f0 fn_le_f0').1 $
 show lintegral (f 0) - (∫⁻ a, ⨅n, f n a) = lintegral (f 0) - (⨅n, ∫⁻ a, f n a), from
-calc 
-  lintegral (f 0) - (∫⁻ a, ⨅n, f n a) = ∫⁻ a, f 0 a - ⨅n, f n a : 
-    (lintegral_sub (h_meas 0) (measurable.infi h_meas) 
-    (calc 
-      (∫⁻ a, ⨅n, f n a)  ≤ lintegral (f 0) : lintegral_le_lintegral _ _ 
+calc
+  lintegral (f 0) - (∫⁻ a, ⨅n, f n a) = ∫⁻ a, f 0 a - ⨅n, f n a :
+    (lintegral_sub (h_meas 0) (measurable.infi h_meas)
+    (calc
+      (∫⁻ a, ⨅n, f n a)  ≤ lintegral (f 0) : lintegral_le_lintegral _ _
                                              (assume a, infi_le _ _)
           ... < ⊤ : h_fin  )
     (all_ae_of_all $ assume a, infi_le _ _)).symm
   ... = ∫⁻ a, ⨆n, f 0 a - f n a : congr rfl (funext (assume a, ennreal.sub_infi))
-  ... = ⨆n, ∫⁻ a, f 0 a - f n a : 
-    lintegral_supr_ae 
-      (assume n, ennreal.measurable_sub (h_meas 0) (h_meas n)) 
+  ... = ⨆n, ∫⁻ a, f 0 a - f n a :
+    lintegral_supr_ae
+      (assume n, ennreal.measurable_sub (h_meas 0) (h_meas n))
       (assume n, by
         filter_upwards [h_mono n] assume a ha, ennreal.sub_le_sub (le_refl _) ha)
-  ... = ⨆n, lintegral (f 0) - ∫⁻ a, f n a : 
-    have h_mono : ∀ₘ a, ∀n:ℕ, f n.succ a ≤ f n a := all_ae_all_iff.2 h_mono, 
-    have h_mono : ∀n, ∀ₘa, f n a ≤ f 0 a := assume n, 
-    begin 
-      filter_upwards [h_mono], simp only [mem_set_of_eq], assume a, assume h, induction n with n ih, 
+  ... = ⨆n, lintegral (f 0) - ∫⁻ a, f n a :
+    have h_mono : ∀ₘ a, ∀n:ℕ, f n.succ a ≤ f n a := all_ae_all_iff.2 h_mono,
+    have h_mono : ∀n, ∀ₘa, f n a ≤ f 0 a := assume n,
+    begin
+      filter_upwards [h_mono], simp only [mem_set_of_eq], assume a, assume h, induction n with n ih,
       {exact le_refl _}, {exact le_trans (h n) ih}
-    end, 
-    congr rfl (funext $ assume n, lintegral_sub (h_meas _) (h_meas _) 
+    end,
+    congr rfl (funext $ assume n, lintegral_sub (h_meas _) (h_meas _)
       (calc
         (∫⁻ a, f n a) ≤ ∫⁻ a, f 0 a : lintegral_le_lintegral_ae $ h_mono n
         ... < ⊤ : h_fin)
         (h_mono n))
-  ... = lintegral (f 0) - (⨅n, ∫⁻ a, f n a) : ennreal.sub_infi.symm 
+  ... = lintegral (f 0) - (⨅n, ∫⁻ a, f n a) : ennreal.sub_infi.symm
 
 /-- Known as Fatou's lemma -/
 lemma lintegral_liminf_le {f : ℕ → α → ennreal} (h_meas : ∀n, measurable (f n)) :
-  (∫⁻ a, liminf at_top (λ n, f n a)) ≤ liminf at_top (λ n, lintegral (f n)) := 
-calc 
-  (∫⁻ a, liminf at_top (λ n, f n a)) = ∫⁻ a, ⨆n:ℕ, ⨅i≥n, f i a : 
+  (∫⁻ a, liminf at_top (λ n, f n a)) ≤ liminf at_top (λ n, lintegral (f n)) :=
+calc
+  (∫⁻ a, liminf at_top (λ n, f n a)) = ∫⁻ a, ⨆n:ℕ, ⨅i≥n, f i a :
      congr rfl (funext (assume a, liminf_eq_supr_infi_of_nat))
-  ... = ⨆n:ℕ, ∫⁻ a, ⨅i≥n, f i a : 
-    lintegral_supr 
-    begin 
-      assume n, apply measurable.infi, assume i, by_cases h : i ≥ n, 
-      {convert h_meas i, simp [h]}, 
+  ... = ⨆n:ℕ, ∫⁻ a, ⨅i≥n, f i a :
+    lintegral_supr
+    begin
+      assume n, apply measurable.infi, assume i, by_cases h : i ≥ n,
+      {convert h_meas i, simp [h]},
       {convert measurable_const, simp [h]}
     end
-    begin 
-      assume n m hnm a, simp only [le_infi_iff], assume i hi, 
-      refine infi_le_of_le i (infi_le_of_le (le_trans hnm hi) (le_refl _)) 
+    begin
+      assume n m hnm a, simp only [le_infi_iff], assume i hi,
+      refine infi_le_of_le i (infi_le_of_le (le_trans hnm hi) (le_refl _))
     end
-  ... ≤ ⨆n:ℕ, ⨅i≥n, lintegral (f i) : 
-    supr_le_supr $ assume n, le_infi $ 
-      assume i, le_infi $ assume hi, lintegral_le_lintegral _ _ 
+  ... ≤ ⨆n:ℕ, ⨅i≥n, lintegral (f i) :
+    supr_le_supr $ assume n, le_infi $
+      assume i, le_infi $ assume hi, lintegral_le_lintegral _ _
       $ assume a, infi_le_of_le i $ infi_le_of_le hi $ le_refl _
   ... = liminf at_top (λ n, lintegral (f n)) : liminf_eq_supr_infi_of_nat.symm
 
-lemma limsup_lintegral_le {f : ℕ → α → ennreal} {g : α → ennreal} 
-  (hf_meas : ∀ n, measurable (f n)) (hg_meas : measurable g) 
-  (h_bound : ∀n, ∀ₘa, f n a ≤ g a) (h_fin : lintegral g < ⊤) : 
+lemma limsup_lintegral_le {f : ℕ → α → ennreal} {g : α → ennreal}
+  (hf_meas : ∀ n, measurable (f n)) (hg_meas : measurable g)
+  (h_bound : ∀n, ∀ₘa, f n a ≤ g a) (h_fin : lintegral g < ⊤) :
   limsup at_top (λn, lintegral (f n)) ≤ ∫⁻ a, limsup at_top (λn, f n a) :=
-calc 
-  limsup at_top (λn, lintegral (f n)) = ⨅n:ℕ, ⨆i≥n, lintegral (f i) : 
-    limsup_eq_infi_supr_of_nat 
-  ... ≤ ⨅n:ℕ, ∫⁻ a, ⨆i≥n, f i a : 
-    infi_le_infi $ assume n, supr_le $ assume i, supr_le $ assume hi, 
+calc
+  limsup at_top (λn, lintegral (f n)) = ⨅n:ℕ, ⨆i≥n, lintegral (f i) :
+    limsup_eq_infi_supr_of_nat
+  ... ≤ ⨅n:ℕ, ∫⁻ a, ⨆i≥n, f i a :
+    infi_le_infi $ assume n, supr_le $ assume i, supr_le $ assume hi,
     lintegral_le_lintegral _ _ $ assume a, le_supr_of_le i $ le_supr_of_le hi (le_refl _)
-  ... = ∫⁻ a, ⨅n:ℕ, ⨆i≥n, f i a : 
-    (lintegral_infi_ae 
-      (assume n, 
-           @measurable.supr _ _ _ _ _ _ _ _ _ (λ i a, supr (λ (h : i ≥ n), f i a)) 
-      (assume i, measurable.supr_Prop (hf_meas i))) 
-      (assume n, all_ae_of_all $ assume a, 
-       begin 
-         simp only [supr_le_iff], assume i hi, refine le_supr_of_le i _, 
-         rw [supr_pos _], exact le_refl _, exact nat.le_of_succ_le hi    
-       end ) 
-      (lt_of_le_of_lt 
-        (lintegral_le_lintegral_ae 
-        begin 
-          filter_upwards [all_ae_all_iff.2 h_bound], 
+  ... = ∫⁻ a, ⨅n:ℕ, ⨆i≥n, f i a :
+    (lintegral_infi_ae
+      (assume n,
+           @measurable.supr _ _ _ _ _ _ _ _ _ (λ i a, supr (λ (h : i ≥ n), f i a))
+      (assume i, measurable.supr_Prop (hf_meas i)))
+      (assume n, all_ae_of_all $ assume a,
+       begin
+         simp only [supr_le_iff], assume i hi, refine le_supr_of_le i _,
+         rw [supr_pos _], exact le_refl _, exact nat.le_of_succ_le hi
+       end )
+      (lt_of_le_of_lt
+        (lintegral_le_lintegral_ae
+        begin
+          filter_upwards [all_ae_all_iff.2 h_bound],
           simp only [supr_le_iff, mem_set_of_eq],
           assume a ha i hi, exact ha i
-        end ) 
+        end )
         h_fin)).symm
-  ... = ∫⁻ a, limsup at_top (λn, f n a) : 
+  ... = ∫⁻ a, limsup at_top (λn, f n a) :
     lintegral_congr_ae $ all_ae_of_all $ assume a, limsup_eq_infi_supr_of_nat.symm
 
 /-- Dominated convergence theorem for nonnegative functions -/
 lemma dominated_convergence_nn
-  {F : ℕ → α → ennreal} {f : α → ennreal} {g : α → ennreal} 
+  {F : ℕ → α → ennreal} {f : α → ennreal} {g : α → ennreal}
   (hF_meas : ∀n, measurable (F n)) (hf_meas : measurable f) (hg_meas : measurable g)
-  (h_bound : ∀n, ∀ₘ a, F n a ≤ g a) 
-  (h_fin : lintegral g < ⊤) 
+  (h_bound : ∀n, ∀ₘ a, F n a ≤ g a)
+  (h_fin : lintegral g < ⊤)
   (h_lim : ∀ₘ a, tendsto (λ n, F n a) at_top (nhds (f a))) :
-  tendsto (λn, lintegral (F n)) at_top (nhds (lintegral f)) := 
-begin 
-  have limsup_le_lintegral := 
-  calc 
-    limsup at_top (λ (n : ℕ), lintegral (F n)) ≤ ∫⁻ (a : α), limsup at_top (λn, F n a) : 
+  tendsto (λn, lintegral (F n)) at_top (nhds (lintegral f)) :=
+begin
+  have limsup_le_lintegral :=
+  calc
+    limsup at_top (λ (n : ℕ), lintegral (F n)) ≤ ∫⁻ (a : α), limsup at_top (λn, F n a) :
       limsup_lintegral_le hF_meas hg_meas h_bound h_fin
-    ... = lintegral f : 
+    ... = lintegral f :
       lintegral_congr_ae $
-          by filter_upwards [h_lim] assume a h, limsup_eq_of_tendsto at_top_ne_bot h, 
-  have lintegral_le_liminf := 
-  calc 
-    lintegral f = ∫⁻ (a : α), liminf at_top (λ (n : ℕ), F n a) : 
-      lintegral_congr_ae $ 
+          by filter_upwards [h_lim] assume a h, limsup_eq_of_tendsto at_top_ne_bot h,
+  have lintegral_le_liminf :=
+  calc
+    lintegral f = ∫⁻ (a : α), liminf at_top (λ (n : ℕ), F n a) :
+      lintegral_congr_ae $
       by filter_upwards [h_lim] assume a h, (liminf_eq_of_tendsto at_top_ne_bot h).symm
-    ... ≤ liminf at_top (λ n, lintegral (F n)) : 
-      lintegral_liminf_le hF_meas,  
-  have liminf_eq_limsup := 
-    le_antisymm 
-      (liminf_le_limsup (map_ne_bot at_top_ne_bot)) 
-      (le_trans limsup_le_lintegral lintegral_le_liminf), 
-  have liminf_eq_lintegral : liminf at_top (λ n, lintegral (F n)) = lintegral f := 
-    le_antisymm (by convert limsup_le_lintegral) lintegral_le_liminf, 
-  have limsup_eq_lintegral : limsup at_top (λ n, lintegral (F n)) = lintegral f := 
-    le_antisymm 
-      limsup_le_lintegral  
-      begin convert lintegral_le_liminf, exact liminf_eq_limsup.symm end, 
+    ... ≤ liminf at_top (λ n, lintegral (F n)) :
+      lintegral_liminf_le hF_meas,
+  have liminf_eq_limsup :=
+    le_antisymm
+      (liminf_le_limsup (map_ne_bot at_top_ne_bot))
+      (le_trans limsup_le_lintegral lintegral_le_liminf),
+  have liminf_eq_lintegral : liminf at_top (λ n, lintegral (F n)) = lintegral f :=
+    le_antisymm (by convert limsup_le_lintegral) lintegral_le_liminf,
+  have limsup_eq_lintegral : limsup at_top (λ n, lintegral (F n)) = lintegral f :=
+    le_antisymm
+      limsup_le_lintegral
+      begin convert lintegral_le_liminf, exact liminf_eq_limsup.symm end,
   exact tendsto_of_liminf_eq_limsup ⟨liminf_eq_lintegral, limsup_eq_lintegral⟩
-end 
+end
 
 section
 open encodable

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -811,7 +811,7 @@ def restrict_on {s : set α} (h : d.has s) : dynkin_system α :=
       (compl_subset_compl.mpr $ inter_subset_right _ _),
   has_Union_nat := assume f hd hf,
     begin
-      rw [inter_comm, inter_Union_left],
+      rw [inter_comm, inter_Union],
       apply d.has_Union_nat,
       { exact λ i j h x ⟨⟨_, h₁⟩, _, h₂⟩, hd i j h ⟨h₁, h₂⟩ },
       { simpa [inter_comm] using hf },

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -393,7 +393,7 @@ begin
     ← ennreal.sub_sub_cancel (by exact hk) (measure_mono (Inter_subset _ k)),
     ← measure_diff (Inter_subset _ k) (h k) (is_measurable.Inter h)
       (lt_of_le_of_lt (measure_mono (Inter_subset _ k)) hk),
-    diff_Inter_left, measure_Union_eq_supr_nat],
+    diff_Inter, measure_Union_eq_supr_nat],
   { congr, funext i,
     cases le_total k i with ik ik,
     { exact measure_diff (hs _ _ ik) (h k) (h i)
@@ -873,7 +873,7 @@ iff.intro
 
 lemma all_ae_iff {p : α → Prop} : (∀ₘ a, p a) ↔ volume { a | ¬ p a } = 0 := iff.refl _
 
-lemma all_ae_of_all {p : α → Prop} : (∀a, p a) → ∀ₘ a, p a := assume h, 
+lemma all_ae_of_all {p : α → Prop} : (∀a, p a) → ∀ₘ a, p a := assume h,
 by {rw all_ae_iff, convert volume_empty, simp only [h, not_true], reflexivity}
 
 lemma all_ae_all_iff {ι : Type*} [encodable ι] {p : α → ι → Prop} :

--- a/src/measure_theory/outer_measure.lean
+++ b/src/measure_theory/outer_measure.lean
@@ -372,7 +372,7 @@ private lemma C_Union_nat {s : ℕ → set α} (h : ∀i, C (s i))
 C_iff_le.2 $ λ t, begin
   have hp : m (t ∩ ⋃i, s i) ≤ (⨆n, m (t ∩ ⋃i<n, s i)),
   { convert m.Union (λ i, t ∩ s i),
-    { rw inter_Union_left },
+    { rw inter_Union },
     { simp [ennreal.tsum_eq_supr_nat, C_sum m h hd] } },
   refine le_trans (add_le_add_right' hp) _,
   rw ennreal.supr_add,
@@ -430,9 +430,9 @@ le_infi $ λ f, le_infi $ λ hf, begin
   refine le_trans (add_le_add'
     (infi_le_of_le (λi, f i ∩ s) $ infi_le _ _)
     (infi_le_of_le (λi, f i \ s) $ infi_le _ _)) _,
-  { rw ← inter_Union_right,
+  { rw ← Union_inter,
     exact inter_subset_inter_left _ hf },
-  { rw ← diff_Union_right,
+  { rw ← Union_diff,
     exact diff_subset_diff_left hf },
   { rw ← ennreal.tsum_add,
     exact ennreal.tsum_le_tsum (λ i, hs _) }


### PR DESCRIPTION
Add 4 simple lemmas in `data/set/basic` and `data/set/lattice`. In the latter file, the naming convention was not really coherent, so I used this occasion to normalize things a little bit. 

NB: most of the modifications are whitespace changes in ` src/measure_theory/integration`, which had many trailing spaces. Disable whitespace differences to see the mostly trivial changes made by the PR.