### PR TITLE
feat(tactic/rename_var): A teaching tactic

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -1296,6 +1296,21 @@ end
 Although `reassoc_of` is not a tactic or a meta program, its type is generated
 through meta-programming to make it usable inside normal expressions.
 
+### rename_var
+
+`rename_var old new` renames variable `old` to `new` in the goal.
+`rename_var old new at h` does the same in hypothesis `h`.
+This is meant for teaching bound variables only, Lean will never need such a renaming.
+
+```lean
+example (P : ℕ →  ℕ → Prop) (h : ∀ n, ∃ m, P n m) : ∀ l, ∃ m, P l m :=
+begin
+  rename_var n q at h, -- h is now ∀ (q : ℕ), ∃ (m : ℕ), P q m,
+  rename_var m n, -- goal is now ∀ (l : ℕ), ∃ (n : ℕ), P k n,
+  exact h -- Lean does not care about those bound variable names
+end
+```
+
 ### lint
 User commands to spot common mistakes in the code
 

--- a/src/tactic/basic.lean
+++ b/src/tactic/basic.lean
@@ -13,6 +13,7 @@ import
   tactic.push_neg
   tactic.rcases
   tactic.replacer
+  tactic.rename_var
   tactic.restate_axiom
   tactic.rewrite
   tactic.lint

--- a/src/tactic/rename_var.lean
+++ b/src/tactic/rename_var.lean
@@ -1,0 +1,42 @@
+import tactic.interactive
+
+open expr
+
+meta def expr.rename_var (old new : name) : expr → expr
+| (pi n bi t b) := (pi (if n = old then new else n) bi (expr.rename_var t) (expr.rename_var b))
+| (lam n bi t b) := (lam (if n = old then new else n) bi (expr.rename_var t) (expr.rename_var b))
+| (app t b) := (app (expr.rename_var t) (expr.rename_var b))
+| e := e
+
+namespace tactic
+meta def rename_var_at_goal (old new : name) : tactic unit :=
+do
+  old_tgt ← target,
+  assert `htarget (expr.rename_var old new old_tgt),
+  swap,
+  get_local `htarget >>= tactic.exact
+
+meta def rename_var_at_hyp (old new h : name) : tactic unit :=
+do
+  old_e ← get_local h >>= infer_type,
+  eh ← get_local h,
+  assertv h (expr.rename_var old new old_e) eh,
+  clear eh
+end tactic
+
+namespace tactic.interactive
+open tactic
+setup_tactic_parser
+
+/-- `rename_var old new` renames variable `old` to `new` in the goal.
+    `rename_var old new at h` does the same in hypothesis `h`. -/
+meta def rename_var (old : parse ident) (new : parse ident) (l : parse location) : tactic unit :=
+do
+  match l with
+  | (loc.ns [some h]) := do
+    rename_var_at_hyp old new h
+  | (loc.ns [none]) := do
+    rename_var_at_goal old new
+  | _ := fail "rename_var needs exactly zero or one location."
+  end
+end tactic.interactive

--- a/src/tactic/rename_var.lean
+++ b/src/tactic/rename_var.lean
@@ -2,6 +2,7 @@ import tactic.interactive
 
 open expr
 
+/-- Rename bound variable `old` to `new` in an `expr`-/
 meta def expr.rename_var (old new : name) : expr → expr
 | (pi n bi t b) := (pi (if n = old then new else n) bi (expr.rename_var t) (expr.rename_var b))
 | (lam n bi t b) := (lam (if n = old then new else n) bi (expr.rename_var t) (expr.rename_var b))
@@ -9,6 +10,7 @@ meta def expr.rename_var (old new : name) : expr → expr
 | e := e
 
 namespace tactic
+/-- Rename bound variable `old` to `new` in goal -/
 meta def rename_var_at_goal (old new : name) : tactic unit :=
 do
   old_tgt ← target,
@@ -16,6 +18,7 @@ do
   swap,
   get_local `htarget >>= tactic.exact
 
+/-- Rename bound variable `old` to `new` in assumption `h` -/
 meta def rename_var_at_hyp (old new h : name) : tactic unit :=
 do
   old_e ← get_local h >>= infer_type,

--- a/src/tactic/rename_var.lean
+++ b/src/tactic/rename_var.lean
@@ -1,5 +1,33 @@
+/-
+Copyright (c) 2019 Patrick Massot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Patrick Massot
+-/
+
 import tactic.interactive
 
+/-!
+# Rename bound variable tactic
+
+This files defines a tactic `rename_var` whose main purpose is to teach
+renaming of bound variables.
+
+* `rename_var old new` renames variable `old` to `new` in the goal.
+* `rename_var old new at h` does the same in hypothesis `h`.
+
+```lean
+example (P : ℕ →  ℕ → Prop) (h : ∀ n, ∃ m, P n m) : ∀ l, ∃ m, P l m :=
+begin
+  rename_var n q at h, -- h is now ∀ (q : ℕ), ∃ (m : ℕ), P q m,
+  rename_var m n, -- goal is now ∀ (l : ℕ), ∃ (n : ℕ), P k n,
+  exact h -- Lean does not care about those bound variable names
+end
+```lean
+
+## Tags
+
+teaching, tactic
+-/
 open expr
 
 /-- Rename bound variable `old` to `new` in an `expr`-/

--- a/test/rename_var.lean
+++ b/test/rename_var.lean
@@ -1,0 +1,26 @@
+import tactic.rename_var
+
+example (P : ℕ →  ℕ → Prop) (h : ∀ n, ∃ m, P n m) : true :=
+begin
+  rename_var n q at h,
+  guard_hyp_strict h := ∀ (q : ℕ), ∃ (m : ℕ), P q m,
+  rename_var m z at h,
+  guard_hyp_strict h := ∀ (q : ℕ), ∃ (z : ℕ), P q z,
+  trivial
+end
+
+example (P : ℕ →  ℕ → Prop) (h : ∀ n, ∃ m, P n m) : ∀ n, ∃ m, P n m :=
+begin
+  rename_var n q,
+  guard_target_strict ∀ (q : ℕ), ∃ (m : ℕ), P q m,
+  rename_var m l,
+  guard_target_strict ∀ (q : ℕ), ∃ (l : ℕ), P q l,
+  exact h
+end
+
+example (h : (λ n : ℕ, n) = id) : true :=
+begin
+  rename_var n m at h,
+  guard_hyp_strict h := (λ (m : ℕ), m) = id,
+  trivial
+end


### PR DESCRIPTION
for teaching that bound variables names are irrelevant, and also
help clarify local context.
