### PR TITLE
fix(data/mv_polynomial): faster ring_equiv_congr

### DIFF
--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -1029,6 +1029,7 @@ def ring_equiv_congr [comm_ring γ] (e : α ≃+* γ) : mv_polynomial β α ≃+
     have (e ∘ e.symm) = id,
     { ext a, exact e.apply_symm_apply a },
     by simp only [map_map, this, map_id],
+-- inserting `by exact` prevents a `deterministic timeout` error
   map_mul'  := by exact map_mul _,
   map_add'  := by exact map_add _ }
 

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -1029,8 +1029,8 @@ def ring_equiv_congr [comm_ring γ] (e : α ≃+* γ) : mv_polynomial β α ≃+
     have (e ∘ e.symm) = id,
     { ext a, exact e.apply_symm_apply a },
     by simp only [map_map, this, map_id],
-  map_mul'  := map_mul _,
-  map_add'  := map_add _ }
+  map_mul'  := by exact map_mul _,
+  map_add'  := by exact map_add _ }
 
 section
 variables (β γ δ)


### PR DESCRIPTION
Previously, opening `data/mv_polynomial.lean` in VS Code (with the time limit set to 100000) led to a deterministic timeout. After inserting `by exact` in the `map_mul'` and `map_add'` fields (following #1617), the timeout goes away and `lean --make -T 50000 src/data/mv_polynomial.lean` works as well. 

See https://github.com/leanprover-community/mathlib/issues/1566#issuecomment-544762470.

I don't really understand why this works. Should something like this be done for some of the other slow structures in the file? Or is there a better fix?