### PR TITLE
chore(data/*): flipping inequalities

### DIFF
--- a/src/algebra/archimedean.lean
+++ b/src/algebra/archimedean.lean
@@ -24,7 +24,7 @@ let ⟨n, h⟩ := archimedean.arch x zero_lt_one in
 section linear_ordered_ring
 variables [linear_ordered_ring α] [archimedean α]
 
-lemma pow_unbounded_of_gt_one (x : α) {y : α}
+lemma pow_unbounded_of_one_lt (x : α) {y : α}
     (hy1 : 1 < y) : ∃ n : ℕ, x < y ^ n :=
 have hy0 : 0 <  y - 1 := sub_pos_of_lt hy1,
 let ⟨n, h⟩ := archimedean.arch x hy0 in
@@ -34,7 +34,7 @@ let ⟨n, h⟩ := archimedean.arch x hy0 in
 
 lemma exists_nat_pow_near {x : α} {y : α} (hx : 1 < x) (hy : 1 < y) :
   ∃ n : ℕ, y ^ n ≤ x ∧ x < y ^ (n + 1) :=
-have h : ∃ n : ℕ, x < y ^ n, from pow_unbounded_of_gt_one _ hy,
+have h : ∃ n : ℕ, x < y ^ n, from pow_unbounded_of_one_lt _ hy,
 by classical; exact let n := nat.find h in
   have hn  : x < y ^ n, from nat.find_spec h,
   have hnp : 0 < n,     from nat.pos_iff_ne_zero.2 (λ hn0,
@@ -71,11 +71,11 @@ lemma exists_int_pow_near [discrete_linear_ordered_field α] [archimedean α]
   {x : α} {y : α} (hx : 0 < x) (hy : 1 < y) :
   ∃ n : ℤ, y ^ n ≤ x ∧ x < y ^ (n + 1) :=
 by classical; exact
-let ⟨N, hN⟩ := pow_unbounded_of_gt_one x⁻¹ hy in
+let ⟨N, hN⟩ := pow_unbounded_of_one_lt x⁻¹ hy in
   have he: ∃ m : ℤ, y ^ m ≤ x, from
     ⟨-N, le_of_lt (by rw [(fpow_neg y (↑N)), one_div_eq_inv];
     exact (inv_lt hx (lt_trans (inv_pos hx) hN)).1 hN)⟩,
-let ⟨M, hM⟩ := pow_unbounded_of_gt_one x hy in
+let ⟨M, hM⟩ := pow_unbounded_of_one_lt x hy in
   have hb: ∃ b : ℤ, ∀ m, y ^ m ≤ x → m ≤ b, from
     ⟨M, λ m hm, le_of_not_lt (λ hlt, not_lt_of_ge
   (fpow_le_of_le (le_of_lt hy) (le_of_lt hlt)) (lt_of_le_of_lt hm hM))⟩,

--- a/src/algebra/archimedean.lean
+++ b/src/algebra/archimedean.lean
@@ -30,7 +30,7 @@ have hy0 : 0 <  y - 1 := sub_pos_of_lt hy1,
 let ⟨n, h⟩ := archimedean.arch x hy0 in
 ⟨n, calc x ≤ n • (y - 1)     : h
        ... < 1 + n • (y - 1) : by rw add_comm; exact lt_add_one _
-       ... ≤ y ^ n           : pow_ge_one_add_sub_mul (le_of_lt hy1) _⟩
+       ... ≤ y ^ n           : one_add_sub_mul_le_pow (le_of_lt hy1) _⟩
 
 lemma exists_nat_pow_near {x : α} {y : α} (hx : 1 < x) (hy : 1 < y) :
   ∃ n : ℕ, y ^ n ≤ x ∧ x < y ^ (n + 1) :=

--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -108,11 +108,11 @@ open int
 
 variables {α : Type u} [discrete_linear_ordered_field α]
 
-lemma fpow_nonneg_of_nonneg {a : α} (ha : a ≥ 0) : ∀ (z : ℤ), a ^ z ≥ 0
+lemma fpow_nonneg_of_nonneg {a : α} (ha : 0 ≤ a) : ∀ (z : ℤ), 0 ≤ a ^ z
 | (of_nat n) := pow_nonneg ha _
 | -[1+n] := div_nonneg' zero_le_one $ pow_nonneg ha _
 
-lemma fpow_pos_of_pos {a : α} (ha : a > 0) : ∀ (z : ℤ), a ^ z > 0
+lemma fpow_pos_of_pos {a : α} (ha : 0 < a) : ∀ (z : ℤ), 0 < a ^ z
 | (of_nat n) := pow_pos ha _
 | -[1+n] := div_pos zero_lt_one $ pow_pos ha _
 
@@ -136,7 +136,7 @@ begin
     repeat { apply pow_pos (lt_of_lt_of_le zero_lt_one hx) } }
 end
 
-lemma pow_le_max_of_min_le {x : α} (hx : x ≥ 1) {a b c : ℤ} (h : min a b ≤ c) :
+lemma pow_le_max_of_min_le {x : α} (hx : 1 ≤ x) {a b c : ℤ} (h : min a b ≤ c) :
       x ^ (-c) ≤ max (x ^ (-a)) (x ^ (-b)) :=
 begin
   wlog hle : a ≤ b,
@@ -148,17 +148,17 @@ begin
   simpa only [max_eq_left hfle]
 end
 
-lemma fpow_le_one_of_nonpos {p : α} (hp : p ≥ 1) {z : ℤ} (hz : z ≤ 0) : p ^ z ≤ 1 :=
+lemma fpow_le_one_of_nonpos {p : α} (hp : 1 ≤ p) {z : ℤ} (hz : z ≤ 0) : p ^ z ≤ 1 :=
 calc p ^ z ≤ p ^ 0 : fpow_le_of_le hp hz
           ... = 1        : by simp
 
-lemma fpow_ge_one_of_nonneg {p : α} (hp : p ≥ 1) {z : ℤ} (hz : z ≥ 0) : p ^ z ≥ 1 :=
+lemma fpow_ge_one_of_nonneg {p : α} (hp : 1 ≤ p) {z : ℤ} (hz : 0 ≤ z) : 1 ≤ p ^ z :=
 calc p ^ z ≥ p ^ 0 : fpow_le_of_le hp hz
           ... = 1        : by simp
 
 end ordered_field_power
 
-lemma one_lt_pow {α} [linear_ordered_semiring α] {p : α} (hp : p > 1) : ∀ {n : ℕ}, 1 ≤ n → 1 < p ^ n
+lemma one_lt_pow {α} [linear_ordered_semiring α] {p : α} (hp : 1 < p) : ∀ {n : ℕ}, 1 ≤ n → 1 < p ^ n
 | 1 h := by simp; assumption
 | (k+2) h :=
   begin
@@ -170,6 +170,6 @@ lemma one_lt_pow {α} [linear_ordered_semiring α] {p : α} (hp : p > 1) : ∀ {
     { apply le_of_lt (lt_trans zero_lt_one hp) }
   end
 
-lemma one_lt_fpow {α}  [discrete_linear_ordered_field α] {p : α} (hp : p > 1) :
-  ∀ z : ℤ, z > 0 → 1 < p ^ z
+lemma one_lt_fpow {α}  [discrete_linear_ordered_field α] {p : α} (hp : 1 < p) :
+  ∀ z : ℤ, 0 < z → 1 < p ^ z
 | (int.of_nat n) h := one_lt_pow hp (nat.succ_le_of_lt (int.lt_of_coe_nat_lt_coe_nat h))

--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -152,7 +152,7 @@ lemma fpow_le_one_of_nonpos {p : α} (hp : 1 ≤ p) {z : ℤ} (hz : z ≤ 0) : p
 calc p ^ z ≤ p ^ 0 : fpow_le_of_le hp hz
           ... = 1        : by simp
 
-lemma fpow_ge_one_of_nonneg {p : α} (hp : 1 ≤ p) {z : ℤ} (hz : 0 ≤ z) : 1 ≤ p ^ z :=
+lemma one_le_fpow_of_nonneg {p : α} (hp : 1 ≤ p) {z : ℤ} (hz : 0 ≤ z) : 1 ≤ p ^ z :=
 calc p ^ z ≥ p ^ 0 : fpow_le_of_le hp hz
           ... = 1        : by simp
 

--- a/src/algebra/floor.lean
+++ b/src/algebra/floor.lean
@@ -218,7 +218,7 @@ lemma ceil_pos {a : α} : 0 < ⌈a⌉ ↔ 0 < a :=
 
 @[simp] theorem ceil_zero : ⌈(0 : α)⌉ = 0 := by simp [ceil]
 
-lemma ceil_nonneg [decidable_rel ((<) : α → α → Prop)] {q : α} (hq : q ≥ 0) : ⌈q⌉ ≥ 0 :=
+lemma ceil_nonneg [decidable_rel ((<) : α → α → Prop)] {q : α} (hq : 0 ≤ q) : 0 ≤ ⌈q⌉ :=
 if h : q > 0 then le_of_lt $ ceil_pos.2 h
 else by rw [le_antisymm (le_of_not_lt h) hq, ceil_zero]; trivial
 

--- a/src/algebra/gcd_domain.lean
+++ b/src/algebra/gcd_domain.lean
@@ -465,10 +465,10 @@ by simp [(int.coe_nat_eq_coe_nat_iff _ _).symm, coe_gcd, coe_nat_abs_eq_normaliz
 theorem gcd_mul_right (i j k : ℤ) : gcd (i * j) (k * j) = gcd i k * nat_abs j :=
 by simp [(int.coe_nat_eq_coe_nat_iff _ _).symm, coe_gcd, coe_nat_abs_eq_normalize]
 
-theorem gcd_pos_of_non_zero_left {i : ℤ} (j : ℤ) (i_non_zero : i ≠ 0) : gcd i j > 0 :=
+theorem gcd_pos_of_non_zero_left {i : ℤ} (j : ℤ) (i_non_zero : i ≠ 0) : 0 < gcd i j :=
 nat.gcd_pos_of_pos_left (nat_abs j) (nat_abs_pos_of_ne_zero i_non_zero)
 
-theorem gcd_pos_of_non_zero_right (i : ℤ) {j : ℤ} (j_non_zero : j ≠ 0) : gcd i j > 0 :=
+theorem gcd_pos_of_non_zero_right (i : ℤ) {j : ℤ} (j_non_zero : j ≠ 0) : 0 < gcd i j :=
 nat.gcd_pos_of_pos_right (nat_abs i) (nat_abs_pos_of_ne_zero j_non_zero)
 
 theorem gcd_eq_zero_iff {i j : ℤ} : gcd i j = 0 ↔ i = 0 ∧ j = 0 :=

--- a/src/algebra/group_power.lean
+++ b/src/algebra/group_power.lean
@@ -167,11 +167,11 @@ by induction n with n ih; [exact one_inv.symm,
 @[simp] theorem add_monoid.neg_smul : ∀ (a : β) (n : ℕ), n•(-a) = -(n•a) :=
 @inv_pow (multiplicative β) _
 
-theorem pow_sub (a : α) {m n : ℕ} (h : m ≥ n) : a^(m - n) = a^m * (a^n)⁻¹ :=
+theorem pow_sub (a : α) {m n : ℕ} (h : n ≤ m) : a^(m - n) = a^m * (a^n)⁻¹ :=
 have h1 : m - n + n = m, from nat.sub_add_cancel h,
 have h2 : a^(m - n) * a^n = a^m, by rw [←pow_add, h1],
 eq_mul_inv_of_mul_eq h2
-theorem add_monoid.smul_sub : ∀ (a : β) {m n : ℕ}, m ≥ n → (m - n)•a = m•a - n•a :=
+theorem add_monoid.smul_sub : ∀ (a : β) {m n : ℕ}, n ≤ m → (m - n)•a = m•a - n•a :=
 @pow_sub (multiplicative β) _
 
 theorem pow_inv_comm (a : α) (m n : ℕ) : (a⁻¹)^m * a^n = a^n * (a⁻¹)^m :=
@@ -524,7 +524,7 @@ theorem one_le_pow_of_one_le {a : α} (H : 1 ≤ a) : ∀ (n : ℕ), 1 ≤ a ^ n
 | (n+1) := by simpa only [mul_one] using mul_le_mul H (one_le_pow_of_one_le n)
     zero_le_one (le_trans zero_le_one H)
 
-theorem pow_ge_one_add_mul {a : α} (H : a ≥ 0) :
+theorem pow_ge_one_add_mul {a : α} (H : 0 ≤ a) :
   ∀ (n : ℕ), 1 + n • a ≤ (1 + a) ^ n
 | 0     := le_of_eq $ add_zero _
 | (n+1) := begin
@@ -596,7 +596,7 @@ theorem pow_two_nonneg [linear_ordered_ring α] (a : α) : 0 ≤ a ^ 2 :=
 by rw pow_two; exact mul_self_nonneg _
 
 theorem pow_ge_one_add_sub_mul [linear_ordered_ring α]
-  {a : α} (H : a ≥ 1) (n : ℕ) : 1 + n • (a - 1) ≤ a ^ n :=
+  {a : α} (H : 1 ≤ a) (n : ℕ) : 1 + n • (a - 1) ≤ a ^ n :=
 by simpa only [add_sub_cancel'_right] using pow_ge_one_add_mul (sub_nonneg.2 H) n
 
 namespace int

--- a/src/algebra/group_power.lean
+++ b/src/algebra/group_power.lean
@@ -524,13 +524,13 @@ theorem one_le_pow_of_one_le {a : α} (H : 1 ≤ a) : ∀ (n : ℕ), 1 ≤ a ^ n
 | (n+1) := by simpa only [mul_one] using mul_le_mul H (one_le_pow_of_one_le n)
     zero_le_one (le_trans zero_le_one H)
 
-theorem pow_ge_one_add_mul {a : α} (H : 0 ≤ a) :
+theorem one_add_mul_le_pow {a : α} (H : 0 ≤ a) :
   ∀ (n : ℕ), 1 + n • a ≤ (1 + a) ^ n
 | 0     := le_of_eq $ add_zero _
 | (n+1) := begin
   rw [pow_succ', succ_smul'],
   refine le_trans _ (mul_le_mul_of_nonneg_right
-    (pow_ge_one_add_mul n) (add_nonneg zero_le_one H)),
+    (one_add_mul_le_pow n) (add_nonneg zero_le_one H)),
   rw [mul_add, mul_one, ← add_assoc, add_le_add_iff_left],
   simpa only [one_mul] using mul_le_mul_of_nonneg_right
     ((le_add_iff_nonneg_right 1).2 (add_monoid.smul_nonneg H n)) H
@@ -595,9 +595,9 @@ end linear_ordered_semiring
 theorem pow_two_nonneg [linear_ordered_ring α] (a : α) : 0 ≤ a ^ 2 :=
 by rw pow_two; exact mul_self_nonneg _
 
-theorem pow_ge_one_add_sub_mul [linear_ordered_ring α]
+theorem one_add_sub_mul_le_pow [linear_ordered_ring α]
   {a : α} (H : 1 ≤ a) (n : ℕ) : 1 + n • (a - 1) ≤ a ^ n :=
-by simpa only [add_sub_cancel'_right] using pow_ge_one_add_mul (sub_nonneg.2 H) n
+by simpa only [add_sub_cancel'_right] using one_add_mul_le_pow (sub_nonneg.2 H) n
 
 namespace int
 

--- a/src/algebra/order.lean
+++ b/src/algebra/order.lean
@@ -152,7 +152,7 @@ begin
   apply h₂, apply le_antisymm; apply le_of_not_gt; assumption
 end
 
-lemma ne_iff_lt_or_gt [decidable_linear_order α] {a b : α} : a ≠ b ↔ a < b ∨ a > b :=
+lemma ne_iff_lt_or_gt [decidable_linear_order α] {a b : α} : a ≠ b ↔ a < b ∨ b < a :=
 ⟨lt_or_gt_of_ne, λo, o.elim ne_of_lt ne_of_gt⟩
 
 lemma le_imp_le_of_lt_imp_lt {β} [preorder α] [decidable_linear_order β]

--- a/src/algebra/order_functions.lean
+++ b/src/algebra/order_functions.lean
@@ -208,7 +208,7 @@ def sub_abs_le_abs_sub := @abs_sub_abs_le_abs_sub
 lemma abs_abs_sub_le_abs_sub (a b : α) : abs (abs a - abs b) ≤ abs (a - b) :=
 abs_sub_le_iff.2 ⟨sub_abs_le_abs_sub _ _, by rw abs_sub; apply sub_abs_le_abs_sub⟩
 
-lemma abs_eq (hb : b ≥ 0) : abs a = b ↔ a = b ∨ a = -b :=
+lemma abs_eq (hb : 0 ≤ b0) : abs a = b ↔ a = b ∨ a = -b :=
 iff.intro
   begin
     cases le_total a 0 with a_nonpos a_nonneg,

--- a/src/algebra/order_functions.lean
+++ b/src/algebra/order_functions.lean
@@ -208,7 +208,7 @@ def sub_abs_le_abs_sub := @abs_sub_abs_le_abs_sub
 lemma abs_abs_sub_le_abs_sub (a b : α) : abs (abs a - abs b) ≤ abs (a - b) :=
 abs_sub_le_iff.2 ⟨sub_abs_le_abs_sub _ _, by rw abs_sub; apply sub_abs_le_abs_sub⟩
 
-lemma abs_eq (hb : 0 ≤ b0) : abs a = b ↔ a = b ∨ a = -b :=
+lemma abs_eq (hb : 0 ≤ b) : abs a = b ↔ a = b ∨ a = -b :=
 iff.intro
   begin
     cases le_total a 0 with a_nonpos a_nonneg,

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -46,11 +46,11 @@ ordered_comm_monoid.lt_of_add_lt_add_left a b c
 lemma add_le_add' (h₁ : a ≤ b) (h₂ : c ≤ d) : a + c ≤ b + d :=
 le_trans (add_le_add_right' h₁) (add_le_add_left' h₂)
 
-lemma le_add_of_nonneg_right' (h : b ≥ 0) : a ≤ a + b :=
+lemma le_add_of_nonneg_right' (h : 0 ≤ b) : a ≤ a + b :=
 have a + b ≥ a + 0, from add_le_add_left' h,
 by rwa add_zero at this
 
-lemma le_add_of_nonneg_left' (h : b ≥ 0) : a ≤ b + a :=
+lemma le_add_of_nonneg_left' (h : 0 ≤ b) : a ≤ b + a :=
 have 0 + a ≤ b + a, from add_le_add_right' h,
 by rwa zero_add at this
 

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -52,14 +52,14 @@ lemma lt_mul_iff_one_lt_right {a b : α} (hb : 0 < b) : b < b * a ↔ 1 < a :=
 suffices b * 1 < b * a ↔ 1 < a, by rwa mul_one at this,
 mul_lt_mul_left hb
 
-lemma lt_mul_of_gt_one_right' {a b : α} (hb : 0 < b) : 1 < a → b < b * a :=
+lemma lt_mul_of_one_lt_right' {a b : α} (hb : 0 < b) : 1 < a → b < b * a :=
 (lt_mul_iff_one_lt_right hb).2
 
-lemma le_mul_of_ge_one_right' {a b : α} (hb : 0 ≤ b) (h : 1 ≤ a) : b ≤ b * a :=
+lemma le_mul_of_one_le_right' {a b : α} (hb : 0 ≤ b) (h : 1 ≤ a) : b ≤ b * a :=
 suffices b * 1 ≤ b * a, by rwa mul_one at this,
 mul_le_mul_of_nonneg_left h hb
 
-lemma le_mul_of_ge_one_left' {a b : α} (hb : 0 ≤ b) (h : 1 ≤ a) : b ≤ a * b :=
+lemma le_mul_of_one_le_left' {a b : α} (hb : 0 ≤ b) (h : 1 ≤ a) : b ≤ a * b :=
 suffices 1 * b ≤ a * b, by rwa one_mul at this,
 mul_le_mul_of_nonneg_right h hb
 

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -8,12 +8,11 @@ import tactic.split_ifs order.basic algebra.order algebra.ordered_group algebra.
 universe u
 variable {α : Type u}
 
--- TODO: this is necessary additionally to mul_nonneg otherwise the simplifier can not match
-lemma zero_le_mul [ordered_semiring α] {a b : α} : 0 ≤ a → 0 ≤ b → 0 ≤ a * b :=
+-- `mul_nonneg` and `mul_pos` in core are stated in terms of `≥` and `>`, so we restate them here
+-- for use in syntactic tactics (e.g. `simp` and `rw`).
+lemma mul_nonneg' [ordered_semiring α] {a b : α} : 0 ≤ a → 0 ≤ b → 0 ≤ a * b :=
 mul_nonneg
 
--- mul_pos in core is stated in terms of `>`, so we restate it here for
--- the sake of syntactic tactics (e.g. `simp` and `rw`).
 lemma mul_pos' [ordered_semiring α] {a b : α} (ha : 0 < a) (hb : 0 < b) : 0 < a * b :=
 mul_pos ha hb
 

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -12,6 +12,11 @@ variable {α : Type u}
 lemma zero_le_mul [ordered_semiring α] {a b : α} : 0 ≤ a → 0 ≤ b → 0 ≤ a * b :=
 mul_nonneg
 
+-- mul_pos in core is stated in terms of `>`, so we restate it here for
+-- the sake of syntactic tactics (e.g. `simp` and `rw`).
+lemma mul_pos' [ordered_semiring α] {a b : α} (ha : 0 < a) (hb : 0 < b) : 0 < a * b :=
+mul_pos ha hb
+
 section linear_ordered_semiring
 variable [linear_ordered_semiring α]
 

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -36,30 +36,30 @@ lemma mul_lt_mul'' {a b c d : α} (h1 : a < c) (h2 : b < d) (h3 : 0 ≤ a) (h4 :
   (λ b0, by rw [← b0, mul_zero]; exact
     mul_pos (lt_of_le_of_lt h3 h1) (lt_of_le_of_lt h4 h2))
 
-lemma le_mul_iff_one_le_left {a b : α} (hb : b > 0) : b ≤ a * b ↔ 1 ≤ a :=
+lemma le_mul_iff_one_le_left {a b : α} (hb : 0 < b) : b ≤ a * b ↔ 1 ≤ a :=
 suffices 1 * b ≤ a * b ↔ 1 ≤ a, by rwa one_mul at this,
 mul_le_mul_right hb
 
-lemma lt_mul_iff_one_lt_left {a b : α} (hb : b > 0) : b < a * b ↔ 1 < a :=
+lemma lt_mul_iff_one_lt_left {a b : α} (hb : 0 < b) : b < a * b ↔ 1 < a :=
 suffices 1 * b < a * b ↔ 1 < a, by rwa one_mul at this,
 mul_lt_mul_right hb
 
-lemma le_mul_iff_one_le_right {a b : α} (hb : b > 0) : b ≤ b * a ↔ 1 ≤ a :=
+lemma le_mul_iff_one_le_right {a b : α} (hb : 0 < b) : b ≤ b * a ↔ 1 ≤ a :=
 suffices b * 1 ≤ b * a ↔ 1 ≤ a, by rwa mul_one at this,
 mul_le_mul_left hb
 
-lemma lt_mul_iff_one_lt_right {a b : α} (hb : b > 0) : b < b * a ↔ 1 < a :=
+lemma lt_mul_iff_one_lt_right {a b : α} (hb : 0 < b) : b < b * a ↔ 1 < a :=
 suffices b * 1 < b * a ↔ 1 < a, by rwa mul_one at this,
 mul_lt_mul_left hb
 
-lemma lt_mul_of_gt_one_right' {a b : α} (hb : b > 0) : a > 1 → b < b * a :=
+lemma lt_mul_of_gt_one_right' {a b : α} (hb : 0 < b) : 1 < a → b < b * a :=
 (lt_mul_iff_one_lt_right hb).2
 
-lemma le_mul_of_ge_one_right' {a b : α} (hb : b ≥ 0) (h : a ≥ 1) : b ≤ b * a :=
+lemma le_mul_of_ge_one_right' {a b : α} (hb : 0 ≤ b) (h : 1 ≤ a) : b ≤ b * a :=
 suffices b * 1 ≤ b * a, by rwa mul_one at this,
 mul_le_mul_of_nonneg_left h hb
 
-lemma le_mul_of_ge_one_left' {a b : α} (hb : b ≥ 0) (h : a ≥ 1) : b ≤ a * b :=
+lemma le_mul_of_ge_one_left' {a b : α} (hb : 0 ≤ b) (h : 1 ≤ a) : b ≤ a * b :=
 suffices 1 * b ≤ a * b, by rwa one_mul at this,
 mul_le_mul_of_nonneg_right h hb
 
@@ -109,19 +109,19 @@ lemma mul_lt_one_of_nonneg_of_lt_one_right {a b : α}
 calc a * b ≤ b : mul_le_of_le_one_left hb0 ha
 ... < 1 : hb
 
-lemma mul_le_iff_le_one_left {a b : α} (hb : b > 0) : a * b ≤ b ↔ a ≤ 1 :=
+lemma mul_le_iff_le_one_left {a b : α} (hb : 0 < b) : a * b ≤ b ↔ a ≤ 1 :=
 ⟨ λ h, le_of_not_lt (mt (lt_mul_iff_one_lt_left hb).2 (not_lt_of_ge h)),
   λ h, le_of_not_lt (mt (lt_mul_iff_one_lt_left hb).1 (not_lt_of_ge h)) ⟩
 
-lemma mul_lt_iff_lt_one_left {a b : α} (hb : b > 0) : a * b < b ↔ a < 1 :=
+lemma mul_lt_iff_lt_one_left {a b : α} (hb : 0 < b) : a * b < b ↔ a < 1 :=
 ⟨ λ h, lt_of_not_ge (mt (le_mul_iff_one_le_left hb).2 (not_le_of_gt h)),
   λ h, lt_of_not_ge (mt (le_mul_iff_one_le_left hb).1 (not_le_of_gt h)) ⟩
 
-lemma mul_le_iff_le_one_right {a b : α} (hb : b > 0) : b * a ≤ b ↔ a ≤ 1 :=
+lemma mul_le_iff_le_one_right {a b : α} (hb : 0 < b) : b * a ≤ b ↔ a ≤ 1 :=
 ⟨ λ h, le_of_not_lt (mt (lt_mul_iff_one_lt_right hb).2 (not_lt_of_ge h)),
   λ h, le_of_not_lt (mt (lt_mul_iff_one_lt_right hb).1 (not_lt_of_ge h)) ⟩
 
-lemma mul_lt_iff_lt_one_right {a b : α} (hb : b > 0) : b * a < b ↔ a < 1 :=
+lemma mul_lt_iff_lt_one_right {a b : α} (hb : 0 < b) : b * a < b ↔ a < 1 :=
 ⟨ λ h, lt_of_not_ge (mt (le_mul_iff_one_le_right hb).2 (not_le_of_gt h)),
   λ h, lt_of_not_ge (mt (le_mul_iff_one_le_right hb).1 (not_le_of_gt h)) ⟩
 

--- a/src/analysis/convex.lean
+++ b/src/analysis/convex.lean
@@ -474,7 +474,7 @@ begin
         { rw finset.mul_sum.symm,
           exact division_ring.inv_mul_cancel h_cases },
         { intros i hi,
-          exact zero_le_mul (inv_nonneg.2 h_sum_nonneg) (ha i (finset.mem_insert_of_mem hi))},
+          exact mul_nonneg (inv_nonneg.2 h_sum_nonneg) (ha i (finset.mem_insert_of_mem hi))},
         { intros i hi,
           exact hz i (finset.mem_insert_of_mem hi) } },
       have h_sum_in_A: a k • z k
@@ -621,7 +621,7 @@ begin
                   ≤ s.sum (λ (i : γ), ((s.sum a)⁻¹ * a i) • f (z i)),
     { apply ih _ hf,
       { intros i hi,
-        exact zero_le_mul (inv_nonneg.2 h_sum_nonneg) (ha i (finset.mem_insert_of_mem hi))},
+        exact mul_nonneg (inv_nonneg.2 h_sum_nonneg) (ha i (finset.mem_insert_of_mem hi))},
       { intros i hi,
         exact hz i (finset.mem_insert_of_mem hi) },
       { rw finset.mul_sum.symm,
@@ -631,7 +631,7 @@ begin
       { rw finset.mul_sum.symm,
         exact division_ring.inv_mul_cancel h_cases },
       { intros i hi,
-        exact zero_le_mul (inv_nonneg.2 h_sum_nonneg) (ha i (finset.mem_insert_of_mem hi))},
+        exact mul_nonneg (inv_nonneg.2 h_sum_nonneg) (ha i (finset.mem_insert_of_mem hi))},
       { intros i hi,
         exact hz i (finset.mem_insert_of_mem hi) } },
     have hf': f (a k • z k     + s.sum a •    s.sum (λ (i : γ), ((finset.sum s a)⁻¹ * a i) • z i))

--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -34,7 +34,7 @@ tendsto_infi.2 $ assume p, tendsto_principal.2 $
       ... ≤ n * (r - 1) : mul_le_mul (le_of_lt hn) (le_refl _) (le_of_lt this) hn_nn
       ... ≤ 1 + n * (r - 1) : le_add_of_nonneg_of_le zero_le_one (le_refl _)
       ... = 1 + add_monoid.smul n (r - 1) : by rw [add_monoid.smul_eq_mul]
-      ... ≤ (1 + (r - 1)) ^ n : pow_ge_one_add_mul (le_of_lt this) _
+      ... ≤ (1 + (r - 1)) ^ n : one_add_mul_le_pow (le_of_lt this) _
       ... ≤ r ^ n : by simp; exact le_refl _,
   show {n | p ≤ r ^ n} ∈ at_top,
     from mem_at_top_sets.mpr ⟨n, assume m hnm, le_trans this (pow_le_pow (le_of_lt h) hnm)⟩

--- a/src/computability/partrec_code.lean
+++ b/src/computability/partrec_code.lean
@@ -809,7 +809,7 @@ private lemma evaln_map (k c n) :
 begin
   by_cases kn : n < k,
   { simp [list.nth_range kn] },
-  { rw list.nth_ge_len,
+  { rw list.nth_len_le,
     { cases e : evaln k c n, {refl},
       exact kn.elim (evaln_bound e) },
     simpa using kn }

--- a/src/computability/primrec.lean
+++ b/src/computability/primrec.lean
@@ -60,7 +60,7 @@ protected theorem id : primrec id :=
 
 theorem prec1 {f} (m : ℕ) (hf : primrec f) : primrec (λ n,
    n.elim m (λ y IH, f $ mkpair y IH)) :=
-((prec (const m) (hf.comp right)).comp 
+((prec (const m) (hf.comp right)).comp
   (zero.pair primrec.id)).of_eq $
 λ n, by simp; dsimp; rw [unpair_mkpair]
 
@@ -761,7 +761,7 @@ this.of_eq $ λ a, begin
     generalize : f a = l, generalize : g a = x,
     induction n with n IH generalizing l x, {refl},
     simp, cases l with b l; simp [IH] },
-  rw [this, list.take_all_of_ge (length_le_encode _)]
+  rw [this, list.take_all_of_le (length_le_encode _)]
 end
 
 private lemma list_cons' : by haveI := prim H; exact primrec₂ (@list.cons β) :=
@@ -1237,7 +1237,7 @@ theorem if_lt {n a b f g}
 λ v, begin
   cases e : b v - a v,
   { simp [not_lt.2 (nat.le_of_sub_eq_zero e)] },
-  { simp [nat.lt_of_sub_eq_succ e] }  
+  { simp [nat.lt_of_sub_eq_succ e] }
 end
 
 theorem mkpair : @primrec' 2 (λ v, v.head.mkpair v.tail.head) :=

--- a/src/data/equiv/fin.lean
+++ b/src/data/equiv/fin.lean
@@ -54,11 +54,11 @@ def fin_prod_fin_equiv : fin m × fin n ≃ fin (m * n) :=
     ... = (x.1.1 + 1) * n : eq.symm $ nat.succ_mul _ _
     ... ≤ m * n : nat.mul_le_mul_right _ x.1.2⟩,
   inv_fun := λ x,
-    have H : n > 0, from nat.pos_of_ne_zero $ λ H, nat.not_lt_zero x.1 $ by subst H; from x.2,
+    have H : 0 < n, from nat.pos_of_ne_zero $ λ H, nat.not_lt_zero x.1 $ by subst H; from x.2,
     (⟨x.1 / n, (nat.div_lt_iff_lt_mul _ _ H).2 x.2⟩,
      ⟨x.1 % n, nat.mod_lt _ H⟩),
   left_inv := λ ⟨x, y⟩,
-    have H : n > 0, from nat.pos_of_ne_zero $ λ H, nat.not_lt_zero y.1 $ H ▸ y.2,
+    have H : 0 < n, from nat.pos_of_ne_zero $ λ H, nat.not_lt_zero y.1 $ H ▸ y.2,
     prod.ext
       (fin.eq_of_veq $ calc
               (y.1 + n * x.1) / n

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -112,7 +112,7 @@ else i.pred $
   ne_of_gt (lt_of_le_of_lt (zero_le p) this)
 
 /-- `sub_nat i h` subtracts `m` from `i`, generalizes `fin.pred`. -/
-def sub_nat (m) (i : fin (n + m)) (h : i.val ≥ m) : fin n :=
+def sub_nat (m) (i : fin (n + m)) (h : m ≤ i.val) : fin n :=
 ⟨i.val - m, by simp [nat.sub_lt_right_iff_lt_add h, i.is_lt]⟩
 
 /-- `add_nat i h` adds `m` on `i`, generalizes `fin.succ`. -/
@@ -144,10 +144,10 @@ fin.eq_of_veq rfl
 @[simp] lemma cast_lt_cast_succ {n : ℕ} (a : fin n) (h : a.1 < n) : cast_lt (cast_succ a) h = a :=
 by cases a; refl
 
-@[simp] lemma sub_nat_val (i : fin (n + m)) (h : i.val ≥ m) : (i.sub_nat m h).val = i.val - m :=
+@[simp] lemma sub_nat_val (i : fin (n + m)) (h : m ≤ i.val) : (i.sub_nat m h).val = i.val - m :=
 rfl
 
-@[simp] lemma add_nat_val (i : fin (n + m)) (h : i.val ≥ m) : (i.add_nat m).val = i.val + m :=
+@[simp] lemma add_nat_val (i : fin (n + m)) (h : m ≤ i.val) : (i.add_nat m).val = i.val + m :=
 rfl
 
 @[simp] lemma cast_succ_inj {a b : fin n} : a.cast_succ = b.cast_succ ↔ a = b :=

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -1052,7 +1052,7 @@ lemma card_eq_succ [decidable_eq α] {s : finset α} {n : ℕ} :
   s.card = n + 1 ↔ (∃a t, a ∉ t ∧ insert a t = s ∧ card t = n) :=
 iff.intro
   (assume eq,
-    have card s > 0, from eq.symm ▸ nat.zero_lt_succ _,
+    have 0 < card s, from eq.symm ▸ nat.zero_lt_succ _,
     let ⟨a, has⟩ := finset.exists_mem_of_ne_empty $ card_pos.mp this in
     ⟨a, s.erase a, s.not_mem_erase a, insert_erase has, by simp only [eq, card_erase_of_mem has, pred_succ]⟩)
   (assume ⟨a, t, hat, s_eq, n_eq⟩, s_eq ▸ n_eq ▸ card_insert_of_not_mem hat)
@@ -1903,7 +1903,7 @@ end
 theorem eq_cons {n m : ℕ} (h : n < m) : Ico n m = insert n (Ico (n + 1) m) :=
 by rw [← to_finset, multiset.Ico.eq_cons h, multiset.to_finset_cons, to_finset]
 
-@[simp] theorem pred_singleton {m : ℕ} (h : m > 0) : Ico (m - 1) m = {m - 1} :=
+@[simp] theorem pred_singleton {m : ℕ} (h : 0 < m) : Ico (m - 1) m = {m - 1} :=
 eq_of_veq $ multiset.Ico.pred_singleton h
 
 @[simp] theorem not_mem_top {n m : ℕ} : m ∉ Ico n m :=
@@ -1921,16 +1921,16 @@ eq_of_veq $ multiset.Ico.filter_lt_of_ge hlm
 @[simp] lemma filter_lt (n m l : ℕ) : (Ico n m).filter (λ x, x < l) = Ico n (min m l) :=
 eq_of_veq $ multiset.Ico.filter_lt n m l
 
-lemma filter_ge_of_le_bot {n m l : ℕ} (hln : l ≤ n) : (Ico n m).filter (λ x, x ≥ l) = Ico n m :=
+lemma filter_ge_of_le_bot {n m l : ℕ} (hln : l ≤ n) : (Ico n m).filter (λ x, l ≤ x) = Ico n m :=
 eq_of_veq $ multiset.Ico.filter_ge_of_le_bot hln
 
-lemma filter_ge_of_top_le {n m l : ℕ} (hml : m ≤ l) : (Ico n m).filter (λ x, x ≥ l) = ∅ :=
+lemma filter_ge_of_top_le {n m l : ℕ} (hml : m ≤ l) : (Ico n m).filter (λ x, l ≤ x) = ∅ :=
 eq_of_veq $ multiset.Ico.filter_ge_of_top_le hml
 
-lemma filter_ge_of_ge {n m l : ℕ} (hnl : n ≤ l) : (Ico n m).filter (λ x, x ≥ l) = Ico l m :=
+lemma filter_ge_of_ge {n m l : ℕ} (hnl : n ≤ l) : (Ico n m).filter (λ x, l ≤ x) = Ico l m :=
 eq_of_veq $ multiset.Ico.filter_ge_of_ge hnl
 
-@[simp] lemma filter_ge (n m l : ℕ) : (Ico n m).filter (λ x, x ≥ l) = Ico (max n l) m :=
+@[simp] lemma filter_ge (n m l : ℕ) : (Ico n m).filter (λ x, l ≤ x) = Ico (max n l) m :=
 eq_of_veq $ multiset.Ico.filter_ge n m l
 
 @[simp] lemma diff_left (l n m : ℕ) : (Ico n m) \ (Ico n l) = Ico (max n l) m :=

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -1930,8 +1930,8 @@ eq_of_veq $ multiset.Ico.filter_le_of_top_le hml
 lemma filter_le_of_le {n m l : ℕ} (hnl : n ≤ l) : (Ico n m).filter (λ x, l ≤ x) = Ico l m :=
 eq_of_veq $ multiset.Ico.filter_le_of_le hnl
 
-@[simp] lemma filter_ge (n m l : ℕ) : (Ico n m).filter (λ x, l ≤ x) = Ico (max n l) m :=
-eq_of_veq $ multiset.Ico.filter_ge n m l
+@[simp] lemma filter_le (n m l : ℕ) : (Ico n m).filter (λ x, l ≤ x) = Ico (max n l) m :=
+eq_of_veq $ multiset.Ico.filter_le n m l
 
 @[simp] lemma diff_left (l n m : ℕ) : (Ico n m) \ (Ico n l) = Ico (max n l) m :=
 by ext k; by_cases n ≤ k; simp [h, and_comm]

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -1921,14 +1921,14 @@ eq_of_veq $ multiset.Ico.filter_lt_of_ge hlm
 @[simp] lemma filter_lt (n m l : ℕ) : (Ico n m).filter (λ x, x < l) = Ico n (min m l) :=
 eq_of_veq $ multiset.Ico.filter_lt n m l
 
-lemma filter_ge_of_le_bot {n m l : ℕ} (hln : l ≤ n) : (Ico n m).filter (λ x, l ≤ x) = Ico n m :=
-eq_of_veq $ multiset.Ico.filter_ge_of_le_bot hln
+lemma filter_le_of_le_bot {n m l : ℕ} (hln : l ≤ n) : (Ico n m).filter (λ x, l ≤ x) = Ico n m :=
+eq_of_veq $ multiset.Ico.filter_le_of_le_bot hln
 
-lemma filter_ge_of_top_le {n m l : ℕ} (hml : m ≤ l) : (Ico n m).filter (λ x, l ≤ x) = ∅ :=
-eq_of_veq $ multiset.Ico.filter_ge_of_top_le hml
+lemma filter_le_of_top_le {n m l : ℕ} (hml : m ≤ l) : (Ico n m).filter (λ x, l ≤ x) = ∅ :=
+eq_of_veq $ multiset.Ico.filter_le_of_top_le hml
 
-lemma filter_ge_of_ge {n m l : ℕ} (hnl : n ≤ l) : (Ico n m).filter (λ x, l ≤ x) = Ico l m :=
-eq_of_veq $ multiset.Ico.filter_ge_of_ge hnl
+lemma filter_le_of_le {n m l : ℕ} (hnl : n ≤ l) : (Ico n m).filter (λ x, l ≤ x) = Ico l m :=
+eq_of_veq $ multiset.Ico.filter_le_of_le hnl
 
 @[simp] lemma filter_ge (n m l : ℕ) : (Ico n m).filter (λ x, l ≤ x) = Ico (max n l) m :=
 eq_of_veq $ multiset.Ico.filter_ge n m l

--- a/src/data/fintype.lean
+++ b/src/data/fintype.lean
@@ -337,7 +337,7 @@ match n, hn with
     (λ _ _ _, h _ _))⟩
 end
 
-lemma fintype.exists_ne_of_card_gt_one [fintype α] (h : fintype.card α > 1) (a : α) :
+lemma fintype.exists_ne_of_card_gt_one [fintype α] (h : 1 < fintype.card α) (a : α) :
   ∃ b : α, b ≠ a :=
 let ⟨b, hb⟩ := classical.not_forall.1 (mt fintype.card_le_one_iff.2 (not_le_of_gt h)) in
 let ⟨c, hc⟩ := classical.not_forall.1 hb in

--- a/src/data/fintype.lean
+++ b/src/data/fintype.lean
@@ -337,7 +337,7 @@ match n, hn with
     (λ _ _ _, h _ _))⟩
 end
 
-lemma fintype.exists_ne_of_card_gt_one [fintype α] (h : 1 < fintype.card α) (a : α) :
+lemma fintype.exists_ne_of_one_lt_card [fintype α] (h : 1 < fintype.card α) (a : α) :
   ∃ b : α, b ≠ a :=
 let ⟨b, hb⟩ := classical.not_forall.1 (mt fintype.card_le_one_iff.2 (not_le_of_gt h)) in
 let ⟨c, hc⟩ := classical.not_forall.1 hb in

--- a/src/data/fp/basic.lean
+++ b/src/data/fp/basic.lean
@@ -19,7 +19,7 @@ inductive rmode
 
 class float_cfg :=
 (prec emax : ℕ)
-(prec_pos : prec > 0)
+(prec_pos : 0 < prec)
 (prec_max : prec ≤ emax)
 
 variable [C : float_cfg]

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -114,7 +114,7 @@ begin
 end
 
 protected def induction_on' {C : ℤ → Sort*} (z : ℤ) (b : ℤ) :
-  C b → (∀ k ≥ b, C k → C (k + 1)) → (∀ k ≤ b, C k → C (k - 1)) → C z :=
+  C b → (∀ k, b ≤ k → C k → C (k + 1)) → (∀ k ≤ b, C k → C (k - 1)) → C z :=
 λ H0 Hs Hp,
 begin
   rw ←sub_add_cancel z b,
@@ -169,7 +169,7 @@ lemma nat_abs_ne_zero_of_ne_zero {z : ℤ} (hz : z ≠ 0) : z.nat_abs ≠ 0 :=
 
 @[simp, move_cast] theorem coe_nat_div (m n : ℕ) : ((m / n : ℕ) : ℤ) = m / n := rfl
 
-theorem neg_succ_of_nat_div (m : ℕ) {b : ℤ} (H : b > 0) :
+theorem neg_succ_of_nat_div (m : ℕ) {b : ℤ} (H : 0 < b) :
   -[1+m] / b = -(m / b + 1) :=
 match b, eq_succ_of_zero_lt H with ._, ⟨n, rfl⟩ := rfl end
 
@@ -183,21 +183,21 @@ match b, eq_succ_of_zero_lt H with ._, ⟨n, rfl⟩ := rfl end
 | -[1+ m] -[1+ n] := rfl
 
 
-theorem div_of_neg_of_pos {a b : ℤ} (Ha : a < 0) (Hb : b > 0) : a / b = -((-a - 1) / b + 1) :=
+theorem div_of_neg_of_pos {a b : ℤ} (Ha : a < 0) (Hb : 0 < b) : a / b = -((-a - 1) / b + 1) :=
 match a, b, eq_neg_succ_of_lt_zero Ha, eq_succ_of_zero_lt Hb with
 | ._, ._, ⟨m, rfl⟩, ⟨n, rfl⟩ :=
   by change (- -[1+ m] : ℤ) with (m+1 : ℤ); rw add_sub_cancel; refl
 end
 
-protected theorem div_nonneg {a b : ℤ} (Ha : a ≥ 0) (Hb : b ≥ 0) : a / b ≥ 0 :=
+protected theorem div_nonneg {a b : ℤ} (Ha : 0 ≤ a) (Hb : 0 ≤ b) : 0 ≤ a / b :=
 match a, b, eq_coe_of_zero_le Ha, eq_coe_of_zero_le Hb with
 | ._, ._, ⟨m, rfl⟩, ⟨n, rfl⟩ := coe_zero_le _
 end
 
-protected theorem div_nonpos {a b : ℤ} (Ha : a ≥ 0) (Hb : b ≤ 0) : a / b ≤ 0 :=
+protected theorem div_nonpos {a b : ℤ} (Ha : 0 ≤ a) (Hb : b ≤ 0) : a / b ≤ 0 :=
 nonpos_of_neg_nonneg $ by rw [← int.div_neg]; exact int.div_nonneg Ha (neg_nonneg_of_nonpos Hb)
 
-theorem div_neg' {a b : ℤ} (Ha : a < 0) (Hb : b > 0) : a / b < 0 :=
+theorem div_neg' {a b : ℤ} (Ha : a < 0) (Hb : 0 < b) : a / b < 0 :=
 match a, b, eq_neg_succ_of_lt_zero Ha, eq_succ_of_zero_lt Hb with
 | ._, ._, ⟨m, rfl⟩, ⟨n, rfl⟩ := neg_succ_lt_zero _
 end
@@ -251,7 +251,7 @@ have ∀ {k n : ℕ} {a : ℤ}, (a + n * k.succ) / k.succ = a / k.succ + n, from
       rw [mul_comm, nat.sub_mul_div], rwa mul_comm } }
   end
 end,
-have ∀ {a b c : ℤ}, c > 0 → (a + b * c) / c = a / c + b, from
+have ∀ {a b c : ℤ}, 0 < c → (a + b * c) / c = a / c + b, from
 λ a b c H, match c, eq_succ_of_zero_lt H, b with
 | ._, ⟨k, rfl⟩, (n : ℕ) := this
 | ._, ⟨k, rfl⟩, -[1+ n] :=
@@ -285,7 +285,7 @@ theorem of_nat_mod (m n : nat) : (m % n : ℤ) = of_nat (m % n) := rfl
 
 @[simp] theorem coe_nat_mod (m n : ℕ) : (↑(m % n) : ℤ) = ↑m % ↑n := rfl
 
-theorem neg_succ_of_nat_mod (m : ℕ) {b : ℤ} (bpos : b > 0) :
+theorem neg_succ_of_nat_mod (m : ℕ) {b : ℤ} (bpos : 0 < b) :
   -[1+m] % b = b - 1 - m % b :=
 by rw [sub_sub, add_comm]; exact
 match b, eq_succ_of_zero_lt bpos with ._, ⟨n, rfl⟩ := rfl end
@@ -314,12 +314,12 @@ match a, b, eq_coe_of_zero_le H1, eq_coe_of_zero_le (le_trans H1 (le_of_lt H2)),
   congr_arg of_nat $ nat.mod_eq_of_lt (lt_of_coe_nat_lt_coe_nat H2)
 end
 
-theorem mod_nonneg : ∀ (a : ℤ) {b : ℤ}, b ≠ 0 → a % b ≥ 0
+theorem mod_nonneg : ∀ (a : ℤ) {b : ℤ}, b ≠ 0 → 0 ≤ a % b
 | (m : ℕ) n H := coe_zero_le _
 | -[1+ m] n H :=
   sub_nonneg_of_le $ coe_nat_le_coe_nat_of_le $ nat.mod_lt _ (nat_abs_pos_of_ne_zero H)
 
-theorem mod_lt_of_pos (a : ℤ) {b : ℤ} (H : b > 0) : a % b < b :=
+theorem mod_lt_of_pos (a : ℤ) {b : ℤ} (H : 0 < b) : a % b < b :=
 match a, b, eq_succ_of_zero_lt H with
 | (m : ℕ), ._, ⟨n, rfl⟩ := coe_nat_lt_coe_nat_of_lt (nat.mod_lt _ (nat.succ_pos _))
 | -[1+ m], ._, ⟨n, rfl⟩ := sub_lt_self _ (coe_nat_lt_coe_nat_of_lt $ nat.succ_pos _)
@@ -415,7 +415,7 @@ end
 
 /- properties of / and % -/
 
-@[simp] theorem mul_div_mul_of_pos {a : ℤ} (b c : ℤ) (H : a > 0) : a * b / (a * c) = b / c :=
+@[simp] theorem mul_div_mul_of_pos {a : ℤ} (b c : ℤ) (H : 0 < a) : a * b / (a * c) = b / c :=
 suffices ∀ (m k : ℕ) (b : ℤ), (m.succ * b / (m.succ * k) : ℤ) = b / k, from
 match a, eq_succ_of_zero_lt H, c, eq_coe_or_neg c with
 | ._, ⟨m, rfl⟩, ._, ⟨k, or.inl rfl⟩ := this _ _ _
@@ -440,14 +440,14 @@ end,
   end
 end
 
-@[simp] theorem mul_div_mul_of_pos_left (a : ℤ) {b : ℤ} (c : ℤ) (H : b > 0) :
+@[simp] theorem mul_div_mul_of_pos_left (a : ℤ) {b : ℤ} (c : ℤ) (H : 0 < b) :
   a * b / (c * b) = a / c :=
 by rw [mul_comm, mul_comm c, mul_div_mul_of_pos _ _ H]
 
-@[simp] theorem mul_mod_mul_of_pos {a : ℤ} (b c : ℤ) (H : a > 0) : a * b % (a * c) = a * (b % c) :=
+@[simp] theorem mul_mod_mul_of_pos {a : ℤ} (b c : ℤ) (H : 0 < a) : a * b % (a * c) = a * (b % c) :=
 by rw [mod_def, mod_def, mul_div_mul_of_pos _ _ H, mul_sub_left_distrib, mul_assoc]
 
-theorem lt_div_add_one_mul_self (a : ℤ) {b : ℤ} (H : b > 0) : a < (a / b + 1) * b :=
+theorem lt_div_add_one_mul_self (a : ℤ) {b : ℤ} (H : 0 < b) : a < (a / b + 1) * b :=
 by rw [add_mul, one_mul, mul_comm]; apply lt_add_of_sub_left_lt;
    rw [← mod_def]; apply mod_lt_of_pos _ H
 
@@ -464,7 +464,7 @@ coe_nat_le_coe_nat_of_le (match a, n with
 | -[1+ m], n+1 := nat.succ_le_succ (nat.div_le_self _ _)
 end)
 
-theorem div_le_self {a : ℤ} (b : ℤ) (Ha : a ≥ 0) : a / b ≤ a :=
+theorem div_le_self {a : ℤ} (b : ℤ) (Ha : 0 ≤ a) : a / b ≤ a :=
 by have := le_trans (le_abs_self _) (abs_div_le_abs a b);
    rwa [abs_of_nonneg Ha] at this
 
@@ -475,8 +475,8 @@ theorem div_mul_cancel_of_mod_eq_zero {a b : ℤ} (H : a % b = 0) : a / b * b = 
 by rw [mul_comm, mul_div_cancel_of_mod_eq_zero H]
 
 lemma mod_two_eq_zero_or_one (n : ℤ) : n % 2 = 0 ∨ n % 2 = 1 :=
-have h : n % 2 < 2 := abs_of_nonneg (show (2 : ℤ) ≥ 0, from dec_trivial) ▸ int.mod_lt _ dec_trivial,
-have h₁ : n % 2 ≥ 0 := int.mod_nonneg _ dec_trivial,
+have h : n % 2 < 2 := abs_of_nonneg (show 0 ≤ (2 : ℤ), from dec_trivial) ▸ int.mod_lt _ dec_trivial,
+have h₁ : 0 ≤ n % 2 := int.mod_nonneg _ dec_trivial,
 match (n % 2), h, h₁ with
 | (0 : ℕ) := λ _ _, or.inl rfl
 | (1 : ℕ) := λ _ _, or.inr rfl
@@ -501,7 +501,7 @@ by rcases nat_abs_eq z with eq | eq; rw eq; simp [coe_nat_dvd]
 theorem coe_nat_dvd_right {n : ℕ} {z : ℤ} : z ∣ (↑n : ℤ) ↔ z.nat_abs ∣ n :=
 by rcases nat_abs_eq z with eq | eq; rw eq; simp [coe_nat_dvd]
 
-theorem dvd_antisymm {a b : ℤ} (H1 : a ≥ 0) (H2 : b ≥ 0) : a ∣ b → b ∣ a → a = b :=
+theorem dvd_antisymm {a b : ℤ} (H1 : 0 ≤ a) (H2 : 0 ≤ b) : a ∣ b → b ∣ a → a = b :=
 begin
   rw [← abs_of_nonneg H1, ← abs_of_nonneg H2, abs_eq_nat_abs, abs_eq_nat_abs],
   rw [coe_nat_dvd, coe_nat_dvd, coe_nat_inj'],
@@ -604,7 +604,7 @@ theorem mul_sign : ∀ (i : ℤ), i * sign i = nat_abs i
 | 0       := mul_zero _
 | -[1+ n] := mul_neg_one _
 
-theorem le_of_dvd {a b : ℤ} (bpos : b > 0) (H : a ∣ b) : a ≤ b :=
+theorem le_of_dvd {a b : ℤ} (bpos : 0 < b) (H : a ∣ b) : a ≤ b :=
 match a, b, eq_succ_of_zero_lt bpos, H with
 | (m : ℕ), ._, ⟨n, rfl⟩, H := coe_nat_le_coe_nat_of_le $
   nat.le_of_dvd n.succ_pos $ coe_nat_dvd.1 H
@@ -612,16 +612,16 @@ match a, b, eq_succ_of_zero_lt bpos, H with
   le_trans (le_of_lt $ neg_succ_lt_zero _) (coe_zero_le _)
 end
 
-theorem eq_one_of_dvd_one {a : ℤ} (H : a ≥ 0) (H' : a ∣ 1) : a = 1 :=
+theorem eq_one_of_dvd_one {a : ℤ} (H : 0 ≤ a) (H' : a ∣ 1) : a = 1 :=
 match a, eq_coe_of_zero_le H, H' with
 | ._, ⟨n, rfl⟩, H' := congr_arg coe $
   nat.eq_one_of_dvd_one $ coe_nat_dvd.1 H'
 end
 
-theorem eq_one_of_mul_eq_one_right {a b : ℤ} (H : a ≥ 0) (H' : a * b = 1) : a = 1 :=
+theorem eq_one_of_mul_eq_one_right {a b : ℤ} (H : 0 ≤ a) (H' : a * b = 1) : a = 1 :=
 eq_one_of_dvd_one H ⟨b, H'.symm⟩
 
-theorem eq_one_of_mul_eq_one_left {a b : ℤ} (H : b ≥ 0) (H' : a * b = 1) : b = 1 :=
+theorem eq_one_of_mul_eq_one_left {a b : ℤ} (H : 0 ≤ b) (H' : a * b = 1) : b = 1 :=
 eq_one_of_mul_eq_one_right H (by rw [mul_comm, H'])
 
 lemma of_nat_dvd_of_dvd_nat_abs {a : ℕ} : ∀ {z : ℤ} (haz : a ∣ z.nat_abs), ↑a ∣ z
@@ -664,47 +664,47 @@ by rw ←nat.pow_one p; exact pow_dvd_of_le_of_pow_dvd hk hpk
 protected theorem div_mul_le (a : ℤ) {b : ℤ} (H : b ≠ 0) : a / b * b ≤ a :=
 le_of_sub_nonneg $ by rw [mul_comm, ← mod_def]; apply mod_nonneg _ H
 
-protected theorem div_le_of_le_mul {a b c : ℤ} (H : c > 0) (H' : a ≤ b * c) : a / c ≤ b :=
+protected theorem div_le_of_le_mul {a b c : ℤ} (H : 0 < c) (H' : a ≤ b * c) : a / c ≤ b :=
 le_of_mul_le_mul_right (le_trans (int.div_mul_le _ (ne_of_gt H)) H') H
 
-protected theorem mul_lt_of_lt_div {a b c : ℤ} (H : c > 0) (H3 : a < b / c) : a * c < b :=
+protected theorem mul_lt_of_lt_div {a b c : ℤ} (H : 0 < c) (H3 : a < b / c) : a * c < b :=
 lt_of_not_ge $ mt (int.div_le_of_le_mul H) (not_le_of_gt H3)
 
-protected theorem mul_le_of_le_div {a b c : ℤ} (H1 : c > 0) (H2 : a ≤ b / c) : a * c ≤ b :=
+protected theorem mul_le_of_le_div {a b c : ℤ} (H1 : 0 < c) (H2 : a ≤ b / c) : a * c ≤ b :=
 le_trans (mul_le_mul_of_nonneg_right H2 (le_of_lt H1)) (int.div_mul_le _ (ne_of_gt H1))
 
-protected theorem le_div_of_mul_le {a b c : ℤ} (H1 : c > 0) (H2 : a * c ≤ b) : a ≤ b / c :=
+protected theorem le_div_of_mul_le {a b c : ℤ} (H1 : 0 < c) (H2 : a * c ≤ b) : a ≤ b / c :=
 le_of_lt_add_one $ lt_of_mul_lt_mul_right
   (lt_of_le_of_lt H2 (lt_div_add_one_mul_self _ H1)) (le_of_lt H1)
 
-protected theorem le_div_iff_mul_le {a b c : ℤ} (H : c > 0) : a ≤ b / c ↔ a * c ≤ b :=
+protected theorem le_div_iff_mul_le {a b c : ℤ} (H : 0 < c) : a ≤ b / c ↔ a * c ≤ b :=
 ⟨int.mul_le_of_le_div H, int.le_div_of_mul_le H⟩
 
-protected theorem div_le_div {a b c : ℤ} (H : c > 0) (H' : a ≤ b) : a / c ≤ b / c :=
+protected theorem div_le_div {a b c : ℤ} (H : 0 < c) (H' : a ≤ b) : a / c ≤ b / c :=
 int.le_div_of_mul_le H (le_trans (int.div_mul_le _ (ne_of_gt H)) H')
 
-protected theorem div_lt_of_lt_mul {a b c : ℤ} (H : c > 0) (H' : a < b * c) : a / c < b :=
+protected theorem div_lt_of_lt_mul {a b c : ℤ} (H : 0 < c) (H' : a < b * c) : a / c < b :=
 lt_of_not_ge $ mt (int.mul_le_of_le_div H) (not_le_of_gt H')
 
-protected theorem lt_mul_of_div_lt {a b c : ℤ} (H1 : c > 0) (H2 : a / c < b) : a < b * c :=
+protected theorem lt_mul_of_div_lt {a b c : ℤ} (H1 : 0 < c) (H2 : a / c < b) : a < b * c :=
 lt_of_not_ge $ mt (int.le_div_of_mul_le H1) (not_le_of_gt H2)
 
-protected theorem div_lt_iff_lt_mul {a b c : ℤ} (H : c > 0) : a / c < b ↔ a < b * c :=
+protected theorem div_lt_iff_lt_mul {a b c : ℤ} (H : 0 < c) : a / c < b ↔ a < b * c :=
 ⟨int.lt_mul_of_div_lt H, int.div_lt_of_lt_mul H⟩
 
-protected theorem le_mul_of_div_le {a b c : ℤ} (H1 : b ≥ 0) (H2 : b ∣ a) (H3 : a / b ≤ c) :
+protected theorem le_mul_of_div_le {a b c : ℤ} (H1 : 0 ≤ b) (H2 : b ∣ a) (H3 : a / b ≤ c) :
   a ≤ c * b :=
 by rw [← int.div_mul_cancel H2]; exact mul_le_mul_of_nonneg_right H3 H1
 
-protected theorem lt_div_of_mul_lt {a b c : ℤ} (H1 : b ≥ 0) (H2 : b ∣ c) (H3 : a * b < c) :
+protected theorem lt_div_of_mul_lt {a b c : ℤ} (H1 : 0 ≤ b) (H2 : b ∣ c) (H3 : a * b < c) :
   a < c / b :=
 lt_of_not_ge $ mt (int.le_mul_of_div_le H1 H2) (not_le_of_gt H3)
 
-protected theorem lt_div_iff_mul_lt {a b : ℤ} (c : ℤ) (H : c > 0) (H' : c ∣ b) :
+protected theorem lt_div_iff_mul_lt {a b : ℤ} (c : ℤ) (H : 0 < c) (H' : c ∣ b) :
   a < b / c ↔ a * c < b :=
 ⟨int.mul_lt_of_lt_div H, int.lt_div_of_mul_lt (le_of_lt H) H'⟩
 
-theorem div_pos_of_pos_of_dvd {a b : ℤ} (H1 : a > 0) (H2 : b ≥ 0) (H3 : b ∣ a) : a / b > 0 :=
+theorem div_pos_of_pos_of_dvd {a b : ℤ} (H1 : 0 < a) (H2 : 0 ≤ b) (H3 : b ∣ a) : 0 < a / b :=
 int.lt_div_of_mul_lt H2 H3 (by rwa zero_mul)
 
 theorem div_eq_div_of_mul_eq_mul {a b c d : ℤ} (H1 : b ∣ a) (H2 : d ∣ c) (H3 : b ≠ 0)
@@ -735,7 +735,7 @@ begin
 end
 
 theorem of_nat_add_neg_succ_of_nat_of_ge {m n : ℕ}
-  (h : m ≥ n.succ) : of_nat m + -[1+n] = of_nat (m - n.succ) :=
+  (h : n.succ ≤ m) : of_nat m + -[1+n] = of_nat (m - n.succ) :=
 begin
  change sub_nat_nat _ _ = _,
  have h' : n.succ - m = 0,

--- a/src/data/int/modeq.lean
+++ b/src/data/int/modeq.lean
@@ -111,13 +111,13 @@ lemma mod_coprime {a b : ℕ} (hab : coprime a b) : ∃ y : ℤ, a * y ≡ 1 [ZM
    ↑a * gcd_a a b ≡ ↑a*gcd_a a b + ↑b*gcd_b a b [ZMOD ↑b] : int.modeq.symm $ modeq_add_fac _ $ int.modeq.refl _
               ... ≡ 1 [ZMOD ↑b] : by rw [←gcd_eq_gcd_ab, hgcd]; reflexivity ⟩
 
-lemma exists_unique_equiv (a : ℤ) {b : ℤ} (hb : b > 0) : ∃ z : ℤ, 0 ≤ z ∧ z < b ∧ z ≡ a [ZMOD b] :=
+lemma exists_unique_equiv (a : ℤ) {b : ℤ} (hb : 0 < b) : ∃ z : ℤ, 0 ≤ z ∧ z < b ∧ z ≡ a [ZMOD b] :=
 ⟨ a % b, int.mod_nonneg _ (ne_of_gt hb),
   have a % b < abs b, from int.mod_lt _ (ne_of_gt hb),
   by rwa abs_of_pos hb at this,
   by simp [int.modeq] ⟩
 
-lemma exists_unique_equiv_nat (a : ℤ) {b : ℤ} (hb : b > 0) : ∃ z : ℕ, ↑z < b ∧ ↑z ≡ a [ZMOD b] :=
+lemma exists_unique_equiv_nat (a : ℤ) {b : ℤ} (hb : 0 < b) : ∃ z : ℕ, ↑z < b ∧ ↑z ≡ a [ZMOD b] :=
 let ⟨z, hz1, hz2, hz3⟩ := exists_unique_equiv a hb in
 ⟨z.nat_abs, by split; rw [←int.of_nat_eq_coe, int.of_nat_nat_abs_eq_of_nonneg hz1]; assumption⟩
 

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -1060,14 +1060,14 @@ theorem take_cons (n) (a : α) (l : list α) : take (succ n) (a::l) = a :: take 
 | []     := rfl
 | (a::l) := begin change a :: (take (length l) l) = a :: l, rw take_all end
 
-theorem take_all_of_ge : ∀ {n} {l : list α}, length l ≤ n → take n l = l
+theorem take_all_of_le : ∀ {n} {l : list α}, length l ≤ n → take n l = l
 | 0     []     h := rfl
 | 0     (a::l) h := absurd h (not_le_of_gt (zero_lt_succ _))
 | (n+1) []     h := rfl
 | (n+1) (a::l) h :=
   begin
     change a :: take n l = a :: l,
-    rw [take_all_of_ge (le_of_succ_le_succ h)]
+    rw [take_all_of_le (le_of_succ_le_succ h)]
   end
 
 @[simp] theorem take_left : ∀ l₁ l₂ : list α, take (length l₁) (l₁ ++ l₂) = l₁

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -770,7 +770,7 @@ theorem nth_le_nth : ∀ {l : list α} {n} h, nth l n = some (nth_le l n h)
 | (a :: l) 0     h := rfl
 | (a :: l) (n+1) h := @nth_le_nth l n _
 
-theorem nth_ge_len : ∀ {l : list α} {n}, n ≥ length l → nth l n = none
+theorem nth_ge_len : ∀ {l : list α} {n}, length l ≤ n → nth l n = none
 | []       n     h := rfl
 | (a :: l) (n+1) h := nth_ge_len (le_of_succ_le_succ h)
 
@@ -1009,7 +1009,7 @@ lemma remove_nth_insert_nth (n:ℕ) (l : list α) : (l.insert_nth n a).remove_nt
 by rw [remove_nth_eq_nth_tail, insert_nth, modify_nth_tail_modify_nth_tail_same];
 from modify_nth_tail_id _ _
 
-lemma insert_nth_remove_nth_of_ge : ∀n m as, n < length as → m ≥ n →
+lemma insert_nth_remove_nth_of_ge : ∀n m as, n < length as → n ≤ m →
   insert_nth m a (as.remove_nth n) = (as.insert_nth (m + 1) a).remove_nth n
 | 0     0     []      has _   := (lt_irrefl _ has).elim
 | 0     0     (a::as) has hmn := by simp [remove_nth, insert_nth]
@@ -1060,7 +1060,7 @@ theorem take_cons (n) (a : α) (l : list α) : take (succ n) (a::l) = a :: take 
 | []     := rfl
 | (a::l) := begin change a :: (take (length l) l) = a :: l, rw take_all end
 
-theorem take_all_of_ge : ∀ {n} {l : list α}, n ≥ length l → take n l = l
+theorem take_all_of_ge : ∀ {n} {l : list α}, length l ≤ n → take n l = l
 | 0     []     h := rfl
 | 0     (a::l) h := absurd h (not_le_of_gt (zero_lt_succ _))
 | (n+1) []     h := rfl
@@ -4424,7 +4424,7 @@ by rwa [← succ_singleton, append_consecutive]; exact nat.le_succ _
 theorem eq_cons {n m : ℕ} (h : n < m) : Ico n m = n :: Ico (n + 1) m :=
 by rw [← append_consecutive (nat.le_succ n) h, succ_singleton]; refl
 
-@[simp] theorem pred_singleton {m : ℕ} (h : m > 0) : Ico (m - 1) m = [m - 1] :=
+@[simp] theorem pred_singleton {m : ℕ} (h : 0 < m) : Ico (m - 1) m = [m - 1] :=
 by dsimp [Ico]; rw nat.sub_sub_self h; simp
 
 theorem chain'_succ (n m : ℕ) : chain' (λa b, b = succ a) (Ico n m) :=
@@ -4458,13 +4458,13 @@ begin
   { rw [min_eq_right hlm, filter_lt_of_ge hlm] }
 end
 
-lemma filter_ge_of_le_bot {n m l : ℕ} (hln : l ≤ n) : (Ico n m).filter (λ x, x ≥ l) = Ico n m :=
+lemma filter_ge_of_le_bot {n m l : ℕ} (hln : l ≤ n) : (Ico n m).filter (λ x, l ≤ x) = Ico n m :=
 filter_eq_self.2 $ assume k hk, le_trans hln (mem.1 hk).1
 
-lemma filter_ge_of_top_le {n m l : ℕ} (hml : m ≤ l) : (Ico n m).filter (λ x, x ≥ l) = [] :=
+lemma filter_ge_of_top_le {n m l : ℕ} (hml : m ≤ l) : (Ico n m).filter (λ x, l ≤ xl) = [] :=
 filter_eq_nil.2 $ assume k hk, not_le_of_gt (lt_of_lt_of_le (mem.1 hk).2 hml)
 
-lemma filter_ge_of_ge {n m l : ℕ} (hnl : n ≤ l) : (Ico n m).filter (λ x, x ≥ l) = Ico l m :=
+lemma filter_ge_of_ge {n m l : ℕ} (hnl : n ≤ l) : (Ico n m).filter (λ x, l ≤ x) = Ico l m :=
 begin
   cases le_total l m with hlm hml,
   { rw [← append_consecutive hnl hlm, filter_append,
@@ -4472,7 +4472,7 @@ begin
   { rw [eq_nil_of_le hml, filter_ge_of_top_le hml] }
 end
 
-@[simp] lemma filter_ge (n m l : ℕ) : (Ico n m).filter (λ x, x ≥ l) = Ico (_root_.max n l) m :=
+@[simp] lemma filter_ge (n m l : ℕ) : (Ico n m).filter (λ x, l ≤ x) = Ico (_root_.max n l) m :=
 begin
   cases le_total n l with hnl hln,
   { rw [max_eq_right hnl, filter_ge_of_ge hnl] },

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -1009,7 +1009,7 @@ lemma remove_nth_insert_nth (n:ℕ) (l : list α) : (l.insert_nth n a).remove_nt
 by rw [remove_nth_eq_nth_tail, insert_nth, modify_nth_tail_modify_nth_tail_same];
 from modify_nth_tail_id _ _
 
-lemma insert_nth_remove_nth_of_ge : ∀n m as, n < length as → n ≤ m →
+lemma insert_nth_remove_nth_of_ge : ∀n m as, n < length as → m ≥ n →
   insert_nth m a (as.remove_nth n) = (as.insert_nth (m + 1) a).remove_nth n
 | 0     0     []      has _   := (lt_irrefl _ has).elim
 | 0     0     (a::as) has hmn := by simp [remove_nth, insert_nth]
@@ -4461,7 +4461,7 @@ end
 lemma filter_le_of_le_bot {n m l : ℕ} (hln : l ≤ n) : (Ico n m).filter (λ x, l ≤ x) = Ico n m :=
 filter_eq_self.2 $ assume k hk, le_trans hln (mem.1 hk).1
 
-lemma filter_le_of_top_le {n m l : ℕ} (hml : m ≤ l) : (Ico n m).filter (λ x, l ≤ xl) = [] :=
+lemma filter_le_of_top_le {n m l : ℕ} (hml : m ≤ l) : (Ico n m).filter (λ x, l ≤ x) = [] :=
 filter_eq_nil.2 $ assume k hk, not_le_of_gt (lt_of_lt_of_le (mem.1 hk).2 hml)
 
 lemma filter_le_of_le {n m l : ℕ} (hnl : n ≤ l) : (Ico n m).filter (λ x, l ≤ x) = Ico l m :=

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -770,14 +770,14 @@ theorem nth_le_nth : ∀ {l : list α} {n} h, nth l n = some (nth_le l n h)
 | (a :: l) 0     h := rfl
 | (a :: l) (n+1) h := @nth_le_nth l n _
 
-theorem nth_ge_len : ∀ {l : list α} {n}, length l ≤ n → nth l n = none
+theorem nth_len_le : ∀ {l : list α} {n}, length l ≤ n → nth l n = none
 | []       n     h := rfl
-| (a :: l) (n+1) h := nth_ge_len (le_of_succ_le_succ h)
+| (a :: l) (n+1) h := nth_len_le (le_of_succ_le_succ h)
 
 theorem nth_eq_some {l : list α} {n a} : nth l n = some a ↔ ∃ h, nth_le l n h = a :=
 ⟨λ e,
   have h : n < length l, from lt_of_not_ge $ λ hn,
-    by rw nth_ge_len hn at e; contradiction,
+    by rw nth_len_le hn at e; contradiction,
   ⟨h, by rw nth_le_nth h at e;
     injection e with e; apply nth_le_mem⟩,
 λ ⟨h, e⟩, e ▸ nth_le_nth _⟩
@@ -847,7 +847,7 @@ theorem ext : ∀ {l₁ l₂ : list α}, (∀n, nth l₁ n = nth l₂ n) → l�
 theorem ext_le {l₁ l₂ : list α} (hl : length l₁ = length l₂) (h : ∀n h₁ h₂, nth_le l₁ n h₁ = nth_le l₂ n h₂) : l₁ = l₂ :=
 ext $ λn, if h₁ : n < length l₁
   then by rw [nth_le_nth, nth_le_nth, h n h₁ (by rwa [← hl])]
-  else let h₁ := le_of_not_gt h₁ in by rw [nth_ge_len h₁, nth_ge_len (by rwa [← hl])]
+  else let h₁ := le_of_not_gt h₁ in by { rw [nth_len_le h₁, nth_len_le], rwa [←hl], }
 
 @[simp] theorem index_of_nth_le [decidable_eq α] {a : α} : ∀ {l : list α} h, nth_le l (index_of a l) h = a
 | (b::l) h := by by_cases h' : a = b; simp only [h', if_pos, if_false, index_of_cons, nth_le, @index_of_nth_le l]
@@ -4458,25 +4458,25 @@ begin
   { rw [min_eq_right hlm, filter_lt_of_ge hlm] }
 end
 
-lemma filter_ge_of_le_bot {n m l : ℕ} (hln : l ≤ n) : (Ico n m).filter (λ x, l ≤ x) = Ico n m :=
+lemma filter_le_of_le_bot {n m l : ℕ} (hln : l ≤ n) : (Ico n m).filter (λ x, l ≤ x) = Ico n m :=
 filter_eq_self.2 $ assume k hk, le_trans hln (mem.1 hk).1
 
-lemma filter_ge_of_top_le {n m l : ℕ} (hml : m ≤ l) : (Ico n m).filter (λ x, l ≤ xl) = [] :=
+lemma filter_le_of_top_le {n m l : ℕ} (hml : m ≤ l) : (Ico n m).filter (λ x, l ≤ xl) = [] :=
 filter_eq_nil.2 $ assume k hk, not_le_of_gt (lt_of_lt_of_le (mem.1 hk).2 hml)
 
-lemma filter_ge_of_ge {n m l : ℕ} (hnl : n ≤ l) : (Ico n m).filter (λ x, l ≤ x) = Ico l m :=
+lemma filter_le_of_le {n m l : ℕ} (hnl : n ≤ l) : (Ico n m).filter (λ x, l ≤ x) = Ico l m :=
 begin
   cases le_total l m with hlm hml,
   { rw [← append_consecutive hnl hlm, filter_append,
-      filter_ge_of_top_le (le_refl l), filter_ge_of_le_bot (le_refl l), nil_append] },
-  { rw [eq_nil_of_le hml, filter_ge_of_top_le hml] }
+      filter_le_of_top_le (le_refl l), filter_le_of_le_bot (le_refl l), nil_append] },
+  { rw [eq_nil_of_le hml, filter_le_of_top_le hml] }
 end
 
-@[simp] lemma filter_ge (n m l : ℕ) : (Ico n m).filter (λ x, l ≤ x) = Ico (_root_.max n l) m :=
+@[simp] lemma filter_le (n m l : ℕ) : (Ico n m).filter (λ x, l ≤ x) = Ico (_root_.max n l) m :=
 begin
   cases le_total n l with hnl hln,
-  { rw [max_eq_right hnl, filter_ge_of_ge hnl] },
-  { rw [max_eq_left hln, filter_ge_of_le_bot hln] }
+  { rw [max_eq_right hnl, filter_le_of_le hnl] },
+  { rw [max_eq_left hln, filter_le_of_le_bot hln] }
 end
 
 end Ico

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -3143,7 +3143,7 @@ by rw [Ico, list.Ico.succ_top h, ← coe_add, add_comm]; refl
 theorem eq_cons {n m : ℕ} (h : n < m) : Ico n m = n :: Ico (n + 1) m :=
 congr_arg coe $ list.Ico.eq_cons h
 
-@[simp] theorem pred_singleton {m : ℕ} (h : m > 0) : Ico (m - 1) m = {m - 1} :=
+@[simp] theorem pred_singleton {m : ℕ} (h : 0 < m) : Ico (m - 1) m = {m - 1} :=
 congr_arg coe $ list.Ico.pred_singleton h
 
 @[simp] theorem not_mem_top {n m : ℕ} : m ∉ Ico n m :=
@@ -3161,16 +3161,16 @@ congr_arg coe $ list.Ico.filter_lt_of_ge hlm
 @[simp] lemma filter_lt (n m l : ℕ) : (Ico n m).filter (λ x, x < l) = Ico n (min m l) :=
 congr_arg coe $ list.Ico.filter_lt n m l
 
-lemma filter_ge_of_le_bot {n m l : ℕ} (hln : l ≤ n) : (Ico n m).filter (λ x, x ≥ l) = Ico n m :=
+lemma filter_ge_of_le_bot {n m l : ℕ} (hln : l ≤ n) : (Ico n m).filter (λ x, l ≤ x₂) = Ico n m :=
 congr_arg coe $ list.Ico.filter_ge_of_le_bot hln
 
-lemma filter_ge_of_top_le {n m l : ℕ} (hml : m ≤ l) : (Ico n m).filter (λ x, x ≥ l) = ∅ :=
+lemma filter_ge_of_top_le {n m l : ℕ} (hml : m ≤ l) : (Ico n m).filter (λ x, l ≤ x) = ∅ :=
 congr_arg coe $ list.Ico.filter_ge_of_top_le hml
 
-lemma filter_ge_of_ge {n m l : ℕ} (hnl : n ≤ l) : (Ico n m).filter (λ x, x ≥ l) = Ico l m :=
+lemma filter_ge_of_ge {n m l : ℕ} (hnl : n ≤ l) : (Ico n m).filter (λ x, l ≤ x) = Ico l m :=
 congr_arg coe $ list.Ico.filter_ge_of_ge hnl
 
-@[simp] lemma filter_ge (n m l : ℕ) : (Ico n m).filter (λ x, x ≥ l) = Ico (max n l) m :=
+@[simp] lemma filter_ge (n m l : ℕ) : (Ico n m).filter (λ x, l ≤ x) = Ico (max n l) m :=
 congr_arg coe $ list.Ico.filter_ge n m l
 
 end Ico

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -3161,17 +3161,17 @@ congr_arg coe $ list.Ico.filter_lt_of_ge hlm
 @[simp] lemma filter_lt (n m l : ℕ) : (Ico n m).filter (λ x, x < l) = Ico n (min m l) :=
 congr_arg coe $ list.Ico.filter_lt n m l
 
-lemma filter_ge_of_le_bot {n m l : ℕ} (hln : l ≤ n) : (Ico n m).filter (λ x, l ≤ x₂) = Ico n m :=
-congr_arg coe $ list.Ico.filter_ge_of_le_bot hln
+lemma filter_le_of_le_bot {n m l : ℕ} (hln : l ≤ n) : (Ico n m).filter (λ x, l ≤ x₂) = Ico n m :=
+congr_arg coe $ list.Ico.filter_le_of_le_bot hln
 
-lemma filter_ge_of_top_le {n m l : ℕ} (hml : m ≤ l) : (Ico n m).filter (λ x, l ≤ x) = ∅ :=
-congr_arg coe $ list.Ico.filter_ge_of_top_le hml
+lemma filter_le_of_top_le {n m l : ℕ} (hml : m ≤ l) : (Ico n m).filter (λ x, l ≤ x) = ∅ :=
+congr_arg coe $ list.Ico.filter_le_of_top_le hml
 
-lemma filter_ge_of_ge {n m l : ℕ} (hnl : n ≤ l) : (Ico n m).filter (λ x, l ≤ x) = Ico l m :=
-congr_arg coe $ list.Ico.filter_ge_of_ge hnl
+lemma filter_le_of_le {n m l : ℕ} (hnl : n ≤ l) : (Ico n m).filter (λ x, l ≤ x) = Ico l m :=
+congr_arg coe $ list.Ico.filter_le_of_le hnl
 
-@[simp] lemma filter_ge (n m l : ℕ) : (Ico n m).filter (λ x, l ≤ x) = Ico (max n l) m :=
-congr_arg coe $ list.Ico.filter_ge n m l
+@[simp] lemma filter_le (n m l : ℕ) : (Ico n m).filter (λ x, l ≤ x) = Ico (max n l) m :=
+congr_arg coe $ list.Ico.filter_le n m l
 
 end Ico
 

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -3161,7 +3161,7 @@ congr_arg coe $ list.Ico.filter_lt_of_ge hlm
 @[simp] lemma filter_lt (n m l : ℕ) : (Ico n m).filter (λ x, x < l) = Ico n (min m l) :=
 congr_arg coe $ list.Ico.filter_lt n m l
 
-lemma filter_le_of_le_bot {n m l : ℕ} (hln : l ≤ n) : (Ico n m).filter (λ x, l ≤ x₂) = Ico n m :=
+lemma filter_le_of_le_bot {n m l : ℕ} (hln : l ≤ n) : (Ico n m).filter (λ x, l ≤ x) = Ico n m :=
 congr_arg coe $ list.Ico.filter_le_of_le_bot hln
 
 lemma filter_le_of_top_le {n m l : ℕ} (hml : m ≤ l) : (Ico n m).filter (λ x, l ≤ x) = ∅ :=

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -120,7 +120,7 @@ nat.sub_le_sub_right h 1
 @[simp] lemma pred_one_add (n : ℕ) : pred (1 + n) = n :=
 by rw [add_comm, add_one, pred_succ]
 
-theorem pos_iff_ne_zero : n > 0 ↔ n ≠ 0 :=
+theorem pos_iff_ne_zero : 0 < n ↔ n ≠ 0 :=
 ⟨ne_of_gt, nat.pos_of_ne_zero⟩
 
 theorem pos_iff_ne_zero' : 0 < n ↔ n ≠ 0 := pos_iff_ne_zero
@@ -149,7 +149,7 @@ theorem sub_add_min (n m : ℕ) : n - m + min n m = n :=
   (λ h, by rw [min_eq_left h, sub_eq_zero_of_le h, zero_add])
   (λ h, by rw [min_eq_right h, nat.sub_add_cancel h])
 
-protected theorem add_sub_cancel' {n m : ℕ} (h : n ≥ m) : m + (n - m) = n :=
+protected theorem add_sub_cancel' {n m : ℕ} (h : m ≤ n) : m + (n - m) = n :=
 by rw [add_comm, nat.sub_add_cancel h]
 
 protected theorem sub_eq_of_eq_add (h : k = m + n) : k - m = n :=
@@ -170,9 +170,9 @@ by rw [add_comm a, nat.add_sub_assoc h, add_comm]
 theorem sub_min (n m : ℕ) : n - min n m = n - m :=
 nat.sub_eq_of_eq_add $ by rw [add_comm, sub_add_min]
 
-protected theorem lt_of_sub_pos (h : n - m > 0) : m < n :=
+protected theorem lt_of_sub_pos (h : 0 < n - m) : m < n :=
 lt_of_not_ge
-  (assume : m ≥ n,
+  (assume : n ≤ m,
     have n - m = 0, from sub_eq_zero_of_le this,
     begin rw this at h, exact lt_irrefl _ h end)
 
@@ -182,7 +182,7 @@ lt_imp_lt_of_le_imp_le (λ h, nat.sub_le_sub_right h _)
 protected theorem lt_of_sub_lt_sub_left : m - n < m - k → k < n :=
 lt_imp_lt_of_le_imp_le (nat.sub_le_sub_left _)
 
-protected theorem sub_lt_self (h₁ : m > 0) (h₂ : n > 0) : m - n < m :=
+protected theorem sub_lt_self (h₁ : 0 < m) (h₂ : 0 < n) : m - n < m :=
 calc
   m - n = succ (pred m) - succ (pred n) : by rw [succ_pred_eq_of_pos h₁, succ_pred_eq_of_pos h₂]
     ... = pred m - pred n               : by rw succ_sub_succ
@@ -301,13 +301,13 @@ nat.eq_zero_of_le_zero $
 lemma eq_zero_of_mul_le {a b : ℕ} (hb : 2 ≤ b) (h : b * a ≤ a) : a = 0 :=
 eq_zero_of_double_le $ le_trans (nat.mul_le_mul_right _ hb) h
 
-lemma le_mul_of_pos_left {m n : ℕ} (h : n > 0) : m ≤ n * m :=
+lemma le_mul_of_pos_left {m n : ℕ} (h : 0 < n) : m ≤ n * m :=
 begin
   conv {to_lhs, rw [← one_mul(m)]},
   exact mul_le_mul_of_nonneg_right (nat.succ_le_of_lt h) dec_trivial,
 end
 
-lemma le_mul_of_pos_right {m n : ℕ} (h : n > 0) : m ≤ m * n :=
+lemma le_mul_of_pos_right {m n : ℕ} (h : 0 < n) : m ≤ m * n :=
 begin
   conv {to_lhs, rw [← mul_one(m)]},
   exact mul_le_mul_of_nonneg_left (nat.succ_le_of_lt h) dec_trivial,
@@ -374,11 +374,11 @@ protected theorem eq_mul_of_div_eq_right {a b c : ℕ} (H1 : b ∣ a) (H2 : a / 
   a = b * c :=
 by rw [← H2, nat.mul_div_cancel' H1]
 
-protected theorem div_eq_iff_eq_mul_right {a b c : ℕ} (H : b > 0) (H' : b ∣ a) :
+protected theorem div_eq_iff_eq_mul_right {a b c : ℕ} (H : 0 < b) (H' : b ∣ a) :
   a / b = c ↔ a = b * c :=
 ⟨nat.eq_mul_of_div_eq_right H', nat.div_eq_of_eq_mul_right H⟩
 
-protected theorem div_eq_iff_eq_mul_left {a b c : ℕ} (H : b > 0) (H' : b ∣ a) :
+protected theorem div_eq_iff_eq_mul_left {a b c : ℕ} (H : 0 < b) (H' : b ∣ a) :
   a / b = c ↔ a = c * b :=
 by rw mul_comm; exact nat.div_eq_iff_eq_mul_right H H'
 
@@ -407,10 +407,10 @@ nat.pos_of_ne_zero (λ h, lt_irrefl a
       ... < b : nat.mod_lt a hb
       ... ≤ a : hba))
 
-protected theorem mul_right_inj {a b c : ℕ} (ha : a > 0) : b * a = c * a ↔ b = c :=
+protected theorem mul_right_inj {a b c : ℕ} (ha : 0 < a) : b * a = c * a ↔ b = c :=
 ⟨nat.eq_of_mul_eq_mul_right ha, λ e, e ▸ rfl⟩
 
-protected theorem mul_left_inj {a b c : ℕ} (ha : a > 0) : a * b = a * c ↔ b = c :=
+protected theorem mul_left_inj {a b c : ℕ} (ha : 0 < a) : a * b = a * c ↔ b = c :=
 ⟨nat.eq_of_mul_eq_mul_left ha, λ e, e ▸ rfl⟩
 
 protected lemma div_div_self : ∀ {a b : ℕ}, b ∣ a → 0 < a → a / (a / b) = b
@@ -467,10 +467,10 @@ protected theorem dvd_add_left {k m n : ℕ} (h : k ∣ n) : k ∣ m + n ↔ k �
 protected theorem dvd_add_right {k m n : ℕ} (h : k ∣ m) : k ∣ m + n ↔ k ∣ n :=
 (nat.dvd_add_iff_right h).symm
 
-protected theorem mul_dvd_mul_iff_left {a b c : ℕ} (ha : a > 0) : a * b ∣ a * c ↔ b ∣ c :=
+protected theorem mul_dvd_mul_iff_left {a b c : ℕ} (ha : 0 < a) : a * b ∣ a * c ↔ b ∣ c :=
 exists_congr $ λ d, by rw [mul_assoc, nat.mul_left_inj ha]
 
-protected theorem mul_dvd_mul_iff_right {a b c : ℕ} (hc : c > 0) : a * c ∣ b * c ↔ a ∣ b :=
+protected theorem mul_dvd_mul_iff_right {a b c : ℕ} (hc : 0 < c) : a * c ∣ b * c ↔ a ∣ b :=
 exists_congr $ λ d, by rw [mul_right_comm, nat.mul_right_inj hc]
 
 @[simp] theorem mod_mod (a n : ℕ) : (a % n) % n = a % n :=
@@ -484,16 +484,16 @@ begin
   rcases h with ⟨t, rfl⟩, rw [mul_assoc, add_mul_mod_self_left]
 end
 
-theorem add_pos_left {m : ℕ} (h : m > 0) (n : ℕ) : m + n > 0 :=
+theorem add_pos_left {m : ℕ} (h : 0 < m) (n : ℕ) : 0 < m + n :=
 calc
   m + n > 0 + n : nat.add_lt_add_right h n
     ... = n     : nat.zero_add n
     ... ≥ 0     : zero_le n
 
-theorem add_pos_right (m : ℕ) {n : ℕ} (h : n > 0) : m + n > 0 :=
+theorem add_pos_right (m : ℕ) {n : ℕ} (h : 0 < n) : 0 < m + n :=
 begin rw add_comm, exact add_pos_left h m end
 
-theorem add_pos_iff_pos_or_pos (m n : ℕ) : m + n > 0 ↔ m > 0 ∨ n > 0 :=
+theorem add_pos_iff_pos_or_pos (m n : ℕ) : 0 < m + n ↔ 0 < m ∨ 0 < n :=
 iff.intro
   begin
     intro h,
@@ -690,24 +690,24 @@ by induction n; simp [*, nat.pow_succ, mul_comm, mul_assoc, mul_left_comm]
 protected theorem pow_mul (a b n : ℕ) : n ^ (a * b) = (n ^ a) ^ b :=
 by induction b; simp [*, nat.succ_eq_add_one, nat.pow_add, mul_add, mul_comm]
 
-theorem pow_pos {p : ℕ} (hp : p > 0) : ∀ n : ℕ, p ^ n > 0
+theorem pow_pos {p : ℕ} (hp : 0 < p) : ∀ n : ℕ, 0 < p ^ n
 | 0 := by simp
 | (k+1) := mul_pos (pow_pos _) hp
 
 lemma pow_eq_mul_pow_sub (p : ℕ) {m n : ℕ} (h : m ≤ n) : p ^ m * p ^ (n - m)  = p ^ n :=
 by rw [←nat.pow_add, nat.add_sub_cancel' h]
 
-lemma pow_lt_pow_succ {p : ℕ} (h : p > 1) (n : ℕ) : p^n < p^(n+1) :=
+lemma pow_lt_pow_succ {p : ℕ} (h : 1 < p) (n : ℕ) : p^n < p^(n+1) :=
 suffices p^n*1 < p^n*p, by simpa,
 nat.mul_lt_mul_of_pos_left h (nat.pow_pos (lt_of_succ_lt h) n)
 
-lemma lt_pow_self {p : ℕ} (h : p > 1) : ∀ n : ℕ, n < p ^ n
+lemma lt_pow_self {p : ℕ} (h : 1 < p) : ∀ n : ℕ, n < p ^ n
 | 0 := by simp [zero_lt_one]
 | (n+1) := calc
   n + 1 < p^n + 1 : nat.add_lt_add_right (lt_pow_self _) _
     ... ≤ p ^ (n+1) : pow_lt_pow_succ h _
 
-lemma not_pos_pow_dvd : ∀ {p k : ℕ} (hp : p > 1) (hk : k > 1), ¬ p^k ∣ p
+lemma not_pos_pow_dvd : ∀ {p k : ℕ} (hp : 1 < p) (hk : 1 < k), ¬ p^k ∣ p
 | (succ p) (succ k) hp hk h :=
   have (succ p)^k * succ p ∣ 1 * succ p, by simpa,
   have (succ p) ^ k ∣ 1, from dvd_of_mul_dvd_mul_right (succ_pos _) this,
@@ -715,7 +715,7 @@ lemma not_pos_pow_dvd : ∀ {p k : ℕ} (hp : p > 1) (hk : k > 1), ¬ p^k ∣ p
   have k < (succ p) ^ k, from lt_pow_self hp k,
   have k < 1, by rwa [he] at this,
   have k = 0, from eq_zero_of_le_zero $ le_of_lt_succ this,
-  have 1 > 1, by rwa [this] at hk,
+  have 1 < 1, by rwa [this] at hk,
   absurd this dec_trivial
 
 @[simp] theorem bodd_div2_eq (n : ℕ) : bodd_div2 n = (bodd n, div2 n) :=
@@ -872,7 +872,7 @@ size_le.2 $ lt_of_le_of_lt h (lt_size_self _)
 
 @[simp] theorem fact_succ (n) : fact (succ n) = succ n * fact n := rfl
 
-theorem fact_pos : ∀ n, fact n > 0
+theorem fact_pos : ∀ n, 0 < fact n
 | 0        := zero_lt_one
 | (succ n) := mul_pos (succ_pos _) (fact_pos n)
 
@@ -887,7 +887,7 @@ begin
     { apply dvd_mul_of_dvd_right (IH (le_of_lt_succ hl)) } }
 end
 
-theorem dvd_fact : ∀ {m n}, m > 0 → m ≤ n → m ∣ fact n
+theorem dvd_fact : ∀ {m n}, 0 < m → m ≤ n → m ∣ fact n
 | (succ m) n _ h := dvd_of_mul_right_dvd (fact_dvd_fact h)
 
 theorem fact_le {m n} (h : m ≤ n) : fact m ≤ fact n :=
@@ -1090,7 +1090,7 @@ lemma dvd_div_of_mul_dvd {a b c : ℕ} (h : a * b ∣ c) : b ∣ c / a :=
 if ha : a = 0 then
   by simp [ha]
 else
-  have ha : a > 0, from nat.pos_of_ne_zero ha,
+  have ha : 0 < a, from nat.pos_of_ne_zero ha,
   have h1 : ∃ d, c = a * b * d, from h,
   let ⟨d, hd⟩ := h1 in
   have hac : a ∣ c, from dvd_of_mul_right_dvd h,
@@ -1110,9 +1110,9 @@ lemma div_mul_div {a b c d : ℕ} (hab : b ∣ a) (hcd : d ∣ c) :
 have exi1 : ∃ x, a = b * x, from hab,
 have exi2 : ∃ y, c = d * y, from hcd,
 if hb : b = 0 then by simp [hb]
-else have b > 0, from nat.pos_of_ne_zero hb,
+else have 0 < b, from nat.pos_of_ne_zero hb,
 if hd : d = 0 then by simp [hd]
-else have d > 0, from nat.pos_of_ne_zero hd,
+else have 0 < d, from nat.pos_of_ne_zero hd,
 begin
   cases exi1 with x hx, cases exi2 with y hy,
   rw [hx, hy, nat.mul_div_cancel_left, nat.mul_div_cancel_left],
@@ -1190,8 +1190,8 @@ lemma with_bot.add_eq_one_iff : ∀ {n m : with_bot ℕ}, n + m = 1 ↔ (n = 0 �
 
 -- induction
 
-@[elab_as_eliminator] lemma le_induction {P : nat → Prop} {m} (h0 : P m) (h1 : ∀ n ≥ m, P n → P (n + 1)) :
-  ∀ n ≥ m, P n :=
+@[elab_as_eliminator] lemma le_induction {P : nat → Prop} {m} (h0 : P m) (h1 : ∀ n, m ≤ n → P n → P (n + 1)) :
+  ∀ n, m ≤ n → P n :=
 by apply nat.less_than_or_equal.rec h0; exact h1
 
 @[elab_as_eliminator]

--- a/src/data/nat/cast.lean
+++ b/src/data/nat/cast.lean
@@ -43,7 +43,7 @@ by rw [bit1, cast_add_one, cast_bit0]; refl
 
 lemma cast_two {α : Type*} [semiring α] : ((2 : ℕ) : α) = 2 := by simp
 
-@[simp, move_cast] theorem cast_pred [add_group α] [has_one α] : ∀ {n}, n > 0 → ((n - 1 : ℕ) : α) = n - 1
+@[simp, move_cast] theorem cast_pred [add_group α] [has_one α] : ∀ {n}, 0 < n → ((n - 1 : ℕ) : α) = n - 1
 | (n+1) h := (add_sub_cancel (n:α) 1).symm
 
 @[simp, move_cast] theorem cast_sub [add_group α] [has_one α] {m n} (h : m ≤ n) : ((n - m : ℕ) : α) = n - m :=

--- a/src/data/nat/dist.lean
+++ b/src/data/nat/dist.lean
@@ -35,7 +35,7 @@ begin rw [h, dist_self] end
 theorem dist_eq_sub_of_le {n m : ℕ} (h : n ≤ m) : dist n m = m - n :=
 begin rw [dist.def, sub_eq_zero_of_le h, zero_add] end
 
-theorem dist_eq_sub_of_ge {n m : ℕ} (h : n ≥ m) : dist n m = n - m :=
+theorem dist_eq_sub_of_ge {n m : ℕ} (h : m ≤ n) : dist n m = n - m :=
 begin rw [dist_comm], apply dist_eq_sub_of_le h end
 
 theorem dist_zero_right (n : ℕ) : dist n 0 = n :=
@@ -92,7 +92,7 @@ or.elim (lt_or_ge i j)
 theorem dist_succ_succ {i j : nat} : dist (succ i) (succ j) = dist i j :=
 by simp [dist.def, succ_sub_succ]
 
-theorem dist_pos_of_ne {i j : nat} : i ≠ j → dist i j > 0 :=
+theorem dist_pos_of_ne {i j : nat} : i ≠ j → 0 < dist i j :=
 assume hne, nat.lt_by_cases
   (assume : i < j,
      begin rw [dist_eq_sub_of_le (le_of_lt this)], apply nat.sub_pos_of_lt this end)

--- a/src/data/nat/dist.lean
+++ b/src/data/nat/dist.lean
@@ -35,7 +35,7 @@ begin rw [h, dist_self] end
 theorem dist_eq_sub_of_le {n m : ℕ} (h : n ≤ m) : dist n m = m - n :=
 begin rw [dist.def, sub_eq_zero_of_le h, zero_add] end
 
-theorem dist_eq_sub_of_ge {n m : ℕ} (h : m ≤ n) : dist n m = n - m :=
+theorem dist_eq_sub_of_ge {n m : ℕ} (h : n ≥ m) : dist n m = n - m :=
 begin rw [dist_comm], apply dist_eq_sub_of_le h end
 
 theorem dist_zero_right (n : ℕ) : dist n 0 = n :=

--- a/src/data/nat/gcd.lean
+++ b/src/data/nat/gcd.lean
@@ -20,9 +20,9 @@ theorem gcd_dvd_left (m n : ℕ) : gcd m n ∣ m := (gcd_dvd m n).left
 
 theorem gcd_dvd_right (m n : ℕ) : gcd m n ∣ n := (gcd_dvd m n).right
 
-theorem gcd_le_left {m} (n) (h : m > 0) : gcd m n ≤ m := le_of_dvd h $ gcd_dvd_left m n
+theorem gcd_le_left {m} (n) (h : 0 < m) : gcd m n ≤ m := le_of_dvd h $ gcd_dvd_left m n
 
-theorem gcd_le_right (m) {n} (h : n > 0) : gcd m n ≤ n := le_of_dvd h $ gcd_dvd_right m n
+theorem gcd_le_right (m) {n} (h : 0 < n) : gcd m n ≤ n := le_of_dvd h $ gcd_dvd_right m n
 
 theorem dvd_gcd {m n k : ℕ} : k ∣ m → k ∣ n → k ∣ gcd m n :=
 gcd.induction m n (λn _ kn, by rw gcd_zero_left; exact kn)
@@ -60,15 +60,15 @@ gcd.induction n k
 theorem gcd_mul_right (m n k : ℕ) : gcd (m * n) (k * n) = gcd m k * n :=
 by rw [mul_comm m n, mul_comm k n, mul_comm (gcd m k) n, gcd_mul_left]
 
-theorem gcd_pos_of_pos_left {m : ℕ} (n : ℕ) (mpos : m > 0) : gcd m n > 0 :=
+theorem gcd_pos_of_pos_left {m : ℕ} (n : ℕ) (mpos : 0 < m) : 0 < gcd m n :=
 pos_of_dvd_of_pos (gcd_dvd_left m n) mpos
 
-theorem gcd_pos_of_pos_right (m : ℕ) {n : ℕ} (npos : n > 0) : gcd m n > 0 :=
+theorem gcd_pos_of_pos_right (m : ℕ) {n : ℕ} (npos : 0 < n) : 0 < gcd m n :=
 pos_of_dvd_of_pos (gcd_dvd_right m n) npos
 
 theorem eq_zero_of_gcd_eq_zero_left {m n : ℕ} (H : gcd m n = 0) : m = 0 :=
 or.elim (eq_zero_or_pos m) id
-  (assume H1 : m > 0, absurd (eq.symm H) (ne_of_lt (gcd_pos_of_pos_left _ H1)))
+  (assume H1 : 0 < m, absurd (eq.symm H) (ne_of_lt (gcd_pos_of_pos_left _ H1)))
 
 theorem eq_zero_of_gcd_eq_zero_right {m n : ℕ} (H : gcd m n = 0) : n = 0 :=
 by rw gcd_comm at H; exact eq_zero_of_gcd_eq_zero_left H
@@ -182,7 +182,7 @@ theorem coprime.gcd_eq_one {m n : ℕ} : coprime m n → gcd m n = 1 := id
 
 theorem coprime.symm {m n : ℕ} : coprime n m → coprime m n := (gcd_comm m n).trans
 
-theorem coprime_of_dvd {m n : ℕ} (H : ∀ k > 1, k ∣ m → ¬ k ∣ n) : coprime m n :=
+theorem coprime_of_dvd {m n : ℕ} (H : ∀ k, 1 < k → k ∣ m → ¬ k ∣ n) : coprime m n :=
 or.elim (eq_zero_or_pos (gcd m n))
   (λg0, by rw [eq_zero_of_gcd_eq_zero_left g0, eq_zero_of_gcd_eq_zero_right g0] at H; exact false.elim
     (H 2 dec_trivial (dvd_zero _) (dvd_zero _)))
@@ -219,22 +219,22 @@ theorem coprime.gcd_mul_right_cancel_right {k m : ℕ} (n : ℕ) (H : coprime k 
    gcd m (n * k) = gcd m n :=
 by rw [mul_comm n k, H.gcd_mul_left_cancel_right n]
 
-theorem coprime_div_gcd_div_gcd {m n : ℕ} (H : gcd m n > 0) :
+theorem coprime_div_gcd_div_gcd {m n : ℕ} (H : 0 < gcd m n) :
   coprime (m / gcd m n) (n / gcd m n) :=
 by delta coprime; rw [gcd_div (gcd_dvd_left m n) (gcd_dvd_right m n), nat.div_self H]
 
-theorem not_coprime_of_dvd_of_dvd {m n d : ℕ} (dgt1 : d > 1) (Hm : d ∣ m) (Hn : d ∣ n) :
+theorem not_coprime_of_dvd_of_dvd {m n d : ℕ} (dgt1 : 1 < d) (Hm : d ∣ m) (Hn : d ∣ n) :
   ¬ coprime m n :=
 λ (co : gcd m n = 1),
 not_lt_of_ge (le_of_dvd zero_lt_one $ by rw ←co; exact dvd_gcd Hm Hn) dgt1
 
-theorem exists_coprime {m n : ℕ} (H : gcd m n > 0) :
+theorem exists_coprime {m n : ℕ} (H : 0 < gcd m n) :
   ∃ m' n', coprime m' n' ∧ m = m' * gcd m n ∧ n = n' * gcd m n :=
 ⟨_, _, coprime_div_gcd_div_gcd H,
   (nat.div_mul_cancel (gcd_dvd_left m n)).symm,
   (nat.div_mul_cancel (gcd_dvd_right m n)).symm⟩
 
-theorem exists_coprime' {m n : ℕ} (H : gcd m n > 0) :
+theorem exists_coprime' {m n : ℕ} (H : 0 < gcd m n) :
   ∃ g m' n', 0 < g ∧ coprime m' n' ∧ m = m' * g ∧ n = n' * g :=
 let ⟨m', n', h⟩ := exists_coprime H in ⟨_, m', n', H, h⟩
 
@@ -323,7 +323,7 @@ case nat.zero {
   have : m = 0 := eq_zero_of_gcd_eq_zero_right h0, subst this,
   exact ⟨⟨⟨0, dvd_refl 0⟩, ⟨n, dvd_refl n⟩⟩, (zero_mul n).symm⟩ },
 case nat.succ : tmp hpos {
-  replace hpos : gcd k m > 0 := hpos.symm ▸ nat.zero_lt_succ _; clear tmp,
+  replace hpos : 0 < gcd k m := hpos.symm ▸ nat.zero_lt_succ _; clear tmp,
   have hd : gcd k m * (k / gcd k m) = k := (nat.mul_div_cancel' (gcd_dvd_left k m)),
   refine ⟨⟨⟨gcd k m,  gcd_dvd_right k m⟩, ⟨k / gcd k m, _⟩⟩, hd.symm⟩,
   apply dvd_of_mul_dvd_mul_left hpos,

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -133,7 +133,7 @@ have hn0 : 0 < n := nat.pos_of_ne_zero (λ h, by simp * at *),
 (nat.mul_left_inj (show 0 < 2, from dec_trivial)).1 $
 by rw [mul_add, two_mul_odd_div_two hm1, mul_left_comm, two_mul_odd_div_two hn1,
   two_mul_odd_div_two (nat.odd_mul_odd hm1 hn1), nat.mul_sub_left_distrib, mul_one,
-  ← nat.add_sub_assoc hm0, nat.sub_add_cancel (le_mul_of_ge_one_right' (nat.zero_le _) hn0)]
+  ← nat.add_sub_assoc hm0, nat.sub_add_cancel (le_mul_of_one_le_right' (nat.zero_le _) hn0)]
 
 lemma odd_of_mod_four_eq_one {n : ℕ} (h : n % 4 = 1) : n % 2 = 1 :=
 @modeq.modeq_of_modeq_mul_left 2 n 1 2 h

--- a/src/data/nat/pairing.lean
+++ b/src/data/nat/pairing.lean
@@ -55,13 +55,13 @@ begin
         nat.add_sub_cancel, nat.add_sub_cancel_left] }
 end
 
-theorem unpair_lt {n : ℕ} (n1 : n ≥ 1) : (unpair n).1 < n :=
+theorem unpair_lt {n : ℕ} (n1 : 1 ≤ n) : (unpair n).1 < n :=
 let s := sqrt n in begin
   simp [unpair], change sqrt n with s,
   by_cases h : n - s * s < s; simp [h],
   { exact lt_of_lt_of_le h (sqrt_le_self _) },
   { simp at h,
-    have s0 : s > 0 := sqrt_pos.2 n1,
+    have s0 : 0 < s := sqrt_pos.2 n1,
     exact lt_of_le_of_lt h (nat.sub_lt_self n1 (mul_pos s0 s0)) }
 end
 

--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -46,7 +46,7 @@ end
 @[simp] theorem not_even_bit1 (n : nat) : ¬ even (bit1 n) :=
 by simp [bit1] with parity_simps
 
-@[parity_simps] theorem even_sub {m n : nat} (h : m ≥ n) : even (m - n) ↔ (even m ↔ even n) :=
+@[parity_simps] theorem even_sub {m n : nat} (h : n ≤ m) : even (m - n) ↔ (even m ↔ even n) :=
 begin
   conv { to_rhs, rw [←nat.sub_add_cancel h, even_add] },
   by_cases h : even n; simp [h]

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -13,22 +13,22 @@ open decidable
 
 /-- `prime p` means that `p` is a prime number, that is, a natural number
   at least 2 whose only divisors are `p` and `1`. -/
-def prime (p : ℕ) := p ≥ 2 ∧ ∀ m ∣ p, m = 1 ∨ m = p
+def prime (p : ℕ) := 2 ≤ p ∧ ∀ m ∣ p, m = 1 ∨ m = p
 
-theorem prime.ge_two {p : ℕ} : prime p → p ≥ 2 := and.left
+theorem prime.two_le {p : ℕ} : prime p → 2 ≤ p := and.left
 
-theorem prime.gt_one {p : ℕ} : prime p → p > 1 := prime.ge_two
+theorem prime.one_lt {p : ℕ} : prime p → 1 < p := prime.two_le
 
 lemma prime.ne_one {p : ℕ} (hp : p.prime) : p ≠ 1 :=
-ne.symm $ (ne_of_lt hp.gt_one)
+ne.symm $ (ne_of_lt hp.one_lt)
 
-theorem prime_def_lt {p : ℕ} : prime p ↔ p ≥ 2 ∧ ∀ m < p, m ∣ p → m = 1 :=
+theorem prime_def_lt {p : ℕ} : prime p ↔ 2 ≤ p ∧ ∀ m < p, m ∣ p → m = 1 :=
 and_congr_right $ λ p2, forall_congr $ λ m,
 ⟨λ h l d, (h d).resolve_right (ne_of_lt l),
  λ h d, (decidable.lt_or_eq_of_le $
    le_of_dvd (le_of_succ_le p2) d).imp_left (λ l, h l d)⟩
 
-theorem prime_def_lt' {p : ℕ} : prime p ↔ p ≥ 2 ∧ ∀ m, 2 ≤ m → m < p → ¬ m ∣ p :=
+theorem prime_def_lt' {p : ℕ} : prime p ↔ 2 ≤ p ∧ ∀ m, 2 ≤ m → m < p → ¬ m ∣ p :=
 prime_def_lt.trans $ and_congr_right $ λ p2, forall_congr $ λ m,
 ⟨λ h m2 l d, not_lt_of_ge m2 ((h l d).symm ▸ dec_trivial),
 λ h l d, begin
@@ -38,7 +38,7 @@ prime_def_lt.trans $ and_congr_right $ λ p2, forall_congr $ λ m,
   { exact (h dec_trivial l).elim d }
 end⟩
 
-theorem prime_def_le_sqrt {p : ℕ} : prime p ↔ p ≥ 2 ∧
+theorem prime_def_le_sqrt {p : ℕ} : prime p ↔ 2 ≤ p ∧
   ∀ m, 2 ≤ m → m ≤ sqrt p → ¬ m ∣ p :=
 prime_def_lt'.trans $ and_congr_right $ λ p2,
 ⟨λ a m m2 l, a m m2 $ lt_of_le_of_lt l $ sqrt_lt_self p2,
@@ -70,8 +70,8 @@ assume hn : n = 0,
 have h2 : ¬ prime 0, from dec_trivial,
 h2 (hn ▸ h)
 
-theorem prime.pos {p : ℕ} (pp : prime p) : p > 0 :=
-lt_of_succ_lt pp.gt_one
+theorem prime.pos {p : ℕ} (pp : prime p) : 0 < p :=
+lt_of_succ_lt pp.one_lt
 
 theorem not_prime_zero : ¬ prime 0 := dec_trivial
 
@@ -81,8 +81,8 @@ theorem prime_two : prime 2 := dec_trivial
 
 theorem prime_three : prime 3 := dec_trivial
 
-theorem prime.pred_pos {p : ℕ} (pp : prime p) : pred p > 0 :=
-lt_pred_iff.2 pp.gt_one
+theorem prime.pred_pos {p : ℕ} (pp : prime p) : 0 < pred p :=
+lt_pred_iff.2 pp.one_lt
 
 theorem succ_pred_prime {p : ℕ} (pp : prime p) : succ (pred p) = p :=
 succ_pred_eq_of_pos pp.pos
@@ -90,18 +90,18 @@ succ_pred_eq_of_pos pp.pos
 theorem dvd_prime {p m : ℕ} (pp : prime p) : m ∣ p ↔ m = 1 ∨ m = p :=
 ⟨λ d, pp.2 m d, λ h, h.elim (λ e, e.symm ▸ one_dvd _) (λ e, e.symm ▸ dvd_refl _)⟩
 
-theorem dvd_prime_ge_two {p m : ℕ} (pp : prime p) (H : m ≥ 2) : m ∣ p ↔ m = p :=
+theorem dvd_prime_two_le {p m : ℕ} (pp : prime p) (H : 2 ≤ m) : m ∣ p ↔ m = p :=
 (dvd_prime pp).trans $ or_iff_right_of_imp $ not.elim $ ne_of_gt H
 
 theorem prime.not_dvd_one {p : ℕ} (pp : prime p) : ¬ p ∣ 1
-| d := (not_le_of_gt pp.gt_one) $ le_of_dvd dec_trivial d
+| d := (not_le_of_gt pp.one_lt) $ le_of_dvd dec_trivial d
 
 theorem not_prime_mul {a b : ℕ} (a1 : 1 < a) (b1 : 1 < b) : ¬ prime (a * b) :=
 λ h, ne_of_lt (nat.mul_lt_mul_of_pos_left b1 (lt_of_succ_lt a1)) $
-by simpa using (dvd_prime_ge_two h a1).1 (dvd_mul_right _ _)
+by simpa using (dvd_prime_two_le h a1).1 (dvd_mul_right _ _)
 
 section min_fac
-  private lemma min_fac_lemma (n k : ℕ) (h : ¬ k * k > n) :
+  private lemma min_fac_lemma (n k : ℕ) (h : ¬ n < k * k) :
     sqrt n - k < sqrt n + 2 - k :=
   (nat.sub_lt_sub_right_iff $ le_sqrt.2 $ le_of_not_gt h).2 $
   nat.lt_add_of_pos_right dec_trivial
@@ -132,10 +132,10 @@ section min_fac
     by simp [min_fac, this]; congr
 
   private def min_fac_prop (n k : ℕ) :=
-    k ≥ 2 ∧ k ∣ n ∧ ∀ m ≥ 2, m ∣ n → k ≤ m
+    2 ≤ k ∧ k ∣ n ∧ ∀ m, 2 ≤ m → m ∣ n → k ≤ m
 
-  theorem min_fac_aux_has_prop {n : ℕ} (n2 : n ≥ 2) (nd2 : ¬ 2 ∣ n) :
-    ∀ k i, k = 2*i+3 → (∀ m ≥ 2, m ∣ n → k ≤ m) → min_fac_prop n (min_fac_aux n k)
+  theorem min_fac_aux_has_prop {n : ℕ} (n2 : 2 ≤ n) (nd2 : ¬ 2 ∣ n) :
+    ∀ k i, k = 2*i+3 → (∀ m, 2 ≤ m → m ∣ n → k ≤ m) → min_fac_prop n (min_fac_aux n k)
   | k := λ i e a, begin
     rw min_fac_aux,
     by_cases h : n < k*k; simp [h],
@@ -143,7 +143,7 @@ section min_fac
         prime_def_le_sqrt.2 ⟨n2, λ m m2 l d,
           not_lt_of_ge l $ lt_of_lt_of_le (sqrt_lt.2 h) (a m m2 d)⟩,
       from ⟨n2, dvd_refl _, λ m m2 d, le_of_eq
-        ((dvd_prime_ge_two pp m2).1 d).symm⟩ },
+        ((dvd_prime_two_le pp m2).1 d).symm⟩ },
     have k2 : 2 ≤ k, { subst e, exact dec_trivial },
     by_cases dk : k ∣ n; simp [dk],
     { exact ⟨k2, dk, a⟩ },
@@ -180,21 +180,21 @@ section min_fac
   let ⟨f2, fd, a⟩ := min_fac_has_prop n1 in
   prime_def_lt'.2 ⟨f2, λ m m2 l d, not_le_of_gt l (a m m2 (dvd_trans d fd))⟩
 
-  theorem min_fac_le_of_dvd {n : ℕ} : ∀ {m : ℕ}, m ≥ 2 → m ∣ n → min_fac n ≤ m :=
+  theorem min_fac_le_of_dvd {n : ℕ} : ∀ {m : ℕ}, 2 ≤ m → m ∣ n → min_fac n ≤ m :=
   by by_cases n1 : n = 1;
     [exact λ m m2 d, n1.symm ▸ le_trans dec_trivial m2,
      exact (min_fac_has_prop n1).2.2]
 
-  theorem min_fac_pos (n : ℕ) : min_fac n > 0 :=
+  theorem min_fac_pos (n : ℕ) : 0 < min_fac n :=
   by by_cases n1 : n = 1;
      [exact n1.symm ▸ dec_trivial, exact (min_fac_prime n1).pos]
 
-  theorem min_fac_le {n : ℕ} (H : n > 0) : min_fac n ≤ n :=
+  theorem min_fac_le {n : ℕ} (H : 0 < n) : min_fac n ≤ n :=
   le_of_dvd H (min_fac_dvd n)
 
-  theorem prime_def_min_fac {p : ℕ} : prime p ↔ p ≥ 2 ∧ min_fac p = p :=
-  ⟨λ pp, ⟨pp.ge_two,
-    let ⟨f2, fd, a⟩ := min_fac_has_prop $ ne_of_gt pp.gt_one in
+  theorem prime_def_min_fac {p : ℕ} : prime p ↔ 2 ≤ p ∧ min_fac p = p :=
+  ⟨λ pp, ⟨pp.two_le,
+    let ⟨f2, fd, a⟩ := min_fac_has_prop $ ne_of_gt pp.one_lt in
     ((dvd_prime pp).1 fd).resolve_left (ne_of_gt f2)⟩,
    λ ⟨p2, e⟩, e ▸ min_fac_prime (ne_of_gt p2)⟩
 
@@ -209,26 +209,26 @@ section min_fac
   instance decidable_prime (p : ℕ) : decidable (prime p) :=
   decidable_of_iff' _ prime_def_min_fac
 
-  theorem not_prime_iff_min_fac_lt {n : ℕ} (n2 : n ≥ 2) : ¬ prime n ↔ min_fac n < n :=
+  theorem not_prime_iff_min_fac_lt {n : ℕ} (n2 : 2 ≤ n) : ¬ prime n ↔ min_fac n < n :=
   (not_congr $ prime_def_min_fac.trans $ and_iff_right n2).trans $
     (lt_iff_le_and_ne.trans $ and_iff_right $ min_fac_le $ le_of_succ_le n2).symm
 
 end min_fac
 
-theorem exists_dvd_of_not_prime {n : ℕ} (n2 : n ≥ 2) (np : ¬ prime n) :
+theorem exists_dvd_of_not_prime {n : ℕ} (n2 : 2 ≤ n) (np : ¬ prime n) :
   ∃ m, m ∣ n ∧ m ≠ 1 ∧ m ≠ n :=
-⟨min_fac n, min_fac_dvd _, ne_of_gt (min_fac_prime (ne_of_gt n2)).gt_one,
+⟨min_fac n, min_fac_dvd _, ne_of_gt (min_fac_prime (ne_of_gt n2)).one_lt,
   ne_of_lt $ (not_prime_iff_min_fac_lt n2).1 np⟩
 
-theorem exists_dvd_of_not_prime2 {n : ℕ} (n2 : n ≥ 2) (np : ¬ prime n) :
-  ∃ m, m ∣ n ∧ m ≥ 2 ∧ m < n :=
-⟨min_fac n, min_fac_dvd _, (min_fac_prime (ne_of_gt n2)).ge_two,
+theorem exists_dvd_of_not_prime2 {n : ℕ} (n2 : 2 ≤ n) (np : ¬ prime n) :
+  ∃ m, m ∣ n ∧ 2 ≤ m ∧ m < n :=
+⟨min_fac n, min_fac_dvd _, (min_fac_prime (ne_of_gt n2)).two_le,
   (not_prime_iff_min_fac_lt n2).1 np⟩
 
-theorem exists_prime_and_dvd {n : ℕ} (n2 : n ≥ 2) : ∃ p, prime p ∧ p ∣ n :=
+theorem exists_prime_and_dvd {n : ℕ} (n2 : 2 ≤ n) : ∃ p, prime p ∧ p ∣ n :=
 ⟨min_fac n, min_fac_prime (ne_of_gt n2), min_fac_dvd _⟩
 
-theorem exists_infinite_primes (n : ℕ) : ∃ p, p ≥ n ∧ prime p :=
+theorem exists_infinite_primes (n : ℕ) : ∃ p, n ≤ p ∧ prime p :=
 let p := min_fac (fact n + 1) in
 have f1 : fact n + 1 ≠ 1, from ne_of_gt $ succ_lt_succ $ fact_pos _,
 have pp : prime p, from min_fac_prime f1,

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -244,7 +244,7 @@ lemma prime.eq_two_or_odd {p : ℕ} (hp : prime p) : p = 2 ∨ p % 2 = 1 :=
   or.inr
 
 theorem factors_lemma {k} : (k+2) / min_fac (k+2) < k+2 :=
-div_lt_self dec_trivial (min_fac_prime dec_trivial).gt_one
+div_lt_self dec_trivial (min_fac_prime dec_trivial).one_lt
 
 /-- `factors n` is the prime factorization of `n`, listed in increasing order. -/
 def factors : ℕ → list ℕ
@@ -278,7 +278,7 @@ lemma prod_factors : ∀ {n}, 0 < n → list.prod (factors n) = n
 
 theorem prime.coprime_iff_not_dvd {p n : ℕ} (pp : prime p) : coprime p n ↔ ¬ p ∣ n :=
 ⟨λ co d, pp.not_dvd_one $ co.dvd_of_dvd_mul_left (by simp [d]),
- λ nd, coprime_of_dvd $ λ m m2 mp, ((dvd_prime_ge_two pp m2).1 mp).symm ▸ nd⟩
+ λ nd, coprime_of_dvd $ λ m m2 mp, ((dvd_prime_two_le pp m2).1 mp).symm ▸ nd⟩
 
 theorem prime.dvd_iff_not_coprime {p n : ℕ} (pp : prime p) : p ∣ n ↔ ¬ coprime p n :=
 iff_not_comm.2 pp.coprime_iff_not_dvd
@@ -327,7 +327,7 @@ theorem prime.coprime_pow_of_not_dvd {p m a : ℕ} (pp : prime p) (h : ¬ p ∣ 
 (pp.coprime_iff_not_dvd.2 h).symm.pow_right _
 
 theorem coprime_primes {p q : ℕ} (pp : prime p) (pq : prime q) : coprime p q ↔ p ≠ q :=
-pp.coprime_iff_not_dvd.trans $ not_congr $ dvd_prime_ge_two pq pp.ge_two
+pp.coprime_iff_not_dvd.trans $ not_congr $ dvd_prime_two_le pq pp.two_le
 
 theorem coprime_pow_primes {p q : ℕ} (n m : ℕ) (pp : prime p) (pq : prime q) (h : p ≠ q) :
   coprime (p^n) (q^m) :=

--- a/src/data/nat/sqrt.lean
+++ b/src/data/nat/sqrt.lean
@@ -14,7 +14,7 @@ namespace nat
 theorem sqrt_aux_dec {b} (h : b ≠ 0) : shiftr b 2 < b :=
 begin
   simp [shiftr_eq_div_pow],
-  apply (nat.div_lt_iff_lt_mul' (dec_trivial : 4 > 0)).2,
+  apply (nat.div_lt_iff_lt_mul' (dec_trivial : 0 < 4)).2,
   have := nat.mul_lt_mul_of_pos_left
     (dec_trivial : 1 < 4) (nat.pos_of_ne_zero h),
   rwa mul_one at this
@@ -158,12 +158,12 @@ theorem le_three_of_sqrt_eq_one {n : ℕ} (h : sqrt n = 1) : n ≤ 3 :=
 le_of_lt_succ $ (@sqrt_lt n 2).1 $
 by rw [h]; exact dec_trivial
 
-theorem sqrt_lt_self {n : ℕ} (h : n > 1) : sqrt n < n :=
+theorem sqrt_lt_self {n : ℕ} (h : 1 < n) : sqrt n < n :=
 sqrt_lt.2 $ by
   have := nat.mul_lt_mul_of_pos_left h (lt_of_succ_lt h);
   rwa [mul_one] at this
 
-theorem sqrt_pos {n : ℕ} : sqrt n > 0 ↔ n > 0 := le_sqrt
+theorem sqrt_pos {n : ℕ} : 0 < sqrt n ↔ 0 < n := le_sqrt
 
 theorem sqrt_add_eq (n : ℕ) {a : ℕ} (h : a ≤ n + n) : sqrt (n*n + a) = n :=
 le_antisymm

--- a/src/data/nat/totient.lean
+++ b/src/data/nat/totient.lean
@@ -34,7 +34,7 @@ calc ((range n.succ).filter (∣ n)).sum φ
     (λ _ _, rfl)
     (λ a b ha hb h,
       have ha : a * (n / a) = n, from nat.mul_div_cancel' (mem_filter.1 ha).2,
-      have (n / a) > 0, from nat.pos_of_ne_zero (λ h, by simp [*, lt_irrefl] at *),
+      have 0 < (n / a), from nat.pos_of_ne_zero (λ h, by simp [*, lt_irrefl] at *),
       by rw [← nat.mul_right_inj this, ha, h, nat.mul_div_cancel' (mem_filter.1 hb).2])
     (λ b hb,
       have hb : b < n.succ ∧ b ∣ n, by simpa [-range_succ] using hb,

--- a/src/data/num/lemmas.lean
+++ b/src/data/num/lemmas.lean
@@ -32,7 +32,7 @@ namespace pos_num
   | (bit0 p) := rfl
   | (bit1 p) := (congr_arg _root_.bit0 (succ_to_nat p)).trans $
     show ↑p + 1 + ↑p + 1 = ↑p + ↑p + 1 + 1, by simp
-  
+
   theorem one_add (n : pos_num) : 1 + n = succ n := by cases n; refl
   theorem add_one (n : pos_num) : n + 1 = succ n := by cases n; refl
 
@@ -72,7 +72,7 @@ namespace pos_num
   | (bit1 p) := (add_to_nat (bit0 (m * p)) m).trans $
     show (↑(m * p) + ↑(m * p) + ↑m : ℕ) = ↑m * (p + p) + m, by rw [mul_to_nat, left_distrib]
 
-  theorem to_nat_pos : ∀ n : pos_num, (n : ℕ) > 0
+  theorem to_nat_pos : ∀ n : pos_num, 0 < (n : ℕ)
   | 1        := zero_lt_one
   | (bit0 p) := let h := to_nat_pos p in add_pos h h
   | (bit1 p) := nat.succ_pos _
@@ -429,7 +429,7 @@ namespace num
 
   @[simp] theorem cast_bit0 [semiring α] (n : num) : (n.bit0 : α) = _root_.bit0 n :=
   by rw [← bit0_of_bit0, _root_.bit0, cast_add]; refl
-  
+
   @[simp] theorem cast_bit1 [semiring α] (n : num) : (n.bit1 : α) = _root_.bit1 n :=
   by rw [← bit1_of_bit1, _root_.bit1, bit0_of_bit0, cast_add, cast_bit0]; refl
 

--- a/src/data/num/lemmas.lean
+++ b/src/data/num/lemmas.lean
@@ -391,7 +391,7 @@ namespace pos_num
   theorem one_le_cast [linear_ordered_semiring α] (n : pos_num) : (1 : α) ≤ n :=
   by rw [← cast_to_nat, ← nat.cast_one, nat.cast_le]; apply to_nat_pos
 
-  theorem cast_pos [linear_ordered_semiring α] (n : pos_num) : (n : α) > 0 :=
+  theorem cast_pos [linear_ordered_semiring α] (n : pos_num) : 0 < (n : α) :=
   lt_of_lt_of_le zero_lt_one (one_le_cast n)
 
   @[simp] theorem cast_mul [semiring α] (m n) : ((m * n : pos_num) : α) = m * n :=

--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -124,15 +124,15 @@ include p_prime
 The multiplicity of `p : ℕ` in `a : ℤ` is finite exactly when `a ≠ 0`.
 -/
 lemma finite_int_prime_iff {p : ℕ} [p_prime : p.prime] {a : ℤ} : finite (p : ℤ) a ↔ a ≠ 0 :=
-by simp [finite_int_iff, ne.symm (ne_of_lt (p_prime.gt_one))]
+by simp [finite_int_iff, ne.symm (ne_of_lt (p_prime.one_lt))]
 
 /--
 A rewrite lemma for `padic_val_rat p q` when `q` is expressed in terms of `rat.mk`.
 -/
 protected lemma defn {q : ℚ} {n d : ℤ} (hqz : q ≠ 0) (qdf : q = n /. d) :
   padic_val_rat p q = (multiplicity (p : ℤ) n).get (finite_int_iff.2
-    ⟨ne.symm $ ne_of_lt p_prime.gt_one, λ hn, by simp * at *⟩) -
-  (multiplicity (p : ℤ) d).get (finite_int_iff.2 ⟨ne.symm $ ne_of_lt p_prime.gt_one,
+    ⟨ne.symm $ ne_of_lt p_prime.one_lt, λ hn, by simp * at *⟩) -
+  (multiplicity (p : ℤ) d).get (finite_int_iff.2 ⟨ne.symm $ ne_of_lt p_prime.one_lt,
     λ hd, by simp * at *⟩) :=
 have hn : n ≠ 0, from rat.mk_num_ne_zero_of_ne_zero hqz qdf,
 have hd : d ≠ 0, from rat.mk_denom_ne_zero_of_ne_zero hqz qdf,
@@ -320,7 +320,7 @@ end
 -/
 @[simp] protected lemma neg (q : ℚ) : padic_norm p (-q) = padic_norm p q :=
 if hq : q = 0 then by simp [hq]
-else by simp [padic_norm, hq, hp.gt_one]
+else by simp [padic_norm, hq, hp.one_lt]
 
 /--
 If the p-adic norm of `q` is 0, then `q` is 0.
@@ -363,7 +363,7 @@ begin
   unfold padic_norm,
   rw [if_neg _],
   { refine fpow_le_one_of_nonpos _ _,
-    { exact_mod_cast le_of_lt hp.gt_one, },
+    { exact_mod_cast le_of_lt hp.one_lt, },
     { rw [padic_val_rat_of_int _ hp.ne_one hz, neg_nonpos],
       norm_cast, simp }},
   exact_mod_cast hz
@@ -385,7 +385,7 @@ else
     apply le_max_iff.2,
     left,
     apply fpow_le_of_le,
-    { exact_mod_cast le_of_lt hp.gt_one },
+    { exact_mod_cast le_of_lt hp.one_lt },
     { apply neg_le_neg,
       have : padic_val_rat p q =
               min (padic_val_rat p q) (padic_val_rat p r),
@@ -472,7 +472,7 @@ begin
   { apply fpow_nonneg_of_nonneg,
     exact_mod_cast le_of_lt hp.pos },
   { apply fpow_le_of_le,
-    exact_mod_cast le_of_lt hp.gt_one,
+    exact_mod_cast le_of_lt hp.one_lt,
     apply neg_le_neg,
     rw padic_val_rat_of_int _ hp.ne_one _,
     { norm_cast,

--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -277,7 +277,7 @@ by simp [hq, padic_norm]
 /--
 The p-adic norm is nonnegative.
 -/
-protected lemma nonneg (q : ℚ) : padic_norm p q ≥ 0 :=
+protected lemma nonneg (q : ℚ) : 0 ≤ padic_norm p q :=
 if hq : q = 0 then by simp [hq]
 else
   begin

--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -139,7 +139,7 @@ have hd : d ≠ 0, from rat.mk_denom_ne_zero_of_ne_zero hqz qdf,
 let ⟨c, hc1, hc2⟩ := rat.num_denom_mk hn hd qdf in
 by rw [padic_val_rat, dif_pos];
   simp [hc1, hc2, multiplicity.mul' (nat.prime_iff_prime_int.1 p_prime),
-    (ne.symm (ne_of_lt p_prime.gt_one)), hqz]
+    (ne.symm (ne_of_lt p_prime.one_lt)), hqz]
 
 /--
 A rewrite lemma for `padic_val_rat p (q * r)` with conditions `q ≠ 0`, `r ≠ 0`.

--- a/src/data/padics/padic_numbers.lean
+++ b/src/data/padics/padic_numbers.lean
@@ -263,7 +263,7 @@ by simpa [hk] using padic_norm.image p hk'
 
 lemma norm_one : norm (1 : padic_seq p) = 1 :=
 have h1 : ¬ (1 : padic_seq p) ≈ 0, from one_not_equiv_zero _,
-by simp [h1, norm, hp.gt_one]
+by simp [h1, norm, hp.one_lt]
 
 private lemma norm_eq_of_equiv_aux {f g : padic_seq p} (hf : ¬ f ≈ 0) (hg : ¬ g ≈ 0) (hfg : f ≈ g)
   (h : padic_norm p (f (stationary_point hf)) ≠ padic_norm p (g (stationary_point hg)))

--- a/src/data/padics/padic_numbers.lean
+++ b/src/data/padics/padic_numbers.lean
@@ -775,7 +775,7 @@ end
 instance : nondiscrete_normed_field ℚ_[p] :=
 { non_trivial := ⟨padic.of_rat p (p⁻¹), begin
     have h0 : p ≠ 0 := ne_of_gt (hp.pos),
-    have h1 : 1 < p := prime.gt_one hp,
+    have h1 : 1 < p := hp.one_lt,
     rw [← padic.cast_eq_of_rat, eq_padic_norm],
     simp only [padic_norm, inv_eq_zero],
     simp only [if_neg] {discharger := `[exact_mod_cast h0]},
@@ -816,7 +816,7 @@ theorem norm_rat_le_one : ∀ {q : ℚ} (hq : ¬ p ∣ q.denom), ∥(q : ℚ_[p]
       have h : (multiplicity p d).get _ = 0, by simp [multiplicity_eq_zero_of_not_dvd, hq],
       rw_mod_cast [h, sub_zero],
       apply fpow_le_one_of_nonpos,
-      { exact_mod_cast le_of_lt hp.gt_one, },
+      { exact_mod_cast le_of_lt hp.one_lt, },
       { apply neg_nonpos_of_nonneg, norm_cast, simp, }
     end
 

--- a/src/data/padics/padic_numbers.lean
+++ b/src/data/padics/padic_numbers.lean
@@ -71,7 +71,7 @@ variables {p : ℕ} [nat.prime p]
 /-- The p-adic norm of the entries of a nonzero Cauchy sequence of rationals is eventually
 constant. -/
 lemma stationary {f : cau_seq ℚ (padic_norm p)} (hf : ¬ f ≈ 0) :
-  ∃ N, ∀ m n, m ≥ N → n ≥ N → padic_norm p (f n) = padic_norm p (f m) :=
+  ∃ N, ∀ m n, N ≤ m → N ≤ n → padic_norm p (f n) = padic_norm p (f m) :=
 have ∃ ε > 0, ∃ N1, ∀ j ≥ N1, ε ≤ padic_norm p (f j),
   from cau_seq.abv_pos_of_not_lim_zero $ not_lim_zero_of_not_congr_zero hf,
 let ⟨ε, hε, N1, hN1⟩ := this,

--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -10,7 +10,7 @@ import data.nat.basic data.nat.prime algebra.group_power
 /-- `ℕ+` is the type of positive natural numbers. It is defined as a subtype,
   and the VM representation of `ℕ+` is the same as `ℕ` because the proof
   is not stored. -/
-def pnat := {n : ℕ // n > 0}
+def pnat := {n : ℕ // 0 < n}
 notation `ℕ+` := pnat
 
 instance coe_pnat_nat : has_coe ℕ+ ℕ := ⟨subtype.val⟩
@@ -20,7 +20,7 @@ namespace nat
 
 /-- Convert a natural number to a positive natural number. The
   positivity assumption is inferred by `dec_trivial`. -/
-def to_pnat (n : ℕ) (h : n > 0 . tactic.exact_dec_trivial) : ℕ+ := ⟨n, h⟩
+def to_pnat (n : ℕ) (h : 0 < n . tactic.exact_dec_trivial) : ℕ+ := ⟨n, h⟩
 
 /-- Write a successor as an element of `ℕ+`. -/
 def succ_pnat (n : ℕ) : ℕ+ := ⟨succ n, succ_pos n⟩
@@ -35,7 +35,7 @@ theorem succ_pnat_inj {n m : ℕ} : succ_pnat n = succ_pnat m → n = m :=
 def to_pnat' (n : ℕ) : ℕ+ := succ_pnat (pred n)
 
 @[simp] theorem to_pnat'_coe : ∀ (n : ℕ),
- ((to_pnat' n) : ℕ) = ite (n > 0) n 1
+ ((to_pnat' n) : ℕ) = ite (0 < n) n 1
 | 0 := rfl
 | (m + 1) := by {rw [if_pos (succ_pos m)], refl}
 
@@ -68,7 +68,7 @@ instance : decidable_eq ℕ+ := λ (a b : ℕ+), by apply_instance
 instance : decidable_linear_order ℕ+ :=
 subtype.decidable_linear_order _
 
-@[simp] theorem pos (n : ℕ+) : (n : ℕ) > 0 := n.2
+@[simp] theorem pos (n : ℕ+) : 0 < (n : ℕ) := n.2
 
 theorem eq {m n : ℕ+} : (m : ℕ) = n → m = n := subtype.eq
 
@@ -98,7 +98,7 @@ instance : add_right_cancel_semigroup ℕ+ :=
 
 @[simp] theorem ne_zero (n : ℕ+) : (n : ℕ) ≠ 0 := ne_of_gt n.2
 
-@[simp] theorem to_pnat'_coe {n : ℕ} : n > 0 → (n.to_pnat' : ℕ) = n := succ_pred_eq_of_pos
+@[simp] theorem to_pnat'_coe {n : ℕ} : 0 < n → (n.to_pnat' : ℕ) = n := succ_pred_eq_of_pos
 
 @[simp] theorem coe_to_pnat' (n : ℕ+) : (n : ℕ).to_pnat' = n := eq (to_pnat'_coe n.pos)
 
@@ -114,7 +114,7 @@ instance : comm_monoid ℕ+ :=
 @[simp] theorem mul_coe (m n : ℕ+) : ((m * n : ℕ+) : ℕ) = m * n := rfl
 instance coe_mul_hom : is_monoid_hom (coe : ℕ+ → ℕ) :=
  {map_one := one_coe, map_mul := mul_coe}
- 
+
 @[simp] lemma coe_bit0 (a : ℕ+) : ((bit0 a : ℕ+) : ℕ) = bit0 (a : ℕ) := rfl
 @[simp] lemma coe_bit1 (a : ℕ+) : ((bit1 a : ℕ+) : ℕ) = bit1 (a : ℕ) := rfl
 
@@ -144,7 +144,7 @@ instance : distrib ℕ+ :=
 -/
 instance : has_sub ℕ+ := ⟨λ a b, to_pnat' (a - b : ℕ)⟩
 
-theorem sub_coe (a b : ℕ+) : ((a - b : ℕ+) : ℕ) = ite (a > b) (a - b : ℕ) 1 :=
+theorem sub_coe (a b : ℕ+) : ((a - b : ℕ+) : ℕ) = ite (b < a) (a - b : ℕ) 1 :=
 begin
   change ((to_pnat' ((a : ℕ) - (b :  ℕ)) : ℕ)) =
     ite ((a : ℕ) > (b : ℕ)) ((a : ℕ) - (b : ℕ)) 1,

--- a/src/data/polynomial.lean
+++ b/src/data/polynomial.lean
@@ -959,7 +959,7 @@ have zn0 : (0 : α) ≠ 1, from λ h, by haveI := subsingleton_of_zero_eq_one _ 
   begin
     have := congr_arg nat_degree hr,
     rw [nat_degree_mul_eq' hpnr0,  nat_degree_pow_eq' hpn0', add_mul, add_assoc] at this,
-    exact ne_of_lt (lt_add_of_le_of_pos (le_mul_of_ge_one_right' (nat.zero_le _) hnp)
+    exact ne_of_lt (lt_add_of_le_of_pos (le_mul_of_one_le_right' (nat.zero_le _) hnp)
       (add_pos_of_pos_of_nonneg (by rwa one_mul) (nat.zero_le _))) this
   end⟩
 

--- a/src/data/rat/basic.lean
+++ b/src/data/rat/basic.lean
@@ -46,7 +46,7 @@ rat, rationals, field, ℚ, numerator, denominator, num, denom
 structure rat := mk' ::
 (num : ℤ)
 (denom : ℕ)
-(pos : denom > 0)
+(pos : 0 < denom)
 (cop : num.nat_abs.coprime denom)
 notation `ℚ` := rat
 
@@ -60,7 +60,7 @@ instance : has_repr ℚ := ⟨rat.repr⟩
 instance : has_to_string ℚ := ⟨rat.repr⟩
 meta instance : has_to_format ℚ := ⟨coe ∘ rat.repr⟩
 
-instance : encodable ℚ := encodable.of_equiv (Σ n : ℤ, {d : ℕ // d > 0 ∧ n.nat_abs.coprime d})
+instance : encodable ℚ := encodable.of_equiv (Σ n : ℤ, {d : ℕ // 0 < d ∧ n.nat_abs.coprime d})
   ⟨λ ⟨a, b, c, d⟩, ⟨a, b, c, d⟩, λ⟨a, b, c, d⟩, ⟨a, b, c, d⟩,
    λ ⟨a, b, c, d⟩, rfl, λ⟨a, b, c, d⟩, rfl⟩
 
@@ -222,7 +222,7 @@ theorem num_denom' {n d h c} : (⟨n, d, h, c⟩ : ℚ) = n /. d := num_denom.sy
 theorem of_int_eq_mk (z : ℤ) : of_int z = z /. 1 := num_denom'
 
 @[elab_as_eliminator] theorem {u} num_denom_cases_on {C : ℚ → Sort u}
-   : ∀ (a : ℚ) (H : ∀ n d, d > 0 → (int.nat_abs n).coprime d → C (n /. d)), C a
+   : ∀ (a : ℚ) (H : ∀ n d, 0 < d → (int.nat_abs n).coprime d → C (n /. d)), C a
 | ⟨n, d, h, c⟩ H := by rw num_denom'; exact H n d h c
 
 @[elab_as_eliminator] theorem {u} num_denom_cases_on' {C : ℚ → Sort u}

--- a/src/data/rat/order.lean
+++ b/src/data/rat/order.lean
@@ -26,9 +26,9 @@ variables (a b c : ℚ)
 open_locale rat
 
 protected def nonneg : ℚ → Prop
-| ⟨n, d, h, c⟩ := n ≥ 0
+| ⟨n, d, h, c⟩ := 0 ≤ n
 
-@[simp] theorem mk_nonneg (a : ℤ) {b : ℤ} (h : b > 0) : (a /. b).nonneg ↔ a ≥ 0 :=
+@[simp] theorem mk_nonneg (a : ℤ) {b : ℤ} (h : 0 < b) : (a /. b).nonneg ↔ 0 ≤ a :=
 begin
   generalize ha : a /. b = x, cases x with n₁ d₁ h₁ c₁, rw num_denom' at ha,
   simp [rat.nonneg],
@@ -84,7 +84,7 @@ instance : has_le ℚ := ⟨rat.le⟩
 instance decidable_le : decidable_rel ((≤) : ℚ → ℚ → Prop)
 | a b := show decidable (rat.nonneg (b - a)), by apply_instance
 
-protected theorem le_def {a b c d : ℤ} (b0 : b > 0) (d0 : d > 0) :
+protected theorem le_def {a b c d : ℤ} (b0 : 0 < b) (d0 : 0 < d) :
   a /. b ≤ c /. d ↔ a * d ≤ c * b :=
 show rat.nonneg _ ↔ _,
 by simpa [ne_of_gt b0, ne_of_gt d0, mul_pos b0 d0, mul_comm]

--- a/src/data/rat/order.lean
+++ b/src/data/rat/order.lean
@@ -45,27 +45,27 @@ protected def nonneg_add {a b} : rat.nonneg a → rat.nonneg b → rat.nonneg (a
 num_denom_cases_on' a $ λ n₁ d₁ h₁,
 num_denom_cases_on' b $ λ n₂ d₂ h₂,
 begin
-  have d₁0 : (d₁:ℤ) > 0 := int.coe_nat_pos.2 (nat.pos_of_ne_zero h₁),
-  have d₂0 : (d₂:ℤ) > 0 := int.coe_nat_pos.2 (nat.pos_of_ne_zero h₂),
-  simp [d₁0, d₂0, h₁, h₂, mul_pos d₁0 d₂0],
+  have d₁0 : 0 < (d₁:ℤ) := int.coe_nat_pos.2 (nat.pos_of_ne_zero h₁),
+  have d₂0 : 0 < (d₂:ℤ) := int.coe_nat_pos.2 (nat.pos_of_ne_zero h₂),
+  simp [d₁0, d₂0, h₁, h₂, mul_pos' d₁0 d₂0],
   intros n₁0 n₂0,
-  apply add_nonneg; apply mul_nonneg; {assumption <|> apply int.coe_zero_le}
+  apply add_nonneg; apply mul_nonneg; {assumption <|> apply int.coe_zero_le},
 end
 
 protected def nonneg_mul {a b} : rat.nonneg a → rat.nonneg b → rat.nonneg (a * b) :=
 num_denom_cases_on' a $ λ n₁ d₁ h₁,
 num_denom_cases_on' b $ λ n₂ d₂ h₂,
 begin
-  have d₁0 : (d₁:ℤ) > 0 := int.coe_nat_pos.2 (nat.pos_of_ne_zero h₁),
-  have d₂0 : (d₂:ℤ) > 0 := int.coe_nat_pos.2 (nat.pos_of_ne_zero h₂),
-  simp [d₁0, d₂0, h₁, h₂, mul_pos d₁0 d₂0],
+  have d₁0 : 0 < (d₁:ℤ) := int.coe_nat_pos.2 (nat.pos_of_ne_zero h₁),
+  have d₂0 : 0 < (d₂:ℤ) := int.coe_nat_pos.2 (nat.pos_of_ne_zero h₂),
+  simp [d₁0, d₂0, h₁, h₂, mul_pos' d₁0 d₂0],
   exact mul_nonneg
 end
 
 protected def nonneg_antisymm {a} : rat.nonneg a → rat.nonneg (-a) → a = 0 :=
 num_denom_cases_on' a $ λ n d h,
 begin
-  have d0 : (d:ℤ) > 0 := int.coe_nat_pos.2 (nat.pos_of_ne_zero h),
+  have d0 : 0 < (d:ℤ) := int.coe_nat_pos.2 (nat.pos_of_ne_zero h),
   simp [d0, h],
   exact λ h₁ h₂, le_antisymm h₂ h₁
 end
@@ -87,7 +87,7 @@ instance decidable_le : decidable_rel ((≤) : ℚ → ℚ → Prop)
 protected theorem le_def {a b c d : ℤ} (b0 : 0 < b) (d0 : 0 < d) :
   a /. b ≤ c /. d ↔ a * d ≤ c * b :=
 show rat.nonneg _ ↔ _,
-by simpa [ne_of_gt b0, ne_of_gt d0, mul_pos b0 d0, mul_comm]
+by simpa [ne_of_gt b0, ne_of_gt d0, mul_pos' b0 d0, mul_comm]
    using @sub_nonneg _ _ (b * c) (a * d)
 
 protected theorem le_refl : a ≤ a :=

--- a/src/data/real/irrational.lean
+++ b/src/data/real/irrational.lean
@@ -12,7 +12,7 @@ open rat real multiplicity
 def irrational (x : ℝ) := ¬ ∃ q : ℚ, x = q
 
 theorem irr_nrt_of_notint_nrt {x : ℝ} (n : ℕ) (m : ℤ)
-  (hxr : x ^ n = m) (hv : ¬ ∃ y : ℤ, x = y) (hnpos : n > 0) :
+  (hxr : x ^ n = m) (hv : ¬ ∃ y : ℤ, x = y) (hnpos : 0 < n) :
   irrational x
 | ⟨q, e⟩ := begin
   rw [e, ← cast_pow] at hxr, cases q with N D P C,

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -309,7 +309,7 @@ lemma of_real_mul {p q : ℝ} (hp : 0 ≤ p) :
 begin
   cases le_total 0 q with hq hq,
   { apply nnreal.eq,
-    have := max_eq_left (zero_le_mul hp hq),
+    have := max_eq_left (mul_nonneg hp hq),
     simpa [nnreal.of_real, hp, hq, max_eq_left] },
   { have hpq := mul_nonpos_of_nonneg_of_nonpos hp hq,
     rw [of_real_eq_zero.2 hq, of_real_eq_zero.2 hpq, mul_zero] }

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -268,7 +268,7 @@ lemma mul_val : ∀ a b : zmodp p hp, (a * b).val = (a.val * b.val) % p
 | ⟨_, _⟩ ⟨_, _⟩ := rfl
 
 @[simp] lemma one_val : (1 : zmodp p hp).val = 1 :=
-nat.mod_eq_of_lt hp.gt_one
+nat.mod_eq_of_lt hp.one_lt
 
 @[simp] lemma zero_val : (0 : zmodp p hp).val = 0 := rfl
 
@@ -345,7 +345,7 @@ end
 
 instance : discrete_field (zmodp p hp) :=
 { zero_ne_one := fin.ne_of_vne $ show 0 ≠ 1 % p,
-    by rw nat.mod_eq_of_lt hp.gt_one;
+    by rw nat.mod_eq_of_lt hp.one_lt;
       exact zero_ne_one,
   mul_inv_cancel := mul_inv_cancel_aux hp,
   inv_mul_cancel := λ a, by rw mul_comm; exact mul_inv_cancel_aux hp _,

--- a/src/data/zmod/quadratic_reciprocity.lean
+++ b/src/data/zmod/quadratic_reciprocity.lean
@@ -29,7 +29,7 @@ hp.eq_two_or_odd.elim
     λ hx, have 2 * (p / 2) ∣ n * (p / 2),
         by rw [two_mul_odd_div_two hp1, ← card_units_zmodp hp, ← order_of_eq_card_of_forall_mem_gpowers hg];
         exact order_of_dvd_of_pow_eq_one (by rwa [pow_mul, hn]),
-      let ⟨m, hm⟩ := dvd_of_mul_dvd_mul_right (nat.div_pos hp.ge_two dec_trivial) this in
+      let ⟨m, hm⟩ := dvd_of_mul_dvd_mul_right (nat.div_pos hp.two_le dec_trivial) this in
       ⟨g ^ m, by rwa [← pow_mul, mul_comm, ← hm]⟩⟩)
 
 lemma euler_criterion {a : zmodp p hp} (ha : a ≠ 0) :
@@ -147,7 +147,7 @@ finset.ext.2 $ λ x,
     exact calc 2 * m + (q - 1) * p ≤ 2 * (p / 2) + (q - 1) * p :
       add_le_add_right ((mul_le_mul_left dec_trivial).2 (le_of_lt_succ (mem_range.1 (by simp * at *)))) _
     ... < _ : begin rw [two_mul_odd_div_two hp1, nat.mul_sub_right_distrib, one_mul],
-        rw [← nat.sub_add_comm hp.pos, nat.add_sub_cancel' (le_mul_of_ge_one_left' (nat.zero_le _) hq.pos), mul_comm],
+        rw [← nat.sub_add_comm hp.pos, nat.add_sub_cancel' (le_mul_of_one_le_left' (nat.zero_le _) hq.pos), mul_comm],
         exact lt_add_of_pos_right _ dec_trivial
       end,
   end,
@@ -298,7 +298,7 @@ have hpqpnat : (((⟨p * q, mul_pos hp.pos hq.pos⟩ : ℕ+) : ℕ) : ℤ) = (p 
 have hpqpnat' : ((⟨p * q, mul_pos hp.pos hq.pos⟩ : ℕ+) : ℕ) = p * q, by simp,
 have hpq1 : ((⟨p * q, mul_pos hp.pos hq.pos⟩ : ℕ+) : ℕ) % 2 = 1,
   from nat.odd_mul_odd hp1 hq1,
-have hpq1' : p * q > 1, from one_lt_mul hp.pos hq.gt_one,
+have hpq1' : p * q > 1, from one_lt_mul hp.pos hq.one_lt,
 have hhq0 : ∀ a : ℕ, coprime q a → a ≠ 0,
   from λ a, imp_not_comm.1 $ by simp [hq.coprime_iff_not_dvd] {contextual := tt},
 have hpq0 : 0 < p * q / 2, from nat.div_pos (succ_le_of_lt $ one_lt_mul hp.pos hq.one_lt) dec_trivial,

--- a/src/data/zmod/quadratic_reciprocity.lean
+++ b/src/data/zmod/quadratic_reciprocity.lean
@@ -301,7 +301,7 @@ have hpq1 : ((⟨p * q, mul_pos hp.pos hq.pos⟩ : ℕ+) : ℕ) % 2 = 1,
 have hpq1' : p * q > 1, from one_lt_mul hp.pos hq.gt_one,
 have hhq0 : ∀ a : ℕ, coprime q a → a ≠ 0,
   from λ a, imp_not_comm.1 $ by simp [hq.coprime_iff_not_dvd] {contextual := tt},
-have hpq0 : 0 < p * q / 2, from nat.div_pos (succ_le_of_lt $ one_lt_mul hp.pos hq.gt_one) dec_trivial,
+have hpq0 : 0 < p * q / 2, from nat.div_pos (succ_le_of_lt $ one_lt_mul hp.pos hq.one_lt) dec_trivial,
 have hinj : ∀ a₁ a₂ : ℕ,
     a₁ ∈ (range (p * q / 2).succ).filter (coprime (p * q)) →
     a₂ ∈ (range (p * q / 2).succ).filter (coprime (p * q)) →
@@ -483,7 +483,7 @@ def legendre_sym (a p : ℕ) (hp : nat.prime p) : ℤ :=
 if (a : zmodp p hp) = 0 then 0 else if ∃ b : zmodp p hp, b ^ 2 = a then 1 else -1
 
 lemma legendre_sym_eq_pow (a p : ℕ) (hp : nat.prime p) : (legendre_sym a p hp : zmodp p hp) = (a ^ (p / 2)) :=
-if ha : (a : zmodp p hp) = 0 then by simp [*, legendre_sym, _root_.zero_pow (nat.div_pos hp.ge_two (succ_pos 1))]
+if ha : (a : zmodp p hp) = 0 then by simp [*, legendre_sym, _root_.zero_pow (nat.div_pos hp.two_le (succ_pos 1))]
 else
 (nat.prime.eq_two_or_odd hp).elim
   (λ hp2, begin subst hp2,

--- a/src/data/zsqrtd/basic.lean
+++ b/src/data/zsqrtd/basic.lean
@@ -460,7 +460,7 @@ parameter {d : ℕ}
   protected theorem mul_nonneg (a b : ℤ√d) : 0 ≤ a → 0 ≤ b → 0 ≤ a * b :=
   by repeat {rw ← nonneg_iff_zero_le}; exact nonneg_mul
 
-  theorem not_sq_le_succ (c d y) (h : c > 0) : ¬sq_le (y + 1) c 0 d :=
+  theorem not_sq_le_succ (c d y) (h : 0 < c) : ¬sq_le (y + 1) c 0 d :=
   not_le_of_gt $ mul_pos (mul_pos h $ nat.succ_pos _) $ nat.succ_pos _
 
   /-- A nonsquare is a natural number that is not equal to the square of an

--- a/src/data/zsqrtd/gaussian_int.lean
+++ b/src/data/zsqrtd/gaussian_int.lean
@@ -85,7 +85,7 @@ let n := (rat.of_int (norm y))⁻¹ in let c := y.conj in
 instance : has_div ℤ[i] := ⟨gaussian_int.div⟩
 
 lemma div_def (x y : ℤ[i]) : x / y = ⟨round ((x * conj y).re / norm y : ℚ),
-  round ((x * conj y).im / norm y : ℚ)⟩ := 
+  round ((x * conj y).im / norm y : ℚ)⟩ :=
 show zsqrtd.mk _ _ = _, by simp [rat.of_int_eq_mk, rat.mk_eq_div, div_eq_mul_inv]
 
 lemma to_complex_div_re (x y : ℤ[i]) : ((x / y : ℤ[i]) : ℂ).re = round ((x / y : ℂ).re) :=
@@ -145,7 +145,7 @@ int.coe_nat_lt.1 (by simp [-int.coe_nat_lt, norm_mod_lt x hy])
 lemma norm_le_norm_mul_left (x : ℤ[i]) {y : ℤ[i]} (hy : y ≠ 0) :
   (norm x).nat_abs ≤ (norm (x * y)).nat_abs :=
 by rw [norm_mul, int.nat_abs_mul];
-  exact le_mul_of_ge_one_right' (nat.zero_le _)
+  exact le_mul_of_one_le_right' (nat.zero_le _)
     (int.coe_nat_le.1 (by rw [coe_nat_abs_norm]; exact norm_pos.2 hy))
 
 instance : nonzero_comm_ring ℤ[i] :=

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -507,7 +507,7 @@ lemma sign_surjective (hα : 1 < fintype.card α) : function.surjective (sign : 
 λ a, (int.units_eq_one_or a).elim
   (λ h, ⟨1, by simp [h]⟩)
   (λ h, let ⟨x⟩ := fintype.card_pos_iff.1 (lt_trans zero_lt_one hα) in
-    let ⟨y, hxy⟩ := fintype.exists_ne_of_card_gt_one hα x in
+    let ⟨y, hxy⟩ := fintype.exists_ne_of_one_lt_card hα x in
     ⟨swap y x, by rw [sign_swap hxy, h]⟩ )
 
 lemma eq_sign_of_surjective_hom {s : perm α → units ℤ}

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -120,7 +120,7 @@ rotate_eq_self_iff_eq_repeat.2 ⟨(1 : G),
 /-- Cauchy's theorem -/
 lemma exists_prime_order_of_dvd_card [fintype G] {p : ℕ} (hp : nat.prime p)
   (hdvd : p ∣ card G) : ∃ x : G, order_of x = p :=
-let n : ℕ+ := ⟨p - 1, nat.sub_pos_of_lt hp.gt_one⟩ in
+let n : ℕ+ := ⟨p - 1, nat.sub_pos_of_lt hp.one_lt⟩ in
 let p' : ℕ+ := ⟨p, hp.pos⟩ in
 have hn : p' = n + 1 := subtype.eq (nat.succ_sub hp.pos),
 have hcard : card (vectors_prod_eq_one G (n + 1)) = card G ^ (n : ℕ),
@@ -140,9 +140,9 @@ have hcard_pos : 0 < card (fixed_points (multiplicative (zmod p')) (vectors_prod
   fintype.card_pos_iff.2 ⟨⟨⟨vector.repeat 1 p', one_mem_vectors_prod_eq_one _⟩,
     one_mem_fixed_points_rotate _⟩⟩,
 have hlt : 1 < card (fixed_points (multiplicative (zmod p')) (vectors_prod_eq_one G p')) :=
-  calc (1 : ℕ) < p' : hp.gt_one
+  calc (1 : ℕ) < p' : hp.one_lt
   ... ≤ _ : nat.le_of_dvd hcard_pos hdvdcard₂,
-let ⟨⟨⟨⟨x, hx₁⟩, hx₂⟩, hx₃⟩, hx₄⟩ := fintype.exists_ne_of_card_gt_one hlt
+let ⟨⟨⟨⟨x, hx₁⟩, hx₂⟩, hx₃⟩, hx₄⟩ := fintype.exists_ne_of_one_lt_card hlt
   ⟨_, one_mem_fixed_points_rotate p'⟩ in
 have hx : x ≠ list.repeat (1 : G) p', from λ h, by simpa [h, vector.repeat] using hx₄,
 have nG : nonempty G, from ⟨1⟩,

--- a/src/number_theory/sum_two_squares.lean
+++ b/src/number_theory/sum_two_squares.lean
@@ -24,7 +24,7 @@ have hpk : p ∣ k.val ^ 2 + 1,
   by rw [← zmodp.eq_zero_iff_dvd_nat hp]; simp *,
 have hkmul : (k.val ^ 2 + 1 : ℤ[i]) = ⟨k.val, 1⟩ * ⟨k.val, -1⟩ :=
   by simp [_root_.pow_two, zsqrtd.ext],
-have hpne1 : p ≠ 1, from (ne_of_lt (hp.gt_one)).symm,
+have hpne1 : p ≠ 1, from (ne_of_lt (hp.one_lt)).symm,
 have hkltp : 1 + k.val * k.val < p * p,
   from calc 1 + k.val * k.val ≤ k.val + k.val * k.val :
     add_le_add_right (nat.pos_of_ne_zero
@@ -47,7 +47,7 @@ have hpk₂ : ¬ (p : ℤ[i]) ∣ ⟨k.val, 1⟩ :=
           by simpa [hx0] using congr_arg zsqrtd.im hx),
 have hpu : ¬ is_unit (p : ℤ[i]), from mt norm_eq_one_iff.2 $
   by rw [norm_nat_cast, int.nat_abs_mul, nat.mul_eq_one_iff];
-  exact λ h, (ne_of_lt hp.gt_one).symm h.1,
+  exact λ h, (ne_of_lt hp.one_lt).symm h.1,
 let ⟨y, hy⟩ := hpk in
 have hpi : ¬ irreducible (p : ℤ[i]),
   from mt irreducible_iff_prime.1


### PR DESCRIPTION
Let's flip some inequalities... These are most of them in `data/*`, except for the files involving real numbers (or p-adics).