### PR TITLE
fix(data/{nat,int}/parity): fix definition of 'even'

### DIFF
--- a/src/data/int/parity.lean
+++ b/src/data/int/parity.lean
@@ -15,7 +15,7 @@ by cases mod_two_eq_zero_or_one n with h h; simp [h]
 @[simp] theorem mod_two_ne_zero {n : int} : ¬ n % 2 = 0 ↔ n % 2 = 1 :=
 by cases mod_two_eq_zero_or_one n with h h; simp [h]
 
-def even (n : int) : Prop := ∃ m, n = 2 * m
+def even (n : int) : Prop := 2 ∣ n
 
 @[simp] theorem even_coe_nat (n : nat) : even n ↔ nat.even n :=
 have ∀ m, 2 * to_nat m = to_nat (2 * m),

--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -15,7 +15,7 @@ by cases mod_two_eq_zero_or_one n with h h; simp [h]
 @[simp] theorem mod_two_ne_zero {n : nat} : ¬ n % 2 = 0 ↔ n % 2 = 1 :=
 by cases mod_two_eq_zero_or_one n with h h; simp [h]
 
-def even (n : nat) : Prop := ∃ m, n = 2 * m
+def even (n : nat) : Prop := 2 ∣ n
 
 theorem even_iff {n : nat} : even n ↔ n % 2 = 0 :=
 ⟨λ ⟨m, hm⟩, by simp [hm], λ h, ⟨n / 2, (mod_add_div n 2).symm.trans (by simp [h])⟩⟩


### PR DESCRIPTION
This fixes a silly mistake on my part. I defined `even` to be `∃ m, n = 2 * m`, instead of, more simply, `2 | n` (which is definitionally equivalent).
