### PR TITLE
fix(topology/metric_space): fix uniform structure on Pi types

### DIFF
--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -1482,15 +1482,17 @@ finset.induction_on s (λ _, bot_le) (λ n s hns ih H,
   by simp only [mem_insert, or_imp_distrib, forall_and_distrib, forall_eq] at H;
      simp only [sup_insert]; exact sup_le H.1 (ih H.2))
 
-lemma sup_le_iff {a : α} : s.sup f ≤ a ↔ (∀b ∈ s, f b ≤ a) :=
+@[simp] lemma sup_le_iff {a : α} : s.sup f ≤ a ↔ (∀b ∈ s, f b ≤ a) :=
 iff.intro (assume h b hb, le_trans (le_sup hb) h) sup_le
 
 lemma sup_mono (h : s₁ ⊆ s₂) : s₁.sup f ≤ s₂.sup f :=
 sup_le $ assume b hb, le_sup (h hb)
 
-lemma sup_lt [is_total α (≤)] {a : α} : (⊥ < a) → (∀b ∈ s, f b < a) → s.sup f < a :=
+@[simp] lemma sup_lt_iff [is_total α (≤)] {a : α} (ha : ⊥ < a) :
+  s.sup f < a ↔ (∀b ∈ s, f b < a) :=
 by letI := classical.dec_eq β; from
-finset.induction_on s (by simp) (by simp {contextual := tt})
+⟨ λh b hb, lt_of_le_of_lt (le_sup hb) h,
+  finset.induction_on s (by simp [ha]) (by simp {contextual := tt}) ⟩
 
 lemma comp_sup_eq_sup_comp [is_total α (≤)] {γ : Type} [semilattice_sup_bot γ]
   (g : α → γ) (mono_g : monotone g) (bot : g ⊥ = ⊥) : g (s.sup f) = s.sup (g ∘ f) :=

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -127,6 +127,10 @@ finite.induction_on hf
     have h₂ : (⋂x∈is, s x) ∈ f, from hi $ assume a ha, hs _ $ by simp only [ha, mem_insert_iff, or_true],
     by simp [inter_mem_sets h₁ h₂])
 
+lemma Inter_mem_sets_of_fintype {β : Type v} {s : β → set α} [fintype β] (h : ∀i, s i ∈ f) :
+  (⋂i, s i) ∈ f :=
+by simpa using Inter_mem_sets finite_univ (λi hi, h i)
+
 lemma exists_sets_subset_iff : (∃t ∈ f, t ⊆ s) ↔ s ∈ f :=
 ⟨assume ⟨t, ht, ts⟩, mem_sets_of_superset ht ts, assume hs, ⟨s, hs, subset.refl _⟩⟩
 
@@ -544,6 +548,24 @@ begin
   rintros x ⟨hx, xt⟩,
   exact hx xt
 end
+
+@[simp] lemma infi_principal_finset {ι : Type w} (s : finset ι) (f : ι → set α) :
+  (⨅i∈s, principal (f i)) = principal (⋂i∈s, f i) :=
+begin
+  ext t,
+  simp [mem_infi_sets_finset],
+  split,
+  { rintros ⟨p, hp, ht⟩,
+    calc (⋂ (i : ι) (H : i ∈ s), f i) ≤ (⋂ (i : ι) (H : i ∈ s), p i) :
+      infi_le_infi (λi, infi_le_infi (λhi, mem_principal_sets.1 (hp i hi)))
+    ... ≤ t : ht },
+  { assume h,
+    exact ⟨f, λi hi, subset.refl _, h⟩ }
+end
+
+@[simp] lemma infi_principal_fintype {ι : Type w} [fintype ι] (f : ι → set α) :
+  (⨅i, principal (f i)) = principal (⋂i, f i) :=
+by simpa using infi_principal_finset finset.univ f
 
 end lattice
 

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -9,7 +9,7 @@ Many definitions and theorems expected on metric spaces are already introduced o
 topological spaces. For example:
   open and closed sets, compactness, completeness, continuity and uniform continuity
 -/
-import data.real.nnreal topology.metric_space.emetric_space topology.algebra.ordered topology.uniform_space.pi
+import data.real.nnreal topology.metric_space.emetric_space topology.algebra.ordered
 open lattice set filter classical topological_space
 noncomputable theory
 
@@ -868,16 +868,19 @@ instance metric_space_pi : metric_space (Πb, π b) :=
   end,
   to_uniform_space := Pi.uniform_space _,
   uniformity_dist := begin
-    simp [Pi.uniformity, uniformity_dist, comap_infi],
+    -- with simp only on next line, the proof fails for no reason...
+    simp [Pi.uniformity, uniformity_dist, comap_infi, comap_infi, gt_iff_lt, preimage_set_of_eq,
+          comap_principal],
     rw infi_comm, congr, funext ε,
     rw infi_comm, congr, funext εpos,
-    simp [ext_iff, εpos, dist],
+    simp only [ext_iff, εpos, dist, principal_eq_iff_eq, prod.forall, mem_Inter, mem_set_of_eq,
+               infi_principal_fintype],
     assume a b,
     let ε' : nnreal := ⟨ε, le_of_lt εpos⟩,
     have A : ε' = nnreal.of_real ε, by simp [nnreal.of_real, ε', le_of_lt εpos],
     change (∀ (i : β), dist (a i) (b i) < ε) ↔ (sup univ (λ (i : β), nndist (a i) (b i))) < ε',
     simp only [finset.sup_lt_iff (show ⊥ < ε', from εpos)],
-    simp [nndist_dist, A, εpos]
+    simp [nndist_dist, A, εpos],
   end }
 
 end pi

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -9,7 +9,7 @@ Many definitions and theorems expected on metric spaces are already introduced o
 topological spaces. For example:
   open and closed sets, compactness, completeness, continuity and uniform continuity
 -/
-import data.real.nnreal topology.metric_space.emetric_space topology.algebra.ordered
+import data.real.nnreal topology.metric_space.emetric_space topology.algebra.ordered topology.uniform_space.pi
 open lattice set filter classical topological_space
 noncomputable theory
 
@@ -865,6 +865,19 @@ instance metric_space_pi : metric_space (Πb, π b) :=
     { refine eq.symm (comp_sup_eq_sup_comp _ _ _),
       exact (assume x y h, ennreal.coe_le_coe.2 h), refl },
     simp [dist, edist_nndist, ennreal.of_real, A]
+  end,
+  to_uniform_space := Pi.uniform_space _,
+  uniformity_dist := begin
+    simp [Pi.uniformity, uniformity_dist, comap_infi],
+    rw infi_comm, congr, funext ε,
+    rw infi_comm, congr, funext εpos,
+    simp [ext_iff, εpos, dist],
+    assume a b,
+    let ε' : nnreal := ⟨ε, le_of_lt εpos⟩,
+    have A : ε' = nnreal.of_real ε, by simp [nnreal.of_real, ε', le_of_lt εpos],
+    change (∀ (i : β), dist (a i) (b i) < ε) ↔ (sup univ (λ (i : β), nndist (a i) (b i))) < ε',
+    simp only [finset.sup_lt_iff (show ⊥ < ε', from εpos)],
+    simp [nndist_dist, A, εpos]
   end }
 
 end pi

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -310,11 +310,11 @@ instance emetric_space_pi [∀b, emetric_space (π b)] : emetric_space (Πb, π 
     end,
   to_uniform_space := Pi.uniform_space _,
   uniformity_edist := begin
-    -- with simp only on next line, the proof fails for no reason...
-    simp [Pi.uniformity, emetric_space.uniformity_edist, comap_infi, gt_iff_lt, preimage_set_of_eq,
+    simp only [Pi.uniformity, emetric_space.uniformity_edist, comap_infi, gt_iff_lt, preimage_set_of_eq,
           comap_principal],
     rw infi_comm, congr, funext ε,
     rw infi_comm, congr, funext εpos,
+    change 0 < ε at εpos,
     simp [ext_iff, εpos]
   end }
 

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -18,7 +18,7 @@ The class `emetric_space` therefore extends `uniform_space` (and `topological_sp
 
 import data.real.nnreal data.real.ennreal
 import topology.uniform_space.separation topology.uniform_space.uniform_embedding topology.uniform_space.pi
-import topology.bases tactic.tidy
+import topology.bases
 open lattice set filter classical
 noncomputable theory
 
@@ -310,7 +310,9 @@ instance emetric_space_pi [∀b, emetric_space (π b)] : emetric_space (Πb, π 
     end,
   to_uniform_space := Pi.uniform_space _,
   uniformity_edist := begin
-    simp [Pi.uniformity, emetric_space.uniformity_edist, comap_infi],
+    -- with simp only on next line, the proof fails for no reason...
+    simp [Pi.uniformity, emetric_space.uniformity_edist, comap_infi, gt_iff_lt, preimage_set_of_eq,
+          comap_principal],
     rw infi_comm, congr, funext ε,
     rw infi_comm, congr, funext εpos,
     simp [ext_iff, εpos]

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -17,8 +17,8 @@ The class `emetric_space` therefore extends `uniform_space` (and `topological_sp
 -/
 
 import data.real.nnreal data.real.ennreal
-import topology.uniform_space.separation topology.uniform_space.uniform_embedding
-import topology.bases
+import topology.uniform_space.separation topology.uniform_space.uniform_embedding topology.uniform_space.pi
+import topology.bases tactic.tidy
 open lattice set filter classical
 noncomputable theory
 
@@ -307,7 +307,14 @@ instance emetric_space_pi [∀b, emetric_space (π b)] : emetric_space (Πb, π 
       have eq1 : sup univ (λ (b : β), edist (f b) (g b)) ≤ 0 := le_of_eq eq0,
       simp only [finset.sup_le_iff] at eq1,
       exact (funext $ assume b, eq_of_edist_eq_zero $ bot_unique $ eq1 b $ mem_univ b),
-    end }
+    end,
+  to_uniform_space := Pi.uniform_space _,
+  uniformity_edist := begin
+    simp [Pi.uniformity, emetric_space.uniformity_edist, comap_infi],
+    rw infi_comm, congr, funext ε,
+    rw infi_comm, congr, funext εpos,
+    simp [ext_iff, εpos]
+  end }
 
 end pi
 


### PR DESCRIPTION
The uniform structure induced from a metric space structure on a Pi type is currently not defeq to the product uniform structure. This is fixed in this PR. Before the PR,
```lean
lemma diamond {n : ℕ} : is_open (pi (univ : set (fin n)) (λi, (univ : set ℝ))) :=
begin
  have A : finite (univ : set (fin n)) := finite_univ,
  have B : ∀i : fin n, i ∈ univ → is_open (univ : set ℝ) := λi hi, is_open_univ,
  convert is_open_set_pi A B,
end
```
leaves the goal `uniform_space.to_topological_space (fin n → ℝ) = Pi.topological_space`. After the PR, there is no goal left.