### PR TITLE
feat(algebra/group): define `mul/add_left/right_injective`

### DIFF
--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -20,6 +20,14 @@ instance monoid_to_is_right_id {α : Type*} [monoid α]
 : is_right_id α (*) 1 :=
 ⟨ monoid.mul_one ⟩
 
+@[to_additive]
+theorem mul_left_injective [left_cancel_semigroup α] (a : α) : function.injective ((*) a) :=
+λ b c, mul_left_cancel
+
+@[to_additive]
+theorem mul_right_injective [right_cancel_semigroup α] (a : α) : function.injective (λ x, x * a) :=
+λ b c, mul_right_cancel
+
 @[simp, to_additive]
 theorem mul_left_inj [left_cancel_semigroup α] (a : α) {b c : α} : a * b = a * c ↔ b = c :=
 ⟨mul_left_cancel, congr_arg _⟩


### PR DESCRIPTION
Same as `mul_left_cancel` etc but uses `function.injective`.
This makes it easier to use functions from `function.injective` namespace.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
