### PR TITLE
refactor(order/bounds): make the first argument of `x ∈ upper_bounds s` implicit

### DIFF
--- a/src/data/real/basic.lean
+++ b/src/data/real/basic.lean
@@ -364,15 +364,14 @@ theorem Sup_of_not_bdd_above {s : set ℝ} (hs : ¬ bdd_above s) : lattice.Sup s
 dif_neg $ assume h, hs h.2
 
 theorem Sup_univ : real.Sup set.univ = 0 :=
-real.Sup_of_not_bdd_above $ λ h,
-Exists.dcases_on h $ λ x h', not_le_of_lt (lt_add_one _) $ h' (x + 1) $ set.mem_univ _
+real.Sup_of_not_bdd_above $ λ ⟨x, h⟩, not_le_of_lt (lt_add_one _) $ h (set.mem_univ _)
 
 theorem Inf_empty : lattice.Inf (∅ : set ℝ) = 0 :=
 show Inf ∅ = 0, by simp [Inf]; exact Sup_empty
 
 theorem Inf_of_not_bdd_below {s : set ℝ} (hs : ¬ bdd_below s) : lattice.Inf s = 0 :=
 have bdd_above {x | -x ∈ s} → bdd_below s, from
-  assume ⟨b, hb⟩, ⟨-b, assume x hxs, neg_le.2 $ hb _ $ by simp [hxs]⟩,
+  assume ⟨b, hb⟩, ⟨-b, assume x hxs, neg_le.2 $ hb $ by simp [hxs]⟩,
 have ¬ bdd_above {x | -x ∈ s}, from mt this hs,
 neg_eq_zero.2 $ Sup_of_not_bdd_above $ this
 

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -147,8 +147,8 @@ instance : no_top_order ℝ≥0 :=
 lemma bdd_above_coe {s : set ℝ≥0} : bdd_above ((coe : nnreal → ℝ) '' s) ↔ bdd_above s :=
 iff.intro
   (assume ⟨b, hb⟩, ⟨nnreal.of_real b, assume ⟨y, hy⟩ hys, show y ≤ max b 0, from
-    le_max_left_of_le $ hb _ $ set.mem_image_of_mem _ hys⟩)
-  (assume ⟨b, hb⟩, ⟨b, assume y ⟨x, hx, eq⟩, eq ▸ hb _ $ hx⟩)
+    le_max_left_of_le $ hb $ set.mem_image_of_mem _ hys⟩)
+  (assume ⟨b, hb⟩, ⟨b, assume y ⟨x, hx, eq⟩, eq ▸ hb hx⟩)
 
 lemma bdd_below_coe (s : set ℝ≥0) : bdd_below ((coe : nnreal → ℝ) '' s) :=
 ⟨0, assume r ⟨q, _, eq⟩, eq ▸ q.2⟩

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -180,10 +180,10 @@ instance : conditionally_complete_linear_order_bot ℝ≥0 :=
   Inf     := Inf,
   le_cSup := assume s a hs ha, le_cSup (bdd_above_coe.2 hs) (set.mem_image_of_mem _ ha),
   cSup_le := assume s a hs h,show Sup ((coe : nnreal → ℝ) '' s) ≤ a, from
-    cSup_le (by simp [hs]) $ assume r ⟨b, hb, eq⟩, eq ▸ h _ hb,
+    cSup_le (by simp [hs]) $ assume r ⟨b, hb, eq⟩, eq ▸ h hb,
   cInf_le := assume s a _ has, cInf_le (bdd_below_coe s) (set.mem_image_of_mem _ has),
   le_cInf := assume s a hs h, show (↑a : ℝ) ≤ Inf ((coe : nnreal → ℝ) '' s), from
-    le_cInf (by simp [hs]) $ assume r ⟨b, hb, eq⟩, eq ▸ h _ hb,
+    le_cInf (by simp [hs]) $ assume r ⟨b, hb, eq⟩, eq ▸ h hb,
   cSup_empty := nnreal.eq $ by simp [coe_Sup, real.Sup_empty]; refl,
   decidable_le := begin assume x y, apply classical.dec end,
   .. nnreal.linear_ordered_semiring, .. lattice.lattice_of_decidable_linear_order,

--- a/src/order/bounds.lean
+++ b/src/order/bounds.lean
@@ -16,9 +16,9 @@ section preorder
 variables [preorder α] [preorder β] {f : α → β}
 
 /-- The set of upper bounds of a set. -/
-def upper_bounds (s : set α) : set α := { x | ∀a ∈ s, a ≤ x }
+def upper_bounds (s : set α) : set α := { x | ∀ ⦃a⦄, a ∈ s →  a ≤ x }
 /-- The set of lower bounds of a set. -/
-def lower_bounds (s : set α) : set α := { x | ∀a ∈ s, x ≤ a }
+def lower_bounds (s : set α) : set α := { x | ∀ ⦃a⦄, a ∈ s → x ≤ a }
 /-- `a` is a least element of a set `s`; for a partial order, it is unique if exists. -/
 def is_least (s : set α) (a : α) : Prop := a ∈ s ∧ a ∈ lower_bounds s
 /-- `a` is a greatest element of a set `s`; for a partial order, it is unique if exists -/
@@ -29,18 +29,18 @@ def is_lub (s : set α) : α → Prop := is_least (upper_bounds s)
 def is_glb (s : set α) : α → Prop := is_greatest (lower_bounds s)
 
 lemma upper_bounds_mono (h₁ : a₁ ≤ a₂) (h₂ : a₁ ∈ upper_bounds s) : a₂ ∈ upper_bounds s :=
-λ a h, le_trans (h₂ _ h) h₁
+λ a h, le_trans (h₂ h) h₁
 
 lemma lower_bounds_mono (h₁ : a₂ ≤ a₁) (h₂ : a₁ ∈ lower_bounds s) : a₂ ∈ lower_bounds s :=
-λ a h, le_trans h₁ (h₂ _ h)
+λ a h, le_trans h₁ (h₂ h)
 
 lemma mem_upper_bounds_image (Hf : monotone f) (Ha : a ∈ upper_bounds s) :
   f a ∈ upper_bounds (f '' s) :=
-ball_image_of_ball (assume x H, Hf (Ha _ ‹x ∈ s›))
+ball_image_of_ball (assume x H, Hf (Ha ‹x ∈ s›))
 
 lemma mem_lower_bounds_image (Hf : monotone f) (Ha : a ∈ lower_bounds s) :
   f a ∈ lower_bounds (f '' s) :=
-ball_image_of_ball (assume x H, Hf (Ha _ ‹x ∈ s›))
+ball_image_of_ball (assume x H, Hf (Ha ‹x ∈ s›))
 
 lemma is_lub_singleton {a : α} : is_lub {a} a :=
 by simp [is_lub, is_least, upper_bounds, lower_bounds] {contextual := tt}
@@ -54,13 +54,13 @@ section partial_order
 variables [partial_order α]
 
 lemma eq_of_is_least_of_is_least (Ha : is_least s a₁) (Hb : is_least s a₂) : a₁ = a₂ :=
-le_antisymm (Ha.right _ Hb.left) (Hb.right _ Ha.left)
+le_antisymm (Ha.right Hb.left) (Hb.right Ha.left)
 
 lemma is_least_iff_eq_of_is_least (Ha : is_least s a₁) : is_least s a₂ ↔ a₁ = a₂ :=
 iff.intro (eq_of_is_least_of_is_least Ha) (assume h, h ▸ Ha)
 
 lemma eq_of_is_greatest_of_is_greatest (Ha : is_greatest s a₁) (Hb : is_greatest s a₂) : a₁ = a₂ :=
-le_antisymm (Hb.right _ Ha.left) (Ha.right _ Hb.left)
+le_antisymm (Hb.right Ha.left) (Ha.right Hb.left)
 
 lemma is_greatest_iff_eq_of_is_greatest (Ha : is_greatest s a₁) : is_greatest s a₂ ↔ a₁ = a₂ :=
 iff.intro (eq_of_is_greatest_of_is_greatest Ha) (assume h, h ▸ Ha)
@@ -72,10 +72,10 @@ lemma is_lub_iff_eq_of_is_lub : is_lub s a₁ → (is_lub s a₂ ↔ a₁ = a₂
 is_least_iff_eq_of_is_least
 
 lemma is_lub_le_iff (h : is_lub s a₁) : a₁ ≤ a₂ ↔ a₂ ∈ upper_bounds s :=
-⟨λ hl, upper_bounds_mono hl h.1, h.2 _⟩
+⟨λ hl, upper_bounds_mono hl h.1, λ hr, h.2 hr⟩
 
 lemma le_is_glb_iff (h : is_glb s a₁) : a₂ ≤ a₁ ↔ a₂ ∈ lower_bounds s :=
-⟨λ hl, lower_bounds_mono hl h.1, h.2 _⟩
+⟨λ hl, lower_bounds_mono hl h.1, λ hr, h.2 hr⟩
 
 lemma eq_of_is_glb_of_is_glb : is_glb s a₁ → is_glb s a₂ → a₁ = a₂ :=
 eq_of_is_greatest_of_is_greatest
@@ -86,13 +86,13 @@ is_greatest_iff_eq_of_is_greatest
 lemma ne_empty_of_is_lub [no_bot_order α] (hs : is_lub s a) : s ≠ ∅ :=
 let ⟨a', ha'⟩ := no_bot a in
 assume h,
-have a ≤ a', from hs.right _ (by simp [upper_bounds, h]),
+have a ≤ a', from hs.right (by simp [upper_bounds, h]),
 lt_irrefl a $ lt_of_le_of_lt this ha'
 
 lemma ne_empty_of_is_glb [no_top_order α] (hs : is_glb s a) : s ≠ ∅ :=
 let ⟨a', ha'⟩ := no_top a in
 assume h,
-have a' ≤ a, from hs.right _ (by simp [lower_bounds, h]),
+have a' ≤ a, from hs.right (by simp [lower_bounds, h]),
 lt_irrefl a $ lt_of_lt_of_le ha' this
 
 end partial_order
@@ -107,15 +107,15 @@ by simp [is_lub, is_least, lower_bounds, upper_bounds]
 
 lemma is_lub_union_sup [semilattice_sup α] (hs : is_lub s a₁) (ht : is_lub t a₂) :
   is_lub (s ∪ t) (a₁ ⊔ a₂) :=
-⟨assume c h, h.cases_on (le_sup_left_of_le ∘ hs.left c) (le_sup_right_of_le ∘ ht.left c),
+⟨assume c h, h.cases_on (λ h, le_sup_left_of_le $ hs.left h) (λ h, le_sup_right_of_le $ ht.left h),
   assume c hc, sup_le
-    (hs.right _ $ assume d hd, hc _ $ or.inl hd) (ht.right _ $ assume d hd, hc _ $ or.inr hd)⟩
+    (hs.right $ assume d hd, hc $ or.inl hd) (ht.right $ assume d hd, hc $ or.inr hd)⟩
 
 lemma is_glb_union_inf [semilattice_inf α] (hs : is_glb s a₁) (ht : is_glb t a₂) :
   is_glb (s ∪ t) (a₁ ⊓ a₂) :=
-⟨assume c h, h.cases_on (inf_le_left_of_le ∘ hs.left c) (inf_le_right_of_le ∘ ht.left c),
+⟨assume c h, h.cases_on (λ h, inf_le_left_of_le $ hs.left h) (λ h, inf_le_right_of_le $ ht.left h),
   assume c hc, le_inf
-    (hs.right _ $ assume d hd, hc _ $ or.inl hd) (ht.right _ $ assume d hd, hc _ $ or.inr hd)⟩
+    (hs.right $ assume d hd, hc $ or.inl hd) (ht.right $ assume d hd, hc $ or.inr hd)⟩
 
 lemma is_lub_insert_sup [semilattice_sup α] (h : is_lub s a₁) : is_lub (insert a₂ s) (a₂ ⊔ a₁) :=
 by rw [insert_eq]; exact is_lub_union_sup is_lub_singleton h

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -37,38 +37,38 @@ section preorder
 variables [preorder α] [preorder β] {s t : set α} {a b : α}
 
 /-- A set is bounded above if there exists an upper bound. -/
-def bdd_above (s : set α) := ∃x, ∀y∈s, y ≤ x
+def bdd_above (s : set α) := ∃x, x ∈ upper_bounds s
 
 /-- A set is bounded below if there exists a lower bound. -/
-def bdd_below (s : set α) := ∃x, ∀y∈s, x ≤ y
+def bdd_below (s : set α) := ∃x, x ∈ lower_bounds s
 
 /-Introduction rules for boundedness above and below.
 Most of the time, it is more efficient to use ⟨w, P⟩ where P is a proof
 that all elements of the set are bounded by w. However, they are sometimes handy.-/
-lemma bdd_above.mk (a : α) (H : ∀y∈s, y≤a) : bdd_above s := ⟨a, H⟩
-lemma bdd_below.mk (a : α) (H : ∀y∈s, a≤y) : bdd_below s := ⟨a, H⟩
+lemma bdd_above.mk (a : α) (H : a ∈ upper_bounds s) : bdd_above s := ⟨a, H⟩
+lemma bdd_below.mk (a : α) (H : a ∈ lower_bounds s) : bdd_below s := ⟨a, H⟩
 
 /-Empty sets and singletons are trivially bounded. For finite sets, we need
 a notion of maximum and minimum, i.e., a lattice structure, see later on.-/
 @[simp] lemma bdd_above_empty : ∀ [nonempty α], bdd_above (∅ : set α)
-| ⟨x⟩ := ⟨x, by simp⟩
+| ⟨x⟩ := ⟨x, by simp [upper_bounds]⟩
 
 @[simp] lemma bdd_below_empty : ∀ [nonempty α], bdd_below (∅ : set α)
-| ⟨x⟩ := ⟨x, by simp⟩
+| ⟨x⟩ := ⟨x, by simp [lower_bounds]⟩
 
 @[simp] lemma bdd_above_singleton : bdd_above ({a} : set α) :=
-⟨a, by simp only [set.mem_singleton_iff, forall_eq]⟩
+⟨a, by simp only [upper_bounds, set.mem_set_of_eq, set.mem_singleton_iff, forall_eq]⟩
 
 @[simp] lemma bdd_below_singleton : bdd_below ({a} : set α) :=
-⟨a, by simp only [set.mem_singleton_iff, forall_eq]⟩
+⟨a, by simp only [lower_bounds, set.mem_set_of_eq, set.mem_singleton_iff, forall_eq]⟩
 
 /-If a set is included in another one, boundedness of the second implies boundedness
 of the first-/
 lemma bdd_above_subset (st : s ⊆ t) : bdd_above t → bdd_above s
-| ⟨w, hw⟩ := ⟨w, λ y ys, hw _ (st ys)⟩
+| ⟨w, hw⟩ := ⟨w, λ y ys, hw (st ys)⟩
 
 lemma bdd_below_subset (st : s ⊆ t) : bdd_below t → bdd_below s
-| ⟨w, hw⟩ := ⟨w, λ y ys, hw _ (st ys)⟩
+| ⟨w, hw⟩ := ⟨w, λ y ys, hw (st ys)⟩
 
 /- Boundedness of intersections of sets, in different guises, deduced from the
 monotonicity of boundedness.-/
@@ -86,21 +86,21 @@ bdd_below_subset (set.inter_subset_right _ _)
 
 /--The image under a monotone function of a set which is bounded above is bounded above-/
 lemma bdd_above_of_bdd_above_of_monotone {f : α → β} (hf : monotone f) : bdd_above s → bdd_above (f '' s)
-| ⟨C, hC⟩ := ⟨f C, by rintro y ⟨x, x_bnd, rfl⟩; exact hf (hC x x_bnd)⟩
+| ⟨C, hC⟩ := ⟨f C, by rintro y ⟨x, x_bnd, rfl⟩; exact hf (hC x_bnd)⟩
 
 /--The image under a monotone function of a set which is bounded below is bounded below-/
 lemma bdd_below_of_bdd_below_of_monotone {f : α → β} (hf : monotone f) : bdd_below s → bdd_below (f '' s)
-| ⟨C, hC⟩ := ⟨f C, by rintro y ⟨x, x_bnd, rfl⟩; exact hf (hC x x_bnd)⟩
+| ⟨C, hC⟩ := ⟨f C, by rintro y ⟨x, x_bnd, rfl⟩; exact hf (hC x_bnd)⟩
 
 end preorder
 
 /--When there is a global maximum, every set is bounded above.-/
 @[simp] lemma bdd_above_top [order_top α] (s : set α) : bdd_above s :=
-⟨⊤, by intros; apply order_top.le_top⟩
+⟨⊤, assume a ha, order_top.le_top a⟩
 
 /--When there is a global minimum, every set is bounded below.-/
 @[simp] lemma bdd_below_bot [order_bot α] (s : set α) : bdd_below s :=
-⟨⊥, by intros; apply order_bot.bot_le⟩
+⟨⊥, assume a ha,  order_bot.bot_le a⟩
 
 /-When there is a max (i.e., in the class semilattice_sup), then the union of
 two bounded sets is bounded, by the maximum of the bounds for the two sets.
@@ -121,9 +121,9 @@ show (bdd_above s ∧ bdd_above t) → bdd_above (s ∪ t), from
   let ⟨⟨ws, hs⟩, ⟨wt, ht⟩⟩ := H in
     /-hs : ∀ (y : α), y ∈ s → y ≤ ws      ht : ∀ (y : α), y ∈ s → y ≤ wt-/
   have Bs : ∀b∈s, b ≤ ws ⊔ wt,
-    by intros; apply le_trans (hs b ‹b ∈ s›) _; simp only [lattice.le_sup_left],
+    by intros; apply le_trans (hs ‹b ∈ s›) _; simp only [lattice.le_sup_left],
   have Bt : ∀b∈t, b ≤ ws ⊔ wt,
-    by intros; apply le_trans (ht b ‹b ∈ t›) _; simp only [lattice.le_sup_right],
+    by intros; apply le_trans (ht ‹b ∈ t›) _; simp only [lattice.le_sup_right],
   show bdd_above (s ∪ t),
     begin
     apply bdd_above.mk (ws ⊔ wt),
@@ -178,9 +178,9 @@ show (bdd_below s ∧ bdd_below t) → bdd_below (s ∪ t), from
   let ⟨⟨ws, hs⟩, ⟨wt, ht⟩⟩ := H in
     /-hs : ∀ (y : α), y ∈ s → ws ≤ y      ht : ∀ (y : α), y ∈ s → wt ≤ y-/
   have Bs : ∀b∈s, ws ⊓ wt ≤ b,
-    by intros; apply le_trans _ (hs b ‹b ∈ s›); simp only [lattice.inf_le_left],
+    by intros; apply le_trans _ (hs ‹b ∈ s›); simp only [lattice.inf_le_left],
   have Bt : ∀b∈t, ws ⊓ wt ≤ b,
-    by intros; apply le_trans _ (ht b ‹b ∈ t›); simp only [lattice.inf_le_right],
+    by intros; apply le_trans _ (ht ‹b ∈ t›); simp only [lattice.inf_le_right],
   show bdd_below (s ∪ t),
     begin
     apply bdd_below.mk (ws ⊓ wt),
@@ -295,13 +295,13 @@ lemma cSup_lower_bounds_eq_cInf {s : set α} (h : bdd_below s) (hs : s ≠ ∅) 
 let ⟨b, hb⟩ := h, ⟨a, ha⟩ := ne_empty_iff_exists_mem.1 hs in
 le_antisymm
   (cSup_le (ne_empty_iff_exists_mem.2 ⟨b, hb⟩) $ assume a ha, le_cInf hs ha)
-  (le_cSup ⟨a, assume y hy, hy a ha⟩ $ assume x hx, cInf_le h hx)
+  (le_cSup ⟨a, assume y hy, hy ha⟩ $ assume x hx, cInf_le h hx)
 
 lemma cInf_upper_bounds_eq_cSup {s : set α} (h : bdd_above s) (hs : s ≠ ∅) :
   Inf (upper_bounds s) = Sup s :=
 let ⟨b, hb⟩ := h, ⟨a, ha⟩ := ne_empty_iff_exists_mem.1 hs in
 le_antisymm
-  (cInf_le ⟨a, assume y hy, hy a ha⟩ $ assume x hx, le_cSup h hx)
+  (cInf_le ⟨a, assume y hy, hy ha⟩ $ assume x hx, le_cSup h hx)
   (le_cInf (ne_empty_iff_exists_mem.2 ⟨b, hb⟩) $ assume a ha, cSup_le hs ha)
 
 /--Introduction rule to prove that b is the supremum of s: it suffices to check that b
@@ -648,15 +648,15 @@ begin
   rcases ne_empty_iff_exists_mem.1 hs with ⟨x, hxs⟩,
   by_cases bnd : ∃b:α, ↑b ∈ upper_bounds s,
   { rcases bnd with ⟨b, hb⟩,
-    have bdd : bdd_above {a : α | ↑a ∈ s}, from ⟨b, assume y hy, coe_le_coe.1 $ hb _ hy⟩,
+    have bdd : bdd_above {a : α | ↑a ∈ s}, from ⟨b, assume y hy, coe_le_coe.1 $ hb hy⟩,
     refine ⟨(Sup {a : α | ↑a ∈ s} : α), _, _⟩,
     { assume a has,
-      rcases (le_coe_iff _ _).1 (hb _ has) with ⟨a, rfl, h⟩,
+      rcases (le_coe_iff _ _).1 (hb has) with ⟨a, rfl, h⟩,
       exact (coe_le_coe.2 $ le_cSup bdd has) },
     { assume a hs,
-      rcases (le_coe_iff _ _).1 (hb _ hxs) with ⟨x, rfl, h⟩,
+      rcases (le_coe_iff _ _).1 (hb hxs) with ⟨x, rfl, h⟩,
       refine (coe_le_iff _ _).2 (assume c hc, _), subst hc,
-      exact (cSup_le (ne_empty_of_mem hxs) $ assume b (hbs : ↑b ∈ s), coe_le_coe.1 $ hs _ hbs), } },
+      exact (cSup_le (ne_empty_of_mem hxs) $ assume b (hbs : ↑b ∈ s), coe_le_coe.1 $ hs hbs), } },
   exact ⟨⊤, assume a _, le_top, assume a,
     match a with
     | some a, ha := (bnd ⟨a, ha⟩).elim
@@ -672,9 +672,9 @@ begin
     exact (assume a has, (coe_le_iff _ _).2 $ assume x hx, cInf_le (bdd_below_bot _) $
       show ↑x ∈ s, from hx ▸ has),
     { assume a has,
-      rcases (le_coe_iff _ _).1 (has _ hxs) with ⟨x, rfl, h⟩,
+      rcases (le_coe_iff _ _).1 (has hxs) with ⟨x, rfl, h⟩,
       exact (coe_le_coe.2 $ le_cInf (ne_empty_of_mem hxs) $
-        assume b hbs, coe_le_coe.1 $ has _ hbs) } },
+        assume b hbs, coe_le_coe.1 $ has hbs) } },
   exact ⟨⊤, assume a, match a with
     | some a, ha := (hs ⟨a, ha⟩).elim
     | none,   ha := _root_.le_refl _

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -227,9 +227,9 @@ hold in both worlds, sometimes with additional assumptions of non-emptyness or
 boundedness.-/
 class conditionally_complete_lattice (α : Type u) extends lattice α, has_Sup α, has_Inf α :=
 (le_cSup : ∀s a, bdd_above s → a ∈ s → a ≤ Sup s)
-(cSup_le : ∀s a, s ≠ ∅ → (∀b∈s, b ≤ a) → Sup s ≤ a)
+(cSup_le : ∀s a, s ≠ ∅ → a ∈ upper_bounds s → Sup s ≤ a)
 (cInf_le : ∀s a, bdd_below s → a ∈ s → Inf s ≤ a)
-(le_cInf : ∀s a, s ≠ ∅ → (∀b∈s, a ≤ b) → a ≤ Inf s)
+(le_cInf : ∀s a, s ≠ ∅ → a ∈ lower_bounds s → a ≤ Inf s)
 
 class conditionally_complete_linear_order (α : Type u)
   extends conditionally_complete_lattice α, decidable_linear_order α
@@ -621,7 +621,7 @@ noncomputable instance : conditionally_complete_linear_order_bot ℕ :=
   le_cSup    := assume s a hb ha, by rw [Sup_nat_def hb]; revert a ha; exact @nat.find_spec _ _ hb,
   cSup_le    := assume s a hs ha, by rw [Sup_nat_def ⟨a, ha⟩]; exact nat.find_min' _ ha,
   le_cInf    := assume s a hs hb,
-    by rw [Inf_nat_def (ne_empty_iff_exists_mem.1 hs)]; exact hb _ (@nat.find_spec (λn, n ∈ s) _ _),
+    by rw [Inf_nat_def (ne_empty_iff_exists_mem.1 hs)]; exact hb (@nat.find_spec (λn, n ∈ s) _ _),
   cInf_le    := assume s a hb ha, by rw [Inf_nat_def ⟨a, ha⟩]; exact nat.find_min' _ ha,
   cSup_empty :=
   begin

--- a/src/order/galois_connection.lean
+++ b/src/order/galois_connection.lean
@@ -51,24 +51,24 @@ lemma monotone_l : monotone l :=
 assume a b H, gc.l_le (le_trans H (gc.le_u_l b))
 
 lemma upper_bounds_l_image_subset {s : set α} : upper_bounds (l '' s) ⊆ u ⁻¹' upper_bounds s :=
-assume b hb c, assume : c ∈ s, gc.le_u (hb _ (mem_image_of_mem _ ‹c ∈ s›))
+assume b hb c, assume : c ∈ s, gc.le_u (hb (mem_image_of_mem _ ‹c ∈ s›))
 
 lemma lower_bounds_u_image_subset {s : set β} : lower_bounds (u '' s) ⊆ l ⁻¹' lower_bounds s :=
-assume a ha c, assume : c ∈ s, gc.l_le (ha _ (mem_image_of_mem _ ‹c ∈ s›))
+assume a ha c, assume : c ∈ s, gc.l_le (ha (mem_image_of_mem _ ‹c ∈ s›))
 
 lemma is_lub_l_image {s : set α} {a : α} (h : is_lub s a) : is_lub (l '' s) (l a) :=
 ⟨mem_upper_bounds_image gc.monotone_l $ and.elim_left ‹is_lub s a›,
-  assume b hb, gc.l_le $ and.elim_right ‹is_lub s a› _ $ gc.upper_bounds_l_image_subset hb⟩
+  assume b hb, gc.l_le $ and.elim_right ‹is_lub s a› $ gc.upper_bounds_l_image_subset hb⟩
 
 lemma is_glb_u_image {s : set β} {b : β} (h : is_glb s b) : is_glb (u '' s) (u b) :=
 ⟨mem_lower_bounds_image gc.monotone_u $ and.elim_left ‹is_glb s b›,
-  assume a ha, gc.le_u $ and.elim_right ‹is_glb s b› _ $ gc.lower_bounds_u_image_subset ha⟩
+  assume a ha, gc.le_u $ and.elim_right ‹is_glb s b› $ gc.lower_bounds_u_image_subset ha⟩
 
 lemma is_glb_l {a : α} : is_glb { b | a ≤ u b } (l a) :=
-⟨assume b, gc.l_le, assume b h, h _ $ gc.le_u_l _⟩
+⟨assume b, gc.l_le, assume b h, h $ gc.le_u_l _⟩
 
 lemma is_lub_u {b : β} : is_lub { a | l a ≤ b } (u b) :=
-⟨assume b, gc.le_u, assume b h, h _ $ gc.l_u_le _⟩
+⟨assume b, gc.le_u, assume b h, h $ gc.l_u_le _⟩
 
 end
 

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -489,15 +489,15 @@ forall_sets_neq_empty_iff_neq_bot.mp $ assume t ht,
       have a ∈ t₂, from ht₂ $ by rwa [h],
       ne_empty_iff_exists_mem.mpr ⟨a, ht ⟨‹a ∈ t₁›, ‹a ∈ t₂›⟩⟩)
     (assume : a ≠ a',
-      have a' < a, from lt_of_le_of_ne (ha.left _ ‹a' ∈ s›) this.symm,
+      have a' < a, from lt_of_le_of_ne (ha.left ‹a' ∈ s›) this.symm,
       let ⟨l, hl, hlt₁⟩ := hl ⟨a', this⟩ in
       have ∃a'∈s, l < a',
         from classical.by_contradiction $ assume : ¬ ∃a'∈s, l < a',
           have ∀a'∈s, a' ≤ l, from assume a ha, not_lt.1 $ assume ha', this ⟨a, ha, ha'⟩,
-          have ¬ l < a, from not_lt.2 $ ha.right _ this,
+          have ¬ l < a, from not_lt.2 $ ha.right this,
           this ‹l < a›,
       let ⟨a', ha', ha'l⟩ := this in
-      have a' ∈ t₁, from hlt₁ _ ‹l < a'›  $ ha.left _ ha',
+      have a' ∈ t₁, from hlt₁ _ ‹l < a'›  $ ha.left ha',
       ne_empty_iff_exists_mem.mpr ⟨a', ht ⟨‹a' ∈ t₁›, ht₂ ‹a' ∈ s›⟩⟩)
 
 lemma nhds_principal_ne_bot_of_is_glb : ∀ {a : α} {s : set α}, is_glb s a → s ≠ ∅ →
@@ -511,7 +511,7 @@ lemma is_lub_of_mem_nhds {s : set α} {a : α} {f : filter α}
   have s ∩ {a | b < a} ∈ f ⊓ 𝓝 a,
     from inter_mem_inf_sets hsf (mem_nhds_sets (is_open_lt' _) hba),
   let ⟨x, ⟨hxs, hxb⟩⟩ := inhabited_of_mem_sets hfa this in
-  have b < b, from lt_of_lt_of_le hxb $ hb _ hxs,
+  have b < b, from lt_of_lt_of_le hxb $ hb hxs,
   lt_irrefl b this⟩
 
 lemma is_glb_of_mem_nhds : ∀ {s : set α} {a : α} {f : filter α},
@@ -532,7 +532,7 @@ have ∀a'∈s, ¬ b < f a',
       have f a < f a', from hs this,
       lt_irrefl (f a') $ by rwa [h] at this)
     (assume h : a ≠ a',
-      have a' < a, from lt_of_le_of_ne (ha.left _ ha') h.symm,
+      have a' < a, from lt_of_le_of_ne (ha.left ha') h.symm,
       have {x | a' < x} ∈ 𝓝 a, from mem_nhds_sets (is_open_lt' _) this,
       have {x | a' < x} ∩ t₁ ∈ 𝓝 a, from inter_mem_sets this ht₁,
       have ({x | a' < x} ∩ t₁) ∩ s ∈ 𝓝 a ⊓ principal s,
@@ -544,7 +544,7 @@ have ∀a'∈s, ¬ b < f a',
 and.intro
   (assume b' ⟨a', ha', h_eq⟩, h_eq ▸ not_lt.1 $ this _ ha')
   (assume b' hb', le_of_tendsto hnbot hb $
-      mem_inf_sets_of_right $ assume x hx, hb' _ $ mem_image_of_mem _ hx)
+      mem_inf_sets_of_right $ assume x hx, hb' $ mem_image_of_mem _ hx)
 
 lemma is_glb_of_is_glb_of_tendsto {f : α → β} {s : set α} {a : α} {b : β}
   (hf : ∀x∈s, ∀y∈s, x ≤ y → f x ≤ f y) : is_glb s a → s ≠ ∅ →
@@ -584,7 +584,7 @@ begin
     (λ x _, is_open_lt continuous_const continuous_id) _ with ⟨t, st, ft, ht⟩,
   { refine H ((bdd_below_finite ft).imp $ λ C hC y hy, _),
     rcases mem_bUnion_iff.1 (ht hy) with ⟨x, hx, xy⟩,
-    exact le_trans (hC _ hx) (le_of_lt xy) },
+    exact le_trans (hC hx) (le_of_lt xy) },
   { refine λ x hx, mem_bUnion_iff.2 (not_imp_comm.1 _ H),
     exact λ h, ⟨x, λ y hy, le_of_not_lt (h.imp $ λ ys, ⟨_, hy, ys⟩)⟩ }
 end

--- a/src/topology/instances/real.lean
+++ b/src/topology/instances/real.lean
@@ -405,7 +405,7 @@ lemma real.bounded_iff_bdd_below_bdd_above {s : set ℝ} : bounded s ↔ bdd_bel
 end,
 begin
   rintros ⟨⟨m, hm⟩, ⟨M, hM⟩⟩,
-  have I : s ⊆ Icc m M := λx hx, ⟨hm x hx, hM x hx⟩,
+  have I : s ⊆ Icc m M := λx hx, ⟨hm hx, hM hx⟩,
   have : Icc m M = closed_ball ((m+M)/2) ((M-m)/2) :=
     by rw closed_ball_Icc; congr; ring,
   rw this at I,

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -227,7 +227,8 @@ begin
   have Bβ : ⟦B⟧ = to_GH_space β,
   { rw eq_to_GH_space_iff,
     exact ⟨λx, F (Ψ' x), ⟨(Kuratowski_embedding.isometry _).comp IΨ', by rw range_comp⟩⟩ },
-  refine cInf_le ⟨0, begin simp, assume t _ _ _ _ ht, rw ← ht, exact Hausdorff_dist_nonneg end⟩ _,
+  refine cInf_le ⟨0,
+    begin simp [lower_bounds], assume t _ _ _ _ ht, rw ← ht, exact Hausdorff_dist_nonneg end⟩ _,
   apply (mem_image _ _ _).2,
   existsi (⟨A, B⟩ : nonempty_compacts ℓ_infty_ℝ × nonempty_compacts ℓ_infty_ℝ),
   simp [Aα, Bβ]

--- a/src/topology/metric_space/gromov_hausdorff_realized.lean
+++ b/src/topology/metric_space/gromov_hausdorff_realized.lean
@@ -261,7 +261,7 @@ technical lemmas -/
 
 lemma HD_below_aux1 {f : Cb α β} (C : ℝ) {x : α} : bdd_below (range (λ (y : β), f (inl x, inr y) + C)) :=
 let ⟨cf, hcf⟩ := (real.bounded_iff_bdd_below_bdd_above.1 bounded_range).1 in
-⟨cf + C, forall_range_iff.2 (λi, add_le_add_right ((λx, hcf (f x) (mem_range_self _)) _) _)⟩
+⟨cf + C, forall_range_iff.2 (λi, add_le_add_right ((λx, hcf (mem_range_self x)) _) _)⟩
 
 private lemma HD_bound_aux1 (f : Cb α β) (C : ℝ) : bdd_above (range (λ (x : α), infi (λy:β, f (inl x, inr y) + C))) :=
 begin
@@ -269,12 +269,12 @@ begin
   refine ⟨Cf + C, forall_range_iff.2 (λx, _)⟩,
   calc infi (λy:β, f (inl x, inr y) + C) ≤ f (inl x, inr (default β)) + C :
     cinfi_le (HD_below_aux1 C)
-    ... ≤ Cf + C : add_le_add ((λx, hCf (f x) (mem_range_self _)) _) (le_refl _)
+    ... ≤ Cf + C : add_le_add ((λx, hCf (mem_range_self x)) _) (le_refl _)
 end
 
 lemma HD_below_aux2 {f : Cb α β} (C : ℝ) {y : β} : bdd_below (range (λ (x : α), f (inl x, inr y) + C)) :=
 let ⟨cf, hcf⟩ := (real.bounded_iff_bdd_below_bdd_above.1 bounded_range).1 in
-⟨cf + C, forall_range_iff.2 (λi, add_le_add_right ((λx, hcf (f x) (mem_range_self _)) _) _)⟩
+⟨cf + C, forall_range_iff.2 (λi, add_le_add_right ((λx, hcf (mem_range_self x)) _) _)⟩
 
 private lemma HD_bound_aux2 (f : Cb α β) (C : ℝ) : bdd_above (range (λ (y : β), infi (λx:α, f (inl x, inr y) + C))) :=
 begin
@@ -282,7 +282,7 @@ begin
   refine ⟨Cf + C, forall_range_iff.2 (λy, _)⟩,
   calc infi (λx:α, f (inl x, inr y) + C) ≤ f (inl (default α), inr y) + C :
     cinfi_le (HD_below_aux2 C)
-  ... ≤ Cf + C : add_le_add ((λx, hCf (f x) (mem_range_self _)) _) (le_refl _)
+  ... ≤ Cf + C : add_le_add ((λx, hCf (mem_range_self x)) _) (le_refl _)
 end
 
 /-- Explicit bound on HD (dist). This means that when looking for minimizers it will
@@ -320,9 +320,9 @@ private lemma HD_lipschitz_aux1 (f g : Cb α β) :
   supr (λx:α, infi (λy:β, f (inl x, inr y))) ≤ supr (λx:α, infi (λy:β, g (inl x, inr y))) + dist f g :=
 begin
   rcases (real.bounded_iff_bdd_below_bdd_above.1 bounded_range).1 with ⟨cg, hcg⟩,
-  have Hcg : ∀x, cg ≤ g x := λx, hcg (g x) (mem_range_self _),
+  have Hcg : ∀x, cg ≤ g x := λx, hcg (mem_range_self x),
   rcases (real.bounded_iff_bdd_below_bdd_above.1 bounded_range).1 with ⟨cf, hcf⟩,
-  have Hcf : ∀x, cf ≤ f x := λx, hcf (f x) (mem_range_self _),
+  have Hcf : ∀x, cf ≤ f x := λx, hcf (mem_range_self x),
 
   -- prove the inequality but with `dist f g` inside, by using inequalities comparing
   -- supr to supr and infi to infi
@@ -354,9 +354,9 @@ private lemma HD_lipschitz_aux2 (f g : Cb α β) :
   supr (λy:β, infi (λx:α, f (inl x, inr y))) ≤ supr (λy:β, infi (λx:α, g (inl x, inr y))) + dist f g :=
 begin
   rcases (real.bounded_iff_bdd_below_bdd_above.1 bounded_range).1 with ⟨cg, hcg⟩,
-  have Hcg : ∀x, cg ≤ g x := λx, hcg (g x) (mem_range_self _),
+  have Hcg : ∀x, cg ≤ g x := λx, hcg (mem_range_self x),
   rcases (real.bounded_iff_bdd_below_bdd_above.1 bounded_range).1 with ⟨cf, hcf⟩,
-  have Hcf : ∀x, cf ≤ f x := λx, hcf (f x) (mem_range_self _),
+  have Hcf : ∀x, cf ≤ f x := λx, hcf (mem_range_self x),
 
   -- prove the inequality but with `dist f g` inside, by using inequalities comparing
   -- supr to supr and infi to infi


### PR DESCRIPTION
Also use `∈ *_bounds` in the definition of `conditionally_complete_lattice`

It seems to me that it better agrees with the implicit/explicit argument policy in mathlib.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
