### PR TITLE
feat(tactic/core): derive handler for simple instances

### DIFF
--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -1146,7 +1146,7 @@ meta def is_in_mathlib (n : name) : tactic bool :=
 do ml ← get_mathlib_dir, e ← get_env, return $ e.is_prefix_of_file ml n
 
 /--
-Tries to derive unary algebraic instances by unfolding the newly introduced type.
+Tries to derive unary instances by unfolding the newly introduced type.
 
 For example,
 ```

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -1144,7 +1144,7 @@ do e ← get_env,
   since it is expensive to execute `get_mathlib_dir` many times. -/
 meta def is_in_mathlib (n : name) : tactic bool :=
 do ml ← get_mathlib_dir, e ← get_env, return $ e.is_prefix_of_file ml n
-
+#check reducibility_hints
 /--
 Tries to derive unary instances by unfolding the newly introduced type.
 
@@ -1167,7 +1167,7 @@ Multiple instances can be added with `@[derive [ring, module ℝ]]`.
      | expr.app (expr.const nm _) _ := nm
      | _ := "inst"
      end,
-   add_decl $ declaration.defn nm [] tgt v reducibility_hints.abbrev tt,
+   add_decl $ mk_definition nm [] tgt v,
    set_basic_attribute `instance nm tt,
    return tt) <|> return ff
 end tactic

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -1144,7 +1144,6 @@ do e ← get_env,
   since it is expensive to execute `get_mathlib_dir` many times. -/
 meta def is_in_mathlib (n : name) : tactic bool :=
 do ml ← get_mathlib_dir, e ← get_env, return $ e.is_prefix_of_file ml n
-#check reducibility_hints
 /--
 Tries to derive unary instances by unfolding the newly introduced type.
 

--- a/test/delta_instance.lean
+++ b/test/delta_instance.lean
@@ -1,0 +1,17 @@
+/-
+Copyright (c) 2019 Robert Y. Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Y. Lewis
+-/
+
+import tactic.core
+
+@[derive ring] def T := ℤ
+
+class binclass (T1 T2 : Type)
+
+instance : binclass ℤ ℤ := ⟨_, _⟩
+
+@[derive [ring, binclass ℤ]] def U := ℤ
+
+@[derive λ α, binclass α ℤ] def V := ℤ


### PR DESCRIPTION
https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/deriving.20instances

This is a simple derive handler for adding instances that can be found just by unfolding a new definition.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
