### PR TITLE
feat(data/zmod/basic): val_min_abs

### DIFF
--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -16,7 +16,7 @@ There are two types defined, `zmod n`, which is for integers modulo a positive n
 
 `val_min_abs` returns the integer closest to zero in the equivalence class.
 
-A coercion `cast` is defined from `zmod n` into any semiring. This is a semiring hom is the ring has
+A coercion `cast` is defined from `zmod n` into any semiring. This is a semiring hom if the ring has
 characteristic dividing `n`
 
 ## Implentation notes

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -390,20 +390,26 @@ lemma le_div_two_iff_lt_neg {p : ℕ} (hp : prime p) (hp1 : p % 2 = 1)
 lemma ne_neg_self (hp1 : p % 2 = 1) {a : zmodp p hp} (ha : a ≠ 0) : a ≠ -a :=
 @zmod.ne_neg_self ⟨p, hp.pos⟩ hp1 _ ha
 
-def val_min_abs {n : ℕ+} (x : zmod n) : ℤ := zmod.val_min_abs x
+variable {hp}
 
-@[simp] lemma coe_val_min_abs {n : ℕ+} (x : zmod n) :
-  (x.val_min_abs : zmod n) = x :=
+/-- `val_min_abs x` returns the integer in the same equivalence class as `x` that is closest to `0`,
+  The result will be in the interval `(-n/2, n/2]` -/
+def val_min_abs (x : zmodp p hp) : ℤ := zmod.val_min_abs x
+
+@[simp] lemma coe_val_min_abs (x : zmodp p hp) :
+  (x.val_min_abs : zmodp p hp) = x :=
 zmod.coe_val_min_abs x
 
-lemma nat_abs_val_min_abs_le {n : ℕ+} (x : zmod n) : x.val_min_abs.nat_abs ≤ n / 2 :=
+lemma nat_abs_val_min_abs_le (x : zmodp p hp) : x.val_min_abs.nat_abs ≤ p / 2 :=
 zmod.nat_abs_val_min_abs_le x
 
-@[simp] lemma val_min_abs_zero {n : ℕ+} : (0 : zmod n).val_min_abs = 0 :=
+@[simp] lemma val_min_abs_zero : (0 : zmodp p hp).val_min_abs = 0 :=
 zmod.val_min_abs_zero
 
-@[simp] lemma val_min_abs_eq_zero {n : ℕ+} (x : zmod n) : x.val_min_abs = 0 ↔ x = 0 :=
+@[simp] lemma val_min_abs_eq_zero (x : zmodp p hp) : x.val_min_abs = 0 ↔ x = 0 :=
 zmod.val_min_abs_eq_zero x
+
+variable (hp)
 
 lemma prime_ne_zero {q : ℕ} (hq : prime q) (hpq : p ≠ q) : (q : zmodp p hp) ≠ 0 :=
 by rwa [← nat.cast_zero, ne.def, zmodp.eq_iff_modeq_nat, nat.modeq.modeq_zero_iff,


### PR DESCRIPTION
`val_min _abs : zmod n -> int` returns the integer in the appropriate equivalence class that is closest to zero. This is useful in some number theory proofs.

Also, a header for the `zmod` file is added.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
