### PR TITLE
minor updates to the installation instructions

### DIFF
--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -13,10 +13,10 @@ All commands below should be typed inside a terminal.
 
   1. Install [VS Code](https://code.visualstudio.com/).
   2. Launch VS Code.
-  3. Click on the extension icon ![(image of icon)](new-extensions-icon.png) 
-     (or ![(image of icon)](extensions-icon.png) in older versions) in the side bar on the left edge of 
-     the screen (or press <kbd>⇧ Shift</kbd><kbd>⌘ Command</kbd><kbd>X</kbd>) and search for `leanprover`.
-  4. Click "install", and then "reload" to restart VS Code.
+  3. Click on the extension icon ![(image of icon)](new-extensions-icon.png)
+     (or ![(image of icon)](extensions-icon.png) in older versions) in the side bar on the left edge of
+     the screen (or press <kbd>Shift</kbd><kbd>Ctrl</kbd><kbd>X</kbd>) and search for `leanprover`.
+  4. Click "install" (In old versions of VSCode, you might need to click "reload" afterwards)
   5. Verify Lean is working, for example by saving a file `test.lean` and entering `#eval 1+1`.
     A green line should appear underneath `#eval 1+1`, and hovering the mouse over it you should see `2`
     displayed.

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -38,7 +38,11 @@ At a terminal, run the command
   ```bash
   curl https://raw.githubusercontent.com/leanprover-community/mathlib-tools/master/scripts/remote-install-update-mathlib.sh -sSf | bash
   ```
-(This will install tools that, amongst other things, let you download compiled binaries for mathlib.)
+If the script asks you whether you want to install `python3` and `pip3`, type `y`.
+
+This will install tools that, amongst other things, let you download compiled binaries for mathlib.
+
+Then run `source ~/.profile`, so that your environment knows about `update-mathlib`.
 
 Installing and configuring an editor
 ---
@@ -48,10 +52,10 @@ This document describes using VS Code (for emacs, look at https://github.com/lea
 
 1. Install [VS Code](https://code.visualstudio.com/).
 2. Launch VS Code.
-3. Click on the extension icon ![(image of icon)](new-extensions-icon.png) 
-   (or ![(image of icon)](extensions-icon.png) in older versions) in the side bar on the left edge of 
+3. Click on the extension icon ![(image of icon)](new-extensions-icon.png)
+   (or ![(image of icon)](extensions-icon.png) in older versions) in the side bar on the left edge of
    the screen (or press <kbd>⇧ Shift</kbd><kbd>⌘ Command</kbd><kbd>X</kbd>) and search for `leanprover`.
-4. Click "install", and then "reload" to restart VS Code.
+4. Click "install" (In old versions of VSCode, you might need to click "reload" afterwards)
 5. Verify Lean is working, for example by saving a file `test.lean` and entering `#eval 1+1`.
    A green line should appear underneath `#eval 1+1`, and hovering the mouse over it you should see `2`
    displayed.

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -29,8 +29,7 @@ Installing `elan`
    and hit enter when a question is asked.
    To make sure the terminal will find the installed files, run `echo 'PATH="$HOME/.elan/bin:$PATH"' >> $HOME/.profile`.
 
-  Then type `source $HOME/.elan/env` so that your environment knows about `elan`.
-  (Alternatively, you can close and reopen Git Bash.)
+  Then close and reopen Git Bash.
 
 
 Installing mathlib supporting tools
@@ -62,6 +61,7 @@ Then, at a terminal, run the command
   ```bash
   curl https://raw.githubusercontent.com/leanprover-community/mathlib-tools/master/scripts/remote-install-update-mathlib.sh -sSf | bash
   ```
+Run `source ~/.profile` or close and reopen Git Bash.
 
 Installing and configuring an editor
 ---
@@ -71,10 +71,10 @@ This document describes using VS Code (for emacs, look at https://github.com/lea
 
 1. Install [VS Code](https://code.visualstudio.com/).
 2. Launch VS Code.
-3. Click on the extension icon ![(image of icon)](new-extensions-icon.png) 
-   (or ![(image of icon)](extensions-icon.png) in older versions) in the side bar on the left edge of 
-   the screen (or press <kbd>⇧ Shift</kbd><kbd>⌘ Command</kbd><kbd>X</kbd>) and search for `leanprover`.
-4. Click "install", and then "reload" to restart VS Code.
+3. Click on the extension icon ![(image of icon)](new-extensions-icon.png)
+   (or ![(image of icon)](extensions-icon.png) in older versions) in the side bar on the left edge of
+   the screen (or press <kbd>Shift</kbd><kbd>Ctrl</kbd><kbd>X</kbd>) and search for `leanprover`.
+4. Click "install" (In old versions of VSCode, you might need to click "reload" afterwards)
 5. Setup the default shell:
   * If you're using `git bash`, press `ctrl-shift-p` to open the command palette, and type
     `Select Default Shell`, then select `git bash` from the menu.


### PR DESCRIPTION
In preparation for our Lean course in Amsterdam, I've installed Lean on fresh installations of
Windows, Ubuntu, and MacOS. Some of the instructions were not 100% accurate, so here are my corrections:

* Windows and Linux instructions were referring to the `Command` key, which should be `Ctrl`
* The newest version of VSCode does not require reload after installing the Lean extension
* To confirm that the `update-mathlib` installation script should install `python3`, one needs to press `y`, which is not immediately obvious
* In some places, there where missing instructions to `source` or to restart the terminal
* On Windows, the command `source $HOME/.elan/env` did not work for me because that file did not exist. I replaced this by an instruction to restart Git Bash.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
