### PR TITLE
cleanup(data/equiv/basic): drop `quot_equiv_of_quot'`, rename `quot_equiv_of_quot`

### DIFF
--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -657,23 +657,6 @@ def subtype_pi_equiv_pi {α : Sort u} {β : α → Sort v} {p : Πa, β a → Pr
 
 end
 
-section
-
-local attribute [elab_with_expected_type] quot.lift
-
-def quot_equiv_of_quot' {r : α → α → Prop} {s : β → β → Prop} (e : α ≃ β)
-  (h : ∀ a a', r a a' ↔ s (e a) (e a')) : quot r ≃ quot s :=
-⟨quot.lift (λ a, quot.mk _ (e a)) (λ a a' H, quot.sound ((h a a').mp H)),
- quot.lift (λ b, quot.mk _ (e.symm b)) (λ b b' H, quot.sound ((h _ _).mpr (by convert H; simp))),
- quot.ind $ by simp,
- quot.ind $ by simp⟩
-
-def quot_equiv_of_quot {r : α → α → Prop} (e : α ≃ β) :
-  quot r ≃ quot (λ b b', r (e.symm b) (e.symm b')) :=
-quot_equiv_of_quot' e (by simp)
-
-end
-
 namespace set
 open set
 
@@ -944,7 +927,8 @@ def equiv_punit_of_unique [unique α] : α ≃ punit.{v} :=
 equiv_of_unique_of_unique
 
 namespace quot
-protected def congr {α β} {ra : α → α → Prop} {rb : β → β → Prop} (e : α ≃ β)
+
+protected def congr {ra : α → α → Prop} {rb : β → β → Prop} (e : α ≃ β)
   (eq : ∀a₁ a₂, ra a₁ a₂ ↔ rb (e a₁) (e a₂)) :
   quot ra ≃ quot rb :=
 { to_fun := quot.map e (assume a₁ a₂, (eq a₁ a₂).1),
@@ -957,18 +941,24 @@ protected def congr {α β} {ra : α → α → Prop} {rb : β → β → Prop} 
 
 /-- Quotients are congruent on equivalences under equality of their relation.
 An alternative is just to use rewriting with `eq`, but then computational proofs get stuck. -/
-protected def congr_right {α} {r r' : α → α → Prop} (eq : ∀a₁ a₂, r a₁ a₂ ↔ r' a₁ a₂) :
+protected def congr_right {r r' : α → α → Prop} (eq : ∀a₁ a₂, r a₁ a₂ ↔ r' a₁ a₂) :
   quot r ≃ quot r' :=
 quot.congr (equiv.refl α) eq
+
+
+protected def congr_left {r : α → α → Prop} (e : α ≃ β) :
+  quot r ≃ quot (λ b b', r (e.symm b) (e.symm b')) :=
+@quot.congr α β r (λ b b', r (e.symm b) (e.symm b')) e (λ a₁ a₂, by simp only [e.symm_apply_apply])
+
 end quot
 
 namespace quotient
-protected def congr {α β} {ra : setoid α} {rb : setoid β} (e : α ≃ β)
+protected def congr {ra : setoid α} {rb : setoid β} (e : α ≃ β)
   (eq : ∀a₁ a₂, @setoid.r α ra a₁ a₂ ↔ @setoid.r β rb (e a₁) (e a₂)) :
   quotient ra ≃ quotient rb :=
 quot.congr e eq
 
-protected def congr_right {α} {r r' : setoid α}
+protected def congr_right {r r' : setoid α}
   (eq : ∀a₁ a₂, @setoid.r α r a₁ a₂ ↔ @setoid.r α r' a₁ a₂) : quotient r ≃ quotient r' :=
 quot.congr_right eq
 end quotient

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -928,6 +928,8 @@ equiv_of_unique_of_unique
 
 namespace quot
 
+/-- An equivalence `e : α ≃ β` generates an equivalence between quotient spaces,
+if `ra a₁ a₂ ↔ rb (e a₁) (e a₂). -/
 protected def congr {ra : α → α → Prop} {rb : β → β → Prop} (e : α ≃ β)
   (eq : ∀a₁ a₂, ra a₁ a₂ ↔ rb (e a₁) (e a₂)) :
   quot ra ≃ quot rb :=
@@ -945,7 +947,8 @@ protected def congr_right {r r' : α → α → Prop} (eq : ∀a₁ a₂, r a₁
   quot r ≃ quot r' :=
 quot.congr (equiv.refl α) eq
 
-
+/-- An equivalence `e : α ≃ β` generates an equivalence between the quotient space of `α`
+by a relation `ra` and the quotient space of `β` by the image of this relation under `e`. -/
 protected def congr_left {r : α → α → Prop} (e : α ≃ β) :
   quot r ≃ quot (λ b b', r (e.symm b) (e.symm b')) :=
 @quot.congr α β r (λ b b', r (e.symm b) (e.symm b')) e (λ a₁ a₂, by simp only [e.symm_apply_apply])
@@ -953,11 +956,15 @@ protected def congr_left {r : α → α → Prop} (e : α ≃ β) :
 end quot
 
 namespace quotient
+/-- An equivalence `e : α ≃ β` generates an equivalence between quotient spaces,
+if `ra a₁ a₂ ↔ rb (e a₁) (e a₂). -/
 protected def congr {ra : setoid α} {rb : setoid β} (e : α ≃ β)
   (eq : ∀a₁ a₂, @setoid.r α ra a₁ a₂ ↔ @setoid.r β rb (e a₁) (e a₂)) :
   quotient ra ≃ quotient rb :=
 quot.congr e eq
 
+/-- Quotients are congruent on equivalences under equality of their relation.
+An alternative is just to use rewriting with `eq`, but then computational proofs get stuck. -/
 protected def congr_right {r r' : setoid α}
   (eq : ∀a₁ a₂, @setoid.r α r a₁ a₂ ↔ @setoid.r α r' a₁ a₂) : quotient r ≃ quotient r' :=
 quot.congr_right eq


### PR DESCRIPTION
* `quot_equiv_of_quot` was the same as `quot.congr`
* rename `quot_equiv_of_quot` to `quot.congr_left` to match
  `quot.congr` and `quot.congr_right`.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
