### PR TITLE
docs(tactic/lint) add code fence around #print statement to avoid its…

### DIFF
--- a/src/tactic/lint.lean
+++ b/src/tactic/lint.lean
@@ -119,7 +119,7 @@ meta def fold_over_with_cond_sorted {α} (l : list declaration)
   return $ ds₂.to_list
 
 /-- Make the output of `fold_over_with_cond` printable, in the following form:
-      #print <name> <open multiline comment> <elt of α> <close multiline comment> -/
+      `#print <name> <open multiline comment> <elt of α> <close multiline comment>` -/
 meta def print_decls {α} [has_to_format α] (ds : list (declaration × α)) : format :=
 ds.foldl
   (λ f x, f ++ "\n" ++ to_fmt "#print " ++ to_fmt x.1.to_name ++ " /- " ++ to_fmt x.2 ++ " -/")


### PR DESCRIPTION
… args looking like html tags.

I'm really not sure what to do about this line,
statements <name> get implicitly treated like html tags in markdown.
we can put it in a code fence, but <name> isn't really valid if we assume code fences are supposed to be valid lean.

given that there are plenty of other statements which aren't stand alone valid lean,
I just put a code fence around it for now.  If anyone has a better idea...

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
