### PR TITLE
chore(algebra/order_functions): rename `min/max_distrib_of_monotone` 

### DIFF
--- a/src/algebra/order_functions.lean
+++ b/src/algebra/order_functions.lean
@@ -130,10 +130,10 @@ left_comm max max_comm max_assoc a b c
 theorem max.right_comm (a b c : α) : max (max a b) c = max (max a c) b :=
 right_comm max max_comm max_assoc a b c
 
-lemma max_distrib_of_monotone (hf : monotone f) : f (max a b) = max (f a) (f b) :=
+lemma monotone.map_max (hf : monotone f) : f (max a b) = max (f a) (f b) :=
 by cases le_total a b; simp [h, hf h]
 
-lemma min_distrib_of_monotone (hf : monotone f) : f (min a b) = min (f a) (f b) :=
+lemma monotone.map_min (hf : monotone f) : f (min a b) = min (f a) (f b) :=
 by cases le_total a b; simp [h, hf h]
 
 theorem min_choice (a b : α) : min a b = a ∨ min a b = b :=
@@ -260,10 +260,10 @@ lemma monotone_mul_of_nonneg (ha : 0 ≤ a) : monotone (λ x, a*x) :=
 assume b c b_le_c, mul_le_mul_of_nonneg_left b_le_c ha
 
 lemma mul_max_of_nonneg (b c : α) (ha : 0 ≤ a) : a * max b c = max (a * b) (a * c) :=
-max_distrib_of_monotone (monotone_mul_of_nonneg ha)
+(monotone_mul_of_nonneg ha).map_max
 
 lemma mul_min_of_nonneg (b c : α) (ha : 0 ≤ a) : a * min b c = min (a * b) (a * c) :=
-min_distrib_of_monotone (monotone_mul_of_nonneg ha)
+(monotone_mul_of_nonneg ha).map_min
 
 end decidable_linear_ordered_semiring
 

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -771,7 +771,7 @@ instance prod.metric_space_max [metric_space β] : metric_space (α × β) :=
   edist := λ x y, max (edist x.1 y.1) (edist x.2 y.2),
   edist_dist := assume x y, begin
     have : monotone ennreal.of_real := assume x y h, ennreal.of_real_le_of_real h,
-    rw [edist_dist, edist_dist, (max_distrib_of_monotone this).symm]
+    rw [edist_dist, edist_dist, this.map_max.symm]
   end,
   uniformity_dist := begin
     refine uniformity_prod.trans _,


### PR DESCRIPTION
These names better align with `monoid_hom.map_mul` etc.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
