### PR TITLE
doc(contribute/index.md): add line about large PRs [ci skip]

### DIFF
--- a/docs/contribute/index.md
+++ b/docs/contribute/index.md
@@ -15,6 +15,7 @@ to make the process of contributing as smooth as possible.
    - The [git commit conventions](https://github.com/leanprover/lean/blob/master/doc/commit_convention.md).
 3. Create a pull request from a feature branch on your personal fork,
    as explained in the link above, or from a branch of the main repository if you have commit access (you can ask for access on Zulip).
+4. If you've made a lot of changes/additions, try to make many PRs containing small, self-contained pieces. This helps you get feedback as you go along, and it is much easier to review. This is especially important for new contributors.
 
 
 ## The nursery


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
