### PR TITLE
refactor(analysis/asymptotics): introduce `is_O_with`

### DIFF
--- a/src/analysis/asymptotics.lean
+++ b/src/analysis/asymptotics.lean
@@ -817,36 +817,6 @@ is_o_const_mul_right_iff' $ is_unit.mk0 c hc
 
 /-! ### Multiplication -/
 
-theorem is_O_with.mul_same_left {f₂ g : α → 𝕜} (f₁ : α → 𝕜) (h : is_O_with c f₂ g l) :
-  is_O_with c (λ x, f₁ x * f₂ x) (λ x, f₁ x * g x) l :=
-begin
-  apply mem_sets_of_superset h,
-  intros x hx,
-  simp only [mem_set_of_eq, normed_field.norm_mul] at hx ⊢,
-  rw [mul_left_comm],
-  exact mul_le_mul_of_nonneg_left hx (norm_nonneg _)
-end
-
-theorem is_O.mul_same_left {f₂ g : α → 𝕜} (f₁ : α → 𝕜) (h : is_O f₂ g l) :
-  is_O (λ x, f₁ x * f₂ x) (λ x, f₁ x * g x) l :=
-let ⟨c, hc⟩ := h in (hc.mul_same_left f₁).is_O
-
-theorem is_o.mul_same_left {f₂ g : α → 𝕜} (f₁ : α → 𝕜) (h : is_o f₂ g l) :
-  is_o (λ x, f₁ x * f₂ x) (λ x, f₁ x * g x) l :=
-λ c hc, (h hc).mul_same_left f₁
-
-theorem is_O_with.mul_same_right {f₁ g : α → 𝕜} (h : is_O_with c f₁ g l) (f₂ : α → 𝕜) :
-  is_O_with c (λ x, f₁ x * f₂ x) (λ x, g x * f₂ x) l :=
-(h.mul_same_left f₂).congr rfl (λ x, mul_comm _ _) (λ x, mul_comm _ _)
-
-theorem is_O.mul_same_right {f₁ g : α → 𝕜} (h : is_O f₁ g l) (f₂ : α → 𝕜) :
-  is_O (λ x, f₁ x * f₂ x) (λ x, g x * f₂ x) l :=
-let ⟨c, hc⟩ := h in (hc.mul_same_right f₂).is_O
-
-theorem is_o.mul_same_right {f₁ g : α → 𝕜} (h : is_o f₁ g l) (f₂ : α → 𝕜) :
-  is_o (λ x, f₁ x * f₂ x) (λ x, g x * f₂ x) l :=
-λ c hc, (h hc).mul_same_right f₂
-
 theorem is_O_with.mul {f₁ f₂ : α → R} {g₁ g₂ : α → 𝕜} {c₁ c₂ : ℝ}
   (h₁ : is_O_with c₁ f₁ g₁ l) (h₂ : is_O_with c₂ f₂ g₂ l) :
   is_O_with (c₁ * c₂) (λ x, f₁ x * f₂ x) (λ x, g₁ x * g₂ x) l :=
@@ -941,19 +911,6 @@ section smul
 
 variables [normed_space 𝕜 E'] [normed_space 𝕜 F']
 
-theorem is_O_with.smul_same_left (k : α → 𝕜) (h : is_O_with c f' g' l) :
-  is_O_with c (λ x, k x • f' x) (λ x, k x • g' x) l :=
-by refine ((h.norm_norm.mul_same_left (norm ∘ k)).congr rfl _ _).of_norm_norm;
-  intros; simp only [function.comp, norm_smul]
-
-theorem is_O.smul_same_left (k : α → 𝕜) (h : is_O f' g' l) :
-  is_O (λ x, k x • f' x) (λ x, k x • g' x) l :=
-let ⟨c, hc⟩ := h in (hc.smul_same_left k).is_O
-
-theorem is_o.smul_same_left (k : α → 𝕜) (h : is_o f' g' l) :
-  is_o (λ x, k x • f' x) (λ x, k x • g' x) l :=
-λ c hc, (h hc).smul_same_left k
-
 theorem is_O_with.smul {k₁ k₂ : α → 𝕜} (h₁ : is_O_with c k₁ k₂ l) (h₂ : is_O_with c' f' g' l) :
   is_O_with (c * c') (λ x, k₁ x • f' x) (λ x, k₂ x • g' x) l :=
 by refine ((h₁.norm_norm.mul h₂.norm_norm).congr rfl _ _).of_norm_norm;
@@ -986,7 +943,7 @@ end smul
 theorem is_o.tendsto_0 {f g : α → 𝕜} {l : filter α} (h : is_o f g l) :
   tendsto (λ x, f x / (g x)) l (𝓝 0) :=
 have eq₁ : is_o (λ x, f x / g x) (λ x, g x / g x) l,
-  from h.mul_same_right _,
+  from h.mul_is_O (is_O_refl _ _),
 have eq₂ : is_O (λ x, g x / g x) (λ x, (1 : 𝕜)) l,
   from is_O_of_le _ (λ x, by by_cases h : ∥g x∥ = 0; simp [h, zero_le_one]),
 (is_o_one_iff 𝕜).mp (eq₁.trans_is_O eq₂)
@@ -1021,7 +978,7 @@ begin
   have nmp : n = m + p := (nat.add_sub_cancel' (le_of_lt h)).symm,
   have : (λ(x : 𝕜), x^m) = (λx, x^m * 1), by simp only [mul_one],
   simp only [this, pow_add, nmp],
-  refine is_o.mul_same_left _ ((is_o_one_iff _).2 _),
+  refine is_O.mul_is_o (is_O_refl _ _) ((is_o_one_iff _).2 _),
   convert (continuous_pow p).tendsto (0 : 𝕜),
   exact (zero_pow (nat.sub_pos_of_lt h)).symm
 end

--- a/src/analysis/asymptotics.lean
+++ b/src/analysis/asymptotics.lean
@@ -600,18 +600,18 @@ theorem is_o_refl_left : is_o (λ x, f' x - f' x) g' l :=
 
 variables {g' l}
 
-theorem is_O_with_zero_right_iff (hc : 0 < c) :
+theorem is_O_with_zero_right_iff :
   is_O_with c f' (λ x, (0 : F')) l ↔ {x | f' x = 0} ∈ l :=
-by simp only [is_O_with, exists_prop, hc, true_and, norm_zero, mul_zero, norm_le_zero_iff]
+by simp only [is_O_with, exists_prop, true_and, norm_zero, mul_zero, norm_le_zero_iff]
 
 theorem is_O_zero_right_iff : is_O f' (λ x, (0 : F')) l ↔ {x | f' x = 0} ∈ l :=
-⟨λ h, let ⟨c, cpos, hc⟩ := h.exists_pos in  (is_O_with_zero_right_iff cpos).1 hc,
-  λ h, ((is_O_with_zero_right_iff zero_lt_one).2 h).is_O⟩
+⟨λ h, let ⟨c, hc⟩ := h in  (is_O_with_zero_right_iff).1 hc,
+  λ h, (is_O_with_zero_right_iff.2 h).is_O⟩
 
 theorem is_o_zero_right_iff :
   is_o f' (λ x, (0 : F')) l ↔ {x | f' x = 0} ∈ l :=
 ⟨λ h, is_O_zero_right_iff.1 h.is_O,
-  λ h c hc, (is_O_with_zero_right_iff hc).2 h⟩
+  λ h c hc, is_O_with_zero_right_iff.2 h⟩
 
 theorem is_O_with_const_const (c : E) {c' : F'} (hc' : c' ≠ 0) (l : filter α) :
   is_O_with (∥c∥ / ∥c'∥) (λ x : α, c) (λ x, c') l :=

--- a/src/analysis/asymptotics.lean
+++ b/src/analysis/asymptotics.lean
@@ -19,6 +19,10 @@ Here `l` is any filter on the domain of `f` and `g`, which are assumed to be the
 of `f` and `g` do not need to be the same; all that is needed that there is a norm associated with
 these types, and it is the norm that is compared asymptotically.
 
+The relation `is_O_with c` is introduced to factor out common algebraic arguments in the proofs of
+similar properties of `is_O` and `is_o`. Usually proofs outside of this file should use `is_O`
+instead.
+
 Often the ranges of `f` and `g` will be the real numbers, in which case the norm is the absolute
 value. In general, we have
 
@@ -58,7 +62,7 @@ section defs
 /-- This version of the Landau notation `is_O_with C f g l` where `f` and `g` are two functions on
 a type `α` and `l` is a filter on `α`, means that eventually for `l`, `∥f∥` is bounded by `C * ∥g∥`.
 In other words, `∥f∥ / ∥g∥` is eventually bounded by `C`, modulo division by zero issues that are
-avoided by this definition. -/
+avoided by this definition. Probably you want to use `is_O` instead of this relation. -/
 def is_O_with (c : ℝ) (f : α → E) (g : α → F) (l : filter α) : Prop :=
 { x | ∥ f x ∥ ≤ c * ∥ g x ∥ } ∈ l
 

--- a/src/analysis/asymptotics.lean
+++ b/src/analysis/asymptotics.lean
@@ -606,7 +606,7 @@ by simp only [is_O_with, exists_prop, true_and, norm_zero, mul_zero, norm_le_zer
 
 theorem is_O_zero_right_iff : is_O f' (λ x, (0 : F')) l ↔ {x | f' x = 0} ∈ l :=
 ⟨λ h, let ⟨c, hc⟩ := h in  (is_O_with_zero_right_iff).1 hc,
-  λ h, (is_O_with_zero_right_iff.2 h).is_O⟩
+  λ h, (is_O_with_zero_right_iff.2 h : is_O_with 1 _ _ _).is_O⟩
 
 theorem is_o_zero_right_iff :
   is_o f' (λ x, (0 : F')) l ↔ {x | f' x = 0} ∈ l :=

--- a/src/analysis/asymptotics.lean
+++ b/src/analysis/asymptotics.lean
@@ -1,18 +1,19 @@
 /-
 Copyright (c) 2019 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Jeremy Avigad
+Authors: Jeremy Avigad, Yury Kudryashov
 -/
 
-import analysis.normed_space.basic
+import analysis.normed_space.basic tactic.alias
 
 /-!
 # Asymptotics
 
 We introduce these relations:
 
-  `is_O f g l` : "f is big O of g along l"
-  `is_o f g l` : "f is little o of g along l"
+* `is_O_with c f g l` : "f is big O of g along l with constant c";
+* `is_O f g l` : "f is big O of g along l";
+* `is_o f g l` : "f is little o of g along l".
 
 Here `l` is any filter on the domain of `f` and `g`, which are assumed to be the same. The codomains
 of `f` and `g` do not need to be the same; all that is needed that there is a norm associated with
@@ -37,784 +38,1011 @@ it suffices to assume that `f` is zero wherever `g` is. (This generalization is 
 the Fréchet derivative.)
 -/
 
-open filter
+open filter set
 open_locale topological_space
 
 namespace asymptotics
 
-variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*} {𝕜 : Type*} {𝕜' : Type*}
+variables {α : Type*} {β : Type*} {E : Type*} {F : Type*} {G : Type*}
+  {E' : Type*} {F' : Type*} {G' : Type*} {R : Type*} {R' : Type*} {𝕜 : Type*} {𝕜' : Type*}
 
-section
-variables [has_norm β] [has_norm γ] [has_norm δ]
+variables [has_norm E] [has_norm F] [has_norm G] [normed_group E'] [normed_group F']
+  [normed_group G'] [normed_ring R] [normed_ring R'] [normed_field 𝕜] [normed_field 𝕜']
+  {c c' : ℝ} {f : α → E} {g : α → F} {k : α → G} {f' : α → E'} {g' : α → F'} {k' : α → G'}
+  {l l' : filter α}
+
+section defs
+
+/-! ### Definitions -/
+
+/-- This version of the Landau notation `is_O_with C f g l` where `f` and `g` are two functions on
+a type `α` and `l` is a filter on `α`, means that eventually for `l`, `∥f∥` is bounded by `C * ∥g∥`.
+In other words, `∥f∥ / ∥g∥` is eventually bounded by `C`, modulo division by zero issues that are
+avoided by this definition. -/
+def is_O_with (c : ℝ) (f : α → E) (g : α → F) (l : filter α) : Prop :=
+{ x | ∥ f x ∥ ≤ c * ∥ g x ∥ } ∈ l
 
 /-- The Landau notation `is_O f g l` where `f` and `g` are two functions on a type `α` and `l` is
 a filter on `α`, means that eventually for `l`, `∥f∥` is bounded by a constant multiple of `∥g∥`.
 In other words, `∥f∥ / ∥g∥` is eventually bounded, modulo division by zero issues that are avoided
 by this definition. -/
-def is_O (f : α → β) (g : α → γ) (l : filter α) : Prop :=
-∃ c > 0, { x | ∥ f x ∥ ≤ c * ∥ g x ∥ } ∈ l
+def is_O (f : α → E) (g : α → F) (l : filter α) : Prop := ∃ c : ℝ, is_O_with c f g l
 
 /-- The Landau notation `is_o f g l` where `f` and `g` are two functions on a type `α` and `l` is
 a filter on `α`, means that eventually for `l`, `∥f∥` is bounded by an arbitrarily small constant
 multiple of `∥g∥`. In other words, `∥f∥ / ∥g∥` tends to `0` along `l`, modulo division by zero
 issues that are avoided by this definition. -/
-def is_o (f : α → β) (g : α → γ) (l : filter α) : Prop :=
-∀ c > 0, { x | ∥ f x ∥ ≤  c * ∥ g x ∥ } ∈ l
+def is_o (f : α → E) (g : α → F) (l : filter α) : Prop := ∀ ⦃c : ℝ⦄, 0 < c → is_O_with c f g l
 
-theorem is_O_refl (f : α → β) (l : filter α) : is_O f f l :=
-⟨1, zero_lt_one, by { filter_upwards [univ_mem_sets], intros x _, simp }⟩
+end defs
 
-theorem is_O.comp {f : α → β} {g : α → γ} {l : filter α} (hfg : is_O f g l)
-    {δ : Type*} (k : δ → α) :
-  is_O (f ∘ k) (g ∘ k) (l.comap k) :=
-let ⟨c, cpos, hfgc⟩ := hfg in
-⟨c, cpos, mem_comap_sets.mpr ⟨_, hfgc, set.subset.refl _⟩⟩
+/-! ### Conversions -/
 
-theorem is_o.comp {f : α → β} {g : α → γ} {l : filter α} (hfg : is_o f g l)
-    {δ : Type*} (k : δ → α) :
-  is_o (f ∘ k) (g ∘ k) (l.comap k) :=
-λ c cpos, mem_comap_sets.mpr ⟨_, hfg c cpos, set.subset.refl _⟩
+theorem is_O_with.is_O (h : is_O_with c f g l) : is_O f g l := ⟨c, h⟩
 
-theorem is_O.mono {f : α → β} {g : α → γ} {l₁ l₂ : filter α} (h : l₁ ≤ l₂)
-  (h' : is_O f g l₂) : is_O f g l₁ :=
-let ⟨c, cpos, h'c⟩ := h' in ⟨c, cpos, h (h'c)⟩
+theorem is_o.is_O_with (hgf : is_o f g l) : is_O_with 1 f g l := hgf zero_lt_one
 
-theorem is_o.mono {f : α → β} {g : α → γ} {l₁ l₂ : filter α} (h : l₁ ≤ l₂)
-  (h' : is_o f g l₂) : is_o f g l₁ :=
-λ c cpos, h (h' c cpos)
+theorem is_o.is_O (hgf : is_o f g l) : is_O f g l := hgf.is_O_with.is_O
 
-theorem is_o.to_is_O {f : α → β} {g : α → γ} {l : filter α} (hgf : is_o f g l) : is_O f g l :=
-⟨1, zero_lt_one, hgf 1 zero_lt_one⟩
+theorem is_O_with.weaken (h : is_O_with c f g' l) (hc : c ≤ c') : is_O_with c' f g' l :=
+mem_sets_of_superset h $ λ x hx,
+calc ∥f x∥ ≤ c * ∥g' x∥ : hx
+... ≤ _ : mul_le_mul_of_nonneg_right hc (norm_nonneg _)
 
-theorem is_O.trans {f : α → β} {g : α → γ} {k : α → δ} {l : filter α}
-    (h₁ : is_O f g l) (h₂ : is_O g k l) :
-  is_O f k l :=
-let ⟨c,  cpos,  hc⟩  := h₁,
-    ⟨c', c'pos, hc'⟩ := h₂ in
+theorem is_O_with.exists_pos (h : is_O_with c f g' l) :
+  ∃ c' (H : 0 < c'), is_O_with c' f g' l :=
+⟨max c 1, lt_of_lt_of_le zero_lt_one (le_max_right c 1), h.weaken $ le_max_left c 1⟩
+
+theorem is_O.exists_pos (h : is_O f g' l) : ∃ c (H : 0 < c), is_O_with c f g' l :=
+let ⟨c, hc⟩ := h in hc.exists_pos
+
+theorem is_O_with.exists_nonneg (h : is_O_with c f g' l) :
+  ∃ c' (H : 0 ≤ c'), is_O_with c' f g' l :=
+let ⟨c, cpos, hc⟩ := h.exists_pos in ⟨c, le_of_lt cpos, hc⟩
+
+theorem is_O.exists_nonneg (h : is_O f g' l) :
+  ∃ c (H : 0 ≤ c), is_O_with c f g' l :=
+let ⟨c, hc⟩ := h in hc.exists_nonneg
+
+/-! ### Congruence -/
+
+theorem is_O_with_congr {c₁ c₂} {f₁ f₂ : α → E} {g₁ g₂ : α → F} {l : filter α}
+  (hc : c₁ = c₂) (hf : {x | f₁ x = f₂ x} ∈ l) (hg : {x | g₁ x = g₂ x} ∈ l) :
+  is_O_with c₁ f₁ g₁ l ↔ is_O_with c₂ f₂ g₂ l :=
 begin
-  use [c * c', mul_pos cpos c'pos],
-  filter_upwards [hc, hc'], dsimp,
-  intros x h₁x h₂x, rw mul_assoc,
-  exact le_trans h₁x (mul_le_mul_of_nonneg_left h₂x (le_of_lt cpos))
+  subst c₂,
+  apply filter.congr_sets,
+  filter_upwards [hf, hg],
+  assume x e₁ e₂,
+  dsimp at e₁ e₂ ⊢,
+  rw [e₁, e₂]
 end
 
-theorem is_o.trans_is_O {f : α → β} {g : α → γ} {k : α → δ} {l : filter α}
-    (h₁ : is_o f g l) (h₂ : is_O g k l) :
-  is_o f k l :=
-begin
-  intros c cpos,
-  rcases h₂ with ⟨c', c'pos, hc'⟩,
-  have cc'pos := div_pos cpos c'pos,
-  filter_upwards [h₁ (c / c') cc'pos, hc'], dsimp,
-  intros x h₁x h₂x,
-  refine le_trans h₁x (le_trans (mul_le_mul_of_nonneg_left h₂x (le_of_lt cc'pos)) _),
-  rw [←mul_assoc, div_mul_cancel _ (ne_of_gt c'pos)]
-end
+theorem is_O_with.congr' {c₁ c₂} {f₁ f₂ : α → E} {g₁ g₂ : α → F} {l : filter α}
+  (hc : c₁ = c₂) (hf : {x | f₁ x = f₂ x} ∈ l) (hg : {x | g₁ x = g₂ x} ∈ l) :
+  is_O_with c₁ f₁ g₁ l → is_O_with c₂ f₂ g₂ l :=
+(is_O_with_congr hc hf hg).mp
 
-theorem is_O.trans_is_o {f : α → β} {g : α → γ} {k : α → δ} {l : filter α}
-    (h₁ : is_O f g l) (h₂ : is_o g k l) :
-  is_o f k l :=
-begin
-  intros c cpos,
-  rcases h₁ with ⟨c', c'pos, hc'⟩,
-  have cc'pos := div_pos cpos c'pos,
-  filter_upwards [hc', h₂ (c / c') cc'pos], dsimp,
-  intros x h₁x h₂x,
-  refine le_trans h₁x (le_trans (mul_le_mul_of_nonneg_left h₂x (le_of_lt c'pos)) _),
-  rw [←mul_assoc, mul_div_cancel' _ (ne_of_gt c'pos)]
-end
+theorem is_O_with.congr {c₁ c₂} {f₁ f₂ : α → E} {g₁ g₂ : α → F} {l : filter α}
+  (hc : c₁ = c₂) (hf : ∀ x, f₁ x = f₂ x) (hg : ∀ x, g₁ x = g₂ x) :
+  is_O_with c₁ f₁ g₁ l → is_O_with c₂ f₂ g₂ l :=
+λ h, h.congr' hc (univ_mem_sets' hf) (univ_mem_sets' hg)
 
-theorem is_o.trans {f : α → β} {g : α → γ} {k : α → δ} {l : filter α}
-    (h₁ : is_o f g l) (h₂ : is_o g k l) :
-  is_o f k l :=
-h₁.to_is_O.trans_is_o h₂
+theorem is_O_with.congr_left {f₁ f₂ : α → E} {l : filter α} (hf : ∀ x, f₁ x = f₂ x) :
+  is_O_with c f₁ g l → is_O_with c f₂ g l :=
+is_O_with.congr rfl hf (λ _, rfl)
 
-theorem is_o_join {f : α → β} {g : α → γ} {l₁ l₂ : filter α}
-    (h₁ : is_o f g l₁) (h₂ : is_o f g l₂) :
-  is_o f g (l₁ ⊔ l₂) :=
-begin
-  intros c cpos,
-  rw mem_sup_sets,
-  exact ⟨h₁ c cpos, h₂ c cpos⟩
-end
+theorem is_O_with.congr_right {g₁ g₂ : α → F} {l : filter α} (hg : ∀ x, g₁ x = g₂ x) :
+  is_O_with c f g₁ l → is_O_with c f g₂ l :=
+is_O_with.congr rfl (λ _, rfl) hg
 
-theorem is_O_congr {f₁ f₂ : α → β} {g₁ g₂ : α → γ} {l : filter α}
+theorem is_O_with.congr_const {c₁ c₂} {l : filter α} (hc : c₁ = c₂) :
+  is_O_with c₁ f g l → is_O_with c₂ f g l :=
+is_O_with.congr hc (λ _, rfl) (λ _, rfl)
+
+theorem is_O_congr {f₁ f₂ : α → E} {g₁ g₂ : α → F} {l : filter α}
     (hf : {x | f₁ x = f₂ x} ∈ l) (hg : {x | g₁ x = g₂ x} ∈ l) :
   is_O f₁ g₁ l ↔ is_O f₂ g₂ l :=
-bex_congr $ λ c _, filter.congr_sets $
-by filter_upwards [hf, hg] λ x e₁ e₂,
-  by dsimp at e₁ e₂ ⊢; rw [e₁, e₂]
+exists_congr $ λ c, is_O_with_congr rfl hf hg
 
-theorem is_o_congr {f₁ f₂ : α → β} {g₁ g₂ : α → γ} {l : filter α}
-    (hf : {x | f₁ x = f₂ x} ∈ l) (hg : {x | g₁ x = g₂ x} ∈ l) :
-  is_o f₁ g₁ l ↔ is_o f₂ g₂ l :=
-ball_congr $ λ c _, filter.congr_sets $
-by filter_upwards [hf, hg] λ x e₁ e₂,
-  by dsimp at e₁ e₂ ⊢; rw [e₁, e₂]
+theorem is_O.congr' {f₁ f₂ : α → E} {g₁ g₂ : α → F} {l : filter α}
+  (hf : {x | f₁ x = f₂ x} ∈ l) (hg : {x | g₁ x = g₂ x} ∈ l) :
+  is_O f₁ g₁ l → is_O f₂ g₂ l :=
+(is_O_congr hf hg).mp
 
-theorem is_O.congr {f₁ f₂ : α → β} {g₁ g₂ : α → γ} {l : filter α}
+theorem is_O.congr {f₁ f₂ : α → E} {g₁ g₂ : α → F} {l : filter α}
     (hf : ∀ x, f₁ x = f₂ x) (hg : ∀ x, g₁ x = g₂ x) :
   is_O f₁ g₁ l → is_O f₂ g₂ l :=
-(is_O_congr (univ_mem_sets' hf) (univ_mem_sets' hg)).1
+λ h, h.congr' (univ_mem_sets' hf) (univ_mem_sets' hg)
 
-theorem is_o.congr {f₁ f₂ : α → β} {g₁ g₂ : α → γ} {l : filter α}
-    (hf : ∀ x, f₁ x = f₂ x) (hg : ∀ x, g₁ x = g₂ x) :
-  is_o f₁ g₁ l → is_o f₂ g₂ l :=
-(is_o_congr (univ_mem_sets' hf) (univ_mem_sets' hg)).1
-
-theorem is_O_congr_left {f₁ f₂ : α → β} {g : α → γ} {l : filter α}
-    (h : {x | f₁ x = f₂ x} ∈ l) :
-  is_O f₁ g l ↔ is_O f₂ g l :=
-is_O_congr h (univ_mem_sets' $ λ _, rfl)
-
-theorem is_o_congr_left {f₁ f₂ : α → β} {g : α → γ} {l : filter α}
-    (h : {x | f₁ x = f₂ x} ∈ l) :
-  is_o f₁ g l ↔ is_o f₂ g l :=
-is_o_congr h (univ_mem_sets' $ λ _, rfl)
-
-theorem is_O.congr_left {f₁ f₂ : α → β} {g : α → γ} {l : filter α}
-  (hf : ∀ x, f₁ x = f₂ x) : is_O f₁ g l → is_O f₂ g l :=
+theorem is_O.congr_left {f₁ f₂ : α → E} {l : filter α} (hf : ∀ x, f₁ x = f₂ x) :
+  is_O f₁ g l → is_O f₂ g l :=
 is_O.congr hf (λ _, rfl)
 
-theorem is_o.congr_left {f₁ f₂ : α → β} {g : α → γ} {l : filter α}
-  (hf : ∀ x, f₁ x = f₂ x) : is_o f₁ g l → is_o f₂ g l :=
-is_o.congr hf (λ _, rfl)
-
-theorem is_O_congr_right {f : α → β} {g₁ g₂ : α → γ} {l : filter α}
-    (h : {x | g₁ x = g₂ x} ∈ l) :
-  is_O f g₁ l ↔ is_O f g₂ l :=
-is_O_congr (univ_mem_sets' $ λ _, rfl) h
-
-theorem is_o_congr_right {f : α → β} {g₁ g₂ : α → γ} {l : filter α}
-    (h : {x | g₁ x = g₂ x} ∈ l) :
-  is_o f g₁ l ↔ is_o f g₂ l :=
-is_o_congr (univ_mem_sets' $ λ _, rfl) h
-
-theorem is_O.congr_right {f : α → β} {g₁ g₂ : α → γ} {l : filter α}
-  (hg : ∀ x, g₁ x = g₂ x) : is_O f g₁ l → is_O f g₂ l :=
+theorem is_O.congr_right {g₁ g₂ : α → E} {l : filter α} (hg : ∀ x, g₁ x = g₂ x) :
+  is_O f g₁ l → is_O f g₂ l :=
 is_O.congr (λ _, rfl) hg
 
-theorem is_o.congr_right {f : α → β} {g₁ g₂ : α → γ} {l : filter α}
-  (hg : ∀ x, g₁ x = g₂ x) : is_o f g₁ l → is_o f g₂ l :=
+theorem is_o_congr {f₁ f₂ : α → E} {g₁ g₂ : α → F} {l : filter α}
+    (hf : {x | f₁ x = f₂ x} ∈ l) (hg : {x | g₁ x = g₂ x} ∈ l) :
+  is_o f₁ g₁ l ↔ is_o f₂ g₂ l :=
+ball_congr (λ c hc, is_O_with_congr (eq.refl c) hf hg)
+
+theorem is_o.congr' {f₁ f₂ : α → E} {g₁ g₂ : α → F} {l : filter α}
+  (hf : {x | f₁ x = f₂ x} ∈ l) (hg : {x | g₁ x = g₂ x} ∈ l) :
+  is_o f₁ g₁ l → is_o f₂ g₂ l :=
+(is_o_congr hf hg).mp
+
+theorem is_o.congr {f₁ f₂ : α → E} {g₁ g₂ : α → F} {l : filter α}
+    (hf : ∀ x, f₁ x = f₂ x) (hg : ∀ x, g₁ x = g₂ x) :
+  is_o f₁ g₁ l → is_o f₂ g₂ l :=
+λ h, h.congr' (univ_mem_sets' hf) (univ_mem_sets' hg)
+
+theorem is_o.congr_left {f₁ f₂ : α → E} {l : filter α} (hf : ∀ x, f₁ x = f₂ x) :
+  is_o f₁ g l → is_o f₂ g l :=
+is_o.congr hf (λ _, rfl)
+
+theorem is_o.congr_right {g₁ g₂ : α → E} {l : filter α} (hg : ∀ x, g₁ x = g₂ x) :
+  is_o f g₁ l → is_o f g₂ l :=
 is_o.congr (λ _, rfl) hg
 
+/-! ### Filter operations and transitivity -/
+
+theorem is_O_with.comp_tendsto (hcfg : is_O_with c f g l)
+  {k : β → α} {l' : filter β} (hk : tendsto k l' l):
+  is_O_with c (f ∘ k) (g ∘ k) l' :=
+hk hcfg
+
+theorem is_O.comp_tendsto (hfg : is_O f g l) {k : β → α} {l' : filter β} (hk : tendsto k l' l) :
+  is_O (f ∘ k) (g ∘ k) l' :=
+hfg.imp (λ c h, h.comp_tendsto hk)
+
+theorem is_o.comp_tendsto (hfg : is_o f g l) {k : β → α} {l' : filter β} (hk : tendsto k l' l) :
+  is_o (f ∘ k) (g ∘ k) l' :=
+λ c cpos, (hfg cpos).comp_tendsto hk
+
+theorem is_O_with.mono (h : is_O_with c f g l') (hl : l ≤ l') : is_O_with c f g l :=
+hl h
+
+theorem is_O.mono (h : is_O f g l') (hl : l ≤ l') : is_O f g l :=
+h.imp (λ c h, h.mono hl)
+
+theorem is_o.mono (h : is_o f g l') (hl : l ≤ l') : is_o f g l :=
+λ c cpos, (h cpos).mono hl
+
+theorem is_O_with.trans (hfg : is_O_with c f g l) (hgk : is_O_with c' g k l) (hc : 0 ≤ c) :
+  is_O_with (c * c') f k l :=
+begin
+  filter_upwards [hfg, hgk],
+  assume x hx hx',
+  calc ∥f x∥ ≤ c * ∥g x∥ : hx
+  ... ≤ c * (c' * ∥k x∥) : mul_le_mul_of_nonneg_left hx' hc
+  ... = c * c' * ∥k x∥ : (mul_assoc _ _ _).symm
 end
+
+theorem is_O.trans (hfg : is_O f g' l) (hgk : is_O g' k l) : is_O f k l :=
+let ⟨c, cnonneg, hc⟩ := hfg.exists_nonneg, ⟨c', hc'⟩ := hgk in (hc.trans hc' cnonneg).is_O
+
+theorem is_o.trans_is_O_with (hfg : is_o f g l) (hgk : is_O_with c g k l) (hc : 0 < c) :
+  is_o f k l :=
+begin
+  intros c' c'pos,
+  have : 0 < c' / c, from div_pos c'pos hc,
+  exact ((hfg this).trans hgk (le_of_lt this)).congr_const (div_mul_cancel _ (ne_of_gt hc))
+end
+
+theorem is_o.trans_is_O (hfg : is_o f g l) (hgk : is_O g k' l) : is_o f k' l :=
+let ⟨c, cpos, hc⟩ := hgk.exists_pos in hfg.trans_is_O_with hc cpos
+
+theorem is_O_with.trans_is_o (hfg : is_O_with c f g l) (hgk : is_o g k l) (hc : 0 < c) :
+  is_o f k l :=
+begin
+  intros c' c'pos,
+  have : 0 < c' / c, from div_pos c'pos hc,
+  exact (hfg.trans (hgk this) (le_of_lt hc)).congr_const (mul_div_cancel' _ (ne_of_gt hc))
+end
+
+theorem is_O.trans_is_o (hfg : is_O f g' l) (hgk : is_o g' k l) : is_o f k l :=
+let ⟨c, cpos, hc⟩ := hfg.exists_pos in hc.trans_is_o hgk cpos
+
+theorem is_o.trans (hfg : is_o f g l) (hgk : is_o g k' l) : is_o f k' l :=
+hfg.trans_is_O hgk.is_O
+
+theorem is_o.trans' (hfg : is_o f g' l) (hgk : is_o g' k l) : is_o f k l :=
+hfg.is_O.trans_is_o hgk
 
 section
-variables [has_norm β] [normed_group γ] [normed_group δ]
 
-@[simp]
-theorem is_O_norm_right {f : α → β} {g : α → γ} {l : filter α} :
-  is_O f (λ x, ∥g x∥) l ↔ is_O f g l :=
-by simp only [is_O, norm_norm]
+variable (l)
 
-@[simp]
-theorem is_o_norm_right {f : α → β} {g : α → γ} {l : filter α} :
-  is_o f (λ x, ∥g x∥) l ↔ is_o f g l :=
-by simp only [is_o, norm_norm]
+theorem is_O_with_of_le' (hfg : ∀ x, ∥f x∥ ≤ c * ∥g x∥) : is_O_with c f g l :=
+univ_mem_sets' hfg
 
-@[simp]
-theorem is_O_neg_right {f : α → β} {g : α → γ} {l : filter α} :
-  is_O f (λ x, -(g x)) l ↔ is_O f g l :=
-by { rw ←is_O_norm_right, simp only [norm_neg], rw is_O_norm_right }
+theorem is_O_with_of_le (hfg : ∀ x, ∥f x∥ ≤ ∥g x∥) : is_O_with 1 f g l :=
+is_O_with_of_le' l $ λ x, by { rw one_mul, exact hfg x }
 
-@[simp]
-theorem is_o_neg_right {f : α → β} {g : α → γ} {l : filter α} :
-  is_o f (λ x, -(g x)) l ↔ is_o f g l :=
-by { rw ←is_o_norm_right, simp only [norm_neg], rw is_o_norm_right }
+theorem is_O_of_le' (hfg : ∀ x, ∥f x∥ ≤ c * ∥g x∥) : is_O f g l :=
+(is_O_with_of_le' l hfg).is_O
 
-theorem is_O_iff {f : α → β} {g : α → γ} {l : filter α} :
-  is_O f g l ↔ ∃ c, { x | ∥f x∥ ≤ c * ∥g x∥ } ∈ l :=
-suffices (∃ c, { x | ∥f x∥ ≤ c * ∥g x∥ } ∈ l) → is_O f g l,
-  from ⟨λ ⟨c, cpos, hc⟩, ⟨c, hc⟩, this⟩,
-assume ⟨c, hc⟩,
-or.elim (lt_or_ge 0 c)
-  (assume : c > 0, ⟨c, this, hc⟩)
-  (assume h'c : c ≤ 0,
-    have {x : α | ∥f x∥ ≤ 1 * ∥g x∥} ∈ l,
-      begin
-        filter_upwards [hc], intros x,
-        show ∥f x∥ ≤ c * ∥g x∥ → ∥f x∥ ≤ 1 * ∥g x∥,
-        { intro hx, apply le_trans hx,
-          apply mul_le_mul_of_nonneg_right _ (norm_nonneg _),
-          show c ≤ 1, from le_trans h'c zero_le_one }
-      end,
-    ⟨1, zero_lt_one, this⟩)
-
-theorem is_O_join {f : α → β} {g : α → γ} {l₁ l₂ : filter α}
-    (h₁ : is_O f g l₁) (h₂ : is_O f g l₂) :
-  is_O f g (l₁ ⊔ l₂) :=
-begin
-  rcases h₁ with ⟨c₁, c₁pos, hc₁⟩,
-  rcases h₂ with ⟨c₂, c₂pos, hc₂⟩,
-  have : 0 < max c₁ c₂, by { rw lt_max_iff, left, exact c₁pos },
-  use [max c₁ c₂, this],
-  rw mem_sup_sets, split,
-  { filter_upwards [hc₁], dsimp, intros x hx,
-    exact le_trans hx (mul_le_mul_of_nonneg_right (le_max_left _ _) (norm_nonneg _)) },
-  filter_upwards [hc₂], dsimp, intros x hx,
-    exact le_trans hx (mul_le_mul_of_nonneg_right (le_max_right _ _) (norm_nonneg _))
-end
-
-lemma is_O.prod_rightl {f : α → β} {g₁ : α → γ} {g₂ : α → δ} {l : filter α}
-  (h : is_O f g₁ l) : is_O f (λx, (g₁ x, g₂ x)) l :=
-begin
-  have : is_O g₁ (λx, (g₁ x, g₂ x)) l :=
-    ⟨1, zero_lt_one, filter.univ_mem_sets' (λx, by simp [norm, le_refl])⟩,
-  exact is_O.trans h this
-end
-
-lemma is_O.prod_rightr {f : α → β} {g₁ : α → γ} {g₂ : α → δ} {l : filter α}
-  (h : is_O f g₂ l) : is_O f (λx, (g₁ x, g₂ x)) l :=
-begin
-  have : is_O g₂ (λx, (g₁ x, g₂ x)) l :=
-    ⟨1, zero_lt_one, filter.univ_mem_sets' (λx, by simp [norm, le_refl])⟩,
-  exact is_O.trans h this
-end
-
-lemma is_o.prod_rightl {f : α → β} {g₁ : α → γ} {g₂ : α → δ} {l : filter α}
-  (h : is_o f g₁ l) : is_o f (λx, (g₁ x, g₂ x)) l :=
-is_o.trans_is_O h (is_O.prod_rightl (is_O_refl g₁ l))
-
-lemma is_o.prod_rightr {f : α → β} {g₁ : α → γ} {g₂ : α → δ} {l : filter α}
-  (h : is_o f g₂ l) : is_o f (λx, (g₁ x, g₂ x)) l :=
-is_o.trans_is_O h (is_O.prod_rightr (is_O_refl g₂ l))
+theorem is_O_of_le (hfg : ∀ x, ∥f x∥ ≤ ∥g x∥) : is_O f g l :=
+(is_O_with_of_le l hfg).is_O
 
 end
+
+theorem is_O_with_refl (f : α → E) (l : filter α) : is_O_with 1 f f l :=
+is_O_with_of_le l $ λ _, le_refl _
+
+theorem is_O_refl (f : α → E) (l : filter α) : is_O f f l := (is_O_with_refl f l).is_O
+
+theorem is_O_with.trans_le (hfg : is_O_with c f g l) (hgk : ∀ x, ∥g x∥ ≤ ∥k x∥) (hc : 0 ≤ c) :
+  is_O_with c f k l :=
+(hfg.trans (is_O_with_of_le l hgk) hc).congr_const $ mul_one c
+
+theorem is_O.trans_le (hfg : is_O f g' l) (hgk : ∀ x, ∥g' x∥ ≤ ∥k x∥) :
+  is_O f k l :=
+hfg.trans (is_O_of_le l hgk)
+
+section bot
+
+variables (c f g)
+
+theorem is_O_with_bot : is_O_with c f g ⊥ := trivial
+
+theorem is_O_bot : is_O f g ⊥ := (is_O_with_bot c f g).is_O
+
+theorem is_o_bot : is_o f g ⊥ := λ c _, is_O_with_bot c f g
+
+end bot
+
+theorem is_O_with.join (h : is_O_with c f g l) (h' : is_O_with c f g l') :
+  is_O_with c f g (l ⊔ l') :=
+mem_sup_sets.2 ⟨h, h'⟩
+
+theorem is_O_with.join' (h : is_O_with c f g' l) (h' : is_O_with c' f g' l') :
+  is_O_with (max c c') f g' (l ⊔ l') :=
+mem_sup_sets.2 ⟨(h.weaken $ le_max_left c c'), (h'.weaken $ le_max_right c c')⟩
+
+theorem is_O.join (h : is_O f g' l) (h' : is_O f g' l') : is_O f g' (l ⊔ l') :=
+let ⟨c, hc⟩ := h, ⟨c', hc'⟩ := h' in (hc.join' hc').is_O
+
+theorem is_o.join (h : is_o f g l) (h' : is_o f g l') :
+  is_o f g (l ⊔ l') :=
+λ c cpos, (h cpos).join (h' cpos)
+
+/-! ### Simplification : norm -/
+
+@[simp] theorem is_O_with_norm_right : is_O_with c f (λ x, ∥g' x∥) l ↔ is_O_with c f g' l :=
+by simp only [is_O_with, norm_norm]
+
+alias is_O_with_norm_right ↔ asymptotics.is_O_with.of_norm_right asymptotics.is_O_with.norm_right
+
+@[simp] theorem is_O_norm_right : is_O f (λ x, ∥g' x∥) l ↔ is_O f g' l :=
+exists_congr $ λ _,  is_O_with_norm_right
+
+alias is_O_norm_right ↔ asymptotics.is_O.of_norm_right asymptotics.is_O.norm_right
+
+@[simp] theorem is_o_norm_right : is_o f (λ x, ∥g' x∥) l ↔ is_o f g' l :=
+forall_congr $ λ _, forall_congr $ λ _, is_O_with_norm_right
+
+alias is_o_norm_right ↔ asymptotics.is_o.of_norm_right asymptotics.is_o.norm_right
+
+@[simp] theorem is_O_with_norm_left : is_O_with c (λ x, ∥f' x∥) g l ↔ is_O_with c f' g l :=
+by simp only [is_O_with, norm_norm]
+
+alias is_O_with_norm_left ↔ asymptotics.is_O_with.of_norm_left asymptotics.is_O_with.norm_left
+
+@[simp] theorem is_O_norm_left : is_O (λ x, ∥f' x∥) g l ↔ is_O f' g l :=
+exists_congr $ λ _, is_O_with_norm_left
+
+alias is_O_norm_left ↔ asymptotics.is_O.of_norm_left asymptotics.is_O.norm_left
+
+@[simp] theorem is_o_norm_left : is_o (λ x, ∥f' x∥) g l ↔ is_o f' g l :=
+forall_congr $ λ _, forall_congr $ λ _, is_O_with_norm_left
+
+alias is_o_norm_left ↔ asymptotics.is_o.of_norm_left asymptotics.is_o.norm_left
+
+theorem is_O_with_norm_norm :
+  is_O_with c (λ x, ∥f' x∥) (λ x, ∥g' x∥) l ↔ is_O_with c f' g' l :=
+is_O_with_norm_left.trans is_O_with_norm_right
+
+alias is_O_with_norm_norm ↔ asymptotics.is_O_with.of_norm_norm asymptotics.is_O_with.norm_norm
+
+theorem is_O_norm_norm :
+  is_O (λ x, ∥f' x∥) (λ x, ∥g' x∥) l ↔ is_O f' g' l :=
+is_O_norm_left.trans is_O_norm_right
+
+alias is_O_norm_norm ↔ asymptotics.is_O.of_norm_norm asymptotics.is_O.norm_norm
+
+theorem is_o_norm_norm :
+  is_o (λ x, ∥f' x∥) (λ x, ∥g' x∥) l ↔ is_o f' g' l :=
+is_o_norm_left.trans is_o_norm_right
+
+alias is_o_norm_norm ↔ asymptotics.is_o.of_norm_norm asymptotics.is_o.norm_norm
+
+/-! ### Simplification: negate -/
+
+@[simp] theorem is_O_with_neg_right : is_O_with c f (λ x, -(g' x)) l ↔ is_O_with c f g' l :=
+by simp only [is_O_with, norm_neg]
+
+alias is_O_with_neg_right ↔ asymptotics.is_O_with.of_neg_right asymptotics.is_O_with.neg_right
+
+@[simp] theorem is_O_neg_right : is_O f (λ x, -(g' x)) l ↔ is_O f g' l :=
+exists_congr $ λ _, is_O_with_neg_right
+
+alias is_O_neg_right ↔ asymptotics.is_O.of_neg_right asymptotics.is_O.neg_right
+
+@[simp] theorem is_o_neg_right : is_o f (λ x, -(g' x)) l ↔ is_o f g' l :=
+forall_congr $ λ _, forall_congr $ λ _, is_O_with_neg_right
+
+alias is_o_neg_right ↔ asymptotics.is_o.of_neg_right asymptotics.is_o.neg_right
+
+@[simp] theorem is_O_with_neg_left : is_O_with c (λ x, -(f' x)) g l ↔ is_O_with c f' g l :=
+by simp only [is_O_with, norm_neg]
+
+alias is_O_with_neg_left ↔ asymptotics.is_O_with.of_neg_left asymptotics.is_O_with.neg_left
+
+@[simp] theorem is_O_neg_left : is_O (λ x, -(f' x)) g l ↔ is_O f' g l :=
+exists_congr $ λ _, is_O_with_neg_left
+
+alias is_O_neg_left ↔ asymptotics.is_O.of_neg_left asymptotics.is_O.neg_left
+
+@[simp] theorem is_o_neg_left : is_o (λ x, -(f' x)) g l ↔ is_o f' g l :=
+forall_congr $ λ _, forall_congr $ λ _, is_O_with_neg_left
+
+alias is_o_neg_left ↔ asymptotics.is_o.of_neg_right asymptotics.is_o.neg_left
+
+/-! ### Product of functions (right) -/
+
+lemma is_O_with_fst_prod : is_O_with 1 f' (λ x, (f' x, g' x)) l :=
+is_O_with_of_le l $ λ x, le_max_left _ _
+
+lemma is_O_with_snd_prod : is_O_with 1 g' (λ x, (f' x, g' x)) l :=
+is_O_with_of_le l $ λ x, le_max_right _ _
+
+lemma is_O_fst_prod : is_O f' (λ x, (f' x, g' x)) l := is_O_with_fst_prod.is_O
+
+lemma is_O_snd_prod : is_O g' (λ x, (f' x, g' x)) l := is_O_with_snd_prod.is_O
 
 section
-variables [normed_group β] [normed_group δ] [has_norm γ]
 
-@[simp] theorem is_O_norm_left {f : α → β} {g : α → γ} {l : filter α} :
-  is_O (λ x, ∥f x∥) g l ↔ is_O f g l :=
-by simp only [is_O, norm_norm]
+variables (f' k')
 
-@[simp] theorem is_o_norm_left {f : α → β} {g : α → γ} {l : filter α} :
-  is_o (λ x, ∥f x∥) g l ↔ is_o f g l :=
-by simp only [is_o, norm_norm]
+lemma is_O_with.prod_rightl (h : is_O_with c f g' l) (hc : 0 ≤ c) :
+  is_O_with c f (λ x, (g' x, k' x)) l :=
+(h.trans is_O_with_fst_prod hc).congr_const (mul_one c)
 
-@[simp] theorem is_O_neg_left {f : α → β} {g : α → γ} {l : filter α} :
-  is_O (λ x, -f x) g l ↔ is_O f g l :=
-by { rw ←is_O_norm_left, simp only [norm_neg], rw is_O_norm_left }
+lemma is_O.prod_rightl (h : is_O f g' l) : is_O f (λx, (g' x, k' x)) l :=
+let ⟨c, cnonneg, hc⟩ := h.exists_nonneg in (hc.prod_rightl k' cnonneg).is_O
 
-@[simp] theorem is_o_neg_left {f : α → β} {g : α → γ} {l : filter α} :
-  is_o (λ x, -f x) g l ↔ is_o f g l :=
-by { rw ←is_o_norm_left, simp only [norm_neg], rw is_o_norm_left }
+lemma is_o.prod_rightl (h : is_o f g' l) : is_o f (λ x, (g' x, k' x)) l :=
+λ c cpos, (h cpos).prod_rightl k' (le_of_lt cpos)
 
-theorem is_O.add {f₁ f₂ : α → β} {g : α → γ} {l : filter α} (h₁ : is_O f₁ g l) (h₂ : is_O f₂ g l) :
-  is_O (λ x, f₁ x + f₂ x) g l :=
-let ⟨c₁, c₁pos, hc₁⟩ := h₁,
-    ⟨c₂, c₂pos, hc₂⟩ := h₂ in
-begin
-  use [c₁ + c₂, add_pos c₁pos c₂pos],
-  filter_upwards [hc₁, hc₂],
-  intros x hx₁ hx₂,
-  show ∥f₁ x + f₂ x∥ ≤ (c₁ + c₂) * ∥g x∥,
-  rw add_mul,
-  exact norm_add_le_of_le hx₁ hx₂
+lemma is_O_with.prod_rightr (h : is_O_with c f g' l) (hc : 0 ≤ c) :
+  is_O_with c f (λ x, (f' x, g' x)) l :=
+(h.trans is_O_with_snd_prod hc).congr_const (mul_one c)
+
+lemma is_O.prod_rightr (h : is_O f g' l) : is_O f (λx, (f' x, g' x)) l :=
+let ⟨c, cnonneg, hc⟩ := h.exists_nonneg in (hc.prod_rightr f' cnonneg).is_O
+
+lemma is_o.prod_rightr (h : is_o f g' l) : is_o f (λx, (f' x, g' x)) l :=
+λ c cpos, (h cpos).prod_rightr f' (le_of_lt cpos)
+
 end
 
-theorem is_o.add {f₁ f₂ : α → β} {g : α → γ} {l : filter α} (h₁ : is_o f₁ g l) (h₂ : is_o f₂ g l) :
-  is_o (λ x, f₁ x + f₂ x) g l :=
+lemma is_O_with.prod_left_same (hf : is_O_with c f' k' l) (hg : is_O_with c g' k' l) :
+  is_O_with c (λ x, (f' x, g' x)) k' l :=
 begin
-  intros c cpos,
-  filter_upwards [h₁ (c / 2) (half_pos cpos), h₂ (c / 2) (half_pos cpos)],
-  intros x hx₁ hx₂, dsimp at hx₁ hx₂,
-  apply le_trans (norm_add_le_of_le hx₁ hx₂),
-  rw [←mul_add, ←two_mul, ←mul_assoc, div_mul_cancel _ two_ne_zero]
+  filter_upwards [hf, hg],
+  simp only [mem_set_of_eq],
+  exact λ x, max_le
 end
 
-theorem is_O.sub {f₁ f₂ : α → β} {g : α → γ} {l : filter α} (h₁ : is_O f₁ g l) (h₂ : is_O f₂ g l) :
-  is_O (λ x, f₁ x - f₂ x) g l :=
-h₁.add (is_O_neg_left.mpr h₂)
+lemma is_O_with.prod_left (hf : is_O_with c f' k' l) (hg : is_O_with c' g' k' l) :
+  is_O_with (max c c') (λ x, (f' x, g' x)) k' l :=
+(hf.weaken $ le_max_left c c').prod_left_same (hg.weaken $ le_max_right c c')
 
-theorem is_o.sub {f₁ f₂ : α → β} {g : α → γ} {l : filter α} (h₁ : is_o f₁ g l) (h₂ : is_o f₂ g l) :
-  is_o (λ x, f₁ x - f₂ x) g l :=
-h₁.add (is_o_neg_left.mpr h₂)
+lemma is_O_with.prod_left_fst (h : is_O_with c (λ x, (f' x, g' x)) k' l) :
+  is_O_with c f' k' l :=
+(is_O_with_fst_prod.trans h zero_le_one).congr_const $ one_mul c
 
-theorem is_O_comm {f₁ f₂ : α → β} {g : α → γ} {l : filter α} :
-  is_O (λ x, f₁ x - f₂ x) g l ↔ is_O (λ x, f₂ x - f₁ x) g l :=
-by simpa using @is_O_neg_left _ _ _ _ _ (λ x, f₂ x - f₁ x) g l
+lemma is_O_with.prod_left_snd (h : is_O_with c (λ x, (f' x, g' x)) k' l) :
+  is_O_with c g' k' l :=
+(is_O_with_snd_prod.trans h zero_le_one).congr_const $ one_mul c
 
-theorem is_O.symm {f₁ f₂ : α → β} {g : α → γ} {l : filter α} :
-  is_O (λ x, f₁ x - f₂ x) g l → is_O (λ x, f₂ x - f₁ x) g l :=
-is_O_comm.1
+lemma is_O_with_prod_left :
+   is_O_with c (λ x, (f' x, g' x)) k' l ↔ is_O_with c f' k' l ∧ is_O_with c g' k' l :=
+⟨λ h, ⟨h.prod_left_fst, h.prod_left_snd⟩, λ h, h.1.prod_left_same h.2⟩
 
-theorem is_O.tri {f₁ f₂ f₃ : α → β} {g : α → γ} {l : filter α}
-    (h₁ : is_O (λ x, f₁ x - f₂ x) g l)
-    (h₂ : is_O (λ x, f₂ x - f₃ x) g l) :
+lemma is_O.prod_left (hf : is_O f' k' l) (hg : is_O g' k' l) : is_O (λ x, (f' x, g' x)) k' l :=
+let ⟨c, hf⟩ := hf, ⟨c', hg⟩ := hg in (hf.prod_left hg).is_O
+
+lemma is_O.prod_left_fst (h : is_O (λ x, (f' x, g' x)) k' l) : is_O f' k' l :=
+is_O_fst_prod.trans h
+
+lemma is_O.prod_left_snd (h : is_O (λ x, (f' x, g' x)) k' l) : is_O g' k' l :=
+is_O_snd_prod.trans h
+
+@[simp] lemma is_O_prod_left :
+  is_O (λ x, (f' x, g' x)) k' l ↔ is_O f' k' l ∧ is_O g' k' l :=
+⟨λ h, ⟨h.prod_left_fst, h.prod_left_snd⟩, λ h, h.1.prod_left h.2⟩
+
+lemma is_o.prod_left (hf : is_o f' k' l) (hg : is_o g' k' l) : is_o (λ x, (f' x, g' x)) k' l :=
+λ c hc, (hf hc).prod_left_same (hg hc)
+
+lemma is_o.prod_left_fst (h : is_o (λ x, (f' x, g' x)) k' l) : is_o f' k' l :=
+is_O_fst_prod.trans_is_o h
+
+lemma is_o.prod_left_snd (h : is_o (λ x, (f' x, g' x)) k' l) : is_o g' k' l :=
+is_O_snd_prod.trans_is_o h
+
+@[simp] lemma is_o_prod_left :
+  is_o (λ x, (f' x, g' x)) k' l ↔ is_o f' k' l ∧ is_o g' k' l :=
+⟨λ h, ⟨h.prod_left_fst, h.prod_left_snd⟩, λ h, h.1.prod_left h.2⟩
+
+/-! ### Addition and subtraction -/
+
+section add_sub
+
+variables {c₁ c₂ : ℝ} {f₁ f₂ : α → E'}
+
+theorem is_O_with.add (h₁ : is_O_with c₁ f₁ g l) (h₂ : is_O_with c₂ f₂ g l) :
+  is_O_with (c₁ + c₂) (λ x, f₁ x + f₂ x) g l :=
+by filter_upwards [h₁, h₂] λ x hx₁ hx₂,
+calc ∥f₁ x + f₂ x∥ ≤ c₁ * ∥g x∥ + c₂ * ∥g x∥ : norm_add_le_of_le hx₁ hx₂
+               ... = (c₁ + c₂) * ∥g x∥       : (add_mul _ _ _).symm
+
+theorem is_O.add : is_O f₁ g l → is_O f₂ g l → is_O (λ x, f₁ x + f₂ x) g l
+| ⟨c₁, hc₁⟩ ⟨c₂, hc₂⟩ := (hc₁.add hc₂).is_O
+
+theorem is_o.add (h₁ : is_o f₁ g l) (h₂ : is_o f₂ g l) : is_o (λ x, f₁ x + f₂ x) g l :=
+λ c cpos, ((h₁ $ half_pos cpos).add (h₂ $ half_pos cpos)).congr_const (add_halves c)
+
+theorem is_O.add_is_o (h₁ : is_O f₁ g l) (h₂ : is_o f₂ g l) : is_O (λ x, f₁ x + f₂ x) g l :=
+h₁.add h₂.is_O
+
+theorem is_o.add_is_O (h₁ : is_o f₁ g l) (h₂ : is_O f₂ g l) : is_O (λ x, f₁ x + f₂ x) g l :=
+h₁.is_O.add h₂
+
+theorem is_O_with.add_is_o (h₁ : is_O_with c₁ f₁ g l) (h₂ : is_o f₂ g l) (hc : c₁ < c₂) :
+  is_O_with c₂ (λx, f₁ x + f₂ x) g l :=
+(h₁.add (h₂ (sub_pos.2 hc))).congr_const (add_sub_cancel'_right _ _)
+
+theorem is_o.add_is_O_with (h₁ : is_o f₁ g l) (h₂ : is_O_with c₁ f₂ g l) (hc : c₁ < c₂) :
+  is_O_with c₂ (λx, f₁ x + f₂ x) g l :=
+(h₂.add_is_o h₁ hc).congr_left $ λ _, add_comm _ _
+
+theorem is_O_with.sub (h₁ : is_O_with c₁ f₁ g l) (h₂ : is_O_with c₂ f₂ g l) :
+  is_O_with (c₁ + c₂) (λ x, f₁ x - f₂ x) g l :=
+h₁.add h₂.neg_left
+
+theorem is_O_with.sub_is_o (h₁ : is_O_with c₁ f₁ g l) (h₂ : is_o f₂ g l) (hc : c₁ < c₂) :
+  is_O_with c₂ (λ x, f₁ x - f₂ x) g l :=
+h₁.add_is_o h₂.neg_left hc
+
+theorem is_O.sub (h₁ : is_O f₁ g l) (h₂ : is_O f₂ g l) : is_O (λ x, f₁ x - f₂ x) g l :=
+h₁.add h₂.neg_left
+
+theorem is_o.sub (h₁ : is_o f₁ g l) (h₂ : is_o f₂ g l) : is_o (λ x, f₁ x - f₂ x) g l :=
+h₁.add h₂.neg_left
+
+end add_sub
+
+/-! ### Lemmas about `is_O (f₁ - f₂) g l` / `is_o (f₁ - f₂) g l` treated as a binary relation -/
+
+section is_oO_as_rel
+
+variables {f₁ f₂ f₃ : α → E'}
+
+theorem is_O_with.symm (h : is_O_with c (λ x, f₁ x - f₂ x) g l) :
+  is_O_with c (λ x, f₂ x - f₁ x) g l :=
+h.neg_left.congr_left $ λ x, neg_sub _ _
+
+theorem is_O_with_comm :
+  is_O_with c (λ x, f₁ x - f₂ x) g l ↔ is_O_with c (λ x, f₂ x - f₁ x) g l :=
+⟨is_O_with.symm, is_O_with.symm⟩
+
+theorem is_O.symm (h : is_O (λ x, f₁ x - f₂ x) g l) : is_O (λ x, f₂ x - f₁ x) g l :=
+h.neg_left.congr_left $ λ x, neg_sub _ _
+
+theorem is_O_comm : is_O (λ x, f₁ x - f₂ x) g l ↔ is_O (λ x, f₂ x - f₁ x) g l :=
+⟨is_O.symm, is_O.symm⟩
+
+theorem is_o.symm (h : is_o (λ x, f₁ x - f₂ x) g l) : is_o (λ x, f₂ x - f₁ x) g l :=
+by simpa only [neg_sub] using h.neg_left
+
+theorem is_o_comm : is_o (λ x, f₁ x - f₂ x) g l ↔ is_o (λ x, f₂ x - f₁ x) g l :=
+⟨is_o.symm, is_o.symm⟩
+
+theorem is_O_with.triangle (h₁ : is_O_with c (λ x, f₁ x - f₂ x) g l)
+  (h₂ : is_O_with c' (λ x, f₂ x - f₃ x) g l) :
+  is_O_with (c + c') (λ x, f₁ x - f₃ x) g l :=
+(h₁.add h₂).congr_left $ λ x, sub_add_sub_cancel _ _ _
+
+theorem is_O.triangle (h₁ : is_O (λ x, f₁ x - f₂ x) g l) (h₂ : is_O (λ x, f₂ x - f₃ x) g l) :
   is_O (λ x, f₁ x - f₃ x) g l :=
-(h₁.add h₂).congr_left (by simp)
+(h₁.add h₂).congr_left $ λ x, sub_add_sub_cancel _ _ _
 
-theorem is_O.congr_of_sub {f₁ f₂ : α → β} {g : α → γ} {l : filter α}
-    (h : is_O (λ x, f₁ x - f₂ x) g l) :
+theorem is_o.triangle (h₁ : is_o (λ x, f₁ x - f₂ x) g l) (h₂ : is_o (λ x, f₂ x - f₃ x) g l) :
+  is_o (λ x, f₁ x - f₃ x) g l :=
+(h₁.add h₂).congr_left $ λ x, sub_add_sub_cancel _ _ _
+
+theorem is_O.congr_of_sub (h : is_O (λ x, f₁ x - f₂ x) g l) :
   is_O f₁ g l ↔ is_O f₂ g l :=
 ⟨λ h', (h'.sub h).congr_left (λ x, sub_sub_cancel _ _),
  λ h', (h.add h').congr_left (λ x, sub_add_cancel _ _)⟩
 
-theorem is_o_comm {f₁ f₂ : α → β} {g : α → γ} {l : filter α} :
-  is_o (λ x, f₁ x - f₂ x) g l ↔ is_o (λ x, f₂ x - f₁ x) g l :=
-by simpa using @is_o_neg_left _ _ _ _ _ (λ x, f₂ x - f₁ x) g l
-
-theorem is_o.symm {f₁ f₂ : α → β} {g : α → γ} {l : filter α} :
-  is_o (λ x, f₁ x - f₂ x) g l → is_o (λ x, f₂ x - f₁ x) g l :=
-is_o_comm.1
-
-theorem is_o.tri {f₁ f₂ f₃ : α → β} {g : α → γ} {l : filter α}
-    (h₁ : is_o (λ x, f₁ x - f₂ x) g l)
-    (h₂ : is_o (λ x, f₂ x - f₃ x) g l) :
-  is_o (λ x, f₁ x - f₃ x) g l :=
-(h₁.add h₂).congr_left (by simp)
-
-theorem is_o.congr_of_sub {f₁ f₂ : α → β} {g : α → γ} {l : filter α}
-    (h : is_o (λ x, f₁ x - f₂ x) g l) :
+theorem is_o.congr_of_sub (h : is_o (λ x, f₁ x - f₂ x) g l) :
   is_o f₁ g l ↔ is_o f₂ g l :=
 ⟨λ h', (h'.sub h).congr_left (λ x, sub_sub_cancel _ _),
  λ h', (h.add h').congr_left (λ x, sub_add_cancel _ _)⟩
 
-@[simp] theorem is_O_prod_left {f₁ : α → β} {f₂ : α → δ} {g : α → γ} {l : filter α} :
-  is_O (λx, (f₁ x, f₂ x)) g l ↔ is_O f₁ g l ∧ is_O f₂ g l :=
+end is_oO_as_rel
+
+/-! ### Zero, one, and other constants -/
+
+section zero_const
+
+variables (g' l)
+
+theorem is_o_zero : is_o (λ x, (0 : E')) g' l :=
+λ c hc, univ_mem_sets' $ λ x, by simpa using mul_nonneg (le_of_lt hc) (norm_nonneg $ g' x)
+
+theorem is_O_with_zero (hc : 0 < c) : is_O_with c (λ x, (0 : E')) g' l :=
+(is_o_zero g' l) hc
+
+theorem is_O_zero : is_O (λ x, (0 : E')) g' l := (is_o_zero g' l).is_O
+
+theorem is_O_refl_left : is_O (λ x, f' x - f' x) g' l :=
+(is_O_zero g' l).congr_left $ λ x, (sub_self _).symm
+
+theorem is_o_refl_left : is_o (λ x, f' x - f' x) g' l :=
+(is_o_zero g' l).congr_left $ λ x, (sub_self _).symm
+
+variables {g' l}
+
+theorem is_O_with_zero_right_iff (hc : 0 < c) :
+  is_O_with c f' (λ x, (0 : F')) l ↔ {x | f' x = 0} ∈ l :=
+by simp only [is_O_with, exists_prop, hc, true_and, norm_zero, mul_zero, norm_le_zero_iff]
+
+theorem is_O_zero_right_iff : is_O f' (λ x, (0 : F')) l ↔ {x | f' x = 0} ∈ l :=
+⟨λ h, let ⟨c, cpos, hc⟩ := h.exists_pos in  (is_O_with_zero_right_iff cpos).1 hc,
+  λ h, ((is_O_with_zero_right_iff zero_lt_one).2 h).is_O⟩
+
+theorem is_o_zero_right_iff :
+  is_o f' (λ x, (0 : F')) l ↔ {x | f' x = 0} ∈ l :=
+⟨λ h, is_O_zero_right_iff.1 h.is_O,
+  λ h c hc, (is_O_with_zero_right_iff hc).2 h⟩
+
+theorem is_O_with_const_const (c : E) {c' : F'} (hc' : c' ≠ 0) (l : filter α) :
+  is_O_with (∥c∥ / ∥c'∥) (λ x : α, c) (λ x, c') l :=
 begin
-  split,
-  { assume h,
-    split,
-    { exact is_O.trans (is_O.prod_rightl (is_O_refl f₁ l)) h },
-    { exact is_O.trans (is_O.prod_rightr (is_O_refl f₂ l)) h } },
-  { rintros ⟨h₁, h₂⟩,
-    have : is_O (λx, ∥f₁ x∥ + ∥f₂ x∥) g l :=
-      is_O.add (is_O_norm_left.2 h₁) (is_O_norm_left.2 h₂),
-    apply is_O.trans _ this,
-    refine ⟨1, zero_lt_one, filter.univ_mem_sets' (λx, _)⟩,
-    simp only [norm, max_le_iff, one_mul, set.mem_set_of_eq],
-    split; exact le_trans (by simp) (le_abs_self _) }
-end
-
-@[simp] theorem is_o_prod_left {f₁ : α → β} {f₂ : α → δ} {g : α → γ} {l : filter α} :
-  is_o (λx, (f₁ x, f₂ x)) g l ↔ is_o f₁ g l ∧ is_o f₂ g l :=
-begin
-  split,
-  { assume h,
-    split,
-    { exact is_O.trans_is_o (is_O.prod_rightl (is_O_refl f₁ l)) h },
-    { exact is_O.trans_is_o (is_O.prod_rightr (is_O_refl f₂ l)) h } },
-  { rintros ⟨h₁, h₂⟩,
-    have : is_o (λx, ∥f₁ x∥ + ∥f₂ x∥) g l :=
-      is_o.add (is_o_norm_left.2 h₁) (is_o_norm_left.2 h₂),
-    apply is_O.trans_is_o _ this,
-    refine ⟨1, zero_lt_one, filter.univ_mem_sets' (λx, _)⟩,
-    simp only [norm, max_le_iff, one_mul, set.mem_set_of_eq],
-    split; exact le_trans (by simp) (le_abs_self _) }
-end
-
-end
-
-section
-variables [normed_group β] [normed_group γ]
-
-theorem is_O_zero (g : α → γ) (l : filter α) :
-  is_O (λ x, (0 : β)) g l :=
-⟨1, zero_lt_one, by { filter_upwards [univ_mem_sets], intros x _, simp }⟩
-
-theorem is_O_refl_left {f : α → β} {g : α → γ} {l : filter α} :
-  is_O (λ x, f x - f x) g l :=
-by simpa using is_O_zero g l
-
-theorem is_O_zero_right_iff {f : α → β} {l : filter α} :
-  is_O f (λ x, (0 : γ)) l ↔ {x | f x = 0} ∈ l :=
-begin
-  rw [is_O_iff], split,
-  { rintros ⟨c, hc⟩,
-    filter_upwards [hc], dsimp,
-    intro x, rw [norm_zero, mul_zero], intro hx,
-    rw ←norm_eq_zero,
-    exact le_antisymm hx (norm_nonneg _) },
-  intro h, use 0,
-  filter_upwards [h], dsimp,
-  intros x hx,
-  rw [hx, norm_zero, zero_mul]
-end
-
-theorem is_o_zero (g : α → γ) (l : filter α) :
-  is_o (λ x, (0 : β)) g l :=
-λ c cpos,
-by { filter_upwards [univ_mem_sets], intros x _, simp,
-     exact mul_nonneg (le_of_lt cpos) (norm_nonneg _)}
-
-theorem is_o_refl_left {f : α → β} {g : α → γ} {l : filter α} :
-  is_o (λ x, f x - f x) g l :=
-by simpa using is_o_zero g l
-
-theorem is_o_zero_right_iff {f : α → β} (l : filter α) :
-  is_o f (λ x, (0 : γ)) l ↔ {x | f x = 0} ∈ l :=
-begin
-  split,
-  { intro h, exact is_O_zero_right_iff.mp h.to_is_O },
-  intros h c cpos,
-  filter_upwards [h], dsimp,
-  intros x hx,
-  rw [hx, norm_zero, norm_zero, mul_zero]
-end
-
-end
-
-section
-variables [has_norm β] [normed_field 𝕜]
-
-open normed_field
-
-theorem is_O_const_one (c : β) (l : filter α) :
-  is_O (λ x : α, c) (λ x, (1 : 𝕜)) l :=
-begin
-  rw is_O_iff,
-  refine ⟨∥c∥, _⟩,
-  simp only [norm_one, mul_one],
   apply univ_mem_sets',
-  simp [le_refl],
+  intro x,
+  rw [mem_set_of_eq, div_mul_cancel],
+  rwa [ne.def, norm_eq_zero]
 end
 
+theorem is_O_const_const (c : E) {c' : F'} (hc' : c' ≠ 0) (l : filter α) :
+  is_O (λ x : α, c) (λ x, c') l :=
+(is_O_with_const_const c hc' l).is_O
+
+end zero_const
+
+theorem is_O_with_const_one (c : E) (l : filter α) : is_O_with ∥c∥ (λ x : α, c) (λ x, (1 : 𝕜)) l :=
+begin
+  refine (is_O_with_const_const c _ l).congr_const _,
+  { rw [normed_field.norm_one, div_one] },
+  { exact one_ne_zero }
 end
+
+theorem is_O_const_one (c : E) (l : filter α) : is_O (λ x : α, c) (λ x, (1 : 𝕜)) l :=
+(is_O_with_const_one c l).is_O
 
 section
-variables [normed_field 𝕜] [normed_group γ]
 
-theorem is_O_const_mul_left {f : α → 𝕜} {g : α → γ} {l : filter α} (h : is_O f g l) (c : 𝕜) :
-  is_O (λ x, c * f x) g l :=
- begin
-  cases classical.em (c = 0) with h'' h'',
-  { simp [h''], apply is_O_zero },
-  rcases h with ⟨c', c'pos, h'⟩,
-  have cne0 : ∥c∥ ≠ 0, from mt (norm_eq_zero _).mp h'',
-  have cpos : ∥c∥ > 0, from lt_of_le_of_ne (norm_nonneg _) (ne.symm cne0),
-  refine ⟨∥c∥ * c', mul_pos cpos c'pos, _⟩,
-  filter_upwards [h'], dsimp,
-  intros x h₀,
-  rw [normed_field.norm_mul, mul_assoc],
-  exact mul_le_mul_of_nonneg_left h₀ (norm_nonneg _)
+variable (𝕜)
+
+theorem is_o_const_iff_is_o_one {c : F'} (hc : c ≠ 0) :
+  is_o f (λ x, c) l ↔ is_o f (λ x, (1:𝕜)) l :=
+⟨λ h, h.trans_is_O $ is_O_const_one c l, λ h, h.trans_is_O $ is_O_const_const _ hc _⟩
+
 end
 
-theorem is_O_const_mul_left_iff {f : α → 𝕜} {g : α → γ} {l : filter α} {c : 𝕜} (hc : c ≠ 0) :
-  is_O (λ x, c * f x) g l ↔ is_O f g l :=
+theorem is_o_const_iff {c : F'} (hc : c ≠ 0) :
+  is_o f' (λ x, c) l ↔ tendsto f' l (𝓝 0) :=
+(is_o_const_iff_is_o_one ℝ hc).trans
 begin
+  clear hc c,
+  simp only [is_o, is_O_with, normed_field.norm_one, mul_one, normed_group.tendsto_nhds_zero],
+  -- Now the only difference is `≤` vs `<`
   split,
-  { intro h,
-    convert is_O_const_mul_left h c⁻¹, ext,
-    rw [←mul_assoc, inv_mul_cancel hc, one_mul] },
-  intro h, apply is_O_const_mul_left h
-end
-
-theorem is_o_const_mul_left {f : α → 𝕜} {g : α → γ} {l : filter α} (h : is_o f g l) (c : 𝕜) :
-  is_o (λ x, c * f x) g l :=
-begin
-  cases classical.em (c = 0) with h'' h'',
-  { simp [h''], apply is_o_zero },
-  have cne0 : ∥c∥ ≠ 0, from mt (norm_eq_zero _).mp h'',
-  have cpos : ∥c∥ > 0, from lt_of_le_of_ne (norm_nonneg _) (ne.symm cne0),
-  intros c' c'pos, dsimp,
-  filter_upwards [h (c' / ∥c∥) (div_pos c'pos cpos)], dsimp,
-  intros x hx, rw [normed_field.norm_mul],
-  apply le_trans (mul_le_mul_of_nonneg_left hx (le_of_lt cpos)),
-  rw [←mul_assoc, mul_div_cancel' _ cne0]
-end
-
-theorem is_o_const_mul_left_iff {f : α → 𝕜} {g : α → γ} {l : filter α} {c : 𝕜} (hc : c ≠ 0) :
-  is_o (λ x, c * f x) g l ↔ is_o f g l :=
-begin
-  split,
-  { intro h,
-    convert is_o_const_mul_left h c⁻¹, ext,
-    rw [←mul_assoc, inv_mul_cancel hc, one_mul] },
-  intro h',
-  apply is_o_const_mul_left h'
-end
-
-end
-
-section
-variables [normed_group β] [normed_field 𝕜]
-
-theorem is_O_of_is_O_const_mul_right {f : α → β} {g : α → 𝕜} {l : filter α} {c : 𝕜}
-    (h : is_O f (λ x, c * g x) l) :
-  is_O f g l  :=
-begin
-  cases classical.em (c = 0) with h' h',
-  { simp [h', is_O_zero_right_iff] at h, rw is_O_congr_left h, apply is_O_zero },
-  have cne0 : ∥c∥ ≠ 0, from mt (norm_eq_zero _).mp h',
-  have cpos : ∥c∥ > 0, from lt_of_le_of_ne (norm_nonneg _) (ne.symm cne0),
-  rcases h with ⟨c', c'pos, h''⟩,
-  refine ⟨c' * ∥c∥, mul_pos c'pos cpos, _⟩,
-  convert h'', ext x, dsimp,
-  rw [normed_field.norm_mul, mul_assoc]
-end
-
-theorem is_O_const_mul_right_iff {f : α → β} {g : α → 𝕜} {l : filter α} {c : 𝕜} (hc : c ≠ 0) :
-  is_O f (λ x, c * g x) l ↔ is_O f g l :=
-begin
-  split,
-  { intro h, exact is_O_of_is_O_const_mul_right h },
-  intro h,
-  apply is_O_of_is_O_const_mul_right,
-  show is_O f (λ (x : α), c⁻¹ * (c * g x)) l,
-  convert h, ext, rw [←mul_assoc, inv_mul_cancel hc, one_mul]
-end
-
-theorem is_o_of_is_o_const_mul_right {f : α → β} {g : α → 𝕜} {l : filter α} {c : 𝕜}
-    (h : is_o f (λ x, c * g x) l) :
-  is_o f g l  :=
-begin
-  cases classical.em (c = 0) with h' h',
-  { simp [h', is_o_zero_right_iff] at h, rw is_o_congr_left h, apply is_o_zero },
-  have cne0 : ∥c∥ ≠ 0, from mt (norm_eq_zero _).mp h',
-  have cpos : ∥c∥ > 0, from lt_of_le_of_ne (norm_nonneg _) (ne.symm cne0),
-  intros c' c'pos,
-  convert h (c' / ∥c∥) (div_pos c'pos cpos), dsimp,
-  ext x, rw [normed_field.norm_mul, ←mul_assoc, div_mul_cancel _ cne0]
-end
-
-theorem is_o_const_mul_right {f : α → β} {g : α → 𝕜} {l : filter α} {c : 𝕜} (hc : c ≠ 0) :
-  is_o f (λ x, c * g x) l ↔ is_o f g l :=
-begin
-  split,
-  { intro h, exact is_o_of_is_o_const_mul_right h },
-  intro h,
-  apply is_o_of_is_o_const_mul_right,
-  show is_o f (λ (x : α), c⁻¹ * (c * g x)) l,
-  convert h, ext, rw [←mul_assoc, inv_mul_cancel hc, one_mul]
-end
-
-theorem is_o_one_iff {f : α → β} {l : filter α} :
-  is_o f (λ x, (1 : 𝕜)) l ↔ tendsto f l (𝓝 0) :=
-begin
-  rw [normed_group.tendsto_nhds_zero, is_o], split,
-  { intros h e epos,
-    filter_upwards [h (e / 2) (half_pos epos)], simp,
+  { intros h ε hε0,
+    apply mem_sets_of_superset (h (half_pos hε0)),
     intros x hx,
-    exact lt_of_le_of_lt hx (half_lt_self epos) },
-  intros h e epos,
-  filter_upwards [h e epos], simp,
-  intros x hx,
-  exact le_of_lt hx
+    simp only [mem_set_of_eq] at hx ⊢,
+    exact lt_of_le_of_lt hx (half_lt_self hε0) },
+  { intros h ε hε0,
+    apply mem_sets_of_superset (h ε hε0),
+    intros x hx,
+    simp only [mem_set_of_eq] at hx ⊢,
+    exact le_of_lt hx }
 end
 
-theorem is_O_one_of_tendsto {f : α → β} {l : filter α} {y : β}
-  (h : tendsto f l (𝓝 y)) : is_O f (λ x, (1 : 𝕜)) l :=
+theorem is_O_const_of_tendsto {y : E'} (h : tendsto f' l (𝓝 y)) {c : F'} (hc : c ≠ 0) :
+  is_O f' (λ x, c) l :=
 begin
-  have Iy : ∥y∥ < ∥y∥ + 1 := lt_add_one _,
-  refine ⟨∥y∥ + 1, lt_of_le_of_lt (norm_nonneg _) Iy, _⟩,
-  simp only [mul_one, normed_field.norm_one],
-  have : tendsto (λx, ∥f x∥) l (𝓝 ∥y∥) :=
-    (continuous_norm.tendsto _).comp h,
+  refine is_O.trans _ (is_O_const_const (∥y∥ + 1) hc l),
+  use 1,
+  simp only [is_O_with, one_mul],
+  have : tendsto (λx, ∥f' x∥) l (𝓝 ∥y∥), from (continuous_norm.tendsto _).comp h,
+  have Iy : ∥y∥ < ∥∥y∥ + 1∥, from lt_of_lt_of_le (lt_add_one _) (le_abs_self _),
   exact this (ge_mem_nhds Iy)
 end
 
+section
+
+variable (𝕜)
+
+theorem is_o_one_iff : is_o f' (λ x, (1 : 𝕜)) l ↔ tendsto f' l (𝓝 0) :=
+is_o_const_iff one_ne_zero
+
+theorem is_O_one_of_tendsto {y : E'} (h : tendsto f' l (𝓝 y)) :
+  is_O f' (λ x, (1:𝕜)) l :=
+is_O_const_of_tendsto h one_ne_zero
+
+theorem is_O.trans_tendsto_nhds (hfg : is_O f g' l) {y : F'} (hg : tendsto g' l (𝓝 y)) :
+  is_O f (λ x, (1:𝕜)) l :=
+hfg.trans $ is_O_one_of_tendsto 𝕜 hg
+
 end
 
-section
-variables [normed_group β] [normed_group γ]
+theorem is_O.trans_tendsto (hfg : is_O f' g' l) (hg : tendsto g' l (𝓝 0)) :
+  tendsto f' l (𝓝 0) :=
+(is_o_one_iff ℝ).1 $ hfg.trans_is_o $ (is_o_one_iff ℝ).2 hg
 
-theorem is_O.trans_tendsto {f : α → β} {g : α → γ} {l : filter α}
-    (h₁ : is_O f g l) (h₂ : tendsto g l (𝓝 0)) :
-  tendsto f l (𝓝 0) :=
-(@is_o_one_iff _ _ ℝ _ _ _ _).1 $ h₁.trans_is_o $ is_o_one_iff.2 h₂
+theorem is_o.trans_tendsto (hfg : is_o f' g' l) (hg : tendsto g' l (𝓝 0)) :
+  tendsto f' l (𝓝 0) :=
+hfg.is_O.trans_tendsto hg
 
-theorem is_o.trans_tendsto {f : α → β} {g : α → γ} {l : filter α}
-  (h₁ : is_o f g l) : tendsto g l (𝓝 0) → tendsto f l (𝓝 0) :=
-h₁.to_is_O.trans_tendsto
+/-! ### Multiplication by a constant -/
 
-end
+theorem is_O_with_const_mul_self (c : R) (f : α → R) (l : filter α) :
+  is_O_with ∥c∥ (λ x, c * f x) f l :=
+is_O_with_of_le' _ $ λ x, norm_mul_le _ _
 
-section
-variables [normed_field 𝕜] [normed_field 𝕜']
+theorem is_O_const_mul_self (c : R) (f : α → R) (l : filter α) :
+  is_O (λ x, c * f x) f l :=
+(is_O_with_const_mul_self c f l).is_O
 
-theorem is_O_mul {f₁ f₂ : α → 𝕜} {g₁ g₂ : α → 𝕜'} {l : filter α}
-    (h₁ : is_O f₁ g₁ l) (h₂ : is_O f₂ g₂ l) :
-  is_O (λ x, f₁ x * f₂ x) (λ x, g₁ x * g₂ x) l :=
+theorem is_O_with.const_mul_left {f : α → R} (h : is_O_with c f g l) (c' : R) :
+  is_O_with (∥c'∥ * c) (λ x, c' * f x) g l :=
+(is_O_with_const_mul_self c' f l).trans h (norm_nonneg c')
+
+theorem is_O.const_mul_left {f : α → R} (h : is_O f g l) (c' : R) :
+  is_O (λ x, c' * f x) g l :=
+let ⟨c, hc⟩ := h in (hc.const_mul_left c').is_O
+
+theorem is_O_with_self_const_mul' (u : units R) (f : α → R) (l : filter α) :
+  is_O_with ∥(↑u⁻¹:R)∥ f (λ x, ↑u * f x) l :=
+(is_O_with_const_mul_self ↑u⁻¹ _ l).congr_left $ λ x, u.inv_mul_cancel_left (f x)
+
+theorem is_O_with_self_const_mul (c : 𝕜) (hc : c ≠ 0) (f : α → 𝕜) (l : filter α) :
+  is_O_with ∥c∥⁻¹ f (λ x, c * f x) l :=
+(is_O_with_self_const_mul' (units.mk0 c hc) f l).congr_const $
+  normed_field.norm_inv c
+
+theorem is_O_self_const_mul' {c : R} (hc : is_unit c) (f : α → R) (l : filter α) :
+  is_O f (λ x, c * f x) l :=
+let ⟨u, hu⟩ := hc in hu.symm ▸ (is_O_with_self_const_mul' u f l).is_O
+
+theorem is_O_self_const_mul (c : 𝕜) (hc : c ≠ 0) (f : α → 𝕜) (l : filter α) :
+  is_O f (λ x, c * f x) l :=
+is_O_self_const_mul' (is_unit.mk0 c hc) f l
+
+theorem is_O_const_mul_left_iff' {f : α → R} {c : R} (hc : is_unit c) :
+  is_O (λ x, c * f x) g l ↔ is_O f g l :=
+⟨(is_O_self_const_mul' hc f l).trans, λ h, h.const_mul_left c⟩
+
+theorem is_O_const_mul_left_iff {f : α → 𝕜} {c : 𝕜} (hc : c ≠ 0) :
+  is_O (λ x, c * f x) g l ↔ is_O f g l :=
+is_O_const_mul_left_iff' $ is_unit.mk0 c hc
+
+theorem is_o.const_mul_left {f : α → R} (h : is_o f g l) (c : R) :
+  is_o (λ x, c * f x) g l :=
+(is_O_const_mul_self c f l).trans_is_o h
+
+theorem is_o_const_mul_left_iff' {f : α → R} {c : R} (hc : is_unit c) :
+  is_o (λ x, c * f x) g l ↔ is_o f g l :=
+⟨(is_O_self_const_mul' hc f l).trans_is_o, λ h, h.const_mul_left c⟩
+
+theorem is_o_const_mul_left_iff {f : α → 𝕜} {c : 𝕜} (hc : c ≠ 0) :
+  is_o (λ x, c * f x) g l ↔ is_o f g l :=
+is_o_const_mul_left_iff' $ is_unit.mk0 c hc
+
+theorem is_O_with.of_const_mul_right {g : α → R} {c : R} (hc' : 0 ≤ c')
+  (h : is_O_with c' f (λ x, c * g x) l) :
+  is_O_with (c' * ∥c∥) f g l :=
+h.trans (is_O_with_const_mul_self c g l) hc'
+
+theorem is_O.of_const_mul_right {g : α → R} {c : R}
+  (h : is_O f (λ x, c * g x) l) :
+  is_O f g l :=
+let ⟨c, cnonneg, hc⟩ := h.exists_nonneg in (hc.of_const_mul_right cnonneg).is_O
+
+theorem is_O_with.const_mul_right' {g : α → R} {u : units R} {c' : ℝ} (hc' : 0 ≤ c')
+  (h : is_O_with c' f g l) :
+  is_O_with (c' * ∥(↑u⁻¹:R)∥) f (λ x, ↑u * g x) l :=
+h.trans (is_O_with_self_const_mul' _ _ _) hc'
+
+theorem is_O_with.const_mul_right {g : α → 𝕜} {c : 𝕜} (hc : c ≠ 0)
+  {c' : ℝ} (hc' : 0 ≤ c') (h : is_O_with c' f g l) :
+  is_O_with (c' * ∥c∥⁻¹) f (λ x, c * g x) l :=
+h.trans (is_O_with_self_const_mul c hc g l) hc'
+
+theorem is_O.const_mul_right' {g : α → R} {c : R} (hc : is_unit c) (h : is_O f g l) :
+  is_O f (λ x, c * g x) l :=
+h.trans (is_O_self_const_mul' hc g l)
+
+theorem is_O.const_mul_right {g : α → 𝕜} {c : 𝕜} (hc : c ≠ 0) (h : is_O f g l) :
+  is_O f (λ x, c * g x) l :=
+h.const_mul_right' $ is_unit.mk0 c hc
+
+theorem is_O_const_mul_right_iff' {g : α → R} {c : R} (hc : is_unit c) :
+  is_O f (λ x, c * g x) l ↔ is_O f g l :=
+⟨λ h, h.of_const_mul_right, λ h, h.const_mul_right' hc⟩
+
+theorem is_O_const_mul_right_iff {g : α → 𝕜} {c : 𝕜} (hc : c ≠ 0) :
+  is_O f (λ x, c * g x) l ↔ is_O f g l :=
+is_O_const_mul_right_iff' $ is_unit.mk0 c hc
+
+theorem is_o.of_const_mul_right {g : α → R} {c : R} (h : is_o f (λ x, c * g x) l) :
+  is_o f g l :=
+h.trans_is_O (is_O_const_mul_self c g l)
+
+theorem is_o.const_mul_right' {g : α → R} {c : R} (hc : is_unit c) (h : is_o f g l) :
+  is_o f (λ x, c * g x) l :=
+h.trans_is_O (is_O_self_const_mul' hc g l)
+
+theorem is_o.const_mul_right {g : α → 𝕜} {c : 𝕜} (hc : c ≠ 0) (h : is_o f g l) :
+  is_o f (λ x, c * g x) l :=
+h.const_mul_right' $ is_unit.mk0 c hc
+
+theorem is_o_const_mul_right_iff' {g : α → R} {c : R} (hc : is_unit c) :
+  is_o f (λ x, c * g x) l ↔ is_o f g l :=
+⟨λ h, h.of_const_mul_right, λ h, h.const_mul_right' hc⟩
+
+theorem is_o_const_mul_right_iff {g : α → 𝕜} {c : 𝕜} (hc : c ≠ 0) :
+  is_o f (λ x, c * g x) l ↔ is_o f g l :=
+is_o_const_mul_right_iff' $ is_unit.mk0 c hc
+
+/-! ### Multiplication -/
+
+theorem is_O_with.mul_same_left {f₂ g : α → 𝕜} (f₁ : α → 𝕜) (h : is_O_with c f₂ g l) :
+  is_O_with c (λ x, f₁ x * f₂ x) (λ x, f₁ x * g x) l :=
 begin
-  rcases h₁ with ⟨c₁, c₁pos, hc₁⟩,
-  rcases h₂ with ⟨c₂, c₂pos, hc₂⟩,
-  refine ⟨c₁ * c₂, mul_pos c₁pos c₂pos, _⟩,
-  filter_upwards [hc₁, hc₂], dsimp,
-  intros x hx₁ hx₂,
-  rw [normed_field.norm_mul, normed_field.norm_mul, mul_assoc, mul_left_comm c₂, ←mul_assoc],
-  exact mul_le_mul hx₁ hx₂ (norm_nonneg _) (mul_nonneg (le_of_lt c₁pos) (norm_nonneg _))
+  apply mem_sets_of_superset h,
+  intros x hx,
+  simp only [mem_set_of_eq, normed_field.norm_mul] at hx ⊢,
+  rw [mul_left_comm],
+  exact mul_le_mul_of_nonneg_left hx (norm_nonneg _)
 end
 
-theorem is_o_mul_left {f₁ f₂ : α → 𝕜} {g₁ g₂ : α → 𝕜'} {l : filter α}
-    (h₁ : is_O f₁ g₁ l) (h₂ : is_o f₂ g₂ l) :
+theorem is_O.mul_same_left {f₂ g : α → 𝕜} (f₁ : α → 𝕜) (h : is_O f₂ g l) :
+  is_O (λ x, f₁ x * f₂ x) (λ x, f₁ x * g x) l :=
+let ⟨c, hc⟩ := h in (hc.mul_same_left f₁).is_O
+
+theorem is_o.mul_same_left {f₂ g : α → 𝕜} (f₁ : α → 𝕜) (h : is_o f₂ g l) :
+  is_o (λ x, f₁ x * f₂ x) (λ x, f₁ x * g x) l :=
+λ c hc, (h hc).mul_same_left f₁
+
+theorem is_O_with.mul_same_right {f₁ g : α → 𝕜} (h : is_O_with c f₁ g l) (f₂ : α → 𝕜) :
+  is_O_with c (λ x, f₁ x * f₂ x) (λ x, g x * f₂ x) l :=
+(h.mul_same_left f₂).congr rfl (λ x, mul_comm _ _) (λ x, mul_comm _ _)
+
+theorem is_O.mul_same_right {f₁ g : α → 𝕜} (h : is_O f₁ g l) (f₂ : α → 𝕜) :
+  is_O (λ x, f₁ x * f₂ x) (λ x, g x * f₂ x) l :=
+let ⟨c, hc⟩ := h in (hc.mul_same_right f₂).is_O
+
+theorem is_o.mul_same_right {f₁ g : α → 𝕜} (h : is_o f₁ g l) (f₂ : α → 𝕜) :
+  is_o (λ x, f₁ x * f₂ x) (λ x, g x * f₂ x) l :=
+λ c hc, (h hc).mul_same_right f₂
+
+theorem is_O_with.mul {f₁ f₂ : α → R} {g₁ g₂ : α → 𝕜} {c₁ c₂ : ℝ}
+  (h₁ : is_O_with c₁ f₁ g₁ l) (h₂ : is_O_with c₂ f₂ g₂ l) :
+  is_O_with (c₁ * c₂) (λ x, f₁ x * f₂ x) (λ x, g₁ x * g₂ x) l :=
+begin
+  filter_upwards [h₁, h₂], simp only [mem_set_of_eq],
+  intros x hx₁ hx₂,
+  apply le_trans (norm_mul_le _ _),
+  convert mul_le_mul hx₁ hx₂ (norm_nonneg _) (le_trans (norm_nonneg _) hx₁) using 1,
+  rw normed_field.norm_mul,
+  ac_refl
+end
+
+theorem is_O.mul {f₁ f₂ : α → R} {g₁ g₂ : α → 𝕜}
+  (h₁ : is_O f₁ g₁ l) (h₂ : is_O f₂ g₂ l) :
+  is_O (λ x, f₁ x * f₂ x) (λ x, g₁ x * g₂ x) l :=
+let ⟨c, hc⟩ := h₁, ⟨c', hc'⟩ := h₂ in (hc.mul hc').is_O
+
+theorem is_O.mul_is_o {f₁ f₂ : α → R} {g₁ g₂ : α → 𝕜}
+  (h₁ : is_O f₁ g₁ l) (h₂ : is_o f₂ g₂ l) :
   is_o (λ x, f₁ x * f₂ x) (λ x, g₁ x * g₂ x) l :=
 begin
   intros c cpos,
-  rcases h₁ with ⟨c₁, c₁pos, hc₁⟩,
-  filter_upwards [hc₁, h₂ (c / c₁) (div_pos cpos c₁pos)], dsimp,
-  intros x hx₁ hx₂,
-  rw [normed_field.norm_mul, normed_field.norm_mul],
-  apply le_trans (mul_le_mul hx₁ hx₂ (norm_nonneg _) (mul_nonneg (le_of_lt c₁pos) (norm_nonneg _))),
-  rw [mul_comm c₁, mul_assoc, mul_left_comm c₁, ←mul_assoc _ c₁, div_mul_cancel _ (ne_of_gt c₁pos)],
-  rw [mul_left_comm]
+  rcases h₁.exists_pos with ⟨c', c'pos, hc'⟩,
+  exact (hc'.mul (h₂ (div_pos cpos c'pos))).congr_const (mul_div_cancel' _ (ne_of_gt c'pos))
 end
 
-theorem is_o_mul_right {f₁ f₂ : α → 𝕜} {g₁ g₂ : α → 𝕜'} {l : filter α}
-    (h₁ : is_o f₁ g₁ l) (h₂ : is_O f₂ g₂ l) :
+theorem is_o.mul_is_O {f₁ f₂ : α → R} {g₁ g₂ : α → 𝕜}
+  (h₁ : is_o f₁ g₁ l) (h₂ : is_O f₂ g₂ l) :
   is_o (λ x, f₁ x * f₂ x) (λ x, g₁ x * g₂ x) l :=
-by convert is_o_mul_left h₂ h₁; simp only [mul_comm]
-
-theorem is_o_mul {f₁ f₂ : α → 𝕜} {g₁ g₂ : α → 𝕜'} {l : filter α}
-    (h₁ : is_o f₁ g₁ l) (h₂ : is_o f₂ g₂ l) :
-  is_o (λ x, f₁ x * f₂ x) (λ x, g₁ x * g₂ x) l :=
-is_o_mul_left h₁.to_is_O h₂
-
-end
-
-/-
-Note: the theorems in the next two sections can also be used for the integers, since
-scalar multiplication is multiplication.
--/
-
-section
-variables [normed_field 𝕜] [normed_group β] [normed_space 𝕜 β] [normed_group γ]
-
-set_option class.instance_max_depth 43
-
-theorem is_O_const_smul_left {f : α → β} {g : α → γ} {l : filter α} (h : is_O f g l) (c : 𝕜) :
-  is_O (λ x, c • f x) g l :=
 begin
-  rw [←is_O_norm_left], simp only [norm_smul],
-  apply is_O_const_mul_left,
-  rw [is_O_norm_left],
-  apply h
+  intros c cpos,
+  rcases h₂.exists_pos with ⟨c', c'pos, hc'⟩,
+  exact ((h₁ (div_pos cpos c'pos)).mul hc').congr_const (div_mul_cancel _ (ne_of_gt c'pos))
 end
 
-theorem is_O_const_smul_left_iff {f : α → β} {g : α → γ} {l : filter α} {c : 𝕜} (hc : c ≠ 0) :
-  is_O (λ x, c • f x) g l ↔ is_O f g l :=
+theorem is_o.mul {f₁ f₂ : α → R} {g₁ g₂ : α → 𝕜} (h₁ : is_o f₁ g₁ l) (h₂ : is_o f₂ g₂ l) :
+  is_o (λ x, f₁ x * f₂ x) (λ x, g₁ x * g₂ x) l :=
+h₁.mul_is_O h₂.is_O
+
+/-! ### Scalar multiplication -/
+
+section smul_const
+variables [normed_space 𝕜 E']
+
+theorem is_O_with.const_smul_left (h : is_O_with c f' g l) (c' : 𝕜) :
+  is_O_with (∥c'∥ * c) (λ x, c' • f' x) g l :=
+by refine ((h.norm_left.const_mul_left (∥c'∥)).congr _ _ (λ _, rfl)).of_norm_left;
+    intros; simp only [norm_norm, norm_smul]
+
+theorem is_O_const_smul_left_iff {c : 𝕜} (hc : c ≠ 0) :
+  is_O (λ x, c • f' x) g l ↔ is_O f' g l :=
 begin
   have cne0 : ∥c∥ ≠ 0, from mt (norm_eq_zero _).mp hc,
   rw [←is_O_norm_left], simp only [norm_smul],
-  rw [is_O_const_mul_left_iff cne0, is_O_norm_left]
+  rw [is_O_const_mul_left_iff cne0, is_O_norm_left],
 end
 
-theorem is_o_const_smul_left {f : α → β} {g : α → γ} {l : filter α} (h : is_o f g l) (c : 𝕜) :
-  is_o (λ x, c • f x) g l :=
+theorem is_o_const_smul_left (h : is_o f' g l) (c : 𝕜) :
+  is_o (λ x, c • f' x) g l :=
 begin
-  rw [←is_o_norm_left], simp only [norm_smul],
-  apply is_o_const_mul_left,
-  rw [is_o_norm_left],
-  apply h
+  refine ((h.norm_left.const_mul_left (∥c∥)).congr_left _).of_norm_left,
+  exact λ x, (norm_smul _ _).symm
 end
 
-theorem is_o_const_smul_left_iff {f : α → β} {g : α → γ} {l : filter α} {c : 𝕜} (hc : c ≠ 0) :
-  is_o (λ x, c • f x) g l ↔ is_o f g l :=
+theorem is_o_const_smul_left_iff {c : 𝕜} (hc : c ≠ 0) :
+  is_o (λ x, c • f' x) g l ↔ is_o f' g l :=
 begin
   have cne0 : ∥c∥ ≠ 0, from mt (norm_eq_zero _).mp hc,
   rw [←is_o_norm_left], simp only [norm_smul],
   rw [is_o_const_mul_left_iff cne0, is_o_norm_left]
 end
 
-end
-
-section
-variables [normed_group β] [normed_field 𝕜] [normed_group γ] [normed_space 𝕜 γ]
-
-set_option class.instance_max_depth 43
-
-theorem is_O_const_smul_right {f : α → β} {g : α → γ} {l : filter α} {c : 𝕜} (hc : c ≠ 0) :
-  is_O f (λ x, c • g x) l ↔ is_O f g l :=
+theorem is_O_const_smul_right {c : 𝕜} (hc : c ≠ 0) :
+  is_O f (λ x, c • f' x) l ↔ is_O f f' l :=
 begin
   have cne0 : ∥c∥ ≠ 0, from mt (norm_eq_zero _).mp hc,
   rw [←is_O_norm_right], simp only [norm_smul],
   rw [is_O_const_mul_right_iff cne0, is_O_norm_right]
 end
 
-theorem is_o_const_smul_right {f : α → β} {g : α → γ} {l : filter α} {c : 𝕜} (hc : c ≠ 0) :
-  is_o f (λ x, c • g x) l ↔ is_o f g l :=
+theorem is_o_const_smul_right {c : 𝕜} (hc : c ≠ 0) :
+  is_o f (λ x, c • f' x) l ↔ is_o f f' l :=
 begin
   have cne0 : ∥c∥ ≠ 0, from mt (norm_eq_zero _).mp hc,
   rw [←is_o_norm_right], simp only [norm_smul],
-  rw [is_o_const_mul_right cne0, is_o_norm_right]
+  rw [is_o_const_mul_right_iff cne0, is_o_norm_right]
 end
 
-end
+end smul_const
 
-section
-variables [normed_field 𝕜] [normed_group β] [normed_space 𝕜 β]
-[normed_group γ] [normed_space 𝕜 γ]
+section smul
 
-set_option class.instance_max_depth 43
+variables [normed_space 𝕜 E'] [normed_space 𝕜 F']
 
-theorem is_O_smul {k : α → 𝕜} {f : α → β} {g : α → γ} {l : filter α} (h : is_O f g l) :
-  is_O (λ x, k x • f x) (λ x, k x • g x) l :=
-begin
-  rw [←is_O_norm_left, ←is_O_norm_right], simp only [norm_smul],
-  apply is_O_mul (is_O_refl _ _),
-  rw [is_O_norm_left, is_O_norm_right],
-  exact h
-end
+theorem is_O_with.smul_same_left (k : α → 𝕜) (h : is_O_with c f' g' l) :
+  is_O_with c (λ x, k x • f' x) (λ x, k x • g' x) l :=
+by refine ((h.norm_norm.mul_same_left (norm ∘ k)).congr rfl _ _).of_norm_norm;
+  intros; simp only [function.comp, norm_smul]
 
-theorem is_o_smul {k : α → 𝕜} {f : α → β} {g : α → γ} {l : filter α} (h : is_o f g l) :
-  is_o (λ x, k x • f x) (λ x, k x • g x) l :=
-begin
-  rw [←is_o_norm_left, ←is_o_norm_right], simp only [norm_smul],
-  apply is_o_mul_left (is_O_refl _ _),
-  rw [is_o_norm_left, is_o_norm_right],
-  exact h
-end
+theorem is_O.smul_same_left (k : α → 𝕜) (h : is_O f' g' l) :
+  is_O (λ x, k x • f' x) (λ x, k x • g' x) l :=
+let ⟨c, hc⟩ := h in (hc.smul_same_left k).is_O
 
-end
+theorem is_o.smul_same_left (k : α → 𝕜) (h : is_o f' g' l) :
+  is_o (λ x, k x • f' x) (λ x, k x • g' x) l :=
+λ c hc, (h hc).smul_same_left k
 
-section
-variables [normed_field 𝕜]
+theorem is_O_with.smul {k₁ k₂ : α → 𝕜} (h₁ : is_O_with c k₁ k₂ l) (h₂ : is_O_with c' f' g' l) :
+  is_O_with (c * c') (λ x, k₁ x • f' x) (λ x, k₂ x • g' x) l :=
+by refine ((h₁.norm_norm.mul h₂.norm_norm).congr rfl _ _).of_norm_norm;
+  by intros; simp only [norm_smul]
 
-theorem tendsto_nhds_zero_of_is_o {f g : α → 𝕜} {l : filter α} (h : is_o f g l) :
+theorem is_O.smul {k₁ k₂ : α → 𝕜} (h₁ : is_O k₁ k₂ l) (h₂ : is_O f' g' l) :
+  is_O (λ x, k₁ x • f' x) (λ x, k₂ x • g' x) l :=
+by refine ((h₁.norm_norm.mul h₂.norm_norm).congr _ _).of_norm_norm;
+  by intros; simp only [norm_smul]
+
+theorem is_O.smul_is_o {k₁ k₂ : α → 𝕜} (h₁ : is_O k₁ k₂ l) (h₂ : is_o f' g' l) :
+  is_o (λ x, k₁ x • f' x) (λ x, k₂ x • g' x) l :=
+by refine ((h₁.norm_norm.mul_is_o h₂.norm_norm).congr _ _).of_norm_norm;
+  by intros; simp only [norm_smul]
+
+theorem is_o.smul_is_O {k₁ k₂ : α → 𝕜} (h₁ : is_o k₁ k₂ l) (h₂ : is_O f' g' l) :
+  is_o (λ x, k₁ x • f' x) (λ x, k₂ x • g' x) l :=
+by refine ((h₁.norm_norm.mul_is_O h₂.norm_norm).congr _ _).of_norm_norm;
+  by intros; simp only [norm_smul]
+
+theorem is_o.smul {k₁ k₂ : α → 𝕜} (h₁ : is_o k₁ k₂ l) (h₂ : is_o f' g' l) :
+  is_o (λ x, k₁ x • f' x) (λ x, k₂ x • g' x) l :=
+by refine ((h₁.norm_norm.mul h₂.norm_norm).congr _ _).of_norm_norm;
+  by intros; simp only [norm_smul]
+
+end smul
+
+/-! ### Relation between `f = o(g)` and `f / g → 0` -/
+
+theorem is_o.tendsto_0 {f g : α → 𝕜} {l : filter α} (h : is_o f g l) :
   tendsto (λ x, f x / (g x)) l (𝓝 0) :=
 have eq₁ : is_o (λ x, f x / g x) (λ x, g x / g x) l,
-  from is_o_mul_right h (is_O_refl _ _),
+  from h.mul_same_right _,
 have eq₂ : is_O (λ x, g x / g x) (λ x, (1 : 𝕜)) l,
-  begin
-    use [1, zero_lt_one],
-    filter_upwards [univ_mem_sets], simp,
-    intro x,
-    cases classical.em (∥g x∥ = 0) with h' h'; simp [h'],
-    exact zero_le_one
-  end,
-is_o_one_iff.mp (eq₁.trans_is_O eq₂)
+  from is_O_of_le _ (λ x, by by_cases h : ∥g x∥ = 0; simp [h, zero_le_one]),
+(is_o_one_iff 𝕜).mp (eq₁.trans_is_O eq₂)
 
 private theorem is_o_of_tendsto {f g : α → 𝕜} {l : filter α}
     (hgf : ∀ x, g x = 0 → f x = 0) (h : tendsto (λ x, f x / (g x)) l (𝓝 0)) :
   is_o f g l :=
 have eq₁ : is_o (λ x, f x / (g x)) (λ x, (1 : 𝕜)) l,
-  from is_o_one_iff.mpr h,
+  from (is_o_one_iff _).mpr h,
 have eq₂ : is_o (λ x, f x / g x * g x) g l,
-  by convert is_o_mul_right eq₁ (is_O_refl _ _); simp,
+  by convert eq₁.mul_is_O (is_O_refl _ _); simp,
 have eq₃ : is_O f (λ x, f x / g x * g x) l,
   begin
-    use [1, zero_lt_one],
-    refine filter.univ_mem_sets' (assume x, _),
-    suffices : ∥f x∥ ≤ ∥f x∥ / ∥g x∥ * ∥g x∥, { simpa },
-    by_cases g x = 0,
-    { simp only [h, hgf x h, norm_zero, mul_zero] },
-    { rw [div_mul_cancel], exact mt (norm_eq_zero _).1 h }
+    refine is_O_of_le _ (λ x, _),
+    by_cases H : g x = 0,
+    { simp only [H, hgf _ H, mul_zero] },
+    { simp only [div_mul_cancel _ H] }
   end,
 eq₃.trans_is_o eq₂
 
 theorem is_o_iff_tendsto {f g : α → 𝕜} {l : filter α}
     (hgf : ∀ x, g x = 0 → f x = 0) :
   is_o f g l ↔ tendsto (λ x, f x / (g x)) l (𝓝 0) :=
-iff.intro tendsto_nhds_zero_of_is_o (is_o_of_tendsto hgf)
+iff.intro is_o.tendsto_0 (is_o_of_tendsto hgf)
+
+/-! ### Miscellanous lemmas -/
 
 theorem is_o_pow_pow {m n : ℕ} (h : m < n) :
   is_o (λ(x : 𝕜), x^n) (λx, x^m) (𝓝 0) :=
 begin
   let p := n - m,
   have nmp : n = m + p := (nat.add_sub_cancel' (le_of_lt h)).symm,
-  have : (λ(x : 𝕜), x^m) = (λx, x^m * 1), by simp,
+  have : (λ(x : 𝕜), x^m) = (λx, x^m * 1), by simp only [mul_one],
   simp only [this, pow_add, nmp],
-  refine is_o_mul_left (is_O_refl _ _) (is_o_one_iff.2 _),
+  refine is_o.mul_same_left _ ((is_o_one_iff _).2 _),
   convert (continuous_pow p).tendsto (0 : 𝕜),
   exact (zero_pow (nat.sub_pos_of_lt h)).symm
 end
 
 theorem is_o_pow_id {n : ℕ} (h : 1 < n) :
   is_o (λ(x : 𝕜), x^n) (λx, x) (𝓝 0) :=
-by { convert is_o_pow_pow h, simp }
+by { convert is_o_pow_pow h, simp only [pow_one] }
 
+theorem is_O_with.right_le_sub_of_lt_1 {f₁ f₂ : α → E'} (h : is_O_with c f₁ f₂ l) (hc : c < 1) :
+  is_O_with (1 / (1 - c)) f₂ (λx, f₂ x - f₁ x) l :=
+mem_sets_of_superset h $ λ x hx,
+begin
+  simp only [mem_set_of_eq] at hx ⊢,
+  rw [mul_comm, one_div_eq_inv, ← div_eq_mul_inv, le_div_iff, mul_sub, mul_one, mul_comm],
+  { exact le_trans (sub_le_sub_left hx _) (norm_sub_norm_le _ _) },
+  { exact sub_pos.2 hc }
 end
+
+theorem is_O_with.right_le_add_of_lt_1 {f₁ f₂ : α → E'} (h : is_O_with c f₁ f₂ l) (hc : c < 1) :
+  is_O_with (1 / (1 - c)) f₂ (λx, f₁ x + f₂ x) l :=
+(h.neg_right.right_le_sub_of_lt_1 hc).neg_right.neg_left.congr rfl (λ x, neg_neg _)
+  (λ x, by rw [neg_sub, sub_neg_eq_add])
 
 end asymptotics

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -252,7 +252,7 @@ lemma has_deriv_within_at.union (hs : has_deriv_within_at f f' s x) (ht : has_de
   has_deriv_within_at f f' (s ∪ t) x :=
 begin
   simp only [has_deriv_within_at, nhds_within_union],
-  exact is_o_join hs ht,
+  exact hs.join ht,
 end
 
 lemma has_deriv_within_at.nhds_within (h : has_deriv_within_at f f' s x)
@@ -957,38 +957,35 @@ begin
   have : is_o (λ (h : 𝕜), h^2 * (1 + h)⁻¹) (λ (h : 𝕜), h * 1) (𝓝 0),
   { have : tendsto (λ (h : 𝕜), (1 + h)⁻¹) (𝓝 0) (𝓝 (1 + 0)⁻¹) :=
       ((tendsto_const_nhds).add tendsto_id).inv' (by norm_num),
-    exact is_o_mul_right (is_o_pow_id (by norm_num)) (is_O_one_of_tendsto this) },
-  apply (is_o_congr _ _).2 this,
-  { have : metric.ball (0 : 𝕜) (∥(1:𝕜)∥) ∈ 𝓝 (0 : 𝕜),
-    { apply mem_nhds_sets metric.is_open_ball,
-      simp [zero_lt_one] },
+    exact is_o.mul_is_O (is_o_pow_id one_lt_two) (is_O_one_of_tendsto _ this) },
+  apply this.congr' _ _,
+  { have : metric.ball (0 : 𝕜) 1 ∈ 𝓝 (0 : 𝕜),
+      from metric.ball_mem_nhds 0 zero_lt_one,
     filter_upwards [this],
     assume h hx,
     have : 0 < ∥1 + h∥ := calc
-      0 < ∥(1:𝕜)∥ - ∥-h∥ : by rwa [norm_neg, sub_pos, ← dist_zero_right h]
+      0 < ∥(1:𝕜)∥ - ∥-h∥ : by rwa [norm_neg, sub_pos, ← dist_zero_right h, normed_field.norm_one]
       ... ≤ ∥1 - -h∥ : norm_sub_norm_le _ _
       ... = ∥1 + h∥ : by simp,
     have : 1 + h ≠ 0 := (norm_pos_iff (1 + h)).mp this,
-    calc (1 + h)⁻¹ - 1⁻¹ - h * -1 =
-      (1+h)⁻¹ - ((1+h) * (1+h)⁻¹) + h * ((1+h) * (1+h)⁻¹) :
-        by { simp only [mul_inv_cancel this], simp }
-      ... = h^2 * (1+h)⁻¹ : by { generalize : (1+h)⁻¹ = y, ring } },
-  { convert univ_mem_sets, simp }
+    simp only [mem_set_of_eq, smul_eq_mul, inv_one],
+    field_simp [this, -add_comm],
+    ring },
+  { exact univ_mem_sets' mul_one }
 end
 
 theorem has_deriv_at_inv (x_ne_zero : x ≠ 0) :
   has_deriv_at (λy, y⁻¹) (-(x^2)⁻¹) x :=
 begin
   have A : has_deriv_at (λy, y⁻¹) (-1) (x⁻¹ * x : 𝕜),
-    by { simp [inv_mul_cancel x_ne_zero, has_deriv_at_inv_one] },
+    by { simp only [inv_mul_cancel x_ne_zero, has_deriv_at_inv_one] },
   have B : has_deriv_at (λy, x⁻¹ * y) (x⁻¹) x,
-    by { convert ((has_deriv_at_const x (x⁻¹)).mul (has_deriv_at_id x)), simp },
-  convert (has_deriv_at_const _ (x⁻¹)).mul (A.comp x B : _),
+    by simpa only [mul_one] using (has_deriv_at_id x).const_mul x⁻¹,
+  convert (A.comp x B : _).const_mul x⁻¹,
   { ext y,
-    have : x⁻¹ * (y⁻¹ * x) = y⁻¹,
-      by rw [← mul_assoc, mul_comm, ← mul_assoc, mul_inv_cancel x_ne_zero, one_mul],
-    simp [mul_inv', this] },
-  { simp [pow_two, mul_inv'] }
+    rw [function.comp_apply, mul_inv', inv_inv', mul_comm, mul_assoc, mul_inv_cancel x_ne_zero,
+      mul_one] },
+  { rw [pow_two, mul_inv', smul_eq_mul, mul_neg_one, neg_mul_eq_mul_neg] }
 end
 
 theorem has_deriv_within_at_inv (x_ne_zero : x ≠ 0) (s : set 𝕜) :

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -175,7 +175,7 @@ begin
     this.comp_tendsto tendsto_arg,
   have : is_o (λ n, f (x + d n) - f x - f' (d n)) d l := by simpa only [add_sub_cancel'],
   have : is_o (λn, c n • (f (x + d n) - f x - f' (d n))) (λn, c n • d n) l :=
-    this.smul_same_left c,
+    (is_O_refl c l).smul_is_o this,
   have : is_o (λn, c n • (f (x + d n) - f x - f' (d n))) (λn, (1:ℝ)) l :=
     this.trans_is_O (is_O_one_of_tendsto ℝ cdlim),
   have L1 : tendsto (λn, c n • (f (x + d n) - f x - f' (d n))) l (𝓝 0) :=
@@ -1170,8 +1170,7 @@ begin
     ... = C * (∥x-p∥ * ∥x-p∥) : mul_assoc _ _ _ end)⟩,
   have B : asymptotics.is_o (λ (x : E × F), ∥x - p∥ * ∥x - p∥)
     (λx, 1 * ∥x - p∥) (𝓝 p),
-  { apply asymptotics.is_o.mul_same_right,
-    apply asymptotics.is_o.norm_left,
+  { refine asymptotics.is_o.mul_is_O (asymptotics.is_o.norm_left _) (asymptotics.is_O_refl _ _),
     apply (asymptotics.is_o_one_iff ℝ).2,
     rw [← sub_self p],
     exact tendsto_id.sub tendsto_const_nhds },

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -164,25 +164,22 @@ theorem has_fderiv_within_at.lim (h : has_fderiv_within_at f f' s x) {α : Type*
   (cdlim : tendsto (λ n, c n • d n) l (𝓝 v)) :
   tendsto (λn, c n • (f (x + d n) - f x)) l (𝓝 (f' v)) :=
 begin
-  have at_top_is_finer : l ≤ comap (λ n, x + d n) (nhds_within x s),
+  have tendsto_arg : tendsto (λ n, x + d n) l (nhds_within x s),
   { conv in (nhds_within x s) { rw ← add_zero x },
-    rw [← tendsto_iff_comap, nhds_within, tendsto_inf],
+    rw [nhds_within, tendsto_inf],
     split,
     { apply tendsto_const_nhds.add (tangent_cone_at.lim_zero l clim cdlim) },
     { rwa tendsto_principal } },
   have : is_o (λ y, f y - f x - f' (y - x)) (λ y, y - x) (nhds_within x s) := h,
-  have : is_o (λ n, f (x + d n) - f x - f' ((x + d n) - x)) (λ n, (x + d n)  - x)
-    ((nhds_within x s).comap (λn, x+ d n)) := is_o.comp this _,
-  have : is_o (λ n, f (x + d n) - f x - f' (d n)) d
-    ((nhds_within x s).comap (λn, x + d n)) := by simpa,
-  have : is_o (λn, f (x + d n) - f x - f' (d n)) d l :=
-    is_o.mono at_top_is_finer this,
+  have : is_o (λ n, f (x + d n) - f x - f' ((x + d n) - x)) (λ n, (x + d n)  - x) l :=
+    this.comp_tendsto tendsto_arg,
+  have : is_o (λ n, f (x + d n) - f x - f' (d n)) d l := by simpa only [add_sub_cancel'],
   have : is_o (λn, c n • (f (x + d n) - f x - f' (d n))) (λn, c n • d n) l :=
-    is_o_smul this,
+    this.smul_same_left c,
   have : is_o (λn, c n • (f (x + d n) - f x - f' (d n))) (λn, (1:ℝ)) l :=
-    this.trans_is_O (is_O_one_of_tendsto cdlim),
+    this.trans_is_O (is_O_one_of_tendsto ℝ cdlim),
   have L1 : tendsto (λn, c n • (f (x + d n) - f x - f' (d n))) l (𝓝 0) :=
-    is_o_one_iff.1 this,
+    (is_o_one_iff ℝ).1 this,
   have L2 : tendsto (λn, f' (c n • d n)) l (𝓝 (f' v)) :=
     tendsto.comp f'.cont.continuous_at cdlim,
   have L3 : tendsto (λn, (c n • (f (x + d n) - f x - f' (d n)) +  f' (c n • d n)))
@@ -254,22 +251,22 @@ theorem has_fderiv_at_iff_is_o_nhds_zero : has_fderiv_at f f' x ↔
 begin
   split,
   { assume H,
-    have : 𝓝 0 ≤ comap (λ (z : E), z + x) (𝓝 (0 + x)),
-    { refine tendsto_iff_comap.mp _,
-      exact (continuous_id.add continuous_const).tendsto _ },
-    apply is_o.mono this,
-    convert is_o.comp H (λz, z + x) ; { try {ext}, simp } },
+    have : tendsto (λ (z : E), z + x) (𝓝 0) (𝓝 (0 + x)),
+      from tendsto_id.add tendsto_const_nhds,
+    rw [zero_add] at this,
+    refine (H.comp_tendsto this).congr _ _;
+      intro z; simp only [function.comp, add_sub_cancel', add_comm z] },
   { assume H,
-    have : 𝓝 x ≤ comap (λ (z : E), z - x) (𝓝 (x - x)),
-    { refine tendsto_iff_comap.mp _,
-      exact (continuous_id.add continuous_const).tendsto _ },
-    apply is_o.mono this,
-    convert is_o.comp H (λz, z - x) ; { try {ext}, simp } }
+    have : tendsto (λ (z : E), z - x) (𝓝 x) (𝓝 (x - x)),
+      from tendsto_id.sub tendsto_const_nhds,
+    rw [sub_self] at this,
+    refine (H.comp_tendsto this).congr _ _;
+      intro z; simp only [function.comp, add_sub_cancel'_right] }
 end
 
 theorem has_fderiv_at_filter.mono (h : has_fderiv_at_filter f f' x L₂) (hst : L₁ ≤ L₂) :
   has_fderiv_at_filter f f' x L₁ :=
-is_o.mono hst h
+h.mono hst
 
 theorem has_fderiv_within_at.mono (h : has_fderiv_within_at f f' t x) (hst : s ⊆ t) :
   has_fderiv_within_at f f' s x :=
@@ -327,7 +324,7 @@ lemma has_fderiv_within_at.union (hs : has_fderiv_within_at f f' s x) (ht : has_
   has_fderiv_within_at f f' (s ∪ t) x :=
 begin
   simp only [has_fderiv_within_at, nhds_within_union],
-  exact is_o_join hs ht,
+  exact hs.join ht,
 end
 
 lemma has_fderiv_within_at.nhds_within (h : has_fderiv_within_at f f' s x)
@@ -370,7 +367,7 @@ lemma has_fderiv_within_at_of_not_mem_closure (h : x ∉ closure s) :
   has_fderiv_within_at f f' s x :=
 begin
   simp [mem_closure_iff_nhds_within_ne_bot] at h,
-  simp [has_fderiv_within_at, has_fderiv_at_filter, h, is_o]
+  simp [has_fderiv_within_at, has_fderiv_at_filter, h, is_o, is_O_with],
 end
 
 lemma differentiable_within_at.mono (h : differentiable_within_at 𝕜 f t x) (st : s ⊆ t) :
@@ -1008,7 +1005,7 @@ lemma fderiv_sub
 
 theorem has_fderiv_at_filter.is_O_sub (h : has_fderiv_at_filter f f' x L) :
 is_O (λ x', f x' - f x) (λ x', x' - x) L :=
-h.to_is_O.congr_of_sub.2 (f'.is_O_sub _ _)
+h.is_O.congr_of_sub.2 (f'.is_O_sub _ _)
 
 theorem has_fderiv_at_filter.sub_const
   (hf : has_fderiv_at_filter f f' x L) (c : F) :
@@ -1165,7 +1162,7 @@ begin
   rcases h.bound with ⟨C, Cpos, hC⟩,
   have A : asymptotics.is_O (λx : E × F, b (x.1 - p.1, x.2 - p.2))
     (λx, ∥x - p∥ * ∥x - p∥) (𝓝 p) :=
-  ⟨C, Cpos, filter.univ_mem_sets' (λx, begin
+  ⟨C, filter.univ_mem_sets' (λx, begin
     simp only [mem_set_of_eq, norm_mul, norm_norm],
     calc ∥b (x.1 - p.1, x.2 - p.2)∥ ≤ C * ∥x.1 - p.1∥ * ∥x.2 - p.2∥ : hC _ _
     ... ≤ C * ∥x-p∥ * ∥x-p∥ : by apply_rules [mul_le_mul, le_max_left, le_max_right, norm_nonneg,
@@ -1173,15 +1170,11 @@ begin
     ... = C * (∥x-p∥ * ∥x-p∥) : mul_assoc _ _ _ end)⟩,
   have B : asymptotics.is_o (λ (x : E × F), ∥x - p∥ * ∥x - p∥)
     (λx, 1 * ∥x - p∥) (𝓝 p),
-  { apply asymptotics.is_o_mul_right _ (asymptotics.is_O_refl _ _),
-    rw [asymptotics.is_o_iff_tendsto],
-    { simp only [div_one],
-      have : 0 = ∥p - p∥, by simp,
-      rw this,
-      have : continuous (λx, ∥x-p∥) :=
-        continuous_norm.comp (continuous_id.sub continuous_const),
-      exact this.tendsto p },
-    simp only [forall_prop_of_false, not_false_iff, one_ne_zero, forall_true_iff] },
+  { apply asymptotics.is_o.mul_same_right,
+    apply asymptotics.is_o.norm_left,
+    apply (asymptotics.is_o_one_iff ℝ).2,
+    rw [← sub_self p],
+    exact tendsto_id.sub tendsto_const_nhds },
   simp only [one_mul, asymptotics.is_o_norm_right] at B,
   exact A.trans_is_o B
 end
@@ -1305,8 +1298,8 @@ theorem has_fderiv_at_filter.comp {g : F → G} {g' : F →L[𝕜] G}
   (hf : has_fderiv_at_filter f f' x L) :
   has_fderiv_at_filter (g ∘ f) (g'.comp f') x L :=
 let eq₁ := (g'.is_O_comp _ _).trans_is_o hf in
-let eq₂ := ((hg.comp f).mono le_comap_map).trans_is_O hf.is_O_sub in
-by { refine eq₂.tri (eq₁.congr_left (λ x', _)), simp }
+let eq₂ := (hg.comp_tendsto tendsto_map).trans_is_O hf.is_O_sub in
+by { refine eq₂.triangle (eq₁.congr_left (λ x', _)), simp }
 
 /- A readable version of the previous theorem,
    a general form of the chain rule. -/
@@ -1318,7 +1311,7 @@ example {g : F → G} {g' : F →L[𝕜] G}
 begin
   unfold has_fderiv_at_filter at hg,
   have : is_o (λ x', g (f x') - g (f x) - g' (f x' - f x)) (λ x', f x' - f x) L,
-    from (hg.comp f).mono le_comap_map,
+    from hg.comp_tendsto (le_refl _),
   have eq₁ : is_o (λ x', g (f x') - g (f x) - g' (f x' - f x)) (λ x', x' - x) L,
     from this.trans_is_O hf.is_O_sub,
   have eq₂ : is_o (λ x', f x' - f x - f' (x' - x)) (λ x', x' - x) L,
@@ -1330,7 +1323,7 @@ begin
     from this.trans_is_o eq₂,
   have eq₃ : is_o (λ x', g' (f x' - f x) - (g' (f' (x' - x)))) (λ x', x' - x) L,
     by { refine this.congr_left _, simp},
-  exact eq₁.tri eq₃
+  exact eq₁.triangle eq₃
 end
 
 theorem has_fderiv_within_at.comp {g : F → G} {g' : F →L[𝕜] G} {t : set F}

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -83,7 +83,7 @@ begin
     have : is_o (λ x, h x) (λ x, x - k) (nhds_within k (Icc 0 1)) :=
       (hf k k_mem_K.1).has_deriv_within_at,
     have : {x | ∥h x∥ ≤ (D-C) * ∥x-k∥} ∈ nhds_within k (Icc 0 1) :=
-      this (D-C) (sub_pos_of_lt hD),
+      this (sub_pos_of_lt hD),
     rcases mem_nhds_within.1 this with ⟨s, s_open, ks, hs⟩,
     rcases is_open_iff.1 s_open k ks with ⟨ε, εpos, hε⟩,
     change 0 < ε at εpos,

--- a/src/analysis/complex/exponential.lean
+++ b/src/analysis/complex/exponential.lean
@@ -48,9 +48,8 @@ lemma has_deriv_at_exp (x : ℂ) : has_deriv_at exp (exp x) x :=
 begin
   rw has_deriv_at_iff_is_o_nhds_zero,
   have : (1 : ℕ) < 2 := by norm_num,
-  refine is_O.trans_is_o (is_O_iff.2 ⟨∥exp x∥, _⟩) (is_o_pow_id this),
-  have : metric.ball (0 : ℂ) 1 ∈ nhds (0 : ℂ) :=
-    mem_nhds_sets metric.is_open_ball (by simp [zero_lt_one]),
+  refine is_O.trans_is_o ⟨∥exp x∥, _⟩ (is_o_pow_id this),
+  have : metric.ball (0 : ℂ) 1 ∈ nhds (0 : ℂ) := metric.ball_mem_nhds 0 zero_lt_one,
   apply filter.mem_sets_of_superset this (λz hz, _),
   simp only [metric.mem_ball, dist_zero_right] at hz,
   simp only [exp_zero, mul_one, one_mul, add_comm, normed_field.norm_pow,

--- a/src/analysis/normed_space/bounded_linear_maps.lean
+++ b/src/analysis/normed_space/bounded_linear_maps.lean
@@ -134,11 +134,11 @@ open asymptotics filter
 theorem is_O_id {f : E → F} (h : is_bounded_linear_map 𝕜 f) (l : filter E) :
   is_O f (λ x, x) l :=
 let ⟨M, hMp, hM⟩ := h.bound in
-⟨M, hMp, mem_sets_of_superset univ_mem_sets (λ x _, hM x)⟩
+⟨M, mem_sets_of_superset univ_mem_sets (λ x _, hM x)⟩
 
 theorem is_O_comp {E : Type*} {g : F → G} (hg : is_bounded_linear_map 𝕜 g)
   {f : E → F} (l : filter E) : is_O (λ x', g (f x')) f l :=
-((hg.is_O_id ⊤).comp _).mono (map_le_iff_le_comap.mp lattice.le_top)
+(hg.is_O_id ⊤).comp_tendsto lattice.le_top
 
 theorem is_O_sub {f : E → F} (h : is_bounded_linear_map 𝕜 f)
   (l : filter E) (x : E) : is_O (λ x', f (x' - x)) (λ x', x' - x) l :=

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -158,16 +158,15 @@ section
 open asymptotics filter
 
 theorem is_O_id (l : filter E) : is_O f (λ x, x) l :=
-let ⟨M, hMp, hM⟩ := f.bound in
-⟨M, hMp, mem_sets_of_superset univ_mem_sets (λ x _, hM x)⟩
+let ⟨M, hMp, hM⟩ := f.bound in is_O_of_le' l hM
 
 theorem is_O_comp {E : Type*} (g : F →L[𝕜] G) (f : E → F) (l : filter E) :
   is_O (λ x', g (f x')) f l :=
-((g.is_O_id ⊤).comp _).mono (map_le_iff_le_comap.mp lattice.le_top)
+(g.is_O_id ⊤).comp_tendsto lattice.le_top
 
 theorem is_O_sub (f : E →L[𝕜] F) (l : filter E) (x : E) :
   is_O (λ x', f (x' - x)) (λ x', x' - x) l :=
-is_O_comp f _ l
+f.is_O_comp _ l
 
 end
 


### PR DESCRIPTION
I use it to factor out common parts of the proofs of facts about
`is_O` and `is_o`. It can also be used with `principal s` filter to
operate with `∀ x ∈ s, ∥f x∥ ≤ C * ∥g x∥` is a manner similar to `is_O`.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)