### PR TITLE
feat(string): `split_on` a `char`

### DIFF
--- a/src/data/string/defs.lean
+++ b/src/data/string/defs.lean
@@ -1,3 +1,4 @@
+import data.list.defs
 
 namespace string
 
@@ -6,5 +7,8 @@ intercalate (singleton c) ∘ f ∘ split (= c)
 
 def over_list (f : list char → list char) : string → string :=
 list.as_string ∘ f ∘ string.to_list
+
+def split_on (c : char) (s : string) :=
+(s.to_list.split_on c).map list.as_string
 
 end string

--- a/src/data/string/defs.lean
+++ b/src/data/string/defs.lean
@@ -8,7 +8,7 @@ intercalate (singleton c) ∘ f ∘ split (= c)
 def over_list (f : list char → list char) : string → string :=
 list.as_string ∘ f ∘ string.to_list
 
-def split_on (c : char) (s : string) :=
+def split_on (c : char) (s : string) : list string :=
 (s.to_list.split_on c).map list.as_string
 
 end string


### PR DESCRIPTION
Split a `string` at a `char`.

<br><br>

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
