### PR TITLE
feat(topology/uniform_space): Abstract completions

### DIFF
--- a/src/topology/algebra/group_completion.lean
+++ b/src/topology/algebra/group_completion.lean
@@ -75,33 +75,7 @@ have hf : uniform_continuous f, from uniform_continuous_of_continuous hf,
 
 lemma is_add_group_hom_map [add_group β] [uniform_add_group β]
   {f : α → β} [is_add_group_hom f] (hf : continuous f) : is_add_group_hom (completion.map f) :=
-is_add_group_hom_extension ((continuous_coe _).comp hf)
-
-section instance_max_depth
--- TODO: continuous_add requires some long proofs through
--- uniform_add_group / topological_add_group w.r.t prod / completion etc
-set_option class.instance_max_depth 52
-
-lemma is_add_group_hom_prod [add_group β] [uniform_add_group β] :
-  is_add_group_hom (@completion.prod α β _ _) :=
-{ map_add := assume ⟨a₁, a₂⟩ ⟨b₁, b₂⟩,
-  begin
-    refine completion.induction_on₄ a₁ a₂ b₁ b₂ (is_closed_eq _ _) _,
-    { refine continuous.comp uniform_continuous_prod.continuous _ ,
-      refine continuous_add _ _,
-      exact continuous.prod_mk (continuous_fst.comp continuous_fst) (continuous_snd.comp continuous_fst),
-      exact continuous.prod_mk (continuous_fst.comp continuous_snd) (continuous_snd.comp continuous_snd) },
-    { refine continuous_add _ _,
-      refine continuous.comp uniform_continuous_prod.continuous _,
-      exact continuous.prod_mk (continuous_fst.comp continuous_fst) (continuous_snd.comp continuous_fst),
-      refine continuous.comp uniform_continuous_prod.continuous _,
-      exact continuous.prod_mk (continuous_fst.comp continuous_snd) (continuous_snd.comp continuous_snd) },
-    { assume a b c d,
-      show completion.prod (↑a + ↑c, ↑b + ↑d) = completion.prod (↑a, ↑b) + completion.prod (↑c, ↑d),
-      norm_cast }
-  end }
-
-end instance_max_depth
+(is_add_group_hom_extension  ((continuous_coe _).comp hf) : _)
 
 instance {α : Type*} [uniform_space α] [add_comm_group α] [uniform_add_group α] : add_comm_group (completion α) :=
 { add_comm  := assume a b, completion.induction_on₂ a b

--- a/src/topology/algebra/uniform_ring.lean
+++ b/src/topology/algebra/uniform_ring.lean
@@ -120,7 +120,7 @@ instance top_ring_compl : topological_ring (completion α) :=
   continuous_neg := continuous_neg' }
 
 instance is_ring_hom_map : is_ring_hom (completion.map f) :=
-completion.is_ring_hom_extension $ (continuous_coe β).comp hf
+(completion.is_ring_hom_extension $ (continuous_coe β).comp hf : _)
 
 variables (R : Type*) [comm_ring R] [uniform_space R] [uniform_add_group R] [topological_ring R]
 

--- a/src/topology/maps.lean
+++ b/src/topology/maps.lean
@@ -45,6 +45,14 @@ lemma dense_range.inhabited (df : dense_range f) (b : β) : inhabited α :=
   exact classical.some (classical.some_spec this),
  end⟩
 
+lemma dense_range.nonempty (hf : dense_range f) : nonempty α ↔ nonempty β :=
+begin
+  split ; intro h ; cases classical.inhabited_of_nonempty h with x,
+  { exact ⟨f x⟩ },
+  { rcases exists_mem_of_ne_empty (mem_closure_iff.1 (hf x) _ is_open_univ trivial)
+      with ⟨_, ⟨_, a, _⟩⟩,
+    exact ⟨a⟩ },
+end
 end dense_range
 
 section inducing

--- a/src/topology/uniform_space/absolute_value.lean
+++ b/src/topology/uniform_space/absolute_value.lean
@@ -10,10 +10,12 @@ import topology.uniform_space.basic
 /-!
 # Uniform structure induced by an absolute value
 
-We build an uniform space structure on a commutative ring `R` equipped with an absolute value into
+We build a uniform space structure on a commutative ring `R` equipped with an absolute value into
 a linear ordered field `𝕜`. Of course in the case `R` is `ℚ`, `ℝ` or `ℂ` and
 `𝕜 = ℝ`, we get the same thing as the metric space construction, and the general construction
 follows exactly the same path.
+
+## Implementation details
 
 Note that we import `data.real.cau_seq` because this is where absolute values are defined, but
 the current file does not depend on real numbers. TODO: extract absolute values from that

--- a/src/topology/uniform_space/absolute_value.lean
+++ b/src/topology/uniform_space/absolute_value.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2019 Patrick Massot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Patrick Massot
+-/
+
+import data.real.cau_seq
+import topology.uniform_space.basic
+
+/-!
+# Uniform structure induced by an absolute value
+
+We build an uniform space structure on a commutative ring `R` equipped with an absolute value into
+a linear ordered field `𝕜`. Of course in the case `R` is `ℚ`, `ℝ` or `ℂ` and
+`𝕜 = ℝ`, we get the same thing as the metric space construction, and the general construction
+follows exactly the same path.
+
+Note that we import `data.real.cau_seq` because this is where absolute values are defined, but
+the current file does not depend on real numbers. TODO: extract absolute values from that
+`data.real` folder.
+
+## References
+
+* [N. Bourbaki, *Topologie générale*][bourbaki1966]
+
+## Tags
+
+absolute value, uniform spaces
+-/
+
+open set function lattice filter uniform_space
+
+namespace is_absolute_value
+variables {𝕜 : Type*} [discrete_linear_ordered_field 𝕜]
+variables {R : Type*} [comm_ring R] (abv : R → 𝕜) [is_absolute_value abv]
+
+/-- The uniformity coming from an absolute value. -/
+def uniform_space_core : uniform_space.core R :=
+{ uniformity := (⨅ ε>0, principal {p:R×R | abv (p.2 - p.1) < ε}),
+  refl := le_infi $ assume ε, le_infi $ assume ε_pos, principal_mono.2
+    (λ ⟨x, y⟩ h, by simpa [show x = y, from h, abv_zero abv]),
+  symm := tendsto_infi.2 $ assume ε, tendsto_infi.2 $ assume h,
+    tendsto_infi' ε $ tendsto_infi' h $ tendsto_principal_principal.2 $ λ ⟨x, y⟩ h,
+      have h : abv (y - x) < ε, by simpa [-sub_eq_add_neg] using h,
+      by rwa abv_sub abv at h,
+  comp := le_infi $ assume ε, le_infi $ assume h, lift'_le
+    (mem_infi_sets (ε / 2) $ mem_infi_sets (div_pos_of_pos_of_pos h two_pos) (subset.refl _)) $
+    have ∀ (a b c : R), abv (c-a) < ε / 2 → abv (b-c) < ε / 2 → abv (b-a) < ε,
+      from assume a b c hac hcb,
+       calc abv (b - a) ≤ _ : abv_sub_le abv b c a
+        ... = abv (c - a) + abv (b - c) : add_comm _ _
+        ... < ε / 2 + ε / 2 : add_lt_add hac hcb
+        ... = ε : by rw [div_add_div_same, add_self_div_two],
+    by simpa [comp_rel] }
+
+/-- The uniform structure coming from an absolute value. -/
+def uniform_space : uniform_space R :=
+uniform_space.of_core (uniform_space_core abv)
+
+theorem mem_uniformity {s : set (R×R)} :
+  s ∈ (uniform_space_core abv).uniformity ↔
+  (∃ε>0, ∀{a b:R}, abv (b - a) < ε → (a, b) ∈ s) :=
+begin
+  suffices : s ∈ (⨅ ε: {ε : 𝕜 // ε > 0}, principal {p:R×R | abv (p.2 - p.1) < ε.val}) ↔ _,
+  { rw infi_subtype at this,
+    exact this },
+  rw mem_infi,
+  { simp [subset_def] },
+  { exact assume ⟨r, hr⟩ ⟨p, hp⟩, ⟨⟨min r p, lt_min hr hp⟩, by simp [lt_min_iff, (≥)] {contextual := tt}⟩, },
+  { exact ⟨⟨1, zero_lt_one⟩⟩ }
+end
+
+end is_absolute_value

--- a/src/topology/uniform_space/abstract_completion.lean
+++ b/src/topology/uniform_space/abstract_completion.lean
@@ -30,7 +30,7 @@ inclusion, see `uniform_space/UniformSpace` for the category packaging.
 ## Implementation notes
 
 A tiny technical advantage of using a characteristic predicate such as the properties listed in
-`completion_pkg` instead of stating the universal property is that the universal property
+`abstract_completion` instead of stating the universal property is that the universal property
 derived from the predicate is more universe polymorphic.
 
 ## References
@@ -52,7 +52,7 @@ open filter set function
 universes u
 /-- A completion of `α` is the data of a complete separated uniform space (from the same universe)
 and a map from `α` with dense range and inducing the original uniform structure on `α`. -/
-structure completion_pkg (α : Type u) [uniform_space α] :=
+structure abstract_completion (α : Type u) [uniform_space α] :=
 (space : Type u)
 (coe : α → space)
 (uniform_struct : uniform_space space)
@@ -62,10 +62,10 @@ structure completion_pkg (α : Type u) [uniform_space α] :=
 (dense : dense_range coe)
 
 local attribute [instance]
-completion_pkg.uniform_struct completion_pkg.complete completion_pkg.separation
+abstract_completion.uniform_struct abstract_completion.complete abstract_completion.separation
 
-namespace completion_pkg
-variables {α : Type*} [uniform_space α] (pkg : completion_pkg α)
+namespace abstract_completion
+variables {α : Type*} [uniform_space α] (pkg : abstract_completion α)
 local notation `hatα` := pkg.space
 local notation `ι` := pkg.coe
 
@@ -144,7 +144,7 @@ end extend
 
 section map_sec
 
-variables (pkg' : completion_pkg β)
+variables (pkg' : abstract_completion β)
 local notation `hatβ` := pkg'.space
 local notation `ι'` := pkg'.coe
 
@@ -186,7 +186,7 @@ lemma extend_map [complete_space γ] [separated γ] {f : β → γ} {g : α → 
 pkg.funext (pkg'.continuous_extend.comp (pkg.continuous_map pkg' _)) pkg.continuous_extend $ λ a,
   by rw [pkg.extend_coe (hf.comp hg), comp_app, pkg.map_coe pkg' hg, pkg'.extend_coe hf]
 
-variables (pkg'' : completion_pkg γ)
+variables (pkg'' : abstract_completion γ)
 
 lemma map_comp {g : β → γ} {f : α → β} (hg : uniform_continuous g) (hf : uniform_continuous f) :
   (pkg'.map pkg'' g) ∘ (pkg.map pkg' f) = pkg.map pkg'' (g ∘ f) :=
@@ -197,7 +197,7 @@ end map_sec
 section compare
 -- We can now compare two completion packages for the same uniform space
 
-variables (pkg' : completion_pkg α)
+variables (pkg' : abstract_completion α)
 
 /-- The comparison map between two completions of the same uniform space. -/
 def compare : pkg.space → pkg'.space :=
@@ -235,12 +235,12 @@ pkg'.uniform_continuous_compare pkg
 end compare
 
 section prod
-variables (pkg' : completion_pkg β)
+variables (pkg' : abstract_completion β)
 local notation `hatβ` := pkg'.space
 local notation `ι'` := pkg'.coe
 
 /-- Products of completions -/
-protected def prod : completion_pkg (α × β) :=
+protected def prod : abstract_completion (α × β) :=
 { space := hatα × hatβ,
   coe := λ p, ⟨ι p.1, ι' p.2⟩,
   uniform_struct := prod.uniform_space,
@@ -253,7 +253,7 @@ end prod
 
 
 section extension₂
-variables (pkg' : completion_pkg β)
+variables (pkg' : abstract_completion β)
 local notation `hatβ` := pkg'.space
 local notation `ι'` := pkg'.coe
 
@@ -276,18 +276,18 @@ variables [complete_space γ] (f)
 
 lemma uniform_continuous_extension₂ : uniform_continuous₂ (pkg.extend₂ pkg' f) :=
 begin
-  rw [uniform_continuous₂_def, completion_pkg.extend₂, uncurry'_curry],
+  rw [uniform_continuous₂_def, abstract_completion.extend₂, uncurry'_curry],
   apply uniform_continuous_extend
 end
 
 end extension₂
 
 section map₂
-variables (pkg' : completion_pkg β)
+variables (pkg' : abstract_completion β)
 local notation `hatβ` := pkg'.space
 local notation `ι'` := pkg'.coe
 
-variables {γ : Type*} [uniform_space γ] (pkg'' : completion_pkg γ)
+variables {γ : Type*} [uniform_space γ] (pkg'' : abstract_completion γ)
 local notation `hatγ` := pkg''.space
 local notation `ι''` := pkg''.coe
 
@@ -310,4 +310,4 @@ lemma map₂_coe_coe (a : α) (b : β) (f : α → β → γ) (hf : uniform_cont
 pkg.extension₂_coe_coe pkg' (pkg''.uniform_continuous_coe.comp hf) a b
 
 end map₂
-end completion_pkg
+end abstract_completion

--- a/src/topology/uniform_space/compare_reals.lean
+++ b/src/topology/uniform_space/compare_reals.lean
@@ -35,7 +35,7 @@ TODO:
 
 ## Implementation notes
 
-The heavy work is done in `topology/uniform_space/completion_pkg` which provides an abstract
+The heavy work is done in `topology/uniform_space/abstract_completion` which provides an abstract
 caracterization of completions of uniform spaces, and isomorphisms between them. The only work left
 here is to prove the uniform space structure coming from the absolute value on ℚ (with values in ℚ,
 not referring to ℝ) coincides with the one coming from the metric space structure (which of course
@@ -76,7 +76,7 @@ end
 
 /-- Cauchy reals packaged as a completion of ℚ using the absolute value route. -/
 noncomputable
-def rational_cau_seq_pkg : @completion_pkg ℚ $ is_absolute_value.uniform_space (abs : ℚ → ℚ) :=
+def rational_cau_seq_pkg : @abstract_completion ℚ $ is_absolute_value.uniform_space (abs : ℚ → ℚ) :=
 { space := ℝ,
   coe := (coe : ℚ → ℝ),
   uniform_struct := by apply_instance,
@@ -101,7 +101,7 @@ def Bourbakiℝ : Type := completion Q
 instance : uniform_space Bourbakiℝ := completion.uniform_space Q
 
 /-- Bourbaki reals packaged as a completion of Q using the general theory. -/
-def Bourbaki_pkg : completion_pkg Q := completion.cpkg
+def Bourbaki_pkg : abstract_completion Q := completion.cpkg
 
 /-- The equivalence between Bourbaki and Cauchy reals-/
 noncomputable def compare_equiv : Bourbakiℝ ≃ ℝ :=

--- a/src/topology/uniform_space/compare_reals.lean
+++ b/src/topology/uniform_space/compare_reals.lean
@@ -99,7 +99,7 @@ instance : uniform_space Q := is_absolute_value.uniform_space (abs : ℚ → ℚ
 /-- Real numbers constructed as in Bourbaki. -/
 def Bourbakiℝ : Type := completion Q
 
-instance : uniform_space Bourbakiℝ := completion.uniform_space Q
+instance bourbaki.uniform_space: uniform_space Bourbakiℝ := completion.uniform_space Q
 
 /-- Bourbaki reals packaged as a completion of Q using the general theory. -/
 def Bourbaki_pkg : abstract_completion Q := completion.cpkg

--- a/src/topology/uniform_space/compare_reals.lean
+++ b/src/topology/uniform_space/compare_reals.lean
@@ -86,6 +86,7 @@ def rational_cau_seq_pkg : @abstract_completion ℚ $ is_absolute_value.uniform_
                            exact uniform_embedding_of_rat.to_uniform_inducing },
   dense := dense_embedding_of_rat.dense }
 
+namespace compare_reals
 /-- Type wrapper around ℚ to make sure the absolute value uniform space instance is picked up
 instead of the metric space one. We proved in rat.uniform_space_eq that they are equal,
 but they are not definitionaly equal, so it would confuse the type class system (and probably
@@ -112,3 +113,4 @@ Bourbaki_pkg.uniform_continuous_compare_equiv _
 
 lemma compare_uc_symm : uniform_continuous (compare_equiv).symm :=
 Bourbaki_pkg.uniform_continuous_compare_equiv_symm _
+end compare_reals

--- a/src/topology/uniform_space/compare_reals.lean
+++ b/src/topology/uniform_space/compare_reals.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2019 Patrick MAssot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Patrick Massot
+-/
+
+import topology.uniform_space.absolute_value
+import topology.instances.real
+import topology.uniform_space.completion
+
+/-!
+# Comparison of Cauchy reals and Bourbaki reals
+
+In `data.real.basic` real numbers are defined using the so called Cauchy construction (although
+it is due to Georg Canter). More precisely, this construction applies to commutative rings equipped
+with an absolute value with values in a linear ordered field.
+
+On the other hand, in the `uniform_space` folder, we construct completions of general uniform
+spaces, which allows to construct the Bourbaki real numbers. In this file we build uniformly
+continuous bijections from Cauchy reals to Bourbaki reals and back. This is a cross sanity check of
+both constructions. Of course those two constructions are variations on the completion idea, simply
+with different level of generality. Comparing with Dedekind cuts or quasi-morphisms would be of a
+completely different nature.
+
+Note that `metric_space/cau_seq_filter` also relates the notions of Cauchy sequences in metric
+spaces and Cauchy filters in general uniform spaces, and `metric_space/completion` makes sure
+the completion (as a uniform space) of a metric space is a metric space.
+
+Historical note: mathlib used to define real numbers in an intermediate way, using completion
+of uniform spaces but extending multiplication in an ad-hoc way.
+
+TODO:
+* Upgrade this isomorphism to a topological ring isomorphism.
+* Do the same comparison for p-adic numbers
+
+## Implementation notes
+
+The heavy work is done in `topology/uniform_space/completion_pkg` which provides an abstract
+caracterization of completions of uniform spaces, and isomorphisms between them. The only work left
+here is to prove the uniform space structure coming from the absolute value on ℚ (with values in ℚ,
+not referring to ℝ) coincides with the one coming from the metric space structure (which of course
+does use ℝ).
+
+## References
+
+* [N. Bourbaki, *Topologie générale*][bourbaki1966]
+
+## Tags
+
+real numbers, completion, uniform spaces
+-/
+
+open set function lattice filter cau_seq uniform_space
+
+/-- The metric space uniform structure on ℚ (which presupposes the existence
+of real numbers) agrees with the one coming directly from (abs : ℚ → ℚ). -/
+lemma rat.uniform_space_eq :
+  is_absolute_value.uniform_space (abs : ℚ → ℚ) = metric_space.to_uniform_space' :=
+begin
+  ext s,
+  erw [metric.mem_uniformity_dist, is_absolute_value.mem_uniformity],
+  split ; rintro ⟨ε, ε_pos, h⟩,
+  { use [ε, by exact_mod_cast ε_pos],
+    intros a b hab,
+    apply h,
+    rw [rat.dist_eq, abs_sub] at hab,
+    exact_mod_cast hab },
+  { obtain ⟨ε', h', h''⟩ : ∃ ε' : ℚ, 0 < ε' ∧ (ε' : ℝ) < ε, from exists_pos_rat_lt ε_pos,
+    use [ε', h'],
+    intros a b hab,
+    apply h,
+    rw [rat.dist_eq, abs_sub],
+    refine lt_trans _ h'',
+    exact_mod_cast hab }
+end
+
+/-- Cauchy reals packaged as a completion of ℚ using the absolute value route. -/
+noncomputable
+def rational_cau_seq_pkg : @completion_pkg ℚ $ is_absolute_value.uniform_space (abs : ℚ → ℚ) :=
+{ space := ℝ,
+  coe := (coe : ℚ → ℝ),
+  uniform_struct := by apply_instance,
+  complete :=  by apply_instance,
+  separation :=  by apply_instance,
+  uniform_inducing := by { rw rat.uniform_space_eq,
+                           exact uniform_embedding_of_rat.to_uniform_inducing },
+  dense := dense_embedding_of_rat.dense }
+
+/-- Type wrapper around ℚ to make sure the absolute value uniform space instance is picked up
+instead of the metric space one. We proved in rat.uniform_space_eq that they are equal,
+but they are not definitionaly equal, so it would confuse the type class system (and probably
+also human readers). -/
+def Q := ℚ
+
+instance : comm_ring Q := by unfold Q ; apply_instance
+instance : uniform_space Q := is_absolute_value.uniform_space (abs : ℚ → ℚ)
+
+/-- Real numbers constructed as in Bourbaki. -/
+def Bourbakiℝ : Type := completion Q
+
+instance : uniform_space Bourbakiℝ := completion.uniform_space Q
+
+/-- Bourbaki reals packaged as a completion of Q using the general theory. -/
+def Bourbaki_pkg : completion_pkg Q := completion.cpkg
+
+/-- The equivalence between Bourbaki and Cauchy reals-/
+noncomputable def compare_equiv : Bourbakiℝ ≃ ℝ :=
+Bourbaki_pkg.compare_equiv rational_cau_seq_pkg
+
+lemma compare_uc : uniform_continuous (compare_equiv) :=
+Bourbaki_pkg.uniform_continuous_compare_equiv _
+
+lemma compare_uc_symm : uniform_continuous (compare_equiv).symm :=
+Bourbaki_pkg.uniform_continuous_compare_equiv_symm _

--- a/src/topology/uniform_space/compare_reals.lean
+++ b/src/topology/uniform_space/compare_reals.lean
@@ -12,7 +12,7 @@ import topology.uniform_space.completion
 # Comparison of Cauchy reals and Bourbaki reals
 
 In `data.real.basic` real numbers are defined using the so called Cauchy construction (although
-it is due to Georg Canter). More precisely, this construction applies to commutative rings equipped
+it is due to Georg Cantor). More precisely, this construction applies to commutative rings equipped
 with an absolute value with values in a linear ordered field.
 
 On the other hand, in the `uniform_space` folder, we construct completions of general uniform

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -475,10 +475,7 @@ cpkg.extend f
 variables [separated β]
 
 @[simp] lemma extension_coe (hf : uniform_continuous f) (a : α) : (completion.extension f) a = f a :=
-begin
-  rw [completion.extension, if_pos hf],
-  exact dense_inducing_coe.extend_eq_of_cont hf.continuous a
-end
+cpkg.extend_coe hf a
 
 variables [complete_space β]
 
@@ -487,9 +484,6 @@ cpkg.uniform_continuous_extend
 
 lemma continuous_extension : continuous (completion.extension f) :=
 cpkg.continuous_extend
-
-@[simp] lemma extension_coe (hf : uniform_continuous f) (a : α) : (completion.extension f) a = f a :=
-cpkg.extend_coe hf a
 
 lemma extension_unique (hf : uniform_continuous f) {g : completion α → β} (hg : uniform_continuous g)
   (h : ∀ a : α, f a = g (a : completion α)) : completion.extension f = g :=
@@ -580,18 +574,13 @@ variables [separated γ] {f}
 
 @[simp] lemma extension₂_coe_coe (hf : uniform_continuous $ uncurry' f) (a : α) (b : β) :
   completion.extension₂ f a b = f a b :=
-by simpa [completion.extension₂, curry, (prod_coe_coe _ _).symm, extension_coe hf]
+cpkg.extension₂_coe_coe cpkg hf a b
 
 variables [complete_space γ] (f)
 
 lemma uniform_continuous_extension₂ : uniform_continuous₂ (completion.extension₂ f) :=
 cpkg.uniform_continuous_extension₂ cpkg f
 
-variables {f}
-
-@[simp] lemma extension₂_coe_coe (hf : uniform_continuous $ uncurry' f) (a : α) (b : β) :
-  completion.extension₂ f a b = f a b :=
-cpkg.extension₂_coe_coe cpkg hf a b
 end extension₂
 
 section map₂

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -35,10 +35,10 @@ This formalization is mostly based on
 From a slightly different perspective in order to reuse material in topology.uniform_space.basic.
 -/
 import data.set.basic
-import topology.uniform_space.uniform_embedding topology.uniform_space.separation
+import topology.uniform_space.completion_pkg topology.uniform_space.separation
 
 noncomputable theory
-local attribute [instance] classical.prop_decidable
+local attribute [instance, priority 0] classical.prop_decidable
 open filter set
 universes u v w x
 
@@ -341,26 +341,10 @@ instance : t2_space (completion α) := separated_t2
 
 instance : regular_space (completion α) := separated_regular
 
-lemma nonempty_completion_iff : nonempty (completion α) ↔ nonempty α :=
-begin
-  conv_rhs { rw ← nonempty_Cauchy_iff },
-  split ; rintro ⟨c⟩,
-  { rcases quotient.exists_rep c with ⟨a, _⟩,
-    exact ⟨a⟩ },
-  { exact ⟨⟦c⟧⟩ }
-end
-
 /-- Automatic coercion from `α` to its completion. Not always injective. -/
 instance : has_coe α (completion α) := ⟨quotient.mk ∘ pure_cauchy⟩
 
 protected lemma coe_eq : (coe : α → completion α) = quotient.mk ∘ pure_cauchy := rfl
-
-lemma uniform_continuous_coe : uniform_continuous (coe : α → completion α) :=
-uniform_continuous.comp
-  uniform_continuous_quotient_mk uniform_inducing_pure_cauchy.uniform_continuous
-
-lemma continuous_coe : continuous (coe : α → completion α) :=
-uniform_continuous.continuous (uniform_continuous_coe α)
 
 lemma comap_coe_eq_uniformity :
   (𝓤 _).comap (λ(p:α×α), ((p.1 : completion α), (p.2 : completion α))) = 𝓤 α :=
@@ -376,14 +360,39 @@ end
 lemma uniform_inducing_coe : uniform_inducing  (coe : α → completion α) :=
 ⟨comap_coe_eq_uniformity α⟩
 
+variables {α}
+
+lemma dense : closure (range (coe : α → completion α)) = univ :=
+by rw [completion.coe_eq, range_comp]; exact quotient_dense_of_dense pure_cauchy_dense
+
+variables (α)
+
+def cpkg {α : Type*} [uniform_space α] : completion_pkg α :=
+{ space := completion α,
+  coe := coe,
+  uniform_struct := by apply_instance,
+  complete := by apply_instance,
+  separation := by apply_instance,
+  uniform_inducing := completion.uniform_inducing_coe α,
+  dense := (dense_range_iff_closure_eq _).2 completion.dense }
+
+local attribute [instance]
+completion_pkg.uniform_struct completion_pkg.complete completion_pkg.separation
+
+lemma nonempty_completion_iff : nonempty (completion α) ↔ nonempty α :=
+(dense_range.nonempty (cpkg.dense)).symm
+
+lemma uniform_continuous_coe : uniform_continuous (coe : α → completion α) :=
+cpkg.uniform_continuous_coe
+
+lemma continuous_coe : continuous (coe : α → completion α) :=
+cpkg.continuous_coe
+
 lemma uniform_embedding_coe [separated α] : uniform_embedding  (coe : α → completion α) :=
 { comap_uniformity := comap_coe_eq_uniformity α,
   inj := injective_separated_pure_cauchy }
 
 variable {α}
-
-lemma dense : closure (range (coe : α → completion α)) = univ :=
-by rw [completion.coe_eq, range_comp]; exact quotient_dense_of_dense pure_cauchy_dense
 
 lemma dense_inducing_coe : dense_inducing (coe : α → completion α) :=
 { dense := (dense_range_iff_closure_eq _).2 dense,
@@ -453,7 +462,7 @@ this ((a, b), (c, d))
 
 lemma ext [t2_space β] {f g : completion α → β} (hf : continuous f) (hg : continuous g)
   (h : ∀a:α, f a = g a) : f = g :=
-funext $ assume a, completion.induction_on a (is_closed_eq hf hg) h
+cpkg.funext hf hg h
 
 section extension
 variables {f : α → β}
@@ -461,10 +470,7 @@ variables {f : α → β}
 /-- "Extension" to the completion. It is defined for any map `f` but
 returns an arbitrary constant value if `f` is not uniformly continuous -/
 protected def extension (f : α → β) : completion α → β :=
-if uniform_continuous f then
-  dense_inducing_coe.extend f
-else
-  λ x, f (classical.inhabited_of_nonempty $ (nonempty_completion_iff α).1 ⟨x⟩).default
+cpkg.extend f
 
 variables [separated β]
 
@@ -477,29 +483,21 @@ end
 variables [complete_space β]
 
 lemma uniform_continuous_extension : uniform_continuous (completion.extension f) :=
-begin
-  by_cases hf : uniform_continuous f,
-  { rw [completion.extension, if_pos hf],
-    exact uniform_continuous_uniformly_extend (uniform_inducing_coe α)
-      ((dense_range_iff_closure_eq _).2 dense) hf },
-  { rw [completion.extension, if_neg hf],
-    exact uniform_continuous_of_const (assume a b, by congr) }
-end
+cpkg.uniform_continuous_extend
 
 lemma continuous_extension : continuous (completion.extension f) :=
-uniform_continuous_extension.continuous
+cpkg.continuous_extend
+
+@[simp] lemma extension_coe (hf : uniform_continuous f) (a : α) : (completion.extension f) a = f a :=
+cpkg.extend_coe hf a
 
 lemma extension_unique (hf : uniform_continuous f) {g : completion α → β} (hg : uniform_continuous g)
   (h : ∀ a : α, f a = g (a : completion α)) : completion.extension f = g :=
-begin
-  apply completion.ext uniform_continuous_extension.continuous hg.continuous,
-  simpa only [extension_coe hf] using h
-end
+cpkg.extend_unique hf hg h
 
 @[simp] lemma extension_comp_coe {f : completion α → β} (hf : uniform_continuous f) :
   completion.extension (f ∘ coe) = f :=
-funext $ λ x, completion.induction_on x (is_closed_eq continuous_extension hf.continuous)
-    (λ y, completion.extension_coe (hf.comp $ uniform_continuous_coe α) y)
+cpkg.extend_comp_coe hf
 end extension
 
 section map
@@ -507,28 +505,23 @@ variables {f : α → β}
 
 /-- Completion functor acting on morphisms -/
 protected def map (f : α → β) : completion α → completion β :=
-completion.extension (coe ∘ f)
+cpkg.map cpkg f
 
 lemma uniform_continuous_map : uniform_continuous (completion.map f) :=
-uniform_continuous_extension
+cpkg.uniform_continuous_map cpkg f
 
 lemma continuous_map : continuous (completion.map f) :=
-uniform_continuous_extension.continuous
+cpkg.continuous_map cpkg f
 
 @[simp] lemma map_coe (hf : uniform_continuous f) (a : α) : (completion.map f) a = f a :=
-by rw [completion.map, extension_coe]; from (uniform_continuous_coe β).comp hf
+cpkg.map_coe cpkg hf a
 
 lemma map_unique {f : α → β} {g : completion α → completion β}
   (hg : uniform_continuous g) (h : ∀a:α, ↑(f a) = g a) : completion.map f = g :=
-completion.ext continuous_map hg.continuous $
-begin
-  intro a,
-  simp only [completion.map, (∘), h],
-  rw [extension_coe (hg.comp (uniform_continuous_coe α))]
-end
+cpkg.map_unique cpkg hg h
 
 @[simp] lemma map_id : completion.map (@id α) = id :=
-map_unique uniform_continuous_id (assume a, rfl)
+cpkg.map_id
 
 lemma extension_map [complete_space γ] [separated γ] {f : β → γ} {g : α → β}
   (hf : uniform_continuous f) (hg : uniform_continuous g) :
@@ -576,32 +569,12 @@ uniform_continuous_map
 
 end separation_quotient_completion
 
-section prod
-
-protected def prod {α β} [uniform_space α] [uniform_space β] :
-  completion α × completion β → completion (α × β) :=
-dense_inducing.extend (dense_inducing_coe.prod dense_inducing_coe) coe
-
-lemma uniform_continuous_prod : uniform_continuous (@completion.prod α β _ _) :=
-uniform_continuous_uniformly_extend
-  ((uniform_inducing_coe α).prod $ uniform_inducing_coe β)
-  (eq_univ_iff_forall.1 dense₂)
-  (uniform_continuous_coe _)
-
-@[move_cast]
-lemma prod_coe_coe (a : α) (b : β) : coe (a, b) =
-  completion.prod ((a : completion α), (b : completion β)) :=
-(dense_inducing.extend_eq_of_cont (dense_inducing_coe.prod dense_inducing_coe)
-  (continuous_coe $ α × β) (a, b)).symm
-
-end prod
-
 section extension₂
 variables (f : α → β → γ)
 open function
 
 protected def extension₂ (f : α → β → γ) : completion α → completion β → γ :=
-curry $ completion.extension (uncurry' f) ∘ completion.prod
+cpkg.extend₂ cpkg f
 
 variables [separated γ] {f}
 
@@ -612,30 +585,32 @@ by simpa [completion.extension₂, curry, (prod_coe_coe _ _).symm, extension_coe
 variables [complete_space γ] (f)
 
 lemma uniform_continuous_extension₂ : uniform_continuous₂ (completion.extension₂ f) :=
-begin
-  rw [uniform_continuous₂_def, completion.extension₂, uncurry'_curry],
-  exact uniform_continuous_extension.comp uniform_continuous_prod,
-end
+cpkg.uniform_continuous_extension₂ cpkg f
 
+variables {f}
+
+@[simp] lemma extension₂_coe_coe (hf : uniform_continuous $ uncurry' f) (a : α) (b : β) :
+  completion.extension₂ f a b = f a b :=
+cpkg.extension₂_coe_coe cpkg hf a b
 end extension₂
 
 section map₂
 open function
 
 protected def map₂ (f : α → β → γ) : completion α → completion β → completion γ :=
-completion.extension₂ (coe ∘ f)
+cpkg.map₂ cpkg cpkg f
 
 lemma uniform_continuous_map₂ (f : α → β → γ) : uniform_continuous (uncurry' $ completion.map₂ f) :=
-uniform_continuous_extension₂ _
+cpkg.uniform_continuous_map₂ cpkg cpkg f
 
 lemma continuous_map₂ {δ} [topological_space δ] {f : α → β → γ}
   {a : δ → completion α} {b : δ → completion β} (ha : continuous a) (hb : continuous b) :
   continuous (λd:δ, completion.map₂ f (a d) (b d)) :=
-((uniform_continuous_map₂ f).continuous.comp (continuous.prod_mk ha hb) : _)
+cpkg.continuous_map₂ cpkg cpkg ha hb
 
 lemma map₂_coe_coe (a : α) (b : β) (f : α → β → γ) (hf : uniform_continuous $ uncurry' f) :
   completion.map₂ f (a : completion α) (b : completion β) = f a b :=
-completion.extension₂_coe_coe ((uniform_continuous_coe γ).comp hf) a b
+cpkg.map₂_coe_coe cpkg cpkg a b f hf
 
 end map₂
 end completion

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -35,7 +35,7 @@ This formalization is mostly based on
 From a slightly different perspective in order to reuse material in topology.uniform_space.basic.
 -/
 import data.set.basic
-import topology.uniform_space.completion_pkg topology.uniform_space.separation
+import topology.uniform_space.abstract_completion topology.uniform_space.separation
 
 noncomputable theory
 local attribute [instance, priority 0] classical.prop_decidable
@@ -367,7 +367,7 @@ by rw [completion.coe_eq, range_comp]; exact quotient_dense_of_dense pure_cauchy
 
 variables (α)
 
-def cpkg {α : Type*} [uniform_space α] : completion_pkg α :=
+def cpkg {α : Type*} [uniform_space α] : abstract_completion α :=
 { space := completion α,
   coe := coe,
   uniform_struct := by apply_instance,
@@ -377,7 +377,7 @@ def cpkg {α : Type*} [uniform_space α] : completion_pkg α :=
   dense := (dense_range_iff_closure_eq _).2 completion.dense }
 
 local attribute [instance]
-completion_pkg.uniform_struct completion_pkg.complete completion_pkg.separation
+abstract_completion.uniform_struct abstract_completion.complete abstract_completion.separation
 
 lemma nonempty_completion_iff : nonempty (completion α) ↔ nonempty α :=
 (dense_range.nonempty (cpkg.dense)).symm

--- a/src/topology/uniform_space/completion_pkg.lean
+++ b/src/topology/uniform_space/completion_pkg.lean
@@ -10,7 +10,7 @@ import topology.uniform_space.uniform_embedding
 /-!
 # Abstract theory of Hausdorff completions of uniform spaces
 
-This file caracterizes Hausdorff completions of a uniform space α as complete Hausdorff spaces
+This file characterizes Hausdorff completions of a uniform space α as complete Hausdorff spaces
 equipped with a map from α which has dense image and induce the original uniform structure on α.
 Assuming these properties we "extend" uniformly continuous maps from α to complete Hausdorff spaces
 to the completions of α. This is the universal property expected from a completion.
@@ -35,7 +35,7 @@ derived from the predicate is more universe polymorphic.
 
 ## References
 
-We don't know any traditionnal text discussing this. Real world mathematics simply silently
+We don't know any traditional text discussing this. Real world mathematics simply silently
 identify the results of any two constructions that lead to something one could reasonnably
 call a completion.
 

--- a/src/topology/uniform_space/completion_pkg.lean
+++ b/src/topology/uniform_space/completion_pkg.lean
@@ -1,0 +1,313 @@
+/-
+Copyright (c) 2019 Patrick Massot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Patrick Massot
+-/
+
+import topology.uniform_space.cauchy
+import topology.uniform_space.uniform_embedding
+
+/-!
+# Abstract theory of Hausdorff completions of uniform spaces
+
+This file caracterizes Hausdorff completions of a uniform space α as complete Hausdorff spaces
+equipped with a map from α which has dense image and induce the original uniform structure on α.
+Assuming these properties we "extend" uniformly continuous maps from α to complete Hausdorff spaces
+to the completions of α. This is the universal property expected from a completion.
+It is then used to extend uniformly continuous maps from α to α' to maps between
+completions of α and α'.
+
+This file does not construct any such completion, it only study consequences of their existence.
+The first advantage is that formal properties are clearly highlighted without interference from
+construction details. The second advantage is that this framework can then be used to compare
+different completion constructions. See `topology/uniform_space/compare_reals` for an example.
+Of course the comparison comes from the universal property as usual.
+
+A general explicit construction of completions is done in `uniform_space/completion`, leading
+to a functor from uniform spaces to complete Hausdorff uniform spaces that is left adjoint to the
+inclusion, see `uniform_space/UniformSpace` for the category packaging.
+
+## Implementation notes
+
+A tiny technical advantage of using a characteristic predicate such as the properties listed in
+`completion_pkg` instead of stating the universal property is that the universal property
+derived from the predicate is more universe polymorphic.
+
+## References
+
+We don't know any traditionnal text discussing this. Real world mathematics simply silently
+identify the results of any two constructions that lead to something one could reasonnably
+call a completion.
+
+## Tags
+
+uniform spaces, completion, universal property
+-/
+
+noncomputable theory
+local attribute [instance, priority 0] classical.prop_decidable
+
+open filter set function
+
+universes u
+/-- A completion of `α` is the data of a complete separated uniform space (from the same universe)
+and a map from `α` with dense range and inducing the original uniform structure on `α`. -/
+structure completion_pkg (α : Type u) [uniform_space α] :=
+(space : Type u)
+(coe : α → space)
+(uniform_struct : uniform_space space)
+(complete : complete_space space)
+(separation : separated space)
+(uniform_inducing : uniform_inducing coe)
+(dense : dense_range coe)
+
+local attribute [instance]
+completion_pkg.uniform_struct completion_pkg.complete completion_pkg.separation
+
+namespace completion_pkg
+variables {α : Type*} [uniform_space α] (pkg : completion_pkg α)
+local notation `hatα` := pkg.space
+local notation `ι` := pkg.coe
+
+lemma dense' : closure (range ι) = univ :=
+(dense_range_iff_closure_eq _).1 pkg.dense
+
+lemma dense_inducing : dense_inducing ι :=
+⟨pkg.uniform_inducing.inducing, pkg.dense⟩
+
+lemma uniform_continuous_coe : uniform_continuous ι :=
+uniform_inducing.uniform_continuous pkg.uniform_inducing
+
+lemma continuous_coe : continuous ι :=
+pkg.uniform_continuous_coe.continuous
+
+@[elab_as_eliminator]
+lemma induction_on {p : hatα → Prop}
+  (a : hatα) (hp : is_closed {a | p a}) (ih : ∀ a, p (ι a)) : p a :=
+is_closed_property pkg.dense' hp ih a
+
+variables {β : Type*} [uniform_space β]
+
+protected lemma funext [t2_space β] {f g : hatα → β} (hf : continuous f) (hg : continuous g)
+  (h : ∀ a, f (ι a) = g (ι a)) : f = g :=
+funext $ assume a, pkg.induction_on a (is_closed_eq hf hg) h
+
+section extend
+/-- Extension of maps to completions -/
+protected def extend (f : α → β) : hatα → β :=
+if uniform_continuous f then
+  pkg.dense_inducing.extend f
+else
+  λ x, f (classical.inhabited_of_nonempty $ pkg.dense.nonempty.2 ⟨x⟩).default
+
+variables {f : α → β}
+
+lemma extend_def (hf : uniform_continuous f) : pkg.extend f = pkg.dense_inducing.extend f :=
+if_pos hf
+
+lemma extend_coe [t2_space β] (hf : uniform_continuous f) (a : α) :
+(pkg.extend f) (ι a) = f a :=
+begin
+  rw pkg.extend_def hf,
+  exact pkg.dense_inducing.extend_eq_of_cont hf.continuous a
+end
+
+variables [complete_space β] [separated β]
+
+lemma uniform_continuous_extend : uniform_continuous (pkg.extend f) :=
+begin
+  by_cases hf : uniform_continuous f,
+  { rw pkg.extend_def hf,
+    exact uniform_continuous_uniformly_extend (pkg.uniform_inducing)
+      (pkg.dense) hf },
+  { change uniform_continuous (ite _ _ _),
+    rw if_neg hf,
+    exact uniform_continuous_of_const (assume a b, by congr) }
+end
+
+lemma continuous_extend : continuous (pkg.extend f) :=
+pkg.uniform_continuous_extend.continuous
+
+lemma extend_unique (hf : uniform_continuous f) {g : hatα → β} (hg : uniform_continuous g)
+  (h : ∀ a : α, f a = g (ι a)) : pkg.extend f = g :=
+begin
+  apply pkg.funext pkg.continuous_extend hg.continuous,
+  simpa only [pkg.extend_coe hf] using h
+end
+
+@[simp] lemma extend_comp_coe {f : hatα → β} (hf : uniform_continuous f) :
+  pkg.extend (f ∘ ι) = f :=
+funext $ λ x, pkg.induction_on x (is_closed_eq pkg.continuous_extend hf.continuous)
+    (λ y, pkg.extend_coe (hf.comp $ pkg.uniform_continuous_coe) y)
+
+end extend
+
+section map_sec
+
+variables (pkg' : completion_pkg β)
+local notation `hatβ` := pkg'.space
+local notation `ι'` := pkg'.coe
+
+/-- Lifting maps to completions -/
+protected def map (f : α → β) : hatα → hatβ := pkg.extend (ι' ∘ f)
+
+local notation `map` := pkg.map pkg'
+
+variables (f : α → β)
+
+lemma uniform_continuous_map : uniform_continuous (map f) :=
+pkg.uniform_continuous_extend
+
+lemma continuous_map : continuous (map f) := pkg.continuous_extend
+
+variables {f}
+
+@[simp] lemma map_coe (hf : uniform_continuous f) (a : α) : map f (ι a) = ι' (f a) :=
+pkg.extend_coe (pkg'.uniform_continuous_coe.comp hf) a
+
+lemma map_unique {f : α → β} {g : hatα → hatβ}
+  (hg : uniform_continuous g) (h : ∀ a, ι' (f a) = g (ι a)) : map f = g :=
+pkg.funext (pkg.continuous_map _ _) hg.continuous $
+begin
+  intro a,
+  change pkg.extend (ι' ∘ f) _ = _,
+  simp only [(∘), h],
+  rw [pkg.extend_coe (hg.comp pkg.uniform_continuous_coe)]
+end
+
+@[simp] lemma map_id : pkg.map pkg id = id :=
+pkg.map_unique pkg uniform_continuous_id (assume a, rfl)
+
+variables {γ : Type*} [uniform_space γ]
+
+lemma extend_map [complete_space γ] [separated γ] {f : β → γ} {g : α → β}
+  (hf : uniform_continuous f) (hg : uniform_continuous g) :
+  pkg'.extend f ∘ map g = pkg.extend (f ∘ g) :=
+pkg.funext (pkg'.continuous_extend.comp (pkg.continuous_map pkg' _)) pkg.continuous_extend $ λ a,
+  by rw [pkg.extend_coe (hf.comp hg), comp_app, pkg.map_coe pkg' hg, pkg'.extend_coe hf]
+
+variables (pkg'' : completion_pkg γ)
+
+lemma map_comp {g : β → γ} {f : α → β} (hg : uniform_continuous g) (hf : uniform_continuous f) :
+  (pkg'.map pkg'' g) ∘ (pkg.map pkg' f) = pkg.map pkg'' (g ∘ f) :=
+pkg.extend_map pkg' (pkg''.uniform_continuous_coe.comp hg) hf
+
+end map_sec
+
+section compare
+-- We can now compare two completion packages for the same uniform space
+
+variables (pkg' : completion_pkg α)
+
+/-- The comparison map between two completions of the same uniform space. -/
+def compare : pkg.space → pkg'.space :=
+pkg.extend pkg'.coe
+
+lemma uniform_continuous_compare : uniform_continuous (pkg.compare pkg') :=
+pkg.uniform_continuous_extend
+
+lemma compare_coe (a : α) : pkg.compare pkg' (pkg.coe a) = pkg'.coe a :=
+pkg.extend_coe pkg'.uniform_continuous_coe a
+
+lemma inverse_compare : (pkg.compare pkg') ∘ (pkg'.compare pkg) = id :=
+begin
+  have uc := pkg.uniform_continuous_compare pkg',
+  have uc' := pkg'.uniform_continuous_compare pkg,
+  apply pkg'.funext (uc.comp uc').continuous continuous_id,
+  intro a,
+  rw [comp_app, pkg'.compare_coe pkg, pkg.compare_coe pkg'],
+  refl
+end
+
+/-- The bijection between two completions of the same uniform space. -/
+def compare_equiv : pkg.space ≃ pkg'.space :=
+{ to_fun := pkg.compare pkg',
+  inv_fun := pkg'.compare pkg,
+  left_inv := congr_fun (pkg'.inverse_compare pkg),
+  right_inv := congr_fun (pkg.inverse_compare pkg') }
+
+lemma uniform_continuous_compare_equiv : uniform_continuous (pkg.compare_equiv pkg') :=
+pkg.uniform_continuous_compare pkg'
+
+lemma uniform_continuous_compare_equiv_symm : uniform_continuous (pkg.compare_equiv pkg').symm :=
+pkg'.uniform_continuous_compare pkg
+
+end compare
+
+section prod
+variables (pkg' : completion_pkg β)
+local notation `hatβ` := pkg'.space
+local notation `ι'` := pkg'.coe
+
+/-- Products of completions -/
+protected def prod : completion_pkg (α × β) :=
+{ space := hatα × hatβ,
+  coe := λ p, ⟨ι p.1, ι' p.2⟩,
+  uniform_struct := prod.uniform_space,
+  complete := by apply_instance,
+  separation := by apply_instance,
+  uniform_inducing := uniform_inducing.prod pkg.uniform_inducing pkg'.uniform_inducing,
+  dense := dense_range_prod pkg.dense pkg'.dense }
+end prod
+
+
+
+section extension₂
+variables (pkg' : completion_pkg β)
+local notation `hatβ` := pkg'.space
+local notation `ι'` := pkg'.coe
+
+variables {γ : Type*} [uniform_space γ]
+
+open function
+
+/-- Extend two variable map to completions. -/
+protected def extend₂ (f : α → β → γ) : hatα → hatβ → γ :=
+curry $ (pkg.prod pkg').extend (uncurry' f)
+
+variables [separated γ] {f : α → β → γ}
+
+lemma extension₂_coe_coe (hf : uniform_continuous $ uncurry' f) (a : α) (b : β) :
+  pkg.extend₂ pkg' f (ι a) (ι' b) = f a b :=
+show (pkg.prod pkg').extend (uncurry' f) ((pkg.prod pkg').coe (a, b)) = uncurry' f (a, b),
+  from (pkg.prod pkg').extend_coe hf _
+
+variables [complete_space γ] (f)
+
+lemma uniform_continuous_extension₂ : uniform_continuous₂ (pkg.extend₂ pkg' f) :=
+begin
+  rw [uniform_continuous₂_def, completion_pkg.extend₂, uncurry'_curry],
+  apply uniform_continuous_extend
+end
+
+end extension₂
+
+section map₂
+variables (pkg' : completion_pkg β)
+local notation `hatβ` := pkg'.space
+local notation `ι'` := pkg'.coe
+
+variables {γ : Type*} [uniform_space γ] (pkg'' : completion_pkg γ)
+local notation `hatγ` := pkg''.space
+local notation `ι''` := pkg''.coe
+
+local notation f `∘₂` g := bicompr f g
+
+/-- Lift two variable maps to completions. -/
+protected def map₂ (f : α → β → γ) : hatα → hatβ → hatγ :=
+pkg.extend₂ pkg' (pkg''.coe ∘₂ f)
+
+lemma uniform_continuous_map₂ (f : α → β → γ) : uniform_continuous (uncurry' $ pkg.map₂ pkg' pkg'' f) :=
+pkg.uniform_continuous_extension₂ pkg' _
+
+lemma continuous_map₂ {δ} [topological_space δ] {f : α → β → γ}
+  {a : δ → hatα} {b : δ → hatβ} (ha : continuous a) (hb : continuous b) :
+  continuous (λd:δ, pkg.map₂ pkg' pkg'' f (a d) (b d)) :=
+((pkg.uniform_continuous_map₂ pkg' pkg'' f).continuous.comp (continuous.prod_mk ha hb) : _)
+
+lemma map₂_coe_coe (a : α) (b : β) (f : α → β → γ) (hf : uniform_continuous₂ f) :
+  pkg.map₂ pkg' pkg'' f (ι a) (ι' b) = ι'' (f a b) :=
+pkg.extension₂_coe_coe pkg' (pkg''.uniform_continuous_coe.comp hf) a b
+
+end map₂
+end completion_pkg


### PR DESCRIPTION
Define abstract completions, study their properties and derived constructions. Use this study in the concrete completion files, and for comparing completions constructed at different level of generality, especially for real numbers.

See the headers of `completion_pkg.lean` and `compare_reals.lean` for more details.

This comes from the perfectoid spaces project.
