### PR TITLE
feat(algebra,data/complex/exponential): add abs_neg_one_pow, remove hyp from div_le_div_of_le_left

### DIFF
--- a/src/algebra/field.lean
+++ b/src/algebra/field.lean
@@ -179,7 +179,7 @@ lemma div_div_cancel (ha : a ≠ 0) : a / (a / b) = b :=
 if b0 : b = 0 then by simp only [b0, div_zero] else
 field.div_div_cancel ha b0
 
-@[simp] lemma inv_eq_zero (a : α) : a⁻¹ = 0 ↔ a = 0 :=
+@[simp] lemma inv_eq_zero {a : α} : a⁻¹ = 0 ↔ a = 0 :=
 classical.by_cases (assume : a = 0, by simp [*])(assume : a ≠ 0, by simp [*, inv_ne_zero])
 
 lemma neg_inv' (a : α) : (-a)⁻¹ = - a⁻¹ :=

--- a/src/algebra/group_power.lean
+++ b/src/algebra/group_power.lean
@@ -504,6 +504,9 @@ lemma pow_abs [decidable_linear_ordered_comm_ring α] (a : α) (n : ℕ) : (abs 
 by induction n with n ih; [exact (abs_one).symm,
   rw [pow_succ, pow_succ, ih, abs_mul]]
 
+lemma abs_neg_one_pow [decidable_linear_ordered_comm_ring α] (n : ℕ) : abs ((-1 : α)^n) = 1 :=
+by rw [←pow_abs, abs_neg, abs_one, one_pow]
+
 lemma inv_pow' [discrete_field α] (a : α) (n : ℕ) : (a ^ n)⁻¹ = a⁻¹ ^ n :=
 by induction n; simp [*, pow_succ, mul_inv', mul_comm]
 

--- a/src/algebra/ordered_field.lean
+++ b/src/algebra/ordered_field.lean
@@ -169,11 +169,11 @@ lemma mul_self_inj_of_nonneg {a b : α} (a0 : 0 ≤ a) (b0 : 0 ≤ b) : a * a = 
 (mul_self_eq_mul_self_iff a b).trans $ or_iff_left_of_imp $
 λ h, by subst a; rw [le_antisymm (neg_nonneg.1 a0) b0, neg_zero]
 
-lemma div_le_div_of_le_left {a b c : α} (ha : 0 ≤ a) (hb : 0 < b) (hc : 0 < c) (h : c ≤ b) :
+lemma div_le_div_of_le_left {a b c : α} (ha : 0 ≤ a) (hc : 0 < c) (h : c ≤ b) :
   a / b ≤ a / c :=
 by haveI := classical.dec_eq α; exact
 if ha0 : a = 0 then by simp [ha0]
-else (div_le_div_left (lt_of_le_of_ne ha (ne.symm ha0)) hb hc).2 h
+else (div_le_div_left (lt_of_le_of_ne ha (ne.symm ha0)) (lt_of_lt_of_le hc h) hc).2 h
 
 end linear_ordered_field
 

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -304,7 +304,7 @@ series_ratio_test n (complex.abs z / n) (div_nonneg_of_nonneg_of_pos (complex.ab
       mul_comm m.succ, nat.cast_mul, ← div_div_eq_div_mul, mul_div_assoc,
       mul_div_right_comm, abs_mul, abs_div, abs_cast_nat];
     exact mul_le_mul_of_nonneg_right
-      (div_le_div_of_le_left (abs_nonneg _) (nat.cast_pos.2 (nat.succ_pos _)) hn0
+      (div_le_div_of_le_left (abs_nonneg _) hn0
         (nat.cast_le.2 (le_trans hm (nat.le_succ _)))) (abs_nonneg _))
 
 noncomputable theory


### PR DESCRIPTION
### What
1. Fix implicit argument for `inv_eq_zero`
2. Add `|-1|^n = 1` lemma
3. Remove unnecessary hypothesis from `div_le_div_of_le_left`.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
