### PR TITLE
chore(ring_theory/algebra): make first type argument explicit in alg_hom

### DIFF
--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -150,7 +150,7 @@ structure alg_hom (R : Type u) (A : Type v) (B : Type w)
 (commutes' : ∀ r : R, to_fun (algebra_map A r) = algebra_map B r)
 
 infixr ` →ₐ `:25 := alg_hom _
-notation A ` →ₐ[`:25 R `] ` B := @alg_hom R A B _ _ _ _ _
+notation A ` →ₐ[`:25 R `] ` B := alg_hom R A B
 
 namespace alg_hom
 

--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -144,12 +144,12 @@ variables {R A}
 end algebra
 
 /-- Defining the homomorphism in the category R-Alg. -/
-structure alg_hom {R : Type u} (A : Type v) (B : Type w)
+structure alg_hom (R : Type u) (A : Type v) (B : Type w)
   [comm_ring R] [ring A] [ring B] [algebra R A] [algebra R B] :=
 (to_fun : A → B) [hom : is_ring_hom to_fun]
 (commutes' : ∀ r : R, to_fun (algebra_map A r) = algebra_map B r)
 
-infixr ` →ₐ `:25 := alg_hom
+infixr ` →ₐ `:25 := alg_hom _
 notation A ` →ₐ[`:25 R `] ` B := @alg_hom R A B _ _ _ _ _
 
 namespace alg_hom


### PR DESCRIPTION
Now this works, and it didn't work previously even with `@`
```lean
structure alg_equiv (α β γ : Type*) [comm_ring α] [ring β] [ring γ]
  [algebra α β] [algebra α γ] extends alg_hom α β γ :=
```

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
