### PR TITLE
feat(data/list/basic): list.prod_range_succ, list.sum_range_succ

### DIFF
--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -4250,7 +4250,7 @@ nodup_pmap (λ _ _ _ _, fin.veq_of_eq) (nodup_range _)
 @[simp] lemma length_fin_range (n : ℕ) : (fin_range n).length = n :=
 by rw [fin_range, length_pmap, length_range]
 
-@[simp, to_additive list.sum_range_succ]
+@[to_additive list.sum_range_succ]
 theorem prod_range_succ {α : Type u} [monoid α] (f : ℕ → α) (n : ℕ) :
   ((range n.succ).map f).prod = ((range n).map f).prod * f n :=
 by rw [range_concat, ←concat_eq_append, map_concat, concat_eq_append,

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -4253,7 +4253,7 @@ by rw [fin_range, length_pmap, length_range]
 @[to_additive list.sum_range_succ]
 theorem prod_range_succ {α : Type u} [monoid α] (f : ℕ → α) (n : ℕ) :
   ((range n.succ).map f).prod = ((range n).map f).prod * f n :=
-by rw [range_concat, ←concat_eq_append, map_concat, concat_eq_append,
+by rw [range_concat, map_append, map_singleton,
   prod_append, prod_cons, prod_nil, mul_one]
 
 /--

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -4252,9 +4252,9 @@ by rw [fin_range, length_pmap, length_range]
 
 @[simp, to_additive list.sum_range_succ]
 theorem prod_range_succ {α : Type u} [monoid α] (f : ℕ → α) (n : ℕ) :
-((range (succ n)).map f).prod = ((range n).map f).prod * f n :=
+  ((range n.succ).map f).prod = ((range n).map f).prod * f n :=
 by rw [range_concat, ←concat_eq_append, map_concat, concat_eq_append,
- prod_append, prod_cons, prod_nil, mul_one]
+  prod_append, prod_cons, prod_nil, mul_one]
 
 /--
 `Ico n m` is the list of natural numbers `n ≤ x < m`.

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -4209,7 +4209,7 @@ mt mem_range.1 $ lt_irrefl _
 theorem nth_range {m n : ℕ} (h : m < n) : nth (range n) m = some m :=
 by simp only [range_eq_range', nth_range' _ h, zero_add]
 
-theorem range_concat (n : ℕ) : range (n + 1) = range n ++ [n] :=
+theorem range_concat (n : ℕ) : range (succ n) = range n ++ [n] :=
 by simp only [range_eq_range', range'_concat, zero_add]
 
 theorem iota_eq_reverse_range' : ∀ n : ℕ, iota n = reverse (range' 1 n)
@@ -4249,6 +4249,12 @@ nodup_pmap (λ _ _ _ _, fin.veq_of_eq) (nodup_range _)
 
 @[simp] lemma length_fin_range (n : ℕ) : (fin_range n).length = n :=
 by rw [fin_range, length_pmap, length_range]
+
+@[simp, to_additive list.sum_range_succ]
+theorem prod_range_succ {α : Type u} [monoid α] (f : ℕ → α) (n : ℕ) :
+((range (succ n)).map f).prod = ((range n).map f).prod * f n :=
+by rw [range_concat, ←concat_eq_append, map_concat, concat_eq_append,
+ prod_append, prod_cons, prod_nil, mul_one]
 
 /--
 `Ico n m` is the list of natural numbers `n ≤ x < m`.


### PR DESCRIPTION
cf. `finset.prod_range_succ` in algebra.big_operators

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
