### PR TITLE
chore(algebra/Mon): update the category of monoids to use bundled homs

### DIFF
--- a/src/algebra/CommRing/basic.lean
+++ b/src/algebra/CommRing/basic.lean
@@ -7,7 +7,7 @@ Introduce CommRing -- the category of commutative rings.
 
 import algebra.Mon.basic
 import category_theory.fully_faithful
-import algebra.ring
+import algebra.ring.hom
 import data.int.basic
 
 universes u v

--- a/src/algebra/CommRing/basic.lean
+++ b/src/algebra/CommRing/basic.lean
@@ -7,7 +7,7 @@ Introduce CommRing -- the category of commutative rings.
 
 import algebra.Mon.basic
 import category_theory.fully_faithful
-import algebra.ring.hom
+import algebra.ring
 import data.int.basic
 
 universes u v
@@ -77,7 +77,7 @@ instance to_Ring.faithful : faithful (to_Ring) := {}
 /-- The forgetful functor from commutative rings to (multiplicative) commutative monoids. -/
 def forget_to_CommMon : CommRing.{u} ⥤ CommMon.{u} :=
 { obj := λ X, { α := X.1 },
-  map := λ X Y f, ⟨ f, by apply_instance ⟩ }
+  map := λ X Y f, as_monoid_hom f }
 
 instance forget_to_CommMon.faithful : faithful (forget_to_CommMon) := {}
 

--- a/src/algebra/CommRing/colimits.lean
+++ b/src/algebra/CommRing/colimits.lean
@@ -312,10 +312,6 @@ def colimit_cocone : cocone F :=
 | (add x y) := desc_fun_lift x + desc_fun_lift y
 | (mul x y) := desc_fun_lift x * desc_fun_lift y
 
-@[simp] lemma naturality_bundled {G : J ⥤ CommRing} (s : cocone G) {j j' : J} (f : j ⟶ j') (x : G.obj j) :
-  (s.ι.app j') ((G.map f) x) = (s.ι.app j) x :=
-congr_fun (congr_arg (λ k : G.obj j ⟶ s.X, (k : G.obj j → s.X)) (s.ι.naturality f)) x
-
 def desc_fun (s : cocone F) : colimit_type F → s.X :=
 begin
   fapply quot.lift,
@@ -329,7 +325,7 @@ begin
     -- trans
     { exact eq.trans r_ih_h r_ih_k },
     -- map
-    { rw naturality_bundled, },
+    { rw cocone.naturality_bundled, },
     -- zero
     { erw is_ring_hom.map_zero ⇑((s.ι).app r), refl },
     -- one

--- a/src/algebra/Mon/basic.lean
+++ b/src/algebra/Mon/basic.lean
@@ -25,6 +25,7 @@ namespace Mon
 
 instance (x : Mon) : monoid x := x.str
 
+-- TODO a tactic, so we could write `by bundled_hom monoid_hom`?
 instance : bundled_hom.{u} monoid :=
 { hom := λ X Y _ _, by exactI X →* Y,
   to_fun := λ X Y _ _ f, by exactI f.to_fun,

--- a/src/algebra/Mon/basic.lean
+++ b/src/algebra/Mon/basic.lean
@@ -7,7 +7,7 @@ Introduce Mon -- the category of monoids.
 Currently only the basic setup.
 -/
 
-import category_theory.concrete_category algebra.group
+import category_theory.concrete_category algebra.group.hom
 
 universes u v
 
@@ -23,23 +23,29 @@ namespace Mon
 
 instance (x : Mon) : monoid x := x.str
 
-instance concrete_is_monoid_hom : concrete_category @is_monoid_hom :=
-⟨by introsI α ia; apply_instance,
-  by introsI α β γ ia ib ic f g hf hg; apply_instance⟩
+-- TODO provide a generic constructor
+instance category_Mon : large_category Mon.{u} :=
+{ hom := λ X Y, X →* Y,
+  id := λ X, monoid_hom.id X,
+  comp := λ X Y Z f g, @monoid_hom.comp X.α Y.α Z.α _ _ _ g f, }
 
 def of (X : Type u) [monoid X] : Mon := ⟨X⟩
 
-abbreviation forget : Mon.{u} ⥤ Type u := forget
+def forget : Mon ⥤ Type u :=
+{ obj := λ X, X.α,
+  map := λ X Y f, monoid_hom.to_fun f }
 
-instance hom_is_monoid_hom {R S : Mon} (f : R ⟶ S) : is_monoid_hom (f : R → S) := f.2
+-- TODO remove?
+instance hom_is_monoid_hom {R S : Mon} (f : R ⟶ S) : is_monoid_hom (f : R → S) := by apply_instance
 
-/-- Morphisms in `Mon` are defined using `subtype is_monoid_hom`,
-so we provide a canonical bijection with `R →* S`. -/
-def hom_equiv_monoid_hom (R S : Mon) : (R ⟶ S) ≃ (R →* S) :=
-{ to_fun := λ f, @as_monoid_hom _ _ _ _ f.val f.property,
-  inv_fun := λ f, ⟨f, f.is_monoid_hom⟩,
-  right_inv := λ f, by rcases f; refl,
-  left_inv := λ f, by rcases f; refl }
+-- TODO remove
+-- /-- Morphisms in `Mon` are defined using `subtype is_monoid_hom`,
+-- so we provide a canonical bijection with `R →* S`. -/
+-- def hom_equiv_monoid_hom (R S : Mon) : (R ⟶ S) ≃ (R →* S) :=
+-- { to_fun := λ f, @as_monoid_hom _ _ _ _ f.val f.property,
+--   inv_fun := λ f, ⟨f, f.is_monoid_hom⟩,
+--   right_inv := λ f, by rcases f; refl,
+--   left_inv := λ f, by rcases f; refl }
 
 end Mon
 
@@ -47,25 +53,22 @@ namespace CommMon
 
 instance (x : CommMon) : comm_monoid x := x.str
 
-@[reducible] def is_comm_monoid_hom {α β} [comm_monoid α] [comm_monoid β] (f : α → β) : Prop :=
-is_monoid_hom f
-
-instance concrete_is_comm_monoid_hom : concrete_category @is_comm_monoid_hom :=
-⟨by introsI α ia; apply_instance,
-  by introsI α β γ ia ib ic f g hf hg; apply_instance⟩
+instance category_CommMon : large_category CommMon.{u} :=
+{ hom := λ X Y, X →* Y,
+  id := λ X, monoid_hom.id X,
+  comp := λ X Y Z f g, @monoid_hom.comp X.α Y.α Z.α _ _ _ g f, }
 
 def of (X : Type u) [comm_monoid X] : CommMon := ⟨X⟩
 
-abbreviation forget : CommMon.{u} ⥤ Type u := forget
+abbreviation forget : CommMon.{u} ⥤ Type u :=
+{ obj := λ X, X.α,
+  map := λ X Y f, monoid_hom.to_fun f }
 
-instance hom_is_comm_monoid_hom {R S : CommMon} (f : R ⟶ S) :
-  is_comm_monoid_hom (f : R → S) := f.2
-
+-- TODO provide a generic constructor
 /-- The forgetful functor from commutative monoids to monoids. -/
 def forget_to_Mon : CommMon ⥤ Mon :=
-concrete_functor
-  (by intros _ c; exact { ..c })
-  (by introsI _ _ _ _ f i;  exact { ..i })
+{ obj := λ X, Mon.of X.α,
+  map := λ X Y f, f }
 
 instance : faithful (forget_to_Mon) := {}
 

--- a/src/algebra/Mon/basic.lean
+++ b/src/algebra/Mon/basic.lean
@@ -7,7 +7,9 @@ Introduce Mon -- the category of monoids.
 Currently only the basic setup.
 -/
 
-import category_theory.concrete_category algebra.group.hom
+import category_theory.concrete_category
+import category_theory.bundled_hom
+import algebra.group.hom
 
 universes u v
 
@@ -23,29 +25,20 @@ namespace Mon
 
 instance (x : Mon) : monoid x := x.str
 
--- TODO provide a generic constructor
-instance category_Mon : large_category Mon.{u} :=
-{ hom := λ X Y, X →* Y,
-  id := λ X, monoid_hom.id X,
-  comp := λ X Y Z f g, @monoid_hom.comp X.α Y.α Z.α _ _ _ g f, }
+instance : bundled_hom.{u} monoid :=
+{ hom := λ X Y _ _, by exactI X →* Y,
+  to_fun := λ X Y _ _ f, by exactI f.to_fun,
+  id := λ X _, by exactI monoid_hom.id X,
+  comp := λ X Y Z _ _ _ f g, by exactI monoid_hom.comp g f }
 
+/-- Construct a bundled monoid from an unbundled monoid. -/
 def of (X : Type u) [monoid X] : Mon := ⟨X⟩
 
-def forget : Mon ⥤ Type u :=
-{ obj := λ X, X.α,
-  map := λ X Y f, monoid_hom.to_fun f }
+/-- The forgetful functor from monoids to underlying types. -/
+abbreviation forget : Mon.{u} ⥤ Type u := bundled_hom.forget
 
--- TODO remove?
-instance hom_is_monoid_hom {R S : Mon} (f : R ⟶ S) : is_monoid_hom (f : R → S) := by apply_instance
-
--- TODO remove
--- /-- Morphisms in `Mon` are defined using `subtype is_monoid_hom`,
--- so we provide a canonical bijection with `R →* S`. -/
--- def hom_equiv_monoid_hom (R S : Mon) : (R ⟶ S) ≃ (R →* S) :=
--- { to_fun := λ f, @as_monoid_hom _ _ _ _ f.val f.property,
---   inv_fun := λ f, ⟨f, f.is_monoid_hom⟩,
---   right_inv := λ f, by rcases f; refl,
---   left_inv := λ f, by rcases f; refl }
+-- We already know that all forgetful functors out of bundled hom categories are faithful:
+example : faithful forget := by apply_instance
 
 end Mon
 
@@ -53,23 +46,23 @@ namespace CommMon
 
 instance (x : CommMon) : comm_monoid x := x.str
 
-instance category_CommMon : large_category CommMon.{u} :=
-{ hom := λ X Y, X →* Y,
-  id := λ X, monoid_hom.id X,
-  comp := λ X Y Z f g, @monoid_hom.comp X.α Y.α Z.α _ _ _ g f, }
+instance : bundled_hom.{u} comm_monoid :=
+{ hom := λ X Y _ _, by exactI X →* Y,
+  to_fun := λ X Y _ _ f, by exactI f.to_fun,
+  id := λ X _, by exactI monoid_hom.id X,
+  comp := λ X Y Z _ _ _ f g, by exactI monoid_hom.comp g f }
 
+/-- Construct a bundled commutative monoid from an unbundled commutative monoid. -/
 def of (X : Type u) [comm_monoid X] : CommMon := ⟨X⟩
 
-abbreviation forget : CommMon.{u} ⥤ Type u :=
-{ obj := λ X, X.α,
-  map := λ X Y f, monoid_hom.to_fun f }
+/-- The forgetful functor from commutative monoids to underlying types. -/
+abbreviation forget : CommMon.{u} ⥤ Type u := bundled_hom.forget
 
--- TODO provide a generic constructor
 /-- The forgetful functor from commutative monoids to monoids. -/
-def forget_to_Mon : CommMon ⥤ Mon :=
-{ obj := λ X, Mon.of X.α,
-  map := λ X Y f, f }
+def forget_to_Mon : CommMon ⥤ Mon := bundled_hom.forget_to comm_monoid monoid
 
 instance : faithful (forget_to_Mon) := {}
+instance : full (forget_to_Mon) :=
+{ preimage := λ X Y f, f }
 
 end CommMon

--- a/src/algebra/Mon/colimits.lean
+++ b/src/algebra/Mon/colimits.lean
@@ -129,21 +129,10 @@ def colimit : Mon := ⟨colimit_type F, by apply_instance⟩
 def cocone_fun (j : J) (x : (F.obj j).α) : colimit_type F :=
 quot.mk _ (of j x)
 
-instance cocone_is_hom (j : J) : is_monoid_hom (cocone_fun F j) :=
-{ map_one :=
-  begin
-    apply quot.sound,
-    apply relation.one,
-  end,
-  map_mul := λ x y,
-  begin
-    apply quot.sound,
-    apply relation.mul,
-  end }
-
 def cocone_morphism (j : J) : F.obj j ⟶ colimit F :=
-{ val := cocone_fun F j,
-  property := by apply_instance }
+{ to_fun := cocone_fun F j,
+  map_one' := quot.sound (relation.one _ _),
+  map_mul' := λ x y, quot.sound (relation.mul _ _ _) }
 
 @[simp] lemma cocone_naturality {j j' : J} (f : j ⟶ j') :
   F.map f ≫ (cocone_morphism F j') = cocone_morphism F j :=
@@ -180,7 +169,7 @@ begin
     -- trans
     { exact eq.trans r_ih_h r_ih_k },
     -- map
-    { rw cocone.naturality_bundled, },
+    { sorry }, -- { rw cocone.naturality_bundled, },
     -- mul
     { rw is_monoid_hom.map_mul ⇑((s.ι).app r_j) },
     -- one
@@ -197,19 +186,16 @@ begin
     { rw mul_one, } }
 end
 
-instance desc_fun_is_morphism (s : cocone F) : is_monoid_hom (desc_fun F s) :=
-{ map_one := rfl,
-  map_mul := λ x y,
+@[simp] def desc_morphism (s : cocone F) : colimit F ⟶ s.X :=
+{ to_fun := desc_fun F s,
+  map_one' := rfl,
+  map_mul' := λ x y,
   begin
     induction x, induction y,
     refl,
     refl,
     refl,
   end, }
-
-@[simp] def desc_morphism (s : cocone F) : colimit F ⟶ s.X :=
-{ val := desc_fun F s,
-  property := by apply_instance }
 
 def colimit_is_colimit : is_colimit (colimit_cocone F) :=
 { desc := λ s, desc_morphism F s,

--- a/src/algebra/Mon/colimits.lean
+++ b/src/algebra/Mon/colimits.lean
@@ -169,7 +169,7 @@ begin
     -- trans
     { exact eq.trans r_ih_h r_ih_k },
     -- map
-    { sorry }, -- { rw cocone.naturality_bundled, },
+    { rw cocone.naturality_bundled', },
     -- mul
     { rw is_monoid_hom.map_mul ⇑((s.ι).app r_j) },
     -- one

--- a/src/category_theory/bundled.lean
+++ b/src/category_theory/bundled.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2018 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison, Johannes Hölzl, Reid Barton, Sean Leather
+
+Bundled types.
+-/
+
+/-!
+`bundled c` provides a uniform structure for bundling a type equipped with a type class.
+
+We provide `category` instances for these in `concrete_category.lean` (for categories with unbundled
+homs, e.g. topological spaces) and in `bundled_hom.lean` (for categories with bundled homs, e.g.
+monoids).
+-/
+
+universes u v
+
+namespace category_theory
+variables {c d : Type u → Type v} {α : Type u}
+
+/-- `bundled` is a type bundled with a type class instance for that type. Only
+the type class is exposed as a parameter. -/
+structure bundled (c : Type u → Type v) : Type (max (u+1) v) :=
+(α : Type u)
+(str : c α . tactic.apply_instance)
+
+def mk_ob {c : Type u → Type v} (α : Type u) [str : c α] : bundled c := ⟨α, str⟩
+
+namespace bundled
+
+instance : has_coe_to_sort (bundled c) :=
+{ S := Type u, coe := bundled.α }
+
+/-- Map over the bundled structure -/
+def map (f : ∀ {α}, c α → d α) (b : bundled c) : bundled d :=
+⟨b.α, f b.str⟩
+
+end bundled
+
+end category_theory

--- a/src/category_theory/bundled_hom.lean
+++ b/src/category_theory/bundled_hom.lean
@@ -3,11 +3,17 @@ Copyright (c) 2019 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import category_theory.concrete_category
+import category_theory.bundled
+import category_theory.types
 
 /-!
-TODO
+# Category instances for algebraic structures that use bundled homs.
 
+Many algebraic structures in Lean initially used unbundled homs (e.g. a bare function between types, along with
+an a `is_monoid_hom` typeclass), but the general trend is towards using bundled homs.
+
+While the helper functions in `category_theory/concrete_category.lean` are useful for categories
+with unbundled homs, this file provides similar infrastructure for categories with bundled homs.
 -/
 
 universes w v u
@@ -18,13 +24,17 @@ variables (c : Type u → Type v)
 
 -- TODO the square brackets here are useless, remove them and the resulting @s?
 structure bundled_hom :=
-(hom : Π (α β : Type u) [Iα : c α] [Iβ : c β], Type w)
-(to_fun : Π {α β : Type u} [Iα : c α] [Iβ : c β], @hom α β Iα Iβ → α → β)
-(id : Π (α : Type u) [I : c α], @hom α α I I)
-(comp : Π (α β γ : Type u) [Iα : c α] [Iβ : c β] [Iγ : c γ], @hom α β Iα Iβ → @hom β γ Iβ Iγ → @hom α γ Iα Iγ)
-(hom_ext : Π (α β : Type u) [Iα : c α] [Iβ : c β] {f g : @hom α β Iα Iβ} (h : @to_fun α β Iα Iβ f = @to_fun α β Iα Iβ g), f = g . obviously)
-(id_to_fun : Π (α : Type u) [I : c α], @to_fun α α I I (@id α I) = _root_.id . obviously)
-(comp_to_fun : Π (α β γ : Type u) [Iα : c α] [Iβ : c β] [Iγ : c γ] (f : @hom α β Iα Iβ) (g : @hom β γ Iβ Iγ), @to_fun α γ Iα Iγ (@comp α β γ Iα Iβ Iγ f g) = (@to_fun β γ Iβ Iγ g) ∘ (@to_fun α β Iα Iβ f) . obviously)
+(hom : Π {α β : Type u} (Iα : c α) (Iβ : c β), Type w)
+(to_fun : Π {α β : Type u} (Iα : c α) (Iβ : c β), hom Iα Iβ → α → β)
+(id : Π {α : Type u} (I : c α), hom I I)
+(comp : Π {α β γ : Type u} (Iα : c α) (Iβ : c β) (Iγ : c γ),
+  hom Iα Iβ → hom Iβ Iγ → hom Iα Iγ)
+(hom_ext : Π {α β : Type u} (Iα : c α) (Iβ : c β) {f g : hom Iα Iβ}
+  (h : to_fun Iα Iβ f = to_fun Iα Iβ g), f = g . obviously)
+(id_to_fun : Π {α : Type u} (I : c α), to_fun I I (id I) = _root_.id . obviously)
+(comp_to_fun : Π {α β γ : Type u} (Iα : c α) (Iβ : c β) (Iγ : c γ)
+  (f : hom Iα Iβ) (g : hom Iβ Iγ),
+  to_fun Iα Iγ (comp Iα Iβ Iγ f g) = (to_fun Iβ Iγ g) ∘ (to_fun Iα Iβ f) . obviously)
 
 attribute [class] bundled_hom
 
@@ -33,10 +43,28 @@ attribute [simp] bundled_hom.id_to_fun bundled_hom.comp_to_fun
 
 namespace bundled_hom
 
-instance [S : bundled_hom c] : category (bundled c) :=
+section
+variable [S : bundled_hom c]
+include S
+
+instance : category (bundled c) :=
 { hom := λ X Y, @bundled_hom.hom c S X.α Y.α X.str Y.str,
   id := λ X, @bundled_hom.id c S X.α X.str,
   comp := λ X Y Z f g, @bundled_hom.comp c S X.α Y.α Z.α X.str Y.str Z.str f g }
+
+instance {X Y : bundled c} : has_coe_to_fun (X ⟶ Y) :=
+{ F   := λ f, X → Y,
+  coe := λ f, S.to_fun X.str Y.str f }
+
+@[simp] lemma coe_id {X : bundled c} : ((𝟙 X) : X → X) = _root_.id :=
+S.id_to_fun X.str
+@[simp] lemma coe_comp {X Y Z : bundled c} (f : X ⟶ Y) (g : Y ⟶ Z) (x : X) :
+  (f ≫ g) x = g (f x) :=
+begin
+  unfold_coes,
+  erw S.comp_to_fun
+end
+end
 
 variables {c}
 
@@ -56,6 +84,11 @@ meta def trivial_forget_hom : tactic unit := `[exact (λ X Y f, f)]
 -- Example usage is:
 -- `def forget_to_Mon : CommMon ⥤ Mon := bundled_hom.forget_to comm_monoid monoid`
 
+/--
+Construct a forgetful functor `bundled c ⥤ bundled d`, where the category instances were provided
+via `bundled_hom`. There are arguments providing evidence that there really is a forgetful functor,
+but can often be omitted, and provided via `auto_param` tactics.
+-/
 def forget_to [Sc : bundled_hom c] [Sd : bundled_hom d]
    (forget_obj : Π α, c α → d α . trivial_forget_obj)
    (forget_hom : Π (X Y : bundled c), @bundled_hom.hom c Sc X.α Y.α X.str Y.str → @bundled_hom.hom d Sd X.α Y.α (forget_obj X.α X.str) (forget_obj Y.α Y.str) . trivial_forget_hom)

--- a/src/category_theory/bundled_hom.lean
+++ b/src/category_theory/bundled_hom.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2019 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import category_theory.concrete_category
+
+/-!
+TODO
+
+-/
+
+universes w v u
+
+namespace category_theory
+
+variables (c : Type u → Type v)
+
+-- TODO the square brackets here are useless, remove them and the resulting @s?
+structure bundled_hom :=
+(hom : Π (α β : Type u) [Iα : c α] [Iβ : c β], Type w)
+(to_fun : Π {α β : Type u} [Iα : c α] [Iβ : c β], @hom α β Iα Iβ → α → β)
+(id : Π (α : Type u) [I : c α], @hom α α I I)
+(comp : Π (α β γ : Type u) [Iα : c α] [Iβ : c β] [Iγ : c γ], @hom α β Iα Iβ → @hom β γ Iβ Iγ → @hom α γ Iα Iγ)
+(hom_ext : Π (α β : Type u) [Iα : c α] [Iβ : c β] {f g : @hom α β Iα Iβ} (h : @to_fun α β Iα Iβ f = @to_fun α β Iα Iβ g), f = g . obviously)
+(id_to_fun : Π (α : Type u) [I : c α], @to_fun α α I I (@id α I) = _root_.id . obviously)
+(comp_to_fun : Π (α β γ : Type u) [Iα : c α] [Iβ : c β] [Iγ : c γ] (f : @hom α β Iα Iβ) (g : @hom β γ Iβ Iγ), @to_fun α γ Iα Iγ (@comp α β γ Iα Iβ Iγ f g) = (@to_fun β γ Iβ Iγ g) ∘ (@to_fun α β Iα Iβ f) . obviously)
+
+attribute [class] bundled_hom
+
+attribute [extensionality] bundled_hom.hom_ext
+attribute [simp] bundled_hom.id_to_fun bundled_hom.comp_to_fun
+
+namespace bundled_hom
+
+instance [S : bundled_hom c] : category (bundled c) :=
+{ hom := λ X Y, @bundled_hom.hom c S X.α Y.α X.str Y.str,
+  id := λ X, @bundled_hom.id c S X.α X.str,
+  comp := λ X Y Z f g, @bundled_hom.comp c S X.α Y.α Z.α X.str Y.str Z.str f g }
+
+variables {c}
+
+def forget [S : bundled_hom c] : bundled c ⥤ Type u :=
+{ obj := λ X, X.α,
+  map := λ X Y f, @bundled_hom.to_fun c S X.α Y.α X.str Y.str f }
+
+instance [S : bundled_hom c] : faithful (@forget c _) := {}
+
+variables (c) (d : Type u → Type v)
+
+meta def trivial_forget_obj : tactic unit := `[exact (λ α s, by resetI; apply_instance)]
+meta def trivial_forget_hom : tactic unit := `[exact (λ X Y f, f)]
+
+-- This has pretty disgusting arguments, but it should only be used in simple cases where
+-- everything can be provided by `auto_param`.
+-- Example usage is:
+-- `def forget_to_Mon : CommMon ⥤ Mon := bundled_hom.forget_to comm_monoid monoid`
+
+def forget_to [Sc : bundled_hom c] [Sd : bundled_hom d]
+   (forget_obj : Π α, c α → d α . trivial_forget_obj)
+   (forget_hom : Π (X Y : bundled c), @bundled_hom.hom c Sc X.α Y.α X.str Y.str → @bundled_hom.hom d Sd X.α Y.α (forget_obj X.α X.str) (forget_obj Y.α Y.str) . trivial_forget_hom)
+   (map_id : Π X : bundled c, forget_hom X X (𝟙 X) = @bundled_hom.id d Sd X.α (forget_obj X.α X.str) . obviously)
+   (map_comp : Π (X Y Z : bundled c) (f : @bundled_hom.hom c Sc X.α Y.α X.str Y.str) (g : @bundled_hom.hom c Sc Y.α Z.α Y.str Z.str), forget_hom X Z (@bundled_hom.comp c Sc X.α Y.α Z.α X.str Y.str Z.str f g) = @bundled_hom.comp d Sd X.α Y.α Z.α (forget_obj X.α X.str) (forget_obj Y.α Y.str) (forget_obj Z.α Z.str) (forget_hom X Y f) (forget_hom Y Z g) . obviously)
+   : bundled c ⥤ bundled d :=
+{ obj := λ X, ⟨X.α, forget_obj X.α X.str⟩,
+  map := λ X Y f, forget_hom X Y f }
+
+end bundled_hom
+
+end category_theory

--- a/src/category_theory/bundled_hom.lean
+++ b/src/category_theory/bundled_hom.lean
@@ -52,9 +52,11 @@ instance : category (bundled c) :=
   id := λ X, @bundled_hom.id c S X.α X.str,
   comp := λ X Y Z f g, @bundled_hom.comp c S X.α Y.α Z.α X.str Y.str Z.str f g }
 
-instance {X Y : bundled c} : has_coe_to_fun (X ⟶ Y) :=
+def has_coe_to_fun {X Y : bundled c} : has_coe_to_fun (X ⟶ Y) :=
 { F   := λ f, X → Y,
   coe := λ f, S.to_fun X.str Y.str f }
+
+local attribute [instance] has_coe_to_fun
 
 @[simp] lemma coe_id {X : bundled c} : ((𝟙 X) : X → X) = _root_.id :=
 S.id_to_fun X.str

--- a/src/category_theory/concrete_category.lean
+++ b/src/category_theory/concrete_category.lean
@@ -5,13 +5,14 @@ Authors: Scott Morrison, Johannes Hölzl, Reid Barton, Sean Leather
 
 Bundled type and structure.
 -/
-import category_theory.functor
 import category_theory.types
+import category_theory.bundled
 
 universes u v
 
 namespace category_theory
 variables {c d : Type u → Type v} {α : Type u}
+
 
 /--
 `concrete_category @hom` collects the evidence that a type constructor `c` and a
@@ -26,29 +27,13 @@ structure concrete_category (hom : out_param $ ∀ {α β}, c α → c β → (�
 
 attribute [class] concrete_category
 
-/-- `bundled` is a type bundled with a type class instance for that type. Only
-the type class is exposed as a parameter. -/
-structure bundled (c : Type u → Type v) : Type (max (u+1) v) :=
-(α : Type u)
-(str : c α . tactic.apply_instance)
-
-def mk_ob {c : Type u → Type v} (α : Type u) [str : c α] : bundled c := ⟨α, str⟩
-
 namespace bundled
 
-instance : has_coe_to_sort (bundled c) :=
-{ S := Type u, coe := bundled.α }
-
-/-- Map over the bundled structure -/
-def map (f : ∀ {α}, c α → d α) (b : bundled c) : bundled d :=
-⟨b.α, f b.str⟩
-
-section concrete_category
 variables (hom : ∀ {α β : Type u}, c α → c β → (α → β) → Prop)
 variables [h : concrete_category @hom]
 include h
 
-instance : category (bundled c) :=
+instance : category.{u+1} (bundled c) :=
 { hom   := λ a b, subtype (hom a.2 b.2),
   id    := λ a, ⟨@id a.1, h.hom_id a.2⟩,
   comp  := λ a b c f g, ⟨g.1 ∘ f.1, h.hom_comp a.2 b.2 c.2 g.2 f.2⟩ }
@@ -72,8 +57,6 @@ instance : has_coe_to_fun (X ⟶ Y) :=
 @[simp] lemma coe_comp {X Y Z : bundled c} (f : X ⟶ Y) (g : Y ⟶ Z) (x : X) : (f ≫ g) x = g (f x) := rfl
 @[simp] lemma bundled_hom_coe (val : X → Y) (prop) (x : X) :
   (⟨val, prop⟩ : X ⟶ Y) x = val x := rfl
-
-end concrete_category
 
 end bundled
 

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -6,6 +6,7 @@ Authors: Stephen Morgan, Scott Morrison, Floris van Doorn
 import category_theory.const
 import category_theory.yoneda
 import category_theory.concrete_category
+import category_theory.bundled_hom
 import category_theory.equivalence
 
 universes v u u' -- declare the `v`'s first; see `category_theory.category` for an explanation
@@ -136,9 +137,14 @@ def whisker {K : Type v} [small_category K] (E : K ⥤ J) (c : cone F) : cone (E
 @[simp] lemma whisker_π_app (c : cone F) {K : Type v} [small_category K] (E : K ⥤ J) (k : K) :
   (c.whisker E).π.app k = (c.π).app (E.obj k) := rfl
 
+-- We now prove a lemma about naturality of cones over functors into bundled categories.
+-- Since we now have two ways to construct bundled categories (unbundled homs, or bundled homs),
+-- we prove this lemma twice, with slightly different hypotheses.
 section
 omit 𝒞
 variables {m : Type v → Type v}
+
+section unbundled_hom
 variables (hom : ∀ {α β : Type v}, m α → m β → (α → β) → Prop)
 variables [h : concrete_category @hom]
 include h
@@ -146,6 +152,21 @@ include h
 @[simp] lemma naturality_bundled {G : J ⥤ bundled m} (s : cone G) {j j' : J} (f : j ⟶ j') (x : s.X) :
    (G.map f) ((s.π.app j) x) = (s.π.app j') x :=
 congr_fun (congr_arg (λ k : s.X ⟶ G.obj j', (k : s.X → G.obj j')) (s.π.naturality f).symm) x
+end unbundled_hom
+
+section bundled_hom
+variables [S : bundled_hom.{v} m]
+include S
+
+@[simp] lemma naturality_bundled' {G : J ⥤ bundled m} (s : cone G) {j j' : J} (f : j ⟶ j') (x : s.X) :
+   (G.map f) ((s.π.app j) x) = (s.π.app j') x :=
+begin
+  convert congr_fun (congr_arg (λ k : s.X ⟶ G.obj j', (k : s.X → G.obj j')) (s.π.naturality f).symm) x;
+  { dsimp, simp },
+end
+
+end bundled_hom
+
 end
 end cone
 
@@ -169,9 +190,14 @@ def whisker {K : Type v} [small_category K] (E : K ⥤ J) (c : cocone F) : cocon
 @[simp] lemma whisker_ι_app (c : cocone F) {K : Type v} [small_category K] (E : K ⥤ J) (k : K) :
   (c.whisker E).ι.app k = (c.ι).app (E.obj k) := rfl
 
+-- We now prove a lemma about naturality of cocones over functors into bundled categories.
+-- Since we now have two ways to construct bundled categories (unbundled homs, or bundled homs),
+-- we prove this lemma twice, with slightly different hypotheses.
 section
 omit 𝒞
 variables {m : Type v → Type v}
+
+section unbundled_hom
 variables (hom : ∀ {α β : Type v}, m α → m β → (α → β) → Prop)
 variables [h : concrete_category @hom]
 include h
@@ -179,6 +205,20 @@ include h
 @[simp] lemma naturality_bundled {G : J ⥤ bundled m} (s : cocone G) {j j' : J} (f : j ⟶ j') (x : G.obj j) :
   (s.ι.app j') ((G.map f) x) = (s.ι.app j) x :=
 congr_fun (congr_arg (λ k : G.obj j ⟶ s.X, (k : G.obj j → s.X)) (s.ι.naturality f)) x
+end unbundled_hom
+
+section bundled_hom
+variables [S : bundled_hom.{v} m]
+include S
+
+@[simp] lemma naturality_bundled' {G : J ⥤ bundled m} (s : cocone G) {j j' : J} (f : j ⟶ j') (x : G.obj j) :
+  (s.ι.app j') ((G.map f) x) = (s.ι.app j) x :=
+begin
+  convert congr_fun (congr_arg (λ k : G.obj j ⟶ s.X, (k : G.obj j → s.X)) (s.ι.naturality f)) x;
+  { dsimp, simp },
+end
+
+end bundled_hom
 end
 
 end cocone

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -158,6 +158,8 @@ section bundled_hom
 variables [S : bundled_hom.{v} m]
 include S
 
+local attribute [instance] bundled_hom.has_coe_to_fun
+
 @[simp] lemma naturality_bundled' {G : J ⥤ bundled m} (s : cone G) {j j' : J} (f : j ⟶ j') (x : s.X) :
    (G.map f) ((s.π.app j) x) = (s.π.app j') x :=
 begin
@@ -210,6 +212,8 @@ end unbundled_hom
 section bundled_hom
 variables [S : bundled_hom.{v} m]
 include S
+
+local attribute [instance] bundled_hom.has_coe_to_fun
 
 @[simp] lemma naturality_bundled' {G : J ⥤ bundled m} (s : cocone G) {j j' : J} (f : j ⟶ j') (x : G.obj j) :
   (s.ι.app j') ((G.map f) x) = (s.ι.app j) x :=

--- a/src/category_theory/single_obj.lean
+++ b/src/category_theory/single_obj.lean
@@ -137,10 +137,10 @@ open category_theory
 /-- The fully faithful functor from `Mon` to `Cat`. -/
 def to_Cat : Mon ⥤ Cat :=
 { obj := λ x, Cat.of (single_obj x),
-  map := λ x y f, (Mon.hom_equiv_monoid_hom x y).trans (single_obj.map_hom x y) f }
+  map := λ x y f, (single_obj.map_hom x y) f }
 
 instance to_Cat_full : full to_Cat :=
-{ preimage := λ x y, ((Mon.hom_equiv_monoid_hom x y).trans (single_obj.map_hom x y)).inv_fun,
+{ preimage := λ x y, (single_obj.map_hom x y).inv_fun,
   witness' := λ x y, by apply equiv.right_inv }
 
 instance to_Cat_faithful : faithful to_Cat :=


### PR DESCRIPTION
Since it seems that we've decided to deprecate `is_monoid_hom` in favour of the bundled `monoid_hom`, I've updated `Mon`, the category of monoids, to use bundled morphisms.

This necessitated building some parallel infrastructure to `concrete_category`, to support bundled homs, which I've put in `category_theory/bundled_hom.lean`. Mostly the transition was fairly smooth.