### PR TITLE
fix(scripts/mk_all): don't add `lint_mathlib` to `all.lean` [skip ci]

### DIFF
--- a/scripts/mk_all.sh
+++ b/scripts/mk_all.sh
@@ -8,7 +8,7 @@ for d in $(find $DIR/../src/ -type d)
 do
   cd "$d" # cd to that directory
   echo "/- automatically generated file importing all files in this directory and subdirectories. -/" > all.lean
-  find . -maxdepth 1 -mindepth 1 -name 'all.lean' -prune -o -name '.*' -prune -o -name '*.lean' -print -o -type d -print |
+  find . -maxdepth 1 -mindepth 1 -name 'all.lean' -prune -o -name 'lint_mathlib.lean' -prune -o -name '.*' -prune -o -name '*.lean' -print -o -type d -print |
   # find all non-hidden files with the .lean extension (except all.lean) and all subdirectories
   sed 's/$/\.all/; s/\.lean\.all//; s/^\.\//       \./; 1s/^      /import/' >> all.lean
   # Now modify this output so that Lean can parse it. Changes `./foo.lean` to `.foo` and `foodir` to `.foodir.all`. Also adds indentation, a comment and `import`. Write this to `all.lean`


### PR DESCRIPTION
This way one can run `scripts/mk_all.sh` twice in a row without creating a circular dependency.