### PR TITLE
refactor(linear_algebra/basic): use smul_right

### DIFF
--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -64,32 +64,51 @@ variables {E : Type*} [normed_group E] [normed_space 𝕜 E]
 variables {F : Type*} [normed_group F] [normed_space 𝕜 F]
 variables {G : Type*} [normed_group G] [normed_space 𝕜 G]
 
+/-- A function `f` has the continuous linear map `f'` as derivative along the filter `L` if
+`f x' = f x + f' (x' - x) + o (x' - x)` when `x'` converges along the filter `L`. This definition
+is designed to be specialized for `L = nhds x` (in `has_fderiv_at`), giving rise to the usual notion
+of Fréchet derivative, and for `L = nhds_within x s` (in `has_fderiv_within_at`), giving rise to
+the notion of Fréchet derivative along the set `s`. -/
 def has_fderiv_at_filter (f : E → F) (f' : E →L[𝕜] F) (x : E) (L : filter E) :=
 is_o (λ x', f x' - f x - f' (x' - x)) (λ x', x' - x) L
 
+/-- A function `f` has the continuous linear map `f'` as derivative at `x` within a set `s` if
+`f x' = f x + f' (x' - x) + o (x' - x)` when `x'` tends to `x` inside `s`. -/
 def has_fderiv_within_at (f : E → F) (f' : E →L[𝕜] F) (s : set E) (x : E) :=
 has_fderiv_at_filter f f' x (nhds_within x s)
 
+/-- A function `f` has the continuous linear map `f'` as derivative at `x` if
+`f x' = f x + f' (x' - x) + o (x' - x)` when `x'` tends to `x`. -/
 def has_fderiv_at (f : E → F) (f' : E →L[𝕜] F) (x : E) :=
 has_fderiv_at_filter f f' x (nhds x)
 
 variables (𝕜)
 
+/-- A function `f` is differentiable at a point `x` within a set `s` if it admits a derivative
+there (possibly non-unique). -/
 def differentiable_within_at (f : E → F) (s : set E) (x : E) :=
 ∃f' : E →L[𝕜] F, has_fderiv_within_at f f' s x
 
+/-- A function `f` is differentiable at a point `x` if it admits a derivative there (possibly
+non-unique). -/
 def differentiable_at (f : E → F) (x : E) :=
 ∃f' : E →L[𝕜] F, has_fderiv_at f f' x
 
+/-- If `f` has a derivative at `x` within `s`, then `fderiv_within 𝕜 f s x` is such a derivative.
+Otherwise, it is set to `0`. -/
 def fderiv_within (f : E → F) (s : set E) (x : E) : E →L[𝕜] F :=
 if h : ∃f', has_fderiv_within_at f f' s x then classical.some h else 0
 
+/-- If `f` has a derivative at `x`, then `fderiv 𝕜 f x` is such a derivative. Otherwise, it is
+set to `0`. -/
 def fderiv (f : E → F) (x : E) : E →L[𝕜] F :=
 if h : ∃f', has_fderiv_at f f' x then classical.some h else 0
 
+/-- `differentiable_on 𝕜 f s` means that `f` is differentiable within `s` at any point of `s`. -/
 def differentiable_on (f : E → F) (s : set E) :=
 ∀x ∈ s, differentiable_within_at 𝕜 f s x
 
+/-- `differentiable 𝕜 f` means that `f` is differentiable at any point. -/
 def differentiable (f : E → F) :=
 ∀x, differentiable_at 𝕜 f x
 
@@ -1082,14 +1101,14 @@ variables {c : E → 𝕜} {c' : E →L[𝕜] 𝕜}
 
 theorem has_fderiv_within_at.smul'
   (hc : has_fderiv_within_at c c' s x) (hf : has_fderiv_within_at f f' s x) :
-  has_fderiv_within_at (λ y, c y • f y) (c x • f' + c'.scalar_prod_space_iso (f x)) s x :=
+  has_fderiv_within_at (λ y, c y • f y) (c x • f' + c'.smul_right (f x)) s x :=
 begin
   have : is_bounded_bilinear_map 𝕜 (λ (p : 𝕜 × F), p.1 • p.2) := is_bounded_bilinear_map_smul,
   exact has_fderiv_at.comp_has_fderiv_within_at x (this.has_fderiv_at (c x, f x)) (hc.prod hf)
 end
 
 theorem has_fderiv_at.smul' (hc : has_fderiv_at c c' x) (hf : has_fderiv_at f f' x) :
-  has_fderiv_at (λ y, c y • f y) (c x • f' + c'.scalar_prod_space_iso (f x)) x :=
+  has_fderiv_at (λ y, c y • f y) (c x • f' + c'.smul_right (f x)) x :=
 begin
   have : is_bounded_bilinear_map 𝕜 (λ (p : 𝕜 × F), p.1 • p.2) := is_bounded_bilinear_map_smul,
   exact has_fderiv_at.comp x (this.has_fderiv_at (c x, f x)) (hc.prod hf)
@@ -1115,12 +1134,12 @@ lemma differentiable.smul' (hc : differentiable 𝕜 c) (hf : differentiable �
 lemma fderiv_within_smul' (hxs : unique_diff_within_at 𝕜 s x)
   (hc : differentiable_within_at 𝕜 c s x) (hf : differentiable_within_at 𝕜 f s x) :
   fderiv_within 𝕜 (λ y, c y • f y) s x =
-    c x • fderiv_within 𝕜 f s x + (fderiv_within 𝕜 c s x).scalar_prod_space_iso (f x) :=
+    c x • fderiv_within 𝕜 f s x + (fderiv_within 𝕜 c s x).smul_right (f x) :=
 (hc.has_fderiv_within_at.smul' hf.has_fderiv_within_at).fderiv_within hxs
 
 lemma fderiv_smul' (hc : differentiable_at 𝕜 c x) (hf : differentiable_at 𝕜 f x) :
   fderiv 𝕜 (λ y, c y • f y) x =
-    c x • fderiv 𝕜 f x + (fderiv 𝕜 c x).scalar_prod_space_iso (f x) :=
+    c x • fderiv 𝕜 f x + (fderiv 𝕜 c x).smul_right (f x) :=
 (hc.has_fderiv_at.smul' hf.has_fderiv_at).fderiv
 
 end smul

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -122,7 +122,7 @@ begin
     (unique_diff_on_Icc_zero_one t ht),
   refine le_trans (op_norm_comp_le _ _) (mul_le_mul (bound _ t_s) _ (norm_nonneg _) C0),
   have : fderiv_within ℝ (λ (t : ℝ), x + t • (y - x)) (Icc 0 1) t =
-      (id : ℝ →L[ℝ] ℝ).scalar_prod_space_iso (y - x) := calc
+      (id : ℝ →L[ℝ] ℝ).smul_right (y - x) := calc
     fderiv_within ℝ (λ (t : ℝ), x + t • (y - x)) (Icc 0 1) t
     = fderiv ℝ (λ (t : ℝ), x + t • (y - x)) t :
       differentiable.fderiv_within (D1 t) (unique_diff_on_Icc_zero_one t ht)
@@ -130,11 +130,11 @@ begin
       fderiv_add (differentiable_at_const _) ((differentiable.smul' differentiable_id (differentiable_const _)) t)
     ... = fderiv ℝ (λ (t : ℝ), t • (y-x)) t :
       by rw [fderiv_const, zero_add]
-    ... = t • fderiv ℝ (λ (t : ℝ), (y-x)) t + (fderiv ℝ id t).scalar_prod_space_iso (y - x) :
+    ... = t • fderiv ℝ (λ (t : ℝ), (y-x)) t + (fderiv ℝ id t).smul_right (y - x) :
       fderiv_smul' differentiable_at_id (differentiable_at_const _)
-    ... = (id : ℝ →L[ℝ] ℝ).scalar_prod_space_iso (y - x) :
+    ... = (id : ℝ →L[ℝ] ℝ).smul_right (y - x) :
       by rw [fderiv_const, smul_zero, zero_add, fderiv_id],
-  rw [this, scalar_prod_space_iso_norm],
+  rw [this, smul_right_norm],
   calc ∥(id : ℝ →L[ℝ] ℝ)∥ * ∥y - x∥ ≤ 1 * ∥y-x∥ :
     mul_le_mul_of_nonneg_right norm_id (norm_nonneg _)
   ... = ∥y - x∥ : one_mul _

--- a/src/analysis/normed_space/bounded_linear_maps.lean
+++ b/src/analysis/normed_space/bounded_linear_maps.lean
@@ -21,11 +21,13 @@ variables {G : Type*} [normed_group G] [normed_space 𝕜 G]
 
 set_option class.instance_max_depth 70
 
+/-- A function `f` satisfies `is_bounded_linear_map 𝕜 f` if it is linear and satisfies the
+inequality `∥ f x ∥ ≤ M * ∥ x ∥` for some positive constant `M`. -/
 structure is_bounded_linear_map (𝕜 : Type*) [normed_field 𝕜]
   {E : Type*} [normed_group E] [normed_space 𝕜 E]
   {F : Type*} [normed_group F] [normed_space 𝕜 F] (f : E → F)
   extends is_linear_map 𝕜 f : Prop :=
-(bound : ∃ M > 0, ∀ x : E, ∥ f x ∥ ≤ M * ∥ x ∥)
+(bound : ∃ M, 0 < M ∧ ∀ x : E, ∥ f x ∥ ≤ M * ∥ x ∥)
 
 lemma is_linear_map.with_bound
   {f : E → F} (hf : is_linear_map 𝕜 f) (M : ℝ) (h : ∀ x : E, ∥ f x ∥ ≤ M * ∥ x ∥) :
@@ -42,6 +44,7 @@ lemma continuous_linear_map.is_bounded_linear_map (f : E →L[𝕜] F) : is_boun
 
 namespace is_bounded_linear_map
 
+/-- Construct a linear map from a function `f` satisfying `is_bounded_linear_map 𝕜 f`. -/
 def to_linear_map (f : E → F) (h : is_bounded_linear_map 𝕜 f) : E →ₗ[𝕜] F :=
 (is_linear_map.mk' _ h.to_is_linear_map)
 
@@ -195,6 +198,8 @@ section bilinear_map
 
 variable (𝕜)
 
+/-- A map `f : E × F → G` satisfies `is_bounded_bilinear_map 𝕜 f` if it is bilinear and
+continuous. -/
 structure is_bounded_bilinear_map (f : E × F → G) : Prop :=
 (add_left   : ∀(x₁ x₂ : E) (y : F), f (x₁ + x₂, y) = f (x₁, y) + f (x₂, y))
 (smul_left  : ∀(c : 𝕜) (x : E) (y : F), f (c • x, y) = c • f (x,y))
@@ -275,6 +280,8 @@ def is_bounded_bilinear_map.linear_deriv (h : is_bounded_bilinear_map 𝕜 f) (p
     simp [h.smul_left, h.smul_right, smul_add]
   end }
 
+/-- The derivative of a bounded bilinear map at a point `p : E × F`, as a continuous linear map
+from `E × F` to `G`. -/
 def is_bounded_bilinear_map.deriv (h : is_bounded_bilinear_map 𝕜 f) (p : E × F) : (E × F) →L[𝕜] G :=
 (h.linear_deriv p).with_bound $ begin
   rcases h.bound with ⟨C, Cpos, hC⟩,

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -22,7 +22,7 @@ variables {𝕜 : Type*} {E : Type*} {F : Type*} {G : Type*}
 open metric continuous_linear_map
 
 lemma exists_pos_bound_of_bound {f : E → F} (M : ℝ) (h : ∀x, ∥f x∥ ≤ M * ∥x∥) :
-  ∃ N > 0, ∀x, ∥f x∥ ≤ N * ∥x∥ :=
+  ∃ N, 0 < N ∧ ∀x, ∥f x∥ ≤ N * ∥x∥ :=
 ⟨max M 1, lt_of_lt_of_le zero_lt_one (le_max_right _ _), λx, calc
   ∥f x∥ ≤ M * ∥x∥ : h x
   ... ≤ max M 1 * ∥x∥ : mul_le_mul_of_nonneg_right (le_max_left _ _) (norm_nonneg _) ⟩
@@ -42,6 +42,7 @@ begin
   exact continuous_of_lipschitz this
 end
 
+/-- Construct a continuous linear map from a linear map and a bound on this linear map. -/
 def linear_map.with_bound (f : E →ₗ[𝕜] F) (h : ∃C : ℝ, ∀x, ∥f x∥ ≤ C * ∥x∥) : E →L[𝕜] F :=
 ⟨f, let ⟨C, hC⟩ := h in linear_map.continuous_of_bound f C hC⟩
 
@@ -57,7 +58,7 @@ namespace continuous_linear_map
 The continuity ensures boundedness on a ball of some radius δ. The nondiscreteness is then
 used to rescale any element into an element of norm in [δ/C, δ], whose image has a controlled norm.
 The norm control for the original element follows by rescaling. -/
-theorem bound : ∃ C > 0, ∀ x : E, ∥f x∥ ≤ C * ∥x∥ :=
+theorem bound : ∃ C, 0 < C ∧ (∀ x : E, ∥f x∥ ≤ C * ∥x∥) :=
 begin
   have : continuous_at f 0 := continuous_iff_continuous_at.1 f.2 _,
   rcases metric.tendsto_nhds_nhds.1 this 1 zero_lt_one with ⟨ε, ε_pos, hε⟩,
@@ -113,11 +114,11 @@ instance has_op_norm : has_norm (E →L[𝕜] F) := ⟨op_norm⟩
 -- So that invocations of real.Inf_le ma𝕜e sense: we show that the set of
 -- bounds is nonempty and bounded below.
 lemma bounds_nonempty {f : E →L[𝕜] F} :
-  ∃ c, c ∈ { c | c ≥ 0 ∧ ∀ x, ∥f x∥ ≤ c * ∥x∥ } :=
+  ∃ c, c ∈ { c | 0 ≤ c ∧ ∀ x, ∥f x∥ ≤ c * ∥x∥ } :=
 let ⟨M, hMp, hMb⟩ := f.bound in ⟨M, le_of_lt hMp, hMb⟩
 
 lemma bounds_bdd_below {f : E →L[𝕜] F} :
-  bdd_below { c | c ≥ 0 ∧ ∀ x, ∥f x∥ ≤ c * ∥x∥ } :=
+  bdd_below { c | 0 ≤ c ∧ ∀ x, ∥f x∥ ≤ c * ∥x∥ } :=
 ⟨0, λ _ ⟨hn, _⟩, hn⟩
 
 lemma op_norm_nonneg : 0 ≤ ∥f∥ :=
@@ -233,8 +234,8 @@ end op_norm
 
 /-- The norm of the tensor product of a scalar linear map and of an element of a normed space
 is the product of the norms. -/
-@[simp] lemma scalar_prod_space_iso_norm {c : E →L[𝕜] 𝕜} {f : F} :
-  ∥scalar_prod_space_iso c f∥ = ∥c∥ * ∥f∥ :=
+@[simp] lemma smul_right_norm {c : E →L[𝕜] 𝕜} {f : F} :
+  ∥smul_right c f∥ = ∥c∥ * ∥f∥ :=
 begin
   refine le_antisymm _ _,
   { apply op_norm_le_bound _ (mul_nonneg (norm_nonneg _) (norm_nonneg _)) (λx, _),
@@ -250,8 +251,8 @@ begin
       apply op_norm_le_bound _ (div_nonneg (norm_nonneg _) this) (λx, _),
       rw [div_mul_eq_mul_div, le_div_iff this],
       calc ∥c x∥ * ∥f∥ = ∥c x • f∥ : (norm_smul _ _).symm
-      ... = ∥((scalar_prod_space_iso c f) : E → F) x∥ : rfl
-      ... ≤ ∥scalar_prod_space_iso c f∥ * ∥x∥ : le_op_norm _ _ } },
+      ... = ∥((smul_right c f) : E → F) x∥ : rfl
+      ... ≤ ∥smul_right c f∥ * ∥x∥ : le_op_norm _ _ } },
 end
 
 end continuous_linear_map

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1440,7 +1440,7 @@ exact comap_mono (inf_le_inf le_sup_left (le_refl _)) end
 set_option class.instance_max_depth 41
 
 /--
-Second Isomorphism Law : the canonical map from p/(p ∩ p') to (p+p')/p' is a linear isomorphism.
+Second Isomorphism Law : the canonical map from p/(p ∩ p') to (p+p')/p' as a linear isomorphism.
 -/
 noncomputable def sup_quotient_equiv_quotient_inf (p p' : submodule R M) :
   (comap p.subtype (p ⊓ p')).quotient ≃ₗ[R] (comap (p ⊔ p').subtype p').quotient :=

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1459,7 +1459,7 @@ noncomputable def sup_quotient_equiv_quotient_inf (p p' : submodule R M) :
 
 section prod
 
-/-- The cartesian product of two linear maps is a linear map. -/
+/-- The cartesian product of two linear maps as a linear map. -/
 def prod {R M M₂ M₃ : Type*} [ring R] [add_comm_group M] [add_comm_group M₂] [add_comm_group M₃]
   [module R M] [module R M₂] [module R M₃]
   (f₁ : M →ₗ[R] M₂) (f₂ : M →ₗ[R] M₃) : M →ₗ[R] (M₂ × M₃) :=

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -144,7 +144,7 @@ instance linear_map_apply_is_add_group_hom (a : M) :
   is_add_group_hom (λ f : M →ₗ[R] M₂, f a) :=
 { map_add := λ f g, linear_map.add_apply f g a }
 
-lemma sum_apply [decidable_eq M₃] (t : finset M₃) (f : M₃ → M →ₗ[R] M₂) (b : M) :
+lemma sum_apply (t : finset ι) (f : ι → M →ₗ[R] M₂) (b : M) :
   t.sum f b = t.sum (λd, f d b) :=
 (@finset.sum_hom _ _ _ t f _ _ (λ g : M →ₗ[R] M₂, g b) _).symm
 
@@ -293,6 +293,8 @@ lemma le_def {p p' : submodule R M} : p ≤ p' ↔ (p : set M) ⊆ p' := iff.rfl
 
 lemma le_def' {p p' : submodule R M} : p ≤ p' ↔ ∀ x ∈ p, x ∈ p' := iff.rfl
 
+/-- If two submodules p and p' satisfy p ⊆ p', then `of_le p p'` is the linear map version of this
+inclusion. -/
 def of_le {p p' : submodule R M} (h : p ≤ p') : p →ₗ[R] p' :=
 linear_map.cod_restrict _ p.subtype $ λ ⟨x, hx⟩, h hx
 
@@ -731,6 +733,7 @@ begin
 end
 
 -- TODO(Mario): Factor through add_subgroup
+/-- The equivalence relation associated to a submodule `p`, defined by `x ≈ y` iff `y - x ∈ p`. -/
 def quotient_rel : setoid M :=
 ⟨λ x y, x - y ∈ p, λ x, by simp,
  λ x y h, by simpa using neg_mem _ h,
@@ -741,6 +744,8 @@ def quotient : Type* := quotient (quotient_rel p)
 
 namespace quotient
 
+/-- Map associating to an element of `M` the corresponding element of `M/p`,
+when `p` is a submodule of `M`. -/
 def mk {p : submodule R M} : M → quotient p := quotient.mk'
 
 @[simp] theorem mk_eq_mk {p : submodule R M} (x : M) : (quotient.mk x : quotient p) = mk x := rfl
@@ -1421,6 +1426,10 @@ let F : f.ker.quotient →ₗ[R] f.range :=
 
 open submodule
 
+/--
+Canonical linear map from the quotient p/(p ∩ p') to (p+p')/p', mapping x + (p ∩ p') to x + p',
+where p and p' are submodules of an ambient module.
+-/
 def sup_quotient_to_quotient_inf (p p' : submodule R M) :
   (comap p.subtype (p ⊓ p')).quotient →ₗ[R] (comap (p ⊔ p').subtype p').quotient :=
 (comap p.subtype (p ⊓ p')).liftq
@@ -1430,7 +1439,9 @@ exact comap_mono (inf_le_inf le_sup_left (le_refl _)) end
 
 set_option class.instance_max_depth 41
 
-/-- Second Isomorphism Law -/
+/--
+Second Isomorphism Law : the canonical map from p/(p ∩ p') to (p+p')/p' is a linear isomorphism.
+-/
 noncomputable def sup_quotient_equiv_quotient_inf (p p' : submodule R M) :
   (comap p.subtype (p ⊓ p')).quotient ≃ₗ[R] (comap (p ⊔ p').subtype p').quotient :=
 { .. sup_quotient_to_quotient_inf p p',
@@ -1448,7 +1459,7 @@ noncomputable def sup_quotient_equiv_quotient_inf (p p' : submodule R M) :
 
 section prod
 
-/-- The product of two linear maps is a linear map. -/
+/-- The cartesian product of two linear maps is a linear map. -/
 def prod {R M M₂ M₃ : Type*} [ring R] [add_comm_group M] [add_comm_group M₂] [add_comm_group M₃]
   [module R M] [module R M₂] [module R M₃]
   (f₁ : M →ₗ[R] M₂) (f₂ : M →ₗ[R] M₃) : M →ₗ[R] (M₂ × M₃) :=
@@ -1464,16 +1475,6 @@ lemma is_linear_map_prod_iso {R M M₂ M₃ : Type*} [comm_ring R] [add_comm_gro
   [add_comm_group M₃] [module R M] [module R M₂] [module R M₃] :
   is_linear_map R (λ(p : (M →ₗ[R] M₂) × (M →ₗ[R] M₃)), (linear_map.prod p.1 p.2 : (M →ₗ[R] (M₂ × M₃)))) :=
 ⟨λu v, rfl, λc u, rfl⟩
-
-/-- The product by a linear map into the scalar ring is a linear map. -/
-def scalar_prod_space_iso {R M M₂ : Type*} [comm_ring R] [add_comm_group M] [add_comm_group M₂]
-  [module R M] [module R M₂] (c : M →ₗ[R] R) (f : M₂) : M →ₗ[R] M₂ :=
-{ to_fun := λx, (c x) • f,
-  add := λx y, begin
-    change c (x + y) • f = (c x) • f + (c y) • f,
-    simp [add_smul],
-  end,
-  smul := λa x, by simp [smul_smul] }
 
 end prod
 

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -46,12 +46,13 @@ class topological_module (α : Type u) (β : Type v)
   [module α β]
   extends topological_semimodule α β : Prop
 
+/-- A topological vector space is a topological module over a field. -/
 class topological_vector_space (α : Type u) (β : Type v)
   [discrete_field α] [topological_space α]
   [topological_space β] [add_comm_group β] [vector_space α β]
   extends topological_module α β
 
-/- Continuous linear maps between modules. Only put the type classes that are necessary for the
+/-- Continuous linear maps between modules. We only put the type classes that are necessary for the
 definition, although in applications β and γ will be topological modules over the topological
 ring α -/
 structure continuous_linear_map
@@ -196,9 +197,9 @@ variables (c : α) (f g : β →L[α] γ) (x y z : β)
 
 /-- Associating to a scalar-valued linear map and an element of `γ` the
 `γ`-valued linear map obtained by multiplying the two (a.k.a. tensoring by `γ`) -/
-def scalar_prod_space_iso (c : β →L[α] α) (f : γ) : β →L[α] γ :=
+def smul_right (c : β →L[α] α) (f : γ) : β →L[α] γ :=
 { cont := continuous_smul c.2 continuous_const,
-  ..c.to_linear_map.scalar_prod_space_iso f }
+  ..c.to_linear_map.smul_right f }
 
 variable [topological_add_group γ]
 


### PR DESCRIPTION
There are two identical definitions in `linear_algebra/basic`, named `smul_right` and `scalar_prod_space_iso`. I had introduced the second one some time ago, unaware of the existence of the first one. In this PR, I remove `scalar_prod_space_iso` and replace all its subsequent uses with `smul_right`. 

I have also used this occasion to lint all the files this PR touches.