### PR TITLE
feat(tactic/obtain): make type argument optional

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -113,6 +113,10 @@ rcases h with ⟨patt⟩
 
  The syntax `obtain ⟨patt⟩ : type := proof` is also supported.
 
+ If `⟨patt⟩` is omitted, `rcases` will try to infer the pattern.
+
+ If `type` is omitted, `:= proof` is required.
+
 
 ### simpa
 

--- a/src/tactic/rcases.lean
+++ b/src/tactic/rcases.lean
@@ -470,8 +470,7 @@ do nm ← mk_fresh_name,
    gs ← get_goals,
    set_goals (g::gs)
 | (pat, some tp, some val) :=
-do e ← to_expr ``(%%val : %%tp) >>= note_anon,
-   tactic.rcases ``(%%e) $ rcases_patt_inverted.invert_list (pat.get_or_else [default _])
+  tactic.rcases ``(%%val : %%tp) $ rcases_patt_inverted.invert_list (pat.get_or_else [default _])
 
 end interactive
 end tactic

--- a/test/rcases.lean
+++ b/test/rcases.lean
@@ -91,3 +91,17 @@ begin
   guard_hyp h := true,
   trivial
 end
+
+example : true :=
+begin
+  obtain ⟨h, h2⟩ := and.intro trivial trivial,
+  guard_hyp h := true,
+  guard_hyp h2 := true,
+  trivial
+end
+
+example : true :=
+begin
+  success_if_fail {obtain ⟨h, h2⟩},
+  trivial
+end


### PR DESCRIPTION
https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/obtain/near/173183243

`obtain ⟨h, h2⟩ := and.intro trivial trivial` is equivalent to `rcases and.intro trivial trivial with ⟨h, h2⟩`, but I think there's no reason not to support it with `obtain` as well.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
