### PR TITLE
feat(*): add command for declaring library notes

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -1443,6 +1443,11 @@ At various places in mathlib, we leave implementation notes that are referenced 
 files. To keep track of these notes, we use the command `library_note`. This makes it easy to
 retrieve a list of all notes, e.g. for documentation output.
 
+These notes can be referenced in mathlib with the syntax `Note [note id]`.
+Often, these references will be made in code comments (`--`) that won't be displayed in docs.
+If such a reference is made in a doc string or module doc, it will be linked to the corresponding
+note in the doc display.
+
 Syntax:
 ```
 library_note "note id" "note message"
@@ -1458,4 +1463,13 @@ Terms will free variables are not well-typed, and one should not use them in tac
 The reason for working with open types is for performance: instantiating variables requires
 iterating through the expression. In one performance test `pi_binders` was more than 6x
 quicker than `mk_local_pis` (when applied to the type of all imported declarations 100x)."
+```
+
+This note can be referenced near a usage of `pi_binders`:
+
+
+```
+-- See Note [open expressions]
+/-- behavior of f -/
+def f := pi_binders ...
 ```

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -1436,3 +1436,26 @@ available, you should use
 run_cmd mk_simp_attr `simp_name
 run_cmd add_doc_string `simp_attr.simp_name "Description of the simp set here"
 ```
+
+### library_note
+
+At various places in mathlib, we leave implementation notes that are referenced from many other
+files. To keep track of these notes, we use the command `library_note`. This makes it easy to
+retrieve a list of all notes, e.g. for documentation output.
+
+Syntax:
+```
+library_note "note id" "note message"
+```
+
+An example from `meta.expr`:
+
+```
+library_note "open expressions"
+"Some declarations work with open expressions, i.e. an expr that has free variables.
+Terms will free variables are not well-typed, and one should not use them in tactics like
+`infer_type` or `unify`. You can still do syntactic analysis/manipulation on them.
+The reason for working with open types is for performance: instantiating variables requires
+iterating through the expression. In one performance test `pi_binders` was more than 6x
+quicker than `mk_local_pis` (when applied to the type of all imported declarations 100x)."
+```

--- a/src/algebra/category/Mon/basic.lean
+++ b/src/algebra/category/Mon/basic.lean
@@ -20,12 +20,20 @@ along with the relevant forgetful functors between them.
 
 ## Implementation notes
 
-### Note [locally reducible category instances]
+See Note [locally reducible category instances]
 
-We make SemiRing (and the other categories) locally reducible in order
+TODO: Probably @[derive] should be able to create instances of the
+required form (without `id`), and then we could use that instead of
+this obscure `local attribute [reducible]` method.
+-/
+
+library_note "locally reducible category instances"
+"We make SemiRing (and the other categories) locally reducible in order
 to define its instances. This is because writing, for example,
 
-  instance : concrete_category SemiRing := by { delta SemiRing, apply_instance }
+```
+instance : concrete_category SemiRing := by { delta SemiRing, apply_instance }
+```
 
 results in an instance of the form `id (bundled_hom.concrete_category _)`
 and this `id`, not being [reducible], prevents a later instance search
@@ -34,12 +42,7 @@ SemiRing are really semiring morphisms (`→+*`), and therefore have a coercion
 to functions, for example. It's especially important that the `has_coe_to_sort`
 instance not contain an extra `id` as we want the `semiring ↥R` instance to
 also apply to `semiring R.α` (it seems to be impractical to guarantee that
-we always access `R.α` through the coercion rather than directly).
-
-TODO: Probably @[derive] should be able to create instances of the
-required form (without `id`), and then we could use that instead of
-this obscure `local attribute [reducible]` method.
--/
+we always access `R.α` through the coercion rather than directly)."
 
 universes u v
 

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -48,14 +48,14 @@ is_group_hom, is_monoid_hom, monoid_hom
 
 -/
 
-/- Note [low priority instance on morphisms]:
-  We have instances stating that the composition or the product of two morphisms is again a morphism.
-  Type class inference will "succeed" in applying these instances when they shouldn't apply (for
-  example when the goal is just `⊢ is_mul_hom f` the instances `is_mul_hom.comp` or `is_mul_hom.mul`
-  might still succeed). This can cause type class inference to loop.
-  To avoid this, we make the priority of these instances very low. We should think about not making
-  these declarations instances in the first place.
--/
+library_note "low priority instance on morphisms"
+"We have instances stating that the composition or the product of two morphisms is again a morphism.
+Type class inference will 'succeed' in applying these instances when they shouldn't apply (for
+example when the goal is just `⊢ is_mul_hom f` the instances `is_mul_hom.comp` or `is_mul_hom.mul`
+might still succeed). This can cause type class inference to loop.
+To avoid this, we make the priority of these instances very low. We should think about not making
+these declarations instances in the first place."
+
 universes u v
 variables {α : Type u} {β : Type v}
 

--- a/src/algebra/module.lean
+++ b/src/algebra/module.lean
@@ -356,8 +356,8 @@ lemma mul_mem_right (h : a ∈ I) : a * b ∈ I := mul_comm b a ▸ I.mul_mem_le
 
 end ideal
 
-/- Note[vector space definition]:
-Vector spaces are defined as an `abbreviation` for modules,
+library_note "vector space definition"
+"Vector spaces are defined as an `abbreviation` for modules,
 if the base ring is a field.
 (A previous definition made `vector_space` a structure
 defined to be `module`.)
@@ -366,8 +366,7 @@ for type class inference, which means that all instances for modules
 are immediately picked up for vector spaces as well.
 A cosmetic disadvantage is that one can not extend vector spaces an sich,
 in definitions such as `normed_space`.
-The solution is to extend `module` instead.
--/
+The solution is to extend `module` instead."
 
 /-- A vector space is the same as a module, except the scalar ring is actually
   a field. (This adds commutativity of the multiplication and existence of inverses.)

--- a/src/category_theory/limits/preserves.lean
+++ b/src/category_theory/limits/preserves.lean
@@ -7,21 +7,6 @@ import category_theory.limits.limits
 
 /-!
 # Preservation and reflection of (co)limits.
--/
-
-open category_theory
-
-namespace category_theory.limits
-
-universes v u₁ u₂ u₃ -- declare the `v`'s first; see `category_theory.category` for an explanation
-
-variables {C : Type u₁} [𝒞 : category.{v} C]
-variables {D : Type u₂} [𝒟 : category.{v} D]
-include 𝒞 𝒟
-
-variables {J : Type v} [small_category J] {K : J ⥤ C}
-
-/- Note on "preservation of (co)limits"
 
 There are various distinct notions of "preserving limits". The one we
 aim to capture here is: A functor F : C → D "preserves limits" if it
@@ -45,8 +30,19 @@ certain form, we say that a functor F preserves the limit of a
 diagram K if F sends every limit cone on K to a limit cone. This is
 vacuously satisfied when K does not admit a limit, which is consistent
 with the above definition of "preserves limits".
-
 -/
+
+open category_theory
+
+namespace category_theory.limits
+
+universes v u₁ u₂ u₃ -- declare the `v`'s first; see `category_theory.category` for an explanation
+
+variables {C : Type u₁} [𝒞 : category.{v} C]
+variables {D : Type u₂} [𝒟 : category.{v} D]
+include 𝒞 𝒟
+
+variables {J : Type v} [small_category J] {K : J ⥤ C}
 
 class preserves_limit (K : J ⥤ C) (F : C ⥤ D) : Type (max u₁ u₂ v) :=
 (preserves : Π {c : cone K}, is_limit c → is_limit (F.map_cone c))

--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -242,8 +242,7 @@ have h : ∀ {x : quotient s} {a : α}, x ∈ t → a ∈ s →
 
 end quotient_group
 
-/- Note [use has_coe_t]:
-We use the class `has_coe_t` instead of `has_coe` if the first-argument is a variable.
+library_note "use has_coe_t"
+"We use the class `has_coe_t` instead of `has_coe` if the first-argument is a variable.
 Using `has_coe` would cause looping of type-class inference. See
-<https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/remove.20all.20instances.20with.20variable.20domain>
--/
+<https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/remove.20all.20instances.20with.20variable.20domain>"

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -4,14 +4,21 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura
 -/
 
+import tactic.library_note
+
 /-!
+# Basic logic properties
+
+This file is one of the earliest imports in mathlib.
+
+## Implementation notes
+
 Theorems that require decidability hypotheses are in the namespace "decidable".
 Classical versions are in the namespace "classical".
 
-Note: in the presence of automation, this whole file may be unnecessary. On the other hand,
+In the presence of automation, this whole file may be unnecessary. On the other hand,
 maybe it is useful for writing automation.
 -/
-
 
 
 section miscellany
@@ -35,7 +42,7 @@ instance : decidable_eq empty := λa, a.elim
   {α} [subsingleton α] : decidable_eq α
 | a b := is_true (subsingleton.elim a b)
 
-/- Add an instance to "undo" coercion transitivity into a chain of coercions, because
+/-- Add an instance to "undo" coercion transitivity into a chain of coercions, because
    most simp lemmas are stated with respect to simple coercions and will not match when
    part of a chain. -/
 @[simp] theorem coe_coe {α β γ} [has_coe α β] [has_coe_t β γ]
@@ -95,8 +102,8 @@ lemma ne_comm {α} {a b : α} : a ≠ b ↔ b ≠ a := ⟨ne.symm, ne.symm⟩
 
 end miscellany
 
-/-
-    propositional connectives
+/-!
+### Declarations about propositional connectives
 -/
 
 @[simp] theorem false_ne_true : false ≠ true
@@ -105,7 +112,7 @@ end miscellany
 section propositional
 variables {a b c d : Prop}
 
-/- implies -/
+/-! ### Declarations about `implies` -/
 
 theorem iff_of_eq (e : a = b) : a ↔ b := e ▸ iff.rfl
 
@@ -138,7 +145,7 @@ iff_true_intro $ λ_, trivial
 @[simp] theorem imp_iff_right (ha : a) : (a → b) ↔ b :=
 ⟨λf, f ha, imp_intro⟩
 
-/- not -/
+/-! ### Declarations about `not` -/
 
 def not.elim {α : Sort*} (H1 : ¬a) (H2 : a) : α := absurd H2 H1
 
@@ -176,7 +183,7 @@ theorem imp.swap : (a → b → c) ↔ (b → a → c) :=
 theorem imp_not_comm : (a → ¬b) ↔ (b → ¬a) :=
 imp.swap
 
-/- and -/
+/-! ### Declarations about `and` -/
 
 theorem not_and_of_not_left (b : Prop) : ¬a → ¬(a ∧ b) :=
 mt and.left
@@ -211,7 +218,7 @@ iff.intro and.right (λ hb, ⟨h hb, hb⟩)
 lemma and.congr_right_iff : (a ∧ b ↔ a ∧ c) ↔ (a → (b ↔ c)) :=
 ⟨λ h ha, by simp [ha] at h; exact h, and_congr_right⟩
 
-/- or -/
+/-! ### Declarations about `or` -/
 
 theorem or_of_or_of_imp_of_imp (h₁ : a ∨ b) (h₂ : a → c) (h₃ : b → d) : c ∨ d :=
 or.imp h₂ h₃ h₁
@@ -238,7 +245,7 @@ or.comm.trans or_iff_not_imp_left
 theorem not_imp_not [decidable a] : (¬ a → ¬ b) ↔ (b → a) :=
 ⟨assume h hb, by_contradiction $ assume na, h na hb, mt⟩
 
-/- distributivity -/
+/-! ### Declarations about distributivity -/
 
 theorem and_or_distrib_left : a ∧ (b ∨ c) ↔ (a ∧ b) ∨ (a ∧ c) :=
 ⟨λ ⟨ha, hbc⟩, hbc.imp (and.intro ha) (and.intro ha),
@@ -254,7 +261,7 @@ theorem or_and_distrib_left : a ∨ (b ∧ c) ↔ (a ∨ b) ∧ (a ∨ c) :=
 theorem and_or_distrib_right : (a ∧ b) ∨ c ↔ (a ∨ c) ∧ (b ∨ c) :=
 (or.comm.trans or_and_distrib_left).trans (and_congr or.comm or.comm)
 
-/- iff -/
+/-! Declarations about `iff` -/
 
 theorem iff_of_true (ha : a) (hb : b) : a ↔ b :=
 ⟨λ_, hb, λ _, ha⟩
@@ -335,7 +342,7 @@ def decidable_of_bool : ∀ (b : bool) (h : b ↔ a), decidable a
 | tt h := is_true (h.1 rfl)
 | ff h := is_false (mt h.2 bool.ff_ne_tt)
 
-/- de morgan's laws -/
+/-! ### De Morgan's laws -/
 
 theorem not_and_of_not_or_not (h : ¬ a ∨ ¬ b) : ¬ (a ∧ b)
 | ⟨ha, hb⟩ := or.elim h (absurd ha) (absurd hb)
@@ -363,7 +370,7 @@ by rw [← not_and_distrib, not_not]
 
 end propositional
 
-/- equality -/
+/-! ### Declarations about equality -/
 
 section equality
 variables {α : Sort*} {a b : α}
@@ -406,9 +413,7 @@ by { subst hx, subst hy }
 
 end equality
 
-/-
-  quantifiers
--/
+/-! ### Declarations about quantifiers -/
 
 section quantifiers
 variables {α : Sort*} {β : Sort*} {p q : α → Prop} {b : Prop}
@@ -552,7 +557,7 @@ mt Exists.fst
 
 end quantifiers
 
-/- classical versions -/
+/-! ### Classical versions of earlier lemmas -/
 
 namespace classical
 variables {α : Sort*} {p : α → Prop}
@@ -603,14 +608,14 @@ by apply_instance
 noncomputable lemma dec_eq (α : Sort*) : decidable_eq α := -- see Note [classical lemma]
 by apply_instance
 
-/- Note [classical lemma]:
-  We make decidability results that depends on `classical.choice` noncomputable lemmas.
-  * We have to mark them as noncomputable, because otherwise Lean will try to generate bytecode
-    for them, and fail because it depends on `classical.choice`.
-  * We make them lemmas, and not definitions, because otherwise later definitions will raise
-    "failed to generate bytecode" errors when writing something like
-    `letI := classical.dec_eq _`.
-  Cf. <https://leanprover-community.github.io/archive/113488general/08268noncomputabletheorem.html> -/
+library_note "classical lemma"
+"We make decidability results that depends on `classical.choice` noncomputable lemmas.
+* We have to mark them as noncomputable, because otherwise Lean will try to generate bytecode
+  for them, and fail because it depends on `classical.choice`.
+* We make them lemmas, and not definitions, because otherwise later definitions will raise
+  \"failed to generate bytecode\" errors when writing something like
+  `letI := classical.dec_eq _`.
+Cf. <https://leanprover-community.github.io/archive/113488general/08268noncomputabletheorem.html>"
 
 @[elab_as_eliminator]
 noncomputable def {u} exists_cases {C : Sort u} (H0 : C) (H : ∀ a, p a → C) : C :=
@@ -631,9 +636,7 @@ noncomputable def {u} exists.classical_rec_on
  {α} {p : α → Prop} (h : ∃ a, p a) {C : Sort u} (H : ∀ a, p a → C) : C :=
 H (classical.some h) (classical.some_spec h)
 
-/-
-   bounded quantifiers
--/
+/-! ### Declarations about bounded quantifiers -/
 
 section bounded_quantifiers
 variables {α : Sort*} {r p q : α → Prop} {P Q : ∀ x, p x → Prop} {b : Prop}

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -369,14 +369,13 @@ meta def instantiate_lambdas_or_apps : list expr → expr → expr
 | es      (elet _ _ v b) := instantiate_lambdas_or_apps es $ b.instantiate_var v
 | es      e              := mk_app e es
 
-/- Note [open expressions]:
-  Some declarations work with open expressions, i.e. an expr that has free variables.
-  Terms will free variables are not well-typed, and one should not use them in tactics like
-  `infer_type` or `unify`. You can still do syntactic analysis/manipulation on them.
-  The reason for working with open types is for performance: instantiating variables requires
-  iterating through the expression. In one performance test `pi_binders` was more than 6x
-  quicker than `mk_local_pis` (when applied to the type of all imported declarations 100x).
-  -/
+library_note "open expressions"
+"Some declarations work with open expressions, i.e. an expr that has free variables.
+Terms will free variables are not well-typed, and one should not use them in tactics like
+`infer_type` or `unify`. You can still do syntactic analysis/manipulation on them.
+The reason for working with open types is for performance: instantiating variables requires
+iterating through the expression. In one performance test `pi_binders` was more than 6x
+quicker than `mk_local_pis` (when applied to the type of all imported declarations 100x)."
 
 /-- Get the codomain/target of a pi-type.
   This definition doesn't instantiate bound variables, and therefore produces a term that is open.-/

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Simon Hudon, Scott Morrison, Keeley Hoek
 -/
-import data.dlist.basic category.basic meta.expr meta.rb_map data.bool
+import data.dlist.basic category.basic meta.expr meta.rb_map data.bool tactic.library_note
 
 namespace expr
 open tactic

--- a/src/tactic/library_note.lean
+++ b/src/tactic/library_note.lean
@@ -50,7 +50,7 @@ open tactic
 
 /-- Creates a name to store `note_id`. -/
 private meta def get_name_for (note_id : string) : name :=
-`library_note <.> to_string note_id.hash
+`library_note <.> ("_" + to_string note_id.hash)
 
 /-- If `note_name` and `note` are `pexpr`s representing strings,
 `add_library_note note_name note` adds a declaration of type `string × string` and tags it with

--- a/src/tactic/library_note.lean
+++ b/src/tactic/library_note.lean
@@ -50,7 +50,7 @@ open tactic
 
 /-- Creates a name to store `note_id`. -/
 private meta def get_name_for (note_id : string) : name :=
-`library_note <.> ("_" + to_string note_id.hash)
+`library_note <.> ("_" ++ to_string note_id.hash)
 
 /-- If `note_name` and `note` are `pexpr`s representing strings,
 `add_library_note note_name note` adds a declaration of type `string × string` and tags it with

--- a/src/tactic/library_note.lean
+++ b/src/tactic/library_note.lean
@@ -23,7 +23,12 @@ iterating through the expression. In one performance test `pi_binders` was more 
 quicker than `mk_local_pis` (when applied to the type of all imported declarations 100x)."
 ```
 
-Since these notes are used in files imported by `tactic.core`, this file has no imports..
+These notes can be referenced in mathlib with the syntax `Note [note id]`.
+Often, these references will be made in code comments (`--`) that won't be displayed in docs.
+If such a reference is made in a doc string or module doc, it will be linked to the corresponding
+note in the doc display.
+
+Since these notes are used in files imported by `tactic.core`, this file has no imports.
 
 ## Implementation details
 

--- a/src/tactic/library_note.lean
+++ b/src/tactic/library_note.lean
@@ -45,7 +45,7 @@ open tactic
 
 /-- Creates a name to store `note_id`. -/
 private meta def get_name_for (note_id : string) : name :=
-name.mk_numeral ⟨note_id.hash, undefined⟩ `library_note
+`library_note <.> to_string note_id.hash
 
 /-- If `note_name` and `note` are `pexpr`s representing strings,
 `add_library_note note_name note` adds a declaration of type `string × string` and tags it with

--- a/src/tactic/library_note.lean
+++ b/src/tactic/library_note.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2019 Robert Y. Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Y. Lewis
+-/
+
+/-!
+# Library notes
+
+At various places in mathlib, we leave implementation notes that are referenced from many other
+files. To keep track of these notes, we use the command `library_note`. This makes it easy to
+retrieve a list of all notes, e.g. for documentation output.
+
+An example from `meta.expr`:
+
+```
+library_note "open expressions"
+"Some declarations work with open expressions, i.e. an expr that has free variables.
+Terms will free variables are not well-typed, and one should not use them in tactics like
+`infer_type` or `unify`. You can still do syntactic analysis/manipulation on them.
+The reason for working with open types is for performance: instantiating variables requires
+iterating through the expression. In one performance test `pi_binders` was more than 6x
+quicker than `mk_local_pis` (when applied to the type of all imported declarations 100x)."
+```
+
+Since these notes are used in files imported by `tactic.core`, this file has no imports..
+
+## Implementation details
+
+`library_note note_id note_msg` creates a declaration `` `library_note.i `` for some `i`.
+This declaration is a pair of strings `note_id` and `note_msg`, and it gets tagged with the
+`library_note` attribute.
+-/
+
+/-- A rudimentary hash function on strings. -/
+def string.hash (s : string) : ℕ :=
+s.fold 1 (λ h c, (33*h + c.val) % unsigned_sz)
+
+/-- A user attribute `library_note` for tagging decls of type `string × string` for use in note output. -/
+@[user_attribute] meta def library_note_attr : user_attribute :=
+{ name := `library_note,
+  descr := "Notes about library features to be included in documentation" }
+
+open tactic
+
+/-- Creates a name to store `note_id`. -/
+private meta def get_name_for (note_id : string) : name :=
+name.mk_numeral ⟨note_id.hash, undefined⟩ `library_note
+
+/-- If `note_name` and `note` are `pexpr`s representing strings,
+`add_library_note note_name note` adds a declaration of type `string × string` and tags it with
+the `library_note` attribute. -/
+meta def tactic.add_library_note (note_name note : pexpr) : tactic unit :=
+do note_name ← to_expr note_name,
+   note ← to_expr note,
+   let decl_name := get_name_for (to_string note_name),
+   body ← to_expr ``((%%note_name, %%note) : string × string),
+   add_decl $ mk_definition decl_name [] `(string × string) body,
+   library_note_attr.set decl_name () tt none
+
+open lean lean.parser interactive
+/-- A command to add library notes. Syntax:
+```
+library_note "note id" "note content"
+``` -/
+@[user_command] meta def library_note (_ : parse (tk "library_note")) : parser unit :=
+do name ← parser.pexpr,
+   note ← parser.pexpr,
+   of_tactic $ tactic.add_library_note name note
+
+/-- Collects all notes in the current environment. Returns a list of pairs `(note_id, note_content)` -/
+meta def tactic.get_library_notes : tactic (list (string × string)) :=
+attribute.get_instances `library_note >>= list.mmap (λ dcl, mk_const dcl >>= eval_expr (string × string))

--- a/src/tactic/lint.lean
+++ b/src/tactic/lint.lean
@@ -269,33 +269,31 @@ meta def instance_priority (d : declaration) : tactic (option string) := do
   let always_applies := relevant_args.all expr.is_var ∧ relevant_args.nodup,
   if always_applies then return $ some "set priority below 1000" else return none
 
-/- Note [lower instance priority]:
-  Certain instances always apply during type-class resolution. For example, the instance
-  `add_comm_group.to_add_group {α} [add_comm_group α] : add_group α` applies to all type-class
-  resolution problems of the form `add_group _`, and type-class inference will then do an
-  exhaustive search to find a commutative group. These instances take a long time to fail.
-  Other instances will only apply if the goal has a certain shape. For example
-  `int.add_group : add_group ℤ` or
-  `add_group.prod {α β} [add_group α] [add_group β] : add_group (α × β)`. Usually these instances
-  will fail quickly, and when they apply, they are almost the desired instance.
-  For this reason, we want the instances of the second type (that only apply in specific cases) to
-  always have higher priority than the instances of the first type (that always apply).
-  See also #1561.
+library_note "lower instance priority"
+"Certain instances always apply during type-class resolution. For example, the instance
+`add_comm_group.to_add_group {α} [add_comm_group α] : add_group α` applies to all type-class
+resolution problems of the form `add_group _`, and type-class inference will then do an
+exhaustive search to find a commutative group. These instances take a long time to fail.
+Other instances will only apply if the goal has a certain shape. For example
+`int.add_group : add_group ℤ` or
+`add_group.prod {α β} [add_group α] [add_group β] : add_group (α × β)`. Usually these instances
+will fail quickly, and when they apply, they are almost the desired instance.
+For this reason, we want the instances of the second type (that only apply in specific cases) to
+always have higher priority than the instances of the first type (that always apply).
+See also #1561.
 
-  Therefore, if we create an instance that always applies, we set the priority of these instances to
-  100 (or something similar, which is below the default value of 1000).
--/
+Therefore, if we create an instance that always applies, we set the priority of these instances to
+100 (or something similar, which is below the default value of 1000)."
 
-/- Note [default priority]:
-  Instances that always apply should be applied after instances that only apply in specific cases,
-  see note [lower instance priority] above.
+library_note "default priority"
+"Instances that always apply should be applied after instances that only apply in specific cases,
+see note [lower instance priority] above.
 
-  Classes that use the `extends` keyword automatically generate instances that always apply.
-  Therefore, we set the priority of these instances to 100 (or something similar, which is below the
-  default value of 1000) using `set_option default_priority 100`.
-  We have to put this option inside a section, so that the default priority is the default
-  1000 outside the section.
--/
+Classes that use the `extends` keyword automatically generate instances that always apply.
+Therefore, we set the priority of these instances to 100 (or something similar, which is below the
+default value of 1000) using `set_option default_priority 100`.
+We have to put this option inside a section, so that the default priority is the default
+1000 outside the section."
 
 /-- A linter object for checking instance priorities of instances that always apply.
   This is in the default linter set. -/

--- a/src/tactic/localized.lean
+++ b/src/tactic/localized.lean
@@ -55,9 +55,6 @@ do ns ← many ident,
    cmds ← get_localized ns,
    cmds.mmap' emit_code_here
 
-def string_hash (s : string) : ℕ :=
-s.fold 1 (λ h c, (33*h + c.val) % unsigned_sz)
-
 /-- Add a new command to a notation namespace and execute it right now.
   The new command is added as a declaration to the environment with name `_localized_decl.<number>`.
   This declaration has attribute `_localized` and as value a name-string pair. -/
@@ -70,7 +67,7 @@ do cmd ← parser.pexpr, cmd ← i_to_expr cmd, cmd ← eval_expr string cmd,
    nm ← ident,
    env ← get_env,
    let dummy_decl_name := mk_num_name `_localized_decl
-     ((string_hash (cmd ++ nm.to_string) + env.fingerprint) % unsigned_sz),
+     ((string.hash (cmd ++ nm.to_string) + env.fingerprint) % unsigned_sz),
    add_decl (declaration.defn dummy_decl_name [] `(name × string)
     (reflect (⟨nm, cmd⟩ : name × string)) (reducibility_hints.regular 1 tt) ff),
    localized_attr.set dummy_decl_name unit.star tt


### PR DESCRIPTION
This came up in a recent PR: we have various notes scattered around the library, but no consistent way to track and reference them.

This provides a user command `library_note` to declare these notes, which makes them easy to retrieve, and e.g. display in doc generation. It doesn't change anything about note references yet. For references that occur in visible comments (e.g. doc strings), we can parse them in doc generation and link to the correct note. But many appear in line comments, so there's not much to do with those.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
