### PR TITLE
feat(linear_algebra/dim): findim equivalence

### DIFF
--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -9,10 +9,10 @@ import linear_algebra.basis
 import set_theory.ordinal
 noncomputable theory
 
-universes u v v' w w'
+universes u u' u'' v v' w w'
 
 variables {α : Type u} {β γ δ ε : Type v}
-variables {ι : Type w} {ι' : Type w'} {η : Type u} {φ : η → Type u}
+variables {ι : Type w} {ι' : Type w'} {η : Type u''} {φ : η → Type u'}
 -- TODO: relax these universe constraints
 
 section vector_space
@@ -310,12 +310,16 @@ begin
   simp [λ i, (hb i).mk_range_eq_dim.symm, cardinal.sum_mk]
 end
 
-lemma dim_fun {β : Type u} [add_comm_group β] [vector_space α β] :
-  vector_space.dim α (η → β) = fintype.card η * vector_space.dim α β :=
-by rw [dim_pi, cardinal.sum_const, cardinal.fintype_card]
+lemma dim_fun :
+  vector_space.dim α (η → β) = cardinal.lift.{u'' v} (fintype.card η : cardinal) * cardinal.lift.{v u''} (vector_space.dim α β) :=
+by rw [dim_pi, cardinal.sum_const_eq_lift_mul, cardinal.fintype_card]
 
 lemma dim_fun' : vector_space.dim α (η → α) = fintype.card η :=
-by rw [dim_fun, dim_of_field α, mul_one]
+by rw [dim_fun, dim_of_field α, cardinal.lift_one, mul_one,
+    cardinal.lift_nat_cast, cardinal.nat_cast_inj]
+
+lemma dim_fin_fun (n : ℕ) : dim α (fin n → α) = n :=
+by simp [dim_fun']
 
 end fintype
 

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -310,12 +310,16 @@ begin
   simp [λ i, (hb i).mk_range_eq_dim.symm, cardinal.sum_mk]
 end
 
-lemma dim_fun :
+lemma dim_fun {β η : Type u} [fintype η] [add_comm_group β] [vector_space α β] :
+  vector_space.dim α (η → β) = fintype.card η * vector_space.dim α β :=
+by rw [dim_pi, cardinal.sum_const, cardinal.fintype_card]
+
+lemma dim_fun_eq_lift_mul :
   vector_space.dim α (η → β) = cardinal.lift.{u'' v} (fintype.card η : cardinal) * cardinal.lift.{v u''} (vector_space.dim α β) :=
 by rw [dim_pi, cardinal.sum_const_eq_lift_mul, cardinal.fintype_card]
 
 lemma dim_fun' : vector_space.dim α (η → α) = fintype.card η :=
-by rw [dim_fun, dim_of_field α, cardinal.lift_one, mul_one,
+by rw [dim_fun_eq_lift_mul, dim_of_field α, cardinal.lift_one, mul_one,
     cardinal.lift_nat_cast, cardinal.nat_cast_inj]
 
 lemma dim_fin_fun (n : ℕ) : dim α (fin n → α) = n :=

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -315,12 +315,12 @@ lemma dim_fun {β η : Type u} [fintype η] [add_comm_group β] [vector_space α
 by rw [dim_pi, cardinal.sum_const, cardinal.fintype_card]
 
 lemma dim_fun_eq_lift_mul :
-  vector_space.dim α (η → β) = cardinal.lift.{u'' v} (fintype.card η : cardinal) * cardinal.lift.{v u''} (vector_space.dim α β) :=
-by rw [dim_pi, cardinal.sum_const_eq_lift_mul, cardinal.fintype_card]
+  vector_space.dim α (η → β) = (fintype.card η : cardinal.{max u'' v}) *
+    cardinal.lift.{v u''} (vector_space.dim α β) :=
+by rw [dim_pi, cardinal.sum_const_eq_lift_mul, cardinal.fintype_card, cardinal.lift_nat_cast]
 
 lemma dim_fun' : vector_space.dim α (η → α) = fintype.card η :=
-by rw [dim_fun_eq_lift_mul, dim_of_field α, cardinal.lift_one, mul_one,
-    cardinal.lift_nat_cast, cardinal.nat_cast_inj]
+by rw [dim_fun_eq_lift_mul, dim_of_field α, cardinal.lift_one, mul_one, cardinal.nat_cast_inj]
 
 lemma dim_fin_fun (n : ℕ) : dim α (fin n → α) = n :=
 by simp [dim_fun']

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -505,6 +505,20 @@ calc lift.{u (max v w)} a = lift.{v (max u w)} b
     = lift.{(max u v) w} (lift.{v u} b) : by simp
   ... ↔ lift.{u v} a = lift.{v u} b : lift_inj
 
+theorem mk_prod {α : Type u} {β : Type v} :
+  mk (α × β) = lift.{u v} (mk α) * lift.{v u} (mk β) :=
+quotient.sound ⟨equiv.prod_congr (equiv.ulift).symm (equiv.ulift).symm⟩
+
+theorem sum_const_eq_lift_mul (ι : Type u) (a : cardinal.{v}) :
+  sum (λ _:ι, a) = lift.{u v} (mk ι) * lift.{v u} a :=
+begin
+  apply quotient.induction_on a,
+  intro α,
+  simp only [cardinal.mk_def, cardinal.sum_mk, cardinal.lift_id],
+  convert mk_prod using 1,
+  exact quotient.sound ⟨equiv.sigma_equiv_prod ι α⟩,
+end
+
 /-- `ω` is the smallest infinite cardinal, also known as ℵ₀. -/
 def omega : cardinal.{u} := lift (mk ℕ)
 


### PR DESCRIPTION
Added a lemma stating that every finite dimensional vectorspace over K is isomorphic to K^n.
Some lemmas needed to be generalized in terms of universe levels to achieve that.

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
