### PR TITLE
feat(algebra/order): allow simp to flip inequalities

### DIFF
--- a/src/algebra/order.lean
+++ b/src/algebra/order.lean
@@ -7,6 +7,9 @@ Authors: Mario Carneiro
 universe u
 variables {α : Type u}
 
+@[simp] lemma ge_iff_le [preorder α] {a b : α} : a ≥ b ↔ b ≤ a := iff.refl _
+@[simp] lemma gt_iff_lt [preorder α] {a b : α} : a > b ↔ b < a := iff.refl _
+
 lemma not_le_of_lt [preorder α] {a b : α} (h : a < b) : ¬ b ≤ a :=
 (le_not_le_of_lt h).right
 

--- a/src/data/rat/order.lean
+++ b/src/data/rat/order.lean
@@ -67,7 +67,7 @@ num_denom_cases_on' a $ λ n d h,
 begin
   have d0 : (d:ℤ) > 0 := int.coe_nat_pos.2 (nat.pos_of_ne_zero h),
   simp [d0, h],
-  exact λ h₁ h₂, le_antisymm (nonpos_of_neg_nonneg h₂) h₁
+  exact λ h₁ h₂, le_antisymm h₂ h₁
 end
 
 protected def nonneg_total : rat.nonneg a ∨ rat.nonneg (-a) :=

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -603,13 +603,13 @@ lemma eq_pow_of_pell_lem {a y k} (a1 : 1 < a) (ypos : y > 0) : k > 0 → a > y^k
 have y < a → 2*a*y ≥ a + (y*y + 1), begin
   intro ya, induction y with y IH, exact absurd ypos (lt_irrefl _),
   cases nat.eq_zero_or_pos y with y0 ypos,
-  { rw y0, simp [two_mul], apply add_le_add_left, exact a1 },
+  { rw y0, simpa [two_mul], },
   { rw [nat.mul_succ, nat.mul_succ, nat.succ_mul y],
     have : 2 * a ≥ y + nat.succ y,
     { change y + y < 2 * a, rw ← two_mul,
       exact mul_lt_mul_of_pos_left (nat.lt_of_succ_lt ya) dec_trivial },
     have := add_le_add (IH ypos (nat.lt_of_succ_lt ya)) this,
-    simp at this, simp, exact this }
+    simpa }
 end, λk0 yak,
 lt_of_lt_of_le (int.coe_nat_lt_coe_nat_of_lt yak) $
 by rw sub_sub; apply le_sub_right_of_add_le;

--- a/src/tactic/linarith.lean
+++ b/src/tactic/linarith.lean
@@ -67,7 +67,7 @@ neg_of_neg_pos (by simpa)
 
 lemma mul_nonpos {α} [ordered_ring α] {a b : α} (ha : a ≤ 0) (hb : b > 0) : b * a ≤ 0 :=
 have (-b)*a ≥ 0, from mul_nonneg_of_nonpos_of_nonpos (le_of_lt (neg_neg_of_pos hb)) ha,
-nonpos_of_neg_nonneg (by simp at this; exact this)
+(by simpa)
 
 lemma mul_eq {α} [ordered_semiring α] {a b : α} (ha : a = 0) (hb : b > 0) : b * a = 0 :=
 by simp *


### PR DESCRIPTION
We have a constant problem that while `a > b` is definitionally equal to `b < a`, tactics that work at the syntactic level can't see this.

This change introduces two simp lemmas, rewriting `>` and `≥` in terms of `<` and `≤`. This requires a few tweaks elsewhere (essentially places where `simp` now finishes or comes closer to finishing).

Later, I would like to
1. Just do some general cleanup, replacing lots of `>` with `<` in basic files.
2. Start adding `@[simp]` to many more lemmas about inequalities.
3. Provide substitutes for the default `well_founded` tactics, which actually break when `simp` is too good at inequalities. See #1419.