### PR TITLE
feat(algebra/*,data/real/*): add some inequalities about `canonically_ordered_comm_semiring`s

### DIFF
--- a/src/algebra/group_power.lean
+++ b/src/algebra/group_power.lean
@@ -532,6 +532,25 @@ lemma smul_le_smul_of_le_right {a b : α} (hab : a ≤ b) : ∀ i : ℕ, i • a
 
 end add_monoid
 
+namespace canonically_ordered_semiring
+variable [canonically_ordered_comm_semiring α]
+
+theorem pow_pos {a : α} (H : 0 < a) : ∀ n : ℕ, 0 < a ^ n
+| 0     := canonically_ordered_semiring.zero_lt_one
+| (n+1) := canonically_ordered_semiring.mul_pos.2 ⟨H, pow_pos n⟩
+
+lemma pow_le_pow_of_le_left {a b : α} (hab : a ≤ b) : ∀ i : ℕ, a^i ≤ b^i
+| 0     := by simp
+| (k+1) := canonically_ordered_semiring.mul_le_mul hab (pow_le_pow_of_le_left k)
+
+theorem one_le_pow_of_one_le {a : α} (H : 1 ≤ a) (n : ℕ) : 1 ≤ a ^ n :=
+by simpa only [one_pow] using pow_le_pow_of_le_left H n
+
+theorem pow_le_one {a : α} (H : a ≤ 1) (n : ℕ) : a ^ n ≤ 1:=
+by simpa only [one_pow] using pow_le_pow_of_le_left H n
+
+end canonically_ordered_semiring
+
 section linear_ordered_semiring
 variable [linear_ordered_semiring α]
 

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -362,7 +362,9 @@ end prio
 namespace canonically_ordered_semiring
 open canonically_ordered_monoid
 
-lemma mul_le_mul [canonically_ordered_comm_semiring α] {a b c d : α} (hab : a ≤ b) (hcd : c ≤ d) :
+variable [canonically_ordered_comm_semiring α]
+
+lemma mul_le_mul {a b c d : α} (hab : a ≤ b) (hcd : c ≤ d) :
   a * c ≤ b * d :=
 begin
   rcases (le_iff_exists_add _ _).1 hab with ⟨b, rfl⟩,
@@ -370,6 +372,13 @@ begin
   suffices : a * c ≤ a * c + (a * d + b * c + b * d), by simpa [mul_add, add_mul],
   exact (le_iff_exists_add _ _).2 ⟨_, rfl⟩
 end
+
+/-- A version of `zero_lt_one : 0 < 1` for a `canonically_ordered_comm_semiring`. -/
+lemma zero_lt_one : (0:α) < 1 := lt_of_le_of_ne (zero_le 1) zero_ne_one
+
+lemma mul_pos {a b : α} : 0 < a * b ↔ (0 < a) ∧ (0 < b) :=
+by simp only [zero_lt_iff_ne_zero, ne.def, canonically_ordered_comm_semiring.mul_eq_zero_iff,
+  not_or_distrib]
 
 end canonically_ordered_semiring
 

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -195,8 +195,11 @@ lemma coe_le_iff : ↑r ≤ a ↔ (∀p:nnreal, a = p → r ≤ p) := with_top.c
 
 lemma lt_iff_exists_coe : a < b ↔ (∃p:nnreal, a = p ∧ ↑p < b) := with_top.lt_iff_exists_coe a b
 
--- TODO: move to canonically ordered semiring ...
-protected lemma zero_lt_one : 0 < (1 : ennreal) := zero_lt_coe_iff.mpr zero_lt_one
+protected lemma zero_lt_one : 0 < (1 : ennreal) :=
+  canonically_ordered_semiring.zero_lt_one
+
+protected lemma pow_pos : 0 < a → ∀ n : ℕ, 0 < a^n :=
+  canonically_ordered_semiring.pow_pos
 
 @[simp] lemma not_lt_zero : ¬ a < 0 := by simp
 


### PR DESCRIPTION
Use them for `nnreal` and `ennreal`.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
