### PR TITLE
fix(*): lower instance priority

### DIFF
--- a/src/algebra/category/CommRing/basic.lean
+++ b/src/algebra/category/CommRing/basic.lean
@@ -39,14 +39,14 @@ def of (R : Type u) [semiring R] : SemiRing := bundled.of R
 
 local attribute [reducible] SemiRing
 
-instance : has_coe_to_sort SemiRing := infer_instance
+instance : has_coe_to_sort SemiRing := infer_instance -- short-circuit type class inference
 
 instance (R : SemiRing) : semiring R := R.str
 
 instance bundled_hom : bundled_hom @ring_hom :=
 ⟨@ring_hom.to_fun, @ring_hom.id, @ring_hom.comp, @ring_hom.coe_inj⟩
 
-instance : concrete_category SemiRing := infer_instance
+instance : concrete_category SemiRing := infer_instance -- short-circuit type class inference
 
 instance has_forget_to_Mon : has_forget₂ SemiRing Mon :=
 bundled_hom.mk_has_forget₂ @semiring.to_monoid (λ R₁ R₂, ring_hom.to_monoid_hom) (λ _ _ _, rfl)
@@ -68,13 +68,13 @@ def of (R : Type u) [ring R] : Ring := bundled.of R
 
 local attribute [reducible] Ring
 
-instance : has_coe_to_sort Ring := infer_instance
+instance : has_coe_to_sort Ring := infer_instance -- short-circuit type class inference
 
 instance (R : Ring) : ring R := R.str
 
-instance : concrete_category Ring := infer_instance
+instance : concrete_category Ring := infer_instance -- short-circuit type class inference
 
-instance has_forget_to_SemiRing : has_forget₂ Ring SemiRing := infer_instance
+instance has_forget_to_SemiRing : has_forget₂ Ring SemiRing := infer_instance  -- short-circuit type class inference
 instance has_forget_to_AddCommGroup : has_forget₂ Ring AddCommGroup :=
 -- can't use bundled_hom.mk_has_forget₂, since AddCommGroup is an induced category
 { forget₂ :=
@@ -93,13 +93,13 @@ def of (R : Type u) [comm_semiring R] : CommSemiRing := bundled.of R
 
 local attribute [reducible] CommSemiRing
 
-instance : has_coe_to_sort CommSemiRing := infer_instance
+instance : has_coe_to_sort CommSemiRing := infer_instance -- short-circuit type class inference
 
 instance (R : CommSemiRing) : comm_semiring R := R.str
 
-instance : concrete_category CommSemiRing := infer_instance
+instance : concrete_category CommSemiRing := infer_instance -- short-circuit type class inference
 
-instance has_forget_to_SemiRing : has_forget₂ CommSemiRing SemiRing := infer_instance
+instance has_forget_to_SemiRing : has_forget₂ CommSemiRing SemiRing := infer_instance -- short-circuit type class inference
 
 /-- The forgetful functor from commutative rings to (multiplicative) commutative monoids. -/
 instance has_forget_to_CommMon : has_forget₂ CommSemiRing CommMon :=
@@ -119,13 +119,13 @@ def of (R : Type u) [comm_ring R] : CommRing := bundled.of R
 
 local attribute [reducible] CommRing
 
-instance : has_coe_to_sort CommRing := infer_instance
+instance : has_coe_to_sort CommRing := infer_instance -- short-circuit type class inference
 
 instance (R : CommRing) : comm_ring R := R.str
 
-instance : concrete_category CommRing := infer_instance
+instance : concrete_category CommRing := infer_instance -- short-circuit type class inference
 
-instance has_forget_to_Ring : has_forget₂ CommRing Ring := infer_instance
+instance has_forget_to_Ring : has_forget₂ CommRing Ring := infer_instance -- short-circuit type class inference
 
 /-- The forgetful functor from commutative rings to (multiplicative) commutative monoids. -/
 instance has_forget_to_CommSemiRing : has_forget₂ CommRing CommSemiRing :=

--- a/src/algebra/category/Group.lean
+++ b/src/algebra/category/Group.lean
@@ -39,7 +39,7 @@ namespace Group
 local attribute [reducible] Group
 
 @[to_additive]
-instance : has_coe_to_sort Group := infer_instance
+instance : has_coe_to_sort Group := infer_instance -- short-circuit type class inference
 
 @[to_additive add_group]
 instance (G : Group) : group G := G.str
@@ -48,10 +48,10 @@ instance (G : Group) : group G := G.str
 instance : has_one Group := ⟨Group.of punit⟩
 
 @[to_additive]
-instance : concrete_category Group := infer_instance
+instance : concrete_category Group := infer_instance -- short-circuit type class inference
 
 @[to_additive has_forget_to_AddMon]
-instance has_forget_to_Mon : has_forget₂ Group Mon := infer_instance
+instance has_forget_to_Mon : has_forget₂ Group Mon := infer_instance -- short-circuit type class inference
 
 end Group
 
@@ -68,17 +68,17 @@ namespace CommGroup
 local attribute [reducible] CommGroup
 
 @[to_additive]
-instance : has_coe_to_sort CommGroup := infer_instance
+instance : has_coe_to_sort CommGroup := infer_instance -- short-circuit type class inference
 
 @[to_additive add_comm_group]
 instance (G : CommGroup) : comm_group G := G.str
 
 @[to_additive] instance : has_one CommGroup := ⟨CommGroup.of punit⟩
 
-@[to_additive] instance : concrete_category CommGroup := infer_instance
+@[to_additive] instance : concrete_category CommGroup := infer_instance -- short-circuit type class inference
 
 @[to_additive has_forget_to_AddGroup]
-instance has_forget_to_Group : has_forget₂ CommGroup Group := infer_instance
+instance has_forget_to_Group : has_forget₂ CommGroup Group := infer_instance -- short-circuit type class inference
 
 @[to_additive has_forget_to_AddCommMon]
 instance has_forget_to_CommMon : has_forget₂ CommGroup CommMon :=

--- a/src/algebra/category/Mon/basic.lean
+++ b/src/algebra/category/Mon/basic.lean
@@ -58,7 +58,7 @@ def of (M : Type u) [monoid M] : Mon := bundled.of M
 local attribute [reducible] Mon
 
 @[to_additive]
-instance : has_coe_to_sort Mon := infer_instance
+instance : has_coe_to_sort Mon := infer_instance -- short-circuit type class inference
 
 @[to_additive add_monoid]
 instance (M : Mon) : monoid M := M.str
@@ -68,7 +68,7 @@ instance bundled_hom : bundled_hom @monoid_hom :=
 ⟨@monoid_hom.to_fun, @monoid_hom.id, @monoid_hom.comp, @monoid_hom.coe_inj⟩
 
 @[to_additive]
-instance : concrete_category Mon := infer_instance
+instance : concrete_category Mon := infer_instance -- short-circuit type class inference
 
 end Mon
 
@@ -85,16 +85,16 @@ def of (M : Type u) [comm_monoid M] : CommMon := bundled.of M
 local attribute [reducible] CommMon
 
 @[to_additive]
-instance : has_coe_to_sort CommMon := infer_instance
+instance : has_coe_to_sort CommMon := infer_instance -- short-circuit type class inference
 
 @[to_additive add_comm_monoid]
 instance (M : CommMon) : comm_monoid M := M.str
 
 @[to_additive]
-instance : concrete_category CommMon := infer_instance
+instance : concrete_category CommMon := infer_instance -- short-circuit type class inference
 
 @[to_additive has_forget_to_AddMon]
-instance has_forget_to_Mon : has_forget₂ CommMon Mon := infer_instance
+instance has_forget_to_Mon : has_forget₂ CommMon Mon := infer_instance -- short-circuit type class inference
 
 end CommMon
 

--- a/src/algebra/char_zero.lean
+++ b/src/algebra/char_zero.lean
@@ -34,6 +34,7 @@ theorem ordered_cancel_comm_monoid.char_zero_of_inj_zero {α : Type*}
   (H : ∀ n:ℕ, (n:α) = 0 → n = 0) : char_zero α :=
 char_zero_of_inj_zero (@add_left_cancel _ _) H
 
+@[priority 100] -- see Note [lower instance priority]
 instance linear_ordered_semiring.to_char_zero {α : Type*}
   [linear_ordered_semiring α] : char_zero α :=
 ordered_cancel_comm_monoid.char_zero_of_inj_zero $

--- a/src/algebra/euclidean_domain.lean
+++ b/src/algebra/euclidean_domain.lean
@@ -10,6 +10,8 @@ import data.int.basic
 
 universe u
 
+set_option default_priority 100 -- see Note [default priority]
+
 class euclidean_domain (α : Type u) extends nonzero_comm_ring α :=
 (quotient : α → α → α)
 (quotient_zero : ∀ a, quotient a 0 = 0)
@@ -35,8 +37,10 @@ variables [euclidean_domain α]
 
 local infix ` ≺ `:50 := euclidean_domain.r
 
+@[priority 100] -- see Note [lower instance priority]
 instance : has_div α := ⟨quotient⟩
 
+@[priority 100] -- see Note [lower instance priority]
 instance : has_mod α := ⟨remainder⟩
 
 theorem div_add_mod (a b : α) : b * (a / b) + a % b = a :=
@@ -235,6 +239,7 @@ by have := @xgcd_aux_P _ _ _ a b a b 1 0 0 1
   (by rw [P, mul_one, mul_zero, add_zero]) (by rw [P, mul_one, mul_zero, zero_add]);
 rwa [xgcd_aux_val, xgcd_val] at this
 
+@[priority 100] -- see Note [lower instance priority]
 instance (α : Type*) [e : euclidean_domain α] : integral_domain α :=
 by haveI := classical.dec_eq α; exact
 { eq_zero_or_eq_zero_of_mul_eq_zero :=
@@ -331,6 +336,7 @@ instance int.euclidean_domain : euclidean_domain ℤ :=
     by rw [← mul_one a.nat_abs, int.nat_abs_mul];
     exact mul_le_mul_of_nonneg_left (int.nat_abs_pos_of_ne_zero b0) (nat.zero_le _) }
 
+@[priority 100] -- see Note [lower instance priority]
 instance discrete_field.to_euclidean_domain {K : Type u} [discrete_field K] : euclidean_domain K :=
 { quotient := (/),
   remainder := λ a b, if b = 0 then a else 0,

--- a/src/algebra/euclidean_domain.lean
+++ b/src/algebra/euclidean_domain.lean
@@ -10,8 +10,8 @@ import data.int.basic
 
 universe u
 
+section prio
 set_option default_priority 100 -- see Note [default priority]
-
 class euclidean_domain (α : Type u) extends nonzero_comm_ring α :=
 (quotient : α → α → α)
 (quotient_zero : ∀ a, quotient a 0 = 0)
@@ -30,6 +30,7 @@ class euclidean_domain (α : Type u) extends nonzero_comm_ring α :=
   function from weak to strong. I've currently divided the lemmas into
   strong and weak depending on whether they require `val_le_mul_left` or not. -/
 (mul_left_not_lt : ∀ a {b}, b ≠ 0 → ¬r (a * b) a)
+end prio
 
 namespace euclidean_domain
 variable {α : Type u}

--- a/src/algebra/field.lean
+++ b/src/algebra/field.lean
@@ -9,10 +9,12 @@ open set
 universe u
 variables {α : Type u}
 
--- Default priority sufficient as core version has custom-set lower priority (100)
 /-- Core version `division_ring_has_div` erratically requires two instances of `division_ring` -/
+-- priority 900 sufficient as core version has custom-set lower priority (100)
+@[priority 900] -- see Note [lower instance priority]
 instance division_ring_has_div' [division_ring α] : has_div α := ⟨algebra.div⟩
 
+@[priority 100] -- see Note [lower instance priority]
 instance division_ring.to_domain [s : division_ring α] : domain α :=
 { eq_zero_or_eq_zero_of_mul_eq_zero := λ a b h,
     classical.by_contradiction $ λ hn,
@@ -122,6 +124,7 @@ lemma div_eq_iff_mul_eq (hb : b ≠ 0) : a / b = c ↔ c * b = a :=
 
 end division_ring
 
+@[priority 100] -- see Note [lower instance priority]
 instance field.to_integral_domain [F : field α] : integral_domain α :=
 { ..F, ..division_ring.to_domain }
 

--- a/src/algebra/gcd_domain.lean
+++ b/src/algebra/gcd_domain.lean
@@ -12,6 +12,8 @@ import algebra.associated data.int.gcd
 variables {α : Type*}
 
 set_option old_structure_cmd true
+set_option default_priority 100 -- see Note [default priority]
+
 
 /-- Normalization domain: multiplying with `norm_unit` gives a normal form for associated elements. -/
 class normalization_domain (α : Type*) extends integral_domain α :=

--- a/src/algebra/gcd_domain.lean
+++ b/src/algebra/gcd_domain.lean
@@ -12,15 +12,18 @@ import algebra.associated data.int.gcd
 variables {α : Type*}
 
 set_option old_structure_cmd true
+
+
+
+section prio
 set_option default_priority 100 -- see Note [default priority]
-
-
 /-- Normalization domain: multiplying with `norm_unit` gives a normal form for associated elements. -/
 class normalization_domain (α : Type*) extends integral_domain α :=
 (norm_unit : α → units α)
 (norm_unit_zero      : norm_unit 0 = 1)
 (norm_unit_mul       : ∀{a b}, a ≠ 0 → b ≠ 0 → norm_unit (a * b) = norm_unit a * norm_unit b)
 (norm_unit_coe_units : ∀(u : units α), norm_unit u = u⁻¹)
+end prio
 
 export normalization_domain (norm_unit norm_unit_zero norm_unit_mul norm_unit_coe_units)
 
@@ -129,6 +132,8 @@ quotient.induction_on a normalize_idem
 
 end associates
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- GCD domain: an integral domain with normalization and `gcd` (greatest common divisor) and
 `lcm` (least common multiple) operations. In this setting `gcd` and `lcm` form a bounded lattice on
 the associated elements where `gcd` is the infimum, `lcm` is the supremum, `1` is bottom, and
@@ -144,6 +149,7 @@ class gcd_domain (α : Type*) extends normalization_domain α :=
 (gcd_mul_lcm    : ∀a b, gcd a b * lcm a b = normalize (a * b))
 (lcm_zero_left  : ∀a, lcm 0 a = 0)
 (lcm_zero_right : ∀a, lcm a 0 = 0)
+end prio
 
 export gcd_domain (gcd lcm gcd_dvd_left gcd_dvd_right dvd_gcd  lcm_zero_left lcm_zero_right)
 

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -49,10 +49,12 @@ is_group_hom, is_monoid_hom, monoid_hom
 -/
 
 /- Note [low priority instance on morphisms]:
-  We have instances stating that the composition of product of two morphisms is again a morphism.
-  Type class inference will "succeed" in applying these instances when they shouldn't apply, which
-  causes a very long instance resolution that fails. To avoid this, we make the priority of these
-  instances very low.
+  We have instances stating that the composition or the product of two morphisms is again a morphism.
+  Type class inference will "succeed" in applying these instances when they shouldn't apply (for
+  example when the goal is just `⊢ is_mul_hom f` the instances `is_mul_hom.comp` or `is_mul_hom.mul`
+  might still succeed). This can cause type class inference to loop.
+  To avoid this, we make the priority of these instances very low. We should think about not making
+  these declarations instances in the first place.
 -/
 universes u v
 variables {α : Type u} {β : Type v}

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -49,6 +49,7 @@ is_group_hom, is_monoid_hom, monoid_hom
 -/
 universes u v
 variables {α : Type u} {β : Type v}
+set_option default_priority 100 -- see Note [default priority]
 
 /-- Predicate for maps which preserve an addition. -/
 class is_add_hom {α β : Type*} [has_add α] [has_add β] (f : α → β) : Prop :=
@@ -161,7 +162,7 @@ variables [group α] [group β] (f : α → β) [is_group_hom f]
 open is_mul_hom (map_mul)
 
 /-- A group homomorphism is a monoid homomorphism. -/
-@[to_additive to_is_add_monoid_hom]
+@[priority 100, to_additive to_is_add_monoid_hom] -- see Note [lower instance priority]
 instance to_is_monoid_hom : is_monoid_hom f :=
 is_monoid_hom.of_mul f
 

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -31,6 +31,7 @@ lie bracket, ring commutator, jacobi identity, lie ring, lie algebra
 -/
 
 universes u v
+set_option default_priority 100 -- see Note [default priority]
 
 /--
 A binary operation, intended use in Lie algebras and similar structures.

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -31,7 +31,6 @@ lie bracket, ring commutator, jacobi identity, lie ring, lie algebra
 -/
 
 universes u v
-set_option default_priority 100 -- see Note [default priority]
 
 /--
 A binary operation, intended use in Lie algebras and similar structures.
@@ -80,6 +79,8 @@ end
 
 end ring_commutator
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /--
 A Lie ring is an additive group with compatible product, known as the bracket, satisfying the
 Jacobi identity. The bracket is not associative unless it is identically zero.
@@ -89,6 +90,7 @@ class lie_ring (L : Type v) [add_comm_group L] extends has_bracket L :=
 (lie_add : ∀ (x y z : L), ⁅z, x + y⁆ = ⁅z, x⁆ + ⁅z, y⁆)
 (lie_self : ∀ (x : L), ⁅x, x⁆ = 0)
 (jacobi : ∀ (x y z : L), ⁅x, ⁅y, z⁆⁆ + ⁅y, ⁅z, x⁆⁆ + ⁅z, ⁅x, y⁆⁆ = 0)
+end prio
 
 section lie_ring
 
@@ -151,6 +153,8 @@ def lie_ring.of_associative_ring (A : Type v) [ring A] : lie_ring A :=
 
 end lie_ring
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /--
 A Lie algebra is a module with compatible product, known as the bracket, satisfying the Jacobi
 identity. Forgetting the scalar multiplication, every Lie algebra is a Lie ring.
@@ -158,6 +162,7 @@ identity. Forgetting the scalar multiplication, every Lie algebra is a Lie ring.
 class lie_algebra (R : Type u) (L : Type v)
   [comm_ring R] [add_comm_group L] extends module R L, lie_ring L :=
 (lie_smul : ∀ (t : R) (x y : L), ⁅x, t • y⁆ = t • ⁅x, y⁆)
+end prio
 
 @[simp] lemma lie_smul  (R : Type u) (L : Type v) [comm_ring R] [add_comm_group L] [lie_algebra R L]
   (t : R) (x y : L) : ⁅x, t • y⁆ = t • ⁅x, y⁆ :=

--- a/src/algebra/module.lean
+++ b/src/algebra/module.lean
@@ -16,6 +16,7 @@ When they can be inferred from the type it is faster to use this method than to 
 
 import algebra.ring algebra.big_operators group_theory.subgroup group_theory.group_action
 open function
+set_option default_priority 100 -- see Note [default priority]
 
 universes u v w x
 variables {α : Type u} {β : Type v} {γ : Type w} {δ : Type x}

--- a/src/algebra/module.lean
+++ b/src/algebra/module.lean
@@ -16,7 +16,6 @@ When they can be inferred from the type it is faster to use this method than to 
 
 import algebra.ring algebra.big_operators group_theory.subgroup group_theory.group_action
 open function
-set_option default_priority 100 -- see Note [default priority]
 
 universes u v w x
 variables {α : Type u} {β : Type v} {γ : Type w} {δ : Type x}
@@ -26,6 +25,8 @@ variables {α : Type u} {β : Type v} {γ : Type w} {δ : Type x}
 
 -- infixr ` • `:73 := has_scalar.smul
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A semimodule is a generalization of vector spaces to a scalar semiring.
   It consists of a scalar semiring `α` and an additive monoid of "vectors" `β`,
   connected by a "scalar multiplication" operation `r • x : β`
@@ -35,6 +36,7 @@ class semimodule (α : Type u) (β : Type v) [semiring α]
   [add_comm_monoid β] extends distrib_mul_action α β :=
 (add_smul : ∀(r s : α) (x : β), (r + s) • x = r • x + s • x)
 (zero_smul : ∀x : β, (0 : α) • x = 0)
+end prio
 
 section semimodule
 variables [R:semiring α] [add_comm_monoid β] [semimodule α β] (r s : α) (x y : β)
@@ -54,12 +56,15 @@ by rw [←one_smul α x, ←zero_eq_one, zero_smul]
 
 end semimodule
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A module is a generalization of vector spaces to a scalar ring.
   It consists of a scalar ring `α` and an additive group of "vectors" `β`,
   connected by a "scalar multiplication" operation `r • x : β`
   (where `r : α` and `x : β`) with some natural associativity and
   distributivity axioms similar to those on a ring. -/
 class module (α : Type u) (β : Type v) [ring α] [add_comm_group β] extends semimodule α β
+end prio
 
 structure module.core (α β) [ring α] [add_comm_group β] extends has_scalar α β :=
 (smul_add : ∀(r : α) (x y : β), r • (x + y) = r • x + r • y)
@@ -351,12 +356,15 @@ lemma mul_mem_right (h : a ∈ I) : a * b ∈ I := mul_comm b a ▸ I.mul_mem_le
 
 end ideal
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A vector space is the same as a module, except the scalar ring is actually
   a field. (This adds commutativity of the multiplication and existence of inverses.)
   This is the traditional generalization of spaces like `ℝ^n`, which have a natural
   addition operation and a way to multiply them by real numbers, but no multiplication
   operation between vectors. -/
 class vector_space (α : Type u) (β : Type v) [discrete_field α] [add_comm_group β] extends module α β
+end prio
 
 instance discrete_field.to_vector_space {α : Type*} [discrete_field α] : vector_space α α :=
 { .. ring.to_module }

--- a/src/algebra/order_functions.lean
+++ b/src/algebra/order_functions.lean
@@ -86,8 +86,8 @@ lemma max_min_distrib_right : max (min a b) c = min (max a c) (max b c) := sup_i
 lemma min_max_distrib_left : min a (max b c) = max (min a b) (min a c) := inf_sup_left
 lemma min_max_distrib_right : min (max a b) c = max (min a c) (min b c) := inf_sup_right
 
-instance max_idem : is_idempotent α max := by apply_instance
-instance min_idem : is_idempotent α min := by apply_instance
+instance max_idem : is_idempotent α max := by apply_instance -- short-circuit type class inference
+instance min_idem : is_idempotent α min := by apply_instance -- short-circuit type class inference
 
 @[simp] lemma min_le_iff : min a b ≤ c ↔ a ≤ c ∨ b ≤ c :=
 have a ≤ b → (a ≤ c ∨ b ≤ c ↔ a ≤ c),

--- a/src/algebra/ordered_field.lean
+++ b/src/algebra/ordered_field.lean
@@ -146,6 +146,7 @@ calc (λx, x * c) '' {r | a ≤ r ∧ r ≤ b } = (λx, x / c) ⁻¹' {r | a ≤
   ... = {r | a * c ≤ r ∧ r ≤ b * c} :
     set.ext $ by simp [le_div_iff, div_le_iff, hc]
 
+@[priority 100] -- see Note [lower instance priority]
 instance linear_ordered_field.to_densely_ordered : densely_ordered α :=
 { dense := assume a₁ a₂ h, ⟨(a₁ + a₂) / 2,
   calc a₁ = (a₁ + a₁) / 2 : (add_self_div_two a₁).symm
@@ -153,9 +154,11 @@ instance linear_ordered_field.to_densely_ordered : densely_ordered α :=
   calc (a₁ + a₂) / 2 < (a₂ + a₂) / 2 : div_lt_div_of_lt_of_pos (add_lt_add_right h _) two_pos
     ... = a₂ : add_self_div_two a₂⟩ }
 
+@[priority 100] -- see Note [lower instance priority]
 instance linear_ordered_field.to_no_top_order : no_top_order α :=
 { no_top := assume a, ⟨a + 1, lt_add_of_le_of_pos (le_refl a) zero_lt_one ⟩ }
 
+@[priority 100] -- see Note [lower instance priority]
 instance linear_ordered_field.to_no_bot_order : no_bot_order α :=
 { no_bot := assume a, ⟨a + -1,
     add_lt_of_le_of_neg (le_refl _) (neg_lt_of_neg_lt $ by simp [zero_lt_one]) ⟩ }

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -6,6 +6,7 @@ Authors: Mario Carneiro, Johannes Hölzl
 Ordered monoids and groups.
 -/
 import algebra.group order.bounded_lattice tactic.basic
+set_option default_priority 100 -- see Note [default priority]
 
 universe u
 variable {α : Type u}
@@ -398,6 +399,7 @@ instance with_zero.canonically_ordered_monoid :
 
 end canonically_ordered_monoid
 
+@[priority 100] -- see Note [lower instance priority]
 instance ordered_cancel_comm_monoid.to_ordered_comm_monoid
   [H : ordered_cancel_comm_monoid α] : ordered_comm_monoid α :=
 { lt_of_add_lt_add_left := @lt_of_add_lt_add_left _ _, ..H }
@@ -666,6 +668,7 @@ namespace decidable_linear_ordered_comm_group
 variables [s : decidable_linear_ordered_comm_group α]
 include s
 
+@[priority 100] -- see Note [lower instance priority]
 instance : decidable_linear_ordered_cancel_comm_monoid α :=
 { le_of_add_le_add_left := λ x y z, le_of_add_le_add_left,
   add_left_cancel := λ x y z, add_left_cancel,
@@ -692,7 +695,8 @@ namespace nonneg_comm_group
 variable [s : nonneg_comm_group α]
 include s
 
-@[reducible] instance to_ordered_comm_group : ordered_comm_group α :=
+@[reducible, priority 100] -- see Note [lower instance priority]
+instance to_ordered_comm_group : ordered_comm_group α :=
 { le := λ a b, nonneg (b - a),
   lt := λ a b, pos (b - a),
   lt_iff_le_not_le := λ a b, by simp; rw [pos_iff]; simp,

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -6,7 +6,6 @@ Authors: Mario Carneiro, Johannes Hölzl
 Ordered monoids and groups.
 -/
 import algebra.group order.bounded_lattice tactic.basic
-set_option default_priority 100 -- see Note [default priority]
 
 universe u
 variable {α : Type u}
@@ -14,7 +13,7 @@ variable {α : Type u}
 section old_structure_cmd
 
 set_option old_structure_cmd true
-
+set_option default_priority 100 -- see Note [default priority]
 /-- An ordered (additive) commutative monoid is a commutative monoid
   with a partial order such that addition is an order embedding, i.e.
   `a + b ≤ a + c ↔ b ≤ c`. These monoids are automatically cancellative. -/
@@ -681,6 +680,8 @@ eq_of_abs_sub_eq_zero (le_antisymm _ _ h (abs_nonneg (a - b)))
 end decidable_linear_ordered_comm_group
 
 set_option old_structure_cmd true
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- This is not so much a new structure as a construction mechanism
   for ordered groups, by specifying only the "positive cone" of the group. -/
 class nonneg_comm_group (α : Type*) extends add_comm_group α :=
@@ -690,6 +691,7 @@ class nonneg_comm_group (α : Type*) extends add_comm_group α :=
 (zero_nonneg : nonneg 0)
 (add_nonneg : ∀ {a b}, nonneg a → nonneg b → nonneg (a + b))
 (nonneg_antisymm : ∀ {a}, nonneg a → nonneg (-a) → a = 0)
+end prio
 
 namespace nonneg_comm_group
 variable [s : nonneg_comm_group α]

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import tactic.split_ifs order.basic algebra.order algebra.ordered_group algebra.ring data.nat.cast
+set_option default_priority 100 -- see Note [default priority]
 
 universe u
 variable {α : Type u}
@@ -157,15 +158,18 @@ decidable.le_iff_le_iff_lt_iff_lt.2 $ mul_lt_mul_right h
 
 end decidable_linear_ordered_semiring
 
+@[priority 100] -- see Note [lower instance priority]
 instance linear_ordered_semiring.to_no_top_order {α : Type*} [linear_ordered_semiring α] :
   no_top_order α :=
 ⟨assume a, ⟨a + 1, lt_add_of_pos_right _ zero_lt_one⟩⟩
 
+@[priority 100] -- see Note [lower instance priority]
 instance linear_ordered_semiring.to_no_bot_order {α : Type*} [linear_ordered_ring α] :
   no_bot_order α :=
 ⟨assume a, ⟨a - 1, sub_lt_iff_lt_add.mpr $ lt_add_of_pos_right _ zero_lt_one⟩⟩
 
-instance to_domain [s : linear_ordered_ring α] : domain α :=
+@[priority 100] -- see Note [lower instance priority]
+instance linear_ordered_ring.to_domain [s : linear_ordered_ring α] : domain α :=
 { eq_zero_or_eq_zero_of_mul_eq_zero := @linear_ordered_ring.eq_zero_or_eq_zero_of_mul_eq_zero α s,
   ..s }
 
@@ -242,6 +246,7 @@ namespace nonneg_ring
 open nonneg_comm_group
 variable [s : nonneg_ring α]
 
+@[priority 100] -- see Note [lower instance priority]
 instance to_ordered_ring : ordered_ring α :=
 { le := (≤),
   lt := (<),
@@ -281,6 +286,7 @@ namespace linear_nonneg_ring
 open nonneg_comm_group
 variable [s : linear_nonneg_ring α]
 
+@[priority 100] -- see Note [lower instance priority]
 instance to_nonneg_ring : nonneg_ring α :=
 { mul_pos := λ a b pa pb,
   let ⟨a1, a2⟩ := (pos_iff α a).1 pa,
@@ -293,6 +299,7 @@ instance to_nonneg_ring : nonneg_ring α :=
       (ne_of_gt (pos_def.1 pb))⟩,
   ..s }
 
+@[priority 100] -- see Note [lower instance priority]
 instance to_linear_order : linear_order α :=
 { le := (≤),
   lt := (<),
@@ -303,6 +310,7 @@ instance to_linear_order : linear_order α :=
   le_total := nonneg_total_iff.1 nonneg_total,
   ..s }
 
+@[priority 100] -- see Note [lower instance priority]
 instance to_linear_ordered_ring : linear_ordered_ring α :=
 { le := (≤),
   lt := (<),
@@ -321,6 +329,7 @@ instance to_linear_ordered_ring : linear_ordered_ring α :=
     exact zero_ne_one _ (nonneg_antisymm this h).symm
   end, ..s }
 
+@[priority 80] -- see Note [lower instance priority]
 instance to_decidable_linear_ordered_comm_ring
   [decidable_pred (@nonneg α _)]
   [comm : @is_commutative α (*)]

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import tactic.split_ifs order.basic algebra.order algebra.ordered_group algebra.ring data.nat.cast
-set_option default_priority 100 -- see Note [default priority]
 
 universe u
 variable {α : Type u}
@@ -229,6 +228,8 @@ end
 end linear_ordered_ring
 
 set_option old_structure_cmd true
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- Extend `nonneg_comm_group` to support ordered rings
   specified by their nonnegative elements -/
 class nonneg_ring (α : Type*)
@@ -241,6 +242,7 @@ class nonneg_ring (α : Type*)
 class linear_nonneg_ring (α : Type*) extends domain α, nonneg_comm_group α :=
 (mul_nonneg : ∀ {a b}, nonneg a → nonneg b → nonneg (a * b))
 (nonneg_total : ∀ a, nonneg a ∨ nonneg (-a))
+end prio
 
 namespace nonneg_ring
 open nonneg_comm_group
@@ -342,9 +344,12 @@ instance to_decidable_linear_ordered_comm_ring
 
 end linear_nonneg_ring
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 class canonically_ordered_comm_semiring (α : Type*) extends
   canonically_ordered_monoid α, comm_semiring α, zero_ne_one_class α :=
 (mul_eq_zero_iff (a b : α) : a * b = 0 ↔ a = 0 ∨ b = 0)
+end prio
 
 namespace canonically_ordered_semiring
 open canonically_ordered_monoid

--- a/src/algebra/ring.lean
+++ b/src/algebra/ring.lean
@@ -46,6 +46,7 @@ domain, integral_domain, nonzero_comm_semiring, nonzero_comm_ring, units
 -/
 universes u v w
 variable {α : Type u}
+set_option default_priority 100 -- see Note [default priority]
 
 section
 variable [semiring α]
@@ -158,10 +159,12 @@ instance comp {γ} [semiring γ] (g : β → γ) [is_semiring_hom g] :
   map_mul := λ x y, by simp [map_mul f]; rw map_mul g; refl }
 
 /-- A semiring homomorphism is an additive monoid homomorphism. -/
+@[priority 100] -- see Note [lower instance priority]
 instance : is_add_monoid_hom f :=
 { ..‹is_semiring_hom f› }
 
 /-- A semiring homomorphism is a monoid homomorphism. -/
+@[priority 100] -- see Note [lower instance priority]
 instance : is_monoid_hom f :=
 { ..‹is_semiring_hom f› }
 
@@ -300,9 +303,11 @@ instance comp {γ} [ring γ] (g : β → γ) [is_ring_hom g] :
   map_one := by simp [map_one f]; exact map_one g }
 
 /-- A ring homomorphism is also a semiring homomorphism. -/
+@[priority 100] -- see Note [lower instance priority]
 instance : is_semiring_hom f :=
 { map_zero := map_zero f, ..‹is_ring_hom f› }
 
+@[priority 100] -- see Note [lower instance priority]
 instance : is_add_group_hom f := { }
 
 end is_ring_hom
@@ -438,12 +443,14 @@ class nonzero_comm_semiring (α : Type*) extends comm_semiring α, zero_ne_one_c
 class nonzero_comm_ring (α : Type*) extends comm_ring α, zero_ne_one_class α
 
 /-- A nonzero commutative ring is a nonzero commutative semiring. -/
+@[priority 100] -- see Note [lower instance priority]
 instance nonzero_comm_ring.to_nonzero_comm_semiring {α : Type*} [I : nonzero_comm_ring α] :
   nonzero_comm_semiring α :=
 { zero_ne_one := by convert zero_ne_one,
   ..show comm_semiring α, by apply_instance }
 
 /-- An integral domain is a nonzero commutative ring. -/
+@[priority 100] -- see Note [lower instance priority]
 instance integral_domain.to_nonzero_comm_ring (α : Type*) [id : integral_domain α] :
   nonzero_comm_ring α :=
 { ..id }
@@ -530,6 +537,7 @@ section
   include s
 
 /-- An integral domain is a domain. -/
+  @[priority 100] -- see Note [lower instance priority]
   instance integral_domain.to_domain : domain α := {..s}
 
 /-- Right multiplcation by a nonzero element of an integral domain is injective. -/

--- a/src/algebra/ring.lean
+++ b/src/algebra/ring.lean
@@ -46,7 +46,6 @@ domain, integral_domain, nonzero_comm_semiring, nonzero_comm_ring, units
 -/
 universes u v w
 variable {α : Type u}
-set_option default_priority 100 -- see Note [default priority]
 
 section
 variable [semiring α]
@@ -314,9 +313,12 @@ end is_ring_hom
 
 set_option old_structure_cmd true
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- Bundled semiring homomorphisms; use this for bundled ring homomorphisms too. -/
 structure ring_hom (α : Type*) (β : Type*) [semiring α] [semiring β]
   extends monoid_hom α β, add_monoid_hom α β
+end prio
 
 infixr ` →+* `:25 := ring_hom
 
@@ -436,11 +438,14 @@ def mk' {γ} [ring γ] (f : α →* γ) (map_add : ∀ a b : α, f (a + b) = f a
 
 end ring_hom
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- Predicate for commutative semirings in which zero does not equal one. -/
 class nonzero_comm_semiring (α : Type*) extends comm_semiring α, zero_ne_one_class α
 
 /-- Predicate for commutative rings in which zero does not equal one. -/
 class nonzero_comm_ring (α : Type*) extends comm_ring α, zero_ne_one_class α
+end prio
 
 /-- A nonzero commutative ring is a nonzero commutative semiring. -/
 @[priority 100] -- see Note [lower instance priority]
@@ -479,10 +484,13 @@ def nonzero_comm_semiring.of_ne [comm_semiring α] {x y : α} (h : x ≠ y) : no
 /-- this is needed for compatibility between Lean 3.4.2 and Lean 3.5.0c -/
 def has_div_of_division_ring [division_ring α] : has_div α := division_ring_has_div
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A domain is a ring with no zero divisors, i.e. satisfying
   the condition `a * b = 0 ↔ a = 0 ∨ b = 0`. Alternatively, a domain
   is an integral domain without assuming commutativity of multiplication. -/
 class domain (α : Type u) extends ring α, no_zero_divisors α, zero_ne_one_class α
+end prio
 
 section domain
   variable [domain α]

--- a/src/algebra/ring.lean
+++ b/src/algebra/ring.lean
@@ -150,6 +150,7 @@ variables (f : α → β) [is_semiring_hom f] {x y : α}
 instance id : is_semiring_hom (@id α) := by refine {..}; intros; refl
 
 /-- The composition of two semiring homomorphisms is a semiring homomorphism. -/
+@[priority 10] -- see Note [low priority instance on morphisms]
 instance comp {γ} [semiring γ] (g : β → γ) [is_semiring_hom g] :
   is_semiring_hom (g ∘ f) :=
 { map_zero := by simp [map_zero f]; exact map_zero g,
@@ -295,6 +296,7 @@ by simp [map_add f, map_neg f]
 instance id : is_ring_hom (@id α) := by refine {..}; intros; refl
 
 /-- The composition of two ring homomorphisms is a ring homomorphism. -/
+@[priority 10] -- see Note [low priority instance on morphisms]
 instance comp {γ} [ring γ] (g : β → γ) [is_ring_hom g] :
   is_ring_hom (g ∘ f) :=
 { map_add := λ x y, by simp [map_add f]; rw map_add g; refl,

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -8,7 +8,7 @@ is Lipschitz continuous for the same bound.
 -/
 import analysis.calculus.fderiv
 
-set_option class.instance_max_depth 100
+set_option class.instance_max_depth 120
 
 variables {E : Type*} [normed_group E] [normed_space ℝ E]
           {F : Type*} [normed_group F] [normed_space ℝ F]

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -12,7 +12,6 @@ import topology.instances.nnreal topology.instances.complex
 import topology.algebra.module
 
 variables {α : Type*} {β : Type*} {γ : Type*} {ι : Type*}
-set_option default_priority 100 -- see Note [default priority]
 
 noncomputable theory
 open filter metric
@@ -27,10 +26,13 @@ export has_norm (norm)
 
 notation `∥`:1024 e:1 `∥`:1 := norm e
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A normed group is an additive group endowed with a norm for which `dist x y = ∥x - y∥` defines
 a metric space structure. -/
 class normed_group (α : Type*) extends has_norm α, add_comm_group α, metric_space α :=
 (dist_eq : ∀ x y, dist x y = norm (x - y))
+end prio
 
 /-- Construct a normed group from a translation invariant distance -/
 def normed_group.of_add_dist [has_norm α] [add_comm_group α] [metric_space α]
@@ -269,10 +271,13 @@ end normed_group
 
 section normed_ring
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A normed ring is a ring endowed with a norm which satisfies the inequality `∥x y∥ ≤ ∥x∥ ∥y∥`. -/
 class normed_ring (α : Type*) extends has_norm α, ring α, metric_space α :=
 (dist_eq : ∀ x y, dist x y = norm (x - y))
 (norm_mul : ∀ a b, norm (a * b) ≤ norm a * norm b)
+end prio
 
 @[priority 100] -- see Note [lower instance priority]
 instance normed_ring.to_normed_group [β : normed_ring α] : normed_group α := { ..β }
@@ -340,6 +345,8 @@ instance normed_top_ring [normed_ring α] : topological_ring α :=
     have ∀ e : α, -e - -x = -(e - x), by intro; simp,
     by simp only [this, norm_neg]; apply lim_norm ⟩
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A normed field is a field with a norm satisfying ∥x y∥ = ∥x∥ ∥y∥. -/
 class normed_field (α : Type*) extends has_norm α, discrete_field α, metric_space α :=
 (dist_eq : ∀ x y, dist x y = norm (x - y))
@@ -350,6 +357,7 @@ class normed_field (α : Type*) extends has_norm α, discrete_field α, metric_s
 by the powers of any element, and thus to relate algebra and topology. -/
 class nondiscrete_normed_field (α : Type*) extends normed_field α :=
 (non_trivial : ∃x:α, 1<∥x∥)
+end prio
 
 @[priority 100] -- see Note [lower instance priority]
 instance normed_field.to_normed_ring [i : normed_field α] : normed_ring α :=
@@ -459,11 +467,14 @@ by rw [← rat.norm_cast_real, ← int.norm_cast_real]; congr' 1; norm_cast
 
 section normed_space
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A normed space over a normed field is a vector space endowed with a norm which satisfies the
 equality `∥c • x∥ = ∥c∥ ∥x∥`. -/
 class normed_space (α : Type*) (β : Type*) [normed_field α] [normed_group β]
   extends vector_space α β :=
 (norm_smul : ∀ (a:α) (b:β), norm (a • b) = has_norm.norm a * norm b)
+end prio
 
 variables [normed_field α] [normed_group β]
 

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -12,6 +12,7 @@ import topology.instances.nnreal topology.instances.complex
 import topology.algebra.module
 
 variables {α : Type*} {β : Type*} {γ : Type*} {ι : Type*}
+set_option default_priority 100 -- see Note [default priority]
 
 noncomputable theory
 open filter metric
@@ -248,6 +249,7 @@ continuous_subtype_mk _ continuous_norm
 
 /-- A normed group is a uniform additive group, i.e., addition and subtraction are uniformly
 continuous. -/
+@[priority 100] -- see Note [lower instance priority]
 instance normed_uniform_group : uniform_add_group α :=
 begin
   refine ⟨metric.uniform_continuous_iff.2 $ assume ε hε, ⟨ε / 2, half_pos hε, assume a b h, _⟩⟩,
@@ -258,8 +260,10 @@ begin
     ... = ε : add_halves _
 end
 
-instance normed_top_monoid : topological_add_monoid α := by apply_instance
-instance normed_top_group : topological_add_group α := by apply_instance
+@[priority 100] -- see Note [lower instance priority]
+instance normed_top_monoid : topological_add_monoid α := by apply_instance -- short-circuit type class inference
+@[priority 100] -- see Note [lower instance priority]
+instance normed_top_group : topological_add_group α := by apply_instance -- short-circuit type class inference
 
 end normed_group
 
@@ -270,6 +274,7 @@ class normed_ring (α : Type*) extends has_norm α, ring α, metric_space α :=
 (dist_eq : ∀ x y, dist x y = norm (x - y))
 (norm_mul : ∀ a b, norm (a * b) ≤ norm a * norm b)
 
+@[priority 100] -- see Note [lower instance priority]
 instance normed_ring.to_normed_group [β : normed_ring α] : normed_group α := { ..β }
 
 lemma norm_mul_le {α : Type*} [normed_ring α] (a b : α) : (∥a*b∥) ≤ (∥a∥) * (∥b∥) :=
@@ -297,6 +302,7 @@ instance prod.normed_ring [normed_ring α] [normed_ring β] : normed_ring (α ×
   ..prod.normed_group }
 end normed_ring
 
+@[priority 100] -- see Note [lower instance priority]
 instance normed_ring_top_monoid [normed_ring α] : topological_monoid α :=
 ⟨ continuous_iff_continuous_at.2 $ λ x, tendsto_iff_norm_tendsto_zero.2 $
     have ∀ e : α × α, e.fst * e.snd - x.fst * x.snd =
@@ -328,6 +334,7 @@ instance normed_ring_top_monoid [normed_ring α] : topological_monoid α :=
     end ⟩
 
 /-- A normed ring is a topological ring. -/
+@[priority 100] -- see Note [lower instance priority]
 instance normed_top_ring [normed_ring α] : topological_ring α :=
 ⟨ continuous_iff_continuous_at.2 $ λ x, tendsto_iff_norm_tendsto_zero.2 $
     have ∀ e : α, -e - -x = -(e - x), by intro; simp,
@@ -344,6 +351,7 @@ by the powers of any element, and thus to relate algebra and topology. -/
 class nondiscrete_normed_field (α : Type*) extends normed_field α :=
 (non_trivial : ∃x:α, 1<∥x∥)
 
+@[priority 100] -- see Note [lower instance priority]
 instance normed_field.to_normed_ring [i : normed_field α] : normed_ring α :=
 { norm_mul := by finish [i.norm_mul'], ..i }
 
@@ -506,6 +514,7 @@ lemma tendsto_smul_const {g : γ → F} {e : filter γ} (s : α) {b : F} :
   (tendsto g e (𝓝 b)) → tendsto (λ x, s • (g x)) e (𝓝 (s • b)) :=
 tendsto_smul tendsto_const_nhds
 
+@[priority 100] -- see Note [lower instance priority]
 instance normed_space.topological_vector_space : topological_vector_space α E :=
 { continuous_smul := continuous_iff_continuous_at.2 $ λp, tendsto_smul
     (continuous_iff_continuous_at.1 continuous_fst _) (continuous_iff_continuous_at.1 continuous_snd _) }

--- a/src/analysis/normed_space/bounded_linear_maps.lean
+++ b/src/analysis/normed_space/bounded_linear_maps.lean
@@ -150,7 +150,7 @@ end
 end is_bounded_linear_map
 
 section
-set_option class.instance_max_depth 180
+set_option class.instance_max_depth 240
 
 lemma is_bounded_linear_map_prod_iso :
   is_bounded_linear_map 𝕜 (λ(p : (E →L[𝕜] F) × (E →L[𝕜] G)),
@@ -301,7 +301,7 @@ end
 @[simp] lemma is_bounded_bilinear_map_deriv_coe (h : is_bounded_bilinear_map 𝕜 f) (p q : E × F) :
   h.deriv p q = f (p.1, q.2) + f (q.1, p.2) := rfl
 
-set_option class.instance_max_depth 95
+set_option class.instance_max_depth 100
 
 /-- Given a bounded bilinear map `f`, the map associating to a point `p` the derivative of `f` at
 `p` is itself a bounded linear map. -/

--- a/src/analysis/normed_space/real_inner_product.lean
+++ b/src/analysis/normed_space/real_inner_product.lean
@@ -42,7 +42,6 @@ The Coq code is available at the following address: <http://www.lri.fr/~sboldo/e
 -/
 
 noncomputable theory
-set_option default_priority 100 -- see Note [default priority]
 
 open real set lattice
 open_locale topological_space
@@ -55,6 +54,8 @@ class has_inner (α : Type*) := (inner : α → α → ℝ)
 
 export has_inner (inner)
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /--
 An inner product space is a real vector space with an additional operation called inner product.
 Inner product spaces over complex vector space will be defined in another file.
@@ -65,6 +66,7 @@ class inner_product_space (α : Type*) extends add_comm_group α, vector_space �
 (definite  : ∀ x, inner x x = 0 → x = 0)
 (add_left  : ∀ x y z, inner (x + y) z = inner x z + inner y z)
 (smul_left : ∀ x y r, inner (r • x) y = r * inner x y)
+end prio
 
 variable [inner_product_space α]
 

--- a/src/analysis/normed_space/real_inner_product.lean
+++ b/src/analysis/normed_space/real_inner_product.lean
@@ -42,6 +42,7 @@ The Coq code is available at the following address: <http://www.lri.fr/~sboldo/e
 -/
 
 noncomputable theory
+set_option default_priority 100 -- see Note [default priority]
 
 open real set lattice
 open_locale topological_space
@@ -141,6 +142,7 @@ end basic_properties
 section norm
 
 /-- An inner product naturally induces a norm. -/
+@[priority 100] -- see Note [lower instance priority]
 instance inner_product_space_has_norm : has_norm α := ⟨λx, sqrt (inner x x)⟩
 
 lemma norm_eq_sqrt_inner {x : α} : ∥x∥ = sqrt (inner x x) := rfl
@@ -179,6 +181,7 @@ lemma parallelogram_law_with_norm {x y : α} :
 by { simp only [(inner_self_eq_norm_square _).symm], exact parallelogram_law }
 
 /-- An inner product space forms a normed group w.r.t. its associated norm. -/
+@[priority 100] -- see Note [lower instance priority]
 instance inner_product_space_is_normed_group : normed_group α :=
 normed_group.of_core α
 { norm_eq_zero_iff := assume x, iff.intro

--- a/src/category/basic.lean
+++ b/src/category/basic.lean
@@ -8,6 +8,7 @@ Extends the theory on functors, applicatives and monads.
 
 universes u v w
 variables {α β γ : Type u}
+set_option default_priority 100 -- see Note [default priority]
 
 notation a ` $< `:1 f:1 := f a
 

--- a/src/category/basic.lean
+++ b/src/category/basic.lean
@@ -8,7 +8,6 @@ Extends the theory on functors, applicatives and monads.
 
 universes u v w
 variables {α β γ : Type u}
-set_option default_priority 100 -- see Note [default priority]
 
 notation a ` $< `:1 f:1 := f a
 
@@ -190,8 +189,11 @@ instance : is_lawful_monad (sum.{v u} e) :=
 
 end sum
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 class is_comm_applicative (m : Type* → Type*) [applicative m] extends is_lawful_applicative m : Prop :=
 (commutative_prod : ∀{α β} (a : m α) (b : m β), prod.mk <$> a <*> b = (λb a, (a, b)) <$> b <*> a)
+end prio
 
 lemma is_comm_applicative.commutative_map
   {m : Type* → Type*} [applicative m] [is_comm_applicative m]

--- a/src/category/bitraversable/basic.lean
+++ b/src/category/bitraversable/basic.lean
@@ -36,19 +36,23 @@ traversable bitraversable iterator functor bifunctor applicative
 -/
 
 universes u
-set_option default_priority 100 -- see Note [default priority]
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 class bitraversable (t : Type u → Type u → Type u)
   extends bifunctor t :=
 (bitraverse : Π {m : Type u → Type u} [applicative m] {α α' β β'},
   (α → m α') → (β → m β') → t α β → m (t α' β'))
 export bitraversable ( bitraverse )
+end prio
 
 def bisequence {t m} [bitraversable t] [applicative m] {α β} : t (m α) (m β) → m (t α β) :=
 bitraverse id id
 
 open functor
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 class is_lawful_bitraversable (t : Type u → Type u → Type u) [bitraversable t]
   extends is_lawful_bifunctor t :=
 (id_bitraverse : ∀ {α β} (x : t α β), bitraverse id.mk id.mk x = id.mk x )
@@ -65,6 +69,7 @@ class is_lawful_bitraversable (t : Type u → Type u → Type u) [bitraversable 
     (η : applicative_transformation F G) {α α' β β'}
     (f : α → F β) (f' : α' → F β') (x : t α α'),
   η (bitraverse f f' x) = bitraverse (@η _ ∘ f) (@η _ ∘ f') x)
+end prio
 
 export is_lawful_bitraversable ( id_bitraverse comp_bitraverse
                                  bitraverse_eq_bimap_id  )

--- a/src/category/bitraversable/basic.lean
+++ b/src/category/bitraversable/basic.lean
@@ -43,8 +43,8 @@ class bitraversable (t : Type u → Type u → Type u)
   extends bifunctor t :=
 (bitraverse : Π {m : Type u → Type u} [applicative m] {α α' β β'},
   (α → m α') → (β → m β') → t α β → m (t α' β'))
-export bitraversable ( bitraverse )
 end prio
+export bitraversable ( bitraverse )
 
 def bisequence {t m} [bitraversable t] [applicative m] {α β} : t (m α) (m β) → m (t α β) :=
 bitraverse id id

--- a/src/category/bitraversable/basic.lean
+++ b/src/category/bitraversable/basic.lean
@@ -36,6 +36,7 @@ traversable bitraversable iterator functor bifunctor applicative
 -/
 
 universes u
+set_option default_priority 100 -- see Note [default priority]
 
 class bitraversable (t : Type u → Type u → Type u)
   extends bifunctor t :=

--- a/src/category/monad/cont.lean
+++ b/src/category/monad/cont.lean
@@ -12,7 +12,6 @@ import tactic.ext
 import category.monad.basic category.monad.writer
 
 universes u v w
-set_option default_priority 100 -- see Note [default priority]
 
 structure monad_cont.label (α : Type w) (m : Type u → Type v) (β : Type u) :=
 (apply : α → m β)
@@ -24,6 +23,8 @@ class monad_cont (m : Type u → Type v) :=
 
 open monad_cont
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 class is_lawful_monad_cont (m : Type u → Type v) [monad m] [monad_cont m]
 extends is_lawful_monad m :=
 (call_cc_bind_right {α ω γ} (cmd : m α) (next : (label ω m γ) → α → m ω) :
@@ -32,6 +33,7 @@ extends is_lawful_monad m :=
   call_cc (λ f : label α m β, goto f x >>= dead f) = pure x)
 (call_cc_dummy {α β} (dummy : m α) :
   call_cc (λ f : label α m β, dummy) = dummy)
+end prio
 
 export is_lawful_monad_cont
 

--- a/src/category/monad/cont.lean
+++ b/src/category/monad/cont.lean
@@ -12,6 +12,7 @@ import tactic.ext
 import category.monad.basic category.monad.writer
 
 universes u v w
+set_option default_priority 100 -- see Note [default priority]
 
 structure monad_cont.label (α : Type w) (m : Type u → Type v) (β : Type u) :=
 (apply : α → m β)

--- a/src/category/monad/writer.lean
+++ b/src/category/monad/writer.lean
@@ -148,6 +148,7 @@ export monad_writer_adapter (adapt_writer)
 section
 variables {ω ω' : Type u} {m m' : Type u → Type v}
 
+@[priority 100] -- see Note [lower instance priority]
 instance monad_writer_adapter_trans {n n' : Type u → Type v} [monad_functor m m' n n'] [monad_writer_adapter ω ω' m m'] : monad_writer_adapter ω ω' n n' :=
 ⟨λ α f, monad_map (λ α, (adapt_writer f : m α → m' α))⟩
 

--- a/src/category/traversable/basic.lean
+++ b/src/category/traversable/basic.lean
@@ -50,6 +50,7 @@ Synopsis
 -/
 
 open function (hiding comp)
+set_option default_priority 100 -- see Note [default priority]
 
 universes u v w
 

--- a/src/category/traversable/basic.lean
+++ b/src/category/traversable/basic.lean
@@ -50,7 +50,6 @@ Synopsis
 -/
 
 open function (hiding comp)
-set_option default_priority 100 -- see Note [default priority]
 
 universes u v w
 
@@ -94,9 +93,12 @@ end applicative_transformation
 
 open applicative_transformation
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 class traversable (t : Type u → Type u) extends functor t :=
 (traverse : Π {m : Type u → Type u} [applicative m] {α β},
    (α → m β) → t α → m (t β))
+end prio
 
 open functor
 
@@ -115,6 +117,8 @@ def sequence [traversable t] : t (f α) → f (t α) := traverse id
 
 end functions
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 class is_lawful_traversable (t : Type u → Type u) [traversable t]
   extends is_lawful_functor t : Type (u+1) :=
 (id_traverse : ∀ {α} (x : t α), traverse id.mk x = x )
@@ -129,6 +133,7 @@ class is_lawful_traversable (t : Type u → Type u) [traversable t]
     [is_lawful_applicative F] [is_lawful_applicative G]
     (η : applicative_transformation F G) {α β} (f : α → F β) (x : t α),
   η (traverse f x) = traverse (@η _ ∘ f) x)
+end prio
 
 instance : traversable id := ⟨λ _ _ _ _, id⟩
 instance : is_lawful_traversable id := by refine {..}; intros; refl

--- a/src/category_theory/adjunction/limits.lean
+++ b/src/category_theory/adjunction/limits.lean
@@ -44,6 +44,7 @@ def functoriality_is_left_adjoint :
     counit := functoriality_counit adj K } }
 
 /-- A left adjoint preserves colimits. -/
+@[priority 100] -- see Note [lower instance priority]
 instance left_adjoint_preserves_colimits : preserves_colimits F :=
 { preserves_colimits_of_shape := λ J 𝒥,
   { preserves_colimit := λ F,
@@ -54,6 +55,7 @@ instance left_adjoint_preserves_colimits : preserves_colimits F :=
 
 omit adj
 
+@[priority 100] -- see Note [lower instance priority]
 instance is_equivalence_preserves_colimits (E : C ⥤ D) [is_equivalence E] : preserves_colimits E :=
 adjunction.left_adjoint_preserves_colimits E.adjunction
 
@@ -98,6 +100,7 @@ def functoriality_is_right_adjoint :
     counit := functoriality_counit' adj K } }
 
 /-- A right adjoint preserves limits. -/
+@[priority 100] -- see Note [lower instance priority]
 instance right_adjoint_preserves_limits : preserves_limits G :=
 { preserves_limits_of_shape := λ J 𝒥,
   { preserves_limit := λ K,
@@ -108,6 +111,7 @@ instance right_adjoint_preserves_limits : preserves_limits G :=
 
 omit adj
 
+@[priority 100] -- see Note [lower instance priority]
 instance is_equivalence_preserves_limits (E : D ⥤ C) [is_equivalence E] : preserves_limits E :=
 adjunction.right_adjoint_preserves_limits E.inv.adjunction
 

--- a/src/category_theory/category/default.lean
+++ b/src/category_theory/category/default.lean
@@ -23,7 +23,6 @@ Users may like to add `f ⊚ g` for composition in the standard convention, usin
 local notation f ` ⊚ `:80 g:80 := category.comp g f    -- type as \oo
 ```
 -/
-set_option default_priority 100 -- see Note [default priority]
 
 universes v u  -- The order in this declaration matters: v often needs to be explicitly specified while u often can be omitted
 
@@ -44,6 +43,8 @@ class has_hom (obj : Type u) : Type (max u (v+1)) :=
 
 infixr ` ⟶ `:10 := has_hom.hom -- type as \h
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 class category_struct (obj : Type u)
 extends has_hom.{v} obj : Type (max u (v+1)) :=
 (id       : Π X : obj, hom X X)
@@ -63,6 +64,7 @@ extends category_struct.{v} obj : Type (max u (v+1)) :=
 (comp_id' : ∀ {X Y : obj} (f : hom X Y), f ≫ 𝟙 Y = f . obviously)
 (assoc'   : ∀ {W X Y Z : obj} (f : hom W X) (g : hom X Y) (h : hom Y Z),
   (f ≫ g) ≫ h = f ≫ (g ≫ h) . obviously)
+end prio
 
 -- `restate_axiom` is a command that creates a lemma from a structure field,
 -- discarding any auto_param wrappers from the type.

--- a/src/category_theory/category/default.lean
+++ b/src/category_theory/category/default.lean
@@ -23,6 +23,7 @@ Users may like to add `f ⊚ g` for composition in the standard convention, usin
 local notation f ` ⊚ `:80 g:80 := category.comp g f    -- type as \oo
 ```
 -/
+set_option default_priority 100 -- see Note [default priority]
 
 universes v u  -- The order in this declaration matters: v often needs to be explicitly specified while u often can be omitted
 
@@ -136,6 +137,7 @@ namespace preorder
 
 variables (α : Type u)
 
+@[priority 100] -- see Note [lower instance priority]
 instance small_category [preorder α] : small_category α :=
 { hom  := λ U V, ulift (plift (U ≤ V)),
   id   := λ X, ⟨ ⟨ le_refl X ⟩ ⟩,

--- a/src/category_theory/concrete_category/basic.lean
+++ b/src/category_theory/concrete_category/basic.lean
@@ -34,6 +34,7 @@ related work.
 -/
 
 universe u
+set_option default_priority 100 -- see Note [default priority]
 
 namespace category_theory
 

--- a/src/category_theory/concrete_category/basic.lean
+++ b/src/category_theory/concrete_category/basic.lean
@@ -34,14 +34,16 @@ related work.
 -/
 
 universe u
-set_option default_priority 100 -- see Note [default priority]
 
 namespace category_theory
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A concrete category is a category `C` with a fixed faithful functor `forget : C ⥤ Type`. -/
 class concrete_category (C : Type (u+1)) extends category.{u} C :=
 (forget : C ⥤ Type u)
 [forget_faithful : faithful forget]
+end prio
 
 attribute [instance] concrete_category.forget_faithful
 

--- a/src/category_theory/equivalence.lean
+++ b/src/category_theory/equivalence.lean
@@ -294,6 +294,7 @@ namespace equivalence
 def ess_surj_of_equivalence (F : C ⥤ D) [is_equivalence F] : ess_surj F :=
 ⟨ λ Y : D, F.inv.obj Y, λ Y : D, (F.inv_fun_id.app Y) ⟩
 
+@[priority 100] -- see Note [lower instance priority]
 instance faithful_of_equivalence (F : C ⥤ D) [is_equivalence F] : faithful F :=
 { injectivity' := λ X Y f g w,
   begin
@@ -301,6 +302,7 @@ instance faithful_of_equivalence (F : C ⥤ D) [is_equivalence F] : faithful F :
     simpa only [cancel_epi, cancel_mono, is_equivalence.inv_fun_map] using p
   end }.
 
+@[priority 100] -- see Note [lower instance priority]
 instance full_of_equivalence (F : C ⥤ D) [is_equivalence F] : full F :=
 { preimage := λ X Y f, (F.fun_inv_id.app X).inv ≫ (F.inv.map f) ≫ (F.fun_inv_id.app Y).hom,
   witness' := λ X Y f,

--- a/src/category_theory/groupoid.lean
+++ b/src/category_theory/groupoid.lean
@@ -7,17 +7,19 @@ Authors: Reid Barton
 import category_theory.category
 import category_theory.isomorphism
 import data.equiv.basic
-set_option default_priority 100 -- see Note [default priority]
 
 namespace category_theory
 
 universes v u -- declare the `v`'s first; see `category_theory.category` for an explanation
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A `groupoid` is a category such that all morphisms are isomorphisms. -/
 class groupoid (obj : Type u) extends category.{v} obj : Type (max u (v+1)) :=
 (inv       : Π {X Y : obj}, (X ⟶ Y) → (Y ⟶ X))
 (inv_comp' : ∀ {X Y : obj} (f : X ⟶ Y), comp (inv f) f = id Y . obviously)
 (comp_inv' : ∀ {X Y : obj} (f : X ⟶ Y), comp f (inv f) = id X . obviously)
+end prio
 
 restate_axiom groupoid.inv_comp'
 restate_axiom groupoid.comp_inv'

--- a/src/category_theory/groupoid.lean
+++ b/src/category_theory/groupoid.lean
@@ -7,6 +7,7 @@ Authors: Reid Barton
 import category_theory.category
 import category_theory.isomorphism
 import data.equiv.basic
+set_option default_priority 100 -- see Note [default priority]
 
 namespace category_theory
 
@@ -31,6 +32,7 @@ section
 variables {C : Type u} [𝒞 : groupoid.{v} C] {X Y : C}
 include 𝒞
 
+@[priority 100] -- see Note [lower instance priority]
 instance is_iso.of_groupoid (f : X ⟶ Y) : is_iso f := { inv := groupoid.inv f }
 
 variables (X Y)

--- a/src/category_theory/isomorphism.lean
+++ b/src/category_theory/isomorphism.lean
@@ -201,10 +201,12 @@ is_iso.of_iso $ (as_iso f) ≪≫ (as_iso h)
 @[simp] lemma iso.inv_inv (f : X ≅ Y) : inv (f.inv) = f.hom := rfl
 @[simp] lemma iso.inv_hom (f : X ≅ Y) : inv (f.hom) = f.inv := rfl
 
+@[priority 100] -- see Note [lower instance priority]
 instance epi_of_iso (f : X ⟶ Y) [is_iso f] : epi f  :=
 { left_cancellation := λ Z g h w,
   -- This is an interesting test case for better rewrite automation.
   by rw [← is_iso.inv_hom_id_assoc f g, w, is_iso.inv_hom_id_assoc f h] }
+@[priority 100] -- see Note [lower instance priority]
 instance mono_of_iso (f : X ⟶ Y) [is_iso f] : mono f :=
 { right_cancellation := λ Z g h w,
   by rw [←category.comp_id C g, ←category.comp_id C h, ←is_iso.hom_inv_id f, ←category.assoc, w, ←category.assoc] }

--- a/src/category_theory/limits/lattice.lean
+++ b/src/category_theory/limits/lattice.lean
@@ -17,6 +17,7 @@ variables {α : Type u}
 
 -- It would be nice to only use the `Inf` half of the complete lattice, but
 -- this seems not to have been described separately.
+@[priority 100] -- see Note [lower instance priority]
 instance has_limits_of_complete_lattice [complete_lattice α] : has_limits.{u} α :=
 { has_limits_of_shape := λ J 𝒥, by exactI
   { has_limit := λ F,
@@ -28,6 +29,7 @@ instance has_limits_of_complete_lattice [complete_lattice α] : has_limits.{u} �
       { lift := λ s, ⟨⟨complete_lattice.le_Inf _ _
         begin rintros _ ⟨j, rfl⟩, exact (s.π.app j).down.down, end⟩⟩ } } } }
 
+@[priority 100] -- see Note [lower instance priority]
 instance has_colimits_of_complete_lattice [complete_lattice α] : has_colimits.{u} α :=
 { has_colimits_of_shape := λ J 𝒥, by exactI
   { has_colimit := λ F,

--- a/src/category_theory/limits/limits.lean
+++ b/src/category_theory/limits/limits.lean
@@ -418,10 +418,12 @@ class has_limits :=
 
 variables {J C}
 
+@[priority 100] -- see Note [lower instance priority]
 instance has_limit_of_has_limits_of_shape
   {J : Type v} [small_category J] [H : has_limits_of_shape J C] (F : J ⥤ C) : has_limit F :=
 has_limits_of_shape.has_limit F
 
+@[priority 100] -- see Note [lower instance priority]
 instance has_limits_of_shape_of_has_limits
   {J : Type v} [small_category J] [H : has_limits.{v} C] : has_limits_of_shape J C :=
 has_limits.has_limits_of_shape C J
@@ -677,10 +679,12 @@ class has_colimits :=
 
 variables {J C}
 
+@[priority 100] -- see Note [lower instance priority]
 instance has_colimit_of_has_colimits_of_shape
   {J : Type v} [small_category J] [H : has_colimits_of_shape J C] (F : J ⥤ C) : has_colimit F :=
 has_colimits_of_shape.has_colimit F
 
+@[priority 100] -- see Note [lower instance priority]
 instance has_colimits_of_shape_of_has_colimits
   {J : Type v} [small_category J] [H : has_colimits.{v} C] : has_colimits_of_shape J C :=
 has_colimits.has_colimits_of_shape C J

--- a/src/category_theory/limits/preserves.lean
+++ b/src/category_theory/limits/preserves.lean
@@ -63,7 +63,7 @@ class preserves_limits (F : C ⥤ D) : Type (max u₁ u₂ (v+1)) :=
 class preserves_colimits (F : C ⥤ D) : Type (max u₁ u₂ (v+1)) :=
 (preserves_colimits_of_shape : Π {J : Type v} [𝒥 : small_category J], by exactI preserves_colimits_of_shape J F)
 
-attribute [instance]
+attribute [instance, priority 100] -- see Note [lower instance priority]
   preserves_limits_of_shape.preserves_limit preserves_limits.preserves_limits_of_shape
   preserves_colimits_of_shape.preserves_colimit preserves_colimits.preserves_colimits_of_shape
 
@@ -167,16 +167,20 @@ by { split, intros, cases a, cases b, congr, funext J 𝒥, resetI, apply subsin
 instance reflects_colimits_subsingleton (F : C ⥤ D) : subsingleton (reflects_colimits F) :=
 by { split, intros, cases a, cases b, congr, funext J 𝒥, resetI, apply subsingleton.elim }
 
+@[priority 100] -- see Note [lower instance priority]
 instance reflects_limit_of_reflects_limits_of_shape (K : J ⥤ C) (F : C ⥤ D)
   [H : reflects_limits_of_shape J F] : reflects_limit K F :=
 reflects_limits_of_shape.reflects_limit J F
+@[priority 100] -- see Note [lower instance priority]
 instance reflects_colimit_of_reflects_colimits_of_shape (K : J ⥤ C) (F : C ⥤ D)
   [H : reflects_colimits_of_shape J F] : reflects_colimit K F :=
 reflects_colimits_of_shape.reflects_colimit J F
 
+@[priority 100] -- see Note [lower instance priority]
 instance reflects_limits_of_shape_of_reflects_limits (F : C ⥤ D)
   [H : reflects_limits F] : reflects_limits_of_shape J F :=
 reflects_limits.reflects_limits_of_shape F
+@[priority 100] -- see Note [lower instance priority]
 instance reflects_colimits_of_shape_of_reflects_colimits (F : C ⥤ D)
   [H : reflects_colimits F] : reflects_colimits_of_shape J F :=
 reflects_colimits.reflects_colimits_of_shape F

--- a/src/category_theory/limits/shapes/binary_products.lean
+++ b/src/category_theory/limits/shapes/binary_products.lean
@@ -114,8 +114,10 @@ class has_binary_coproducts :=
 
 attribute [instance] has_binary_products.has_limits_of_shape has_binary_coproducts.has_colimits_of_shape
 
+@[priority 100] -- see Note [lower instance priority]
 instance [has_finite_products.{v} C] : has_binary_products.{v} C :=
 { has_limits_of_shape := by apply_instance }
+@[priority 100] -- see Note [lower instance priority]
 instance [has_finite_coproducts.{v} C] : has_binary_coproducts.{v} C :=
 { has_colimits_of_shape := by apply_instance }
 

--- a/src/category_theory/limits/shapes/finite_limits.lean
+++ b/src/category_theory/limits/shapes/finite_limits.lean
@@ -37,8 +37,10 @@ class has_finite_colimits :=
 
 attribute [instance] has_finite_limits.has_limits_of_shape has_finite_colimits.has_colimits_of_shape
 
+@[priority 100] -- see Note [lower instance priority]
 instance [has_limits.{v} C] : has_finite_limits.{v} C :=
 { has_limits_of_shape := λ J _ _, by { resetI, apply_instance } }
+@[priority 100] -- see Note [lower instance priority]
 instance [has_colimits.{v} C] : has_finite_colimits.{v} C :=
 { has_colimits_of_shape := λ J _ _, by { resetI, apply_instance } }
 

--- a/src/category_theory/limits/shapes/finite_products.lean
+++ b/src/category_theory/limits/shapes/finite_products.lean
@@ -23,13 +23,17 @@ class has_finite_coproducts :=
 
 attribute [instance] has_finite_products.has_limits_of_shape has_finite_coproducts.has_colimits_of_shape
 
+@[priority 100] -- see Note [lower instance priority]
 instance has_finite_products_of_has_products [has_products.{v} C] : has_finite_products.{v} C :=
 { has_limits_of_shape := λ J _, by apply_instance }
+@[priority 100] -- see Note [lower instance priority]
 instance has_finite_coproducts_of_has_coproducts [has_coproducts.{v} C] : has_finite_coproducts.{v} C :=
 { has_colimits_of_shape := λ J _, by apply_instance }
 
+@[priority 100] -- see Note [lower instance priority]
 instance has_finite_products_of_has_finite_limits [has_finite_limits.{v} C] : has_finite_products.{v} C :=
 { has_limits_of_shape := λ J _ _, by { resetI, apply_instance } }
+@[priority 100] -- see Note [lower instance priority]
 instance has_finite_coproducts_of_has_finite_colimits [has_finite_colimits.{v} C] : has_finite_coproducts.{v} C :=
 { has_colimits_of_shape := λ J _ _, by { resetI, apply_instance } }
 

--- a/src/category_theory/limits/shapes/terminal.lean
+++ b/src/category_theory/limits/shapes/terminal.lean
@@ -22,10 +22,12 @@ class has_initial :=
 
 attribute [instance] has_terminal.has_limits_of_shape has_initial.has_colimits_of_shape
 
+@[priority 100] -- see Note [lower instance priority]
 instance [has_finite_products.{v} C] : has_terminal.{v} C :=
 { has_limits_of_shape :=
   { has_limit := λ F,
       has_limit_of_equivalence_comp ((functor.empty.{v} (discrete pempty.{v+1})).as_equivalence.symm) } }
+@[priority 100] -- see Note [lower instance priority]
 instance [has_finite_coproducts.{v} C] : has_initial.{v} C :=
 { has_colimits_of_shape :=
   { has_colimit := λ F,

--- a/src/category_theory/monad/adjunction.lean
+++ b/src/category_theory/monad/adjunction.lean
@@ -5,6 +5,7 @@ Authors: Scott Morrison
 -/
 import category_theory.monad.algebra
 import category_theory.adjunction.fully_faithful
+set_option default_priority 100 -- see Note [default priority]
 
 namespace category_theory
 open category
@@ -137,6 +138,7 @@ end reflective
 
 /-- Any reflective inclusion has a monadic right adjoint.
     cf Prop 5.3.3 of [Riehl][riehl2017] -/
+@[priority 100] -- see Note [lower instance priority]
 instance monadic_of_reflective [reflective R] : monadic_right_adjoint R :=
 { eqv := equivalence.equivalence_of_fully_faithfully_ess_surj _ }
 

--- a/src/category_theory/monad/adjunction.lean
+++ b/src/category_theory/monad/adjunction.lean
@@ -5,7 +5,6 @@ Authors: Scott Morrison
 -/
 import category_theory.monad.algebra
 import category_theory.adjunction.fully_faithful
-set_option default_priority 100 -- see Note [default priority]
 
 namespace category_theory
 open category
@@ -57,16 +56,19 @@ def comparison_forget [is_right_adjoint R] : comparison R ⋙ forget ((left_adjo
 
 end monad
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A functor is *reflective*, or *a reflective inclusion*, if it is fully faithful and right adjoint. -/
 class reflective (R : D ⥤ C) extends is_right_adjoint R, full R, faithful R.
-
-instance μ_iso_of_reflective [reflective R] : is_iso (μ_ ((left_adjoint R) ⋙ R)) :=
-by { dsimp [adjunction.monad], apply_instance }
 
 /-- A right adjoint functor `R : D ⥤ C` is *monadic* if the comparison function `monad.comparison R` from `D` to the
 category of Eilenberg-Moore algebras for the adjunction is an equivalence. -/
 class monadic_right_adjoint (R : D ⥤ C) extends is_right_adjoint R :=
 (eqv : is_equivalence (monad.comparison R))
+end prio
+
+instance μ_iso_of_reflective [reflective R] : is_iso (μ_ ((left_adjoint R) ⋙ R)) :=
+by { dsimp [adjunction.monad], apply_instance }
 
 attribute [instance] monadic_right_adjoint.eqv
 

--- a/src/computability/primrec.lean
+++ b/src/computability/primrec.lean
@@ -248,9 +248,8 @@ instance prod {α β} [primcodable α] [primcodable β] : primcodable (α × β)
   (pair right ((primcodable.prim α).comp left))).of_eq $
 λ n, begin
   simp [nat.unpaired],
-  cases decode α n.unpair.1; simp, {refl},
-  cases decode β n.unpair.2; simp, {refl},
-  refl
+  cases decode α n.unpair.1, { simp },
+  cases decode β n.unpair.2; simp
 end⟩
 
 end primcodable

--- a/src/computability/primrec.lean
+++ b/src/computability/primrec.lean
@@ -18,6 +18,7 @@ for this.)
 import data.equiv.list
 
 open denumerable encodable
+set_option default_priority 100 -- see Note [default priority]
 
 namespace nat
 

--- a/src/computability/primrec.lean
+++ b/src/computability/primrec.lean
@@ -18,7 +18,6 @@ for this.)
 import data.equiv.list
 
 open denumerable encodable
-set_option default_priority 100 -- see Note [default priority]
 
 namespace nat
 
@@ -101,10 +100,13 @@ end primrec
 
 end nat
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A `primcodable` type is an `encodable` type for which
   the encode/decode functions are primitive recursive. -/
 class primcodable (α : Type*) extends encodable α :=
 (prim : nat.primrec (λ n, encodable.encode (decode n)))
+end prio
 
 namespace primcodable
 open nat.primrec

--- a/src/data/analysis/topology.lean
+++ b/src/data/analysis/topology.lean
@@ -46,7 +46,7 @@ def of_equiv (E : σ ≃ τ) : ctop α σ → ctop α τ
 
 end
 
-instance to_topsp (F : ctop α σ) : topological_space α :=
+def to_topsp (F : ctop α σ) : topological_space α :=
 topological_space.generate_from (set.range F.f)
 
 theorem to_topsp_is_topological_basis (F : ctop α σ) :

--- a/src/data/analysis/topology.lean
+++ b/src/data/analysis/topology.lean
@@ -46,6 +46,7 @@ def of_equiv (E : σ ≃ τ) : ctop α σ → ctop α τ
 
 end
 
+/-- Every `ctop` is a topological space. -/
 def to_topsp (F : ctop α σ) : topological_space α :=
 topological_space.generate_from (set.range F.f)
 

--- a/src/data/equiv/denumerable.lean
+++ b/src/data/equiv/denumerable.lean
@@ -9,6 +9,7 @@ from nat, where the functions are known inverses of each other.
 -/
 import data.equiv.encodable data.sigma data.fintype data.list.min_max
 open nat
+set_option default_priority 100 -- see Note [default priority]
 
 /-- A denumerable type is one which is (constructively) bijective with ℕ.
   Although we already have a name for this property, namely `α ≃ ℕ`,

--- a/src/data/equiv/denumerable.lean
+++ b/src/data/equiv/denumerable.lean
@@ -9,13 +9,15 @@ from nat, where the functions are known inverses of each other.
 -/
 import data.equiv.encodable data.sigma data.fintype data.list.min_max
 open nat
-set_option default_priority 100 -- see Note [default priority]
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A denumerable type is one which is (constructively) bijective with ℕ.
   Although we already have a name for this property, namely `α ≃ ℕ`,
   we are here interested in using it as a typeclass. -/
 class denumerable (α : Type*) extends encodable α :=
 (decode_inv : ∀ n, ∃ a ∈ decode n, encode a = n)
+end prio
 
 namespace denumerable
 

--- a/src/data/fintype.lean
+++ b/src/data/fintype.lean
@@ -470,9 +470,9 @@ theorem fintype.card_subtype_le [fintype α] (p : α → Prop) [decidable_pred p
   fintype.card {x // p x} ≤ fintype.card α :=
 by rw fintype.subtype_card; exact card_le_of_subset (subset_univ _)
 
-theorem fintype.card_subtype_lt [fintype α] {p : α → Prop} [decidable_pred p] 
+theorem fintype.card_subtype_lt [fintype α] {p : α → Prop} [decidable_pred p]
   {x : α} (hx : ¬ p x) : fintype.card {x // p x} < fintype.card α :=
-by rw [fintype.subtype_card]; exact finset.card_lt_card 
+by rw [fintype.subtype_card]; exact finset.card_lt_card
   ⟨subset_univ _, classical.not_forall.2 ⟨x, by simp [*, set.mem_def]⟩⟩
 
 instance psigma.fintype {α : Type*} {β : α → Type*} [fintype α] [∀ a, fintype (β a)] :
@@ -761,6 +761,7 @@ namespace infinite
 lemma exists_not_mem_finset [infinite α] (s : finset α) : ∃ x, x ∉ s :=
 classical.not_forall.1 $ λ h, not_fintype ⟨s, h⟩
 
+@[priority 100] -- see Note [lower instance priority]
 instance nonempty (α : Type*) [infinite α] : nonempty α :=
 nonempty_of_exists (exists_not_mem_finset (∅ : finset α))
 

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1194,13 +1194,16 @@ funext $ int.eq_cast f (is_ring_hom.map_one f) (λ _ _, is_ring_hom.map_add f)
 @[simp, squash_cast] theorem cast_id (n : ℤ) : ↑n = n :=
 (eq_cast id rfl (λ _ _, rfl) n).symm
 
-@[simp, move_cast] theorem cast_min [decidable_linear_ordered_comm_ring α] {a b : ℤ} : (↑(min a b) : α) = min a b :=
+@[simp, move_cast] theorem cast_min [decidable_linear_ordered_comm_ring α] {a b : ℤ} :
+  (↑(min a b) : α) = min a b :=
 by by_cases a ≤ b; simp [h, min]
 
-@[simp, move_cast] theorem cast_max [decidable_linear_ordered_comm_ring α] {a b : ℤ} : (↑(max a b) : α) = max a b :=
+@[simp, move_cast] theorem cast_max [decidable_linear_ordered_comm_ring α] {a b : ℤ} :
+  (↑(max a b) : α) = max a b :=
 by by_cases a ≤ b; simp [h, max]
 
-@[simp, move_cast] theorem cast_abs [decidable_linear_ordered_comm_ring α] {q : ℤ} : ((abs q : ℤ) : α) = abs q :=
+@[simp, move_cast] theorem cast_abs [decidable_linear_ordered_comm_ring α] {q : ℤ} :
+  ((abs q : ℤ) : α) = abs q :=
 by simp [abs]
 
 end cast

--- a/src/data/string/basic.lean
+++ b/src/data/string/basic.lean
@@ -25,7 +25,7 @@ using_well_founded {rel_tac :=
 instance has_lt' : has_lt string :=
 ⟨λ s₁ s₂, ltb s₁.mk_iterator s₂.mk_iterator⟩
 
-instance decidable_lt : @decidable_rel string (<) := by apply_instance
+instance decidable_lt : @decidable_rel string (<) := by apply_instance -- short-circuit type class inference
 
 @[simp] theorem lt_iff_to_list_lt :
   ∀ {s₁ s₂ : string}, s₁ < s₂ ↔ s₁.to_list < s₂.to_list
@@ -48,7 +48,7 @@ instance decidable_lt : @decidable_rel string (<) := by apply_instance
 
 instance has_le : has_le string := ⟨λ s₁ s₂, ¬ s₂ < s₁⟩
 
-instance decidable_le : @decidable_rel string (≤) := by apply_instance
+instance decidable_le : @decidable_rel string (≤) := by apply_instance -- short-circuit type class inference
 
 @[simp] theorem le_iff_to_list_le
   {s₁ s₂ : string} : s₁ ≤ s₂ ↔ s₁.to_list ≤ s₂.to_list :=

--- a/src/field_theory/subfield.lean
+++ b/src/field_theory/subfield.lean
@@ -30,18 +30,24 @@ instance is_subfield.field [is_subfield S] : discrete_field S :=
 instance univ.is_subfield : is_subfield (@set.univ F) :=
 { inv_mem := by intros; trivial }
 
+/- note: in the next two declarations, if we let type-class inference figure out the instance
+  `is_ring_hom.is_subring_preimage` then that instance only applies when particular instances of
+  `is_add_subgroup _` and `is_submonoid _` are chosen (which are not the default ones).
+  If we specify it explicitly, then it doesn't complain. -/
 instance preimage.is_subfield {K : Type*} [discrete_field K]
   (f : F → K) [is_ring_hom f] (s : set K) [is_subfield s] : is_subfield (f ⁻¹' s) :=
 { inv_mem := λ a ha0 (ha : f a ∈ s), show f a⁻¹ ∈ s,
-    by rw [is_field_hom.map_inv' f ha0];
-      exact is_subfield.inv_mem ((is_field_hom.map_ne_zero f).2 ha0) ha }
+    by { rw [is_field_hom.map_inv' f ha0],
+         exact is_subfield.inv_mem ((is_field_hom.map_ne_zero f).2 ha0) ha },
+  ..is_ring_hom.is_subring_preimage f s }
 
 instance image.is_subfield {K : Type*} [discrete_field K]
   (f : F → K) [is_ring_hom f] (s : set F) [is_subfield s] : is_subfield (f '' s) :=
 { inv_mem := λ a ha0 ⟨x, hx⟩,
     have hx0 : x ≠ 0, from λ hx0, ha0 (hx.2 ▸ hx0.symm ▸ is_ring_hom.map_zero f),
     ⟨x⁻¹, is_subfield.inv_mem hx0 hx.1,
-    by rw [← hx.2, is_field_hom.map_inv' f hx0]; refl⟩ }
+    by { rw [← hx.2, is_field_hom.map_inv' f hx0], refl }⟩,
+  ..is_ring_hom.is_subring_image f s }
 
 instance range.is_subfield {K : Type*} [discrete_field K]
   (f : F → K) [is_ring_hom f] : is_subfield (set.range f) :=

--- a/src/field_theory/subfield.lean
+++ b/src/field_theory/subfield.lean
@@ -5,12 +5,14 @@ Authors: Andreas Swerdlow
 -/
 
 import ring_theory.subring
-set_option default_priority 100 -- see Note [default priority]
 
 variables {F : Type*} [discrete_field F] (S : set F)
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 class is_subfield extends is_subring S : Prop :=
 (inv_mem : ∀ {x : F}, x ≠ 0 → x ∈ S → x⁻¹ ∈ S)
+end prio
 
 instance is_subfield.field [is_subfield S] : discrete_field S :=
 { inv := λ x, ⟨x⁻¹, if hx0 : x = 0

--- a/src/field_theory/subfield.lean
+++ b/src/field_theory/subfield.lean
@@ -5,6 +5,7 @@ Authors: Andreas Swerdlow
 -/
 
 import ring_theory.subring
+set_option default_priority 100 -- see Note [default priority]
 
 variables {F : Type*} [discrete_field F] (S : set F)
 

--- a/src/geometry/manifold/real_instances.lean
+++ b/src/geometry/manifold/real_instances.lean
@@ -55,6 +55,7 @@ section
 local attribute [reducible] euclidean_space euclidean_half_space euclidean_quadrant
 variable {n : ℕ}
 
+ -- short-circuit type class inference
 instance : vector_space ℝ (euclidean_space n) := by apply_instance
 instance : normed_group (euclidean_space n) := by apply_instance
 instance : normed_space ℝ (euclidean_space n) := by apply_instance

--- a/src/geometry/manifold/smooth_manifold_with_corners.lean
+++ b/src/geometry/manifold/smooth_manifold_with_corners.lean
@@ -102,7 +102,6 @@ real and complex manifolds).
 -/
 
 noncomputable theory
-set_option default_priority 100 -- see Note [default priority]
 
 universes u v w u' v' w'
 

--- a/src/geometry/manifold/smooth_manifold_with_corners.lean
+++ b/src/geometry/manifold/smooth_manifold_with_corners.lean
@@ -102,6 +102,7 @@ real and complex manifolds).
 -/
 
 noncomputable theory
+set_option default_priority 100 -- see Note [default priority]
 
 universes u v w u' v' w'
 

--- a/src/group_theory/group_action.lean
+++ b/src/group_theory/group_action.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
 import data.set.finite group_theory.coset
-set_option default_priority 100 -- see Note [default priority]
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
@@ -14,10 +13,13 @@ class has_scalar (α : Type u) (γ : Type v) := (smul : α → γ → γ)
 
 infixr ` • `:73 := has_scalar.smul
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- Typeclass for multiplictive actions by monoids. This generalizes group actions. -/
 class mul_action (α : Type u) (β : Type v) [monoid α] extends has_scalar α β :=
 (one_smul : ∀ b : β, (1 : α) • b = b)
 (mul_smul : ∀ (x y : α) (b : β), (x * y) • b = x • y • b)
+end prio
 
 section
 variables [monoid α] [mul_action α β]
@@ -170,10 +172,13 @@ mul_action.comp_hom (quotient H) (subtype.val : I → α)
 
 end mul_action
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- Typeclass for multiplicative actions on additive structures. This generalizes group modules. -/
 class distrib_mul_action (α : Type u) (β : Type v) [monoid α] [add_monoid β] extends mul_action α β :=
 (smul_add : ∀(r : α) (x y : β), r • (x + y) = r • x + r • y)
 (smul_zero {} : ∀(r : α), r • (0 : β) = 0)
+end prio
 
 section
 variables [monoid α] [add_monoid β] [distrib_mul_action α β]

--- a/src/group_theory/group_action.lean
+++ b/src/group_theory/group_action.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
 import data.set.finite group_theory.coset
+set_option default_priority 100 -- see Note [default priority]
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Mitchell Rowett, Scott Morrison, Johan Commelin, Mario
 -/
 import group_theory.submonoid
 open set function
+set_option default_priority 100 -- see Note [default priority]
 
 variables {α : Type*} {β : Type*} {a a₁ a₂ b c: α}
 

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -6,7 +6,6 @@ Authors: Johannes Hölzl, Mitchell Rowett, Scott Morrison, Johan Commelin, Mario
 -/
 import group_theory.submonoid
 open set function
-set_option default_priority 100 -- see Note [default priority]
 
 variables {α : Type*} {β : Type*} {a a₁ a₂ b c: α}
 
@@ -19,6 +18,8 @@ assume a₁ a₂ h,
 have a⁻¹ * a * a₁ = a⁻¹ * a * a₂, by rw [mul_assoc, mul_assoc, h],
 by rwa [inv_mul_self, one_mul, one_mul] at this
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- `s` is an additive subgroup: a set containing 0 and closed under addition and negation. -/
 class is_add_subgroup (s : set β) extends is_add_submonoid s : Prop :=
 (neg_mem {a} : a ∈ s → -a ∈ s)
@@ -27,6 +28,7 @@ class is_add_subgroup (s : set β) extends is_add_submonoid s : Prop :=
 @[to_additive is_add_subgroup]
 class is_subgroup (s : set α) extends is_submonoid s : Prop :=
 (inv_mem {a} : a ∈ s → a⁻¹ ∈ s)
+end prio
 
 instance additive.is_add_subgroup
   (s : set α) [is_subgroup s] : @is_add_subgroup (additive α) _ s :=
@@ -160,12 +162,15 @@ theorem is_add_subgroup.sub_mem {α} [add_group α] (s : set α) [is_add_subgrou
   (ha : a ∈ s) (hb : b ∈ s) : a - b ∈ s :=
 is_add_submonoid.add_mem ha (is_add_subgroup.neg_mem hb)
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 class normal_add_subgroup [add_group α] (s : set α) extends is_add_subgroup s : Prop :=
 (normal : ∀ n ∈ s, ∀ g : α, g + n - g ∈ s)
 
 @[to_additive normal_add_subgroup]
 class normal_subgroup [group α] (s : set α) extends is_subgroup s : Prop :=
 (normal : ∀ n ∈ s, ∀ g : α, g * n * g⁻¹ ∈ s)
+end prio
 
 @[to_additive normal_add_subgroup_of_add_comm_group]
 lemma normal_subgroup_of_comm_group [comm_group α] (s : set α) [hs : is_subgroup s] :

--- a/src/logic/relator.lean
+++ b/src/logic/relator.lean
@@ -75,6 +75,8 @@ assume p q h r s l, imp_congr h l
 lemma rel_not : (iff ⇒ iff) not not :=
 assume p q h, not_congr h
 
+@[priority 100] -- see Note [lower instance priority]
+-- (this is an instance is always applies, since the relation is an out-param)
 instance bi_total_eq {α : Type u₁} : relator.bi_total (@eq α) :=
 ⟨assume a, ⟨a, rfl⟩, assume a, ⟨a, rfl⟩⟩
 

--- a/src/logic/unique.lean
+++ b/src/logic/unique.lean
@@ -19,7 +19,7 @@ instance punit.unique : unique punit.{u} :=
 
 instance fin.unique : unique (fin 1) :=
 { default := 0,
-  uniq := λ ⟨n, hn⟩, fin.eq_of_veq 
+  uniq := λ ⟨n, hn⟩, fin.eq_of_veq
     (nat.eq_zero_of_le_zero (nat.le_of_lt_succ hn)) }
 
 namespace unique
@@ -29,12 +29,14 @@ section
 
 variables [unique α]
 
+@[priority 100] -- see Note [lower instance priority]
 instance : inhabited α := to_inhabited ‹unique α›
 
 lemma eq_default (a : α) : a = default α := uniq _ a
 
 lemma default_eq (a : α) : default α = a := (uniq _ a).symm
 
+@[priority 100] -- see Note [lower instance priority]
 instance : subsingleton α := ⟨λ a b, by rw [eq_default a, eq_default b]⟩
 
 lemma forall_iff {p : α → Prop} : (∀ a, p a) ↔ p (default α) :=

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -21,6 +21,7 @@ import topology.instances.ennreal
        measure_theory.outer_measure
 
 noncomputable theory
+set_option default_priority 100 -- see Note [default priority]
 
 open classical set lattice filter finset function
 open_locale classical topological_space

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -21,7 +21,6 @@ import topology.instances.ennreal
        measure_theory.outer_measure
 
 noncomputable theory
-set_option default_priority 100 -- see Note [default priority]
 
 open classical set lattice filter finset function
 open_locale classical topological_space
@@ -792,10 +791,13 @@ end is_complete
 
 namespace measure_theory
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A measure space is a measurable space equipped with a
   measure, referred to as `volume`. -/
 class measure_space (α : Type*) extends measurable_space α :=
 (μ {} : measure α)
+end prio
 
 section measure_space
 variables {α : Type*} [measure_space α] {s₁ s₂ : set α}

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -5,7 +5,6 @@ Authors: Jeremy Avigad, Mario Carneiro
 -/
 import logic.basic data.sum data.set.basic algebra.order
 open function
-set_option default_priority 100 -- see Note [default priority]
 
 /- TODO: automatic construction of dual definitions / theorems -/
 
@@ -331,9 +330,12 @@ def partial_order_of_SO (r) [is_strict_order α r] : partial_order α :=
       (asymm h)⟩,
     λ ⟨h₁, h₂⟩, h₁.resolve_left (λ e, h₂ $ e ▸ or.inl rfl)⟩ }
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- This is basically the same as `is_strict_total_order`, but that definition is
   in Type (probably by mistake) and also has redundant assumptions. -/
 @[algebra] class is_strict_total_order' (α : Type u) (lt : α → α → Prop) extends is_trichotomous α lt, is_strict_order α lt : Prop.
+end prio
 
 /-- Construct a linear order from a `is_strict_total_order'` relation -/
 def linear_order_of_STO' (r) [is_strict_total_order' α r] : linear_order α :=
@@ -405,9 +407,12 @@ instance is_extensional_of_is_strict_total_order'
   .resolve_left $ mt (H _).2 (irrefl a))
   .resolve_right $ mt (H _).1 (irrefl b)⟩
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A well order is a well-founded linear order. -/
 @[algebra] class is_well_order (α : Type u) (r : α → α → Prop) extends is_strict_total_order' α r : Prop :=
 (wf : well_founded r)
+end prio
 
 @[priority 100] -- see Note [lower instance priority]
 instance is_well_order.is_strict_total_order {α} (r : α → α → Prop) [is_well_order α r] : is_strict_total_order α r := by apply_instance
@@ -558,5 +563,8 @@ lemma directed_of_mono {ι} [decidable_linear_order ι] (f : ι → α)
   (H : ∀ i j, i ≤ j → f i ≼ f j) : directed (≼) f :=
 λ a b, ⟨max a b, H _ _ (le_max_left _ _), H _ _ (le_max_right _ _)⟩
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 class directed_order (α : Type u) extends preorder α :=
 (directed : ∀ i j : α, ∃ k, i ≤ k ∧ j ≤ k)
+end prio

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -5,6 +5,7 @@ Authors: Jeremy Avigad, Mario Carneiro
 -/
 import logic.basic data.sum data.set.basic algebra.order
 open function
+set_option default_priority 100 -- see Note [default priority]
 
 /- TODO: automatic construction of dual definitions / theorems -/
 
@@ -376,6 +377,7 @@ theorem is_strict_weak_order_of_is_order_connected [is_asymm α r]
     ⟨is_order_connected.neg_trans h₁ h₃, is_order_connected.neg_trans h₄ h₂⟩,
   ..@is_irrefl_of_is_asymm α r _ }
 
+@[priority 100] -- see Note [lower instance priority]
 instance is_order_connected_of_is_strict_total_order'
   [is_strict_total_order' α r] : is_order_connected α r :=
 ⟨λ a b c h, (trichotomous _ _).imp_right (λ o,
@@ -396,6 +398,7 @@ instance [linear_order α] : is_strict_weak_order α (<) := by apply_instance
 @[algebra] class is_extensional (α : Type u) (r : α → α → Prop) : Prop :=
 (ext : ∀ a b, (∀ x, r x a ↔ r x b) → a = b)
 
+@[priority 100] -- see Note [lower instance priority]
 instance is_extensional_of_is_strict_total_order'
   [is_strict_total_order' α r] : is_extensional α r :=
 ⟨λ a b H, ((@trichotomous _ r _ a b)
@@ -406,11 +409,17 @@ instance is_extensional_of_is_strict_total_order'
 @[algebra] class is_well_order (α : Type u) (r : α → α → Prop) extends is_strict_total_order' α r : Prop :=
 (wf : well_founded r)
 
+@[priority 100] -- see Note [lower instance priority]
 instance is_well_order.is_strict_total_order {α} (r : α → α → Prop) [is_well_order α r] : is_strict_total_order α r := by apply_instance
+@[priority 100] -- see Note [lower instance priority]
 instance is_well_order.is_extensional {α} (r : α → α → Prop) [is_well_order α r] : is_extensional α r := by apply_instance
+@[priority 100] -- see Note [lower instance priority]
 instance is_well_order.is_trichotomous {α} (r : α → α → Prop) [is_well_order α r] : is_trichotomous α r := by apply_instance
+@[priority 100] -- see Note [lower instance priority]
 instance is_well_order.is_trans {α} (r : α → α → Prop) [is_well_order α r] : is_trans α r := by apply_instance
+@[priority 100] -- see Note [lower instance priority]
 instance is_well_order.is_irrefl {α} (r : α → α → Prop) [is_well_order α r] : is_irrefl α r := by apply_instance
+@[priority 100] -- see Note [lower instance priority]
 instance is_well_order.is_asymm {α} (r : α → α → Prop) [is_well_order α r] : is_asymm α r := by apply_instance
 
 noncomputable def decidable_linear_order_of_is_well_order (r : α → α → Prop) [is_well_order α r] :

--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -7,6 +7,7 @@ Type class hierarchy for Boolean algebras.
 -/
 import order.bounded_lattice
 set_option old_structure_cmd true
+set_option default_priority 100 -- see Note [default priority]
 
 namespace lattice
 universes u

--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -7,12 +7,13 @@ Type class hierarchy for Boolean algebras.
 -/
 import order.bounded_lattice
 set_option old_structure_cmd true
-set_option default_priority 100 -- see Note [default priority]
 
 namespace lattice
 universes u
 variables {α : Type u} {w x y z : α}
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A boolean algebra is a bounded distributive lattice with a
   complementation operation `-` such that `x ⊓ - x = ⊥` and `x ⊔ - x = ⊤`.
   This is a generalization of (classical) logic of propositions, or
@@ -21,6 +22,7 @@ class boolean_algebra α extends bounded_distrib_lattice α, has_neg α, has_sub
 (inf_neg_eq_bot : ∀x:α, x ⊓ - x = ⊥)
 (sup_neg_eq_top : ∀x:α, x ⊔ - x = ⊤)
 (sub_eq : ∀x y:α, x - y = x ⊓ - y)
+end prio
 
 section boolean_algebra
 variables [boolean_algebra α]

--- a/src/order/bounded_lattice.lean
+++ b/src/order/bounded_lattice.lean
@@ -12,6 +12,7 @@ import order.lattice data.option.basic
        tactic.pi_instances
 
 set_option old_structure_cmd true
+set_option default_priority 100 -- see Note [default priority]
 
 universes u v
 
@@ -217,15 +218,19 @@ end semilattice_inf_bot
   of all finite suprema and infima, taking `inf ∅ = ⊤` and `sup ∅ = ⊥`. -/
 class bounded_lattice (α : Type u) extends lattice α, order_top α, order_bot α
 
+@[priority 100] -- see Note [lower instance priority]
 instance semilattice_inf_top_of_bounded_lattice (α : Type u) [bl : bounded_lattice α] : semilattice_inf_top α :=
 { le_top := assume x, @le_top α _ x, ..bl }
 
+@[priority 100] -- see Note [lower instance priority]
 instance semilattice_inf_bot_of_bounded_lattice (α : Type u) [bl : bounded_lattice α] : semilattice_inf_bot α :=
 { bot_le := assume x, @bot_le α _ x, ..bl }
 
+@[priority 100] -- see Note [lower instance priority]
 instance semilattice_sup_top_of_bounded_lattice (α : Type u) [bl : bounded_lattice α] : semilattice_sup_top α :=
 { le_top := assume x, @le_top α _ x, ..bl }
 
+@[priority 100] -- see Note [lower instance priority]
 instance semilattice_sup_bot_of_bounded_lattice (α : Type u) [bl : bounded_lattice α] : semilattice_sup_bot α :=
 { bot_le := assume x, @bot_le α _ x, ..bl }
 

--- a/src/order/bounded_lattice.lean
+++ b/src/order/bounded_lattice.lean
@@ -12,7 +12,6 @@ import order.lattice data.option.basic
        tactic.pi_instances
 
 set_option old_structure_cmd true
-set_option default_priority 100 -- see Note [default priority]
 
 universes u v
 
@@ -27,11 +26,14 @@ class has_bot (α : Type u) := (bot : α)
 notation `⊤` := has_top.top _
 notation `⊥` := has_bot.bot _
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- An `order_top` is a partial order with a maximal element.
   (We could state this on preorders, but then it wouldn't be unique
   so distinguishing one would seem odd.) -/
 class order_top (α : Type u) extends has_top α, partial_order α :=
 (le_top : ∀ a : α, a ≤ ⊤)
+end prio
 
 section order_top
 variables [order_top α] {a b : α}
@@ -80,11 +82,14 @@ begin
   cases A; cases B; injection this; congr'
 end
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- An `order_bot` is a partial order with a minimal element.
   (We could state this on preorders, but then it wouldn't be unique
   so distinguishing one would seem odd.) -/
 class order_bot (α : Type u) extends has_bot α, partial_order α :=
 (bot_le : ∀ a : α, ⊥ ≤ a)
+end prio
 
 section order_bot
 variables [order_bot α] {a b : α}
@@ -135,8 +140,11 @@ begin
   cases A; cases B; injection this; congr'
 end
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A `semilattice_sup_top` is a semilattice with top and join. -/
 class semilattice_sup_top (α : Type u) extends order_top α, semilattice_sup α
+end prio
 
 section semilattice_sup_top
 variables [semilattice_sup_top α] {a : α}
@@ -149,8 +157,11 @@ sup_of_le_right le_top
 
 end semilattice_sup_top
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A `semilattice_sup_bot` is a semilattice with bottom and join. -/
 class semilattice_sup_bot (α : Type u) extends order_bot α, semilattice_sup α
+end prio
 
 section semilattice_sup_bot
 variables [semilattice_sup_bot α] {a b : α}
@@ -180,8 +191,11 @@ instance nat.subtype.semilattice_sup_bot (s : set ℕ) [decidable_pred s] [h : n
   ..subtype.linear_order s,
   ..lattice.lattice_of_decidable_linear_order }
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A `semilattice_inf_top` is a semilattice with top and meet. -/
 class semilattice_inf_top (α : Type u) extends order_top α, semilattice_inf α
+end prio
 
 section semilattice_inf_top
 variables [semilattice_inf_top α] {a b : α}
@@ -197,8 +211,11 @@ by rw [eq_top_iff, le_inf_iff]; simp
 
 end semilattice_inf_top
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A `semilattice_inf_bot` is a semilattice with bottom and meet. -/
 class semilattice_inf_bot (α : Type u) extends order_bot α, semilattice_inf α
+end prio
 
 section semilattice_inf_bot
 variables [semilattice_inf_bot α] {a : α}
@@ -213,10 +230,13 @@ end semilattice_inf_bot
 
 /- Bounded lattices -/
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A bounded lattice is a lattice with a top and bottom element,
   denoted `⊤` and `⊥` respectively. This allows for the interpretation
   of all finite suprema and infima, taking `inf ∅ = ⊤` and `sup ∅ = ⊥`. -/
 class bounded_lattice (α : Type u) extends lattice α, order_top α, order_bot α
+end prio
 
 @[priority 100] -- see Note [lower instance priority]
 instance semilattice_inf_top_of_bounded_lattice (α : Type u) [bl : bounded_lattice α] : semilattice_inf_top α :=
@@ -246,8 +266,11 @@ begin
   cases A; cases B; injection H1; injection H2; injection H3; congr'
 end
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A bounded distributive lattice is exactly what it sounds like. -/
 class bounded_distrib_lattice α extends distrib_lattice α, bounded_lattice α
+end prio
 
 lemma inf_eq_bot_iff_le_compl {α : Type u} [bounded_distrib_lattice α] {a b c : α}
   (h₁ : b ⊔ c = ⊤) (h₂ : b ⊓ c = ⊥) : a ⊓ b = ⊥ ↔ a ≤ c :=

--- a/src/order/complete_boolean_algebra.lean
+++ b/src/order/complete_boolean_algebra.lean
@@ -8,6 +8,7 @@ Theory of complete Boolean algebras.
 import order.complete_lattice order.boolean_algebra data.set.basic
 
 set_option old_structure_cmd true
+set_option default_priority 100 -- see Note [default priority]
 
 universes u v w
 variables {α : Type u} {β : Type v} {ι : Sort w}
@@ -87,6 +88,7 @@ end
 
 end complete_distrib_lattice
 
+@[priority 100] -- see Note [lower instance priority]
 instance [d : complete_distrib_lattice α] : bounded_distrib_lattice α :=
 { le_sup_inf := assume x y z,
     calc (x ⊔ y) ⊓ (x ⊔ z) ≤ (⨅ b ∈ ({z, y} : set α), x ⊔ b) :

--- a/src/order/complete_boolean_algebra.lean
+++ b/src/order/complete_boolean_algebra.lean
@@ -8,13 +8,14 @@ Theory of complete Boolean algebras.
 import order.complete_lattice order.boolean_algebra data.set.basic
 
 set_option old_structure_cmd true
-set_option default_priority 100 -- see Note [default priority]
 
 universes u v w
 variables {α : Type u} {β : Type v} {ι : Sort w}
 
 namespace lattice
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A complete distributive lattice is a bit stronger than the name might
   suggest; perhaps completely distributive lattice is more descriptive,
   as this class includes a requirement that the lattice join
@@ -22,6 +23,7 @@ namespace lattice
 class complete_distrib_lattice α extends complete_lattice α :=
 (infi_sup_le_sup_Inf : ∀a s, (⨅ b ∈ s, a ⊔ b) ≤ a ⊔ Inf s)
 (inf_Sup_le_supr_inf : ∀a s, a ⊓ Sup s ≤ (⨆ b ∈ s, a ⊓ b))
+end prio
 
 section complete_distrib_lattice
 variables [complete_distrib_lattice α] {a b : α} {s t : set α}
@@ -97,8 +99,11 @@ instance [d : complete_distrib_lattice α] : bounded_distrib_lattice α :=
       ... = x ⊔ y ⊓ z : by rw insert_of_has_insert; simp,
   ..d }
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A complete boolean algebra is a completely distributive boolean algebra. -/
 class complete_boolean_algebra α extends boolean_algebra α, complete_distrib_lattice α
+end prio
 
 section complete_boolean_algebra
 variables [complete_boolean_algebra α] {a b : α} {s : set α} {f : ι → α}

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -8,6 +8,7 @@ Theory of complete lattices.
 import order.bounded_lattice data.set.basic tactic.pi_instances
 
 set_option old_structure_cmd true
+set_option default_priority 100 -- see Note [default priority]
 open set
 
 namespace lattice

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -8,7 +8,6 @@ Theory of complete lattices.
 import order.bounded_lattice data.set.basic tactic.pi_instances
 
 set_option old_structure_cmd true
-set_option default_priority 100 -- see Note [default priority]
 open set
 
 namespace lattice
@@ -34,6 +33,8 @@ lemma has_Sup_to_nonempty (α) [has_Sup α] : nonempty α := ⟨Sup ∅⟩
 notation `⨆` binders `, ` r:(scoped f, supr f) := r
 notation `⨅` binders `, ` r:(scoped f, infi f) := r
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A complete lattice is a bounded lattice which
   has suprema and infima for every subset. -/
 class complete_lattice (α : Type u) extends bounded_lattice α, has_Sup α, has_Inf α :=
@@ -44,6 +45,7 @@ class complete_lattice (α : Type u) extends bounded_lattice α, has_Sup α, has
 
 /-- A complete linear order is a linear order whose lattice structure is complete. -/
 class complete_linear_order (α : Type u) extends complete_lattice α, decidable_linear_order α
+end prio
 
 section
 variables [complete_lattice α] {s t : set α} {a b : α}

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -27,7 +27,6 @@ import
   tactic.finish data.set.finite
 
 set_option old_structure_cmd true
-set_option default_priority 100 -- see Note [default priority]
 
 open preorder set lattice
 
@@ -217,6 +216,8 @@ end semilattice_inf
 
 
 namespace lattice
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A conditionally complete lattice is a lattice in which
 every nonempty subset which is bounded above has a supremum, and
 every nonempty subset which is bounded below has an infimum.
@@ -238,6 +239,7 @@ class conditionally_complete_linear_order (α : Type u)
 class conditionally_complete_linear_order_bot (α : Type u)
   extends conditionally_complete_lattice α, decidable_linear_order α, order_bot α :=
 (cSup_empty : Sup ∅ = ⊥)
+end prio
 
 /- A complete lattice is a conditionally complete lattice, as there are no restrictions
 on the properties of Inf and Sup in a complete lattice.-/

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -27,6 +27,7 @@ import
   tactic.finish data.set.finite
 
 set_option old_structure_cmd true
+set_option default_priority 100 -- see Note [default priority]
 
 open preorder set lattice
 
@@ -241,6 +242,7 @@ class conditionally_complete_linear_order_bot (α : Type u)
 /- A complete lattice is a conditionally complete lattice, as there are no restrictions
 on the properties of Inf and Sup in a complete lattice.-/
 
+@[priority 100] -- see Note [lower instance priority]
 instance conditionally_complete_lattice_of_complete_lattice [complete_lattice α]:
   conditionally_complete_lattice α :=
 { le_cSup := by intros; apply le_Sup; assumption,
@@ -249,6 +251,7 @@ instance conditionally_complete_lattice_of_complete_lattice [complete_lattice α
   le_cInf := by intros; apply le_Inf; assumption,
   ..‹complete_lattice α›}
 
+@[priority 100] -- see Note [lower instance priority]
 instance conditionally_complete_linear_order_of_complete_linear_order [complete_linear_order α]:
   conditionally_complete_linear_order α :=
 { ..lattice.conditionally_complete_lattice_of_complete_lattice, .. ‹complete_linear_order α› }

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -9,7 +9,6 @@ Defines the inf/sup (semi)-lattice with optionally top/bot type class hierarchy.
 import order.basic
 
 set_option old_structure_cmd true
-set_option default_priority 100 -- see Note [default priority]
 
 universes u v w
 
@@ -38,6 +37,8 @@ class has_inf (α : Type u) := (inf : α → α → α)
 infix ⊔ := has_sup.sup
 infix ⊓ := has_inf.inf
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A `semilattice_sup` is a join-semilattice, that is, a partial order
   with a join (a.k.a. lub / least upper bound, sup / supremum) operation
   `⊔` which is the least element larger than both factors. -/
@@ -45,6 +46,7 @@ class semilattice_sup (α : Type u) extends has_sup α, partial_order α :=
 (le_sup_left : ∀ a b : α, a ≤ a ⊔ b)
 (le_sup_right : ∀ a b : α, b ≤ a ⊔ b)
 (sup_le : ∀ a b c : α, a ≤ c → b ≤ c → a ⊔ b ≤ c)
+end prio
 
 section semilattice_sup
 variables {α : Type u} [semilattice_sup α] {a b c d : α}
@@ -146,6 +148,8 @@ assume x y, ⟨x ⊔ y, hf _ _ le_sup_left, hf _ _ le_sup_right⟩
 
 end semilattice_sup
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A `semilattice_inf` is a meet-semilattice, that is, a partial order
   with a meet (a.k.a. glb / greatest lower bound, inf / infimum) operation
   `⊓` which is the greatest element smaller than both factors. -/
@@ -153,6 +157,7 @@ class semilattice_inf (α : Type u) extends has_inf α, partial_order α :=
 (inf_le_left : ∀ a b : α, a ⊓ b ≤ a)
 (inf_le_right : ∀ a b : α, a ⊓ b ≤ b)
 (le_inf : ∀ a b c : α, a ≤ b → a ≤ c → a ≤ b ⊓ c)
+end prio
 
 section semilattice_inf
 variables {α : Type u} [semilattice_inf α] {a b c d : α}
@@ -248,9 +253,12 @@ end semilattice_inf
 
 /- Lattices -/
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A lattice is a join-semilattice which is also a meet-semilattice. -/
 -- TODO(lint): Fix double namespace issue
 @[nolint] class lattice (α : Type u) extends semilattice_sup α, semilattice_inf α
+end prio
 
 section lattice
 variables {α : Type u} [lattice α] {a b c d : α}
@@ -282,6 +290,8 @@ end lattice
 
 variables {α : Type u} {x y z w : α}
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A distributive lattice is a lattice that satisfies any of four
   equivalent distribution properties (of sup over inf or inf over sup,
   on the left or right). A classic example of a distributive lattice
@@ -290,6 +300,7 @@ variables {α : Type u} {x y z w : α}
   as a sublattice of a powerset lattice. -/
 class distrib_lattice α extends lattice α :=
 (le_sup_inf : ∀x y z : α, (x ⊔ y) ⊓ (x ⊔ z) ≤ x ⊔ (y ⊓ z))
+end prio
 
 section distrib_lattice
 variables [distrib_lattice α]

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -9,6 +9,7 @@ Defines the inf/sup (semi)-lattice with optionally top/bot type class hierarchy.
 import order.basic
 
 set_option old_structure_cmd true
+set_option default_priority 100 -- see Note [default priority]
 
 universes u v w
 
@@ -328,6 +329,7 @@ end distrib_lattice
 
 /- Lattices derived from linear orders -/
 
+@[priority 100] -- see Note [lower instance priority]
 instance lattice_of_decidable_linear_order {α : Type u} [o : decidable_linear_order α] : lattice α :=
 { sup          := max,
   le_sup_left  := le_max_left,
@@ -343,6 +345,7 @@ instance lattice_of_decidable_linear_order {α : Type u} [o : decidable_linear_o
 theorem sup_eq_max [decidable_linear_order α] : x ⊔ y = max x y := rfl
 theorem inf_eq_min [decidable_linear_order α] : x ⊓ y = min x y := rfl
 
+@[priority 100] -- see Note [lower instance priority]
 instance distrib_lattice_of_decidable_linear_order {α : Type u} [o : decidable_linear_order α] : distrib_lattice α :=
 { le_sup_inf := assume a b c,
     match le_total b c with

--- a/src/ring_theory/adjoin_root.lean
+++ b/src/ring_theory/adjoin_root.lean
@@ -95,8 +95,9 @@ principal_ideal_domain.is_maximal_of_irreducible ‹irreducible f›
 noncomputable instance field : discrete_field (adjoin_root f) :=
 ideal.quotient.field (span {f} : ideal (polynomial α))
 
+ -- short-circuit type class inference
 instance : is_field_hom (coe : α → adjoin_root f) := by apply_instance
-
+ -- short-circuit type class inference
 instance lift_is_field_hom [field β] {i : α → β} [is_ring_hom i] {a : β}
   {h : f.eval₂ i a = 0} : is_field_hom (lift i a h) := by apply_instance
 

--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -13,6 +13,7 @@ import linear_algebra.tensor_product
 import ring_theory.subring
 
 noncomputable theory
+set_option default_priority 100 -- see Note [default priority]
 
 universes u v w u₁ v₁
 
@@ -40,7 +41,7 @@ variables {R : Type u} {S : Type v} {A : Type w}
 variables [comm_ring R] [comm_ring S] [ring A] [algebra R A]
 
 /-- The codomain of an algebra. -/
-instance : has_scalar R A := infer_instance
+instance : has_scalar R A := infer_instance -- short-circuit type class inference
 
 include R
 

--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -13,13 +13,14 @@ import linear_algebra.tensor_product
 import ring_theory.subring
 
 noncomputable theory
-set_option default_priority 100 -- see Note [default priority]
 
 universes u v w u₁ v₁
 
 open lattice
 open_locale tensor_product
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- The category of R-algebras where R is a commutative
 ring is the under category R ↓ CRing. In the categorical
 setting we have a forgetful functor R-Alg ⥤ R-Mod.
@@ -29,6 +30,7 @@ class algebra (R : Type u) (A : Type v) [comm_ring R] [ring A] extends has_scala
 (to_fun : R → A) [hom : is_ring_hom to_fun]
 (commutes' : ∀ r x, x * to_fun r = to_fun r * x)
 (smul_def' : ∀ r x, r • x = to_fun r * x)
+end prio
 
 attribute [instance] algebra.hom
 

--- a/src/ring_theory/ideals.lean
+++ b/src/ring_theory/ideals.lean
@@ -10,7 +10,6 @@ variables {α : Type u} {β : Type v} {a b : α}
 open set function lattice
 
 open_locale classical
-set_option default_priority 100 -- see Note [default priority]
 
 namespace ideal
 variables [comm_ring α] (I : ideal α)
@@ -353,8 +352,11 @@ begin
   use [I, Imax], apply H, apply ideal.subset_span, exact set.mem_singleton a
 end
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 class local_ring (α : Type u) extends nonzero_comm_ring α :=
 (is_local : ∀ (a : α), (is_unit a) ∨ (is_unit (1 - a)))
+end prio
 
 namespace local_ring
 variable [local_ring α]
@@ -455,8 +457,11 @@ have xmemI : x ∈ I, from ((Iuniq Ix Ixmax) ▸ Hx),
 have ymemI : y ∈ I, from ((Iuniq Iy Iymax) ▸ Hy),
 Imax.1 $ I.eq_top_of_is_unit_mem (I.add_mem xmemI ymemI) H
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 class is_local_ring_hom [comm_ring α] [comm_ring β] (f : α → β) extends is_ring_hom f : Prop :=
 (map_nonunit : ∀ a, is_unit (f a) → is_unit a)
+end prio
 
 @[simp] lemma is_unit_of_map_unit [comm_ring α] [comm_ring β] (f : α → β) [is_local_ring_hom f]
   (a) (h : is_unit (f a)) : is_unit a :=

--- a/src/ring_theory/ideals.lean
+++ b/src/ring_theory/ideals.lean
@@ -10,6 +10,7 @@ variables {α : Type u} {β : Type v} {a b : α}
 open set function lattice
 
 open_locale classical
+set_option default_priority 100 -- see Note [default priority]
 
 namespace ideal
 variables [comm_ring α] (I : ideal α)
@@ -131,6 +132,7 @@ theorem is_maximal.is_prime {I : ideal α} (H : I.is_maximal) : I.is_prime :=
   exact I.neg_mem_iff.1 ((I.add_mem_iff_right $ I.mul_mem_left hxy).1 this)
 end⟩
 
+@[priority 100] -- see Note [lower instance priority]
 instance is_maximal.is_prime' (I : ideal α) : ∀ [H : I.is_maximal], I.is_prime := is_maximal.is_prime
 
 theorem exists_le_maximal (I : ideal α) (hI : I ≠ ⊤) :
@@ -357,8 +359,6 @@ class local_ring (α : Type u) extends nonzero_comm_ring α :=
 namespace local_ring
 variable [local_ring α]
 
-instance : comm_ring α := by apply_instance
-
 lemma is_unit_or_is_unit_one_sub_self (a : α) :
   (is_unit a) ∨ (is_unit (1 - a)) :=
 is_local a
@@ -504,6 +504,7 @@ end local_ring
 namespace discrete_field
 variables [discrete_field α]
 
+@[priority 100] -- see Note [lower instance priority]
 instance : local_ring α :=
 { is_local := λ a,
   if h : a = 0

--- a/src/ring_theory/maps.lean
+++ b/src/ring_theory/maps.lean
@@ -38,6 +38,7 @@ namespace is_ring_anti_hom
 
 variables [ring R] [ring F] (f : R → F) [is_ring_anti_hom f]
 
+@[priority 100] -- see Note [lower instance priority]
 instance : is_add_group_hom f :=
 { to_is_add_hom := ⟨λ x y, is_ring_anti_hom.map_add f⟩ }
 

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -319,6 +319,7 @@ end
 instance is_noetherian_ring.to_is_noetherian {α : Type*} [ring α] :
   ∀ [is_noetherian_ring α], is_noetherian α α := id
 
+@[priority 80] -- see Note [lower instance priority]
 instance ring.is_noetherian_of_fintype (R M) [fintype M] [ring R] [add_comm_group M] [module R M] : is_noetherian R M :=
 by letI := classical.dec; exact
 ⟨assume s, ⟨to_finset s, by rw [finset.coe_to_finset', submodule.span_eq]⟩⟩

--- a/src/ring_theory/principal_ideal_domain.lean
+++ b/src/ring_theory/principal_ideal_domain.lean
@@ -8,7 +8,6 @@ import algebra.euclidean_domain
 import ring_theory.ideals ring_theory.noetherian ring_theory.unique_factorization_domain
 
 variables {α : Type*}
-set_option default_priority 100 -- see Note [default priority]
 
 open set function ideal
 open_locale classical
@@ -16,8 +15,12 @@ open_locale classical
 class ideal.is_principal [comm_ring α] (S : ideal α) : Prop :=
 (principal : ∃ a, S = span {a})
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 class principal_ideal_domain (α : Type*) extends integral_domain α :=
 (principal : ∀ (S : ideal α), S.is_principal)
+end prio
+
 attribute [instance] principal_ideal_domain.principal
 namespace ideal.is_principal
 variable [comm_ring α]

--- a/src/ring_theory/principal_ideal_domain.lean
+++ b/src/ring_theory/principal_ideal_domain.lean
@@ -8,6 +8,7 @@ import algebra.euclidean_domain
 import ring_theory.ideals ring_theory.noetherian ring_theory.unique_factorization_domain
 
 variables {α : Type*}
+set_option default_priority 100 -- see Note [default priority]
 
 open set function ideal
 open_locale classical
@@ -68,6 +69,7 @@ lemma mod_mem_iff {S : ideal α} {x y : α} (hy : y ∈ S) : x % y ∈ S ↔ x �
 ⟨λ hxy, div_add_mod x y ▸ ideal.add_mem S (mul_mem_right S hy) hxy,
   λ hx, (mod_eq_sub_mul_div x y).symm ▸ ideal.sub_mem S hx (ideal.mul_mem_right S hy)⟩
 
+@[priority 100] -- see Note [lower instance priority]
 instance euclidean_domain.to_principal_ideal_domain : principal_ideal_domain α :=
 { principal := λ S, by exactI
     ⟨if h : {x : α | x ∈ S ∧ x ≠ 0} = ∅
@@ -95,6 +97,7 @@ end
 namespace principal_ideal_domain
 variables [principal_ideal_domain α]
 
+@[priority 100] -- see Note [lower instance priority]
 instance is_noetherian_ring : is_noetherian_ring α :=
 ⟨assume s : ideal α,
 begin

--- a/src/ring_theory/subring.lean
+++ b/src/ring_theory/subring.lean
@@ -8,14 +8,16 @@ import group_theory.subgroup
 import algebra.ring
 
 universes u v
-set_option default_priority 100 -- see Note [default priority]
 
 open group
 
 variables {R : Type u} [ring R]
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- `S` is a subring: a set containing 1 and closed under multiplication, addition and and additive inverse. -/
 class is_subring (S : set R) extends is_add_subgroup S, is_submonoid S : Prop.
+end prio
 
 instance subset.ring {S : set R} [is_subring S] : ring S :=
 by subtype_instance

--- a/src/ring_theory/subring.lean
+++ b/src/ring_theory/subring.lean
@@ -8,6 +8,7 @@ import group_theory.subgroup
 import algebra.ring
 
 universes u v
+set_option default_priority 100 -- see Note [default priority]
 
 open group
 

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -96,7 +96,7 @@ instance : linear_order cardinal.{u} :=
 
 noncomputable instance : decidable_linear_order cardinal.{u} := classical.DLO _
 
-noncomputable instance : distrib_lattice cardinal.{u} := by apply_instance
+noncomputable instance : distrib_lattice cardinal.{u} := by apply_instance -- short-circuit type class inference
 
 instance : has_zero cardinal.{u} := ⟨⟦pempty⟧⟩
 

--- a/src/tactic/linarith.lean
+++ b/src/tactic/linarith.lean
@@ -166,6 +166,7 @@ meta def comp.lt (c1 c2 : comp) : bool :=
 
 meta instance comp.has_lt : has_lt comp := ⟨λ a b, comp.lt a b⟩
 meta instance pcomp.has_lt : has_lt pcomp := ⟨λ p1 p2, p1.c < p2.c⟩
+ -- short-circuit type class inference
 meta instance pcomp.has_lt_dec : decidable_rel ((<) : pcomp → pcomp → Prop) := by apply_instance
 
 meta def comp.coeff_of (c : comp) (a : ℕ) : ℤ :=

--- a/src/tactic/lint.lean
+++ b/src/tactic/lint.lean
@@ -274,11 +274,13 @@ meta def instance_priority (d : declaration) : tactic (option string) := do
   For example, the instance `int.add_group : add_group ℤ` should be tried before
   `add_comm_group.to_comm_group [add_comm_group α] : comm_group α`, because the second instance will
   take a long time to fail (an exhaustive search through the tree) and the first one fails almost
-  instantly.
+  instantly. See also #1561.
 
   Classes that use the `extends` keyword automatically generate instances that always apply.
   Therefore, we set the priority of these instances to 100 (or something similar, which is below the
   default value of 1000) using `set_option default_priority 100`
+  Note that we have to put this option inside a section, so that the default priority is the default
+  1000 outside the section.
 -/
 
 /- Note [lower instance priority]:
@@ -286,7 +288,7 @@ meta def instance_priority (d : declaration) : tactic (option string) := do
   For example, the instance `int.add_group : add_group ℤ` should be tried before
   `add_comm_group.to_comm_group [add_comm_group α] : comm_group α`, because the second instance will
   take a long time to fail (an exhaustive search through the tree) and the first one fails almost
-  instantly.
+  instantly. See also #1561.
 
   Therefore, if we create an instance that always applies, we set the priority of these instances to
   100 (or something similar, which is below the default value of 1000).

--- a/src/tactic/lint.lean
+++ b/src/tactic/lint.lean
@@ -269,29 +269,32 @@ meta def instance_priority (d : declaration) : tactic (option string) := do
   let always_applies := relevant_args.all expr.is_var ∧ relevant_args.nodup,
   if always_applies then return $ some "set priority below 1000" else return none
 
-/- Note [default priority]:
-  Instances that always apply should be applied after instances that only apply in specific cases.
-  For example, the instance `int.add_group : add_group ℤ` should be tried before
-  `add_comm_group.to_comm_group [add_comm_group α] : comm_group α`, because the second instance will
-  take a long time to fail (an exhaustive search through the tree) and the first one fails almost
-  instantly. See also #1561.
-
-  Classes that use the `extends` keyword automatically generate instances that always apply.
-  Therefore, we set the priority of these instances to 100 (or something similar, which is below the
-  default value of 1000) using `set_option default_priority 100`
-  Note that we have to put this option inside a section, so that the default priority is the default
-  1000 outside the section.
--/
-
 /- Note [lower instance priority]:
-  Instances that always apply should be applied after instances that only apply in specific cases.
-  For example, the instance `int.add_group : add_group ℤ` should be tried before
-  `add_comm_group.to_comm_group [add_comm_group α] : comm_group α`, because the second instance will
-  take a long time to fail (an exhaustive search through the tree) and the first one fails almost
-  instantly. See also #1561.
+  Certain instances always apply during type-class resolution. For example, the instance
+  `add_comm_group.to_add_group {α} [add_comm_group α] : add_group α` applies to all type-class
+  resolution problems of the form `add_group _`, and type-class inference will then do an
+  exhaustive search to find a commutative group. These instances take a long time to fail.
+  Other instances will only apply if the goal has a certain shape. For example
+  `int.add_group : add_group ℤ` or
+  `add_group.prod {α β} [add_group α] [add_group β] : add_group (α × β)`. Usually these instances
+  will fail quickly, and when they apply, they are almost the desired instance.
+  For this reason, we want the instances of the second type (that only apply in specific cases) to
+  always have higher priority than the instances of the first type (that always apply).
+  See also #1561.
 
   Therefore, if we create an instance that always applies, we set the priority of these instances to
   100 (or something similar, which is below the default value of 1000).
+-/
+
+/- Note [default priority]:
+  Instances that always apply should be applied after instances that only apply in specific cases,
+  see note [lower instance priority] above.
+
+  Classes that use the `extends` keyword automatically generate instances that always apply.
+  Therefore, we set the priority of these instances to 100 (or something similar, which is below the
+  default value of 1000) using `set_option default_priority 100`.
+  We have to put this option inside a section, so that the default priority is the default
+  1000 outside the section.
 -/
 
 /-- A linter object for checking instance priorities of instances that always apply.

--- a/src/tactic/ring.lean
+++ b/src/tactic/ring.lean
@@ -133,6 +133,8 @@ theorem horner_add_horner_gt {α} [comm_semiring α] (a₁ x n₁ b₁ a₂ n₂
   @horner α _ a₁ x n₁ b₁ + horner a₂ x n₂ b₂ = horner a' x n₂ b' :=
 by simp [h₂.symm, h₃.symm, h₁.symm, horner, pow_add, mul_add, mul_comm, mul_left_comm]
 
+-- set_option trace.class_instances true
+-- set_option class.instance_max_depth 128
 theorem horner_add_horner_eq {α} [comm_semiring α] (a₁ x n b₁ a₂ b₂ a' b' t)
   (h₁ : a₁ + a₂ = a') (h₂ : b₁ + b₂ = b') (h₃ : horner a' x n b' = t) :
   @horner α _ a₁ x n b₁ + horner a₂ x n b₂ = t :=

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -13,13 +13,14 @@ import topology.algebra.monoid topology.homeomorph
 
 open classical set lattice filter topological_space
 open_locale classical topological_space
-set_option default_priority 100 -- see Note [default priority]
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
 
 section topological_group
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A topological (additive) group is a group in which the addition and negation operations are
 continuous. -/
 class topological_add_group (α : Type u) [topological_space α] [add_group α]
@@ -32,6 +33,7 @@ continuous. -/
 class topological_group (α : Type*) [topological_space α] [group α]
   extends topological_monoid α : Prop :=
 (continuous_inv : continuous (λa:α, a⁻¹))
+end prio
 
 variables [topological_space α] [group α]
 
@@ -245,6 +247,8 @@ nhds_translation_add_neg x
 
 end topological_add_group
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- additive group with a neighbourhood around 0.
 Only used to construct a topology and uniform space.
 
@@ -255,6 +259,7 @@ class add_group_with_zero_nhd (α : Type u) extends add_comm_group α :=
 (Z : filter α)
 (zero_Z {} : pure 0 ≤ Z)
 (sub_Z {} : tendsto (λp:α×α, p.1 - p.2) (Z.prod Z) Z)
+end prio
 
 namespace add_group_with_zero_nhd
 variables (α) [add_group_with_zero_nhd α]

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -13,6 +13,7 @@ import topology.algebra.monoid topology.homeomorph
 
 open classical set lattice filter topological_space
 open_locale classical topological_space
+set_option default_priority 100 -- see Note [default priority]
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
@@ -260,6 +261,7 @@ variables (α) [add_group_with_zero_nhd α]
 
 local notation `Z` := add_group_with_zero_nhd.Z
 
+@[priority 100] -- see Note [lower instance priority]
 instance : topological_space α :=
 topological_space.mk_of_nhds $ λa, map (λx, x + a) (Z α)
 
@@ -302,6 +304,7 @@ topological_space.nhds_mk_of_nhds _ _
 
 lemma nhds_zero_eq_Z : 𝓝 0 = Z α := by simp [nhds_eq]; exact filter.map_id
 
+@[priority 100] -- see Note [lower instance priority]
 instance : topological_add_monoid α :=
 ⟨ continuous_iff_continuous_at.2 $ assume ⟨a, b⟩,
   begin
@@ -313,6 +316,7 @@ instance : topological_add_monoid α :=
     exact tendsto_map.comp add_Z
   end⟩
 
+@[priority 100] -- see Note [lower instance priority]
 instance : topological_add_group α :=
 ⟨continuous_iff_continuous_at.2 $ assume a,
   begin

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -11,6 +11,7 @@ import topology.algebra.ring linear_algebra.basic ring_theory.algebra
 open topological_space
 
 universes u v w u'
+set_option default_priority 100 -- see Note [default priority]
 
 /-- A topological semimodule, over a semiring which is also a topological space, is a
 semimodule in which scalar multiplication is continuous. In applications, α will be a topological

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -11,8 +11,9 @@ import topology.algebra.ring linear_algebra.basic ring_theory.algebra
 open topological_space
 
 universes u v w u'
-set_option default_priority 100 -- see Note [default priority]
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A topological semimodule, over a semiring which is also a topological space, is a
 semimodule in which scalar multiplication is continuous. In applications, α will be a topological
 semiring and β a topological additive semigroup, but this is not needed for the definition -/
@@ -21,6 +22,7 @@ class topological_semimodule (α : Type u) (β : Type v)
   [topological_space β] [add_comm_monoid β]
   [semimodule α β] : Prop :=
 (continuous_smul : continuous (λp : α × β, p.1 • p.2))
+end prio
 
 section
 
@@ -38,6 +40,8 @@ continuous_smul'.comp (hf.prod_mk hg)
 
 end
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A topological module, over a ring which is also a topological space, is a module in which
 scalar multiplication is continuous. In applications, α will be a topological ring and β a
 topological additive group, but this is not needed for the definition -/
@@ -52,6 +56,7 @@ class topological_vector_space (α : Type u) (β : Type v)
   [discrete_field α] [topological_space α]
   [topological_space β] [add_comm_group β] [vector_space α β]
   extends topological_module α β
+end prio
 
 /-- Continuous linear maps between modules. We only put the type classes that are necessary for the
 definition, although in applications β and γ will be topological modules over the topological

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -80,6 +80,7 @@ private lemma is_closed_eq : is_closed {p : α × α | p.1 = p.2} :=
 by simp [le_antisymm_iff];
    exact is_closed_inter t.is_closed_le' (is_closed_le continuous_snd continuous_fst)
 
+@[priority 100] -- see Note [lower instance priority]
 instance ordered_topology.to_t2_space : t2_space α :=
 { t2 :=
   have is_open {p : α × α | p.1 ≠ p.2}, from is_closed_eq,
@@ -394,6 +395,7 @@ match dense_or_discrete a₁ a₂ with
       ... ≤ b₂ : h₁ _ hb₂⟩
 end
 
+@[priority 100] -- see Note [lower instance priority]
 instance orderable_topology.to_ordered_topology : ordered_topology α :=
 { is_closed_le' :=
     is_open_prod_iff.mpr $ assume a₁ a₂ (h : ¬ a₁ ≤ a₂),
@@ -401,8 +403,9 @@ instance orderable_topology.to_ordered_topology : ordered_topology α :=
       let ⟨u, v, hu, hv, ha₁, ha₂, h⟩ := order_separated h in
       ⟨v, u, hv, hu, ha₂, ha₁, assume ⟨b₁, b₂⟩ ⟨h₁, h₂⟩, not_le_of_gt $ h b₂ h₂ b₁ h₁⟩ }
 
-instance orderable_topology.t2_space : t2_space α := by apply_instance
+def orderable_topology.t2_space : t2_space α := by apply_instance
 
+@[priority 100] -- see Note [lower instance priority]
 instance orderable_topology.regular_space : regular_space α :=
 { regular := assume s a hs ha,
     have -s ∈ 𝓝 a, from mem_nhds_sets hs ha,

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -403,7 +403,7 @@ instance orderable_topology.to_ordered_topology : ordered_topology α :=
       let ⟨u, v, hu, hv, ha₁, ha₂, h⟩ := order_separated h in
       ⟨v, u, hv, hu, ha₂, ha₁, assume ⟨b₁, b₂⟩ ⟨h₁, h₂⟩, not_le_of_gt $ h b₂ h₂ b₁ h₁⟩ }
 
-def orderable_topology.t2_space : t2_space α := by apply_instance
+lemma orderable_topology.t2_space : t2_space α := by apply_instance
 
 @[priority 100] -- see Note [lower instance priority]
 instance orderable_topology.regular_space : regular_space α :=

--- a/src/topology/algebra/ring.lean
+++ b/src/topology/algebra/ring.lean
@@ -10,21 +10,26 @@ import topology.algebra.group ring_theory.ideals
 
 open classical set lattice filter topological_space
 open_locale classical
-set_option default_priority 100 -- see Note [default priority]
 
 section topological_ring
 universes u v w
 variables (α : Type u) [topological_space α]
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A topological semiring is a semiring where addition and multiplication are continuous. -/
 class topological_semiring [semiring α]
   extends topological_add_monoid α, topological_monoid α : Prop
+end prio
 
 variables [ring α]
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A topological ring is a ring where the ring operations are continuous. -/
 class topological_ring extends topological_add_monoid α, topological_monoid α : Prop :=
 (continuous_neg : continuous (λa:α, -a))
+end prio
 
 variables [t : topological_ring α]
 @[priority 100] -- see Note [lower instance priority]

--- a/src/topology/algebra/ring.lean
+++ b/src/topology/algebra/ring.lean
@@ -10,6 +10,7 @@ import topology.algebra.group ring_theory.ideals
 
 open classical set lattice filter topological_space
 open_locale classical
+set_option default_priority 100 -- see Note [default priority]
 
 section topological_ring
 universes u v w
@@ -26,8 +27,10 @@ class topological_ring extends topological_add_monoid α, topological_monoid α 
 (continuous_neg : continuous (λa:α, -a))
 
 variables [t : topological_ring α]
+@[priority 100] -- see Note [lower instance priority]
 instance topological_ring.to_topological_semiring : topological_semiring α := {..t}
 
+@[priority 100] -- see Note [lower instance priority]
 instance topological_ring.to_topological_add_group : topological_add_group α := {..t}
 end topological_ring
 

--- a/src/topology/algebra/uniform_ring.lean
+++ b/src/topology/algebra/uniform_ring.lean
@@ -159,14 +159,8 @@ by rw ring_sep_quot α; apply_instance
 instance [comm_ring α] [uniform_space α] [uniform_add_group α] [topological_ring α] :
   topological_ring (quotient (separation_setoid α)) :=
 begin
-  convert topological_ring_quotient (⊥ : ideal α).closure,
-  { apply ring_sep_rel },
-  { dsimp [topological_ring_quotient_topology, quotient.topological_space, to_topological_space],
-    congr,
-    apply ring_sep_rel,
-    apply ring_sep_rel },
-  { apply ring_sep_rel },
-  { simp [uniform_space.comm_ring] },
+  convert topological_ring_quotient (⊥ : ideal α).closure; try {apply ring_sep_rel},
+  simp [uniform_space.comm_ring]
 end
 
 end uniform_space

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -185,6 +185,7 @@ class first_countable_topology : Prop :=
 class second_countable_topology : Prop :=
 (is_open_generated_countable : ∃b:set (set α), countable b ∧ t = topological_space.generate_from b)
 
+@[priority 100] -- see Note [lower instance priority]
 instance second_countable_topology.to_first_countable_topology
   [second_countable_topology α] : first_countable_topology α :=
 let ⟨b, hb, eq⟩ := second_countable_topology.is_open_generated_countable α in
@@ -243,6 +244,7 @@ begin
   exact assume a, (hg a).2.2.2.1
 end
 
+@[priority 100] -- see Note [lower instance priority]
 instance second_countable_topology.to_separable_space
   [second_countable_topology α] : separable_space α :=
 let ⟨b, hb₁, hb₂, hb₃, hb₄, eq⟩ := is_open_generated_countable_inter α in

--- a/src/topology/instances/complex.lean
+++ b/src/topology/instances/complex.lean
@@ -36,7 +36,7 @@ metric.uniform_continuous_iff.2 $ λ ε ε0, ⟨_, ε0, λ a b h,
 instance : uniform_add_group ℂ :=
 uniform_add_group.mk' uniform_continuous_add uniform_continuous_neg
 
-instance : topological_add_group ℂ := by apply_instance
+instance : topological_add_group ℂ := by apply_instance -- short-circuit type class inference
 
 lemma uniform_continuous_inv (s : set ℂ) {r : ℝ} (r0 : 0 < r) (H : ∀ x ∈ s, r ≤ abs x) :
   uniform_continuous (λp:s, p.1⁻¹) :=
@@ -117,7 +117,7 @@ lemma continuous_of_real : continuous of_real := uniform_continuous_of_real.cont
 instance : topological_ring ℂ :=
 { continuous_mul := complex.continuous_mul, ..complex.topological_add_group }
 
-instance : topological_semiring ℂ := by apply_instance
+instance : topological_semiring ℂ := by apply_instance -- short-circuit type class inference
 
 def real_prod_homeo : homeomorph ℂ (ℝ × ℝ) :=
 { to_equiv := real_prod_equiv,

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -30,7 +30,7 @@ topological_space.generate_from {s | ∃a, s = {b | a < b} ∨ s = {b | b < a}}
 
 instance : orderable_topology ennreal := ⟨rfl⟩
 
-instance : t2_space ennreal := by apply_instance
+instance : t2_space ennreal := by apply_instance -- short-circuit type class inference
 
 instance : second_countable_topology ennreal :=
 ⟨⟨⋃q ≥ (0:ℚ), {{a : ennreal | a < nnreal.of_real q}, {a : ennreal | ↑(nnreal.of_real q) < a}},

--- a/src/topology/instances/nnreal.lean
+++ b/src/topology/instances/nnreal.lean
@@ -13,7 +13,7 @@ open_locale topological_space
 namespace nnreal
 open_locale nnreal
 
-instance : topological_space ℝ≥0 := infer_instance
+instance : topological_space ℝ≥0 := infer_instance -- short-circuit type class inference
 
 instance : topological_semiring ℝ≥0 :=
 { continuous_mul :=

--- a/src/topology/instances/real.lean
+++ b/src/topology/instances/real.lean
@@ -99,6 +99,7 @@ uniform_add_group.mk' real.uniform_continuous_add real.uniform_continuous_neg
 instance : uniform_add_group ℚ :=
 uniform_add_group.mk' rat.uniform_continuous_add rat.uniform_continuous_neg
 
+ -- short-circuit type class inference
 instance : topological_add_group ℝ := by apply_instance
 instance : topological_add_group ℚ := by apply_instance
 
@@ -197,7 +198,7 @@ tendsto_of_uniform_continuous_subtype
 instance : topological_ring ℝ :=
 { continuous_mul := real.continuous_mul, ..real.topological_add_group }
 
-instance : topological_semiring ℝ := by apply_instance
+instance : topological_semiring ℝ := by apply_instance  -- short-circuit type class inference
 
 lemma rat.continuous_mul : continuous (λp : ℚ × ℚ, p.1 * p.2) :=
 embedding_of_rat.continuous_iff.2 $ by simp [(∘)]; exact

--- a/src/topology/instances/real.lean
+++ b/src/topology/instances/real.lean
@@ -39,6 +39,9 @@ theorem rat.dist_eq (x y : ℚ) : dist x y = abs (x - y) := rfl
 
 @[elim_cast, simp] lemma rat.dist_cast (x y : ℚ) : dist (x : ℝ) y = dist x y := rfl
 
+section low_prio
+-- we want to ignore this instance for the next declaration
+local attribute [instance, priority 10] int.uniform_space
 instance : metric_space ℤ :=
 begin
   letI M := metric_space.induced coe int.cast_injective real.metric_space,
@@ -49,6 +52,7 @@ begin
   simpa using (@int.cast_le ℝ _ _ 0).2 (int.lt_add_one_iff.1 $
     (@int.cast_lt ℝ _ (abs (a - b)) 1).1 $ by simpa using h)
 end
+end low_prio
 
 theorem int.dist_eq (x y : ℤ) : dist x y = abs (x - y) := rfl
 

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -15,6 +15,7 @@ noncomputable theory
 
 open_locale uniformity
 open_locale topological_space
+set_option default_priority 100 -- see Note [default priority]
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
@@ -70,9 +71,11 @@ class metric_space (α : Type u) extends has_dist α : Type u :=
 
 variables [metric_space α]
 
+@[priority 100] -- see Note [lower instance priority]
 instance metric_space.to_uniform_space' : uniform_space α :=
 metric_space.to_uniform_space α
 
+@[priority 200] -- see Note [lower instance priority]
 instance metric_space.to_has_edist : has_edist α := ⟨metric_space.edist⟩
 
 @[simp] theorem dist_self (x : α) : dist x x = 0 := metric_space.dist_self x
@@ -452,6 +455,7 @@ end metric
 
 open metric
 
+@[priority 100] -- see Note [lower instance priority]
 instance metric_space.to_separated : separated α :=
 separated_def.2 $ λ x y h, eq_of_forall_dist_le $
   λ ε ε0, le_of_lt (h _ (dist_mem_uniformity ε0))
@@ -488,6 +492,7 @@ theorem uniformity_edist : 𝓤 α = (⨅ ε>0, principal {p:α×α | edist p.1 
 by simpa [infi_subtype] using @metric.uniformity_edist' α _
 
 /-- A metric space induces an emetric space -/
+@[priority 100] -- see Note [lower instance priority]
 instance metric_space.to_emetric_space : emetric_space α :=
 { edist               := edist,
   edist_self          := by simp [edist_dist],
@@ -1011,10 +1016,12 @@ lemma proper_space_of_compact_closed_ball_of_le
 end⟩
 
 /- A compact metric space is proper -/
+@[priority 100] -- see Note [lower instance priority]
 instance proper_of_compact [compact_space α] : proper_space α :=
 ⟨assume x r, compact_of_is_closed_subset compact_univ is_closed_ball (subset_univ _)⟩
 
 /-- A proper space is locally compact -/
+@[priority 100] -- see Note [lower instance priority]
 instance locally_compact_of_proper [proper_space α] :
   locally_compact_space α :=
 begin
@@ -1030,6 +1037,7 @@ begin
 end
 
 /-- A proper space is complete -/
+@[priority 100] -- see Note [lower instance priority]
 instance complete_of_proper [proper_space α] : complete_space α :=
 ⟨begin
   intros f hf,
@@ -1049,6 +1057,7 @@ end⟩
 compact, and therefore admits a countable dense subset. Taking a countable union over the balls
 centered at a fixed point and with integer radius, one obtains a countable set which is
 dense in the whole space. -/
+@[priority 100] -- see Note [lower instance priority]
 instance second_countable_of_proper [proper_space α] :
   second_countable_topology α :=
 begin

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -15,7 +15,6 @@ noncomputable theory
 
 open_locale uniformity
 open_locale topological_space
-set_option default_priority 100 -- see Note [default priority]
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
@@ -47,6 +46,8 @@ class has_dist (α : Type*) := (dist : α → α → ℝ)
 
 export has_dist (dist)
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- Metric space
 
 Each metric space induces a canonical `uniform_space` and hence a canonical `topological_space`.
@@ -68,6 +69,7 @@ class metric_space (α : Type u) extends has_dist α : Type u :=
 (edist_dist : ∀ x y : α, edist x y = ennreal.of_real (dist x y) . control_laws_tac)
 (to_uniform_space : uniform_space α := uniform_space_of_dist dist dist_self dist_comm dist_triangle)
 (uniformity_dist : 𝓤 α = ⨅ ε>0, principal {p:α×α | dist p.1 p.2 < ε} . control_laws_tac)
+end prio
 
 variables [metric_space α]
 

--- a/src/topology/metric_space/cau_seq_filter.lean
+++ b/src/topology/metric_space/cau_seq_filter.lean
@@ -405,6 +405,7 @@ lemma cau_seq_iff_cauchy_seq {α : Type u} [normed_field α] {u : ℕ → α} :
 
 /-- A complete normed field is complete as a metric space, as Cauchy sequences converge by
 assumption and this suffices to characterize completeness. -/
+@[priority 100] -- see Note [lower instance priority]
 instance complete_space_of_cau_seq_complete [cau_seq.is_complete β norm] : complete_space β :=
 begin
   apply complete_of_cauchy_seq_tendsto,

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -21,7 +21,6 @@ import topology.uniform_space.separation topology.uniform_space.uniform_embeddin
 import topology.bases
 open lattice set filter classical
 noncomputable theory
-set_option default_priority 100 -- see Note [default priority]
 
 open_locale uniformity topological_space
 
@@ -86,6 +85,8 @@ uniform_space.of_core {
   symm       := tendsto_infi.2 $ assume ε, tendsto_infi.2 $ assume h,
     tendsto_infi' ε $ tendsto_infi' h $ tendsto_principal_principal.2 $ by simp [edist_comm] }
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- Extended metric spaces, with an extended distance `edist` possibly taking the
 value ∞
 
@@ -105,6 +106,7 @@ class emetric_space (α : Type u) extends has_edist α : Type u :=
 (edist_triangle : ∀ x y z : α, edist x z ≤ edist x y + edist y z)
 (to_uniform_space : uniform_space α := uniform_space_of_edist edist edist_self edist_comm edist_triangle)
 (uniformity_edist : 𝓤 α = ⨅ ε>0, principal {p:α×α | edist p.1 p.2 < ε} . control_laws_tac)
+end prio
 
 /- emetric spaces are less common than metric spaces. Therefore, we work in a dedicated
 namespace, while notions associated to metric spaces are mostly in the root namespace. -/

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -21,6 +21,7 @@ import topology.uniform_space.separation topology.uniform_space.uniform_embeddin
 import topology.bases
 open lattice set filter classical
 noncomputable theory
+set_option default_priority 100 -- see Note [default priority]
 
 open_locale uniformity topological_space
 
@@ -109,6 +110,7 @@ class emetric_space (α : Type u) extends has_edist α : Type u :=
 namespace, while notions associated to metric spaces are mostly in the root namespace. -/
 variables [emetric_space α]
 
+@[priority 100] -- see Note [lower instance priority]
 instance emetric_space.to_uniform_space' : uniform_space α :=
 emetric_space.to_uniform_space α
 
@@ -233,6 +235,7 @@ end emetric
 open emetric
 
 /-- An emetric space is separated -/
+@[priority 100] -- see Note [lower instance priority]
 instance to_separated : separated α :=
 separated_def.2 $ λ x y h, eq_of_forall_edist_le $
 λ ε ε0, le_of_lt (h _ (edist_mem_uniformity ε0))
@@ -569,6 +572,7 @@ end compact
 
 section first_countable
 
+@[priority 100] -- see Note [lower instance priority]
 instance (α : Type u) [emetric_space α] :
   topological_space.first_countable_topology α :=
 ⟨assume a, ⟨⋃ i:ℕ, {ball a i⁻¹},

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -532,6 +532,8 @@ the two spaces, by gluing them (approximately) along the two matching subsets. -
 variables {α : Type u} [metric_space α] [compact_space α] [nonempty α]
           {β : Type v} [metric_space β] [compact_space β] [nonempty β]
 
+-- we want to ignore these instances in the following theorem
+local attribute [instance, priority 10] sum.topological_space sum.uniform_space
 /-- If there are subsets which are ε1-dense and ε3-dense in two spaces, and
 isometric up to ε2, then the Gromov-Hausdorff distance between the spaces is bounded by
 ε1 + ε2/2 + ε3. -/

--- a/src/topology/metric_space/gromov_hausdorff_realized.lean
+++ b/src/topology/metric_space/gromov_hausdorff_realized.lean
@@ -423,12 +423,8 @@ def premetric_optimal_GH_dist : premetric_space (α ⊕ β) :=
 local attribute [instance] premetric_optimal_GH_dist premetric.dist_setoid
 
 /-- A metric space which realizes the optimal coupling between α and β -/
-@[reducible] definition optimal_GH_coupling : Type* :=
+@[derive [metric_space]] definition optimal_GH_coupling : Type* :=
 premetric.metric_quot (α ⊕ β)
-
-instance : metric_space (optimal_GH_coupling α β) := by apply_instance
-
-private lemma optimal_GH_dist.dist_eq (p q : α ⊕ β) : dist ⟦p⟧ ⟦q⟧ = (optimal_GH_dist α β).val (p, q) := rfl
 
 /-- Injection of α in the optimal coupling between α and β -/
 def optimal_GH_injl (x : α) : optimal_GH_coupling α β := ⟦inl x⟧
@@ -438,7 +434,6 @@ lemma isometry_optimal_GH_injl : isometry (optimal_GH_injl α β) :=
 begin
   refine isometry_emetric_iff_metric.2 (λx y, _),
   change dist ⟦inl x⟧ ⟦inl y⟧ = dist x y,
-  rw [optimal_GH_dist.dist_eq α β],
   exact candidates_dist_inl (optimal_GH_dist_mem_candidates_b α β) _ _,
 end
 
@@ -450,7 +445,6 @@ lemma isometry_optimal_GH_injr : isometry (optimal_GH_injr α β) :=
 begin
   refine isometry_emetric_iff_metric.2 (λx y, _),
   change dist ⟦inr x⟧ ⟦inr y⟧ = dist x y,
-  rw [optimal_GH_dist.dist_eq α β],
   exact candidates_dist_inr (optimal_GH_dist_mem_candidates_b α β) _ _,
 end
 

--- a/src/topology/metric_space/premetric_space.lean
+++ b/src/topology/metric_space/premetric_space.lean
@@ -14,6 +14,7 @@ is canonically a metric space.
 
 import topology.metric_space.basic tactic.linarith
 noncomputable theory
+set_option default_priority 100 -- see Note [default priority]
 
 universes u v
 variables {α : Type u}

--- a/src/topology/metric_space/premetric_space.lean
+++ b/src/topology/metric_space/premetric_space.lean
@@ -14,15 +14,17 @@ is canonically a metric space.
 
 import topology.metric_space.basic tactic.linarith
 noncomputable theory
-set_option default_priority 100 -- see Note [default priority]
 
 universes u v
 variables {α : Type u}
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 class premetric_space (α : Type u) extends has_dist α : Type u :=
 (dist_self : ∀ x : α, dist x x = 0)
 (dist_comm : ∀ x y : α, dist x y = dist y x)
 (dist_triangle : ∀ x y z : α, dist x z ≤ dist x y + dist y z)
+end prio
 
 namespace premetric
 section

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -11,7 +11,6 @@ import topology.subset_properties
 open set filter lattice
 open_locale topological_space
 local attribute [instance] classical.prop_decidable -- TODO: use "open_locale classical"
-set_option default_priority 100 -- see Note [default priority]
 
 universes u v
 variables {α : Type u} {β : Type v} [topological_space α]
@@ -302,11 +301,14 @@ end separation
 
 section regularity
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A T₃ space, also known as a regular space (although this condition sometimes
   omits T₂), is one in which for every closed `C` and `x ∉ C`, there exist
   disjoint open sets containing `x` and `C` respectively. -/
 class regular_space (α : Type u) [topological_space α] extends t1_space α : Prop :=
 (regular : ∀{s:set α} {a}, is_closed s → a ∉ s → ∃t, is_open t ∧ s ⊆ t ∧ 𝓝 a ⊓ principal t = ⊥)
+end prio
 
 lemma nhds_is_closed [regular_space α] {a : α} {s : set α} (h : s ∈ 𝓝 a) :
   ∃t∈(𝓝 a), t ⊆ s ∧ is_closed t :=
@@ -334,12 +336,15 @@ end regularity
 
 section normality
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A T₄ space, also known as a normal space (although this condition sometimes
   omits T₂), is one in which for every pair of disjoint closed sets `C` and `D`,
   there exist disjoint open sets containing `C` and `D` respectively. -/
 class normal_space (α : Type u) [topological_space α] extends t1_space α : Prop :=
 (normal : ∀ s t : set α, is_closed s → is_closed t → disjoint s t →
   ∃ u v, is_open u ∧ is_open v ∧ s ⊆ u ∧ t ⊆ v ∧ disjoint u v)
+end prio
 
 theorem normal_separation [normal_space α] (s t : set α)
   (H1 : is_closed s) (H2 : is_closed t) (H3 : disjoint s t) :

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -11,6 +11,7 @@ import topology.subset_properties
 open set filter lattice
 open_locale topological_space
 local attribute [instance] classical.prop_decidable -- TODO: use "open_locale classical"
+set_option default_priority 100 -- see Note [default priority]
 
 universes u v
 variables {α : Type u} {β : Type v} [topological_space α]
@@ -121,6 +122,7 @@ class t1_space (α : Type u) [topological_space α] : Prop :=
 lemma is_closed_singleton [t1_space α] {x : α} : is_closed ({x} : set α) :=
 t1_space.t1 x
 
+@[priority 100] -- see Note [lower instance priority]
 instance t1_space.t0_space [t1_space α] : t0_space α :=
 ⟨λ x y h, ⟨-{x}, is_open_compl_iff.2 is_closed_singleton,
   or.inr ⟨λ hyx, or.cases_on hyx h.symm id, λ hx, hx $ or.inl rfl⟩⟩⟩
@@ -142,6 +144,7 @@ lemma t2_separation [t2_space α] {x y : α} (h : x ≠ y) :
   ∃u v : set α, is_open u ∧ is_open v ∧ x ∈ u ∧ y ∈ v ∧ u ∩ v = ∅ :=
 t2_space.t2 x y h
 
+@[priority 100] -- see Note [lower instance priority]
 instance t2_space.t1_space [t2_space α] : t1_space α :=
 ⟨λ x, is_open_iff_forall_mem_open.2 $ λ y hxy,
 let ⟨u, v, hu, hv, hyu, hxv, huv⟩ := t2_separation (mt mem_singleton_of_eq hxy) in
@@ -195,6 +198,7 @@ lim_eq nhds_neq_bot (le_refl _)
 lim_eq begin rw [closure_eq_nhds] at h, exact h end inf_le_left
 end lim
 
+@[priority 100] -- see Note [lower instance priority]
 instance t2_space_discrete {α : Type*} [topological_space α] [discrete_topology α] : t2_space α :=
 { t2 := assume x y hxy, ⟨{x}, {y}, is_open_discrete _, is_open_discrete _, mem_insert _ _, mem_insert _ _,
   eq_empty_iff_forall_not_mem.2 $ by intros z hz;
@@ -290,6 +294,7 @@ lemma locally_compact_of_compact_nhds [t2_space α] (h : ∀ x : α, ∃ s, s �
    subset.trans (diff_subset_comm.mp kuw) un,
    compact_diff kc wo⟩⟩
 
+@[priority 100] -- see Note [lower instance priority]
 instance locally_compact_of_compact [t2_space α] [compact_space α] : locally_compact_space α :=
 locally_compact_of_compact_nhds (assume x, ⟨univ, mem_nhds_sets is_open_univ trivial, compact_univ⟩)
 
@@ -315,6 +320,7 @@ let ⟨t, ht₁, ht₂, ht₃⟩ := this in
   is_closed_compl_iff.mpr ht₁⟩
 
 variable (α)
+@[priority 100] -- see Note [lower instance priority]
 instance regular_space.t2_space [regular_space α] : t2_space α :=
 ⟨λ x y hxy,
 let ⟨s, hs, hys, hxs⟩ := regular_space.regular is_closed_singleton
@@ -340,6 +346,7 @@ theorem normal_separation [normal_space α] (s t : set α)
   ∃ u v, is_open u ∧ is_open v ∧ s ⊆ u ∧ t ⊆ v ∧ disjoint u v :=
 normal_space.normal s t H1 H2 H3
 
+@[priority 100] -- see Note [lower instance priority]
 instance normal_space.regular_space [normal_space α] : regular_space α :=
 { regular := λ s x hs hxs, let ⟨u, v, hu, hv, hsu, hxv, huv⟩ := normal_separation s {x} hs is_closed_singleton
       (λ _ ⟨hx, hy⟩, hxs $ set.mem_of_eq_of_mem (set.eq_of_mem_singleton hy).symm hx) in

--- a/src/topology/sequences.lean
+++ b/src/topology/sequences.lean
@@ -159,6 +159,7 @@ namespace topological_space
 namespace first_countable_topology
 
 /-- Every first-countable space is sequential. -/
+@[priority 100] -- see Note [lower instance priority]
 instance [topological_space α] [first_countable_topology α] : sequential_space α :=
 ⟨show ∀ M, sequential_closure M = closure M, from assume M,
   suffices closure M ⊆ sequential_closure M,

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -574,6 +574,7 @@ subset_connected_component
 class connected_space (α : Type u) [topological_space α] : Prop :=
 (is_connected_univ : is_connected (univ : set α))
 
+@[priority 100] -- see Note [lower instance priority]
 instance irreducible_space.connected_space (α : Type u) [topological_space α]
   [irreducible_space α] : connected_space α :=
 ⟨is_connected_of_is_irreducible $ irreducible_space.is_irreducible_univ α⟩
@@ -634,6 +635,7 @@ let ⟨r, hrt, hruv⟩ := ht u v hu hv (subset.trans hts hsuv) ⟨x, hxt, hxu⟩
 class totally_separated_space (α : Type u) [topological_space α] : Prop :=
 (is_totally_separated_univ : is_totally_separated (univ : set α))
 
+@[priority 100] -- see Note [lower instance priority]
 instance totally_separated_space.totally_disconnected_space (α : Type u) [topological_space α]
   [totally_separated_space α] : totally_disconnected_space α :=
 ⟨is_totally_disconnected_of_is_totally_separated $ totally_separated_space.is_totally_separated_univ α⟩

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -30,6 +30,7 @@ open set lattice filter classical
 open_locale classical topological_space
 
 set_option eqn_compiler.zeta true
+set_option default_priority 100 -- see Note [default priority]
 
 universes u
 section

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -30,7 +30,6 @@ open set lattice filter classical
 open_locale classical topological_space
 
 set_option eqn_compiler.zeta true
-set_option default_priority 100 -- see Note [default priority]
 
 universes u
 section
@@ -101,6 +100,8 @@ def uniform_space.core.to_topological_space {α : Type u} (u : uniform_space.cor
 lemma uniform_space.core_eq : ∀{u₁ u₂ : uniform_space.core α}, u₁.uniformity = u₂.uniformity → u₁ = u₂
 | ⟨u₁, _, _, _⟩  ⟨u₂, _, _, _⟩ h := have u₁ = u₂, from h, by simp [*]
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 /-- A uniform space is a generalization of the "uniform" topological aspects of a
   metric space. It consists of a filter on `α × α` called the "uniformity", which
   satisfies properties analogous to the reflexivity, symmetry, and triangle properties
@@ -110,6 +111,7 @@ lemma uniform_space.core_eq : ∀{u₁ u₂ : uniform_space.core α}, u₁.unifo
   A topological group also has a natural uniformity, even when it is not metrizable. -/
 class uniform_space (α : Type u) extends topological_space α, uniform_space.core α :=
 (is_open_uniformity : ∀s, is_open s ↔ (∀x∈s, { p : α × α | p.1 = x → p.2 ∈ s } ∈ uniformity))
+end prio
 
 @[pattern] def uniform_space.mk' {α} (t : topological_space α)
   (c : uniform_space.core α)

--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -318,6 +318,7 @@ lemma compact_iff_totally_bounded_complete {s : set α} :
 λ ⟨ht, hc⟩, compact_iff_ultrafilter_le_nhds.2
   (λf hf hfs, hc _ (totally_bounded_iff_ultrafilter.1 ht _ hf hfs) hfs)⟩
 
+@[priority 100] -- see Note [lower instance priority]
 instance complete_of_compact {α : Type u} [uniform_space α] [compact_space α] : complete_space α :=
 ⟨λf hf, by simpa [principal_univ] using (compact_iff_totally_bounded_complete.1 compact_univ).2 f hf⟩
 

--- a/src/topology/uniform_space/pi.lean
+++ b/src/topology/uniform_space/pi.lean
@@ -33,9 +33,6 @@ begin
   exact infi_le (λ j, uniform_space.comap (λ (a : Π (i : ι), α i), a j) (U j)) i
 end
 
-lemma Pi.uniform_space_topology :
-  (Pi.uniform_space α).to_topological_space = Pi.topological_space := rfl
-
 instance Pi.complete [∀ i, complete_space (α i)] : complete_space (Π i, α i) :=
 ⟨begin
   intros f hf,
@@ -46,9 +43,7 @@ instance Pi.complete [∀ i, complete_space (α i)] : complete_space (Π i, α i
     exact (cauchy_iff_exists_le_nhds $ map_ne_bot hf.1).1 key },
   choose x hx using this,
   use x,
-  rw [show 𝓝 x = (⨅i, comap (λa, a i) (𝓝 (x i))),
-        by rw Pi.uniform_space_topology ; exact nhds_pi,
-      le_infi_iff],
+  rw [nhds_pi, le_infi_iff],
   exact λ i, map_le_iff_le_comap.mp (hx i),
 end⟩
 

--- a/src/topology/uniform_space/separation.lean
+++ b/src/topology/uniform_space/separation.lean
@@ -51,6 +51,7 @@ theorem separated_def' {α : Type u} [uniform_space α] :
 separated_def.trans $ forall_congr $ λ x, forall_congr $ λ y,
 by rw ← not_imp_not; simp [classical.not_forall]
 
+@[priority 100] -- see Note [lower instance priority]
 instance separated_t2 [s : separated α] : t2_space α :=
 ⟨assume x y, assume h : x ≠ y,
 let ⟨d, hd, (hxy : (x, y) ∉ d)⟩ := separated_def'.1 s x y h in
@@ -68,6 +69,7 @@ have u ∩ v = ∅, from
   hxy $ hd'd' this,
 ⟨u, v, hu₂, hv₂, hu₃, hv₃, this⟩⟩
 
+@[priority 100] -- see Note [lower instance priority]
 instance separated_regular [separated α] : regular_space α :=
 { regular := λs a hs ha,
     have -s ∈ 𝓝 a,


### PR DESCRIPTION
use lower instance priority for instances that always apply
also do this for automatically generated instances using the `extend` keyword
also add a comment to most places where we short-circuit type-class inference. This can lead to greatly increased search times (see issue #1561), so we might want to delete some/all of them.

This PR will almost certainly break things, although I strongly expect that it will decrease the overall type-class inference search space. I investigated one place where type-class inference was short-circuited. This short-circuiting was necessary before the change, but not afterwards.