### PR TITLE
feat(vector_space): make vector_space a reducible def

### DIFF
--- a/src/algebra/module.lean
+++ b/src/algebra/module.lean
@@ -336,19 +336,20 @@ end ideal
   This is the traditional generalization of spaces like `ℝ^n`, which have a natural
   addition operation and a way to multiply them by real numbers, but no multiplication
   operation between vectors. -/
-class vector_space (α : Type u) (β : Type v) [discrete_field α] [add_comm_group β] extends module α β
+@[reducible] def vector_space (α : Type u) (β : Type v) [discrete_field α] [add_comm_group β] :=
+module α β
 
-instance discrete_field.to_vector_space {α : Type*} [discrete_field α] : vector_space α α :=
-{ .. ring.to_module }
+-- instance discrete_field.to_vector_space {α : Type*} [discrete_field α] : vector_space α α :=
+-- { .. ring.to_module }
 
-/-- Subspace of a vector space. Defined to equal `submodule`. -/
-@[reducible] def subspace (α : Type u) (β : Type v)
-  [discrete_field α] [add_comm_group β] [vector_space α β] : Type v :=
-submodule α β
+-- /-- Subspace of a vector space. Defined to equal `submodule`. -/
+-- @[reducible] def subspace (α : Type u) (β : Type v)
+--   [discrete_field α] [add_comm_group β] [vector_space α β] : Type v :=
+-- submodule α β
 
-instance subspace.vector_space {α β}
-  {f : discrete_field α} [add_comm_group β] [vector_space α β]
-  (p : subspace α β) : vector_space α p := {..submodule.module p}
+-- instance subspace.vector_space {α β}
+--   {f : discrete_field α} [add_comm_group β] [vector_space α β]
+--   (p : subspace α β) : vector_space α p := {..submodule.module p}
 
 namespace submodule
 

--- a/src/algebra/pi_instances.lean
+++ b/src/algebra/pi_instances.lean
@@ -83,7 +83,7 @@ variables {I f}
 
 instance module         (α) {r : ring α}           [∀ i, add_comm_group $ f i]  [∀ i, module α $ f i]         : module α (Π i : I, f i)       := {..pi.semimodule I f α}
 
-instance vector_space   (α) {r : discrete_field α} [∀ i, add_comm_group $ f i]  [∀ i, vector_space α $ f i]   : vector_space α (Π i : I, f i) := {..pi.module α}
+-- instance vector_space   (α) {r : discrete_field α} [∀ i, add_comm_group $ f i]  [∀ i, vector_space α $ f i]   : vector_space α (Π i : I, f i) := {..pi.module α}
 
 instance left_cancel_semigroup [∀ i, left_cancel_semigroup $ f i] : left_cancel_semigroup (Π i : I, f i) :=
 by pi_instance
@@ -101,7 +101,7 @@ instance ordered_cancel_comm_monoid [∀ i, ordered_cancel_comm_monoid $ f i] : 
 by pi_instance
 
 instance ordered_comm_group [∀ i, ordered_comm_group $ f i] : ordered_comm_group (Π i : I, f i) :=
-{ add_lt_add_left := λ a b hab c, ⟨λ i, add_le_add_left (hab.1 i) (c i), 
+{ add_lt_add_left := λ a b hab c, ⟨λ i, add_le_add_left (hab.1 i) (c i),
     λ h, hab.2 $ λ i, le_of_add_le_add_left (h i)⟩,
   add_le_add_left := λ x y hxy c i, add_le_add_left (hxy i) _,
   ..pi.add_comm_group,
@@ -344,8 +344,8 @@ instance {r : semiring α} [add_comm_monoid β] [add_comm_monoid γ]
 instance {r : ring α} [add_comm_group β] [add_comm_group γ]
   [module α β] [module α γ] : module α (β × γ) := {}
 
-instance {r : discrete_field α} [add_comm_group β] [add_comm_group γ]
-  [vector_space α β] [vector_space α γ] : vector_space α (β × γ) := {}
+-- instance {r : discrete_field α} [add_comm_group β] [add_comm_group γ]
+--   [vector_space α β] [vector_space α γ] : vector_space α (β × γ) := {}
 
 section substructures
 variables (s : set α) (t : set β)

--- a/src/data/finsupp.lean
+++ b/src/data/finsupp.lean
@@ -1254,8 +1254,8 @@ instance [semiring γ] [add_comm_monoid β] [semimodule γ β] : semimodule γ (
 instance [ring γ] [add_comm_group β] [module γ β] : module γ (α →₀ β) :=
 { ..finsupp.semimodule α β }
 
-instance [discrete_field γ] [add_comm_group β] [vector_space γ β] : vector_space γ (α →₀ β) :=
-{ ..finsupp.module α β }
+-- instance [discrete_field γ] [add_comm_group β] [vector_space γ β] : vector_space γ (α →₀ β) :=
+-- { ..finsupp.module α β }
 
 variables {α β}
 lemma support_smul {R:semiring γ} [add_comm_monoid β] [semimodule γ β] {b : γ} {g : α →₀ β} :

--- a/src/data/polynomial.lean
+++ b/src/data/polynomial.lean
@@ -1880,7 +1880,7 @@ end integral_domain
 
 section field
 variables [discrete_field α] {p q : polynomial α}
-instance : vector_space α (polynomial α) := finsupp.vector_space _ _
+-- instance : vector_space α (polynomial α) := finsupp.vector_space _ _
 
 lemma is_unit_iff_degree_eq_zero : is_unit p ↔ degree p = 0 :=
 ⟨degree_eq_zero_of_is_unit,

--- a/src/field_theory/mv_polynomial.lean
+++ b/src/field_theory/mv_polynomial.lean
@@ -17,8 +17,8 @@ namespace mv_polynomial
 universes u v
 variables {σ : Type u} {α : Type v} [decidable_eq σ]
 
-instance [discrete_field α] : vector_space α (mv_polynomial σ α) :=
-finsupp.vector_space _ _
+-- instance [discrete_field α] : vector_space α (mv_polynomial σ α) :=
+-- finsupp.vector_space _ _
 
 section
 variables (σ α) [discrete_field α] (m : ℕ)
@@ -203,7 +203,7 @@ variables (σ : Type u) (α : Type u) [decidable_eq σ] [fintype σ] [discrete_f
 def R : Type u := restrict_degree σ α (fintype.card α - 1)
 
 instance R.add_comm_group : add_comm_group (R σ α) := by dunfold R; apply_instance
-instance R.vector_space : vector_space α (R σ α) := by dunfold R; apply_instance
+-- instance R.vector_space : vector_space α (R σ α) := by dunfold R; apply_instance
 
 noncomputable instance decidable_restrict_degree (m : ℕ) :
   decidable_pred (λn, n ∈ {n : σ →₀ ℕ | ∀i, n i ≤ m }) :=

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -706,8 +706,8 @@ module.of_core $ by refine {smul := (•), ..};
   repeat {rintro ⟨⟩ <|> intro}; simp [smul_add, add_smul, smul_smul,
     -mk_add, (mk_add p).symm, -mk_smul, (mk_smul p).symm]
 
-instance {α β} {R:discrete_field α} [add_comm_group β] [vector_space α β]
-  (p : submodule α β) : vector_space α (quotient p) := {}
+-- instance {α β} {R:discrete_field α} [add_comm_group β] [vector_space α β]
+--   (p : submodule α β) : vector_space α (quotient p) := {}
 
 end quotient
 

--- a/src/linear_algebra/dual.lean
+++ b/src/linear_algebra/dual.lean
@@ -43,7 +43,7 @@ variables {K : Type u} {V : Type v} {ι : Type w}
 variables [discrete_field K] [add_comm_group V] [vector_space K V]
 open vector_space module module.dual submodule linear_map cardinal function
 
-instance dual.vector_space : vector_space K (dual K V) := {..dual.module K V}
+-- instance dual.vector_space : vector_space K (dual K V) := {..dual.module K V}
 
 variables [decidable_eq V] [decidable_eq (module.dual K V)] [decidable_eq ι]
 variables {B : ι → V} (h : is_basis K B)

--- a/src/linear_algebra/dual.lean
+++ b/src/linear_algebra/dual.lean
@@ -43,7 +43,7 @@ variables {K : Type u} {V : Type v} {ι : Type w}
 variables [discrete_field K] [add_comm_group V] [vector_space K V]
 open vector_space module module.dual submodule linear_map cardinal function
 
--- instance dual.vector_space : vector_space K (dual K V) := {..dual.module K V}
+instance dual.vector_space : vector_space K (dual K V) := {..dual.module K V}
 
 variables [decidable_eq V] [decidable_eq (module.dual K V)] [decidable_eq ι]
 variables {B : ι → V} (h : is_basis K B)
@@ -182,7 +182,7 @@ begin
   rcases exists_subset_is_basis (linear_independent_singleton H) with ⟨b, hv, hb⟩,
   swap 4, assumption,
   have hv' : v = (λ (i : b), i.val) ⟨v, hv (set.mem_singleton v)⟩ := rfl,
-  let hx := h (hb.to_dual v),
+  let hx := h ((hb.to_dual : V → dual K V) v),
   erw [eval_apply, hv', to_dual_apply, if_pos rfl, zero_apply _] at hx,
   exact one_ne_zero hx
 end


### PR DESCRIPTION
Make vector space a reducible def for module, rather than extending module, to save on having to define a bunch more instances.

Not sure if this will build.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
