### PR TITLE
feat(meta/expr): use structure_fields

### DIFF
--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -452,38 +452,14 @@ namespace environment
 meta def in_current_file' (env : environment) (n : name) : bool :=
 env.in_current_file n && (n ∉ [``quot, ``quot.mk, ``quot.lift, ``quot.ind])
 
-/-- Tests whether `n` is an inductive type with one constructor without indices.
-  If so, returns the number of paramaters and the name of the constructor.
-  Otherwise, returns `none`. -/
-meta def is_structure_like (env : environment) (n : name) : option (nat × name) :=
-do guardb (env.is_inductive n),
-  d ← (env.get n).to_option,
-  [intro] ← pure (env.constructors_of n) | none,
-  guard (env.inductive_num_indices n = 0),
-  some (env.inductive_num_params n, intro)
-
-/-- Tests whether `n` is a structure.
-  It will first test whether `n` is structure-like and then test that the first projection is
-  defined in the environment and is a projection. -/
+/-- Tests whether `n` is a structure. -/
 meta def is_structure (env : environment) (n : name) : bool :=
-option.is_some $ do
-  (nparams, intro) ← env.is_structure_like n,
-  di ← (env.get intro).to_option,
-  expr.pi x _ _ _ ← nparams.iterate
-    (λ e : option expr, do expr.pi _ _ _ body ← e | none, some body)
-    (some di.type) | none,
-  env.is_projection (n ++ x.deinternalize_field)
+(env.structure_fields n).is_some
 
-/-- Get all projections of the structure `n`. Returns `none` if `n` is not structure-like.
-  If `n` is not a structure, but is structure-like, this does not check whether the names
-  are existing declarations. -/
-meta def get_projections (env : environment) (n : name) : option (list name) := do
-  (nparams, intro) ← env.is_structure_like n,
-  di ← (env.get intro).to_option,
-  tgt ← nparams.iterate
-    (λ e : option expr, do expr.pi _ _ _ body ← e | none, some body)
-    (some di.type) | none,
-  return $ tgt.binding_names.map (λ x, n ++ x.deinternalize_field)
+/-- Get the full names of all projections of the structure `n`. Returns `none` if `n` is not a
+  structure. -/
+meta def structure_fields_full (env : environment) (n : name) : option (list name) :=
+(env.structure_fields n).map (list.map $ λ n', n ++ n')
 
 /-- Tests whether `nm` is a generalized inductive type that is not a normal inductive type.
   Note that `is_ginductive` returns `tt` even on regular inductive types.
@@ -594,7 +570,7 @@ do l' ← l.mfilter (λ⟨proj, val⟩, bnot <$> is_proof val),
 meta def is_eta_expansion (val : expr) : tactic (option expr) := do
   e ← get_env,
   type ← infer_type val,
-  projs ← e.get_projections type.get_app_fn.const_name,
+  projs ← e.structure_fields_full type.get_app_fn.const_name,
   let args := (val.get_app_args).drop type.get_app_args.length,
   is_eta_expansion_aux val (projs.zip args)
 

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -43,7 +43,7 @@ meta def simps_add_projections : ∀(e : environment) (nm : name) (suffix : stri
   let rhs_ap := rhs.instantiate_lambdas_or_apps type_args,
   let str := tgt.get_app_fn.const_name,
   if e.is_structure str then do
-    projs ← e.get_projections str,
+    projs ← e.structure_fields_full str,
     [intro] ← return $ e.constructors_of str | fail "unreachable code (3)",
     let params := get_app_args tgt, -- the parameters of the structure
     if is_constant_of (get_app_fn rhs_ap) intro then do -- if the value is a constructor application

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -72,15 +72,6 @@ run_cmd do
   e.get `name_clash_fst_2,
   e.get `name_clash_snd_3
 
-/- test whether environment.get_projections works correctly on all structures -/
-meta def test_projection (env : environment) (n : name) : tactic unit := do
-  ns ← env.get_projections n,
-  ns.mmap' $ λ n, if (env.is_projection n).is_some then skip else fail ns,
-  skip
-
-run_cmd do e ← get_env, e.mfold ()
-  (λ d _, if e.is_structure d.to_name then test_projection e d.to_name else skip)
-
 /- check projections for nested structures -/
 
 namespace count_nested

--- a/test/tactics.lean
+++ b/test/tactics.lean
@@ -358,7 +358,7 @@ def eta_expansion_test2 : ℕ ≃ ℕ :=
 
 run_cmd do e ← get_env, x ← e.get `eta_expansion_test2,
   let v := (x.value.get_app_args).drop 2,
-  projs ← e.get_projections `equiv,
+  projs ← e.structure_fields_full `equiv,
   b ← expr.is_eta_expansion_aux x.value (projs.zip v),
   guard $ b = some `(@my_rfl ℕ)
 


### PR DESCRIPTION
removes `is_structure_like`
simplifies definition of `is_structure`
renames and simplifies definition `get_projections`. It is now called `structure_fields_full`

I tested it:
* On all declarations in mathlib the behavior of `is_structure` hasn't changed.
* For all declarations where `is_structure` is true, the behavior of `get_projections` hasn't changed.