### PR TITLE
 chore(*): use localized command in mathlib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 _cache
 __pycache__
 all.lean
+*.depend

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -1068,6 +1068,8 @@ open_locale namespace1 namespace2 ...
 ```
 localized "attribute [simp] le_refl" in le
 ```
+* Warning 1: as a limitation on user commands, you cannot put `open_locale` directly after your imports. You have to write another command first (e.g. `open`, `namespace`, `universe variables`, `noncomputable theory`, `run_cmd tactic.skip`, ...).
+* Warning 2: You have to fully specify the names used in localized notation, so that the localized notation also works when the appropriate namespaces are not opened.
 
 ### swap
 

--- a/src/algebra/CommRing/adjunctions.lean
+++ b/src/algebra/CommRing/adjunctions.lean
@@ -19,7 +19,7 @@ open category_theory
 
 namespace CommRing
 
-local attribute [instance, priority 0] classical.prop_decidable
+open_locale classical
 
 private def free_obj (α : Type u) : CommRing.{u} := ⟨mv_polynomial α ℤ⟩
 

--- a/src/algebra/archimedean.lean
+++ b/src/algebra/archimedean.lean
@@ -8,9 +8,9 @@ Archimedean groups and fields.
 import algebra.group_power algebra.field_power
 import data.rat tactic.linarith tactic.abel
 
-local infix ` • ` := add_monoid.smul
-
 variables {α : Type*}
+
+open_locale add_monoid
 
 class floor_ring (α) [linear_ordered_ring α] :=
 (floor : α → ℤ)

--- a/src/algebra/direct_limit.lean
+++ b/src/algebra/direct_limit.lean
@@ -105,7 +105,7 @@ theorem lift_unique (F : direct_limit G f →ₗ[R] P) (x) :
 direct_limit.induction_on x $ λ i x, by rw lift_of; refl
 
 section totalize
-local attribute [instance, priority 0] classical.dec
+open_locale classical
 variables (G f)
 noncomputable def totalize : Π i j, G i →ₗ[R] G j :=
 λ i j, if h : i ≤ j then f i j h else 0
@@ -329,7 +329,7 @@ quotient.induction_on' z $ λ x, free_abelian_group.induction_on x
 let ⟨i, x, hx⟩ := exists_of z in hx ▸ ih i x
 
 section of_zero_exact
-local attribute [instance, priority 0] classical.dec
+open_locale classical
 variables (G f)
 lemma of.zero_exact_aux2 {x : free_comm_ring Σ i, G i} {s t} (hxs : is_supported x s) {j k}
   (hj : ∀ z : Σ i, G i, z ∈ s → z.1 ≤ j) (hk : ∀ z : Σ i, G i, z ∈ t → z.1 ≤ k)
@@ -502,7 +502,7 @@ ring.direct_limit.induction_on p $ λ i x H,
     ring.direct_limit.of_one]⟩
 
 section
-local attribute [instance, priority 0] classical.dec
+open_locale classical
 
 noncomputable def inv (p : ring.direct_limit G f) : ring.direct_limit G f :=
 if H : p = 0 then 0 else classical.some (direct_limit.exists_inv G f H)
@@ -522,7 +522,7 @@ protected noncomputable def field : field (ring.direct_limit G f) :=
 protected noncomputable def discrete_field : discrete_field (ring.direct_limit G f) :=
 { has_decidable_eq := classical.dec_eq _,
   inv_zero := dif_pos rfl,
-  ..direct_limit.field G f }  
+  ..direct_limit.field G f }
 
 end
 

--- a/src/algebra/group_power.lean
+++ b/src/algebra/group_power.lean
@@ -31,7 +31,7 @@ def add_monoid.smul [add_monoid α] (n : ℕ) (a : α) : α :=
 @monoid.pow (multiplicative α) _ a n
 
 precedence `•`:70
-local infix ` • ` := add_monoid.smul
+localized "infix ` • ` := add_monoid.smul" in add_monoid
 
 @[priority 5] instance monoid.has_pow [monoid α] : has_pow α ℕ := ⟨monoid.pow⟩
 
@@ -195,8 +195,9 @@ def gsmul (n : ℤ) (a : β) : β :=
 
 @[priority 10] instance group.has_pow : has_pow α ℤ := ⟨gpow⟩
 
-local infix ` • `:70 := gsmul
-local infix ` •ℕ `:70 := add_monoid.smul
+localized "infix ` • `:70 := gsmul" in group
+localized "infix ` •ℕ `:70 := add_monoid.smul" in smul
+localized "infix ` •ℤ `:70 := gsmul" in smul
 
 @[simp] theorem gpow_coe_nat (a : α) (n : ℕ) : a ^ (n:ℤ) = a ^ n := rfl
 @[simp] theorem gsmul_coe_nat (a : β) (n : ℕ) : (n:ℤ) • a = n •ℕ a := rfl
@@ -337,7 +338,7 @@ theorem map_gsmul (a : α) (n : ℤ) : f (gsmul n a) = gsmul n (f a) :=
 
 end is_add_group_hom
 
-local infix ` •ℤ `:70 := gsmul
+open_locale smul
 
 section comm_monoid
 variables [comm_group α] {β : Type*} [add_comm_group β]

--- a/src/analysis/complex/exponential.lean
+++ b/src/analysis/complex/exponential.lean
@@ -268,7 +268,7 @@ real.intermediate_value'
 
 noncomputable def pi : ℝ := 2 * classical.some exists_cos_eq_zero
 
-local notation `π` := pi
+localized "notation `π` := real.pi" in real
 
 @[simp] lemma cos_pi_div_two : cos (π / 2) = 0 :=
 by rw [pi, mul_div_cancel_left _ (@two_ne_zero' ℝ _ _ _)];
@@ -926,7 +926,7 @@ end real
 
 namespace complex
 
-local notation `π` := real.pi
+open_locale real
 
 /-- `arg` returns values in the range (-π, π], such that for `x ≠ 0`,
   `sin (arg x) = x.im / x.abs` and `cos (arg x) = x.re / x.abs`,

--- a/src/analysis/complex/exponential.lean
+++ b/src/analysis/complex/exponential.lean
@@ -1376,7 +1376,7 @@ by simp only [rpow_def, complex.cpow_def];
 lemma rpow_def_of_pos {x : ℝ} (hx : 0 < x) (y : ℝ) : x ^ y = exp (log x * y) :=
 by rw [rpow_def_of_nonneg (le_of_lt hx), if_neg (ne_of_gt hx)]
 
-local notation `π` := pi
+open_locale real
 
 lemma rpow_def_of_neg {x : ℝ} (hx : x < 0) (y : ℝ) : x ^ y = exp (log (-x) * y) * cos (y * π) :=
 begin
@@ -1444,7 +1444,7 @@ end complex
 
 namespace real
 
-local notation `π` := pi
+open_locale real
 
 variables {x y z : ℝ}
 
@@ -1571,8 +1571,6 @@ have hn0 : (n : ℝ) ≠ 0, by simpa [nat.pos_iff_ne_zero'] using hn,
 by rw [← rpow_nat_cast, ← rpow_mul hx, mul_inv_cancel hn0, rpow_one]
 
 section prove_rpow_is_continuous
-
-local notation `π` := pi
 
 lemma continuous_rpow_aux1 : continuous (λp : {p:ℝ×ℝ // 0 < p.1}, p.val.1 ^ p.val.2) :=
 suffices h : continuous (λ p : {p:ℝ×ℝ // 0 < p.1 }, exp (log p.val.1 * p.val.2)),

--- a/src/analysis/convex.lean
+++ b/src/analysis/convex.lean
@@ -14,9 +14,8 @@ import tactic.linarith
 import linear_algebra.basic
 import ring_theory.algebra
 
-local attribute [instance] classical.prop_decidable
-
 open set
+open_locale classical
 
 section vector_space
 variables {α : Type*} {β : Type*} {ι : Sort _}

--- a/src/analysis/normed_space/banach.lean
+++ b/src/analysis/normed_space/banach.lean
@@ -10,9 +10,9 @@ bounded linear map between Banach spaces has a bounded inverse.
 -/
 
 import topology.metric_space.baire analysis.normed_space.bounded_linear_maps
-local attribute [instance] classical.prop_decidable
 
 open function metric set filter finset
+open_locale classical
 
 variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 {E : Type*} [normed_group E] [complete_space E] [normed_space 𝕜 E]

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -15,7 +15,7 @@ variables {α : Type*} {β : Type*} {γ : Type*} {ι : Type*}
 
 noncomputable theory
 open filter metric
-local notation f `→_{`:50 a `}`:0 b := tendsto f (nhds a) (nhds b)
+localized "notation f `→_{`:50 a `}`:0 b := filter.tendsto f (_root_.nhds a) (_root_.nhds b)" in filter
 
 class has_norm (α : Type*) := (norm : α → ℝ)
 
@@ -492,7 +492,7 @@ instance fintype.normed_space {E : ι → Type*} [fintype ι] [∀i, normed_grou
 end normed_space
 
 section summable
-local attribute [instance] classical.prop_decidable
+open_locale classical
 open finset filter
 variables [normed_group α] [complete_space α]
 

--- a/src/analysis/normed_space/bounded_linear_maps.lean
+++ b/src/analysis/normed_space/bounded_linear_maps.lean
@@ -9,9 +9,7 @@ import algebra.field
 import analysis.normed_space.operator_norm
 
 noncomputable theory
-local attribute [instance] classical.prop_decidable
-
-local notation f ` →_{`:50 a `} `:0 b := filter.tendsto f (nhds a) (nhds b)
+open_locale classical filter
 
 open filter (tendsto)
 open metric

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -12,7 +12,7 @@ its basic properties. In particular, show that this space is itself a normed spa
 import topology.metric_space.lipschitz
 import analysis.asymptotics
 noncomputable theory
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 set_option class.instance_max_depth 70
 

--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -9,7 +9,7 @@ import analysis.normed_space.basic
 import topology.instances.ennreal
 
 noncomputable theory
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 open classical function lattice filter finset metric
 

--- a/src/category_theory/natural_isomorphism.lean
+++ b/src/category_theory/natural_isomorphism.lean
@@ -110,8 +110,8 @@ begin
   ext, rw [←nat_trans.exchange], simp, refl
 end
 omit ℰ
--- suggested local notation for nat_iso.hcomp. Currently unused.
-local infix ` ■ `:80 := hcomp
+-- declare local notation for nat_iso.hcomp
+localized "infix ` ■ `:80 := category_theory.nat_iso.hcomp" in category
 
 
 end nat_iso

--- a/src/computability/turing_machine.lean
+++ b/src/computability/turing_machine.lean
@@ -338,7 +338,7 @@ inductive stmt
   the tape head `a : Γ`, either halts (returns `none`) or returns
   a new state `q' : Λ` and a `stmt` describing what to do,
   either a move left or right, or a write command.
-  
+
   Both `Λ` and `Γ` are required to be inhabited; the default value
   for `Γ` is the "blank" tape value, and the default value of `Λ` is
   the initial state. -/
@@ -421,7 +421,7 @@ def machine.map : machine Γ' Λ'
 theorem machine.map_step {S} (ss : supports M S)
   [pointed_map f₁] (f₂₁ : function.right_inverse f₁ f₂)
   (g₂₁ : ∀ q ∈ S, g₂ (g₁ q) = q) :
-  ∀ c : cfg Γ Λ, c.q ∈ S → 
+  ∀ c : cfg Γ Λ, c.q ∈ S →
     (step M c).map (cfg.map f₁ g₁) =
     step (M.map f₁ f₂ g₁ g₂) (cfg.map f₁ g₁ c)
 | ⟨q, T⟩ h := begin
@@ -525,7 +525,7 @@ def supports_stmt (S : finset Λ) : stmt → Prop
 def supports (M : Λ → stmt) (S : finset Λ) :=
 default Λ ∈ S ∧ ∀ q ∈ S, supports_stmt S (M q)
 
-local attribute [instance] classical.dec
+open_locale classical
 noncomputable def stmts₁ : stmt → finset stmt
 | Q@(move d q)       := insert Q (stmts₁ q)
 | Q@(write a q)      := insert Q (stmts₁ q)
@@ -667,7 +667,7 @@ variables [fintype Γ] [fintype σ]
 noncomputable def tr_stmts (S : finset Λ) : finset Λ' :=
 (TM1.stmts M S).product finset.univ
 
-local attribute [instance] classical.dec
+open_locale classical
 local attribute [simp] TM1.stmts₁_self
 theorem tr_supports {S : finset Λ} (ss : TM1.supports M S) :
   TM0.supports tr (↑(tr_stmts S)) :=
@@ -976,7 +976,7 @@ fun_respects.2 $ λ ⟨l₁, v, (a, L, R)⟩, begin
     change (tape.mk' L R).1 with R.head,
     cases p R.head v; [apply IH₂, apply IH₁] },
   case TM1.stmt.goto : l {
-    simp only [tr_normal, step_aux_read enc dec enc0 encdec, step_aux], 
+    simp only [tr_normal, step_aux_read enc dec enc0 encdec, step_aux],
     apply refl_trans_gen.refl },
   case TM1.stmt.halt {
     simp only [tr_normal, step_aux, tr_cfg, step_aux_move enc enc0,
@@ -985,7 +985,7 @@ fun_respects.2 $ λ ⟨l₁, v, (a, L, R)⟩, begin
 end
 
 omit enc0 encdec
-local attribute [instance] classical.dec
+open_locale classical
 parameters [fintype Γ]
 noncomputable def writes : stmt₁ → finset Λ'
 | (stmt.move d q)       := writes q
@@ -1197,7 +1197,7 @@ def supports_stmt (S : finset Λ) : stmt → Prop
 def supports (M : Λ → stmt) (S : finset Λ) :=
 default Λ ∈ S ∧ ∀ q ∈ S, supports_stmt S (M q)
 
-local attribute [instance] classical.dec
+open_locale classical
 noncomputable def stmts₁ : stmt → finset stmt
 | Q@(push k f q)     := insert Q (stmts₁ q)
 | Q@(peek k f q)     := insert Q (stmts₁ q)
@@ -1304,11 +1304,11 @@ instance stackel.inhabited (k) : inhabited (stackel k) :=
 
 def stackel.is_bottom {k} : stackel k → bool
 | (stackel.bottom _) := tt
-| _ := ff 
+| _ := ff
 
 def stackel.is_top {k} : stackel k → bool
 | (stackel.top _) := tt
-| _ := ff 
+| _ := ff
 
 def stackel.get {k} : stackel k → option (Γ k)
 | (stackel.val a) := some a
@@ -1649,7 +1649,7 @@ begin
 end
 
 variables [fintype K] [∀ k, fintype (Γ k)] [fintype σ]
-local attribute [instance] classical.dec
+open_locale classical
 local attribute [simp] TM2.stmts₁_self
 
 noncomputable def tr_stmts₁ : stmt₂ → finset Λ'

--- a/src/data/analysis/topology.lean
+++ b/src/data/analysis/topology.lean
@@ -149,6 +149,8 @@ filter_eq $ set.ext $ λ x,
 ⟨λ ⟨⟨s, as⟩, h⟩, mem_nhds_sets_iff.2 ⟨_, h, F.is_open _, as⟩,
  λ h, let ⟨s, h, as⟩ := F.mem_nhds.1 h in ⟨⟨s, h⟩, as⟩⟩⟩
 
+local notation f `→_{`:50 a `}`:0 b := filter.tendsto f (nhds a) (nhds b)
+
 @[simp] theorem nhds_σ (m : α → β) (F : realizer α) (a : α) :
   (F.nhds a).σ = {s : F.σ // a ∈ F.F s} := rfl
 @[simp] theorem nhds_F (m : α → β) (F : realizer α) (a : α) (s) :

--- a/src/data/analysis/topology.lean
+++ b/src/data/analysis/topology.lean
@@ -149,8 +149,6 @@ filter_eq $ set.ext $ λ x,
 ⟨λ ⟨⟨s, as⟩, h⟩, mem_nhds_sets_iff.2 ⟨_, h, F.is_open _, as⟩,
  λ h, let ⟨s, h, as⟩ := F.mem_nhds.1 h in ⟨⟨s, h⟩, as⟩⟩⟩
 
-local notation f `→_{`:50 a `}`:0 b := filter.tendsto f (nhds a) (nhds b)
-
 @[simp] theorem nhds_σ (m : α → β) (F : realizer α) (a : α) :
   (F.nhds a).σ = {s : F.σ // a ∈ F.F s} := rfl
 @[simp] theorem nhds_F (m : α → β) (F : realizer α) (a : α) (s) :

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -7,9 +7,9 @@ import algebra.archimedean
 import data.nat.choose data.complex.basic
 import tactic.linarith
 
-local attribute [instance, priority 0] classical.prop_decidable
 local notation `abs'` := _root_.abs
 open is_absolute_value
+open_locale classical
 
 section
 open real is_absolute_value finset

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -4665,7 +4665,7 @@ namespace func
 variables {a : α}
 variables {as as1 as2 as3 : list α}
 
-local notation as ` {` m ` ↦ ` a `}` := set a as m
+localized "notation as ` {` m ` ↦ ` a `}` := list.func.set a as m" in list.func
 
 /- set -/
 

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -26,16 +26,18 @@ theorem ext_iff : (∀ i j, M i j = N i j) ↔ M = N :=
 @[extensionality] theorem ext : (∀ i j, M i j = N i j) → M = N :=
 ext_iff.mp
 
+end ext
+
 def transpose (M : matrix m n α) : matrix n m α
 | x y := M y x
+
+localized "postfix `ᵀ`:1500 := matrix.transpose" in matrix
 
 def col (w : m → α) : matrix m punit α
 | x y := w x
 
 def row (v : n → α) : matrix punit n α
 | x y := v y
-
-end ext
 
 instance [has_add α] : has_add (matrix m n α) := pi.has_add
 instance [add_semigroup α] : add_semigroup (matrix m n α) := pi.add_semigroup
@@ -96,7 +98,7 @@ protected def mul [has_mul α] [add_comm_monoid α] (M : matrix l m α) (N : mat
   matrix l n α :=
 λ i k, finset.univ.sum (λ j, M i j * N j k)
 
-local notation M `⬝` N := M.mul N
+localized "infixl ` ⬝ `:75 := matrix.mul" in matrix
 
 theorem mul_val [has_mul α] [add_comm_monoid α] {M : matrix l m α} {N : matrix m n α} {i k} :
   (M ⬝ N) i k = finset.univ.sum (λ j, M i j * N j k) := rfl
@@ -288,7 +290,7 @@ end semiring
 
 section transpose
 
-local postfix `ᵀ` : 1500 := transpose
+open_locale matrix
 
 @[simp] lemma transpose_transpose (M : matrix m n α) :
   Mᵀᵀ = M :=

--- a/src/data/matrix/pequiv.lean
+++ b/src/data/matrix/pequiv.lean
@@ -40,8 +40,7 @@ variables [fintype k] [fintype l] [fintype m] [fintype n]
 variables [decidable_eq k] [decidable_eq l] [decidable_eq m] [decidable_eq n]
 variables {α : Type v}
 
-local infix ` ⬝ `:70 := matrix.mul
-local postfix `ᵀ` : 1500 := transpose
+open_locale matrix
 
 /-- `to_matrix` returns a matrix containing ones and zeros. `f.to_matrix i j` is `1` if
   `f i = some j` and `0` otherwise -/

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -15,7 +15,7 @@ open list subtype nat lattice
 
 variables {α : Type*} {β : Type*} {γ : Type*}
 
-local infix ` • ` := add_monoid.smul
+open_locale add_monoid
 
 /-- `multiset α` is the quotient of `list α` by list permutation. The result
   is a type of finite sets with duplicates allowed.  -/

--- a/src/data/nat/totient.lean
+++ b/src/data/nat/totient.lean
@@ -11,7 +11,7 @@ namespace nat
 
 def totient (n : ℕ) : ℕ := ((range n).filter (nat.coprime n)).card
 
-local notation `φ` := totient
+localized "notation `φ` := nat.totient" in nat
 
 lemma totient_le (n : ℕ) : φ n ≤ n :=
 calc totient n ≤ (range n).card : card_le_of_subset (filter_subset _)

--- a/src/data/padics/hensel.lean
+++ b/src/data/padics/hensel.lean
@@ -31,7 +31,7 @@ p-adic, p adic, padic, p-adic integer
 
 noncomputable theory
 
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 -- We begin with some general lemmas that are used below in the computation.
 

--- a/src/data/padics/padic_integers.lean
+++ b/src/data/padics/padic_integers.lean
@@ -40,7 +40,7 @@ p-adic, p adic, padic, p-adic integer
 
 open nat padic metric
 noncomputable theory
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 /-- The p-adic integers ℤ_p are the p-adic numbers with norm ≤ 1. -/
 def padic_int (p : ℕ) [p.prime] := {x : ℚ_[p] // ∥x∥ ≤ 1}

--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -47,7 +47,7 @@ open nat
 
 attribute [class] nat.prime
 
-local infix `/.`:70 := rat.mk
+open_locale rat
 
 open multiplicity
 

--- a/src/data/padics/padic_numbers.lean
+++ b/src/data/padics/padic_numbers.lean
@@ -56,7 +56,7 @@ p-adic, p adic, padic, norm, valuation, cauchy, completion, p-adic completion
 -/
 
 noncomputable theory
-local attribute [instance, priority 1] classical.prop_decidable
+open_locale classical
 
 open nat multiplicity padic_norm cau_seq cau_seq.completion metric
 

--- a/src/data/pfun.lean
+++ b/src/data/pfun.lean
@@ -545,7 +545,7 @@ begin
 end
 
 section
-local attribute  [instance] classical.prop_decidable
+open_locale classical
 
 lemma core_res (f : α → β) (s : set α) (t : set β) : core (res f s) t = -s ∪ f ⁻¹' t :=
 by { ext, rw mem_core_res, by_cases h : x ∈ s; simp [h] }

--- a/src/data/polynomial.lean
+++ b/src/data/polynomial.lean
@@ -1588,7 +1588,7 @@ section multiplicity
 def decidable_dvd_monic (p : polynomial α) (hq : monic q) : decidable (q ∣ p) :=
 decidable_of_iff (p %ₘ q = 0) (dvd_iff_mod_by_monic_eq_zero hq)
 
-local attribute [instance, priority 0] classical.dec
+open_locale classical
 
 lemma multiplicity_X_sub_C_finite (a : α) (h0 : p ≠ 0) :
   multiplicity.finite (X - C a) p :=

--- a/src/data/rat/basic.lean
+++ b/src/data/rat/basic.lean
@@ -97,7 +97,7 @@ def mk : ℤ → ℤ → ℚ
 | n (int.of_nat d) := mk_nat n d
 | n -[1+ d]        := mk_pnat (-n) d.succ_pnat
 
-local infix ` /. `:70 := mk
+localized "infix ` /. `:70 := rat.mk" in rat
 
 theorem mk_pnat_eq (n d h) : mk_pnat n ⟨d, h⟩ = n /. d :=
 by change n /. d with dite _ _ _; simp [ne_of_gt h]

--- a/src/data/rat/cast.lean
+++ b/src/data/rat/cast.lean
@@ -23,7 +23,7 @@ rat, rationals, field, ℚ, numerator, denominator, num, denom, cast, coercion, 
 
 namespace rat
 variable {α : Type*}
-local infix ` /. `:70 := rat.mk
+open_locale rat
 
 section with_div_ring
 variable [division_ring α]

--- a/src/data/rat/order.lean
+++ b/src/data/rat/order.lean
@@ -23,7 +23,7 @@ rat, rationals, field, ℚ, numerator, denominator, num, denom, order, ordering,
 
 namespace rat
 variables (a b c : ℚ)
-local infix ` /. `:70 := rat.mk
+open_locale rat
 
 protected def nonneg : ℚ → Prop
 | ⟨n, d, h, c⟩ := n ≥ 0

--- a/src/data/real/basic.lean
+++ b/src/data/real/basic.lean
@@ -287,9 +287,13 @@ theorem Sup_le (S : set ℝ) (h₁ : ∃ x, x ∈ S) (h₂ : ∃ x, ∀ y ∈ S,
 by simp [Sup, h₁, h₂]; exact
 classical.some_spec (exists_sup S h₁ h₂) y
 
+section
+-- this proof times out without this
+local attribute [instance, priority 1000] classical.prop_decidable
 theorem lt_Sup (S : set ℝ) (h₁ : ∃ x, x ∈ S) (h₂ : ∃ x, ∀ y ∈ S, y ≤ x)
   {y} : y < Sup S ↔ ∃ z ∈ S, y < z :=
 by simpa [not_forall] using not_congr (@Sup_le S h₁ h₂ y)
+end
 
 theorem le_Sup (S : set ℝ) (h₂ : ∃ x, ∀ y ∈ S, y ≤ x) {x} (xS : x ∈ S) : x ≤ Sup S :=
 (Sup_le S ⟨_, xS⟩ h₂).1 (le_refl _) _ xS
@@ -315,9 +319,13 @@ begin
   { exact le_neg.2 (H _ hz) }
 end
 
+section
+-- this proof times out without this
+local attribute [instance, priority 1000] classical.prop_decidable
 theorem Inf_lt (S : set ℝ) (h₁ : ∃ x, x ∈ S) (h₂ : ∃ x, ∀ y ∈ S, x ≤ y)
   {y} : Inf S < y ↔ ∃ z ∈ S, z < y :=
 by simpa [not_forall] using not_congr (@le_Inf S h₁ h₂ y)
+end
 
 theorem Inf_le (S : set ℝ) (h₂ : ∃ x, ∀ y ∈ S, x ≤ y) {x} (xS : x ∈ S) : Inf S ≤ x :=
 (le_Inf S ⟨_, xS⟩ h₂).1 (le_refl _) _ xS

--- a/src/data/real/basic.lean
+++ b/src/data/real/basic.lean
@@ -122,7 +122,7 @@ instance : ordered_cancel_comm_monoid ℝ := by apply_instance
 instance : ordered_comm_monoid ℝ        := by apply_instance
 instance : domain ℝ                     := by apply_instance
 
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 noncomputable instance : discrete_linear_ordered_field ℝ :=
 { decidable_le := by apply_instance,

--- a/src/data/real/cau_seq_completion.lean
+++ b/src/data/real/cau_seq_completion.lean
@@ -83,7 +83,7 @@ congr_arg mk (const_sub _ _)
 
 end
 
-local attribute [instance] classical.prop_decidable
+open_locale classical
 section
 
 parameters {α : Type*} [discrete_linear_ordered_field α]

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -9,14 +9,14 @@ import data.real.nnreal order.bounds data.set.intervals tactic.norm_num
 noncomputable theory
 open classical set lattice
 
-local attribute [instance] prop_decidable
+open_locale classical
 variables {α : Type*} {β : Type*}
 
 /-- The extended nonnegative real numbers. This is usually denoted [0, ∞],
   and is relevant as the codomain of a measure. -/
 def ennreal := with_top nnreal
 
-local notation `∞` := (⊤ : ennreal)
+localized "notation `∞` := (⊤ : ennreal)" in ennreal
 
 namespace ennreal
 variables {a b c d : ennreal} {r p q : nnreal}

--- a/src/data/real/hyperreal.lean
+++ b/src/data/real/hyperreal.lean
@@ -7,11 +7,9 @@ Construction of the hyperreal numbers as an ultraproduct of real sequences.
 
 import data.real.basic algebra.field order.filter.filter_product analysis.specific_limits
 
-local attribute [instance] classical.prop_decidable
-
 open filter filter.filter_product
 
-open filter filter.filter_product
+local attribute [instance] classical.prop_decidable -- TODO: use "open_locale classical"
 
 /-- Hyperreal numbers on the ultrafilter extending the cofinite filter -/
 @[reducible] def hyperreal := filter.filterprod ℝ (@hyperfilter ℕ)
@@ -30,8 +28,8 @@ noncomputable def epsilon : ℝ* := of_seq (λ n, n⁻¹)
 /-- A sample infinite hyperreal-/
 noncomputable def omega : ℝ* := of_seq (λ n, n)
 
-local notation `ε` := epsilon
-local notation `ω` := omega
+localized "notation `ε` := hyperreal.epsilon" in hyperreal
+localized "notation `ω` := hyperreal.omega" in hyperreal
 
 lemma epsilon_eq_inv_omega : ε = ω⁻¹ := rfl
 

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -10,10 +10,10 @@ import data.real.basic order.lattice algebra.field
 noncomputable theory
 open lattice
 
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 def nnreal := {r : ℝ // 0 ≤ r}
-local notation ` ℝ≥0 ` := nnreal
+localized "notation ` ℝ≥0 ` := nnreal" in nnreal
 
 namespace nnreal
 

--- a/src/data/set/countable.lean
+++ b/src/data/set/countable.lean
@@ -12,7 +12,7 @@ noncomputable theory
 open function set encodable
 
 open classical (hiding some)
-local attribute [instance] prop_decidable
+open_locale classical
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
 

--- a/src/data/set/disjointed.lean
+++ b/src/data/set/disjointed.lean
@@ -7,7 +7,7 @@ Disjointed sets
 -/
 import data.set.lattice data.nat.basic tactic.wlog
 open set classical lattice
-local attribute [instance] prop_decidable
+open_locale classical
 
 universes u v w x
 variables {α : Type u} {β : Type v} {γ : Type w} {ι : Sort x}

--- a/src/field_theory/mv_polynomial.lean
+++ b/src/field_theory/mv_polynomial.lean
@@ -9,7 +9,7 @@ Multivariate functions of the form `α^n → α` are isomorphic to multivariate 
 import linear_algebra.finsupp_vector_space field_theory.finite data.mv_polynomial
 noncomputable theory
 
-local attribute [instance, priority 0] classical.prop_decidable
+open_locale classical
 
 open lattice set linear_map submodule
 
@@ -95,7 +95,7 @@ namespace mv_polynomial
 universe u
 variables (σ : Type u) (α : Type u) [decidable_eq σ] [discrete_field α]
 
-local attribute [instance, priority 0] classical.prop_decidable
+open_locale classical
 
 lemma dim_mv_polynomial : vector_space.dim α (mv_polynomial σ α) = cardinal.mk (σ →₀ ℕ) :=
 by rw [← cardinal.lift_inj, ← (is_basis_monomials σ α).mk_eq_dim]

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -19,7 +19,7 @@ variables {α : Type u} {β : Type v} {γ : Type w}
 namespace polynomial
 
 noncomputable theory
-local attribute [instance, priority 0] classical.prop_decidable
+open_locale classical
 variables [discrete_field α] [discrete_field β] [discrete_field γ]
 open polynomial
 

--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -14,10 +14,10 @@ def left_coset [has_mul α] (a : α) (s : set α) : set α := (λ x, a * x) '' s
 @[to_additive right_add_coset]
 def right_coset [has_mul α] (s : set α) (a : α) : set α := (λ x, x * a) '' s
 
-local infix ` *l `:70 := left_coset
-local infix ` +l `:70 := left_add_coset
-local infix ` *r `:70 := right_coset
-local infix ` +r `:70 := right_add_coset
+localized "infix ` *l `:70 := left_coset" in coset
+localized "infix ` +l `:70 := left_add_coset" in coset
+localized "infix ` *r `:70 := right_coset" in coset
+localized "infix ` +r `:70 := right_add_coset" in coset
 
 section coset_mul
 variable [has_mul α]

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -185,7 +185,7 @@ by rw [order_eq_card_gpowers, fintype.card_eq_one_iff];
 ⟨λ h, by conv { to_lhs, rw [← pow_one a, ← h, pow_order_of_eq_one] }, λ h, by simp [h]⟩
 
 section classical
-local attribute [instance] classical.prop_decidable
+open_locale classical
 open quotient_group
 
 /- TODO: use cardinal theory, introduce `card : set α → ℕ`, or setup decidability for cosets -/
@@ -374,7 +374,7 @@ le_antisymm
             pow_order_of_eq_one, one_gpow]⟩⟩) (λ _ _ h, subtype.eq (subtype.mk.inj h))
     ... = (univ.filter (λ b : α, b ^ order_of a = 1)).card : set.card_fintype_of_finset _ _)
 
-local notation `φ` := nat.totient
+open_locale nat -- use φ for nat.totient
 
 private lemma card_order_of_eq_totient_aux₁ :
   ∀ {d : ℕ}, d ∣ fintype.card α → 0 < (univ.filter (λ a : α, order_of a = d)).card →

--- a/src/linear_algebra/tensor_product.lean
+++ b/src/linear_algebra/tensor_product.lean
@@ -138,8 +138,8 @@ def tensor_product : Type* :=
 quotient_add_group.quotient (tensor_product.relators R M N)
 variables {R}
 
-local infix ` ⊗ `:100 := tensor_product _
-local notation M ` ⊗[`:100 R `] ` N:100 := tensor_product R M N
+localized "infix ` ⊗ `:100 := tensor_product _" in tensor_product
+localized "notation M ` ⊗[`:100 R `] ` N:100 := tensor_product R M N" in tensor_product
 
 namespace tensor_product
 

--- a/src/logic/function.lean
+++ b/src/logic/function.lean
@@ -88,7 +88,7 @@ theorem right_inverse.comp {γ} {f : α → β} {g : β → α} {h : β → γ} 
   (hf : right_inverse f g) (hh : right_inverse h i) : right_inverse (h ∘ f) (g ∘ i) :=
 left_inverse.comp hh hf
 
-local attribute [instance] classical.prop_decidable
+local attribute [instance, priority 1] classical.prop_decidable
 
 /-- We can use choice to construct explicitly a partial inverse for
   a given injective function `f`. -/
@@ -113,7 +113,7 @@ end
 section inv_fun
 variables {α : Type u} [inhabited α] {β : Sort v} {f : α → β} {s : set α} {a : α} {b : β}
 
-local attribute [instance] classical.prop_decidable
+local attribute [instance, priority 1] classical.prop_decidable
 
 /-- Construct the inverse for a function `f` on domain `s`. -/
 noncomputable def inv_fun_on (f : α → β) (s : set α) (b : β) : α :=

--- a/src/measure_theory/ae_eq_fun.lean
+++ b/src/measure_theory/ae_eq_fun.lean
@@ -10,7 +10,7 @@ We define almost everywhere equal functions, and show that
 import measure_theory.integration
 
 noncomputable theory
-local attribute [instance, priority 0] classical.prop_decidable
+open_locale classical
 
 namespace measure_theory
 open set lattice filter topological_space

--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -9,7 +9,7 @@ Bochner integral on real normed space
 import measure_theory.simple_func_dense
 
 noncomputable theory
-local attribute [instance, priority 0] classical.prop_decidable
+open_locale classical
 
 set_option class.instance_max_depth 100
 
@@ -27,7 +27,7 @@ def simple_func : Type* :=
 { f : α →₁ γ // ∃ (s : simple_func α γ) (hs : integrable s), mk s s.measurable hs = f}
 variables {α γ}
 
-local infixr ` →ₛ `:25 := simple_func
+local infixr ` →ₛ `:25 := measure_theory.l1.simple_func
 
 namespace simple_func
 open ae_eq_fun

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -18,7 +18,7 @@ import measure_theory.measurable_space topology.instances.ennreal analysis.norme
 noncomputable theory
 
 open classical set lattice real
-local attribute [instance] prop_decidable
+open_locale classical
 
 universes u v w x y
 variables {α : Type u} {β : Type v} {γ : Type w} {δ : Type x} {ι : Sort y} {s t u : set α}

--- a/src/measure_theory/decomposition.lean
+++ b/src/measure_theory/decomposition.lean
@@ -11,10 +11,10 @@ TODO:
 -/
 import measure_theory.measure_space
 
-local attribute [instance, priority 0] classical.prop_decidable
+open set lattice filter
+open_locale classical
 
 namespace measure_theory
-open set lattice filter
 
 variables {α : Type*} [measurable_space α] {μ ν : measure α}
 

--- a/src/measure_theory/giry_monad.lean
+++ b/src/measure_theory/giry_monad.lean
@@ -7,7 +7,7 @@ Giry monad: `measure` is a monad in the category of `measurable_space` and `meas
 -/
 import measure_theory.integration
 noncomputable theory
-local attribute [instance, priority 0] classical.prop_decidable
+open_locale classical
 
 open classical set lattice filter
 

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -14,7 +14,7 @@ import
   measure_theory.borel_space
 noncomputable theory
 open lattice set filter
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 section sequence_of_directed
 variables {α : Type*} {β : Type*} [encodable α] [inhabited α]
@@ -147,7 +147,8 @@ theorem map_map (g : β → γ) (h: γ → δ) (f : α →ₛ β) : (f.map g).ma
 
 theorem coe_map (g : β → γ) (f : α →ₛ β) : (f.map g : α → γ) = g ∘ f := rfl
 
-@[simp] theorem range_map (g : β → γ) (f : α →ₛ β) : (f.map g).range = f.range.image g :=
+@[simp] theorem range_map [decidable_eq γ] (g : β → γ) (f : α →ₛ β) :
+  (f.map g).range = f.range.image g :=
 begin
   ext c,
   simp [mem_range],

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -866,6 +866,9 @@ calc
         (h_mono n))
   ... = lintegral (f 0) - (⨅n, ∫⁻ a, f n a) : ennreal.sub_infi.symm
 
+section priority
+-- for some reason the next proof fails without changing the priority of this instance
+local attribute [instance, priority 1000] classical.prop_decidable
 /-- Known as Fatou's lemma -/
 lemma lintegral_liminf_le {f : ℕ → α → ennreal} (h_meas : ∀n, measurable (f n)) :
   (∫⁻ a, liminf at_top (λ n, f n a)) ≤ liminf at_top (λ n, lintegral (f n)) :=
@@ -888,6 +891,7 @@ calc
       assume i, le_infi $ assume hi, lintegral_le_lintegral _ _
       $ assume a, infi_le_of_le i $ infi_le_of_le hi $ le_refl _
   ... = liminf at_top (λ n, lintegral (f n)) : liminf_eq_supr_infi_of_nat.symm
+end priority
 
 lemma limsup_lintegral_le {f : ℕ → α → ennreal} {g : α → ennreal}
   (hf_meas : ∀ n, measurable (f n)) (hg_meas : measurable g)

--- a/src/measure_theory/l1_space.lean
+++ b/src/measure_theory/l1_space.lean
@@ -9,7 +9,7 @@ Integrable functions and L¹ space
 import measure_theory.ae_eq_fun
 
 noncomputable theory
-local attribute [instance, priority 0] classical.prop_decidable
+open_locale classical
 
 set_option class.instance_max_depth 100
 

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -7,7 +7,7 @@ Measurable spaces -- σ-algberas
 -/
 import data.set.disjointed order.galois_connection data.set.countable
 open set lattice encodable
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 universes u v w x
 variables {α : Type u} {β : Type v} {γ : Type w} {δ : Type x} {ι : Sort x}

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -23,7 +23,7 @@ import topology.instances.ennreal
 noncomputable theory
 
 open classical set lattice filter finset function
-local attribute [instance] prop_decidable
+open_locale classical
 
 universes u v w x
 

--- a/src/measure_theory/outer_measure.lean
+++ b/src/measure_theory/outer_measure.lean
@@ -13,7 +13,7 @@ import algebra.big_operators algebra.module
 noncomputable theory
 
 open set lattice finset function filter encodable
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 namespace measure_theory
 

--- a/src/measure_theory/probability_mass_function.lean
+++ b/src/measure_theory/probability_mass_function.lean
@@ -8,7 +8,7 @@ Probability mass function -- discrete probability measures
 import topology.instances.nnreal topology.instances.ennreal topology.algebra.infinite_sum
 noncomputable theory
 variables {α : Type*} {β : Type*} {γ : Type*}
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 /-- Probability mass functions, i.e. discrete probability measures -/
 def {u} pmf (α : Type u) : Type u := { f : α → nnreal // has_sum f 1 }

--- a/src/measure_theory/simple_func_dense.lean
+++ b/src/measure_theory/simple_func_dense.lean
@@ -13,6 +13,7 @@ noncomputable theory
 open lattice set filter topological_space
 open_locale classical
 
+
 universes u v
 variables {α : Type u} {β : Type v} {ι : Type*}
 
@@ -21,6 +22,7 @@ open ennreal nat metric
 open_locale measure_theory
 variables [measure_space α] [normed_group β] [second_countable_topology β]
 
+local infixr ` →ₛ `:25 := simple_func
 lemma simple_func_sequence_tendsto {f : α → β} (hf : measurable f) :
   ∃ (F : ℕ → (α →ₛ β)), ∀ x : α, tendsto (λ n, F n x) at_top (nhds (f x)) ∧
   ∀ n, ∥F n x∥ ≤ ∥f x∥ + ∥f x∥ :=

--- a/src/measure_theory/simple_func_dense.lean
+++ b/src/measure_theory/simple_func_dense.lean
@@ -11,16 +11,16 @@ import measure_theory.l1_space
 
 noncomputable theory
 open lattice set filter topological_space
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 universes u v
 variables {α : Type u} {β : Type v} {ι : Type*}
 
 namespace measure_theory
 open ennreal nat metric
+open_locale measure_theory
 variables [measure_space α] [normed_group β] [second_countable_topology β]
 
-local infixr ` →ₛ `:25 := simple_func
 lemma simple_func_sequence_tendsto {f : α → β} (hf : measurable f) :
   ∃ (F : ℕ → (α →ₛ β)), ∀ x : α, tendsto (λ n, F n x) at_top (nhds (f x)) ∧
   ∀ n, ∥F n x∥ ≤ ∥f x∥ + ∥f x∥ :=

--- a/src/number_theory/dioph.lean
+++ b/src/number_theory/dioph.lean
@@ -621,19 +621,19 @@ section
   by simp; exact ⟨proj_dioph none, (vector_allp_iff_forall _ _).2 $ λi,
     reindex_dioph_fn ((vector_allp_iff_forall _ _).1 dg _) _⟩
 
-  local notation x ` D∧ `:35 y := and_dioph x y
-  local notation x ` D∨ `:35 y := or_dioph x y
+  localized "notation x ` D∧ `:35 y := dioph.and_dioph x y" in dioph
+  localized "notation x ` D∨ `:35 y := dioph.or_dioph x y" in dioph
 
-  local notation `D∃`:30 := vec_ex1_dioph
+  localized "notation `D∃`:30 := dioph.vec_ex1_dioph" in dioph
 
-  local prefix `&`:max := of_nat'
+  localized "prefix `&`:max := of_nat'" in dioph
   theorem proj_dioph_of_nat {n : ℕ} (m : ℕ) [is_lt m n] : dioph_fn (λv : vector3 ℕ n, v &m) :=
   proj_dioph &m
-  local prefix `D&`:100 := proj_dioph_of_nat
+  localized "prefix `D&`:100 := dioph.proj_dioph_of_nat" in dioph
 
   theorem const_dioph (n : ℕ) : dioph_fn (const (α → ℕ) n) :=
   abs_poly_dioph (poly.const n)
-  local prefix `D.`:100 := const_dioph
+  localized "prefix `D.`:100 := dioph.const_dioph" in dioph
 
   variables {f g : (α → ℕ) → ℕ} (df : dioph_fn f) (dg : dioph_fn g)
   include df dg
@@ -650,26 +650,26 @@ section
   dioph_comp2 df dg $ of_no_dummies _ (poly.proj &0 - poly.proj &1)
     (λv, (int.coe_nat_eq_coe_nat_iff _ _).symm.trans
     ⟨@sub_eq_zero_of_eq ℤ _ (v &0) (v &1), eq_of_sub_eq_zero⟩)
-  local infix ` D= `:50 := eq_dioph
+  localized "infix ` D= `:50 := dioph.eq_dioph" in dioph
 
   theorem add_dioph : dioph_fn (λv, f v + g v) :=
   dioph_fn_comp2 df dg $ abs_poly_dioph (poly.proj &0 + poly.proj &1)
-  local infix ` D+ `:80 := add_dioph
+  localized "infix ` D+ `:80 := dioph.add_dioph" in dioph
 
   theorem mul_dioph : dioph_fn (λv, f v * g v) :=
   dioph_fn_comp2 df dg $ abs_poly_dioph (poly.proj &0 * poly.proj &1)
-  local infix ` D* `:90 := mul_dioph
+  localized "infix ` D* `:90 := dioph.mul_dioph" in dioph
 
   theorem le_dioph : dioph (λv, f v ≤ g v) :=
   dioph_comp2 df dg $ ext (D∃2 $ D&1 D+ D&0 D= D&2) (λv, ⟨λ⟨x, hx⟩, le.intro hx, le.dest⟩)
-  local infix ` D≤ `:50 := le_dioph
+  localized "infix ` D≤ `:50 := dioph.le_dioph" in dioph
 
   theorem lt_dioph : dioph (λv, f v < g v) := df D+ (D. 1) D≤ dg
-  local infix ` D< `:50 := lt_dioph
+  localized "infix ` D< `:50 := dioph.lt_dioph" in dioph
 
   theorem ne_dioph : dioph (λv, f v ≠ g v) :=
   ext (df D< dg D∨ dg D< df) $ λv, ne_iff_lt_or_gt.symm
-  local infix ` D≠ `:50 := ne_dioph
+  localized "infix ` D≠ `:50 := dioph.ne_dioph" in dioph
 
   theorem sub_dioph : dioph_fn (λv, f v - g v) :=
   dioph_fn_comp2 df dg $ (dioph_fn_vec _).2 $
@@ -685,11 +685,11 @@ section
     { exact or.inr ⟨yz, nat.sub_eq_zero_of_le yz⟩ },
     { exact or.inl (nat.sub_add_cancel zy).symm },
   end⟩
-  local infix ` D- `:80 := sub_dioph
+  localized "infix ` D- `:80 := dioph.sub_dioph" in dioph
 
   theorem dvd_dioph : dioph (λv, f v ∣ g v) :=
   dioph_comp (D∃2 $ D&2 D= D&1 D* D&0) [f, g] (by exact ⟨df, dg⟩)
-  local infix ` D∣ `:50 := dvd_dioph
+  localized "infix ` D∣ `:50 := dioph.dvd_dioph" in dioph
 
   theorem mod_dioph : dioph_fn (λv, f v % g v) :=
   have dioph (λv : vector3 ℕ 3, (v &2 = 0 ∨ v &0 < v &2) ∧ ∃ (x : ℕ), v &0 + v &2 * x = v &1),
@@ -698,11 +698,11 @@ section
   show ((y = 0 ∨ z < y) ∧ ∃ c, z + y * c = x) ↔ x % y = z, from
   ⟨λ⟨h, c, hc⟩, begin rw ← hc; simp; cases h with x0 hl, rw [x0, mod_zero], exact mod_eq_of_lt hl end,
   λe, by rw ← e; exact ⟨or_iff_not_imp_left.2 $ λh, mod_lt _ (nat.pos_of_ne_zero h), x / y, mod_add_div _ _⟩⟩
-  local infix ` D% `:80 := mod_dioph
+  localized "infix ` D% `:80 := dioph.mod_dioph" in dioph
 
   theorem modeq_dioph {h : (α → ℕ) → ℕ} (dh : dioph_fn h) : dioph (λv, f v ≡ g v [MOD h v]) :=
   df D% dh D= dg D% dh
-  local notation `D≡` := modeq_dioph
+  localized "notation `D≡` := dioph.modeq_dioph" in dioph
 
   theorem div_dioph : dioph_fn (λv, f v / g v) :=
   have dioph (λv : vector3 ℕ 3, v &2 = 0 ∧ v &0 = 0 ∨ v &0 * v &2 ≤ v &1 ∧ v &1 < (v &0 + 1) * v &2),
@@ -715,7 +715,7 @@ section
     (λypos, iff.trans ⟨λo, o.resolve_left $ λ⟨h1, _⟩, ne_of_gt ypos h1, or.inr⟩
       (le_antisymm_iff.trans $ and_congr (nat.le_div_iff_mul_le _ _ ypos) $
         iff.trans ⟨lt_succ_of_le, le_of_lt_succ⟩ (div_lt_iff_lt_mul _ _ ypos)).symm)
-  local infix ` D/ `:80 := div_dioph
+  localized "infix ` D/ `:80 := dioph.div_dioph" in dioph
 
   omit df dg
   open pell

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -503,7 +503,7 @@ protected def lt_sup {α} {r : α → α → Prop} (wf : well_founded r) {s : se
 min_mem wf { x | ∀a ∈ s, r a x } (ne_empty_iff_exists_mem.mpr h) x hx
 
 section
-local attribute [instance, priority 0] classical.prop_decidable
+open_locale classical
 protected noncomputable def succ {α} {r : α → α → Prop} (wf : well_founded r) (x : α) : α :=
 if h : ∃y, r x y then wf.min { y | r x y } (ne_empty_iff_exists_mem.mpr h) else x
 

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -596,7 +596,7 @@ end conditionally_complete_linear_order_bot
 
 section
 
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 noncomputable instance : has_Inf ℕ :=
 ⟨λs, if h : ∃n, n ∈ s then @nat.find (λn, n ∈ s) _ h else 0⟩
@@ -637,7 +637,7 @@ end lattice /-end of namespace lattice-/
 
 namespace with_top
 open lattice
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 variables [conditionally_complete_linear_order_bot α]
 

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -11,7 +11,7 @@ open lattice set
 
 universes u v w x y
 
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 namespace lattice
 variables {α : Type u} {ι : Sort v}

--- a/src/order/filter/filter_product.lean
+++ b/src/order/filter/filter_product.lean
@@ -10,7 +10,7 @@ import algebra.pi_instances
 
 universes u v
 variables {α : Type u} (β : Type v) (φ : filter α)
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 namespace filter
 

--- a/src/order/filter/lift.lean
+++ b/src/order/filter/lift.lean
@@ -9,7 +9,7 @@ import order.filter.basic
 
 open lattice set
 
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 namespace filter
 variables {α : Type*} {β : Type*} {γ : Type*} {ι : Sort*}

--- a/src/order/filter/pointwise.lean
+++ b/src/order/filter/pointwise.lean
@@ -17,7 +17,8 @@ open classical set lattice
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
 
-local attribute [instance] classical.prop_decidable pointwise_one pointwise_mul pointwise_add
+open_locale classical
+local attribute [instance] pointwise_one pointwise_mul pointwise_add
 
 namespace filter
 open set

--- a/src/order/zorn.lean
+++ b/src/order/zorn.lean
@@ -12,7 +12,7 @@ noncomputable theory
 
 universes u
 open set classical
-local attribute [instance] prop_decidable
+open_locale classical
 
 namespace zorn
 

--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -14,8 +14,7 @@ import ring_theory.subring
 universes u v w u₁ v₁
 
 open lattice
-
-local infix ` ⊗ `:100 := tensor_product
+open_locale tensor_product
 
 /-- The category of R-algebras where R is a commutative
 ring is the under category R ↓ CRing. In the categorical

--- a/src/ring_theory/euclidean_domain.lean
+++ b/src/ring_theory/euclidean_domain.lean
@@ -5,7 +5,7 @@ Authors: Mario Carneiro, Chris Hughes
 -/
 import algebra.associated algebra.euclidean_domain ring_theory.ideals
 noncomputable theory
-local attribute [instance] classical.dec
+open_locale classical
 open euclidean_domain set ideal
 
 theorem span_gcd {α} [euclidean_domain α] (x y : α) :

--- a/src/ring_theory/ideals.lean
+++ b/src/ring_theory/ideals.lean
@@ -9,7 +9,7 @@ universes u v
 variables {α : Type u} {β : Type v} {a b : α}
 open set function lattice
 
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 namespace ideal
 variables [comm_ring α] (I : ideal α)
@@ -511,4 +511,3 @@ instance : local_ring α :=
   else or.inl $ is_unit_of_mul_one a a⁻¹ $ div_self h }
 
 end discrete_field
-

--- a/src/ring_theory/multiplicity.lean
+++ b/src/ring_theory/multiplicity.lean
@@ -136,7 +136,7 @@ eq_some_iff.2 (by simpa)
 lemma eq_top_iff_not_finite {a b : α} : multiplicity a b = ⊤ ↔ ¬ finite a b :=
 roption.eq_none_iff'
 
-local attribute [instance, priority 0] classical.prop_decidable
+open_locale classical
 
 lemma multiplicity_le_multiplicity_iff {a b c d : α} : multiplicity a b ≤ multiplicity c d ↔
   (∀ n : ℕ, a ^ n ∣ b → c ^ n ∣ d) :=
@@ -201,7 +201,7 @@ section comm_ring
 
 variables [comm_ring α] [decidable_rel ((∣) : α → α → Prop)]
 
-local attribute [instance, priority 0] classical.prop_decidable
+open_locale classical
 
 @[simp] protected lemma neg (a b : α) : multiplicity a (-b) = multiplicity a b :=
 roption.ext' (by simp only [multiplicity]; conv in (_ ∣ - _) {rw dvd_neg})
@@ -322,7 +322,7 @@ have hsucc : ¬p ^ ((get (multiplicity p a) ((finite_mul_iff hp).1 h).1 +
 by rw [← enat.coe_inj, enat.coe_get, eq_some_iff];
   exact ⟨hdiv, hsucc⟩
 
-local attribute [instance, priority 0] classical.prop_decidable
+open_locale classical
 
 protected lemma mul {p a b : α} (hp : prime p) :
   multiplicity p (a * b) = multiplicity p a + multiplicity p b :=

--- a/src/ring_theory/principal_ideal_domain.lean
+++ b/src/ring_theory/principal_ideal_domain.lean
@@ -10,7 +10,7 @@ import ring_theory.ideals ring_theory.noetherian ring_theory.unique_factorizatio
 variables {α : Type*}
 
 open set function ideal
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 class ideal.is_principal [comm_ring α] (S : ideal α) : Prop :=
 (principal : ∃ a, S = span {a})
@@ -103,7 +103,7 @@ begin
 end⟩
 
 section
-local attribute [instance] classical.prop_decidable
+open_locale classical
 open submodule
 
 lemma factors_decreasing (b₁ b₂ : α) (h₁ : b₁ ≠ 0) (h₂ : ¬ is_unit b₂) :
@@ -136,7 +136,7 @@ associates.forall_associated.2 $ assume a,
 by rw [associates.irreducible_mk_iff, associates.prime_mk, irreducible_iff_prime]
 
 section
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 noncomputable def factors (a : α) : multiset α :=
 if h : a = 0 then ∅ else classical.some

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -32,7 +32,7 @@ cardinal number, cardinal arithmetic, cardinal exponentiation, omega
 -/
 
 open function lattice set
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 universes u v w x
 variables {α β : Type u}

--- a/src/set_theory/cofinality.lean
+++ b/src/set_theory/cofinality.lean
@@ -9,7 +9,7 @@ import set_theory.ordinal
 noncomputable theory
 
 open function cardinal set
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 universes u v w
 variables {α : Type*} {r : α → α → Prop}

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -11,7 +11,7 @@ import order.order_iso set_theory.cardinal data.sum
 noncomputable theory
 
 open function cardinal set
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 universes u v w
 variables {α : Type*} {β : Type*} {γ : Type*}
@@ -880,6 +880,8 @@ theorem lt_lift_iff {a : ordinal.{u}} {b : ordinal.{max u v}} :
 
 /-- `ω` is the first infinite ordinal, defined as the order type of `ℕ`. -/
 def omega : ordinal.{u} := lift $ @type ℕ (<) _
+
+localized "notation `ω` := ordinal.omega.{0}" in ordinal
 
 theorem card_omega : card omega = cardinal.omega := rfl
 

--- a/src/set_theory/ordinal_notation.lean
+++ b/src/set_theory/ordinal_notation.lean
@@ -7,8 +7,7 @@ Ordinal notations (constructive ordinal arithmetic for ordinals < ε₀).
 -/
 import set_theory.ordinal data.pnat.basic
 open ordinal
-
-local notation `ω` := omega.{0}
+open_locale ordinal -- get notation for `ω`
 
 /-- Recursive definition of an ordinal notation. `zero` denotes the
   ordinal 0, and `oadd e n a` is intended to refer to `ω^e * n + a`.

--- a/src/set_theory/schroeder_bernstein.lean
+++ b/src/set_theory/schroeder_bernstein.lean
@@ -8,7 +8,7 @@ The Schröder-Bernstein theorem, and well ordering of cardinals.
 import order.fixed_points data.set.lattice logic.function logic.embedding order.zorn
 
 open lattice set classical
-local attribute [instance] prop_decidable
+open_locale classical
 
 universes u v
 
@@ -129,4 +129,3 @@ end
 
 end embedding
 end function
-

--- a/src/tactic/basic.lean
+++ b/src/tactic/basic.lean
@@ -9,6 +9,7 @@ import
   tactic.interactive
   tactic.library_search
   tactic.lift
+  tactic.localized
   tactic.mk_iff_of_inductive_prop
   tactic.push_neg
   tactic.rcases

--- a/src/tactic/default.lean
+++ b/src/tactic/default.lean
@@ -23,8 +23,10 @@ import
   tactic.finish
   tactic.tauto
   tactic.tidy
-  tactic.abel tactic.ring
-  tactic.linarith tactic.omega
+  tactic.abel
+  tactic.ring
+  tactic.linarith
+  tactic.omega
   tactic.wlog
   tactic.tfae
   tactic.apply_fun

--- a/src/tactic/finish.lean
+++ b/src/tactic/finish.lean
@@ -111,7 +111,7 @@ variable  {α : Type u}
 variables (p q : Prop)
 variable  (s : α → Prop)
 
-local attribute [instance] classical.prop_decidable
+local attribute [instance, priority 1] classical.prop_decidable
 theorem not_not_eq : (¬ ¬ p) = p := propext not_not
 theorem not_and_eq : (¬ (p ∧ q)) = (¬ p ∨ ¬ q) := propext not_and_distrib
 theorem not_or_eq : (¬ (p ∨ q)) = (¬ p ∧ ¬ q) := propext not_or_distrib

--- a/src/tactic/localized.lean
+++ b/src/tactic/localized.lean
@@ -71,3 +71,6 @@ do cmds ← get_localized ns, cmds.mmap' trace
 
 -- you can run `open_locale classical` to get the decidability of all propositions.
 localized "attribute [instance, priority 1] classical.prop_decidable" in classical
+
+localized "postfix `?`:9001 := optional" in parser
+localized "postfix *:9001 := lean.parser.many" in parser

--- a/src/tactic/omega/coeffs.lean
+++ b/src/tactic/omega/coeffs.lean
@@ -76,7 +76,7 @@ lemma val_between_eq_val_between
     apply nat.le_add_right
   end
 
-local notation as ` {` m ` ↦ ` a `}` := set a as m
+open_locale list.func
 
 def val_between_set {a : int} {l n : nat} :
   ∀ {m}, l ≤ n → n < l + m → val_between v ([] {n ↦ a}) l m = a * v n
@@ -195,7 +195,7 @@ begin
             { apply le_max_right <|> apply le_max_left } } }
 end
 
-local notation v ` ⟨` m ` ↦ ` a `⟩` := update m a v
+open_locale omega
 
 lemma val_except_update_set
   {n : nat} {as : list int} {i j : int} :

--- a/src/tactic/omega/eq_elim.lean
+++ b/src/tactic/omega/eq_elim.lean
@@ -62,7 +62,7 @@ let a_n : int := get n as in
 let m : int := a_n + 1 in
 ((symmod b m) + (coeffs.val v (as.map (λ x, symmod x m)))) / m
 
-local notation as ` {` m ` ↦ ` a `}` := set a as m
+open_locale list.func
 
 def rhs : nat → int → list int → term
 | n b as :=
@@ -94,7 +94,7 @@ lemma rhs_correct_aux {v : nat → int} {m : int} {as : list int} :
       simp only [hk, list.length_map] }
   end
 
-local notation v ` ⟨` m ` ↦ ` a `⟩` := update m a v
+open_locale omega
 
 lemma rhs_correct {v : nat → int}
   {b : int} {as : list int} (n : nat) :

--- a/src/tactic/omega/int/dnf.lean
+++ b/src/tactic/omega/int/dnf.lean
@@ -12,11 +12,7 @@ import tactic.omega.int.form
 namespace omega
 namespace int
 
-local notation x ` =* ` y := form.eq x y
-local notation x ` ≤* ` y := form.le x y
-local notation `¬* ` p   := form.not p
-local notation p ` ∨* ` q := form.or p q
-local notation p ` ∧* ` q := form.and p q
+open_locale omega.int
 
 @[simp] def push_neg : form → form
 | (p ∨* q) := (push_neg p) ∧* (push_neg q)

--- a/src/tactic/omega/int/form.lean
+++ b/src/tactic/omega/int/form.lean
@@ -19,11 +19,11 @@ inductive form
 | or  : form → form → form
 | and : form → form → form
 
-local notation x ` =* ` y := form.eq x y
-local notation x ` ≤* ` y := form.le x y
-local notation `¬* ` p   := form.not p
-local notation p ` ∨* ` q := form.or p q
-local notation p ` ∧* ` q := form.and p q
+localized "notation x ` =* ` y := omega.int.form.eq x y" in omega.int
+localized "notation x ` ≤* ` y := omega.int.form.le x y" in omega.int
+localized "notation `¬* ` p   := omega.int.form.not p" in omega.int
+localized "notation p ` ∨* ` q := omega.int.form.or p q" in omega.int
+localized "notation p ` ∧* ` q := omega.int.form.and p q" in omega.int
 
 namespace form
 

--- a/src/tactic/omega/int/main.lean
+++ b/src/tactic/omega/int/main.lean
@@ -14,11 +14,7 @@ open tactic
 namespace omega
 namespace int
 
-local notation x ` =* ` y := form.eq x y
-local notation x ` ≤* ` y := form.le x y
-local notation `¬* ` p   := form.not p
-local notation p ` ∨* ` q := form.or p q
-local notation p ` ∧* ` q := form.and p q
+open_locale omega.int
 
 run_cmd mk_simp_attr `sugar
 attribute [sugar]

--- a/src/tactic/omega/int/preterm.lean
+++ b/src/tactic/omega/int/preterm.lean
@@ -17,9 +17,9 @@ inductive preterm : Type
 | var : int → nat → preterm
 | add : preterm → preterm → preterm
 
-local notation `&` k    := preterm.cst k
-local infix ` ** ` : 300 := preterm.var
-local notation t `+*` s := preterm.add t s
+localized "notation `&` k    := omega.int.preterm.cst k" in omega.int
+localized "infix ` ** ` : 300 := omega.int.preterm.var" in omega.int
+localized "notation t `+*` s := omega.int.preterm.add t s" in omega.int
 
 namespace preterm
 
@@ -47,7 +47,7 @@ def repr : preterm → string
 
 end preterm
 
-local notation as ` {` m ` ↦ ` a `}` := list.func.set a as m
+open_locale list.func -- get notation for list.func.set
 
 @[simp] def canonize : preterm → term
 | (& i)      := ⟨i, []⟩

--- a/src/tactic/omega/misc.lean
+++ b/src/tactic/omega/misc.lean
@@ -6,6 +6,8 @@ Author: Seul Baek
 Miscellaneous.
 -/
 
+import tactic.localized
+
 variables {α β γ : Type}
 
 namespace omega
@@ -25,7 +27,7 @@ lemma pred_mono_2' {c : Prop → Prop → Prop} {a1 a2 b1 b2 : Prop} :
 def update (m : nat) (a : α) (v : nat → α) : nat → α
 | n := if n = m then a else v n
 
-local notation v ` ⟨` m ` ↦ ` a `⟩` := update m a v
+localized "notation v ` ⟨` m ` ↦ ` a `⟩` := omega.update m a v" in omega
 
 lemma update_eq (m : nat) (a : α) (v : nat → α) : (v ⟨m ↦ a⟩) m = a :=
 by simp only [update, if_pos rfl]

--- a/src/tactic/omega/nat/dnf.lean
+++ b/src/tactic/omega/nat/dnf.lean
@@ -12,11 +12,7 @@ import tactic.omega.nat.form
 namespace omega
 namespace nat
 
-local notation x ` =* ` y := form.eq x y
-local notation x ` ≤* ` y := form.le x y
-local notation `¬* ` p   := form.not p
-local notation p ` ∨* ` q := form.or p q
-local notation p ` ∧* ` q := form.and p q
+open_locale omega.nat
 
 @[simp] def dnf_core : form → list clause
 | (p ∨* q) := (dnf_core p) ++ (dnf_core q)
@@ -78,7 +74,7 @@ def terms.vars : list term → list bool
 | []      := []
 | (t::ts) := bools.or (term.vars t) (terms.vars ts)
 
-local notation as ` {` m ` ↦ ` a `}` := list.func.set a as m
+open_locale list.func -- get notation for list.func.set
 
 def nonneg_consts_core : nat → list bool → list term
 | _ [] := []

--- a/src/tactic/omega/nat/form.lean
+++ b/src/tactic/omega/nat/form.lean
@@ -20,11 +20,11 @@ inductive form
 | or  : form → form → form
 | and : form → form → form
 
-local notation x ` =* ` y := form.eq x y
-local notation x ` ≤* ` y := form.le x y
-local notation `¬* ` p   := form.not p
-local notation p ` ∨* ` q := form.or p q
-local notation p ` ∧* ` q := form.and p q
+localized "notation x ` =* ` y := omega.nat.form.eq x y" in omega.nat
+localized "notation x ` ≤* ` y := omega.nat.form.le x y" in omega.nat
+localized "notation `¬* ` p   := omega.nat.form.not p" in omega.nat
+localized "notation p ` ∨* ` q := omega.nat.form.or p q" in omega.nat
+localized "notation p ` ∧* ` q := omega.nat.form.and p q" in omega.nat
 
 namespace form
 

--- a/src/tactic/omega/nat/main.lean
+++ b/src/tactic/omega/nat/main.lean
@@ -16,17 +16,7 @@ open tactic
 namespace omega
 namespace nat
 
-local notation `&` k    := preterm.cst k
-local infix ` ** ` : 300 := preterm.var
-local notation t ` +* ` s := preterm.add t s
-local notation t ` -* ` s := preterm.sub t s
-
-local notation x ` =* ` y := form.eq x y
-local notation x ` ≤* ` y := form.le x y
-local notation `¬* ` p   := form.not p
-local notation p ` ∨* ` q := form.or p q
-local notation p ` ∧* ` q := form.and p q
-
+open_locale omega.nat
 
 run_cmd mk_simp_attr `sugar_nat
 attribute [sugar_nat]

--- a/src/tactic/omega/nat/neg_elim.lean
+++ b/src/tactic/omega/nat/neg_elim.lean
@@ -11,11 +11,7 @@ import tactic.omega.nat.form
 namespace omega
 namespace nat
 
-local notation x ` =* ` y := form.eq x y
-local notation x ` ≤* ` y := form.le x y
-local notation `¬* ` p   := form.not p
-local notation p ` ∨* ` q := form.or p q
-local notation p ` ∧* ` q := form.and p q
+open_locale omega.nat
 
 @[simp] def push_neg : form → form
 | (p ∨* q) := (push_neg p) ∧* (push_neg q)

--- a/src/tactic/omega/nat/preterm.lean
+++ b/src/tactic/omega/nat/preterm.lean
@@ -20,10 +20,10 @@ inductive preterm : Type
 | add : preterm → preterm → preterm
 | sub : preterm → preterm → preterm
 
-local notation `&` k := preterm.cst k
-local infix ` ** ` : 300 := preterm.var
-local notation t ` +* ` s := preterm.add t s
-local notation t ` -* ` s := preterm.sub t s
+localized "notation `&` k := omega.nat.preterm.cst k" in omega.nat
+localized "infix ` ** ` : 300 := omega.nat.preterm.var" in omega.nat
+localized "notation t ` +* ` s := omega.nat.preterm.add t s" in omega.nat
+localized "notation t ` -* ` s := omega.nat.preterm.sub t s" in omega.nat
 
 namespace preterm
 
@@ -107,7 +107,7 @@ def sub_free : preterm → Prop
 
 end preterm
 
-local notation as ` {` m ` ↦ ` a `}` := list.func.set a as m
+open_locale list.func -- get notation for list.func.set
 
 @[simp] def canonize : preterm → term
 | (& m)    := ⟨↑m, []⟩

--- a/src/tactic/omega/nat/sub_elim.lean
+++ b/src/tactic/omega/nat/sub_elim.lean
@@ -13,16 +13,7 @@ import tactic.omega.nat.form
 namespace omega
 namespace nat
 
-local notation `&` k    := preterm.cst k
-local infix ` ** ` : 300 := preterm.var
-local notation t ` +* ` s := preterm.add t s
-local notation t ` -* ` s := preterm.sub t s
-
-local notation x ` =* ` y := form.eq x y
-local notation x ` ≤* ` y := form.le x y
-local notation `¬* ` p   := form.not p
-local notation p ` ∨* ` q := form.or p q
-local notation p ` ∧* ` q := form.and p q
+open_locale omega.nat
 
 namespace preterm
 

--- a/src/tactic/push_neg.lean
+++ b/src/tactic/push_neg.lean
@@ -21,7 +21,7 @@ variable  {α : Sort u}
 variables (p q : Prop)
 variable  (s : α → Prop)
 
-local attribute [instance] classical.prop_decidable
+local attribute [instance, priority 1] classical.prop_decidable
 theorem not_not_eq : (¬ ¬ p) = p := propext not_not
 theorem not_and_eq : (¬ (p ∧ q)) = (¬ p ∨ ¬ q) := propext not_and_distrib
 theorem not_or_eq : (¬ (p ∨ q)) = (¬ p ∧ ¬ q) := propext not_or_distrib

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -12,7 +12,7 @@ import group_theory.quotient_group
 import topology.algebra.monoid topology.order
 
 open classical set lattice filter topological_space
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -22,7 +22,7 @@ import logic.function algebra.big_operators data.set.lattice data.finset
 
 noncomputable theory
 open lattice finset filter function classical
-local attribute [instance] classical.prop_decidable -- warning: the priority of this instance is too high
+local attribute [instance] classical.prop_decidable -- TODO: use "open_locale classical"
 
 def option.cases_on' {α β} : option α → β → (α → β) → β
 | none     n s := n

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -22,7 +22,7 @@ import logic.function algebra.big_operators data.set.lattice data.finset
 
 noncomputable theory
 open lattice finset filter function classical
-local attribute [instance] prop_decidable
+local attribute [instance] classical.prop_decidable -- warning: the priority of this instance is too high
 
 def option.cases_on' {α β} : option α → β → (α → β) → β
 | none     n s := n

--- a/src/topology/algebra/monoid.lean
+++ b/src/topology/algebra/monoid.lean
@@ -12,7 +12,7 @@ import topology.constructions
 import algebra.pi_instances
 
 open classical set lattice filter topological_space
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -11,7 +11,7 @@ import topology.algebra.group
 import topology.constructions
 
 open classical set lattice filter topological_space
-local attribute [instance] classical.prop_decidable
+local attribute [instance] classical.prop_decidable -- warning: the priority of this instance is too high
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -11,7 +11,7 @@ import topology.algebra.group
 import topology.constructions
 
 open classical set lattice filter topological_space
-local attribute [instance] classical.prop_decidable -- warning: the priority of this instance is too high
+local attribute [instance] classical.prop_decidable -- TODO: use "open_locale classical"
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}

--- a/src/topology/algebra/ring.lean
+++ b/src/topology/algebra/ring.lean
@@ -9,7 +9,7 @@ Theory of topological rings.
 import topology.algebra.group ring_theory.ideals
 
 open classical set lattice filter topological_space
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 section topological_ring
 universes u v w

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -17,9 +17,7 @@ import topology.uniform_space.uniform_embedding topology.uniform_space.complete_
 import topology.algebra.group
 
 noncomputable theory
-local attribute [instance, priority 0] classical.prop_decidable
-
-local notation `𝓤` := uniformity
+open_locale classical uniformity
 
 section uniform_add_group
 open filter set

--- a/src/topology/algebra/uniform_ring.lean
+++ b/src/topology/algebra/uniform_ring.lean
@@ -9,7 +9,7 @@ Theory of topological rings with uniform structure.
 import topology.algebra.group_completion topology.algebra.ring
 
 open classical set lattice filter topological_space add_comm_group
-local attribute [instance] classical.prop_decidable
+open_locale classical
 noncomputable theory
 
 namespace uniform_space.completion

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -37,7 +37,7 @@ topological space, interior, closure, frontier, neighborhood, continuity, contin
 -/
 
 open set filter lattice classical
-local attribute [instance, priority 0] prop_decidable
+open_locale classical
 
 universes u v w
 

--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -9,7 +9,7 @@ import topology.maps topology.subset_properties topology.separation topology.bas
 noncomputable theory
 
 open set filter lattice
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*}
 

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -8,10 +8,10 @@ Extended non-negative reals
 import topology.instances.nnreal data.real.ennreal
 noncomputable theory
 open classical set lattice filter metric
-local attribute [instance] prop_decidable
+open_locale classical
 variables {α : Type*} {β : Type*} {γ : Type*}
 
-local notation `∞` := (⊤ : ennreal)
+open_locale ennreal
 
 namespace ennreal
 variables {a b c d : ennreal} {r p q : nnreal}

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -334,6 +334,9 @@ begin
     exact (finset.sum_le_sum $ assume a ha, hf a h) }
 end
 
+section priority
+-- for some reason the next proof fails without changing the priority of this instance
+local attribute [instance, priority 1000] classical.prop_decidable
 lemma mul_Sup {s : set ennreal} {a : ennreal} : a * Sup s = ⨆i∈s, a * i :=
 begin
   by_cases hs : ∀x∈s, x = (0:ennreal),
@@ -354,6 +357,7 @@ begin
         (ennreal.tendsto_mul_right (tendsto_id' inf_le_left) (or.inl s₁))),
     rw [this.symm, Sup_image] }
 end
+end priority
 
 lemma mul_supr {ι : Sort*} {f : ι → ennreal} {a : ennreal} : a * supr f = ⨆i, a * f i :=
 by rw [← Sup_range, mul_Sup, supr_range]

--- a/src/topology/instances/nnreal.lean
+++ b/src/topology/instances/nnreal.lean
@@ -10,7 +10,7 @@ noncomputable theory
 open set topological_space metric
 
 namespace nnreal
-local notation ` ℝ≥0 ` := nnreal
+open_locale nnreal
 
 instance : topological_space ℝ≥0 := infer_instance
 

--- a/src/topology/instances/real.lean
+++ b/src/topology/instances/real.lean
@@ -26,7 +26,7 @@ import topology.metric_space.basic topology.algebra.uniform_group
 
 noncomputable theory
 open classical set lattice filter topological_space metric
-local attribute [instance] prop_decidable
+open_locale classical
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}

--- a/src/topology/maps.lean
+++ b/src/topology/maps.lean
@@ -9,7 +9,7 @@ import topology.order topology.separation
 noncomputable theory
 
 open set filter lattice
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*}
 

--- a/src/topology/metric_space/baire.lean
+++ b/src/topology/metric_space/baire.lean
@@ -16,7 +16,7 @@ the statement. "Baire" is however in the docstring of all the theorems, to facil
 -/
 import topology.metric_space.basic analysis.specific_limits
 noncomputable theory
-local attribute [instance] classical.prop_decidable
+open_locale classical
 
 open filter lattice encodable set
 

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -13,7 +13,7 @@ import data.real.nnreal topology.metric_space.emetric_space topology.algebra.ord
 open lattice set filter classical topological_space
 noncomputable theory
 
-local notation `𝓤` := uniformity
+open_locale uniformity
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}

--- a/src/topology/metric_space/closeds.lean
+++ b/src/topology/metric_space/closeds.lean
@@ -16,7 +16,7 @@ always finite in this context.
 
 import topology.metric_space.hausdorff_distance topology.opens
 noncomputable theory
-local attribute [instance, priority 0] classical.prop_decidable
+open_locale classical
 
 universe u
 open classical lattice set function topological_space filter

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -21,7 +21,7 @@ import topology.uniform_space.separation topology.uniform_space.uniform_embeddin
 open lattice set filter classical
 noncomputable theory
 
-local notation `𝓤` := uniformity
+open_locale uniformity
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -31,7 +31,7 @@ topology.metric_space.completion
 
 
 noncomputable theory
-local attribute [instance, priority 0] classical.prop_decidable
+open_locale classical
 universes u v w
 
 open classical lattice set function topological_space filter metric quotient

--- a/src/topology/metric_space/gromov_hausdorff_realized.lean
+++ b/src/topology/metric_space/gromov_hausdorff_realized.lean
@@ -11,7 +11,7 @@ import topology.bounded_continuous_function topology.metric_space.gluing
 topology.metric_space.hausdorff_distance
 
 noncomputable theory
-local attribute [instance, priority 0] classical.prop_decidable
+open_locale classical
 universes u v w
 
 open classical lattice set function topological_space filter metric quotient

--- a/src/topology/metric_space/hausdorff_distance.lean
+++ b/src/topology/metric_space/hausdorff_distance.lean
@@ -17,7 +17,7 @@ This files introduces:
 import topology.metric_space.isometry topology.instances.ennreal
        topology.metric_space.lipschitz
 noncomputable theory
-local attribute [instance, priority 0] classical.prop_decidable
+open_locale classical
 universes u v w
 
 open classical lattice set function topological_space filter
@@ -25,7 +25,7 @@ open classical lattice set function topological_space filter
 namespace emetric
 
 section inf_edist
-local notation `∞` := (⊤ : ennreal)
+open_locale ennreal
 variables {α : Type u} {β : Type v} [emetric_space α] [emetric_space β] {x y : α} {s t : set α} {Φ : α → β}
 
 /-- The minimal edistance of a point to a set -/
@@ -145,7 +145,7 @@ lemma Hausdorff_edist_def {α : Type u} [emetric_space α] (s t : set α) :
 attribute [irreducible] Hausdorff_edist
 
 section Hausdorff_edist
-local notation `∞` := (⊤ : ennreal)
+open_locale ennreal
 variables {α : Type u} {β : Type v} [emetric_space α] [emetric_space β]
           {x y : α} {s t u : set α} {Φ : α → β}
 

--- a/src/topology/order.lean
+++ b/src/topology/order.lean
@@ -8,7 +8,7 @@ Order on topological structures. Lattice structure, Galois connection, and appli
 import topology.basic
 
 open set filter lattice classical
-local attribute [instance] prop_decidable
+open_locale classical
 
 universes u v w
 

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -9,7 +9,7 @@ Separation properties of topological spaces.
 import topology.order
 
 open set filter lattice
-local attribute [instance] classical.prop_decidable
+local attribute [instance] classical.prop_decidable -- warning: the priority of this instance is too high
 
 universes u v
 variables {α : Type u} {β : Type v} [topological_space α]

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -9,7 +9,7 @@ Separation properties of topological spaces.
 import topology.order
 
 open set filter lattice
-local attribute [instance] classical.prop_decidable -- warning: the priority of this instance is too high
+local attribute [instance] classical.prop_decidable -- TODO: use "open_locale classical"
 
 universes u v
 variables {α : Type u} {β : Type v} [topological_space α]

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -118,6 +118,9 @@ have ∀(x : α) (i : set α), i ∈ d → x ∈ i → (∃ (i : β), i ∈ f ''
   finite_image f hd₂,
   subset.trans hd₃ $ by simpa only [subset_def, mem_sUnion, exists_imp_distrib, mem_Union, exists_prop, and_imp]⟩
 
+section
+-- this proof times out without this
+local attribute [instance, priority 1000] classical.prop_decidable
 lemma compact_of_finite_subcover {s : set α}
   (h : ∀c, (∀t∈c, is_open t) → s ⊆ ⋃₀ c → ∃c'⊆c, finite c' ∧ s ⊆ ⋃₀ c') : compact s :=
 assume f hfn hfs, classical.by_contradiction $ assume : ¬ (∃x∈s, f ⊓ nhds x ≠ ⊥),
@@ -152,6 +155,7 @@ assume f hfn hfs, classical.by_contradiction $ assume : ¬ (∃x∈s, f ⊓ nhds
         ... ⊆ - - closure (b ⟨t, htc'⟩) : by rw lattice.neg_neg; exact subset.refl _),
     show false, from this hxt,
   hfn $ by rwa [empty_in_sets_eq_bot] at this
+end
 
 lemma compact_iff_finite_subcover {s : set α} :
   compact s ↔ (∀c, (∀t∈c, is_open t) → s ⊆ ⋃₀ c → ∃c'⊆c, finite c' ∧ s ⊆ ⋃₀ c') :=

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -10,7 +10,7 @@ connected, totally disconnected, totally separated.
 import topology.basic
 
 open set filter lattice classical
-local attribute [instance] prop_decidable
+open_locale classical
 
 universes u v
 variables {α : Type u} {β : Type v} [topological_space α]

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -27,7 +27,7 @@ A major difference is that this formalization is heavily based on the filter lib
 import order.filter.basic order.filter.lift topology.constructions
 
 open set lattice filter classical
-local attribute [instance, priority 0] prop_decidable
+open_locale classical
 
 set_option eqn_compiler.zeta true
 
@@ -152,7 +152,7 @@ variables [uniform_space α]
 def uniformity (α : Type u) [uniform_space α] : filter (α × α) :=
   (@uniform_space.to_core α _).uniformity
 
-local notation `𝓤` := uniformity
+localized "notation `𝓤` := uniformity" in uniformity
 
 lemma is_open_uniformity {s : set α} :
   is_open s ↔ (∀x∈s, { p : α × α | p.1 = x → p.2 ∈ s } ∈ 𝓤 α) :=
@@ -463,7 +463,7 @@ calc map f (nhds a) ≤
 end uniform_space
 end
 
-local notation `𝓤` := uniformity
+open_locale uniformity
 
 section constructions
 variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*} {ι : Sort*}

--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -8,11 +8,11 @@ Theory of Cauchy filters in uniform spaces. Complete uniform spaces. Totally bou
 import topology.uniform_space.basic
 
 open filter topological_space lattice set classical
-local attribute [instance, priority 0] prop_decidable
+open_locale classical
 variables {α : Type*} {β : Type*} [uniform_space α]
 universe u
 
-local notation `𝓤` := uniformity
+open_locale uniformity
 
 /-- A filter `f` is Cauchy if for every entourage `r`, there exists an
   `s ∈ f` such that `s × s ⊆ r`. This is a generalization of Cauchy

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -38,11 +38,10 @@ import data.set.basic
 import topology.uniform_space.uniform_embedding topology.uniform_space.separation
 
 noncomputable theory
-local attribute [instance] classical.prop_decidable
 open filter set
 universes u v w x
 
-local notation `𝓤` := uniformity
+open_locale uniformity classical
 
 /-- Space of Cauchy filters
 

--- a/src/topology/uniform_space/pi.lean
+++ b/src/topology/uniform_space/pi.lean
@@ -10,7 +10,7 @@ import topology.uniform_space.cauchy
 import topology.uniform_space.separation
 noncomputable theory
 
-local notation `𝓤` := uniformity
+open_locale uniformity
 
 section
 open filter lattice uniform_space

--- a/src/topology/uniform_space/separation.lean
+++ b/src/topology/uniform_space/separation.lean
@@ -8,7 +8,7 @@ Hausdorff properties of uniform spaces. Separation quotient.
 import topology.uniform_space.basic
 
 open filter topological_space lattice set classical
-local attribute [instance, priority 0] prop_decidable
+open_locale classical
 noncomputable theory
 set_option eqn_compiler.zeta true
 
@@ -16,7 +16,7 @@ universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
 variables [uniform_space α] [uniform_space β] [uniform_space γ]
 
-local notation `𝓤` := uniformity
+open_locale uniformity
 
 /- separated uniformity -/
 

--- a/src/topology/uniform_space/uniform_embedding.lean
+++ b/src/topology/uniform_space/uniform_embedding.lean
@@ -8,8 +8,8 @@ Uniform embeddings of uniform spaces. Extension of uniform continuous functions.
 import topology.uniform_space.cauchy topology.uniform_space.separation
 
 open filter topological_space lattice set classical
-local attribute [instance, priority 0] prop_decidable
-local notation `𝓤` := uniformity
+open_locale classical
+open_locale uniformity
 
 section
 variables {α : Type*} {β : Type*} {γ : Type*}


### PR DESCRIPTION
Use the `localized` and `open_locale` commands throughout mathlib.

There might still be some errors.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
