### PR TITLE
fix(dioph): remove global vector3 notation

### DIFF
--- a/src/number_theory/dioph.lean
+++ b/src/number_theory/dioph.lean
@@ -109,7 +109,7 @@ namespace vector3
 @[pattern] def cons {α} {n} (a : α) (v : vector3 α n) : vector3 α (succ n) :=
 λi, by {refine i.cases' _ _, exact a, exact v}
 
-localized "notation a :: b := vector3.cons a b" in vector3
+notation a :: b := cons a b
 localized "notation `[` l:(foldr `, ` (h t, vector3.cons h t) nil `]`) := l" in vector3
 
 @[simp] theorem cons_fz {α} {n} (a : α) (v : vector3 α n) : (a :: v) fz = a := rfl
@@ -161,7 +161,7 @@ rfl
 def append {α} {m} (v : vector3 α m) {n} (w : vector3 α n) : vector3 α (n+m) :=
 nat.rec_on m (λ_, w) (λm IH v, v.cons_elim $ λa t, @fin2.cases' (n+m) (λ_, α) a (IH t)) v
 
-localized "infix ` +-+ `:65 := vector3.append" in vector3
+local infix ` +-+ `:65 := vector3.append
 
 @[simp] theorem append_nil {α} {n} (w : vector3 α n) : [] +-+ w = w := rfl
 
@@ -436,7 +436,7 @@ namespace option
 def cons {α β} (a : β) (v : α → β) : option α → β :=
 by {refine option.rec _ _, exacts [a, v]}
 
-localized "notation a :: b := option.cons a b" in option
+notation a :: b := cons a b
 
 @[simp] theorem cons_head_tail {α β} (v : option α → β) : v none :: v ∘ some = v :=
 funext $ λo, by cases o; refl
@@ -452,7 +452,6 @@ def dioph {α : Type u} (S : set (α → ℕ)) : Prop :=
 namespace dioph
 section
   variables {α β γ : Type u}
-  open_locale option
   theorem ext {S S' : set (α → ℕ)} (d : dioph S) (H : ∀v, S v ↔ S' v) : dioph S' :=
   eq.rec d $ show S = S', from set.ext H
 
@@ -493,7 +492,7 @@ section
     exact ⟨ulift empty, [], λv, by simp; exact ⟨λ⟨t⟩, empty.rec _ t, trivial⟩⟩,
     simp at d,
     exact let ⟨⟨β, p, pe⟩, dl⟩ := d, ⟨γ, pl, ple⟩ := IH dl in
-    ⟨β ⊕ γ, list.cons (p.remap (inl ⊗ inr ∘ inl)) (pl.map (λq, q.remap (inl ⊗ (inr ∘ inr)))), λv,
+    ⟨β ⊕ γ, p.remap (inl ⊗ inr ∘ inl) :: pl.map (λq, q.remap (inl ⊗ (inr ∘ inr))), λv,
       by simp; exact iff.trans (and_congr (pe v) (ple v))
       ⟨λ⟨⟨m, hm⟩, ⟨n, hn⟩⟩,
         ⟨m ⊗ n, by rw [
@@ -595,12 +594,11 @@ section
     show (option.cons x v) ∘ (cons none some) = x :: v,
     from funext $ λs, by cases s with a b; refl]
 
-  theorem dioph_fn_vec {n} (f : vector3 ℕ n → ℕ) :
-    dioph_fn f ↔ dioph (λv : vector3 ℕ (succ n), f (v ∘ fs) = v fz) :=
-  ⟨λh, reindex_dioph h (option.cons fz fs), λh, reindex_dioph h (none :: some)⟩
+  theorem dioph_fn_vec {n} (f : vector3 ℕ n → ℕ) : dioph_fn f ↔ dioph (λv : vector3 ℕ (succ n), f (v ∘ fs) = v fz) :=
+  ⟨λh, reindex_dioph h (fz :: fs), λh, reindex_dioph h (none :: some)⟩
 
   theorem dioph_pfun_vec {n} (f : vector3 ℕ n →. ℕ) : dioph_pfun f ↔ dioph (λv : vector3 ℕ (succ n), f.graph (v ∘ fs, v fz)) :=
-  ⟨λh, reindex_dioph h (option.cons fz fs), λh, reindex_dioph h (none :: some)⟩
+  ⟨λh, reindex_dioph h (fz :: fs), λh, reindex_dioph h (none :: some)⟩
 
   theorem dioph_fn_compn {α : Type} : ∀ {n} {S : set (α ⊕ fin2 n → ℕ)} (d : dioph S) {f : vector3 ((α → ℕ) → ℕ) n} (df : vector_allp dioph_fn f),
     dioph (λv : α → ℕ, S (v ⊗ λi, f i v))

--- a/src/number_theory/dioph.lean
+++ b/src/number_theory/dioph.lean
@@ -109,8 +109,8 @@ namespace vector3
 @[pattern] def cons {α} {n} (a : α) (v : vector3 α n) : vector3 α (succ n) :=
 λi, by {refine i.cases' _ _, exact a, exact v}
 
-localized "notation a :: b := cons a b" in vector3
-localized "notation `[` l:(foldr `, ` (h t, cons h t) nil `]`) := l" in vector3
+localized "notation a :: b := vector3.cons a b" in vector3
+localized "notation `[` l:(foldr `, ` (h t, vector3.cons h t) nil `]`) := l" in vector3
 
 @[simp] theorem cons_fz {α} {n} (a : α) (v : vector3 α n) : (a :: v) fz = a := rfl
 @[simp] theorem cons_fs {α} {n} (a : α) (v : vector3 α n) (i) : (a :: v) (fs i) = v i := rfl
@@ -161,7 +161,7 @@ rfl
 def append {α} {m} (v : vector3 α m) {n} (w : vector3 α n) : vector3 α (n+m) :=
 nat.rec_on m (λ_, w) (λm IH v, v.cons_elim $ λa t, @fin2.cases' (n+m) (λ_, α) a (IH t)) v
 
-infix ` +-+ `:65 := append
+localized "infix ` +-+ `:65 := vector3.append" in vector3
 
 @[simp] theorem append_nil {α} {n} (w : vector3 α n) : [] +-+ w = w := rfl
 
@@ -436,7 +436,7 @@ namespace option
 def cons {α β} (a : β) (v : α → β) : option α → β :=
 by {refine option.rec _ _, exacts [a, v]}
 
-notation a :: b := cons a b
+localized "notation a :: b := option.cons a b" in option
 
 @[simp] theorem cons_head_tail {α β} (v : option α → β) : v none :: v ∘ some = v :=
 funext $ λo, by cases o; refl
@@ -452,7 +452,7 @@ def dioph {α : Type u} (S : set (α → ℕ)) : Prop :=
 namespace dioph
 section
   variables {α β γ : Type u}
-
+  open_locale option
   theorem ext {S S' : set (α → ℕ)} (d : dioph S) (H : ∀v, S v ↔ S' v) : dioph S' :=
   eq.rec d $ show S = S', from set.ext H
 
@@ -493,7 +493,7 @@ section
     exact ⟨ulift empty, [], λv, by simp; exact ⟨λ⟨t⟩, empty.rec _ t, trivial⟩⟩,
     simp at d,
     exact let ⟨⟨β, p, pe⟩, dl⟩ := d, ⟨γ, pl, ple⟩ := IH dl in
-    ⟨β ⊕ γ, p.remap (inl ⊗ inr ∘ inl) :: pl.map (λq, q.remap (inl ⊗ (inr ∘ inr))), λv,
+    ⟨β ⊕ γ, list.cons (p.remap (inl ⊗ inr ∘ inl)) (pl.map (λq, q.remap (inl ⊗ (inr ∘ inr)))), λv,
       by simp; exact iff.trans (and_congr (pe v) (ple v))
       ⟨λ⟨⟨m, hm⟩, ⟨n, hn⟩⟩,
         ⟨m ⊗ n, by rw [

--- a/src/number_theory/dioph.lean
+++ b/src/number_theory/dioph.lean
@@ -109,8 +109,11 @@ namespace vector3
 @[pattern] def cons {α} {n} (a : α) (v : vector3 α n) : vector3 α (succ n) :=
 λi, by {refine i.cases' _ _, exact a, exact v}
 
-notation a :: b := cons a b
+/- We do not want to make the following notation global, because then these expressions will be
+overloaded, and only the expected type will be able to disambiguate the meaning. Worse: Lean will
+try to insert a coercion from `vector3 α _` to `list α`, if a list is expected. -/
 localized "notation `[` l:(foldr `, ` (h t, vector3.cons h t) nil `]`) := l" in vector3
+notation a :: b := cons a b
 
 @[simp] theorem cons_fz {α} {n} (a : α) (v : vector3 α n) : (a :: v) fz = a := rfl
 @[simp] theorem cons_fs {α} {n} (a : α) (v : vector3 α n) (i) : (a :: v) (fs i) = v i := rfl

--- a/src/number_theory/dioph.lean
+++ b/src/number_theory/dioph.lean
@@ -109,8 +109,8 @@ namespace vector3
 @[pattern] def cons {α} {n} (a : α) (v : vector3 α n) : vector3 α (succ n) :=
 λi, by {refine i.cases' _ _, exact a, exact v}
 
-notation a :: b := cons a b
-notation `[` l:(foldr `, ` (h t, cons h t) nil `]`) := l
+localized "notation a :: b := cons a b" in vector3
+localized "notation `[` l:(foldr `, ` (h t, cons h t) nil `]`) := l" in vector3
 
 @[simp] theorem cons_fz {α} {n} (a : α) (v : vector3 α n) : (a :: v) fz = a := rfl
 @[simp] theorem cons_fs {α} {n} (a : α) (v : vector3 α n) (i) : (a :: v) (fs i) = v i := rfl
@@ -204,7 +204,9 @@ end
 
 end vector3
 
+section vector3
 open vector3
+open_locale vector3
 
 /-- "Curried" exists, i.e. ∃ x1 ... xn, f [x1, ..., xn] -/
 def vector_ex {α} : Π k, (vector3 α k → Prop) → Prop
@@ -254,6 +256,7 @@ end
 theorem vector_allp.imp {α} {p q : α → Prop} (h : ∀ x, p x → q x)
   {n} {v : vector3 α n} (al : vector_allp p v) : vector_allp q v :=
 (vector_allp_iff_forall _ _).2 (λi, h _ $ (vector_allp_iff_forall _ _).1 al _)
+end vector3
 
 /-- `list_all p l` is equivalent to `∀ a ∈ l, p a`, but unfolds directly to a conjunction,
   i.e. `list_all p [0, 1, 2] = p 0 ∧ p 1 ∧ p 2`. -/
@@ -579,7 +582,8 @@ end
 
 section
   variables {α β γ : Type}
-
+  open vector3
+  open_locale vector3
   theorem dioph_fn_vec_comp1 {n} {S : set (vector3 ℕ (succ n))} (d : dioph S) {f : (vector3 ℕ n) → ℕ} (df : dioph_fn f) :
     dioph (λv : vector3 ℕ n, S (cons (f v) v)) :=
   ext (dioph_fn_comp1 (reindex_dioph d (none :: some)) df) $ λv, by rw [
@@ -591,11 +595,12 @@ section
     show (option.cons x v) ∘ (cons none some) = x :: v,
     from funext $ λs, by cases s with a b; refl]
 
-  theorem dioph_fn_vec {n} (f : vector3 ℕ n → ℕ) : dioph_fn f ↔ dioph (λv : vector3 ℕ (succ n), f (v ∘ fs) = v fz) :=
-  ⟨λh, reindex_dioph h (fz :: fs), λh, reindex_dioph h (none :: some)⟩
+  theorem dioph_fn_vec {n} (f : vector3 ℕ n → ℕ) :
+    dioph_fn f ↔ dioph (λv : vector3 ℕ (succ n), f (v ∘ fs) = v fz) :=
+  ⟨λh, reindex_dioph h (option.cons fz fs), λh, reindex_dioph h (none :: some)⟩
 
   theorem dioph_pfun_vec {n} (f : vector3 ℕ n →. ℕ) : dioph_pfun f ↔ dioph (λv : vector3 ℕ (succ n), f.graph (v ∘ fs, v fz)) :=
-  ⟨λh, reindex_dioph h (fz :: fs), λh, reindex_dioph h (none :: some)⟩
+  ⟨λh, reindex_dioph h (option.cons fz fs), λh, reindex_dioph h (none :: some)⟩
 
   theorem dioph_fn_compn {α : Type} : ∀ {n} {S : set (α ⊕ fin2 n → ℕ)} (d : dioph S) {f : vector3 ((α → ℕ) → ℕ) n} (df : vector_allp dioph_fn f),
     dioph (λv : α → ℕ, S (v ⊗ λi, f i v))


### PR DESCRIPTION
it overloads list notation, and then tries to find a coercion from vector3 to list

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
