### PR TITLE
feat(analysis/normed_space): Riesz's lemma

### DIFF
--- a/src/analysis/normed_space/riesz_lemma.lean
+++ b/src/analysis/normed_space/riesz_lemma.lean
@@ -2,11 +2,15 @@
 Copyright (c) 2019 Jean Lo. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jean Lo
-
-Riesz's lemma on a normed space over a normed field.
 -/
 import analysis.normed_space.basic
 import topology.metric_space.hausdorff_distance
+
+/-!
+# Riesz's lemma
+
+Riesz's lemma, stated for a normed space over a normed field.
+-/
 
 variables {𝕜 : Type*} [normed_field 𝕜]
 variables {E : Type*} [normed_group E] [normed_space 𝕜 E]

--- a/src/analysis/normed_space/riesz_lemma.lean
+++ b/src/analysis/normed_space/riesz_lemma.lean
@@ -1,30 +1,33 @@
 import analysis.normed_space.basic
 import topology.metric_space.hausdorff_distance
 
-variables {k : Type*} [normed_field k]
-variables {α : Type*} [normed_group α] [normed_space k α]
+variables {𝕜 : Type*} [normed_field 𝕜]
+variables {E : Type*} [normed_group E] [normed_space 𝕜 E]
 
-/-- Riesz's Lemma. Stated in terms of multiples of norms since in
-    general the existence of an element of norm exactly 1 is not
-    guaranteed. -/
-lemma riesz_lemma {β : subspace k α} (hβc : is_closed β.carrier)
-(hβ : ∃ a : α, a ∉ β) {r : ℝ} (hr : r < 1) :
-∃ x ≠ (0 : α), ∀ y : β, r * ∥x∥ ≤ ∥x - y∥ :=
-let ⟨a, ha⟩ := hβ in or.cases_on (le_or_lt r 0)
-(λ hle, ⟨a, λ ha₀, ha (ha₀.symm ▸ (submodule.zero β)), λ b,
-calc _ ≤ 0 : mul_nonpos_of_nonpos_of_nonneg hle (norm_nonneg _)
-...    ≤ _ : norm_nonneg _⟩)
-(λ hlt, let d := metric.inf_dist a β in
-have hβn : β.carrier ≠ ∅, from set.ne_empty_of_mem (submodule.zero β),
+/--
+Riesz's Lemma, which usually states that it is possible to find a
+vector with norm 1 whose distance to a closed proper subspace is
+arbitrarily close to 1. It is stated here in terms of multiples of
+norms, since in general the existence of an element of norm exactly 1
+is not guaranteed.
+-/
+lemma riesz_lemma {F : subspace 𝕜 E} (hFc : is_closed F.carrier)
+  (hF : ∃ x : E, x ∉ F) {r : ℝ} (hr : r < 1) :
+  ∃ x₀ : E, ∀ y : F, r * ∥x₀∥ ≤ ∥x₀ - y∥ :=
+or.cases_on (le_or_lt r 0)
+(λ hle, ⟨0, λ _, by {rw [norm_zero, mul_zero], exact norm_nonneg _}⟩)
+(λ hlt,
+let ⟨x, hx⟩ := hF in
+let d := metric.inf_dist x F in
+have hFn : F.carrier ≠ ∅, from set.ne_empty_of_mem (submodule.zero F),
 have hdp : 0 < d,
-  from lt_of_le_of_ne metric.inf_dist_nonneg $ λ heq, ha
-  ((metric.mem_iff_inf_dist_zero_of_closed hβc hβn).2 heq.symm),
+  from lt_of_le_of_ne metric.inf_dist_nonneg $ λ heq, hx
+  ((metric.mem_iff_inf_dist_zero_of_closed hFc hFn).2 heq.symm),
 have hdlt : d < d / r, from lt_div_of_mul_lt hlt ((mul_lt_iff_lt_one_right hdp).2 hr),
-let ⟨b₀, hb₀β, hab₀⟩ := metric.exists_dist_lt_of_inf_dist_lt hdlt hβn in
-⟨a - b₀, λ haeq, ha ((eq_of_sub_eq_zero haeq).symm ▸ hb₀β),
-λ b,
-have hb₀b : (b₀ + b) ∈ β.carrier, from β.add hb₀β b.property,
+let ⟨y₀, hy₀F, hxy₀⟩ := metric.exists_dist_lt_of_inf_dist_lt hdlt hFn in
+⟨x - y₀, λ y,
+have hy₀y : (y₀ + y) ∈ F.carrier, from F.add hy₀F y.property,
 le_of_lt $ calc
-∥a - b₀ - b∥ = dist a (b₀ + b) : by { rw [sub_sub, dist_eq_norm] }
-...          ≥ d : metric.inf_dist_le_dist_of_mem hb₀b
-...          > _ : by { rw ←dist_eq_norm, exact (lt_div_iff' hlt).1 hab₀ }⟩)
+∥x - y₀ - y∥ = dist x (y₀ + y) : by { rw [sub_sub, dist_eq_norm] }
+...          ≥ d : metric.inf_dist_le_dist_of_mem hy₀y
+...          > _ : by { rw ←dist_eq_norm, exact (lt_div_iff' hlt).1 hxy₀ }⟩)

--- a/src/analysis/normed_space/riesz_lemma.lean
+++ b/src/analysis/normed_space/riesz_lemma.lean
@@ -1,16 +1,21 @@
+/-
+Copyright (c) 2019 Jean Lo. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jean Lo
+
+Riesz's lemma on a normed space over a normed field.
+-/
 import analysis.normed_space.basic
 import topology.metric_space.hausdorff_distance
 
 variables {𝕜 : Type*} [normed_field 𝕜]
 variables {E : Type*} [normed_group E] [normed_space 𝕜 E]
 
-/--
-Riesz's Lemma, which usually states that it is possible to find a
+/-- Riesz's lemma, which usually states that it is possible to find a
 vector with norm 1 whose distance to a closed proper subspace is
-arbitrarily close to 1. It is stated here in terms of multiples of
+arbitrarily close to 1. The statement here is in terms of multiples of
 norms, since in general the existence of an element of norm exactly 1
-is not guaranteed.
--/
+is not guaranteed. -/
 lemma riesz_lemma {F : subspace 𝕜 E} (hFc : is_closed F.carrier)
   (hF : ∃ x : E, x ∉ F) {r : ℝ} (hr : r < 1) :
   ∃ x₀ : E, ∀ y : F, r * ∥x₀∥ ≤ ∥x₀ - y∥ :=
@@ -23,7 +28,8 @@ have hFn : F.carrier ≠ ∅, from set.ne_empty_of_mem (submodule.zero F),
 have hdp : 0 < d,
   from lt_of_le_of_ne metric.inf_dist_nonneg $ λ heq, hx
   ((metric.mem_iff_inf_dist_zero_of_closed hFc hFn).2 heq.symm),
-have hdlt : d < d / r, from lt_div_of_mul_lt hlt ((mul_lt_iff_lt_one_right hdp).2 hr),
+have hdlt : d < d / r,
+  from lt_div_of_mul_lt hlt ((mul_lt_iff_lt_one_right hdp).2 hr),
 let ⟨y₀, hy₀F, hxy₀⟩ := metric.exists_dist_lt_of_inf_dist_lt hdlt hFn in
 ⟨x - y₀, λ y,
 have hy₀y : (y₀ + y) ∈ F.carrier, from F.add hy₀F y.property,

--- a/src/analysis/normed_space/riesz_lemma.lean
+++ b/src/analysis/normed_space/riesz_lemma.lean
@@ -1,0 +1,30 @@
+import analysis.normed_space.basic
+import topology.metric_space.hausdorff_distance
+
+variables {k : Type*} [normed_field k]
+variables {α : Type*} [normed_group α] [normed_space k α]
+
+/-- Riesz's Lemma. Stated in terms of multiples of norms since in
+    general the existence of an element of norm exactly 1 is not
+    guaranteed. -/
+lemma riesz_lemma {β : subspace k α} (hβc : is_closed β.carrier)
+(hβ : ∃ a : α, a ∉ β)
+{r : ℝ} (hr : r < 1) : ∃ x : α, ∀ y : β, r * ∥x∥ ≤ ∥x - y∥ :=
+or.cases_on (le_or_lt r 0)
+(λ hle, ⟨0, λ b, by {rw [norm_zero, mul_zero], exact norm_nonneg _}⟩)
+(λ hlt,
+let ⟨a, ha⟩ := hβ in
+let d := metric.inf_dist a β in
+have hβn : β.carrier ≠ ∅, from set.ne_empty_of_mem (submodule.zero β),
+have hdp : 0 < d,
+  from lt_of_le_of_ne metric.inf_dist_nonneg $ λ heq, ha
+  ((metric.mem_iff_inf_dist_zero_of_closed hβc hβn).2 heq.symm),
+have hdlt : d < d / r, from lt_div_of_mul_lt hlt ((mul_lt_iff_lt_one_right hdp).2 hr),
+let ⟨b₀, hb₀β, hab₀⟩ := metric.exists_dist_lt_of_inf_dist_lt hdlt hβn in
+⟨a - b₀, λ b,
+have hb₀b : (b₀ + b) ∈ β.carrier, from β.add hb₀β b.property,
+le_of_lt $ calc
+∥a - b₀ - b∥ = dist a (b₀ + b) : by { rw [sub_sub, dist_eq_norm] }
+...          ≥ d : metric.inf_dist_le_dist_of_mem hb₀b
+...          > _ : by { rw ←dist_eq_norm, exact (lt_div_iff' hlt).1 hab₀ }⟩)
+

--- a/src/analysis/normed_space/riesz_lemma.lean
+++ b/src/analysis/normed_space/riesz_lemma.lean
@@ -3,13 +3,16 @@ Copyright (c) 2019 Jean Lo. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jean Lo
 -/
+
 import analysis.normed_space.basic
 import topology.metric_space.hausdorff_distance
 
 /-!
 # Riesz's lemma
 
-Riesz's lemma, stated for a normed space over a normed field.
+Riesz's lemma, stated for a normed space over a normed field: for any
+closed proper subspace F of E, there is a nonzero x such that ∥x - F∥
+is at least r * ∥x∥ for any r < 1.
 -/
 
 variables {𝕜 : Type*} [normed_field 𝕜]
@@ -20,7 +23,7 @@ vector with norm 1 whose distance to a closed proper subspace is
 arbitrarily close to 1. The statement here is in terms of multiples of
 norms, since in general the existence of an element of norm exactly 1
 is not guaranteed. -/
-lemma riesz_lemma {F : subspace 𝕜 E} (hFc : is_closed F.carrier)
+lemma riesz_lemma {F : subspace 𝕜 E} (hFc : is_closed (F : set E))
   (hF : ∃ x : E, x ∉ F) {r : ℝ} (hr : r < 1) :
   ∃ x₀ : E, ∀ y : F, r * ∥x₀∥ ≤ ∥x₀ - y∥ :=
 or.cases_on (le_or_lt r 0)
@@ -28,7 +31,7 @@ or.cases_on (le_or_lt r 0)
 (λ hlt,
 let ⟨x, hx⟩ := hF in
 let d := metric.inf_dist x F in
-have hFn : F.carrier ≠ ∅, from set.ne_empty_of_mem (submodule.zero F),
+have hFn : (F : set E) ≠ ∅, from set.ne_empty_of_mem (submodule.zero F),
 have hdp : 0 < d,
   from lt_of_le_of_ne metric.inf_dist_nonneg $ λ heq, hx
   ((metric.mem_iff_inf_dist_zero_of_closed hFc hFn).2 heq.symm),
@@ -36,7 +39,7 @@ have hdlt : d < d / r,
   from lt_div_of_mul_lt hlt ((mul_lt_iff_lt_one_right hdp).2 hr),
 let ⟨y₀, hy₀F, hxy₀⟩ := metric.exists_dist_lt_of_inf_dist_lt hdlt hFn in
 ⟨x - y₀, λ y,
-have hy₀y : (y₀ + y) ∈ F.carrier, from F.add hy₀F y.property,
+have hy₀y : (y₀ + y) ∈ F, from F.add hy₀F y.property,
 le_of_lt $ calc
 ∥x - y₀ - y∥ = dist x (y₀ + y) : by { rw [sub_sub, dist_eq_norm] }
 ...          ≥ d : metric.inf_dist_le_dist_of_mem hy₀y

--- a/src/analysis/normed_space/riesz_lemma.lean
+++ b/src/analysis/normed_space/riesz_lemma.lean
@@ -8,23 +8,23 @@ variables {α : Type*} [normed_group α] [normed_space k α]
     general the existence of an element of norm exactly 1 is not
     guaranteed. -/
 lemma riesz_lemma {β : subspace k α} (hβc : is_closed β.carrier)
-(hβ : ∃ a : α, a ∉ β)
-{r : ℝ} (hr : r < 1) : ∃ x : α, ∀ y : β, r * ∥x∥ ≤ ∥x - y∥ :=
-or.cases_on (le_or_lt r 0)
-(λ hle, ⟨0, λ b, by {rw [norm_zero, mul_zero], exact norm_nonneg _}⟩)
-(λ hlt,
-let ⟨a, ha⟩ := hβ in
-let d := metric.inf_dist a β in
+(hβ : ∃ a : α, a ∉ β) {r : ℝ} (hr : r < 1) :
+∃ x ≠ (0 : α), ∀ y : β, r * ∥x∥ ≤ ∥x - y∥ :=
+let ⟨a, ha⟩ := hβ in or.cases_on (le_or_lt r 0)
+(λ hle, ⟨a, λ ha₀, ha (ha₀.symm ▸ (submodule.zero β)), λ b,
+calc _ ≤ 0 : mul_nonpos_of_nonpos_of_nonneg hle (norm_nonneg _)
+...    ≤ _ : norm_nonneg _⟩)
+(λ hlt, let d := metric.inf_dist a β in
 have hβn : β.carrier ≠ ∅, from set.ne_empty_of_mem (submodule.zero β),
 have hdp : 0 < d,
   from lt_of_le_of_ne metric.inf_dist_nonneg $ λ heq, ha
   ((metric.mem_iff_inf_dist_zero_of_closed hβc hβn).2 heq.symm),
 have hdlt : d < d / r, from lt_div_of_mul_lt hlt ((mul_lt_iff_lt_one_right hdp).2 hr),
 let ⟨b₀, hb₀β, hab₀⟩ := metric.exists_dist_lt_of_inf_dist_lt hdlt hβn in
-⟨a - b₀, λ b,
+⟨a - b₀, λ haeq, ha ((eq_of_sub_eq_zero haeq).symm ▸ hb₀β),
+λ b,
 have hb₀b : (b₀ + b) ∈ β.carrier, from β.add hb₀β b.property,
 le_of_lt $ calc
 ∥a - b₀ - b∥ = dist a (b₀ + b) : by { rw [sub_sub, dist_eq_norm] }
 ...          ≥ d : metric.inf_dist_le_dist_of_mem hb₀b
 ...          > _ : by { rw ←dist_eq_norm, exact (lt_div_iff' hlt).1 hab₀ }⟩)
-

--- a/src/topology/metric_space/hausdorff_distance.lean
+++ b/src/topology/metric_space/hausdorff_distance.lean
@@ -456,7 +456,7 @@ lemma mem_closure_iff_inf_dist_zero (h : s ≠ ∅) : x ∈ closure s ↔ inf_di
 by simp [mem_closure_iff_inf_edist_zero, inf_dist, ennreal.to_real_eq_zero_iff, inf_edist_ne_top h]
 
 /-- Given a closed set `s`, a point belongs to `s` iff its infimum distance to this set vanishes -/
-lemma mem_iff_ind_dist_zero_of_closed (h : is_closed s) (hs : s ≠ ∅) :
+lemma mem_iff_inf_dist_zero_of_closed (h : is_closed s) (hs : s ≠ ∅) :
   x ∈ s ↔ inf_dist x s = 0 :=
 begin
   have := @mem_closure_iff_inf_dist_zero _ _ s x hs,


### PR DESCRIPTION
Riesz's lemma stated for a normed space. It's temporarily punted into its own file and since I'm unsure neither of where it belongs nor what a convention-conforming name for it should be — could someone please give me some pointers on this?

also fixed what seemed to be a typo in `topology/metric/hausdorff_distance`.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
