### PR TITLE
chore(category_theory): use the new @[ext] attribute on structures

### DIFF
--- a/src/algebraic_geometry/presheafed_space.lean
+++ b/src/algebraic_geometry/presheafed_space.lean
@@ -90,7 +90,7 @@ instance category_of_PresheafedSpaces : category (PresheafedSpace.{v} C) :=
   begin
     ext1, swap,
     { dsimp, simp only [id_comp] },
-    { ext1 U,
+    { ext1, ext1 U,
       op_induction,
       cases U,
       dsimp,
@@ -100,7 +100,7 @@ instance category_of_PresheafedSpaces : category (PresheafedSpace.{v} C) :=
   begin
     ext1, swap,
     { dsimp, simp only [comp_id] },
-    { ext1 U,
+    { ext1, ext1 U,
       op_induction,
       cases U,
       dsimp,
@@ -178,7 +178,7 @@ def map_presheaf (F : C ⥤ D) : PresheafedSpace.{v} C ⥤ PresheafedSpace.{v} D
   begin
     ext1, swap,
     { refl },
-    { ext1,
+    { ext,
       dsimp,
       simp only [presheaf.pushforward, eq_to_hom_map, map_id, comp_id, id_c_app],
       refl }
@@ -214,7 +214,7 @@ def on_presheaf {F G : C ⥤ D} (α : F ⟶ G) : G.map_presheaf ⟶ F.map_preshe
   begin
     ext1, swap,
     { refl },
-    { ext1 U,
+    { ext1, ext1 U,
       op_induction,
       cases U,
       dsimp,

--- a/src/algebraic_geometry/presheafed_space.lean
+++ b/src/algebraic_geometry/presheafed_space.lean
@@ -90,7 +90,7 @@ instance category_of_PresheafedSpaces : category (PresheafedSpace.{v} C) :=
   begin
     ext1, swap,
     { dsimp, simp only [id_comp] },
-    { ext1, ext1 U,
+    { ext U,
       op_induction,
       cases U,
       dsimp,
@@ -100,7 +100,7 @@ instance category_of_PresheafedSpaces : category (PresheafedSpace.{v} C) :=
   begin
     ext1, swap,
     { dsimp, simp only [comp_id] },
-    { ext1, ext1 U,
+    { ext U,
       op_induction,
       cases U,
       dsimp,
@@ -214,7 +214,7 @@ def on_presheaf {F G : C ⥤ D} (α : F ⟶ G) : G.map_presheaf ⟶ F.map_preshe
   begin
     ext1, swap,
     { refl },
-    { ext1, ext1 U,
+    { ext U,
       op_induction,
       cases U,
       dsimp,

--- a/src/category_theory/adjunction/basic.lean
+++ b/src/category_theory/adjunction/basic.lean
@@ -71,7 +71,7 @@ by rw [equiv.symm_apply_eq]; simp [-hom_equiv_counit]
 @[simp] lemma left_triangle :
   (whisker_right adj.unit F) ≫ (whisker_left F adj.counit) = nat_trans.id _ :=
 begin
-  ext1 X, dsimp,
+  ext, dsimp,
   erw [← adj.hom_equiv_counit, equiv.symm_apply_eq, adj.hom_equiv_unit],
   simp
 end
@@ -79,7 +79,7 @@ end
 @[simp] lemma right_triangle :
   (whisker_left G adj.unit) ≫ (whisker_right adj.counit G) = nat_trans.id _ :=
 begin
-  ext1 Y, dsimp,
+  ext, dsimp,
   erw [← adj.hom_equiv_unit, ← equiv.eq_symm_apply, adj.hom_equiv_counit],
   simp
 end
@@ -288,8 +288,8 @@ namespace equivalence
 
 def to_adjunction (e : C ≌ D) : e.functor ⊣ e.inverse :=
 mk_of_unit_counit ⟨e.unit, e.counit,
-  by { ext, dsimp, simp only [id_comp], exact e.functor_unit_comp X, },
-  by { ext, dsimp, simp only [id_comp], exact e.unit_inverse_comp X, }⟩
+  by { ext, dsimp, simp only [id_comp], exact e.functor_unit_comp _, },
+  by { ext, dsimp, simp only [id_comp], exact e.unit_inverse_comp _, }⟩
 
 end equivalence
 

--- a/src/category_theory/adjunction/fully_faithful.lean
+++ b/src/category_theory/adjunction/fully_faithful.lean
@@ -28,14 +28,14 @@ instance unit_is_iso_of_L_fully_faithful [full L] [faithful L] : is_iso (adjunct
 { inv := { app := λ Y f, L.preimage ((h.hom_equiv (unop Y) (L.obj X)).symm f) },
   inv_hom_id' :=
   begin
-    ext1, ext1, dsimp,
+    ext, dsimp,
     simp only [adjunction.hom_equiv_counit, preimage_comp, preimage_map, category.assoc],
     rw ←h.unit_naturality,
     simp,
   end,
   hom_inv_id' :=
   begin
-    ext1, ext1, dsimp,
+    ext, dsimp,
     apply L.injectivity,
     simp,
   end }.
@@ -47,14 +47,14 @@ instance counit_is_iso_of_R_fully_faithful [full R] [faithful R] : is_iso (adjun
 { inv := { app := λ Y f, R.preimage ((h.hom_equiv (R.obj X) Y) f) },
   inv_hom_id' :=
   begin
-    ext1, ext1, dsimp,
+    ext, dsimp,
     simp only [adjunction.hom_equiv_unit, preimage_comp, preimage_map],
     rw ←h.counit_naturality,
     simp,
   end,
   hom_inv_id' :=
   begin
-    ext1, ext1, dsimp,
+    ext, dsimp,
     apply R.injectivity,
     simp,
   end }

--- a/src/category_theory/comma.lean
+++ b/src/category_theory/comma.lean
@@ -21,23 +21,13 @@ structure comma (L : A ⥤ T) (R : B ⥤ T) : Type (max u₁ u₂ v₃) :=
 
 variables {L : A ⥤ T} {R : B ⥤ T}
 
-structure comma_morphism (X Y : comma L R) :=
+@[ext] structure comma_morphism (X Y : comma L R) :=
 (left : X.left ⟶ Y.left . obviously)
 (right : X.right ⟶ Y.right . obviously)
 (w' : L.map left ≫ Y.hom = X.hom ≫ R.map right . obviously)
 
 restate_axiom comma_morphism.w'
 attribute [simp] comma_morphism.w
-
-namespace comma_morphism
-@[ext] lemma ext
-  {X Y : comma L R} {f g : comma_morphism X Y}
-  (l : f.left = g.left) (r : f.right = g.right) : f = g :=
-begin
-  cases f, cases g,
-  congr; assumption
-end
-end comma_morphism
 
 instance comma_category : category (comma L R) :=
 { hom := comma_morphism,

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -206,16 +206,12 @@ end
 
 end cocone
 
-structure cone_morphism (A B : cone F) :=
+@[ext] structure cone_morphism (A B : cone F) :=
 (hom : A.X ⟶ B.X)
 (w'  : ∀ j : J, hom ≫ B.π.app j = A.π.app j . obviously)
 
 restate_axiom cone_morphism.w'
 attribute [simp] cone_morphism.w
-
-@[ext] lemma cone_morphism.ext {A B : cone F} {f g : cone_morphism A B}
-  (w : f.hom = g.hom) : f = g :=
-by cases f; cases g; simpa using w
 
 @[simps] instance cone.category : category.{v} (cone F) :=
 { hom  := λ A B, cone_morphism A B,
@@ -270,16 +266,12 @@ include 𝒟
 end
 end cones
 
-structure cocone_morphism (A B : cocone F) :=
+@[ext] structure cocone_morphism (A B : cocone F) :=
 (hom : A.X ⟶ B.X)
 (w'  : ∀ j : J, A.ι.app j ≫ hom = B.ι.app j . obviously)
 
 restate_axiom cocone_morphism.w'
 attribute [simp] cocone_morphism.w
-
-@[ext] lemma cocone_morphism.ext
-  {A B : cocone F} {f g : cocone_morphism A B} (w : f.hom = g.hom) : f = g :=
-by cases f; cases g; simpa using w
 
 @[simps] instance cocone.category : category.{v} (cocone F) :=
 { hom  := λ A B, cocone_morphism A B,

--- a/src/category_theory/limits/functor_category.lean
+++ b/src/category_theory/limits/functor_category.lean
@@ -61,7 +61,7 @@ def functor_category_is_limit_cone [has_limits_of_shape J C] (F : J ⥤ K ⥤ C)
   { app := λ k, limit.lift (F.flip.obj k) (((evaluation K C).obj k).map_cone s) },
   uniq' := λ s m w,
   begin
-    ext1 k,
+    ext1, ext1 k,
     exact is_limit.uniq _
       (((evaluation K C).obj k).map_cone s) (m.app k) (λ j, nat_trans.congr_app (w j) k)
   end }
@@ -72,7 +72,7 @@ def functor_category_is_colimit_cocone [has_colimits_of_shape.{v} J C] (F : J �
   { app := λ k, colimit.desc (F.flip.obj k) (((evaluation K C).obj k).map_cocone s) },
   uniq' := λ s m w,
   begin
-    ext1 k,
+    ext1, ext1 k,
     exact is_colimit.uniq _
       (((evaluation K C).obj k).map_cocone s) (m.app k) (λ j, nat_trans.congr_app (w j) k)
   end }

--- a/src/category_theory/monad/algebra.lean
+++ b/src/category_theory/monad/algebra.lean
@@ -41,7 +41,7 @@ restate_axiom algebra.assoc'
 namespace algebra
 variables {T : C ⥤ C} [monad.{v₁} T]
 
-structure hom (A B : algebra T) :=
+@[ext] structure hom (A B : algebra T) :=
 (f : A.A ⟶ B.A)
 (h' : T.map f ≫ B.a = A.a ≫ f . obviously)
 
@@ -49,8 +49,6 @@ restate_axiom hom.h'
 attribute [simp] hom.h
 
 namespace hom
-@[ext] lemma ext {A B : algebra T} (f g : hom A B) (w : f.f = g.f) : f = g :=
-by { cases f, cases g, congr, assumption }
 
 @[simps] def id (A : algebra T) : hom A A :=
 { f := 𝟙 A.A }

--- a/src/category_theory/natural_transformation.lean
+++ b/src/category_theory/natural_transformation.lean
@@ -28,7 +28,7 @@ The field `app` provides the components of the natural transformation.
 
 Naturality is expressed by `α.naturality_lemma`.
 -/
-structure nat_trans (F G : C ⥤ D) : Type (max u₁ v₂) :=
+@[ext] structure nat_trans (F G : C ⥤ D) : Type (max u₁ v₂) :=
 (app : Π X : C, (F.obj X) ⟶ (G.obj X))
 (naturality' : ∀ {{X Y : C}} (f : X ⟶ Y), (F.map f) ≫ (app Y) = (app X) ≫ (G.map f) . obviously)
 
@@ -57,15 +57,6 @@ def vcomp (α : nat_trans F G) (β : nat_trans G H) : nat_trans F H :=
     /- `obviously'` says: -/
     intros, simp, rw [←assoc, naturality, assoc, ←naturality],
   end }
-
--- We'll want to be able to prove that two natural transformations are equal if they are componentwise equal.
-@[ext] lemma ext {α β : nat_trans F G} (w : ∀ X : C, α.app X = β.app X) : α = β :=
-begin
-  induction α with α_components α_naturality,
-  induction β with β_components β_naturality,
-  have hc : α_components = β_components := funext w,
-  subst hc
-end
 
 @[simp] lemma vcomp_app (α : nat_trans F G) (β : nat_trans G H) (X : C) :
   (vcomp α β).app X = (α.app X) ≫ (β.app X) := rfl

--- a/src/category_theory/whiskering.lean
+++ b/src/category_theory/whiskering.lean
@@ -33,7 +33,7 @@ variables (C D E)
   { app := λ H,
     { app := λ c, H.map (τ.app c),
       naturality' := λ X Y f, begin dsimp, rw [←H.map_comp, ←H.map_comp, ←τ.naturality] end },
-    naturality' := λ X Y f, begin ext1, dsimp, rw [f.naturality] end } }
+    naturality' := λ X Y f, begin ext, dsimp, rw [f.naturality] end } }
 
 @[simps] def whiskering_right : (D ⥤ E) ⥤ ((C ⥤ D) ⥤ (C ⥤ E)) :=
 { obj := λ H,
@@ -43,7 +43,7 @@ variables (C D E)
   { app := λ F,
     { app := λ c, τ.app (F.obj c),
       naturality' := λ X Y f, begin dsimp, rw [τ.naturality] end },
-    naturality' := λ X Y f, begin ext1, dsimp, rw [←nat_trans.naturality] end } }
+    naturality' := λ X Y f, begin ext, dsimp, rw [←nat_trans.naturality] end } }
 
 variables {C} {D} {E}
 
@@ -139,7 +139,7 @@ omit 𝒟
 lemma triangle (F : A ⥤ B) (G : B ⥤ C) :
   (associator F (𝟭 B) G).hom ≫ (whisker_left F (left_unitor G).hom) =
     (whisker_right (right_unitor F).hom G) :=
-by { ext1, dsimp, simp }
+by { ext, dsimp, simp }
 
 variables {E : Type u₅} [ℰ : category.{v₅} E]
 include 𝒟 ℰ
@@ -149,7 +149,7 @@ variables (F : A ⥤ B) (G : B ⥤ C) (H : C ⥤ D) (K : D ⥤ E)
 lemma pentagon :
   (whisker_right (associator F G H).hom K) ≫ (associator F (G ⋙ H) K).hom ≫ (whisker_left F (associator G H K).hom) =
     ((associator (F ⋙ G) H K).hom ≫ (associator F G (H ⋙ K)).hom) :=
-by { ext1, dsimp, simp }
+by { ext, dsimp, simp }
 
 end functor
 

--- a/src/category_theory/yoneda.lean
+++ b/src/category_theory/yoneda.lean
@@ -27,8 +27,8 @@ include 𝒞
 { obj := λ X,
   { obj := λ Y, unop Y ⟶ X,
     map := λ Y Y' f g, f.unop ≫ g,
-    map_comp' := λ _ _ _ f g, begin ext1, dsimp, erw [category.assoc] end,
-    map_id' := λ Y, begin ext1, dsimp, erw [category.id_comp] end },
+    map_comp' := λ _ _ _ f g, begin ext, dsimp, erw [category.assoc] end,
+    map_id' := λ Y, begin ext, dsimp, erw [category.id_comp] end },
   map := λ X X' f, { app := λ Y g, g ≫ f } }
 
 @[simps] def coyoneda : Cᵒᵖ ⥤ (C ⥤ Type v₁) :=
@@ -38,8 +38,8 @@ include 𝒞
     map_comp' := λ _ _ _ f g, begin ext1, dsimp, erw [category.assoc] end,
     map_id' := λ Y, begin ext1, dsimp, erw [category.comp_id] end },
   map := λ X X' f, { app := λ Y g, f.unop ≫ g },
-  map_comp' := λ _ _ _ f g, begin ext1, ext1, dsimp, erw [category.assoc] end,
-  map_id' := λ X, begin ext1, ext1, dsimp, erw [category.id_comp] end }
+  map_comp' := λ _ _ _ f g, begin ext, dsimp, erw [category.assoc] end,
+  map_id' := λ X, begin ext, dsimp, erw [category.id_comp] end }
 
 namespace yoneda
 
@@ -146,9 +146,7 @@ def yoneda_lemma : yoneda_pairing C ≅ yoneda_evaluation C :=
   { app := λ F x, ulift.up ((x.app F.1) (𝟙 (unop F.1))),
     naturality' :=
     begin
-      intros X Y f, ext1, ext1,
-      cases f, cases Y, cases X,
-      dsimp,
+      intros X Y f, ext, dsimp,
       erw [category.id_comp,
            ←functor_to_types.naturality,
            obj_map_id,
@@ -160,21 +158,17 @@ def yoneda_lemma : yoneda_pairing C ≅ yoneda_evaluation C :=
     { app := λ X a, (F.2.map a.op) x.down,
       naturality' :=
       begin
-        intros X Y f, ext1,
-        cases x, cases F,
-        dsimp,
-        erw [functor_to_types.map_comp]
+        intros X Y f, ext, dsimp,
+        rw [functor_to_types.map_comp]
       end },
     naturality' :=
     begin
-      intros X Y f, ext1, ext1, ext1,
-      cases x, cases f, cases Y, cases X,
-      dsimp,
-      erw [←functor_to_types.naturality, functor_to_types.map_comp]
+      intros X Y f, ext, dsimp,
+      rw [←functor_to_types.naturality, functor_to_types.map_comp]
     end },
   hom_inv_id' :=
   begin
-    ext1, ext1, ext1, ext1, cases X, dsimp,
+    ext, dsimp,
     erw [←functor_to_types.naturality,
          obj_map_id,
          functor_to_types.naturality,
@@ -183,10 +177,8 @@ def yoneda_lemma : yoneda_pairing C ≅ yoneda_evaluation C :=
   end,
   inv_hom_id' :=
   begin
-    ext1, ext1, ext1,
-    cases x, cases X,
-    dsimp,
-    erw [functor_to_types.map_id]
+    ext, dsimp,
+    rw [functor_to_types.map_id]
   end }.
 
 variables {C}


### PR DESCRIPTION
Now that we can directly tag structures with `@[ext]`, we can remove a few `@[ext]` lemmas in the category theory library.

There's one change here we may want to consider: the `@[ext]` generated lemma for a natural transformation is a bit lame: it just asserts that the `app` fields are the same, but the better lemma is to apply function extensionality. Of course, because `funext` is an `[ext]` lemma, calling `ext` blows through this in two steps anyway.

Also, slight cleanup of the (automatically generated) proofs of the Yoneda lemma.