### PR TITLE
refactor(topology/*): define and use dense_inducing

### DIFF
--- a/src/data/prod.lean
+++ b/src/data/prod.lean
@@ -79,7 +79,8 @@ instance lex.decidable [decidable_eq α] [decidable_eq β]
 
 end prod
 
-lemma function.injective_prod {f : α → γ} {g : β → δ}
-  (hf : ∀ {a a'}, f a = f a' → a = a') (hg : ∀ {b b'}, g b = g b' → b = b') :
-  ∀ p p' : α × β, (f p.1, g p.2) = (f p'.1, g p'.2) → p = p' :=
+open function
+
+lemma function.injective_prod {f : α → γ} {g : β → δ} (hf : injective f) (hg : injective g) :
+  injective (λ p : α × β, (f p.1, g p.2)) :=
 assume ⟨a₁, b₁⟩ ⟨a₂, b₂⟩, by { simp [prod.mk.inj_iff],exact λ ⟨eq₁, eq₂⟩, ⟨hf eq₁, hg eq₂⟩ }

--- a/src/data/prod.lean
+++ b/src/data/prod.lean
@@ -78,3 +78,8 @@ instance lex.decidable [decidable_eq α] [decidable_eq β]
 λ p q, decidable_of_decidable_of_iff (by apply_instance) (lex_def r s).symm
 
 end prod
+
+lemma function.injective_prod {f : α → γ} {g : β → δ}
+  (hf : ∀ {a a'}, f a = f a' → a = a') (hg : ∀ {b b'}, g b = g b' → b = b') :
+  ∀ p p' : α × β, (f p.1, g p.2) = (f p'.1, g p'.2) → p = p' :=
+assume ⟨a₁, b₁⟩ ⟨a₂, b₂⟩, by { simp [prod.mk.inj_iff],exact λ ⟨eq₁, eq₂⟩, ⟨hf eq₁, hg eq₂⟩ }

--- a/src/logic/function.lean
+++ b/src/logic/function.lean
@@ -218,6 +218,17 @@ end update
 lemma uncurry_def {α β γ} (f : α → β → γ) : uncurry f = (λp, f p.1 p.2) :=
 funext $ assume ⟨a, b⟩, rfl
 
+-- `uncurry'` is the version of `uncurry` with correct definitional reductions
+def uncurry' {α β γ} (f : α → β → γ) := λ p : α × β, f p.1 p.2
+
+@[simp]
+lemma curry_uncurry' {α : Type*} {β : Type*} {γ : Type*} (f : α → β → γ) : curry (uncurry' f) = f :=
+by funext ; refl
+
+@[simp]
+lemma uncurry'_curry {α : Type*} {β : Type*} {γ : Type*} (f : α × β → γ) : uncurry' (curry f) = f :=
+by { funext, simp [curry, uncurry', prod.mk.eta] }
+
 def restrict {α β} (f : α → β) (s : set α) : subtype s → β := λ x, f x.val
 
 theorem restrict_eq {α β} (f : α → β) (s : set α) : function.restrict f s = f ∘ (@subtype.val _ s) := rfl
@@ -238,6 +249,8 @@ lemma uncurry_bicompr (f : α → β → γ) (g : γ → δ) :
   uncurry (g ∘₂ f) = (g ∘ uncurry f) :=
 funext $ λ ⟨p, q⟩, rfl
 
+lemma uncurry'_bicompr (f : α → β → γ) (g : γ → δ) :
+  uncurry' (g ∘₂ f) = (g ∘ uncurry' f) := rfl
 end bicomp
 
 end function

--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -93,7 +93,7 @@ variables [normed_space ℝ γ]
 
 -- bochner integration over functions in l1 space
 def integral (f : α →₁ γ) : γ :=
-dense_embedding.extend dense_embedding_of_simple_func simple_func.integral f
+dense_embedding_of_simple_func.to_dense_inducing.extend simple_func.integral f
 
 end l1
 

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -270,7 +270,8 @@ theorem induced_orderable_topology' {α : Type u} {β : Type v}
 begin
   letI := induced f ta,
   refine ⟨eq_of_nhds_eq_nhds (λ a, _)⟩,
-  rw [nhds_induced_eq_comap, nhds_generate_from, @nhds_eq_orderable β _ _], apply le_antisymm,
+  rw [nhds_induced, nhds_generate_from, @nhds_eq_orderable β _ _],
+  apply le_antisymm,
   { refine le_infi (λ s, le_infi $ λ hs, le_principal_iff.2 _),
     rcases hs with ⟨ab, b, rfl|rfl⟩,
     { exact mem_comap_sets.2 ⟨{x | f b < x},

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -13,7 +13,8 @@ Uniform structure on topological groups:
 * `add_group_with_zero_nhd`: construct the topological structure from a group with a neighbourhood
   around zero. Then with `topological_add_group.to_uniform_space` one can derive a `uniform_space`.
 -/
-import topology.uniform_space.uniform_embedding topology.uniform_space.separation topology.algebra.group
+import topology.uniform_space.uniform_embedding topology.uniform_space.complete_separated
+import topology.algebra.group
 
 noncomputable theory
 local attribute [instance, priority 0] classical.prop_decidable
@@ -85,12 +86,12 @@ le_antisymm
       filter.map_mono (uniform_continuous_add uniform_continuous_id uniform_continuous_const))
 
 lemma uniform_embedding_translate (a : α) : uniform_embedding (λx:α, x + a) :=
-begin
-  refine ⟨assume x y, eq_of_add_eq_add_right, _⟩,
-  rw [← uniformity_translate a, comap_map] {occs := occurrences.pos [1]},
-  rintros ⟨p₁, p₂⟩ ⟨q₁, q₂⟩,
-  simp [prod.eq_iff_fst_eq_snd_eq] {contextual := tt}
-end
+{ comap_uniformity := begin
+    rw [← uniformity_translate a, comap_map] {occs := occurrences.pos [1]},
+    rintros ⟨p₁, p₂⟩ ⟨q₁, q₂⟩,
+    simp [prod.eq_iff_fst_eq_snd_eq] {contextual := tt}
+  end,
+  inj := assume x y, eq_of_add_eq_add_right }
 
 section
 variables (α)
@@ -312,7 +313,7 @@ variables [topological_space α] [add_comm_group α] [topological_add_group α]
 
 -- β is a dense subgroup of α, inclusion is denoted by e
 variables [topological_space β] [add_comm_group β] [topological_add_group β]
-variables {e : β → α} [is_add_group_hom e] (de : dense_embedding e)
+variables {e : β → α} [is_add_group_hom e] (de : dense_inducing e)
 include de
 
 lemma tendsto_sub_comap_self (x₀ : α) :
@@ -330,20 +331,7 @@ begin
 end
 end
 
-namespace dense_embedding
-open filter
-variables {α : Type*} [topological_space α]
-variables {β : Type*} [topological_space β]
-variables {γ : Type*} [uniform_space γ] [complete_space γ] [separated γ]
-
-lemma continuous_extend_of_cauchy {e : α → β} {f : α → γ}
-  (de : dense_embedding e) (h : ∀ b : β, cauchy (map f (comap e $ nhds b))) :
-  continuous (de.extend f) :=
-continuous_extend de $ λ b, complete_space.complete (h b)
-
-end dense_embedding
-
-namespace dense_embedding
+namespace dense_inducing
 variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*}
 variables {G : Type*}
 
@@ -354,8 +342,8 @@ variables [topological_space β] [add_comm_group β] [topological_add_group β]
 variables [topological_space γ] [add_comm_group γ] [topological_add_group γ]
 variables [topological_space δ] [add_comm_group δ] [topological_add_group δ]
 variables [uniform_space G] [add_comm_group G] [uniform_add_group G] [separated G] [complete_space G]
-variables {e : β → α} [is_add_group_hom e] (de : dense_embedding e)
-variables {f : δ → γ} [is_add_group_hom f] (df : dense_embedding f)
+variables {e : β → α} [is_add_group_hom e] (de : dense_inducing e)
+variables {f : δ → γ} [is_add_group_hom f] (df : dense_inducing f)
 variables {φ : β × δ → G} (hφ : continuous φ) [bilin : is_Z_bilin φ]
 
 include de df hφ bilin
@@ -385,7 +373,7 @@ private lemma extend_Z_bilin_key (x₀ : α) (y₀ : γ) :
 begin
   let Nx := nhds x₀,
   let Ny := nhds y₀,
-  let dp := dense_embedding.prod de df,
+  let dp := dense_inducing.prod de df,
   let ee := λ u : β × β, (e u.1, e u.2),
   let ff := λ u : δ × δ, (f u.1, f u.2),
 
@@ -445,22 +433,24 @@ begin
 
   exact W4 h₁ h₂ h₃ h₄
 end
+
 omit W'_nhd
 
+open dense_inducing
+
 /-- Bourbaki GT III.6.5 Theorem I:
-ℤ-bilinear continuous maps from dense sub-groups into a complete Hausdorff group extend by continuity.
+ℤ-bilinear continuous maps from dense images into a complete Hausdorff group extend by continuity.
 Note: Bourbaki assumes that α and β are also complete Hausdorff, but this is not necessary. -/
-theorem extend_Z_bilin  : continuous (extend (dense_embedding.prod de df) φ) :=
+theorem extend_Z_bilin  : continuous (extend (de.prod df) φ) :=
 begin
-  let dp := dense_embedding.prod de df,
-  refine dense_embedding.continuous_extend_of_cauchy (dense_embedding.prod de df) _,
+  refine continuous_extend_of_cauchy _ _,
   rintro ⟨x₀, y₀⟩,
   split,
   { apply map_ne_bot,
     apply comap_neq_bot,
 
     intros U h,
-    rcases exists_mem_of_ne_empty (mem_closure_iff_nhds.1 (dp.dense (x₀, y₀)) U h)
+    rcases exists_mem_of_ne_empty (mem_closure_iff_nhds.1 ((de.prod df).dense (x₀, y₀)) U h)
       with ⟨x, x_in, ⟨z, z_x⟩⟩,
     existsi z,
     cc },
@@ -494,4 +484,4 @@ begin
       rcases p with ⟨⟨x, y⟩, ⟨x', y'⟩⟩,
       apply h ; tauto } }
 end
-end dense_embedding
+end dense_inducing

--- a/src/topology/algebra/uniform_ring.lean
+++ b/src/topology/algebra/uniform_ring.lean
@@ -13,35 +13,46 @@ local attribute [instance] classical.prop_decidable
 noncomputable theory
 
 namespace uniform_space.completion
-open dense_embedding uniform_space
-variables (α : Type*) [ring α] [uniform_space α] [uniform_add_group α] [topological_ring α] [separated α]
-
-instance is_Z_bilin_mul : is_Z_bilin (λp:α×α, p.1 * p.2) :=
-⟨assume a a' b, add_mul a a' b, assume a b b', mul_add a b b'⟩
+open dense_inducing uniform_space function
+variables (α : Type*) [ring α] [uniform_space α] [uniform_add_group α] [topological_ring α]
 
 instance : has_one (completion α) := ⟨(1:α)⟩
 
-instance : has_mul (completion α) :=
-⟨λa b, extend (dense_embedding_coe.prod dense_embedding_coe)
-  ((coe : α → completion α) ∘ (λp:α×α, p.1 * p.2)) (a, b)⟩
+instance : has_mul (completion α) := ⟨curry $ (dense_inducing_coe.prod dense_inducing_coe).extend
+(coe ∘ uncurry' (*))⟩
 
+@[elim_cast]
 lemma coe_one : ((1 : α) : completion α) = 1 := rfl
 
-lemma continuous_mul' : continuous (λp:completion α×completion α, p.1 * p.2) :=
-suffices continuous $ extend (dense_embedding_coe.prod dense_embedding_coe) $
-  ((coe : α → completion α) ∘ (λp:α×α, p.1 * p.2)),
-{ convert this, ext ⟨a, b⟩, refl },
-extend_Z_bilin dense_embedding_coe dense_embedding_coe ((continuous_coe α).comp continuous_mul')
-
-section rules
 variables {α}
+
+@[move_cast]
 lemma coe_mul (a b : α) : ((a * b : α) : completion α) = a * b :=
-eq.symm (extend_e_eq (dense_embedding_coe.prod dense_embedding_coe) (a, b))
+((dense_inducing_coe.prod dense_inducing_coe).extend_eq_of_cont
+  ((continuous_coe α).comp continuous_mul') (a, b)).symm
+
+lemma continuous_mul' : continuous (λp:completion α×completion α, p.1 * p.2) :=
+begin
+  haveI : is_Z_bilin ((coe ∘ uncurry' (*)) : α × α → completion α) :=
+  { add_left := begin
+      introv,
+      change coe ((a + a')*b) = coe (a*b) + coe (a'*b),
+      rw_mod_cast add_mul
+    end,
+    add_right := begin
+      introv,
+      change coe (a*(b + b')) = coe (a*b) + coe (a*b'),
+      rw_mod_cast mul_add
+    end },
+  have : continuous ((coe ∘ uncurry' (*)) : α × α → completion α),
+    from (continuous_coe α).comp continuous_mul',
+  convert dense_inducing_coe.extend_Z_bilin dense_inducing_coe this,
+  simp only [(*), curry, prod.mk.eta]
+end
 
 lemma continuous_mul {β : Type*} [topological_space β] {f g : β → completion α}
   (hf : continuous f) (hg : continuous g) : continuous (λb, f b * g b) :=
-(continuous_mul' α).comp (continuous.prod_mk hf hg)
-end rules
+continuous_mul'.comp (continuous.prod_mk hf hg)
 
 instance : ring (completion α) :=
 { one_mul       := assume a, completion.induction_on a
@@ -78,26 +89,47 @@ instance : ring (completion α) :=
 
 instance is_ring_hom_coe : is_ring_hom (coe : α → completion α) :=
 ⟨coe_one α, assume a b, coe_mul a b, assume a b, coe_add a b⟩
-universe u
-instance is_ring_hom_extension
-  {β : Type u} [uniform_space β] [ring β] [uniform_add_group β] [topological_ring β]
-    [complete_space β] [separated β]
-  {f : α → β} [is_ring_hom f] (hf : continuous f) :
+
+universes u v
+variables {β : Type u} [uniform_space β] [ring β] [uniform_add_group β] [topological_ring β]
+          {f : α → β} [is_ring_hom f] (hf : continuous f)
+
+instance is_ring_hom_extension [complete_space β] [separated β] :
   is_ring_hom (completion.extension f) :=
 have hf : uniform_continuous f, from uniform_continuous_of_continuous hf,
 { map_one := by rw [← coe_one, extension_coe hf, is_ring_hom.map_one f],
   map_add := assume a b, completion.induction_on₂ a b
     (is_closed_eq
       (continuous_extension.comp continuous_add')
-      (continuous_add (continuous_extension.comp continuous_fst) (continuous_extension.comp continuous_snd)))
+      (continuous_add (continuous_extension.comp continuous_fst)
+                      (continuous_extension.comp continuous_snd)))
     (assume a b,
-      by rw [← coe_add, extension_coe hf, extension_coe hf, extension_coe hf, is_add_group_hom.map_add f]),
+      by rw [← coe_add, extension_coe hf, extension_coe hf, extension_coe hf,
+             is_add_group_hom.map_add f]),
   map_mul := assume a b, completion.induction_on₂ a b
     (is_closed_eq
-      (continuous_extension.comp (continuous_mul' α))
-      (_root_.continuous_mul (continuous_extension.comp continuous_fst) (continuous_extension.comp continuous_snd)))
+      (continuous_extension.comp continuous_mul')
+      (_root_.continuous_mul (continuous_extension.comp continuous_fst)
+                             (continuous_extension.comp continuous_snd)))
     (assume a b,
       by rw [← coe_mul, extension_coe hf, extension_coe hf, extension_coe hf, is_ring_hom.map_mul f]) }
+
+instance top_ring_compl : topological_ring (completion α) :=
+{ continuous_add := continuous_add',
+  continuous_mul := continuous_mul',
+  continuous_neg := continuous_neg' }
+
+instance is_ring_hom_map : is_ring_hom (completion.map f) :=
+completion.is_ring_hom_extension $ (continuous_coe β).comp hf
+
+variables (R : Type*) [comm_ring R] [uniform_space R] [uniform_add_group R] [topological_ring R]
+
+instance : comm_ring (completion R) :=
+{ mul_comm := assume a b, completion.induction_on₂ a b
+      (is_closed_eq (continuous_mul continuous_fst continuous_snd)
+                    (continuous_mul continuous_snd continuous_fst))
+      (assume a b, by rw [← coe_mul, ← coe_mul, mul_comm]),
+ ..completion.ring }
 
 end uniform_space.completion
 

--- a/src/topology/algebra/uniform_ring.lean
+++ b/src/topology/algebra/uniform_ring.lean
@@ -31,7 +31,7 @@ lemma coe_mul (a b : α) : ((a * b : α) : completion α) = a * b :=
 ((dense_inducing_coe.prod dense_inducing_coe).extend_eq_of_cont
   ((continuous_coe α).comp continuous_mul') (a, b)).symm
 
-lemma continuous_mul' : continuous (λp:completion α×completion α, p.1 * p.2) :=
+lemma continuous_mul' : continuous (λ p : completion α × completion α, p.1 * p.2) :=
 begin
   haveI : is_Z_bilin ((coe ∘ uncurry' (*)) : α × α → completion α) :=
   { add_left := begin
@@ -90,7 +90,7 @@ instance : ring (completion α) :=
 instance is_ring_hom_coe : is_ring_hom (coe : α → completion α) :=
 ⟨coe_one α, assume a b, coe_mul a b, assume a b, coe_add a b⟩
 
-universes u v
+universes u
 variables {β : Type u} [uniform_space β] [ring β] [uniform_add_group β] [topological_ring β]
           {f : α → β} [is_ring_hom f] (hf : continuous f)
 

--- a/src/topology/algebra/uniform_ring.lean
+++ b/src/topology/algebra/uniform_ring.lean
@@ -18,8 +18,8 @@ variables (α : Type*) [ring α] [uniform_space α] [uniform_add_group α] [topo
 
 instance : has_one (completion α) := ⟨(1:α)⟩
 
-instance : has_mul (completion α) := ⟨curry $ (dense_inducing_coe.prod dense_inducing_coe).extend
-(coe ∘ uncurry' (*))⟩
+instance : has_mul (completion α) :=
+  ⟨curry $ (dense_inducing_coe.prod dense_inducing_coe).extend (coe ∘ uncurry' (*))⟩
 
 @[elim_cast]
 lemma coe_one : ((1 : α) : completion α) = 1 := rfl

--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -901,7 +901,7 @@ variables [topological_space α] [topological_space β] [topological_space γ] [
 /-- The product of two dense inducings is a dense inducing -/
 protected def prod {e₁ : α → β} {e₂ : γ → δ} (de₁ : dense_inducing e₁) (de₂ : dense_inducing e₂) :
   dense_inducing (λ(p : α × γ), (e₁ p.1, e₂ p.2)) :=
-{ induced := (inducing_prod_mk de₁.to_inducing de₂.to_inducing).induced,
+{ induced := (de₁.to_inducing.prod_mk de₂.to_inducing).induced,
   dense := dense_range_prod de₁.dense de₂.dense }
 end dense_inducing
 

--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -35,7 +35,7 @@ lemma is_open_prod {s : set α} {t : set β} (hs : is_open s) (ht : is_open t) :
 is_open_inter (continuous_fst s hs) (continuous_snd t ht)
 
 lemma nhds_prod_eq {a : α} {b : β} : nhds (a, b) = filter.prod (nhds a) (nhds b) :=
-by rw [filter.prod, prod.topological_space, nhds_inf, nhds_induced_eq_comap, nhds_induced_eq_comap]
+by rw [filter.prod, prod.topological_space, nhds_inf, nhds_induced, nhds_induced]
 
 instance [topological_space α] [discrete_topology α] [topological_space β] [discrete_topology β] :
   discrete_topology (α × β) :=
@@ -136,6 +136,12 @@ show (λp:α×β, f p.1 p.2) (a, b) ∈ closure u, from
 lemma is_closed_prod [topological_space α] [topological_space β] {s₁ : set α} {s₂ : set β}
   (h₁ : is_closed s₁) (h₂ : is_closed s₂) : is_closed (set.prod s₁ s₂) :=
 closure_eq_iff_is_closed.mp $ by simp [h₁, h₂, closure_prod_eq, closure_eq_of_is_closed]
+
+lemma dense_range_prod [topological_space δ] {f : α → β} {g : γ → δ} (hf : dense_range f)
+  (hg : dense_range g) : dense_range (λ p : α × γ, (f p.1, g p.2)) :=
+have closure (range $ λ p : α×γ, (f p.1, g p.2)) = set.prod (closure $ range f) (closure $ range g),
+    by rw [←closure_prod_eq, prod_range_range_eq],
+assume ⟨b, d⟩, this.symm ▸ mem_prod.2 ⟨hf _, hg _⟩
 
 protected lemma is_open_map.prod
   [topological_space α] [topological_space β] [topological_space γ] [topological_space δ]
@@ -338,8 +344,7 @@ lemma continuous_sum_rec {f : α → γ} {g : β → γ}
 continuous_sup_dom hf hg
 
 lemma embedding_inl : embedding (@sum.inl α β) :=
-⟨λ _ _, sum.inl.inj_iff.mp,
-  begin
+⟨⟨begin
     unfold sum.topological_space,
     apply le_antisymm,
     { rw ← coinduced_le_iff_le_induced, exact lattice.le_sup_left },
@@ -353,11 +358,10 @@ lemma embedding_inl : embedding (@sum.inl α β) :=
       have : sum.inr ⁻¹' (@sum.inl α β '' u) = ∅ :=
         eq_empty_iff_forall_not_mem.mpr (assume a ⟨b, _, h⟩, sum.inl_ne_inr h), rw this,
       exact ⟨⟨hu, is_open_empty⟩, rfl⟩ }
-  end⟩
+  end⟩, λ _ _, sum.inl.inj_iff.mp⟩
 
 lemma embedding_inr : embedding (@sum.inr α β) :=
-⟨λ _ _, sum.inr.inj_iff.mp,
-  begin
+⟨⟨begin
     unfold sum.topological_space,
     apply le_antisymm,
     { rw ← coinduced_le_iff_le_induced, exact lattice.le_sup_right },
@@ -371,7 +375,7 @@ lemma embedding_inr : embedding (@sum.inr α β) :=
       have : sum.inr ⁻¹' (@sum.inr α β '' u) = u :=
         preimage_image_eq u (λ _ _, sum.inr.inj_iff.mp), rw this,
       exact ⟨⟨is_open_empty, hu⟩, rfl⟩ }
-  end⟩
+  end⟩, λ _ _, sum.inr.inj_iff.mp⟩
 
 instance [topological_space α] [topological_space β] [compact_space α] [compact_space β] :
   compact_space (α ⊕ β) :=
@@ -392,7 +396,7 @@ lemma embedding_graph {f : α → β} (hf : continuous f) : embedding (λx, (x, 
 embedding_of_embedding_compose (continuous_id.prod_mk hf) continuous_fst embedding_id
 
 lemma embedding_subtype_val : embedding (@subtype.val α p) :=
-⟨subtype.val_injective, rfl⟩
+⟨⟨rfl⟩, subtype.val_injective⟩
 
 lemma continuous_subtype_val : continuous (@subtype.val α p) :=
 continuous_induced_dom
@@ -414,7 +418,7 @@ map_nhds_induced_eq (by simp [subtype.val_image, h])
 
 lemma nhds_subtype_eq_comap {a : α} {h : p a} :
   nhds (⟨a, h⟩ : subtype p) = comap subtype.val (nhds a) :=
-nhds_induced_eq_comap
+nhds_induced _ _
 
 lemma tendsto_subtype_rng [topological_space α] {p : α → Prop} {b : filter β} {f : β → subtype p} :
   ∀{a:subtype p}, tendsto f b (nhds a) ↔ tendsto (λx, subtype.val (f x)) b (nhds a.val)
@@ -471,11 +475,11 @@ iff.intro (assume h, compact_image h hf.continuous) $ assume h, begin
   let u' : filter β := map f u,
   have : u' ≤ principal (f '' s), begin
     rw [map_le_iff_le_comap, comap_principal], convert us',
-    exact preimage_image_eq _ hf.1
+    exact preimage_image_eq _ hf.inj
   end,
   rcases h u' (ultrafilter_map hu) this with ⟨_, ⟨a, ha, ⟨⟩⟩, _⟩,
   refine ⟨a, ha, _⟩,
-  rwa [hf.2, nhds_induced_eq_comap, ←map_le_iff_le_comap]
+  rwa [hf.induced, nhds_induced, ←map_le_iff_le_comap]
 end
 
 lemma compact_iff_compact_in_subtype {s : set {a // p a}} :
@@ -544,7 +548,7 @@ continuous_infi_dom continuous_induced_dom
 lemma nhds_pi [t : ∀i, topological_space (π i)] {a : Πi, π i} :
   nhds a = (⨅i, comap (λx, x i) (nhds (a i))) :=
 calc nhds a = (⨅i, @nhds _ (@topological_space.induced _ _ (λx:Πi, π i, x i) (t i)) a) : nhds_infi
-  ... = (⨅i, comap (λx, x i) (nhds (a i))) : by simp [nhds_induced_eq_comap]
+  ... = (⨅i, comap (λx, x i) (nhds (a i))) : by simp [nhds_induced]
 
 /-- Tychonoff's theorem -/
 lemma compact_pi_infinite [∀i, topological_space (π i)] {s : Πi:ι, set (π i)} :
@@ -713,7 +717,7 @@ continuous_sigma $ λ i,
 lemma embedding_sigma_map {τ : ι → Type*} [Π i, topological_space (τ i)]
   {f : Π i, σ i → τ i} (hf : ∀ i, embedding (f i)) : embedding (sigma.map id f) :=
 begin
-  refine ⟨injective_sigma_map function.injective_id (λ i, (hf i).1), _⟩,
+  refine ⟨⟨_⟩, injective_sigma_map function.injective_id (λ i, (hf i).inj)⟩,
   refine le_antisymm
     (continuous_iff_le_induced.mp (continuous_sigma_map (λ i, (hf i).continuous))) _,
   intros s hs,
@@ -722,7 +726,7 @@ begin
   { intro i,
     apply is_open_induced_iff.mp,
     convert hs i,
-    exact (hf i).2.symm },
+    exact (hf i).induced.symm },
   choose t ht using this,
   apply is_open_induced_iff.mpr,
   refine ⟨⋃ i, sigma.mk i '' t i, is_open_Union (λ i, is_open_map_sigma_mk _ (ht i).1), _⟩,
@@ -889,6 +893,15 @@ continuous_iff_continuous_at.mpr $ assume ⟨a, l⟩, continuous_at_remove_nth
 
 end vector
 
+namespace dense_inducing
+variables [topological_space α] [topological_space β] [topological_space γ] [topological_space δ]
+
+/-- The product of two dense inducings is a dense inducing -/
+protected def prod {e₁ : α → β} {e₂ : γ → δ} (de₁ : dense_inducing e₁) (de₂ : dense_inducing e₂) :
+  dense_inducing (λ(p : α × γ), (e₁ p.1, e₂ p.2)) :=
+{ induced := (inducing_prod_mk de₁.to_inducing de₂.to_inducing).induced,
+  dense := dense_range_prod de₁.dense de₂.dense }
+end dense_inducing
 
 namespace dense_embedding
 variables [topological_space α] [topological_space β] [topological_space γ] [topological_space δ]
@@ -896,16 +909,9 @@ variables [topological_space α] [topological_space β] [topological_space γ] [
 /-- The product of two dense embeddings is a dense embedding -/
 protected def prod {e₁ : α → β} {e₂ : γ → δ} (de₁ : dense_embedding e₁) (de₂ : dense_embedding e₂) :
   dense_embedding (λ(p : α × γ), (e₁ p.1, e₂ p.2)) :=
-{ dense_embedding .
-  dense   :=
-    have closure (range (λ(p : α × γ), (e₁ p.1, e₂ p.2))) =
-        set.prod (closure (range e₁)) (closure (range e₂)),
-      by rw [←closure_prod_eq, prod_range_range_eq],
-    assume ⟨b, d⟩, begin rw [this], simp, constructor, apply de₁.dense, apply de₂.dense end,
-  inj     := assume ⟨x₁, x₂⟩ ⟨y₁, y₂⟩,
+{ inj := assume ⟨x₁, x₂⟩ ⟨y₁, y₂⟩,
     by simp; exact assume h₁ h₂, ⟨de₁.inj h₁, de₂.inj h₂⟩,
-  induced := assume ⟨a, b⟩,
-    by rw [nhds_prod_eq, nhds_prod_eq, ←prod_comap_comap_eq, de₁.induced, de₂.induced] }
+  ..dense_inducing.prod de₁.to_dense_inducing de₂.to_dense_inducing }
 
 def subtype_emb (p : α → Prop) {e : α → β} (de : dense_embedding e) (x : {x // p x}) :
   {x // x ∈ closure (e '' {x | p x})} :=
@@ -924,8 +930,8 @@ protected def subtype (p : α → Prop) {e : α → β} (de : dense_embedding e)
       assumption
     end,
   inj     := assume ⟨x, hx⟩ ⟨y, hy⟩ h, subtype.eq $ de.inj $ @@congr_arg subtype.val h,
-  induced := assume ⟨x, hx⟩,
-    by simp [subtype_emb, nhds_subtype_eq_comap, comap_comap_comp, (∘), (de.induced x).symm] }
+  induced := (induced_iff_nhds_eq _).2 (assume ⟨x, hx⟩,
+    by simp [subtype_emb, nhds_subtype_eq_comap, de.to_inducing.nhds_eq_comap, comap_comap_comp, (∘)]) }
 
 end dense_embedding
 
@@ -942,14 +948,15 @@ lemma is_closed_property2 [topological_space α] [topological_space β] {e : α 
   (he : dense_embedding e) (hp : is_closed {q:β×β | p q.1 q.2}) (h : ∀a₁ a₂, p (e a₁) (e a₂)) :
   ∀b₁ b₂, p b₁ b₂ :=
 have ∀q:β×β, p q.1 q.2,
-  from is_closed_property (he.prod he).closure_range hp $ assume a, h _ _,
+  from is_closed_property (he.prod he).to_dense_inducing.closure_range hp $ assume a, h _ _,
 assume b₁ b₂, this ⟨b₁, b₂⟩
 
 lemma is_closed_property3 [topological_space α] [topological_space β] {e : α → β} {p : β → β → β → Prop}
   (he : dense_embedding e) (hp : is_closed {q:β×β×β | p q.1 q.2.1 q.2.2}) (h : ∀a₁ a₂ a₃, p (e a₁) (e a₂) (e a₃)) :
   ∀b₁ b₂ b₃, p b₁ b₂ b₃ :=
 have ∀q:β×β×β, p q.1 q.2.1 q.2.2,
-  from is_closed_property (he.prod $ he.prod he).closure_range hp $ assume ⟨a₁, a₂, a₃⟩, h _ _ _,
+  from is_closed_property (he.prod $ he.prod he).to_dense_inducing.closure_range hp $
+    assume ⟨a₁, a₂, a₃⟩, h _ _ _,
 assume b₁ b₂ b₃, this ⟨b₁, b₂, b₃⟩
 
 lemma mem_closure_of_continuous [topological_space α] [topological_space β]
@@ -1044,12 +1051,12 @@ lemma compact_preimage {s : set β} (h : α ≃ₜ β) : compact (h ⁻¹' s) �
 by rw ← image_symm; exact h.symm.compact_image
 
 protected lemma embedding (h : α ≃ₜ β) : embedding h :=
-⟨h.to_equiv.injective, h.induced_eq.symm⟩
+⟨⟨h.induced_eq.symm⟩, h.to_equiv.injective⟩
 
 protected lemma dense_embedding (h : α ≃ₜ β) : dense_embedding h :=
 { dense   := assume a, by rw [h.range_coe, closure_univ]; trivial,
   inj     := h.to_equiv.injective,
-  induced := assume a, by rw [← nhds_induced_eq_comap, h.induced_eq] }
+  induced := (induced_iff_nhds_eq _).2 (assume a, by rw [← nhds_induced, h.induced_eq]) }
 
 protected lemma is_open_map (h : α ≃ₜ β) : is_open_map h :=
 begin

--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -344,7 +344,7 @@ lemma continuous_sum_rec {f : α → γ} {g : β → γ}
 continuous_sup_dom hf hg
 
 lemma embedding_inl : embedding (@sum.inl α β) :=
-⟨⟨begin
+{ induced := begin
     unfold sum.topological_space,
     apply le_antisymm,
     { rw ← coinduced_le_iff_le_induced, exact lattice.le_sup_left },
@@ -358,10 +358,11 @@ lemma embedding_inl : embedding (@sum.inl α β) :=
       have : sum.inr ⁻¹' (@sum.inl α β '' u) = ∅ :=
         eq_empty_iff_forall_not_mem.mpr (assume a ⟨b, _, h⟩, sum.inl_ne_inr h), rw this,
       exact ⟨⟨hu, is_open_empty⟩, rfl⟩ }
-  end⟩, λ _ _, sum.inl.inj_iff.mp⟩
+  end,
+  inj := λ _ _, sum.inl.inj_iff.mp }
 
 lemma embedding_inr : embedding (@sum.inr α β) :=
-⟨⟨begin
+{ induced := begin
     unfold sum.topological_space,
     apply le_antisymm,
     { rw ← coinduced_le_iff_le_induced, exact lattice.le_sup_right },
@@ -375,7 +376,8 @@ lemma embedding_inr : embedding (@sum.inr α β) :=
       have : sum.inr ⁻¹' (@sum.inr α β '' u) = u :=
         preimage_image_eq u (λ _ _, sum.inr.inj_iff.mp), rw this,
       exact ⟨⟨is_open_empty, hu⟩, rfl⟩ }
-  end⟩, λ _ _, sum.inr.inj_iff.mp⟩
+  end,
+  inj := λ _ _, sum.inr.inj_iff.mp }
 
 instance [topological_space α] [topological_space β] [compact_space α] [compact_space β] :
   compact_space (α ⊕ β) :=

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -48,8 +48,7 @@ instance : second_countable_topology ennreal :=
     end)⟩⟩
 
 lemma embedding_coe : embedding (coe : nnreal → ennreal) :=
-and.intro (assume a b, coe_eq_coe.1) $
-begin
+⟨⟨begin
   refine le_antisymm _ _,
   { rw [orderable_topology.topology_eq_generate_intervals ennreal,
       ← coinduced_le_iff_le_induced],
@@ -63,8 +62,9 @@ begin
     refine le_generate_from (assume s ha, _),
     rcases ha with ⟨a, rfl | rfl⟩,
     exact ⟨{b : ennreal | ↑a < b}, @is_open_lt' ennreal ennreal.topological_space _ _ _, by simp⟩,
-    exact ⟨{b : ennreal | b < ↑a}, @is_open_gt' ennreal ennreal.topological_space _ _ _, by simp⟩, },
-end
+    exact ⟨{b : ennreal | b < ↑a}, @is_open_gt' ennreal ennreal.topological_space _ _ _, by simp⟩ }
+  end⟩,
+  assume a b, coe_eq_coe.1⟩
 
 lemma is_open_ne_top : is_open {a : ennreal | a ≠ ⊤} :=
 is_open_neg (is_closed_eq continuous_id continuous_const)
@@ -85,7 +85,7 @@ continuous (λa, (f a : ennreal)) ↔ continuous f :=
 embedding_coe.continuous_iff.symm
 
 lemma nhds_coe {r : nnreal} : nhds (r : ennreal) = (nhds r).map coe :=
-by rw [embedding_coe.2, map_nhds_induced_eq coe_range_mem_nhds]
+by rw [embedding_coe.induced, map_nhds_induced_eq coe_range_mem_nhds]
 
 lemma nhds_coe_coe {r p : nnreal} : nhds ((r : ennreal), (p : ennreal)) =
   (nhds (r, p)).map (λp:nnreal×nnreal, (p.1, p.2)) :=

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -90,7 +90,7 @@ by rw [embedding_coe.induced, map_nhds_induced_eq coe_range_mem_nhds]
 lemma nhds_coe_coe {r p : nnreal} : nhds ((r : ennreal), (p : ennreal)) =
   (nhds (r, p)).map (λp:nnreal×nnreal, (p.1, p.2)) :=
 begin
-  rw [(embedding_prod_mk embedding_coe embedding_coe).map_nhds_eq],
+  rw [(embedding_coe.prod_mk embedding_coe).map_nhds_eq],
   rw [← prod_range_range_eq],
   exact prod_mem_nhds_sets coe_range_mem_nhds coe_range_mem_nhds
 end

--- a/src/topology/instances/real.lean
+++ b/src/topology/instances/real.lean
@@ -60,7 +60,7 @@ let ⟨ε,ε0, hε⟩ := mem_nhds_iff.1 ht in
 let ⟨q, h⟩ := exists_rat_near x ε0 in
 ne_empty_iff_exists_mem.2 ⟨_, hε (mem_ball'.2 h), q, rfl⟩
 
-theorem embedding_of_rat : embedding (coe : ℚ → ℝ) := dense_embedding_of_rat.embedding
+theorem embedding_of_rat : embedding (coe : ℚ → ℝ) := dense_embedding_of_rat.to_embedding
 
 theorem continuous_of_rat : continuous (coe : ℚ → ℝ) := uniform_continuous_of_rat.continuous
 
@@ -71,7 +71,7 @@ let ⟨δ, δ0, Hδ⟩ := rat_add_continuous_lemma abs ε0 in
 
 -- TODO(Mario): Find a way to use rat_add_continuous_lemma
 theorem rat.uniform_continuous_add : uniform_continuous (λp : ℚ × ℚ, p.1 + p.2) :=
-uniform_embedding_of_rat.uniform_continuous_iff.2 $ by simp [(∘)]; exact
+uniform_embedding_of_rat.to_uniform_inducing.uniform_continuous_iff.2 $ by simp [(∘)]; exact
 real.uniform_continuous_add.comp ((uniform_continuous_of_rat.comp uniform_continuous_fst).prod_mk
   (uniform_continuous_of_rat.comp uniform_continuous_snd))
 

--- a/src/topology/maps.lean
+++ b/src/topology/maps.lean
@@ -163,30 +163,30 @@ by { ext x, rw [set.mem_preimage, ← closure_induced he.inj, he.induced] }
 
 end embedding
 
-structure dense_inducing [topological_space α] [topological_space β] (e : α → β)
-  extends inducing e : Prop :=
-(dense   : ∀x, x ∈ closure (range e))
+structure dense_inducing [topological_space α] [topological_space β] (i : α → β)
+  extends inducing i : Prop  :=
+(dense   : ∀x, x ∈ closure (range i))
 
 namespace dense_inducing
 variables [topological_space α] [topological_space β]
-variables {e : α → β} (di : dense_inducing e)
+variables {i : α → β} (di : dense_inducing i)
 
-lemma nhds_eq_comap (di : dense_inducing e) :
-  ∀ a : α, nhds a = comap e (nhds $ e a) :=
-di.induced.symm ▸ nhds_induced e
+lemma nhds_eq_comap (di : dense_inducing i) :
+  ∀ a : α, nhds a = comap i (nhds $ i a) :=
+di.induced.symm ▸ nhds_induced i
 
-protected lemma continuous_at (di : dense_inducing e) {a : α} : continuous_at e a :=
+protected lemma continuous_at (di : dense_inducing i) {a : α} : continuous_at i a :=
 by rw [continuous_at, di.nhds_eq_comap a]; exact tendsto_comap
 
-protected lemma continuous (de : dense_inducing e) : continuous e :=
+protected lemma continuous (de : dense_inducing i) : continuous i :=
 continuous_iff_continuous_at.mpr $ λ a, de.continuous_at
 
-lemma closure_range : closure (range e) = univ :=
+lemma closure_range : closure (range i) = univ :=
 let h := di.dense in
 set.ext $ assume x, ⟨assume _, trivial, assume _, @h x⟩
 
-lemma self_sub_closure_image_preimage_of_open {s : set β} (di : dense_inducing e) :
-  is_open s → s ⊆ closure (e '' (e ⁻¹' s)) :=
+lemma self_sub_closure_image_preimage_of_open {s : set β} (di : dense_inducing i) :
+  is_open s → s ⊆ closure (i '' (i ⁻¹' s)) :=
 begin
   intros s_op b b_in_s,
   rw [image_preimage_eq_inter_range, mem_closure_iff],
@@ -196,20 +196,20 @@ begin
   exact (dense_iff_inter_open.1 di.closure_range) _ (is_open_inter U_op s_op) ne_e
 end
 
-lemma closure_image_nhds_of_nhds {s : set α} {a : α} (di : dense_inducing e) :
-  s ∈ nhds a → closure (e '' s) ∈ nhds (e a) :=
+lemma closure_image_nhds_of_nhds {s : set α} {a : α} (di : dense_inducing i) :
+  s ∈ nhds a → closure (i '' s) ∈ nhds (i a) :=
 begin
   rw [di.nhds_eq_comap a, mem_comap_sets],
   intro h,
   rcases h with ⟨t, t_nhd, sub⟩,
   rw mem_nhds_sets_iff at t_nhd,
   rcases t_nhd with ⟨U, U_sub, ⟨U_op, e_a_in_U⟩⟩,
-  have := calc e ⁻¹' U ⊆ e⁻¹' t : preimage_mono U_sub
+  have := calc i ⁻¹' U ⊆ i⁻¹' t : preimage_mono U_sub
                    ... ⊆ s      : sub,
-  have := calc U ⊆ closure (e '' (e ⁻¹' U)) : self_sub_closure_image_preimage_of_open di U_op
-             ... ⊆ closure (e '' s)         : closure_mono (image_subset e this),
-  have U_nhd : U ∈ nhds (e a) := mem_nhds_sets U_op e_a_in_U,
-  exact (nhds (e a)).sets_of_superset U_nhd this
+  have := calc U ⊆ closure (i '' (i ⁻¹' U)) : self_sub_closure_image_preimage_of_open di U_op
+             ... ⊆ closure (i '' s)         : closure_mono (image_subset i this),
+  have U_nhd : U ∈ nhds (i a) := mem_nhds_sets U_op e_a_in_U,
+  exact (nhds (i a)).sets_of_superset U_nhd this
 end
 
 variables [topological_space δ] {f : γ → α} {g : γ → δ} {h : δ → β}
@@ -218,72 +218,72 @@ variables [topological_space δ] {f : γ → α} {g : γ → δ} {h : δ → β}
 g↓     ↓e
  δ -h→ β
 -/
-lemma tendsto_comap_nhds_nhds  {d : δ} {a : α} (di : dense_inducing e) (H : tendsto h (nhds d) (nhds (e a)))
-  (comm : h ∘ g = e ∘ f) : tendsto f (comap g (nhds d)) (nhds a) :=
+lemma tendsto_comap_nhds_nhds  {d : δ} {a : α} (di : dense_inducing i) (H : tendsto h (nhds d) (nhds (i a)))
+  (comm : h ∘ g = i ∘ f) : tendsto f (comap g (nhds d)) (nhds a) :=
 begin
   have lim1 : map g (comap g (nhds d)) ≤ nhds d := map_comap_le,
   replace lim1 : map h (map g (comap g (nhds d))) ≤ map h (nhds d) := map_mono lim1,
   rw [filter.map_map, comm, ← filter.map_map, map_le_iff_le_comap] at lim1,
-  have lim2 :  comap e (map h (nhds d)) ≤  comap e  (nhds (e a)) := comap_mono H,
+  have lim2 :  comap i (map h (nhds d)) ≤  comap i  (nhds (i a)) := comap_mono H,
   rw ← di.nhds_eq_comap at lim2,
   exact le_trans lim1 lim2,
 end
 
-protected lemma nhds_inf_neq_bot (di : dense_inducing e) {b : β} : nhds b ⊓ principal (range e) ≠ ⊥ :=
+protected lemma nhds_inf_neq_bot (di : dense_inducing i) {b : β} : nhds b ⊓ principal (range i) ≠ ⊥ :=
 begin
   have h := di.dense,
   simp [closure_eq_nhds] at h,
   exact h _
 end
 
-lemma comap_nhds_neq_bot (di : dense_inducing e) {b : β} : comap e (nhds b) ≠ ⊥ :=
+lemma comap_nhds_neq_bot (di : dense_inducing i) {b : β} : comap i (nhds b) ≠ ⊥ :=
 forall_sets_neq_empty_iff_neq_bot.mp $
-assume s ⟨t, ht, (hs : e ⁻¹' t ⊆ s)⟩,
-have t ∩ range e ∈ nhds b ⊓ principal (range e),
+assume s ⟨t, ht, (hs : i ⁻¹' t ⊆ s)⟩,
+have t ∩ range i ∈ nhds b ⊓ principal (range i),
   from inter_mem_inf_sets ht (subset.refl _),
 let ⟨_, ⟨hx₁, y, rfl⟩⟩ := inhabited_of_mem_sets di.nhds_inf_neq_bot this in
 subset_ne_empty hs $ ne_empty_of_mem hx₁
 
 variables [topological_space γ]
-/-- If `e : α → β` is a dense inducing, then any function `α → γ` "extends" to a function `β → γ`. -/
-def extend (di : dense_inducing e) (f : α → γ) (b : β) : γ :=
-@lim _ _ ⟨f (dense_range.inhabited di.dense b).default⟩ (map f (comap e (nhds b)))
+/-- If `i : α → β` is a dense inducing, then any function `α → γ` "extends" to a function `β → γ`. -/
+def extend (di : dense_inducing i) (f : α → γ) (b : β) : γ :=
+@lim _ _ ⟨f (dense_range.inhabited di.dense b).default⟩ (map f (comap i (nhds b)))
 
-lemma extend_eq [t2_space γ] {b : β} {c : γ} {f : α → γ} (hf : map f (comap e (nhds b)) ≤ nhds c) :
+lemma extend_eq [t2_space γ] {b : β} {c : γ} {f : α → γ} (hf : map f (comap i (nhds b)) ≤ nhds c) :
   di.extend f b = c :=
 @lim_eq _ _ (id _) _ _ _ (by simp; exact comap_nhds_neq_bot di) hf
 
 lemma extend_e_eq [t2_space γ] {f : α → γ} (a : α) (hf : continuous_at f a) :
-  di.extend f (e a) = f a :=
+  di.extend f (i a) = f a :=
 extend_eq _ $ di.nhds_eq_comap a ▸ hf
 
 lemma extend_eq_of_cont [t2_space γ] {f : α → γ} (hf : continuous f) (a : α) :
-  di.extend f (e a) = f a :=
+  di.extend f (i a) = f a :=
 di.extend_e_eq a (continuous_iff_continuous_at.1 hf a)
 
-lemma tendsto_extend [regular_space γ] {b : β} {f : α → γ} (di : dense_inducing e)
-  (hf : {b | ∃c, tendsto f (comap e $ nhds b) (nhds c)} ∈ nhds b) :
+lemma tendsto_extend [regular_space γ] {b : β} {f : α → γ} (di : dense_inducing i)
+  (hf : {b | ∃c, tendsto f (comap i $ nhds b) (nhds c)} ∈ nhds b) :
   tendsto (di.extend f) (nhds b) (nhds (di.extend f b)) :=
-let φ := {b | tendsto f (comap e $ nhds b) (nhds $ di.extend f b)} in
+let φ := {b | tendsto f (comap i $ nhds b) (nhds $ di.extend f b)} in
 have hφ : φ ∈ nhds b,
   from (nhds b).sets_of_superset hf $ assume b ⟨c, hc⟩,
-    show tendsto f (comap e (nhds b)) (nhds (di.extend f b)), from (di.extend_eq hc).symm ▸ hc,
+    show tendsto f (comap i (nhds b)) (nhds (di.extend f b)), from (di.extend_eq hc).symm ▸ hc,
 assume s hs,
 let ⟨s'', hs''₁, hs''₂, hs''₃⟩ := nhds_is_closed hs in
-let ⟨s', hs'₁, (hs'₂ : e ⁻¹' s' ⊆ f ⁻¹' s'')⟩ := mem_of_nhds hφ hs''₁ in
+let ⟨s', hs'₁, (hs'₂ : i ⁻¹' s' ⊆ f ⁻¹' s'')⟩ := mem_of_nhds hφ hs''₁ in
 let ⟨t, (ht₁ : t ⊆ φ ∩ s'), ht₂, ht₃⟩ := mem_nhds_sets_iff.mp $ inter_mem_sets hφ hs'₁ in
-have h₁ : closure (f '' (e ⁻¹' s')) ⊆ s'',
+have h₁ : closure (f '' (i ⁻¹' s')) ⊆ s'',
   by rw [closure_subset_iff_subset_of_is_closed hs''₃, image_subset_iff]; exact hs'₂,
-have h₂ : t ⊆ di.extend f ⁻¹' closure (f '' (e ⁻¹' t)), from
+have h₂ : t ⊆ di.extend f ⁻¹' closure (f '' (i ⁻¹' t)), from
   assume b' hb',
   have nhds b' ≤ principal t, by simp; exact mem_nhds_sets ht₂ hb',
-  have map f (comap e (nhds b')) ≤ nhds (di.extend f b') ⊓ principal (f '' (e ⁻¹' t)),
-    from calc _ ≤ map f (comap e (nhds b' ⊓ principal t)) : map_mono $ comap_mono $ le_inf (le_refl _) this
-      ... ≤ map f (comap e (nhds b')) ⊓ map f (comap e (principal t)) :
+  have map f (comap i (nhds b')) ≤ nhds (di.extend f b') ⊓ principal (f '' (i ⁻¹' t)),
+    from calc _ ≤ map f (comap i (nhds b' ⊓ principal t)) : map_mono $ comap_mono $ le_inf (le_refl _) this
+      ... ≤ map f (comap i (nhds b')) ⊓ map f (comap i (principal t)) :
         le_inf (map_mono $ comap_mono $ inf_le_left) (map_mono $ comap_mono $ inf_le_right)
-      ... ≤ map f (comap e (nhds b')) ⊓ principal (f '' (e ⁻¹' t)) : by simp [le_refl]
+      ... ≤ map f (comap i (nhds b')) ⊓ principal (f '' (i ⁻¹' t)) : by simp [le_refl]
       ... ≤ _ : inf_le_inf ((ht₁ hb').left) (le_refl _),
-  show di.extend f b' ∈ closure (f '' (e ⁻¹' t)),
+  show di.extend f b' ∈ closure (f '' (i ⁻¹' t)),
   begin
     rw [closure_eq_nhds],
     apply neq_bot_of_le_neq_bot _ this,
@@ -292,24 +292,24 @@ have h₂ : t ⊆ di.extend f ⁻¹' closure (f '' (e ⁻¹' t)), from
   end,
 (nhds b).sets_of_superset
   (show t ∈ nhds b, from mem_nhds_sets ht₂ ht₃)
-  (calc t ⊆ di.extend f ⁻¹' closure (f '' (e ⁻¹' t)) : h₂
-    ... ⊆ di.extend f ⁻¹' closure (f '' (e ⁻¹' s')) :
+  (calc t ⊆ di.extend f ⁻¹' closure (f '' (i ⁻¹' t)) : h₂
+    ... ⊆ di.extend f ⁻¹' closure (f '' (i ⁻¹' s')) :
       preimage_mono $ closure_mono $ image_subset f $ preimage_mono $ subset.trans ht₁ $ inter_subset_right _ _
     ... ⊆ di.extend f ⁻¹' s'' : preimage_mono h₁
     ... ⊆ di.extend f ⁻¹' s : preimage_mono hs''₂)
 
-lemma continuous_extend [regular_space γ] {f : α → γ} (di : dense_inducing e)
-  (hf : ∀b, ∃c, tendsto f (comap e (nhds b)) (nhds c)) : continuous (di.extend f) :=
+lemma continuous_extend [regular_space γ] {f : α → γ} (di : dense_inducing i)
+  (hf : ∀b, ∃c, tendsto f (comap i (nhds b)) (nhds c)) : continuous (di.extend f) :=
 continuous_iff_continuous_at.mpr $ assume b, di.tendsto_extend $ univ_mem_sets' hf
 
 lemma mk'
-  [topological_space α] [topological_space β] (e : α → β)
-  (c     : continuous e)
-  (dense : ∀x, x ∈ closure (range e))
+  [topological_space α] [topological_space β] (i : α → β)
+  (c     : continuous i)
+  (dense : ∀x, x ∈ closure (range i))
   (H     : ∀ (a:α) s ∈ nhds a,
-    ∃t ∈ nhds (e a), ∀ b, e b ∈ t → b ∈ s) :
-  dense_inducing e :=
-{ induced := (induced_iff_nhds_eq e).2 $
+    ∃t ∈ nhds (i a), ∀ b, i b ∈ t → b ∈ s) :
+  dense_inducing i :=
+{ induced := (induced_iff_nhds_eq i).2 $
     λ a, le_antisymm (tendsto_iff_comap.1 $ c.tendsto _) (by simpa [le_def] using H a),
   dense := dense }
 end dense_inducing

--- a/src/topology/maps.lean
+++ b/src/topology/maps.lean
@@ -13,109 +13,179 @@ local attribute [instance] classical.prop_decidable
 
 variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*}
 
+section dense_range
+variables [topological_space α] [topological_space β] [topological_space γ]
+          (f : α → β) (g : β → γ)
+
+def dense_range := ∀ x, x ∈ closure (range f)
+
+lemma dense_range_iff_closure_eq : dense_range f ↔ closure (range f) = univ :=
+eq_univ_iff_forall.symm
+
+variables {f}
+
+lemma dense_range_comp (hf : dense_range f) (hg : dense_range g) (cg : continuous g) :
+  dense_range (g ∘ f) :=
+begin
+  have : g '' (closure $ range f) ⊆ closure (g '' range f),
+    from image_closure_subset_closure_image cg,
+  have : closure (g '' closure (range f)) ⊆ closure (g '' range f),
+    by simpa [closure_closure] using (closure_mono this),
+  intro c,
+  rw range_comp,
+  apply this,
+  rw [(dense_range_iff_closure_eq f).1 hf, image_univ],
+  exact hg c
+end
+
+lemma dense_range.inhabited (df : dense_range f) (b : β) : inhabited α :=
+⟨begin
+  have := exists_mem_of_ne_empty (mem_closure_iff.1 (df b) _ is_open_univ trivial),
+  simp only [mem_range, univ_inter] at this,
+  exact classical.some (classical.some_spec this),
+ end⟩
+
+end dense_range
+
+section inducing
+structure inducing [tα : topological_space α] [tβ : topological_space β] (f : α → β) : Prop :=
+(induced : tα = tβ.induced f)
+
+variables [topological_space α] [topological_space β] [topological_space γ] [topological_space δ]
+
+lemma inducing_id : inducing (@id α) :=
+⟨induced_id.symm⟩
+
+lemma inducing_compose {f : α → β} {g : β → γ} (hg : inducing g) (hf : inducing f) :
+  inducing (g ∘ f) :=
+⟨by rw [hf.induced, hg.induced, induced_compose]⟩
+
+lemma inducing_prod_mk {f : α → β} {g : γ → δ} (hf : inducing f) (hg : inducing g) :
+  inducing (λx:α×γ, (f x.1, g x.2)) :=
+⟨by rw [prod.topological_space, prod.topological_space, hf.induced, hg.induced,
+         induced_compose, induced_compose, induced_inf, induced_compose, induced_compose]⟩
+
+lemma inducing_of_inducing_compose {f : α → β} {g : β → γ} (hf : continuous f) (hg : continuous g)
+  (hgf : inducing (g ∘ f)) : inducing f :=
+⟨le_antisymm
+    (by rwa ← continuous_iff_le_induced)
+    (by { rw [hgf.induced, ← continuous_iff_le_induced], apply hg.comp continuous_induced_dom })⟩
+
+lemma inducing_open {f : α → β} {s : set α}
+  (hf : inducing f) (h : is_open (range f)) (hs : is_open s) : is_open (f '' s) :=
+let ⟨t, ht, h_eq⟩ := by rw [hf.induced] at hs; exact hs in
+have is_open (t ∩ range f), from is_open_inter ht h,
+h_eq ▸ by rwa [image_preimage_eq_inter_range]
+
+lemma inducing_is_closed {f : α → β} {s : set α}
+  (hf : inducing f) (h : is_closed (range f)) (hs : is_closed s) : is_closed (f '' s) :=
+let ⟨t, ht, h_eq⟩ := by rw [hf.induced, is_closed_induced_iff] at hs; exact hs in
+have is_closed (t ∩ range f), from is_closed_inter ht h,
+h_eq.symm ▸ by rwa [image_preimage_eq_inter_range]
+
+lemma inducing.nhds_eq_comap [topological_space α] [topological_space β] {f : α → β}
+  (hf : inducing f) : ∀ (a : α), nhds a = comap f (nhds $ f a) :=
+(induced_iff_nhds_eq f).1 hf.induced
+
+lemma inducing.map_nhds_eq [topological_space α] [topological_space β] {f : α → β}
+  (hf : inducing f) (a : α) (h : range f ∈ nhds (f a)) : (nhds a).map f = nhds (f a) :=
+hf.induced.symm ▸ map_nhds_induced_eq h
+
+lemma inducing.tendsto_nhds_iff {ι : Type*}
+  {f : ι → β} {g : β → γ} {a : filter ι} {b : β} (hg : inducing g) :
+  tendsto f a (nhds b) ↔ tendsto (g ∘ f) a (nhds (g b)) :=
+by rw [tendsto, tendsto, hg.induced, nhds_induced, ← map_le_iff_le_comap, filter.map_map]
+
+lemma inducing.continuous_iff {f : α → β} {g : β → γ} (hg : inducing g) :
+  continuous f ↔ continuous (g ∘ f) :=
+by simp [continuous_iff_continuous_at, continuous_at, inducing.tendsto_nhds_iff hg]
+
+lemma inducing.continuous {f : α → β} (hf : inducing f) : continuous f :=
+hf.continuous_iff.mp continuous_id
+end inducing
 section embedding
 
 /-- A function between topological spaces is an embedding if it is injective,
   and for all `s : set α`, `s` is open iff it is the preimage of an open set. -/
-def embedding [tα : topological_space α] [tβ : topological_space β] (f : α → β) : Prop :=
-function.injective f ∧ tα = tβ.induced f
+structure embedding [tα : topological_space α] [tβ : topological_space β] (f : α → β)
+  extends inducing f : Prop :=
+(inj  :  function.injective f)
 
 variables [topological_space α] [topological_space β] [topological_space γ] [topological_space δ]
 
+def embedding.mk' (f : α → β) (inj  :  function.injective f)
+  (induced : ∀a, comap f (nhds (f a)) = nhds a) : embedding f :=
+⟨⟨(induced_iff_nhds_eq f).2 (λ a, (induced a).symm)⟩, inj⟩
+
 lemma embedding_id : embedding (@id α) :=
-⟨assume a₁ a₂ h, h, induced_id.symm⟩
+⟨inducing_id, assume a₁ a₂ h, h⟩
 
 lemma embedding_compose {f : α → β} {g : β → γ} (hg : embedding g) (hf : embedding f) :
   embedding (g ∘ f) :=
-⟨assume a₁ a₂ h, hf.left $ hg.left h, by rw [hf.right, hg.right, induced_compose]⟩
+⟨inducing_compose hg.1 hf.1, assume a₁ a₂ h, hf.inj $ hg.inj h⟩
 
 lemma embedding_prod_mk {f : α → β} {g : γ → δ} (hf : embedding f) (hg : embedding g) :
   embedding (λx:α×γ, (f x.1, g x.2)) :=
-⟨assume ⟨x₁, x₂⟩ ⟨y₁, y₂⟩, by simp; exact assume h₁ h₂, ⟨hf.left h₁, hg.left h₂⟩,
-  by rw [prod.topological_space, prod.topological_space, hf.right, hg.right,
-         induced_compose, induced_compose, induced_inf, induced_compose, induced_compose]⟩
+⟨inducing_prod_mk hf.1 hg.1,
+ assume ⟨x₁, x₂⟩ ⟨y₁, y₂⟩, by simp; exact assume h₁ h₂, ⟨hf.inj h₁, hg.inj h₂⟩⟩
 
 lemma embedding_of_embedding_compose {f : α → β} {g : β → γ} (hf : continuous f) (hg : continuous g)
   (hgf : embedding (g ∘ f)) : embedding f :=
-⟨assume a₁ a₂ h, hgf.left $ by simp [h, (∘)],
-  le_antisymm
-    (by rwa ← continuous_iff_le_induced)
-    (by rw [hgf.right, ← continuous_iff_le_induced];
-        apply hg.comp continuous_induced_dom)⟩
+⟨inducing_of_inducing_compose hf hg hgf.1, assume a₁ a₂ h, hgf.inj $ by simp [h, (∘)]⟩
 
 lemma embedding_open {f : α → β} {s : set α}
   (hf : embedding f) (h : is_open (range f)) (hs : is_open s) : is_open (f '' s) :=
-let ⟨t, ht, h_eq⟩ := by rw [hf.right] at hs; exact hs in
-have is_open (t ∩ range f), from is_open_inter ht h,
-h_eq ▸ by rwa [image_preimage_eq_inter_range]
+inducing_open hf.1 h hs
 
 lemma embedding_is_closed {f : α → β} {s : set α}
   (hf : embedding f) (h : is_closed (range f)) (hs : is_closed s) : is_closed (f '' s) :=
-let ⟨t, ht, h_eq⟩ := by rw [hf.right, is_closed_induced_iff] at hs; exact hs in
-have is_closed (t ∩ range f), from is_closed_inter ht h,
-h_eq.symm ▸ by rwa [image_preimage_eq_inter_range]
+inducing_is_closed hf.1 h hs
 
 lemma embedding.map_nhds_eq [topological_space α] [topological_space β] {f : α → β}
   (hf : embedding f) (a : α) (h : range f ∈ nhds (f a)) : (nhds a).map f = nhds (f a) :=
-by rw [hf.2]; exact map_nhds_induced_eq h
+inducing.map_nhds_eq hf.1 a h
 
 lemma embedding.tendsto_nhds_iff {ι : Type*}
   {f : ι → β} {g : β → γ} {a : filter ι} {b : β} (hg : embedding g) :
   tendsto f a (nhds b) ↔ tendsto (g ∘ f) a (nhds (g b)) :=
-by rw [tendsto, tendsto, hg.right, nhds_induced_eq_comap, ← map_le_iff_le_comap, filter.map_map]
+by rw [tendsto, tendsto, hg.induced, nhds_induced, ← map_le_iff_le_comap, filter.map_map]
 
 lemma embedding.continuous_iff {f : α → β} {g : β → γ} (hg : embedding g) :
   continuous f ↔ continuous (g ∘ f) :=
-by simp [continuous_iff_continuous_at, continuous_at, embedding.tendsto_nhds_iff hg]
+inducing.continuous_iff hg.1
 
 lemma embedding.continuous {f : α → β} (hf : embedding f) : continuous f :=
-hf.continuous_iff.mp continuous_id
+inducing.continuous hf.1
 
 lemma embedding.closure_eq_preimage_closure_image {e : α → β} (he : embedding e) (s : set α) :
   closure s = e ⁻¹' closure (e '' s) :=
-by ext x; rw [set.mem_preimage, ← closure_induced he.1, he.2]
+by { ext x,  rw [set.mem_preimage, ← closure_induced he.inj, he.induced] }
 
 end embedding
 
-
--- TODO: use embeddings from above!
-structure dense_embedding [topological_space α] [topological_space β] (e : α → β) : Prop :=
+structure dense_inducing [topological_space α] [topological_space β] (e : α → β)
+  extends inducing e : Prop  :=
 (dense   : ∀x, x ∈ closure (range e))
-(inj     : function.injective e)
-(induced : ∀a, comap e (nhds (e a)) = nhds a)
 
-theorem dense_embedding.mk'
-  [topological_space α] [topological_space β] (e : α → β)
-  (c     : continuous e)
-  (dense : ∀x, x ∈ closure (range e))
-  (inj   : function.injective e)
-  (H     : ∀ (a:α) s ∈ nhds a,
-    ∃t ∈ nhds (e a), ∀ b, e b ∈ t → b ∈ s) :
-  dense_embedding e :=
-⟨dense, inj, λ a, le_antisymm
-  (by simpa [le_def] using H a)
-  (tendsto_iff_comap.1 $ c.tendsto _)⟩
-
-namespace dense_embedding
+namespace dense_inducing
 variables [topological_space α] [topological_space β]
-variables {e : α → β} (de : dense_embedding e)
+variables {e : α → β} (di : dense_inducing e)
 
-protected lemma embedding (de : dense_embedding e) : embedding e :=
-⟨de.inj, eq_of_nhds_eq_nhds begin intro a, rw [← de.induced a, nhds_induced_eq_comap] end⟩
+lemma nhds_eq_comap (di : dense_inducing e) :
+  ∀ a : α, nhds a = comap e (nhds $ e a) :=
+di.induced.symm ▸ nhds_induced e
 
-protected lemma continuous_at (de : dense_embedding e) {a : α} : continuous_at e a :=
-by rw [continuous_at, ←de.induced a]; exact tendsto_comap
+protected lemma continuous_at (di : dense_inducing e) {a : α} : continuous_at e a :=
+by rw [continuous_at, di.nhds_eq_comap a]; exact tendsto_comap
 
-protected lemma continuous (de : dense_embedding e) : continuous e :=
+protected lemma continuous (de : dense_inducing e) : continuous e :=
 continuous_iff_continuous_at.mpr $ λ a, de.continuous_at
 
-lemma inj_iff (de : dense_embedding e) {x y} : e x = e y ↔ x = y := de.inj.eq_iff
-
 lemma closure_range : closure (range e) = univ :=
-let h := de.dense in
+let h := di.dense in
 set.ext $ assume x, ⟨assume _, trivial, assume _, @h x⟩
 
-lemma self_sub_closure_image_preimage_of_open {s : set β} (de : dense_embedding e) :
+lemma self_sub_closure_image_preimage_of_open {s : set β} (di : dense_inducing e) :
   is_open s → s ⊆ closure (e '' (e ⁻¹' s)) :=
 begin
   intros s_op b b_in_s,
@@ -123,20 +193,20 @@ begin
   intros U U_op b_in,
   rw ←inter_assoc,
   have ne_e : U ∩ s ≠ ∅ := ne_empty_of_mem ⟨b_in, b_in_s⟩,
-  exact (dense_iff_inter_open.1 de.closure_range) _ (is_open_inter U_op s_op) ne_e
+  exact (dense_iff_inter_open.1 di.closure_range) _ (is_open_inter U_op s_op) ne_e
 end
 
-lemma closure_image_nhds_of_nhds {s : set α} {a : α} (de : dense_embedding e) :
+lemma closure_image_nhds_of_nhds {s : set α} {a : α} (di : dense_inducing e) :
   s ∈ nhds a → closure (e '' s) ∈ nhds (e a) :=
 begin
-  rw [← de.induced a, mem_comap_sets],
+  rw [di.nhds_eq_comap a, mem_comap_sets],
   intro h,
   rcases h with ⟨t, t_nhd, sub⟩,
   rw mem_nhds_sets_iff at t_nhd,
   rcases t_nhd with ⟨U, U_sub, ⟨U_op, e_a_in_U⟩⟩,
   have := calc e ⁻¹' U ⊆ e⁻¹' t : preimage_mono U_sub
                    ... ⊆ s      : sub,
-  have := calc U ⊆ closure (e '' (e ⁻¹' U)) : self_sub_closure_image_preimage_of_open de U_op
+  have := calc U ⊆ closure (e '' (e ⁻¹' U)) : self_sub_closure_image_preimage_of_open di U_op
              ... ⊆ closure (e '' s)         : closure_mono (image_subset e this),
   have U_nhd : U ∈ nhds (e a) := mem_nhds_sets U_op e_a_in_U,
   exact (nhds (e a)).sets_of_superset U_nhd this
@@ -148,111 +218,126 @@ variables [topological_space δ] {f : γ → α} {g : γ → δ} {h : δ → β}
 g↓     ↓e
  δ -h→ β
 -/
-lemma tendsto_comap_nhds_nhds  {d : δ} {a : α} (de : dense_embedding e) (H : tendsto h (nhds d) (nhds (e a)))
+lemma tendsto_comap_nhds_nhds  {d : δ} {a : α} (di : dense_inducing e) (H : tendsto h (nhds d) (nhds (e a)))
   (comm : h ∘ g = e ∘ f) : tendsto f (comap g (nhds d)) (nhds a) :=
 begin
   have lim1 : map g (comap g (nhds d)) ≤ nhds d := map_comap_le,
   replace lim1 : map h (map g (comap g (nhds d))) ≤ map h (nhds d) := map_mono lim1,
   rw [filter.map_map, comm, ← filter.map_map, map_le_iff_le_comap] at lim1,
   have lim2 :  comap e (map h (nhds d)) ≤  comap e  (nhds (e a)) := comap_mono H,
-  rw de.induced at lim2,
+  rw ← di.nhds_eq_comap at lim2,
   exact le_trans lim1 lim2,
 end
 
-protected lemma nhds_inf_neq_bot (de : dense_embedding e) {b : β} : nhds b ⊓ principal (range e) ≠ ⊥ :=
+protected lemma nhds_inf_neq_bot (di : dense_inducing e) {b : β} : nhds b ⊓ principal (range e) ≠ ⊥ :=
 begin
-  have h := de.dense,
+  have h := di.dense,
   simp [closure_eq_nhds] at h,
   exact h _
 end
 
-lemma comap_nhds_neq_bot (de : dense_embedding e) {b : β} : comap e (nhds b) ≠ ⊥ :=
+lemma comap_nhds_neq_bot (di : dense_inducing e) {b : β} : comap e (nhds b) ≠ ⊥ :=
 forall_sets_neq_empty_iff_neq_bot.mp $
 assume s ⟨t, ht, (hs : e ⁻¹' t ⊆ s)⟩,
 have t ∩ range e ∈ nhds b ⊓ principal (range e),
   from inter_mem_inf_sets ht (subset.refl _),
-let ⟨_, ⟨hx₁, y, rfl⟩⟩ := inhabited_of_mem_sets de.nhds_inf_neq_bot this in
+let ⟨_, ⟨hx₁, y, rfl⟩⟩ := inhabited_of_mem_sets di.nhds_inf_neq_bot this in
 subset_ne_empty hs $ ne_empty_of_mem hx₁
 
 variables [topological_space γ]
-/-- If `e : α → β` is a dense embedding, then any function `α → γ` extends to a function `β → γ`.
-It only extends the parts of `β` which are not mapped by `e`, everything else equal to `f (e a)`.
-This allows us to gain equality even if `γ` is not T2. -/
-def extend (de : dense_embedding e) (f : α → γ) (b : β) : γ :=
-have nonempty γ, from
-  let ⟨_, ⟨_, a, _⟩⟩ := exists_mem_of_ne_empty (mem_closure_iff.1 (de.dense b) _ is_open_univ trivial) in
-  ⟨f a⟩,
-if hb : b ∈ range e
-then f (classical.some hb)
-else @lim _ _ (classical.inhabited_of_nonempty this) (map f (comap e (nhds b)))
-
-lemma extend_e_eq {f : α → γ} (a : α) : de.extend f (e a) = f a :=
-have e a ∈ range e := ⟨a, rfl⟩,
-begin
-  simp [extend, this],
-  congr,
-  refine classical.some_spec2 (λx, x = a) _,
-  exact assume a h, de.inj h
-end
+/-- If `e : α → β` is a dense inducing, then any function `α → γ` "extends" to a function `β → γ`. -/
+def extend (di : dense_inducing e) (f : α → γ) (b : β) : γ :=
+@lim _ _ ⟨f (dense_range.inhabited di.dense b).default⟩ (map f (comap e (nhds b)))
 
 lemma extend_eq [t2_space γ] {b : β} {c : γ} {f : α → γ} (hf : map f (comap e (nhds b)) ≤ nhds c) :
-  de.extend f b = c :=
-begin
-  by_cases hb : b ∈ range e,
-  { rcases hb with ⟨a, rfl⟩,
-    rw [extend_e_eq],
-    have f_a_c : tendsto f (pure a) (nhds c),
-    { rw [de.induced] at hf,
-      refine le_trans (map_mono _) hf,
-      exact pure_le_nhds a },
-    have f_a_fa : tendsto f (pure a) (nhds (f a)),
-    { rw [tendsto, filter.map_pure], exact pure_le_nhds _  },
-    exact tendsto_nhds_unique pure_neq_bot f_a_fa f_a_c },
-  { simp [extend, hb],
-    exact @lim_eq _ _ (id _) _ _ _ (by simp; exact comap_nhds_neq_bot de) hf }
-end
+  di.extend f b = c :=
+@lim_eq _ _ (id _) _ _ _ (by simp; exact comap_nhds_neq_bot di) hf
 
-lemma tendsto_extend [regular_space γ] {b : β} {f : α → γ} (de : dense_embedding e)
+lemma extend_e_eq [t2_space γ] {f : α → γ} (a : α)  (hf : continuous_at f a) :
+  di.extend f (e a) = f a :=
+extend_eq _ $ di.nhds_eq_comap a ▸ hf
+
+lemma extend_eq_of_cont [t2_space γ] {f : α → γ} (hf : continuous f) (a : α) :
+  di.extend f (e a) = f a :=
+di.extend_e_eq a (continuous_iff_continuous_at.1 hf a)
+
+lemma tendsto_extend [regular_space γ] {b : β} {f : α → γ} (di : dense_inducing e)
   (hf : {b | ∃c, tendsto f (comap e $ nhds b) (nhds c)} ∈ nhds b) :
-  tendsto (de.extend f) (nhds b) (nhds (de.extend f b)) :=
-let φ := {b | tendsto f (comap e $ nhds b) (nhds $ de.extend f b)} in
+  tendsto (di.extend f) (nhds b) (nhds (di.extend f b)) :=
+let φ := {b | tendsto f (comap e $ nhds b) (nhds $ di.extend f b)} in
 have hφ : φ ∈ nhds b,
   from (nhds b).sets_of_superset hf $ assume b ⟨c, hc⟩,
-    show tendsto f (comap e (nhds b)) (nhds (de.extend f b)), from (de.extend_eq hc).symm ▸ hc,
+    show tendsto f (comap e (nhds b)) (nhds (di.extend f b)), from (di.extend_eq hc).symm ▸ hc,
 assume s hs,
 let ⟨s'', hs''₁, hs''₂, hs''₃⟩ := nhds_is_closed hs in
 let ⟨s', hs'₁, (hs'₂ : e ⁻¹' s' ⊆ f ⁻¹' s'')⟩ := mem_of_nhds hφ hs''₁ in
 let ⟨t, (ht₁ : t ⊆ φ ∩ s'), ht₂, ht₃⟩ := mem_nhds_sets_iff.mp $ inter_mem_sets hφ hs'₁ in
 have h₁ : closure (f '' (e ⁻¹' s')) ⊆ s'',
   by rw [closure_subset_iff_subset_of_is_closed hs''₃, image_subset_iff]; exact hs'₂,
-have h₂ : t ⊆ de.extend f ⁻¹' closure (f '' (e ⁻¹' t)), from
+have h₂ : t ⊆ di.extend f ⁻¹' closure (f '' (e ⁻¹' t)), from
   assume b' hb',
   have nhds b' ≤ principal t, by simp; exact mem_nhds_sets ht₂ hb',
-  have map f (comap e (nhds b')) ≤ nhds (de.extend f b') ⊓ principal (f '' (e ⁻¹' t)),
+  have map f (comap e (nhds b')) ≤ nhds (di.extend f b') ⊓ principal (f '' (e ⁻¹' t)),
     from calc _ ≤ map f (comap e (nhds b' ⊓ principal t)) : map_mono $ comap_mono $ le_inf (le_refl _) this
       ... ≤ map f (comap e (nhds b')) ⊓ map f (comap e (principal t)) :
         le_inf (map_mono $ comap_mono $ inf_le_left) (map_mono $ comap_mono $ inf_le_right)
       ... ≤ map f (comap e (nhds b')) ⊓ principal (f '' (e ⁻¹' t)) : by simp [le_refl]
       ... ≤ _ : inf_le_inf ((ht₁ hb').left) (le_refl _),
-  show de.extend f b' ∈ closure (f '' (e ⁻¹' t)),
+  show di.extend f b' ∈ closure (f '' (e ⁻¹' t)),
   begin
     rw [closure_eq_nhds],
     apply neq_bot_of_le_neq_bot _ this,
     simp,
-    exact de.comap_nhds_neq_bot
+    exact di.comap_nhds_neq_bot
   end,
 (nhds b).sets_of_superset
   (show t ∈ nhds b, from mem_nhds_sets ht₂ ht₃)
-  (calc t ⊆ de.extend f ⁻¹' closure (f '' (e ⁻¹' t)) : h₂
-    ... ⊆ de.extend f ⁻¹' closure (f '' (e ⁻¹' s')) :
+  (calc t ⊆ di.extend f ⁻¹' closure (f '' (e ⁻¹' t)) : h₂
+    ... ⊆ di.extend f ⁻¹' closure (f '' (e ⁻¹' s')) :
       preimage_mono $ closure_mono $ image_subset f $ preimage_mono $ subset.trans ht₁ $ inter_subset_right _ _
-    ... ⊆ de.extend f ⁻¹' s'' : preimage_mono h₁
-    ... ⊆ de.extend f ⁻¹' s : preimage_mono hs''₂)
+    ... ⊆ di.extend f ⁻¹' s'' : preimage_mono h₁
+    ... ⊆ di.extend f ⁻¹' s : preimage_mono hs''₂)
 
-lemma continuous_extend [regular_space γ] {f : α → γ} (de : dense_embedding e)
-  (hf : ∀b, ∃c, tendsto f (comap e (nhds b)) (nhds c)) : continuous (de.extend f) :=
-continuous_iff_continuous_at.mpr $ assume b, de.tendsto_extend $ univ_mem_sets' hf
+lemma continuous_extend [regular_space γ] {f : α → γ} (di : dense_inducing e)
+  (hf : ∀b, ∃c, tendsto f (comap e (nhds b)) (nhds c)) : continuous (di.extend f) :=
+continuous_iff_continuous_at.mpr $ assume b, di.tendsto_extend $ univ_mem_sets' hf
 
+lemma mk'
+  [topological_space α] [topological_space β] (e : α → β)
+  (c     : continuous e)
+  (dense : ∀x, x ∈ closure (range e))
+  (H     : ∀ (a:α) s ∈ nhds a,
+    ∃t ∈ nhds (e a), ∀ b, e b ∈ t → b ∈ s) :
+  dense_inducing e :=
+{ induced := (induced_iff_nhds_eq e).2 $
+    λ a, le_antisymm (tendsto_iff_comap.1 $ c.tendsto _) (by simpa [le_def] using H a),
+  dense := dense }
+end dense_inducing
+
+structure dense_embedding [topological_space α] [topological_space β] (e : α → β)
+  extends dense_inducing e : Prop  :=
+(inj   : function.injective e)
+
+theorem dense_embedding.mk'
+  [topological_space α] [topological_space β] (e : α → β)
+  (c     : continuous e)
+  (dense : ∀x, x ∈ closure (range e))
+  (inj   : function.injective e)
+  (H     : ∀ (a:α) s ∈ nhds a,
+    ∃t ∈ nhds (e a), ∀ b, e b ∈ t → b ∈ s) :
+  dense_embedding e :=
+{ inj := inj,
+  ..dense_inducing.mk' e c dense H}
+
+namespace dense_embedding
+variables [topological_space α] [topological_space β]
+variables {e : α → β} (de : dense_embedding e)
+
+lemma inj_iff {x y} : e x = e y ↔ x = y := de.inj.eq_iff
+
+lemma to_embedding : embedding e :=
+{ induced := de.induced,
+  inj := de.inj }
 end dense_embedding
 
 
@@ -380,7 +465,7 @@ lemma closed_embedding.closed_iff_image_closed {f : α → β} (hf : closed_embe
 ⟨embedding_is_closed hf.1 hf.2,
  λ h, begin
    convert ←continuous_iff_is_closed.mp hf.1.continuous _ h,
-   apply preimage_image_eq _ hf.1.1
+   apply preimage_image_eq _ hf.1.inj
  end⟩
 
 lemma closed_embedding.closed_iff_preimage_closed {f : α → β} (hf : closed_embedding f)
@@ -393,7 +478,7 @@ end
 lemma closed_embedding_of_continuous_injective_closed {f : α → β} (h₁ : continuous f)
   (h₂ : function.injective f) (h₃ : is_closed_map f) : closed_embedding f :=
 begin
-  refine ⟨⟨h₂, _⟩, by convert h₃ univ is_closed_univ; simp⟩,
+  refine ⟨⟨⟨_⟩, h₂⟩, by convert h₃ univ is_closed_univ; simp⟩,
   apply le_antisymm (continuous_iff_le_induced.mp h₁) _,
   intro s',
   change is_open _ ≤ is_open _,

--- a/src/topology/maps.lean
+++ b/src/topology/maps.lean
@@ -24,7 +24,7 @@ eq_univ_iff_forall.symm
 
 variables {f}
 
-lemma dense_range_comp (hf : dense_range f) (hg : dense_range g) (cg : continuous g) :
+lemma dense_range.comp (hg : dense_range g) (hf : dense_range f) (cg : continuous g) :
   dense_range (g ∘ f) :=
 begin
   have : g '' (closure $ range f) ⊆ closure (g '' range f),
@@ -109,11 +109,11 @@ section embedding
   and for all `s : set α`, `s` is open iff it is the preimage of an open set. -/
 structure embedding [tα : topological_space α] [tβ : topological_space β] (f : α → β)
   extends inducing f : Prop :=
-(inj  :  function.injective f)
+(inj : function.injective f)
 
 variables [topological_space α] [topological_space β] [topological_space γ] [topological_space δ]
 
-def embedding.mk' (f : α → β) (inj  :  function.injective f)
+def embedding.mk' (f : α → β) (inj : function.injective f)
   (induced : ∀a, comap f (nhds (f a)) = nhds a) : embedding f :=
 ⟨⟨(induced_iff_nhds_eq f).2 (λ a, (induced a).symm)⟩, inj⟩
 
@@ -159,12 +159,12 @@ inducing.continuous hf.1
 
 lemma embedding.closure_eq_preimage_closure_image {e : α → β} (he : embedding e) (s : set α) :
   closure s = e ⁻¹' closure (e '' s) :=
-by { ext x,  rw [set.mem_preimage, ← closure_induced he.inj, he.induced] }
+by { ext x, rw [set.mem_preimage, ← closure_induced he.inj, he.induced] }
 
 end embedding
 
 structure dense_inducing [topological_space α] [topological_space β] (e : α → β)
-  extends inducing e : Prop  :=
+  extends inducing e : Prop :=
 (dense   : ∀x, x ∈ closure (range e))
 
 namespace dense_inducing
@@ -253,7 +253,7 @@ lemma extend_eq [t2_space γ] {b : β} {c : γ} {f : α → γ} (hf : map f (com
   di.extend f b = c :=
 @lim_eq _ _ (id _) _ _ _ (by simp; exact comap_nhds_neq_bot di) hf
 
-lemma extend_e_eq [t2_space γ] {f : α → γ} (a : α)  (hf : continuous_at f a) :
+lemma extend_e_eq [t2_space γ] {f : α → γ} (a : α) (hf : continuous_at f a) :
   di.extend f (e a) = f a :=
 extend_eq _ $ di.nhds_eq_comap a ▸ hf
 
@@ -316,7 +316,7 @@ end dense_inducing
 
 structure dense_embedding [topological_space α] [topological_space β] (e : α → β)
   extends dense_inducing e : Prop  :=
-(inj   : function.injective e)
+(inj : function.injective e)
 
 theorem dense_embedding.mk'
   [topological_space α] [topological_space β] (e : α → β)

--- a/src/topology/metric_space/completion.lean
+++ b/src/topology/metric_space/completion.lean
@@ -57,7 +57,7 @@ end
 protected lemma completion.dist_triangle (x y z : completion α) : dist x z ≤ dist x y + dist y z :=
 begin
   apply induction_on₃ x y z,
-   { refine is_closed_le _ (continuous_add _ _),
+  { refine is_closed_le _ (continuous_add _ _),
     { have : continuous (λp : completion α × completion α × completion α, (p.1, p.2.2)) :=
         continuous.prod_mk continuous_fst (continuous.comp continuous_snd continuous_snd),
       exact (completion.uniform_continuous_dist.continuous.comp this : _) },

--- a/src/topology/metric_space/completion.lean
+++ b/src/topology/metric_space/completion.lean
@@ -22,20 +22,16 @@ namespace metric
 /-- The distance on the completion is obtained by extending the distance on the original space,
 by uniform continuity. -/
 instance : has_dist (completion α) :=
-⟨λx y, completion.extension (λp:α×α, dist p.1 p.2) (completion.prod (x, y))⟩
+⟨completion.extension₂ dist⟩
 
 /-- The new distance is uniformly continuous. -/
 protected lemma completion.uniform_continuous_dist :
   uniform_continuous (λp:completion α × completion α, dist p.1 p.2) :=
-uniform_continuous.comp uniform_continuous_extension uniform_continuous_prod
+uniform_continuous_extension₂ dist
 
 /-- The new distance is an extension of the original distance. -/
 protected lemma completion.dist_eq (x y : α) : dist (x : completion α) y = dist x y :=
-begin
-  unfold dist,
-  rw [completion.prod_coe_coe, completion.extension_coe],
-  exact uniform_continuous_dist',
-end
+completion.extension₂_coe_coe uniform_continuous_dist' _ _
 
 /- Let us check that the new distance satisfies the axioms of a distance, by starting from the
 properties on α and extending them to `completion α` by continuity. -/
@@ -43,9 +39,8 @@ protected lemma completion.dist_self (x : completion α) : dist x x = 0 :=
 begin
   apply induction_on x,
   { refine is_closed_eq _ continuous_const,
-    have : continuous (λx : completion α, (x, x)) :=
-      continuous.prod_mk continuous_id continuous_id,
-    exact completion.uniform_continuous_dist.continuous.comp this },
+    exact (completion.uniform_continuous_dist.continuous.comp
+             (continuous.prod_mk continuous_id continuous_id) : _) },
   { assume a,
     rw [completion.dist_eq, dist_self] }
 end
@@ -54,7 +49,7 @@ protected lemma completion.dist_comm (x y : completion α) : dist x y = dist y x
 begin
   apply induction_on₂ x y,
   { refine is_closed_eq completion.uniform_continuous_dist.continuous _,
-    exact completion.uniform_continuous_dist.continuous.comp continuous_swap },
+    exact (completion.uniform_continuous_dist.continuous.comp continuous_swap : _) },
   { assume a b,
     rw [completion.dist_eq, completion.dist_eq, dist_comm] }
 end
@@ -62,17 +57,17 @@ end
 protected lemma completion.dist_triangle (x y z : completion α) : dist x z ≤ dist x y + dist y z :=
 begin
   apply induction_on₃ x y z,
-  { refine is_closed_le _ (continuous_add _ _),
+   { refine is_closed_le _ (continuous_add _ _),
     { have : continuous (λp : completion α × completion α × completion α, (p.1, p.2.2)) :=
         continuous.prod_mk continuous_fst (continuous.comp continuous_snd continuous_snd),
-      exact completion.uniform_continuous_dist.continuous.comp this },
+      exact (completion.uniform_continuous_dist.continuous.comp this : _) },
     { have : continuous (λp : completion α × completion α × completion α, (p.1, p.2.1)) :=
         continuous.prod_mk continuous_fst (continuous_fst.comp continuous_snd),
-      exact completion.uniform_continuous_dist.continuous.comp this },
+      exact (completion.uniform_continuous_dist.continuous.comp this : _) },
     { have : continuous (λp : completion α × completion α × completion α, (p.2.1, p.2.2)) :=
         continuous.prod_mk (continuous_fst.comp continuous_snd)
                            (continuous.comp continuous_snd continuous_snd),
-      exact continuous.comp completion.uniform_continuous_dist.continuous this }},
+      exact (continuous.comp completion.uniform_continuous_dist.continuous this : _) } },
   { assume a b c,
     rw [completion.dist_eq, completion.dist_eq, completion.dist_eq],
     exact dist_triangle a b c }

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -1005,7 +1005,8 @@ begin
   { assume n,
     rw [nonempty_compacts.to_GH_space, ← (u n).to_GH_space_rep,
         to_GH_space_eq_to_GH_space_iff_isometric],
-    exact ⟨(isom n).isometric_on_range.symm⟩
+    constructor,
+    convert (isom n).isometric_on_range.symm,
   },
   -- Finally, we have proved the convergence of `u n`
   exact ⟨L.to_GH_space, by simpa [this] using M⟩

--- a/src/topology/order.lean
+++ b/src/topology/order.lean
@@ -558,6 +558,10 @@ theorem nhds_induced [T : topological_space α] (f : β → α) (a : β) :
   @nhds β (topological_space.induced f T) a = comap f (nhds (f a)) :=
 filter_eq $ by ext s; rw mem_nhds_induced; rw mem_comap_sets
 
+lemma induced_iff_nhds_eq [tα : topological_space α] [tβ : topological_space β] (f : β → α) :
+tβ = tα.induced f ↔ ∀ b, nhds b = comap f (nhds $ f b) :=
+⟨λ h a, h.symm ▸ nhds_induced f a, λ h, eq_of_nhds_eq_nhds $ λ x, by rw [h, nhds_induced]⟩
+
 theorem map_nhds_induced_of_surjective [T : topological_space α]
     {f : β → α} (hf : function.surjective f) (a : β) (s : set α) :
   map f (@nhds β (topological_space.induced f T) a) = nhds (f a) :=
@@ -859,16 +863,9 @@ iff.refl _
 theorem is_open_induced {s : set β} (h : is_open s) : (induced f t).is_open (f ⁻¹' s) :=
 ⟨s, h, rfl⟩
 
-lemma nhds_induced_eq_comap {a : α} : @nhds α (induced f t) a = comap f (nhds (f a)) :=
-calc @nhds α (induced f t) a = (⨅ s (x : s ∈ preimage f '' set_of is_open ∧ a ∈ s), principal s) :
-    by simp [nhds, is_open_induced_eq, -mem_image, and_comm]
-  ... = (⨅ s (x : is_open s ∧ f a ∈ s), principal (f ⁻¹' s)) :
-    by simp only [infi_and, infi_image]; refl
-  ... = _ : by simp [nhds, comap_infi, and_comm]
-
 lemma map_nhds_induced_eq {a : α} (h : range f ∈ nhds (f a)) :
   map f (@nhds α (induced f t) a) = nhds (f a) :=
-by rw [nhds_induced_eq_comap, filter.map_comap h]
+by rw [nhds_induced, filter.map_comap h]
 
 lemma closure_induced [t : topological_space β] {f : α → β} {a : α} {s : set α}
   (hf : ∀x y, f x = f y → x = y) :
@@ -886,7 +883,7 @@ have comap f (nhds (f a) ⊓ principal (f '' s)) ≠ ⊥ ↔ nhds (f a) ⊓ prin
       ne_empty_of_mem $ hs $ by rwa [←ha₂] at hb₁⟩,
 calc a ∈ @closure α (topological_space.induced f t) s
     ↔ (@nhds α (topological_space.induced f t) a) ⊓ principal s ≠ ⊥ : by rw [closure_eq_nhds]; refl
-  ... ↔ comap f (nhds (f a)) ⊓ principal (f ⁻¹' (f '' s)) ≠ ⊥ : by rw [nhds_induced_eq_comap, preimage_image_eq _ hf]
+  ... ↔ comap f (nhds (f a)) ⊓ principal (f ⁻¹' (f '' s)) ≠ ⊥ : by rw [nhds_induced, preimage_image_eq _ hf]
   ... ↔ comap f (nhds (f a) ⊓ principal (f '' s)) ≠ ⊥ : by rw [comap_inf, ←comap_principal]
   ... ↔ _ : by rwa [closure_eq_nhds]
 

--- a/src/topology/stone_cech.lean
+++ b/src/topology/stone_cech.lean
@@ -105,19 +105,24 @@ end
 
 open topological_space
 
-/-- `pure : α → ultrafilter α` defines a dense embedding of `α` in `ultrafilter α`. -/
-lemma dense_embedding_pure : @dense_embedding _ _ ⊥ _ (pure : α → ultrafilter α) :=
+/-- `pure : α → ultrafilter α` defines a dense inducing of `α` in `ultrafilter α`. -/
+lemma dense_inducing_pure : @dense_inducing _ _ ⊥ _ (pure : α → ultrafilter α) :=
 by letI : topological_space α := ⊥; exact
-dense_embedding.mk' pure continuous_bot
+dense_inducing.mk' pure continuous_bot
   (assume x, mem_closure_iff_ultrafilter.mpr
      ⟨x.map ultrafilter.pure, range_mem_map,
       ultrafilter_converges_iff.mpr (bind_pure x).symm⟩)
-  ultrafilter_pure_injective
   (assume a s as,
      ⟨{u | s ∈ u.val},
       mem_nhds_sets (ultrafilter_is_open_basic s) (mem_pure_sets.mpr (mem_of_nhds as)),
       assume b hb, mem_pure_sets.mp hb⟩)
 
+-- The following refined version will never be used
+
+/-- `pure : α → ultrafilter α` defines a dense embedding of `α` in `ultrafilter α`. -/
+lemma dense_embedding_pure : @dense_embedding _ _ ⊥ _ (pure : α → ultrafilter α) :=
+by letI : topological_space α := ⊥ ;
+exact { inj := ultrafilter_pure_injective, ..dense_inducing_pure }
 end embedding
 
 section extension
@@ -127,17 +132,21 @@ section extension
   dense embedding and `γ` is Hausdorff. For existence, we will invoke
   `dense_embedding.continuous_extend`. -/
 
-variables {γ : Type*} [topological_space γ]
+variables {γ : Type*} [topological_space γ] [t2_space γ]
 
 /-- The extension of a function `α → γ` to a function `ultrafilter α → γ`.
   When `γ` is a compact Hausdorff space it will be continuous. -/
 def ultrafilter.extend (f : α → γ) : ultrafilter α → γ :=
-by letI : topological_space α := ⊥; exact dense_embedding_pure.extend f
+by letI : topological_space α := ⊥; exact dense_inducing_pure.extend f
 
 lemma ultrafilter_extend_extends (f : α → γ) : ultrafilter.extend f ∘ pure = f :=
-by letI : topological_space α := ⊥; exact funext dense_embedding_pure.extend_e_eq
+begin
+  letI : topological_space α := ⊥,
+  letI : discrete_topology α := ⟨rfl⟩,
+  exact funext (dense_inducing_pure.extend_eq_of_cont continuous_of_discrete_topology)
+end
 
-variables [t2_space γ] [compact_space γ]
+variables  [compact_space γ]
 
 lemma continuous_ultrafilter_extend (f : α → γ) : continuous (ultrafilter.extend f) :=
 have ∀ (b : ultrafilter α), ∃ c, tendsto f (comap ultrafilter.pure (nhds b)) (nhds c) := assume b,
@@ -148,7 +157,7 @@ have ∀ (b : ultrafilter α), ∃ c, tendsto f (comap ultrafilter.pure (nhds b)
 begin
   letI : topological_space α := ⊥,
   letI : normal_space γ := normal_of_compact_t2,
-  exact dense_embedding_pure.continuous_extend this
+  exact dense_inducing_pure.continuous_extend this
 end
 
 /-- The value of `ultrafilter.extend f` on an ultrafilter `b` is the
@@ -169,7 +178,7 @@ lemma ultrafilter_extend_eq_iff {f : α → γ} {b : ultrafilter α} {c : γ} :
    exact le_refl _
  end,
  assume h, by letI : topological_space α := ⊥; exact
-   dense_embedding_pure.extend_eq (le_trans (map_mono (ultrafilter_comap_pure_nhds _)) h)⟩
+   dense_inducing_pure.extend_eq (le_trans (map_mono (ultrafilter_comap_pure_nhds _)) h)⟩
 
 end extension
 
@@ -208,7 +217,7 @@ def stone_cech_unit (x : α) : stone_cech α := ⟦pure x⟧
   not be an embedding, for example if α is not Hausdorff.) -/
 lemma stone_cech_unit_dense : closure (range (@stone_cech_unit α _)) = univ :=
 begin
-  convert quotient_dense_of_dense (eq_univ_iff_forall.mp dense_embedding_pure.closure_range),
+  convert quotient_dense_of_dense (eq_univ_iff_forall.mp dense_inducing_pure.closure_range),
   rw [←range_comp], refl
 end
 

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -562,7 +562,7 @@ def uniform_space.comap (f : α → β) (u : uniform_space β) : uniform_space �
     (comap_mono u.comp),
   is_open_uniformity := λ s, begin
     change (@is_open α (u.to_topological_space.induced f) s ↔ _),
-    simp [is_open_iff_nhds, nhds_induced_eq_comap, mem_nhds_uniformity_iff, filter.comap, and_comm],
+    simp [is_open_iff_nhds, nhds_induced, mem_nhds_uniformity_iff, filter.comap, and_comm],
     refine ball_congr (λ x hx, ⟨_, _⟩),
     { rintro ⟨t, hts, ht⟩, refine ⟨_, ht, _⟩,
       rintro ⟨x₁, x₂⟩ h rfl, exact hts (h rfl) },
@@ -588,15 +588,7 @@ tendsto_comap
 
 theorem to_topological_space_comap {f : α → β} {u : uniform_space β} :
   @uniform_space.to_topological_space _ (uniform_space.comap f u) =
-  topological_space.induced f (@uniform_space.to_topological_space β u) :=
-eq_of_nhds_eq_nhds $ assume a,
-begin
-  simp [nhds_induced_eq_comap, nhds_eq_uniformity, nhds_eq_uniformity],
-  change (u.uniformity.comap (λp:α×α, (f p.1, f p.2))).lift' (preimage (λa', (a, a'))) =
-           comap f ((𝓤 β).lift' (preimage (λb, (f a, b)))),
-  rw [comap_lift'_eq monotone_preimage, comap_lift'_eq2 monotone_preimage],
-  exact rfl
-end
+  topological_space.induced f (@uniform_space.to_topological_space β u) := rfl
 
 lemma uniform_continuous_comap' {f : γ → β} {g : α → γ} [v : uniform_space β] [u : uniform_space α]
   (h : uniform_continuous (f ∘ g)) : @uniform_continuous α γ u (uniform_space.comap f v) g :=
@@ -765,6 +757,26 @@ lemma to_topological_space_prod [u : uniform_space α] [v : uniform_space β] :
     @prod.topological_space α β u.to_topological_space v.to_topological_space := rfl
 
 end prod
+
+section
+open uniform_space function
+variables [uniform_space α] [uniform_space β] [uniform_space γ] [uniform_space δ]
+
+local notation f `∘₂` g := function.bicompr f g
+
+def uniform_continuous₂ (f : α → β → γ) := uniform_continuous (uncurry' f)
+
+lemma uniform_continuous₂_def (f : α → β → γ) : uniform_continuous₂ f ↔ uniform_continuous (uncurry' f) := iff.rfl
+
+lemma uniform_continuous₂_curry (f : α × β → γ) : uniform_continuous₂ (function.curry f) ↔ uniform_continuous f :=
+by rw  [←uncurry'_curry f] {occs := occurrences.pos [2]} ; refl
+
+lemma uniform_continuous₂.comp {f : α → β → γ} {g : γ → δ}
+  (hg : uniform_continuous g) (hf : uniform_continuous₂ f) :
+uniform_continuous₂ (g ∘₂ f) :=
+hg.comp hf
+
+end
 
 lemma to_topological_space_subtype [u : uniform_space α] {p : α → Prop} :
   @uniform_space.to_topological_space (subtype p) subtype.uniform_space =

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -773,7 +773,7 @@ by rw  [←uncurry'_curry f] {occs := occurrences.pos [2]} ; refl
 
 lemma uniform_continuous₂.comp {f : α → β → γ} {g : γ → δ}
   (hg : uniform_continuous g) (hf : uniform_continuous₂ f) :
-uniform_continuous₂ (g ∘₂ f) :=
+  uniform_continuous₂ (g ∘₂ f) :=
 hg.comp hf
 
 end

--- a/src/topology/uniform_space/complete_separated.lean
+++ b/src/topology/uniform_space/complete_separated.lean
@@ -10,13 +10,26 @@ This file is for elementary lemmas that depend on both Cauchy filters and separa
 import topology.uniform_space.cauchy topology.uniform_space.separation
 
 open filter
-variables {α : Type*} [uniform_space α]
+variables {α : Type*}
 
 /-In a separated space, a complete set is closed -/
-lemma is_closed_of_is_complete [separated α] {s : set α} (h : is_complete s) : is_closed s :=
+lemma is_closed_of_is_complete  [uniform_space α] [separated α] {s : set α} (h : is_complete s) :
+  is_closed s :=
 is_closed_iff_nhds.2 $ λ a ha, begin
   let f := nhds a ⊓ principal s,
   have : cauchy f := cauchy_downwards (cauchy_nhds) ha (lattice.inf_le_left),
   rcases h f this (lattice.inf_le_right) with ⟨y, ys, fy⟩,
   rwa (tendsto_nhds_unique ha lattice.inf_le_left fy : a = y)
 end
+
+namespace dense_inducing
+open filter
+variables [topological_space α] {β : Type*} [topological_space β]
+variables {γ : Type*} [uniform_space γ] [complete_space γ] [separated γ]
+
+lemma continuous_extend_of_cauchy {e : α → β} {f : α → γ}
+  (de : dense_inducing e) (h : ∀ b : β, cauchy (map f (comap e $ nhds b))) :
+  continuous (de.extend f) :=
+de.continuous_extend $ λ b, complete_space.complete (h b)
+
+end dense_inducing

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -142,20 +142,23 @@ mem_uniformity.trans $ bex_congr $ λ t h, prod.forall
 def pure_cauchy (a : α) : Cauchy α :=
 ⟨pure a, cauchy_pure⟩
 
-lemma uniform_embedding_pure_cauchy : uniform_embedding (pure_cauchy : α → Cauchy α) :=
-⟨assume a₁ a₂ h,
-  have (pure_cauchy a₁).val = (pure_cauchy a₂).val, from congr_arg _ h,
-  have {a₁} = ({a₂} : set α),
-    from principal_eq_iff_eq.mp this,
-  by simp at this; assumption,
+lemma uniform_inducing_pure_cauchy : uniform_inducing (pure_cauchy : α → Cauchy α) :=
+⟨have (preimage (λ (x : α × α), (pure_cauchy (x.fst), pure_cauchy (x.snd))) ∘ gen) = id,
+      from funext $ assume s, set.ext $ assume ⟨a₁, a₂⟩,
+        by simp [preimage, gen, pure_cauchy, prod_principal_principal],
+    calc comap (λ (x : α × α), (pure_cauchy (x.fst), pure_cauchy (x.snd))) ((𝓤 α).lift' gen)
+          = (𝓤 α).lift' (preimage (λ (x : α × α), (pure_cauchy (x.fst), pure_cauchy (x.snd))) ∘ gen) :
+        comap_lift'_eq monotone_gen
+      ... = 𝓤 α : by simp [this]⟩
 
-  have (preimage (λ (x : α × α), (pure_cauchy (x.fst), pure_cauchy (x.snd))) ∘ gen) = id,
-    from funext $ assume s, set.ext $ assume ⟨a₁, a₂⟩,
-      by simp [preimage, gen, pure_cauchy, prod_principal_principal],
-  calc comap (λ (x : α × α), (pure_cauchy (x.fst), pure_cauchy (x.snd))) ((𝓤 α).lift' gen)
-        = (𝓤 α).lift' (preimage (λ (x : α × α), (pure_cauchy (x.fst), pure_cauchy (x.snd))) ∘ gen) :
-      comap_lift'_eq monotone_gen
-    ... = 𝓤 α : by simp [this]⟩
+lemma uniform_embedding_pure_cauchy : uniform_embedding (pure_cauchy : α → Cauchy α) :=
+{ inj :=
+    assume a₁ a₂ h,
+    have (pure_cauchy a₁).val = (pure_cauchy a₂).val, from congr_arg _ h,
+    have {a₁} = ({a₂} : set α),
+      from principal_eq_iff_eq.mp this,
+    by simp at this; assumption,
+  ..uniform_inducing_pure_cauchy }
 
 lemma pure_cauchy_dense : ∀x, x ∈ closure (range pure_cauchy) :=
 assume f,
@@ -183,13 +186,16 @@ begin
       ne_empty_of_mem this)
 end
 
+lemma dense_inducing_pure_cauchy : dense_inducing pure_cauchy :=
+uniform_inducing_pure_cauchy.dense_inducing pure_cauchy_dense
+
 lemma dense_embedding_pure_cauchy : dense_embedding pure_cauchy :=
 uniform_embedding_pure_cauchy.dense_embedding pure_cauchy_dense
 
 lemma nonempty_Cauchy_iff : nonempty (Cauchy α) ↔ nonempty α :=
 begin
   split ; rintro ⟨c⟩,
-  { have := eq_univ_iff_forall.1 dense_embedding_pure_cauchy.closure_range c,
+  { have := eq_univ_iff_forall.1 dense_embedding_pure_cauchy.to_dense_inducing.closure_range c,
     have := mem_closure_iff.1 this _ is_open_univ trivial,
     rcases exists_mem_of_ne_empty this with ⟨_, ⟨_, a, _⟩⟩,
     exact ⟨a⟩ },
@@ -200,7 +206,7 @@ section
 set_option eqn_compiler.zeta true
 instance : complete_space (Cauchy α) :=
 complete_space_extension
-  uniform_embedding_pure_cauchy
+  uniform_inducing_pure_cauchy
   pure_cauchy_dense $
   assume f hf,
   let f' : Cauchy α := ⟨f, hf⟩ in
@@ -225,7 +231,7 @@ variables [_root_.complete_space β] [separated β]
 
 def extend (f : α → β) : (Cauchy α → β) :=
 if uniform_continuous f then
-  dense_embedding_pure_cauchy.extend f
+  dense_inducing_pure_cauchy.extend f
 else
   λ x, f (classical.inhabited_of_nonempty $ nonempty_Cauchy_iff.1 ⟨x⟩).default
 
@@ -233,14 +239,14 @@ lemma extend_pure_cauchy {f : α → β} (hf : uniform_continuous f) (a : α) :
   extend f (pure_cauchy a) = f a :=
 begin
   rw [extend, if_pos hf],
-  exact uniformly_extend_of_emb uniform_embedding_pure_cauchy pure_cauchy_dense _
+  exact uniformly_extend_of_ind uniform_inducing_pure_cauchy pure_cauchy_dense hf _
 end
 
 lemma uniform_continuous_extend {f : α → β} : uniform_continuous (extend f) :=
 begin
   by_cases hf : uniform_continuous f,
   { rw [extend, if_pos hf],
-    exact uniform_continuous_uniformly_extend uniform_embedding_pure_cauchy pure_cauchy_dense hf },
+    exact uniform_continuous_uniformly_extend uniform_inducing_pure_cauchy pure_cauchy_dense hf },
   { rw [extend, if_neg hf],
     exact uniform_continuous_of_const (assume a b, by congr) }
 end
@@ -287,32 +293,11 @@ lemma injective_separated_pure_cauchy {α : Type*} [uniform_space α] [s : separ
   function.injective (λa:α, ⟦pure_cauchy a⟧) | a b h :=
 separated_def.1 s _ _ $ assume s hs,
 let ⟨t, ht, hts⟩ :=
-  by rw [← (@uniform_embedding_pure_cauchy α _).right, filter.mem_comap_sets] at hs; exact hs in
+  by rw [← (@uniform_embedding_pure_cauchy α _).comap_uniformity, filter.mem_comap_sets] at hs; exact hs in
 have (pure_cauchy a, pure_cauchy b) ∈ t, from quotient.exact h t ht,
 @hts (a, b) this
 
 end
-
-section prod
-variables {α : Type*} {β : Type*} [uniform_space α] [uniform_space β]
-
-def prod : Cauchy α × Cauchy β → Cauchy (α × β) :=
-dense_embedding.extend (dense_embedding_pure_cauchy.prod dense_embedding_pure_cauchy) pure_cauchy
-
-lemma prod_pure_cauchy_pure_cauchy (a : α) (b :β) :
-  prod (pure_cauchy a, pure_cauchy b) = pure_cauchy (a, b) :=
-uniformly_extend_of_emb
-  (uniform_embedding_pure_cauchy.prod uniform_embedding_pure_cauchy)
-  (dense_embedding_pure_cauchy.prod dense_embedding_pure_cauchy).dense
-  (a, b)
-
-lemma uniform_continuous_prod : uniform_continuous (@prod α β _ _) :=
-uniform_continuous_uniformly_extend
-  (uniform_embedding_pure_cauchy.prod uniform_embedding_pure_cauchy)
-  (dense_embedding_pure_cauchy.prod dense_embedding_pure_cauchy).dense
-  uniform_embedding_pure_cauchy.uniform_continuous
-
-end prod
 
 end Cauchy
 
@@ -354,6 +339,15 @@ instance : t2_space (completion α) := separated_t2
 
 instance : regular_space (completion α) := separated_regular
 
+lemma nonempty_completion_iff : nonempty (completion α) ↔ nonempty α :=
+begin
+  conv_rhs { rw ← nonempty_Cauchy_iff },
+  split ; rintro ⟨c⟩,
+  { rcases quotient.exists_rep c with ⟨a, _⟩,
+    exact ⟨a⟩ },
+  { exact ⟨⟦c⟧⟩ }
+end
+
 /-- Automatic coercion from `α` to its completion. Not always injective. -/
 instance : has_coe α (completion α) := ⟨quotient.mk ∘ pure_cauchy⟩
 
@@ -361,7 +355,7 @@ protected lemma coe_eq : (coe : α → completion α) = quotient.mk ∘ pure_cau
 
 lemma uniform_continuous_coe : uniform_continuous (coe : α → completion α) :=
 uniform_continuous.comp
-  uniform_continuous_quotient_mk uniform_embedding_pure_cauchy.uniform_continuous
+  uniform_continuous_quotient_mk uniform_inducing_pure_cauchy.uniform_continuous
 
 lemma continuous_coe : continuous (coe : α → completion α) :=
 uniform_continuous.continuous (uniform_continuous_coe α)
@@ -374,19 +368,28 @@ begin
   { ext ⟨a, b⟩; simp; refl },
   rw [this, ← filter.comap_comap_comp],
   change filter.comap _ (filter.comap _ (𝓤 $ quotient $ separation_setoid $ Cauchy α)) = 𝓤 α,
-  rw [comap_quotient_eq_uniformity, uniform_embedding_pure_cauchy.2]
+  rw [comap_quotient_eq_uniformity, uniform_embedding_pure_cauchy.comap_uniformity]
 end
 
+lemma uniform_inducing_coe : uniform_inducing  (coe : α → completion α) :=
+⟨comap_coe_eq_uniformity α⟩
+
 lemma uniform_embedding_coe [separated α] : uniform_embedding  (coe : α → completion α) :=
-⟨injective_separated_pure_cauchy, comap_coe_eq_uniformity α⟩
+{ comap_uniformity := comap_coe_eq_uniformity α,
+  inj := injective_separated_pure_cauchy }
 
 variable {α}
 
 lemma dense : closure (range (coe : α → completion α)) = univ :=
 by rw [completion.coe_eq, range_comp]; exact quotient_dense_of_dense pure_cauchy_dense
 
+lemma dense_inducing_coe : dense_inducing (coe : α → completion α) :=
+{ dense := (dense_range_iff_closure_eq _).2 dense,
+  ..(uniform_inducing_coe α).inducing }
+
 lemma dense_embedding_coe [separated α]: dense_embedding (coe : α → completion α) :=
-(uniform_embedding_coe α).dense_embedding (assume x, by rw [dense]; exact mem_univ _)
+{ inj := injective_separated_pure_cauchy,
+  ..dense_inducing_coe }
 
 lemma dense₂ : closure (range (λx:α × β, ((x.1 : completion α), (x.2 : completion β)))) = univ :=
 by rw [← set.prod_range_range_eq, closure_prod_eq, dense, dense, univ_prod_univ]
@@ -454,20 +457,39 @@ section extension
 variables {f : α → β}
 variables [complete_space β] [separated β]
 
-/-- "Extension" to the completion. Based on `Cauchy.extend`, which is defined for any map `f` but
+/-- "Extension" to the completion. It is defined for any map `f` but
 returns an arbitrary constant value if `f` is not uniformly continuous -/
 protected def extension (f : α → β) : completion α → β :=
-quotient.lift (extend f) $ assume a b,
-  eq_of_separated_of_uniform_continuous uniform_continuous_extend
+if uniform_continuous f then
+  dense_inducing_coe.extend f
+else
+  λ x, f (classical.inhabited_of_nonempty $ (nonempty_completion_iff α).1 ⟨x⟩).default
 
 lemma uniform_continuous_extension : uniform_continuous (completion.extension f) :=
-uniform_continuous_quotient_lift uniform_continuous_extend
+begin
+  by_cases hf : uniform_continuous f,
+  { rw [completion.extension, if_pos hf],
+    exact uniform_continuous_uniformly_extend (uniform_inducing_coe α)
+      ((dense_range_iff_closure_eq _).2 dense) hf },
+  { rw [completion.extension, if_neg hf],
+    exact uniform_continuous_of_const (assume a b, by congr) }
+end
 
 lemma continuous_extension : continuous (completion.extension f) :=
 uniform_continuous_extension.continuous
 
 @[simp] lemma extension_coe (hf : uniform_continuous f) (a : α) : (completion.extension f) a = f a :=
-extend_pure_cauchy hf a
+begin
+  rw [completion.extension, if_pos hf],
+  exact dense_inducing_coe.extend_eq_of_cont hf.continuous a
+end
+
+lemma extension_unique (hf : uniform_continuous f) {g : completion α → β} (hg : uniform_continuous g)
+  (h : ∀ a : α, f a = g (a : completion α)) : completion.extension f = g :=
+begin
+  apply completion.ext uniform_continuous_extension.continuous hg.continuous,
+  simpa only [extension_coe hf] using h
+end
 
 end extension
 
@@ -479,7 +501,7 @@ protected def map (f : α → β) : completion α → completion β :=
 completion.extension (coe ∘ f)
 
 lemma uniform_continuous_map : uniform_continuous (completion.map f) :=
-uniform_continuous_quotient_lift uniform_continuous_extend
+uniform_continuous_extension
 
 lemma continuous_map : continuous (completion.map f) :=
 uniform_continuous_extension.continuous
@@ -546,41 +568,63 @@ uniform_continuous_map
 end separation_quotient_completion
 
 section prod
-variables [uniform_space β]
-protected def prod {α β} [uniform_space α] [uniform_space β] (p : completion α × completion β) : completion (α × β) :=
-quotient.lift_on₂ p.1 p.2 (λa b, ⟦Cauchy.prod (a, b)⟧) $ assume a b c d hab hcd,
-  quotient.sound $ separated_of_uniform_continuous uniform_continuous_prod $
-  separation_prod.2 ⟨hab, hcd⟩
+
+protected def prod {α β} [uniform_space α] [uniform_space β] :
+  completion α × completion β → completion (α × β) :=
+dense_inducing.extend (dense_inducing_coe.prod dense_inducing_coe) coe
 
 lemma uniform_continuous_prod : uniform_continuous (@completion.prod α β _ _) :=
-uniform_continuous_quotient_lift₂ $
-  suffices uniform_continuous (quotient.mk ∘ Cauchy.prod),
-  { convert this, ext ⟨a, b⟩, refl },
-  uniform_continuous_quotient_mk.comp Cauchy.uniform_continuous_prod
+uniform_continuous_uniformly_extend
+  ((uniform_inducing_coe α).prod $ uniform_inducing_coe β)
+  (eq_univ_iff_forall.1 dense₂)
+  (uniform_continuous_coe _)
 
-lemma prod_coe_coe (a : α) (b : β) :
-  completion.prod ((a : completion α), (b : completion β)) = (a, b) :=
-congr_arg quotient.mk $ Cauchy.prod_pure_cauchy_pure_cauchy a b
+@[move_cast]
+lemma prod_coe_coe (a : α) (b : β) : coe (a, b) =
+  completion.prod ((a : completion α), (b : completion β)) :=
+(dense_inducing.extend_eq_of_cont (dense_inducing_coe.prod dense_inducing_coe)
+  (continuous_coe $ α × β) (a, b)).symm
 
 end prod
 
+section extension₂
+variables [complete_space γ] [separated γ] (f : α → β → γ)
+open function
+
+protected def extension₂ (f : α → β → γ) : completion α → completion β → γ :=
+curry $ completion.extension (uncurry' f) ∘ completion.prod
+
+lemma uniform_continuous_extension₂ : uniform_continuous₂ (completion.extension₂ f) :=
+begin
+  rw [uniform_continuous₂_def, completion.extension₂, uncurry'_curry],
+  exact uniform_continuous_extension.comp uniform_continuous_prod,
+end
+
+variables {f}
+
+@[simp] lemma extension₂_coe_coe (hf : uniform_continuous $ uncurry' f) (a : α) (b : β) :
+  completion.extension₂ f a b = f a b :=
+by simpa [completion.extension₂, curry, (prod_coe_coe _ _).symm, extension_coe hf]
+
+end extension₂
+
 section map₂
+open function
 
-protected def map₂ (f : α → β → γ) (a : completion α) (b : completion β) : completion γ :=
-completion.map (λp:α×β, f p.1 p.2) (completion.prod (a, b))
+protected def map₂ (f : α → β → γ) : completion α → completion β → completion γ :=
+completion.extension₂ (coe ∘ f)
 
-lemma uniform_continuous_map₂' (f : α → β → γ) :
-  uniform_continuous (λp:completion α×completion β, completion.map₂ f p.1 p.2) :=
-uniform_continuous.comp completion.uniform_continuous_map uniform_continuous_prod
+lemma uniform_continuous_map₂ (f : α → β → γ) : uniform_continuous (uncurry' $ completion.map₂ f) :=
+uniform_continuous_extension₂ _
 
 lemma continuous_map₂ {δ} [topological_space δ] {f : α → β → γ}
   {a : δ → completion α} {b : δ → completion β} (ha : continuous a) (hb : continuous b) :
   continuous (λd:δ, completion.map₂ f (a d) (b d)) :=
-(uniform_continuous_map₂' f).continuous.comp (continuous.prod_mk ha hb)
+((uniform_continuous_map₂ f).continuous.comp (continuous.prod_mk ha hb) : _)
 
-lemma map₂_coe_coe (a : α) (b : β) (f : α → β → γ) (hf : uniform_continuous (λp:α×β, f p.1 p.2)) :
+lemma map₂_coe_coe (a : α) (b : β) (f : α → β → γ) (hf : uniform_continuous $ uncurry' f) :
   completion.map₂ f (a : completion α) (b : completion β) = f a b :=
-by rw [completion.map₂, completion.prod_coe_coe, completion.map_coe hf]
+completion.extension₂_coe_coe ((uniform_continuous_coe γ).comp hf) a b
 
 end map₂
 end completion

--- a/src/topology/uniform_space/uniform_embedding.lean
+++ b/src/topology/uniform_space/uniform_embedding.lean
@@ -23,8 +23,8 @@ def uniform_inducing.mk' {f : α → β} (h : ∀ s, s ∈ 𝓤 α ↔
     ∃ t ∈ 𝓤 β, ∀ x y : α, (f x, f y) ∈ t → (x, y) ∈ s) : uniform_inducing f :=
 ⟨by simp [eq_comm, filter.ext_iff, subset_def, h]⟩
 
-lemma uniform_inducing.comp {f : α → β} (hf : uniform_inducing f)
-  {g : β → γ} (hg : uniform_inducing g) : uniform_inducing (g ∘ f) :=
+lemma uniform_inducing.comp {g : β → γ} (hg : uniform_inducing g)
+  {f : α → β} (hf : uniform_inducing f) : uniform_inducing (g ∘ f) :=
 ⟨ by rw [show (λ (x : α × α), ((g ∘ f) x.1, (g ∘ f) x.2)) =
          (λ y : β × β, (g y.1, g y.2)) ∘ (λ x : α × α, (f x.1, f x.2)), by ext ; simp,
         ← filter.comap_comap_comp, hg.1, hf.1]⟩
@@ -32,22 +32,23 @@ lemma uniform_inducing.comp {f : α → β} (hf : uniform_inducing f)
 structure uniform_embedding (f : α → β) extends uniform_inducing f : Prop :=
 (inj : function.injective f)
 
-lemma uniform_embedding.comp {f : α → β} (hf : uniform_embedding f)
-  {g : β → γ} (hg : uniform_embedding g) : uniform_embedding (g ∘ f) :=
+lemma uniform_embedding.comp {g : β → γ} (hg : uniform_embedding g)
+  {f : α → β} (hf : uniform_embedding f) : uniform_embedding (g ∘ f) :=
 { inj := function.injective_comp hg.inj hf.inj,
-  ..hf.to_uniform_inducing.comp hg.to_uniform_inducing }
+  ..hg.to_uniform_inducing.comp hf.to_uniform_inducing }
 
 theorem uniform_embedding_def {f : α → β} :
   uniform_embedding f ↔ function.injective f ∧ ∀ s, s ∈ 𝓤 α ↔
     ∃ t ∈ 𝓤 β, ∀ x y : α, (f x, f y) ∈ t → (x, y) ∈ s :=
 begin
-  split, rintro ⟨⟨h⟩, h'⟩,
-  rw [eq_comm, filter.ext_iff] at h,
-  simp [*, subset_def],
-  rintro ⟨h, h'⟩,
-  refine uniform_embedding.mk ⟨_⟩ h,
-  rw [eq_comm, filter.ext_iff],
-  simp [*, subset_def]
+  split,
+  { rintro ⟨⟨h⟩, h'⟩,
+    rw [eq_comm, filter.ext_iff] at h,
+    simp [*, subset_def] },
+  { rintro ⟨h, h'⟩,
+    refine uniform_embedding.mk ⟨_⟩ h,
+    rw [eq_comm, filter.ext_iff],
+    simp [*, subset_def] }
 end
 
 theorem uniform_embedding_def' {f : α → β} :

--- a/src/topology/uniform_space/uniform_embedding.lean
+++ b/src/topology/uniform_space/uniform_embedding.lean
@@ -1,29 +1,56 @@
 /-
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johannes Hölzl, Sébastien Gouëzel
+Authors: Johannes Hölzl, Sébastien Gouëzel, Patrick Massot
 
 Uniform embeddings of uniform spaces. Extension of uniform continuous functions.
 -/
-import topology.uniform_space.cauchy
+import topology.uniform_space.cauchy topology.uniform_space.separation
 
 open filter topological_space lattice set classical
 local attribute [instance, priority 0] prop_decidable
-variables {α : Type*} {β : Type*} {γ : Type*} [uniform_space α]
-universe u
-
 local notation `𝓤` := uniformity
 
-def uniform_embedding [uniform_space β] (f : α → β) :=
-function.injective f ∧
-comap (λx:α×α, (f x.1, f x.2)) (𝓤 β) = 𝓤 α
+section
+variables {α : Type*} {β : Type*} {γ : Type*}
+          [uniform_space α] [uniform_space β] [uniform_space γ]
+universe u
 
-theorem uniform_embedding_def [uniform_space β] {f : α → β} :
+structure uniform_inducing (f : α → β) : Prop :=
+(comap_uniformity : comap (λx:α×α, (f x.1, f x.2)) (𝓤 β) = 𝓤 α)
+
+def uniform_inducing.mk' {f : α → β} (h : ∀ s, s ∈ 𝓤 α ↔
+    ∃ t ∈ 𝓤 β, ∀ x y : α, (f x, f y) ∈ t → (x, y) ∈ s) : uniform_inducing f :=
+⟨by simp [eq_comm, filter.ext_iff, subset_def, h]⟩
+
+lemma uniform_inducing.comp {f : α → β} (hf : uniform_inducing f)
+  {g : β → γ} (hg : uniform_inducing g) : uniform_inducing (g ∘ f) :=
+⟨ by rw [show (λ (x : α × α), ((g ∘ f) x.1, (g ∘ f) x.2)) =
+         (λ y : β × β, (g y.1, g y.2)) ∘ (λ x : α × α, (f x.1, f x.2)), by ext ; simp,
+        ← filter.comap_comap_comp, hg.1, hf.1]⟩
+
+structure uniform_embedding (f : α → β) extends uniform_inducing f : Prop :=
+(inj : function.injective f)
+
+lemma uniform_embedding.comp {f : α → β} (hf : uniform_embedding f)
+  {g : β → γ} (hg : uniform_embedding g) : uniform_embedding (g ∘ f) :=
+{ inj := function.injective_comp hg.inj hf.inj,
+  ..hf.to_uniform_inducing.comp hg.to_uniform_inducing }
+
+theorem uniform_embedding_def {f : α → β} :
   uniform_embedding f ↔ function.injective f ∧ ∀ s, s ∈ 𝓤 α ↔
     ∃ t ∈ 𝓤 β, ∀ x y : α, (f x, f y) ∈ t → (x, y) ∈ s :=
-by rw [uniform_embedding, eq_comm, filter.ext_iff]; simp [subset_def]
+begin
+  split, rintro ⟨⟨h⟩, h'⟩,
+  rw [eq_comm, filter.ext_iff] at h,
+  simp [*, subset_def],
+  rintro ⟨h, h'⟩,
+  refine uniform_embedding.mk ⟨_⟩ h,
+  rw [eq_comm, filter.ext_iff],
+  simp [*, subset_def]
+end
 
-theorem uniform_embedding_def' [uniform_space β] {f : α → β} :
+theorem uniform_embedding_def' {f : α → β} :
   uniform_embedding f ↔ function.injective f ∧ uniform_continuous f ∧
     ∀ s, s ∈ 𝓤 α →
       ∃ t ∈ 𝓤 β, ∀ x y : α, (f x, f y) ∈ t → (x, y) ∈ s :=
@@ -32,35 +59,49 @@ by simp [uniform_embedding_def, uniform_continuous_def]; exact
  λ ⟨I, H₁, H₂⟩, ⟨I, λ s, ⟨H₂ s,
    λ ⟨t, tu, h⟩, sets_of_superset _ (H₁ t tu) (λ ⟨a, b⟩, h a b)⟩⟩⟩
 
-lemma uniform_embedding.uniform_continuous [uniform_space β] {f : α → β}
-  (hf : uniform_embedding f) : uniform_continuous f :=
-(uniform_embedding_def'.1 hf).2.1
+lemma uniform_inducing.uniform_continuous {f : α → β}
+  (hf : uniform_inducing f) : uniform_continuous f :=
+by simp [uniform_continuous, hf.comap_uniformity.symm, tendsto_comap]
 
-lemma uniform_embedding.uniform_continuous_iff [uniform_space β] [uniform_space γ] {f : α → β}
-  {g : β → γ} (hg : uniform_embedding g) : uniform_continuous f ↔ uniform_continuous (g ∘ f) :=
-by simp [uniform_continuous, tendsto]; rw [← hg.2, ← map_le_iff_le_comap, filter.map_map]
+lemma uniform_inducing.uniform_continuous_iff {f : α → β} {g : β → γ} (hg : uniform_inducing g) :
+  uniform_continuous f ↔ uniform_continuous (g ∘ f) :=
+by simp [uniform_continuous, tendsto]; rw [← hg.comap_uniformity, ← map_le_iff_le_comap, filter.map_map]
 
-lemma uniform_embedding.embedding [uniform_space β] {f : α → β} (h : uniform_embedding f) : embedding f :=
+lemma uniform_inducing.inducing {f : α → β} (h : uniform_inducing f) : inducing f :=
 begin
-  refine ⟨h.left, eq_of_nhds_eq_nhds $ assume a, _⟩,
-  rw [nhds_induced_eq_comap, nhds_eq_uniformity, nhds_eq_uniformity, ← h.right,
+  refine ⟨eq_of_nhds_eq_nhds $ assume a, _ ⟩,
+  rw [nhds_induced, nhds_eq_uniformity, nhds_eq_uniformity, ← h.comap_uniformity,
     comap_lift'_eq, comap_lift'_eq2];
     { refl <|> exact monotone_preimage }
 end
 
-lemma uniform_embedding.dense_embedding [uniform_space β] {f : α → β}
-  (h : uniform_embedding f) (hd : ∀x, x ∈ closure (range f)) : dense_embedding f :=
+lemma uniform_inducing.prod {α' : Type*} {β' : Type*} [uniform_space α'] [uniform_space β']
+  {e₁ : α → α'} {e₂ : β → β'} (h₁ : uniform_inducing e₁) (h₂ : uniform_inducing e₂) :
+  uniform_inducing (λp:α×β, (e₁ p.1, e₂ p.2)) :=
+⟨by simp [(∘), uniformity_prod, h₁.comap_uniformity.symm, h₂.comap_uniformity.symm,
+           comap_inf, comap_comap_comp]⟩
+
+lemma uniform_inducing.dense_inducing {f : α → β} (h : uniform_inducing f) (hd : dense_range f) :
+  dense_inducing f :=
 { dense   := hd,
-  inj     := h.left,
-  induced := assume a, by rw [h.embedding.2, nhds_induced_eq_comap] }
+  induced := h.inducing.induced }
 
+lemma uniform_embedding.embedding {f : α → β} (h : uniform_embedding f) : embedding f :=
+{ induced := h.to_uniform_inducing.inducing.induced,
+  inj := h.inj }
 
-lemma closure_image_mem_nhds_of_uniform_embedding
-  [uniform_space α] [uniform_space β] {s : set (α×α)} {e : α → β} (b : β)
-  (he₁ : uniform_embedding e) (he₂ : dense_embedding e) (hs : s ∈ 𝓤 α) :
+lemma uniform_embedding.dense_embedding {f : α → β} (h : uniform_embedding f) (hd : dense_range f) :
+  dense_embedding f :=
+{ dense   := hd,
+  inj     := h.inj,
+  induced := h.embedding.induced }
+
+lemma closure_image_mem_nhds_of_uniform_inducing
+  {s : set (α×α)} {e : α → β} (b : β)
+  (he₁ : uniform_inducing e) (he₂ : dense_inducing e) (hs : s ∈ 𝓤 α) :
   ∃a, closure (e '' {a' | (a, a') ∈ s}) ∈ nhds b :=
 have s ∈ comap (λp:α×α, (e p.1, e p.2)) (𝓤 β),
-  from he₁.right.symm ▸ hs,
+  from he₁.comap_uniformity.symm ▸ hs,
 let ⟨t₁, ht₁u, ht₁⟩ := this in
 have ht₁ : ∀p:α×α, (e p.1, e p.2) ∈ t₁ → p ∈ s, from ht₁,
 let ⟨t₂, ht₂u, ht₂s, ht₂c⟩ := comp_symm_of_uniformity ht₁u in
@@ -90,37 +131,31 @@ have ∀b', (b, b') ∈ t → b' ∈ closure (e '' {a' | (a, a') ∈ s}),
   from assume b' hb', by rw [closure_eq_nhds]; exact this b' hb',
 ⟨a, (nhds b).sets_of_superset (mem_nhds_left b htu) this⟩
 
-lemma uniform_embedding_comap {f : α → β} [u : uniform_space β] (hf : function.injective f) :
-  @uniform_embedding α β (uniform_space.comap f u) u f :=
-⟨hf, rfl⟩
+lemma uniform_embedding_subtype_emb (p : α → Prop) {e : α → β} (ue : uniform_embedding e)
+  (de : dense_embedding e) : uniform_embedding (de.subtype_emb p) :=
+{ comap_uniformity := by simp [comap_comap_comp, (∘), dense_embedding.subtype_emb,
+           uniformity_subtype, ue.comap_uniformity.symm],
+  inj := (de.subtype p).inj }
 
-lemma uniform_embedding_subtype_emb {α : Type*} {β : Type*} [uniform_space α] [uniform_space β]
-  (p : α → Prop) {e : α → β} (ue : uniform_embedding e) (de : dense_embedding e) :
-  uniform_embedding (de.subtype_emb p) :=
-⟨(de.subtype p).inj,
-  by simp [comap_comap_comp, (∘), dense_embedding.subtype_emb, uniformity_subtype, ue.right.symm]⟩
-
-lemma uniform_embedding.prod {α' : Type*} {β' : Type*}
-  [uniform_space α] [uniform_space β] [uniform_space α'] [uniform_space β']
+lemma uniform_embedding.prod {α' : Type*} {β' : Type*} [uniform_space α'] [uniform_space β']
   {e₁ : α → α'} {e₂ : β → β'} (h₁ : uniform_embedding e₁) (h₂ : uniform_embedding e₂) :
   uniform_embedding (λp:α×β, (e₁ p.1, e₂ p.2)) :=
-⟨assume ⟨a₁, b₁⟩ ⟨a₂, b₂⟩,
-  by simp [prod.mk.inj_iff]; exact assume eq₁ eq₂, ⟨h₁.left eq₁, h₂.left eq₂⟩,
-  by simp [(∘), uniformity_prod, h₁.right.symm, h₂.right.symm, comap_inf, comap_comap_comp]⟩
+{ inj := function.injective_prod h₁.inj h₂.inj,
+  ..h₁.to_uniform_inducing.prod h₂.to_uniform_inducing }
 
 /-- A set is complete iff its image under a uniform embedding is complete. -/
-lemma is_complete_image_iff [uniform_space β] {m : α → β} {s : set α}
-  (hm : uniform_embedding m) : is_complete (m '' s) ↔ is_complete s :=
+lemma is_complete_image_iff {m : α → β} {s : set α} (hm : uniform_embedding m) :
+  is_complete (m '' s) ↔ is_complete s :=
 begin
   refine ⟨λ c f hf fs, _, λ c f hf fs, _⟩,
   { let f' := map m f,
-    have cf' : cauchy f' := cauchy_map (uniform_embedding.uniform_continuous hm) hf,
+    have cf' : cauchy f' := cauchy_map hm.to_uniform_inducing.uniform_continuous hf,
     have f's : f' ≤ principal (m '' s),
     { simp only [filter.le_principal_iff, set.mem_image, filter.mem_map],
       exact mem_sets_of_superset (filter.le_principal_iff.1 fs) (λx hx, ⟨x, hx, rfl⟩) },
     rcases c f' cf' f's with ⟨y, yms, hy⟩,
     rcases mem_image_iff_bex.1 yms with ⟨x, xs, rfl⟩,
-    rw [map_le_iff_le_comap, ← nhds_induced_eq_comap, ← (uniform_embedding.embedding hm).2] at hy,
+    rw [map_le_iff_le_comap, ← nhds_induced, ← (uniform_embedding.embedding hm).induced] at hy,
     exact ⟨x, xs, hy⟩ },
   { rw filter.le_principal_iff at fs,
     let f' := comap m f,
@@ -137,22 +172,19 @@ begin
         rw ← yx at xt,
         exact ⟨y, xt⟩ },
       apply cauchy_comap _ hf this,
-      simp only [hm.2, le_refl] },
+      simp only [hm.comap_uniformity, le_refl] },
     have : f' ≤ principal s := by simp [f']; exact
-      ⟨m '' s, by simpa using fs, by simp [preimage_image_eq s hm.1]⟩,
+      ⟨m '' s, by simpa using fs, by simp [preimage_image_eq s hm.inj]⟩,
     rcases c f' cf' this with ⟨x, xs, hx⟩,
     existsi [m x, mem_image_of_mem m xs],
-    rw [(uniform_embedding.embedding hm).2, nhds_induced_eq_comap] at hx,
+    rw [(uniform_embedding.embedding hm).induced, nhds_induced] at hx,
     calc f = map m f' : (map_comap $ filter.mem_sets_of_superset fs $ image_subset_range _ _).symm
       ... ≤ map m (comap m (nhds (m x))) : map_mono hx
       ... ≤ nhds (m x) : map_comap_le }
 end
 
-lemma complete_space_extension [uniform_space β] {m : β → α}
-  (hm : uniform_embedding m)
-  (dense : ∀x, x ∈ closure (range m))
-  (h : ∀f:filter β, cauchy f → ∃x:α, map m f ≤ nhds x) :
-  complete_space α :=
+lemma complete_space_extension {m : β → α} (hm : uniform_inducing m) (dense : dense_range m)
+  (h : ∀f:filter β, cauchy f → ∃x:α, map m f ≤ nhds x) : complete_space α :=
 ⟨assume (f : filter α), assume hf : cauchy f,
 let
   p : set (α × α) → set α → set α := λs t, {y : α| ∃x:α, x ∈ t ∧ (x, y) ∈ s},
@@ -175,7 +207,7 @@ have comap m g ≠ ⊥, from comap_neq_bot $ assume t ht,
   let ⟨t'', ht'', ht'_sub⟩ := (mem_lift'_sets mp₁).mp ht_mem in
   let ⟨x, (hx : x ∈ t'')⟩ := inhabited_of_mem_sets hf.left ht'' in
   have h₀ : nhds x ⊓ principal (range m) ≠ ⊥,
-    by simp [closure_eq_nhds] at dense; exact dense x,
+    by simpa [dense_range, closure_eq_nhds] using dense x,
   have h₁ : {y | (x, y) ∈ t'} ∈ nhds x ⊓ principal (range m),
     from @mem_inf_sets_of_left α (nhds x) (principal (range m)) _ $ mem_nhds_left x ht',
   have h₂ : range m ∈ nhds x ⊓ principal (range m),
@@ -205,7 +237,7 @@ have cauchy g, from
       comp_s₂ $ prod_mk_mem_comp_rel (prod_t this) hc₂)⟩,
 
 have cauchy (filter.comap m g),
-  from cauchy_comap (le_of_eq hm.right) ‹cauchy g› (by assumption),
+  from cauchy_comap (le_of_eq hm.comap_uniformity) ‹cauchy g› (by assumption),
 
 let ⟨x, (hx : map m (filter.comap m g) ≤ nhds x)⟩ := h _ this in
 have map m (filter.comap m g) ⊓ nhds x ≠ ⊥,
@@ -216,55 +248,63 @@ have g ⊓ nhds x ≠ ⊥,
 ⟨x, calc f ≤ g : by assumption
   ... ≤ nhds x : le_nhds_of_cauchy_adhp ‹cauchy g› this⟩⟩
 
-lemma totally_bounded_preimage [uniform_space α] [uniform_space β] {f : α → β} {s : set β}
-  (hf : uniform_embedding f) (hs : totally_bounded s) : totally_bounded (f ⁻¹' s) :=
+lemma totally_bounded_preimage {f : α → β} {s : set β} (hf : uniform_embedding f)
+  (hs : totally_bounded s) : totally_bounded (f ⁻¹' s) :=
 λ t ht, begin
-  rw ← hf.2 at ht,
+  rw ← hf.comap_uniformity at ht,
   rcases mem_comap_sets.2 ht with ⟨t', ht', ts⟩,
   rcases totally_bounded_iff_subset.1
     (totally_bounded_subset (image_preimage_subset f s) hs) _ ht' with ⟨c, cs, hfc, hct⟩,
-  refine ⟨f ⁻¹' c, finite_preimage (inj_on_of_injective _ hf.1) hfc, λ x h, _⟩,
+  refine ⟨f ⁻¹' c, finite_preimage (inj_on_of_injective _ hf.inj) hfc, λ x h, _⟩,
   have := hct (mem_image_of_mem f h), simp at this ⊢,
   rcases this with ⟨z, zc, zt⟩,
   rcases cs zc with ⟨y, yc, rfl⟩,
   exact ⟨y, zc, ts (by exact zt)⟩
 end
 
+end
+
+lemma uniform_embedding_comap {α : Type*} {β : Type*} {f : α → β} [u : uniform_space β]
+  (hf : function.injective f) : @uniform_embedding α β (uniform_space.comap f u) u f :=
+@uniform_embedding.mk _ _ (uniform_space.comap f u) _ _
+  (@uniform_inducing.mk _ _ (uniform_space.comap f u) _ _ rfl) hf
+
 section uniform_extension
 
-variables
-  [uniform_space β]
-  [uniform_space γ]
-  {e : β → α}
-  (h_e : uniform_embedding e)
-  (h_dense : ∀x, x ∈ closure (range e))
-  {f : β → γ}
-  (h_f : uniform_continuous f)
+variables {α : Type*} {β : Type*} {γ : Type*}
+          [uniform_space α] [uniform_space β] [uniform_space γ]
+          [separated γ]
+          {e : β → α}
+          (h_e : uniform_inducing e)
+          (h_dense : dense_range e)
+          {f : β → γ}
+          (h_f : uniform_continuous f)
+include h_f
 
-local notation `ψ` := (h_e.dense_embedding h_dense).extend f
+local notation `ψ` := (h_e.dense_inducing h_dense).extend f
 
-lemma uniformly_extend_of_emb (b : β) : ψ (e b) = f b :=
-dense_embedding.extend_e_eq _ b
+lemma uniformly_extend_of_ind (b : β) : ψ (e b) = f b :=
+dense_inducing.extend_e_eq _ b (continuous_iff_continuous_at.1 h_f.continuous b)
 
 lemma uniformly_extend_exists [complete_space γ] (a : α) :
   ∃c, tendsto f (comap e (nhds a)) (nhds c) :=
-let de := (h_e.dense_embedding h_dense) in
+let de := (h_e.dense_inducing h_dense) in
 have cauchy (nhds a), from cauchy_nhds,
 have cauchy (comap e (nhds a)), from
-  cauchy_comap (le_of_eq h_e.right) this de.comap_nhds_neq_bot,
+  cauchy_comap (le_of_eq h_e.comap_uniformity) this de.comap_nhds_neq_bot,
 have cauchy (map f (comap e (nhds a))), from
   cauchy_map h_f this,
 complete_space.complete this
 
-lemma uniformly_extend_spec [complete_space γ] (h_f : uniform_continuous f) (a : α) :
+lemma uniformly_extend_spec [complete_space γ] (a : α) :
   tendsto f (comap e (nhds a)) (nhds (ψ a)) :=
-let de := (h_e.dense_embedding h_dense) in
+let de := (h_e.dense_inducing h_dense) in
 begin
   by_cases ha : a ∈ range e,
   { rcases ha with ⟨b, rfl⟩,
-    rw [uniformly_extend_of_emb, de.induced],
+    rw [uniformly_extend_of_ind _ _ h_f, ← de.nhds_eq_comap],
     exact h_f.continuous.tendsto _ },
-  { simp only [dense_embedding.extend, dif_neg ha],
+  { simp only [dense_inducing.extend, dif_neg ha],
     exact (@lim_spec _ _ (id _) _ $ uniformly_extend_exists h_e h_dense h_f _) }
 end
 
@@ -275,7 +315,7 @@ let ⟨s, hs, hs_comp⟩ := (mem_lift'_sets $
 have h_pnt : ∀{a m}, m ∈ nhds a → ∃c, c ∈ f '' preimage e m ∧ (c, ψ a) ∈ s ∧ (ψ a, c) ∈ s,
   from assume a m hm,
   have nb : map f (comap e (nhds a)) ≠ ⊥,
-    from map_ne_bot (h_e.dense_embedding h_dense).comap_nhds_neq_bot,
+    from map_ne_bot (h_e.dense_inducing h_dense).comap_nhds_neq_bot,
   have (f '' preimage e m) ∩ ({c | (c, ψ a) ∈ s } ∩ {c | (ψ a, c) ∈ s }) ∈ map f (comap e (nhds a)),
     from inter_mem_sets (image_mem_map $ preimage_mem_comap $ hm)
       (uniformly_extend_spec h_e h_dense h_f _ (inter_mem_sets (mem_nhds_right _ hs) (mem_nhds_left _ hs))),
@@ -283,7 +323,7 @@ have h_pnt : ∀{a m}, m ∈ nhds a → ∃c, c ∈ f '' preimage e m ∧ (c, ψ
 have preimage (λp:β×β, (f p.1, f p.2)) s ∈ 𝓤 β,
   from h_f hs,
 have preimage (λp:β×β, (f p.1, f p.2)) s ∈ comap (λx:β×β, (e x.1, e x.2)) (𝓤 α),
-  by rwa [h_e.right.symm] at this,
+  by rwa [h_e.comap_uniformity.symm] at this,
 let ⟨t, ht, ts⟩ := this in
 show preimage (λp:(α×α), (ψ p.1, ψ p.2)) d ∈ 𝓤 α,
   from (𝓤 α).sets_of_superset (interior_mem_uniformity ht) $
@@ -308,8 +348,9 @@ show preimage (λp:(α×α), (ψ p.1, ψ p.2)) d ∈ 𝓤 α,
   hs_comp $ show (ψ x₁, ψ x₂) ∈ comp_rel s (comp_rel s s),
     from ⟨a, ha₂, ⟨b, this, hb₂⟩⟩
 
-lemma uniform_extend_subtype {α : Type*} {β : Type*} {γ : Type*}
-  [uniform_space α] [uniform_space β] [uniform_space γ] [complete_space γ]
+omit h_f
+
+lemma uniform_extend_subtype [complete_space γ]
   {p : α → Prop} {e : α → β} {f : α → γ} {b : β} {s : set α}
   (hf : uniform_continuous (λx:subtype p, f x.val))
   (he : uniform_embedding e) (hd : ∀x:β, x ∈ closure (range e))
@@ -324,7 +365,7 @@ have ue' : uniform_embedding (de.subtype_emb p),
 have b ∈ closure (e '' {x | p x}),
   from (closure_mono $ mono_image $ hp) (mem_of_nhds hb),
 let ⟨c, (hc : tendsto (f ∘ subtype.val) (comap (de.subtype_emb p) (nhds ⟨b, this⟩)) (nhds c))⟩ :=
-  uniformly_extend_exists ue' de'.dense hf _ in
+  uniformly_extend_exists ue'.to_uniform_inducing de'.dense hf _ in
 begin
   rw [nhds_subtype_eq_comap] at hc,
   simp [comap_comap_comp] at hc,
@@ -334,7 +375,7 @@ begin
   exact ⟨_, hb, assume x,
     begin
       change e x ∈ (closure (e '' s)) → x ∈ range subtype.val,
-      rw [←closure_induced, closure_eq_nhds, mem_set_of_eq, (≠), nhds_induced_eq_comap, de.induced],
+      rw [←closure_induced, closure_eq_nhds, mem_set_of_eq, (≠), nhds_induced, ← de.to_dense_inducing.nhds_eq_comap],
       change x ∈ {x | nhds x ⊓ principal s ≠ ⊥} → x ∈ range subtype.val,
       rw [←closure_eq_nhds, closure_eq_of_is_closed hs],
       exact assume hxs, ⟨⟨x, hp x hxs⟩, rfl⟩,


### PR DESCRIPTION
Traditionally, topology extends functions defined on dense subspaces (equipped by the induced topology). In mathlib, this was made type-theory-friendly by rather factoring through `dense_embedding` maps. A map `f : α  → β` between topological spaces is a dense embedding if its image is dense, it is injective, and it pulls back the topology from `β` to the topology on `α`. It turns out
that the injectivity was never used in any serious way. It used not to be used at all until we noticed it could be used to ensure the factorization equation `dense_embedding.extend_e_eq` could be made to
hold without any assumption on the map to be extended. But of course this formalization trick is mathematically completely irrelevant.

On the other hand, assuming injectivity prevents direct use in uniform spaces completion, because the map from a space to its (separated) completion is injective only when the original space is separated. This is why mathlib ring completion currently assumes a separated topological ring, and the perfectoid spaces project needed a lot of effort to drop that assumption. This commit makes all this completely painless.

Along the way, we improve consistency and readability by turning a couple of conjunctions into structures. Also we introduce a predicate `dense_range` which was already everywhere, but without a name, and with duplicated proofs.

It also introduces a long overdue fix to `function.uncurry` (which suffered from abusive pattern
matching, similar to `prod.map`). Also removes the duplication `nhds_induced_eq_comap`/`nhds_induced`.

@sgouezel could you check I didn't harm your metric space completion and Gromov-Hausdorff work? It should be only little simplification, or a bit of help to the elaborator (especially a couple of `: _` added with speed).

@rwbarton same question for the Stone-Cech compactification. The main difference should be that the map from a discrete space to ultrafilter on it is first proved to be dense inducing before adding that injectivity also holds. And then injectivity is no longer used anywhere. It means the `t2_space` assumption needs to be added a bit earlier but this should be totally irrelevant.

See discussion at https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/function.20extension and https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/induced.20neighborhoods