### PR TITLE
feat(data|set_theory): various new lemmas

### DIFF
--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -82,7 +82,6 @@ lt_add_of_le_of_pos (le_refl _) zero_lt_one
 lemma lt_one_add (x : α) : x < 1 + x :=
 by { rw [add_comm], apply lt_add_one }
 
-
 lemma one_lt_two : 1 < (2 : α) := lt_add_one _
 
 lemma one_lt_mul {a b : α} (ha : 1 ≤ a) (hb : 1 < b) : 1 < a * b :=

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -79,7 +79,7 @@ bit1_pos (le_of_lt h)
 lemma lt_add_one (a : α) : a < a + 1 :=
 lt_add_of_le_of_pos (le_refl _) zero_lt_one
 
-lemma lt_one_add (x : α) : x < 1 + x :=
+lemma lt_one_add (a : α) : a < 1 + a :=
 by { rw [add_comm], apply lt_add_one }
 
 lemma one_lt_two : 1 < (2 : α) := lt_add_one _

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -79,6 +79,10 @@ bit1_pos (le_of_lt h)
 lemma lt_add_one (a : α) : a < a + 1 :=
 lt_add_of_le_of_pos (le_refl _) zero_lt_one
 
+lemma lt_one_add (x : α) : x < 1 + x :=
+by { rw [add_comm], apply lt_add_one }
+
+
 lemma one_lt_two : 1 < (2 : α) := lt_add_one _
 
 lemma one_lt_mul {a b : α} (ha : 1 ≤ a) (hb : 1 < b) : 1 < a * b :=

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -909,7 +909,7 @@ by { dsimp [set_value], simp [swap_apply_left] }
 
 end swap
 
-protected lemma forall_congr {α β} {p : α → Prop} {q : β → Prop} (f : α ≃ β)
+protected lemma forall_congr {p : α → Prop} {q : β → Prop} (f : α ≃ β)
   (h : ∀{x}, p x ↔ q (f x)) : (∀x, p x) ↔ (∀y, q y) :=
 begin
   split; intros h₂ x,

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -909,6 +909,14 @@ by { dsimp [set_value], simp [swap_apply_left] }
 
 end swap
 
+protected lemma forall_congr {α β} {p : α → Prop} {q : β → Prop} (f : α ≃ β)
+  (h : ∀{x}, p x ↔ q (f x)) : (∀x, p x) ↔ (∀y, q y) :=
+begin
+  split; intros h₂ x,
+  { rw [←f.right_inv x], apply h.mp, apply h₂ },
+  apply h.mpr, apply h₂
+end
+
 end equiv
 
 instance {α} [subsingleton α] : subsingleton (ulift α) := equiv.ulift.subsingleton

--- a/src/data/equiv/list.lean
+++ b/src/data/equiv/list.lean
@@ -245,6 +245,12 @@ end denumerable
 
 namespace equiv
 
+def list_unit_equiv : list unit ≃ ℕ :=
+{ to_fun := list.length,
+  inv_fun := list.repeat (),
+  left_inv := λ u, list.injective_length (by simp),
+  right_inv := λ n, list.length_repeat () n }
+
 def list_nat_equiv_nat : list ℕ ≃ ℕ := denumerable.eqv _
 
 def list_equiv_self_of_equiv_nat {α : Type} (e : α ≃ ℕ) : list α ≃ α :=

--- a/src/data/equiv/list.lean
+++ b/src/data/equiv/list.lean
@@ -245,7 +245,7 @@ end denumerable
 
 namespace equiv
 
-/-- The type of natural numbers is naturally equivalent to lists on unit. -/
+/-- The type lists on unit is canonically equivalent to the natural numbers. -/
 def list_unit_equiv : list unit ≃ ℕ :=
 { to_fun := list.length,
   inv_fun := list.repeat (),

--- a/src/data/equiv/list.lean
+++ b/src/data/equiv/list.lean
@@ -245,6 +245,7 @@ end denumerable
 
 namespace equiv
 
+/-- The type of natural numbers is naturally equivalent to lists on unit. -/
 def list_unit_equiv : list unit ≃ ℕ :=
 { to_fun := list.length,
   inv_fun := list.repeat (),

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -7,7 +7,7 @@ More about finite numbers.
 -/
 import data.nat.basic
 
-open fin nat
+open fin nat function
 
 /-- `fin 0` is empty -/
 def fin_zero_elim {C : Sort*} : fin 0 → C :=
@@ -25,6 +25,8 @@ by cases a; refl
 protected lemma ext_iff (a b : fin n) : a = b ↔ a.val = b.val :=
 iff.intro (congr_arg _) fin.eq_of_veq
 
+lemma injective_val {n : ℕ} : injective (val : fin n → ℕ) := λ _ _, fin.eq_of_veq
+
 lemma eq_iff_veq (a b : fin n) : a = b ↔ a.1 = b.1 :=
 ⟨veq_of_eq, eq_of_veq⟩
 
@@ -39,6 +41,12 @@ instance fin_to_nat (n : ℕ) : has_coe (fin n) nat := ⟨fin.val⟩
 @[simp] lemma coe_mk {m n : ℕ} (h : m < n) : ((⟨m, h⟩ : fin n) : ℕ) = m := rfl
 
 lemma coe_eq_val (a : fin n) : (a : ℕ) = a.val := rfl
+
+@[simp] lemma val_one  {n : ℕ} : (1 : fin (n+2)).val = 1 := rfl
+@[simp] lemma val_two  {n : ℕ} : (2 : fin (n+3)).val = 2 := rfl
+@[simp] lemma coe_zero {n : ℕ} : ((0 : fin (n+1)) : ℕ) = 0 := rfl
+@[simp] lemma coe_one  {n : ℕ} : ((1 : fin (n+2)) : ℕ) = 1 := rfl
+@[simp] lemma coe_two  {n : ℕ} : ((2 : fin (n+3)) : ℕ) = 2 := rfl
 
 instance {n : ℕ} : decidable_linear_order (fin n) :=
 decidable_linear_order.lift fin.val (@fin.eq_of_veq _) (by apply_instance)
@@ -158,7 +166,7 @@ def clamp (n m : ℕ) : fin (m + 1) := fin.of_nat $ min n m
 @[simp] lemma clamp_val (n m : ℕ) : (clamp n m).val = min n m :=
 nat.mod_eq_of_lt $ nat.lt_succ_iff.mpr $ min_le_right _ _
 
-lemma injective_cast_le {n₁ n₂ : ℕ} (h : n₁ ≤ n₂) : function.injective (fin.cast_le h)
+lemma injective_cast_le {n₁ n₂ : ℕ} (h : n₁ ≤ n₂) : injective (fin.cast_le h)
 | ⟨i₁, h₁⟩ ⟨i₂, h₂⟩ eq := fin.eq_of_veq $ show i₁ = i₂, from fin.veq_of_eq eq
 
 theorem succ_above_ne (p : fin (n+1)) (i : fin n) : p.succ_above i ≠ p :=

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -257,7 +257,7 @@ theorem append_subset_of_subset_of_subset {l₁ l₂ l : list α} (l₁subl : l�
   l₁ ++ l₂ ⊆ l :=
 λ a h, (mem_append.1 h).elim (@l₁subl _) (@l₂subl _)
 
-@[simp] theorem append_subset_iff {α} {l₁ l₂ l : list α} :
+@[simp] theorem append_subset_iff {l₁ l₂ l : list α} :
   l₁ ++ l₂ ⊆ l ↔ l₁ ⊆ l ∧ l₂ ⊆ l :=
 begin
   split,
@@ -443,7 +443,7 @@ by induction n; [refl, simp only [*, repeat, join, append_nil]]
 @[simp] theorem bind_eq_bind {α β} (f : α → list β) (l : list α) :
   l >>= f = l.bind f := rfl
 
-@[simp] theorem bind_append {α β} (f : α → list β) (l₁ l₂ : list α) :
+@[simp] theorem bind_append (f : α → list β) (l₁ l₂ : list α) :
   (l₁ ++ l₂).bind f = l₁.bind f ++ l₂.bind f :=
 append_bind _ _ _
 
@@ -1086,17 +1086,16 @@ eq_nil_of_length_eq_zero $ by rw [← length_map f l, h]; refl
   map f (join L) = join (map (map f) L) :=
 by induction L; [refl, simp only [*, join, map, map_append]]
 
-theorem bind_ret_eq_map {α β} (f : α → β) (l : list α) :
+theorem bind_ret_eq_map (f : α → β) (l : list α) :
   l.bind (list.ret ∘ f) = map f l :=
 by unfold list.bind; induction l; simp only [map, join, list.ret, cons_append, nil_append, *]; split; refl
 
-@[simp] theorem map_eq_map {α β} (f : α → β) (l : list α) :
-  f <$> l = map f l := rfl
+@[simp] theorem map_eq_map (f : α → β) (l : list α) : f <$> l = map f l := rfl
 
 @[simp] theorem map_tail (f : α → β) (l) : map f (tail l) = tail (map f l) :=
 by cases l; refl
 
-@[simp] theorem injective_map_iff {α β} {f : α → β} : injective (map f) ↔ injective f :=
+@[simp] theorem injective_map_iff {f : α → β} : injective (map f) ↔ injective f :=
 begin
   split; intros h x y hxy,
   { suffices : [x] = [y], { simpa using this }, apply h, simp [hxy] },
@@ -3936,8 +3935,7 @@ theorem chain'.iff {S : α → α → Prop}
   (H : ∀ a b, R a b ↔ S a b) {l : list α} : chain' R l ↔ chain' S l :=
 ⟨chain'.imp (λ a b, (H a b).1), chain'.imp (λ a b, (H a b).2)⟩
 
-theorem chain'.iff_mem : ∀ {l : list α},
-  chain' R l ↔ chain' (λ x y, x ∈ l ∧ y ∈ l ∧ R x y) l
+theorem chain'.iff_mem : ∀ {l : list α}, chain' R l ↔ chain' (λ x y, x ∈ l ∧ y ∈ l ∧ R x y) l
 | [] := iff.rfl
 | (x::l) :=
   ⟨λ h, (chain.iff_mem.1 h).imp $ λ a b ⟨h₁, h₂, h₃⟩, ⟨h₁, or.inr h₂, h₃⟩,

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -164,11 +164,17 @@ theorem length_pos_iff_exists_mem {l : list α} : 0 < length l ↔ ∃ a, a ∈ 
 theorem length_eq_one {l : list α} : length l = 1 ↔ ∃ a, l = [a] :=
 ⟨match l with [a], _ := ⟨a, rfl⟩ end, λ ⟨a, e⟩, e.symm ▸ rfl⟩
 
-lemma injective_length [subsingleton α] : injective (length : list α → ℕ) :=
+lemma injective_length_iff : subsingleton α ↔ injective (list.length : list α → ℕ) :=
 begin
-  intro l, induction l with x l; intros l' h; cases l'; try {contradiction},
-  refl, simp only, use subsingleton.elim _ _, apply l_ih, injection h
+  split,
+  { intros hα l1 l2 hl, induction l1 generalizing l2; cases l2,
+    { refl }, { cases hl }, { cases hl },
+    congr, exactI subsingleton.elim _ _, apply l1_ih, simpa using hl },
+  { intro h, refine ⟨λ x y, _⟩, suffices : [x] = [y], { simpa using this }, apply h, refl }
 end
+
+lemma injective_length [subsingleton α] : injective (length : list α → ℕ) :=
+injective_length_iff.mp $ by apply_instance
 
 /- set-theoretic notation of lists -/
 

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -233,10 +233,10 @@ iff.intro or_exists_of_exists_mem_cons
 
 theorem subset_def {l₁ l₂ : list α} : l₁ ⊆ l₂ ↔ ∀ ⦃a : α⦄, a ∈ l₁ → a ∈ l₂ := iff.rfl
 
-theorem subset_app_of_subset_left (l l₁ l₂ : list α) : l ⊆ l₁ → l ⊆ l₁++l₂ :=
+theorem subset_append_of_subset_left (l l₁ l₂ : list α) : l ⊆ l₁ → l ⊆ l₁++l₂ :=
 λ s, subset.trans s $ subset_append_left _ _
 
-theorem subset_app_of_subset_right (l l₁ l₂ : list α) : l ⊆ l₂ → l ⊆ l₁++l₂ :=
+theorem subset_append_of_subset_right (l l₁ l₂ : list α) : l ⊆ l₂ → l ⊆ l₁++l₂ :=
 λ s, subset.trans s $ subset_append_right _ _
 
 @[simp] theorem cons_subset {a : α} {l m : list α} :
@@ -247,7 +247,7 @@ theorem cons_subset_of_subset_of_mem {a : α} {l m : list α}
   (ainm : a ∈ m) (lsubm : l ⊆ m) : a::l ⊆ m :=
 cons_subset.2 ⟨ainm, lsubm⟩
 
-theorem app_subset_of_subset_of_subset {l₁ l₂ l : list α} (l₁subl : l₁ ⊆ l) (l₂subl : l₂ ⊆ l) :
+theorem append_subset_of_subset_of_subset {l₁ l₂ l : list α} (l₁subl : l₁ ⊆ l) (l₂subl : l₂ ⊆ l) :
   l₁ ++ l₂ ⊆ l :=
 λ a h, (mem_append.1 h).elim (@l₁subl _) (@l₂subl _)
 
@@ -256,7 +256,7 @@ theorem app_subset_of_subset_of_subset {l₁ l₂ l : list α} (l₁subl : l₁ 
 begin
   split,
   { intro h, simp only [subset_def] at *, split; intros; simp* },
-  { rintro ⟨h1, h2⟩, apply app_subset_of_subset_of_subset h1 h2 }
+  { rintro ⟨h1, h2⟩, apply append_subset_of_subset_of_subset h1 h2 }
 end
 
 theorem eq_nil_of_subset_nil : ∀ {l : list α}, l ⊆ [] → l = []
@@ -602,10 +602,10 @@ sublist.cons2 _ _ _ s
 theorem sublist_cons_of_sublist (a : α) {l₁ l₂ : list α} : l₁ <+ l₂ → l₁ <+ a::l₂ :=
 sublist.cons _ _ _
 
-theorem sublist_app_of_sublist_left {l l₁ l₂ : list α} (s : l <+ l₁) : l <+ l₁++l₂ :=
+theorem sublist_append_of_sublist_left {l l₁ l₂ : list α} (s : l <+ l₁) : l <+ l₁++l₂ :=
 s.trans $ sublist_append_left _ _
 
-theorem sublist_app_of_sublist_right {l l₁ l₂ : list α} (s : l <+ l₂) : l <+ l₁++l₂ :=
+theorem sublist_append_of_sublist_right {l l₁ l₂ : list α} (s : l <+ l₂) : l <+ l₁++l₂ :=
 s.trans $ sublist_append_right _ _
 
 theorem sublist_of_cons_sublist_cons {l₁ l₂ : list α} : ∀ {a : α}, a::l₁ <+ a::l₂ → l₁ <+ l₂
@@ -639,7 +639,7 @@ end
 theorem reverse_sublist {l₁ l₂ : list α} (h : l₁ <+ l₂) : l₁.reverse <+ l₂.reverse :=
 begin
   induction h with _ _ _ _ ih _ _ a _ ih, {refl},
-  { rw reverse_cons, exact sublist_app_of_sublist_left ih },
+  { rw reverse_cons, exact sublist_append_of_sublist_left ih },
   { rw [reverse_cons, reverse_cons], exact append_sublist_append_of_sublist_right ih [a] }
 end
 
@@ -3657,7 +3657,7 @@ theorem pairwise_append {l₁ l₂ : list α} : pairwise R (l₁++l₂) ↔
 by induction l₁ with x l₁ IH; [simp only [list.pairwise.nil, forall_prop_of_false (not_mem_nil _), forall_true_iff, and_true, true_and, nil_append],
 simp only [cons_append, pairwise_cons, forall_mem_append, IH, forall_mem_cons, forall_and_distrib, and_assoc, and.left_comm]]
 
-theorem pairwise_app_comm (s : symmetric R) {l₁ l₂ : list α} :
+theorem pairwise_append_comm (s : symmetric R) {l₁ l₂ : list α} :
   pairwise R (l₁++l₂) ↔ pairwise R (l₂++l₁) :=
 have ∀ l₁ l₂ : list α,
   (∀ (x : α), x ∈ l₁ → ∀ (y : α), y ∈ l₂ → R x y) →
@@ -3668,7 +3668,7 @@ by simp only [pairwise_append, and.left_comm]; rw iff.intro (this l₁ l₂) (th
 theorem pairwise_middle (s : symmetric R) {a : α} {l₁ l₂ : list α} :
   pairwise R (l₁ ++ a::l₂) ↔ pairwise R (a::(l₁++l₂)) :=
 show pairwise R (l₁ ++ ([a] ++ l₂)) ↔ pairwise R ([a] ++ l₁ ++ l₂),
-by rw [← append_assoc, pairwise_append, @pairwise_append _ _ ([a] ++ l₁), pairwise_app_comm s];
+by rw [← append_assoc, pairwise_append, @pairwise_append _ _ ([a] ++ l₁), pairwise_append_comm s];
    simp only [mem_append, or_comm]
 
 theorem pairwise_map (f : β → α) :
@@ -4056,10 +4056,11 @@ by simp only [nodup, pairwise_append, disjoint_iff_ne]
 theorem disjoint_of_nodup_append {l₁ l₂ : list α} (d : nodup (l₁++l₂)) : disjoint l₁ l₂ :=
 (nodup_append.1 d).2.2
 
-theorem nodup_append_of_nodup {l₁ l₂ : list α} (d₁ : nodup l₁) (d₂ : nodup l₂) (dj : disjoint l₁ l₂) : nodup (l₁++l₂) :=
+theorem nodup_append_of_nodup {l₁ l₂ : list α} (d₁ : nodup l₁) (d₂ : nodup l₂)
+  (dj : disjoint l₁ l₂) : nodup (l₁++l₂) :=
 nodup_append.2 ⟨d₁, d₂, dj⟩
 
-theorem nodup_app_comm {l₁ l₂ : list α} : nodup (l₁++l₂) ↔ nodup (l₂++l₁) :=
+theorem nodup_append_comm {l₁ l₂ : list α} : nodup (l₁++l₂) ↔ nodup (l₂++l₁) :=
 by simp only [nodup_append, and.left_comm, disjoint_comm]
 
 theorem nodup_middle {a : α} {l₁ l₂ : list α} : nodup (l₁ ++ a::l₂) ↔ nodup (a::(l₁++l₂)) :=

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -1487,7 +1487,7 @@ by induction L; [refl, simp only [*, join, map, sum_cons, length_append]]
 @[simp] theorem length_bind (l : list α) (f : α → list β) : length (list.bind l f) = sum (map (length ∘ f) l) :=
 by rw [list.bind, length_join, map_map]
 
-def exists_lt_of_sum_lt [decidable_linear_ordered_cancel_comm_monoid β] {l : list α}
+lemma exists_lt_of_sum_lt [decidable_linear_ordered_cancel_comm_monoid β] {l : list α}
   (f g : α → β) (h : (l.map f).sum < (l.map g).sum) : ∃ x ∈ l, f x < g x :=
 begin
   induction l with x l,
@@ -1497,7 +1497,7 @@ begin
     exact lt_of_add_lt_add_left' (lt_of_lt_of_le h $ add_le_add_right (le_of_not_gt h') _) }
 end
 
-def exists_le_of_sum_le [decidable_linear_ordered_cancel_comm_monoid β] {l : list α}
+lemma exists_le_of_sum_le [decidable_linear_ordered_cancel_comm_monoid β] {l : list α}
   (hl : l ≠ []) (f g : α → β) (h : (l.map f).sum ≤ (l.map g).sum) : ∃ x ∈ l, f x ≤ g x :=
 begin
   cases l with x l,
@@ -2725,8 +2725,7 @@ begin
   { rw filter_map_cons_some _ _ _ eq },
 end
 
-lemma rel_filter_map {f : α → option γ} {q : β → option δ} :
-  ((r ⇒ option.rel p) ⇒ forall₂ r ⇒ forall₂ p) filter_map filter_map
+lemma rel_filter_map : ((r ⇒ option.rel p) ⇒ forall₂ r ⇒ forall₂ p) filter_map filter_map
 | f g hfg _ _ forall₂.nil := forall₂.nil
 | f g hfg (a::as) (b::bs) (forall₂.cons h₁ h₂) :=
   by rw [filter_map_cons, filter_map_cons];
@@ -2813,11 +2812,11 @@ mem_insert_iff.2 (or.inr h)
 theorem eq_or_mem_of_mem_insert {a b : α} {l : list α} (h : a ∈ insert b l) : a = b ∨ a ∈ l :=
 mem_insert_iff.1 h
 
-@[simp] theorem length_insert_of_mem {a : α} [decidable_eq α] {l : list α} (h : a ∈ l) :
+@[simp] theorem length_insert_of_mem {a : α} {l : list α} (h : a ∈ l) :
   length (insert a l) = length l :=
 by rw insert_of_mem h
 
-@[simp] theorem length_insert_of_not_mem {a : α} [decidable_eq α] {l : list α} (h : a ∉ l) :
+@[simp] theorem length_insert_of_not_mem {a : α} {l : list α} (h : a ∉ l) :
   length (insert a l) = length l + 1 :=
 by rw insert_of_not_mem h; refl
 
@@ -3937,7 +3936,7 @@ theorem chain'.iff {S : α → α → Prop}
   (H : ∀ a b, R a b ↔ S a b) {l : list α} : chain' R l ↔ chain' S l :=
 ⟨chain'.imp (λ a b, (H a b).1), chain'.imp (λ a b, (H a b).2)⟩
 
-theorem chain'.iff_mem {S : α → α → Prop} : ∀ {l : list α},
+theorem chain'.iff_mem : ∀ {l : list α},
   chain' R l ↔ chain' (λ x y, x ∈ l ∧ y ∈ l ∧ R x y) l
 | [] := iff.rfl
 | (x::l) :=
@@ -5087,8 +5086,6 @@ end nat
 
 end list
 
-theorem option.to_list_nodup : ∀ o : option α, o.to_list.nodup
+theorem option.to_list_nodup {α} : ∀ o : option α, o.to_list.nodup
 | none     := list.nodup_nil
 | (some x) := list.nodup_singleton x
-
-#sanity_check

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -524,58 +524,6 @@ by {induction s, contradiction, refl}
 theorem cons_head_tail [inhabited α] {l : list α} (h : l ≠ []) : (head l)::(tail l) = l :=
 by {induction l, contradiction, refl}
 
-/- map -/
-
-lemma map_congr {f g : α → β} : ∀ {l : list α}, (∀ x ∈ l, f x = g x) → map f l = map g l
-| []     _ := rfl
-| (a::l) h := let ⟨h₁, h₂⟩ := forall_mem_cons.1 h in
-  by rw [map, map, h₁, map_congr h₂]
-
-theorem map_concat (f : α → β) (a : α) (l : list α) : map f (concat l a) = concat (map f l) (f a) :=
-by induction l; [refl, simp only [*, concat_eq_append, cons_append, map, map_append]]; split; refl
-
-theorem map_id' {f : α → α} (h : ∀ x, f x = x) (l : list α) : map f l = l :=
-by induction l; [refl, simp only [*, map]]; split; refl
-
-@[simp] theorem foldl_map (g : β → γ) (f : α → γ → α) (a : α) (l : list β) : foldl f a (map g l) = foldl (λx y, f x (g y)) a l :=
-by revert a; induction l; intros; [refl, simp only [*, map, foldl]]
-
-@[simp] theorem foldr_map (g : β → γ) (f : γ → α → α) (a : α) (l : list β) : foldr f a (map g l) = foldr (f ∘ g) a l :=
-by revert a; induction l; intros; [refl, simp only [*, map, foldr]]
-
-theorem foldl_hom (f : α → β) (g : α → γ → α) (g' : β → γ → β) (a : α)
-  (h : ∀a x, f (g a x) = g' (f a) x) (l : list γ) : f (foldl g a l) = foldl g' (f a) l :=
-by revert a; induction l; intros; [refl, simp only [*, foldl]]
-
-theorem foldr_hom (f : α → β) (g : γ → α → α) (g' : γ → β → β) (a : α)
-  (h : ∀x a, f (g x a) = g' x (f a)) (l : list γ) : f (foldr g a l) = foldr g' (f a) l :=
-by revert a; induction l; intros; [refl, simp only [*, foldr]]
-
-theorem eq_nil_of_map_eq_nil {f : α → β} {l : list α} (h : map f l = nil) : l = nil :=
-eq_nil_of_length_eq_zero $ by rw [← length_map f l, h]; refl
-
-@[simp] theorem map_join (f : α → β) (L : list (list α)) :
-  map f (join L) = join (map (map f) L) :=
-by induction L; [refl, simp only [*, join, map, map_append]]
-
-theorem bind_ret_eq_map {α β} (f : α → β) (l : list α) :
-  l.bind (list.ret ∘ f) = map f l :=
-by unfold list.bind; induction l; simp only [map, join, list.ret, cons_append, nil_append, *]; split; refl
-
-@[simp] theorem map_eq_map {α β} (f : α → β) (l : list α) :
-  f <$> l = map f l := rfl
-
-@[simp] theorem map_tail (f : α → β) (l) : map f (tail l) = tail (map f l) :=
-by cases l; refl
-
-/- map₂ -/
-
-theorem nil_map₂ (f : α → β → γ) (l : list β) : map₂ f [] l = [] :=
-by cases l; refl
-
-theorem map₂_nil (f : α → β → γ) (l : list α) : map₂ f l [] = [] :=
-by cases l; refl
-
 /- sublists -/
 
 @[simp] theorem nil_sublist : Π (l : list α), [] <+ l
@@ -1046,6 +994,58 @@ lemma mem_insert_nth {a b : α} : ∀ {n : ℕ} {l : list α} (hi : n ≤ l.leng
 end
 
 end insert_nth
+
+/- map -/
+
+lemma map_congr {f g : α → β} : ∀ {l : list α}, (∀ x ∈ l, f x = g x) → map f l = map g l
+| []     _ := rfl
+| (a::l) h := let ⟨h₁, h₂⟩ := forall_mem_cons.1 h in
+  by rw [map, map, h₁, map_congr h₂]
+
+theorem map_concat (f : α → β) (a : α) (l : list α) : map f (concat l a) = concat (map f l) (f a) :=
+by induction l; [refl, simp only [*, concat_eq_append, cons_append, map, map_append]]; split; refl
+
+theorem map_id' {f : α → α} (h : ∀ x, f x = x) (l : list α) : map f l = l :=
+by induction l; [refl, simp only [*, map]]; split; refl
+
+@[simp] theorem foldl_map (g : β → γ) (f : α → γ → α) (a : α) (l : list β) : foldl f a (map g l) = foldl (λx y, f x (g y)) a l :=
+by revert a; induction l; intros; [refl, simp only [*, map, foldl]]
+
+@[simp] theorem foldr_map (g : β → γ) (f : γ → α → α) (a : α) (l : list β) : foldr f a (map g l) = foldr (f ∘ g) a l :=
+by revert a; induction l; intros; [refl, simp only [*, map, foldr]]
+
+theorem foldl_hom (f : α → β) (g : α → γ → α) (g' : β → γ → β) (a : α)
+  (h : ∀a x, f (g a x) = g' (f a) x) (l : list γ) : f (foldl g a l) = foldl g' (f a) l :=
+by revert a; induction l; intros; [refl, simp only [*, foldl]]
+
+theorem foldr_hom (f : α → β) (g : γ → α → α) (g' : γ → β → β) (a : α)
+  (h : ∀x a, f (g x a) = g' x (f a)) (l : list γ) : f (foldr g a l) = foldr g' (f a) l :=
+by revert a; induction l; intros; [refl, simp only [*, foldr]]
+
+theorem eq_nil_of_map_eq_nil {f : α → β} {l : list α} (h : map f l = nil) : l = nil :=
+eq_nil_of_length_eq_zero $ by rw [← length_map f l, h]; refl
+
+@[simp] theorem map_join (f : α → β) (L : list (list α)) :
+  map f (join L) = join (map (map f) L) :=
+by induction L; [refl, simp only [*, join, map, map_append]]
+
+theorem bind_ret_eq_map {α β} (f : α → β) (l : list α) :
+  l.bind (list.ret ∘ f) = map f l :=
+by unfold list.bind; induction l; simp only [map, join, list.ret, cons_append, nil_append, *]; split; refl
+
+@[simp] theorem map_eq_map {α β} (f : α → β) (l : list α) :
+  f <$> l = map f l := rfl
+
+@[simp] theorem map_tail (f : α → β) (l) : map f (tail l) = tail (map f l) :=
+by cases l; refl
+
+/- map₂ -/
+
+theorem nil_map₂ (f : α → β → γ) (l : list β) : map₂ f [] l = [] :=
+by cases l; refl
+
+theorem map₂_nil (f : α → β → γ) (l : list α) : map₂ f l [] = [] :=
+by cases l; refl
 
 /- take, drop -/
 @[simp] theorem take_zero (l : list α) : take 0 l = [] := rfl

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -164,17 +164,17 @@ theorem length_pos_iff_exists_mem {l : list α} : 0 < length l ↔ ∃ a, a ∈ 
 theorem length_eq_one {l : list α} : length l = 1 ↔ ∃ a, l = [a] :=
 ⟨match l with [a], _ := ⟨a, rfl⟩ end, λ ⟨a, e⟩, e.symm ▸ rfl⟩
 
-lemma injective_length_iff : subsingleton α ↔ injective (list.length : list α → ℕ) :=
+lemma injective_length_iff : injective (list.length : list α → ℕ) ↔ subsingleton α :=
 begin
   split,
+  { intro h, refine ⟨λ x y, _⟩, suffices : [x] = [y], { simpa using this }, apply h, refl },
   { intros hα l1 l2 hl, induction l1 generalizing l2; cases l2,
     { refl }, { cases hl }, { cases hl },
-    congr, exactI subsingleton.elim _ _, apply l1_ih, simpa using hl },
-  { intro h, refine ⟨λ x y, _⟩, suffices : [x] = [y], { simpa using this }, apply h, refl }
+    congr, exactI subsingleton.elim _ _, apply l1_ih, simpa using hl }
 end
 
 lemma injective_length [subsingleton α] : injective (length : list α → ℕ) :=
-injective_length_iff.mp $ by apply_instance
+injective_length_iff.mpr $ by apply_instance
 
 /- set-theoretic notation of lists -/
 

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -1090,7 +1090,7 @@ theorem bind_ret_eq_map (f : α → β) (l : list α) :
   l.bind (list.ret ∘ f) = map f l :=
 by unfold list.bind; induction l; simp only [map, join, list.ret, cons_append, nil_append, *]; split; refl
 
-@[simp] theorem map_eq_map (f : α → β) (l : list α) : f <$> l = map f l := rfl
+@[simp] theorem map_eq_map {α β} (f : α → β) (l : list α) : f <$> l = map f l := rfl
 
 @[simp] theorem map_tail (f : α → β) (l) : map f (tail l) = tail (map f l) :=
 by cases l; refl

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -105,11 +105,8 @@ end
 
 theorem pred_eq_of_eq_succ {m n : ℕ} (H : m = n.succ) : m.pred = n := by simp [H]
 
-lemma pred_eq_succ_iff {n m : ℕ} : pred n = succ m ↔ n = m + 2 :=
-begin
-  cases n, split; intro h, cases h, cases h,
-  simp, split; intro h, rw h, injection h
-end
+@[simp] lemma pred_eq_succ_iff {n m : ℕ} : pred n = succ m ↔ n = m + 2 :=
+by cases n; split; rintro ⟨⟩; refl
 
 theorem pred_sub (n m : ℕ) : pred n - m = pred (n - m) :=
 by rw [← sub_one, nat.sub_sub, one_add]; refl

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -105,6 +105,12 @@ end
 
 theorem pred_eq_of_eq_succ {m n : ℕ} (H : m = n.succ) : m.pred = n := by simp [H]
 
+lemma pred_eq_succ_iff {n m : ℕ} : pred n = succ m ↔ n = m + 2 :=
+begin
+  cases n, split; intro h, cases h, cases h,
+  simp, split; intro h, rw h, injection h
+end
+
 theorem pred_sub (n m : ℕ) : pred n - m = pred (n - m) :=
 by rw [← sub_one, nat.sub_sub, one_add]; refl
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -64,7 +64,7 @@ h hx
 
 @[simp] theorem set_of_mem_eq {s : set α} : {x | x ∈ s} = s := rfl
 
-@[simp] lemma set_of_app_iff {p : α → Prop} {x : α} : { x | p x } x ↔ p x := iff.refl _
+lemma set_of_app_iff {p : α → Prop} {x : α} : { x | p x } x ↔ p x := iff.refl _
 
 theorem mem_def {a : α} {s : set α} : a ∈ s ↔ s a := iff.rfl
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -64,6 +64,8 @@ h hx
 
 @[simp] theorem set_of_mem_eq {s : set α} : {x | x ∈ s} = s := rfl
 
+@[simp] lemma set_of_app_iff {α} {p : α → Prop} {x : α} : { x | p x } x ↔ p x := iff.refl _
+
 theorem mem_def {a : α} {s : set α} : a ∈ s ↔ s a := iff.rfl
 
 instance decidable_mem (s : set α) [H : decidable_pred s] : ∀ a, decidable (a ∈ s) := H

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -64,7 +64,7 @@ h hx
 
 @[simp] theorem set_of_mem_eq {s : set α} : {x | x ∈ s} = s := rfl
 
-@[simp] lemma set_of_app_iff {α} {p : α → Prop} {x : α} : { x | p x } x ↔ p x := iff.refl _
+@[simp] lemma set_of_app_iff {p : α → Prop} {x : α} : { x | p x } x ↔ p x := iff.refl _
 
 theorem mem_def {a : α} {s : set α} : a ∈ s ↔ s a := iff.rfl
 

--- a/src/data/subtype.lean
+++ b/src/data/subtype.lean
@@ -13,6 +13,13 @@ variables {α : Sort*} {p : α → Prop}
   (∀ x, q x) ↔ (∀ a b, q ⟨a, b⟩) :=
 ⟨assume h a b, h ⟨a, b⟩, assume h ⟨a, b⟩, h a b⟩
 
+/-- An alternative version of `subtype.forall`. This one is useful if Lean cannot figure out `q`
+  when using `subtype.forall` from right to left. -/
+theorem subtype.forall' {q : ∀x, p x → Prop} :
+  (∀ x h, q x h) ↔ (∀ x : {a // p a}, q x.1 x.2) :=
+(@subtype.forall _ _ (λ x, q x.1 x.2)).symm
+
+
 @[simp] theorem subtype.exists {q : {a // p a} → Prop} :
   (∃ x, q x) ↔ (∃ a b, q ⟨a, b⟩) :=
 ⟨assume ⟨⟨a, b⟩, h⟩, ⟨a, b, h⟩, assume ⟨a, b, h⟩, ⟨⟨a, b⟩, h⟩⟩

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -264,6 +264,13 @@ by rintros ⟨α⟩ ⟨β⟩ ⟨γ⟩ hα ⟨e⟩; exact
   let ⟨a⟩ := ne_zero_iff_nonempty.1 hα in
   ⟨@embedding.arrow_congr_right _ _ _ ⟨a⟩ e⟩
 
+theorem power_le_max_power_one {a b c : cardinal} (h : b ≤ c) : a ^ b ≤ max (a ^ c) 1 :=
+begin
+  by_cases ha : a = 0,
+  simp [ha, zero_power_le],
+  exact le_trans (power_le_power_left ha h) (le_max_left _ _)
+end
+
 theorem power_le_power_right {a b c : cardinal} : a ≤ b → a ^ c ≤ b ^ c :=
 quotient.induction_on₃ a b c $ assume α β γ ⟨e⟩, ⟨embedding.arrow_congr_left e⟩
 

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -141,7 +141,7 @@ quotient.induction_on a $ assume α, quotient.sound ⟨equiv.pempty_sum α⟩
 private theorem zero_mul (a : cardinal.{u}) : 0 * a = 0 :=
 quotient.induction_on a $ assume α, quotient.sound ⟨equiv.pempty_prod α⟩
 
-protected theorem one_mul (a : cardinal.{u}) : 1 * a = a :=
+private theorem one_mul (a : cardinal.{u}) : 1 * a = a :=
 quotient.induction_on a $ assume α, quotient.sound ⟨equiv.punit_prod α⟩
 
 private theorem left_distrib (a b c : cardinal.{u}) : a * (b + c) = a * b + a * c :=
@@ -719,8 +719,8 @@ begin
     right, by_cases hb : b = 0, { left, exact hb },
     right, rw [← ne, ← one_le_iff_ne_zero] at ha hb, split,
     { rw [← mul_one a], refine lt_of_le_of_lt (mul_le_mul (le_refl a) hb) h },
-    { rw [← one_mul b], refine lt_of_le_of_lt (mul_le_mul ha (le_refl b)) h }},
-  rintro (rfl|rfl|⟨ha,hb⟩); simp only [*, mul_lt_omega, omega_pos, zero_mul, mul_zero]
+    { rw [← _root_.one_mul b], refine lt_of_le_of_lt (mul_le_mul ha (le_refl b)) h }},
+  rintro (rfl|rfl|⟨ha,hb⟩); simp only [*, mul_lt_omega, omega_pos, _root_.zero_mul, mul_zero]
 end
 
 lemma mul_lt_omega_iff_of_ne_zero {a b : cardinal} (ha : a ≠ 0) (hb : b ≠ 0) :

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -59,7 +59,7 @@ def mk : Type u → cardinal := quotient.mk
 
 localized "notation `#` := cardinal.mk" in cardinal
 
-protected lemma eq {α β : Type*} : mk α = mk β ↔ nonempty (α ≃ β) := quotient.eq
+protected lemma eq : mk α = mk β ↔ nonempty (α ≃ β) := quotient.eq
 
 @[simp] theorem mk_def (α : Type u) : @eq cardinal ⟦α⟧ (mk α) := rfl
 

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -807,6 +807,10 @@ quotient.sound ⟨equiv.set.univ α⟩
 theorem mk_image_le {α β : Type u} {f : α → β} {s : set α} : mk (f '' s) ≤ mk s :=
 mk_le_of_surjective surjective_onto_image
 
+theorem mk_image_le_lift {α : Type u} {β : Type v} {f : α → β} {s : set α} :
+  lift.{v u} (mk (f '' s)) ≤ lift.{u v} (mk s) :=
+lift_mk_le.{v u 0}.mpr ⟨embedding.of_surjective surjective_onto_image⟩
+
 theorem mk_range_le {α β : Type u} {f : α → β} : mk (range f) ≤ mk α :=
 mk_le_of_surjective surjective_onto_range
 

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -1743,7 +1743,7 @@ begin
   exact ordinal.min_le (λ i:ι α, ⟦⟨α, i.1, i.2⟩⟧) ⟨_, _⟩
 end
 
-lemma ord_eq_min (α : Type u) : ord (mk α) =
+def ord_eq_min (α : Type u) : ord (mk α) =
   @ordinal.min _ _ (λ i:{r // is_well_order α r}, ⟦⟨α, i.1, i.2⟩⟧) := rfl
 
 theorem ord_eq (α) : ∃ (r : α → α → Prop) [wo : is_well_order α r],
@@ -2730,7 +2730,7 @@ end, λ ⟨o, e⟩, e.symm ▸ le_of_eq (H.deriv_fp _)⟩
 end ordinal
 
 namespace cardinal
-section
+section using_ordinals
 open ordinal
 
 theorem ord_is_limit {c} (co : omega ≤ c) : (ord c).is_limit :=
@@ -2924,7 +2924,7 @@ begin
     rw [mk_def, e], apply typein_lt_type }
 end
 
-end
+end using_ordinals
 
 theorem mul_eq_max {a b : cardinal} (ha : omega ≤ a) (hb : omega ≤ b) : a * b = max a b :=
 le_antisymm
@@ -3210,18 +3210,6 @@ begin
   refine ⟨h, _⟩, rintro ⟨x, hx⟩, simp [set.sum_compl_symm_apply_of_mem, hx, equiv.symm]
 end
 
-theorem extend_function_infinite {α : Type u} {β : Type v} {s : set α} (f : s ↪ β)
-  (hα : omega ≤ #α) (hs : #s < #α) (h : nonempty (α ≃ β)) :
-  ∃ (g : α ≃ β), ∀ x : s, g x = f x :=
-begin
-  apply extend_function f, have := h, cases this with g, rw [← lift_mk_eq] at h,
-  cases cardinal.eq.mp (mk_compl_of_omega_le s hα hs) with g2,
-  cases cardinal.eq.mp (mk_compl_of_omega_le (range f) _ _) with g3,
-  { constructor, exact g2.trans (g.trans g3.symm) },
-  { rw [← lift_le, ← h], refine le_trans _ (lift_le.mpr hα), simp },
-  rwa [← lift_lt, ← h, mk_range_eq_lift, lift_lt], exact f.2
-end
-
 theorem extend_function_finite {α β : Type*} {s : set α} (f : s ↪ β)
   (hs : #α < omega) (h : nonempty (α ≃ β)) : ∃ (g : α ≃ β), ∀ x : s, g x = f x :=
 begin
@@ -3236,7 +3224,12 @@ theorem extend_function_of_lt {α β : Type*} {s : set α} (f : s ↪ β) (hs : 
   (h : nonempty (α ≃ β)) : ∃ (g : α ≃ β), ∀ x : s, g x = f x :=
 begin
   cases (le_or_lt omega (#α)) with hα hα,
-  { exact extend_function_infinite f hα hs h },
+  { apply extend_function f, have := h, cases this with g, rw [← lift_mk_eq] at h,
+    cases cardinal.eq.mp (mk_compl_of_omega_le s hα hs) with g2,
+    cases cardinal.eq.mp (mk_compl_of_omega_le (range f) _ _) with g3,
+    { constructor, exact g2.trans (g.trans g3.symm) },
+    { rw [← lift_le, ← h], refine le_trans _ (lift_le.mpr hα), simp },
+    rwa [← lift_lt, ← h, mk_range_eq_lift, lift_lt], exact f.2 },
   { exact extend_function_finite f hα h }
 end
 

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -10,7 +10,7 @@ Ordinals are defined as equivalences of well-ordered sets by order isomorphism.
 import order.order_iso set_theory.cardinal data.sum
 noncomputable theory
 
-open function cardinal set
+open function cardinal set equiv
 open_locale classical cardinal
 
 universes u v w
@@ -164,7 +164,7 @@ begin
   exact irrefl _ this
 end
 
-def lt_le [is_trans β s] (f : r ≺i s) (g : s ≼i t) : r ≺i t :=
+def lt_le (f : r ≺i s) (g : s ≼i t) : r ≺i t :=
 ⟨@order_embedding.trans _ _ _ r s t f g, g f.top, λ a,
  by simp only [g.init_iff, f.down', exists_and_distrib_left.symm,
    exists_swap, order_embedding.trans_apply, exists_eq_right']; refl⟩
@@ -172,7 +172,7 @@ def lt_le [is_trans β s] (f : r ≺i s) (g : s ≼i t) : r ≺i t :=
 @[simp] theorem lt_le_apply [is_trans β s] [is_trans γ t] (f : r ≺i s) (g : s ≼i t) (a : α) : (f.lt_le g) a = g (f a) :=
 order_embedding.trans_apply _ _ _
 
-@[simp] theorem lt_le_top [is_trans β s] [is_trans γ t] (f : r ≺i s) (g : s ≼i t) : (f.lt_le g).top = g f.top := rfl
+@[simp] theorem lt_le_top [is_trans β s] (f : r ≺i s) (g : s ≼i t) : (f.lt_le g).top = g f.top := rfl
 
 @[trans] protected def trans [is_trans β s] [is_trans γ t] (f : r ≺i s) (g : s ≺i t) : r ≺i t :=
 lt_le f g
@@ -182,13 +182,13 @@ lt_le_apply _ _ _
 
 @[simp] theorem trans_top [is_trans β s] [is_trans γ t] (f : r ≺i s) (g : s ≺i t) : (f.trans g).top = g f.top := rfl
 
-def equiv_lt [is_trans β s] [is_trans γ t] (f : r ≃o s) (g : s ≺i t) : r ≺i t :=
+def equiv_lt (f : r ≃o s) (g : s ≺i t) : r ≺i t :=
 ⟨@order_embedding.trans _ _ _ r s t f g, g.top, λ c,
  by simp only [g.down', coe_fn_coe_base, order_embedding.trans_apply]; exact
  ⟨λ ⟨b, h⟩, ⟨f.symm b, by simp only [h, order_iso.apply_symm_apply, order_iso.coe_coe_fn]⟩, λ ⟨a, h⟩, ⟨f a, h⟩⟩⟩
 
 def lt_equiv {r : α → α → Prop} {s : β → β → Prop} {t : γ → γ → Prop}
-  [is_trans β s] [is_trans γ t] (f : principal_seg r s) (g : s ≃o t) : principal_seg r t :=
+  (f : principal_seg r s) (g : s ≃o t) : principal_seg r t :=
 ⟨@order_embedding.trans _ _ _ r s t f g, g f.top,
   begin
     intro x,
@@ -225,8 +225,7 @@ lemma top_lt_top {r : α → α → Prop} {s : β → β → Prop} {t : γ → �
 by { rw [subsingleton.elim h (f.trans g)], apply principal_seg.lt_top }
 
 /-- Any element of a well order yields a principal segment -/
-def of_element {α : Type*} (r : α → α → Prop) [is_well_order α r] (a : α) :
-  subrel r {b | r b a} ≺i r :=
+def of_element {α : Type*} (r : α → α → Prop) (a : α) : subrel r {b | r b a} ≺i r :=
 ⟨subrel.order_embedding _ _, a, λ b,
   ⟨λ h, ⟨⟨_, h⟩, rfl⟩, λ ⟨⟨_, h⟩, rfl⟩, h⟩⟩
 
@@ -602,7 +601,7 @@ instance : has_zero ordinal :=
 ⟨⟦⟨pempty, empty_relation, by apply_instance⟩⟧⟩
 
 theorem zero_eq_type_empty : 0 = @type empty empty_relation _ :=
-quotient.sound ⟨⟨equiv.empty_equiv_pempty.symm, λ _ _, iff.rfl⟩⟩
+quotient.sound ⟨⟨empty_equiv_pempty.symm, λ _ _, iff.rfl⟩⟩
 
 @[simp] theorem card_zero : card 0 = 0 := rfl
 
@@ -621,7 +620,7 @@ instance : has_one ordinal :=
 ⟨⟦⟨punit, empty_relation, by apply_instance⟩⟧⟩
 
 theorem one_eq_type_unit : 1 = @type unit empty_relation _ :=
-quotient.sound ⟨⟨equiv.punit_equiv_punit, λ _ _, iff.rfl⟩⟩
+quotient.sound ⟨⟨punit_equiv_punit, λ _ _, iff.rfl⟩⟩
 
 @[simp] theorem card_one : card 1 = 1 := rfl
 
@@ -688,14 +687,14 @@ instance : add_monoid ordinal.{u} :=
 { add       := (+),
   zero      := 0,
   zero_add  := λ o, induction_on o $ λ α r _, eq.symm $ quotient.sound
-    ⟨⟨(equiv.pempty_sum α).symm, λ a b, sum.lex_inr_inr.symm⟩⟩,
+    ⟨⟨(pempty_sum α).symm, λ a b, sum.lex_inr_inr.symm⟩⟩,
   add_zero  := λ o, induction_on o $ λ α r _, eq.symm $ quotient.sound
-    ⟨⟨(equiv.sum_pempty α).symm, λ a b, sum.lex_inl_inl.symm⟩⟩,
+    ⟨⟨(sum_pempty α).symm, λ a b, sum.lex_inl_inl.symm⟩⟩,
   add_assoc := λ o₁ o₂ o₃, quotient.induction_on₃ o₁ o₂ o₃ $
     λ ⟨α, r, _⟩ ⟨β, s, _⟩ ⟨γ, t, _⟩, quot.sound
-    ⟨⟨equiv.sum_assoc _ _ _, λ a b,
+    ⟨⟨sum_assoc _ _ _, λ a b,
     begin rcases a with ⟨a|a⟩|a; rcases b with ⟨b|b⟩|b;
-      simp only [equiv.sum_assoc_apply_in1, equiv.sum_assoc_apply_in2, equiv.sum_assoc_apply_in3,
+      simp only [sum_assoc_apply_in1, sum_assoc_apply_in2, sum_assoc_apply_in3,
         sum.lex_inl_inl, sum.lex_inr_inr, sum.lex.sep, sum.lex_inr_inl] end⟩⟩ }
 
 theorem add_succ (o₁ o₂ : ordinal) : o₁ + succ o₂ = succ (o₁ + o₂) :=
@@ -824,14 +823,14 @@ by simp only [lt_iff_le_not_le, lift_le]
 
 @[simp] theorem lift_zero : lift 0 = 0 :=
 quotient.sound ⟨(order_iso.preimage equiv.ulift _).trans
- ⟨equiv.pempty_equiv_pempty, λ a b, iff.rfl⟩⟩
+ ⟨pempty_equiv_pempty, λ a b, iff.rfl⟩⟩
 
 theorem zero_eq_lift_type_empty : 0 = lift.{0 u} (@type empty empty_relation _) :=
 by rw [← zero_eq_type_empty, lift_zero]
 
 @[simp] theorem lift_one : lift 1 = 1 :=
 quotient.sound ⟨(order_iso.preimage equiv.ulift _).trans
- ⟨equiv.punit_equiv_punit, λ a b, iff.rfl⟩⟩
+ ⟨punit_equiv_punit, λ a b, iff.rfl⟩⟩
 
 theorem one_eq_lift_type_unit : 1 = lift.{0 u} (@type unit empty_relation _) :=
 by rw [← one_eq_type_unit, lift_one]
@@ -1121,9 +1120,8 @@ begin
 end
 
 lemma mk_initial_seg (o : ordinal.{u}) :
-  mk {o' : ordinal | o' < o} = cardinal.lift.{u u+1} o.card :=
+  #{o' : ordinal | o' < o} = cardinal.lift.{u u+1} o.card :=
 by rw [lift_card, ←type_subrel_lt, card_type]
-
 
 /-- A normal ordinal function is a strictly increasing function which is
   order-continuous. -/
@@ -1402,17 +1400,17 @@ instance : monoid ordinal.{u} :=
     quot.sound ⟨order_iso.prod_lex_congr g f⟩,
   one := 1,
   mul_assoc := λ a b c, quotient.induction_on₃ a b c $ λ ⟨α, r, _⟩ ⟨β, s, _⟩ ⟨γ, t, _⟩,
-    eq.symm $ quotient.sound ⟨⟨equiv.prod_assoc _ _ _, λ a b, begin
+    eq.symm $ quotient.sound ⟨⟨prod_assoc _ _ _, λ a b, begin
       rcases a with ⟨⟨a₁, a₂⟩, a₃⟩,
       rcases b with ⟨⟨b₁, b₂⟩, b₃⟩,
       simp [prod.lex_def, and_or_distrib_left, or_assoc, and_assoc]
     end⟩⟩,
   mul_one := λ a, induction_on a $ λ α r _, quotient.sound
-    ⟨⟨equiv.punit_prod _, λ a b, by rcases a with ⟨⟨⟨⟩⟩, a⟩; rcases b with ⟨⟨⟨⟩⟩, b⟩;
+    ⟨⟨punit_prod _, λ a b, by rcases a with ⟨⟨⟨⟩⟩, a⟩; rcases b with ⟨⟨⟨⟩⟩, b⟩;
     simp only [prod.lex_def, empty_relation, false_or]; dsimp only;
     simp only [eq_self_iff_true, true_and]; refl⟩⟩,
   one_mul := λ a, induction_on a $ λ α r _, quotient.sound
-    ⟨⟨equiv.prod_punit _, λ a b, by rcases a with ⟨a, ⟨⟨⟩⟩⟩; rcases b with ⟨b, ⟨⟨⟩⟩⟩;
+    ⟨⟨prod_punit _, λ a b, by rcases a with ⟨a, ⟨⟨⟩⟩⟩; rcases b with ⟨b, ⟨⟨⟩⟩⟩;
     simp only [prod.lex_def, empty_relation, and_false, or_false]; refl⟩⟩ }
 
 @[simp] theorem type_mul {α β : Type u} (r : α → α → Prop) (s : β → β → Prop)
@@ -1438,10 +1436,10 @@ type_eq_zero_iff_empty.2 (λ ⟨⟨_, e⟩⟩, e.elim)
 
 theorem mul_add (a b c : ordinal) : a * (b + c) = a * b + a * c :=
 quotient.induction_on₃ a b c $ λ ⟨α, r, _⟩ ⟨β, s, _⟩ ⟨γ, t, _⟩,
-quotient.sound ⟨⟨equiv.sum_prod_distrib _ _ _, begin
+quotient.sound ⟨⟨sum_prod_distrib _ _ _, begin
   rintro ⟨a₁|a₁, a₂⟩ ⟨b₁|b₁, b₂⟩; simp only [prod.lex_def,
     sum.lex_inl_inl, sum.lex.sep, sum.lex_inr_inl, sum.lex_inr_inr,
-    equiv.sum_prod_distrib_apply_left, equiv.sum_prod_distrib_apply_right];
+    sum_prod_distrib_apply_left, sum_prod_distrib_apply_right];
   simp only [sum.inl.inj_iff, true_or, false_and, false_or]
 end⟩⟩
 
@@ -1571,8 +1569,7 @@ instance : has_div ordinal := ⟨ordinal.div⟩
 
 @[simp] theorem div_zero (a : ordinal) : a / 0 = 0 := dif_pos rfl
 
-def div_def (a) {b : ordinal} (h : b ≠ 0) : a / b =
-  omin {o | a < b * succ o} _ := dif_neg h
+def div_def (a) {b : ordinal} (h : b ≠ 0) : a / b = omin {o | a < b * succ o} _ := dif_neg h
 
 theorem lt_mul_succ_div (a) {b : ordinal} (h : b ≠ 0) : a < b * succ (a / b) :=
 by rw div_def a h; exact omin_mem {o | a < b * succ o} _
@@ -1746,7 +1743,7 @@ begin
   exact ordinal.min_le (λ i:ι α, ⟦⟨α, i.1, i.2⟩⟧) ⟨_, _⟩
 end
 
-def ord_eq_min (α : Type u) : ord (mk α) =
+lemma ord_eq_min (α : Type u) : ord (mk α) =
   @ordinal.min _ _ (λ i:{r // is_well_order α r}, ⟦⟨α, i.1, i.2⟩⟧) := rfl
 
 theorem ord_eq (α) : ∃ (r : α → α → Prop) [wo : is_well_order α r],
@@ -2733,6 +2730,7 @@ end, λ ⟨o, e⟩, e.symm ▸ le_of_eq (H.deriv_fp _)⟩
 end ordinal
 
 namespace cardinal
+section
 open ordinal
 
 theorem ord_is_limit {c} (co : omega ≤ c) : (ord c).is_limit :=
@@ -2917,13 +2915,15 @@ begin
     { exact ⟨(set.embedding_of_subset this).trans
         ((equiv.set.prod _ _).trans (H.prod_congr H)).to_embedding⟩ },
     refine (equiv.set.insert _).trans
-      ((equiv.refl _).sum_congr equiv.punit_equiv_punit),
+      ((equiv.refl _).sum_congr punit_equiv_punit),
     apply @irrefl _ r },
   cases lt_or_ge (card (typein (<) (g p)).succ) omega with qo qo,
   { exact lt_of_lt_of_le (mul_lt_omega qo qo) ol },
   { suffices, {exact lt_of_le_of_lt (IH _ this qo) this},
     rw ← lt_ord, apply (ord_is_limit ol).2,
     rw [mk_def, e], apply typein_lt_type }
+end
+
 end
 
 theorem mul_eq_max {a b : cardinal} (ha : omega ≤ a) (hb : omega ≤ b) : a * b = max a b :=
@@ -2975,7 +2975,7 @@ begin
     { have : a ≠ 0, { rintro rfl, exact not_lt_of_le ha omega_pos },
       left, use ha,
       { rw [← not_lt], intro hb, apply ne_of_gt _ h, refine lt_of_lt_of_le hb (le_mul_left this) },
-      { rintro rfl, apply this, rw [mul_zero] at h, subst h }},
+      { rintro rfl, apply this, rw [_root_.mul_zero] at h, subst h }},
     right, by_cases h2a : a = 0, { right, exact h2a },
     have hb : b ≠ 0, { rintro rfl, apply h2a, rw [mul_zero] at h, subst h },
     left, rw [← h, mul_lt_omega_iff, lt_omega, lt_omega] at ha,
@@ -3109,7 +3109,7 @@ calc  mk (list α)
     = sum (λ n : ℕ, mk α ^ (n : cardinal.{u})) : mk_list_eq_sum_pow α
 ... ≤ sum (λ n : ℕ, mk α) : sum_le_sum _ _ $ λ n, pow_le H1 $ nat_lt_omega n
 ... = sum (λ n : ulift.{u} ℕ, mk α) : quotient.sound
-  ⟨@equiv.sigma_congr_left _ _ (λ _, quotient.out (mk α)) equiv.ulift.symm⟩
+  ⟨@sigma_congr_left _ _ (λ _, quotient.out (mk α)) equiv.ulift.symm⟩
 ... = omega * mk α : sum_const _ _
 ... = max (omega) (mk α) : mul_eq_max (le_refl _) H1
 ... = mk α : max_eq_right H1
@@ -3164,7 +3164,7 @@ lemma mk_compl_of_omega_le {α : Type*} (s : set α) (h : omega ≤ #α) (h2 : #
 by { refine eq_of_add_eq_of_omega_le _ h2 h, exact mk_sum_compl s }
 
 lemma mk_compl_finset_of_omega_le {α : Type*} (s : finset α) (h : omega ≤ #α) :
-  #(-s : set α) = #α :=
+  #(-s.to_set : set α) = #α :=
 by { apply mk_compl_of_omega_le _ h, exact lt_of_lt_of_le (finset_card_lt_omega s) h }
 
 lemma mk_compl_eq_mk_compl_infinite {α : Type*} {s t : set α} (h : omega ≤ #α) (hs : #s < #α)
@@ -3205,8 +3205,8 @@ theorem extend_function {α β : Type*} {s : set α} (f : s ↪ β)
 begin
   intros, have := h, cases this with g,
   let h : α ≃ β := (set.sum_compl (s : set α)).symm.trans
-    ((equiv.sum_congr (equiv.set.range f f.2) g).trans
-    (equiv.set.sum_compl (range f))),
+    ((sum_congr (equiv.set.range f f.2) g).trans
+    (set.sum_compl (range f))),
   refine ⟨h, _⟩, rintro ⟨x, hx⟩, simp [set.sum_compl_symm_apply_of_mem, hx, equiv.symm]
 end
 


### PR DESCRIPTION
Various lemmas I've accumulated during proving for fun, proof grounds, and some other occassions.

Also did some cleanup (mostly with `#sanity_check`) on some files (`list/basic` and `ordinal`)

I added the definitions to extend a injection to an equivalence at the bottom of `ordinal`.

I hope this is not too many additions for a single PR.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
