### PR TITLE
doc(data/rel): add docs to definitions

### DIFF
--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -598,7 +598,7 @@ multiset.induction_on s (by simp; exact zero_ne_one.symm) $
 theorem irreducible_mk_iff (a : α) : irreducible (associates.mk a) ↔ irreducible a :=
 begin
   simp [irreducible, is_unit_mk],
-  apply and_congr (iff.refl _),
+  apply and_congr iff.rfl,
   split,
   { assume h x y eq,
     have : is_unit (associates.mk x) ∨ is_unit (associates.mk y),

--- a/src/algebra/order.lean
+++ b/src/algebra/order.lean
@@ -7,8 +7,8 @@ Authors: Mario Carneiro
 universe u
 variables {α : Type u}
 
-@[simp] lemma ge_iff_le [preorder α] {a b : α} : a ≥ b ↔ b ≤ a := iff.refl _
-@[simp] lemma gt_iff_lt [preorder α] {a b : α} : a > b ↔ b < a := iff.refl _
+@[simp] lemma ge_iff_le [preorder α] {a b : α} : a ≥ b ↔ b ≤ a := iff.rfl
+@[simp] lemma gt_iff_lt [preorder α] {a b : α} : a > b ↔ b < a := iff.rfl
 
 lemma not_le_of_lt [preorder α] {a b : α} (h : a < b) : ¬ b ≤ a :=
 (le_not_le_of_lt h).right

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -574,7 +574,7 @@ def subtype_equiv_of_subtype' {p : α → Prop} (e : α ≃ β) :
 subtype_congr e $ by simp
 
 def subtype_congr_prop {α : Type*} {p q : α → Prop} (h : p = q) : subtype p ≃ subtype q :=
-subtype_congr (equiv.refl α) (assume a, h ▸ iff.refl _)
+subtype_congr (equiv.refl α) (assume a, h ▸ iff.rfl)
 
 def set_congr {α : Type*} {s t : set α} (h : s = t) : s ≃ t :=
 subtype_congr_prop h

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -60,9 +60,9 @@ lemma forall_iff {p : fin n → Prop} : (∀ i, p i) ↔ ∀ i h, p ⟨i, h⟩ :
 
 lemma zero_le (a : fin (n + 1)) : 0 ≤ a := zero_le a.1
 
-lemma lt_iff_val_lt_val : a < b ↔ a.val < b.val := iff.refl _
+lemma lt_iff_val_lt_val : a < b ↔ a.val < b.val := iff.rfl
 
-lemma le_iff_val_le_val : a ≤ b ↔ a.val ≤ b.val := iff.refl _
+lemma le_iff_val_le_val : a ≤ b ↔ a.val ≤ b.val := iff.rfl
 
 @[simp] lemma succ_val (j : fin n) : j.succ.val = j.val.succ :=
 by cases j; simp [fin.succ]

--- a/src/data/finmap.lean
+++ b/src/data/finmap.lean
@@ -293,7 +293,7 @@ theorem mem_list_to_finmap (a : α) (xs : list (sigma β)) : a ∈ xs.to_finmap 
 by { induction xs with x xs; [skip, cases x];
      simp only [to_finmap_cons, *, not_mem_empty, exists_or_distrib, list.not_mem_nil, finmap.to_finmap_nil, iff_self,
                 exists_false, mem_cons_iff, mem_insert, exists_and_distrib_left];
-     apply or_congr _ (iff.refl _),
+     apply or_congr _ iff.rfl,
      conv { to_lhs, rw ← and_true (a = x_fst) },
      apply and_congr_right, rintro ⟨⟩, simp only [exists_eq, iff_self, heq_iff_eq] }
 

--- a/src/data/opposite.lean
+++ b/src/data/opposite.lean
@@ -47,8 +47,8 @@ def unop : αᵒᵖ → α := id
 lemma op_inj : function.injective (op : α → αᵒᵖ) := λ _ _, id
 lemma unop_inj : function.injective (unop : αᵒᵖ → α) := λ _ _, id
 
-@[simp] lemma op_inj_iff (x y : α) : op x = op y ↔ x = y := iff.refl _
-@[simp] lemma unop_inj_iff (x y : αᵒᵖ) : unop x = unop y ↔ x = y := iff.refl _
+@[simp] lemma op_inj_iff (x y : α) : op x = op y ↔ x = y := iff.rfl
+@[simp] lemma unop_inj_iff (x y : αᵒᵖ) : unop x = unop y ↔ x = y := iff.rfl
 
 @[simp] lemma op_unop (x : αᵒᵖ) : op (unop x) = x := rfl
 @[simp] lemma unop_op (x : α) : unop (op x) = x := rfl

--- a/src/data/pfun.lean
+++ b/src/data/pfun.lean
@@ -486,7 +486,7 @@ def image (s : set α) : set β := rel.image f.graph' s
 lemma image_def (s : set α) : image f s = {y | ∃ x ∈ s, y ∈ f x} := rfl
 
 lemma mem_image (y : β) (s : set α) : y ∈ image f s ↔ ∃ x ∈ s, y ∈ f x :=
-iff.refl _
+iff.rfl
 
 lemma image_mono {s t : set α} (h : s ⊆ t) : f.image s ⊆ f.image t :=
 rel.image_mono _ h
@@ -502,7 +502,7 @@ def preimage (s : set β) : set α := rel.preimage (λ x y, y ∈ f x) s
 lemma preimage_def (s : set β) : preimage f s = {x | ∃ y ∈ s, y ∈ f x} := rfl
 
 lemma mem_preimage (s : set β) (x : α) : x ∈ preimage f s ↔ ∃ y ∈ s, y ∈ f x :=
-iff.refl _
+iff.rfl
 
 lemma preimage_subset_dom (s : set β) : f.preimage s ⊆ f.dom :=
 assume x ⟨y, ys, fxy⟩, roption.dom_iff_mem.mpr ⟨y, fxy⟩

--- a/src/data/rel.lean
+++ b/src/data/rel.lean
@@ -9,6 +9,7 @@ import tactic.basic data.set.lattice order.complete_lattice logic.relator
 
 variables {α : Type*} {β : Type*} {γ : Type*}
 
+/-- A relation on `α` and `β`, aka a set-valued function, aka a partial multifunction --/
 @[derive lattice.complete_lattice]
 def rel (α : Type*) (β : Type*) := α → β → Prop
 
@@ -16,20 +17,24 @@ namespace rel
 
 variables {δ : Type*} (r : rel α β)
 
+/-- The inverse relation : `r.inv x y ↔ r y x`. Note that this is *not* a groupoid inverse. -/
 def inv : rel β α := flip r
 
 lemma inv_def (x : α) (y : β) : r.inv y x ↔ r x y := iff.rfl
 
 lemma inv_inv : inv (inv r) = r := by { ext x y, reflexivity }
 
+/-- Domain of a relation -/
 def dom := {x | ∃ y, r x y}
 
+/-- Codomain aka range of a relation-/
 def codom := {y | ∃ x, r x y}
 
 lemma codom_inv : r.inv.codom = r.dom := by { ext x y, reflexivity }
 
 lemma dom_inv : r.inv.dom = r.codom := by { ext x y, reflexivity}
 
+/-- Composition of relation; note that it follows the category theory order of arguments. -/
 def comp (r : rel α β) (s : rel β γ) : rel α γ :=
 λ x z, ∃ y, r x y ∧ s y z
 
@@ -57,6 +62,7 @@ by { ext x y, split; apply eq.symm }
 lemma inv_comp (r : rel α β) (s : rel β γ) : inv (r ∘ s) = inv s ∘ inv r :=
 by { ext x z, simp [comp, inv, flip, and.comm] }
 
+/-- Image of a set under a relation -/
 def image (s : set α) : set β := {y | ∃ x ∈ s, r x y}
 
 lemma mem_image (y : β) (s : set α) : y ∈ image r s ↔ ∃ x ∈ s, r x y :=
@@ -88,6 +94,7 @@ end
 
 lemma image_univ : r.image set.univ = r.codom := by { ext y, simp [mem_image, codom] }
 
+/-- Preimage of a set under a relation `r`. Same as the image of `s` under `r.flip` -/
 def preimage (s : set β) : set α := image (inv r) s
 
 lemma mem_preimage (x : α) (s : set β) : x ∈ preimage r s ↔ ∃ y ∈ s, r x y :=
@@ -115,6 +122,8 @@ by simp only [preimage, inv_comp, image_comp]
 lemma preimage_univ : r.preimage set.univ = r.dom :=
 by { rw [preimage, image_univ, codom_inv] }
 
+/-- Core of a set `s : set β` w.r.t `r : rel α β` is the set of `x : α` that are related *only*
+to elements of `s`. -/
 def core (s : set β) := {x | ∀ y, r x y → y ∈ s}
 
 lemma mem_core (x : α) (s : set β) : x ∈ core r s ↔ ∀ y, r x y → y ∈ s :=
@@ -144,6 +153,7 @@ begin
   intros h z y rzy syz, exact h y rzy z syz
 end
 
+/-- Restrict the domain of a relation to a subtype. -/
 def restrict_domain (s : set α) : rel {x // x ∈ s} β :=
 λ x y, r x.val y
 
@@ -159,6 +169,7 @@ end rel
 
 namespace function
 
+/-- The graph of a function as a relation. -/
 def graph (f : α → β) : rel α β := λ x y, f x = y
 
 end function

--- a/src/data/rel.lean
+++ b/src/data/rel.lean
@@ -60,7 +60,7 @@ by { ext x z, simp [comp, inv, flip, and.comm] }
 def image (s : set α) : set β := {y | ∃ x ∈ s, r x y}
 
 lemma mem_image (y : β) (s : set α) : y ∈ image r s ↔ ∃ x ∈ s, r x y :=
-iff.refl _
+iff.rfl
 
 lemma image_mono {s t : set α} (h : s ⊆ t) : r.image s ⊆ r.image t :=
 assume y ⟨x, xs, rxy⟩, ⟨x, h xs, rxy⟩
@@ -99,7 +99,7 @@ lemma image_univ : r.image set.univ = r.codom := by { ext y, simp [mem_image, co
 def preimage (s : set β) : set α := image (inv r) s
 
 lemma mem_preimage (x : α) (s : set β) : x ∈ preimage r s ↔ ∃ y ∈ s, r x y :=
-iff.refl _
+iff.rfl
 
 lemma preimage_def (s : set β) : preimage r s = {x | ∃ y ∈ s, r x y} :=
 set.ext $ λ x, mem_preimage _ _ _
@@ -126,7 +126,7 @@ by { rw [preimage, image_univ, codom_inv] }
 def core (s : set β) := {x | ∀ y, r x y → y ∈ s}
 
 lemma mem_core (x : α) (s : set β) : x ∈ core r s ↔ ∀ y, r x y → y ∈ s :=
-iff.refl _
+iff.rfl
 
 lemma core_mono {s t : set β} (h : s ⊆ t) : r.core s ⊆ r.core t :=
 assume x h' y rxy, h (h' y rxy)

--- a/src/data/rel.lean
+++ b/src/data/rel.lean
@@ -5,7 +5,7 @@ Authors: Jeremy Avigad
 
 Operations on set-valued functions, aka partial multifunctions, aka relations.
 -/
-import tactic.basic data.set.lattice order.complete_lattice
+import tactic.basic data.set.lattice order.complete_lattice logic.relator
 
 variables {α : Type*} {β : Type*} {γ : Type*}
 
@@ -62,26 +62,18 @@ def image (s : set α) : set β := {y | ∃ x ∈ s, r x y}
 lemma mem_image (y : β) (s : set α) : y ∈ image r s ↔ ∃ x ∈ s, r x y :=
 iff.refl _
 
-lemma image_mono {s t : set α} (h : s ⊆ t) : r.image s ⊆ r.image t :=
-assume y ⟨x, xs, rxy⟩, ⟨x, h xs, rxy⟩
+lemma image_subset : ((⊆) ⇒ (⊆)) r.image r.image :=
+assume s t h y ⟨x, xs, rxy⟩, ⟨x, h xs, rxy⟩
+
+lemma image_mono : monotone r.image := r.image_subset
 
 lemma image_inter (s t : set α) : r.image (s ∩ t) ⊆ r.image s ∩ r.image t :=
-assume y ⟨x, ⟨xs, xt⟩, rxy⟩, ⟨⟨x, xs, rxy⟩, ⟨x, xt, rxy⟩⟩
+r.image_mono.map_inf_le s t
 
 lemma image_union (s t : set α) : r.image (s ∪ t) = r.image s ∪ r.image t :=
-set.subset.antisymm
-  (λ y ⟨x, xst, rxy⟩,
-    begin
-      cases xst with xs xt,
-      { left, exact ⟨x, xs, rxy⟩ },
-      right, exact ⟨x, xt, rxy⟩
-    end)
-  (λ y ymem,
-    begin
-      rcases ymem with ⟨x, xs, rxy⟩ | ⟨x, xt, rxy⟩; existsi x,
-      { split, { left, exact xs }, exact rxy},
-      split, { right, exact xt }, exact rxy
-    end)
+le_antisymm
+  (λ y ⟨x, xst, rxy⟩, xst.elim (λ xs, or.inl ⟨x, ⟨xs, rxy⟩⟩) (λ xt, or.inr ⟨x, ⟨xt, rxy⟩⟩))
+  (r.image_mono.le_map_sup s t)
 
 @[simp]
 lemma image_id (s : set α) : image (@eq α) s = s :=
@@ -128,19 +120,16 @@ def core (s : set β) := {x | ∀ y, r x y → y ∈ s}
 lemma mem_core (x : α) (s : set β) : x ∈ core r s ↔ ∀ y, r x y → y ∈ s :=
 iff.refl _
 
-lemma core_mono {s t : set β} (h : s ⊆ t) : r.core s ⊆ r.core t :=
-assume x h' y rxy, h (h' y rxy)
+lemma core_subset : ((⊆) ⇒ (⊆)) r.core r.core :=
+assume s t h x h' y rxy, h (h' y rxy)
+
+lemma core_mono : monotone r.core := r.core_subset
 
 lemma core_inter (s t : set β) : r.core (s ∩ t) = r.core s ∩ r.core t :=
 set.ext (by simp [mem_core, imp_and_distrib, forall_and_distrib])
 
-lemma core_union (s t : set β) : r.core (s ∪ t) ⊇ r.core s ∪ r.core t :=
-λ x,
-  begin
-    simp [mem_core], intro h, cases h with hs ht; intros y rxy,
-    { left, exact hs y rxy },
-    right, exact ht y rxy
-  end
+lemma core_union (s t : set β) : r.core s ∪ r.core t ⊆ r.core (s ∪ t) :=
+r.core_mono.le_map_sup s t
 
 lemma core_univ : r.core set.univ = set.univ := set.ext (by simp [mem_core])
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -64,7 +64,7 @@ h hx
 
 @[simp] theorem set_of_mem_eq {s : set α} : {x | x ∈ s} = s := rfl
 
-lemma set_of_app_iff {p : α → Prop} {x : α} : { x | p x } x ↔ p x := iff.refl _
+lemma set_of_app_iff {p : α → Prop} {x : α} : { x | p x } x ↔ p x := iff.rfl
 
 theorem mem_def {a : α} {s : set α} : a ∈ s ↔ s a := iff.rfl
 

--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -24,7 +24,7 @@ instance lattice_set : complete_lattice (set α) :=
   le_antisymm  := assume a b, subset.antisymm,
 
   lt           := λ x y, x ⊆ y ∧ ¬ y ⊆ x,
-  lt_iff_le_not_le := λ x y, iff.refl _,
+  lt_iff_le_not_le := λ x y, iff.rfl,
 
   sup          := (∪),
   le_sup_left  := subset_union_left,
@@ -668,7 +668,7 @@ set.ext $ by simp [seq]
 
 @[simp] lemma mem_seq_iff {s : set (α → β)} {t : set α} {b : β} :
   b ∈ seq s t ↔ ∃ (f ∈ s) (a ∈ t), (f : α → β) a = b :=
-iff.refl _
+iff.rfl
 
 lemma seq_subset {s : set (α → β)} {t : set α} {u : set β} :
   seq s t ⊆ u ↔ (∀f∈s, ∀a∈t, (f : α → β) a ∈ u) :=
@@ -803,7 +803,7 @@ end disjoint
 
 namespace set
 
-protected theorem disjoint_iff {s t : set α} : disjoint s t ↔ s ∩ t ⊆ ∅ := iff.refl _
+protected theorem disjoint_iff {s t : set α} : disjoint s t ↔ s ∩ t ⊆ ∅ := iff.rfl
 
 lemma not_disjoint_iff {s t : set α} : ¬disjoint s t ↔ ∃x, x ∈ s ∧ x ∈ t :=
 by { rw [set.disjoint_iff, subset_empty_iff], apply ne_empty_iff_exists_mem }

--- a/src/group_theory/free_group.lean
+++ b/src/group_theory/free_group.lean
@@ -159,7 +159,7 @@ iff.intro
   cons_cons
 
 lemma append_append_left_iff : ∀L, red (L ++ L₁) (L ++ L₂) ↔ red L₁ L₂
-| []       := iff.refl _
+| []       := iff.rfl
 | (p :: L) := by simp [append_append_left_iff L, cons_cons_iff]
 
 lemma append_append (h₁ : red L₁ L₃) (h₂ : red L₂ L₄) : red (L₁ ++ L₂) (L₃ ++ L₄) :=

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -256,7 +256,7 @@ let b : measurable_space α :=
         (hf i).elim (by simp {contextual := tt}) (assume hi, false.elim $ h ⟨i, hi⟩)) } in
 have b = ⊥, from bot_unique $ assume s hs,
   hs.elim (assume s, s.symm ▸ @is_measurable_empty _ ⊥) (assume s, s.symm ▸ @is_measurable.univ _ ⊥),
-this ▸ iff.refl _
+this ▸ iff.rfl
 
 @[simp] theorem is_measurable_top {s : set α} : @is_measurable _ ⊤ s := trivial
 

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -637,7 +637,7 @@ def a_e (μ : measure α) : filter α :=
   inter_sets := λ s t hs ht, by simp [compl_inter]; exact measure_union_null hs ht,
   sets_of_superset := λ s t hs hst, measure_mono_null (set.compl_subset_compl.2 hst) hs }
 
-lemma mem_a_e_iff (s : set α) : s ∈ μ.a_e.sets ↔ μ (- s) = 0 := iff.refl _
+lemma mem_a_e_iff (s : set α) : s ∈ μ.a_e.sets ↔ μ (- s) = 0 := iff.rfl
 
 end measure
 
@@ -871,7 +871,7 @@ iff.intro
   (assume h', by filter_upwards [h, h'] assume a hpq hp, hpq.1 hp)
   (assume h', by filter_upwards [h, h'] assume a hpq hq, hpq.2 hq)
 
-lemma all_ae_iff {p : α → Prop} : (∀ₘ a, p a) ↔ volume { a | ¬ p a } = 0 := iff.refl _
+lemma all_ae_iff {p : α → Prop} : (∀ₘ a, p a) ↔ volume { a | ¬ p a } = 0 := iff.rfl
 
 lemma all_ae_of_all {p : α → Prop} : (∀a, p a) → ∀ₘ a, p a := assume h,
 by {rw all_ae_iff, convert volume_empty, simp only [h, not_true], reflexivity}

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -237,7 +237,7 @@ protected def mk_of_closure (s : set (set α)) (hs : (generate s).sets = s) : fi
 lemma mk_of_closure_sets {s : set (set α)} {hs : (generate s).sets = s} :
   filter.mk_of_closure s hs = generate s :=
 filter.ext $ assume u,
-show u ∈ (filter.mk_of_closure s hs).sets ↔ u ∈ (generate s).sets, from hs.symm ▸ iff.refl _
+show u ∈ (filter.mk_of_closure s hs).sets ↔ u ∈ (generate s).sets, from hs.symm ▸ iff.rfl
 
 /- Galois insertion from sets of sets into a filters. -/
 def gi_generate (α : Type*) :
@@ -278,7 +278,7 @@ instance : has_top (filter α) :=
   inter_sets       := assume x y hx hy a, mem_inter (hx _) (hy _) }⟩
 
 lemma mem_top_sets_iff_forall {s : set α} : s ∈ (⊤ : filter α) ↔ (∀x, x ∈ s) :=
-iff.refl _
+iff.rfl
 
 @[simp] lemma mem_top_sets {s : set α} : s ∈ (⊤ : filter α) ↔ s = univ :=
 by rw [mem_top_sets_iff_forall, eq_univ_iff_forall]
@@ -959,7 +959,7 @@ by simp only [pure, has_pure.pure, ne.def, not_false_iff, singleton_ne_empty, pr
 
 lemma mem_seq_sets_def {f : filter (α → β)} {g : filter α} {s : set β} :
   s ∈ f.seq g ↔ (∃u ∈ f, ∃t ∈ g, ∀x∈u, ∀y∈t, (x : α → β) y ∈ s) :=
-iff.refl _
+iff.rfl
 
 lemma mem_seq_sets_iff {f : filter (α → β)} {g : filter α} {s : set β} :
   s ∈ f.seq g ↔ (∃u ∈ f, ∃t ∈ g, set.seq u t ⊆ s) :=
@@ -1067,7 +1067,7 @@ section bind
   s ∈ bind f m ↔ ∃t ∈ f, ∀x ∈ t, s ∈ m x :=
 calc s ∈ bind f m ↔ {a | s ∈ m a} ∈ f : by simp only [bind, mem_map, iff_self, mem_join_sets, mem_set_of_eq]
                      ... ↔ (∃t ∈ f, t ⊆ {a | s ∈ m a}) : exists_sets_subset_iff.symm
-                     ... ↔ (∃t ∈ f, ∀x ∈ t, s ∈ m x) : iff.refl _
+                     ... ↔ (∃t ∈ f, ∀x ∈ t, s ∈ m x) : iff.rfl
 
 lemma bind_mono {f : filter α} {g h : α → filter β} (h₁ : {a | g a ≤ h a} ∈ f) :
   bind f g ≤ bind f h :=

--- a/src/order/filter/partial.lean
+++ b/src/order/filter/partial.lean
@@ -27,7 +27,7 @@ theorem rmap_sets (r : rel α β) (f : filter α) : (rmap r f).sets = r.core ⁻
 @[simp]
 theorem mem_rmap (r : rel α β) (l : filter α) (s : set β) :
   s ∈ l.rmap r ↔ r.core s ∈ l :=
-iff.refl _
+iff.rfl
 
 @[simp]
 theorem rmap_rmap (r : rel α β) (s : rel β γ) (l : filter α) :
@@ -43,7 +43,7 @@ def rtendsto (r : rel α β) (l₁ : filter α) (l₂ : filter β) := l₁.rmap 
 
 theorem rtendsto_def (r : rel α β) (l₁ : filter α) (l₂ : filter β) :
   rtendsto r l₁ l₂ ↔ ∀ s ∈ l₂, r.core s ∈ l₁ :=
-iff.refl _
+iff.rfl
 
 def rcomap (r : rel α β) (f : filter β) : filter α :=
 { sets             := rel.image (λ s t, r.core s ⊆ t) f.sets,
@@ -101,7 +101,7 @@ def rcomap' (r : rel α β) (f : filter β) : filter α :=
 @[simp]
 lemma mem_rcomap' (r : rel α β) (l : filter β) (s : set α) :
   s ∈ l.rcomap' r ↔ ∃ t ∈ l, rel.preimage r t ⊆ s :=
-iff.refl _
+iff.rfl
 
 theorem rcomap'_sets (r : rel α β) (f : filter β) :
   (rcomap' r f).sets = rel.image (λ s t, r.preimage s ⊆ t) f.sets := rfl
@@ -149,17 +149,17 @@ filter.rmap f.graph' l
 
 @[simp]
 lemma mem_pmap (f : α →. β) (l : filter α) (s : set β) : s ∈ l.pmap f ↔ f.core s ∈ l :=
-iff.refl _
+iff.rfl
 
 def ptendsto (f : α →. β) (l₁ : filter α) (l₂ : filter β) := l₁.pmap f ≤ l₂
 
 theorem ptendsto_def (f : α →. β) (l₁ : filter α) (l₂ : filter β) :
   ptendsto f l₁ l₂ ↔ ∀ s ∈ l₂, f.core s ∈ l₁ :=
-iff.refl _
+iff.rfl
 
 theorem ptendsto_iff_rtendsto (l₁ : filter α) (l₂ : filter β) (f : α →. β) :
   ptendsto f l₁ l₂ ↔ rtendsto f.graph' l₁ l₂ :=
-iff.refl _
+iff.rfl
 
 theorem pmap_res (l : filter α) (s : set α) (f : α → β) :
   pmap (pfun.res f s) l = map f (l ⊓ principal s) :=

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -356,6 +356,24 @@ by apply_instance
 
 end lattice
 
+namespace monotone
+
+open lattice
+
+variables {α : Type u} {β : Type v}
+
+lemma le_map_sup [semilattice_sup α] [semilattice_sup β]
+  {f : α → β} (h : monotone f) (x y : α) :
+  f x ⊔ f y ≤ f (x ⊔ y) :=
+sup_le (h le_sup_left) (h le_sup_right)
+
+lemma map_inf_le [semilattice_inf α] [semilattice_inf β]
+  {f : α → β} (h : monotone f) (x y : α) :
+  f (x ⊓ y) ≤ f x ⊓ f y :=
+le_inf (h inf_le_left) (h inf_le_right)
+
+end monotone
+
 namespace order_dual
 open lattice
 variable (α : Type*)

--- a/src/set_theory/zfc.lean
+++ b/src/set_theory/zfc.lean
@@ -612,9 +612,9 @@ Set.ext $ λz, by change (x : Class.{u}) z ↔ (y : Class.{u}) z; simp [*]
 @[simp] theorem mem_hom_left (x : Set.{u}) (A : Class.{u}) : (x : Class.{u}) ∈ A ↔ A x :=
 to_Set_of_Set _ _
 
-@[simp] theorem mem_hom_right (x y : Set.{u}) : (y : Class.{u}) x ↔ x ∈ y := iff.refl _
+@[simp] theorem mem_hom_right (x y : Set.{u}) : (y : Class.{u}) x ↔ x ∈ y := iff.rfl
 
-@[simp] theorem subset_hom (x y : Set.{u}) : (x : Class.{u}) ⊆ y ↔ x ⊆ y := iff.refl _
+@[simp] theorem subset_hom (x y : Set.{u}) : (x : Class.{u}) ⊆ y ↔ x ⊆ y := iff.rfl
 
 @[simp] theorem sep_hom (p : Set.{u} → Prop) (x : Set.{u}) : (↑{y ∈ x | p y} : Class.{u}) = {y ∈ x | p y} :=
 set.ext $ λy, Set.mem_sep

--- a/src/topology/instances/nnreal.lean
+++ b/src/topology/instances/nnreal.lean
@@ -32,7 +32,7 @@ instance : orderable_topology ℝ≥0 :=
     (le_generate_from $ assume s hs,
     match s, hs with
     | _, ⟨⟨a, ha⟩, or.inl rfl⟩ := ⟨{b : ℝ | a < b}, is_open_lt' a, rfl⟩
-    | _, ⟨⟨a, ha⟩, or.inr rfl⟩ := ⟨{b : ℝ | b < a}, is_open_gt' a, set.ext $ assume b, iff.refl _⟩
+    | _, ⟨⟨a, ha⟩, or.inr rfl⟩ := ⟨{b : ℝ | b < a}, is_open_gt' a, set.ext $ assume b, iff.rfl⟩
     end)
     begin
       apply coinduced_le_iff_le_induced.1,

--- a/src/topology/order.lean
+++ b/src/topology/order.lean
@@ -255,7 +255,7 @@ def topological_space.induced {α : Type u} {β : Type v} (f : α → β) (t : t
 
 lemma is_open_induced_iff [t : topological_space β] {s : set α} {f : α → β} :
   @is_open α (t.induced f) s ↔ (∃t, is_open t ∧ f ⁻¹' t = s) :=
-iff.refl _
+iff.rfl
 
 lemma is_closed_induced_iff [t : topological_space β] {s : set α} {f : α → β} :
   @is_closed α (t.induced f) s ↔ (∃t, is_closed t ∧ s = f ⁻¹' t) :=
@@ -277,7 +277,7 @@ def topological_space.coinduced {α : Type u} {β : Type v} (f : α → β) (t :
 
 lemma is_open_coinduced {t : topological_space α} {s : set β} {f : α → β} :
   @is_open β (topological_space.coinduced f t) s ↔ is_open (f ⁻¹' s) :=
-iff.refl _
+iff.rfl
 
 variables {t t₁ t₂ : topological_space α} {t' : topological_space β} {f : α → β} {g : β → α}
 
@@ -534,7 +534,7 @@ variables [t : topological_space β] {f : α → β}
 
 theorem is_open_induced_eq {s : set α} :
   @_root_.is_open _ (induced f t) s ↔ s ∈ preimage f '' {s | is_open s} :=
-iff.refl _
+iff.rfl
 
 theorem is_open_induced {s : set β} (h : is_open s) : (induced f t).is_open (f ⁻¹' s) :=
 ⟨s, h, rfl⟩

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -119,13 +119,13 @@ class uniform_space (α : Type u) extends topological_space α, uniform_space.co
 def uniform_space.of_core {α : Type u} (u : uniform_space.core α) : uniform_space α :=
 { to_core := u,
   to_topological_space := u.to_topological_space,
-  is_open_uniformity := assume a, iff.refl _ }
+  is_open_uniformity := assume a, iff.rfl }
 
 def uniform_space.of_core_eq {α : Type u} (u : uniform_space.core α) (t : topological_space α)
   (h : t = u.to_topological_space) : uniform_space α :=
 { to_core := u,
   to_topological_space := t,
-  is_open_uniformity := assume a, h.symm ▸ iff.refl _ }
+  is_open_uniformity := assume a, h.symm ▸ iff.rfl }
 
 lemma uniform_space.to_core_to_topological_space (u : uniform_space α) :
   u.to_core.to_topological_space = u.to_topological_space :=

--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -24,7 +24,7 @@ def is_complete (s : set α) := ∀f, cauchy f → f ≤ principal s → ∃x∈
 
 lemma cauchy_iff {f : filter α} :
   cauchy f ↔ (f ≠ ⊥ ∧ (∀ s ∈ 𝓤 α, ∃t∈f.sets, set.prod t t ⊆ s)) :=
-and_congr (iff.refl _) $ forall_congr $ assume s, forall_congr $ assume hs, mem_prod_same_iff
+and_congr iff.rfl $ forall_congr $ assume s, forall_congr $ assume hs, mem_prod_same_iff
 
 lemma cauchy_map_iff {l : filter β} {f : β → α} :
   cauchy (l.map f) ↔ (l ≠ ⊥ ∧ tendsto (λp:β×β, (f p.1, f p.2)) (l.prod l) (𝓤 α)) :=


### PR DESCRIPTION
TO CONTRIBUTORS:

This PR depends on already approved but not yet merged #1673 and #1675. This one only adds some docstrings. I don't want to add the module documentation now, because I'm going to split the code between several files.

Make sure you have:

  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
