### PR TITLE
doc(*): correct bad markdown

### DIFF
--- a/docs/contribute/doc.md
+++ b/docs/contribute/doc.md
@@ -12,7 +12,8 @@ Each mathlib file should start with:
 
 (See the example below.)
 
-Headers use atx-style headers (with hash signs, no underlying dash).
+Headers use atx-style headers (with hash signs, no underlying dash). 
+The open and close delimiters `/-!` and `-/` should appear on their own lines.
 
 The mandatory title of the file is a first level header. It is followed by a summary of the content
 of the file.
@@ -129,6 +130,8 @@ have multiple sections or namespaces following one sectioning comment.
 Sectioning comments are for display and readability only. They have no semantic meaning.
 
 Third-level headers `###` should be used for titles inside sectioning comments.
+
+If the comment is more than one line long, the delimiters `/-!` and `-/` should appear on their own lines.
 
 See [meta/expr.lean](../../src/meta/expr.lean) for an example in practice.
 

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -6,7 +6,8 @@ Authors: Sébastien Gouëzel
 
 import analysis.calculus.deriv
 
-/-! # The mean value inequality
+/-! 
+# The mean value inequality
 
 A bound on the derivative of a function implies that this function
 is Lipschitz continuous for the same bound, on a segment or more generally in a convex set.

--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -76,7 +76,8 @@ local infixr ` →ₛ `:25 := simple_func
 namespace simple_func
 
 section bintegral
-/-! ### The Bochner integral of simple functions
+/-! 
+### The Bochner integral of simple functions
 
 Define the Bochner integral of simple functions of the type `α →ₛ β` where `β` is a normed group,
 and prove basic property of this integral.

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -7,13 +7,13 @@ import data.string.defs
 /-!
 # Additional operations on expr and related types
 
- This file defines basic operations on the types expr, name, declaration, level, environment.
+This file defines basic operations on the types expr, name, declaration, level, environment.
 
- This file is mostly for non-tactics. Tactics should generally be placed in `tactic.core`.
+This file is mostly for non-tactics. Tactics should generally be placed in `tactic.core`.
 
- ## Tags
+## Tags
 
- expr, name, declaration, level, environment, meta, metaprogramming, tactic
+expr, name, declaration, level, environment, meta, metaprogramming, tactic
 -/
 
 namespace binder_info


### PR DESCRIPTION
The markdown processing for doc generation doesn't like spaces at the beginning of header lines ` # title`. It seems that leading whitespace is included in doc strings of this form:
```
/-! # header
text on a second line -/
```

For some reason, single-line comments `/-! ### header -/` seem to be fine.

I'll also change this in the doc processing -- stripping whitespace from the beginning and end of markdown blocks will fix some cases of this. But we should try to follow the convention that module docs with more than one line have the `/-!` and `-/` on separate lines.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
