### PR TITLE
feat(data/list/defs): move list.sum to list/defs.lean

### DIFF
--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -1372,8 +1372,9 @@ variables [is_lawful_monad m]
 
 end mfoldl_mfoldr
 
-/- sum -/
+/- prod -/
 
+-- list.sum was already defined in defs.lean, but we couldn't tag it with `to_additive` yet.
 attribute [to_additive] list.prod
 
 section monoid

--- a/src/data/list/defs.lean
+++ b/src/data/list/defs.lean
@@ -120,6 +120,13 @@ let (b', l') := scanr_aux f b l in b' :: l'
      prod [a, b, c] = ((1 * a) * b) * c -/
 def prod [has_mul α] [has_one α] : list α → α := foldl (*) 1
 
+/-- Sum of a list.
+
+     sum [a, b, c] = ((0 + a) + b) + c -/
+-- Later this will be tagged with `to_additive`, but this can't be done yet because of import
+-- dependencies.
+def sum [has_add α] [has_zero α] : list α → α := foldl (+) 0
+
 def partition_map (f : α → β ⊕ γ) : list α → list β × list γ
 | [] := ([],[])
 | (x::xs) :=


### PR DESCRIPTION
Currently, `list.prod` is defined to `list/defs.lean`, but `list.sum` waits until `list/basic.lean`, by which time we have `to_additive` available. This PR instead defines `list.sum` in parallel with `list.prod` by hand, and tags it using `to_additive` in `list/basic.lean`.

(I was tripped up by this while formalising an IMO problem, where I was trying to work with minimal imports.)