### PR TITLE
chore(topology/algebra/ordered): use interval notation here and there

### DIFF
--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -80,26 +80,26 @@ lemma left_mem_Ici : a ∈ Ici a := by simp
 @[simp] lemma right_mem_Ioc : b ∈ Ioc a b ↔ a < b := by simp [le_refl]
 lemma right_mem_Iic : a ∈ Iic a := by simp
 
-lemma dual_Ici : @Ici (order_dual α) _ a = @Iic α _ a := rfl
-lemma dual_Iic : @Iic (order_dual α) _ a = @Ici α _ a := rfl
-lemma dual_Ioi : @Ioi (order_dual α) _ a = @Iio α _ a := rfl
-lemma dual_Iio : @Iio (order_dual α) _ a = @Ioi α _ a := rfl
-lemma dual_Icc : @Icc (order_dual α) _ a b = @Icc α _ b a :=
+@[simp] lemma dual_Ici : @Ici (order_dual α) _ a = @Iic α _ a := rfl
+@[simp] lemma dual_Iic : @Iic (order_dual α) _ a = @Ici α _ a := rfl
+@[simp] lemma dual_Ioi : @Ioi (order_dual α) _ a = @Iio α _ a := rfl
+@[simp] lemma dual_Iio : @Iio (order_dual α) _ a = @Ioi α _ a := rfl
+@[simp] lemma dual_Icc : @Icc (order_dual α) _ a b = @Icc α _ b a :=
 set.ext $ λ x, and_comm _ _
-lemma dual_Ioc : @Ioc (order_dual α) _ a b = @Ico α _ b a :=
+@[simp] lemma dual_Ioc : @Ioc (order_dual α) _ a b = @Ico α _ b a :=
 set.ext $ λ x, and_comm _ _
-lemma dual_Ico : @Ico (order_dual α) _ a b = @Ioc α _ b a :=
+@[simp] lemma dual_Ico : @Ico (order_dual α) _ a b = @Ioc α _ b a :=
 set.ext $ λ x, and_comm _ _
-lemma dual_Ioo : @Ioo (order_dual α) _ a b = @Ioo α _ b a :=
+@[simp] lemma dual_Ioo : @Ioo (order_dual α) _ a b = @Ioo α _ b a :=
 set.ext $ λ x, and_comm _ _
 
-lemma nonempty_Icc : (Icc a b).nonempty ↔ a ≤ b :=
+@[simp] lemma nonempty_Icc : (Icc a b).nonempty ↔ a ≤ b :=
 ⟨λ ⟨x, hx⟩, le_trans hx.1 hx.2, λ h, ⟨a, left_mem_Icc.2 h⟩⟩
 
-lemma nonempty_Ico : (Ico a b).nonempty ↔ a < b :=
+@[simp] lemma nonempty_Ico : (Ico a b).nonempty ↔ a < b :=
 ⟨λ ⟨x, hx⟩, lt_of_le_of_lt hx.1 hx.2, λ h, ⟨a, left_mem_Ico.2 h⟩⟩
 
-lemma nonempty_Ioc : (Ioc a b).nonempty ↔ a < b :=
+@[simp] lemma nonempty_Ioc : (Ioc a b).nonempty ↔ a < b :=
 ⟨λ ⟨x, hx⟩, lt_of_lt_of_le hx.1 hx.2, λ h, ⟨b, right_mem_Ioc.2 h⟩⟩
 
 lemma nonempty_Ici : (Ici a).nonempty := ⟨a, left_mem_Ici⟩

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -80,6 +80,19 @@ lemma left_mem_Ici : a ∈ Ici a := by simp
 @[simp] lemma right_mem_Ioc : b ∈ Ioc a b ↔ a < b := by simp [le_refl]
 lemma right_mem_Iic : a ∈ Iic a := by simp
 
+lemma dual_Ici : @Ici (order_dual α) _ a = @Iic α _ a := rfl
+lemma dual_Iic : @Iic (order_dual α) _ a = @Ici α _ a := rfl
+lemma dual_Ioi : @Ioi (order_dual α) _ a = @Iio α _ a := rfl
+lemma dual_Iio : @Iio (order_dual α) _ a = @Ioi α _ a := rfl
+lemma dual_Icc : @Icc (order_dual α) _ a b = @Icc α _ b a :=
+set.ext $ λ x, and_comm _ _
+lemma dual_Ioc : @Ioc (order_dual α) _ a b = @Ico α _ b a :=
+set.ext $ λ x, and_comm _ _
+lemma dual_Ico : @Ico (order_dual α) _ a b = @Ioc α _ b a :=
+set.ext $ λ x, and_comm _ _
+lemma dual_Ioo : @Ioo (order_dual α) _ a b = @Ioo α _ b a :=
+set.ext $ λ x, and_comm _ _
+
 lemma nonempty_Icc : (Icc a b).nonempty ↔ a ≤ b :=
 ⟨λ ⟨x, hx⟩, le_trans hx.1 hx.2, λ h, ⟨a, left_mem_Icc.2 h⟩⟩
 
@@ -120,6 +133,12 @@ ne_empty_iff_exists_mem.2 ⟨b, le_refl b⟩
 
 lemma Ici_ne_empty (a : α) : Ici a ≠ ∅ :=
 ne_empty_iff_exists_mem.2 ⟨a, le_refl a⟩
+
+lemma Ici_subset_Ioi : Ici a ⊆ Ioi b ↔ b < a :=
+⟨λ h, h left_mem_Ici, λ h x hx, lt_of_lt_of_le h hx⟩
+
+lemma Iic_subset_Iio : Iic a ⊆ Iio b ↔ a < b :=
+⟨λ h, h right_mem_Iic, λ h x hx, lt_of_le_of_lt hx h⟩
 
 lemma Ioo_subset_Ioo (h₁ : a₂ ≤ a₁) (h₂ : b₁ ≤ b₂) :
   Ioo a₁ b₁ ⊆ Ioo a₂ b₂ :=

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -63,13 +63,13 @@ begin
     refine generate_from_le _, rintro _ ⟨a, rfl | rfl⟩; [skip, apply H],
     by_cases h : ∃ a', ∀ b, a < b ↔ a' ≤ b,
     { rcases h with ⟨a', ha'⟩,
-      rw (_ : {b | a < b} = -Iio a'), {exact (H _).compl _},
+      rw (_ : Ioi a = -Iio a'), {exact (H _).compl _},
       simp [set.ext_iff, ha'] },
     { rcases is_open_Union_countable
         (λ a' : {a' : α // a < a'}, {b | a'.1 < b})
         (λ a', is_open_lt' _) with ⟨v, ⟨hv⟩, vu⟩,
       simp [set.ext_iff] at vu,
-      have : {b | a < b} = ⋃ x : v, -Iio x.1.1,
+      have : Ioi a = ⋃ x : v, -Iio x.1.1,
       { simp [set.ext_iff],
         refine λ x, ⟨λ ax, _, λ ⟨a', ⟨h, av⟩, ax⟩, lt_of_lt_of_le h ax⟩,
         rcases (vu x).2 _ with ⟨a', h₁, h₂⟩,
@@ -96,13 +96,13 @@ begin
     refine generate_from_le _, rintro _ ⟨a, rfl | rfl⟩, {apply H},
     by_cases h : ∃ a', ∀ b, b < a ↔ b ≤ a',
     { rcases h with ⟨a', ha'⟩,
-      rw (_ : {b | b < a} = -{x | a' < x}), {exact (H _).compl _},
+      rw (_ : Iio a = -Ioi a'), {exact (H _).compl _},
       simp [set.ext_iff, ha'] },
     { rcases is_open_Union_countable
         (λ a' : {a' : α // a' < a}, {b | b < a'.1})
         (λ a', is_open_gt' _) with ⟨v, ⟨hv⟩, vu⟩,
       simp [set.ext_iff] at vu,
-      have : {b | b < a} = ⋃ x : v, -{b | x.1.1 < b},
+      have : Iio a = ⋃ x : v, -Ioi x.1.1,
       { simp [set.ext_iff],
         refine λ x, ⟨λ ax, _, λ ⟨a', ⟨h, av⟩, ax⟩, lt_of_le_of_lt ax h⟩,
         rcases (vu x).2 _ with ⟨a', h₁, h₂⟩,

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -128,6 +128,7 @@ by { rw [← not_le], intro h', apply not_le_of_lt h, exact hf h' }
 
 end monotone
 
+/-- Type tag for a set with dual order: `≤` means `≥` and `<` means `>`. -/
 def order_dual (α : Type*) := α
 
 namespace order_dual

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -418,7 +418,8 @@ lemma mem_infi {f : ι → filter α} (h : directed (≥) f) (ne : nonempty ι) 
   s ∈ infi f ↔ s ∈ ⋃ i, (f i).sets :=
 show  s  ∈ (infi f).sets ↔ s ∈ ⋃ i, (f i).sets, by rw infi_sets_eq h ne
 
-lemma infi_sets_eq' {f : β → filter α} {s : set β}
+@[nolint] -- Intentional use of `≥`
+lemma binfi_sets_eq {f : β → filter α} {s : set β}
   (h : directed_on (f ⁻¹'o (≥)) s) (ne : ∃i, i ∈ s) :
   (⨅ i∈s, f i).sets = (⋃ i ∈ s, (f i).sets) :=
 let ⟨i, hi⟩ := ne in
@@ -427,6 +428,12 @@ calc (⨅ i ∈ s, f i).sets  = (⨅ t : {t // t ∈ s}, (f t.val)).sets : by rw
     (assume ⟨x, hx⟩ ⟨y, hy⟩, match h x hx y hy with ⟨z, h₁, h₂, h₃⟩ := ⟨⟨z, h₁⟩, h₂, h₃⟩ end)
     ⟨⟨i, hi⟩⟩
   ... = (⨆ t ∈ {t | t ∈ s}, (f t).sets) : by rw [supr_subtype]; refl
+
+@[nolint] -- Intentional use of `≥`
+lemma mem_binfi {f : β → filter α} {s : set β}
+  (h : directed_on (f ⁻¹'o (≥)) s) (ne : ∃i, i ∈ s) {t : set α} :
+  t ∈ (⨅ i∈s, f i) ↔ t ∈ ⋃ i ∈ s, (f i).sets :=
+by rw [← binfi_sets_eq h ne]
 
 lemma infi_sets_eq_finite (f : ι → filter α) :
   (⨅i, f i).sets = (⋃t:finset (plift ι), (⨅i∈t, f (plift.down i)).sets) :=

--- a/src/order/filter/lift.lean
+++ b/src/order/filter/lift.lean
@@ -24,7 +24,7 @@ protected def lift (f : filter α) (g : set α → filter β) :=
 variables {f f₁ f₂ : filter α} {g g₁ g₂ : set α → filter β}
 
 lemma lift_sets_eq (hg : monotone g) : (f.lift g).sets = (⋃t∈f.sets, (g t).sets) :=
-infi_sets_eq'
+binfi_sets_eq
   (assume s hs t ht, ⟨s ∩ t, inter_mem_sets hs ht,
     hg $ inter_subset_left s t, hg $ inter_subset_right s t⟩)
   ⟨univ, univ_mem_sets⟩

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -322,12 +322,13 @@ section linear_order
 variables [topological_space α] [linear_order α] [t : orderable_topology α]
 include t
 
-lemma exists_Ico_subset_of_mem_nhds' {a : α} {s : set α} (hs : s ∈ 𝓝 a) {l : α} (hl : l < a) :
+lemma exists_Ioc_subset_of_mem_nhds' {a : α} {s : set α} (hs : s ∈ 𝓝 a) {l : α} (hl : l < a) :
   ∃ l' ∈ Ico l a, Ioc l' a ⊆ s :=
 begin
   rw [nhds_eq_orderable a] at hs,
   rcases hs with ⟨t₁, ht₁, t₂, ht₂, hts⟩,
 
+  -- First we show that `t₂` includes `(-∞, a]`, so it suffices to show `(l', ∞) ⊆ t₁`
   suffices : ∃ l' ∈ Ico l a, Ioi l' ⊆ t₁,
   { have A : principal (Iic a) ≤ ⨅ b ∈ Ioi a, principal (Iio b),
       from (le_infi $ λ b, le_infi $ λ hb, principal_mono.2 $ Iic_subset_Iio.2 hb),
@@ -336,6 +337,7 @@ begin
     from this.imp (λ l', Exists.imp $ λ hl' hl x hx, B ⟨hl hx.1, hx.2⟩) },
   clear hts ht₂ t₂,
 
+  -- Now we find `l` such that `(l', ∞) ⊆ t₁`
   letI := classical.DLO α,
   rw [mem_binfi, mem_bUnion_iff] at ht₁,
   { rcases ht₁ with ⟨b, hb, hb'⟩,
@@ -347,20 +349,20 @@ begin
   exact ⟨l, hl⟩
 end
 
-lemma exists_Ioc_subset_of_mem_nhds' {a : α} {s : set α} (hs : s ∈ 𝓝 a) {u : α} (hu : a < u) :
+lemma exists_Ico_subset_of_mem_nhds' {a : α} {s : set α} (hs : s ∈ 𝓝 a) {u : α} (hu : a < u) :
   ∃ u' ∈ Ioc a u, Ico a u' ⊆ s :=
 begin
-  convert @exists_Ico_subset_of_mem_nhds' (order_dual α) _ _ _ _ _ hs _ hu,
+  convert @exists_Ioc_subset_of_mem_nhds' (order_dual α) _ _ _ _ _ hs _ hu,
   ext, rw [dual_Ico, dual_Ioc]
 end
 
-lemma exists_Ico_subset_of_mem_nhds {a : α} {s : set α} (hs : s ∈ 𝓝 a) (h : ∃ l, l < a) :
+lemma exists_Ioc_subset_of_mem_nhds {a : α} {s : set α} (hs : s ∈ 𝓝 a) (h : ∃ l, l < a) :
   ∃ l < a, Ioc l a ⊆ s :=
-let ⟨l', hl'⟩ := h in let ⟨l, hl⟩ := exists_Ico_subset_of_mem_nhds' hs hl' in ⟨l, hl.fst.2, hl.snd⟩
+let ⟨l', hl'⟩ := h in let ⟨l, hl⟩ := exists_Ioc_subset_of_mem_nhds' hs hl' in ⟨l, hl.fst.2, hl.snd⟩
 
-lemma exists_Ioc_subset_of_mem_nhds {a : α} {s : set α} (hs : s ∈ 𝓝 a) (h : ∃ u, a < u) :
+lemma exists_Ico_subset_of_mem_nhds {a : α} {s : set α} (hs : s ∈ 𝓝 a) (h : ∃ u, a < u) :
   ∃ u (_ : a < u), Ico a u ⊆ s :=
-let ⟨l', hl'⟩ := h in let ⟨l, hl⟩ := exists_Ioc_subset_of_mem_nhds' hs hl' in ⟨l, hl.fst.1, hl.snd⟩
+let ⟨l', hl'⟩ := h in let ⟨l, hl⟩ := exists_Ico_subset_of_mem_nhds' hs hl' in ⟨l, hl.fst.1, hl.snd⟩
 
 lemma mem_nhds_unbounded {a : α} {s : set α} (hu : ∃u, a < u) (hl : ∃l, l < a) :
   s ∈ 𝓝 a ↔ (∃l u, l < a ∧ a < u ∧ ∀b, l < b → b < u → b ∈ s) :=
@@ -411,7 +413,7 @@ instance orderable_topology.regular_space : regular_space α :=
     have ∃t:set α, is_open t ∧ (∀l∈ s, l < a → l ∈ t) ∧ 𝓝 a ⊓ principal t = ⊥,
       from by_cases
         (assume h : ∃l, l < a,
-          let ⟨l, hl, h⟩ := exists_Ico_subset_of_mem_nhds hs' h in
+          let ⟨l, hl, h⟩ := exists_Ioc_subset_of_mem_nhds hs' h in
           match dense_or_discrete l a with
           | or.inl ⟨b, hb₁, hb₂⟩ := ⟨{a | a < b}, is_open_gt' _,
               assume c hcs hca, show c < b,
@@ -428,7 +430,7 @@ instance orderable_topology.regular_space : regular_space α :=
     have ∃t:set α, is_open t ∧ (∀u∈ s, u>a → u ∈ t) ∧ 𝓝 a ⊓ principal t = ⊥,
       from by_cases
         (assume h : ∃u, u > a,
-          let ⟨u, hu, h⟩ := exists_Ioc_subset_of_mem_nhds hs' h in
+          let ⟨u, hu, h⟩ := exists_Ico_subset_of_mem_nhds hs' h in
           match dense_or_discrete a u with
           | or.inl ⟨b, hb₁, hb₂⟩ := ⟨{a | b < a}, is_open_lt' _,
               assume c hcs hca, show c > b,
@@ -457,8 +459,8 @@ lemma mem_nhds_iff_exists_Ioo_subset' {a l' u' : α} {s : set α}
 begin
   split,
   { assume h,
-    rcases exists_Ioc_subset_of_mem_nhds' h hu' with ⟨u, au, hu⟩,
-    rcases exists_Ico_subset_of_mem_nhds' h hl' with ⟨l, la, hl⟩,
+    rcases exists_Ico_subset_of_mem_nhds' h hu' with ⟨u, au, hu⟩,
+    rcases exists_Ioc_subset_of_mem_nhds' h hl' with ⟨l, la, hl⟩,
     refine ⟨l, u, ⟨la.2, au.1⟩, λx hx, _⟩,
     cases le_total a x with hax hax,
     { exact hu ⟨hax, hx.2⟩ },
@@ -489,7 +491,7 @@ begin
   split,
   { assume h,
     rcases mem_nhds_within_iff_exists_mem_nhds_inter.1 h with ⟨v, va, hv⟩,
-    rcases exists_Ioc_subset_of_mem_nhds va ⟨u', hu'⟩ with ⟨u, au, hu⟩,
+    rcases exists_Ico_subset_of_mem_nhds va ⟨u', hu'⟩ with ⟨u, au, hu⟩,
     refine ⟨u, au, λx hx, _⟩,
     refine hv ⟨_, hx.1⟩,
     exact hu ⟨le_of_lt hx.1, hx.2⟩ },
@@ -527,7 +529,7 @@ begin
   split,
   { assume h,
     rcases mem_nhds_within_iff_exists_mem_nhds_inter.1 h with ⟨v, va, hv⟩,
-    rcases exists_Ico_subset_of_mem_nhds va ⟨l', hl'⟩ with ⟨l, la, hl⟩,
+    rcases exists_Ioc_subset_of_mem_nhds va ⟨l', hl'⟩ with ⟨l, la, hl⟩,
     refine ⟨l, la, λx hx, _⟩,
     refine hv ⟨_, hx.2⟩,
     exact hl ⟨hx.1, le_of_lt hx.2⟩ },
@@ -565,7 +567,7 @@ begin
   split,
   { assume h,
     rcases mem_nhds_within_iff_exists_mem_nhds_inter.1 h with ⟨v, va, hv⟩,
-    rcases exists_Ioc_subset_of_mem_nhds va ⟨u', hu'⟩ with ⟨u, au, hu⟩,
+    rcases exists_Ico_subset_of_mem_nhds va ⟨u', hu'⟩ with ⟨u, au, hu⟩,
     refine ⟨u, au, λx hx, _⟩,
     refine hv ⟨_, hx.1⟩,
     exact hu hx },
@@ -603,7 +605,7 @@ begin
   split,
   { assume h,
     rcases mem_nhds_within_iff_exists_mem_nhds_inter.1 h with ⟨v, va, hv⟩,
-    rcases exists_Ico_subset_of_mem_nhds va ⟨l', hl'⟩ with ⟨l, la, hl⟩,
+    rcases exists_Ioc_subset_of_mem_nhds va ⟨l', hl'⟩ with ⟨l, la, hl⟩,
     refine ⟨l, la, λx hx, _⟩,
     refine hv ⟨_, hx.2⟩,
     exact hl hx },
@@ -674,7 +676,7 @@ forall_sets_neq_empty_iff_neq_bot.mp $ assume t ht,
       ne_empty_iff_exists_mem.mpr ⟨a, ht ⟨‹a ∈ t₁›, ‹a ∈ t₂›⟩⟩)
     (assume : a ≠ a',
       have a' < a, from lt_of_le_of_ne (ha.left ‹a' ∈ s›) this.symm,
-      let ⟨l, hl, hlt₁⟩ := exists_Ico_subset_of_mem_nhds ht₁ ⟨a', this⟩ in
+      let ⟨l, hl, hlt₁⟩ := exists_Ioc_subset_of_mem_nhds ht₁ ⟨a', this⟩ in
       have ∃a'∈s, l < a',
         from classical.by_contradiction $ assume : ¬ ∃a'∈s, l < a',
           have ∀a'∈s, a' ≤ l, from assume a ha, not_lt.1 $ assume ha', this ⟨a, ha, ha'⟩,

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -177,8 +177,7 @@ end ordered_topology
   This is restricted to linear orders. Only then it is guaranteed that they are also a ordered
   topology. -/
 class orderable_topology (α : Type*) [t : topological_space α] [partial_order α] : Prop :=
-(topology_eq_generate_intervals :
-  t = generate_from {s | ∃a, s = {b : α | a < b} ∨ s = {b : α | b < a}})
+(topology_eq_generate_intervals : t = generate_from {s | ∃a, s = Ioi a ∨ s = Iio a})
 
 section orderable_topology
 
@@ -192,7 +191,7 @@ variables [topological_space α] [partial_order α] [t : orderable_topology α]
 include t
 
 lemma is_open_iff_generate_intervals {s : set α} :
-  is_open s ↔ generate_open {s | ∃a, s = {b : α | a < b} ∨ s = {b : α | b < a}} s :=
+  is_open s ↔ generate_open {s | ∃a, s = Ioi a ∨ s = Iio a} s :=
 by rw [t.topology_eq_generate_intervals]; refl
 
 lemma is_open_lt' (a : α) : is_open {b:α | a < b} :=
@@ -213,8 +212,8 @@ mem_nhds_sets (is_open_gt' _) h
 lemma ge_mem_nhds {a b : α} (h : a < b) : {a | a ≤ b} ∈ 𝓝 a :=
 (𝓝 a).sets_of_superset (gt_mem_nhds h) $ assume b hb, le_of_lt hb
 
-lemma nhds_eq_orderable {a : α} :
-  𝓝 a = (⨅b<a, principal {c | b < c}) ⊓ (⨅b>a, principal {c | c < b}) :=
+lemma nhds_eq_orderable (a : α) :
+  𝓝 a = (⨅b ∈ Iio a, principal (Ioi b)) ⊓ (⨅b ∈ Ioi a, principal (Iio b)) :=
 by rw [t.topology_eq_generate_intervals, nhds_generate_from];
 from le_antisymm
   (le_inf
@@ -230,7 +229,7 @@ from le_antisymm
 
 lemma tendsto_orderable {f : β → α} {a : α} {x : filter β} :
   tendsto f x (𝓝 a) ↔ (∀a'<a, {b | a' < f b} ∈ x) ∧ (∀a'>a, {b | a' > f b} ∈ x) :=
-by simp [@nhds_eq_orderable α _ _, tendsto_inf, tendsto_infi, tendsto_principal]
+by simp [nhds_eq_orderable a, tendsto_inf, tendsto_infi, tendsto_principal]
 
 /-- Also known as squeeze or sandwich theorem. -/
 lemma tendsto_of_tendsto_of_tendsto_of_le_of_le {f g h : β → α} {b : filter β} {a : α}
@@ -246,9 +245,9 @@ tendsto_orderable.2
     by filter_upwards [this, hfh] assume a h₁ h₂, lt_of_le_of_lt h₂ h₁⟩
 
 lemma nhds_orderable_unbounded {a : α} (hu : ∃u, a < u) (hl : ∃l, l < a) :
-  𝓝 a = (⨅l (h₂ : l < a) u (h₂ : a < u), principal {x | l < x ∧ x < u }) :=
+  𝓝 a = (⨅l (h₂ : l < a) u (h₂ : a < u), principal (Ioo l u)) :=
 let ⟨u, hu⟩ := hu, ⟨l, hl⟩ := hl in
-calc 𝓝 a = (⨅b<a, principal {c | b < c}) ⊓ (⨅b>a, principal {c | c < b}) : nhds_eq_orderable
+calc 𝓝 a = (⨅b<a, principal {c | b < c}) ⊓ (⨅b>a, principal {c | c < b}) : nhds_eq_orderable a
   ... = (⨅b<a, principal {c | b < c} ⊓ (⨅b>a, principal {c | c < b})) :
     binfi_inf hl
   ... = (⨅l<a, (⨅u>a, principal {c | c < u} ⊓ principal {c | l < c})) :
@@ -278,7 +277,7 @@ theorem induced_orderable_topology' {α : Type u} {β : Type v}
 begin
   letI := induced f ta,
   refine ⟨eq_of_nhds_eq_nhds (λ a, _)⟩,
-  rw [nhds_induced, nhds_generate_from, @nhds_eq_orderable β _ _],
+  rw [nhds_induced, nhds_generate_from, nhds_eq_orderable (f a)],
   apply le_antisymm,
   { refine le_infi (λ s, le_infi $ λ hs, le_principal_iff.2 _),
     rcases hs with ⟨ab, b, rfl|rfl⟩,
@@ -308,69 +307,78 @@ induced_orderable_topology' f @hf
   (λ a x ax, let ⟨b, ab, bx⟩ := H ax in ⟨b, hf.1 ab, le_of_lt bx⟩)
 
 lemma nhds_top_orderable [topological_space α] [order_top α] [orderable_topology α] :
-  𝓝 (⊤:α) = (⨅l (h₂ : l < ⊤), principal {x | l < x}) :=
-by rw [@nhds_eq_orderable α _ _]; simp [(>)]
+  𝓝 (⊤:α) = (⨅l (h₂ : l < ⊤), principal (Ioi l)) :=
+by simp [nhds_eq_orderable (⊤:α)]
 
 lemma nhds_bot_orderable [topological_space α] [order_bot α] [orderable_topology α] :
-  𝓝 (⊥:α) = (⨅l (h₂ : ⊥ < l), principal {x | x < l}) :=
-by rw [@nhds_eq_orderable α _ _]; simp
+  𝓝 (⊥:α) = (⨅l (h₂ : ⊥ < l), principal (Iio l)) :=
+by simp [nhds_eq_orderable (⊥:α)]
 
 section linear_order
 
 variables [topological_space α] [linear_order α] [t : orderable_topology α]
 include t
 
-lemma mem_nhds_orderable_dest {a : α} {s : set α} (hs : s ∈ 𝓝 a) :
-  ((∃u, u>a) → ∃u, a < u ∧ ∀b, a ≤ b → b < u → b ∈ s) ∧
-  ((∃l, l<a) → ∃l, l < a ∧ ∀b, l < b → b ≤ a → b ∈ s) :=
+lemma mem_nhds_orderable_dest' {a : α} {s : set α} (hs : s ∈ 𝓝 a) :
+  (∀ u' ∈ Ioi a, ∃u ∈ Ioc a u', Ico a u ⊆ s) ∧
+  (∀ l' ∈ Iio a, ∃l ∈ Ico l' a, Ioc l a ⊆ s) :=
 let ⟨t₁, ht₁, t₂, ht₂, hts⟩ :=
   mem_inf_sets.mp $ by rw [@nhds_eq_orderable α _ _ _] at hs; exact hs in
-have ht₁ : ((∃l, l<a) → ∃l, l < a ∧ ∀b, l < b → b ∈ t₁) ∧ (∀b, a ≤ b → b ∈ t₁),
+have ht₁ : (∀ l' ∈ Iio a, ∃l ∈ Ico l' a, Ioc l a ⊆ t₁) ∧ (Ici a ⊆ t₁),
   from infi_sets_induct ht₁
-    (by simp {contextual := tt})
+    ⟨λ l' hl', ⟨l', left_mem_Ico.2 hl', subset_univ _⟩, subset_univ _⟩
     (assume a' s₁ s₂ hs₁ ⟨hs₂, hs₃⟩,
       begin
         by_cases a' < a,
         { simp [h] at hs₁,
           letI := classical.DLO α,
-          exact ⟨assume hx, let ⟨u, hu₁, hu₂⟩ := hs₂ hx in
-            ⟨max u a', max_lt hu₁ h, assume b hb,
-              ⟨hs₁ $ lt_of_le_of_lt (le_max_right _ _) hb,
-                hu₂ _ $ lt_of_le_of_lt (le_max_left _ _) hb⟩⟩,
-            assume b hb, ⟨hs₁ $ lt_of_lt_of_le h hb, hs₃ _ hb⟩⟩ },
+          exact ⟨assume x hx, let ⟨u, hu₁, hu₂⟩ := hs₂ _ hx in
+            ⟨max u a', ⟨le_max_left_of_le hu₁.1, max_lt hu₁.2 h⟩, assume b hb,
+              ⟨hs₁ $ lt_of_le_of_lt (le_max_right _ _) hb.1,
+                hu₂ ⟨lt_of_le_of_lt (le_max_left _ _) hb.1, hb.2⟩⟩⟩,
+            assume b hb, ⟨hs₁ $ lt_of_lt_of_le h hb, hs₃ hb⟩⟩ },
         { simp [h] at hs₁, simp [hs₁],
           exact ⟨by simpa using hs₂, hs₃⟩ }
       end)
     (assume s₁ s₂ h ih, and.intro
-      (assume hx, let ⟨u, hu₁, hu₂⟩ := ih.left hx in ⟨u, hu₁, assume b hb, h $ hu₂ _ hb⟩)
-      (assume b hb, h $ ih.right _ hb)),
-have ht₂ : ((∃u, u>a) → ∃u, a < u ∧ ∀b, b < u → b ∈ t₂) ∧ (∀b, b ≤ a → b ∈ t₂),
+      (assume l' hl', let ⟨u, hu₁, hu₂⟩ := ih.left l' hl' in ⟨u, hu₁, assume b hb, h $ hu₂ hb⟩)
+      (assume b hb, h $ ih.right hb)),
+have ht₂ : (∀ u' ∈ Ioi a, ∃u ∈ Ioc a u', Ico a u ⊆ t₂) ∧ (Iic a ⊆ t₂),
   from infi_sets_induct ht₂
-    (by simp {contextual := tt})
+    ⟨λ u' hu', ⟨u', right_mem_Ioc.2 hu', subset_univ _⟩, subset_univ _⟩
     (assume a' s₁ s₂ hs₁ ⟨hs₂, hs₃⟩,
       begin
         by_cases a' > a,
         { simp [h] at hs₁,
           letI := classical.DLO α,
-          exact ⟨assume hx, let ⟨u, hu₁, hu₂⟩ := hs₂ hx in
-            ⟨min u a', lt_min hu₁ h, assume b hb,
-              ⟨hs₁ $ lt_of_lt_of_le hb (min_le_right _ _),
-                hu₂ _ $ lt_of_lt_of_le hb (min_le_left _ _)⟩⟩,
-            assume b hb, ⟨hs₁ $ lt_of_le_of_lt hb h, hs₃ _ hb⟩⟩ },
+          exact ⟨assume x hx, let ⟨u, hu₁, hu₂⟩ := hs₂ _ hx in
+            ⟨min u a', ⟨lt_min hu₁.1 h, min_le_left_of_le hu₁.2⟩, assume b hb,
+              ⟨hs₁ $ lt_of_lt_of_le hb.2 (min_le_right _ _),
+                hu₂ ⟨hb.1, lt_of_lt_of_le hb.2 (min_le_left _ _)⟩⟩⟩,
+            assume b hb, ⟨hs₁ $ lt_of_le_of_lt hb h, hs₃ hb⟩⟩ },
         { simp [h] at hs₁, simp [hs₁],
           exact ⟨by simpa using hs₂, hs₃⟩ }
       end)
     (assume s₁ s₂ h ih, and.intro
-      (assume hx, let ⟨u, hu₁, hu₂⟩ := ih.left hx in ⟨u, hu₁, assume b hb, h $ hu₂ _ hb⟩)
-      (assume b hb, h $ ih.right _ hb)),
+      (assume u' hu', let ⟨u, hu₁, hu₂⟩ := ih.left u' hu' in ⟨u, hu₁, assume b hb, h $ hu₂ hb⟩)
+      (assume b hb, h $ ih.right hb)),
 and.intro
-  (assume hx, let ⟨u, hu, h⟩ := ht₂.left hx in ⟨u, hu, assume b hb hbu, hts ⟨ht₁.right b hb, h _ hbu⟩⟩)
-  (assume hx, let ⟨l, hl, h⟩ := ht₁.left hx in ⟨l, hl, assume b hbl hb, hts ⟨h _ hbl, ht₂.right b hb⟩⟩)
+  (assume u' hu', let ⟨u, hu, h⟩ := ht₂.left u' hu' in
+    ⟨u, hu, assume b hb, hts ⟨ht₁.right hb.1, h hb⟩⟩)
+  (assume l' hl', let ⟨l, hl, h⟩ := ht₁.left l' hl' in
+    ⟨l, hl, assume b hb, hts ⟨h hb, ht₂.right hb.2⟩⟩)
+
+lemma mem_nhds_orderable_dest {a : α} {s : set α} (hs : s ∈ 𝓝 a) :
+  ((∃ u, a < u) → ∃u ∈ Ioi a, Ico a u ⊆ s) ∧
+  ((∃ l, l < a) → ∃l ∈ Iio a, Ioc l a ⊆ s) :=
+let ⟨h₁, h₂⟩ := mem_nhds_orderable_dest' hs in
+⟨λ ⟨u', hu'⟩, (h₁ u' hu').imp $ λ u hu, ⟨hu.fst.left, hu.snd⟩,
+ λ ⟨l', hl'⟩, (h₂ l' hl').imp $ λ l hl, ⟨hl.fst.right, hl.snd⟩⟩
 
 lemma mem_nhds_unbounded {a : α} {s : set α} (hu : ∃u, a < u) (hl : ∃l, l < a) :
   s ∈ 𝓝 a ↔ (∃l u, l < a ∧ a < u ∧ ∀b, l < b → b < u → b ∈ s) :=
 let ⟨l, hl'⟩ := hl, ⟨u, hu'⟩ := hu in
-have 𝓝 a = (⨅p : {l // l < a} × {u // a < u}, principal {x | p.1.val < x ∧ x < p.2.val }),
+have 𝓝 a = (⨅p : {l // l < a} × {u // a < u}, principal (Ioo p.1.val p.2.val)),
   by simp [nhds_orderable_unbounded hu hl, infi_subtype, infi_prod],
 iff.intro
   (assume hs, by rw [this] at hs; from infi_sets_induct hs
@@ -421,7 +429,7 @@ instance orderable_topology.regular_space : regular_space α :=
           match dense_or_discrete l a with
           | or.inl ⟨b, hb₁, hb₂⟩ := ⟨{a | a < b}, is_open_gt' _,
               assume c hcs hca, show c < b,
-                from lt_of_not_ge $ assume hbc, h c (lt_of_lt_of_le hb₁ hbc) (le_of_lt hca) hcs,
+                from lt_of_not_ge $ assume hbc, h ⟨lt_of_lt_of_le hb₁ hbc, le_of_lt hca⟩ hcs,
               inf_principal_eq_bot $ (𝓝 a).sets_of_superset (mem_nhds_sets (is_open_lt' _) hb₂) $
                 assume x (hx : b < x), show ¬ x < b, from not_lt.2 $ le_of_lt hx⟩
           | or.inr ⟨h₁, h₂⟩ := ⟨{a' | a' < a}, is_open_gt' _, assume b hbs hba, hba,
@@ -438,7 +446,7 @@ instance orderable_topology.regular_space : regular_space α :=
           match dense_or_discrete a u with
           | or.inl ⟨b, hb₁, hb₂⟩ := ⟨{a | b < a}, is_open_lt' _,
               assume c hcs hca, show c > b,
-                from lt_of_not_ge $ assume hbc, h c (le_of_lt hca) (lt_of_le_of_lt hbc hb₂) hcs,
+                from lt_of_not_ge $ assume hbc, h ⟨le_of_lt hca, lt_of_le_of_lt hbc hb₂⟩ hcs,
               inf_principal_eq_bot $ (𝓝 a).sets_of_superset (mem_nhds_sets (is_open_gt' _) hb₁) $
                 assume x (hx : b > x), show ¬ x > b, from not_lt.2 $ le_of_lt hx⟩
           | or.inr ⟨h₁, h₂⟩ := ⟨{a' | a' > a}, is_open_lt' _, assume b hbs hba, hba,
@@ -467,8 +475,8 @@ begin
     rcases (mem_nhds_orderable_dest h).2 ⟨l', hl'⟩ with ⟨l, la, hl⟩,
     refine ⟨l, u, ⟨la, au⟩, λx hx, _⟩,
     by_cases hax : a ≤ x,
-    { exact hu _ hax hx.2 },
-    { exact hl _ hx.1 (le_of_not_ge hax) } },
+    { exact hu ⟨hax, hx.2⟩ },
+    { exact hl ⟨hx.1, le_of_not_ge hax⟩ } },
   { rintros ⟨l, u, ha, h⟩,
     apply mem_sets_of_superset (mem_nhds_sets is_open_Ioo ha) h }
 end
@@ -498,7 +506,7 @@ begin
     rcases (mem_nhds_orderable_dest va).1 ⟨u', hu'⟩ with ⟨u, au, hu⟩,
     refine ⟨u, au, λx hx, _⟩,
     refine hv ⟨_, hx.1⟩,
-    exact hu _ (le_of_lt hx.1) hx.2 },
+    exact hu ⟨le_of_lt hx.1, hx.2⟩ },
   { rintros ⟨u, au, hu⟩,
     rw mem_nhds_within_iff_exists_mem_nhds_inter,
     refine ⟨Iio u, mem_nhds_sets is_open_Iio au, _⟩,
@@ -536,7 +544,7 @@ begin
     rcases (mem_nhds_orderable_dest va).2 ⟨l', hl'⟩ with ⟨l, la, hl⟩,
     refine ⟨l, la, λx hx, _⟩,
     refine hv ⟨_, hx.2⟩,
-    exact hl _ hx.1 (le_of_lt hx.2) },
+    exact hl ⟨hx.1, le_of_lt hx.2⟩ },
   { rintros ⟨l, la, ha⟩,
     rw mem_nhds_within_iff_exists_mem_nhds_inter,
     refine ⟨Ioi l, mem_nhds_sets is_open_Ioi la, _⟩,
@@ -574,7 +582,7 @@ begin
     rcases (mem_nhds_orderable_dest va).1 ⟨u', hu'⟩ with ⟨u, au, hu⟩,
     refine ⟨u, au, λx hx, _⟩,
     refine hv ⟨_, hx.1⟩,
-    exact hu _ hx.1 hx.2 },
+    exact hu hx },
   { rintros ⟨u, au, hu⟩,
     rw mem_nhds_within_iff_exists_mem_nhds_inter,
     refine ⟨Iio u, mem_nhds_sets is_open_Iio au, _⟩,
@@ -612,7 +620,7 @@ begin
     rcases (mem_nhds_orderable_dest va).2 ⟨l', hl'⟩ with ⟨l, la, hl⟩,
     refine ⟨l, la, λx hx, _⟩,
     refine hv ⟨_, hx.2⟩,
-    exact hl _ hx.1 hx.2 },
+    exact hl hx },
   { rintros ⟨l, la, ha⟩,
     rw mem_nhds_within_iff_exists_mem_nhds_inter,
     refine ⟨Ioi l, mem_nhds_sets is_open_Ioi la, _⟩,
@@ -688,7 +696,7 @@ forall_sets_neq_empty_iff_neq_bot.mp $ assume t ht,
           have ¬ l < a, from not_lt.2 $ ha.right this,
           this ‹l < a›,
       let ⟨a', ha', ha'l⟩ := this in
-      have a' ∈ t₁, from hlt₁ _ ‹l < a'›  $ ha.left ha',
+      have a' ∈ t₁, from hlt₁ ⟨‹l < a'›, ha.left ha'⟩,
       ne_empty_iff_exists_mem.mpr ⟨a', ht ⟨‹a' ∈ t₁›, ht₂ ‹a' ∈ s›⟩⟩)
 
 lemma nhds_principal_ne_bot_of_is_glb : ∀ {a : α} {s : set α}, is_glb s a → s ≠ ∅ →

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -135,7 +135,7 @@ lemma mem_nhds_of_is_topological_basis {a : α} {s : set α} {b : set (set α)}
   (hb : is_topological_basis b) : s ∈ 𝓝 a ↔ ∃t∈b, a ∈ t ∧ t ⊆ s :=
 begin
   change s ∈ (𝓝 a).sets ↔ ∃t∈b, a ∈ t ∧ t ⊆ s,
-  rw [hb.2.2, nhds_generate_from, infi_sets_eq'],
+  rw [hb.2.2, nhds_generate_from, binfi_sets_eq],
   { simp only [mem_bUnion_iff, exists_prop, mem_set_of_eq, and_assoc, and.left_comm], refl },
   { exact assume s ⟨hs₁, hs₂⟩ t ⟨ht₁, ht₂⟩,
       have a ∈ s ∩ t, from ⟨hs₁, ht₁⟩,

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -371,7 +371,7 @@ lemma nhds_le_of_le {f a} {s : set α} (h : a ∈ s) (o : is_open s) (sf : princ
 by rw nhds_def; exact infi_le_of_le s (infi_le_of_le ⟨h, o⟩ sf)
 
 lemma nhds_sets {a : α} : (𝓝 a).sets = {s | ∃t⊆s, is_open t ∧ a ∈ t} :=
-calc (𝓝 a).sets = (⋃s∈{s : set α| a ∈ s ∧ is_open s}, (principal s).sets) : infi_sets_eq'
+calc (𝓝 a).sets = (⋃s∈{s : set α| a ∈ s ∧ is_open s}, (principal s).sets) : binfi_sets_eq
   (assume x ⟨hx₁, hx₂⟩ y ⟨hy₁, hy₂⟩,
     ⟨x ∩ y, ⟨⟨hx₁, hy₁⟩, is_open_inter hx₂ hy₂⟩,
       le_principal_iff.2 (inter_subset_left _ _),

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -62,8 +62,8 @@ lemma embedding_coe : embedding (coe : nnreal → ennreal) :=
   { rw [orderable_topology.topology_eq_generate_intervals nnreal],
     refine le_generate_from (assume s ha, _),
     rcases ha with ⟨a, rfl | rfl⟩,
-    exact ⟨{b : ennreal | ↑a < b}, @is_open_lt' ennreal ennreal.topological_space _ _ _, by simp⟩,
-    exact ⟨{b : ennreal | b < ↑a}, @is_open_gt' ennreal ennreal.topological_space _ _ _, by simp⟩ }
+    exact ⟨Ioi a, is_open_Ioi, by simp [Ioi]⟩,
+    exact ⟨Iio a, is_open_Iio, by simp [Iio]⟩ }
   end⟩,
   assume a b, coe_eq_coe.1⟩
 


### PR DESCRIPTION
Also prove a slightly more general version of `mem_nhds_orderable_dest`.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
