### PR TITLE
style(*): use notation `𝓝` for `nhds`

### DIFF
--- a/docs/contribute/style.md
+++ b/docs/contribute/style.md
@@ -290,7 +290,7 @@ focussing braces and indented. Braces are not alone on their line.
 
 ```lean
 lemma mem_nhds_of_is_topological_basis {a : α} {s : set α} {b : set (set α)}
-  (hb : is_topological_basis b) : s ∈ (nhds a).sets ↔ ∃t∈b, a ∈ t ∧ t ⊆ s :=
+  (hb : is_topological_basis b) : s ∈ (𝓝 a).sets ↔ ∃t∈b, a ∈ t ∧ t ⊆ s :=
 begin
   rw [hb.2.2, nhds_generate_from, infi_sets_eq'],
   { simpa [and_comm, and.left_comm] },

--- a/docs/theories/topology.md
+++ b/docs/theories/topology.md
@@ -86,16 +86,16 @@ Informally, one can think of `F` as the set of "big" subsets of `X`. For example
 
 Note that if `F` is a filter that contains the empty set, then it contains all subsets of `X` by the first axiom. This filter is sometimes called "bottom" (we will see why a little later on). Some references demand that the empty set is not allowed to be in a filter -- Lean does not have this restriction. A filter not containing the empty set is sometimes called a "proper filter".
 
-If `X` is a topological space, and `x ∈ X`, then the _neighbourhood filter_ `nhds x` of `x` is the set of subsets `Y` of `X` such that `x` is in the interior of `Y`. One checks easily that this is a filter (technical point: to see that this is actually the definition of `nhds x` in mathlib, it helps to know that the set of all filters on a type is a complete lattice, partially ordered using `F ≤ G` iff `G ⊆ F`, so the definition, which involves an inf, is actually a union; also, the definition I give is not literally the definition in mathlib, but `lemma nhds_sets` says that their definition is the one here. Note also that this is why the filter with the most sets is called bottom!).
+If `X` is a topological space, and `x ∈ X`, then the _neighbourhood filter_ `𝓝 x` of `x` is the set of subsets `Y` of `X` such that `x` is in the interior of `Y`. One checks easily that this is a filter (technical point: to see that this is actually the definition of `𝓝 x` in mathlib, it helps to know that the set of all filters on a type is a complete lattice, partially ordered using `F ≤ G` iff `G ⊆ F`, so the definition, which involves an inf, is actually a union; also, the definition I give is not literally the definition in mathlib, but `lemma nhds_sets` says that their definition is the one here. Note also that this is why the filter with the most sets is called bottom!).
 
-Why are we interested in these filters? Well, given a map `f` from `ℕ` to a topological space `X`, one can check that the resulting sequence `f 0`, `f 1`, `f 2`... tends to `x ∈ F` if and only if the pre-image of any element in the filter `nhds x` is in the cofinite filter on `ℕ` -- this is just another way of saying that given any open set `U` containing `x`, there exists `N` such that for all `n ≥ N`, `f n ∈ U`. So filters provide a way of thinking about limits.
+Why are we interested in these filters? Well, given a map `f` from `ℕ` to a topological space `X`, one can check that the resulting sequence `f 0`, `f 1`, `f 2`... tends to `x ∈ F` if and only if the pre-image of any element in the filter `𝓝 x` is in the cofinite filter on `ℕ` -- this is just another way of saying that given any open set `U` containing `x`, there exists `N` such that for all `n ≥ N`, `f n ∈ U`. So filters provide a way of thinking about limits.
 
 The _principal filter_ `principal Y` attached to a subset `Y` of a set `X` is the collection of all subsets of `X` that contain `Y`. So it's not difficult to convince yourself that the following results should be true:
 
 ```lean
-example : interior Y = {x | nhds x ≤ filter.principal Y} := interior_eq_nhds
+example : interior Y = {x | 𝓝 x ≤ filter.principal Y} := interior_eq_nhds
 
-example : is_open Y ↔ ∀ y ∈ Y, Y ∈ (nhds y).sets := is_open_iff_mem_nhds
+example : is_open Y ↔ ∀ y ∈ Y, Y ∈ (𝓝 y).sets := is_open_iff_mem_nhds
 ```
 
 ### Compactness with filters
@@ -109,7 +109,7 @@ of compactness is also written in filter-theoretic terms:
 ```lean
 /-- A set `s` is compact if every filter that contains `s` also meets every
   neighborhood of some `a ∈ s`. -/
-def compact (Y : set X) := ∀F, F ≠ ⊥ → F ≤ principal Y → ∃y∈Y, F ⊓ nhds y ≠ ⊥
+def compact (Y : set X) := ∀F, F ≠ ⊥ → F ≤ principal Y → ∃y∈Y, F ⊓ 𝓝 y ≠ ⊥
 ```
 
 Translated, this says that a subset `Y` of a topological space `X` is compact if for every proper filter `F` on `X`, if `Y` is an element of `F` then there's an element `y` of `Y` such that the smallest filter containing both F and the neighbourhood filter of `y` is not the filter of all subsets of `X` either. This should be thought of as being the correct general analogue of the Bolzano-Weierstrass theorem, that in a compact subspace of `ℝ^n`, any sequence has a convergent subsequence.
@@ -137,7 +137,7 @@ Of course Hausdorffness is what we need to ensure that limits are unique, but be
 
 ```lean
 lemma tendsto_nhds_unique [t2_space X] {f : β → X} {l : filter β} {x y : X}
-  (hl : l ≠ ⊥) (hx : tendsto f l (nhds x)) (hb : tendsto f l (nhds y)) : x = y
+  (hl : l ≠ ⊥) (hx : tendsto f l (𝓝 x)) (hb : tendsto f l (𝓝 y)) : x = y
 ```
 
 Note that actually this statement is more general than the classical statement that if a sequence tends to two limits in a Hausdorff space then the limits are the same, because it applies to any non-trivial filter on any set rather than just the cofinite filter on the natural numbers.

--- a/src/analysis/asymptotics.lean
+++ b/src/analysis/asymptotics.lean
@@ -24,7 +24,7 @@ norm explicitly.
 If `f` and `g` are functions to a normed field like the reals or complex numbers and `g` is always
 nonzero, we have
 
-  `is_o f g l ↔ tendsto (λ x, f x / (g x)) (nhds 0) l`.
+  `is_o f g l ↔ tendsto (λ x, f x / (g x)) (𝓝 0) l`.
 
 In fact, the right-to-left direction holds without the hypothesis on `g`, and in the other direction
 it suffices to assume that `f` is zero wherever `g` is. (This generalization is useful in defining
@@ -32,6 +32,7 @@ the Fréchet derivative.)
 -/
 import analysis.normed_space.basic
 open filter
+open_locale topological_space
 
 namespace asymptotics
 
@@ -570,7 +571,7 @@ begin
 end
 
 theorem is_o_one_iff {f : α → β} {l : filter α} :
-  is_o f (λ x, (1 : γ)) l ↔ tendsto f l (nhds 0) :=
+  is_o f (λ x, (1 : γ)) l ↔ tendsto f l (𝓝 0) :=
 begin
   rw [normed_group.tendsto_nhds_zero, is_o], split,
   { intros h e epos,
@@ -584,12 +585,12 @@ begin
 end
 
 theorem is_O_one_of_tendsto {f : α → β} {l : filter α} {y : β}
-  (h : tendsto f l (nhds y)) : is_O f (λ x, (1 : γ)) l :=
+  (h : tendsto f l (𝓝 y)) : is_O f (λ x, (1 : γ)) l :=
 begin
   have Iy : ∥y∥ < ∥y∥ + 1 := lt_add_one _,
   refine ⟨∥y∥ + 1, lt_of_le_of_lt (norm_nonneg _) Iy, _⟩,
   simp only [mul_one, normed_field.norm_one],
-  have : tendsto (λx, ∥f x∥) l (nhds ∥y∥) :=
+  have : tendsto (λx, ∥f x∥) l (𝓝 ∥y∥) :=
     (continuous_norm.tendsto _).comp h,
   exact this (ge_mem_nhds Iy)
 end
@@ -600,12 +601,12 @@ section
 variables [normed_group β] [normed_group γ]
 
 theorem is_O.trans_tendsto {f : α → β} {g : α → γ} {l : filter α}
-    (h₁ : is_O f g l) (h₂ : tendsto g l (nhds 0)) :
-  tendsto f l (nhds 0) :=
+    (h₁ : is_O f g l) (h₂ : tendsto g l (𝓝 0)) :
+  tendsto f l (𝓝 0) :=
 (@is_o_one_iff _ _ ℝ _ _ _ _).1 $ h₁.trans_is_o $ is_o_one_iff.2 h₂
 
 theorem is_o.trans_tendsto {f : α → β} {g : α → γ} {l : filter α}
-  (h₁ : is_o f g l) : tendsto g l (nhds 0) → tendsto f l (nhds 0) :=
+  (h₁ : is_o f g l) : tendsto g l (𝓝 0) → tendsto f l (𝓝 0) :=
 h₁.to_is_O.trans_tendsto
 
 end
@@ -751,7 +752,7 @@ section
 variables [normed_field β]
 
 theorem tendsto_nhds_zero_of_is_o {f g : α → β} {l : filter α} (h : is_o f g l) :
-  tendsto (λ x, f x / (g x)) l (nhds 0) :=
+  tendsto (λ x, f x / (g x)) l (𝓝 0) :=
 have eq₁ : is_o (λ x, f x / g x) (λ x, g x / g x) l,
   from is_o_mul_right h (is_O_refl _ _),
 have eq₂ : is_O (λ x, g x / g x) (λ x, (1 : β)) l,
@@ -765,7 +766,7 @@ have eq₂ : is_O (λ x, g x / g x) (λ x, (1 : β)) l,
 is_o_one_iff.mp (eq₁.trans_is_O eq₂)
 
 private theorem is_o_of_tendsto {f g : α → β} {l : filter α}
-    (hgf : ∀ x, g x = 0 → f x = 0) (h : tendsto (λ x, f x / (g x)) l (nhds 0)) :
+    (hgf : ∀ x, g x = 0 → f x = 0) (h : tendsto (λ x, f x / (g x)) l (𝓝 0)) :
   is_o f g l :=
 have eq₁ : is_o (λ x, f x / (g x)) (λ x, (1 : β)) l,
   from is_o_one_iff.mpr h,
@@ -784,7 +785,7 @@ eq₃.trans_is_o eq₂
 
 theorem is_o_iff_tendsto {f g : α → β} {l : filter α}
     (hgf : ∀ x, g x = 0 → f x = 0) :
-  is_o f g l ↔ tendsto (λ x, f x / (g x)) l (nhds 0) :=
+  is_o f g l ↔ tendsto (λ x, f x / (g x)) l (𝓝 0) :=
 iff.intro tendsto_nhds_zero_of_is_o (is_o_of_tendsto hgf)
 
 end

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -51,6 +51,7 @@ usual formulas (and existence assertions) for the derivative of
 import analysis.asymptotics analysis.calculus.tangent_cone
 
 open filter asymptotics continuous_linear_map set
+open_locale topological_space
 
 noncomputable theory
 local attribute [instance, priority 10] classical.decidable_inhabited classical.prop_decidable
@@ -80,7 +81,7 @@ has_fderiv_at_filter f f' x (nhds_within x s)
 /-- A function `f` has the continuous linear map `f'` as derivative at `x` if
 `f x' = f x + f' (x' - x) + o (x' - x)` when `x'` tends to `x`. -/
 def has_fderiv_at (f : E → F) (f' : E →L[𝕜] F) (x : E) :=
-has_fderiv_at_filter f f' x (nhds x)
+has_fderiv_at_filter f f' x (𝓝 x)
 
 variables (𝕜)
 
@@ -133,8 +134,8 @@ tangent cone related discussions. -/
 theorem has_fderiv_within_at.lim (h : has_fderiv_within_at f f' s x)
   {c : ℕ → 𝕜} {d : ℕ → E} {v : E} (dtop : {n : ℕ | x + d n ∈ s} ∈ (at_top : filter ℕ))
   (clim : tendsto (λ (n : ℕ), ∥c n∥) at_top at_top)
-  (cdlim : tendsto (λ (n : ℕ), c n • d n) at_top (nhds v)) :
-  tendsto (λn, c n • (f (x + d n) - f x)) at_top (nhds (f' v)) :=
+  (cdlim : tendsto (λ (n : ℕ), c n • d n) at_top (𝓝 v)) :
+  tendsto (λn, c n • (f (x + d n) - f x)) at_top (𝓝 (f' v)) :=
 begin
   have at_top_is_finer : at_top ≤ comap (λ (n : ℕ), x + d n) (nhds_within x s),
   { conv in (nhds_within x s) { rw ← add_zero x },
@@ -153,12 +154,12 @@ begin
     is_o_smul this,
   have : is_o (λn:ℕ, c n • (f (x + d n) - f x - f' (d n))) (λn, (1:ℝ)) at_top :=
     this.trans_is_O (is_O_one_of_tendsto cdlim),
-  have L1 : tendsto (λn:ℕ, c n • (f (x + d n) - f x - f' (d n))) at_top (nhds 0) :=
+  have L1 : tendsto (λn:ℕ, c n • (f (x + d n) - f x - f' (d n))) at_top (𝓝 0) :=
     is_o_one_iff.1 this,
-  have L2 : tendsto (λn:ℕ, f' (c n • d n)) at_top (nhds (f' v)) :=
+  have L2 : tendsto (λn:ℕ, f' (c n • d n)) at_top (𝓝 (f' v)) :=
     tendsto.comp f'.cont.continuous_at cdlim,
   have L3 : tendsto (λn:ℕ, (c n • (f (x + d n) - f x - f' (d n)) +  f' (c n • d n)))
-            at_top (nhds (0 + f' v)) :=
+            at_top (𝓝 (0 + f' v)) :=
     tendsto_add L1 L2,
   have : (λn:ℕ, (c n • (f (x + d n) - f x - f' (d n)) +  f' (c n • d n)))
           = (λn: ℕ, c n • (f (x + d n) - f x)),
@@ -204,7 +205,7 @@ section fderiv_properties
 
 theorem has_fderiv_at_filter_iff_tendsto :
   has_fderiv_at_filter f f' x L ↔
-  tendsto (λ x', ∥x' - x∥⁻¹ * ∥f x' - f x - f' (x' - x)∥) L (nhds 0) :=
+  tendsto (λ x', ∥x' - x∥⁻¹ * ∥f x' - f x - f' (x' - x)∥) L (𝓝 0) :=
 have h : ∀ x', ∥x' - x∥ = 0 → ∥f x' - f x - f' (x' - x)∥ = 0, from λ x' hx',
   by { rw [sub_eq_zero.1 ((norm_eq_zero (x' - x)).1 hx')], simp },
 begin
@@ -214,11 +215,11 @@ begin
 end
 
 theorem has_fderiv_within_at_iff_tendsto : has_fderiv_within_at f f' s x ↔
-  tendsto (λ x', ∥x' - x∥⁻¹ * ∥f x' - f x - f' (x' - x)∥) (nhds_within x s) (nhds 0) :=
+  tendsto (λ x', ∥x' - x∥⁻¹ * ∥f x' - f x - f' (x' - x)∥) (nhds_within x s) (𝓝 0) :=
 has_fderiv_at_filter_iff_tendsto
 
 theorem has_fderiv_at_iff_tendsto : has_fderiv_at f f' x ↔
-  tendsto (λ x', ∥x' - x∥⁻¹ * ∥f x' - f x - f' (x' - x)∥) (nhds x) (nhds 0) :=
+  tendsto (λ x', ∥x' - x∥⁻¹ * ∥f x' - f x - f' (x' - x)∥) (𝓝 x) (𝓝 0) :=
 has_fderiv_at_filter_iff_tendsto
 
 theorem has_fderiv_at_filter.mono (h : has_fderiv_at_filter f f' x L₂) (hst : L₁ ≤ L₂) :
@@ -229,7 +230,7 @@ theorem has_fderiv_within_at.mono (h : has_fderiv_within_at f f' t x) (hst : s �
   has_fderiv_within_at f f' s x :=
 h.mono (nhds_within_mono _ hst)
 
-theorem has_fderiv_at.has_fderiv_at_filter (h : has_fderiv_at f f' x) (hL : L ≤ nhds x) :
+theorem has_fderiv_at.has_fderiv_at_filter (h : has_fderiv_at f f' x) (hL : L ≤ 𝓝 x) :
   has_fderiv_at_filter f f' x L :=
 h.mono hL
 
@@ -259,7 +260,7 @@ lemma has_fderiv_within_at_inter' (h : t ∈ nhds_within x s) :
   has_fderiv_within_at f f' (s ∩ t) x ↔ has_fderiv_within_at f f' s x :=
 by simp [has_fderiv_within_at, nhds_within_restrict'' s h]
 
-lemma has_fderiv_within_at_inter (h : t ∈ nhds x) :
+lemma has_fderiv_within_at_inter (h : t ∈ 𝓝 x) :
   has_fderiv_within_at f f' (s ∩ t) x ↔ has_fderiv_within_at f f' s x :=
 by simp [has_fderiv_within_at, nhds_within_restrict' s h]
 
@@ -303,7 +304,7 @@ begin
   refl
 end
 
-lemma differentiable_within_at_inter (ht : t ∈ nhds x) :
+lemma differentiable_within_at_inter (ht : t ∈ 𝓝 x) :
   differentiable_within_at 𝕜 f (s ∩ t) x ↔ differentiable_within_at 𝕜 f s x :=
 by simp only [differentiable_within_at, has_fderiv_within_at, has_fderiv_at_filter,
     nhds_within_restrict' s ht]
@@ -318,7 +319,7 @@ lemma differentiable_at.differentiable_within_at
 (differentiable_within_at_univ.2 h).mono (subset_univ _)
 
 lemma differentiable_within_at.differentiable_at
-  (h : differentiable_within_at 𝕜 f s x) (hs : s ∈ nhds x) : differentiable_at 𝕜 f x :=
+  (h : differentiable_within_at 𝕜 f s x) (hs : s ∈ 𝓝 x) : differentiable_at 𝕜 f x :=
 begin
   have : s = univ ∩ s, by rw univ_inter,
   rwa [this, differentiable_within_at_inter hs, differentiable_within_at_univ] at h
@@ -371,7 +372,7 @@ begin
     simp [fderiv_within, this, -has_fderiv_within_at_univ] }
 end
 
-lemma fderiv_within_inter (ht : t ∈ nhds x) (hs : unique_diff_within_at 𝕜 s x) :
+lemma fderiv_within_inter (ht : t ∈ 𝓝 x) (hs : unique_diff_within_at 𝕜 s x) :
   fderiv_within 𝕜 f (s ∩ t) x = fderiv_within 𝕜 f s x :=
 begin
   by_cases h : differentiable_within_at 𝕜 f (s ∩ t) x,
@@ -414,7 +415,7 @@ lemma has_fderiv_within_at.congr_of_mem_nhds_within (h : has_fderiv_within_at f 
 has_fderiv_at_filter.congr_of_mem_sets h h₁ hx
 
 lemma has_fderiv_at.congr_of_mem_nhds (h : has_fderiv_at f f' x)
-  (h₁ : {y | f₁ y = f y} ∈ nhds x) : has_fderiv_at f₁ f' x :=
+  (h₁ : {y | f₁ y = f y} ∈ 𝓝 x) : has_fderiv_at f₁ f' x :=
 has_fderiv_at_filter.congr_of_mem_sets h h₁ (mem_of_nhds h₁ : _)
 
 lemma differentiable_within_at.congr_mono (h : differentiable_within_at 𝕜 f s x)
@@ -439,7 +440,7 @@ lemma differentiable_on.congr (h : differentiable_on 𝕜 f s) (h' : ∀x ∈ s,
 λ x hx, (h x hx).congr h' (h' x hx)
 
 lemma differentiable_at.congr_of_mem_nhds (h : differentiable_at 𝕜 f x)
-  (hL : {y | f₁ y = f y} ∈ nhds x) : differentiable_at 𝕜 f₁ x :=
+  (hL : {y | f₁ y = f y} ∈ 𝓝 x) : differentiable_at 𝕜 f₁ x :=
 has_fderiv_at.differentiable_at (has_fderiv_at_filter.congr_of_mem_sets h.has_fderiv_at hL (mem_of_nhds hL : _))
 
 lemma differentiable_within_at.fderiv_within_congr_mono (h : differentiable_within_at 𝕜 f s x)
@@ -478,7 +479,7 @@ begin
   exact hL
 end
 
-lemma fderiv_congr_of_mem_nhds (hL : {y | f₁ y = f y} ∈ nhds x) :
+lemma fderiv_congr_of_mem_nhds (hL : {y | f₁ y = f y} ∈ 𝓝 x) :
   fderiv 𝕜 f₁ x = fderiv 𝕜 f x :=
 begin
   have A : f₁ x = f x := (mem_of_nhds hL : _),
@@ -810,10 +811,10 @@ end sub
 section continuous
 
 theorem has_fderiv_at_filter.tendsto_nhds
-  (hL : L ≤ nhds x) (h : has_fderiv_at_filter f f' x L) :
-  tendsto f L (nhds (f x)) :=
+  (hL : L ≤ 𝓝 x) (h : has_fderiv_at_filter f f' x L) :
+  tendsto f L (𝓝 (f x)) :=
 begin
-  have : tendsto (λ x', f x' - f x) L (nhds 0),
+  have : tendsto (λ x', f x' - f x) L (𝓝 0),
   { refine h.is_O_sub.trans_tendsto (tendsto_le_left hL _),
     rw ← sub_self x, exact tendsto_sub tendsto_id tendsto_const_nhds },
   have := tendsto_add this tendsto_const_nhds,
@@ -868,7 +869,7 @@ begin
   rw [has_fderiv_at, has_fderiv_at_filter, this],
   rcases h.bound with ⟨C, Cpos, hC⟩,
   have A : asymptotics.is_O (λx : E × F, b (x.1 - p.1, x.2 - p.2))
-    (λx, ∥x - p∥ * ∥x - p∥) (nhds p) :=
+    (λx, ∥x - p∥ * ∥x - p∥) (𝓝 p) :=
   ⟨C, Cpos, filter.univ_mem_sets' (λx, begin
     simp only [mem_set_of_eq, norm_mul, norm_norm],
     calc ∥b (x.1 - p.1, x.2 - p.2)∥ ≤ C * ∥x.1 - p.1∥ * ∥x.2 - p.2∥ : hC _ _
@@ -876,7 +877,7 @@ begin
       le_of_lt Cpos, le_refl, mul_nonneg, norm_nonneg, norm_nonneg]
     ... = C * (∥x-p∥ * ∥x-p∥) : mul_assoc _ _ _ end)⟩,
   have B : asymptotics.is_o (λ (x : E × F), ∥x - p∥ * ∥x - p∥)
-    (λx, 1 * ∥x - p∥) (nhds p),
+    (λx, 1 * ∥x - p∥) (𝓝 p),
   { apply asymptotics.is_o_mul_right _ (asymptotics.is_O_refl _ _),
     rw [asymptotics.is_o_iff_tendsto],
     { simp only [div_one],
@@ -1216,8 +1217,8 @@ variables {F : Type*} [normed_group F] [normed_space ℝ F]
 variables {G : Type*} [normed_group G] [normed_space ℝ G]
 
 theorem has_fderiv_at_filter_real_equiv {f : E → F} {f' : E →L[ℝ] F} {x : E} {L : filter E} :
-  tendsto (λ x' : E, ∥x' - x∥⁻¹ * ∥f x' - f x - f' (x' - x)∥) L (nhds 0) ↔
-  tendsto (λ x' : E, ∥x' - x∥⁻¹ • (f x' - f x - f' (x' - x))) L (nhds 0) :=
+  tendsto (λ x' : E, ∥x' - x∥⁻¹ * ∥f x' - f x - f' (x' - x)∥) L (𝓝 0) ↔
+  tendsto (λ x' : E, ∥x' - x∥⁻¹ • (f x' - f x - f' (x' - x))) L (𝓝 0) :=
 begin
   symmetry,
   rw [tendsto_iff_norm_tendsto_zero], refine tendsto.congr'r (λ x', _),

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -67,7 +67,7 @@ variables {G : Type*} [normed_group G] [normed_space 𝕜 G]
 
 /-- A function `f` has the continuous linear map `f'` as derivative along the filter `L` if
 `f x' = f x + f' (x' - x) + o (x' - x)` when `x'` converges along the filter `L`. This definition
-is designed to be specialized for `L = nhds x` (in `has_fderiv_at`), giving rise to the usual notion
+is designed to be specialized for `L = 𝓝 x` (in `has_fderiv_at`), giving rise to the usual notion
 of Fréchet derivative, and for `L = nhds_within x s` (in `has_fderiv_within_at`), giving rise to
 the notion of Fréchet derivative along the set `s`. -/
 def has_fderiv_at_filter (f : E → F) (f' : E →L[𝕜] F) (x : E) (L : filter E) :=

--- a/src/analysis/calculus/tangent_cone.lean
+++ b/src/analysis/calculus/tangent_cone.lean
@@ -30,11 +30,12 @@ variables {G : Type*} [normed_group G] [normed_space ℝ G]
 
 set_option class.instance_max_depth 50
 open filter set
+open_locale topological_space
 
 /-- The set of all tangent directions to the set `s` at the point `x`. -/
 def tangent_cone_at (s : set E) (x : E) : set E :=
 {y : E | ∃(c : ℕ → 𝕜) (d : ℕ → E), {n:ℕ | x + d n ∈ s} ∈ (at_top : filter ℕ) ∧
-  (tendsto (λn, ∥c n∥) at_top at_top) ∧ (tendsto (λn, c n • d n) at_top (nhds y))}
+  (tendsto (λn, ∥c n∥) at_top at_top) ∧ (tendsto (λn, c n • d n) at_top (𝓝 y))}
 
 /-- A property ensuring that the tangent cone to `s` at `x` spans a dense subset of the whole space.
 The main role of this property is to ensure that the differential within `s` at `x` is unique,
@@ -85,14 +86,14 @@ end
 /-- Auxiliary lemma ensuring that, under the assumptions defining the tangent cone,
 the sequence `d` tends to 0 at infinity. -/
 lemma tangent_cone_at.lim_zero {c : ℕ → 𝕜} {d : ℕ → E}
-  (hc : tendsto (λn, ∥c n∥) at_top at_top) (hd : tendsto (λn, c n • d n) at_top (nhds y)) :
-  tendsto d at_top (nhds 0) :=
+  (hc : tendsto (λn, ∥c n∥) at_top at_top) (hd : tendsto (λn, c n • d n) at_top (𝓝 y)) :
+  tendsto d at_top (𝓝 0) :=
 begin
-  have A : tendsto (λn, ∥c n∥⁻¹) at_top (nhds 0) :=
+  have A : tendsto (λn, ∥c n∥⁻¹) at_top (𝓝 0) :=
     tendsto_inverse_at_top_nhds_0.comp hc,
-  have B : tendsto (λn, ∥c n • d n∥) at_top (nhds ∥y∥) :=
+  have B : tendsto (λn, ∥c n • d n∥) at_top (𝓝 ∥y∥) :=
     (continuous_norm.tendsto _).comp hd,
-  have C : tendsto (λn, ∥c n∥⁻¹ * ∥c n • d n∥) at_top (nhds (0 * ∥y∥)) :=
+  have C : tendsto (λn, ∥c n∥⁻¹ * ∥c n • d n∥) at_top (𝓝 (0 * ∥y∥)) :=
     tendsto_mul A B,
   rw zero_mul at C,
   have : {n | ∥c n∥⁻¹ * ∥c n • d n∥ = ∥d n∥} ∈ (@at_top ℕ _),
@@ -102,21 +103,21 @@ begin
     rw mem_set_of_eq at hn,
     rw [mem_set_of_eq, ← norm_inv, ← norm_smul, smul_smul, inv_mul_cancel, one_smul],
     simpa [norm_eq_zero] using (ne_of_lt (lt_of_lt_of_le zero_lt_one hn)).symm },
-  have D : tendsto (λ (n : ℕ), ∥d n∥) at_top (nhds 0) :=
+  have D : tendsto (λ (n : ℕ), ∥d n∥) at_top (𝓝 0) :=
     tendsto.congr' this C,
   rw tendsto_zero_iff_norm_tendsto_zero,
   exact D
 end
 
 /-- Intersecting with a neighborhood of the point does not change the tangent cone. -/
-lemma tangent_cone_inter_nhds (ht : t ∈ nhds x) :
+lemma tangent_cone_inter_nhds (ht : t ∈ 𝓝 x) :
   tangent_cone_at 𝕜 (s ∩ t) x = tangent_cone_at 𝕜 s x :=
 begin
   refine subset.antisymm (tangent_cone_mono (inter_subset_left _ _)) _,
   rintros y ⟨c, d, ds, ctop, clim⟩,
   refine ⟨c, d, _, ctop, clim⟩,
   have : {n : ℕ | x + d n ∈ t} ∈ at_top,
-  { have : tendsto (λn, x + d n) at_top (nhds (x + 0)) :=
+  { have : tendsto (λn, x + d n) at_top (𝓝 (x + 0)) :=
       tendsto_add tendsto_const_nhds (tangent_cone_at.lim_zero ctop clim),
     rw add_zero at this,
     exact mem_map.1 (this ht) },
@@ -158,7 +159,7 @@ begin
     simp at hn,
     simp [hn, (hd' n).1] },
   { apply tendsto_prod_mk_nhds hy,
-    change tendsto (λ (n : ℕ), c n • d' n) at_top (nhds 0),
+    change tendsto (λ (n : ℕ), c n • d' n) at_top (𝓝 0),
     rw tendsto_zero_iff_norm_tendsto_zero,
     refine squeeze_zero (λn, norm_nonneg _) (λn, (hd' n).2) _,
     apply tendsto_pow_at_top_nhds_0_of_lt_1; norm_num }
@@ -200,7 +201,7 @@ begin
     simp at hn,
     simp [hn, (hd' n).1] },
   { apply tendsto_prod_mk_nhds _ hy,
-    change tendsto (λ (n : ℕ), c n • d' n) at_top (nhds 0),
+    change tendsto (λ (n : ℕ), c n • d' n) at_top (𝓝 0),
     rw tendsto_zero_iff_norm_tendsto_zero,
     refine squeeze_zero (λn, norm_nonneg _) (λn, (hd' n).2) _,
     apply tendsto_pow_at_top_nhds_0_of_lt_1; norm_num }
@@ -225,7 +226,7 @@ begin
       by { ext n, exact abs_of_nonneg (pow_nonneg (by norm_num) _) },
     rw this,
     exact tendsto_pow_at_top_at_top_of_gt_1 (by norm_num) },
-  show filter.tendsto (λ (n : ℕ), c n • d n) filter.at_top (nhds (y - x)),
+  show filter.tendsto (λ (n : ℕ), c n • d n) filter.at_top (𝓝 (y - x)),
   { have : (λ (n : ℕ), c n • d n) = (λn, y - x),
     { ext n,
       simp only [d, smul_smul],
@@ -255,7 +256,7 @@ begin
   exact ⟨closure_mono (submodule.span_mono (tangent_cone_mono st)), closure_mono st h.2⟩
 end
 
-lemma unique_diff_within_at_inter (ht : t ∈ nhds x) :
+lemma unique_diff_within_at_inter (ht : t ∈ 𝓝 x) :
   unique_diff_within_at 𝕜 (s ∩ t) x ↔ unique_diff_within_at 𝕜 s x :=
 begin
   have : x ∈ closure (s ∩ t) ↔ x ∈ closure s,
@@ -269,7 +270,7 @@ begin
   rw [unique_diff_within_at, unique_diff_within_at, tangent_cone_inter_nhds ht, this]
 end
 
-lemma unique_diff_within_at.inter (hs : unique_diff_within_at 𝕜 s x) (ht : t ∈ nhds x) :
+lemma unique_diff_within_at.inter (hs : unique_diff_within_at 𝕜 s x) (ht : t ∈ 𝓝 x) :
   unique_diff_within_at 𝕜 (s ∩ t) x :=
 (unique_diff_within_at_inter ht).2 hs
 
@@ -281,7 +282,7 @@ begin
   { assume H,
     rw mem_nhds_within at ht,
     rcases ht with ⟨u, u_open, xu, us⟩,
-    have : u ∈ nhds x := mem_nhds_sets u_open xu,
+    have : u ∈ 𝓝 x := mem_nhds_sets u_open xu,
     rw ← unique_diff_within_at_inter this at H,
     apply H.mono,
     exact λ p ⟨ps, pu⟩, ⟨ps, us ⟨pu, ps⟩⟩ }

--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -71,6 +71,7 @@ local attribute [instance, priority 10] classical.decidable_inhabited classical.
 universes u v w
 
 open set
+open_locale topological_space
 
 variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 {E : Type u} [normed_group E] [normed_space 𝕜 E]
@@ -220,7 +221,7 @@ end
 The iterated differential within a set `s` at a point `x` is not modified if one intersects
 `s` with a neighborhood of `x`.
 -/
-lemma iterated_fderiv_within_inter (hu : u ∈ nhds x) (xs : x ∈ s)
+lemma iterated_fderiv_within_inter (hu : u ∈ 𝓝 x) (xs : x ∈ s)
   (hs : unique_diff_on 𝕜 s) :
   iterated_fderiv_within 𝕜 n f (s ∩ u) x = iterated_fderiv_within 𝕜 n f s x :=
 begin

--- a/src/analysis/complex/exponential.lean
+++ b/src/analysis/complex/exponential.lean
@@ -33,10 +33,11 @@ exp, log, sin, cos, tan, arcsin, arccos, arctan, angle, argument, power, square 
 -/
 
 open finset filter metric
+open_locale topological_space
 
 namespace complex
 
-lemma tendsto_exp_zero_one : tendsto exp (nhds 0) (nhds 1) :=
+lemma tendsto_exp_zero_one : tendsto exp (𝓝 0) (𝓝 1) :=
 tendsto_nhds_nhds.2 $ λ ε ε0,
   ⟨min (ε / 2) 1, lt_min (div_pos ε0 (by norm_num)) (by norm_num),
     λ x h, have h : abs x < min (ε / 2) 1, by simpa [dist_eq] using h,
@@ -49,12 +50,12 @@ tendsto_nhds_nhds.2 $ λ ε ε0,
 
 lemma continuous_exp : continuous exp :=
 continuous_iff_continuous_at.2 (λ x,
-  have H1 : tendsto (λ h, exp (x + h)) (nhds 0) (nhds (exp x)),
+  have H1 : tendsto (λ h, exp (x + h)) (𝓝 0) (𝓝 (exp x)),
     by simpa [exp_add] using tendsto_mul tendsto_const_nhds tendsto_exp_zero_one,
-  have H2 : tendsto (λ y, y - x) (nhds x) (nhds (x - x)) :=
+  have H2 : tendsto (λ y, y - x) (𝓝 x) (𝓝 (x - x)) :=
      tendsto_sub tendsto_id (@tendsto_const_nhds _ _ _ x _),
   suffices tendsto ((λ h, exp (x + h)) ∘
-      (λ y, id y - (λ z, x) y)) (nhds x) (nhds (exp x)),
+      (λ y, id y - (λ z, x) y)) (𝓝 x) (𝓝 (exp x)),
     by simp only [function.comp, add_sub_cancel'_right, id.def] at this;
       exact this,
   tendsto.comp H1 (by rw [sub_self] at H2; exact H2))
@@ -197,7 +198,7 @@ end
 
 section prove_log_is_continuous
 
-lemma tendsto_log_one_zero : tendsto log (nhds 1) (nhds 0) :=
+lemma tendsto_log_one_zero : tendsto log (𝓝 1) (𝓝 0) :=
 begin
   rw tendsto_nhds_nhds, assume ε ε0,
   let δ := min (exp ε - 1) (1 - exp (-ε)),
@@ -227,14 +228,14 @@ begin
   rw continuous_at,
   let f₁ := λ h:{h:ℝ // 0 < h}, log (x.1 * h.1),
   let f₂ := λ y:{y:ℝ // 0 < y}, subtype.mk (x.1 ⁻¹ * y.1) (mul_pos (inv_pos x.2) y.2),
-  have H1 : tendsto f₁ (nhds ⟨1, zero_lt_one⟩) (nhds (log (x.1*1))),
+  have H1 : tendsto f₁ (𝓝 ⟨1, zero_lt_one⟩) (𝓝 (log (x.1*1))),
     have : f₁ = λ h:{h:ℝ // 0 < h}, log x.1 + log h.1,
       ext h, rw ← log_mul x.2 h.2,
     simp only [this, log_mul x.2 zero_lt_one, log_one], exact
       tendsto_add tendsto_const_nhds (tendsto.comp tendsto_log_one_zero continuous_at_subtype_val),
-  have H2 : tendsto f₂ (nhds x) (nhds ⟨x.1⁻¹ * x.1, mul_pos (inv_pos x.2) x.2⟩),
+  have H2 : tendsto f₂ (𝓝 x) (𝓝 ⟨x.1⁻¹ * x.1, mul_pos (inv_pos x.2) x.2⟩),
     rw tendsto_subtype_rng, exact tendsto_mul tendsto_const_nhds continuous_at_subtype_val,
-  suffices h : tendsto (f₁ ∘ f₂) (nhds x) (nhds (log x.1)),
+  suffices h : tendsto (f₁ ∘ f₂) (𝓝 x) (𝓝 (log x.1)),
   begin
     convert h, ext y,
     have : x.val * (x.val⁻¹ * y.val) = y.val,

--- a/src/analysis/normed_space/banach.lean
+++ b/src/analysis/normed_space/banach.lean
@@ -12,7 +12,7 @@ bounded linear map between Banach spaces has a bounded inverse.
 import topology.metric_space.baire analysis.normed_space.bounded_linear_maps
 
 open function metric set filter finset
-open_locale classical
+open_locale classical topological_space
 
 variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 {E : Type*} [normed_group E] [complete_space E] [normed_space 𝕜 E]
@@ -152,12 +152,12 @@ begin
     { simp [lin.map_zero] },
     { rw [sum_range_succ, lin.add, IH, nat.iterate_succ'],
       simp [u, h] } },
-  have : tendsto (λn, (range n).sum u) at_top (nhds x) :=
+  have : tendsto (λn, (range n).sum u) at_top (𝓝 x) :=
     tendsto_sum_nat_of_has_sum (has_sum_tsum su),
-  have L₁ : tendsto (λn, f((range n).sum u)) at_top (nhds (f x)) :=
+  have L₁ : tendsto (λn, f((range n).sum u)) at_top (𝓝 (f x)) :=
     tendsto.comp (hf.continuous.tendsto _) this,
   simp only [fsumeq] at L₁,
-  have L₂ : tendsto (λn, y - (h^[n]) y) at_top (nhds (y - 0)),
+  have L₂ : tendsto (λn, y - (h^[n]) y) at_top (𝓝 (y - 0)),
   { refine tendsto_sub tendsto_const_nhds _,
     rw tendsto_iff_norm_tendsto_zero,
     simp only [sub_zero],

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -15,6 +15,7 @@ variables {α : Type*} {β : Type*} {γ : Type*} {ι : Type*}
 
 noncomputable theory
 open filter metric
+open_locale topological_space
 localized "notation f `→_{`:50 a `}`:0 b := filter.tendsto f (_root_.nhds a) (_root_.nhds b)" in filter
 
 class has_norm (α : Type*) := (norm : α → ℝ)
@@ -141,7 +142,7 @@ lemma ball_0_eq (ε : ℝ) : ball (0:α) ε = {x | ∥x∥ < ε} :=
 set.ext $ assume a, by simp
 
 theorem normed_group.tendsto_nhds_zero {f : γ → α} {l : filter γ} :
-  tendsto f l (nhds 0) ↔ ∀ ε > 0, { x | ∥ f x ∥ < ε } ∈ l :=
+  tendsto f l (𝓝 0) ↔ ∀ ε > 0, { x | ∥ f x ∥ < ε } ∈ l :=
 begin
   rw [metric.tendsto_nhds], simp only [normed_group.dist_eq, sub_zero],
   split,
@@ -197,12 +198,12 @@ instance fintype.normed_group {π : ι → Type*} [fintype ι] [∀i, normed_gro
     show nndist (x a) (y a) = nnnorm (x a - y a), from nndist_eq_nnnorm _ _ }
 
 lemma tendsto_iff_norm_tendsto_zero {f : ι → β} {a : filter ι} {b : β} :
-  tendsto f a (nhds b) ↔ tendsto (λ e, ∥ f e - b ∥) a (nhds 0) :=
+  tendsto f a (𝓝 b) ↔ tendsto (λ e, ∥ f e - b ∥) a (𝓝 0) :=
 by rw tendsto_iff_dist_tendsto_zero ; simp only [(dist_eq_norm _ _).symm]
 
 lemma tendsto_zero_iff_norm_tendsto_zero {f : γ → β} {a : filter γ} :
-  tendsto f a (nhds 0) ↔ tendsto (λ e, ∥ f e ∥) a (nhds 0) :=
-have tendsto f a (nhds 0) ↔ tendsto (λ e, ∥ f e - 0 ∥) a (nhds 0) :=
+  tendsto f a (𝓝 0) ↔ tendsto (λ e, ∥ f e ∥) a (𝓝 0) :=
+have tendsto f a (𝓝 0) ↔ tendsto (λ e, ∥ f e - 0 ∥) a (𝓝 0) :=
   tendsto_iff_norm_tendsto_zero,
 by simpa
 
@@ -427,7 +428,7 @@ variables {E : Type*} {F : Type*}
 [normed_group E] [normed_space α E] [normed_group F] [normed_space α F]
 
 lemma tendsto_smul {f : γ → α} { g : γ → F} {e : filter γ} {s : α} {b : F} :
-  (tendsto f e (nhds s)) → (tendsto g e (nhds b)) → tendsto (λ x, (f x) • (g x)) e (nhds (s • b)) :=
+  (tendsto f e (𝓝 s)) → (tendsto g e (𝓝 b)) → tendsto (λ x, (f x) • (g x)) e (𝓝 (s • b)) :=
 begin
   intros limf limg,
   rw tendsto_iff_norm_tendsto_zero,
@@ -440,15 +441,15 @@ begin
   { exact ineq },
   { clear ineq,
 
-    have limf': tendsto (λ x, ∥f x - s∥) e (nhds 0) := tendsto_iff_norm_tendsto_zero.1 limf,
-    have limg' : tendsto (λ x, ∥g x∥) e (nhds ∥b∥) := filter.tendsto.comp (continuous_iff_continuous_at.1 continuous_norm _) limg,
+    have limf': tendsto (λ x, ∥f x - s∥) e (𝓝 0) := tendsto_iff_norm_tendsto_zero.1 limf,
+    have limg' : tendsto (λ x, ∥g x∥) e (𝓝 ∥b∥) := filter.tendsto.comp (continuous_iff_continuous_at.1 continuous_norm _) limg,
 
     have lim1 := tendsto_mul limf' limg',
     simp only [zero_mul, sub_eq_add_neg] at lim1,
 
     have limg3 := tendsto_iff_norm_tendsto_zero.1 limg,
 
-    have lim2 := tendsto_mul (tendsto_const_nhds : tendsto _ _ (nhds ∥ s ∥)) limg3,
+    have lim2 := tendsto_mul (tendsto_const_nhds : tendsto _ _ (𝓝 ∥ s ∥)) limg3,
     simp only [sub_eq_add_neg, mul_zero] at lim2,
 
     rw [show (0:ℝ) = 0 + 0, by simp],
@@ -456,7 +457,7 @@ begin
 end
 
 lemma tendsto_smul_const {g : γ → F} {e : filter γ} (s : α) {b : F} :
-  (tendsto g e (nhds b)) → tendsto (λ x, s • (g x)) e (nhds (s • b)) :=
+  (tendsto g e (𝓝 b)) → tendsto (λ x, s • (g x)) e (𝓝 (s • b)) :=
 tendsto_smul tendsto_const_nhds
 
 instance normed_space.topological_vector_space : topological_vector_space α E :=
@@ -547,9 +548,9 @@ lemma summable_of_summable_norm {f : ι → α} (hf : summable (λa, ∥f a∥))
 summable_of_norm_bounded _ hf (assume i, le_refl _)
 
 lemma norm_tsum_le_tsum_norm {f : ι → α} (hf : summable (λi, ∥f i∥)) : ∥(∑i, f i)∥ ≤ (∑ i, ∥f i∥) :=
-have h₁ : tendsto (λs:finset ι, ∥s.sum f∥) at_top (nhds ∥(∑ i, f i)∥) :=
+have h₁ : tendsto (λs:finset ι, ∥s.sum f∥) at_top (𝓝 ∥(∑ i, f i)∥) :=
   (continuous_norm.tendsto _).comp (has_sum_tsum $ summable_of_summable_norm hf),
-have h₂ : tendsto (λs:finset ι, s.sum (λi, ∥f i∥)) at_top (nhds (∑ i, ∥f i∥)) :=
+have h₂ : tendsto (λs:finset ι, s.sum (λi, ∥f i∥)) at_top (𝓝 (∑ i, ∥f i∥)) :=
   has_sum_tsum hf,
 le_of_tendsto_of_tendsto at_top_ne_bot h₁ h₂ $ univ_mem_sets' $ assume s, norm_triangle_sum _ _
 

--- a/src/analysis/normed_space/real_inner_product.lean
+++ b/src/analysis/normed_space/real_inner_product.lean
@@ -44,6 +44,7 @@ The Coq code is available at the following address: http://www.lri.fr/~sboldo/el
 noncomputable theory
 
 open real set lattice
+open_locale topological_space
 
 universes u v w
 
@@ -238,10 +239,10 @@ begin
     let w : ℕ → K := λ n, classical.some (h n),
     exact ⟨w, λ n, classical.some_spec (h n)⟩,
   rcases exists_seq with ⟨w, hw⟩,
-  have norm_tendsto : tendsto (λ n, ∥u - w n∥) at_top (nhds δ),
-    have h : tendsto (λ n:ℕ, δ) at_top (nhds δ),
+  have norm_tendsto : tendsto (λ n, ∥u - w n∥) at_top (𝓝 δ),
+    have h : tendsto (λ n:ℕ, δ) at_top (𝓝 δ),
       exact tendsto_const_nhds,
-    have h' : tendsto (λ n:ℕ, δ + 1 / (n + 1)) at_top (nhds δ),
+    have h' : tendsto (λ n:ℕ, δ + 1 / (n + 1)) at_top (𝓝 δ),
       convert tendsto_add h tendsto_one_div_add_at_top_nhds_0_nat, simp only [add_zero],
     exact tendsto_of_tendsto_of_tendsto_of_le_of_le h h'
       (by { rw mem_at_top_sets, use 0, assume n hn, exact δ_le _ })
@@ -304,16 +305,16 @@ begin
       ... = 8 * δ * div + 4 * div * div : by ring,
     exact add_nonneg (mul_nonneg (mul_nonneg (by norm_num) zero_le_δ) (le_of_lt nat.one_div_pos_of_nat))
       (mul_nonneg (mul_nonneg (by norm_num) (le_of_lt nat.one_div_pos_of_nat)) (le_of_lt nat.one_div_pos_of_nat)),
-    -- third goal : `tendsto (λ (n : ℕ), sqrt (b n)) at_top (nhds 0)`
+    -- third goal : `tendsto (λ (n : ℕ), sqrt (b n)) at_top (𝓝 0)`
     apply tendsto.comp,
     { convert continuous_sqrt.continuous_at, exact sqrt_zero.symm },
-    have eq₁ : tendsto (λ (n : ℕ), 8 * δ * (1 / (n + 1))) at_top (nhds (0:ℝ)),
+    have eq₁ : tendsto (λ (n : ℕ), 8 * δ * (1 / (n + 1))) at_top (𝓝 (0:ℝ)),
       convert tendsto_mul (@tendsto_const_nhds _ _ _ (8 * δ) _) tendsto_one_div_add_at_top_nhds_0_nat,
       simp only [mul_zero],
-    have : tendsto (λ (n : ℕ), (4:ℝ) * (1 / (n + 1))) at_top (nhds (0:ℝ)),
+    have : tendsto (λ (n : ℕ), (4:ℝ) * (1 / (n + 1))) at_top (𝓝 (0:ℝ)),
       convert tendsto_mul (@tendsto_const_nhds _ _ _ (4:ℝ) _) tendsto_one_div_add_at_top_nhds_0_nat,
       simp only [mul_zero],
-    have eq₂ : tendsto (λ (n : ℕ), (4:ℝ) * (1 / (n + 1)) * (1 / (n + 1))) at_top (nhds (0:ℝ)),
+    have eq₂ : tendsto (λ (n : ℕ), (4:ℝ) * (1 / (n + 1)) * (1 / (n + 1))) at_top (𝓝 (0:ℝ)),
       convert tendsto_mul this tendsto_one_div_add_at_top_nhds_0_nat,
       simp only [mul_zero],
     convert tendsto_add eq₁ eq₂, simp only [add_zero],
@@ -323,7 +324,7 @@ begin
   use v, use hv,
   have h_cont : continuous (λ v, ∥u - v∥) :=
     continuous.comp continuous_norm (continuous_sub continuous_const continuous_id),
-  have : tendsto (λ n, ∥u - w n∥) at_top (nhds ∥u - v∥),
+  have : tendsto (λ n, ∥u - w n∥) at_top (𝓝 ∥u - v∥),
     convert (tendsto.comp h_cont.continuous_at w_tendsto),
   exact tendsto_nhds_unique at_top_ne_bot this norm_tendsto,
   exact subtype.mem _

--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -9,14 +9,14 @@ import analysis.normed_space.basic algebra.geom_sum
 import topology.instances.ennreal
 
 noncomputable theory
-open_locale classical
+open_locale classical topological_space
 
 open classical function lattice filter finset metric
 
 variables {α : Type*} {β : Type*} {ι : Type*}
 
 lemma summable_of_absolute_convergence_real {f : ℕ → ℝ} :
-  (∃r, tendsto (λn, (range n).sum (λi, abs (f i))) at_top (nhds r)) → summable f
+  (∃r, tendsto (λn, (range n).sum (λi, abs (f i))) at_top (𝓝 r)) → summable f
 | ⟨r, hr⟩ :=
   begin
     refine summable_of_summable_norm ⟨r, (has_sum_iff_tendsto_nat_of_nonneg _ _).2 _⟩,
@@ -39,7 +39,7 @@ tendsto_infi.2 $ assume p, tendsto_principal.2 $
   show {n | p ≤ r ^ n} ∈ at_top,
     from mem_at_top_sets.mpr ⟨n, assume m hnm, le_trans this (pow_le_pow (le_of_lt h) hnm)⟩
 
-lemma tendsto_inverse_at_top_nhds_0 : tendsto (λr:ℝ, r⁻¹) at_top (nhds 0) :=
+lemma tendsto_inverse_at_top_nhds_0 : tendsto (λr:ℝ, r⁻¹) at_top (𝓝 0) :=
 tendsto_orderable_unbounded (no_top 0) (no_bot 0) $ assume l u hl hu,
   mem_at_top_sets.mpr ⟨u⁻¹ + 1, assume b hb,
     have u⁻¹ < b, from lt_of_lt_of_le (lt_add_of_pos_right _ zero_lt_one) hb,
@@ -52,17 +52,17 @@ tendsto_orderable_unbounded (no_top 0) (no_bot 0) $ assume l u hl hu,
     end⟩⟩
 
 lemma tendsto_pow_at_top_nhds_0_of_lt_1 {r : ℝ} (h₁ : 0 ≤ r) (h₂ : r < 1) :
-  tendsto (λn:ℕ, r^n) at_top (nhds 0) :=
+  tendsto (λn:ℕ, r^n) at_top (𝓝 0) :=
 by_cases
   (assume : r = 0, (tendsto_add_at_top_iff_nat 1).mp $ by simp [pow_succ, this, tendsto_const_nhds])
   (assume : r ≠ 0,
-    have tendsto (λn, (r⁻¹ ^ n)⁻¹) at_top (nhds 0),
+    have tendsto (λn, (r⁻¹ ^ n)⁻¹) at_top (𝓝 0),
       from tendsto.comp tendsto_inverse_at_top_nhds_0
         (tendsto_pow_at_top_at_top_of_gt_1 $ one_lt_inv (lt_of_le_of_ne h₁ this.symm) h₂),
     tendsto.congr' (univ_mem_sets' $ by simp *) this)
 
 lemma tendsto_pow_at_top_nhds_0_of_lt_1_normed_field {K : Type*} [normed_field K] {ξ : K}
-  (_ : ∥ξ∥ < 1) : tendsto (λ n : ℕ, ξ^n) at_top (nhds 0) :=
+  (_ : ∥ξ∥ < 1) : tendsto (λ n : ℕ, ξ^n) at_top (𝓝 0) :=
 begin
   rw[tendsto_iff_norm_tendsto_zero],
   convert tendsto_pow_at_top_nhds_0_of_lt_1 (norm_nonneg ξ) ‹∥ξ∥ < 1›,
@@ -76,15 +76,15 @@ tendsto_coe_nat_real_at_top_iff.1 $
   have hr : 1 < (k : ℝ), by rw [← nat.cast_one, nat.cast_lt]; exact h,
   by simpa using tendsto_pow_at_top_at_top_of_gt_1 hr
 
-lemma tendsto_inverse_at_top_nhds_0_nat : tendsto (λ n : ℕ, (n : ℝ)⁻¹) at_top (nhds 0) :=
+lemma tendsto_inverse_at_top_nhds_0_nat : tendsto (λ n : ℕ, (n : ℝ)⁻¹) at_top (𝓝 0) :=
 tendsto.comp tendsto_inverse_at_top_nhds_0 (tendsto_coe_nat_real_at_top_iff.2 tendsto_id)
 
-lemma tendsto_one_div_at_top_nhds_0_nat : tendsto (λ n : ℕ, 1/(n : ℝ)) at_top (nhds 0) :=
+lemma tendsto_one_div_at_top_nhds_0_nat : tendsto (λ n : ℕ, 1/(n : ℝ)) at_top (𝓝 0) :=
 by simpa only [inv_eq_one_div] using tendsto_inverse_at_top_nhds_0_nat
 
 lemma tendsto_one_div_add_at_top_nhds_0_nat :
-  tendsto (λ n : ℕ, 1 / ((n : ℝ) + 1)) at_top (nhds 0) :=
-suffices tendsto (λ n : ℕ, 1 / (↑(n + 1) : ℝ)) at_top (nhds 0), by simpa,
+  tendsto (λ n : ℕ, 1 / ((n : ℝ) + 1)) at_top (𝓝 0) :=
+suffices tendsto (λ n : ℕ, 1 / (↑(n + 1) : ℝ)) at_top (𝓝 0), by simpa,
 (tendsto_add_at_top_iff_nat 1).2 tendsto_one_div_at_top_nhds_0_nat
 
 lemma has_sum_geometric {r : ℝ} (h₁ : 0 ≤ r) (h₂ : r < 1) :
@@ -92,7 +92,7 @@ lemma has_sum_geometric {r : ℝ} (h₁ : 0 ≤ r) (h₂ : r < 1) :
 have r ≠ 1, from ne_of_lt h₂,
 have r + -1 ≠ 0,
   by rw [←sub_eq_add_neg, ne, sub_eq_iff_eq_add]; simp; assumption,
-have tendsto (λn, (r ^ n - 1) * (r - 1)⁻¹) at_top (nhds ((0 - 1) * (r - 1)⁻¹)),
+have tendsto (λn, (r ^ n - 1) * (r - 1)⁻¹) at_top (𝓝 ((0 - 1) * (r - 1)⁻¹)),
   from tendsto_mul
     (tendsto_sub (tendsto_pow_at_top_nhds_0_of_lt_1 h₁ h₂) tendsto_const_nhds) tendsto_const_nhds,
 have (λ n, (range n).sum (λ i, r ^ i)) = (λ n, geom_series r n) := rfl,

--- a/src/data/analysis/topology.lean
+++ b/src/data/analysis/topology.lean
@@ -8,6 +8,7 @@ Computational realization of topological spaces (experimental).
 import topology.bases data.analysis.filter
 open set
 open filter (hiding realizer)
+open_locale topological_space
 
 /-- A `ctop α σ` is a realization of a topology (basis) on `α`,
   represented by a type `σ` together with operations for the top element and
@@ -80,7 +81,7 @@ protected theorem is_basis [T : topological_space α] (F : realizer α) :
 by have := to_topsp_is_topological_basis F.F; rwa F.eq at this
 
 protected theorem mem_nhds [T : topological_space α] (F : realizer α) {s : set α} {a : α} :
-  s ∈ nhds a ↔ ∃ b, a ∈ F.F b ∧ F.F b ⊆ s :=
+  s ∈ 𝓝 a ↔ ∃ b, a ∈ F.F b ∧ F.F b ⊆ s :=
 by have := mem_nhds_to_topsp F.F; rwa F.eq at this
 
 theorem is_open_iff [topological_space α] (F : realizer α) {s : set α} :
@@ -102,7 +103,7 @@ protected theorem is_open [topological_space α] (F : realizer α) (s : F.σ) : 
 is_open_iff_nhds.2 $ λ a m, by simpa using F.mem_nhds.2 ⟨s, m, subset.refl _⟩
 
 theorem ext' [T : topological_space α] {σ : Type*} {F : ctop α σ}
-  (H : ∀ a s, s ∈ nhds a ↔ ∃ b, a ∈ F b ∧ F b ⊆ s) :
+  (H : ∀ a s, s ∈ 𝓝 a ↔ ∃ b, a ∈ F b ∧ F b ⊆ s) :
   F.to_topsp = T :=
 topological_space_eq $ funext $ λ s, begin
   have : ∀ T s, @topological_space.is_open _ T s ↔ _ := @is_open_iff_mem_nhds α,
@@ -114,7 +115,7 @@ end
 
 theorem ext [T : topological_space α] {σ : Type*} {F : ctop α σ}
   (H₁ : ∀ a, is_open (F a))
-  (H₂ : ∀ a s, s ∈ nhds a → ∃ b, a ∈ F b ∧ F b ⊆ s) :
+  (H₂ : ∀ a s, s ∈ 𝓝 a → ∃ b, a ∈ F b ∧ F b ⊆ s) :
   F.to_topsp = T :=
 ext' $ λ a s, ⟨H₂ a s, λ ⟨b, h₁, h₂⟩, mem_nhds_sets_iff.2 ⟨_, h₂, H₁ _, h₁⟩⟩
 
@@ -138,7 +139,7 @@ def of_equiv (F : realizer α) (E : F.σ ≃ τ) : realizer α :=
 @[simp] theorem of_equiv_F (F : realizer α) (E : F.σ ≃ τ) (s : τ) :
   (F.of_equiv E).F s = F.F (E.symm s) := by delta of_equiv; simp
 
-protected def nhds (F : realizer α) (a : α) : (nhds a).realizer :=
+protected def nhds (F : realizer α) (a : α) : (𝓝 a).realizer :=
 ⟨{s : F.σ // a ∈ F.F s},
 { f            := λ s, F.F s.1,
   pt           := ⟨_, F.F.top_mem a⟩,
@@ -155,7 +156,7 @@ filter_eq $ set.ext $ λ x,
   (F.nhds a).F s = F.F s.1 := rfl
 
 theorem tendsto_nhds_iff {m : β → α} {f : filter β} (F : f.realizer) (R : realizer α) {a : α} :
-  tendsto m f (nhds a) ↔ ∀ t, a ∈ R.F t → ∃ s, ∀ x ∈ F.F s, m x ∈ R.F t :=
+  tendsto m f (𝓝 a) ↔ ∀ t, a ∈ R.F t → ∃ s, ∀ x ∈ F.F s, m x ∈ R.F t :=
 (F.tendsto_iff _ (R.nhds a)).trans subtype.forall
 
 end ctop.realizer
@@ -183,4 +184,4 @@ theorem locally_finite_iff_exists_realizer [topological_space α]
 
 def compact.realizer [topological_space α] (R : realizer α) (s : set α) :=
 ∀ {f : filter α} (F : f.realizer) (x : F.σ), f ≠ ⊥ →
-  F.F x ⊆ s → {a // a∈s ∧ nhds a ⊓ f ≠ ⊥}
+  F.F x ⊆ s → {a // a∈s ∧ 𝓝 a ⊓ f ≠ ⊥}

--- a/src/data/padics/hensel.lean
+++ b/src/data/padics/hensel.lean
@@ -31,7 +31,7 @@ p-adic, p adic, padic, p-adic integer
 
 noncomputable theory
 
-open_locale classical
+open_locale classical topological_space
 
 -- We begin with some general lemmas that are used below in the computation.
 
@@ -45,7 +45,7 @@ let ⟨z, hz⟩ := F.eval_sub_factor x y in calc
 open filter metric
 
 private lemma comp_tendsto_lim {p : ℕ} [p.prime] {F : polynomial ℤ_[p]} (ncs : cau_seq ℤ_[p] norm) :
-  tendsto (λ i, F.eval (ncs i)) at_top (nhds (F.eval ncs.lim)) :=
+  tendsto (λ i, F.eval (ncs i)) at_top (𝓝 (F.eval ncs.lim)) :=
 @tendsto.comp _ _ _ ncs
   (λ k, F.eval k)
   _ _ _
@@ -57,11 +57,11 @@ parameters {p : ℕ} [nat.prime p] {ncs : cau_seq ℤ_[p] norm} {F : polynomial 
 include ncs_der_val
 
 private lemma ncs_tendsto_const :
-  tendsto (λ i, ∥F.derivative.eval (ncs i)∥) at_top (nhds ∥F.derivative.eval a∥) :=
+  tendsto (λ i, ∥F.derivative.eval (ncs i)∥) at_top (𝓝 ∥F.derivative.eval a∥) :=
 by convert tendsto_const_nhds; ext; rw ncs_der_val
 
 private lemma ncs_tendsto_lim :
-  tendsto (λ i, ∥F.derivative.eval (ncs i)∥) at_top (nhds (∥F.derivative.eval ncs.lim∥)) :=
+  tendsto (λ i, ∥F.derivative.eval (ncs i)∥) at_top (𝓝 (∥F.derivative.eval ncs.lim∥)) :=
 tendsto.comp (continuous_iff_continuous_at.1 continuous_norm _) (comp_tendsto_lim _)
 
 private lemma norm_deriv_eq : ∥F.derivative.eval ncs.lim∥ = ∥F.derivative.eval a∥ :=
@@ -71,10 +71,10 @@ end
 
 section
 parameters {p : ℕ} [nat.prime p] {ncs : cau_seq ℤ_[p] norm} {F : polynomial ℤ_[p]}
-           (hnorm : tendsto (λ i, ∥F.eval (ncs i)∥) at_top (nhds 0))
+           (hnorm : tendsto (λ i, ∥F.eval (ncs i)∥) at_top (𝓝 0))
 include hnorm
 
-private lemma tendsto_zero_of_norm_tendsto_zero : tendsto (λ i, F.eval (ncs i)) at_top (nhds 0) :=
+private lemma tendsto_zero_of_norm_tendsto_zero : tendsto (λ i, F.eval (ncs i)) at_top (𝓝 0) :=
 tendsto_iff_norm_tendsto_zero.2 (by simpa using hnorm)
 
 lemma limit_zero_of_norm_tendsto_zero : F.eval ncs.lim = 0 :=
@@ -299,7 +299,7 @@ private lemma newton_seq_dist_to_a : ∀ n : ℕ, 0 < n → ∥newton_seq n - a�
 ... = ∥newton_seq (k+1) - a∥ : max_eq_right_of_lt hlt
 ... = ∥polynomial.eval a F∥ / ∥polynomial.eval a (polynomial.derivative F)∥ : newton_seq_dist_to_a (k+1) (succ_pos _)
 
-private lemma bound' : tendsto (λ n : ℕ, ∥F.derivative.eval a∥ * T^(2^n)) at_top (nhds 0) :=
+private lemma bound' : tendsto (λ n : ℕ, ∥F.derivative.eval a∥ * T^(2^n)) at_top (𝓝 0) :=
 begin
   rw ←mul_zero (∥F.derivative.eval a∥),
   exact tendsto_mul (tendsto_const_nhds)
@@ -320,7 +320,7 @@ begin
   simpa [normed_field.norm_mul, real.norm_eq_abs, abs_of_nonneg (mtn n)] using hN _ hn
 end
 
-private lemma bound'_sq : tendsto (λ n : ℕ, ∥F.derivative.eval a∥^2 * T^(2^n)) at_top (nhds 0) :=
+private lemma bound'_sq : tendsto (λ n : ℕ, ∥F.derivative.eval a∥^2 * T^(2^n)) at_top (𝓝 0) :=
 begin
   rw [←mul_zero (∥F.derivative.eval a∥), _root_.pow_two],
   simp only [mul_assoc],
@@ -351,18 +351,18 @@ setoid.symm (cau_seq.equiv_lim newton_cau_seq) _ hε
 private lemma soln_deriv_norm : ∥F.derivative.eval soln∥ = ∥F.derivative.eval a∥ :=
 norm_deriv_eq newton_seq_deriv_norm
 
-private lemma newton_seq_norm_tendsto_zero : tendsto (λ i, ∥F.eval (newton_cau_seq i)∥) at_top (nhds 0) :=
+private lemma newton_seq_norm_tendsto_zero : tendsto (λ i, ∥F.eval (newton_cau_seq i)∥) at_top (𝓝 0) :=
 squeeze_zero (λ _, norm_nonneg _) newton_seq_norm_le bound'_sq
 
 private lemma newton_seq_dist_tendsto :
-  tendsto (λ n, ∥newton_cau_seq n - a∥) at_top (nhds (∥F.eval a∥ / ∥F.derivative.eval a∥)) :=
+  tendsto (λ n, ∥newton_cau_seq n - a∥) at_top (𝓝 (∥F.eval a∥ / ∥F.derivative.eval a∥)) :=
 tendsto.congr'
   (suffices ∃ k, ∀ n ≥ k,  ∥F.eval a∥ / ∥F.derivative.eval a∥ = ∥newton_cau_seq n - a∥, by simpa,
     ⟨1, λ _ hx, (newton_seq_dist_to_a _ hx).symm⟩)
   (tendsto_const_nhds)
 
 private lemma newton_seq_dist_tendsto' :
-  tendsto (λ n, ∥newton_cau_seq n - a∥) at_top (nhds ∥soln - a∥) :=
+  tendsto (λ n, ∥newton_cau_seq n - a∥) at_top (𝓝 ∥soln - a∥) :=
 tendsto.comp (continuous_iff_continuous_at.1 continuous_norm _)
              (tendsto_sub (tendsto_limit _) tendsto_const_nhds)
 

--- a/src/data/real/hyperreal.lean
+++ b/src/data/real/hyperreal.lean
@@ -8,6 +8,7 @@ Construction of the hyperreal numbers as an ultraproduct of real sequences.
 import data.real.basic algebra.field order.filter.filter_product analysis.specific_limits
 
 open filter filter.filter_product
+open_locale topological_space
 
 local attribute [instance] classical.prop_decidable -- TODO: use "open_locale classical"
 
@@ -54,7 +55,7 @@ lemma omega_ne_zero : ω ≠ 0 := ne_of_gt omega_pos
 
 theorem epsilon_mul_omega : ε * ω = 1 := @inv_mul_cancel _ _ ω omega_ne_zero
 
-lemma lt_of_tendsto_zero_of_pos {f : ℕ → ℝ} (hf : tendsto f at_top (nhds 0)) :
+lemma lt_of_tendsto_zero_of_pos {f : ℕ → ℝ} (hf : tendsto f at_top (𝓝 0)) :
   ∀ {r : ℝ}, r > 0 → of_seq f < (r : ℝ*) :=
 begin
   simp only [metric.tendsto_at_top, dist_zero_right, norm, lt_def U] at hf ⊢,
@@ -66,12 +67,12 @@ begin
     (set.finite_subset (set.finite_le_nat N) hs)
 end
 
-lemma neg_lt_of_tendsto_zero_of_pos {f : ℕ → ℝ} (hf : tendsto f at_top (nhds 0)) :
+lemma neg_lt_of_tendsto_zero_of_pos {f : ℕ → ℝ} (hf : tendsto f at_top (𝓝 0)) :
   ∀ {r : ℝ}, r > 0 → (-r : ℝ*) < of_seq f :=
 λ r hr, have hg : _ := tendsto_neg hf,
 neg_lt_of_neg_lt (by rw [neg_zero] at hg; exact lt_of_tendsto_zero_of_pos hg hr)
 
-lemma gt_of_tendsto_zero_of_neg {f : ℕ → ℝ} (hf : tendsto f at_top (nhds 0)) :
+lemma gt_of_tendsto_zero_of_neg {f : ℕ → ℝ} (hf : tendsto f at_top (𝓝 0)) :
   ∀ {r : ℝ}, r < 0 → (r : ℝ*) < of_seq f :=
 λ r hr, by rw [←of_eq_coe, ←neg_neg r, of_neg];
 exact neg_lt_of_tendsto_zero_of_pos hf (neg_pos.mpr hr)
@@ -564,7 +565,7 @@ lemma infinitesimal_mul {x y : ℝ*} :
 zero_mul 0 ▸ is_st_mul
 
 theorem infinitesimal_of_tendsto_zero {f : ℕ → ℝ} :
-  tendsto f at_top (nhds 0) → infinitesimal (of_seq f) :=
+  tendsto f at_top (𝓝 0) → infinitesimal (of_seq f) :=
 λ hf d hd, by rw [←of_eq_coe, ←of_eq_coe, sub_eq_add_neg,
   ←of_neg, ←of_add, ←of_add, zero_add, zero_add, of_eq_coe, of_eq_coe];
 exact ⟨neg_lt_of_tendsto_zero_of_pos hf hd, lt_of_tendsto_zero_of_pos hf hd⟩
@@ -645,9 +646,9 @@ end
 
 -- ST STUFF THAT REQUIRES INFINITESIMAL MACHINERY
 
-theorem is_st_of_tendsto {f : ℕ → ℝ} {r : ℝ} (hf : tendsto f at_top (nhds r)) :
+theorem is_st_of_tendsto {f : ℕ → ℝ} {r : ℝ} (hf : tendsto f at_top (𝓝 r)) :
   is_st (of_seq f) r :=
-have hg : tendsto (λ n, f n - r) at_top (nhds 0) :=
+have hg : tendsto (λ n, f n - r) at_top (𝓝 0) :=
   (sub_self r) ▸ (tendsto_sub hf tendsto_const_nhds),
 by rw [←(zero_add r), ←(sub_add_cancel f (λ n, r))];
 exact is_st_add (infinitesimal_of_tendsto_zero hg) (is_st_refl_real r)

--- a/src/measure_theory/decomposition.lean
+++ b/src/measure_theory/decomposition.lean
@@ -12,7 +12,7 @@ TODO:
 import measure_theory.measure_space
 
 open set lattice filter
-open_locale classical
+open_locale classical topological_space
 
 namespace measure_theory
 
@@ -52,7 +52,7 @@ begin
     ac_refl },
 
   have d_Union : ∀(s : ℕ → set α), (∀n, is_measurable (s n)) → monotone s →
-    tendsto (λn, d (s n)) at_top (nhds (d (⋃n, s n))),
+    tendsto (λn, d (s n)) at_top (𝓝 (d (⋃n, s n))),
   { assume s hs hm,
     refine tendsto_sub _ _;
       refine (nnreal.tendsto_coe.2 $
@@ -61,7 +61,7 @@ begin
     exact hν _ },
 
   have d_Inter : ∀(s : ℕ → set α), (∀n, is_measurable (s n)) → (∀n m, n ≤ m → s m ⊆ s n) →
-    tendsto (λn, d (s n)) at_top (nhds (d (⋂n, s n))),
+    tendsto (λn, d (s n)) at_top (𝓝 (d (⋂n, s n))),
   { assume s hs hm,
     refine tendsto_sub _ _;
       refine (nnreal.tendsto_coe.2 $
@@ -150,19 +150,19 @@ begin
 
   let s := ⋃ m, ⋂n, f m n,
   have γ_le_d_s : γ ≤ d s,
-  { have hγ : tendsto (λm:ℕ, γ - 2 * (1/2)^m) at_top (nhds γ),
-    { suffices : tendsto (λm:ℕ, γ - 2 * (1/2)^m) at_top (nhds (γ - 2 * 0)), { simpa },
+  { have hγ : tendsto (λm:ℕ, γ - 2 * (1/2)^m) at_top (𝓝 γ),
+    { suffices : tendsto (λm:ℕ, γ - 2 * (1/2)^m) at_top (𝓝 (γ - 2 * 0)), { simpa },
       exact (tendsto_sub tendsto_const_nhds $ tendsto_mul tendsto_const_nhds $
         tendsto_pow_at_top_nhds_0_of_lt_1
           (le_of_lt $ half_pos $ zero_lt_one) (half_lt_self zero_lt_one)) },
-    have hd : tendsto (λm, d (⋂n, f m n)) at_top (nhds (d (⋃ m, ⋂ n, f m n))),
+    have hd : tendsto (λm, d (⋂n, f m n)) at_top (𝓝 (d (⋃ m, ⋂ n, f m n))),
     { refine d_Union _ _ _,
       { assume n, exact is_measurable.Inter (assume m, hf _ _) },
       { exact assume n m hnm, subset_Inter
           (assume i, subset.trans (Inter_subset (f n) i) $ f_subset_f hnm $ le_refl _) } },
     refine le_of_tendsto_of_tendsto (@at_top_ne_bot ℕ _ _) hγ hd (univ_mem_sets' $ assume m, _),
     change γ - 2 * (1 / 2) ^ m ≤ d (⋂ (n : ℕ), f m n),
-    have : tendsto (λn, d (f m n)) at_top (nhds (d (⋂ n, f m n))),
+    have : tendsto (λn, d (f m n)) at_top (𝓝 (d (⋂ n, f m n))),
     { refine d_Inter _ _ _,
       { assume n, exact hf _ _ },
       { assume n m hnm, exact f_subset_f (le_refl _) hnm } },

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -14,7 +14,7 @@ import
   measure_theory.borel_space
 noncomputable theory
 open lattice set filter
-open_locale classical
+open_locale classical topological_space
 
 section sequence_of_directed
 variables {α : Type*} {β : Type*} [encodable α] [inhabited α]
@@ -1143,8 +1143,8 @@ lemma dominated_convergence_nn
   {F : ℕ → α → ennreal} {f : α → ennreal} {g : α → ennreal}
   (hF_meas : ∀n, measurable (F n)) (h_bound : ∀n, ∀ₘ a, F n a ≤ g a)
   (h_fin : lintegral g < ⊤)
-  (h_lim : ∀ₘ a, tendsto (λ n, F n a) at_top (nhds (f a))) :
-  tendsto (λn, lintegral (F n)) at_top (nhds (lintegral f)) :=
+  (h_lim : ∀ₘ a, tendsto (λ n, F n a) at_top (𝓝 (f a))) :
+  tendsto (λn, lintegral (F n)) at_top (𝓝 (lintegral f)) :=
 begin
   have limsup_le_lintegral :=
   calc

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -23,7 +23,7 @@ import topology.instances.ennreal
 noncomputable theory
 
 open classical set lattice filter finset function
-open_locale classical
+open_locale classical topological_space
 
 universes u v w x
 
@@ -412,7 +412,7 @@ by rw [← measure_union hd (hs.inter ht) (hs.diff ht), inter_union_diff s t]
 
 lemma tendsto_measure_Union {μ : measure α} {s : ℕ → set α}
   (hs : ∀n, is_measurable (s n)) (hm : monotone s) :
-  tendsto (μ ∘ s) at_top (nhds (μ (⋃n, s n))) :=
+  tendsto (μ ∘ s) at_top (𝓝 (μ (⋃n, s n))) :=
 begin
   rw measure_Union_eq_supr_nat hs hm,
   exact tendsto_at_top_supr_nat (μ ∘ s) (assume n m hnm, measure_mono $ hm $ hnm)
@@ -420,7 +420,7 @@ end
 
 lemma tendsto_measure_Inter {μ : measure α} {s : ℕ → set α}
   (hs : ∀n, is_measurable (s n)) (hm : ∀n m, n ≤ m → s m ⊆ s n) (hf : ∃i, μ (s i) < ⊤) :
-  tendsto (μ ∘ s) at_top (nhds (μ (⋂n, s n))) :=
+  tendsto (μ ∘ s) at_top (𝓝 (μ (⋂n, s n))) :=
 begin
   rw measure_Inter_eq_infi_nat hs hm hf,
   exact tendsto_at_top_infi_nat (μ ∘ s) (assume n m hnm, measure_mono $ hm _ _ $ hnm),

--- a/src/measure_theory/simple_func_dense.lean
+++ b/src/measure_theory/simple_func_dense.lean
@@ -11,8 +11,7 @@ import measure_theory.l1_space
 
 noncomputable theory
 open lattice set filter topological_space
-open_locale classical
-
+open_locale classical topological_space
 
 universes u v
 variables {α : Type u} {β : Type v} {ι : Type*}
@@ -24,7 +23,7 @@ variables [measure_space α] [normed_group β] [second_countable_topology β]
 
 local infixr ` →ₛ `:25 := simple_func
 lemma simple_func_sequence_tendsto {f : α → β} (hf : measurable f) :
-  ∃ (F : ℕ → (α →ₛ β)), ∀ x : α, tendsto (λ n, F n x) at_top (nhds (f x)) ∧
+  ∃ (F : ℕ → (α →ₛ β)), ∀ x : α, tendsto (λ n, F n x) at_top (𝓝 (f x)) ∧
   ∀ n, ∥F n x∥ ≤ ∥f x∥ + ∥f x∥ :=
 -- enumerate a countable dense subset {e k} of β
 let ⟨D, ⟨D_countable, D_dense⟩⟩ := separable_space.exists_countable_closure_eq_univ β in
@@ -238,7 +237,7 @@ classical.by_cases
 
 lemma simple_func_sequence_tendsto' {f : α → β} (hfm : measurable f)
   (hfi : integrable f) : ∃ (F : ℕ → (α →ₛ β)), (∀n, integrable (F n)) ∧
-   tendsto (λ n, ∫⁻ x,  nndist (F n x) (f x)) at_top  (nhds 0) :=
+   tendsto (λ n, ∫⁻ x,  nndist (F n x) (f x)) at_top  (𝓝 0) :=
 let ⟨F, hF⟩ := simple_func_sequence_tendsto hfm in
 let G : ℕ → α → ennreal := λn x, nndist (F n x) (f x) in
 let g : α → ennreal := λx, nnnorm (f x) + nnnorm (f x) + nnnorm (f x) in
@@ -257,7 +256,7 @@ have h_finite : lintegral g < ⊤ :=
       (∫⁻ x, nnnorm (f x)) + (∫⁻ x, nnnorm (f x)) + (∫⁻ x, nnnorm (f x)) :
     by rw [lintegral_add, lintegral_add]; simp only [measurable_coe_nnnorm hfm, measurable_add]
     ... < ⊤ : by { simp only [and_self, add_lt_top], exact hfi},
-have h_lim : ∀ₘ x, tendsto (λ n, G n x) at_top (nhds 0) := all_ae_of_all $ λ x,
+have h_lim : ∀ₘ x, tendsto (λ n, G n x) at_top (𝓝 0) := all_ae_of_all $ λ x,
   begin
     apply (@tendsto_coe ℕ at_top (λ n, nndist (F n x) (f x)) 0).2,
     apply (@nnreal.tendsto_coe ℕ at_top (λ n, nndist (F n x) (f x)) 0).1,

--- a/src/order/filter/pointwise.lean
+++ b/src/order/filter/pointwise.lean
@@ -5,7 +5,7 @@ Authors: Zhouhang Zhou
 
 The pointwise operations on filters have nice properties, such as
   • map m (f₁ * f₂) = map m f₁ * map m f₂
-  • nhds x * nhds y = nhds (x * y)
+  • 𝓝 x * 𝓝 y = 𝓝 (x * y)
 
 -/
 

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -12,7 +12,7 @@ import group_theory.quotient_group
 import topology.algebra.monoid topology.homeomorph
 
 open classical set lattice filter topological_space
-open_locale classical
+open_locale classical topological_space
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
@@ -50,7 +50,7 @@ continuous_inv'.comp_continuous_on hf
 
 @[to_additive]
 lemma tendsto_inv [topological_group α] {f : β → α} {x : filter β} {a : α}
-  (hf : tendsto f x (nhds a)) : tendsto (λx, (f x)⁻¹) x (nhds a⁻¹) :=
+  (hf : tendsto f x (𝓝 a)) : tendsto (λx, (f x)⁻¹) x (𝓝 a⁻¹) :=
 tendsto.comp (continuous_iff_continuous_at.mp (topological_group.continuous_inv α) a) hf
 
 @[to_additive topological_add_group]
@@ -98,10 +98,10 @@ protected def homeomorph.inv (α : Type*) [topological_space α] [group α] [top
   .. equiv.inv α }
 
 @[to_additive exists_nhds_half]
-lemma exists_nhds_split [topological_group α] {s : set α} (hs : s ∈ nhds (1 : α)) :
-  ∃ V ∈ nhds (1 : α), ∀ v w ∈ V, v * w ∈ s :=
+lemma exists_nhds_split [topological_group α] {s : set α} (hs : s ∈ 𝓝 (1 : α)) :
+  ∃ V ∈ 𝓝 (1 : α), ∀ v w ∈ V, v * w ∈ s :=
 begin
-  have : ((λa:α×α, a.1 * a.2) ⁻¹' s) ∈ nhds ((1, 1) : α × α) :=
+  have : ((λa:α×α, a.1 * a.2) ⁻¹' s) ∈ 𝓝 ((1, 1) : α × α) :=
     tendsto_mul' (by simpa using hs),
   rw nhds_prod_eq at this,
   rcases mem_prod_iff.1 this with ⟨V₁, H₁, V₂, H₂, H⟩,
@@ -109,20 +109,20 @@ begin
 end
 
 @[to_additive exists_nhds_half_neg]
-lemma exists_nhds_split_inv [topological_group α] {s : set α} (hs : s ∈ nhds (1 : α)) :
-  ∃ V ∈ nhds (1 : α), ∀ v w ∈ V, v * w⁻¹ ∈ s :=
+lemma exists_nhds_split_inv [topological_group α] {s : set α} (hs : s ∈ 𝓝 (1 : α)) :
+  ∃ V ∈ 𝓝 (1 : α), ∀ v w ∈ V, v * w⁻¹ ∈ s :=
 begin
-  have : tendsto (λa:α×α, a.1 * (a.2)⁻¹) ((nhds (1:α)).prod (nhds (1:α))) (nhds 1),
-  { simpa using tendsto_mul (@tendsto_fst α α (nhds 1) (nhds 1)) (tendsto_inv tendsto_snd) },
-  have : ((λa:α×α, a.1 * (a.2)⁻¹) ⁻¹' s) ∈ (nhds (1:α)).prod (nhds (1:α)) :=
+  have : tendsto (λa:α×α, a.1 * (a.2)⁻¹) ((𝓝 (1:α)).prod (𝓝 (1:α))) (𝓝 1),
+  { simpa using tendsto_mul (@tendsto_fst α α (𝓝 1) (𝓝 1)) (tendsto_inv tendsto_snd) },
+  have : ((λa:α×α, a.1 * (a.2)⁻¹) ⁻¹' s) ∈ (𝓝 (1:α)).prod (𝓝 (1:α)) :=
     this (by simpa using hs),
   rcases mem_prod_iff.1 this with ⟨V₁, H₁, V₂, H₂, H⟩,
   exact ⟨V₁ ∩ V₂, inter_mem_sets H₁ H₂, assume v w ⟨hv, _⟩ ⟨_, hw⟩, @H (v, w) ⟨hv, hw⟩⟩
 end
 
 @[to_additive exists_nhds_quarter]
-lemma exists_nhds_split4 [topological_group α] {u : set α} (hu : u ∈ nhds (1 : α)) :
-  ∃ V ∈ nhds (1 : α), ∀ {v w s t}, v ∈ V → w ∈ V → s ∈ V → t ∈ V → v * w * s * t ∈ u :=
+lemma exists_nhds_split4 [topological_group α] {u : set α} (hu : u ∈ 𝓝 (1 : α)) :
+  ∃ V ∈ 𝓝 (1 : α), ∀ {v w s t}, v ∈ V → w ∈ V → s ∈ V → t ∈ V → v * w * s * t ∈ u :=
 begin
   rcases exists_nhds_split hu with ⟨W, W_nhd, h⟩,
   rcases exists_nhds_split W_nhd with ⟨V, V_nhd, h'⟩,
@@ -134,10 +134,10 @@ end
 section
 variable (α)
 @[to_additive]
-lemma nhds_one_symm [topological_group α] : comap (λr:α, r⁻¹) (nhds (1 : α)) = nhds (1 : α) :=
+lemma nhds_one_symm [topological_group α] : comap (λr:α, r⁻¹) (𝓝 (1 : α)) = 𝓝 (1 : α) :=
 begin
-  have lim : tendsto (λr:α, r⁻¹) (nhds 1) (nhds 1),
-  { simpa using tendsto_inv (@tendsto_id α (nhds 1)) },
+  have lim : tendsto (λr:α, r⁻¹) (𝓝 1) (𝓝 1),
+  { simpa using tendsto_inv (@tendsto_id α (𝓝 1)) },
   refine comap_eq_of_inverse _ _ lim lim,
   { funext x, simp },
 end
@@ -145,13 +145,13 @@ end
 
 @[to_additive]
 lemma nhds_translation_mul_inv [topological_group α] (x : α) :
-  comap (λy:α, y * x⁻¹) (nhds 1) = nhds x :=
+  comap (λy:α, y * x⁻¹) (𝓝 1) = 𝓝 x :=
 begin
   refine comap_eq_of_inverse (λy:α, y * x) _ _ _,
   { funext x; simp },
-  { suffices : tendsto (λy:α, y * x⁻¹) (nhds x) (nhds (x * x⁻¹)), { simpa },
+  { suffices : tendsto (λy:α, y * x⁻¹) (𝓝 x) (𝓝 (x * x⁻¹)), { simpa },
     exact tendsto_mul tendsto_id tendsto_const_nhds },
-  { suffices : tendsto (λy:α, y * x) (nhds 1) (nhds (1 * x)), { simpa },
+  { suffices : tendsto (λy:α, y * x) (𝓝 1) (𝓝 (1 * x)), { simpa },
     exact tendsto_mul tendsto_id tendsto_const_nhds }
 end
 
@@ -236,10 +236,10 @@ lemma continuous_on.sub [topological_add_group α] [topological_space β] {f : �
 continuous_sub'.comp_continuous_on (hf.prod hg)
 
 lemma tendsto_sub [topological_add_group α] {f : β → α} {g : β → α} {x : filter β} {a b : α}
-  (hf : tendsto f x (nhds a)) (hg : tendsto g x (nhds b)) : tendsto (λx, f x - g x) x (nhds (a - b)) :=
+  (hf : tendsto f x (𝓝 a)) (hg : tendsto g x (𝓝 b)) : tendsto (λx, f x - g x) x (𝓝 (a - b)) :=
 by simp; exact tendsto_add hf (tendsto_neg hg)
 
-lemma nhds_translation [topological_add_group α] (x : α) : comap (λy:α, y - x) (nhds 0) = nhds x :=
+lemma nhds_translation [topological_add_group α] (x : α) : comap (λy:α, y - x) (𝓝 0) = 𝓝 x :=
 nhds_translation_add_neg x
 
 end topological_add_group
@@ -284,7 +284,7 @@ begin
   exact ⟨V₁ ∩ V₂, inter_mem_sets H₁ H₂, assume v w ⟨hv, _⟩ ⟨_, hw⟩, @H (v, w) ⟨hv, hw⟩⟩
 end
 
-lemma nhds_eq (a : α) : nhds a = map (λx, x + a) (Z α) :=
+lemma nhds_eq (a : α) : 𝓝 a = map (λx, x + a) (Z α) :=
 topological_space.nhds_mk_of_nhds _ _
   (assume a, calc pure a = map (λx, x + a) (pure 0) : by simp
     ... ≤ _ : map_mono zero_Z)
@@ -300,7 +300,7 @@ topological_space.nhds_mk_of_nhds _ _
         simpa using eqt _ _ hxt hb }
     end)
 
-lemma nhds_zero_eq_Z : nhds 0 = Z α := by simp [nhds_eq]; exact filter.map_id
+lemma nhds_zero_eq_Z : 𝓝 0 = Z α := by simp [nhds_eq]; exact filter.map_id
 
 instance : topological_add_monoid α :=
 ⟨ continuous_iff_continuous_at.2 $ assume ⟨a, b⟩,
@@ -388,7 +388,7 @@ section
 variables [topological_space α] [comm_group α] [topological_group α]
 
 @[to_additive]
-lemma nhds_pointwise_mul (x y : α) : nhds (x * y) = nhds x * nhds y :=
+lemma nhds_pointwise_mul (x y : α) : 𝓝 (x * y) = 𝓝 x * 𝓝 y :=
 filter_eq $ set.ext $ assume s,
 begin
   rw [← nhds_translation_mul_inv x, ← nhds_translation_mul_inv y, ← nhds_translation_mul_inv (x*y)],
@@ -411,7 +411,7 @@ begin
 end
 
 @[to_additive]
-lemma nhds_is_mul_hom : is_mul_hom (λx:α, nhds x) := ⟨λ_ _, nhds_pointwise_mul _ _⟩
+lemma nhds_is_mul_hom : is_mul_hom (λx:α, 𝓝 x) := ⟨λ_ _, nhds_pointwise_mul _ _⟩
 
 end
 

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -22,6 +22,7 @@ import logic.function algebra.big_operators data.set.lattice data.finset
 
 noncomputable theory
 open lattice finset filter function classical
+open_locale topological_space
 local attribute [instance] classical.prop_decidable -- TODO: use "open_locale classical"
 
 def option.cases_on' {α β} : option α → β → (α → β) → β
@@ -43,7 +44,7 @@ This is based on Mario Carneiro's infinite sum in Metamath.
 For the definition or many statements, α does not need to be a topological monoid. We only add
 this assumption later, for the lemmas where it is relevant.
 -/
-def has_sum (f : β → α) (a : α) : Prop := tendsto (λs:finset β, s.sum f) at_top (nhds a)
+def has_sum (f : β → α) (a : α) : Prop := tendsto (λs:finset β, s.sum f) at_top (𝓝 a)
 
 /-- `summable f` means that `f` has some (infinite) sum. Use `tsum` to get the value. -/
 def summable (f : β → α) : Prop := ∃a, has_sum f a
@@ -89,7 +90,7 @@ have ∀x y, j x = j y → x = y,
   by rwa [h₁, h₁] at this,
 have (λs:finset γ, s.sum (f ∘ j)) = (λs:finset β, s.sum f) ∘ (λs:finset γ, s.image j),
   from funext $ assume s, (sum_image $ assume x _ y _, this x y).symm,
-show tendsto (λs:finset γ, s.sum (f ∘ j)) at_top (nhds a),
+show tendsto (λs:finset γ, s.sum (f ∘ j)) at_top (𝓝 a),
    by rw [this]; apply hf.comp (tendsto_finset_image_at_top_at_top h₂)
 
 lemma has_sum_iff_has_sum_of_iso {j : γ → β} (i : β → γ)
@@ -106,11 +107,11 @@ lemma has_sum_hom (g : α → γ) [add_comm_monoid γ] [topological_space γ]
   has_sum (g ∘ f) (g a) :=
 have (λs:finset β, s.sum (g ∘ f)) = g ∘ (λs:finset β, s.sum f),
   from funext $ assume s, sum_hom g,
-show tendsto (λs:finset β, s.sum (g ∘ f)) at_top (nhds (g a)),
+show tendsto (λs:finset β, s.sum (g ∘ f)) at_top (𝓝 (g a)),
   by rw [this]; exact tendsto.comp (continuous_iff_continuous_at.mp h₃ a) hf
 
 lemma tendsto_sum_nat_of_has_sum {f : ℕ → α} (h : has_sum f a) :
-  tendsto (λn:ℕ, (range n).sum f) at_top (nhds a) :=
+  tendsto (λn:ℕ, (range n).sum f) at_top (𝓝 a) :=
 suffices map (λ (n : ℕ), sum (range n) f) at_top ≤ map (λ (s : finset ℕ), sum s f) at_top,
   from le_trans this h,
 assume s (hs : {t : finset ℕ | t.sum f ∈ s} ∈ at_top),
@@ -161,7 +162,7 @@ mem_at_top_sets.mpr $ exists.intro fsts $ assume bs (hbs : fsts ⊆ bs),
     set.ne_empty_iff_exists_mem.mpr $ exists.intro cs' $
     by simp [sum_eq, this]; { intros b hb, simp [cs', hb, finset.subset_union_right] },
   have tendsto (λp:(Πb:β, finset (γ b)), bs.sum (λb, (p b).sum (λc, f ⟨b, c⟩)))
-      (⨅b (h : b ∈ bs), at_top.comap (λp, p b)) (nhds (bs.sum g)),
+      (⨅b (h : b ∈ bs), at_top.comap (λp, p b)) (𝓝 (bs.sum g)),
     from tendsto_finset_sum bs $
       assume c hc, tendsto_infi' c $ tendsto_infi' hc $ by apply tendsto.comp (hf c) tendsto_comap,
   have bs.sum g ∈ s,
@@ -492,7 +493,7 @@ lemma summable_iff_cauchy : summable f ↔ cauchy (map (λ (s : finset β), sum 
 variable [uniform_add_group α]
 
 lemma summable_iff_vanishing :
-  summable f ↔ ∀ e ∈ nhds (0:α), (∃s:finset β, ∀t, disjoint t s → t.sum f ∈ e) :=
+  summable f ↔ ∀ e ∈ 𝓝 (0:α), (∃s:finset β, ∀t, disjoint t s → t.sum f ∈ e) :=
 begin
   simp only [summable_iff_cauchy, cauchy_map_iff, and_iff_right at_top_ne_bot,
     prod_at_top_at_top_eq, uniformity_eq_comap_nhds_zero α, tendsto_comap_iff, (∘)],

--- a/src/topology/algebra/monoid.lean
+++ b/src/topology/algebra/monoid.lean
@@ -12,7 +12,7 @@ import topology.constructions topology.continuous_on
 import algebra.pi_instances
 
 open classical set lattice filter topological_space
-open_locale classical
+open_locale classical topological_space
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
@@ -64,19 +64,19 @@ lemma continuous_pow : ∀ n : ℕ, continuous (λ a : α, a ^ n)
 | (k+1) := show continuous (λ (a : α), a * a ^ k), from continuous_mul continuous_id (continuous_pow _)
 
 @[to_additive]
-lemma tendsto_mul' {a b : α} : tendsto (λp:α×α, p.fst * p.snd) (nhds (a, b)) (nhds (a * b)) :=
+lemma tendsto_mul' {a b : α} : tendsto (λp:α×α, p.fst * p.snd) (𝓝 (a, b)) (𝓝 (a * b)) :=
 continuous_iff_continuous_at.mp (topological_monoid.continuous_mul α) (a, b)
 
 @[to_additive]
 lemma tendsto_mul {f : β → α} {g : β → α} {x : filter β} {a b : α}
-  (hf : tendsto f x (nhds a)) (hg : tendsto g x (nhds b)) :
-  tendsto (λx, f x * g x) x (nhds (a * b)) :=
+  (hf : tendsto f x (𝓝 a)) (hg : tendsto g x (𝓝 b)) :
+  tendsto (λx, f x * g x) x (𝓝 (a * b)) :=
 tendsto.comp (by rw [←nhds_prod_eq]; exact tendsto_mul') (hf.prod_mk hg)
 
 @[to_additive]
 lemma tendsto_list_prod {f : γ → β → α} {x : filter β} {a : γ → α} :
-  ∀l:list γ, (∀c∈l, tendsto (f c) x (nhds (a c))) →
-    tendsto (λb, (l.map (λc, f c b)).prod) x (nhds ((l.map a).prod))
+  ∀l:list γ, (∀c∈l, tendsto (f c) x (𝓝 (a c))) →
+    tendsto (λb, (l.map (λc, f c b)).prod) x (𝓝 ((l.map a).prod))
 | []       _ := by simp [tendsto_const_nhds]
 | (f :: l) h :=
   begin
@@ -108,20 +108,20 @@ variables [topological_space α] [comm_monoid α]
 
 @[to_additive]
 lemma is_submonoid.mem_nhds_one (β : set α) [is_submonoid β] (oβ : is_open β) :
-  β ∈ nhds (1 : α) :=
+  β ∈ 𝓝 (1 : α) :=
 mem_nhds_sets_iff.2 ⟨β, (by refl), oβ, is_submonoid.one_mem _⟩
 
 variable [topological_monoid α]
 
 @[to_additive]
 lemma tendsto_multiset_prod {f : γ → β → α} {x : filter β} {a : γ → α} (s : multiset γ) :
-  (∀c∈s, tendsto (f c) x (nhds (a c))) →
-    tendsto (λb, (s.map (λc, f c b)).prod) x (nhds ((s.map a).prod)) :=
+  (∀c∈s, tendsto (f c) x (𝓝 (a c))) →
+    tendsto (λb, (s.map (λc, f c b)).prod) x (𝓝 ((s.map a).prod)) :=
 by { rcases s with ⟨l⟩, simp, exact tendsto_list_prod l }
 
 @[to_additive]
 lemma tendsto_finset_prod {f : γ → β → α} {x : filter β} {a : γ → α} (s : finset γ) :
-  (∀c∈s, tendsto (f c) x (nhds (a c))) → tendsto (λb, s.prod (λc, f c b)) x (nhds (s.prod a)) :=
+  (∀c∈s, tendsto (f c) x (𝓝 (a c))) → tendsto (λb, s.prod (λc, f c b)) x (𝓝 (s.prod a)) :=
 tendsto_multiset_prod _
 
 @[to_additive]

--- a/src/topology/algebra/open_subgroup.lean
+++ b/src/topology/algebra/open_subgroup.lean
@@ -21,6 +21,7 @@ end open_add_subgroup
 
 namespace open_subgroup
 open function lattice topological_space
+open_locale topological_space
 variables {G : Type*} [group G] [topological_space G]
 variables {U V : open_subgroup G}
 
@@ -58,7 +59,7 @@ protected lemma mul_mem {g₁ g₂ : G} (h₁ : g₁ ∈ U) (h₂ : g₂ ∈ U) 
   @is_submonoid.mul_mem G _ U _ g₁ g₂ h₁ h₂
 
 @[to_additive]
-lemma mem_nhds_one : (U : set G) ∈ nhds (1 : G) :=
+lemma mem_nhds_one : (U : set G) ∈ 𝓝 (1 : G) :=
 mem_nhds_sets U.is_open U.one_mem
 variable {U}
 

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -12,6 +12,7 @@ import topology.constructions
 
 open classical set lattice filter topological_space
 local attribute [instance] classical.prop_decidable -- TODO: use "open_locale classical"
+open_locale topological_space
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
@@ -51,19 +52,19 @@ lemma is_closed_Icc {a b : α} : is_closed (Icc a b) :=
 is_closed_inter (is_closed_ge' a) (is_closed_le' b)
 
 lemma le_of_tendsto_of_tendsto {f g : β → α} {b : filter β} {a₁ a₂ : α} (hb : b ≠ ⊥)
-  (hf : tendsto f b (nhds a₁)) (hg : tendsto g b (nhds a₂)) (h : {b | f b ≤ g b} ∈ b) :
+  (hf : tendsto f b (𝓝 a₁)) (hg : tendsto g b (𝓝 a₂)) (h : {b | f b ≤ g b} ∈ b) :
   a₁ ≤ a₂ :=
-have tendsto (λb, (f b, g b)) b (nhds (a₁, a₂)),
+have tendsto (λb, (f b, g b)) b (𝓝 (a₁, a₂)),
   by rw [nhds_prod_eq]; exact hf.prod_mk hg,
 show (a₁, a₂) ∈ {p:α×α | p.1 ≤ p.2},
   from mem_of_closed_of_tendsto hb this t.is_closed_le' h
 
 lemma le_of_tendsto {f : β → α} {a b : α} {x : filter β}
-  (nt : x ≠ ⊥) (lim : tendsto f x (nhds a)) (h : f ⁻¹' {c | c ≤ b} ∈ x) : a ≤ b :=
+  (nt : x ≠ ⊥) (lim : tendsto f x (𝓝 a)) (h : f ⁻¹' {c | c ≤ b} ∈ x) : a ≤ b :=
 le_of_tendsto_of_tendsto nt lim tendsto_const_nhds h
 
 lemma ge_of_tendsto {f : β → α} {a b : α} {x : filter β}
-  (nt : x ≠ ⊥) (lim : tendsto f x (nhds a)) (h : f ⁻¹' {c | b ≤ c} ∈ x) : b ≤ a :=
+  (nt : x ≠ ⊥) (lim : tendsto f x (𝓝 a)) (h : f ⁻¹' {c | b ≤ c} ∈ x) : b ≤ a :=
 le_of_tendsto_of_tendsto nt tendsto_const_nhds lim h
 
 @[simp] lemma closure_le_eq [topological_space β] {f g : β → α} (hf : continuous f) (hg : continuous g) :
@@ -142,9 +143,9 @@ continuous_if this hf hg
 
 end
 
-lemma tendsto_max {b : filter β} {a₁ a₂ : α} (hf : tendsto f b (nhds a₁)) (hg : tendsto g b (nhds a₂)) :
-  tendsto (λb, max (f b) (g b)) b (nhds (max a₁ a₂)) :=
-show tendsto ((λp:α×α, max p.1 p.2) ∘ (λb, (f b, g b))) b (nhds (max a₁ a₂)),
+lemma tendsto_max {b : filter β} {a₁ a₂ : α} (hf : tendsto f b (𝓝 a₁)) (hg : tendsto g b (𝓝 a₂)) :
+  tendsto (λb, max (f b) (g b)) b (𝓝 (max a₁ a₂)) :=
+show tendsto ((λp:α×α, max p.1 p.2) ∘ (λb, (f b, g b))) b (𝓝 (max a₁ a₂)),
   from tendsto.comp
     begin
       rw [←nhds_prod_eq],
@@ -152,9 +153,9 @@ show tendsto ((λp:α×α, max p.1 p.2) ∘ (λb, (f b, g b))) b (nhds (max a₁
     end
     (hf.prod_mk hg)
 
-lemma tendsto_min {b : filter β} {a₁ a₂ : α} (hf : tendsto f b (nhds a₁)) (hg : tendsto g b (nhds a₂)) :
-  tendsto (λb, min (f b) (g b)) b (nhds (min a₁ a₂)) :=
-show tendsto ((λp:α×α, min p.1 p.2) ∘ (λb, (f b, g b))) b (nhds (min a₁ a₂)),
+lemma tendsto_min {b : filter β} {a₁ a₂ : α} (hf : tendsto f b (𝓝 a₁)) (hg : tendsto g b (𝓝 a₂)) :
+  tendsto (λb, min (f b) (g b)) b (𝓝 (min a₁ a₂)) :=
+show tendsto ((λp:α×α, min p.1 p.2) ∘ (λb, (f b, g b))) b (𝓝 (min a₁ a₂)),
   from tendsto.comp
     begin
       rw [←nhds_prod_eq],
@@ -195,20 +196,20 @@ by rw [@is_open_iff_generate_intervals α _ _ t]; exact generate_open.basic _ �
 lemma is_open_gt' (a : α) : is_open {b:α | b < a} :=
 by rw [@is_open_iff_generate_intervals α _ _ t]; exact generate_open.basic _ ⟨a, or.inr rfl⟩
 
-lemma lt_mem_nhds {a b : α} (h : a < b) : {b | a < b} ∈ nhds b :=
+lemma lt_mem_nhds {a b : α} (h : a < b) : {b | a < b} ∈ 𝓝 b :=
 mem_nhds_sets (is_open_lt' _) h
 
-lemma le_mem_nhds {a b : α} (h : a < b) : {b | a ≤ b} ∈ nhds b :=
-(nhds b).sets_of_superset (lt_mem_nhds h) $ assume b hb, le_of_lt hb
+lemma le_mem_nhds {a b : α} (h : a < b) : {b | a ≤ b} ∈ 𝓝 b :=
+(𝓝 b).sets_of_superset (lt_mem_nhds h) $ assume b hb, le_of_lt hb
 
-lemma gt_mem_nhds {a b : α} (h : a < b) : {a | a < b} ∈ nhds a :=
+lemma gt_mem_nhds {a b : α} (h : a < b) : {a | a < b} ∈ 𝓝 a :=
 mem_nhds_sets (is_open_gt' _) h
 
-lemma ge_mem_nhds {a b : α} (h : a < b) : {a | a ≤ b} ∈ nhds a :=
-(nhds a).sets_of_superset (gt_mem_nhds h) $ assume b hb, le_of_lt hb
+lemma ge_mem_nhds {a b : α} (h : a < b) : {a | a ≤ b} ∈ 𝓝 a :=
+(𝓝 a).sets_of_superset (gt_mem_nhds h) $ assume b hb, le_of_lt hb
 
 lemma nhds_eq_orderable {a : α} :
-  nhds a = (⨅b<a, principal {c | b < c}) ⊓ (⨅b>a, principal {c | c < b}) :=
+  𝓝 a = (⨅b<a, principal {c | b < c}) ⊓ (⨅b>a, principal {c | c < b}) :=
 by rw [t.topology_eq_generate_intervals, nhds_generate_from];
 from le_antisymm
   (le_inf
@@ -223,14 +224,14 @@ from le_antisymm
     end)
 
 lemma tendsto_orderable {f : β → α} {a : α} {x : filter β} :
-  tendsto f x (nhds a) ↔ (∀a'<a, {b | a' < f b} ∈ x) ∧ (∀a'>a, {b | a' > f b} ∈ x) :=
+  tendsto f x (𝓝 a) ↔ (∀a'<a, {b | a' < f b} ∈ x) ∧ (∀a'>a, {b | a' > f b} ∈ x) :=
 by simp [@nhds_eq_orderable α _ _, tendsto_inf, tendsto_infi, tendsto_principal]
 
 /-- Also known as squeeze or sandwich theorem. -/
 lemma tendsto_of_tendsto_of_tendsto_of_le_of_le {f g h : β → α} {b : filter β} {a : α}
-  (hg : tendsto g b (nhds a)) (hh : tendsto h b (nhds a))
+  (hg : tendsto g b (𝓝 a)) (hh : tendsto h b (𝓝 a))
   (hgf : {b | g b ≤ f b} ∈ b) (hfh : {b | f b ≤ h b} ∈ b) :
-  tendsto f b (nhds a) :=
+  tendsto f b (𝓝 a) :=
 tendsto_orderable.2
   ⟨assume a' h',
     have {b : β | a' < g b} ∈ b, from (tendsto_orderable.1 hg).left a' h',
@@ -240,9 +241,9 @@ tendsto_orderable.2
     by filter_upwards [this, hfh] assume a h₁ h₂, lt_of_le_of_lt h₂ h₁⟩
 
 lemma nhds_orderable_unbounded {a : α} (hu : ∃u, a < u) (hl : ∃l, l < a) :
-  nhds a = (⨅l (h₂ : l < a) u (h₂ : a < u), principal {x | l < x ∧ x < u }) :=
+  𝓝 a = (⨅l (h₂ : l < a) u (h₂ : a < u), principal {x | l < x ∧ x < u }) :=
 let ⟨u, hu⟩ := hu, ⟨l, hl⟩ := hl in
-calc nhds a = (⨅b<a, principal {c | b < c}) ⊓ (⨅b>a, principal {c | c < b}) : nhds_eq_orderable
+calc 𝓝 a = (⨅b<a, principal {c | b < c}) ⊓ (⨅b>a, principal {c | c < b}) : nhds_eq_orderable
   ... = (⨅b<a, principal {c | b < c} ⊓ (⨅b>a, principal {c | c < b})) :
     binfi_inf hl
   ... = (⨅l<a, (⨅u>a, principal {c | c < u} ⊓ principal {c | l < c})) :
@@ -256,7 +257,7 @@ calc nhds a = (⨅b<a, principal {c | b < c}) ⊓ (⨅b>a, principal {c | c < b}
 
 lemma tendsto_orderable_unbounded {f : β → α} {a : α} {x : filter β}
   (hu : ∃u, a < u) (hl : ∃l, l < a) (h : ∀l u, l < a → a < u → {b | l < f b ∧ f b < u } ∈ x) :
-  tendsto f x (nhds a) :=
+  tendsto f x (𝓝 a) :=
 by rw [nhds_orderable_unbounded hu hl];
 from (tendsto_infi.2 $ assume l, tendsto_infi.2 $ assume hl,
   tendsto_infi.2 $ assume u, tendsto_infi.2 $ assume hu, tendsto_principal.2 $ h l u hl hu)
@@ -302,11 +303,11 @@ induced_orderable_topology' f @hf
   (λ a x ax, let ⟨b, ab, bx⟩ := H ax in ⟨b, hf.1 ab, le_of_lt bx⟩)
 
 lemma nhds_top_orderable [topological_space α] [order_top α] [orderable_topology α] :
-  nhds (⊤:α) = (⨅l (h₂ : l < ⊤), principal {x | l < x}) :=
+  𝓝 (⊤:α) = (⨅l (h₂ : l < ⊤), principal {x | l < x}) :=
 by rw [@nhds_eq_orderable α _ _]; simp [(>)]
 
 lemma nhds_bot_orderable [topological_space α] [order_bot α] [orderable_topology α] :
-  nhds (⊥:α) = (⨅l (h₂ : ⊥ < l), principal {x | x < l}) :=
+  𝓝 (⊥:α) = (⨅l (h₂ : ⊥ < l), principal {x | x < l}) :=
 by rw [@nhds_eq_orderable α _ _]; simp
 
 section linear_order
@@ -314,7 +315,7 @@ section linear_order
 variables [topological_space α] [linear_order α] [t : orderable_topology α]
 include t
 
-lemma mem_nhds_orderable_dest {a : α} {s : set α} (hs : s ∈ nhds a) :
+lemma mem_nhds_orderable_dest {a : α} {s : set α} (hs : s ∈ 𝓝 a) :
   ((∃u, u>a) → ∃u, a < u ∧ ∀b, a ≤ b → b < u → b ∈ s) ∧
   ((∃l, l<a) → ∃l, l < a ∧ ∀b, l < b → b ≤ a → b ∈ s) :=
 let ⟨t₁, ht₁, t₂, ht₂, hts⟩ :=
@@ -362,9 +363,9 @@ and.intro
   (assume hx, let ⟨l, hl, h⟩ := ht₁.left hx in ⟨l, hl, assume b hbl hb, hts ⟨h _ hbl, ht₂.right b hb⟩⟩)
 
 lemma mem_nhds_unbounded {a : α} {s : set α} (hu : ∃u, a < u) (hl : ∃l, l < a) :
-  s ∈ nhds a ↔ (∃l u, l < a ∧ a < u ∧ ∀b, l < b → b < u → b ∈ s) :=
+  s ∈ 𝓝 a ↔ (∃l u, l < a ∧ a < u ∧ ∀b, l < b → b < u → b ∈ s) :=
 let ⟨l, hl'⟩ := hl, ⟨u, hu'⟩ := hu in
-have nhds a = (⨅p : {l // l < a} × {u // a < u}, principal {x | p.1.val < x ∧ x < p.2.val }),
+have 𝓝 a = (⨅p : {l // l < a} × {u // a < u}, principal {x | p.1.val < x ∧ x < p.2.val }),
   by simp [nhds_orderable_unbounded hu hl, infi_subtype, infi_prod],
 iff.intro
   (assume hs, by rw [this] at hs; from infi_sets_induct hs
@@ -404,9 +405,9 @@ instance orderable_topology.t2_space : t2_space α := by apply_instance
 
 instance orderable_topology.regular_space : regular_space α :=
 { regular := assume s a hs ha,
-    have -s ∈ nhds a, from mem_nhds_sets hs ha,
+    have -s ∈ 𝓝 a, from mem_nhds_sets hs ha,
     let ⟨h₁, h₂⟩ := mem_nhds_orderable_dest this in
-    have ∃t:set α, is_open t ∧ (∀l∈ s, l < a → l ∈ t) ∧ nhds a ⊓ principal t = ⊥,
+    have ∃t:set α, is_open t ∧ (∀l∈ s, l < a → l ∈ t) ∧ 𝓝 a ⊓ principal t = ⊥,
       from by_cases
         (assume h : ∃l, l < a,
           let ⟨l, hl, h⟩ := h₂ h in
@@ -414,16 +415,16 @@ instance orderable_topology.regular_space : regular_space α :=
           | or.inl ⟨b, hb₁, hb₂⟩ := ⟨{a | a < b}, is_open_gt' _,
               assume c hcs hca, show c < b,
                 from lt_of_not_ge $ assume hbc, h c (lt_of_lt_of_le hb₁ hbc) (le_of_lt hca) hcs,
-              inf_principal_eq_bot $ (nhds a).sets_of_superset (mem_nhds_sets (is_open_lt' _) hb₂) $
+              inf_principal_eq_bot $ (𝓝 a).sets_of_superset (mem_nhds_sets (is_open_lt' _) hb₂) $
                 assume x (hx : b < x), show ¬ x < b, from not_lt.2 $ le_of_lt hx⟩
           | or.inr ⟨h₁, h₂⟩ := ⟨{a' | a' < a}, is_open_gt' _, assume b hbs hba, hba,
-              inf_principal_eq_bot $ (nhds a).sets_of_superset (mem_nhds_sets (is_open_lt' _) hl) $
+              inf_principal_eq_bot $ (𝓝 a).sets_of_superset (mem_nhds_sets (is_open_lt' _) hl) $
                 assume x (hx : l < x), show ¬ x < a, from not_lt.2 $ h₁ _ hx⟩
           end)
         (assume : ¬ ∃l, l < a, ⟨∅, is_open_empty, assume l _ hl, (this ⟨l, hl⟩).elim,
           by rw [principal_empty, inf_bot_eq]⟩),
     let ⟨t₁, ht₁o, ht₁s, ht₁a⟩ := this in
-    have ∃t:set α, is_open t ∧ (∀u∈ s, u>a → u ∈ t) ∧ nhds a ⊓ principal t = ⊥,
+    have ∃t:set α, is_open t ∧ (∀u∈ s, u>a → u ∈ t) ∧ 𝓝 a ⊓ principal t = ⊥,
       from by_cases
         (assume h : ∃u, u > a,
           let ⟨u, hu, h⟩ := h₁ h in
@@ -431,10 +432,10 @@ instance orderable_topology.regular_space : regular_space α :=
           | or.inl ⟨b, hb₁, hb₂⟩ := ⟨{a | b < a}, is_open_lt' _,
               assume c hcs hca, show c > b,
                 from lt_of_not_ge $ assume hbc, h c (le_of_lt hca) (lt_of_le_of_lt hbc hb₂) hcs,
-              inf_principal_eq_bot $ (nhds a).sets_of_superset (mem_nhds_sets (is_open_gt' _) hb₁) $
+              inf_principal_eq_bot $ (𝓝 a).sets_of_superset (mem_nhds_sets (is_open_gt' _) hb₁) $
                 assume x (hx : b > x), show ¬ x > b, from not_lt.2 $ le_of_lt hx⟩
           | or.inr ⟨h₁, h₂⟩ := ⟨{a' | a' > a}, is_open_lt' _, assume b hbs hba, hba,
-              inf_principal_eq_bot $ (nhds a).sets_of_superset (mem_nhds_sets (is_open_gt' _) hu) $
+              inf_principal_eq_bot $ (𝓝 a).sets_of_superset (mem_nhds_sets (is_open_gt' _) hu) $
                 assume x (hx : u > x), show ¬ x > a, from not_lt.2 $ h₂ _ hx⟩
           end)
         (assume : ¬ ∃u, u > a, ⟨∅, is_open_empty, assume l _ hl, (this ⟨l, hl⟩).elim,
@@ -477,7 +478,7 @@ variables [topological_space α] [topological_space β]
   [linear_order α] [linear_order β] [orderable_topology α] [orderable_topology β]
 
 lemma nhds_principal_ne_bot_of_is_lub {a : α} {s : set α} (ha : is_lub s a) (hs : s ≠ ∅) :
-  nhds a ⊓ principal s ≠ ⊥ :=
+  𝓝 a ⊓ principal s ≠ ⊥ :=
 let ⟨a', ha'⟩ := exists_mem_of_ne_empty hs in
 forall_sets_neq_empty_iff_neq_bot.mp $ assume t ht,
   let ⟨t₁, ht₁, t₂, ht₂, ht⟩ := mem_inf_sets.mp ht in
@@ -500,30 +501,30 @@ forall_sets_neq_empty_iff_neq_bot.mp $ assume t ht,
       ne_empty_iff_exists_mem.mpr ⟨a', ht ⟨‹a' ∈ t₁›, ht₂ ‹a' ∈ s›⟩⟩)
 
 lemma nhds_principal_ne_bot_of_is_glb : ∀ {a : α} {s : set α}, is_glb s a → s ≠ ∅ →
-  nhds a ⊓ principal s ≠ ⊥ :=
+  𝓝 a ⊓ principal s ≠ ⊥ :=
 @nhds_principal_ne_bot_of_is_lub (order_dual α) _ _ _
 
 lemma is_lub_of_mem_nhds {s : set α} {a : α} {f : filter α}
-  (hsa : a ∈ upper_bounds s) (hsf : s ∈ f) (hfa : f ⊓ nhds a ≠ ⊥) : is_lub s a :=
+  (hsa : a ∈ upper_bounds s) (hsf : s ∈ f) (hfa : f ⊓ 𝓝 a ≠ ⊥) : is_lub s a :=
 ⟨hsa, assume b hb,
   not_lt.1 $ assume hba,
-  have s ∩ {a | b < a} ∈ f ⊓ nhds a,
+  have s ∩ {a | b < a} ∈ f ⊓ 𝓝 a,
     from inter_mem_inf_sets hsf (mem_nhds_sets (is_open_lt' _) hba),
   let ⟨x, ⟨hxs, hxb⟩⟩ := inhabited_of_mem_sets hfa this in
   have b < b, from lt_of_lt_of_le hxb $ hb _ hxs,
   lt_irrefl b this⟩
 
 lemma is_glb_of_mem_nhds : ∀ {s : set α} {a : α} {f : filter α},
-  a ∈ lower_bounds s → s ∈ f → f ⊓ nhds a ≠ ⊥ → is_glb s a :=
+  a ∈ lower_bounds s → s ∈ f → f ⊓ 𝓝 a ≠ ⊥ → is_glb s a :=
 @is_lub_of_mem_nhds (order_dual α) _ _ _
 
 lemma is_lub_of_is_lub_of_tendsto {f : α → β} {s : set α} {a : α} {b : β}
   (hf : ∀x∈s, ∀y∈s, x ≤ y → f x ≤ f y) (ha : is_lub s a) (hs : s ≠ ∅)
-  (hb : tendsto f (nhds a ⊓ principal s) (nhds b)) : is_lub (f '' s) b :=
-have hnbot : (nhds a ⊓ principal s) ≠ ⊥, from nhds_principal_ne_bot_of_is_lub ha hs,
+  (hb : tendsto f (𝓝 a ⊓ principal s) (𝓝 b)) : is_lub (f '' s) b :=
+have hnbot : (𝓝 a ⊓ principal s) ≠ ⊥, from nhds_principal_ne_bot_of_is_lub ha hs,
 have ∀a'∈s, ¬ b < f a',
   from assume a' ha' h,
-  have {x | x < f a'} ∈ nhds b, from mem_nhds_sets (is_open_gt' _) h,
+  have {x | x < f a'} ∈ 𝓝 b, from mem_nhds_sets (is_open_gt' _) h,
   let ⟨t₁, ht₁, t₂, ht₂, hs⟩ := mem_inf_sets.mp (hb this) in
   by_cases
     (assume h : a = a',
@@ -532,9 +533,9 @@ have ∀a'∈s, ¬ b < f a',
       lt_irrefl (f a') $ by rwa [h] at this)
     (assume h : a ≠ a',
       have a' < a, from lt_of_le_of_ne (ha.left _ ha') h.symm,
-      have {x | a' < x} ∈ nhds a, from mem_nhds_sets (is_open_lt' _) this,
-      have {x | a' < x} ∩ t₁ ∈ nhds a, from inter_mem_sets this ht₁,
-      have ({x | a' < x} ∩ t₁) ∩ s ∈ nhds a ⊓ principal s,
+      have {x | a' < x} ∈ 𝓝 a, from mem_nhds_sets (is_open_lt' _) this,
+      have {x | a' < x} ∩ t₁ ∈ 𝓝 a, from inter_mem_sets this ht₁,
+      have ({x | a' < x} ∩ t₁) ∩ s ∈ 𝓝 a ⊓ principal s,
         from inter_mem_inf_sets this (subset.refl s),
       let ⟨x, ⟨hx₁, hx₂⟩, hx₃⟩ := inhabited_of_mem_sets hnbot this in
       have hxa' : f x < f a', from hs ⟨hx₂, ht₂ hx₃⟩,
@@ -547,18 +548,18 @@ and.intro
 
 lemma is_glb_of_is_glb_of_tendsto {f : α → β} {s : set α} {a : α} {b : β}
   (hf : ∀x∈s, ∀y∈s, x ≤ y → f x ≤ f y) : is_glb s a → s ≠ ∅ →
-  tendsto f (nhds a ⊓ principal s) (nhds b) → is_glb (f '' s) b :=
+  tendsto f (𝓝 a ⊓ principal s) (𝓝 b) → is_glb (f '' s) b :=
 @is_lub_of_is_lub_of_tendsto (order_dual α) (order_dual β) _ _ _ _ _ _ f s a b
   (λ x hx y hy, hf y hy x hx)
 
 lemma is_glb_of_is_lub_of_tendsto : ∀ {f : α → β} {s : set α} {a : α} {b : β},
   (∀x∈s, ∀y∈s, x ≤ y → f y ≤ f x) → is_lub s a → s ≠ ∅ →
-  tendsto f (nhds a ⊓ principal s) (nhds b) → is_glb (f '' s) b :=
+  tendsto f (𝓝 a ⊓ principal s) (𝓝 b) → is_glb (f '' s) b :=
 @is_lub_of_is_lub_of_tendsto α (order_dual β) _ _ _ _ _ _
 
 lemma is_lub_of_is_glb_of_tendsto : ∀ {f : α → β} {s : set α} {a : α} {b : β},
   (∀x∈s, ∀y∈s, x ≤ y → f y ≤ f x) → is_glb s a → s ≠ ∅ →
-  tendsto f (nhds a ⊓ principal s) (nhds b) → is_lub (f '' s) b :=
+  tendsto f (𝓝 a ⊓ principal s) (𝓝 b) → is_lub (f '' s) b :=
 @is_glb_of_is_glb_of_tendsto α (order_dual β) _ _ _ _ _ _
 
 lemma mem_closure_of_is_lub {a : α} {s : set α} (ha : is_lub s a) (hs : s ≠ ∅) : a ∈ closure s :=
@@ -750,21 +751,21 @@ section liminf_limsup
 section ordered_topology
 variables [semilattice_sup α] [topological_space α] [orderable_topology α]
 
-lemma is_bounded_le_nhds (a : α) : (nhds a).is_bounded (≤) :=
+lemma is_bounded_le_nhds (a : α) : (𝓝 a).is_bounded (≤) :=
 match forall_le_or_exists_lt_sup a with
-| or.inl h := ⟨a, show {x : α | x ≤ a} ∈ nhds a, from univ_mem_sets' h⟩
+| or.inl h := ⟨a, show {x : α | x ≤ a} ∈ 𝓝 a, from univ_mem_sets' h⟩
 | or.inr ⟨b, hb⟩ := ⟨b, ge_mem_nhds hb⟩
 end
 
 lemma is_bounded_under_le_of_tendsto {f : filter β} {u : β → α} {a : α}
-  (h : tendsto u f (nhds a)) : f.is_bounded_under (≤) u :=
+  (h : tendsto u f (𝓝 a)) : f.is_bounded_under (≤) u :=
 is_bounded_of_le h (is_bounded_le_nhds a)
 
-lemma is_cobounded_ge_nhds (a : α) : (nhds a).is_cobounded (≥) :=
+lemma is_cobounded_ge_nhds (a : α) : (𝓝 a).is_cobounded (≥) :=
 is_cobounded_of_is_bounded nhds_neq_bot (is_bounded_le_nhds a)
 
 lemma is_cobounded_under_ge_of_tendsto {f : filter β} {u : β → α} {a : α}
-  (hf : f ≠ ⊥) (h : tendsto u f (nhds a)) : f.is_cobounded_under (≥) u :=
+  (hf : f ≠ ⊥) (h : tendsto u f (𝓝 a)) : f.is_cobounded_under (≥) u :=
 is_cobounded_of_is_bounded (map_ne_bot hf) (is_bounded_under_le_of_tendsto h)
 
 end ordered_topology
@@ -772,21 +773,21 @@ end ordered_topology
 section ordered_topology
 variables [semilattice_inf α] [topological_space α] [orderable_topology α]
 
-lemma is_bounded_ge_nhds (a : α) : (nhds a).is_bounded (≥) :=
+lemma is_bounded_ge_nhds (a : α) : (𝓝 a).is_bounded (≥) :=
 match forall_le_or_exists_lt_inf a with
-| or.inl h := ⟨a, show {x : α | a ≤ x} ∈ nhds a, from univ_mem_sets' h⟩
+| or.inl h := ⟨a, show {x : α | a ≤ x} ∈ 𝓝 a, from univ_mem_sets' h⟩
 | or.inr ⟨b, hb⟩ := ⟨b, le_mem_nhds hb⟩
 end
 
 lemma is_bounded_under_ge_of_tendsto {f : filter β} {u : β → α} {a : α}
-  (h : tendsto u f (nhds a)) : f.is_bounded_under (≥) u :=
+  (h : tendsto u f (𝓝 a)) : f.is_bounded_under (≥) u :=
 is_bounded_of_le h (is_bounded_ge_nhds a)
 
-lemma is_cobounded_le_nhds (a : α) : (nhds a).is_cobounded (≤) :=
+lemma is_cobounded_le_nhds (a : α) : (𝓝 a).is_cobounded (≤) :=
 is_cobounded_of_is_bounded nhds_neq_bot (is_bounded_ge_nhds a)
 
 lemma is_cobounded_under_le_of_tendsto {f : filter β} {u : β → α} {a : α}
-  (hf : f ≠ ⊥) (h : tendsto u f (nhds a)) : f.is_cobounded_under (≤) u :=
+  (hf : f ≠ ⊥) (h : tendsto u f (𝓝 a)) : f.is_cobounded_under (≤) u :=
 is_cobounded_of_is_bounded (map_ne_bot hf) (is_bounded_under_ge_of_tendsto h)
 
 end ordered_topology
@@ -810,38 +811,38 @@ variables [topological_space α] [orderable_topology α]
 their common value, at least if the filter is eventually bounded above and below. -/
 theorem le_nhds_of_Limsup_eq_Liminf {f : filter α} {a : α}
   (hl : f.is_bounded (≤)) (hg : f.is_bounded (≥)) (hs : f.Limsup = a) (hi : f.Liminf = a) :
-  f ≤ nhds a :=
+  f ≤ 𝓝 a :=
 tendsto_orderable.2 $ and.intro
   (assume b hb, gt_mem_sets_of_Liminf_gt hg $ hi.symm ▸ hb)
   (assume b hb, lt_mem_sets_of_Limsup_lt hl $ hs.symm ▸ hb)
 
-theorem Limsup_nhds (a : α) : Limsup (nhds a) = a :=
+theorem Limsup_nhds (a : α) : Limsup (𝓝 a) = a :=
 cInf_intro (ne_empty_iff_exists_mem.2 $ is_bounded_le_nhds a)
-  (assume a' (h : {n : α | n ≤ a'} ∈ nhds a), show a ≤ a', from @mem_of_nhds α _ a _ h)
-  (assume b (hba : a < b), show ∃c (h : {n : α | n ≤ c} ∈ nhds a), c < b, from
+  (assume a' (h : {n : α | n ≤ a'} ∈ 𝓝 a), show a ≤ a', from @mem_of_nhds α _ a _ h)
+  (assume b (hba : a < b), show ∃c (h : {n : α | n ≤ c} ∈ 𝓝 a), c < b, from
     match dense_or_discrete a b with
     | or.inl ⟨c, hac, hcb⟩ := ⟨c, ge_mem_nhds hac, hcb⟩
-    | or.inr ⟨_, h⟩        := ⟨a, (nhds a).sets_of_superset (gt_mem_nhds hba) h, hba⟩
+    | or.inr ⟨_, h⟩        := ⟨a, (𝓝 a).sets_of_superset (gt_mem_nhds hba) h, hba⟩
     end)
 
-theorem Liminf_nhds : ∀ (a : α), Liminf (nhds a) = a :=
+theorem Liminf_nhds : ∀ (a : α), Liminf (𝓝 a) = a :=
 @Limsup_nhds (order_dual α) _ _ _
 
 /-- If a filter is converging, its limsup coincides with its limit. -/
-theorem Liminf_eq_of_le_nhds {f : filter α} {a : α} (hf : f ≠ ⊥) (h : f ≤ nhds a) : f.Liminf = a :=
+theorem Liminf_eq_of_le_nhds {f : filter α} {a : α} (hf : f ≠ ⊥) (h : f ≤ 𝓝 a) : f.Liminf = a :=
 have hb_ge : is_bounded (≥) f, from is_bounded_of_le h (is_bounded_ge_nhds a),
 have hb_le : is_bounded (≤) f, from is_bounded_of_le h (is_bounded_le_nhds a),
 le_antisymm
   (calc f.Liminf ≤ f.Limsup : Liminf_le_Limsup hf hb_le hb_ge
-    ... ≤ (nhds a).Limsup :
+    ... ≤ (𝓝 a).Limsup :
       Limsup_le_Limsup_of_le h (is_cobounded_of_is_bounded hf hb_ge) (is_bounded_le_nhds a)
     ... = a : Limsup_nhds a)
-  (calc a = (nhds a).Liminf : (Liminf_nhds a).symm
+  (calc a = (𝓝 a).Liminf : (Liminf_nhds a).symm
     ... ≤ f.Liminf :
       Liminf_le_Liminf_of_le h (is_bounded_ge_nhds a) (is_cobounded_of_is_bounded hf hb_le))
 
 /-- If a filter is converging, its liminf coincides with its limit. -/
-theorem Limsup_eq_of_le_nhds : ∀ {f : filter α} {a : α}, f ≠ ⊥ → f ≤ nhds a → f.Limsup = a :=
+theorem Limsup_eq_of_le_nhds : ∀ {f : filter α} {a : α}, f ≠ ⊥ → f ≤ 𝓝 a → f.Limsup = a :=
 @Liminf_eq_of_le_nhds (order_dual α) _ _ _
 
 end conditionally_complete_linear_order
@@ -853,17 +854,17 @@ variables [complete_linear_order α] [topological_space α] [orderable_topology 
 /-- If the liminf and the limsup of a function coincide, then the limit of the function
 exists and has the same value -/
 theorem tendsto_of_liminf_eq_limsup {f : filter β} {u : β → α} {a : α}
-  (h : liminf f u = a ∧ limsup f u = a) : tendsto u f (nhds a) :=
+  (h : liminf f u = a ∧ limsup f u = a) : tendsto u f (𝓝 a) :=
   le_nhds_of_Limsup_eq_Liminf is_bounded_le_of_top is_bounded_ge_of_bot h.2 h.1
 
 /-- If a function has a limit, then its limsup coincides with its limit-/
 theorem limsup_eq_of_tendsto {f : filter β} {u : β → α} {a : α} (hf : f ≠ ⊥)
-  (h : tendsto u f (nhds a)) : limsup f u = a :=
+  (h : tendsto u f (𝓝 a)) : limsup f u = a :=
   Limsup_eq_of_le_nhds (map_ne_bot hf) h
 
 /-- If a function has a limit, then its liminf coincides with its limit-/
 theorem liminf_eq_of_tendsto {f : filter β} {u : β → α} {a : α} (hf : f ≠ ⊥)
-  (h : tendsto u f (nhds a)) : liminf f u = a :=
+  (h : tendsto u f (𝓝 a)) : liminf f u = a :=
   Liminf_eq_of_le_nhds (map_ne_bot hf) h
 
 end complete_linear_order
@@ -874,7 +875,7 @@ end orderable_topology
 
 lemma orderable_topology_of_nhds_abs
   {α : Type*} [decidable_linear_ordered_comm_group α] [topological_space α]
-  (h_nhds : ∀a:α, nhds a = (⨅r>0, principal {b | abs (a - b) < r})) : orderable_topology α :=
+  (h_nhds : ∀a:α, 𝓝 a = (⨅r>0, principal {b | abs (a - b) < r})) : orderable_topology α :=
 orderable_topology.mk $ eq_of_nhds_eq_nhds $ assume a:α, le_antisymm_iff.mpr
 begin
   simp [infi_and, topological_space.nhds_generate_from,
@@ -905,20 +906,20 @@ begin
 end
 
 lemma tendsto_at_top_supr_nat [topological_space α] [complete_linear_order α] [orderable_topology α]
-  (f : ℕ → α) (hf : monotone f) : tendsto f at_top (nhds (⨆i, f i)) :=
+  (f : ℕ → α) (hf : monotone f) : tendsto f at_top (𝓝 (⨆i, f i)) :=
 tendsto_orderable.2 $ and.intro
   (assume a ha, let ⟨n, hn⟩ := lt_supr_iff.1 ha in
     mem_at_top_sets.2 ⟨n, assume i hi, lt_of_lt_of_le hn (hf hi)⟩)
   (assume a ha, univ_mem_sets' (assume n, lt_of_le_of_lt (le_supr _ n) ha))
 
 lemma tendsto_at_top_infi_nat [topological_space α] [complete_linear_order α] [orderable_topology α]
-  (f : ℕ → α) (hf : ∀{n m}, n ≤ m → f m ≤ f n) : tendsto f at_top (nhds (⨅i, f i)) :=
+  (f : ℕ → α) (hf : ∀{n m}, n ≤ m → f m ≤ f n) : tendsto f at_top (𝓝 (⨅i, f i)) :=
 @tendsto_at_top_supr_nat (order_dual α) _ _ _ _ @hf
 
 lemma supr_eq_of_tendsto {α} [topological_space α] [complete_linear_order α] [orderable_topology α]
-  {f : ℕ → α} {a : α} (hf : monotone f) : tendsto f at_top (nhds a) → supr f = a :=
+  {f : ℕ → α} {a : α} (hf : monotone f) : tendsto f at_top (𝓝 a) → supr f = a :=
 tendsto_nhds_unique at_top_ne_bot (tendsto_at_top_supr_nat f hf)
 
 lemma infi_eq_of_tendsto {α} [topological_space α] [complete_linear_order α] [orderable_topology α]
-  {f : ℕ → α} {a : α} (hf : ∀n m, n ≤ m → f m ≤ f n) : tendsto f at_top (nhds a) → infi f = a :=
+  {f : ℕ → α} {a : α} (hf : ∀n m, n ≤ m → f m ≤ f n) : tendsto f at_top (𝓝 a) → infi f = a :=
 tendsto_nhds_unique at_top_ne_bot (tendsto_at_top_infi_nat f hf)

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -17,7 +17,7 @@ import topology.uniform_space.uniform_embedding topology.uniform_space.complete_
 import topology.algebra.group
 
 noncomputable theory
-open_locale classical uniformity
+open_locale classical uniformity topological_space
 
 section uniform_add_group
 open filter set
@@ -94,7 +94,7 @@ lemma uniform_embedding_translate (a : α) : uniform_embedding (λx:α, x + a) :
 
 section
 variables (α)
-lemma uniformity_eq_comap_nhds_zero : 𝓤 α = comap (λx:α×α, x.2 - x.1) (nhds (0:α)) :=
+lemma uniformity_eq_comap_nhds_zero : 𝓤 α = comap (λx:α×α, x.2 - x.1) (𝓝 (0:α)) :=
 begin
   rw [nhds_eq_comap_uniformity, filter.comap_comap_comp],
   refine le_antisymm (filter.map_le_iff_le_comap.1 _) _,
@@ -119,7 +119,7 @@ begin
 end
 
 lemma uniform_continuous_of_tendsto_zero [uniform_space β] [add_group β] [uniform_add_group β]
-  {f : α → β} [is_add_group_hom f] (h : tendsto f (nhds 0) (nhds 0)) :
+  {f : α → β} [is_add_group_hom f] (h : tendsto f (𝓝 0) (𝓝 0)) :
   uniform_continuous f :=
 begin
   have : ((λx:β×β, x.2 - x.1) ∘ (λx:α×α, (f x.1, f x.2))) = (λx:α×α, f (x.2 - x.1)),
@@ -133,7 +133,7 @@ lemma uniform_continuous_of_continuous [uniform_space β] [add_group β] [unifor
   {f : α → β} [is_add_group_hom f] (h : continuous f) :
   uniform_continuous f :=
 uniform_continuous_of_tendsto_zero $
-  suffices tendsto f (nhds 0) (nhds (f 0)), by rwa [is_add_group_hom.map_zero f] at this,
+  suffices tendsto f (𝓝 0) (𝓝 (f 0)), by rwa [is_add_group_hom.map_zero f] at this,
   h.tendsto 0
 
 end uniform_add_group
@@ -146,13 +146,13 @@ variables {G : Type u} [add_comm_group G] [topological_space G] [topological_add
 
 variable (G)
 def topological_add_group.to_uniform_space : uniform_space G :=
-{ uniformity          := comap (λp:G×G, p.2 - p.1) (nhds 0),
+{ uniformity          := comap (λp:G×G, p.2 - p.1) (𝓝 0),
   refl                :=
     by refine map_le_iff_le_comap.1 (le_trans _ (pure_le_nhds 0));
       simp [set.subset_def] {contextual := tt},
   symm                :=
   begin
-    suffices : tendsto ((λp, -p) ∘ (λp:G×G, p.2 - p.1)) (comap (λp:G×G, p.2 - p.1) (nhds 0)) (nhds (-0)),
+    suffices : tendsto ((λp, -p) ∘ (λp:G×G, p.2 - p.1)) (comap (λp:G×G, p.2 - p.1) (𝓝 0)) (𝓝 (-0)),
     { simpa [(∘), tendsto_comap_iff] },
     exact tendsto.comp (tendsto_neg tendsto_id) tendsto_comap
   end,
@@ -163,7 +163,7 @@ def topological_add_group.to_uniform_space : uniform_space G :=
     { rcases H with ⟨U, U_nhds, U_sub⟩,
       rcases exists_nhds_half U_nhds with ⟨V, ⟨V_nhds, V_sum⟩⟩,
       existsi ((λp:G×G, p.2 - p.1) ⁻¹' V),
-      have H : (λp:G×G, p.2 - p.1) ⁻¹' V ∈ comap (λp:G×G, p.2 - p.1) (nhds (0 : G)),
+      have H : (λp:G×G, p.2 - p.1) ⁻¹' V ∈ comap (λp:G×G, p.2 - p.1) (𝓝 (0 : G)),
         by existsi [V, V_nhds] ; refl,
       existsi H,
       have comp_rel_sub : comp_rel ((λp:G×G, p.2 - p.1) ⁻¹' V) ((λp:G×G, p.2 - p.1) ⁻¹' V) ⊆ (λp:G×G, p.2 - p.1) ⁻¹' U,
@@ -179,7 +179,7 @@ def topological_add_group.to_uniform_space : uniform_space G :=
   begin
     intro S,
     let S' := λ x, {p : G × G | p.1 = x → p.2 ∈ S},
-    show is_open S ↔ ∀ (x : G), x ∈ S → S' x ∈ comap (λp:G×G, p.2 - p.1) (nhds (0 : G)),
+    show is_open S ↔ ∀ (x : G), x ∈ S → S' x ∈ comap (λp:G×G, p.2 - p.1) (𝓝 (0 : G)),
     rw [is_open_iff_mem_nhds],
     refine forall_congr (assume a, forall_congr (assume ha, _)),
     rw [← nhds_translation a, mem_comap_sets, mem_comap_sets],
@@ -193,14 +193,14 @@ def topological_add_group.to_uniform_space : uniform_space G :=
 section
 local attribute [instance] topological_add_group.to_uniform_space
 
-lemma uniformity_eq_comap_nhds_zero' : 𝓤 G = comap (λp:G×G, p.2 - p.1) (nhds (0 : G)) := rfl
+lemma uniformity_eq_comap_nhds_zero' : 𝓤 G = comap (λp:G×G, p.2 - p.1) (𝓝 (0 : G)) := rfl
 
 variable {G}
 lemma topological_add_group_is_uniform : uniform_add_group G :=
 have tendsto
     ((λp:(G×G), p.1 - p.2) ∘ (λp:(G×G)×(G×G), (p.1.2 - p.1.1, p.2.2 - p.2.1)))
-    (comap (λp:(G×G)×(G×G), (p.1.2 - p.1.1, p.2.2 - p.2.1)) ((nhds 0).prod (nhds 0)))
-    (nhds (0 - 0)) :=
+    (comap (λp:(G×G)×(G×G), (p.1.2 - p.1.1, p.2.2 - p.2.1)) ((𝓝 0).prod (𝓝 0)))
+    (𝓝 (0 - 0)) :=
   (tendsto_sub tendsto_fst tendsto_snd).comp tendsto_comap,
 begin
   constructor,
@@ -292,13 +292,13 @@ variables {ψ : α × β → G} (hψ : continuous ψ) [ψbilin : is_Z_bilin ψ]
 
 include hψ ψbilin
 
-lemma is_Z_bilin.tendsto_zero_left (x₁ : α) : tendsto ψ (nhds (x₁, 0)) (nhds 0) :=
+lemma is_Z_bilin.tendsto_zero_left (x₁ : α) : tendsto ψ (𝓝 (x₁, 0)) (𝓝 0) :=
 begin
   have := continuous.tendsto hψ (x₁, 0),
   rwa [is_Z_bilin.zero_right ψ] at this
 end
 
-lemma is_Z_bilin.tendsto_zero_right (y₁ : β) : tendsto ψ (nhds (0, y₁)) (nhds 0) :=
+lemma is_Z_bilin.tendsto_zero_right (y₁ : β) : tendsto ψ (𝓝 (0, y₁)) (𝓝 0) :=
 begin
   have := continuous.tendsto hψ (0, y₁),
   rwa [is_Z_bilin.zero_left ψ] at this
@@ -315,13 +315,13 @@ variables {e : β → α} [is_add_group_hom e] (de : dense_inducing e)
 include de
 
 lemma tendsto_sub_comap_self (x₀ : α) :
-  tendsto (λt:β×β, t.2 - t.1) (comap (λp:β×β, (e p.1, e p.2)) $ nhds (x₀, x₀)) (nhds 0) :=
+  tendsto (λt:β×β, t.2 - t.1) (comap (λp:β×β, (e p.1, e p.2)) $ 𝓝 (x₀, x₀)) (𝓝 0) :=
 begin
   have comm : (λx:α×α, x.2-x.1) ∘ (λt:β×β, (e t.1, e t.2)) = e ∘ (λt:β×β, t.2 - t.1),
   { ext t,
     change e t.2 - e t.1 = e (t.2 - t.1),
     rwa ← is_add_group_hom.map_sub e t.2 t.1 },
-  have lim : tendsto (λ x : α × α, x.2-x.1) (nhds (x₀, x₀)) (nhds (e 0)),
+  have lim : tendsto (λ x : α × α, x.2-x.1) (𝓝 (x₀, x₀)) (𝓝 (e 0)),
     { have := continuous.tendsto (continuous_sub'.comp continuous_swap) (x₀, x₀),
       simpa [-sub_eq_add_neg, sub_self, eq.symm (is_add_group_hom.map_zero e)] using this },
   have := de.tendsto_comap_nhds_nhds lim comm,
@@ -346,17 +346,17 @@ variables {φ : β × δ → G} (hφ : continuous φ) [bilin : is_Z_bilin φ]
 
 include de df hφ bilin
 
-variables {W' : set G} (W'_nhd : W' ∈ nhds (0 : G))
+variables {W' : set G} (W'_nhd : W' ∈ 𝓝 (0 : G))
 include W'_nhd
 
 private lemma extend_Z_bilin_aux (x₀ : α) (y₁ : δ) :
-  ∃ U₂ ∈ comap e (nhds x₀), ∀ x x' ∈ U₂, φ (x' - x, y₁) ∈ W' :=
+  ∃ U₂ ∈ comap e (𝓝 x₀), ∀ x x' ∈ U₂, φ (x' - x, y₁) ∈ W' :=
 begin
-  let Nx := nhds x₀,
+  let Nx := 𝓝 x₀,
   let ee := λ u : β × β, (e u.1, e u.2),
 
-  have lim1 : tendsto (λ a : β × β, (a.2 - a.1, y₁)) (filter.prod (comap e Nx) (comap e Nx)) (nhds (0, y₁)),
-  { have := tendsto.prod_mk (tendsto_sub_comap_self de x₀) (tendsto_const_nhds : tendsto (λ (p : β × β), y₁) (comap ee $ nhds (x₀, x₀)) (nhds y₁)),
+  have lim1 : tendsto (λ a : β × β, (a.2 - a.1, y₁)) (filter.prod (comap e Nx) (comap e Nx)) (𝓝 (0, y₁)),
+  { have := tendsto.prod_mk (tendsto_sub_comap_self de x₀) (tendsto_const_nhds : tendsto (λ (p : β × β), y₁) (comap ee $ 𝓝 (x₀, x₀)) (𝓝 y₁)),
     rw [nhds_prod_eq, prod_comap_comap_eq, ←nhds_prod_eq],
     exact (this : _) },
 
@@ -366,23 +366,23 @@ begin
 end
 
 private lemma extend_Z_bilin_key (x₀ : α) (y₀ : γ) :
-  ∃ U ∈ comap e (nhds x₀), ∃ V ∈ comap f (nhds y₀),
+  ∃ U ∈ comap e (𝓝 x₀), ∃ V ∈ comap f (𝓝 y₀),
     ∀ x x' ∈ U, ∀ y y' ∈ V, φ (x', y') - φ (x, y) ∈ W' :=
 begin
-  let Nx := nhds x₀,
-  let Ny := nhds y₀,
+  let Nx := 𝓝 x₀,
+  let Ny := 𝓝 y₀,
   let dp := dense_inducing.prod de df,
   let ee := λ u : β × β, (e u.1, e u.2),
   let ff := λ u : δ × δ, (f u.1, f u.2),
 
-  have lim_φ : filter.tendsto φ (nhds (0, 0)) (nhds 0),
+  have lim_φ : filter.tendsto φ (𝓝 (0, 0)) (𝓝 0),
   { have := continuous.tendsto hφ (0, 0),
     rwa [is_Z_bilin.zero φ] at this },
 
   have lim_φ_sub_sub : tendsto (λ (p : (β × β) × (δ × δ)), φ (p.1.2 - p.1.1, p.2.2 - p.2.1))
-    (filter.prod (comap ee $ nhds (x₀, x₀)) (comap ff $ nhds (y₀, y₀))) (nhds 0),
+    (filter.prod (comap ee $ 𝓝 (x₀, x₀)) (comap ff $ 𝓝 (y₀, y₀))) (𝓝 0),
   { have lim_sub_sub :  tendsto (λ (p : (β × β) × δ × δ), (p.1.2 - p.1.1, p.2.2 - p.2.1))
-      (filter.prod (comap ee (nhds (x₀, x₀))) (comap ff (nhds (y₀, y₀)))) (filter.prod (nhds 0) (nhds 0)),
+      (filter.prod (comap ee (𝓝 (x₀, x₀))) (comap ff (𝓝 (y₀, y₀)))) (filter.prod (𝓝 0) (𝓝 0)),
     { have := filter.prod_mono (tendsto_sub_comap_self de x₀) (tendsto_sub_comap_self df y₀),
       rwa prod_map_map_eq at this },
     rw ← nhds_prod_eq at lim_sub_sub,
@@ -390,7 +390,7 @@ begin
 
   rcases exists_nhds_quarter W'_nhd with ⟨W, W_nhd, W4⟩,
 
-  have : ∃ U₁ ∈ comap e (nhds x₀), ∃ V₁ ∈ comap f (nhds y₀),
+  have : ∃ U₁ ∈ comap e (𝓝 x₀), ∃ V₁ ∈ comap f (𝓝 y₀),
     ∀ x x' ∈ U₁, ∀ y y' ∈ V₁,  φ (x'-x, y'-y) ∈ W,
   { have := tendsto_prod_iff.1 lim_φ_sub_sub W W_nhd,
     repeat { rw [nhds_prod_eq, ←prod_comap_comap_eq] at this },
@@ -454,7 +454,7 @@ begin
     cc },
   { suffices : map (λ (p : (β × δ) × (β × δ)), φ p.2 - φ p.1)
       (comap (λ (p : (β × δ) × β × δ), ((e p.1.1, f p.1.2), (e p.2.1, f p.2.2)))
-         (filter.prod (nhds (x₀, y₀)) (nhds (x₀, y₀)))) ≤ nhds 0,
+         (filter.prod (𝓝 (x₀, y₀)) (𝓝 (x₀, y₀)))) ≤ 𝓝 0,
     by rwa [uniformity_eq_comap_nhds_zero G, prod_map_map_eq, ←map_le_iff_le_comap, filter.map_map,
         prod_comap_comap_eq],
 
@@ -473,8 +473,8 @@ begin
 
     simp only [exists_prop],
     split,
-    { change U' ∈ nhds x₀ at U'_nhd,
-      change V' ∈ nhds y₀ at V'_nhd,
+    { change U' ∈ 𝓝 x₀ at U'_nhd,
+      change V' ∈ 𝓝 y₀ at V'_nhd,
       have := prod_mem_prod U'_nhd V'_nhd,
       tauto },
     { intros p h',

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -9,6 +9,7 @@ Bases of topologies. Countability axioms.
 import topology.constructions data.set.countable
 
 open set filter lattice classical
+open_locale topological_space
 
 namespace filter
 universe u
@@ -131,9 +132,9 @@ lemma is_topological_basis_of_open_of_nhds {s : set (set α)}
         by rw nhds_generate_from; exact infi_le_of_le v (infi_le_of_le ⟨hav, hvs⟩ $ le_principal_iff.2 hvu))⟩
 
 lemma mem_nhds_of_is_topological_basis {a : α} {s : set α} {b : set (set α)}
-  (hb : is_topological_basis b) : s ∈ nhds a ↔ ∃t∈b, a ∈ t ∧ t ⊆ s :=
+  (hb : is_topological_basis b) : s ∈ 𝓝 a ↔ ∃t∈b, a ∈ t ∧ t ⊆ s :=
 begin
-  change s ∈ (nhds a).sets ↔ ∃t∈b, a ∈ t ∧ t ⊆ s,
+  change s ∈ (𝓝 a).sets ↔ ∃t∈b, a ∈ t ∧ t ⊆ s,
   rw [hb.2.2, nhds_generate_from, infi_sets_eq'],
   { simp only [mem_bUnion_iff, exists_prop, mem_set_of_eq, and_assoc, and.left_comm], refl },
   { exact assume s ⟨hs₁, hs₂⟩ t ⟨ht₁, ht₂⟩,
@@ -178,7 +179,7 @@ class separable_space : Prop :=
 /-- A first-countable space is one in which every point has a
   countable neighborhood basis. -/
 class first_countable_topology : Prop :=
-(nhds_generated_countable : ∀a:α, (nhds a).has_countable_basis)
+(nhds_generated_countable : ∀a:α, (𝓝 a).has_countable_basis)
 
 /-- A second-countable space is one with a countable basis. -/
 class second_countable_topology : Prop :=
@@ -245,7 +246,7 @@ end
 instance second_countable_topology.to_separable_space
   [second_countable_topology α] : separable_space α :=
 let ⟨b, hb₁, hb₂, hb₃, hb₄, eq⟩ := is_open_generated_countable_inter α in
-have nhds_eq : ∀a, nhds a = (⨅ s : {s : set α // a ∈ s ∧ s ∈ b}, principal s.val),
+have nhds_eq : ∀a, 𝓝 a = (⨅ s : {s : set α // a ∈ s ∧ s ∈ b}, principal s.val),
   by intro a; rw [eq, nhds_generate_from, infi_subtype]; refl,
 have ∀s∈b, ∃a, a ∈ s, from assume s hs, exists_mem_of_ne_empty $ assume eq, hb₂ $ eq ▸ hs,
 have ∃f:∀s∈b, α, ∀s h, f s h ∈ s, by simp only [skolem] at this; exact this,

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -11,7 +11,7 @@ import order.filter
 
 The main definition is the type class `topological space α` which endows a type `α` with a topology.
 Then `set α` gets predicates `is_open`, `is_closed` and functions `interior`, `closure` and
-`frontier`. Each point `x` of `α` gets a neighborhood filter `nhds x`.
+`frontier`. Each point `x` of `α` gets a neighborhood filter `𝓝 x`.
 
 This file also defines locally finite families of subsets of `α`.
 
@@ -357,16 +357,18 @@ end
 /-- neighbourhood filter -/
 def nhds (a : α) : filter α := (⨅ s ∈ {s : set α | a ∈ s ∧ is_open s}, principal s)
 
-lemma nhds_def (a : α) : nhds a = (⨅ s ∈ {s : set α | a ∈ s ∧ is_open s}, principal s) := rfl
+localized "notation `𝓝` := nhds" in topological_space
 
-lemma le_nhds_iff {f a} : f ≤ nhds a ↔ ∀ s : set α, a ∈ s → is_open s → s ∈ f :=
+lemma nhds_def (a : α) : 𝓝 a = (⨅ s ∈ {s : set α | a ∈ s ∧ is_open s}, principal s) := rfl
+
+lemma le_nhds_iff {f a} : f ≤ 𝓝 a ↔ ∀ s : set α, a ∈ s → is_open s → s ∈ f :=
 by simp [nhds_def]
 
-lemma nhds_le_of_le {f a} {s : set α} (h : a ∈ s) (o : is_open s) (sf : principal s ≤ f) : nhds a ≤ f :=
+lemma nhds_le_of_le {f a} {s : set α} (h : a ∈ s) (o : is_open s) (sf : principal s ≤ f) : 𝓝 a ≤ f :=
 by rw nhds_def; exact infi_le_of_le s (infi_le_of_le ⟨h, o⟩ sf)
 
-lemma nhds_sets {a : α} : (nhds a).sets = {s | ∃t⊆s, is_open t ∧ a ∈ t} :=
-calc (nhds a).sets = (⋃s∈{s : set α| a ∈ s ∧ is_open s}, (principal s).sets) : infi_sets_eq'
+lemma nhds_sets {a : α} : (𝓝 a).sets = {s | ∃t⊆s, is_open t ∧ a ∈ t} :=
+calc (𝓝 a).sets = (⋃s∈{s : set α| a ∈ s ∧ is_open s}, (principal s).sets) : infi_sets_eq'
   (assume x ⟨hx₁, hx₂⟩ y ⟨hy₁, hy₂⟩,
     ⟨x ∩ y, ⟨⟨hx₁, hy₁⟩, is_open_inter hx₂ hy₂⟩,
       le_principal_iff.2 (inter_subset_left _ _),
@@ -378,8 +380,8 @@ calc (nhds a).sets = (⋃s∈{s : set α| a ∈ s ∧ is_open s}, (principal s).
       (assume t ⟨i, hi₁, hi₂, hi₃⟩, mem_Union.2 ⟨i, mem_Union.2 ⟨⟨hi₃, hi₂⟩, hi₁⟩⟩)
 
 lemma map_nhds {a : α} {f : α → β} :
-  map f (nhds a) = (⨅ s ∈ {s : set α | a ∈ s ∧ is_open s}, principal (image f s)) :=
-calc map f (nhds a) = (⨅ s ∈ {s : set α | a ∈ s ∧ is_open s}, map f (principal s)) :
+  map f (𝓝 a) = (⨅ s ∈ {s : set α | a ∈ s ∧ is_open s}, principal (image f s)) :=
+calc map f (𝓝 a) = (⨅ s ∈ {s : set α | a ∈ s ∧ is_open s}, map f (principal s)) :
     map_binfi_eq
     (assume x ⟨hx₁, hx₂⟩ y ⟨hy₁, hy₂⟩,
       ⟨x ∩ y, ⟨⟨hx₁, hy₁⟩, is_open_inter hx₂ hy₂⟩,
@@ -391,23 +393,23 @@ calc map f (nhds a) = (⨅ s ∈ {s : set α | a ∈ s ∧ is_open s}, map f (pr
 attribute [irreducible] nhds
 
 lemma mem_nhds_sets_iff {a : α} {s : set α} :
- s ∈ nhds a ↔ ∃t⊆s, is_open t ∧ a ∈ t :=
+ s ∈ 𝓝 a ↔ ∃t⊆s, is_open t ∧ a ∈ t :=
 by simp only [nhds_sets, mem_set_of_eq, exists_prop]
 
-lemma mem_of_nhds {a : α} {s : set α} : s ∈ nhds a → a ∈ s :=
+lemma mem_of_nhds {a : α} {s : set α} : s ∈ 𝓝 a → a ∈ s :=
 λ H, let ⟨t, ht, _, hs⟩ := mem_nhds_sets_iff.1 H in ht hs
 
 lemma mem_nhds_sets {a : α} {s : set α} (hs : is_open s) (ha : a ∈ s) :
- s ∈ nhds a :=
+ s ∈ 𝓝 a :=
 mem_nhds_sets_iff.2 ⟨s, subset.refl _, hs, ha⟩
 
 theorem all_mem_nhds (x : α) (P : set α → Prop) (hP : ∀ s t, s ⊆ t → P s → P t) :
-  (∀ s ∈ nhds x, P s) ↔ (∀ s, is_open s → x ∈ s → P s) :=
+  (∀ s ∈ 𝓝 x, P s) ↔ (∀ s, is_open s → x ∈ s → P s) :=
 iff.intro
   (λ h s os xs, h s (mem_nhds_sets os xs))
   (λ h t,
     begin
-      change t ∈ (nhds x).sets → P t,
+      change t ∈ (𝓝 x).sets → P t,
       rw nhds_sets,
       rintros ⟨s, hs, opens, xs⟩,
       exact hP _ _ hs (h s opens xs),
@@ -415,73 +417,73 @@ iff.intro
 
 theorem all_mem_nhds_filter (x : α) (f : set α → set β) (hf : ∀ s t, s ⊆ t → f s ⊆ f t)
     (l : filter β) :
-  (∀ s ∈ nhds x, f s ∈ l) ↔ (∀ s, is_open s → x ∈ s → f s ∈ l) :=
+  (∀ s ∈ 𝓝 x, f s ∈ l) ↔ (∀ s, is_open s → x ∈ s → f s ∈ l) :=
 all_mem_nhds _ _ (λ s t ssubt h, mem_sets_of_superset h (hf s t ssubt))
 
 theorem rtendsto_nhds {r : rel β α} {l : filter β} {a : α} :
-  rtendsto r l (nhds a) ↔ (∀ s, is_open s → a ∈ s → r.core s ∈ l) :=
+  rtendsto r l (𝓝 a) ↔ (∀ s, is_open s → a ∈ s → r.core s ∈ l) :=
 all_mem_nhds_filter _ _ (λ s t, id) _
 
 theorem rtendsto'_nhds {r : rel β α} {l : filter β} {a : α} :
-  rtendsto' r l (nhds a) ↔ (∀ s, is_open s → a ∈ s → r.preimage s ∈ l) :=
+  rtendsto' r l (𝓝 a) ↔ (∀ s, is_open s → a ∈ s → r.preimage s ∈ l) :=
 by { rw [rtendsto'_def], apply all_mem_nhds_filter, apply rel.preimage_mono }
 
 theorem ptendsto_nhds {f : β →. α} {l : filter β} {a : α} :
-  ptendsto f l (nhds a) ↔ (∀ s, is_open s → a ∈ s → f.core s ∈ l) :=
+  ptendsto f l (𝓝 a) ↔ (∀ s, is_open s → a ∈ s → f.core s ∈ l) :=
 rtendsto_nhds
 
 theorem ptendsto'_nhds {f : β →. α} {l : filter β} {a : α} :
-  ptendsto' f l (nhds a) ↔ (∀ s, is_open s → a ∈ s → f.preimage s ∈ l) :=
+  ptendsto' f l (𝓝 a) ↔ (∀ s, is_open s → a ∈ s → f.preimage s ∈ l) :=
 rtendsto'_nhds
 
 theorem tendsto_nhds {f : β → α} {l : filter β} {a : α} :
-  tendsto f l (nhds a) ↔ (∀ s, is_open s → a ∈ s → f ⁻¹' s ∈ l) :=
+  tendsto f l (𝓝 a) ↔ (∀ s, is_open s → a ∈ s → f ⁻¹' s ∈ l) :=
 all_mem_nhds_filter _ _ (λ s t h, preimage_mono h) _
 
-lemma tendsto_const_nhds {a : α} {f : filter β} : tendsto (λb:β, a) f (nhds a) :=
+lemma tendsto_const_nhds {a : α} {f : filter β} : tendsto (λb:β, a) f (𝓝 a) :=
 tendsto_nhds.mpr $ assume s hs ha, univ_mem_sets' $ assume _, ha
 
-lemma pure_le_nhds : pure ≤ (nhds : α → filter α) :=
+lemma pure_le_nhds : pure ≤ (𝓝 : α → filter α) :=
 assume a, by rw nhds_def; exact le_infi
   (assume s, le_infi $ assume ⟨h₁, _⟩, principal_mono.mpr $
     singleton_subset_iff.2 h₁)
 
 lemma tendsto_pure_nhds {α : Type*} [topological_space β] (f : α → β) (a : α) :
-  tendsto f (pure a) (nhds (f a)) :=
+  tendsto f (pure a) (𝓝 (f a)) :=
 begin
   rw [tendsto, filter.map_pure],
   exact pure_le_nhds (f a)
 end
 
-@[simp] lemma nhds_neq_bot {a : α} : nhds a ≠ ⊥ :=
-assume : nhds a = ⊥,
+@[simp] lemma nhds_neq_bot {a : α} : 𝓝 a ≠ ⊥ :=
+assume : 𝓝 a = ⊥,
 have pure a = (⊥ : filter α),
   from lattice.bot_unique $ this ▸ pure_le_nhds a,
 pure_neq_bot this
 
-lemma interior_eq_nhds {s : set α} : interior s = {a | nhds a ≤ principal s} :=
+lemma interior_eq_nhds {s : set α} : interior s = {a | 𝓝 a ≤ principal s} :=
 set.ext $ λ x, by simp only [mem_interior, le_principal_iff, mem_nhds_sets_iff]; refl
 
 lemma mem_interior_iff_mem_nhds {s : set α} {a : α} :
-  a ∈ interior s ↔ s ∈ nhds a :=
+  a ∈ interior s ↔ s ∈ 𝓝 a :=
 by simp only [interior_eq_nhds, le_principal_iff]; refl
 
-lemma is_open_iff_nhds {s : set α} : is_open s ↔ ∀a∈s, nhds a ≤ principal s :=
+lemma is_open_iff_nhds {s : set α} : is_open s ↔ ∀a∈s, 𝓝 a ≤ principal s :=
 calc is_open s ↔ s ⊆ interior s : subset_interior_iff_open.symm
-  ... ↔ (∀a∈s, nhds a ≤ principal s) : by rw [interior_eq_nhds]; refl
+  ... ↔ (∀a∈s, 𝓝 a ≤ principal s) : by rw [interior_eq_nhds]; refl
 
-lemma is_open_iff_mem_nhds {s : set α} : is_open s ↔ ∀a∈s, s ∈ nhds a :=
+lemma is_open_iff_mem_nhds {s : set α} : is_open s ↔ ∀a∈s, s ∈ 𝓝 a :=
 is_open_iff_nhds.trans $ forall_congr $ λ _, imp_congr_right $ λ _, le_principal_iff
 
-lemma closure_eq_nhds {s : set α} : closure s = {a | nhds a ⊓ principal s ≠ ⊥} :=
+lemma closure_eq_nhds {s : set α} : closure s = {a | 𝓝 a ⊓ principal s ≠ ⊥} :=
 calc closure s = - interior (- s) : closure_eq_compl_interior_compl
-  ... = {a | ¬ nhds a ≤ principal (-s)} : by rw [interior_eq_nhds]; refl
-  ... = {a | nhds a ⊓ principal s ≠ ⊥} : set.ext $ assume a, not_congr
+  ... = {a | ¬ 𝓝 a ≤ principal (-s)} : by rw [interior_eq_nhds]; refl
+  ... = {a | 𝓝 a ⊓ principal s ≠ ⊥} : set.ext $ assume a, not_congr
     (inf_eq_bot_iff_le_compl
       (show principal s ⊔ principal (-s) = ⊤, by simp only [sup_principal, union_compl_self, principal_univ])
       (by simp only [inf_principal, inter_compl_self, principal_empty])).symm
 
-theorem mem_closure_iff_nhds {s : set α} {a : α} : a ∈ closure s ↔ ∀ t ∈ nhds a, t ∩ s ≠ ∅ :=
+theorem mem_closure_iff_nhds {s : set α} {a : α} : a ∈ closure s ↔ ∀ t ∈ 𝓝 a, t ∩ s ≠ ∅ :=
 mem_closure_iff.trans
 ⟨λ H t ht, subset_ne_empty
   (inter_subset_inter_left _ interior_subset)
@@ -491,25 +493,25 @@ mem_closure_iff.trans
 /-- `x` belongs to the closure of `s` if and only if some ultrafilter
   supported on `s` converges to `x`. -/
 lemma mem_closure_iff_ultrafilter {s : set α} {x : α} :
-  x ∈ closure s ↔ ∃ (u : ultrafilter α), s ∈ u.val ∧ u.val ≤ nhds x :=
+  x ∈ closure s ↔ ∃ (u : ultrafilter α), s ∈ u.val ∧ u.val ≤ 𝓝 x :=
 begin
-  rw closure_eq_nhds, change nhds x ⊓ principal s ≠ ⊥ ↔ _, symmetry,
+  rw closure_eq_nhds, change 𝓝 x ⊓ principal s ≠ ⊥ ↔ _, symmetry,
   convert exists_ultrafilter_iff _, ext u,
   rw [←le_principal_iff, inf_comm, le_inf_iff]
 end
 
-lemma is_closed_iff_nhds {s : set α} : is_closed s ↔ ∀a, nhds a ⊓ principal s ≠ ⊥ → a ∈ s :=
+lemma is_closed_iff_nhds {s : set α} : is_closed s ↔ ∀a, 𝓝 a ⊓ principal s ≠ ⊥ → a ∈ s :=
 calc is_closed s ↔ closure s = s : by rw [closure_eq_iff_is_closed]
   ... ↔ closure s ⊆ s : ⟨assume h, by rw h, assume h, subset.antisymm h subset_closure⟩
-  ... ↔ (∀a, nhds a ⊓ principal s ≠ ⊥ → a ∈ s) : by rw [closure_eq_nhds]; refl
+  ... ↔ (∀a, 𝓝 a ⊓ principal s ≠ ⊥ → a ∈ s) : by rw [closure_eq_nhds]; refl
 
 lemma closure_inter_open {s t : set α} (h : is_open s) : s ∩ closure t ⊆ closure (s ∩ t) :=
 assume a ⟨hs, ht⟩,
-have s ∈ nhds a, from mem_nhds_sets h hs,
-have nhds a ⊓ principal s = nhds a, from inf_of_le_left $ by rwa le_principal_iff,
-have nhds a ⊓ principal (s ∩ t) ≠ ⊥,
-  from calc nhds a ⊓ principal (s ∩ t) = nhds a ⊓ (principal s ⊓ principal t) : by rw inf_principal
-    ... = nhds a ⊓ principal t : by rw [←inf_assoc, this]
+have s ∈ 𝓝 a, from mem_nhds_sets h hs,
+have 𝓝 a ⊓ principal s = 𝓝 a, from inf_of_le_left $ by rwa le_principal_iff,
+have 𝓝 a ⊓ principal (s ∩ t) ≠ ⊥,
+  from calc 𝓝 a ⊓ principal (s ∩ t) = 𝓝 a ⊓ (principal s ⊓ principal t) : by rw inf_principal
+    ... = 𝓝 a ⊓ principal t : by rw [←inf_assoc, this]
     ... ≠ ⊥ : by rw [closure_eq_nhds] at ht; assumption,
 by rw [closure_eq_nhds]; assumption
 
@@ -520,19 +522,19 @@ calc closure s \ closure t = (- closure t) ∩ closure s : by simp only [diff_eq
   ... ⊆ closure (s \ t) : closure_mono $ diff_subset_diff (subset.refl s) subset_closure
 
 lemma mem_of_closed_of_tendsto {f : β → α} {b : filter β} {a : α} {s : set α}
-  (hb : b ≠ ⊥) (hf : tendsto f b (nhds a)) (hs : is_closed s) (h : f ⁻¹' s ∈ b) : a ∈ s :=
-have b.map f ≤ nhds a ⊓ principal s,
+  (hb : b ≠ ⊥) (hf : tendsto f b (𝓝 a)) (hs : is_closed s) (h : f ⁻¹' s ∈ b) : a ∈ s :=
+have b.map f ≤ 𝓝 a ⊓ principal s,
   from le_trans (le_inf (le_refl _) (le_principal_iff.mpr h)) (inf_le_inf hf (le_refl _)),
 is_closed_iff_nhds.mp hs a $ neq_bot_of_le_neq_bot (map_ne_bot hb) this
 
 lemma mem_of_closed_of_tendsto' {f : β → α} {x : filter β} {a : α} {s : set α}
-  (hf : tendsto f x (nhds a)) (hs : is_closed s) (h : x ⊓ principal (f ⁻¹' s) ≠ ⊥) : a ∈ s :=
+  (hf : tendsto f x (𝓝 a)) (hs : is_closed s) (h : x ⊓ principal (f ⁻¹' s) ≠ ⊥) : a ∈ s :=
 is_closed_iff_nhds.mp hs _ $ neq_bot_of_le_neq_bot (@map_ne_bot _ _ _ f h) $
   le_inf (le_trans (map_mono $ inf_le_left) hf) $
     le_trans (map_mono $ inf_le_right_of_le $ by simp only [comap_principal, le_principal_iff]; exact subset.refl _) (@map_comap_le _ _ _ f)
 
 lemma mem_closure_of_tendsto {f : β → α} {b : filter β} {a : α} {s : set α}
-  (hb : b ≠ ⊥) (hf : tendsto f b (nhds a)) (h : f ⁻¹' s ∈ b) : a ∈ closure s :=
+  (hb : b ≠ ⊥) (hf : tendsto f b (𝓝 a)) (h : f ⁻¹' s ∈ b) : a ∈ closure s :=
 mem_of_closed_of_tendsto hb hf (is_closed_closure) $
   filter.mem_sets_of_superset h (preimage_mono subset_closure)
 
@@ -541,9 +543,9 @@ section lim
 variables [inhabited α]
 
 /-- If `f` is a filter, then `lim f` is a limit of the filter, if it exists. -/
-noncomputable def lim (f : filter α) : α := epsilon $ λa, f ≤ nhds a
+noncomputable def lim (f : filter α) : α := epsilon $ λa, f ≤ 𝓝 a
 
-lemma lim_spec {f : filter α} (h : ∃a, f ≤ nhds a) : f ≤ nhds (lim f) := epsilon_spec h
+lemma lim_spec {f : filter α} (h : ∃a, f ≤ 𝓝 a) : f ≤ 𝓝 (lim f) := epsilon_spec h
 end lim
 
 
@@ -553,7 +555,7 @@ section locally_finite
 /-- A family of sets in `set α` is locally finite if at every point `x:α`,
   there is a neighborhood of `x` which meets only finitely many sets in the family -/
 def locally_finite (f : β → set α) :=
-∀x:α, ∃t ∈ nhds x, finite {i | f i ∩ t ≠ ∅ }
+∀x:α, ∃t ∈ 𝓝 x, finite {i | f i ∩ t ≠ ∅ }
 
 lemma locally_finite_of_finite {f : β → set α} (h : finite (univ : set β)) : locally_finite f :=
 assume x, ⟨univ, univ_mem_sets, finite_subset h $ subset_univ _⟩
@@ -570,15 +572,15 @@ lemma is_closed_Union_of_locally_finite {f : β → set α}
 is_open_iff_nhds.mpr $ assume a, assume h : a ∉ (⋃i, f i),
   have ∀i, a ∈ -f i,
     from assume i hi, h $ mem_Union.2 ⟨i, hi⟩,
-  have ∀i, - f i ∈ (nhds a).sets,
+  have ∀i, - f i ∈ (𝓝 a).sets,
     by rw [nhds_sets]; exact assume i, ⟨- f i, subset.refl _, h₂ i, this i⟩,
   let ⟨t, h_sets, (h_fin : finite {i | f i ∩ t ≠ ∅ })⟩ := h₁ a in
 
-  calc nhds a ≤ principal (t ∩ (⋂ i∈{i | f i ∩ t ≠ ∅ }, - f i)) :
+  calc 𝓝 a ≤ principal (t ∩ (⋂ i∈{i | f i ∩ t ≠ ∅ }, - f i)) :
   begin
     rw [le_principal_iff],
-    apply @filter.inter_mem_sets _ (nhds a) _ _ h_sets,
-    apply @filter.Inter_mem_sets _ (nhds a) _ _ _ h_fin,
+    apply @filter.inter_mem_sets _ (𝓝 a) _ _ h_sets,
+    apply @filter.Inter_mem_sets _ (𝓝 a) _ _ _ h_fin,
     exact assume i h, this i
   end
   ... ≤ principal (- ⋃i, f i) :
@@ -596,6 +598,7 @@ end topological_space
 section continuous
 variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*}
 variables [topological_space α] [topological_space β] [topological_space γ]
+open_locale topological_space
 
 /-- A function between topological spaces is continuous if the preimage
   of every open set is open. -/
@@ -603,10 +606,10 @@ def continuous (f : α → β) := ∀s, is_open s → is_open (f ⁻¹' s)
 
 /-- A function between topological spaces is continuous at a point `x₀`
 if `f x` tends to `f x₀` when `x` tends to `x₀`. -/
-def continuous_at (f : α → β) (x : α) := tendsto f (nhds x) (nhds (f x))
+def continuous_at (f : α → β) (x : α) := tendsto f (𝓝 x) (𝓝 (f x))
 
 lemma continuous_at.preimage_mem_nhds {f : α → β} {x : α} {t : set β} (h : continuous_at f x)
-  (ht : t ∈ nhds (f x)) : f ⁻¹' t ∈ nhds x :=
+  (ht : t ∈ 𝓝 (f x)) : f ⁻¹' t ∈ 𝓝 x :=
 h ht
 
 lemma continuous_id : continuous (id : α → α) :=
@@ -622,8 +625,8 @@ lemma continuous_at.comp {g : β → γ} {f : α → β} {x : α}
 hg.comp hf
 
 lemma continuous.tendsto {f : α → β} (hf : continuous f) (x) :
-  tendsto f (nhds x) (nhds (f x)) | s :=
-show s ∈ nhds (f x) → s ∈ map f (nhds x),
+  tendsto f (𝓝 x) (𝓝 (f x)) | s :=
+show s ∈ 𝓝 (f x) → s ∈ map f (𝓝 x),
 by simp [nhds_sets]; exact
 assume t t_subset t_open fx_in_t,
   ⟨f ⁻¹' t, preimage_mono t_subset, hf t t_open, fx_in_t⟩
@@ -634,9 +637,9 @@ h.tendsto x
 
 lemma continuous_iff_continuous_at {f : α → β} : continuous f ↔ ∀ x, continuous_at f x :=
 ⟨continuous.tendsto,
-  assume hf : ∀x, tendsto f (nhds x) (nhds (f x)),
+  assume hf : ∀x, tendsto f (𝓝 x) (𝓝 (f x)),
   assume s, assume hs : is_open s,
-  have ∀a, f a ∈ s → s ∈ nhds (f a),
+  have ∀a, f a ∈ s → s ∈ 𝓝 (f a),
     by simp [nhds_sets]; exact assume a ha, ⟨s, subset.refl s, hs, ha⟩,
   show is_open (f ⁻¹' s),
     by simp [is_open_iff_nhds]; exact assume a ha, hf a (this a ha)⟩
@@ -650,11 +653,11 @@ lemma continuous_iff_is_closed {f : α → β} :
   assume hf s, by rw [←is_closed_compl_iff, ←is_closed_compl_iff]; exact hf _⟩
 
 lemma continuous_at_iff_ultrafilter {f : α → β} (x) : continuous_at f x ↔
-  ∀ g, is_ultrafilter g → g ≤ nhds x → g.map f ≤ nhds (f x) :=
-tendsto_iff_ultrafilter f (nhds x) (nhds (f x))
+  ∀ g, is_ultrafilter g → g ≤ 𝓝 x → g.map f ≤ 𝓝 (f x) :=
+tendsto_iff_ultrafilter f (𝓝 x) (𝓝 (f x))
 
 lemma continuous_iff_ultrafilter {f : α → β} :
-  continuous f ↔ ∀ x g, is_ultrafilter g → g ≤ nhds x → g.map f ≤ nhds (f x) :=
+  continuous f ↔ ∀ x g, is_ultrafilter g → g ≤ 𝓝 x → g.map f ≤ 𝓝 (f x) :=
 by simp only [continuous_iff_continuous_at, continuous_at_iff_ultrafilter]
 
 lemma continuous_if {p : α → Prop} {f g : α → β} {h : ∀a, decidable (p a)}
@@ -701,12 +704,12 @@ lemma open_dom_of_pcontinuous {f : α →. β} (h : pcontinuous f) : is_open f.d
 by rw [←pfun.preimage_univ]; exact h _ is_open_univ
 
 lemma pcontinuous_iff' {f : α →. β} :
-  pcontinuous f ↔ ∀ {x y} (h : y ∈ f x), ptendsto' f (nhds x) (nhds y) :=
+  pcontinuous f ↔ ∀ {x y} (h : y ∈ f x), ptendsto' f (𝓝 x) (𝓝 y) :=
 begin
   split,
   { intros h x y h',
     rw [ptendsto'_def],
-    change ∀ (s : set β), s ∈ (nhds y).sets → pfun.preimage f s ∈ (nhds x).sets,
+    change ∀ (s : set β), s ∈ (𝓝 y).sets → pfun.preimage f s ∈ (𝓝 x).sets,
     rw [nhds_sets, nhds_sets],
     rintros s ⟨t, tsubs, opent, yt⟩,
     exact ⟨f.preimage t, pfun.preimage_mono _ tsubs, h _ opent, ⟨y, yt, h'⟩⟩
@@ -716,24 +719,24 @@ begin
   rintros x ⟨y, ys, fxy⟩ t,
   rw [mem_principal_sets],
   assume h : f.preimage s ⊆ t,
-  change t ∈ nhds x,
+  change t ∈ 𝓝 x,
   apply mem_sets_of_superset _ h,
-  have h' : ∀ s ∈ nhds y, f.preimage s ∈ nhds x,
+  have h' : ∀ s ∈ 𝓝 y, f.preimage s ∈ 𝓝 x,
   { intros s hs,
-     have : ptendsto' f (nhds x) (nhds y) := hf fxy,
+     have : ptendsto' f (𝓝 x) (𝓝 y) := hf fxy,
      rw ptendsto'_def at this,
      exact this s hs },
-  show f.preimage s ∈ nhds x,
+  show f.preimage s ∈ 𝓝 x,
   apply h', rw mem_nhds_sets_iff, exact ⟨s, set.subset.refl _, os, ys⟩
 end
 
 lemma image_closure_subset_closure_image {f : α → β} {s : set α} (h : continuous f) :
   f '' closure s ⊆ closure (f '' s) :=
-have ∀ (a : α), nhds a ⊓ principal s ≠ ⊥ → nhds (f a) ⊓ principal (f '' s) ≠ ⊥,
+have ∀ (a : α), 𝓝 a ⊓ principal s ≠ ⊥ → 𝓝 (f a) ⊓ principal (f '' s) ≠ ⊥,
   from assume a ha,
-  have h₁ : ¬ map f (nhds a ⊓ principal s) = ⊥,
+  have h₁ : ¬ map f (𝓝 a ⊓ principal s) = ⊥,
     by rwa[map_eq_bot_iff],
-  have h₂ : map f (nhds a ⊓ principal s) ≤ nhds (f a) ⊓ principal (f '' s),
+  have h₂ : map f (𝓝 a ⊓ principal s) ≤ 𝓝 (f a) ⊓ principal (f '' s),
     from le_inf
       (le_trans (map_mono inf_le_left) $ by rw [continuous_iff_continuous_at] at h; exact h a)
       (le_trans (map_mono inf_le_right) $ by simp; exact subset.refl _),

--- a/src/topology/bounded_continuous_function.lean
+++ b/src/topology/bounded_continuous_function.lean
@@ -12,6 +12,7 @@ import analysis.normed_space.basic topology.metric_space.cau_seq_filter
 
 noncomputable theory
 local attribute [instance] classical.decidable_inhabited classical.prop_decidable
+open_locale topological_space
 
 open set lattice filter metric
 
@@ -21,13 +22,13 @@ variables {α : Type u} {β : Type v} {γ : Type w}
 /-- A locally uniform limit of continuous functions is continuous -/
 lemma continuous_of_locally_uniform_limit_of_continuous [topological_space α] [metric_space β]
   {F : ℕ → α → β} {f : α → β}
-  (L : ∀x:α, ∃s ∈ nhds x, ∀ε>(0:ℝ), ∃n, ∀y∈s, dist (F n y) (f y) ≤ ε)
+  (L : ∀x:α, ∃s ∈ 𝓝 x, ∀ε>(0:ℝ), ∃n, ∀y∈s, dist (F n y) (f y) ≤ ε)
   (C : ∀ n, continuous (F n)) : continuous f :=
 continuous_iff'.2 $ λ x ε ε0, begin
   rcases L x with ⟨r, rx, hr⟩,
   rcases hr (ε/2/2) (half_pos $ half_pos ε0) with ⟨n, hn⟩,
   rcases continuous_iff'.1 (C n) x (ε/2) (half_pos ε0) with ⟨s, sx, hs⟩,
-  refine ⟨_, (nhds x).inter_sets rx sx, _⟩,
+  refine ⟨_, (𝓝 x).inter_sets rx sx, _⟩,
   rintro y ⟨yr, ys⟩,
   calc dist (f y) (f x)
         ≤ dist (F n y) (F n x) + (dist (F n y) (f y) + dist (F n x) (f x)) : dist_triangle4_left _ _ _ _
@@ -131,7 +132,7 @@ theorem continuous_eval : continuous (λ p : (α →ᵇ β) × α, p.1 p.2) :=
 continuous_iff'.2 $ λ ⟨f, x⟩ ε ε0,
 /- use the continuity of `f` to find a neighborhood of `x` where it varies at most by ε/2 -/
 let ⟨s, sx, Hs⟩ := continuous_iff'.1 f.2.1 x (ε/2) (half_pos ε0) in
-/- s : set α, sx : s ∈ nhds x, Hs : ∀ (b : α), b ∈ s → dist (f.val b) (f.val x) < ε / 2 -/
+/- s : set α, sx : s ∈ 𝓝 x, Hs : ∀ (b : α), b ∈ s → dist (f.val b) (f.val x) < ε / 2 -/
 ⟨set.prod (ball f (ε/2)) s, prod_mem_nhds_sets (ball_mem_nhds _ (half_pos ε0)) sx,
 λ ⟨g, y⟩ ⟨hg, hy⟩, calc dist (g y) (f x)
       ≤ dist (g y) (f y) + dist (f y) (f x) : dist_triangle _ _ _
@@ -157,7 +158,7 @@ begin
   have fx_cau : ∀x, cauchy_seq (λn, f n x) :=
     λx, cauchy_seq_iff_le_tendsto_0.2 ⟨b, b0, f_bdd x, b_lim⟩,
   choose F hF using λx, cauchy_seq_tendsto_of_complete (fx_cau x),
-  /- F : α → β,  hF : ∀ (x : α), tendsto (λ (n : ℕ), f n x) at_top (nhds (F x))
+  /- F : α → β,  hF : ∀ (x : α), tendsto (λ (n : ℕ), f n x) at_top (𝓝 (F x))
   `F` is the desired limit function. Check that it is uniformly approximated by `f N` -/
   have fF_bdd : ∀x N, dist (f N x) (F x) ≤ b N :=
     λ x N, le_of_tendsto (by simp)
@@ -220,7 +221,7 @@ and several useful variations around it. -/
 theorem arzela_ascoli₁ [compact_space β]
   (A : set (α →ᵇ β))
   (closed : is_closed A)
-  (H : ∀ (x:α) (ε > 0), ∃U ∈ nhds x, ∀ (y z ∈ U) (f : α →ᵇ β),
+  (H : ∀ (x:α) (ε > 0), ∃U ∈ 𝓝 x, ∀ (y z ∈ U) (f : α →ᵇ β),
     f ∈ A → dist (f y) (f z) < ε) :
   compact A :=
 begin
@@ -285,7 +286,7 @@ theorem arzela_ascoli₂
   (A : set (α →ᵇ β))
   (closed : is_closed A)
   (in_s : ∀(f : α →ᵇ β) (x : α), f ∈ A → f x ∈ s)
-  (H : ∀(x:α) (ε > 0), ∃U ∈ nhds x, ∀ (y z ∈ U) (f : α →ᵇ β),
+  (H : ∀(x:α) (ε > 0), ∃U ∈ 𝓝 x, ∀ (y z ∈ U) (f : α →ᵇ β),
     f ∈ A → dist (f y) (f z) < ε) :
   compact A :=
 /- This version is deduced from the previous one by restricting to the compact type in the target,
@@ -311,7 +312,7 @@ theorem arzela_ascoli
   (s : set β) (hs : compact s)
   (A : set (α →ᵇ β))
   (in_s : ∀(f : α →ᵇ β) (x : α), f ∈ A → f x ∈ s)
-  (H : ∀(x:α) (ε > 0), ∃U ∈ nhds x, ∀ (y z ∈ U) (f : α →ᵇ β),
+  (H : ∀(x:α) (ε > 0), ∃U ∈ 𝓝 x, ∀ (y z ∈ U) (f : α →ᵇ β),
     f ∈ A → dist (f y) (f z) < ε) :
   compact (closure A) :=
 /- This version is deduced from the previous one by checking that the closure of A, in
@@ -320,7 +321,7 @@ arzela_ascoli₂ s hs (closure A) is_closed_closure
   (λ f x hf, (mem_of_closed' (closed_of_compact _ hs)).2 $ λ ε ε0,
     let ⟨g, gA, dist_fg⟩ := mem_closure_iff'.1 hf ε ε0 in
     ⟨g x, in_s g x gA, lt_of_le_of_lt (dist_coe_le_dist _) dist_fg⟩)
-  (λ x ε ε0, show ∃ U ∈ nhds x,
+  (λ x ε ε0, show ∃ U ∈ 𝓝 x,
       ∀ y z ∈ U, ∀ (f : α →ᵇ β), f ∈ closure A → dist (f y) (f z) < ε,
     begin
       refine bex.imp_right (λ U U_set hU y z hy hz f hf, _) (H x (ε/2) (half_pos ε0)),
@@ -337,10 +338,10 @@ instance is when the source space is a metric space, and there is a fixed modulu
 for all the functions in the set A -/
 
 lemma equicontinuous_of_continuity_modulus {α : Type u} [metric_space α]
-  (b : ℝ → ℝ) (b_lim : tendsto b (nhds 0) (nhds 0))
+  (b : ℝ → ℝ) (b_lim : tendsto b (𝓝 0) (𝓝 0))
   (A : set (α →ᵇ β))
   (H : ∀(x y:α) (f : α →ᵇ β), f ∈ A → dist (f x) (f y) ≤ b (dist x y))
-  (x:α) (ε : ℝ) (ε0 : ε > 0) : ∃U ∈ nhds x, ∀ (y z ∈ U) (f : α →ᵇ β),
+  (x:α) (ε : ℝ) (ε0 : ε > 0) : ∃U ∈ 𝓝 x, ∀ (y z ∈ U) (f : α →ᵇ β),
     f ∈ A → dist (f y) (f z) < ε :=
 begin
   rcases tendsto_nhds_nhds.1 b_lim ε ε0 with ⟨δ, δ0, hδ⟩,

--- a/src/topology/compact_open.lean
+++ b/src/topology/compact_open.lean
@@ -9,6 +9,7 @@ Type of continuous maps and the compact-open topology on them.
 import topology.subset_properties tactic.tidy
 
 open set
+open_locale topological_space
 
 universes u v w
 
@@ -69,12 +70,12 @@ variables {α β}
 lemma continuous_ev [locally_compact_space α] : continuous (ev α β) :=
 continuous_iff_continuous_at.mpr $ assume ⟨f, x⟩ n hn,
   let ⟨v, vn, vo, fxv⟩ := mem_nhds_sets_iff.mp hn in
-  have v ∈ nhds (f.val x), from mem_nhds_sets vo fxv,
+  have v ∈ 𝓝 (f.val x), from mem_nhds_sets vo fxv,
   let ⟨s, hs, sv, sc⟩ :=
     locally_compact_space.local_compact_nhds x (f.val ⁻¹' v)
       (f.property.tendsto x this) in
   let ⟨u, us, uo, xu⟩ := mem_nhds_sets_iff.mp hs in
-  show (ev α β) ⁻¹' n ∈ nhds (f, x), from
+  show (ev α β) ⁻¹' n ∈ 𝓝 (f, x), from
   let w := set.prod (compact_open.gen s v) u in
   have w ⊆ ev α β ⁻¹' n, from assume ⟨f', x'⟩ ⟨hf', hx'⟩, calc
     f'.val x' ∈ f'.val '' s  : mem_image_of_mem f'.val (us hx')

--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -32,7 +32,7 @@ product, sum, disjoint union, subspace, quotient space
 noncomputable theory
 
 open topological_space set filter lattice
-open_locale classical
+open_locale classical topological_space
 
 universes u v w x
 variables {α : Type u} {β : Type v} {γ : Type w} {δ : Type x}
@@ -93,15 +93,15 @@ section topα
 variable [topological_space α]
 
 /-
-The nhds filter and the subspace topology.
+The 𝓝 filter and the subspace topology.
 -/
 
 theorem mem_nhds_subtype (s : set α) (a : {x // x ∈ s}) (t : set {x // x ∈ s}) :
-  t ∈ nhds a ↔ ∃ u ∈ nhds a.val, (@subtype.val α s) ⁻¹' u ⊆ t :=
+  t ∈ 𝓝 a ↔ ∃ u ∈ 𝓝 a.val, (@subtype.val α s) ⁻¹' u ⊆ t :=
 by rw mem_nhds_induced
 
 theorem nhds_subtype (s : set α) (a : {x // x ∈ s}) :
-  nhds a = comap subtype.val (nhds a.val) :=
+  𝓝 a = comap subtype.val (𝓝 a.val) :=
 by rw nhds_induced
 
 end topα
@@ -130,7 +130,7 @@ lemma is_open_prod {s : set α} {t : set β} (hs : is_open s) (ht : is_open t) :
   is_open (set.prod s t) :=
 is_open_inter (continuous_fst s hs) (continuous_snd t ht)
 
-lemma nhds_prod_eq {a : α} {b : β} : nhds (a, b) = filter.prod (nhds a) (nhds b) :=
+lemma nhds_prod_eq {a : α} {b : β} : 𝓝 (a, b) = filter.prod (𝓝 a) (𝓝 b) :=
 by rw [filter.prod, prod.topological_space, nhds_inf, nhds_induced, nhds_induced]
 
 instance [discrete_topology α] [discrete_topology β] : discrete_topology (α × β) :=
@@ -138,15 +138,15 @@ instance [discrete_topology α] [discrete_topology β] : discrete_topology (α �
   by rw [nhds_prod_eq, nhds_discrete α, nhds_discrete β, nhds_bot, filter.prod_pure_pure]⟩
 
 lemma prod_mem_nhds_sets {s : set α} {t : set β} {a : α} {b : β}
-  (ha : s ∈ nhds a) (hb : t ∈ nhds b) : set.prod s t ∈ nhds (a, b) :=
+  (ha : s ∈ 𝓝 a) (hb : t ∈ 𝓝 b) : set.prod s t ∈ 𝓝 (a, b) :=
 by rw [nhds_prod_eq]; exact prod_mem_prod ha hb
 
-lemma nhds_swap (a : α) (b : β) : nhds (a, b) = (nhds (b, a)).map prod.swap :=
+lemma nhds_swap (a : α) (b : β) : 𝓝 (a, b) = (𝓝 (b, a)).map prod.swap :=
 by rw [nhds_prod_eq, filter.prod_comm, nhds_prod_eq]; refl
 
 lemma tendsto_prod_mk_nhds {γ} {a : α} {b : β} {f : filter γ} {ma : γ → α} {mb : γ → β}
-  (ha : tendsto ma f (nhds a)) (hb : tendsto mb f (nhds b)) :
-  tendsto (λc, (ma c, mb c)) f (nhds (a, b)) :=
+  (ha : tendsto ma f (𝓝 a)) (hb : tendsto mb f (𝓝 b)) :
+  tendsto (λc, (ma c, mb c)) f (𝓝 (a, b)) :=
 by rw [nhds_prod_eq]; exact filter.tendsto.prod_mk ha hb
 
 lemma continuous_at.prod {f : α → β} {g : α → γ} {x : α}
@@ -264,8 +264,8 @@ end
 lemma closure_prod_eq {s : set α} {t : set β} :
   closure (set.prod s t) = set.prod (closure s) (closure t) :=
 set.ext $ assume ⟨a, b⟩,
-have filter.prod (nhds a) (nhds b) ⊓ principal (set.prod s t) =
-  filter.prod (nhds a ⊓ principal s) (nhds b ⊓ principal t),
+have filter.prod (𝓝 a) (𝓝 b) ⊓ principal (set.prod s t) =
+  filter.prod (𝓝 a ⊓ principal s) (𝓝 b ⊓ principal t),
   by rw [←prod_inf_prod, prod_principal_principal],
 by simp [closure_eq_nhds, nhds_prod_eq, this]; exact prod_neq_bot
 
@@ -393,29 +393,29 @@ lemma continuous_at_subtype_val {p : α → Prop} {a : subtype p} :
   continuous_at subtype.val a :=
 continuous_iff_continuous_at.mp continuous_subtype_val _
 
-lemma map_nhds_subtype_val_eq {a : α} (ha : p a) (h : {a | p a} ∈ nhds a) :
-  map (@subtype.val α p) (nhds ⟨a, ha⟩) = nhds a :=
+lemma map_nhds_subtype_val_eq {a : α} (ha : p a) (h : {a | p a} ∈ 𝓝 a) :
+  map (@subtype.val α p) (𝓝 ⟨a, ha⟩) = 𝓝 a :=
 map_nhds_induced_eq (by simp [subtype.val_image, h])
 
 lemma nhds_subtype_eq_comap {a : α} {h : p a} :
-  nhds (⟨a, h⟩ : subtype p) = comap subtype.val (nhds a) :=
+  𝓝 (⟨a, h⟩ : subtype p) = comap subtype.val (𝓝 a) :=
 nhds_induced _ _
 
 lemma tendsto_subtype_rng {β : Type*} {p : α → Prop} {b : filter β} {f : β → subtype p} :
-  ∀{a:subtype p}, tendsto f b (nhds a) ↔ tendsto (λx, subtype.val (f x)) b (nhds a.val)
+  ∀{a:subtype p}, tendsto f b (𝓝 a) ↔ tendsto (λx, subtype.val (f x)) b (𝓝 a.val)
 | ⟨a, ha⟩ := by rw [nhds_subtype_eq_comap, tendsto_comap_iff]
 
 lemma continuous_subtype_nhds_cover {ι : Sort*} {f : α → β} {c : ι → α → Prop}
-  (c_cover : ∀x:α, ∃i, {x | c i x} ∈ nhds x)
+  (c_cover : ∀x:α, ∃i, {x | c i x} ∈ 𝓝 x)
   (f_cont  : ∀i, continuous (λ(x : subtype (c i)), f x.val)) :
   continuous f :=
 continuous_iff_continuous_at.mpr $ assume x,
-  let ⟨i, (c_sets : {x | c i x} ∈ nhds x)⟩ := c_cover x in
+  let ⟨i, (c_sets : {x | c i x} ∈ 𝓝 x)⟩ := c_cover x in
   let x' : subtype (c i) := ⟨x, mem_of_nhds c_sets⟩ in
-  calc map f (nhds x) = map f (map subtype.val (nhds x')) :
+  calc map f (𝓝 x) = map f (map subtype.val (𝓝 x')) :
       congr_arg (map f) (map_nhds_subtype_val_eq _ $ c_sets).symm
-    ... = map (λx:subtype (c i), f x.val) (nhds x') : rfl
-    ... ≤ nhds (f x) : continuous_iff_continuous_at.mp (f_cont i) x'
+    ... = map (λx:subtype (c i), f x.val) (𝓝 x') : rfl
+    ... ≤ 𝓝 (f x) : continuous_iff_continuous_at.mp (f_cont i) x'
 
 lemma continuous_subtype_is_closed_cover {ι : Sort*} {f : α → β} (c : ι → α → Prop)
   (h_lf : locally_finite (λi, {x | c i x}))
@@ -489,9 +489,9 @@ lemma continuous_apply [∀i, topological_space (π i)] (i : ι) :
 continuous_infi_dom continuous_induced_dom
 
 lemma nhds_pi [t : ∀i, topological_space (π i)] {a : Πi, π i} :
-  nhds a = (⨅i, comap (λx, x i) (nhds (a i))) :=
-calc nhds a = (⨅i, @nhds _ (@topological_space.induced _ _ (λx:Πi, π i, x i) (t i)) a) : nhds_infi
-  ... = (⨅i, comap (λx, x i) (nhds (a i))) : by simp [nhds_induced]
+  𝓝 a = (⨅i, comap (λx, x i) (𝓝 (a i))) :=
+calc 𝓝 a = (⨅i, @nhds _ (@topological_space.induced _ _ (λx:Πi, π i, x i) (t i)) a) : nhds_infi
+  ... = (⨅i, comap (λx, x i) (𝓝 (a i))) : by simp [nhds_induced]
 
 lemma is_open_set_pi [∀a, topological_space (π a)] {i : set ι} {s : Πa, set (π a)}
   (hi : finite i) (hs : ∀a∈i, is_open (s a)) : is_open (pi i s) :=

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -21,13 +21,14 @@ equipped with the subspace topology.
 -/
 
 open set filter
+open_locale topological_space
 
 variables {α : Type*} {β : Type*} {γ : Type*}
 variables [topological_space α]
 
 /-- The "neighborhood within" filter. Elements of `nhds_within a s` are sets containing the
 intersection of `s` and a neighborhood of `a`. -/
-def nhds_within (a : α) (s : set α) : filter α := nhds a ⊓ principal s
+def nhds_within (a : α) (s : set α) : filter α := 𝓝 a ⊓ principal s
 
 theorem nhds_within_eq (a : α) (s : set α) :
   nhds_within a s = ⨅ t ∈ {t : set α | a ∈ t ∧ is_open t}, principal (t ∩ s) :=
@@ -37,7 +38,7 @@ begin
   simp only [inf_principal]
 end
 
-theorem nhds_within_univ (a : α) : nhds_within a set.univ = nhds a :=
+theorem nhds_within_univ (a : α) : nhds_within a set.univ = 𝓝 a :=
 by rw [nhds_within, principal_univ, lattice.inf_top_eq]
 
 theorem mem_nhds_within (t : set α) (a : α) (s : set α) :
@@ -50,7 +51,7 @@ begin
   exact ⟨u, λ x xu xs, hu ⟨xu, xs⟩, openu, au⟩
 end
 
-lemma mem_nhds_within_of_mem_nhds {s t : set α} {a : α} (h : s ∈ nhds a) :
+lemma mem_nhds_within_of_mem_nhds {s t : set α} {a : α} (h : s ∈ 𝓝 a) :
   s ∈ nhds_within a t :=
 mem_inf_sets_of_left h
 
@@ -61,7 +62,7 @@ begin
   exact univ_mem_sets
 end
 
-theorem inter_mem_nhds_within (s : set α) {t : set α} {a : α} (h : t ∈ nhds a) :
+theorem inter_mem_nhds_within (s : set α) {t : set α} {a : α} (h : t ∈ 𝓝 a) :
   s ∩ t ∈ nhds_within a s :=
 inter_mem_sets (mem_inf_sets_of_right (mem_principal_self s)) (mem_inf_sets_of_left h)
 
@@ -74,7 +75,7 @@ le_antisymm
   (lattice.le_inf lattice.inf_le_left (le_principal_iff.mpr (inter_mem_sets self_mem_nhds_within h)))
   (lattice.inf_le_inf (le_refl _) (principal_mono.mpr (set.inter_subset_left _ _)))
 
-theorem nhds_within_restrict' {a : α} (s : set α) {t : set α} (h : t ∈ nhds a) :
+theorem nhds_within_restrict' {a : α} (s : set α) {t : set α} (h : t ∈ 𝓝 a) :
   nhds_within a s = nhds_within a (s ∩ t) :=
 nhds_within_restrict'' s $ mem_inf_sets_of_left h
 
@@ -97,7 +98,7 @@ theorem nhds_within_eq_nhds_within {a : α} {s t u : set α}
 by rw [nhds_within_restrict t h₀ h₁, nhds_within_restrict u h₀ h₁, h₂]
 
 theorem nhds_within_eq_of_open {a : α} {s : set α} (h₀ : a ∈ s) (h₁ : is_open s) :
-  nhds_within a s = nhds a :=
+  nhds_within a s = 𝓝 a :=
 by rw [←nhds_within_univ]; apply nhds_within_eq_nhds_within h₀ h₁;
      rw [set.univ_inter, set.inter_self]
 
@@ -148,7 +149,7 @@ theorem tendsto_nhds_within_mono_right {f : β → α} {l : filter β}
 tendsto_le_right (nhds_within_mono a hst) h
 
 theorem tendsto_nhds_within_of_tendsto_nhds {f : α → β} {a : α}
-    {s : set α} {l : filter β} (h : tendsto f (nhds a) l) :
+    {s : set α} {l : filter β} (h : tendsto f (𝓝 a) l) :
   tendsto f (nhds_within a s) l :=
 by rw [←nhds_within_univ] at h; exact tendsto_nhds_within_mono_left (set.subset_univ _) h
 
@@ -190,7 +191,7 @@ theorem nhds_within_subtype (s : set α) (a : {x // x ∈ s}) (t : set {x // x �
 filter_eq $ by ext u; rw mem_nhds_within_subtype
 
 theorem nhds_within_eq_map_subtype_val {s : set α} {a : α} (h : a ∈ s) :
-  nhds_within a s = map subtype.val (nhds ⟨a, h⟩) :=
+  nhds_within a s = map subtype.val (𝓝 ⟨a, h⟩) :=
 have h₀ : s ∈ nhds_within a s,
   by { rw [mem_nhds_within], existsi set.univ, simp [set.diff_eq] },
 have h₁ : ∀ y ∈ s, ∃ x, @subtype.val _ s x = y,
@@ -201,7 +202,7 @@ begin
 end
 
 theorem tendsto_nhds_within_iff_subtype {s : set α} {a : α} (h : a ∈ s) (f : α → β) (l : filter β) :
-  tendsto f (nhds_within a s) l ↔ tendsto (function.restrict f s) (nhds ⟨a, h⟩) l :=
+  tendsto f (nhds_within a s) l ↔ tendsto (function.restrict f s) (𝓝 ⟨a, h⟩) l :=
 by rw [tendsto, tendsto, function.restrict, nhds_within_eq_map_subtype_val h,
     ←(@filter.map_map _ _ _ _ subtype.val)]
 
@@ -210,7 +211,7 @@ variables [topological_space β] [topological_space γ]
 /-- A function between topological spaces is continuous at a point `x₀` within a subset `s`
 if `f x` tends to `f x₀` when `x` tends to `x₀` while staying within `s`. -/
 def continuous_within_at (f : α → β) (s : set α) (x : α) : Prop :=
-tendsto f (nhds_within x s) (nhds (f x))
+tendsto f (nhds_within x s) (𝓝 (f x))
 
 /-- A function between topological spaces is continuous on a subset `s`
 when it's continuous at every point of `s` within `s`. -/
@@ -272,7 +273,7 @@ theorem nhds_within_le_comap {x : α} {s : set α} {f : α → β} (ctsf : conti
 map_le_iff_le_comap.1 ctsf.tendsto_nhds_within_image
 
 theorem continuous_within_at_iff_ptendsto_res (f : α → β) {x : α} {s : set α} :
-  continuous_within_at f s x ↔ ptendsto (pfun.res f s) (nhds x) (nhds (f x)) :=
+  continuous_within_at f s x ↔ ptendsto (pfun.res f s) (𝓝 x) (𝓝 (f x)) :=
 tendsto_iff_ptendsto _ _ _ _
 
 lemma continuous_iff_continuous_on_univ {f : α → β} : continuous f ↔ continuous_on f univ :=
@@ -287,7 +288,7 @@ lemma continuous_within_at_inter' {f : α → β} {s t : set α} {x : α} (h : t
   continuous_within_at f (s ∩ t) x ↔ continuous_within_at f s x :=
 by simp [continuous_within_at, nhds_within_restrict'' s h]
 
-lemma continuous_within_at_inter {f : α → β} {s t : set α} {x : α} (h : t ∈ nhds x) :
+lemma continuous_within_at_inter {f : α → β} {s t : set α} {x : α} (h : t ∈ 𝓝 x) :
   continuous_within_at f (s ∩ t) x ↔ continuous_within_at f s x :=
 by simp [continuous_within_at, nhds_within_restrict' s h]
 
@@ -320,7 +321,7 @@ lemma continuous_at.continuous_within_at {f : α → β} {s : set α} {x : α} (
 continuous_within_at.mono ((continuous_within_at_univ f x).2 h) (subset_univ _)
 
 lemma continuous_within_at.continuous_at {f : α → β} {s : set α} {x : α}
-  (h : continuous_within_at f s x) (hs : s ∈ nhds x) : continuous_at f x :=
+  (h : continuous_within_at f s x) (hs : s ∈ 𝓝 x) : continuous_at f x :=
 begin
   have : s = univ ∩ s, by rw univ_inter,
   rwa [this, continuous_within_at_inter hs, continuous_within_at_univ] at h
@@ -361,7 +362,7 @@ lemma continuous.comp_continuous_on {g : β → γ} {f : α → β} {s : set α}
 hg.continuous_on.comp hf subset_preimage_univ
 
 lemma continuous_within_at.preimage_mem_nhds_within {f : α → β} {x : α} {s : set α} {t : set β}
-  (h : continuous_within_at f s x) (ht : t ∈ nhds (f x)) : f ⁻¹' t ∈ nhds_within x s :=
+  (h : continuous_within_at f s x) (ht : t ∈ 𝓝 (f x)) : f ⁻¹' t ∈ nhds_within x s :=
 h ht
 
 lemma continuous_within_at.preimage_mem_nhds_within' {f : α → β} {x : α} {s : set α} {t : set β}

--- a/src/topology/dense_embedding.lean
+++ b/src/topology/dense_embedding.lean
@@ -24,7 +24,7 @@ has to be `dense_inducing` (not necessarily injective).
 noncomputable theory
 
 open set filter lattice
-open_locale classical
+open_locale classical topological_space
 
 variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*}
 
@@ -82,7 +82,7 @@ variables [topological_space α] [topological_space β]
 variables {i : α → β} (di : dense_inducing i)
 
 lemma nhds_eq_comap (di : dense_inducing i) :
-  ∀ a : α, nhds a = comap i (nhds $ i a) :=
+  ∀ a : α, 𝓝 a = comap i (𝓝 $ i a) :=
 di.to_inducing.nhds_eq_comap
 
 protected lemma continuous (di : dense_inducing i) : continuous i :=
@@ -103,7 +103,7 @@ begin
 end
 
 lemma closure_image_nhds_of_nhds {s : set α} {a : α} (di : dense_inducing i) :
-  s ∈ nhds a → closure (i '' s) ∈ nhds (i a) :=
+  s ∈ 𝓝 a → closure (i '' s) ∈ 𝓝 (i a) :=
 begin
   rw [di.nhds_eq_comap a, mem_comap_sets],
   intro h,
@@ -114,8 +114,8 @@ begin
                    ... ⊆ s      : sub,
   have := calc U ⊆ closure (i '' (i ⁻¹' U)) : self_sub_closure_image_preimage_of_open di U_op
              ... ⊆ closure (i '' s)         : closure_mono (image_subset i this),
-  have U_nhd : U ∈ nhds (i a) := mem_nhds_sets U_op e_a_in_U,
-  exact (nhds (i a)).sets_of_superset U_nhd this
+  have U_nhd : U ∈ 𝓝 (i a) := mem_nhds_sets U_op e_a_in_U,
+  exact (𝓝 (i a)).sets_of_superset U_nhd this
 end
 
 /-- The product of two dense inducings is a dense inducing -/
@@ -131,27 +131,27 @@ variables [topological_space δ] {f : γ → α} {g : γ → δ} {h : δ → β}
 g↓     ↓e
  δ -h→ β
 -/
-lemma tendsto_comap_nhds_nhds  {d : δ} {a : α} (di : dense_inducing i) (H : tendsto h (nhds d) (nhds (i a)))
-  (comm : h ∘ g = i ∘ f) : tendsto f (comap g (nhds d)) (nhds a) :=
+lemma tendsto_comap_nhds_nhds  {d : δ} {a : α} (di : dense_inducing i) (H : tendsto h (𝓝 d) (𝓝 (i a)))
+  (comm : h ∘ g = i ∘ f) : tendsto f (comap g (𝓝 d)) (𝓝 a) :=
 begin
-  have lim1 : map g (comap g (nhds d)) ≤ nhds d := map_comap_le,
-  replace lim1 : map h (map g (comap g (nhds d))) ≤ map h (nhds d) := map_mono lim1,
+  have lim1 : map g (comap g (𝓝 d)) ≤ 𝓝 d := map_comap_le,
+  replace lim1 : map h (map g (comap g (𝓝 d))) ≤ map h (𝓝 d) := map_mono lim1,
   rw [filter.map_map, comm, ← filter.map_map, map_le_iff_le_comap] at lim1,
-  have lim2 :  comap i (map h (nhds d)) ≤  comap i  (nhds (i a)) := comap_mono H,
+  have lim2 :  comap i (map h (𝓝 d)) ≤  comap i  (𝓝 (i a)) := comap_mono H,
   rw ← di.nhds_eq_comap at lim2,
   exact le_trans lim1 lim2,
 end
 
-protected lemma nhds_inf_neq_bot (di : dense_inducing i) {b : β} : nhds b ⊓ principal (range i) ≠ ⊥ :=
+protected lemma nhds_inf_neq_bot (di : dense_inducing i) {b : β} : 𝓝 b ⊓ principal (range i) ≠ ⊥ :=
 begin
   convert di.dense b,
   simp [closure_eq_nhds]
 end
 
-lemma comap_nhds_neq_bot (di : dense_inducing i) {b : β} : comap i (nhds b) ≠ ⊥ :=
+lemma comap_nhds_neq_bot (di : dense_inducing i) {b : β} : comap i (𝓝 b) ≠ ⊥ :=
 forall_sets_neq_empty_iff_neq_bot.mp $
 assume s ⟨t, ht, (hs : i ⁻¹' t ⊆ s)⟩,
-have t ∩ range i ∈ nhds b ⊓ principal (range i),
+have t ∩ range i ∈ 𝓝 b ⊓ principal (range i),
   from inter_mem_inf_sets ht (subset.refl _),
 let ⟨_, ⟨hx₁, y, rfl⟩⟩ := inhabited_of_mem_sets di.nhds_inf_neq_bot this in
 subset_ne_empty hs $ ne_empty_of_mem hx₁
@@ -163,9 +163,9 @@ variables [topological_space γ]
   continuous extension, then `g` is the unique such extension. In general,
   `g` might not be continuous or even extend `f`. -/
 def extend (di : dense_inducing i) (f : α → γ) (b : β) : γ :=
-@lim _ _ ⟨f (dense_range.inhabited di.dense b).default⟩ (map f (comap i (nhds b)))
+@lim _ _ ⟨f (dense_range.inhabited di.dense b).default⟩ (map f (comap i (𝓝 b)))
 
-lemma extend_eq [t2_space γ] {b : β} {c : γ} {f : α → γ} (hf : map f (comap i (nhds b)) ≤ nhds c) :
+lemma extend_eq [t2_space γ] {b : β} {c : γ} {f : α → γ} (hf : map f (comap i (𝓝 b)) ≤ 𝓝 c) :
   di.extend f b = c :=
 @lim_eq _ _ (id _) _ _ _ (by simp; exact comap_nhds_neq_bot di) hf
 
@@ -178,12 +178,12 @@ lemma extend_eq_of_cont [t2_space γ] {f : α → γ} (hf : continuous f) (a : �
 di.extend_e_eq a (continuous_iff_continuous_at.1 hf a)
 
 lemma tendsto_extend [regular_space γ] {b : β} {f : α → γ} (di : dense_inducing i)
-  (hf : {b | ∃c, tendsto f (comap i $ nhds b) (nhds c)} ∈ nhds b) :
-  tendsto (di.extend f) (nhds b) (nhds (di.extend f b)) :=
-let φ := {b | tendsto f (comap i $ nhds b) (nhds $ di.extend f b)} in
-have hφ : φ ∈ nhds b,
-  from (nhds b).sets_of_superset hf $ assume b ⟨c, hc⟩,
-    show tendsto f (comap i (nhds b)) (nhds (di.extend f b)), from (di.extend_eq hc).symm ▸ hc,
+  (hf : {b | ∃c, tendsto f (comap i $ 𝓝 b) (𝓝 c)} ∈ 𝓝 b) :
+  tendsto (di.extend f) (𝓝 b) (𝓝 (di.extend f b)) :=
+let φ := {b | tendsto f (comap i $ 𝓝 b) (𝓝 $ di.extend f b)} in
+have hφ : φ ∈ 𝓝 b,
+  from (𝓝 b).sets_of_superset hf $ assume b ⟨c, hc⟩,
+    show tendsto f (comap i (𝓝 b)) (𝓝 (di.extend f b)), from (di.extend_eq hc).symm ▸ hc,
 assume s hs,
 let ⟨s'', hs''₁, hs''₂, hs''₃⟩ := nhds_is_closed hs in
 let ⟨s', hs'₁, (hs'₂ : i ⁻¹' s' ⊆ f ⁻¹' s'')⟩ := mem_of_nhds hφ hs''₁ in
@@ -192,12 +192,12 @@ have h₁ : closure (f '' (i ⁻¹' s')) ⊆ s'',
   by rw [closure_subset_iff_subset_of_is_closed hs''₃, image_subset_iff]; exact hs'₂,
 have h₂ : t ⊆ di.extend f ⁻¹' closure (f '' (i ⁻¹' t)), from
   assume b' hb',
-  have nhds b' ≤ principal t, by simp; exact mem_nhds_sets ht₂ hb',
-  have map f (comap i (nhds b')) ≤ nhds (di.extend f b') ⊓ principal (f '' (i ⁻¹' t)),
-    from calc _ ≤ map f (comap i (nhds b' ⊓ principal t)) : map_mono $ comap_mono $ le_inf (le_refl _) this
-      ... ≤ map f (comap i (nhds b')) ⊓ map f (comap i (principal t)) :
+  have 𝓝 b' ≤ principal t, by simp; exact mem_nhds_sets ht₂ hb',
+  have map f (comap i (𝓝 b')) ≤ 𝓝 (di.extend f b') ⊓ principal (f '' (i ⁻¹' t)),
+    from calc _ ≤ map f (comap i (𝓝 b' ⊓ principal t)) : map_mono $ comap_mono $ le_inf (le_refl _) this
+      ... ≤ map f (comap i (𝓝 b')) ⊓ map f (comap i (principal t)) :
         le_inf (map_mono $ comap_mono $ inf_le_left) (map_mono $ comap_mono $ inf_le_right)
-      ... ≤ map f (comap i (nhds b')) ⊓ principal (f '' (i ⁻¹' t)) : by simp [le_refl]
+      ... ≤ map f (comap i (𝓝 b')) ⊓ principal (f '' (i ⁻¹' t)) : by simp [le_refl]
       ... ≤ _ : inf_le_inf ((ht₁ hb').left) (le_refl _),
   show di.extend f b' ∈ closure (f '' (i ⁻¹' t)),
   begin
@@ -206,8 +206,8 @@ have h₂ : t ⊆ di.extend f ⁻¹' closure (f '' (i ⁻¹' t)), from
     simp,
     exact di.comap_nhds_neq_bot
   end,
-(nhds b).sets_of_superset
-  (show t ∈ nhds b, from mem_nhds_sets ht₂ ht₃)
+(𝓝 b).sets_of_superset
+  (show t ∈ 𝓝 b, from mem_nhds_sets ht₂ ht₃)
   (calc t ⊆ di.extend f ⁻¹' closure (f '' (i ⁻¹' t)) : h₂
     ... ⊆ di.extend f ⁻¹' closure (f '' (i ⁻¹' s')) :
       preimage_mono $ closure_mono $ image_subset f $ preimage_mono $ subset.trans ht₁ $ inter_subset_right _ _
@@ -215,15 +215,15 @@ have h₂ : t ⊆ di.extend f ⁻¹' closure (f '' (i ⁻¹' t)), from
     ... ⊆ di.extend f ⁻¹' s : preimage_mono hs''₂)
 
 lemma continuous_extend [regular_space γ] {f : α → γ} (di : dense_inducing i)
-  (hf : ∀b, ∃c, tendsto f (comap i (nhds b)) (nhds c)) : continuous (di.extend f) :=
+  (hf : ∀b, ∃c, tendsto f (comap i (𝓝 b)) (𝓝 c)) : continuous (di.extend f) :=
 continuous_iff_continuous_at.mpr $ assume b, di.tendsto_extend $ univ_mem_sets' hf
 
 lemma mk'
   (i : α → β)
   (c     : continuous i)
   (dense : ∀x, x ∈ closure (range i))
-  (H     : ∀ (a:α) s ∈ nhds a,
-    ∃t ∈ nhds (i a), ∀ b, i b ∈ t → b ∈ s) :
+  (H     : ∀ (a:α) s ∈ 𝓝 a,
+    ∃t ∈ 𝓝 (i a), ∀ b, i b ∈ t → b ∈ s) :
   dense_inducing i :=
 { induced := (induced_iff_nhds_eq i).2 $
     λ a, le_antisymm (tendsto_iff_comap.1 $ c.tendsto _) (by simpa [le_def] using H a),
@@ -240,8 +240,8 @@ theorem dense_embedding.mk'
   (c     : continuous e)
   (dense : ∀x, x ∈ closure (range e))
   (inj   : function.injective e)
-  (H     : ∀ (a:α) s ∈ nhds a,
-    ∃t ∈ nhds (e a), ∀ b, e b ∈ t → b ∈ s) :
+  (H     : ∀ (a:α) s ∈ 𝓝 a,
+    ∃t ∈ 𝓝 (e a), ∀ b, e b ∈ t → b ∈ s) :
   dense_embedding e :=
 { inj := inj,
   ..dense_inducing.mk' e c dense H}

--- a/src/topology/instances/complex.lean
+++ b/src/topology/instances/complex.lean
@@ -9,6 +9,7 @@ import data.complex.basic topology.metric_space.basic topology.instances.real
 
 noncomputable theory
 open filter metric
+open_locale topological_space
 
 namespace complex
 
@@ -50,7 +51,7 @@ metric.uniform_continuous_iff.2 $ λ ε ε0,
 lemma continuous_abs : continuous (abs : ℂ → ℝ) :=
 uniform_continuous_abs.continuous
 
-lemma tendsto_inv {r : ℂ} (r0 : r ≠ 0) : tendsto (λq, q⁻¹) (nhds r) (nhds r⁻¹) :=
+lemma tendsto_inv {r : ℂ} (r0 : r ≠ 0) : tendsto (λq, q⁻¹) (𝓝 r) (𝓝 r⁻¹) :=
 by rw ← abs_pos at r0; exact
 tendsto_of_uniform_continuous_subtype
   (uniform_continuous_inv {x | abs r / 2 < abs x} (half_pos r0) (λ x h, le_of_lt h))

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -9,6 +9,7 @@ import topology.instances.nnreal data.real.ennreal
 noncomputable theory
 open classical set lattice filter metric
 open_locale classical
+open_locale topological_space
 variables {α : Type*} {β : Type*} {γ : Type*}
 
 open_locale ennreal
@@ -71,24 +72,24 @@ is_open_neg (is_closed_eq continuous_id continuous_const)
 
 lemma is_open_Ico_zero : is_open (Ico 0 b) := by { rw ennreal.Ico_eq_Iio, exact is_open_Iio}
 
-lemma coe_range_mem_nhds : range (coe : nnreal → ennreal) ∈ nhds (r : ennreal) :=
+lemma coe_range_mem_nhds : range (coe : nnreal → ennreal) ∈ 𝓝 (r : ennreal) :=
 have {a : ennreal | a ≠ ⊤} = range (coe : nnreal → ennreal),
   from set.ext $ assume a, by cases a; simp [none_eq_top, some_eq_coe],
 this ▸ mem_nhds_sets is_open_ne_top coe_ne_top
 
 lemma tendsto_coe {f : filter α} {m : α → nnreal} {a : nnreal} :
-  tendsto (λa, (m a : ennreal)) f (nhds ↑a) ↔ tendsto m f (nhds a) :=
+  tendsto (λa, (m a : ennreal)) f (𝓝 ↑a) ↔ tendsto m f (𝓝 a) :=
 embedding_coe.tendsto_nhds_iff.symm
 
 lemma continuous_coe {α} [topological_space α] {f : α → nnreal} :
 continuous (λa, (f a : ennreal)) ↔ continuous f :=
 embedding_coe.continuous_iff.symm
 
-lemma nhds_coe {r : nnreal} : nhds (r : ennreal) = (nhds r).map coe :=
+lemma nhds_coe {r : nnreal} : 𝓝 (r : ennreal) = (𝓝 r).map coe :=
 by rw [embedding_coe.induced, map_nhds_induced_eq coe_range_mem_nhds]
 
-lemma nhds_coe_coe {r p : nnreal} : nhds ((r : ennreal), (p : ennreal)) =
-  (nhds (r, p)).map (λp:nnreal×nnreal, (p.1, p.2)) :=
+lemma nhds_coe_coe {r p : nnreal} : 𝓝 ((r : ennreal), (p : ennreal)) =
+  (𝓝 (r, p)).map (λp:nnreal×nnreal, (p.1, p.2)) :=
 begin
   rw [(embedding_coe.prod_mk embedding_coe).map_nhds_eq],
   rw [← prod_range_range_eq],
@@ -98,19 +99,19 @@ end
 lemma continuous_of_real : continuous ennreal.of_real :=
 (continuous_coe.2 continuous_id).comp nnreal.continuous_of_real
 
-lemma tendsto_of_real {f : filter α} {m : α → ℝ} {a : ℝ} (h : tendsto m f (nhds a)) :
-  tendsto (λa, ennreal.of_real (m a)) f (nhds (ennreal.of_real a)) :=
+lemma tendsto_of_real {f : filter α} {m : α → ℝ} {a : ℝ} (h : tendsto m f (𝓝 a)) :
+  tendsto (λa, ennreal.of_real (m a)) f (𝓝 (ennreal.of_real a)) :=
 tendsto.comp (continuous.tendsto continuous_of_real _) h
 
 lemma tendsto_to_nnreal {a : ennreal} : a ≠ ⊤ →
-  tendsto (ennreal.to_nnreal) (nhds a) (nhds a.to_nnreal) :=
+  tendsto (ennreal.to_nnreal) (𝓝 a) (𝓝 a.to_nnreal) :=
 begin
   cases a; simp [some_eq_coe, none_eq_top, nhds_coe, tendsto_map'_iff, (∘)],
   exact tendsto_id
 end
 
 lemma tendsto_nhds_top {m : α → ennreal} {f : filter α}
-  (h : ∀n:ℕ, {a | ↑n < m a} ∈ f) : tendsto m f (nhds ⊤) :=
+  (h : ∀n:ℕ, {a | ↑n < m a} ∈ f) : tendsto m f (𝓝 ⊤) :=
 tendsto_nhds_generate_from $ assume s hs,
 match s, hs with
 | _, ⟨none,   or.inl rfl⟩, hr := (lt_irrefl ⊤ hr).elim
@@ -121,7 +122,7 @@ match s, hs with
 | _, ⟨a,      or.inr rfl⟩, hr := (not_top_lt $ show ⊤ < a, from hr).elim
 end
 
-lemma nhds_top : nhds ∞ = ⨅a:{a:ennreal // a ≠ ⊤}, principal (Ioi a) :=
+lemma nhds_top : 𝓝 ∞ = ⨅a:{a:ennreal // a ≠ ⊤}, principal (Ioi a) :=
 begin
   rw nhds_generate_from,
   refine le_antisymm
@@ -142,7 +143,7 @@ begin
         contradiction } }
 end
 
-lemma nhds_zero : nhds (0 : ennreal) = ⨅a:{a:ennreal // a ≠ 0}, principal (Iio a) :=
+lemma nhds_zero : 𝓝 (0 : ennreal) = ⨅a:{a:ennreal // a ≠ 0}, principal (Iio a) :=
 begin
   rw nhds_generate_from,
   refine le_antisymm
@@ -164,9 +165,9 @@ begin
 end
 
 -- using Icc because
--- • don't have 'Ioo (x - ε) (x + ε) ∈ nhds x' unless x > 0
+-- • don't have 'Ioo (x - ε) (x + ε) ∈ 𝓝 x' unless x > 0
 -- • (x - y ≤ ε ↔ x ≤ ε + y) is true, while (x - y < ε ↔ x < ε + y) is not
-lemma Icc_mem_nhds : x ≠ ⊤ → ε > 0 → Icc (x - ε) (x + ε) ∈ nhds x :=
+lemma Icc_mem_nhds : x ≠ ⊤ → ε > 0 → Icc (x - ε) (x + ε) ∈ 𝓝 x :=
 begin
   assume xt ε0, rw mem_nhds_sets_iff,
   by_cases x0 : x = 0,
@@ -177,7 +178,7 @@ begin
     exact ⟨is_open_Ioo, mem_Ioo_self_sub_add xt x0 ε0 ε0 ⟩ }
 end
 
-lemma nhds_of_ne_top : x ≠ ⊤ → nhds x = ⨅ε:{ε:ennreal // ε > 0}, principal (Icc (x - ε) (x + ε)) :=
+lemma nhds_of_ne_top : x ≠ ⊤ → 𝓝 x = ⨅ε:{ε:ennreal // ε > 0}, principal (Icc (x - ε) (x + ε)) :=
 begin
   assume xt, refine le_antisymm _ _,
   -- first direction
@@ -203,16 +204,16 @@ begin
 end
 
 protected theorem tendsto_nhds {f : filter α} {u : α → ennreal} {a : ennreal} (ha : a ≠ ⊤) :
-  tendsto u f (nhds a) ↔ ∀ ε > 0, ∃ n ∈ f, ∀x ∈ n,  (u x) ∈ Icc (a - ε) (a + ε) :=
+  tendsto u f (𝓝 a) ↔ ∀ ε > 0, ∃ n ∈ f, ∀x ∈ n,  (u x) ∈ Icc (a - ε) (a + ε) :=
 by { simp only [nhds_of_ne_top ha, tendsto_infi, subtype.forall, tendsto_principal, mem_Icc],
   refine forall_congr (assume ε, forall_congr $ assume hε, exists_sets_subset_iff.symm) }
 
 protected lemma tendsto_at_top [nonempty β] [semilattice_sup β] {f : β → ennreal} {a : ennreal}
-  (ha : a ≠ ⊤) : tendsto f at_top (nhds a) ↔ ∀ε>0, ∃N, ∀n≥N, (f n) ∈ Icc (a - ε) (a + ε) :=
+  (ha : a ≠ ⊤) : tendsto f at_top (𝓝 a) ↔ ∀ε>0, ∃N, ∀n≥N, (f n) ∈ Icc (a - ε) (a + ε) :=
 by { simp only [nhds_of_ne_top ha, tendsto_infi, subtype.forall, tendsto_at_top_principal], refl }
 
 lemma tendsto_coe_nnreal_nhds_top {α} {l : filter α} {f : α → nnreal} (h : tendsto f l at_top) :
-  tendsto (λa, (f a : ennreal)) l (nhds (⊤:ennreal)) :=
+  tendsto (λa, (f a : ennreal)) l (𝓝 (⊤:ennreal)) :=
 tendsto_nhds_top $ assume n,
 have {a : α | ↑(n+1) ≤ f a} ∈ l := h $ mem_at_top _,
 mem_sets_of_superset this $ assume a (ha : ↑(n+1) ≤ f a),
@@ -224,11 +225,11 @@ end
 
 instance : topological_add_monoid ennreal :=
 ⟨ continuous_iff_continuous_at.2 $
-  have hl : ∀a:ennreal, tendsto (λ (p : ennreal × ennreal), p.fst + p.snd) (nhds (⊤, a)) (nhds ⊤), from
+  have hl : ∀a:ennreal, tendsto (λ (p : ennreal × ennreal), p.fst + p.snd) (𝓝 (⊤, a)) (𝓝 ⊤), from
     assume a, tendsto_nhds_top $ assume n,
-    have set.prod {a | ↑n < a } univ ∈ nhds ((⊤:ennreal), a), from
+    have set.prod {a | ↑n < a } univ ∈ 𝓝 ((⊤:ennreal), a), from
       prod_mem_nhds_sets (lt_mem_nhds $ coe_nat n ▸ coe_lt_top) univ_mem_sets,
-    show {a : ennreal × ennreal | ↑n < a.fst + a.snd} ∈ nhds (⊤, a),
+    show {a : ennreal × ennreal | ↑n < a.fst + a.snd} ∈ 𝓝 (⊤, a),
     begin filter_upwards [this] assume ⟨a₁, a₂⟩ ⟨h₁, h₂⟩, lt_of_lt_of_le h₁ (le_add_right $ le_refl _) end,
   begin
     rintro ⟨a₁, a₂⟩,
@@ -240,8 +241,8 @@ instance : topological_add_monoid ennreal :=
   end ⟩
 
 protected lemma tendsto_mul' (ha : a ≠ 0 ∨ b ≠ ⊤) (hb : b ≠ 0 ∨ a ≠ ⊤) :
-  tendsto (λp:ennreal×ennreal, p.1 * p.2) (nhds (a, b)) (nhds (a * b)) :=
-have ht : ∀b:ennreal, b ≠ 0 → tendsto (λp:ennreal×ennreal, p.1 * p.2) (nhds ((⊤:ennreal), b)) (nhds ⊤),
+  tendsto (λp:ennreal×ennreal, p.1 * p.2) (𝓝 (a, b)) (𝓝 (a * b)) :=
+have ht : ∀b:ennreal, b ≠ 0 → tendsto (λp:ennreal×ennreal, p.1 * p.2) (𝓝 ((⊤:ennreal), b)) (𝓝 ⊤),
 begin
   refine assume b hb, tendsto_nhds_top $ assume n, _,
   rcases dense (zero_lt_iff_ne_zero.2 hb) with ⟨ε', hε', hεb'⟩,
@@ -273,13 +274,13 @@ begin
 end
 
 protected lemma tendsto_mul {f : filter α} {ma : α → ennreal} {mb : α → ennreal} {a b : ennreal}
-  (hma : tendsto ma f (nhds a)) (ha : a ≠ 0 ∨ b ≠ ⊤) (hmb : tendsto mb f (nhds b)) (hb : b ≠ 0 ∨ a ≠ ⊤) :
-  tendsto (λa, ma a * mb a) f (nhds (a * b)) :=
-show tendsto ((λp:ennreal×ennreal, p.1 * p.2) ∘ (λa, (ma a, mb a))) f (nhds (a * b)), from
+  (hma : tendsto ma f (𝓝 a)) (ha : a ≠ 0 ∨ b ≠ ⊤) (hmb : tendsto mb f (𝓝 b)) (hb : b ≠ 0 ∨ a ≠ ⊤) :
+  tendsto (λa, ma a * mb a) f (𝓝 (a * b)) :=
+show tendsto ((λp:ennreal×ennreal, p.1 * p.2) ∘ (λa, (ma a, mb a))) f (𝓝 (a * b)), from
 tendsto.comp (ennreal.tendsto_mul' ha hb) (tendsto_prod_mk_nhds hma hmb)
 
 protected lemma tendsto_mul_right {f : filter α} {m : α → ennreal} {a b : ennreal}
-  (hm : tendsto m f (nhds b)) (hb : b ≠ 0 ∨ a ≠ ⊤) : tendsto (λb, a * m b) f (nhds (a * b)) :=
+  (hm : tendsto m f (𝓝 b)) (hb : b ≠ 0 ∨ a ≠ ⊤) : tendsto (λb, a * m b) f (𝓝 (a * b)) :=
 by_cases
   (assume : a = 0, by simp [this, tendsto_const_nhds])
   (assume ha : a ≠ 0, ennreal.tendsto_mul tendsto_const_nhds (or.inl ha) hm hb)
@@ -365,7 +366,7 @@ by rw [← Sup_range, mul_Sup, supr_range]
 lemma supr_mul {ι : Sort*} {f : ι → ennreal} {a : ennreal} : supr f * a = ⨆i, f i * a :=
 by rw [mul_comm, mul_supr]; congr; funext; rw [mul_comm]
 
-protected lemma tendsto_coe_sub : ∀{b:ennreal}, tendsto (λb:ennreal, ↑r - b) (nhds b) (nhds (↑r - b)) :=
+protected lemma tendsto_coe_sub : ∀{b:ennreal}, tendsto (λb:ennreal, ↑r - b) (𝓝 b) (𝓝 (↑r - b)) :=
 begin
   refine (forall_ennreal.2 $ and.intro (assume a, _) _),
   { simp [@nhds_coe a, tendsto_map'_iff, (∘), tendsto_coe, coe_sub.symm],
@@ -466,7 +467,7 @@ let ⟨i, (hi : f i ≠ 0)⟩ := classical.not_forall.mp h in
 have sum_ne_0 : (∑i, f i) ≠ 0, from ne_of_gt $
   calc 0 < f i : lt_of_le_of_ne (zero_le _) hi.symm
     ... ≤ (∑i, f i) : ennreal.le_tsum _,
-have tendsto (λs:finset α, s.sum ((*) a ∘ f)) at_top (nhds (a * (∑i, f i))),
+have tendsto (λs:finset α, s.sum ((*) a ∘ f)) at_top (𝓝 (a * (∑i, f i))),
   by rw [← show (*) a ∘ (λs:finset α, s.sum f) = λs, s.sum ((*) a ∘ f),
          from funext $ λ s, finset.mul_sum];
   exact ennreal.tendsto_mul_right (has_sum_tsum ennreal.summable) (or.inl sum_ne_0),
@@ -489,7 +490,7 @@ le_antisymm
     ... ≤ (∑b:α, ⨆ (h : a = b), f b) : ennreal.le_tsum _)
 
 lemma has_sum_iff_tendsto_nat {f : ℕ → ennreal} (r : ennreal) :
-  has_sum f r ↔ tendsto (λn:ℕ, (finset.range n).sum f) at_top (nhds r) :=
+  has_sum f r ↔ tendsto (λn:ℕ, (finset.range n).sum f) at_top (𝓝 r) :=
 begin
   refine ⟨tendsto_sum_nat_of_has_sum, assume h, _⟩,
   rw [← supr_eq_of_tendsto _ h, ← ennreal.tsum_eq_supr_nat],
@@ -517,7 +518,7 @@ lemma summable_of_le {f g : β → nnreal} (hgf : ∀b, g b ≤ f b) : summable 
 | ⟨r, hfr⟩ := let ⟨p, _, hp⟩ := exists_le_has_sum_of_le hgf hfr in summable_spec hp
 
 lemma has_sum_iff_tendsto_nat {f : ℕ → nnreal} (r : nnreal) :
-  has_sum f r ↔ tendsto (λn:ℕ, (finset.range n).sum f) at_top (nhds r) :=
+  has_sum f r ↔ tendsto (λn:ℕ, (finset.range n).sum f) at_top (𝓝 r) :=
 begin
   rw [← ennreal.has_sum_coe, ennreal.has_sum_iff_tendsto_nat],
   simp only [ennreal.coe_finset_sum.symm],
@@ -536,7 +537,7 @@ have summable g', from
 show summable (λb, g' b : β → ℝ), from nnreal.summable_coe.2 this
 
 lemma has_sum_iff_tendsto_nat_of_nonneg {f : ℕ → ℝ} (hf : ∀i, 0 ≤ f i) (r : ℝ) :
-  has_sum f r ↔ tendsto (λn:ℕ, (finset.range n).sum f) at_top (nhds r) :=
+  has_sum f r ↔ tendsto (λn:ℕ, (finset.range n).sum f) at_top (𝓝 r) :=
 ⟨tendsto_sum_nat_of_has_sum,
   assume hfr,
   have 0 ≤ r := ge_of_tendsto at_top_ne_bot hfr $ univ_mem_sets' $ assume i,
@@ -575,7 +576,7 @@ emetric_space.to_metric_space edist_ne_top_of_mem_ball
 local attribute [instance] metric_space_emetric_ball
 
 lemma nhds_eq_nhds_emetric_ball (a x : β) (r : ennreal) (h : x ∈ ball a r) :
-  nhds x = map (coe : ball a r → β) (nhds ⟨x, h⟩) :=
+  𝓝 x = map (coe : ball a r → β) (𝓝 ⟨x, h⟩) :=
 (map_nhds_subtype_val_eq _ $ mem_nhds_sets emetric.is_open_ball h).symm
 end
 
@@ -587,7 +588,7 @@ open emetric
 most efficient. -/
 lemma emetric.cauchy_seq_iff_le_tendsto_0 [inhabited β] [semilattice_sup β] {s : β → α} :
   cauchy_seq s ↔ (∃ (b: β → ennreal), (∀ n m N : β, N ≤ n → N ≤ m → edist (s n) (s m) ≤ b N)
-                    ∧ (tendsto b at_top (nhds 0))) :=
+                    ∧ (tendsto b at_top (𝓝 0))) :=
 ⟨begin
   assume hs,
   rw emetric.cauchy_seq_iff at hs,
@@ -601,7 +602,7 @@ lemma emetric.cauchy_seq_iff_le_tendsto_0 [inhabited β] [semilattice_sup β] {s
     simp only [and_true, eq_self_iff_true, set.mem_set_of_eq],
     exact ⟨hm, hn⟩ },
   --Prove that it tends to `0`, by using the Cauchy property of `s`
-  have D : tendsto b at_top (nhds 0),
+  have D : tendsto b at_top (𝓝 0),
   { refine tendsto_orderable.2 ⟨λa ha, absurd ha (ennreal.not_lt_zero), λε εpos, _⟩,
     rcases dense εpos with ⟨δ, δpos, δlt⟩,
     rcases hs δ δpos with ⟨N, hN⟩,
@@ -619,7 +620,7 @@ end,
 begin
   rintros ⟨b, ⟨b_bound, b_lim⟩⟩,
   /-b : ℕ → ℝ, b_bound : ∀ (n m N : ℕ), N ≤ n → N ≤ m → edist (s n) (s m) ≤ b N,
-    b_lim : tendsto b at_top (nhds 0)-/
+    b_lim : tendsto b at_top (𝓝 0)-/
   refine emetric.cauchy_seq_iff.2 (λε εpos, _),
   have : {n | b n < ε} ∈ at_top := (tendsto_orderable.1 b_lim ).2 _ εpos,
   rcases filter.mem_at_top_sets.1 this with ⟨N, hN⟩,
@@ -632,7 +633,7 @@ lemma continuous_of_le_add_edist {f : α → ennreal} (C : ennreal)
   (hC : C ≠ ⊤) (h : ∀x y, f x ≤ f y + C * edist x y) : continuous f :=
 begin
   refine continuous_iff_continuous_at.2 (λx, tendsto_orderable.2 ⟨_, _⟩),
-  show ∀e, e < f x → {y : α | e < f y} ∈ nhds x,
+  show ∀e, e < f x → {y : α | e < f y} ∈ 𝓝 x,
   { assume e he,
     let ε := min (f x - e) 1,
     have : ε < ⊤ := lt_of_le_of_lt (min_le_right _ _) (by simp [lt_top_iff_ne_top]),
@@ -660,7 +661,7 @@ begin
         show e < f y, from
           (ennreal.add_lt_add_iff_right ‹ε < ⊤›).1 this }},
     apply filter.mem_sets_of_superset (ball_mem_nhds _ (‹0 < C⁻¹ * (ε/2)›)) this },
-  show ∀e, f x < e → {y : α | f y < e} ∈ nhds x,
+  show ∀e, f x < e → {y : α | f y < e} ∈ 𝓝 x,
   { assume e he,
     let ε := min (e - f x) 1,
     have : ε < ⊤ := lt_of_le_of_lt (min_le_right _ _) (by simp [lt_top_iff_ne_top]),
@@ -701,9 +702,9 @@ theorem continuous_edist [topological_space β] {f g : β → α}
 continuous_edist'.comp (hf.prod_mk hg)
 
 theorem tendsto_edist {f g : β → α} {x : filter β} {a b : α}
-  (hf : tendsto f x (nhds a)) (hg : tendsto g x (nhds b)) :
-  tendsto (λx, edist (f x) (g x)) x (nhds (edist a b)) :=
-have tendsto (λp:α×α, edist p.1 p.2) (nhds (a, b)) (nhds (edist a b)),
+  (hf : tendsto f x (𝓝 a)) (hg : tendsto g x (𝓝 b)) :
+  tendsto (λx, edist (f x) (g x)) x (𝓝 (edist a b)) :=
+have tendsto (λp:α×α, edist p.1 p.2) (𝓝 (a, b)) (𝓝 (edist a b)),
   from continuous_iff_continuous_at.mp continuous_edist' (a, b),
 tendsto.comp (by rw [nhds_prod_eq] at this; exact this) (hf.prod_mk hg)
 

--- a/src/topology/instances/nnreal.lean
+++ b/src/topology/instances/nnreal.lean
@@ -8,6 +8,7 @@ Nonnegative real numbers.
 import data.real.nnreal topology.instances.real topology.algebra.infinite_sum
 noncomputable theory
 open set topological_space metric
+open_locale topological_space
 
 namespace nnreal
 open_locale nnreal
@@ -69,16 +70,16 @@ lemma continuous_coe : continuous (coe : nnreal → ℝ) :=
 continuous_subtype_val
 
 lemma tendsto_coe {f : filter α} {m : α → nnreal} :
-  ∀{x : nnreal}, tendsto (λa, (m a : ℝ)) f (nhds (x : ℝ)) ↔ tendsto m f (nhds x)
+  ∀{x : nnreal}, tendsto (λa, (m a : ℝ)) f (𝓝 (x : ℝ)) ↔ tendsto m f (𝓝 x)
 | ⟨r, hr⟩ := by rw [nhds_subtype_eq_comap, tendsto_comap_iff]; refl
 
-lemma tendsto_of_real {f : filter α} {m : α → ℝ} {x : ℝ} (h : tendsto m f (nhds x)) :
-  tendsto (λa, nnreal.of_real (m a)) f (nhds (nnreal.of_real x)) :=
+lemma tendsto_of_real {f : filter α} {m : α → ℝ} {x : ℝ} (h : tendsto m f (𝓝 x)) :
+  tendsto (λa, nnreal.of_real (m a)) f (𝓝 (nnreal.of_real x)) :=
 tendsto.comp (continuous_iff_continuous_at.1 continuous_of_real _) h
 
 lemma tendsto_sub {f : filter α} {m n : α → nnreal} {r p : nnreal}
-  (hm : tendsto m f (nhds r)) (hn : tendsto n f (nhds p)) :
-  tendsto (λa, m a - n a) f (nhds (r - p)) :=
+  (hm : tendsto m f (𝓝 r)) (hn : tendsto n f (𝓝 p)) :
+  tendsto (λa, m a - n a) f (𝓝 (r - p)) :=
 tendsto_of_real $ tendsto_sub (tendsto_coe.2 hm) (tendsto_coe.2 hn)
 
 lemma continuous_sub' : continuous (λp:nnreal×nnreal, p.1 - p.2) :=

--- a/src/topology/instances/real.lean
+++ b/src/topology/instances/real.lean
@@ -27,6 +27,7 @@ import topology.metric_space.basic topology.algebra.uniform_group
 noncomputable theory
 open classical set lattice filter topological_space metric
 open_locale classical
+open_locale topological_space
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
@@ -149,7 +150,7 @@ metric.uniform_continuous_iff.2 $ λ ε ε0,
 lemma rat.continuous_abs : continuous (abs : ℚ → ℚ) :=
 rat.uniform_continuous_abs.continuous
 
-lemma real.tendsto_inv {r : ℝ} (r0 : r ≠ 0) : tendsto (λq, q⁻¹) (nhds r) (nhds r⁻¹) :=
+lemma real.tendsto_inv {r : ℝ} (r0 : r ≠ 0) : tendsto (λq, q⁻¹) (𝓝 r) (𝓝 r⁻¹) :=
 by rw ← abs_pos_iff at r0; exact
 tendsto_of_uniform_continuous_subtype
   (real.uniform_continuous_inv {x | abs r / 2 < abs x} (half_pos r0) (λ x h, le_of_lt h))
@@ -344,7 +345,7 @@ instance : proper_space ℝ :=
 open real
 
 lemma real.intermediate_value {f : ℝ → ℝ} {a b t : ℝ}
-  (hf : ∀ x, a ≤ x → x ≤ b → tendsto f (nhds x) (nhds (f x)))
+  (hf : ∀ x, a ≤ x → x ≤ b → tendsto f (𝓝 x) (𝓝 (f x)))
   (ha : f a ≤ t) (hb : t ≤ f b) (hab : a ≤ b) : ∃ x : ℝ, a ≤ x ∧ x ≤ b ∧ f x = t :=
 let x := real.Sup {x | f x ≤ t ∧ a ≤ x ∧ x ≤ b} in
 have hx₁ : ∃ y, ∀ g ∈ {x | f x ≤ t ∧ a ≤ x ∧ x ≤ b}, g ≤ y := ⟨b, λ _ h, h.2.2⟩,
@@ -388,7 +389,7 @@ have hxb : x ≤ b, from (Sup_le _ hx₂ hx₁).2 (λ _ h, h.2.2),
         end)⟩
 
 lemma real.intermediate_value' {f : ℝ → ℝ} {a b t : ℝ}
-  (hf : ∀ x, a ≤ x → x ≤ b → tendsto f (nhds x) (nhds (f x)))
+  (hf : ∀ x, a ≤ x → x ≤ b → tendsto f (𝓝 x) (𝓝 (f x)))
   (ha : t ≤ f a) (hb : f b ≤ t) (hab : a ≤ b) : ∃ x : ℝ, a ≤ x ∧ x ≤ b ∧ f x = t :=
 let ⟨x, hx₁, hx₂, hx₃⟩ := @real.intermediate_value
   (λ x, - f x) a b (-t) (λ x hax hxb, tendsto_neg (hf x hax hxb))

--- a/src/topology/list.lean
+++ b/src/topology/list.lean
@@ -8,19 +8,20 @@ Topology on lists and vectors.
 import topology.constructions
 
 open topological_space set filter
+open_locale topological_space
 
 variables {α : Type*} {β : Type*}
 
 instance [topological_space α] : topological_space (list α) :=
 topological_space.mk_of_nhds (traverse nhds)
 
-lemma nhds_list [topological_space α] (as : list α) : nhds as = traverse nhds as :=
+lemma nhds_list [topological_space α] (as : list α) : 𝓝 as = traverse 𝓝 as :=
 begin
   refine nhds_mk_of_nhds _ _ _ _,
   { assume l, induction l,
     case list.nil { exact le_refl _ },
     case list.cons : a l ih {
-      suffices : list.cons <$> pure a <*> pure l ≤ list.cons <$> nhds a <*> traverse nhds l,
+      suffices : list.cons <$> pure a <*> pure l ≤ list.cons <$> 𝓝 a <*> traverse 𝓝 l,
       { simpa only [-filter.pure_def] with functor_norm using this },
       exact filter.seq_mono (filter.map_mono $ pure_le_nhds a) ih } },
   { assume l s hs,
@@ -47,28 +48,28 @@ begin
       exact mem_traverse_sets _ _ (this.imp $ assume a s ⟨hs, ha⟩, mem_nhds_sets hs ha) } }
 end
 
-lemma nhds_nil [topological_space α] : nhds ([] : list α) = pure [] :=
+lemma nhds_nil [topological_space α] : 𝓝 ([] : list α) = pure [] :=
 by rw [nhds_list, list.traverse_nil _]; apply_instance
 
 lemma nhds_cons [topological_space α] (a : α) (l : list α) :
-  nhds (a :: l) = list.cons <$> nhds a <*> nhds l  :=
+  𝓝 (a :: l) = list.cons <$> 𝓝 a <*> 𝓝 l  :=
 by rw [nhds_list, list.traverse_cons _, ← nhds_list]; apply_instance
 
 namespace list
 variables [topological_space α] [topological_space β]
 
 lemma tendsto_cons' {a : α} {l : list α} :
-  tendsto (λp:α×list α, list.cons p.1 p.2) ((nhds a).prod (nhds l)) (nhds (a :: l)) :=
+  tendsto (λp:α×list α, list.cons p.1 p.2) ((𝓝 a).prod (𝓝 l)) (𝓝 (a :: l)) :=
 by rw [nhds_cons, tendsto, map_prod]; exact le_refl _
 
 lemma tendsto_cons {α : Type*} {f : α → β} {g : α → list β}
-  {a : _root_.filter α} {b : β} {l : list β} (hf : tendsto f a (nhds b)) (hg : tendsto g a (nhds l)) :
-  tendsto (λa, list.cons (f a) (g a)) a (nhds (b :: l)) :=
+  {a : _root_.filter α} {b : β} {l : list β} (hf : tendsto f a (𝓝 b)) (hg : tendsto g a (𝓝 l)) :
+  tendsto (λa, list.cons (f a) (g a)) a (𝓝 (b :: l)) :=
 tendsto_cons'.comp (tendsto.prod_mk hf hg)
 
 lemma tendsto_cons_iff {β : Type*} {f : list α → β} {b : _root_.filter β} {a : α} {l : list α} :
-  tendsto f (nhds (a :: l)) b ↔ tendsto (λp:α×list α, f (p.1 :: p.2)) ((nhds a).prod (nhds l)) b :=
-have nhds (a :: l) = ((nhds a).prod (nhds l)).map (λp:α×list α, (p.1 :: p.2)),
+  tendsto f (𝓝 (a :: l)) b ↔ tendsto (λp:α×list α, f (p.1 :: p.2)) ((𝓝 a).prod (𝓝 l)) b :=
+have 𝓝 (a :: l) = ((𝓝 a).prod (𝓝 l)).map (λp:α×list α, (p.1 :: p.2)),
 begin
   simp only
     [nhds_cons, filter.prod_eq, (filter.map_def _ _).symm, (filter.seq_eq_filter_seq _ _).symm],
@@ -78,8 +79,8 @@ by rw [this, filter.tendsto_map'_iff]
 
 lemma tendsto_nhds {β : Type*} {f : list α → β} {r : list α → _root_.filter β}
   (h_nil : tendsto f (pure []) (r []))
-  (h_cons : ∀l a, tendsto f (nhds l) (r l) → tendsto (λp:α×list α, f (p.1 :: p.2)) ((nhds a).prod (nhds l)) (r (a::l))) :
-  ∀l, tendsto f (nhds l) (r l)
+  (h_cons : ∀l a, tendsto f (𝓝 l) (r l) → tendsto (λp:α×list α, f (p.1 :: p.2)) ((𝓝 a).prod (𝓝 l)) (r (a::l))) :
+  ∀l, tendsto f (𝓝 l) (r l)
 | []     := by rwa [nhds_nil]
 | (a::l) := by rw [tendsto_cons_iff]; exact h_cons l a (tendsto_nhds l)
 
@@ -96,15 +97,15 @@ begin
 end
 
 lemma tendsto_insert_nth' {a : α} : ∀{n : ℕ} {l : list α},
-  tendsto (λp:α×list α, insert_nth n p.1 p.2) ((nhds a).prod (nhds l)) (nhds (insert_nth n a l))
+  tendsto (λp:α×list α, insert_nth n p.1 p.2) ((𝓝 a).prod (𝓝 l)) (𝓝 (insert_nth n a l))
 | 0     l  := tendsto_cons'
 | (n+1) [] :=
-  suffices tendsto (λa, []) (nhds a) (nhds ([] : list α)),
+  suffices tendsto (λa, []) (𝓝 a) (𝓝 ([] : list α)),
     by simpa [nhds_nil, tendsto, map_prod, -filter.pure_def, (∘), insert_nth],
   tendsto_const_nhds
 | (n+1) (a'::l) :=
-  have (nhds a).prod (nhds (a' :: l)) =
-    ((nhds a).prod ((nhds a').prod (nhds l))).map (λp:α×α×list α, (p.1, p.2.1 :: p.2.2)),
+  have (𝓝 a).prod (𝓝 (a' :: l)) =
+    ((𝓝 a).prod ((𝓝 a').prod (𝓝 l))).map (λp:α×α×list α, (p.1, p.2.1 :: p.2.2)),
   begin
     simp only
       [nhds_cons, filter.prod_eq, (filter.map_def _ _).symm, (filter.seq_eq_filter_seq _ _).symm],
@@ -118,8 +119,8 @@ lemma tendsto_insert_nth' {a : α} : ∀{n : ℕ} {l : list α},
   end
 
 lemma tendsto_insert_nth {β : Type*} {n : ℕ} {a : α} {l : list α} {f : β → α} {g : β → list α}
-  {b : _root_.filter β} (hf : tendsto f b (nhds a)) (hg : tendsto g b (nhds l)) :
-  tendsto (λb:β, insert_nth n (f b) (g b)) b (nhds (insert_nth n a l)) :=
+  {b : _root_.filter β} (hf : tendsto f b (𝓝 a)) (hg : tendsto g b (𝓝 l)) :
+  tendsto (λb:β, insert_nth n (f b) (g b)) b (𝓝 (insert_nth n a l)) :=
 tendsto_insert_nth'.comp (tendsto.prod_mk hf hg)
 
 lemma continuous_insert_nth {n : ℕ} : continuous (λp:α×list α, insert_nth n p.1 p.2) :=
@@ -127,7 +128,7 @@ continuous_iff_continuous_at.mpr $
   assume ⟨a, l⟩, by rw [continuous_at, nhds_prod_eq]; exact tendsto_insert_nth'
 
 lemma tendsto_remove_nth : ∀{n : ℕ} {l : list α},
-  tendsto (λl, remove_nth l n) (nhds l) (nhds (remove_nth l n))
+  tendsto (λl, remove_nth l n) (𝓝 l) (𝓝 (remove_nth l n))
 | _ []      := by rw [nhds_nil]; exact tendsto_pure_nhds _ _
 | 0 (a::l) := by rw [tendsto_cons_iff]; exact tendsto_snd
 | (n+1) (a::l) :=
@@ -152,7 +153,7 @@ lemma cons_val {n : ℕ} {a : α} : ∀{v : vector α n}, (a :: v).val = a :: v.
 | ⟨l, hl⟩ := rfl
 
 lemma tendsto_cons [topological_space α] {n : ℕ} {a : α} {l : vector α n}:
-  tendsto (λp:α×vector α n, vector.cons p.1 p.2) ((nhds a).prod (nhds l)) (nhds (a :: l)) :=
+  tendsto (λp:α×vector α n, vector.cons p.1 p.2) ((𝓝 a).prod (𝓝 l)) (𝓝 (a :: l)) :=
 by
   simp [tendsto_subtype_rng, cons_val];
   exact tendsto_cons tendsto_fst (tendsto.comp continuous_at_subtype_val tendsto_snd)
@@ -160,7 +161,7 @@ by
 lemma tendsto_insert_nth
   [topological_space α] {n : ℕ} {i : fin (n+1)} {a:α} :
   ∀{l:vector α n}, tendsto (λp:α×vector α n, insert_nth p.1 i p.2)
-    ((nhds a).prod (nhds l)) (nhds (insert_nth a i l))
+    ((𝓝 a).prod (𝓝 l)) (𝓝 (insert_nth a i l))
 | ⟨l, hl⟩ :=
 begin
   rw [insert_nth, tendsto_subtype_rng],
@@ -181,7 +182,7 @@ continuous_insert_nth'.comp (continuous.prod_mk hf hg)
 lemma continuous_at_remove_nth [topological_space α] {n : ℕ} {i : fin (n+1)} :
   ∀{l:vector α (n+1)}, continuous_at (remove_nth i) l
 | ⟨l, hl⟩ :=
---  ∀{l:vector α (n+1)}, tendsto (remove_nth i) (nhds l) (nhds (remove_nth i l))
+--  ∀{l:vector α (n+1)}, tendsto (remove_nth i) (𝓝 l) (𝓝 (remove_nth i l))
 --| ⟨l, hl⟩ :=
 begin
   rw [continuous_at, remove_nth, tendsto_subtype_rng],
@@ -194,4 +195,3 @@ lemma continuous_remove_nth [topological_space α] {n : ℕ} {i : fin (n+1)} :
 continuous_iff_continuous_at.mpr $ assume ⟨a, l⟩, continuous_at_remove_nth
 
 end vector
-

--- a/src/topology/local_homeomorph.lean
+++ b/src/topology/local_homeomorph.lean
@@ -38,6 +38,7 @@ For design notes, see `local_equiv.lean`.
 -/
 
 open function set
+open_locale topological_space
 
 variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*}
 [topological_space α] [topological_space β] [topological_space γ] [topological_space δ]
@@ -443,7 +444,7 @@ begin
   { assume f_cont,
     have : e.to_fun (e.inv_fun x) = x := e.right_inv h,
     rw ← this at f_cont,
-    have : e.source ∈ nhds (e.inv_fun x) := mem_nhds_sets e.open_source (e.map_target h),
+    have : e.source ∈ 𝓝 (e.inv_fun x) := mem_nhds_sets e.open_source (e.map_target h),
     rw [← continuous_within_at_inter this, inter_comm],
     exact continuous_within_at.comp f_cont
       ((e.continuous_at_to_fun (e.map_target h)).continuous_within_at) (inter_subset_right _ _) },
@@ -482,7 +483,7 @@ begin
   { assume fe_cont x hx,
     have := e.continuous_within_at_iff_continuous_within_at_comp_right (h hx),
     rw this,
-    have : e.source ∈ nhds (e.inv_fun x) := mem_nhds_sets e.open_source (e.map_target (h hx)),
+    have : e.source ∈ 𝓝 (e.inv_fun x) := mem_nhds_sets e.open_source (e.map_target (h hx)),
     rw [← continuous_within_at_inter this, inter_comm],
     exact fe_cont _ (by simp [hx, h hx, e.map_target (h hx)]) }
 end
@@ -497,7 +498,7 @@ begin
   rw [← continuous_within_at_inter' h, ← continuous_within_at_inter' h],
   split,
   { assume f_cont,
-    have : e.source ∈ nhds (f x) := mem_nhds_sets e.open_source hx,
+    have : e.source ∈ 𝓝 (f x) := mem_nhds_sets e.open_source hx,
     apply continuous_within_at.comp (e.continuous_to_fun (f x) hx) f_cont (inter_subset_right _ _) },
   { assume fe_cont,
     have : continuous_within_at (e.inv_fun ∘ (e.to_fun ∘ f)) (s ∩ f ⁻¹' e.source) x,
@@ -510,7 +511,7 @@ end
 /-- Continuity at a point can be read under left composition with a local homeomorphism if a
 neighborhood of the initial point is sent to the source of the local homeomorphism-/
 lemma continuous_at_iff_continuous_at_comp_left
-  {f : γ → α} {x : γ} (h : f ⁻¹' e.source ∈ nhds x) :
+  {f : γ → α} {x : γ} (h : f ⁻¹' e.source ∈ 𝓝 x) :
   continuous_at f x ↔ continuous_at (e.to_fun ∘ f) x :=
 begin
   have hx : f x ∈ e.source := (mem_of_nhds h : _),

--- a/src/topology/maps.lean
+++ b/src/topology/maps.lean
@@ -42,6 +42,7 @@ open map, closed map, embedding, quotient map, identification map
 -/
 
 open set filter lattice
+open_locale topological_space
 
 variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*}
 
@@ -77,16 +78,16 @@ have is_closed (t ∩ range f), from is_closed_inter ht h,
 h_eq.symm ▸ by rwa [image_preimage_eq_inter_range]
 
 lemma inducing.nhds_eq_comap {f : α → β} (hf : inducing f) :
-  ∀ (a : α), nhds a = comap f (nhds $ f a) :=
+  ∀ (a : α), 𝓝 a = comap f (𝓝 $ f a) :=
 (induced_iff_nhds_eq f).1 hf.induced
 
-lemma inducing.map_nhds_eq {f : α → β} (hf : inducing f) (a : α) (h : range f ∈ nhds (f a)) :
-  (nhds a).map f = nhds (f a) :=
+lemma inducing.map_nhds_eq {f : α → β} (hf : inducing f) (a : α) (h : range f ∈ 𝓝 (f a)) :
+  (𝓝 a).map f = 𝓝 (f a) :=
 hf.induced.symm ▸ map_nhds_induced_eq h
 
 lemma inducing.tendsto_nhds_iff {ι : Type*}
   {f : ι → β} {g : β → γ} {a : filter ι} {b : β} (hg : inducing g) :
-  tendsto f a (nhds b) ↔ tendsto (g ∘ f) a (nhds (g b)) :=
+  tendsto f a (𝓝 b) ↔ tendsto (g ∘ f) a (𝓝 (g b)) :=
 by rw [tendsto, tendsto, hg.induced, nhds_induced, ← map_le_iff_le_comap, filter.map_map]
 
 lemma inducing.continuous_iff {f : α → β} {g : β → γ} (hg : inducing g) :
@@ -107,7 +108,7 @@ structure embedding [tα : topological_space α] [tβ : topological_space β] (f
 variables [topological_space α] [topological_space β] [topological_space γ]
 
 lemma embedding.mk' (f : α → β) (inj : function.injective f)
-  (induced : ∀a, comap f (nhds (f a)) = nhds a) : embedding f :=
+  (induced : ∀a, comap f (𝓝 (f a)) = 𝓝 a) : embedding f :=
 ⟨⟨(induced_iff_nhds_eq f).2 (λ a, (induced a).symm)⟩, inj⟩
 
 lemma embedding_id : embedding (@id α) :=
@@ -132,12 +133,12 @@ lemma embedding_is_closed {f : α → β} {s : set α}
 inducing_is_closed hf.1 h hs
 
 lemma embedding.map_nhds_eq {f : α → β}
-  (hf : embedding f) (a : α) (h : range f ∈ nhds (f a)) : (nhds a).map f = nhds (f a) :=
+  (hf : embedding f) (a : α) (h : range f ∈ 𝓝 (f a)) : (𝓝 a).map f = 𝓝 (f a) :=
 inducing.map_nhds_eq hf.1 a h
 
 lemma embedding.tendsto_nhds_iff {ι : Type*}
   {f : ι → β} {g : β → γ} {a : filter ι} {b : β} (hg : embedding g) :
-  tendsto f a (nhds b) ↔ tendsto (g ∘ f) a (nhds (g b)) :=
+  tendsto f a (𝓝 b) ↔ tendsto (g ∘ f) a (𝓝 (g b)) :=
 by rw [tendsto, tendsto, hg.induced, nhds_induced, ← map_le_iff_le_comap, filter.map_map]
 
 lemma embedding.continuous_iff {f : α → β} {g : β → γ} (hg : embedding g) :
@@ -192,7 +193,7 @@ variables [topological_space α] [topological_space β]
 
 def is_open_map (f : α → β) := ∀ U : set α, is_open U → is_open (f '' U)
 
-lemma is_open_map_iff_nhds_le (f : α → β) : is_open_map f ↔ ∀(a:α), nhds (f a) ≤ (nhds a).map f :=
+lemma is_open_map_iff_nhds_le (f : α → β) : is_open_map f ↔ ∀(a:α), 𝓝 (f a) ≤ (𝓝 a).map f :=
 begin
   split,
   { assume h a s hs,

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -14,6 +14,7 @@ open lattice set filter classical topological_space
 noncomputable theory
 
 open_locale uniformity
+open_locale topological_space
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
@@ -363,7 +364,7 @@ cauchy_iff.trans $ and_congr iff.rfl
                ⟨t, tf, h⟩ := H ε ε0 in
    ⟨t, tf, λ ⟨x, y⟩ ⟨hx, hy⟩, hε (h x y hx hy)⟩⟩
 
-theorem nhds_eq : nhds x = (⨅ε:{ε:ℝ // ε>0}, principal (ball x ε.val)) :=
+theorem nhds_eq : 𝓝 x = (⨅ε:{ε:ℝ // ε>0}, principal (ball x ε.val)) :=
 begin
   rw [nhds_eq_uniformity, uniformity_dist', lift'_infi],
   { apply congr_arg, funext ε,
@@ -374,7 +375,7 @@ begin
   { intros, refl }
 end
 
-theorem mem_nhds_iff : s ∈ nhds x ↔ ∃ε>0, ball x ε ⊆ s :=
+theorem mem_nhds_iff : s ∈ 𝓝 x ↔ ∃ε>0, ball x ε ⊆ s :=
 begin
   rw [nhds_eq, mem_infi],
   { simp },
@@ -390,11 +391,11 @@ by simp [is_open_iff_nhds, mem_nhds_iff]
 theorem is_open_ball : is_open (ball x ε) :=
 is_open_iff.2 $ λ y, exists_ball_subset_ball
 
-theorem ball_mem_nhds (x : α) {ε : ℝ} (ε0 : 0 < ε) : ball x ε ∈ nhds x :=
+theorem ball_mem_nhds (x : α) {ε : ℝ} (ε0 : 0 < ε) : ball x ε ∈ 𝓝 x :=
 mem_nhds_sets is_open_ball (mem_ball_self ε0)
 
 theorem tendsto_nhds_nhds [metric_space β] {f : α → β} {a b} :
-  tendsto f (nhds a) (nhds b) ↔
+  tendsto f (𝓝 a) (𝓝 b) ↔
     ∀ ε > 0, ∃ δ > 0, ∀{x:α}, dist x a < δ → dist (f x) b < ε :=
 ⟨λ H ε ε0, mem_nhds_iff.1 (H (ball_mem_nhds _ ε0)),
  λ H s hs,
@@ -413,16 +414,16 @@ let ⟨δ, δ_pos, hδ⟩ := continuous_iff.1 hf b ε hε in
 ⟨δ / 2, half_pos δ_pos, assume a ha, hδ a $ lt_of_le_of_lt ha $ div_two_lt_of_pos δ_pos⟩
 
 theorem tendsto_nhds {f : filter β} {u : β → α} {a : α} :
-  tendsto u f (nhds a) ↔ ∀ ε > 0, ∃ n ∈ f, ∀x ∈ n,  dist (u x) a < ε :=
+  tendsto u f (𝓝 a) ↔ ∀ ε > 0, ∃ n ∈ f, ∀x ∈ n,  dist (u x) a < ε :=
 by simp only [metric.nhds_eq, tendsto_infi, subtype.forall, tendsto_principal, mem_ball];
   exact forall_congr (assume ε, forall_congr (assume hε, exists_sets_subset_iff.symm))
 
 theorem continuous_iff' [topological_space β] {f : β → α} :
-  continuous f ↔ ∀a (ε > 0), ∃ n ∈ nhds a, ∀b ∈ n, dist (f b) (f a) < ε :=
+  continuous f ↔ ∀a (ε > 0), ∃ n ∈ 𝓝 a, ∀b ∈ n, dist (f b) (f a) < ε :=
 continuous_iff_continuous_at.trans $ forall_congr $ λ b, tendsto_nhds
 
 theorem tendsto_at_top [nonempty β] [semilattice_sup β] {u : β → α} {a : α} :
-  tendsto u at_top (nhds a) ↔ ∀ε>0, ∃N, ∀n≥N, dist (u n) a < ε :=
+  tendsto u at_top (𝓝 a) ↔ ∀ε>0, ∃N, ∀n≥N, dist (u n) a < ε :=
 by simp only [metric.nhds_eq, tendsto_infi, subtype.forall, tendsto_at_top_principal]; refl
 
 end metric
@@ -574,14 +575,14 @@ by ext y; rw [mem_closed_ball, dist_comm, real.dist_eq,
   abs_sub_le_iff, mem_Icc, ← sub_le_iff_le_add', sub_le]
 
 lemma squeeze_zero {α} {f g : α → ℝ} {t₀ : filter α} (hf : ∀t, 0 ≤ f t) (hft : ∀t, f t ≤ g t)
-  (g0 : tendsto g t₀ (nhds 0)) : tendsto f t₀ (nhds 0) :=
+  (g0 : tendsto g t₀ (𝓝 0)) : tendsto f t₀ (𝓝 0) :=
 begin
   apply tendsto_of_tendsto_of_tendsto_of_le_of_le (tendsto_const_nhds) g0;
   simp [*]; exact filter.univ_mem_sets
 end
 
 theorem metric.uniformity_eq_comap_nhds_zero :
-  𝓤 α = comap (λp:α×α, dist p.1 p.2) (nhds (0 : ℝ)) :=
+  𝓤 α = comap (λp:α×α, dist p.1 p.2) (𝓝 (0 : ℝ)) :=
 begin
   simp only [uniformity_dist', nhds_eq, comap_infi, comap_principal],
   congr, funext ε,
@@ -591,7 +592,7 @@ begin
 end
 
 lemma cauchy_seq_iff_tendsto_dist_at_top_0 [inhabited β] [semilattice_sup β] {u : β → α} :
-  cauchy_seq u ↔ tendsto (λ (n : β × β), dist (u n.1) (u n.2)) at_top (nhds 0) :=
+  cauchy_seq u ↔ tendsto (λ (n : β × β), dist (u n.1) (u n.2)) at_top (𝓝 0) :=
 by rw [cauchy_seq_iff_prod_map, metric.uniformity_eq_comap_nhds_zero, ← map_le_iff_le_comap,
   filter.map_map, tendsto, prod.map_def]
 
@@ -663,7 +664,7 @@ most efficient. -/
 lemma cauchy_seq_iff_le_tendsto_0 {s : ℕ → α} : cauchy_seq s ↔ ∃ b : ℕ → ℝ,
   (∀ n, 0 ≤ b n) ∧
   (∀ n m N : ℕ, N ≤ n → N ≤ m → dist (s n) (s m) ≤ b N) ∧
-  tendsto b at_top (nhds 0) :=
+  tendsto b at_top (𝓝 0) :=
 ⟨λ hs, begin
   /- `s` is a Cauchy sequence. The sequence `b` will be constructed by taking
   the supremum of the distances between `s n` and `s m` for `n m ≥ N`.
@@ -795,16 +796,16 @@ theorem continuous_dist [topological_space β] {f g : β → α}
 continuous_dist'.comp (hf.prod_mk hg)
 
 theorem tendsto_dist {f g : β → α} {x : filter β} {a b : α}
-  (hf : tendsto f x (nhds a)) (hg : tendsto g x (nhds b)) :
-  tendsto (λx, dist (f x) (g x)) x (nhds (dist a b)) :=
-have tendsto (λp:α×α, dist p.1 p.2) (nhds (a, b)) (nhds (dist a b)),
+  (hf : tendsto f x (𝓝 a)) (hg : tendsto g x (𝓝 b)) :
+  tendsto (λx, dist (f x) (g x)) x (𝓝 (dist a b)) :=
+have tendsto (λp:α×α, dist p.1 p.2) (𝓝 (a, b)) (𝓝 (dist a b)),
   from continuous_iff_continuous_at.mp continuous_dist' (a, b),
 tendsto.comp (by rw [nhds_prod_eq] at this; exact this) (hf.prod_mk hg)
 
-lemma nhds_comap_dist (a : α) : (nhds (0 : ℝ)).comap (λa', dist a' a) = nhds a :=
+lemma nhds_comap_dist (a : α) : (𝓝 (0 : ℝ)).comap (λa', dist a' a) = 𝓝 a :=
 have h₁ : ∀ε, (λa', dist a' a) ⁻¹' ball 0 ε ⊆ ball a ε,
   by simp [subset_def, real.dist_0_eq_abs],
-have h₂ : tendsto (λa', dist a' a) (nhds a) (nhds (dist a a)),
+have h₂ : tendsto (λa', dist a' a) (𝓝 a) (𝓝 (dist a a)),
   from tendsto_dist tendsto_id tendsto_const_nhds,
 le_antisymm
   (by simp [h₁, nhds_eq, infi_le_infi, principal_mono,
@@ -812,7 +813,7 @@ le_antisymm
   (by simpa [map_le_iff_le_comap.symm, tendsto] using h₂)
 
 lemma tendsto_iff_dist_tendsto_zero {f : β → α} {x : filter β} {a : α} :
-  (tendsto f x (nhds a)) ↔ (tendsto (λb, dist (f b) a) x (nhds 0)) :=
+  (tendsto f x (𝓝 a)) ↔ (tendsto (λb, dist (f b) a) x (𝓝 0)) :=
 by rw [← nhds_comap_dist a, tendsto_comap_iff]
 
 lemma uniform_continuous_nndist' : uniform_continuous (λp:α×α, nndist p.1 p.2) :=
@@ -826,7 +827,7 @@ lemma continuous_nndist [topological_space β] {f g : β → α}
 continuous_nndist'.comp (hf.prod_mk hg)
 
 lemma tendsto_nndist' (a b :α) :
-  tendsto (λp:α×α, nndist p.1 p.2) (filter.prod (nhds a) (nhds b)) (nhds (nndist a b)) :=
+  tendsto (λp:α×α, nndist p.1 p.2) (filter.prod (𝓝 a) (𝓝 b)) (𝓝 (nndist a b)) :=
 by rw [← nhds_prod_eq]; exact continuous_iff_continuous_at.1 continuous_nndist' _
 
 namespace metric

--- a/src/topology/metric_space/cau_seq_filter.lean
+++ b/src/topology/metric_space/cau_seq_filter.lean
@@ -11,6 +11,7 @@ import tactic.linarith
 
 universes u v
 open set filter classical emetric
+open_locale topological_space
 
 variable {β : Type v}
 
@@ -41,7 +42,7 @@ begin
   simpa [half_pow] using this
 end
 
-lemma half_pow_tendsto_zero : tendsto (λn, half_pow n) at_top (nhds 0) :=
+lemma half_pow_tendsto_zero : tendsto (λn, half_pow n) at_top (𝓝 0) :=
 begin
   unfold half_pow,
   rw ← ennreal.of_real_zero,
@@ -106,7 +107,7 @@ lemma cauchy_seq_of_edist_le_half_pow [emetric_space β]
 begin
   refine emetric.cauchy_seq_iff_le_tendsto_0.2 ⟨λn:ℕ, 2 * half_pow n, ⟨_, _⟩⟩,
   { exact λk l N hk hl, edist_le_two_mul_half_pow hk hl h },
-  { have : tendsto (λn, 2 * half_pow n) at_top (nhds (2 * 0)) :=
+  { have : tendsto (λn, 2 * half_pow n) at_top (𝓝 (2 * 0)) :=
       ennreal.tendsto_mul_right half_pow_tendsto_zero (by simp),
     simpa using this }
 end
@@ -134,7 +135,7 @@ noncomputable def B2 (B : ℕ → ennreal) (n : ℕ) :=
 lemma B2_pos (hB : ∀n, 0 < B n) (n : ℕ) : 0 < B2 B n :=
 by unfold B2; simp [half_pow_pos n, hB n]
 
-lemma B2_lim : tendsto (λn, B2 B n) at_top (nhds 0) :=
+lemma B2_lim : tendsto (λn, B2 B n) at_top (𝓝 0) :=
 begin
   have : ∀n, B2 B n ≤ half_pow n := λn, lattice.inf_le_left,
   exact tendsto_of_tendsto_of_tendsto_of_le_of_le tendsto_const_nhds half_pow_tendsto_zero
@@ -217,8 +218,8 @@ The Nth one has radius `< B2 N < ε/2`. This set is in `f`, so we can find an el
 also in `t1`.
 `dist(x, seq N) < ε/2` since `seq N` is in this set, and `dist (seq N, y) < ε/2`,
 so `x` is in the ε-ball around `y`, and thus in `t2`. -/
-lemma le_nhds_cau_filter_lim {y : β} (H : tendsto (seq_of_cau_filter hf B hB) at_top (nhds y)) :
-  f ≤ nhds y :=
+lemma le_nhds_cau_filter_lim {y : β} (H : tendsto (seq_of_cau_filter hf B hB) at_top (𝓝 y)) :
+  f ≤ 𝓝 y :=
 begin
   refine (le_nhds_iff_adhp_of_cauchy hf).2 _,
   refine forall_sets_neq_empty_iff_neq_bot.1 (λs hs, _),
@@ -260,7 +261,7 @@ end sequentially_complete
 
 /-- An emetric space in which every Cauchy sequence converges is complete. -/
 theorem complete_of_cauchy_seq_tendsto {α : Type u} [emetric_space α]
-  (H : ∀u : ℕ → α, cauchy_seq u → ∃x, tendsto u at_top (nhds x)) :
+  (H : ∀u : ℕ → α, cauchy_seq u → ∃x, tendsto u at_top (𝓝 x)) :
   complete_space α :=
 ⟨begin
   -- Consider a Cauchy filter `f`
@@ -283,7 +284,7 @@ converging. This is often applied for `B N = 2^{-N}`, i.e., with a very fast con
 to do in general for arbitrary Cauchy sequences. -/
 theorem emetric.complete_of_convergent_controlled_sequences {α : Type u} [emetric_space α]
   (B : ℕ → ennreal) (hB : ∀n, 0 < B n)
-  (H : ∀u : ℕ → α, (∀N n m : ℕ, N ≤ n → N ≤ m → edist (u n) (u m) < B N) → ∃x, tendsto u at_top (nhds x)) :
+  (H : ∀u : ℕ → α, (∀N n m : ℕ, N ≤ n → N ≤ m → edist (u n) (u m) < B N) → ∃x, tendsto u at_top (𝓝 x)) :
   complete_space α :=
 ⟨begin
   -- Consider a Cauchy filter `f`.
@@ -308,7 +309,7 @@ converging. This is often applied for `B N = 2^{-N}`, i.e., with a very fast con
 to do in general for arbitrary Cauchy sequences. -/
 theorem metric.complete_of_convergent_controlled_sequences {α : Type u} [metric_space α]
   (B : ℕ → real) (hB : ∀n, 0 < B n)
-  (H : ∀u : ℕ → α, (∀N n m : ℕ, N ≤ n → N ≤ m → dist (u n) (u m) < B N) → ∃x, tendsto u at_top (nhds x)) :
+  (H : ∀u : ℕ → α, (∀N n m : ℕ, N ≤ n → N ≤ m → dist (u n) (u m) < B N) → ∃x, tendsto u at_top (𝓝 x)) :
   complete_space α :=
 begin
   -- this follows from the same criterion in emetric spaces. We just need to translate
@@ -331,7 +332,7 @@ multiplicative absolute value on normed fields. -/
 
 lemma tendsto_limit [normed_ring β] [hn : is_absolute_value (norm : β → ℝ)]
   (f : cau_seq β norm) [cau_seq.is_complete β norm] :
-  tendsto f at_top (nhds f.lim) :=
+  tendsto f at_top (𝓝 f.lim) :=
 _root_.tendsto_nhds.mpr
 begin
   intros s os lfs,

--- a/src/topology/metric_space/closeds.lean
+++ b/src/topology/metric_space/closeds.lean
@@ -17,6 +17,7 @@ always finite in this context.
 import topology.metric_space.hausdorff_distance topology.opens
 noncomputable theory
 open_locale classical
+open_locale topological_space
 
 universe u
 open classical lattice set function topological_space filter
@@ -184,7 +185,7 @@ begin
   have main : ∀n:ℕ, edist (s n) t ≤ 2 * B n := λn, Hausdorff_edist_le_of_mem_edist (I1 n) (I2 n),
   -- from this, the convergence of `s n` to `t0` follows.
   refine (tendsto_at_top _).2 (λε εpos, _),
-  have : tendsto (λn, 2 * ennreal.half_pow n) at_top (nhds (2 * 0)) :=
+  have : tendsto (λn, 2 * ennreal.half_pow n) at_top (𝓝 (2 * 0)) :=
     ennreal.tendsto_mul_right ennreal.half_pow_tendsto_zero (by simp),
   rw mul_zero at this,
   have Z := (tendsto_orderable.1 this).2 ε εpos,

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -22,7 +22,7 @@ import topology.bases
 open lattice set filter classical
 noncomputable theory
 
-open_locale uniformity
+open_locale uniformity topological_space
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
@@ -382,7 +382,7 @@ eq_empty_iff_forall_not_mem.trans
 ⟨λh, le_bot_iff.1 (le_of_not_gt (λ ε0, h _ (mem_ball_self ε0))),
 λε0 y h, not_lt_of_le (le_of_eq ε0) (pos_of_mem_ball h)⟩
 
-theorem nhds_eq : nhds x = (⨅ε:{ε:ennreal // ε>0}, principal (ball x ε.val)) :=
+theorem nhds_eq : 𝓝 x = (⨅ε:{ε:ennreal // ε>0}, principal (ball x ε.val)) :=
 begin
   rw [nhds_eq_uniformity, uniformity_edist'', lift'_infi],
   { apply congr_arg, funext ε,
@@ -393,7 +393,7 @@ begin
   { intros, refl }
 end
 
-theorem mem_nhds_iff : s ∈ nhds x ↔ ∃ε>0, ball x ε ⊆ s :=
+theorem mem_nhds_iff : s ∈ 𝓝 x ↔ ∃ε>0, ball x ε ⊆ s :=
 begin
   rw [nhds_eq, mem_infi],
   { simp },
@@ -409,7 +409,7 @@ by simp [is_open_iff_nhds, mem_nhds_iff]
 theorem is_open_ball : is_open (ball x ε) :=
 is_open_iff.2 $ λ y, exists_ball_subset_ball
 
-theorem ball_mem_nhds (x : α) {ε : ennreal} (ε0 : 0 < ε) : ball x ε ∈ nhds x :=
+theorem ball_mem_nhds (x : α) {ε : ennreal} (ε0 : 0 < ε) : ball x ε ∈ 𝓝 x :=
 mem_nhds_sets is_open_ball (mem_ball_self ε0)
 
 /-- ε-characterization of the closure in emetric spaces -/
@@ -433,14 +433,14 @@ begin
 end⟩
 
 theorem tendsto_nhds {f : filter β} {u : β → α} {a : α} :
-  tendsto u f (nhds a) ↔ ∀ ε > 0, ∃ n ∈ f, ∀x ∈ n, edist (u x) a < ε :=
+  tendsto u f (𝓝 a) ↔ ∀ ε > 0, ∃ n ∈ f, ∀x ∈ n, edist (u x) a < ε :=
 ⟨λ H ε ε0, ⟨u⁻¹' (ball a ε), H (ball_mem_nhds _ ε0), by simp⟩,
  λ H s hs,
   let ⟨ε, ε0, hε⟩ := mem_nhds_iff.1 hs, ⟨δ, δ0, hδ⟩ := H _ ε0 in
   f.sets_of_superset δ0 (λx xδ, hε (hδ x xδ))⟩
 
 theorem tendsto_at_top [inhabited β] [semilattice_sup β] (u : β → α) {a : α} :
-  tendsto u at_top (nhds a) ↔ ∀ε>0, ∃N, ∀n≥N, edist (u n) a < ε :=
+  tendsto u at_top (𝓝 a) ↔ ∀ε>0, ∃N, ∀n≥N, edist (u n) a < ε :=
 begin
   rw tendsto_nhds,
   apply forall_congr,

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -32,6 +32,7 @@ topology.metric_space.completion
 
 noncomputable theory
 open_locale classical
+open_locale topological_space
 universes u v w
 
 open classical lattice set function topological_space filter metric quotient
@@ -727,7 +728,7 @@ a uniformly bounded diameter, and for all ε the number of balls of radius ε re
 to cover the space is uniformly bounded. This is an equivalence, but we only prove the
 interesting direction that these conditions imply compactness. -/
 lemma totally_bounded {t : set GH_space} {C : ℝ} {u : ℕ → ℝ} {K : ℕ → ℕ}
-  (ulim : tendsto u at_top (nhds 0))
+  (ulim : tendsto u at_top (𝓝 0))
   (hdiam : ∀p ∈ t, diam (univ : set (GH_space.rep p)) ≤ C)
   (hcov : ∀p ∈ t, ∀n:ℕ, ∃s : set (GH_space.rep p), cardinal.mk s ≤ K n ∧ univ ⊆ ⋃x∈s, ball x (u n)) :
   totally_bounded t :=
@@ -998,7 +999,7 @@ begin
   -- therefore, it converges to a limit `L`
   rcases cauchy_seq_tendsto_of_complete this with ⟨L, hL⟩,
   -- the images of `X3 n` in the Gromov-Hausdorff space converge to the image of `L`
-  have M : tendsto (λn, (X3 n).to_GH_space) at_top (nhds L.to_GH_space) :=
+  have M : tendsto (λn, (X3 n).to_GH_space) at_top (𝓝 L.to_GH_space) :=
     tendsto.comp (to_GH_space_continuous.tendsto _) hL,
   -- By construction, the image of `X3 n` in the Gromov-Hausdorff space is `u n`.
   have : ∀n, (X3 n).to_GH_space = u n,

--- a/src/topology/metric_space/gromov_hausdorff_realized.lean
+++ b/src/topology/metric_space/gromov_hausdorff_realized.lean
@@ -12,6 +12,7 @@ topology.metric_space.hausdorff_distance
 
 noncomputable theory
 open_locale classical
+open_locale topological_space
 universes u v w
 
 open classical lattice set function topological_space filter metric quotient
@@ -239,7 +240,7 @@ begin
     simp only [set.mem_Icc],
     exact ⟨candidates_nonneg hf, candidates_le_max_var hf⟩ },
   { refine equicontinuous_of_continuity_modulus (λt, 2 * max_var α β * t) _ _ _,
-    { have : tendsto (λ (t : ℝ), 2 * max_var α β * t) (nhds 0) (nhds (2 * max_var α β * 0)) :=
+    { have : tendsto (λ (t : ℝ), 2 * max_var α β * t) (𝓝 0) (𝓝 (2 * max_var α β * 0)) :=
         tendsto_mul tendsto_const_nhds tendsto_id,
       simpa using this },
     { assume x y f hf,

--- a/src/topology/metric_space/lipschitz.lean
+++ b/src/topology/metric_space/lipschitz.lean
@@ -7,11 +7,12 @@ Lipschitz functions and the Banach fixed-point theorem
 -/
 import topology.metric_space.basic analysis.specific_limits
 open filter
+open_locale topological_space
 
 variables {α : Type*} {β : Type*} {γ : Type*}
 
 lemma fixed_point_of_tendsto_iterate [topological_space α] [t2_space α] {f : α → α} {x : α}
-  (hf : tendsto f (nhds x) (nhds (f x))) (hx : ∃ x₀ : α, tendsto (λ n, f^[n] x₀) at_top (nhds x)) :
+  (hf : tendsto f (𝓝 x) (𝓝 (f x))) (hx : ∃ x₀ : α, tendsto (λ n, f^[n] x₀) at_top (𝓝 x)) :
   f x = x :=
 begin
   rcases hx with ⟨x₀, hx⟩,

--- a/src/topology/order.lean
+++ b/src/topology/order.lean
@@ -42,7 +42,7 @@ finer, coarser, induced topology, coinduced topology
 -/
 
 open set filter lattice classical
-open_locale classical
+open_locale classical topological_space
 
 universes u v w
 
@@ -102,7 +102,7 @@ begin
   letI := topological_space.mk_of_nhds n,
   refine le_antisymm (assume s hs, _) (assume s hs, _),
   { have h₀ : {b | s ∈ n b} ⊆ s := assume b hb, mem_pure_sets.1 $ h₀ b hb,
-    have h₁ : {b | s ∈ n b} ∈ nhds a,
+    have h₁ : {b | s ∈ n b} ∈ 𝓝 a,
     { refine mem_nhds_sets (assume b (hb : s ∈ n b), _) hs,
       rcases h₁ hb with ⟨t, ht, hts, h⟩,
       exact mem_sets_of_superset ht h },
@@ -226,7 +226,7 @@ le_antisymm
 
 lemma eq_bot_of_singletons_open {t : topological_space α} (h : ∀ x, t.is_open {x}) : t = ⊥ :=
 bot_unique  $ le_of_nhds_le_nhds $ assume x,
-  have nhds x ≤ pure x, from nhds_le_of_le (mem_singleton _) (h x) (by simp),
+  have 𝓝 x ≤ pure x, from nhds_le_of_le (mem_singleton _) (h x) (by simp),
   le_trans this (@pure_le_nhds _ ⊥ x)
 
 end lattice
@@ -499,10 +499,10 @@ continuous_iff_le_induced.2 $ bot_le
 lemma continuous_top {t : tspace α} : cont t ⊤ f :=
 continuous_iff_coinduced_le.2 $ le_top
 
-/- nhds in the induced topology -/
+/- 𝓝 in the induced topology -/
 
 theorem mem_nhds_induced [T : topological_space α] (f : β → α) (a : β) (s : set β) :
-  s ∈ @nhds β (topological_space.induced f T) a ↔ ∃ u ∈ nhds (f a), f ⁻¹' u ⊆ s :=
+  s ∈ @nhds β (topological_space.induced f T) a ↔ ∃ u ∈ 𝓝 (f a), f ⁻¹' u ⊆ s :=
 begin
   simp only [nhds_sets, is_open_induced_iff, exists_prop, set.mem_set_of_eq],
   split,
@@ -513,16 +513,16 @@ begin
 end
 
 theorem nhds_induced [T : topological_space α] (f : β → α) (a : β) :
-  @nhds β (topological_space.induced f T) a = comap f (nhds (f a)) :=
+  @nhds β (topological_space.induced f T) a = comap f (𝓝 (f a)) :=
 filter_eq $ by ext s; rw mem_nhds_induced; rw mem_comap_sets
 
 lemma induced_iff_nhds_eq [tα : topological_space α] [tβ : topological_space β] (f : β → α) :
-tβ = tα.induced f ↔ ∀ b, nhds b = comap f (nhds $ f b) :=
+tβ = tα.induced f ↔ ∀ b, 𝓝 b = comap f (𝓝 $ f b) :=
 ⟨λ h a, h.symm ▸ nhds_induced f a, λ h, eq_of_nhds_eq_nhds $ λ x, by rw [h, nhds_induced]⟩
 
 theorem map_nhds_induced_of_surjective [T : topological_space α]
     {f : β → α} (hf : function.surjective f) (a : β) :
-  map f (@nhds β (topological_space.induced f T) a) = nhds (f a) :=
+  map f (@nhds β (topological_space.induced f T) a) = 𝓝 (f a) :=
 by rw [nhds_induced, map_comap_of_surjective hf]
 
 end constructions
@@ -539,28 +539,28 @@ iff.refl _
 theorem is_open_induced {s : set β} (h : is_open s) : (induced f t).is_open (f ⁻¹' s) :=
 ⟨s, h, rfl⟩
 
-lemma map_nhds_induced_eq {a : α} (h : range f ∈ nhds (f a)) :
-  map f (@nhds α (induced f t) a) = nhds (f a) :=
+lemma map_nhds_induced_eq {a : α} (h : range f ∈ 𝓝 (f a)) :
+  map f (@nhds α (induced f t) a) = 𝓝 (f a) :=
 by rw [nhds_induced, filter.map_comap h]
 
 lemma closure_induced [t : topological_space β] {f : α → β} {a : α} {s : set α}
   (hf : ∀x y, f x = f y → x = y) :
   a ∈ @closure α (topological_space.induced f t) s ↔ f a ∈ closure (f '' s) :=
-have comap f (nhds (f a) ⊓ principal (f '' s)) ≠ ⊥ ↔ nhds (f a) ⊓ principal (f '' s) ≠ ⊥,
+have comap f (𝓝 (f a) ⊓ principal (f '' s)) ≠ ⊥ ↔ 𝓝 (f a) ⊓ principal (f '' s) ≠ ⊥,
   from ⟨assume h₁ h₂, h₁ $ h₂.symm ▸ comap_bot,
     assume h,
     forall_sets_neq_empty_iff_neq_bot.mp $
       assume s₁ ⟨s₂, hs₂, (hs : f ⁻¹' s₂ ⊆ s₁)⟩,
-      have f '' s ∈ nhds (f a) ⊓ principal (f '' s),
+      have f '' s ∈ 𝓝 (f a) ⊓ principal (f '' s),
         from mem_inf_sets_of_right $ by simp [subset.refl],
-      have s₂ ∩ f '' s ∈ nhds (f a) ⊓ principal (f '' s),
+      have s₂ ∩ f '' s ∈ 𝓝 (f a) ⊓ principal (f '' s),
         from inter_mem_sets hs₂ this,
       let ⟨b, hb₁, ⟨a, ha, ha₂⟩⟩ := inhabited_of_mem_sets h this in
       ne_empty_of_mem $ hs $ by rwa [←ha₂] at hb₁⟩,
 calc a ∈ @closure α (topological_space.induced f t) s
     ↔ (@nhds α (topological_space.induced f t) a) ⊓ principal s ≠ ⊥ : by rw [closure_eq_nhds]; refl
-  ... ↔ comap f (nhds (f a)) ⊓ principal (f ⁻¹' (f '' s)) ≠ ⊥ : by rw [nhds_induced, preimage_image_eq _ hf]
-  ... ↔ comap f (nhds (f a) ⊓ principal (f '' s)) ≠ ⊥ : by rw [comap_inf, ←comap_principal]
+  ... ↔ comap f (𝓝 (f a)) ⊓ principal (f ⁻¹' (f '' s)) ≠ ⊥ : by rw [nhds_induced, preimage_image_eq _ hf]
+  ... ↔ comap f (𝓝 (f a) ⊓ principal (f '' s)) ≠ ⊥ : by rw [comap_inf, ←comap_principal]
   ... ↔ _ : by rwa [closure_eq_nhds]
 
 end induced

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -9,6 +9,7 @@ Separation properties of topological spaces.
 import topology.subset_properties
 
 open set filter lattice
+open_locale topological_space
 local attribute [instance] classical.prop_decidable -- TODO: use "open_locale classical"
 
 universes u v
@@ -124,7 +125,7 @@ instance t1_space.t0_space [t1_space α] : t0_space α :=
 ⟨λ x y h, ⟨-{x}, is_open_compl_iff.2 is_closed_singleton,
   or.inr ⟨λ hyx, or.cases_on hyx h.symm id, λ hx, hx $ or.inl rfl⟩⟩⟩
 
-lemma compl_singleton_mem_nhds [t1_space α] {x y : α} (h : y ≠ x) : - {x} ∈ nhds y :=
+lemma compl_singleton_mem_nhds [t1_space α] {x y : α} (h : y ≠ x) : - {x} ∈ 𝓝 y :=
 mem_nhds_sets is_closed_singleton $ by rwa [mem_compl_eq, mem_singleton_iff]
 
 @[simp] lemma closure_singleton [t1_space α] {a : α} :
@@ -146,51 +147,51 @@ instance t2_space.t1_space [t2_space α] : t1_space α :=
 let ⟨u, v, hu, hv, hyu, hxv, huv⟩ := t2_separation (mt mem_singleton_of_eq hxy) in
 ⟨u, λ z hz1 hz2, ((ext_iff _ _).1 huv x).1 ⟨mem_singleton_iff.1 hz2 ▸ hz1, hxv⟩, hu, hyu⟩⟩
 
-lemma eq_of_nhds_neq_bot [ht : t2_space α] {x y : α} (h : nhds x ⊓ nhds y ≠ ⊥) : x = y :=
+lemma eq_of_nhds_neq_bot [ht : t2_space α] {x y : α} (h : 𝓝 x ⊓ 𝓝 y ≠ ⊥) : x = y :=
 classical.by_contradiction $ assume : x ≠ y,
 let ⟨u, v, hu, hv, hx, hy, huv⟩ := t2_space.t2 x y this in
-have u ∩ v ∈ nhds x ⊓ nhds y,
+have u ∩ v ∈ 𝓝 x ⊓ 𝓝 y,
   from inter_mem_inf_sets (mem_nhds_sets hu hx) (mem_nhds_sets hv hy),
 h $ empty_in_sets_eq_bot.mp $ huv ▸ this
 
-lemma t2_iff_nhds : t2_space α ↔ ∀ {x y : α}, nhds x ⊓ nhds y ≠ ⊥ → x = y :=
+lemma t2_iff_nhds : t2_space α ↔ ∀ {x y : α}, 𝓝 x ⊓ 𝓝 y ≠ ⊥ → x = y :=
 ⟨assume h, by exactI λ x y, eq_of_nhds_neq_bot,
  assume h, ⟨assume x y xy,
-   have nhds x ⊓ nhds y = ⊥ := classical.by_contradiction (mt h xy),
+   have 𝓝 x ⊓ 𝓝 y = ⊥ := classical.by_contradiction (mt h xy),
    let ⟨u', hu', v', hv', u'v'⟩ := empty_in_sets_eq_bot.mpr this,
        ⟨u, uu', uo, hu⟩ := mem_nhds_sets_iff.mp hu',
        ⟨v, vv', vo, hv⟩ := mem_nhds_sets_iff.mp hv' in
    ⟨u, v, uo, vo, hu, hv, disjoint.eq_bot $ disjoint_mono uu' vv' u'v'⟩⟩⟩
 
 lemma t2_iff_ultrafilter :
-  t2_space α ↔ ∀ f {x y : α}, is_ultrafilter f → f ≤ nhds x → f ≤ nhds y → x = y :=
+  t2_space α ↔ ∀ f {x y : α}, is_ultrafilter f → f ≤ 𝓝 x → f ≤ 𝓝 y → x = y :=
 t2_iff_nhds.trans
   ⟨assume h f x y u fx fy, h $ neq_bot_of_le_neq_bot u.1 (le_inf fx fy),
    assume h x y xy,
      let ⟨f, hf, uf⟩ := exists_ultrafilter xy in
      h f uf (le_trans hf lattice.inf_le_left) (le_trans hf lattice.inf_le_right)⟩
 
-@[simp] lemma nhds_eq_nhds_iff {a b : α} [t2_space α] : nhds a = nhds b ↔ a = b :=
+@[simp] lemma nhds_eq_nhds_iff {a b : α} [t2_space α] : 𝓝 a = 𝓝 b ↔ a = b :=
 ⟨assume h, eq_of_nhds_neq_bot $ by rw [h, inf_idem]; exact nhds_neq_bot, assume h, h ▸ rfl⟩
 
-@[simp] lemma nhds_le_nhds_iff {a b : α} [t2_space α] : nhds a ≤ nhds b ↔ a = b :=
+@[simp] lemma nhds_le_nhds_iff {a b : α} [t2_space α] : 𝓝 a ≤ 𝓝 b ↔ a = b :=
 ⟨assume h, eq_of_nhds_neq_bot $ by rw [inf_of_le_left h]; exact nhds_neq_bot, assume h, h ▸ le_refl _⟩
 
 lemma tendsto_nhds_unique [t2_space α] {f : β → α} {l : filter β} {a b : α}
-  (hl : l ≠ ⊥) (ha : tendsto f l (nhds a)) (hb : tendsto f l (nhds b)) : a = b :=
+  (hl : l ≠ ⊥) (ha : tendsto f l (𝓝 a)) (hb : tendsto f l (𝓝 b)) : a = b :=
 eq_of_nhds_neq_bot $ neq_bot_of_le_neq_bot (map_ne_bot hl) $ le_inf ha hb
 
 section lim
 variables [inhabited α] [t2_space α] {f : filter α}
 
-lemma lim_eq {a : α} (hf : f ≠ ⊥) (h : f ≤ nhds a) : lim f = a :=
+lemma lim_eq {a : α} (hf : f ≠ ⊥) (h : f ≤ 𝓝 a) : lim f = a :=
 eq_of_nhds_neq_bot $ neq_bot_of_le_neq_bot hf $ le_inf (lim_spec ⟨_, h⟩) h
 
-@[simp] lemma lim_nhds_eq {a : α} : lim (nhds a) = a :=
+@[simp] lemma lim_nhds_eq {a : α} : lim (𝓝 a) = a :=
 lim_eq nhds_neq_bot (le_refl _)
 
 @[simp] lemma lim_nhds_eq_of_closure {a : α} {s : set α} (h : a ∈ closure s) :
-  lim (nhds a ⊓ principal s) = a :=
+  lim (𝓝 a ⊓ principal s) = a :=
 lim_eq begin rw [closure_eq_nhds] at h, exact h end inf_le_left
 end lim
 
@@ -225,12 +226,12 @@ instance Pi.t2_space {α : Type*} {β : α → Type v} [t₂ : Πa, topological_
   separated_by_f (λz, z i) (infi_le _ i) hi⟩
 
 lemma is_closed_diagonal [t2_space α] : is_closed {p:α×α | p.1 = p.2} :=
-is_closed_iff_nhds.mpr $ assume ⟨a₁, a₂⟩ h, eq_of_nhds_neq_bot $ assume : nhds a₁ ⊓ nhds a₂ = ⊥, h $
+is_closed_iff_nhds.mpr $ assume ⟨a₁, a₂⟩ h, eq_of_nhds_neq_bot $ assume : 𝓝 a₁ ⊓ 𝓝 a₂ = ⊥, h $
   let ⟨t₁, ht₁, t₂, ht₂, (h' : t₁ ∩ t₂ ⊆ ∅)⟩ :=
     by rw [←empty_in_sets_eq_bot, mem_inf_sets] at this; exact this in
   begin
-    change t₁ ∈ nhds a₁ at ht₁,
-    change t₂ ∈ nhds a₂ at ht₂,
+    change t₁ ∈ 𝓝 a₁ at ht₁,
+    change t₂ ∈ 𝓝 a₂ at ht₂,
     rw [nhds_prod_eq, ←empty_in_sets_eq_bot],
     apply filter.sets_of_superset,
     apply inter_mem_inf_sets (prod_mem_prod ht₁ ht₂) (mem_principal_sets.mpr (subset.refl _)),
@@ -269,7 +270,7 @@ is_open_compl_iff.mpr $ is_open_iff_forall_mem_open.mpr $ assume x hx,
     subset_compl_comm.mp (subset.trans su (subset_compl_iff_disjoint.mpr uv)),
 ⟨v, this, vo, by simpa using xv⟩
 
-lemma locally_compact_of_compact_nhds [t2_space α] (h : ∀ x : α, ∃ s, s ∈ nhds x ∧ compact s) :
+lemma locally_compact_of_compact_nhds [t2_space α] (h : ∀ x : α, ∃ s, s ∈ 𝓝 x ∧ compact s) :
   locally_compact_space α :=
 ⟨assume x n hn,
   let ⟨u, un, uo, xu⟩ := mem_nhds_sets_iff.mp hn in
@@ -281,7 +282,7 @@ lemma locally_compact_of_compact_nhds [t2_space α] (h : ∀ x : α, ∃ s, s �
   let ⟨v, w, vo, wo, xv, kuw, vw⟩ :=
     compact_compact_separated compact_singleton (compact_diff kc uo)
       (by rw [singleton_inter_eq_empty]; exact λ h, h.2 xu) in
-  have wn : -w ∈ nhds x, from
+  have wn : -w ∈ 𝓝 x, from
    mem_nhds_sets_iff.mpr
      ⟨v, subset_compl_iff_disjoint.mpr vw, vo, singleton_subset_iff.mp xv⟩,
   ⟨k - w,
@@ -300,12 +301,12 @@ section regularity
   omits T₂), is one in which for every closed `C` and `x ∉ C`, there exist
   disjoint open sets containing `x` and `C` respectively. -/
 class regular_space (α : Type u) [topological_space α] extends t1_space α : Prop :=
-(regular : ∀{s:set α} {a}, is_closed s → a ∉ s → ∃t, is_open t ∧ s ⊆ t ∧ nhds a ⊓ principal t = ⊥)
+(regular : ∀{s:set α} {a}, is_closed s → a ∉ s → ∃t, is_open t ∧ s ⊆ t ∧ 𝓝 a ⊓ principal t = ⊥)
 
-lemma nhds_is_closed [regular_space α] {a : α} {s : set α} (h : s ∈ nhds a) :
-  ∃t∈(nhds a), t ⊆ s ∧ is_closed t :=
+lemma nhds_is_closed [regular_space α] {a : α} {s : set α} (h : s ∈ 𝓝 a) :
+  ∃t∈(𝓝 a), t ⊆ s ∧ is_closed t :=
 let ⟨s', h₁, h₂, h₃⟩ := mem_nhds_sets_iff.mp h in
-have ∃t, is_open t ∧ -s' ⊆ t ∧ nhds a ⊓ principal t = ⊥,
+have ∃t, is_open t ∧ -s' ⊆ t ∧ 𝓝 a ⊓ principal t = ⊥,
   from regular_space.regular (is_closed_compl_iff.mpr h₂) (not_not_intro h₃),
 let ⟨t, ht₁, ht₂, ht₃⟩ := this in
 ⟨-t,

--- a/src/topology/sequences.lean
+++ b/src/topology/sequences.lean
@@ -21,10 +21,11 @@ import topology.basic
 import topology.bases
 
 open set filter
+open_locale topological_space
 
 variables {α : Type*} {β : Type*}
 
-local notation f ` ⟶ ` limit := tendsto f at_top (nhds limit)
+local notation f ` ⟶ ` limit := tendsto f at_top (𝓝 limit)
 
 /- Statements about sequences in general topological spaces. -/
 section topological_space
@@ -33,10 +34,10 @@ variables [topological_space α] [topological_space β]
 /-- A sequence converges in the sence of topological spaces iff the associated statement for filter
 holds. -/
 lemma topological_space.seq_tendsto_iff {x : ℕ → α} {limit : α} :
-  tendsto x at_top (nhds limit) ↔
+  tendsto x at_top (𝓝 limit) ↔
     ∀ U : set α, limit ∈ U → is_open U → ∃ n0 : ℕ, ∀ n ≥ n0, (x n) ∈ U :=
 iff.intro
-  (assume ttol : tendsto x at_top (nhds limit),
+  (assume ttol : tendsto x at_top (𝓝 limit),
     show ∀ U : set α, limit ∈ U → is_open U → ∃ n0 : ℕ, ∀ n ≥ n0, (x n) ∈ U, from
       assume U limitInU isOpenU,
       have {n | (x n) ∈ U} ∈ at_top :=
@@ -131,7 +132,7 @@ def sequentially_continuous (f : α → β) : Prop :=
 lemma continuous.to_sequentially_continuous {f : α → β} (_ : continuous f) :
   sequentially_continuous f :=
 assume x limit (_ : x ⟶ limit),
-have tendsto f (nhds limit) (nhds (f limit)), from continuous.tendsto ‹continuous f› limit,
+have tendsto f (𝓝 limit) (𝓝 (f limit)), from continuous.tendsto ‹continuous f› limit,
 show (f ∘ x) ⟶ (f limit), from tendsto.comp this ‹(x ⟶ limit)›
 
 /-- In a sequential space, continuity and sequential continuity coincide. -/
@@ -174,7 +175,7 @@ instance [topological_space α] [first_countable_topology α] : sequential_space
     apply hp, rw gbasis, rw ← le_principal_iff, apply lattice.infi_le_of_le i _, apply le_refl _ },
   -- It remains to show that x converges to p. Intuitively this is the case
   -- because x i ∈ g i, and the g i get "arbitrarily small" around p. Formally:
-  have gssnhds : ∀ s ∈ nhds p, ∃ i, g i ⊆ s,
+  have gssnhds : ∀ s ∈ 𝓝 p, ∃ i, g i ⊆ s,
   { intro s, rw gbasis, rw mem_infi,
     { simp, intros i hi, use i, assumption },
     { apply directed_of_mono, intros, apply principal_mono.mpr, apply gmon, assumption },

--- a/src/topology/stone_cech.lean
+++ b/src/topology/stone_cech.lean
@@ -14,6 +14,7 @@ import topology.bases topology.dense_embedding
 noncomputable theory
 
 open filter lattice set
+open_locale topological_space
 
 universes u v
 
@@ -59,10 +60,10 @@ end
 /-- Every ultrafilter `u` on `ultrafilter α` converges to a unique
   point of `ultrafilter α`, namely `mjoin u`. -/
 lemma ultrafilter_converges_iff {u : ultrafilter (ultrafilter α)} {x : ultrafilter α} :
-  u.val ≤ nhds x ↔ x = mjoin u :=
+  u.val ≤ 𝓝 x ↔ x = mjoin u :=
 begin
   rw [eq_comm, ultrafilter.eq_iff_val_le_val],
-  change u.val ≤ nhds x ↔ x.val.sets ⊆ {a | {v : ultrafilter α | a ∈ v.val} ∈ u.val},
+  change u.val ≤ 𝓝 x ↔ x.val.sets ⊆ {a | {v : ultrafilter α | a ∈ v.val} ∈ u.val},
   simp only [topological_space.nhds_generate_from, lattice.le_infi_iff, ultrafilter_basis,
     le_principal_iff],
   split; intro h,
@@ -80,7 +81,7 @@ t2_iff_ultrafilter.mpr $ assume f x y u fx fy,
   have hy : y = mjoin ⟨f, u⟩, from ultrafilter_converges_iff.mp fy,
   hx.trans hy.symm
 
-lemma ultrafilter_comap_pure_nhds (b : ultrafilter α) : comap pure (nhds b) ≤ b.val :=
+lemma ultrafilter_comap_pure_nhds (b : ultrafilter α) : comap pure (𝓝 b) ≤ b.val :=
 begin
   rw topological_space.nhds_generate_from,
   simp only [comap_infi, comap_principal],
@@ -151,7 +152,7 @@ end
 variables  [compact_space γ]
 
 lemma continuous_ultrafilter_extend (f : α → γ) : continuous (ultrafilter.extend f) :=
-have ∀ (b : ultrafilter α), ∃ c, tendsto f (comap ultrafilter.pure (nhds b)) (nhds c) := assume b,
+have ∀ (b : ultrafilter α), ∃ c, tendsto f (comap ultrafilter.pure (𝓝 b)) (𝓝 c) := assume b,
   -- b.map f is an ultrafilter on γ, which is compact, so it converges to some c in γ.
   let ⟨c, _, h⟩ := compact_iff_ultrafilter_le_nhds.mp compact_univ (b.map f).val (b.map f).property
     (by rw [le_principal_iff]; exact univ_mem_sets) in
@@ -165,12 +166,12 @@ end
 /-- The value of `ultrafilter.extend f` on an ultrafilter `b` is the
   unique limit of the ultrafilter `b.map f` in `γ`. -/
 lemma ultrafilter_extend_eq_iff {f : α → γ} {b : ultrafilter α} {c : γ} :
-  ultrafilter.extend f b = c ↔ b.val.map f ≤ nhds c :=
+  ultrafilter.extend f b = c ↔ b.val.map f ≤ 𝓝 c :=
 ⟨assume h, begin
    -- Write b as an ultrafilter limit of pure ultrafilters, and use
    -- the facts that ultrafilter.extend is a continuous extension of f.
    let b' : ultrafilter (ultrafilter α) := b.map pure,
-   have t : b'.val ≤ nhds b,
+   have t : b'.val ≤ 𝓝 b,
      from ultrafilter_converges_iff.mpr (by exact (bind_pure _).symm),
    rw ←h,
    have := (continuous_ultrafilter_extend f).tendsto b,
@@ -243,7 +244,7 @@ continuous_quot_lift _ (continuous_ultrafilter_extend f)
 
 end extension
 
-lemma convergent_eqv_pure {u : ultrafilter α} {x : α} (ux : u.val ≤ nhds x) : u ≈ pure x :=
+lemma convergent_eqv_pure {u : ultrafilter α} {x : α} (ux : u.val ≤ 𝓝 x) : u ≈ pure x :=
 assume γ tγ h₁ h₂ f hf, begin
   resetI,
   transitivity f x, swap, symmetry,
@@ -254,9 +255,9 @@ end
 lemma continuous_stone_cech_unit : continuous (stone_cech_unit : α → stone_cech α) :=
 continuous_iff_ultrafilter.mpr $ λ x g u gx,
   let g' : ultrafilter α := ⟨g, u⟩ in
-  have (g'.map ultrafilter.pure).val ≤ nhds g',
+  have (g'.map ultrafilter.pure).val ≤ 𝓝 g',
     by rw ultrafilter_converges_iff; exact (bind_pure _).symm,
-  have (g'.map stone_cech_unit).val ≤ nhds ⟦g'⟧, from
+  have (g'.map stone_cech_unit).val ≤ 𝓝 ⟦g'⟧, from
     (continuous_at_iff_ultrafilter g').mp
       (continuous_quotient_mk.tendsto g') _ (ultrafilter_map u) this,
   by rwa (show ⟦g'⟧ = ⟦pure x⟧, from quotient.sound $ convergent_eqv_pure gx) at this
@@ -270,10 +271,10 @@ begin
   resetI,
   let ff := stone_cech_extend hf,
   change ff ⟦x⟧ = ff ⟦y⟧,
-  have lim : ∀ z : ultrafilter α, g ≤ nhds ⟦z⟧ → tendsto ff g (nhds (ff ⟦z⟧)) :=
+  have lim : ∀ z : ultrafilter α, g ≤ 𝓝 ⟦z⟧ → tendsto ff g (𝓝 (ff ⟦z⟧)) :=
   assume z gz,
-    calc map ff g ≤ map ff (nhds ⟦z⟧) : map_mono gz
-              ... ≤ nhds (ff ⟦z⟧) : (continuous_stone_cech_extend hf).tendsto _,
+    calc map ff g ≤ map ff (𝓝 ⟦z⟧) : map_mono gz
+              ... ≤ 𝓝 (ff ⟦z⟧) : (continuous_stone_cech_extend hf).tendsto _,
   exact tendsto_nhds_unique u.1 (lim x gx) (lim y gy)
 end
 

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -10,7 +10,7 @@ connected, totally disconnected, totally separated.
 import topology.constructions
 
 open set filter lattice classical
-open_locale classical
+open_locale classical topological_space
 
 universes u v
 variables {α : Type u} {β : Type v} [topological_space α]
@@ -20,12 +20,12 @@ section compact
 
 /-- A set `s` is compact if for every filter `f` that contains `s`,
     every set of `f` also meets every neighborhood of some `a ∈ s`. -/
-def compact (s : set α) := ∀f, f ≠ ⊥ → f ≤ principal s → ∃a∈s, f ⊓ nhds a ≠ ⊥
+def compact (s : set α) := ∀f, f ≠ ⊥ → f ≤ principal s → ∃a∈s, f ⊓ 𝓝 a ≠ ⊥
 
 lemma compact_inter {s t : set α} (hs : compact s) (ht : is_closed t) : compact (s ∩ t) :=
 assume f hnf hstf,
-let ⟨a, hsa, (ha : f ⊓ nhds a ≠ ⊥)⟩ := hs f hnf (le_trans hstf (le_principal_iff.2 (inter_subset_left _ _))) in
-have ∀a, principal t ⊓ nhds a ≠ ⊥ → a ∈ t,
+let ⟨a, hsa, (ha : f ⊓ 𝓝 a ≠ ⊥)⟩ := hs f hnf (le_trans hstf (le_principal_iff.2 (inter_subset_left _ _))) in
+have ∀a, principal t ⊓ 𝓝 a ≠ ⊥ → a ∈ t,
   by intro a; rw [inf_comm]; rw [is_closed_iff_nhds] at ht; exact ht a,
 have a ∈ t,
   from this a $ neq_bot_of_le_neq_bot ha $ inf_le_inf (le_trans hstf (le_principal_iff.2 (inter_subset_right _ _))) (le_refl _),
@@ -39,32 +39,32 @@ lemma compact_of_is_closed_subset {s t : set α}
 by convert ← compact_inter hs ht; exact inter_eq_self_of_subset_right h
 
 lemma compact_adherence_nhdset {s t : set α} {f : filter α}
-  (hs : compact s) (hf₂ : f ≤ principal s) (ht₁ : is_open t) (ht₂ : ∀a∈s, nhds a ⊓ f ≠ ⊥ → a ∈ t) :
+  (hs : compact s) (hf₂ : f ≤ principal s) (ht₁ : is_open t) (ht₂ : ∀a∈s, 𝓝 a ⊓ f ≠ ⊥ → a ∈ t) :
   t ∈ f :=
 classical.by_cases mem_sets_of_neq_bot $
   assume : f ⊓ principal (- t) ≠ ⊥,
-  let ⟨a, ha, (hfa : f ⊓ principal (-t) ⊓ nhds a ≠ ⊥)⟩ := hs _ this $ inf_le_left_of_le hf₂ in
+  let ⟨a, ha, (hfa : f ⊓ principal (-t) ⊓ 𝓝 a ≠ ⊥)⟩ := hs _ this $ inf_le_left_of_le hf₂ in
   have a ∈ t,
     from ht₂ a ha $ neq_bot_of_le_neq_bot hfa $ le_inf inf_le_right $ inf_le_left_of_le inf_le_left,
-  have nhds a ⊓ principal (-t) ≠ ⊥,
+  have 𝓝 a ⊓ principal (-t) ≠ ⊥,
     from neq_bot_of_le_neq_bot hfa $ le_inf inf_le_right $ inf_le_left_of_le inf_le_right,
-  have ∀s∈(nhds a ⊓ principal (-t)).sets, s ≠ ∅,
+  have ∀s∈(𝓝 a ⊓ principal (-t)).sets, s ≠ ∅,
     from forall_sets_neq_empty_iff_neq_bot.mpr this,
   have false,
     from this _ ⟨t, mem_nhds_sets ht₁ ‹a ∈ t›, -t, subset.refl _, subset.refl _⟩ (inter_compl_self _),
   by contradiction
 
 lemma compact_iff_ultrafilter_le_nhds {s : set α} :
-  compact s ↔ (∀f, is_ultrafilter f → f ≤ principal s → ∃a∈s, f ≤ nhds a) :=
+  compact s ↔ (∀f, is_ultrafilter f → f ≤ principal s → ∃a∈s, f ≤ 𝓝 a) :=
 ⟨assume hs : compact s, assume f hf hfs,
   let ⟨a, ha, h⟩ := hs _ hf.left hfs in
   ⟨a, ha, le_of_ultrafilter hf h⟩,
 
-  assume hs : (∀f, is_ultrafilter f → f ≤ principal s → ∃a∈s, f ≤ nhds a),
+  assume hs : (∀f, is_ultrafilter f → f ≤ principal s → ∃a∈s, f ≤ 𝓝 a),
   assume f hf hfs,
-  let ⟨a, ha, (h : ultrafilter_of f ≤ nhds a)⟩ :=
+  let ⟨a, ha, (h : ultrafilter_of f ≤ 𝓝 a)⟩ :=
     hs (ultrafilter_of f) (ultrafilter_ultrafilter_of hf) (le_trans ultrafilter_of_le hfs) in
-  have ultrafilter_of f ⊓ nhds a ≠ ⊥,
+  have ultrafilter_of f ⊓ 𝓝 a ≠ ⊥,
     by simp only [inf_of_le_left, h]; exact (ultrafilter_ultrafilter_of hf).left,
   ⟨a, ha, neq_bot_of_le_neq_bot this (inf_le_inf ultrafilter_of_le (le_refl _))⟩⟩
 
@@ -86,7 +86,7 @@ classical.by_contradiction $ assume h,
   have f ≤ principal s, from infi_le_of_le ⟨∅, empty_subset _, finite_empty⟩ $
     show principal (s \ ⋃₀∅) ≤ principal s, from le_principal_iff.2 (diff_subset _ _),
   let
-    ⟨a, ha, (h : f ⊓ nhds a ≠ ⊥)⟩ := hs f ‹f ≠ ⊥› this,
+    ⟨a, ha, (h : f ⊓ 𝓝 a ≠ ⊥)⟩ := hs f ‹f ≠ ⊥› this,
     ⟨t, ht₁, (ht₂ : a ∈ t)⟩ := hc₂ ha
   in
   have f ≤ principal (-t),
@@ -123,16 +123,16 @@ section
 local attribute [instance, priority 1000] classical.prop_decidable
 lemma compact_of_finite_subcover {s : set α}
   (h : ∀c, (∀t∈c, is_open t) → s ⊆ ⋃₀ c → ∃c'⊆c, finite c' ∧ s ⊆ ⋃₀ c') : compact s :=
-assume f hfn hfs, classical.by_contradiction $ assume : ¬ (∃x∈s, f ⊓ nhds x ≠ ⊥),
-  have hf : ∀x∈s, nhds x ⊓ f = ⊥,
+assume f hfn hfs, classical.by_contradiction $ assume : ¬ (∃x∈s, f ⊓ 𝓝 x ≠ ⊥),
+  have hf : ∀x∈s, 𝓝 x ⊓ f = ⊥,
     by simpa only [not_exists, not_not, inf_comm],
   have ¬ ∃x∈s, ∀t∈f.sets, x ∈ closure t,
     from assume ⟨x, hxs, hx⟩,
-    have ∅ ∈ nhds x ⊓ f, by rw [empty_in_sets_eq_bot, hf x hxs],
+    have ∅ ∈ 𝓝 x ⊓ f, by rw [empty_in_sets_eq_bot, hf x hxs],
     let ⟨t₁, ht₁, t₂, ht₂, ht⟩ := by rw [mem_inf_sets] at this; exact this in
-    have ∅ ∈ nhds x ⊓ principal t₂,
-      from (nhds x ⊓ principal t₂).sets_of_superset (inter_mem_inf_sets ht₁ (subset.refl t₂)) ht,
-    have nhds x ⊓ principal t₂ = ⊥,
+    have ∅ ∈ 𝓝 x ⊓ principal t₂,
+      from (𝓝 x ⊓ principal t₂).sets_of_superset (inter_mem_inf_sets ht₁ (subset.refl t₂)) ht,
+    have 𝓝 x ⊓ principal t₂ = ⊥,
       by rwa [empty_in_sets_eq_bot] at this,
     by simp only [closure_eq_nhds] at hx; exact hx t₂ ht₂ this,
   have ∀x∈s, ∃t∈f.sets, x ∉ closure t, by simpa only [not_exists, not_forall],
@@ -355,7 +355,7 @@ begin
   simp [compact_iff_ultrafilter_le_nhds, nhds_pi],
   exact assume h f hf hfs,
     let p : Πi:ι, filter (π i) := λi, map (λx:Πi:ι, π i, x i) f in
-    have ∀i:ι, ∃a, a∈s i ∧ p i ≤ nhds a,
+    have ∀i:ι, ∃a, a∈s i ∧ p i ≤ 𝓝 a,
       from assume i, h i (p i) (ultrafilter_map hf) $
       show (λx:Πi:ι, π i, x i) ⁻¹' s i ∈ f.sets,
         from mem_sets_of_superset hfs $ assume x (hx : ∀i, x i ∈ s i), hx i,
@@ -391,7 +391,7 @@ Hausdorff spaces but not in general. This one is the precise condition on X need
 evaluation `map C(X, Y) × X → Y` to be continuous for all `Y` when `C(X, Y)` is given the
 compact-open topology. -/
 class locally_compact_space (α : Type*) [topological_space α] : Prop :=
-(local_compact_nhds : ∀ (x : α) (n ∈ nhds x), ∃ s ∈ nhds x, s ⊆ n ∧ compact s)
+(local_compact_nhds : ∀ (x : α) (n ∈ 𝓝 x), ∃ s ∈ 𝓝 x, s ⊆ n ∧ compact s)
 
 end compact
 

--- a/src/topology/topological_fiber_bundle.lean
+++ b/src/topology/topological_fiber_bundle.lean
@@ -106,6 +106,7 @@ Fiber bundle, topological bundle, vector bundle, local trivialization, structure
 variables {ι : Type*} {B : Type*} {F : Type*}
 
 open topological_space set
+open_locale topological_space
 
 section topological_fiber_bundle
 
@@ -148,7 +149,7 @@ begin
   /- Take a small enough open neighborhood u of `proj x`, contained in a trivialization domain o.
     One should show that its preimage is open. -/
   suffices : is_open (proj ⁻¹' u),
-  { have : proj ⁻¹' u ∈ nhds x := mem_nhds_sets this xu,
+  { have : proj ⁻¹' u ∈ 𝓝 x := mem_nhds_sets this xu,
     apply filter.mem_sets_of_superset this,
     exact preimage_mono (subset.trans (inter_subset_right _ _) st) },
   -- to do this, rewrite `proj ⁻¹' u` in terms of the trivialization, and use its continuity.

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -27,7 +27,7 @@ A major difference is that this formalization is heavily based on the filter lib
 import order.filter.basic order.filter.lift topology.separation
 
 open set lattice filter classical
-open_locale classical
+open_locale classical topological_space
 
 set_option eqn_compiler.zeta true
 
@@ -240,7 +240,7 @@ calc (𝓤 α).lift' (λd, comp_rel d (comp_rel d d)) =
   ... ≤ (𝓤 α) : comp_le_uniformity
 
 lemma mem_nhds_uniformity_iff {x : α} {s : set α} :
-  s ∈ nhds x ↔ {p : α × α | p.1 = x → p.2 ∈ s} ∈ 𝓤 α :=
+  s ∈ 𝓝 x ↔ {p : α × α | p.1 = x → p.2 ∈ s} ∈ 𝓤 α :=
 ⟨ begin
     simp only [mem_nhds_sets_iff, is_open_uniformity, and_imp, exists_imp_distrib],
     exact assume t ts ht xt, by filter_upwards [ht x xt] assume ⟨x', y⟩ h eq, ts $ h eq
@@ -260,13 +260,13 @@ lemma mem_nhds_uniformity_iff {x : α} {s : set α} :
         from tr this rfl,
     hs⟩⟩
 
-lemma nhds_eq_comap_uniformity {x : α} : nhds x = (𝓤 α).comap (prod.mk x) :=
+lemma nhds_eq_comap_uniformity {x : α} : 𝓝 x = (𝓤 α).comap (prod.mk x) :=
 by ext s; rw [mem_nhds_uniformity_iff, mem_comap_sets]; from iff.intro
   (assume hs, ⟨_, hs, assume x hx, hx rfl⟩)
   (assume ⟨t, h, ht⟩, (𝓤 α).sets_of_superset h $
     assume ⟨p₁, p₂⟩ hp (h : p₁ = x), ht $ by simp [h.symm, hp])
 
-lemma nhds_eq_uniformity {x : α} : nhds x = (𝓤 α).lift' (λs:set (α×α), {y | (x, y) ∈ s}) :=
+lemma nhds_eq_uniformity {x : α} : 𝓝 x = (𝓤 α).lift' (λs:set (α×α), {y | (x, y) ∈ s}) :=
 begin
   ext s,
   rw [mem_lift'_sets], tactic.swap, apply monotone_preimage,
@@ -279,23 +279,23 @@ begin
 end
 
 lemma mem_nhds_left (x : α) {s : set (α×α)} (h : s ∈ 𝓤 α) :
-  {y : α | (x, y) ∈ s} ∈ nhds x :=
-have nhds x ≤ principal {y : α | (x, y) ∈ s},
+  {y : α | (x, y) ∈ s} ∈ 𝓝 x :=
+have 𝓝 x ≤ principal {y : α | (x, y) ∈ s},
   by rw [nhds_eq_uniformity]; exact infi_le_of_le s (infi_le _ h),
 by simp at this; assumption
 
 lemma mem_nhds_right (y : α) {s : set (α×α)} (h : s ∈ 𝓤 α) :
-  {x : α | (x, y) ∈ s} ∈ nhds y :=
+  {x : α | (x, y) ∈ s} ∈ 𝓝 y :=
 mem_nhds_left _ (symm_le_uniformity h)
 
-lemma tendsto_right_nhds_uniformity {a : α} : tendsto (λa', (a', a)) (nhds a) (𝓤 α) :=
+lemma tendsto_right_nhds_uniformity {a : α} : tendsto (λa', (a', a)) (𝓝 a) (𝓤 α) :=
 assume s, mem_nhds_right a
 
-lemma tendsto_left_nhds_uniformity {a : α} : tendsto (λa', (a, a')) (nhds a) (𝓤 α) :=
+lemma tendsto_left_nhds_uniformity {a : α} : tendsto (λa', (a, a')) (𝓝 a) (𝓤 α) :=
 assume s, mem_nhds_left a
 
 lemma lift_nhds_left {x : α} {g : set α → filter β} (hg : monotone g) :
-  (nhds x).lift g = (𝓤 α).lift (λs:set (α×α), g {y | (x, y) ∈ s}) :=
+  (𝓝 x).lift g = (𝓤 α).lift (λs:set (α×α), g {y | (x, y) ∈ s}) :=
 eq.trans
   begin
     rw [nhds_eq_uniformity],
@@ -304,20 +304,20 @@ eq.trans
   (congr_arg _ $ funext $ assume s, filter.lift_principal hg)
 
 lemma lift_nhds_right {x : α} {g : set α → filter β} (hg : monotone g) :
-  (nhds x).lift g = (𝓤 α).lift (λs:set (α×α), g {y | (y, x) ∈ s}) :=
-calc (nhds x).lift g = (𝓤 α).lift (λs:set (α×α), g {y | (x, y) ∈ s}) : lift_nhds_left hg
+  (𝓝 x).lift g = (𝓤 α).lift (λs:set (α×α), g {y | (y, x) ∈ s}) :=
+calc (𝓝 x).lift g = (𝓤 α).lift (λs:set (α×α), g {y | (x, y) ∈ s}) : lift_nhds_left hg
   ... = ((@prod.swap α α) <$> (𝓤 α)).lift (λs:set (α×α), g {y | (x, y) ∈ s}) : by rw [←uniformity_eq_symm]
   ... = (𝓤 α).lift (λs:set (α×α), g {y | (x, y) ∈ image prod.swap s}) :
     map_lift_eq2 $ hg.comp monotone_preimage
   ... = _ : by simp [image_swap_eq_preimage_swap]
 
 lemma nhds_nhds_eq_uniformity_uniformity_prod {a b : α} :
-  filter.prod (nhds a) (nhds b) =
+  filter.prod (𝓝 a) (𝓝 b) =
   (𝓤 α).lift (λs:set (α×α), (𝓤 α).lift' (λt:set (α×α),
     set.prod {y : α | (y, a) ∈ s} {y : α | (b, y) ∈ t})) :=
 begin
   rw [prod_def],
-  show (nhds a).lift (λs:set α, (nhds b).lift (λt:set α, principal (set.prod s t))) = _,
+  show (𝓝 a).lift (λs:set α, (𝓝 b).lift (λt:set α, principal (set.prod s t))) = _,
   rw [lift_nhds_right],
   apply congr_arg, funext s,
   rw [lift_nhds_left],
@@ -328,7 +328,7 @@ begin
 end
 
 lemma nhds_eq_uniformity_prod {a b : α} :
-  nhds (a, b) =
+  𝓝 (a, b) =
   (𝓤 α).lift' (λs:set (α×α), set.prod {y : α | (y, a) ∈ s} {y : α | (b, y) ∈ s}) :=
 begin
   rw [nhds_prod_eq, nhds_nhds_eq_uniformity_uniformity_prod, lift_lift'_same_eq_lift'],
@@ -341,7 +341,7 @@ lemma nhdset_of_mem_uniformity {d : set (α×α)} (s : set (α×α)) (hd : d ∈
 let cl_d := {p:α×α | ∃x y, (p.1, x) ∈ d ∧ (x, y) ∈ s ∧ (y, p.2) ∈ d} in
 have ∀p ∈ s, ∃t ⊆ cl_d, is_open t ∧ p ∈ t, from
   assume ⟨x, y⟩ hp, mem_nhds_sets_iff.mp $
-  show cl_d ∈ nhds (x, y),
+  show cl_d ∈ 𝓝 (x, y),
   begin
     rw [nhds_eq_uniformity_prod, mem_lift'_sets],
     exact ⟨d, hd, assume ⟨a, b⟩ ⟨ha, hb⟩, ⟨x, y, ha, hp, hb⟩⟩,
@@ -361,7 +361,7 @@ end
 lemma closure_eq_inter_uniformity {t : set (α×α)} :
   closure t = (⋂ d ∈ 𝓤 α, comp_rel d (comp_rel t d)) :=
 set.ext $ assume ⟨a, b⟩,
-calc (a, b) ∈ closure t ↔ (nhds (a, b) ⊓ principal t ≠ ⊥) : by simp [closure_eq_nhds]
+calc (a, b) ∈ closure t ↔ (𝓝 (a, b) ⊓ principal t ≠ ⊥) : by simp [closure_eq_nhds]
   ... ↔ (((@prod.swap α α) <$> 𝓤 α).lift'
       (λ (s : set (α × α)), set.prod {x : α | (x, a) ∈ s} {y : α | (b, y) ∈ s}) ⊓ principal t ≠ ⊥) :
     by rw [←uniformity_eq_symm, nhds_eq_uniformity_prod]
@@ -658,8 +658,8 @@ uniform_continuous_comap' hf
 
 lemma tendsto_of_uniform_continuous_subtype
   [uniform_space α] [uniform_space β] {f : α → β} {s : set α} {a : α}
-  (hf : uniform_continuous (λx:s, f x.val)) (ha : s ∈ nhds a) :
-  tendsto f (nhds a) (nhds (f a)) :=
+  (hf : uniform_continuous (λx:s, f x.val)) (ha : s ∈ 𝓝 a) :
+  tendsto f (𝓝 a) (𝓝 (f a)) :=
 by rw [(@map_nhds_subtype_val_eq α _ s a (mem_of_nhds ha) ha).symm]; exact
 tendsto_map' (continuous_iff_continuous_at.mp hf.continuous _)
 

--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -12,7 +12,7 @@ open_locale classical
 variables {α : Type*} {β : Type*} [uniform_space α]
 universe u
 
-open_locale uniformity
+open_locale uniformity topological_space
 
 /-- A filter `f` is Cauchy if for every entourage `r`, there exists an
   `s ∈ f` such that `s × s ⊆ r`. This is a generalization of Cauchy
@@ -20,7 +20,7 @@ open_locale uniformity
   cofinitely many of the `a n` is Cauchy iff `a` is a Cauchy sequence. -/
 def cauchy (f : filter α) := f ≠ ⊥ ∧ filter.prod f f ≤ (𝓤 α)
 
-def is_complete (s : set α) := ∀f, cauchy f → f ≤ principal s → ∃x∈s, f ≤ nhds x
+def is_complete (s : set α) := ∀f, cauchy f → f ≤ principal s → ∃x∈s, f ≤ 𝓝 x
 
 lemma cauchy_iff {f : filter α} :
   cauchy f ↔ (f ≠ ⊥ ∧ (∀ s ∈ 𝓤 α, ∃t∈f.sets, set.prod t t ⊆ s)) :=
@@ -33,9 +33,9 @@ by rw [cauchy, (≠), map_eq_bot_iff, prod_map_map_eq]; refl
 lemma cauchy_downwards {f g : filter α} (h_c : cauchy f) (hg : g ≠ ⊥) (h_le : g ≤ f) : cauchy g :=
 ⟨hg, le_trans (filter.prod_mono h_le h_le) h_c.right⟩
 
-lemma cauchy_nhds {a : α} : cauchy (nhds a) :=
+lemma cauchy_nhds {a : α} : cauchy (𝓝 a) :=
 ⟨nhds_neq_bot,
-  calc filter.prod (nhds a) (nhds a) =
+  calc filter.prod (𝓝 a) (𝓝 a) =
     (𝓤 α).lift (λs:set (α×α), (𝓤 α).lift' (λt:set(α×α),
       set.prod {y : α | (y, a) ∈ s} {y : α | (a, y) ∈ t})) : nhds_nhds_eq_uniformity_uniformity_prod
     ... ≤ (𝓤 α).lift' (λs:set (α×α), comp_rel s s) :
@@ -51,7 +51,7 @@ cauchy_downwards cauchy_nhds
   (pure_le_nhds a)
 
 lemma le_nhds_of_cauchy_adhp {f : filter α} {x : α} (hf : cauchy f)
-  (adhs : f ⊓ nhds x ≠ ⊥) : f ≤ nhds x :=
+  (adhs : f ⊓ 𝓝 x ≠ ⊥) : f ≤ 𝓝 x :=
 have ∀s∈f.sets, x ∈ closure s,
 begin
   intros s hs,
@@ -83,11 +83,11 @@ calc f ≤ f.lift' (λs:set α, {y | x ∈ closure s ∧ y ∈ closure s}) :
   end
   ... = (𝓤 α).lift' (λs:set (α×α), {y | (x, y) ∈ s}) :
     by rw [←uniformity_eq_uniformity_closure]
-  ... = nhds x :
+  ... = 𝓝 x :
     by rw [nhds_eq_uniformity]
 
 lemma le_nhds_iff_adhp_of_cauchy {f : filter α} {x : α} (hf : cauchy f) :
-  f ≤ nhds x ↔ f ⊓ nhds x ≠ ⊥ :=
+  f ≤ 𝓝 x ↔ f ⊓ 𝓝 x ≠ ⊥ :=
 ⟨assume h, (inf_of_le_left h).symm ▸ hf.left,
 le_nhds_of_cauchy_adhp hf⟩
 
@@ -120,7 +120,7 @@ iff.trans (and_iff_right (map_ne_bot at_top_ne_bot)) (prod_map_at_top_eq u u ▸
 /-- A complete space is defined here using uniformities. A uniform space
   is complete if every Cauchy filter converges. -/
 class complete_space (α : Type u) [uniform_space α] : Prop :=
-(complete : ∀{f:filter α}, cauchy f → ∃x, f ≤ nhds x)
+(complete : ∀{f:filter α}, cauchy f → ∃x, f ≤ 𝓝 x)
 
 lemma complete_univ {α : Type u} [uniform_space α] [complete_space α] :
   is_complete (univ : set α) :=
@@ -155,26 +155,26 @@ lemma complete_space_of_is_complete_univ (h : is_complete (univ : set α)) : com
 ⟨λ f hf, let ⟨x, _, hx⟩ := h f hf ((@principal_univ α).symm ▸ le_top) in ⟨x, hx⟩⟩
 
 lemma cauchy_iff_exists_le_nhds [complete_space α] {l : filter α} (hl : l ≠ ⊥) :
-  cauchy l ↔ (∃x, l ≤ nhds x) :=
+  cauchy l ↔ (∃x, l ≤ 𝓝 x) :=
 ⟨complete_space.complete, assume ⟨x, hx⟩, cauchy_downwards cauchy_nhds hl hx⟩
 
 lemma cauchy_map_iff_exists_tendsto [complete_space α] {l : filter β} {f : β → α}
-  (hl : l ≠ ⊥) : cauchy (l.map f) ↔ (∃x, tendsto f l (nhds x)) :=
+  (hl : l ≠ ⊥) : cauchy (l.map f) ↔ (∃x, tendsto f l (𝓝 x)) :=
 cauchy_iff_exists_le_nhds (map_ne_bot hl)
 
 /-- A Cauchy sequence in a complete space converges -/
 theorem cauchy_seq_tendsto_of_complete [semilattice_sup β] [complete_space α]
-  {u : β → α} (H : cauchy_seq u) : ∃x, tendsto u at_top (nhds x) :=
+  {u : β → α} (H : cauchy_seq u) : ∃x, tendsto u at_top (𝓝 x) :=
 complete_space.complete H
 
 /-- If `K` is a complete subset, then any cauchy sequence in `K` converges to a point in `K` -/
 lemma cauchy_seq_tendsto_of_is_complete [semilattice_sup β] {K : set α} (h₁ : is_complete K)
-  {u : β → α} (h₂ : ∀ n, u n ∈ K) (h₃ : cauchy_seq u) : ∃ v ∈ K, tendsto u at_top (nhds v) :=
+  {u : β → α} (h₂ : ∀ n, u n ∈ K) (h₃ : cauchy_seq u) : ∃ v ∈ K, tendsto u at_top (𝓝 v) :=
 h₁ _ h₃ $ le_principal_iff.2 $ mem_map_sets_iff.2 ⟨univ, univ_mem_sets,
   by { simp only [image_univ], rintros _ ⟨n, rfl⟩, exact h₂ n }⟩
 
 theorem le_nhds_lim_of_cauchy {α} [uniform_space α] [complete_space α]
-  [inhabited α] {f : filter α} (hf : cauchy f) : f ≤ nhds (lim f) :=
+  [inhabited α] {f : filter α} (hf : cauchy f) : f ≤ 𝓝 (lim f) :=
 lim_spec (complete_space.complete hf)
 
 lemma is_complete_of_is_closed [complete_space α] {s : set α}

--- a/src/topology/uniform_space/complete_separated.lean
+++ b/src/topology/uniform_space/complete_separated.lean
@@ -11,13 +11,15 @@ import topology.uniform_space.cauchy topology.uniform_space.separation
 import topology.dense_embedding
 
 open filter
+open_locale topological_space
+
 variables {α : Type*}
 
 /-In a separated space, a complete set is closed -/
 lemma is_closed_of_is_complete  [uniform_space α] [separated α] {s : set α} (h : is_complete s) :
   is_closed s :=
 is_closed_iff_nhds.2 $ λ a ha, begin
-  let f := nhds a ⊓ principal s,
+  let f := 𝓝 a ⊓ principal s,
   have : cauchy f := cauchy_downwards (cauchy_nhds) ha (lattice.inf_le_left),
   rcases h f this (lattice.inf_le_right) with ⟨y, ys, fy⟩,
   rwa (tendsto_nhds_unique ha lattice.inf_le_left fy : a = y)
@@ -29,7 +31,7 @@ variables [topological_space α] {β : Type*} [topological_space β]
 variables {γ : Type*} [uniform_space γ] [complete_space γ] [separated γ]
 
 lemma continuous_extend_of_cauchy {e : α → β} {f : α → γ}
-  (de : dense_inducing e) (h : ∀ b : β, cauchy (map f (comap e $ nhds b))) :
+  (de : dense_inducing e) (h : ∀ b : β, cauchy (map f (comap e $ 𝓝 b))) :
   continuous (de.extend f) :=
 de.continuous_extend $ λ b, complete_space.complete (h b)
 

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -41,7 +41,7 @@ noncomputable theory
 open filter set
 universes u v w x
 
-open_locale uniformity classical
+open_locale uniformity classical topological_space
 
 /-- Space of Cauchy filters
 
@@ -317,10 +317,10 @@ instance complete_space_separation [h : complete_space α] :
   have cauchy (f.comap (λx, ⟦x⟧)), from
     cauchy_comap comap_quotient_le_uniformity hf $
       comap_neq_bot_of_surj hf.left $ assume b, quotient.exists_rep _,
-  let ⟨x, (hx : f.comap (λx, ⟦x⟧) ≤ nhds x)⟩ := complete_space.complete this in
+  let ⟨x, (hx : f.comap (λx, ⟦x⟧) ≤ 𝓝 x)⟩ := complete_space.complete this in
   ⟨⟦x⟧, calc f = map (λx, ⟦x⟧) (f.comap (λx, ⟦x⟧)) :
       (map_comap $ univ_mem_sets' $ assume b, quotient.exists_rep _).symm
-    ... ≤ map (λx, ⟦x⟧) (nhds x) : map_mono hx
+    ... ≤ map (λx, ⟦x⟧) (𝓝 x) : map_mono hx
     ... ≤ _ : continuous_iff_continuous_at.mp uniform_continuous_quotient_mk.continuous _⟩⟩
 
 

--- a/src/topology/uniform_space/pi.lean
+++ b/src/topology/uniform_space/pi.lean
@@ -10,7 +10,7 @@ import topology.uniform_space.cauchy
 import topology.uniform_space.separation
 noncomputable theory
 
-open_locale uniformity
+open_locale uniformity topological_space
 
 section
 open filter lattice uniform_space
@@ -39,14 +39,14 @@ lemma Pi.uniform_space_topology :
 instance Pi.complete [∀ i, complete_space (α i)] : complete_space (Π i, α i) :=
 ⟨begin
   intros f hf,
-  have : ∀ i, ∃ x : α i, filter.map (λ a : Πi, α i, a i) f ≤ nhds x,
+  have : ∀ i, ∃ x : α i, filter.map (λ a : Πi, α i, a i) f ≤ 𝓝 x,
   { intro i,
     have key : cauchy (map (λ (a : Π (i : ι), α i), a i) f),
       from cauchy_map (Pi.uniform_continuous_proj α i) hf,
     exact (cauchy_iff_exists_le_nhds $ map_ne_bot hf.1).1 key },
   choose x hx using this,
   use x,
-  rw [show nhds x = (⨅i, comap (λa, a i) (nhds (x i))),
+  rw [show 𝓝 x = (⨅i, comap (λa, a i) (𝓝 (x i))),
         by rw Pi.uniform_space_topology ; exact nhds_pi,
       le_infi_iff],
   exact λ i, map_le_iff_le_comap.mp (hx i),

--- a/src/topology/uniform_space/separation.lean
+++ b/src/topology/uniform_space/separation.lean
@@ -8,7 +8,7 @@ Hausdorff properties of uniform spaces. Separation quotient.
 import topology.uniform_space.basic
 
 open filter topological_space lattice set classical
-open_locale classical
+open_locale classical topological_space
 noncomputable theory
 set_option eqn_compiler.zeta true
 
@@ -55,10 +55,10 @@ instance separated_t2 [s : separated α] : t2_space α :=
 ⟨assume x y, assume h : x ≠ y,
 let ⟨d, hd, (hxy : (x, y) ∉ d)⟩ := separated_def'.1 s x y h in
 let ⟨d', hd', (hd'd' : comp_rel d' d' ⊆ d)⟩ := comp_mem_uniformity_sets hd in
-have {y | (x, y) ∈ d'} ∈ nhds x,
+have {y | (x, y) ∈ d'} ∈ 𝓝 x,
   from mem_nhds_left x hd',
 let ⟨u, hu₁, hu₂, hu₃⟩ := mem_nhds_sets_iff.mp this in
-have {x | (x, y) ∈ d'} ∈ nhds y,
+have {x | (x, y) ∈ d'} ∈ 𝓝 y,
   from mem_nhds_right y hd',
 let ⟨v, hv₁, hv₂, hv₃⟩ := mem_nhds_sets_iff.mp this in
 have u ∩ v = ∅, from
@@ -70,7 +70,7 @@ have u ∩ v = ∅, from
 
 instance separated_regular [separated α] : regular_space α :=
 { regular := λs a hs ha,
-    have -s ∈ nhds a,
+    have -s ∈ 𝓝 a,
       from mem_nhds_sets hs ha,
     have {p : α × α | p.1 = a → p.2 ∈ -s} ∈ 𝓤 α,
       from mem_nhds_uniformity_iff.mp this,
@@ -88,8 +88,8 @@ instance separated_regular [separated α] : regular_space α :=
         let ⟨x, (hx : (a, x) ∈ d), y, ⟨hx₁, hx₂⟩, (hy : (y, _) ∈ d)⟩ := @this ⟨a, a'⟩ ⟨hae, ha'⟩ in
         have (a, a') ∈ comp_rel d d, from ⟨y, hx₂, hy⟩,
         h this rfl,
-    have closure e ∈ nhds a, from (nhds a).sets_of_superset (mem_nhds_left a hd) subset_closure,
-    have nhds a ⊓ principal (-closure e) = ⊥,
+    have closure e ∈ 𝓝 a, from (𝓝 a).sets_of_superset (mem_nhds_left a hd) subset_closure,
+    have 𝓝 a ⊓ principal (-closure e) = ⊥,
       from (@inf_eq_bot_iff_le_compl _ _ _ (principal (- closure e)) (principal (closure e))
         (by simp [principal_univ, union_comm]) (by simp)).mpr (by simp [this]),
     ⟨- closure e, is_closed_closure, assume x h₁ h₂, @e_subset x h₂ h₁, this⟩,

--- a/src/topology/uniform_space/uniform_embedding.lean
+++ b/src/topology/uniform_space/uniform_embedding.lean
@@ -10,7 +10,7 @@ import topology.dense_embedding
 
 open filter topological_space lattice set classical
 open_locale classical
-open_locale uniformity
+open_locale uniformity topological_space
 
 section
 variables {α : Type*} {β : Type*} {γ : Type*}
@@ -101,20 +101,20 @@ lemma uniform_embedding.dense_embedding {f : α → β} (h : uniform_embedding f
 lemma closure_image_mem_nhds_of_uniform_inducing
   {s : set (α×α)} {e : α → β} (b : β)
   (he₁ : uniform_inducing e) (he₂ : dense_inducing e) (hs : s ∈ 𝓤 α) :
-  ∃a, closure (e '' {a' | (a, a') ∈ s}) ∈ nhds b :=
+  ∃a, closure (e '' {a' | (a, a') ∈ s}) ∈ 𝓝 b :=
 have s ∈ comap (λp:α×α, (e p.1, e p.2)) (𝓤 β),
   from he₁.comap_uniformity.symm ▸ hs,
 let ⟨t₁, ht₁u, ht₁⟩ := this in
 have ht₁ : ∀p:α×α, (e p.1, e p.2) ∈ t₁ → p ∈ s, from ht₁,
 let ⟨t₂, ht₂u, ht₂s, ht₂c⟩ := comp_symm_of_uniformity ht₁u in
 let ⟨t, htu, hts, htc⟩ := comp_symm_of_uniformity ht₂u in
-have preimage e {b' | (b, b') ∈ t₂} ∈ comap e (nhds b),
+have preimage e {b' | (b, b') ∈ t₂} ∈ comap e (𝓝 b),
   from preimage_mem_comap $ mem_nhds_left b ht₂u,
 let ⟨a, (ha : (b, e a) ∈ t₂)⟩ := inhabited_of_mem_sets (he₂.comap_nhds_neq_bot) this in
 have ∀b' (s' : set (β × β)), (b, b') ∈ t → s' ∈ 𝓤 β →
   {y : β | (b', y) ∈ s'} ∩ e '' {a' : α | (a, a') ∈ s} ≠ ∅,
   from assume b' s' hb' hs',
-  have preimage e {b'' | (b', b'') ∈ s' ∩ t} ∈ comap e (nhds b'),
+  have preimage e {b'' | (b', b'') ∈ s' ∩ t} ∈ comap e (𝓝 b'),
     from preimage_mem_comap $ mem_nhds_left b' $ inter_mem_sets hs' htu,
   let ⟨a₂, ha₂s', ha₂t⟩ := inhabited_of_mem_sets (he₂.comap_nhds_neq_bot) this in
   have (e a, e a₂) ∈ t₁,
@@ -122,7 +122,7 @@ have ∀b' (s' : set (β × β)), (b, b') ∈ t → s' ∈ 𝓤 β →
   have e a₂ ∈ {b'':β | (b', b'') ∈ s'} ∩ e '' {a' | (a, a') ∈ s},
     from ⟨ha₂s', mem_image_of_mem _ $ ht₁ (a, a₂) this⟩,
   ne_empty_of_mem this,
-have ∀b', (b, b') ∈ t → nhds b' ⊓ principal (e '' {a' | (a, a') ∈ s}) ≠ ⊥,
+have ∀b', (b, b') ∈ t → 𝓝 b' ⊓ principal (e '' {a' | (a, a') ∈ s}) ≠ ⊥,
 begin
   intros b' hb',
   rw [nhds_eq_uniformity, lift'_inf_principal_eq, lift'_neq_bot_iff],
@@ -131,7 +131,7 @@ begin
 end,
 have ∀b', (b, b') ∈ t → b' ∈ closure (e '' {a' | (a, a') ∈ s}),
   from assume b' hb', by rw [closure_eq_nhds]; exact this b' hb',
-⟨a, (nhds b).sets_of_superset (mem_nhds_left b htu) this⟩
+⟨a, (𝓝 b).sets_of_superset (mem_nhds_left b htu) this⟩
 
 lemma uniform_embedding_subtype_emb (p : α → Prop) {e : α → β} (ue : uniform_embedding e)
   (de : dense_embedding e) : uniform_embedding (dense_embedding.subtype_emb p e) :=
@@ -181,12 +181,12 @@ begin
     existsi [m x, mem_image_of_mem m xs],
     rw [(uniform_embedding.embedding hm).induced, nhds_induced] at hx,
     calc f = map m f' : (map_comap $ filter.mem_sets_of_superset fs $ image_subset_range _ _).symm
-      ... ≤ map m (comap m (nhds (m x))) : map_mono hx
-      ... ≤ nhds (m x) : map_comap_le }
+      ... ≤ map m (comap m (𝓝 (m x))) : map_mono hx
+      ... ≤ 𝓝 (m x) : map_comap_le }
 end
 
 lemma complete_space_extension {m : β → α} (hm : uniform_inducing m) (dense : dense_range m)
-  (h : ∀f:filter β, cauchy f → ∃x:α, map m f ≤ nhds x) : complete_space α :=
+  (h : ∀f:filter β, cauchy f → ∃x:α, map m f ≤ 𝓝 x) : complete_space α :=
 ⟨assume (f : filter α), assume hf : cauchy f,
 let
   p : set (α × α) → set α → set α := λs t, {y : α| ∃x:α, x ∈ t ∧ (x, y) ∈ s},
@@ -208,14 +208,14 @@ have comap m g ≠ ⊥, from comap_neq_bot $ assume t ht,
   let ⟨t', ht', ht_mem⟩ := (mem_lift_sets $ monotone_lift' monotone_const mp₀).mp ht in
   let ⟨t'', ht'', ht'_sub⟩ := (mem_lift'_sets mp₁).mp ht_mem in
   let ⟨x, (hx : x ∈ t'')⟩ := inhabited_of_mem_sets hf.left ht'' in
-  have h₀ : nhds x ⊓ principal (range m) ≠ ⊥,
+  have h₀ : 𝓝 x ⊓ principal (range m) ≠ ⊥,
     by simpa [dense_range, closure_eq_nhds] using dense x,
-  have h₁ : {y | (x, y) ∈ t'} ∈ nhds x ⊓ principal (range m),
-    from @mem_inf_sets_of_left α (nhds x) (principal (range m)) _ $ mem_nhds_left x ht',
-  have h₂ : range m ∈ nhds x ⊓ principal (range m),
-    from @mem_inf_sets_of_right α (nhds x) (principal (range m)) _ $ subset.refl _,
-  have {y | (x, y) ∈ t'} ∩ range m ∈ nhds x ⊓ principal (range m),
-    from @inter_mem_sets α (nhds x ⊓ principal (range m)) _ _ h₁ h₂,
+  have h₁ : {y | (x, y) ∈ t'} ∈ 𝓝 x ⊓ principal (range m),
+    from @mem_inf_sets_of_left α (𝓝 x) (principal (range m)) _ $ mem_nhds_left x ht',
+  have h₂ : range m ∈ 𝓝 x ⊓ principal (range m),
+    from @mem_inf_sets_of_right α (𝓝 x) (principal (range m)) _ $ subset.refl _,
+  have {y | (x, y) ∈ t'} ∩ range m ∈ 𝓝 x ⊓ principal (range m),
+    from @inter_mem_sets α (𝓝 x ⊓ principal (range m)) _ _ h₁ h₂,
   let ⟨y, xyt', b, b_eq⟩ := inhabited_of_mem_sets h₀ this in
   ⟨b, b_eq.symm ▸ ht'_sub ⟨x, hx, xyt'⟩⟩,
 
@@ -241,14 +241,14 @@ have cauchy g, from
 have cauchy (filter.comap m g),
   from cauchy_comap (le_of_eq hm.comap_uniformity) ‹cauchy g› (by assumption),
 
-let ⟨x, (hx : map m (filter.comap m g) ≤ nhds x)⟩ := h _ this in
-have map m (filter.comap m g) ⊓ nhds x ≠ ⊥,
+let ⟨x, (hx : map m (filter.comap m g) ≤ 𝓝 x)⟩ := h _ this in
+have map m (filter.comap m g) ⊓ 𝓝 x ≠ ⊥,
   from (le_nhds_iff_adhp_of_cauchy (cauchy_map hm.uniform_continuous this)).mp hx,
-have g ⊓ nhds x ≠ ⊥,
+have g ⊓ 𝓝 x ≠ ⊥,
   from neq_bot_of_le_neq_bot this (inf_le_inf (assume s hs, ⟨s, hs, subset.refl _⟩) (le_refl _)),
 
 ⟨x, calc f ≤ g : by assumption
-  ... ≤ nhds x : le_nhds_of_cauchy_adhp ‹cauchy g› this⟩⟩
+  ... ≤ 𝓝 x : le_nhds_of_cauchy_adhp ‹cauchy g› this⟩⟩
 
 lemma totally_bounded_preimage {f : α → β} {s : set β} (hf : uniform_embedding f)
   (hs : totally_bounded s) : totally_bounded (f ⁻¹' s) :=
@@ -284,12 +284,12 @@ variables {α : Type*} {β : Type*} {γ : Type*}
 local notation `ψ` := (h_e.dense_inducing h_dense).extend f
 
 lemma uniformly_extend_exists [complete_space γ] (a : α) :
-  ∃c, tendsto f (comap e (nhds a)) (nhds c) :=
+  ∃c, tendsto f (comap e (𝓝 a)) (𝓝 c) :=
 let de := (h_e.dense_inducing h_dense) in
-have cauchy (nhds a), from cauchy_nhds,
-have cauchy (comap e (nhds a)), from
+have cauchy (𝓝 a), from cauchy_nhds,
+have cauchy (comap e (𝓝 a)), from
   cauchy_comap (le_of_eq h_e.comap_uniformity) this de.comap_nhds_neq_bot,
-have cauchy (map f (comap e (nhds a))), from
+have cauchy (map f (comap e (𝓝 a))), from
   cauchy_map h_f this,
 complete_space.complete this
 
@@ -297,8 +297,8 @@ lemma uniform_extend_subtype [complete_space γ]
   {p : α → Prop} {e : α → β} {f : α → γ} {b : β} {s : set α}
   (hf : uniform_continuous (λx:subtype p, f x.val))
   (he : uniform_embedding e) (hd : ∀x:β, x ∈ closure (range e))
-  (hb : closure (e '' s) ∈ nhds b) (hs : is_closed s) (hp : ∀x∈s, p x) :
-  ∃c, tendsto f (comap e (nhds b)) (nhds c) :=
+  (hb : closure (e '' s) ∈ 𝓝 b) (hs : is_closed s) (hp : ∀x∈s, p x) :
+  ∃c, tendsto f (comap e (𝓝 b)) (𝓝 c) :=
 have de : dense_embedding e,
   from he.dense_embedding hd,
 have de' : dense_embedding (dense_embedding.subtype_emb p e),
@@ -307,19 +307,19 @@ have ue' : uniform_embedding (dense_embedding.subtype_emb p e),
   from uniform_embedding_subtype_emb _ he de,
 have b ∈ closure (e '' {x | p x}),
   from (closure_mono $ mono_image $ hp) (mem_of_nhds hb),
-let ⟨c, (hc : tendsto (f ∘ subtype.val) (comap (dense_embedding.subtype_emb p e) (nhds ⟨b, this⟩)) (nhds c))⟩ :=
+let ⟨c, (hc : tendsto (f ∘ subtype.val) (comap (dense_embedding.subtype_emb p e) (𝓝 ⟨b, this⟩)) (𝓝 c))⟩ :=
   uniformly_extend_exists ue'.to_uniform_inducing de'.dense hf _ in
 begin
   rw [nhds_subtype_eq_comap] at hc,
   simp [comap_comap_comp] at hc,
-  change (tendsto (f ∘ @subtype.val α p) (comap (e ∘ @subtype.val α p) (nhds b)) (nhds c)) at hc,
+  change (tendsto (f ∘ @subtype.val α p) (comap (e ∘ @subtype.val α p) (𝓝 b)) (𝓝 c)) at hc,
   rw [←comap_comap_comp, tendsto_comap'_iff] at hc,
   exact ⟨c, hc⟩,
   exact ⟨_, hb, assume x,
     begin
       change e x ∈ (closure (e '' s)) → x ∈ range subtype.val,
       rw [←closure_induced, closure_eq_nhds, mem_set_of_eq, (≠), nhds_induced, ← de.to_dense_inducing.nhds_eq_comap],
-      change x ∈ {x | nhds x ⊓ principal s ≠ ⊥} → x ∈ range subtype.val,
+      change x ∈ {x | 𝓝 x ⊓ principal s ≠ ⊥} → x ∈ range subtype.val,
       rw [←closure_eq_nhds, closure_eq_of_is_closed hs],
       exact assume hxs, ⟨⟨x, hp x hxs⟩, rfl⟩,
       exact de.inj
@@ -334,7 +334,7 @@ dense_inducing.extend_e_eq _ b (continuous_iff_continuous_at.1 h_f.continuous b)
 include h_f
 
 lemma uniformly_extend_spec [complete_space γ] (a : α) :
-  tendsto f (comap e (nhds a)) (nhds (ψ a)) :=
+  tendsto f (comap e (𝓝 a)) (𝓝 (ψ a)) :=
 let de := (h_e.dense_inducing h_dense) in
 begin
   by_cases ha : a ∈ range e,
@@ -349,11 +349,11 @@ lemma uniform_continuous_uniformly_extend [cγ : complete_space γ] : uniform_co
 assume d hd,
 let ⟨s, hs, hs_comp⟩ := (mem_lift'_sets $
   monotone_comp_rel monotone_id $ monotone_comp_rel monotone_id monotone_id).mp (comp_le_uniformity3 hd) in
-have h_pnt : ∀{a m}, m ∈ nhds a → ∃c, c ∈ f '' preimage e m ∧ (c, ψ a) ∈ s ∧ (ψ a, c) ∈ s,
+have h_pnt : ∀{a m}, m ∈ 𝓝 a → ∃c, c ∈ f '' preimage e m ∧ (c, ψ a) ∈ s ∧ (ψ a, c) ∈ s,
   from assume a m hm,
-  have nb : map f (comap e (nhds a)) ≠ ⊥,
+  have nb : map f (comap e (𝓝 a)) ≠ ⊥,
     from map_ne_bot (h_e.dense_inducing h_dense).comap_nhds_neq_bot,
-  have (f '' preimage e m) ∩ ({c | (c, ψ a) ∈ s } ∩ {c | (ψ a, c) ∈ s }) ∈ map f (comap e (nhds a)),
+  have (f '' preimage e m) ∩ ({c | (c, ψ a) ∈ s } ∩ {c | (ψ a, c) ∈ s }) ∈ map f (comap e (𝓝 a)),
     from inter_mem_sets (image_mem_map $ preimage_mem_comap $ hm)
       (uniformly_extend_spec h_e h_dense h_f _ (inter_mem_sets (mem_nhds_right _ hs) (mem_nhds_left _ hs))),
   inhabited_of_mem_sets nb this,
@@ -365,9 +365,9 @@ let ⟨t, ht, ts⟩ := this in
 show preimage (λp:(α×α), (ψ p.1, ψ p.2)) d ∈ 𝓤 α,
   from (𝓤 α).sets_of_superset (interior_mem_uniformity ht) $
   assume ⟨x₁, x₂⟩ hx_t,
-  have nhds (x₁, x₂) ≤ principal (interior t),
+  have 𝓝 (x₁, x₂) ≤ principal (interior t),
     from is_open_iff_nhds.mp is_open_interior (x₁, x₂) hx_t,
-  have interior t ∈ filter.prod (nhds x₁) (nhds x₂),
+  have interior t ∈ filter.prod (𝓝 x₁) (𝓝 x₂),
     by rwa [nhds_prod_eq, le_principal_iff] at this,
   let ⟨m₁, hm₁, m₂, hm₂, (hm : set.prod m₁ m₂ ⊆ interior t)⟩ := mem_prod_iff.mp this in
   let ⟨a, ha₁, _, ha₂⟩ := h_pnt hm₁ in


### PR DESCRIPTION
This introduces a localized notation for the neighborhood filter, which is currently used in mathlib over 700 times without notation...