### PR TITLE
fix(*): use has_coe_t

### DIFF
--- a/src/data/seq/computation.lean
+++ b/src/data/seq/computation.lean
@@ -27,7 +27,7 @@ variables {α : Type u} {β : Type v} {γ : Type w}
 /-- `return a` is the computation that immediately terminates with result `a`. -/
 def return (a : α) : computation α := ⟨stream.const (some a), λn a', id⟩
 
-instance : has_coe α (computation α) := ⟨return⟩
+instance : has_coe_t α (computation α) := ⟨return⟩ -- note [use has_coe_t]
 
 /-- `think c` is the computation that delays for one "tick" and then performs
   computation `c`. -/

--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -170,7 +170,7 @@ lemma induction_on {C : quotient s → Prop} (x : quotient s)
 quotient.induction_on' x H
 
 @[to_additive]
-instance : has_coe α (quotient s) := ⟨mk⟩
+instance : has_coe_t α (quotient s) := ⟨mk⟩ -- note [use has_coe_t]
 
 @[elab_as_eliminator, to_additive]
 lemma induction_on' {C : quotient s → Prop} (x : quotient s)
@@ -241,3 +241,9 @@ have h : ∀ {x : quotient s} {a : α}, x ∈ t → a ∈ s →
   right_inv := λ ⟨⟨a, ha⟩, ⟨x, hx⟩⟩, show (_, _) = _, by simp [h hx ha] }
 
 end quotient_group
+
+/- Note [use has_coe_t]:
+We use the class `has_coe_t` instead of `has_coe` if the first-argument is a variable.
+Using `has_coe` would cause looping of type-class inference. See
+https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/remove.20all.20instances.20with.20variable.20domain
+-/

--- a/src/order/filter/filter_product.lean
+++ b/src/order/filter/filter_product.lean
@@ -58,7 +58,7 @@ def lift_rel₂ (R : β → β → Prop) : β* → β* → Prop :=
   ⟨ λ ha, by filter_upwards [h₁, h₂, ha] λ i hi1 hi2 hia, by simpa [hi1.symm, hi2.symm],
     λ hb, by filter_upwards [h₁, h₂, hb] λ i hi1 hi2 hib, by simpa [hi1.symm.symm, hi2.symm.symm] ⟩
 
-instance coe_filterprod : has_coe β β* := ⟨ of ⟩
+instance coe_filterprod : has_coe_t β β* := ⟨ of ⟩ -- note [use has_coe_t]
 
 instance [has_add β] : has_add β* := { add := lift₂ has_add.add }
 

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -112,7 +112,7 @@ instance of.is_ring_hom : is_ring_hom (of : α → localization α S) :=
 
 variables {S}
 
-instance : has_coe α (localization α S) := ⟨of⟩
+instance : has_coe_t α (localization α S) := ⟨of⟩ -- note [use has_coe_t]
 
 instance coe.is_ring_hom : is_ring_hom (coe : α → localization α S) :=
 localization.of.is_ring_hom

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -341,7 +341,7 @@ instance : t2_space (completion α) := separated_t2
 instance : regular_space (completion α) := separated_regular
 
 /-- Automatic coercion from `α` to its completion. Not always injective. -/
-instance : has_coe α (completion α) := ⟨quotient.mk ∘ pure_cauchy⟩
+instance : has_coe_t α (completion α) := ⟨quotient.mk ∘ pure_cauchy⟩ -- note [use has_coe_t]
 
 protected lemma coe_eq : (coe : α → completion α) = quotient.mk ∘ pure_cauchy := rfl
 


### PR DESCRIPTION
Use the class `has_coe_t` instead of `has_coe` if the first-argument is a variable.
Using `has_coe` would cause looping of type-class inference. See
https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/remove.20all.20instances.20with.20variable.20domain

This might break something, but probably not.