### PR TITLE
feat(lint): avoid Travis error when declarations are renamed

### DIFF
--- a/scripts/mk_nolint.lean
+++ b/scripts/mk_nolint.lean
@@ -32,7 +32,8 @@ meta def main : io unit :=
 do (ns, _) ← run_tactic $ lint_mathlib tt tt active_linters tt,
    handle ← mk_file_handle "nolints.txt" mode.write,
    put_str_ln handle "import .all",
-   put_str_ln handle "attribute [nolint]",
+   put_str_ln handle "run_cmd tactic.skip",
+   put_str_ln handle "apply_nolint",
    (ns.to_list.merge_sort (λ a b, name.lex_cmp a b = ordering.lt)).mmap $
      λ n, put_str_ln handle (to_string n) >> return n,
    close handle

--- a/scripts/nolints.txt
+++ b/scripts/nolints.txt
@@ -1,5 +1,6 @@
 import .all
-attribute [nolint]
+run_cmd tactic.skip
+apply_nolint
 AddCommGroup
 AddCommGroup.of
 AddCommMon
@@ -1386,7 +1387,6 @@ is_closed_map
 is_cobounded_ge_nhds
 is_cobounded_under_ge_of_tendsto
 is_comm_applicative
-is_complete
 is_conj
 is_cyclic
 is_cyclic.comm_group

--- a/src/tactic/lint.lean
+++ b/src/tactic/lint.lean
@@ -463,3 +463,13 @@ let ns := env.decl_filter_map $ λ dcl,
 { name := "Lint",
   descr := "Lint: Find common mistakes in current file.",
   action := λ es, do (_, s) ← lint, return [(s.to_string,"")] }
+
+/-- Tries to apply the `nolint` attribute to a list of declarations. Always succeeds, even if some
+of the declarations don't exist. -/
+meta def apply_nolint_tac (decls : list name) : tactic unit :=
+decls.mmap' (λ d, try (nolint_attr.set d () tt))
+
+/-- `apply_nolint id1 id2 ...` tries to apply the `nolint` attribute to `id1`, `id2`, ...
+It will always succeed, even if some of the declarations do not exist. -/
+@[user_command] meta def apply_nolint_cmd (_ : parse $ tk "apply_nolint") : parser unit :=
+ident_* >>= ↑apply_nolint_tac


### PR DESCRIPTION
This was suggested by @fpvandoorn . It makes the Travis linting check slightly more robust -- it will no longer fail when attempting to apply the `nolint` attribute to declarations that no longer exist.

Note that this doesn't avoid all errors when renaming declarations. Suppose `def d := ...` exists in mathlib without a doc string. A PR renaming `d` to `d2`, without documenting it, will still raise an error. But a PR that renames `d` to `d2` and adds a doc string will pass. This would fail before, since it would try to apply the `nolint` attribute to the nonexistent declaration `d`.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
