### PR TITLE
feat(tactic/{abel,ring}): state conditions of tactics more precisely

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -169,9 +169,23 @@ they are only meant to be used on small, straightforward problems.
 All accept an optional list of simplifier rules, typically definitions that should be expanded.
 (The equations and identities should not refer to the local context.) All also accept an optional list of `ematch` lemmas, which must be preceded by `using`.
 
+### abel
+
+Evaluate expressions in the language of *additive*, commutative monoids and groups.
+It attempts to prove the goal outright if there is no `at`
+specifier and the target is an equality, but if this
+fails, it falls back to rewriting all monoid expressions into a normal form.
+If there is an `at` specifier, it rewrites the given target into a normal form.
+```lean
+example {α : Type*} {a b : α} [add_comm_monoid α] : a + (b + a) = a + a + b := by abel
+example {α : Type*} {a b : α} [add_comm_group α] : (a + b) - ((b + a) + a) = -a := by abel
+example {α : Type*} {a b : α} [add_comm_group α] (hyp : a + a - a = b - b) : a = 0 :=
+by { abel at hyp, exact hyp }
+```
+
 ### ring
 
-Evaluate expressions in the language of (semi-)rings.
+Evaluate expressions in the language of *commutative* (semi)rings.
 Based on [Proving Equalities in a Commutative Ring Done Right in Coq](http://www.cs.ru.nl/~freek/courses/tt-2014/read/10.1.1.61.3041.pdf) by Benjamin Grégoire and Assia Mahboubi.
 
 ### congr'

--- a/src/tactic/abel.lean
+++ b/src/tactic/abel.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 
-Evaluate expressions in the language of commutative monoids and groups.
+Evaluate expressions in the language of additive, commutative monoids and groups.
 -/
 import algebra.group_power tactic.norm_num
 
@@ -289,7 +289,7 @@ open tactic.abel
 local postfix `?`:9001 := optional
 
 /-- Tactic for solving equations in the language of
-  commutative monoids and groups.
+  *additive*, commutative monoids and groups.
   This version of `abel` fails if the target is not an equality
   that is provable by the axioms of commutative monoids/groups. -/
 meta def abel1 : tactic unit :=
@@ -311,7 +311,7 @@ do mode ← ident?, match mode with
 end
 
 /-- Tactic for solving equations in the language of
-  commutative monoids and groups.
+  *additive*, commutative monoids and groups.
   Attempts to prove the goal outright if there is no `at`
   specifier and the target is an equality, but if this
   fails it falls back to rewriting all monoid expressions

--- a/src/tactic/ring.lean
+++ b/src/tactic/ring.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 
-Evaluate expressions in the language of (semi-)rings.
+Evaluate expressions in the language of commutative (semi)rings.
 Based on http://www.cs.ru.nl/~freek/courses/tt-2014/read/10.1.1.61.3041.pdf .
 -/
 import algebra.group_power tactic.norm_num
@@ -470,7 +470,7 @@ open tactic.ring
 
 local postfix `?`:9001 := optional
 
-/-- Tactic for solving equations in the language of rings.
+/-- Tactic for solving equations in the language of *commutative* (semi)rings.
   This version of `ring` fails if the target is not an equality
   that is provable by the axioms of commutative (semi)rings. -/
 meta def ring1 (red : parse (tk "!")?) : tactic unit :=
@@ -492,7 +492,7 @@ do mode ← ident?, match mode with
 | _            := failed
 end
 
-/-- Tactic for solving equations in the language of rings.
+/-- Tactic for solving equations in the language of *commutative* (semi)rings.
   Attempts to prove the goal outright if there is no `at`
   specifier and the target is an equality, but if this
   fails it falls back to rewriting all ring expressions

--- a/test/abel.lean
+++ b/test/abel.lean
@@ -1,0 +1,5 @@
+import tactic.abel
+variables {α : Type*} {a b : α}
+
+example [add_comm_monoid α] : a + (b + a) = a + a + b := by abel
+example [add_comm_group α] : (a + b) - ((b + a) + a) = -a := by abel


### PR DESCRIPTION
### What
1. update docstrings for `abel` and `ring` to make assumptions clear
2. Add `abel` to the tactic document and test folder

### Why
1. I - just like other users before [[1](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/abelian.20failure), [2](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Abel.20tactic.20problem)] - got confused that `abel` does not work, for example, for `comm_group` instances. Moreover, `ring` does not work on rings but commutative (semi)rings. 
2. `abel` was missing from the tactic document and test folder

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
