### PR TITLE
refactor(data/equiv/encodable): bring `directed.sequence*` from `integration`, use `quotient.rep` instead of `quot.rep`

### DIFF
--- a/src/data/equiv/encodable.lean
+++ b/src/data/equiv/encodable.lean
@@ -297,7 +297,7 @@ variables {α : Type*} {β : Type*} [encodable α] [inhabited α]
 
 /-- Given a `directed r` function `f : α → β` defined on an encodable inhabited type,
 construct a noncomputable sequence such that `r (f (x n)) (f (x (n + 1)))`
-and `r a (f (x (encode a + 1))`. -/
+and `r (f a) (f (x (encode a + 1))`. -/
 protected noncomputable def sequence {r : β → β → Prop} (f : α → β) (hf : directed r f) : ℕ → α
 | 0       := default α
 | (n + 1) :=

--- a/src/data/equiv/encodable.lean
+++ b/src/data/equiv/encodable.lean
@@ -39,6 +39,7 @@ def of_left_inverse [encodable α]
   (f : β → α) (finv : α → β) (linv : ∀ b, finv (f b) = b) : encodable β :=
 of_left_injection f (some ∘ finv) (λ b, congr_arg some (linv b))
 
+/-- If `α` is encodable and `β ≃ α`, then so is `β` -/
 def of_equiv (α) [encodable α] (e : β ≃ α) : encodable β :=
 of_left_inverse e e.symm e.left_inv
 
@@ -318,7 +319,7 @@ begin
   { exact (classical.some_spec (hf p a)).1 }
 end
 
-lemma rel_sequence {r : β → β → Prop} (hr : reflexive r) {f : α → β} (hf : directed r f) (a : α) :
+lemma rel_sequence {r : β → β → Prop} {f : α → β} (hf : directed r f) (a : α) :
   r (f a) (f (hf.sequence f (encode a + 1))) :=
 begin
   simp only [directed.sequence, encodek],
@@ -331,7 +332,7 @@ lemma sequence_mono : monotone (f ∘ (hf.sequence f)) :=
 monotone_of_monotone_nat $ hf.sequence_mono_nat le_refl
 
 lemma le_sequence (a : α) : f a ≤ f (hf.sequence f (encode a + 1)) :=
-hf.rel_sequence le_refl a
+hf.rel_sequence a
 
 end directed
 

--- a/src/data/equiv/encodable.lean
+++ b/src/data/equiv/encodable.lean
@@ -304,18 +304,17 @@ protected noncomputable def sequence {r : β → β → Prop} (f : α → β) (h
 | (n + 1) :=
   let p := sequence n in
   match decode α n with
-  | none     := p
+  | none     := classical.some (hf p p)
   | (some a) := classical.some (hf p a)
   end
 
-lemma sequence_mono_nat {r : β → β → Prop} (hr : reflexive r) {f : α → β}
-  (hf : directed r f) (n : ℕ) :
+lemma sequence_mono_nat {r : β → β → Prop} {f : α → β} (hf : directed r f) (n : ℕ) :
   r (f (hf.sequence f n)) (f (hf.sequence f (n+1))) :=
 begin
   dsimp [directed.sequence],
   generalize eq : hf.sequence f n = p,
   cases h : decode α n with a,
-  { exact hr _ },
+  { exact (classical.some_spec (hf p p)).1 },
   { exact (classical.some_spec (hf p a)).1 }
 end
 
@@ -329,7 +328,7 @@ end
 variables [preorder β] {f : α → β} (hf : directed (≤) f)
 
 lemma sequence_mono : monotone (f ∘ (hf.sequence f)) :=
-monotone_of_monotone_nat $ hf.sequence_mono_nat le_refl
+monotone_of_monotone_nat $ hf.sequence_mono_nat
 
 lemma le_sequence (a : α) : f a ≤ f (hf.sequence f (encode a + 1)) :=
 hf.rel_sequence a

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -20,9 +20,9 @@ namespace measure_theory
 
 variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*}
 
-/-- A function from `f` a measurable space to any type is called *simple*,
+/-- A function `f` from a measurable space to any type is called *simple*,
 if every preimage `f ⁻¹' {x}` is measurable, and the range is finite. This structure bundles
-a function with the properties. -/
+a function with these properties. -/
 structure {u v} simple_func (α : Type u) [measurable_space α] (β : Type v) :=
 (to_fun : α → β)
 (measurable_sn : ∀ x, is_measurable (to_fun ⁻¹' {x}))
@@ -40,7 +40,7 @@ instance has_coe_to_fun : has_coe_to_fun (α →ₛ β) := ⟨_, to_fun⟩
 by cases f; cases g; congr; exact funext H
 
 /-- Range of a simple function `α →ₛ β` as a `finset β`. -/
-protected def range (f : α →ₛ β) : finset β:= f.finite.to_finset
+protected def range (f : α →ₛ β) : finset β := f.finite.to_finset
 
 @[simp] theorem mem_range {f : α →ₛ β} {b} : b ∈ f.range ↔ ∃ a, f a = b :=
 finite.mem_to_finset

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -878,8 +878,7 @@ iff.intro
 
 lemma all_ae_iff {p : α → Prop} : (∀ₘ a, p a) ↔ volume { a | ¬ p a } = 0 := iff.rfl
 
-lemma all_ae_of_all {p : α → Prop} : (∀a, p a) → ∀ₘ a, p a := assume h,
-by {rw all_ae_iff, convert volume_empty, simp only [h, not_true], reflexivity}
+lemma all_ae_of_all {p : α → Prop} : (∀a, p a) → ∀ₘ a, p a := univ_mem_sets'
 
 lemma all_ae_all_iff {ι : Type*} [encodable ι] {p : α → ι → Prop} :
   (∀ₘ a, ∀i, p a i) ↔ (∀i, ∀ₘ a, p a i) :=


### PR DESCRIPTION
`sequence_of_directed` in `measure_theory/integration` did not belong
there.

Also add some docstrings.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)