### PR TITLE
refactor(topology/*): use dot notation with `compact`, prove `compact.image` with `continuous_on`

### DIFF
--- a/src/analysis/complex/polynomial.lean
+++ b/src/analysis/complex/polynomial.lean
@@ -13,10 +13,9 @@ lemma exists_forall_abs_polynomial_eval_le (p : polynomial ℂ) :
   ∃ x, ∀ y, (p.eval x).abs ≤ (p.eval y).abs :=
 if hp0 : 0 < degree p
 then let ⟨r, hr0, hr⟩ := polynomial.tendsto_infinity complex.abs hp0 ((p.eval 0).abs) in
-  let ⟨x, hx₁, hx₂⟩ := exists_forall_le_of_compact_of_continuous (λ y, (p.eval y).abs)
-    (continuous_abs.comp p.continuous_eval)
-    (closed_ball 0 r) (proper_space.compact_ball _ _)
-    (set.ne_empty_iff_exists_mem.2 ⟨0, by simp [le_of_lt hr0]⟩) in
+  let ⟨x, hx₁, hx₂⟩ := (proper_space.compact_ball (0:ℂ) r).exists_forall_le
+    (set.ne_empty_iff_exists_mem.2 ⟨0, by simp [le_of_lt hr0]⟩)
+    (λ z, abs (p.eval z)) (continuous_abs.comp p.continuous_eval).continuous_on in
   ⟨x, λ y, if hy : y.abs ≤ r then hx₂ y $ by simpa [complex.dist_eq] using hy
     else le_trans (hx₂ _ (by simp [le_of_lt hr0])) (le_of_lt (hr y (lt_of_not_ge hy)))⟩
 else ⟨p.coeff 0, by rw [eq_C_of_degree_le_zero (le_of_not_gt hp0)]; simp⟩

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1162,7 +1162,7 @@ eq_univ_iff_forall
 theorem range_inl_union_range_inr : range (@sum.inl α β) ∪ range sum.inr = univ :=
 ext $ λ x, by cases x; simp
 
-theorem range_quot_mk (r : α → α → Prop) : range (quot.mk r) = univ :=
+@[simp] theorem range_quot_mk (r : α → α → Prop) : range (quot.mk r) = univ :=
 range_iff_surjective.2 quot.exists_rep
 
 @[simp] theorem image_univ {ι : Type*} {f : ι → β} : f '' univ = range f :=

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1159,6 +1159,12 @@ eq_univ_iff_forall
 
 @[simp] theorem range_id : range (@id α) = univ := range_iff_surjective.2 surjective_id
 
+theorem range_inl_union_range_inr : range (@sum.inl α β) ∪ range sum.inr = univ :=
+ext $ λ x, by cases x; simp
+
+theorem range_quot_mk (r : α → α → Prop) : range (quot.mk r) = univ :=
+range_iff_surjective.2 quot.exists_rep
+
 @[simp] theorem image_univ {ι : Type*} {f : ι → β} : f '' univ = range f :=
 ext $ by simp [image, range]
 

--- a/src/measure_theory/lebesgue_measure.lean
+++ b/src/measure_theory/lebesgue_measure.lean
@@ -97,9 +97,8 @@ begin
   suffices : ∀ (s:finset ℕ) b
     (cv : Icc a b ⊆ ⋃ i ∈ (↑s:set ℕ), Ioo (c i) (d i)),
     (of_real (b - a) : ennreal) ≤ s.sum (λ i, of_real (d i - c i)),
-  { rcases @compact_elim_finite_subcover_image _ _
-      _ (Icc a b) univ (λ i, Ioo (c i) (d i)) compact_Icc
-      (λ i _, is_open_Ioo) (by simpa using ss) with ⟨s, su, hf, hs⟩,
+  { rcases compact_Icc.elim_finite_subcover_image (λ (i : ℕ) (_ : i ∈ univ) ,
+      @is_open_Ioo _ _ _ _ (c i) (d i)) (by simpa using ss) with ⟨s, su, hf, hs⟩,
     have e : (⋃ i ∈ (↑hf.to_finset:set ℕ),
       Ioo (c i) (d i)) = (⋃ i ∈ s, Ioo (c i) (d i)), {simp [set.ext_iff]},
     rw ennreal.tsum_eq_supr_sum,

--- a/src/measure_theory/lebesgue_measure.lean
+++ b/src/measure_theory/lebesgue_measure.lean
@@ -97,7 +97,7 @@ begin
   suffices : ∀ (s:finset ℕ) b
     (cv : Icc a b ⊆ ⋃ i ∈ (↑s:set ℕ), Ioo (c i) (d i)),
     (of_real (b - a) : ennreal) ≤ s.sum (λ i, of_real (d i - c i)),
-  { rcases compact_Icc.elim_finite_subcover_image (λ (i : ℕ) (_ : i ∈ univ) ,
+  { rcases compact_Icc.elim_finite_subcover_image (λ (i : ℕ) (_ : i ∈ univ),
       @is_open_Ioo _ _ _ _ (c i) (d i)) (by simpa using ss) with ⟨s, su, hf, hs⟩,
     have e : (⋃ i ∈ (↑hf.to_finset:set ℕ),
       Ioo (c i) (d i)) = (⋃ i ∈ s, Ioo (c i) (d i)), {simp [set.ext_iff]},

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -728,9 +728,7 @@ lemma gc_map_comap (m : α → β) : galois_connection (map m) (comap m) :=
 assume f g, map_le_iff_le_comap
 
 lemma map_mono : monotone (map m) := (gc_map_comap m).monotone_l
-lemma monotone_map (m : α → β) : monotone (map m) := map_mono
 lemma comap_mono : monotone (comap m) := (gc_map_comap m).monotone_u
-lemma monotone_comap (m : α → β) : monotone (comap m) := comap_mono
 
 @[simp] lemma map_bot : map m ⊥ = ⊥ := (gc_map_comap m).l_bot
 @[simp] lemma map_sup : map m (f₁ ⊔ f₂) = map m f₁ ⊔ map m f₂ := (gc_map_comap m).l_sup
@@ -763,7 +761,7 @@ le_antisymm
         assume i,
         exact (ht i).2
       end⟩)
-  (supr_le $ assume i, monotone_comap $ le_supr _ _)
+  (supr_le $ assume i, comap_mono $ le_supr _ _)
 
 lemma comap_Sup {s : set (filter β)} {m : α → β} : comap m (Sup s) = (⨆f∈s, comap m f) :=
 by simp only [Sup_eq_supr, comap_supr, eq_self_iff_true]
@@ -774,7 +772,7 @@ le_antisymm
     ⟨t₁ ∪ t₂,
       ⟨g₁.sets_of_superset ht₁ (subset_union_left _ _), g₂.sets_of_superset ht₂ (subset_union_right _ _)⟩,
       union_subset hs₁ hs₂⟩)
-  (sup_le (comap_mono le_sup_left) (comap_mono le_sup_right))
+  ((@comap_mono _ _ m).le_map_sup _ _)
 
 lemma map_comap {f : filter β} {m : α → β} (hf : range m ∈ f) : (f.comap m).map m = f :=
 le_antisymm
@@ -803,7 +801,7 @@ this ▸ hb
 lemma le_of_map_le_map_inj_iff {f g : filter α} {m : α → β} {s : set α}
   (hsf : s ∈ f) (hsg : s ∈ g) (hm : ∀x∈s, ∀y∈s, m x = m y → x = y) :
   map m f ≤ map m g ↔ f ≤ g :=
-iff.intro (le_of_map_le_map_inj' hsf hsg hm) map_mono
+iff.intro (le_of_map_le_map_inj' hsf hsg hm) (λ h, map_mono h)
 
 lemma eq_of_map_eq_map_inj' {f g : filter α} {m : α → β} {s : set α}
   (hsf : s ∈ f) (hsg : s ∈ g) (hm : ∀x∈s, ∀y∈s, m x = m y → x = y)
@@ -926,10 +924,13 @@ calc map m (⨅i (h : p i), f i) = map m (⨅i:subtype p, f i.val) : by simp onl
     ⟨⟨i, hi⟩⟩
   ... = (⨅i (h : p i), map m (f i)) : by simp only [infi_subtype, eq_self_iff_true]
 
+lemma map_inf_le {f g : filter α} {m : α → β} : map m (f ⊓ g) ≤ map m f ⊓ map m g :=
+(@map_mono _ _ m).map_inf_le f g
+
 lemma map_inf' {f g : filter α} {m : α → β} {t : set α} (htf : t ∈ f) (htg : t ∈ g)
   (h : ∀x∈t, ∀y∈t, m x = m y → x = y) : map m (f ⊓ g) = map m f ⊓ map m g :=
 begin
-  refine le_antisymm ((monotone_map m).map_inf_le _ _) (assume s hs, _),
+  refine le_antisymm map_inf_le (assume s hs, _),
   simp only [map, mem_inf_sets, exists_prop, mem_map, mem_preimage, mem_inf_sets] at hs ⊢,
   rcases hs with ⟨t₁, h₁, t₂, h₂, hs⟩,
   refine ⟨m '' (t₁ ∩ t), _, m '' (t₂ ∩ t), _, _⟩,

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -727,10 +727,10 @@ lemma map_le_iff_le_comap : map m f ≤ g ↔ f ≤ comap m g :=
 lemma gc_map_comap (m : α → β) : galois_connection (map m) (comap m) :=
 assume f g, map_le_iff_le_comap
 
-lemma map_mono (h : f₁ ≤ f₂) : map m f₁ ≤ map m f₂ := (gc_map_comap m).monotone_l h
-lemma monotone_map : monotone (map m) | a b := map_mono
-lemma comap_mono (h : g₁ ≤ g₂) : comap m g₁ ≤ comap m g₂ := (gc_map_comap m).monotone_u h
-lemma monotone_comap : monotone (comap m) | a b := comap_mono
+lemma map_mono : monotone (map m) := (gc_map_comap m).monotone_l
+lemma monotone_map (m : α → β) : monotone (map m) := map_mono
+lemma comap_mono : monotone (comap m) := (gc_map_comap m).monotone_u
+lemma monotone_comap (m : α → β) : monotone (comap m) := comap_mono
 
 @[simp] lemma map_bot : map m ⊥ = ⊥ := (gc_map_comap m).l_bot
 @[simp] lemma map_sup : map m (f₁ ⊔ f₂) = map m f₁ ⊔ map m f₂ := (gc_map_comap m).l_sup
@@ -846,13 +846,24 @@ forall_sets_neq_empty_iff_neq_bot.mp $ assume s ⟨t, ht, t_s⟩,
   let ⟨a, (ha : a ∈ preimage m t)⟩ := hm t ht in
   neq_bot_of_le_neq_bot (ne_empty_of_mem ha) t_s
 
-lemma comap_neq_bot_of_surj {f : filter β} {m : α → β}
-  (hf : f ≠ ⊥) (hm : ∀b, ∃a, m a = b) : comap m f ≠ ⊥ :=
+lemma comap_ne_bot_of_range_mem {f : filter β} {m : α → β}
+  (hf : f ≠ ⊥) (hm : range m ∈ f) : comap m f ≠ ⊥ :=
 comap_neq_bot $ assume t ht,
-  let
-    ⟨b, (hx : b ∈ t)⟩ := inhabited_of_mem_sets hf ht,
-    ⟨a, (ha : m a = b)⟩ := hm b
-  in ⟨a, ha.symm ▸ hx⟩
+  let ⟨_, ha, a, rfl⟩ := inhabited_of_mem_sets hf (inter_mem_sets ht hm)
+  in ⟨a, ha⟩
+
+lemma comap_inf_principal_ne_bot_of_image_mem {f : filter β} {m : α → β}
+  (hf : f ≠ ⊥) {s : set α} (hs : m '' s ∈ f) : (comap m f ⊓ principal s) ≠ ⊥ :=
+begin
+  refine compl_compl s ▸ mt mem_sets_of_neq_bot _,
+  rintros ⟨t, ht, hts⟩,
+  rcases inhabited_of_mem_sets hf (inter_mem_sets hs ht) with ⟨_, ⟨x, hxs, rfl⟩, hxt⟩,
+  exact absurd hxs (hts hxt)
+end
+
+lemma comap_neq_bot_of_surj {f : filter β} {m : α → β}
+  (hf : f ≠ ⊥) (hm : function.surjective m) : comap m f ≠ ⊥ :=
+comap_ne_bot_of_range_mem hf $ univ_mem_sets' hm
 
 @[simp] lemma map_eq_bot_iff : map m f = ⊥ ↔ f = ⊥ :=
 ⟨by rw [←empty_in_sets_eq_bot, ←empty_in_sets_eq_bot]; exact id,
@@ -918,9 +929,7 @@ calc map m (⨅i (h : p i), f i) = map m (⨅i:subtype p, f i.val) : by simp onl
 lemma map_inf' {f g : filter α} {m : α → β} {t : set α} (htf : t ∈ f) (htg : t ∈ g)
   (h : ∀x∈t, ∀y∈t, m x = m y → x = y) : map m (f ⊓ g) = map m f ⊓ map m g :=
 begin
-  refine le_antisymm
-    (le_inf (map_mono inf_le_left) (map_mono inf_le_right))
-    (assume s hs, _),
+  refine le_antisymm ((monotone_map m).map_inf_le _ _) (assume s hs, _),
   simp only [map, mem_inf_sets, exists_prop, mem_map, mem_preimage, mem_inf_sets] at hs ⊢,
   rcases hs with ⟨t₁, h₁, t₂, h₂, hs⟩,
   refine ⟨m '' (t₁ ∩ t), _, m '' (t₂ ∩ t), _, _⟩,
@@ -932,9 +941,9 @@ begin
     { exact λ x ⟨_, hx⟩ y ⟨_, hy⟩, h x hx y hy } }
 end
 
-lemma map_inf {f g : filter α} {m : α → β} (h : ∀ x y, m x = m y → x = y) :
+lemma map_inf {f g : filter α} {m : α → β} (h : function.injective m) :
   map m (f ⊓ g) = map m f ⊓ map m g :=
-map_inf' univ_mem_sets univ_mem_sets (assume x _ y _, h x y)
+map_inf' univ_mem_sets univ_mem_sets (assume x _ y _ hxy, h hxy)
 
 lemma map_eq_comap_of_inverse {f : filter α} {m : α → β} {n : β → α}
   (h₁ : m ∘ n = id) (h₂ : n ∘ m = id) : map m f = comap n f :=
@@ -1185,6 +1194,10 @@ lemma tendsto_le_right {f : α → β} {x : filter α} {y z : filter β}
   (h₁ : y ≤ z) (h₂ : tendsto f x y) : tendsto f x z :=
 le_trans h₂ h₁
 
+lemma tendsto.ne_bot {f : α → β} {x : filter α} {y : filter β} (h : tendsto f x y) (hx : x ≠ ⊥) :
+  y ≠ ⊥ :=
+neq_bot_of_le_neq_bot (map_ne_bot hx) h
+
 lemma tendsto_map {f : α → β} {x : filter α} : tendsto f x (map f x) := le_refl (map f x)
 
 lemma tendsto_map' {f : β → γ} {g : α → β} {x : filter α} {y : filter γ}
@@ -1233,6 +1246,10 @@ le_trans (map_mono inf_le_left) h
 lemma tendsto_inf_right {f : α → β} {x₁ x₂ : filter α} {y : filter β}
   (h : tendsto f x₂ y) : tendsto f (x₁ ⊓ x₂) y  :=
 le_trans (map_mono inf_le_right) h
+
+lemma tendsto.inf {f : α → β} {x₁ x₂ : filter α} {y₁ y₂ : filter β}
+  (h₁ : tendsto f x₁ y₁) (h₂ : tendsto f x₂ y₂) : tendsto f (x₁ ⊓ x₂) (y₁ ⊓ y₂) :=
+tendsto_inf.2 ⟨tendsto_inf_left h₁, tendsto_inf_right h₂⟩
 
 lemma tendsto_infi {f : α → β} {x : filter α} {y : ι → filter β} :
   tendsto f x (⨅i, y i) ↔ ∀i, tendsto f x (y i) :=

--- a/src/order/filter/lift.lean
+++ b/src/order/filter/lift.lean
@@ -57,13 +57,13 @@ infi_le_infi $ assume s, infi_le_infi $ assume hs, hg s hs
 
 lemma map_lift_eq {m : β → γ} (hg : monotone g) : map m (f.lift g) = f.lift (map m ∘ g) :=
 have monotone (map m ∘ g),
-  from monotone_map.comp hg,
+  from map_mono.comp hg,
 filter_eq $ set.ext $
   by simp only [mem_lift_sets, hg, @mem_lift_sets _ _ f _ this, exists_prop, forall_const, mem_map, iff_self, function.comp_app]
 
 lemma comap_lift_eq {m : γ → β} (hg : monotone g) : comap m (f.lift g) = f.lift (comap m ∘ g) :=
 have monotone (comap m ∘ g),
-  from monotone_comap.comp hg,
+  from comap_mono.comp hg,
 filter_eq $ set.ext begin
   simp only [hg, @mem_lift_sets _ _ f _ this, comap, mem_lift_sets, mem_set_of_eq, exists_prop,
     function.comp_apply],

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -1125,7 +1125,7 @@ begin
 end
 
 /-- The extreme value theorem: a continuous function realizes its maximum on a compact set -/
-lemma compact.exists_forall_ge {α : Type u} [topological_space α] {s : set α}:
+lemma compact.exists_forall_ge {α : Type u} [topological_space α]:
   ∀ {s : set α}, compact s → s ≠ ∅ → ∀ {f : α → β}, continuous_on f s →
   ∃x∈s, ∀y∈s, f y ≤ f x :=
 @compact.exists_forall_le (order_dual β) _ _ _ _ _

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -766,8 +766,8 @@ lemma bdd_below_of_compact {α : Type u} [topological_space α] [linear_order α
 begin
   by_contra H,
   letI := classical.DLO α,
-  rcases @compact_elim_finite_subcover_image α _ _ _ s (λ x, {b | x < b}) hs
-    (λ x _, is_open_lt continuous_const continuous_id) _ with ⟨t, st, ft, ht⟩,
+  rcases hs.elim_finite_subcover_image (λ x (_ : x ∈ s), @is_open_Ioi _ _ _ _ x) _
+    with ⟨t, st, ft, ht⟩,
   { refine H ((bdd_below_finite ft).imp $ λ C hC y hy, _),
     rcases mem_bUnion_iff.1 (ht hy) with ⟨x, hx, xy⟩,
     exact le_trans (hC hx) (le_of_lt xy) },
@@ -996,11 +996,11 @@ by rw [infi, cInf_of_cInf_of_monotone_of_continuous Mf Cf
   (λ h, range_eq_empty.1 h ‹_›) H, ← range_comp]; refl
 
 /-- The extreme value theorem: a continuous function realizes its minimum on a compact set -/
-lemma exists_forall_le_of_compact_of_continuous {α : Type u} [topological_space α]
-  (f : α → β) (hf : continuous f) (s : set α) (hs : compact s) (ne_s : s ≠ ∅) :
+lemma compact.exists_forall_le {α : Type u} [topological_space α]
+  {s : set α} (hs : compact s) (ne_s : s ≠ ∅) (f : α → β) (hf : continuous_on f s) :
   ∃x∈s, ∀y∈s, f x ≤ f y :=
 begin
-  have C : compact (f '' s) := compact_image hs hf,
+  have C : compact (f '' s) := hs.image_on hf,
   haveI := has_Inf_to_nonempty β,
   have B : bdd_below (f '' s) := bdd_below_of_compact C,
   have : Inf (f '' s) ∈ f '' s :=
@@ -1010,10 +1010,10 @@ begin
 end
 
 /-- The extreme value theorem: a continuous function realizes its maximum on a compact set -/
-lemma exists_forall_ge_of_compact_of_continuous {α : Type u} [topological_space α] :
-  ∀ f : α → β, continuous f → ∀ s : set α, compact s → s ≠ ∅ →
+lemma compact.exists_forall_ge {α : Type u} [topological_space α] {s : set α}:
+  ∀ {s : set α}, compact s → s ≠ ∅ → ∀ {f : α → β}, continuous_on f s →
   ∃x∈s, ∀y∈s, f y ≤ f x :=
-@exists_forall_le_of_compact_of_continuous (order_dual β) _ _ _ _ _
+@compact.exists_forall_le (order_dual β) _ _ _ _ _
 
 end conditionally_complete_linear_order
 

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -1000,7 +1000,7 @@ lemma compact.exists_forall_le {α : Type u} [topological_space α]
   {s : set α} (hs : compact s) (ne_s : s ≠ ∅) (f : α → β) (hf : continuous_on f s) :
   ∃x∈s, ∀y∈s, f x ≤ f y :=
 begin
-  have C : compact (f '' s) := hs.image_on hf,
+  have C : compact (f '' s) := hs.image_of_continuous_on hf,
   haveI := has_Inf_to_nonempty β,
   have B : bdd_below (f '' s) := bdd_below_of_compact C,
   have : Inf (f '' s) ∈ f '' s :=

--- a/src/topology/bounded_continuous_function.lean
+++ b/src/topology/bounded_continuous_function.lean
@@ -63,8 +63,7 @@ bounded_range_iff.2 f.2.2
 /-- If a function is continuous on a compact space, it is automatically bounded,
 and therefore gives rise to an element of the type of bounded continuous functions -/
 def mk_of_compact [compact_space α] (f : α → β) (hf : continuous f) : α →ᵇ β :=
-⟨f, hf, bounded_range_iff.1 $ by rw ← image_univ; exact
-  bounded_of_compact (compact_image compact_univ hf)⟩
+⟨f, hf, bounded_range_iff.1 $ bounded_of_compact $ compact_range hf⟩
 
 /-- If a function is bounded on a discrete space, it is automatically continuous,
 and therefore gives rise to an element of the type of bounded continuous functions -/
@@ -255,7 +254,7 @@ begin
   /- For all x, the set hU x is an open set containing x on which the elements of A
   fluctuate by at most ε₂.
   We extract finitely many of these sets that cover the whole space, by compactness -/
-  rcases compact_elim_finite_subcover_image compact_univ
+  rcases compact_univ.elim_finite_subcover_image
     (λx _, (hU x).2.1) (λx hx, mem_bUnion (mem_univ _) (hU x).1)
     with ⟨tα, _, ⟨_⟩, htα⟩,
   /- tα : set α, htα : univ ⊆ ⋃x ∈ tα, U x -/
@@ -304,7 +303,7 @@ begin
   have M : lipschitz_with 1 coe := lipschitz_with.subtype_coe s,
   let F : (α →ᵇ s) → α →ᵇ β := comp coe M,
   refine compact_of_is_closed_subset
-    (compact_image (_ : compact (F ⁻¹' A)) (continuous_comp M)) closed (λ f hf, _),
+    ((_ : compact (F ⁻¹' A)).image (continuous_comp M)) closed (λ f hf, _),
   { haveI : compact_space s := compact_iff_compact_space.1 hs,
     refine arzela_ascoli₁ _ (continuous_iff_is_closed.1 (continuous_comp M) _ closed)
       (λ x ε ε0, bex.imp_right (λ U U_nhds hU y z hy hz f hf, _) (H x ε ε0)),

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -186,6 +186,14 @@ begin
     exact forall_sets_neq_empty_iff_neq_bot.2 h (u ∩ s) this }
 end
 
+lemma nhds_within_ne_bot_of_mem {s : set α} {x : α} (hx : x ∈ s) :
+  nhds_within x s ≠ ⊥ :=
+mem_closure_iff_nhds_within_ne_bot.1 $ subset_closure hx
+
+lemma is_closed.mem_of_nhds_within_ne_bot {s : set α} (hs : is_closed s)
+  {x : α} (hx : nhds_within x s ≠ ⊥) : x ∈ s :=
+by simpa only [closure_eq_of_is_closed hs] using mem_closure_iff_nhds_within_ne_bot.2 hx
+
 /-
 nhds_within and subtypes
 -/

--- a/src/topology/homeomorph.lean
+++ b/src/topology/homeomorph.lean
@@ -72,16 +72,14 @@ le_antisymm
     rwa [coinduced_compose, self_comp_symm, coinduced_id] at this,
   end
 
+protected lemma embedding (h : α ≃ₜ β) : embedding h :=
+⟨⟨h.induced_eq.symm⟩, h.to_equiv.injective⟩
+
 lemma compact_image {s : set α} (h : α ≃ₜ β) : compact (h '' s) ↔ compact s :=
-⟨λ hs, by have := compact_image hs h.symm.continuous;
-  rwa [← image_comp, symm_comp_self, image_id] at this,
-λ hs, compact_image hs h.continuous⟩
+h.embedding.compact_iff_compact_image.symm
 
 lemma compact_preimage {s : set β} (h : α ≃ₜ β) : compact (h ⁻¹' s) ↔ compact s :=
 by rw ← image_symm; exact h.symm.compact_image
-
-protected lemma embedding (h : α ≃ₜ β) : embedding h :=
-⟨⟨h.induced_eq.symm⟩, h.to_equiv.injective⟩
 
 protected lemma dense_embedding (h : α ≃ₜ β) : dense_embedding h :=
 { dense   := assume a, by rw [h.range_coe, closure_univ]; trivial,

--- a/src/topology/instances/complex.lean
+++ b/src/topology/instances/complex.lean
@@ -119,7 +119,8 @@ instance : topological_ring ℂ :=
 
 instance : topological_semiring ℂ := by apply_instance -- short-circuit type class inference
 
-def real_prod_homeo : homeomorph ℂ (ℝ × ℝ) :=
+/-- `ℂ` is homeomorphic to the real plane with `max` norm. -/
+def real_prod_homeo : ℂ ≃ₜ (ℝ × ℝ) :=
 { to_equiv := real_prod_equiv,
   continuous_to_fun := continuous_re.prod_mk continuous_im,
   continuous_inv_fun := show continuous (λ p : ℝ × ℝ, complex.mk p.1 p.2),
@@ -131,7 +132,7 @@ instance : proper_space ℂ :=
 ⟨λx r, begin
   refine real_prod_homeo.symm.compact_preimage.1
     (compact_of_is_closed_subset
-      (compact_prod _ _ (proper_space.compact_ball x.re r) (proper_space.compact_ball x.im r))
+      ((proper_space.compact_ball x.re r).prod (proper_space.compact_ball x.im r))
       (continuous_iff_is_closed.1 real_prod_homeo.symm.continuous _ is_closed_ball) _),
   exact λ p h, ⟨
     le_trans (abs_re_le_abs (⟨p.1, p.2⟩ - x)) h,

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -1038,12 +1038,14 @@ lemma finite_cover_balls_of_compact {α : Type u} [metric_space α] {s : set α}
   (hs : compact s) {e : ℝ} (he : e > 0) :
   ∃t ⊆ s, finite t ∧ s ⊆ ⋃x∈t, ball x e :=
 begin
-  apply compact_elim_finite_subcover_image hs,
+  apply hs.elim_finite_subcover_image,
   { simp [is_open_ball] },
   { intros x xs,
     simp,
     exact ⟨x, ⟨xs, by simpa⟩⟩ }
 end
+
+alias finite_cover_balls_of_compact ← compact.finite_cover_balls
 
 end compact
 
@@ -1068,7 +1070,7 @@ lemma proper_space_of_compact_closed_ball_of_le
       apply inter_eq_self_of_subset_right,
       exact closed_ball_subset_closed_ball (le_of_lt (not_le.1 hr)) },
     rw this,
-    exact compact_inter (h x R (le_refl _)) is_closed_ball }
+    exact (h x R (le_refl _)).inter_right is_closed_ball }
 end⟩
 
 /- A compact metric space is proper -/
@@ -1195,7 +1197,7 @@ lemma second_countable_of_countable_discretization {α : Type u} [metric_space �
   second_countable_topology α :=
 begin
   classical, by_cases hs : (univ : set α) = ∅,
-  { haveI : compact_space α := ⟨by rw hs; exact compact_of_finite (set.finite_empty)⟩, by apply_instance },
+  { haveI : compact_space α := ⟨by rw hs; exact compact_empty⟩, by apply_instance },
   rcases exists_mem_of_ne_empty hs with ⟨x0, hx0⟩,
   letI : inhabited α := ⟨x0⟩,
   refine second_countable_of_almost_dense_set (λε ε0, _),
@@ -1303,9 +1305,11 @@ lemma bounded_of_compact {s : set α} (h : compact s) : bounded s :=
 let ⟨t, ht, fint, subs⟩ := finite_cover_balls_of_compact h zero_lt_one in
 bounded.subset subs $ (bounded_bUnion fint).2 $ λ i hi, bounded_ball
 
+alias bounded_of_compact ← compact.bounded
+
 /-- A finite set is bounded -/
 lemma bounded_of_finite {s : set α} (h : finite s) : bounded s :=
-bounded_of_compact $ compact_of_finite h
+h.compact.bounded
 
 /-- A singleton is bounded -/
 lemma bounded_singleton {x : α} : bounded ({x} : set α) :=
@@ -1319,12 +1323,12 @@ exists_congr $ λ C, ⟨
 
 /-- In a compact space, all sets are bounded -/
 lemma bounded_of_compact_space [compact_space α] : bounded s :=
-(bounded_of_compact compact_univ).subset (subset_univ _)
+compact_univ.bounded.subset (subset_univ _)
 
 /-- In a proper space, a set is compact if and only if it is closed and bounded -/
 lemma compact_iff_closed_bounded [proper_space α] :
   compact s ↔ is_closed s ∧ bounded s :=
-⟨λ h, ⟨closed_of_compact _ h, bounded_of_compact h⟩, begin
+⟨λ h, ⟨closed_of_compact _ h, h.bounded⟩, begin
   rintro ⟨hc, hb⟩,
   classical, by_cases s = ∅, {simp [h, compact_empty]},
   rcases exists_mem_of_ne_empty h with ⟨x, hx⟩,
@@ -1351,7 +1355,7 @@ begin
       exact mul_le_mul_of_nonneg_left (add_le_add hx hy) (le_max_right _ _)
     end⟩,
   have : compact K := compact_iff_closed_bounded.2 ⟨A, B⟩,
-  have C : compact (f '' K) := compact_image this f_cont,
+  have C : compact (f '' K) := this.image f_cont,
   have : f '' K = closed_ball x₀ r,
     by { rw image_preimage_eq_of_subset, rw hf, exact subset_univ _ },
   rwa this at C

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -1035,7 +1035,7 @@ section compact
 /-- Any compact set in a metric space can be covered by finitely many balls of a given positive
 radius -/
 lemma finite_cover_balls_of_compact {α : Type u} [metric_space α] {s : set α}
-  (hs : compact s) {e : ℝ} (he : e > 0) :
+  (hs : compact s) {e : ℝ} (he : 0 < e) :
   ∃t ⊆ s, finite t ∧ s ⊆ ⋃x∈t, ball x e :=
 begin
   apply hs.elim_finite_subcover_image,

--- a/src/topology/metric_space/closeds.lean
+++ b/src/topology/metric_space/closeds.lean
@@ -239,8 +239,7 @@ instance closeds.compact_space [compact_space α] : compact_space (closeds α) :
   -- `F` is ε-dense
   { assume u _,
     rcases main u.val with ⟨t0, t0s, Dut0⟩,
-    have : finite t0 := finite_subset fs t0s,
-    have : is_closed t0 := closed_of_compact _ (compact_of_finite this),
+    have : is_closed t0 := closed_of_compact _ (finite_subset fs t0s).compact,
     let t : closeds α := ⟨t0, this⟩,
     have : t ∈ F := t0s,
     have : edist u t < ε := lt_of_le_of_lt Dut0 δlt,
@@ -329,8 +328,8 @@ end
 the same statement for closed subsets -/
 instance nonempty_compacts.compact_space [compact_space α] : compact_space (nonempty_compacts α) :=
 ⟨begin
-  rw compact_iff_compact_image_of_embedding nonempty_compacts.to_closeds.uniform_embedding.embedding,
-  exact compact_of_closed nonempty_compacts.is_closed_in_closeds
+  rw embedding.compact_iff_compact_image nonempty_compacts.to_closeds.uniform_embedding.embedding,
+  exact nonempty_compacts.is_closed_in_closeds.compact
 end⟩
 
 /-- In a second countable space, the type of nonempty compact subsets is second countable -/
@@ -411,7 +410,7 @@ begin
         rw [h, Hausdorff_edist_empty t.property.1] at Dtc,
         exact not_top_lt Dtc },
       -- let `d` be the version of `c` in the type `nonempty_compacts α`
-      let d : nonempty_compacts α := ⟨c, ⟨‹c ≠ ∅›, compact_of_finite ‹finite c›⟩⟩,
+      let d : nonempty_compacts α := ⟨c, ⟨‹c ≠ ∅›, ‹finite c›.compact⟩⟩,
       have : c ⊆ s,
       { assume x hx,
         rcases (mem_image _ _ _).1 hx.1 with ⟨y, ⟨ya, yx⟩⟩,

--- a/src/topology/metric_space/gromov_hausdorff_realized.lean
+++ b/src/topology/metric_space/gromov_hausdorff_realized.lean
@@ -401,7 +401,7 @@ variables (α : Type u) (β : Type v) [metric_space α] [compact_space α] [none
 we can finally select a candidate minimizing HD. This will be the candidate realizing the
 optimal coupling. -/
 private lemma exists_minimizer : ∃f ∈ candidates_b α β, ∀g ∈ candidates_b α β, HD f ≤ HD g :=
-exists_forall_le_of_compact_of_continuous _ HD_continuous _ compact_candidates_b candidates_b_ne_empty
+compact_candidates_b.exists_forall_le candidates_b_ne_empty _ HD_continuous.continuous_on
 
 private definition optimal_GH_dist : Cb α β := classical.some (exists_minimizer α β)
 
@@ -463,9 +463,8 @@ instance compact_space_optimal_GH_coupling : compact_space (optimal_GH_coupling 
       rw this,
       exact mem_union_right _ (mem_image_of_mem _ (mem_univ _)) } },
   rw this,
-  exact compact_union_of_compact
-    (compact_image (compact_univ) (isometry_optimal_GH_injl α β).continuous)
-    (compact_image (compact_univ) (isometry_optimal_GH_injr α β).continuous)
+  exact (compact_univ.image (isometry_optimal_GH_injl α β).continuous).union
+    (compact_univ.image (isometry_optimal_GH_injr α β).continuous)
 end⟩
 
 /-- For any candidate f, HD(f) is larger than or equal to the Hausdorff distance in the

--- a/src/topology/metric_space/isometry.lean
+++ b/src/topology/metric_space/isometry.lean
@@ -222,8 +222,7 @@ open bounded_continuous_function metric topological_space
 
 namespace Kuratowski_embedding
 
-/- In this section, we show that any separable metric space can be embedded isometrically
-in ℓ^∞(ℝ) -/
+/-! ### In this section, we show that any separable metric space can be embedded isometrically in ℓ^∞(ℝ) -/
 
 variables {f g : ℓ_infty_ℝ} {n : ℕ} {C : ℝ} [metric_space α] (x : ℕ → α) (a b : α)
 
@@ -314,5 +313,5 @@ begin
     have A : Kuratowski_embedding α x ∈ range (Kuratowski_embedding α) := ⟨x, by simp⟩,
     apply ne_empty_of_mem A },
   { rw ← image_univ,
-    exact compact_image compact_univ (Kuratowski_embedding.isometry α).continuous },
+    exact compact_univ.image (Kuratowski_embedding.isometry α).continuous },
 end⟩

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -363,7 +363,7 @@ lemma normal_of_compact_t2 [compact_space α] [t2_space α] : normal_space α :=
 begin
   refine ⟨assume s t hs ht st, _⟩,
   simp only [disjoint_iff],
-  exact compact_compact_separated (compact_of_closed hs) (compact_of_closed ht) st.eq_bot
+  exact compact_compact_separated hs.compact ht.compact st.eq_bot
 end
 
 end normality

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -348,7 +348,7 @@ instance [compact_space α] [compact_space β] : compact_space (α × β) :=
 /-- The disjoint union of two compact spaces is compact. -/
 instance [compact_space α] [compact_space β] : compact_space (α ⊕ β) :=
 ⟨by convert (compact_range continuous_inl).union (compact_range continuous_inr);
-  [by { ext x, cases x; simp }, assumption, assumption ]⟩
+  [by { ext x, cases x; simp }, assumption, assumption]⟩
 
 section tychonoff
 variables {ι : Type*} {π : ι → Type*} [∀i, topological_space (π i)]

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -276,7 +276,7 @@ compact_of_is_closed_subset compact_univ h (subset_univ _)
 
 variables [topological_space β]
 
-lemma compact.image_on {s : set α} {f : α → β} (hs : compact s)
+lemma compact.image_of_continuous_on {s : set α} {f : α → β} (hs : compact s)
   (hf : continuous_on f s) : compact (f '' s) :=
 begin
   intros l lne ls,
@@ -290,7 +290,7 @@ end
 
 lemma compact.image {s : set α} {f : α → β} (hs : compact s) (hf : continuous f) :
   compact (f '' s) :=
-hs.image_on hf.continuous_on
+hs.image_of_continuous_on hf.continuous_on
 
 lemma compact_range [compact_space α] {f : α → β} (hf : continuous f) :
   compact (range f) :=
@@ -343,12 +343,14 @@ end
 
 /-- The product of two compact spaces is compact. -/
 instance [compact_space α] [compact_space β] : compact_space (α × β) :=
-⟨by convert compact_univ.prod compact_univ; [by simp, assumption, assumption]⟩
+⟨by { rw ← univ_prod_univ, exact compact_univ.prod compact_univ }⟩
 
 /-- The disjoint union of two compact spaces is compact. -/
 instance [compact_space α] [compact_space β] : compact_space (α ⊕ β) :=
-⟨by convert (compact_range continuous_inl).union (compact_range continuous_inr);
-  [by { ext x, cases x; simp }, assumption, assumption ]⟩
+⟨begin
+  rw ← range_inl_union_range_inr,
+  exact (compact_range continuous_inl).union (compact_range continuous_inr)
+end⟩
 
 section tychonoff
 variables {ι : Type*} {π : ι → Type*} [∀i, topological_space (π i)]
@@ -380,10 +382,7 @@ end tychonoff
 
 instance quot.compact_space {r : α → α → Prop} [compact_space α] :
   compact_space (quot r) :=
-⟨begin
-  convert ← compact_univ.image continuous_quot_mk; [skip, assumption],
-  rw [image_univ, range_iff_surjective], exact quot.exists_rep,
- end⟩
+⟨by { rw ← range_quot_mk, exact compact_range continuous_quot_mk }⟩
 
 instance quotient.compact_space {s : setoid α} [compact_space α] :
   compact_space (quotient s) :=

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -7,7 +7,7 @@ Properties of subsets of topological spaces: compact, clopen, irreducible,
 connected, totally disconnected, totally separated.
 -/
 
-import topology.constructions
+import topology.continuous_on
 
 open set filter lattice classical
 open_locale classical topological_space
@@ -22,23 +22,25 @@ section compact
     every set of `f` also meets every neighborhood of some `a ∈ s`. -/
 def compact (s : set α) := ∀f, f ≠ ⊥ → f ≤ principal s → ∃a∈s, f ⊓ 𝓝 a ≠ ⊥
 
-lemma compact_inter {s t : set α} (hs : compact s) (ht : is_closed t) : compact (s ∩ t) :=
+lemma compact.inter_right {s t : set α} (hs : compact s) (ht : is_closed t) : compact (s ∩ t) :=
 assume f hnf hstf,
 let ⟨a, hsa, (ha : f ⊓ 𝓝 a ≠ ⊥)⟩ := hs f hnf (le_trans hstf (le_principal_iff.2 (inter_subset_left _ _))) in
-have ∀a, principal t ⊓ 𝓝 a ≠ ⊥ → a ∈ t,
-  by intro a; rw [inf_comm]; rw [is_closed_iff_nhds] at ht; exact ht a,
 have a ∈ t,
-  from this a $ neq_bot_of_le_neq_bot ha $ inf_le_inf (le_trans hstf (le_principal_iff.2 (inter_subset_right _ _))) (le_refl _),
+  from ht.mem_of_nhds_within_ne_bot $ neq_bot_of_le_neq_bot (by { rw inf_comm at ha, exact ha }) $
+    inf_le_inf (le_refl _) (le_trans hstf (le_principal_iff.2 (inter_subset_right _ _))),
 ⟨a, ⟨hsa, this⟩, ha⟩
 
+lemma compact.inter_left {s t : set α} (ht : compact t) (hs : is_closed s) : compact (s ∩ t) :=
+inter_comm t s ▸ ht.inter_right hs
+
 lemma compact_diff {s t : set α} (hs : compact s) (ht : is_open t) : compact (s \ t) :=
-compact_inter hs (is_closed_compl_iff.mpr ht)
+hs.inter_right (is_closed_compl_iff.mpr ht)
 
 lemma compact_of_is_closed_subset {s t : set α}
   (hs : compact s) (ht : is_closed t) (h : t ⊆ s) : compact t :=
-by convert ← compact_inter hs ht; exact inter_eq_self_of_subset_right h
+inter_eq_self_of_subset_right h ▸ hs.inter_right ht
 
-lemma compact_adherence_nhdset {s t : set α} {f : filter α}
+lemma compact.adherence_nhdset {s t : set α} {f : filter α}
   (hs : compact s) (hf₂ : f ≤ principal s) (ht₁ : is_open t) (ht₂ : ∀a∈s, 𝓝 a ⊓ f ≠ ⊥ → a ∈ t) :
   t ∈ f :=
 classical.by_cases mem_sets_of_neq_bot $
@@ -46,9 +48,9 @@ classical.by_cases mem_sets_of_neq_bot $
   let ⟨a, ha, (hfa : f ⊓ principal (-t) ⊓ 𝓝 a ≠ ⊥)⟩ := hs _ this $ inf_le_left_of_le hf₂ in
   have a ∈ t,
     from ht₂ a ha $ neq_bot_of_le_neq_bot hfa $ le_inf inf_le_right $ inf_le_left_of_le inf_le_left,
-  have 𝓝 a ⊓ principal (-t) ≠ ⊥,
+  have nhds_within a (-t) ≠ ⊥,
     from neq_bot_of_le_neq_bot hfa $ le_inf inf_le_right $ inf_le_left_of_le inf_le_right,
-  have ∀s∈(𝓝 a ⊓ principal (-t)).sets, s ≠ ∅,
+  have ∀s∈ nhds_within a (-t), s ≠ ∅,
     from forall_sets_neq_empty_iff_neq_bot.mpr this,
   have false,
     from this _ ⟨t, mem_nhds_sets ht₁ ‹a ∈ t›, -t, subset.refl _, subset.refl _⟩ (inter_compl_self _),
@@ -68,7 +70,7 @@ lemma compact_iff_ultrafilter_le_nhds {s : set α} :
     by simp only [inf_of_le_left, h]; exact (ultrafilter_ultrafilter_of hf).left,
   ⟨a, ha, neq_bot_of_le_neq_bot this (inf_le_inf ultrafilter_of_le (le_refl _))⟩⟩
 
-lemma compact_elim_finite_subcover {s : set α} {c : set (set α)}
+lemma compact.elim_finite_subcover {s : set α} {c : set (set α)}
   (hs : compact s) (hc₁ : ∀t∈c, is_open t) (hc₂ : s ⊆ ⋃₀ c) : ∃c'⊆c, finite c' ∧ s ⊆ ⋃₀ c' :=
 classical.by_contradiction $ assume h,
   have h : ∀{c'}, c' ⊆ c → finite c' → ¬ s ⊆ ⋃₀ c',
@@ -98,14 +100,14 @@ classical.by_contradiction $ assume h,
     le_inf inf_le_right (inf_le_left_of_le ‹f ≤ principal (- t)›),
   this ‹a ∈ t›
 
-lemma compact_elim_finite_subcover_image {s : set α} {b : set β} {c : β → set α}
+lemma compact.elim_finite_subcover_image {s : set α} {b : set β} {c : β → set α}
   (hs : compact s) (hc₁ : ∀i∈b, is_open (c i)) (hc₂ : s ⊆ ⋃i∈b, c i) :
   ∃b'⊆b, finite b' ∧ s ⊆ ⋃i∈b', c i :=
 if h : b = ∅ then ⟨∅, empty_subset _, finite_empty, h ▸ hc₂⟩ else
 let ⟨i, hi⟩ := exists_mem_of_ne_empty h in
 have hc'₁ : ∀i∈c '' b, is_open i, from assume i ⟨j, hj, h⟩, h ▸ hc₁ _ hj,
 have hc'₂ : s ⊆ ⋃₀ (c '' b), by rwa set.sUnion_image,
-let ⟨d, hd₁, hd₂, hd₃⟩ := compact_elim_finite_subcover hs hc'₁ hc'₂ in
+let ⟨d, hd₁, hd₂, hd₃⟩ := hs.elim_finite_subcover hc'₁ hc'₂ in
 have ∀x : d, ∃i, i ∈ b ∧ c i = x, from assume ⟨x, hx⟩, hd₁ hx,
 let ⟨f', hf⟩ := axiom_of_choice this,
     f := λx:set α, (if h : x ∈ d then f' ⟨x, h⟩ else i : β) in
@@ -159,7 +161,7 @@ end
 
 lemma compact_iff_finite_subcover {s : set α} :
   compact s ↔ (∀c, (∀t∈c, is_open t) → s ⊆ ⋃₀ c → ∃c'⊆c, finite c' ∧ s ⊆ ⋃₀ c') :=
-⟨assume hc c, compact_elim_finite_subcover hc, compact_of_finite_subcover⟩
+⟨assume hc c, hc.elim_finite_subcover, compact_of_finite_subcover⟩
 
 lemma compact_empty : compact (∅ : set α) :=
 assume f hnf hsf, not.elim hnf $
@@ -170,11 +172,11 @@ compact_of_finite_subcover $ assume c hc₁ hc₂,
   let ⟨i, hic, hai⟩ := (show ∃i ∈ c, a ∈ i, from mem_sUnion.1 $ singleton_subset_iff.1 hc₂) in
   ⟨{i}, singleton_subset_iff.2 hic, finite_singleton _, by rwa [sUnion_singleton, singleton_subset_iff]⟩
 
-lemma compact_bUnion_of_compact {s : set β} {f : β → set α} (hs : finite s) :
+lemma set.finite.compact_bUnion {s : set β} {f : β → set α} (hs : finite s) :
   (∀i ∈ s, compact (f i)) → compact (⋃i ∈ s, f i) :=
 assume hf, compact_of_finite_subcover $ assume c c_open c_cover,
   have ∀i : subtype s, ∃c' ⊆ c, finite c' ∧ f i ⊆ ⋃₀ c', from
-    assume ⟨i, hi⟩, compact_elim_finite_subcover (hf i hi) c_open
+    assume ⟨i, hi⟩, (hf i hi).elim_finite_subcover c_open
       (calc f i ⊆ ⋃i ∈ s, f i : subset_bUnion_of_mem hi
             ... ⊆ ⋃₀ c        : c_cover),
   let ⟨finite_subcovers, h⟩ := axiom_of_choice this in
@@ -186,15 +188,15 @@ assume hf, compact_of_finite_subcover $ assume c c_open c_cover,
     ... ⊆ ⋃₀ c'                      : sUnion_mono (subset_Union _ _),
   ⟨c', ‹c' ⊆ c›, ‹finite c'›, this⟩
 
-lemma compact_Union_of_compact {f : β → set α} [fintype β]
+lemma compact_Union {f : β → set α} [fintype β]
   (h : ∀i, compact (f i)) : compact (⋃i, f i) :=
-by rw ← bUnion_univ; exact compact_bUnion_of_compact finite_univ (λ i _, h i)
+by rw ← bUnion_univ; exact finite_univ.compact_bUnion (λ i _, h i)
 
-lemma compact_of_finite {s : set α} (hs : finite s) : compact s :=
-bUnion_of_singleton s ▸ compact_bUnion_of_compact hs (λ _ _, compact_singleton)
+lemma set.finite.compact {s : set α} (hs : finite s) : compact s :=
+bUnion_of_singleton s ▸ hs.compact_bUnion (λ _ _, compact_singleton)
 
-lemma compact_union_of_compact {s t : set α} (hs : compact s) (ht : compact t) : compact (s ∪ t) :=
-by rw union_eq_Union; exact compact_Union_of_compact (λ b, by cases b; assumption)
+lemma compact.union {s t : set α} (hs : compact s) (ht : compact t) : compact (s ∪ t) :=
+by rw union_eq_Union; exact compact_Union (λ b, by cases b; assumption)
 
 section tube_lemma
 
@@ -238,7 +240,7 @@ let ⟨uvs, h⟩ := classical.axiom_of_choice this in
 have us_cover : s ⊆ ⋃i, (uvs i).1, from
   assume x hx, set.subset_Union _ ⟨x,hx⟩ (by simpa using (h ⟨x,hx⟩).2.2.1),
 let ⟨s0, _, s0_fin, s0_cover⟩ :=
-  compact_elim_finite_subcover_image hs (λi _, (h i).1) $
+  hs.elim_finite_subcover_image (λi _, (h i).1) $
     by rw bUnion_univ; exact us_cover in
 let u := ⋃(i ∈ s0), (uvs i).1 in
 let v := ⋂(i ∈ s0), (uvs i).2 in
@@ -268,28 +270,35 @@ class compact_space (α : Type*) [topological_space α] : Prop :=
 
 lemma compact_univ [h : compact_space α] : compact (univ : set α) := h.compact_univ
 
-lemma compact_of_closed [compact_space α] {s : set α} (h : is_closed s) :
+lemma is_closed.compact [compact_space α] {s : set α} (h : is_closed s) :
   compact s :=
 compact_of_is_closed_subset compact_univ h (subset_univ _)
 
 variables [topological_space β]
 
-lemma compact_image {s : set α} {f : α → β} (hs : compact s) (hf : continuous f) :
+lemma compact.image_on {s : set α} {f : α → β} (hs : compact s)
+  (hf : continuous_on f s) : compact (f '' s) :=
+begin
+  intros l lne ls,
+  have ne_bot : l.comap f ⊓ principal s ≠ ⊥,
+    from comap_inf_principal_ne_bot_of_image_mem lne (le_principal_iff.1 ls),
+  rcases hs (l.comap f ⊓ principal s) ne_bot inf_le_right with ⟨a, has, ha⟩,
+  use [f a, mem_image_of_mem f has],
+  rw [inf_assoc, @inf_comm _ _ _ (𝓝 a)] at ha,
+  exact neq_bot_of_le_neq_bot (@@map_ne_bot f ha) (tendsto_comap.inf $ hf a has)
+end
+
+lemma compact.image {s : set α} {f : α → β} (hs : compact s) (hf : continuous f) :
   compact (f '' s) :=
-compact_of_finite_subcover $ assume c hco hcs,
-  have hdo : ∀t∈c, is_open (f ⁻¹' t), from assume t' ht, hf _ $ hco _ ht,
-  have hds : s ⊆ ⋃i∈c, f ⁻¹' i,
-    by simpa [subset_def, -mem_image] using hcs,
-  let ⟨d', hcd', hfd', hd'⟩ := compact_elim_finite_subcover_image hs hdo hds in
-  ⟨d', hcd', hfd', by simpa [subset_def, -mem_image, image_subset_iff] using hd'⟩
+hs.image_on hf.continuous_on
 
 lemma compact_range [compact_space α] {f : α → β} (hf : continuous f) :
   compact (range f) :=
-by rw ← image_univ; exact compact_image compact_univ hf
+by rw ← image_univ; exact compact_univ.image hf
 
-lemma compact_iff_compact_image_of_embedding {s : set α} {f : α → β} (hf : embedding f) :
+lemma embedding.compact_iff_compact_image {s : set α} {f : α → β} (hf : embedding f) :
   compact s ↔ compact (f '' s) :=
-iff.intro (assume h, compact_image h hf.continuous) $ assume h, begin
+iff.intro (assume h, h.image hf.continuous) $ assume h, begin
   rw compact_iff_ultrafilter_le_nhds at ⊢ h,
   intros u hu us',
   let u' : filter β := map f u,
@@ -304,7 +313,7 @@ end
 
 lemma compact_iff_compact_in_subtype {p : α → Prop} {s : set {a // p a}} :
   compact s ↔ compact (subtype.val '' s) :=
-compact_iff_compact_image_of_embedding embedding_subtype_val
+embedding_subtype_val.compact_iff_compact_image
 
 lemma compact_iff_compact_univ {s : set α} : compact s ↔ compact (univ : set (subtype s)) :=
 by rw [compact_iff_compact_in_subtype, image_univ, subtype.val_range]; refl
@@ -312,15 +321,15 @@ by rw [compact_iff_compact_in_subtype, image_univ, subtype.val_range]; refl
 lemma compact_iff_compact_space {s : set α} : compact s ↔ compact_space s :=
 compact_iff_compact_univ.trans ⟨λ h, ⟨h⟩, @compact_space.compact_univ _ _⟩
 
-lemma compact_prod (s : set α) (t : set β) (ha : compact s) (hb : compact t) : compact (set.prod s t) :=
+lemma compact.prod {s : set α} {t : set β} (hs : compact s) (ht : compact t) : compact (set.prod s t) :=
 begin
-  rw compact_iff_ultrafilter_le_nhds at ha hb ⊢,
+  rw compact_iff_ultrafilter_le_nhds at hs ht ⊢,
   intros f hf hfs,
   rw le_principal_iff at hfs,
-  rcases ha (map prod.fst f) (ultrafilter_map hf)
+  rcases hs (map prod.fst f) (ultrafilter_map hf)
     (le_principal_iff.2 (mem_map_sets_iff.2
       ⟨_, hfs, image_subset_iff.2 (λ s h, h.1)⟩)) with ⟨a, sa, ha⟩,
-  rcases hb (map prod.snd f) (ultrafilter_map hf)
+  rcases ht (map prod.snd f) (ultrafilter_map hf)
     (le_principal_iff.2 (mem_map_sets_iff.2
       ⟨_, hfs, image_subset_iff.2 (λ s h, h.2)⟩)) with ⟨b, tb, hb⟩,
   rw map_le_iff_le_comap at ha hb,
@@ -330,26 +339,16 @@ end
 
 /-- Finite topological spaces are compact. -/
 @[priority 100] instance fintype.compact_space [fintype α] : compact_space α :=
-{ compact_univ := compact_of_finite set.finite_univ }
+{ compact_univ := set.finite_univ.compact }
 
 /-- The product of two compact spaces is compact. -/
 instance [compact_space α] [compact_space β] : compact_space (α × β) :=
-⟨begin
-  have A : compact (set.prod (univ : set α) (univ : set β)) :=
-    compact_prod univ univ compact_univ compact_univ,
-  have : set.prod (univ : set α) (univ : set β) = (univ : set (α × β)) := by simp,
-  rwa this at A,
-end⟩
+⟨by convert compact_univ.prod compact_univ; [by simp, assumption, assumption]⟩
 
 /-- The disjoint union of two compact spaces is compact. -/
 instance [compact_space α] [compact_space β] : compact_space (α ⊕ β) :=
-⟨begin
-  have A : compact (@sum.inl α β '' univ) := compact_image compact_univ continuous_inl,
-  have B : compact (@sum.inr α β '' univ) := compact_image compact_univ continuous_inr,
-  have C := compact_union_of_compact A B,
-  have : (@sum.inl α β '' univ) ∪ (@sum.inr α β '' univ) = univ := by ext; cases x; simp,
-  rwa this at C,
-end⟩
+⟨by convert (compact_range continuous_inl).union (compact_range continuous_inr);
+  [by { ext x, cases x; simp }, assumption, assumption ]⟩
 
 section tychonoff
 variables {ι : Type*} {π : ι → Type*} [∀i, topological_space (π i)]
@@ -382,10 +381,8 @@ end tychonoff
 instance quot.compact_space {r : α → α → Prop} [compact_space α] :
   compact_space (quot r) :=
 ⟨begin
-   have : quot.mk r '' univ = univ,
-     by rw [image_univ, range_iff_surjective]; exact quot.exists_rep,
-   rw ←this,
-   exact compact_image compact_univ continuous_quot_mk
+  convert ← compact_univ.image continuous_quot_mk; [skip, assumption],
+  rw [image_univ, range_iff_surjective], exact quot.exists_rep,
  end⟩
 
 instance quotient.compact_space {s : setoid α} [compact_space α] :

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -872,7 +872,7 @@ begin
     rcases mem_Union.1 (hc₂ hx) with ⟨i, h⟩,
     rcases comp_mem_uniformity_sets (is_open_uniformity.1 (hc₁ i) x h) with ⟨m', hm', mm'⟩,
     exact mem_bUnion hm' ⟨i, _, hm', λ y hy, mm' hy rfl⟩ },
-  rcases compact_elim_finite_subcover_image hs hu₁ hu₂ with ⟨b, bu, b_fin, b_cover⟩,
+  rcases hs.elim_finite_subcover_image hu₁ hu₂ with ⟨b, bu, b_fin, b_cover⟩,
   refine ⟨_, Inter_mem_sets b_fin bu, λ x hx, _⟩,
   rcases mem_bUnion_iff.1 (b_cover hx) with ⟨n, bn, i, m, hm, h⟩,
   refine ⟨i, λ y hy, h _⟩,


### PR DESCRIPTION
I'm not happy about the name `compact.image_on`. Any suggestions? I'd like to keep it in the `compact` namespace, not `continuous_on`, because it matches both the main assumption and the conclusion.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)