### PR TITLE
fix(tactic/ext): handle case where goal is solved early

### DIFF
--- a/src/tactic/ext.lean
+++ b/src/tactic/ext.lean
@@ -89,7 +89,7 @@ do e ← get_env,
             solve1 $ do
             { h ← intro1, hs ← injection h, subst_vars,
               repeat (refine ``( and.intro _ _ ) >> reflexivity ),
-              reflexivity },
+              done <|> reflexivity },
             solve1 $ do
             { repeat (do refine ``(and_imp.mpr _),
                          h ← intro1, cases h, skip ),

--- a/test/ext.lean
+++ b/test/ext.lean
@@ -171,3 +171,5 @@ begin
   refl,
   refl,
 end
+
+@[ext] structure dumb (V : Type) := (val : V)


### PR DESCRIPTION
```lean
import tactic.ext

@[ext] structure dumb (V : Type) := (val : V)
```

The generation of `ext_iff` failed because there were no goals left on this line.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
