### PR TITLE
chore(*): various simple lemmas about `*_equiv`, add missing attrs

### DIFF
--- a/src/data/equiv/algebra.lean
+++ b/src/data/equiv/algebra.lean
@@ -299,15 +299,15 @@ equiv.symm_apply_apply (e.to_equiv)
 lemma map_one {α β} [monoid α] [monoid β] (h : α ≃* β) : h 1 = 1 :=
 by rw [←mul_one (h 1), ←h.apply_symm_apply 1, ←h.map_mul, one_mul]
 
-@[to_additive]
-lemma map_eq_one_iff {α β} [monoid α] [monoid β] (h : α ≃* β) (x : α) :
+@[simp, to_additive]
+lemma map_eq_one_iff {α β} [monoid α] [monoid β] (h : α ≃* β) {x : α} :
   h x = 1 ↔ x = 1 :=
 h.map_one ▸ h.to_equiv.apply_eq_iff_eq x 1
 
 @[to_additive]
-lemma map_ne_one_iff {α β} [monoid α] [monoid β] (h : α ≃* β) (x : α) :
+lemma map_ne_one_iff {α β} [monoid α] [monoid β] (h : α ≃* β) {x : α} :
   h x ≠ 1 ↔ x ≠ 1 :=
-⟨mt (h.map_eq_one_iff x).2, mt (h.map_eq_one_iff x).1⟩
+⟨mt h.map_eq_one_iff.2, mt h.map_eq_one_iff.1⟩
 
 /--
 Extract the forward direction of a multiplicative equivalence
@@ -490,16 +490,24 @@ section
 variables [semiring α] [semiring β] (f : α ≃+* β) (x y : α)
 
 /-- A ring isomorphism preserves multiplication. -/
-lemma map_mul : f (x * y) = f x * f y := f.map_mul' x y
+@[simp] lemma map_mul : f (x * y) = f x * f y := f.map_mul' x y
 
 /-- A ring isomorphism sends one to one. -/
-lemma map_one : f 1 = 1 := (f : α ≃* β).map_one
+@[simp] lemma map_one : f 1 = 1 := (f : α ≃* β).map_one
 
 /-- A ring isomorphism preserves addition. -/
-lemma map_add : f (x + y) = f x + f y := f.map_add' x y
+@[simp] lemma map_add : f (x + y) = f x + f y := f.map_add' x y
 
 /-- A ring isomorphism sends zero to zero. -/
-lemma map_zero : f 0 = 0 := (f : α ≃+ β).map_zero
+@[simp] lemma map_zero : f 0 = 0 := (f : α ≃+ β).map_zero
+
+variable {x}
+
+@[simp] lemma map_eq_one_iff : f x = 1 ↔ x = 1 := (f : α ≃* β).map_eq_one_iff
+@[simp] lemma map_eq_zero_iff : f x = 0 ↔ x = 0 := (f : α ≃+ β).map_eq_zero_iff
+
+lemma map_ne_one_iff : f x ≠ 1 ↔ x ≠ 1 := (f : α ≃* β).map_ne_one_iff
+lemma map_ne_zero_iff : f x ≠ 0 ↔ x ≠ 0 := (f : α ≃+ β).map_ne_zero_iff
 
 end
 
@@ -507,11 +515,11 @@ section
 
 variables [ring α] [ring β] (f : α ≃+* β) (x y : α)
 
-lemma map_neg : f (-x) = -f x := (f : α ≃+ β).map_neg x
+@[simp] lemma map_neg : f (-x) = -f x := (f : α ≃+ β).map_neg x
 
-lemma map_sub : f (x - y) = f x - f y := (f : α ≃+ β).map_sub x y
+@[simp] lemma map_sub : f (x - y) = f x - f y := (f : α ≃+ β).map_sub x y
 
-lemma map_neg_one : f (-1) = -1 := f.map_one ▸ f.map_neg 1
+@[simp] lemma map_neg_one : f (-1) = -1 := f.map_one ▸ f.map_neg 1
 
 end
 

--- a/src/data/set/function.lean
+++ b/src/data/set/function.lean
@@ -179,6 +179,9 @@ lemma bij_on.mk {f : α → β} {a : set α} {b : set β}
       bij_on f a b :=
 ⟨h₁, h₂, h₃⟩
 
+lemma inj_on.to_bij_on {f : α → β} {a : set α} (h : inj_on f a) : bij_on f a (f '' a) :=
+bij_on.mk (maps_to_image f a) h (subset.refl _)
+
 theorem bij_on_of_eq_on {f1 f2 : α → β} {a : set α} {b : set β} (h₁ : eq_on f1 f2 a)
      (h₂ : bij_on f1 a b) : bij_on f2 a b :=
 let ⟨map, inj, surj⟩ := h₂ in

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1315,21 +1315,36 @@ section
 variable (M)
 
 /-- The identity map is a linear equivalence. -/
-def refl : M ≃ₗ[R] M := { .. linear_map.id, .. equiv.refl M }
+@[refl] def refl : M ≃ₗ[R] M := { .. linear_map.id, .. equiv.refl M }
 end
 
 /-- Linear equivalences are symmetric. -/
-def symm (e : M ≃ₗ[R] M₂) : M₂ ≃ₗ[R] M :=
+@[symm] def symm (e : M ≃ₗ[R] M₂) : M₂ ≃ₗ[R] M :=
 { .. e.to_linear_map.inverse e.inv_fun e.left_inv e.right_inv,
   .. e.to_equiv.symm }
 
 /-- Linear equivalences are transitive. -/
-def trans (e₁ : M ≃ₗ[R] M₂) (e₂ : M₂ ≃ₗ[R] M₃) : M ≃ₗ[R] M₃ :=
+@[trans] def trans (e₁ : M ≃ₗ[R] M₂) (e₂ : M₂ ≃ₗ[R] M₃) : M ≃ₗ[R] M₃ :=
 { .. e₂.to_linear_map.comp e₁.to_linear_map,
   .. e₁.to_equiv.trans e₂.to_equiv }
 
+/-- A linear equivalence is an additive equivalence. -/
+def to_add_equiv (e : M ≃ₗ[R] M₂) : M ≃+ M₂ := { map_add' := e.add, .. e }
+
 @[simp] theorem apply_symm_apply (e : M ≃ₗ[R] M₂) (c : M₂) : e (e.symm c) = c := e.6 c
 @[simp] theorem symm_apply_apply (e : M ≃ₗ[R] M₂) (b : M) : e.symm (e b) = b := e.5 b
+
+@[simp] theorem map_add (e : M ≃ₗ[R] M₂) (a b : M) : e (a + b) = e a + e b := e.add a b
+@[simp] theorem map_zero (e : M ≃ₗ[R] M₂) : e 0 = 0 := e.to_linear_map.map_zero
+@[simp] theorem map_neg (e : M ≃ₗ[R] M₂) (a : M) : e (-a) = -e a := e.to_linear_map.map_neg a
+@[simp] theorem map_sub (e : M ≃ₗ[R] M₂) (a b : M) : e (a - b) = e a - e b :=
+e.to_linear_map.map_sub a b
+@[simp] theorem map_smul (e : M ≃ₗ[R] M₂) (c : R) (x : M) : e (c • x) = c • e x := e.smul c x
+
+@[simp] theorem map_eq_zero_iff (e : M ≃ₗ[R] M₂) {x : M} : e x = 0 ↔ x = 0 :=
+e.to_add_equiv.map_eq_zero_iff
+@[simp] theorem map_ne_zero_iff (e : M ≃ₗ[R] M₂) {x : M} : e x ≠ 0 ↔ x ≠ 0 :=
+e.to_add_equiv.map_ne_zero_iff
 
 /-- A bijective linear map is a linear equivalence. Here, bijectivity is described by saying that
 the kernel of `f` is `{0}` and the range is the universal set. -/

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -556,7 +556,7 @@ begin
   ext b,
   rw [h.image_eq_preimage, set.preimage, set.mem_set_of_eq,
     mem_non_zero_divisors_iff_ne_zero, mem_non_zero_divisors_iff_ne_zero, ne.def],
-  exact h.to_add_equiv.symm.map_ne_zero_iff b
+  exact h.symm.map_ne_zero_iff
 end
 
 end map

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -409,6 +409,8 @@ def to_homeomorph (e : M ≃L[R] M₂) : M ≃ₜ M₂ := { ..e }
 @[simp] lemma map_smul (e : M ≃L[R] M₂) (c : R) (x : M) : e (c • x) = c • (e x) :=
 (e : M →L[R] M₂).map_smul c x
 @[simp] lemma map_neg (e : M ≃L[R] M₂) (x : M) : e (-x) = -e x := (e : M →L[R] M₂).map_neg x
+@[simp] lemma map_eq_zero_iff (e : M ≃L[R] M₂) {x : M} : e x = 0 ↔ x = 0 :=
+e.to_linear_equiv.map_eq_zero_iff
 
 section
 variable (M)
@@ -442,5 +444,13 @@ by { ext, refl }
 
 @[simp] theorem apply_symm_apply (e : M ≃L[R] M₂) (c : M₂) : e (e.symm c) = c := e.1.6 c
 @[simp] theorem symm_apply_apply (e : M ≃L[R] M₂) (b : M) : e.symm (e b) = b := e.1.5 b
+
+@[simp] theorem coe_comp_coe_symm (e : M ≃L[R] M₂) :
+  (e : M →L[R] M₂).comp (e.symm : M₂ →L[R] M) = continuous_linear_map.id :=
+continuous_linear_map.ext e.apply_symm_apply
+
+@[simp] theorem coe_symm_comp_coe (e : M ≃L[R] M₂) :
+  (e.symm : M₂ →L[R] M).comp (e : M →L[R] M₂) = continuous_linear_map.id :=
+continuous_linear_map.ext e.symm_apply_apply
 
 end continuous_linear_equiv


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)