### PR TITLE
chore(algebra/order_functions): some proofs work for semirings

### DIFF
--- a/src/algebra/order_functions.lean
+++ b/src/algebra/order_functions.lean
@@ -239,6 +239,7 @@ max_distrib_of_monotone (monotone_mul_of_nonneg ha)
 
 lemma mul_min_of_nonneg (b c : α) (ha : 0 ≤ a) : a * min b c = min (a * b) (a * c) :=
 min_distrib_of_monotone (monotone_mul_of_nonneg ha)
+
 end decidable_linear_ordered_semiring
 
 section decidable_linear_ordered_comm_ring

--- a/src/algebra/order_functions.lean
+++ b/src/algebra/order_functions.lean
@@ -228,10 +228,8 @@ max_le_iff.2 (by split; simpa)
 
 end decidable_linear_ordered_comm_group
 
-section decidable_linear_ordered_comm_ring
-variables [decidable_linear_ordered_comm_ring α] {a b c d : α}
-
-@[simp] lemma abs_one : abs (1 : α) = 1 := abs_of_pos zero_lt_one
+section decidable_linear_ordered_semiring
+variables [decidable_linear_ordered_semiring α] {a b c d : α}
 
 lemma monotone_mul_of_nonneg (ha : 0 ≤ a) : monotone (λ x, a*x) :=
 assume b c b_le_c, mul_le_mul_of_nonneg_left b_le_c ha
@@ -241,6 +239,12 @@ max_distrib_of_monotone (monotone_mul_of_nonneg ha)
 
 lemma mul_min_of_nonneg (b c : α) (ha : 0 ≤ a) : a * min b c = min (a * b) (a * c) :=
 min_distrib_of_monotone (monotone_mul_of_nonneg ha)
+end decidable_linear_ordered_semiring
+
+section decidable_linear_ordered_comm_ring
+variables [decidable_linear_ordered_comm_ring α] {a b c d : α}
+
+@[simp] lemma abs_one : abs (1 : α) = 1 := abs_of_pos zero_lt_one
 
 lemma max_mul_mul_le_max_mul_max (b c : α) (ha : 0 ≤ a) (hd: 0 ≤ d) :
   max (a * b) (d * c) ≤ max a c * max d b :=


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)