### PR TITLE
feat(algebra/big_operators): sum_ite

### DIFF
--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -202,7 +202,7 @@ from classical.by_cases
       prod_const_one.trans (h₁ this).symm)
 
 @[to_additive] lemma prod_ite [comm_monoid γ] {s : finset α}
-  {p : α → Prop} {h : decidable_pred p} (f g : α → γ) (h : γ → β) :
+  {p : α → Prop} {hp : decidable_pred p} (f g : α → γ) (h : γ → β) :
   s.prod (λ x, h (if p x then f x else g x)) =
   (s.filter p).prod (λ x, h (f x)) * (s.filter (λ x, ¬ p x)).prod (λ x, h (g x)) :=
 by letI := classical.dec_eq α; exact

--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -201,7 +201,23 @@ from classical.by_cases
     (prod_congr rfl $ λ b hb, h₀ b hb $ by rintro rfl; cc).trans $
       prod_const_one.trans (h₁ this).symm)
 
-@[simp, to_additive] lemma prod_ite [decidable_eq α] (s : finset α) (a : α) (b : β) :
+@[to_additive] lemma prod_ite [comm_monoid γ] {s : finset α}
+  {p : α → Prop} {h : decidable_pred p} (f g : α → γ) (h : γ → β) :
+  s.prod (λ x, h (if p x then f x else g x)) =
+  (s.filter p).prod (λ x, h (f x)) * (s.filter (λ x, ¬ p x)).prod (λ x, h (g x)) :=
+by letI := classical.dec_eq α; exact
+calc s.prod (λ x, h (if p x then f x else g x))
+    = (s.filter p ∪ s.filter (λ x, ¬ p x)).prod (λ x, h (if p x then f x else g x)) :
+  by rw [filter_union_filter_neg_eq]
+... = (s.filter p).prod (λ x, h (if p x then f x else g x)) *
+    (s.filter (λ x, ¬ p x)).prod (λ x, h (if p x then f x else g x)) :
+  prod_union (by simp [disjoint_right] {contextual := tt})
+... = (s.filter p).prod (λ x, h (f x)) * (s.filter (λ x, ¬ p x)).prod (λ x, h (g x)) :
+  congr_arg2 _
+    (prod_congr rfl (by simp {contextual := tt}))
+    (prod_congr rfl (by simp {contextual := tt}))
+
+@[simp, to_additive] lemma prod_ite_eq [decidable_eq α] (s : finset α) (a : α) (b : β) :
   s.prod (λ x, (ite (a = x) b 1)) = ite (a ∈ s) b 1 :=
 begin
   rw ←finset.prod_filter,
@@ -502,14 +518,14 @@ lemma mul_sum : b * s.sum f = s.sum (λx, b * f x) :=
 @[simp] lemma sum_mul_boole [decidable_eq α] (s : finset α) (f : α → β) (a : α) :
   s.sum (λ x, (f x * ite (a = x) 1 0)) = ite (a ∈ s) (f a) 0 :=
 begin
-  convert sum_ite s a (f a),
+  convert sum_ite_eq s a (f a),
   funext,
   split_ifs with h; simp [h],
 end
 @[simp] lemma sum_boole_mul [decidable_eq α] (s : finset α) (f : α → β) (a : α) :
   s.sum (λ x, (ite (a = x) 1 0) * f x) = ite (a ∈ s) (f a) 0 :=
 begin
-  convert sum_ite s a (f a),
+  convert sum_ite_eq s a (f a),
   funext,
   split_ifs with h; simp [h],
 end


### PR DESCRIPTION
rename the current `sum_ite` to `sum_ite_eq` and add a more general version

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
