### PR TITLE
feat(analysis/normed_space/finite_dimension): finite-dimensional spaces on complete fields

### DIFF
--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -148,7 +148,7 @@ lemma ball_0_eq (ε : ℝ) : ball (0:α) ε = {x | ∥x∥ < ε} :=
 set.ext $ assume a, by simp
 
 theorem normed_group.tendsto_nhds_zero {f : γ → α} {l : filter γ} :
-  tendsto f l (𝓝 0) ↔ ∀ ε, 0 < ε → { x | ∥ f x ∥ < ε } ∈ l :=
+  tendsto f l (𝓝 0) ↔ ∀ ε > 0, { x | ∥ f x ∥ < ε } ∈ l :=
 begin
   rw [metric.tendsto_nhds], simp only [normed_group.dist_eq, sub_zero],
   split,
@@ -561,7 +561,7 @@ open finset filter
 variables [normed_group α] [complete_space α]
 
 lemma summable_iff_vanishing_norm {f : ι → α} :
-  summable f ↔ ∀ε, 0 < ε → (∃s:finset ι, ∀t, disjoint t s → ∥ t.sum f ∥ < ε) :=
+  summable f ↔ ∀ε > 0, ∃s:finset ι, ∀t, disjoint t s → ∥ t.sum f ∥ < ε :=
 begin
   simp only [summable_iff_vanishing, metric.mem_nhds_iff, exists_imp_distrib],
   split,

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -18,12 +18,16 @@ open filter metric
 open_locale topological_space
 localized "notation f `→_{`:50 a `}`:0 b := filter.tendsto f (_root_.nhds a) (_root_.nhds b)" in filter
 
+/-- Auxiliary class, endowing a type `α` with a function `norm : α → ℝ`. This class is designed to
+be extended in more interesting classes specifying the properties of the norm. -/
 class has_norm (α : Type*) := (norm : α → ℝ)
 
 export has_norm (norm)
 
 notation `∥`:1024 e:1 `∥`:1 := norm e
 
+/-- A normed group is an additive group endowed with a norm for which `dist x y = ∥x - y∥` defines
+a metric space structure. -/
 class normed_group (α : Type*) extends has_norm α, add_comm_group α, metric_space α :=
 (dist_eq : ∀ x y, dist x y = norm (x - y))
 
@@ -54,6 +58,8 @@ structure normed_group.core (α : Type*) [add_comm_group α] [has_norm α] :=
 (triangle : ∀ x y : α, ∥x + y∥ ≤ ∥x∥ + ∥y∥)
 (norm_neg : ∀ x : α, ∥-x∥ = ∥x∥)
 
+/-- Constructing a normed group from core properties of a norm, i.e., registering the distance and
+the metric space structure from the norm properties. -/
 noncomputable def normed_group.of_core (α : Type*) [add_comm_group α] [has_norm α]
   (C : normed_group.core α) : normed_group α :=
 { dist := λ x y, ∥x - y∥,
@@ -142,7 +148,7 @@ lemma ball_0_eq (ε : ℝ) : ball (0:α) ε = {x | ∥x∥ < ε} :=
 set.ext $ assume a, by simp
 
 theorem normed_group.tendsto_nhds_zero {f : γ → α} {l : filter γ} :
-  tendsto f l (𝓝 0) ↔ ∀ ε > 0, { x | ∥ f x ∥ < ε } ∈ l :=
+  tendsto f l (𝓝 0) ↔ ∀ ε, 0 < ε → { x | ∥ f x ∥ < ε } ∈ l :=
 begin
   rw [metric.tendsto_nhds], simp only [normed_group.dist_eq, sub_zero],
   split,
@@ -153,9 +159,9 @@ begin
   exact ⟨_, h ε εgt0, set.subset.refl _⟩
 end
 
-
 section nnnorm
 
+/-- Version of the norm taking values in nonnegative reals. -/
 def nnnorm (a : α) : nnreal := ⟨norm a, norm_nonneg a⟩
 
 @[simp] lemma coe_nnnorm (a : α) : (nnnorm a : ℝ) = norm a := rfl
@@ -179,23 +185,39 @@ nnreal.coe_le.2 $ dist_norm_norm_le g h
 
 end nnnorm
 
+/-- A submodule of a normed group is also a normed group, with the restriction of the norm.
+As all instances can be inferred from the submodule `s`, they are put as implicit instead of
+typeclasses. -/
+instance submodule.normed_group {𝕜 : Type*} {_ : ring 𝕜}
+  {E : Type*} [normed_group E] {_ : module 𝕜 E} (s : submodule 𝕜 E) : normed_group s :=
+{ norm := λx, norm (x : E),
+  dist_eq := λx y, dist_eq_norm (x : E) (y : E) }
+
+/-- normed group instance on the product of two normed groups, using the sup norm. -/
 instance prod.normed_group : normed_group (α × β) :=
 { norm := λx, max ∥x.1∥ ∥x.2∥,
   dist_eq := assume (x y : α × β),
     show max (dist x.1 y.1) (dist x.2 y.2) = (max ∥(x - y).1∥ ∥(x - y).2∥), by simp [dist_eq_norm] }
 
 lemma norm_fst_le (x : α × β) : ∥x.1∥ ≤ ∥x∥ :=
-begin have : ∥x∥ = max (∥x.fst∥) (∥x.snd∥) := rfl, rw this, simp[le_max_left] end
+by simp [norm, le_max_left]
 
 lemma norm_snd_le (x : α × β) : ∥x.2∥ ≤ ∥x∥ :=
-begin have : ∥x∥ = max (∥x.fst∥) (∥x.snd∥) := rfl, rw this, simp[le_max_right] end
+by simp [norm, le_max_right]
 
-instance fintype.normed_group {π : ι → Type*} [fintype ι] [∀i, normed_group (π i)] :
+/-- normed group instance on the product of finitely many normed groups, using the sup norm. -/
+instance pi.normed_group {π : ι → Type*} [fintype ι] [∀i, normed_group (π i)] :
   normed_group (Πb, π b) :=
 { norm := λf, ((finset.sup finset.univ (λ b, nnnorm (f b)) : nnreal) : ℝ),
   dist_eq := assume x y,
     congr_arg (coe : nnreal → ℝ) $ congr_arg (finset.sup finset.univ) $ funext $ assume a,
     show nndist (x a) (y a) = nnnorm (x a - y a), from nndist_eq_nnnorm _ _ }
+
+/-- The norm of an element in a product space is `≤ r` if and only if the norm of each
+component is. -/
+lemma pi_norm_le_iff {π : ι → Type*} [fintype ι] [∀i, normed_group (π i)] {r : ℝ} (hr : 0 ≤ r)
+  {x : Πb, π b} : ∥x∥ ≤ r ↔ ∀i, ∥x i∥ ≤ r :=
+by { simp only [(dist_zero_right _).symm, dist_pi_le_iff hr], refl }
 
 lemma tendsto_iff_norm_tendsto_zero {f : ι → β} {a : filter ι} {b : β} :
   tendsto f a (𝓝 b) ↔ tendsto (λ e, ∥ f e - b ∥) a (𝓝 0) :=
@@ -224,6 +246,8 @@ end
 lemma continuous_nnnorm : continuous (nnnorm : α → nnreal) :=
 continuous_subtype_mk _ continuous_norm
 
+/-- A normed group is a uniform additive group, i.e., addition and subtraction are uniformly
+continuous. -/
 instance normed_uniform_group : uniform_add_group α :=
 begin
   refine ⟨metric.uniform_continuous_iff.2 $ assume ε hε, ⟨ε / 2, half_pos hε, assume a b h, _⟩⟩,
@@ -241,6 +265,7 @@ end normed_group
 
 section normed_ring
 
+/-- A normed ring is a ring endowed with a norm which satisfies the inequality `∥x y∥ ≤ ∥x∥ ∥y∥`. -/
 class normed_ring (α : Type*) extends has_norm α, ring α, metric_space α :=
 (dist_eq : ∀ x y, dist x y = norm (x - y))
 (norm_mul : ∀ a b, norm (a * b) ≤ norm a * norm b)
@@ -257,6 +282,7 @@ lemma norm_pow_le {α : Type*} [normed_ring α] (a : α) : ∀ {n : ℕ}, 0 < n 
            (mul_le_mul (le_refl _)
                        (norm_pow_le (nat.succ_pos _)) (norm_nonneg _) (norm_nonneg _))
 
+/-- Normed ring structure on the product of two normed rings, using the sup norm. -/
 instance prod.normed_ring [normed_ring α] [normed_ring β] : normed_ring (α × β) :=
 { norm_mul := assume x y,
   calc
@@ -301,16 +327,20 @@ instance normed_ring_top_monoid [normed_ring α] : topological_monoid α :=
             { apply tendsto_const_nhds }}}}
     end ⟩
 
+/-- A normed ring is a topological ring. -/
 instance normed_top_ring [normed_ring α] : topological_ring α :=
 ⟨ continuous_iff_continuous_at.2 $ λ x, tendsto_iff_norm_tendsto_zero.2 $
     have ∀ e : α, -e - -x = -(e - x), by intro; simp,
     by simp only [this, norm_neg]; apply lim_norm ⟩
 
-
+/-- A normed field is a field with a norm satisfying ∥x y∥ = ∥x∥ ∥y∥. -/
 class normed_field (α : Type*) extends has_norm α, discrete_field α, metric_space α :=
 (dist_eq : ∀ x y, dist x y = norm (x - y))
 (norm_mul' : ∀ a b, norm (a * b) = norm a * norm b)
 
+/-- A nondiscrete normed field is a normed field in which there is an element of norm different from
+`0` and `1`. This makes it possible to bring any element arbitrarily close to `0` by multiplication
+by the powers of any element, and thus to relate algebra and topology. -/
 class nondiscrete_normed_field (α : Type*) extends normed_field α :=
 (non_trivial : ∃x:α, 1<∥x∥)
 
@@ -407,6 +437,8 @@ by rw [← rat.norm_cast_real, ← int.norm_cast_real]; congr' 1; norm_cast
 
 section normed_space
 
+/-- A normed space over a normed field is a vector space endowed with a norm which satisfies the
+equality `∥c • x∥ = ∥c∥ ∥x∥`. -/
 class normed_space (α : Type*) (β : Type*) [normed_field α] [normed_group β]
   extends vector_space α β :=
 (norm_smul : ∀ (a:α) (b:β), norm (a • b) = has_norm.norm a * norm b)
@@ -493,6 +525,7 @@ begin
     exact mul_le_mul_of_nonneg_right hn.1 (norm_nonneg _) }
 end
 
+/-- The product of two normed spaces is a normed space, with the sup norm. -/
 instance : normed_space α (E × F) :=
 { norm_smul :=
   begin
@@ -507,12 +540,18 @@ instance : normed_space α (E × F) :=
   ..prod.normed_group,
   ..prod.vector_space }
 
-instance fintype.normed_space {E : ι → Type*} [fintype ι] [∀i, normed_group (E i)]
+/-- The product of finitely many normed spaces is a normed space, with the sup norm. -/
+instance pi.normed_space {E : ι → Type*} [fintype ι] [∀i, normed_group (E i)]
   [∀i, normed_space α (E i)] : normed_space α (Πi, E i) :=
 { norm_smul := λ a f,
     show (↑(finset.sup finset.univ (λ (b : ι), nnnorm (a • f b))) : ℝ) =
       nnnorm a * ↑(finset.sup finset.univ (λ (b : ι), nnnorm (f b))),
     by simp only [(nnreal.coe_mul _ _).symm, nnreal.mul_finset_sup, nnnorm_smul] }
+
+/-- A subspace of a normed space is also a normed space, with the restriction of the norm. -/
+instance submodule.normed_space {𝕜 : Type*} [normed_field 𝕜]
+  {E : Type*} [normed_group E] [normed_space 𝕜 E] (s : submodule 𝕜 E) : normed_space 𝕜 s :=
+{ norm_smul := λc x, norm_smul c (x : E) }
 
 end normed_space
 
@@ -522,7 +561,7 @@ open finset filter
 variables [normed_group α] [complete_space α]
 
 lemma summable_iff_vanishing_norm {f : ι → α} :
-  summable f ↔ ∀ε>0, (∃s:finset ι, ∀t, disjoint t s → ∥ t.sum f ∥ < ε) :=
+  summable f ↔ ∀ε, 0 < ε → (∃s:finset ι, ∀t, disjoint t s → ∥ t.sum f ∥ < ε) :=
 begin
   simp only [summable_iff_vanishing, metric.mem_nhds_iff, exists_imp_distrib],
   split,

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -85,7 +85,6 @@ lemma continuous_equiv_fun_basis {n : ℕ} {ι : Type u} [fintype ι] (ξ : ι �
   (hn : fintype.card ι = n) (hξ : is_basis 𝕜 ξ) : continuous (equiv_fun_basis hξ) :=
 begin
   resetI,
-  classical,
   induction n with n IH generalizing ι E,
   { apply linear_map.continuous_of_bound _ 0 (λx, _),
     have : equiv_fun_basis hξ x = 0,

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -6,7 +6,6 @@ Authors: Sébastien Gouëzel
 
 import analysis.normed_space.operator_norm linear_algebra.finite_dimensional tactic.omega
 
-
 /-!
 # Finite dimensional normed spaces over complete fields
 
@@ -24,7 +23,7 @@ are continuous. Moreover, a finite-dimensional subspace is always complete and c
   closed
 * `finite_dimensional.proper` : a finite-dimensional space over a proper field is proper. This
   is not registered as an instance, as the field would be an unknown metavariable in typeclass
-  resolution.
+  resolution. It is however registered as an instance for `𝕜 = ℝ`.
 
 ## Implementation notes
 
@@ -57,7 +56,7 @@ lemma linear_map.continuous_on_pi {ι : Type u} [fintype ι] {𝕜 : Type u} [no
   {E : Type v} [normed_group E] [normed_space 𝕜 E] (f : (ι → 𝕜) →ₗ[𝕜] E) : continuous f :=
 begin
   -- for the proof, write `f` in the standard basis, and use that each coordinate is a continuous
-  -- function
+  -- function.
   have : (f : (ι → 𝕜) → E) =
          (λx, finset.sum finset.univ (λi:ι, x i • (f (λj, if i = j then 1 else 0)))),
     by { ext x, exact f.pi_apply_eq_sum_univ x },
@@ -73,7 +72,6 @@ variables {𝕜 : Type u} [nondiscrete_normed_field 𝕜]
 {E : Type u} [normed_group E] [normed_space 𝕜 E]
 {F : Type v} [normed_group F] [normed_space 𝕜 F]
 [complete_space 𝕜]
-include 𝕜
 
 set_option class.instance_max_depth 150
 
@@ -224,7 +222,6 @@ section proper_field
 -- we use linear equivs, which require all the types to live in the same universe
 variables (𝕜 : Type u) [nondiscrete_normed_field 𝕜]
 (E : Type u) [normed_group E] [normed_space 𝕜 E] [proper_space 𝕜]
-include 𝕜
 
 /-- Any finite-dimensional vector space over a proper field is proper.
 We do not register this as an instance to avoid an instance loop when trying to prove the
@@ -252,7 +249,7 @@ end proper_field
 /- Over the real numbers, we can register the previous statement as an instance as it will not
 cause problems in instance resolution since the properness of `ℝ` is already known. -/
 instance finite_dimensional.proper_real
-  (F : Type) [normed_group F] [normed_space ℝ F] [finite_dimensional ℝ F] : proper_space F :=
-finite_dimensional.proper ℝ F
+  (E : Type) [normed_group E] [normed_space ℝ E] [finite_dimensional ℝ E] : proper_space E :=
+finite_dimensional.proper ℝ E
 
 attribute [instance, priority 900] finite_dimensional.proper_real

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -34,7 +34,7 @@ then the identities from `E` to `E'` and from `E'`to `E` are continuous thanks t
 `linear_map.continuous_of_finite_dimensional`. This gives the desired norm equivalence.
 
 The proofs rely on linear equivalences, which are only defined in mathlib for types in the same
-universe. Therefore, all the results in this file are restricted to spaces leaving in the same
+universe. Therefore, all the results in this file are restricted to spaces living in the same
 universe as their base field.
 -/
 

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -84,7 +84,7 @@ finite-dimensional space is continuous, in `linear_map.continuous_of_finite_dime
 lemma continuous_equiv_fun_basis {n : ℕ} {ι : Type u} [fintype ι] (ξ : ι → E)
   (hn : fintype.card ι = n) (hξ : is_basis 𝕜 ξ) : continuous (equiv_fun_basis hξ) :=
 begin
-  resetI,
+  unfreezeI,
   induction n with n IH generalizing ι E,
   { apply linear_map.continuous_of_bound _ 0 (λx, _),
     have : equiv_fun_basis hξ x = 0,

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -1,0 +1,211 @@
+/-
+Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sébastien Gouëzel
+-/
+
+import analysis.normed_space.operator_norm linear_algebra.finite_dimensional
+tactic.omega topology.metric_space.isometry
+
+
+/-!
+# Properties of norms in finite dimension
+
+Over a complete nondiscrete field, all norms are equivalent in finite dimension, all
+finite-dimensional subspaces are closed, and all linear maps are continuous. These facts are
+all proved in this file
+-/
+
+universes u v w
+
+open set
+open_locale classical
+
+set_option class.instance_max_depth 100
+
+lemma linear_map.continuous_on_pi {ι : Type u} [fintype ι] {𝕜 : Type u} [normed_field 𝕜]
+  {E : Type v} [normed_group E] [normed_space 𝕜 E] (f : (ι → 𝕜) →ₗ[𝕜] E) : continuous f :=
+begin
+  have : (f : (ι → 𝕜) → E) = (λx, finset.sum finset.univ (λi:ι, x i • (f (λj, if i = j then 1 else 0)))),
+  { ext x,
+    exact f.pi_apply_eq_sum_univ x },
+  rw this,
+  refine continuous_finset_sum _ (λi hi, _),
+  exact continuous_smul (continuous_apply i) continuous_const
+end
+
+
+open finite_dimensional
+
+-- To get a reasonable compile time for `continuous_equiv_fun_basis`, typeclass inference needs
+-- to be guided.
+local attribute [instance, priority 10000] pi.module normed_space.to_vector_space
+  vector_space.to_module submodule.add_comm_group submodule.module
+  linear_map.finite_dimensional_range Pi.complete nondiscrete_normed_field.to_normed_field
+
+section complete_field
+
+-- we use linear equivs, which require all the types to live in the same universe
+variables {𝕜 : Type u} [nondiscrete_normed_field 𝕜]
+{E : Type u} [normed_group E] [normed_space 𝕜 E]
+{F : Type u} [normed_group F] [normed_space 𝕜 F]
+[complete_space 𝕜]
+include 𝕜
+
+set_option class.instance_max_depth 150
+
+/-- In finite dimension over a complete field, the canonical identification (in terms of a basis)
+with 𝕜^n together with its sup norm is continuous. This is the nontrivial part in the fact that all
+norms are equivalent in finite dimension.
+Do not use this statement as its formulation is awkward (in terms of the dimension n, as the proof
+is done by induction over n) and it is superceded by the fact that every linear map on a
+finite-dimensional space is continuous, in `linear_map.continuous_of_finite_dimensional`. -/
+lemma continuous_equiv_fun_basis {n : ℕ} {ι : Type u} [fintype ι] (ξ : ι → E)
+  (hn : fintype.card ι = n) (hξ : is_basis 𝕜 ξ) : continuous (equiv_fun_basis hξ) :=
+begin
+  resetI,
+  classical,
+  induction n with n IH generalizing ι E,
+  { apply linear_map.continuous_of_bound _ 0 (λx, _),
+    have : equiv_fun_basis hξ x = 0,
+      by { ext i, exact (fintype.card_eq_zero_iff.1 hn i).elim },
+    change ∥equiv_fun_basis hξ x∥ ≤ 0 * ∥x∥,
+    rw this,
+    simp [norm_nonneg] },
+  { haveI : finite_dimensional 𝕜 E := finite_dimensional_of_finite_basis hξ,
+    -- first step: thanks to the inductive assumption, any n-dimensional subspace is equivalent
+    -- to a standard space of dimension n, hence it is complete and therefore closed.
+    have H₁ : ∀s : submodule 𝕜 E, findim 𝕜 s = n → is_closed (s : set E),
+    { assume s s_dim,
+      rcases exists_is_basis_finite 𝕜 s with ⟨b, b_basis, b_finite⟩,
+      letI : fintype b := set.finite.fintype b_finite,
+      have U : uniform_embedding (equiv_fun_basis b_basis).symm,
+      { have : fintype.card b = n,
+          by { rw ← s_dim, exact (findim_eq_card b_basis).symm },
+        have : continuous (equiv_fun_basis b_basis) := IH (subtype.val : b → s) this b_basis,
+        exact (equiv_fun_basis b_basis).symm.uniform_embedding (linear_map.continuous_on_pi _) this },
+      have : is_complete (range ((equiv_fun_basis b_basis).symm)),
+      { rw [← image_univ, is_complete_image_iff U],
+        convert complete_univ,
+        change complete_space (b → 𝕜),
+        apply_instance },
+      have : is_complete (range (subtype.val : s → E)),
+      { change is_complete (range ((equiv_fun_basis b_basis).symm.to_equiv)) at this,
+        rw equiv.range_eq_univ at this,
+        rwa [← set.image_univ, is_complete_image_iff],
+        exact isometry_subtype_val.uniform_embedding },
+      apply is_closed_of_is_complete,
+      convert this,
+      rw set.subtype.val_range,
+      ext x,
+      refl },
+    -- second step: any linear form is continuous, as its kernel is closed by the first step
+    have H₂ : ∀f : E →ₗ[𝕜] 𝕜, continuous f,
+    { assume f,
+      have : findim 𝕜 f.ker = n ∨ findim 𝕜 f.ker = n.succ,
+      { have Z := f.findim_range_add_findim_ker,
+        rw [findim_eq_card hξ, hn] at Z,
+        have : findim 𝕜 f.range = 0 ∨ findim 𝕜 f.range = 1,
+        { have I : ∀(k : ℕ), k ≤ 1 ↔ k = 0 ∨ k = 1, by omega manual,
+          have : findim 𝕜 f.range ≤ findim 𝕜 𝕜 := findim_submodule_le _,
+          rwa [findim_of_field, I] at this },
+        cases this,
+        { rw this at Z,
+          right,
+          simpa using Z },
+        { left,
+          rw [this, add_comm, nat.add_one] at Z,
+          exact nat.succ_inj Z } },
+      have : is_closed (f.ker : set E),
+      { cases this,
+        { exact H₁ _ this },
+        { have : f.ker = ⊤,
+            by { apply eq_top_of_findim_eq, rw [findim_eq_card hξ, hn, this] },
+          simp [this] } },
+      exact linear_map.continuous_iff_is_closed_ker.2 this },
+    -- third step: applying the continuity to the linear form corresponding to a coefficient in the
+    -- basis decomposition, deduce that all such coefficients are controlled in terms of the norm
+    have : ∀i:ι, ∃C, 0 ≤ C ∧ ∀(x:E), ∥equiv_fun_basis hξ x i∥ ≤ C * ∥x∥,
+    { assume i,
+      let f : E →ₗ[𝕜] 𝕜 := (linear_map.proj i).comp (equiv_fun_basis hξ),
+      let f' : E →L[𝕜] 𝕜 := {cont := H₂ f, ..f},
+      exact ⟨∥f'∥, norm_nonneg _, λx, continuous_linear_map.le_op_norm f' x⟩ },
+    -- fourth step: combine the bound on each coefficient to get a global bound and the continuity
+    choose C0 hC0 using this,
+    let C := finset.sum finset.univ C0,
+    have C_nonneg : 0 ≤ C := finset.sum_nonneg (λi hi, (hC0 i).1),
+    have C0_le : ∀i, C0 i ≤ C :=
+      λi, finset.single_le_sum (λj hj, (hC0 j).1) (finset.mem_univ _),
+    apply linear_map.continuous_of_bound _ C (λx, _),
+    rw pi_norm_le_iff,
+    { exact λi, le_trans ((hC0 i).2 x) (mul_le_mul_of_nonneg_right (C0_le i) (norm_nonneg _)) },
+    { exact mul_nonneg C_nonneg (norm_nonneg _) } }
+end
+
+/-- Any linear map on a finite dimensional space over a complete field is continuous. -/
+theorem linear_map.continuous_of_finite_dimensional [finite_dimensional 𝕜 E] (f : E →ₗ[𝕜] F) :
+  continuous f :=
+begin
+  rcases exists_is_basis_finite 𝕜 E with ⟨b, b_basis, b_finite⟩,
+  letI : fintype b := set.finite.fintype b_finite,
+  have A : continuous (equiv_fun_basis b_basis) :=
+    continuous_equiv_fun_basis _ rfl b_basis,
+  have B : continuous (f.comp ((equiv_fun_basis b_basis).symm : (b → 𝕜) →ₗ[𝕜] E)) :=
+    linear_map.continuous_on_pi _,
+  have : continuous ((f.comp ((equiv_fun_basis b_basis).symm : (b → 𝕜) →ₗ[𝕜] E))
+                      ∘ (equiv_fun_basis b_basis)) := B.comp A,
+  convert this,
+  ext x,
+  simp only [linear_equiv.coe_apply, function.comp_app, coe_fn_coe_base, linear_map.comp_apply],
+  rw linear_equiv.symm_apply_apply
+end
+
+/-- Any finite-dimensional vector space over a complete field is complete.
+We do not register this as an instance to avoid an instance loop when trying to prove the
+completeness of 𝕜, and the sarch for 𝕜 as an unknown metavariable. Declare the instance explicitly
+when needed. -/
+lemma finite_dimensional.complete [finite_dimensional 𝕜 E] : complete_space E :=
+begin
+  rcases exists_is_basis_finite 𝕜 E with ⟨b, b_basis, b_finite⟩,
+  letI : fintype b := set.finite.fintype b_finite,
+  have : uniform_embedding (equiv_fun_basis b_basis).symm :=
+    linear_equiv.uniform_embedding _ (linear_map.continuous_of_finite_dimensional _)
+    (linear_map.continuous_of_finite_dimensional _),
+  have : is_complete ((equiv_fun_basis b_basis).symm.to_equiv '' univ) :=
+    (is_complete_image_iff this).mpr complete_univ,
+  rw [image_univ, equiv.range_eq_univ] at this,
+  exact complete_space_of_is_complete_univ this
+end
+
+end complete_field
+
+section proper_field
+-- we use linear equivs, which require all the types to live in the same universe
+variables {𝕜 : Type u} [nondiscrete_normed_field 𝕜]
+{E : Type u} [normed_group E] [normed_space 𝕜 E]
+{F : Type u} [normed_group F] [normed_space 𝕜 F]
+[proper_space 𝕜]
+include 𝕜
+
+/-- Any finite-dimensional vector space over a proper field is proper.
+We do not register this as an instance to avoid an instance loop when trying to prove the
+properness of 𝕜, and the sarch for 𝕜 as an unknown metavariable. Declare the instance explicitly
+when needed. -/
+lemma finite_dimensional.proper [finite_dimensional 𝕜 E] : proper_space E :=
+begin
+  rcases exists_is_basis_finite 𝕜 E with ⟨b, b_basis, b_finite⟩,
+  letI : fintype b := set.finite.fintype b_finite,
+  let e := (equiv_fun_basis b_basis),
+  let f : E →L[𝕜] (b → 𝕜) :=
+    {cont := linear_map.continuous_of_finite_dimensional _, ..e.to_linear_map},
+  refine metric.proper_image_of_proper e.symm
+    (linear_map.continuous_of_finite_dimensional _) _ (∥f∥)  (λx y, _),
+  { exact equiv.range_eq_univ e.symm.to_equiv },
+  { have A : e (e.symm x) = x := linear_equiv.apply_symm_apply _ _,
+    have B : e (e.symm y) = y := linear_equiv.apply_symm_apply _ _,
+    conv_lhs { rw [← A, ← B] },
+    change dist (f (e.symm x)) (f (e.symm y)) ≤ ∥f∥ * dist (e.symm x) (e.symm y),
+    exact f.lipschitz.2 _ _ }
+end
+
+end proper_field

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -4,12 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
 
-import analysis.normed_space.operator_norm linear_algebra.finite_dimensional
-tactic.omega topology.metric_space.isometry
+import analysis.normed_space.operator_norm linear_algebra.finite_dimensional tactic.omega
 
 
 /-!
-# Properties of norms in finite dimension over complete fields
+# Finite dimensional normed spaces over complete fields
 
 Over a complete nondiscrete field, in finite dimension, all norms are equivalent and all linear maps
 are continuous. Moreover, a finite-dimensional subspace is always complete and closed.
@@ -30,17 +29,17 @@ are continuous. Moreover, a finite-dimensional subspace is always complete and c
 ## Implementation notes
 
 The fact that all norms are equivalent is not written explicitly, as it would mean having two norms
-on a single space, which is not the way we use type classes. However, if one has a
+on a single space, which is not the way type classes work. However, if one has a
 finite-dimensional vector space `E` with a norm, and a copy `E'` of this type with another norm,
-then the identity from `E` to `E'` and from `E'`to `E` are continuous thanks to
-`linear_map.continuous_of_finite_dimensional`. This gives the desired normed equivalence.
+then the identities from `E` to `E'` and from `E'`to `E` are continuous thanks to
+`linear_map.continuous_of_finite_dimensional`. This gives the desired norm equivalence.
 
 The proofs rely on linear equivalences, which are only defined in mathlib for types in the same
 universe. Therefore, all the results in this file are restricted to spaces leaving in the same
 universe as their base field.
 -/
 
-universes u v w
+universes u v
 
 open set finite_dimensional
 open_locale classical
@@ -102,7 +101,7 @@ begin
     have H₁ : ∀s : submodule 𝕜 E, findim 𝕜 s = n → is_closed (s : set E),
     { assume s s_dim,
       rcases exists_is_basis_finite 𝕜 s with ⟨b, b_basis, b_finite⟩,
-      letI : fintype b := set.finite.fintype b_finite,
+      letI : fintype b := finite.fintype b_finite,
       have U : uniform_embedding (equiv_fun_basis b_basis).symm,
       { have : fintype.card b = n,
           by { rw ← s_dim, exact (findim_eq_card b_basis).symm },
@@ -116,13 +115,10 @@ begin
       have : is_complete (range (subtype.val : s → E)),
       { change is_complete (range ((equiv_fun_basis b_basis).symm.to_equiv)) at this,
         rw equiv.range_eq_univ at this,
-        rwa [← set.image_univ, is_complete_image_iff],
+        rwa [← image_univ, is_complete_image_iff],
         exact isometry_subtype_val.uniform_embedding },
       apply is_closed_of_is_complete,
-      convert this,
-      rw set.subtype.val_range,
-      ext x,
-      refl },
+      rwa subtype.val_range at this },
     -- second step: any linear form is continuous, as its kernel is closed by the first step
     have H₂ : ∀f : E →ₗ[𝕜] 𝕜, continuous f,
     { assume f,
@@ -173,7 +169,7 @@ begin
   -- for the proof, go to a model vector space `b → 𝕜` thanks to `continuous_equiv_fun_basis`, and
   -- argue that all linear maps there are continuous.
   rcases exists_is_basis_finite 𝕜 E with ⟨b, b_basis, b_finite⟩,
-  letI : fintype b := set.finite.fintype b_finite,
+  letI : fintype b := finite.fintype b_finite,
   have A : continuous (equiv_fun_basis b_basis) :=
     continuous_equiv_fun_basis _ rfl b_basis,
   have B : continuous (f.comp ((equiv_fun_basis b_basis).symm : (b → 𝕜) →ₗ[𝕜] E)) :=
@@ -190,11 +186,11 @@ end
 We do not register this as an instance to avoid an instance loop when trying to prove the
 completeness of 𝕜, and the search for 𝕜 as an unknown metavariable. Declare the instance explicitly
 when needed. -/
-variables (𝕜 E E)
+variables (𝕜 E)
 lemma finite_dimensional.complete [finite_dimensional 𝕜 E] : complete_space E :=
 begin
   rcases exists_is_basis_finite 𝕜 E with ⟨b, b_basis, b_finite⟩,
-  letI : fintype b := set.finite.fintype b_finite,
+  letI : fintype b := finite.fintype b_finite,
   have : uniform_embedding (equiv_fun_basis b_basis).symm :=
     linear_equiv.uniform_embedding _ (linear_map.continuous_of_finite_dimensional _)
     (linear_map.continuous_of_finite_dimensional _),
@@ -211,13 +207,10 @@ lemma submodule.complete_of_finite_dimensional (s : submodule 𝕜 E) [finite_di
 begin
   haveI : complete_space s := finite_dimensional.complete 𝕜 s,
   have : is_complete (range (subtype.val : s → E)),
-  { rw [← set.image_univ, is_complete_image_iff],
+  { rw [← image_univ, is_complete_image_iff],
     { exact complete_univ },
     { exact isometry_subtype_val.uniform_embedding } },
-  convert this,
-  rw set.subtype.val_range,
-  ext x,
-  refl
+  rwa subtype.val_range at this
 end
 
 /-- A finite-dimensional subspace is closed. -/
@@ -240,7 +233,7 @@ when needed. -/
 lemma finite_dimensional.proper [finite_dimensional 𝕜 E] : proper_space E :=
 begin
   rcases exists_is_basis_finite 𝕜 E with ⟨b, b_basis, b_finite⟩,
-  letI : fintype b := set.finite.fintype b_finite,
+  letI : fintype b := finite.fintype b_finite,
   let e := equiv_fun_basis b_basis,
   let f : E →L[𝕜] (b → 𝕜) :=
     { cont := linear_map.continuous_of_finite_dimensional _, ..e.to_linear_map },

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -23,7 +23,9 @@ are continuous. Moreover, a finite-dimensional subspace is always complete and c
   closed
 * `finite_dimensional.proper` : a finite-dimensional space over a proper field is proper. This
   is not registered as an instance, as the field would be an unknown metavariable in typeclass
-  resolution. It is however registered as an instance for `𝕜 = ℝ`.
+  resolution. It is however registered as an instance for `𝕜 = ℝ` and `𝕜 = ℂ`. As properness
+  implies completeness, there is no need to also register `finite_dimensional.complete` on `ℝ` or
+  `ℂ`.
 
 ## Implementation notes
 
@@ -252,3 +254,11 @@ instance finite_dimensional.proper_real
 finite_dimensional.proper ℝ E
 
 attribute [instance, priority 900] finite_dimensional.proper_real
+
+/- Over the complex numbers, we can register the previous statement as an instance as it will not
+cause problems in instance resolution since the properness of `ℂ` is already known. -/
+instance finite_dimensional.proper_complex
+  (E : Type) [normed_group E] [normed_space ℂ E] [finite_dimensional ℂ E] : proper_space E :=
+finite_dimensional.proper ℂ E
+
+attribute [instance, priority 900] finite_dimensional.proper_complex

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -70,6 +70,9 @@ protected theorem surjective : ∀ f : α ≃ β, surjective f
 protected theorem bijective (f : α ≃ β) : bijective f :=
 ⟨f.injective, f.surjective⟩
 
+@[simp] lemma range_eq_univ {α : Type*} {β : Type*} (e : equiv α β) : set.range e = set.univ :=
+set.eq_univ_of_forall e.surjective
+
 protected theorem subsingleton (e : α ≃ β) : ∀ [subsingleton β], subsingleton α
 | ⟨H⟩ := ⟨λ a b, e.injective (H _ _)⟩
 

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -70,7 +70,7 @@ protected theorem surjective : ∀ f : α ≃ β, surjective f
 protected theorem bijective (f : α ≃ β) : bijective f :=
 ⟨f.injective, f.surjective⟩
 
-@[simp] lemma range_eq_univ {α : Type*} {β : Type*} (e : equiv α β) : set.range e = set.univ :=
+@[simp] lemma range_eq_univ {α : Type*} {β : Type*} (e : α ≃ β) : set.range e = set.univ :=
 set.eq_univ_of_forall e.surjective
 
 protected theorem subsingleton (e : α ≃ β) : ∀ [subsingleton β], subsingleton α

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -79,6 +79,25 @@ finset.smul_sum
 
 end finsupp
 
+section
+open_locale classical
+
+/-- decomposing `x : ι → R` as a sum along the canonical basis-/
+lemma pi_eq_sum_univ {ι : Type u} [fintype ι] {R : Type v} [semiring R] (x : ι → R) :
+  x = finset.sum finset.univ (λi:ι, x i • (λj, if i = j then 1 else 0)) :=
+begin
+  ext k,
+  rw pi.finset_sum_apply,
+  have : finset.sum finset.univ (λ (x_1 : ι), x x_1 * ite (k = x_1) 1 0) = x k,
+    by { have := finset.sum_mul_boole finset.univ x k, rwa if_pos (finset.mem_univ _) at this },
+  rw ← this,
+  apply finset.sum_congr rfl (λl hl, _),
+  simp only [smul_eq_mul, mul_ite, pi.smul_apply],
+  conv_lhs { rw eq_comm }
+end
+
+end
+
 namespace linear_map
 section
 variables [ring R] [add_comm_group M] [add_comm_group M₂] [add_comm_group M₃] [add_comm_group M₄]
@@ -176,6 +195,21 @@ include M
 instance endomorphism_ring : ring (M →ₗ[R] M) :=
 by refine {mul := (*), one := 1, ..linear_map.add_comm_group, ..};
   { intros, apply linear_map.ext, simp }
+
+end
+
+section
+open_locale classical
+
+/-- A linear map `f` applied to `x : ι → R` can be computed using the image under `f` of elements
+of the canonical basis. -/
+lemma pi_apply_eq_sum_univ {ι : Type u} [fintype ι] (f : (ι → R) →ₗ[R] M) (x : ι → R) :
+  f x = finset.sum finset.univ (λi:ι, x i • (f (λj, if i = j then 1 else 0))) :=
+begin
+  conv_lhs { rw [pi_eq_sum_univ x, f.map_sum] },
+  apply finset.sum_congr rfl (λl hl, _),
+  rw f.map_smul
+end
 
 end
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -82,7 +82,7 @@ end finsupp
 section
 open_locale classical
 
-/-- decomposing `x : ι → R` as a sum along the canonical basis-/
+/-- decomposing `x : ι → R` as a sum along the canonical basis -/
 lemma pi_eq_sum_univ {ι : Type u} [fintype ι] {R : Type v} [semiring R] (x : ι → R) :
   x = finset.sum finset.univ (λi:ι, x i • (λj, if i = j then 1 else 0)) :=
 begin

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -920,6 +920,22 @@ theorem module.card_fintype [fintype R] [fintype M] :
 calc card M = card (ι → R)    : card_congr (equiv_fun_basis h).to_equiv
         ... = card R ^ card ι : card_fun
 
+/-- Given a basis `v` indexed by `ι`, the canonical linear equivalence between `ι → R` and `M` maps
+a function `x : ι → R` to the linear combination `∑_i x i • v i`. -/
+@[simp] lemma equiv_fun_basis_symm_apply (x : ι → R) :
+  (equiv_fun_basis h).symm x = finset.sum finset.univ (λi, x i • v i) :=
+begin
+  change finsupp.sum
+      ((finsupp.equiv_fun_on_fintype.symm : (ι → R) ≃ (ι →₀ R)) x) (λ (i : ι) (a : R), a • v i)
+    = finset.sum finset.univ (λi, x i • v i),
+  dsimp [finsupp.equiv_fun_on_fintype, finsupp.sum],
+  rw finset.sum_filter,
+  refine finset.sum_congr rfl (λi hi, _),
+  by_cases H : x i = 0,
+  { simp [H] },
+  { simp [H], refl }
+end
+
 end module
 
 section vector_space
@@ -1223,7 +1239,7 @@ begin
 end
 
 section
-variables (R ι)
+variables (R η)
 
 lemma is_basis_fun₀ : is_basis R
     (λ (ji : Σ (j : η), (λ _, unit) j),
@@ -1236,13 +1252,12 @@ end
 
 lemma is_basis_fun : is_basis R (λ i, std_basis R (λi:η, R) i 1) :=
 begin
-  apply is_basis.comp (is_basis_fun₀ R) (λ i, ⟨i, punit.star⟩) ,
-  { apply bijective_iff_has_inverse.2,
-    use (λ x, x.1),
-    simp [function.left_inverse, function.right_inverse],
-    intros _ b,
-    rw [unique.eq_default b, unique.eq_default punit.star] },
-  apply_instance
+  apply is_basis.comp (is_basis_fun₀ R η) (λ i, ⟨i, punit.star⟩),
+  apply bijective_iff_has_inverse.2,
+  use (λ x, x.1),
+  simp [function.left_inverse, function.right_inverse],
+  intros _ b,
+  rw [unique.eq_default b, unique.eq_default punit.star]
 end
 
 end

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -72,7 +72,7 @@ end
 instance [finite_dimensional K V] (S : submodule K V) : finite_dimensional K S :=
 finite_dimensional_iff_dim_lt_omega.2 (lt_of_le_of_lt (dim_submodule_le _) (dim_lt_omega K V))
 
-/-- The dimension of a finite dimensional vector space, in ℕ-/
+/-- The dimension of a finite-dimensional vector space as a natural number -/
 noncomputable def findim (K V : Type*) [discrete_field K]
   [add_comm_group V] [vector_space K V] [finite_dimensional K V] : ℕ :=
 classical.some (lt_omega.1 (dim_lt_omega K V))

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -20,7 +20,8 @@ universes u v w
 
 open vector_space cardinal submodule module function
 
-variables {K : Type u} {V : Type v} [discrete_field K] [add_comm_group V] [vector_space K V]
+variables {K : Type u} {V V₂ : Type v} [discrete_field K] [add_comm_group V] [vector_space K V]
+[add_comm_group V₂] [vector_space K V₂]
 
 /-- `finite_dimensional` vector spaces are defined to be noetherian modules.
   Use `finite_dimensional.of_fg` to prove finite dimensional from a conventional
@@ -71,6 +72,7 @@ end
 instance [finite_dimensional K V] (S : submodule K V) : finite_dimensional K S :=
 finite_dimensional_iff_dim_lt_omega.2 (lt_of_le_of_lt (dim_submodule_le _) (dim_lt_omega K V))
 
+/-- The dimension of a finite dimensional vector space, in ℕ-/
 noncomputable def findim (K V : Type*) [discrete_field K]
   [add_comm_group V] [vector_space K V] [finite_dimensional K V] : ℕ :=
 classical.some (lt_omega.1 (dim_lt_omega K V))
@@ -104,6 +106,25 @@ begin
   rw [this, map_top (submodule.subtype S), range_subtype],
 end
 
+/-- The dimension of a submodule is bounded by the dimension of the ambient space. -/
+lemma findim_submodule_le [finite_dimensional K V] (s : submodule K V) : findim K s ≤ findim K V :=
+begin
+  have := dim_submodule_le s,
+  rw [← findim_eq_dim, ← findim_eq_dim] at this,
+  norm_cast at this,
+  exact this
+end
+
+variable (K)
+/-- A field is one-dimensional as a vector space over itself. -/
+@[simp] lemma findim_of_field : findim K K = 1 :=
+begin
+  have := dim_of_field K,
+  rw [← findim_eq_dim] at this,
+  norm_cast at this,
+  exact this
+end
+
 /-- The vector space of functions on a fintype has finite dimension. -/
 instance finite_dimensional_fintype_fun {ι : Type*} [fintype ι] :
   finite_dimensional K (ι → K) :=
@@ -124,6 +145,8 @@ end
 @[simp] lemma findim_fin_fun {n : ℕ} : findim K (fin n → K) = n :=
 by simp
 
+variable {K}
+
 section
 
 variables {ι : Type w} [fintype ι] [decidable_eq V]
@@ -139,6 +162,17 @@ finite_dimensional.of_fg $ fg_of_finite_basis h
 lemma dim_eq_card : dim K V = fintype.card ι :=
 by rw [←h.mk_range_eq_dim, cardinal.fintype_card,
        set.card_range_of_injective (h.injective zero_ne_one)]
+
+/-- The findim of a vector space is equal to the cardinality of any basis.
+The assumption `[finite_dimensional K V]` is redundant, as there is a finite basis anyway, but it
+is necessary to make sense of `findim`. -/
+lemma findim_eq_card [finite_dimensional K V] : findim K V = fintype.card ι :=
+begin
+  have := dim_eq_card h,
+  rw ← findim_eq_dim at this,
+  norm_cast at this,
+  exact this
+end
 
 end
 
@@ -184,5 +218,23 @@ by rw [← mul_assoc, hfg, one_mul, mul_one] at this; rwa ← this
 
 lemma mul_eq_one_comm [finite_dimensional K V] {f g : V →ₗ[K] V} : f * g = 1 ↔ g * f = 1 :=
 ⟨mul_eq_one_of_mul_eq_one, mul_eq_one_of_mul_eq_one⟩
+
+instance finite_dimensional_range [h : finite_dimensional K V] (f : V →ₗ[K] V₂) :
+  finite_dimensional K f.range :=
+begin
+  rw finite_dimensional_iff_dim_lt_omega at h ⊢,
+  exact lt_of_le_of_lt (dim_range_le f) h
+end
+
+/-- rank-nullity theorem -/
+theorem findim_range_add_findim_ker [finite_dimensional K V] (f : V →ₗ[K] V₂) :
+  findim K f.range + findim K f.ker = findim K V :=
+begin
+  classical,
+  have := dim_range_add_dim_ker f,
+  rw [← findim_eq_dim, ← findim_eq_dim, ← findim_eq_dim] at this,
+  norm_cast at this,
+  exact this
+end
 
 end linear_map

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -161,11 +161,11 @@ lemma dim_eq_card : dim K V = fintype.card ι :=
 by rw [←h.mk_range_eq_dim, cardinal.fintype_card,
        set.card_range_of_injective (h.injective zero_ne_one)]
 
-/-- The findim of a vector space is equal to the cardinality of any basis.
-The assumption `[finite_dimensional K V]` is redundant, as there is a finite basis anyway, but it
-is necessary to make sense of `findim`. -/
-lemma findim_eq_card [finite_dimensional K V] : findim K V = fintype.card ι :=
+/-- The findim of a vector space is equal to the cardinality of any basis. -/
+lemma findim_eq_card : by { haveI : finite_dimensional K V := finite_dimensional_of_finite_basis h,
+  exact findim K V = fintype.card ι } :=
 begin
+  haveI : finite_dimensional K V := finite_dimensional_of_finite_basis h,
   have := dim_eq_card h,
   rw ← findim_eq_dim at this,
   exact_mod_cast this

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -111,8 +111,7 @@ lemma findim_submodule_le [finite_dimensional K V] (s : submodule K V) : findim 
 begin
   have := dim_submodule_le s,
   rw [← findim_eq_dim, ← findim_eq_dim] at this,
-  norm_cast at this,
-  exact this
+  exact_mod_cast this
 end
 
 variable (K)
@@ -121,8 +120,7 @@ variable (K)
 begin
   have := dim_of_field K,
   rw [← findim_eq_dim] at this,
-  norm_cast at this,
-  exact this
+  exact_mod_cast this
 end
 
 /-- The vector space of functions on a fintype has finite dimension. -/
@@ -170,8 +168,7 @@ lemma findim_eq_card [finite_dimensional K V] : findim K V = fintype.card ι :=
 begin
   have := dim_eq_card h,
   rw ← findim_eq_dim at this,
-  norm_cast at this,
-  exact this
+  exact_mod_cast this
 end
 
 end
@@ -233,8 +230,7 @@ begin
   classical,
   have := dim_range_add_dim_ker f,
   rw [← findim_eq_dim, ← findim_eq_dim, ← findim_eq_dim] at this,
-  norm_cast at this,
-  exact this
+  exact_mod_cast this
 end
 
 end linear_map

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -1267,6 +1267,31 @@ lemma compact_iff_closed_bounded [proper_space α] :
   exact compact_of_is_closed_subset (proper_space.compact_ball x r) hc hr
 end⟩
 
+/-- The image of a proper space under an expanding onto map is proper. -/
+lemma proper_image_of_proper [proper_space α] [metric_space β] (f : α → β)
+  (f_cont : continuous f) (hf : range f = univ) (C : ℝ)
+  (hC : ∀x y, dist x y ≤ C * dist (f x) (f y)) : proper_space β :=
+begin
+  apply proper_space_of_compact_closed_ball_of_le 0 (λx₀ r hr, _),
+  let K := f ⁻¹' (closed_ball x₀ r),
+  have A : is_closed K :=
+    continuous_iff_is_closed.1 f_cont (closed_ball x₀ r) (is_closed_ball),
+  have B : bounded K := ⟨max C 0 * (r + r), λx y hx hy, calc
+    dist x y ≤ C * dist (f x) (f y) : hC x y
+    ... ≤ max C 0 * dist (f x) (f y) : mul_le_mul_of_nonneg_right (le_max_left _ _) (dist_nonneg)
+    ... ≤ max C 0 * (dist (f x) x₀ + dist (f y) x₀) :
+      mul_le_mul_of_nonneg_left (dist_triangle_right (f x) (f y) x₀) (le_max_right _ _)
+    ... ≤ max C 0 * (r + r) : begin
+      simp only [mem_closed_ball, mem_preimage] at hx hy,
+      exact mul_le_mul_of_nonneg_left (add_le_add hx hy) (le_max_right _ _)
+    end⟩,
+  have : compact K := compact_iff_closed_bounded.2 ⟨A, B⟩,
+  have C : compact (f '' K) := compact_image this f_cont,
+  have : f '' K = closed_ball x₀ r,
+    by { rw image_preimage_eq_of_subset, rw hf, exact subset_univ _ },
+  rwa this at C
+end
+
 end bounded
 
 section diam


### PR DESCRIPTION
Over a complete field, finite-dimensional vector spaces are complete, all norms are equivalent, all linear functions are continuous. This PR adds a file `analysis/normed_space/finite_dimension.lean` containing these facts, and some supporting tools for this in the library (and some linting in the files I have touched).