### PR TITLE
refactor(algebra/big_operators,data/finset): use `finset.disjoint` in definitions

### DIFF
--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -74,28 +74,27 @@ lemma prod_union_inter [decidable_eq α] : (s₁ ∪ s₂).prod f * (s₁ ∩ s�
 fold_union_inter
 
 @[to_additive]
-lemma prod_union [decidable_eq α] (h : s₁ ∩ s₂ = ∅) : (s₁ ∪ s₂).prod f = s₁.prod f * s₂.prod f :=
-by rw [←prod_union_inter, h]; exact (mul_one _).symm
+lemma prod_union [decidable_eq α] (h : disjoint s₁ s₂) : (s₁ ∪ s₂).prod f = s₁.prod f * s₂.prod f :=
+by rw [←prod_union_inter, (disjoint_iff_inter_eq_empty.mp h)]; exact (mul_one _).symm
 
 @[to_additive]
 lemma prod_sdiff [decidable_eq α] (h : s₁ ⊆ s₂) : (s₂ \ s₁).prod f * s₁.prod f = s₂.prod f :=
-by rw [←prod_union (sdiff_inter_self _ _), sdiff_union_of_subset h]
+by rw [←prod_union sdiff_disjoint, sdiff_union_of_subset h]
 
 @[to_additive]
 lemma prod_bind [decidable_eq α] {s : finset γ} {t : γ → finset α} :
-  (∀x∈s, ∀y∈s, x ≠ y → t x ∩ t y = ∅) → (s.bind t).prod f = s.prod (λx, (t x).prod f) :=
+  (∀x∈s, ∀y∈s, x ≠ y → disjoint (t x) (t y)) → (s.bind t).prod f = s.prod (λx, (t x).prod f) :=
 by haveI := classical.dec_eq γ; exact
 finset.induction_on s (λ _, by simp only [bind_empty, prod_empty])
   (assume x s hxs ih hd,
-  have hd' : ∀x∈s, ∀y∈s, x ≠ y → t x ∩ t y = ∅,
+  have hd' : ∀x∈s, ∀y∈s, x ≠ y → disjoint (t x) (t y),
     from assume _ hx _ hy, hd _ (mem_insert_of_mem hx) _ (mem_insert_of_mem hy),
-  have t x ∩ finset.bind s t = ∅,
-    from eq_empty_of_forall_not_mem $ assume a,
-      by rw [mem_inter, mem_bind];
-      rintro ⟨h₁, y, hys, hy₂⟩;
-      exact eq_empty_iff_forall_not_mem.1
-        (hd _ (mem_insert_self _ _) _ (mem_insert_of_mem hys) (assume h, hxs (h.symm ▸ hys)))
-        _ (mem_inter_of_mem h₁ hy₂),
+  have ∀y∈s, x ≠ y,
+    from assume _ hy h, by rw [←h] at hy; contradiction,
+  have ∀y∈s, disjoint (t x) (t y),
+    from assume _ hy, hd _ (mem_insert_self _ _) _ (mem_insert_of_mem hy) (this _ hy),
+  have disjoint (t x) (finset.bind s t),
+    from (disjoint_bind_right _ _ _).mpr this,
   by simp only [bind_insert, prod_insert hxs, prod_union this, ih hd'])
 
 @[to_additive]
@@ -103,9 +102,11 @@ lemma prod_product {s : finset γ} {t : finset α} {f : γ×α → β} :
   (s.product t).prod f = s.prod (λx, t.prod $ λy, f (x, y)) :=
 begin
   haveI := classical.dec_eq α, haveI := classical.dec_eq γ,
-  rw [product_eq_bind, prod_bind (λ x hx y hy h, eq_empty_of_forall_not_mem _)],
+  rw [product_eq_bind, prod_bind],
   { congr, funext, exact prod_image (λ _ _ _ _ H, (prod.mk.inj H).2) },
-  simp only [mem_inter, mem_image], rintro ⟨_, _⟩ ⟨⟨_, _, _⟩, ⟨_, _, _⟩⟩, apply h, cc
+  simp only [disjoint_iff_ne, mem_image],
+  rintros _ _ _ _ h ⟨_, _⟩ ⟨_, _, ⟨_, _⟩⟩ ⟨_, _⟩ ⟨_, _, ⟨_, _⟩⟩ _,
+  apply h, cc
 end
 
 @[to_additive]
@@ -116,9 +117,9 @@ by haveI := classical.dec_eq α; haveI := (λ a, classical.dec_eq (σ a)); exact
 calc (s.sigma t).prod f =
        (s.bind (λa, (t a).image (λs, sigma.mk a s))).prod f : by rw sigma_eq_bind
   ... = s.prod (λa, ((t a).image (λs, sigma.mk a s)).prod f) :
-    prod_bind $ assume a₁ ha a₂ ha₂ h, eq_empty_of_forall_not_mem $
-    by simp only [mem_inter, mem_image];
-    rintro ⟨_, _⟩ ⟨⟨_, _, _⟩, ⟨_, _, _⟩⟩; apply h; cc
+    prod_bind $ assume a₁ ha a₂ ha₂ h,
+    by simp only [disjoint_iff_ne, mem_image];
+    rintro ⟨_, _⟩ ⟨_, _, _⟩ ⟨_, _⟩ ⟨_, _, _⟩ ⟨_, _⟩; apply h; cc
   ... = (s.prod $ λa, (t a).prod $ λs, f ⟨a, s⟩) :
     prod_congr rfl $ λ _ _, prod_image $ λ _ _ _ _ _, by cc
 
@@ -134,7 +135,7 @@ begin
     rcases finset.mem_image.1 ha with ⟨b, hb, rfl⟩,
     exact eq b hb },
   assume a₀ _ a₁ _ ne,
-  refine disjoint_iff_inter_eq_empty.1 (disjoint_iff_ne.2 _),
+  refine (disjoint_iff_ne.2 _),
   assume c₀ h₀ c₁ h₁,
   rcases mem_filter.1 h₀ with ⟨h₀, rfl⟩,
   rcases mem_filter.1 h₁ with ⟨h₁, rfl⟩,
@@ -389,7 +390,7 @@ end comm_group
 multiset.card_sigma _ _
 
 lemma card_bind [decidable_eq β] {s : finset α} {t : α → finset β}
-  (h : ∀ x ∈ s, ∀ y ∈ s, x ≠ y → t x ∩ t y = ∅) :
+  (h : ∀ x ∈ s, ∀ y ∈ s, x ≠ y → disjoint (t x) (t y)) :
   (s.bind t).card = s.sum (λ u, card (t u)) :=
 calc (s.bind t).card = (s.bind t).sum (λ _, 1) : by simp
 ... = s.sum (λ a, (t a).sum (λ _, 1)) : finset.sum_bind h
@@ -443,13 +444,12 @@ begin
   induction s using finset.induction with a s ha ih,
   { rw [pi_empty, sum_singleton], refl },
   { have h₁ : ∀x ∈ t a, ∀y ∈ t a, ∀h : x ≠ y,
-        image (pi.cons s a x) (pi s t) ∩ image (pi.cons s a y) (pi s t) = ∅,
+        disjoint (image (pi.cons s a x) (pi s t)) (image (pi.cons s a y) (pi s t)),
     { assume x hx y hy h,
-      apply eq_empty_of_forall_not_mem,
-      simp only [mem_inter, mem_image],
-      rintro p₁ ⟨⟨p₂, hp, eq⟩, ⟨p₃, hp₃, rfl⟩⟩,
+      simp only [disjoint_iff_ne, mem_image],
+      rintros _ ⟨p₂, hp, eq₂⟩ _ ⟨p₃, hp₃, eq₃⟩ eq,
       have : pi.cons s a x p₂ a (mem_insert_self _ _) = pi.cons s a y p₃ a (mem_insert_self _ _),
-      { rw [eq] },
+      { rw [eq₂, eq₃, eq] },
       rw [pi.cons_same, pi.cons_same] at this,
       exact h this },
     rw [prod_insert ha, pi_insert ha, ih, sum_mul, sum_bind h₁],
@@ -495,7 +495,7 @@ lemma sum_le_sum_of_subset_of_nonneg
   (h : s₁ ⊆ s₂) (hf : ∀x∈s₂, x ∉ s₁ → 0 ≤ f x) : s₁.sum f ≤ s₂.sum f :=
 calc s₁.sum f ≤ (s₂ \ s₁).sum f + s₁.sum f :
     le_add_of_nonneg_left' $ sum_nonneg $ by simpa only [mem_sdiff, and_imp]
-  ... = (s₂ \ s₁ ∪ s₁).sum f : (sum_union (sdiff_inter_self _ _)).symm
+  ... = (s₂ \ s₁ ∪ s₁).sum f : (sum_union sdiff_disjoint).symm
   ... = s₂.sum f : by rw [sdiff_union_of_subset h]
 
 lemma sum_eq_zero_iff_of_nonneg : (∀x∈s, 0 ≤ f x) → (s.sum f = 0 ↔ ∀x∈s, f x = 0) :=
@@ -524,7 +524,8 @@ sum_le_sum_of_subset_of_nonneg h $ assume x h₁ h₂, zero_le _
 
 lemma sum_le_sum_of_ne_zero (h : ∀x∈s₁, f x ≠ 0 → x ∈ s₂) : s₁.sum f ≤ s₂.sum f :=
 calc s₁.sum f = (s₁.filter (λx, f x = 0)).sum f + (s₁.filter (λx, f x ≠ 0)).sum f :
-    by rw [←sum_union, filter_union_filter_neg_eq]; apply filter_inter_filter_neg_eq
+    by rw [←sum_union, filter_union_filter_neg_eq];
+       exact disjoint_filter (assume _ h n_h, n_h h)
   ... ≤ s₂.sum f : add_le_of_nonpos_of_le'
       (sum_nonpos $ by simp only [mem_filter, and_imp]; exact λ _ _, le_of_eq)
       (sum_le_sum_of_subset $ by simpa only [subset_iff, mem_filter, and_imp])

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -1755,6 +1755,11 @@ theorem card_sdiff {s t : finset α} (h : s ⊆ t) : card (t \ s) = card t - car
 suffices card (t \ s) = card ((t \ s) ∪ s) - card s, by rwa sdiff_union_of_subset h at this,
 by rw [card_disjoint_union sdiff_disjoint, nat.add_sub_cancel]
 
+lemma disjoint_filter {s : finset α} {p q : α → Prop} [decidable_pred p] [decidable_pred q] :
+    (∀x, p x → ¬ q x) → disjoint (s.filter p) (s.filter q) :=
+assume h, by simp only [disjoint_iff_ne, mem_filter]; rintros a ⟨_, ha⟩ b ⟨_, hb⟩ eq;
+rw [eq] at ha; exact h _ ha hb
+
 end disjoint
 
 theorem sort_sorted_lt [decidable_linear_order α] (s : finset α) :

--- a/src/data/nat/totient.lean
+++ b/src/data/nat/totient.lean
@@ -60,7 +60,7 @@ calc ((range n.succ).filter (∣ n)).sum φ
                 hb.2 ▸ coprime_div_gcd_div_gcd (hb.2.symm ▸ hd0)⟩,
           hb.2 ▸ nat.mul_div_cancel' (gcd_dvd_right _ _)⟩))
 ... = ((filter (∣ n) (range n.succ)).bind (λ d, (range n).filter (λ m, gcd n m = d))).card :
-  (card_bind (by simp [finset.ext]; cc)).symm
+  (card_bind (by intros; apply disjoint_filter; cc)).symm
 ... = (range n).card :
   congr_arg card (finset.ext.2 (λ m, ⟨by finish,
     λ hm, have h : m < n, from mem_range.1 hm,

--- a/src/data/zmod/quadratic_reciprocity.lean
+++ b/src/data/zmod/quadratic_reciprocity.lean
@@ -182,7 +182,8 @@ calc (range (q / 2)).prod (λ n, ((range p).erase 0).prod (+ p * n)) *
   have h₂ : ∀ x, x ∈ range (q / 2) → ∀ y, y ∈ range (q / 2) → x ≠ y →
       disjoint (image (+p * x) (erase (range p) 0)) (image (+ p * y) (erase (range p) 0)) :=
     λ x hx y hy hxy, begin
-      suffices : ∀ z a, a ≠ 0 → a < p → a + p * x = z → ∀ bpy b, b ≠ 0 → b < p → b + p * y = bpy → z ≠ bpy,
+      suffices : ∀ z a, a ≠ 0 → a < p → a + p * x = z →
+                 ∀ bpy b, b ≠ 0 → b < p → b + p * y = bpy → z ≠ bpy,
       { simpa [disjoint_iff_ne] },
       assume z a ha0 hap ha bpy b hb0 hbp hb hzb,
       have : (a + p * x) / p = (b + p * y) / p,
@@ -259,7 +260,8 @@ have hq0 : (q : zmodp p hp) ≠ 0, by rwa [← nat.cast_zero, ne.def, zmodp.eq_i
             zero_mod, mod_eq_of_lt (lt_of_le_of_lt hxp (nat.div_lt_self hp.pos (lt_succ_self _)))]))).1 $
 have h₁ : disjoint ((range (succ (p * q / 2))).filter (coprime (p * q)))
       (filter (λ x, ¬coprime q x) (filter (coprime p) (range (succ (p * q / 2))))),
-  by { rw [finset.filter_filter], apply finset.disjoint_filter, rintros _ hpq ⟨_, hq⟩, exact hq (coprime.coprime_mul_left hpq) },
+  by {rw [finset.filter_filter], apply finset.disjoint_filter,
+      rintros _ hpq ⟨_, hq⟩, exact hq (coprime.coprime_mul_left hpq)},
 calc ((((range ((p * q) / 2).succ).filter (coprime (p * q))).prod (λ x, x) : ℕ) : zmodp p hp)
      * (q ^ (p / 2) * ((range (p / 2).succ).erase 0).prod (λ x, x) : zmodp p hp)
    = (((range (succ (p * q / 2))).filter (coprime (p * q)) ∪

--- a/src/data/zmod/quadratic_reciprocity.lean
+++ b/src/data/zmod/quadratic_reciprocity.lean
@@ -434,7 +434,7 @@ calc ((((range (p / 2).succ).erase 0).prod (λ x, (x : zmodp p hp)) ^ 2)) * (-1)
   begin
     rw ← prod_union,
     { exact finset.prod_congr (by simp [finset.ext, -not_lt, -not_le]; tauto) (λ _ _, rfl) },
-    { apply disjoint_filter, simp [-not_lt, - not_le]; tauto }
+    { apply disjoint_filter, tauto }
   end
 ... = -1 : by simp
 

--- a/src/data/zmod/quadratic_reciprocity.lean
+++ b/src/data/zmod/quadratic_reciprocity.lean
@@ -166,9 +166,9 @@ calc (range (q / 2)).prod (λ n, ((range p).erase 0).prod (+ p * n)) *
   by simp only [prod_image (λ _ _ _ _ h, add_right_cancel h)]; refl
 ... = ((range (q / 2)).bind (λ x, (erase (range p) 0).image (+ p * x))
          ∪ (erase (range (succ (p / 2))) 0).image (+ q / 2 * p)).prod (λ x, x) :
-  have h₁ : finset.bind (range (q / 2)) (λ x, ((range p).erase 0).image (+ p * x)) ∩
-      image (+ q / 2 * p) (erase (range (succ (p / 2))) 0) = ∅ :=
-    eq_empty_iff_forall_not_mem.2 $ λ x, begin
+  have h₁ : disjoint (finset.bind (range (q / 2)) (λ x, ((range p).erase 0).image (+ p * x)))
+      (image (+ q / 2 * p) (erase (range (succ (p / 2))) 0)) :=
+    disjoint_iff.2 $ eq_empty_iff_forall_not_mem.2 $ λ x, begin
       suffices : ∀ a, a ≠ 0 → a ≤ p / 2 → a + q / 2 * p = x → ∀ b, b < q / 2 →
         ∀ c, c ≠ 0 → c < p → ¬c + p * b = x,
       { simpa [lt_succ_iff] },
@@ -180,13 +180,13 @@ calc (range (q / 2)).prod (λ n, ((range p).erase 0).prod (+ p * n)) *
       exact lt_irrefl _ hbq
     end,
   have h₂ : ∀ x, x ∈ range (q / 2) → ∀ y, y ∈ range (q / 2) → x ≠ y →
-      (erase (range p) 0).image (+ p * x) ∩ image (+ p * y) (erase (range p) 0) = ∅ :=
+      disjoint (image (+p * x) (erase (range p) 0)) (image (+ p * y) (erase (range p) 0)) :=
     λ x hx y hy hxy, begin
-      suffices : ∀ z a, a ≠ 0 → a < p → a + p * x = z → ∀ b, b ≠ 0 → b < p → b + p * y ≠ z,
-      { simpa [finset.ext] },
-      assume z a ha0 hap ha b hb0 hbp hb,
+      suffices : ∀ z a, a ≠ 0 → a < p → a + p * x = z → ∀ bpy b, b ≠ 0 → b < p → b + p * y = bpy → z ≠ bpy,
+      { simpa [disjoint_iff_ne] },
+      assume z a ha0 hap ha bpy b hb0 hbp hb hzb,
       have : (a + p * x) / p = (b + p * y) / p,
-      { rw [ha, hb] },
+      { rw [ha, hb, hzb] },
       rw [nat.add_mul_div_left _ _ hp.pos, nat.add_mul_div_left _ _ hp.pos,
         (nat.div_eq_zero_iff hp.pos).2 hap, (nat.div_eq_zero_iff hp.pos).2 hbp] at this,
       simpa [hxy]
@@ -257,9 +257,9 @@ have hq0 : (q : zmodp p hp) ≠ 0, by rwa [← nat.cast_zero, ne.def, zmodp.eq_i
           assume x hx0 hxp,
           by rwa [← @nat.cast_zero (zmodp p hp), zmodp.eq_iff_modeq_nat, nat.modeq,
             zero_mod, mod_eq_of_lt (lt_of_le_of_lt hxp (nat.div_lt_self hp.pos (lt_succ_self _)))]))).1 $
-have h₁ : (range (succ (p * q / 2))).filter (coprime (p * q)) ∩
-      filter (λ x, ¬coprime q x) (filter (coprime p) (range (succ (p * q / 2)))) = ∅,
-  by have := @coprime.coprime_mul_left p q; simp [finset.ext, *] at * {contextual := tt},
+have h₁ : disjoint ((range (succ (p * q / 2))).filter (coprime (p * q)))
+      (filter (λ x, ¬coprime q x) (filter (coprime p) (range (succ (p * q / 2))))),
+  by { rw [finset.filter_filter], apply finset.disjoint_filter, rintros _ hpq ⟨_, hq⟩, exact hq (coprime.coprime_mul_left hpq) },
 calc ((((range ((p * q) / 2).succ).filter (coprime (p * q))).prod (λ x, x) : ℕ) : zmodp p hp)
      * (q ^ (p / 2) * ((range (p / 2).succ).erase 0).prod (λ x, x) : zmodp p hp)
    = (((range (succ (p * q / 2))).filter (coprime (p * q)) ∪
@@ -432,7 +432,7 @@ calc ((((range (p / 2).succ).erase 0).prod (λ x, (x : zmodp p hp)) ^ 2)) * (-1)
   begin
     rw ← prod_union,
     { exact finset.prod_congr (by simp [finset.ext, -not_lt, -not_le]; tauto) (λ _ _, rfl) },
-    { simp [finset.ext, -not_lt, - not_le]; tauto }
+    { apply disjoint_filter, simp [-not_lt, - not_le]; tauto }
   end
 ... = -1 : by simp
 

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -149,7 +149,7 @@ lemma sum_card_order_of_eq_card_pow_eq_one {n : ℕ} (hn : 0 < n) :
   ((finset.range n.succ).filter (∣ n)).sum (λ m, (finset.univ.filter (λ a : α, order_of a = m)).card)
   = (finset.univ.filter (λ a : α, a ^ n = 1)).card :=
 calc ((finset.range n.succ).filter (∣ n)).sum (λ m, (finset.univ.filter (λ a : α, order_of a = m)).card)
-    = _ : (finset.card_bind (by simp [finset.ext]; intros; apply finset.disjoint_filter; cc)).symm
+    = _ : (finset.card_bind (by { intros, apply finset.disjoint_filter, cc })).symm
 ... = _ : congr_arg finset.card (finset.ext.2 (begin
   assume a,
   suffices : order_of a ≤ n ∧ order_of a ∣ n ↔ a ^ n = 1,

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -149,7 +149,7 @@ lemma sum_card_order_of_eq_card_pow_eq_one {n : ℕ} (hn : 0 < n) :
   ((finset.range n.succ).filter (∣ n)).sum (λ m, (finset.univ.filter (λ a : α, order_of a = m)).card)
   = (finset.univ.filter (λ a : α, a ^ n = 1)).card :=
 calc ((finset.range n.succ).filter (∣ n)).sum (λ m, (finset.univ.filter (λ a : α, order_of a = m)).card)
-    = _ : (finset.card_bind (by simp [finset.ext]; cc)).symm
+    = _ : (finset.card_bind (by simp [finset.ext]; intros; apply finset.disjoint_filter; cc)).symm
 ... = _ : congr_arg finset.card (finset.ext.2 (begin
   assume a,
   suffices : order_of a ≤ n ∧ order_of a ∣ n ↔ a ^ n = 1,

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -231,7 +231,7 @@ has_sum_of_has_sum $ assume u, exists.intro (ii u) $
       by simp [mem_bind]; existsi i h; simp [h, hi, this],
     by rw [hji h] at this; exact hnc this,
   calc (u ∪ jj v).sum g = (jj v).sum g : (sum_subset (subset_union_right _ _) this).symm
-    ... = v.sum _ : sum_bind $ by intros x hx y hy hxy; by_cases f x = 0; by_cases f y = 0; simp [*]; cc
+    ... = v.sum _ : sum_bind $ by intros x _ y _ _; by_cases f x = 0; by_cases f y = 0; simp [*]; cc
     ... = v.sum f : sum_congr rfl $ by intros x hx; by_cases f x = 0; simp [*]
 
 lemma has_sum_iff_has_sum_of_ne_zero : has_sum f a ↔ has_sum g a :=

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -231,7 +231,7 @@ has_sum_of_has_sum $ assume u, exists.intro (ii u) $
       by simp [mem_bind]; existsi i h; simp [h, hi, this],
     by rw [hji h] at this; exact hnc this,
   calc (u ∪ jj v).sum g = (jj v).sum g : (sum_subset (subset_union_right _ _) this).symm
-    ... = v.sum _ : sum_bind $ by intros x hx y hy hxy; by_cases f x = 0; by_cases f y = 0; simp [*]
+    ... = v.sum _ : sum_bind $ by intros x hx y hy hxy; by_cases f x = 0; by_cases f y = 0; simp [*]; cc
     ... = v.sum f : sum_congr rfl $ by intros x hx; by_cases f x = 0; simp [*]
 
 lemma has_sum_iff_has_sum_of_ne_zero : has_sum f a ↔ has_sum g a :=
@@ -502,9 +502,8 @@ begin
     rcases h e he with ⟨⟨s₁, s₂⟩, h⟩,
     use [s₁ ∪ s₂],
     assume t ht,
-    have : (s₁ ∪ s₂) ∩ t = ∅ := finset.disjoint_iff_inter_eq_empty.1 ht.symm,
     specialize h (s₁ ∪ s₂, (s₁ ∪ s₂) ∪ t) ⟨le_sup_left, le_sup_left_of_le le_sup_right⟩,
-    simpa only [finset.sum_union this, add_sub_cancel'] using h },
+    simpa only [finset.sum_union ht.symm, add_sub_cancel'] using h },
   { assume h e he,
     rcases exists_nhds_half_neg he with ⟨d, hd, hde⟩,
     rcases h d hd with ⟨s, h⟩,


### PR DESCRIPTION
In `algebra/big_operators.lean`, some definitions don't use `finset.disjoint` but write out 
out s₁ ∩ s₂ = ∅ (which is slightly incompatible with `disjoint`). This pull request changes those definitions to use `disjoint` instead, and includes updates to fix dependencies on these definitions. Since many uses included the lemma `finset.filter_inter_filter_neg_eq`, I introduced a lemma `finset.disjoint_filter` which serves the same role.

Zulip discussion: https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/disjoint.20in.20algebra.2Ebig_operators

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
