### PR TITLE
feat(order/conditionally_complete_lattice): with_top (with_bot L) ins…

### DIFF
--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -224,17 +224,16 @@ open_locale classical
 
 noncomputable instance {α : Type*} [preorder α] [has_Sup α] : has_Sup (with_top α) :=
 ⟨λ S, if ⊤ ∈ S then ⊤ else
-  if ¬ bdd_above (coe ⁻¹' S : set α) then ⊤ else ↑(Sup (coe ⁻¹' S : set α))⟩
+  if bdd_above (coe ⁻¹' S : set α) then ↑(Sup (coe ⁻¹' S : set α)) else ⊤⟩
 
 noncomputable instance {α : Type*} [has_Inf α] : has_Inf (with_top α) :=
 ⟨λ S, if S ⊆ {⊤} then ⊤ else ↑(Inf (coe ⁻¹' S : set α))⟩
 
 noncomputable instance {α : Type*} [has_Sup α] : has_Sup (with_bot α) :=
-⟨λ S, if S ⊆ {⊥} then ⊥ else ↑(Sup (coe ⁻¹' S : set α))⟩
+⟨(@with_top.lattice.has_Inf (order_dual α) _).Inf⟩
 
 noncomputable instance {α : Type*} [preorder α] [has_Inf α] : has_Inf (with_bot α) :=
-⟨λ S, if ⊥ ∈ S then ⊥ else
-  if ¬ bdd_below (coe ⁻¹' S : set α) then ⊥ else ↑(Inf (coe ⁻¹' S : set α))⟩
+⟨(@with_top.lattice.has_Sup (order_dual α) _ _).Sup⟩
 
 end with_top_bot
 
@@ -705,11 +704,35 @@ begin
     assume a _, le_top⟩
 end
 
-noncomputable instance : has_Sup (with_top α) := ⟨λs, classical.some $ has_lub s⟩
-noncomputable instance : has_Inf (with_top α) := ⟨λs, classical.some $ has_glb s⟩
+--noncomputable instance : has_Sup (with_top α) := ⟨λs, classical.some $ has_lub s⟩
+--noncomputable instance : has_Inf (with_top α) := ⟨λs, classical.some $ has_glb s⟩
+noncomputable example : has_Sup (with_top α) := by apply_instance
 
-lemma is_lub_Sup (s : set (with_top α)) : is_lub s (Sup s) := classical.some_spec _
-lemma is_glb_Inf (s : set (with_top α)) : is_glb s (Inf s) := classical.some_spec _
+lemma is_lub_Sup (s : set (with_top α)) : is_lub s (Sup s) :=
+begin
+  split,
+  { show ite _ _ _ ∈ _,
+    split_ifs,
+    { intros _ _, exact le_top},
+    { rintro (⟨⟩|a) ha, contradiction,
+      apply some_le_some.2,
+      exact le_cSup h_1 ha},
+    { intros _ _, exact le_top}},
+  { show ite _ _ _ ∈ _,
+    split_ifs,
+    { rintro (⟨⟩|a) ha, exact _root_.le_refl _,
+      exfalso, apply not_top_le_coe a, exact ha h},
+    { rintro (⟨⟩|b) hb, exact le_top,
+      apply some_le_some.2,
+      by_cases ((coe ⁻¹' s : set α) = ∅),
+      { rw [h, cSup_empty], exact bot_le},
+      { refine cSup_le h _,
+        intros a ha, exact some_le_some.1 (hb ha)}},
+    { rintro (⟨⟩|b) hb, exact _root_.le_refl _,
+      exfalso, apply h_1, use b, intros a ha, exact some_le_some.1 (hb ha)}}
+end
+
+lemma is_glb_Inf (s : set (with_top α)) : is_glb s (Inf s) := sorry
 
 noncomputable instance : complete_linear_order (with_top α) :=
 { Sup := Sup, le_Sup := assume s, (is_lub_Sup s).1, Sup_le := assume s, (is_lub_Sup s).2,
@@ -812,18 +835,18 @@ As an application, one can deduce that the extended reals [-∞, ∞] are a comp
 open lattice
 
 open_locale classical
-/-- Extends `Sup` from a conditionally complete lattice `α` to `with_top α`.
-The new `Sup` returns a non-junk value for more subsets (e.g. for unbounded-above subsets of `α`). -/
-noncomputable instance with_top.conditionally_complete_lattice.has_Sup
-  {α : Type*} [conditionally_complete_lattice α] : has_Sup (with_top α) :=
-⟨λ S, if ⊤ ∈ S then ⊤ else
-      let So := (coe ⁻¹' S : set α) in
-      if bdd_above So then ↑(Sup So) else ⊤⟩
+--/-- Extends `Sup` from a conditionally complete lattice `α` to `with_top α`.
+--The new `Sup` returns a non-junk value for more subsets (e.g. for unbounded-above subsets of `α`). -/
+--noncomputable instance with_top.conditionally_complete_lattice.has_Sup
+--  {α : Type*} [conditionally_complete_lattice α] : has_Sup (with_top α) :=
+--⟨λ S, if ⊤ ∈ S then ⊤ else
+--      let So := (coe ⁻¹' S : set α) in
+--      if bdd_above So then ↑(Sup So) else ⊤⟩
 
-/-- Extends `Inf` from a conditionally complete lattice `α` to `with_top α`. -/
-noncomputable instance with_top.conditionally_complete_lattice.has_Inf
-  {α : Type*} [conditionally_complete_lattice α] : has_Inf (with_top α) :=
-⟨λ S, if S ⊆ {⊤} then ⊤ else ↑(Inf (coe ⁻¹' S) : α)⟩
+--/-- Extends `Inf` from a conditionally complete lattice `α` to `with_top α`. -/
+--noncomputable instance with_top.conditionally_complete_lattice.has_Inf
+--  {α : Type*} [conditionally_complete_lattice α] : has_Inf (with_top α) :=
+--⟨λ S, if S ⊆ {⊤} then ⊤ else ↑(Inf (coe ⁻¹' S) : α)⟩
 
 /-- Adding a top element to a conditionally complete lattice gives a conditionally complete lattice -/
 noncomputable instance with_top.conditionally_complete_lattice
@@ -880,28 +903,28 @@ noncomputable instance with_top.conditionally_complete_lattice
       },
     end,
   ..with_top.lattice,
-  ..with_top.conditionally_complete_lattice.has_Sup,
-  ..with_top.conditionally_complete_lattice.has_Inf
+  ..with_top.lattice.has_Sup,
+  ..with_top.lattice.has_Inf
 }
 
 
-/-- Extends `Sup` from a conditionally complete lattice `α` to `with_bot α`. -/
-noncomputable instance with_bot.conditionally_complete_lattice.has_Sup
-  {α : Type*} [conditionally_complete_lattice α] : has_Sup (with_bot α) :=
-⟨(@with_top.conditionally_complete_lattice.has_Inf (order_dual α) _).Inf⟩
+--/-- Extends `Sup` from a conditionally complete lattice `α` to `with_bot α`. -/
+--noncomputable instance with_bot.conditionally_complete_lattice.has_Sup
+--  {α : Type*} [conditionally_complete_lattice α] : has_Sup (with_bot α) :=
+--⟨(@with_top.lattice.has_Inf (order_dual α) _).Inf⟩
 
-/-- Extends Inf from a conditionally complete lattice `α` to `with_bot α`.
-The new Inf returns a non-junk value for more subsets (e.g. for unbounded-below subsets of `α`). -/
-noncomputable instance with_bot.conditionally_complete_lattice.has_Inf
-  {α : Type*} [conditionally_complete_lattice α] : has_Sup (with_bot α) :=
-⟨(@with_top.conditionally_complete_lattice.has_Sup (order_dual α) _).Sup⟩
+--/-- Extends Inf from a conditionally complete lattice `α` to `with_bot α`.
+--The new Inf returns a non-junk value for more subsets (e.g. for unbounded-below subsets of `α`). -/
+--noncomputable instance with_bot.conditionally_complete_lattice.has_Inf
+--  {α : Type*} [conditionally_complete_lattice α] : has_Sup (with_bot α) :=
+--⟨(@with_top.lattice.has_Sup (order_dual α) _).Sup⟩
 
 /-- Adding a bottom element to a conditionally complete lattice gives a conditionally complete lattice -/
 noncomputable instance with_bot.conditionally_complete_lattice
   {α : Type*} [conditionally_complete_lattice α] :
   conditionally_complete_lattice (with_bot α) :=
-{ Sup := @has_Inf.Inf _ (@with_top.conditionally_complete_lattice.has_Inf (order_dual α) _),
-  Inf := @has_Sup.Sup _ (@with_top.conditionally_complete_lattice.has_Sup (order_dual α) _),
+{ Sup := @has_Inf.Inf _ (@with_top.lattice.has_Inf (order_dual α) _),
+  Inf := @has_Sup.Sup _ (@with_top.lattice.has_Sup (order_dual α) _ _),
   le_cSup := (@with_top.conditionally_complete_lattice (order_dual α) _).cInf_le,
   cSup_le := (@with_top.conditionally_complete_lattice (order_dual α) _).le_cInf,
   cInf_le := (@with_top.conditionally_complete_lattice (order_dual α) _).le_cSup,
@@ -980,8 +1003,8 @@ noncomputable instance {α : Type*} [conditionally_complete_lattice α] :
         }
       }
     end,
-  ..with_top.conditionally_complete_lattice.has_Inf,
-  ..with_top.conditionally_complete_lattice.has_Sup,
+  ..with_top.lattice.has_Inf,
+  ..with_top.lattice.has_Sup,
   ..with_top.lattice.bounded_lattice
 }
 end with_top_bot

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -732,7 +732,30 @@ begin
       exfalso, apply h_1, use b, intros a ha, exact some_le_some.1 (hb ha)}}
 end
 
-lemma is_glb_Inf (s : set (with_top α)) : is_glb s (Inf s) := sorry
+lemma is_glb_Inf (s : set (with_top α)) : is_glb s (Inf s) :=
+begin
+  split,
+  { show ite _ _ _ ∈ _,
+    split_ifs,
+    { intros a ha, exact top_le_iff.2 (set.mem_singleton_iff.1 (h ha))},
+    { rintro (⟨⟩|a) ha, exact le_top,
+      refine some_le_some.2 (cInf_le _ ha),
+      use ⊥,
+      intros _ _, exact bot_le}},
+  { show ite _ _ _ ∈ _,
+    split_ifs,
+    { intros _ _, exact le_top},
+    { rintro (⟨⟩|a) ha,
+      { exfalso, apply h, intros b hb, exact set.mem_singleton_iff.2 (top_le_iff.1 (ha hb))},
+      { refine some_le_some.2 (le_cInf _ _),
+        { refine mt _ h,
+          rintro hs (⟨⟩|b) hb,
+          { exact mem_singleton _},
+          { exfalso, apply not_mem_empty b, rwa ←hs}},
+        { intros b hb,
+          rw ←some_le_some,
+          refine ha hb}}}}
+end
 
 noncomputable instance : complete_linear_order (with_top α) :=
 { Sup := Sup, le_Sup := assume s, (is_lub_Sup s).1, Sup_le := assume s, (is_lub_Sup s).2,

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -772,6 +772,20 @@ end order_dual
 
 section with_top_bot
 
+/-! ### Complete lattice structure on `with_top (with_bot α)`
+
+If `α` is a `conditionally_complete_lattice`, then we show that `with_top α` and `with_bot α`
+also inherit the structure of conditionally complete lattices. Furthermore, we show
+that `with_top (with_bot α)` naturally inherits the structure of a complete lattice. Note that
+for α a conditionally complete lattice, `Sup` and `Inf` both return junk values
+for sets which are empty or unbounded. The extension of `Sup` to `with_top α` fixes
+the unboundedness problem and the extension to `with_bot α` fixes the problem with
+the empty set.
+
+As an application, one can deduce that the extended reals [-∞, ∞] are a complete lattice.
+-/
+
+
 open lattice
 
 open_locale classical
@@ -794,7 +808,7 @@ noncomputable instance with_top.conditionally_complete_lattice
   conditionally_complete_lattice (with_top α) :=
 { le_cSup := λ S a hS haS,
     let So := (coe ⁻¹' S : set α) in
-    show a ≤ (ite (⊤ ∈ S) ⊤ (ite (bdd_above So) ↑(Sup So) ⊤)),
+    show a ≤ (if (⊤ ∈ S) then ⊤ else (if (bdd_above So) then ↑(Sup So) else ⊤)),
     begin
       split_ifs,
       { exact le_top},
@@ -803,7 +817,7 @@ noncomputable instance with_top.conditionally_complete_lattice
     end,
   cSup_le := λ S a hS haS,
     let So := (coe ⁻¹' S : set α) in
-    show (ite (⊤ ∈ S) ⊤ (ite (bdd_above So) ↑(Sup So) ⊤)) ≤ a,
+    show (if (⊤ ∈ S) then ⊤ else (if (bdd_above So) then ↑(Sup So) else ⊤)) ≤ a,
     begin
       split_ifs,
       { exact haS h},
@@ -816,7 +830,7 @@ noncomputable instance with_top.conditionally_complete_lattice
         exfalso, apply h_1, use a, intros b hb, exact with_top.some_le_some.1 (haS hb)},
     end,
   cInf_le := λ S a hS haS,
-    show (ite (S ⊆ {⊤}) ⊤ ↑(Inf (coe ⁻¹' S))) ≤ a,
+    show (if (S ⊆ {⊤}) then ⊤ else ↑(Inf (coe ⁻¹' S))) ≤ a,
     begin
       cases a, exact le_top,
       split_ifs,
@@ -825,23 +839,23 @@ noncomputable instance with_top.conditionally_complete_lattice
         rcases hS with ⟨⟨⟩|a, ha⟩,
         { use a, intros b hb, exact false.elim (with_top.not_top_le_coe b (ha hb))},
         { use a, intros b hb, exact with_top.some_le_some.1 (ha hb)}}
-  end,
+    end,
   le_cInf := λ S a hS haS,
-    show a ≤ (ite (S ⊆ {⊤}) ⊤ ↑(Inf (coe ⁻¹' S))),
+    show a ≤ (if (S ⊆ {⊤}) then ⊤ else ↑(Inf (coe ⁻¹' S))),
     begin
-    cases a with a,
-    { split_ifs, exact _root_.le_refl _,
-      exfalso, apply h, intros s hs, simpa using top_le_iff.1 (haS hs),
-    },
-    { split_ifs, exact le_top,
-      refine with_top.some_le_some.2 (le_cInf _ _),
-      { apply mt _ h,
-        rintro h2 (⟨⟩|a) ha,
-        { exact set.mem_singleton _},
-        { exfalso, apply set.not_mem_empty a, rwa h2.symm}},
-      { intros b hb, exact with_top.some_le_some.1 (haS hb) }
-    },
-  end,
+      cases a with a,
+      { split_ifs, exact _root_.le_refl _,
+        exfalso, apply h, intros s hs, simpa using top_le_iff.1 (haS hs),
+      },
+      { split_ifs, exact le_top,
+        refine with_top.some_le_some.2 (le_cInf _ _),
+        { apply mt _ h,
+          rintro h2 (⟨⟩|a) ha,
+          { exact set.mem_singleton _},
+          { exfalso, apply set.not_mem_empty a, rwa h2.symm}},
+        { intros b hb, exact with_top.some_le_some.1 (haS hb) }
+      },
+    end,
   ..with_top.lattice,
   ..with_top.conditionally_complete_lattice.has_Sup,
   ..with_top.conditionally_complete_lattice.has_Inf
@@ -883,39 +897,39 @@ local attribute [instance, priority 10] classical.prop_decidable
 noncomputable instance {α : Type*} [conditionally_complete_lattice α] :
   complete_lattice (with_top (with_bot α)) :=
 { le_Sup := λ S a ha,
-  show a ≤ ite _ _ _,
-  begin
-    split_ifs,
-    { exact le_top},
-    { cases a, contradiction, exact with_top.some_le_some.2 (le_cSup h_1 ha)},
-    { exact le_top}
-  end,
+    show a ≤ ite _ _ _,
+    begin
+      split_ifs,
+      { exact le_top},
+      { cases a, contradiction, exact with_top.some_le_some.2 (le_cSup h_1 ha)},
+      { exact le_top}
+    end,
   Sup_le := λ S a ha,
-  show ite _ _ _ ≤ a,
-  begin
-    split_ifs,
-    { exact ha _ h},
-    { cases a, exact le_top,
-      apply with_top.some_le_some.2,
-      show ite _ _ _ ≤ _,
-      split_ifs, exact bot_le,
-      cases a with a,
-      { exfalso,
-        apply h_2,
-        intros b hb,
-        exact set.mem_singleton_iff.2 (le_bot_iff.1 (with_top.some_le_some.1 (ha (some b) hb))),
-      },
-      { apply with_bot.some_le_some.2,
-        refine cSup_le _ _,
-        { refine mt _ h_2,
-          rintro hS (⟨⟩|b) hb,
-          { exact set.mem_singleton _},
-          { exfalso, apply set.not_mem_empty (b : α), erw ←hS, exact hb}},
-        { intros b hb, exact with_bot.some_le_some.1 (with_top.some_le_some.1 (ha _ hb))}}},
-    { cases a with a,
-      { exact _root_.le_refl _},
-      { exfalso, apply h_1, use a, intros b hb, exact with_top.some_le_some.1 (ha _ hb)}}
-  end,
+    show ite _ _ _ ≤ a,
+    begin
+      split_ifs,
+      { exact ha _ h},
+      { cases a, exact le_top,
+        apply with_top.some_le_some.2,
+        show ite _ _ _ ≤ _,
+        split_ifs, exact bot_le,
+        cases a with a,
+        { exfalso,
+          apply h_2,
+          intros b hb,
+          exact set.mem_singleton_iff.2 (le_bot_iff.1 (with_top.some_le_some.1 (ha (some b) hb))),
+        },
+        { apply with_bot.some_le_some.2,
+          refine cSup_le _ _,
+          { refine mt _ h_2,
+            rintro hS (⟨⟩|b) hb,
+            { exact set.mem_singleton _},
+            { exfalso, apply set.not_mem_empty (b : α), erw ←hS, exact hb}},
+          { intros b hb, exact with_bot.some_le_some.1 (with_top.some_le_some.1 (ha _ hb))}}},
+      { cases a with a,
+        { exact _root_.le_refl _},
+        { exfalso, apply h_1, use a, intros b hb, exact with_top.some_le_some.1 (ha _ hb)}}
+    end,
   Inf_le := λ S a haS,
     show ite _ _ _ ≤ a,
     begin

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -664,46 +664,6 @@ open_locale classical
 
 variables [conditionally_complete_linear_order_bot α]
 
-lemma has_lub (s : set (with_top α)) : ∃a, is_lub s a :=
-begin
-  by_cases hs : s = ∅, { subst hs, exact ⟨⊥, is_lub_empty⟩, },
-  rcases ne_empty_iff_exists_mem.1 hs with ⟨x, hxs⟩,
-  by_cases bnd : ∃b:α, ↑b ∈ upper_bounds s,
-  { rcases bnd with ⟨b, hb⟩,
-    have bdd : bdd_above {a : α | ↑a ∈ s}, from ⟨b, assume y hy, coe_le_coe.1 $ hb hy⟩,
-    refine ⟨(Sup {a : α | ↑a ∈ s} : α), _, _⟩,
-    { assume a has,
-      rcases (le_coe_iff _ _).1 (hb has) with ⟨a, rfl, h⟩,
-      exact (coe_le_coe.2 $ le_cSup bdd has) },
-    { assume a hs,
-      rcases (le_coe_iff _ _).1 (hb hxs) with ⟨x, rfl, h⟩,
-      refine (coe_le_iff _ _).2 (assume c hc, _), subst hc,
-      exact (cSup_le (ne_empty_of_mem hxs) $ assume b (hbs : ↑b ∈ s), coe_le_coe.1 $ hs hbs), } },
-  exact ⟨⊤, assume a _, le_top, assume a,
-    match a with
-    | some a, ha := (bnd ⟨a, ha⟩).elim
-    | none,   ha := _root_.le_refl ⊤
-    end⟩
-end
-
-lemma has_glb (s : set (with_top α)) : ∃a, is_glb s a :=
-begin
-  by_cases hs : ∃x:α, ↑x ∈ s,
-  { rcases hs with ⟨x, hxs⟩,
-    refine ⟨(Inf {a : α | ↑a ∈ s} : α), _, _⟩,
-    exact (assume a has, (coe_le_iff _ _).2 $ assume x hx, cInf_le (bdd_below_bot _) $
-      show ↑x ∈ s, from hx ▸ has),
-    { assume a has,
-      rcases (le_coe_iff _ _).1 (has hxs) with ⟨x, rfl, h⟩,
-      exact (coe_le_coe.2 $ le_cInf (ne_empty_of_mem hxs) $
-        assume b hbs, coe_le_coe.1 $ has hbs) } },
-  exact ⟨⊤, assume a, match a with
-    | some a, ha := (hs ⟨a, ha⟩).elim
-    | none,   ha := _root_.le_refl _
-    end,
-    assume a _, le_top⟩
-end
-
 lemma is_lub_Sup (s : set (with_top α)) : is_lub s (Sup s) :=
 begin
   split,

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -704,10 +704,6 @@ begin
     assume a _, le_top⟩
 end
 
---noncomputable instance : has_Sup (with_top α) := ⟨λs, classical.some $ has_lub s⟩
---noncomputable instance : has_Inf (with_top α) := ⟨λs, classical.some $ has_glb s⟩
-noncomputable example : has_Sup (with_top α) := by apply_instance
-
 lemma is_lub_Sup (s : set (with_top α)) : is_lub s (Sup s) :=
 begin
   split,

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -11,7 +11,7 @@ has a least upper bound and a greatest lower bound, denoted below by Sup s and I
 Typical examples are real, nat, int with their usual orders.
 
 The theory is very comparable to the theory of complete lattices, except that suitable
-boundedness and non-emptyness assumptions have to be added to most statements.
+boundedness and nonemptiness assumptions have to be added to most statements.
 We introduce two predicates bdd_above and bdd_below to express this boundedness, prove
 their basic properties, and then go on to prove most useful properties of Sup and Inf
 in conditionally complete lattices.
@@ -245,7 +245,7 @@ Typical examples are real numbers or natural numbers.
 
 To differentiate the statements from the corresponding statements in (unconditional)
 complete lattices, we prefix Inf and Sup by a c everywhere. The same statements should
-hold in both worlds, sometimes with additional assumptions of non-emptyness or
+hold in both worlds, sometimes with additional assumptions of nonemptiness or
 boundedness.-/
 class conditionally_complete_lattice (α : Type u) extends lattice α, has_Sup α, has_Inf α :=
 (le_cSup : ∀s a, bdd_above s → a ∈ s → a ≤ Sup s)
@@ -350,7 +350,7 @@ have ¬(b < Inf s) :=
   show false, by finish [lt_irrefl (Inf s)],
 show Inf s = b, by finish
 
-/--When an element a of a set s is larger than all elements of the set, it is Sup s-/
+/--When an element a of a set s is larger than all other elements of the set, it is Sup s-/
 theorem cSup_of_mem_of_le (_ : a ∈ s) (_ : ∀w∈s, w ≤ a) : Sup s = a :=
 have bdd_above s := ⟨a, by assumption⟩,
 have s ≠ ∅ := ne_empty_of_mem ‹a ∈ s›,
@@ -358,7 +358,7 @@ have A : a ≤ Sup s := le_cSup ‹bdd_above s› ‹a ∈ s›,
 have B : Sup s ≤ a := cSup_le ‹s ≠ ∅› ‹∀w∈s, w ≤ a›,
 le_antisymm B A
 
-/--When an element a of a set s is smaller than all elements of the set, it is Inf s-/
+/--When an element a of a set s is smaller than all other elements of the set, it is Inf s-/
 theorem cInf_of_mem_of_le (_ : a ∈ s) (_ : ∀w∈s, a ≤ w) : Inf s = a :=
 have bdd_below s := ⟨a, by assumption⟩,
 have s ≠ ∅ := ne_empty_of_mem ‹a ∈ s›,
@@ -368,15 +368,15 @@ le_antisymm A B
 
 /--b < Sup s when there is an element a in s with b < a, when s is bounded above.
 This is essentially an iff, except that the assumptions for the two implications are
-slightly different (one needs boundedness above for one direction, nonemptyness and linear
+slightly different (one needs boundedness above for one direction, nonemptiness and linear
 order for the other one), so we formulate separately the two implications, contrary to
 the complete_lattice case.-/
 lemma lt_cSup_of_lt (_ : bdd_above s) (_ : a ∈ s) (_ : b < a) : b < Sup s :=
 lt_of_lt_of_le ‹b < a› (le_cSup ‹bdd_above s› ‹a ∈ s›)
 
-/--Inf s < b s when there is an element a in s with a < b, when s is bounded below.
+/--Inf s < b when there is an element a in s with a < b, when s is bounded below.
 This is essentially an iff, except that the assumptions for the two implications are
-slightly different (one needs boundedness below for one direction, nonemptyness and linear
+slightly different (one needs boundedness below for one direction, nonemptiness and linear
 order for the other one), so we formulate separately the two implications, contrary to
 the complete_lattice case.-/
 
@@ -407,7 +407,7 @@ have Inf s ≤ w := cInf_le ‹bdd_below s› ‹w ∈ s›,
 have w ≤ Sup s := le_cSup ‹bdd_above s› ‹w ∈ s›,
 le_trans ‹Inf s ≤ w› ‹w ≤ Sup s›
 
-/--The sup of a union of sets is the max of the suprema of each subset, under the assumptions
+/--The sup of a union of two sets is the max of the suprema of each subset, under the assumptions
 that all sets are bounded above and nonempty.-/
 theorem cSup_union (_ : bdd_above s) (_ : s ≠ ∅) (_ : bdd_above t) (_ : t ≠ ∅) :
 Sup (s ∪ t) = Sup s ⊔ Sup t :=
@@ -427,7 +427,7 @@ have B : Sup s ⊔ Sup t ≤ Sup (s ∪ t) :=
   by simp only [lattice.sup_le_iff]; split; assumption; assumption,
 le_antisymm A B
 
-/--The inf of a union of sets is the min of the infima of each subset, under the assumptions
+/--The inf of a union of two sets is the min of the infima of each subset, under the assumptions
 that all sets are bounded below and nonempty.-/
 theorem cInf_union (_ : bdd_below s) (_ : s ≠ ∅) (_ : bdd_below t) (_ : t ≠ ∅) :
 Inf (s ∪ t) = Inf s ⊓ Inf t :=
@@ -447,7 +447,7 @@ have B : Inf (s ∪ t) ≤ Inf s ⊓ Inf t  :=
   by simp only [lattice.le_inf_iff]; split; assumption; assumption,
 le_antisymm B A
 
-/--The supremum of an intersection of sets is bounded by the minimum of the suprema of each
+/--The supremum of an intersection of two sets is bounded by the minimum of the suprema of each
 set, if all sets are bounded above and nonempty.-/
 theorem cSup_inter_le (_ : bdd_above s) (_ : bdd_above t) (_ : s ∩ t ≠ ∅) :
 Sup (s ∩ t) ≤ Sup s ⊓ Sup t :=
@@ -457,7 +457,7 @@ begin
   apply le_cSup ‹bdd_above t› ‹b ∈ t›
 end
 
-/--The infimum of an intersection of sets is bounded below by the maximum of the
+/--The infimum of an intersection of two sets is bounded below by the maximum of the
 infima of each set, if all sets are bounded below and nonempty.-/
 theorem le_cInf_inter (_ : bdd_below s) (_ : bdd_below t) (_ : s ∩ t ≠ ∅) :
 Inf s ⊔ Inf t ≤ Inf (s ∩ t) :=
@@ -847,7 +847,7 @@ for sets which are empty or unbounded. The extension of `Sup` to `with_top α` f
 the unboundedness problem and the extension to `with_bot α` fixes the problem with
 the empty set.
 
-As an application, one can deduce that the extended reals [-∞, ∞] are a complete lattice.
+This result can be used to show that the extended reals [-∞, ∞] are a complete lattice.
 -/
 
 

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -854,18 +854,6 @@ As an application, one can deduce that the extended reals [-∞, ∞] are a comp
 open lattice
 
 open_locale classical
---/-- Extends `Sup` from a conditionally complete lattice `α` to `with_top α`.
---The new `Sup` returns a non-junk value for more subsets (e.g. for unbounded-above subsets of `α`). -/
---noncomputable instance with_top.conditionally_complete_lattice.has_Sup
---  {α : Type*} [conditionally_complete_lattice α] : has_Sup (with_top α) :=
---⟨λ S, if ⊤ ∈ S then ⊤ else
---      let So := (coe ⁻¹' S : set α) in
---      if bdd_above So then ↑(Sup So) else ⊤⟩
-
---/-- Extends `Inf` from a conditionally complete lattice `α` to `with_top α`. -/
---noncomputable instance with_top.conditionally_complete_lattice.has_Inf
---  {α : Type*} [conditionally_complete_lattice α] : has_Inf (with_top α) :=
---⟨λ S, if S ⊆ {⊤} then ⊤ else ↑(Inf (coe ⁻¹' S) : α)⟩
 
 /-- Adding a top element to a conditionally complete lattice gives a conditionally complete lattice -/
 noncomputable instance with_top.conditionally_complete_lattice
@@ -925,18 +913,6 @@ noncomputable instance with_top.conditionally_complete_lattice
   ..with_top.lattice.has_Sup,
   ..with_top.lattice.has_Inf
 }
-
-
---/-- Extends `Sup` from a conditionally complete lattice `α` to `with_bot α`. -/
---noncomputable instance with_bot.conditionally_complete_lattice.has_Sup
---  {α : Type*} [conditionally_complete_lattice α] : has_Sup (with_bot α) :=
---⟨(@with_top.lattice.has_Inf (order_dual α) _).Inf⟩
-
---/-- Extends Inf from a conditionally complete lattice `α` to `with_bot α`.
---The new Inf returns a non-junk value for more subsets (e.g. for unbounded-below subsets of `α`). -/
---noncomputable instance with_bot.conditionally_complete_lattice.has_Inf
---  {α : Type*} [conditionally_complete_lattice α] : has_Sup (with_bot α) :=
---⟨(@with_top.lattice.has_Sup (order_dual α) _).Sup⟩
 
 /-- Adding a bottom element to a conditionally complete lattice gives a conditionally complete lattice -/
 noncomputable instance with_bot.conditionally_complete_lattice

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -884,7 +884,7 @@ noncomputable instance {α : Type*} [conditionally_complete_lattice α] : bounde
   ..with_top.order_top,
   ..conditionally_complete_lattice.to_lattice _ }
 
-def with_top.cSup_empty {α : Type*} [conditionally_complete_lattice α] :
+theorem with_bot.cSup_empty {α : Type*} [conditionally_complete_lattice α] :
   Sup (∅ : set (with_bot α)) = ⊥ :=
 begin
   show ite _ _ _ = ⊥,
@@ -900,7 +900,7 @@ noncomputable instance {α : Type*} [conditionally_complete_lattice α] :
       { show ite _ _ _ ≤ a,
         split_ifs,
         { rw h at h_1, cases h_1 },
-        { convert bot_le, convert with_top.cSup_empty, rw h, refl },
+        { convert bot_le, convert with_bot.cSup_empty, rw h, refl },
         { exfalso, apply h_2, use ⊥, rw h, rintro b ⟨⟩ } },
       { refine (with_top.is_lub_Sup' h).2 ha }
     end,

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -214,7 +214,7 @@ finite.induction_on H
 
 end semilattice_inf
 
-section with_top_bot
+section
 
 /-!
 Extension of Sup and Inf from a preorder `α` to `with_top α` and `with_bot α`
@@ -235,7 +235,7 @@ noncomputable instance {α : Type*} [has_Sup α] : has_Sup (with_bot α) :=
 noncomputable instance {α : Type*} [preorder α] [has_Inf α] : has_Inf (with_bot α) :=
 ⟨(@with_top.lattice.has_Sup (order_dual α) _ _).Sup⟩
 
-end with_top_bot
+end -- section
 
 namespace lattice
 /-- A conditionally complete lattice is a lattice in which
@@ -269,7 +269,7 @@ instance conditionally_complete_lattice_of_complete_lattice [complete_lattice α
   cSup_le := by intros; apply Sup_le; assumption,
   cInf_le := by intros; apply Inf_le; assumption,
   le_cInf := by intros; apply le_Inf; assumption,
-  ..‹complete_lattice α›}
+  ..‹complete_lattice α› }
 
 instance conditionally_complete_linear_order_of_complete_linear_order [complete_linear_order α]:
   conditionally_complete_linear_order α :=
@@ -493,13 +493,13 @@ cSup_of_mem_of_le (by simp only [set.mem_set_of_eq]) (λw Hw, by simp only [set.
 lemma csupr_le_csupr {f g : β → α} (B : bdd_above (range g)) (H : ∀x, f x ≤ g x) : supr f ≤ supr g :=
 begin
   classical, by_cases nonempty β,
-  { have Rf : range f ≠ ∅, {simpa},
+  { have Rf : range f ≠ ∅, { simpa },
     apply cSup_le Rf,
     rintros y ⟨x, rfl⟩,
     have : g x ∈ range g := ⟨x, rfl⟩,
     exact le_cSup_of_le B this (H x) },
-  { have Rf : range f = ∅, {simpa},
-    have Rg : range g = ∅, {simpa},
+  { have Rf : range f = ∅, { simpa },
+    have Rg : range g = ∅, { simpa },
     unfold supr, rw [Rf, Rg] }
 end
 
@@ -515,13 +515,13 @@ le_cSup H (mem_range_self _)
 lemma cinfi_le_cinfi {f g : β → α} (B : bdd_below (range f)) (H : ∀x, f x ≤ g x) : infi f ≤ infi g :=
 begin
   classical, by_cases nonempty β,
-  { have Rg : range g ≠ ∅, {simpa},
+  { have Rg : range g ≠ ∅, { simpa },
     apply le_cInf Rg,
     rintros y ⟨x, rfl⟩,
     have : f x ∈ range f := ⟨x, rfl⟩,
     exact cInf_le_of_le B this (H x) },
-  { have Rf : range f = ∅, {simpa},
-    have Rg : range g = ∅, {simpa},
+  { have Rf : range f = ∅, { simpa },
+    have Rg : range g = ∅, { simpa },
     unfold infi, rw [Rf, Rg] }
 end
 
@@ -672,26 +672,30 @@ begin
   split,
   { show ite _ _ _ ∈ _,
     split_ifs,
-    { intros _ _, exact le_top},
-    { rintro (⟨⟩|a) ha, contradiction,
+    { intros _ _, exact le_top },
+    { rintro (⟨⟩|a) ha,
+      { contradiction },
       apply some_le_some.2,
-      exact le_cSup h_1 ha},
-    { intros _ _, exact le_top}},
+      exact le_cSup h_1 ha },
+    { intros _ _, exact le_top } },
   { show ite _ _ _ ∈ _,
     split_ifs,
-    { rintro (⟨⟩|a) ha, exact _root_.le_refl _,
-      exfalso, apply not_top_le_coe a, exact ha h},
-    { rintro (⟨⟩|b) hb, exact le_top,
-      apply some_le_some.2,
-      refine cSup_le _ _,
+    { rintro (⟨⟩|a) ha,
+      { exact _root_.le_refl _ },
+      { exact false.elim (not_top_le_coe a (ha h)) } },
+    { rintro (⟨⟩|b) hb,
+      { exact le_top },
+      refine some_le_some.2 (cSup_le _ _),
       { refine mt _ h,
         rw ne_empty_iff_exists_mem at hs,
         intro h2,
-        rcases hs with ⟨⟨⟩|b, hb⟩, assumption,
-        exfalso, revert h2, exact ne_empty_of_mem hb},
-      { intros a ha, exact some_le_some.1 (hb ha)}},
-    { rintro (⟨⟩|b) hb, exact _root_.le_refl _,
-      exfalso, apply h_1, use b, intros a ha, exact some_le_some.1 (hb ha)}}
+        rcases hs with ⟨⟨⟩|b, hb⟩,
+        { assumption },
+        { exfalso, revert h2, exact ne_empty_of_mem hb } },
+      { intros a ha, exact some_le_some.1 (hb ha) } },
+    { rintro (⟨⟩|b) hb,
+      { exact _root_.le_refl _ },
+      { exfalso, apply h_1, use b, intros a ha, exact some_le_some.1 (hb ha) } } }
 end
 
 lemma is_lub_Sup (s : set (with_top α)) : is_lub s (Sup s) :=
@@ -700,10 +704,9 @@ begin
   { rw hs,
     show is_lub ∅ (ite _ _ _),
     split_ifs,
-    { cases h},
-    { rw [preimage_empty, cSup_empty], exact is_lub_empty},
-    { exfalso, apply h_1, use ⊥, rintro a ⟨⟩}
-  },
+    { cases h },
+    { rw [preimage_empty, cSup_empty], exact is_lub_empty },
+    { exfalso, apply h_1, use ⊥, rintro a ⟨⟩ } },
   exact is_lub_Sup' hs,
 end
 
@@ -715,38 +718,39 @@ begin
   split,
   { show ite _ _ _ ∈ _,
     split_ifs,
-    { intros a ha, exact top_le_iff.2 (set.mem_singleton_iff.1 (h ha))},
-    { rintro (⟨⟩|a) ha, exact le_top,
+    { intros a ha, exact top_le_iff.2 (set.mem_singleton_iff.1 (h ha)) },
+    { rintro (⟨⟩|a) ha,
+      { exact le_top },
       refine some_le_some.2 (cInf_le _ ha),
       rcases hs with ⟨⟨⟩|b, hb⟩,
       { exfalso,
         apply h,
         intros c hc,
         rw [mem_singleton_iff, ←top_le_iff],
-        exact hb hc},
+        exact hb hc },
       use b,
       intros c hc,
-      refine some_le_some.1 (hb hc)}},
+      exact some_le_some.1 (hb hc) } },
   { show ite _ _ _ ∈ _,
     split_ifs,
-    { intros _ _, exact le_top},
+    { intros _ _, exact le_top },
     { rintro (⟨⟩|a) ha,
-      { exfalso, apply h, intros b hb, exact set.mem_singleton_iff.2 (top_le_iff.1 (ha hb))},
+      { exfalso, apply h, intros b hb, exact set.mem_singleton_iff.2 (top_le_iff.1 (ha hb)) },
       { refine some_le_some.2 (le_cInf _ _),
         { refine mt _ h,
           rintro hs (⟨⟩|b) hb,
-          { exact mem_singleton _},
-          { exfalso, apply not_mem_empty b, rwa ←hs}},
+          { exact mem_singleton _ },
+          { exfalso, apply not_mem_empty b, rwa ←hs } },
         { intros b hb,
           rw ←some_le_some,
-          refine ha hb}}}}
+          exact ha hb } } } }
 end
 
 lemma is_glb_Inf (s : set (with_top α)) : is_glb s (Inf s) :=
 begin
   by_cases hs : bdd_below s,
-  { exact is_glb_Inf' hs},
-  { exfalso, apply hs, use ⊥, intros _ _, exact bot_le},
+  { exact is_glb_Inf' hs },
+  { exfalso, apply hs, use ⊥, intros _ _, exact bot_le },
 end
 
 noncomputable instance : complete_linear_order (with_top α) :=
@@ -860,27 +864,25 @@ noncomputable instance with_top.conditionally_complete_lattice
   le_cInf := λ S a hS haS, (with_top.is_glb_Inf' ⟨a, haS⟩).2 haS,
   ..with_top.lattice,
   ..with_top.lattice.has_Sup,
-  ..with_top.lattice.has_Inf
-}
+  ..with_top.lattice.has_Inf }
 
 /-- Adding a bottom element to a conditionally complete lattice gives a conditionally complete lattice -/
 noncomputable instance with_bot.conditionally_complete_lattice
   {α : Type*} [conditionally_complete_lattice α] :
   conditionally_complete_lattice (with_bot α) :=
-{ Sup := @has_Inf.Inf _ (@with_top.lattice.has_Inf (order_dual α) _),
-  Inf := @has_Sup.Sup _ (@with_top.lattice.has_Sup (order_dual α) _ _),
-  le_cSup := (@with_top.conditionally_complete_lattice (order_dual α) _).cInf_le,
+{ le_cSup := (@with_top.conditionally_complete_lattice (order_dual α) _).cInf_le,
   cSup_le := (@with_top.conditionally_complete_lattice (order_dual α) _).le_cInf,
   cInf_le := (@with_top.conditionally_complete_lattice (order_dual α) _).le_cSup,
   le_cInf := (@with_top.conditionally_complete_lattice (order_dual α) _).cSup_le,
-  ..with_bot.lattice }
+  ..with_bot.lattice,
+  ..with_bot.lattice.has_Sup,
+  ..with_bot.lattice.has_Inf }
 
 /-- Adding a bottom and a top to a conditionally complete lattice gives a bounded lattice-/
 noncomputable instance {α : Type*} [conditionally_complete_lattice α] : bounded_lattice (with_top (with_bot α)) :=
 { ..with_top.order_bot,
   ..with_top.order_top,
-  ..conditionally_complete_lattice.to_lattice _,
- }
+  ..conditionally_complete_lattice.to_lattice _ }
 
 def with_top.cSup_empty {α : Type*} [conditionally_complete_lattice α] :
   Sup (∅ : set (with_bot α)) = ⊥ :=
@@ -897,25 +899,24 @@ noncomputable instance {α : Type*} [conditionally_complete_lattice α] :
       by_cases h : S = ∅,
       { show ite _ _ _ ≤ a,
         split_ifs,
-        { rw h at h_1, cases h_1},
-        { convert bot_le, convert with_top.cSup_empty, rw h, refl},
-        { exfalso, apply h_2, use ⊥, rw h, rintro b ⟨⟩}},
-      { refine (with_top.is_lub_Sup' h).2 ha},
+        { rw h at h_1, cases h_1 },
+        { convert bot_le, convert with_top.cSup_empty, rw h, refl },
+        { exfalso, apply h_2, use ⊥, rw h, rintro b ⟨⟩ } },
+      { refine (with_top.is_lub_Sup' h).2 ha }
     end,
   Inf_le := λ S a haS,
     show ite _ _ _ ≤ a,
     begin
       split_ifs,
       { cases a with a, exact _root_.le_refl _,
-        cases (h haS); tauto,
-      },
+        cases (h haS); tauto },
       { cases a,
-        { exact le_top},
-        { apply with_top.some_le_some.2, refine cInf_le _ haS, use ⊥, intros b hb, exact bot_le}}
+        { exact le_top },
+        { apply with_top.some_le_some.2, refine cInf_le _ haS, use ⊥, intros b hb, exact bot_le } }
     end,
   le_Inf := λ S a haS, (with_top.is_glb_Inf' ⟨a, haS⟩).2 haS,
   ..with_top.lattice.has_Inf,
   ..with_top.lattice.has_Sup,
-  ..with_top.lattice.bounded_lattice
-}
+  ..with_top.lattice.bounded_lattice }
+
 end with_top_bot

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -100,7 +100,7 @@ end preorder
 
 /--When there is a global minimum, every set is bounded below.-/
 @[simp] lemma bdd_below_bot [order_bot α] (s : set α) : bdd_below s :=
-⟨⊥, assume a ha,  order_bot.bot_le a⟩
+⟨⊥, assume a ha, order_bot.bot_le a⟩
 
 /-When there is a max (i.e., in the class semilattice_sup), then the union of
 two bounded sets is bounded, by the maximum of the bounds for the two sets.
@@ -214,6 +214,29 @@ finite.induction_on H
 
 end semilattice_inf
 
+section with_top_bot
+
+/-!
+Extension of Sup and Inf from a preorder `α` to `with_top α` and `with_bot α`
+-/
+
+open_locale classical
+
+noncomputable instance {α : Type*} [preorder α] [has_Sup α] : has_Sup (with_top α) :=
+⟨λ S, if ⊤ ∈ S then ⊤ else
+  if ¬ bdd_above (coe ⁻¹' S : set α) then ⊤ else ↑(Sup (coe ⁻¹' S : set α))⟩
+
+noncomputable instance {α : Type*} [has_Inf α] : has_Inf (with_top α) :=
+⟨λ S, if S ⊆ {⊤} then ⊤ else ↑(Inf (coe ⁻¹' S : set α))⟩
+
+noncomputable instance {α : Type*} [has_Sup α] : has_Sup (with_bot α) :=
+⟨λ S, if S ⊆ {⊥} then ⊥ else ↑(Sup (coe ⁻¹' S : set α))⟩
+
+noncomputable instance {α : Type*} [preorder α] [has_Inf α] : has_Inf (with_bot α) :=
+⟨λ S, if ⊥ ∈ S then ⊥ else
+  if ¬ bdd_below (coe ⁻¹' S : set α) then ⊥ else ↑(Inf (coe ⁻¹' S : set α))⟩
+
+end with_top_bot
 
 namespace lattice
 /-- A conditionally complete lattice is a lattice in which


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [x ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [x ] make sure definitions and lemmas are put in the right files
  * [x ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)

--------

This PR is a response to the comment in #1703 that my proof that ereal := [-infty,infty] was a complete lattice should be generalised to the statement that with_top(with_bot(cond complete lattice)) = complete lattice. I'll come back to #1703 and use this stuff, if we can get this PR into an acceptable form.

This PR shows that if L is a conditionally complete lattice then `with_top (with_bot L) is a complete lattice. It does it by showing that with_bot (conditionally complete lattice) is conditionally complete, using duality to prove the same for with_top (thanks Chris), and then picking up the pieces by dealing with the empty and unbounded cases. The idea is that Sup on a conditionally complete lattice returns junk in the empty / unbounded cases, but the extensions of Sup to with_bot / with_top fix these problems (they fix one each). 

I had to make up some instance names. Are they OK? I didn't really know what I was doing. But then neither did Lean.

I could envisage some other lattice classes e.g. a conditionally complete lattice with a top (so all non-empty sets have a least upper bound, but only non-empty bounded-below sets have a greatest lower bound). It seemed a bit ridiculous to introduce these classes, we already have e.g. conditionally_complete_linear_order_bot for with_bot(conditionally complete linear order), and linear orders are probably the main use case.

I could have used conditionally_complete_linear_order_bot here but then I would have ended up proving that a conditionally complete linear order gives rise to a complete linear order after adding top and bot, which is a weaker result than what I have proved.

Patrick pointed out [here](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/option.20golf.20puzzle/near/181623482) that I could have used `tauto` to help me along in some places, but this would have involved adding an import which I was reluctant to do (simply because I don't understand the import tree, for all I know tauto uses lattices or there is some other principle which says I shouldn't do it). All my proofs are short really, modulo many case splits, which as far as I can see are unavoidable.