### PR TITLE
chore(algebra/ordered_field): add simp attributes to inv_pos' and others

### DIFF
--- a/src/algebra/ordered_field.lean
+++ b/src/algebra/ordered_field.lean
@@ -202,16 +202,16 @@ end nat
 section
 variables {α : Type*} [discrete_linear_ordered_field α] (a b c : α)
 
-lemma inv_pos' {a : α} : 0 < a⁻¹ ↔ 0 < a :=
+@[simp] lemma inv_pos' {a : α} : 0 < a⁻¹ ↔ 0 < a :=
 ⟨by rw [inv_eq_one_div]; exact pos_of_one_div_pos, inv_pos⟩
 
-lemma inv_neg' {a : α} : a⁻¹ < 0 ↔ a < 0 :=
+@[simp] lemma inv_neg' {a : α} : a⁻¹ < 0 ↔ a < 0 :=
 ⟨by rw [inv_eq_one_div]; exact neg_of_one_div_neg, inv_lt_zero⟩
 
-lemma inv_nonneg {a : α} : 0 ≤ a⁻¹ ↔ 0 ≤ a :=
+@[simp] lemma inv_nonneg {a : α} : 0 ≤ a⁻¹ ↔ 0 ≤ a :=
 le_iff_le_iff_lt_iff_lt.2 inv_neg'
 
-lemma inv_nonpos {a : α} : a⁻¹ ≤ 0 ↔ a ≤ 0 :=
+@[simp] lemma inv_nonpos {a : α} : a⁻¹ ≤ 0 ↔ a ≤ 0 :=
 le_iff_le_iff_lt_iff_lt.2 inv_pos'
 
 lemma abs_inv : abs a⁻¹ = (abs a)⁻¹ :=


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
