### PR TITLE
doc(linear_algebra): rename lin_equiv to linear_equiv

### DIFF
--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -24,8 +24,8 @@ Many of the relevant definitions, including `module`, `submodule`, and `linear_m
   that is, elements of `M` are identified if their difference is in `p`. This is itself a module.
 * The kernel `ker` and range `range` of a linear map are submodules of the domain and codomain
   respectively.
-* `lin_equiv M M₂`, the type of linear equivalences between `M` and `M₂`, is a structure that extends
-  `linear_map` and `equiv`.
+* `linear_equiv M M₂`, the type of linear equivalences between `M` and `M₂`, is a structure that
+  extends `linear_map` and `equiv`.
 * The general linear group is defined to be the group of invertible linear maps from `M` to itself.
 
 ## Main statements
@@ -37,8 +37,8 @@ Many of the relevant definitions, including `module`, `submodule`, and `linear_m
 
 * We continue to use the notation `M →ₗ[R] M₂` for the type of linear maps from `M` to `M₂` over the
   ring `R`.
-* We introduce the notations `M ≃ₗ M₂` and `M ≃ₗ[R] M₂` for `lin_equiv M M₂`. In the first, the ring
-  `R` is implicit.
+* We introduce the notations `M ≃ₗ M₂` and `M ≃ₗ[R] M₂` for `linear_equiv M M₂`. In the first, the
+  ring `R` is implicit.
 
 ## Implementation notes
 

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -24,7 +24,7 @@ diagonal matrix (range, ker and rank).
 
 ## Main definitions
 
-to_lin, to_matrix, lin_equiv_matrix
+to_lin, to_matrix, linear_equiv_matrix
 
 ## Tags
 
@@ -119,7 +119,7 @@ def to_matrix [decidable_eq n] : ((n → R) →ₗ[R] (m → R)) → matrix m n 
 
 end linear_map
 
-section lin_equiv_matrix
+section linear_equiv_matrix
 
 variables {R : Type v} [comm_ring R] [decidable_eq n]
 
@@ -165,7 +165,7 @@ begin
 end
 
 /-- Linear maps (n → R) →ₗ[R] (m → R) are linearly equivalent to matrix  m n R. -/
-def lin_equiv_matrix' : ((n → R) →ₗ[R] (m → R)) ≃ₗ[R] matrix m n R :=
+def linear_equiv_matrix' : ((n → R) →ₗ[R] (m → R)) ≃ₗ[R] matrix m n R :=
 { to_fun := to_matrix,
   inv_fun := to_lin,
   right_inv := λ _, to_lin_to_matrix,
@@ -175,15 +175,15 @@ def lin_equiv_matrix' : ((n → R) →ₗ[R] (m → R)) ≃ₗ[R] matrix m n R :
 
 /-- Given a basis of two modules M₁ and M₂ over a commutative ring R, we get a linear equivalence
 between linear maps M₁ →ₗ M₂ and matrices over R indexed by the bases. -/
-def lin_equiv_matrix {ι κ M₁ M₂ : Type*}
+def linear_equiv_matrix {ι κ M₁ M₂ : Type*}
   [add_comm_group M₁] [module R M₁]
   [add_comm_group M₂] [module R M₂]
   [fintype ι] [decidable_eq ι] [fintype κ] [decidable_eq κ]
   {v₁ : ι → M₁} {v₂ : κ → M₂} (hv₁ : is_basis R v₁) (hv₂ : is_basis R v₂) :
   (M₁ →ₗ[R] M₂) ≃ₗ[R] matrix κ ι R :=
-linear_equiv.trans (linear_equiv.arrow_congr (equiv_fun_basis hv₁) (equiv_fun_basis hv₂)) lin_equiv_matrix'
+linear_equiv.trans (linear_equiv.arrow_congr (equiv_fun_basis hv₁) (equiv_fun_basis hv₂)) linear_equiv_matrix'
 
-end lin_equiv_matrix
+end linear_equiv_matrix
 
 namespace matrix
 


### PR DESCRIPTION
In `linear_algebra/basic`, linear equivalences are defined as `linear_equiv` in the code, but as `lin_equiv` in the doc. I change the doc. For coherence, I also rename `lin_equiv_matrix` to `linear_equiv_matrix`.