### PR TITLE
feat(analysis/calculus/deriv): add aliases for `const op f` and `f op const`

### DIFF
--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -53,6 +53,10 @@ We also show the existence and compute the derivatives of:
   - division
   - polynomials
 
+For most binary operations we also define `const_op` and `op_const` theorems for the cases when
+the first or second argument is a constant. This makes writing chains of `has_deriv_at`'s easier,
+and they more frequently lead to the desired result.
+
 ## Implementation notes
 
 Most of the theorems are direct restatements of the corresponding theorems

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -467,14 +467,141 @@ lemma deriv_add
   deriv (λy, f y + g y) x = deriv f x + deriv g x :=
 (hf.has_deriv_at.add hg.has_deriv_at).deriv
 
+theorem has_deriv_at_filter.add_const
+  (hf : has_deriv_at_filter f f' x L) (c : F) :
+  has_deriv_at_filter (λ y, f y + c) f' x L :=
+add_zero f' ▸ hf.add (has_deriv_at_filter_const x L c)
+
+theorem has_deriv_within_at.add_const
+  (hf : has_deriv_within_at f f' s x) (c : F) :
+  has_deriv_within_at (λ y, f y + c) f' s x :=
+hf.add_const c
+
+theorem has_deriv_at.add_const
+  (hf : has_deriv_at f f' x) (c : F) :
+  has_deriv_at (λ x, f x + c) f' x :=
+hf.add_const c
+
+lemma deriv_within_add_const (hxs : unique_diff_within_at 𝕜 s x)
+  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
+  deriv_within (λy, f y + c) s x = deriv_within f s x :=
+(hf.has_deriv_within_at.add_const c).deriv_within hxs
+
+lemma deriv_add_const (hf : differentiable_at 𝕜 f x) (c : F) :
+  deriv (λy, f y + c) x = deriv f x :=
+(hf.has_deriv_at.add_const c).deriv
+
+theorem has_deriv_at_filter.const_add (c : F) (hf : has_deriv_at_filter f f' x L) :
+  has_deriv_at_filter (λ y, c + f y) f' x L :=
+zero_add f' ▸ (has_deriv_at_filter_const x L c).add hf
+
+theorem has_deriv_within_at.const_add (c : F) (hf : has_deriv_within_at f f' s x) :
+  has_deriv_within_at (λ y, c + f y) f' s x :=
+hf.const_add c
+
+theorem has_deriv_at.const_add (c : F) (hf : has_deriv_at f f' x) :
+  has_deriv_at (λ x, c + f x) f' x :=
+hf.const_add c
+
+lemma deriv_within_const_add (hxs : unique_diff_within_at 𝕜 s x)
+  (c : F) (hf : differentiable_within_at 𝕜 f s x) :
+  deriv_within (λy, c + f y) s x = deriv_within f s x :=
+(hf.has_deriv_within_at.const_add c).deriv_within hxs
+
+lemma deriv_const_add (c : F) (hf : differentiable_at 𝕜 f x) :
+  deriv (λy, c + f y) x = deriv f x :=
+(hf.has_deriv_at.const_add c).deriv
+
 end add
+
+section mul_vector
+/-! ### Derivative of the multiplication of a scalar function and a vector function -/
+variables {c : 𝕜 → 𝕜} {c' : 𝕜}
+
+theorem has_deriv_within_at.smul
+  (hc : has_deriv_within_at c c' s x) (hf : has_deriv_within_at f f' s x) :
+  has_deriv_within_at (λ y, c y • f y) (c x • f' + c' • f x) s x :=
+begin
+  show has_fderiv_within_at _ _ _ _,
+  convert has_fderiv_within_at.smul hc hf,
+  ext,
+  simp [smul_add, (mul_smul _ _ _).symm, mul_comm]
+end
+
+theorem has_deriv_at.smul
+  (hc : has_deriv_at c c' x) (hf : has_deriv_at f f' x) :
+  has_deriv_at (λ y, c y • f y) (c x • f' + c' • f x) x :=
+begin
+  rw [← has_deriv_within_at_univ] at *,
+  exact hc.smul hf
+end
+
+lemma deriv_within_smul (hxs : unique_diff_within_at 𝕜 s x)
+  (hc : differentiable_within_at 𝕜 c s x) (hf : differentiable_within_at 𝕜 f s x) :
+  deriv_within (λ y, c y • f y) s x = c x • deriv_within f s x + (deriv_within c s x) • f x :=
+(hc.has_deriv_within_at.smul hf.has_deriv_within_at).deriv_within hxs
+
+lemma deriv_smul (hc : differentiable_at 𝕜 c x) (hf : differentiable_at 𝕜 f x) :
+  deriv (λ y, c y • f y) x = c x • deriv f x + (deriv c x) • f x :=
+(hc.has_deriv_at.smul hf.has_deriv_at).deriv
+
+theorem has_deriv_within_at.smul_const
+  (hc : has_deriv_within_at c c' s x) (f : F) :
+  has_deriv_within_at (λ y, c y • f) (c' • f) s x :=
+begin
+  have := hc.smul (has_deriv_within_at_const x s f),
+  rwa [smul_zero, zero_add] at this
+end
+
+theorem has_deriv_at.smul_const
+  (hc : has_deriv_at c c' x) (f : F) :
+  has_deriv_at (λ y, c y • f) (c' • f) x :=
+begin
+  rw [← has_deriv_within_at_univ] at *,
+  exact hc.smul_const f
+end
+
+lemma deriv_within_smul_const (hxs : unique_diff_within_at 𝕜 s x)
+  (hc : differentiable_within_at 𝕜 c s x) (f : F) :
+  deriv_within (λ y, c y • f) s x = (deriv_within c s x) • f :=
+(hc.has_deriv_within_at.smul_const f).deriv_within hxs
+
+lemma deriv_smul_const (hc : differentiable_at 𝕜 c x) (f : F) :
+  deriv (λ y, c y • f) x = (deriv c x) • f :=
+(hc.has_deriv_at.smul_const f).deriv
+
+theorem has_deriv_within_at.const_smul
+  (c : 𝕜) (hf : has_deriv_within_at f f' s x) :
+  has_deriv_within_at (λ y, c • f y) (c • f') s x :=
+begin
+  convert (has_deriv_within_at_const x s c).smul hf,
+  rw [zero_smul, add_zero]
+end
+
+theorem has_deriv_at.const_smul (c : 𝕜) (hf : has_deriv_at f f' x) :
+  has_deriv_at (λ y, c • f y) (c • f') x :=
+begin
+  rw [← has_deriv_within_at_univ] at *,
+  exact hf.const_smul c
+end
+
+lemma deriv_within_const_smul (hxs : unique_diff_within_at 𝕜 s x)
+  (c : 𝕜) (hf : differentiable_within_at 𝕜 f s x) :
+  deriv_within (λ y, c • f y) s x = c • deriv_within f s x :=
+(hf.has_deriv_within_at.const_smul c).deriv_within hxs
+
+lemma deriv_const_smul (c : 𝕜) (hf : differentiable_at 𝕜 f x) :
+  deriv (λ y, c • f y) x = c • deriv f x :=
+(hf.has_deriv_at.const_smul c).deriv
+
+end mul_vector
 
 section neg
 /-! ### Derivative of the negative of a function -/
 
 theorem has_deriv_at_filter.neg (h : has_deriv_at_filter f f' x L) :
   has_deriv_at_filter (λ x, -f x) (-f') x L :=
-(h.smul (-1)).congr (by simp) (by simp)
+h.neg.congr (by simp) (by simp)
 
 theorem has_deriv_within_at.neg (h : has_deriv_within_at f f' s x) :
   has_deriv_within_at (λ x, -f x) (-f') s x :=
@@ -530,6 +657,51 @@ lemma deriv_sub
 theorem has_deriv_at_filter.is_O_sub (h : has_deriv_at_filter f f' x L) :
   is_O (λ x', f x' - f x) (λ x', x' - x) L :=
 has_fderiv_at_filter.is_O_sub h
+
+theorem has_deriv_at_filter.sub_const
+  (hf : has_deriv_at_filter f f' x L) (c : F) :
+  has_deriv_at_filter (λ x, f x - c) f' x L :=
+hf.add_const (-c)
+
+theorem has_deriv_within_at.sub_const
+  (hf : has_deriv_within_at f f' s x) (c : F) :
+  has_deriv_within_at (λ x, f x - c) f' s x :=
+hf.sub_const c
+
+theorem has_deriv_at.sub_const
+  (hf : has_deriv_at f f' x) (c : F) :
+  has_deriv_at (λ x, f x - c) f' x :=
+hf.sub_const c
+
+lemma deriv_within_sub_const (hxs : unique_diff_within_at 𝕜 s x)
+  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
+  deriv_within (λy, f y - c) s x = deriv_within f s x :=
+(hf.has_deriv_within_at.sub_const c).deriv_within hxs
+
+lemma deriv_sub_const (c : F) (hf : differentiable_at 𝕜 f x) :
+  deriv (λ y, f y - c) x = deriv f x :=
+(hf.has_deriv_at.sub_const c).deriv
+
+theorem has_deriv_at_filter.const_sub (c : F) (hf : has_deriv_at_filter f f' x L) :
+  has_deriv_at_filter (λ x, c - f x) (-f') x L :=
+hf.neg.const_add c
+
+theorem has_deriv_within_at.const_sub (c : F) (hf : has_deriv_within_at f f' s x) :
+  has_deriv_within_at (λ x, c - f x) (-f') s x :=
+hf.const_sub c
+
+theorem has_deriv_at.const_sub (c : F) (hf : has_deriv_at f f' x) :
+  has_deriv_at (λ x, c - f x) (-f') x :=
+hf.const_sub c
+
+lemma deriv_within_const_sub (hxs : unique_diff_within_at 𝕜 s x)
+  (c : F) (hf : differentiable_within_at 𝕜 f s x) :
+  deriv_within (λy, c - f y) s x = -deriv_within f s x :=
+(hf.has_deriv_within_at.const_sub c).deriv_within hxs
+
+lemma deriv_const_sub (c : F) (hf : differentiable_at 𝕜 f x) :
+  deriv (λ y, c - f y) x = -deriv f x :=
+(hf.has_deriv_at.const_sub c).deriv
 
 end sub
 
@@ -695,70 +867,79 @@ end
 
 end composition_vector
 
-section mul_vector
-/-! ### Derivative of the multiplication of a scalar function and a vector function -/
-variables {c : 𝕜 → 𝕜} {c' : 𝕜}
-
-theorem has_deriv_within_at.smul'
-  (hc : has_deriv_within_at c c' s x) (hf : has_deriv_within_at f f' s x) :
-  has_deriv_within_at (λ y, c y • f y) (c x • f' + c' • f x) s x :=
-begin
-  show has_fderiv_within_at _ _ _ _,
-  convert has_fderiv_within_at.smul' hc hf,
-  ext,
-  simp [smul_add, (mul_smul _ _ _).symm, mul_comm]
-end
-
-theorem has_deriv_at.smul'
-  (hc : has_deriv_at c c' x) (hf : has_deriv_at f f' x) :
-  has_deriv_at (λ y, c y • f y) (c x • f' + c' • f x) x :=
-begin
-  show has_fderiv_at _ _ _,
-  convert has_fderiv_at.smul' hc hf,
-  ext,
-  simp [smul_add, (mul_smul _ _ _).symm, mul_comm]
-end
-
-lemma deriv_within_smul' (hxs : unique_diff_within_at 𝕜 s x)
-  (hc : differentiable_within_at 𝕜 c s x) (hf : differentiable_within_at 𝕜 f s x) :
-  deriv_within (λ y, c y • f y) s x = c x • deriv_within f s x + (deriv_within c s x) • f x :=
-(hc.has_deriv_within_at.smul' hf.has_deriv_within_at).deriv_within hxs
-
-lemma deriv_smul' (hc : differentiable_at 𝕜 c x) (hf : differentiable_at 𝕜 f x) :
-  deriv (λ y, c y • f y) x = c x • deriv f x + (deriv c x) • f x :=
-(hc.has_deriv_at.smul' hf.has_deriv_at).deriv
-
-end mul_vector
-
 section mul
 /-! ### Derivative of the multiplication of two scalar functions -/
 variables {c d : 𝕜 → 𝕜} {c' d' : 𝕜}
 
 theorem has_deriv_within_at.mul
   (hc : has_deriv_within_at c c' s x) (hd : has_deriv_within_at d d' s x) :
-  has_deriv_within_at (λ y, c y * d y) (c x * d' + d x * c') s x :=
+  has_deriv_within_at (λ y, c y * d y) (c' * d x + c x * d') s x :=
 begin
-  show has_fderiv_within_at _ _ _ _,
-  convert has_fderiv_within_at.mul hc hd,
-  ext, simp, ring,
+  convert hc.smul hd using 1,
+  rw [smul_eq_mul, smul_eq_mul, add_comm]
 end
 
 theorem has_deriv_at.mul (hc : has_deriv_at c c' x) (hd : has_deriv_at d d' x) :
-  has_deriv_at (λ y, c y * d y) (c x * d' + d x * c') x :=
+  has_deriv_at (λ y, c y * d y) (c' * d x + c x * d') x :=
 begin
-  show has_fderiv_at _ _ _,
-  convert has_fderiv_at.mul hc hd,
-  ext, simp, ring,
+  rw [← has_deriv_within_at_univ] at *,
+  exact hc.mul hd
 end
 
 lemma deriv_within_mul (hxs : unique_diff_within_at 𝕜 s x)
   (hc : differentiable_within_at 𝕜 c s x) (hd : differentiable_within_at 𝕜 d s x) :
-  deriv_within (λ y, c y * d y) s x = c x * deriv_within d s x + d x * deriv_within c s x :=
+  deriv_within (λ y, c y * d y) s x = deriv_within c s x * d x + c x * deriv_within d s x :=
 (hc.has_deriv_within_at.mul hd.has_deriv_within_at).deriv_within hxs
 
 lemma deriv_mul (hc : differentiable_at 𝕜 c x) (hd : differentiable_at 𝕜 d x) :
-  deriv (λ y, c y * d y) x = c x * deriv d x + d x * deriv c x :=
+  deriv (λ y, c y * d y) x = deriv c x * d x + c x * deriv d x :=
 (hc.has_deriv_at.mul hd.has_deriv_at).deriv
+
+theorem has_deriv_within_at.mul_const (hc : has_deriv_within_at c c' s x) (d : 𝕜) :
+  has_deriv_within_at (λ y, c y * d) (c' * d) s x :=
+begin
+  convert hc.mul (has_deriv_within_at_const x s d),
+  rw [mul_zero, add_zero]
+end
+
+theorem has_deriv_at.mul_const (hc : has_deriv_at c c' x) (d : 𝕜) :
+  has_deriv_at (λ y, c y * d) (c' * d) x :=
+begin
+  rw [← has_deriv_within_at_univ] at *,
+  exact hc.mul_const d  
+end
+
+lemma deriv_within_mul_const (hxs : unique_diff_within_at 𝕜 s x)
+  (hc : differentiable_within_at 𝕜 c s x) (d : 𝕜) :
+  deriv_within (λ y, c y * d) s x = deriv_within c s x * d :=
+(hc.has_deriv_within_at.mul_const d).deriv_within hxs
+
+lemma deriv_mul_const (hc : differentiable_at 𝕜 c x) (d : 𝕜) :
+  deriv (λ y, c y * d) x = deriv c x * d :=
+(hc.has_deriv_at.mul_const d).deriv
+
+theorem has_deriv_within_at.const_mul (c : 𝕜) (hd : has_deriv_within_at d d' s x) :
+  has_deriv_within_at (λ y, c * d y) (c * d') s x :=
+begin
+  convert (has_deriv_within_at_const x s c).mul hd,
+  rw [zero_mul, zero_add]
+end
+
+theorem has_deriv_at.const_mul (c : 𝕜) (hd : has_deriv_at d d' x) :
+  has_deriv_at (λ y, c * d y) (c * d') x :=
+begin
+  rw [← has_deriv_within_at_univ] at *,
+  exact hd.const_mul c
+end
+
+lemma deriv_within_const_mul (hxs : unique_diff_within_at 𝕜 s x)
+  (c : 𝕜) (hd : differentiable_within_at 𝕜 d s x) :
+  deriv_within (λ y, c * d y) s x = c * deriv_within d s x :=
+(hd.has_deriv_within_at.const_mul c).deriv_within hxs
+
+lemma deriv_const_mul (c : 𝕜) (hd : differentiable_at 𝕜 d x) :
+  deriv (λ y, c * d y) x = c * deriv d x :=
+(hd.has_deriv_at.const_mul c).deriv
 
 end mul
 
@@ -834,7 +1015,7 @@ end
 
 lemma has_fderiv_at_inv (x_ne_zero : x ≠ 0) :
   has_fderiv_at (λx, x⁻¹) (smul_right 1 (-(x^2)⁻¹) : 𝕜 →L[𝕜] 𝕜) x :=
-by simpa [has_deriv_at_iff_has_fderiv_at] using has_deriv_at_inv x_ne_zero
+has_deriv_at_inv x_ne_zero
 
 lemma has_fderiv_within_at_inv (x_ne_zero : x ≠ 0) :
   has_fderiv_within_at (λx, x⁻¹) (smul_right 1 (-(x^2)⁻¹) : 𝕜 →L[𝕜] 𝕜) s x :=

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -70,20 +70,9 @@ derivative, differentiable, Fréchet, calculus
 -/
 
 open filter asymptotics continuous_linear_map set
-open_locale topological_space
+open_locale topological_space classical
 
 noncomputable theory
-local attribute [instance, priority 10] classical.decidable_inhabited classical.prop_decidable
--- local attribute [instance, priority 10000] continuous_linear_map.add_comm_group
---   continuous_linear_map.module normed_field.normed_field normed_field.nondiscrete_normed_field
--- local attribute [instance, priority 5000] normed_space.to_module
---   module.to_semimodule semimodule.to_distrib_mul_action distrib_mul_action.to_mul_action
---   mul_action.to_has_scalar add_comm_group.to_add_comm_monoid
---   add_comm_monoid.to_add_monoid ring.to_monoid ring.to_semiring
---   nondiscrete_normed_field.to_normed_field
---   normed_group.to_add_comm_group normed_field.to_discrete_field discrete_field.to_field
---   field.to_division_ring field.to_comm_ring comm_ring.to_ring uniform_space.to_topological_space
---   metric_space.to_uniform_space' normed_group.to_has_norm
 
 set_option class.instance_max_depth 90
 
@@ -1659,7 +1648,6 @@ variables {E : Type*} [normed_group E] [normed_space ℝ E]
 variables {F : Type*} [normed_group F] [normed_space ℝ F]
 variables {f : E → F} {f' : E →L[ℝ] F} {x : E}
 
--- set_option trace.class_instances true
 theorem has_fderiv_at_filter_real_equiv {L : filter E} :
   tendsto (λ x' : E, ∥x' - x∥⁻¹ * ∥f x' - f x - f' (x' - x)∥) L (𝓝 0) ↔
   tendsto (λ x' : E, ∥x' - x∥⁻¹ • (f x' - f x - f' (x' - x))) L (𝓝 0) :=
@@ -1669,8 +1657,6 @@ begin
   have : ∥x' + -x∥⁻¹ ≥ 0, from inv_nonneg.mpr (norm_nonneg _),
   simp [norm_smul, real.norm_eq_abs, abs_of_nonneg this]
 end
-
--- set_option trace.class_instances false
 
 lemma has_fderiv_at.lim_real (hf : has_fderiv_at f f' x) (v : E) :
   tendsto (λ (c:ℝ), c • (f (x + c⁻¹ • v) - f x)) at_top (𝓝 (f' v)) :=

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -35,6 +35,10 @@ usual formulas (and existence assertions) for the derivative of
 * multiplication of two scalar functions
 * composition of functions (the chain rule)
 
+For most binary operations we also define `const_op` and `op_const` theorems for the cases when
+the first or second argument is a constant. This makes writing chains of `has_deriv_at`'s easier,
+and they more frequently lead to the desired result.
+
 One can also interpret the derivative of a function `f : 𝕜 → E` as an element of `E` (by identifying
 a linear function from `𝕜` to `E` with its value at `1`). Results on the Fréchet derivative are
 translated to this more elementary point of view on the derivative in the file `deriv.lean`. The

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2019 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jeremy Avigad, Sébastien Gouëzel
+Authors: Jeremy Avigad, Sébastien Gouëzel, Yury Kudryashov
 -/
 
 import analysis.asymptotics analysis.calculus.tangent_cone
@@ -70,6 +70,16 @@ open_locale topological_space
 
 noncomputable theory
 local attribute [instance, priority 10] classical.decidable_inhabited classical.prop_decidable
+-- local attribute [instance, priority 10000] continuous_linear_map.add_comm_group
+--   continuous_linear_map.module normed_field.normed_field normed_field.nondiscrete_normed_field
+-- local attribute [instance, priority 5000] normed_space.to_module
+--   module.to_semimodule semimodule.to_distrib_mul_action distrib_mul_action.to_mul_action
+--   mul_action.to_has_scalar add_comm_group.to_add_comm_monoid
+--   add_comm_monoid.to_add_monoid ring.to_monoid ring.to_semiring
+--   nondiscrete_normed_field.to_normed_field
+--   normed_group.to_add_comm_group normed_field.to_discrete_field discrete_field.to_field
+--   field.to_division_ring field.to_comm_ring comm_ring.to_ring uniform_space.to_topological_space
+--   metric_space.to_uniform_space' normed_group.to_has_norm
 
 set_option class.instance_max_depth 90
 
@@ -732,47 +742,46 @@ e.differentiable.differentiable_on
 
 end continuous_linear_map
 
-section smul_const
+section const_smul
 /-! ### Derivative of a function multiplied by a constant -/
-
-theorem has_fderiv_at_filter.smul (h : has_fderiv_at_filter f f' x L) (c : 𝕜) :
+theorem has_fderiv_at_filter.const_smul (h : has_fderiv_at_filter f f' x L) (c : 𝕜) :
   has_fderiv_at_filter (λ x, c • f x) (c • f') x L :=
 (is_o_const_smul_left h c).congr_left $ λ x, by simp [smul_neg, smul_add]
 
-theorem has_fderiv_within_at.smul (h : has_fderiv_within_at f f' s x) (c : 𝕜) :
+theorem has_fderiv_within_at.const_smul (h : has_fderiv_within_at f f' s x) (c : 𝕜) :
   has_fderiv_within_at (λ x, c • f x) (c • f') s x :=
-h.smul c
+h.const_smul c
 
-theorem has_fderiv_at.smul (h : has_fderiv_at f f' x) (c : 𝕜) :
+theorem has_fderiv_at.const_smul (h : has_fderiv_at f f' x) (c : 𝕜) :
   has_fderiv_at (λ x, c • f x) (c • f') x :=
-h.smul c
+h.const_smul c
 
-lemma differentiable_within_at.smul (h : differentiable_within_at 𝕜 f s x) (c : 𝕜) :
+lemma differentiable_within_at.const_smul (h : differentiable_within_at 𝕜 f s x) (c : 𝕜) :
   differentiable_within_at 𝕜 (λy, c • f y) s x :=
-(h.has_fderiv_within_at.smul c).differentiable_within_at
+(h.has_fderiv_within_at.const_smul c).differentiable_within_at
 
-lemma differentiable_at.smul (h : differentiable_at 𝕜 f x) (c : 𝕜) :
+lemma differentiable_at.const_smul (h : differentiable_at 𝕜 f x) (c : 𝕜) :
   differentiable_at 𝕜 (λy, c • f y) x :=
-(h.has_fderiv_at.smul c).differentiable_at
+(h.has_fderiv_at.const_smul c).differentiable_at
 
-lemma differentiable_on.smul (h : differentiable_on 𝕜 f s) (c : 𝕜) :
+lemma differentiable_on.const_smul (h : differentiable_on 𝕜 f s) (c : 𝕜) :
   differentiable_on 𝕜 (λy, c • f y) s :=
-λx hx, (h x hx).smul c
+λx hx, (h x hx).const_smul c
 
-lemma differentiable.smul (h : differentiable 𝕜 f) (c : 𝕜) :
+lemma differentiable.const_smul (h : differentiable 𝕜 f) (c : 𝕜) :
   differentiable 𝕜 (λy, c • f y) :=
-λx, (h x).smul c
+λx, (h x).const_smul c
 
-lemma fderiv_within_smul (hxs : unique_diff_within_at 𝕜 s x)
+lemma fderiv_within_const_smul (hxs : unique_diff_within_at 𝕜 s x)
   (h : differentiable_within_at 𝕜 f s x) (c : 𝕜) :
   fderiv_within 𝕜 (λy, c • f y) s x = c • fderiv_within 𝕜 f s x :=
-(h.has_fderiv_within_at.smul c).fderiv_within hxs
+(h.has_fderiv_within_at.const_smul c).fderiv_within hxs
 
-lemma fderiv_smul (h : differentiable_at 𝕜 f x) (c : 𝕜) :
+lemma fderiv_const_smul (h : differentiable_at 𝕜 f x) (c : 𝕜) :
   fderiv 𝕜 (λy, c • f y) x = c • fderiv 𝕜 f x :=
-(h.has_fderiv_at.smul c).fderiv
+(h.has_fderiv_at.const_smul c).fderiv
 
-end smul_const
+end const_smul
 
 section add
 /-! ### Derivative of the sum of two functions -/
@@ -822,6 +831,96 @@ lemma fderiv_add
   fderiv 𝕜 (λy, f y + g y) x = fderiv 𝕜 f x + fderiv 𝕜 g x :=
 (hf.has_fderiv_at.add hg.has_fderiv_at).fderiv
 
+theorem has_fderiv_at_filter.add_const
+  (hf : has_fderiv_at_filter f f' x L) (c : F) :
+  has_fderiv_at_filter (λ y, f y + c) f' x L :=
+add_zero f' ▸ hf.add (has_fderiv_at_filter_const _ _ _)
+
+theorem has_fderiv_within_at.add_const
+  (hf : has_fderiv_within_at f f' s x) (c : F) :
+  has_fderiv_within_at (λ y, f y + c) f' s x :=
+hf.add_const c
+
+theorem has_fderiv_at.add_const
+  (hf : has_fderiv_at f f' x) (c : F):
+  has_fderiv_at (λ x, f x + c) f' x :=
+hf.add_const c
+
+lemma differentiable_within_at.add_const
+  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
+  differentiable_within_at 𝕜 (λ y, f y + c) s x :=
+(hf.has_fderiv_within_at.add_const c).differentiable_within_at
+
+lemma differentiable_at.add_const
+  (hf : differentiable_at 𝕜 f x) (c : F) :
+  differentiable_at 𝕜 (λ y, f y + c) x :=
+(hf.has_fderiv_at.add_const c).differentiable_at
+
+lemma differentiable_on.add_const
+  (hf : differentiable_on 𝕜 f s) (c : F) :
+  differentiable_on 𝕜 (λy, f y + c) s :=
+λx hx, (hf x hx).add_const c
+
+lemma differentiable.add_const
+  (hf : differentiable 𝕜 f) (c : F) :
+  differentiable 𝕜 (λy, f y + c) :=
+λx, (hf x).add_const c
+
+lemma fderiv_within_add_const (hxs : unique_diff_within_at 𝕜 s x)
+  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
+  fderiv_within 𝕜 (λy, f y + c) s x = fderiv_within 𝕜 f s x :=
+(hf.has_fderiv_within_at.add_const c).fderiv_within hxs
+
+lemma fderiv_add_const
+  (hf : differentiable_at 𝕜 f x) (c : F) :
+  fderiv 𝕜 (λy, f y + c) x = fderiv 𝕜 f x :=
+(hf.has_fderiv_at.add_const c).fderiv
+
+theorem has_fderiv_at_filter.const_add
+  (hf : has_fderiv_at_filter f f' x L) (c : F) :
+  has_fderiv_at_filter (λ y, c + f y) f' x L :=
+zero_add f' ▸ (has_fderiv_at_filter_const _ _ _).add hf
+
+theorem has_fderiv_within_at.const_add
+  (hf : has_fderiv_within_at f f' s x) (c : F) :
+  has_fderiv_within_at (λ y, c + f y) f' s x :=
+hf.const_add c
+
+theorem has_fderiv_at.const_add
+  (hf : has_fderiv_at f f' x) (c : F):
+  has_fderiv_at (λ x, c + f x) f' x :=
+hf.const_add c
+
+lemma differentiable_within_at.const_add
+  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
+  differentiable_within_at 𝕜 (λ y, c + f y) s x :=
+(hf.has_fderiv_within_at.const_add c).differentiable_within_at
+
+lemma differentiable_at.const_add
+  (hf : differentiable_at 𝕜 f x) (c : F) :
+  differentiable_at 𝕜 (λ y, c + f y) x :=
+(hf.has_fderiv_at.const_add c).differentiable_at
+
+lemma differentiable_on.const_add
+  (hf : differentiable_on 𝕜 f s) (c : F) :
+  differentiable_on 𝕜 (λy, c + f y) s :=
+λx hx, (hf x hx).const_add c
+
+lemma differentiable.const_add
+  (hf : differentiable 𝕜 f) (c : F) :
+  differentiable 𝕜 (λy, c + f y) :=
+λx, (hf x).const_add c
+
+lemma fderiv_within_const_add (hxs : unique_diff_within_at 𝕜 s x)
+  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
+  fderiv_within 𝕜 (λy, c + f y) s x = fderiv_within 𝕜 f s x :=
+(hf.has_fderiv_within_at.const_add c).fderiv_within hxs
+
+lemma fderiv_const_add
+  (hf : differentiable_at 𝕜 f x) (c : F) :
+  fderiv 𝕜 (λy, c + f y) x = fderiv 𝕜 f x :=
+(hf.has_fderiv_at.const_add c).fderiv
+
 end add
 
 section neg
@@ -829,7 +928,7 @@ section neg
 
 theorem has_fderiv_at_filter.neg (h : has_fderiv_at_filter f f' x L) :
   has_fderiv_at_filter (λ x, -f x) (-f') x L :=
-(h.smul (-1:𝕜)).congr (by simp) (by simp)
+(h.const_smul (-1:𝕜)).congr (by simp) (by simp)
 
 theorem has_fderiv_within_at.neg (h : has_fderiv_within_at f f' s x) :
   has_fderiv_within_at (λ x, -f x) (-f') s x :=
@@ -917,6 +1016,96 @@ lemma fderiv_sub
 theorem has_fderiv_at_filter.is_O_sub (h : has_fderiv_at_filter f f' x L) :
 is_O (λ x', f x' - f x) (λ x', x' - x) L :=
 h.to_is_O.congr_of_sub.2 (f'.is_O_sub _ _)
+
+theorem has_fderiv_at_filter.sub_const
+  (hf : has_fderiv_at_filter f f' x L) (c : F) :
+  has_fderiv_at_filter (λ x, f x - c) f' x L :=
+hf.add_const (-c)
+
+theorem has_fderiv_within_at.sub_const
+  (hf : has_fderiv_within_at f f' s x) (c : F) :
+  has_fderiv_within_at (λ x, f x - c) f' s x :=
+hf.sub_const c
+
+theorem has_fderiv_at.sub_const
+  (hf : has_fderiv_at f f' x) (c : F) :
+  has_fderiv_at (λ x, f x - c) f' x :=
+hf.sub_const c
+
+lemma differentiable_within_at.sub_const
+  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
+  differentiable_within_at 𝕜 (λ y, f y - c) s x :=
+(hf.has_fderiv_within_at.sub_const c).differentiable_within_at
+
+lemma differentiable_at.sub_const
+  (hf : differentiable_at 𝕜 f x) (c : F) :
+  differentiable_at 𝕜 (λ y, f y - c) x :=
+(hf.has_fderiv_at.sub_const c).differentiable_at
+
+lemma differentiable_on.sub_const
+  (hf : differentiable_on 𝕜 f s) (c : F) :
+  differentiable_on 𝕜 (λy, f y - c) s :=
+λx hx, (hf x hx).sub_const c
+
+lemma differentiable.sub_const
+  (hf : differentiable 𝕜 f) (c : F) :
+  differentiable 𝕜 (λy, f y - c) :=
+λx, (hf x).sub_const c
+
+lemma fderiv_within_sub_const (hxs : unique_diff_within_at 𝕜 s x)
+  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
+  fderiv_within 𝕜 (λy, f y - c) s x = fderiv_within 𝕜 f s x :=
+(hf.has_fderiv_within_at.sub_const c).fderiv_within hxs
+
+lemma fderiv_sub_const
+  (hf : differentiable_at 𝕜 f x) (c : F) :
+  fderiv 𝕜 (λy, f y - c) x = fderiv 𝕜 f x :=
+(hf.has_fderiv_at.sub_const c).fderiv
+
+theorem has_fderiv_at_filter.const_sub
+  (hf : has_fderiv_at_filter f f' x L) (c : F) :
+  has_fderiv_at_filter (λ x, c - f x) (-f') x L :=
+hf.neg.const_add c
+
+theorem has_fderiv_within_at.const_sub
+  (hf : has_fderiv_within_at f f' s x) (c : F) :
+  has_fderiv_within_at (λ x, c - f x) (-f') s x :=
+hf.const_sub c
+
+theorem has_fderiv_at.const_sub
+  (hf : has_fderiv_at f f' x) (c : F) :
+  has_fderiv_at (λ x, c - f x) (-f') x :=
+hf.const_sub c
+
+lemma differentiable_within_at.const_sub
+  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
+  differentiable_within_at 𝕜 (λ y, c - f y) s x :=
+(hf.has_fderiv_within_at.const_sub c).differentiable_within_at
+
+lemma differentiable_at.const_sub
+  (hf : differentiable_at 𝕜 f x) (c : F) :
+  differentiable_at 𝕜 (λ y, c - f y) x :=
+(hf.has_fderiv_at.const_sub c).differentiable_at
+
+lemma differentiable_on.const_sub
+  (hf : differentiable_on 𝕜 f s) (c : F) :
+  differentiable_on 𝕜 (λy, c - f y) s :=
+λx hx, (hf x hx).const_sub c
+
+lemma differentiable.const_sub
+  (hf : differentiable 𝕜 f) (c : F) :
+  differentiable 𝕜 (λy, c - f y) :=
+λx, (hf x).const_sub c
+
+lemma fderiv_within_const_sub (hxs : unique_diff_within_at 𝕜 s x)
+  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
+  fderiv_within 𝕜 (λy, c - f y) s x = -fderiv_within 𝕜 f s x :=
+(hf.has_fderiv_within_at.const_sub c).fderiv_within hxs
+
+lemma fderiv_const_sub
+  (hf : differentiable_at 𝕜 f x) (c : F) :
+  fderiv 𝕜 (λy, c - f y) x = -fderiv 𝕜 f x :=
+(hf.has_fderiv_at.const_sub c).fderiv
 
 end sub
 
@@ -1223,7 +1412,7 @@ section smul
 
 variables {c : E → 𝕜} {c' : E →L[𝕜] 𝕜}
 
-theorem has_fderiv_within_at.smul'
+theorem has_fderiv_within_at.smul
   (hc : has_fderiv_within_at c c' s x) (hf : has_fderiv_within_at f f' s x) :
   has_fderiv_within_at (λ y, c y • f y) (c x • f' + c'.smul_right (f x)) s x :=
 begin
@@ -1231,40 +1420,84 @@ begin
   exact has_fderiv_at.comp_has_fderiv_within_at x (this.has_fderiv_at (c x, f x)) (hc.prod hf)
 end
 
-theorem has_fderiv_at.smul' (hc : has_fderiv_at c c' x) (hf : has_fderiv_at f f' x) :
+theorem has_fderiv_at.smul (hc : has_fderiv_at c c' x) (hf : has_fderiv_at f f' x) :
   has_fderiv_at (λ y, c y • f y) (c x • f' + c'.smul_right (f x)) x :=
 begin
   have : is_bounded_bilinear_map 𝕜 (λ (p : 𝕜 × F), p.1 • p.2) := is_bounded_bilinear_map_smul,
   exact has_fderiv_at.comp x (this.has_fderiv_at (c x, f x)) (hc.prod hf)
 end
 
-lemma differentiable_within_at.smul'
+lemma differentiable_within_at.smul
   (hc : differentiable_within_at 𝕜 c s x) (hf : differentiable_within_at 𝕜 f s x) :
   differentiable_within_at 𝕜 (λ y, c y • f y) s x :=
-(hc.has_fderiv_within_at.smul' hf.has_fderiv_within_at).differentiable_within_at
+(hc.has_fderiv_within_at.smul hf.has_fderiv_within_at).differentiable_within_at
 
-lemma differentiable_at.smul' (hc : differentiable_at 𝕜 c x) (hf : differentiable_at 𝕜 f x) :
+lemma differentiable_at.smul (hc : differentiable_at 𝕜 c x) (hf : differentiable_at 𝕜 f x) :
   differentiable_at 𝕜 (λ y, c y • f y) x :=
-(hc.has_fderiv_at.smul' hf.has_fderiv_at).differentiable_at
+(hc.has_fderiv_at.smul hf.has_fderiv_at).differentiable_at
 
-lemma differentiable_on.smul' (hc : differentiable_on 𝕜 c s) (hf : differentiable_on 𝕜 f s) :
+lemma differentiable_on.smul (hc : differentiable_on 𝕜 c s) (hf : differentiable_on 𝕜 f s) :
   differentiable_on 𝕜 (λ y, c y • f y) s :=
-λx hx, (hc x hx).smul' (hf x hx)
+λx hx, (hc x hx).smul (hf x hx)
 
-lemma differentiable.smul' (hc : differentiable 𝕜 c) (hf : differentiable 𝕜 f) :
+lemma differentiable.smul (hc : differentiable 𝕜 c) (hf : differentiable 𝕜 f) :
   differentiable 𝕜 (λ y, c y • f y) :=
-λx, (hc x).smul' (hf x)
+λx, (hc x).smul (hf x)
 
-lemma fderiv_within_smul' (hxs : unique_diff_within_at 𝕜 s x)
+lemma fderiv_within_smul (hxs : unique_diff_within_at 𝕜 s x)
   (hc : differentiable_within_at 𝕜 c s x) (hf : differentiable_within_at 𝕜 f s x) :
   fderiv_within 𝕜 (λ y, c y • f y) s x =
     c x • fderiv_within 𝕜 f s x + (fderiv_within 𝕜 c s x).smul_right (f x) :=
-(hc.has_fderiv_within_at.smul' hf.has_fderiv_within_at).fderiv_within hxs
+(hc.has_fderiv_within_at.smul hf.has_fderiv_within_at).fderiv_within hxs
 
-lemma fderiv_smul' (hc : differentiable_at 𝕜 c x) (hf : differentiable_at 𝕜 f x) :
+lemma fderiv_smul (hc : differentiable_at 𝕜 c x) (hf : differentiable_at 𝕜 f x) :
   fderiv 𝕜 (λ y, c y • f y) x =
     c x • fderiv 𝕜 f x + (fderiv 𝕜 c x).smul_right (f x) :=
-(hc.has_fderiv_at.smul' hf.has_fderiv_at).fderiv
+(hc.has_fderiv_at.smul hf.has_fderiv_at).fderiv
+
+theorem has_fderiv_within_at.smul_const (hc : has_fderiv_within_at c c' s x) (f : F) :
+  has_fderiv_within_at (λ y, c y • f) (c'.smul_right f) s x :=
+begin
+  convert hc.smul (has_fderiv_within_at_const f x s),
+  -- Help Lean find an instance
+  letI : distrib_mul_action 𝕜 (E →L[𝕜] F) :=
+    continuous_linear_map.module.to_distrib_mul_action,
+  rw [smul_zero, zero_add]
+end
+
+theorem has_fderiv_at.smul_const (hc : has_fderiv_at c c' x) (f : F) :
+  has_fderiv_at (λ y, c y • f) (c'.smul_right f) x :=
+begin
+  rw [← has_fderiv_within_at_univ] at *,
+  exact hc.smul_const f
+end
+
+lemma differentiable_within_at.smul_const
+  (hc : differentiable_within_at 𝕜 c s x) (f : F) :
+  differentiable_within_at 𝕜 (λ y, c y • f) s x :=
+(hc.has_fderiv_within_at.smul_const f).differentiable_within_at
+
+lemma differentiable_at.smul_const (hc : differentiable_at 𝕜 c x) (f : F) :
+  differentiable_at 𝕜 (λ y, c y • f) x :=
+(hc.has_fderiv_at.smul_const f).differentiable_at
+
+lemma differentiable_on.smul_const (hc : differentiable_on 𝕜 c s) (f : F) :
+  differentiable_on 𝕜 (λ y, c y • f) s :=
+λx hx, (hc x hx).smul_const f
+
+lemma differentiable.smul_const (hc : differentiable 𝕜 c) (f : F) :
+  differentiable 𝕜 (λ y, c y • f) :=
+λx, (hc x).smul_const f
+
+lemma fderiv_within_smul_const (hxs : unique_diff_within_at 𝕜 s x)
+  (hc : differentiable_within_at 𝕜 c s x) (f : F) :
+  fderiv_within 𝕜 (λ y, c y • f) s x =
+    (fderiv_within 𝕜 c s x).smul_right f :=
+(hc.has_fderiv_within_at.smul_const f).fderiv_within hxs
+
+lemma fderiv_smul_const (hc : differentiable_at 𝕜 c x) (f : F) :
+  fderiv 𝕜 (λ y, c y • f) x = (fderiv 𝕜 c x).smul_right f :=
+(hc.has_fderiv_at.smul_const f).fderiv
 
 end smul
 
@@ -1323,6 +1556,89 @@ lemma fderiv_mul (hc : differentiable_at 𝕜 c x) (hd : differentiable_at 𝕜 
     c x • fderiv 𝕜 d x + d x • fderiv 𝕜 c x :=
 (hc.has_fderiv_at.mul hd.has_fderiv_at).fderiv
 
+theorem has_fderiv_within_at.mul_const
+  (hc : has_fderiv_within_at c c' s x) (d : 𝕜) :
+  has_fderiv_within_at (λ y, c y * d) (d • c') s x :=
+begin
+  have := hc.mul (has_fderiv_within_at_const d x s),
+  letI : distrib_mul_action 𝕜 (E →L[𝕜] 𝕜) := continuous_linear_map.module.to_distrib_mul_action,
+  rwa [smul_zero, zero_add] at this
+end
+
+theorem has_fderiv_at.mul_const (hc : has_fderiv_at c c' x) (d : 𝕜) :
+  has_fderiv_at (λ y, c y * d) (d • c') x :=
+begin
+  rw [← has_fderiv_within_at_univ] at *,
+  exact hc.mul_const d
+end
+
+lemma differentiable_within_at.mul_const
+  (hc : differentiable_within_at 𝕜 c s x) (d : 𝕜) :
+  differentiable_within_at 𝕜 (λ y, c y * d) s x :=
+(hc.has_fderiv_within_at.mul_const d).differentiable_within_at
+
+lemma differentiable_at.mul_const (hc : differentiable_at 𝕜 c x) (d : 𝕜) :
+  differentiable_at 𝕜 (λ y, c y * d) x :=
+(hc.has_fderiv_at.mul_const d).differentiable_at
+
+lemma differentiable_on.mul_const (hc : differentiable_on 𝕜 c s) (d : 𝕜) :
+  differentiable_on 𝕜 (λ y, c y * d) s :=
+λx hx, (hc x hx).mul_const d
+
+lemma differentiable.mul_const (hc : differentiable 𝕜 c) (d : 𝕜) :
+  differentiable 𝕜 (λ y, c y * d) :=
+λx, (hc x).mul_const d
+
+lemma fderiv_within_mul_const (hxs : unique_diff_within_at 𝕜 s x)
+  (hc : differentiable_within_at 𝕜 c s x) (d : 𝕜) :
+  fderiv_within 𝕜 (λ y, c y * d) s x = d • fderiv_within 𝕜 c s x :=
+(hc.has_fderiv_within_at.mul_const d).fderiv_within hxs
+
+lemma fderiv_mul_const (hc : differentiable_at 𝕜 c x) (d : 𝕜) :
+  fderiv 𝕜 (λ y, c y * d) x = d • fderiv 𝕜 c x :=
+(hc.has_fderiv_at.mul_const d).fderiv
+
+theorem has_fderiv_within_at.const_mul
+  (hc : has_fderiv_within_at c c' s x) (d : 𝕜) :
+  has_fderiv_within_at (λ y, d * c y) (d • c') s x :=
+begin
+  simp only [mul_comm d],
+  exact hc.mul_const d,
+end
+
+theorem has_fderiv_at.const_mul (hc : has_fderiv_at c c' x) (d : 𝕜) :
+  has_fderiv_at (λ y, d * c y) (d • c') x :=
+begin
+  simp only [mul_comm d],
+  exact hc.mul_const d,
+end
+
+lemma differentiable_within_at.const_mul
+  (hc : differentiable_within_at 𝕜 c s x) (d : 𝕜) :
+  differentiable_within_at 𝕜 (λ y, d * c y) s x :=
+(hc.has_fderiv_within_at.const_mul d).differentiable_within_at
+
+lemma differentiable_at.const_mul (hc : differentiable_at 𝕜 c x) (d : 𝕜) :
+  differentiable_at 𝕜 (λ y, d * c y) x :=
+(hc.has_fderiv_at.const_mul d).differentiable_at
+
+lemma differentiable_on.const_mul (hc : differentiable_on 𝕜 c s) (d : 𝕜) :
+  differentiable_on 𝕜 (λ y, d * c y) s :=
+λx hx, (hc x hx).const_mul d
+
+lemma differentiable.const_mul (hc : differentiable 𝕜 c) (d : 𝕜) :
+  differentiable 𝕜 (λ y, d * c y) :=
+λx, (hc x).const_mul d
+
+lemma fderiv_within_const_mul (hxs : unique_diff_within_at 𝕜 s x)
+  (hc : differentiable_within_at 𝕜 c s x) (d : 𝕜) :
+  fderiv_within 𝕜 (λ y, d * c y) s x = d • fderiv_within 𝕜 c s x :=
+(hc.has_fderiv_within_at.const_mul d).fderiv_within hxs
+
+lemma fderiv_const_mul (hc : differentiable_at 𝕜 c x) (d : 𝕜) :
+  fderiv 𝕜 (λ y, d * c y) x = d • fderiv 𝕜 c x :=
+(hc.has_fderiv_at.const_mul d).fderiv
+
 end mul
 
 end
@@ -1339,6 +1655,7 @@ variables {E : Type*} [normed_group E] [normed_space ℝ E]
 variables {F : Type*} [normed_group F] [normed_space ℝ F]
 variables {f : E → F} {f' : E →L[ℝ] F} {x : E}
 
+-- set_option trace.class_instances true
 theorem has_fderiv_at_filter_real_equiv {L : filter E} :
   tendsto (λ x' : E, ∥x' - x∥⁻¹ * ∥f x' - f x - f' (x' - x)∥) L (𝓝 0) ↔
   tendsto (λ x' : E, ∥x' - x∥⁻¹ • (f x' - f x - f' (x' - x))) L (𝓝 0) :=
@@ -1348,6 +1665,8 @@ begin
   have : ∥x' + -x∥⁻¹ ≥ 0, from inv_nonneg.mpr (norm_nonneg _),
   simp [norm_smul, real.norm_eq_abs, abs_of_nonneg this]
 end
+
+-- set_option trace.class_instances false
 
 lemma has_fderiv_at.lim_real (hf : has_fderiv_at f f' x) (v : E) :
   tendsto (λ (c:ℝ), c • (f (x + c⁻¹ • v) - f x)) at_top (𝓝 (f' v)) :=

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -202,10 +202,7 @@ begin
   { simp only [h], ring },
   let h' := λ x, (g b - g a) * f' x - (f b - f a) * g' x,
   have hhh' : ∀ x ∈ Ioo a b, has_deriv_at h (h' x) x,
-  { assume x hx,
-    convert ((has_deriv_at_const x (g b - g a)).mul (hff' x hx)).sub
-      ((has_deriv_at_const x (f b - f a)).mul (hgg' x hx)),
-    simp only [h', mul_zero, add_zero] },
+    from λ x hx, ((hff' x hx).const_mul (g b - g a)).sub ((hgg' x hx).const_mul (f b - f a)),
   have hhc : continuous_on h (Icc a b),
     from (continuous_on_const.mul hfc).sub (continuous_on_const.mul hgc),
   rcases exists_has_deriv_at_eq_zero h h' hab hhc hI hhh' with ⟨c, cmem, hc⟩,

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -133,8 +133,7 @@ begin
   have C0 : 0 ≤ C := le_trans (norm_nonneg _) (bound x xs),
   let g := λ(t:ℝ), f (x + t • (y-x)),
   have D1 : differentiable ℝ (λt:ℝ, x + t • (y-x)) :=
-    differentiable.add (differentiable_const _)
-      (differentiable.smul' differentiable_id (differentiable_const _)),
+      (differentiable_id.smul_const (y - x)).const_add x,
   have segm : (λ (t : ℝ), x + t • (y - x)) '' Icc 0 1 ⊆ s,
     by { rw [← segment_eq_image_Icc_zero_one], apply convex_segment_iff.1 hs x y xs ys },
   have : f x = g 0, by { simp only [g], rw [zero_smul, add_zero] },
@@ -153,14 +152,12 @@ begin
     deriv_within (λ (t : ℝ), x + t • (y - x)) (Icc 0 1) t
     = deriv (λ (t : ℝ), x + t • (y - x)) t :
       differentiable_at.deriv_within (D1 t) (unique_diff_on_Icc_zero_one t ht)
-    ... = deriv (λ (t : ℝ), x) t + deriv (λ (t : ℝ), t • (y-x)) t :
-      deriv_add (differentiable_at_const _) ((differentiable.smul' differentiable_id (differentiable_const _)) t)
     ... = deriv (λ (t : ℝ), t • (y-x)) t :
-      by rw [deriv_const, zero_add]
-    ... = t • deriv (λ (t : ℝ), (y-x)) t + (deriv (@_root_.id ℝ) t) • (y - x) :
-      deriv_smul' differentiable_at_id (differentiable_at_const _)
+      deriv_const_add x ((differentiable_id.smul_const (y - x)) t)
+    ... = (deriv (@_root_.id ℝ) t) • (y - x) :
+      deriv_smul_const differentiable_at_id _
     ... = y - x :
-      by rw [deriv_const, smul_zero, zero_add, deriv_id, one_smul],
+      by rw [deriv_id, one_smul],
   rw [this]
 end
 

--- a/src/analysis/complex/exponential.lean
+++ b/src/analysis/complex/exponential.lean
@@ -75,23 +75,28 @@ funext $ λ x, (has_deriv_at_exp x).deriv
 lemma continuous_exp : continuous exp :=
 differentiable_exp.continuous
 
+end complex
+
+lemma has_deriv_at.cexp {f : ℂ → ℂ} {f' x : ℂ} (hf : has_deriv_at f f' x) :
+  has_deriv_at (complex.exp ∘ f) (f' * complex.exp (f x)) x :=
+(complex.has_deriv_at_exp (f x)).comp x hf
+
+lemma has_deriv_within_at.cexp {f : ℂ → ℂ} {f' x : ℂ} {s : set ℂ}
+  (hf : has_deriv_within_at f f' s x) :
+  has_deriv_within_at (complex.exp ∘ f) (f' * complex.exp (f x)) s x :=
+(complex.has_deriv_at_exp (f x)).comp_has_deriv_within_at x hf
+
+namespace complex
+
 /-- The complex sine function is everywhere differentiable, with the derivative `cos x`. -/
 lemma has_deriv_at_sin (x : ℂ) : has_deriv_at sin (cos x) x :=
 begin
-  have A : has_deriv_at (λ(z:ℂ), exp (z * I)) (I * exp (x * I)) x,
-  { convert (has_deriv_at_exp _).comp x ((has_deriv_at_id x).mul (has_deriv_at_const x I)),
-    simp },
-  have B : has_deriv_at (λ(z:ℂ), exp (-z * I)) (-I * exp (-x * I)) x,
-  { convert (has_deriv_at_exp _).comp x ((has_deriv_at_id x).neg.mul (has_deriv_at_const x I)),
-    simp },
-  have C : has_deriv_at (λ(z:ℂ), exp (-z * I) - exp (z * I)) (-I * (exp (x * I) + exp (-x * I))) x,
-    by { convert has_deriv_at.sub B A, ring },
-  convert has_deriv_at.mul C (has_deriv_at_const x (I/(2:ℂ))),
-  { ext z, simp [sin, mul_div_assoc] },
-  { simp only [cos, neg_mul_eq_neg_mul_symm, mul_neg_eq_neg_mul_symm, zero_add, sub_eq_add_neg, mul_zero],
-    rw [← mul_assoc, ← mul_div_right_comm, I_mul_I, div_eq_mul_inv, div_eq_mul_inv],
-    generalize : (2 : ℂ)⁻¹ = u,
-    ring }
+  simp only [cos, div_eq_mul_inv],
+  convert ((((has_deriv_at_id x).neg.mul_const I).cexp.sub
+    ((has_deriv_at_id x).mul_const I).cexp).mul_const I).mul_const (2:ℂ)⁻¹,
+  simp only [function.comp, id],
+  rw [add_comm, one_mul, mul_comm (_ - _), mul_sub, mul_left_comm, ← mul_assoc, ← mul_assoc,
+    I_mul_I, mul_assoc (-1:ℂ), I_mul_I, neg_one_mul, neg_neg, one_mul, neg_one_mul, sub_neg_eq_add]
 end
 
 lemma differentiable_sin : differentiable ℂ sin :=
@@ -106,19 +111,11 @@ differentiable_sin.continuous
 /-- The complex cosine function is everywhere differentiable, with the derivative `-sin x`. -/
 lemma has_deriv_at_cos (x : ℂ) : has_deriv_at cos (-sin x) x :=
 begin
-  have A : has_deriv_at (λ(z:ℂ), exp (z * I)) (I * exp (x * I)) x,
-  { convert (has_deriv_at_exp _).comp x ((has_deriv_at_id x).mul (has_deriv_at_const x I)),
-    simp },
-  have B : has_deriv_at (λ(z:ℂ), exp (-z * I)) (-I * exp (-x * I)) x,
-  { convert (has_deriv_at_exp _).comp x ((has_deriv_at_id x).neg.mul (has_deriv_at_const x I)),
-    simp },
-  have C : has_deriv_at (λ(z:ℂ), exp (z * I) + exp (-z * I)) (I * (exp (x * I) - exp (-x * I))) x,
-    by { convert has_deriv_at.add A B, ring },
-  convert has_deriv_at.mul C (has_deriv_at_const x (1/(2:ℂ))),
-  { ext z, simp [cos, mul_div_assoc], refl },
-  { simp only [sin, div_eq_mul_inv, neg_mul_eq_neg_mul_symm, one_mul, zero_add, sub_eq_add_neg, mul_zero],
-    generalize : (2 : ℂ)⁻¹ = u,
-    ring }
+  simp only [sin, div_eq_mul_inv, neg_mul_eq_neg_mul],
+  convert (((has_deriv_at_id x).mul_const I).cexp.add
+    ((has_deriv_at_id x).neg.mul_const I).cexp).mul_const (2:ℂ)⁻¹,
+  simp only [function.comp, id],
+  rw [one_mul, neg_one_mul, neg_sub, mul_comm, mul_sub, sub_eq_add_neg, neg_mul_eq_neg_mul]
 end
 
 lemma differentiable_cos : differentiable ℂ cos :=
@@ -140,12 +137,9 @@ lemma continuous_tan : continuous (λ x : {x // cos x ≠ 0}, tan x) :=
 /-- The complex hyperbolic sine function is everywhere differentiable, with the derivative `sinh x`. -/
 lemma has_deriv_at_sinh (x : ℂ) : has_deriv_at sinh (cosh x) x :=
 begin
-  have C : has_deriv_at (λ(z:ℂ), exp z - exp(-z)) (exp x + exp (-x)) x,
-  { convert (has_deriv_at_exp x).sub ((has_deriv_at_exp _).comp x (has_deriv_at_id x).neg),
-    simp },
-  convert has_deriv_at.mul C (has_deriv_at_const x (1/(2:ℂ))),
-  { ext z, simp [sinh, div_eq_mul_inv] },
-  { simp [cosh, div_eq_mul_inv, mul_comm] }
+  simp only [cosh, div_eq_mul_inv],
+  convert ((has_deriv_at_exp x).sub (has_deriv_at_id x).neg.cexp).mul_const (2:ℂ)⁻¹,
+  rw [id, neg_one_mul, neg_neg]
 end
 
 lemma differentiable_sinh : differentiable ℂ sinh :=
@@ -160,12 +154,9 @@ differentiable_sinh.continuous
 /-- The complex hyperbolic cosine function is everywhere differentiable, with the derivative `cosh x`. -/
 lemma has_deriv_at_cosh (x : ℂ) : has_deriv_at cosh (sinh x) x :=
 begin
-  have C : has_deriv_at (λ(z:ℂ), exp z + exp(-z)) (exp x - exp (-x)) x,
-  { convert (has_deriv_at_exp x).add ((has_deriv_at_exp _).comp x (has_deriv_at_id x).neg),
-    simp },
-  convert has_deriv_at.mul C (has_deriv_at_const x (1/(2:ℂ))),
-  { ext z, simp [cosh, div_eq_mul_inv] },
-  { simp [sinh, div_eq_mul_inv, mul_comm] }
+  simp only [sinh, div_eq_mul_inv],
+  convert ((has_deriv_at_exp x).add (has_deriv_at_id x).neg.cexp).mul_const (2:ℂ)⁻¹,
+  rw [id, neg_one_mul, sub_eq_add_neg]
 end
 
 lemma differentiable_cosh : differentiable ℂ cosh :=
@@ -1876,3 +1867,13 @@ lemma tendsto_pow_mul_exp_neg_at_top_nhds_0 (n : ℕ) : tendsto (λx, x^n * exp 
 end exp
 
 end real
+
+lemma has_deriv_at.rexp {f : ℝ → ℝ} {f' x : ℝ} (hf : has_deriv_at f f' x) :
+  has_deriv_at (real.exp ∘ f) (f' * real.exp (f x)) x :=
+(real.has_deriv_at_exp (f x)).comp x hf
+
+lemma has_deriv_within_at.rexp {f : ℝ → ℝ} {f' x : ℝ} {s : set ℝ}
+  (hf : has_deriv_within_at f f' s x) :
+  has_deriv_within_at (real.exp ∘ f) (f' * real.exp (f x)) s x :=
+(real.has_deriv_at_exp (f x)).comp_has_deriv_within_at x hf
+


### PR DESCRIPTION
These functions produce simpler answers.

Should I mention these versions in the file header docs?

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)