### PR TITLE
fix(tactic/core): correct `of_int` doc string

### DIFF
--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -19,7 +19,7 @@ nat.binary_rec
     do e ← tac, tactic.mk_app (cond b ``bit1 ``bit0) [e])
 
 /-- Given an expr `α` representing a type with numeral structure,
-`of_nat α n` creates the `α`-valued numeral expression corresponding to `n`.
+`of_int α n` creates the `α`-valued numeral expression corresponding to `n`.
 The output is either a numeral or the negation of a numeral. -/
 protected meta def of_int (α : expr) : ℤ → tactic expr
 | (n : ℕ) := expr.of_nat α n


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
