### PR TITLE
feat(logic/unique): forall_iff and exists_iff

### DIFF
--- a/src/logic/unique.lean
+++ b/src/logic/unique.lean
@@ -37,6 +37,12 @@ lemma default_eq (a : α) : default α = a := (uniq _ a).symm
 
 instance : subsingleton α := ⟨λ a b, by rw [eq_default a, eq_default b]⟩
 
+lemma forall_iff {p : α → Prop} : (∀ a, p a) ↔ p (default α) :=
+⟨λ h, h _, λ h x, by rwa [unique.eq_default x]⟩
+
+lemma exists_iff {p : α → Prop} : Exists p ↔ p (default α) :=
+⟨λ ⟨a, ha⟩, eq_default a ▸ ha, exists.intro (default α)⟩
+
 end
 
 protected lemma subsingleton_unique' : ∀ (h₁ h₂ : unique α), h₁ = h₂


### PR DESCRIPTION
Maybe these should be `@[simp]`. My use case in `fin 1` and it's slightly annoying to have `default (fin 1)` everwhere instead of `0`, but maybe that should also be a `@[simp]` lemma.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
