### PR TITLE
fix(category_theory/category): get rid of plift in preorder.category

### DIFF
--- a/src/category_theory/category.lean
+++ b/src/category_theory/category.lean
@@ -133,9 +133,9 @@ namespace preorder
 
 variables (α : Type u)
 
-instance small_category [preorder α] : small_category α :=
-{ hom  := λ U V, ulift (plift (U ≤ V)),
-  id   := λ X, ⟨ ⟨ le_refl X ⟩ ⟩,
-  comp := λ X Y Z f g, ⟨ ⟨ le_trans _ _ _ f.down.down g.down.down ⟩ ⟩ }
+instance small_category [preorder α] : category α :=
+{ hom  := (≤),
+  id   := le_refl,
+  comp := @le_trans _ _ }
 
 end preorder

--- a/src/category_theory/discrete_category.lean
+++ b/src/category_theory/discrete_category.lean
@@ -12,15 +12,15 @@ universes v₁ v₂ u₁ u₂ -- declare the `v`'s first; see `category_theory.c
 -- We only work in `Type`, rather than `Sort`, as we need to use `ulift`.
 def discrete (α : Type u₁) := α
 
-instance discrete_category (α : Type u₁) : small_category (discrete α) :=
-{ hom  := λ X Y, ulift (plift (X = Y)),
-  id   := λ X, ulift.up (plift.up rfl),
-  comp := λ X Y Z g f, by { rcases f with ⟨⟨rfl⟩⟩, exact g } }
+instance discrete_category (α : Type u₁) : category (discrete α) :=
+{ hom  := (=),
+  id   := eq.refl,
+  comp := λ X Y Z g f, by { rcases f with rfl, exact g } }
 
 namespace discrete
 
 variables {α : Type u₁}
-@[simp] lemma id_def (X : discrete α) : ulift.up (plift.up (eq.refl X)) = 𝟙 X := rfl
+@[simp] lemma id_def (X : discrete α) : eq.refl X = 𝟙 X := rfl
 
 end discrete
 
@@ -31,7 +31,7 @@ namespace functor
 
 @[simp] def of_function {I : Type u₁} (F : I → C) : (discrete I) ⥤ C :=
 { obj := F,
-  map := λ X Y f, begin cases f, cases f, cases f, exact 𝟙 (F X) end }
+  map := λ X Y f, begin cases f, exact 𝟙 (F X) end }
 
 end functor
 
@@ -77,11 +77,7 @@ include 𝒞
 
 @[simp] lemma functor_map_id
   (F : discrete J ⥤ C) {j : discrete J} (f : j ⟶ j) : F.map f = 𝟙 (F.obj j) :=
-begin
-  have h : f = 𝟙 j, cases f, cases f, ext,
-  rw h,
-  simp,
-end
+by simp
 
 end discrete
 


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
