### PR TITLE
feat(tactic/auto_cases): run auto_cases on false and psigma

### DIFF
--- a/src/tactic/auto_cases.lean
+++ b/src/tactic/auto_cases.lean
@@ -15,6 +15,7 @@ do t' ← infer_type h,
   let use_cases := match t' with
   | `(empty)     := tt
   | `(pempty)    := tt
+  | `(false)     := tt
   | `(unit)      := tt
   | `(punit)     := tt
   | `(ulift _)   := tt
@@ -22,6 +23,7 @@ do t' ← infer_type h,
   | `(prod _ _)  := tt
   | `(and _ _)   := tt
   | `(sigma _)   := tt
+  | `(psigma _)  := tt
   | `(subtype _) := tt
   | `(Exists _)  := tt
   | `(fin 0)     := tt


### PR DESCRIPTION
`auto_cases` is a tactic that runs `cases` on any "likely looking" hypotheses. It's mainly (solely?) used as a component on `tidy` at the moment. This PR adds `false` and `psigma _ _` to the list of hypothesis patterns that `auto_cases` will call `cases` on.