### PR TITLE
feat(order/conditionally_complete_lattice): add complete_linear_order instance for enat

### DIFF
--- a/src/data/nat/enat.lean
+++ b/src/data/nat/enat.lean
@@ -225,6 +225,7 @@ end
 
 section with_top
 
+/-- Computably converts an `enat` to a `with_top ℕ`. -/
 def to_with_top (x : enat) [decidable x.dom]: with_top ℕ := x.to_option
 
 lemma to_with_top_top : to_with_top ⊤ = ⊤ := rfl
@@ -248,6 +249,50 @@ enat.cases_on y (by simp) (enat.cases_on x (by simp) (by intros; simp))
 by simp only [lt_iff_le_not_le, to_with_top_le]
 
 end with_top
+
+section with_top_equiv
+open_locale classical
+
+/-- Order isomorphism between `enat` and `with_top ℕ`. -/
+noncomputable def with_top_equiv : enat ≃ with_top ℕ :=
+{ to_fun := λ x, to_with_top x,
+  inv_fun := λ x, match x with (some n) := coe n | none := ⊤ end,
+  left_inv := λ x, by apply enat.cases_on x; intros; simp; refl,
+  right_inv := λ x, by cases x; simp [with_top_equiv._match_1]; refl }
+
+@[simp] lemma with_top_equiv_top : with_top_equiv ⊤ = ⊤ :=
+to_with_top_top'
+
+@[simp] lemma with_top_equiv_coe (n : nat) : with_top_equiv n = n :=
+to_with_top_coe' _
+
+@[simp] lemma with_top_equiv_zero : with_top_equiv 0 = 0 :=
+with_top_equiv_coe _
+
+@[simp] lemma with_top_equiv_le {x y : enat} : with_top_equiv x ≤ with_top_equiv y ↔ x ≤ y :=
+to_with_top_le
+
+@[simp] lemma with_top_equiv_lt {x y : enat} : with_top_equiv x < with_top_equiv y ↔ x < y :=
+to_with_top_lt
+
+@[simp] lemma with_top_equiv_symm_top : with_top_equiv.symm ⊤ = ⊤ :=
+rfl
+
+@[simp] lemma with_top_equiv_symm_coe (n : nat) : with_top_equiv.symm n = n :=
+rfl
+
+@[simp] lemma with_top_equiv_symm_zero : with_top_equiv.symm 0 = 0 :=
+rfl
+
+@[simp] lemma with_top_equiv_symm_le {x y : with_top ℕ} :
+  with_top_equiv.symm x ≤ with_top_equiv.symm y ↔ x ≤ y :=
+by rw ← with_top_equiv_le; simp
+
+@[simp] lemma with_top_equiv_symm_lt {x y : with_top ℕ} :
+  with_top_equiv.symm x < with_top_equiv.symm y ↔ x < y :=
+by rw ← with_top_equiv_lt; simp
+
+end with_top_equiv
 
 lemma lt_wf : well_founded ((<) : enat → enat → Prop) :=
 show well_founded (λ a b : enat, a < b),

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -716,6 +716,38 @@ le_antisymm
 
 end with_top
 
+namespace enat
+open_locale classical
+open lattice
+
+noncomputable instance : complete_linear_order enat :=
+{ Sup := λ s, with_top_equiv.symm $ Sup (with_top_equiv '' s),
+  Inf := λ s, with_top_equiv.symm $ Inf (with_top_equiv '' s),
+  le_Sup := by intros; rw ← with_top_equiv_le; simp; apply le_Sup _; simpa,
+  Inf_le := by intros; rw ← with_top_equiv_le; simp; apply Inf_le _; simpa,
+  Sup_le := begin
+    intros s a h1,
+    rw [← with_top_equiv_le, with_top_equiv.right_inverse_symm],
+    apply Sup_le _,
+    rintros b ⟨x, h2, rfl⟩,
+    rw with_top_equiv_le,
+    apply h1,
+    assumption
+  end,
+  le_Inf := begin
+    intros s a h1,
+    rw [← with_top_equiv_le, with_top_equiv.right_inverse_symm],
+    apply le_Inf _,
+    rintros b ⟨x, h2, rfl⟩,
+    rw with_top_equiv_le,
+    apply h1,
+    assumption
+  end,
+  ..enat.decidable_linear_order,
+  ..enat.lattice.bounded_lattice }
+
+end enat
+
 section order_dual
 open lattice
 


### PR DESCRIPTION
I hope I didn't miss an orphan instance somewhere else.  This PR adds an instance for `complete_linear_order enat` via an isomorphism to `with_top nat`.  (We already had `complete_linear_order (with_top nat)`.)  This isomorphism extends the existing `enat.to_with_top` function.


TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
