### PR TITLE
chore(data/set/basic) make set_of_eq_eq_singleton a simp lemma

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -464,6 +464,7 @@ theorem singleton_def (a : α) : ({a} : set α) = insert a ∅ := rfl
 @[simp] theorem mem_singleton_iff {a b : α} : a ∈ ({b} : set α) ↔ a = b :=
 by finish [singleton_def]
 
+@[simp]
 lemma set_of_eq_eq_singleton {a : α} : {n | n = a} = {a} := set.ext $ λ n, (set.mem_singleton_iff).symm
 
 -- TODO: again, annotation needed


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion. <https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/simp.20lemmas/near/174204832>

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
