### PR TITLE
feat(tactic/delta_instance): handle parameters and use in library

### DIFF
--- a/src/category_theory/comma.lean
+++ b/src/category_theory/comma.lean
@@ -190,13 +190,12 @@ end comma
 
 omit 𝒜 ℬ
 
+@[derive category]
 def over (X : T) := comma.{v₃ 0 v₃} (𝟭 T) (functor.of.obj X)
 
 namespace over
 
 variables {X : T}
-
-instance category : category (over X) := by delta over; apply_instance
 
 @[extensionality] lemma over_morphism.ext {X : T} {U V : over X} {f g : U ⟶ V}
   (h : f.left = g.left) : f = g :=
@@ -254,13 +253,12 @@ end
 
 end over
 
+@[derive category]
 def under (X : T) := comma.{0 v₃ v₃} (functor.of.obj X) (𝟭 T)
 
 namespace under
 
 variables {X : T}
-
-instance : category (under X) := by delta under; apply_instance
 
 @[extensionality] lemma under_morphism.ext {X : T} {U V : under X} {f g : U ⟶ V}
   (h : f.right = g.right) : f = g :=

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -11,6 +11,7 @@ namespace nat
 
 /-- Modular equality. `modeq n a b`, or `a ≡ b [MOD n]`, means
   that `a - b` is a multiple of `n`. -/
+@[derive decidable]
 def modeq (n a b : ℕ) := a % n = b % n
 
 notation a ` ≡ `:50 b ` [MOD `:50 n `]`:0 := modeq n a b
@@ -23,8 +24,6 @@ variables {n m a b c d : ℕ}
 @[symm] protected theorem symm : a ≡ b [MOD n] → b ≡ a [MOD n] := eq.symm
 
 @[trans] protected theorem trans : a ≡ b [MOD n] → b ≡ c [MOD n] → a ≡ c [MOD n] := eq.trans
-
-instance : decidable (a ≡ b [MOD n]) := by unfold modeq; apply_instance
 
 theorem modeq_zero_iff : a ≡ 0 [MOD n] ↔ n ∣ a :=
 by rw [modeq, zero_mod, dvd_iff_mod_eq_zero]

--- a/src/data/rel.lean
+++ b/src/data/rel.lean
@@ -9,14 +9,12 @@ import tactic.basic data.set.lattice order.complete_lattice
 
 variables {α : Type*} {β : Type*} {γ : Type*}
 
+@[derive lattice.complete_lattice]
 def rel (α : Type*) (β : Type*) := α → β → Prop
 
 namespace rel
 
 variables {δ : Type*} (r : rel α β)
-
-instance : lattice.complete_lattice (rel α β) :=
-by unfold rel; apply_instance
 
 def inv : rel β α := flip r
 

--- a/src/field_theory/mv_polynomial.lean
+++ b/src/field_theory/mv_polynomial.lean
@@ -200,10 +200,8 @@ namespace mv_polynomial
 universe u
 variables (σ : Type u) (α : Type u) [fintype σ] [discrete_field α] [fintype α]
 
+@[derive [add_comm_group, vector_space α]]
 def R : Type u := restrict_degree σ α (fintype.card α - 1)
-
-instance R.add_comm_group : add_comm_group (R σ α) := by dunfold R; apply_instance
-instance R.vector_space : vector_space α (R σ α) := by dunfold R; apply_instance
 
 noncomputable instance decidable_restrict_degree (m : ℕ) :
   decidable_pred (λn, n ∈ {n : σ →₀ ℕ | ∀i, n i ≤ m }) :=

--- a/src/linear_algebra/dual.lean
+++ b/src/linear_algebra/dual.lean
@@ -14,17 +14,11 @@ namespace module
 variables (R : Type*) (M : Type*)
 variables [comm_ring R] [add_comm_group M] [module R M]
 
-def dual := M →ₗ[R] R
+@[derive [add_comm_group, module R]] def dual := M →ₗ[R] R
 
 namespace dual
 
 instance : has_coe_to_fun (dual R M) := ⟨_, linear_map.to_fun⟩
-
-instance : add_comm_group (dual R M) :=
-by delta dual; apply_instance
-
-instance : module R (dual R M) :=
-by delta dual; apply_instance
 
 def eval : M →ₗ[R] (dual R (dual R M)) := linear_map.id.flip
 
@@ -43,7 +37,7 @@ variables {K : Type u} {V : Type v} {ι : Type w}
 variables [discrete_field K] [add_comm_group V] [vector_space K V]
 open vector_space module module.dual submodule linear_map cardinal function
 
-instance dual.vector_space : vector_space K (dual K V) := {..dual.module K V}
+instance dual.vector_space : vector_space K (dual K V) := { ..module.dual.inst K V }
 
 variables [decidable_eq V] [decidable_eq (module.dual K V)] [decidable_eq ι]
 variables {B : ι → V} (h : is_basis K B)
@@ -207,7 +201,6 @@ begin
   rcases exists_is_basis_fintype h with ⟨b, hb, ⟨hf⟩⟩,
   resetI,
   rw [← hb.to_dual_to_dual, range_comp, hb.to_dual_range, map_top, to_dual_range _],
-  delta dual_basis,
   apply_instance
 end
 

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -1185,7 +1185,7 @@ This derive handler applies only to declarations made using `def`, and will fail
 declaration if it is unable to derive an instance. It is run with higher priority than the built-in
 handlers, which will fail on `def`s.
 -/
-@[derive_handler, priority 1000] meta def delta_instance : derive_handler :=
+@[derive_handler, priority 2000] meta def delta_instance : derive_handler :=
 λ cls new_decl_name,
 do env ← get_env,
 if env.is_inductive new_decl_name then return ff else

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -1190,7 +1190,7 @@ Multiple instances can be added with `@[derive [ring, module ℝ]]`.
      (intros >> reset_instance_cache >> delta_target [new_decl_name]  >> apply_instance >> done),
    inst ← instantiate_mvars inst,
    tgt ← instantiate_mvars tgt,
-   nm ← get_unused_name $ new_decl_name ++
+   nm ← get_unused_decl_name $ new_decl_name ++
      match cls with
      -- the postfix is needed because we can't protect this name. using nm.last directly can
      -- conflict with open namespaces

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -1155,6 +1155,14 @@ do e ← get_env,
 meta def is_in_mathlib (n : name) : tactic bool :=
 do ml ← get_mathlib_dir, e ← get_env, return $ e.is_prefix_of_file ml n
 
+private meta def apply_under_pis_aux (p : pexpr) (cnst : pexpr) : ℕ → expr → pexpr
+| n (expr.pi nm bi tp bd) := expr.pi nm bi (pexpr.of_expr tp) (apply_under_pis_aux (n+1) bd)
+| n _ := let vars := ((list.range n).reverse.map (@expr.var ff)), bd := vars.foldl expr.app cnst.mk_explicit in
+         p bd
+
+private meta def apply_under_pis (p : pexpr) (cnst : pexpr) (body : expr) : pexpr :=
+apply_under_pis_aux p cnst 0 body
+
 /--
 Tries to derive instances by unfolding the newly introduced type and applying type class resolution.
 
@@ -1167,23 +1175,22 @@ adds an instance `ring new_int`, defined to be the instance of `ring ℤ` found 
 Multiple instances can be added with `@[derive [ring, module ℝ]]`.
 -/
 @[derive_handler] meta def delta_instance : derive_handler :=
-λ cls new_decl_name,
-(do new_decl_type ← declaration.type <$> get_decl new_decl_name,
-   (new_decl_ctx, _) ← mk_local_pis new_decl_type,
-   new_decl ← mk_app new_decl_name new_decl_ctx,
-   tgt ← to_expr ``(%%cls %%new_decl) >>= pis new_decl_ctx,
-   (_, inst) ← solve_aux tgt
-     (intros >> reset_instance_cache >> delta_target [new_decl_name]  >> apply_instance >> done),
-   inst ← instantiate_mvars inst,
+λ cls tp,
+(do body_tp ← declaration.type <$> get_decl tp,
+   tp' ← resolve_name tp,
+   tgt ← to_expr $ apply_under_pis cls tp' body_tp,
+   (_, v) ← solve_aux tgt
+     (intros >> reset_instance_cache >> delta_target [tp]  >> apply_instance >> done),
+   v ← instantiate_mvars v,
    tgt ← instantiate_mvars tgt,
-   nm ← get_unused_name $ new_decl_name ++
+   nm ← get_unused_name $ tp ++
      match cls with
      -- the postfix is needed because we can't protect this name. using nm.last directly can
      -- conflict with open namespaces
      | (expr.const nm _) := nm.last ++ "_1"
      | _ := "inst"
      end,
-   add_decl $ mk_definition nm inst.collect_univ_params tgt inst,
+   add_decl $ mk_definition nm v.collect_univ_params tgt v,
    set_basic_attribute `instance nm tt,
    return tt) <|> return ff
 

--- a/src/topology/uniform_space/compare_reals.lean
+++ b/src/topology/uniform_space/compare_reals.lean
@@ -91,9 +91,8 @@ namespace compare_reals
 instead of the metric space one. We proved in rat.uniform_space_eq that they are equal,
 but they are not definitionaly equal, so it would confuse the type class system (and probably
 also human readers). -/
-def Q := ℚ
+@[derive comm_ring] def Q := ℚ
 
-instance : comm_ring Q := by unfold Q ; apply_instance
 instance : uniform_space Q := is_absolute_value.uniform_space (abs : ℚ → ℚ)
 
 /-- Real numbers constructed as in Bourbaki. -/

--- a/test/delta_instance.lean
+++ b/test/delta_instance.lean
@@ -15,3 +15,5 @@ instance : binclass ℤ ℤ := ⟨_, _⟩
 @[derive [ring, binclass ℤ]] def U := ℤ
 
 @[derive λ α, binclass α ℤ] def V := ℤ
+
+@[derive ring] def id_ring (α) [ring α] : Type := α

--- a/test/delta_instance.lean
+++ b/test/delta_instance.lean
@@ -3,8 +3,9 @@ Copyright (c) 2019 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
 -/
+import data.set
 
-import tactic.core
+@[derive has_coe_to_sort] def X : Type := set ℕ
 
 @[derive ring] def T := ℤ
 
@@ -17,3 +18,7 @@ instance : binclass ℤ ℤ := ⟨_, _⟩
 @[derive λ α, binclass α ℤ] def V := ℤ
 
 @[derive ring] def id_ring (α) [ring α] : Type := α
+
+@[derive decidable_eq] def S := ℕ
+
+@[derive decidable_eq] inductive P | a | b | c


### PR DESCRIPTION
I didn't bother to try the `derive_instance` handler on real examples in the library when I made the first PR. Had I done so, I would have noticed it was too weak to use on all but the most basic examples. This PR strengthens it to deal with types that have arguments.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
