### PR TITLE
feat(tactic/interactive): move `rotate` into interactive namespace

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -1043,3 +1043,11 @@ open_locale namespace1 namespace2 ...
 ```
 localized "attribute [simp] le_refl" in le
 ```
+
+### swap
+
+`swap n` will move the `n`th goal to the front. `swap` defaults to `swap 2`, and so interchanges the first and second goals.
+
+### rotate
+
+`rotate` moves the first goal to the back. `rotate n` will do this `n` times.

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -66,6 +66,10 @@ do gs ← get_goals,
    | _        := skip
    end
 
+/-- `rotate n` cyclically shifts the goals `n` times.
+ `rotate` defaults to `rotate 1`. -/
+meta def rotate (n := 1) : tactic unit := tactic.rotate n
+
 /-- Clear all hypotheses starting with `_`, like `_match` and `_let_match`. -/
 meta def clear_ : tactic unit := tactic.repeat $ do
   l ← local_context,

--- a/test/tactics.lean
+++ b/test/tactics.lean
@@ -214,6 +214,14 @@ by {ac_change a + d + e + f + c + g + b ≤ _, refl}
 
 end convert_to
 
+section swap
+
+example {α₁ α₂ α₃ : Type} : true :=
+by {have : α₁, have : α₂, have : α₃, swap, swap,
+    rotate, rotate, rotate, rotate 2, rotate 2, triv, recover}
+
+end swap
+
 private meta def get_exception_message (t : lean.parser unit) : lean.parser string
 | s := match t s with
        | result.success a s' := result.success "No exception" s


### PR DESCRIPTION
also document `swap`

I occasionally find it annoying that `tactic.rotate` is not in the interactive namespace. Someone also [pointed out](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/easy.20questions/near/171840194) that `swap` is defined in mathlib instead of core, but not documented, so I documented it.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
