### PR TITLE
fix(topology/uniform_space): sanity_check pass

### DIFF
--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -412,7 +412,7 @@ lemma interior_mem_uniformity {s : set (α × α)} (hs : s ∈ 𝓤 α) :
   interior s ∈ 𝓤 α :=
 by rw [uniformity_eq_uniformity_interior]; exact mem_lift' hs
 
-lemma mem_uniformity_is_closed [uniform_space α] {s : set (α×α)} (h : s ∈ 𝓤 α) :
+lemma mem_uniformity_is_closed {s : set (α×α)} (h : s ∈ 𝓤 α) :
   ∃t ∈ 𝓤 α, is_closed t ∧ t ⊆ s :=
 have s ∈ (𝓤 α).lift' closure, by rwa [uniformity_eq_uniformity_closure] at h,
 have ∃ t ∈ 𝓤 α, closure t ⊆ s,
@@ -752,7 +752,7 @@ lemma uniform_continuous.prod_mk_right {f : α × β → γ} (h : uniform_contin
   uniform_continuous (λ b, f (a,b)) :=
 h.comp (uniform_continuous_const.prod_mk  uniform_continuous_id)
 
-lemma to_topological_space_prod [u : uniform_space α] [v : uniform_space β] :
+lemma to_topological_space_prod {α} {β} [u : uniform_space α] [v : uniform_space β] :
   @uniform_space.to_topological_space (α × β) prod.uniform_space =
     @prod.topological_space α β u.to_topological_space v.to_topological_space := rfl
 
@@ -849,12 +849,11 @@ begin
 end
 
 /- We can now define the uniform structure on the disjoint union -/
-instance sum.uniform_space [u₁ : uniform_space α] [u₂ : uniform_space β] : uniform_space (α ⊕ β) :=
+instance sum.uniform_space : uniform_space (α ⊕ β) :=
 { to_core := uniform_space.core.sum,
   is_open_uniformity := λ s, ⟨uniformity_sum_of_open_aux, open_of_uniformity_sum_aux⟩ }
 
-lemma sum.uniformity [uniform_space α] [uniform_space β] :
-  𝓤 (α ⊕ β) =
+lemma sum.uniformity : 𝓤 (α ⊕ β) =
     map (λ p : α × α, (inl p.1, inl p.2)) (𝓤 α) ⊔
     map (λ p : β × β, (inr p.1, inr p.2)) (𝓤 β) := rfl
 

--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -7,7 +7,6 @@ Theory of Cauchy filters in uniform spaces. Complete uniform spaces. Totally bou
 -/
 import topology.uniform_space.basic
 
-
 open filter topological_space lattice set classical
 local attribute [instance, priority 0] prop_decidable
 variables {α : Type*} {β : Type*} [uniform_space α]
@@ -112,7 +111,7 @@ lemma cauchy_comap [uniform_space β] {f : filter β} {m : α → β}
 /-- Cauchy sequences. Usually defined on ℕ, but often it is also useful to say that a function
 defined on ℝ is Cauchy at +∞ to deduce convergence. Therefore, we define it in a type class that
 is general enough to cover both ℕ and ℝ, which are the main motivating examples. -/
-def cauchy_seq [inhabited β] [semilattice_sup β] (u : β → α) := cauchy (at_top.map u)
+def cauchy_seq [semilattice_sup β] (u : β → α) := cauchy (at_top.map u)
 
 lemma cauchy_seq_iff_prod_map [inhabited β] [semilattice_sup β] {u : β → α} :
   cauchy_seq u ↔ map (prod.map u u) at_top ≤ 𝓤 α :=
@@ -155,21 +154,21 @@ instance complete_space.prod [uniform_space β] [complete_space α] [complete_sp
 lemma complete_space_of_is_complete_univ (h : is_complete (univ : set α)) : complete_space α :=
 ⟨λ f hf, let ⟨x, _, hx⟩ := h f hf ((@principal_univ α).symm ▸ le_top) in ⟨x, hx⟩⟩
 
-lemma cauchy_iff_exists_le_nhds [uniform_space α] [complete_space α] {l : filter α} (hl : l ≠ ⊥) :
+lemma cauchy_iff_exists_le_nhds [complete_space α] {l : filter α} (hl : l ≠ ⊥) :
   cauchy l ↔ (∃x, l ≤ nhds x) :=
 ⟨complete_space.complete, assume ⟨x, hx⟩, cauchy_downwards cauchy_nhds hl hx⟩
 
-lemma cauchy_map_iff_exists_tendsto [uniform_space α] [complete_space α] {l : filter β} {f : β → α}
+lemma cauchy_map_iff_exists_tendsto [complete_space α] {l : filter β} {f : β → α}
   (hl : l ≠ ⊥) : cauchy (l.map f) ↔ (∃x, tendsto f l (nhds x)) :=
 cauchy_iff_exists_le_nhds (map_ne_bot hl)
 
 /-- A Cauchy sequence in a complete space converges -/
-theorem cauchy_seq_tendsto_of_complete [inhabited β] [semilattice_sup β] [complete_space α]
+theorem cauchy_seq_tendsto_of_complete [semilattice_sup β] [complete_space α]
   {u : β → α} (H : cauchy_seq u) : ∃x, tendsto u at_top (nhds x) :=
 complete_space.complete H
 
 /-- If `K` is a complete subset, then any cauchy sequence in `K` converges to a point in `K` -/
-lemma cauchy_seq_tendsto_of_is_complete [inhabited β] [semilattice_sup β] {K : set α} (h₁ : is_complete K)
+lemma cauchy_seq_tendsto_of_is_complete [semilattice_sup β] {K : set α} (h₁ : is_complete K)
   {u : β → α} (h₂ : ∀ n, u n ∈ K) (h₃ : cauchy_seq u) : ∃ v ∈ K, tendsto u at_top (nhds v) :=
 h₁ _ h₃ $ le_principal_iff.2 $ mem_map_sets_iff.2 ⟨univ, univ_mem_sets,
   by { simp only [image_univ], rintros _ ⟨n, rfl⟩, exact h₂ n }⟩
@@ -208,14 +207,14 @@ theorem totally_bounded_iff_subset {s : set α} : totally_bounded s ↔
 end,
 λ H d hd, let ⟨t, _, ht⟩ := H d hd in ⟨t, ht⟩⟩
 
-lemma totally_bounded_subset [uniform_space α] {s₁ s₂ : set α} (hs : s₁ ⊆ s₂)
+lemma totally_bounded_subset {s₁ s₂ : set α} (hs : s₁ ⊆ s₂)
   (h : totally_bounded s₂) : totally_bounded s₁ :=
 assume d hd, let ⟨t, ht₁, ht₂⟩ := h d hd in ⟨t, ht₁, subset.trans hs ht₂⟩
 
-lemma totally_bounded_empty [uniform_space α] : totally_bounded (∅ : set α) :=
+lemma totally_bounded_empty : totally_bounded (∅ : set α) :=
 λ d hd, ⟨∅, finite_empty, empty_subset _⟩
 
-lemma totally_bounded_closure [uniform_space α] {s : set α} (h : totally_bounded s) :
+lemma totally_bounded_closure {s : set α} (h : totally_bounded s) :
   totally_bounded (closure s) :=
 assume t ht,
 let ⟨t', ht', hct', htt'⟩ := mem_uniformity_is_closed ht, ⟨c, hcf, hc⟩ := h t' ht' in
@@ -226,7 +225,7 @@ let ⟨t', ht', hct', htt'⟩ := mem_uniformity_is_closed ht, ⟨c, hcf, hc⟩ :
     ... ⊆ _ : bUnion_subset $ assume i hi, subset.trans (assume x, @htt' (x, i))
       (subset_bUnion_of_mem hi)⟩
 
-lemma totally_bounded_image [uniform_space α] [uniform_space β] {f : α → β} {s : set α}
+lemma totally_bounded_image [uniform_space β] {f : α → β} {s : set α}
   (hf : uniform_continuous f) (hs : totally_bounded s) : totally_bounded (f '' s) :=
 assume t ht,
 have {p:α×α | (f p.1, f p.2) ∈ t} ∈ 𝓤 α,

--- a/src/topology/uniform_space/separation.lean
+++ b/src/topology/uniform_space/separation.lean
@@ -7,7 +7,6 @@ Hausdorff properties of uniform spaces. Separation quotient.
 -/
 import topology.uniform_space.basic
 
-
 open filter topological_space lattice set classical
 local attribute [instance, priority 0] prop_decidable
 noncomputable theory
@@ -162,7 +161,7 @@ lemma uniform_continuous_quotient_lift
   (hf : uniform_continuous f) : uniform_continuous (λa, quotient.lift f h a) :=
 uniform_continuous_quotient hf
 
-lemma uniform_continuous_quotient_lift₂ [uniform_space γ]
+lemma uniform_continuous_quotient_lift₂
   {f : α → β → γ} {h : ∀a c b d, (a, b) ∈ separation_rel α → (c, d) ∈ separation_rel β → f a c = f b d}
   (hf : uniform_continuous (λp:α×β, f p.1 p.2)) :
   uniform_continuous (λp:_×_, quotient.lift₂ f h p.1 p.2) :=

--- a/src/topology/uniform_space/uniform_embedding.lean
+++ b/src/topology/uniform_space/uniform_embedding.lean
@@ -19,7 +19,7 @@ universe u
 structure uniform_inducing (f : α → β) : Prop :=
 (comap_uniformity : comap (λx:α×α, (f x.1, f x.2)) (𝓤 β) = 𝓤 α)
 
-def uniform_inducing.mk' {f : α → β} (h : ∀ s, s ∈ 𝓤 α ↔
+lemma uniform_inducing.mk' {f : α → β} (h : ∀ s, s ∈ 𝓤 α ↔
     ∃ t ∈ 𝓤 β, ∀ x y : α, (f x, f y) ∈ t → (x, y) ∈ s) : uniform_inducing f :=
 ⟨by simp [eq_comm, filter.ext_iff, subset_def, h]⟩
 
@@ -274,18 +274,13 @@ section uniform_extension
 
 variables {α : Type*} {β : Type*} {γ : Type*}
           [uniform_space α] [uniform_space β] [uniform_space γ]
-          [separated γ]
           {e : β → α}
           (h_e : uniform_inducing e)
           (h_dense : dense_range e)
           {f : β → γ}
           (h_f : uniform_continuous f)
-include h_f
 
 local notation `ψ` := (h_e.dense_inducing h_dense).extend f
-
-lemma uniformly_extend_of_ind (b : β) : ψ (e b) = f b :=
-dense_inducing.extend_e_eq _ b (continuous_iff_continuous_at.1 h_f.continuous b)
 
 lemma uniformly_extend_exists [complete_space γ] (a : α) :
   ∃c, tendsto f (comap e (nhds a)) (nhds c) :=
@@ -296,6 +291,46 @@ have cauchy (comap e (nhds a)), from
 have cauchy (map f (comap e (nhds a))), from
   cauchy_map h_f this,
 complete_space.complete this
+
+lemma uniform_extend_subtype [complete_space γ]
+  {p : α → Prop} {e : α → β} {f : α → γ} {b : β} {s : set α}
+  (hf : uniform_continuous (λx:subtype p, f x.val))
+  (he : uniform_embedding e) (hd : ∀x:β, x ∈ closure (range e))
+  (hb : closure (e '' s) ∈ nhds b) (hs : is_closed s) (hp : ∀x∈s, p x) :
+  ∃c, tendsto f (comap e (nhds b)) (nhds c) :=
+have de : dense_embedding e,
+  from he.dense_embedding hd,
+have de' : dense_embedding (de.subtype_emb p),
+  by exact de.subtype p,
+have ue' : uniform_embedding (de.subtype_emb p),
+  from uniform_embedding_subtype_emb _ he de,
+have b ∈ closure (e '' {x | p x}),
+  from (closure_mono $ mono_image $ hp) (mem_of_nhds hb),
+let ⟨c, (hc : tendsto (f ∘ subtype.val) (comap (de.subtype_emb p) (nhds ⟨b, this⟩)) (nhds c))⟩ :=
+  uniformly_extend_exists ue'.to_uniform_inducing de'.dense hf _ in
+begin
+  rw [nhds_subtype_eq_comap] at hc,
+  simp [comap_comap_comp] at hc,
+  change (tendsto (f ∘ @subtype.val α p) (comap (e ∘ @subtype.val α p) (nhds b)) (nhds c)) at hc,
+  rw [←comap_comap_comp, tendsto_comap'_iff] at hc,
+  exact ⟨c, hc⟩,
+  exact ⟨_, hb, assume x,
+    begin
+      change e x ∈ (closure (e '' s)) → x ∈ range subtype.val,
+      rw [←closure_induced, closure_eq_nhds, mem_set_of_eq, (≠), nhds_induced, ← de.to_dense_inducing.nhds_eq_comap],
+      change x ∈ {x | nhds x ⊓ principal s ≠ ⊥} → x ∈ range subtype.val,
+      rw [←closure_eq_nhds, closure_eq_of_is_closed hs],
+      exact assume hxs, ⟨⟨x, hp x hxs⟩, rfl⟩,
+      exact de.inj
+    end⟩
+end
+
+variables [separated γ]
+
+lemma uniformly_extend_of_ind (b : β) : ψ (e b) = f b :=
+dense_inducing.extend_e_eq _ b (continuous_iff_continuous_at.1 h_f.continuous b)
+
+include h_f
 
 lemma uniformly_extend_spec [complete_space γ] (a : α) :
   tendsto f (comap e (nhds a)) (nhds (ψ a)) :=
@@ -348,39 +383,4 @@ show preimage (λp:(α×α), (ψ p.1, ψ p.2)) d ∈ 𝓤 α,
   have (a, b) ∈ s, from @this (a, b) ⟨ha₁, hb₁⟩,
   hs_comp $ show (ψ x₁, ψ x₂) ∈ comp_rel s (comp_rel s s),
     from ⟨a, ha₂, ⟨b, this, hb₂⟩⟩
-
-omit h_f
-
-lemma uniform_extend_subtype [complete_space γ]
-  {p : α → Prop} {e : α → β} {f : α → γ} {b : β} {s : set α}
-  (hf : uniform_continuous (λx:subtype p, f x.val))
-  (he : uniform_embedding e) (hd : ∀x:β, x ∈ closure (range e))
-  (hb : closure (e '' s) ∈ nhds b) (hs : is_closed s) (hp : ∀x∈s, p x) :
-  ∃c, tendsto f (comap e (nhds b)) (nhds c) :=
-have de : dense_embedding e,
-  from he.dense_embedding hd,
-have de' : dense_embedding (de.subtype_emb p),
-  by exact de.subtype p,
-have ue' : uniform_embedding (de.subtype_emb p),
-  from uniform_embedding_subtype_emb _ he de,
-have b ∈ closure (e '' {x | p x}),
-  from (closure_mono $ mono_image $ hp) (mem_of_nhds hb),
-let ⟨c, (hc : tendsto (f ∘ subtype.val) (comap (de.subtype_emb p) (nhds ⟨b, this⟩)) (nhds c))⟩ :=
-  uniformly_extend_exists ue'.to_uniform_inducing de'.dense hf _ in
-begin
-  rw [nhds_subtype_eq_comap] at hc,
-  simp [comap_comap_comp] at hc,
-  change (tendsto (f ∘ @subtype.val α p) (comap (e ∘ @subtype.val α p) (nhds b)) (nhds c)) at hc,
-  rw [←comap_comap_comp, tendsto_comap'_iff] at hc,
-  exact ⟨c, hc⟩,
-  exact ⟨_, hb, assume x,
-    begin
-      change e x ∈ (closure (e '' s)) → x ∈ range subtype.val,
-      rw [←closure_induced, closure_eq_nhds, mem_set_of_eq, (≠), nhds_induced, ← de.to_dense_inducing.nhds_eq_comap],
-      change x ∈ {x | nhds x ⊓ principal s ≠ ⊥} → x ∈ range subtype.val,
-      rw [←closure_eq_nhds, closure_eq_of_is_closed hs],
-      exact assume hxs, ⟨⟨x, hp x hxs⟩, rfl⟩,
-      exact de.inj
-    end⟩
-end
 end uniform_extension


### PR DESCRIPTION
This is purely a `#sanity_check` PR. It cleans up the topology/uniform_space folder.