### PR TITLE
feat(order/lattice): add `monotone.le_map_sup` and `monotone.map_inf_le`

### DIFF
--- a/src/data/rel.lean
+++ b/src/data/rel.lean
@@ -5,7 +5,7 @@ Authors: Jeremy Avigad
 
 Operations on set-valued functions, aka partial multifunctions, aka relations.
 -/
-import tactic.basic data.set.lattice order.complete_lattice
+import tactic.basic data.set.lattice order.complete_lattice logic.relator
 
 variables {α : Type*} {β : Type*} {γ : Type*}
 
@@ -62,26 +62,18 @@ def image (s : set α) : set β := {y | ∃ x ∈ s, r x y}
 lemma mem_image (y : β) (s : set α) : y ∈ image r s ↔ ∃ x ∈ s, r x y :=
 iff.refl _
 
-lemma image_mono {s t : set α} (h : s ⊆ t) : r.image s ⊆ r.image t :=
-assume y ⟨x, xs, rxy⟩, ⟨x, h xs, rxy⟩
+lemma image_subset : ((⊆) ⇒ (⊆)) r.image r.image :=
+assume s t h y ⟨x, xs, rxy⟩, ⟨x, h xs, rxy⟩
+
+lemma image_mono : monotone r.image := r.image_subset
 
 lemma image_inter (s t : set α) : r.image (s ∩ t) ⊆ r.image s ∩ r.image t :=
-assume y ⟨x, ⟨xs, xt⟩, rxy⟩, ⟨⟨x, xs, rxy⟩, ⟨x, xt, rxy⟩⟩
+r.image_mono.map_inf_le s t
 
 lemma image_union (s t : set α) : r.image (s ∪ t) = r.image s ∪ r.image t :=
-set.subset.antisymm
-  (λ y ⟨x, xst, rxy⟩,
-    begin
-      cases xst with xs xt,
-      { left, exact ⟨x, xs, rxy⟩ },
-      right, exact ⟨x, xt, rxy⟩
-    end)
-  (λ y ymem,
-    begin
-      rcases ymem with ⟨x, xs, rxy⟩ | ⟨x, xt, rxy⟩; existsi x,
-      { split, { left, exact xs }, exact rxy},
-      split, { right, exact xt }, exact rxy
-    end)
+le_antisymm
+  (λ y ⟨x, xst, rxy⟩, xst.elim (λ xs, or.inl ⟨x, ⟨xs, rxy⟩⟩) (λ xt, or.inr ⟨x, ⟨xt, rxy⟩⟩))
+  (r.image_mono.le_map_sup s t)
 
 @[simp]
 lemma image_id (s : set α) : image (@eq α) s = s :=
@@ -128,19 +120,16 @@ def core (s : set β) := {x | ∀ y, r x y → y ∈ s}
 lemma mem_core (x : α) (s : set β) : x ∈ core r s ↔ ∀ y, r x y → y ∈ s :=
 iff.refl _
 
-lemma core_mono {s t : set β} (h : s ⊆ t) : r.core s ⊆ r.core t :=
-assume x h' y rxy, h (h' y rxy)
+lemma core_subset : ((⊆) ⇒ (⊆)) r.core r.core :=
+assume s t h x h' y rxy, h (h' y rxy)
+
+lemma core_mono : monotone r.core := r.core_subset
 
 lemma core_inter (s t : set β) : r.core (s ∩ t) = r.core s ∩ r.core t :=
 set.ext (by simp [mem_core, imp_and_distrib, forall_and_distrib])
 
-lemma core_union (s t : set β) : r.core (s ∪ t) ⊇ r.core s ∪ r.core t :=
-λ x,
-  begin
-    simp [mem_core], intro h, cases h with hs ht; intros y rxy,
-    { left, exact hs y rxy },
-    right, exact ht y rxy
-  end
+lemma core_union (s t : set β) : r.core s ∪ r.core t ⊆ r.core (s ∪ t) :=
+r.core_mono.le_map_sup s t
 
 lemma core_univ : r.core set.univ = set.univ := set.ext (by simp [mem_core])
 

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -356,6 +356,24 @@ by apply_instance
 
 end lattice
 
+namespace monotone
+
+open lattice
+
+variables {α : Type u} {β : Type v}
+
+lemma le_map_sup [semilattice_sup α] [semilattice_sup β]
+  {f : α → β} (h : monotone f) (x y : α) :
+  f x ⊔ f y ≤ f (x ⊔ y) :=
+sup_le (h le_sup_left) (h le_sup_right)
+
+lemma map_inf_le [semilattice_inf α] [semilattice_inf β]
+  {f : α → β} (h : monotone f) (x y : α) :
+  f (x ⊓ y) ≤ f x ⊓ f y :=
+le_inf (h inf_le_left) (h inf_le_right)
+
+end monotone
+
 namespace order_dual
 open lattice
 variable (α : Type*)


### PR DESCRIPTION
Use it to simplify some proofs in `data/rel`.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
