### PR TITLE
perf(data/gaussian_int): speed up div and mod

### DIFF
--- a/src/data/zsqrtd/gaussian_int.lean
+++ b/src/data/zsqrtd/gaussian_int.lean
@@ -78,13 +78,15 @@ lemma nat_abs_norm_eq (x : ℤ[i]) : x.norm.nat_abs =
 int.coe_nat_inj $ begin simp, simp [norm] end
 
 protected def div (x y : ℤ[i]) : ℤ[i] :=
-⟨round ((x * conj y).re / norm y : ℚ),
- round ((x * conj y).im / norm y : ℚ)⟩
+let n := (rat.of_int (norm y))⁻¹ in let c := y.conj in
+⟨round (rat.of_int (x * c).re * n : ℚ),
+ round (rat.of_int (x * c).im * n : ℚ)⟩
 
 instance : has_div ℤ[i] := ⟨gaussian_int.div⟩
 
 lemma div_def (x y : ℤ[i]) : x / y = ⟨round ((x * conj y).re / norm y : ℚ),
- round ((x * conj y).im / norm y : ℚ)⟩ := rfl
+  round ((x * conj y).im / norm y : ℚ)⟩ := 
+show zsqrtd.mk _ _ = _, by simp [rat.of_int_eq_mk, rat.mk_eq_div, div_eq_mul_inv]
 
 lemma to_complex_div_re (x y : ℤ[i]) : ((x / y : ℤ[i]) : ℂ).re = round ((x / y : ℂ).re) :=
 by rw [div_def, ← @rat.cast_round ℝ _ _];


### PR DESCRIPTION
avoid using `int.cast`, and use `rat.of_int`.

This sped up `#eval (⟨1414,152⟩ : gaussian_int) % ⟨123,456⟩` from about 5 seconds to 2 milliseconds

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
