### PR TITLE
feat(meta/expr): `simp` and `dsimp` an expr

### DIFF
--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -120,6 +120,26 @@ meta def is_num_eq : expr → expr → bool
 | `(%%a/%%a') `(%%b/%%b') :=  a.is_num_eq b
 | _ _ := ff
 
+meta def is_eq_or_iff_after_binders : expr → bool
+| (expr.pi n bi d b) := is_eq_or_iff_after_binders b
+| `(%%a = %%b)       := tt
+| `(%%a ↔ %%b)       := tt
+| _                  := ff
+
+meta def simp (t : expr)
+  (cfg : simp_config := {}) (discharger : tactic unit := failed)
+  (no_defaults := ff) (attr_names : list name := []) (hs : list simp_arg_type := []) :
+  tactic (expr × expr) :=
+do (s, to_unfold) ← mk_simp_set no_defaults attr_names hs,
+   simplify s to_unfold t cfg `eq discharger
+
+meta def dsimp (t : expr)
+  (cfg : dsimp_config := {})
+  (no_defaults := ff) (attr_names : list name := []) (hs : list simp_arg_type := []) :
+  tactic expr :=
+do (s, to_unfold) ← mk_simp_set no_defaults attr_names hs,
+   s.dsimplify to_unfold t cfg
+
 end expr
 
 

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -120,12 +120,6 @@ meta def is_num_eq : expr → expr → bool
 | `(%%a/%%a') `(%%b/%%b') :=  a.is_num_eq b
 | _ _ := ff
 
-meta def is_eq_or_iff_after_binders : expr → bool
-| (expr.pi n bi d b) := is_eq_or_iff_after_binders b
-| `(%%a = %%b)       := tt
-| `(%%a ↔ %%b)       := tt
-| _                  := ff
-
 meta def simp (t : expr)
   (cfg : simp_config := {}) (discharger : tactic unit := failed)
   (no_defaults := ff) (attr_names : list name := []) (hs : list simp_arg_type := []) :


### PR DESCRIPTION
Add a `simp` and `dsimp` function in the `expr` namespace, ~and a misc expr utility (similar in form to `is_num_eq` above it) for `rewrite_search`~.

<br><br>

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
