### PR TITLE
refactor(topology/algebra/ordered): use `tfae`, prove equality of some `nhds_within`

### DIFF
--- a/src/analysis/calculus/extend_deriv.lean
+++ b/src/analysis/calculus/extend_deriv.lean
@@ -190,7 +190,7 @@ begin
   /- This is a specialization of `has_fderiv_at_boundary_of_differentiable`. To be in the setting of
   this theorem, we need to work on an open interval with closure contained in `s ∪ {a}`, that we
   call `t = (b, a)`. Then, we check all the assumptions of this theorem and we apply it. -/
-  obtain ⟨b, ba, sab⟩ : ∃ (b : ℝ), b < a ∧ Ico b a ⊆ s :=
+  obtain ⟨b, ba, sab⟩ : ∃ b ∈ Iio a, Ico b a ⊆ s :=
     mem_nhds_within_Iio_iff_exists_Ico_subset.1 hs,
   let t := Ioo b a,
   have ts : t ⊆ s := subset.trans Ioo_subset_Ico_self sab,

--- a/src/analysis/calculus/extend_deriv.lean
+++ b/src/analysis/calculus/extend_deriv.lean
@@ -153,7 +153,7 @@ begin
   /- This is a specialization of `has_fderiv_at_boundary_of_tendsto_fderiv`. To be in the setting of
   this theorem, we need to work on an open interval with closure contained in `s ∪ {a}`, that we
   call `t = (a, b)`. Then, we check all the assumptions of this theorem and we apply it. -/
-  obtain ⟨b, ab, sab⟩ : ∃ (b : ℝ), a < b ∧ Ioc a b ⊆ s :=
+  obtain ⟨b, ab, sab⟩ : ∃ b ∈ Ioi a, Ioc a b ⊆ s :=
     mem_nhds_within_Ioi_iff_exists_Ioc_subset.1 hs,
   let t := Ioo a b,
   have ts : t ⊆ s := subset.trans Ioo_subset_Ioc_self sab,

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -256,12 +256,24 @@ class no_bot_order (α : Type u) [preorder α] : Prop :=
 lemma no_bot [preorder α] [no_bot_order α] : ∀a:α, ∃a', a' < a :=
 no_bot_order.no_bot
 
+instance order_dual.no_top_order (α : Type u) [preorder α] [no_bot_order α] :
+  no_top_order (order_dual α) :=
+⟨λ a, @no_bot α _ _ a⟩
+
+instance order_dual.no_bot_order (α : Type u) [preorder α] [no_top_order α] :
+  no_bot_order (order_dual α) :=
+⟨λ a, @no_top α _ _ a⟩
+
 /-- An order is dense if there is an element between any pair of distinct elements. -/
 class densely_ordered (α : Type u) [preorder α] : Prop :=
 (dense : ∀a₁ a₂:α, a₁ < a₂ → ∃a, a₁ < a ∧ a < a₂)
 
 lemma dense [preorder α] [densely_ordered α] : ∀{a₁ a₂:α}, a₁ < a₂ → ∃a, a₁ < a ∧ a < a₂ :=
 densely_ordered.dense
+
+instance order_dual.densely_ordered (α : Type u) [preorder α] [densely_ordered α] :
+  densely_ordered (order_dual α) :=
+⟨λ a₁ a₂ ha, (@dense α _ _ _ _ ha).imp $ λ a, and.symm⟩
 
 lemma le_of_forall_le_of_dense [linear_order α] [densely_ordered α] {a₁ a₂ : α} (h : ∀a₃>a₂, a₁ ≤ a₃) :
   a₁ ≤ a₂ :=

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -522,12 +522,19 @@ characterized as the sets containing suitable intervals to the right or to the l
 We give now these characterizations. -/
 
 -- NB: If you extend the list, append to the end please to avoid breaking the API
-/-- A few statements equivalent to `s ∈ nhds_within a (Ioi a)`. Most implications don't require
-`(a, +∞)` to be nonempty however if `(a, +∞)` is empty, then `nhds_within (a, +∞)=⊥`, and we
-don't care too much about this case. -/
-lemma tfae_mem_nhds_within_Ioi {a u' : α} (hu' : a < u') (s : set α) :
-  tfae [s ∈ nhds_within a (Ioi a), s ∈ nhds_within a (Ioc a u'), s ∈ nhds_within a (Ioo a u'),
-    ∃ u ∈ Ioc a u', Ioo a u ⊆ s, ∃ u ∈ Ioi a, Ioo a u ⊆ s] :=
+/-- The following statements are equivalent:
+
+0. `s` is a neighborhood of `a` within `(a, +∞)`
+1. `s` is a neighborhood of `a` within `(a, b]`
+2. `s` is a neighborhood of `a` within `(a, b)`
+3. `s` includes `(a, u)` for some `u ∈ (a, b]`
+4. `s` includes `(a, u)` for some `u > a` -/
+lemma tfae_mem_nhds_within_Ioi {a b : α} (hab : a < b) (s : set α) :
+  tfae [s ∈ nhds_within a (Ioi a), -- 0 : `s` is a neighborhood of `a` within `(a, +∞)`
+    s ∈ nhds_within a (Ioc a b),   -- 1 : `s` is a neighborhood of `a` within `(a, b]`
+    s ∈ nhds_within a (Ioo a b),   -- 2 : `s` is a neighborhood of `a` within `(a, b)`
+    ∃ u ∈ Ioc a b, Ioo a u ⊆ s,    -- 3 : `s` includes `(a, u)` for some `u ∈ (a, b]`
+    ∃ u ∈ Ioi a, Ioo a u ⊆ s] :=   -- 4 : `s` includes `(a, u)` for some `u > a`
 begin
   tfae_have : 1 → 2, from λ h, nhds_within_mono _ Ioc_subset_Ioi_self h,
   tfae_have : 2 → 3, from λ h, nhds_within_mono _ Ioo_subset_Ioc_self h,
@@ -538,7 +545,7 @@ begin
   tfae_have : 3 → 4,
   { assume h,
     rcases mem_nhds_within_iff_exists_mem_nhds_inter.1 h with ⟨v, va, hv⟩,
-    rcases exists_Ico_subset_of_mem_nhds' va hu' with ⟨u, au, hu⟩,
+    rcases exists_Ico_subset_of_mem_nhds' va hab with ⟨u, au, hu⟩,
     refine ⟨u, au, λx hx, _⟩,
     refine hv ⟨hu ⟨le_of_lt hx.1, hx.2⟩, _⟩,
     exact Ioo_subset_Ioo_right au.2 hx  },
@@ -579,14 +586,21 @@ begin
     exact ⟨u, au, subset.trans Ioo_subset_Ioc_self as⟩ }
 end
 
-/-- A few statements equivalent to `s ∈ nhds_within a (Iio a)`. Most implications don't require
-`(-∞, a)` to be nonempty however if `(-∞, a)` is empty, then `nhds_within (-∞, a)=⊥`, and we
-don't care too much about this case. -/
-lemma tfae_mem_nhds_within_Iio {l' a : α} (hl' : l' < a) (s : set α) :
-  tfae [s ∈ nhds_within a (Iio a), s ∈ nhds_within a (Ico l' a), s ∈ nhds_within a (Ioo l' a),
-    ∃ l ∈ Ico l' a, Ioo l a ⊆ s, ∃ l ∈ Iio a, Ioo l a ⊆ s] :=
+/-- The following statements are equivalent:
+
+0. `s` is a neighborhood of `b` within `(-∞, b)`
+1. `s` is a neighborhood of `b` within `[a, b)`
+2. `s` is a neighborhood of `b` within `(a, b)`
+3. `s` includes `(l, b)` for some `l ∈ [a, b)`
+4. `s` includes `(l, b)` for some `l < b` -/
+lemma tfae_mem_nhds_within_Iio {a b : α} (h : a < b) (s : set α) :
+  tfae [s ∈ nhds_within b (Iio b), -- 0 : `s` is a neighborhood of `b` within `(-∞, b)`
+    s ∈ nhds_within b (Ico a b),   -- 1 : `s` is a neighborhood of `b` within `[a, b)`
+    s ∈ nhds_within b (Ioo a b),   -- 2 : `s` is a neighborhood of `b` within `(a, b)`
+    ∃ l ∈ Ico a b, Ioo l b ⊆ s,    -- 3 : `s` includes `(l, b)` for some `l ∈ [a, b)`
+    ∃ l ∈ Iio b, Ioo l b ⊆ s] :=   -- 4 : `s` includes `(l, b)` for some `l < b`
 begin
-  have := @tfae_mem_nhds_within_Ioi (order_dual α) _ _ _ _ _ hl' s,
+  have := @tfae_mem_nhds_within_Ioi (order_dual α) _ _ _ _ _ h s,
   -- If we call `convert` here, it generates wrong equations, so we need to simplify first
   simp only [exists_prop] at this ⊢,
   rw [dual_Ioi, dual_Ioc, dual_Ioo] at this,


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)