### PR TITLE
 chore(data/matrix): rows and columns the right way around

### DIFF
--- a/src/data/matrix.lean
+++ b/src/data/matrix.lean
@@ -29,10 +29,10 @@ ext_iff.mp
 def transpose (M : matrix m n α) : matrix n m α
 | x y := M y x
 
-def row (w : m → α) : matrix m punit α
+def col (w : m → α) : matrix m punit α
 | x y := w x
 
-def col (v : n → α) : matrix punit n α
+def row (v : n → α) : matrix punit n α
 | x y := v y
 
 end ext
@@ -304,8 +304,8 @@ by ext i j; refl
 
 end transpose
 
-def minor (A : matrix m n α) (col : l → m) (row : o → n) : matrix l o α :=
-λ i j, A (col i) (row j)
+def minor (A : matrix m n α) (row : l → m) (col : o → n) : matrix l o α :=
+λ i j, A (row i) (col j)
 
 @[reducible]
 def sub_left {m l r : nat} (A : matrix (fin m) (fin (l + r)) α) : matrix (fin m) (fin l) α :=

--- a/src/data/matrix.lean
+++ b/src/data/matrix.lean
@@ -264,7 +264,7 @@ begin
 end
 
 lemma vec_mul_vec_eq (w : m → α) (v : n → α) :
-  vec_mul_vec w v = (row w) ⬝ (col v) :=
+  vec_mul_vec w v = (col w) ⬝ (row v) :=
 by simp [matrix.mul]; refl
 
 end semiring


### PR DESCRIPTION
It's ROWman CathOLic.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
