### PR TITLE
feat(data/set/intervals): add `nonempty_Icc` etc, `image_(add/mul)_(left/right)_Icc`

### DIFF
--- a/src/algebra/ordered_field.lean
+++ b/src/algebra/ordered_field.lean
@@ -135,20 +135,6 @@ lemma half_lt_self : 0 < a → a / 2 < a := div_two_lt_of_pos
 
 lemma one_half_lt_one : (1 / 2 : α) < 1 := half_lt_self zero_lt_one
 
-lemma ivl_translate : (λx, x + c) '' {r:α | a ≤ r ∧ r ≤ b } = {r:α | a + c ≤ r ∧ r ≤ b + c} :=
-calc (λx, x + c) '' {r | a ≤ r ∧ r ≤ b } = (λx, x - c) ⁻¹' {r | a ≤ r ∧ r ≤ b } :
-    congr_fun (set.image_eq_preimage_of_inverse
-      (assume a, add_sub_cancel a c) (assume b, sub_add_cancel b c)) _
-  ... = {r | a + c ≤ r ∧ r ≤ b + c} :
-    set.ext $ by simp [-sub_eq_add_neg, le_sub_iff_add_le, sub_le_iff_le_add]
-
-lemma ivl_stretch (hc : 0 < c) : (λx, x * c) '' {r | a ≤ r ∧ r ≤ b } = {r | a * c ≤ r ∧ r ≤ b * c} :=
-calc (λx, x * c) '' {r | a ≤ r ∧ r ≤ b } = (λx, x / c) ⁻¹' {r | a ≤ r ∧ r ≤ b } :
-    congr_fun (set.image_eq_preimage_of_inverse
-      (assume a, mul_div_cancel _ $ ne_of_gt hc) (assume b, div_mul_cancel _ $ ne_of_gt hc)) _
-  ... = {r | a * c ≤ r ∧ r ≤ b * c} :
-    set.ext $ by simp [le_div_iff, div_le_iff, hc]
-
 @[priority 100] -- see Note [lower instance priority]
 instance linear_ordered_field.to_densely_ordered : densely_ordered α :=
 { dense := assume a₁ a₂ h, ⟨(a₁ + a₂) / 2,

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -972,11 +972,15 @@ eq_univ_of_forall $ by simp [image]; exact H
 @[simp] theorem image_singleton {f : α → β} {a : α} : f '' {a} = {f a} :=
 ext $ λ x, by simp [image]; rw eq_comm
 
+theorem nonempty.image_const {s : set α} (hs : s.nonempty) (a : β) : (λ _, a) '' s = {a} :=
+ext $ λ x, ⟨λ ⟨y, _, h⟩, h ▸ mem_singleton _,
+  λ h, (eq_of_mem_singleton h).symm ▸ hs.imp (λ y hy, ⟨hy, rfl⟩)⟩
+
 @[simp] lemma image_eq_empty {α β} {f : α → β} {s : set α} : f '' s = ∅ ↔ s = ∅ :=
 by simp only [eq_empty_iff_forall_not_mem]; exact
 ⟨λ H a ha, H _ ⟨_, ha, rfl⟩, λ H b ⟨_, ha, _⟩, H _ ha⟩
 
-lemma inter_singleton_ne_empty {α : Type*} {s : set α} {a : α} : s ∩ {a} ≠ ∅ ↔ a ∈ s :=
+lemma inter_singleton_ne_empty {s : set α} {a : α} : s ∩ {a} ≠ ∅ ↔ a ∈ s :=
 by finish  [set.inter_singleton_eq_empty]
 
 theorem fix_set_compl (t : set α) : compl t = - t := rfl

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot
 -/
 
-import order.lattice algebra.order_functions tactic.tauto
+import order.lattice algebra.order_functions algebra.ordered_field tactic.tauto
 
 /-!
 # Intervals
@@ -79,6 +79,19 @@ lemma left_mem_Ici : a ∈ Ici a := by simp
 @[simp] lemma right_mem_Icc : b ∈ Icc a b ↔ a ≤ b := by simp [le_refl]
 @[simp] lemma right_mem_Ioc : b ∈ Ioc a b ↔ a < b := by simp [le_refl]
 lemma right_mem_Iic : a ∈ Iic a := by simp
+
+lemma nonempty_Icc : (Icc a b).nonempty ↔ a ≤ b :=
+⟨λ ⟨x, hx⟩, le_trans hx.1 hx.2, λ h, ⟨a, left_mem_Icc.2 h⟩⟩
+
+lemma nonempty_Ico : (Ico a b).nonempty ↔ a < b :=
+⟨λ ⟨x, hx⟩, lt_of_le_of_lt hx.1 hx.2, λ h, ⟨a, left_mem_Ico.2 h⟩⟩
+
+lemma nonempty_Ioc : (Ioc a b).nonempty ↔ a < b :=
+⟨λ ⟨x, hx⟩, lt_of_lt_of_le hx.1 hx.2, λ h, ⟨b, right_mem_Ioc.2 h⟩⟩
+
+lemma nonempty_Ici : (Ici a).nonempty := ⟨a, left_mem_Ici⟩
+
+lemma nonempty_Iic : (Iic a).nonempty := ⟨a, right_mem_Iic⟩
 
 @[simp] lemma Ioo_eq_empty (h : b ≤ a) : Ioo a b = ∅ :=
 eq_empty_iff_forall_not_mem.2 $ λ x ⟨h₁, h₂⟩, not_le_of_lt (lt_trans h₁ h₂) h
@@ -426,10 +439,23 @@ section ordered_comm_group
 
 variables {α : Type u} [ordered_comm_group α]
 
+lemma image_add_left_Icc (a b c : α) : ((+) a) '' Icc b c = Icc (a + b) (a + c) :=
+begin
+  ext x,
+  split,
+  { rintros ⟨x, hx, rfl⟩,
+    exact ⟨add_le_add_left hx.1 a, add_le_add_left hx.2 a⟩},
+  { intro hx,
+    refine ⟨-a + x, _, add_neg_cancel_left _ _⟩,
+    exact ⟨le_neg_add_iff_add_le.2 hx.1, neg_add_le_iff_le_add.2 hx.2⟩ }
+end
+
+lemma image_add_right_Icc (a b c : α) : (λ x, x + c) '' Icc a b = Icc (a + c) (b + c) :=
+by convert image_add_left_Icc c a b using 1; simp only [add_comm _ c]
+
 lemma image_neg_Iio (r : α) : image (λz, -z) (Iio r) = Ioi (-r) :=
 begin
-  apply set.ext,
-  intros z,
+  ext z,
   apply iff.intro,
   { intros hz,
     apply exists.elim hz,
@@ -478,5 +504,41 @@ begin
 end
 
 end decidable_linear_ordered_comm_group
+
+section linear_ordered_field
+
+variables {α : Type u} [linear_ordered_field α]
+
+lemma image_mul_right_Icc' (a b : α) {c : α} (h : 0 < c) :
+  (λ x, x * c) '' Icc a b = Icc (a * c) (b * c) :=
+begin
+  ext x,
+  split,
+  { rintros ⟨x, hx, rfl⟩,
+    exact ⟨mul_le_mul_of_nonneg_right hx.1 (le_of_lt h),
+      mul_le_mul_of_nonneg_right hx.2 (le_of_lt h)⟩ },
+  { intro hx,
+    refine ⟨x / c, _, div_mul_cancel x (ne_of_gt h)⟩,
+    exact ⟨le_div_of_mul_le h hx.1, div_le_of_le_mul h (mul_comm b c ▸ hx.2)⟩ }
+end
+
+lemma image_mul_right_Icc {a b c : α} (hab : a ≤ b) (hc : 0 ≤ c) :
+  (λ x, x * c) '' Icc a b = Icc (a * c) (b * c) :=
+begin
+  cases eq_or_lt_of_le hc,
+  { subst c,
+    simp [(nonempty_Icc.2 hab).image_const] },
+  exact image_mul_right_Icc' a b ‹0 < c›
+end
+
+lemma image_mul_left_Icc' {a : α} (h : 0 < a) (b c : α) :
+  ((*) a) '' Icc b c = Icc (a * b) (a * c) :=
+by { convert image_mul_right_Icc' b c h using 1; simp only [mul_comm _ a] }
+
+lemma image_mul_left_Icc {a b c : α} (ha : 0 ≤ a) (hbc : b ≤ c) :
+  ((*) a) '' Icc b c = Icc (a * b) (a * c) :=
+by { convert image_mul_right_Icc hbc ha using 1; simp only [mul_comm _ a] }
+
+end linear_ordered_field
 
 end set


### PR DESCRIPTION
Also remove `ivl_*` versions from `ordered_field`.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)