### PR TITLE
feat(analysis/calculus/local_extr): Fermat's Theorem, Rolle's Theorem, Lagrange's MVT, Cauchy's MVT

### DIFF
--- a/src/analysis/asymptotics.lean
+++ b/src/analysis/asymptotics.lean
@@ -30,7 +30,7 @@ norm explicitly.
 If `f` and `g` are functions to a normed field like the reals or complex numbers and `g` is always
 nonzero, we have
 
-  `is_o f g l ↔ tendsto (λ x, f x / (g x)) (𝓝 0) l`.
+  `is_o f g l ↔ tendsto (λ x, f x / (g x)) l (𝓝 0)`.
 
 In fact, the right-to-left direction holds without the hypothesis on `g`, and in the other direction
 it suffices to assume that `f` is zero wherever `g` is. (This generalization is useful in defining

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -217,6 +217,10 @@ lemma has_deriv_within_at.nhds_within (h : has_deriv_within_at f f' s x)
   (ht : s ∈ nhds_within x t) : has_deriv_within_at f f' t x :=
 (has_deriv_within_at_inter' ht).1 (h.mono (inter_subset_right _ _))
 
+lemma has_deriv_within_at.has_deriv_at (h : has_deriv_within_at f f' s x) (hs : s ∈ 𝓝 x) :
+  has_deriv_at f f' x :=
+has_fderiv_within_at.has_fderiv_at h hs
+
 lemma differentiable_within_at.has_deriv_within_at (h : differentiable_within_at 𝕜 f s x) :
   has_deriv_within_at f (deriv_within f s x) s x :=
 show has_fderiv_within_at _ _ _ _, by { convert h.has_fderiv_within_at, simp [deriv_within] }

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -324,6 +324,10 @@ lemma has_fderiv_within_at.nhds_within (h : has_fderiv_within_at f f' s x)
   (ht : s ∈ nhds_within x t) : has_fderiv_within_at f f' t x :=
 (has_fderiv_within_at_inter' ht).1 (h.mono (inter_subset_right _ _))
 
+lemma has_fderiv_within_at.has_fderiv_at (h : has_fderiv_within_at f f' s x) (hs : s ∈ 𝓝 x) :
+  has_fderiv_at f f' x :=
+by rwa [← univ_inter s, has_fderiv_within_at_inter hs, has_fderiv_within_at_univ] at h
+
 lemma differentiable_within_at.has_fderiv_within_at (h : differentiable_within_at 𝕜 f s x) :
   has_fderiv_within_at f (fderiv_within 𝕜 f s x) s x :=
 begin
@@ -368,10 +372,7 @@ end
 
 lemma differentiable_within_at_univ :
   differentiable_within_at 𝕜 f univ x ↔ differentiable_at 𝕜 f x :=
-begin
-  simp [differentiable_within_at, has_fderiv_within_at, nhds_within_univ],
-  refl
-end
+by simp only [differentiable_within_at, has_fderiv_within_at_univ, differentiable_at]
 
 lemma differentiable_within_at_inter (ht : t ∈ 𝓝 x) :
   differentiable_within_at 𝕜 f (s ∩ t) x ↔ differentiable_within_at 𝕜 f s x :=
@@ -389,10 +390,7 @@ lemma differentiable_at.differentiable_within_at
 
 lemma differentiable_within_at.differentiable_at
   (h : differentiable_within_at 𝕜 f s x) (hs : s ∈ 𝓝 x) : differentiable_at 𝕜 f x :=
-begin
-  have : s = univ ∩ s, by rw univ_inter,
-  rwa [this, differentiable_within_at_inter hs, differentiable_within_at_univ] at h
-end
+h.imp (λ f' hf', hf'.has_fderiv_at hs)
 
 lemma differentiable_at.fderiv_within
   (h : differentiable_at 𝕜 f x) (hxs : unique_diff_within_at 𝕜 s x) :

--- a/src/analysis/calculus/local_extr.lean
+++ b/src/analysis/calculus/local_extr.lean
@@ -18,16 +18,23 @@ This set is used in the proof of Fermat's Theorem (see below), and can be used t
 
 ## Main statements
 
-First we prove that `0 ≤ f' y` whenever `a` is a local maximum of `f` on `s`,
-`f` has derivative `f'` at `a` within `s`, and `y` belongs to the positive tangent cone
-of `s` at `a`. Hence if both `y` and `-y` belong to the positive tangent cone, then `f' y = 0`.
-These facts are used to prove
-[Fermat's Theorem](https://en.wikipedia.org/wiki/Fermat's_theorem_(stationary_points)):
-the derivative of a differentiable function at a local extremum point equals zero.
+For each theorem name listed below, we also prove similar theorems for `min`, `extr` (if applicable)`,
+and `(f)deriv` instead of `has_fderiv`.
 
-Then we use Fermat's Theorem to prove
-[Rolle's Theorem](https://en.wikipedia.org/wiki/Rolle's_theorem): given a function `f` continuous
-on `[a, b]` and differentiable on `(a, b)`, there exists `c ∈ (a, b)` such that `f' c = 0`.
+* `is_local_max_on.has_fderiv_within_at_nonpos` : `0 ≤ f' y` whenever `a` is a local maximum
+  of `f` on `s`, `f` has derivative `f'` at `a` within `s`, and `y` belongs to the positive tangent
+  cone of `s` at `a`.
+
+* `is_local_max_on.has_fderiv_within_at_eq_zero` : In the settings of the previous theorem, if both
+  `y` and `-y` belong to the positive tangent cone, then `f' y = 0`.
+
+* `is_local_max.has_fderiv_at_eq_zero` :
+  [Fermat's Theorem](https://en.wikipedia.org/wiki/Fermat's_theorem_(stationary_points)),
+  the derivative of a differentiable function at a local extremum point equals zero.
+
+* `exists_has_deriv_at_eq_zero` :
+  [Rolle's Theorem](https://en.wikipedia.org/wiki/Rolle's_theorem): given a function `f` continuous
+  on `[a, b]` and differentiable on `(a, b)`, there exists `c ∈ (a, b)` such that `f' c = 0`.
 
 ## Implementation notes
 

--- a/src/analysis/calculus/local_extr.lean
+++ b/src/analysis/calculus/local_extr.lean
@@ -83,7 +83,6 @@ begin
     from tendsto_at_top_mono _ (λ n, le_abs_self _) hc,
   refine le_of_tendsto at_top_ne_bot (hf.lim at_top hd hc' hcd) _,
   replace hd : tendsto (λ n, a + d n) at_top (nhds_within (a + 0) s),
-   -- TODO use `tendsto.inf`once #1809 is landed
   from tendsto_inf.2 ⟨tendsto_const_nhds.add (tangent_cone_at.lim_zero _ hc' hcd),
     by rwa tendsto_principal⟩,
   rw [add_zero] at hd,
@@ -166,6 +165,7 @@ lemma is_local_extr.has_fderiv_at_eq_zero (h : is_local_extr f a) :
   has_fderiv_at f f' a → f' = 0 :=
 h.elim is_local_min.has_fderiv_at_eq_zero is_local_max.has_fderiv_at_eq_zero
 
+/-- Fermat's Theorem: the derivative of a function at a local extremum equals zero. -/
 lemma is_local_extr.fderiv_eq_zero (h : is_local_extr f a) : fderiv ℝ f a = 0 :=
 h.elim is_local_min.fderiv_eq_zero is_local_max.fderiv_eq_zero
 
@@ -175,27 +175,33 @@ section real
 
 variables {f : ℝ → ℝ} {f' : ℝ} {a b : ℝ}
 
+/-- Fermat's Theorem: the derivative of a function at a local extremum equals zero. -/
 lemma is_local_min.has_deriv_at_eq_zero (h : is_local_min f a) (hf : has_deriv_at f f' a) :
   f' = 0 :=
 by simpa using continuous_linear_map.ext_iff.1
   (h.has_fderiv_at_eq_zero (has_deriv_at_iff_has_fderiv_at.1 hf)) 1
 
+/-- Fermat's Theorem: the derivative of a function at a local extremum equals zero. -/
 lemma is_local_min.deriv_eq_zero (h : is_local_min f a) : deriv f a = 0 :=
 if hf : differentiable_at ℝ f a then h.has_deriv_at_eq_zero hf.has_deriv_at
 else deriv_zero_of_not_differentiable_at hf
 
+/-- Fermat's Theorem: the derivative of a function at a local extremum equals zero. -/
 lemma is_local_max.has_deriv_at_eq_zero (h : is_local_max f a) (hf : has_deriv_at f f' a) :
   f' = 0 :=
 neg_eq_zero.1 $ h.neg.has_deriv_at_eq_zero hf.neg
 
+/-- Fermat's Theorem: the derivative of a function at a local extremum equals zero. -/
 lemma is_local_max.deriv_eq_zero (h : is_local_max f a) : deriv f a = 0 :=
 if hf : differentiable_at ℝ f a then h.has_deriv_at_eq_zero hf.has_deriv_at
 else deriv_zero_of_not_differentiable_at hf
 
+/-- Fermat's Theorem: the derivative of a function at a local extremum equals zero. -/
 lemma is_local_extr.has_deriv_at_eq_zero (h : is_local_extr f a) :
   has_deriv_at f f' a → f' = 0 :=
 h.elim is_local_min.has_deriv_at_eq_zero is_local_max.has_deriv_at_eq_zero
 
+/-- Fermat's Theorem: the derivative of a function at a local extremum equals zero. -/
 lemma is_local_extr.deriv_eq_zero (h : is_local_extr f a) : deriv f a = 0 :=
 h.elim is_local_min.deriv_eq_zero is_local_max.deriv_eq_zero
 
@@ -207,6 +213,8 @@ variables (f f' : ℝ → ℝ) {a b : ℝ} (hab : a < b) (hfc : continuous_on f 
 
 include hab hfc hfI
 
+/-- A continuous function on a closed interval with `f a = f b` takes either its maximum
+or its minimum value at a point in the interior of the interval. -/
 lemma exists_Ioo_extr_on_Icc : ∃ c ∈ Ioo a b, is_extr_on f (Icc a b) c :=
 begin
   have ne : Icc a b ≠ ∅, from ne_empty_of_mem (left_mem_Icc.2 (le_of_lt hab)),
@@ -231,6 +239,8 @@ begin
       exacts [λ h, by rw h, λ h, by rw [h, hfI]] }
 end
 
+/-- A continuous function on a closed interval with `f a = f b` has a local extremum at some
+point of the corresponding open interval. -/
 lemma exists_local_extr_Ioo : ∃ c ∈ Ioo a b, is_local_extr f c :=
 let ⟨c, cmem, hc⟩ := exists_Ioo_extr_on_Icc f hab hfc hfI
 in ⟨c, cmem, hc.is_local_extr $ mem_nhds_sets_iff.2 ⟨Ioo a b, Ioo_subset_Icc_self, is_open_Ioo, cmem⟩⟩

--- a/src/analysis/calculus/local_extr.lean
+++ b/src/analysis/calculus/local_extr.lean
@@ -40,7 +40,7 @@ and `(f)deriv` instead of `has_fderiv`.
 
 For each mathematical fact we prove several versions of its formalization:
 
-* for maximums and minimums;
+* for maxima and minima;
 * using `has_fderiv*`/`has_deriv*` or `fderiv*`/`deriv*`.
 
 For the `fderiv*`/`deriv*` versions we omit the differentiability condition whenever it is possible

--- a/src/analysis/calculus/local_extr.lean
+++ b/src/analysis/calculus/local_extr.lean
@@ -21,11 +21,13 @@ This set is used in the proof of Fermat's Theorem (see below), and can be used t
 First we prove that `0 ≤ f' y` whenever `a` is a local maximum of `f` on `s`,
 `f` has derivative `f'` at `a` within `s`, and `y` belongs to the positive tangent cone
 of `s` at `a`. Hence if both `y` and `-y` belong to the positive tangent cone, then `f' y = 0`.
-These facts are used to prove Fermat's Theorem: the derivative of a differentiable function
-at a local extremum point equals zero.
+These facts are used to prove
+[Fermat's Theorem](https://en.wikipedia.org/wiki/Fermat's_theorem_(stationary_points):
+the derivative of a differentiable function at a local extremum point equals zero.
 
-Then we use Fermat's Theorem to prove Rolle's Theorem: given a function `f` continuous on `[a, b]`
-and differentiable on `(a, b)`, there exists `c ∈ (a, b)` such that `f' c = 0`.
+Then we use Fermat's Theorem to prove
+[Rolle's Theorem](https://en.wikipedia.org/wiki/Rolle's_theorem): given a function `f` continuous
+on `[a, b]` and differentiable on `(a, b)`, there exists `c ∈ (a, b)` such that `f' c = 0`.
 
 ## Implementation notes
 
@@ -48,9 +50,9 @@ section vector_space
 variables {E : Type u} [normed_group E] [normed_space ℝ E] {f : E → ℝ} {a : E}
   {f' : E →L[ℝ] ℝ}
 
-/-- "Positive" tangent cone to `s` at `x`; the definition differs from `tangent_cone_at`
-by the requirement. One can think about `pos_tangent_cone_at` as `tangent_cone_at nnreal`
-but we have no theory of normed semifields yet. -/
+/-- "Positive" tangent cone to `s` at `x`; the only difference from `tangent_cone_at`
+is that we require `c n → ∞` instead of `∥c n∥ → ∞`. One can think about `pos_tangent_cone_at`
+as `tangent_cone_at nnreal` but we have no theory of normed semifields yet. -/
 def pos_tangent_cone_at (s : set E) (x : E) : set E :=
 {y : E | ∃(c : ℕ → ℝ) (d : ℕ → E), {n:ℕ | x + d n ∈ s} ∈ (at_top : filter ℕ) ∧
   (tendsto c at_top at_top) ∧ (tendsto (λn, c n • d n) at_top (𝓝 y))}

--- a/src/analysis/calculus/local_extr.lean
+++ b/src/analysis/calculus/local_extr.lean
@@ -21,7 +21,7 @@ This set is used in the proof of Fermat's Theorem (see below), and can be used t
 For each theorem name listed below, we also prove similar theorems for `min`, `extr` (if applicable)`,
 and `(f)deriv` instead of `has_fderiv`.
 
-* `is_local_max_on.has_fderiv_within_at_nonpos` : `0 ≤ f' y` whenever `a` is a local maximum
+* `is_local_max_on.has_fderiv_within_at_nonpos` : `f' y ≤ 0` whenever `a` is a local maximum
   of `f` on `s`, `f` has derivative `f'` at `a` within `s`, and `y` belongs to the positive tangent
   cone of `s` at `a`.
 

--- a/src/analysis/calculus/local_extr.lean
+++ b/src/analysis/calculus/local_extr.lean
@@ -1,0 +1,276 @@
+/-
+Copyright (c) 2019 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov
+-/
+
+import analysis.calculus.deriv
+
+/-! # Local extrema of smooth functions
+
+## Main definitions
+
+* `is_local_min f a` : `f a ≤ f x` in some neighborhood of `a`;
+* `is_local_max f a` : `f x ≤ f a` in some neighborhood of `a`;
+* `is_local_extr f a` : one of the above.
+
+## Main statements
+
+Rolle's Theorem, Lagrange's and Cauchy's Mean Value Theorems.
+
+TODO:
+
+* if `deriv f` is positive on an interval, then `f` is strictly increasing;
+* similarly for negative/nonpositive/nonnegative;
+* in particular, if `∀ x, deriv f x = 0`, then `f = const`.
+* possibly move some lemmas to other file(s)
+-/
+
+universes u v
+
+open filter set
+open_locale topological_space classical
+
+section defs
+
+variables {α : Type u} {β : Type v} [topological_space α] [preorder β]
+  (f : α → β) (a : α)
+
+/-- `a` is a local minimum of `f` if `f a ≤ f x` in a neighborhood of `a`. -/
+def is_local_min : Prop := {x | f a ≤ f x} ∈ 𝓝 a
+
+/-- `a` is a local maximum of `f` if `f x ≤ f a` in a neighborhood of `a`. -/
+def is_local_max : Prop := {x | f x ≤ f a} ∈ 𝓝 a
+
+/-- `a` is a local extremum of `f` if it is either a local minimum, or a local maximum. -/
+def is_local_extr : Prop := is_local_min f a ∨ is_local_max f a
+
+variables {f a}
+
+lemma is_local_min_const {b : β} : is_local_min (λ _, b) a :=
+univ_mem_sets' $ λ _, le_refl _
+
+lemma is_local_max_const {b : β} : is_local_max (λ _, b) a :=
+univ_mem_sets' $ λ _, le_refl _
+
+end defs
+
+section ordered_comm_monoid
+
+variables {α : Type u} {G : Type v} [topological_space α] [ordered_comm_monoid G]
+  {f g : α → G} {a : α}
+
+lemma is_local_min.add (hf : is_local_min f a) (hg : is_local_min g a) : is_local_min (f + g) a :=
+mem_sets_of_superset (inter_mem_sets hf hg) $ λ x ⟨hfx, hgx⟩, add_le_add' hfx hgx
+
+lemma is_local_max.add (hf : is_local_max f a) (hg : is_local_max g a) : is_local_max (f + g) a :=
+mem_sets_of_superset (inter_mem_sets hf hg) $ λ x ⟨hfx, hgx⟩, add_le_add' hfx hgx
+
+lemma is_local_min.add_left (hf : is_local_min f a) (b : G) :
+  is_local_min (λ x, b + f x) a :=
+is_local_min_const.add hf
+
+lemma is_local_min.add_right (hf : is_local_min f a) (b : G) :
+  is_local_min (λ x, f x + b) a :=
+hf.add is_local_min_const
+
+lemma is_local_max.add_left (hf : is_local_max f a) (b : G) :
+  is_local_max (λ x, b + f x) a :=
+is_local_max_const.add hf
+
+lemma is_local_max.add_right (hf : is_local_max f a) (b : G) :
+  is_local_max (λ x, f x + b) a :=
+hf.add is_local_max_const
+
+end ordered_comm_monoid
+
+section ordered_comm_group
+
+variables {α : Type u} {G : Type v} [topological_space α] [ordered_comm_group G]
+  {f g : α → G} {a : α}
+
+lemma is_local_min.neg (hf : is_local_min f a) : is_local_max (-f) a :=
+mem_sets_of_superset hf $ λ x, neg_le_neg
+
+lemma is_local_max.neg (hf : is_local_max f a) : is_local_min (-f) a :=
+mem_sets_of_superset hf $ λ x, neg_le_neg
+
+lemma is_local_min.sub (hf : is_local_min f a) (hg : is_local_max g a) :
+  is_local_min (f - g) a :=
+hf.add hg.neg
+
+lemma is_local_max.sub (hf : is_local_max f a) (hg : is_local_min g a) :
+  is_local_max (f - g) a :=
+hf.add hg.neg
+
+end ordered_comm_group
+
+section vector_space
+
+variables {E : Type u} [normed_group E] [normed_space ℝ E] {f : E → ℝ} {a : E}
+  {f' : E →L[ℝ] ℝ}
+
+lemma is_local_min.has_fderiv_at_eq_zero (h : is_local_min f a) (hf : has_fderiv_at f f' a) :
+  f' = 0 :=
+begin
+  suffices : ∀ v : E, (0:ℝ) ≤ f' v,
+  { ext v,
+    exact le_antisymm (by simpa using this (-v)) (this v) },
+  refine λ v, ge_of_tendsto at_top_ne_bot (hf.lim_real v) _,
+  apply mp_sets (mem_at_top (1:ℝ)),
+  have : tendsto (λ b:ℝ, a + b⁻¹ • v) at_top (𝓝 (a + (0:ℝ) • v)),
+    from tendsto_const_nhds.add (tendsto_smul tendsto_inverse_at_top_nhds_0 tendsto_const_nhds),
+  rw [zero_smul, add_zero] at this,
+  apply mem_sets_of_superset (mem_map.1 $ this h),
+  simp only [mem_set_of_eq, smul_eq_mul, mem_preimage],
+  assume c hfc hc,
+  exact mul_nonneg (le_trans zero_le_one hc) (sub_nonneg.2 hfc)
+end
+
+/-- The derivative at a local minimum equals zero. -/
+lemma is_local_min.fderiv_eq_zero (h : is_local_min f a) : fderiv ℝ f a = 0 :=
+if hf : differentiable_at ℝ f a then h.has_fderiv_at_eq_zero hf.has_fderiv_at
+else fderiv_zero_of_not_differentiable_at hf
+
+lemma is_local_max.has_fderiv_at_eq_zero (h : is_local_max f a) (hf : has_fderiv_at f f' a) :
+  f' = 0 :=
+neg_eq_zero.1 $ h.neg.has_fderiv_at_eq_zero hf.neg
+
+lemma is_local_max.fderiv_eq_zero (h : is_local_max f a) : fderiv ℝ f a = 0 :=
+if hf : differentiable_at ℝ f a then h.has_fderiv_at_eq_zero hf.has_fderiv_at
+else fderiv_zero_of_not_differentiable_at hf
+
+lemma is_local_extr.has_fderiv_at_eq_zero (h : is_local_extr f a) :
+  has_fderiv_at f f' a → f' = 0 :=
+h.elim is_local_min.has_fderiv_at_eq_zero is_local_max.has_fderiv_at_eq_zero
+
+lemma is_local_extr.fderiv_eq_zero (h : is_local_extr f a) : fderiv ℝ f a = 0 :=
+h.elim is_local_min.fderiv_eq_zero is_local_max.fderiv_eq_zero
+
+end vector_space
+
+section real
+
+variables {f : ℝ → ℝ} {f' : ℝ} {a b : ℝ}
+
+lemma is_local_min.has_deriv_at_eq_zero (h : is_local_min f a) (hf : has_deriv_at f f' a) :
+  f' = 0 :=
+by simpa using continuous_linear_map.ext_iff.1
+  (h.has_fderiv_at_eq_zero (has_deriv_at_iff_has_fderiv_at.1 hf)) 1
+
+lemma is_local_min.deriv_eq_zero (h : is_local_min f a) : deriv f a = 0 :=
+if hf : differentiable_at ℝ f a then h.has_deriv_at_eq_zero hf.has_deriv_at
+else deriv_zero_of_not_differentiable_at hf
+
+lemma is_local_max.has_deriv_at_eq_zero (h : is_local_max f a) (hf : has_deriv_at f f' a) :
+  f' = 0 :=
+neg_eq_zero.1 $ h.neg.has_deriv_at_eq_zero hf.neg
+
+lemma is_local_max.deriv_eq_zero (h : is_local_max f a) : deriv f a = 0 :=
+if hf : differentiable_at ℝ f a then h.has_deriv_at_eq_zero hf.has_deriv_at
+else deriv_zero_of_not_differentiable_at hf
+
+lemma is_local_extr.has_deriv_at_eq_zero (h : is_local_extr f a) :
+  has_deriv_at f f' a → f' = 0 :=
+h.elim is_local_min.has_deriv_at_eq_zero is_local_max.has_deriv_at_eq_zero
+
+lemma is_local_extr.deriv_eq_zero (h : is_local_extr f a) : deriv f a = 0 :=
+h.elim is_local_min.deriv_eq_zero is_local_max.deriv_eq_zero
+
+end real
+
+section MVT
+
+variables (f f' : ℝ → ℝ) {a b : ℝ} (hab : a < b) (hfc : continuous f) (hfI : f a = f b)
+
+include hab hfc hfI
+
+lemma exists_global_extr_Ioo :
+  ∃ c ∈ Ioo a b, (∀ x ∈ Icc a b, f c ≤ f x) ∨ (∀ x ∈ Icc a b, f x ≤ f c) :=
+begin
+  -- Consider absolute min and max points
+  obtain ⟨c, cmem, cle⟩ : ∃ c ∈ Icc a b, ∀ x ∈ Icc a b, f c ≤ f x,
+    from exists_forall_le_of_compact_of_continuous f hfc (Icc a b) compact_Icc
+      (ne_empty_of_mem $ left_mem_Icc.2 $ le_of_lt hab),
+  obtain ⟨C, Cmem, Cge⟩ : ∃ C ∈ Icc a b, ∀ x ∈ Icc a b, f x ≤ f C,
+    from exists_forall_ge_of_compact_of_continuous f hfc (Icc a b) compact_Icc
+      (ne_empty_of_mem $ left_mem_Icc.2 $ le_of_lt hab),
+  by_cases hc : f c = f a,
+  { by_cases hC : f C = f a,
+    { have : ∀ x ∈ Icc a b, f x = f a,
+        from λ x hx, le_antisymm (hC ▸ Cge x hx) (hc ▸ cle x hx),
+      -- `f` is a constant, so we can take any point in `Ioo a b`
+      rcases dense hab with ⟨c', hc'⟩,
+      refine ⟨c', hc', or.inl _⟩,
+      assume x hx,
+      rw [this x hx, ← hC],
+      exact Cge c' ⟨le_of_lt hc'.1, le_of_lt hc'.2⟩ },
+
+    { refine ⟨C, ⟨lt_of_le_of_ne Cmem.1 $ mt _ hC, lt_of_le_of_ne Cmem.2 $ mt _ hC⟩, or.inr Cge⟩,
+      exacts [λ h, by rw h, λ h, by rw [h, hfI]] } },
+  { refine ⟨c, ⟨lt_of_le_of_ne cmem.1 $ mt _ hc, lt_of_le_of_ne cmem.2 $ mt _ hc⟩, or.inl cle⟩,
+      exacts [λ h, by rw h, λ h, by rw [h, hfI]] }
+end
+
+lemma exists_local_extr_Ioo : ∃ c ∈ Ioo a b, is_local_extr f c :=
+by rcases exists_global_extr_Ioo f hab hfc hfI with ⟨c, cmem, hc | hc⟩; use [c, cmem]; [left,right];
+  exact mem_nhds_iff_exists_Ioo_subset.2 ⟨a, b, cmem, λ x hx, hc _ ⟨le_of_lt hx.1, le_of_lt hx.2⟩⟩
+
+variable (hff' : ∀ x ∈ Ioo a b, has_deriv_at f (f' x) x)
+
+include hff'
+
+/-- Rolle's Theorem `has_deriv_at` version -/
+lemma exists_has_deriv_at_eq_zero :
+  ∃ c ∈ Ioo a b, f' c = 0 :=
+let ⟨c, cmem, hc⟩ := exists_local_extr_Ioo f hab hfc hfI in
+  ⟨c, cmem, hc.has_deriv_at_eq_zero $ hff' c cmem⟩
+
+omit hfI
+
+/-- Cauchy version of the Mean Value Theorem -/
+lemma exists_ratio_has_deriv_at_eq_ratio_slope
+  (g g' : ℝ → ℝ) (hgc : continuous g) (hgg' : ∀ x ∈ Ioo a b, has_deriv_at g (g' x) x) :
+  ∃ c ∈ Ioo a b, (g b - g a) * f' c = (f b - f a) * g' c :=
+begin
+  let h := λ x, (g b - g a) * f x - (f b - f a) * g x,
+  have hI : h a = h b,
+  { simp only [h], ring },
+  let h' := λ x, (g b - g a) * f' x - (f b - f a) * g' x,
+  have hhh' : ∀ x ∈ Ioo a b, has_deriv_at h (h' x) x,
+  { assume x hx,
+    convert ((has_deriv_at_const x (g b - g a)).mul (hff' x hx)).sub
+      ((has_deriv_at_const x (f b - f a)).mul (hgg' x hx)),
+    simp only [h', mul_zero, add_zero] },
+  have hhc : continuous h,
+    from (continuous_const.mul hfc).sub (continuous_const.mul hgc),
+  rcases exists_has_deriv_at_eq_zero h h' hab hhc hI hhh' with ⟨c, cmem, hc⟩,
+  exact ⟨c, cmem, sub_eq_zero.1 hc⟩
+end
+
+lemma exists_has_deriv_at_eq_slope : ∃ c ∈ Ioo a b, f' c = (f b - f a) / (b - a) :=
+begin
+  rcases exists_ratio_has_deriv_at_eq_ratio_slope f f' hab hfc hff' id 1 continuous_id (λ x hx, has_deriv_at_id x) with ⟨c, cmem, hc⟩,
+  use [c, cmem],
+  simp only [id, pi.one_apply, mul_one] at hc,
+  rw [← hc, mul_div_cancel_left],
+  exact ne_of_gt (sub_pos.2 hab)
+end
+
+omit hff'
+
+lemma exists_deriv_eq_zero : ∃ c ∈ Ioo a b, deriv f c = 0 :=
+let ⟨c, cmem, hc⟩ := exists_local_extr_Ioo f hab hfc hfI in
+  ⟨c, cmem, hc.deriv_eq_zero⟩
+
+lemma exists_ratio_deriv_eq_ratio_slope (hfd : ∀ x ∈ Ioo a b, differentiable_at ℝ f x)
+  (g : ℝ → ℝ) (hgc : continuous g) (hgd : ∀ x ∈ Ioo a b, differentiable_at ℝ g x):
+  ∃ c ∈ Ioo a b, (g b - g a) * (deriv f c) = (f b - f a) * (deriv g c) :=
+exists_ratio_has_deriv_at_eq_ratio_slope f (deriv f) hab hfc
+  (λ x hx, (hfd x hx).has_deriv_at) g (deriv g) hgc (λ x hx, (hgd x hx).has_deriv_at)
+
+lemma exists_deriv_eq_slope (hfd : ∀ x ∈ Ioo a b, differentiable_at ℝ f x) :
+  ∃ c ∈ Ioo a b, deriv f c = (f b - f a) / (b - a) :=
+exists_has_deriv_at_eq_slope f (deriv f) hab hfc (λ x hx, (hfd x hx).has_deriv_at)
+
+end MVT

--- a/src/analysis/calculus/local_extr.lean
+++ b/src/analysis/calculus/local_extr.lean
@@ -22,7 +22,7 @@ First we prove that `0 ≤ f' y` whenever `a` is a local maximum of `f` on `s`,
 `f` has derivative `f'` at `a` within `s`, and `y` belongs to the positive tangent cone
 of `s` at `a`. Hence if both `y` and `-y` belong to the positive tangent cone, then `f' y = 0`.
 These facts are used to prove
-[Fermat's Theorem](https://en.wikipedia.org/wiki/Fermat's_theorem_(stationary_points):
+[Fermat's Theorem](https://en.wikipedia.org/wiki/Fermat's_theorem_(stationary_points)):
 the derivative of a differentiable function at a local extremum point equals zero.
 
 Then we use Fermat's Theorem to prove
@@ -38,6 +38,16 @@ For each mathematical fact we prove several versions of its formalization:
 
 For the `fderiv*`/`deriv*` versions we omit the differentiability condition whenever it is possible
 due to the fact that `fderiv` and `deriv` are defined to be zero for non-differentiable functions.
+
+## References
+
+* [Fermat's Theorem](https://en.wikipedia.org/wiki/Fermat's_theorem_(stationary_points));
+* [Rolle's Theorem](https://en.wikipedia.org/wiki/Rolle's_theorem);
+* [Tangent cone](https://en.wikipedia.org/wiki/Tangent_cone);
+
+## Tags
+
+local extremum, Fermat's Theorem, Rolle's Theorem
 -/
 
 universes u v

--- a/src/analysis/calculus/local_extr.lean
+++ b/src/analysis/calculus/local_extr.lean
@@ -10,7 +10,7 @@ import topology.local_extr analysis.calculus.deriv
 
 ## Main definitions
 
-In a real normed space `E` We define `pos_tangent_cone_at (s : set E) (x : E)`.
+In a real normed space `E` we define `pos_tangent_cone_at (s : set E) (x : E)`.
 This would be the same as `tangent_cone_at ℝ≥0 s x` if we had a theory of normed semifields.
 This set is used in the proof of Fermat's Theorem (see below), and can be used to formalize
 [Lagrange multipliers](https://en.wikipedia.org/wiki/Lagrange_multiplier) and/or

--- a/src/analysis/calculus/local_extr.lean
+++ b/src/analysis/calculus/local_extr.lean
@@ -30,7 +30,7 @@ section vector_space
 variables {E : Type u} [normed_group E] [normed_space ℝ E] {f : E → ℝ} {a : E}
   {f' : E →L[ℝ] ℝ}
 
-/-- "Positive" tangent cone to `s` at `x`; the definition differs fron `tangent_cone_at`
+/-- "Positive" tangent cone to `s` at `x`; the definition differs from `tangent_cone_at`
 by the requirement. One can think about `pos_tangent_cone_at` as `tangent_cone_at nnreal`
 but we have no theory of normed semifields yet. -/
 def pos_tangent_cone_at (s : set E) (x : E) : set E :=

--- a/src/analysis/calculus/local_extr.lean
+++ b/src/analysis/calculus/local_extr.lean
@@ -74,7 +74,7 @@ begin
   exact mem_pos_tangent_cone_at_of_segment_subset (subset_univ _)
 end
 
-lemma is_local_max_on.has_fderiv_within_at_nonpos {s : set E} (h : is_local_max_on f a s)
+lemma is_local_max_on.has_fderiv_within_at_nonpos {s : set E} (h : is_local_max_on f s a)
   (hf : has_fderiv_within_at f f' s a) {y} (hy : y ∈ pos_tangent_cone_at s a) :
   f' y ≤ 0 :=
 begin
@@ -95,49 +95,49 @@ begin
   exact mul_nonpos_of_nonneg_of_nonpos hn (sub_nonpos.2 hnf)
 end
 
-lemma is_local_max_on.fderiv_within_nonpos {s : set E} (h : is_local_max_on f a s)
+lemma is_local_max_on.fderiv_within_nonpos {s : set E} (h : is_local_max_on f s a)
   (hf : differentiable_within_at ℝ f s a) {y} (hy : y ∈ pos_tangent_cone_at s a) :
   (fderiv_within ℝ f s a : E → ℝ) y ≤ 0 :=
 h.has_fderiv_within_at_nonpos hf.has_fderiv_within_at hy
 
-lemma is_local_max_on.has_fderiv_within_at_eq_zero {s : set E} (h : is_local_max_on f a s)
+lemma is_local_max_on.has_fderiv_within_at_eq_zero {s : set E} (h : is_local_max_on f s a)
   (hf : has_fderiv_within_at f f' s a) {y} (hy : y ∈ pos_tangent_cone_at s a)
   (hy' : -y ∈ pos_tangent_cone_at s a) :
   f' y = 0 :=
 le_antisymm (h.has_fderiv_within_at_nonpos hf hy) $
   by simpa using h.has_fderiv_within_at_nonpos hf hy'
 
-lemma is_local_max_on.fderiv_within_eq_zero {s : set E} (h : is_local_max_on f a s)
+lemma is_local_max_on.fderiv_within_eq_zero {s : set E} (h : is_local_max_on f s a)
   {y} (hy : y ∈ pos_tangent_cone_at s a) (hy' : -y ∈ pos_tangent_cone_at s a) :
   (fderiv_within ℝ f s a : E → ℝ) y = 0 :=
 if hf : differentiable_within_at ℝ f s a
 then h.has_fderiv_within_at_eq_zero hf.has_fderiv_within_at hy hy'
 else by { rw fderiv_within_zero_of_not_differentiable_within_at hf, refl }
 
-lemma is_local_min_on.has_fderiv_within_at_nonneg {s : set E} (h : is_local_min_on f a s)
+lemma is_local_min_on.has_fderiv_within_at_nonneg {s : set E} (h : is_local_min_on f s a)
   (hf : has_fderiv_within_at f f' s a) {y} (hy : y ∈ pos_tangent_cone_at s a) :
   0 ≤ f' y :=
 by simpa using h.neg.has_fderiv_within_at_nonpos hf.neg hy
 
-lemma is_local_min_on.fderiv_within_nonneg {s : set E} (h : is_local_min_on f a s)
+lemma is_local_min_on.fderiv_within_nonneg {s : set E} (h : is_local_min_on f s a)
   (hf : differentiable_within_at ℝ f s a) {y} (hy : y ∈ pos_tangent_cone_at s a) :
   (0:ℝ) ≤ (fderiv_within ℝ f s a : E → ℝ) y :=
 h.has_fderiv_within_at_nonneg hf.has_fderiv_within_at hy
 
-lemma is_local_min_on.has_fderiv_within_at_eq_zero {s : set E} (h : is_local_min_on f a s)
+lemma is_local_min_on.has_fderiv_within_at_eq_zero {s : set E} (h : is_local_min_on f s a)
   (hf : has_fderiv_within_at f f' s a) {y} (hy : y ∈ pos_tangent_cone_at s a)
   (hy' : -y ∈ pos_tangent_cone_at s a) :
   f' y = 0 :=
 by simpa using h.neg.has_fderiv_within_at_eq_zero hf.neg hy hy'
 
-lemma is_local_min_on.fderiv_within_eq_zero {s : set E} (h : is_local_min_on f a s)
+lemma is_local_min_on.fderiv_within_eq_zero {s : set E} (h : is_local_min_on f s a)
   {y} (hy : y ∈ pos_tangent_cone_at s a) (hy' : -y ∈ pos_tangent_cone_at s a) :
   (fderiv_within ℝ f s a : E → ℝ) y = 0 :=
 if hf : differentiable_within_at ℝ f s a
 then h.has_fderiv_within_at_eq_zero hf.has_fderiv_within_at hy hy'
 else by { rw fderiv_within_zero_of_not_differentiable_within_at hf, refl }
 
-/-- The derivative at a local minimum equals zero. -/
+/-- Fermat's Theorem: the derivative of a function at a local minimum equals zero. -/
 lemma is_local_min.has_fderiv_at_eq_zero (h : is_local_min f a) (hf : has_fderiv_at f f' a) :
   f' = 0 :=
 begin
@@ -146,19 +146,22 @@ begin
     rw pos_tangent_cone_at_univ; apply mem_univ
 end
 
-/-- The derivative at a local minimum equals zero. -/
+/-- Fermat's Theorem: the derivative of a function at a local minimum equals zero. -/
 lemma is_local_min.fderiv_eq_zero (h : is_local_min f a) : fderiv ℝ f a = 0 :=
 if hf : differentiable_at ℝ f a then h.has_fderiv_at_eq_zero hf.has_fderiv_at
 else fderiv_zero_of_not_differentiable_at hf
 
+/-- Fermat's Theorem: the derivative of a function at a local maximum equals zero. -/
 lemma is_local_max.has_fderiv_at_eq_zero (h : is_local_max f a) (hf : has_fderiv_at f f' a) :
   f' = 0 :=
 neg_eq_zero.1 $ h.neg.has_fderiv_at_eq_zero hf.neg
 
+/-- Fermat's Theorem: the derivative of a function at a local maximum equals zero. -/
 lemma is_local_max.fderiv_eq_zero (h : is_local_max f a) : fderiv ℝ f a = 0 :=
 if hf : differentiable_at ℝ f a then h.has_fderiv_at_eq_zero hf.has_fderiv_at
 else fderiv_zero_of_not_differentiable_at hf
 
+/-- Fermat's Theorem: the derivative of a function at a local extremum equals zero. -/
 lemma is_local_extr.has_fderiv_at_eq_zero (h : is_local_extr f a) :
   has_fderiv_at f f' a → f' = 0 :=
 h.elim is_local_min.has_fderiv_at_eq_zero is_local_max.has_fderiv_at_eq_zero
@@ -198,21 +201,20 @@ h.elim is_local_min.deriv_eq_zero is_local_max.deriv_eq_zero
 
 end real
 
-section MVT
+section Rolle
 
-variables (f f' : ℝ → ℝ) {a b : ℝ} (hab : a < b) (hfc : continuous f) (hfI : f a = f b)
+variables (f f' : ℝ → ℝ) {a b : ℝ} (hab : a < b) (hfc : continuous_on f (Icc a b)) (hfI : f a = f b)
 
 include hab hfc hfI
 
-lemma exists_global_extr_Ioo :
-  ∃ c ∈ Ioo a b, (∀ x ∈ Icc a b, f c ≤ f x) ∨ (∀ x ∈ Icc a b, f x ≤ f c) :=
+lemma exists_Ioo_extr_on_Icc : ∃ c ∈ Ioo a b, is_extr_on f (Icc a b) c :=
 begin
   have ne : Icc a b ≠ ∅, from ne_empty_of_mem (left_mem_Icc.2 (le_of_lt hab)),
   -- Consider absolute min and max points
   obtain ⟨c, cmem, cle⟩ : ∃ c ∈ Icc a b, ∀ x ∈ Icc a b, f c ≤ f x,
-    from compact_Icc.exists_forall_le ne f hfc.continuous_on,
+    from compact_Icc.exists_forall_le ne hfc,
   obtain ⟨C, Cmem, Cge⟩ : ∃ C ∈ Icc a b, ∀ x ∈ Icc a b, f x ≤ f C,
-    from compact_Icc.exists_forall_ge ne f hfc.continuous_on,
+    from compact_Icc.exists_forall_ge ne hfc,
   by_cases hc : f c = f a,
   { by_cases hC : f C = f a,
     { have : ∀ x ∈ Icc a b, f x = f a,
@@ -221,9 +223,8 @@ begin
       rcases dense hab with ⟨c', hc'⟩,
       refine ⟨c', hc', or.inl _⟩,
       assume x hx,
-      rw [this x hx, ← hC],
+      rw [mem_set_of_eq, this x hx, ← hC],
       exact Cge c' ⟨le_of_lt hc'.1, le_of_lt hc'.2⟩ },
-
     { refine ⟨C, ⟨lt_of_le_of_ne Cmem.1 $ mt _ hC, lt_of_le_of_ne Cmem.2 $ mt _ hC⟩, or.inr Cge⟩,
       exacts [λ h, by rw h, λ h, by rw [h, hfI]] } },
   { refine ⟨c, ⟨lt_of_le_of_ne cmem.1 $ mt _ hc, lt_of_le_of_ne cmem.2 $ mt _ hc⟩, or.inl cle⟩,
@@ -231,64 +232,18 @@ begin
 end
 
 lemma exists_local_extr_Ioo : ∃ c ∈ Ioo a b, is_local_extr f c :=
-by rcases exists_global_extr_Ioo f hab hfc hfI with ⟨c, cmem, hc | hc⟩; use [c, cmem]; [left,right];
-  exact mem_nhds_iff_exists_Ioo_subset.2 ⟨a, b, cmem, λ x hx, hc _ ⟨le_of_lt hx.1, le_of_lt hx.2⟩⟩
-
-variable (hff' : ∀ x ∈ Ioo a b, has_deriv_at f (f' x) x)
-
-include hff'
+let ⟨c, cmem, hc⟩ := exists_Ioo_extr_on_Icc f hab hfc hfI
+in ⟨c, cmem, hc.is_local_extr $ mem_nhds_sets_iff.2 ⟨Ioo a b, Ioo_subset_Icc_self, is_open_Ioo, cmem⟩⟩
 
 /-- Rolle's Theorem `has_deriv_at` version -/
-lemma exists_has_deriv_at_eq_zero :
+lemma exists_has_deriv_at_eq_zero (hff' : ∀ x ∈ Ioo a b, has_deriv_at f (f' x) x) :
   ∃ c ∈ Ioo a b, f' c = 0 :=
 let ⟨c, cmem, hc⟩ := exists_local_extr_Ioo f hab hfc hfI in
   ⟨c, cmem, hc.has_deriv_at_eq_zero $ hff' c cmem⟩
 
-omit hfI
-
-/-- Cauchy version of the Mean Value Theorem -/
-lemma exists_ratio_has_deriv_at_eq_ratio_slope
-  (g g' : ℝ → ℝ) (hgc : continuous g) (hgg' : ∀ x ∈ Ioo a b, has_deriv_at g (g' x) x) :
-  ∃ c ∈ Ioo a b, (g b - g a) * f' c = (f b - f a) * g' c :=
-begin
-  let h := λ x, (g b - g a) * f x - (f b - f a) * g x,
-  have hI : h a = h b,
-  { simp only [h], ring },
-  let h' := λ x, (g b - g a) * f' x - (f b - f a) * g' x,
-  have hhh' : ∀ x ∈ Ioo a b, has_deriv_at h (h' x) x,
-  { assume x hx,
-    convert ((has_deriv_at_const x (g b - g a)).mul (hff' x hx)).sub
-      ((has_deriv_at_const x (f b - f a)).mul (hgg' x hx)),
-    simp only [h', mul_zero, add_zero] },
-  have hhc : continuous h,
-    from (continuous_const.mul hfc).sub (continuous_const.mul hgc),
-  rcases exists_has_deriv_at_eq_zero h h' hab hhc hI hhh' with ⟨c, cmem, hc⟩,
-  exact ⟨c, cmem, sub_eq_zero.1 hc⟩
-end
-
-lemma exists_has_deriv_at_eq_slope : ∃ c ∈ Ioo a b, f' c = (f b - f a) / (b - a) :=
-begin
-  rcases exists_ratio_has_deriv_at_eq_ratio_slope f f' hab hfc hff' id 1 continuous_id (λ x hx, has_deriv_at_id x) with ⟨c, cmem, hc⟩,
-  use [c, cmem],
-  simp only [id, pi.one_apply, mul_one] at hc,
-  rw [← hc, mul_div_cancel_left],
-  exact ne_of_gt (sub_pos.2 hab)
-end
-
-omit hff'
-
+/-- Rolle's Theorem `deriv` version -/
 lemma exists_deriv_eq_zero : ∃ c ∈ Ioo a b, deriv f c = 0 :=
 let ⟨c, cmem, hc⟩ := exists_local_extr_Ioo f hab hfc hfI in
   ⟨c, cmem, hc.deriv_eq_zero⟩
 
-lemma exists_ratio_deriv_eq_ratio_slope (hfd : ∀ x ∈ Ioo a b, differentiable_at ℝ f x)
-  (g : ℝ → ℝ) (hgc : continuous g) (hgd : ∀ x ∈ Ioo a b, differentiable_at ℝ g x):
-  ∃ c ∈ Ioo a b, (g b - g a) * (deriv f c) = (f b - f a) * (deriv g c) :=
-exists_ratio_has_deriv_at_eq_ratio_slope f (deriv f) hab hfc
-  (λ x hx, (hfd x hx).has_deriv_at) g (deriv g) hgc (λ x hx, (hgd x hx).has_deriv_at)
-
-lemma exists_deriv_eq_slope (hfd : ∀ x ∈ Ioo a b, differentiable_at ℝ f x) :
-  ∃ c ∈ Ioo a b, deriv f c = (f b - f a) / (b - a) :=
-exists_has_deriv_at_eq_slope f (deriv f) hab hfc (λ x hx, (hfd x hx).has_deriv_at)
-
-end MVT
+end Rolle

--- a/src/analysis/calculus/local_extr.lean
+++ b/src/analysis/calculus/local_extr.lean
@@ -8,16 +8,34 @@ import topology.local_extr analysis.calculus.deriv
 
 /-! # Local extrema of smooth functions
 
+## Main definitions
+
+In a real normed space `E` We define `pos_tangent_cone_at (s : set E) (x : E)`.
+This would be the same as `tangent_cone_at ℝ≥0 s x` if we had a theory of normed semifields.
+This set is used in the proof of Fermat's Theorem (see below), and can be used to formalize
+[Lagrange multipliers](https://en.wikipedia.org/wiki/Lagrange_multiplier) and/or
+[Karush–Kuhn–Tucker conditions](https://en.wikipedia.org/wiki/Karush–Kuhn–Tucker_conditions).
+
 ## Main statements
 
-Rolle's Theorem, Lagrange's and Cauchy's Mean Value Theorems.
+First we prove that `0 ≤ f' y` whenever `a` is a local maximum of `f` on `s`,
+`f` has derivative `f'` at `a` within `s`, and `y` belongs to the positive tangent cone
+of `s` at `a`. Hence if both `y` and `-y` belong to the positive tangent cone, then `f' y = 0`.
+These facts are used to prove Fermat's Theorem: the derivative of a differentiable function
+at a local extremum point equals zero.
 
-TODO:
+Then we use Fermat's Theorem to prove Rolle's Theorem: given a function `f` continuous on `[a, b]`
+and differentiable on `(a, b)`, there exists `c ∈ (a, b)` such that `f' c = 0`.
 
-* if `deriv f` is positive on an interval, then `f` is strictly increasing;
-* similarly for negative/nonpositive/nonnegative;
-* in particular, if `∀ x, deriv f x = 0`, then `f = const`.
-* possibly move some lemmas to other file(s)
+## Implementation notes
+
+For each mathematical fact we prove several versions of its formalization:
+
+* for maximums and minimums;
+* using `has_fderiv*`/`has_deriv*` or `fderiv*`/`deriv*`.
+
+For the `fderiv*`/`deriv*` versions we omit the differentiability condition whenever it is possible
+due to the fact that `fderiv` and `deriv` are defined to be zero for non-differentiable functions.
 -/
 
 universes u v
@@ -74,6 +92,8 @@ begin
   exact mem_pos_tangent_cone_at_of_segment_subset (subset_univ _)
 end
 
+/-- If `f` has a local max on `s` at `a`, `f'` is the derivative of `f` at `a` within `s`, and
+`y` belongs to the positive tangent cone of s at a, then `f' y ≤ 0`. -/
 lemma is_local_max_on.has_fderiv_within_at_nonpos {s : set E} (h : is_local_max_on f s a)
   (hf : has_fderiv_within_at f f' s a) {y} (hy : y ∈ pos_tangent_cone_at s a) :
   f' y ≤ 0 :=
@@ -94,11 +114,15 @@ begin
   exact mul_nonpos_of_nonneg_of_nonpos hn (sub_nonpos.2 hnf)
 end
 
+/-- If `f` has a local max on `s` at `a`, `f` is differentiable at `a` within `s`, and
+`y` belongs to the positive tangent cone of s at a, then `f' y ≤ 0`. -/
 lemma is_local_max_on.fderiv_within_nonpos {s : set E} (h : is_local_max_on f s a)
   (hf : differentiable_within_at ℝ f s a) {y} (hy : y ∈ pos_tangent_cone_at s a) :
   (fderiv_within ℝ f s a : E → ℝ) y ≤ 0 :=
 h.has_fderiv_within_at_nonpos hf.has_fderiv_within_at hy
 
+/-- If `f` has a local max on `s` at `a`, `f'` is a derivative of `f` at `a` within `s`, and
+both `y` and `-y` belong to the positive tangent cone of s at a, then `f' y ≤ 0`. -/
 lemma is_local_max_on.has_fderiv_within_at_eq_zero {s : set E} (h : is_local_max_on f s a)
   (hf : has_fderiv_within_at f f' s a) {y} (hy : y ∈ pos_tangent_cone_at s a)
   (hy' : -y ∈ pos_tangent_cone_at s a) :
@@ -106,6 +130,8 @@ lemma is_local_max_on.has_fderiv_within_at_eq_zero {s : set E} (h : is_local_max
 le_antisymm (h.has_fderiv_within_at_nonpos hf hy) $
   by simpa using h.has_fderiv_within_at_nonpos hf hy'
 
+/-- If `f` has a local max on `s` at `a` and both `y` and `-y` belong to the positive tangent cone
+of s at a, then `f' y = 0`. -/
 lemma is_local_max_on.fderiv_within_eq_zero {s : set E} (h : is_local_max_on f s a)
   {y} (hy : y ∈ pos_tangent_cone_at s a) (hy' : -y ∈ pos_tangent_cone_at s a) :
   (fderiv_within ℝ f s a : E → ℝ) y = 0 :=
@@ -113,22 +139,30 @@ if hf : differentiable_within_at ℝ f s a
 then h.has_fderiv_within_at_eq_zero hf.has_fderiv_within_at hy hy'
 else by { rw fderiv_within_zero_of_not_differentiable_within_at hf, refl }
 
+/-- If `f` has a local min on `s` at `a`, `f'` is the derivative of `f` at `a` within `s`, and
+`y` belongs to the positive tangent cone of s at a, then `0 ≤ f' y`. -/
 lemma is_local_min_on.has_fderiv_within_at_nonneg {s : set E} (h : is_local_min_on f s a)
   (hf : has_fderiv_within_at f f' s a) {y} (hy : y ∈ pos_tangent_cone_at s a) :
   0 ≤ f' y :=
 by simpa using h.neg.has_fderiv_within_at_nonpos hf.neg hy
 
+/-- If `f` has a local min on `s` at `a`, `f` is differentiable at `a` within `s`, and
+`y` belongs to the positive tangent cone of s at a, then `0 ≤ f' y`. -/
 lemma is_local_min_on.fderiv_within_nonneg {s : set E} (h : is_local_min_on f s a)
   (hf : differentiable_within_at ℝ f s a) {y} (hy : y ∈ pos_tangent_cone_at s a) :
   (0:ℝ) ≤ (fderiv_within ℝ f s a : E → ℝ) y :=
 h.has_fderiv_within_at_nonneg hf.has_fderiv_within_at hy
 
+/-- If `f` has a local max on `s` at `a`, `f'` is a derivative of `f` at `a` within `s`, and
+both `y` and `-y` belong to the positive tangent cone of s at a, then `f' y ≤ 0`. -/
 lemma is_local_min_on.has_fderiv_within_at_eq_zero {s : set E} (h : is_local_min_on f s a)
   (hf : has_fderiv_within_at f f' s a) {y} (hy : y ∈ pos_tangent_cone_at s a)
   (hy' : -y ∈ pos_tangent_cone_at s a) :
   f' y = 0 :=
 by simpa using h.neg.has_fderiv_within_at_eq_zero hf.neg hy hy'
 
+/-- If `f` has a local min on `s` at `a` and both `y` and `-y` belong to the positive tangent cone
+of s at a, then `f' y = 0`. -/
 lemma is_local_min_on.fderiv_within_eq_zero {s : set E} (h : is_local_min_on f s a)
   {y} (hy : y ∈ pos_tangent_cone_at s a) (hy' : -y ∈ pos_tangent_cone_at s a) :
   (fderiv_within ℝ f s a : E → ℝ) y = 0 :=

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -193,6 +193,8 @@ begin
   exact ne_of_gt (sub_pos.2 hab)
 end
 
+omit hff'
+
 lemma exists_ratio_deriv_eq_ratio_slope :
   ∃ c ∈ Ioo a b, (g b - g a) * (deriv f c) = (f b - f a) * (deriv g c) :=
 exists_ratio_has_deriv_at_eq_ratio_slope f (deriv f) hab hfc

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Sébastien Gouëzel
+Authors: Sébastien Gouëzel, Yury Kudryashov
 -/
 
 import analysis.calculus.local_extr
@@ -9,9 +9,19 @@ import analysis.calculus.local_extr
 /-!
 # The mean value inequality and equalities
 
-A bound on the derivative of a function implies that this function
-is Lipschitz continuous for the same bound, on a segment or more generally in a convex set.
-This is proved in `norm_image_sub_le_of_norm_deriv_le_convex`.
+In this file we prove the following facts:
+
+* `convex.norm_image_sub_le_of_norm_deriv_le` : if `f` is differentaible on a convex set `s`
+  and the norm of its derivative is bounded by `C`, then `f` is Lipschitz continuous on `s` with
+  constant `C`.
+
+* `convex.is_const_of_fderiv_within_eq_zero` : if a function has derivative `0` on a convex set `s`,
+  then it is a constant on `s`.
+
+* `exists_ratio_has_deriv_at_eq_ratio_slope` and `exists_ratio_deriv_eq_ratio_slope` :
+  Cauchy's Mean Value Theorem.
+
+* `exists_has_deriv_at_eq_slope` and `exists_deriv_eq_slope` : Lagrange's Mean Value Theorem.
 -/
 
 set_option class.instance_max_depth 120
@@ -99,7 +109,7 @@ end
 
 /-- The mean value theorem on a convex set: if the derivative of a function is bounded by C, then
 the function is C-Lipschitz -/
-theorem norm_image_sub_le_of_norm_deriv_le_convex {f : E → F} {C : ℝ} {s : set E} {x y : E}
+theorem convex.norm_image_sub_le_of_norm_deriv_le {f : E → F} {C : ℝ} {s : set E} {x y : E}
   (hf : differentiable_on ℝ f s) (bound : ∀x∈s, ∥fderiv_within ℝ f s x∥ ≤ C)
   (hs : convex s) (xs : x ∈ s) (ys : y ∈ s) : ∥f y - f x∥ ≤ C * ∥y - x∥ :=
 begin
@@ -150,7 +160,7 @@ theorem convex.is_const_of_fderiv_within_eq_zero {s : set E} (hs : convex s)
 have bound : ∀ x ∈ s, ∥fderiv_within ℝ f s x∥ ≤ 0,
   from λ x hx, by simp only [hf' x hx, _root_.norm_zero],
 by simpa only [(dist_eq_norm _ _).symm, zero_mul, dist_le_zero, eq_comm]
-  using norm_image_sub_le_of_norm_deriv_le_convex hf bound hs hx hy
+  using hs.norm_image_sub_le_of_norm_deriv_le hf bound hx hy
 
 /-! ### Functions `[a, b] → ℝ`. -/
 
@@ -164,7 +174,7 @@ variables (f f' : ℝ → ℝ) {a b : ℝ} (hab : a < b) (hfc : continuous_on f 
 
 include hab hfc hff' hgc hgg'
 
-/-- Cauchy version of the Mean Value Theorem -/
+/-- Cauchy's Mean Value Theorem, `has_deriv_at` version. -/
 lemma exists_ratio_has_deriv_at_eq_ratio_slope :
   ∃ c ∈ Ioo a b, (g b - g a) * f' c = (f b - f a) * g' c :=
 begin
@@ -185,7 +195,7 @@ end
 
 omit hgc hgg'
 
-/-- Mean Value Theorem, `has_deriv_at` version -/
+/-- Lagrange's Mean Value Theorem, `has_deriv_at` version -/
 lemma exists_has_deriv_at_eq_slope : ∃ c ∈ Ioo a b, f' c = (f b - f a) / (b - a) :=
 begin
   rcases exists_ratio_has_deriv_at_eq_ratio_slope f f' hab hfc hff'
@@ -198,12 +208,14 @@ end
 
 omit hff'
 
+/-- Cauchy's Mean Value Theorem, `deriv` version. -/
 lemma exists_ratio_deriv_eq_ratio_slope :
   ∃ c ∈ Ioo a b, (g b - g a) * (deriv f c) = (f b - f a) * (deriv g c) :=
 exists_ratio_has_deriv_at_eq_ratio_slope f (deriv f) hab hfc
   (λ x hx, ((hfd x hx).differentiable_at $ mem_nhds_sets is_open_Ioo hx).has_deriv_at)
   g (deriv g) hgc (λ x hx, ((hgd x hx).differentiable_at $ mem_nhds_sets is_open_Ioo hx).has_deriv_at)
 
+/-- Lagrange's Mean Value Theorem, `deriv` version. -/
 lemma exists_deriv_eq_slope : ∃ c ∈ Ioo a b, deriv f c = (f b - f a) / (b - a) :=
 exists_has_deriv_at_eq_slope f (deriv f) hab hfc
   (λ x hx, ((hfd x hx).differentiable_at $ mem_nhds_sets is_open_Ioo hx).has_deriv_at)

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -4,10 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
 
-import analysis.calculus.deriv
+import analysis.calculus.local_extr
 
 /-!
-# The mean value inequality
+# The mean value inequality and equalities
 
 A bound on the derivative of a function implies that this function
 is Lipschitz continuous for the same bound, on a segment or more generally in a convex set.
@@ -20,6 +20,8 @@ variables {E : Type*} [normed_group E] [normed_space ℝ E]
           {F : Type*} [normed_group F] [normed_space ℝ F]
 
 open metric set lattice asymptotics continuous_linear_map
+
+/-! ### Vector-valued functions -/
 
 /-- The mean value theorem along a segment: a bound on the derivative of a function along a segment
 implies a bound on the distance of the endpoints images -/
@@ -138,3 +140,65 @@ begin
       by rw [deriv_const, smul_zero, zero_add, deriv_id, one_smul],
   rw [this]
 end
+
+theorem convex.is_const_of_fderiv_within_eq_zero {s : set E} (hs : convex s)
+  {f : E → F} (hf : differentiable_on ℝ f s) (hf' : ∀ x ∈ s, fderiv_within ℝ f s x = 0)
+  {x y : E} (hx : x ∈ s) (hy : y ∈ s) :
+  f x = f y :=
+have bound : ∀ x ∈ s, ∥fderiv_within ℝ f s x∥ ≤ 0,
+  from λ x hx, by simp only [hf' x hx, _root_.norm_zero],
+by simpa only [(dist_eq_norm _ _).symm, zero_mul, dist_le_zero, eq_comm]
+  using norm_image_sub_le_of_norm_deriv_le_convex hf bound hs hx hy
+
+/-! ### `ℝ`-valued functions. -/
+
+section interval
+
+-- Declare all variables here to make sure they come in a correct order
+variables (f f' : ℝ → ℝ) {a b : ℝ} (hab : a < b) (hfc : continuous_on f (Icc a b))
+  (hff' : ∀ x ∈ Ioo a b, has_deriv_at f (f' x) x) (hfd : ∀ x ∈ Ioo a b, differentiable_at ℝ f x)
+  (g g' : ℝ → ℝ) (hgc : continuous_on g (Icc a b)) (hgg' : ∀ x ∈ Ioo a b, has_deriv_at g (g' x) x)
+  (hgd : ∀ x ∈ Ioo a b, differentiable_at ℝ g x)
+
+include hab hfc hff' hgc hgg'
+
+/-- Cauchy version of the Mean Value Theorem -/
+lemma exists_ratio_has_deriv_at_eq_ratio_slope :
+  ∃ c ∈ Ioo a b, (g b - g a) * f' c = (f b - f a) * g' c :=
+begin
+  let h := λ x, (g b - g a) * f x - (f b - f a) * g x,
+  have hI : h a = h b,
+  { simp only [h], ring },
+  let h' := λ x, (g b - g a) * f' x - (f b - f a) * g' x,
+  have hhh' : ∀ x ∈ Ioo a b, has_deriv_at h (h' x) x,
+  { assume x hx,
+    convert ((has_deriv_at_const x (g b - g a)).mul (hff' x hx)).sub
+      ((has_deriv_at_const x (f b - f a)).mul (hgg' x hx)),
+    simp only [h', mul_zero, add_zero] },
+  have hhc : continuous_on h (Icc a b),
+    from (continuous_on_const.mul hfc).sub (continuous_on_const.mul hgc),
+  rcases exists_has_deriv_at_eq_zero h h' hab hhc hI hhh' with ⟨c, cmem, hc⟩,
+  exact ⟨c, cmem, sub_eq_zero.1 hc⟩
+end
+
+omit hgc hgg'
+
+lemma exists_has_deriv_at_eq_slope : ∃ c ∈ Ioo a b, f' c = (f b - f a) / (b - a) :=
+begin
+  rcases exists_ratio_has_deriv_at_eq_ratio_slope f f' hab hfc hff'
+    id 1 continuous_id.continuous_on (λ x hx, has_deriv_at_id x) with ⟨c, cmem, hc⟩,
+  use [c, cmem],
+  simp only [_root_.id, pi.one_apply, mul_one] at hc,
+  rw [← hc, mul_div_cancel_left],
+  exact ne_of_gt (sub_pos.2 hab)
+end
+
+lemma exists_ratio_deriv_eq_ratio_slope :
+  ∃ c ∈ Ioo a b, (g b - g a) * (deriv f c) = (f b - f a) * (deriv g c) :=
+exists_ratio_has_deriv_at_eq_ratio_slope f (deriv f) hab hfc
+  (λ x hx, (hfd x hx).has_deriv_at) g (deriv g) hgc (λ x hx, (hgd x hx).has_deriv_at)
+
+lemma exists_deriv_eq_slope : ∃ c ∈ Ioo a b, deriv f c = (f b - f a) / (b - a) :=
+exists_has_deriv_at_eq_slope f (deriv f) hab hfc (λ x hx, (hfd x hx).has_deriv_at)
+
+end interval

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -201,9 +201,11 @@ omit hff'
 lemma exists_ratio_deriv_eq_ratio_slope :
   ∃ c ∈ Ioo a b, (g b - g a) * (deriv f c) = (f b - f a) * (deriv g c) :=
 exists_ratio_has_deriv_at_eq_ratio_slope f (deriv f) hab hfc
-  (λ x hx, (hfd x hx).has_deriv_at) g (deriv g) hgc (λ x hx, (hgd x hx).has_deriv_at)
+  (λ x hx, ((hfd x hx).differentiable_at $ mem_nhds_sets is_open_Ioo hx).has_deriv_at)
+  g (deriv g) hgc (λ x hx, ((hgd x hx).differentiable_at $ mem_nhds_sets is_open_Ioo hx).has_deriv_at)
 
 lemma exists_deriv_eq_slope : ∃ c ∈ Ioo a b, deriv f c = (f b - f a) / (b - a) :=
-exists_has_deriv_at_eq_slope f (deriv f) hab hfc (λ x hx, (hfd x hx).has_deriv_at)
+exists_has_deriv_at_eq_slope f (deriv f) hab hfc
+  (λ x hx, ((hfd x hx).differentiable_at $ mem_nhds_sets is_open_Ioo hx).has_deriv_at)
 
 end interval

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -21,7 +21,7 @@ variables {E : Type*} [normed_group E] [normed_space ℝ E]
 
 open metric set lattice asymptotics continuous_linear_map
 
-/-! ### Vector-valued functions -/
+/-! ### Vector-valued functions `f : E → F` -/
 
 /-- The mean value theorem along a segment: a bound on the derivative of a function along a segment
 implies a bound on the distance of the endpoints images -/
@@ -141,6 +141,8 @@ begin
   rw [this]
 end
 
+/-- If a function has zero Fréchet derivative at every point of a convex set,
+then it is a constant on this set. -/
 theorem convex.is_const_of_fderiv_within_eq_zero {s : set E} (hs : convex s)
   {f : E → F} (hf : differentiable_on ℝ f s) (hf' : ∀ x ∈ s, fderiv_within ℝ f s x = 0)
   {x y : E} (hx : x ∈ s) (hy : y ∈ s) :
@@ -150,15 +152,15 @@ have bound : ∀ x ∈ s, ∥fderiv_within ℝ f s x∥ ≤ 0,
 by simpa only [(dist_eq_norm _ _).symm, zero_mul, dist_le_zero, eq_comm]
   using norm_image_sub_le_of_norm_deriv_le_convex hf bound hs hx hy
 
-/-! ### `ℝ`-valued functions. -/
+/-! ### Functions `[a, b] → ℝ`. -/
 
 section interval
 
 -- Declare all variables here to make sure they come in a correct order
 variables (f f' : ℝ → ℝ) {a b : ℝ} (hab : a < b) (hfc : continuous_on f (Icc a b))
-  (hff' : ∀ x ∈ Ioo a b, has_deriv_at f (f' x) x) (hfd : ∀ x ∈ Ioo a b, differentiable_at ℝ f x)
+  (hff' : ∀ x ∈ Ioo a b, has_deriv_at f (f' x) x) (hfd : differentiable_on ℝ f (Ioo a b))
   (g g' : ℝ → ℝ) (hgc : continuous_on g (Icc a b)) (hgg' : ∀ x ∈ Ioo a b, has_deriv_at g (g' x) x)
-  (hgd : ∀ x ∈ Ioo a b, differentiable_at ℝ g x)
+  (hgd : differentiable_on ℝ g (Ioo a b))
 
 include hab hfc hff' hgc hgg'
 
@@ -183,6 +185,7 @@ end
 
 omit hgc hgg'
 
+/-- Mean Value Theorem, `has_deriv_at` version -/
 lemma exists_has_deriv_at_eq_slope : ∃ c ∈ Ioo a b, f' c = (f b - f a) / (b - a) :=
 begin
   rcases exists_ratio_has_deriv_at_eq_ratio_slope f f' hab hfc hff'

--- a/src/analysis/complex/polynomial.lean
+++ b/src/analysis/complex/polynomial.lean
@@ -15,7 +15,7 @@ if hp0 : 0 < degree p
 then let ⟨r, hr0, hr⟩ := polynomial.tendsto_infinity complex.abs hp0 ((p.eval 0).abs) in
   let ⟨x, hx₁, hx₂⟩ := (proper_space.compact_ball (0:ℂ) r).exists_forall_le
     (set.ne_empty_iff_exists_mem.2 ⟨0, by simp [le_of_lt hr0]⟩)
-    (λ z, abs (p.eval z)) (continuous_abs.comp p.continuous_eval).continuous_on in
+    (continuous_abs.comp p.continuous_eval).continuous_on in
   ⟨x, λ y, if hy : y.abs ≤ r then hx₂ y $ by simpa [complex.dist_eq] using hy
     else le_trans (hx₂ _ (by simp [le_of_lt hr0])) (le_of_lt (hr y (lt_of_not_ge hy)))⟩
 else ⟨p.coeff 0, by rw [eq_C_of_degree_le_zero (le_of_not_gt hp0)]; simp⟩

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -363,7 +363,7 @@ lemma principal_mono {s t : set α} : principal s ≤ principal t ↔ s ⊆ t :=
 by simp only [le_principal_iff, iff_self, mem_principal_sets]
 
 lemma monotone_principal : monotone (principal : set α → filter α) :=
-by simp only [monotone, principal_mono]; exact assume a b h, h
+λ _ _, principal_mono.2
 
 @[simp] lemma principal_eq_iff_eq {s t : set α} : principal s = principal t ↔ s = t :=
 by simp only [le_antisymm_iff, le_principal_iff, mem_principal_sets]; refl

--- a/src/order/filter/extr.lean
+++ b/src/order/filter/extr.lean
@@ -8,6 +8,8 @@ import order.filter.basic logic.relator tactic.alias
 
 /-! # Minimum and maximum w.r.t. a filter and on a aet
 
+## Main Definitions
+
 This file defines six predicates of the form `is_A_B`, where `A` is `min`, `max`, or `extr`,
 and `B` is `filter` or `on`.
 
@@ -17,7 +19,56 @@ and `B` is `filter` or `on`.
 
 Similar predicates with `_on` suffix are particular cases for `l = principal s`.
 
-We also define various operations on these statements.
+## Main statements
+
+### Change of the filter (set) argument
+
+* `is_*_filter.filter_mono` : replace the filter with a smaller one;
+* `is_*_filter.filter_inf` : replace a filter `l` with `l ⊓ l'`;
+* `is_*_on.on_subset` : restrict to a smaller set;
+* `is_*_on.inter` : replace a set `s` wtih `s ∩ t`.
+
+### Composition
+
+* `is_*_*.comp_mono` : if `x` is an extremum for `f` and `g` is a monotone function,
+  then `x` is an extremum for `g ∘ f`;
+* `is_*_*.comp_antimono` : similarly for the case of monotonically decreasing `g`;
+* `is_*_*.bicomp_mono` : if `x` is an extremum of the same type for `f` and `g`
+  and a binary operation `op` is monotone in both arguments, then `x` is an extremum
+  of the same type for `λ x, op (f x) (g x)`.
+* `is_*_filter.comp_tendsto` : if `g x` is an extremum for `f` w.r.t. `l'` and `tendsto g l l'`,
+  then `x` is an extremum for `f ∘ g` w.r.t. `l`.
+* `is_*_on.on_preimage` : if `g x` is an extremum for `f` on `s`, then `x` is an extremum
+  for `f ∘ g` on `g ⁻¹' s`.
+
+### Algebraic operations
+
+* `is_*_*.add` : if `x` is an extremum of the same type for two functions,
+  then it is an extremum of the same type for their sum;
+* `is_*_*.neg` : if `x` is an extremum for `f`, then it is an extremum
+  of the opposite type for `-f`;
+* `is_*_*.sub` : if `x` is an a minimum for `f` and a maximum for `g`,
+  then it is a minimum for `f - g` and a maximum for `g - f`;
+* `is_*_*.max`, `is_*_*.min`, `is_*_*.sup`, `is_*_*.inf` : similarly for `is_*_*.add`
+  for pointwise `max`, `min`, `sup`, `inf`, respectively.
+
+
+### Miscelanous definitions
+
+* `is_*_*_const` : any point is both a minimum and maximum for a constant function;
+* `is_min/max_*.is_ext` : any minimum/maximum point is an extremum;
+* `is_*_*.dual`, `is_*_*.undual`: conversion between codomains `α` and `dual α`;
+
+## Missing features (TODO)
+
+* Multiplication and division;
+* `is_*_*.bicompl` : if `x` is a minimum for `f`, `y` is a minimum for `g`, and `op` is a monotone
+  binary operation, then `(x, y)` is a minimum for `uncurry' (bicompl op f g)`. From this point of view,
+  `is_*_*.bicomp` is a composition
+* It would be nice to have a tactic that specializes `comp_(anti)mono` or `bicomp_mono`
+  based on a proof of monotonicity of a given (binary) function. The tactic should maintain a `meta`
+  list of known (anti)monotone (binary) functions with their names, as well as a list of special
+  types of filters, and define the missing lemmas once one of these two lists grows.
 -/
 
 universes u v w x

--- a/src/order/filter/extr.lean
+++ b/src/order/filter/extr.lean
@@ -6,14 +6,14 @@ Authors: Yury Kudryashov
 
 import order.filter.basic logic.relator tactic.alias
 
-/-! # Minimum and maximum w.r.t. a filter and on a set
+/-! # Minimum and maximum w.r.t. a filter and on a aet
 
 This file defines six predicates of the form `is_A_B`, where `A` is `min`, `max`, or `extr`,
 and `B` is `filter` or `on`.
 
-* `is_min_filter f a l` means that `f a ≤ f x` in some `l`-neighborhood of `a`;
-* `is_max_filter f a l` means that `f x ≤ f a` in some `l`-neighborhood of `a`;
-* `is_extr_filter f a l` means `is_min_filter f a l` or `is_max_filter f a l`.
+* `is_min_filter f l a` means that `f a ≤ f x` in some `l`-neighborhood of `a`;
+* `is_max_filter f l a` means that `f x ≤ f a` in some `l`-neighborhood of `a`;
+* `is_extr_filter f l a` means `is_min_filter f l a` or `is_max_filter f l a`.
 
 Similar predicates with `_on` suffix are particular cases for `l = principal s`.
 
@@ -30,83 +30,88 @@ section preorder
 
 variables [preorder β] [preorder γ]
 
-variables (f : α → β) (a : α) (s : set α) (l : filter α)
+variables (f : α → β) (s : set α) (l : filter α) (a : α)
 
 /-! ### Definitions -/
 
-def is_min_filter (f : α → β) (a : α) (l : filter α) : Prop := {x | f a ≤ f x} ∈ l
+/-- `is_min_filter f l a` means that `f a ≤ f x` in some `l`-neighborhood of `a` -/
+def is_min_filter : Prop := {x | f a ≤ f x} ∈ l
 
-def is_max_filter (f : α → β) (a : α) (l : filter α) : Prop := {x | f x ≤ f a} ∈ l
+/-- `is_max_filter f l a` means that `f x ≤ f a` in some `l`-neighborhood of `a` -/
+def is_max_filter : Prop := {x | f x ≤ f a} ∈ l
 
-def is_extr_filter (f : α → β) (a : α) (l : filter α) : Prop :=
-is_min_filter f a l ∨ is_max_filter f a l
+/-- `is_extr_filter f l a` means `is_min_filter f l a` or `is_max_filter f l a` -/
+def is_extr_filter : Prop := is_min_filter f l a ∨ is_max_filter f l a
 
-def is_min_on := is_min_filter f a (principal s)
+/-- `is_min_on f s a` means that `f a ≤ f x` for all `x ∈ a`. Note that we do not assume `a ∈ s`. -/
+def is_min_on := is_min_filter f (principal s) a
 
-def is_max_on := is_max_filter f a (principal s)
+/-- `is_max_on f s a` means that `f x ≤ f a` for all `x ∈ a`. Note that we do not assume `a ∈ s`. -/
+def is_max_on := is_max_filter f (principal s) a
 
-def is_extr_on : Prop := is_extr_filter f a (principal s)
+/-- `is_extr_on f s a` means `is_min_on f s a` or `is_max_on f s a` -/
+def is_extr_on : Prop := is_extr_filter f (principal s) a
 
-variables {f a s l} {t : set α} {l' : filter α}
+variables {f s a l} {t : set α} {l' : filter α}
 
 lemma is_extr_on.elim {p : Prop} :
-  is_extr_on f a s → (is_min_on f a s → p) → (is_max_on f a s → p) → p :=
+  is_extr_on f s a → (is_min_on f s a → p) → (is_max_on f s a → p) → p :=
 or.elim
 
-lemma is_min_on_iff : is_min_on f a s ↔ ∀ x ∈ s, f a ≤ f x := iff.rfl
+lemma is_min_on_iff : is_min_on f s a ↔ ∀ x ∈ s, f a ≤ f x := iff.rfl
 
-lemma is_max_on_iff : is_max_on f a s ↔ ∀ x ∈ s, f x ≤ f a := iff.rfl
+lemma is_max_on_iff : is_max_on f s a ↔ ∀ x ∈ s, f x ≤ f a := iff.rfl
 
-lemma is_min_on_univ_iff : is_min_on f a univ ↔ ∀ x, f a ≤ f x :=
+lemma is_min_on_univ_iff : is_min_on f univ a ↔ ∀ x, f a ≤ f x :=
 univ_subset_iff.trans eq_univ_iff_forall
 
-lemma is_max_on_univ_iff : is_max_on f a univ ↔ ∀ x, f x ≤ f a :=
+lemma is_max_on_univ_iff : is_max_on f univ a ↔ ∀ x, f x ≤ f a :=
 univ_subset_iff.trans eq_univ_iff_forall
 
 /-! ### Conversion to `is_extr_*` -/
 
-lemma is_min_filter.is_extr : is_min_filter f a l → is_extr_filter f a l := or.inl
+lemma is_min_filter.is_extr : is_min_filter f l a → is_extr_filter f l a := or.inl
 
-lemma is_max_filter.is_extr : is_max_filter f a l → is_extr_filter f a l := or.inr
+lemma is_max_filter.is_extr : is_max_filter f l a → is_extr_filter f l a := or.inr
 
-lemma is_min_on.is_extr (h : is_min_on f a s) : is_extr_on f a s := h.is_extr
+lemma is_min_on.is_extr (h : is_min_on f s a) : is_extr_on f s a := h.is_extr
 
-lemma is_max_on.is_extr (h : is_max_on f a s) : is_extr_on f a s := h.is_extr
+lemma is_max_on.is_extr (h : is_max_on f s a) : is_extr_on f s a := h.is_extr
 
 /-! ### Constant function -/
 
-lemma is_min_filter_const {b : β} : is_min_filter (λ _, b) a l :=
+lemma is_min_filter_const {b : β} : is_min_filter (λ _, b) l a :=
 univ_mem_sets' $ λ _, le_refl _
 
-lemma is_max_filter_const {b : β} : is_max_filter (λ _, b) a l :=
+lemma is_max_filter_const {b : β} : is_max_filter (λ _, b) l a :=
 univ_mem_sets' $ λ _, le_refl _
 
-lemma is_extr_filter_const {b : β} : is_extr_filter (λ _, b) a l := is_min_filter_const.is_extr
+lemma is_extr_filter_const {b : β} : is_extr_filter (λ _, b) l a := is_min_filter_const.is_extr
 
-lemma is_min_on_const {b : β} : is_min_on (λ _, b) a s := is_min_filter_const
+lemma is_min_on_const {b : β} : is_min_on (λ _, b) s a := is_min_filter_const
 
-lemma is_max_on_const {b : β} : is_max_on (λ _, b) a s := is_max_filter_const
+lemma is_max_on_const {b : β} : is_max_on (λ _, b) s a := is_max_filter_const
 
-lemma is_extr_on_const {b : β} : is_extr_on (λ _, b) a s := is_extr_filter_const
+lemma is_extr_on_const {b : β} : is_extr_on (λ _, b) s a := is_extr_filter_const
 
 /-! ### Order dual -/
 
-lemma is_min_filter_dual_iff : @is_min_filter α (order_dual β) _ f a l ↔ is_max_filter f a l :=
+lemma is_min_filter_dual_iff : @is_min_filter α (order_dual β) _ f l a ↔ is_max_filter f l a :=
 iff.rfl
 
-lemma is_max_filter_dual_iff : @is_max_filter α (order_dual β) _ f a l ↔ is_min_filter f a l :=
+lemma is_max_filter_dual_iff : @is_max_filter α (order_dual β) _ f l a ↔ is_min_filter f l a :=
 iff.rfl
 
-lemma is_extr_filter_dual_iff : @is_extr_filter α (order_dual β) _ f a l ↔ is_extr_filter f a l :=
+lemma is_extr_filter_dual_iff : @is_extr_filter α (order_dual β) _ f l a ↔ is_extr_filter f l a :=
 or_comm _ _
 
 alias is_min_filter_dual_iff ↔ is_min_filter.undual is_max_filter.dual
 alias is_max_filter_dual_iff ↔ is_max_filter.undual is_min_filter.dual
 alias is_extr_filter_dual_iff ↔ is_extr_filter.undual is_extr_filter.dual
 
-lemma is_min_on_dual_iff : @is_min_on α (order_dual β) _ f a s ↔ is_max_on f a s := iff.rfl
-lemma is_max_on_dual_iff : @is_max_on α (order_dual β) _ f a s ↔ is_min_on f a s := iff.rfl
-lemma is_extr_on_dual_iff : @is_extr_on α (order_dual β) _ f a s ↔ is_extr_on f a s := or_comm _ _
+lemma is_min_on_dual_iff : @is_min_on α (order_dual β) _ f s a ↔ is_max_on f s a := iff.rfl
+lemma is_max_on_dual_iff : @is_max_on α (order_dual β) _ f s a ↔ is_min_on f s a := iff.rfl
+lemma is_extr_on_dual_iff : @is_extr_on α (order_dual β) _ f s a ↔ is_extr_on f s a := or_comm _ _
 
 alias is_min_on_dual_iff ↔ is_min_on.undual is_max_on.dual
 alias is_max_on_dual_iff ↔ is_max_on.undual is_min_on.dual
@@ -114,148 +119,148 @@ alias is_extr_on_dual_iff ↔ is_extr_on.undual is_extr_on.dual
 
 /-! ### Operations on the filter/set -/
 
-lemma is_min_filter.filter_mono (h : is_min_filter f a l) (hl : l' ≤ l) :
-  is_min_filter f a l' := hl h
+lemma is_min_filter.filter_mono (h : is_min_filter f l a) (hl : l' ≤ l) :
+  is_min_filter f l' a := hl h
 
-lemma is_max_filter.filter_mono (h : is_max_filter f a l) (hl : l' ≤ l) :
-  is_max_filter f a l' := hl h
+lemma is_max_filter.filter_mono (h : is_max_filter f l a) (hl : l' ≤ l) :
+  is_max_filter f l' a := hl h
 
-lemma is_extr_filter.filter_mono (h : is_extr_filter f a l) (hl : l' ≤ l) :
-  is_extr_filter f a l' :=
+lemma is_extr_filter.filter_mono (h : is_extr_filter f l a) (hl : l' ≤ l) :
+  is_extr_filter f l' a :=
 h.elim (λ h, (h.filter_mono hl).is_extr) (λ h, (h.filter_mono hl).is_extr)
 
-lemma is_min_filter.filter_inf (h : is_min_filter f a l) (l') : is_min_filter f a (l ⊓ l') :=
+lemma is_min_filter.filter_inf (h : is_min_filter f l a) (l') : is_min_filter f (l ⊓ l') a :=
 h.filter_mono inf_le_left
 
-lemma is_max_filter.filter_inf (h : is_max_filter f a l) (l') : is_max_filter f a (l ⊓ l') :=
+lemma is_max_filter.filter_inf (h : is_max_filter f l a) (l') : is_max_filter f (l ⊓ l') a :=
 h.filter_mono inf_le_left
 
-lemma is_extr_filter.filter_inf (h : is_extr_filter f a l) (l') : is_extr_filter f a (l ⊓ l') :=
+lemma is_extr_filter.filter_inf (h : is_extr_filter f l a) (l') : is_extr_filter f (l ⊓ l') a :=
 h.filter_mono inf_le_left
 
-lemma is_min_on.on_subset (hf : is_min_on f a t) (h : s ⊆ t) : is_min_on f a s :=
+lemma is_min_on.on_subset (hf : is_min_on f t a) (h : s ⊆ t) : is_min_on f s a :=
 hf.filter_mono $ principal_mono.2 h
 
-lemma is_max_on.on_subset (hf : is_max_on f a t) (h : s ⊆ t) : is_max_on f a s :=
+lemma is_max_on.on_subset (hf : is_max_on f t a) (h : s ⊆ t) : is_max_on f s a :=
 hf.filter_mono $ principal_mono.2 h
 
-lemma is_extr_on.on_subset (hf : is_extr_on f a t) (h : s ⊆ t) : is_extr_on f a s :=
+lemma is_extr_on.on_subset (hf : is_extr_on f t a) (h : s ⊆ t) : is_extr_on f s a :=
 hf.filter_mono $ principal_mono.2 h
 
-lemma is_min_on.inter (hf : is_min_on f a s) (t) : is_min_on f a (s ∩ t) :=
+lemma is_min_on.inter (hf : is_min_on f s a) (t) : is_min_on f (s ∩ t) a :=
 hf.on_subset (inter_subset_left s t)
 
-lemma is_max_on.inter (hf : is_max_on f a s) (t) : is_max_on f a (s ∩ t) :=
+lemma is_max_on.inter (hf : is_max_on f s a) (t) : is_max_on f (s ∩ t) a :=
 hf.on_subset (inter_subset_left s t)
 
-lemma is_extr_on.inter (hf : is_extr_on f a s) (t) : is_extr_on f a (s ∩ t) :=
+lemma is_extr_on.inter (hf : is_extr_on f s a) (t) : is_extr_on f (s ∩ t) a :=
 hf.on_subset (inter_subset_left s t)
 
 /-! ### Composition with (anti)monotone functions -/
 
-lemma is_min_filter.comp_mono (hf : is_min_filter f a l) {g : β → γ} (hg : monotone g) :
-  is_min_filter (g ∘ f) a l :=
+lemma is_min_filter.comp_mono (hf : is_min_filter f l a) {g : β → γ} (hg : monotone g) :
+  is_min_filter (g ∘ f) l a :=
 mem_sets_of_superset hf $ λ x hx, hg hx
 
-lemma is_max_filter.comp_mono (hf : is_max_filter f a l) {g : β → γ} (hg : monotone g) :
-  is_max_filter (g ∘ f) a l :=
+lemma is_max_filter.comp_mono (hf : is_max_filter f l a) {g : β → γ} (hg : monotone g) :
+  is_max_filter (g ∘ f) l a :=
 mem_sets_of_superset hf $ λ x hx, hg hx
 
-lemma is_extr_filter.comp_mono (hf : is_extr_filter f a l) {g : β → γ} (hg : monotone g) :
-  is_extr_filter (g ∘ f) a l :=
+lemma is_extr_filter.comp_mono (hf : is_extr_filter f l a) {g : β → γ} (hg : monotone g) :
+  is_extr_filter (g ∘ f) l a :=
 hf.elim (λ hf, (hf.comp_mono hg).is_extr)  (λ hf, (hf.comp_mono hg).is_extr)
 
-lemma is_min_filter.comp_antimono (hf : is_min_filter f a l) {g : β → γ}
+lemma is_min_filter.comp_antimono (hf : is_min_filter f l a) {g : β → γ}
   (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
-  is_max_filter (g ∘ f) a l :=
+  is_max_filter (g ∘ f) l a :=
 hf.dual.comp_mono (λ x y h, hg h)
 
-lemma is_max_filter.comp_antimono (hf : is_max_filter f a l) {g : β → γ}
+lemma is_max_filter.comp_antimono (hf : is_max_filter f l a) {g : β → γ}
   (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
-  is_min_filter (g ∘ f) a l :=
+  is_min_filter (g ∘ f) l a :=
 hf.dual.comp_mono (λ x y h, hg h)
 
-lemma is_extr_filter.comp_antimono (hf : is_extr_filter f a l) {g : β → γ}
+lemma is_extr_filter.comp_antimono (hf : is_extr_filter f l a) {g : β → γ}
   (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
-  is_extr_filter (g ∘ f) a l :=
+  is_extr_filter (g ∘ f) l a :=
 hf.dual.comp_mono (λ x y h, hg h)
 
-lemma is_min_on.comp_mono (hf : is_min_on f a s) {g : β → γ} (hg : monotone g) :
-  is_min_on (g ∘ f) a s :=
+lemma is_min_on.comp_mono (hf : is_min_on f s a) {g : β → γ} (hg : monotone g) :
+  is_min_on (g ∘ f) s a :=
 hf.comp_mono hg
 
-lemma is_max_on.comp_mono (hf : is_max_on f a s) {g : β → γ} (hg : monotone g) :
-  is_max_on (g ∘ f) a s :=
+lemma is_max_on.comp_mono (hf : is_max_on f s a) {g : β → γ} (hg : monotone g) :
+  is_max_on (g ∘ f) s a :=
 hf.comp_mono hg
 
-lemma is_extr_on.comp_mono (hf : is_extr_on f a s) {g : β → γ} (hg : monotone g) :
-  is_extr_on (g ∘ f) a s :=
+lemma is_extr_on.comp_mono (hf : is_extr_on f s a) {g : β → γ} (hg : monotone g) :
+  is_extr_on (g ∘ f) s a :=
 hf.comp_mono hg
 
-lemma is_min_on.comp_antimono (hf : is_min_on f a s) {g : β → γ}
+lemma is_min_on.comp_antimono (hf : is_min_on f s a) {g : β → γ}
   (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
-  is_max_on (g ∘ f) a s :=
+  is_max_on (g ∘ f) s a :=
 hf.comp_antimono hg
 
-lemma is_max_on.comp_antimono (hf : is_max_on f a s) {g : β → γ}
+lemma is_max_on.comp_antimono (hf : is_max_on f s a) {g : β → γ}
   (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
-  is_min_on (g ∘ f) a s :=
+  is_min_on (g ∘ f) s a :=
 hf.comp_antimono hg
 
-lemma is_extr_on.comp_antimono (hf : is_extr_on f a s) {g : β → γ}
+lemma is_extr_on.comp_antimono (hf : is_extr_on f s a) {g : β → γ}
   (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
-  is_extr_on (g ∘ f) a s :=
+  is_extr_on (g ∘ f) s a :=
 hf.comp_antimono hg
 
 lemma is_min_filter.bicomp_mono [preorder δ] {op : β → γ → δ} (hop : ((≤) ⇒ (≤) ⇒ (≤)) op op)
-  (hf : is_min_filter f a l) {g : α → γ} (hg : is_min_filter g a l) :
-  is_min_filter (λ x, op (f x) (g x)) a l :=
+  (hf : is_min_filter f l a) {g : α → γ} (hg : is_min_filter g l a) :
+  is_min_filter (λ x, op (f x) (g x)) l a :=
 mem_sets_of_superset (inter_mem_sets hf hg) $ λ x ⟨hfx, hgx⟩, hop hfx hgx
 
 lemma is_max_filter.bicomp_mono [preorder δ] {op : β → γ → δ} (hop : ((≤) ⇒ (≤) ⇒ (≤)) op op)
-  (hf : is_max_filter f a l) {g : α → γ} (hg : is_max_filter g a l) :
-  is_max_filter (λ x, op (f x) (g x)) a l :=
+  (hf : is_max_filter f l a) {g : α → γ} (hg : is_max_filter g l a) :
+  is_max_filter (λ x, op (f x) (g x)) l a :=
 mem_sets_of_superset (inter_mem_sets hf hg) $ λ x ⟨hfx, hgx⟩, hop hfx hgx
 
 -- No `extr` version because we need `hf` and `hg` to be of the same kind
 
 lemma is_min_on.bicomp_mono [preorder δ] {op : β → γ → δ} (hop : ((≤) ⇒ (≤) ⇒ (≤)) op op)
-  (hf : is_min_on f a s) {g : α → γ} (hg : is_min_on g a s) :
-  is_min_on (λ x, op (f x) (g x)) a s :=
+  (hf : is_min_on f s a) {g : α → γ} (hg : is_min_on g s a) :
+  is_min_on (λ x, op (f x) (g x)) s a :=
 hf.bicomp_mono hop hg
 
 lemma is_max_on.bicomp_mono [preorder δ] {op : β → γ → δ} (hop : ((≤) ⇒ (≤) ⇒ (≤)) op op)
-  (hf : is_max_on f a s) {g : α → γ} (hg : is_max_on g a s) :
-  is_max_on (λ x, op (f x) (g x)) a s :=
+  (hf : is_max_on f s a) {g : α → γ} (hg : is_max_on g s a) :
+  is_max_on (λ x, op (f x) (g x)) s a :=
 hf.bicomp_mono hop hg
 
 /-! ### Composition with `tendsto` -/
 
-lemma is_min_filter.comp_tendsto {g : δ → α} {l' : filter δ} {b : δ} (hf : is_min_filter f (g b) l)
+lemma is_min_filter.comp_tendsto {g : δ → α} {l' : filter δ} {b : δ} (hf : is_min_filter f l (g b))
   (hg : tendsto g l' l) :
-  is_min_filter (f ∘ g) b l' :=
+  is_min_filter (f ∘ g) l' b :=
 hg hf
 
-lemma is_max_filter.comp_tendsto {g : δ → α} {l' : filter δ} {b : δ} (hf : is_max_filter f (g b) l)
+lemma is_max_filter.comp_tendsto {g : δ → α} {l' : filter δ} {b : δ} (hf : is_max_filter f l (g b))
   (hg : tendsto g l' l) :
-  is_max_filter (f ∘ g) b l' :=
+  is_max_filter (f ∘ g) l' b :=
 hg hf
 
-lemma is_extr_filter.comp_tendsto {g : δ → α} {l' : filter δ} {b : δ} (hf : is_extr_filter f (g b) l)
+lemma is_extr_filter.comp_tendsto {g : δ → α} {l' : filter δ} {b : δ} (hf : is_extr_filter f l (g b))
   (hg : tendsto g l' l) :
-  is_extr_filter (f ∘ g) b l' :=
+  is_extr_filter (f ∘ g) l' b :=
 hf.elim (λ hf, (hf.comp_tendsto hg).is_extr) (λ hf, (hf.comp_tendsto hg).is_extr)
 
-lemma is_min_on.on_preimage (g : δ → α) {b : δ} (hf : is_min_on f (g b) s) :
-  is_min_on (f ∘ g) b (g ⁻¹' s) :=
+lemma is_min_on.on_preimage (g : δ → α) {b : δ} (hf : is_min_on f s (g b)) :
+  is_min_on (f ∘ g) (g ⁻¹' s) b :=
 hf.comp_tendsto (tendsto_principal_principal.mpr $ subset.refl _)
 
-lemma is_max_on.on_preimage (g : δ → α) {b : δ} (hf : is_max_on f (g b) s) :
-  is_max_on (f ∘ g) b (g ⁻¹' s) :=
+lemma is_max_on.on_preimage (g : δ → α) {b : δ} (hf : is_max_on f s (g b)) :
+  is_max_on (f ∘ g) (g ⁻¹' s) b :=
 hf.comp_tendsto (tendsto_principal_principal.mpr $ subset.refl _)
 
-lemma is_extr_on.on_preimage (g : δ → α) {b : δ} (hf : is_extr_on f (g b) s) :
-  is_extr_on (f ∘ g) b (g ⁻¹' s) :=
+lemma is_extr_on.on_preimage (g : δ → α) {b : δ} (hf : is_extr_on f s (g b)) :
+  is_extr_on (f ∘ g) (g ⁻¹' s) b :=
 hf.elim (λ hf, (hf.on_preimage g).is_extr) (λ hf, (hf.on_preimage g).is_extr)
 
 end preorder
@@ -265,22 +270,22 @@ section ordered_comm_monoid
 
 variables [ordered_comm_monoid β] {f g : α → β} {a : α} {s : set α} {l : filter α}
 
-lemma is_min_filter.add (hf : is_min_filter f a l) (hg : is_min_filter g a l) :
-  is_min_filter (λ x, f x + g x) a l :=
-show is_min_filter (λ x, f x + g x) a l,
+lemma is_min_filter.add (hf : is_min_filter f l a) (hg : is_min_filter g l a) :
+  is_min_filter (λ x, f x + g x) l a :=
+show is_min_filter (λ x, f x + g x) l a,
 from hf.bicomp_mono (λ x x' hx y y' hy, add_le_add' hx hy) hg
 
-lemma is_max_filter.add (hf : is_max_filter f a l) (hg : is_max_filter g a l) :
-  is_max_filter (λ x, f x + g x) a l :=
-show is_max_filter (λ x, f x + g x) a l,
+lemma is_max_filter.add (hf : is_max_filter f l a) (hg : is_max_filter g l a) :
+  is_max_filter (λ x, f x + g x) l a :=
+show is_max_filter (λ x, f x + g x) l a,
 from hf.bicomp_mono (λ x x' hx y y' hy, add_le_add' hx hy) hg
 
-lemma is_min_on.add (hf : is_min_on f a s) (hg : is_min_on g a s) :
-  is_min_on (λ x, f x + g x) a s :=
+lemma is_min_on.add (hf : is_min_on f s a) (hg : is_min_on g s a) :
+  is_min_on (λ x, f x + g x) s a :=
 hf.add hg
 
-lemma is_max_on.add (hf : is_max_on f a s) (hg : is_max_on g a s) :
-  is_max_on (λ x, f x + g x) a s :=
+lemma is_max_on.add (hf : is_max_on f s a) (hg : is_max_on g s a) :
+  is_max_on (λ x, f x + g x) s a :=
 hf.add hg
 
 end ordered_comm_monoid
@@ -291,38 +296,38 @@ section ordered_comm_group
 
 variables [ordered_comm_group β] {f g : α → β} {a : α} {s : set α} {l : filter α}
 
-lemma is_min_filter.neg (hf : is_min_filter f a l) : is_max_filter (λ x, -f x) a l :=
+lemma is_min_filter.neg (hf : is_min_filter f l a) : is_max_filter (λ x, -f x) l a :=
 hf.comp_antimono (λ x y hx, neg_le_neg hx)
 
-lemma is_max_filter.neg (hf : is_max_filter f a l) : is_min_filter (λ x, -f x) a l :=
+lemma is_max_filter.neg (hf : is_max_filter f l a) : is_min_filter (λ x, -f x) l a :=
 hf.comp_antimono (λ x y hx, neg_le_neg hx)
 
-lemma is_extr_filter.neg (hf : is_extr_filter f a l) : is_extr_filter (λ x, -f x) a l :=
+lemma is_extr_filter.neg (hf : is_extr_filter f l a) : is_extr_filter (λ x, -f x) l a :=
 hf.elim (λ hf, hf.neg.is_extr) (λ hf, hf.neg.is_extr)
 
-lemma is_min_on.neg (hf : is_min_on f a s) : is_max_on (λ x, -f x) a s :=
+lemma is_min_on.neg (hf : is_min_on f s a) : is_max_on (λ x, -f x) s a :=
 hf.comp_antimono (λ x y hx, neg_le_neg hx)
 
-lemma is_max_on.neg (hf : is_max_on f a s) : is_min_on (λ x, -f x) a s :=
+lemma is_max_on.neg (hf : is_max_on f s a) : is_min_on (λ x, -f x) s a :=
 hf.comp_antimono (λ x y hx, neg_le_neg hx)
 
-lemma is_extr_on.neg (hf : is_extr_on f a s) : is_extr_on (λ x, -f x) a s :=
+lemma is_extr_on.neg (hf : is_extr_on f s a) : is_extr_on (λ x, -f x) s a :=
 hf.elim (λ hf, hf.neg.is_extr) (λ hf, hf.neg.is_extr)
 
-lemma is_min_filter.sub (hf : is_min_filter f a l) (hg : is_max_filter g a l) :
-  is_min_filter (λ x, f x - g x) a l :=
+lemma is_min_filter.sub (hf : is_min_filter f l a) (hg : is_max_filter g l a) :
+  is_min_filter (λ x, f x - g x) l a :=
 hf.add hg.neg
 
-lemma is_max_filter.sub (hf : is_max_filter f a l) (hg : is_min_filter g a l) :
-  is_max_filter (λ x, f x - g x) a l :=
+lemma is_max_filter.sub (hf : is_max_filter f l a) (hg : is_min_filter g l a) :
+  is_max_filter (λ x, f x - g x) l a :=
 hf.add hg.neg
 
-lemma is_min_on.sub (hf : is_min_on f a s) (hg : is_max_on g a s) :
-  is_min_on (λ x, f x - g x) a s :=
+lemma is_min_on.sub (hf : is_min_on f s a) (hg : is_max_on g s a) :
+  is_min_on (λ x, f x - g x) s a :=
 hf.add hg.neg
 
-lemma is_max_on.sub (hf : is_max_on f a s) (hg : is_min_on g a s) :
-  is_max_on (λ x, f x - g x) a s :=
+lemma is_max_on.sub (hf : is_max_on f s a) (hg : is_min_on g s a) :
+  is_max_on (λ x, f x - g x) s a :=
 hf.add hg.neg
 
 end ordered_comm_group
@@ -333,22 +338,22 @@ section semilattice_sup
 
 variables [semilattice_sup β] {f g : α → β} {a : α} {s : set α} {l : filter α}
 
-lemma is_min_filter.sup (hf : is_min_filter f a l) (hg : is_min_filter g a l) :
-  is_min_filter (λ x, f x ⊔ g x) a l :=
-show is_min_filter (λ x, f x ⊔ g x) a l,
+lemma is_min_filter.sup (hf : is_min_filter f l a) (hg : is_min_filter g l a) :
+  is_min_filter (λ x, f x ⊔ g x) l a :=
+show is_min_filter (λ x, f x ⊔ g x) l a,
 from hf.bicomp_mono (λ x x' hx y y' hy, sup_le_sup hx hy) hg
 
-lemma is_max_filter.sup (hf : is_max_filter f a l) (hg : is_max_filter g a l) :
-  is_max_filter (λ x, f x ⊔ g x) a l :=
-show is_max_filter (λ x, f x ⊔ g x) a l,
+lemma is_max_filter.sup (hf : is_max_filter f l a) (hg : is_max_filter g l a) :
+  is_max_filter (λ x, f x ⊔ g x) l a :=
+show is_max_filter (λ x, f x ⊔ g x) l a,
 from hf.bicomp_mono (λ x x' hx y y' hy, sup_le_sup hx hy) hg
 
-lemma is_min_on.sup (hf : is_min_on f a s) (hg : is_min_on g a s) :
-  is_min_on (λ x, f x ⊔ g x) a s :=
+lemma is_min_on.sup (hf : is_min_on f s a) (hg : is_min_on g s a) :
+  is_min_on (λ x, f x ⊔ g x) s a :=
 hf.sup hg
 
-lemma is_max_on.sup (hf : is_max_on f a s) (hg : is_max_on g a s) :
-  is_max_on (λ x, f x ⊔ g x) a s :=
+lemma is_max_on.sup (hf : is_max_on f s a) (hg : is_max_on g s a) :
+  is_max_on (λ x, f x ⊔ g x) s a :=
 hf.sup hg
 
 end semilattice_sup
@@ -357,22 +362,22 @@ section semilattice_inf
 
 variables [semilattice_inf β] {f g : α → β} {a : α} {s : set α} {l : filter α}
 
-lemma is_min_filter.inf (hf : is_min_filter f a l) (hg : is_min_filter g a l) :
-  is_min_filter (λ x, f x ⊓ g x) a l :=
-show is_min_filter (λ x, f x ⊓ g x) a l,
+lemma is_min_filter.inf (hf : is_min_filter f l a) (hg : is_min_filter g l a) :
+  is_min_filter (λ x, f x ⊓ g x) l a :=
+show is_min_filter (λ x, f x ⊓ g x) l a,
 from hf.bicomp_mono (λ x x' hx y y' hy, inf_le_inf hx hy) hg
 
-lemma is_max_filter.inf (hf : is_max_filter f a l) (hg : is_max_filter g a l) :
-  is_max_filter (λ x, f x ⊓ g x) a l :=
-show is_max_filter (λ x, f x ⊓ g x) a l,
+lemma is_max_filter.inf (hf : is_max_filter f l a) (hg : is_max_filter g l a) :
+  is_max_filter (λ x, f x ⊓ g x) l a :=
+show is_max_filter (λ x, f x ⊓ g x) l a,
 from hf.bicomp_mono (λ x x' hx y y' hy, inf_le_inf hx hy) hg
 
-lemma is_min_on.inf (hf : is_min_on f a s) (hg : is_min_on g a s) :
-  is_min_on (λ x, f x ⊓ g x) a s :=
+lemma is_min_on.inf (hf : is_min_on f s a) (hg : is_min_on g s a) :
+  is_min_on (λ x, f x ⊓ g x) s a :=
 hf.inf hg
 
-lemma is_max_on.inf (hf : is_max_on f a s) (hg : is_max_on g a s) :
-  is_max_on (λ x, f x ⊓ g x) a s :=
+lemma is_max_on.inf (hf : is_max_on f s a) (hg : is_max_on g s a) :
+  is_max_on (λ x, f x ⊓ g x) s a :=
 hf.inf hg
 
 end semilattice_inf
@@ -383,40 +388,40 @@ section decidable_linear_order
 
 variables [decidable_linear_order β] {f g : α → β} {a : α} {s : set α} {l : filter α}
 
-lemma is_min_filter.min (hf : is_min_filter f a l) (hg : is_min_filter g a l) :
-  is_min_filter (λ x, min (f x) (g x)) a l :=
-show is_min_filter (λ x, min (f x) (g x)) a l,
+lemma is_min_filter.min (hf : is_min_filter f l a) (hg : is_min_filter g l a) :
+  is_min_filter (λ x, min (f x) (g x)) l a :=
+show is_min_filter (λ x, min (f x) (g x)) l a,
 from hf.bicomp_mono (λ x x' hx y y' hy, min_le_min hx hy) hg
 
-lemma is_max_filter.min (hf : is_max_filter f a l) (hg : is_max_filter g a l) :
-  is_max_filter (λ x, min (f x) (g x)) a l :=
-show is_max_filter (λ x, min (f x) (g x)) a l,
+lemma is_max_filter.min (hf : is_max_filter f l a) (hg : is_max_filter g l a) :
+  is_max_filter (λ x, min (f x) (g x)) l a :=
+show is_max_filter (λ x, min (f x) (g x)) l a,
 from hf.bicomp_mono (λ x x' hx y y' hy, min_le_min hx hy) hg
 
-lemma is_min_on.min (hf : is_min_on f a s) (hg : is_min_on g a s) :
-  is_min_on (λ x, min (f x) (g x)) a s :=
+lemma is_min_on.min (hf : is_min_on f s a) (hg : is_min_on g s a) :
+  is_min_on (λ x, min (f x) (g x)) s a :=
 hf.min hg
 
-lemma is_max_on.min (hf : is_max_on f a s) (hg : is_max_on g a s) :
-  is_max_on (λ x, min (f x) (g x)) a s :=
+lemma is_max_on.min (hf : is_max_on f s a) (hg : is_max_on g s a) :
+  is_max_on (λ x, min (f x) (g x)) s a :=
 hf.min hg
 
-lemma is_min_filter.max (hf : is_min_filter f a l) (hg : is_min_filter g a l) :
-  is_min_filter (λ x, max (f x) (g x)) a l :=
-show is_min_filter (λ x, max (f x) (g x)) a l,
+lemma is_min_filter.max (hf : is_min_filter f l a) (hg : is_min_filter g l a) :
+  is_min_filter (λ x, max (f x) (g x)) l a :=
+show is_min_filter (λ x, max (f x) (g x)) l a,
 from hf.bicomp_mono (λ x x' hx y y' hy, max_le_max hx hy) hg
 
-lemma is_max_filter.max (hf : is_max_filter f a l) (hg : is_max_filter g a l) :
-  is_max_filter (λ x, max (f x) (g x)) a l :=
-show is_max_filter (λ x, max (f x) (g x)) a l,
+lemma is_max_filter.max (hf : is_max_filter f l a) (hg : is_max_filter g l a) :
+  is_max_filter (λ x, max (f x) (g x)) l a :=
+show is_max_filter (λ x, max (f x) (g x)) l a,
 from hf.bicomp_mono (λ x x' hx y y' hy, max_le_max hx hy) hg
 
-lemma is_min_on.max (hf : is_min_on f a s) (hg : is_min_on g a s) :
-  is_min_on (λ x, max (f x) (g x)) a s :=
+lemma is_min_on.max (hf : is_min_on f s a) (hg : is_min_on g s a) :
+  is_min_on (λ x, max (f x) (g x)) s a :=
 hf.max hg
 
-lemma is_max_on.max (hf : is_max_on f a s) (hg : is_max_on g a s) :
-  is_max_on (λ x, max (f x) (g x)) a s :=
+lemma is_max_on.max (hf : is_max_on f s a) (hg : is_max_on g s a) :
+  is_max_on (λ x, max (f x) (g x)) s a :=
 hf.max hg
 
 end decidable_linear_order

--- a/src/order/filter/extr.lean
+++ b/src/order/filter/extr.lean
@@ -53,7 +53,7 @@ Similar predicates with `_on` suffix are particular cases for `l = principal s`.
   for pointwise `max`, `min`, `sup`, `inf`, respectively.
 
 
-### Miscelanous definitions
+### Miscellaneous definitions
 
 * `is_*_*_const` : any point is both a minimum and maximum for a constant function;
 * `is_min/max_*.is_ext` : any minimum/maximum point is an extremum;

--- a/src/order/filter/extr.lean
+++ b/src/order/filter/extr.lean
@@ -1,0 +1,422 @@
+/-
+Copyright (c) 2019 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov
+-/
+
+import order.filter.basic logic.relator tactic.alias
+
+/-! # Minimum and maximum w.r.t. a filter and on a set
+
+This file defines six predicates of the form `is_A_B`, where `A` is `min`, `max`, or `extr`,
+and `B` is `filter` or `on`.
+
+* `is_min_filter f a l` means that `f a ≤ f x` in some `l`-neighborhood of `a`;
+* `is_max_filter f a l` means that `f x ≤ f a` in some `l`-neighborhood of `a`;
+* `is_extr_filter f a l` means `is_min_filter f a l` or `is_max_filter f a l`.
+
+Similar predicates with `_on` suffix are particular cases for `l = principal s`.
+
+We also define various operations on these statements.
+-/
+
+universes u v w x
+
+variables {α : Type u} {β : Type v} {γ : Type w} {δ : Type x}
+
+open set lattice filter
+
+section preorder
+
+variables [preorder β] [preorder γ]
+
+variables (f : α → β) (a : α) (s : set α) (l : filter α)
+
+/-! ### Definitions -/
+
+def is_min_filter (f : α → β) (a : α) (l : filter α) : Prop := {x | f a ≤ f x} ∈ l
+
+def is_max_filter (f : α → β) (a : α) (l : filter α) : Prop := {x | f x ≤ f a} ∈ l
+
+def is_extr_filter (f : α → β) (a : α) (l : filter α) : Prop :=
+is_min_filter f a l ∨ is_max_filter f a l
+
+def is_min_on := is_min_filter f a (principal s)
+
+def is_max_on := is_max_filter f a (principal s)
+
+def is_extr_on : Prop := is_extr_filter f a (principal s)
+
+variables {f a s l} {t : set α} {l' : filter α}
+
+lemma is_extr_on.elim {p : Prop} :
+  is_extr_on f a s → (is_min_on f a s → p) → (is_max_on f a s → p) → p :=
+or.elim
+
+lemma is_min_on_iff : is_min_on f a s ↔ ∀ x ∈ s, f a ≤ f x := iff.rfl
+
+lemma is_max_on_iff : is_max_on f a s ↔ ∀ x ∈ s, f x ≤ f a := iff.rfl
+
+lemma is_min_on_univ_iff : is_min_on f a univ ↔ ∀ x, f a ≤ f x :=
+univ_subset_iff.trans eq_univ_iff_forall
+
+lemma is_max_on_univ_iff : is_max_on f a univ ↔ ∀ x, f x ≤ f a :=
+univ_subset_iff.trans eq_univ_iff_forall
+
+/-! ### Conversion to `is_extr_*` -/
+
+lemma is_min_filter.is_extr : is_min_filter f a l → is_extr_filter f a l := or.inl
+
+lemma is_max_filter.is_extr : is_max_filter f a l → is_extr_filter f a l := or.inr
+
+lemma is_min_on.is_extr (h : is_min_on f a s) : is_extr_on f a s := h.is_extr
+
+lemma is_max_on.is_extr (h : is_max_on f a s) : is_extr_on f a s := h.is_extr
+
+/-! ### Constant function -/
+
+lemma is_min_filter_const {b : β} : is_min_filter (λ _, b) a l :=
+univ_mem_sets' $ λ _, le_refl _
+
+lemma is_max_filter_const {b : β} : is_max_filter (λ _, b) a l :=
+univ_mem_sets' $ λ _, le_refl _
+
+lemma is_extr_filter_const {b : β} : is_extr_filter (λ _, b) a l := is_min_filter_const.is_extr
+
+lemma is_min_on_const {b : β} : is_min_on (λ _, b) a s := is_min_filter_const
+
+lemma is_max_on_const {b : β} : is_max_on (λ _, b) a s := is_max_filter_const
+
+lemma is_extr_on_const {b : β} : is_extr_on (λ _, b) a s := is_extr_filter_const
+
+/-! ### Order dual -/
+
+lemma is_min_filter_dual_iff : @is_min_filter α (order_dual β) _ f a l ↔ is_max_filter f a l :=
+iff.rfl
+
+lemma is_max_filter_dual_iff : @is_max_filter α (order_dual β) _ f a l ↔ is_min_filter f a l :=
+iff.rfl
+
+lemma is_extr_filter_dual_iff : @is_extr_filter α (order_dual β) _ f a l ↔ is_extr_filter f a l :=
+or_comm _ _
+
+alias is_min_filter_dual_iff ↔ is_min_filter.undual is_max_filter.dual
+alias is_max_filter_dual_iff ↔ is_max_filter.undual is_min_filter.dual
+alias is_extr_filter_dual_iff ↔ is_extr_filter.undual is_extr_filter.dual
+
+lemma is_min_on_dual_iff : @is_min_on α (order_dual β) _ f a s ↔ is_max_on f a s := iff.rfl
+lemma is_max_on_dual_iff : @is_max_on α (order_dual β) _ f a s ↔ is_min_on f a s := iff.rfl
+lemma is_extr_on_dual_iff : @is_extr_on α (order_dual β) _ f a s ↔ is_extr_on f a s := or_comm _ _
+
+alias is_min_on_dual_iff ↔ is_min_on.undual is_max_on.dual
+alias is_max_on_dual_iff ↔ is_max_on.undual is_min_on.dual
+alias is_extr_on_dual_iff ↔ is_extr_on.undual is_extr_on.dual
+
+/-! ### Operations on the filter/set -/
+
+lemma is_min_filter.filter_mono (h : is_min_filter f a l) (hl : l' ≤ l) :
+  is_min_filter f a l' := hl h
+
+lemma is_max_filter.filter_mono (h : is_max_filter f a l) (hl : l' ≤ l) :
+  is_max_filter f a l' := hl h
+
+lemma is_extr_filter.filter_mono (h : is_extr_filter f a l) (hl : l' ≤ l) :
+  is_extr_filter f a l' :=
+h.elim (λ h, (h.filter_mono hl).is_extr) (λ h, (h.filter_mono hl).is_extr)
+
+lemma is_min_filter.filter_inf (h : is_min_filter f a l) (l') : is_min_filter f a (l ⊓ l') :=
+h.filter_mono inf_le_left
+
+lemma is_max_filter.filter_inf (h : is_max_filter f a l) (l') : is_max_filter f a (l ⊓ l') :=
+h.filter_mono inf_le_left
+
+lemma is_extr_filter.filter_inf (h : is_extr_filter f a l) (l') : is_extr_filter f a (l ⊓ l') :=
+h.filter_mono inf_le_left
+
+lemma is_min_on.on_subset (hf : is_min_on f a t) (h : s ⊆ t) : is_min_on f a s :=
+hf.filter_mono $ principal_mono.2 h
+
+lemma is_max_on.on_subset (hf : is_max_on f a t) (h : s ⊆ t) : is_max_on f a s :=
+hf.filter_mono $ principal_mono.2 h
+
+lemma is_extr_on.on_subset (hf : is_extr_on f a t) (h : s ⊆ t) : is_extr_on f a s :=
+hf.filter_mono $ principal_mono.2 h
+
+lemma is_min_on.inter (hf : is_min_on f a s) (t) : is_min_on f a (s ∩ t) :=
+hf.on_subset (inter_subset_left s t)
+
+lemma is_max_on.inter (hf : is_max_on f a s) (t) : is_max_on f a (s ∩ t) :=
+hf.on_subset (inter_subset_left s t)
+
+lemma is_extr_on.inter (hf : is_extr_on f a s) (t) : is_extr_on f a (s ∩ t) :=
+hf.on_subset (inter_subset_left s t)
+
+/-! ### Composition with (anti)monotone functions -/
+
+lemma is_min_filter.comp_mono (hf : is_min_filter f a l) {g : β → γ} (hg : monotone g) :
+  is_min_filter (g ∘ f) a l :=
+mem_sets_of_superset hf $ λ x hx, hg hx
+
+lemma is_max_filter.comp_mono (hf : is_max_filter f a l) {g : β → γ} (hg : monotone g) :
+  is_max_filter (g ∘ f) a l :=
+mem_sets_of_superset hf $ λ x hx, hg hx
+
+lemma is_extr_filter.comp_mono (hf : is_extr_filter f a l) {g : β → γ} (hg : monotone g) :
+  is_extr_filter (g ∘ f) a l :=
+hf.elim (λ hf, (hf.comp_mono hg).is_extr)  (λ hf, (hf.comp_mono hg).is_extr)
+
+lemma is_min_filter.comp_antimono (hf : is_min_filter f a l) {g : β → γ}
+  (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
+  is_max_filter (g ∘ f) a l :=
+hf.dual.comp_mono (λ x y h, hg h)
+
+lemma is_max_filter.comp_antimono (hf : is_max_filter f a l) {g : β → γ}
+  (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
+  is_min_filter (g ∘ f) a l :=
+hf.dual.comp_mono (λ x y h, hg h)
+
+lemma is_extr_filter.comp_antimono (hf : is_extr_filter f a l) {g : β → γ}
+  (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
+  is_extr_filter (g ∘ f) a l :=
+hf.dual.comp_mono (λ x y h, hg h)
+
+lemma is_min_on.comp_mono (hf : is_min_on f a s) {g : β → γ} (hg : monotone g) :
+  is_min_on (g ∘ f) a s :=
+hf.comp_mono hg
+
+lemma is_max_on.comp_mono (hf : is_max_on f a s) {g : β → γ} (hg : monotone g) :
+  is_max_on (g ∘ f) a s :=
+hf.comp_mono hg
+
+lemma is_extr_on.comp_mono (hf : is_extr_on f a s) {g : β → γ} (hg : monotone g) :
+  is_extr_on (g ∘ f) a s :=
+hf.comp_mono hg
+
+lemma is_min_on.comp_antimono (hf : is_min_on f a s) {g : β → γ}
+  (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
+  is_max_on (g ∘ f) a s :=
+hf.comp_antimono hg
+
+lemma is_max_on.comp_antimono (hf : is_max_on f a s) {g : β → γ}
+  (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
+  is_min_on (g ∘ f) a s :=
+hf.comp_antimono hg
+
+lemma is_extr_on.comp_antimono (hf : is_extr_on f a s) {g : β → γ}
+  (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
+  is_extr_on (g ∘ f) a s :=
+hf.comp_antimono hg
+
+lemma is_min_filter.bicomp_mono [preorder δ] {op : β → γ → δ} (hop : ((≤) ⇒ (≤) ⇒ (≤)) op op)
+  (hf : is_min_filter f a l) {g : α → γ} (hg : is_min_filter g a l) :
+  is_min_filter (λ x, op (f x) (g x)) a l :=
+mem_sets_of_superset (inter_mem_sets hf hg) $ λ x ⟨hfx, hgx⟩, hop hfx hgx
+
+lemma is_max_filter.bicomp_mono [preorder δ] {op : β → γ → δ} (hop : ((≤) ⇒ (≤) ⇒ (≤)) op op)
+  (hf : is_max_filter f a l) {g : α → γ} (hg : is_max_filter g a l) :
+  is_max_filter (λ x, op (f x) (g x)) a l :=
+mem_sets_of_superset (inter_mem_sets hf hg) $ λ x ⟨hfx, hgx⟩, hop hfx hgx
+
+-- No `extr` version because we need `hf` and `hg` to be of the same kind
+
+lemma is_min_on.bicomp_mono [preorder δ] {op : β → γ → δ} (hop : ((≤) ⇒ (≤) ⇒ (≤)) op op)
+  (hf : is_min_on f a s) {g : α → γ} (hg : is_min_on g a s) :
+  is_min_on (λ x, op (f x) (g x)) a s :=
+hf.bicomp_mono hop hg
+
+lemma is_max_on.bicomp_mono [preorder δ] {op : β → γ → δ} (hop : ((≤) ⇒ (≤) ⇒ (≤)) op op)
+  (hf : is_max_on f a s) {g : α → γ} (hg : is_max_on g a s) :
+  is_max_on (λ x, op (f x) (g x)) a s :=
+hf.bicomp_mono hop hg
+
+/-! ### Composition with `tendsto` -/
+
+lemma is_min_filter.comp_tendsto {g : δ → α} {l' : filter δ} {b : δ} (hf : is_min_filter f (g b) l)
+  (hg : tendsto g l' l) :
+  is_min_filter (f ∘ g) b l' :=
+hg hf
+
+lemma is_max_filter.comp_tendsto {g : δ → α} {l' : filter δ} {b : δ} (hf : is_max_filter f (g b) l)
+  (hg : tendsto g l' l) :
+  is_max_filter (f ∘ g) b l' :=
+hg hf
+
+lemma is_extr_filter.comp_tendsto {g : δ → α} {l' : filter δ} {b : δ} (hf : is_extr_filter f (g b) l)
+  (hg : tendsto g l' l) :
+  is_extr_filter (f ∘ g) b l' :=
+hf.elim (λ hf, (hf.comp_tendsto hg).is_extr) (λ hf, (hf.comp_tendsto hg).is_extr)
+
+lemma is_min_on.on_preimage (g : δ → α) {b : δ} (hf : is_min_on f (g b) s) :
+  is_min_on (f ∘ g) b (g ⁻¹' s) :=
+hf.comp_tendsto (tendsto_principal_principal.mpr $ subset.refl _)
+
+lemma is_max_on.on_preimage (g : δ → α) {b : δ} (hf : is_max_on f (g b) s) :
+  is_max_on (f ∘ g) b (g ⁻¹' s) :=
+hf.comp_tendsto (tendsto_principal_principal.mpr $ subset.refl _)
+
+lemma is_extr_on.on_preimage (g : δ → α) {b : δ} (hf : is_extr_on f (g b) s) :
+  is_extr_on (f ∘ g) b (g ⁻¹' s) :=
+hf.elim (λ hf, (hf.on_preimage g).is_extr) (λ hf, (hf.on_preimage g).is_extr)
+
+end preorder
+
+/-! ### Pointwise addition -/
+section ordered_comm_monoid
+
+variables [ordered_comm_monoid β] {f g : α → β} {a : α} {s : set α} {l : filter α}
+
+lemma is_min_filter.add (hf : is_min_filter f a l) (hg : is_min_filter g a l) :
+  is_min_filter (λ x, f x + g x) a l :=
+show is_min_filter (λ x, f x + g x) a l,
+from hf.bicomp_mono (λ x x' hx y y' hy, add_le_add' hx hy) hg
+
+lemma is_max_filter.add (hf : is_max_filter f a l) (hg : is_max_filter g a l) :
+  is_max_filter (λ x, f x + g x) a l :=
+show is_max_filter (λ x, f x + g x) a l,
+from hf.bicomp_mono (λ x x' hx y y' hy, add_le_add' hx hy) hg
+
+lemma is_min_on.add (hf : is_min_on f a s) (hg : is_min_on g a s) :
+  is_min_on (λ x, f x + g x) a s :=
+hf.add hg
+
+lemma is_max_on.add (hf : is_max_on f a s) (hg : is_max_on g a s) :
+  is_max_on (λ x, f x + g x) a s :=
+hf.add hg
+
+end ordered_comm_monoid
+
+/-! ### Pointwise negation and subtraction -/
+
+section ordered_comm_group
+
+variables [ordered_comm_group β] {f g : α → β} {a : α} {s : set α} {l : filter α}
+
+lemma is_min_filter.neg (hf : is_min_filter f a l) : is_max_filter (λ x, -f x) a l :=
+hf.comp_antimono (λ x y hx, neg_le_neg hx)
+
+lemma is_max_filter.neg (hf : is_max_filter f a l) : is_min_filter (λ x, -f x) a l :=
+hf.comp_antimono (λ x y hx, neg_le_neg hx)
+
+lemma is_extr_filter.neg (hf : is_extr_filter f a l) : is_extr_filter (λ x, -f x) a l :=
+hf.elim (λ hf, hf.neg.is_extr) (λ hf, hf.neg.is_extr)
+
+lemma is_min_on.neg (hf : is_min_on f a s) : is_max_on (λ x, -f x) a s :=
+hf.comp_antimono (λ x y hx, neg_le_neg hx)
+
+lemma is_max_on.neg (hf : is_max_on f a s) : is_min_on (λ x, -f x) a s :=
+hf.comp_antimono (λ x y hx, neg_le_neg hx)
+
+lemma is_extr_on.neg (hf : is_extr_on f a s) : is_extr_on (λ x, -f x) a s :=
+hf.elim (λ hf, hf.neg.is_extr) (λ hf, hf.neg.is_extr)
+
+lemma is_min_filter.sub (hf : is_min_filter f a l) (hg : is_max_filter g a l) :
+  is_min_filter (λ x, f x - g x) a l :=
+hf.add hg.neg
+
+lemma is_max_filter.sub (hf : is_max_filter f a l) (hg : is_min_filter g a l) :
+  is_max_filter (λ x, f x - g x) a l :=
+hf.add hg.neg
+
+lemma is_min_on.sub (hf : is_min_on f a s) (hg : is_max_on g a s) :
+  is_min_on (λ x, f x - g x) a s :=
+hf.add hg.neg
+
+lemma is_max_on.sub (hf : is_max_on f a s) (hg : is_min_on g a s) :
+  is_max_on (λ x, f x - g x) a s :=
+hf.add hg.neg
+
+end ordered_comm_group
+
+/-! ### Pointwise `sup`/`inf` -/
+
+section semilattice_sup
+
+variables [semilattice_sup β] {f g : α → β} {a : α} {s : set α} {l : filter α}
+
+lemma is_min_filter.sup (hf : is_min_filter f a l) (hg : is_min_filter g a l) :
+  is_min_filter (λ x, f x ⊔ g x) a l :=
+show is_min_filter (λ x, f x ⊔ g x) a l,
+from hf.bicomp_mono (λ x x' hx y y' hy, sup_le_sup hx hy) hg
+
+lemma is_max_filter.sup (hf : is_max_filter f a l) (hg : is_max_filter g a l) :
+  is_max_filter (λ x, f x ⊔ g x) a l :=
+show is_max_filter (λ x, f x ⊔ g x) a l,
+from hf.bicomp_mono (λ x x' hx y y' hy, sup_le_sup hx hy) hg
+
+lemma is_min_on.sup (hf : is_min_on f a s) (hg : is_min_on g a s) :
+  is_min_on (λ x, f x ⊔ g x) a s :=
+hf.sup hg
+
+lemma is_max_on.sup (hf : is_max_on f a s) (hg : is_max_on g a s) :
+  is_max_on (λ x, f x ⊔ g x) a s :=
+hf.sup hg
+
+end semilattice_sup
+
+section semilattice_inf
+
+variables [semilattice_inf β] {f g : α → β} {a : α} {s : set α} {l : filter α}
+
+lemma is_min_filter.inf (hf : is_min_filter f a l) (hg : is_min_filter g a l) :
+  is_min_filter (λ x, f x ⊓ g x) a l :=
+show is_min_filter (λ x, f x ⊓ g x) a l,
+from hf.bicomp_mono (λ x x' hx y y' hy, inf_le_inf hx hy) hg
+
+lemma is_max_filter.inf (hf : is_max_filter f a l) (hg : is_max_filter g a l) :
+  is_max_filter (λ x, f x ⊓ g x) a l :=
+show is_max_filter (λ x, f x ⊓ g x) a l,
+from hf.bicomp_mono (λ x x' hx y y' hy, inf_le_inf hx hy) hg
+
+lemma is_min_on.inf (hf : is_min_on f a s) (hg : is_min_on g a s) :
+  is_min_on (λ x, f x ⊓ g x) a s :=
+hf.inf hg
+
+lemma is_max_on.inf (hf : is_max_on f a s) (hg : is_max_on g a s) :
+  is_max_on (λ x, f x ⊓ g x) a s :=
+hf.inf hg
+
+end semilattice_inf
+
+/-! ### Pointwise `min`/`max` -/
+
+section decidable_linear_order
+
+variables [decidable_linear_order β] {f g : α → β} {a : α} {s : set α} {l : filter α}
+
+lemma is_min_filter.min (hf : is_min_filter f a l) (hg : is_min_filter g a l) :
+  is_min_filter (λ x, min (f x) (g x)) a l :=
+show is_min_filter (λ x, min (f x) (g x)) a l,
+from hf.bicomp_mono (λ x x' hx y y' hy, min_le_min hx hy) hg
+
+lemma is_max_filter.min (hf : is_max_filter f a l) (hg : is_max_filter g a l) :
+  is_max_filter (λ x, min (f x) (g x)) a l :=
+show is_max_filter (λ x, min (f x) (g x)) a l,
+from hf.bicomp_mono (λ x x' hx y y' hy, min_le_min hx hy) hg
+
+lemma is_min_on.min (hf : is_min_on f a s) (hg : is_min_on g a s) :
+  is_min_on (λ x, min (f x) (g x)) a s :=
+hf.min hg
+
+lemma is_max_on.min (hf : is_max_on f a s) (hg : is_max_on g a s) :
+  is_max_on (λ x, min (f x) (g x)) a s :=
+hf.min hg
+
+lemma is_min_filter.max (hf : is_min_filter f a l) (hg : is_min_filter g a l) :
+  is_min_filter (λ x, max (f x) (g x)) a l :=
+show is_min_filter (λ x, max (f x) (g x)) a l,
+from hf.bicomp_mono (λ x x' hx y y' hy, max_le_max hx hy) hg
+
+lemma is_max_filter.max (hf : is_max_filter f a l) (hg : is_max_filter g a l) :
+  is_max_filter (λ x, max (f x) (g x)) a l :=
+show is_max_filter (λ x, max (f x) (g x)) a l,
+from hf.bicomp_mono (λ x x' hx y y' hy, max_le_max hx hy) hg
+
+lemma is_min_on.max (hf : is_min_on f a s) (hg : is_min_on g a s) :
+  is_min_on (λ x, max (f x) (g x)) a s :=
+hf.max hg
+
+lemma is_max_on.max (hf : is_max_on f a s) (hg : is_max_on g a s) :
+  is_max_on (λ x, max (f x) (g x)) a s :=
+hf.max hg
+
+end decidable_linear_order

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -1112,7 +1112,7 @@ end densely_ordered
 
 /-- The extreme value theorem: a continuous function realizes its minimum on a compact set -/
 lemma compact.exists_forall_le {α : Type u} [topological_space α]
-  {s : set α} (hs : compact s) (ne_s : s ≠ ∅) (f : α → β) (hf : continuous_on f s) :
+  {s : set α} (hs : compact s) (ne_s : s ≠ ∅) {f : α → β} (hf : continuous_on f s) :
   ∃x∈s, ∀y∈s, f x ≤ f y :=
 begin
   have C : compact (f '' s) := hs.image_of_continuous_on hf,

--- a/src/topology/local_extr.lean
+++ b/src/topology/local_extr.lean
@@ -8,11 +8,26 @@ import order.filter.extr topology.continuous_on
 
 /-! # Local extrema of functions on topological spaces
 
+## Main definitions
+
 This file defines special versions of `is_*_filter f a l`, `*=min/max/extr`,
 from `order/filter/extr` for two kinds of filters: `nhds_within` and `nhds`.
+These versions are called `is_local_*_on` and `is_local_*`, respectively.
 
-Most statements in this file repeat those from `order/filter/extr`, and are needed only to make
-dot notation return output of a correct type instead of just `is_min/max_filter`.
+## Main statements
+
+Many lemmas in this file restate those from `order/filter/extr`, and you can find
+a detailed documentation there. These convenience lemmas are provided only to make the dot notation
+return propositions of expected types, not just `is_*_filter`.
+
+Here is the list of statements specific to these two types of filters:
+
+* `is_local_*.on`, `is_local_*_on.on_subset`: restrict to a subset;
+* `is_local_*_on.inter` : intersect the set with another one;
+* `is_*_on.localize` : a global extremum is a local extremum too.
+* `is_[local_]*_on.is_local_*` : if we have `is_local_*_on f s a` and `s ∈ 𝓝 a`,
+  then we have `is_local_* f a`.
+
 -/
 
 universes u v w x
@@ -86,13 +101,13 @@ hf.on_subset (inter_subset_left s t)
 lemma is_local_extr_on.inter (hf : is_local_extr_on f s a) (t) : is_local_extr_on f (s ∩ t) a :=
 hf.on_subset (inter_subset_left s t)
 
-lemma is_min_on.is_local_min_on (hf : is_min_on f s a) : is_local_min_on f s a :=
+lemma is_min_on.localize (hf : is_min_on f s a) : is_local_min_on f s a :=
 hf.filter_mono $ lattice.inf_le_right
 
-lemma is_max_on.is_local_max_on (hf : is_max_on f s a) : is_local_max_on f s a :=
+lemma is_max_on.localize (hf : is_max_on f s a) : is_local_max_on f s a :=
 hf.filter_mono $ lattice.inf_le_right
 
-lemma is_extr_on.is_local_extr_on (hf : is_extr_on f s a) : is_local_extr_on f s a :=
+lemma is_extr_on.localize (hf : is_extr_on f s a) : is_local_extr_on f s a :=
 hf.filter_mono $ lattice.inf_le_right
 
 lemma is_local_min_on.is_local_min (hf : is_local_min_on f s a) (hs : s ∈ 𝓝 a) : is_local_min f a :=
@@ -107,13 +122,13 @@ lemma is_local_extr_on.is_local_extr (hf : is_local_extr_on f s a) (hs : s ∈ �
 hf.elim (λ hf, (hf.is_local_min hs).is_extr) (λ hf, (hf.is_local_max hs).is_extr)
 
 lemma is_min_on.is_local_min (hf : is_min_on f s a) (hs : s ∈ 𝓝 a) : is_local_min f a :=
-hf.is_local_min_on.is_local_min hs
+hf.localize.is_local_min hs
 
 lemma is_max_on.is_local_max (hf : is_max_on f s a) (hs : s ∈ 𝓝 a) : is_local_max f a :=
-hf.is_local_max_on.is_local_max hs
+hf.localize.is_local_max hs
 
 lemma is_extr_on.is_local_extr (hf : is_extr_on f s a) (hs : s ∈ 𝓝 a) : is_local_extr f a :=
-hf.is_local_extr_on.is_local_extr hs
+hf.localize.is_local_extr hs
 
 /-! ### Constant -/
 

--- a/src/topology/local_extr.lean
+++ b/src/topology/local_extr.lean
@@ -24,74 +24,102 @@ open_locale topological_space
 
 section preorder
 
-variables [preorder β] [preorder γ] (f : α → β) (a : α) (s : set α)
+variables [preorder β] [preorder γ] (f : α → β) (s : set α) (a : α)
 
-/-- `is_local_min_on f a s` means that `f a ≤ f x` for all `x ∈ s` in some neighborhood of `a`. -/
-def is_local_min_on := is_min_filter f a (nhds_within a s)
+/-- `is_local_min_on f s a` means that `f a ≤ f x` for all `x ∈ s` in some neighborhood of `a`. -/
+def is_local_min_on := is_min_filter f (nhds_within a s) a
 
-/-- `is_local_max_on f a s` means that `f x ≤ f a` for all `x ∈ s` in some neighborhood of `a`. -/
-def is_local_max_on := is_max_filter f a (nhds_within a s)
+/-- `is_local_max_on f s a` means that `f x ≤ f a` for all `x ∈ s` in some neighborhood of `a`. -/
+def is_local_max_on := is_max_filter f (nhds_within a s) a
 
-/-- `is_local_extr_on f a s` means `is_local_min_on f a s ∨ is_local_max_on f a s`. -/
-def is_local_extr_on := is_extr_filter f a (nhds_within a s)
+/-- `is_local_extr_on f s a` means `is_local_min_on f s a ∨ is_local_max_on f s a`. -/
+def is_local_extr_on := is_extr_filter f (nhds_within a s) a
 
 /-- `is_local_min f a` means that `f a ≤ f x` for all `x` in some neighborhood of `a`. -/
-def is_local_min := is_min_filter f a (𝓝 a)
+def is_local_min := is_min_filter f (𝓝 a) a
 
 /-- `is_local_max f a` means that `f x ≤ f a` for all `x ∈ s` in some neighborhood of `a`. -/
-def is_local_max := is_max_filter f a (𝓝 a)
+def is_local_max := is_max_filter f (𝓝 a) a
 
-/-- `is_local_extr_on f a s` means `is_local_min_on f a s ∨ is_local_max_on f a s`. -/
-def is_local_extr := is_extr_filter f a (𝓝 a)
+/-- `is_local_extr_on f s a` means `is_local_min_on f s a ∨ is_local_max_on f s a`. -/
+def is_local_extr := is_extr_filter f (𝓝 a) a
 
-variables {f a s}
+variables {f s a}
 
 lemma is_local_extr_on.elim {p : Prop} :
-  is_local_extr_on f a s → (is_local_min_on f a s → p) → (is_local_max_on f a s → p) → p :=
+  is_local_extr_on f s a → (is_local_min_on f s a → p) → (is_local_max_on f s a → p) → p :=
 or.elim
 
 lemma is_local_extr.elim {p : Prop} :
   is_local_extr f a → (is_local_min f a → p) → (is_local_max f a → p) → p :=
 or.elim
 
-
 /-! ### Restriction to (sub)sets -/
 
-lemma is_local_min.on (h : is_local_min f a) (s) : is_local_min_on f a s :=
+lemma is_local_min.on (h : is_local_min f a) (s) : is_local_min_on f s a :=
 h.filter_inf _
 
-lemma is_local_max.on (h : is_local_max f a) (s) : is_local_max_on f a s :=
+lemma is_local_max.on (h : is_local_max f a) (s) : is_local_max_on f s a :=
 h.filter_inf _
 
-lemma is_local_extr.on (h : is_local_extr f a) (s) : is_local_extr_on f a s :=
+lemma is_local_extr.on (h : is_local_extr f a) (s) : is_local_extr_on f s a :=
 h.filter_inf _
 
-lemma is_local_min_on.on_subset {t : set α} (hf : is_local_min_on f a t) (h : s ⊆ t) :
-  is_local_min_on f a s :=
+lemma is_local_min_on.on_subset {t : set α} (hf : is_local_min_on f t a) (h : s ⊆ t) :
+  is_local_min_on f s a :=
 hf.filter_mono $ nhds_within_mono a h
 
-lemma is_local_max_on.on_subset {t : set α} (hf : is_local_max_on f a t) (h : s ⊆ t) :
-  is_local_max_on f a s :=
+lemma is_local_max_on.on_subset {t : set α} (hf : is_local_max_on f t a) (h : s ⊆ t) :
+  is_local_max_on f s a :=
 hf.filter_mono $ nhds_within_mono a h
 
-lemma is_local_extr_on.on_subset {t : set α} (hf : is_local_extr_on f a t) (h : s ⊆ t) :
-  is_local_extr_on f a s :=
+lemma is_local_extr_on.on_subset {t : set α} (hf : is_local_extr_on f t a) (h : s ⊆ t) :
+  is_local_extr_on f s a :=
 hf.filter_mono $ nhds_within_mono a h
 
-lemma is_local_min_on.inter (hf : is_local_min_on f a s) (t) : is_local_min_on f a (s ∩ t) :=
+lemma is_local_min_on.inter (hf : is_local_min_on f s a) (t) : is_local_min_on f (s ∩ t) a :=
 hf.on_subset (inter_subset_left s t)
 
-lemma is_local_max_on.inter (hf : is_local_max_on f a s) (t) : is_local_max_on f a (s ∩ t) :=
+lemma is_local_max_on.inter (hf : is_local_max_on f s a) (t) : is_local_max_on f (s ∩ t) a :=
 hf.on_subset (inter_subset_left s t)
 
-lemma is_local_extr_on.inter (hf : is_local_extr_on f a s) (t) : is_local_extr_on f a (s ∩ t) :=
+lemma is_local_extr_on.inter (hf : is_local_extr_on f s a) (t) : is_local_extr_on f (s ∩ t) a :=
 hf.on_subset (inter_subset_left s t)
+
+lemma is_min_on.is_local_min_on (hf : is_min_on f s a) : is_local_min_on f s a :=
+hf.filter_mono $ lattice.inf_le_right
+
+lemma is_max_on.is_local_max_on (hf : is_max_on f s a) : is_local_max_on f s a :=
+hf.filter_mono $ lattice.inf_le_right
+
+lemma is_extr_on.is_local_extr_on (hf : is_extr_on f s a) : is_local_extr_on f s a :=
+hf.filter_mono $ lattice.inf_le_right
+
+lemma is_local_min_on.is_local_min (hf : is_local_min_on f s a) (hs : s ∈ 𝓝 a) : is_local_min f a :=
+have 𝓝 a ≤ principal s, from le_principal_iff.2 hs,
+hf.filter_mono $ lattice.le_inf (le_refl _) this
+
+lemma is_local_max_on.is_local_max (hf : is_local_max_on f s a) (hs : s ∈ 𝓝 a) : is_local_max f a :=
+have 𝓝 a ≤ principal s, from le_principal_iff.2 hs,
+hf.filter_mono $ lattice.le_inf (le_refl _) this
+
+lemma is_local_extr_on.is_local_extr (hf : is_local_extr_on f s a) (hs : s ∈ 𝓝 a) : is_local_extr f a :=
+hf.elim (λ hf, (hf.is_local_min hs).is_extr) (λ hf, (hf.is_local_max hs).is_extr)
+
+lemma is_min_on.is_local_min (hf : is_min_on f s a) (hs : s ∈ 𝓝 a) : is_local_min f a :=
+hf.is_local_min_on.is_local_min hs
+
+lemma is_max_on.is_local_max (hf : is_max_on f s a) (hs : s ∈ 𝓝 a) : is_local_max f a :=
+hf.is_local_max_on.is_local_max hs
+
+lemma is_extr_on.is_local_extr (hf : is_extr_on f s a) (hs : s ∈ 𝓝 a) : is_local_extr f a :=
+hf.is_local_extr_on.is_local_extr hs
 
 /-! ### Constant -/
 
-lemma is_local_min_on_const {b : β} : is_local_min_on (λ _, b) a s := is_min_filter_const
-lemma is_local_max_on_const {b : β} : is_local_max_on (λ _, b) a s := is_max_filter_const
-lemma is_local_extr_on_const {b : β} : is_local_extr_on (λ _, b) a s := is_extr_filter_const
+lemma is_local_min_on_const {b : β} : is_local_min_on (λ _, b) s a := is_min_filter_const
+lemma is_local_max_on_const {b : β} : is_local_max_on (λ _, b) s a := is_max_filter_const
+lemma is_local_extr_on_const {b : β} : is_local_extr_on (λ _, b) s a := is_extr_filter_const
 
 lemma is_local_min_const {b : β} : is_local_min (λ _, b) a := is_min_filter_const
 lemma is_local_max_const {b : β} : is_local_max (λ _, b) a := is_max_filter_const
@@ -126,31 +154,31 @@ lemma is_local_extr.comp_antimono (hf : is_local_extr f a) {g : β → γ}
   is_local_extr (g ∘ f) a :=
 hf.comp_antimono hg
 
-lemma is_local_min_on.comp_mono (hf : is_local_min_on f a s) {g : β → γ} (hg : monotone g) :
-  is_local_min_on (g ∘ f) a s :=
+lemma is_local_min_on.comp_mono (hf : is_local_min_on f s a) {g : β → γ} (hg : monotone g) :
+  is_local_min_on (g ∘ f) s a :=
 hf.comp_mono hg
 
-lemma is_local_max_on.comp_mono (hf : is_local_max_on f a s) {g : β → γ} (hg : monotone g) :
-  is_local_max_on (g ∘ f) a s :=
+lemma is_local_max_on.comp_mono (hf : is_local_max_on f s a) {g : β → γ} (hg : monotone g) :
+  is_local_max_on (g ∘ f) s a :=
 hf.comp_mono hg
 
-lemma is_local_extr_on.comp_mono (hf : is_local_extr_on f a s) {g : β → γ} (hg : monotone g) :
-  is_local_extr_on (g ∘ f) a s :=
+lemma is_local_extr_on.comp_mono (hf : is_local_extr_on f s a) {g : β → γ} (hg : monotone g) :
+  is_local_extr_on (g ∘ f) s a :=
 hf.comp_mono hg
 
-lemma is_local_min_on.comp_antimono (hf : is_local_min_on f a s) {g : β → γ}
+lemma is_local_min_on.comp_antimono (hf : is_local_min_on f s a) {g : β → γ}
   (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
-  is_local_max_on (g ∘ f) a s :=
+  is_local_max_on (g ∘ f) s a :=
 hf.comp_antimono hg
 
-lemma is_local_max_on.comp_antimono (hf : is_local_max_on f a s) {g : β → γ}
+lemma is_local_max_on.comp_antimono (hf : is_local_max_on f s a) {g : β → γ}
   (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
-  is_local_min_on (g ∘ f) a s :=
+  is_local_min_on (g ∘ f) s a :=
 hf.comp_antimono hg
 
-lemma is_local_extr_on.comp_antimono (hf : is_local_extr_on f a s) {g : β → γ}
+lemma is_local_extr_on.comp_antimono (hf : is_local_extr_on f s a) {g : β → γ}
   (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
-  is_local_extr_on (g ∘ f) a s :=
+  is_local_extr_on (g ∘ f) s a :=
 hf.comp_antimono hg
 
 lemma is_local_min.bicomp_mono [preorder δ] {op : β → γ → δ} (hop : ((≤) ⇒ (≤) ⇒ (≤)) op op)
@@ -166,13 +194,13 @@ hf.bicomp_mono hop hg
 -- No `extr` version because we need `hf` and `hg` to be of the same kind
 
 lemma is_local_min_on.bicomp_mono [preorder δ] {op : β → γ → δ} (hop : ((≤) ⇒ (≤) ⇒ (≤)) op op)
-  (hf : is_local_min_on f a s) {g : α → γ} (hg : is_local_min_on g a s) :
-  is_local_min_on (λ x, op (f x) (g x)) a s :=
+  (hf : is_local_min_on f s a) {g : α → γ} (hg : is_local_min_on g s a) :
+  is_local_min_on (λ x, op (f x) (g x)) s a :=
 hf.bicomp_mono hop hg
 
 lemma is_local_max_on.bicomp_mono [preorder δ] {op : β → γ → δ} (hop : ((≤) ⇒ (≤) ⇒ (≤)) op op)
-  (hf : is_local_max_on f a s) {g : α → γ} (hg : is_local_max_on g a s) :
-  is_local_max_on (λ x, op (f x) (g x)) a s :=
+  (hf : is_local_max_on f s a) {g : α → γ} (hg : is_local_max_on g s a) :
+  is_local_max_on (λ x, op (f x) (g x)) s a :=
 hf.bicomp_mono hop hg
 
 /-! ### Composition with `continuous_at` -/
@@ -194,17 +222,17 @@ hf.comp_tendsto hg
 
 lemma is_local_min.comp_continuous_on [topological_space δ] {s : set δ} {g : δ → α} {b : δ}
   (hf : is_local_min f (g b)) (hg : continuous_on g s) (hb : b ∈ s) :
-  is_local_min_on (f ∘ g) b s :=
+  is_local_min_on (f ∘ g) s b :=
 hf.comp_tendsto (hg b hb)
 
 lemma is_local_max.comp_continuous_on [topological_space δ] {s : set δ} {g : δ → α} {b : δ}
   (hf : is_local_max f (g b)) (hg : continuous_on g s) (hb : b ∈ s) :
-  is_local_max_on (f ∘ g) b s :=
+  is_local_max_on (f ∘ g) s b :=
 hf.comp_tendsto (hg b hb)
 
 lemma is_local_extr.comp_continuous_on [topological_space δ] {s : set δ} (g : δ → α) {b : δ}
   (hf : is_local_extr f (g b)) (hg : continuous_on g s) (hb : b ∈ s) :
-  is_local_extr_on (f ∘ g) b s :=
+  is_local_extr_on (f ∘ g) s b :=
 hf.elim (λ hf, (hf.comp_continuous_on hg hb).is_extr)
   (λ hf, (is_local_max.comp_continuous_on hf hg hb).is_extr)
 
@@ -223,12 +251,12 @@ lemma is_local_max.add (hf : is_local_max f a) (hg : is_local_max g a) :
   is_local_max (λ x, f x + g x) a :=
 hf.add hg
 
-lemma is_local_min_on.add (hf : is_local_min_on f a s) (hg : is_local_min_on g a s) :
-  is_local_min_on (λ x, f x + g x) a s :=
+lemma is_local_min_on.add (hf : is_local_min_on f s a) (hg : is_local_min_on g s a) :
+  is_local_min_on (λ x, f x + g x) s a :=
 hf.add hg
 
-lemma is_local_max_on.add (hf : is_local_max_on f a s) (hg : is_local_max_on g a s) :
-  is_local_max_on (λ x, f x + g x) a s :=
+lemma is_local_max_on.add (hf : is_local_max_on f s a) (hg : is_local_max_on g s a) :
+  is_local_max_on (λ x, f x + g x) s a :=
 hf.add hg
 
 end ordered_comm_monoid
@@ -248,13 +276,13 @@ hf.neg
 lemma is_local_extr.neg (hf : is_local_extr f a) : is_local_extr (λ x, -f x) a :=
 hf.neg
 
-lemma is_local_min_on.neg (hf : is_local_min_on f a s) : is_local_max_on (λ x, -f x) a s :=
+lemma is_local_min_on.neg (hf : is_local_min_on f s a) : is_local_max_on (λ x, -f x) s a :=
 hf.neg
 
-lemma is_local_max_on.neg (hf : is_local_max_on f a s) : is_local_min_on (λ x, -f x) a s :=
+lemma is_local_max_on.neg (hf : is_local_max_on f s a) : is_local_min_on (λ x, -f x) s a :=
 hf.neg
 
-lemma is_local_extr_on.neg (hf : is_local_extr_on f a s) : is_local_extr_on (λ x, -f x) a s :=
+lemma is_local_extr_on.neg (hf : is_local_extr_on f s a) : is_local_extr_on (λ x, -f x) s a :=
 hf.neg
 
 lemma is_local_min.sub (hf : is_local_min f a) (hg : is_local_max g a) :
@@ -265,12 +293,12 @@ lemma is_local_max.sub (hf : is_local_max f a) (hg : is_local_min g a) :
   is_local_max (λ x, f x - g x) a :=
 hf.sub hg
 
-lemma is_local_min_on.sub (hf : is_local_min_on f a s) (hg : is_local_max_on g a s) :
-  is_local_min_on (λ x, f x - g x) a s :=
+lemma is_local_min_on.sub (hf : is_local_min_on f s a) (hg : is_local_max_on g s a) :
+  is_local_min_on (λ x, f x - g x) s a :=
 hf.sub hg
 
-lemma is_local_max_on.sub (hf : is_local_max_on f a s) (hg : is_local_min_on g a s) :
-  is_local_max_on (λ x, f x - g x) a s :=
+lemma is_local_max_on.sub (hf : is_local_max_on f s a) (hg : is_local_min_on g s a) :
+  is_local_max_on (λ x, f x - g x) s a :=
 hf.sub hg
 
 end ordered_comm_group
@@ -291,12 +319,12 @@ lemma is_local_max.sup (hf : is_local_max f a) (hg : is_local_max g a) :
   is_local_max (λ x, f x ⊔ g x) a :=
 hf.sup hg
 
-lemma is_local_min_on.sup (hf : is_local_min_on f a s) (hg : is_local_min_on g a s) :
-  is_local_min_on (λ x, f x ⊔ g x) a s :=
+lemma is_local_min_on.sup (hf : is_local_min_on f s a) (hg : is_local_min_on g s a) :
+  is_local_min_on (λ x, f x ⊔ g x) s a :=
 hf.sup hg
 
-lemma is_local_max_on.sup (hf : is_local_max_on f a s) (hg : is_local_max_on g a s) :
-  is_local_max_on (λ x, f x ⊔ g x) a s :=
+lemma is_local_max_on.sup (hf : is_local_max_on f s a) (hg : is_local_max_on g s a) :
+  is_local_max_on (λ x, f x ⊔ g x) s a :=
 hf.sup hg
 
 end semilattice_sup
@@ -313,12 +341,12 @@ lemma is_local_max.inf (hf : is_local_max f a) (hg : is_local_max g a) :
   is_local_max (λ x, f x ⊓ g x) a :=
 hf.inf hg
 
-lemma is_local_min_on.inf (hf : is_local_min_on f a s) (hg : is_local_min_on g a s) :
-  is_local_min_on (λ x, f x ⊓ g x) a s :=
+lemma is_local_min_on.inf (hf : is_local_min_on f s a) (hg : is_local_min_on g s a) :
+  is_local_min_on (λ x, f x ⊓ g x) s a :=
 hf.inf hg
 
-lemma is_local_max_on.inf (hf : is_local_max_on f a s) (hg : is_local_max_on g a s) :
-  is_local_max_on (λ x, f x ⊓ g x) a s :=
+lemma is_local_max_on.inf (hf : is_local_max_on f s a) (hg : is_local_max_on g s a) :
+  is_local_max_on (λ x, f x ⊓ g x) s a :=
 hf.inf hg
 
 end semilattice_inf
@@ -337,12 +365,12 @@ lemma is_local_max.min (hf : is_local_max f a) (hg : is_local_max g a) :
   is_local_max (λ x, min (f x) (g x)) a :=
 hf.min hg
 
-lemma is_local_min_on.min (hf : is_local_min_on f a s) (hg : is_local_min_on g a s) :
-  is_local_min_on (λ x, min (f x) (g x)) a s :=
+lemma is_local_min_on.min (hf : is_local_min_on f s a) (hg : is_local_min_on g s a) :
+  is_local_min_on (λ x, min (f x) (g x)) s a :=
 hf.min hg
 
-lemma is_local_max_on.min (hf : is_local_max_on f a s) (hg : is_local_max_on g a s) :
-  is_local_max_on (λ x, min (f x) (g x)) a s :=
+lemma is_local_max_on.min (hf : is_local_max_on f s a) (hg : is_local_max_on g s a) :
+  is_local_max_on (λ x, min (f x) (g x)) s a :=
 hf.min hg
 
 lemma is_local_min.max (hf : is_local_min f a) (hg : is_local_min g a) :
@@ -353,12 +381,12 @@ lemma is_local_max.max (hf : is_local_max f a) (hg : is_local_max g a) :
   is_local_max (λ x, max (f x) (g x)) a :=
 hf.max hg
 
-lemma is_local_min_on.max (hf : is_local_min_on f a s) (hg : is_local_min_on g a s) :
-  is_local_min_on (λ x, max (f x) (g x)) a s :=
+lemma is_local_min_on.max (hf : is_local_min_on f s a) (hg : is_local_min_on g s a) :
+  is_local_min_on (λ x, max (f x) (g x)) s a :=
 hf.max hg
 
-lemma is_local_max_on.max (hf : is_local_max_on f a s) (hg : is_local_max_on g a s) :
-  is_local_max_on (λ x, max (f x) (g x)) a s :=
+lemma is_local_max_on.max (hf : is_local_max_on f s a) (hg : is_local_max_on g s a) :
+  is_local_max_on (λ x, max (f x) (g x)) s a :=
 hf.max hg
 
 end decidable_linear_order

--- a/src/topology/metric_space/gromov_hausdorff_realized.lean
+++ b/src/topology/metric_space/gromov_hausdorff_realized.lean
@@ -401,7 +401,7 @@ variables (α : Type u) (β : Type v) [metric_space α] [compact_space α] [none
 we can finally select a candidate minimizing HD. This will be the candidate realizing the
 optimal coupling. -/
 private lemma exists_minimizer : ∃f ∈ candidates_b α β, ∀g ∈ candidates_b α β, HD f ≤ HD g :=
-compact_candidates_b.exists_forall_le candidates_b_ne_empty _ HD_continuous.continuous_on
+compact_candidates_b.exists_forall_le candidates_b_ne_empty HD_continuous.continuous_on
 
 private definition optimal_GH_dist : Cb α β := classical.some (exists_minimizer α β)
 


### PR DESCRIPTION
Should be ready now.

`pos_tangent_cone_at` is here for the case if someone (me? someone else?) will formalize [Lagrange multipliers](https://en.wikipedia.org/wiki/Lagrange_multiplier) and/or [Karush–Kuhn–Tucker conditions](https://en.wikipedia.org/wiki/Karush%E2%80%93Kuhn%E2%80%93Tucker_conditions).

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)