### PR TITLE
(docs/tactics.md) adding `norm_num` [ci skip]

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -197,9 +197,10 @@ example : (2 : ℝ) + 2 = 4 := by norm_num
 example : (12345.2 : ℝ) ≠ 12345.3 := by norm_num
 example : (73 : ℝ) < 789/2 := by norm_num
 example : 123456789 + 987654321 = 1111111110 := by norm_num
+example (R : Type*) [ring R] : (2 : R) + 2 = 4 := by norm_num
+example (F : Type*) [linear_ordered_field F] : (2 : F) + 2 < 5 := by norm_num
 example : nat.prime (2^13 - 1) := by norm_num
 example : ¬ nat.prime (2^11 - 1) := by norm_num
-example (R : Type*) [ring R] : (2 : R) + 2 = 4 := by norm_num
 ```
 
 ### ring

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -188,19 +188,18 @@ by { abel at hyp, exact hyp }
 
 ### norm_num
 
-Normalises numerical expressions. It supports the operations
-  `+` `-` `*` `/` `^` `<` `≤` over ordered fields (or other
-  appropriate classes), as well as `-` `/` `%` over `ℤ` and `ℕ`.
-
-In practice, this means that certain goals of the form `A = B` or `A ≠ B`, where `A` and `B` are
-numerical expressions, can be solved with `norm_num`. The tactic may succeed even if `A` and `B`
-are real numbers, and may not time out even if the numerals involved are large.
+Normalises numerical expressions. It supports the operations `+` `-` `*` `/` `^` and `%` over numerical types such as `ℕ`, `ℤ`, `ℚ`, `ℝ`, `ℂ`, and can prove goals of the form `A = B`, `A ≠ B`, `A < B` and `A ≤ B`, where `A` and `B` are
+numerical expressions. It also has a relatively simple primality prover.
 ```lean
 import data.real.basic
 
 example : (2 : ℝ) + 2 = 4 := by norm_num
 example : (12345.2 : ℝ) ≠ 12345.3 := by norm_num
+example : (73 : ℝ) < 789/2 := by norm_num
 example : 123456789 + 987654321 = 1111111110 := by norm_num
+example : nat.prime (2^13 - 1) := by norm_num
+example : ¬ nat.prime (2^11 - 1) := by norm_num
+example (R : Type*) [ring R] : (2 : R) + 2 = 4 := by norm_num
 ```
 
 ### ring

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -199,7 +199,7 @@ are real numbers, and may not time out even if the numerals involved are large.
 import data.real.basic
 
 example : (2 : ℝ) + 2 = 4 := by norm_num
-example : (12345.2 : ℝ) < 12345.3 := by norm_num
+example : (12345.2 : ℝ) ≠ 12345.3 := by norm_num
 example : 123456789 + 987654321 = 1111111110 := by norm_num
 ```
 

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -186,6 +186,23 @@ example {α : Type*} {a b : α} [add_comm_group α] (hyp : a + a - a = b - b) : 
 by { abel at hyp, exact hyp }
 ```
 
+### norm_num
+
+Normalises numerical expressions. It supports the operations
+  `+` `-` `*` `/` `^` `<` `≤` over ordered fields (or other
+  appropriate classes), as well as `-` `/` `%` over `ℤ` and `ℕ`.
+
+In practice, this means that certain goals of the form `A = B` or `A ≠ B`, where `A` and `B` are
+numerical expressions, can be solved with `norm_num`. The tactic may succeed even if `A` and `B`
+are real numbers, and may not time out even if the numerals involved are large.
+```lean
+import data.real.basic
+
+example : (2 : ℝ) + 2 = 4 := by norm_num
+example : (12345.2 : ℝ) < 12345.3 := by norm_num
+example : 123456789 + 987654321 = 1111111110 := by norm_num
+```
+
 ### ring
 
 Evaluate expressions in the language of *commutative* (semi)rings.

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -201,6 +201,7 @@ example (R : Type*) [ring R] : (2 : R) + 2 = 4 := by norm_num
 example (F : Type*) [linear_ordered_field F] : (2 : F) + 2 < 5 := by norm_num
 example : nat.prime (2^13 - 1) := by norm_num
 example : ¬ nat.prime (2^11 - 1) := by norm_num
+example (x : ℝ) (h : x = 123 + 456) : x = 579 := by norm_num at h; assumption
 ```
 
 ### ring

--- a/src/tactic/norm_num.lean
+++ b/src/tactic/norm_num.lean
@@ -464,8 +464,11 @@ do ns ← loc.get_locals,
    when (¬ ns.empty) $ try tactic.contradiction
 
 /-- Normalize numerical expressions. Supports the operations
-  `+` `-` `*` `/` `^` `<` `≤` over ordered fields (or other
-  appropriate classes), as well as `-` `/` `%` over `ℤ` and `ℕ`. -/
+  `+` `-` `*` `/` `^` and `%` over numerical types such as
+`ℕ`, `ℤ`, `ℚ`, `ℝ`, `ℂ` and some general algebraic types,
+and can prove goals of the form `A = B`, `A ≠ B`, `A < B` and `A ≤ B`,
+where `A` and `B` are numerical expressions.
+It also has a relatively simple primality prover. -/
 meta def norm_num (hs : parse simp_arg_list) (l : parse location) : tactic unit :=
 repeat1 $ orelse' (norm_num1 l) $
 simp_core {} (norm_num1 (loc.ns [none])) ff hs [] l


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)

----

`norm_num` is a mathlib tactic and is not documented in the mathlib tactic docs. I'm fixing this because I wanted to set a norm_num puzzle on Twitter and give the hint "look in the tactic docs" and then I discovered it wasn't there ;-)
