### PR TITLE
feat(.travis): add linting to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ install:
   - if [ $RESULT -eq 0 ]; then git checkout -f HEAD ; fi
   - git clean -d -f -q
   - ./purge_olean.sh
+  - bash scripts/rm_all.sh || true
   - rm mathlib.txt || true
   - export LEAN_VERSION=lean-`lean --run scripts/lean_version.lean`
 
@@ -78,6 +79,9 @@ jobs:
         - travis_long "leanpkg test"
         - lean --recursive --export=mathlib.txt src/
         - travis_long "leanchecker mathlib.txt"
+        - bash scripts/mk_all.sh
+        - travis_long "lean src/lint_mathlib.lean"
+        - bash scripts/rm_all.sh
         - sh scripts/deploy_nightly.sh
 
     - stage: Test

--- a/scripts/mk_all.sh
+++ b/scripts/mk_all.sh
@@ -20,5 +20,5 @@ import all
 
 open nat -- need to do something before running a command
 
-#lint_mathlib
+#lint_mathlib- only def_lemma dup_namespace
 EOT


### PR DESCRIPTION
~~This is currently blocked by #1580 -- it temporarily changes the changes there so that `#lint-` either succeeds silently, or fails with all linting errors. Easily updated when we come to a conclusion.~~

If I've done things correctly, this should check every PR for duplicated namespaces and def/lemma choices. There's no complicated report to Travis.

PRs that modify `.travis` are tested with the new config, right?

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
