### PR TITLE
chore(order/filter): rephrase filter.has_le

### DIFF
--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -196,7 +196,7 @@ end join
 section lattice
 
 instance : partial_order (filter α) :=
-{ le            := λf g, g.sets ⊆ f.sets,
+{ le            := λf g, ∀ ⦃U : set α⦄, U ∈ g → U ∈ f,
   le_antisymm   := assume a b h₁ h₂, filter_eq $ subset.antisymm h₂ h₁,
   le_refl       := assume a, subset.refl _,
   le_trans      := assume a b c h₁ h₂, subset.trans h₂ h₁ }
@@ -212,7 +212,7 @@ inductive generate_sets (g : set (set α)) : set α → Prop
 
 /-- `generate g` is the smallest filter containing the sets `g`. -/
 def generate (g : set (set α)) : filter α :=
-{ sets             := {s | generate_sets g s},
+{ sets             := generate_sets g,
   univ_sets        := generate_sets.univ,
   sets_of_superset := assume x y, generate_sets.superset,
   inter_sets       := assume s t, generate_sets.inter }
@@ -239,7 +239,7 @@ show u ∈ (filter.mk_of_closure s hs).sets ↔ u ∈ (generate s).sets, from hs
 def gi_generate (α : Type*) :
   @galois_insertion (set (set α)) (order_dual (filter α)) _ _ filter.generate filter.sets :=
 { gc        := assume s f, sets_iff_generate,
-  le_l_u    := assume f u, generate_sets.basic,
+  le_l_u    := assume f u h, generate_sets.basic h,
   choice    := λs hs, filter.mk_of_closure s (le_antisymm hs $ sets_iff_generate.1 $ le_refl _),
   choice_eq := assume s hs, mk_of_closure_sets }
 

--- a/src/order/filter/lift.lean
+++ b/src/order/filter/lift.lean
@@ -29,6 +29,9 @@ infi_sets_eq'
     hg $ inter_subset_left s t, hg $ inter_subset_right s t⟩)
   ⟨univ, univ_mem_sets⟩
 
+lemma mem_lift_iff (hg : monotone g) {s : set β} : s ∈ f.lift g ↔ s ∈ ⋃t∈f.sets, (g t).sets :=
+show s ∈ (f.lift g).sets ↔ _, by rw lift_sets_eq hg
+
 lemma mem_lift {s : set β} {t : set α} (ht : t ∈ f.sets) (hs : s ∈ (g t).sets) :
   s ∈ (f.lift g).sets :=
 le_principal_iff.mp $ show f.lift g ≤ principal s,
@@ -175,8 +178,7 @@ le_antisymm
           @hg s₁ s₂ ▸ le_inf (infi_le_of_le i $ infi_le_of_le s₁ $ infi_le _ hs₁) hs₂)
         (assume s₁ s₂ hs₁ hs₂, le_trans hs₂ $ g_mono hs₁),
     begin
-      rw [lift_sets_eq g_mono],
-      simp only [mem_Union, exists_imp_distrib],
+      simp only [mem_lift_iff g_mono, mem_Union, exists_imp_distrib],
       exact assume t ht hs, this t ht hs
     end)
 
@@ -302,7 +304,7 @@ le_antisymm
   (le_infi $ assume i, lift_mono (infi_le _ _) (le_refl _))
   (assume s,
   begin
-    rw [lift_sets_eq hg],
+    rw mem_lift_iff hg,
     simp only [mem_Union, exists_imp_distrib, infi_sets_eq hf hι],
     exact assume t i ht hs, mem_infi_sets i $ mem_lift ht hs
   end)

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -421,7 +421,7 @@ all_mem_nhds _ _ (λ s t ssubt h, mem_sets_of_superset h (hf s t ssubt))
 
 theorem rtendsto_nhds {r : rel β α} {l : filter β} {a : α} :
   rtendsto r l (nhds a) ↔ (∀ s, is_open s → a ∈ s → r.core s ∈ l) :=
-all_mem_nhds_filter _ _ (λ s t h, λ x hx, λ y hy, h (hx y hy)) _
+all_mem_nhds_filter _ _ (λ s t, id) _
 
 theorem rtendsto'_nhds {r : rel β α} {l : filter β} {a : α} :
   rtendsto' r l (nhds a) ↔ (∀ s, is_open s → a ∈ s → r.preimage s ∈ l) :=


### PR DESCRIPTION
The goal of this tiny refactor is to prevent `filter.sets` leaking when
proving a filter g is finer than another one f. We want the goal to be
`s ∈ f → s ∈ g` instead of the definitionaly equivalent
`s ∈ f.sets → s ∈ g.sets`