### PR TITLE
feat(algebra,equiv,logic): add various lemmas

### DIFF
--- a/src/algebra/order_functions.lean
+++ b/src/algebra/order_functions.lean
@@ -163,6 +163,25 @@ lemma min_sub {α : Type u} [decidable_linear_ordered_comm_group α] (a b c : α
       min a b - c = min (a - c) (b - c) :=
 by simp [min_add, sub_eq_add_neg]
 
+
+/- Some lemmas about types that have an ordering and a binary operation, with no
+  rules relating them. -/
+lemma fn_min_add_fn_max [decidable_linear_order α] [add_comm_semigroup β] (f : α → β) (n m : α) :
+  f (min n m) + f (max n m) = f n + f m :=
+by { cases le_total n m with h h; simp [h] }
+
+lemma min_add_max [decidable_linear_order α] [add_comm_semigroup α] (n m : α) :
+  min n m + max n m = n + m :=
+fn_min_add_fn_max id n m
+
+lemma fn_min_mul_fn_max [decidable_linear_order α] [comm_semigroup β] (f : α → β) (n m : α) :
+  f (min n m) * f (max n m) = f n * f m :=
+by { cases le_total n m with h h; simp [h, mul_comm] }
+
+lemma min_mul_max [decidable_linear_order α] [comm_semigroup α] (n m : α) :
+  min n m * max n m = n * m :=
+fn_min_mul_fn_max id n m
+
 section decidable_linear_ordered_comm_group
 variables [decidable_linear_ordered_comm_group α] {a b c : α}
 

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -205,6 +205,16 @@ lt_of_not_ge (λ ha, absurd h (not_lt_of_ge (mul_nonneg_of_nonpos_of_nonpos ha h
 lemma pos_of_mul_neg_right {a b : α} (h : a * b < 0) (ha : a ≤ 0) : 0 < b :=
 lt_of_not_ge (λ hb, absurd h (not_lt_of_ge (mul_nonneg_of_nonpos_of_nonpos ha hb)))
 
+/- The sum of two squares is zero iff both elements are zero. -/
+lemma mul_self_add_mul_self_eq_zero {x y : α} : x * x + y * y = 0 ↔ x = 0 ∧ y = 0 :=
+begin
+  split; intro h, swap, { rcases h with ⟨rfl, rfl⟩, simp },
+  have : y * y ≤ 0, { rw [← h], apply le_add_of_nonneg_left (mul_self_nonneg x) },
+  have : y * y = 0 := le_antisymm this (mul_self_nonneg y),
+  have hx : x = 0, { rwa [this, add_zero, mul_self_eq_zero] at h },
+  rw mul_self_eq_zero at this, split; assumption
+end
+
 end linear_ordered_ring
 
 set_option old_structure_cmd true

--- a/src/algebra/ring.lean
+++ b/src/algebra/ring.lean
@@ -228,6 +228,17 @@ section comm_ring
   theorem dvd_add_right {a b c : α} (h : a ∣ b) : a ∣ b + c ↔ a ∣ c :=
   (dvd_add_iff_right h).symm
 
+/-- Vieta's formula for a quadratic equation, relating the coefficients of the polynomial with
+  its roots. This particular version states that if we have a root `x` of a monic quadratic
+  polynomial, then there is another root `y` such that `x + y` is negative the `a_1` coefficient
+  and `x * y` is the `a_0` coefficient. -/
+lemma Vieta_formula_quadratic {b c x : α} (h : x * x - b * x + c = 0) :
+  ∃ y : α, y * y - b * y + c = 0 ∧ x + y = b ∧ x * y = c :=
+begin
+  have : c = b * x - x * x, { apply eq_of_sub_eq_zero, simpa using h },
+  use b - x, simp [left_distrib, mul_comm, this],
+end
+
 end comm_ring
 
 /-- Predicate for ring homomorphisms (deprecated -- use the bundled `semiring_hom` version). -/
@@ -405,6 +416,9 @@ section domain
 
   @[simp] theorem zero_eq_mul {a b : α} : 0 = a * b ↔ a = 0 ∨ b = 0 :=
   by rw [eq_comm, mul_eq_zero]
+
+  lemma mul_self_eq_zero {α} [domain α] {x : α} : x * x = 0 ↔ x = 0 := by simp
+  lemma zero_eq_mul_self {α} [domain α] {x : α} : 0 = x * x ↔ x = 0 := by simp
 
 /-- The product of two nonzero elements of a domain is nonzero. -/
   theorem mul_ne_zero' {a b : α} (h₁ : a ≠ 0) (h₂ : b ≠ 0) : a * b ≠ 0 :=

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -569,6 +569,16 @@ def subtype_subtype_equiv_subtype {α : Type u} (p : α → Prop) (q : subtype p
   λ⟨a, ha⟩, ⟨⟨a, ha.cases_on $ assume h _, h⟩, by { cases ha, exact ha_h }⟩,
   assume ⟨⟨a, ha⟩, h⟩, rfl, assume ⟨a, h₁, h₂⟩, rfl⟩
 
+/- A subtype of a sigma-type is a sigma-type over a subtype. -/
+def sigma_subtype {α : Type u} (p : α → Type v) (q : α → Prop) :
+  { y : sigma p // q y.1 } ≃ Σ(x : subtype q), p x.1 :=
+begin
+  fsplit,
+  rintro ⟨⟨x, y⟩, z⟩, exact ⟨⟨x, z⟩, y⟩,
+  rintro ⟨⟨x, y⟩, z⟩, exact ⟨⟨x, z⟩, y⟩,
+  rintro ⟨⟨x, y⟩, z⟩, refl,
+  rintro ⟨⟨x, y⟩, z⟩, refl,
+end
 /-- aka coimage -/
 def equiv_sigma_subtype {α : Type u} {β : Type v} (f : α → β) : α ≃ Σ b, {x : α // f x = b} :=
 ⟨λ x, ⟨f x, x, rfl⟩, λ x, x.2.1, λ x, rfl, λ ⟨b, x, H⟩, sigma.eq H $ eq.drec_on H $ subtype.eq rfl⟩

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -570,7 +570,7 @@ def subtype_subtype_equiv_subtype {α : Type u} (p : α → Prop) (q : subtype p
   assume ⟨⟨a, ha⟩, h⟩, rfl, assume ⟨a, h₁, h₂⟩, rfl⟩
 
 /- A subtype of a sigma-type is a sigma-type over a subtype. -/
-def sigma_subtype {α : Type u} (p : α → Type v) (q : α → Prop) :
+def subtype_sigma_equiv {α : Type u} (p : α → Type v) (q : α → Prop) :
   { y : sigma p // q y.1 } ≃ Σ(x : subtype q), p x.1 :=
 begin
   fsplit,
@@ -579,6 +579,7 @@ begin
   rintro ⟨⟨x, y⟩, z⟩, refl,
   rintro ⟨⟨x, y⟩, z⟩, refl,
 end
+
 /-- aka coimage -/
 def equiv_sigma_subtype {α : Type u} {β : Type v} (f : α → β) : α ≃ Σ b, {x : α // f x = b} :=
 ⟨λ x, ⟨f x, x, rfl⟩, λ x, x.2.1, λ x, rfl, λ ⟨b, x, H⟩, sigma.eq H $ eq.drec_on H $ subtype.eq rfl⟩

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -4499,7 +4499,7 @@ section tfae
 /- tfae: The Following (propositions) Are Equivalent -/
 
 theorem tfae_nil : tfae [] := forall_mem_nil _
-theorem tfae_singleton (p) : tfae [p] := by simp [tfae]
+theorem tfae_singleton (p) : tfae [p] := by simp [tfae, -eq_iff_iff]
 
 theorem tfae_cons_of_mem {a b} {l : list Prop} (h : b ∈ l) :
   tfae (a::l) ↔ (a ↔ b) ∧ tfae l :=

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -92,6 +92,8 @@ theorem iff_of_eq (e : a = b) : a ↔ b := e ▸ iff.rfl
 
 theorem iff_iff_eq : (a ↔ b) ↔ a = b := ⟨propext, iff_of_eq⟩
 
+@[simp] lemma eq_iff_iff {p q : Prop} : (p = q) ↔ (p ↔ q) := iff_iff_eq.symm
+
 @[simp] theorem imp_self : (a → a) ↔ true := iff_true_intro id
 
 theorem imp_intro {α β} (h : α) (h₂ : β) : α := h

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -376,6 +376,9 @@ protected lemma eq.congr {x₁ x₂ y₁ y₂ : α} (h₁ : x₁ = y₁) (h₂ :
   (x₁ = x₂) ↔ (y₁ = y₂) :=
 by { subst h₁, subst h₂ }
 
+lemma eq.congr_left {x y z : α} (h : x = y) : x = z ↔ y = z := by rw [h]
+lemma eq.congr_right {x y z : α} (h : x = y) : z = x ↔ z = y := by rw [h]
+
 lemma congr_arg2 {α β γ : Type*} (f : α → β → γ) {x x' : α} {y y' : β}
   (hx : x = x') (hy : y = y') : f x y = f x' y' :=
 by { subst hx, subst hy }


### PR DESCRIPTION
These lemmas mostly come from the solution to IMO 1988-6.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
