### PR TITLE
refactor(calculus): simplify derivative extension

### DIFF
--- a/src/analysis/calculus/extend_deriv.lean
+++ b/src/analysis/calculus/extend_deriv.lean
@@ -72,12 +72,12 @@ begin
     have op : is_open (B ∩ s) := is_open_inter is_open_ball s_open,
     rw differentiable_at.fderiv_within _ (op.unique_diff_on z z_in),
     exact (diff z z_in).differentiable_at (mem_nhds_sets op z_in) },
-  refine continuous_within_at.closure_le _ _ key ;
-  try { -- common start for both continuity proofs
+  rintros ⟨u, v⟩ uv_in,
+  refine continuous_within_at.closure_le uv_in _ _ key,
+  all_goals { -- common start for both continuity proofs
     have : (B ∩ s).prod (B ∩ s) ⊆ s.prod s, by mono ; exact inter_subset_right _ _,
-    rintros ⟨u, v⟩ mem,
     obtain ⟨u_in, v_in⟩ : u ∈ closure s ∧ v ∈ closure s,
-      by simpa [closure_prod_eq] using closure_mono this mem,
+      by simpa [closure_prod_eq] using closure_mono this uv_in,
     apply continuous_within_at.mono _ this,
     simp only [continuous_within_at, nhds_prod_eq] },
   { rw nhds_within_prod_eq,

--- a/src/analysis/calculus/extend_deriv.lean
+++ b/src/analysis/calculus/extend_deriv.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
 
-import analysis.calculus.mean_value topology.sequences
+import analysis.calculus.mean_value
 import tactic.monotonicity
 
 /-!

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -96,6 +96,22 @@ lemma closure_lt_subset_le [topological_space β] {f g : β → α} (hf : contin
   closure {b | f b < g b} ⊆ {b | f b ≤ g b} :=
 by { rw [←closure_le_eq hf hg], exact closure_mono (λ b, le_of_lt) }
 
+lemma continuous_within_at.closure_le [topological_space β]
+ {f g : β → α} {s : set β}
+ (hf : ∀ x ∈ closure s, continuous_within_at f s x)
+ (hg : ∀ x ∈ closure s, continuous_within_at g s x)
+ (h : ∀ x ∈ s, f x ≤ g x) : ∀ x ∈ closure s, f x ≤ g x :=
+begin
+  let ψ := λ x, (f x, g x),
+  have cont : ∀ x ∈ closure s, continuous_within_at ψ s x,
+    from λ x x_in, continuous_within_at.prod (hf _ x_in) (hg _ x_in),
+  change closure s ⊆ ψ ⁻¹' {p | p.1 ≤ p.2},
+  change s ⊆ ψ ⁻¹' {p | p.1 ≤ p.2} at h,
+  rw ← image_subset_iff at *,
+  calc ψ '' closure s ⊆ closure (ψ '' s) : continuous_within_at.image_closure cont
+  ... ⊆ closure {p | p.1 ≤ p.2} : closure_mono h
+  ... = {p | p.1 ≤ p.2} : closure_eq_iff_is_closed.2 (ordered_topology.is_closed_le' _)
+end
 end preorder
 
 section partial_order

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -97,20 +97,26 @@ lemma closure_lt_subset_le [topological_space β] {f g : β → α} (hf : contin
 by { rw [←closure_le_eq hf hg], exact closure_mono (λ b, le_of_lt) }
 
 lemma continuous_within_at.closure_le [topological_space β]
- {f g : β → α} {s : set β}
- (hf : ∀ x ∈ closure s, continuous_within_at f s x)
- (hg : ∀ x ∈ closure s, continuous_within_at g s x)
- (h : ∀ x ∈ s, f x ≤ g x) : ∀ x ∈ closure s, f x ≤ g x :=
+ {f g : β → α} {s : set β} {x : β} (hx : x ∈ closure s)
+ (hf : continuous_within_at f s x)
+ (hg : continuous_within_at g s x)
+ (h : ∀ y ∈ s, f y ≤ g y) : f x ≤ g x :=
 begin
   let ψ := λ x, (f x, g x),
-  have cont : ∀ x ∈ closure s, continuous_within_at ψ s x,
-    from λ x x_in, continuous_within_at.prod (hf _ x_in) (hg _ x_in),
-  change closure s ⊆ ψ ⁻¹' {p | p.1 ≤ p.2},
-  change s ⊆ ψ ⁻¹' {p | p.1 ≤ p.2} at h,
-  rw ← image_subset_iff at *,
-  calc ψ '' closure s ⊆ closure (ψ '' s) : continuous_within_at.image_closure cont
-  ... ⊆ closure {p | p.1 ≤ p.2} : closure_mono h
-  ... = {p | p.1 ≤ p.2} : closure_eq_iff_is_closed.2 (ordered_topology.is_closed_le' _)
+  have cont : continuous_within_at ψ s x,
+    from continuous_within_at.prod hf hg,
+  let H :=  {p : α × α | p.1 ≤ p.2},
+  change ψ x ∈ H,
+  suffices : ψ x ∈ closure H,
+    by rwa ← (closure_eq_iff_is_closed.2 (ordered_topology.is_closed_le' α) : closure H = H),
+  rw [closure_eq_nhds, mem_set_of_eq] at *,
+  have hψ : map ψ (principal s) ≤ principal H,
+    by rwa [map_principal, principal_mono, image_subset_iff],
+  apply neq_bot_of_le_neq_bot (map_ne_bot hx : map ψ (𝓝 x ⊓ principal s) ≠ ⊥),
+  calc
+  map ψ (𝓝 x ⊓ principal s) = map ψ ((𝓝 x ⊓ principal s) ⊓ principal s) : by rw [inf_assoc, inf_idem]
+  ... ≤  map ψ (𝓝 x ⊓ principal s) ⊓ map ψ (principal s) : filter.map_inf_le
+  ... ≤ 𝓝 (ψ x) ⊓ (principal H) : inf_le_inf cont hψ
 end
 end preorder
 

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -102,22 +102,12 @@ lemma continuous_within_at.closure_le [topological_space β]
  (hg : continuous_within_at g s x)
  (h : ∀ y ∈ s, f y ≤ g y) : f x ≤ g x :=
 begin
-  let ψ := λ x, (f x, g x),
-  have cont : continuous_within_at ψ s x,
-    from continuous_within_at.prod hf hg,
-  let H :=  {p : α × α | p.1 ≤ p.2},
-  change ψ x ∈ H,
-  suffices : ψ x ∈ closure H,
-    by rwa ← (closure_eq_iff_is_closed.2 (ordered_topology.is_closed_le' α) : closure H = H),
-  rw [closure_eq_nhds, mem_set_of_eq] at *,
-  have hψ : map ψ (principal s) ≤ principal H,
-    by rwa [map_principal, principal_mono, image_subset_iff],
-  apply neq_bot_of_le_neq_bot (map_ne_bot hx : map ψ (𝓝 x ⊓ principal s) ≠ ⊥),
-  calc
-  map ψ (𝓝 x ⊓ principal s) = map ψ ((𝓝 x ⊓ principal s) ⊓ principal s) : by rw [inf_assoc, inf_idem]
-  ... ≤  map ψ (𝓝 x ⊓ principal s) ⊓ map ψ (principal s) : filter.map_inf_le
-  ... ≤ 𝓝 (ψ x) ⊓ (principal H) : inf_le_inf cont hψ
+  show (f x, g x) ∈ {p : α × α | p.1 ≤ p.2},
+  suffices : (f x, g x) ∈ closure {p : α × α | p.1 ≤ p.2},
+    by rwa ← closure_eq_iff_is_closed.2 (ordered_topology.is_closed_le' α),
+  exact (continuous_within_at.prod hf hg).mem_closure hx h
 end
+
 end preorder
 
 section partial_order

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -127,6 +127,11 @@ theorem nhds_within_inter' (a : α) (s t : set α) :
   nhds_within a (s ∩ t) = (nhds_within a s) ⊓ principal t :=
 by { unfold nhds_within, rw [←inf_principal, lattice.inf_assoc] }
 
+lemma nhds_within_prod_eq {α : Type*} [topological_space α] {β : Type*} [topological_space β]
+  (a : α) (b : β) (s : set α) (t : set β) :
+  nhds_within (a, b) (s.prod t) = (nhds_within a s).prod (nhds_within b t) :=
+by { unfold nhds_within, rw [nhds_prod_eq, ←filter.prod_inf_prod, filter.prod_principal_principal] }
+
 theorem tendsto_if_nhds_within {f g : α → β} {p : α → Prop} [decidable_pred p]
     {a : α} {s : set α} {l : filter β}
     (h₀ : tendsto f (nhds_within a (s ∩ p)) l)
@@ -319,6 +324,14 @@ lemma continuous_within_at.mem_closure_image  {f : α → β} {s : set α} {x : 
   (h : continuous_within_at f s x) (hx : x ∈ closure s) : f x ∈ closure (f '' s) :=
 mem_closure_of_tendsto (mem_closure_iff_nhds_within_ne_bot.1 hx) h $
 mem_sets_of_superset self_mem_nhds_within (subset_preimage_image f s)
+
+lemma continuous_within_at.image_closure {f : α → β} {s : set α}
+  (hf : ∀ x ∈ closure s, continuous_within_at f s x) :
+  f '' (closure s) ⊆ closure (f '' s) :=
+begin
+  rintros _ ⟨x, hx, rfl⟩,
+  exact (hf x hx).mem_closure_image hx
+end
 
 lemma continuous_on.congr_mono {f g : α → β} {s s₁ : set α} (h : continuous_on f s)
   (h' : ∀x ∈ s₁, g x = f x) (h₁ : s₁ ⊆ s) : continuous_on g s₁ :=

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -325,6 +325,10 @@ lemma continuous_within_at.mem_closure_image  {f : α → β} {s : set α} {x : 
 mem_closure_of_tendsto (mem_closure_iff_nhds_within_ne_bot.1 hx) h $
 mem_sets_of_superset self_mem_nhds_within (subset_preimage_image f s)
 
+lemma continuous_within_at.mem_closure {f : α → β} {s : set α} {x : α} {A : set β}
+  (h : continuous_within_at f s x) (hx : x ∈ closure s) (hA : s ⊆ f⁻¹' A) : f x ∈ closure A :=
+closure_mono (image_subset_iff.2 hA) (h.mem_closure_image hx)
+
 lemma continuous_within_at.image_closure {f : α → β} {s : set α}
   (hf : ∀ x ∈ closure s, continuous_within_at f s x) :
   f '' (closure s) ⊆ closure (f '' s) :=


### PR DESCRIPTION
This is the PR promised in the #1794 discussion. Sébastien used sequences to prove a derivative extension lemma. The main point of the current PR us to make sure the library allows a sequence-free proof. Recall the main lemma replacing the use of sequences in topology is
```lean
lemma image_closure_subset_closure_image {f : α → β} {s : set α} (h : continuous f) :
  f '' closure s ⊆ closure (f '' s)
```
from [here](https://github.com/leanprover-community/mathlib/blob/7e2d4b853b53d33d0b7fc243d460d14fc3879726/src/topology/basic.lean#L738-L739). Here we need a version with weaker assumptions. This PR introduces:
```lean
lemma continuous_within_at.image_closure {f : α → β} {s : set α}
  (hf : ∀ x ∈ closure s, continuous_within_at f s x) :
  f '' (closure s) ⊆ closure (f '' s)
```
which is a tiny repackaging of an existing lemma. I also added a lemma about ordered topologies with similar weak assumptions:
```lean
lemma continuous_within_at.closure_le  {f g : β → α} {s : set β}
 (hf : ∀ x ∈ closure s, continuous_within_at f s x) (hg : ∀ x ∈ closure s, continuous_within_at g s x)
 (h : ∀ x ∈ s, f x ≤ g x) : ∀ x ∈ closure s, f x ≤ g x
``` 
for which I couldn't find  a good name.
Using those two lemmas indeed simplifies the derivative extension main lemma (at least if you like that kind of proof).