### PR TITLE
chore(data/set/lattice): drop `Union_eq_sUnion_range` and `Inter_eq_sInter_range`

### DIFF
--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -421,12 +421,6 @@ theorem inter_empty_of_inter_sUnion_empty {s t : set α} {S : set (set α)} (hs 
 eq_empty_of_subset_empty $ by rw ← h; exact
 inter_subset_inter_right _ (subset_sUnion_of_mem hs)
 
-theorem Union_eq_sUnion_range (s : α → set β) : (⋃ i, s i) = ⋃₀ (range s) :=
-by rw [← image_univ, sUnion_image]; simp
-
-theorem Inter_eq_sInter_range {α I : Type} (s : I → set α) : (⋂ i, s i) = ⋂₀ (range s) :=
-by rw [← image_univ, sInter_image]; simp
-
 theorem range_sigma_eq_Union_range {γ : α → Type*} (f : sigma γ → β) :
   range f = ⋃ a, range (λ b, f ⟨a, b⟩) :=
 set.ext $ by simp

--- a/src/set_theory/cofinality.lean
+++ b/src/set_theory/cofinality.lean
@@ -359,7 +359,7 @@ theorem unbounded_of_unbounded_Union {α β : Type u} (r : α → α → Prop) [
   (s : β → set α)
   (h₁ : unbounded r $ ⋃x, s x) (h₂ : mk β < strict_order.cof r) : ∃x : β, unbounded r (s x) :=
 begin
-  rw [Union_eq_sUnion_range] at h₁,
+  rw [← sUnion_range] at h₁,
   have : mk ↥(range (λ (i : β), s i)) < strict_order.cof r := lt_of_le_of_lt mk_range_le h₂,
   rcases unbounded_of_unbounded_sUnion r h₁ this with ⟨_, ⟨x, rfl⟩, u⟩, exact ⟨x, u⟩
 end


### PR DESCRIPTION
Two reasons:

* we already have `sUnion_range` and `sInter_range`, no need to repeat
  ourselves;
* proofs used wrong universes.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
