### PR TITLE
doc(*): move detailed headers into real module docs

### DIFF
--- a/src/analysis/asymptotics.lean
+++ b/src/analysis/asymptotics.lean
@@ -2,6 +2,12 @@
 Copyright (c) 2019 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Jeremy Avigad
+-/
+
+import analysis.normed_space.basic
+
+/-!
+# Asymptotics
 
 We introduce these relations:
 
@@ -30,7 +36,7 @@ In fact, the right-to-left direction holds without the hypothesis on `g`, and in
 it suffices to assume that `f` is zero wherever `g` is. (This generalization is useful in defining
 the Fréchet derivative.)
 -/
-import analysis.normed_space.basic
+
 open filter
 open_locale topological_space
 

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -2,8 +2,12 @@
 Copyright (c) 2019 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Sébastien Gouëzel
+-/
 
-The Fréchet derivative.
+import analysis.asymptotics analysis.calculus.tangent_cone
+
+/-!
+# The Fréchet derivative
 
 Let `E` and `F` be normed spaces, `f : E → F`, and `f' : E →L[𝕜] F` a
 continuous 𝕜-linear map, where `𝕜` is a non-discrete normed field. Then
@@ -14,6 +18,24 @@ says that `f` has derivative `f'` at `x`, where the domain of interest
 is restricted to `s`. We also have
 
   `has_fderiv_at f f' x := has_fderiv_within_at f f' x univ`
+
+## Main results
+
+In addition to the definition and basic properties of the derivative, this file contains the
+usual formulas (and existence assertions) for the derivative of
+* constants
+* the identity
+* bounded linear maps
+* bounded bilinear maps
+* sum of two functions
+* multiplication of a function by a scalar constant
+* negative of a function
+* subtraction of two functions
+* multiplication of a function by a scalar function
+* multiplication of two scalar functions
+* composition of functions (the chain rule)
+
+## Implementation details
 
 The derivative is defined in terms of the `is_o` relation, but also
 characterized in terms of the `tendsto` relation.
@@ -32,23 +54,11 @@ they imply the uniqueness of the derivative. This is satisfied for open subsets,
 for `univ`. This uniqueness only holds when the field is non-discrete, which we request at the very
 beginning: otherwise, a derivative can be defined, but it has no interesting properties whatsoever.
 
-In addition to the definition and basic properties of the derivative, this file contains the
-usual formulas (and existence assertions) for the derivative of
-* constants
-* the identity
-* bounded linear maps
-* bounded bilinear maps
-* sum of two functions
-* multiplication of a function by a scalar constant
-* negative of a function
-* subtraction of two functions
-* multiplication of a function by a scalar function
-* multiplication of two scalar functions
-* composition of functions (the chain rule)
+## Tags
+
+derivative, differentiable, Fréchet, calculus
 
 -/
-
-import analysis.asymptotics analysis.calculus.tangent_cone
 
 open filter asymptotics continuous_linear_map set
 open_locale topological_space

--- a/src/analysis/calculus/tangent_cone.lean
+++ b/src/analysis/calculus/tangent_cone.lean
@@ -2,6 +2,12 @@
 Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
+-/
+
+import analysis.convex analysis.normed_space.bounded_linear_maps
+
+/-!
+# Tangent cone
 
 In this file, we define two predicates `unique_diff_within_at 𝕜 s x` and `unique_diff_on 𝕜 s`
 ensuring that, if a function has two derivatives, then they have to coincide. As a direct
@@ -16,12 +22,12 @@ One should however think of this definition as an implementation detail: the onl
 introduce the predicates `unique_diff_within_at` and `unique_diff_on` is to ensure the uniqueness
 of the derivative. This is why their names reflect their uses, and not how they are defined.
 
+## Implementation details
+
 Note that this file is imported by `deriv.lean`. Hence, derivatives are not defined yet. The
 property of uniqueness of the derivative is therefore proved in `deriv.lean`, but based on the
 properties of the tangent cone we prove here.
 -/
-
-import analysis.convex analysis.normed_space.bounded_linear_maps
 
 variables (𝕜 : Type*) [nondiscrete_normed_field 𝕜]
 variables {E : Type*} [normed_group E] [normed_space 𝕜 E]

--- a/src/analysis/complex/exponential.lean
+++ b/src/analysis/complex/exponential.lean
@@ -12,19 +12,19 @@ import topology.instances.complex tactic.linarith data.complex.exponential
 ## Main definitions
 
 This file contains the following definitions:
-• π, arcsin, arccos, arctan
-• argument of a complex number
-• logarithm on real and complex numbers
-• complex and real power function
+* π, arcsin, arccos, arctan
+* argument of a complex number
+* logarithm on real and complex numbers
+* complex and real power function
 
 ## Main statements
 
 The following functions are shown to be continuous:
-• complex and real exponential function
-• sin, cos, tan, sinh, cosh
-• logarithm on real numbers
-• real power function
-• square root function
+* complex and real exponential function
+* sin, cos, tan, sinh, cosh
+* logarithm on real numbers
+* real power function
+* square root function
 
 ## Tags
 

--- a/src/category_theory/category/default.lean
+++ b/src/category_theory/category/default.lean
@@ -2,20 +2,27 @@
 Copyright (c) 2017 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stephen Morgan, Scott Morrison, Johannes Hölzl, Reid Barton
+-/
 
-Defines a category, as a typeclass parametrised by the type of objects.
+import tactic.basic
+import tactic.tidy
+
+/-!
+# Categories
+
+Defines a category, as a type class parametrised by the type of objects.
+
+## Notations
+
 Introduces notations
-  `X ⟶ Y` for the morphism spaces,
-  `f ≫ g` for composition in the 'arrows' convention.
+* `X ⟶ Y` for the morphism spaces,
+* `f ≫ g` for composition in the 'arrows' convention.
 
 Users may like to add `f ⊚ g` for composition in the standard convention, using
 ```
 local notation f ` ⊚ `:80 g:80 := category.comp g f    -- type as \oo
 ```
 -/
-
-import tactic.basic
-import tactic.tidy
 
 universes v u  -- The order in this declaration matters: v often needs to be explicitly specified while u often can be omitted
 

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -2,8 +2,12 @@
 Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Chris Hughes
+-/
 
-# zmod and zmodp
+import data.int.modeq data.int.gcd data.fintype data.pnat.basic tactic.ring
+
+/-!
+# Integers mod `n`
 
 Definition of the integers mod n, and the field structure on the integers mod p.
 
@@ -12,11 +16,11 @@ There are two types defined, `zmod n`, which is for integers modulo a positive n
 
 ## Definitions
 
-`val` is inherited from `fin` and returns the least natural number in the equivalence class
+* `val` is inherited from `fin` and returns the least natural number in the equivalence class
 
-`val_min_abs` returns the integer closest to zero in the equivalence class.
+* `val_min_abs` returns the integer closest to zero in the equivalence class.
 
-A coercion `cast` is defined from `zmod n` into any semiring. This is a semiring hom if the ring has
+* A coercion `cast` is defined from `zmod n` into any semiring. This is a semiring hom if the ring has
 characteristic dividing `n`
 
 ## Implentation notes
@@ -24,10 +28,7 @@ characteristic dividing `n`
 `zmod` and `zmodp` are implemented as different types so that the field instance for `zmodp` can be
 synthesized. This leads to a lot of code duplication and most of the functions and theorems for
 `zmod` are restated for `zmodp`
-
 -/
-
-import data.int.modeq data.int.gcd data.fintype data.pnat.basic tactic.ring
 
 open nat nat.modeq int
 

--- a/src/data/zmod/quadratic_reciprocity.lean
+++ b/src/data/zmod/quadratic_reciprocity.lean
@@ -3,8 +3,10 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
+
 import field_theory.finite data.zmod.basic data.nat.parity
-/-
+
+/-!
 # Quadratic reciprocity.
 
 This file contains results about quadratic residues modulo a prime number.

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -2,19 +2,25 @@
 Copyright (c) 2019 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
+-/
+
+import ring_theory.noetherian linear_algebra.dimension
+import ring_theory.principal_ideal_domain
+
+/-!
+# Finite dimensional vector spaces
 
 Definition and basic properties of finite dimensional vector spaces.
+
+## Main definitions
 
 The class `finite_dimensional` is defined to be `is_noetherian`, for ease of transfer of proofs.
 However an additional constructor `finite_dimensional.of_fg` is provided to prove
 finite dimensionality in a conventional manner.
 
 Also defined is `findim`, the dimension of a finite dimensional space, returning a `nat`,
-as opposed to `dim`, which returns a `cardinal`,
+as opposed to `dim`, which returns a `cardinal`.
 -/
-
-import ring_theory.noetherian linear_algebra.dimension
-import ring_theory.principal_ideal_domain
 
 universes u v w
 

--- a/src/tactic/finish.lean
+++ b/src/tactic/finish.lean
@@ -2,6 +2,12 @@
 Copyright (c) 2017 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Jesse Michael Han
+-/
+
+import logic.basic
+
+/-!
+# The `finish` family of tactics
 
 These tactics do straightforward things: they call the simplifier, split conjunctive assumptions,
 eliminate existential quantifiers on the left, and look for contradictions. They rely on ematching
@@ -10,20 +16,21 @@ and congruence closure to try to finish off a goal at the end.
 The procedures *do* split on disjunctions and recreate the smt state for each terminal call, so
 they are only meant to be used on small, straightforward problems.
 
+## Main definitions
+
 We provide the following tactics:
 
-  finish  -- solves the goal or fails
-  clarify -- makes as much progress as possible while not leaving more than one goal
-  safe    -- splits freely, finishes off whatever subgoals it can, and leaves the rest
+  `finish`  -- solves the goal or fails
+  `clarify` -- makes as much progress as possible while not leaving more than one goal
+  `safe`    -- splits freely, finishes off whatever subgoals it can, and leaves the rest
 
 All accept an optional list of simplifier rules, typically definitions that should be expanded.
 (The equations and identities should not refer to the local context.)
 
-The variants ifinish, iclarify, and isafe restrict to intuitionistic logic. They do not work
-well with the current heuristic instantiation method used by ematch, so they should be revisited
+The variants `ifinish`, `iclarify`, and `isafe` restrict to intuitionistic logic. They do not work
+well with the current heuristic instantiation method used by `ematch`, so they should be revisited
 when the API changes.
 -/
-import logic.basic
 
 declare_trace auto.done
 declare_trace auto.finish

--- a/src/tactic/localized.lean
+++ b/src/tactic/localized.lean
@@ -1,4 +1,14 @@
 /-
+Copyright (c) 2019 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Floris van Doorn
+-/
+
+import tactic.core meta.rb_map
+
+/-!
+# Localized notation
+
 This consists of two user-commands which allow you to declare notation and commands localized to a namespace.
 
 * Declare notation which is localized to a namespace using:
@@ -20,7 +30,7 @@ localized "attribute [simp] le_refl" in le
 ```
 The code is inspired by code from Gabriel Ebner from the hott3 repository.
 -/
-import tactic.core meta.rb_map
+
 open lean lean.parser interactive tactic native
 
 reserve notation `localized`

--- a/src/topology/metric_space/gluing.lean
+++ b/src/topology/metric_space/gluing.lean
@@ -3,39 +3,49 @@ Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Gluing metric spaces
 Authors: Sébastien Gouëzel
+-/
+
+import topology.metric_space.isometry topology.metric_space.premetric_space
+
+/-!
+# Metric space gluing
 
 Gluing two metric spaces along a common subset. Formally, we are given
+
+```
      Φ
   γ ---> α
   |
   |Ψ
   v
   β
-where hΦ : isometry Φ and hΨ : isometry Ψ
+```
+where `hΦ : isometry Φ` and `hΨ : isometry Ψ`.
 We want to complete the square by a space `glue_space hΦ hΨ` and two isometries
 `to_glue_l hΦ hΨ` and `to_glue_r hΦ hΨ` that make the square commute.
-We start by defining a predistance on the disjoint union α ⊕ β, for which
-points Φ p and Ψ p are at distance 0. The (quotient) metric space associated
+We start by defining a predistance on the disjoint union `α ⊕ β`, for which
+points `Φ p` and `Ψ p` are at distance 0. The (quotient) metric space associated
 to this predistance is the desired space.
 
-This is an instance of a more general construction, where Φ and Ψ do not have to be isometries,
-but the distances in the image almost coincide, up to 2ε say. Then one can almost glue the two
-spaces so that the images of a point under Φ and Ψ are ε-close. If ε > 0, this yields a
-metric space structure on α ⊕ β, without the need to take a quotient. In particular, when
-α and β are inhabited, this gives a natural metric space structure on α ⊕ β, where the basepoints
+This is an instance of a more general construction, where `Φ` and `Ψ` do not have to be isometries,
+but the distances in the image almost coincide, up to `2ε` say. Then one can almost glue the two
+spaces so that the images of a point under `Φ` and `Ψ` are ε-close. If `ε > 0`, this yields a
+metric space structure on `α ⊕ β`, without the need to take a quotient. In particular, when
+`α` and `β` are inhabited, this gives a natural metric space structure on `α ⊕ β`, where the basepoints
 are at distance 1, say, and the distances between other points are obtained by going through the
 two basepoints.
 
 We also define the inductive limit of metric spaces. Given
+```
      f 0        f 1        f 2        f 3
 X 0 -----> X 1 -----> X 2 -----> X 3 -----> ...
-where the X n are metric spaces and f n isometric embeddings, we define the inductive
-limit of the X n, also known as the increasing union of the X n in this context, if we
-identify X n and X (n+1) through f n. This is a metric space in which all X n embed
-isometrically and in a way compatible with f n.
--/
+```
+where the `X n` are metric spaces and `f n` isometric embeddings, we define the inductive
+limit of the `X n`, also known as the increasing union of the `X n` in this context, if we
+identify `X n` and `X (n+1)` through `f n`. This is a metric space in which all `X n` embed
+isometrically and in a way compatible with `f n`.
 
-import topology.metric_space.isometry topology.metric_space.premetric_space
+-/
 
 noncomputable theory
 

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -2,19 +2,27 @@
 Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Sébastien Gouëzel
+-/
 
-The Gromov-Hausdorff distance on the space of nonempty compact metric spaces up to isometry.
+import topology.metric_space.closeds set_theory.cardinal topology.metric_space.gromov_hausdorff_realized
+topology.metric_space.completion
+
+/-!
+# Gromov-Hausdorff distance
+
+This file defines the Gromov-Hausdorff distance on the space of nonempty compact metric spaces
+up to isometry.
 
 We introduces the space of all nonempty compact metric spaces, up to isometry,
 called `GH_space`, and endow it with a metric space structure. The distance,
 known as the Gromov-Hausdorff distance, is defined as follows: given two
-nonempty compact spaces X and Y, their distance is the minimum Hausdorff distance
-between all possible isometric embeddings of X and Y in all metric spaces.
+nonempty compact spaces `X` and `Y`, their distance is the minimum Hausdorff distance
+between all possible isometric embeddings of `X` and `Y` in all metric spaces.
 To define properly the Gromov-Hausdorff space, we consider the non-empty
-compact subsets of ℓ^∞(ℝ) up to isometry, which is a well-defined type,
+compact subsets of `ℓ^∞(ℝ)` up to isometry, which is a well-defined type,
 and define the distance as the infimum of the Hausdorff distance over all
 embeddings in ℓ^∞(ℝ). We prove that this coincides with the previous description,
-as all separable metric spaces embed isometrically into ℓ^∞(ℝ), through an
+as all separable metric spaces embed isometrically into `ℓ^∞(ℝ)`, through an
 embedding called the Kuratowski embedding.
 To prove that we have a distance, we should show that if spaces can be coupled
 to be arbitrarily close, then they are isometric. More generally, the Gromov-Hausdorff
@@ -22,13 +30,12 @@ distance is realized, i.e., there is a coupling for which the Hausdorff distance
 is exactly the Gromov-Hausdorff distance. This follows from a compactness
 argument, essentially following from Arzela-Ascoli.
 
+## Main results
+
 We prove the most important properties of the Gromov-Hausdorff space: it is a polish space,
 i.e., it is complete and second countable. We also prove the Gromov compactness criterion.
+
 -/
-
-import topology.metric_space.closeds set_theory.cardinal topology.metric_space.gromov_hausdorff_realized
-topology.metric_space.completion
-
 
 noncomputable theory
 open_locale classical

--- a/src/topology/metric_space/hausdorff_distance.lean
+++ b/src/topology/metric_space/hausdorff_distance.lean
@@ -2,20 +2,29 @@
 Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Sébastien Gouëzel
+-/
+
+import topology.metric_space.isometry topology.instances.ennreal
+       topology.metric_space.lipschitz
+
+/-!
+# Hausdorff distance
+
 The Hausdorff distance on subsets of a metric (or emetric) space.
+
 Given two subsets `s` and `t` of a metric space, their Hausdorff distance is the smallest `d`
 such that any point `s` is within `d` of a point in `t`, and conversely. This quantity
 is often infinite (think of `s` bounded and `t` unbounded), and therefore better
 expressed in the setting of emetric spaces.
+
+## Main definitions
+
 This files introduces:
 * `inf_edist x s`, the infimum edistance of a point `x` to a set `s` in an emetric space
 * `Hausdorff_edist s t`, the Hausdorff edistance of two sets in an emetric space
 * Versions of these notions on metric spaces, called respectively `inf_dist` and
 `Hausdorff_dist`.
 -/
-
-import topology.metric_space.isometry topology.instances.ennreal
-       topology.metric_space.lipschitz
 noncomputable theory
 open_locale classical
 universes u v w

--- a/src/topology/sequences.lean
+++ b/src/topology/sequences.lean
@@ -2,8 +2,13 @@
 Copyright (c) 2018 Jan-David Salchow. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jan-David Salchow
+-/
 
-Sequences in topological spaces.
+import topology.basic
+import topology.bases
+
+/-!
+# Sequences in topological spaces
 
 In this file we define sequences in topological spaces and show how they are related to
 filters and the topology. In particular, we
@@ -13,12 +18,9 @@ filters and the topology. In particular, we
 * define sequential continuity and show that it coincides with continuity in sequential spaces,
 * provide an instance that shows that every first-countable (and in particular metric) space is a sequential space.
 
-TODO:
+# TODO
 * Sequential compactness should be handled here.
 -/
-
-import topology.basic
-import topology.bases
 
 open set filter
 open_locale topological_space


### PR DESCRIPTION
A bunch of files in the library have fairly detailed docs in the copyright header, which isn't semantically meaningful. This is a more or less random pass to find and fix some of them. Some minor touch-ups too.

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
