### PR TITLE
feat(data/pnat/divisors): divisors of a positive natural number

### DIFF
--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -563,7 +563,7 @@ subtype_congr (equiv.refl α) (assume a, h ▸ iff.refl _)
 def set_congr {α : Type*} {s t : set α} (h : s = t) : s ≃ t :=
 subtype_congr_prop h
 
-def subtype_subtype_equiv_subtype_ex {α : Type u} (p : α → Prop) (q : subtype p → Prop) :
+def subtype_subtype_equiv_subtype_exists {α : Type u} (p : α → Prop) (q : subtype p → Prop) :
   subtype q ≃ {a : α // ∃h:p a, q ⟨a, h⟩ } :=
 ⟨λ⟨⟨a, ha⟩, ha'⟩, ⟨a, ha, ha'⟩,
   λ⟨a, ha⟩, ⟨⟨a, ha.cases_on $ assume h _, h⟩, by { cases ha, exact ha_h }⟩,
@@ -571,7 +571,7 @@ def subtype_subtype_equiv_subtype_ex {α : Type u} (p : α → Prop) (q : subtyp
 
 def subtype_subtype_equiv_subtype_inter {α : Type u} (p q : α → Prop) :
   {x : subtype p // q x.1} ≃ subtype (λ x, p x ∧ q x) :=
-(subtype_subtype_equiv_subtype_ex p _).trans $
+(subtype_subtype_equiv_subtype_exists p _).trans $
 subtype_congr_right $ λ x, exists_prop
 
 /-- If the outer subtype has more restrictive predicate than the inner one,
@@ -598,7 +598,7 @@ def subtype_sigma_equiv {α : Type u} (p : α → Type v) (q : α → Prop) :
  λ ⟨⟨x, y⟩, h⟩, rfl⟩
 
 /-- A sigma type over a subtype is equivalent to the sigma set over the original type,
-if the fiber if empty outside of the subset -/
+if the fiber is empty outside of the subset -/
 def sigma_subtype_equiv_of_subset {α : Type u} (p : α → Type v) (q : α → Prop)
   (h : ∀ x (y : p x), q x) :
   (Σ x : subtype q, p x) ≃ Σ x : α, p x :=
@@ -616,12 +616,12 @@ def sigma_subtype_preimage_equiv_subtype {α : Type u} {β : Type v} (f : α →
 calc (Σ y : subtype q, {x : α // f x = y}) ≃
   Σ y : subtype q, {x : subtype p // subtype.mk (f x) ((h x).1 x.2) = y} :
   begin
-  apply sigma_congr_right,
-  assume y,
-  symmetry,
-  refine (subtype_subtype_equiv_subtype_ex _ _).trans (subtype_congr_right _),
-  assume x,
-  exact ⟨λ ⟨hp, h'⟩, congr_arg subtype.val h', λ h', ⟨(h x).2 (h'.symm ▸ y.2), subtype.eq h'⟩⟩
+    apply sigma_congr_right,
+    assume y,
+    symmetry,
+    refine (subtype_subtype_equiv_subtype_exists _ _).trans (subtype_congr_right _),
+    assume x,
+    exact ⟨λ ⟨hp, h'⟩, congr_arg subtype.val h', λ h', ⟨(h x).2 (h'.symm ▸ y.2), subtype.eq h'⟩⟩
   end
 
    ... ≃ subtype p : sigma_preimage_equiv (λ x : subtype p, (⟨f x, (h x).1 x.property⟩ : subtype q))

--- a/src/data/nat/gcd.lean
+++ b/src/data/nat/gcd.lean
@@ -33,11 +33,12 @@ dvd_antisymm
   (dvd_gcd (gcd_dvd_right m n) (gcd_dvd_left m n))
   (dvd_gcd (gcd_dvd_right n m) (gcd_dvd_left n m))
 
-theorem gcd_of_dvd_left {m n : ℕ} (h : m ∣ n) : gcd m n = m :=
-by rw [gcd_rec, mod_eq_zero_of_dvd h, gcd_zero_left]
+theorem gcd_eq_left_iff_dvd {m n : ℕ} : m ∣ n ↔ gcd m n = m :=
+⟨λ h, by rw [gcd_rec, mod_eq_zero_of_dvd h, gcd_zero_left],
+ λ h, h ▸ gcd_dvd_right m n⟩
 
-theorem gcd_of_dvd_right {m n : ℕ} (h : m ∣ n) : gcd n m = m :=
-(gcd_comm _ _).trans $ gcd_of_dvd_left h
+theorem gcd_eq_right_iff_dvd {m n : ℕ} : (m ∣ n) ↔ gcd n m = m :=
+by rw gcd_comm; apply gcd_eq_left_iff_dvd
 
 theorem gcd_assoc (m n k : ℕ) : gcd (gcd m n) k = gcd m (gcd n k) :=
 dvd_antisymm

--- a/src/data/nat/gcd.lean
+++ b/src/data/nat/gcd.lean
@@ -20,6 +20,10 @@ theorem gcd_dvd_left (m n : ℕ) : gcd m n ∣ m := (gcd_dvd m n).left
 
 theorem gcd_dvd_right (m n : ℕ) : gcd m n ∣ n := (gcd_dvd m n).right
 
+theorem gcd_le_left {m} (n) (h : m > 0) : gcd m n ≤ m := le_of_dvd h $ gcd_dvd_left m n
+
+theorem gcd_le_right (m) {n} (h : n > 0) : gcd m n ≤ n := le_of_dvd h $ gcd_dvd_right m n
+
 theorem dvd_gcd {m n k : ℕ} : k ∣ m → k ∣ n → k ∣ gcd m n :=
 gcd.induction m n (λn _ kn, by rw gcd_zero_left; exact kn)
   (λn m mpos IH H1 H2, by rw gcd_rec; exact IH ((dvd_mod_iff H1).2 H2) H1)
@@ -28,6 +32,12 @@ theorem gcd_comm (m n : ℕ) : gcd m n = gcd n m :=
 dvd_antisymm
   (dvd_gcd (gcd_dvd_right m n) (gcd_dvd_left m n))
   (dvd_gcd (gcd_dvd_right n m) (gcd_dvd_left n m))
+
+theorem gcd_of_dvd_left {m n : ℕ} (h : m ∣ n) : gcd m n = m :=
+by rw [gcd_rec, mod_eq_zero_of_dvd h, gcd_zero_left]
+
+theorem gcd_of_dvd_right {m n : ℕ} (h : m ∣ n) : gcd n m = m :=
+(gcd_comm _ _).trans $ gcd_of_dvd_left h
 
 theorem gcd_assoc (m n k : ℕ) : gcd (gcd m n) k = gcd m (gcd n k) :=
 dvd_antisymm
@@ -258,6 +268,15 @@ lemma coprime_mul_iff_left {k m n : ℕ} : coprime (m * n) k ↔ coprime m k ∧
 lemma coprime_mul_iff_right {k m n : ℕ} : coprime k (m * n) ↔ coprime k m ∧ coprime k n :=
 by { repeat { rw [coprime, nat.gcd_comm k] }, exact coprime_mul_iff_left }
 
+lemma coprime.gcd_left (k : ℕ) {m n : ℕ} (hmn : coprime m n) : coprime (gcd k m) n :=
+hmn.coprime_dvd_left $ gcd_dvd_right k m
+
+lemma coprime.gcd_right (k : ℕ) {m n : ℕ} (hmn : coprime m n) : coprime m (gcd k n) :=
+hmn.coprime_dvd_right $ gcd_dvd_right k n
+
+lemma coprime.gcd_both (k l : ℕ) {m n : ℕ} (hmn : coprime m n) : coprime (gcd k m) (gcd l n) :=
+(hmn.gcd_left k).gcd_right l
+
 lemma coprime.mul_dvd_of_dvd_of_dvd {a n m : ℕ} (hmn : coprime m n)
   (hm : m ∣ a) (hn : n ∣ a) : m * n ∣ a :=
 let ⟨k, hk⟩ := hm in hk.symm ▸ mul_dvd_mul_left _ (hmn.symm.dvd_of_dvd_mul_left (hk ▸ hn))
@@ -293,16 +312,43 @@ by simp [coprime]
 @[simp] theorem coprime_self (n : ℕ) : coprime n n ↔ n = 1 :=
 by simp [coprime]
 
-theorem exists_eq_prod_and_dvd_and_dvd {m n k : ℕ} (H : k ∣ m * n) :
-  ∃ m' n', k = m' * n' ∧ m' ∣ m ∧ n' ∣ n :=
-or.elim (eq_zero_or_pos (gcd k m))
-  (λg0, ⟨0, n,
-    by rw [zero_mul, eq_zero_of_gcd_eq_zero_left g0],
-    by rw [eq_zero_of_gcd_eq_zero_right g0]; apply dvd_zero, dvd_refl _⟩)
-  (λgpos, let hd := (nat.mul_div_cancel' (gcd_dvd_left k m)).symm in
-     ⟨_, _, hd, gcd_dvd_right _ _,
-    dvd_of_mul_dvd_mul_left gpos $ by rw [←hd, ←gcd_mul_right]; exact
-      dvd_gcd (dvd_mul_right _ _) H⟩)
+/-- Represent a divisor of `m * n` as a product of a divisor of `m` and a divisor of `n`. -/
+def prod_dvd_and_dvd_of_dvd_prod {m n k : ℕ} (H : k ∣ m * n) :
+  { d : {m' // m' ∣ m} × {n' // n' ∣ n} // k = d.1 * d.2 } :=
+begin
+cases h0 : (gcd k m),
+case nat.zero {
+  have : k = 0 := eq_zero_of_gcd_eq_zero_left h0, subst this,
+  have : m = 0 := eq_zero_of_gcd_eq_zero_right h0, subst this,
+  exact ⟨⟨⟨0, dvd_refl 0⟩, ⟨n, dvd_refl n⟩⟩, (zero_mul n).symm⟩ },
+case nat.succ : tmp hpos {
+  replace hpos : gcd k m > 0 := hpos.symm ▸ nat.zero_lt_succ _; clear tmp,
+  have hd : gcd k m * (k / gcd k m) = k := (nat.mul_div_cancel' (gcd_dvd_left k m)),
+  refine ⟨⟨⟨gcd k m,  gcd_dvd_right k m⟩, ⟨k / gcd k m, _⟩⟩, hd.symm⟩,
+  apply dvd_of_mul_dvd_mul_left hpos,
+  rw [hd, ← gcd_mul_right],
+  exact dvd_gcd (dvd_mul_right _ _) H }
+end
+
+theorem gcd_mul_dvd_mul_gcd (k m n : ℕ) : gcd k (m * n) ∣ gcd k m * gcd k n :=
+begin
+rcases (prod_dvd_and_dvd_of_dvd_prod $ gcd_dvd_right k (m * n)) with ⟨⟨⟨m', hm'⟩, ⟨n', hn'⟩⟩, h⟩,
+replace h : gcd k (m * n) = m' * n' := h,
+rw h,
+have hm'n' : m' * n' ∣ k := h ▸ gcd_dvd_left _ _,
+apply mul_dvd_mul,
+  { have hm'k : m' ∣ k := dvd_trans (dvd_mul_right m' n') hm'n',
+    exact dvd_gcd hm'k hm' },
+  { have hn'k : n' ∣ k := dvd_trans (dvd_mul_left n' m') hm'n',
+    exact dvd_gcd hn'k hn' }
+end
+
+theorem coprime.gcd_mul (k : ℕ) {m n : ℕ} (h : coprime m n) : gcd k (m * n) = gcd k m * gcd k n :=
+dvd_antisymm
+  (gcd_mul_dvd_mul_gcd k m n)
+  ((h.gcd_both k k).mul_dvd_of_dvd_of_dvd
+    (gcd_dvd_gcd_mul_right_right _ _ _)
+    (gcd_dvd_gcd_mul_left_right _ _ _))
 
 theorem pow_dvd_pow_iff {a b n : ℕ} (n0 : 0 < n) : a ^ n ∣ b ^ n ↔ a ∣ b :=
 begin

--- a/src/data/pnat/divisors.lean
+++ b/src/data/pnat/divisors.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2019 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Yury Kudryashov
+-/
+import data.fintype data.pnat.basic tactic.alias
+
+/-!
+# Divisors of a positive natural number
+
+Given a number `n : ℕ+`, `divisors n` is the set of all positive
+numbers `d` such that `d ∣ n`.
+
+We prove a few equivalences involving this type:
+
+* `divisors n ≃ { d : fin (n + 1) // d ∣ n }`;
+* `divisors n ≃ { d : ℕ // d ∣ n }`;
+* given two coprime numbers `m` and `n`, `divisors (m * n) ≃ divisors m × divisors n`;
+* `rev_equiv : equiv.perm (divisors n)`, `rev_equiv d = n / d`.
+-/
+
+namespace pnat
+
+/-- Divisors of a positive natural number -/
+def divisors (n : ℕ+) : Type := { d : ℕ+ // d ∣ n }
+
+instance divisors.has_coe (n : ℕ+) : has_coe (divisors n) ℕ+ := ⟨subtype.val⟩
+
+/-- A natural divisor of a positive number is positive -/
+def divisors.of_dvd {n : ℕ+} {d : ℕ} (h : d ∣ n) : divisors n :=
+⟨⟨d, nat.pos_of_dvd_of_pos h n.2⟩, h⟩
+
+alias divisors.of_dvd ← has_dvd.dvd.to_pnat_divisors
+
+def divisors_equiv_subtype_nat (n : ℕ+) : divisors n ≃ { m : ℕ // m ∣ n } :=
+@equiv.subtype_subtype_equiv_subtype ℕ ((<) 0) (λ m, m ∣ n) (λ m h, nat.pos_of_dvd_of_pos h n.2)
+
+def divisors_equiv_subtype_fin (n : ℕ+) : divisors n ≃ { m : fin (n + 1) // (m : ℕ) ∣ n } :=
+calc divisors n ≃ { m : ℕ // m ∣ n } : n.divisors_equiv_subtype_nat
+            ... ≃ { m : {m : ℕ // m < n+1} // (m : ℕ) ∣ n } :
+  (@equiv.subtype_subtype_equiv_subtype ℕ ((>) (n+1)) (λ m, (m : ℕ) ∣ n) $
+    λ m h, nat.lt_succ_of_le $ nat.le_of_dvd n.2 h).symm
+            ... ≃ { m : fin (n + 1) // (m : ℕ) ∣ n } :
+  equiv.subtype_congr (equiv.fin_equiv_subtype _).symm $ λ m, iff.rfl
+
+namespace divisors
+
+instance (n : ℕ+) : fintype (divisors n) := fintype.of_equiv _ n.divisors_equiv_subtype_fin.symm
+
+/-- The equivalence that reverses the divisors of `n` sending each `d` to `n / d`. -/
+def rev_equiv (n : ℕ+) : equiv.perm (divisors n) :=
+{ to_fun := λ d, of_dvd $ nat.div_dvd_of_dvd d.property,
+  inv_fun := λ d, of_dvd $ nat.div_dvd_of_dvd d.property,
+  right_inv := λ d, subtype.ext.2 $ subtype.ext.2 $ nat.div_div_self d.property n.property,
+  left_inv := λ d, subtype.ext.2 $ subtype.ext.2 $ nat.div_div_self d.property n.property }
+
+abbreviation rev {n : ℕ+} : divisors n → divisors n := rev_equiv n
+
+lemma rev_involutive {n : ℕ+} (d : divisors n) : rev (rev d) = d := (rev_equiv n).left_inv d
+
+@[simp] lemma mul_rev {n : ℕ+} (d : divisors n) : (d : ℕ+) * d.rev = n :=
+subtype.ext.2 $ nat.mul_div_cancel' d.2
+@[simp] lemma rev_mul {n : ℕ+} (d : divisors n) : (d.rev : ℕ+) * d = n :=
+subtype.ext.2 $ nat.div_mul_cancel d.2
+
+@[simp] lemma mul_rev_nat {n : ℕ+} (d : divisors n) : (d : ℕ) * d.rev = n :=
+congr_arg subtype.val d.mul_rev
+@[simp] lemma rev_mul_nat {n : ℕ+} (d : divisors n) : (d.rev : ℕ) * d = n :=
+congr_arg subtype.val d.rev_mul
+
+def fin_rev_mul {n : ℕ+} (d : divisors n) (k : fin d) : fin n :=
+by refine ⟨(d.rev : ℕ) * k, _⟩;
+calc (d.rev : ℕ) * k < d.rev * d : nat.mul_lt_mul_of_pos_left k.2 (pos _)
+                 ... = n         : rev_mul_nat d
+
+def fin_rev_div {n : ℕ+} (d : divisors n) (k : fin n) : fin d :=
+⟨(k : ℕ) / d.rev, nat.div_lt_of_lt_mul $ d.rev_mul_nat.symm ▸ k.2⟩
+
+lemma fin_rev_div_mul_eq {n : ℕ+} (d : divisors n) (k : fin d) :
+  d.fin_rev_div (d.fin_rev_mul k) = k :=
+fin.eq_of_veq $ nat.mul_div_right _ (pos _)
+
+lemma fin_rev_mul_div_eq_of_dvd {n : ℕ+} (d : divisors n) (k : fin n) (h : (d.rev : ℕ) ∣ k) :
+  d.fin_rev_mul (d.fin_rev_div k) = k :=
+fin.eq_of_veq $ nat.mul_div_cancel' h
+
+def of_mul_of_coprime_equiv_prod {k l : ℕ+} (h : nat.coprime k l) :
+  divisors (k * l) ≃ divisors k × divisors l :=
+{ to_fun := λ x, ⟨⟨gcd (x : ℕ+) k, gcd_dvd_right _ _⟩, ⟨gcd (x : ℕ+) l, gcd_dvd_right _ _⟩⟩,
+  inv_fun := λ x, ⟨(x.fst : ℕ+) * x.snd, mul_dvd_mul x.fst.property x.snd.property⟩,
+  right_inv :=
+  begin
+  rintros ⟨⟨x, hx⟩, ⟨y, hy⟩⟩,
+  ext1; apply subtype.eq,
+    { calc gcd (x * y) k = gcd x k : subtype.eq $ (h.symm.coprime_dvd_left hy).gcd_mul_right_cancel x 
+                     ... = x       : subtype.eq $ nat.gcd_eq_left_iff_dvd.1 hx },
+    { calc gcd (x * y) l = gcd y l : subtype.eq $ (h.coprime_dvd_left hx).gcd_mul_left_cancel y
+                     ... = y       : subtype.eq $ nat.gcd_eq_left_iff_dvd.1 hy }
+  end,
+  left_inv :=
+  begin
+  rintros ⟨x, hx⟩,
+  apply subtype.eq,
+  calc (gcd x k) * (gcd x l) = gcd x (k * l) : subtype.eq $ (h.gcd_mul x).symm
+                         ... = x             : subtype.eq $ nat.gcd_eq_left_iff_dvd.1 hx
+  end }
+
+alias of_mul_of_coprime_equiv_prod ← nat.coprime.divisors_mul_equiv_prod_divisors
+
+end divisors
+end pnat

--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -207,7 +207,7 @@ def left_coset_equiv_subgroup (g : α) : left_coset g s ≃ s :=
 noncomputable def group_equiv_quotient_times_subgroup (hs : is_subgroup s) :
   α ≃ quotient s × s :=
 calc α ≃ Σ L : quotient s, {x : α // (x : quotient s)= L} :
-  equiv.equiv_fib quotient_group.mk
+  (equiv.sigma_preimage_equiv quotient_group.mk).symm
     ... ≃ Σ L : quotient s, left_coset (quotient.out' L) s :
   equiv.sigma_congr_right (λ L,
     begin rw ← eq_class_eq_left_coset,

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -31,7 +31,7 @@ end
 lemma card_modeq_card_fixed_points [fintype α] [fintype G] [fintype (fixed_points G α)]
   {p n : ℕ} (hp : nat.prime p) (h : card G = p ^ n) : card α ≡ card (fixed_points G α) [MOD p] :=
 calc card α = card (Σ y : quotient (orbit_rel G α), {x // quotient.mk' x = y}) :
-  card_congr (equiv_fib (@quotient.mk' _ (orbit_rel G α)))
+  card_congr (sigma_preimage_equiv (@quotient.mk' _ (orbit_rel G α))).symm
 ... = univ.sum (λ a : quotient (orbit_rel G α), card {x // quotient.mk' x = a}) : card_sigma _
 ... ≡ (@univ (fixed_points G α) _).sum (λ _, 1) [MOD p] :
 begin

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -778,7 +778,7 @@ quotient.sound ⟨equiv.option_equiv_sum_punit α⟩
 
 theorem mk_list_eq_sum_pow (α : Type u) : mk (list α) = sum (λ n : ℕ, (mk α)^(n:cardinal.{u})) :=
 calc  mk (list α)
-    = mk (Σ n, vector α n) : quotient.sound ⟨equiv.equiv_sigma_subtype list.length⟩
+    = mk (Σ n, vector α n) : quotient.sound ⟨(equiv.sigma_preimage_equiv list.length).symm⟩
 ... = mk (Σ n, fin n → α) : quotient.sound ⟨equiv.sigma_congr_right $ λ n,
   ⟨vector.nth, vector.of_fn, vector.of_fn_nth, λ f, funext $ vector.nth_of_fn f⟩⟩
 ... = mk (Σ n : ℕ, ulift.{u} (fin n) → α) : quotient.sound ⟨equiv.sigma_congr_right $ λ n,

--- a/src/set_theory/cofinality.lean
+++ b/src/set_theory/cofinality.lean
@@ -400,7 +400,7 @@ begin
   refine ⟨a, {x | ∃(h : x ∈ s), f ⟨x, h⟩ = a}, _, _, _⟩,
   { rintro x ⟨hx, hx'⟩, exact hx },
   { refine le_trans ha _, apply ge_of_eq, apply quotient.sound, constructor,
-    refine equiv.trans _ (equiv.subtype_subtype_equiv_subtype_ex _ _).symm,
+    refine equiv.trans _ (equiv.subtype_subtype_equiv_subtype_exists _ _).symm,
     simp only [set_coe_eq_subtype, mem_singleton_iff, mem_preimage, mem_set_of_eq] },
   rintro x ⟨hx, hx'⟩, exact hx'
 end

--- a/src/set_theory/cofinality.lean
+++ b/src/set_theory/cofinality.lean
@@ -400,7 +400,7 @@ begin
   refine ⟨a, {x | ∃(h : x ∈ s), f ⟨x, h⟩ = a}, _, _, _⟩,
   { rintro x ⟨hx, hx'⟩, exact hx },
   { refine le_trans ha _, apply ge_of_eq, apply quotient.sound, constructor,
-    refine equiv.trans _ (equiv.subtype_subtype_equiv_subtype _ _).symm,
+    refine equiv.trans _ (equiv.subtype_subtype_equiv_subtype_ex _ _).symm,
     simp only [set_coe_eq_subtype, mem_singleton_iff, mem_preimage, mem_set_of_eq] },
   rintro x ⟨hx, hx'⟩, exact hx'
 end


### PR DESCRIPTION
~~Depends on #1382 and #1384.~~ The only commit on top of these two PRs is https://github.com/leanprover-community/mathlib/pull/1385/commits/59e1d2fa77e6e7ab7c1a47acdc6780efcd4ee465

This PR contains only some basic properties of the set of divisors.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
