### PR TITLE
refactor(analysis/calculus/deriv): Use equality of functions

### DIFF
--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -452,7 +452,7 @@ have ¬differentiable_at 𝕜 (λ y, -f y) x, from λ h', by simpa only [neg_neg
 by simp only [deriv_zero_of_not_differentiable_at h,
   deriv_zero_of_not_differentiable_at this, neg_zero]
 
-lemma deriv_neg' : deriv (λy, -f y) = (λ x, - deriv f x) :=
+@[simp] lemma deriv_neg' : deriv (λy, -f y) = (λ x, - deriv f x) :=
 funext $ λ x, deriv_neg
 
 end neg

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -318,8 +318,11 @@ has_deriv_at_filter_id _ _
 theorem has_deriv_at_id : has_deriv_at id 1 x :=
 has_deriv_at_filter_id _ _
 
-@[simp] lemma deriv_id : deriv (@id ℝ) = λ _, 1 :=
-funext $ λ x, has_deriv_at.deriv (has_deriv_at_id x)
+lemma deriv_id : deriv id x = 1 :=
+has_deriv_at.deriv (has_deriv_at_id x)
+
+@[simp] lemma deriv_id' : deriv (@id ℝ) = λ _, 1 :=
+funext deriv_id
 
 lemma deriv_within_id (hxs : unique_diff_within_at 𝕜 s x) : deriv_within id s x = 1 :=
 by { unfold deriv_within, rw fderiv_within_id, simp, assumption }
@@ -339,8 +342,11 @@ has_deriv_at_filter_const _ _ _
 theorem has_deriv_at_const : has_deriv_at (λ x, c) 0 x :=
 has_deriv_at_filter_const _ _ _
 
-@[simp] lemma deriv_const : deriv (λ x, c) = λ x, 0 :=
-funext $ λ x, has_deriv_at.deriv (has_deriv_at_const x c)
+lemma deriv_const : deriv (λ x, c) x = 0 :=
+has_deriv_at.deriv (has_deriv_at_const x c)
+
+@[simp] lemma deriv_const' : deriv (λ x:𝕜, c) = λ x, 0 :=
+funext (λ x, deriv_const x c)
 
 lemma deriv_within_const (hxs : unique_diff_within_at 𝕜 s x) : deriv_within (λ x, c) s x = 0 :=
 by { rw (differentiable_at_const _).deriv_within hxs, apply deriv_const }
@@ -440,12 +446,14 @@ lemma deriv_within_neg (hxs : unique_diff_within_at 𝕜 s x)
   deriv_within (λy, -f y) s x = - deriv_within f s x :=
 h.has_deriv_within_at.neg.deriv_within hxs
 
-lemma deriv_neg : deriv (λy, -f y) = λ y, - deriv f y :=
-funext $ assume x,
+lemma deriv_neg : deriv (λy, -f y) x = - deriv f x :=
 if h : differentiable_at 𝕜 f x then h.has_deriv_at.neg.deriv else
 have ¬differentiable_at 𝕜 (λ y, -f y) x, from λ h', by simpa only [neg_neg] using h'.neg,
 by simp only [deriv_zero_of_not_differentiable_at h,
   deriv_zero_of_not_differentiable_at this, neg_zero]
+
+lemma deriv_neg' : deriv (λy, -f y) = (λ x, - deriv f x) :=
+funext $ λ x, deriv_neg
 
 end neg
 
@@ -964,11 +972,14 @@ lemma differentiable_pow : differentiable 𝕜 (λx:𝕜, x^n) :=
 lemma differentiable_on_pow : differentiable_on 𝕜 (λx, x^n) s :=
 differentiable_pow.differentiable_on
 
-@[simp] lemma deriv_pow : deriv (λx, x^n) = λ x, (n : 𝕜) * x^(n-1) :=
-funext $ λ x, (has_deriv_at_pow n x).deriv
+lemma deriv_pow : deriv (λx, x^n) x = (n : 𝕜) * x^(n-1) :=
+(has_deriv_at_pow n x).deriv
+
+@[simp] lemma deriv_pow' : deriv (λx, x^n) = λ x, (n : 𝕜) * x^(n-1) :=
+funext $ λ x, deriv_pow
 
 lemma deriv_within_pow (hxs : unique_diff_within_at 𝕜 s x) :
   deriv_within (λx, x^n) s x = (n : 𝕜) * x^(n-1) :=
-by rw [differentiable_at.deriv_within differentiable_at_pow hxs, deriv_pow]
+by rw [differentiable_at_pow.deriv_within hxs, deriv_pow]
 
 end pow

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -318,8 +318,8 @@ has_deriv_at_filter_id _ _
 theorem has_deriv_at_id : has_deriv_at id 1 x :=
 has_deriv_at_filter_id _ _
 
-@[simp] lemma deriv_id : deriv id x = 1 :=
-has_deriv_at.deriv (has_deriv_at_id x)
+@[simp] lemma deriv_id : deriv (@id ℝ) = λ _, 1 :=
+funext $ λ x, has_deriv_at.deriv (has_deriv_at_id x)
 
 lemma deriv_within_id (hxs : unique_diff_within_at 𝕜 s x) : deriv_within id s x = 1 :=
 by { unfold deriv_within, rw fderiv_within_id, simp, assumption }
@@ -339,8 +339,8 @@ has_deriv_at_filter_const _ _ _
 theorem has_deriv_at_const : has_deriv_at (λ x, c) 0 x :=
 has_deriv_at_filter_const _ _ _
 
-lemma deriv_const : deriv (λ x, c) x = 0 :=
-has_deriv_at.deriv (has_deriv_at_const x c)
+@[simp] lemma deriv_const : deriv (λ x, c) = λ x, 0 :=
+funext $ λ x, has_deriv_at.deriv (has_deriv_at_const x c)
 
 lemma deriv_within_const (hxs : unique_diff_within_at 𝕜 s x) : deriv_within (λ x, c) s x = 0 :=
 by { rw (differentiable_at_const _).deriv_within hxs, apply deriv_const }
@@ -440,8 +440,12 @@ lemma deriv_within_neg (hxs : unique_diff_within_at 𝕜 s x)
   deriv_within (λy, -f y) s x = - deriv_within f s x :=
 h.has_deriv_within_at.neg.deriv_within hxs
 
-lemma deriv_neg (h : differentiable_at 𝕜 f x) : deriv (λy, -f y) x = - deriv f x :=
-h.has_deriv_at.neg.deriv
+lemma deriv_neg : deriv (λy, -f y) = λ y, - deriv f y :=
+funext $ assume x,
+if h : differentiable_at 𝕜 f x then h.has_deriv_at.neg.deriv else
+have ¬differentiable_at 𝕜 (λ y, -f y) x, from λ h', by simpa only [neg_neg] using h'.neg,
+by simp only [deriv_zero_of_not_differentiable_at h,
+  deriv_zero_of_not_differentiable_at this, neg_zero]
 
 end neg
 
@@ -960,14 +964,11 @@ lemma differentiable_pow : differentiable 𝕜 (λx:𝕜, x^n) :=
 lemma differentiable_on_pow : differentiable_on 𝕜 (λx, x^n) s :=
 differentiable_pow.differentiable_on
 
-@[simp] lemma deriv_pow : deriv (λx, x^n) x = (n : 𝕜) * x^(n-1) :=
-(has_deriv_at_pow n x).deriv
+@[simp] lemma deriv_pow : deriv (λx, x^n) = λ x, (n : 𝕜) * x^(n-1) :=
+funext $ λ x, (has_deriv_at_pow n x).deriv
 
 lemma deriv_within_pow (hxs : unique_diff_within_at 𝕜 s x) :
   deriv_within (λx, x^n) s x = (n : 𝕜) * x^(n-1) :=
-begin
-  rw differentiable_at.deriv_within differentiable_at_pow hxs,
-  exact deriv_pow
-end
+by rw [differentiable_at.deriv_within differentiable_at_pow hxs, deriv_pow]
 
 end pow

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -321,7 +321,7 @@ has_deriv_at_filter_id _ _
 lemma deriv_id : deriv id x = 1 :=
 has_deriv_at.deriv (has_deriv_at_id x)
 
-@[simp] lemma deriv_id' : deriv (@id ℝ) = λ _, 1 :=
+@[simp] lemma deriv_id' : deriv (@id 𝕜) = λ _, 1 :=
 funext deriv_id
 
 lemma deriv_within_id (hxs : unique_diff_within_at 𝕜 s x) : deriv_within id s x = 1 :=

--- a/src/analysis/complex/exponential.lean
+++ b/src/analysis/complex/exponential.lean
@@ -124,7 +124,7 @@ end
 lemma differentiable_cos : differentiable ℂ cos :=
 λx, (has_deriv_at_cos x).differentiable_at
 
-lemma deriv_cos : deriv cos x = -sin x :=
+lemma deriv_cos {x : ℂ} : deriv cos x = -sin x :=
 (has_deriv_at_cos x).deriv
 
 @[simp] lemma deriv_cos' : deriv cos = (λ x, -sin x) :=

--- a/src/analysis/complex/exponential.lean
+++ b/src/analysis/complex/exponential.lean
@@ -124,8 +124,11 @@ end
 lemma differentiable_cos : differentiable ℂ cos :=
 λx, (has_deriv_at_cos x).differentiable_at
 
-@[simp] lemma deriv_cos : deriv cos = (λ x, -sin x) :=
-funext $ λ x, (has_deriv_at_cos x).deriv
+lemma deriv_cos : deriv cos x = -sin x :=
+(has_deriv_at_cos x).deriv
+
+@[simp] lemma deriv_cos' : deriv cos = (λ x, -sin x) :=
+funext $ λ x, deriv_cos
 
 lemma continuous_cos : continuous cos :=
 differentiable_cos.continuous
@@ -214,8 +217,11 @@ lemma has_deriv_at_cos (x : ℝ) : has_deriv_at cos (-sin x) x :=
 lemma differentiable_cos : differentiable ℝ cos :=
 λx, (has_deriv_at_cos x).differentiable_at
 
-@[simp] lemma deriv_cos : deriv cos = (λ x, - sin x) :=
-funext $ λ x, (has_deriv_at_cos x).deriv
+lemma deriv_cos : deriv cos x = - sin x :=
+(has_deriv_at_cos x).deriv
+
+@[simp] lemma deriv_cos' : deriv cos = (λ x, - sin x) :=
+funext $ λ _, deriv_cos
 
 lemma continuous_cos : continuous cos :=
 differentiable_cos.continuous

--- a/src/analysis/complex/exponential.lean
+++ b/src/analysis/complex/exponential.lean
@@ -65,8 +65,12 @@ end
 lemma differentiable_exp : differentiable ℂ exp :=
 λx, (has_deriv_at_exp x).differentiable_at
 
-@[simp] lemma deriv_exp {x : ℂ} : deriv exp x = exp x :=
-(has_deriv_at_exp x).deriv
+@[simp] lemma deriv_exp : deriv exp = exp :=
+funext $ λ x, (has_deriv_at_exp x).deriv
+
+@[simp] lemma iter_deriv_exp : ∀ n : ℕ, (deriv^[n] exp) = exp
+| 0 := rfl
+| (n+1) := by rw [nat.iterate_succ, deriv_exp, iter_deriv_exp n]
 
 lemma continuous_exp : continuous exp :=
 differentiable_exp.continuous
@@ -93,8 +97,8 @@ end
 lemma differentiable_sin : differentiable ℂ sin :=
 λx, (has_deriv_at_sin x).differentiable_at
 
-@[simp] lemma deriv_sin {x : ℂ} : deriv sin x = cos x :=
-(has_deriv_at_sin x).deriv
+@[simp] lemma deriv_sin : deriv sin = cos :=
+funext $ λ x, (has_deriv_at_sin x).deriv
 
 lemma continuous_sin : continuous sin :=
 differentiable_sin.continuous
@@ -120,8 +124,8 @@ end
 lemma differentiable_cos : differentiable ℂ cos :=
 λx, (has_deriv_at_cos x).differentiable_at
 
-@[simp] lemma deriv_cos {x : ℂ} : deriv cos x = -sin x :=
-(has_deriv_at_cos x).deriv
+@[simp] lemma deriv_cos : deriv cos = (λ x, -sin x) :=
+funext $ λ x, (has_deriv_at_cos x).deriv
 
 lemma continuous_cos : continuous cos :=
 differentiable_cos.continuous
@@ -144,8 +148,8 @@ end
 lemma differentiable_sinh : differentiable ℂ sinh :=
 λx, (has_deriv_at_sinh x).differentiable_at
 
-@[simp] lemma deriv_sinh {x : ℂ} : deriv sinh x = cosh x :=
-(has_deriv_at_sinh x).deriv
+@[simp] lemma deriv_sinh : deriv sinh = cosh :=
+funext $ λ x, (has_deriv_at_sinh x).deriv
 
 lemma continuous_sinh : continuous sinh :=
 differentiable_sinh.continuous
@@ -164,8 +168,8 @@ end
 lemma differentiable_cosh : differentiable ℂ cosh :=
 λx, (has_deriv_at_cosh x).differentiable_at
 
-@[simp] lemma deriv_cosh {x : ℂ} : deriv cosh x = sinh x :=
-(has_deriv_at_cosh x).deriv
+@[simp] lemma deriv_cosh : deriv cosh = sinh :=
+funext $ λ x, (has_deriv_at_cosh x).deriv
 
 lemma continuous_cosh : continuous cosh :=
 differentiable_cosh.continuous
@@ -182,8 +186,12 @@ has_deriv_at_real_of_complex (complex.has_deriv_at_exp x)
 lemma differentiable_exp : differentiable ℝ exp :=
 λx, (has_deriv_at_exp x).differentiable_at
 
-@[simp] lemma deriv_exp : deriv exp x = exp x :=
-(has_deriv_at_exp x).deriv
+@[simp] lemma deriv_exp : deriv exp = exp :=
+funext $ λ x, (has_deriv_at_exp x).deriv
+
+@[simp] lemma iter_deriv_exp : ∀ n : ℕ, (deriv^[n] exp) = exp
+| 0 := rfl
+| (n+1) := by rw [nat.iterate_succ, deriv_exp, iter_deriv_exp n]
 
 lemma continuous_exp : continuous exp :=
 differentiable_exp.continuous
@@ -194,8 +202,8 @@ has_deriv_at_real_of_complex (complex.has_deriv_at_sin x)
 lemma differentiable_sin : differentiable ℝ sin :=
 λx, (has_deriv_at_sin x).differentiable_at
 
-@[simp] lemma deriv_sin : deriv sin x = cos x :=
-(has_deriv_at_sin x).deriv
+@[simp] lemma deriv_sin : deriv sin = cos :=
+funext $ λ x, (has_deriv_at_sin x).deriv
 
 lemma continuous_sin : continuous sin :=
 differentiable_sin.continuous
@@ -206,8 +214,8 @@ lemma has_deriv_at_cos (x : ℝ) : has_deriv_at cos (-sin x) x :=
 lemma differentiable_cos : differentiable ℝ cos :=
 λx, (has_deriv_at_cos x).differentiable_at
 
-@[simp] lemma deriv_cos : deriv cos x = - sin x :=
-(has_deriv_at_cos x).deriv
+@[simp] lemma deriv_cos : deriv cos = (λ x, - sin x) :=
+funext $ λ x, (has_deriv_at_cos x).deriv
 
 lemma continuous_cos : continuous cos :=
 differentiable_cos.continuous
@@ -224,8 +232,8 @@ has_deriv_at_real_of_complex (complex.has_deriv_at_sinh x)
 lemma differentiable_sinh : differentiable ℝ sinh :=
 λx, (has_deriv_at_sinh x).differentiable_at
 
-@[simp] lemma deriv_sinh : deriv sinh x = cosh x :=
-(has_deriv_at_sinh x).deriv
+@[simp] lemma deriv_sinh : deriv sinh = cosh :=
+funext $ λ x, (has_deriv_at_sinh x).deriv
 
 lemma continuous_sinh : continuous sinh :=
 differentiable_sinh.continuous
@@ -236,8 +244,8 @@ has_deriv_at_real_of_complex (complex.has_deriv_at_cosh x)
 lemma differentiable_cosh : differentiable ℝ cosh :=
 λx, (has_deriv_at_cosh x).differentiable_at
 
-@[simp] lemma deriv_cosh : deriv cosh x = sinh x :=
-(has_deriv_at_cosh x).deriv
+@[simp] lemma deriv_cosh : deriv cosh = sinh :=
+funext $ λ x, (has_deriv_at_cosh x).deriv
 
 lemma continuous_cosh : continuous cosh :=
 differentiable_cosh.continuous


### PR DESCRIPTION
This way we can rewrite, e.g., in `deriv (deriv sin)`.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
