### PR TITLE
feat(field_theory/finite): cardinality of images of polynomials

### DIFF
--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -429,6 +429,17 @@ finset.induction_on s (by simp)
     ... ≤ (insert a s).sum (λ a, card (t a)) :
     by rw sum_insert has; exact add_le_add_left ih _)
 
+theorem card_eq_sum_card_image [decidable_eq β] (f : α → β) (s : finset α) :
+  s.card = (s.image f).sum (λ a, (s.filter (λ x, f x = a)).card) :=
+by letI := classical.dec_eq α; exact
+calc s.card = ((s.image f).bind (λ a, s.filter (λ x, f x = a))).card :
+  congr_arg _ (finset.ext.2 $ λ x,
+    ⟨λ hs, mem_bind.2 ⟨f x, mem_image_of_mem _ hs,
+      mem_filter.2 ⟨hs, rfl⟩⟩,
+    λ h, let ⟨a, ha₁, ha₂⟩ := mem_bind.1 h in by convert filter_subset s ha₂⟩)
+... = (s.image f).sum (λ a, (s.filter (λ x, f x = a)).card) :
+  card_bind (by simp [disjoint_left, finset.ext] {contextual := tt})
+
 lemma gsmul_sum [add_comm_group β] {f : α → β} {s : finset α} (z : ℤ) :
   gsmul z (s.sum f) = s.sum (λa, gsmul z (f a)) :=
 (finset.sum_hom (gsmul z)).symm
@@ -612,6 +623,14 @@ end linear_ordered_comm_ring
   (s : finset α) (t : Π a, finset (δ a)) :
   (s.pi t).card = s.prod (λ a, card (t a)) :=
 multiset.card_pi _ _
+
+theorem card_le_mul_card_image [decidable_eq β] {f : α → β} (s : finset α)
+  (n : ℕ) (hn : ∀ a ∈ s.image f, (s.filter (λ x, f x = a)).card ≤ n) :
+  s.card ≤ n * (s.image f).card :=
+calc s.card = (s.image f).sum (λ a, (s.filter (λ x, f x = a)).card) :
+  card_eq_sum_card_image _ _
+... ≤ (s.image f).sum (λ _, n) : sum_le_sum hn
+... = _ : by simp [mul_comm]
 
 @[simp] lemma prod_range_id_eq_fact (n : ℕ) : ((range n.succ).erase 0).prod (λ x, x) = nat.fact n :=
 calc ((range n.succ).erase 0).prod (λ x, x) = (range n).prod nat.succ :

--- a/src/data/polynomial.lean
+++ b/src/data/polynomial.lean
@@ -1258,6 +1258,9 @@ eval₂.is_ring_hom (C ∘ f)
 @[simp] lemma degree_neg (p : polynomial α) : degree (-p) = degree p :=
 by unfold degree; rw support_neg
 
+@[simp] lemma nat_degree_neg (p : polynomial α) : nat_degree (-p) = nat_degree p :=
+by simp [nat_degree]
+
 @[simp] lemma nat_degree_int_cast (n : ℤ) : nat_degree (n : polynomial α) = 0 :=
 by simp [int_cast_eq_C]
 

--- a/src/data/polynomial.lean
+++ b/src/data/polynomial.lean
@@ -653,6 +653,9 @@ le_antisymm (max_eq_right_of_lt h ▸ degree_add_le _ _) $ degree_le_degree $
     exact mt leading_coeff_eq_zero.1 (ne_zero_of_degree_gt h)
   end
 
+lemma degree_add_C (hp : 0 < degree p) : degree (p + C a) = degree p :=
+add_comm (C a) p ▸ degree_add_eq_of_degree_lt $ lt_of_le_of_lt degree_C_le hp
+
 lemma degree_add_eq_of_leading_coeff_add_ne_zero (h : leading_coeff p + leading_coeff q ≠ 0) :
   degree (p + q) = max p.degree q.degree :=
 le_antisymm (degree_add_le _ _) $
@@ -1843,8 +1846,25 @@ end
 lemma card_roots' {p : polynomial α} (hp0 : p ≠ 0) : p.roots.card ≤ nat_degree p :=
 with_bot.coe_le_coe.1 (le_trans (card_roots hp0) (le_of_eq $ degree_eq_nat_degree hp0))
 
+lemma card_roots_sub_C {p : polynomial α} {a : α} (hp0 : 0 < degree p) :
+  ((p - C a).roots.card : with_bot ℕ) ≤ degree p :=
+calc ((p - C a).roots.card : with_bot ℕ) ≤ degree (p - C a) :
+  card_roots $ mt sub_eq_zero.1 $ λ h, not_le_of_gt hp0 $ h.symm ▸ degree_C_le
+... = degree p : by rw [sub_eq_add_neg, ← C_neg]; exact degree_add_C hp0
+
+lemma card_roots_sub_C' {p : polynomial α} {a : α} (hp0 : 0 < degree p) :
+  (p - C a).roots.card ≤ nat_degree p :=
+with_bot.coe_le_coe.1 (le_trans (card_roots_sub_C hp0) (le_of_eq $ degree_eq_nat_degree
+  (λ h, by simp [*, lt_irrefl] at *)))
+
 @[simp] lemma mem_roots (hp : p ≠ 0) : a ∈ p.roots ↔ is_root p a :=
 by unfold roots; rw dif_neg hp; exact (classical.some_spec (exists_finset_roots hp)).2 _
+
+@[simp] lemma mem_roots_sub_C {p : polynomial α} {a x : α} (hp0 : 0 < degree p) :
+  x ∈ (p - C a).roots ↔ p.eval x = a :=
+(mem_roots (show p - C a ≠ 0, from mt sub_eq_zero.1 $ λ h,
+    not_le_of_gt hp0 $ h.symm ▸ degree_C_le)).trans
+  (by rw [is_root.def, eval_sub, eval_C, sub_eq_zero])
 
 lemma card_roots_X_pow_sub_C {n : ℕ} (hn : 0 < n) (a : α) :
   (roots ((X : polynomial α) ^ n - C a)).card ≤ n :=

--- a/src/field_theory/finite.lean
+++ b/src/field_theory/finite.lean
@@ -61,30 +61,28 @@ finset.card_le_mul_card_image _ _
 lemma exists_root_sum_quadratic {f g : polynomial α} (hf2 : degree f = 2)
   (hg2 : degree g = 2) (hα : fintype.card α % 2 = 1) : ∃ a b, f.eval a + g.eval b = 0 :=
 by letI := classical.dec_eq α; exact
-have ∀ f : polynomial α, degree f = 2 →
-    fintype.card α ≤ 2 * (univ.image (λ x : α, eval x f)).card,
-  from λ f hf, have hf0 : f ≠ 0, from λ h, by simp * at *; contradiction,
-    calc fintype.card α ≤ nat_degree f * (univ.image (λ x, eval x f)).card :
-      card_image_polynomial_eval (hf.symm ▸ dec_trivial)
-    ... = _ : by rw [degree_eq_nat_degree hf0, show (2 : with_bot ℕ) = (2 : ℕ), from rfl,
-      with_bot.coe_eq_coe] at hf; rw hf,
-have ∀ f : polynomial α, degree f = 2 →
-    fintype.card α < 2 * (univ.image (λ x : α, eval x f)).card,
-  from λ f hf, lt_of_le_of_ne (this _ hf) (mt (congr_arg (% 2)) (by simp *)),
-have h : fintype.card α < (univ.image (λ x : α, eval x f)).card +
-    (univ.image (λ x : α, eval x (-g))).card,
-  from (mul_lt_mul_left (show 2 > 0, by norm_num)).1 $
-    by rw [two_mul, mul_add]; exact add_lt_add (this _ hf2) (this _ (by simpa)),
-have hd : ¬ disjoint (univ.image (λ x : α, eval x f)) (univ.image (λ x : α, eval x (-g))),
-  from λ hd, by rw [← card_disjoint_union hd, ← not_le] at h;
-    exact h (card_le_of_subset $ subset_univ _),
+suffices ¬ disjoint (univ.image (λ x : α, eval x f)) (univ.image (λ x : α, eval x (-g))),
 begin
-  simp only [disjoint_left, mem_image] at hd,
-  push_neg at hd,
-  rcases hd with ⟨x, ⟨a, _, ha⟩, ⟨b, _, hb⟩⟩,
-  use [a, b],
-  rw [ha, ← hb, eval_neg, neg_add_self]
-end
+  simp only [disjoint_left, mem_image] at this,
+  push_neg at this,
+  rcases this with ⟨x, ⟨a, _, ha⟩, ⟨b, _, hb⟩⟩,
+  exact ⟨a, b, by rw [ha, ← hb, eval_neg, neg_add_self]⟩
+end,
+assume hd : disjoint _ _,
+lt_irrefl (2 * ((univ.image (λ x : α, eval x f)) ∪ (univ.image (λ x : α, eval x (-g)))).card) $
+calc 2 * ((univ.image (λ x : α, eval x f)) ∪ (univ.image (λ x : α, eval x (-g)))).card
+    ≤ 2 * fintype.card α : nat.mul_le_mul_left _ (finset.card_le_of_subset (subset_univ _))
+... = fintype.card α + fintype.card α : two_mul _
+... < nat_degree f * (univ.image (λ x : α, eval x f)).card +
+      nat_degree (-g) * (univ.image (λ x : α, eval x (-g))).card :
+    add_lt_add_of_lt_of_le
+      (lt_of_le_of_ne
+        (card_image_polynomial_eval (by rw hf2; exact dec_trivial))
+        (mt (congr_arg (%2)) (by simp [nat_degree_eq_of_degree_eq_some hf2, hα])))
+      (card_image_polynomial_eval (by rw [degree_neg, hg2]; exact dec_trivial))
+... = 2 * (univ.image (λ x : α, eval x f) ∪ univ.image (λ x : α, eval x (-g))).card :
+  by rw [card_disjoint_union hd]; simp [nat_degree_eq_of_degree_eq_some hf2,
+    nat_degree_eq_of_degree_eq_some hg2, bit0, mul_add]
 
 end polynomial
 

--- a/src/field_theory/finite.lean
+++ b/src/field_theory/finite.lean
@@ -48,6 +48,8 @@ variables [fintype α] [integral_domain α]
 
 open finset polynomial
 
+/-- The cardinality of a field is at most n times the cardinality of the image of a degree n
+  polnyomial -/
 lemma card_image_polynomial_eval [decidable_eq α] {p : polynomial α} (hp : 0 < p.degree) :
   fintype.card α ≤ nat_degree p * (univ.image (λ x, eval x p)).card :=
 have hdp : ∀ {a : α}, degree p = degree (p - C a),
@@ -75,7 +77,8 @@ calc fintype.card α = fintype.card (Σ a : set.range (λ x, eval x p), {x // p.
   sum_le_sum (λ a _, by rw [nat_degree_eq_of_degree_eq (@hdp a)]; exact card_roots' (@hp0 a))
 ... = _ : by rw [sum_const, add_monoid.smul_eq_mul', nat.cast_id]
 
-lemma exists_root_sum_quadratic (f g : polynomial α) (hf2 : degree f = 2)
+/-- If `f` and `g` are quadratic polynomials, then the `f.eval a + g.eval b = 0` has a solution. -/
+lemma exists_root_sum_quadratic {f g : polynomial α} (hf2 : degree f = 2)
   (hg2 : degree g = 2) (hα : fintype.card α % 2 = 1) : ∃ a b, f.eval a + g.eval b = 0 :=
 by letI := classical.dec_eq α; exact
 have ∀ f : polynomial α, degree f = 2 →

--- a/src/field_theory/finite.lean
+++ b/src/field_theory/finite.lean
@@ -52,30 +52,10 @@ open finset polynomial
   polnyomial -/
 lemma card_image_polynomial_eval [decidable_eq α] {p : polynomial α} (hp : 0 < p.degree) :
   fintype.card α ≤ nat_degree p * (univ.image (λ x, eval x p)).card :=
-have hdp : ∀ {a : α}, degree p = degree (p - C a),
-  from λ a, eq.symm $ by rw [sub_eq_add_neg, add_comm]; exact
-    degree_add_eq_of_degree_lt
-      (show degree (-C a) < degree p, by rw degree_neg;
-        exact lt_of_le_of_lt (degree_C_le) hp),
-have hp0 : ∀ {a : α}, p - C a ≠ 0, from λ a h, by rw [@hdp a, h] at hp; simp * at *,
-have hroots : ∀ {x a : α}, x ∈ (p - C a).roots ↔ p.eval x = a,
-  from λ _ _, by rw [mem_roots hp0, is_root, eval_sub, eval_C, sub_eq_zero],
-calc fintype.card α = fintype.card (Σ a : set.range (λ x, eval x p), {x // p.eval x = a}) :
-  fintype.card_congr (equiv.sigma_subtype_preimage_equiv _
-    (set.range (λ x, eval x p)) (set.mem_range_self : _)).symm
-... = univ.sum (λ a : set.range (λ x, eval x p), fintype.card {x // p.eval x = a}) :
-  fintype.card_sigma _
-... = (univ.image (λ x, eval x p)).sum (λ a, (p - C a).roots.card) :
-  finset.sum_bij (λ a _, a)
-    (λ ⟨a, x, hx⟩ _, mem_image.2 ⟨x, mem_univ _, hx⟩)
-    (λ ⟨a, ha⟩ _, finset.card_congr (λ a _, a.val) (λ ⟨x, hx⟩ _, by rwa hroots)
-      (λ _ _ _ _, subtype.ext.2)
-      (λ x hx, ⟨⟨x, by rwa ← hroots⟩, mem_univ _, rfl⟩))
-    (λ _ _ _ _, subtype.ext.2)
-    (λ x, by rw [mem_image]; exact λ ⟨a, _, ha⟩, ⟨⟨x, ⟨a, ha⟩⟩, mem_univ _, rfl⟩)
-... ≤ (univ.image (λ x, eval x p)).sum (λ _, p.nat_degree) :
-  sum_le_sum (λ a _, by rw [nat_degree_eq_of_degree_eq (@hdp a)]; exact card_roots' (@hp0 a))
-... = _ : by rw [sum_const, add_monoid.smul_eq_mul', nat.cast_id]
+finset.card_le_mul_card_image _ _
+  (λ a _, calc _ = (p - C a).roots.card : congr_arg card
+    (by simp [finset.ext, mem_roots_sub_C hp, -sub_eq_add_neg])
+    ... ≤ _ : card_roots_sub_C' hp)
 
 /-- If `f` and `g` are quadratic polynomials, then the `f.eval a + g.eval b = 0` has a solution. -/
 lemma exists_root_sum_quadratic {f g : polynomial α} (hf2 : degree f = 2)


### PR DESCRIPTION
One lemma about the cardinality of images of polynomials of roots of polynomials, and another about existence of roots of polynomials of a particular form over finite fields of odd cardinality.

These lemmas were used in a proof of the four squares theorem (every natural number is the sum of four squares, on Freek's list). They're difficult lemmas for the library, because they're not really textbook theorems, or theorems you might expect to find, but they still might be useful.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
