### PR TITLE
feat(finset): add has_sep instance

### DIFF
--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -659,6 +659,29 @@ begin
   { intro x, simp, intros hx hx₂, refine ⟨or.resolve_left (h hx) hx₂, hx₂⟩ }
 end
 
+/- We can simplify an application of filter where the decidability is inferred in "the wrong way" -/
+@[simp] lemma filter_congr_decidable {α} (s : finset α) (p : α → Prop) (h : decidable_pred p)
+  [decidable_pred p] : @filter α p h s = s.filter p :=
+by congr
+
+section classical
+open_locale classical
+/-- The following instance allows us to write `{ x ∈ s | p x }` for `finset.filter s p`.
+  Since the former notation requires us to define this for all propositions `p`, and `finset.filter`
+  only works for decidable propositions, the notation `{ x ∈ s | p x }` is only compatible with
+  classical logic because it uses `classical.prop_decidable`.
+  We don't want to redo all lemmas of `finset.filter` for `has_sep.sep`, so we make sure that `simp`
+  unfolds the notation `{ x ∈ s | p x }` to `finset.filter s p`. If `p` happens to be decidable, the
+  simp-lemma `filter_congr_decidable` will make sure that `finset.filter` uses the right instance
+  for decidability.
+-/
+noncomputable instance {α : Type*} : has_sep α (finset α) := ⟨λ p x, x.filter p⟩
+
+@[simp] lemma sep_def {α : Type*} (s : finset α) (p : α → Prop) : {x ∈ s | p x} = s.filter p := rfl
+
+end classical
+
+
 end filter
 
 /- range -/

--- a/test/examples.lean
+++ b/test/examples.lean
@@ -177,3 +177,25 @@ meta structure meta_struct (α : Type u) : Type u :=
   (z : list α)
   (k : list (list α))
   (w : expr)
+
+/- tests of has_sep on finset -/
+
+
+example {α} (s : finset α) (p : α → Prop) [decidable_pred p] : {x ∈ s | p x} = s.filter p :=
+by simp
+
+example {α} (s : finset α) (p : α → Prop) [decidable_pred p] :
+  {x ∈ s | p x} = @finset.filter α p (λ _, classical.prop_decidable _) s :=
+by simp
+
+section
+open_locale classical
+
+example {α} (s : finset α) (p : α → Prop) : {x ∈ s | p x} = s.filter p :=
+by simp
+
+example (n m k : ℕ) : {x ∈ finset.range n | x < m ∨ x < k } =
+  {x ∈ finset.range n | x < m } ∪ {x ∈ finset.range n | x < k } :=
+by simp [finset.filter_or]
+
+end


### PR DESCRIPTION
Define a `has_sep` instance on finset.

* See doc-string for more info:
```lean
/-- The following instance allows us to write `{ x ∈ s | p x }` for `finset.filter s p`.
  Since the former notation requires us to define this for all propositions `p`, and `finset.filter`
  only works for decidable propositions, the notation `{ x ∈ s | p x }` is only compatible with
  classical logic because it uses `classical.prop_decidable`.
  We don't want to redo all lemmas of `finset.filter` for `has_sep.sep`, so we make sure that `simp`
  unfolds the notation `{ x ∈ s | p x }` to `finset.filter s p`. If `p` happens to be decidable, the
  simp-lemma `filter_congr_decidable` will make sure that `finset.filter` uses the right instance
  for decidability.
-/
```
* The added tests show that `simp` is willing to apply lemmas which have explicit `[decidable_pred p]` arguments, because it first rewrites away the `classical.prop_decidable`.
* A small disadvantage is that after using `simp`, your nice notation `{x ∈ s | p x}` will become `s.filter p`, but I don't know how to avoid that without duplicating a whole lot of lemmas.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

Mentioned before on Zulip: https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/potential.20PR's

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
