### PR TITLE
feat(tactic/finish): parse ematch lemmas with `finish using ...`

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -163,7 +163,7 @@ they are only meant to be used on small, straightforward problems.
 * safe:    splits freely, finishes off whatever subgoals it can, and leaves the rest
 
 All accept an optional list of simplifier rules, typically definitions that should be expanded.
-(The equations and identities should not refer to the local context.)
+(The equations and identities should not refer to the local context.) All also accept an optional list of `ematch` lemmas, which must be preceded by `using`.
 
 ### ring
 

--- a/test/finish4.lean
+++ b/test/finish4.lean
@@ -6,7 +6,7 @@ Author(s): Jesse Michael Han
 Tests for `finish using [...]`
 -/
 
-import tactic.finish order.boolean_algebra
+import tactic.finish
 
 section list_rev
 open list
@@ -23,9 +23,11 @@ def rev : list α → list α
 lemma hd_rev (a : α) (l : list α) :
   a :: rev l =  rev (append1 a l) :=
 begin
-  induction l, refl,
+  induction l with l_hd l_tl ih, refl,
   -- finish -- fails
-  -- finish[rev, length_rev, append1, length_append1] -- fails
+  -- finish[rev, append1] -- fails
+  -- finish[rev, append1, ih] -- fails
+  -- finish[rev, append1, ih.symm] -- times out
   finish using [rev, append1]
 end
 

--- a/test/finish4.lean
+++ b/test/finish4.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2019 Jesse Michael Han. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Jesse Michael Han 
+
+Tests for `finish using [...]`
+-/
+
+import tactic.finish order.boolean_algebra
+
+section list_rev
+open list
+variable {α : Type*}
+
+def append1 (a : α) : list α → list α 
+| nil      := [a]
+| (b :: l) := b :: (append1 l)
+
+def rev : list α → list α
+| nil := nil
+| (a :: l) := append1 a (rev l)
+
+lemma hd_rev (a : α) (l : list α) :
+  a :: rev l =  rev (append1 a l) :=
+begin
+  induction l, refl,
+  -- finish -- fails
+  -- finish[rev, length_rev, append1, length_append1] -- fails
+  finish using [rev, append1]
+end
+
+end list_rev
+
+section barber
+variables (man : Type) (barber : man)
+variable  (shaves : man → man → Prop)
+
+example (h : ∀ x : man, shaves barber x ↔ ¬ shaves x x) : false :=
+by finish using [h barber]
+
+end barber
+
+constant real : Type
+@[instance] constant  orreal : ordered_ring real
+constants (log exp : real → real)
+constant  log_exp_eq : ∀ x, log (exp x) = x
+constant  exp_log_eq : ∀ {x}, x > 0 → exp (log x) = x
+constant  exp_pos    : ∀ x, exp x > 0
+constant  exp_add    : ∀ x y, exp (x + y) = exp x * exp y
+
+theorem log_mul' {x y : real} (hx : x > 0) (hy : y > 0) :
+  log (x * y) = log x + log y :=
+by finish using [log_exp_eq, exp_log_eq, exp_add]


### PR DESCRIPTION
This extends `finish` with the ability to parse a list of `ematch` lemmas preceded by the token "using" after optionally parsing a list of `simp` lemmas, e.g. `finish[h1,...,hn] using [e1,...,en]`.

It is currently not convenient to have many `ematch` lemmas in the environment, because `ematch` will become quite slow. However, it is sometimes desirable to e.g. allow the ematching part of `finish` to use certain lemmas for just one goal without affecting the speed of other calls to `finish`, and `finish using ...` allows the user to do this.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
