### PR TITLE
fix(metric_space/gromo_hausdorff): lemma should be instance + linting

### DIFF
--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -13,7 +13,7 @@ topology.metric_space.completion
 This file defines the Gromov-Hausdorff distance on the space of nonempty compact metric spaces
 up to isometry.
 
-We introduces the space of all nonempty compact metric spaces, up to isometry,
+We introduce the space of all nonempty compact metric spaces, up to isometry,
 called `GH_space`, and endow it with a metric space structure. The distance,
 known as the Gromov-Hausdorff distance, is defined as follows: given two
 nonempty compact spaces `X` and `Y`, their distance is the minimum Hausdorff distance
@@ -21,7 +21,7 @@ between all possible isometric embeddings of `X` and `Y` in all metric spaces.
 To define properly the Gromov-Hausdorff space, we consider the non-empty
 compact subsets of `ℓ^∞(ℝ)` up to isometry, which is a well-defined type,
 and define the distance as the infimum of the Hausdorff distance over all
-embeddings in ℓ^∞(ℝ). We prove that this coincides with the previous description,
+embeddings in `ℓ^∞(ℝ)`. We prove that this coincides with the previous description,
 as all separable metric spaces embed isometrically into `ℓ^∞(ℝ)`, through an
 embedding called the Kuratowski embedding.
 To prove that we have a distance, we should show that if spaces can be coupled
@@ -38,8 +38,7 @@ i.e., it is complete and second countable. We also prove the Gromov compactness 
 -/
 
 noncomputable theory
-open_locale classical
-open_locale topological_space
+open_locale classical topological_space
 universes u v w
 
 open classical lattice set function topological_space filter metric quotient
@@ -54,9 +53,9 @@ namespace Gromov_Hausdorff
 
 section GH_space
 /- In this section, we define the Gromov-Hausdorff space, denoted `GH_space` as the quotient
-of nonempty compact subsets of ℓ^∞(ℝ) by identifying isometric sets.
+of nonempty compact subsets of `ℓ^∞(ℝ)` by identifying isometric sets.
 Using the Kuratwoski embedding, we get a canonical map `to_GH_space` mapping any nonempty
-compact type to GH_space. -/
+compact type to `GH_space`. -/
 
 /-- Equivalence relation identifying two nonempty compact sets which are isometric -/
 private definition isometry_rel : nonempty_compacts ℓ_infty_ℝ → nonempty_compacts ℓ_infty_ℝ → Prop :=
@@ -73,11 +72,11 @@ setoid.mk isometry_rel is_equivalence_isometry_rel
 /-- The Gromov-Hausdorff space -/
 definition GH_space : Type := quotient (isometry_rel.setoid)
 
-/-- Map any nonempty compact type to GH_space -/
+/-- Map any nonempty compact type to `GH_space` -/
 definition to_GH_space (α : Type u) [metric_space α] [compact_space α] [nonempty α] : GH_space :=
   ⟦nonempty_compacts.Kuratowski_embedding α⟧
 
-/-- A metric space representative of any abstract point in GH_space -/
+/-- A metric space representative of any abstract point in `GH_space` -/
 definition GH_space.rep (p : GH_space) : Type := (quot.out p).val
 
 lemma eq_to_GH_space_iff {α : Type u} [metric_space α] [compact_space α] [nonempty α] {p : nonempty_compacts ℓ_infty_ℝ} :
@@ -127,7 +126,7 @@ begin
   exact quot.out_eq p
 end
 
-/-- Two nonempty compact spaces have the same image in GH_space if and only if they are isometric -/
+/-- Two nonempty compact spaces have the same image in `GH_space` if and only if they are isometric -/
 lemma to_GH_space_eq_to_GH_space_iff_isometric {α : Type u} [metric_space α] [compact_space α] [nonempty α]
   {β : Type u} [metric_space β] [compact_space β] [nonempty β] :
   to_GH_space α = to_GH_space β ↔ nonempty (α ≃ᵢ β) :=
@@ -157,13 +156,15 @@ begin
   exact ⟨h'⟩
 end⟩
 
-/-- Distance on GH_space : the distance between two nonempty compact spaces is the infimum
+/-- Distance on `GH_space`: the distance between two nonempty compact spaces is the infimum
 Hausdorff distance between isometric copies of the two spaces in a metric space. For the definition,
-we only consider embeddings in ℓ^∞(ℝ), but we will prove below that it works for all spaces. -/
+we only consider embeddings in `ℓ^∞(ℝ)`, but we will prove below that it works for all spaces. -/
 instance : has_dist (GH_space) :=
 { dist := λx y, Inf ((λp : nonempty_compacts ℓ_infty_ℝ × nonempty_compacts ℓ_infty_ℝ, Hausdorff_dist p.1.val p.2.val) ''
                       (set.prod {a | ⟦a⟧ = x} {b | ⟦b⟧ = y})) }
 
+/-- The Gromov-Hausdorff distance between two nonempty compact metric spaces, equal by definition to
+the distance of the equivalence classes of these spaces in the Gromov-Hausdorff space. -/
 def GH_dist (α : Type u) (β : Type v) [metric_space α] [nonempty α] [compact_space α]
   [metric_space β] [nonempty β] [compact_space β] : ℝ := dist (to_GH_space α) (to_GH_space β)
 
@@ -177,10 +178,10 @@ theorem GH_dist_le_Hausdorff_dist {α : Type u} [metric_space α] [compact_space
   {γ : Type w} [metric_space γ] {Φ : α → γ} {Ψ : β → γ} (ha : isometry Φ) (hb : isometry Ψ) :
   GH_dist α β ≤ Hausdorff_dist (range Φ) (range Ψ) :=
 begin
-  /- For the proof, we want to embed γ in ℓ^∞(ℝ), to say that the Hausdorff distance is realized
-  in ℓ^∞(ℝ) and therefore bounded below by the Gromov-Hausdorff-distance. However, γ is not
-  separable in general. We restrict to the union of the images of α and β in γ, which is
-  separable and therefore embeddable in ℓ^∞(ℝ). -/
+  /- For the proof, we want to embed `γ` in `ℓ^∞(ℝ)`, to say that the Hausdorff distance is realized
+  in `ℓ^∞(ℝ)` and therefore bounded below by the Gromov-Hausdorff-distance. However, `γ` is not
+  separable in general. We restrict to the union of the images of `α` and `β` in `γ`, which is
+  separable and therefore embeddable in `ℓ^∞(ℝ)`. -/
   rcases exists_mem_of_nonempty α with ⟨xα, _⟩,
   letI : inhabited α := ⟨xα⟩,
   letI : inhabited β := classical.inhabited_of_nonempty (by assumption),
@@ -199,12 +200,12 @@ begin
   { rw [ΦΦ', ΨΨ', range_comp, range_comp],
     exact Hausdorff_dist_image (isometry_subtype_val) },
   rw this,
-  -- Embed s in ℓ^∞(ℝ) through its Kuratowski embedding
+  -- Embed `s` in `ℓ^∞(ℝ)` through its Kuratowski embedding
   let F := Kuratowski_embedding (subtype s),
   have : Hausdorff_dist (F '' (range Φ')) (F '' (range Ψ')) = Hausdorff_dist (range Φ') (range Ψ') :=
     Hausdorff_dist_image (Kuratowski_embedding.isometry _),
   rw ← this,
-  -- Let A and B be the images of α and β under this embedding. They are in ℓ^∞(ℝ), and
+  -- Let `A` and `B` be the images of `α` and `β` under this embedding. They are in `ℓ^∞(ℝ)`, and
   -- their Hausdorff distance is the same as in the original space.
   let A : nonempty_compacts ℓ_infty_ℝ := ⟨F '' (range Φ'), ⟨by simp,
       (compact_range IΦ'.continuous).image (Kuratowski_embedding.isometry _).continuous⟩⟩,
@@ -231,11 +232,11 @@ lemma Hausdorff_dist_optimal {α : Type u} [metric_space α] [compact_space α] 
   {β : Type v} [metric_space β] [compact_space β] [nonempty β] :
   Hausdorff_dist (range (optimal_GH_injl α β)) (range (optimal_GH_injr α β)) = GH_dist α β :=
 begin
-  /- we only need to check the inequality ≤, as the other one follows from the previous lemma.
+  /- we only need to check the inequality `≤`, as the other one follows from the previous lemma.
      As the Gromov-Hausdorff distance is an infimum, we need to check that the Hausdorff distance
      in the optimal coupling is smaller than the Hausdorff distance of any coupling.
      First, we check this for couplings which already have small Hausdorff distance: in this
-     case, the induced "distance" on α ⊕ β belongs to the candidates family introduced in the
+     case, the induced "distance" on `α ⊕ β` belongs to the candidates family introduced in the
      definition of the optimal coupling, and the conclusion follows from the optimality
      of the optimal coupling within this family.
   -/
@@ -325,7 +326,6 @@ begin
         ... = dist z (f (inr y)) : by rw hx
         ... ≤ r : le_of_lt hz },
     simp [HD, csupr_le I1, csupr_le I2] },
-
   /- Get the same inequality for any coupling. If the coupling is quite good, the desired
   inequality has been proved above. If it is bad, then the inequality is obvious. -/
   have B : ∀p q : nonempty_compacts (ℓ_infty_ℝ), ⟦p⟧ = to_GH_space α → ⟦q⟧ = to_GH_space β →
@@ -349,7 +349,7 @@ begin
   { exact GH_dist_le_Hausdorff_dist (isometry_optimal_GH_injl α β) (isometry_optimal_GH_injr α β) }
 end
 
-/-- The Gromov-Hausdorff distance can also be realized by a coupling in ℓ^∞(ℝ), by embedding
+/-- The Gromov-Hausdorff distance can also be realized by a coupling in `ℓ^∞(ℝ)`, by embedding
 the optimal coupling through its Kuratowski embedding. -/
 theorem GH_dist_eq_Hausdorff_dist (α : Type u) [metric_space α] [compact_space α] [nonempty α]
   (β : Type v) [metric_space β] [compact_space β] [nonempty β] :
@@ -367,8 +367,8 @@ begin
     exact (Hausdorff_dist_image (Kuratowski_embedding.isometry _)).symm },
 end
 
--- without the next two lines, { exact closed_of_compact (range Φ) hΦ } in the next
--- proof is very slow, as the t2_space instance is very hard to find
+-- without the next two lines, `{ exact closed_of_compact (range Φ) hΦ }` in the next
+-- proof is very slow, as the `t2_space` instance is very hard to find
 local attribute [instance, priority 10] orderable_topology.t2_space
 local attribute [instance, priority 10] ordered_topology.to_t2_space
 
@@ -416,10 +416,11 @@ instance GH_space_metric_space : metric_space GH_space :=
     exact ⟨e⟩
   end,
   dist_triangle := λx y z, begin
-    /- To show the triangular inequality between X, Y and Z, realize an optimal coupling
-    between X and Y in a space γ1, and an optimal coupling between Y and Z in a space γ2. Then,
-    glue these metric spaces along Y. We get a new space γ in which X and Y are optimally coupled,
-    as well as Y and Z. Apply the triangle inequality for the Hausdorff distance in γ to conclude. -/
+    /- To show the triangular inequality between `X`, `Y` and `Z`, realize an optimal coupling
+    between `X` and `Y` in a space `γ1`, and an optimal coupling between `Y`and `Z` in a space `γ2`.
+    Then, glue these metric spaces along `Y`. We get a new space `γ` in which `X` and `Y` are
+    optimally coupled, as well as `Y` and `Z`. Apply the triangle inequality for the Hausdorff
+    distance in `γ` to conclude. -/
     let X := x.rep,
     let Y := y.rep,
     let Z := z.rep,
@@ -472,8 +473,8 @@ instance GH_space_metric_space : metric_space GH_space :=
 end GH_space --section
 end Gromov_Hausdorff
 
-/-- In particular, nonempty compacts of a metric space map to GH_space. We register this
-in the topological_space namespace to take advantage of the notation p.to_GH_space -/
+/-- In particular, nonempty compacts of a metric space map to `GH_space`. We register this
+in the topological_space namespace to take advantage of the notation `p.to_GH_space`. -/
 definition topological_space.nonempty_compacts.to_GH_space {α : Type u} [metric_space α]
   (p : nonempty_compacts α) : Gromov_Hausdorff.GH_space := Gromov_Hausdorff.to_GH_space p.val
 
@@ -508,10 +509,10 @@ to_GH_space_lipschitz.to_continuous
 end nonempty_compacts
 
 section
-/- In this section, we show that if two metric spaces are isometric up to ε2, then their
-Gromov-Hausdorff distance is bounded by ε2 / 2. More generally, if there are subsets which are
-ε1-dense and ε3-dense in two spaces, and isometric up to ε2, then the Gromov-Hausdorff distance
-between the spaces is bounded by ε1 + ε2/2 + ε3. For this, we construct a suitable coupling between
+/- In this section, we show that if two metric spaces are isometric up to `ε₂`, then their
+Gromov-Hausdorff distance is bounded by `ε₂ / 2`. More generally, if there are subsets which are
+`ε₁`-dense and `ε₃`-dense in two spaces, and isometric up to `ε₂`, then the Gromov-Hausdorff distance
+between the spaces is bounded by `ε₁ + ε₂/2 + ε₃`. For this, we construct a suitable coupling between
 the two spaces, by gluing them (approximately) along the two matching subsets. -/
 
 variables {α : Type u} [metric_space α] [compact_space α] [nonempty α]
@@ -519,37 +520,37 @@ variables {α : Type u} [metric_space α] [compact_space α] [nonempty α]
 
 -- we want to ignore these instances in the following theorem
 local attribute [instance, priority 10] sum.topological_space sum.uniform_space
-/-- If there are subsets which are ε1-dense and ε3-dense in two spaces, and
-isometric up to ε2, then the Gromov-Hausdorff distance between the spaces is bounded by
-ε1 + ε2/2 + ε3. -/
-theorem GH_dist_le_of_approx_subsets {s : set α} (Φ : s → β) {ε1 ε2 ε3 : ℝ}
-  (hs : ∀x : α, ∃y ∈ s, dist x y ≤ ε1) (hs' : ∀x : β, ∃y : s, dist x (Φ y) ≤ ε3)
-  (H : ∀x y : s, abs (dist x y - dist (Φ x) (Φ y)) ≤ ε2) :
-  GH_dist α β ≤ ε1 + ε2 / 2 + ε3 :=
+/-- If there are subsets which are `ε₁`-dense and `ε₃`-dense in two spaces, and
+isometric up to `ε₂`, then the Gromov-Hausdorff distance between the spaces is bounded by
+`ε₁ + ε₂/2 + ε₃`. -/
+theorem GH_dist_le_of_approx_subsets {s : set α} (Φ : s → β) {ε₁ ε₂ ε₃ : ℝ}
+  (hs : ∀x : α, ∃y ∈ s, dist x y ≤ ε₁) (hs' : ∀x : β, ∃y : s, dist x (Φ y) ≤ ε₃)
+  (H : ∀x y : s, abs (dist x y - dist (Φ x) (Φ y)) ≤ ε₂) :
+  GH_dist α β ≤ ε₁ + ε₂ / 2 + ε₃ :=
 begin
   refine real.le_of_forall_epsilon_le (λδ δ0, _),
   rcases exists_mem_of_nonempty α with ⟨xα, _⟩,
   rcases hs xα with ⟨xs, hxs, Dxs⟩,
   have sne : s ≠ ∅ := ne_empty_of_mem hxs,
   letI : nonempty (subtype s) := ⟨⟨xs, hxs⟩⟩,
-  have : 0 ≤ ε2 := le_trans (abs_nonneg _) (H ⟨xs, hxs⟩ ⟨xs, hxs⟩),
-  have : ∀ p q : s, abs (dist p q - dist (Φ p) (Φ q)) ≤ 2 * (ε2/2 + δ) := λp q, calc
-    abs (dist p q - dist (Φ p) (Φ q)) ≤ ε2 : H p q
-    ... ≤ 2 * (ε2/2 + δ) : by linarith,
-  -- glue α and β along the almost matching subsets
-  letI : metric_space (α ⊕ β) := glue_metric_approx (@subtype.val α s) (λx, Φ x) (ε2/2 + δ) (by linarith) this,
+  have : 0 ≤ ε₂ := le_trans (abs_nonneg _) (H ⟨xs, hxs⟩ ⟨xs, hxs⟩),
+  have : ∀ p q : s, abs (dist p q - dist (Φ p) (Φ q)) ≤ 2 * (ε₂/2 + δ) := λp q, calc
+    abs (dist p q - dist (Φ p) (Φ q)) ≤ ε₂ : H p q
+    ... ≤ 2 * (ε₂/2 + δ) : by linarith,
+  -- glue `α` and `β` along the almost matching subsets
+  letI : metric_space (α ⊕ β) := glue_metric_approx (@subtype.val α s) (λx, Φ x) (ε₂/2 + δ) (by linarith) this,
   let Fl := @sum.inl α β,
   let Fr := @sum.inr α β,
   have Il : isometry Fl := isometry_emetric_iff_metric.2 (λx y, rfl),
   have Ir : isometry Fr := isometry_emetric_iff_metric.2 (λx y, rfl),
-  /- The proof goes as follows : the GH_dist is bounded by the Hausdorff distance of the images in the
+  /- The proof goes as follows : the `GH_dist` is bounded by the Hausdorff distance of the images in the
   coupling, which is bounded (using the triangular inequality) by the sum of the Hausdorff distances
-  of α and s (in the coupling or, equivalently in the original space), of s and Φ s, and of Φ s and β
-  (in the coupling or, equivalently, in the original space). The first term is bounded by ε1,
-  by ε1-density. The third one is bounded by ε3. And the middle one is bounded by ε2/2 as in the
-  coupling the points x and Φ x are at distance ε2/2 by construction of the coupling (in fact
-  ε2/2 + δ where δ is an arbitrarily small positive constant where positivity is used to ensure
-  that the coupling is really a metric space and not a premetric space on α ⊕ β). -/
+  of `α` and `s` (in the coupling or, equivalently in the original space), of `s` and `Φ s`, and of
+  `Φ s` and `β` (in the coupling or, equivalently, in the original space). The first term is bounded
+  by `ε₁`, by `ε₁`-density. The third one is bounded by `ε₃`. And the middle one is bounded by `ε₂/2`
+  as in the coupling the points `x` and `Φ x` are at distance `ε₂/2` by construction of the coupling
+  (in fact `ε₂/2 + δ` where `δ` is an arbitrarily small positive constant where positivity is used
+  to ensure that the coupling is really a metric space and not a premetric space on `α ⊕ β`). -/
   have : GH_dist α β ≤ Hausdorff_dist (range Fl) (range Fr) :=
     GH_dist_le_Hausdorff_dist Il Ir,
   have : Hausdorff_dist (range Fl) (range Fr) ≤ Hausdorff_dist (range Fl) (Fl '' s)
@@ -562,29 +563,29 @@ begin
   { have B : bounded (range Fr) := (compact_range Ir.continuous).bounded,
     exact Hausdorff_dist_triangle' (Hausdorff_edist_ne_top_of_ne_empty_of_bounded
       (by simpa [-nonempty_subtype]) (by simpa) (bounded.subset (image_subset_range _ _) B) B) },
-  have : Hausdorff_dist (range Fl) (Fl '' s) ≤ ε1,
+  have : Hausdorff_dist (range Fl) (Fl '' s) ≤ ε₁,
   { rw [← image_univ, Hausdorff_dist_image Il],
-    have : 0 ≤ ε1 := le_trans dist_nonneg Dxs,
+    have : 0 ≤ ε₁ := le_trans dist_nonneg Dxs,
     refine Hausdorff_dist_le_of_mem_dist this (λx hx, hs x)
       (λx hx, ⟨x, mem_univ _, by simpa⟩) },
-  have : Hausdorff_dist (Fl '' s) (Fr '' (range Φ)) ≤ ε2/2 + δ,
+  have : Hausdorff_dist (Fl '' s) (Fr '' (range Φ)) ≤ ε₂/2 + δ,
   { refine Hausdorff_dist_le_of_mem_dist (by linarith) _ _,
     { assume x' hx',
       rcases (set.mem_image _ _ _).1 hx' with ⟨x, ⟨x_in_s, xx'⟩⟩,
       rw ← xx',
       use [Fr (Φ ⟨x, x_in_s⟩), mem_image_of_mem Fr (mem_range_self _)],
-      exact le_of_eq (glue_dist_glued_points (@subtype.val α s) Φ (ε2/2 + δ) ⟨x, x_in_s⟩) },
+      exact le_of_eq (glue_dist_glued_points (@subtype.val α s) Φ (ε₂/2 + δ) ⟨x, x_in_s⟩) },
     { assume x' hx',
       rcases (set.mem_image _ _ _).1 hx' with ⟨y, ⟨y_in_s', yx'⟩⟩,
       rcases mem_range.1 y_in_s' with ⟨x, xy⟩,
       use [Fl x, mem_image_of_mem _ x.2],
       rw [← yx', ← xy, dist_comm],
-      exact le_of_eq (glue_dist_glued_points (@subtype.val α s) Φ (ε2/2 + δ) x) } },
-  have : Hausdorff_dist (Fr '' (range Φ)) (range Fr) ≤ ε3,
+      exact le_of_eq (glue_dist_glued_points (@subtype.val α s) Φ (ε₂/2 + δ) x) } },
+  have : Hausdorff_dist (Fr '' (range Φ)) (range Fr) ≤ ε₃,
   { rw [← @image_univ _ _ Fr, Hausdorff_dist_image Ir],
     rcases exists_mem_of_nonempty β with ⟨xβ, _⟩,
     rcases hs' xβ with ⟨xs', Dxs'⟩,
-    have : 0 ≤ ε3 := le_trans dist_nonneg Dxs',
+    have : 0 ≤ ε₃ := le_trans dist_nonneg Dxs',
     refine Hausdorff_dist_le_of_mem_dist this (λx hx, ⟨x, mem_univ _, by simpa⟩) (λx _, _),
     rcases hs' x with ⟨y, Dy⟩,
     exact ⟨Φ y, mem_range_self _, Dy⟩ },
@@ -593,15 +594,15 @@ end
 end --section
 
 /-- The Gromov-Hausdorff space is second countable. -/
-lemma second_countable : second_countable_topology GH_space :=
+instance second_countable : second_countable_topology GH_space :=
 begin
   refine second_countable_of_countable_discretization (λδ δpos, _),
   let ε := (2/5) * δ,
   have εpos : 0 < ε := mul_pos (by norm_num) δpos,
   have : ∀p:GH_space, ∃s : set (p.rep), finite s ∧ (univ ⊆ (⋃x∈s, ball x ε)) :=
     λp, by simpa using finite_cover_balls_of_compact (@compact_univ p.rep _ _) εpos,
-  -- for each p, s p is a finite ε-dense subset of p (or rather the metric space
-  -- p.rep representing p)
+  -- for each `p`, `s p` is a finite `ε`-dense subset of `p` (or rather the metric space
+  -- `p.rep` representing `p`)
   choose s hs using this,
   have : ∀p:GH_space, ∀t:set (p.rep), finite t → ∃n:ℕ, ∃e:equiv t (fin n), true,
   { assume p t ht,
@@ -610,38 +611,38 @@ begin
     rcases hn with e,
     exact ⟨n, e, trivial⟩ },
   choose N e hne using this,
-  -- cardinality of the nice finite subset s p of p.rep, called N p
+  -- cardinality of the nice finite subset `s p` of `p.rep`, called `N p`
   let N := λp:GH_space, N p (s p) (hs p).1,
-  -- equiv from s p, a nice finite subset of p.rep, to fin (N p), called E p
+  -- equiv from `s p`, a nice finite subset of `p.rep`, to `fin (N p)`, called `E p`
   let E := λp:GH_space, e p (s p) (hs p).1,
-  -- A function F associating to p ∈ GH_space the data of all distances of points
-  -- in the ε-dense set s p.
+  -- A function `F` associating to `p : GH_space` the data of all distances between points
+  -- in the `ε`-dense set `s p`.
   let F : GH_space → Σn:ℕ, (fin n → fin n → ℤ) :=
     λp, ⟨N p, λa b, floor (ε⁻¹ * dist ((E p).inv_fun a) ((E p).inv_fun b))⟩,
   refine ⟨_, by apply_instance, F, λp q hpq, _⟩,
   /- As the target space of F is countable, it suffices to show that two points
-  p and q with F p = F q are at distance ≤ δ.
-  For this, we construct a map Φ from s p ⊆ p.rep (representing p)
-  to q.rep (representing q) which is almost an isometry on s p, and
-  with image s q. For this, we compose the identification of s p with fin (N p)
-  and the inverse of the identification of s q with fin (N q). Together with
-  the fact that N p = N q, this constructs Ψ between s p and s q, and then
-  composing with the canonical inclusion we get Φ. -/
+  `p` and `q` with `F p = F q` are at distance `≤ δ`.
+  For this, we construct a map `Φ` from `s p ⊆ p.rep` (representing `p`)
+  to `q.rep` (representing `q`) which is almost an isometry on `s p`, and
+  with image `s q`. For this, we compose the identification of `s p` with `fin (N p)`
+  and the inverse of the identification of `s q` with `fin (N q)`. Together with
+  the fact that `N p = N q`, this constructs `Ψ` between `s p` and `s q`, and then
+  composing with the canonical inclusion we get `Φ`. -/
   have Npq : N p = N q := (sigma.mk.inj_iff.1 hpq).1,
   let Ψ : s p → s q := λx, (E q).inv_fun (fin.cast Npq ((E p).to_fun x)),
   let Φ : s p → q.rep := λx, Ψ x,
-  -- Use the almost isometry Φ to show that p.rep and q.rep
+  -- Use the almost isometry `Φ` to show that `p.rep` and `q.rep`
   -- are within controlled Gromov-Hausdorff distance.
   have main : GH_dist p.rep q.rep ≤ ε + ε/2 + ε,
   { refine GH_dist_le_of_approx_subsets Φ  _ _ _,
     show ∀x : p.rep, ∃ (y : p.rep) (H : y ∈ s p), dist x y ≤ ε,
-    { -- by construction, s p is ε-dense
+    { -- by construction, `s p` is `ε`-dense
       assume x,
       have : x ∈ ⋃y∈(s p), ball y ε := (hs p).2 (mem_univ _),
       rcases mem_bUnion_iff.1 this with ⟨y, ⟨ys, hy⟩⟩,
       exact ⟨y, ys, le_of_lt hy⟩ },
     show ∀x : q.rep, ∃ (z : s p), dist x (Φ z) ≤ ε,
-    { -- by construction, s q is ε-dense, and it is the range of Φ
+    { -- by construction, `s q` is `ε`-dense, and it is the range of `Φ`
       assume x,
       have : x ∈ ⋃y∈(s q), ball y ε := (hs q).2 (mem_univ _),
       rcases mem_bUnion_iff.1 this with ⟨y, ⟨ys, hy⟩⟩,
@@ -660,38 +661,38 @@ begin
       rw this,
       exact le_of_lt hy },
     show ∀x y : s p, abs (dist x y - dist (Φ x) (Φ y)) ≤ ε,
-    { /- the distance between x and y is encoded in F p, and the distance between
-      Φ x and Φ y (two points of s q) is encoded in F q, all this up to ε.
-      As F p = F q, the distances are almost equal. -/
+    { /- the distance between `x` and `y` is encoded in `F p`, and the distance between
+      `Φ x` and `Φ y` (two points of `s q`) is encoded in `F q`, all this up to `ε`.
+      As `F p = F q`, the distances are almost equal. -/
       assume x y,
       have : dist (Φ x) (Φ y) = dist (Ψ x) (Ψ y) := rfl,
       rw this,
-      -- introduce i, that codes both x and Φ x in fin (N p) = fin (N q)
+      -- introduce `i`, that codes both `x` and `Φ x` in `fin (N p) = fin (N q)`
       let i := ((E p).to_fun x).1,
       have hip : i < N p := ((E p).to_fun x).2,
       have hiq : i < N q, by rwa Npq at hip,
       have i' : i = ((E q).to_fun (Ψ x)).1, by { simp [Ψ, (E q).right_inv _] },
-      -- introduce j, that codes both y and Φ y in fin (N p) = fin (N q)
+      -- introduce `j`, that codes both `y` and `Φ y` in `fin (N p) = fin (N q)`
       let j := ((E p).to_fun y).1,
       have hjp : j < N p := ((E p).to_fun y).2,
       have hjq : j < N q, by rwa Npq at hjp,
       have j' : j = ((E q).to_fun (Ψ y)).1, by { simp [Ψ, (E q).right_inv _] },
-      -- Express dist x y in terms of F p
+      -- Express `dist x y` in terms of `F p`
       have : (F p).2 ((E p).to_fun x) ((E p).to_fun y) = floor (ε⁻¹ * dist x y),
         by simp only [F, (E p).left_inv _],
       have Ap : (F p).2 ⟨i, hip⟩ ⟨j, hjp⟩ = floor (ε⁻¹ * dist x y),
         by { rw ← this, congr; apply (fin.ext_iff _ _).2; refl },
-      -- Express dist (Φ x) (Φ y) in terms of F q
+      -- Express `dist (Φ x) (Φ y)` in terms of `F q`
       have : (F q).2 ((E q).to_fun (Ψ x)) ((E q).to_fun (Ψ y)) = floor (ε⁻¹ * dist (Ψ x) (Ψ y)),
         by simp only [F, (E q).left_inv _],
       have Aq : (F q).2 ⟨i, hiq⟩ ⟨j, hjq⟩ = floor (ε⁻¹ * dist (Ψ x) (Ψ y)),
         by { rw ← this, congr; apply (fin.ext_iff _ _).2; [exact i', exact j'] },
-      -- use the equality between F p and F q to deduce that the distances have equal
+      -- use the equality between `F p` and `F q` to deduce that the distances have equal
       -- integer parts
       have : (F p).2 ⟨i, hip⟩ ⟨j, hjp⟩ = (F q).2 ⟨i, hiq⟩ ⟨j, hjq⟩,
       { -- we want to `subst hpq` where `hpq : F p = F q`, except that `subst` only works
-        -- with a constant, so replace `F q` (and everything that depends on it) by a constant f
-        -- then subst
+        -- with a constant, so replace `F q` (and everything that depends on it) by a constant `f`
+        -- then `subst`
         revert hiq hjq,
         change N q with (F q).1,
         generalize_hyp : F q = f at hpq ⊢,
@@ -699,7 +700,7 @@ begin
         intros,
         refl },
       rw [Ap, Aq] at this,
-      -- deduce that the distances coincide up to ε, by a straightforward computation
+      -- deduce that the distances coincide up to `ε`, by a straightforward computation
       -- that should be automated
       have I := calc
         abs (ε⁻¹) * abs (dist x y - dist (Ψ x) (Ψ y)) =
@@ -718,9 +719,9 @@ begin
     ... = δ : by { simp [ε], ring }
 end
 
-/-- Compactness criterion : a closed set of compact metric spaces is compact if the spaces have
-a uniformly bounded diameter, and for all ε the number of balls of radius ε required
-to cover the space is uniformly bounded. This is an equivalence, but we only prove the
+/-- Compactness criterion: a closed set of compact metric spaces is compact if the spaces have
+a uniformly bounded diameter, and for all `ε` the number of balls of radius `ε` required
+to cover the spaces is uniformly bounded. This is an equivalence, but we only prove the
 interesting direction that these conditions imply compactness. -/
 lemma totally_bounded {t : set GH_space} {C : ℝ} {u : ℕ → ℝ} {K : ℕ → ℕ}
   (ulim : tendsto u at_top (𝓝 0))
@@ -728,20 +729,20 @@ lemma totally_bounded {t : set GH_space} {C : ℝ} {u : ℕ → ℝ} {K : ℕ �
   (hcov : ∀p ∈ t, ∀n:ℕ, ∃s : set (GH_space.rep p), cardinal.mk s ≤ K n ∧ univ ⊆ ⋃x∈s, ball x (u n)) :
   totally_bounded t :=
 begin
-  /- Let δ>0, and ε = δ/5. For each p, we construct a finite subset s p of p, which
-  is ε-dense and has cardinality at most K n. Encoding the mutual distances of points in s p,
-  up to ε, we will get a map F associating to p finitely many data, and making it possible to
-  reconstruct p up to ε. This is enough to prove total boundedness. -/
+  /- Let `δ>0`, and `ε = δ/5`. For each `p`, we construct a finite subset `s p` of `p`, which
+  is `ε`-dense and has cardinality at most `K n`. Encoding the mutual distances of points in `s p`,
+  up to `ε`, we will get a map `F` associating to `p` finitely many data, and making it possible to
+  reconstruct `p` up to `ε`. This is enough to prove total boundedness. -/
   refine metric.totally_bounded_of_finite_discretization (λδ δpos, _),
   let ε := (1/5) * δ,
   have εpos : 0 < ε := mul_pos (by norm_num) δpos,
-  -- choose n for which ε < u n
+  -- choose `n` for which `u n < ε`
   rcases metric.tendsto_at_top.1 ulim ε εpos with ⟨n, hn⟩,
   have u_le_ε : u n ≤ ε,
   { have := hn n (le_refl _),
     simp only [real.dist_eq, add_zero, sub_eq_add_neg, neg_zero] at this,
     exact le_of_lt (lt_of_le_of_lt (le_abs_self _) this) },
-  -- construct a finite subset s p of p which is ε-dense and has cardinal ≤ K n
+  -- construct a finite subset `s p` of `p` which is `ε`-dense and has cardinal `≤ K n`
   have : ∀p:GH_space, ∃s : set (p.rep), ∃N ≤ K n, ∃E : equiv s (fin N),
     p ∈ t → univ ⊆ ⋃x∈s, ball x (u n),
   { assume p,
@@ -757,32 +758,32 @@ begin
       use [s, N, scard, E],
       simp [hp, scover] } },
   choose s N hN E hs using this,
-  -- Define a function F taking values in a finite type and associating to p enough data
-  -- to reconstruct it up to ε, namely the (discretized) distances between elements of s p.
+  -- Define a function `F` taking values in a finite type and associating to `p` enough data
+  -- to reconstruct it up to `ε`, namely the (discretized) distances between elements of `s p`.
   let M := (floor (ε⁻¹ * max C 0)).to_nat,
   let F : GH_space → (Σk:fin ((K n).succ), (fin k → fin k → fin (M.succ))) :=
     λp, ⟨⟨N p, lt_of_le_of_lt (hN p) (nat.lt_succ_self _)⟩,
          λa b, ⟨min M (floor (ε⁻¹ * dist ((E p).inv_fun a) ((E p).inv_fun b))).to_nat,
                 lt_of_le_of_lt ( min_le_left _ _) (nat.lt_succ_self _) ⟩ ⟩,
   refine ⟨_, by apply_instance, (λp, F p), _⟩,
-  -- It remains to show that if F p = F q, then p and q are ε-close
+  -- It remains to show that if `F p = F q`, then `p` and `q` are `ε`-close
   rintros ⟨p, pt⟩ ⟨q, qt⟩ hpq,
   have Npq : N p = N q := (fin.ext_iff _ _).1 (sigma.mk.inj_iff.1 hpq).1,
   let Ψ : s p → s q := λx, (E q).inv_fun (fin.cast Npq ((E p).to_fun x)),
   let Φ : s p → q.rep := λx, Ψ x,
   have main : GH_dist (p.rep) (q.rep) ≤ ε + ε/2 + ε,
-  { -- to prove the main inequality, argue that s p is ε-dense in p, and s q is ε-dense in q,
-    -- and s p and s q are almost isometric. Then closeness follows
-    -- from GH_dist_le_of_approx_subsets
+  { -- to prove the main inequality, argue that `s p` is `ε`-dense in `p`, and `s q` is `ε`-dense
+    -- in `q`, and `s p` and `s q` are almost isometric. Then closeness follows
+    -- from `GH_dist_le_of_approx_subsets`
     refine GH_dist_le_of_approx_subsets Φ  _ _ _,
     show ∀x : p.rep, ∃ (y : p.rep) (H : y ∈ s p), dist x y ≤ ε,
-    { -- by construction, s p is ε-dense
+    { -- by construction, `s p` is `ε`-dense
       assume x,
       have : x ∈ ⋃y∈(s p), ball y (u n) := (hs p pt) (mem_univ _),
       rcases mem_bUnion_iff.1 this with ⟨y, ⟨ys, hy⟩⟩,
       exact ⟨y, ys, le_trans (le_of_lt hy) u_le_ε⟩ },
     show ∀x : q.rep, ∃ (z : s p), dist x (Φ z) ≤ ε,
-    { -- by construction, s q is ε-dense, and it is the range of Φ
+    { -- by construction, `s q` is `ε`-dense, and it is the range of `Φ`
       assume x,
       have : x ∈ ⋃y∈(s q), ball y (u n) := (hs q qt) (mem_univ _),
       rcases mem_bUnion_iff.1 this with ⟨y, ⟨ys, hy⟩⟩,
@@ -801,23 +802,23 @@ begin
       rw this,
       exact le_trans (le_of_lt hy) u_le_ε },
     show ∀x y : s p, abs (dist x y - dist (Φ x) (Φ y)) ≤ ε,
-    { /- the distance between x and y is encoded in F p, and the distance between
-      Φ x and Φ y (two points of s q) is encoded in F q, all this up to ε.
-      As F p = F q, the distances are almost equal. -/
+    { /- the distance between `x` and `y` is encoded in `F p`, and the distance between
+      `Φ x` and `Φ y` (two points of `s q`) is encoded in `F q`, all this up to `ε`.
+      As `F p = F q`, the distances are almost equal. -/
       assume x y,
       have : dist (Φ x) (Φ y) = dist (Ψ x) (Ψ y) := rfl,
       rw this,
-      -- introduce i, that codes both x and Φ x in fin (N p) = fin (N q)
+      -- introduce `i`, that codes both `x` and `Φ x` in `fin (N p) = fin (N q)`
       let i := ((E p).to_fun x).1,
       have hip : i < N p := ((E p).to_fun x).2,
       have hiq : i < N q, by rwa Npq at hip,
       have i' : i = ((E q).to_fun (Ψ x)).1, by { simp [Ψ, (E q).right_inv _] },
-      -- introduce j, that codes both y and Φ y in fin (N p) = fin (N q)
+      -- introduce `j`, that codes both `y` and `Φ y` in `fin (N p) = fin (N q)`
       let j := ((E p).to_fun y).1,
       have hjp : j < N p := ((E p).to_fun y).2,
       have hjq : j < N q, by rwa Npq at hjp,
       have j' : j = ((E q).to_fun (Ψ y)).1, by { simp [Ψ, (E q).right_inv _] },
-      -- Express dist x y in terms of F p
+      -- Express `dist x y` in terms of `F p`
       have Ap : ((F p).2 ⟨i, hip⟩ ⟨j, hjp⟩).1 = (floor (ε⁻¹ * dist x y)).to_nat := calc
         ((F p).2 ⟨i, hip⟩ ⟨j, hjp⟩).1 = ((F p).2 ((E p).to_fun x) ((E p).to_fun y)).1 :
           by { congr; apply (fin.ext_iff _ _).2; refl }
@@ -831,7 +832,7 @@ begin
           refine le_trans (dist_le_diam_of_mem compact_univ.bounded (mem_univ _) (mem_univ _)) _,
           exact hdiam p pt
         end,
-      -- Express dist (Φ x) (Φ y) in terms of F q
+      -- Express `dist (Φ x) (Φ y)` in terms of `F q`
       have Aq : ((F q).2 ⟨i, hiq⟩ ⟨j, hjq⟩).1 = (floor (ε⁻¹ * dist (Ψ x) (Ψ y))).to_nat := calc
         ((F q).2 ⟨i, hiq⟩ ⟨j, hjq⟩).1 = ((F q).2 ((E q).to_fun (Ψ x)) ((E q).to_fun (Ψ y))).1 :
           by { congr; apply (fin.ext_iff _ _).2; [exact i', exact j'] }
@@ -845,12 +846,12 @@ begin
           refine le_trans (dist_le_diam_of_mem compact_univ.bounded (mem_univ _) (mem_univ _)) _,
           exact hdiam q qt
         end,
-      -- use the equality between F p and F q to deduce that the distances have equal
+      -- use the equality between `F p` and `F q` to deduce that the distances have equal
       -- integer parts
       have : ((F p).2 ⟨i, hip⟩ ⟨j, hjp⟩).1 = ((F q).2 ⟨i, hiq⟩ ⟨j, hjq⟩).1,
       { -- we want to `subst hpq` where `hpq : F p = F q`, except that `subst` only works
-        -- with a constant, so replace `F q` (and everything that depends on it) by a constant f
-        -- then subst
+        -- with a constant, so replace `F q` (and everything that depends on it) by a constant `f`
+        -- then `subst`
         revert hiq hjq,
         change N q with (F q).1,
         generalize_hyp : F q = f at hpq ⊢,
@@ -864,7 +865,7 @@ begin
         have D' : floor (ε⁻¹ * dist (Ψ x) (Ψ y)) ≥ 0 :=
           floor_nonneg.2 (mul_nonneg (le_of_lt (inv_pos εpos)) dist_nonneg),
         rw [← int.to_nat_of_nonneg D, ← int.to_nat_of_nonneg D', this] },
-      -- deduce that the distances coincide up to ε, by a straightforward computation
+      -- deduce that the distances coincide up to `ε`, by a straightforward computation
       -- that should be automated
       have I := calc
         abs (ε⁻¹) * abs (dist x y - dist (Ψ x) (Ψ y)) =
@@ -903,12 +904,17 @@ compact metric space we are looking for.  -/
 
 variables (X : ℕ → Type) [∀n, metric_space (X n)] [∀n, compact_space (X n)] [∀n, nonempty (X n)]
 
+/-- Auxiliary structure used to glue metric spaces below, recording an isometric embedding
+of a type `A` in another metric space. -/
 structure aux_gluing_struct (A : Type) [metric_space A] : Type 1 :=
 (space  : Type)
 (metric : metric_space space)
 (embed  : A → space)
 (isom   : isometry embed)
 
+/-- Auxiliary sequence of metric spaces, containing copies of `X 0`, ..., `X n`, where each
+`X i` is glued to `X (i+1)` in an optimal way. The space at step `n+1` is obtained from the space
+at step `n` by adding `X (n+1)`, glued in an optimal way to the `X n` already sitting there. -/
 def aux_gluing (n : ℕ) : aux_gluing_struct (X n) := nat.rec_on n
   { space  := X 0,
     metric := by apply_instance,
@@ -925,18 +931,18 @@ def aux_gluing (n : ℕ) : aux_gluing_struct (X n) := nat.rec_on n
 instance : complete_space (GH_space) :=
 begin
   have : ∀ (n : ℕ), 0 < ((1:ℝ) / 2) ^ n, by { apply _root_.pow_pos, norm_num },
-  -- start from a sequence of nonempty compact metric spaces within distance 1/2^n of each other
+  -- start from a sequence of nonempty compact metric spaces within distance `1/2^n` of each other
   refine metric.complete_of_convergent_controlled_sequences (λn, (1/2)^n) this (λu hu, _),
-  -- X n is a representative of u n
+  -- `X n` is a representative of `u n`
   let X := λn, (u n).rep,
-  -- glue them together successively in an optimal way, getting a sequence of metric spaces Y n
+  -- glue them together successively in an optimal way, getting a sequence of metric spaces `Y n`
   let Y := aux_gluing X,
   letI : ∀n, metric_space (Y n).space := λn, (Y n).metric,
   have E : ∀n:ℕ, glue_space (Y n).isom (isometry_optimal_GH_injl (X n) (X n.succ)) = (Y n.succ).space :=
     λn, by { simp [Y, aux_gluing], refl },
   let c := λn, cast (E n),
   have ic : ∀n, isometry (c n) := λn x y, rfl,
-  -- there is a canonical embedding of Y n in Y (n+1), by construction
+  -- there is a canonical embedding of `Y n` in `Y (n+1)`, by construction
   let f : Πn, (Y n).space → (Y n.succ).space :=
     λn, (c n) ∘ (to_glue_l (aux_gluing X n).isom (isometry_optimal_GH_injl (X n) (X n.succ))),
   have I : ∀n, isometry (f n),
@@ -944,12 +950,12 @@ begin
     apply isometry.comp,
     { assume x y, refl },
     { apply to_glue_l_isometry } },
-  -- consider the inductive limit Z0 of the Y n, and then its completion Z
+  -- consider the inductive limit `Z0` of the `Y n`, and then its completion `Z`
   let Z0 := metric.inductive_limit I,
   let Z := uniform_space.completion Z0,
   let Φ := to_inductive_limit I,
   let coeZ := (coe : Z0 → Z),
-  -- let X2 n be the image of X n in the space Z
+  -- let `X2 n` be the image of `X n` in the space `Z`
   let X2 := λn, range (coeZ ∘ (Φ n) ∘ (Y n).embed),
   have isom : ∀n, isometry (coeZ ∘ (Φ n) ∘ (Y n).embed),
   { assume n,
@@ -957,7 +963,7 @@ begin
     apply isometry.comp _ (Y n).isom,
     apply to_inductive_limit_isometry },
   -- The Hausdorff distance of `X2 n` and `X2 (n+1)` is by construction the distance between
-  -- `u n` and `u (n+1)`, therefore bounded by 1/2^n
+  -- `u n` and `u (n+1)`, therefore bounded by `1/2^n`
   have D2 : ∀n, Hausdorff_dist (X2 n) (X2 n.succ) < (1/2)^n,
   { assume n,
     have X2n : X2 n = range ((coeZ ∘ (Φ n.succ) ∘ (c n)
@@ -986,7 +992,7 @@ begin
     ⟨by { simp only [X2, set.range_eq_empty, not_not, ne.def], apply_instance },
       compact_range (isom n).continuous ⟩⟩,
   -- `X3 n` is a Cauchy sequence by construction, as the successive distances are
-  -- bounded by (1/2)^n
+  -- bounded by `(1/2)^n`
   have : cauchy_seq X3,
   { refine cauchy_seq_of_le_geometric (1/2) 1 (by norm_num) (λn, _),
     rw one_mul,


### PR DESCRIPTION
The only nontrivial change in this PR is the conversion of `lemma second_countable : second_countable_topology GH_space` to an instance (as it should always have been). I have taken this opportunity to clean up the docstrings in this file.