### PR TITLE
feat(conv/conv): conv tactics for zooming/saving state

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -694,8 +694,9 @@ additionally provides
    * `norm_num`, and
    * `conv` (within another `conv`).
 Using `conv` inside a `conv` block allows the user to return to the previous
-state of an outer `conv` block to continue editing an expression without
-having to start a new `conv` block. For example:
+state of the outer `conv` block after it is finished. Thus you can continue
+editing an expression without having to start a new `conv` block and re-scoping
+everything. For example:
 ```lean
 example (a b c d : ℕ) (h₁ : b = c) (h₂ : a + c = a + d) : a + b = a + d :=
 by conv {
@@ -707,10 +708,10 @@ by conv {
   rw h₂,
 }
 ```
-Without `conv` the above example would need to be proved using two successive `conv` blocks.
+Without `conv` the above example would need to be proved using two successive
+`conv` blocks each beginning with `to_lhs`.
 
-Also, as a shorthand `conv_lhs` and `conv_rhs`
-are provided, so that
+Also, as a shorthand `conv_lhs` and `conv_rhs` are provided, so that
 ```lean
 example : 0 + 0 = 0 :=
 begin

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -708,6 +708,24 @@ end
 ```
 and likewise for `to_rhs`.
 
+### conv
+
+The `conv` tactic provides a `conv` within a `conv`. It allows the user to return to a previous state of the outer `conv` block to continue editing an expression without having to start a new `conv` block. For example:
+
+```lean
+example (a b c d : ℕ) (h₁ : b = c) (h₂ : a + c = a + d) : a + b = a + d :=
+by conv {
+  to_lhs,
+  conv {
+    congr, skip,
+    rw h₁,
+  },
+  rw h₂,
+}
+```
+
+Without `conv` the above example would need to be proved using two successive `conv` blocks.
+
 ### mono
 
 - `mono` applies a monotonicity rule.

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -687,31 +687,15 @@ end
 after `fin_cases p; simp`, there are three goals, `f 0`, `f 1`, and `f 2`.
 
 ### conv
-The `conv` tactic is built-in to lean. Currently mathlib additionally provides
+The `conv` tactic is built-in to lean. Inside `conv` blocks mathlib currently
+additionally provides
    * `erw`,
-   * `ring` and `ring2`, and
-   * `norm_num`
-inside `conv` blocks. Also, as a shorthand `conv_lhs` and `conv_rhs`
-are provided, so that
-```
-example : 0 + 0 = 0 :=
-begin
-  conv_lhs {simp}
-end
-```
-just means
-```
-example : 0 + 0 = 0 :=
-begin
-  conv {to_lhs, simp}
-end
-```
-and likewise for `to_rhs`.
-
-### conv
-
-The `conv` tactic provides a `conv` within a `conv`. It allows the user to return to a previous state of the outer `conv` block to continue editing an expression without having to start a new `conv` block. For example:
-
+   * `ring` and `ring2`,
+   * `norm_num`, and
+   * `conv` (within another `conv`).
+Using `conv` inside a `conv` block allows the user to return to the previous
+state of an outer `conv` block to continue editing an expression without
+having to start a new `conv` block. For example:
 ```lean
 example (a b c d : ℕ) (h₁ : b = c) (h₂ : a + c = a + d) : a + b = a + d :=
 by conv {
@@ -723,8 +707,24 @@ by conv {
   rw h₂,
 }
 ```
-
 Without `conv` the above example would need to be proved using two successive `conv` blocks.
+
+Also, as a shorthand `conv_lhs` and `conv_rhs`
+are provided, so that
+```lean
+example : 0 + 0 = 0 :=
+begin
+  conv_lhs { simp }
+end
+```
+just means
+```lean
+example : 0 + 0 = 0 :=
+begin
+  conv { to_lhs, simp }
+end
+```
+and likewise for `to_rhs`.
 
 ### mono
 

--- a/src/tactic/converter/interactive.lean
+++ b/src/tactic/converter/interactive.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Leonardo de Moura, Keeley Hoek
+Authors: Lucas Allen, Keeley Hoek, Leonardo de Moura
 
 Converter monad for building simplifiers.
 -/
@@ -87,6 +87,17 @@ do pf ← lock_tactic_state (do m ← lhs >>= mk_meta_var,
 namespace interactive
 open interactive
 open tactic.interactive (rw_rules)
+
+/-- The `conv` tactic provides a `conv` within a `conv`. It allows the user to return to a
+previous state of the outer conv block to continue editing an expression without having to
+start a new conv block. -/
+protected meta def conv (t : conv.interactive.itactic) : conv unit :=
+do transitivity,
+   a :: rest ← get_goals,
+   set_goals [a],
+   t,
+   all_goals reflexivity,
+   set_goals rest
 
 meta def erw (q : parse rw_rules) (cfg : rewrite_cfg := {md := semireducible}) : conv unit :=
 rw q cfg

--- a/test/conv/conv.lean
+++ b/test/conv/conv.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2019 Lucas Allen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Lucas Allen
+
+Tests for the `conv` tactic inside the inveractive `conv` monad
+-/
+
+import tactic.converter.interactive
+
+example (a b c d : ℕ) (h₁ : b = c) (h₂ : a + c = a + d) : a + b = a + d :=
+begin
+conv {     --| a + b = a + d
+  --Conv to the left hand side
+  to_lhs,  -- | a + b
+  --Zoom into the left hand side.
+  conv {   -- | a + b
+    congr, -- two goals: | a and | b
+    skip,  -- | b
+    rw h₁, -- | c
+  },       -- | a + c
+  --At this point, to get back to this position, without zoom, we would need to close
+  --this conv block, and open a new one.
+  rw h₂,   -- | a + d
+},         -- goals accomplished
+end
+
+example : 1 + (5 * 8) - (3 * 14) + (4 * 99 - 45) - 350 = 1 :=
+begin
+  have h₁ : 5 * 8 = 40, from dec_trivial,
+  have h₂ : 3 * 14 = 42, from dec_trivial,
+  have h₃ : 4 * 99 - 45 = 351, from dec_trivial,
+  conv {
+    to_lhs,    -- conv to the left hand side
+    conv {     -- zooming in to rewrite 4 * 99 - 45 to 351
+      congr, congr, skip,
+      rw h₃,
+    },         -- returning to the left hand side, note we don't need to open a new conv block
+    conv {     -- zooming in to rewrite 3 * 14 to 42
+      congr, congr, congr, skip,
+      rw h₂,
+    },         -- returning to the left hand side
+    conv {     -- zooming in to rewrite 5 * 8 to 40
+      congr, congr, congr, congr, skip,
+      rw h₁,
+    },         -- returning to the left hand side
+  },
+end


### PR DESCRIPTION
By @u6338192's request, just the `conv` zooming functionality of #1270. (Which is now renamed.)

<br>
<br>

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
