### PR TITLE
fix(scripts/mk_all): ignore hidden files

### DIFF
--- a/scripts/mk_all.sh
+++ b/scripts/mk_all.sh
@@ -7,7 +7,7 @@ for d in $(find $DIR/../src/ -type d)
 # For every subfolder of src/ (including src/ itself)
 do
   cd "$d" # cd to that directory
-  find . -maxdepth 1 -mindepth 1 -name 'all.lean' -prune -o -name '*.lean' -print -o -type d -print |
+  find . -maxdepth 1 -mindepth 1 -name 'all.lean' -prune -o -name '.*' -prune -o -name '*.lean' -print -o -type d -print |
   # find all files with .lean extension (except all.lean) and all subdirectories
   sed 's/$/\.all/; s/\.lean\.all//; s/^\.\//       \./; 1s/^      /\/- automatically generated file importing all files in this directory and subdirectories. -\/\nimport/' > all.lean
   # Now modify this output so that Lean can parse it. Changes `./foo.lean` to `.foo` and `foodir` to `.foodir.all`. Also adds indentation, a comment and `import`. Write this to `all.lean`

--- a/scripts/mk_all.sh
+++ b/scripts/mk_all.sh
@@ -9,7 +9,7 @@ do
   cd "$d" # cd to that directory
   echo "/- automatically generated file importing all files in this directory and subdirectories. -/" > all.lean
   find . -maxdepth 1 -mindepth 1 -name 'all.lean' -prune -o -name '.*' -prune -o -name '*.lean' -print -o -type d -print |
-  # find all files with .lean extension (except all.lean) and all subdirectories
+  # find all non-hidden files with the .lean extension (except all.lean) and all subdirectories
   sed 's/$/\.all/; s/\.lean\.all//; s/^\.\//       \./; 1s/^      /import/' >> all.lean
   # Now modify this output so that Lean can parse it. Changes `./foo.lean` to `.foo` and `foodir` to `.foodir.all`. Also adds indentation, a comment and `import`. Write this to `all.lean`
 done


### PR DESCRIPTION
Emacs sometimes creates temporary files with names like `.#name.lean`; they shouldn't be `import`ed in `all.lean`.