### PR TITLE
Proved some of the lemmas.

### DIFF
--- a/src/category_theory/mwe.lean
+++ b/src/category_theory/mwe.lean
@@ -26,26 +26,51 @@ begin
   {exact (fin.ext_iff _ _).2  (eq.trans rfl (eq.symm (nat.eq_of_lt_succ_of_not_lt a.is_lt h)))}
 end)
 
+
+lemma cast_succ_val_lt {n : ℕ} (i : fin n) : (fin.cast_succ i).val < n :=
+begin
+ rw [fin.cast_succ_val],
+ exact i.is_lt,
+end
+
+lemma cast_lt_cast_succ {n : ℕ} (i : fin n)  :
+  fin.cast_lt (fin.cast_succ i) (cast_succ_val_lt _) = i :=
+fin.eq_of_veq (by simp only [fin.cast_lt_val, fin.cast_succ_val])
+
+#print cast_lt_cast_succ
+#check
+
 lemma map_comp {l m n : ℕ} (f : hom l m) (g : hom m n) : map (g ∘ f) = (map g) ∘ (map f) :=
 begin
   ext,
   dsimp [map],
   split_ifs,
-   { split_ifs,
-    by_cases h2 : ((dite (x.val < l) (λ (h : x.val < l), fin.cast_succ (f (fin.cast_lt x h)))
-            (λ (h : ¬x.val < l), fin.last m)).val < m),
+   {  by_cases h2 : ((dite (x.val < l) (λ (h : x.val < l), fin.cast_succ (f (fin.cast_lt x h)))
+        (λ (h : ¬x.val < l), fin.last m)).val < m),
     {
       rw dif_pos h2,
       split_ifs,
       tidy,
-      sorry
+      simp [cast_lt_cast_succ],
     },
     {
       rw dif_neg h2,
+      split_ifs at h2,
       sorry
     }
   },
-  {
-    sorry
-  }-- succeeds, but does nothing
+  {by_cases h2 : ((dite (x.val < l) (λ (h : x.val < l), fin.cast_succ (f (fin.cast_lt x h)))
+            (λ (h : ¬x.val < l), fin.last m)).val < m),
+    {
+      rw dif_pos h2,
+      split_ifs at h2,
+      simp [fin.last] at h2,
+      exact (absurd h2 (irrefl m)),
+    },
+    {
+      rw dif_neg h2,
+    }
+  }
 end
+
+lemma foo (n : ℕ) : ¬(n < n) := by library_search

--- a/src/category_theory/mwe.lean
+++ b/src/category_theory/mwe.lean
@@ -5,7 +5,7 @@ def hom (n m : ℕ) := fin n → fin m
 def map {n m : ℕ} (f : hom n m) : hom (n+1) (m+1) :=
 λ i, if h : i.val < n then (f (i.cast_lt h)).cast_succ else fin.last _
 
-lemma map_increasing {n m : ℕ} (f: hom n m) (h : monotone f) : monotone (map f) :=
+lemma map_increasing {n m : ℕ} (f: hom n m) (w : monotone f) : monotone (map f) :=
 λ a b h,
 begin
   dsimp [map],
@@ -16,6 +16,8 @@ begin
   linarith},
   {apply fin.le_last}
 end
+
+lemma fooo {a b n : ℕ} (h1 : a ≤ b) (h2 : ¬(a < n)) :¬ (b < n) := by library_search
 
 lemma map_id {n m : ℕ} (f : hom n m) : map (@id (fin n)) = @id (fin (n+1)) :=
 funext (λ a,
@@ -38,8 +40,8 @@ lemma cast_lt_cast_succ {n : ℕ} (i : fin n)  :
 fin.eq_of_veq (by simp only [fin.cast_lt_val, fin.cast_succ_val])
 
 lemma map_comp {l m n : ℕ} (f : hom l m) (g : hom m n) : map (g ∘ f) = (map g) ∘ (map f) :=
+funext (λ x,
 begin
-  ext,
   dsimp [map],
   split_ifs,
   { -- x.val < l
@@ -71,4 +73,4 @@ begin
       rw dif_neg h2,
     },
   }
-end
+end)

--- a/src/category_theory/mwe.lean
+++ b/src/category_theory/mwe.lean
@@ -37,40 +37,38 @@ lemma cast_lt_cast_succ {n : ℕ} (i : fin n)  :
   fin.cast_lt (fin.cast_succ i) (cast_succ_val_lt _) = i :=
 fin.eq_of_veq (by simp only [fin.cast_lt_val, fin.cast_succ_val])
 
-#print cast_lt_cast_succ
-#check
-
 lemma map_comp {l m n : ℕ} (f : hom l m) (g : hom m n) : map (g ∘ f) = (map g) ∘ (map f) :=
 begin
   ext,
   dsimp [map],
   split_ifs,
-   {  by_cases h2 : ((dite (x.val < l) (λ (h : x.val < l), fin.cast_succ (f (fin.cast_lt x h)))
-        (λ (h : ¬x.val < l), fin.last m)).val < m),
-    {
+  { -- x.val < l
+    by_cases h2 : ((dite (x.val < l) (λ h, fin.cast_succ (f (fin.cast_lt x h)))
+      (λ h, fin.last m)).val < m),
+    { -- (dite (x.val < l) (λ h, fin.cast_succ (f (fin.cast_lt x h))) (λ h, fin.last m)).val < m
       rw dif_pos h2,
       split_ifs,
       tidy,
       simp [cast_lt_cast_succ],
     },
-    {
+    { -- ¬((dite (x.val < l) (λ h, fin.cast_succ (f (fin.cast_lt x h))) (λ h, fin.last m)).val < m)
       rw dif_neg h2,
       split_ifs at h2,
-      sorry
-    }
+      rw [fin.cast_succ_val] at h2,
+      exact absurd ((f (fin.cast_lt x h)).is_lt) h2,
+    },
   },
-  {by_cases h2 : ((dite (x.val < l) (λ (h : x.val < l), fin.cast_succ (f (fin.cast_lt x h)))
-            (λ (h : ¬x.val < l), fin.last m)).val < m),
-    {
+  { -- ¬(x.val < l)
+    by_cases h2 : ((dite (x.val < l) (λ h, fin.cast_succ (f (fin.cast_lt x h)))
+            (λ h, fin.last m)).val < m),
+    { -- (dite (x.val < l) (λ h, fin.cast_succ (f (fin.cast_lt x h))) (λ h, fin.last m)).val < m
       rw dif_pos h2,
       split_ifs at h2,
       simp [fin.last] at h2,
       exact (absurd h2 (irrefl m)),
     },
-    {
+    { -- ¬((dite (x.val < l) (λ h, fin.cast_succ (f (fin.cast_lt x h))) (λ h, fin.last m)).val < m)
       rw dif_neg h2,
-    }
+    },
   }
 end
-
-lemma foo (n : ℕ) : ¬(n < n) := by library_search

--- a/src/category_theory/mwe.lean
+++ b/src/category_theory/mwe.lean
@@ -1,0 +1,51 @@
+import data.fin
+import tactic
+
+def hom (n m : ℕ) := fin n → fin m
+def map {n m : ℕ} (f : hom n m) : hom (n+1) (m+1) :=
+λ i, if h : i.val < n then (f (i.cast_lt h)).cast_succ else fin.last _
+
+lemma map_increasing {n m : ℕ} (f: hom n m) (h : monotone f) : monotone (map f) :=
+λ a b h,
+begin
+  dsimp [map],
+  split_ifs,
+  {tidy},
+  {apply fin.le_last},
+  {rw [fin.le_iff_val_le_val] at h,
+  linarith},
+  {apply fin.le_last}
+end
+
+lemma map_id {n m : ℕ} (f : hom n m) : map (@id (fin n)) = @id (fin (n+1)) :=
+funext (λ a,
+begin
+  dsimp [map],
+  split_ifs,
+  {tidy},
+  {exact (fin.ext_iff _ _).2  (eq.trans rfl (eq.symm (nat.eq_of_lt_succ_of_not_lt a.is_lt h)))}
+end)
+
+lemma map_comp {l m n : ℕ} (f : hom l m) (g : hom m n) : map (g ∘ f) = (map g) ∘ (map f) :=
+begin
+  ext,
+  dsimp [map],
+  split_ifs,
+   { split_ifs,
+    by_cases h2 : ((dite (x.val < l) (λ (h : x.val < l), fin.cast_succ (f (fin.cast_lt x h)))
+            (λ (h : ¬x.val < l), fin.last m)).val < m),
+    {
+      rw dif_pos h2,
+      split_ifs,
+      tidy,
+      sorry
+    },
+    {
+      rw dif_neg h2,
+      sorry
+    }
+  },
+  {
+    sorry
+  }-- succeeds, but does nothing
+end

--- a/src/category_theory/zigzag_2.lean
+++ b/src/category_theory/zigzag_2.lean
@@ -65,7 +65,14 @@ def above {n m : Δ} (f : n ⟶ m) (j : fin m) := { i : fin n | f i ≥ j }
 def T : Δ ⥤ Δ :=
 { obj := λ n, (n + 1 : ℕ),
   map := λ n m f, ⟨λ i, if h : i.val < n then (f (i.cast_lt h)).cast_succ else fin.last _, sorry⟩,
-  map_id' := sorry,
+  map_id' :=
+  λ n, Δ.hom_ext (funext (λ a,
+  begin
+    rw [Δ.mk_coe, Δ.id_coe],
+    split_ifs,
+    {tidy},
+    {exact (fin.ext_iff _ _).2  (eq.trans rfl (eq.symm (nat.eq_of_lt_succ_of_not_lt a.is_lt h)))}
+  end)),
   map_comp' := sorry, } -- see https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60split_ifs.60.2C.20and.20nested.20.60dite.60/near/167593063
 
 def Δ_ := ℕ
@@ -75,7 +82,12 @@ instance : has_coe Δ_ Δ :=
 instance category_Δ_ : category Δ_ :=
 { hom := λ n m, { f : fin (n+1) → fin (m+1) | monotone f ∧ f 0 = 0 ∧ f (fin.last _) = fin.last _ },
   id := λ n, ⟨id, by obviously⟩,
-  comp := λ l m n f g, ⟨g.val ∘ f.val, sorry⟩ }.
+  comp := λ l m n f g, ⟨g.val ∘ f.val,
+  by obviously,
+  /- These two proofs aren't very good since the naming f_property_right_left is done automatically
+  by tidy and could change is tidy was to change. -/
+  by {tidy, rwa [f_property_right_left]},
+  by {tidy, rwa [f_property_right_right]}⟩ }.
 
 def prime_obj (n : Δ) : Δ_ᵒᵖ := op (n + 1 : ℕ)
 def prime_map_fn {n m : Δ} (f : n ⟶ m) (j : fin (m + 2)) : fin (n + 2) := sorry

--- a/src/category_theory/zigzag_2.lean
+++ b/src/category_theory/zigzag_2.lean
@@ -71,7 +71,7 @@ def T : Δ ⥤ Δ :=
     rw [Δ.mk_coe, Δ.id_coe],
     split_ifs,
     {tidy},
-    {exact (fin.ext_iff _ _).2  (eq.trans rfl (eq.symm (nat.eq_of_lt_succ_of_not_lt a.is_lt h)))}
+    {exact fin.eq_of_veq (eq.trans rfl (eq.symm (nat.eq_of_lt_succ_of_not_lt a.is_lt h)))}
   end)),
   map_comp' := sorry, } -- see https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60split_ifs.60.2C.20and.20nested.20.60dite.60/near/167593063
 

--- a/src/category_theory/zigzag_2.lean
+++ b/src/category_theory/zigzag_2.lean
@@ -64,7 +64,19 @@ def above {n m : Δ} (f : n ⟶ m) (j : fin m) := { i : fin n | f i ≥ j }
 
 def T : Δ ⥤ Δ :=
 { obj := λ n, (n + 1 : ℕ),
-  map := λ n m f, ⟨λ i, if h : i.val < n then (f (i.cast_lt h)).cast_succ else fin.last _, sorry⟩,
+  map := λ n m f,
+  ⟨λ i, if h : i.val < n then (f (i.cast_lt h)).cast_succ else fin.last _,
+  λ a b h,
+  begin
+    tidy,
+    split_ifs,
+    {tidy},
+    {apply fin.le_last},
+    {rw [fin.le_iff_val_le_val] at h,
+    dsimp [(Δ)] at n, -- without this line linarith doesn't know that n : ℕ and fails
+    linarith},
+    {apply fin.le_last}
+  end⟩,
   map_id' :=
   λ n, Δ.hom_ext (funext (λ a,
   begin
@@ -73,7 +85,7 @@ def T : Δ ⥤ Δ :=
     {tidy},
     {exact fin.eq_of_veq (eq.trans rfl (eq.symm (nat.eq_of_lt_succ_of_not_lt a.is_lt h)))}
   end)),
-  map_comp' := sorry, } -- see https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60split_ifs.60.2C.20and.20nested.20.60dite.60/near/167593063
+  map_comp' := sorry } -- see https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60split_ifs.60.2C.20and.20nested.20.60dite.60/near/167593063
 
 def Δ_ := ℕ
 instance : has_coe Δ_ Δ :=


### PR DESCRIPTION
I added the file `mwe` for dealing with the lemmas that use `split_ifs` (based on this discussion https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60split_ifs.60.2C.20and.20nested.20.60dite.60/near/167593063). I have prove both `map_id` and `map_comp` in this setting but I haven't managed to translate the proof of `mam_comp` into the setting of the file `zigzag_2`. I also filled in the sorry in `instance category_Δ_` but the proofs are problematic as they rely on the behavior of tidy.