### PR TITLE
fix(algebra/*/colimits): avoid explicit `infer_instance`

### DIFF
--- a/src/algebra/CommRing/colimits.lean
+++ b/src/algebra/CommRing/colimits.lean
@@ -427,8 +427,7 @@ def colimit_is_colimit : is_colimit (colimit_cocone F) :=
     refl
   end }.
 
--- FIXME why is this infer_instance needed!?
-instance has_colimits_CommRing : @has_colimits CommRing.{v} infer_instance :=
+instance has_colimits_CommRing : has_colimits.{v} CommRing.{v} :=
 { has_colimits_of_shape := λ J 𝒥,
   { has_colimit := λ F, by exactI
     { cocone := colimit_cocone F,

--- a/src/algebra/Mon/colimits.lean
+++ b/src/algebra/Mon/colimits.lean
@@ -231,8 +231,7 @@ def colimit_is_colimit : is_colimit (colimit_cocone F) :=
     refl
   end }.
 
--- FIXME why is this infer_instance needed!?
-instance has_colimits_Mon : @has_colimits Mon.{v} infer_instance :=
+instance has_colimits_Mon : has_colimits.{v} Mon.{v} :=
 { has_colimits_of_shape := λ J 𝒥,
   { has_colimit := λ F, by exactI
     { cocone := colimit_cocone F,


### PR DESCRIPTION
With an explicit universe level Lean can do it automatically.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
