### PR TITLE
perf(data/polynomial, field_theory/splitting_field): memory problems

### DIFF
--- a/src/data/polynomial.lean
+++ b/src/data/polynomial.lean
@@ -1786,7 +1786,7 @@ if hn : n = 0
 then if h : (X : polynomial α) ^ n - C a = 0
   then by simp only [nat.zero_le, nth_roots, roots, h, dif_pos rfl, card_empty]
   else with_bot.coe_le_coe.1 (le_trans (card_roots h)
-    (by rw [hn, pow_zero, ← @C_1 α _ _, ← is_ring_hom.map_sub (@C α _ _)];
+   (by rw [hn, pow_zero, ← @C_1 α _ _, ← @is_ring_hom.map_sub _ _ _ _ (@C α _ _)];
       exact degree_C_le))
 else by rw [← with_bot.coe_le_coe, ← degree_X_pow_sub_C (nat.pos_of_ne_zero hn) a];
   exact card_roots (X_pow_sub_C_ne_zero (nat.pos_of_ne_zero hn) a)

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -10,6 +10,8 @@ import ring_theory.unique_factorization_domain
 import data.polynomial ring_theory.principal_ideal_domain
        algebra.euclidean_domain
 
+local attribute [instance, priority 100000] is_ring_hom.id
+
 universes u v w
 
 variables {α : Type u} {β : Type v} {γ : Type w}


### PR DESCRIPTION
Fixes a handful of bad type class searches that were slow and expensive. Both are related to unbundled homs, so this might just be a temporary patch.

Should `local attribute [instance, priority 100000] is_ring_hom.id` be global, at the point of definition? (It's already a global instance, just boosting the priority here.)

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
