### PR TITLE
chore(topology/*): reverse order on topological and uniform spaces

### DIFF
--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -294,7 +294,7 @@ measurable.is_glb hf $ λ b, is_glb_infi
 
 lemma measurable.supr_Prop {α} [topological_space α] [complete_linear_order α]
   [orderable_topology α] [second_countable_topology α]
-  {β} [measurable_space β] {p : Prop} {f : β → α} (hf : measurable f): 
+  {β} [measurable_space β] {p : Prop} {f : β → α} (hf : measurable f):
   measurable (λ b, ⨆ h : p, f b) :=
 classical.by_cases
   (assume h : p, begin convert hf, funext, exact supr_pos h end)
@@ -302,7 +302,7 @@ classical.by_cases
 
 lemma measurable.infi_Prop {α} [topological_space α] [complete_linear_order α]
   [orderable_topology α] [second_countable_topology α]
-  {β} [measurable_space β] {p : Prop} {f : β → α} (hf : measurable f): 
+  {β} [measurable_space β] {p : Prop} {f : β → α} (hf : measurable f):
   measurable (λ b, ⨅ h : p, f b) :=
 classical.by_cases
   (assume h : p, begin convert hf, funext, exact infi_pos h end )
@@ -352,17 +352,17 @@ end
 end real
 
 namespace nnreal
-open filter measure_theory 
+open filter measure_theory
 
-lemma measurable_add [measurable_space α] {f : α → nnreal} {g : α → nnreal} : 
+lemma measurable_add [measurable_space α] {f : α → nnreal} {g : α → nnreal} :
   measurable f → measurable g → measurable (λa, f a + g a) :=
 measurable_of_continuous2 continuous_add'
 
-lemma measurable_sub [measurable_space α] {f g: α → nnreal} 
-  (hf : measurable f) (hg : measurable g) : measurable (λ a, f a - g a) := 
+lemma measurable_sub [measurable_space α] {f g: α → nnreal}
+  (hf : measurable f) (hg : measurable g) : measurable (λ a, f a - g a) :=
 measurable_of_continuous2 continuous_sub' hf hg
 
-lemma measurable_mul [measurable_space α] {f : α → nnreal} {g : α → nnreal} : 
+lemma measurable_mul [measurable_space α] {f : α → nnreal} {g : α → nnreal} :
   measurable f → measurable g → measurable (λa, f a * g a) :=
 measurable_of_continuous2 continuous_mul'
 
@@ -467,14 +467,14 @@ begin
   { simp [measurable_const] }
 end
 
-lemma measurable_sub {α : Type*} [measurable_space α] {f g : α → ennreal} : 
+lemma measurable_sub {α : Type*} [measurable_space α] {f g : α → ennreal} :
   measurable f → measurable g → measurable (λa, f a - g a) :=
 begin
   refine measurable_of_measurable_nnreal_nnreal (has_sub.sub) _ _ _,
   { simp only [ennreal.coe_sub.symm],
-    exact measurable_coe.comp 
+    exact measurable_coe.comp
       (nnreal.measurable_sub (measurable_fst measurable_id) (measurable_snd measurable_id)) },
-  { simp [measurable_const] }, 
+  { simp [measurable_const] },
   { simp [measurable_const] }
 end
 

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -584,9 +584,15 @@ eq.trans supr_union $ congr_arg (λx:α, x ⊔ (⨆x∈s, f x)) supr_supr_eq_lef
 show (⨅ x ∈ insert b (∅ : set β), f x) = f b,
   by simp
 
+@[simp] theorem infi_pair {f : β → α} {a b : β} : (⨅ x ∈ ({a, b} : set β), f x) = f a ⊓ f b :=
+by { rw [show {a, b} = (insert b {a} : set β), from rfl, infi_insert, inf_comm], simp }
+
 @[simp] theorem supr_singleton {f : β → α} {b : β} : (⨆ x ∈ (singleton b : set β), f x) = f b :=
 show (⨆ x ∈ insert b (∅ : set β), f x) = f b,
   by simp
+
+@[simp] theorem supr_pair {f : β → α} {a b : β} : (⨆ x ∈ ({a, b} : set β), f x) = f a ⊔ f b :=
+by { rw [show {a, b} = (insert b {a} : set β), from rfl, supr_insert, sup_comm], simp }
 
 lemma infi_image {γ} {f : β → γ} {g : γ → α} {t : set β} :
   (⨅ c ∈ f '' t, g c) = (⨅ b ∈ t, g (f b)) :=

--- a/src/topology/Top/adjunctions.lean
+++ b/src/topology/Top/adjunctions.lean
@@ -15,19 +15,19 @@ namespace Top
 def adj₁ : discrete ⊣ forget :=
 { hom_equiv := λ X Y,
   { to_fun := λ f, f,
-    inv_fun := λ f, ⟨f, continuous_top⟩,
+    inv_fun := λ f, ⟨f, continuous_bot⟩,
     left_inv := by tidy,
     right_inv := by tidy },
   unit := { app := λ X, id },
-  counit := { app := λ X, ⟨id, continuous_top⟩ } }
+  counit := { app := λ X, ⟨id, continuous_bot⟩ } }
 
 def adj₂ : forget ⊣ trivial :=
 { hom_equiv := λ X Y,
-  { to_fun := λ f, ⟨f, continuous_bot⟩,
+  { to_fun := λ f, ⟨f, continuous_top⟩,
     inv_fun := λ f, f,
     left_inv := by tidy,
     right_inv := by tidy },
-  unit := { app := λ X, ⟨id, continuous_bot⟩ },
+  unit := { app := λ X, ⟨id, continuous_top⟩ },
   counit := { app := λ X, id } }
 
 end Top

--- a/src/topology/Top/basic.lean
+++ b/src/topology/Top/basic.lean
@@ -24,11 +24,11 @@ def of (X : Type u) [topological_space X] : Top := ⟨X⟩
 abbreviation forget : Top.{u} ⥤ Type u := forget
 
 def discrete : Type u ⥤ Top.{u} :=
-{ obj := λ X, ⟨X, ⊤⟩,
-  map := λ X Y f, ⟨f, continuous_top⟩ }
-
-def trivial : Type u ⥤ Top.{u} :=
 { obj := λ X, ⟨X, ⊥⟩,
   map := λ X Y f, ⟨f, continuous_bot⟩ }
+
+def trivial : Type u ⥤ Top.{u} :=
+{ obj := λ X, ⟨X, ⊤⟩,
+  map := λ X Y f, ⟨f, continuous_top⟩ }
 
 end Top

--- a/src/topology/Top/limits.lean
+++ b/src/topology/Top/limits.lean
@@ -17,15 +17,15 @@ namespace Top
 variables {J : Type u} [small_category J]
 
 def limit (F : J ⥤ Top.{u}) : cone F :=
-{ X := ⟨limit (F ⋙ forget), ⨆ j, (F.obj j).str.induced (limit.π (F ⋙ forget) j)⟩,
+{ X := ⟨limit (F ⋙ forget), ⨅j, (F.obj j).str.induced (limit.π (F ⋙ forget) j)⟩,
   π :=
-  { app := λ j, ⟨limit.π (F ⋙ forget) j, continuous_iff_induced_le.mpr (lattice.le_supr _ j)⟩,
+  { app := λ j, ⟨limit.π (F ⋙ forget) j, continuous_iff_le_induced.mpr (lattice.infi_le _ _)⟩,
     naturality' := λ j j' f, subtype.eq ((limit.cone (F ⋙ forget)).π.naturality f) } }
 
 def limit_is_limit (F : J ⥤ Top.{u}) : is_limit (limit F) :=
-by refine is_limit.of_faithful forget (limit.is_limit _) (λ s, ⟨_, _⟩) (λ s, rfl);
-   exact continuous_iff_le_coinduced.mpr (lattice.supr_le $ λ j,
-     induced_le_iff_le_coinduced.mpr $ continuous_iff_le_coinduced.mp (s.π.app j).property)
+by { refine is_limit.of_faithful forget (limit.is_limit _) (λ s, ⟨_, _⟩) (λ s, rfl),
+     exact continuous_iff_coinduced_le.mpr (lattice.le_infi $ λ j,
+       coinduced_le_iff_le_induced.mp $ continuous_iff_coinduced_le.mp (s.π.app j).property) }
 
 instance Top_has_limits : has_limits.{u} Top.{u} :=
 { has_limits_of_shape := λ J 𝒥,
@@ -38,15 +38,15 @@ instance forget_preserves_limits : preserves_limits (forget : Top.{u} ⥤ Type u
       (limit.is_limit F) (limit.is_limit (F ⋙ forget)) } }
 
 def colimit (F : J ⥤ Top.{u}) : cocone F :=
-{ X := ⟨colimit (F ⋙ forget), ⨅ j, (F.obj j).str.coinduced (colimit.ι (F ⋙ forget) j)⟩,
+{ X := ⟨colimit (F ⋙ forget), ⨆ j, (F.obj j).str.coinduced (colimit.ι (F ⋙ forget) j)⟩,
   ι :=
-  { app := λ j, ⟨colimit.ι (F ⋙ forget) j, continuous_iff_le_coinduced.mpr (lattice.infi_le _ j)⟩,
+  { app := λ j, ⟨colimit.ι (F ⋙ forget) j, continuous_iff_coinduced_le.mpr (lattice.le_supr _ j)⟩,
     naturality' := λ j j' f, subtype.eq ((colimit.cocone (F ⋙ forget)).ι.naturality f) } }
 
 def colimit_is_colimit (F : J ⥤ Top.{u}) : is_colimit (colimit F) :=
-by refine is_colimit.of_faithful forget (colimit.is_colimit _) (λ s, ⟨_, _⟩) (λ s, rfl);
-   exact continuous_iff_induced_le.mpr (lattice.le_infi $ λ j,
-     induced_le_iff_le_coinduced.mpr $ continuous_iff_le_coinduced.mp (s.ι.app j).property)
+by { refine is_colimit.of_faithful forget (colimit.is_colimit _) (λ s, ⟨_, _⟩) (λ s, rfl),
+     exact continuous_iff_le_induced.mpr (lattice.supr_le $ λ j,
+       coinduced_le_iff_le_induced.mp $ continuous_iff_coinduced_le.mp (s.ι.app j).property) }
 
 instance Top_has_colimits : has_colimits.{u} Top.{u} :=
 { has_colimits_of_shape := λ J 𝒥,

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -271,6 +271,14 @@ begin
   letI := induced f ta,
   refine ⟨eq_of_nhds_eq_nhds (λ a, _)⟩,
   rw [nhds_induced_eq_comap, nhds_generate_from, @nhds_eq_orderable β _ _], apply le_antisymm,
+  { refine le_infi (λ s, le_infi $ λ hs, le_principal_iff.2 _),
+    rcases hs with ⟨ab, b, rfl|rfl⟩,
+    { exact mem_comap_sets.2 ⟨{x | f b < x},
+        mem_inf_sets_of_left $ mem_infi_sets _ $ mem_infi_sets (hf.2 ab) $ mem_principal_self _,
+        λ x, hf.1⟩ },
+    { exact mem_comap_sets.2 ⟨{x | x < f b},
+        mem_inf_sets_of_right $ mem_infi_sets _ $ mem_infi_sets (hf.2 ab) $ mem_principal_self _,
+        λ x, hf.1⟩ } },
   { rw [← map_le_iff_le_comap],
     refine le_inf _ _; refine le_infi (λ x, le_infi $ λ h, le_principal_iff.2 _); simp,
     { rcases H₁ h with ⟨b, ab, xb⟩,
@@ -279,14 +287,6 @@ begin
     { rcases H₂ h with ⟨b, ab, xb⟩,
       refine mem_infi_sets _ (mem_infi_sets ⟨ab, b, or.inr rfl⟩ (mem_principal_sets.2 _)),
       exact λ c hc, lt_of_lt_of_le (hf.2 hc) xb } },
-  refine le_infi (λ s, le_infi $ λ hs, le_principal_iff.2 _),
-  rcases hs with ⟨ab, b, rfl|rfl⟩,
-  { exact mem_comap_sets.2 ⟨{x | f b < x},
-      mem_inf_sets_of_left $ mem_infi_sets _ $ mem_infi_sets (hf.2 ab) $ mem_principal_self _,
-      λ x, hf.1⟩ },
-  { exact mem_comap_sets.2 ⟨{x | x < f b},
-      mem_inf_sets_of_right $ mem_infi_sets _ $ mem_infi_sets (hf.2 ab) $ mem_principal_self _,
-      λ x, hf.1⟩ }
 end
 
 theorem induced_orderable_topology {α : Type u} {β : Type v}

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -40,13 +40,13 @@ let b' := (λf, ⋂₀ f) '' {f:set (set α) | finite f ∧ f ⊆ s ∧ ⋂₀ f
     by rw sInter_empty; exact nonempty_iff_univ_ne_empty.1 ⟨a⟩⟩, sInter_empty⟩, mem_univ _⟩,
  have generate_from s = generate_from b',
     from le_antisymm
-      (generate_from_le $ assume s hs,
+      (le_generate_from $ assume u ⟨t, ⟨hft, htb, ne⟩, eq⟩,
+        eq ▸ @is_open_sInter _ (generate_from s) _ hft (assume s hs, generate_open.basic _ $ htb hs))
+      (le_generate_from $ assume s hs,
         by_cases
           (assume : s = ∅, by rw [this]; apply @is_open_empty _ _)
           (assume : s ≠ ∅, generate_open.basic _ ⟨{s}, ⟨finite_singleton s, singleton_subset_iff.2 hs,
-            by rwa [sInter_singleton]⟩, sInter_singleton s⟩))
-      (generate_from_le $ assume u ⟨t, ⟨hft, htb, ne⟩, eq⟩,
-        eq ▸ @is_open_sInter _ (generate_from s) _ hft (assume s hs, generate_open.basic _ $ htb hs)),
+            by rwa [sInter_singleton]⟩, sInter_singleton s⟩)),
   this ▸ hs⟩
 
 lemma is_topological_basis_of_open_of_nhds {s : set (set α)}
@@ -60,11 +60,11 @@ lemma is_topological_basis_of_open_of_nhds {s : set (set α)}
     let ⟨u, h₁, h₂, _⟩ := h_nhds a univ trivial (is_open_univ _) in
     ⟨u, h₁, h₂⟩,
   le_antisymm
+    (le_generate_from h_open)
     (assume u hu,
       (@is_open_iff_nhds α (generate_from _) _).mpr $ assume a hau,
         let ⟨v, hvs, hav, hvu⟩ := h_nhds a u hau hu in
-        by rw nhds_generate_from; exact infi_le_of_le v (infi_le_of_le ⟨hav, hvs⟩ $ le_principal_iff.2 hvu))
-    (generate_from_le h_open)⟩
+        by rw nhds_generate_from; exact infi_le_of_le v (infi_le_of_le ⟨hav, hvs⟩ $ le_principal_iff.2 hvu))⟩
 
 lemma mem_nhds_of_is_topological_basis {a : α} {s : set α} {b : set (set α)}
   (hb : is_topological_basis b) : s ∈ nhds a ↔ ∃t∈b, a ∈ t ∧ t ⊆ s :=

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -34,7 +34,8 @@ instance : second_countable_topology ennreal :=
 ⟨⟨⋃q ≥ (0:ℚ), {{a : ennreal | a < nnreal.of_real q}, {a : ennreal | ↑(nnreal.of_real q) < a}},
   countable_bUnion (countable_encodable _) $ assume a ha, countable_insert (countable_singleton _),
   le_antisymm
-    (generate_from_le $ λ s h, begin
+    (le_generate_from $ by simp [or_imp_distrib, is_open_lt', is_open_gt'] {contextual := tt})
+    (le_generate_from $ λ s h, begin
       rcases h with ⟨a, hs | hs⟩;
       [ rw show s = ⋃q∈{q:ℚ | 0 ≤ q ∧ a < nnreal.of_real q}, {b | ↑(nnreal.of_real q) < b},
            from set.ext (assume b, by simp [hs, @ennreal.lt_iff_exists_rat_btwn a b, and_assoc]),
@@ -43,26 +44,25 @@ instance : second_countable_topology ennreal :=
       { apply is_open_Union, intro q,
         apply is_open_Union, intro hq,
         exact generate_open.basic _ (mem_bUnion hq.1 $ by simp) }
-    end)
-    (generate_from_le $ by simp [or_imp_distrib, is_open_lt', is_open_gt'] {contextual := tt})⟩⟩
+    end)⟩⟩
 
 lemma embedding_coe : embedding (coe : nnreal → ennreal) :=
 and.intro (assume a b, coe_eq_coe.1) $
 begin
   refine le_antisymm _ _,
-  { rw [orderable_topology.topology_eq_generate_intervals nnreal],
-    refine generate_from_le (assume s ha, _),
-    rcases ha with ⟨a, rfl | rfl⟩,
-    exact ⟨{b : ennreal | ↑a < b}, @is_open_lt' ennreal ennreal.topological_space _ _ _, by simp⟩,
-    exact ⟨{b : ennreal | b < ↑a}, @is_open_gt' ennreal ennreal.topological_space _ _ _, by simp⟩, },
   { rw [orderable_topology.topology_eq_generate_intervals ennreal,
-      induced_le_iff_le_coinduced],
-    refine generate_from_le (assume s ha, _),
+      ← coinduced_le_iff_le_induced],
+    refine le_generate_from (assume s ha, _),
     rcases ha with ⟨a, rfl | rfl⟩,
     show is_open {b : nnreal | a < ↑b},
     { cases a; simp [none_eq_top, some_eq_coe, is_open_lt'] },
     show is_open {b : nnreal | ↑b < a},
-    { cases a; simp [none_eq_top, some_eq_coe, is_open_gt', is_open_const] } }
+    { cases a; simp [none_eq_top, some_eq_coe, is_open_gt', is_open_const] } },
+  { rw [orderable_topology.topology_eq_generate_intervals nnreal],
+    refine le_generate_from (assume s ha, _),
+    rcases ha with ⟨a, rfl | rfl⟩,
+    exact ⟨{b : ennreal | ↑a < b}, @is_open_lt' ennreal ennreal.topological_space _ _ _, by simp⟩,
+    exact ⟨{b : ennreal | b < ↑a}, @is_open_gt' ennreal ennreal.topological_space _ _ _, by simp⟩, },
 end
 
 lemma is_open_ne_top : is_open {a : ennreal | a ≠ ⊤} :=

--- a/src/topology/instances/nnreal.lean
+++ b/src/topology/instances/nnreal.lean
@@ -29,10 +29,15 @@ topological_space.subtype.second_countable_topology _ _
 
 instance : orderable_topology ℝ≥0 :=
 ⟨ le_antisymm
+    (le_generate_from $ assume s hs,
+    match s, hs with
+    | _, ⟨⟨a, ha⟩, or.inl rfl⟩ := ⟨{b : ℝ | a < b}, is_open_lt' a, rfl⟩
+    | _, ⟨⟨a, ha⟩, or.inr rfl⟩ := ⟨{b : ℝ | b < a}, is_open_gt' a, set.ext $ assume b, iff.refl _⟩
+    end)
     begin
-      apply induced_le_iff_le_coinduced.2,
+      apply coinduced_le_iff_le_induced.1,
       rw [orderable_topology.topology_eq_generate_intervals ℝ],
-      apply generate_from_le,
+      apply le_generate_from,
       assume s hs,
       rcases hs with ⟨a, rfl | rfl⟩,
       { show topological_space.generate_open _ {b : ℝ≥0 | a < b },
@@ -51,12 +56,7 @@ instance : orderable_topology ℝ≥0 :=
               show 0 ≤ a, from le_trans b.2 (le_of_lt hb)),
           rw [this],
           apply @is_open_empty } },
-    end
-    (generate_from_le $ assume s hs,
-    match s, hs with
-    | _, ⟨⟨a, ha⟩, or.inl rfl⟩ := ⟨{b : ℝ | a < b}, is_open_lt' a, rfl⟩
-    | _, ⟨⟨a, ha⟩, or.inr rfl⟩ := ⟨{b : ℝ | b < a}, is_open_gt' a, set.ext $ assume b, iff.refl _⟩
-    end) ⟩
+    end⟩
 
 section coe
 variable {α : Type*}
@@ -81,14 +81,14 @@ lemma tendsto_sub {f : filter α} {m n : α → nnreal} {r p : nnreal}
   tendsto (λa, m a - n a) f (nhds (r - p)) :=
 tendsto_of_real $ tendsto_sub (tendsto_coe.2 hm) (tendsto_coe.2 hn)
 
-lemma continuous_sub' : continuous (λp:nnreal×nnreal, p.1 - p.2) := 
-  continuous_subtype_mk _ (continuous_max 
-    (continuous_sub (continuous.comp continuous_coe continuous_fst) 
-                    (continuous.comp continuous_coe continuous_snd)) 
+lemma continuous_sub' : continuous (λp:nnreal×nnreal, p.1 - p.2) :=
+  continuous_subtype_mk _ (continuous_max
+    (continuous_sub (continuous.comp continuous_coe continuous_fst)
+                    (continuous.comp continuous_coe continuous_snd))
                                                       continuous_const)
 
-lemma continuous_sub [topological_space α] {f g : α → nnreal} 
-  (hf : continuous f) (hg : continuous g) : continuous (λ a, f a - g a) := 
+lemma continuous_sub [topological_space α] {f g : α → nnreal}
+  (hf : continuous f) (hg : continuous g) : continuous (λ a, f a - g a) :=
 continuous_sub'.comp (hf.prod_mk hg)
 
 lemma has_sum_coe {f : α → nnreal} {r : nnreal} : has_sum (λa, (f a : ℝ)) (r : ℝ) ↔ has_sum f r :=

--- a/src/topology/maps.lean
+++ b/src/topology/maps.lean
@@ -33,15 +33,15 @@ lemma embedding_prod_mk {f : α → β} {g : γ → δ} (hf : embedding f) (hg :
   embedding (λx:α×γ, (f x.1, g x.2)) :=
 ⟨assume ⟨x₁, x₂⟩ ⟨y₁, y₂⟩, by simp; exact assume h₁ h₂, ⟨hf.left h₁, hg.left h₂⟩,
   by rw [prod.topological_space, prod.topological_space, hf.right, hg.right,
-         induced_compose, induced_compose, induced_sup, induced_compose, induced_compose]⟩
+         induced_compose, induced_compose, induced_inf, induced_compose, induced_compose]⟩
 
 lemma embedding_of_embedding_compose {f : α → β} {g : β → γ} (hf : continuous f) (hg : continuous g)
   (hgf : embedding (g ∘ f)) : embedding f :=
 ⟨assume a₁ a₂ h, hgf.left $ by simp [h, (∘)],
   le_antisymm
-    (by rw [hgf.right, ← continuous_iff_induced_le];
-        apply hg.comp continuous_induced_dom)
-    (by rwa ← continuous_iff_induced_le)⟩
+    (by rwa ← continuous_iff_le_induced)
+    (by rw [hgf.right, ← continuous_iff_le_induced];
+        apply hg.comp continuous_induced_dom)⟩
 
 lemma embedding_open {f : α → β} {s : set α}
   (hf : embedding f) (h : is_open (range f)) (hs : is_open s) : is_open (f '' s) :=
@@ -276,13 +276,13 @@ protected lemma of_quotient_map_compose {f : α → β} {g : β → γ}
   (hgf : quotient_map (g ∘ f)) : quotient_map g :=
 ⟨assume b, let ⟨a, h⟩ := hgf.left b in ⟨f a, h⟩,
   le_antisymm
-    (by rwa ← continuous_iff_le_coinduced)
-    (by rw [hgf.right, ← continuous_iff_le_coinduced];
-        apply continuous_coinduced_rng.comp hf)⟩
+    (by rw [hgf.right, ← continuous_iff_coinduced_le];
+        apply continuous_coinduced_rng.comp hf)
+    (by rwa ← continuous_iff_coinduced_le)⟩
 
 protected lemma continuous_iff {f : α → β} {g : β → γ} (hf : quotient_map f) :
   continuous g ↔ continuous (g ∘ f) :=
-by rw [continuous_iff_le_coinduced, continuous_iff_le_coinduced, hf.right, coinduced_compose]
+by rw [continuous_iff_coinduced_le, continuous_iff_coinduced_le, hf.right, coinduced_compose]
 
 protected lemma continuous {f : α → β} (hf : quotient_map f) : continuous f :=
 hf.continuous_iff.mp continuous_id
@@ -394,7 +394,7 @@ lemma closed_embedding_of_continuous_injective_closed {f : α → β} (h₁ : co
   (h₂ : function.injective f) (h₃ : is_closed_map f) : closed_embedding f :=
 begin
   refine ⟨⟨h₂, _⟩, by convert h₃ univ is_closed_univ; simp⟩,
-  apply le_antisymm _ (continuous_iff_induced_le.mp h₁),
+  apply le_antisymm (continuous_iff_le_induced.mp h₁) _,
   intro s',
   change is_open _ ≤ is_open _,
   rw [←is_closed_compl_iff, ←is_closed_compl_iff],

--- a/src/topology/order.lean
+++ b/src/topology/order.lean
@@ -95,10 +95,7 @@ def tmp_order : partial_order (topological_space α) :=
 
 local attribute [instance] tmp_order
 
--- the following name looks wrong but will become correct at the end of the section when
--- using the permanent partial order
-
-lemma le_generate_from_iff_subset_is_open {g : set (set α)} {t : topological_space α} :
+private lemma generate_from_le_iff_subset_is_open {g : set (set α)} {t : topological_space α} :
   topological_space.generate_from g ≤ t ↔ g ⊆ {s | t.is_open s} :=
 iff.intro
   (assume ht s hs, ht _ $ topological_space.generate_open.basic s hs)
@@ -119,10 +116,10 @@ topological_space_eq hs.symm
 
 def gi_generate_from (α : Type*) :
   galois_insertion topological_space.generate_from (λt:topological_space α, {s | t.is_open s}) :=
-{ gc        := assume g t, le_generate_from_iff_subset_is_open,
+{ gc        := assume g t, generate_from_le_iff_subset_is_open,
   le_l_u    := assume ts s hs, topological_space.generate_open.basic s hs,
   choice    := λg hg, mk_of_closure g
-    (subset.antisymm hg $ le_generate_from_iff_subset_is_open.1 $ le_refl _),
+    (subset.antisymm hg $ generate_from_le_iff_subset_is_open.1 $ le_refl _),
   choice_eq := assume s hs, mk_of_closure_sets }
 
 lemma generate_from_mono {α} {g₁ g₂ : set (set α)} (h : g₁ ⊆ g₂) :
@@ -138,6 +135,10 @@ instance : partial_order (topological_space α) :=
   le_antisymm := assume t s h₁ h₂, topological_space_eq $ le_antisymm h₂ h₁,
   le_refl     := assume t, le_refl t.is_open,
   le_trans    := assume a b c h₁ h₂, le_trans h₂ h₁ }
+
+lemma le_generate_from_iff_subset_is_open {g : set (set α)} {t : topological_space α} :
+  t ≤ topological_space.generate_from g ↔ g ⊆ {s | t.is_open s} :=
+generate_from_le_iff_subset_is_open
 
 instance : complete_lattice (topological_space α) :=
 @order_dual.lattice.complete_lattice _ old_complete_lattice

--- a/src/topology/order.lean
+++ b/src/topology/order.lean
@@ -141,7 +141,7 @@ lemma le_generate_from_iff_subset_is_open {g : set (set α)} {t : topological_sp
 generate_from_le_iff_subset_is_open
 
 instance : complete_lattice (topological_space α) :=
-@order_dual.lattice.complete_lattice _ old_complete_lattice
+@order_dual.lattice.complete_lattice _ tmp_complete_lattice
 
 class discrete_topology (α : Type*) [t : topological_space α] : Prop :=
 (eq_bot : t = ⊥)

--- a/src/topology/order.lean
+++ b/src/topology/order.lean
@@ -82,13 +82,23 @@ section lattice
 
 variables {α : Type u} {β : Type v}
 
-instance : partial_order (topological_space α) :=
+/- The following partial order will be convenient in order to get a complete
+   lattice instance via the Galois insertion method, but the partial order
+   that will be used elsewhere is the dual one, defined at the end of this
+   section. -/
+
+def tmp_order : partial_order (topological_space α) :=
 { le          := λt s, t.is_open ≤ s.is_open,
   le_antisymm := assume t s h₁ h₂, topological_space_eq $ le_antisymm h₁ h₂,
   le_refl     := assume t, le_refl t.is_open,
   le_trans    := assume a b c h₁ h₂, @le_trans _ _ a.is_open b.is_open c.is_open h₁ h₂ }
 
-lemma generate_from_le_iff_subset_is_open {g : set (set α)} {t : topological_space α} :
+local attribute [instance] tmp_order
+
+-- the following name looks wrong but will become correct at the end of the section when
+-- using the permanent partial order
+
+lemma le_generate_from_iff_subset_is_open {g : set (set α)} {t : topological_space α} :
   topological_space.generate_from g ≤ t ↔ g ⊆ {s | t.is_open s} :=
 iff.intro
   (assume ht s hs, ht _ $ topological_space.generate_open.basic s hs)
@@ -109,30 +119,40 @@ topological_space_eq hs.symm
 
 def gi_generate_from (α : Type*) :
   galois_insertion topological_space.generate_from (λt:topological_space α, {s | t.is_open s}) :=
-{ gc        := assume g t, generate_from_le_iff_subset_is_open,
+{ gc        := assume g t, le_generate_from_iff_subset_is_open,
   le_l_u    := assume ts s hs, topological_space.generate_open.basic s hs,
   choice    := λg hg, mk_of_closure g
-    (subset.antisymm hg $ generate_from_le_iff_subset_is_open.1 $ le_refl _),
+    (subset.antisymm hg $ le_generate_from_iff_subset_is_open.1 $ le_refl _),
   choice_eq := assume s hs, mk_of_closure_sets }
 
 lemma generate_from_mono {α} {g₁ g₂ : set (set α)} (h : g₁ ⊆ g₂) :
   topological_space.generate_from g₁ ≤ topological_space.generate_from g₂ :=
 (gi_generate_from _).gc.monotone_l h
 
-instance {α : Type u} : complete_lattice (topological_space α) :=
+def old_complete_lattice {α : Type u} : complete_lattice (topological_space α) :=
 (gi_generate_from α).lift_complete_lattice
 
+
+instance : partial_order (topological_space α) :=
+{ le          := λ t s, s.is_open ≤ t.is_open,
+  le_antisymm := assume t s h₁ h₂, topological_space_eq $ le_antisymm h₂ h₁,
+  le_refl     := assume t, le_refl t.is_open,
+  le_trans    := assume a b c h₁ h₂, le_trans h₂ h₁ }
+
+instance : complete_lattice (topological_space α) :=
+@order_dual.lattice.complete_lattice _ old_complete_lattice
+
 class discrete_topology (α : Type*) [t : topological_space α] : Prop :=
-(eq_top : t = ⊤)
+(eq_bot : t = ⊥)
 
 @[simp] lemma is_open_discrete [topological_space α] [discrete_topology α] (s : set α) :
   is_open s :=
-(discrete_topology.eq_top α).symm ▸ trivial
+(discrete_topology.eq_bot α).symm ▸ trivial
 
 lemma continuous_of_discrete_topology [topological_space α] [discrete_topology α] [topological_space β] {f : α → β} : continuous f :=
 λs hs, is_open_discrete _
 
-lemma nhds_top (α : Type*) : (@nhds α ⊤) = pure :=
+lemma nhds_bot (α : Type*) : (@nhds α ⊥) = pure :=
 begin
   ext a s,
   rw [mem_nhds_sets_iff, mem_pure_iff],
@@ -142,24 +162,23 @@ begin
 end
 
 lemma nhds_discrete (α : Type*) [topological_space α] [discrete_topology α] : (@nhds α _) = pure :=
-(discrete_topology.eq_top α).symm ▸ nhds_top α
+(discrete_topology.eq_bot α).symm ▸ nhds_bot α
 
-lemma le_of_nhds_le_nhds {t₁ t₂ : topological_space α} (h : ∀x, @nhds α t₂ x ≤ @nhds α t₁ x) :
+lemma le_of_nhds_le_nhds {t₁ t₂ : topological_space α} (h : ∀x, @nhds α t₁ x ≤ @nhds α t₂ x) :
   t₁ ≤ t₂ :=
-assume s, show @is_open α t₁ s → @is_open α t₂ s,
-  begin simp only [is_open_iff_nhds, le_principal_iff];
-    exact assume hs a ha, h _ $ hs _ ha end
+assume s, show @is_open α t₂ s → @is_open α t₁ s,
+  by { simp only [is_open_iff_nhds, le_principal_iff],  exact assume hs a ha, h _ $ hs _ ha }
 
-lemma eq_of_nhds_eq_nhds {t₁ t₂ : topological_space α} (h : ∀x, @nhds α t₂ x = @nhds α t₁ x) :
+lemma eq_of_nhds_eq_nhds {t₁ t₂ : topological_space α} (h : ∀x, @nhds α t₁ x = @nhds α t₂ x) :
   t₁ = t₂ :=
 le_antisymm
   (le_of_nhds_le_nhds $ assume x, le_of_eq $ h x)
   (le_of_nhds_le_nhds $ assume x, le_of_eq $ (h x).symm)
 
-lemma eq_top_of_singletons_open {t : topological_space α} (h : ∀ x, t.is_open {x}) : t = ⊤ :=
-top_unique $ le_of_nhds_le_nhds $ assume x,
+lemma eq_bot_of_singletons_open {t : topological_space α} (h : ∀ x, t.is_open {x}) : t = ⊥ :=
+bot_unique  $ le_of_nhds_le_nhds $ assume x,
   have nhds x ≤ pure x, from nhds_le_of_le (mem_singleton _) (h x) (by simp),
-  le_trans this (@pure_le_nhds _ ⊤ x)
+  le_trans this (@pure_le_nhds _ ⊥ x)
 
 end lattice
 
@@ -213,41 +232,41 @@ iff.refl _
 
 variables {t t₁ t₂ : topological_space α} {t' : topological_space β} {f : α → β} {g : β → α}
 
-lemma induced_le_iff_le_coinduced {f : α → β } {tα : topological_space α} {tβ : topological_space β} :
-  tβ.induced f ≤ tα ↔ tβ ≤ tα.coinduced f :=
+lemma coinduced_le_iff_le_induced {f : α → β } {tα : topological_space α} {tβ : topological_space β} :
+  tα.coinduced f ≤ tβ ↔ tα ≤ tβ.induced f :=
 iff.intro
-  (assume h s hs, show tα.is_open (f ⁻¹' s), from h _ ⟨s, hs, rfl⟩)
   (assume h s ⟨t, ht, hst⟩, hst ▸ h _ ht)
+  (assume h s hs, show tα.is_open (f ⁻¹' s), from h _ ⟨s, hs, rfl⟩)
 
-lemma gc_induced_coinduced (f : α → β) :
-  galois_connection (topological_space.induced f) (topological_space.coinduced f) :=
-assume f g, induced_le_iff_le_coinduced
+lemma gc_coinduced_induced (f : α → β) :
+  galois_connection (topological_space.coinduced f) (topological_space.induced f) :=
+assume f g, coinduced_le_iff_le_induced
 
 lemma induced_mono (h : t₁ ≤ t₂) : t₁.induced g ≤ t₂.induced g :=
-(gc_induced_coinduced g).monotone_l h
+(gc_coinduced_induced g).monotone_u h
 
 lemma coinduced_mono (h : t₁ ≤ t₂) : t₁.coinduced f ≤ t₂.coinduced f :=
-(gc_induced_coinduced f).monotone_u h
+(gc_coinduced_induced f).monotone_l h
 
-@[simp] lemma induced_bot : (⊥ : topological_space α).induced g = ⊥ :=
-(gc_induced_coinduced g).l_bot
+@[simp] lemma induced_top : (⊤ : topological_space α).induced g = ⊤ :=
+(gc_coinduced_induced g).u_top
 
-@[simp] lemma induced_sup : (t₁ ⊔ t₂).induced g = t₁.induced g ⊔ t₂.induced g :=
-(gc_induced_coinduced g).l_sup
+@[simp] lemma induced_inf : (t₁ ⊓ t₂).induced g = t₁.induced g ⊓ t₂.induced g :=
+(gc_coinduced_induced g).u_inf
 
-@[simp] lemma induced_supr {ι : Sort w} {t : ι → topological_space α} :
-  (⨆i, t i).induced g = (⨆i, (t i).induced g) :=
-(gc_induced_coinduced g).l_supr
+@[simp] lemma induced_infi {ι : Sort w} {t : ι → topological_space α} :
+  (⨅i, t i).induced g = (⨅i, (t i).induced g) :=
+(gc_coinduced_induced g).u_infi
 
-@[simp] lemma coinduced_top : (⊤ : topological_space α).coinduced f = ⊤ :=
-(gc_induced_coinduced f).u_top
+@[simp] lemma coinduced_bot : (⊥ : topological_space α).coinduced f = ⊥ :=
+(gc_coinduced_induced f).l_bot
 
-@[simp] lemma coinduced_inf : (t₁ ⊓ t₂).coinduced f = t₁.coinduced f ⊓ t₂.coinduced f :=
-(gc_induced_coinduced f).u_inf
+@[simp] lemma coinduced_sup : (t₁ ⊔ t₂).coinduced f = t₁.coinduced f ⊔ t₂.coinduced f :=
+(gc_coinduced_induced f).l_sup
 
-@[simp] lemma coinduced_infi {ι : Sort w} {t : ι → topological_space α} :
-  (⨅i, t i).coinduced f = (⨅i, (t i).coinduced f) :=
-(gc_induced_coinduced f).u_infi
+@[simp] lemma coinduced_supr {ι : Sort w} {t : ι → topological_space α} :
+  (⨆i, t i).coinduced f = (⨆i, (t i).coinduced f) :=
+(gc_coinduced_induced f).l_supr
 
 lemma induced_id [t : topological_space α] : t.induced id = t :=
 topological_space_eq $ funext $ assume s, propext $
@@ -277,15 +296,15 @@ variables {α : Type u} {β : Type v}
 instance inhabited_topological_space {α : Type u} : inhabited (topological_space α) :=
 ⟨⊤⟩
 
-instance : topological_space empty := ⊤
+instance : topological_space empty := ⊥
 instance : discrete_topology empty := ⟨rfl⟩
-instance : topological_space unit := ⊤
+instance : topological_space unit := ⊥
 instance : discrete_topology unit := ⟨rfl⟩
-instance : topological_space bool := ⊤
+instance : topological_space bool := ⊥
 instance : discrete_topology bool := ⟨rfl⟩
-instance : topological_space ℕ := ⊤
+instance : topological_space ℕ := ⊥
 instance : discrete_topology ℕ := ⟨rfl⟩
-instance : topological_space ℤ := ⊤
+instance : topological_space ℤ := ⊥
 instance : discrete_topology ℤ := ⟨rfl⟩
 
 instance sierpinski_space : topological_space Prop :=
@@ -301,17 +320,17 @@ instance {s : setoid α} [t : topological_space α] : topological_space (quotien
 coinduced quotient.mk t
 
 instance [t₁ : topological_space α] [t₂ : topological_space β] : topological_space (α × β) :=
-induced prod.fst t₁ ⊔ induced prod.snd t₂
+induced prod.fst t₁ ⊓ induced prod.snd t₂
 
 instance [t₁ : topological_space α] [t₂ : topological_space β] : topological_space (α ⊕ β) :=
-coinduced sum.inl t₁ ⊓ coinduced sum.inr t₂
+coinduced sum.inl t₁ ⊔ coinduced sum.inr t₂
 
 instance {β : α → Type v} [t₂ : Πa, topological_space (β a)] : topological_space (sigma β) :=
-⨅a, coinduced (sigma.mk a) (t₂ a)
+⨆a, coinduced (sigma.mk a) (t₂ a)
 
 instance Pi.topological_space {β : α → Type v} [t₂ : Πa, topological_space (β a)] :
   topological_space (Πa, β a) :=
-⨆a, induced (λf, f a) (t₂ a)
+⨅a, induced (λf, f a) (t₂ a)
 
 instance [topological_space α] : topological_space (list α) :=
 topological_space.mk_of_nhds (traverse nhds)
@@ -370,16 +389,16 @@ eq_univ_of_forall $ λ x, begin
   exact ne_empty_of_mem ⟨w_in_V, mem_image_of_mem quotient.mk w_in_range⟩
 end
 
-lemma generate_from_le {t : topological_space α} { g : set (set α) } (h : ∀s∈g, is_open s) :
-  generate_from g ≤ t :=
-generate_from_le_iff_subset_is_open.2 h
+lemma le_generate_from {t : topological_space α} { g : set (set α) } (h : ∀s∈g, is_open s) :
+  t ≤ generate_from g :=
+le_generate_from_iff_subset_is_open.2 h
 
 lemma induced_generate_from_eq {α β} {b : set (set β)} {f : α → β} :
   (generate_from b).induced f = topological_space.generate_from (preimage f '' b) :=
 le_antisymm
-  (induced_le_iff_le_coinduced.2 $ generate_from_le $ assume s hs,
+  (le_generate_from $ ball_image_iff.2 $ assume s hs, ⟨s, generate_open.basic _ hs, rfl⟩)
+  (coinduced_le_iff_le_induced.1 $ le_generate_from $ assume s hs,
     generate_open.basic _ $ mem_image_of_mem _ hs)
-  (generate_from_le $ ball_image_iff.2 $ assume s hs, ⟨s, generate_open.basic _ hs, rfl⟩)
 
 protected def topological_space.nhds_adjoint (a : α) (f : filter α) : topological_space α :=
 { is_open        := λs, a ∈ s → s ∈ f,
@@ -388,36 +407,35 @@ protected def topological_space.nhds_adjoint (a : α) (f : filter α) : topologi
   is_open_sUnion := assume k hk ⟨u, hu, hau⟩, mem_sets_of_superset (hk u hu hau) (subset_sUnion_of_mem hu) }
 
 lemma gc_nhds (a : α) :
-  @galois_connection _ (order_dual (filter α)) _ _ (λt, @nhds α t a) (topological_space.nhds_adjoint a) :=
-assume t (f : filter α), show f ≤ @nhds α t a ↔ _,
-by rw le_nhds_iff; exact ⟨λ H s hs has, H _ has hs, λ H s has hs, H _ hs has⟩
+  galois_connection  (topological_space.nhds_adjoint a) (λt, @nhds α t a):=
+assume f t, by { rw le_nhds_iff, exact ⟨λ H s hs has, H _ has hs, λ H s has hs, H _ hs has⟩ }
 
 lemma nhds_mono {t₁ t₂ : topological_space α} {a : α} (h : t₁ ≤ t₂) :
-  @nhds α t₂ a ≤ @nhds α t₁ a := (gc_nhds a).monotone_l h
+  @nhds α t₁ a ≤ @nhds α t₂ a := (gc_nhds a).monotone_u h
 
-lemma nhds_supr {ι : Sort*} {t : ι → topological_space α} {a : α} :
-  @nhds α (supr t) a = (⨅i, @nhds α (t i) a) := (gc_nhds a).l_supr
+lemma nhds_infi {ι : Sort*} {t : ι → topological_space α} {a : α} :
+  @nhds α (infi t) a = (⨅i, @nhds α (t i) a) := (gc_nhds a).u_infi
 
-lemma nhds_Sup {s : set (topological_space α)} {a : α} :
-  @nhds α (Sup s) a = (⨅t∈s, @nhds α t a) := (gc_nhds a).l_Sup
+lemma nhds_Inf {s : set (topological_space α)} {a : α} :
+  @nhds α (Inf s) a = (⨅t∈s, @nhds α t a) := (gc_nhds a).u_Inf
 
-lemma nhds_sup {t₁ t₂ : topological_space α} {a : α} :
-  @nhds α (t₁ ⊔ t₂) a = @nhds α t₁ a ⊓ @nhds α t₂ a := (gc_nhds a).l_sup
+lemma nhds_inf {t₁ t₂ : topological_space α} {a : α} :
+  @nhds α (t₁ ⊓ t₂) a = @nhds α t₁ a ⊓ @nhds α t₂ a := (gc_nhds a).u_inf
 
-lemma nhds_bot {a : α} : @nhds α ⊥ a = ⊤ := (gc_nhds a).l_bot
+lemma nhds_top {a : α} : @nhds α ⊤ a = ⊤ := (gc_nhds a).u_top
 
 instance {p : α → Prop} [topological_space α] [discrete_topology α] :
   discrete_topology (subtype p) :=
-⟨top_unique $ assume s hs,
+⟨bot_unique $ assume s hs,
   ⟨subtype.val '' s, is_open_discrete _, (set.preimage_image_eq _ subtype.val_injective)⟩⟩
 
 instance sum.discrete_topology [topological_space α] [topological_space β]
   [hα : discrete_topology α] [hβ : discrete_topology β] : discrete_topology (α ⊕ β) :=
-⟨by unfold sum.topological_space; simp [hα.eq_top, hβ.eq_top]⟩
+⟨by unfold sum.topological_space; simp [hα.eq_bot, hβ.eq_bot]⟩
 
 instance sigma.discrete_topology {β : α → Type v} [Πa, topological_space (β a)]
   [h : Πa, discrete_topology (β a)] : discrete_topology (sigma β) :=
-⟨by unfold sigma.topological_space; simp [λ a, (h a).eq_top]⟩
+⟨by { unfold sigma.topological_space, simp [λ a, (h a).eq_bot] }⟩
 
 local notation `cont` := @continuous _ _
 local notation `tspace` := topological_space
@@ -425,16 +443,16 @@ open topological_space
 
 variables {γ : Type*} {f : α → β} {ι : Sort*}
 
-lemma continuous_iff_le_coinduced {t₁ : tspace α} {t₂ : tspace β} :
-  cont t₁ t₂ f ↔ t₂ ≤ coinduced f t₁ := iff.rfl
+lemma continuous_iff_coinduced_le {t₁ : tspace α} {t₂ : tspace β} :
+  cont t₁ t₂ f ↔ coinduced f t₁ ≤ t₂ := iff.rfl
 
-lemma continuous_iff_induced_le {t₁ : tspace α} {t₂ : tspace β} :
-  cont t₁ t₂ f ↔ induced f t₂ ≤ t₁ :=
-iff.trans continuous_iff_le_coinduced (gc_induced_coinduced f _ _).symm
+lemma continuous_iff_le_induced {t₁ : tspace α} {t₂ : tspace β} :
+  cont t₁ t₂ f ↔ t₁ ≤ induced f t₂ :=
+iff.trans continuous_iff_coinduced_le (gc_coinduced_induced f _ _)
 
 theorem continuous_generated_from {t : tspace α} {b : set (set β)}
   (h : ∀s∈b, is_open (f ⁻¹' s)) : cont t (generate_from b) f :=
-continuous_iff_le_coinduced.2 $ generate_from_le h
+continuous_iff_coinduced_le.2 $ le_generate_from h
 
 lemma continuous_induced_dom {t : tspace β} : cont (induced f t) t f :=
 assume s h, ⟨_, h, rfl⟩
@@ -451,76 +469,77 @@ lemma continuous_coinduced_dom {g : β → γ} {t₁ : tspace α} {t₂ : tspace
 assume s hs, h s hs
 
 lemma continuous_le_dom {t₁ t₂ : tspace α} {t₃ : tspace β}
-  (h₁ : t₁ ≤ t₂) (h₂ : cont t₁ t₃ f) : cont t₂ t₃ f :=
+  (h₁ : t₂ ≤ t₁) (h₂ : cont t₁ t₃ f) : cont t₂ t₃ f :=
 assume s h, h₁ _ (h₂ s h)
 
 lemma continuous_le_rng {t₁ : tspace α} {t₂ t₃ : tspace β}
-  (h₁ : t₃ ≤ t₂) (h₂ : cont t₁ t₂ f) : cont t₁ t₃ f :=
+  (h₁ : t₂ ≤ t₃) (h₂ : cont t₁ t₂ f) : cont t₁ t₃ f :=
 assume s h, h₂ s (h₁ s h)
 
-lemma continuous_inf_dom {t₁ t₂ : tspace α} {t₃ : tspace β}
-  (h₁ : cont t₁ t₃ f) (h₂ : cont t₂ t₃ f) : cont (t₁ ⊓ t₂) t₃ f :=
+lemma continuous_sup_dom {t₁ t₂ : tspace α} {t₃ : tspace β}
+  (h₁ : cont t₁ t₃ f) (h₂ : cont t₂ t₃ f) : cont (t₁ ⊔ t₂) t₃ f :=
 assume s h, ⟨h₁ s h, h₂ s h⟩
 
-lemma continuous_inf_rng_left {t₁ : tspace α} {t₃ t₂ : tspace β} :
-  cont t₁ t₂ f → cont t₁ (t₂ ⊓ t₃) f :=
-continuous_le_rng inf_le_left
+lemma continuous_sup_rng_left {t₁ : tspace α} {t₃ t₂ : tspace β} :
+  cont t₁ t₂ f → cont t₁ (t₂ ⊔ t₃) f :=
+continuous_le_rng le_sup_left
 
-lemma continuous_inf_rng_right {t₁ : tspace α} {t₃ t₂ : tspace β} :
-  cont t₁ t₃ f → cont t₁ (t₂ ⊓ t₃) f :=
-continuous_le_rng inf_le_right
+lemma continuous_sup_rng_right {t₁ : tspace α} {t₃ t₂ : tspace β} :
+  cont t₁ t₃ f → cont t₁ (t₂ ⊔ t₃) f :=
+continuous_le_rng le_sup_right
 
-lemma continuous_Inf_dom {t₁ : set (tspace α)} {t₂ : tspace β}
-  (h : ∀t∈t₁, cont t t₂ f) : cont (Inf t₁) t₂ f :=
-continuous_iff_induced_le.2 $ le_Inf $ assume t ht, continuous_iff_induced_le.1 $ h t ht
+lemma continuous_Sup_dom {t₁ : set (tspace α)} {t₂ : tspace β}
+  (h : ∀t∈t₁, cont t t₂ f) : cont (Sup t₁) t₂ f :=
+continuous_iff_le_induced.2 $ Sup_le $ assume t ht, continuous_iff_le_induced.1 $ h t ht
 
-lemma continuous_Inf_rng {t₁ : tspace α} {t₂ : set (tspace β)} {t : tspace β}
-  (h₁ : t ∈ t₂) (hf : cont t₁ t f) : cont t₁ (Inf t₂) f :=
-continuous_iff_le_coinduced.2 $ Inf_le_of_le h₁ $ continuous_iff_le_coinduced.1 hf
+lemma continuous_Sup_rng {t₁ : tspace α} {t₂ : set (tspace β)} {t : tspace β}
+  (h₁ : t ∈ t₂) (hf : cont t₁ t f) : cont t₁ (Sup t₂) f :=
+continuous_iff_coinduced_le.2 $ le_Sup_of_le h₁ $ continuous_iff_coinduced_le.1 hf
 
-lemma continuous_infi_dom {t₁ : ι → tspace α} {t₂ : tspace β}
-  (h : ∀i, cont (t₁ i) t₂ f) : cont (infi t₁) t₂ f :=
-continuous_Inf_dom $ assume t ⟨i, (t_eq : t₁ i = t)⟩, t_eq ▸ h i
+lemma continuous_supr_dom {t₁ : ι → tspace α} {t₂ : tspace β}
+  (h : ∀i, cont (t₁ i) t₂ f) : cont (supr t₁) t₂ f :=
+continuous_Sup_dom $ assume t ⟨i, (t_eq : t₁ i = t)⟩, t_eq ▸ h i
 
-lemma continuous_infi_rng {t₁ : tspace α} {t₂ : ι → tspace β} {i : ι}
-  (h : cont t₁ (t₂ i) f) : cont t₁ (infi t₂) f :=
-continuous_Inf_rng ⟨i, rfl⟩ h
+lemma continuous_supr_rng {t₁ : tspace α} {t₂ : ι → tspace β} {i : ι}
+  (h : cont t₁ (t₂ i) f) : cont t₁ (supr t₂) f :=
+continuous_Sup_rng ⟨i, rfl⟩ h
 
-lemma continuous_sup_rng {t₁ : tspace α} {t₂ t₃ : tspace β}
-  (h₁ : cont t₁ t₂ f) (h₂ : cont t₁ t₃ f) : cont t₁ (t₂ ⊔ t₃) f :=
-continuous_iff_le_coinduced.2 $ sup_le
-  (continuous_iff_le_coinduced.1 h₁)
-  (continuous_iff_le_coinduced.1 h₂)
+lemma continuous_inf_rng {t₁ : tspace α} {t₂ t₃ : tspace β}
+  (h₁ : cont t₁ t₂ f) (h₂ : cont t₁ t₃ f) : cont t₁ (t₂ ⊓ t₃) f :=
+continuous_iff_coinduced_le.2 $ le_inf
+  (continuous_iff_coinduced_le.1 h₁)
+  (continuous_iff_coinduced_le.1 h₂)
 
-lemma continuous_sup_dom_left {t₁ t₂ : tspace α} {t₃ : tspace β} :
-  cont t₁ t₃ f → cont (t₁ ⊔ t₂) t₃ f :=
-continuous_le_dom le_sup_left
+lemma continuous_inf_dom_left {t₁ t₂ : tspace α} {t₃ : tspace β} :
+  cont t₁ t₃ f → cont (t₁ ⊓ t₂) t₃ f :=
+continuous_le_dom inf_le_left
 
-lemma continuous_sup_dom_right {t₁ t₂ : tspace α} {t₃ : tspace β} :
-  cont t₂ t₃ f → cont (t₁ ⊔ t₂) t₃ f :=
-continuous_le_dom le_sup_right
+lemma continuous_inf_dom_right {t₁ t₂ : tspace α} {t₃ : tspace β} :
+  cont t₂ t₃ f → cont (t₁ ⊓ t₂) t₃ f :=
+continuous_le_dom inf_le_right
 
-lemma continuous_Sup_dom {t₁ : set (tspace α)} {t₂ : tspace β} {t : tspace α} (h₁ : t ∈ t₁) :
-  cont t t₂ f → cont (Sup t₁) t₂ f :=
-continuous_le_dom $ le_Sup h₁
+lemma continuous_Inf_dom {t₁ : set (tspace α)} {t₂ : tspace β} {t : tspace α} (h₁ : t ∈ t₁) :
+  cont t t₂ f → cont (Inf t₁) t₂ f :=
+continuous_le_dom $ Inf_le h₁
 
-lemma continuous_Sup_rng {t₁ : tspace α} {t₂ : set (tspace β)}
-  (h : ∀t∈t₂, cont t₁ t f) : cont t₁ (Sup t₂) f :=
-continuous_iff_le_coinduced.2 $ Sup_le $ assume b hb, continuous_iff_le_coinduced.1 $ h b hb
+lemma continuous_Inf_rng {t₁ : tspace α} {t₂ : set (tspace β)}
+  (h : ∀t∈t₂, cont t₁ t f) : cont t₁ (Inf t₂) f :=
+continuous_iff_coinduced_le.2 $ le_Inf $ assume b hb, continuous_iff_coinduced_le.1 $ h b hb
 
-lemma continuous_supr_dom {t₁ : ι → tspace α} {t₂ : tspace β} {i : ι} :
-  cont (t₁ i) t₂ f → cont (supr t₁) t₂ f :=
-continuous_le_dom $ le_supr _ _
+lemma continuous_infi_dom {t₁ : ι → tspace α} {t₂ : tspace β} {i : ι} :
+  cont (t₁ i) t₂ f → cont (infi t₁) t₂ f :=
+continuous_le_dom $ infi_le _ _
 
-lemma continuous_supr_rng {t₁ : tspace α} {t₂ : ι → tspace β}
-  (h : ∀i, cont t₁ (t₂ i) f) : cont t₁ (supr t₂) f :=
-continuous_iff_le_coinduced.2 $ supr_le $ assume i, continuous_iff_le_coinduced.1 $ h i
+lemma continuous_infi_rng {t₁ : tspace α} {t₂ : ι → tspace β}
+  (h : ∀i, cont t₁ (t₂ i) f) : cont t₁ (infi t₂) f :=
+continuous_iff_coinduced_le.2 $ le_infi $ assume i, continuous_iff_coinduced_le.1 $ h i
 
-lemma continuous_top {t : tspace β} : cont ⊤ t f :=
-continuous_iff_induced_le.2 $ le_top
+lemma continuous_bot {t : tspace β} : cont ⊥ t f :=
+continuous_iff_le_induced.2 $ bot_le
 
-lemma continuous_bot {t : tspace α} : cont t ⊥ f :=
-continuous_iff_le_coinduced.2 $ bot_le
+lemma continuous_top {t : tspace α} : cont t ⊤ f :=
+continuous_iff_coinduced_le.2 $ le_top
+
 /- nhds in the induced topology -/
 
 theorem mem_nhds_induced [T : topological_space α] (f : β → α) (a : β) (s : set β) :
@@ -806,15 +825,15 @@ end sierpinski
 section infi
 variables {α : Type u} {ι : Type v} {t : ι → topological_space α}
 
-lemma is_open_infi_iff {s : set α} : @is_open _ (⨅ i, t i) s ↔ ∀ i, @is_open _ (t i) s :=
+lemma is_open_supr_iff {s : set α} : @is_open _ (⨆ i, t i) s ↔ ∀ i, @is_open _ (t i) s :=
 begin
   -- s defines a map from α to Prop, which is continuous iff s is open.
-  suffices : @continuous _ _ (⨅ i, t i) _ s ↔ ∀ i, @continuous _ _ (t i) _ s,
+  suffices : @continuous _ _ (⨆ i, t i) _ s ↔ ∀ i, @continuous _ _ (t i) _ s,
   { simpa only [continuous_Prop] using this },
-  simp only [continuous_iff_induced_le, le_infi_iff]
+  simp only [continuous_iff_le_induced, supr_le_iff]
 end
 
-lemma is_closed_infi_iff {s : set α} : @is_closed _ (⨅ i, t i) s ↔ ∀ i, @is_closed _ (t i) s :=
-is_open_infi_iff
+lemma is_closed_infi_iff {s : set α} : @is_closed _ (⨆ i, t i) s ↔ ∀ i, @is_closed _ (t i) s :=
+is_open_supr_iff
 
 end infi

--- a/src/topology/order.lean
+++ b/src/topology/order.lean
@@ -126,7 +126,7 @@ lemma generate_from_mono {α} {g₁ g₂ : set (set α)} (h : g₁ ⊆ g₂) :
   topological_space.generate_from g₁ ≤ topological_space.generate_from g₂ :=
 (gi_generate_from _).gc.monotone_l h
 
-def old_complete_lattice {α : Type u} : complete_lattice (topological_space α) :=
+def tmp_complete_lattice {α : Type u} : complete_lattice (topological_space α) :=
 (gi_generate_from α).lift_complete_lattice
 
 

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -201,7 +201,7 @@ instance t2_space_discrete [topological_space α] [discrete_topology α] : t2_sp
 
 private lemma separated_by_f
   [tα : topological_space α] [tβ : topological_space β] [t2_space β]
-  (f : α → β) (hf : tβ.induced f ≤ tα) {x y : α} (h : f x ≠ f y) :
+  (f : α → β) (hf : tα ≤ tβ.induced f) {x y : α} (h : f x ≠ f y) :
   ∃u v : set α, is_open u ∧ is_open v ∧ x ∈ u ∧ y ∈ v ∧ u ∩ v = ∅ :=
 let ⟨u, v, uo, vo, xu, yv, uv⟩ := t2_separation h in
 ⟨f ⁻¹' u, f ⁻¹' v, hf _ ⟨u, uo, rfl⟩, hf _ ⟨v, vo, rfl⟩, xu, yv,
@@ -215,14 +215,14 @@ instance [t₁ : topological_space α] [t2_space α] [t₂ : topological_space �
   t2_space (α × β) :=
 ⟨assume ⟨x₁,x₂⟩ ⟨y₁,y₂⟩ h,
   or.elim (not_and_distrib.mp (mt prod.ext_iff.mpr h))
-    (λ h₁, separated_by_f prod.fst le_sup_left h₁)
-    (λ h₂, separated_by_f prod.snd le_sup_right h₂)⟩
+    (λ h₁, separated_by_f prod.fst inf_le_left h₁)
+    (λ h₂, separated_by_f prod.snd inf_le_right h₂)⟩
 
 instance Pi.t2_space {β : α → Type v} [t₂ : Πa, topological_space (β a)] [Πa, t2_space (β a)] :
   t2_space (Πa, β a) :=
 ⟨assume x y h,
   let ⟨i, hi⟩ := not_forall.mp (mt funext h) in
-  separated_by_f (λz, z i) (le_supr _ i) hi⟩
+  separated_by_f (λz, z i) (infi_le _ i) hi⟩
 
 end separation
 

--- a/src/topology/stone_cech.lean
+++ b/src/topology/stone_cech.lean
@@ -106,9 +106,9 @@ end
 open topological_space
 
 /-- `pure : α → ultrafilter α` defines a dense embedding of `α` in `ultrafilter α`. -/
-lemma dense_embedding_pure : @dense_embedding _ _ ⊤ _ (pure : α → ultrafilter α) :=
-by letI : topological_space α := ⊤; exact
-dense_embedding.mk' pure continuous_top
+lemma dense_embedding_pure : @dense_embedding _ _ ⊥ _ (pure : α → ultrafilter α) :=
+by letI : topological_space α := ⊥; exact
+dense_embedding.mk' pure continuous_bot
   (assume x, mem_closure_iff_ultrafilter.mpr
      ⟨x.map ultrafilter.pure, range_mem_map,
       ultrafilter_converges_iff.mpr (bind_pure x).symm⟩)
@@ -132,10 +132,10 @@ variables {γ : Type*} [topological_space γ]
 /-- The extension of a function `α → γ` to a function `ultrafilter α → γ`.
   When `γ` is a compact Hausdorff space it will be continuous. -/
 def ultrafilter.extend (f : α → γ) : ultrafilter α → γ :=
-by letI : topological_space α := ⊤; exact dense_embedding_pure.extend f
+by letI : topological_space α := ⊥; exact dense_embedding_pure.extend f
 
 lemma ultrafilter_extend_extends (f : α → γ) : ultrafilter.extend f ∘ pure = f :=
-by letI : topological_space α := ⊤; exact funext dense_embedding_pure.extend_e_eq
+by letI : topological_space α := ⊥; exact funext dense_embedding_pure.extend_e_eq
 
 variables [t2_space γ] [compact_space γ]
 
@@ -146,7 +146,7 @@ have ∀ (b : ultrafilter α), ∃ c, tendsto f (comap ultrafilter.pure (nhds b)
     (by rw [le_principal_iff]; exact univ_mem_sets) in
   ⟨c, le_trans (map_mono (ultrafilter_comap_pure_nhds _)) h⟩,
 begin
-  letI : topological_space α := ⊤,
+  letI : topological_space α := ⊥,
   letI : normal_space γ := normal_of_compact_t2,
   exact dense_embedding_pure.continuous_extend this
 end
@@ -168,7 +168,7 @@ lemma ultrafilter_extend_eq_iff {f : α → γ} {b : ultrafilter α} {c : γ} :
    rw ultrafilter_extend_extends,
    exact le_refl _
  end,
- assume h, by letI : topological_space α := ⊤; exact
+ assume h, by letI : topological_space α := ⊥; exact
    dense_embedding_pure.extend_eq (le_trans (map_mono (ultrafilter_comap_pure_nhds _)) h)⟩
 
 end extension

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -469,12 +469,12 @@ section constructions
 variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*} {ι : Sort*}
 
 instance : partial_order (uniform_space α) :=
-{ le          := λt s, s.uniformity ≤ t.uniformity,
-  le_antisymm := assume t s h₁ h₂, uniform_space_eq $ le_antisymm h₂ h₁,
+{ le          := λt s, t.uniformity ≤ s.uniformity,
+  le_antisymm := assume t s h₁ h₂, uniform_space_eq $ le_antisymm h₁ h₂,
   le_refl     := assume t, le_refl _,
-  le_trans    := assume a b c h₁ h₂, @le_trans _ _ c.uniformity b.uniformity a.uniformity h₂ h₁ }
+  le_trans    := assume a b c h₁ h₂, le_trans h₁ h₂ }
 
-instance : has_Sup (uniform_space α) :=
+instance : has_Inf (uniform_space α) :=
 ⟨assume s, uniform_space.of_core {
   uniformity := (⨅u∈s, @uniformity α u),
   refl       := le_infi $ assume u, le_infi $ assume hu, u.refl,
@@ -483,21 +483,21 @@ instance : has_Sup (uniform_space α) :=
   comp       := le_infi $ assume u, le_infi $ assume hu,
     le_trans (lift'_mono (infi_le_of_le _ $ infi_le _ hu) $ le_refl _) u.comp }⟩
 
-private lemma le_Sup {tt : set (uniform_space α)} {t : uniform_space α} (h : t ∈ tt) :
-  t ≤ Sup tt :=
+private lemma Inf_le {tt : set (uniform_space α)} {t : uniform_space α} (h : t ∈ tt) :
+  Inf tt ≤ t :=
 show (⨅u∈tt, @uniformity α u) ≤ t.uniformity,
   from infi_le_of_le t $ infi_le _ h
 
-private lemma Sup_le {tt : set (uniform_space α)} {t : uniform_space α} (h : ∀t'∈tt, t' ≤ t) :
-  Sup tt ≤ t :=
+private lemma le_Inf {tt : set (uniform_space α)} {t : uniform_space α} (h : ∀t'∈tt, t ≤ t') :
+  t ≤ Inf tt :=
 show t.uniformity ≤ (⨅u∈tt, @uniformity α u),
   from le_infi $ assume t', le_infi $ assume ht', h t' ht'
 
-instance : has_bot (uniform_space α) :=
+instance : has_top (uniform_space α) :=
 ⟨uniform_space.of_core { uniformity := ⊤, refl := le_top, symm := le_top, comp := le_top }⟩
 
-instance : has_top (uniform_space α) :=
-⟨{ to_topological_space := ⊤,
+instance : has_bot (uniform_space α) :=
+⟨{ to_topological_space := ⊥,
   uniformity  := principal id_rel,
   refl        := le_refl _,
   symm        := by simp [tendsto]; apply subset.refl,
@@ -510,41 +510,41 @@ instance : has_top (uniform_space α) :=
     assume s, by simp [is_open_fold, subset_def, id_rel] {contextual := tt } } ⟩
 
 instance : complete_lattice (uniform_space α) :=
-{ sup           := λa b, Sup {a, b},
-  le_sup_left   := assume a b, le_Sup $ by simp,
-  le_sup_right  := assume a b, le_Sup $ by simp,
-  sup_le        := assume a b c h₁ h₂, Sup_le $ assume t',
-    begin simp, intro h, cases h with h h, repeat { subst h; assumption } end,
-  inf           := λa b, Sup {x | x ≤ a ∧ x ≤ b},
-  le_inf        := assume a b c h₁ h₂, le_Sup ⟨h₁, h₂⟩,
-  inf_le_left   := assume a b, Sup_le $ assume x ⟨ha, hb⟩, ha,
-  inf_le_right  := assume a b, Sup_le $ assume x ⟨ha, hb⟩, hb,
+{ sup           := λa b, Inf {x | a ≤ x ∧ b ≤ x},
+  le_sup_left   := λ a b, le_Inf (λ _ ⟨h, _⟩, h),
+  le_sup_right  := λ a b, le_Inf (λ _ ⟨_, h⟩, h),
+  sup_le        := λ a b c h₁ h₂, Inf_le ⟨h₁, h₂⟩,
+  inf           := λ a b, Inf {a, b},
+  le_inf        := λ a b c h₁ h₂, le_Inf (λ u h,
+                     by { cases h, exact h.symm ▸ h₂, exact (mem_singleton_iff.1 h).symm ▸ h₁ }),
+  inf_le_left   := λ a b, Inf_le (by simp),
+  inf_le_right  := λ a b, Inf_le (by simp),
   top           := ⊤,
-  le_top        := assume u, u.refl,
+  le_top        := λ a, show a.uniformity ≤ ⊤, from le_top,
   bot           := ⊥,
-  bot_le        := assume a, show a.uniformity ≤ ⊤, from le_top,
-  Sup           := Sup,
-  le_Sup        := assume s u, le_Sup,
-  Sup_le        := assume s u, Sup_le,
-  Inf           := λtt, Sup {t | ∀t'∈tt, t ≤ t'},
-  le_Inf        := assume s a hs, le_Sup hs,
-  Inf_le        := assume s a ha, Sup_le $ assume u hs, hs _ ha,
+  bot_le        := λ u, u.refl,
+  Sup           := λ tt, Inf {t | ∀ t' ∈ tt, t' ≤ t},
+  le_Sup        := λ s u h, le_Inf (λ u' h', h' u h),
+  Sup_le        := λ s u h, Inf_le h,
+  Inf           := Inf,
+  le_Inf        := λ s a hs, le_Inf hs,
+  Inf_le        := λ s a ha, Inf_le ha,
   ..uniform_space.partial_order }
 
-lemma supr_uniformity {ι : Sort*} {u : ι → uniform_space α} :
-  (supr u).uniformity = (⨅i, (u i).uniformity) :=
+lemma infi_uniformity {ι : Sort*} {u : ι → uniform_space α} :
+  (infi u).uniformity = (⨅i, (u i).uniformity) :=
 show (⨅a (h : ∃i:ι, u i = a), a.uniformity) = _, from
 le_antisymm
   (le_infi $ assume i, infi_le_of_le (u i) $ infi_le _ ⟨i, rfl⟩)
   (le_infi $ assume a, le_infi $ assume ⟨i, (ha : u i = a)⟩, ha ▸ infi_le _ _)
 
-lemma sup_uniformity {u v : uniform_space α} :
-  (u ⊔ v).uniformity = u.uniformity ⊓ v.uniformity :=
-have (u ⊔ v) = (⨆i (h : i = u ∨ i = v), i), by simp [supr_or, supr_sup_eq],
-calc (u ⊔ v).uniformity = ((⨆i (h : i = u ∨ i = v), i) : uniform_space α).uniformity : by rw [this]
-  ... = _ : by simp [supr_uniformity, infi_or, infi_inf_eq]
+lemma inf_uniformity {u v : uniform_space α} :
+  (u ⊓ v).uniformity = u.uniformity ⊓ v.uniformity :=
+have (u ⊓ v) = (⨅i (h : i = u ∨ i = v), i), by simp [infi_or, infi_inf_eq],
+calc (u ⊓ v).uniformity = ((⨅i (h : i = u ∨ i = v), i) : uniform_space α).uniformity : by rw [this]
+  ... = _ : by simp [infi_uniformity, infi_or, infi_inf_eq]
 
-instance inhabited_uniform_space : inhabited (uniform_space α) := ⟨⊤⟩
+instance inhabited_uniform_space : inhabited (uniform_space α) := ⟨⊥⟩
 
 /-- Given `f : α → β` and a uniformity `u` on `β`, the inverse image of `u` under `f`
   is the inverse image in the filter sense of the induced function `α × α → β × β`. -/
@@ -579,7 +579,7 @@ lemma uniform_space.comap_comap_comp {α β γ} [uγ : uniform_space γ] {f : α
 by ext ; dsimp [uniform_space.comap] ; rw filter.comap_comap_comp
 
 lemma uniform_continuous_iff {α β} [uα : uniform_space α] [uβ : uniform_space β] (f : α → β) :
-  uniform_continuous f ↔ uβ.comap f ≤ uα :=
+  uniform_continuous f ↔ uα ≤ uβ.comap f :=
 filter.map_le_iff_le_comap
 
 lemma uniform_continuous_comap {f : α → β} [u : uniform_space β] :
@@ -592,8 +592,8 @@ theorem to_topological_space_comap {f : α → β} {u : uniform_space β} :
 eq_of_nhds_eq_nhds $ assume a,
 begin
   simp [nhds_induced_eq_comap, nhds_eq_uniformity, nhds_eq_uniformity],
-  change comap f ((𝓤 β).lift' (preimage (λb, (f a, b)))) =
-      (u.uniformity.comap (λp:α×α, (f p.1, f p.2))).lift' (preimage (λa', (a, a'))),
+  change (u.uniformity.comap (λp:α×α, (f p.1, f p.2))).lift' (preimage (λa', (a, a'))) =
+           comap f ((𝓤 β).lift' (preimage (λb, (f a, b)))),
   rw [comap_lift'_eq monotone_preimage, comap_lift'_eq2 monotone_preimage],
   exact rfl
 end
@@ -607,58 +607,57 @@ lemma to_topological_space_mono {u₁ u₂ : uniform_space α} (h : u₁ ≤ u�
 le_of_nhds_le_nhds $ assume a,
   by rw [@nhds_eq_uniformity α u₁ a, @nhds_eq_uniformity α u₂ a]; exact (lift'_mono h $ le_refl _)
 
-lemma to_topological_space_top : @uniform_space.to_topological_space α ⊤ = ⊤ := rfl
+lemma to_topological_space_bot : @uniform_space.to_topological_space α ⊥ = ⊥ := rfl
 
-lemma to_topological_space_bot : @uniform_space.to_topological_space α ⊥ = ⊥ :=
-bot_unique $ assume s hs, classical.by_cases
-  (assume : s = ∅, this.symm ▸ @is_open_empty _ ⊥)
+lemma to_topological_space_top : @uniform_space.to_topological_space α ⊤ = ⊤ :=
+top_unique $ assume s hs, classical.by_cases
+  (assume : s = ∅, this.symm ▸ @is_open_empty _ ⊤)
   (assume : s ≠ ∅,
     let ⟨x, hx⟩ := exists_mem_of_ne_empty this in
     have s = univ, from top_unique $ assume y hy, hs x hx (x, y) rfl,
-    this.symm ▸ @is_open_univ _ ⊥)
+    this.symm ▸ @is_open_univ _ ⊤)
 
-lemma to_topological_space_supr {ι : Sort*} {u : ι → uniform_space α} :
-  @uniform_space.to_topological_space α (supr u) = (⨆i, @uniform_space.to_topological_space α (u i)) :=
+lemma to_topological_space_infi {ι : Sort*} {u : ι → uniform_space α} :
+  (infi u).to_topological_space = ⨅i, (u i).to_topological_space :=
 classical.by_cases
   (assume h : nonempty ι,
     eq_of_nhds_eq_nhds $ assume a,
     begin
-      rw [nhds_supr, nhds_eq_uniformity],
-      change _ = (supr u).uniformity.lift' (preimage $ prod.mk a),
+      rw [nhds_infi, nhds_eq_uniformity],
+      change (infi u).uniformity.lift' (preimage $ prod.mk a) = _,
       begin
-        rw [supr_uniformity, lift'_infi],
-        exact (congr_arg _ $ funext $ assume i, @nhds_eq_uniformity α (u i) a),
+        rw [infi_uniformity, lift'_infi],
+        exact (congr_arg _ $ funext $ assume i, (@nhds_eq_uniformity α (u i) a).symm),
         exact h,
         exact assume a b, rfl
       end
     end)
   (assume : ¬ nonempty ι,
     le_antisymm
-      (have supr u = ⊥, from bot_unique $ supr_le $ assume i, (this ⟨i⟩).elim,
-        have @uniform_space.to_topological_space _ (supr u) = ⊥,
-          from this.symm ▸ to_topological_space_bot,
-        this.symm ▸ bot_le)
-      (supr_le $ assume i, to_topological_space_mono $ le_supr _ _))
+      (le_infi $ assume i, to_topological_space_mono $ infi_le _ _)
+      (have infi u = ⊤, from top_unique $ le_infi $ assume i, (this ⟨i⟩).elim,
+        have @uniform_space.to_topological_space _ (infi u) = ⊤,
+          from this.symm ▸ to_topological_space_top,
+        this.symm ▸ le_top))
 
-lemma to_topological_space_Sup {s : set (uniform_space α)} :
-  @uniform_space.to_topological_space α (Sup s) = (⨆i∈s, @uniform_space.to_topological_space α i) :=
+lemma to_topological_space_Inf {s : set (uniform_space α)} :
+  (Inf s).to_topological_space = (⨅i∈s, @uniform_space.to_topological_space α i) :=
 begin
-  rw [Sup_eq_supr, to_topological_space_supr],
+  rw [Inf_eq_infi, to_topological_space_infi],
   apply congr rfl,
   funext x,
-  exact to_topological_space_supr
+  exact to_topological_space_infi
 end
 
-lemma to_topological_space_sup {u v : uniform_space α} :
-  @uniform_space.to_topological_space α (u ⊔ v) =
-    @uniform_space.to_topological_space α u ⊔ @uniform_space.to_topological_space α v :=
-ord_continuous_sup $ assume s, to_topological_space_Sup
+lemma to_topological_space_inf {u v : uniform_space α} :
+  (u ⊓ v).to_topological_space = u.to_topological_space ⊓ v.to_topological_space :=
+by rw [to_topological_space_Inf, infi_pair]
 
-instance : uniform_space empty := ⊤
-instance : uniform_space unit := ⊤
-instance : uniform_space bool := ⊤
-instance : uniform_space ℕ := ⊤
-instance : uniform_space ℤ := ⊤
+instance : uniform_space empty := ⊥
+instance : uniform_space unit := ⊥
+instance : uniform_space bool := ⊥
+instance : uniform_space ℕ := ⊥
+instance : uniform_space ℤ := ⊥
 
 instance {p : α → Prop} [t : uniform_space α] : uniform_space (subtype p) :=
 uniform_space.comap subtype.val t
@@ -690,16 +689,16 @@ section prod
   but we want to have the uniformity of uniform convergence on function spaces -/
 instance [u₁ : uniform_space α] [u₂ : uniform_space β] : uniform_space (α × β) :=
 uniform_space.of_core_eq
-  (u₁.comap prod.fst ⊔ u₂.comap prod.snd).to_core
+  (u₁.comap prod.fst ⊓ u₂.comap prod.snd).to_core
   prod.topological_space
-  (calc prod.topological_space = (u₁.comap prod.fst ⊔ u₂.comap prod.snd).to_topological_space :
-      by rw [to_topological_space_sup, to_topological_space_comap, to_topological_space_comap]; refl
+  (calc prod.topological_space = (u₁.comap prod.fst ⊓ u₂.comap prod.snd).to_topological_space :
+      by rw [to_topological_space_inf, to_topological_space_comap, to_topological_space_comap]; refl
     ... = _ : by rw [uniform_space.to_core_to_topological_space])
 
 theorem uniformity_prod [uniform_space α] [uniform_space β] : 𝓤 (α × β) =
   (𝓤 α).comap (λp:(α × β) × α × β, (p.1.1, p.2.1)) ⊓
   (𝓤 β).comap (λp:(α × β) × α × β, (p.1.2, p.2.2)) :=
-sup_uniformity
+inf_uniformity
 
 lemma uniformity_prod_eq_prod [uniform_space α] [uniform_space β] :
   𝓤 (α×β) =
@@ -734,11 +733,11 @@ by rw [uniformity_prod]; exact inter_mem_inf_sets (preimage_mem_comap ha) (preim
 
 lemma tendsto_prod_uniformity_fst [uniform_space α] [uniform_space β] :
   tendsto (λp:(α×β)×(α×β), (p.1.1, p.2.1)) (𝓤 (α × β)) (𝓤 α) :=
-le_trans (map_mono (@le_sup_left (uniform_space (α×β)) _ _ _)) map_comap_le
+le_trans (map_mono (@inf_le_left (uniform_space (α×β)) _ _ _)) map_comap_le
 
 lemma tendsto_prod_uniformity_snd [uniform_space α] [uniform_space β] :
   tendsto (λp:(α×β)×(α×β), (p.1.2, p.2.2)) (𝓤 (α × β)) (𝓤 β) :=
-le_trans (map_mono (@le_sup_right (uniform_space (α×β)) _ _ _)) map_comap_le
+le_trans (map_mono (@inf_le_right (uniform_space (α×β)) _ _ _)) map_comap_le
 
 lemma uniform_continuous_fst [uniform_space α] [uniform_space β] : uniform_continuous (λp:α×β, p.1) :=
 tendsto_prod_uniformity_fst

--- a/src/topology/uniform_space/pi.lean
+++ b/src/topology/uniform_space/pi.lean
@@ -20,17 +20,17 @@ include U
 
 instance Pi.uniform_space : uniform_space (Πi, α i) :=
 uniform_space.of_core_eq
-  (⨆i, uniform_space.comap (λ a : Πi, α i, a i) (U i)).to_core
-  Pi.topological_space $ eq.symm to_topological_space_supr
+  (⨅i, uniform_space.comap (λ a : Πi, α i, a i) (U i)).to_core
+  Pi.topological_space $ eq.symm to_topological_space_infi
 
 lemma Pi.uniformity :
   𝓤 (Π i, α i) = ⨅ i : ι, filter.comap (λ a, (a.1 i, a.2 i)) $ 𝓤 (α i) :=
-supr_uniformity
+infi_uniformity
 
 lemma Pi.uniform_continuous_proj (i : ι) : uniform_continuous (λ (a : Π (i : ι), α i), a i) :=
 begin
   rw uniform_continuous_iff,
-  apply le_supr (λ j, uniform_space.comap (λ (a : Π (i : ι), α i), a j) (U j))
+  exact infi_le (λ j, uniform_space.comap (λ (a : Π (i : ι), α i), a j) (U j)) i
 end
 
 lemma Pi.uniform_space_topology :


### PR DESCRIPTION
This is the change discussed in https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Order.20on.20topologies. It makes the order on `topological_space a` and `uniform_space a` consistent with the order on `filter a`. The only slightly painful point is the adjunction between `generate_from` and associating to a topology on `a` the corresponding set of `set a`. In the end I decided to keep the old mathlib order for the first 50 lines of the file and switch after setting up this adjunction, which is used only to construct the complete lattice instance.

Many changes that appear to be large are only switching the arguments of `le_antisymm` in the many proofs of topology equalities by double inequalities. I also added two tiny lemmas about complete lattices, one of which was inlined in a proof I had to refactor (and the other one is the obvious variation):
```lean
@[simp] theorem infi_pair {f : β → α} {a b : β} : (⨅ x ∈ ({a, b} : set β), f x) = f a ⊓ f b :=
by { rw [show {a, b} = (insert b {a} : set β), from rfl, infi_insert, inf_comm], simp }
```
And of course there are some random white space trimming differences, you can ask GitHub to hide them...