### PR TITLE
chore(group_theory/free_group,order/zorn): rename zorn.zorn and sum.sum

### DIFF
--- a/src/group_theory/free_group.lean
+++ b/src/group_theory/free_group.lean
@@ -561,7 +561,7 @@ instance sum.is_group_hom : is_group_hom (@sum α _) :=
 prod.is_group_hom
 
 -- TODO(lint): This should probably be renamed `sum.mul`
-@[simp, nolint] lemma sum.sum : sum (x * y) = sum x + sum y :=
+@[simp, nolint] lemma sum.mul : sum (x * y) = sum x + sum y :=
 prod.mul
 
 @[simp] lemma sum.one : sum (1:free_group α) = 0 :=

--- a/src/group_theory/free_group.lean
+++ b/src/group_theory/free_group.lean
@@ -560,8 +560,7 @@ prod.of
 instance sum.is_group_hom : is_group_hom (@sum α _) :=
 prod.is_group_hom
 
--- TODO(lint): This should probably be renamed `sum.mul`
-@[simp, nolint] lemma sum.mul : sum (x * y) = sum x + sum y :=
+@[simp] lemma sum.mul : sum (x * y) = sum x + sum y :=
 prod.mul
 
 @[simp] lemma sum.one : sum (1:free_group α) = 0 :=

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -1647,7 +1647,7 @@ in
 have ∀c (hc: chain r c) a (ha : a ∈ c), r a (sup c hc),
   from assume c hc a ha, infi_le_of_le ⟨a, mem_insert_of_mem _ ha⟩ (le_refl _),
 have (∃ (u : τ), ∀ (a : τ), r u a → r a u),
-  from zorn (assume c hc, ⟨sup c hc, this c hc⟩) (assume f₁ f₂ f₃ h₁ h₂, le_trans h₂ h₁),
+  from exists_maximal_of_chains_bounded (assume c hc, ⟨sup c hc, this c hc⟩) (assume f₁ f₂ f₃ h₁ h₂, le_trans h₂ h₁),
 let ⟨uτ, hmin⟩ := this in
 ⟨uτ.val, uτ.property.right, uτ.property.left, assume g hg₁ hg₂,
   hmin ⟨g, hg₁, le_trans hg₂ uτ.property.right⟩ hg₂⟩

--- a/src/order/zorn.lean
+++ b/src/order/zorn.lean
@@ -206,7 +206,7 @@ h₃ this.symm
 
 If every chain has an upper bound, then there is a maximal element -/
 -- TODO(lint): rename to exists_maximal_of_chains_bounded
-@[nolint] theorem zorn
+@[nolint] theorem exists_maximal_of_chains_bounded
   (h : ∀c, chain c → ∃ub, ∀a∈c, a ≺ ub) (trans : ∀{a b c}, a ≺ b → b ≺ c → a ≺ c) :
   ∃m, ∀a, m ≺ a → a ≺ m :=
 have ∃ub, ∀a∈max_chain, a ≺ ub,
@@ -224,7 +224,7 @@ end chain
 
 theorem zorn_partial_order {α : Type u} [partial_order α]
   (h : ∀c:set α, @chain α (≤) c → ∃ub, ∀a∈c, a ≤ ub) : ∃m:α, ∀a, m ≤ a → a = m :=
-let ⟨m, hm⟩ := @zorn α (≤) h (assume a b c, le_trans) in
+let ⟨m, hm⟩ := @exists_maximal_of_chains_bounded α (≤) h (assume a b c, le_trans) in
 ⟨m, assume a ha, le_antisymm (hm a ha) ha⟩
 
 theorem zorn_partial_order₀ {α : Type u} [partial_order α] (s : set α)

--- a/src/order/zorn.lean
+++ b/src/order/zorn.lean
@@ -205,8 +205,7 @@ h₃ this.symm
 /-- Zorn's lemma
 
 If every chain has an upper bound, then there is a maximal element -/
--- TODO(lint): rename to exists_maximal_of_chains_bounded
-@[nolint] theorem exists_maximal_of_chains_bounded
+theorem exists_maximal_of_chains_bounded
   (h : ∀c, chain c → ∃ub, ∀a∈c, a ≺ ub) (trans : ∀{a b c}, a ≺ b → b ≺ c → a ≺ c) :
   ∃m, ∀a, m ≺ a → a ≺ m :=
 have ∃ub, ∀a∈max_chain, a ≺ ub,


### PR DESCRIPTION
A continuation of the linting fixes from #1599 

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
