### PR TITLE
feat(topology/metric_space/basic): define `cauchy_seq_of_le_tendsto_0`

### DIFF
--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -688,6 +688,17 @@ begin
     exact lt_of_le_of_lt this (lt_add_of_pos_right _ zero_lt_one) }
 end
 
+/-- A version of `cauchy_seq_iff_le_tendsto_0.2` that doesn't assume `0 ≤ b n`. -/
+lemma cauchy_seq_of_le_tendsto_0 {s : ℕ → α} (b : ℕ → ℝ)
+  (h : ∀ n m N : ℕ, N ≤ n → N ≤ m → dist (s n) (s m) ≤ b N) (h₀ : tendsto b at_top (nhds 0)) :
+  cauchy_seq s :=
+metric.cauchy_seq_iff.2 $ λ ε ε0,
+  (metric.tendsto_at_top.1 h₀ ε ε0).imp $ λ N hN m n hm hn,
+  calc dist (s m) (s n) ≤ b N : h m n N hm hn
+                    ... ≤ abs (b N) : le_abs_self _
+                    ... = dist (b N) 0 : by rw real.dist_0_eq_abs; refl
+                    ... < ε : (hN _ (le_refl N))
+
 /-- Yet another metric characterization of Cauchy sequences on integers. This one is often the
 most efficient. -/
 lemma cauchy_seq_iff_le_tendsto_0 {s : ℕ → α} : cauchy_seq s ↔ ∃ b : ℕ → ℝ,
@@ -720,12 +731,7 @@ lemma cauchy_seq_iff_le_tendsto_0 {s : ℕ → α} : cauchy_seq s ↔ ∃ b : �
   rintro _ ⟨⟨m', n'⟩, ⟨hm', hn'⟩, rfl⟩,
   exact le_of_lt (hN _ _ (le_trans hn hm') (le_trans hn hn'))
   end,
-λ ⟨b, _, b_bound, b_lim⟩, metric.cauchy_seq_iff.2 $ λ ε ε0,
-  (metric.tendsto_at_top.1 b_lim ε ε0).imp $ λ N hN m n hm hn,
-  calc dist (s m) (s n) ≤ b N : b_bound m n N hm hn
-                    ... ≤ abs (b N) : le_abs_self _
-                    ... = dist (b N) 0 : by rw real.dist_0_eq_abs; refl
-                    ... < ε : (hN _ (le_refl N)) ⟩
+λ ⟨b, _, b_bound, b_lim⟩, cauchy_seq_of_le_tendsto_0 b b_bound b_lim⟩
 
 end cauchy_seq
 

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -671,6 +671,18 @@ begin
                     ... = ε : add_halves _⟩ }
 end
 
+/-- If the distance between `s n` and `s m`, `n, m ≥ N` is bounded above by `b N`
+and `b` converges to zero, then `s` is a Cauchy sequence.  -/
+lemma cauchy_seq_of_le_tendsto_0 {s : β → α} (b : β → ℝ)
+  (h : ∀ n m N : β, N ≤ n → N ≤ m → dist (s n) (s m) ≤ b N) (h₀ : tendsto b at_top (nhds 0)) :
+  cauchy_seq s :=
+metric.cauchy_seq_iff.2 $ λ ε ε0,
+  (metric.tendsto_at_top.1 h₀ ε ε0).imp $ λ N hN m n hm hn,
+  calc dist (s m) (s n) ≤ b N : h m n N hm hn
+                    ... ≤ abs (b N) : le_abs_self _
+                    ... = dist (b N) 0 : by rw real.dist_0_eq_abs; refl
+                    ... < ε : (hN _ (le_refl N))
+
 /-- A Cauchy sequence on the natural numbers is bounded. -/
 theorem cauchy_seq_bdd {u : ℕ → α} (hu : cauchy_seq u) :
   ∃ R > 0, ∀ m n, dist (u m) (u n) < R :=
@@ -687,17 +699,6 @@ begin
   { have : _ ≤ R := finset.le_sup (finset.mem_range.2 h),
     exact lt_of_le_of_lt this (lt_add_of_pos_right _ zero_lt_one) }
 end
-
-/-- A version of `cauchy_seq_iff_le_tendsto_0.2` that doesn't assume `0 ≤ b n`. -/
-lemma cauchy_seq_of_le_tendsto_0 {s : ℕ → α} (b : ℕ → ℝ)
-  (h : ∀ n m N : ℕ, N ≤ n → N ≤ m → dist (s n) (s m) ≤ b N) (h₀ : tendsto b at_top (nhds 0)) :
-  cauchy_seq s :=
-metric.cauchy_seq_iff.2 $ λ ε ε0,
-  (metric.tendsto_at_top.1 h₀ ε ε0).imp $ λ N hN m n hm hn,
-  calc dist (s m) (s n) ≤ b N : h m n N hm hn
-                    ... ≤ abs (b N) : le_abs_self _
-                    ... = dist (b N) 0 : by rw real.dist_0_eq_abs; refl
-                    ... < ε : (hN _ (le_refl N))
 
 /-- Yet another metric characterization of Cauchy sequences on integers. This one is often the
 most efficient. -/


### PR DESCRIPTION
Sometimes it is convenient to avoid proving `0 ≤ b n`.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
