### PR TITLE
Should say `analysis.topology.topological_space`

### DIFF
--- a/docs/install/project.md
+++ b/docs/install/project.md
@@ -28,7 +28,7 @@ terminal.
 If you want to make sure everything is working, you can start by
 creating, say `my_project/src/test.lean` containing:
 ```lean
-import topology.basic
+import analysis.topology.topological_space
 
 #check topological_space
 ```


### PR DESCRIPTION
instead of `topology.basic` which seem to no longer exist

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
