### PR TITLE
simps using user-defined projections

### DIFF
--- a/src/data/list/defs.lean
+++ b/src/data/list/defs.lean
@@ -531,11 +531,11 @@ protected def traverse {F : Type u → Type v} [applicative F] {α β : Type*} (
 | [] := pure []
 | (x :: xs) := list.cons <$> f x <*> traverse xs
 
-/-- `get_rest l l₁` returns `some l₂` if `l = l₁ ++ l₂`.
+/-- `drop_prefix l l₁` returns `some l₂` if `l = l₁ ++ l₂`.
   If `l₁` is not a prefix of `l`, returns `none` -/
-def get_rest [decidable_eq α] : list α → list α → option (list α)
+def drop_prefix [decidable_eq α] : list α → list α → option (list α)
 | l      []      := some l
 | []     _       := none
-| (x::l) (y::l₁) := if x = y then get_rest l l₁ else none
+| (x::l) (y::l₁) := if x = y then drop_prefix l l₁ else none
 
 end list

--- a/src/data/string/defs.lean
+++ b/src/data/string/defs.lean
@@ -19,13 +19,13 @@ x.to_list.is_prefix_of y.to_list
 def is_suffix_of (x y : string) : bool :=
 x.to_list.is_suffix_of y.to_list
 
-/-- `get_rest s t` returns `some r` if `s = t ++ r`.
+/-- `drop_prefix s t` returns `some r` if `s = t ++ r`.
   If `t` is not a prefix of `s`, returns `none` -/
-def get_rest (s t : string) : option string :=
-list.as_string <$> s.to_list.get_rest t.to_list
+def drop_prefix (s t : string) : option string :=
+list.as_string <$> s.to_list.drop_prefix t.to_list
 
 /-- Removes the first `n` elements from the string `s` -/
-def popn (s : string) (n : nat) : string :=
+def drop (s : string) (n : nat) : string :=
 (s.mk_iterator.nextn n).next_to_string
 
 end string

--- a/src/tactic/lint.lean
+++ b/src/tactic/lint.lean
@@ -137,7 +137,7 @@ ds.foldl
 meta def print_decls_sorted_mathlib {α} [has_to_format α] (n : ℕ)
   (ds : list (string × list (declaration × α))) : format :=
 ds.foldl
-  (λ f x, f ++ "\n\n" ++ to_fmt "-- " ++ to_fmt (x.1.popn n) ++ print_decls x.2)
+  (λ f x, f ++ "\n\n" ++ to_fmt "-- " ++ to_fmt (x.1.drop n) ++ print_decls x.2)
   format.nil
 
 /-- Auxilliary definition for `check_unused_arguments` -/

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
-import tactic.core
+import tactic.core category.traversable.basic tactic.replacer
 /-!
   # simps attribute
   This file defines the `@[simps]` attribute, to automatically generate simp-lemmas
@@ -18,29 +18,68 @@ open tactic expr
 /-- Add a lemma with `nm` stating that `lhs = rhs`. `type` is the type of both `lhs` and `rhs`,
   `args` is the list of local constants occurring, and `univs` is the list of universe variables.
   If `add_simp` then we make the resulting lemma a simp-lemma. -/
-meta def simps_add_projection (nm : name) (type lhs rhs : expr) (args : list expr)
-  (univs : list name) (add_simp : bool) : tactic unit := do
-  eq_ap ← mk_mapp `eq $ [type, lhs, rhs].map some,
-  refl_ap ← mk_app `eq.refl [type, lhs],
-  decl_name ← get_unused_decl_name nm,
-  let decl_type := eq_ap.pis args,
-  let decl_value := refl_ap.lambdas args,
-  let decl := declaration.thm decl_name univs decl_type (pure decl_value),
-  add_decl decl <|> fail format!"failed to add projection lemma {decl_name}.",
-  when add_simp $
-    set_basic_attribute `simp decl_name tt >> set_basic_attribute `_refl_lemma decl_name tt
+meta def simps_add_projection (nm : name) (type lhs rhs pr : expr) (args : list expr)
+  (univs : list name) (add_simp : bool) : tactic unit :=
+do eq_ap ← mk_mapp `eq [type, lhs, rhs],
+   decl_name ← get_unused_decl_name nm,
+   let decl_type := eq_ap.pis args,
+   decl_type ← instantiate_mvars decl_type,
+   decl_value ← instantiate_mvars pr,
+   when_tracing `simps_lemmas_names $ trace!"New lemma: {decl_name} : {decl_type}",
+   let decl := declaration.thm decl_name univs decl_type (pure decl_value),
+   trace_error (sformat!"failed to add projection lemma {decl_name}.") $ add_decl decl,
+   when add_simp $
+     set_basic_attribute `simp decl_name tt >> set_basic_attribute `_refl_lemma decl_name tt
+
+meta def simps_add_projection' (nm : name) (type lhs rhs : expr) (pr : option expr) (args : list expr)
+  (univs : list name) (add_simp : bool) : tactic unit :=
+do decl_value ← match pr with
+                | none := mk_app `eq.refl [type, lhs]
+                | (some pr) := pure pr
+                end,
+   let decl_value := decl_value.lambdas args,
+   simps_add_projection nm type lhs rhs decl_value args univs add_simp
+
+open native
+
+@[user_attribute]
+meta def projection_attr : user_attribute (rb_lmap name (name × name)) name :=
+{ name := `projection,
+  descr := "descr",
+  cache_cfg := { mk_cache := λ ls,
+                 do { ls.mfoldl (λ m l,
+                       do d ← projection_attr.get_param l,
+                          decl ← get_decl l,
+                          (_,t) ← mk_local_pis decl.type,
+                          (lhs,rhs) ← match_eq t,
+                          pure $ m.insert d (lhs.get_app_fn.const_name,l) ) (rb_lmap.mk _ _) },
+                 dependencies := [] },
+  parser := lean.parser.ident }
+
+meta def get_ext_projections (env : environment) (n : name) : tactic (list $ name × name) :=
+do m ← projection_attr.get_cache,
+   pure $ m.find n
+
+meta def apply_congr : list expr → expr → tactic expr
+| [] p := pure p
+| (v :: vs) p :=
+  mk_congr_fun p v >>= apply_congr vs
+
+declare_trace simps_lemmas_names
 
 /-- Derive lemmas specifying the projections of the declaration.
   If `todo` is non-empty, it will generate exactly the names in `todo`. -/
-meta def simps_add_projections : ∀(e : environment) (nm : name) (suffix : string)
-  (type lhs rhs : expr) (args : list expr) (univs : list name)
+@[replaceable]
+meta def simps_add_projections' : ∀(e : environment) (nm : name) (suffix : string)
+  (type lhs rhs : expr) (pr : option expr) (args : list expr) (univs : list name)
   (add_simp must_be_str short_nm : bool) (todo : list string), tactic unit
-| e nm suffix type lhs rhs args univs add_simp must_be_str short_nm todo := do
+| e nm suffix type lhs rhs pr args univs add_simp must_be_str short_nm todo := do
   (type_args, tgt) ← mk_local_pis_whnf type,
   tgt ← whnf tgt,
   let new_args := args ++ type_args,
   let lhs_ap := lhs.mk_app type_args,
   let rhs_ap := rhs.instantiate_lambdas_or_apps type_args,
+  pr ← traverse (apply_congr type_args) pr,
   let str := tgt.get_app_fn.const_name,
   if e.is_structure str then do
     projs ← e.get_projections str,
@@ -55,8 +94,8 @@ meta def simps_add_projections : ∀(e : environment) (nm : name) (suffix : stri
       let rhs_ap := eta.lhoare rhs_ap, -- eta-reduce `rhs_ap`
       /- we want to generate the current projection if it is in `todo` or when `rhs_ap` was an
       eta-expansion -/
-      when ("" ∈ todo ∨ (todo = [] ∧ eta.is_some)) $
-        simps_add_projection (nm.append_suffix suffix) tgt lhs_ap rhs_ap new_args univs add_simp,
+      when ("" ∈ todo ∨ (todo = [] ∧ eta.is_some)) $ do
+        { simps_add_projection' (nm.append_suffix suffix) tgt lhs_ap rhs_ap pr new_args univs add_simp },
       -- if `rhs_ap` was an eta-expansion and `todo` is empty, we stop
       when ¬(todo = [""] ∨ (eta.is_some ∧ todo = [])) $ do
         /- remove "" from todo. This allows a to generate lemmas + nested version of them.
@@ -67,30 +106,46 @@ meta def simps_add_projections : ∀(e : environment) (nm : name) (suffix : stri
           let x := (todo.find $ λ x, projs.all $ λ proj, ¬ ("_" ++ proj.last).is_prefix_of x).iget,
             simp_lemma := nm.append_suffix $ suffix ++ x, needed_proj := (x.split_on '_').tail.head in
           fail format!"Invalid simp-lemma {simp_lemma}. Projection {needed_proj} doesn't exist.",
-        pairs.mmap' $ λ ⟨proj, new_rhs⟩, do
-          new_type ← infer_type new_rhs,
-          let new_todo := todo.filter_map $ λ x, string.get_rest x $ "_" ++ proj.last,
-          b ← is_prop new_type,
-          -- we only continue with this field if it is non-propositional or mentioned in todo
-          when ((¬ b ∧ todo = []) ∨ (todo ≠ [] ∧ new_todo ≠ [])) $ do
-            -- cannot use `mk_app` here, since the resulting application might still be a function.
-            new_lhs ← mk_mapp proj $ (params ++ [lhs_ap]).map some,
-            let new_suffix := if short_nm then "_" ++ proj.last else
-              suffix ++ "_" ++ proj.last,
-            simps_add_projections e nm new_suffix new_type new_lhs new_rhs new_args univs
-              add_simp ff short_nm new_todo
+        pairs.mmap' $ λ ⟨proj, new_rhs⟩,
+        do { new_type ← infer_type new_rhs,
+             let new_todo := todo.filter_map $ λ x, string.drop_prefix x $ "_" ++ proj.last,
+             b ← is_prop new_type,
+             -- we only continue with this field if it is non-propositional or mentioned in todo
+             when ((¬ b ∧ todo = []) ∨ (todo ≠ [] ∧ new_todo ≠ [])) $ do
+               -- cannot use `mk_app` here, since the resulting application might still be a function.
+               new_lhs ← mk_mapp proj $ (params ++ [lhs_ap]).map some,
+               let new_suffix := if short_nm then "_" ++ proj.last else
+                 suffix ++ "_" ++ proj.last,
+               simps_add_projections' e nm new_suffix new_type new_lhs new_rhs none new_args univs
+                 add_simp ff short_nm new_todo },
+        let t_params := tgt.get_app_args,
+        projs' ← get_ext_projections e str,
+        projs'.mmap' $ λ ⟨proj,lmm⟩, try $
+        do { d ← get_decl lmm,
+             lmm ← mk_const lmm,
+             new_lhs ← mk_mapp proj $ t_params.map some,
+             (new_rhs, prf, _) ← rewrite lmm (new_lhs rhs_ap) { md := transparency.all },
+             new_rhs ← instantiate_mvars new_rhs,
+             prf ← instantiate_mvars prf,
+             let new_lhs := new_lhs lhs_ap,
+             new_type ← infer_type new_lhs,
+             let new_todo := todo.filter_map $ λ x, string.drop_prefix x $ "_" ++ proj.last,
+             let new_suffix := if short_nm then "_" ++ proj.last else
+               suffix ++ "_" ++ proj.last,
+             simps_add_projections' e nm new_suffix new_type new_lhs new_rhs (some prf) new_args univs
+               add_simp ff short_nm new_todo }
     else do
       when must_be_str $
         fail "Invalid `simps` attribute. Body is not a constructor application",
       when (todo ≠ [] ∧ todo ≠ [""]) $
         fail format!"Invalid simp-lemma {nm.append_suffix $ suffix ++ todo.head}. Too many projections given.",
-      simps_add_projection (nm.append_suffix suffix) tgt lhs_ap rhs_ap new_args univs add_simp
+      simps_add_projection' (nm.append_suffix suffix) tgt lhs_ap rhs_ap pr new_args univs add_simp
   else do
     when must_be_str $
       fail "Invalid `simps` attribute. Target is not a structure",
     when (todo ≠ [] ∧ todo ≠ [""]) $
-        fail format!"Invalid simp-lemma {nm.append_suffix $ suffix ++ todo.head}. Too many projections given.",
-    simps_add_projection (nm.append_suffix suffix) tgt lhs_ap rhs_ap new_args univs add_simp
+        fail!"Invalid simp-lemma {nm.append_suffix $ suffix ++ todo.head}. Too many projections given.",
+    simps_add_projection' (nm.append_suffix suffix) tgt lhs_ap rhs_ap pr new_args univs add_simp
 
 /-- `simps_tac` derives simp-lemmas for all (nested) non-Prop projections of the declaration.
   If `todo` is non-empty, it will generate exactly the names in `todo`.
@@ -102,7 +157,9 @@ meta def simps_tac (nm : name) (add_simp : bool) (short_nm : bool := ff)
   d ← e.get nm,
   let lhs : expr := const d.to_name (d.univ_params.map level.param),
   let todo := todo.erase_dup.map $ λ proj, "_" ++ proj,
-  simps_add_projections e nm "" d.type lhs d.value [] d.univ_params add_simp tt short_nm todo
+  let t := d.type,
+  pr ← mk_app ``rfl [t,lhs],
+  simps_add_projections e nm "" d.type lhs d.value pr [] d.univ_params add_simp tt short_nm todo
 
 reserve notation `lemmas_only`
 reserve notation `short_name`
@@ -146,6 +203,9 @@ prod.mk <$> (option.is_none <$> (tk "lemmas_only")?) <*>
 * `@[simps]` reduces let-expressions where necessary.
 * If one of the fields is a partially applied constructor, we will eta-expand it
   (this likely never happens).
+
+Using `set_option trace.simps_lemmas_names true` before the attribute `@[simps]` will list
+the lemmas being declared.
   -/
 @[user_attribute] meta def simps_attr : user_attribute unit (bool × bool × list string) :=
 { name := `simps,


### PR DESCRIPTION
This PR lets the user define custom projections so that `simps` can generate lemmas for them.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
