### PR TITLE
chore(src/tactic/interactive): `convert` docstring

### DIFF
--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -156,7 +156,8 @@ do h' ← get_unused_name `h,
 /--
 Similar to `refine` but generates equality proof obligations
 for every discrepancy between the goal and the type of the rule.
-`convert e using n` (with `n : ℕ`) bounds the depth of the search for discrepancies.
+`convert e using n` (with `n : ℕ`) bounds the depth of the search
+for discrepancies, analogous to `congr' n`.
 -/
 meta def convert (sym : parse (with_desc "←" (tk "<-")?)) (r : parse texpr) (n : parse (tk "using" *> small_nat)?) : tactic unit :=
 do v ← mk_mvar,

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -156,7 +156,7 @@ do h' ← get_unused_name `h,
 /--
 Similar to `refine` but generates equality proof obligations
 for every discrepancy between the goal and the type of the rule.
-`convert e using n` (n a nat) is also a thing (bounds the search).
+`convert e using n` (with `n : ℕ`) bounds the depth of the search for discrepancies.
 -/
 meta def convert (sym : parse (with_desc "←" (tk "<-")?)) (r : parse texpr) (n : parse (tk "using" *> small_nat)?) : tactic unit :=
 do v ← mk_mvar,

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -156,6 +156,7 @@ do h' ← get_unused_name `h,
 /--
 Similar to `refine` but generates equality proof obligations
 for every discrepancy between the goal and the type of the rule.
+`convert e using n` (n a nat) is also a thing (bounds the search).
 -/
 meta def convert (sym : parse (with_desc "←" (tk "<-")?)) (r : parse texpr) (n : parse (tk "using" *> small_nat)?) : tactic unit :=
 do v ← mk_mvar,


### PR DESCRIPTION
The `using` option to `convert` was not mentioned in the docstring, and I often struggle to remember the (perhaps slightly exotic?) `using` catchphrase

TO CONTRIBUTORS:

Make sure you have:

  * [x ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [x ] make sure definitions and lemmas are put in the right files
  * [x ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
