### PR TITLE
chore(algebra/group/to_additive): map_namespace should make a meta constant

### DIFF
--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -105,7 +105,7 @@ meta def aux_attr : user_attribute (name_map name) name :=
 
 meta def map_namespace (src tgt : name) : command :=
 do let n := src.mk_string "_to_additive",
-   let decl := declaration.cnst n [] `(Type) ff,
+   let decl := declaration.thm n [] `(unit) (pure (reflect ())),
    add_decl decl,
    aux_attr.set n tgt tt
 
@@ -162,7 +162,7 @@ do
 
 meta def proceed_fields (env : environment) (src tgt : name) (prio : ℕ) : command :=
 let aux := proceed_fields_aux src tgt prio in
-do
+do 
 aux (λ n, pure $ list.map name.to_string $ (env.structure_fields n).get_or_else []) >>
 aux (λ n, (list.map (λ (x : name), "to_" ++ x.to_string) <$>
                             (ancestor_attr.get_param n <|> pure []))) >>

--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -104,9 +104,8 @@ meta def aux_attr : user_attribute (name_map name) name :=
   parser    := lean.parser.ident }
 
 meta def map_namespace (src tgt : name) : command :=
-do decl ← get_decl `expr, -- random choice
-   let n := src.mk_string "_to_additive",
-   let decl := decl.update_name n,
+do let n := src.mk_string "_to_additive",
+   let decl := declaration.cnst n [] `(Type) ff,
    add_decl decl,
    aux_attr.set n tgt tt
 
@@ -163,7 +162,7 @@ do
 
 meta def proceed_fields (env : environment) (src tgt : name) (prio : ℕ) : command :=
 let aux := proceed_fields_aux src tgt prio in
-do 
+do
 aux (λ n, pure $ list.map name.to_string $ (env.structure_fields n).get_or_else []) >>
 aux (λ n, (list.map (λ (x : name), "to_" ++ x.to_string) <$>
                             (ancestor_attr.get_param n <|> pure []))) >>
@@ -254,4 +253,3 @@ attribute [to_additive] eq_mul_of_inv_mul_eq
 attribute [to_additive] mul_eq_of_eq_inv_mul
 attribute [to_additive] mul_eq_of_eq_mul_inv
 attribute [to_additive neg_add] mul_inv
-

--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -104,7 +104,7 @@ meta def aux_attr : user_attribute (name_map name) name :=
   parser    := lean.parser.ident }
 
 meta def map_namespace (src tgt : name) : command :=
-do decl ← get_decl `bool, -- random choice
+do decl ← get_decl `expr, -- random choice
    let n := src.mk_string "_to_additive",
    let decl := decl.update_name n,
    add_decl decl,


### PR DESCRIPTION
`map_namespace` now produces a `meta constant` instead of a constant. This means that after importing `group_theory/coset` and typing `#print axioms`, `quotient_group._to_additive` is not in the list, since it is now a `meta constant`. This is a little bit neater, and it doesn't look like we're adding any axioms.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
