### PR TITLE
chore(travis): add instance priority linter to CI

### DIFF
--- a/scripts/mk_all.sh
+++ b/scripts/mk_all.sh
@@ -39,5 +39,5 @@ cat <<EOT >> lint_mathlib.lean
 
 open nat -- need to do something before running a command
 
-#lint_mathlib- only unused_arguments dup_namespace doc_blame illegal_constants def_lemma
+#lint_mathlib- only unused_arguments dup_namespace doc_blame illegal_constants def_lemma instance_priority
 EOT

--- a/scripts/mk_nolint.lean
+++ b/scripts/mk_nolint.lean
@@ -25,7 +25,7 @@ open io io.fs
 /-- Defines the list of linters that will be considered. -/
 meta def active_linters :=
 [`linter.unused_arguments, `linter.dup_namespace, `linter.doc_blame,
- `linter.illegal_constants, `linter.def_lemma] --, `linter.instance_priority]
+ `linter.illegal_constants, `linter.def_lemma, `linter.instance_priority]
 
 /-- Runs when called with `lean --run` -/
 meta def main : io unit :=

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -329,7 +329,7 @@ begin
 end
 
 /-- Finite topological spaces are compact. -/
-instance fintype.compact_space [fintype α] : compact_space α :=
+@[priority 100] instance fintype.compact_space [fintype α] : compact_space α :=
 { compact_univ := compact_of_finite set.finite_univ }
 
 /-- The product of two compact spaces is compact. -/


### PR DESCRIPTION
This will almost certainly fail to build at first. I think there should only be a few linter failures, which we can fix. If there are many we can regenerate nolints.txt.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
