### PR TITLE
chore(unicode): improve arrows

### DIFF
--- a/docs/extras/simp.md
+++ b/docs/extras/simp.md
@@ -39,7 +39,7 @@ This lemma is then added to `simp`'s armoury. Note several things however.
 1) It might not be wise to make a random theorem into a simp lemma. Ideally the result has to be of a certain kind, the most important kinds being those of the form `A=B` and `A↔B`. Note however that if you want to add `fact` to `simp`'s weaponry, you can prove
 
 ```lean
-@[simp] lemma my_lemma : fact <-> true
+@[simp] lemma my_lemma : fact ↔ true
 ```
 
 (and in fact more recent versions of Lean do this automatically when you try to add random theorems to the simp dataset).

--- a/src/category/traversable/basic.lean
+++ b/src/category/traversable/basic.lean
@@ -16,7 +16,7 @@ http://hackage.haskell.org/package/base-4.11.1.0/docs/Data-Traversable.html
 Traversable collections are a generalization of functors. Whereas
 functors (such as `list`) allow us to apply a function to every
 element, it does not allow functions which external effects encoded in
-a monad. Consider for instance a functor `invite : email -> io response`
+a monad. Consider for instance a functor `invite : email → io response`
 that takes an email address, sends an email and wait for a
 response. If we have a list `guests : list email`, using calling
 `invite` using `map` gives us the following: `map invite guests : list

--- a/src/category/traversable/basic.lean
+++ b/src/category/traversable/basic.lean
@@ -17,7 +17,7 @@ Traversable collections are a generalization of functors. Whereas
 functors (such as `list`) allow us to apply a function to every
 element, it does not allow functions which external effects encoded in
 a monad. Consider for instance a functor `invite : email → io response`
-that takes an email address, sends an email and wait for a
+that takes an email address, sends an email and waits for a
 response. If we have a list `guests : list email`, using calling
 `invite` using `map` gives us the following: `map invite guests : list
 (io response)`.  It is not what we need. We need something of type `io

--- a/src/computability/primrec.lean
+++ b/src/computability/primrec.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Mario Carneiro
 
 The primitive recursive functions are the least collection of functions
-nat -> nat which are closed under projections (using the mkpair
+nat → nat which are closed under projections (using the mkpair
 pairing function), composition, zero, successor, and primitive recursion
 (i.e. nat.rec where the motive is C n := nat).
 

--- a/src/data/list/defs.lean
+++ b/src/data/list/defs.lean
@@ -144,7 +144,7 @@ find_indexes_aux p l 0
 
 /-- `lookmap` is a combination of `lookup` and `filter_map`.
   `lookmap f l` will apply `f : α → option α` to each element of the list,
-  replacing `a -> b` at the first value `a` in the list such that `f a = some b`. -/
+  replacing `a → b` at the first value `a` in the list such that `f a = some b`. -/
 def lookmap (f : α → option α) : list α → list α
 | []     := []
 | (a::l) :=

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -761,7 +761,7 @@ lemma eval₂_sub : (p - q).eval₂ f g = p.eval₂ f g - q.eval₂ f g := is_ri
 lemma hom_C (f : mv_polynomial σ ℤ → β) [is_ring_hom f] (n : ℤ) : f (C n) = (n : β) :=
 congr_fun (int.eq_cast' (f ∘ C)) n
 
-/-- A ring homomorphism f : Z[X_1, X_2, ...] -> R
+/-- A ring homomorphism f : Z[X_1, X_2, ...] → R
 is determined by the evaluations f(X_1), f(X_2), ... -/
 @[simp] lemma eval₂_hom_X {α : Type u} [decidable_eq α] (c : ℤ → β) [is_ring_hom c]
   (f : mv_polynomial α ℤ → β) [is_ring_hom f] (x : mv_polynomial α ℤ) :

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -1249,13 +1249,13 @@ section prod
 variables {s : set α} {t : set β} {f : filter α} {g : filter β}
 /- The product filter cannot be defined using the monad structure on filters. For example:
 
-  F := do {x <- seq, y <- top, return (x, y)}
+  F := do {x ← seq, y ← top, return (x, y)}
   hence:
-    s ∈ F  <->  ∃n, [n..∞] × univ ⊆ s
+    s ∈ F  ↔  ∃n, [n..∞] × univ ⊆ s
 
-  G := do {y <- top, x <- seq, return (x, y)}
+  G := do {y ← top, x ← seq, return (x, y)}
   hence:
-    s ∈ G  <->  ∀i:ℕ, ∃n, [n..∞] × {i} ⊆ s
+    s ∈ G  ↔  ∀i:ℕ, ∃n, [n..∞] × {i} ⊆ s
 
   Now ⋃i, [i..∞] × {i}  is in G but not in F.
 

--- a/src/tactic/apply.lean
+++ b/src/tactic/apply.lean
@@ -53,7 +53,7 @@ mwhen (has_opt_auto_param_inst_for_apply ms) $ do
 private meta def retry_apply_aux : Π (e : expr) (cfg : apply_cfg), list (bool × name ×  expr) → tactic (list (name × expr))
 | e cfg gs :=
 focus1 (do {
-     tgt : expr ← target, t <- infer_type e,
+     tgt : expr ← target, t ← infer_type e,
      unify t tgt,
      exact e,
      gs' ← get_goals,

--- a/src/tactic/finish.lean
+++ b/src/tactic/finish.lean
@@ -323,7 +323,7 @@ do p ← resolve_name n,
    end
 
 private meta def add_hinst_lemma_from_pexpr (md : transparency) (lhs_lemma : bool) (hs : hinst_lemmas)
-  : pexpr -> smt_tactic hinst_lemmas
+  : pexpr → smt_tactic hinst_lemmas
 | p@(expr.const c [])          := add_hinst_lemma_from_name md lhs_lemma c hs p
 | p@(expr.local_const c _ _ _) := add_hinst_lemma_from_name md lhs_lemma c hs p
 | p                          := do new_e ← to_expr p, h ← hinst_lemma.mk_core md new_e lhs_lemma,


### PR DESCRIPTION
It took a very long time to read every source file. Hopefully I didn't miss any.

ASCII arrows `->` are *so* 2018.

<br>
<br>
<br>

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
