### PR TITLE
fix(tactic/linarith): handle neq goals

### DIFF
--- a/src/tactic/linarith.lean
+++ b/src/tactic/linarith.lean
@@ -640,6 +640,7 @@ meta def get_contr_lemma_name : expr → option name
 | `(%%a < %%b) := return `lt_of_not_ge
 | `(%%a ≤ %%b) := return `le_of_not_gt
 | `(%%a = %%b) := return ``eq_of_not_lt_of_not_gt
+| `(%%a ≠ %%b) := return `not.intro
 | `(%%a ≥ %%b) := return `le_of_not_gt
 | `(%%a > %%b) := return `lt_of_not_ge
 | `(¬ %%a < %%b) := return `not.intro

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -137,3 +137,7 @@ by linarith only [hx, hx2]
 
 example (x y z : ℚ) (hx : x < 5) (hy : y < 5000000000) (hz : z > 34*y) : x ≤ 5 :=
 by linarith only [hx]
+
+example (x y : ℚ) (h : x < y) : x ≠ y := by linarith
+
+example (x y : ℚ) (h : x < y) : ¬ x = y := by linarith


### PR DESCRIPTION
`linarith` was ignoring goals like `x ≠ y` but handling `¬ x = y`.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
