### PR TITLE
refactor(topology/algebra/ordered): prove IVT for a connected set

### DIFF
--- a/src/algebra/order.lean
+++ b/src/algebra/order.lean
@@ -175,9 +175,6 @@ lemma le_iff_le_iff_lt_iff_lt {β} [decidable_linear_order α] [decidable_linear
   {a b : α} {c d : β} : (a ≤ b ↔ c ≤ d) ↔ (b < a ↔ d < c) :=
 ⟨lt_iff_lt_of_le_iff_le, λ H, not_lt.symm.trans $ iff.trans (not_congr H) $ not_lt⟩
 
-lemma min_le_max [decidable_linear_order α] (a b : α) : min a b ≤ max a b :=
-le_trans (min_le_left a b) (le_max_left a b)
-
 end decidable
 
 namespace ordering

--- a/src/algebra/order_functions.lean
+++ b/src/algebra/order_functions.lean
@@ -85,6 +85,7 @@ lemma max_min_distrib_left : max a (min b c) = min (max a b) (max a c) := sup_in
 lemma max_min_distrib_right : max (min a b) c = min (max a c) (max b c) := sup_inf_right
 lemma min_max_distrib_left : min a (max b c) = max (min a b) (min a c) := inf_sup_left
 lemma min_max_distrib_right : min (max a b) c = max (min a c) (min b c) := inf_sup_right
+lemma min_le_max : min a b ≤ max a b := le_trans (min_le_left a b) (le_max_left a b)
 
 instance max_idem : is_idempotent α max := by apply_instance -- short-circuit type class inference
 instance min_idem : is_idempotent α min := by apply_instance -- short-circuit type class inference

--- a/src/analysis/complex/exponential.lean
+++ b/src/analysis/complex/exponential.lean
@@ -243,9 +243,9 @@ lemma continuous_cosh : continuous cosh :=
 differentiable_cosh.continuous
 
 lemma exists_exp_eq_of_pos {x : ℝ} (hx : 0 < x) : ∃ y, exp y = x :=
-have ∀ {z}, 1 ≤ z → ∃ y, exp y = z,
-  from λ z hz, intermediate_value_univ 0 (z - 1) continuous_exp (by simpa)
-    (by simpa using add_one_le_exp_of_nonneg (sub_nonneg.2 hz)),
+have ∀ {z:ℝ}, 1 ≤ z → z ∈ set.range exp,
+  from λ z hz, intermediate_value_univ 0 (z - 1) continuous_exp
+    ⟨by simpa, by simpa using add_one_le_exp_of_nonneg (sub_nonneg.2 hz)⟩,
 match le_total x 1 with
 | (or.inl hx1) := let ⟨y, hy⟩ := this (one_le_inv hx hx1) in
   ⟨-y, by rw [exp_neg, hy, inv_inv']⟩
@@ -371,11 +371,9 @@ show continuous ((log ∘ @subtype.val ℝ (λr, 0 < r)) ∘ λa, ⟨f a, h a⟩
 
 end prove_log_is_continuous
 
-lemma exists_cos_eq_zero : ∃ x ∈ set.Icc (1:ℝ) 2, cos x = 0 :=
-intermediate_value_Icc' (by norm_num)
-  continuous_cos.continuous_on
-  (le_of_lt cos_one_pos)
-  (le_of_lt cos_two_neg)
+lemma exists_cos_eq_zero : 0 ∈ cos '' set.Icc (1:ℝ) 2 :=
+intermediate_value_Icc' (by norm_num) continuous_cos.continuous_on
+  ⟨le_of_lt cos_two_neg, le_of_lt cos_one_pos⟩
 
 /-- The number π = 3.14159265... Defined here using choice as twice a zero of cos in [1,2], from
 which one can derive all its properties. For explicit bounds on π, see `data.real.pi`. -/
@@ -385,15 +383,15 @@ localized "notation `π` := real.pi" in real
 
 @[simp] lemma cos_pi_div_two : cos (π / 2) = 0 :=
 by rw [pi, mul_div_cancel_left _ (@two_ne_zero' ℝ _ _ _)];
-  exact (classical.some_spec exists_cos_eq_zero).snd
+  exact (classical.some_spec exists_cos_eq_zero).2
 
 lemma one_le_pi_div_two : (1 : ℝ) ≤ π / 2 :=
 by rw [pi, mul_div_cancel_left _ (@two_ne_zero' ℝ _ _ _)];
-  exact (classical.some_spec exists_cos_eq_zero).fst.1
+  exact (classical.some_spec exists_cos_eq_zero).1.1
 
 lemma pi_div_two_le_two : π / 2 ≤ 2 :=
 by rw [pi, mul_div_cancel_left _ (@two_ne_zero' ℝ _ _ _)];
-  exact (classical.some_spec exists_cos_eq_zero).fst.2
+  exact (classical.some_spec exists_cos_eq_zero).1.2
 
 lemma two_le_pi : (2 : ℝ) ≤ π :=
 (div_le_div_right (show (0 : ℝ) < 2, by norm_num)).1
@@ -663,13 +661,10 @@ begin
   linarith
 end
 
-lemma exists_sin_eq {x : ℝ} (hx : x ∈ set.Icc (-1:ℝ) 1) :
-  ∃ y ∈ set.Icc (-(π / 2)) (π / 2), sin y = x :=
-intermediate_value_Icc
+lemma exists_sin_eq : set.Icc (-1:ℝ) 1 ⊆  sin '' set.Icc (-(π / 2)) (π / 2) :=
+by convert intermediate_value_Icc
   (le_trans (neg_nonpos.2 (le_of_lt pi_div_two_pos)) (le_of_lt pi_div_two_pos))
-  continuous_sin.continuous_on
-  (by { rw [sin_neg, sin_pi_div_two], exact hx.1 })
-  (by { rw sin_pi_div_two, exact hx.2 })
+  continuous_sin.continuous_on; simp only [sin_neg, sin_pi_div_two]
 
 lemma sin_lt {x : ℝ} (h : 0 < x) : sin x < x :=
 begin
@@ -796,17 +791,17 @@ if hx : -1 ≤ x ∧ x ≤ 1 then classical.some (exists_sin_eq hx) else 0
 
 lemma arcsin_le_pi_div_two (x : ℝ) : arcsin x ≤ π / 2 :=
 if hx : -1 ≤ x ∧ x ≤ 1
-then by rw [arcsin, dif_pos hx]; exact (classical.some_spec (exists_sin_eq hx)).fst.2
+then by rw [arcsin, dif_pos hx]; exact (classical.some_spec (exists_sin_eq hx)).1.2
 else by rw [arcsin, dif_neg hx]; exact le_of_lt pi_div_two_pos
 
 lemma neg_pi_div_two_le_arcsin (x : ℝ) : -(π / 2) ≤ arcsin x :=
 if hx : -1 ≤ x ∧ x ≤ 1
-then by rw [arcsin, dif_pos hx]; exact (classical.some_spec (exists_sin_eq hx)).fst.1
+then by rw [arcsin, dif_pos hx]; exact (classical.some_spec (exists_sin_eq hx)).1.1
 else by rw [arcsin, dif_neg hx]; exact neg_nonpos.2 (le_of_lt pi_div_two_pos)
 
 lemma sin_arcsin {x : ℝ} (hx₁ : -1 ≤ x) (hx₂ : x ≤ 1) : sin (arcsin x) = x :=
 by rw [arcsin, dif_pos (and.intro hx₁ hx₂)];
-  exact (classical.some_spec (exists_sin_eq ⟨hx₁, hx₂⟩)).snd
+  exact (classical.some_spec (exists_sin_eq ⟨hx₁, hx₂⟩)).2
 
 lemma arcsin_sin {x : ℝ} (hx₁ : -(π / 2) ≤ x) (hx₂ : x ≤ π / 2) : arcsin (sin x) = x :=
 sin_inj_of_le_of_le_pi_div_two (neg_pi_div_two_le_arcsin _) (arcsin_le_pi_div_two _) hx₁ hx₂

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -2,13 +2,29 @@
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
-
-Theory of ordered topology.
 -/
 import order.liminf_limsup
 import data.set.intervals
 import topology.algebra.group
 import topology.constructions
+
+/-! # Theory of ordered topology
+
+## Main definitions
+`ordered_topology` and `orderable_topology`
+
+TODO expand
+
+## Main statements
+
+This file contains the proofs of the following facts:
+
+* all intervals `I??` are connected,
+* Intermediate Value Theorem, both for connected sets and `Icc` intervals,
+* Extreme Value Theorem: a continuous function on a compact set takes its maximum value.
+
+TODO expand
+-/
 
 open classical set lattice filter topological_space
 open_locale topological_space classical

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -135,6 +135,29 @@ is_open_lt continuous_const continuous_id
 lemma is_open_Ioo {a b : α} : is_open (Ioo a b) :=
 is_open_inter is_open_Ioi is_open_Iio
 
+lemma is_connected.forall_Icc_subset {s : set α} (hs : is_connected s)
+  {a b : α} (ha : a ∈ s) (hb : b ∈ s) :
+  Icc a b ⊆ s :=
+begin
+  assume x hx,
+  obtain ⟨y, hy, hy'⟩ : (s ∩ ((Iic x) ∩ (Ici x))).nonempty,
+    from is_connected_closed_iff.1 hs (Iic x) (Ici x) is_closed_Iic is_closed_Ici
+      (λ y _, le_total y x) ⟨a, ha, hx.1⟩ ⟨b, hb, hx.2⟩,
+  exact le_antisymm hy'.1 hy'.2 ▸ hy
+end
+
+/-- Intermediate Value Theorem for continuous functions on connected sets. -/
+lemma is_connected.intermediate_value {γ : Type*} [topological_space γ] {s : set γ}
+  (hs : is_connected s) {a b : γ} (ha : a ∈ s) (hb : b ∈ s) {f : γ → α} (hf : continuous_on f s) :
+  Icc (f a) (f b) ⊆ f '' s :=
+(hs.image f hf).forall_Icc_subset (mem_image_of_mem f ha) (mem_image_of_mem f hb)
+
+/-- Intermediate Value Theorem for continuous functions on connected spaces. -/
+lemma intermediate_value_univ {γ : Type*} [topological_space γ] [H : connected_space γ]
+  (a b : γ) {f : γ → α} (hf : continuous f) :
+  Icc (f a) (f b) ⊆ range f :=
+@image_univ _ _ f ▸ H.is_connected_univ.intermediate_value trivial trivial hf.continuous_on
+
 end linear_order
 
 section decidable_linear_order
@@ -1010,29 +1033,6 @@ lemma cinfi_of_cinfi_of_monotone_of_continuous {f : α → β} {g : γ → α}
   (Mf : continuous f) (Cf : monotone f) (H : bdd_below (range g)) : f (infi g) = infi (f ∘ g) :=
 by rw [infi, cInf_of_cInf_of_monotone_of_continuous Mf Cf
   (λ h, range_eq_empty.1 h ‹_›) H, ← range_comp]; refl
-
-lemma is_connected.forall_Icc_subset {s : set α} (hs : is_connected s)
-  {a b : α} (ha : a ∈ s) (hb : b ∈ s) :
-  Icc a b ⊆ s :=
-begin
-  assume x hx,
-  obtain ⟨y, hy, hy'⟩ : (s ∩ ((Iic x) ∩ (Ici x))).nonempty,
-    from is_connected_closed_iff.1 hs (Iic x) (Ici x) is_closed_Iic is_closed_Ici
-      (λ y _, le_total y x) ⟨a, ha, hx.1⟩ ⟨b, hb, hx.2⟩,
-  exact le_antisymm hy'.1 hy'.2 ▸ hy
-end
-
-/-- Intermediate Value Theorem for continuous functions on connected sets. -/
-lemma is_connected.intermediate_value {γ : Type*} [topological_space γ] {s : set γ}
-  (hs : is_connected s) {a b : γ} (ha : a ∈ s) (hb : b ∈ s) {f : γ → α} (hf : continuous_on f s) :
-  Icc (f a) (f b) ⊆ f '' s :=
-(hs.image f hf).forall_Icc_subset (mem_image_of_mem f ha) (mem_image_of_mem f hb)
-
-/-- Intermediate Value Theorem for continuous functions on connected spaces. -/
-lemma intermediate_value_univ {γ : Type*} [topological_space γ] [H : connected_space γ]
-  (a b : γ) {f : γ → α} (hf : continuous f) :
-  Icc (f a) (f b) ⊆ range f :=
-@image_univ _ _ f ▸ H.is_connected_univ.intermediate_value trivial trivial hf.continuous_on
 
 section densely_ordered
 

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -1043,7 +1043,6 @@ is_connected_closed_iff.2
 begin
   rintros s t hs ht hab ⟨x, hx⟩ ⟨y, hy⟩,
   wlog hxy : x ≤ y := le_total x y using [x y s t, y x t s],
-
   -- `c = Sup (Icc x y ∩ s)` belongs to `Icc a b`, `s`, and `t`.
   -- First two statements follow from general properties of `cSup`
   let S := Icc x y ∩ s,
@@ -1055,7 +1054,6 @@ begin
   have xyab : Icc x y ⊆ Icc a b := Icc_subset_Icc hx.1.1 hy.1.2,
   have Sab : S ⊆ Icc a b := subset.trans (inter_subset_left _ _) xyab,
   refine ⟨c, Sab c_mem, c_mem.2, _⟩,
-
   -- Now we need to prove `c ∈ t`; we deduce it from `Ioc c y ⊆ (s ∪ t) \ s ⊆ t`
   cases eq_or_lt_of_le c_mem.1.2 with hcy hcy, { exact hcy.symm ▸ hy.2 },
   suffices : Icc c y ⊆ t, from this (left_mem_Icc.2 (le_of_lt hcy)),

--- a/src/topology/instances/real.lean
+++ b/src/topology/instances/real.lean
@@ -347,60 +347,6 @@ compact_of_totally_bounded_is_closed
 instance : proper_space ℝ :=
 { compact_ball := λx r, by rw closed_ball_Icc; apply compact_Icc }
 
-open real
-
-lemma real.intermediate_value {f : ℝ → ℝ} {a b t : ℝ}
-  (hf : ∀ x, a ≤ x → x ≤ b → tendsto f (𝓝 x) (𝓝 (f x)))
-  (ha : f a ≤ t) (hb : t ≤ f b) (hab : a ≤ b) : ∃ x : ℝ, a ≤ x ∧ x ≤ b ∧ f x = t :=
-let x := real.Sup {x | f x ≤ t ∧ a ≤ x ∧ x ≤ b} in
-have hx₁ : ∃ y, ∀ g ∈ {x | f x ≤ t ∧ a ≤ x ∧ x ≤ b}, g ≤ y := ⟨b, λ _ h, h.2.2⟩,
-have hx₂ : ∃ y, y ∈ {x | f x ≤ t ∧ a ≤ x ∧ x ≤ b} := ⟨a, ha, le_refl _, hab⟩,
-have hax : a ≤ x, from le_Sup _ hx₁ ⟨ha, le_refl _, hab⟩,
-have hxb : x ≤ b, from (Sup_le _ hx₂ hx₁).2 (λ _ h, h.2.2),
-⟨x, hax, hxb,
-  eq_of_forall_dist_le $ λ ε ε0,
-    let ⟨δ, hδ0, hδ⟩ := metric.tendsto_nhds_nhds.1 (hf _ hax hxb) ε ε0 in
-    (le_total t (f x)).elim
-      (λ h, le_of_not_gt $ λ hfε, begin
-        rw [dist_eq, abs_of_nonneg (sub_nonneg.2 h)] at hfε,
-        refine mt (Sup_le {x | f x ≤ t ∧ a ≤ x ∧ x ≤ b} hx₂ hx₁).2
-          (not_le_of_gt (sub_lt_self x (half_pos hδ0)))
-          (λ g hg, le_of_not_gt
-            (λ hgδ, not_lt_of_ge hg.1
-              (lt_trans (lt_sub.1 hfε) (sub_lt_of_sub_lt
-                (lt_of_le_of_lt (le_abs_self _) _))))),
-        rw abs_sub,
-        exact hδ (abs_sub_lt_iff.2 ⟨lt_of_le_of_lt (sub_nonpos.2 (le_Sup _ hx₁ hg)) hδ0,
-          by simp only [x] at *; linarith⟩)
-        end)
-      (λ h, le_of_not_gt $ λ hfε, begin
-        rw [dist_eq, abs_of_nonpos (sub_nonpos.2 h)] at hfε,
-        exact mt (le_Sup {x | f x ≤ t ∧ a ≤ x ∧ x ≤ b})
-          (λ h : ∀ k, k ∈ {x | f x ≤ t ∧ a ≤ x ∧ x ≤ b} → k ≤ x,
-            not_le_of_gt ((lt_add_iff_pos_left x).2 (half_pos hδ0))
-              (h _ ⟨le_trans (le_sub_iff_add_le.2 (le_trans (le_abs_self _)
-                    (le_of_lt (hδ $ by rw [dist_eq, add_sub_cancel, abs_of_nonneg (le_of_lt (half_pos hδ0))];
-                      exact half_lt_self hδ0))))
-                  (by linarith),
-                le_trans hax (le_of_lt ((lt_add_iff_pos_left _).2 (half_pos hδ0))),
-                le_of_not_gt (λ hδy, not_lt_of_ge hb (lt_of_le_of_lt
-                  (show f b ≤ f b - f x - ε + t, by linarith)
-                  (add_lt_of_neg_of_le
-                    (sub_neg_of_lt (lt_of_le_of_lt (le_abs_self _)
-                      (@hδ b (abs_sub_lt_iff.2 ⟨by simp only [x] at *; linarith,
-                        by linarith⟩))))
-                    (le_refl _))))⟩))
-          hx₁
-        end)⟩
-
-lemma real.intermediate_value' {f : ℝ → ℝ} {a b t : ℝ}
-  (hf : ∀ x, a ≤ x → x ≤ b → tendsto f (𝓝 x) (𝓝 (f x)))
-  (ha : t ≤ f a) (hb : f b ≤ t) (hab : a ≤ b) : ∃ x : ℝ, a ≤ x ∧ x ≤ b ∧ f x = t :=
-let ⟨x, hx₁, hx₂, hx₃⟩ := @real.intermediate_value
-  (λ x, - f x) a b (-t) (λ x hax hxb, (hf x hax hxb).neg)
-  (neg_le_neg ha) (neg_le_neg hb) hab in
-⟨x, hx₁, hx₂, neg_inj hx₃⟩
-
 lemma real.bounded_iff_bdd_below_bdd_above {s : set ℝ} : bounded s ↔ bdd_below s ∧ bdd_above s :=
 ⟨begin
   assume bdd,

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -1,13 +1,20 @@
 /-
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johannes Hölzl, Mario Carneiro
-
-Properties of subsets of topological spaces: compact, clopen, irreducible,
-connected, totally disconnected, totally separated.
+Authors: Johannes Hölzl, Mario Carneiro, Yury Kudryashov
 -/
 
 import topology.continuous_on
+
+/-!
+# Properties of subsets of topological spaces
+
+## Main definitions
+
+`compact`, `is_clopen`, `is_irreducible`, `is_connected`, `is_totally_disconnected`, `is_totally_separated`
+
+TODO: write better docs
+-/
 
 open set filter lattice classical
 open_locale classical topological_space
@@ -200,6 +207,8 @@ section tube_lemma
 
 variables [topological_space β]
 
+/-- `nhds_contain_boxes s t` means that any neighborhood of `s × t` in `α × β` includes
+a product of a neighborhood of `s` by a neighborhood of `t`. -/
 def nhds_contain_boxes (s : set α) (t : set β) : Prop :=
 ∀ (n : set (α × β)) (hn : is_open n) (hp : set.prod s t ⊆ n),
 ∃ (u : set α) (v : set β), is_open u ∧ is_open v ∧ s ⊆ u ∧ t ⊆ v ∧ set.prod u v ⊆ n
@@ -432,7 +441,7 @@ end clopen
 
 section irreducible
 
-/-- A irreducible set is one where there is no non-trivial pair of disjoint opens. -/
+/-- An irreducible set is one where there is no non-trivial pair of disjoint opens. -/
 def is_irreducible (s : set α) : Prop :=
 ∀ (u v : set α), is_open u → is_open v →
   (∃ x, x ∈ s ∩ u) → (∃ x, x ∈ s ∩ v) → ∃ x, x ∈ s ∩ (u ∩ v)
@@ -489,7 +498,7 @@ closure_eq_iff_is_closed.1 $ eq_irreducible_component
   (is_irreducible_closure is_irreducible_irreducible_component)
   subset_closure
 
-/-- A irreducible space is one where there is no non-trivial pair of disjoint opens. -/
+/-- An irreducible space is one where there is no non-trivial pair of disjoint opens. -/
 class irreducible_space (α : Type u) [topological_space α] : Prop :=
 (is_irreducible_univ : is_irreducible (univ : set α))
 
@@ -674,6 +683,7 @@ end connected
 
 section totally_disconnected
 
+/-- A set is called totally disconnected if all of its connected components are singletons. -/
 def is_totally_disconnected (s : set α) : Prop :=
 ∀ t, t ⊆ s → is_connected t → subsingleton t
 
@@ -684,6 +694,7 @@ theorem is_totally_disconnected_singleton {x} : is_totally_disconnected ({x} : s
 λ t ht _, ⟨λ ⟨p, hp⟩ ⟨q, hq⟩, subtype.eq $ show p = q,
 from (eq_of_mem_singleton (ht hp)).symm ▸ (eq_of_mem_singleton (ht hq)).symm⟩
 
+/-- A space is totally disconnected if all of its connected components are singletons. -/
 class totally_disconnected_space (α : Type u) [topological_space α] : Prop :=
 (is_totally_disconnected_univ : is_totally_disconnected (univ : set α))
 
@@ -691,6 +702,8 @@ end totally_disconnected
 
 section totally_separated
 
+/-- A set `s` is called totally separated if any two points of this set can be separated
+by two disjoint open sets covering `s`. -/
 def is_totally_separated (s : set α) : Prop :=
 ∀ x ∈ s, ∀ y ∈ s, x ≠ y → ∃ u v : set α, is_open u ∧ is_open v ∧
   x ∈ u ∧ y ∈ v ∧ s ⊆ u ∪ v ∧ u ∩ v = ∅
@@ -708,6 +721,8 @@ assume hxy : x ≠ y, let ⟨u, v, hu, hv, hxu, hyv, hsuv, huv⟩ := H x (hts hx
 let ⟨r, hrt, hruv⟩ := ht u v hu hv (subset.trans hts hsuv) ⟨x, hxt, hxu⟩ ⟨y, hyt, hyv⟩ in
 ((ext_iff _ _).1 huv r).1 hruv⟩
 
+/-- A space is totally separated if any two points can be separated by two disjoint open sets
+covering the whole space. -/
 class totally_separated_space (α : Type u) [topological_space α] : Prop :=
 (is_totally_separated_univ : is_totally_separated (univ : set α))
 

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -570,19 +570,22 @@ let ⟨r, hrs, hruv⟩ := H u v hu hv (subset.trans subset_closure hcsuv) ⟨p, 
 theorem is_connected.image [topological_space β] {s : set α} (H : is_connected s)
   (f : α → β) (hf : continuous_on f s) : is_connected (f '' s) :=
 begin
+  -- Unfold/destruct definitions in hypotheses
   rintros u v hu hv huv ⟨_, ⟨x, xs, rfl⟩, xu⟩ ⟨_, ⟨y, ys, rfl⟩, yv⟩,
   rcases continuous_on_iff'.1 hf u hu with ⟨u', hu', u'_eq⟩,
   rcases continuous_on_iff'.1 hf v hv with ⟨v', hv', v'_eq⟩,
 
-  rw [image_subset_iff, preimage_union] at huv,
-  replace huv := subset_inter huv (subset.refl _),
-  rw [inter_distrib_right, u'_eq, v'_eq, ← inter_distrib_right] at huv,
-  replace huv := (subset_inter_iff.1 huv).1,
+  -- Reformulate `huv : f '' s ⊆ u ∪ v` in terms of `u'` and `v'`
+  replace huv : s ⊆ u' ∪ v',
+  { rw [image_subset_iff, preimage_union] at huv,
+    replace huv := subset_inter huv (subset.refl _),
+    rw [inter_distrib_right, u'_eq, v'_eq, ← inter_distrib_right] at huv,
+    exact (subset_inter_iff.1 huv).1 },
 
-  obtain ⟨z, hz⟩ : ∃ z, z ∈ s ∩ (u' ∩ v'),
+  -- Now `s ⊆ u' ∪ v'`, so we can apply `‹is_connected s›`
+  obtain ⟨z, hz⟩ : (s ∩ (u' ∩ v')).nonempty,
   { refine H u' v' hu' hv' huv ⟨x, _⟩ ⟨y, _⟩; rw inter_comm,
     exacts [u'_eq ▸ ⟨xu, xs⟩, v'_eq ▸ ⟨yv, ys⟩] },
-
   rw [← inter_self s, inter_assoc, inter_left_comm s u', ← inter_assoc,
     inter_comm s, inter_comm s, ← u'_eq, ← v'_eq] at hz,
   exact ⟨f z, ⟨z, hz.1.2, rfl⟩, hz.1.1, hz.2.1⟩

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -207,8 +207,8 @@ section tube_lemma
 
 variables [topological_space β]
 
-/-- `nhds_contain_boxes s t` means that any neighborhood of `s × t` in `α × β` includes
-a product of a neighborhood of `s` by a neighborhood of `t`. -/
+/-- `nhds_contain_boxes s t` means that any open neighborhood of `s × t` in `α × β` includes
+a product of an open neighborhood of `s` by an open neighborhood of `t`. -/
 def nhds_contain_boxes (s : set α) (t : set β) : Prop :=
 ∀ (n : set (α × β)) (hn : is_open n) (hp : set.prod s t ⊆ n),
 ∃ (u : set α) (v : set β), is_open u ∧ is_open v ∧ s ⊆ u ∧ t ⊆ v ∧ set.prod u v ⊆ n
@@ -583,14 +583,12 @@ begin
   rintros u v hu hv huv ⟨_, ⟨x, xs, rfl⟩, xu⟩ ⟨_, ⟨y, ys, rfl⟩, yv⟩,
   rcases continuous_on_iff'.1 hf u hu with ⟨u', hu', u'_eq⟩,
   rcases continuous_on_iff'.1 hf v hv with ⟨v', hv', v'_eq⟩,
-
   -- Reformulate `huv : f '' s ⊆ u ∪ v` in terms of `u'` and `v'`
   replace huv : s ⊆ u' ∪ v',
   { rw [image_subset_iff, preimage_union] at huv,
     replace huv := subset_inter huv (subset.refl _),
     rw [inter_distrib_right, u'_eq, v'_eq, ← inter_distrib_right] at huv,
     exact (subset_inter_iff.1 huv).1 },
-
   -- Now `s ⊆ u' ∪ v'`, so we can apply `‹is_connected s›`
   obtain ⟨z, hz⟩ : (s ∩ (u' ∩ v')).nonempty,
   { refine H u' v' hu' hv' huv ⟨x, _⟩ ⟨y, _⟩; rw inter_comm,

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -478,6 +478,7 @@ let ⟨m, hm, hsm, hmm⟩ := zorn.zorn_subset₀ { t : set α | is_irreducible t
     λ x hxc, set.subset_sUnion_of_mem hxc⟩) s H in
 ⟨m, hm, hsm, λ u hu hmu, hmm _ hu hmu⟩
 
+/-- A maximal irreducible set that contains a given point. -/
 def irreducible_component (x : α) : set α :=
 classical.some (exists_irreducible {x} is_irreducible_singleton)
 


### PR DESCRIPTION
Also prove that intervals are connected, and deduce the classical IVT
from this.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)