### PR TITLE
refactor(data/fintype): shorten proof of card_eq

### DIFF
--- a/src/data/fintype.lean
+++ b/src/data/fintype.lean
@@ -161,24 +161,11 @@ theorem card_congr {α β} [fintype α] [fintype β] (f : α ≃ β) : card α =
 by rw ← of_equiv_card f; congr
 
 theorem card_eq {α β} [F : fintype α] [G : fintype β] : card α = card β ↔ nonempty (α ≃ β) :=
-⟨λ e, match F, G, e with ⟨⟨s, nd⟩, h⟩, ⟨⟨s', nd'⟩, h'⟩, e' := begin
-  change multiset.card s = multiset.card s' at e',
-  revert nd nd' h h' e',
-  refine quotient.induction_on₂ s s' (λ l₁ l₂
-    (nd₁ : l₁.nodup) (nd₂ : l₂.nodup)
-    (h₁ : ∀ x, x ∈ l₁) (h₂ : ∀ x, x ∈ l₂)
-    (e' : l₁.length = l₂.length), _),
-  haveI := classical.dec_eq α,
-  refine ⟨equiv.of_bijective ⟨_, _⟩⟩,
-  { refine λ a, l₂.nth_le (l₁.index_of a) _,
-    rw ← e', exact list.index_of_lt_length.2 (h₁ a) },
-  { intros a b h, simpa [h₁] using congr_arg l₁.nth
-      (list.nodup_iff_nth_le_inj.1 nd₂ _ _ _ _ h) },
-  { have := classical.dec_eq β,
-    refine λ b, ⟨l₁.nth_le (l₂.index_of b) _, _⟩,
-    { rw e', exact list.index_of_lt_length.2 (h₂ b) },
-    { simp [nd₁] } }
-end end, λ ⟨f⟩, card_congr f⟩
+⟨λ h, ⟨by classical; 
+  calc α ≃ fin (card α) : trunc.out (equiv_fin α)
+     ... ≃ fin (card β) : by rw h
+     ... ≃ β : (trunc.out (equiv_fin β)).symm⟩, 
+λ ⟨f⟩, card_congr f⟩
 
 def of_subsingleton (a : α) [subsingleton α] : fintype α :=
 ⟨finset.singleton a, λ b, finset.mem_singleton.2 (subsingleton.elim _ _)⟩


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
