### PR TITLE
refactor(data/list/min_max): use with_top for maximum and define argmax

### DIFF
--- a/src/data/equiv/denumerable.lean
+++ b/src/data/equiv/denumerable.lean
@@ -166,7 +166,7 @@ lemma of_nat_surjective_aux : ∀ {x : ℕ} (hx : x ∈ s), ∃ n, of_nat s n = 
   (λ (y : ℕ) (hy : y ∈ s), ⟨y, hy⟩) (by simp) in
 have hmt : ∀ {y : s}, y ∈ t ↔ y < ⟨x, hx⟩,
   by simp [list.mem_filter, subtype.ext, t]; intros; refl,
-have wf : ∀ m : s, m ∈ list.maximum t → m.1 < x,
+have wf : ∀ m : s, list.maximum t = m → m.1 < x,
   from λ m hmax, by simpa [hmt] using list.maximum_mem hmax,
 begin
   cases hmax : list.maximum t with m,

--- a/src/data/equiv/denumerable.lean
+++ b/src/data/equiv/denumerable.lean
@@ -166,16 +166,20 @@ lemma of_nat_surjective_aux : ∀ {x : ℕ} (hx : x ∈ s), ∃ n, of_nat s n = 
   (λ (y : ℕ) (hy : y ∈ s), ⟨y, hy⟩) (by simp) in
 have hmt : ∀ {y : s}, y ∈ t ↔ y < ⟨x, hx⟩,
   by simp [list.mem_filter, subtype.ext, t]; intros; refl,
-if ht : t = [] then ⟨0, le_antisymm (@bot_le s _ _)
-  (le_of_not_gt (λ h, list.not_mem_nil ⊥ $
-    by rw [← ht, hmt]; exact h))⟩
-else by letI : inhabited s := ⟨⊥⟩;
-  exact have wf : (list.maximum t).1 < x, by simpa [hmt] using list.maximum_mem ht,
-  let ⟨a, ha⟩ := of_nat_surjective_aux (list.maximum t).2 in
-  ⟨a + 1, le_antisymm
-    (by rw of_nat; exact succ_le_of_lt (by rw ha; exact wf)) $
-    by rw of_nat; exact le_succ_of_forall_lt_le
-      (λ z hz, by rw ha; exact list.le_maximum_of_mem (hmt.2 hz))⟩
+have wf : ∀ m : s, m ∈ list.maximum t → m.1 < x,
+  from λ m hmax, by simpa [hmt] using list.maximum_mem hmax,
+begin
+  cases hmax : list.maximum t with m,
+  { exact ⟨0, le_antisymm (@bot_le s _ _)
+      (le_of_not_gt (λ h, list.not_mem_nil (⊥ : s) $
+        by rw [← list.maximum_eq_none.1 hmax, hmt]; exact h))⟩ },
+  { cases of_nat_surjective_aux m.2 with a ha,
+    exact ⟨a + 1, le_antisymm
+      (by rw of_nat; exact succ_le_of_lt (by rw ha; exact wf _ hmax)) $
+      by rw of_nat; exact le_succ_of_forall_lt_le
+        (λ z hz, by rw ha; cases m; exact list.le_maximum_of_mem (hmt.2 hz) hmax)⟩ }
+end
+using_well_founded {dec_tac := `[tauto]}
 
 lemma of_nat_surjective : surjective (of_nat s) :=
 λ ⟨x, hx⟩, of_nat_surjective_aux hx

--- a/src/data/list/min_max.lean
+++ b/src/data/list/min_max.lean
@@ -15,7 +15,8 @@ The main definition are `argmax`, `argmin`, `minimum` and `maximum` for lists.
   `f a = f b`, it returns whichever of `a` or `b` comes first in the list.
   `argmax f []` = none`
 
-`minimum l` returns the smallest element of `l`. `minimum [] = none`
+`minimum l` returns an `with_top α`, the smallest element of `l` for nonempty lists, and `⊤` for
+`[]`
 -/
 namespace list
 variables {α : Type*} {β : Type*} [decidable_linear_order β]
@@ -194,10 +195,12 @@ theorem argmin_eq_some_iff [decidable_eq α] {f : α → β} {m : α} {l : list 
 
 variable [decidable_linear_order α]
 
-/-- `maximum l` returns the largest element of `l`. `maximum [] = default α` -/
+/-- `maximum l` returns an `with_bot α`, the largest element of `l` for nonempty lists, and `⊥` for
+`[]`  -/
 def maximum (l : list α) : with_bot α := argmax id l
 
-/-- `minimum l` returns the smallest element of `l`. `minimum [] = default α` -/
+/-- `minimum l` returns an `with_top α`, the smallest element of `l` for nonempty lists, and `⊤` for
+`[]`  -/
 def minimum (l : list α) : with_top α := argmin id l
 
 @[simp] lemma maximum_nil : maximum ([] : list α) = ⊥ := rfl

--- a/src/data/list/min_max.lean
+++ b/src/data/list/min_max.lean
@@ -45,8 +45,7 @@ if_pos (le_refl _)
 
 @[simp] lemma argmax_singleton {f : α → β} {a : α} : argmax f [a] = some a := rfl
 
-@[simp] lemma argmin_singleton {f : α → β} {a : α} : argmin f [a] = a :=
-@argmax_singleton _ (order_dual β) _ _ _
+@[simp] lemma argmin_singleton {f : α → β} {a : α} : argmin f [a] = a := rfl
 
 @[simp] lemma foldl_argmax₂_eq_none {f : α → β} {l : list α} {o : option α} :
   l.foldl (argmax₂ f) o = none ↔ l = [] ∧ o = none :=
@@ -204,6 +203,10 @@ def minimum (l : list α) : option α := argmin id l
 @[simp] lemma maximum_nil : maximum ([] : list α) = none := rfl
 
 @[simp] lemma minimum_nil : minimum ([] : list α) = none := rfl
+
+@[simp] lemma maximum_singleton (a : α) : maximum [a] = some a := rfl
+
+@[simp] lemma minimum_singleton (a : α) : minimum [a] = some a := rfl
 
 theorem maximum_mem {l : list α} {m : α} : m ∈ maximum l → m ∈ l := argmax_mem
 

--- a/src/tactic/omega/find_scalars.lean
+++ b/src/tactic/omega/find_scalars.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Seul Baek. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Seul Baek
 
-A tactic which performs Fourier–Motzkin elimination to find 
+A tactic which performs Fourier–Motzkin elimination to find
 a contradictory linear combination of input constraints.
 -/
 
@@ -54,7 +54,7 @@ meta def find_scalars_core : nat → list (list nat × term) → tactic (list na
 
 meta def find_scalars (ts : list term) : tactic (list nat) :=
 find_scalars_core
-  (ts.map (λ t : term, t.snd.length)).maximum
+  (ts.map (λ t : term, t.snd.length)).maximum.iget
   (ts.map_with_index (λ m t, (list.func.set 1 [] m, t)))
 
 end omega


### PR DESCRIPTION
I define `argmin` and `argmax` returning optional values, and also redefine `minimum` and `maximum` in terms of `argmin` and `argmax`. 

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
