### PR TITLE
chore(.mergify.yml): add rule to check for maintainer approval

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -29,7 +29,12 @@ pull_request_rules:
         method: squash
         strict: smart
         strict_method: merge
-  
+# rule used to protect master branch
+  - name: approved by maintainer
+    conditions:
+      - approved-reviews-by=@leanprover-community/mathlib-maintainers
+    actions: {}
+
  # In practice this turns out to be really annoying.
  # - name: remove outdated reviews
  #   conditions:


### PR DESCRIPTION
If I've done this correctly: this should add a rule that checks whether a PR has been approved by a maintainer. Then we can protect the master branch to only allow PRs that meet this rule, and disable the automatic code owner review request.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
