### PR TITLE
refactor: change field notation from k to \bbk

### DIFF
--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -5,8 +5,8 @@ Authors: Jeremy Avigad, Sébastien Gouëzel
 
 The Fréchet derivative.
 
-Let `E` and `F` be normed spaces, `f : E → F`, and `f' : E →L[k] F` a
-continuous k-linear map, where `k` is a non-discrete normed field. Then
+Let `E` and `F` be normed spaces, `f : E → F`, and `f' : E →L[𝕂] F` a
+continuous 𝕂-linear map, where `𝕂` is a non-discrete normed field. Then
 
   `has_fderiv_within_at f f' s x`
 
@@ -18,12 +18,12 @@ is restricted to `s`. We also have
 The derivative is defined in terms of the `is_o` relation, but also
 characterized in terms of the `tendsto` relation.
 
-We also introduce predicates `differentiable_within_at k f s x` (where `k` is the base field,
+We also introduce predicates `differentiable_within_at 𝕂 f s x` (where `𝕂` is the base field,
 `f` the function to be differentiated, `x` the point at which the derivative is asserted to exist,
-and `s` the set along which the derivative is defined), as well as `differentiable_at k f x`,
-`differentiable_on k f s` and `differentiable k f` to express the existence of a derivative.
+and `s` the set along which the derivative is defined), as well as `differentiable_at 𝕂 f x`,
+`differentiable_on 𝕂 f s` and `differentiable 𝕂 f` to express the existence of a derivative.
 
-To be able to compute with derivatives, we write `fderiv_within k f s x` and `fderiv k f x`
+To be able to compute with derivatives, we write `fderiv_within 𝕂 f s x` and `fderiv 𝕂 f x`
 for some choice of a derivative if it exists, and the zero function otherwise. This choice only
 behaves well along sets for which the derivative is unique, i.e., those for which the tangent
 directions span a dense subset of the whole space. The predicates `unique_diff_within_at s x` and
@@ -59,43 +59,43 @@ set_option class.instance_max_depth 90
 
 section
 
-variables {k : Type*} [nondiscrete_normed_field k]
-variables {E : Type*} [normed_group E] [normed_space k E]
-variables {F : Type*} [normed_group F] [normed_space k F]
-variables {G : Type*} [normed_group G] [normed_space k G]
+variables {𝕂 : Type*} [nondiscrete_normed_field 𝕂]
+variables {E : Type*} [normed_group E] [normed_space 𝕂 E]
+variables {F : Type*} [normed_group F] [normed_space 𝕂 F]
+variables {G : Type*} [normed_group G] [normed_space 𝕂 G]
 
-def has_fderiv_at_filter (f : E → F) (f' : E →L[k] F) (x : E) (L : filter E) :=
+def has_fderiv_at_filter (f : E → F) (f' : E →L[𝕂] F) (x : E) (L : filter E) :=
 is_o (λ x', f x' - f x - f' (x' - x)) (λ x', x' - x) L
 
-def has_fderiv_within_at (f : E → F) (f' : E →L[k] F) (s : set E) (x : E) :=
+def has_fderiv_within_at (f : E → F) (f' : E →L[𝕂] F) (s : set E) (x : E) :=
 has_fderiv_at_filter f f' x (nhds_within x s)
 
-def has_fderiv_at (f : E → F) (f' : E →L[k] F) (x : E) :=
+def has_fderiv_at (f : E → F) (f' : E →L[𝕂] F) (x : E) :=
 has_fderiv_at_filter f f' x (nhds x)
 
-variables (k)
+variables (𝕂)
 
 def differentiable_within_at (f : E → F) (s : set E) (x : E) :=
-∃f' : E →L[k] F, has_fderiv_within_at f f' s x
+∃f' : E →L[𝕂] F, has_fderiv_within_at f f' s x
 
 def differentiable_at (f : E → F) (x : E) :=
-∃f' : E →L[k] F, has_fderiv_at f f' x
+∃f' : E →L[𝕂] F, has_fderiv_at f f' x
 
-def fderiv_within (f : E → F) (s : set E) (x : E) : E →L[k] F :=
+def fderiv_within (f : E → F) (s : set E) (x : E) : E →L[𝕂] F :=
 if h : ∃f', has_fderiv_within_at f f' s x then classical.some h else 0
 
-def fderiv (f : E → F) (x : E) : E →L[k] F :=
+def fderiv (f : E → F) (x : E) : E →L[𝕂] F :=
 if h : ∃f', has_fderiv_at f f' x then classical.some h else 0
 
 def differentiable_on (f : E → F) (s : set E) :=
-∀x ∈ s, differentiable_within_at k f s x
+∀x ∈ s, differentiable_within_at 𝕂 f s x
 
 def differentiable (f : E → F) :=
-∀x, differentiable_at k f x
+∀x, differentiable_at 𝕂 f x
 
-variables {k}
+variables {𝕂}
 variables {f f₀ f₁ g : E → F}
-variables {f' f₀' f₁' g' : E →L[k] F}
+variables {f' f₀' f₁' g' : E →L[𝕂] F}
 variables {x : E}
 variables {s t : set E}
 variables {L L₁ L₂ : filter E}
@@ -107,10 +107,10 @@ We prove that the definitions `unique_diff_within_at` and `unique_diff_on` indee
 uniqueness of the derivative. -/
 
 /-- `unique_diff_within_at` achieves its goal: it implies the uniqueness of the derivative. -/
-theorem unique_diff_within_at.eq (H : unique_diff_within_at k s x)
+theorem unique_diff_within_at.eq (H : unique_diff_within_at 𝕂 s x)
   (h : has_fderiv_within_at f f' s x) (h₁ : has_fderiv_within_at f f₁' s x) : f' = f₁' :=
 begin
-  have A : ∀y ∈ tangent_cone_at k s x, f' y = f₁' y,
+  have A : ∀y ∈ tangent_cone_at 𝕂 s x, f' y = f₁' y,
   { assume y hy,
     rcases hy with ⟨c, d, hd, hc, ylim⟩,
     have at_top_is_finer : at_top ≤ comap (λ (n : ℕ), x + d n) (nhds_within (x + 0) s),
@@ -138,18 +138,18 @@ begin
       apply tendsto_sub ((f₁'.continuous.tendsto _).comp ylim) ((f'.continuous.tendsto _).comp ylim) },
     have : f₁' y - f' y = 0 := tendsto_nhds_unique (by simp) L' L,
     exact (sub_eq_zero_iff_eq.1 this).symm },
-  have B : ∀y ∈ submodule.span k (tangent_cone_at k s x), f' y = f₁' y,
+  have B : ∀y ∈ submodule.span 𝕂 (tangent_cone_at 𝕂 s x), f' y = f₁' y,
   { assume y hy,
     apply submodule.span_induction hy,
     { exact λy hy, A y hy },
     { simp only [continuous_linear_map.map_zero] },
     { simp {contextual := tt} },
     { simp {contextual := tt} } },
-  have C : ∀y ∈ closure ((submodule.span k (tangent_cone_at k s x)) : set E), f' y = f₁' y,
+  have C : ∀y ∈ closure ((submodule.span 𝕂 (tangent_cone_at 𝕂 s x)) : set E), f' y = f₁' y,
   { assume y hy,
     let K := {y | f' y = f₁' y},
-    have : (submodule.span k (tangent_cone_at k s x) : set E) ⊆ K := B,
-    have : closure (submodule.span k (tangent_cone_at k s x) : set E) ⊆ closure K :=
+    have : (submodule.span 𝕂 (tangent_cone_at 𝕂 s x) : set E) ⊆ K := B,
+    have : closure (submodule.span 𝕂 (tangent_cone_at 𝕂 s x) : set E) ⊆ closure K :=
       closure_mono this,
     have : y ∈ closure K := this hy,
     rwa closure_eq_of_is_closed (is_closed_eq f'.continuous f₁'.continuous) at this },
@@ -158,7 +158,7 @@ begin
   exact C y (mem_univ _)
 end
 
-theorem unique_diff_on.eq (H : unique_diff_on k s) (hx : x ∈ s)
+theorem unique_diff_on.eq (H : unique_diff_on 𝕂 s) (hx : x ∈ s)
   (h : has_fderiv_within_at f f' s x) (h₁ : has_fderiv_within_at f f₁' s x) : f' = f₁' :=
 unique_diff_within_at.eq (H x hx) h h₁
 
@@ -203,10 +203,10 @@ theorem has_fderiv_at.has_fderiv_within_at
 h.has_fderiv_at_filter lattice.inf_le_left
 
 lemma has_fderiv_within_at.differentiable_within_at (h : has_fderiv_within_at f f' s x) :
-  differentiable_within_at k f s x :=
+  differentiable_within_at 𝕂 f s x :=
 ⟨f', h⟩
 
-lemma has_fderiv_at.differentiable_at (h : has_fderiv_at f f' x) : differentiable_at k f x :=
+lemma has_fderiv_at.differentiable_at (h : has_fderiv_at f f' x) : differentiable_at 𝕂 f x :=
 ⟨f', h⟩
 
 @[simp] lemma has_fderiv_within_at_univ :
@@ -228,8 +228,8 @@ lemma has_fderiv_within_at_inter (h : t ∈ nhds x) :
   has_fderiv_within_at f f' (s ∩ t) x ↔ has_fderiv_within_at f f' s x :=
 by simp [has_fderiv_within_at, nhds_within_restrict' s h]
 
-lemma differentiable_within_at.has_fderiv_within_at (h : differentiable_within_at k f s x) :
-  has_fderiv_within_at f (fderiv_within k f s x) s x :=
+lemma differentiable_within_at.has_fderiv_within_at (h : differentiable_within_at 𝕂 f s x) :
+  has_fderiv_within_at f (fderiv_within 𝕂 f s x) s x :=
 begin
   dunfold fderiv_within,
   dunfold differentiable_within_at at h,
@@ -237,8 +237,8 @@ begin
   exact classical.some_spec h
 end
 
-lemma differentiable_at.has_fderiv_at (h : differentiable_at k f x) :
-  has_fderiv_at f (fderiv k f x) x :=
+lemma differentiable_at.has_fderiv_at (h : differentiable_at 𝕂 f x) :
+  has_fderiv_at f (fderiv 𝕂 f x) x :=
 begin
   dunfold fderiv,
   dunfold differentiable_at at h,
@@ -246,102 +246,102 @@ begin
   exact classical.some_spec h
 end
 
-lemma has_fderiv_at.fderiv (h : has_fderiv_at f f' x) : fderiv k f x = f' :=
+lemma has_fderiv_at.fderiv (h : has_fderiv_at f f' x) : fderiv 𝕂 f x = f' :=
 by { ext, rw has_fderiv_at_unique h h.differentiable_at.has_fderiv_at }
 
 lemma has_fderiv_within_at.fderiv_within
-  (h : has_fderiv_within_at f f' s x) (hxs : unique_diff_within_at k s x) :
-  fderiv_within k f s x = f' :=
+  (h : has_fderiv_within_at f f' s x) (hxs : unique_diff_within_at 𝕂 s x) :
+  fderiv_within 𝕂 f s x = f' :=
 by { ext, rw hxs.eq h h.differentiable_within_at.has_fderiv_within_at }
 
-lemma differentiable_within_at.mono (h : differentiable_within_at k f t x) (st : s ⊆ t) :
-  differentiable_within_at k f s x :=
+lemma differentiable_within_at.mono (h : differentiable_within_at 𝕂 f t x) (st : s ⊆ t) :
+  differentiable_within_at 𝕂 f s x :=
 begin
   rcases h with ⟨f', hf'⟩,
   exact ⟨f', hf'.mono st⟩
 end
 
 lemma differentiable_within_at_univ :
-  differentiable_within_at k f univ x ↔ differentiable_at k f x :=
+  differentiable_within_at 𝕂 f univ x ↔ differentiable_at 𝕂 f x :=
 begin
   simp [differentiable_within_at, has_fderiv_within_at, nhds_within_univ],
   refl
 end
 
 lemma differentiable_within_at_inter (ht : t ∈ nhds x) :
-  differentiable_within_at k f (s ∩ t) x ↔ differentiable_within_at k f s x :=
+  differentiable_within_at 𝕂 f (s ∩ t) x ↔ differentiable_within_at 𝕂 f s x :=
 by simp only [differentiable_within_at, has_fderiv_within_at, has_fderiv_at_filter,
     nhds_within_restrict' s ht]
 
 lemma differentiable_at.differentiable_within_at
-  (h : differentiable_at k f x) : differentiable_within_at k f s x :=
+  (h : differentiable_at 𝕂 f x) : differentiable_within_at 𝕂 f s x :=
 (differentiable_within_at_univ.2 h).mono (subset_univ _)
 
 lemma differentiable_within_at.differentiable_at
-  (h : differentiable_within_at k f s x) (hs : s ∈ nhds x) : differentiable_at k f x :=
+  (h : differentiable_within_at 𝕂 f s x) (hs : s ∈ nhds x) : differentiable_at 𝕂 f x :=
 begin
   have : s = univ ∩ s, by rw univ_inter,
   rwa [this, differentiable_within_at_inter hs, differentiable_within_at_univ] at h
 end
 
 lemma differentiable.fderiv_within
-  (h : differentiable_at k f x) (hxs : unique_diff_within_at k s x) :
-  fderiv_within k f s x = fderiv k f x :=
+  (h : differentiable_at 𝕂 f x) (hxs : unique_diff_within_at 𝕂 s x) :
+  fderiv_within 𝕂 f s x = fderiv 𝕂 f x :=
 begin
   apply has_fderiv_within_at.fderiv_within _ hxs,
   exact h.has_fderiv_at.has_fderiv_within_at
 end
 
-lemma differentiable_on.mono (h : differentiable_on k f t) (st : s ⊆ t) :
-  differentiable_on k f s :=
+lemma differentiable_on.mono (h : differentiable_on 𝕂 f t) (st : s ⊆ t) :
+  differentiable_on 𝕂 f s :=
 λx hx, (h x (st hx)).mono st
 
 lemma differentiable_on_univ :
-  differentiable_on k f univ ↔ differentiable k f :=
+  differentiable_on 𝕂 f univ ↔ differentiable 𝕂 f :=
 by { simp [differentiable_on, differentiable_within_at_univ], refl }
 
-lemma differentiable.differentiable_on (h : differentiable k f) : differentiable_on k f s :=
+lemma differentiable.differentiable_on (h : differentiable 𝕂 f) : differentiable_on 𝕂 f s :=
 (differentiable_on_univ.2 h).mono (subset_univ _)
 
 lemma differentiable_on_of_locally_differentiable_on
-  (h : ∀x∈s, ∃u, is_open u ∧ x ∈ u ∧ differentiable_on k f (s ∩ u)) : differentiable_on k f s :=
+  (h : ∀x∈s, ∃u, is_open u ∧ x ∈ u ∧ differentiable_on 𝕂 f (s ∩ u)) : differentiable_on 𝕂 f s :=
 begin
   assume x xs,
   rcases h x xs with ⟨t, t_open, xt, ht⟩,
   exact (differentiable_within_at_inter (mem_nhds_sets t_open xt)).1 (ht x ⟨xs, xt⟩)
 end
 
-lemma fderiv_within_subset (st : s ⊆ t) (ht : unique_diff_within_at k s x)
-  (h : differentiable_within_at k f t x) :
-  fderiv_within k f s x = fderiv_within k f t x :=
+lemma fderiv_within_subset (st : s ⊆ t) (ht : unique_diff_within_at 𝕂 s x)
+  (h : differentiable_within_at 𝕂 f t x) :
+  fderiv_within 𝕂 f s x = fderiv_within 𝕂 f t x :=
 ((differentiable_within_at.has_fderiv_within_at h).mono st).fderiv_within ht
 
-@[simp] lemma fderiv_within_univ : fderiv_within k f univ = fderiv k f :=
+@[simp] lemma fderiv_within_univ : fderiv_within 𝕂 f univ = fderiv 𝕂 f :=
 begin
   ext x : 1,
-  by_cases h : differentiable_at k f x,
+  by_cases h : differentiable_at 𝕂 f x,
   { apply has_fderiv_within_at.fderiv_within _ (is_open_univ.unique_diff_within_at (mem_univ _)),
     rw has_fderiv_within_at_univ,
     apply h.has_fderiv_at },
-  { have : fderiv k f x = 0,
+  { have : fderiv 𝕂 f x = 0,
       by { unfold differentiable_at at h, simp [fderiv, h] },
     rw this,
-    have : ¬(differentiable_within_at k f univ x), by rwa differentiable_within_at_univ,
+    have : ¬(differentiable_within_at 𝕂 f univ x), by rwa differentiable_within_at_univ,
     unfold differentiable_within_at at this,
     simp [fderiv_within, this, -has_fderiv_within_at_univ] }
 end
 
-lemma fderiv_within_inter (ht : t ∈ nhds x) (hs : unique_diff_within_at k s x) :
-  fderiv_within k f (s ∩ t) x = fderiv_within k f s x :=
+lemma fderiv_within_inter (ht : t ∈ nhds x) (hs : unique_diff_within_at 𝕂 s x) :
+  fderiv_within 𝕂 f (s ∩ t) x = fderiv_within 𝕂 f s x :=
 begin
-  by_cases h : differentiable_within_at k f (s ∩ t) x,
+  by_cases h : differentiable_within_at 𝕂 f (s ∩ t) x,
   { apply fderiv_within_subset (inter_subset_left _ _) _ ((differentiable_within_at_inter ht).1 h),
     apply hs.inter ht },
-  { have : fderiv_within k f (s ∩ t) x = 0,
+  { have : fderiv_within 𝕂 f (s ∩ t) x = 0,
       by { unfold differentiable_within_at at h, simp [fderiv_within, h] },
     rw this,
     rw differentiable_within_at_inter ht at h,
-    have : fderiv_within k f s x = 0,
+    have : fderiv_within 𝕂 f s x = 0,
       by { unfold differentiable_within_at at h, simp [fderiv_within, h] },
     rw this }
 end
@@ -377,33 +377,33 @@ lemma has_fderiv_at.congr_of_mem_nhds (h : has_fderiv_at f f' x)
   (h₁ : {y | f₁ y = f y} ∈ nhds x) : has_fderiv_at f₁ f' x :=
 has_fderiv_at_filter.congr_of_mem_sets h h₁ (mem_of_nhds h₁ : _)
 
-lemma differentiable_within_at.congr_mono (h : differentiable_within_at k f s x)
-  (ht : ∀x ∈ t, f₁ x = f x) (hx : f₁ x = f x) (h₁ : t ⊆ s) : differentiable_within_at k f₁ t x :=
+lemma differentiable_within_at.congr_mono (h : differentiable_within_at 𝕂 f s x)
+  (ht : ∀x ∈ t, f₁ x = f x) (hx : f₁ x = f x) (h₁ : t ⊆ s) : differentiable_within_at 𝕂 f₁ t x :=
 (has_fderiv_within_at.congr_mono h.has_fderiv_within_at ht hx h₁).differentiable_within_at
 
 lemma differentiable_within_at.congr_of_mem_nhds_within
-  (h : differentiable_within_at k f s x) (h₁ : {y | f₁ y = f y} ∈ nhds_within x s)
-  (hx : f₁ x = f x) : differentiable_within_at k f₁ s x :=
+  (h : differentiable_within_at 𝕂 f s x) (h₁ : {y | f₁ y = f y} ∈ nhds_within x s)
+  (hx : f₁ x = f x) : differentiable_within_at 𝕂 f₁ s x :=
 (h.has_fderiv_within_at.congr_of_mem_nhds_within h₁ hx).differentiable_within_at
 
-lemma differentiable_on.congr_mono (h : differentiable_on k f s) (h' : ∀x ∈ t, f₁ x = f x)
-  (h₁ : t ⊆ s) : differentiable_on k f₁ t :=
+lemma differentiable_on.congr_mono (h : differentiable_on 𝕂 f s) (h' : ∀x ∈ t, f₁ x = f x)
+  (h₁ : t ⊆ s) : differentiable_on 𝕂 f₁ t :=
 λ x hx, (h x (h₁ hx)).congr_mono h' (h' x hx) h₁
 
-lemma differentiable_at.congr_of_mem_nhds (h : differentiable_at k f x)
-  (hL : {y | f₁ y = f y} ∈ nhds x) : differentiable_at k f₁ x :=
+lemma differentiable_at.congr_of_mem_nhds (h : differentiable_at 𝕂 f x)
+  (hL : {y | f₁ y = f y} ∈ nhds x) : differentiable_at 𝕂 f₁ x :=
 has_fderiv_at.differentiable_at (has_fderiv_at_filter.congr_of_mem_sets h.has_fderiv_at hL (mem_of_nhds hL : _))
 
-lemma differentiable_within_at.fderiv_within_congr_mono (h : differentiable_within_at k f s x)
-  (hs : ∀x ∈ t, f₁ x = f x) (hx : f₁ x = f x) (hxt : unique_diff_within_at k t x) (h₁ : t ⊆ s) :
-  fderiv_within k f₁ t x = fderiv_within k f s x :=
+lemma differentiable_within_at.fderiv_within_congr_mono (h : differentiable_within_at 𝕂 f s x)
+  (hs : ∀x ∈ t, f₁ x = f x) (hx : f₁ x = f x) (hxt : unique_diff_within_at 𝕂 t x) (h₁ : t ⊆ s) :
+  fderiv_within 𝕂 f₁ t x = fderiv_within 𝕂 f s x :=
 (has_fderiv_within_at.congr_mono h.has_fderiv_within_at hs hx h₁).fderiv_within hxt
 
-lemma fderiv_within_congr_of_mem_nhds_within (hs : unique_diff_within_at k s x)
+lemma fderiv_within_congr_of_mem_nhds_within (hs : unique_diff_within_at 𝕂 s x)
   (hL : {y | f₁ y = f y} ∈ nhds_within x s) (hx : f₁ x = f x) :
-  fderiv_within k f₁ s x = fderiv_within k f s x :=
+  fderiv_within 𝕂 f₁ s x = fderiv_within 𝕂 f s x :=
 begin
-  by_cases h : differentiable_within_at k f s x ∨ differentiable_within_at k f₁ s x,
+  by_cases h : differentiable_within_at 𝕂 f s x ∨ differentiable_within_at 𝕂 f₁ s x,
   { cases h,
     { apply has_fderiv_within_at.fderiv_within _ hs,
       exact has_fderiv_at_filter.congr_of_mem_sets h.has_fderiv_within_at hL hx },
@@ -414,16 +414,16 @@ begin
       ext y,
       exact eq_comm } },
   { push_neg at h,
-    have A : fderiv_within k f s x = 0,
+    have A : fderiv_within 𝕂 f s x = 0,
       by { unfold differentiable_within_at at h, simp [fderiv_within, h] },
-    have A₁ : fderiv_within k f₁ s x = 0,
+    have A₁ : fderiv_within 𝕂 f₁ s x = 0,
       by { unfold differentiable_within_at at h, simp [fderiv_within, h] },
     rw [A, A₁] }
 end
 
-lemma fderiv_within_congr (hs : unique_diff_within_at k s x)
+lemma fderiv_within_congr (hs : unique_diff_within_at 𝕂 s x)
   (hL : ∀y∈s, f₁ y = f y) (hx : f₁ x = f x) :
-  fderiv_within k f₁ s x = fderiv_within k f s x :=
+  fderiv_within 𝕂 f₁ s x = fderiv_within 𝕂 f s x :=
 begin
   apply fderiv_within_congr_of_mem_nhds_within hs _ hx,
   apply mem_sets_of_superset self_mem_nhds_within,
@@ -431,7 +431,7 @@ begin
 end
 
 lemma fderiv_congr_of_mem_nhds (hL : {y | f₁ y = f y} ∈ nhds x) :
-  fderiv k f₁ x = fderiv k f x :=
+  fderiv 𝕂 f₁ x = fderiv 𝕂 f x :=
 begin
   have A : f₁ x = f x := (mem_of_nhds hL : _),
   rw [← fderiv_within_univ, ← fderiv_within_univ],
@@ -445,33 +445,33 @@ end congr
 section id
 
 theorem has_fderiv_at_filter_id (x : E) (L : filter E) :
-  has_fderiv_at_filter id (id : E →L[k] E) x L :=
+  has_fderiv_at_filter id (id : E →L[𝕂] E) x L :=
 (is_o_zero _ _).congr_left $ by simp
 
 theorem has_fderiv_within_at_id (x : E) (s : set E) :
-  has_fderiv_within_at id (id : E →L[k] E) s x :=
+  has_fderiv_within_at id (id : E →L[𝕂] E) s x :=
 has_fderiv_at_filter_id _ _
 
-theorem has_fderiv_at_id (x : E) : has_fderiv_at id (id : E →L[k] E) x :=
+theorem has_fderiv_at_id (x : E) : has_fderiv_at id (id : E →L[𝕂] E) x :=
 has_fderiv_at_filter_id _ _
 
-lemma differentiable_at_id : differentiable_at k id x :=
+lemma differentiable_at_id : differentiable_at 𝕂 id x :=
 (has_fderiv_at_id x).differentiable_at
 
-lemma differentiable_within_at_id : differentiable_within_at k id s x :=
+lemma differentiable_within_at_id : differentiable_within_at 𝕂 id s x :=
 differentiable_at_id.differentiable_within_at
 
-lemma differentiable_id : differentiable k (id : E → E) :=
+lemma differentiable_id : differentiable 𝕂 (id : E → E) :=
 λx, differentiable_at_id
 
-lemma differentiable_on_id : differentiable_on k id s :=
+lemma differentiable_on_id : differentiable_on 𝕂 id s :=
 differentiable_id.differentiable_on
 
-lemma fderiv_id : fderiv k id x = id :=
+lemma fderiv_id : fderiv 𝕂 id x = id :=
 has_fderiv_at.fderiv (has_fderiv_at_id x)
 
-lemma fderiv_within_id (hxs : unique_diff_within_at k s x) :
-  fderiv_within k id s x = id :=
+lemma fderiv_within_id (hxs : unique_diff_within_at 𝕂 s x) :
+  fderiv_within 𝕂 id s x = id :=
 begin
   rw differentiable.fderiv_within (differentiable_at_id) hxs,
   exact fderiv_id
@@ -483,37 +483,37 @@ end id
 section const
 
 theorem has_fderiv_at_filter_const (c : F) (x : E) (L : filter E) :
-  has_fderiv_at_filter (λ x, c) (0 : E →L[k] F) x L :=
+  has_fderiv_at_filter (λ x, c) (0 : E →L[𝕂] F) x L :=
 (is_o_zero _ _).congr_left $ λ _, by simp only [zero_apply, sub_self]
 
 theorem has_fderiv_within_at_const (c : F) (x : E) (s : set E) :
-  has_fderiv_within_at (λ x, c) (0 : E →L[k] F) s x :=
+  has_fderiv_within_at (λ x, c) (0 : E →L[𝕂] F) s x :=
 has_fderiv_at_filter_const _ _ _
 
 theorem has_fderiv_at_const (c : F) (x : E) :
-  has_fderiv_at (λ x, c) (0 : E →L[k] F) x :=
+  has_fderiv_at (λ x, c) (0 : E →L[𝕂] F) x :=
 has_fderiv_at_filter_const _ _ _
 
-lemma differentiable_at_const (c : F) : differentiable_at k (λx, c) x :=
+lemma differentiable_at_const (c : F) : differentiable_at 𝕂 (λx, c) x :=
 ⟨0, has_fderiv_at_const c x⟩
 
-lemma differentiable_within_at_const (c : F) : differentiable_within_at k (λx, c) s x :=
+lemma differentiable_within_at_const (c : F) : differentiable_within_at 𝕂 (λx, c) s x :=
 differentiable_at.differentiable_within_at (differentiable_at_const _)
 
-lemma fderiv_const (c : F) : fderiv k (λy, c) x = 0 :=
+lemma fderiv_const (c : F) : fderiv 𝕂 (λy, c) x = 0 :=
 has_fderiv_at.fderiv (has_fderiv_at_const c x)
 
-lemma fderiv_within_const (c : F) (hxs : unique_diff_within_at k s x) :
-  fderiv_within k (λy, c) s x = 0 :=
+lemma fderiv_within_const (c : F) (hxs : unique_diff_within_at 𝕂 s x) :
+  fderiv_within 𝕂 (λy, c) s x = 0 :=
 begin
   rw differentiable.fderiv_within (differentiable_at_const _) hxs,
   exact fderiv_const _
 end
 
-lemma differentiable_const (c : F) : differentiable k (λx : E, c) :=
+lemma differentiable_const (c : F) : differentiable 𝕂 (λx : E, c) :=
 λx, differentiable_at_const _
 
-lemma differentiable_on_const (c : F) : differentiable_on k (λx, c) s :=
+lemma differentiable_on_const (c : F) : differentiable_on 𝕂 (λx, c) s :=
 (differentiable_const _).differentiable_on
 
 end const
@@ -521,7 +521,7 @@ end const
 /- Bounded linear maps -/
 section is_bounded_linear_map
 
-lemma is_bounded_linear_map.has_fderiv_at_filter (h : is_bounded_linear_map k f) :
+lemma is_bounded_linear_map.has_fderiv_at_filter (h : is_bounded_linear_map 𝕂 f) :
   has_fderiv_at_filter f h.to_continuous_linear_map x L :=
 begin
   have : (λ (x' : E), f x' - f x - h.to_continuous_linear_map (x' - x)) = λx', 0,
@@ -533,39 +533,39 @@ begin
   exact asymptotics.is_o_zero _ _
 end
 
-lemma is_bounded_linear_map.has_fderiv_within_at (h : is_bounded_linear_map k f) :
+lemma is_bounded_linear_map.has_fderiv_within_at (h : is_bounded_linear_map 𝕂 f) :
   has_fderiv_within_at f h.to_continuous_linear_map s x :=
 h.has_fderiv_at_filter
 
-lemma is_bounded_linear_map.has_fderiv_at (h : is_bounded_linear_map k f) :
+lemma is_bounded_linear_map.has_fderiv_at (h : is_bounded_linear_map 𝕂 f) :
   has_fderiv_at f h.to_continuous_linear_map x  :=
 h.has_fderiv_at_filter
 
-lemma is_bounded_linear_map.differentiable_at (h : is_bounded_linear_map k f) :
-  differentiable_at k f x :=
+lemma is_bounded_linear_map.differentiable_at (h : is_bounded_linear_map 𝕂 f) :
+  differentiable_at 𝕂 f x :=
 h.has_fderiv_at.differentiable_at
 
-lemma is_bounded_linear_map.differentiable_within_at (h : is_bounded_linear_map k f) :
-  differentiable_within_at k f s x :=
+lemma is_bounded_linear_map.differentiable_within_at (h : is_bounded_linear_map 𝕂 f) :
+  differentiable_within_at 𝕂 f s x :=
 h.differentiable_at.differentiable_within_at
 
-lemma is_bounded_linear_map.fderiv (h : is_bounded_linear_map k f) :
-  fderiv k f x = h.to_continuous_linear_map :=
+lemma is_bounded_linear_map.fderiv (h : is_bounded_linear_map 𝕂 f) :
+  fderiv 𝕂 f x = h.to_continuous_linear_map :=
 has_fderiv_at.fderiv (h.has_fderiv_at)
 
-lemma is_bounded_linear_map.fderiv_within (h : is_bounded_linear_map k f)
-  (hxs : unique_diff_within_at k s x) : fderiv_within k f s x = h.to_continuous_linear_map :=
+lemma is_bounded_linear_map.fderiv_within (h : is_bounded_linear_map 𝕂 f)
+  (hxs : unique_diff_within_at 𝕂 s x) : fderiv_within 𝕂 f s x = h.to_continuous_linear_map :=
 begin
   rw differentiable.fderiv_within h.differentiable_at hxs,
   exact h.fderiv
 end
 
-lemma is_bounded_linear_map.differentiable (h : is_bounded_linear_map k f) :
-  differentiable k f :=
+lemma is_bounded_linear_map.differentiable (h : is_bounded_linear_map 𝕂 f) :
+  differentiable 𝕂 f :=
 λx, h.differentiable_at
 
-lemma is_bounded_linear_map.differentiable_on (h : is_bounded_linear_map k f) :
-  differentiable_on k f s :=
+lemma is_bounded_linear_map.differentiable_on (h : is_bounded_linear_map 𝕂 f) :
+  differentiable_on 𝕂 f s :=
 h.differentiable.differentiable_on
 
 end is_bounded_linear_map
@@ -573,41 +573,41 @@ end is_bounded_linear_map
 /- multiplication by a constant -/
 section smul_const
 
-theorem has_fderiv_at_filter.smul (h : has_fderiv_at_filter f f' x L) (c : k) :
+theorem has_fderiv_at_filter.smul (h : has_fderiv_at_filter f f' x L) (c : 𝕂) :
   has_fderiv_at_filter (λ x, c • f x) (c • f') x L :=
 (is_o_const_smul_left h c).congr_left $ λ x, by simp [smul_neg, smul_add]
 
-theorem has_fderiv_within_at.smul (h : has_fderiv_within_at f f' s x) (c : k) :
+theorem has_fderiv_within_at.smul (h : has_fderiv_within_at f f' s x) (c : 𝕂) :
   has_fderiv_within_at (λ x, c • f x) (c • f') s x :=
 h.smul c
 
-theorem has_fderiv_at.smul (h : has_fderiv_at f f' x) (c : k) :
+theorem has_fderiv_at.smul (h : has_fderiv_at f f' x) (c : 𝕂) :
   has_fderiv_at (λ x, c • f x) (c • f') x :=
 h.smul c
 
-lemma differentiable_within_at.smul (h : differentiable_within_at k f s x) (c : k) :
-  differentiable_within_at k (λy, c • f y) s x :=
+lemma differentiable_within_at.smul (h : differentiable_within_at 𝕂 f s x) (c : 𝕂) :
+  differentiable_within_at 𝕂 (λy, c • f y) s x :=
 (h.has_fderiv_within_at.smul c).differentiable_within_at
 
-lemma differentiable_at.smul (h : differentiable_at k f x) (c : k) :
-  differentiable_at k (λy, c • f y) x :=
+lemma differentiable_at.smul (h : differentiable_at 𝕂 f x) (c : 𝕂) :
+  differentiable_at 𝕂 (λy, c • f y) x :=
 (h.has_fderiv_at.smul c).differentiable_at
 
-lemma differentiable_on.smul (h : differentiable_on k f s) (c : k) :
-  differentiable_on k (λy, c • f y) s :=
+lemma differentiable_on.smul (h : differentiable_on 𝕂 f s) (c : 𝕂) :
+  differentiable_on 𝕂 (λy, c • f y) s :=
 λx hx, (h x hx).smul c
 
-lemma differentiable.smul (h : differentiable k f) (c : k) :
-  differentiable k (λy, c • f y) :=
+lemma differentiable.smul (h : differentiable 𝕂 f) (c : 𝕂) :
+  differentiable 𝕂 (λy, c • f y) :=
 λx, (h x).smul c
 
-lemma fderiv_within_smul (hxs : unique_diff_within_at k s x)
-  (h : differentiable_within_at k f s x) (c : k) :
-  fderiv_within k (λy, c • f y) s x = c • fderiv_within k f s x :=
+lemma fderiv_within_smul (hxs : unique_diff_within_at 𝕂 s x)
+  (h : differentiable_within_at 𝕂 f s x) (c : 𝕂) :
+  fderiv_within 𝕂 (λy, c • f y) s x = c • fderiv_within 𝕂 f s x :=
 (h.has_fderiv_within_at.smul c).fderiv_within hxs
 
-lemma fderiv_smul (h : differentiable_at k f x) (c : k) :
-  fderiv k (λy, c • f y) x = c • fderiv k f x :=
+lemma fderiv_smul (h : differentiable_at 𝕂 f x) (c : 𝕂) :
+  fderiv 𝕂 (λy, c • f y) x = c • fderiv 𝕂 f x :=
 (h.has_fderiv_at.smul c).fderiv
 
 end smul_const
@@ -631,33 +631,33 @@ theorem has_fderiv_at.add
 hf.add hg
 
 lemma differentiable_within_at.add
-  (hf : differentiable_within_at k f s x) (hg : differentiable_within_at k g s x) :
-  differentiable_within_at k (λ y, f y + g y) s x :=
+  (hf : differentiable_within_at 𝕂 f s x) (hg : differentiable_within_at 𝕂 g s x) :
+  differentiable_within_at 𝕂 (λ y, f y + g y) s x :=
 (hf.has_fderiv_within_at.add hg.has_fderiv_within_at).differentiable_within_at
 
 lemma differentiable_at.add
-  (hf : differentiable_at k f x) (hg : differentiable_at k g x) :
-  differentiable_at k (λ y, f y + g y) x :=
+  (hf : differentiable_at 𝕂 f x) (hg : differentiable_at 𝕂 g x) :
+  differentiable_at 𝕂 (λ y, f y + g y) x :=
 (hf.has_fderiv_at.add hg.has_fderiv_at).differentiable_at
 
 lemma differentiable_on.add
-  (hf : differentiable_on k f s) (hg : differentiable_on k g s) :
-  differentiable_on k (λy, f y + g y) s :=
+  (hf : differentiable_on 𝕂 f s) (hg : differentiable_on 𝕂 g s) :
+  differentiable_on 𝕂 (λy, f y + g y) s :=
 λx hx, (hf x hx).add (hg x hx)
 
 lemma differentiable.add
-  (hf : differentiable k f) (hg : differentiable k g) :
-  differentiable k (λy, f y + g y) :=
+  (hf : differentiable 𝕂 f) (hg : differentiable 𝕂 g) :
+  differentiable 𝕂 (λy, f y + g y) :=
 λx, (hf x).add (hg x)
 
-lemma fderiv_within_add (hxs : unique_diff_within_at k s x)
-  (hf : differentiable_within_at k f s x) (hg : differentiable_within_at k g s x) :
-  fderiv_within k (λy, f y + g y) s x = fderiv_within k f s x + fderiv_within k g s x :=
+lemma fderiv_within_add (hxs : unique_diff_within_at 𝕂 s x)
+  (hf : differentiable_within_at 𝕂 f s x) (hg : differentiable_within_at 𝕂 g s x) :
+  fderiv_within 𝕂 (λy, f y + g y) s x = fderiv_within 𝕂 f s x + fderiv_within 𝕂 g s x :=
 (hf.has_fderiv_within_at.add hg.has_fderiv_within_at).fderiv_within hxs
 
 lemma fderiv_add
-  (hf : differentiable_at k f x) (hg : differentiable_at k g x) :
-  fderiv k (λy, f y + g y) x = fderiv k f x + fderiv k g x :=
+  (hf : differentiable_at 𝕂 f x) (hg : differentiable_at 𝕂 g x) :
+  fderiv 𝕂 (λy, f y + g y) x = fderiv 𝕂 f x + fderiv 𝕂 g x :=
 (hf.has_fderiv_at.add hg.has_fderiv_at).fderiv
 
 end add
@@ -667,7 +667,7 @@ section neg
 
 theorem has_fderiv_at_filter.neg (h : has_fderiv_at_filter f f' x L) :
   has_fderiv_at_filter (λ x, -f x) (-f') x L :=
-(h.smul (-1:k)).congr (by simp) (by simp)
+(h.smul (-1:𝕂)).congr (by simp) (by simp)
 
 theorem has_fderiv_within_at.neg (h : has_fderiv_within_at f f' s x) :
   has_fderiv_within_at (λ x, -f x) (-f') s x :=
@@ -677,29 +677,29 @@ theorem has_fderiv_at.neg (h : has_fderiv_at f f' x) :
   has_fderiv_at (λ x, -f x) (-f') x :=
 h.neg
 
-lemma differentiable_within_at.neg (h : differentiable_within_at k f s x) :
-  differentiable_within_at k (λy, -f y) s x :=
+lemma differentiable_within_at.neg (h : differentiable_within_at 𝕂 f s x) :
+  differentiable_within_at 𝕂 (λy, -f y) s x :=
 h.has_fderiv_within_at.neg.differentiable_within_at
 
-lemma differentiable_at.neg (h : differentiable_at k f x) :
-  differentiable_at k (λy, -f y) x :=
+lemma differentiable_at.neg (h : differentiable_at 𝕂 f x) :
+  differentiable_at 𝕂 (λy, -f y) x :=
 h.has_fderiv_at.neg.differentiable_at
 
-lemma differentiable_on.neg (h : differentiable_on k f s) :
-  differentiable_on k (λy, -f y) s :=
+lemma differentiable_on.neg (h : differentiable_on 𝕂 f s) :
+  differentiable_on 𝕂 (λy, -f y) s :=
 λx hx, (h x hx).neg
 
-lemma differentiable.neg (h : differentiable k f) :
-  differentiable k (λy, -f y) :=
+lemma differentiable.neg (h : differentiable 𝕂 f) :
+  differentiable 𝕂 (λy, -f y) :=
 λx, (h x).neg
 
-lemma fderiv_within_neg (hxs : unique_diff_within_at k s x)
-  (h : differentiable_within_at k f s x) :
-  fderiv_within k (λy, -f y) s x = - fderiv_within k f s x :=
+lemma fderiv_within_neg (hxs : unique_diff_within_at 𝕂 s x)
+  (h : differentiable_within_at 𝕂 f s x) :
+  fderiv_within 𝕂 (λy, -f y) s x = - fderiv_within 𝕂 f s x :=
 h.has_fderiv_within_at.neg.fderiv_within hxs
 
-lemma fderiv_neg (h : differentiable_at k f x) :
-  fderiv k (λy, -f y) x = - fderiv k f x :=
+lemma fderiv_neg (h : differentiable_at 𝕂 f x) :
+  fderiv 𝕂 (λy, -f y) x = - fderiv 𝕂 f x :=
 h.has_fderiv_at.neg.fderiv
 
 end neg
@@ -723,33 +723,33 @@ theorem has_fderiv_at.sub
 hf.sub hg
 
 lemma differentiable_within_at.sub
-  (hf : differentiable_within_at k f s x) (hg : differentiable_within_at k g s x) :
-  differentiable_within_at k (λ y, f y - g y) s x :=
+  (hf : differentiable_within_at 𝕂 f s x) (hg : differentiable_within_at 𝕂 g s x) :
+  differentiable_within_at 𝕂 (λ y, f y - g y) s x :=
 (hf.has_fderiv_within_at.sub hg.has_fderiv_within_at).differentiable_within_at
 
 lemma differentiable_at.sub
-  (hf : differentiable_at k f x) (hg : differentiable_at k g x) :
-  differentiable_at k (λ y, f y - g y) x :=
+  (hf : differentiable_at 𝕂 f x) (hg : differentiable_at 𝕂 g x) :
+  differentiable_at 𝕂 (λ y, f y - g y) x :=
 (hf.has_fderiv_at.sub hg.has_fderiv_at).differentiable_at
 
 lemma differentiable_on.sub
-  (hf : differentiable_on k f s) (hg : differentiable_on k g s) :
-  differentiable_on k (λy, f y - g y) s :=
+  (hf : differentiable_on 𝕂 f s) (hg : differentiable_on 𝕂 g s) :
+  differentiable_on 𝕂 (λy, f y - g y) s :=
 λx hx, (hf x hx).sub (hg x hx)
 
 lemma differentiable.sub
-  (hf : differentiable k f) (hg : differentiable k g) :
-  differentiable k (λy, f y - g y) :=
+  (hf : differentiable 𝕂 f) (hg : differentiable 𝕂 g) :
+  differentiable 𝕂 (λy, f y - g y) :=
 λx, (hf x).sub (hg x)
 
-lemma fderiv_within_sub (hxs : unique_diff_within_at k s x)
-  (hf : differentiable_within_at k f s x) (hg : differentiable_within_at k g s x) :
-  fderiv_within k (λy, f y - g y) s x = fderiv_within k f s x - fderiv_within k g s x :=
+lemma fderiv_within_sub (hxs : unique_diff_within_at 𝕂 s x)
+  (hf : differentiable_within_at 𝕂 f s x) (hg : differentiable_within_at 𝕂 g s x) :
+  fderiv_within 𝕂 (λy, f y - g y) s x = fderiv_within 𝕂 f s x - fderiv_within 𝕂 g s x :=
 (hf.has_fderiv_within_at.sub hg.has_fderiv_within_at).fderiv_within hxs
 
 lemma fderiv_sub
-  (hf : differentiable_at k f x) (hg : differentiable_at k g x) :
-  fderiv k (λy, f y - g y) x = fderiv k f x - fderiv k g x :=
+  (hf : differentiable_at 𝕂 f x) (hg : differentiable_at 𝕂 g x) :
+  fderiv 𝕂 (λy, f y - g y) x = fderiv 𝕂 f x - fderiv 𝕂 g x :=
 (hf.has_fderiv_at.sub hg.has_fderiv_at).fderiv
 
 theorem has_fderiv_at_filter.is_O_sub (h : has_fderiv_at_filter f f' x L) :
@@ -781,17 +781,17 @@ theorem has_fderiv_at.continuous_at (h : has_fderiv_at f f' x) :
   continuous_at f x :=
 has_fderiv_at_filter.tendsto_nhds (le_refl _) h
 
-lemma differentiable_within_at.continuous_within_at (h : differentiable_within_at k f s x) :
+lemma differentiable_within_at.continuous_within_at (h : differentiable_within_at 𝕂 f s x) :
   continuous_within_at f s x :=
 let ⟨f', hf'⟩ := h in hf'.continuous_within_at
 
-lemma differentiable_at.continuous_at (h : differentiable_at k f x) : continuous_at f x :=
+lemma differentiable_at.continuous_at (h : differentiable_at 𝕂 f x) : continuous_at f x :=
 let ⟨f', hf'⟩ := h in hf'.continuous_at
 
-lemma differentiable_on.continuous_on (h : differentiable_on k f s) : continuous_on f s :=
+lemma differentiable_on.continuous_on (h : differentiable_on 𝕂 f s) : continuous_on f s :=
 λx hx, (h x hx).continuous_within_at
 
-lemma differentiable.continuous (h : differentiable k f) : continuous f :=
+lemma differentiable.continuous (h : differentiable 𝕂 f) : continuous f :=
 continuous_iff_continuous_at.2 $ λx, (h x).continuous_at
 
 end continuous
@@ -801,7 +801,7 @@ end continuous
 section bilinear_map
 variables {b : E × F → G} {u : set (E × F) }
 
-lemma is_bounded_bilinear_map.has_fderiv_at (h : is_bounded_bilinear_map k b) (p : E × F) :
+lemma is_bounded_bilinear_map.has_fderiv_at (h : is_bounded_bilinear_map 𝕂 b) (p : E × F) :
   has_fderiv_at b (h.deriv p) p :=
 begin
   have : (λ (x : E × F), b x - b p - (h.deriv p) (x - p)) = (λx, b (x.1 - p.1, x.2 - p.2)),
@@ -840,38 +840,38 @@ begin
   exact A.trans_is_o B
 end
 
-lemma is_bounded_bilinear_map.has_fderiv_within_at (h : is_bounded_bilinear_map k b) (p : E × F) :
+lemma is_bounded_bilinear_map.has_fderiv_within_at (h : is_bounded_bilinear_map 𝕂 b) (p : E × F) :
   has_fderiv_within_at b (h.deriv p) u p :=
 (h.has_fderiv_at p).has_fderiv_within_at
 
-lemma is_bounded_bilinear_map.differentiable_at (h : is_bounded_bilinear_map k b) (p : E × F) :
-  differentiable_at k b p :=
+lemma is_bounded_bilinear_map.differentiable_at (h : is_bounded_bilinear_map 𝕂 b) (p : E × F) :
+  differentiable_at 𝕂 b p :=
 (h.has_fderiv_at p).differentiable_at
 
-lemma is_bounded_bilinear_map.differentiable_within_at (h : is_bounded_bilinear_map k b) (p : E × F) :
-  differentiable_within_at k b u p :=
+lemma is_bounded_bilinear_map.differentiable_within_at (h : is_bounded_bilinear_map 𝕂 b) (p : E × F) :
+  differentiable_within_at 𝕂 b u p :=
 (h.differentiable_at p).differentiable_within_at
 
-lemma is_bounded_bilinear_map.fderiv (h : is_bounded_bilinear_map k b) (p : E × F) :
-  fderiv k b p = h.deriv p :=
+lemma is_bounded_bilinear_map.fderiv (h : is_bounded_bilinear_map 𝕂 b) (p : E × F) :
+  fderiv 𝕂 b p = h.deriv p :=
 has_fderiv_at.fderiv (h.has_fderiv_at p)
 
-lemma is_bounded_bilinear_map.fderiv_within (h : is_bounded_bilinear_map k b) (p : E × F)
-  (hxs : unique_diff_within_at k u p) : fderiv_within k b u p = h.deriv p :=
+lemma is_bounded_bilinear_map.fderiv_within (h : is_bounded_bilinear_map 𝕂 b) (p : E × F)
+  (hxs : unique_diff_within_at 𝕂 u p) : fderiv_within 𝕂 b u p = h.deriv p :=
 begin
   rw differentiable.fderiv_within (h.differentiable_at p) hxs,
   exact h.fderiv p
 end
 
-lemma is_bounded_bilinear_map.differentiable (h : is_bounded_bilinear_map k b) :
-  differentiable k b :=
+lemma is_bounded_bilinear_map.differentiable (h : is_bounded_bilinear_map 𝕂 b) :
+  differentiable 𝕂 b :=
 λx, h.differentiable_at x
 
-lemma is_bounded_bilinear_map.differentiable_on (h : is_bounded_bilinear_map k b) :
-  differentiable_on k b u :=
+lemma is_bounded_bilinear_map.differentiable_on (h : is_bounded_bilinear_map 𝕂 b) :
+  differentiable_on 𝕂 b u :=
 h.differentiable.differentiable_on
 
-lemma is_bounded_bilinear_map.continuous (h : is_bounded_bilinear_map k b) :
+lemma is_bounded_bilinear_map.continuous (h : is_bounded_bilinear_map 𝕂 b) :
   continuous b :=
 h.differentiable.continuous
 
@@ -880,7 +880,7 @@ end bilinear_map
 
 /- Cartesian products -/
 section cartesian_product
-variables {f₂ : E → G} {f₂' : E →L[k] G}
+variables {f₂ : E → G} {f₂' : E →L[𝕂] G}
 
 lemma has_fderiv_at_filter.prod
   (hf₁ : has_fderiv_at_filter f₁ f₁' x L) (hf₂ : has_fderiv_at_filter f₂ f₂' x L) :
@@ -903,33 +903,33 @@ lemma has_fderiv_at.prod (hf₁ : has_fderiv_at f₁ f₁' x) (hf₂ : has_fderi
 hf₁.prod hf₂
 
 lemma differentiable_within_at.prod
-  (hf₁ : differentiable_within_at k f₁ s x) (hf₂ : differentiable_within_at k f₂ s x) :
-  differentiable_within_at k (λx:E, (f₁ x, f₂ x)) s x :=
+  (hf₁ : differentiable_within_at 𝕂 f₁ s x) (hf₂ : differentiable_within_at 𝕂 f₂ s x) :
+  differentiable_within_at 𝕂 (λx:E, (f₁ x, f₂ x)) s x :=
 (hf₁.has_fderiv_within_at.prod hf₂.has_fderiv_within_at).differentiable_within_at
 
-lemma differentiable_at.prod (hf₁ : differentiable_at k f₁ x) (hf₂ : differentiable_at k f₂ x) :
-  differentiable_at k (λx:E, (f₁ x, f₂ x)) x :=
+lemma differentiable_at.prod (hf₁ : differentiable_at 𝕂 f₁ x) (hf₂ : differentiable_at 𝕂 f₂ x) :
+  differentiable_at 𝕂 (λx:E, (f₁ x, f₂ x)) x :=
 (hf₁.has_fderiv_at.prod hf₂.has_fderiv_at).differentiable_at
 
-lemma differentiable_on.prod (hf₁ : differentiable_on k f₁ s) (hf₂ : differentiable_on k f₂ s) :
-  differentiable_on k (λx:E, (f₁ x, f₂ x)) s :=
+lemma differentiable_on.prod (hf₁ : differentiable_on 𝕂 f₁ s) (hf₂ : differentiable_on 𝕂 f₂ s) :
+  differentiable_on 𝕂 (λx:E, (f₁ x, f₂ x)) s :=
 λx hx, differentiable_within_at.prod (hf₁ x hx) (hf₂ x hx)
 
-lemma differentiable.prod (hf₁ : differentiable k f₁) (hf₂ : differentiable k f₂) :
-  differentiable k (λx:E, (f₁ x, f₂ x)) :=
+lemma differentiable.prod (hf₁ : differentiable 𝕂 f₁) (hf₂ : differentiable 𝕂 f₂) :
+  differentiable 𝕂 (λx:E, (f₁ x, f₂ x)) :=
 λ x, differentiable_at.prod (hf₁ x) (hf₂ x)
 
 lemma differentiable_at.fderiv_prod
-  (hf₁ : differentiable_at k f₁ x) (hf₂ : differentiable_at k f₂ x) :
-  fderiv k (λx:E, (f₁ x, f₂ x)) x =
-    continuous_linear_map.prod (fderiv k f₁ x) (fderiv k f₂ x) :=
+  (hf₁ : differentiable_at 𝕂 f₁ x) (hf₂ : differentiable_at 𝕂 f₂ x) :
+  fderiv 𝕂 (λx:E, (f₁ x, f₂ x)) x =
+    continuous_linear_map.prod (fderiv 𝕂 f₁ x) (fderiv 𝕂 f₂ x) :=
 has_fderiv_at.fderiv (has_fderiv_at.prod hf₁.has_fderiv_at hf₂.has_fderiv_at)
 
 lemma differentiable_at.fderiv_within_prod
-  (hf₁ : differentiable_within_at k f₁ s x) (hf₂ : differentiable_within_at k f₂ s x)
-  (hxs : unique_diff_within_at k s x) :
-  fderiv_within k (λx:E, (f₁ x, f₂ x)) s x =
-    continuous_linear_map.prod (fderiv_within k f₁ s x) (fderiv_within k f₂ s x) :=
+  (hf₁ : differentiable_within_at 𝕂 f₁ s x) (hf₂ : differentiable_within_at 𝕂 f₂ s x)
+  (hxs : unique_diff_within_at 𝕂 s x) :
+  fderiv_within 𝕂 (λx:E, (f₁ x, f₂ x)) s x =
+    continuous_linear_map.prod (fderiv_within 𝕂 f₁ s x) (fderiv_within 𝕂 f₂ s x) :=
 begin
   apply has_fderiv_within_at.fderiv_within _ hxs,
   exact has_fderiv_within_at.prod hf₁.has_fderiv_within_at hf₂.has_fderiv_within_at
@@ -945,7 +945,7 @@ get confused since there are too many possibilities for composition -/
 
 variable (x)
 
-theorem has_fderiv_at_filter.comp {g : F → G} {g' : F →L[k] G}
+theorem has_fderiv_at_filter.comp {g : F → G} {g' : F →L[𝕂] G}
   (hg : has_fderiv_at_filter g g' (f x) (L.map f))
   (hf : has_fderiv_at_filter f f' x L) :
   has_fderiv_at_filter (g ∘ f) (g'.comp f') x L :=
@@ -956,7 +956,7 @@ by { refine eq₂.tri (eq₁.congr_left (λ x', _)), simp }
 /- A readable version of the previous theorem,
    a general form of the chain rule. -/
 
-example {g : F → G} {g' : F →L[k] G}
+example {g : F → G} {g' : F →L[𝕂] G}
   (hg : has_fderiv_at_filter g g' (f x) (L.map f))
   (hf : has_fderiv_at_filter f f' x L) :
   has_fderiv_at_filter (g ∘ f) (g'.comp f') x L :=
@@ -978,7 +978,7 @@ begin
   exact eq₁.tri eq₃
 end
 
-theorem has_fderiv_within_at.comp {g : F → G} {g' : F →L[k] G}
+theorem has_fderiv_within_at.comp {g : F → G} {g' : F →L[𝕂] G}
   (hg : has_fderiv_within_at g g' (f '' s) (f x))
   (hf : has_fderiv_within_at f f' s x) :
   has_fderiv_within_at (g ∘ f) (g'.comp f') s x :=
@@ -986,12 +986,12 @@ theorem has_fderiv_within_at.comp {g : F → G} {g' : F →L[k] G}
   hf.continuous_within_at.tendsto_nhds_within_image).comp x hf
 
 /-- The chain rule. -/
-theorem has_fderiv_at.comp {g : F → G} {g' : F →L[k] G}
+theorem has_fderiv_at.comp {g : F → G} {g' : F →L[𝕂] G}
   (hg : has_fderiv_at g g' (f x)) (hf : has_fderiv_at f f' x) :
   has_fderiv_at (g ∘ f) (g'.comp f') x :=
 (hg.mono hf.continuous_at).comp x hf
 
-theorem has_fderiv_at.comp_has_fderiv_within_at {g : F → G} {g' : F →L[k] G}
+theorem has_fderiv_at.comp_has_fderiv_within_at {g : F → G} {g' : F →L[𝕂] G}
   (hg : has_fderiv_at g g' (f x)) (hf : has_fderiv_within_at f f' s x) :
   has_fderiv_within_at (g ∘ f) (g'.comp f') s x :=
 begin
@@ -1000,8 +1000,8 @@ begin
 end
 
 lemma differentiable_within_at.comp {g : F → G} {t : set F}
-  (hg : differentiable_within_at k g t (f x)) (hf : differentiable_within_at k f s x)
-  (h : f '' s ⊆ t) : differentiable_within_at k (g ∘ f) s x :=
+  (hg : differentiable_within_at 𝕂 g t (f x)) (hf : differentiable_within_at 𝕂 f s x)
+  (h : f '' s ⊆ t) : differentiable_within_at 𝕂 (g ∘ f) s x :=
 begin
   rcases hf with ⟨f', hf'⟩,
   rcases hg with ⟨g', hg'⟩,
@@ -1009,15 +1009,15 @@ begin
 end
 
 lemma differentiable_at.comp {g : F → G}
-  (hg : differentiable_at k g (f x)) (hf : differentiable_at k f x) :
-  differentiable_at k (g ∘ f) x :=
+  (hg : differentiable_at 𝕂 g (f x)) (hf : differentiable_at 𝕂 f x) :
+  differentiable_at 𝕂 (g ∘ f) x :=
 (hg.has_fderiv_at.comp x hf.has_fderiv_at).differentiable_at
 
 lemma fderiv_within.comp {g : F → G} {t : set F}
-  (hg : differentiable_within_at k g t (f x)) (hf : differentiable_within_at k f s x)
-  (h : f '' s ⊆ t) (hxs : unique_diff_within_at k s x) :
-  fderiv_within k (g ∘ f) s x =
-    continuous_linear_map.comp (fderiv_within k g t (f x)) (fderiv_within k f s x) :=
+  (hg : differentiable_within_at 𝕂 g t (f x)) (hf : differentiable_within_at 𝕂 f s x)
+  (h : f '' s ⊆ t) (hxs : unique_diff_within_at 𝕂 s x) :
+  fderiv_within 𝕂 (g ∘ f) s x =
+    continuous_linear_map.comp (fderiv_within 𝕂 g t (f x)) (fderiv_within 𝕂 f s x) :=
 begin
   apply has_fderiv_within_at.fderiv_within _ hxs,
   apply has_fderiv_within_at.comp x _ (hf.has_fderiv_within_at),
@@ -1025,69 +1025,69 @@ begin
 end
 
 lemma fderiv.comp {g : F → G}
-  (hg : differentiable_at k g (f x)) (hf : differentiable_at k f x) :
-  fderiv k (g ∘ f) x = continuous_linear_map.comp (fderiv k g (f x)) (fderiv k f x) :=
+  (hg : differentiable_at 𝕂 g (f x)) (hf : differentiable_at 𝕂 f x) :
+  fderiv 𝕂 (g ∘ f) x = continuous_linear_map.comp (fderiv 𝕂 g (f x)) (fderiv 𝕂 f x) :=
 begin
   apply has_fderiv_at.fderiv,
   exact has_fderiv_at.comp x hg.has_fderiv_at hf.has_fderiv_at
 end
 
 lemma differentiable_on.comp {g : F → G} {t : set F}
-  (hg : differentiable_on k g t) (hf : differentiable_on k f s) (st : f '' s ⊆ t) :
-  differentiable_on k (g ∘ f) s :=
+  (hg : differentiable_on 𝕂 g t) (hf : differentiable_on 𝕂 f s) (st : f '' s ⊆ t) :
+  differentiable_on 𝕂 (g ∘ f) s :=
 λx hx, differentiable_within_at.comp x (hg (f x) (st (mem_image_of_mem _ hx))) (hf x hx) st
 
-lemma differentiable.comp {g : F → G} (hg : differentiable k g) (hf : differentiable k f) :
-  differentiable k (g ∘ f) :=
+lemma differentiable.comp {g : F → G} (hg : differentiable 𝕂 g) (hf : differentiable 𝕂 f) :
+  differentiable 𝕂 (g ∘ f) :=
 λx, differentiable_at.comp x (hg (f x)) (hf x)
 
 end composition
 
 /- Multiplication by a scalar function -/
 section smul
-variables {c : E → k} {c' : E →L[k] k}
+variables {c : E → 𝕂} {c' : E →L[𝕂] 𝕂}
 
 theorem has_fderiv_within_at.smul'
   (hc : has_fderiv_within_at c c' s x) (hf : has_fderiv_within_at f f' s x) :
   has_fderiv_within_at (λ y, c y • f y) (c x • f' + c'.scalar_prod_space_iso (f x)) s x :=
 begin
-  have : is_bounded_bilinear_map k (λ (p : k × F), p.1 • p.2) := is_bounded_bilinear_map_smul,
+  have : is_bounded_bilinear_map 𝕂 (λ (p : 𝕂 × F), p.1 • p.2) := is_bounded_bilinear_map_smul,
   exact has_fderiv_at.comp_has_fderiv_within_at x (this.has_fderiv_at (c x, f x)) (hc.prod hf)
 end
 
 theorem has_fderiv_at.smul' (hc : has_fderiv_at c c' x) (hf : has_fderiv_at f f' x) :
   has_fderiv_at (λ y, c y • f y) (c x • f' + c'.scalar_prod_space_iso (f x)) x :=
 begin
-  have : is_bounded_bilinear_map k (λ (p : k × F), p.1 • p.2) := is_bounded_bilinear_map_smul,
+  have : is_bounded_bilinear_map 𝕂 (λ (p : 𝕂 × F), p.1 • p.2) := is_bounded_bilinear_map_smul,
   exact has_fderiv_at.comp x (this.has_fderiv_at (c x, f x)) (hc.prod hf)
 end
 
 lemma differentiable_within_at.smul'
-  (hc : differentiable_within_at k c s x) (hf : differentiable_within_at k f s x) :
-  differentiable_within_at k (λ y, c y • f y) s x :=
+  (hc : differentiable_within_at 𝕂 c s x) (hf : differentiable_within_at 𝕂 f s x) :
+  differentiable_within_at 𝕂 (λ y, c y • f y) s x :=
 (hc.has_fderiv_within_at.smul' hf.has_fderiv_within_at).differentiable_within_at
 
-lemma differentiable_at.smul' (hc : differentiable_at k c x) (hf : differentiable_at k f x) :
-  differentiable_at k (λ y, c y • f y) x :=
+lemma differentiable_at.smul' (hc : differentiable_at 𝕂 c x) (hf : differentiable_at 𝕂 f x) :
+  differentiable_at 𝕂 (λ y, c y • f y) x :=
 (hc.has_fderiv_at.smul' hf.has_fderiv_at).differentiable_at
 
-lemma differentiable_on.smul' (hc : differentiable_on k c s) (hf : differentiable_on k f s) :
-  differentiable_on k (λ y, c y • f y) s :=
+lemma differentiable_on.smul' (hc : differentiable_on 𝕂 c s) (hf : differentiable_on 𝕂 f s) :
+  differentiable_on 𝕂 (λ y, c y • f y) s :=
 λx hx, (hc x hx).smul' (hf x hx)
 
-lemma differentiable.smul' (hc : differentiable k c) (hf : differentiable k f) :
-  differentiable k (λ y, c y • f y) :=
+lemma differentiable.smul' (hc : differentiable 𝕂 c) (hf : differentiable 𝕂 f) :
+  differentiable 𝕂 (λ y, c y • f y) :=
 λx, (hc x).smul' (hf x)
 
-lemma fderiv_within_smul' (hxs : unique_diff_within_at k s x)
-  (hc : differentiable_within_at k c s x) (hf : differentiable_within_at k f s x) :
-  fderiv_within k (λ y, c y • f y) s x =
-    c x • fderiv_within k f s x + (fderiv_within k c s x).scalar_prod_space_iso (f x) :=
+lemma fderiv_within_smul' (hxs : unique_diff_within_at 𝕂 s x)
+  (hc : differentiable_within_at 𝕂 c s x) (hf : differentiable_within_at 𝕂 f s x) :
+  fderiv_within 𝕂 (λ y, c y • f y) s x =
+    c x • fderiv_within 𝕂 f s x + (fderiv_within 𝕂 c s x).scalar_prod_space_iso (f x) :=
 (hc.has_fderiv_within_at.smul' hf.has_fderiv_within_at).fderiv_within hxs
 
-lemma fderiv_smul' (hc : differentiable_at k c x) (hf : differentiable_at k f x) :
-  fderiv k (λ y, c y • f y) x =
-    c x • fderiv k f x + (fderiv k c x).scalar_prod_space_iso (f x) :=
+lemma fderiv_smul' (hc : differentiable_at 𝕂 c x) (hf : differentiable_at 𝕂 f x) :
+  fderiv 𝕂 (λ y, c y • f y) x =
+    c x • fderiv 𝕂 f x + (fderiv 𝕂 c x).scalar_prod_space_iso (f x) :=
 (hc.has_fderiv_at.smul' hf.has_fderiv_at).fderiv
 
 end smul
@@ -1097,13 +1097,13 @@ end smul
 
 section mul
 set_option class.instance_max_depth 120
-variables {c d : E → k} {c' d' : E →L[k] k}
+variables {c d : E → 𝕂} {c' d' : E →L[𝕂] 𝕂}
 
 theorem has_fderiv_within_at.mul
   (hc : has_fderiv_within_at c c' s x) (hd : has_fderiv_within_at d d' s x) :
   has_fderiv_within_at (λ y, c y * d y) (c x • d' + d x • c') s x :=
 begin
-  have : is_bounded_bilinear_map k (λ (p : k × k), p.1 * p.2) := is_bounded_bilinear_map_mul,
+  have : is_bounded_bilinear_map 𝕂 (λ (p : 𝕂 × 𝕂), p.1 * p.2) := is_bounded_bilinear_map_mul,
   convert has_fderiv_at.comp_has_fderiv_within_at x (this.has_fderiv_at (c x, d x)) (hc.prod hd),
   ext z,
   change c x * d' z + d x * c' z = c x * d' z + c' z * d x,
@@ -1113,7 +1113,7 @@ end
 theorem has_fderiv_at.mul (hc : has_fderiv_at c c' x) (hd : has_fderiv_at d d' x) :
   has_fderiv_at (λ y, c y * d y) (c x • d' + d x • c') x :=
 begin
-  have : is_bounded_bilinear_map k (λ (p : k × k), p.1 * p.2) := is_bounded_bilinear_map_mul,
+  have : is_bounded_bilinear_map 𝕂 (λ (p : 𝕂 × 𝕂), p.1 * p.2) := is_bounded_bilinear_map_mul,
   convert has_fderiv_at.comp x (this.has_fderiv_at (c x, d x)) (hc.prod hd),
   ext z,
   change c x * d' z + d x * c' z = c x * d' z + c' z * d x,
@@ -1121,31 +1121,31 @@ begin
 end
 
 lemma differentiable_within_at.mul
-  (hc : differentiable_within_at k c s x) (hd : differentiable_within_at k d s x) :
-  differentiable_within_at k (λ y, c y * d y) s x :=
+  (hc : differentiable_within_at 𝕂 c s x) (hd : differentiable_within_at 𝕂 d s x) :
+  differentiable_within_at 𝕂 (λ y, c y * d y) s x :=
 (hc.has_fderiv_within_at.mul hd.has_fderiv_within_at).differentiable_within_at
 
-lemma differentiable_at.mul (hc : differentiable_at k c x) (hd : differentiable_at k d x) :
-  differentiable_at k (λ y, c y * d y) x :=
+lemma differentiable_at.mul (hc : differentiable_at 𝕂 c x) (hd : differentiable_at 𝕂 d x) :
+  differentiable_at 𝕂 (λ y, c y * d y) x :=
 (hc.has_fderiv_at.mul hd.has_fderiv_at).differentiable_at
 
-lemma differentiable_on.mul (hc : differentiable_on k c s) (hd : differentiable_on k d s) :
-  differentiable_on k (λ y, c y * d y) s :=
+lemma differentiable_on.mul (hc : differentiable_on 𝕂 c s) (hd : differentiable_on 𝕂 d s) :
+  differentiable_on 𝕂 (λ y, c y * d y) s :=
 λx hx, (hc x hx).mul (hd x hx)
 
-lemma differentiable.mul (hc : differentiable k c) (hd : differentiable k d) :
-  differentiable k (λ y, c y * d y) :=
+lemma differentiable.mul (hc : differentiable 𝕂 c) (hd : differentiable 𝕂 d) :
+  differentiable 𝕂 (λ y, c y * d y) :=
 λx, (hc x).mul (hd x)
 
-lemma fderiv_within_mul (hxs : unique_diff_within_at k s x)
-  (hc : differentiable_within_at k c s x) (hd : differentiable_within_at k d s x) :
-  fderiv_within k (λ y, c y * d y) s x =
-    c x • fderiv_within k d s x + d x • fderiv_within k c s x :=
+lemma fderiv_within_mul (hxs : unique_diff_within_at 𝕂 s x)
+  (hc : differentiable_within_at 𝕂 c s x) (hd : differentiable_within_at 𝕂 d s x) :
+  fderiv_within 𝕂 (λ y, c y * d y) s x =
+    c x • fderiv_within 𝕂 d s x + d x • fderiv_within 𝕂 c s x :=
 (hc.has_fderiv_within_at.mul hd.has_fderiv_within_at).fderiv_within hxs
 
-lemma fderiv_mul (hc : differentiable_at k c x) (hd : differentiable_at k d x) :
-  fderiv k (λ y, c y * d y) x =
-    c x • fderiv k d x + d x • fderiv k c x :=
+lemma fderiv_mul (hc : differentiable_at 𝕂 c x) (hd : differentiable_at 𝕂 d x) :
+  fderiv 𝕂 (λ y, c y * d y) x =
+    c x • fderiv 𝕂 d x + d x • fderiv 𝕂 c x :=
 (hc.has_fderiv_at.mul hd.has_fderiv_at).fderiv
 
 end mul

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -5,8 +5,8 @@ Authors: Jeremy Avigad, Sébastien Gouëzel
 
 The Fréchet derivative.
 
-Let `E` and `F` be normed spaces, `f : E → F`, and `f' : E →L[𝕂] F` a
-continuous 𝕂-linear map, where `𝕂` is a non-discrete normed field. Then
+Let `E` and `F` be normed spaces, `f : E → F`, and `f' : E →L[𝕜] F` a
+continuous 𝕜-linear map, where `𝕜` is a non-discrete normed field. Then
 
   `has_fderiv_within_at f f' s x`
 
@@ -18,12 +18,12 @@ is restricted to `s`. We also have
 The derivative is defined in terms of the `is_o` relation, but also
 characterized in terms of the `tendsto` relation.
 
-We also introduce predicates `differentiable_within_at 𝕂 f s x` (where `𝕂` is the base field,
+We also introduce predicates `differentiable_within_at 𝕜 f s x` (where `𝕜` is the base field,
 `f` the function to be differentiated, `x` the point at which the derivative is asserted to exist,
-and `s` the set along which the derivative is defined), as well as `differentiable_at 𝕂 f x`,
-`differentiable_on 𝕂 f s` and `differentiable 𝕂 f` to express the existence of a derivative.
+and `s` the set along which the derivative is defined), as well as `differentiable_at 𝕜 f x`,
+`differentiable_on 𝕜 f s` and `differentiable 𝕜 f` to express the existence of a derivative.
 
-To be able to compute with derivatives, we write `fderiv_within 𝕂 f s x` and `fderiv 𝕂 f x`
+To be able to compute with derivatives, we write `fderiv_within 𝕜 f s x` and `fderiv 𝕜 f x`
 for some choice of a derivative if it exists, and the zero function otherwise. This choice only
 behaves well along sets for which the derivative is unique, i.e., those for which the tangent
 directions span a dense subset of the whole space. The predicates `unique_diff_within_at s x` and
@@ -59,43 +59,43 @@ set_option class.instance_max_depth 90
 
 section
 
-variables {𝕂 : Type*} [nondiscrete_normed_field 𝕂]
-variables {E : Type*} [normed_group E] [normed_space 𝕂 E]
-variables {F : Type*} [normed_group F] [normed_space 𝕂 F]
-variables {G : Type*} [normed_group G] [normed_space 𝕂 G]
+variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
+variables {E : Type*} [normed_group E] [normed_space 𝕜 E]
+variables {F : Type*} [normed_group F] [normed_space 𝕜 F]
+variables {G : Type*} [normed_group G] [normed_space 𝕜 G]
 
-def has_fderiv_at_filter (f : E → F) (f' : E →L[𝕂] F) (x : E) (L : filter E) :=
+def has_fderiv_at_filter (f : E → F) (f' : E →L[𝕜] F) (x : E) (L : filter E) :=
 is_o (λ x', f x' - f x - f' (x' - x)) (λ x', x' - x) L
 
-def has_fderiv_within_at (f : E → F) (f' : E →L[𝕂] F) (s : set E) (x : E) :=
+def has_fderiv_within_at (f : E → F) (f' : E →L[𝕜] F) (s : set E) (x : E) :=
 has_fderiv_at_filter f f' x (nhds_within x s)
 
-def has_fderiv_at (f : E → F) (f' : E →L[𝕂] F) (x : E) :=
+def has_fderiv_at (f : E → F) (f' : E →L[𝕜] F) (x : E) :=
 has_fderiv_at_filter f f' x (nhds x)
 
-variables (𝕂)
+variables (𝕜)
 
 def differentiable_within_at (f : E → F) (s : set E) (x : E) :=
-∃f' : E →L[𝕂] F, has_fderiv_within_at f f' s x
+∃f' : E →L[𝕜] F, has_fderiv_within_at f f' s x
 
 def differentiable_at (f : E → F) (x : E) :=
-∃f' : E →L[𝕂] F, has_fderiv_at f f' x
+∃f' : E →L[𝕜] F, has_fderiv_at f f' x
 
-def fderiv_within (f : E → F) (s : set E) (x : E) : E →L[𝕂] F :=
+def fderiv_within (f : E → F) (s : set E) (x : E) : E →L[𝕜] F :=
 if h : ∃f', has_fderiv_within_at f f' s x then classical.some h else 0
 
-def fderiv (f : E → F) (x : E) : E →L[𝕂] F :=
+def fderiv (f : E → F) (x : E) : E →L[𝕜] F :=
 if h : ∃f', has_fderiv_at f f' x then classical.some h else 0
 
 def differentiable_on (f : E → F) (s : set E) :=
-∀x ∈ s, differentiable_within_at 𝕂 f s x
+∀x ∈ s, differentiable_within_at 𝕜 f s x
 
 def differentiable (f : E → F) :=
-∀x, differentiable_at 𝕂 f x
+∀x, differentiable_at 𝕜 f x
 
-variables {𝕂}
+variables {𝕜}
 variables {f f₀ f₁ g : E → F}
-variables {f' f₀' f₁' g' : E →L[𝕂] F}
+variables {f' f₀' f₁' g' : E →L[𝕜] F}
 variables {x : E}
 variables {s t : set E}
 variables {L L₁ L₂ : filter E}
@@ -107,10 +107,10 @@ We prove that the definitions `unique_diff_within_at` and `unique_diff_on` indee
 uniqueness of the derivative. -/
 
 /-- `unique_diff_within_at` achieves its goal: it implies the uniqueness of the derivative. -/
-theorem unique_diff_within_at.eq (H : unique_diff_within_at 𝕂 s x)
+theorem unique_diff_within_at.eq (H : unique_diff_within_at 𝕜 s x)
   (h : has_fderiv_within_at f f' s x) (h₁ : has_fderiv_within_at f f₁' s x) : f' = f₁' :=
 begin
-  have A : ∀y ∈ tangent_cone_at 𝕂 s x, f' y = f₁' y,
+  have A : ∀y ∈ tangent_cone_at 𝕜 s x, f' y = f₁' y,
   { assume y hy,
     rcases hy with ⟨c, d, hd, hc, ylim⟩,
     have at_top_is_finer : at_top ≤ comap (λ (n : ℕ), x + d n) (nhds_within (x + 0) s),
@@ -138,18 +138,18 @@ begin
       apply tendsto_sub ((f₁'.continuous.tendsto _).comp ylim) ((f'.continuous.tendsto _).comp ylim) },
     have : f₁' y - f' y = 0 := tendsto_nhds_unique (by simp) L' L,
     exact (sub_eq_zero_iff_eq.1 this).symm },
-  have B : ∀y ∈ submodule.span 𝕂 (tangent_cone_at 𝕂 s x), f' y = f₁' y,
+  have B : ∀y ∈ submodule.span 𝕜 (tangent_cone_at 𝕜 s x), f' y = f₁' y,
   { assume y hy,
     apply submodule.span_induction hy,
     { exact λy hy, A y hy },
     { simp only [continuous_linear_map.map_zero] },
     { simp {contextual := tt} },
     { simp {contextual := tt} } },
-  have C : ∀y ∈ closure ((submodule.span 𝕂 (tangent_cone_at 𝕂 s x)) : set E), f' y = f₁' y,
+  have C : ∀y ∈ closure ((submodule.span 𝕜 (tangent_cone_at 𝕜 s x)) : set E), f' y = f₁' y,
   { assume y hy,
     let K := {y | f' y = f₁' y},
-    have : (submodule.span 𝕂 (tangent_cone_at 𝕂 s x) : set E) ⊆ K := B,
-    have : closure (submodule.span 𝕂 (tangent_cone_at 𝕂 s x) : set E) ⊆ closure K :=
+    have : (submodule.span 𝕜 (tangent_cone_at 𝕜 s x) : set E) ⊆ K := B,
+    have : closure (submodule.span 𝕜 (tangent_cone_at 𝕜 s x) : set E) ⊆ closure K :=
       closure_mono this,
     have : y ∈ closure K := this hy,
     rwa closure_eq_of_is_closed (is_closed_eq f'.continuous f₁'.continuous) at this },
@@ -158,7 +158,7 @@ begin
   exact C y (mem_univ _)
 end
 
-theorem unique_diff_on.eq (H : unique_diff_on 𝕂 s) (hx : x ∈ s)
+theorem unique_diff_on.eq (H : unique_diff_on 𝕜 s) (hx : x ∈ s)
   (h : has_fderiv_within_at f f' s x) (h₁ : has_fderiv_within_at f f₁' s x) : f' = f₁' :=
 unique_diff_within_at.eq (H x hx) h h₁
 
@@ -203,10 +203,10 @@ theorem has_fderiv_at.has_fderiv_within_at
 h.has_fderiv_at_filter lattice.inf_le_left
 
 lemma has_fderiv_within_at.differentiable_within_at (h : has_fderiv_within_at f f' s x) :
-  differentiable_within_at 𝕂 f s x :=
+  differentiable_within_at 𝕜 f s x :=
 ⟨f', h⟩
 
-lemma has_fderiv_at.differentiable_at (h : has_fderiv_at f f' x) : differentiable_at 𝕂 f x :=
+lemma has_fderiv_at.differentiable_at (h : has_fderiv_at f f' x) : differentiable_at 𝕜 f x :=
 ⟨f', h⟩
 
 @[simp] lemma has_fderiv_within_at_univ :
@@ -228,8 +228,8 @@ lemma has_fderiv_within_at_inter (h : t ∈ nhds x) :
   has_fderiv_within_at f f' (s ∩ t) x ↔ has_fderiv_within_at f f' s x :=
 by simp [has_fderiv_within_at, nhds_within_restrict' s h]
 
-lemma differentiable_within_at.has_fderiv_within_at (h : differentiable_within_at 𝕂 f s x) :
-  has_fderiv_within_at f (fderiv_within 𝕂 f s x) s x :=
+lemma differentiable_within_at.has_fderiv_within_at (h : differentiable_within_at 𝕜 f s x) :
+  has_fderiv_within_at f (fderiv_within 𝕜 f s x) s x :=
 begin
   dunfold fderiv_within,
   dunfold differentiable_within_at at h,
@@ -237,8 +237,8 @@ begin
   exact classical.some_spec h
 end
 
-lemma differentiable_at.has_fderiv_at (h : differentiable_at 𝕂 f x) :
-  has_fderiv_at f (fderiv 𝕂 f x) x :=
+lemma differentiable_at.has_fderiv_at (h : differentiable_at 𝕜 f x) :
+  has_fderiv_at f (fderiv 𝕜 f x) x :=
 begin
   dunfold fderiv,
   dunfold differentiable_at at h,
@@ -246,102 +246,102 @@ begin
   exact classical.some_spec h
 end
 
-lemma has_fderiv_at.fderiv (h : has_fderiv_at f f' x) : fderiv 𝕂 f x = f' :=
+lemma has_fderiv_at.fderiv (h : has_fderiv_at f f' x) : fderiv 𝕜 f x = f' :=
 by { ext, rw has_fderiv_at_unique h h.differentiable_at.has_fderiv_at }
 
 lemma has_fderiv_within_at.fderiv_within
-  (h : has_fderiv_within_at f f' s x) (hxs : unique_diff_within_at 𝕂 s x) :
-  fderiv_within 𝕂 f s x = f' :=
+  (h : has_fderiv_within_at f f' s x) (hxs : unique_diff_within_at 𝕜 s x) :
+  fderiv_within 𝕜 f s x = f' :=
 by { ext, rw hxs.eq h h.differentiable_within_at.has_fderiv_within_at }
 
-lemma differentiable_within_at.mono (h : differentiable_within_at 𝕂 f t x) (st : s ⊆ t) :
-  differentiable_within_at 𝕂 f s x :=
+lemma differentiable_within_at.mono (h : differentiable_within_at 𝕜 f t x) (st : s ⊆ t) :
+  differentiable_within_at 𝕜 f s x :=
 begin
   rcases h with ⟨f', hf'⟩,
   exact ⟨f', hf'.mono st⟩
 end
 
 lemma differentiable_within_at_univ :
-  differentiable_within_at 𝕂 f univ x ↔ differentiable_at 𝕂 f x :=
+  differentiable_within_at 𝕜 f univ x ↔ differentiable_at 𝕜 f x :=
 begin
   simp [differentiable_within_at, has_fderiv_within_at, nhds_within_univ],
   refl
 end
 
 lemma differentiable_within_at_inter (ht : t ∈ nhds x) :
-  differentiable_within_at 𝕂 f (s ∩ t) x ↔ differentiable_within_at 𝕂 f s x :=
+  differentiable_within_at 𝕜 f (s ∩ t) x ↔ differentiable_within_at 𝕜 f s x :=
 by simp only [differentiable_within_at, has_fderiv_within_at, has_fderiv_at_filter,
     nhds_within_restrict' s ht]
 
 lemma differentiable_at.differentiable_within_at
-  (h : differentiable_at 𝕂 f x) : differentiable_within_at 𝕂 f s x :=
+  (h : differentiable_at 𝕜 f x) : differentiable_within_at 𝕜 f s x :=
 (differentiable_within_at_univ.2 h).mono (subset_univ _)
 
 lemma differentiable_within_at.differentiable_at
-  (h : differentiable_within_at 𝕂 f s x) (hs : s ∈ nhds x) : differentiable_at 𝕂 f x :=
+  (h : differentiable_within_at 𝕜 f s x) (hs : s ∈ nhds x) : differentiable_at 𝕜 f x :=
 begin
   have : s = univ ∩ s, by rw univ_inter,
   rwa [this, differentiable_within_at_inter hs, differentiable_within_at_univ] at h
 end
 
 lemma differentiable.fderiv_within
-  (h : differentiable_at 𝕂 f x) (hxs : unique_diff_within_at 𝕂 s x) :
-  fderiv_within 𝕂 f s x = fderiv 𝕂 f x :=
+  (h : differentiable_at 𝕜 f x) (hxs : unique_diff_within_at 𝕜 s x) :
+  fderiv_within 𝕜 f s x = fderiv 𝕜 f x :=
 begin
   apply has_fderiv_within_at.fderiv_within _ hxs,
   exact h.has_fderiv_at.has_fderiv_within_at
 end
 
-lemma differentiable_on.mono (h : differentiable_on 𝕂 f t) (st : s ⊆ t) :
-  differentiable_on 𝕂 f s :=
+lemma differentiable_on.mono (h : differentiable_on 𝕜 f t) (st : s ⊆ t) :
+  differentiable_on 𝕜 f s :=
 λx hx, (h x (st hx)).mono st
 
 lemma differentiable_on_univ :
-  differentiable_on 𝕂 f univ ↔ differentiable 𝕂 f :=
+  differentiable_on 𝕜 f univ ↔ differentiable 𝕜 f :=
 by { simp [differentiable_on, differentiable_within_at_univ], refl }
 
-lemma differentiable.differentiable_on (h : differentiable 𝕂 f) : differentiable_on 𝕂 f s :=
+lemma differentiable.differentiable_on (h : differentiable 𝕜 f) : differentiable_on 𝕜 f s :=
 (differentiable_on_univ.2 h).mono (subset_univ _)
 
 lemma differentiable_on_of_locally_differentiable_on
-  (h : ∀x∈s, ∃u, is_open u ∧ x ∈ u ∧ differentiable_on 𝕂 f (s ∩ u)) : differentiable_on 𝕂 f s :=
+  (h : ∀x∈s, ∃u, is_open u ∧ x ∈ u ∧ differentiable_on 𝕜 f (s ∩ u)) : differentiable_on 𝕜 f s :=
 begin
   assume x xs,
   rcases h x xs with ⟨t, t_open, xt, ht⟩,
   exact (differentiable_within_at_inter (mem_nhds_sets t_open xt)).1 (ht x ⟨xs, xt⟩)
 end
 
-lemma fderiv_within_subset (st : s ⊆ t) (ht : unique_diff_within_at 𝕂 s x)
-  (h : differentiable_within_at 𝕂 f t x) :
-  fderiv_within 𝕂 f s x = fderiv_within 𝕂 f t x :=
+lemma fderiv_within_subset (st : s ⊆ t) (ht : unique_diff_within_at 𝕜 s x)
+  (h : differentiable_within_at 𝕜 f t x) :
+  fderiv_within 𝕜 f s x = fderiv_within 𝕜 f t x :=
 ((differentiable_within_at.has_fderiv_within_at h).mono st).fderiv_within ht
 
-@[simp] lemma fderiv_within_univ : fderiv_within 𝕂 f univ = fderiv 𝕂 f :=
+@[simp] lemma fderiv_within_univ : fderiv_within 𝕜 f univ = fderiv 𝕜 f :=
 begin
   ext x : 1,
-  by_cases h : differentiable_at 𝕂 f x,
+  by_cases h : differentiable_at 𝕜 f x,
   { apply has_fderiv_within_at.fderiv_within _ (is_open_univ.unique_diff_within_at (mem_univ _)),
     rw has_fderiv_within_at_univ,
     apply h.has_fderiv_at },
-  { have : fderiv 𝕂 f x = 0,
+  { have : fderiv 𝕜 f x = 0,
       by { unfold differentiable_at at h, simp [fderiv, h] },
     rw this,
-    have : ¬(differentiable_within_at 𝕂 f univ x), by rwa differentiable_within_at_univ,
+    have : ¬(differentiable_within_at 𝕜 f univ x), by rwa differentiable_within_at_univ,
     unfold differentiable_within_at at this,
     simp [fderiv_within, this, -has_fderiv_within_at_univ] }
 end
 
-lemma fderiv_within_inter (ht : t ∈ nhds x) (hs : unique_diff_within_at 𝕂 s x) :
-  fderiv_within 𝕂 f (s ∩ t) x = fderiv_within 𝕂 f s x :=
+lemma fderiv_within_inter (ht : t ∈ nhds x) (hs : unique_diff_within_at 𝕜 s x) :
+  fderiv_within 𝕜 f (s ∩ t) x = fderiv_within 𝕜 f s x :=
 begin
-  by_cases h : differentiable_within_at 𝕂 f (s ∩ t) x,
+  by_cases h : differentiable_within_at 𝕜 f (s ∩ t) x,
   { apply fderiv_within_subset (inter_subset_left _ _) _ ((differentiable_within_at_inter ht).1 h),
     apply hs.inter ht },
-  { have : fderiv_within 𝕂 f (s ∩ t) x = 0,
+  { have : fderiv_within 𝕜 f (s ∩ t) x = 0,
       by { unfold differentiable_within_at at h, simp [fderiv_within, h] },
     rw this,
     rw differentiable_within_at_inter ht at h,
-    have : fderiv_within 𝕂 f s x = 0,
+    have : fderiv_within 𝕜 f s x = 0,
       by { unfold differentiable_within_at at h, simp [fderiv_within, h] },
     rw this }
 end
@@ -377,33 +377,33 @@ lemma has_fderiv_at.congr_of_mem_nhds (h : has_fderiv_at f f' x)
   (h₁ : {y | f₁ y = f y} ∈ nhds x) : has_fderiv_at f₁ f' x :=
 has_fderiv_at_filter.congr_of_mem_sets h h₁ (mem_of_nhds h₁ : _)
 
-lemma differentiable_within_at.congr_mono (h : differentiable_within_at 𝕂 f s x)
-  (ht : ∀x ∈ t, f₁ x = f x) (hx : f₁ x = f x) (h₁ : t ⊆ s) : differentiable_within_at 𝕂 f₁ t x :=
+lemma differentiable_within_at.congr_mono (h : differentiable_within_at 𝕜 f s x)
+  (ht : ∀x ∈ t, f₁ x = f x) (hx : f₁ x = f x) (h₁ : t ⊆ s) : differentiable_within_at 𝕜 f₁ t x :=
 (has_fderiv_within_at.congr_mono h.has_fderiv_within_at ht hx h₁).differentiable_within_at
 
 lemma differentiable_within_at.congr_of_mem_nhds_within
-  (h : differentiable_within_at 𝕂 f s x) (h₁ : {y | f₁ y = f y} ∈ nhds_within x s)
-  (hx : f₁ x = f x) : differentiable_within_at 𝕂 f₁ s x :=
+  (h : differentiable_within_at 𝕜 f s x) (h₁ : {y | f₁ y = f y} ∈ nhds_within x s)
+  (hx : f₁ x = f x) : differentiable_within_at 𝕜 f₁ s x :=
 (h.has_fderiv_within_at.congr_of_mem_nhds_within h₁ hx).differentiable_within_at
 
-lemma differentiable_on.congr_mono (h : differentiable_on 𝕂 f s) (h' : ∀x ∈ t, f₁ x = f x)
-  (h₁ : t ⊆ s) : differentiable_on 𝕂 f₁ t :=
+lemma differentiable_on.congr_mono (h : differentiable_on 𝕜 f s) (h' : ∀x ∈ t, f₁ x = f x)
+  (h₁ : t ⊆ s) : differentiable_on 𝕜 f₁ t :=
 λ x hx, (h x (h₁ hx)).congr_mono h' (h' x hx) h₁
 
-lemma differentiable_at.congr_of_mem_nhds (h : differentiable_at 𝕂 f x)
-  (hL : {y | f₁ y = f y} ∈ nhds x) : differentiable_at 𝕂 f₁ x :=
+lemma differentiable_at.congr_of_mem_nhds (h : differentiable_at 𝕜 f x)
+  (hL : {y | f₁ y = f y} ∈ nhds x) : differentiable_at 𝕜 f₁ x :=
 has_fderiv_at.differentiable_at (has_fderiv_at_filter.congr_of_mem_sets h.has_fderiv_at hL (mem_of_nhds hL : _))
 
-lemma differentiable_within_at.fderiv_within_congr_mono (h : differentiable_within_at 𝕂 f s x)
-  (hs : ∀x ∈ t, f₁ x = f x) (hx : f₁ x = f x) (hxt : unique_diff_within_at 𝕂 t x) (h₁ : t ⊆ s) :
-  fderiv_within 𝕂 f₁ t x = fderiv_within 𝕂 f s x :=
+lemma differentiable_within_at.fderiv_within_congr_mono (h : differentiable_within_at 𝕜 f s x)
+  (hs : ∀x ∈ t, f₁ x = f x) (hx : f₁ x = f x) (hxt : unique_diff_within_at 𝕜 t x) (h₁ : t ⊆ s) :
+  fderiv_within 𝕜 f₁ t x = fderiv_within 𝕜 f s x :=
 (has_fderiv_within_at.congr_mono h.has_fderiv_within_at hs hx h₁).fderiv_within hxt
 
-lemma fderiv_within_congr_of_mem_nhds_within (hs : unique_diff_within_at 𝕂 s x)
+lemma fderiv_within_congr_of_mem_nhds_within (hs : unique_diff_within_at 𝕜 s x)
   (hL : {y | f₁ y = f y} ∈ nhds_within x s) (hx : f₁ x = f x) :
-  fderiv_within 𝕂 f₁ s x = fderiv_within 𝕂 f s x :=
+  fderiv_within 𝕜 f₁ s x = fderiv_within 𝕜 f s x :=
 begin
-  by_cases h : differentiable_within_at 𝕂 f s x ∨ differentiable_within_at 𝕂 f₁ s x,
+  by_cases h : differentiable_within_at 𝕜 f s x ∨ differentiable_within_at 𝕜 f₁ s x,
   { cases h,
     { apply has_fderiv_within_at.fderiv_within _ hs,
       exact has_fderiv_at_filter.congr_of_mem_sets h.has_fderiv_within_at hL hx },
@@ -414,16 +414,16 @@ begin
       ext y,
       exact eq_comm } },
   { push_neg at h,
-    have A : fderiv_within 𝕂 f s x = 0,
+    have A : fderiv_within 𝕜 f s x = 0,
       by { unfold differentiable_within_at at h, simp [fderiv_within, h] },
-    have A₁ : fderiv_within 𝕂 f₁ s x = 0,
+    have A₁ : fderiv_within 𝕜 f₁ s x = 0,
       by { unfold differentiable_within_at at h, simp [fderiv_within, h] },
     rw [A, A₁] }
 end
 
-lemma fderiv_within_congr (hs : unique_diff_within_at 𝕂 s x)
+lemma fderiv_within_congr (hs : unique_diff_within_at 𝕜 s x)
   (hL : ∀y∈s, f₁ y = f y) (hx : f₁ x = f x) :
-  fderiv_within 𝕂 f₁ s x = fderiv_within 𝕂 f s x :=
+  fderiv_within 𝕜 f₁ s x = fderiv_within 𝕜 f s x :=
 begin
   apply fderiv_within_congr_of_mem_nhds_within hs _ hx,
   apply mem_sets_of_superset self_mem_nhds_within,
@@ -431,7 +431,7 @@ begin
 end
 
 lemma fderiv_congr_of_mem_nhds (hL : {y | f₁ y = f y} ∈ nhds x) :
-  fderiv 𝕂 f₁ x = fderiv 𝕂 f x :=
+  fderiv 𝕜 f₁ x = fderiv 𝕜 f x :=
 begin
   have A : f₁ x = f x := (mem_of_nhds hL : _),
   rw [← fderiv_within_univ, ← fderiv_within_univ],
@@ -445,33 +445,33 @@ end congr
 section id
 
 theorem has_fderiv_at_filter_id (x : E) (L : filter E) :
-  has_fderiv_at_filter id (id : E →L[𝕂] E) x L :=
+  has_fderiv_at_filter id (id : E →L[𝕜] E) x L :=
 (is_o_zero _ _).congr_left $ by simp
 
 theorem has_fderiv_within_at_id (x : E) (s : set E) :
-  has_fderiv_within_at id (id : E →L[𝕂] E) s x :=
+  has_fderiv_within_at id (id : E →L[𝕜] E) s x :=
 has_fderiv_at_filter_id _ _
 
-theorem has_fderiv_at_id (x : E) : has_fderiv_at id (id : E →L[𝕂] E) x :=
+theorem has_fderiv_at_id (x : E) : has_fderiv_at id (id : E →L[𝕜] E) x :=
 has_fderiv_at_filter_id _ _
 
-lemma differentiable_at_id : differentiable_at 𝕂 id x :=
+lemma differentiable_at_id : differentiable_at 𝕜 id x :=
 (has_fderiv_at_id x).differentiable_at
 
-lemma differentiable_within_at_id : differentiable_within_at 𝕂 id s x :=
+lemma differentiable_within_at_id : differentiable_within_at 𝕜 id s x :=
 differentiable_at_id.differentiable_within_at
 
-lemma differentiable_id : differentiable 𝕂 (id : E → E) :=
+lemma differentiable_id : differentiable 𝕜 (id : E → E) :=
 λx, differentiable_at_id
 
-lemma differentiable_on_id : differentiable_on 𝕂 id s :=
+lemma differentiable_on_id : differentiable_on 𝕜 id s :=
 differentiable_id.differentiable_on
 
-lemma fderiv_id : fderiv 𝕂 id x = id :=
+lemma fderiv_id : fderiv 𝕜 id x = id :=
 has_fderiv_at.fderiv (has_fderiv_at_id x)
 
-lemma fderiv_within_id (hxs : unique_diff_within_at 𝕂 s x) :
-  fderiv_within 𝕂 id s x = id :=
+lemma fderiv_within_id (hxs : unique_diff_within_at 𝕜 s x) :
+  fderiv_within 𝕜 id s x = id :=
 begin
   rw differentiable.fderiv_within (differentiable_at_id) hxs,
   exact fderiv_id
@@ -483,37 +483,37 @@ end id
 section const
 
 theorem has_fderiv_at_filter_const (c : F) (x : E) (L : filter E) :
-  has_fderiv_at_filter (λ x, c) (0 : E →L[𝕂] F) x L :=
+  has_fderiv_at_filter (λ x, c) (0 : E →L[𝕜] F) x L :=
 (is_o_zero _ _).congr_left $ λ _, by simp only [zero_apply, sub_self]
 
 theorem has_fderiv_within_at_const (c : F) (x : E) (s : set E) :
-  has_fderiv_within_at (λ x, c) (0 : E →L[𝕂] F) s x :=
+  has_fderiv_within_at (λ x, c) (0 : E →L[𝕜] F) s x :=
 has_fderiv_at_filter_const _ _ _
 
 theorem has_fderiv_at_const (c : F) (x : E) :
-  has_fderiv_at (λ x, c) (0 : E →L[𝕂] F) x :=
+  has_fderiv_at (λ x, c) (0 : E →L[𝕜] F) x :=
 has_fderiv_at_filter_const _ _ _
 
-lemma differentiable_at_const (c : F) : differentiable_at 𝕂 (λx, c) x :=
+lemma differentiable_at_const (c : F) : differentiable_at 𝕜 (λx, c) x :=
 ⟨0, has_fderiv_at_const c x⟩
 
-lemma differentiable_within_at_const (c : F) : differentiable_within_at 𝕂 (λx, c) s x :=
+lemma differentiable_within_at_const (c : F) : differentiable_within_at 𝕜 (λx, c) s x :=
 differentiable_at.differentiable_within_at (differentiable_at_const _)
 
-lemma fderiv_const (c : F) : fderiv 𝕂 (λy, c) x = 0 :=
+lemma fderiv_const (c : F) : fderiv 𝕜 (λy, c) x = 0 :=
 has_fderiv_at.fderiv (has_fderiv_at_const c x)
 
-lemma fderiv_within_const (c : F) (hxs : unique_diff_within_at 𝕂 s x) :
-  fderiv_within 𝕂 (λy, c) s x = 0 :=
+lemma fderiv_within_const (c : F) (hxs : unique_diff_within_at 𝕜 s x) :
+  fderiv_within 𝕜 (λy, c) s x = 0 :=
 begin
   rw differentiable.fderiv_within (differentiable_at_const _) hxs,
   exact fderiv_const _
 end
 
-lemma differentiable_const (c : F) : differentiable 𝕂 (λx : E, c) :=
+lemma differentiable_const (c : F) : differentiable 𝕜 (λx : E, c) :=
 λx, differentiable_at_const _
 
-lemma differentiable_on_const (c : F) : differentiable_on 𝕂 (λx, c) s :=
+lemma differentiable_on_const (c : F) : differentiable_on 𝕜 (λx, c) s :=
 (differentiable_const _).differentiable_on
 
 end const
@@ -521,7 +521,7 @@ end const
 /- Bounded linear maps -/
 section is_bounded_linear_map
 
-lemma is_bounded_linear_map.has_fderiv_at_filter (h : is_bounded_linear_map 𝕂 f) :
+lemma is_bounded_linear_map.has_fderiv_at_filter (h : is_bounded_linear_map 𝕜 f) :
   has_fderiv_at_filter f h.to_continuous_linear_map x L :=
 begin
   have : (λ (x' : E), f x' - f x - h.to_continuous_linear_map (x' - x)) = λx', 0,
@@ -533,39 +533,39 @@ begin
   exact asymptotics.is_o_zero _ _
 end
 
-lemma is_bounded_linear_map.has_fderiv_within_at (h : is_bounded_linear_map 𝕂 f) :
+lemma is_bounded_linear_map.has_fderiv_within_at (h : is_bounded_linear_map 𝕜 f) :
   has_fderiv_within_at f h.to_continuous_linear_map s x :=
 h.has_fderiv_at_filter
 
-lemma is_bounded_linear_map.has_fderiv_at (h : is_bounded_linear_map 𝕂 f) :
+lemma is_bounded_linear_map.has_fderiv_at (h : is_bounded_linear_map 𝕜 f) :
   has_fderiv_at f h.to_continuous_linear_map x  :=
 h.has_fderiv_at_filter
 
-lemma is_bounded_linear_map.differentiable_at (h : is_bounded_linear_map 𝕂 f) :
-  differentiable_at 𝕂 f x :=
+lemma is_bounded_linear_map.differentiable_at (h : is_bounded_linear_map 𝕜 f) :
+  differentiable_at 𝕜 f x :=
 h.has_fderiv_at.differentiable_at
 
-lemma is_bounded_linear_map.differentiable_within_at (h : is_bounded_linear_map 𝕂 f) :
-  differentiable_within_at 𝕂 f s x :=
+lemma is_bounded_linear_map.differentiable_within_at (h : is_bounded_linear_map 𝕜 f) :
+  differentiable_within_at 𝕜 f s x :=
 h.differentiable_at.differentiable_within_at
 
-lemma is_bounded_linear_map.fderiv (h : is_bounded_linear_map 𝕂 f) :
-  fderiv 𝕂 f x = h.to_continuous_linear_map :=
+lemma is_bounded_linear_map.fderiv (h : is_bounded_linear_map 𝕜 f) :
+  fderiv 𝕜 f x = h.to_continuous_linear_map :=
 has_fderiv_at.fderiv (h.has_fderiv_at)
 
-lemma is_bounded_linear_map.fderiv_within (h : is_bounded_linear_map 𝕂 f)
-  (hxs : unique_diff_within_at 𝕂 s x) : fderiv_within 𝕂 f s x = h.to_continuous_linear_map :=
+lemma is_bounded_linear_map.fderiv_within (h : is_bounded_linear_map 𝕜 f)
+  (hxs : unique_diff_within_at 𝕜 s x) : fderiv_within 𝕜 f s x = h.to_continuous_linear_map :=
 begin
   rw differentiable.fderiv_within h.differentiable_at hxs,
   exact h.fderiv
 end
 
-lemma is_bounded_linear_map.differentiable (h : is_bounded_linear_map 𝕂 f) :
-  differentiable 𝕂 f :=
+lemma is_bounded_linear_map.differentiable (h : is_bounded_linear_map 𝕜 f) :
+  differentiable 𝕜 f :=
 λx, h.differentiable_at
 
-lemma is_bounded_linear_map.differentiable_on (h : is_bounded_linear_map 𝕂 f) :
-  differentiable_on 𝕂 f s :=
+lemma is_bounded_linear_map.differentiable_on (h : is_bounded_linear_map 𝕜 f) :
+  differentiable_on 𝕜 f s :=
 h.differentiable.differentiable_on
 
 end is_bounded_linear_map
@@ -573,41 +573,41 @@ end is_bounded_linear_map
 /- multiplication by a constant -/
 section smul_const
 
-theorem has_fderiv_at_filter.smul (h : has_fderiv_at_filter f f' x L) (c : 𝕂) :
+theorem has_fderiv_at_filter.smul (h : has_fderiv_at_filter f f' x L) (c : 𝕜) :
   has_fderiv_at_filter (λ x, c • f x) (c • f') x L :=
 (is_o_const_smul_left h c).congr_left $ λ x, by simp [smul_neg, smul_add]
 
-theorem has_fderiv_within_at.smul (h : has_fderiv_within_at f f' s x) (c : 𝕂) :
+theorem has_fderiv_within_at.smul (h : has_fderiv_within_at f f' s x) (c : 𝕜) :
   has_fderiv_within_at (λ x, c • f x) (c • f') s x :=
 h.smul c
 
-theorem has_fderiv_at.smul (h : has_fderiv_at f f' x) (c : 𝕂) :
+theorem has_fderiv_at.smul (h : has_fderiv_at f f' x) (c : 𝕜) :
   has_fderiv_at (λ x, c • f x) (c • f') x :=
 h.smul c
 
-lemma differentiable_within_at.smul (h : differentiable_within_at 𝕂 f s x) (c : 𝕂) :
-  differentiable_within_at 𝕂 (λy, c • f y) s x :=
+lemma differentiable_within_at.smul (h : differentiable_within_at 𝕜 f s x) (c : 𝕜) :
+  differentiable_within_at 𝕜 (λy, c • f y) s x :=
 (h.has_fderiv_within_at.smul c).differentiable_within_at
 
-lemma differentiable_at.smul (h : differentiable_at 𝕂 f x) (c : 𝕂) :
-  differentiable_at 𝕂 (λy, c • f y) x :=
+lemma differentiable_at.smul (h : differentiable_at 𝕜 f x) (c : 𝕜) :
+  differentiable_at 𝕜 (λy, c • f y) x :=
 (h.has_fderiv_at.smul c).differentiable_at
 
-lemma differentiable_on.smul (h : differentiable_on 𝕂 f s) (c : 𝕂) :
-  differentiable_on 𝕂 (λy, c • f y) s :=
+lemma differentiable_on.smul (h : differentiable_on 𝕜 f s) (c : 𝕜) :
+  differentiable_on 𝕜 (λy, c • f y) s :=
 λx hx, (h x hx).smul c
 
-lemma differentiable.smul (h : differentiable 𝕂 f) (c : 𝕂) :
-  differentiable 𝕂 (λy, c • f y) :=
+lemma differentiable.smul (h : differentiable 𝕜 f) (c : 𝕜) :
+  differentiable 𝕜 (λy, c • f y) :=
 λx, (h x).smul c
 
-lemma fderiv_within_smul (hxs : unique_diff_within_at 𝕂 s x)
-  (h : differentiable_within_at 𝕂 f s x) (c : 𝕂) :
-  fderiv_within 𝕂 (λy, c • f y) s x = c • fderiv_within 𝕂 f s x :=
+lemma fderiv_within_smul (hxs : unique_diff_within_at 𝕜 s x)
+  (h : differentiable_within_at 𝕜 f s x) (c : 𝕜) :
+  fderiv_within 𝕜 (λy, c • f y) s x = c • fderiv_within 𝕜 f s x :=
 (h.has_fderiv_within_at.smul c).fderiv_within hxs
 
-lemma fderiv_smul (h : differentiable_at 𝕂 f x) (c : 𝕂) :
-  fderiv 𝕂 (λy, c • f y) x = c • fderiv 𝕂 f x :=
+lemma fderiv_smul (h : differentiable_at 𝕜 f x) (c : 𝕜) :
+  fderiv 𝕜 (λy, c • f y) x = c • fderiv 𝕜 f x :=
 (h.has_fderiv_at.smul c).fderiv
 
 end smul_const
@@ -631,33 +631,33 @@ theorem has_fderiv_at.add
 hf.add hg
 
 lemma differentiable_within_at.add
-  (hf : differentiable_within_at 𝕂 f s x) (hg : differentiable_within_at 𝕂 g s x) :
-  differentiable_within_at 𝕂 (λ y, f y + g y) s x :=
+  (hf : differentiable_within_at 𝕜 f s x) (hg : differentiable_within_at 𝕜 g s x) :
+  differentiable_within_at 𝕜 (λ y, f y + g y) s x :=
 (hf.has_fderiv_within_at.add hg.has_fderiv_within_at).differentiable_within_at
 
 lemma differentiable_at.add
-  (hf : differentiable_at 𝕂 f x) (hg : differentiable_at 𝕂 g x) :
-  differentiable_at 𝕂 (λ y, f y + g y) x :=
+  (hf : differentiable_at 𝕜 f x) (hg : differentiable_at 𝕜 g x) :
+  differentiable_at 𝕜 (λ y, f y + g y) x :=
 (hf.has_fderiv_at.add hg.has_fderiv_at).differentiable_at
 
 lemma differentiable_on.add
-  (hf : differentiable_on 𝕂 f s) (hg : differentiable_on 𝕂 g s) :
-  differentiable_on 𝕂 (λy, f y + g y) s :=
+  (hf : differentiable_on 𝕜 f s) (hg : differentiable_on 𝕜 g s) :
+  differentiable_on 𝕜 (λy, f y + g y) s :=
 λx hx, (hf x hx).add (hg x hx)
 
 lemma differentiable.add
-  (hf : differentiable 𝕂 f) (hg : differentiable 𝕂 g) :
-  differentiable 𝕂 (λy, f y + g y) :=
+  (hf : differentiable 𝕜 f) (hg : differentiable 𝕜 g) :
+  differentiable 𝕜 (λy, f y + g y) :=
 λx, (hf x).add (hg x)
 
-lemma fderiv_within_add (hxs : unique_diff_within_at 𝕂 s x)
-  (hf : differentiable_within_at 𝕂 f s x) (hg : differentiable_within_at 𝕂 g s x) :
-  fderiv_within 𝕂 (λy, f y + g y) s x = fderiv_within 𝕂 f s x + fderiv_within 𝕂 g s x :=
+lemma fderiv_within_add (hxs : unique_diff_within_at 𝕜 s x)
+  (hf : differentiable_within_at 𝕜 f s x) (hg : differentiable_within_at 𝕜 g s x) :
+  fderiv_within 𝕜 (λy, f y + g y) s x = fderiv_within 𝕜 f s x + fderiv_within 𝕜 g s x :=
 (hf.has_fderiv_within_at.add hg.has_fderiv_within_at).fderiv_within hxs
 
 lemma fderiv_add
-  (hf : differentiable_at 𝕂 f x) (hg : differentiable_at 𝕂 g x) :
-  fderiv 𝕂 (λy, f y + g y) x = fderiv 𝕂 f x + fderiv 𝕂 g x :=
+  (hf : differentiable_at 𝕜 f x) (hg : differentiable_at 𝕜 g x) :
+  fderiv 𝕜 (λy, f y + g y) x = fderiv 𝕜 f x + fderiv 𝕜 g x :=
 (hf.has_fderiv_at.add hg.has_fderiv_at).fderiv
 
 end add
@@ -667,7 +667,7 @@ section neg
 
 theorem has_fderiv_at_filter.neg (h : has_fderiv_at_filter f f' x L) :
   has_fderiv_at_filter (λ x, -f x) (-f') x L :=
-(h.smul (-1:𝕂)).congr (by simp) (by simp)
+(h.smul (-1:𝕜)).congr (by simp) (by simp)
 
 theorem has_fderiv_within_at.neg (h : has_fderiv_within_at f f' s x) :
   has_fderiv_within_at (λ x, -f x) (-f') s x :=
@@ -677,29 +677,29 @@ theorem has_fderiv_at.neg (h : has_fderiv_at f f' x) :
   has_fderiv_at (λ x, -f x) (-f') x :=
 h.neg
 
-lemma differentiable_within_at.neg (h : differentiable_within_at 𝕂 f s x) :
-  differentiable_within_at 𝕂 (λy, -f y) s x :=
+lemma differentiable_within_at.neg (h : differentiable_within_at 𝕜 f s x) :
+  differentiable_within_at 𝕜 (λy, -f y) s x :=
 h.has_fderiv_within_at.neg.differentiable_within_at
 
-lemma differentiable_at.neg (h : differentiable_at 𝕂 f x) :
-  differentiable_at 𝕂 (λy, -f y) x :=
+lemma differentiable_at.neg (h : differentiable_at 𝕜 f x) :
+  differentiable_at 𝕜 (λy, -f y) x :=
 h.has_fderiv_at.neg.differentiable_at
 
-lemma differentiable_on.neg (h : differentiable_on 𝕂 f s) :
-  differentiable_on 𝕂 (λy, -f y) s :=
+lemma differentiable_on.neg (h : differentiable_on 𝕜 f s) :
+  differentiable_on 𝕜 (λy, -f y) s :=
 λx hx, (h x hx).neg
 
-lemma differentiable.neg (h : differentiable 𝕂 f) :
-  differentiable 𝕂 (λy, -f y) :=
+lemma differentiable.neg (h : differentiable 𝕜 f) :
+  differentiable 𝕜 (λy, -f y) :=
 λx, (h x).neg
 
-lemma fderiv_within_neg (hxs : unique_diff_within_at 𝕂 s x)
-  (h : differentiable_within_at 𝕂 f s x) :
-  fderiv_within 𝕂 (λy, -f y) s x = - fderiv_within 𝕂 f s x :=
+lemma fderiv_within_neg (hxs : unique_diff_within_at 𝕜 s x)
+  (h : differentiable_within_at 𝕜 f s x) :
+  fderiv_within 𝕜 (λy, -f y) s x = - fderiv_within 𝕜 f s x :=
 h.has_fderiv_within_at.neg.fderiv_within hxs
 
-lemma fderiv_neg (h : differentiable_at 𝕂 f x) :
-  fderiv 𝕂 (λy, -f y) x = - fderiv 𝕂 f x :=
+lemma fderiv_neg (h : differentiable_at 𝕜 f x) :
+  fderiv 𝕜 (λy, -f y) x = - fderiv 𝕜 f x :=
 h.has_fderiv_at.neg.fderiv
 
 end neg
@@ -723,33 +723,33 @@ theorem has_fderiv_at.sub
 hf.sub hg
 
 lemma differentiable_within_at.sub
-  (hf : differentiable_within_at 𝕂 f s x) (hg : differentiable_within_at 𝕂 g s x) :
-  differentiable_within_at 𝕂 (λ y, f y - g y) s x :=
+  (hf : differentiable_within_at 𝕜 f s x) (hg : differentiable_within_at 𝕜 g s x) :
+  differentiable_within_at 𝕜 (λ y, f y - g y) s x :=
 (hf.has_fderiv_within_at.sub hg.has_fderiv_within_at).differentiable_within_at
 
 lemma differentiable_at.sub
-  (hf : differentiable_at 𝕂 f x) (hg : differentiable_at 𝕂 g x) :
-  differentiable_at 𝕂 (λ y, f y - g y) x :=
+  (hf : differentiable_at 𝕜 f x) (hg : differentiable_at 𝕜 g x) :
+  differentiable_at 𝕜 (λ y, f y - g y) x :=
 (hf.has_fderiv_at.sub hg.has_fderiv_at).differentiable_at
 
 lemma differentiable_on.sub
-  (hf : differentiable_on 𝕂 f s) (hg : differentiable_on 𝕂 g s) :
-  differentiable_on 𝕂 (λy, f y - g y) s :=
+  (hf : differentiable_on 𝕜 f s) (hg : differentiable_on 𝕜 g s) :
+  differentiable_on 𝕜 (λy, f y - g y) s :=
 λx hx, (hf x hx).sub (hg x hx)
 
 lemma differentiable.sub
-  (hf : differentiable 𝕂 f) (hg : differentiable 𝕂 g) :
-  differentiable 𝕂 (λy, f y - g y) :=
+  (hf : differentiable 𝕜 f) (hg : differentiable 𝕜 g) :
+  differentiable 𝕜 (λy, f y - g y) :=
 λx, (hf x).sub (hg x)
 
-lemma fderiv_within_sub (hxs : unique_diff_within_at 𝕂 s x)
-  (hf : differentiable_within_at 𝕂 f s x) (hg : differentiable_within_at 𝕂 g s x) :
-  fderiv_within 𝕂 (λy, f y - g y) s x = fderiv_within 𝕂 f s x - fderiv_within 𝕂 g s x :=
+lemma fderiv_within_sub (hxs : unique_diff_within_at 𝕜 s x)
+  (hf : differentiable_within_at 𝕜 f s x) (hg : differentiable_within_at 𝕜 g s x) :
+  fderiv_within 𝕜 (λy, f y - g y) s x = fderiv_within 𝕜 f s x - fderiv_within 𝕜 g s x :=
 (hf.has_fderiv_within_at.sub hg.has_fderiv_within_at).fderiv_within hxs
 
 lemma fderiv_sub
-  (hf : differentiable_at 𝕂 f x) (hg : differentiable_at 𝕂 g x) :
-  fderiv 𝕂 (λy, f y - g y) x = fderiv 𝕂 f x - fderiv 𝕂 g x :=
+  (hf : differentiable_at 𝕜 f x) (hg : differentiable_at 𝕜 g x) :
+  fderiv 𝕜 (λy, f y - g y) x = fderiv 𝕜 f x - fderiv 𝕜 g x :=
 (hf.has_fderiv_at.sub hg.has_fderiv_at).fderiv
 
 theorem has_fderiv_at_filter.is_O_sub (h : has_fderiv_at_filter f f' x L) :
@@ -781,17 +781,17 @@ theorem has_fderiv_at.continuous_at (h : has_fderiv_at f f' x) :
   continuous_at f x :=
 has_fderiv_at_filter.tendsto_nhds (le_refl _) h
 
-lemma differentiable_within_at.continuous_within_at (h : differentiable_within_at 𝕂 f s x) :
+lemma differentiable_within_at.continuous_within_at (h : differentiable_within_at 𝕜 f s x) :
   continuous_within_at f s x :=
 let ⟨f', hf'⟩ := h in hf'.continuous_within_at
 
-lemma differentiable_at.continuous_at (h : differentiable_at 𝕂 f x) : continuous_at f x :=
+lemma differentiable_at.continuous_at (h : differentiable_at 𝕜 f x) : continuous_at f x :=
 let ⟨f', hf'⟩ := h in hf'.continuous_at
 
-lemma differentiable_on.continuous_on (h : differentiable_on 𝕂 f s) : continuous_on f s :=
+lemma differentiable_on.continuous_on (h : differentiable_on 𝕜 f s) : continuous_on f s :=
 λx hx, (h x hx).continuous_within_at
 
-lemma differentiable.continuous (h : differentiable 𝕂 f) : continuous f :=
+lemma differentiable.continuous (h : differentiable 𝕜 f) : continuous f :=
 continuous_iff_continuous_at.2 $ λx, (h x).continuous_at
 
 end continuous
@@ -801,7 +801,7 @@ end continuous
 section bilinear_map
 variables {b : E × F → G} {u : set (E × F) }
 
-lemma is_bounded_bilinear_map.has_fderiv_at (h : is_bounded_bilinear_map 𝕂 b) (p : E × F) :
+lemma is_bounded_bilinear_map.has_fderiv_at (h : is_bounded_bilinear_map 𝕜 b) (p : E × F) :
   has_fderiv_at b (h.deriv p) p :=
 begin
   have : (λ (x : E × F), b x - b p - (h.deriv p) (x - p)) = (λx, b (x.1 - p.1, x.2 - p.2)),
@@ -840,38 +840,38 @@ begin
   exact A.trans_is_o B
 end
 
-lemma is_bounded_bilinear_map.has_fderiv_within_at (h : is_bounded_bilinear_map 𝕂 b) (p : E × F) :
+lemma is_bounded_bilinear_map.has_fderiv_within_at (h : is_bounded_bilinear_map 𝕜 b) (p : E × F) :
   has_fderiv_within_at b (h.deriv p) u p :=
 (h.has_fderiv_at p).has_fderiv_within_at
 
-lemma is_bounded_bilinear_map.differentiable_at (h : is_bounded_bilinear_map 𝕂 b) (p : E × F) :
-  differentiable_at 𝕂 b p :=
+lemma is_bounded_bilinear_map.differentiable_at (h : is_bounded_bilinear_map 𝕜 b) (p : E × F) :
+  differentiable_at 𝕜 b p :=
 (h.has_fderiv_at p).differentiable_at
 
-lemma is_bounded_bilinear_map.differentiable_within_at (h : is_bounded_bilinear_map 𝕂 b) (p : E × F) :
-  differentiable_within_at 𝕂 b u p :=
+lemma is_bounded_bilinear_map.differentiable_within_at (h : is_bounded_bilinear_map 𝕜 b) (p : E × F) :
+  differentiable_within_at 𝕜 b u p :=
 (h.differentiable_at p).differentiable_within_at
 
-lemma is_bounded_bilinear_map.fderiv (h : is_bounded_bilinear_map 𝕂 b) (p : E × F) :
-  fderiv 𝕂 b p = h.deriv p :=
+lemma is_bounded_bilinear_map.fderiv (h : is_bounded_bilinear_map 𝕜 b) (p : E × F) :
+  fderiv 𝕜 b p = h.deriv p :=
 has_fderiv_at.fderiv (h.has_fderiv_at p)
 
-lemma is_bounded_bilinear_map.fderiv_within (h : is_bounded_bilinear_map 𝕂 b) (p : E × F)
-  (hxs : unique_diff_within_at 𝕂 u p) : fderiv_within 𝕂 b u p = h.deriv p :=
+lemma is_bounded_bilinear_map.fderiv_within (h : is_bounded_bilinear_map 𝕜 b) (p : E × F)
+  (hxs : unique_diff_within_at 𝕜 u p) : fderiv_within 𝕜 b u p = h.deriv p :=
 begin
   rw differentiable.fderiv_within (h.differentiable_at p) hxs,
   exact h.fderiv p
 end
 
-lemma is_bounded_bilinear_map.differentiable (h : is_bounded_bilinear_map 𝕂 b) :
-  differentiable 𝕂 b :=
+lemma is_bounded_bilinear_map.differentiable (h : is_bounded_bilinear_map 𝕜 b) :
+  differentiable 𝕜 b :=
 λx, h.differentiable_at x
 
-lemma is_bounded_bilinear_map.differentiable_on (h : is_bounded_bilinear_map 𝕂 b) :
-  differentiable_on 𝕂 b u :=
+lemma is_bounded_bilinear_map.differentiable_on (h : is_bounded_bilinear_map 𝕜 b) :
+  differentiable_on 𝕜 b u :=
 h.differentiable.differentiable_on
 
-lemma is_bounded_bilinear_map.continuous (h : is_bounded_bilinear_map 𝕂 b) :
+lemma is_bounded_bilinear_map.continuous (h : is_bounded_bilinear_map 𝕜 b) :
   continuous b :=
 h.differentiable.continuous
 
@@ -880,7 +880,7 @@ end bilinear_map
 
 /- Cartesian products -/
 section cartesian_product
-variables {f₂ : E → G} {f₂' : E →L[𝕂] G}
+variables {f₂ : E → G} {f₂' : E →L[𝕜] G}
 
 lemma has_fderiv_at_filter.prod
   (hf₁ : has_fderiv_at_filter f₁ f₁' x L) (hf₂ : has_fderiv_at_filter f₂ f₂' x L) :
@@ -903,33 +903,33 @@ lemma has_fderiv_at.prod (hf₁ : has_fderiv_at f₁ f₁' x) (hf₂ : has_fderi
 hf₁.prod hf₂
 
 lemma differentiable_within_at.prod
-  (hf₁ : differentiable_within_at 𝕂 f₁ s x) (hf₂ : differentiable_within_at 𝕂 f₂ s x) :
-  differentiable_within_at 𝕂 (λx:E, (f₁ x, f₂ x)) s x :=
+  (hf₁ : differentiable_within_at 𝕜 f₁ s x) (hf₂ : differentiable_within_at 𝕜 f₂ s x) :
+  differentiable_within_at 𝕜 (λx:E, (f₁ x, f₂ x)) s x :=
 (hf₁.has_fderiv_within_at.prod hf₂.has_fderiv_within_at).differentiable_within_at
 
-lemma differentiable_at.prod (hf₁ : differentiable_at 𝕂 f₁ x) (hf₂ : differentiable_at 𝕂 f₂ x) :
-  differentiable_at 𝕂 (λx:E, (f₁ x, f₂ x)) x :=
+lemma differentiable_at.prod (hf₁ : differentiable_at 𝕜 f₁ x) (hf₂ : differentiable_at 𝕜 f₂ x) :
+  differentiable_at 𝕜 (λx:E, (f₁ x, f₂ x)) x :=
 (hf₁.has_fderiv_at.prod hf₂.has_fderiv_at).differentiable_at
 
-lemma differentiable_on.prod (hf₁ : differentiable_on 𝕂 f₁ s) (hf₂ : differentiable_on 𝕂 f₂ s) :
-  differentiable_on 𝕂 (λx:E, (f₁ x, f₂ x)) s :=
+lemma differentiable_on.prod (hf₁ : differentiable_on 𝕜 f₁ s) (hf₂ : differentiable_on 𝕜 f₂ s) :
+  differentiable_on 𝕜 (λx:E, (f₁ x, f₂ x)) s :=
 λx hx, differentiable_within_at.prod (hf₁ x hx) (hf₂ x hx)
 
-lemma differentiable.prod (hf₁ : differentiable 𝕂 f₁) (hf₂ : differentiable 𝕂 f₂) :
-  differentiable 𝕂 (λx:E, (f₁ x, f₂ x)) :=
+lemma differentiable.prod (hf₁ : differentiable 𝕜 f₁) (hf₂ : differentiable 𝕜 f₂) :
+  differentiable 𝕜 (λx:E, (f₁ x, f₂ x)) :=
 λ x, differentiable_at.prod (hf₁ x) (hf₂ x)
 
 lemma differentiable_at.fderiv_prod
-  (hf₁ : differentiable_at 𝕂 f₁ x) (hf₂ : differentiable_at 𝕂 f₂ x) :
-  fderiv 𝕂 (λx:E, (f₁ x, f₂ x)) x =
-    continuous_linear_map.prod (fderiv 𝕂 f₁ x) (fderiv 𝕂 f₂ x) :=
+  (hf₁ : differentiable_at 𝕜 f₁ x) (hf₂ : differentiable_at 𝕜 f₂ x) :
+  fderiv 𝕜 (λx:E, (f₁ x, f₂ x)) x =
+    continuous_linear_map.prod (fderiv 𝕜 f₁ x) (fderiv 𝕜 f₂ x) :=
 has_fderiv_at.fderiv (has_fderiv_at.prod hf₁.has_fderiv_at hf₂.has_fderiv_at)
 
 lemma differentiable_at.fderiv_within_prod
-  (hf₁ : differentiable_within_at 𝕂 f₁ s x) (hf₂ : differentiable_within_at 𝕂 f₂ s x)
-  (hxs : unique_diff_within_at 𝕂 s x) :
-  fderiv_within 𝕂 (λx:E, (f₁ x, f₂ x)) s x =
-    continuous_linear_map.prod (fderiv_within 𝕂 f₁ s x) (fderiv_within 𝕂 f₂ s x) :=
+  (hf₁ : differentiable_within_at 𝕜 f₁ s x) (hf₂ : differentiable_within_at 𝕜 f₂ s x)
+  (hxs : unique_diff_within_at 𝕜 s x) :
+  fderiv_within 𝕜 (λx:E, (f₁ x, f₂ x)) s x =
+    continuous_linear_map.prod (fderiv_within 𝕜 f₁ s x) (fderiv_within 𝕜 f₂ s x) :=
 begin
   apply has_fderiv_within_at.fderiv_within _ hxs,
   exact has_fderiv_within_at.prod hf₁.has_fderiv_within_at hf₂.has_fderiv_within_at
@@ -945,7 +945,7 @@ get confused since there are too many possibilities for composition -/
 
 variable (x)
 
-theorem has_fderiv_at_filter.comp {g : F → G} {g' : F →L[𝕂] G}
+theorem has_fderiv_at_filter.comp {g : F → G} {g' : F →L[𝕜] G}
   (hg : has_fderiv_at_filter g g' (f x) (L.map f))
   (hf : has_fderiv_at_filter f f' x L) :
   has_fderiv_at_filter (g ∘ f) (g'.comp f') x L :=
@@ -956,7 +956,7 @@ by { refine eq₂.tri (eq₁.congr_left (λ x', _)), simp }
 /- A readable version of the previous theorem,
    a general form of the chain rule. -/
 
-example {g : F → G} {g' : F →L[𝕂] G}
+example {g : F → G} {g' : F →L[𝕜] G}
   (hg : has_fderiv_at_filter g g' (f x) (L.map f))
   (hf : has_fderiv_at_filter f f' x L) :
   has_fderiv_at_filter (g ∘ f) (g'.comp f') x L :=
@@ -978,7 +978,7 @@ begin
   exact eq₁.tri eq₃
 end
 
-theorem has_fderiv_within_at.comp {g : F → G} {g' : F →L[𝕂] G}
+theorem has_fderiv_within_at.comp {g : F → G} {g' : F →L[𝕜] G}
   (hg : has_fderiv_within_at g g' (f '' s) (f x))
   (hf : has_fderiv_within_at f f' s x) :
   has_fderiv_within_at (g ∘ f) (g'.comp f') s x :=
@@ -986,12 +986,12 @@ theorem has_fderiv_within_at.comp {g : F → G} {g' : F →L[𝕂] G}
   hf.continuous_within_at.tendsto_nhds_within_image).comp x hf
 
 /-- The chain rule. -/
-theorem has_fderiv_at.comp {g : F → G} {g' : F →L[𝕂] G}
+theorem has_fderiv_at.comp {g : F → G} {g' : F →L[𝕜] G}
   (hg : has_fderiv_at g g' (f x)) (hf : has_fderiv_at f f' x) :
   has_fderiv_at (g ∘ f) (g'.comp f') x :=
 (hg.mono hf.continuous_at).comp x hf
 
-theorem has_fderiv_at.comp_has_fderiv_within_at {g : F → G} {g' : F →L[𝕂] G}
+theorem has_fderiv_at.comp_has_fderiv_within_at {g : F → G} {g' : F →L[𝕜] G}
   (hg : has_fderiv_at g g' (f x)) (hf : has_fderiv_within_at f f' s x) :
   has_fderiv_within_at (g ∘ f) (g'.comp f') s x :=
 begin
@@ -1000,8 +1000,8 @@ begin
 end
 
 lemma differentiable_within_at.comp {g : F → G} {t : set F}
-  (hg : differentiable_within_at 𝕂 g t (f x)) (hf : differentiable_within_at 𝕂 f s x)
-  (h : f '' s ⊆ t) : differentiable_within_at 𝕂 (g ∘ f) s x :=
+  (hg : differentiable_within_at 𝕜 g t (f x)) (hf : differentiable_within_at 𝕜 f s x)
+  (h : f '' s ⊆ t) : differentiable_within_at 𝕜 (g ∘ f) s x :=
 begin
   rcases hf with ⟨f', hf'⟩,
   rcases hg with ⟨g', hg'⟩,
@@ -1009,15 +1009,15 @@ begin
 end
 
 lemma differentiable_at.comp {g : F → G}
-  (hg : differentiable_at 𝕂 g (f x)) (hf : differentiable_at 𝕂 f x) :
-  differentiable_at 𝕂 (g ∘ f) x :=
+  (hg : differentiable_at 𝕜 g (f x)) (hf : differentiable_at 𝕜 f x) :
+  differentiable_at 𝕜 (g ∘ f) x :=
 (hg.has_fderiv_at.comp x hf.has_fderiv_at).differentiable_at
 
 lemma fderiv_within.comp {g : F → G} {t : set F}
-  (hg : differentiable_within_at 𝕂 g t (f x)) (hf : differentiable_within_at 𝕂 f s x)
-  (h : f '' s ⊆ t) (hxs : unique_diff_within_at 𝕂 s x) :
-  fderiv_within 𝕂 (g ∘ f) s x =
-    continuous_linear_map.comp (fderiv_within 𝕂 g t (f x)) (fderiv_within 𝕂 f s x) :=
+  (hg : differentiable_within_at 𝕜 g t (f x)) (hf : differentiable_within_at 𝕜 f s x)
+  (h : f '' s ⊆ t) (hxs : unique_diff_within_at 𝕜 s x) :
+  fderiv_within 𝕜 (g ∘ f) s x =
+    continuous_linear_map.comp (fderiv_within 𝕜 g t (f x)) (fderiv_within 𝕜 f s x) :=
 begin
   apply has_fderiv_within_at.fderiv_within _ hxs,
   apply has_fderiv_within_at.comp x _ (hf.has_fderiv_within_at),
@@ -1025,69 +1025,69 @@ begin
 end
 
 lemma fderiv.comp {g : F → G}
-  (hg : differentiable_at 𝕂 g (f x)) (hf : differentiable_at 𝕂 f x) :
-  fderiv 𝕂 (g ∘ f) x = continuous_linear_map.comp (fderiv 𝕂 g (f x)) (fderiv 𝕂 f x) :=
+  (hg : differentiable_at 𝕜 g (f x)) (hf : differentiable_at 𝕜 f x) :
+  fderiv 𝕜 (g ∘ f) x = continuous_linear_map.comp (fderiv 𝕜 g (f x)) (fderiv 𝕜 f x) :=
 begin
   apply has_fderiv_at.fderiv,
   exact has_fderiv_at.comp x hg.has_fderiv_at hf.has_fderiv_at
 end
 
 lemma differentiable_on.comp {g : F → G} {t : set F}
-  (hg : differentiable_on 𝕂 g t) (hf : differentiable_on 𝕂 f s) (st : f '' s ⊆ t) :
-  differentiable_on 𝕂 (g ∘ f) s :=
+  (hg : differentiable_on 𝕜 g t) (hf : differentiable_on 𝕜 f s) (st : f '' s ⊆ t) :
+  differentiable_on 𝕜 (g ∘ f) s :=
 λx hx, differentiable_within_at.comp x (hg (f x) (st (mem_image_of_mem _ hx))) (hf x hx) st
 
-lemma differentiable.comp {g : F → G} (hg : differentiable 𝕂 g) (hf : differentiable 𝕂 f) :
-  differentiable 𝕂 (g ∘ f) :=
+lemma differentiable.comp {g : F → G} (hg : differentiable 𝕜 g) (hf : differentiable 𝕜 f) :
+  differentiable 𝕜 (g ∘ f) :=
 λx, differentiable_at.comp x (hg (f x)) (hf x)
 
 end composition
 
 /- Multiplication by a scalar function -/
 section smul
-variables {c : E → 𝕂} {c' : E →L[𝕂] 𝕂}
+variables {c : E → 𝕜} {c' : E →L[𝕜] 𝕜}
 
 theorem has_fderiv_within_at.smul'
   (hc : has_fderiv_within_at c c' s x) (hf : has_fderiv_within_at f f' s x) :
   has_fderiv_within_at (λ y, c y • f y) (c x • f' + c'.scalar_prod_space_iso (f x)) s x :=
 begin
-  have : is_bounded_bilinear_map 𝕂 (λ (p : 𝕂 × F), p.1 • p.2) := is_bounded_bilinear_map_smul,
+  have : is_bounded_bilinear_map 𝕜 (λ (p : 𝕜 × F), p.1 • p.2) := is_bounded_bilinear_map_smul,
   exact has_fderiv_at.comp_has_fderiv_within_at x (this.has_fderiv_at (c x, f x)) (hc.prod hf)
 end
 
 theorem has_fderiv_at.smul' (hc : has_fderiv_at c c' x) (hf : has_fderiv_at f f' x) :
   has_fderiv_at (λ y, c y • f y) (c x • f' + c'.scalar_prod_space_iso (f x)) x :=
 begin
-  have : is_bounded_bilinear_map 𝕂 (λ (p : 𝕂 × F), p.1 • p.2) := is_bounded_bilinear_map_smul,
+  have : is_bounded_bilinear_map 𝕜 (λ (p : 𝕜 × F), p.1 • p.2) := is_bounded_bilinear_map_smul,
   exact has_fderiv_at.comp x (this.has_fderiv_at (c x, f x)) (hc.prod hf)
 end
 
 lemma differentiable_within_at.smul'
-  (hc : differentiable_within_at 𝕂 c s x) (hf : differentiable_within_at 𝕂 f s x) :
-  differentiable_within_at 𝕂 (λ y, c y • f y) s x :=
+  (hc : differentiable_within_at 𝕜 c s x) (hf : differentiable_within_at 𝕜 f s x) :
+  differentiable_within_at 𝕜 (λ y, c y • f y) s x :=
 (hc.has_fderiv_within_at.smul' hf.has_fderiv_within_at).differentiable_within_at
 
-lemma differentiable_at.smul' (hc : differentiable_at 𝕂 c x) (hf : differentiable_at 𝕂 f x) :
-  differentiable_at 𝕂 (λ y, c y • f y) x :=
+lemma differentiable_at.smul' (hc : differentiable_at 𝕜 c x) (hf : differentiable_at 𝕜 f x) :
+  differentiable_at 𝕜 (λ y, c y • f y) x :=
 (hc.has_fderiv_at.smul' hf.has_fderiv_at).differentiable_at
 
-lemma differentiable_on.smul' (hc : differentiable_on 𝕂 c s) (hf : differentiable_on 𝕂 f s) :
-  differentiable_on 𝕂 (λ y, c y • f y) s :=
+lemma differentiable_on.smul' (hc : differentiable_on 𝕜 c s) (hf : differentiable_on 𝕜 f s) :
+  differentiable_on 𝕜 (λ y, c y • f y) s :=
 λx hx, (hc x hx).smul' (hf x hx)
 
-lemma differentiable.smul' (hc : differentiable 𝕂 c) (hf : differentiable 𝕂 f) :
-  differentiable 𝕂 (λ y, c y • f y) :=
+lemma differentiable.smul' (hc : differentiable 𝕜 c) (hf : differentiable 𝕜 f) :
+  differentiable 𝕜 (λ y, c y • f y) :=
 λx, (hc x).smul' (hf x)
 
-lemma fderiv_within_smul' (hxs : unique_diff_within_at 𝕂 s x)
-  (hc : differentiable_within_at 𝕂 c s x) (hf : differentiable_within_at 𝕂 f s x) :
-  fderiv_within 𝕂 (λ y, c y • f y) s x =
-    c x • fderiv_within 𝕂 f s x + (fderiv_within 𝕂 c s x).scalar_prod_space_iso (f x) :=
+lemma fderiv_within_smul' (hxs : unique_diff_within_at 𝕜 s x)
+  (hc : differentiable_within_at 𝕜 c s x) (hf : differentiable_within_at 𝕜 f s x) :
+  fderiv_within 𝕜 (λ y, c y • f y) s x =
+    c x • fderiv_within 𝕜 f s x + (fderiv_within 𝕜 c s x).scalar_prod_space_iso (f x) :=
 (hc.has_fderiv_within_at.smul' hf.has_fderiv_within_at).fderiv_within hxs
 
-lemma fderiv_smul' (hc : differentiable_at 𝕂 c x) (hf : differentiable_at 𝕂 f x) :
-  fderiv 𝕂 (λ y, c y • f y) x =
-    c x • fderiv 𝕂 f x + (fderiv 𝕂 c x).scalar_prod_space_iso (f x) :=
+lemma fderiv_smul' (hc : differentiable_at 𝕜 c x) (hf : differentiable_at 𝕜 f x) :
+  fderiv 𝕜 (λ y, c y • f y) x =
+    c x • fderiv 𝕜 f x + (fderiv 𝕜 c x).scalar_prod_space_iso (f x) :=
 (hc.has_fderiv_at.smul' hf.has_fderiv_at).fderiv
 
 end smul
@@ -1097,13 +1097,13 @@ end smul
 
 section mul
 set_option class.instance_max_depth 120
-variables {c d : E → 𝕂} {c' d' : E →L[𝕂] 𝕂}
+variables {c d : E → 𝕜} {c' d' : E →L[𝕜] 𝕜}
 
 theorem has_fderiv_within_at.mul
   (hc : has_fderiv_within_at c c' s x) (hd : has_fderiv_within_at d d' s x) :
   has_fderiv_within_at (λ y, c y * d y) (c x • d' + d x • c') s x :=
 begin
-  have : is_bounded_bilinear_map 𝕂 (λ (p : 𝕂 × 𝕂), p.1 * p.2) := is_bounded_bilinear_map_mul,
+  have : is_bounded_bilinear_map 𝕜 (λ (p : 𝕜 × 𝕜), p.1 * p.2) := is_bounded_bilinear_map_mul,
   convert has_fderiv_at.comp_has_fderiv_within_at x (this.has_fderiv_at (c x, d x)) (hc.prod hd),
   ext z,
   change c x * d' z + d x * c' z = c x * d' z + c' z * d x,
@@ -1113,7 +1113,7 @@ end
 theorem has_fderiv_at.mul (hc : has_fderiv_at c c' x) (hd : has_fderiv_at d d' x) :
   has_fderiv_at (λ y, c y * d y) (c x • d' + d x • c') x :=
 begin
-  have : is_bounded_bilinear_map 𝕂 (λ (p : 𝕂 × 𝕂), p.1 * p.2) := is_bounded_bilinear_map_mul,
+  have : is_bounded_bilinear_map 𝕜 (λ (p : 𝕜 × 𝕜), p.1 * p.2) := is_bounded_bilinear_map_mul,
   convert has_fderiv_at.comp x (this.has_fderiv_at (c x, d x)) (hc.prod hd),
   ext z,
   change c x * d' z + d x * c' z = c x * d' z + c' z * d x,
@@ -1121,31 +1121,31 @@ begin
 end
 
 lemma differentiable_within_at.mul
-  (hc : differentiable_within_at 𝕂 c s x) (hd : differentiable_within_at 𝕂 d s x) :
-  differentiable_within_at 𝕂 (λ y, c y * d y) s x :=
+  (hc : differentiable_within_at 𝕜 c s x) (hd : differentiable_within_at 𝕜 d s x) :
+  differentiable_within_at 𝕜 (λ y, c y * d y) s x :=
 (hc.has_fderiv_within_at.mul hd.has_fderiv_within_at).differentiable_within_at
 
-lemma differentiable_at.mul (hc : differentiable_at 𝕂 c x) (hd : differentiable_at 𝕂 d x) :
-  differentiable_at 𝕂 (λ y, c y * d y) x :=
+lemma differentiable_at.mul (hc : differentiable_at 𝕜 c x) (hd : differentiable_at 𝕜 d x) :
+  differentiable_at 𝕜 (λ y, c y * d y) x :=
 (hc.has_fderiv_at.mul hd.has_fderiv_at).differentiable_at
 
-lemma differentiable_on.mul (hc : differentiable_on 𝕂 c s) (hd : differentiable_on 𝕂 d s) :
-  differentiable_on 𝕂 (λ y, c y * d y) s :=
+lemma differentiable_on.mul (hc : differentiable_on 𝕜 c s) (hd : differentiable_on 𝕜 d s) :
+  differentiable_on 𝕜 (λ y, c y * d y) s :=
 λx hx, (hc x hx).mul (hd x hx)
 
-lemma differentiable.mul (hc : differentiable 𝕂 c) (hd : differentiable 𝕂 d) :
-  differentiable 𝕂 (λ y, c y * d y) :=
+lemma differentiable.mul (hc : differentiable 𝕜 c) (hd : differentiable 𝕜 d) :
+  differentiable 𝕜 (λ y, c y * d y) :=
 λx, (hc x).mul (hd x)
 
-lemma fderiv_within_mul (hxs : unique_diff_within_at 𝕂 s x)
-  (hc : differentiable_within_at 𝕂 c s x) (hd : differentiable_within_at 𝕂 d s x) :
-  fderiv_within 𝕂 (λ y, c y * d y) s x =
-    c x • fderiv_within 𝕂 d s x + d x • fderiv_within 𝕂 c s x :=
+lemma fderiv_within_mul (hxs : unique_diff_within_at 𝕜 s x)
+  (hc : differentiable_within_at 𝕜 c s x) (hd : differentiable_within_at 𝕜 d s x) :
+  fderiv_within 𝕜 (λ y, c y * d y) s x =
+    c x • fderiv_within 𝕜 d s x + d x • fderiv_within 𝕜 c s x :=
 (hc.has_fderiv_within_at.mul hd.has_fderiv_within_at).fderiv_within hxs
 
-lemma fderiv_mul (hc : differentiable_at 𝕂 c x) (hd : differentiable_at 𝕂 d x) :
-  fderiv 𝕂 (λ y, c y * d y) x =
-    c x • fderiv 𝕂 d x + d x • fderiv 𝕂 c x :=
+lemma fderiv_mul (hc : differentiable_at 𝕜 c x) (hd : differentiable_at 𝕜 d x) :
+  fderiv 𝕜 (λ y, c y * d y) x =
+    c x • fderiv 𝕜 d x + d x • fderiv 𝕜 c x :=
 (hc.has_fderiv_at.mul hd.has_fderiv_at).fderiv
 
 end mul

--- a/src/analysis/calculus/tangent_cone.lean
+++ b/src/analysis/calculus/tangent_cone.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 
-In this file, we define two predicates `unique_diff_within_at k s x` and `unique_diff_on k s`
+In this file, we define two predicates `unique_diff_within_at 𝕂 s x` and `unique_diff_on 𝕂 s`
 ensuring that, if a function has two derivatives, then they have to coincide. As a direct
 definition of this fact (quantifying on all target types and all functions) would depend on
 universes, we use a more intrinsic definition: if all the possible tangent directions to the set
@@ -23,9 +23,9 @@ properties of the tangent cone we prove here.
 
 import analysis.convex analysis.normed_space.bounded_linear_maps
 
-variables (k : Type*) [nondiscrete_normed_field k]
-variables {E : Type*} [normed_group E] [normed_space k E]
-variables {F : Type*} [normed_group F] [normed_space k F]
+variables (𝕂 : Type*) [nondiscrete_normed_field 𝕂]
+variables {E : Type*} [normed_group E] [normed_space 𝕂 E]
+variables {F : Type*} [normed_group F] [normed_space 𝕂 F]
 variables {G : Type*} [normed_group G] [normed_space ℝ G]
 
 set_option class.instance_max_depth 50
@@ -33,7 +33,7 @@ open filter set
 
 /-- The set of all tangent directions to the set `s` at the point `x`. -/
 def tangent_cone_at (s : set E) (x : E) : set E :=
-{y : E | ∃(c : ℕ → k) (d : ℕ → E), {n:ℕ | x + d n ∈ s} ∈ (at_top : filter ℕ) ∧
+{y : E | ∃(c : ℕ → 𝕂) (d : ℕ → E), {n:ℕ | x + d n ∈ s} ∈ (at_top : filter ℕ) ∧
   (tendsto (λn, ∥c n∥) at_top at_top) ∧ (tendsto (λn, c n • d n) at_top (nhds y))}
 
 /-- A property ensuring that the tangent cone to `s` at `x` spans a dense subset of the whole space.
@@ -43,24 +43,24 @@ To avoid pathologies in dimension 0, we also require that `x` belongs to the clo
 is automatic when `E` is not `0`-dimensional).
  -/
 def unique_diff_within_at (s : set E) (x : E) : Prop :=
-closure ((submodule.span k (tangent_cone_at k s x)) : set E) = univ ∧ x ∈ closure s
+closure ((submodule.span 𝕂 (tangent_cone_at 𝕂 s x)) : set E) = univ ∧ x ∈ closure s
 
 /-- A property ensuring that the tangent cone to `s` at any of its points spans a dense subset of
 the whole space.  The main role of this property is to ensure that the differential along `s` is
 unique, hence this name. The uniqueness it asserts is proved in `unique_diff_on.eq` in
 `deriv.lean`. -/
 def unique_diff_on (s : set E) : Prop :=
-∀x ∈ s, unique_diff_within_at k s x
+∀x ∈ s, unique_diff_within_at 𝕂 s x
 
-variables {k} {x y : E} {s t : set E}
+variables {𝕂} {x y : E} {s t : set E}
 
 section tangent_cone
 /- This section is devoted to the properties of the tangent cone. -/
 
-lemma tangent_cone_univ : tangent_cone_at k univ x = univ :=
+lemma tangent_cone_univ : tangent_cone_at 𝕂 univ x = univ :=
 begin
   refine univ_subset_iff.1 (λy hy, _),
-  rcases exists_one_lt_norm k with ⟨w, hw⟩,
+  rcases exists_one_lt_norm 𝕂 with ⟨w, hw⟩,
   refine ⟨λn, w^n, λn, (w^n)⁻¹ • y, univ_mem_sets' (λn, mem_univ _),  _, _⟩,
   { simp only [norm_pow],
     exact tendsto_pow_at_top_at_top_of_gt_1 hw },
@@ -74,7 +74,7 @@ begin
 end
 
 lemma tangent_cone_mono (h : s ⊆ t) :
-  tangent_cone_at k s x ⊆ tangent_cone_at k t x :=
+  tangent_cone_at 𝕂 s x ⊆ tangent_cone_at 𝕂 t x :=
 begin
   rintros y ⟨c, d, ds, ctop, clim⟩,
   exact ⟨c, d, mem_sets_of_superset ds (λn hn, h hn), ctop, clim⟩
@@ -82,7 +82,7 @@ end
 
 /-- Auxiliary lemma ensuring that, under the assumptions defining the tangent cone,
 the sequence `d` tends to 0 at infinity. -/
-lemma tangent_cone_at.lim_zero {c : ℕ → k} {d : ℕ → E}
+lemma tangent_cone_at.lim_zero {c : ℕ → 𝕂} {d : ℕ → E}
   (hc : tendsto (λn, ∥c n∥) at_top at_top) (hd : tendsto (λn, c n • d n) at_top (nhds y)) :
   tendsto d at_top (nhds 0) :=
 begin
@@ -108,7 +108,7 @@ end
 
 /-- Intersecting with a neighborhood of the point does not change the tangent cone. -/
 lemma tangent_cone_inter_nhds (ht : t ∈ nhds x) :
-  tangent_cone_at k (s ∩ t) x = tangent_cone_at k s x :=
+  tangent_cone_at 𝕂 (s ∩ t) x = tangent_cone_at 𝕂 s x :=
 begin
   refine subset.antisymm (tangent_cone_mono (inter_subset_left _ _)) _,
   rintros y ⟨c, d, ds, ctop, clim⟩,
@@ -123,7 +123,7 @@ end
 
 /-- The tangent cone of a product contains the tangent cone of its left factor. -/
 lemma subset_tangent_cone_prod_left {t : set F} {y : F} (ht : y ∈ closure t) :
-  set.prod (tangent_cone_at k s x) {(0 : F)} ⊆ tangent_cone_at k (set.prod s t) (x, y) :=
+  set.prod (tangent_cone_at 𝕂 s x) {(0 : F)} ⊆ tangent_cone_at 𝕂 (set.prod s t) (x, y) :=
 begin
   rintros ⟨v, w⟩ ⟨⟨c, d, hd, hc, hy⟩, hw⟩,
   have : w = 0, by simpa using hw,
@@ -165,7 +165,7 @@ end
 /-- The tangent cone of a product contains the tangent cone of its right factor. -/
 lemma subset_tangent_cone_prod_right {t : set F} {y : F}
   (hs : x ∈ closure s) :
-  set.prod {(0 : E)} (tangent_cone_at k t y) ⊆ tangent_cone_at k (set.prod s t) (x, y) :=
+  set.prod {(0 : E)} (tangent_cone_at 𝕂 t y) ⊆ tangent_cone_at 𝕂 (set.prod s t) (x, y) :=
 begin
   rintros ⟨v, w⟩ ⟨hv, ⟨c, d, hd, hc, hy⟩⟩,
   have : v = 0, by simpa using hv,
@@ -239,14 +239,14 @@ section unique_diff
 /- This section is devoted to properties of the predicates `unique_diff_within_at` and
 `unique_diff_on`. -/
 
-lemma unique_diff_within_at_univ : unique_diff_within_at k univ x :=
+lemma unique_diff_within_at_univ : unique_diff_within_at 𝕂 univ x :=
 by { rw [unique_diff_within_at, tangent_cone_univ], simp }
 
-lemma unique_diff_on_univ : unique_diff_on k (univ : set E) :=
+lemma unique_diff_on_univ : unique_diff_on 𝕂 (univ : set E) :=
 λx hx, unique_diff_within_at_univ
 
 lemma unique_diff_within_at_inter (ht : t ∈ nhds x) :
-  unique_diff_within_at k (s ∩ t) x ↔ unique_diff_within_at k s x :=
+  unique_diff_within_at 𝕂 (s ∩ t) x ↔ unique_diff_within_at 𝕂 s x :=
 begin
   have : x ∈ closure (s ∩ t) ↔ x ∈ closure s,
   { split,
@@ -259,35 +259,35 @@ begin
   rw [unique_diff_within_at, unique_diff_within_at, tangent_cone_inter_nhds ht, this]
 end
 
-lemma unique_diff_within_at.inter (hs : unique_diff_within_at k s x) (ht : t ∈ nhds x) :
-  unique_diff_within_at k (s ∩ t) x :=
+lemma unique_diff_within_at.inter (hs : unique_diff_within_at 𝕂 s x) (ht : t ∈ nhds x) :
+  unique_diff_within_at 𝕂 (s ∩ t) x :=
 (unique_diff_within_at_inter ht).2 hs
 
-lemma unique_diff_within_at.mono (h : unique_diff_within_at k s x) (st : s ⊆ t) :
-  unique_diff_within_at k t x :=
+lemma unique_diff_within_at.mono (h : unique_diff_within_at 𝕂 s x) (st : s ⊆ t) :
+  unique_diff_within_at 𝕂 t x :=
 begin
   unfold unique_diff_within_at at *,
   rw [← univ_subset_iff, ← h.1],
   exact ⟨closure_mono (submodule.span_mono (tangent_cone_mono st)), closure_mono st h.2⟩
 end
 
-lemma is_open.unique_diff_within_at (hs : is_open s) (xs : x ∈ s) : unique_diff_within_at k s x :=
+lemma is_open.unique_diff_within_at (hs : is_open s) (xs : x ∈ s) : unique_diff_within_at 𝕂 s x :=
 begin
   have := unique_diff_within_at_univ.inter (mem_nhds_sets hs xs),
   rwa univ_inter at this
 end
 
-lemma unique_diff_on_inter (hs : unique_diff_on k s) (ht : is_open t) : unique_diff_on k (s ∩ t) :=
+lemma unique_diff_on_inter (hs : unique_diff_on 𝕂 s) (ht : is_open t) : unique_diff_on 𝕂 (s ∩ t) :=
 λx hx, (hs x hx.1).inter (mem_nhds_sets ht hx.2)
 
-lemma is_open.unique_diff_on (hs : is_open s) : unique_diff_on k s :=
+lemma is_open.unique_diff_on (hs : is_open s) : unique_diff_on 𝕂 s :=
 λx hx, is_open.unique_diff_within_at hs hx
 
 /-- The product of two sets of unique differentiability at points `x` and `y` has unique
 differentiability at `(x, y)`. -/
 lemma unique_diff_within_at.prod {t : set F} {y : F}
-  (hs : unique_diff_within_at k s x) (ht : unique_diff_within_at k t y) :
-  unique_diff_within_at k (set.prod s t) (x, y) :=
+  (hs : unique_diff_within_at 𝕂 s x) (ht : unique_diff_within_at 𝕂 t y) :
+  unique_diff_within_at 𝕂 (set.prod s t) (x, y) :=
 begin
   rw [unique_diff_within_at, ← univ_subset_iff] at ⊢ hs ht,
   split,
@@ -297,14 +297,14 @@ begin
     rcases v with ⟨v₁, v₂⟩,
     rcases metric.mem_closure_iff'.1 (hs.1 (mem_univ v₁)) ε ε_pos with ⟨w₁, w₁_mem, h₁⟩,
     rcases metric.mem_closure_iff'.1 (ht.1 (mem_univ v₂)) ε ε_pos with ⟨w₂, w₂_mem, h₂⟩,
-    have I₁ : (w₁, (0 : F)) ∈ submodule.span k (tangent_cone_at k (set.prod s t) (x, y)),
+    have I₁ : (w₁, (0 : F)) ∈ submodule.span 𝕂 (tangent_cone_at 𝕂 (set.prod s t) (x, y)),
     { apply submodule.span_induction w₁_mem,
       { assume w hw,
-        have : (w, (0 : F)) ∈ (set.prod (tangent_cone_at k s x) {(0 : F)}),
+        have : (w, (0 : F)) ∈ (set.prod (tangent_cone_at 𝕂 s x) {(0 : F)}),
         { rw mem_prod,
           simp [hw],
           apply mem_insert },
-        have : (w, (0 : F)) ∈ tangent_cone_at k (set.prod s t) (x, y) :=
+        have : (w, (0 : F)) ∈ tangent_cone_at 𝕂 (set.prod s t) (x, y) :=
           subset_tangent_cone_prod_left ht.2 this,
         exact submodule.subset_span this },
       { exact submodule.zero_mem _ },
@@ -316,14 +316,14 @@ begin
         have : c • (0 : F) = (0 : F), by simp,
         rw ← this,
         exact submodule.smul_mem _ _ ha } },
-    have I₂ : ((0 : E), w₂) ∈ submodule.span k (tangent_cone_at k (set.prod s t) (x, y)),
+    have I₂ : ((0 : E), w₂) ∈ submodule.span 𝕂 (tangent_cone_at 𝕂 (set.prod s t) (x, y)),
     { apply submodule.span_induction w₂_mem,
       { assume w hw,
-        have : ((0 : E), w) ∈ (set.prod {(0 : E)} (tangent_cone_at k t y)),
+        have : ((0 : E), w) ∈ (set.prod {(0 : E)} (tangent_cone_at 𝕂 t y)),
         { rw mem_prod,
           simp [hw],
           apply mem_insert },
-        have : ((0 : E), w) ∈ tangent_cone_at k (set.prod s t) (x, y) :=
+        have : ((0 : E), w) ∈ tangent_cone_at 𝕂 (set.prod s t) (x, y) :=
           subset_tangent_cone_prod_right hs.2 this,
         exact submodule.subset_span this },
       { exact submodule.zero_mem _ },
@@ -335,7 +335,7 @@ begin
         have : c • (0 : E) = (0 : E), by simp,
         rw ← this,
         exact submodule.smul_mem _ _ ha } },
-    have I : (w₁, w₂) ∈ submodule.span k (tangent_cone_at k (set.prod s t) (x, y)),
+    have I : (w₁, w₂) ∈ submodule.span 𝕂 (tangent_cone_at 𝕂 (set.prod s t) (x, y)),
     { have : (w₁, (0 : F)) + ((0 : E), w₂) = (w₁, w₂), by simp,
       rw ← this,
       exact submodule.add_mem _ I₁ I₂ },
@@ -345,8 +345,8 @@ begin
 end
 
 /-- The product of two sets of unique differentiability is a set of unique differentiability. -/
-lemma unique_diff_on.prod {t : set F} (hs : unique_diff_on k s) (ht : unique_diff_on k t) :
-  unique_diff_on k (set.prod s t) :=
+lemma unique_diff_on.prod {t : set F} (hs : unique_diff_on 𝕂 s) (ht : unique_diff_on 𝕂 t) :
+  unique_diff_on 𝕂 (set.prod s t) :=
 λ ⟨x, y⟩ h, unique_diff_within_at.prod (hs x h.1) (ht y h.2)
 
 /-- In a real vector space, a convex set with nonempty interior is a set of unique

--- a/src/analysis/calculus/tangent_cone.lean
+++ b/src/analysis/calculus/tangent_cone.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 
-In this file, we define two predicates `unique_diff_within_at 𝕂 s x` and `unique_diff_on 𝕂 s`
+In this file, we define two predicates `unique_diff_within_at 𝕜 s x` and `unique_diff_on 𝕜 s`
 ensuring that, if a function has two derivatives, then they have to coincide. As a direct
 definition of this fact (quantifying on all target types and all functions) would depend on
 universes, we use a more intrinsic definition: if all the possible tangent directions to the set
@@ -23,9 +23,9 @@ properties of the tangent cone we prove here.
 
 import analysis.convex analysis.normed_space.bounded_linear_maps
 
-variables (𝕂 : Type*) [nondiscrete_normed_field 𝕂]
-variables {E : Type*} [normed_group E] [normed_space 𝕂 E]
-variables {F : Type*} [normed_group F] [normed_space 𝕂 F]
+variables (𝕜 : Type*) [nondiscrete_normed_field 𝕜]
+variables {E : Type*} [normed_group E] [normed_space 𝕜 E]
+variables {F : Type*} [normed_group F] [normed_space 𝕜 F]
 variables {G : Type*} [normed_group G] [normed_space ℝ G]
 
 set_option class.instance_max_depth 50
@@ -33,7 +33,7 @@ open filter set
 
 /-- The set of all tangent directions to the set `s` at the point `x`. -/
 def tangent_cone_at (s : set E) (x : E) : set E :=
-{y : E | ∃(c : ℕ → 𝕂) (d : ℕ → E), {n:ℕ | x + d n ∈ s} ∈ (at_top : filter ℕ) ∧
+{y : E | ∃(c : ℕ → 𝕜) (d : ℕ → E), {n:ℕ | x + d n ∈ s} ∈ (at_top : filter ℕ) ∧
   (tendsto (λn, ∥c n∥) at_top at_top) ∧ (tendsto (λn, c n • d n) at_top (nhds y))}
 
 /-- A property ensuring that the tangent cone to `s` at `x` spans a dense subset of the whole space.
@@ -43,24 +43,24 @@ To avoid pathologies in dimension 0, we also require that `x` belongs to the clo
 is automatic when `E` is not `0`-dimensional).
  -/
 def unique_diff_within_at (s : set E) (x : E) : Prop :=
-closure ((submodule.span 𝕂 (tangent_cone_at 𝕂 s x)) : set E) = univ ∧ x ∈ closure s
+closure ((submodule.span 𝕜 (tangent_cone_at 𝕜 s x)) : set E) = univ ∧ x ∈ closure s
 
 /-- A property ensuring that the tangent cone to `s` at any of its points spans a dense subset of
 the whole space.  The main role of this property is to ensure that the differential along `s` is
 unique, hence this name. The uniqueness it asserts is proved in `unique_diff_on.eq` in
 `deriv.lean`. -/
 def unique_diff_on (s : set E) : Prop :=
-∀x ∈ s, unique_diff_within_at 𝕂 s x
+∀x ∈ s, unique_diff_within_at 𝕜 s x
 
-variables {𝕂} {x y : E} {s t : set E}
+variables {𝕜} {x y : E} {s t : set E}
 
 section tangent_cone
 /- This section is devoted to the properties of the tangent cone. -/
 
-lemma tangent_cone_univ : tangent_cone_at 𝕂 univ x = univ :=
+lemma tangent_cone_univ : tangent_cone_at 𝕜 univ x = univ :=
 begin
   refine univ_subset_iff.1 (λy hy, _),
-  rcases exists_one_lt_norm 𝕂 with ⟨w, hw⟩,
+  rcases exists_one_lt_norm 𝕜 with ⟨w, hw⟩,
   refine ⟨λn, w^n, λn, (w^n)⁻¹ • y, univ_mem_sets' (λn, mem_univ _),  _, _⟩,
   { simp only [norm_pow],
     exact tendsto_pow_at_top_at_top_of_gt_1 hw },
@@ -74,7 +74,7 @@ begin
 end
 
 lemma tangent_cone_mono (h : s ⊆ t) :
-  tangent_cone_at 𝕂 s x ⊆ tangent_cone_at 𝕂 t x :=
+  tangent_cone_at 𝕜 s x ⊆ tangent_cone_at 𝕜 t x :=
 begin
   rintros y ⟨c, d, ds, ctop, clim⟩,
   exact ⟨c, d, mem_sets_of_superset ds (λn hn, h hn), ctop, clim⟩
@@ -82,7 +82,7 @@ end
 
 /-- Auxiliary lemma ensuring that, under the assumptions defining the tangent cone,
 the sequence `d` tends to 0 at infinity. -/
-lemma tangent_cone_at.lim_zero {c : ℕ → 𝕂} {d : ℕ → E}
+lemma tangent_cone_at.lim_zero {c : ℕ → 𝕜} {d : ℕ → E}
   (hc : tendsto (λn, ∥c n∥) at_top at_top) (hd : tendsto (λn, c n • d n) at_top (nhds y)) :
   tendsto d at_top (nhds 0) :=
 begin
@@ -108,7 +108,7 @@ end
 
 /-- Intersecting with a neighborhood of the point does not change the tangent cone. -/
 lemma tangent_cone_inter_nhds (ht : t ∈ nhds x) :
-  tangent_cone_at 𝕂 (s ∩ t) x = tangent_cone_at 𝕂 s x :=
+  tangent_cone_at 𝕜 (s ∩ t) x = tangent_cone_at 𝕜 s x :=
 begin
   refine subset.antisymm (tangent_cone_mono (inter_subset_left _ _)) _,
   rintros y ⟨c, d, ds, ctop, clim⟩,
@@ -123,7 +123,7 @@ end
 
 /-- The tangent cone of a product contains the tangent cone of its left factor. -/
 lemma subset_tangent_cone_prod_left {t : set F} {y : F} (ht : y ∈ closure t) :
-  set.prod (tangent_cone_at 𝕂 s x) {(0 : F)} ⊆ tangent_cone_at 𝕂 (set.prod s t) (x, y) :=
+  set.prod (tangent_cone_at 𝕜 s x) {(0 : F)} ⊆ tangent_cone_at 𝕜 (set.prod s t) (x, y) :=
 begin
   rintros ⟨v, w⟩ ⟨⟨c, d, hd, hc, hy⟩, hw⟩,
   have : w = 0, by simpa using hw,
@@ -165,7 +165,7 @@ end
 /-- The tangent cone of a product contains the tangent cone of its right factor. -/
 lemma subset_tangent_cone_prod_right {t : set F} {y : F}
   (hs : x ∈ closure s) :
-  set.prod {(0 : E)} (tangent_cone_at 𝕂 t y) ⊆ tangent_cone_at 𝕂 (set.prod s t) (x, y) :=
+  set.prod {(0 : E)} (tangent_cone_at 𝕜 t y) ⊆ tangent_cone_at 𝕜 (set.prod s t) (x, y) :=
 begin
   rintros ⟨v, w⟩ ⟨hv, ⟨c, d, hd, hc, hy⟩⟩,
   have : v = 0, by simpa using hv,
@@ -239,14 +239,14 @@ section unique_diff
 /- This section is devoted to properties of the predicates `unique_diff_within_at` and
 `unique_diff_on`. -/
 
-lemma unique_diff_within_at_univ : unique_diff_within_at 𝕂 univ x :=
+lemma unique_diff_within_at_univ : unique_diff_within_at 𝕜 univ x :=
 by { rw [unique_diff_within_at, tangent_cone_univ], simp }
 
-lemma unique_diff_on_univ : unique_diff_on 𝕂 (univ : set E) :=
+lemma unique_diff_on_univ : unique_diff_on 𝕜 (univ : set E) :=
 λx hx, unique_diff_within_at_univ
 
 lemma unique_diff_within_at_inter (ht : t ∈ nhds x) :
-  unique_diff_within_at 𝕂 (s ∩ t) x ↔ unique_diff_within_at 𝕂 s x :=
+  unique_diff_within_at 𝕜 (s ∩ t) x ↔ unique_diff_within_at 𝕜 s x :=
 begin
   have : x ∈ closure (s ∩ t) ↔ x ∈ closure s,
   { split,
@@ -259,35 +259,35 @@ begin
   rw [unique_diff_within_at, unique_diff_within_at, tangent_cone_inter_nhds ht, this]
 end
 
-lemma unique_diff_within_at.inter (hs : unique_diff_within_at 𝕂 s x) (ht : t ∈ nhds x) :
-  unique_diff_within_at 𝕂 (s ∩ t) x :=
+lemma unique_diff_within_at.inter (hs : unique_diff_within_at 𝕜 s x) (ht : t ∈ nhds x) :
+  unique_diff_within_at 𝕜 (s ∩ t) x :=
 (unique_diff_within_at_inter ht).2 hs
 
-lemma unique_diff_within_at.mono (h : unique_diff_within_at 𝕂 s x) (st : s ⊆ t) :
-  unique_diff_within_at 𝕂 t x :=
+lemma unique_diff_within_at.mono (h : unique_diff_within_at 𝕜 s x) (st : s ⊆ t) :
+  unique_diff_within_at 𝕜 t x :=
 begin
   unfold unique_diff_within_at at *,
   rw [← univ_subset_iff, ← h.1],
   exact ⟨closure_mono (submodule.span_mono (tangent_cone_mono st)), closure_mono st h.2⟩
 end
 
-lemma is_open.unique_diff_within_at (hs : is_open s) (xs : x ∈ s) : unique_diff_within_at 𝕂 s x :=
+lemma is_open.unique_diff_within_at (hs : is_open s) (xs : x ∈ s) : unique_diff_within_at 𝕜 s x :=
 begin
   have := unique_diff_within_at_univ.inter (mem_nhds_sets hs xs),
   rwa univ_inter at this
 end
 
-lemma unique_diff_on_inter (hs : unique_diff_on 𝕂 s) (ht : is_open t) : unique_diff_on 𝕂 (s ∩ t) :=
+lemma unique_diff_on_inter (hs : unique_diff_on 𝕜 s) (ht : is_open t) : unique_diff_on 𝕜 (s ∩ t) :=
 λx hx, (hs x hx.1).inter (mem_nhds_sets ht hx.2)
 
-lemma is_open.unique_diff_on (hs : is_open s) : unique_diff_on 𝕂 s :=
+lemma is_open.unique_diff_on (hs : is_open s) : unique_diff_on 𝕜 s :=
 λx hx, is_open.unique_diff_within_at hs hx
 
 /-- The product of two sets of unique differentiability at points `x` and `y` has unique
 differentiability at `(x, y)`. -/
 lemma unique_diff_within_at.prod {t : set F} {y : F}
-  (hs : unique_diff_within_at 𝕂 s x) (ht : unique_diff_within_at 𝕂 t y) :
-  unique_diff_within_at 𝕂 (set.prod s t) (x, y) :=
+  (hs : unique_diff_within_at 𝕜 s x) (ht : unique_diff_within_at 𝕜 t y) :
+  unique_diff_within_at 𝕜 (set.prod s t) (x, y) :=
 begin
   rw [unique_diff_within_at, ← univ_subset_iff] at ⊢ hs ht,
   split,
@@ -297,14 +297,14 @@ begin
     rcases v with ⟨v₁, v₂⟩,
     rcases metric.mem_closure_iff'.1 (hs.1 (mem_univ v₁)) ε ε_pos with ⟨w₁, w₁_mem, h₁⟩,
     rcases metric.mem_closure_iff'.1 (ht.1 (mem_univ v₂)) ε ε_pos with ⟨w₂, w₂_mem, h₂⟩,
-    have I₁ : (w₁, (0 : F)) ∈ submodule.span 𝕂 (tangent_cone_at 𝕂 (set.prod s t) (x, y)),
+    have I₁ : (w₁, (0 : F)) ∈ submodule.span 𝕜 (tangent_cone_at 𝕜 (set.prod s t) (x, y)),
     { apply submodule.span_induction w₁_mem,
       { assume w hw,
-        have : (w, (0 : F)) ∈ (set.prod (tangent_cone_at 𝕂 s x) {(0 : F)}),
+        have : (w, (0 : F)) ∈ (set.prod (tangent_cone_at 𝕜 s x) {(0 : F)}),
         { rw mem_prod,
           simp [hw],
           apply mem_insert },
-        have : (w, (0 : F)) ∈ tangent_cone_at 𝕂 (set.prod s t) (x, y) :=
+        have : (w, (0 : F)) ∈ tangent_cone_at 𝕜 (set.prod s t) (x, y) :=
           subset_tangent_cone_prod_left ht.2 this,
         exact submodule.subset_span this },
       { exact submodule.zero_mem _ },
@@ -316,14 +316,14 @@ begin
         have : c • (0 : F) = (0 : F), by simp,
         rw ← this,
         exact submodule.smul_mem _ _ ha } },
-    have I₂ : ((0 : E), w₂) ∈ submodule.span 𝕂 (tangent_cone_at 𝕂 (set.prod s t) (x, y)),
+    have I₂ : ((0 : E), w₂) ∈ submodule.span 𝕜 (tangent_cone_at 𝕜 (set.prod s t) (x, y)),
     { apply submodule.span_induction w₂_mem,
       { assume w hw,
-        have : ((0 : E), w) ∈ (set.prod {(0 : E)} (tangent_cone_at 𝕂 t y)),
+        have : ((0 : E), w) ∈ (set.prod {(0 : E)} (tangent_cone_at 𝕜 t y)),
         { rw mem_prod,
           simp [hw],
           apply mem_insert },
-        have : ((0 : E), w) ∈ tangent_cone_at 𝕂 (set.prod s t) (x, y) :=
+        have : ((0 : E), w) ∈ tangent_cone_at 𝕜 (set.prod s t) (x, y) :=
           subset_tangent_cone_prod_right hs.2 this,
         exact submodule.subset_span this },
       { exact submodule.zero_mem _ },
@@ -335,7 +335,7 @@ begin
         have : c • (0 : E) = (0 : E), by simp,
         rw ← this,
         exact submodule.smul_mem _ _ ha } },
-    have I : (w₁, w₂) ∈ submodule.span 𝕂 (tangent_cone_at 𝕂 (set.prod s t) (x, y)),
+    have I : (w₁, w₂) ∈ submodule.span 𝕜 (tangent_cone_at 𝕜 (set.prod s t) (x, y)),
     { have : (w₁, (0 : F)) + ((0 : E), w₂) = (w₁, w₂), by simp,
       rw ← this,
       exact submodule.add_mem _ I₁ I₂ },
@@ -345,8 +345,8 @@ begin
 end
 
 /-- The product of two sets of unique differentiability is a set of unique differentiability. -/
-lemma unique_diff_on.prod {t : set F} (hs : unique_diff_on 𝕂 s) (ht : unique_diff_on 𝕂 t) :
-  unique_diff_on 𝕂 (set.prod s t) :=
+lemma unique_diff_on.prod {t : set F} (hs : unique_diff_on 𝕜 s) (ht : unique_diff_on 𝕜 t) :
+  unique_diff_on 𝕜 (set.prod s t) :=
 λ ⟨x, y⟩ h, unique_diff_within_at.prod (hs x h.1) (ht y h.2)
 
 /-- In a real vector space, a convex set with nonempty interior is a set of unique

--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -15,31 +15,31 @@ equivalently, if it is `C^1` and its derivative is `C^{n-1}`.
 Finally, it is `C^∞` if it is `C^n` for all n.
 
 We formalize these notions by defining iteratively the n-th derivative of a function at the
-(n-1)-th derivative of the derivative. It is called `iterated_fderiv 𝕂 n f x` where `𝕂` is the
+(n-1)-th derivative of the derivative. It is called `iterated_fderiv 𝕜 n f x` where `𝕜` is the
 field, `n` is the number of iterations, `f` is the function and `x` is the point. We also define a
-version `iterated_fderiv_within` relative to a domain, as well as predicates `times_cont_diff 𝕂 n f`
-and `times_cont_diff_on 𝕂 n f s` saying that the function is `C^n`, respectively in the whole space
+version `iterated_fderiv_within` relative to a domain, as well as predicates `times_cont_diff 𝕜 n f`
+and `times_cont_diff_on 𝕜 n f s` saying that the function is `C^n`, respectively in the whole space
 or on the set `s`.
 
 We prove basic properties of these notions.
 
 ## Implementation notes
 
-The n-th derivative of a function belongs to the space E →L[𝕂] (E →L[𝕂] (E ... F)...))),
-where there are n iterations of `E →L[𝕂]`. We define this space inductively, call it
-`iterated_continuous_linear_map 𝕂 n E F`, and denote it by `E [×n]→L[𝕂] F`. We can define
+The n-th derivative of a function belongs to the space E →L[𝕜] (E →L[𝕜] (E ... F)...))),
+where there are n iterations of `E →L[𝕜]`. We define this space inductively, call it
+`iterated_continuous_linear_map 𝕜 n E F`, and denote it by `E [×n]→L[𝕜] F`. We can define
 it inductively either from the left (i.e., saying that the
-(n+1)-th space S_{n+1} is E →L[𝕂] S_n) or from the right (i.e., saying that
-the (n+1)-th space associated to F, denoted by S_{n+1} (F), is equal to S_n (E →L[𝕂] F)).
+(n+1)-th space S_{n+1} is E →L[𝕜] S_n) or from the right (i.e., saying that
+the (n+1)-th space associated to F, denoted by S_{n+1} (F), is equal to S_n (E →L[𝕜] F)).
 For proofs, it turns out to be more convenient to use the latter approach (from the right),
 as it means to prove things at the (n+1)-th step we only need to understand well enough the
-derivative in E →L[𝕂] F (contrary to the approach from the left, where one would need to know
+derivative in E →L[𝕜] F (contrary to the approach from the left, where one would need to know
 enough on the n-th derivative to deduce things on the (n+1)-th derivative).
 In other words, one could define the (n+1)-th derivative either as the derivative of the n-th
 derivative, or as the n-th derivative of the derivative. We use the latter definition.
 
 A difficulty is related to universes: the first and second spaces in the sequence, for n=0
-and 1, are F and E →L[𝕂] F. If E has universe u and F has universe v, then the first one lives in
+and 1, are F and E →L[𝕜] F. If E has universe u and F has universe v, then the first one lives in
 v and the second one in max v u. Since they should live in the same universe (as all the other
 spaces in the construction), it means that at the 0-th step we should not use F, but ulift it to
 universe max v u. But we should also ulift its vector space structure and its normed space
@@ -72,39 +72,39 @@ universes u v w
 
 open set
 
-variables {𝕂 : Type*} [nondiscrete_normed_field 𝕂]
-{E : Type u} [normed_group E] [normed_space 𝕂 E]
-{F : Type u} [normed_group F] [normed_space 𝕂 F]
-{G : Type u} [normed_group G] [normed_space 𝕂 G]
-{s s₁ u : set E} {f f₁ : E → F} {f' f₁' : E →L[𝕂] F} {f₂ : E → G}
-{f₂' : E →L[𝕂] G} {g : F → G} {x : E} {c : F}
+variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
+{E : Type u} [normed_group E] [normed_space 𝕜 E]
+{F : Type u} [normed_group F] [normed_space 𝕜 F]
+{G : Type u} [normed_group G] [normed_space 𝕜 G]
+{s s₁ u : set E} {f f₁ : E → F} {f' f₁' : E →L[𝕜] F} {f₂ : E → G}
+{f₂' : E →L[𝕜] G} {g : F → G} {x : E} {c : F}
 {L : filter E} {t : set F} {b : E × F → G} {sb : set (E × F)} {p : E × F}
 {n : ℕ}
 
-include 𝕂
+include 𝕜
 
 /--
-The space `iterated_continuous_linear_map 𝕂 n E F` is the space E →L[𝕂] (E →L[𝕂] (E ... F)...))),
+The space `iterated_continuous_linear_map 𝕜 n E F` is the space E →L[𝕜] (E →L[𝕜] (E ... F)...))),
 defined inductively over `n`. This is the space to which the `n`-th derivative of a function
 naturally belongs. It is only defined when `E` and `F` live in the same universe.
 -/
-def iterated_continuous_linear_map (𝕂 : Type w) [nondiscrete_normed_field 𝕂] :
-  Π (n : ℕ) (E : Type u) [gE : normed_group E] [@normed_space 𝕂 E _ gE]
-    (F : Type u) [gF : normed_group F] [@normed_space 𝕂 F _ gF], Type u
+def iterated_continuous_linear_map (𝕜 : Type w) [nondiscrete_normed_field 𝕜] :
+  Π (n : ℕ) (E : Type u) [gE : normed_group E] [@normed_space 𝕜 E _ gE]
+    (F : Type u) [gF : normed_group F] [@normed_space 𝕜 F _ gF], Type u
 | 0     E _ _ F _ _ := F
-| (n+1) E _ _ F _ _ := by { resetI, exact iterated_continuous_linear_map n E (E →L[𝕂] F) }
+| (n+1) E _ _ F _ _ := by { resetI, exact iterated_continuous_linear_map n E (E →L[𝕜] F) }
 
-notation E `[×`:25 n `]→L[`:25 𝕂 `] ` F := iterated_continuous_linear_map 𝕂 n E F
+notation E `[×`:25 n `]→L[`:25 𝕜 `] ` F := iterated_continuous_linear_map 𝕜 n E F
 
 /--
 Define by induction a normed group structure on the space of iterated continuous linear
 maps. To avoid `resetI` in the statement, use the @ version with all parameters. As the equation
 compiler chokes on this one, we use the `nat.rec_on` version.
 -/
-def iterated_continuous_linear_map.normed_group_rec (𝕂 : Type w) [h𝕂 : nondiscrete_normed_field 𝕂]
-  (n : ℕ) (E : Type u) [gE : normed_group E] [sE : normed_space 𝕂 E] :
-  ∀(F : Type u) [nF : normed_group F] [sF : @normed_space 𝕂 F _ nF],
-  normed_group (@iterated_continuous_linear_map 𝕂 h𝕂 n E gE sE F nF sF) :=
+def iterated_continuous_linear_map.normed_group_rec (𝕜 : Type w) [h𝕜 : nondiscrete_normed_field 𝕜]
+  (n : ℕ) (E : Type u) [gE : normed_group E] [sE : normed_space 𝕜 E] :
+  ∀(F : Type u) [nF : normed_group F] [sF : @normed_space 𝕜 F _ nF],
+  normed_group (@iterated_continuous_linear_map 𝕜 h𝕜 n E gE sE F nF sF) :=
 nat.rec_on n (λF nF sF, nF) (λn aux_n F nF sF, by { resetI, apply aux_n })
 
 /--
@@ -112,68 +112,68 @@ Define by induction a normed space structure on the space of iterated continuous
 maps. To avoid `resetI` in the statement, use the @ version with all parameters. As the equation
 compiler chokes on this one, we use the `nat.rec_on` version.
 -/
-def iterated_continuous_linear_map.normed_space_rec (𝕂 : Type w) [h𝕂 : nondiscrete_normed_field 𝕂]
-  (n : ℕ) (E : Type u) [gE : normed_group E] [sE : normed_space 𝕂 E] :
-  ∀(F : Type u) [nF : normed_group F] [sF : @normed_space 𝕂 F _ nF],
-  @normed_space 𝕂 (@iterated_continuous_linear_map 𝕂 h𝕂 n E gE sE F nF sF)
-  _ (@iterated_continuous_linear_map.normed_group_rec 𝕂 h𝕂 n E gE sE F nF sF) :=
+def iterated_continuous_linear_map.normed_space_rec (𝕜 : Type w) [h𝕜 : nondiscrete_normed_field 𝕜]
+  (n : ℕ) (E : Type u) [gE : normed_group E] [sE : normed_space 𝕜 E] :
+  ∀(F : Type u) [nF : normed_group F] [sF : @normed_space 𝕜 F _ nF],
+  @normed_space 𝕜 (@iterated_continuous_linear_map 𝕜 h𝕜 n E gE sE F nF sF)
+  _ (@iterated_continuous_linear_map.normed_group_rec 𝕜 h𝕜 n E gE sE F nF sF) :=
 nat.rec_on n (λF nF sF, sF) (λn aux_n F nF sF, by { resetI, apply aux_n })
 
 /--
 Explicit normed group structure on the space of iterated continuous linear maps.
 -/
 instance iterated_continuous_linear_map.normed_group (n : ℕ)
-  (𝕂 : Type w) [h𝕂 : nondiscrete_normed_field 𝕂]
-  (E : Type u) [gE : normed_group E] [sE : normed_space 𝕂 E]
-  (F : Type u) [gF : normed_group F] [sF : normed_space 𝕂 F] :
-  normed_group (E [×n]→L[𝕂] F) :=
-iterated_continuous_linear_map.normed_group_rec 𝕂 n E F
+  (𝕜 : Type w) [h𝕜 : nondiscrete_normed_field 𝕜]
+  (E : Type u) [gE : normed_group E] [sE : normed_space 𝕜 E]
+  (F : Type u) [gF : normed_group F] [sF : normed_space 𝕜 F] :
+  normed_group (E [×n]→L[𝕜] F) :=
+iterated_continuous_linear_map.normed_group_rec 𝕜 n E F
 
 /--
 Explicit normed space structure on the space of iterated continuous linear maps.
 -/
 instance iterated_continuous_linear_map.normed_space (n : ℕ)
-  (𝕂 : Type w) [h𝕂 : nondiscrete_normed_field 𝕂]
-  (E : Type u) [gE : normed_group E] [sE : normed_space 𝕂 E]
-  (F : Type u) [gF : normed_group F] [sF : normed_space 𝕂 F] :
-  normed_space 𝕂 (E [×n]→L[𝕂] F) :=
-iterated_continuous_linear_map.normed_space_rec 𝕂 n E F
+  (𝕜 : Type w) [h𝕜 : nondiscrete_normed_field 𝕜]
+  (E : Type u) [gE : normed_group E] [sE : normed_space 𝕜 E]
+  (F : Type u) [gF : normed_group F] [sF : normed_space 𝕜 F] :
+  normed_space 𝕜 (E [×n]→L[𝕜] F) :=
+iterated_continuous_linear_map.normed_space_rec 𝕜 n E F
 
 /--
 The n-th derivative of a function, defined inductively by saying that the (n+1)-th
 derivative of f is the n-th derivative of the derivative of f.
 -/
-def iterated_fderiv (𝕂 : Type w) [h𝕂 : nondiscrete_normed_field 𝕂] (n : ℕ)
-  {E : Type u} [gE : normed_group E] [sE : normed_space 𝕂 E] :
-  ∀{F : Type u} [gF : normed_group F] [sF : @normed_space 𝕂 F _ gF] (f : E → F),
-  E → @iterated_continuous_linear_map 𝕂 h𝕂 n E gE sE F gF sF :=
-nat.rec_on n (λF gF sF f, f) (λn rec F gF sF f, by { resetI, exact rec (fderiv 𝕂 f) })
+def iterated_fderiv (𝕜 : Type w) [h𝕜 : nondiscrete_normed_field 𝕜] (n : ℕ)
+  {E : Type u} [gE : normed_group E] [sE : normed_space 𝕜 E] :
+  ∀{F : Type u} [gF : normed_group F] [sF : @normed_space 𝕜 F _ gF] (f : E → F),
+  E → @iterated_continuous_linear_map 𝕜 h𝕜 n E gE sE F gF sF :=
+nat.rec_on n (λF gF sF f, f) (λn rec F gF sF f, by { resetI, exact rec (fderiv 𝕜 f) })
 
 @[simp] lemma iterated_fderiv_zero :
-  iterated_fderiv 𝕂 0 f = f := rfl
+  iterated_fderiv 𝕜 0 f = f := rfl
 
 @[simp] lemma iterated_fderiv_succ :
-  iterated_fderiv 𝕂 (n+1) f = (iterated_fderiv 𝕂 n (λx, fderiv 𝕂 f x) : _) := rfl
+  iterated_fderiv 𝕜 (n+1) f = (iterated_fderiv 𝕜 n (λx, fderiv 𝕜 f x) : _) := rfl
 
 /--
 The n-th derivative of a function along a set, defined inductively by saying that the (n+1)-th
 derivative of f is the n-th derivative of the derivative of f.
 -/
-def iterated_fderiv_within (𝕂 : Type w) [h𝕂 :nondiscrete_normed_field 𝕂] (n : ℕ)
-  {E : Type u} [gE : normed_group E] [sE : normed_space 𝕂 E] :
-  ∀{F : Type u} [gF : normed_group F] [sF : @normed_space 𝕂 F _ gF] (f : E → F) (s : set E),
-  E → @iterated_continuous_linear_map 𝕂 h𝕂 n E gE sE F gF sF :=
-nat.rec_on n (λF gF sF f s, f) (λn rec F gF sF f s, by { resetI, exact rec (fderiv_within 𝕂 f s) s})
+def iterated_fderiv_within (𝕜 : Type w) [h𝕜 :nondiscrete_normed_field 𝕜] (n : ℕ)
+  {E : Type u} [gE : normed_group E] [sE : normed_space 𝕜 E] :
+  ∀{F : Type u} [gF : normed_group F] [sF : @normed_space 𝕜 F _ gF] (f : E → F) (s : set E),
+  E → @iterated_continuous_linear_map 𝕜 h𝕜 n E gE sE F gF sF :=
+nat.rec_on n (λF gF sF f s, f) (λn rec F gF sF f s, by { resetI, exact rec (fderiv_within 𝕜 f s) s})
 
 @[simp] lemma iterated_fderiv_within_zero :
-  iterated_fderiv_within 𝕂 0 f s = f := rfl
+  iterated_fderiv_within 𝕜 0 f s = f := rfl
 
 @[simp] lemma iterated_fderiv_within_succ :
-  iterated_fderiv_within 𝕂 (n+1) f s
-  = (iterated_fderiv_within 𝕂 n (λx, fderiv_within 𝕂 f s x) s : _) := rfl
+  iterated_fderiv_within 𝕜 (n+1) f s
+  = (iterated_fderiv_within 𝕜 n (λx, fderiv_within 𝕜 f s x) s : _) := rfl
 
 theorem iterated_fderiv_within_univ {n : ℕ} :
-  iterated_fderiv_within 𝕂 n f univ = iterated_fderiv 𝕂 n f :=
+  iterated_fderiv_within 𝕜 n f univ = iterated_fderiv 𝕜 n f :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F,
@@ -185,9 +185,9 @@ end
 If two functions coincide on a set `s` of unique differentiability, then their iterated
 differentials within this set coincide.
 -/
-lemma iterated_fderiv_within_congr (hs : unique_diff_on 𝕂 s)
+lemma iterated_fderiv_within_congr (hs : unique_diff_on 𝕜 s)
   (hL : ∀y∈s, f₁ y = f y) (hx : x ∈ s) :
-  iterated_fderiv_within 𝕂 n f₁ s x = iterated_fderiv_within 𝕂 n f s x :=
+  iterated_fderiv_within 𝕜 n f₁ s x = iterated_fderiv_within 𝕜 n f s x :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F f x,
@@ -202,8 +202,8 @@ The iterated differential within a set `s` at a point `x` is not modified if one
 `s` with an open set containing `x`.
 -/
 lemma iterated_fderiv_within_inter_open (xu : x ∈ u) (hu : is_open u) (xs : x ∈ s)
-  (hs : unique_diff_on 𝕂 (s ∩ u)) :
-  iterated_fderiv_within 𝕂 n f (s ∩ u) x = iterated_fderiv_within 𝕂 n f s x :=
+  (hs : unique_diff_on 𝕜 (s ∩ u)) :
+  iterated_fderiv_within 𝕜 n f (s ∩ u) x = iterated_fderiv_within 𝕜 n f s x :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F f,
@@ -221,17 +221,17 @@ The iterated differential within a set `s` at a point `x` is not modified if one
 `s` with a neighborhood of `x`.
 -/
 lemma iterated_fderiv_within_inter (hu : u ∈ nhds x) (xs : x ∈ s)
-  (hs : unique_diff_on 𝕂 s) :
-  iterated_fderiv_within 𝕂 n f (s ∩ u) x = iterated_fderiv_within 𝕂 n f s x :=
+  (hs : unique_diff_on 𝕜 s) :
+  iterated_fderiv_within 𝕜 n f (s ∩ u) x = iterated_fderiv_within 𝕜 n f s x :=
 begin
   rcases mem_nhds_sets_iff.1 hu with ⟨v, vu, v_open, xv⟩,
   have A : (s ∩ u) ∩ v = s ∩ v,
   { apply subset.antisymm (inter_subset_inter (inter_subset_left _ _) (subset.refl _)),
     exact λ y ⟨ys, yv⟩, ⟨⟨ys, vu yv⟩, yv⟩ },
-  have : iterated_fderiv_within 𝕂 n f (s ∩ v) x = iterated_fderiv_within 𝕂 n f s x :=
+  have : iterated_fderiv_within 𝕜 n f (s ∩ v) x = iterated_fderiv_within 𝕜 n f s x :=
     iterated_fderiv_within_inter_open xv v_open xs (unique_diff_on_inter hs v_open),
   rw ← this,
-  have : iterated_fderiv_within 𝕂 n f ((s ∩ u) ∩ v) x = iterated_fderiv_within 𝕂 n f (s ∩ u) x,
+  have : iterated_fderiv_within 𝕜 n f ((s ∩ u) ∩ v) x = iterated_fderiv_within 𝕜 n f (s ∩ u) x,
   { refine iterated_fderiv_within_inter_open xv v_open ⟨xs, mem_of_nhds hu⟩ _,
     rw A,
     exact unique_diff_on_inter hs v_open },
@@ -243,23 +243,23 @@ end
 Auxiliary definition defining `C^n` functions by induction over `n`.
 In applications, use `times_cont_diff` instead.
 -/
-def times_cont_diff_rec (𝕂 : Type w) [nondiscrete_normed_field 𝕂] :
-  Π (n : ℕ) {E : Type u} [gE : normed_group E] [@normed_space 𝕂 E _ gE]
-    {F : Type u} [gF : normed_group F] [@normed_space 𝕂 F _ gF] (f : E → F), Prop
+def times_cont_diff_rec (𝕜 : Type w) [nondiscrete_normed_field 𝕜] :
+  Π (n : ℕ) {E : Type u} [gE : normed_group E] [@normed_space 𝕜 E _ gE]
+    {F : Type u} [gF : normed_group F] [@normed_space 𝕜 F _ gF] (f : E → F), Prop
 | 0     E _ _ F _ _ f := by { resetI, exact continuous f }
-| (n+1) E _ _ F _ _ f := by { resetI, exact differentiable 𝕂 f ∧ times_cont_diff_rec n (fderiv 𝕂 f) }
+| (n+1) E _ _ F _ _ f := by { resetI, exact differentiable 𝕜 f ∧ times_cont_diff_rec n (fderiv 𝕜 f) }
 
 @[simp] lemma times_cont_diff_rec_zero :
-  times_cont_diff_rec 𝕂 0 f ↔ continuous f :=
+  times_cont_diff_rec 𝕜 0 f ↔ continuous f :=
 by refl
 
 @[simp] lemma times_cont_diff_rec_succ :
-  times_cont_diff_rec 𝕂 n.succ f ↔
-  differentiable 𝕂 f ∧ times_cont_diff_rec 𝕂 n (λx, fderiv 𝕂 f x) :=
+  times_cont_diff_rec 𝕜 n.succ f ↔
+  differentiable 𝕜 f ∧ times_cont_diff_rec 𝕜 n (λx, fderiv 𝕜 f x) :=
 by refl
 
-lemma times_cont_diff_rec.of_succ (h : times_cont_diff_rec 𝕂 n.succ f) :
-  times_cont_diff_rec 𝕂 n f :=
+lemma times_cont_diff_rec.of_succ (h : times_cont_diff_rec 𝕜 n.succ f) :
+  times_cont_diff_rec 𝕜 n f :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F,
@@ -268,8 +268,8 @@ begin
     exact ⟨h.1, IH h.2⟩ }
 end
 
-lemma times_cont_diff_rec.continuous (h : times_cont_diff_rec 𝕂 n f) :
-  continuous (iterated_fderiv 𝕂 n f) :=
+lemma times_cont_diff_rec.continuous (h : times_cont_diff_rec 𝕜 n f) :
+  continuous (iterated_fderiv 𝕜 n f) :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F f,
@@ -278,8 +278,8 @@ begin
     exact IH (times_cont_diff_rec_succ.1 h).2 }
 end
 
-lemma times_cont_diff_rec.differentiable (h : times_cont_diff_rec 𝕂 (n+1) f) :
-  differentiable 𝕂 (iterated_fderiv 𝕂 n f) :=
+lemma times_cont_diff_rec.differentiable (h : times_cont_diff_rec 𝕜 (n+1) f) :
+  differentiable 𝕜 (iterated_fderiv 𝕜 n f) :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F f,
@@ -292,24 +292,24 @@ end
 Auxiliary definition defining `C^n` functions on a set by induction over `n`.
 In applications, use `times_cont_diff_on` instead.
 -/
-def times_cont_diff_on_rec (𝕂 : Type w) [nondiscrete_normed_field 𝕂] :
-  Π (n : ℕ) {E : Type u} [gE : normed_group E] [@normed_space 𝕂 E _ gE]
-    {F : Type u} [gF : normed_group F] [@normed_space 𝕂 F _ gF] (f : E → F) (s : set E), Prop
+def times_cont_diff_on_rec (𝕜 : Type w) [nondiscrete_normed_field 𝕜] :
+  Π (n : ℕ) {E : Type u} [gE : normed_group E] [@normed_space 𝕜 E _ gE]
+    {F : Type u} [gF : normed_group F] [@normed_space 𝕜 F _ gF] (f : E → F) (s : set E), Prop
 | 0     E _ _ F _ _ f s := by { resetI, exact continuous_on f s }
 | (n+1) E _ _ F _ _ f s := by { resetI,
-                  exact differentiable_on 𝕂 f s ∧ times_cont_diff_on_rec n (fderiv_within 𝕂 f s) s}
+                  exact differentiable_on 𝕜 f s ∧ times_cont_diff_on_rec n (fderiv_within 𝕜 f s) s}
 
 @[simp] lemma times_cont_diff_on_rec_zero :
-  times_cont_diff_on_rec 𝕂 0 f s ↔ continuous_on f s :=
+  times_cont_diff_on_rec 𝕜 0 f s ↔ continuous_on f s :=
 by refl
 
 @[simp] lemma times_cont_diff_on_rec_succ :
-  times_cont_diff_on_rec 𝕂 n.succ f s ↔
-  differentiable_on 𝕂 f s ∧ times_cont_diff_on_rec 𝕂 n (λx, fderiv_within 𝕂 f s x) s :=
+  times_cont_diff_on_rec 𝕜 n.succ f s ↔
+  differentiable_on 𝕜 f s ∧ times_cont_diff_on_rec 𝕜 n (λx, fderiv_within 𝕜 f s x) s :=
 by refl
 
-lemma times_cont_diff_on_rec.of_succ (h : times_cont_diff_on_rec 𝕂 n.succ f s) :
-  times_cont_diff_on_rec 𝕂 n f s :=
+lemma times_cont_diff_on_rec.of_succ (h : times_cont_diff_on_rec 𝕜 n.succ f s) :
+  times_cont_diff_on_rec 𝕜 n f s :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F,
@@ -319,8 +319,8 @@ begin
 end
 
 lemma times_cont_diff_on_rec.continuous_on_iterated_fderiv_within
-  (h : times_cont_diff_on_rec 𝕂 n f s) :
-  continuous_on (iterated_fderiv_within 𝕂 n f s) s :=
+  (h : times_cont_diff_on_rec 𝕜 n f s) :
+  continuous_on (iterated_fderiv_within 𝕜 n f s) s :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F f,
@@ -329,8 +329,8 @@ begin
     exact IH (times_cont_diff_on_rec_succ.1 h).2 }
 end
 
-lemma times_cont_diff_on_rec.differentiable_on (h : times_cont_diff_on_rec 𝕂 (n+1) f s) :
-  differentiable_on 𝕂 (iterated_fderiv_within 𝕂 n f s) s :=
+lemma times_cont_diff_on_rec.differentiable_on (h : times_cont_diff_on_rec 𝕜 (n+1) f s) :
+  differentiable_on 𝕜 (iterated_fderiv_within 𝕜 n f s) s :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F f,
@@ -340,7 +340,7 @@ begin
 end
 
 lemma times_cont_diff_on_rec_univ :
-  times_cont_diff_on_rec 𝕂 n f univ ↔ times_cont_diff_rec 𝕂 n f :=
+  times_cont_diff_on_rec 𝕜 n f univ ↔ times_cont_diff_rec 𝕜 n f :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F f,
@@ -352,14 +352,14 @@ end
 A function is `C^n` on a set, for `n : with_top ℕ`, if its derivatives of order at most `n`
 are all well defined and continuous.
 -/
-def times_cont_diff_on (𝕂 : Type w) [nondiscrete_normed_field 𝕂] (n : with_top ℕ)
-  {E F : Type u} [normed_group E] [normed_space 𝕂 E]
-  [normed_group F] [normed_space 𝕂 F] (f : E → F) (s : set E) :=
-(∀m:ℕ, (m : with_top ℕ) ≤ n → continuous_on (iterated_fderiv_within 𝕂 m f s) s)
-∧ (∀m:ℕ, (m : with_top ℕ) < n → differentiable_on 𝕂 (iterated_fderiv_within 𝕂 m f s) s)
+def times_cont_diff_on (𝕜 : Type w) [nondiscrete_normed_field 𝕜] (n : with_top ℕ)
+  {E F : Type u} [normed_group E] [normed_space 𝕜 E]
+  [normed_group F] [normed_space 𝕜 F] (f : E → F) (s : set E) :=
+(∀m:ℕ, (m : with_top ℕ) ≤ n → continuous_on (iterated_fderiv_within 𝕜 m f s) s)
+∧ (∀m:ℕ, (m : with_top ℕ) < n → differentiable_on 𝕜 (iterated_fderiv_within 𝕜 m f s) s)
 
 @[simp] lemma times_cont_diff_on_zero :
-  times_cont_diff_on 𝕂 0 f s ↔ continuous_on f s :=
+  times_cont_diff_on 𝕜 0 f s ↔ continuous_on f s :=
 by simp [times_cont_diff_on]
 
 /--
@@ -367,7 +367,7 @@ The two definitions of `C^n` functions on domains, directly in terms of continui
 derivatives, or by induction, are equivalent.
 -/
 theorem times_cont_diff_on_iff_times_cont_diff_on_rec :
-  times_cont_diff_on 𝕂 n f s ↔ times_cont_diff_on_rec 𝕂 n f s :=
+  times_cont_diff_on 𝕜 n f s ↔ times_cont_diff_on_rec 𝕜 n f s :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F f,
@@ -409,25 +409,25 @@ end
 
 /- Next lemma is marked as a simp lemma as `C^(n+1)` functions appear mostly in inductions. -/
 @[simp] lemma times_cont_diff_on_succ :
-  times_cont_diff_on 𝕂 n.succ f s ↔
-  differentiable_on 𝕂 f s ∧ times_cont_diff_on 𝕂 n (λx, fderiv_within 𝕂 f s x) s :=
+  times_cont_diff_on 𝕜 n.succ f s ↔
+  differentiable_on 𝕜 f s ∧ times_cont_diff_on 𝕜 n (λx, fderiv_within 𝕜 f s x) s :=
 by simp [times_cont_diff_on_iff_times_cont_diff_on_rec]
 
 lemma times_cont_diff_on.of_le {m n : with_top ℕ}
- (h : times_cont_diff_on 𝕂 n f s) (le : m ≤ n) : times_cont_diff_on 𝕂 m f s :=
+ (h : times_cont_diff_on 𝕜 n f s) (le : m ≤ n) : times_cont_diff_on 𝕜 m f s :=
 ⟨λp hp, h.1 p (le_trans hp le), λp hp, h.2 p (lt_of_lt_of_le hp le)⟩
 
-lemma times_cont_diff_on.of_succ (h : times_cont_diff_on 𝕂 n.succ f s) :
-  times_cont_diff_on 𝕂 n f s :=
+lemma times_cont_diff_on.of_succ (h : times_cont_diff_on 𝕜 n.succ f s) :
+  times_cont_diff_on 𝕜 n f s :=
 h.of_le (with_top.coe_le_coe.2 (nat.le_succ n))
 
-lemma times_cont_diff_on.continuous_on {n : with_top ℕ} (h : times_cont_diff_on 𝕂 n f s) :
+lemma times_cont_diff_on.continuous_on {n : with_top ℕ} (h : times_cont_diff_on 𝕜 n f s) :
   continuous_on f s :=
 h.1 0 (by simp)
 
 lemma times_cont_diff_on.continuous_on_fderiv_within
-  {n : with_top ℕ} (h : times_cont_diff_on 𝕂 n f s) (hn : 1 ≤ n) :
-  continuous_on (fderiv_within 𝕂 f s) s :=
+  {n : with_top ℕ} (h : times_cont_diff_on 𝕜 n f s) (hn : 1 ≤ n) :
+  continuous_on (fderiv_within 𝕜 f s) s :=
 h.1 1 hn
 
 set_option class.instance_max_depth 50
@@ -437,11 +437,11 @@ If a function is at least `C^1`, its bundled derivative (mapping `(x, v)` to `Df
 continuous.
 -/
 lemma times_cont_diff_on.continuous_on_fderiv_within_apply
-  {n : with_top ℕ} (h : times_cont_diff_on 𝕂 n f s) (hn : 1 ≤ n) :
-  continuous_on (λp : E × E, (fderiv_within 𝕂 f s p.1 : E → F) p.2) (set.prod s univ) :=
+  {n : with_top ℕ} (h : times_cont_diff_on 𝕜 n f s) (hn : 1 ≤ n) :
+  continuous_on (λp : E × E, (fderiv_within 𝕜 f s p.1 : E → F) p.2) (set.prod s univ) :=
 begin
-  have A : continuous (λq : (E →L[𝕂] F) × E, q.1 q.2) := is_bounded_bilinear_map_apply.continuous,
-  have B : continuous_on (λp : E × E, (fderiv_within 𝕂 f s p.1, p.2)) (set.prod s univ),
+  have A : continuous (λq : (E →L[𝕜] F) × E, q.1 q.2) := is_bounded_bilinear_map_apply.continuous,
+  have B : continuous_on (λp : E × E, (fderiv_within 𝕜 f s p.1, p.2)) (set.prod s univ),
   { apply continuous_on.prod _ continuous_snd.continuous_on,
     refine continuous_on.comp (h.continuous_on_fderiv_within hn) continuous_fst.continuous_on (λx hx, _),
     simp at hx,
@@ -451,7 +451,7 @@ begin
 end
 
 lemma times_cont_diff_on_top :
-  times_cont_diff_on 𝕂 ⊤ f s ↔ (∀n:ℕ, times_cont_diff_on 𝕂 n f s) :=
+  times_cont_diff_on 𝕜 ⊤ f s ↔ (∀n:ℕ, times_cont_diff_on 𝕜 n f s) :=
 begin
   split,
   { assume h n,
@@ -463,32 +463,32 @@ begin
 end
 
 lemma times_cont_diff_on_fderiv_within_nat {m n : ℕ}
-  (hf : times_cont_diff_on 𝕂 n f s) (h : m + 1 ≤ n) :
-  times_cont_diff_on 𝕂 m (λx, fderiv_within 𝕂 f s x) s :=
+  (hf : times_cont_diff_on 𝕜 n f s) (h : m + 1 ≤ n) :
+  times_cont_diff_on 𝕜 m (λx, fderiv_within 𝕜 f s x) s :=
 begin
-  have : times_cont_diff_on 𝕂 m.succ f s :=
+  have : times_cont_diff_on 𝕜 m.succ f s :=
     hf.of_le (with_top.coe_le_coe.2 h),
   exact (times_cont_diff_on_succ.1 this).2
 end
 
 lemma times_cont_diff_on_fderiv_within {m n : with_top ℕ}
-  (hf : times_cont_diff_on 𝕂 n f s) (h : m + 1 ≤ n) :
-  times_cont_diff_on 𝕂 m (λx, fderiv_within 𝕂 f s x) s :=
+  (hf : times_cont_diff_on 𝕜 n f s) (h : m + 1 ≤ n) :
+  times_cont_diff_on 𝕜 m (λx, fderiv_within 𝕜 f s x) s :=
 begin
   cases m,
   { change ⊤ + 1 ≤ n at h,
     have : n = ⊤, by simpa using h,
     rw this at hf,
-    change times_cont_diff_on 𝕂 ⊤ (λ (x : E), fderiv_within 𝕂 f s x) s,
+    change times_cont_diff_on 𝕜 ⊤ (λ (x : E), fderiv_within 𝕜 f s x) s,
     rw times_cont_diff_on_top at ⊢ hf,
     exact λm, times_cont_diff_on_fderiv_within_nat (hf (m + 1)) (le_refl _) },
-  { have : times_cont_diff_on 𝕂 (m + 1) f s := hf.of_le h,
+  { have : times_cont_diff_on 𝕜 (m + 1) f s := hf.of_le h,
     exact times_cont_diff_on_fderiv_within_nat this (le_refl _) }
 end
 
-lemma times_cont_diff_on.congr_mono {n : with_top ℕ} (H : times_cont_diff_on 𝕂 n f s)
-  (hs : unique_diff_on 𝕂 s₁) (h : ∀x ∈ s₁, f₁ x = f x) (h₁ : s₁ ⊆ s) :
-  times_cont_diff_on 𝕂 n f₁ s₁ :=
+lemma times_cont_diff_on.congr_mono {n : with_top ℕ} (H : times_cont_diff_on 𝕜 n f s)
+  (hs : unique_diff_on 𝕜 s₁) (h : ∀x ∈ s₁, f₁ x = f x) (h₁ : s₁ ⊆ s) :
+  times_cont_diff_on 𝕜 n f₁ s₁ :=
 begin
   tactic.unfreeze_local_instances,
   induction n using with_top.nat_induction with n IH Itop generalizing F,
@@ -502,26 +502,26 @@ begin
     assume n, exact Itop n (H n) h }
 end
 
-lemma times_cont_diff_on.congr {n : with_top ℕ} {s : set E} (H : times_cont_diff_on 𝕂 n f s)
-  (hs : unique_diff_on 𝕂 s) (h : ∀x ∈ s, f₁ x = f x) :
-  times_cont_diff_on 𝕂 n f₁ s :=
+lemma times_cont_diff_on.congr {n : with_top ℕ} {s : set E} (H : times_cont_diff_on 𝕜 n f s)
+  (hs : unique_diff_on 𝕜 s) (h : ∀x ∈ s, f₁ x = f x) :
+  times_cont_diff_on 𝕜 n f₁ s :=
 times_cont_diff_on.congr_mono H hs h (subset.refl _)
 
-lemma times_cont_diff_on.congr_mono' {n m : with_top ℕ} {s : set E} (H : times_cont_diff_on 𝕂 n f s)
-  (hs : unique_diff_on 𝕂 s₁) (h : ∀x ∈ s₁, f₁ x = f x) (h₁ : s₁ ⊆ s) (le : m ≤ n) :
-  times_cont_diff_on 𝕂 m f₁ s₁ :=
+lemma times_cont_diff_on.congr_mono' {n m : with_top ℕ} {s : set E} (H : times_cont_diff_on 𝕜 n f s)
+  (hs : unique_diff_on 𝕜 s₁) (h : ∀x ∈ s₁, f₁ x = f x) (h₁ : s₁ ⊆ s) (le : m ≤ n) :
+  times_cont_diff_on 𝕜 m f₁ s₁ :=
 times_cont_diff_on.of_le (H.congr_mono hs h h₁) le
 
-lemma times_cont_diff_on.mono {n : with_top ℕ} {s t : set E} (h : times_cont_diff_on 𝕂 n f t)
-  (hst : s ⊆ t) (hs : unique_diff_on 𝕂 s) : times_cont_diff_on 𝕂 n f s :=
+lemma times_cont_diff_on.mono {n : with_top ℕ} {s t : set E} (h : times_cont_diff_on 𝕜 n f t)
+  (hst : s ⊆ t) (hs : unique_diff_on 𝕜 s) : times_cont_diff_on 𝕜 n f s :=
 times_cont_diff_on.congr_mono h hs (λx hx, rfl) hst
 
 /--
 Being `C^n` is a local property.
 -/
 lemma times_cont_diff_on_of_locally_times_cont_diff_on {n : with_top ℕ} {s : set E}
-  (hs : unique_diff_on 𝕂 s) (h : ∀x∈s, ∃u, is_open u ∧ x ∈ u ∧ times_cont_diff_on 𝕂 n f (s ∩ u)) :
-  times_cont_diff_on 𝕂 n f s :=
+  (hs : unique_diff_on 𝕜 s) (h : ∀x∈s, ∃u, is_open u ∧ x ∈ u ∧ times_cont_diff_on 𝕜 n f (s ∩ u)) :
+  times_cont_diff_on 𝕜 n f s :=
 begin
   split,
   { assume m hm,
@@ -544,69 +544,69 @@ end
 A function is `C^n`, for `n : with_top ℕ`, if its derivatives of order at most `n` are all well
 defined and continuous.
 -/
-def times_cont_diff (𝕂 : Type w) [nondiscrete_normed_field 𝕂] (n : with_top ℕ)
-  {E F : Type u} [normed_group E] [normed_space 𝕂 E]
-  [normed_group F] [normed_space 𝕂 F] (f : E → F) :=
-(∀m:ℕ, (m : with_top ℕ) ≤ n → continuous (iterated_fderiv 𝕂 m f ))
-∧ (∀m:ℕ, (m : with_top ℕ) < n → differentiable 𝕂 (iterated_fderiv 𝕂 m f))
+def times_cont_diff (𝕜 : Type w) [nondiscrete_normed_field 𝕜] (n : with_top ℕ)
+  {E F : Type u} [normed_group E] [normed_space 𝕜 E]
+  [normed_group F] [normed_space 𝕜 F] (f : E → F) :=
+(∀m:ℕ, (m : with_top ℕ) ≤ n → continuous (iterated_fderiv 𝕜 m f ))
+∧ (∀m:ℕ, (m : with_top ℕ) < n → differentiable 𝕜 (iterated_fderiv 𝕜 m f))
 
 lemma times_cont_diff_on_univ {n : with_top ℕ} :
-  times_cont_diff_on 𝕂 n f univ ↔ times_cont_diff 𝕂 n f :=
+  times_cont_diff_on 𝕜 n f univ ↔ times_cont_diff 𝕜 n f :=
 by simp [times_cont_diff_on, times_cont_diff, iterated_fderiv_within_univ,
         continuous_iff_continuous_on_univ, differentiable_on_univ]
 
 @[simp] lemma times_cont_diff_zero :
-  times_cont_diff 𝕂 0 f ↔ continuous f :=
+  times_cont_diff 𝕜 0 f ↔ continuous f :=
 by simp [times_cont_diff]
 
 theorem times_cont_diff_iff_times_cont_diff_rec :
-  times_cont_diff 𝕂 n f ↔ times_cont_diff_rec 𝕂 n f :=
+  times_cont_diff 𝕜 n f ↔ times_cont_diff_rec 𝕜 n f :=
 by simp [times_cont_diff_on_univ.symm, times_cont_diff_on_rec_univ.symm,
          times_cont_diff_on_iff_times_cont_diff_on_rec]
 
 @[simp] lemma times_cont_diff_succ :
-  times_cont_diff 𝕂 n.succ f ↔
-  differentiable 𝕂 f ∧ times_cont_diff 𝕂 n (λx, fderiv 𝕂 f x) :=
+  times_cont_diff 𝕜 n.succ f ↔
+  differentiable 𝕜 f ∧ times_cont_diff 𝕜 n (λx, fderiv 𝕜 f x) :=
 by simp [times_cont_diff_iff_times_cont_diff_rec]
 
-lemma times_cont_diff.of_le {m n : with_top ℕ} (h : times_cont_diff 𝕂 n f) (le : m ≤ n) :
-  times_cont_diff 𝕂 m f :=
+lemma times_cont_diff.of_le {m n : with_top ℕ} (h : times_cont_diff 𝕜 n f) (le : m ≤ n) :
+  times_cont_diff 𝕜 m f :=
 ⟨λp hp, h.1 p (le_trans hp le), λp hp, h.2 p (lt_of_lt_of_le hp le)⟩
 
-lemma times_cont_diff.of_succ (h : times_cont_diff 𝕂 n.succ f) : times_cont_diff 𝕂 n f :=
+lemma times_cont_diff.of_succ (h : times_cont_diff 𝕜 n.succ f) : times_cont_diff 𝕜 n f :=
 h.of_le (with_top.coe_le_coe.2 (nat.le_succ n))
 
-lemma times_cont_diff.continuous {n : with_top ℕ} (h : times_cont_diff 𝕂 n f) :
+lemma times_cont_diff.continuous {n : with_top ℕ} (h : times_cont_diff 𝕜 n f) :
   continuous f :=
 h.1 0 (by simp)
 
-lemma times_cont_diff.continuous_fderiv {n : with_top ℕ} (h : times_cont_diff 𝕂 n f) (hn : 1 ≤ n) :
-  continuous (fderiv 𝕂 f) :=
+lemma times_cont_diff.continuous_fderiv {n : with_top ℕ} (h : times_cont_diff 𝕜 n f) (hn : 1 ≤ n) :
+  continuous (fderiv 𝕜 f) :=
 h.1 1 hn
 
 lemma times_cont_diff.continuous_fderiv_apply
-  {n : with_top ℕ} (h : times_cont_diff 𝕂 n f) (hn : 1 ≤ n) :
-  continuous (λp : E × E, (fderiv 𝕂 f p.1 : E → F) p.2) :=
+  {n : with_top ℕ} (h : times_cont_diff 𝕜 n f) (hn : 1 ≤ n) :
+  continuous (λp : E × E, (fderiv 𝕜 f p.1 : E → F) p.2) :=
 begin
-  have A : continuous (λq : (E →L[𝕂] F) × E, q.1 q.2) := is_bounded_bilinear_map_apply.continuous,
-  have B : continuous (λp : E × E, (fderiv 𝕂 f p.1, p.2)),
+  have A : continuous (λq : (E →L[𝕜] F) × E, q.1 q.2) := is_bounded_bilinear_map_apply.continuous,
+  have B : continuous (λp : E × E, (fderiv 𝕜 f p.1, p.2)),
   { apply continuous.prod_mk _ continuous_snd,
     exact continuous.comp (h.continuous_fderiv hn) continuous_fst },
   exact A.comp B
 end
 
-lemma times_cont_diff_top : times_cont_diff 𝕂 ⊤ f ↔ (∀n:ℕ, times_cont_diff 𝕂 n f) :=
+lemma times_cont_diff_top : times_cont_diff 𝕜 ⊤ f ↔ (∀n:ℕ, times_cont_diff 𝕜 n f) :=
 by simp [times_cont_diff_on_univ.symm, times_cont_diff_on_rec_univ.symm,
         times_cont_diff_on_top]
 
 lemma times_cont_diff.times_cont_diff_on {n : with_top ℕ} {s : set E}
-  (h : times_cont_diff 𝕂 n f) (hs : unique_diff_on 𝕂 s) : times_cont_diff_on 𝕂 n f s :=
+  (h : times_cont_diff 𝕜 n f) (hs : unique_diff_on 𝕜 s) : times_cont_diff_on 𝕜 n f s :=
 by { rw ← times_cont_diff_on_univ at h, apply times_cont_diff_on.mono h (subset_univ _) hs }
 
 /--
 Constants are C^∞.
 -/
-lemma times_cont_diff_const {n : with_top ℕ} {c : F} : times_cont_diff 𝕂 n (λx : E, c) :=
+lemma times_cont_diff_const {n : with_top ℕ} {c : F} : times_cont_diff 𝕜 n (λx : E, c) :=
 begin
   tactic.unfreeze_local_instances,
   induction n using with_top.nat_induction with n IH Itop generalizing F,
@@ -622,8 +622,8 @@ end
 /--
 Linear functions are C^∞.
 -/
-lemma is_bounded_linear_map.times_cont_diff {n : with_top ℕ} (hf : is_bounded_linear_map 𝕂 f) :
-  times_cont_diff 𝕂 n f :=
+lemma is_bounded_linear_map.times_cont_diff {n : with_top ℕ} (hf : is_bounded_linear_map 𝕜 f) :
+  times_cont_diff 𝕜 n f :=
 begin
   induction n using with_top.nat_induction with n IH Itop,
   { rw times_cont_diff_zero,
@@ -637,26 +637,26 @@ end
 /--
 The first projection in a product is C^∞.
 -/
-lemma times_cont_diff_fst {n : with_top ℕ} : times_cont_diff 𝕂 n (prod.fst : E × F → E) :=
+lemma times_cont_diff_fst {n : with_top ℕ} : times_cont_diff 𝕜 n (prod.fst : E × F → E) :=
 is_bounded_linear_map.times_cont_diff is_bounded_linear_map.fst
 
 /--
 The second projection in a product is C^∞.
 -/
-lemma times_cont_diff_snd {n : with_top ℕ} : times_cont_diff 𝕂 n (prod.snd : E × F → F) :=
+lemma times_cont_diff_snd {n : with_top ℕ} : times_cont_diff 𝕜 n (prod.snd : E × F → F) :=
 is_bounded_linear_map.times_cont_diff is_bounded_linear_map.snd
 
 /--
 The identity is C^∞.
 -/
-lemma times_cont_diff_id {n : with_top ℕ} : times_cont_diff 𝕂 n (id : E → E) :=
+lemma times_cont_diff_id {n : with_top ℕ} : times_cont_diff 𝕜 n (id : E → E) :=
 is_bounded_linear_map.id.times_cont_diff
 
 /--
 Bilinear functions are C^∞.
 -/
-lemma is_bounded_bilinear_map.times_cont_diff {n : with_top ℕ} (hb : is_bounded_bilinear_map 𝕂 b) :
-  times_cont_diff 𝕂 n b :=
+lemma is_bounded_bilinear_map.times_cont_diff {n : with_top ℕ} (hb : is_bounded_bilinear_map 𝕜 b) :
+  times_cont_diff 𝕜 n b :=
 begin
   induction n using with_top.nat_induction with n IH Itop,
   { rw times_cont_diff_zero,
@@ -671,8 +671,8 @@ end
 Composition by bounded linear maps preserves `C^n` functions on domains.
 -/
 lemma times_cont_diff_on.comp_is_bounded_linear {n : with_top ℕ} {s : set E} {f : E → F} {g : F → G}
-  (hf : times_cont_diff_on 𝕂 n f s) (hg : is_bounded_linear_map 𝕂 g) (hs : unique_diff_on 𝕂 s) :
-  times_cont_diff_on 𝕂 n (λx, g (f x)) s :=
+  (hf : times_cont_diff_on 𝕜 n f s) (hg : is_bounded_linear_map 𝕜 g) (hs : unique_diff_on 𝕜 s) :
+  times_cont_diff_on 𝕜 n (λx, g (f x)) s :=
 begin
   tactic.unfreeze_local_instances,
   induction n using with_top.nat_induction with n IH Itop generalizing F G,
@@ -681,8 +681,8 @@ begin
     apply continuous_on.comp this hf (subset_univ _) },
   { rw times_cont_diff_on_succ at hf ⊢,
     refine ⟨differentiable_on.comp hg.differentiable_on hf.1 (subset_univ _), _⟩,
-    let Φ : (E →L[𝕂] F) → (E →L[𝕂] G) := λu, continuous_linear_map.comp (hg.to_continuous_linear_map) u,
-    have : ∀x∈s, fderiv_within 𝕂 (g ∘ f) s x = Φ (fderiv_within 𝕂 f s x),
+    let Φ : (E →L[𝕜] F) → (E →L[𝕜] G) := λu, continuous_linear_map.comp (hg.to_continuous_linear_map) u,
+    have : ∀x∈s, fderiv_within 𝕜 (g ∘ f) s x = Φ (fderiv_within 𝕜 f s x),
     { assume x hx,
       rw [fderiv_within.comp x _ (hf.1 x hx) (subset_univ _) (hs x hx),
           fderiv_within_univ, hg.fderiv],
@@ -700,8 +700,8 @@ end
 Composition by bounded linear maps preserves `C^n` functions.
 -/
 lemma times_cont_diff.comp_is_bounded_linear {n : with_top ℕ} {f : E → F} {g : F → G}
-  (hf : times_cont_diff 𝕂 n f) (hg : is_bounded_linear_map 𝕂 g) :
-  times_cont_diff 𝕂 n (λx, g (f x)) :=
+  (hf : times_cont_diff 𝕜 n f) (hg : is_bounded_linear_map 𝕜 g) :
+  times_cont_diff 𝕜 n (λx, g (f x)) :=
 times_cont_diff_on_univ.1 $ times_cont_diff_on.comp_is_bounded_linear (times_cont_diff_on_univ.2 hf)
   hg is_open_univ.unique_diff_on
 
@@ -709,8 +709,8 @@ times_cont_diff_on_univ.1 $ times_cont_diff_on.comp_is_bounded_linear (times_con
 The cartesian product of `C^n` functions on domains is `C^n`.
 -/
 lemma times_cont_diff_on.prod {n : with_top ℕ} {s : set E} {f : E → F} {g : E → G}
-  (hf : times_cont_diff_on 𝕂 n f s) (hg : times_cont_diff_on 𝕂 n g s) (hs : unique_diff_on 𝕂 s) :
-  times_cont_diff_on 𝕂 n (λx:E, (f x, g x)) s :=
+  (hf : times_cont_diff_on 𝕜 n f s) (hg : times_cont_diff_on 𝕜 n g s) (hs : unique_diff_on 𝕜 s) :
+  times_cont_diff_on 𝕜 n (λx:E, (f x, g x)) s :=
 begin
   tactic.unfreeze_local_instances,
   induction n using with_top.nat_induction with n IH Itop generalizing F G,
@@ -718,9 +718,9 @@ begin
     exact continuous_on.prod hf hg },
   { rw times_cont_diff_on_succ at hf hg ⊢,
     refine ⟨differentiable_on.prod hf.1 hg.1, _⟩,
-    let F₁ := λx : E, (fderiv_within 𝕂 f s x, fderiv_within 𝕂 g s x),
-    let Φ : ((E →L[𝕂] F) × (E →L[𝕂] G)) → (E →L[𝕂] (F × G)) := λp, continuous_linear_map.prod p.1 p.2,
-    have : times_cont_diff_on 𝕂 n (Φ ∘ F₁) s :=
+    let F₁ := λx : E, (fderiv_within 𝕜 f s x, fderiv_within 𝕜 g s x),
+    let Φ : ((E →L[𝕜] F) × (E →L[𝕜] G)) → (E →L[𝕜] (F × G)) := λp, continuous_linear_map.prod p.1 p.2,
+    have : times_cont_diff_on 𝕜 n (Φ ∘ F₁) s :=
       times_cont_diff_on.comp_is_bounded_linear (IH hf.2 hg.2) is_bounded_linear_map_prod_iso hs,
     apply times_cont_diff_on.congr_mono this hs (λx hx, _) (subset.refl _),
     apply differentiable_at.fderiv_within_prod (hf.1 x hx) (hg.1 x hx) (hs x hx) },
@@ -733,8 +733,8 @@ end
 The cartesian product of `C^n` functions is `C^n`.
 -/
 lemma times_cont_diff.prod {n : with_top ℕ} {f : E → F} {g : E → G}
-  (hf : times_cont_diff 𝕂 n f) (hg : times_cont_diff 𝕂 n g) :
-  times_cont_diff 𝕂 n (λx:E, (f x, g x)) :=
+  (hf : times_cont_diff 𝕜 n f) (hg : times_cont_diff 𝕜 n g) :
+  times_cont_diff 𝕜 n (λx:E, (f x, g x)) :=
 times_cont_diff_on_univ.1 $ times_cont_diff_on.prod (times_cont_diff_on_univ.2 hf)
   (times_cont_diff_on_univ.2 hg) is_open_univ.unique_diff_on
 
@@ -742,8 +742,8 @@ times_cont_diff_on_univ.1 $ times_cont_diff_on.prod (times_cont_diff_on_univ.2 h
 The composition of `C^n` functions on domains is `C^n`.
 -/
 lemma times_cont_diff_on.comp {n : with_top ℕ} {s : set E} {t : set F} {g : F → G} {f : E → F}
-  (hg : times_cont_diff_on 𝕂 n g t) (hf : times_cont_diff_on 𝕂 n f s) (hs : unique_diff_on 𝕂 s)
-  (st : f '' s ⊆ t) : times_cont_diff_on 𝕂 n (g ∘ f) s :=
+  (hg : times_cont_diff_on 𝕜 n g t) (hf : times_cont_diff_on 𝕜 n f s) (hs : unique_diff_on 𝕜 s)
+  (st : f '' s ⊆ t) : times_cont_diff_on 𝕜 n (g ∘ f) s :=
 begin
   tactic.unfreeze_local_instances,
   induction n using with_top.nat_induction with n IH Itop generalizing E F G,
@@ -758,18 +758,18 @@ begin
     and the inductive assumption.
     -/
     refine ⟨differentiable_on.comp hg.1 hf.1 st, _⟩,
-    have : ∀x∈s, fderiv_within 𝕂 (g ∘ f) s x =
-      continuous_linear_map.comp (fderiv_within 𝕂 g t (f x)) (fderiv_within 𝕂 f s x),
+    have : ∀x∈s, fderiv_within 𝕜 (g ∘ f) s x =
+      continuous_linear_map.comp (fderiv_within 𝕜 g t (f x)) (fderiv_within 𝕜 f s x),
     { assume x hx,
       apply fderiv_within.comp x _ (hf.1 x hx) st (hs x hx),
       exact hg.1 _ (st (mem_image_of_mem _ hx)) },
     apply times_cont_diff_on.congr _ hs this,
-    have A : times_cont_diff_on 𝕂 n (λx, fderiv_within 𝕂 g t (f x)) s :=
+    have A : times_cont_diff_on 𝕜 n (λx, fderiv_within 𝕜 g t (f x)) s :=
       IH hg.2 (times_cont_diff_on_succ.2 hf).of_succ hs st,
-    have B : times_cont_diff_on 𝕂 n (λx, fderiv_within 𝕂 f s x) s := hf.2,
-    have C : times_cont_diff_on 𝕂 n (λx:E, (fderiv_within 𝕂 f s x, fderiv_within 𝕂 g t (f x))) s :=
+    have B : times_cont_diff_on 𝕜 n (λx, fderiv_within 𝕜 f s x) s := hf.2,
+    have C : times_cont_diff_on 𝕜 n (λx:E, (fderiv_within 𝕜 f s x, fderiv_within 𝕜 g t (f x))) s :=
       times_cont_diff_on.prod B A hs,
-    have D : times_cont_diff_on 𝕂 n (λ(p : (E →L[𝕂] F) × (F →L[𝕂] G)), p.2.comp p.1) univ :=
+    have D : times_cont_diff_on 𝕜 n (λ(p : (E →L[𝕜] F) × (F →L[𝕜] G)), p.2.comp p.1) univ :=
       is_bounded_bilinear_map_comp.times_cont_diff.times_cont_diff_on is_open_univ.unique_diff_on,
     exact IH D C hs (subset_univ _) },
   { rw times_cont_diff_on_top at hf hg ⊢,
@@ -781,8 +781,8 @@ end
 The composition of `C^n` functions is `C^n`.
 -/
 lemma times_cont_diff.comp {n : with_top ℕ} {g : F → G} {f : E → F}
-  (hg : times_cont_diff 𝕂 n g) (hf : times_cont_diff 𝕂 n f) :
-  times_cont_diff 𝕂 n (g ∘ f) :=
+  (hg : times_cont_diff 𝕜 n g) (hf : times_cont_diff 𝕜 n f) :
+  times_cont_diff 𝕜 n (g ∘ f) :=
 times_cont_diff_on_univ.1 $ times_cont_diff_on.comp (times_cont_diff_on_univ.2 hg)
   (times_cont_diff_on_univ.2 hf) is_open_univ.unique_diff_on (subset_univ _)
 
@@ -790,21 +790,21 @@ times_cont_diff_on_univ.1 $ times_cont_diff_on.comp (times_cont_diff_on_univ.2 h
 The bundled derivative of a `C^{n+1}` function is `C^n`.
 -/
 lemma times_cont_diff_on_fderiv_within_apply {m n : with_top  ℕ} {s : set E}
-  {f : E → F} (hf : times_cont_diff_on 𝕂 n f s) (hs : unique_diff_on 𝕂 s) (hmn : m + 1 ≤ n) :
-  times_cont_diff_on 𝕂 m (λp : E × E, (fderiv_within 𝕂 f s p.1 : E →L[𝕂] F) p.2) (set.prod s (univ : set E)) :=
+  {f : E → F} (hf : times_cont_diff_on 𝕜 n f s) (hs : unique_diff_on 𝕜 s) (hmn : m + 1 ≤ n) :
+  times_cont_diff_on 𝕜 m (λp : E × E, (fderiv_within 𝕜 f s p.1 : E →L[𝕜] F) p.2) (set.prod s (univ : set E)) :=
 begin
-  have U : unique_diff_on 𝕂 (set.prod s (univ : set E)) :=
+  have U : unique_diff_on 𝕜 (set.prod s (univ : set E)) :=
     hs.prod unique_diff_on_univ,
-  have A : times_cont_diff_on 𝕂 m (λp : (E →L[𝕂] F) × E, p.1 p.2) univ,
+  have A : times_cont_diff_on 𝕜 m (λp : (E →L[𝕜] F) × E, p.1 p.2) univ,
   { rw times_cont_diff_on_univ,
     apply is_bounded_bilinear_map.times_cont_diff,
     exact is_bounded_bilinear_map_apply },
-  have B : times_cont_diff_on 𝕂 m
-    (λ (p : E × E), ((fderiv_within 𝕂 f s p.fst), p.snd)) (set.prod s univ),
+  have B : times_cont_diff_on 𝕜 m
+    (λ (p : E × E), ((fderiv_within 𝕜 f s p.fst), p.snd)) (set.prod s univ),
   { apply times_cont_diff_on.prod _ _ U,
-    { have I : times_cont_diff_on 𝕂 m (λ (x : E), fderiv_within 𝕂 f s x) s :=
+    { have I : times_cont_diff_on 𝕜 m (λ (x : E), fderiv_within 𝕜 f s x) s :=
         times_cont_diff_on_fderiv_within hf hmn,
-      have J : times_cont_diff_on 𝕂 m (λ (x : E × E), x.1) (set.prod s univ),
+      have J : times_cont_diff_on 𝕜 m (λ (x : E × E), x.1) (set.prod s univ),
       { apply times_cont_diff.times_cont_diff_on _ U,
         apply is_bounded_linear_map.times_cont_diff,
         apply is_bounded_linear_map.fst },
@@ -819,8 +819,8 @@ end
 The bundled derivative of a `C^{n+1}` function is `C^n`.
 -/
 lemma times_cont_diff.times_cont_diff_fderiv_apply {n m : with_top ℕ} {s : set E} {f : E → F}
-  (hf : times_cont_diff 𝕂 n f) (hmn : m + 1 ≤ n) :
-  times_cont_diff 𝕂 m (λp : E × E, (fderiv 𝕂 f p.1 : E →L[𝕂] F) p.2) :=
+  (hf : times_cont_diff 𝕜 n f) (hmn : m + 1 ≤ n) :
+  times_cont_diff 𝕜 m (λp : E × E, (fderiv 𝕜 f p.1 : E →L[𝕜] F) p.2) :=
 begin
   rw ← times_cont_diff_on_univ at ⊢ hf,
   rw [← fderiv_within_univ, ← univ_prod_univ],

--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -15,31 +15,31 @@ equivalently, if it is `C^1` and its derivative is `C^{n-1}`.
 Finally, it is `C^∞` if it is `C^n` for all n.
 
 We formalize these notions by defining iteratively the n-th derivative of a function at the
-(n-1)-th derivative of the derivative. It is called `iterated_fderiv k n f x` where `k` is the
+(n-1)-th derivative of the derivative. It is called `iterated_fderiv 𝕂 n f x` where `𝕂` is the
 field, `n` is the number of iterations, `f` is the function and `x` is the point. We also define a
-version `iterated_fderiv_within` relative to a domain, as well as predicates `times_cont_diff k n f`
-and `times_cont_diff_on k n f s` saying that the function is `C^n`, respectively in the whole space
+version `iterated_fderiv_within` relative to a domain, as well as predicates `times_cont_diff 𝕂 n f`
+and `times_cont_diff_on 𝕂 n f s` saying that the function is `C^n`, respectively in the whole space
 or on the set `s`.
 
 We prove basic properties of these notions.
 
 ## Implementation notes
 
-The n-th derivative of a function belongs to the space E →L[k] (E →L[k] (E ... F)...))),
-where there are n iterations of `E →L[k]`. We define this space inductively, call it
-`iterated_continuous_linear_map k n E F`, and denote it by `E [×n]→L[k] F`. We can define
+The n-th derivative of a function belongs to the space E →L[𝕂] (E →L[𝕂] (E ... F)...))),
+where there are n iterations of `E →L[𝕂]`. We define this space inductively, call it
+`iterated_continuous_linear_map 𝕂 n E F`, and denote it by `E [×n]→L[𝕂] F`. We can define
 it inductively either from the left (i.e., saying that the
-(n+1)-th space S_{n+1} is E →L[k] S_n) or from the right (i.e., saying that
-the (n+1)-th space associated to F, denoted by S_{n+1} (F), is equal to S_n (E →L[k] F)).
+(n+1)-th space S_{n+1} is E →L[𝕂] S_n) or from the right (i.e., saying that
+the (n+1)-th space associated to F, denoted by S_{n+1} (F), is equal to S_n (E →L[𝕂] F)).
 For proofs, it turns out to be more convenient to use the latter approach (from the right),
 as it means to prove things at the (n+1)-th step we only need to understand well enough the
-derivative in E →L[k] F (contrary to the approach from the left, where one would need to know
+derivative in E →L[𝕂] F (contrary to the approach from the left, where one would need to know
 enough on the n-th derivative to deduce things on the (n+1)-th derivative).
 In other words, one could define the (n+1)-th derivative either as the derivative of the n-th
 derivative, or as the n-th derivative of the derivative. We use the latter definition.
 
 A difficulty is related to universes: the first and second spaces in the sequence, for n=0
-and 1, are F and E →L[k] F. If E has universe u and F has universe v, then the first one lives in
+and 1, are F and E →L[𝕂] F. If E has universe u and F has universe v, then the first one lives in
 v and the second one in max v u. Since they should live in the same universe (as all the other
 spaces in the construction), it means that at the 0-th step we should not use F, but ulift it to
 universe max v u. But we should also ulift its vector space structure and its normed space
@@ -72,39 +72,39 @@ universes u v w
 
 open set
 
-variables {k : Type*} [nondiscrete_normed_field k]
-{E : Type u} [normed_group E] [normed_space k E]
-{F : Type u} [normed_group F] [normed_space k F]
-{G : Type u} [normed_group G] [normed_space k G]
-{s s₁ u : set E} {f f₁ : E → F} {f' f₁' : E →L[k] F} {f₂ : E → G}
-{f₂' : E →L[k] G} {g : F → G} {x : E} {c : F}
+variables {𝕂 : Type*} [nondiscrete_normed_field 𝕂]
+{E : Type u} [normed_group E] [normed_space 𝕂 E]
+{F : Type u} [normed_group F] [normed_space 𝕂 F]
+{G : Type u} [normed_group G] [normed_space 𝕂 G]
+{s s₁ u : set E} {f f₁ : E → F} {f' f₁' : E →L[𝕂] F} {f₂ : E → G}
+{f₂' : E →L[𝕂] G} {g : F → G} {x : E} {c : F}
 {L : filter E} {t : set F} {b : E × F → G} {sb : set (E × F)} {p : E × F}
 {n : ℕ}
 
-include k
+include 𝕂
 
 /--
-The space `iterated_continuous_linear_map k n E F` is the space E →L[k] (E →L[k] (E ... F)...))),
+The space `iterated_continuous_linear_map 𝕂 n E F` is the space E →L[𝕂] (E →L[𝕂] (E ... F)...))),
 defined inductively over `n`. This is the space to which the `n`-th derivative of a function
 naturally belongs. It is only defined when `E` and `F` live in the same universe.
 -/
-def iterated_continuous_linear_map (k : Type w) [nondiscrete_normed_field k] :
-  Π (n : ℕ) (E : Type u) [gE : normed_group E] [@normed_space k E _ gE]
-    (F : Type u) [gF : normed_group F] [@normed_space k F _ gF], Type u
+def iterated_continuous_linear_map (𝕂 : Type w) [nondiscrete_normed_field 𝕂] :
+  Π (n : ℕ) (E : Type u) [gE : normed_group E] [@normed_space 𝕂 E _ gE]
+    (F : Type u) [gF : normed_group F] [@normed_space 𝕂 F _ gF], Type u
 | 0     E _ _ F _ _ := F
-| (n+1) E _ _ F _ _ := by { resetI, exact iterated_continuous_linear_map n E (E →L[k] F) }
+| (n+1) E _ _ F _ _ := by { resetI, exact iterated_continuous_linear_map n E (E →L[𝕂] F) }
 
-notation E `[×`:25 n `]→L[`:25 k `] ` F := iterated_continuous_linear_map k n E F
+notation E `[×`:25 n `]→L[`:25 𝕂 `] ` F := iterated_continuous_linear_map 𝕂 n E F
 
 /--
 Define by induction a normed group structure on the space of iterated continuous linear
 maps. To avoid `resetI` in the statement, use the @ version with all parameters. As the equation
 compiler chokes on this one, we use the `nat.rec_on` version.
 -/
-def iterated_continuous_linear_map.normed_group_rec (k : Type w) [hk : nondiscrete_normed_field k]
-  (n : ℕ) (E : Type u) [gE : normed_group E] [sE : normed_space k E] :
-  ∀(F : Type u) [nF : normed_group F] [sF : @normed_space k F _ nF],
-  normed_group (@iterated_continuous_linear_map k hk n E gE sE F nF sF) :=
+def iterated_continuous_linear_map.normed_group_rec (𝕂 : Type w) [h𝕂 : nondiscrete_normed_field 𝕂]
+  (n : ℕ) (E : Type u) [gE : normed_group E] [sE : normed_space 𝕂 E] :
+  ∀(F : Type u) [nF : normed_group F] [sF : @normed_space 𝕂 F _ nF],
+  normed_group (@iterated_continuous_linear_map 𝕂 h𝕂 n E gE sE F nF sF) :=
 nat.rec_on n (λF nF sF, nF) (λn aux_n F nF sF, by { resetI, apply aux_n })
 
 /--
@@ -112,68 +112,68 @@ Define by induction a normed space structure on the space of iterated continuous
 maps. To avoid `resetI` in the statement, use the @ version with all parameters. As the equation
 compiler chokes on this one, we use the `nat.rec_on` version.
 -/
-def iterated_continuous_linear_map.normed_space_rec (k : Type w) [hk : nondiscrete_normed_field k]
-  (n : ℕ) (E : Type u) [gE : normed_group E] [sE : normed_space k E] :
-  ∀(F : Type u) [nF : normed_group F] [sF : @normed_space k F _ nF],
-  @normed_space k (@iterated_continuous_linear_map k hk n E gE sE F nF sF)
-  _ (@iterated_continuous_linear_map.normed_group_rec k hk n E gE sE F nF sF) :=
+def iterated_continuous_linear_map.normed_space_rec (𝕂 : Type w) [h𝕂 : nondiscrete_normed_field 𝕂]
+  (n : ℕ) (E : Type u) [gE : normed_group E] [sE : normed_space 𝕂 E] :
+  ∀(F : Type u) [nF : normed_group F] [sF : @normed_space 𝕂 F _ nF],
+  @normed_space 𝕂 (@iterated_continuous_linear_map 𝕂 h𝕂 n E gE sE F nF sF)
+  _ (@iterated_continuous_linear_map.normed_group_rec 𝕂 h𝕂 n E gE sE F nF sF) :=
 nat.rec_on n (λF nF sF, sF) (λn aux_n F nF sF, by { resetI, apply aux_n })
 
 /--
 Explicit normed group structure on the space of iterated continuous linear maps.
 -/
 instance iterated_continuous_linear_map.normed_group (n : ℕ)
-  (k : Type w) [hk : nondiscrete_normed_field k]
-  (E : Type u) [gE : normed_group E] [sE : normed_space k E]
-  (F : Type u) [gF : normed_group F] [sF : normed_space k F] :
-  normed_group (E [×n]→L[k] F) :=
-iterated_continuous_linear_map.normed_group_rec k n E F
+  (𝕂 : Type w) [h𝕂 : nondiscrete_normed_field 𝕂]
+  (E : Type u) [gE : normed_group E] [sE : normed_space 𝕂 E]
+  (F : Type u) [gF : normed_group F] [sF : normed_space 𝕂 F] :
+  normed_group (E [×n]→L[𝕂] F) :=
+iterated_continuous_linear_map.normed_group_rec 𝕂 n E F
 
 /--
 Explicit normed space structure on the space of iterated continuous linear maps.
 -/
 instance iterated_continuous_linear_map.normed_space (n : ℕ)
-  (k : Type w) [hk : nondiscrete_normed_field k]
-  (E : Type u) [gE : normed_group E] [sE : normed_space k E]
-  (F : Type u) [gF : normed_group F] [sF : normed_space k F] :
-  normed_space k (E [×n]→L[k] F) :=
-iterated_continuous_linear_map.normed_space_rec k n E F
+  (𝕂 : Type w) [h𝕂 : nondiscrete_normed_field 𝕂]
+  (E : Type u) [gE : normed_group E] [sE : normed_space 𝕂 E]
+  (F : Type u) [gF : normed_group F] [sF : normed_space 𝕂 F] :
+  normed_space 𝕂 (E [×n]→L[𝕂] F) :=
+iterated_continuous_linear_map.normed_space_rec 𝕂 n E F
 
 /--
 The n-th derivative of a function, defined inductively by saying that the (n+1)-th
 derivative of f is the n-th derivative of the derivative of f.
 -/
-def iterated_fderiv (k : Type w) [hk : nondiscrete_normed_field k] (n : ℕ)
-  {E : Type u} [gE : normed_group E] [sE : normed_space k E] :
-  ∀{F : Type u} [gF : normed_group F] [sF : @normed_space k F _ gF] (f : E → F),
-  E → @iterated_continuous_linear_map k hk n E gE sE F gF sF :=
-nat.rec_on n (λF gF sF f, f) (λn rec F gF sF f, by { resetI, exact rec (fderiv k f) })
+def iterated_fderiv (𝕂 : Type w) [h𝕂 : nondiscrete_normed_field 𝕂] (n : ℕ)
+  {E : Type u} [gE : normed_group E] [sE : normed_space 𝕂 E] :
+  ∀{F : Type u} [gF : normed_group F] [sF : @normed_space 𝕂 F _ gF] (f : E → F),
+  E → @iterated_continuous_linear_map 𝕂 h𝕂 n E gE sE F gF sF :=
+nat.rec_on n (λF gF sF f, f) (λn rec F gF sF f, by { resetI, exact rec (fderiv 𝕂 f) })
 
 @[simp] lemma iterated_fderiv_zero :
-  iterated_fderiv k 0 f = f := rfl
+  iterated_fderiv 𝕂 0 f = f := rfl
 
 @[simp] lemma iterated_fderiv_succ :
-  iterated_fderiv k (n+1) f = (iterated_fderiv k n (λx, fderiv k f x) : _) := rfl
+  iterated_fderiv 𝕂 (n+1) f = (iterated_fderiv 𝕂 n (λx, fderiv 𝕂 f x) : _) := rfl
 
 /--
 The n-th derivative of a function along a set, defined inductively by saying that the (n+1)-th
 derivative of f is the n-th derivative of the derivative of f.
 -/
-def iterated_fderiv_within (k : Type w) [hk :nondiscrete_normed_field k] (n : ℕ)
-  {E : Type u} [gE : normed_group E] [sE : normed_space k E] :
-  ∀{F : Type u} [gF : normed_group F] [sF : @normed_space k F _ gF] (f : E → F) (s : set E),
-  E → @iterated_continuous_linear_map k hk n E gE sE F gF sF :=
-nat.rec_on n (λF gF sF f s, f) (λn rec F gF sF f s, by { resetI, exact rec (fderiv_within k f s) s})
+def iterated_fderiv_within (𝕂 : Type w) [h𝕂 :nondiscrete_normed_field 𝕂] (n : ℕ)
+  {E : Type u} [gE : normed_group E] [sE : normed_space 𝕂 E] :
+  ∀{F : Type u} [gF : normed_group F] [sF : @normed_space 𝕂 F _ gF] (f : E → F) (s : set E),
+  E → @iterated_continuous_linear_map 𝕂 h𝕂 n E gE sE F gF sF :=
+nat.rec_on n (λF gF sF f s, f) (λn rec F gF sF f s, by { resetI, exact rec (fderiv_within 𝕂 f s) s})
 
 @[simp] lemma iterated_fderiv_within_zero :
-  iterated_fderiv_within k 0 f s = f := rfl
+  iterated_fderiv_within 𝕂 0 f s = f := rfl
 
 @[simp] lemma iterated_fderiv_within_succ :
-  iterated_fderiv_within k (n+1) f s
-  = (iterated_fderiv_within k n (λx, fderiv_within k f s x) s : _) := rfl
+  iterated_fderiv_within 𝕂 (n+1) f s
+  = (iterated_fderiv_within 𝕂 n (λx, fderiv_within 𝕂 f s x) s : _) := rfl
 
 theorem iterated_fderiv_within_univ {n : ℕ} :
-  iterated_fderiv_within k n f univ = iterated_fderiv k n f :=
+  iterated_fderiv_within 𝕂 n f univ = iterated_fderiv 𝕂 n f :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F,
@@ -185,9 +185,9 @@ end
 If two functions coincide on a set `s` of unique differentiability, then their iterated
 differentials within this set coincide.
 -/
-lemma iterated_fderiv_within_congr (hs : unique_diff_on k s)
+lemma iterated_fderiv_within_congr (hs : unique_diff_on 𝕂 s)
   (hL : ∀y∈s, f₁ y = f y) (hx : x ∈ s) :
-  iterated_fderiv_within k n f₁ s x = iterated_fderiv_within k n f s x :=
+  iterated_fderiv_within 𝕂 n f₁ s x = iterated_fderiv_within 𝕂 n f s x :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F f x,
@@ -202,8 +202,8 @@ The iterated differential within a set `s` at a point `x` is not modified if one
 `s` with an open set containing `x`.
 -/
 lemma iterated_fderiv_within_inter_open (xu : x ∈ u) (hu : is_open u) (xs : x ∈ s)
-  (hs : unique_diff_on k (s ∩ u)) :
-  iterated_fderiv_within k n f (s ∩ u) x = iterated_fderiv_within k n f s x :=
+  (hs : unique_diff_on 𝕂 (s ∩ u)) :
+  iterated_fderiv_within 𝕂 n f (s ∩ u) x = iterated_fderiv_within 𝕂 n f s x :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F f,
@@ -221,17 +221,17 @@ The iterated differential within a set `s` at a point `x` is not modified if one
 `s` with a neighborhood of `x`.
 -/
 lemma iterated_fderiv_within_inter (hu : u ∈ nhds x) (xs : x ∈ s)
-  (hs : unique_diff_on k s) :
-  iterated_fderiv_within k n f (s ∩ u) x = iterated_fderiv_within k n f s x :=
+  (hs : unique_diff_on 𝕂 s) :
+  iterated_fderiv_within 𝕂 n f (s ∩ u) x = iterated_fderiv_within 𝕂 n f s x :=
 begin
   rcases mem_nhds_sets_iff.1 hu with ⟨v, vu, v_open, xv⟩,
   have A : (s ∩ u) ∩ v = s ∩ v,
   { apply subset.antisymm (inter_subset_inter (inter_subset_left _ _) (subset.refl _)),
     exact λ y ⟨ys, yv⟩, ⟨⟨ys, vu yv⟩, yv⟩ },
-  have : iterated_fderiv_within k n f (s ∩ v) x = iterated_fderiv_within k n f s x :=
+  have : iterated_fderiv_within 𝕂 n f (s ∩ v) x = iterated_fderiv_within 𝕂 n f s x :=
     iterated_fderiv_within_inter_open xv v_open xs (unique_diff_on_inter hs v_open),
   rw ← this,
-  have : iterated_fderiv_within k n f ((s ∩ u) ∩ v) x = iterated_fderiv_within k n f (s ∩ u) x,
+  have : iterated_fderiv_within 𝕂 n f ((s ∩ u) ∩ v) x = iterated_fderiv_within 𝕂 n f (s ∩ u) x,
   { refine iterated_fderiv_within_inter_open xv v_open ⟨xs, mem_of_nhds hu⟩ _,
     rw A,
     exact unique_diff_on_inter hs v_open },
@@ -243,23 +243,23 @@ end
 Auxiliary definition defining `C^n` functions by induction over `n`.
 In applications, use `times_cont_diff` instead.
 -/
-def times_cont_diff_rec (k : Type w) [nondiscrete_normed_field k] :
-  Π (n : ℕ) {E : Type u} [gE : normed_group E] [@normed_space k E _ gE]
-    {F : Type u} [gF : normed_group F] [@normed_space k F _ gF] (f : E → F), Prop
+def times_cont_diff_rec (𝕂 : Type w) [nondiscrete_normed_field 𝕂] :
+  Π (n : ℕ) {E : Type u} [gE : normed_group E] [@normed_space 𝕂 E _ gE]
+    {F : Type u} [gF : normed_group F] [@normed_space 𝕂 F _ gF] (f : E → F), Prop
 | 0     E _ _ F _ _ f := by { resetI, exact continuous f }
-| (n+1) E _ _ F _ _ f := by { resetI, exact differentiable k f ∧ times_cont_diff_rec n (fderiv k f) }
+| (n+1) E _ _ F _ _ f := by { resetI, exact differentiable 𝕂 f ∧ times_cont_diff_rec n (fderiv 𝕂 f) }
 
 @[simp] lemma times_cont_diff_rec_zero :
-  times_cont_diff_rec k 0 f ↔ continuous f :=
+  times_cont_diff_rec 𝕂 0 f ↔ continuous f :=
 by refl
 
 @[simp] lemma times_cont_diff_rec_succ :
-  times_cont_diff_rec k n.succ f ↔
-  differentiable k f ∧ times_cont_diff_rec k n (λx, fderiv k f x) :=
+  times_cont_diff_rec 𝕂 n.succ f ↔
+  differentiable 𝕂 f ∧ times_cont_diff_rec 𝕂 n (λx, fderiv 𝕂 f x) :=
 by refl
 
-lemma times_cont_diff_rec.of_succ (h : times_cont_diff_rec k n.succ f) :
-  times_cont_diff_rec k n f :=
+lemma times_cont_diff_rec.of_succ (h : times_cont_diff_rec 𝕂 n.succ f) :
+  times_cont_diff_rec 𝕂 n f :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F,
@@ -268,8 +268,8 @@ begin
     exact ⟨h.1, IH h.2⟩ }
 end
 
-lemma times_cont_diff_rec.continuous (h : times_cont_diff_rec k n f) :
-  continuous (iterated_fderiv k n f) :=
+lemma times_cont_diff_rec.continuous (h : times_cont_diff_rec 𝕂 n f) :
+  continuous (iterated_fderiv 𝕂 n f) :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F f,
@@ -278,8 +278,8 @@ begin
     exact IH (times_cont_diff_rec_succ.1 h).2 }
 end
 
-lemma times_cont_diff_rec.differentiable (h : times_cont_diff_rec k (n+1) f) :
-  differentiable k (iterated_fderiv k n f) :=
+lemma times_cont_diff_rec.differentiable (h : times_cont_diff_rec 𝕂 (n+1) f) :
+  differentiable 𝕂 (iterated_fderiv 𝕂 n f) :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F f,
@@ -292,24 +292,24 @@ end
 Auxiliary definition defining `C^n` functions on a set by induction over `n`.
 In applications, use `times_cont_diff_on` instead.
 -/
-def times_cont_diff_on_rec (k : Type w) [nondiscrete_normed_field k] :
-  Π (n : ℕ) {E : Type u} [gE : normed_group E] [@normed_space k E _ gE]
-    {F : Type u} [gF : normed_group F] [@normed_space k F _ gF] (f : E → F) (s : set E), Prop
+def times_cont_diff_on_rec (𝕂 : Type w) [nondiscrete_normed_field 𝕂] :
+  Π (n : ℕ) {E : Type u} [gE : normed_group E] [@normed_space 𝕂 E _ gE]
+    {F : Type u} [gF : normed_group F] [@normed_space 𝕂 F _ gF] (f : E → F) (s : set E), Prop
 | 0     E _ _ F _ _ f s := by { resetI, exact continuous_on f s }
 | (n+1) E _ _ F _ _ f s := by { resetI,
-                  exact differentiable_on k f s ∧ times_cont_diff_on_rec n (fderiv_within k f s) s}
+                  exact differentiable_on 𝕂 f s ∧ times_cont_diff_on_rec n (fderiv_within 𝕂 f s) s}
 
 @[simp] lemma times_cont_diff_on_rec_zero :
-  times_cont_diff_on_rec k 0 f s ↔ continuous_on f s :=
+  times_cont_diff_on_rec 𝕂 0 f s ↔ continuous_on f s :=
 by refl
 
 @[simp] lemma times_cont_diff_on_rec_succ :
-  times_cont_diff_on_rec k n.succ f s ↔
-  differentiable_on k f s ∧ times_cont_diff_on_rec k n (λx, fderiv_within k f s x) s :=
+  times_cont_diff_on_rec 𝕂 n.succ f s ↔
+  differentiable_on 𝕂 f s ∧ times_cont_diff_on_rec 𝕂 n (λx, fderiv_within 𝕂 f s x) s :=
 by refl
 
-lemma times_cont_diff_on_rec.of_succ (h : times_cont_diff_on_rec k n.succ f s) :
-  times_cont_diff_on_rec k n f s :=
+lemma times_cont_diff_on_rec.of_succ (h : times_cont_diff_on_rec 𝕂 n.succ f s) :
+  times_cont_diff_on_rec 𝕂 n f s :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F,
@@ -319,8 +319,8 @@ begin
 end
 
 lemma times_cont_diff_on_rec.continuous_on_iterated_fderiv_within
-  (h : times_cont_diff_on_rec k n f s) :
-  continuous_on (iterated_fderiv_within k n f s) s :=
+  (h : times_cont_diff_on_rec 𝕂 n f s) :
+  continuous_on (iterated_fderiv_within 𝕂 n f s) s :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F f,
@@ -329,8 +329,8 @@ begin
     exact IH (times_cont_diff_on_rec_succ.1 h).2 }
 end
 
-lemma times_cont_diff_on_rec.differentiable_on (h : times_cont_diff_on_rec k (n+1) f s) :
-  differentiable_on k (iterated_fderiv_within k n f s) s :=
+lemma times_cont_diff_on_rec.differentiable_on (h : times_cont_diff_on_rec 𝕂 (n+1) f s) :
+  differentiable_on 𝕂 (iterated_fderiv_within 𝕂 n f s) s :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F f,
@@ -340,7 +340,7 @@ begin
 end
 
 lemma times_cont_diff_on_rec_univ :
-  times_cont_diff_on_rec k n f univ ↔ times_cont_diff_rec k n f :=
+  times_cont_diff_on_rec 𝕂 n f univ ↔ times_cont_diff_rec 𝕂 n f :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F f,
@@ -352,14 +352,14 @@ end
 A function is `C^n` on a set, for `n : with_top ℕ`, if its derivatives of order at most `n`
 are all well defined and continuous.
 -/
-def times_cont_diff_on (k : Type w) [nondiscrete_normed_field k] (n : with_top ℕ)
-  {E F : Type u} [normed_group E] [normed_space k E]
-  [normed_group F] [normed_space k F] (f : E → F) (s : set E) :=
-(∀m:ℕ, (m : with_top ℕ) ≤ n → continuous_on (iterated_fderiv_within k m f s) s)
-∧ (∀m:ℕ, (m : with_top ℕ) < n → differentiable_on k (iterated_fderiv_within k m f s) s)
+def times_cont_diff_on (𝕂 : Type w) [nondiscrete_normed_field 𝕂] (n : with_top ℕ)
+  {E F : Type u} [normed_group E] [normed_space 𝕂 E]
+  [normed_group F] [normed_space 𝕂 F] (f : E → F) (s : set E) :=
+(∀m:ℕ, (m : with_top ℕ) ≤ n → continuous_on (iterated_fderiv_within 𝕂 m f s) s)
+∧ (∀m:ℕ, (m : with_top ℕ) < n → differentiable_on 𝕂 (iterated_fderiv_within 𝕂 m f s) s)
 
 @[simp] lemma times_cont_diff_on_zero :
-  times_cont_diff_on k 0 f s ↔ continuous_on f s :=
+  times_cont_diff_on 𝕂 0 f s ↔ continuous_on f s :=
 by simp [times_cont_diff_on]
 
 /--
@@ -367,7 +367,7 @@ The two definitions of `C^n` functions on domains, directly in terms of continui
 derivatives, or by induction, are equivalent.
 -/
 theorem times_cont_diff_on_iff_times_cont_diff_on_rec :
-  times_cont_diff_on k n f s ↔ times_cont_diff_on_rec k n f s :=
+  times_cont_diff_on 𝕂 n f s ↔ times_cont_diff_on_rec 𝕂 n f s :=
 begin
   tactic.unfreeze_local_instances,
   induction n with n IH generalizing F f,
@@ -409,25 +409,25 @@ end
 
 /- Next lemma is marked as a simp lemma as `C^(n+1)` functions appear mostly in inductions. -/
 @[simp] lemma times_cont_diff_on_succ :
-  times_cont_diff_on k n.succ f s ↔
-  differentiable_on k f s ∧ times_cont_diff_on k n (λx, fderiv_within k f s x) s :=
+  times_cont_diff_on 𝕂 n.succ f s ↔
+  differentiable_on 𝕂 f s ∧ times_cont_diff_on 𝕂 n (λx, fderiv_within 𝕂 f s x) s :=
 by simp [times_cont_diff_on_iff_times_cont_diff_on_rec]
 
 lemma times_cont_diff_on.of_le {m n : with_top ℕ}
- (h : times_cont_diff_on k n f s) (le : m ≤ n) : times_cont_diff_on k m f s :=
+ (h : times_cont_diff_on 𝕂 n f s) (le : m ≤ n) : times_cont_diff_on 𝕂 m f s :=
 ⟨λp hp, h.1 p (le_trans hp le), λp hp, h.2 p (lt_of_lt_of_le hp le)⟩
 
-lemma times_cont_diff_on.of_succ (h : times_cont_diff_on k n.succ f s) :
-  times_cont_diff_on k n f s :=
+lemma times_cont_diff_on.of_succ (h : times_cont_diff_on 𝕂 n.succ f s) :
+  times_cont_diff_on 𝕂 n f s :=
 h.of_le (with_top.coe_le_coe.2 (nat.le_succ n))
 
-lemma times_cont_diff_on.continuous_on {n : with_top ℕ} (h : times_cont_diff_on k n f s) :
+lemma times_cont_diff_on.continuous_on {n : with_top ℕ} (h : times_cont_diff_on 𝕂 n f s) :
   continuous_on f s :=
 h.1 0 (by simp)
 
 lemma times_cont_diff_on.continuous_on_fderiv_within
-  {n : with_top ℕ} (h : times_cont_diff_on k n f s) (hn : 1 ≤ n) :
-  continuous_on (fderiv_within k f s) s :=
+  {n : with_top ℕ} (h : times_cont_diff_on 𝕂 n f s) (hn : 1 ≤ n) :
+  continuous_on (fderiv_within 𝕂 f s) s :=
 h.1 1 hn
 
 set_option class.instance_max_depth 50
@@ -437,11 +437,11 @@ If a function is at least `C^1`, its bundled derivative (mapping `(x, v)` to `Df
 continuous.
 -/
 lemma times_cont_diff_on.continuous_on_fderiv_within_apply
-  {n : with_top ℕ} (h : times_cont_diff_on k n f s) (hn : 1 ≤ n) :
-  continuous_on (λp : E × E, (fderiv_within k f s p.1 : E → F) p.2) (set.prod s univ) :=
+  {n : with_top ℕ} (h : times_cont_diff_on 𝕂 n f s) (hn : 1 ≤ n) :
+  continuous_on (λp : E × E, (fderiv_within 𝕂 f s p.1 : E → F) p.2) (set.prod s univ) :=
 begin
-  have A : continuous (λq : (E →L[k] F) × E, q.1 q.2) := is_bounded_bilinear_map_apply.continuous,
-  have B : continuous_on (λp : E × E, (fderiv_within k f s p.1, p.2)) (set.prod s univ),
+  have A : continuous (λq : (E →L[𝕂] F) × E, q.1 q.2) := is_bounded_bilinear_map_apply.continuous,
+  have B : continuous_on (λp : E × E, (fderiv_within 𝕂 f s p.1, p.2)) (set.prod s univ),
   { apply continuous_on.prod _ continuous_snd.continuous_on,
     refine continuous_on.comp (h.continuous_on_fderiv_within hn) continuous_fst.continuous_on (λx hx, _),
     simp at hx,
@@ -451,7 +451,7 @@ begin
 end
 
 lemma times_cont_diff_on_top :
-  times_cont_diff_on k ⊤ f s ↔ (∀n:ℕ, times_cont_diff_on k n f s) :=
+  times_cont_diff_on 𝕂 ⊤ f s ↔ (∀n:ℕ, times_cont_diff_on 𝕂 n f s) :=
 begin
   split,
   { assume h n,
@@ -463,32 +463,32 @@ begin
 end
 
 lemma times_cont_diff_on_fderiv_within_nat {m n : ℕ}
-  (hf : times_cont_diff_on k n f s) (h : m + 1 ≤ n) :
-  times_cont_diff_on k m (λx, fderiv_within k f s x) s :=
+  (hf : times_cont_diff_on 𝕂 n f s) (h : m + 1 ≤ n) :
+  times_cont_diff_on 𝕂 m (λx, fderiv_within 𝕂 f s x) s :=
 begin
-  have : times_cont_diff_on k m.succ f s :=
+  have : times_cont_diff_on 𝕂 m.succ f s :=
     hf.of_le (with_top.coe_le_coe.2 h),
   exact (times_cont_diff_on_succ.1 this).2
 end
 
 lemma times_cont_diff_on_fderiv_within {m n : with_top ℕ}
-  (hf : times_cont_diff_on k n f s) (h : m + 1 ≤ n) :
-  times_cont_diff_on k m (λx, fderiv_within k f s x) s :=
+  (hf : times_cont_diff_on 𝕂 n f s) (h : m + 1 ≤ n) :
+  times_cont_diff_on 𝕂 m (λx, fderiv_within 𝕂 f s x) s :=
 begin
   cases m,
   { change ⊤ + 1 ≤ n at h,
     have : n = ⊤, by simpa using h,
     rw this at hf,
-    change times_cont_diff_on k ⊤ (λ (x : E), fderiv_within k f s x) s,
+    change times_cont_diff_on 𝕂 ⊤ (λ (x : E), fderiv_within 𝕂 f s x) s,
     rw times_cont_diff_on_top at ⊢ hf,
     exact λm, times_cont_diff_on_fderiv_within_nat (hf (m + 1)) (le_refl _) },
-  { have : times_cont_diff_on k (m + 1) f s := hf.of_le h,
+  { have : times_cont_diff_on 𝕂 (m + 1) f s := hf.of_le h,
     exact times_cont_diff_on_fderiv_within_nat this (le_refl _) }
 end
 
-lemma times_cont_diff_on.congr_mono {n : with_top ℕ} (H : times_cont_diff_on k n f s)
-  (hs : unique_diff_on k s₁) (h : ∀x ∈ s₁, f₁ x = f x) (h₁ : s₁ ⊆ s) :
-  times_cont_diff_on k n f₁ s₁ :=
+lemma times_cont_diff_on.congr_mono {n : with_top ℕ} (H : times_cont_diff_on 𝕂 n f s)
+  (hs : unique_diff_on 𝕂 s₁) (h : ∀x ∈ s₁, f₁ x = f x) (h₁ : s₁ ⊆ s) :
+  times_cont_diff_on 𝕂 n f₁ s₁ :=
 begin
   tactic.unfreeze_local_instances,
   induction n using with_top.nat_induction with n IH Itop generalizing F,
@@ -502,26 +502,26 @@ begin
     assume n, exact Itop n (H n) h }
 end
 
-lemma times_cont_diff_on.congr {n : with_top ℕ} {s : set E} (H : times_cont_diff_on k n f s)
-  (hs : unique_diff_on k s) (h : ∀x ∈ s, f₁ x = f x) :
-  times_cont_diff_on k n f₁ s :=
+lemma times_cont_diff_on.congr {n : with_top ℕ} {s : set E} (H : times_cont_diff_on 𝕂 n f s)
+  (hs : unique_diff_on 𝕂 s) (h : ∀x ∈ s, f₁ x = f x) :
+  times_cont_diff_on 𝕂 n f₁ s :=
 times_cont_diff_on.congr_mono H hs h (subset.refl _)
 
-lemma times_cont_diff_on.congr_mono' {n m : with_top ℕ} {s : set E} (H : times_cont_diff_on k n f s)
-  (hs : unique_diff_on k s₁) (h : ∀x ∈ s₁, f₁ x = f x) (h₁ : s₁ ⊆ s) (le : m ≤ n) :
-  times_cont_diff_on k m f₁ s₁ :=
+lemma times_cont_diff_on.congr_mono' {n m : with_top ℕ} {s : set E} (H : times_cont_diff_on 𝕂 n f s)
+  (hs : unique_diff_on 𝕂 s₁) (h : ∀x ∈ s₁, f₁ x = f x) (h₁ : s₁ ⊆ s) (le : m ≤ n) :
+  times_cont_diff_on 𝕂 m f₁ s₁ :=
 times_cont_diff_on.of_le (H.congr_mono hs h h₁) le
 
-lemma times_cont_diff_on.mono {n : with_top ℕ} {s t : set E} (h : times_cont_diff_on k n f t)
-  (hst : s ⊆ t) (hs : unique_diff_on k s) : times_cont_diff_on k n f s :=
+lemma times_cont_diff_on.mono {n : with_top ℕ} {s t : set E} (h : times_cont_diff_on 𝕂 n f t)
+  (hst : s ⊆ t) (hs : unique_diff_on 𝕂 s) : times_cont_diff_on 𝕂 n f s :=
 times_cont_diff_on.congr_mono h hs (λx hx, rfl) hst
 
 /--
 Being `C^n` is a local property.
 -/
 lemma times_cont_diff_on_of_locally_times_cont_diff_on {n : with_top ℕ} {s : set E}
-  (hs : unique_diff_on k s) (h : ∀x∈s, ∃u, is_open u ∧ x ∈ u ∧ times_cont_diff_on k n f (s ∩ u)) :
-  times_cont_diff_on k n f s :=
+  (hs : unique_diff_on 𝕂 s) (h : ∀x∈s, ∃u, is_open u ∧ x ∈ u ∧ times_cont_diff_on 𝕂 n f (s ∩ u)) :
+  times_cont_diff_on 𝕂 n f s :=
 begin
   split,
   { assume m hm,
@@ -544,69 +544,69 @@ end
 A function is `C^n`, for `n : with_top ℕ`, if its derivatives of order at most `n` are all well
 defined and continuous.
 -/
-def times_cont_diff (k : Type w) [nondiscrete_normed_field k] (n : with_top ℕ)
-  {E F : Type u} [normed_group E] [normed_space k E]
-  [normed_group F] [normed_space k F] (f : E → F) :=
-(∀m:ℕ, (m : with_top ℕ) ≤ n → continuous (iterated_fderiv k m f ))
-∧ (∀m:ℕ, (m : with_top ℕ) < n → differentiable k (iterated_fderiv k m f))
+def times_cont_diff (𝕂 : Type w) [nondiscrete_normed_field 𝕂] (n : with_top ℕ)
+  {E F : Type u} [normed_group E] [normed_space 𝕂 E]
+  [normed_group F] [normed_space 𝕂 F] (f : E → F) :=
+(∀m:ℕ, (m : with_top ℕ) ≤ n → continuous (iterated_fderiv 𝕂 m f ))
+∧ (∀m:ℕ, (m : with_top ℕ) < n → differentiable 𝕂 (iterated_fderiv 𝕂 m f))
 
 lemma times_cont_diff_on_univ {n : with_top ℕ} :
-  times_cont_diff_on k n f univ ↔ times_cont_diff k n f :=
+  times_cont_diff_on 𝕂 n f univ ↔ times_cont_diff 𝕂 n f :=
 by simp [times_cont_diff_on, times_cont_diff, iterated_fderiv_within_univ,
         continuous_iff_continuous_on_univ, differentiable_on_univ]
 
 @[simp] lemma times_cont_diff_zero :
-  times_cont_diff k 0 f ↔ continuous f :=
+  times_cont_diff 𝕂 0 f ↔ continuous f :=
 by simp [times_cont_diff]
 
 theorem times_cont_diff_iff_times_cont_diff_rec :
-  times_cont_diff k n f ↔ times_cont_diff_rec k n f :=
+  times_cont_diff 𝕂 n f ↔ times_cont_diff_rec 𝕂 n f :=
 by simp [times_cont_diff_on_univ.symm, times_cont_diff_on_rec_univ.symm,
          times_cont_diff_on_iff_times_cont_diff_on_rec]
 
 @[simp] lemma times_cont_diff_succ :
-  times_cont_diff k n.succ f ↔
-  differentiable k f ∧ times_cont_diff k n (λx, fderiv k f x) :=
+  times_cont_diff 𝕂 n.succ f ↔
+  differentiable 𝕂 f ∧ times_cont_diff 𝕂 n (λx, fderiv 𝕂 f x) :=
 by simp [times_cont_diff_iff_times_cont_diff_rec]
 
-lemma times_cont_diff.of_le {m n : with_top ℕ} (h : times_cont_diff k n f) (le : m ≤ n) :
-  times_cont_diff k m f :=
+lemma times_cont_diff.of_le {m n : with_top ℕ} (h : times_cont_diff 𝕂 n f) (le : m ≤ n) :
+  times_cont_diff 𝕂 m f :=
 ⟨λp hp, h.1 p (le_trans hp le), λp hp, h.2 p (lt_of_lt_of_le hp le)⟩
 
-lemma times_cont_diff.of_succ (h : times_cont_diff k n.succ f) : times_cont_diff k n f :=
+lemma times_cont_diff.of_succ (h : times_cont_diff 𝕂 n.succ f) : times_cont_diff 𝕂 n f :=
 h.of_le (with_top.coe_le_coe.2 (nat.le_succ n))
 
-lemma times_cont_diff.continuous {n : with_top ℕ} (h : times_cont_diff k n f) :
+lemma times_cont_diff.continuous {n : with_top ℕ} (h : times_cont_diff 𝕂 n f) :
   continuous f :=
 h.1 0 (by simp)
 
-lemma times_cont_diff.continuous_fderiv {n : with_top ℕ} (h : times_cont_diff k n f) (hn : 1 ≤ n) :
-  continuous (fderiv k f) :=
+lemma times_cont_diff.continuous_fderiv {n : with_top ℕ} (h : times_cont_diff 𝕂 n f) (hn : 1 ≤ n) :
+  continuous (fderiv 𝕂 f) :=
 h.1 1 hn
 
 lemma times_cont_diff.continuous_fderiv_apply
-  {n : with_top ℕ} (h : times_cont_diff k n f) (hn : 1 ≤ n) :
-  continuous (λp : E × E, (fderiv k f p.1 : E → F) p.2) :=
+  {n : with_top ℕ} (h : times_cont_diff 𝕂 n f) (hn : 1 ≤ n) :
+  continuous (λp : E × E, (fderiv 𝕂 f p.1 : E → F) p.2) :=
 begin
-  have A : continuous (λq : (E →L[k] F) × E, q.1 q.2) := is_bounded_bilinear_map_apply.continuous,
-  have B : continuous (λp : E × E, (fderiv k f p.1, p.2)),
+  have A : continuous (λq : (E →L[𝕂] F) × E, q.1 q.2) := is_bounded_bilinear_map_apply.continuous,
+  have B : continuous (λp : E × E, (fderiv 𝕂 f p.1, p.2)),
   { apply continuous.prod_mk _ continuous_snd,
     exact continuous.comp (h.continuous_fderiv hn) continuous_fst },
   exact A.comp B
 end
 
-lemma times_cont_diff_top : times_cont_diff k ⊤ f ↔ (∀n:ℕ, times_cont_diff k n f) :=
+lemma times_cont_diff_top : times_cont_diff 𝕂 ⊤ f ↔ (∀n:ℕ, times_cont_diff 𝕂 n f) :=
 by simp [times_cont_diff_on_univ.symm, times_cont_diff_on_rec_univ.symm,
         times_cont_diff_on_top]
 
 lemma times_cont_diff.times_cont_diff_on {n : with_top ℕ} {s : set E}
-  (h : times_cont_diff k n f) (hs : unique_diff_on k s) : times_cont_diff_on k n f s :=
+  (h : times_cont_diff 𝕂 n f) (hs : unique_diff_on 𝕂 s) : times_cont_diff_on 𝕂 n f s :=
 by { rw ← times_cont_diff_on_univ at h, apply times_cont_diff_on.mono h (subset_univ _) hs }
 
 /--
 Constants are C^∞.
 -/
-lemma times_cont_diff_const {n : with_top ℕ} {c : F} : times_cont_diff k n (λx : E, c) :=
+lemma times_cont_diff_const {n : with_top ℕ} {c : F} : times_cont_diff 𝕂 n (λx : E, c) :=
 begin
   tactic.unfreeze_local_instances,
   induction n using with_top.nat_induction with n IH Itop generalizing F,
@@ -622,8 +622,8 @@ end
 /--
 Linear functions are C^∞.
 -/
-lemma is_bounded_linear_map.times_cont_diff {n : with_top ℕ} (hf : is_bounded_linear_map k f) :
-  times_cont_diff k n f :=
+lemma is_bounded_linear_map.times_cont_diff {n : with_top ℕ} (hf : is_bounded_linear_map 𝕂 f) :
+  times_cont_diff 𝕂 n f :=
 begin
   induction n using with_top.nat_induction with n IH Itop,
   { rw times_cont_diff_zero,
@@ -637,26 +637,26 @@ end
 /--
 The first projection in a product is C^∞.
 -/
-lemma times_cont_diff_fst {n : with_top ℕ} : times_cont_diff k n (prod.fst : E × F → E) :=
+lemma times_cont_diff_fst {n : with_top ℕ} : times_cont_diff 𝕂 n (prod.fst : E × F → E) :=
 is_bounded_linear_map.times_cont_diff is_bounded_linear_map.fst
 
 /--
 The second projection in a product is C^∞.
 -/
-lemma times_cont_diff_snd {n : with_top ℕ} : times_cont_diff k n (prod.snd : E × F → F) :=
+lemma times_cont_diff_snd {n : with_top ℕ} : times_cont_diff 𝕂 n (prod.snd : E × F → F) :=
 is_bounded_linear_map.times_cont_diff is_bounded_linear_map.snd
 
 /--
 The identity is C^∞.
 -/
-lemma times_cont_diff_id {n : with_top ℕ} : times_cont_diff k n (id : E → E) :=
+lemma times_cont_diff_id {n : with_top ℕ} : times_cont_diff 𝕂 n (id : E → E) :=
 is_bounded_linear_map.id.times_cont_diff
 
 /--
 Bilinear functions are C^∞.
 -/
-lemma is_bounded_bilinear_map.times_cont_diff {n : with_top ℕ} (hb : is_bounded_bilinear_map k b) :
-  times_cont_diff k n b :=
+lemma is_bounded_bilinear_map.times_cont_diff {n : with_top ℕ} (hb : is_bounded_bilinear_map 𝕂 b) :
+  times_cont_diff 𝕂 n b :=
 begin
   induction n using with_top.nat_induction with n IH Itop,
   { rw times_cont_diff_zero,
@@ -671,8 +671,8 @@ end
 Composition by bounded linear maps preserves `C^n` functions on domains.
 -/
 lemma times_cont_diff_on.comp_is_bounded_linear {n : with_top ℕ} {s : set E} {f : E → F} {g : F → G}
-  (hf : times_cont_diff_on k n f s) (hg : is_bounded_linear_map k g) (hs : unique_diff_on k s) :
-  times_cont_diff_on k n (λx, g (f x)) s :=
+  (hf : times_cont_diff_on 𝕂 n f s) (hg : is_bounded_linear_map 𝕂 g) (hs : unique_diff_on 𝕂 s) :
+  times_cont_diff_on 𝕂 n (λx, g (f x)) s :=
 begin
   tactic.unfreeze_local_instances,
   induction n using with_top.nat_induction with n IH Itop generalizing F G,
@@ -681,8 +681,8 @@ begin
     apply continuous_on.comp this hf (subset_univ _) },
   { rw times_cont_diff_on_succ at hf ⊢,
     refine ⟨differentiable_on.comp hg.differentiable_on hf.1 (subset_univ _), _⟩,
-    let Φ : (E →L[k] F) → (E →L[k] G) := λu, continuous_linear_map.comp (hg.to_continuous_linear_map) u,
-    have : ∀x∈s, fderiv_within k (g ∘ f) s x = Φ (fderiv_within k f s x),
+    let Φ : (E →L[𝕂] F) → (E →L[𝕂] G) := λu, continuous_linear_map.comp (hg.to_continuous_linear_map) u,
+    have : ∀x∈s, fderiv_within 𝕂 (g ∘ f) s x = Φ (fderiv_within 𝕂 f s x),
     { assume x hx,
       rw [fderiv_within.comp x _ (hf.1 x hx) (subset_univ _) (hs x hx),
           fderiv_within_univ, hg.fderiv],
@@ -700,8 +700,8 @@ end
 Composition by bounded linear maps preserves `C^n` functions.
 -/
 lemma times_cont_diff.comp_is_bounded_linear {n : with_top ℕ} {f : E → F} {g : F → G}
-  (hf : times_cont_diff k n f) (hg : is_bounded_linear_map k g) :
-  times_cont_diff k n (λx, g (f x)) :=
+  (hf : times_cont_diff 𝕂 n f) (hg : is_bounded_linear_map 𝕂 g) :
+  times_cont_diff 𝕂 n (λx, g (f x)) :=
 times_cont_diff_on_univ.1 $ times_cont_diff_on.comp_is_bounded_linear (times_cont_diff_on_univ.2 hf)
   hg is_open_univ.unique_diff_on
 
@@ -709,8 +709,8 @@ times_cont_diff_on_univ.1 $ times_cont_diff_on.comp_is_bounded_linear (times_con
 The cartesian product of `C^n` functions on domains is `C^n`.
 -/
 lemma times_cont_diff_on.prod {n : with_top ℕ} {s : set E} {f : E → F} {g : E → G}
-  (hf : times_cont_diff_on k n f s) (hg : times_cont_diff_on k n g s) (hs : unique_diff_on k s) :
-  times_cont_diff_on k n (λx:E, (f x, g x)) s :=
+  (hf : times_cont_diff_on 𝕂 n f s) (hg : times_cont_diff_on 𝕂 n g s) (hs : unique_diff_on 𝕂 s) :
+  times_cont_diff_on 𝕂 n (λx:E, (f x, g x)) s :=
 begin
   tactic.unfreeze_local_instances,
   induction n using with_top.nat_induction with n IH Itop generalizing F G,
@@ -718,9 +718,9 @@ begin
     exact continuous_on.prod hf hg },
   { rw times_cont_diff_on_succ at hf hg ⊢,
     refine ⟨differentiable_on.prod hf.1 hg.1, _⟩,
-    let F₁ := λx : E, (fderiv_within k f s x, fderiv_within k g s x),
-    let Φ : ((E →L[k] F) × (E →L[k] G)) → (E →L[k] (F × G)) := λp, continuous_linear_map.prod p.1 p.2,
-    have : times_cont_diff_on k n (Φ ∘ F₁) s :=
+    let F₁ := λx : E, (fderiv_within 𝕂 f s x, fderiv_within 𝕂 g s x),
+    let Φ : ((E →L[𝕂] F) × (E →L[𝕂] G)) → (E →L[𝕂] (F × G)) := λp, continuous_linear_map.prod p.1 p.2,
+    have : times_cont_diff_on 𝕂 n (Φ ∘ F₁) s :=
       times_cont_diff_on.comp_is_bounded_linear (IH hf.2 hg.2) is_bounded_linear_map_prod_iso hs,
     apply times_cont_diff_on.congr_mono this hs (λx hx, _) (subset.refl _),
     apply differentiable_at.fderiv_within_prod (hf.1 x hx) (hg.1 x hx) (hs x hx) },
@@ -733,8 +733,8 @@ end
 The cartesian product of `C^n` functions is `C^n`.
 -/
 lemma times_cont_diff.prod {n : with_top ℕ} {f : E → F} {g : E → G}
-  (hf : times_cont_diff k n f) (hg : times_cont_diff k n g) :
-  times_cont_diff k n (λx:E, (f x, g x)) :=
+  (hf : times_cont_diff 𝕂 n f) (hg : times_cont_diff 𝕂 n g) :
+  times_cont_diff 𝕂 n (λx:E, (f x, g x)) :=
 times_cont_diff_on_univ.1 $ times_cont_diff_on.prod (times_cont_diff_on_univ.2 hf)
   (times_cont_diff_on_univ.2 hg) is_open_univ.unique_diff_on
 
@@ -742,8 +742,8 @@ times_cont_diff_on_univ.1 $ times_cont_diff_on.prod (times_cont_diff_on_univ.2 h
 The composition of `C^n` functions on domains is `C^n`.
 -/
 lemma times_cont_diff_on.comp {n : with_top ℕ} {s : set E} {t : set F} {g : F → G} {f : E → F}
-  (hg : times_cont_diff_on k n g t) (hf : times_cont_diff_on k n f s) (hs : unique_diff_on k s)
-  (st : f '' s ⊆ t) : times_cont_diff_on k n (g ∘ f) s :=
+  (hg : times_cont_diff_on 𝕂 n g t) (hf : times_cont_diff_on 𝕂 n f s) (hs : unique_diff_on 𝕂 s)
+  (st : f '' s ⊆ t) : times_cont_diff_on 𝕂 n (g ∘ f) s :=
 begin
   tactic.unfreeze_local_instances,
   induction n using with_top.nat_induction with n IH Itop generalizing E F G,
@@ -758,18 +758,18 @@ begin
     and the inductive assumption.
     -/
     refine ⟨differentiable_on.comp hg.1 hf.1 st, _⟩,
-    have : ∀x∈s, fderiv_within k (g ∘ f) s x =
-      continuous_linear_map.comp (fderiv_within k g t (f x)) (fderiv_within k f s x),
+    have : ∀x∈s, fderiv_within 𝕂 (g ∘ f) s x =
+      continuous_linear_map.comp (fderiv_within 𝕂 g t (f x)) (fderiv_within 𝕂 f s x),
     { assume x hx,
       apply fderiv_within.comp x _ (hf.1 x hx) st (hs x hx),
       exact hg.1 _ (st (mem_image_of_mem _ hx)) },
     apply times_cont_diff_on.congr _ hs this,
-    have A : times_cont_diff_on k n (λx, fderiv_within k g t (f x)) s :=
+    have A : times_cont_diff_on 𝕂 n (λx, fderiv_within 𝕂 g t (f x)) s :=
       IH hg.2 (times_cont_diff_on_succ.2 hf).of_succ hs st,
-    have B : times_cont_diff_on k n (λx, fderiv_within k f s x) s := hf.2,
-    have C : times_cont_diff_on k n (λx:E, (fderiv_within k f s x, fderiv_within k g t (f x))) s :=
+    have B : times_cont_diff_on 𝕂 n (λx, fderiv_within 𝕂 f s x) s := hf.2,
+    have C : times_cont_diff_on 𝕂 n (λx:E, (fderiv_within 𝕂 f s x, fderiv_within 𝕂 g t (f x))) s :=
       times_cont_diff_on.prod B A hs,
-    have D : times_cont_diff_on k n (λ(p : (E →L[k] F) × (F →L[k] G)), p.2.comp p.1) univ :=
+    have D : times_cont_diff_on 𝕂 n (λ(p : (E →L[𝕂] F) × (F →L[𝕂] G)), p.2.comp p.1) univ :=
       is_bounded_bilinear_map_comp.times_cont_diff.times_cont_diff_on is_open_univ.unique_diff_on,
     exact IH D C hs (subset_univ _) },
   { rw times_cont_diff_on_top at hf hg ⊢,
@@ -781,8 +781,8 @@ end
 The composition of `C^n` functions is `C^n`.
 -/
 lemma times_cont_diff.comp {n : with_top ℕ} {g : F → G} {f : E → F}
-  (hg : times_cont_diff k n g) (hf : times_cont_diff k n f) :
-  times_cont_diff k n (g ∘ f) :=
+  (hg : times_cont_diff 𝕂 n g) (hf : times_cont_diff 𝕂 n f) :
+  times_cont_diff 𝕂 n (g ∘ f) :=
 times_cont_diff_on_univ.1 $ times_cont_diff_on.comp (times_cont_diff_on_univ.2 hg)
   (times_cont_diff_on_univ.2 hf) is_open_univ.unique_diff_on (subset_univ _)
 
@@ -790,21 +790,21 @@ times_cont_diff_on_univ.1 $ times_cont_diff_on.comp (times_cont_diff_on_univ.2 h
 The bundled derivative of a `C^{n+1}` function is `C^n`.
 -/
 lemma times_cont_diff_on_fderiv_within_apply {m n : with_top  ℕ} {s : set E}
-  {f : E → F} (hf : times_cont_diff_on k n f s) (hs : unique_diff_on k s) (hmn : m + 1 ≤ n) :
-  times_cont_diff_on k m (λp : E × E, (fderiv_within k f s p.1 : E →L[k] F) p.2) (set.prod s (univ : set E)) :=
+  {f : E → F} (hf : times_cont_diff_on 𝕂 n f s) (hs : unique_diff_on 𝕂 s) (hmn : m + 1 ≤ n) :
+  times_cont_diff_on 𝕂 m (λp : E × E, (fderiv_within 𝕂 f s p.1 : E →L[𝕂] F) p.2) (set.prod s (univ : set E)) :=
 begin
-  have U : unique_diff_on k (set.prod s (univ : set E)) :=
+  have U : unique_diff_on 𝕂 (set.prod s (univ : set E)) :=
     hs.prod unique_diff_on_univ,
-  have A : times_cont_diff_on k m (λp : (E →L[k] F) × E, p.1 p.2) univ,
+  have A : times_cont_diff_on 𝕂 m (λp : (E →L[𝕂] F) × E, p.1 p.2) univ,
   { rw times_cont_diff_on_univ,
     apply is_bounded_bilinear_map.times_cont_diff,
     exact is_bounded_bilinear_map_apply },
-  have B : times_cont_diff_on k m
-    (λ (p : E × E), ((fderiv_within k f s p.fst), p.snd)) (set.prod s univ),
+  have B : times_cont_diff_on 𝕂 m
+    (λ (p : E × E), ((fderiv_within 𝕂 f s p.fst), p.snd)) (set.prod s univ),
   { apply times_cont_diff_on.prod _ _ U,
-    { have I : times_cont_diff_on k m (λ (x : E), fderiv_within k f s x) s :=
+    { have I : times_cont_diff_on 𝕂 m (λ (x : E), fderiv_within 𝕂 f s x) s :=
         times_cont_diff_on_fderiv_within hf hmn,
-      have J : times_cont_diff_on k m (λ (x : E × E), x.1) (set.prod s univ),
+      have J : times_cont_diff_on 𝕂 m (λ (x : E × E), x.1) (set.prod s univ),
       { apply times_cont_diff.times_cont_diff_on _ U,
         apply is_bounded_linear_map.times_cont_diff,
         apply is_bounded_linear_map.fst },
@@ -819,8 +819,8 @@ end
 The bundled derivative of a `C^{n+1}` function is `C^n`.
 -/
 lemma times_cont_diff.times_cont_diff_fderiv_apply {n m : with_top ℕ} {s : set E} {f : E → F}
-  (hf : times_cont_diff k n f) (hmn : m + 1 ≤ n) :
-  times_cont_diff k m (λp : E × E, (fderiv k f p.1 : E →L[k] F) p.2) :=
+  (hf : times_cont_diff 𝕂 n f) (hmn : m + 1 ≤ n) :
+  times_cont_diff 𝕂 m (λp : E × E, (fderiv 𝕂 f p.1 : E →L[𝕂] F) p.2) :=
 begin
   rw ← times_cont_diff_on_univ at ⊢ hf,
   rw [← fderiv_within_univ, ← univ_prod_univ],

--- a/src/analysis/normed_space/banach.lean
+++ b/src/analysis/normed_space/banach.lean
@@ -14,17 +14,17 @@ local attribute [instance] classical.prop_decidable
 
 open function metric set filter finset
 
-variables {𝕂 : Type*} [nondiscrete_normed_field 𝕂]
-{E : Type*} [normed_group E] [complete_space E] [normed_space 𝕂 E]
-{F : Type*} [normed_group F] [complete_space F] [normed_space 𝕂 F]
+variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
+{E : Type*} [normed_group E] [complete_space E] [normed_space 𝕜 E]
+{F : Type*} [normed_group F] [complete_space F] [normed_space 𝕜 F]
 {f : E → F}
-include 𝕂
+include 𝕜
 
 set_option class.instance_max_depth 70
 
 /-- The Banach open mapping theorem: if a bounded linear map between Banach spaces is onto, then
 any point has a preimage with controlled norm. -/
-theorem exists_preimage_norm_le (hf : is_bounded_linear_map 𝕂 f) (surj : surjective f) :
+theorem exists_preimage_norm_le (hf : is_bounded_linear_map 𝕜 f) (surj : surjective f) :
   ∃C, 0 < C ∧ ∀y, ∃x, f x = y ∧ ∥x∥ ≤ C * ∥y∥ :=
 begin
   have lin := hf.to_is_linear_map,
@@ -45,7 +45,7 @@ begin
     nonempty_interior_of_Union_of_closed (λn, is_closed_closure) A,
   have : ∃C, 0 ≤ C ∧ ∀y, ∃x, dist (f x) y ≤ (1/2) * ∥y∥ ∧ ∥x∥ ≤ C * ∥y∥,
   { rcases this with ⟨n, a, ε, ⟨εpos, H⟩⟩,
-    rcases exists_one_lt_norm 𝕂 with ⟨c, hc⟩,
+    rcases exists_one_lt_norm 𝕜 with ⟨c, hc⟩,
     refine ⟨(ε/2)⁻¹ * ∥c∥ * 2 * n, _, λy, _⟩,
     { refine mul_nonneg (mul_nonneg (mul_nonneg _ (norm_nonneg _)) (by norm_num)) _,
       refine inv_nonneg.2 (div_nonneg' (le_of_lt εpos) (by norm_num)),
@@ -93,7 +93,7 @@ begin
           ... = ∥y∥/2 : by { rw [inv_mul_cancel, one_mul],  simp [norm_eq_zero, hd] }
           ... = (1/2) * ∥y∥ : by ring,
         rw ← dist_eq_norm at J,
-        have 𝕂 : ∥d⁻¹ • x∥ ≤ (ε / 2)⁻¹ * ∥c∥ * 2 * ↑n * ∥y∥ := calc
+        have 𝕜 : ∥d⁻¹ • x∥ ≤ (ε / 2)⁻¹ * ∥c∥ * 2 * ↑n * ∥y∥ := calc
           ∥d⁻¹ • x∥ = ∥d∥⁻¹ * ∥x₁ - x₂∥ : by rw [norm_smul, norm_inv]
           ... ≤ ((ε / 2)⁻¹ * ∥c∥ * ∥y∥) * (n + n) : begin
               refine mul_le_mul dinv _ (norm_nonneg _) _,
@@ -102,7 +102,7 @@ begin
                 exact inv_nonneg.2 (le_of_lt (half_pos εpos)) }
             end
           ... = (ε / 2)⁻¹ * ∥c∥ * 2 * ↑n * ∥y∥ : by ring,
-        exact ⟨d⁻¹ • x, J, 𝕂⟩ } } },
+        exact ⟨d⁻¹ • x, J, 𝕜⟩ } } },
   rcases this with ⟨C, C0, hC⟩,
   /- Second step of the proof: starting from `y`, we want an exact preimage of `y`. Let `g y` be
   the approximate preimage of `y` given by the first step, and `h y = y - f(g y)` the part that
@@ -174,7 +174,7 @@ begin
 end
 
 /-- The Banach open mapping theorem: a surjective bounded linear map between Banach spaces is open. -/
-theorem open_mapping (hf : is_bounded_linear_map 𝕂 f) (surj : surjective f) : is_open_map f :=
+theorem open_mapping (hf : is_bounded_linear_map 𝕜 f) (surj : surjective f) : is_open_map f :=
 begin
   assume s hs,
   have lin := hf.to_is_linear_map,
@@ -198,8 +198,8 @@ begin
 end
 
 /-- If a bounded linear map is a bijection, then its inverse is also a bounded linear map. -/
-theorem linear_equiv.is_bounded_inv (e : linear_equiv 𝕂 E F) (h : is_bounded_linear_map 𝕂 e.to_fun) :
-  is_bounded_linear_map 𝕂 e.inv_fun :=
+theorem linear_equiv.is_bounded_inv (e : linear_equiv 𝕜 E F) (h : is_bounded_linear_map 𝕜 e.to_fun) :
+  is_bounded_linear_map 𝕜 e.inv_fun :=
 { bound := begin
     have : surjective e.to_fun := (equiv.bijective e.to_equiv).2,
     rcases exists_preimage_norm_le h this with ⟨M, Mpos, hM⟩,

--- a/src/analysis/normed_space/banach.lean
+++ b/src/analysis/normed_space/banach.lean
@@ -14,17 +14,17 @@ local attribute [instance] classical.prop_decidable
 
 open function metric set filter finset
 
-variables {k : Type*} [nondiscrete_normed_field k]
-{E : Type*} [normed_group E] [complete_space E] [normed_space k E]
-{F : Type*} [normed_group F] [complete_space F] [normed_space k F]
+variables {𝕂 : Type*} [nondiscrete_normed_field 𝕂]
+{E : Type*} [normed_group E] [complete_space E] [normed_space 𝕂 E]
+{F : Type*} [normed_group F] [complete_space F] [normed_space 𝕂 F]
 {f : E → F}
-include k
+include 𝕂
 
 set_option class.instance_max_depth 70
 
 /-- The Banach open mapping theorem: if a bounded linear map between Banach spaces is onto, then
 any point has a preimage with controlled norm. -/
-theorem exists_preimage_norm_le (hf : is_bounded_linear_map k f) (surj : surjective f) :
+theorem exists_preimage_norm_le (hf : is_bounded_linear_map 𝕂 f) (surj : surjective f) :
   ∃C, 0 < C ∧ ∀y, ∃x, f x = y ∧ ∥x∥ ≤ C * ∥y∥ :=
 begin
   have lin := hf.to_is_linear_map,
@@ -45,7 +45,7 @@ begin
     nonempty_interior_of_Union_of_closed (λn, is_closed_closure) A,
   have : ∃C, 0 ≤ C ∧ ∀y, ∃x, dist (f x) y ≤ (1/2) * ∥y∥ ∧ ∥x∥ ≤ C * ∥y∥,
   { rcases this with ⟨n, a, ε, ⟨εpos, H⟩⟩,
-    rcases exists_one_lt_norm k with ⟨c, hc⟩,
+    rcases exists_one_lt_norm 𝕂 with ⟨c, hc⟩,
     refine ⟨(ε/2)⁻¹ * ∥c∥ * 2 * n, _, λy, _⟩,
     { refine mul_nonneg (mul_nonneg (mul_nonneg _ (norm_nonneg _)) (by norm_num)) _,
       refine inv_nonneg.2 (div_nonneg' (le_of_lt εpos) (by norm_num)),
@@ -93,7 +93,7 @@ begin
           ... = ∥y∥/2 : by { rw [inv_mul_cancel, one_mul],  simp [norm_eq_zero, hd] }
           ... = (1/2) * ∥y∥ : by ring,
         rw ← dist_eq_norm at J,
-        have K : ∥d⁻¹ • x∥ ≤ (ε / 2)⁻¹ * ∥c∥ * 2 * ↑n * ∥y∥ := calc
+        have 𝕂 : ∥d⁻¹ • x∥ ≤ (ε / 2)⁻¹ * ∥c∥ * 2 * ↑n * ∥y∥ := calc
           ∥d⁻¹ • x∥ = ∥d∥⁻¹ * ∥x₁ - x₂∥ : by rw [norm_smul, norm_inv]
           ... ≤ ((ε / 2)⁻¹ * ∥c∥ * ∥y∥) * (n + n) : begin
               refine mul_le_mul dinv _ (norm_nonneg _) _,
@@ -102,7 +102,7 @@ begin
                 exact inv_nonneg.2 (le_of_lt (half_pos εpos)) }
             end
           ... = (ε / 2)⁻¹ * ∥c∥ * 2 * ↑n * ∥y∥ : by ring,
-        exact ⟨d⁻¹ • x, J, K⟩ } } },
+        exact ⟨d⁻¹ • x, J, 𝕂⟩ } } },
   rcases this with ⟨C, C0, hC⟩,
   /- Second step of the proof: starting from `y`, we want an exact preimage of `y`. Let `g y` be
   the approximate preimage of `y` given by the first step, and `h y = y - f(g y)` the part that
@@ -174,7 +174,7 @@ begin
 end
 
 /-- The Banach open mapping theorem: a surjective bounded linear map between Banach spaces is open. -/
-theorem open_mapping (hf : is_bounded_linear_map k f) (surj : surjective f) : is_open_map f :=
+theorem open_mapping (hf : is_bounded_linear_map 𝕂 f) (surj : surjective f) : is_open_map f :=
 begin
   assume s hs,
   have lin := hf.to_is_linear_map,
@@ -198,8 +198,8 @@ begin
 end
 
 /-- If a bounded linear map is a bijection, then its inverse is also a bounded linear map. -/
-theorem linear_equiv.is_bounded_inv (e : linear_equiv k E F) (h : is_bounded_linear_map k e.to_fun) :
-  is_bounded_linear_map k e.inv_fun :=
+theorem linear_equiv.is_bounded_inv (e : linear_equiv 𝕂 E F) (h : is_bounded_linear_map 𝕂 e.to_fun) :
+  is_bounded_linear_map 𝕂 e.inv_fun :=
 { bound := begin
     have : surjective e.to_fun := (equiv.bijective e.to_equiv).2,
     rcases exists_preimage_norm_le h this with ⟨M, Mpos, hM⟩,

--- a/src/analysis/normed_space/bounded_linear_maps.lean
+++ b/src/analysis/normed_space/bounded_linear_maps.lean
@@ -16,81 +16,81 @@ local notation f ` →_{`:50 a `} `:0 b := filter.tendsto f (nhds a) (nhds b)
 open filter (tendsto)
 open metric
 
-variables {k : Type*} [nondiscrete_normed_field k]
-variables {E : Type*} [normed_group E] [normed_space k E]
-variables {F : Type*} [normed_group F] [normed_space k F]
-variables {G : Type*} [normed_group G] [normed_space k G]
+variables {𝕂 : Type*} [nondiscrete_normed_field 𝕂]
+variables {E : Type*} [normed_group E] [normed_space 𝕂 E]
+variables {F : Type*} [normed_group F] [normed_space 𝕂 F]
+variables {G : Type*} [normed_group G] [normed_space 𝕂 G]
 
 set_option class.instance_max_depth 70
 
-structure is_bounded_linear_map (k : Type*) [normed_field k]
-  {E : Type*} [normed_group E] [normed_space k E]
-  {F : Type*} [normed_group F] [normed_space k F] (f : E → F)
-  extends is_linear_map k f : Prop :=
+structure is_bounded_linear_map (𝕂 : Type*) [normed_field 𝕂]
+  {E : Type*} [normed_group E] [normed_space 𝕂 E]
+  {F : Type*} [normed_group F] [normed_space 𝕂 F] (f : E → F)
+  extends is_linear_map 𝕂 f : Prop :=
 (bound : ∃ M > 0, ∀ x : E, ∥ f x ∥ ≤ M * ∥ x ∥)
 
 lemma is_linear_map.with_bound
-  {f : E → F} (hf : is_linear_map k f) (M : ℝ) (h : ∀ x : E, ∥ f x ∥ ≤ M * ∥ x ∥) :
-  is_bounded_linear_map k f :=
+  {f : E → F} (hf : is_linear_map 𝕂 f) (M : ℝ) (h : ∀ x : E, ∥ f x ∥ ≤ M * ∥ x ∥) :
+  is_bounded_linear_map 𝕂 f :=
 ⟨ hf, classical.by_cases
   (assume : M ≤ 0, ⟨1, zero_lt_one, assume x,
     le_trans (h x) $ mul_le_mul_of_nonneg_right (le_trans this zero_le_one) (norm_nonneg x)⟩)
   (assume : ¬ M ≤ 0, ⟨M, lt_of_not_ge this, h⟩)⟩
 
 /-- A continuous linear map satisfies `is_bounded_linear_map` -/
-lemma continuous_linear_map.is_bounded_linear_map (f : E →L[k] F) : is_bounded_linear_map k f :=
+lemma continuous_linear_map.is_bounded_linear_map (f : E →L[𝕂] F) : is_bounded_linear_map 𝕂 f :=
 { bound := f.bound,
   ..f.to_linear_map }
 
 namespace is_bounded_linear_map
 
-def to_linear_map (f : E → F) (h : is_bounded_linear_map k f) : E →ₗ[k] F :=
+def to_linear_map (f : E → F) (h : is_bounded_linear_map 𝕂 f) : E →ₗ[𝕂] F :=
 (is_linear_map.mk' _ h.to_is_linear_map)
 
 /-- Construct a continuous linear map from is_bounded_linear_map -/
-def to_continuous_linear_map {f : E → F} (hf : is_bounded_linear_map k f) : E →L[k] F :=
+def to_continuous_linear_map {f : E → F} (hf : is_bounded_linear_map 𝕂 f) : E →L[𝕂] F :=
 { cont := let ⟨C, Cpos, hC⟩ := hf.bound in linear_map.continuous_of_bound _ C hC,
   ..to_linear_map f hf}
 
-lemma zero : is_bounded_linear_map k (λ (x:E), (0:F)) :=
+lemma zero : is_bounded_linear_map 𝕂 (λ (x:E), (0:F)) :=
 (0 : E →ₗ F).is_linear.with_bound 0 $ by simp [le_refl]
 
-lemma id : is_bounded_linear_map k (λ (x:E), x) :=
+lemma id : is_bounded_linear_map 𝕂 (λ (x:E), x) :=
 linear_map.id.is_linear.with_bound 1 $ by simp [le_refl]
 
-lemma fst : is_bounded_linear_map k (λ x : E × F, x.1) :=
+lemma fst : is_bounded_linear_map 𝕂 (λ x : E × F, x.1) :=
 begin
-  refine (linear_map.fst k E F).is_linear.with_bound 1 (λx, _),
+  refine (linear_map.fst 𝕂 E F).is_linear.with_bound 1 (λx, _),
   rw one_mul,
   exact le_max_left _ _
 end
 
-lemma snd : is_bounded_linear_map k (λ x : E × F, x.2) :=
+lemma snd : is_bounded_linear_map 𝕂 (λ x : E × F, x.2) :=
 begin
-  refine (linear_map.snd k E F).is_linear.with_bound 1 (λx, _),
+  refine (linear_map.snd 𝕂 E F).is_linear.with_bound 1 (λx, _),
   rw one_mul,
   exact le_max_right _ _
 end
 
 variables { f g : E → F }
 
-lemma smul (c : k) (hf : is_bounded_linear_map k f) :
-  is_bounded_linear_map k (λ e, c • f e) :=
+lemma smul (c : 𝕂) (hf : is_bounded_linear_map 𝕂 f) :
+  is_bounded_linear_map 𝕂 (λ e, c • f e) :=
 let ⟨hlf, M, hMp, hM⟩ := hf in
 (c • hlf.mk' f).is_linear.with_bound (∥c∥ * M) $ assume x,
   calc ∥c • f x∥ = ∥c∥ * ∥f x∥ : norm_smul c (f x)
   ... ≤ ∥c∥ * (M * ∥x∥)        : mul_le_mul_of_nonneg_left (hM _) (norm_nonneg _)
   ... = (∥c∥ * M) * ∥x∥        : (mul_assoc _ _ _).symm
 
-lemma neg (hf : is_bounded_linear_map k f) :
-  is_bounded_linear_map k (λ e, -f e) :=
+lemma neg (hf : is_bounded_linear_map 𝕂 f) :
+  is_bounded_linear_map 𝕂 (λ e, -f e) :=
 begin
-  rw show (λ e, -f e) = (λ e, (-1 : k) • f e), { funext, simp },
+  rw show (λ e, -f e) = (λ e, (-1 : 𝕂) • f e), { funext, simp },
   exact smul (-1) hf
 end
 
-lemma add (hf : is_bounded_linear_map k f) (hg : is_bounded_linear_map k g) :
-  is_bounded_linear_map k (λ e, f e + g e) :=
+lemma add (hf : is_bounded_linear_map 𝕂 f) (hg : is_bounded_linear_map 𝕂 g) :
+  is_bounded_linear_map 𝕂 (λ e, f e + g e) :=
 let ⟨hlf, Mf, hMfp, hMf⟩ := hf in
 let ⟨hlg, Mg, hMgp, hMg⟩ := hg in
 (hlf.mk' _ + hlg.mk' _).is_linear.with_bound (Mf + Mg) $ assume x,
@@ -98,12 +98,12 @@ let ⟨hlg, Mg, hMgp, hMg⟩ := hg in
   ... ≤ Mf * ∥x∥ + Mg * ∥x∥        : add_le_add (hMf x) (hMg x)
   ... ≤ (Mf + Mg) * ∥x∥            : by rw add_mul
 
-lemma sub (hf : is_bounded_linear_map k f) (hg : is_bounded_linear_map k g) :
-  is_bounded_linear_map k (λ e, f e - g e) := add hf (neg hg)
+lemma sub (hf : is_bounded_linear_map 𝕂 f) (hg : is_bounded_linear_map 𝕂 g) :
+  is_bounded_linear_map 𝕂 (λ e, f e - g e) := add hf (neg hg)
 
 lemma comp {g : F → G}
-  (hg : is_bounded_linear_map k g) (hf : is_bounded_linear_map k f) :
-  is_bounded_linear_map k (g ∘ f) :=
+  (hg : is_bounded_linear_map 𝕂 g) (hf : is_bounded_linear_map 𝕂 f) :
+  is_bounded_linear_map 𝕂 (g ∘ f) :=
 let ⟨hlg, Mg, hMgp, hMg⟩ := hg in
 let ⟨hlf, Mf, hMfp, hMf⟩ := hf in
 ((hlg.mk' _).comp (hlf.mk' _)).is_linear.with_bound (Mg * Mf) $ assume x,
@@ -111,7 +111,7 @@ let ⟨hlf, Mf, hMfp, hMf⟩ := hf in
     ... ≤ Mg * (Mf * ∥x∥) : mul_le_mul_of_nonneg_left (hMf _) (le_of_lt hMgp)
     ... = Mg * Mf * ∥x∥   : (mul_assoc _ _ _).symm
 
-lemma tendsto (x : E) (hf : is_bounded_linear_map k f) : f →_{x} (f x) :=
+lemma tendsto (x : E) (hf : is_bounded_linear_map 𝕂 f) : f →_{x} (f x) :=
 let ⟨hf, M, hMp, hM⟩ := hf in
 tendsto_iff_norm_tendsto_zero.2 $
   squeeze_zero (assume e, norm_nonneg _)
@@ -121,26 +121,26 @@ tendsto_iff_norm_tendsto_zero.2 $
     (suffices (λ (e : E), M * ∥e - x∥) →_{x} (M * 0), by simpa,
       tendsto_mul tendsto_const_nhds (lim_norm _))
 
-lemma continuous (hf : is_bounded_linear_map k f) : continuous f :=
+lemma continuous (hf : is_bounded_linear_map 𝕂 f) : continuous f :=
 continuous_iff_continuous_at.2 $ λ _, hf.tendsto _
 
-lemma lim_zero_bounded_linear_map (hf : is_bounded_linear_map k f) :
+lemma lim_zero_bounded_linear_map (hf : is_bounded_linear_map 𝕂 f) :
   (f →_{0} 0) :=
 (hf.1.mk' _).map_zero ▸ continuous_iff_continuous_at.1 hf.continuous 0
 
 section
 open asymptotics filter
 
-theorem is_O_id {f : E → F} (h : is_bounded_linear_map k f) (l : filter E) :
+theorem is_O_id {f : E → F} (h : is_bounded_linear_map 𝕂 f) (l : filter E) :
   is_O f (λ x, x) l :=
 let ⟨M, hMp, hM⟩ := h.bound in
 ⟨M, hMp, mem_sets_of_superset univ_mem_sets (λ x _, hM x)⟩
 
-theorem is_O_comp {g : F → G} (hg : is_bounded_linear_map k g)
+theorem is_O_comp {g : F → G} (hg : is_bounded_linear_map 𝕂 g)
   {f : E → F} (l : filter E) : is_O (λ x', g (f x')) f l :=
 ((hg.is_O_id ⊤).comp _).mono (map_le_iff_le_comap.mp lattice.le_top)
 
-theorem is_O_sub {f : E → F} (h : is_bounded_linear_map k f)
+theorem is_O_sub {f : E → F} (h : is_bounded_linear_map 𝕂 f)
   (l : filter E) (x : E) : is_O (λ x', f (x' - x)) (λ x', x' - x) l :=
 is_O_comp h l
 
@@ -152,8 +152,8 @@ section
 set_option class.instance_max_depth 180
 
 lemma is_bounded_linear_map_prod_iso :
-  is_bounded_linear_map k (λ(p : (E →L[k] F) × (E →L[k] G)),
-                            (continuous_linear_map.prod p.1 p.2 : (E →L[k] (F × G)))) :=
+  is_bounded_linear_map 𝕂 (λ(p : (E →L[𝕂] F) × (E →L[𝕂] G)),
+                            (continuous_linear_map.prod p.1 p.2 : (E →L[𝕂] (F × G)))) :=
 begin
   refine is_linear_map.with_bound ⟨λu v, rfl, λc u, rfl⟩ 1 (λp, _),
   simp only [norm, one_mul],
@@ -168,8 +168,8 @@ begin
       mul_le_mul_of_nonneg_right (le_max_right _ _) (norm_nonneg _) }
 end
 
-lemma continuous_linear_map.is_bounded_linear_map_comp_left (g : continuous_linear_map k F G) :
-  is_bounded_linear_map k (λ(f : E →L[k] F), continuous_linear_map.comp g f) :=
+lemma continuous_linear_map.is_bounded_linear_map_comp_left (g : continuous_linear_map 𝕂 F G) :
+  is_bounded_linear_map 𝕂 (λ(f : E →L[𝕂] F), continuous_linear_map.comp g f) :=
 begin
   refine is_linear_map.with_bound ⟨λu v, _, λc u, _⟩
     (∥g∥) (λu, continuous_linear_map.op_norm_comp_le _ _),
@@ -183,8 +183,8 @@ begin
     rw [this, continuous_linear_map.map_smul] }
 end
 
-lemma continuous_linear_map.is_bounded_linear_map_comp_right (f : continuous_linear_map k E F) :
-  is_bounded_linear_map k (λ(g : F →L[k] G), continuous_linear_map.comp g f) :=
+lemma continuous_linear_map.is_bounded_linear_map_comp_right (f : continuous_linear_map 𝕂 E F) :
+  is_bounded_linear_map 𝕂 (λ(g : F →L[𝕂] G), continuous_linear_map.comp g f) :=
 begin
   refine is_linear_map.with_bound ⟨λu v, rfl, λc u, rfl⟩ (∥f∥) (λg, _),
   rw mul_comm,
@@ -195,32 +195,32 @@ end
 
 section bilinear_map
 
-variable (k)
+variable (𝕂)
 
 structure is_bounded_bilinear_map (f : E × F → G) : Prop :=
 (add_left   : ∀(x₁ x₂ : E) (y : F), f (x₁ + x₂, y) = f (x₁, y) + f (x₂, y))
-(smul_left  : ∀(c : k) (x : E) (y : F), f (c • x, y) = c • f (x,y))
+(smul_left  : ∀(c : 𝕂) (x : E) (y : F), f (c • x, y) = c • f (x,y))
 (add_right  : ∀(x : E) (y₁ y₂ : F), f (x, y₁ + y₂) = f (x, y₁) + f (x, y₂))
-(smul_right : ∀(c : k) (x : E) (y : F), f (x, c • y) = c • f (x,y))
+(smul_right : ∀(c : 𝕂) (x : E) (y : F), f (x, c • y) = c • f (x,y))
 (bound      : ∃C>0, ∀(x : E) (y : F), ∥f (x, y)∥ ≤ C * ∥x∥ * ∥y∥)
 
-variable {k}
+variable {𝕂}
 variable {f : E × F → G}
 
-lemma is_bounded_bilinear_map.map_sub_left (h : is_bounded_bilinear_map k f) {x y : E} {z : F} :
+lemma is_bounded_bilinear_map.map_sub_left (h : is_bounded_bilinear_map 𝕂 f) {x y : E} {z : F} :
   f (x - y, z) = f (x, z) -  f(y, z) :=
-calc f (x - y, z) = f (x + (-1 : k) • y, z) : by simp
-... = f (x, z) + (-1 : k) • f (y, z) : by simp only [h.add_left, h.smul_left]
+calc f (x - y, z) = f (x + (-1 : 𝕂) • y, z) : by simp
+... = f (x, z) + (-1 : 𝕂) • f (y, z) : by simp only [h.add_left, h.smul_left]
 ... = f (x, z) - f (y, z) : by simp
 
-lemma is_bounded_bilinear_map.map_sub_right (h : is_bounded_bilinear_map k f) {x : E} {y z : F} :
+lemma is_bounded_bilinear_map.map_sub_right (h : is_bounded_bilinear_map 𝕂 f) {x : E} {y z : F} :
   f (x, y - z) = f (x, y) - f (x, z) :=
-calc f (x, y - z) = f (x, y + (-1 : k) • z) : by simp
-... = f (x, y) + (-1 : k) • f (x, z) : by simp only [h.add_right, h.smul_right]
+calc f (x, y - z) = f (x, y + (-1 : 𝕂) • z) : by simp
+... = f (x, y) + (-1 : 𝕂) • f (x, z) : by simp only [h.add_right, h.smul_right]
 ... = f (x, y) - f (x, z) : by simp
 
 lemma is_bounded_bilinear_map_smul :
-  is_bounded_bilinear_map k (λ (p : k × E), p.1 • p.2) :=
+  is_bounded_bilinear_map 𝕂 (λ (p : 𝕂 × E), p.1 • p.2) :=
 { add_left   := add_smul,
   smul_left  := λc x y, by simp [smul_smul],
   add_right  := smul_add,
@@ -228,11 +228,11 @@ lemma is_bounded_bilinear_map_smul :
   bound      := ⟨1, zero_lt_one, λx y, by simp [norm_smul]⟩ }
 
 lemma is_bounded_bilinear_map_mul :
-  is_bounded_bilinear_map k (λ (p : k × k), p.1 * p.2) :=
+  is_bounded_bilinear_map 𝕂 (λ (p : 𝕂 × 𝕂), p.1 * p.2) :=
 is_bounded_bilinear_map_smul
 
 lemma is_bounded_bilinear_map_comp :
-  is_bounded_bilinear_map k (λ(p : (E →L[k] F) × (F →L[k] G)), p.2.comp p.1) :=
+  is_bounded_bilinear_map 𝕂 (λ(p : (E →L[𝕂] F) × (F →L[𝕂] G)), p.2.comp p.1) :=
 { add_left := λx₁ x₂ y, begin
       ext z,
       change y (x₁ z + x₂ z) = y (x₁ z) + y (x₂ z),
@@ -251,7 +251,7 @@ lemma is_bounded_bilinear_map_comp :
     ... = 1 * ∥x∥ * ∥ y∥ : by ring ⟩ }
 
 lemma is_bounded_bilinear_map_apply :
-  is_bounded_bilinear_map k (λp : (E →L[k] F) × E, p.1 p.2) :=
+  is_bounded_bilinear_map 𝕂 (λp : (E →L[𝕂] F) × E, p.1 p.2) :=
 { add_left   := by simp,
   smul_left  := by simp,
   add_right  := by simp,
@@ -264,8 +264,8 @@ We define this function here a bounded linear map from `E × F` to `G`. The fact
 is indeed the derivative of `f` is proved in `is_bounded_bilinear_map.has_fderiv_at` in
 `deriv.lean`-/
 
-def is_bounded_bilinear_map.linear_deriv (h : is_bounded_bilinear_map k f) (p : E × F) :
-  (E × F) →ₗ[k] G :=
+def is_bounded_bilinear_map.linear_deriv (h : is_bounded_bilinear_map 𝕂 f) (p : E × F) :
+  (E × F) →ₗ[𝕂] G :=
 { to_fun := λq, f (p.1, q.2) + f (q.1, p.2),
   add := λq₁ q₂, begin
     change f (p.1, q₁.2 + q₂.2) + f (q₁.1 + q₂.1, p.2) =
@@ -277,7 +277,7 @@ def is_bounded_bilinear_map.linear_deriv (h : is_bounded_bilinear_map k f) (p : 
     simp [h.smul_left, h.smul_right, smul_add]
   end }
 
-def is_bounded_bilinear_map.deriv (h : is_bounded_bilinear_map k f) (p : E × F) : (E × F) →L[k] G :=
+def is_bounded_bilinear_map.deriv (h : is_bounded_bilinear_map 𝕂 f) (p : E × F) : (E × F) →L[𝕂] G :=
 (h.linear_deriv p).with_bound $ begin
   rcases h.bound with ⟨C, Cpos, hC⟩,
   refine ⟨C * ∥p.1∥ + C * ∥p.2∥, λq, _⟩,
@@ -293,15 +293,15 @@ def is_bounded_bilinear_map.deriv (h : is_bounded_bilinear_map k f) (p : E × F)
   ... = (C * ∥p.1∥ + C * ∥p.2∥) * ∥q∥ : by ring
 end
 
-@[simp] lemma is_bounded_bilinear_map_deriv_coe (h : is_bounded_bilinear_map k f) (p q : E × F) :
+@[simp] lemma is_bounded_bilinear_map_deriv_coe (h : is_bounded_bilinear_map 𝕂 f) (p q : E × F) :
   h.deriv p q = f (p.1, q.2) + f (q.1, p.2) := rfl
 
 set_option class.instance_max_depth 95
 
 /-- Given a bounded bilinear map `f`, the map associating to a point `p` the derivative of `f` at
 `p` is itself a bounded linear map. -/
-lemma is_bounded_bilinear_map.is_bounded_linear_map_deriv (h : is_bounded_bilinear_map k f) :
-  is_bounded_linear_map k (λp : E × F, h.deriv p) :=
+lemma is_bounded_bilinear_map.is_bounded_linear_map_deriv (h : is_bounded_bilinear_map 𝕂 f) :
+  is_bounded_linear_map 𝕂 (λp : E × F, h.deriv p) :=
 begin
   rcases h.bound with ⟨C, Cpos, hC⟩,
   refine is_linear_map.with_bound ⟨λp₁ p₂, _, λc p, _⟩ (C + C) (λp, _),

--- a/src/analysis/normed_space/bounded_linear_maps.lean
+++ b/src/analysis/normed_space/bounded_linear_maps.lean
@@ -16,81 +16,81 @@ local notation f ` →_{`:50 a `} `:0 b := filter.tendsto f (nhds a) (nhds b)
 open filter (tendsto)
 open metric
 
-variables {𝕂 : Type*} [nondiscrete_normed_field 𝕂]
-variables {E : Type*} [normed_group E] [normed_space 𝕂 E]
-variables {F : Type*} [normed_group F] [normed_space 𝕂 F]
-variables {G : Type*} [normed_group G] [normed_space 𝕂 G]
+variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
+variables {E : Type*} [normed_group E] [normed_space 𝕜 E]
+variables {F : Type*} [normed_group F] [normed_space 𝕜 F]
+variables {G : Type*} [normed_group G] [normed_space 𝕜 G]
 
 set_option class.instance_max_depth 70
 
-structure is_bounded_linear_map (𝕂 : Type*) [normed_field 𝕂]
-  {E : Type*} [normed_group E] [normed_space 𝕂 E]
-  {F : Type*} [normed_group F] [normed_space 𝕂 F] (f : E → F)
-  extends is_linear_map 𝕂 f : Prop :=
+structure is_bounded_linear_map (𝕜 : Type*) [normed_field 𝕜]
+  {E : Type*} [normed_group E] [normed_space 𝕜 E]
+  {F : Type*} [normed_group F] [normed_space 𝕜 F] (f : E → F)
+  extends is_linear_map 𝕜 f : Prop :=
 (bound : ∃ M > 0, ∀ x : E, ∥ f x ∥ ≤ M * ∥ x ∥)
 
 lemma is_linear_map.with_bound
-  {f : E → F} (hf : is_linear_map 𝕂 f) (M : ℝ) (h : ∀ x : E, ∥ f x ∥ ≤ M * ∥ x ∥) :
-  is_bounded_linear_map 𝕂 f :=
+  {f : E → F} (hf : is_linear_map 𝕜 f) (M : ℝ) (h : ∀ x : E, ∥ f x ∥ ≤ M * ∥ x ∥) :
+  is_bounded_linear_map 𝕜 f :=
 ⟨ hf, classical.by_cases
   (assume : M ≤ 0, ⟨1, zero_lt_one, assume x,
     le_trans (h x) $ mul_le_mul_of_nonneg_right (le_trans this zero_le_one) (norm_nonneg x)⟩)
   (assume : ¬ M ≤ 0, ⟨M, lt_of_not_ge this, h⟩)⟩
 
 /-- A continuous linear map satisfies `is_bounded_linear_map` -/
-lemma continuous_linear_map.is_bounded_linear_map (f : E →L[𝕂] F) : is_bounded_linear_map 𝕂 f :=
+lemma continuous_linear_map.is_bounded_linear_map (f : E →L[𝕜] F) : is_bounded_linear_map 𝕜 f :=
 { bound := f.bound,
   ..f.to_linear_map }
 
 namespace is_bounded_linear_map
 
-def to_linear_map (f : E → F) (h : is_bounded_linear_map 𝕂 f) : E →ₗ[𝕂] F :=
+def to_linear_map (f : E → F) (h : is_bounded_linear_map 𝕜 f) : E →ₗ[𝕜] F :=
 (is_linear_map.mk' _ h.to_is_linear_map)
 
 /-- Construct a continuous linear map from is_bounded_linear_map -/
-def to_continuous_linear_map {f : E → F} (hf : is_bounded_linear_map 𝕂 f) : E →L[𝕂] F :=
+def to_continuous_linear_map {f : E → F} (hf : is_bounded_linear_map 𝕜 f) : E →L[𝕜] F :=
 { cont := let ⟨C, Cpos, hC⟩ := hf.bound in linear_map.continuous_of_bound _ C hC,
   ..to_linear_map f hf}
 
-lemma zero : is_bounded_linear_map 𝕂 (λ (x:E), (0:F)) :=
+lemma zero : is_bounded_linear_map 𝕜 (λ (x:E), (0:F)) :=
 (0 : E →ₗ F).is_linear.with_bound 0 $ by simp [le_refl]
 
-lemma id : is_bounded_linear_map 𝕂 (λ (x:E), x) :=
+lemma id : is_bounded_linear_map 𝕜 (λ (x:E), x) :=
 linear_map.id.is_linear.with_bound 1 $ by simp [le_refl]
 
-lemma fst : is_bounded_linear_map 𝕂 (λ x : E × F, x.1) :=
+lemma fst : is_bounded_linear_map 𝕜 (λ x : E × F, x.1) :=
 begin
-  refine (linear_map.fst 𝕂 E F).is_linear.with_bound 1 (λx, _),
+  refine (linear_map.fst 𝕜 E F).is_linear.with_bound 1 (λx, _),
   rw one_mul,
   exact le_max_left _ _
 end
 
-lemma snd : is_bounded_linear_map 𝕂 (λ x : E × F, x.2) :=
+lemma snd : is_bounded_linear_map 𝕜 (λ x : E × F, x.2) :=
 begin
-  refine (linear_map.snd 𝕂 E F).is_linear.with_bound 1 (λx, _),
+  refine (linear_map.snd 𝕜 E F).is_linear.with_bound 1 (λx, _),
   rw one_mul,
   exact le_max_right _ _
 end
 
 variables { f g : E → F }
 
-lemma smul (c : 𝕂) (hf : is_bounded_linear_map 𝕂 f) :
-  is_bounded_linear_map 𝕂 (λ e, c • f e) :=
+lemma smul (c : 𝕜) (hf : is_bounded_linear_map 𝕜 f) :
+  is_bounded_linear_map 𝕜 (λ e, c • f e) :=
 let ⟨hlf, M, hMp, hM⟩ := hf in
 (c • hlf.mk' f).is_linear.with_bound (∥c∥ * M) $ assume x,
   calc ∥c • f x∥ = ∥c∥ * ∥f x∥ : norm_smul c (f x)
   ... ≤ ∥c∥ * (M * ∥x∥)        : mul_le_mul_of_nonneg_left (hM _) (norm_nonneg _)
   ... = (∥c∥ * M) * ∥x∥        : (mul_assoc _ _ _).symm
 
-lemma neg (hf : is_bounded_linear_map 𝕂 f) :
-  is_bounded_linear_map 𝕂 (λ e, -f e) :=
+lemma neg (hf : is_bounded_linear_map 𝕜 f) :
+  is_bounded_linear_map 𝕜 (λ e, -f e) :=
 begin
-  rw show (λ e, -f e) = (λ e, (-1 : 𝕂) • f e), { funext, simp },
+  rw show (λ e, -f e) = (λ e, (-1 : 𝕜) • f e), { funext, simp },
   exact smul (-1) hf
 end
 
-lemma add (hf : is_bounded_linear_map 𝕂 f) (hg : is_bounded_linear_map 𝕂 g) :
-  is_bounded_linear_map 𝕂 (λ e, f e + g e) :=
+lemma add (hf : is_bounded_linear_map 𝕜 f) (hg : is_bounded_linear_map 𝕜 g) :
+  is_bounded_linear_map 𝕜 (λ e, f e + g e) :=
 let ⟨hlf, Mf, hMfp, hMf⟩ := hf in
 let ⟨hlg, Mg, hMgp, hMg⟩ := hg in
 (hlf.mk' _ + hlg.mk' _).is_linear.with_bound (Mf + Mg) $ assume x,
@@ -98,12 +98,12 @@ let ⟨hlg, Mg, hMgp, hMg⟩ := hg in
   ... ≤ Mf * ∥x∥ + Mg * ∥x∥        : add_le_add (hMf x) (hMg x)
   ... ≤ (Mf + Mg) * ∥x∥            : by rw add_mul
 
-lemma sub (hf : is_bounded_linear_map 𝕂 f) (hg : is_bounded_linear_map 𝕂 g) :
-  is_bounded_linear_map 𝕂 (λ e, f e - g e) := add hf (neg hg)
+lemma sub (hf : is_bounded_linear_map 𝕜 f) (hg : is_bounded_linear_map 𝕜 g) :
+  is_bounded_linear_map 𝕜 (λ e, f e - g e) := add hf (neg hg)
 
 lemma comp {g : F → G}
-  (hg : is_bounded_linear_map 𝕂 g) (hf : is_bounded_linear_map 𝕂 f) :
-  is_bounded_linear_map 𝕂 (g ∘ f) :=
+  (hg : is_bounded_linear_map 𝕜 g) (hf : is_bounded_linear_map 𝕜 f) :
+  is_bounded_linear_map 𝕜 (g ∘ f) :=
 let ⟨hlg, Mg, hMgp, hMg⟩ := hg in
 let ⟨hlf, Mf, hMfp, hMf⟩ := hf in
 ((hlg.mk' _).comp (hlf.mk' _)).is_linear.with_bound (Mg * Mf) $ assume x,
@@ -111,7 +111,7 @@ let ⟨hlf, Mf, hMfp, hMf⟩ := hf in
     ... ≤ Mg * (Mf * ∥x∥) : mul_le_mul_of_nonneg_left (hMf _) (le_of_lt hMgp)
     ... = Mg * Mf * ∥x∥   : (mul_assoc _ _ _).symm
 
-lemma tendsto (x : E) (hf : is_bounded_linear_map 𝕂 f) : f →_{x} (f x) :=
+lemma tendsto (x : E) (hf : is_bounded_linear_map 𝕜 f) : f →_{x} (f x) :=
 let ⟨hf, M, hMp, hM⟩ := hf in
 tendsto_iff_norm_tendsto_zero.2 $
   squeeze_zero (assume e, norm_nonneg _)
@@ -121,26 +121,26 @@ tendsto_iff_norm_tendsto_zero.2 $
     (suffices (λ (e : E), M * ∥e - x∥) →_{x} (M * 0), by simpa,
       tendsto_mul tendsto_const_nhds (lim_norm _))
 
-lemma continuous (hf : is_bounded_linear_map 𝕂 f) : continuous f :=
+lemma continuous (hf : is_bounded_linear_map 𝕜 f) : continuous f :=
 continuous_iff_continuous_at.2 $ λ _, hf.tendsto _
 
-lemma lim_zero_bounded_linear_map (hf : is_bounded_linear_map 𝕂 f) :
+lemma lim_zero_bounded_linear_map (hf : is_bounded_linear_map 𝕜 f) :
   (f →_{0} 0) :=
 (hf.1.mk' _).map_zero ▸ continuous_iff_continuous_at.1 hf.continuous 0
 
 section
 open asymptotics filter
 
-theorem is_O_id {f : E → F} (h : is_bounded_linear_map 𝕂 f) (l : filter E) :
+theorem is_O_id {f : E → F} (h : is_bounded_linear_map 𝕜 f) (l : filter E) :
   is_O f (λ x, x) l :=
 let ⟨M, hMp, hM⟩ := h.bound in
 ⟨M, hMp, mem_sets_of_superset univ_mem_sets (λ x _, hM x)⟩
 
-theorem is_O_comp {g : F → G} (hg : is_bounded_linear_map 𝕂 g)
+theorem is_O_comp {g : F → G} (hg : is_bounded_linear_map 𝕜 g)
   {f : E → F} (l : filter E) : is_O (λ x', g (f x')) f l :=
 ((hg.is_O_id ⊤).comp _).mono (map_le_iff_le_comap.mp lattice.le_top)
 
-theorem is_O_sub {f : E → F} (h : is_bounded_linear_map 𝕂 f)
+theorem is_O_sub {f : E → F} (h : is_bounded_linear_map 𝕜 f)
   (l : filter E) (x : E) : is_O (λ x', f (x' - x)) (λ x', x' - x) l :=
 is_O_comp h l
 
@@ -152,8 +152,8 @@ section
 set_option class.instance_max_depth 180
 
 lemma is_bounded_linear_map_prod_iso :
-  is_bounded_linear_map 𝕂 (λ(p : (E →L[𝕂] F) × (E →L[𝕂] G)),
-                            (continuous_linear_map.prod p.1 p.2 : (E →L[𝕂] (F × G)))) :=
+  is_bounded_linear_map 𝕜 (λ(p : (E →L[𝕜] F) × (E →L[𝕜] G)),
+                            (continuous_linear_map.prod p.1 p.2 : (E →L[𝕜] (F × G)))) :=
 begin
   refine is_linear_map.with_bound ⟨λu v, rfl, λc u, rfl⟩ 1 (λp, _),
   simp only [norm, one_mul],
@@ -168,8 +168,8 @@ begin
       mul_le_mul_of_nonneg_right (le_max_right _ _) (norm_nonneg _) }
 end
 
-lemma continuous_linear_map.is_bounded_linear_map_comp_left (g : continuous_linear_map 𝕂 F G) :
-  is_bounded_linear_map 𝕂 (λ(f : E →L[𝕂] F), continuous_linear_map.comp g f) :=
+lemma continuous_linear_map.is_bounded_linear_map_comp_left (g : continuous_linear_map 𝕜 F G) :
+  is_bounded_linear_map 𝕜 (λ(f : E →L[𝕜] F), continuous_linear_map.comp g f) :=
 begin
   refine is_linear_map.with_bound ⟨λu v, _, λc u, _⟩
     (∥g∥) (λu, continuous_linear_map.op_norm_comp_le _ _),
@@ -183,8 +183,8 @@ begin
     rw [this, continuous_linear_map.map_smul] }
 end
 
-lemma continuous_linear_map.is_bounded_linear_map_comp_right (f : continuous_linear_map 𝕂 E F) :
-  is_bounded_linear_map 𝕂 (λ(g : F →L[𝕂] G), continuous_linear_map.comp g f) :=
+lemma continuous_linear_map.is_bounded_linear_map_comp_right (f : continuous_linear_map 𝕜 E F) :
+  is_bounded_linear_map 𝕜 (λ(g : F →L[𝕜] G), continuous_linear_map.comp g f) :=
 begin
   refine is_linear_map.with_bound ⟨λu v, rfl, λc u, rfl⟩ (∥f∥) (λg, _),
   rw mul_comm,
@@ -195,32 +195,32 @@ end
 
 section bilinear_map
 
-variable (𝕂)
+variable (𝕜)
 
 structure is_bounded_bilinear_map (f : E × F → G) : Prop :=
 (add_left   : ∀(x₁ x₂ : E) (y : F), f (x₁ + x₂, y) = f (x₁, y) + f (x₂, y))
-(smul_left  : ∀(c : 𝕂) (x : E) (y : F), f (c • x, y) = c • f (x,y))
+(smul_left  : ∀(c : 𝕜) (x : E) (y : F), f (c • x, y) = c • f (x,y))
 (add_right  : ∀(x : E) (y₁ y₂ : F), f (x, y₁ + y₂) = f (x, y₁) + f (x, y₂))
-(smul_right : ∀(c : 𝕂) (x : E) (y : F), f (x, c • y) = c • f (x,y))
+(smul_right : ∀(c : 𝕜) (x : E) (y : F), f (x, c • y) = c • f (x,y))
 (bound      : ∃C>0, ∀(x : E) (y : F), ∥f (x, y)∥ ≤ C * ∥x∥ * ∥y∥)
 
-variable {𝕂}
+variable {𝕜}
 variable {f : E × F → G}
 
-lemma is_bounded_bilinear_map.map_sub_left (h : is_bounded_bilinear_map 𝕂 f) {x y : E} {z : F} :
+lemma is_bounded_bilinear_map.map_sub_left (h : is_bounded_bilinear_map 𝕜 f) {x y : E} {z : F} :
   f (x - y, z) = f (x, z) -  f(y, z) :=
-calc f (x - y, z) = f (x + (-1 : 𝕂) • y, z) : by simp
-... = f (x, z) + (-1 : 𝕂) • f (y, z) : by simp only [h.add_left, h.smul_left]
+calc f (x - y, z) = f (x + (-1 : 𝕜) • y, z) : by simp
+... = f (x, z) + (-1 : 𝕜) • f (y, z) : by simp only [h.add_left, h.smul_left]
 ... = f (x, z) - f (y, z) : by simp
 
-lemma is_bounded_bilinear_map.map_sub_right (h : is_bounded_bilinear_map 𝕂 f) {x : E} {y z : F} :
+lemma is_bounded_bilinear_map.map_sub_right (h : is_bounded_bilinear_map 𝕜 f) {x : E} {y z : F} :
   f (x, y - z) = f (x, y) - f (x, z) :=
-calc f (x, y - z) = f (x, y + (-1 : 𝕂) • z) : by simp
-... = f (x, y) + (-1 : 𝕂) • f (x, z) : by simp only [h.add_right, h.smul_right]
+calc f (x, y - z) = f (x, y + (-1 : 𝕜) • z) : by simp
+... = f (x, y) + (-1 : 𝕜) • f (x, z) : by simp only [h.add_right, h.smul_right]
 ... = f (x, y) - f (x, z) : by simp
 
 lemma is_bounded_bilinear_map_smul :
-  is_bounded_bilinear_map 𝕂 (λ (p : 𝕂 × E), p.1 • p.2) :=
+  is_bounded_bilinear_map 𝕜 (λ (p : 𝕜 × E), p.1 • p.2) :=
 { add_left   := add_smul,
   smul_left  := λc x y, by simp [smul_smul],
   add_right  := smul_add,
@@ -228,11 +228,11 @@ lemma is_bounded_bilinear_map_smul :
   bound      := ⟨1, zero_lt_one, λx y, by simp [norm_smul]⟩ }
 
 lemma is_bounded_bilinear_map_mul :
-  is_bounded_bilinear_map 𝕂 (λ (p : 𝕂 × 𝕂), p.1 * p.2) :=
+  is_bounded_bilinear_map 𝕜 (λ (p : 𝕜 × 𝕜), p.1 * p.2) :=
 is_bounded_bilinear_map_smul
 
 lemma is_bounded_bilinear_map_comp :
-  is_bounded_bilinear_map 𝕂 (λ(p : (E →L[𝕂] F) × (F →L[𝕂] G)), p.2.comp p.1) :=
+  is_bounded_bilinear_map 𝕜 (λ(p : (E →L[𝕜] F) × (F →L[𝕜] G)), p.2.comp p.1) :=
 { add_left := λx₁ x₂ y, begin
       ext z,
       change y (x₁ z + x₂ z) = y (x₁ z) + y (x₂ z),
@@ -251,7 +251,7 @@ lemma is_bounded_bilinear_map_comp :
     ... = 1 * ∥x∥ * ∥ y∥ : by ring ⟩ }
 
 lemma is_bounded_bilinear_map_apply :
-  is_bounded_bilinear_map 𝕂 (λp : (E →L[𝕂] F) × E, p.1 p.2) :=
+  is_bounded_bilinear_map 𝕜 (λp : (E →L[𝕜] F) × E, p.1 p.2) :=
 { add_left   := by simp,
   smul_left  := by simp,
   add_right  := by simp,
@@ -264,8 +264,8 @@ We define this function here a bounded linear map from `E × F` to `G`. The fact
 is indeed the derivative of `f` is proved in `is_bounded_bilinear_map.has_fderiv_at` in
 `deriv.lean`-/
 
-def is_bounded_bilinear_map.linear_deriv (h : is_bounded_bilinear_map 𝕂 f) (p : E × F) :
-  (E × F) →ₗ[𝕂] G :=
+def is_bounded_bilinear_map.linear_deriv (h : is_bounded_bilinear_map 𝕜 f) (p : E × F) :
+  (E × F) →ₗ[𝕜] G :=
 { to_fun := λq, f (p.1, q.2) + f (q.1, p.2),
   add := λq₁ q₂, begin
     change f (p.1, q₁.2 + q₂.2) + f (q₁.1 + q₂.1, p.2) =
@@ -277,7 +277,7 @@ def is_bounded_bilinear_map.linear_deriv (h : is_bounded_bilinear_map 𝕂 f) (p
     simp [h.smul_left, h.smul_right, smul_add]
   end }
 
-def is_bounded_bilinear_map.deriv (h : is_bounded_bilinear_map 𝕂 f) (p : E × F) : (E × F) →L[𝕂] G :=
+def is_bounded_bilinear_map.deriv (h : is_bounded_bilinear_map 𝕜 f) (p : E × F) : (E × F) →L[𝕜] G :=
 (h.linear_deriv p).with_bound $ begin
   rcases h.bound with ⟨C, Cpos, hC⟩,
   refine ⟨C * ∥p.1∥ + C * ∥p.2∥, λq, _⟩,
@@ -293,15 +293,15 @@ def is_bounded_bilinear_map.deriv (h : is_bounded_bilinear_map 𝕂 f) (p : E ×
   ... = (C * ∥p.1∥ + C * ∥p.2∥) * ∥q∥ : by ring
 end
 
-@[simp] lemma is_bounded_bilinear_map_deriv_coe (h : is_bounded_bilinear_map 𝕂 f) (p q : E × F) :
+@[simp] lemma is_bounded_bilinear_map_deriv_coe (h : is_bounded_bilinear_map 𝕜 f) (p q : E × F) :
   h.deriv p q = f (p.1, q.2) + f (q.1, p.2) := rfl
 
 set_option class.instance_max_depth 95
 
 /-- Given a bounded bilinear map `f`, the map associating to a point `p` the derivative of `f` at
 `p` is itself a bounded linear map. -/
-lemma is_bounded_bilinear_map.is_bounded_linear_map_deriv (h : is_bounded_bilinear_map 𝕂 f) :
-  is_bounded_linear_map 𝕂 (λp : E × F, h.deriv p) :=
+lemma is_bounded_bilinear_map.is_bounded_linear_map_deriv (h : is_bounded_bilinear_map 𝕜 f) :
+  is_bounded_linear_map 𝕜 (λp : E × F, h.deriv p) :=
 begin
   rcases h.bound with ⟨C, Cpos, hC⟩,
   refine is_linear_map.with_bound ⟨λp₁ p₂, _, λc p, _⟩ (C + C) (λp, _),

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -16,13 +16,13 @@ local attribute [instance] classical.prop_decidable
 
 set_option class.instance_max_depth 70
 
-variables {k : Type*} {E : Type*} {F : Type*} {G : Type*}
-[nondiscrete_normed_field k]
-[normed_group E] [normed_space k E]
-[normed_group F] [normed_space k F]
-[normed_group G] [normed_space k G]
-(c : k) (f g : E →L[k] F) (h : F →L[k] G) (x y z : E)
-include k
+variables {𝕂 : Type*} {E : Type*} {F : Type*} {G : Type*}
+[nondiscrete_normed_field 𝕂]
+[normed_group E] [normed_space 𝕂 E]
+[normed_group F] [normed_space 𝕂 F]
+[normed_group G] [normed_space 𝕂 G]
+(c : 𝕂) (f g : E →L[𝕂] F) (h : F →L[𝕂] G) (x y z : E)
+include 𝕂
 
 open metric continuous_linear_map
 
@@ -32,7 +32,7 @@ lemma exists_pos_bound_of_bound {f : E → F} (M : ℝ) (h : ∀x, ∥f x∥ ≤
   ∥f x∥ ≤ M * ∥x∥ : h x
   ... ≤ max M 1 * ∥x∥ : mul_le_mul_of_nonneg_right (le_max_left _ _) (norm_nonneg _) ⟩
 
-lemma linear_map.continuous_of_bound (f : E →ₗ[k] F) (C : ℝ) (h : ∀x, ∥f x∥ ≤ C * ∥x∥) :
+lemma linear_map.continuous_of_bound (f : E →ₗ[𝕂] F) (C : ℝ) (h : ∀x, ∥f x∥ ≤ C * ∥x∥) :
   continuous f :=
 begin
   have : ∀ (x y : E), dist (f x) (f y) ≤ C * dist x y := λx y, calc
@@ -43,13 +43,13 @@ begin
   exact continuous_of_lipschitz this
 end
 
-def linear_map.with_bound (f : E →ₗ[k] F) (h : ∃C : ℝ, ∀x, ∥f x∥ ≤ C * ∥x∥) : E →L[k] F :=
+def linear_map.with_bound (f : E →ₗ[𝕂] F) (h : ∃C : ℝ, ∀x, ∥f x∥ ≤ C * ∥x∥) : E →L[𝕂] F :=
 ⟨f, let ⟨C, hC⟩ := h in linear_map.continuous_of_bound f C hC⟩
 
-@[simp, elim_cast] lemma linear_map_with_bound_coe (f : E →ₗ[k] F) (h : ∃C : ℝ, ∀x, ∥f x∥ ≤ C * ∥x∥) :
-  ((f.with_bound h) : E →ₗ[k] F) = f := rfl
+@[simp, elim_cast] lemma linear_map_with_bound_coe (f : E →ₗ[𝕂] F) (h : ∃C : ℝ, ∀x, ∥f x∥ ≤ C * ∥x∥) :
+  ((f.with_bound h) : E →ₗ[𝕂] F) = f := rfl
 
-@[simp] lemma linear_map_with_bound_apply (f : E →ₗ[k] F) (h : ∃C : ℝ, ∀x, ∥f x∥ ≤ C * ∥x∥) (x : E) :
+@[simp] lemma linear_map_with_bound_apply (f : E →ₗ[𝕂] F) (h : ∃C : ℝ, ∀x, ∥f x∥ ≤ C * ∥x∥) (x : E) :
   f.with_bound h x = f x := rfl
 
 namespace continuous_linear_map
@@ -71,7 +71,7 @@ begin
       rw [dist_eq_norm, sub_zero],
       exact lt_of_le_of_lt ha (half_lt_self ε_pos) },
     simpa using this },
-  rcases exists_one_lt_norm k with ⟨c, hc⟩,
+  rcases exists_one_lt_norm 𝕂 with ⟨c, hc⟩,
   refine ⟨δ⁻¹ * ∥c∥, mul_pos (inv_pos δ_pos) (lt_trans zero_lt_one hc), (λx, _)⟩,
   by_cases h : x = 0,
   { simp only [h, norm_zero, mul_zero, continuous_linear_map.map_zero], },
@@ -92,11 +92,11 @@ theorem is_O_id (l : filter E) : is_O f (λ x, x) l :=
 let ⟨M, hMp, hM⟩ := f.bound in
 ⟨M, hMp, mem_sets_of_superset univ_mem_sets (λ x _, hM x)⟩
 
-theorem is_O_comp (g : F →L[k] G) (f : E → F) (l : filter E) :
+theorem is_O_comp (g : F →L[𝕂] G) (f : E → F) (l : filter E) :
   is_O (λ x', g (f x')) f l :=
 ((g.is_O_id ⊤).comp _).mono (map_le_iff_le_comap.mp lattice.le_top)
 
-theorem is_O_sub (f : E →L[k] F) (l : filter E) (x : E) :
+theorem is_O_sub (f : E →L[𝕂] F) (l : filter E) (x : E) :
   is_O (λ x', f (x' - x)) (λ x', x' - x) l :=
 is_O_comp f _ l
 
@@ -109,15 +109,15 @@ set_option class.instance_max_depth 100
 
 /-- The operator norm of a continuous linear map is the inf of all its bounds. -/
 def op_norm := Inf { c | c ≥ 0 ∧ ∀ x, ∥f x∥ ≤ c * ∥x∥ }
-instance has_op_norm : has_norm (E →L[k] F) := ⟨op_norm⟩
+instance has_op_norm : has_norm (E →L[𝕂] F) := ⟨op_norm⟩
 
--- So that invocations of real.Inf_le make sense: we show that the set of
+-- So that invocations of real.Inf_le ma𝕂e sense: we show that the set of
 -- bounds is nonempty and bounded below.
-lemma bounds_nonempty {f : E →L[k] F} :
+lemma bounds_nonempty {f : E →L[𝕂] F} :
   ∃ c, c ∈ { c | c ≥ 0 ∧ ∀ x, ∥f x∥ ≤ c * ∥x∥ } :=
 let ⟨M, hMp, hMb⟩ := f.bound in ⟨M, le_of_lt hMp, hMb⟩
 
-lemma bounds_bdd_below {f : E →L[k] F} :
+lemma bounds_bdd_below {f : E →L[𝕂] F} :
   bdd_below { c | c ≥ 0 ∧ ∀ x, ∥f x∥ ≤ c * ∥x∥ } :=
 ⟨0, λ _ ⟨hn, _⟩, hn⟩
 
@@ -167,12 +167,12 @@ iff.intro
     ⟨ge_of_eq rfl, λ _, le_of_eq (by { rw [zero_mul, hf], exact norm_zero })⟩)
     (op_norm_nonneg _))
 
-@[simp] lemma norm_zero : ∥(0 : E →L[k] F)∥ = 0 :=
+@[simp] lemma norm_zero : ∥(0 : E →L[𝕂] F)∥ = 0 :=
 by rw op_norm_zero_iff
 
 /-- The norm of the identity is at most 1. It is in fact 1, except when the space is trivial where
 it is 0. It means that one can not do better than an inequality in general. -/
-lemma norm_id : ∥(id : E →L[k] E)∥ ≤ 1 :=
+lemma norm_id : ∥(id : E →L[𝕂] E)∥ ≤ 1 :=
 op_norm_le_bound _ zero_le_one (λx, by simp)
 
 /-- The operator norm is homogeneous. -/
@@ -197,21 +197,21 @@ le_antisymm
       (λ heq, by { rw [←heq, zero_mul], exact hn }))))
 
 lemma op_norm_neg : ∥-f∥ = ∥f∥ := calc
-  ∥-f∥ = ∥(-1:k) • f∥ : by rw neg_one_smul
-  ... = ∥(-1:k)∥ * ∥f∥ : by rw op_norm_smul
+  ∥-f∥ = ∥(-1:𝕂) • f∥ : by rw neg_one_smul
+  ... = ∥(-1:𝕂)∥ * ∥f∥ : by rw op_norm_smul
   ... = ∥f∥ : by simp
 
 /-- Continuous linear maps themselves form a normed space with respect to
     the operator norm. -/
-instance to_normed_group : normed_group (E →L[k] F) :=
+instance to_normed_group : normed_group (E →L[𝕂] F) :=
 normed_group.of_core _ ⟨op_norm_zero_iff, op_norm_triangle, op_norm_neg⟩
 
 /- The next instance should be found automatically, but it is not.
 TODO: fix me -/
-instance to_normed_group_prod : normed_group (E →L[k] (F × G)) :=
+instance to_normed_group_prod : normed_group (E →L[𝕂] (F × G)) :=
 continuous_linear_map.to_normed_group
 
-instance to_normed_space : normed_space k (E →L[k] F) :=
+instance to_normed_space : normed_space 𝕂 (E →L[𝕂] F) :=
 ⟨op_norm_smul⟩
 
 /-- The operator norm is submultiplicative. -/
@@ -234,7 +234,7 @@ end op_norm
 
 /-- The norm of the tensor product of a scalar linear map and of an element of a normed space
 is the product of the norms. -/
-@[simp] lemma scalar_prod_space_iso_norm {c : E →L[k] k} {f : F} :
+@[simp] lemma scalar_prod_space_iso_norm {c : E →L[𝕂] 𝕂} {f : F} :
   ∥scalar_prod_space_iso c f∥ = ∥c∥ * ∥f∥ :=
 begin
   refine le_antisymm _ _,

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -16,13 +16,13 @@ local attribute [instance] classical.prop_decidable
 
 set_option class.instance_max_depth 70
 
-variables {𝕂 : Type*} {E : Type*} {F : Type*} {G : Type*}
-[nondiscrete_normed_field 𝕂]
-[normed_group E] [normed_space 𝕂 E]
-[normed_group F] [normed_space 𝕂 F]
-[normed_group G] [normed_space 𝕂 G]
-(c : 𝕂) (f g : E →L[𝕂] F) (h : F →L[𝕂] G) (x y z : E)
-include 𝕂
+variables {𝕜 : Type*} {E : Type*} {F : Type*} {G : Type*}
+[nondiscrete_normed_field 𝕜]
+[normed_group E] [normed_space 𝕜 E]
+[normed_group F] [normed_space 𝕜 F]
+[normed_group G] [normed_space 𝕜 G]
+(c : 𝕜) (f g : E →L[𝕜] F) (h : F →L[𝕜] G) (x y z : E)
+include 𝕜
 
 open metric continuous_linear_map
 
@@ -32,7 +32,7 @@ lemma exists_pos_bound_of_bound {f : E → F} (M : ℝ) (h : ∀x, ∥f x∥ ≤
   ∥f x∥ ≤ M * ∥x∥ : h x
   ... ≤ max M 1 * ∥x∥ : mul_le_mul_of_nonneg_right (le_max_left _ _) (norm_nonneg _) ⟩
 
-lemma linear_map.continuous_of_bound (f : E →ₗ[𝕂] F) (C : ℝ) (h : ∀x, ∥f x∥ ≤ C * ∥x∥) :
+lemma linear_map.continuous_of_bound (f : E →ₗ[𝕜] F) (C : ℝ) (h : ∀x, ∥f x∥ ≤ C * ∥x∥) :
   continuous f :=
 begin
   have : ∀ (x y : E), dist (f x) (f y) ≤ C * dist x y := λx y, calc
@@ -43,13 +43,13 @@ begin
   exact continuous_of_lipschitz this
 end
 
-def linear_map.with_bound (f : E →ₗ[𝕂] F) (h : ∃C : ℝ, ∀x, ∥f x∥ ≤ C * ∥x∥) : E →L[𝕂] F :=
+def linear_map.with_bound (f : E →ₗ[𝕜] F) (h : ∃C : ℝ, ∀x, ∥f x∥ ≤ C * ∥x∥) : E →L[𝕜] F :=
 ⟨f, let ⟨C, hC⟩ := h in linear_map.continuous_of_bound f C hC⟩
 
-@[simp, elim_cast] lemma linear_map_with_bound_coe (f : E →ₗ[𝕂] F) (h : ∃C : ℝ, ∀x, ∥f x∥ ≤ C * ∥x∥) :
-  ((f.with_bound h) : E →ₗ[𝕂] F) = f := rfl
+@[simp, elim_cast] lemma linear_map_with_bound_coe (f : E →ₗ[𝕜] F) (h : ∃C : ℝ, ∀x, ∥f x∥ ≤ C * ∥x∥) :
+  ((f.with_bound h) : E →ₗ[𝕜] F) = f := rfl
 
-@[simp] lemma linear_map_with_bound_apply (f : E →ₗ[𝕂] F) (h : ∃C : ℝ, ∀x, ∥f x∥ ≤ C * ∥x∥) (x : E) :
+@[simp] lemma linear_map_with_bound_apply (f : E →ₗ[𝕜] F) (h : ∃C : ℝ, ∀x, ∥f x∥ ≤ C * ∥x∥) (x : E) :
   f.with_bound h x = f x := rfl
 
 namespace continuous_linear_map
@@ -71,7 +71,7 @@ begin
       rw [dist_eq_norm, sub_zero],
       exact lt_of_le_of_lt ha (half_lt_self ε_pos) },
     simpa using this },
-  rcases exists_one_lt_norm 𝕂 with ⟨c, hc⟩,
+  rcases exists_one_lt_norm 𝕜 with ⟨c, hc⟩,
   refine ⟨δ⁻¹ * ∥c∥, mul_pos (inv_pos δ_pos) (lt_trans zero_lt_one hc), (λx, _)⟩,
   by_cases h : x = 0,
   { simp only [h, norm_zero, mul_zero, continuous_linear_map.map_zero], },
@@ -92,11 +92,11 @@ theorem is_O_id (l : filter E) : is_O f (λ x, x) l :=
 let ⟨M, hMp, hM⟩ := f.bound in
 ⟨M, hMp, mem_sets_of_superset univ_mem_sets (λ x _, hM x)⟩
 
-theorem is_O_comp (g : F →L[𝕂] G) (f : E → F) (l : filter E) :
+theorem is_O_comp (g : F →L[𝕜] G) (f : E → F) (l : filter E) :
   is_O (λ x', g (f x')) f l :=
 ((g.is_O_id ⊤).comp _).mono (map_le_iff_le_comap.mp lattice.le_top)
 
-theorem is_O_sub (f : E →L[𝕂] F) (l : filter E) (x : E) :
+theorem is_O_sub (f : E →L[𝕜] F) (l : filter E) (x : E) :
   is_O (λ x', f (x' - x)) (λ x', x' - x) l :=
 is_O_comp f _ l
 
@@ -109,15 +109,15 @@ set_option class.instance_max_depth 100
 
 /-- The operator norm of a continuous linear map is the inf of all its bounds. -/
 def op_norm := Inf { c | c ≥ 0 ∧ ∀ x, ∥f x∥ ≤ c * ∥x∥ }
-instance has_op_norm : has_norm (E →L[𝕂] F) := ⟨op_norm⟩
+instance has_op_norm : has_norm (E →L[𝕜] F) := ⟨op_norm⟩
 
--- So that invocations of real.Inf_le ma𝕂e sense: we show that the set of
+-- So that invocations of real.Inf_le ma𝕜e sense: we show that the set of
 -- bounds is nonempty and bounded below.
-lemma bounds_nonempty {f : E →L[𝕂] F} :
+lemma bounds_nonempty {f : E →L[𝕜] F} :
   ∃ c, c ∈ { c | c ≥ 0 ∧ ∀ x, ∥f x∥ ≤ c * ∥x∥ } :=
 let ⟨M, hMp, hMb⟩ := f.bound in ⟨M, le_of_lt hMp, hMb⟩
 
-lemma bounds_bdd_below {f : E →L[𝕂] F} :
+lemma bounds_bdd_below {f : E →L[𝕜] F} :
   bdd_below { c | c ≥ 0 ∧ ∀ x, ∥f x∥ ≤ c * ∥x∥ } :=
 ⟨0, λ _ ⟨hn, _⟩, hn⟩
 
@@ -167,12 +167,12 @@ iff.intro
     ⟨ge_of_eq rfl, λ _, le_of_eq (by { rw [zero_mul, hf], exact norm_zero })⟩)
     (op_norm_nonneg _))
 
-@[simp] lemma norm_zero : ∥(0 : E →L[𝕂] F)∥ = 0 :=
+@[simp] lemma norm_zero : ∥(0 : E →L[𝕜] F)∥ = 0 :=
 by rw op_norm_zero_iff
 
 /-- The norm of the identity is at most 1. It is in fact 1, except when the space is trivial where
 it is 0. It means that one can not do better than an inequality in general. -/
-lemma norm_id : ∥(id : E →L[𝕂] E)∥ ≤ 1 :=
+lemma norm_id : ∥(id : E →L[𝕜] E)∥ ≤ 1 :=
 op_norm_le_bound _ zero_le_one (λx, by simp)
 
 /-- The operator norm is homogeneous. -/
@@ -197,21 +197,21 @@ le_antisymm
       (λ heq, by { rw [←heq, zero_mul], exact hn }))))
 
 lemma op_norm_neg : ∥-f∥ = ∥f∥ := calc
-  ∥-f∥ = ∥(-1:𝕂) • f∥ : by rw neg_one_smul
-  ... = ∥(-1:𝕂)∥ * ∥f∥ : by rw op_norm_smul
+  ∥-f∥ = ∥(-1:𝕜) • f∥ : by rw neg_one_smul
+  ... = ∥(-1:𝕜)∥ * ∥f∥ : by rw op_norm_smul
   ... = ∥f∥ : by simp
 
 /-- Continuous linear maps themselves form a normed space with respect to
     the operator norm. -/
-instance to_normed_group : normed_group (E →L[𝕂] F) :=
+instance to_normed_group : normed_group (E →L[𝕜] F) :=
 normed_group.of_core _ ⟨op_norm_zero_iff, op_norm_triangle, op_norm_neg⟩
 
 /- The next instance should be found automatically, but it is not.
 TODO: fix me -/
-instance to_normed_group_prod : normed_group (E →L[𝕂] (F × G)) :=
+instance to_normed_group_prod : normed_group (E →L[𝕜] (F × G)) :=
 continuous_linear_map.to_normed_group
 
-instance to_normed_space : normed_space 𝕂 (E →L[𝕂] F) :=
+instance to_normed_space : normed_space 𝕜 (E →L[𝕜] F) :=
 ⟨op_norm_smul⟩
 
 /-- The operator norm is submultiplicative. -/
@@ -234,7 +234,7 @@ end op_norm
 
 /-- The norm of the tensor product of a scalar linear map and of an element of a normed space
 is the product of the norms. -/
-@[simp] lemma scalar_prod_space_iso_norm {c : E →L[𝕂] 𝕂} {f : F} :
+@[simp] lemma scalar_prod_space_iso_norm {c : E →L[𝕜] 𝕜} {f : F} :
   ∥scalar_prod_space_iso c f∥ = ∥c∥ * ∥f∥ :=
 begin
   refine le_antisymm _ _,


### PR DESCRIPTION
In some files, a field was denoted by `k`. We replace (only in these files) this notation by `𝕂`, to help the reader understand what is going on.