### PR TITLE
fix(tactic.lift): fix error messages

### DIFF
--- a/src/tactic/lift.lean
+++ b/src/tactic/lift.lean
@@ -57,7 +57,7 @@ if h_some : h.is_some then
   (do prf ← i_to_expr (option.get h_some), prf_ty ← infer_type prf,
   expected_prf_ty ← mk_app `can_lift.cond [old_tp, new_tp, inst, e],
   unify prf_ty expected_prf_ty <|>
-    (do expected_prf_ty2 ← expected_prf_ty.dsimp {} tt [`can_lift],
+    (do expected_prf_ty2 ← s.dsimplify to_unfold expected_prf_ty,
       pformat!"lift tactic failed. The type of\n  {prf}\nis\n  {prf_ty}\nbut it is expected to be\n  {expected_prf_ty2}" >>= fail),
   return prf)
   else (do prf_nm ← get_unused_name,

--- a/test/tactics.lean
+++ b/test/tactics.lean
@@ -262,6 +262,16 @@ instance can_lift_unit : can_lift unit unit :=
 /- test whether new instances of `can_lift` are added as simp lemmas -/
 run_cmd do l ← can_lift_attr.get_cache, guard (`can_lift_unit ∈ l)
 
+/- test error messages -/
+example (n : ℤ) (hn : 0 < n) : true :=
+begin
+  success_if_fail_with_msg {lift n to ℕ using hn} "lift tactic failed. The type of\n  hn\nis
+  0 < n\nbut it is expected to be\n  0 ≤ n",
+  success_if_fail_with_msg {lift (n : option ℤ) to ℕ}
+    "Failed to find a lift from option ℤ to ℕ. Provide an instance of\n  can_lift (option ℤ) ℕ",
+  trivial
+end
+
 end lift
 
 private meta def get_exception_message (t : lean.parser unit) : lean.parser string


### PR DESCRIPTION
One of the commits in #1315 broke the error message handling of the `lift` tactic. 
I fixed it, and added tests to ensure they don't break again.