### PR TITLE
chore(data/matrix): remove unnecessary decidable_eq

### DIFF
--- a/src/data/matrix.lean
+++ b/src/data/matrix.lean
@@ -112,11 +112,11 @@ theorem mul_val' [has_mul α] [add_comm_monoid α] {M N : matrix n n α} {i k} :
   (M * N) i k = finset.univ.sum (λ j, M i j * N j k) := rfl
 
 section semigroup
-variables [decidable_eq m] [decidable_eq n] [semiring α]
+variables [semiring α]
 
 protected theorem mul_assoc (L : matrix l m α) (M : matrix m n α) (N : matrix n o α) :
   (L ⬝ M) ⬝ N = L ⬝ (M ⬝ N) :=
-by funext i k;
+by classical; funext i k;
    simp [finset.mul_sum, finset.sum_mul, mul_assoc];
    rw finset.sum_comm
 


### PR DESCRIPTION
This was generating annoying `decidable_eq (fin n)` goals when rewriting.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
