### PR TITLE
fix(tactic/apply): `tactic.exact` timeout

### DIFF
--- a/src/tactic/apply.lean
+++ b/src/tactic/apply.lean
@@ -53,6 +53,8 @@ mwhen (has_opt_auto_param_inst_for_apply ms) $ do
 private meta def retry_apply_aux : Π (e : expr) (cfg : apply_cfg), list (bool × name ×  expr) → tactic (list (name × expr))
 | e cfg gs :=
 focus1 (do {
+     tgt : expr ← target, t <- infer_type e,
+     unify t tgt,
      exact e,
      gs' ← get_goals,
      let r := reorder_goals gs cfg.new_goals,
@@ -174,7 +176,8 @@ tactic.transitivity' >> match q with
 | none := skip
 | some q :=
   do (r, lhs, rhs) ← target_lhs_rhs,
-     i_to_expr q >>= unify rhs
+     t ← infer_type lhs,
+     i_to_expr ``(%%q : %%t) >>= unify rhs
 end
 
 end interactive


### PR DESCRIPTION
Sometimes `tactic.exact` may timeout for no reason, so we guard `exact` with a `unify`.

See Zulip discussion: https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/.60apply'.60timeout/near/174415043

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
