### PR TITLE
fix(data/matrix): add brackets to mul_neg and neg_mul to correct statement

### DIFF
--- a/src/data/matrix.lean
+++ b/src/data/matrix.lean
@@ -185,10 +185,10 @@ section ring
 variables [ring α]
 
 @[simp] theorem neg_mul (M : matrix m n α) (N : matrix n o α) :
-  (-M) ⬝ N = - (M ⬝ N) := by ext; simp [matrix.mul]
+  (-M) ⬝ N = -(M ⬝ N) := by ext; simp [matrix.mul]
 
 @[simp] theorem mul_neg (M : matrix m n α) (N : matrix n o α) :
-  M ⬝ (-N) = - M ⬝ N := by ext; simp [matrix.mul]
+  M ⬝ (-N) = -(M ⬝ N) := by ext; simp [matrix.mul]
 
 end ring
 

--- a/src/data/matrix.lean
+++ b/src/data/matrix.lean
@@ -185,15 +185,10 @@ section ring
 variables [ring α]
 
 @[simp] theorem neg_mul (M : matrix m n α) (N : matrix n o α) :
-  (-M) ⬝ N = - M ⬝ N := rfl
+  (-M) ⬝ N = - (M ⬝ N) := by ext; simp [matrix.mul]
 
 @[simp] theorem mul_neg (M : matrix m n α) (N : matrix n o α) :
-  M ⬝ (-N) = - M ⬝ N :=
-begin
-  ext i j,
-  unfold matrix.mul,
-  simp,
-end
+  M ⬝ (-N) = - M ⬝ N := by ext; simp [matrix.mul]
 
 end ring
 


### PR DESCRIPTION
Each side of `mul_neg` was identical.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
