### PR TITLE
chore(order/basic): rename `monotone_comp` to `monotone.comp`, reorder arguments

### DIFF
--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -114,7 +114,7 @@ theorem monotone_id : @monotone α α _ _ id := assume x y h, h
 
 theorem monotone_const {b : β} : monotone (λ(a:α), b) := assume x y h, le_refl b
 
-theorem monotone_comp {f : α → β} {g : β → γ} (m_f : monotone f) (m_g : monotone g) :
+protected theorem monotone.comp {g : β → γ} {f : α → β} (m_g : monotone g) (m_f : monotone f) :
   monotone (g ∘ f) :=
 assume a b h, m_g (m_f h)
 

--- a/src/order/filter/lift.lean
+++ b/src/order/filter/lift.lean
@@ -57,13 +57,13 @@ infi_le_infi $ assume s, infi_le_infi $ assume hs, hg s hs
 
 lemma map_lift_eq {m : β → γ} (hg : monotone g) : map m (f.lift g) = f.lift (map m ∘ g) :=
 have monotone (map m ∘ g),
-  from monotone_comp hg monotone_map,
+  from monotone_map.comp hg,
 filter_eq $ set.ext $
   by simp only [mem_lift_sets, hg, @mem_lift_sets _ _ f _ this, exists_prop, forall_const, mem_map, iff_self, function.comp_app]
 
 lemma comap_lift_eq {m : γ → β} (hg : monotone g) : comap m (f.lift g) = f.lift (comap m ∘ g) :=
 have monotone (comap m ∘ g),
-  from monotone_comp hg monotone_comap,
+  from monotone_comap.comp hg,
 filter_eq $ set.ext begin
   simp only [hg, @mem_lift_sets _ _ f _ this, comap, mem_lift_sets, mem_set_of_eq, exists_prop,
     function.comp_apply],
@@ -216,26 +216,26 @@ le_antisymm (lift'_mono' $ assume s hs, le_of_eq $ hh s hs) (lift'_mono' $ assum
 
 lemma map_lift'_eq {m : β → γ} (hh : monotone h) : map m (f.lift' h) = f.lift' (image m ∘ h) :=
 calc map m (f.lift' h) = f.lift (map m ∘ principal ∘ h) :
-    map_lift_eq $ monotone_comp hh monotone_principal
+    map_lift_eq $ monotone_principal.comp hh
   ... = f.lift' (image m ∘ h) : by simp only [(∘), filter.lift', map_principal, eq_self_iff_true]
 
 lemma map_lift'_eq2 {g : set β → set γ} {m : α → β} (hg : monotone g) :
   (map m f).lift' g = f.lift' (g ∘ image m) :=
-map_lift_eq2 $ monotone_comp hg monotone_principal
+map_lift_eq2 $ monotone_principal.comp hg
 
 theorem comap_lift'_eq {m : γ → β} (hh : monotone h) :
   comap m (f.lift' h) = f.lift' (preimage m ∘ h) :=
 calc comap m (f.lift' h) = f.lift (comap m ∘ principal ∘ h) :
-    comap_lift_eq $ monotone_comp hh monotone_principal
+    comap_lift_eq $ monotone_principal.comp hh
   ... = f.lift' (preimage m ∘ h) : by simp only [(∘), filter.lift', comap_principal, eq_self_iff_true]
 
 theorem comap_lift'_eq2 {m : β → α} {g : set β → set γ} (hg : monotone g) :
   (comap m f).lift' g = f.lift' (g ∘ preimage m) :=
-comap_lift_eq2 $ monotone_comp hg monotone_principal
+comap_lift_eq2 $ monotone_principal.comp hg
 
 lemma lift'_principal {s : set α} (hh : monotone h) :
   (principal s).lift' h = principal (h s) :=
-lift_principal $ monotone_comp hh monotone_principal
+lift_principal $ monotone_principal.comp hh
 
 lemma principal_le_lift' {t : set β} (hh : ∀s∈f.sets, t ⊆ h s) :
   principal t ≤ f.lift' h :=
@@ -249,13 +249,13 @@ lemma lift_lift'_assoc {g : set α → set β} {h : set β → filter γ}
   (hg : monotone g) (hh : monotone h) :
   (f.lift' g).lift h = f.lift (λs, h (g s)) :=
 calc (f.lift' g).lift h = f.lift (λs, (principal (g s)).lift h) :
-    lift_assoc (monotone_comp hg monotone_principal)
+    lift_assoc (monotone_principal.comp hg)
   ... = f.lift (λs, h (g s)) : by simp only [lift_principal, hh, eq_self_iff_true]
 
 lemma lift'_lift'_assoc {g : set α → set β} {h : set β → set γ}
   (hg : monotone g) (hh : monotone h) :
   (f.lift' g).lift' h = f.lift' (λs, h (g s)) :=
-lift_lift'_assoc hg (monotone_comp hh monotone_principal)
+lift_lift'_assoc hg (monotone_principal.comp hh)
 
 lemma lift'_lift_assoc {g : set α → filter β} {h : set β → set γ}
   (hg : monotone g) : (f.lift g).lift' h = f.lift (λs, (g s).lift' h) :=
@@ -269,8 +269,8 @@ lemma lift_lift'_same_eq_lift' {g : set α → set α → set β}
   (hg₁ : ∀s, monotone (λt, g s t)) (hg₂ : ∀t, monotone (λs, g s t)) :
   f.lift (λs, f.lift' (g s)) = f.lift' (λs, g s s) :=
 lift_lift_same_eq_lift
-  (assume s, monotone_comp monotone_id $ monotone_comp (hg₁ s) monotone_principal)
-  (assume t, monotone_comp (hg₂ t) monotone_principal)
+  (assume s, monotone_principal.comp (hg₁ s))
+  (assume t, monotone_principal.comp (hg₂ t))
 
 lemma lift'_inf_principal_eq {h : set α → set β} {s : set β} :
   f.lift' h ⊓ principal s = f.lift' (λt, h t ∩ s) :=
@@ -288,7 +288,7 @@ le_antisymm
 
 lemma lift'_neq_bot_iff (hh : monotone h) : (f.lift' h ≠ ⊥) ↔ (∀s∈f.sets, h s ≠ ∅) :=
 calc (f.lift' h ≠ ⊥) ↔ (∀s∈f.sets, principal (h s) ≠ ⊥) :
-    lift_neq_bot_iff (monotone_comp hh monotone_principal)
+    lift_neq_bot_iff (monotone_principal.comp hh)
   ... ↔ (∀s∈f.sets, h s ≠ ∅) : by simp only [principal_eq_bot_iff, iff_self, ne.def, principal_eq_bot_iff]
 
 @[simp] lemma lift'_id {f : filter α} : f.lift' id = f :=

--- a/src/order/fixed_points.lean
+++ b/src/order/fixed_points.lean
@@ -84,7 +84,7 @@ variables [complete_lattice α] [complete_lattice β] {f : β → α} {g : α �
 -- Rolling rule
 theorem lfp_comp (m_f : monotone f) (m_g : monotone g) : lfp (f ∘ g) = f (lfp (g ∘ f)) :=
 le_antisymm
-  (lfp_le $ m_f $ ge_of_eq $ lfp_eq $ monotone_comp m_f m_g)
+  (lfp_le $ m_f $ ge_of_eq $ lfp_eq $ m_g.comp m_f)
   (le_lfp $ assume a fg_le,
     le_trans (m_f $ lfp_le $ show (g ∘ f) (g a) ≤ g a, from m_g fg_le) fg_le)
 
@@ -92,14 +92,14 @@ theorem gfp_comp (m_f : monotone f) (m_g : monotone g) : gfp (f ∘ g) = f (gfp 
 le_antisymm
   (gfp_le $ assume a fg_le,
     le_trans fg_le $ m_f $ le_gfp $ show g a ≤ (g ∘ f) (g a), from m_g fg_le)
-  (le_gfp $ m_f $ le_of_eq $ gfp_eq $ monotone_comp m_f m_g)
+  (le_gfp $ m_f $ le_of_eq $ gfp_eq $ m_g.comp m_f)
 
 -- Diagonal rule
 theorem lfp_lfp {h : α → α → α} (m : ∀⦃a b c d⦄, a ≤ b → c ≤ d → h a c ≤ h b d) :
   lfp (lfp ∘ h) = lfp (λx, h x x) :=
 let f := lfp (lfp ∘ h) in
 have f_eq : f = lfp (h f),
-  from lfp_eq $ monotone_comp (assume a b h x, m h (le_refl _)) monotone_lfp,
+  from lfp_eq $ monotone.comp monotone_lfp (assume a b h x, m h (le_refl _)) ,
 le_antisymm
   (lfp_le $ lfp_le $ ge_of_eq $ lfp_eq $ assume a b h, m h h)
   (lfp_le $ ge_of_eq $
@@ -111,7 +111,7 @@ theorem gfp_gfp {h : α → α → α} (m : ∀⦃a b c d⦄, a ≤ b → c ≤ 
   gfp (gfp ∘ h) = gfp (λx, h x x) :=
 let f := gfp (gfp ∘ h) in
 have f_eq : f = gfp (h f),
-  from gfp_eq $ monotone_comp (assume a b h x, m h (le_refl _)) monotone_gfp,
+  from gfp_eq $ monotone.comp monotone_gfp (assume a b h x, m h (le_refl _)),
 le_antisymm
   (le_gfp $ le_of_eq $
     calc f = gfp (h f)       : f_eq

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -232,7 +232,7 @@ calc (𝓤 α).lift' (λd, comp_rel d (comp_rel d d)) =
   end
   ... ≤ (𝓤 α).lift (λs, (𝓤 α).lift' (λt:set(α×α), comp_rel s t)) :
     lift_mono' $ assume s hs, @uniformity_lift_le_comp α _ _ (principal ∘ comp_rel s) $
-      monotone_comp (monotone_comp_rel monotone_const monotone_id) monotone_principal
+      monotone_principal.comp (monotone_comp_rel monotone_const monotone_id)
   ... = (𝓤 α).lift' (λs:set(α×α), comp_rel s s) :
     lift_lift'_same_eq_lift'
       (assume s, monotone_comp_rel monotone_const monotone_id)
@@ -299,7 +299,7 @@ lemma lift_nhds_left {x : α} {g : set α → filter β} (hg : monotone g) :
 eq.trans
   begin
     rw [nhds_eq_uniformity],
-    exact (filter.lift_assoc $ monotone_comp monotone_preimage $ monotone_comp monotone_preimage monotone_principal)
+    exact (filter.lift_assoc $ monotone_principal.comp $ monotone_preimage.comp monotone_preimage )
   end
   (congr_arg _ $ funext $ assume s, filter.lift_principal hg)
 
@@ -308,7 +308,7 @@ lemma lift_nhds_right {x : α} {g : set α → filter β} (hg : monotone g) :
 calc (nhds x).lift g = (𝓤 α).lift (λs:set (α×α), g {y | (x, y) ∈ s}) : lift_nhds_left hg
   ... = ((@prod.swap α α) <$> (𝓤 α)).lift (λs:set (α×α), g {y | (x, y) ∈ s}) : by rw [←uniformity_eq_symm]
   ... = (𝓤 α).lift (λs:set (α×α), g {y | (x, y) ∈ image prod.swap s}) :
-    map_lift_eq2 $ monotone_comp monotone_preimage hg
+    map_lift_eq2 $ hg.comp monotone_preimage
   ... = _ : by simp [image_swap_eq_preimage_swap]
 
 lemma nhds_nhds_eq_uniformity_uniformity_prod {a b : α} :
@@ -322,7 +322,7 @@ begin
   apply congr_arg, funext s,
   rw [lift_nhds_left],
   refl,
-  exact monotone_comp (monotone_prod monotone_const monotone_id) monotone_principal,
+  exact monotone_principal.comp (monotone_prod monotone_const monotone_id),
   exact (monotone_lift' monotone_const $ monotone_lam $
     assume x, monotone_prod monotone_id monotone_const)
 end

--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -72,7 +72,7 @@ calc f ≤ f.lift' (λs:set α, {y | x ∈ closure s ∧ y ∈ closure s}) :
     rw [prod_same_eq],
     rw [lift'_lift'_assoc],
     exact monotone_prod monotone_id monotone_id,
-    exact monotone_comp (assume s t h x h', closure_mono h h') monotone_preimage
+    exact monotone_preimage.comp (assume s t h x h', closure_mono h h')
   end
   ... ≤ (𝓤 α).lift' (λs:set (α×α), {y | (x, y) ∈ closure s}) : lift'_mono hf.right (le_refl _)
   ... = ((𝓤 α).lift' closure).lift' (λs:set (α×α), {y | (x, y) ∈ s}) :

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -74,8 +74,8 @@ calc map prod.swap ((𝓤 α).lift' gen) =
   end
   ... ≤ (𝓤 α).lift' gen :
     uniformity_lift_le_swap
-      (monotone_comp (monotone_set_of $ assume p,
-        @monotone_mem_sets (α×α) ((filter.prod ((p.2).val) ((p.1).val)))) monotone_principal)
+      (monotone_principal.comp (monotone_set_of $ assume p,
+        @monotone_mem_sets (α×α) ((filter.prod ((p.2).val) ((p.1).val)))))
       begin
         have h := λ(p:Cauchy α×Cauchy α), @filter.prod_comm _ _ (p.2.val) (p.1.val),
         simp [function.comp, h],


### PR DESCRIPTION
fixes #1468 
TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
