### PR TITLE
feat(tactic/rcases): add obtain tactic

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -97,6 +97,21 @@ two subgoals, one with variables `a d e` and the other with `b c d e`.
 result. Like `rcases?`, `rintro? : n` allows for modifying the
 depth of splitting; the default is 5.
 
+### obtain
+
+The `obtain` tactic is a combination of `have` and `rcases`.
+```
+obtain ⟨patt⟩ : type,
+{ ... }
+```
+is equivalent to
+```
+have h : type,
+{ ... },
+rcases h with ⟨patt⟩
+```
+
+
 ### simpa
 
 This is a "finishing" tactic modification of `simp`. It has two forms.

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -100,16 +100,18 @@ depth of splitting; the default is 5.
 ### obtain
 
 The `obtain` tactic is a combination of `have` and `rcases`.
-```
+```lean
 obtain ⟨patt⟩ : type,
 { ... }
 ```
 is equivalent to
-```
+```lean
 have h : type,
 { ... },
 rcases h with ⟨patt⟩
 ```
+
+ The syntax `obtain ⟨patt⟩ : type := proof` is also supported.
 
 
 ### simpa

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -626,6 +626,7 @@ do l ← local_context,
    r ← successes (l.reverse.map (λ h, cases h >> skip)),
    when (r.empty) failed
 
+/-- given a proof `pr : t`, adds `h : t` to the current context, where the name `h` is fresh.  -/
 meta def note_anon (e : expr) : tactic expr :=
 do n ← get_unused_name "lh",
    note n none e

--- a/src/tactic/rcases.lean
+++ b/src/tactic/rcases.lean
@@ -447,8 +447,7 @@ is equivalent to
  { ... },
  rcases h with ⟨patt⟩`.
 -/
-meta def obtain (p : interactive.parse obtain_parse)
-   : tactic unit :=
+meta def obtain (p : interactive.parse obtain_parse) : tactic unit :=
 do nm ← mk_fresh_name,
    e ← to_expr p.2 >>= assert nm,
    (g :: gs) ← get_goals,

--- a/test/rcases.lean
+++ b/test/rcases.lean
@@ -84,3 +84,10 @@ begin
   guard_hyp h := true,
   trivial
 end
+
+example : true :=
+begin
+  obtain h | ⟨⟨⟩⟩ : true ∨ false := or.inl trivial,
+  guard_hyp h := true,
+  trivial
+end

--- a/test/rcases.lean
+++ b/test/rcases.lean
@@ -59,3 +59,28 @@ begin
   rcases s with _ | ⟨⟨⟩⟩,
   { guard_hyp s := α, trivial }
 end
+
+example : true :=
+begin
+  obtain ⟨n, h, f⟩ : ∃ n : ℕ, n = n ∧ true,
+  { existsi 0, simp },
+  guard_hyp n := ℕ,
+  guard_hyp h := n = n,
+  guard_hyp f := true,
+  trivial
+end
+
+example : true :=
+begin
+  obtain : ∃ n : ℕ, n = n ∧ true,
+  { existsi 0, simp },
+  trivial
+end
+
+example : true :=
+begin
+  obtain h | ⟨⟨⟩⟩ : true ∨ false,
+  { left, trivial },
+  guard_hyp h := true,
+  trivial
+end


### PR DESCRIPTION
This was requested by @PatrickMassot . It's a small combination of `rcases` and `have`.

Users should be careful, because this style can encourage redundancy: I think it can be ugly to do trivial boxing and unboxing as in
```lean
obtain ⟨x, h⟩ : ∃ n : ℕ, n = n,
{ existsi 2, refl }
```

But I'm assured by Patrick and others that there are plenty of cases where this will be useful and not redundant.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
