### PR TITLE
refactor(topology,calculus): change subset condition for composition

### DIFF
--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -106,7 +106,11 @@ section derivative_uniqueness
 We prove that the definitions `unique_diff_within_at` and `unique_diff_on` indeed imply the
 uniqueness of the derivative. -/
 
-/-- If a function f has a derivative f', then the local behavior of f is expressed through f'. -/
+/-- If a function f has a derivative f' at x, a rescaled version of f around x converges to f', i.e.,
+`n (f (x + (1/n) v) - f x)` converges to `f' v`. More generally, if `c n` tends to infinity and
+`c n * d n` tends to `v`, then `c n * (f (x + d n) - f x)` tends to `f' v`. This lemma expresses
+this fact, for functions having a derivative within a set. Its specific formulation is useful for
+tangent cone related discussions. -/
 theorem has_fderiv_within_at.lim (h : has_fderiv_within_at f f' s x)
   {c : ℕ → 𝕜} {d : ℕ → E} {v : E} (dtop : {n : ℕ | x + d n ∈ s} ∈ (at_top : filter ℕ))
   (clim : tendsto (λ (n : ℕ), ∥c n∥) at_top at_top)

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -106,38 +106,50 @@ section derivative_uniqueness
 We prove that the definitions `unique_diff_within_at` and `unique_diff_on` indeed imply the
 uniqueness of the derivative. -/
 
+/-- If a function f has a derivative f', then the local behavior of f is expressed through f'. -/
+theorem has_fderiv_within_at.lim (h : has_fderiv_within_at f f' s x)
+  {c : ℕ → 𝕜} {d : ℕ → E} {v : E} (dtop : {n : ℕ | x + d n ∈ s} ∈ (at_top : filter ℕ))
+  (clim : tendsto (λ (n : ℕ), ∥c n∥) at_top at_top)
+  (cdlim : tendsto (λ (n : ℕ), c n • d n) at_top (nhds v)) :
+  tendsto (λn, c n • (f (x + d n) - f x)) at_top (nhds (f' v)) :=
+begin
+  have at_top_is_finer : at_top ≤ comap (λ (n : ℕ), x + d n) (nhds_within (x + 0) s),
+  { rw [← tendsto_iff_comap, nhds_within, tendsto_inf],
+    split,
+    { apply tendsto_add tendsto_const_nhds (tangent_cone_at.lim_zero clim cdlim) },
+    { rwa tendsto_principal } },
+  rw add_zero at at_top_is_finer,
+  have : is_o (λ y, f y - f x - f' (y - x)) (λ y, y - x) (nhds_within x s) := h,
+  have : is_o (λ n:ℕ, f (x + d n) - f x - f' ((x + d n) - x)) (λ n, (x + d n)  - x)
+    ((nhds_within x s).comap (λn, x+ d n)) := is_o.comp this _,
+  have : is_o (λ n:ℕ, f (x + d n) - f x - f' (d n)) d
+    ((nhds_within x s).comap (λn, x + d n)) := by simpa using this,
+  have : is_o (λn:ℕ, f (x + d n) - f x - f' (d n)) d at_top :=
+    is_o.mono at_top_is_finer this,
+  have : is_o (λn:ℕ, c n • (f (x + d n) - f x - f' (d n))) (λn, c n • d n) at_top :=
+    is_o_smul this,
+  have : is_o (λn:ℕ, c n • (f (x + d n) - f x - f' (d n))) (λn, (1:ℝ)) at_top :=
+    this.trans_is_O (is_O_one_of_tendsto cdlim),
+  have L1 : tendsto (λn:ℕ, c n • (f (x + d n) - f x - f' (d n))) at_top (nhds 0) :=
+    is_o_one_iff.1 this,
+  have L2 : tendsto (λn:ℕ, f' (c n • d n)) at_top (nhds (f' v)) :=
+    tendsto.comp f'.cont.continuous_at cdlim,
+  have L3 : tendsto (λn:ℕ, (c n • (f (x + d n) - f x - f' (d n)) +  f' (c n • d n)))
+            at_top (nhds (0 + f' v)) :=
+    tendsto_add L1 L2,
+  have : (λn:ℕ, (c n • (f (x + d n) - f x - f' (d n)) +  f' (c n • d n)))
+          = (λn: ℕ, c n • (f (x + d n) - f x)),
+    by { ext n, simp [smul_add] },
+  rwa [this, zero_add] at L3
+end
+
 /-- `unique_diff_within_at` achieves its goal: it implies the uniqueness of the derivative. -/
 theorem unique_diff_within_at.eq (H : unique_diff_within_at 𝕜 s x)
   (h : has_fderiv_within_at f f' s x) (h₁ : has_fderiv_within_at f f₁' s x) : f' = f₁' :=
 begin
   have A : ∀y ∈ tangent_cone_at 𝕜 s x, f' y = f₁' y,
-  { assume y hy,
-    rcases hy with ⟨c, d, hd, hc, ylim⟩,
-    have at_top_is_finer : at_top ≤ comap (λ (n : ℕ), x + d n) (nhds_within (x + 0) s),
-    { rw [←tendsto_iff_comap, nhds_within, tendsto_inf],
-      split,
-      { apply tendsto_add tendsto_const_nhds (tangent_cone_at.lim_zero hc ylim) },
-      { rwa tendsto_principal } },
-    rw add_zero at at_top_is_finer,
-    have : is_o (λ y, f₁' (y - x) - f' (y - x)) (λ y, y - x) (nhds_within x s),
-      by simpa using h.sub h₁,
-    have : is_o (λ n:ℕ, f₁' ((x + d n) - x) - f' ((x + d n) - x)) (λ n, (x + d n)  - x)
-      ((nhds_within x s).comap (λn, x+ d n)) := is_o.comp this _,
-    have L1 : is_o (λ n:ℕ, f₁' (d n) - f' (d n)) d
-      ((nhds_within x s).comap (λn, x + d n)) := by simpa using this,
-    have L2 : is_o (λn:ℕ, f₁' (d n) - f' (d n)) d at_top :=
-      is_o.mono at_top_is_finer L1,
-    have L3 : is_o (λn:ℕ, c n • (f₁' (d n) - f' (d n))) (λn, c n • d n) at_top :=
-      is_o_smul L2,
-    have L4 : is_o (λn:ℕ, c n • (f₁' (d n) - f' (d n))) (λn, (1:ℝ)) at_top :=
-      L3.trans_is_O (is_O_one_of_tendsto ylim),
-    have L : tendsto (λn:ℕ, c n • (f₁' (d n) - f' (d n))) at_top (nhds 0) :=
-      is_o_one_iff.1 L4,
-    have L' : tendsto (λ (n : ℕ), c n • (f₁' (d n) - f' (d n))) at_top (nhds (f₁' y - f' y)),
-    { simp only [smul_sub, (continuous_linear_map.map_smul _ _ _).symm],
-      apply tendsto_sub ((f₁'.continuous.tendsto _).comp ylim) ((f'.continuous.tendsto _).comp ylim) },
-    have : f₁' y - f' y = 0 := tendsto_nhds_unique (by simp) L' L,
-    exact (sub_eq_zero_iff_eq.1 this).symm },
+  { rintros y ⟨c, d, dtop, clim, cdlim⟩,
+    exact tendsto_nhds_unique (by simp) (h.lim dtop clim cdlim) (h₁.lim dtop clim cdlim) },
   have B : ∀y ∈ submodule.span 𝕜 (tangent_cone_at 𝕜 s x), f' y = f₁' y,
   { assume y hy,
     apply submodule.span_induction hy,
@@ -273,6 +285,11 @@ lemma differentiable_within_at_inter (ht : t ∈ nhds x) :
 by simp only [differentiable_within_at, has_fderiv_within_at, has_fderiv_at_filter,
     nhds_within_restrict' s ht]
 
+lemma differentiable_within_at_inter' (ht : t ∈ nhds_within x s) :
+  differentiable_within_at 𝕜 f (s ∩ t) x ↔ differentiable_within_at 𝕜 f s x :=
+by simp only [differentiable_within_at, has_fderiv_within_at, has_fderiv_at_filter,
+    nhds_within_restrict'' s ht]
+
 lemma differentiable_at.differentiable_within_at
   (h : differentiable_at 𝕜 f x) : differentiable_within_at 𝕜 f s x :=
 (differentiable_within_at_univ.2 h).mono (subset_univ _)
@@ -381,6 +398,10 @@ lemma differentiable_within_at.congr_mono (h : differentiable_within_at 𝕜 f s
   (ht : ∀x ∈ t, f₁ x = f x) (hx : f₁ x = f x) (h₁ : t ⊆ s) : differentiable_within_at 𝕜 f₁ t x :=
 (has_fderiv_within_at.congr_mono h.has_fderiv_within_at ht hx h₁).differentiable_within_at
 
+lemma differentiable_within_at.congr (h : differentiable_within_at 𝕜 f s x)
+  (ht : ∀x ∈ s, f₁ x = f x) (hx : f₁ x = f x) : differentiable_within_at 𝕜 f₁ s x :=
+differentiable_within_at.congr_mono h ht hx (subset.refl _)
+
 lemma differentiable_within_at.congr_of_mem_nhds_within
   (h : differentiable_within_at 𝕜 f s x) (h₁ : {y | f₁ y = f y} ∈ nhds_within x s)
   (hx : f₁ x = f x) : differentiable_within_at 𝕜 f₁ s x :=
@@ -389,6 +410,10 @@ lemma differentiable_within_at.congr_of_mem_nhds_within
 lemma differentiable_on.congr_mono (h : differentiable_on 𝕜 f s) (h' : ∀x ∈ t, f₁ x = f x)
   (h₁ : t ⊆ s) : differentiable_on 𝕜 f₁ t :=
 λ x hx, (h x (h₁ hx)).congr_mono h' (h' x hx) h₁
+
+lemma differentiable_on.congr (h : differentiable_on 𝕜 f s) (h' : ∀x ∈ s, f₁ x = f x) :
+  differentiable_on 𝕜 f₁ s :=
+λ x hx, (h x hx).congr h' (h' x hx)
 
 lemma differentiable_at.congr_of_mem_nhds (h : differentiable_at 𝕜 f x)
   (hL : {y | f₁ y = f y} ∈ nhds x) : differentiable_at 𝕜 f₁ x :=
@@ -980,12 +1005,14 @@ begin
   exact eq₁.tri eq₃
 end
 
-theorem has_fderiv_within_at.comp {g : F → G} {g' : F →L[𝕜] G}
-  (hg : has_fderiv_within_at g g' (f '' s) (f x))
-  (hf : has_fderiv_within_at f f' s x) :
+theorem has_fderiv_within_at.comp {g : F → G} {g' : F →L[𝕜] G} {t : set F}
+  (hg : has_fderiv_within_at g g' t (f x)) (hf : has_fderiv_within_at f f' s x) (hst : s ⊆ f ⁻¹' t) :
   has_fderiv_within_at (g ∘ f) (g'.comp f') s x :=
-(has_fderiv_at_filter.mono hg
-  hf.continuous_within_at.tendsto_nhds_within_image).comp x hf
+begin
+  apply has_fderiv_at_filter.comp _ (has_fderiv_at_filter.mono hg _) hf,
+  apply le_trans hf.continuous_within_at.tendsto_nhds_within_image (nhds_within_mono _ _),
+  rwa image_subset_iff
+end
 
 /-- The chain rule. -/
 theorem has_fderiv_at.comp {g : F → G} {g' : F →L[𝕜] G}
@@ -998,16 +1025,16 @@ theorem has_fderiv_at.comp_has_fderiv_within_at {g : F → G} {g' : F →L[𝕜]
   has_fderiv_within_at (g ∘ f) (g'.comp f') s x :=
 begin
   rw ← has_fderiv_within_at_univ at hg,
-  exact has_fderiv_within_at.comp x (hg.mono (subset_univ _)) hf
+  exact has_fderiv_within_at.comp x hg hf subset_preimage_univ
 end
 
 lemma differentiable_within_at.comp {g : F → G} {t : set F}
   (hg : differentiable_within_at 𝕜 g t (f x)) (hf : differentiable_within_at 𝕜 f s x)
-  (h : f '' s ⊆ t) : differentiable_within_at 𝕜 (g ∘ f) s x :=
+  (h : s ⊆ f ⁻¹' t) : differentiable_within_at 𝕜 (g ∘ f) s x :=
 begin
   rcases hf with ⟨f', hf'⟩,
   rcases hg with ⟨g', hg'⟩,
-  exact ⟨continuous_linear_map.comp g' f', (hg'.mono h).comp x hf'⟩
+  exact ⟨continuous_linear_map.comp g' f', hg'.comp x hf' h⟩
 end
 
 lemma differentiable_at.comp {g : F → G}
@@ -1017,13 +1044,12 @@ lemma differentiable_at.comp {g : F → G}
 
 lemma fderiv_within.comp {g : F → G} {t : set F}
   (hg : differentiable_within_at 𝕜 g t (f x)) (hf : differentiable_within_at 𝕜 f s x)
-  (h : f '' s ⊆ t) (hxs : unique_diff_within_at 𝕜 s x) :
+  (h : s ⊆ f ⁻¹' t) (hxs : unique_diff_within_at 𝕜 s x) :
   fderiv_within 𝕜 (g ∘ f) s x =
     continuous_linear_map.comp (fderiv_within 𝕜 g t (f x)) (fderiv_within 𝕜 f s x) :=
 begin
   apply has_fderiv_within_at.fderiv_within _ hxs,
-  apply has_fderiv_within_at.comp x _ (hf.has_fderiv_within_at),
-  apply hg.has_fderiv_within_at.mono h
+  exact has_fderiv_within_at.comp x (hg.has_fderiv_within_at) (hf.has_fderiv_within_at) h
 end
 
 lemma fderiv.comp {g : F → G}
@@ -1035,9 +1061,9 @@ begin
 end
 
 lemma differentiable_on.comp {g : F → G} {t : set F}
-  (hg : differentiable_on 𝕜 g t) (hf : differentiable_on 𝕜 f s) (st : f '' s ⊆ t) :
+  (hg : differentiable_on 𝕜 g t) (hf : differentiable_on 𝕜 f s) (st : s ⊆ f ⁻¹' t) :
   differentiable_on 𝕜 (g ∘ f) s :=
-λx hx, differentiable_within_at.comp x (hg (f x) (st (mem_image_of_mem _ hx))) (hf x hx) st
+λx hx, differentiable_within_at.comp x (hg (f x) (st hx)) (hf x hx) st
 
 lemma differentiable.comp {g : F → G} (hg : differentiable 𝕜 g) (hf : differentiable 𝕜 f) :
   differentiable 𝕜 (g ∘ f) :=
@@ -1176,3 +1202,68 @@ begin
 end
 
 end
+
+section tangent_cone
+
+variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
+{E : Type*} [normed_group E] [normed_space 𝕜 E]
+{F : Type*} [normed_group F] [normed_space 𝕜 F]
+{f : E → F} {s : set E} {f' : E →L[𝕜] F}
+
+/-- The image of a tangent cone under the differential of a map is included in the tangent cone to
+the image. -/
+lemma has_fderiv_within_at.image_tangent_cone_subset {x : E} (h : has_fderiv_within_at f f' s x) :
+  f' '' (tangent_cone_at 𝕜 s x) ⊆ tangent_cone_at 𝕜 (f '' s) (f x) :=
+begin
+  rw image_subset_iff,
+  rintros v ⟨c, d, dtop, clim, cdlim⟩,
+  refine ⟨c, (λn, f (x + d n) - f x), _, clim, _⟩,
+  show {n : ℕ | f x + (f (x + d n) - f x) ∈ f '' s} ∈ at_top,
+  { apply mem_sets_of_superset dtop,
+    simp [-mem_image, mem_image_of_mem] {contextual := tt} },
+  show tendsto (λ (n : ℕ), c n • (f (x + d n) - f x)) at_top (nhds (f' v)),
+  { apply h.lim dtop clim cdlim, }
+end
+
+/-- If a set has the unique differentiability property at a point x, then the image of this set
+under a map with onto derivative has also the unique differentiability property at the image point.
+-/
+lemma has_fderiv_within_at.unique_diff_within_at {x : E} (h : has_fderiv_within_at f f' s x)
+  (hs : unique_diff_within_at 𝕜 s x) (h' : closure (range f') = univ) :
+  unique_diff_within_at 𝕜 (f '' s) (f x) :=
+begin
+  have A : ∀v ∈ tangent_cone_at 𝕜 s x, f' v ∈ tangent_cone_at 𝕜 (f '' s) (f x),
+  { assume v hv,
+    have := h.image_tangent_cone_subset,
+    rw image_subset_iff at this,
+    exact this hv },
+  have B : ∀v ∈ (submodule.span 𝕜 (tangent_cone_at 𝕜 s x) : set E),
+    f' v ∈ (submodule.span 𝕜 (tangent_cone_at 𝕜 (f '' s) (f x)) : set F),
+  { assume v hv,
+    apply submodule.span_induction hv,
+    { exact λ w hw, submodule.subset_span (A w hw) },
+    { simp },
+    { assume w₁ w₂ hw₁ hw₂,
+      rw continuous_linear_map.map_add,
+      exact submodule.add_mem (submodule.span 𝕜 (tangent_cone_at 𝕜 (f '' s) (f x))) hw₁ hw₂ },
+    { assume a w hw,
+      rw continuous_linear_map.map_smul,
+      exact submodule.smul_mem (submodule.span 𝕜 (tangent_cone_at 𝕜 (f '' s) (f x))) _ hw } },
+  rw [unique_diff_within_at, ← univ_subset_iff],
+  split,
+  show f x ∈ closure (f '' s), from h.continuous_within_at.mem_closure_image hs.2,
+  show univ ⊆ closure ↑(submodule.span 𝕜 (tangent_cone_at 𝕜 (f '' s) (f x))), from calc
+    univ ⊆ closure (range f') : univ_subset_iff.2 h'
+    ... = closure (f' '' univ) : by rw image_univ
+    ... = closure (f' '' (closure (submodule.span 𝕜 (tangent_cone_at 𝕜 s x) : set E))) : by rw hs.1
+    ... ⊆ closure (closure (f' '' (submodule.span 𝕜 (tangent_cone_at 𝕜 s x) : set E))) :
+      closure_mono (image_closure_subset_closure_image f'.cont)
+    ... ⊆  closure (submodule.span 𝕜 (tangent_cone_at 𝕜 (f '' s) (f x)) : set F) : begin
+      rw closure_closure,
+      apply closure_mono,
+      rw image_subset_iff,
+      exact B
+    end
+end
+
+end tangent_cone

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -117,17 +117,17 @@ theorem has_fderiv_within_at.lim (h : has_fderiv_within_at f f' s x)
   (cdlim : tendsto (λ (n : ℕ), c n • d n) at_top (nhds v)) :
   tendsto (λn, c n • (f (x + d n) - f x)) at_top (nhds (f' v)) :=
 begin
-  have at_top_is_finer : at_top ≤ comap (λ (n : ℕ), x + d n) (nhds_within (x + 0) s),
-  { rw [← tendsto_iff_comap, nhds_within, tendsto_inf],
+  have at_top_is_finer : at_top ≤ comap (λ (n : ℕ), x + d n) (nhds_within x s),
+  { conv in (nhds_within x s) { rw ← add_zero x },
+    rw [← tendsto_iff_comap, nhds_within, tendsto_inf],
     split,
     { apply tendsto_add tendsto_const_nhds (tangent_cone_at.lim_zero clim cdlim) },
     { rwa tendsto_principal } },
-  rw add_zero at at_top_is_finer,
   have : is_o (λ y, f y - f x - f' (y - x)) (λ y, y - x) (nhds_within x s) := h,
   have : is_o (λ n:ℕ, f (x + d n) - f x - f' ((x + d n) - x)) (λ n, (x + d n)  - x)
     ((nhds_within x s).comap (λn, x+ d n)) := is_o.comp this _,
   have : is_o (λ n:ℕ, f (x + d n) - f x - f' (d n)) d
-    ((nhds_within x s).comap (λn, x + d n)) := by simpa using this,
+    ((nhds_within x s).comap (λn, x + d n)) := by simpa,
   have : is_o (λn:ℕ, f (x + d n) - f x - f' (d n)) d at_top :=
     is_o.mono at_top_is_finer this,
   have : is_o (λn:ℕ, c n • (f (x + d n) - f x - f' (d n))) (λn, c n • d n) at_top :=
@@ -1014,8 +1014,9 @@ theorem has_fderiv_within_at.comp {g : F → G} {g' : F →L[𝕜] G} {t : set F
   has_fderiv_within_at (g ∘ f) (g'.comp f') s x :=
 begin
   apply has_fderiv_at_filter.comp _ (has_fderiv_at_filter.mono hg _) hf,
-  apply le_trans hf.continuous_within_at.tendsto_nhds_within_image (nhds_within_mono _ _),
-  rwa image_subset_iff
+  calc map f (nhds_within x s)
+      ≤ nhds_within (f x) (f '' s) : hf.continuous_within_at.tendsto_nhds_within_image
+  ... ≤ nhds_within (f x) t        : nhds_within_mono _ (image_subset_iff.mpr hst)
 end
 
 /-- The chain rule. -/
@@ -1221,12 +1222,8 @@ lemma has_fderiv_within_at.image_tangent_cone_subset {x : E} (h : has_fderiv_wit
 begin
   rw image_subset_iff,
   rintros v ⟨c, d, dtop, clim, cdlim⟩,
-  refine ⟨c, (λn, f (x + d n) - f x), _, clim, _⟩,
-  show {n : ℕ | f x + (f (x + d n) - f x) ∈ f '' s} ∈ at_top,
-  { apply mem_sets_of_superset dtop,
-    simp [-mem_image, mem_image_of_mem] {contextual := tt} },
-  show tendsto (λ (n : ℕ), c n • (f (x + d n) - f x)) at_top (nhds (f' v)),
-  { apply h.lim dtop clim cdlim, }
+  refine ⟨c, (λn, f (x + d n) - f x), mem_sets_of_superset dtop _, clim, h.lim dtop clim cdlim⟩,
+  simp [-mem_image, mem_image_of_mem] {contextual := tt}
 end
 
 /-- If a set has the unique differentiability property at a point x, then the image of this set
@@ -1262,12 +1259,9 @@ begin
     ... = closure (f' '' (closure (submodule.span 𝕜 (tangent_cone_at 𝕜 s x) : set E))) : by rw hs.1
     ... ⊆ closure (closure (f' '' (submodule.span 𝕜 (tangent_cone_at 𝕜 s x) : set E))) :
       closure_mono (image_closure_subset_closure_image f'.cont)
-    ... ⊆  closure (submodule.span 𝕜 (tangent_cone_at 𝕜 (f '' s) (f x)) : set F) : begin
-      rw closure_closure,
-      apply closure_mono,
-      rw image_subset_iff,
-      exact B
-    end
+    ... = closure (f' '' (submodule.span 𝕜 (tangent_cone_at 𝕜 s x) : set E)) : closure_closure
+    ... ⊆ closure (submodule.span 𝕜 (tangent_cone_at 𝕜 (f '' s) (f x)) : set F) :
+      closure_mono (image_subset_iff.mpr B)
 end
 
 end tangent_cone

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -112,12 +112,13 @@ begin
   rw this,
   have : f y = g 1, by { simp only [g], rw one_smul, congr' 1, abel },
   rw this,
-  apply norm_image_sub_le_of_norm_deriv_le_segment (hf.comp D1.differentiable_on segm) (λt ht, _),
+  apply norm_image_sub_le_of_norm_deriv_le_segment
+    (hf.comp D1.differentiable_on (image_subset_iff.1 segm)) (λt ht, _),
   /- It remains to check that the derivative of g is bounded by C ∥y-x∥ at any t ∈ [0,1] -/
   have t_s : x + t • (y-x) ∈ s := segm (mem_image_of_mem _ ht),
   simp only [g],
   /- Expand the derivative of the composition, and bound its norm by the product of the norms -/
-  rw fderiv_within.comp t (hf _ t_s) ((D1 t).differentiable_within_at) segm
+  rw fderiv_within.comp t (hf _ t_s) ((D1 t).differentiable_within_at) (image_subset_iff.1 segm)
     (unique_diff_on_Icc_zero_one t ht),
   refine le_trans (op_norm_comp_le _ _) (mul_le_mul (bound _ t_s) _ (norm_nonneg _) C0),
   have : fderiv_within ℝ (λ (t : ℝ), x + t • (y - x)) (Icc 0 1) t =

--- a/src/analysis/calculus/tangent_cone.lean
+++ b/src/analysis/calculus/tangent_cone.lean
@@ -247,6 +247,14 @@ by { rw [unique_diff_within_at, tangent_cone_univ], simp }
 lemma unique_diff_on_univ : unique_diff_on 𝕜 (univ : set E) :=
 λx hx, unique_diff_within_at_univ
 
+lemma unique_diff_within_at.mono (h : unique_diff_within_at 𝕜 s x) (st : s ⊆ t) :
+  unique_diff_within_at 𝕜 t x :=
+begin
+  unfold unique_diff_within_at at *,
+  rw [← univ_subset_iff, ← h.1],
+  exact ⟨closure_mono (submodule.span_mono (tangent_cone_mono st)), closure_mono st h.2⟩
+end
+
 lemma unique_diff_within_at_inter (ht : t ∈ nhds x) :
   unique_diff_within_at 𝕜 (s ∩ t) x ↔ unique_diff_within_at 𝕜 s x :=
 begin
@@ -265,13 +273,23 @@ lemma unique_diff_within_at.inter (hs : unique_diff_within_at 𝕜 s x) (ht : t 
   unique_diff_within_at 𝕜 (s ∩ t) x :=
 (unique_diff_within_at_inter ht).2 hs
 
-lemma unique_diff_within_at.mono (h : unique_diff_within_at 𝕜 s x) (st : s ⊆ t) :
-  unique_diff_within_at 𝕜 t x :=
+lemma unique_diff_within_at_inter' (ht : t ∈ nhds_within x s) :
+  unique_diff_within_at 𝕜 (s ∩ t) x ↔ unique_diff_within_at 𝕜 s x :=
 begin
-  unfold unique_diff_within_at at *,
-  rw [← univ_subset_iff, ← h.1],
-  exact ⟨closure_mono (submodule.span_mono (tangent_cone_mono st)), closure_mono st h.2⟩
+  split,
+  { exact λH, H.mono (inter_subset_left _ _) },
+  { assume H,
+    rw mem_nhds_within at ht,
+    rcases ht with ⟨u, u_open, xu, us⟩,
+    have : u ∈ nhds x := mem_nhds_sets u_open xu,
+    rw ← unique_diff_within_at_inter this at H,
+    apply H.mono,
+    exact λ p ⟨ps, pu⟩, ⟨ps, us ⟨pu, ps⟩⟩ }
 end
+
+lemma unique_diff_within_at.inter' (hs : unique_diff_within_at 𝕜 s x) (ht : t ∈ nhds_within x s) :
+  unique_diff_within_at 𝕜 (s ∩ t) x :=
+(unique_diff_within_at_inter' ht).2 hs
 
 lemma is_open.unique_diff_within_at (hs : is_open s) (xs : x ∈ s) : unique_diff_within_at 𝕜 s x :=
 begin
@@ -279,7 +297,7 @@ begin
   rwa univ_inter at this
 end
 
-lemma unique_diff_on_inter (hs : unique_diff_on 𝕜 s) (ht : is_open t) : unique_diff_on 𝕜 (s ∩ t) :=
+lemma unique_diff_on.inter (hs : unique_diff_on 𝕜 s) (ht : is_open t) : unique_diff_on 𝕜 (s ∩ t) :=
 λx hx, (hs x hx.1).inter (mem_nhds_sets ht hx.2)
 
 lemma is_open.unique_diff_on (hs : is_open s) : unique_diff_on 𝕜 s :=

--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -455,7 +455,7 @@ begin
   have A : continuous (λq : (E →L[𝕜] F) × E, q.1 q.2) := is_bounded_bilinear_map_apply.continuous,
   have B : continuous_on (λp : E × E, (fderiv_within 𝕜 f s p.1, p.2)) (set.prod s univ),
   { apply continuous_on.prod _ continuous_snd.continuous_on,
-    refine continuous_on.comp (h.continuous_on_fderiv_within hn) continuous_fst.continuous_on
+    exact continuous_on.comp (h.continuous_on_fderiv_within hn) continuous_fst.continuous_on
       (prod_subset_preimage_fst _ _) },
   exact A.comp_continuous_on B
 end

--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -229,12 +229,12 @@ begin
   { apply subset.antisymm (inter_subset_inter (inter_subset_left _ _) (subset.refl _)),
     exact λ y ⟨ys, yv⟩, ⟨⟨ys, vu yv⟩, yv⟩ },
   have : iterated_fderiv_within 𝕜 n f (s ∩ v) x = iterated_fderiv_within 𝕜 n f s x :=
-    iterated_fderiv_within_inter_open xv v_open xs (unique_diff_on_inter hs v_open),
+    iterated_fderiv_within_inter_open xv v_open xs (hs.inter v_open),
   rw ← this,
   have : iterated_fderiv_within 𝕜 n f ((s ∩ u) ∩ v) x = iterated_fderiv_within 𝕜 n f (s ∩ u) x,
   { refine iterated_fderiv_within_inter_open xv v_open ⟨xs, mem_of_nhds hu⟩ _,
     rw A,
-    exact unique_diff_on_inter hs v_open },
+    exact hs.inter v_open },
   rw A at this,
   rw ← this
 end
@@ -455,10 +455,8 @@ begin
   have A : continuous (λq : (E →L[𝕜] F) × E, q.1 q.2) := is_bounded_bilinear_map_apply.continuous,
   have B : continuous_on (λp : E × E, (fderiv_within 𝕜 f s p.1, p.2)) (set.prod s univ),
   { apply continuous_on.prod _ continuous_snd.continuous_on,
-    refine continuous_on.comp (h.continuous_on_fderiv_within hn) continuous_fst.continuous_on (λx hx, _),
-    simp at hx,
-    rcases hx with ⟨y, hy⟩,
-    exact hy },
+    refine continuous_on.comp (h.continuous_on_fderiv_within hn) continuous_fst.continuous_on
+      (prod_subset_preimage_fst _ _) },
   exact A.comp_continuous_on B
 end
 
@@ -542,14 +540,14 @@ begin
     refine ⟨u, u_open, xu,_⟩,
     apply continuous_on.congr_mono (hu.1 m hm) (λy hy, _) (subset.refl _),
     symmetry,
-    exact iterated_fderiv_within_inter_open hy.2 u_open hy.1 (unique_diff_on_inter hs u_open) },
+    exact iterated_fderiv_within_inter_open hy.2 u_open hy.1 (hs.inter u_open) },
   { assume m hm,
     apply differentiable_on_of_locally_differentiable_on (λx hx, _),
     rcases h x hx with ⟨u, u_open, xu, hu⟩,
     refine ⟨u, u_open, xu,_⟩,
     apply differentiable_on.congr_mono (hu.2 m hm) (λy hy, _) (subset.refl _),
     symmetry,
-    exact iterated_fderiv_within_inter_open hy.2 u_open hy.1 (unique_diff_on_inter hs u_open) }
+    exact iterated_fderiv_within_inter_open hy.2 u_open hy.1 (hs.inter u_open) }
 end
 
 /--
@@ -692,11 +690,11 @@ begin
     rw times_cont_diff_on_zero at hf ⊢,
     apply continuous_on.comp this hf (subset_univ _) },
   { rw times_cont_diff_on_succ at hf ⊢,
-    refine ⟨differentiable_on.comp hg.differentiable_on hf.1 (subset_univ _), _⟩,
+    refine ⟨differentiable_on.comp hg.differentiable_on hf.1 subset_preimage_univ, _⟩,
     let Φ : (E →L[𝕜] F) → (E →L[𝕜] G) := λu, continuous_linear_map.comp (hg.to_continuous_linear_map) u,
     have : ∀x∈s, fderiv_within 𝕜 (g ∘ f) s x = Φ (fderiv_within 𝕜 f s x),
     { assume x hx,
-      rw [fderiv_within.comp x _ (hf.1 x hx) (subset_univ _) (hs x hx),
+      rw [fderiv_within.comp x _ (hf.1 x hx) subset_preimage_univ (hs x hx),
           fderiv_within_univ, hg.fderiv],
       rw differentiable_within_at_univ,
       exact hg.differentiable_at },
@@ -755,7 +753,7 @@ The composition of `C^n` functions on domains is `C^n`.
 -/
 lemma times_cont_diff_on.comp {n : with_top ℕ} {s : set E} {t : set F} {g : F → G} {f : E → F}
   (hg : times_cont_diff_on 𝕜 n g t) (hf : times_cont_diff_on 𝕜 n f s) (hs : unique_diff_on 𝕜 s)
-  (st : f '' s ⊆ t) : times_cont_diff_on 𝕜 n (g ∘ f) s :=
+  (st : s ⊆ f ⁻¹' t) : times_cont_diff_on 𝕜 n (g ∘ f) s :=
 begin
   tactic.unfreeze_local_instances,
   induction n using with_top.nat_induction with n IH Itop generalizing E F G,
@@ -774,7 +772,7 @@ begin
       continuous_linear_map.comp (fderiv_within 𝕜 g t (f x)) (fderiv_within 𝕜 f s x),
     { assume x hx,
       apply fderiv_within.comp x _ (hf.1 x hx) st (hs x hx),
-      exact hg.1 _ (st (mem_image_of_mem _ hx)) },
+      exact hg.1 _ (st hx) },
     apply times_cont_diff_on.congr _ hs this,
     have A : times_cont_diff_on 𝕜 n (λx, fderiv_within 𝕜 g t (f x)) s :=
       IH hg.2 (times_cont_diff_on_succ.2 hf).of_succ hs st,
@@ -816,11 +814,9 @@ begin
   { apply times_cont_diff_on.prod _ _ U,
     { have I : times_cont_diff_on 𝕜 m (λ (x : E), fderiv_within 𝕜 f s x) s :=
         times_cont_diff_on_fderiv_within hf hmn,
-      have J : times_cont_diff_on 𝕜 m (λ (x : E × E), x.1) (set.prod s univ),
-      { apply times_cont_diff.times_cont_diff_on _ U,
-        apply is_bounded_linear_map.times_cont_diff,
-        apply is_bounded_linear_map.fst },
-      exact times_cont_diff_on.comp I J U (fst_image_prod_subset _ _) },
+      have J : times_cont_diff_on 𝕜 m (λ (x : E × E), x.1) (set.prod s univ) :=
+        times_cont_diff_fst.times_cont_diff_on U,
+      exact times_cont_diff_on.comp I J U (prod_subset_preimage_fst _ _) },
     { apply times_cont_diff.times_cont_diff_on _ U,
       apply is_bounded_linear_map.times_cont_diff,
       apply is_bounded_linear_map.snd } },

--- a/src/data/equiv/local_equiv.lean
+++ b/src/data/equiv/local_equiv.lean
@@ -77,7 +77,7 @@ structure local_equiv (α : Type*) (β : Type*) :=
 (left_inv   : ∀{x}, x ∈ source → inv_fun (to_fun x) = x)
 (right_inv  : ∀{x}, x ∈ target → to_fun (inv_fun x) = x)
 
-attribute [simp] local_equiv.left_inv local_equiv.right_inv
+attribute [simp] local_equiv.left_inv local_equiv.right_inv local_equiv.map_source local_equiv.map_target
 
 /-- Associating a local_equiv to an equiv-/
 def equiv.to_local_equiv (e : equiv α β) : local_equiv α β :=

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -781,6 +781,8 @@ assume x hx, h hx
 
 @[simp] theorem preimage_univ : f ⁻¹' univ = univ := rfl
 
+@[simp] theorem subset_preimage_univ {s : set α} : s ⊆ f ⁻¹' univ := subset_univ _
+
 @[simp] theorem preimage_inter {s t : set β} : f ⁻¹' (s ∩ t) = f ⁻¹' s ∩ f ⁻¹' t := rfl
 
 @[simp] theorem preimage_union {s t : set β} : f ⁻¹' (s ∪ t) = f ⁻¹' s ∪ f ⁻¹' t := rfl
@@ -1348,6 +1350,14 @@ theorem prod_range_range_eq {α β γ δ} {m₁ : α → γ} {m₂ : β → δ} 
   set.prod (range m₁) (range m₂) = range (λp:α×β, (m₁ p.1, m₂ p.2)) :=
 ext $ by simp [range]
 
+theorem prod_range_univ_eq {α β γ} {m₁ : α → γ} :
+  set.prod (range m₁) (univ : set β) = range (λp:α×β, (m₁ p.1, p.2)) :=
+ext $ by simp [range]
+
+theorem prod_univ_range_eq {α β δ} {m₂ : β → δ} :
+  set.prod (univ : set α) (range m₂) = range (λp:α×β, (p.1, m₂ p.2)) :=
+ext $ by simp [range]
+
 @[simp] theorem prod_singleton_singleton {a : α} {b : β} :
   set.prod {a} {b} = ({(a, b)} : set (α×β)) :=
 ext $ by simp [set.prod]
@@ -1375,6 +1385,10 @@ lemma fst_image_prod_subset (s : set α) (t : set β) :
   prod.fst '' (set.prod s t) ⊆ s :=
 λ _ h, let ⟨_, ⟨h₂, _⟩, h₁⟩ := (set.mem_image _ _ _).1 h in h₁ ▸ h₂
 
+lemma prod_subset_preimage_fst (s : set α) (t : set β) :
+  set.prod s t ⊆ prod.fst ⁻¹' s :=
+image_subset_iff.1 (fst_image_prod_subset s t)
+
 lemma fst_image_prod (s : set β) {t : set α} (ht : t ≠ ∅) :
   prod.fst '' (set.prod s t) = s :=
 set.subset.antisymm (fst_image_prod_subset _ _)
@@ -1384,6 +1398,10 @@ set.subset.antisymm (fst_image_prod_subset _ _)
 lemma snd_image_prod_subset (s : set α) (t : set β) :
   prod.snd '' (set.prod s t) ⊆ t :=
 λ _ h, let ⟨_, ⟨_, h₂⟩, h₁⟩ := (set.mem_image _ _ _).1 h in h₁ ▸ h₂
+
+lemma prod_subset_preimage_snd (s : set α) (t : set β) :
+  set.prod s t ⊆ prod.snd ⁻¹' t :=
+image_subset_iff.1 (snd_image_prod_subset s t)
 
 lemma snd_image_prod {s : set α} (hs : s ≠ ∅) (t : set β) :
   prod.snd '' (set.prod s t) = t :=

--- a/src/geometry/manifold/manifold.lean
+++ b/src/geometry/manifold/manifold.lean
@@ -301,6 +301,7 @@ class manifold (H : Type*) [topological_space H] (M : Type*) [topological_space 
 (chart_mem_atlas  : ∀x, chart_at x ∈ atlas)
 
 export manifold
+attribute [simp] mem_chart_source chart_mem_atlas
 
 section manifold
 

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -105,6 +105,9 @@ is_open_and (is_open_lt continuous_const continuous_id) (is_open_lt continuous_i
 lemma is_open_Iio {a : α} : is_open (Iio a) :=
 is_open_lt continuous_id continuous_const
 
+lemma is_open_Ioi {a : α} : is_open (Ioi a) :=
+is_open_lt continuous_const continuous_id
+
 end linear_order
 
 section decidable_linear_order

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -50,6 +50,10 @@ begin
   exact ⟨u, λ x xu xs, hu ⟨xu, xs⟩, openu, au⟩
 end
 
+lemma mem_nhds_within_of_mem_nhds {s t : set α} {a : α} (h : s ∈ nhds a) :
+  s ∈ nhds_within a t :=
+mem_inf_sets_of_left h
+
 theorem self_mem_nhds_within {a : α} {s : set α} : s ∈ nhds_within a s :=
 begin
   rw [nhds_within, mem_inf_principal],
@@ -151,6 +155,26 @@ by rw [←nhds_within_univ] at h; exact tendsto_nhds_within_mono_left (set.subse
 theorem principal_subtype {α : Type*} (s : set α) (t : set {x // x ∈ s}) :
   principal t = comap subtype.val (principal (subtype.val '' t)) :=
 by rw comap_principal; rw set.preimage_image_eq; apply subtype.val_injective
+
+lemma mem_closure_iff_nhds_within_ne_bot {s : set α} {x : α} :
+  x ∈ closure s ↔ nhds_within x s ≠ ⊥ :=
+begin
+  split,
+  { assume hx,
+    rw ← forall_sets_neq_empty_iff_neq_bot,
+    assume o ho,
+    rw mem_nhds_within at ho,
+    rcases ho with ⟨u, u_open, xu, hu⟩,
+    rw mem_closure_iff at hx,
+    exact subset_ne_empty hu (hx u u_open xu) },
+  { assume h,
+    rw mem_closure_iff,
+    rintros u u_open xu,
+    have : u ∩ s ∈ nhds_within x s,
+    { rw mem_nhds_within,
+      exact ⟨u, u_open, xu, subset.refl _⟩ },
+    exact forall_sets_neq_empty_iff_neq_bot.2 h (u ∩ s) this }
+end
 
 /-
 nhds_within and subtypes
@@ -267,6 +291,11 @@ lemma continuous_within_at_inter {f : α → β} {s t : set α} {x : α} (h : t 
   continuous_within_at f (s ∩ t) x ↔ continuous_within_at f s x :=
 by simp [continuous_within_at, nhds_within_restrict' s h]
 
+lemma continuous_within_at.mem_closure_image  {f : α → β} {s : set α} {x : α}
+  (h : continuous_within_at f s x) (hx : x ∈ closure s) : f x ∈ closure (f '' s) :=
+mem_closure_of_tendsto (mem_closure_iff_nhds_within_ne_bot.1 hx) h $
+mem_sets_of_superset self_mem_nhds_within (subset_preimage_image f s)
+
 lemma continuous_on.congr_mono {f g : α → β} {s s₁ : set α} (h : continuous_on f s)
   (h' : ∀x ∈ s₁, g x = f x) (h₁ : s₁ ⊆ s) : continuous_on g s₁ :=
 begin
@@ -282,6 +311,10 @@ begin
   finish
 end
 
+lemma continuous_on.congr {f g : α → β} {s : set α} (h : continuous_on f s)
+  (h' : ∀x ∈ s, g x = f x) : continuous_on g s :=
+h.congr_mono h' (subset.refl _)
+
 lemma continuous_at.continuous_within_at {f : α → β} {s : set α} {x : α} (h : continuous_at f x) :
   continuous_within_at f s x :=
 continuous_within_at.mono ((continuous_within_at_univ f x).2 h) (subset_univ _)
@@ -294,11 +327,11 @@ begin
 end
 
 lemma continuous_within_at.comp {g : β → γ} {f : α → β} {s : set α} {t : set β} {x : α}
-  (hg : continuous_within_at g t (f x)) (hf : continuous_within_at f s x) (h : f '' s ⊆ t) :
+  (hg : continuous_within_at g t (f x)) (hf : continuous_within_at f s x) (h : s ⊆ f ⁻¹' t) :
   continuous_within_at (g ∘ f) s x :=
 begin
   have : tendsto f (principal s) (principal t),
-    by { rw tendsto_principal_principal, exact λx hx, h (mem_image_of_mem _ hx) },
+    by { rw tendsto_principal_principal, exact λx hx, h hx },
   have : tendsto f (nhds_within x s) (principal t) :=
     tendsto_le_left lattice.inf_le_right this,
   have : tendsto f (nhds_within x s) (nhds_within (f x) t) :=
@@ -307,9 +340,9 @@ begin
 end
 
 lemma continuous_on.comp {g : β → γ} {f : α → β} {s : set α} {t : set β}
-  (hg : continuous_on g t) (hf : continuous_on f s) (h : f '' s ⊆ t) :
+  (hg : continuous_on g t) (hf : continuous_on f s) (h : s ⊆ f ⁻¹' t) :
   continuous_on (g ∘ f) s :=
-λx hx, continuous_within_at.comp (hg _ (h (mem_image_of_mem _ hx))) (hf x hx) h
+λx hx, continuous_within_at.comp (hg _ (h hx)) (hf x hx) h
 
 lemma continuous_on.mono {f : α → β} {s t : set α} (hf : continuous_on f s) (h : t ⊆ s)  :
   continuous_on f t :=
@@ -325,16 +358,36 @@ end
 lemma continuous.comp_continuous_on {g : β → γ} {f : α → β} {s : set α}
   (hg : continuous g) (hf : continuous_on f s) :
   continuous_on (g ∘ f) s :=
-hg.continuous_on.comp hf (subset_univ _)
+hg.continuous_on.comp hf subset_preimage_univ
 
 lemma continuous_within_at.preimage_mem_nhds_within {f : α → β} {x : α} {s : set α} {t : set β}
   (h : continuous_within_at f s x) (ht : t ∈ nhds (f x)) : f ⁻¹' t ∈ nhds_within x s :=
 h ht
 
+lemma continuous_within_at.preimage_mem_nhds_within' {f : α → β} {x : α} {s : set α} {t : set β}
+  (h : continuous_within_at f s x) (ht : t ∈ nhds_within (f x) (f '' s)) :
+  f ⁻¹' t ∈ nhds_within x s :=
+begin
+  rw mem_nhds_within at ht,
+  rcases ht with ⟨u, u_open, fxu, hu⟩,
+  have : f ⁻¹' u ∩ s ∈ nhds_within x s :=
+    filter.inter_mem_sets (h (mem_nhds_sets u_open fxu)) self_mem_nhds_within,
+  apply mem_sets_of_superset this,
+  calc f ⁻¹' u ∩ s
+    ⊆ f ⁻¹' u ∩ f ⁻¹' (f '' s) : inter_subset_inter_right _ (subset_preimage_image f s)
+    ... = f ⁻¹' (u ∩ f '' s) : rfl
+    ... ⊆ f ⁻¹' t : preimage_mono hu
+end
+
 lemma continuous_within_at.congr_of_mem_nhds_within {f f₁ : α → β} {s : set α} {x : α}
   (h : continuous_within_at f s x) (h₁ : {y | f₁ y = f y} ∈ nhds_within x s) (hx : f₁ x = f x) :
   continuous_within_at f₁ s x :=
 by rwa [continuous_within_at, filter.tendsto, hx, filter.map_cong h₁]
+
+lemma continuous_within_at.congr {f f₁ : α → β} {s : set α} {x : α}
+  (h : continuous_within_at f s x) (h₁ : ∀y∈s, f₁ y = f y) (hx : f₁ x = f x) :
+  continuous_within_at f₁ s x :=
+h.congr_of_mem_nhds_within (mem_sets_of_superset self_mem_nhds_within h₁) hx
 
 lemma continuous_on_const {s : set α} {c : β} : continuous_on (λx, c) s :=
 continuous_const.continuous_on

--- a/src/topology/local_homeomorph.lean
+++ b/src/topology/local_homeomorph.lean
@@ -540,7 +540,8 @@ end
 
 end continuity
 
-/-- If a local homeomorphism has source and target equal to univ, then it induces a homeomorphism. -/
+/-- If a local homeomorphism has source and target equal to univ, then it induces a homeomorphism
+between the whole spaces, expressed through the following definition. -/
 def to_homeomorph_of_source_eq_univ_target_eq_univ (h : e.source = (univ : set α))
   (h' : e.target = univ) : homeomorph α β :=
 { to_fun := e.to_fun,
@@ -558,12 +559,10 @@ def to_homeomorph_of_source_eq_univ_target_eq_univ (h : e.source = (univ : set �
     rw h'
   end }
 
-@[simp] lemma to_homeomorph_to_fun (h : e.source = (univ : set α))
-  (h' : e.target = univ) :
+@[simp] lemma to_homeomorph_to_fun (h : e.source = (univ : set α)) (h' : e.target = univ) :
   (e.to_homeomorph_of_source_eq_univ_target_eq_univ h h').to_fun = e.to_fun := rfl
 
-@[simp] lemma to_homeomorph_inv_fun (h : e.source = (univ : set α))
-  (h' : e.target = univ) :
+@[simp] lemma to_homeomorph_inv_fun (h : e.source = (univ : set α)) (h' : e.target = univ) :
   (e.to_homeomorph_of_source_eq_univ_target_eq_univ h h').inv_fun = e.inv_fun := rfl
 
 end local_homeomorph

--- a/src/topology/local_homeomorph.lean
+++ b/src/topology/local_homeomorph.lean
@@ -445,7 +445,7 @@ begin
     rw ← this at f_cont,
     have : e.source ∈ nhds (e.inv_fun x) := mem_nhds_sets e.open_source (e.map_target h),
     rw [← continuous_within_at_inter this, inter_comm],
-    apply continuous_within_at.comp f_cont
+    exact continuous_within_at.comp f_cont
       ((e.continuous_at_to_fun (e.map_target h)).continuous_within_at) (inter_subset_right _ _) },
   { assume fe_cont,
     have : continuous_within_at ((f ∘ e.to_fun) ∘ e.inv_fun) (s ∩ e.target) x,
@@ -487,7 +487,7 @@ begin
     exact fe_cont _ (by simp [hx, h hx, e.map_target (h hx)]) }
 end
 
-/-- Continuity within a set at a point can be read under right composition with a local
+/-- Continuity within a set at a point can be read under leftt composition with a local
 homeomorphism if a neighborhood of the initial point is sent to the source of the local
 homeomorphism-/
 lemma continuous_within_at_iff_continuous_within_at_comp_left
@@ -507,7 +507,7 @@ begin
     exact this.congr (λy hy, by simp [e.left_inv hy.2]) (by simp [e.left_inv hx]) }
 end
 
-/-- Continuity at a point can be read under right composition with a local homeomorphism if a
+/-- Continuity at a point can be read under leftt composition with a local homeomorphism if a
 neighborhood of the initial point is sent to the source of the local homeomorphism-/
 lemma continuous_at_iff_continuous_at_comp_left
   {f : γ → α} {x : γ} (h : f ⁻¹' e.source ∈ nhds x) :
@@ -541,7 +541,7 @@ end
 end continuity
 
 /-- If a local homeomorphism has source and target equal to univ, then it induces a homeomorphism
-between the whole spaces, expressed through the following definition. -/
+between the whole spaces, expressed in this definition. -/
 def to_homeomorph_of_source_eq_univ_target_eq_univ (h : e.source = (univ : set α))
   (h' : e.target = univ) : homeomorph α β :=
 { to_fun := e.to_fun,

--- a/src/topology/local_homeomorph.lean
+++ b/src/topology/local_homeomorph.lean
@@ -487,7 +487,7 @@ begin
     exact fe_cont _ (by simp [hx, h hx, e.map_target (h hx)]) }
 end
 
-/-- Continuity within a set at a point can be read under leftt composition with a local
+/-- Continuity within a set at a point can be read under left composition with a local
 homeomorphism if a neighborhood of the initial point is sent to the source of the local
 homeomorphism-/
 lemma continuous_within_at_iff_continuous_within_at_comp_left
@@ -507,7 +507,7 @@ begin
     exact this.congr (λy hy, by simp [e.left_inv hy.2]) (by simp [e.left_inv hx]) }
 end
 
-/-- Continuity at a point can be read under leftt composition with a local homeomorphism if a
+/-- Continuity at a point can be read under left composition with a local homeomorphism if a
 neighborhood of the initial point is sent to the source of the local homeomorphism-/
 lemma continuous_at_iff_continuous_at_comp_left
   {f : γ → α} {x : γ} (h : f ⁻¹' e.source ∈ nhds x) :


### PR DESCRIPTION
A grab bag of small additions that I need in further developments. I don't really think it makes sense to split it into several smaller PRs, but if you insist I will. 

The main change is the reformulation of the subset condition for composition. For instance, for `continuous_on`, the condition for continuity of the composition of `f` (continuous on `s`) and `g` (continuous on `t`) was `f '' s ⊆ t`. I change it everywhere to `s ⊆ f ⁻¹' t`, which is equivalent but computes a lot better (belonging to the image is something complicated, with an existential quantifier, while belonging to the preimage is much simpler). This opened the way to much better simp automation for manifolds.