### PR TITLE
doc(style.md): variables should not have name `a`

### DIFF
--- a/docs/contribute/style.md
+++ b/docs/contribute/style.md
@@ -11,7 +11,7 @@ rather than rigid rules.
 
 - `u`, `v`, `w`, ... for universes
 - `α`, `β`, `γ`, ... for types
-- `a`, `b`, `c`, ... for propositions
+- `b`, `c`, ...      for propositions
 - `x`, `y`, `z`, ... for elements of a generic type
 - `h`, `h₁`, ...     for assumptions
 - `p`, `q`, `r`, ... for predicates and relations
@@ -19,7 +19,7 @@ rather than rigid rules.
 - `s`, `t`, ...      for sets
 - `m`, `n`, `k`, ... for natural numbers
 - `i`, `j`, `k`, ... for integers
-
+- The letter `a` should never be used as a variable, because there is a bug in Lean that assigns the letter `a` to nondependent arguments in tactic expressions, leading to errors.
 
 
 ### Line length ###


### PR DESCRIPTION
Workaround for the letter `a` bug.

See [this thread on Zulip](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Is.20this.20a.20bug.3F) (and others).

This is a suggestion, comments are welcome.