### PR TITLE
doc(*): proper markdown urls [ci skip]

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
   "files.eol": "\n",
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
-  "files.trimTrailingWhitespace": true
+  "files.trimTrailingWhitespace": true,
+  "search.usePCRE2": true
 }

--- a/src/algebra/continued_fractions/basic.lean
+++ b/src/algebra/continued_fractions/basic.lean
@@ -29,7 +29,7 @@ fractions. We hence just call them `continued_fractions` in the library.
 
 ## References
 
-- https://en.wikipedia.org/wiki/Generalized_continued_fraction
+- <https://en.wikipedia.org/wiki/Generalized_continued_fraction>
 - [Wall, H.S., *Analytic Theory of Continued Fractions*][wall2018analytic]
 
 ## Tags

--- a/src/analysis/complex/polynomial.lean
+++ b/src/analysis/complex/polynomial.lean
@@ -22,7 +22,7 @@ then let ⟨r, hr0, hr⟩ := polynomial.tendsto_infinity complex.abs hp0 ((p.eva
 else ⟨p.coeff 0, by rw [eq_C_of_degree_le_zero (le_of_not_gt hp0)]; simp⟩
 
 /- The following proof uses the method given at
-  https://ncatlab.org/nlab/show/fundamental+theorem+of+algebra#classical_fta_via_advanced_calculus -/
+  <https://ncatlab.org/nlab/show/fundamental+theorem+of+algebra#classical_fta_via_advanced_calculus> -/
 /-- The fundamental theorem of algebra. Every non constant complex polynomial
   has a root -/
 lemma exists_root {f : polynomial ℂ} (hf : 0 < degree f) : ∃ z : ℂ, is_root f z :=

--- a/src/analysis/normed_space/real_inner_product.lean
+++ b/src/analysis/normed_space/real_inner_product.lean
@@ -38,7 +38,7 @@ inner product space, norm, orthogonal projection
 *  [Clément & Martin, *The Lax-Milgram Theorem. A detailed proof to be formalized in Coq*]
 *  [Clément & Martin, *A Coq formal proof of the Lax–Milgram theorem*]
 
-The Coq code is available at the following address: http://www.lri.fr/~sboldo/elfic/index.html
+The Coq code is available at the following address: <http://www.lri.fr/~sboldo/elfic/index.html>
 -/
 
 noncomputable theory

--- a/src/category/bitraversable/basic.lean
+++ b/src/category/bitraversable/basic.lean
@@ -13,7 +13,7 @@ import category.functor
 # Bitraversable type class
 
 Type class for traversing bifunctors. The concepts and laws are taken from
-https://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Bitraversable.html
+<https://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Bitraversable.html>
 
 Simple examples of `bitraversable` are `prod` and `sum`. A more elaborate example is
 to define an a-list as:

--- a/src/category/bitraversable/instances.lean
+++ b/src/category/bitraversable/instances.lean
@@ -23,7 +23,7 @@ import category.bitraversable.basic
 
 ## References
 
- * Hackage: https://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Bitraversable.html
+ * Hackage: <https://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Bitraversable.html>
 
 ## Tags
 

--- a/src/category/bitraversable/lemmas.lean
+++ b/src/category/bitraversable/lemmas.lean
@@ -24,7 +24,7 @@ with the applicatives `id` and `comp`
 
 ## References
 
- * Hackage: https://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Bitraversable.html
+ * Hackage: <https://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Bitraversable.html>
 
 ## Tags
 

--- a/src/category/monad/cont.lean
+++ b/src/category/monad/cont.lean
@@ -5,7 +5,7 @@ Author: Simon Hudon
 
 Monad encapsulating continuation passing programming style, similar to
 Haskell's `Cont`, `ContT` and `MonadCont`:
-http://hackage.haskell.org/package/mtl-2.2.2/docs/Control-Monad-Cont.html
+<http://hackage.haskell.org/package/mtl-2.2.2/docs/Control-Monad-Cont.html>
 -/
 
 import tactic.ext

--- a/src/category/traversable/basic.lean
+++ b/src/category/traversable/basic.lean
@@ -11,7 +11,7 @@ import category.applicative
 # Traversable type class
 
 Type classes for traversing collections. The concepts and laws are taken from
-http://hackage.haskell.org/package/base-4.11.1.0/docs/Data-Traversable.html
+<http://hackage.haskell.org/package/base-4.11.1.0/docs/Data-Traversable.html>
 
 Traversable collections are a generalization of functors. Whereas
 functors (such as `list`) allow us to apply a function to every
@@ -28,7 +28,7 @@ all the resulting effects. In the example, the effect is encoded in the
 monad `io` but any applicative functor is accepted by `traverse`.
 
 For more on how to use traversable, consider the Haskell tutorial:
-https://en.wikibooks.org/wiki/Haskell/Traversable
+<https://en.wikibooks.org/wiki/Haskell/Traversable>
 
 ## Main definitions
   * `traversable` type class - exposes the `traverse` function
@@ -41,9 +41,9 @@ traversable iterator functor applicative
 
 ## References
 
- * "Applicative Programming with Effects", by Conor McBride and Ross Paterson, Journal of Functional Programming 18:1 (2008) 1-13, online at http://www.soi.city.ac.uk/~ross/papers/Applicative.html.
- * "The Essence of the Iterator Pattern", by Jeremy Gibbons and Bruno Oliveira, in Mathematically-Structured Functional Programming, 2006, online at http://web.comlab.ox.ac.uk/oucl/work/jeremy.gibbons/publications/#iterator.
- * "An Investigation of the Laws of Traversals", by Mauro Jaskelioff and Ondrej Rypacek, in Mathematically-Structured Functional Programming, 2012, online at http://arxiv.org/pdf/1202.2919.
+ * "Applicative Programming with Effects", by Conor McBride and Ross Paterson, Journal of Functional Programming 18:1 (2008) 1-13, online at <http://www.soi.city.ac.uk/~ross/papers/Applicative.html>
+ * "The Essence of the Iterator Pattern", by Jeremy Gibbons and Bruno Oliveira, in Mathematically-Structured Functional Programming, 2006, online at <http://web.comlab.ox.ac.uk/oucl/work/jeremy.gibbons/publications/#iterator>
+ * "An Investigation of the Laws of Traversals", by Mauro Jaskelioff and Ondrej Rypacek, in Mathematically-Structured Functional Programming, 2012, online at <http://arxiv.org/pdf/1202.2919>
 Synopsis
 
 

--- a/src/category/traversable/lemmas.lean
+++ b/src/category/traversable/lemmas.lean
@@ -10,7 +10,7 @@ Inspired by:
     The Essence of the Iterator Pattern
     Jeremy Gibbons and Bruno César dos Santos Oliveira
     In Journal of Functional Programming. Vol. 19. No. 3&4. Pages 377−402. 2009.
-    http://www.cs.ox.ac.uk/jeremy.gibbons/publications/iterator.pdf
+    <http://www.cs.ox.ac.uk/jeremy.gibbons/publications/iterator.pdf>
 -/
 
 import tactic.cache

--- a/src/category_theory/adjunction/fully_faithful.lean
+++ b/src/category_theory/adjunction/fully_faithful.lean
@@ -20,8 +20,8 @@ include 𝒞 𝒟
 variables {L : C ⥤ D} {R : D ⥤ C} (h : L ⊣ R)
 
 -- Lemma 4.5.13 from [Riehl][riehl2017]
--- Proof in https://stacks.math.columbia.edu/tag/0036
--- or at https://math.stackexchange.com/a/2727177
+-- Proof in <https://stacks.math.columbia.edu/tag/0036>
+-- or at <https://math.stackexchange.com/a/2727177>
 instance unit_is_iso_of_L_fully_faithful [full L] [faithful L] : is_iso (adjunction.unit h) :=
 @nat_iso.is_iso_of_is_iso_app _ _ _ _ _ _ (adjunction.unit h) $ λ X,
 @yoneda.is_iso _ _ _ _ ((adjunction.unit h).app X)

--- a/src/category_theory/elements.lean
+++ b/src/category_theory/elements.lean
@@ -22,8 +22,8 @@ a more convenient API. We prove the equivalence in `category_theory.category_of_
 
 ## References
 * [Emily Riehl, *Category Theory in Context*, Section 2.4][riehl2017]
-* https://en.wikipedia.org/wiki/Category_of_elements
-* https://ncatlab.org/nlab/show/category+of+elements
+* <https://en.wikipedia.org/wiki/Category_of_elements>
+* <https://ncatlab.org/nlab/show/category+of+elements>
 
 ## Tags
 category of elements, Grothendieck construction, comma category

--- a/src/category_theory/monoidal/category.lean
+++ b/src/category_theory/monoidal/category.lean
@@ -192,7 +192,7 @@ end
 --   = ((λ_ X).hom ⊗ (𝟙 Y))
 -- (and the corresponding fact for right unitors)
 -- following the proof on nLab:
--- Lemma 2.2 at https://ncatlab.org/nlab/revision/monoidal+category/115
+-- Lemma 2.2 at <https://ncatlab.org/nlab/revision/monoidal+category/115>
 
 lemma left_unitor_product_aux_perimeter (X Y : C) :
     ((α_ (𝟙_ C) (𝟙_ C) X).hom ⊗ (𝟙 Y)) ≫
@@ -276,7 +276,7 @@ begin
   rw [←right_unitor_product_aux_triangle, ←right_unitor_product_aux_perimeter],
 end
 
--- See Proposition 2.2.4 of http://www-math.mit.edu/~etingof/egnobookfinal.pdf
+-- See Proposition 2.2.4 of <http://www-math.mit.edu/~etingof/egnobookfinal.pdf>
 @[simp] lemma left_unitor_tensor (X Y : C) :
   ((α_ (𝟙_ C) X Y).hom) ≫ ((λ_ (X ⊗ Y)).hom) =
     ((λ_ X).hom ⊗ (𝟙 Y)) :=

--- a/src/category_theory/monoidal/of_has_finite_products.lean
+++ b/src/category_theory/monoidal/of_has_finite_products.lean
@@ -14,7 +14,7 @@ import category_theory.limits.types
 
 A category with a monoidal structure provided in this way is sometimes called a (co)cartesian category,
 although this is also sometimes used to mean a finitely complete category.
-(See https://ncatlab.org/nlab/show/cartesian+category.)
+(See <https://ncatlab.org/nlab/show/cartesian+category>.)
 
 As this works with either products or coproducts, we don't set up either construct as an instance.
 -/

--- a/src/data/holor.lean
+++ b/src/data/holor.lean
@@ -22,11 +22,11 @@ rank at most 1" if it is a tensor product of one-dimensional holors.
 The CP rank of a holor `x` is the smallest N such that `x` is the sum
 of N holors of rank at most 1.
 
-Based on the tensor library found in https://www.isa-afp.org/entries/Deep_Learning.html.
+Based on the tensor library found in <https://www.isa-afp.org/entries/Deep_Learning.html>
 
 ## References
 
-* https://en.wikipedia.org/wiki/Tensor_rank_decomposition
+* <https://en.wikipedia.org/wiki/Tensor_rank_decomposition>
 -/
 
 universes u

--- a/src/data/padics/hensel.lean
+++ b/src/data/padics/hensel.lean
@@ -11,7 +11,7 @@ import analysis.specific_limits topology.algebra.polynomial
 # Hensel's lemma on ℤ_p
 
 This file proves Hensel's lemma on ℤ_p, roughly following Keith Conrad's writeup:
-http://www.math.uconn.edu/~kconrad/blurbs/gradnumthy/hensel.pdf
+<http://www.math.uconn.edu/~kconrad/blurbs/gradnumthy/hensel.pdf>
 
 Hensel's lemma gives a simple condition for the existence of a root of a polynomial.
 
@@ -20,9 +20,9 @@ The proof and motivation are described in the paper
 
 ## References
 
-* http://www.math.uconn.edu/~kconrad/blurbs/gradnumthy/hensel.pdf
+* <http://www.math.uconn.edu/~kconrad/blurbs/gradnumthy/hensel.pdf>
 * [R. Y. Lewis, *A formal proof of Hensel's lemma over the p-adic integers*][lewis2019]
-* https://en.wikipedia.org/wiki/Hensel%27s_lemma
+* <https://en.wikipedia.org/wiki/Hensel%27s_lemma>
 
 ## Tags
 

--- a/src/data/padics/padic_integers.lean
+++ b/src/data/padics/padic_integers.lean
@@ -31,7 +31,7 @@ Coercions into ℤ_p are set up to work with the `norm_cast` tactic.
 
 * [F. Q. Gouêva, *p-adic numbers*][gouvea1997]
 * [R. Y. Lewis, *A formal proof of Hensel's lemma over the p-adic integers*][lewis2019]
-* https://en.wikipedia.org/wiki/P-adic_number
+* <https://en.wikipedia.org/wiki/P-adic_number>
 
 ## Tags
 

--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -34,7 +34,7 @@ by taking (prime p) as a type class argument.
 
 * [F. Q. Gouêva, *p-adic numbers*][gouvea1997]
 * [R. Y. Lewis, *A formal proof of Hensel's lemma over the p-adic integers*][lewis2019]
-* https://en.wikipedia.org/wiki/P-adic_number
+* <https://en.wikipedia.org/wiki/P-adic_number>
 
 ## Tags
 

--- a/src/data/padics/padic_numbers.lean
+++ b/src/data/padics/padic_numbers.lean
@@ -48,7 +48,7 @@ Coercions from ℚ to ℚ_p are set up to work with the `norm_cast` tactic.
 
 * [F. Q. Gouêva, *p-adic numbers*][gouvea1997]
 * [R. Y. Lewis, *A formal proof of Hensel's lemma over the p-adic integers*][lewis2019]
-* https://en.wikipedia.org/wiki/P-adic_number
+* <https://en.wikipedia.org/wiki/P-adic_number>
 
 ## Tags
 

--- a/src/data/real/pi.lean
+++ b/src/data/real/pi.lean
@@ -224,7 +224,7 @@ begin
 end
 
 /- A computation of the first 7 digits of pi is given here:
-  https://gist.github.com/fpvandoorn/5b405988bc2e61953d56e3597db16ecf
+  <https://gist.github.com/fpvandoorn/5b405988bc2e61953d56e3597db16ecf>
   This is not included in mathlib, because of slow compilation time.
   -/
 

--- a/src/data/tree.lean
+++ b/src/data/tree.lean
@@ -15,7 +15,7 @@ to be defined and is better suited for in-kernel computation.
 
 ## References
 
-https://leanprover-community.github.io/archive/113488general/62193tacticquestion.html
+<https://leanprover-community.github.io/archive/113488general/62193tacticquestion.html>
 -/
 
 @[derive has_reflect]

--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -245,5 +245,5 @@ end quotient_group
 /- Note [use has_coe_t]:
 We use the class `has_coe_t` instead of `has_coe` if the first-argument is a variable.
 Using `has_coe` would cause looping of type-class inference. See
-https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/remove.20all.20instances.20with.20variable.20domain
+<https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/remove.20all.20instances.20with.20variable.20domain>
 -/

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -627,7 +627,7 @@ begin
 end
 
 /-- Dedekind's linear independence of characters -/
--- See, for example, Keith Conrad's note https://kconrad.math.uconn.edu/blurbs/galoistheory/linearchar.pdf
+-- See, for example, Keith Conrad's note <https://kconrad.math.uconn.edu/blurbs/galoistheory/linearchar.pdf>
 theorem linear_independent_monoid_hom (G : Type*) [monoid G] (L : Type*) [integral_domain L] :
   @linear_independent _ L (G → L) (λ f, f : (G →* L) → (G → L)) _ _ _ :=
 by letI := classical.dec_eq (G →* L);

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -23,7 +23,7 @@ the notation B x y to refer to the function field, ie. B x y = B.bilin x y.
 
 ## References
 
-* https://en.wikipedia.org/wiki/Bilinear_form
+* <https://en.wikipedia.org/wiki/Bilinear_form>
 
 ## Tags
 

--- a/src/linear_algebra/sesquilinear_form.lean
+++ b/src/linear_algebra/sesquilinear_form.lean
@@ -23,7 +23,7 @@ refer to the function field, ie. S x y = S.bilin x y.
 
 ## References
 
-* https://en.wikipedia.org/wiki/Sesquilinear_form#Over_arbitrary_rings
+* <https://en.wikipedia.org/wiki/Sesquilinear_form#Over_arbitrary_rings>
 
 ## Tags
 

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -608,7 +608,7 @@ by apply_instance
   * We make them lemmas, and not definitions, because otherwise later definitions will raise
     "failed to generate bytecode" errors when writing something like
     `letI := classical.dec_eq _`.
-  Cf. https://leanprover-community.github.io/archive/113488general/08268noncomputabletheorem.html -/
+  Cf. <https://leanprover-community.github.io/archive/113488general/08268noncomputabletheorem.html> -/
 
 @[elab_as_eliminator]
 noncomputable def {u} exists_cases {C : Sort u} (H0 : C) (H : ∀ a, p a → C) : C :=

--- a/src/measure_theory/giry_monad.lean
+++ b/src/measure_theory/giry_monad.lean
@@ -20,7 +20,7 @@ monad to an honest monad of the functor `Measure : Meas ⥤ Meas`.
 
 ## References
 
-* https://ncatlab.org/nlab/show/Giry+monad
+* <https://ncatlab.org/nlab/show/Giry+monad>
 
 ## Tags
 

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -47,9 +47,9 @@ defined in terms of the Galois connection induced by f.
 
 ## References
 
-* https://en.wikipedia.org/wiki/Measurable_space
-* https://en.wikipedia.org/wiki/Sigma-algebra
-* https://en.wikipedia.org/wiki/Dynkin_system
+* <https://en.wikipedia.org/wiki/Measurable_space>
+* <https://en.wikipedia.org/wiki/Sigma-algebra>
+* <https://en.wikipedia.org/wiki/Dynkin_system>
 
 ## Tags
 

--- a/src/ring_theory/maps.lean
+++ b/src/ring_theory/maps.lean
@@ -7,23 +7,23 @@ Authors: Andreas Swerdlow, Kenny Lau
 import data.equiv.algebra
 
 /-!
-# Ring antihomomorphisms, isomorphisms, antiisomorphisms and involutions  
+# Ring antihomomorphisms, isomorphisms, antiisomorphisms and involutions
 
-This file defines ring antihomomorphisms, antiisomorphism and involutions 
-and proves basic properties of them. 
- 
+This file defines ring antihomomorphisms, antiisomorphism and involutions
+and proves basic properties of them.
+
 ## Notations
 
-All types defined in this file are given a coercion to the underlying function. 
+All types defined in this file are given a coercion to the underlying function.
 
 ## References
 
-* https://en.wikipedia.org/wiki/Antihomomorphism
-* https://en.wikipedia.org/wiki/Involution_(mathematics)#Ring_theory
+* <https://en.wikipedia.org/wiki/Antihomomorphism>
+* <https://en.wikipedia.org/wiki/Involution_(mathematics)#Ring_theory>
 
 ## Tags
 
-Ring isomorphism, automorphism, antihomomorphism, antiisomorphism, antiautomorphism, involution  
+Ring isomorphism, automorphism, antihomomorphism, antiisomorphism, antiautomorphism, involution
 -/
 
 variables {R : Type*} {F : Type*}

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -24,7 +24,7 @@ We define the order on cardinal numbers, define omega, and do basic cardinal ari
 
 ## References
 
-* https://en.wikipedia.org/wiki/Cardinal_number
+* <https://en.wikipedia.org/wiki/Cardinal_number>
 
 ## Tags
 

--- a/src/tactic/omega/eq_elim.lean
+++ b/src/tactic/omega/eq_elim.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Seul Baek
 
 Correctness lemmas for equality elimination.
-See 5.5 of http://www.decision-procedures.org/ for details.
+See 5.5 of <http://www.decision-procedures.org/> for details.
 -/
 
 import tactic.omega.clause

--- a/src/tactic/ring.lean
+++ b/src/tactic/ring.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 
 Evaluate expressions in the language of commutative (semi)rings.
-Based on http://www.cs.ru.nl/~freek/courses/tt-2014/read/10.1.1.61.3041.pdf .
+Based on <http://www.cs.ru.nl/~freek/courses/tt-2014/read/10.1.1.61.3041.pdf> .
 -/
 import algebra.group_power tactic.norm_num
 import tactic.converter.interactive

--- a/src/tactic/scc.lean
+++ b/src/tactic/scc.lean
@@ -40,7 +40,7 @@ reason about arbitrary partial orders.
  * Tarjan, R. E. (1972), "Depth-first search and linear graph algorithms",
    SIAM Journal on Computing, 1 (2): 146–160, doi:10.1137/0201010
  * Dijkstra, Edsger (1976), A Discipline of Programming, NJ: Prentice Hall, Ch. 25.
- * https://en.wikipedia.org/wiki/Disjoint-set_data_structure
+ * <https://en.wikipedia.org/wiki/Disjoint-set_data_structure>
 
 ## Tags
 
@@ -85,7 +85,7 @@ transitivity on `p₂`, `p₁` and `p₃.symm` in that order.
 Similarly, we can discover that `e₂` and `e₅` aren't equivalent.
 
 A description of the path compression optimization can be found at:
-https://en.wikipedia.org/wiki/Disjoint-set_data_structure#Path_compression
+<https://en.wikipedia.org/wiki/Disjoint-set_data_structure#Path_compression>
 
 -/
 meta def closure := ref (expr_map (ℕ ⊕ (expr × expr)))

--- a/src/topology/maps.lean
+++ b/src/topology/maps.lean
@@ -31,9 +31,9 @@ This file introduces the following properties of a map `f : X → Y` between top
 
 ## References
 
-* https://en.wikipedia.org/wiki/Open_and_closed_maps
-* https://en.wikipedia.org/wiki/Embedding#General_topology
-* https://en.wikipedia.org/wiki/Quotient_space_(topology)#Quotient_map
+* <https://en.wikipedia.org/wiki/Open_and_closed_maps>
+* <https://en.wikipedia.org/wiki/Embedding#General_topology>
+* <https://en.wikipedia.org/wiki/Quotient_space_(topology)#Quotient_map>
 
 ## Tags
 

--- a/src/topology/sheaves/stalks.lean
+++ b/src/topology/sheaves/stalks.lean
@@ -51,7 +51,7 @@ begin
 end
 
 -- Here are two other potential solutions, suggested by @fpvandoorn at
--- https://github.com/leanprover-community/mathlib/pull/1018#discussion_r283978240
+-- <https://github.com/leanprover-community/mathlib/pull/1018#discussion_r283978240>
 -- However, I can't get the subsequent two proofs to work with either one.
 
 -- def stalk_pushforward (f : X ⟶ Y) (ℱ : X.presheaf C) (x : X) : (f _* ℱ).stalk (f x) ⟶ ℱ.stalk x :=


### PR DESCRIPTION
This is better for doc generation.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
