### PR TITLE
chore(meta/rb_map,tactic/monotonicity): replace rb_map.insert_cons

### DIFF
--- a/src/meta/rb_map.lean
+++ b/src/meta/rb_map.lean
@@ -40,11 +40,6 @@ Otherwise it returns `default`. -/
 meta def find_def {key value} (default : value) (m : rb_map key value) (k : key) :=
 (m.find k).get_or_else default
 
-/-- `insert_cons k x m` adds `x` to the list corresponding to key `k`. -/
-meta def insert_cons {key value} [has_lt key] (k : key) (x : value) (m : rb_map key (list value)) :
-  rb_map key (list value) :=
-m.insert k (x :: m.find_def [] k)
-
 /-- `ifind m key` returns the value corresponding to `key` in `m`, if it exists.
 Otherwise it returns the default value of `value`. -/
 meta def ifind {key value} [inhabited value] (m : rb_map key value) (k : key) : value :=

--- a/src/tactic/monotonicity/basic.lean
+++ b/src/tactic/monotonicity/basic.lean
@@ -122,7 +122,7 @@ open function
 
 @[user_attribute]
 meta def monotonicity.attr : user_attribute
-  (native.rb_map mono_key (list name))
+  (native.rb_lmap mono_key (name))
   (option mono_key × mono_selection) :=
 { name  := `mono
 , descr := "monotonicity of function `f` wrt relations `R₀` and `R₁`: R₀ x y → R₁ (f x) (f y)"
@@ -132,8 +132,8 @@ meta def monotonicity.attr : user_attribute
     do ps ← ls.mmap monotonicity.attr.get_param,
        let ps := ps.filter_map prod.fst,
        pure $ (ps.zip ls).foldl
-         (flip $ uncurry native.rb_map.insert_cons)
-         (native.rb_map.mk mono_key _)  }
+         (flip $ uncurry (λ k n m, m.insert k n))
+         (native.rb_lmap.mk mono_key _)  }
 , after_set := some $ λ n prio p,
   do { (none,v) ← monotonicity.attr.get_param n | pure (),
        k ← monotoncity.check n prio p,


### PR DESCRIPTION
@fpvandoorn pointed this out in #1556 . The type of list-valued rb_maps is already defined, so this function should not be used.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
