### PR TITLE
doc(*): new documentation requirements

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,7 @@ TO CONTRIBUTORS:
 Make sure you have:
 
   * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
+  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
   * [ ] for tactics:
      * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
      * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)

--- a/docs/contribute/code-review.md
+++ b/docs/contribute/code-review.md
@@ -4,8 +4,8 @@ Copy-paste into a comment when reviewing a pull request:
 Check:
 
  * [ ] coding style
+ * [ ] documentation: see [the documentation requirements](doc.md)
  * [ ] for tactics:
-     * [ ] documentation
      * [ ] tests
      * [ ] efficiency (make sure at least it's not outrageously inefficient)
   * [ ] it fits the overall mathlib design

--- a/docs/contribute/doc.md
+++ b/docs/contribute/doc.md
@@ -21,7 +21,8 @@ The other sections, with second level headers are (in this order):
 * *Main definitions* (optional, can be covered in the summary)
 * *Main statements* (optional, can be covered in the summary)
 * *Notations* (omitted only if no notation is introduced in this file)
-* *Implementation notes* (description of important design decisions or interface features)
+* *Implementation notes* (description of important design decisions or interface features,
+  including use of type classes and `simp` canonical form for new definitions)
 * *References* (references to textbooks or papers, or Wikipedia pages)
 * *Tags* (a list of keywords that could be useful when doing text search in mathlib to find where
   something is covered)

--- a/docs/contribute/doc.md
+++ b/docs/contribute/doc.md
@@ -1,0 +1,55 @@
+# Documentation style
+
+We are in the process of implementing new documentation requirements for mathlib. All future pull requests must meet the following standards.
+
+## Header comment
+
+Explain the header fields here.
+
+Replace the example below with a better one?
+
+```
+/-
+Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Y. Lewis
+
+# p-adic norm
+
+This file defines the p-adic valuation and the p-adic norm on ℚ.
+
+The p-adic valuation on ℚ is the difference of the multiplicities of `p` in the numerator and
+denominator of `q`. This function obeys the standard properties of a valuation, with the appropriate
+assumptions on p.
+
+The valuation induces a norm on ℚ. This norm is a nonarchimedean absolute value.
+It takes values in {0} ∪ {1/p^k | k ∈ ℤ}.
+
+## Notations
+
+This file uses the local notation `/.` for `rat.mk`.
+
+## Implementation notes
+
+Much, but not all, of this file assumes that `p` is prime. This assumption is inferred automatically
+by taking (prime p) as a type class argument.
+
+## References
+
+Tags: p-adic, p adic, padic, norm, valuation
+
+-/
+```
+
+## Docstrings
+
+Every definition and major theorem is required to have a doc string.
+
+Explain more here.
+
+## Examples
+
+The following files are maintained as examples of good documentation style:
+
+* where?
+* where?

--- a/docs/contribute/doc.md
+++ b/docs/contribute/doc.md
@@ -1,12 +1,28 @@
 # Documentation style
 
-We are in the process of implementing new documentation requirements for mathlib. All future pull requests must meet the following standards.
+We are in the process of implementing new documentation requirements for mathlib. All future pull
+requests must meet the following standards.
 
 ## Header comment
 
-Explain the header fields here.
+Each mathlib file should start with a header comment with copyright information (see example below)
+followed by general documentation written using Markdown. Headers use atx-style headers (with hash
+signs, no underlying dash).
 
-Replace the example below with a better one?
+The mandatory title of the file is a first level header. It is followed by a summary of the content
+of the file.
+
+The other sections, with second level headers are (in this order):
+* *Main definitions* (optional, can be covered in the summary)
+* *Main statements* (optional, can be covered in the summary)
+* *Notations* (ommited only if no notation is introduced in this file)
+* *Implementation notes*
+* *References* (references to textbooks or papers, or Wikipedia pages)
+
+After references, we write "Tags:" followed by a list of keywords that could be useful when
+doing text search in mathlib to find where something is covered.
+
+The following code block is an example of a file header.
 
 ```
 /-
@@ -36,20 +52,59 @@ by taking (prime p) as a type class argument.
 
 ## References
 
-Tags: p-adic, p adic, padic, norm, valuation
+* F. Q. Gouêva, *p-adic numbers*
+* https://en.wikipedia.org/wiki/P-adic_number
 
+Tags: p-adic, p adic, padic, norm, valuation
 -/
 ```
 
 ## Docstrings
 
-Every definition and major theorem is required to have a doc string.
+Every definition and major theorem is required to have a doc string. Those are introduced
+using `/--` and closed by `-/` above the definition. They can contain some markdown, e.g. backticks
+quotes. They should convey the mathematical meaning of the definition. It is allowed to lie slightly
+about the actual implementation. The following is a docstring example:
 
-Explain more here.
+```lean
+/--
+If `q ≠ 0`, the p-adic norm of a rational `q` is `p ^ (-(padic_val_rat p q))`.
+If `q = 0`, the p-adic norm of `q` is 0.
+-/
+def padic_norm (p : ℕ) (q : ℚ) : ℚ :=
+if q = 0 then 0 else (p : ℚ) ^ (-(padic_val_rat p q))
+```
+
+An example that is slightly lying but still describes the mathematical content would be:
+
+```lean
+/--
+For `p ≠ 1`, the p-adic valuation of an integer `z ≠ 0` is the largest natural number `n` such that
+p^n divides z.
+`padic_val_rat` defines the valuation of a rational `q` to be the valuation of `q.num` minus the
+valuation of `q.denom`.
+If `q = 0` or `p = 1`, then `padic_val_rat p q` defaults to 0.
+-/
+def padic_val_rat (p : ℕ) (q : ℚ) : ℤ :=
+if h : q ≠ 0 ∧ p ≠ 1
+then (multiplicity (p : ℤ) q.num).get
+    (multiplicity.finite_int_iff.2 ⟨h.2, rat.num_ne_zero_of_ne_zero h.1⟩) -
+  (multiplicity (p : ℤ) q.denom).get
+    (multiplicity.finite_int_iff.2 ⟨h.2, by exact_mod_cast rat.denom_ne_zero _⟩)
+else 0
+```
+
+## Theories documentation
+
+In addition to documentation living in Lean file, we have tactic documentation in
+[docs/tactics](../tactics.md), and theory documentation in [docs/theories](../theories) where we
+give overviews spanning several Lean files, and more mathematical explanations in cases where
+formalization requires slightly exotic points of view, see for instance the
+[topology documentation](../theories/topological_spaces.md).
 
 ## Examples
 
 The following files are maintained as examples of good documentation style:
 
-* where?
-* where?
+* [data/padics/padic_norm](../../src/data/padics/padic_norm.lean)
+* [topology/basic](../../src/topology/basic.lean)

--- a/docs/contribute/doc.md
+++ b/docs/contribute/doc.md
@@ -16,7 +16,7 @@ The other sections, with second level headers are (in this order):
 * *Main definitions* (optional, can be covered in the summary)
 * *Main statements* (optional, can be covered in the summary)
 * *Notations* (ommited only if no notation is introduced in this file)
-* *Implementation notes*
+* *Implementation notes* (description of important design decisions or interface features)
 * *References* (references to textbooks or papers, or Wikipedia pages)
 
 After references, we write "Tags:" followed by a list of keywords that could be useful when
@@ -61,9 +61,12 @@ Tags: p-adic, p adic, padic, norm, valuation
 
 ## Docstrings
 
-Every definition and major theorem is required to have a doc string. Those are introduced
-using `/--` and closed by `-/` above the definition. They can contain some markdown, e.g. backticks
-quotes. They should convey the mathematical meaning of the definition. It is allowed to lie slightly
+Every definition and major theorem is required to have a doc string.
+(Doc strings on lemmas are also encouraged, particularly if the lemma has any mathematical content
+or might be useful in another file.)
+These are introduced using `/--` and closed by `-/` above the definition.
+They can contain some markdown, e.g. backtick quotes.
+They should convey the mathematical meaning of the definition. It is allowed to lie slightly
 about the actual implementation. The following is a docstring example:
 
 ```lean
@@ -93,6 +96,9 @@ then (multiplicity (p : ℤ) q.num).get
     (multiplicity.finite_int_iff.2 ⟨h.2, by exact_mod_cast rat.denom_ne_zero _⟩)
 else 0
 ```
+
+The `#doc_blame` command can be run at the bottom of a file to list all definitions that do not have
+doc strings. (It does not list theorems.)
 
 ## Theories documentation
 

--- a/docs/contribute/doc.md
+++ b/docs/contribute/doc.md
@@ -5,9 +5,14 @@ requests must meet the following standards.
 
 ## Header comment
 
-Each mathlib file should start with a header comment with copyright information (see example below)
-followed by general documentation written using Markdown. Headers use atx-style headers (with hash
-signs, no underlying dash).
+Each mathlib file should start with:
+* a header comment with copyright information;
+* the list of imports;
+* a module docstring containing general documentation, written using Markdown.
+
+(See the example below.)
+
+Headers use atx-style headers (with hash signs, no underlying dash).
 
 The mandatory title of the file is a first level header. It is followed by a summary of the content
 of the file.
@@ -15,12 +20,13 @@ of the file.
 The other sections, with second level headers are (in this order):
 * *Main definitions* (optional, can be covered in the summary)
 * *Main statements* (optional, can be covered in the summary)
-* *Notations* (ommited only if no notation is introduced in this file)
+* *Notations* (omitted only if no notation is introduced in this file)
 * *Implementation notes* (description of important design decisions or interface features)
 * *References* (references to textbooks or papers, or Wikipedia pages)
+* *Tags* (a list of keywords that could be useful when doing text search in mathlib to find where
+  something is covered)
 
-After references, we write "Tags:" followed by a list of keywords that could be useful when
-doing text search in mathlib to find where something is covered.
+References should refer to bibtex entries in [the mathlib citations file](../references.bib).
 
 The following code block is an example of a file header.
 
@@ -29,7 +35,14 @@ The following code block is an example of a file header.
 Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
+-/
 
+import data.rat.basic algebra.gcd_domain algebra.field_power
+import ring_theory.multiplicity tactic.ring
+import data.real.cau_seq
+import tactic.norm_cast
+
+/-!
 # p-adic norm
 
 This file defines the p-adic valuation and the p-adic norm on ℚ.
@@ -52,10 +65,12 @@ by taking (prime p) as a type class argument.
 
 ## References
 
-* F. Q. Gouêva, *p-adic numbers*
+* [F. Q. Gouêva, *p-adic numbers*][gouvea1997]
 * https://en.wikipedia.org/wiki/P-adic_number
 
-Tags: p-adic, p adic, padic, norm, valuation
+## Tags
+
+p-adic, p adic, padic, norm, valuation
 -/
 ```
 

--- a/docs/contribute/doc.md
+++ b/docs/contribute/doc.md
@@ -129,3 +129,4 @@ The following files are maintained as examples of good documentation style:
 
 * [data/padics/padic_norm](../../src/data/padics/padic_norm.lean)
 * [topology/basic](../../src/topology/basic.lean)
+* [analysis/calculus/times_cont_diff](../../src/analysis/calculus/times_cont_diff.lean)

--- a/docs/contribute/doc.md
+++ b/docs/contribute/doc.md
@@ -98,7 +98,7 @@ else 0
 ```
 
 The `#doc_blame` command can be run at the bottom of a file to list all definitions that do not have
-doc strings. (It does not list theorems.)
+doc strings. `#doc_blame!` will also list theorems and lemmas.
 
 ## Theories documentation
 

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,0 +1,49 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                     %
+% This is a database of documents referenced in mathlib file headers. %
+%                                                                     %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+@book {bourbaki1966,
+    AUTHOR = {Bourbaki, Nicolas},
+     TITLE = {Elements of mathematics. {G}eneral topology. {P}art 1},
+ PUBLISHER = {Hermann, Paris; Addison-Wesley Publishing Co., Reading,
+              Mass.-London-Don Mills, Ont.},
+      YEAR = {1966},
+     PAGES = {vii+437},
+   MRCLASS = {54.00 (00.00)},
+  MRNUMBER = {0205210},
+}
+
+@book {gouvea1997,
+    AUTHOR = {Gouv\^{e}a, Fernando Q.},
+     TITLE = {{$p$}-adic numbers},
+    SERIES = {Universitext},
+   EDITION = {Second},
+      NOTE = {An introduction},
+ PUBLISHER = {Springer-Verlag, Berlin},
+      YEAR = {1997},
+     PAGES = {vi+298},
+      ISBN = {3-540-62911-4},
+   MRCLASS = {11S80 (11-01 12J25)},
+  MRNUMBER = {1488696},
+       DOI = {10.1007/978-3-642-59058-0},
+       URL = {https://doi.org/10.1007/978-3-642-59058-0},
+}
+
+@book {james1999,
+    AUTHOR = {James, Ioan},
+     TITLE = {Topologies and uniformities},
+    SERIES = {Springer Undergraduate Mathematics Series},
+      NOTE = {Revised version of {{\i}t Topological and uniform spaces}
+              [Springer, New York, 1987;  MR0884154 (89b:54001)]},
+ PUBLISHER = {Springer-Verlag London, Ltd., London},
+      YEAR = {1999},
+     PAGES = {xvi+230},
+      ISBN = {1-85233-061-9},
+   MRCLASS = {54-01 (54A05 54E15)},
+  MRNUMBER = {1687407},
+MRREVIEWER = {Hans-Peter A. K\"{u}nzi},
+       DOI = {10.1007/978-1-4471-3994-2},
+       URL = {https://doi.org/10.1007/978-1-4471-3994-2},
+}

--- a/docs/theories/topological_spaces.md
+++ b/docs/theories/topological_spaces.md
@@ -1,8 +1,8 @@
 # Maths in lean : Topological Spaces.
 
 The `topological_space` typeclass is defined in mathlib,
-in `analysis/topology/topological_space.lean`. There are over 4500
-lines of code in `analysis/topology` at the time of writing,
+in `topology/basic.lean`. There are over 4500
+lines of code in `topology` at the time of writing,
 covering the basics of topological spaces, continuous functions,
 topological groups and rings, and infinite sums. These docs
 are just concerned with the contents of the `topological_space.lean`
@@ -56,7 +56,7 @@ variables {X : Type} [topological_space X] {U V C D Y Z : set X}
 
 example : is_closed C → is_closed D → is_closed (C ∪ D) := is_closed_union
 
-example : is_open ( -C) ↔ is_closed C := is_open_compl_iff 
+example : is_open ( -C) ↔ is_closed C := is_open_compl_iff
 
 example : is_open U → is_closed C → is_open (U - C) := is_open_diff
 
@@ -86,9 +86,9 @@ Informally, one can think of `F` as the set of "big" subsets of `X`. For example
 
 Note that if `F` is a filter that contains the empty set, then it contains all subsets of `X` by the first axiom. This filter is sometimes called "bottom" (we will see why a little later on). Some references demand that the empty set is not allowed to be in a filter -- Lean does not have this restriction. A filter not containing the empty set is sometimes called a "proper filter".
 
-If `X` is a topological space, and `x ∈ X`, then the _neighbourhood filter_ `nhds x` of `x` is the set of subsets `Y` of `X` such that `x` is in the interior of `Y`. One checks easily that this is a filter (technical point: to see that this is actually the definition of `nhds x` in mathlib, it helps to know that the set of all filters on a type is a complete lattice, partially ordered using `F ≤ G` iff `G ⊆ F`, so the definition, which involves an inf, is actually a union; also, the definition I give is not literally the definition in mathlib, but `lemma nhds_sets` says that their definition is the one here. Note also that this is why the filter with the most sets is called bottom!). 
+If `X` is a topological space, and `x ∈ X`, then the _neighbourhood filter_ `nhds x` of `x` is the set of subsets `Y` of `X` such that `x` is in the interior of `Y`. One checks easily that this is a filter (technical point: to see that this is actually the definition of `nhds x` in mathlib, it helps to know that the set of all filters on a type is a complete lattice, partially ordered using `F ≤ G` iff `G ⊆ F`, so the definition, which involves an inf, is actually a union; also, the definition I give is not literally the definition in mathlib, but `lemma nhds_sets` says that their definition is the one here. Note also that this is why the filter with the most sets is called bottom!).
 
-Why are we interested in these filters? Well, given a map `f` from `ℕ` to a topological space `X`, one can check that the resulting sequence `f 0`, `f 1`, `f 2`... tends to `x ∈ F` if and only if the pre-image of any element in the filter `nhds x` is in the cofinite filter on `ℕ` -- this is just another way of saying that given any open set `U` containing `x`, there exists `N` such that for all `n ≥ N`, `f n ∈ U`. So filters provide a way of thinking about limits. 
+Why are we interested in these filters? Well, given a map `f` from `ℕ` to a topological space `X`, one can check that the resulting sequence `f 0`, `f 1`, `f 2`... tends to `x ∈ F` if and only if the pre-image of any element in the filter `nhds x` is in the cofinite filter on `ℕ` -- this is just another way of saying that given any open set `U` containing `x`, there exists `N` such that for all `n ≥ N`, `f n ∈ U`. So filters provide a way of thinking about limits.
 
 The _principal filter_ `principal Y` attached to a subset `Y` of a set `X` is the collection of all subsets of `X` that contain `Y`. So it's not difficult to convince yourself that the following results should be true:
 
@@ -117,8 +117,8 @@ Translated, this says that a subset `Y` of a topological space `X` is compact if
 One might ask why this definition of compactness has been chosen, rather than the standard one about open covers having finite subcovers. The reasons for this are in some sense computer-scientific rather than mathematical -- the issue should not be what definition is ultimately chosen (indeed the developers should feel free to choose whatever definition they like as long as it is logically equivalent to the usual one, and they might have reasons related to non-mathematical points such as running times), the issue should be how to prove that the inbuilt definition is equivalent to the one you want to use in practice. And fortunately, we have
 
 ```lean
-example : compact Y ↔ 
-  (∀ cov : set (set X), (∀ U ∈ cov, is_open U) → Y ⊆ ⋃₀ cov → 
+example : compact Y ↔
+  (∀ cov : set (set X), (∀ U ∈ cov, is_open U) → Y ⊆ ⋃₀ cov →
     ∃ fincov ⊆ cov, set.finite fincov ∧ Y ⊆ ⋃₀ fincov) := compact_iff_finite_subcover
 ```
 
@@ -152,7 +152,7 @@ a topology with the underlying collection of open sets), or more constructively
 as the sets "generated by" `S` using the axioms of a topological space.
 Unsurprisingly, it is this latter definition which is used in Lean, as the
 open sets are naturally an inductive type; the open sets are called
-`generate_open S` and the topology is `generate_from S`. 
+`generate_open S` and the topology is `generate_from S`.
 
 The definition of a basis for a topology in mathlib includes an axiom
 that the topology is generated from the basis in the sense above, which may make
@@ -161,7 +161,7 @@ directly. However again we have a theorem which reduces us to checking
 the two usual axioms for a basis:
 
 ```lean
-example (B : set (set X)) (h_open : ∀ V ∈ B, is_open V) 
+example (B : set (set X)) (h_open : ∀ V ∈ B, is_open V)
   (h_nhds : ∀ (x : X) (U : set X), x ∈ U → is_open U → ∃ V ∈ B, x ∈ V ∧ V ⊆ U) :
 is_topological_basis B :=
 is_topological_basis_of_open_of_nhds h_open h_nhds

--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -2,7 +2,11 @@
 Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
+-/
 
+import analysis.calculus.deriv
+
+/-!
 # Higher differentiabiliity
 
 A function is `C^1` on a domain if it is differentiable there, and its derivative is continuous.
@@ -54,9 +58,12 @@ Therefore, we give (and use) both definitions, named respectively `times_cont_di
 `times_cont_diff` (as well as relativized versions on a set). We show that they are equivalent.
 The first one is mainly auxiliary: in applications, one should always use `times_cont_diff`
 (but the proofs below use heavily the equivalence to show that `times_cont_diff` is well behaved).
--/
 
-import analysis.calculus.deriv
+## Tags
+
+derivative, differentiability, higher derivative, C^n
+
+-/
 
 noncomputable theory
 local attribute [instance, priority 0] classical.decidable_inhabited classical.prop_decidable

--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -1,3 +1,4 @@
+#exit
 /-
 Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
@@ -199,7 +200,10 @@ have hf2 : finite (p : ℤ) (n₂ * d₁),
       enat.get_le_get, multiplicity_le_multiplicity_iff]
   }
 
-
+/--
+Gives sufficient conditions to show that the p-adic valuation of `q` is less than or equal to the
+p-adic vlauation of `q + r`.
+-/
 theorem le_padic_val_rat_add_of_le {q r : ℚ}
   (hq : q ≠ 0) (hr : r ≠ 0) (hqr : q + r ≠ 0)
   (h : padic_val_rat p q ≤ padic_val_rat p r) :
@@ -230,6 +234,9 @@ begin
     ... ≤ _ : min_le_multiplicity_add
 end
 
+/--
+The minimum of the valuations of `q` and `r` is less than or equal to the valuation of `q + r`.
+-/
 theorem min_le_padic_val_rat_add {q r : ℚ}
   (hq : q ≠ 0) (hr : r ≠ 0) (hqr : q + r ≠ 0) :
   min (padic_val_rat p q) (padic_val_rat p r) ≤ padic_val_rat p (q + r) :=
@@ -255,14 +262,26 @@ open padic_val_rat
 variables (p : ℕ) [hp : p.prime]
 include hp
 
+/--
+The p-adic norm of 0 is 0.
+-/
 @[simp] protected lemma zero : padic_norm p 0 = 0 := by simp [padic_norm]
 
+/--
+The p-adic norm of 1 is 1.
+-/
 @[simp] protected lemma one : padic_norm p 1 = 1 := by simp [padic_norm]
 
+/--
+Unfolds the definition of the p-adic norm of `q` when `q ≠ 0`.
+-/
 @[simp] protected lemma eq_fpow_of_nonzero {q : ℚ} (hq : q ≠ 0) :
   padic_norm p q = p ^ (-(padic_val_rat p q)) :=
 by simp [hq, padic_norm]
 
+/--
+If `q ≠ 0`, then `padic_norm p q ≠ 0`.
+-/
 protected lemma nonzero {q : ℚ} (hq : q ≠ 0) : padic_norm p q ≠ 0 :=
 begin
   rw padic_norm.eq_fpow_of_nonzero p hq,
@@ -270,10 +289,16 @@ begin
   exact_mod_cast ne_of_gt hp.pos
 end
 
+/--
+`padic_norm p` is symmetric.
+-/
 @[simp] protected lemma neg (q : ℚ) : padic_norm p (-q) = padic_norm p q :=
 if hq : q = 0 then by simp [hq]
 else by simp [padic_norm, hq, hp.gt_one]
 
+/--
+If the p-adic norm of `q` is 0, then `q` is 0.
+-/
 lemma zero_of_padic_norm_eq_zero {q : ℚ} (h : padic_norm p q = 0) : q = 0 :=
 begin
   apply by_contradiction, intro hq,
@@ -283,6 +308,9 @@ begin
   exact_mod_cast hp.ne_zero
 end
 
+/--
+The p-adic norm is nonnegative.
+-/
 protected lemma nonneg (q : ℚ) : padic_norm p q ≥ 0 :=
 if hq : q = 0 then by simp [hq]
 else
@@ -292,6 +320,9 @@ else
     exact_mod_cast nat.zero_le _
   end
 
+/--
+The p-adic norm is multiplicative.
+-/
 @[simp] protected theorem mul (q r : ℚ) : padic_norm p (q*r) = padic_norm p q * padic_norm p r :=
 if hq : q = 0 then
   by simp [hq]
@@ -302,10 +333,16 @@ else
   have (↑p : ℚ) ≠ 0, by simp [prime.ne_zero hp],
   by simp [padic_norm, *, padic_val_rat.mul, fpow_add this]
 
+/--
+The p-adic norm respects division.
+-/
 @[simp] protected theorem div (q r : ℚ) : padic_norm p (q / r) = padic_norm p q / padic_norm p r :=
 if hr : r = 0 then by simp [hr] else
 eq_div_of_mul_eq _ _ (padic_norm.nonzero _ hr) (by rw [←padic_norm.mul, div_mul_cancel _ hr])
 
+/--
+The p-adic norm of an integer is at most 1.
+-/
 protected theorem of_int (z : ℤ) : padic_norm p ↑z ≤ 1 :=
 if hz : z = 0 then by simp [hz] else
 begin
@@ -318,7 +355,6 @@ begin
   exact_mod_cast hz
 end
 
---TODO: p implicit
 private lemma nonarchimedean_aux {q r : ℚ} (h : padic_val_rat p q ≤ padic_val_rat p r) :
   padic_norm p (q + r) ≤ max (padic_norm p q) (padic_norm p r) :=
 have hnqp : padic_norm p q ≥ 0, from padic_norm.nonneg _ _,
@@ -344,6 +380,10 @@ else
       apply min_le_padic_val_rat_add; assumption }
   end
 
+/--
+The p-adic norm is nonarchimedean: the norm of `p + q` is at most the max of the norm of `p` and
+the norm of `q`.
+-/
 protected theorem nonarchimedean {q r : ℚ} :
   padic_norm p (q + r) ≤ max (padic_norm p q) (padic_norm p r) :=
 begin
@@ -351,14 +391,26 @@ begin
     exact nonarchimedean_aux p hle
 end
 
+/--
+The p-adic norm respects the triangle inequality: the norm of `p + q` is at most the norm of `p`
+plus the norm of `q`.
+-/
 theorem triangle_ineq (q r : ℚ) : padic_norm p (q + r) ≤ padic_norm p q + padic_norm p r :=
 calc padic_norm p (q + r) ≤ max (padic_norm p q) (padic_norm p r) : padic_norm.nonarchimedean p
                        ... ≤ padic_norm p q + padic_norm p r :
                          max_le_add_of_nonneg (padic_norm.nonneg p _) (padic_norm.nonneg p _)
 
+/--
+The p-adic norm of a difference is at most the max of each component. Restates the archimedean
+property of the p-adic norm.
+-/
 protected theorem sub {q r : ℚ} : padic_norm p (q - r) ≤ max (padic_norm p q) (padic_norm p r) :=
 by rw [sub_eq_add_neg, ←padic_norm.neg p r]; apply padic_norm.nonarchimedean
 
+/--
+If the p-adic norms of `q` and `r` are different, then the norm of `q + r` is equal to the max of
+the norms of `q` and `r`.
+-/
 lemma add_eq_max_of_ne {q r : ℚ} (hne : padic_norm p q ≠ padic_norm p r) :
   padic_norm p (q + r) = max (padic_norm p q) (padic_norm p r) :=
 begin
@@ -381,9 +433,16 @@ begin
     assumption }
 end
 
+/--
+The image of `padic_norm p` is {0} ∪ {p^(-n) | n ∈ ℤ}.
+-/
 protected theorem image {q : ℚ} (hq : q ≠ 0) : ∃ n : ℤ, padic_norm p q = p ^ (-n) :=
 ⟨ (padic_val_rat p q), by simp [padic_norm, hq] ⟩
 
+/--
+The p-adic norm is an absolute value: positive-definite and multiplicative, satisfying the triangle
+inequality.
+-/
 instance : is_absolute_value (padic_norm p) :=
 { abv_nonneg := padic_norm.nonneg p,
   abv_eq_zero :=
@@ -396,6 +455,9 @@ instance : is_absolute_value (padic_norm p) :=
   abv_add := padic_norm.triangle_ineq p,
   abv_mul := padic_norm.mul p }
 
+/--
+If `p^n` divides an integer `z`, then the p-adic norm of `z` is at most `p^(-n)`.
+-/
 lemma le_of_dvd {n : ℕ} {z : ℤ} (hd : ↑(p^n) ∣ z) : padic_norm p z ≤ ↑p ^ (-n : ℤ) :=
 begin
   unfold padic_norm, split_ifs with hz hz,

--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -1,4 +1,3 @@
-#exit
 /-
 Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.

--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -2,7 +2,14 @@
 Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
+-/
 
+import data.rat.basic algebra.gcd_domain algebra.field_power
+import ring_theory.multiplicity tactic.ring
+import data.real.cau_seq
+import tactic.norm_cast
+
+/-!
 # p-adic norm
 
 This file defines the p-adic valuation and the p-adic norm on ℚ.
@@ -25,14 +32,13 @@ by taking (prime p) as a type class argument.
 
 ## References
 
-Tags: p-adic, p adic, padic, norm, valuation
+* [F. Q. Gouêva, *p-adic numbers*][gouvea1997]
+* https://en.wikipedia.org/wiki/P-adic_number
 
+## Tags
+
+p-adic, p adic, padic, norm, valuation
 -/
-
-import data.rat.basic algebra.gcd_domain algebra.field_power
-import ring_theory.multiplicity tactic.ring
-import data.real.cau_seq
-import tactic.norm_cast
 
 universe u
 
@@ -61,7 +67,7 @@ then (multiplicity (p : ℤ) q.num).get
 else 0
 
 /--
-Rewrites the definition of `padic_val_rat p q` when `q ≠ 0` and `p` is prime.
+A simplification of the definition of `padic_val_rat p q` when `q ≠ 0` and `p` is prime.
 -/
 lemma padic_val_rat_def (p : ℕ) [hp : p.prime] {q : ℚ} (hq : q ≠ 0) : padic_val_rat p q =
   (multiplicity (p : ℤ) q.num).get (finite_int_iff.2 ⟨hp.ne_one, rat.num_ne_zero_of_ne_zero hq⟩) -
@@ -175,7 +181,7 @@ by rw [div_eq_mul_inv, padic_val_rat.mul p hq (inv_ne_zero hr),
     padic_val_rat.inv p hr, sub_eq_add_neg]
 
 /--
-Gives a condition for `padic_val_rat p (n₁ / d₁) ≤ padic_val_rat p (n₂ / d₂),
+A condition for `padic_val_rat p (n₁ / d₁) ≤ padic_val_rat p (n₂ / d₂),
 in terms of divisibility by `p^n`.
 -/
 lemma padic_val_rat_le_padic_val_rat_iff {n₁ n₂ d₁ d₂ : ℤ}
@@ -200,7 +206,7 @@ have hf2 : finite (p : ℤ) (n₂ * d₁),
   }
 
 /--
-Gives sufficient conditions to show that the p-adic valuation of `q` is less than or equal to the
+Sufficient conditions to show that the p-adic valuation of `q` is less than or equal to the
 p-adic vlauation of `q + r`.
 -/
 theorem le_padic_val_rat_add_of_le {q r : ℚ}

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -3,9 +3,26 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Johannes Hölzl, Mario Carneiro
 
-Cardinal arithmetic.
+# Cardinal Numbers
 
-Cardinals are represented as quotient over equinumerous types.
+We define cardinal numbers as a quotient of types under the equivalence relation of equinumerity.
+We define the order on cardinal numbers, define omega, and do basic cardinal arithmetic:
+  addition, multiplication, power, cardinal successor, minimum, supremum,
+    infinitary sums and products
+
+## Implementation notes
+
+* There is a type of cardinal numbers in every universe level: `cardinal.{u} : Type (u + 1)`
+  is the quotient of types in `Type u`.
+  There is a lift operation lifting cardinal numbers to a higher level.
+* Cardinal arithmetic specifically for infinite cardinals (like `κ * κ = κ`) is in the file
+  `set_theory/ordinal.lean`, because concepts from that file are used in the proof.
+
+## References
+
+* https://en.wikipedia.org/wiki/Cardinal_number
+
+Tags: cardinal number, cardinal arithmetic, cardinal exponentiation, omega
 -/
 
 import data.set.countable data.quot logic.function set_theory.schroeder_bernstein
@@ -16,6 +33,9 @@ local attribute [instance] classical.prop_decidable
 universes u v w x
 variables {α β : Type u}
 
+/-- The equivalence relation on types given by equivalence (bijective correspondence) of types.
+  Quotienting by this equivalence relation gives the cardinal numbers.
+-/
 instance cardinal.is_equivalent : setoid (Type u) :=
 { r := λα β, nonempty (α ≃ β),
   iseqv := ⟨λα,
@@ -30,13 +50,15 @@ def cardinal : Type (u + 1) := quotient cardinal.is_equivalent
 
 namespace cardinal
 
-/-- The cardinal of a type -/
+/-- The cardinal number of a type -/
 def mk : Type u → cardinal := quotient.mk
 
 @[simp] theorem mk_def (α : Type u) : @eq cardinal ⟦α⟧ (mk α) := rfl
 
 @[simp] theorem mk_out (c : cardinal) : mk (c.out) = c := quotient.out_eq _
 
+/-- We define the order on cardinal numbers by `mk α ≤ mk β` if and only if
+  there exists an embedding (injective function) from α to β. -/
 instance : has_le cardinal.{u} :=
 ⟨λq₁ q₂, quotient.lift_on₂ q₁ q₂ (λα β, nonempty $ α ↪ β) $
   assume α β γ δ ⟨e₁⟩ ⟨e₂⟩,
@@ -401,7 +423,8 @@ end
 theorem prod_eq_zero {ι} (f : ι → cardinal) : prod f = 0 ↔ ∃ i, f i = 0 :=
 not_iff_not.1 $ by simpa using prod_ne_zero f
 
-/-- The universe lift operation on cardinals -/
+/-- The universe lift operation on cardinals. You can specify the universes explicitly with
+  `lift.{u v} : cardinal.{u} → cardinal.{max u v}` -/
 def lift (c : cardinal.{u}) : cardinal.{max u v} :=
 quotient.lift_on c (λ α, ⟦ulift α⟧) $ λ α β ⟨e⟩,
 quotient.sound ⟨equiv.ulift.trans $ e.trans equiv.ulift.symm⟩

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -2,7 +2,11 @@
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Johannes Hölzl, Mario Carneiro
+-/
 
+import data.set.countable data.quot logic.function set_theory.schroeder_bernstein
+
+/-!
 # Cardinal Numbers
 
 We define cardinal numbers as a quotient of types under the equivalence relation of equinumerity.
@@ -22,10 +26,10 @@ We define the order on cardinal numbers, define omega, and do basic cardinal ari
 
 * https://en.wikipedia.org/wiki/Cardinal_number
 
-Tags: cardinal number, cardinal arithmetic, cardinal exponentiation, omega
--/
+## Tags
 
-import data.set.countable data.quot logic.function set_theory.schroeder_bernstein
+cardinal number, cardinal arithmetic, cardinal exponentiation, omega
+-/
 
 open function lattice set
 local attribute [instance] classical.prop_decidable

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -17,6 +17,7 @@ universes u v w
 variables {α : Type*} {β : Type*} {γ : Type*}
   {r : α → α → Prop} {s : β → β → Prop} {t : γ → γ → Prop}
 
+/-- If `r` is a relation on `α` and `s` in a relation on `β`, then `f : r ≼i s` is an order embedding whose range is an initial segment. That is, whenever `b < f a` in `β` then `b` is in the range of `f`. -/
 structure initial_seg {α β : Type*} (r : α → α → Prop) (s : β → β → Prop) extends r ≼o s :=
 (init : ∀ a b, s b (to_order_embedding a) → ∃ a', to_order_embedding a' = b)
 
@@ -44,9 +45,11 @@ theorem init_iff (f : r ≼i s) {a : α} {b : β} : s b (f a) ↔ ∃ a', f a' =
 def of_iso (f : r ≃o s) : r ≼i s :=
 ⟨f, λ a b h, ⟨f.symm b, order_iso.apply_symm_apply f _⟩⟩
 
+/-- The identity function shows that `≼i` is reflexive -/
 @[refl] protected def refl (r : α → α → Prop) : r ≼i r :=
 ⟨order_embedding.refl _, λ a b h, ⟨_, rfl⟩⟩
 
+/-- Composition of functions shows that `≼i` is transitive -/
 @[trans] protected def trans (f : r ≼i s) (g : s ≼i t) : r ≼i t :=
 ⟨f.1.trans g.1, λ a c h, begin
   simp at h ⊢,
@@ -83,6 +86,7 @@ by rw subsingleton.elim f g
 theorem antisymm.aux [is_well_order α r] (f : r ≼i s) (g : s ≼i r) : left_inverse g f :=
 initial_seg.eq (f.trans g) (initial_seg.refl _)
 
+/-- If we have order embeddings between `α` and `β` whose images are initial segments, and β is a well-order then `α` and `β` are order-isomorphic. -/
 def antisymm [is_well_order β s] (f : r ≼i s) (g : s ≼i r) : r ≃o s :=
 by haveI := f.to_order_embedding.is_well_order; exact
 ⟨⟨f, g, antisymm.aux f g, antisymm.aux g f⟩, f.ord⟩

--- a/src/tactic/basic.lean
+++ b/src/tactic/basic.lean
@@ -17,3 +17,4 @@ import
   tactic.squeeze
   tactic.where
   tactic.push_neg
+  tactic.doc_blame

--- a/src/tactic/doc_blame.lean
+++ b/src/tactic/doc_blame.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2019 Patrick Massot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Patrick Massot, Robert Y. Lewis
+-/
 import tactic.core
 open tactic declaration environment
 

--- a/src/tactic/doc_blame.lean
+++ b/src/tactic/doc_blame.lean
@@ -1,0 +1,34 @@
+import tactic.interactive
+
+open tactic declaration environment
+
+/-- test that name was not auto-generated -/
+@[reducible] def name.is_not_auto (n : name) : Prop :=
+n.components.ilast ∉ [`no_confusion, `rec_on, `cases_on, `no_confusion_type, `sizeof,
+                      `rec, `mk, `sizeof_spec, `inj_arrow, `has_sizeof_inst, `inj_eq, `inj]
+
+/-- Print the declaration name if it's a definition without a docstring -/
+meta def print_item (env : environment) (decl : declaration) : tactic unit :=
+match decl with
+| (defn n _ _ _ _ _) := do { ds ← doc_string decl.to_name, skip } <|>
+                          when n.is_not_auto (trace n)
+| (cnst n _ _ _) := do { ds ← doc_string decl.to_name, skip } <|>
+                          when n.is_not_auto (trace n)
+| _ := skip
+end
+
+/-- Print all definitions in the current file without a docstring -/
+meta def print_docstring_orphans : tactic unit :=
+do curr_env ← get_env,
+   let decls := curr_env.fold [] list.cons,
+   let local_decls := decls.filter
+     (λ x, environment.in_current_file' curr_env (to_name x) && not (to_name x).is_internal),
+local_decls.mmap' (print_item curr_env)
+
+setup_tactic_parser
+
+reserve prefix `#doc_blame`:max
+
+@[user_command]
+meta def doc_cmd (_ : decl_meta_info) (_ : parse $ tk "#doc_blame") : lean.parser unit :=
+print_docstring_orphans

--- a/src/tactic/doc_blame.lean
+++ b/src/tactic/doc_blame.lean
@@ -7,18 +7,19 @@ n.components.ilast ∉ [`no_confusion, `rec_on, `cases_on, `no_confusion_type, `
                       `rec, `mk, `sizeof_spec, `inj_arrow, `has_sizeof_inst, `inj_eq, `inj]
 
 /-- Print the declaration name if it's a definition without a docstring -/
-meta def print_item (env : environment) : declaration → tactic unit
+meta def print_item (use_thms : bool) (env : environment) : declaration → tactic unit
 | (defn n _ _ _ _ _) := doc_string n >> skip <|> when n.is_not_auto (trace n)
 | (cnst n _ _ _) := doc_string n >> skip <|> when n.is_not_auto (trace n)
+| (thm n _ _ _) := when use_thms (doc_string n >> skip <|> when n.is_not_auto (trace n))
 | _ := skip
 
 /-- Print all definitions in the current file without a docstring -/
-meta def print_docstring_orphans : tactic unit :=
+meta def print_docstring_orphans (use_thms : bool) : tactic unit :=
 do curr_env ← get_env,
    let local_decls : list declaration := curr_env.fold [] $ λ x t,
      if environment.in_current_file' curr_env (to_name x) && not (to_name x).is_internal then x::t
      else t,
-   local_decls.mmap' (print_item curr_env)
+   local_decls.mmap' (print_item use_thms curr_env)
 
 setup_tactic_parser
 
@@ -26,4 +27,5 @@ reserve prefix `#doc_blame`:max
 
 @[user_command]
 meta def doc_cmd (_ : decl_meta_info) (_ : parse $ tk "#doc_blame") : lean.parser unit :=
-print_docstring_orphans
+do use_thms ← (tk "!") >> return tt <|> return ff,
+   print_docstring_orphans use_thms

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -2,7 +2,11 @@
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Jeremy Avigad
+-/
 
+import order.filter
+
+/-!
 # Basic theory of topological spaces.
 
 The main definition is the type class `topological space α` which endows a type `α` with a topology.
@@ -10,7 +14,7 @@ Then `set α` gets predicates `is_open`, `is_closed` and functions `interior`, `
 `frontier`. Each point `x` of `α` gets a neighborhood filter `nhds x`, and relative versions
 `nhds_within x s` for every set `s` in `α`.
 
-Locally finite family of subsets of `α` are defined.
+This file also defines locally finite families of subsets of `α`.
 
 For topological spaces `α` and `β`, a function `f : α → β` and a point `a : α`,
 `continuous_at f a` means `f` is continuous at `a`, and global continuity is
@@ -24,12 +28,13 @@ Topology in mathlib heavily uses filters (even more than in Bourbaki). See expla
 
 ## References
 
-*  N. Bourbaki: General Topology
-*  I. M. James: Topologies and Uniformities
+*  [N. Bourbaki, *General Topology*][bourbaki1966]
+*  [I. M. James, *Topologies and Uniformities*][james1999]
 
-tags: topological space, interior, closure, frontier, neighborhood, continuity, continuous function
+## Tags
+
+topological space, interior, closure, frontier, neighborhood, continuity, continuous function
 -/
-import order.filter
 
 open set filter lattice classical
 local attribute [instance, priority 0] prop_decidable
@@ -542,7 +547,7 @@ noncomputable def lim (f : filter α) : α := epsilon $ λa, f ≤ nhds a
 lemma lim_spec {f : filter α} (h : ∃a, f ≤ nhds a) : f ≤ nhds (lim f) := epsilon_spec h
 end lim
 
-/-- The neighborhood within filter. Elements of `nhds_within a s` are sets containing the
+/-- The "neighborhood within" filter. Elements of `nhds_within a s` are sets containing the
 intersection of `s` and a neighborhood of `a`. -/
 def nhds_within (a : α) (s : set α) : filter α := nhds a ⊓ principal s
 

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -1,22 +1,42 @@
 /-
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johannes Hölzl, Mario Carneiro
+Authors: Johannes Hölzl, Mario Carneiro, Jeremy Avigad
 
-Theory of topological spaces.
+# Basic theory of topological spaces.
 
-Parts of the formalization is based on the books:
-  N. Bourbaki: General Topology
-  I. M. James: Topologies and Uniformities
-A major difference is that this formalization is heavily based on the filter library.
+The main definition is the type class `topological space α` which endows a type `α` with a topology.
+Then `set α` gets predicates `is_open`, `is_closed` and functions `interior`, `closure` and
+`frontier`. Each point `x` of `α` gets a neighborhood filter `nhds x`, and relative versions
+`nhds_within x s` for every set `s` in `α`.
+
+Locally finite family of subsets of `α` are defined.
+
+For topological spaces `α` and `β`, a function `f : α → β` and a point `a : α`,
+`continuous_at f a` means `f` is continuous at `a`, and global continuity is
+`continuous f`. There are also relative versions `continuous_within_at` and `continuous_on`
+and continuity `pcontinuous` for partially defined functions.
+
+## Implementation notes
+
+Topology in mathlib heavily uses filters (even more than in Bourbaki). See explanations in
+`docs/theories/topological_spaces.md`.
+
+## References
+
+*  N. Bourbaki: General Topology
+*  I. M. James: Topologies and Uniformities
+
+tags: topological space, interior, closure, frontier, neighborhood, continuity, continuous function
 -/
 import order.filter
 
 open set filter lattice classical
-local attribute [instance] prop_decidable
+local attribute [instance, priority 0] prop_decidable
 
 universes u v w
 
+/-- A topology on `α`. -/
 structure topological_space (α : Type u) :=
 (is_open       : set α → Prop)
 (is_open_univ   : is_open univ)
@@ -522,10 +542,8 @@ noncomputable def lim (f : filter α) : α := epsilon $ λa, f ≤ nhds a
 lemma lim_spec {f : filter α} (h : ∃a, f ≤ nhds a) : f ≤ nhds (lim f) := epsilon_spec h
 end lim
 
-/-
-The nhds_within filter.
--/
-
+/-- The neighborhood within filter. Elements of `nhds_within a s` are sets containing the
+intersection of `s` and a neighborhood of `a`. -/
 def nhds_within (a : α) (s : set α) : filter α := nhds a ⊓ principal s
 
 theorem nhds_within_eq (a : α) (s : set α) :
@@ -702,11 +720,17 @@ variables [topological_space α] [topological_space β] [topological_space γ]
   of every open set is open. -/
 def continuous (f : α → β) := ∀s, is_open s → is_open (f ⁻¹' s)
 
+/-- A function between topological spaces is continuous at a point `x₀`
+if `f x` tends to `f x₀` when `x` tends to `x₀`. -/
 def continuous_at (f : α → β) (x : α) := tendsto f (nhds x) (nhds (f x))
 
+/-- A function between topological spaces is continuous at a point `x₀` within a subset `s`
+if `f x` tends to `f x₀` when `x` tends to `x₀` while staying within `s`. -/
 def continuous_within_at (f : α → β) (s : set α) (x : α) : Prop :=
 tendsto f (nhds_within x s) (nhds (f x))
 
+/-- A function between topological spaces is continuous on a subset `s`
+when it's continuous at every point of `s` within `s`. -/
 def continuous_on (f : α → β) (s : set α) : Prop := ∀ x ∈ s, continuous_within_at f s x
 
 lemma continuous_id : continuous (id : α → α) :=
@@ -785,6 +809,7 @@ by rw [this]; exact is_closed_union
 
 /- Continuity and partial functions -/
 
+/-- Continuity of a partial function -/
 def pcontinuous (f : α →. β) := ∀ s, is_open s → is_open (f.preimage s)
 
 lemma open_dom_of_pcontinuous {f : α →. β} (h : pcontinuous f) : is_open f.dom :=


### PR DESCRIPTION
We had a few discussions about documentation at our mini-meeting last week in Amsterdam. mathlib is growing fast; it can be hard to keep up to date with additions to the library, let alone to learn the library from scratch. We've been pretty good about requiring explanations, doc strings, and tests for tactics. But the rest of the library is kind of a mess in this regard.

As I see it, there are a number of different levels of documentation:
1. library level. What can be found where? What are the theory-level interfaces? How do I use, e.g., filters or the linear algebra theory? There was an [attempt to document at this level](https://github.com/leanprover-community/mathlib/tree/master/docs/theories), but it's incomplete and not up to date.
2. file level. What are the contents of a particular file? How do I read that file (naming conventions, notation)? What are the important local design decisions? The extremely brief headers we have right now are not enough.
3. declaration level. What does a particular definition mean? What does a theorem prove? Sometimes this can be read off from the name, type, or body. But not always, and this isn't always convenient for text based search. Doc string display can be very useful. But this is underused outside of tactics.
4. sub-proof level. How does a particular proof proceed? What are the main steps? What is the motivation behind particular tactic calls? Most mathlib proofs are illegible right now.

This PR focuses on 2 and 3. I think 4 is very difficult, and in principle we have a method for dealing with 1, although it needs to be updated and enforced.

We experimented with fully documenting a few example files at the meeting, and came up with some standards and rules based on that. (I think there might be one or two more examples that aren't part of this PR yet?) We would require all future PRs to adhere to these standards, and document older files as they are modified. Doc-only PRs would be very welcome.

This PR also adds a user command, `#doc_blame`, that prints all definitions in a file that are missing doc strings. `#doc_blame!` includes theorems. 

The standards are of course up for discussion. What do people think?

cc @PatrickMassot @kbuzzard @fpvandoorn @kappelmann 

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
