### PR TITLE
feat(tactic/squeeze_simp): better handling of private declarations

### DIFF
--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -718,6 +718,9 @@ instance : monad id :=
      let out := format.to_string format!"{{ {fs} }",
      return [(out,"")] }
 
+/-- Like `resolve_name` except when the list of goals is 
+    empty. In that situation `resolve_name` fails whereas
+    `resolve_name'` simply proceeds on a dummy goal -/
 meta def resolve_name' (n : name) : tactic pexpr :=
 do [] ← get_goals | resolve_name n,
    g ← mk_mvar,

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -718,6 +718,12 @@ instance : monad id :=
      let out := format.to_string format!"{{ {fs} }",
      return [(out,"")] }
 
+meta def resolve_name' (n : name) : tactic pexpr :=
+do [] ← get_goals | resolve_name n,
+   g ← mk_mvar,
+   set_goals [g],
+   resolve_name n <* set_goals []
+
 meta def strip_prefix' (n : name) : list string → name → tactic name
 | s name.anonymous := pure $ s.foldl (flip name.mk_string) name.anonymous
 | s (name.mk_string a p) :=
@@ -727,11 +733,15 @@ meta def strip_prefix' (n : name) : list string → name → tactic name
             then pure n'
             else strip_prefix' (a :: s) p }
      <|> strip_prefix' (a :: s) p
-| s (name.mk_numeral a p) := interaction_monad.failed
+| s n@(name.mk_numeral a p) := pure $ s.foldl (flip name.mk_string) n
 
 meta def strip_prefix : name → tactic name
-| n@(name.mk_string a a_1) := strip_prefix' n [a] a_1
-| _ := interaction_monad.failed
+| n@(name.mk_string a a_1) :=
+  if (`_private).is_prefix_of n
+    then let n' := n.update_prefix name.anonymous in
+            n' <$ resolve_name' n' <|> pure n
+    else strip_prefix' n [a] a_1
+| n := pure n
 
 meta def local_binding_info : expr → binder_info
 | (expr.local_const _ _ bi _) := bi


### PR DESCRIPTION
In the following case is not well handled by `squeeze_simp`. I fixed it.

```lean
namespace bar
@[simp]private lemma foo : a = b := sorry

example : a = b := by squeeze_simp 
  -- before: fails
  -- after:  prints `simp only [foo]`

end bar

example : a = b := by squeeze_simp 
  -- before: fails
  -- after:  prints `simp only [_private.351918871.foo]`
```

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
