### PR TITLE
fix(docs/tutorial/category_theory): fix import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
   directories:
     - $TRAVIS_BUILD_DIR/test/
     - $TRAVIS_BUILD_DIR/src/
+    - $TRAVIS_BUILD_DIR/docs/
     - $TRAVIS_BUILD_DIR/archive/
     - $HOME/.elan
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,22 @@ jobs:
         - lean --recursive --export=mathlib.txt src/
         - travis_long "leanchecker mathlib.txt"
 
+    - stage: Docs
+      env: TASK="check Lean proofs"
+      if: type != cron
+      script:
+        - leanpkg configure
+        - travis_long "lean --make docs/"
+
+    - stage: Docs
+      env: TASK="check Lean proofs" LEAN="nightly"
+      if: type = cron
+      script:
+        - elan toolchain install leanprover-community/lean:nightly
+        - elan override set leanprover-community/lean:nightly
+        - leanpkg configure
+        - travis_long "lean --make docs/"
+
     - stage: Archive
       env: TASK="check Lean proofs"
       if: type != cron

--- a/docs/tutorial/category_theory/calculating_colimits_in_Top.lean
+++ b/docs/tutorial/category_theory/calculating_colimits_in_Top.lean
@@ -1,4 +1,4 @@
-import topology.Top.limits
+import topology.category.Top.limits
 import category_theory.limits.shapes
 import topology.instances.real
 


### PR DESCRIPTION
This tutorial file was broken by the renaming in #1432.

I've added new stages to the Travis build that build the docs/ folder so that this sort of thing won't be missed again.

I found this when it broke [my Travis builds](https://travis-ci.com/bryangingechen/lean-web-editor/jobs/235272859) for [my fork of the lean-web-editor](https://github.com/bryangingechen/lean-web-editor). It builds a Lean package importing mathlib with a `leanpkg.toml` file without a `src` field. This is technically deprecated, but it's useful as it ends up building every `.lean` file.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
