### PR TITLE
feat(archive): add archive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
   directories:
     - $TRAVIS_BUILD_DIR/test/
     - $TRAVIS_BUILD_DIR/src/
+    - $TRAVIS_BUILD_DIR/archive/
     - $HOME/.elan
 
 install:
@@ -87,6 +88,20 @@ jobs:
         - travis_long "leanpkg test"
         - lean --recursive --export=mathlib.txt src/
         - travis_long "leanchecker mathlib.txt"
+
+    - stage: Archive
+      env: TASK="check Lean proofs"
+      if: type != cron
+      script:
+        - travis_long "lean --make archive/"
+
+    - stage: Archive
+      env: TASK="check Lean proofs" LEAN="nightly"
+      if: type = cron
+      script:
+        - elan toolchain install leanprover-community/lean:nightly
+        - elan override set leanprover-community/lean:nightly
+        - travis_long "lean --make archive/"
 
   # allow_failures:
   #   - env: TASK="check Lean proofs" LEAN="nightly"

--- a/archive/README.md
+++ b/archive/README.md
@@ -8,7 +8,7 @@ We keep these formalizations here so that when mathlib changes, we can keep thes
 
 If you have done a formalization which you want to add here, just make a pull request to mathlib.
 
-When you make a pull request, do make sure that you put all lemmas which should be in mathlib in the right place (in mathlib).
+When you make a pull request, do make sure that you put all lemmas which are generally useful in right place in mathlib (in the `src/` directory).
 
 Try to adhere to the guidelines for mathlib. They will be much less strictly enforced for the archive, but we still want you to adhere to all the conventions that make maintenance easier. This ensures that when mathlib is changing, the mathlib maintainers can fix these contributions without much effort. Here are the guidelines:
 - The [style guide](../docs/contribute/style.md) for contributors.

--- a/archive/README.md
+++ b/archive/README.md
@@ -1,0 +1,16 @@
+# Archive
+
+This is an archive for formalizations which don't have a good place in mathlib, probably because there is (almost) no math depending on these results.
+
+We keep these formalizations here so that when mathlib changes, we can keep these formalizations up to date.
+
+## Contributing
+
+If you have done a formalization which you want to add here, just make a pull request to mathlib.
+
+When you make a pull request, do make sure that you put all lemmas which should be in mathlib in the right place (in mathlib).
+
+Try to adhere to the guidelines for mathlib. They will be much less strictly enforced for the archive, but we still want you to adhere to all the conventions that make maintenance easier. This ensures that when mathlib is changing, the mathlib maintainers can fix these contributions without much effort. Here are the guidelines:
+- The [style guide](../docs/contribute/style.md) for contributors.
+- The [git commit conventions](https://github.com/leanprover/lean/blob/master/doc/commit_convention.md).
+- You don't have to follow the [naming conventions](../docs/contribute/naming.md).


### PR DESCRIPTION
An archive for all one-off projects, satellite proofs, recreational math, whatever you want to call it.

[Link to one of the Zulip chats about it](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/cubing.20a.20cube/near/166786363).

At first, I suggest we don't make an elaborate file hierarchy yet, we can always add that later. I'm not even sure whether we should base the hierarchy on mathematical topic (`combinatorics`, `game theory`, ...) or source (`IMO`, `fun problem from textbook X`, `folklore problem`). Probably by mathematical topic, though.

I will submit my first entry after #1294 is merged.

@cipher1024: could you check if I didn't mess up the Travis script?