### PR TITLE
feat(measure_theory/set_integral): integrals over subsets

### DIFF
--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -2272,3 +2272,28 @@ by { rw [antidiagonal, multiset.nat.antidiagonal_zero], refl }
 end nat
 
 end finset
+
+namespace finset
+
+/- bUnion -/
+
+variables [decidable_eq α]
+
+@[simp] theorem bUnion_singleton (a : α) (s : α → set β) : (⋃ x ∈ ({a} : finset α), s x) = s a :=
+supr_singleton
+
+@[simp] theorem supr_union {α} [complete_lattice α] {β} [decidable_eq β] {f : β → α} {s t : finset β} :
+  (⨆ x ∈ s ∪ t, f x) = (⨆x∈s, f x) ⊔ (⨆x∈t, f x) :=
+calc (⨆ x ∈ s ∪ t, f x) = (⨆ x, (⨆h : x∈s, f x) ⊔ (⨆h : x∈t, f x)) :
+  congr_arg _ $ funext $ λ x, by { convert supr_or, rw finset.mem_union, rw finset.mem_union, refl, refl }
+                    ... = (⨆x∈s, f x) ⊔ (⨆x∈t, f x) : supr_sup_eq
+
+lemma bUnion_union (s t : finset α) (u : α → set β) :
+  (⋃ x ∈ s ∪ t, u x) = (⋃ x ∈ s, u x) ∪ (⋃ x ∈ t, u x) :=
+supr_union
+
+@[simp] lemma bUnion_insert (a : α) (s : finset α) (t : α → set β) :
+  (⋃ x ∈ insert a s, t x) = t a ∪ (⋃ x ∈ s, t x) :=
+begin rw insert_eq, simp only [bUnion_union, finset.bUnion_singleton] end
+
+end finset

--- a/src/data/indicator_function.lean
+++ b/src/data/indicator_function.lean
@@ -128,8 +128,6 @@ begin
   exact indicator_zero _ _
 end
 
-variables [decidable_eq α]
-
 lemma indicator_finset_bUnion {β} [add_comm_monoid β] {ι} (I : finset ι)
   (s : ι → set α) {f : α → β} : (∀ (i ∈ I) (j ∈ I), i ≠ j → s i ∩ s j = ∅) →
   indicator (⋃ i ∈ I, s i) f = λ a, I.sum (λ i, indicator (s i) f a) :=

--- a/src/data/indicator_function.lean
+++ b/src/data/indicator_function.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2020 Zhouhang Zhou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zhouhang Zhou
+-/
+
+import data.set group_theory.group_action
+
+/-!
+# Indicator function
+
+`indicator (s : set α) (f : α → β) (a : α)` is `f a` if `a ∈ s` and is `0` otherwise.
+
+## Implementation note
+
+In mathematics, an indicator function or a characteristic function is a function used to indicate
+membership of an element in a set `s`, having the value `1` for all elements of `s` and the value  `0`
+otherwise. But since it is usually used to restrict a function to a certain set `s`, we let the
+indicator function take the value `f x` for some function `f`, instead of `1`. If the usual indicator
+function is needed, just set `f` to be the constant function `λx, 1`.
+
+## Tags
+indicator, characteristic
+-/
+
+noncomputable theory
+open_locale classical
+
+open set
+
+universes u v
+variables {α : Type u} {β : Type v}
+
+section has_zero
+variables [has_zero β] {s t : set α} {f g : α → β} {a : α}
+
+/-- `indicator s f a` is `f a` if `a ∈ s`, `0` otherwise.  -/
+@[reducible]
+def indicator (s : set α) (f : α → β) : α → β := λ x, if x ∈ s then f x else 0
+
+@[simp] lemma indicator_of_mem (h : a ∈ s) (f : α → β) : indicator s f a = f a := if_pos h
+
+@[simp] lemma indicator_of_not_mem (h : a ∉ s) (f : α → β) : indicator s f a = 0 := if_neg h
+
+lemma indicator_congr (h : ∀ a ∈ s, f a = g a) : indicator s f = indicator s g :=
+funext $ λx, by { simp only [indicator], split_ifs, { exact h _ h_1 }, refl }
+
+@[simp] lemma indicator_univ (f : α → β) : indicator (univ : set α) f = f :=
+funext $ λx, indicator_of_mem (mem_univ _) f
+
+@[simp] lemma indicator_empty (f : α → β) : indicator (∅ : set α) f = λa, 0 :=
+funext $ λx, indicator_of_not_mem (not_mem_empty _) f
+
+variable (β)
+@[simp] lemma indicator_zero (s : set α) : indicator s (λx, (0:β)) = λx, (0:β) :=
+funext $ λx, by { simp only [indicator], split_ifs, refl, refl }
+variable {β}
+
+lemma indicator_indicator (s t : set α) (f : α → β) : indicator s (indicator t f) = indicator (s ∩ t) f :=
+funext $ λx, by { simp only [indicator], split_ifs, repeat {simp * at * {contextual := tt}} }
+
+lemma indicator_preimage (s : set α) (f : α → β) (B : set β) :
+  (indicator s f)⁻¹' B = s ∩ f ⁻¹' B ∪ (-s) ∩ (λa:α, (0:β)) ⁻¹' B :=
+by { rw [indicator, if_preimage] }
+
+end has_zero
+
+section has_add
+variables [add_monoid β] {s t : set α} {f g : α → β} {a : α}
+
+lemma indicator_union_of_not_mem_inter (h : a ∉ s ∩ t) (f : α → β) :
+  indicator (s ∪ t) f a = indicator s f a + indicator t f a :=
+by { simp only [indicator], split_ifs, repeat {simp * at * {contextual := tt}} }
+
+lemma indicator_union_of_disjoint (h : disjoint s t) (f : α → β) :
+  indicator (s ∪ t) f = λa, indicator s f a + indicator t f a :=
+funext $ λa, indicator_union_of_not_mem_inter
+  (by { convert not_mem_empty a, have := disjoint.eq_bot h, assumption })
+  _
+
+lemma indicator_add (s : set α) (f g : α → β) :
+  indicator s (λa, f a + g a) = λa, indicator s f a + indicator s g a :=
+by { funext, simp only [indicator], split_ifs, { refl }, rw add_zero }
+
+lemma indicator_smul {𝕜 : Type*} [monoid 𝕜] [distrib_mul_action 𝕜 β] (s : set α) (r : 𝕜) (f : α → β) :
+  indicator s (λ (x : α), r • f x) = λ (x : α), r • indicator s f x :=
+by { simp only [indicator], funext, split_ifs, refl, exact (smul_zero r).symm }
+
+lemma indicator_neg {β : Type*} [add_group β] (s : set α) (f : α → β) :
+  indicator s (λa, - f a) = λa, - indicator s f a :=
+by { funext, simp only [indicator], split_ifs, { refl }, rw neg_zero }
+
+lemma indicator_sub {β : Type*} [add_group β] (s : set α) (f g : α → β) :
+  indicator s (λa, f a - g a) = λa, indicator s f a - indicator s g a :=
+by { funext, simp only [indicator], split_ifs, { refl }, rw sub_zero }
+
+end has_add
+
+section order
+variables [has_zero β] [preorder β] {s t : set α} {f g : α → β} {a : α}
+
+lemma indicator_le_indicator (h : f a ≤ g a) : indicator s f a ≤ indicator s g a :=
+by { simp only [indicator], split_ifs with ha, { exact h }, refl }
+
+lemma indicator_le_indicator_of_subset (h : s ⊆ t) (hf : ∀a, 0 ≤ f a) (a : α) :
+  indicator s f a ≤ indicator t f a :=
+begin
+  simp only [indicator],
+  split_ifs,
+  { refl },
+  { have := h h_1, contradiction },
+  { exact hf a },
+  { refl }
+end
+
+end order

--- a/src/data/indicator_function.lean
+++ b/src/data/indicator_function.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhouhang Zhou
 -/
 
-import data.set group_theory.group_action
+import data.set group_theory.group_action algebra.pi_instances
 
 /-!
 # Indicator function
@@ -65,7 +65,7 @@ by { rw [indicator, if_preimage] }
 
 end has_zero
 
-section has_add
+section add_monoid
 variables [add_monoid β] {s t : set α} {f g : α → β} {a : α}
 
 lemma indicator_union_of_not_mem_inter (h : a ∉ s ∩ t) (f : α → β) :
@@ -82,19 +82,53 @@ lemma indicator_add (s : set α) (f g : α → β) :
   indicator s (λa, f a + g a) = λa, indicator s f a + indicator s g a :=
 by { funext, simp only [indicator], split_ifs, { refl }, rw add_zero }
 
-lemma indicator_smul {𝕜 : Type*} [monoid 𝕜] [distrib_mul_action 𝕜 β] (s : set α) (r : 𝕜) (f : α → β) :
+variables (β)
+instance is_add_monoid_hom.indicator (s : set α) : is_add_monoid_hom (λf:α → β, indicator s f) :=
+{ map_add := λ _ _, indicator_add _ _ _,
+  map_zero := indicator_zero _ _ }
+
+variables {β} {𝕜 : Type*} [monoid 𝕜] [distrib_mul_action 𝕜 β]
+
+lemma indicator_smul (s : set α) (r : 𝕜) (f : α → β) :
   indicator s (λ (x : α), r • f x) = λ (x : α), r • indicator s f x :=
 by { simp only [indicator], funext, split_ifs, refl, exact (smul_zero r).symm }
 
-lemma indicator_neg {β : Type*} [add_group β] (s : set α) (f : α → β) :
-  indicator s (λa, - f a) = λa, - indicator s f a :=
-by { funext, simp only [indicator], split_ifs, { refl }, rw neg_zero }
+end add_monoid
 
-lemma indicator_sub {β : Type*} [add_group β] (s : set α) (f g : α → β) :
+section add_group
+variables [add_group β] {s t : set α} {f g : α → β} {a : α}
+
+variables (β)
+instance is_add_group_hom.indicator (s : set α) : is_add_group_hom (λf:α → β, indicator s f) :=
+{ .. is_add_monoid_hom.indicator β s }
+variables {β}
+
+lemma indicator_neg (s : set α) (f : α → β) : indicator s (λa, - f a) = λa, - indicator s f a :=
+show indicator s (- f) = - indicator s f, from is_add_group_hom.map_neg _ _
+
+lemma indicator_sub (s : set α) (f g : α → β) :
   indicator s (λa, f a - g a) = λa, indicator s f a - indicator s g a :=
-by { funext, simp only [indicator], split_ifs, { refl }, rw sub_zero }
+show indicator s (f - g) = indicator s f - indicator s g, from is_add_group_hom.map_sub _ _ _
 
-end has_add
+lemma indicator_compl (s : set α) (f : α → β) : indicator (-s) f = λ a, f a - indicator s f a :=
+begin
+  funext,
+  simp only [indicator],
+  split_ifs with h₁ h₂,
+  { rw sub_zero },
+  { rw sub_self },
+  { rw ← mem_compl_iff at h₂, contradiction }
+end
+
+lemma indicator_sum {β} [add_comm_monoid β] {ι : Type*} (I : finset ι) (s : set α) (f : ι → α → β) :
+  indicator s (I.sum f) = I.sum (λ i, indicator s (f i)) :=
+begin
+  convert (finset.sum_hom _ _).symm,
+  split,
+  exact indicator_zero _ _
+end
+
+end add_group
 
 section order
 variables [has_zero β] [preorder β] {s t : set α} {f g : α → β} {a : α}
@@ -106,9 +140,9 @@ lemma indicator_le_indicator_of_subset (h : s ⊆ t) (hf : ∀a, 0 ≤ f a) (a :
   indicator s f a ≤ indicator t f a :=
 begin
   simp only [indicator],
-  split_ifs,
+  split_ifs with h₁,
   { refl },
-  { have := h h_1, contradiction },
+  { have := h h₁, contradiction },
   { exact hf a },
   { refl }
 end

--- a/src/data/indicator_function.lean
+++ b/src/data/indicator_function.lean
@@ -14,7 +14,7 @@ import data.set group_theory.group_action algebra.pi_instances
 ## Implementation note
 
 In mathematics, an indicator function or a characteristic function is a function used to indicate
-membership of an element in a set `s`, having the value `1` for all elements of `s` and the value  `0`
+membership of an element in a set `s`, having the value `1` for all elements of `s` and the value `0`
 otherwise. But since it is usually used to restrict a function to a certain set `s`, we let the
 indicator function take the value `f x` for some function `f`, instead of `1`. If the usual indicator
 function is needed, just set `f` to be the constant function `λx, 1`.

--- a/src/data/indicator_function.lean
+++ b/src/data/indicator_function.lean
@@ -26,7 +26,7 @@ indicator, characteristic
 noncomputable theory
 open_locale classical
 
-open set
+namespace set
 
 universes u v
 variables {α : Type u} {β : Type v}
@@ -148,3 +148,5 @@ begin
 end
 
 end order
+
+end set

--- a/src/data/indicator_function.lean
+++ b/src/data/indicator_function.lean
@@ -130,7 +130,7 @@ end
 
 variables [decidable_eq α]
 
-lemma indicator_finset_Union {β} [add_comm_monoid β] {ι} (I : finset ι)
+lemma indicator_finset_bUnion {β} [add_comm_monoid β] {ι} (I : finset ι)
   (s : ι → set α) {f : α → β} : (∀ (i ∈ I) (j ∈ I), i ≠ j → s i ∩ s j = ∅) →
   indicator (⋃ i ∈ I, s i) f = λ a, I.sum (λ i, indicator (s i) f a) :=
 begin

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -871,6 +871,15 @@ theorem eq_preimage_subtype_val_iff {p : α → Prop} {s : set (subtype p)} {t :
 ⟨assume s_eq x h, by rw [s_eq]; simp,
  assume h, ext $ assume ⟨x, hx⟩, by simp [h]⟩
 
+lemma if_preimage (p : α → Prop) [decidable_pred p] (f g : α → β) (s : set β) :
+  (λa, if p a then f a else g a)⁻¹' s = (p ∩ f ⁻¹' s) ∪ (-p ∩ g ⁻¹' s) :=
+begin
+  ext,
+  simp only [mem_inter_eq, mem_union_eq, mem_preimage],
+  split_ifs;
+  simp [mem_def, h]
+end
+
 end preimage
 
 /- function image -/

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -871,8 +871,8 @@ theorem eq_preimage_subtype_val_iff {p : α → Prop} {s : set (subtype p)} {t :
 ⟨assume s_eq x h, by rw [s_eq]; simp,
  assume h, ext $ assume ⟨x, hx⟩, by simp [h]⟩
 
-lemma if_preimage (p : α → Prop) [decidable_pred p] (f g : α → β) (s : set β) :
-  (λa, if p a then f a else g a)⁻¹' s = (p ∩ f ⁻¹' s) ∪ (-p ∩ g ⁻¹' s) :=
+lemma if_preimage (s : set α) [decidable_pred s] (f g : α → β) (t : set β) :
+  (λa, if a ∈ s then f a else g a)⁻¹' t = (s ∩ f ⁻¹' t) ∪ (-s ∩ g ⁻¹' t) :=
 begin
   ext,
   simp only [mem_inter_eq, mem_union_eq, mem_preimage],

--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -1106,7 +1106,7 @@ begin
   by_cases hfi : integrable f,
   { have hgi : integrable g := integrable_of_ae_eq hfi h,
     rw [integral_eq f hfm hfi, integral_eq g hgm hgi, (l1.of_fun_eq_of_fun f g hfm hfi hgm hgi).2 h] },
-  { have hgi : ¬ integrable g, { rw integrable_iff_of_ae_eq h at hfi, exact hfi },
+  { have hgi : ¬ integrable g, { rw integrable_congr_ae h at hfi, exact hfi },
     rw [integral_non_integrable hfi, integral_non_integrable hgi] },
 end
 

--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -445,7 +445,7 @@ protected def metric_space : metric_space (α →₁ₛ β) := subtype.metric_sp
 
 local attribute [instance] protected lemma is_add_subgroup : is_add_subgroup
   (λf:α →₁ β, ∃ (s : α →ₛ β), integrable s ∧ ae_eq_fun.mk s s.measurable = f) :=
-{ zero_mem := by { use 0, split, { exact integrable_zero }, { refl } },
+{ zero_mem := by { use 0, split, { apply integrable_zero }, { refl } },
   add_mem :=
   begin
     rintros f g ⟨s, hsi, hs⟩ ⟨t, hti, ht⟩,
@@ -551,7 +551,7 @@ lemma of_simple_func_eq_of_fun (f : α →ₛ β) (hf : integrable f) :
 lemma of_simple_func_eq_mk (f : α →ₛ β) (hf : integrable f) :
   (of_simple_func f hf : α →ₘ β) = ae_eq_fun.mk f f.measurable := rfl
 
-lemma of_simple_func_zero : of_simple_func (0 : α →ₛ β) integrable_zero = 0 := rfl
+lemma of_simple_func_zero : of_simple_func (0 : α →ₛ β) (integrable_zero α β) = 0 := rfl
 
 lemma of_simple_func_add (f g : α →ₛ β) (hf hg) :
   of_simple_func (f + g) (integrable.add f.measurable hf g.measurable hg) = of_simple_func f hf +
@@ -1299,6 +1299,18 @@ classical.by_cases
     rw [integral_non_measurable h, _root_.norm_zero],
     exact integral_nonneg_of_nonneg_ae le_ae
   end )
+
+lemma integral_finset_sum {ι} (s : finset ι) {f : ι → α → β}
+  (hfm : ∀ i, measurable (f i)) (hfi : ∀ i, integrable (f i)) :
+  (∫ a, s.sum (λ i, f i a)) = s.sum (λ i, ∫ a, f i a) :=
+begin
+  refine finset.induction_on s _ _,
+  { simp only [integral_zero, finset.sum_empty] },
+  { assume i s his ih,
+    simp only [his, finset.sum_insert, not_false_iff],
+    rw [integral_add (hfm _) (hfi _) (measurable_finset_sum s hfm)
+        (integrable_finset_sum s hfm hfi), ih] }
+end
 
 end properties
 

--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -1097,8 +1097,8 @@ integral_smul r f
 lemma integral_mul_right (r : ℝ) (f : α → ℝ) : (∫ a, (f a) * r) = (∫ a, f a) * r :=
 by { simp only [mul_comm], exact integral_mul_left r f }
 
-lemma integral_on_div (r : ℝ) (f : α → ℝ) : (∫ a, (f a) / r) = (∫ a, f a) / r :=
-by { simp only [div_eq_mul_inv], apply integral_mul_right }
+lemma integral_div (r : ℝ) (f : α → ℝ) : (∫ a, (f a) / r) = (∫ a, f a) / r :=
+integral_mul_right r⁻¹ f
 
 lemma integral_congr_ae (hfm : measurable f) (hgm : measurable g) (h : ∀ₘ a, f a = g a) :
    (∫ a, f a) = (∫ a, g a) :=
@@ -1286,7 +1286,7 @@ end
 
 lemma integral_le_integral {f g : α → ℝ} (hfm : measurable f) (hfi : integrable f)
   (hgm : measurable g) (hgi : integrable g) (h : ∀ a, f a ≤ g a) : (∫ a, f a) ≤ (∫ a, g a) :=
-integral_le_integral_ae hfm hfi hgm hgi $ by filter_upwards [] h
+integral_le_integral_ae hfm hfi hgm hgi $ univ_mem_sets' h
 
 lemma norm_integral_le_integral_norm (f : α → β) : ∥(∫ a, f a)∥ ≤ ∫ a, ∥f a∥ :=
 have le_ae : ∀ₘ (a : α), 0 ≤ ∥f a∥ := by filter_upwards [] λa, norm_nonneg _,

--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -1033,7 +1033,7 @@ if hf : measurable f ∧ integrable f
 then (l1.of_fun f hf.1 hf.2).integral
 else 0
 
-local notation `∫` binders `, ` r:(scoped f, integral f) := r
+notation `∫` binders `, ` r:(scoped f, integral f) := r
 
 section properties
 
@@ -1042,30 +1042,30 @@ open continuous_linear_map measure_theory.simple_func
 variables {f g : α → β}
 
 lemma integral_eq (f : α → β) (h₁ : measurable f) (h₂ : integrable f) :
-  integral f = (l1.of_fun f h₁ h₂).integral :=
+  (∫ a, f a) = (l1.of_fun f h₁ h₂).integral :=
 dif_pos ⟨h₁, h₂⟩
 
-lemma integral_undef (h : ¬ (measurable f ∧ integrable f)) : integral f = 0 :=
+lemma integral_undef (h : ¬ (measurable f ∧ integrable f)) : (∫ a, f a) = 0 :=
 dif_neg h
 
-lemma integral_non_integrable (h : ¬ integrable f) : integral f = 0 :=
+lemma integral_non_integrable (h : ¬ integrable f) : (∫ a, f a) = 0 :=
 integral_undef $ not_and_of_not_right _ h
 
-lemma integral_non_measurable (h : ¬ measurable f) : integral f = 0 :=
+lemma integral_non_measurable (h : ¬ measurable f) : (∫ a, f a) = 0 :=
 integral_undef $ not_and_of_not_left _ h
 
 variables (α β)
-@[simp] lemma integral_zero : integral (λ(a:α), (0:β)) = 0 :=
+@[simp] lemma integral_zero : (∫ a:α, (0:β)) = 0 :=
 by rw [integral_eq, l1.of_fun_zero, l1.integral_zero]
 
 variables {α β}
 
 lemma integral_add
   (hfm : measurable f) (hfi : integrable f) (hgm : measurable g) (hgi : integrable g) :
-  integral (λa, f a + g a) = integral f + integral g :=
+  (∫ a, f a + g a) = (∫ a, f a) + (∫ a, g a) :=
 by rw [integral_eq, integral_eq f hfm hfi, integral_eq g hgm hgi, l1.of_fun_add, l1.integral_add]
 
-lemma integral_neg (f : α → β) : integral (λa, -f a) = - integral f :=
+lemma integral_neg (f : α → β) : (∫ a, -f a) = - (∫ a, f a) :=
 begin
   by_cases hf : measurable f ∧ integrable f,
   { rw [integral_eq f hf.1 hf.2, integral_eq (λa, - f a) hf.1.neg hf.2.neg, l1.of_fun_neg,
@@ -1077,10 +1077,10 @@ end
 
 lemma integral_sub
   (hfm : measurable f) (hfi : integrable f) (hgm : measurable g) (hgi : integrable g) :
-  integral (λa, f a - g a) = integral f - integral g :=
+  (∫ a, f a - g a) = (∫ a, f a) - (∫ a, g a) :=
 by simp only [sub_eq_add_neg, integral_neg, integral_add, measurable_neg_iff, integrable_neg_iff, *]
 
-lemma integral_smul (r : ℝ) (f : α → β) : integral (λa, r • (f a)) = r • integral f :=
+lemma integral_smul (r : ℝ) (f : α → β) : (∫ a, r • (f a)) = r • (∫ a, f a) :=
 begin
   by_cases hf : measurable f ∧ integrable f,
   { rw [integral_eq f hf.1 hf.2, integral_eq (λa, r • (f a)), l1.of_fun_smul, l1.integral_smul] },
@@ -1091,17 +1091,17 @@ begin
     rw [integral_undef hf, integral_undef hf', smul_zero] }
 end
 
-lemma integral_mul_left (r : ℝ) (f : α → ℝ) : integral (λx, r * (f x)) = r * integral f :=
+lemma integral_mul_left (r : ℝ) (f : α → ℝ) : (∫ a, r * (f a)) = r * (∫ a, f a) :=
 integral_smul r f
 
-lemma integral_mul_right (r : ℝ) (f : α → ℝ) : integral (λx, (f x) * r) = integral f * r :=
+lemma integral_mul_right (r : ℝ) (f : α → ℝ) : (∫ a, (f a) * r) = (∫ a, f a) * r :=
 by { simp only [mul_comm], exact integral_mul_left r f }
 
-lemma integral_on_div (r : ℝ) (f : α → ℝ) : integral (λx, (f x) / r) = integral f / r :=
+lemma integral_on_div (r : ℝ) (f : α → ℝ) : (∫ a, (f a) / r) = (∫ a, f a) / r :=
 by { simp only [div_eq_mul_inv], apply integral_mul_right }
 
 lemma integral_congr_ae (hfm : measurable f) (hgm : measurable g) (h : ∀ₘ a, f a = g a) :
-   integral f = integral g :=
+   (∫ a, f a) = (∫ a, g a) :=
 begin
   by_cases hfi : integrable f,
   { have hgi : integrable g := integrable_of_ae_eq hfi h,
@@ -1111,7 +1111,7 @@ begin
 end
 
 lemma norm_integral_le_lintegral_norm (f : α → β) :
-  ∥integral f∥ ≤ ennreal.to_real (∫⁻ a, ennreal.of_real ∥f a∥) :=
+  ∥(∫ a, f a)∥ ≤ ennreal.to_real (∫⁻ a, ennreal.of_real ∥f a∥) :=
 begin
   by_cases hf : measurable f ∧ integrable f,
   { rw [integral_eq f hf.1 hf.2, ← l1.norm_of_fun_eq_lintegral_norm f hf.1 hf.2],
@@ -1128,7 +1128,7 @@ theorem tendsto_integral_of_dominated_convergence {F : ℕ → α → β} {f : �
   (bound_integrable : integrable bound)
   (h_bound : ∀ n, ∀ₘ a, ∥F n a∥ ≤ bound a)
   (h_lim : ∀ₘ a, tendsto (λ n, F n a) at_top (𝓝 (f a))) :
-  tendsto (λn, ∫ a, F n a) at_top (𝓝 $ integral f) :=
+  tendsto (λn, ∫ a, F n a) at_top (𝓝 $ (∫ a, f a)) :=
 begin
   /- To show `(∫ a, F n a) --> (∫ f)`, suffices to show `∥∫ a, F n a - ∫ f∥ --> 0` -/
   rw tendsto_iff_norm_tendsto_zero,
@@ -1158,7 +1158,7 @@ end
 /-- The Bochner integral of a real-valued function `f : α → ℝ` is the difference between the
   integral of the positive part of `f` and the integral of the negative part of `f`.  -/
 lemma integral_eq_lintegral_max_sub_lintegral_min {f : α → ℝ}
-  (hfm : measurable f) (hfi : integrable f) : integral f =
+  (hfm : measurable f) (hfi : integrable f) : (∫ a, f a) =
   ennreal.to_real (∫⁻ a, ennreal.of_real $ max (f a) 0) -
   ennreal.to_real (∫⁻ a, ennreal.of_real $ - min (f a) 0) :=
 let f₁ : α →₁ ℝ := l1.of_fun f hfm hfi in
@@ -1194,7 +1194,7 @@ begin
 end
 
 lemma integral_eq_lintegral_of_nonneg_ae {f : α → ℝ} (hf : ∀ₘ a, 0 ≤ f a) (hfm : measurable f) :
-  integral f = ennreal.to_real (∫⁻ a, ennreal.of_real $ f a) :=
+  (∫ a, f a) = ennreal.to_real (∫⁻ a, ennreal.of_real $ f a) :=
 begin
   by_cases hfi : integrable f,
   { rw integral_eq_lintegral_max_sub_lintegral_min hfm hfi,
@@ -1224,23 +1224,23 @@ begin
     rw [this, hfi], refl }
 end
 
-lemma integral_nonneg_of_nonneg_ae {f : α → ℝ} (hf : ∀ₘ a, 0 ≤ f a) : 0 ≤ integral f :=
+lemma integral_nonneg_of_nonneg_ae {f : α → ℝ} (hf : ∀ₘ a, 0 ≤ f a) : 0 ≤ (∫ a, f a) :=
 begin
   by_cases hfm : measurable f,
   { rw integral_eq_lintegral_of_nonneg_ae hf hfm, exact to_real_nonneg },
   { rw integral_non_measurable hfm }
 end
 
-lemma integral_nonpos_of_nonpos_ae {f : α → ℝ} (hf : ∀ₘ a, f a ≤ 0) : integral f ≤ 0 :=
+lemma integral_nonpos_of_nonpos_ae {f : α → ℝ} (hf : ∀ₘ a, f a ≤ 0) : (∫ a, f a) ≤ 0 :=
 begin
   have hf : ∀ₘ a, 0 ≤ (-f) a,
   { filter_upwards [hf], simp only [mem_set_of_eq], assume a h, rwa [pi.neg_apply, neg_nonneg] },
-  have : 0 ≤ integral (λa, -f a) := integral_nonneg_of_nonneg_ae hf,
+  have : 0 ≤ (∫ a, -f a) := integral_nonneg_of_nonneg_ae hf,
   rwa [integral_neg, neg_nonneg] at this,
 end
 
 lemma integral_le_integral_ae {f g : α → ℝ} (hfm : measurable f) (hfi : integrable f)
-  (hgm : measurable g) (hgi : integrable g) (h : ∀ₘ a, f a ≤ g a) : integral f ≤ integral g :=
+  (hgm : measurable g) (hgi : integrable g) (h : ∀ₘ a, f a ≤ g a) : (∫ a, f a) ≤ (∫ a, g a) :=
 le_of_sub_nonneg
 begin
   rw ← integral_sub hgm hgi hfm hfi,
@@ -1252,14 +1252,14 @@ begin
 end
 
 lemma integral_le_integral {f g : α → ℝ} (hfm : measurable f) (hfi : integrable f)
-  (hgm : measurable g) (hgi : integrable g) (h : ∀ a, f a ≤ g a) : integral f ≤ integral g :=
+  (hgm : measurable g) (hgi : integrable g) (h : ∀ a, f a ≤ g a) : (∫ a, f a) ≤ (∫ a, g a) :=
 integral_le_integral_ae hfm hfi hgm hgi $ by filter_upwards [] h
 
-lemma norm_integral_le_integral_norm (f : α → β) : ∥integral f∥ ≤ ∫ a, ∥f a∥ :=
+lemma norm_integral_le_integral_norm (f : α → β) : ∥(∫ a, f a)∥ ≤ ∫ a, ∥f a∥ :=
 have le_ae : ∀ₘ (a : α), 0 ≤ ∥f a∥ := by filter_upwards [] λa, norm_nonneg _,
 classical.by_cases
 ( λh : measurable f,
-  calc ∥integral f∥ ≤ ennreal.to_real (∫⁻ a, ennreal.of_real ∥f a∥) : norm_integral_le_lintegral_norm _
+  calc ∥(∫ a, f a)∥ ≤ ennreal.to_real (∫⁻ a, ennreal.of_real ∥f a∥) : norm_integral_le_lintegral_norm _
     ... = ∫ a, ∥f a∥ : (integral_eq_lintegral_of_nonneg_ae le_ae $ measurable.norm h).symm )
 ( λh : ¬measurable f,
   begin

--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -450,7 +450,7 @@ local attribute [instance] protected lemma is_add_subgroup : is_add_subgroup
   begin
     rintros f g ⟨s, hsi, hs⟩ ⟨t, hti, ht⟩,
     use s + t, split,
-    { exact integrable.add s.measurable t.measurable hsi hti },
+    { exact hsi.add s.measurable t.measurable hti },
     { rw [coe_add, ← hs, ← ht], refl }
   end,
   neg_mem :=
@@ -554,14 +554,14 @@ lemma of_simple_func_eq_mk (f : α →ₛ β) (hf : integrable f) :
 lemma of_simple_func_zero : of_simple_func (0 : α →ₛ β) integrable_zero = 0 := rfl
 
 lemma of_simple_func_add (f g : α →ₛ β) (hf hg) :
-  of_simple_func (f + g) (integrable.add f.measurable g.measurable hf hg) = of_simple_func f hf +
+  of_simple_func (f + g) (integrable.add f.measurable hf g.measurable hg) = of_simple_func f hf +
     of_simple_func g hg := rfl
 
 lemma of_simple_func_neg (f : α →ₛ β) (hf) :
   of_simple_func (-f) (integrable.neg hf) = -of_simple_func f hf := rfl
 
 lemma of_simple_func_sub (f g : α →ₛ β) (hf hg) :
-  of_simple_func (f - g) (integrable.sub f.measurable g.measurable hf hg) = of_simple_func f hf -
+  of_simple_func (f - g) (integrable.sub f.measurable hf g.measurable hg) = of_simple_func f hf -
     of_simple_func g hg := rfl
 
 variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 β]
@@ -826,7 +826,7 @@ begin
   simp only [integral],
   rw ← simple_func.bintegral_add f.integrable g.integrable,
   apply simple_func.bintegral_congr (f + g).integrable,
-    { exact integrable.add f.measurable g.measurable f.integrable g.integrable },
+    { exact f.integrable.add f.measurable g.measurable g.integrable },
     { apply add_to_simple_func },
 end
 
@@ -924,8 +924,8 @@ begin
     { show integrable (f.pos_part.to_simple_func.map norm - f.neg_part.to_simple_func.map norm),
       refine integrable_of_ae_eq _ _,
       { exact (f.to_simple_func.pos_part - f.to_simple_func.neg_part) },
-      { exact integrable.sub f.to_simple_func.pos_part.measurable f.to_simple_func.neg_part.measurable
-        (integrable.max_zero f.integrable) (integrable.max_zero f.integrable.neg) },
+      { exact (integrable.max_zero f.integrable).sub f.to_simple_func.pos_part.measurable
+        f.to_simple_func.neg_part.measurable (integrable.max_zero f.integrable.neg) },
       exact ae_eq },
     filter_upwards [ae_eq₁, ae_eq₂],
     simp only [mem_set_of_eq],
@@ -1055,41 +1055,50 @@ lemma integral_non_measurable (h : ¬ measurable f) : integral f = 0 :=
 integral_undef $ not_and_of_not_left _ h
 
 variables (α β)
-@[simp] lemma integral_zero : integral (0 : α → β) = 0 :=
+@[simp] lemma integral_zero : integral (λ(a:α), (0:β)) = 0 :=
 by rw [integral_eq, l1.of_fun_zero, l1.integral_zero]
 
 variables {α β}
 
 lemma integral_add
   (hfm : measurable f) (hfi : integrable f) (hgm : measurable g) (hgi : integrable g) :
-  integral (f + g) = integral f + integral g :=
+  integral (λa, f a + g a) = integral f + integral g :=
 by rw [integral_eq, integral_eq f hfm hfi, integral_eq g hgm hgi, l1.of_fun_add, l1.integral_add]
 
-lemma integral_neg (f : α → β) : integral (-f) = - integral f :=
+lemma integral_neg (f : α → β) : integral (λa, -f a) = - integral f :=
 begin
   by_cases hf : measurable f ∧ integrable f,
-  { rw [integral_eq f hf.1 hf.2, integral_eq (- f) hf.1.neg hf.2.neg, l1.of_fun_neg,
+  { rw [integral_eq f hf.1 hf.2, integral_eq (λa, - f a) hf.1.neg hf.2.neg, l1.of_fun_neg,
     l1.integral_neg] },
-  { have hf' : ¬(measurable (-f) ∧ integrable (-f)),
+  { have hf' : ¬(measurable (λa, -f a) ∧ integrable (λa, -f a)),
     { rwa [measurable_neg_iff, integrable_neg_iff] },
     rw [integral_undef hf, integral_undef hf', neg_zero] }
 end
 
 lemma integral_sub
   (hfm : measurable f) (hfi : integrable f) (hgm : measurable g) (hgi : integrable g) :
-  integral (f - g) = integral f - integral g :=
+  integral (λa, f a - g a) = integral f - integral g :=
 by simp only [sub_eq_add_neg, integral_neg, integral_add, measurable_neg_iff, integrable_neg_iff, *]
 
-lemma integral_smul (r : ℝ) (f : α → β) : integral (r • f) = r • integral f :=
+lemma integral_smul (r : ℝ) (f : α → β) : integral (λa, r • (f a)) = r • integral f :=
 begin
   by_cases hf : measurable f ∧ integrable f,
-  { rw [integral_eq f hf.1 hf.2, integral_eq (r • f), l1.of_fun_smul, l1.integral_smul] },
+  { rw [integral_eq f hf.1 hf.2, integral_eq (λa, r • (f a)), l1.of_fun_smul, l1.integral_smul] },
   { by_cases hr : r = 0,
     { simp only [hr, measure_theory.integral_zero, zero_smul] },
-    have hf' : ¬(measurable (r • f) ∧ integrable (r • f)),
+    have hf' : ¬(measurable (λa, r • f a) ∧ integrable (λa, r • f a)),
     { rwa [← measurable_smul_iff hr f, ← integrable_smul_iff hr f] at hf },
     rw [integral_undef hf, integral_undef hf', smul_zero] }
 end
+
+lemma integral_mul_left (r : ℝ) (f : α → ℝ) : integral (λx, r * (f x)) = r * integral f :=
+integral_smul r f
+
+lemma integral_mul_right (r : ℝ) (f : α → ℝ) : integral (λx, (f x) * r) = integral f * r :=
+by { simp only [mul_comm], exact integral_mul_left r f }
+
+lemma integral_on_div (r : ℝ) (f : α → ℝ) : integral (λx, (f x) / r) = integral f / r :=
+by { simp only [div_eq_mul_inv], apply integral_mul_right }
 
 lemma integral_congr_ae (hfm : measurable f) (hgm : measurable g) (h : ∀ₘ a, f a = g a) :
    integral f = integral g :=
@@ -1226,12 +1235,12 @@ lemma integral_nonpos_of_nonpos_ae {f : α → ℝ} (hf : ∀ₘ a, f a ≤ 0) :
 begin
   have hf : ∀ₘ a, 0 ≤ (-f) a,
   { filter_upwards [hf], simp only [mem_set_of_eq], assume a h, rwa [pi.neg_apply, neg_nonneg] },
-  have : 0 ≤ integral (-f) := integral_nonneg_of_nonneg_ae hf,
+  have : 0 ≤ integral (λa, -f a) := integral_nonneg_of_nonneg_ae hf,
   rwa [integral_neg, neg_nonneg] at this,
 end
 
-lemma integral_le_integral_of_le_ae {f g : α → ℝ} (hfm : measurable f) (hfi : integrable f)
-   (hgm : measurable g) (hgi : integrable g) (h : ∀ₘ a, f a ≤ g a) : integral f ≤ integral g :=
+lemma integral_le_integral_ae {f g : α → ℝ} (hfm : measurable f) (hfi : integrable f)
+  (hgm : measurable g) (hgi : integrable g) (h : ∀ₘ a, f a ≤ g a) : integral f ≤ integral g :=
 le_of_sub_nonneg
 begin
   rw ← integral_sub hgm hgi hfm hfi,
@@ -1241,6 +1250,10 @@ begin
   assume a,
   exact sub_nonneg_of_le
 end
+
+lemma integral_le_integral {f g : α → ℝ} (hfm : measurable f) (hfi : integrable f)
+  (hgm : measurable g) (hgi : integrable g) (h : ∀ a, f a ≤ g a) : integral f ≤ integral g :=
+integral_le_integral_ae hfm hfi hgm hgi $ by filter_upwards [] h
 
 lemma norm_integral_le_integral_norm (f : α → β) : ∥integral f∥ ≤ ∫ a, ∥f a∥ :=
 have le_ae : ∀ₘ (a : α), 0 ≤ ∥f a∥ := by filter_upwards [] λa, norm_nonneg _,

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -262,15 +262,14 @@ assume s (hs : is_measurable s), by trivial
 section order_closed_topology
 variables [linear_order α] [order_closed_topology α] {a b c : α}
 
-lemma is_measurable_Ioo : is_measurable (Ioo a b) := is_measurable_of_is_open is_open_Ioo
-
 lemma is_measurable_Iio : is_measurable (Iio a) := is_measurable_of_is_open is_open_Iio
-
-lemma is_measurable_Ico : is_measurable (Ico a b) :=
-(is_measurable_of_is_closed $ is_closed_le continuous_const continuous_id).inter
-  is_measurable_Iio
-
-lemma is_measurable_Icc : is_measurable (Icc a b) := is_measurable_of_is_closed $ is_closed_Icc
+lemma is_measurable_Ioi : is_measurable (Ioi a) := is_measurable_of_is_open is_open_Ioi
+lemma is_measurable_Ici : is_measurable (Ici a) := is_measurable_of_is_closed is_closed_Ici
+lemma is_measurable_Iic : is_measurable (Iic a) := is_measurable_of_is_closed is_closed_Iic
+lemma is_measurable_Ioo : is_measurable (Ioo a b) := is_measurable_of_is_open is_open_Ioo
+lemma is_measurable_Ioc : is_measurable (Ioc a b) := is_measurable_Ioi.inter is_measurable_Iic
+lemma is_measurable_Ico : is_measurable (Ico a b) := is_measurable_Ici.inter is_measurable_Iio
+lemma is_measurable_Icc : is_measurable (Icc a b) := is_measurable_of_is_closed is_closed_Icc
 
 end order_closed_topology
 

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -270,6 +270,8 @@ lemma is_measurable_Ico : is_measurable (Ico a b) :=
 (is_measurable_of_is_closed $ is_closed_le continuous_const continuous_id).inter
   is_measurable_Iio
 
+lemma is_measurable_Icc : is_measurable (Icc a b) := is_measurable_of_is_closed $ is_closed_Icc
+
 end order_closed_topology
 
 lemma measurable.is_lub {α} [topological_space α] [linear_order α]

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -210,7 +210,7 @@ lemma measurable.neg
 
 lemma measurable_neg_iff
   [add_group α] [topological_add_group α] [measurable_space β] (f : β → α) :
-  measurable (-f) ↔ measurable f :=
+  measurable (λa, -f a) ↔ measurable f :=
 iff.intro
 begin
   assume h,

--- a/src/measure_theory/indicator_function.lean
+++ b/src/measure_theory/indicator_function.lean
@@ -34,8 +34,8 @@ begin
   filter_upwards [h],
   simp only [mem_set_of_eq, indicator],
   assume a ha,
-  split_ifs,
-  { exact ha h_1 },
+  split_ifs with h₁,
+  { exact ha h₁ },
   refl
 end
 
@@ -45,10 +45,10 @@ begin
   filter_upwards [h],
   simp only [mem_set_of_eq, indicator],
   assume a ha,
-  split_ifs,
+  split_ifs with h₁ h₂ h₂,
   { refl },
-  { have := ha.1 h_1, contradiction },
-  { have := ha.2 h_2, contradiction },
+  { have := ha.1 h₁, contradiction },
+  { have := ha.2 h₂, contradiction },
   refl
 end
 
@@ -108,41 +108,33 @@ end
 end order
 
 section tendsto
-variables [has_zero β] [topological_space β]
+variables [has_zero β]
 
 lemma tendsto_indicator_of_monotone (s : ℕ → set α) (hs : monotone s) (f : α → β)
-  (a : α) : tendsto (λi, indicator (s i) f a) at_top (nhds $ indicator (Union s) f a) :=
+  (a : α) : tendsto (λi, indicator (s i) f a) at_top (pure $ indicator (Union s) f a) :=
 begin
   by_cases h : ∃i, a ∈ s i,
-  { rcases h with ⟨i, hi⟩,
-    refine tendsto_nhds.mpr (λ t ht hf, _),
-    simp only [mem_at_top_sets, mem_preimage],
+  { simp only [tendsto_principal, mem_singleton_iff, mem_at_top_sets, filter.pure_def, mem_set_of_eq],
+    rcases h with ⟨i, hi⟩,
     use i, assume n hn,
-    have : indicator (s n) f a = f a := indicator_of_mem (hs hn hi) _,
-    rw this,
-    have : indicator (Union s) f a = f a := indicator_of_mem ((subset_Union _ _) hi) _,
-    rwa this at hf },
+    rw [indicator_of_mem (hs hn hi) _, indicator_of_mem ((subset_Union _ _) hi) _] },
   { rw [not_exists] at h,
     have : (λi, indicator (s i) f a) = λi, 0 := funext (λi, indicator_of_not_mem (h i) _),
     rw this,
     have : indicator (Union s) f a = 0,
       { apply indicator_of_not_mem, simpa only [not_exists, mem_Union] },
     rw this,
-    exact tendsto_const_nhds }
+    exact tendsto_const_pure }
 end
 
 lemma tendsto_indicator_of_antimono (s : ℕ → set α) (hs : ∀i j, i ≤ j → s j ⊆ s i) (f : α → β)
-  (a : α) : tendsto (λi, indicator (s i) f a) at_top (nhds $ indicator (Inter s) f a) :=
+  (a : α) : tendsto (λi, indicator (s i) f a) at_top (pure $ indicator (Inter s) f a) :=
 begin
   by_cases h : ∃i, a ∉ s i,
-  { rcases h with ⟨i, hi⟩,
-    refine tendsto_nhds.mpr (λ t ht hf, _),
-    simp only [mem_at_top_sets, mem_preimage],
+  { simp only [tendsto_principal, mem_singleton_iff, mem_at_top_sets, filter.pure_def, mem_set_of_eq],
+    rcases h with ⟨i, hi⟩,
     use i, assume n hn,
-    have : indicator (s n) f a = 0 := indicator_of_not_mem _ _,
-    rw this,
-    have : indicator (Inter s) f a = 0 := indicator_of_not_mem _ _,
-    rwa this at hf,
+    rw [indicator_of_not_mem _ _, indicator_of_not_mem _ _],
     { simp only [mem_Inter, not_forall], exact ⟨i, hi⟩ },
     { assume h, have := hs i _ hn h, contradiction } },
   { simp only [not_exists, not_not_mem] at h,
@@ -151,7 +143,7 @@ begin
     have : indicator (Inter s) f a = f a,
       { apply indicator_of_mem, simpa only [mem_Inter] },
     rw this,
-    exact tendsto_const_nhds }
+    exact tendsto_const_pure }
 end
 
 end tendsto

--- a/src/measure_theory/indicator_function.lean
+++ b/src/measure_theory/indicator_function.lean
@@ -111,9 +111,9 @@ end
 end order
 
 section tendsto
-variables {ι : Type*} [nonempty ι] [lattice.semilattice_sup ι] [has_zero β]
+variables {ι : Type*} [lattice.semilattice_sup ι] [has_zero β]
 
-lemma tendsto_indicator_of_monotone (s : ι → set α) (hs : monotone s) (f : α → β)
+lemma tendsto_indicator_of_monotone [nonempty ι] (s : ι → set α) (hs : monotone s) (f : α → β)
   (a : α) : tendsto (λi, indicator (s i) f a) at_top (pure $ indicator (Union s) f a) :=
 begin
   by_cases h : ∃i, a ∈ s i,
@@ -130,7 +130,7 @@ begin
     exact tendsto_const_pure }
 end
 
-lemma tendsto_indicator_of_antimono (s : ι → set α) (hs : ∀i j, i ≤ j → s j ⊆ s i) (f : α → β)
+lemma tendsto_indicator_of_antimono [nonempty ι] (s : ι → set α) (hs : ∀i j, i ≤ j → s j ⊆ s i) (f : α → β)
   (a : α) : tendsto (λi, indicator (s i) f a) at_top (pure $ indicator (Inter s) f a) :=
 begin
   by_cases h : ∃i, a ∉ s i,

--- a/src/measure_theory/indicator_function.lean
+++ b/src/measure_theory/indicator_function.lean
@@ -4,21 +4,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhouhang Zhou
 -/
 
+import data.indicator_function
 import measure_theory.measure_space
 import analysis.normed_space.basic
 
 /-!
 # Indicator function
 
-`indicator (s : set α) (f : α → β) (a : α)` is `f a` if `a ∈ s` and is `0` otherwise.
-
-## Implementation note
-
-In mathematics, an indicator function or a characteristic function is a function used to indicate
-membership of an element in a set `s`, having the value `1` for all elements of `s` and the value  `0`
-otherwise. But since it is usually used to restrict a function to a certain set `s`, we let the
-indicator function take the value `f x` for some function `f`, instead of `1`. If the usual indicator
-function is needed, just set `f` to be the constant function `λx, 1`.
+Properties of indicator functions.
 
 ## Tags
 indicator, characteristic
@@ -34,17 +27,6 @@ variables {α : Type u} {β : Type v}
 
 section has_zero
 variables [has_zero β] {s t : set α} {f g : α → β} {a : α}
-
-/-- `indicator s f a` is `f a` if `a ∈ s`, `0` otherwise.  -/
-@[reducible]
-def indicator (s : set α) (f : α → β) : α → β := λ x, if x ∈ s then f x else 0
-
-@[simp] lemma indicator_of_mem (h : a ∈ s) (f : α → β) : indicator s f a = f a := if_pos h
-
-@[simp] lemma indicator_of_not_mem (h : a ∉ s) (f : α → β) : indicator s f a = 0 := if_neg h
-
-lemma indicator_congr (h : ∀ a ∈ s, f a = g a) : indicator s f = indicator s g :=
-funext $ λx, by { simp only [indicator], split_ifs, { exact h _ h_1 }, refl }
 
 lemma indicator_congr_ae [measure_space α] (h : ∀ₘ a, a ∈ s → f a = g a) :
   ∀ₘ a, indicator s f a = indicator s g a :=
@@ -70,38 +52,10 @@ begin
   refl
 end
 
-@[simp] lemma indicator_univ (f : α → β) : indicator (univ : set α) f = f :=
-funext $ λx, indicator_of_mem (mem_univ _) f
-
-@[simp] lemma indicator_empty (f : α → β) : indicator (∅ : set α) f = λa, 0 :=
-funext $ λx, indicator_of_not_mem (not_mem_empty _) f
-
-variable (β)
-@[simp] lemma indicator_zero (s : set α) : indicator s (λx, (0:β)) = λx, (0:β) :=
-funext $ λx, by { simp only [indicator], split_ifs, refl, refl }
-variable {β}
-
-lemma indicator_indicator (s t : set α) (f : α → β) : indicator s (indicator t f) = indicator (s ∩ t) f :=
-funext $ λx, by { simp only [indicator], split_ifs, repeat {simp * at * {contextual := tt}} }
-
-lemma indicator_preimage (s : set α) (f : α → β) (B : set β) :
-  (indicator s f)⁻¹' B = s ∩ f ⁻¹' B ∪ (-s) ∩ (λa:α, (0:β)) ⁻¹' B :=
-by { rw [indicator, if_preimage], refl }
-
 end has_zero
 
 section has_add
 variables [add_monoid β] {s t : set α} {f g : α → β} {a : α}
-
-lemma indicator_union_of_not_mem_inter (h : a ∉ s ∩ t) (f : α → β) :
-  indicator (s ∪ t) f a = indicator s f a + indicator t f a :=
-by { simp only [indicator], split_ifs, repeat {simp * at * {contextual := tt}} }
-
-lemma indicator_union_of_disjoint (h : disjoint s t) (f : α → β) :
-  indicator (s ∪ t) f = λa, indicator s f a + indicator t f a :=
-funext $ λa, indicator_union_of_not_mem_inter
-  (by { convert not_mem_empty a, have := disjoint.eq_bot h, assumption })
-  _
 
 lemma indicator_union_ae [measure_space α] {β : Type*} [add_monoid β]
   (h : ∀ₘ a, a ∉ s ∩ t) (f : α → β) :
@@ -112,22 +66,6 @@ begin
   assume a ha,
   exact indicator_union_of_not_mem_inter ha _
 end
-
-lemma indicator_add (s : set α) (f g : α → β) :
-  indicator s (λa, f a + g a) = λa, indicator s f a + indicator s g a :=
-by { funext, simp only [indicator], split_ifs, { refl }, rw add_zero }
-
-lemma indicator_smul {𝕜 : Type*} [monoid 𝕜] [distrib_mul_action 𝕜 β] (s : set α) (r : 𝕜) (f : α → β) :
-  indicator s (λ (x : α), r • f x) = λ (x : α), r • indicator s f x :=
-by { simp only [indicator], funext, split_ifs, refl, exact (smul_zero r).symm }
-
-lemma indicator_neg {β : Type*} [add_group β] (s : set α) (f : α → β) :
-  indicator s (λa, - f a) = λa, - indicator s f a :=
-by { funext, simp only [indicator], split_ifs, { refl }, rw neg_zero }
-
-lemma indicator_sub {β : Type*} [add_group β] (s : set α) (f g : α → β) :
-  indicator s (λa, f a - g a) = λa, indicator s f a - indicator s g a :=
-by { funext, simp only [indicator], split_ifs, { refl }, rw sub_zero }
 
 end has_add
 
@@ -155,20 +93,6 @@ end norm
 
 section order
 variables [has_zero β] [preorder β] {s t : set α} {f g : α → β} {a : α}
-
-lemma indicator_le_indicator (h : f a ≤ g a) : indicator s f a ≤ indicator s g a :=
-by { simp only [indicator], split_ifs with ha, { exact h }, refl }
-
-lemma indicator_le_indicator_of_subset (h : s ⊆ t) (hf : ∀a, 0 ≤ f a) (a : α) :
-  indicator s f a ≤ indicator t f a :=
-begin
-  simp only [indicator],
-  split_ifs,
-  { refl },
-  { have := h h_1, contradiction },
-  { exact hf a },
-  { refl }
-end
 
 lemma indicator_le_indicator_ae [measure_space α] (h : ∀ₘ a, a ∈ s → f a ≤ g a) :
   ∀ₘ a, indicator s f a ≤ indicator s g a :=

--- a/src/measure_theory/indicator_function.lean
+++ b/src/measure_theory/indicator_function.lean
@@ -86,8 +86,11 @@ end
 lemma norm_indicator_le_norm_self (f : α → β) (a : α) : ∥indicator s f a∥ ≤ ∥f a∥ :=
 by { convert norm_indicator_le_of_subset (subset_univ s) f a, rw indicator_univ }
 
-lemma norm_indicator_eq_indicator_norm (f : α → β) (a : α) :∥indicator s f a∥ = indicator s (λa, ∥f a∥) a :=
+lemma norm_indicator_eq_indicator_norm (f : α → β) (a : α) : ∥indicator s f a∥ = indicator s (λa, ∥f a∥) a :=
 by { simp only [indicator], split_ifs, { refl }, rw norm_zero }
+
+lemma indicator_norm_le_norm_self (f : α → β) (a : α) : indicator s (λa, ∥f a∥) a ≤ ∥f a∥ :=
+by { rw ← norm_indicator_eq_indicator_norm, exact norm_indicator_le_norm_self _ _ }
 
 end norm
 
@@ -108,9 +111,9 @@ end
 end order
 
 section tendsto
-variables [has_zero β]
+variables {ι : Type*} [nonempty ι] [lattice.semilattice_sup ι] [has_zero β]
 
-lemma tendsto_indicator_of_monotone (s : ℕ → set α) (hs : monotone s) (f : α → β)
+lemma tendsto_indicator_of_monotone (s : ι → set α) (hs : monotone s) (f : α → β)
   (a : α) : tendsto (λi, indicator (s i) f a) at_top (pure $ indicator (Union s) f a) :=
 begin
   by_cases h : ∃i, a ∈ s i,
@@ -127,7 +130,7 @@ begin
     exact tendsto_const_pure }
 end
 
-lemma tendsto_indicator_of_antimono (s : ℕ → set α) (hs : ∀i j, i ≤ j → s j ⊆ s i) (f : α → β)
+lemma tendsto_indicator_of_antimono (s : ι → set α) (hs : ∀i j, i ≤ j → s j ⊆ s i) (f : α → β)
   (a : α) : tendsto (λi, indicator (s i) f a) at_top (pure $ indicator (Inter s) f a) :=
 begin
   by_cases h : ∃i, a ∉ s i,
@@ -142,6 +145,31 @@ begin
     rw this,
     have : indicator (Inter s) f a = f a,
       { apply indicator_of_mem, simpa only [mem_Inter] },
+    rw this,
+    exact tendsto_const_pure }
+end
+
+lemma tendsto_indicator_bUnion_finset (s : ι → set α) (f : α → β) (a : α) :
+  tendsto (λ (n : finset ι), indicator (⋃i∈n, s i) f a) at_top (pure $ indicator (Union s) f a) :=
+begin
+  by_cases h : ∃i, a ∈ s i,
+  { simp only [tendsto_principal, mem_singleton_iff, mem_at_top_sets, filter.pure_def,
+               mem_set_of_eq, ge_iff_le, finset.le_iff_subset],
+    rcases h with ⟨i, hi⟩,
+    use {i}, assume n hn,
+    replace hn : i ∈ n := hn (finset.mem_singleton_self _),
+    rw [indicator_of_mem, indicator_of_mem],
+    { rw [mem_Union], use i, assumption },
+    { rw [mem_Union], use i, rw [mem_Union], use hn, assumption } },
+  { rw [not_exists] at h,
+    have : (λ (n : finset ι), indicator (⋃ (i : ι) (H : i ∈ n), s i) f a) = λi, 0,
+      { funext,
+        rw indicator_of_not_mem,
+        simp only [not_exists, exists_prop, mem_Union, not_and],
+        intros, apply h },
+    rw this,
+    have : indicator (Union s) f a = 0,
+      { apply indicator_of_not_mem, simpa only [not_exists, mem_Union] },
     rw this,
     exact tendsto_const_pure }
 end

--- a/src/measure_theory/indicator_function.lean
+++ b/src/measure_theory/indicator_function.lean
@@ -1,0 +1,243 @@
+/-
+Copyright (c) 2020 Zhouhang Zhou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zhouhang Zhou
+-/
+
+import measure_theory.measure_space
+import analysis.normed_space.basic
+
+/-!
+# Indicator function
+
+`indicator (s : set α) (f : α → β) (a : α)` is `f x` if `x ∈ s` and is `0` otherwise.
+
+## Implementation note
+
+In mathematics, an indicator function or a characteristic function is a function used to indicate
+membership of an element in a set `s`, having the value `1` for all elements of `s` and the value  `0`
+otherwise. But since it is usually used to restrict a function to a certain set `s`, we let the
+indicator function take the value `f x` for some function `f`, instead of `1`. If the usual indicator
+function is needed, just set `f` to be the constant function `λx, 1`.
+
+## Tags
+indicator, characteristic
+-/
+
+noncomputable theory
+open_locale classical
+
+open set measure_theory filter
+
+universes u v
+variables {α : Type u} {β : Type v}
+
+section has_zero
+variables [has_zero β] {s t : set α} {f g : α → β} {a : α}
+
+/-- `indicator s f a` is `f a` if `a ∈ s`, `0` otherwise.  -/
+@[reducible]
+def indicator (s : set α) (f : α → β) : α → β := λ x, if x ∈ s then f x else 0
+
+@[simp] lemma indicator_of_mem (h : a ∈ s) (f : α → β) : indicator s f a = f a := if_pos h
+
+@[simp] lemma indicator_of_not_mem (h : a ∉ s) (f : α → β) : indicator s f a = 0 := if_neg h
+
+lemma indicator_congr (h : ∀ a ∈ s, f a = g a) : indicator s f = indicator s g :=
+funext $ λx, by { simp only [indicator], split_ifs, { exact h _ h_1 }, refl }
+
+lemma indicator_congr_ae [measure_space α] (h : ∀ₘ a, a ∈ s → f a = g a) :
+  ∀ₘ a, indicator s f a = indicator s g a :=
+begin
+  filter_upwards [h],
+  simp only [mem_set_of_eq, indicator],
+  assume a ha,
+  split_ifs,
+  { exact ha h_1 },
+  refl
+end
+
+lemma indicator_congr_of_set [measure_space α] (h : ∀ₘ a, a ∈ s ↔ a ∈ t) :
+  ∀ₘ a, indicator s f a = indicator t f a :=
+begin
+  filter_upwards [h],
+  simp only [mem_set_of_eq, indicator],
+  assume a ha,
+  split_ifs,
+  { refl },
+  { have := ha.1 h_1, contradiction },
+  { have := ha.2 h_2, contradiction },
+  refl
+end
+
+@[simp] lemma indicator_univ (f : α → β) : indicator (univ : set α) f = f :=
+funext $ λx, indicator_of_mem (mem_univ _) f
+
+@[simp] lemma indicator_empty (f : α → β) : indicator (∅ : set α) f = λa, 0 :=
+funext $ λx, indicator_of_not_mem (not_mem_empty _) f
+
+variable (β)
+@[simp] lemma indicator_zero (s : set α) : indicator s (λx, (0:β)) = λx, (0:β) :=
+funext $ λx, by { simp only [indicator], split_ifs, refl, refl }
+variable {β}
+
+lemma indicator_indicator (s t : set α) (f : α → β) : indicator s (indicator t f) = indicator (s ∩ t) f :=
+funext $ λx, by { simp only [indicator], split_ifs, repeat {simp * at * {contextual := tt}} }
+
+-- TODO : move
+lemma if_preimage (p : α → Prop) (f g : α → β) (B : set β) :
+  (λa, if p a then f a else g a)⁻¹' B = p ∩ f ⁻¹' B ∪ (-p) ∩ g ⁻¹' B :=
+begin
+  ext,
+  simp only [mem_inter_eq, mem_union_eq, mem_preimage],
+  split_ifs;
+  simp [mem_def, h]
+end
+
+lemma indicator_preimage (s : set α) (f : α → β) (B : set β) :
+  (indicator s f)⁻¹' B = s ∩ f ⁻¹' B ∪ (-s) ∩ (λa:α, (0:β)) ⁻¹' B :=
+by { rw [indicator, if_preimage], refl }
+
+end has_zero
+
+section has_add
+variables [add_monoid β] {s t : set α} {f g : α → β} {a : α}
+
+lemma indicator_union_of_not_mem_inter (h : a ∉ s ∩ t) (f : α → β) :
+  indicator (s ∪ t) f a = indicator s f a + indicator t f a :=
+by { simp only [indicator], split_ifs, repeat {simp * at * {contextual := tt}} }
+
+lemma indicator_union_of_disjoint (h : disjoint s t) (f : α → β) :
+  indicator (s ∪ t) f = λa, indicator s f a + indicator t f a :=
+funext $ λa, indicator_union_of_not_mem_inter
+  (by { convert not_mem_empty a, have := disjoint.eq_bot h, assumption })
+  _
+
+lemma indicator_union_ae [measure_space α] {β : Type*} [add_monoid β]
+  (h : ∀ₘ a, a ∉ s ∩ t) (f : α → β) :
+  ∀ₘ a, indicator (s ∪ t) f a = indicator s f a + indicator t f a :=
+begin
+  filter_upwards [h],
+  simp only [mem_set_of_eq],
+  assume a ha,
+  exact indicator_union_of_not_mem_inter ha _
+end
+
+lemma indicator_add (s : set α) (f g : α → β) :
+  indicator s (λa, f a + g a) = λa, indicator s f a + indicator s g a :=
+by { funext, simp only [indicator], split_ifs, { refl }, rw add_zero }
+
+lemma indicator_smul {𝕜 : Type*} [monoid 𝕜] [distrib_mul_action 𝕜 β] (s : set α) (r : 𝕜) (f : α → β) :
+  indicator s (λ (x : α), r • f x) = λ (x : α), r • indicator s f x :=
+by { simp only [indicator], funext, split_ifs, refl, exact (smul_zero r).symm }
+
+lemma indicator_neg {β : Type*} [add_group β] (s : set α) (f : α → β) :
+  indicator s (λa, - f a) = λa, - indicator s f a :=
+by { funext, simp only [indicator], split_ifs, { refl }, rw neg_zero }
+
+lemma indicator_sub {β : Type*} [add_group β] (s : set α) (f g : α → β) :
+  indicator s (λa, f a - g a) = λa, indicator s f a - indicator s g a :=
+by { funext, simp only [indicator], split_ifs, { refl }, rw sub_zero }
+
+end has_add
+
+section norm
+variables [normed_group β] {s t : set α} {f g : α → β} {a : α}
+
+lemma norm_indicator_le_of_subset (h : s ⊆ t) (f : α → β) (a : α) :
+  ∥indicator s f a∥ ≤ ∥indicator t f a∥ :=
+begin
+  simp only [indicator],
+  split_ifs with h₁ h₂,
+  { refl },
+  { exact absurd (h h₁) h₂ },
+  { simp only [norm_zero, norm_nonneg] },
+  refl
+end
+
+lemma norm_indicator_le_norm_self (f : α → β) (a : α) : ∥indicator s f a∥ ≤ ∥f a∥ :=
+by { convert norm_indicator_le_of_subset (subset_univ s) f a, rw indicator_univ }
+
+lemma norm_indicator_eq_indicator_norm (f : α → β) (a : α) :∥indicator s f a∥ = indicator s (λa, ∥f a∥) a :=
+by { simp only [indicator], split_ifs, { refl }, rw norm_zero }
+
+end norm
+
+section order
+variables [has_zero β] [preorder β] {s t : set α} {f g : α → β} {a : α}
+
+lemma indicator_le_indicator (h : f a ≤ g a) : indicator s f a ≤ indicator s g a :=
+by { simp only [indicator], split_ifs with ha, { exact h }, refl }
+
+lemma indicator_le_indicator_of_subset (h : s ⊆ t) (hf : ∀a, 0 ≤ f a) (a : α) :
+  indicator s f a ≤ indicator t f a :=
+begin
+  simp only [indicator],
+  split_ifs,
+  { refl },
+  { have := h h_1, contradiction },
+  { exact hf a },
+  { refl }
+end
+
+lemma indicator_le_indicator_ae [measure_space α] (h : ∀ₘ a, a ∈ s → f a ≤ g a) :
+  ∀ₘ a, indicator s f a ≤ indicator s g a :=
+begin
+  filter_upwards [h],
+  simp only [mem_set_of_eq, indicator],
+  assume a h,
+  split_ifs with ha,
+  { exact h ha },
+  refl
+end
+
+end order
+
+section tendsto
+variables [has_zero β] [topological_space β]
+
+lemma tendsto_indicator_of_monotone (s : ℕ → set α) (hs : monotone s) (f : α → β)
+  (a : α) : tendsto (λi, indicator (s i) f a) at_top (nhds $ indicator (Union s) f a) :=
+begin
+  by_cases h : ∃i, a ∈ s i,
+  { rcases h with ⟨i, hi⟩,
+    refine tendsto_nhds.mpr (λ t ht hf, _),
+    simp only [mem_at_top_sets, mem_preimage],
+    use i, assume n hn,
+    have : indicator (s n) f a = f a := indicator_of_mem (hs hn hi) _,
+    rw this,
+    have : indicator (Union s) f a = f a := indicator_of_mem ((subset_Union _ _) hi) _,
+    rwa this at hf },
+  { rw [not_exists] at h,
+    have : (λi, indicator (s i) f a) = λi, 0 := funext (λi, indicator_of_not_mem (h i) _),
+    rw this,
+    have : indicator (Union s) f a = 0,
+      { apply indicator_of_not_mem, simpa only [not_exists, mem_Union] },
+    rw this,
+    exact tendsto_const_nhds }
+end
+
+lemma tendsto_indicator_of_decreasing (s : ℕ → set α) (hs : ∀i j, i ≤ j → s j ⊆ s i) (f : α → β)
+  (a : α) : tendsto (λi, indicator (s i) f a) at_top (nhds $ indicator (Inter s) f a) :=
+begin
+  by_cases h : ∃i, a ∉ s i,
+  { rcases h with ⟨i, hi⟩,
+    refine tendsto_nhds.mpr (λ t ht hf, _),
+    simp only [mem_at_top_sets, mem_preimage],
+    use i, assume n hn,
+    have : indicator (s n) f a = 0 := indicator_of_not_mem _ _,
+    rw this,
+    have : indicator (Inter s) f a = 0 := indicator_of_not_mem _ _,
+    rwa this at hf,
+    { simp only [mem_Inter, not_forall], exact ⟨i, hi⟩ },
+    { assume h, have := hs i _ hn h, contradiction } },
+  { simp only [not_exists, not_not_mem] at h,
+    have : (λi, indicator (s i) f a) = λi, f a := funext (λi, indicator_of_mem (h i) _),
+    rw this,
+    have : indicator (Inter s) f a = f a,
+      { apply indicator_of_mem, simpa only [mem_Inter] },
+    rw this,
+    exact tendsto_const_nhds }
+end
+
+end tendsto

--- a/src/measure_theory/indicator_function.lean
+++ b/src/measure_theory/indicator_function.lean
@@ -10,7 +10,7 @@ import analysis.normed_space.basic
 /-!
 # Indicator function
 
-`indicator (s : set α) (f : α → β) (a : α)` is `f x` if `x ∈ s` and is `0` otherwise.
+`indicator (s : set α) (f : α → β) (a : α)` is `f a` if `a ∈ s` and is `0` otherwise.
 
 ## Implementation note
 

--- a/src/measure_theory/indicator_function.lean
+++ b/src/measure_theory/indicator_function.lean
@@ -131,7 +131,7 @@ begin
     exact tendsto_const_nhds }
 end
 
-lemma tendsto_indicator_of_decreasing (s : ℕ → set α) (hs : ∀i j, i ≤ j → s j ⊆ s i) (f : α → β)
+lemma tendsto_indicator_of_antimono (s : ℕ → set α) (hs : ∀i j, i ≤ j → s j ⊆ s i) (f : α → β)
   (a : α) : tendsto (λi, indicator (s i) f a) at_top (nhds $ indicator (Inter s) f a) :=
 begin
   by_cases h : ∃i, a ∉ s i,

--- a/src/measure_theory/indicator_function.lean
+++ b/src/measure_theory/indicator_function.lean
@@ -84,16 +84,6 @@ variable {β}
 lemma indicator_indicator (s t : set α) (f : α → β) : indicator s (indicator t f) = indicator (s ∩ t) f :=
 funext $ λx, by { simp only [indicator], split_ifs, repeat {simp * at * {contextual := tt}} }
 
--- TODO : move
-lemma if_preimage (p : α → Prop) (f g : α → β) (B : set β) :
-  (λa, if p a then f a else g a)⁻¹' B = p ∩ f ⁻¹' B ∪ (-p) ∩ g ⁻¹' B :=
-begin
-  ext,
-  simp only [mem_inter_eq, mem_union_eq, mem_preimage],
-  split_ifs;
-  simp [mem_def, h]
-end
-
 lemma indicator_preimage (s : set α) (f : α → β) (B : set β) :
   (indicator s f)⁻¹' B = s ∩ f ⁻¹' B ∪ (-s) ∩ (λa:α, (0:β)) ⁻¹' B :=
 by { rw [indicator, if_preimage], refl }

--- a/src/measure_theory/l1_space.lean
+++ b/src/measure_theory/l1_space.lean
@@ -146,8 +146,10 @@ lt_of_le_of_lt
 
 @[simp] lemma lintegral_nnnorm_zero : (∫⁻ a : α, nnnorm (0 : β)) = 0 := by simp
 
-lemma integrable_zero : integrable (0 : α → β) :=
+variables (α β)
+@[simp] lemma integrable_zero : integrable (λa:α, (0:β)) :=
 by { have := coe_lt_top, simpa [integrable] }
+variables {α β}
 
 lemma lintegral_nnnorm_add {f : α → β} {g : α → γ} (hf : measurable f) (hg : measurable g) :
   (∫⁻ a, nnnorm (f a) + nnnorm (g a)) = (∫⁻ a, nnnorm (f a)) + ∫⁻ a, nnnorm (g a) :=
@@ -162,6 +164,17 @@ calc
   ... = _ :
     lintegral_nnnorm_add hfm hgm
   ... < ⊤ : add_lt_top.2 ⟨hfi, hgi⟩
+
+lemma integrable_finset_sum {ι} [second_countable_topology β] (s : finset ι) {f : ι → α → β}
+  (hfm : ∀ i, measurable (f i)) (hfi : ∀ i, integrable (f i)) :
+  integrable (λ a, s.sum (λ i, f i a)) :=
+begin
+  refine finset.induction_on s _ _,
+  { simp only [finset.sum_empty, integrable_zero] },
+  { assume i s his ih,
+    simp only [his, finset.sum_insert, not_false_iff],
+    refine (hfi _).add (hfm _) (measurable_finset_sum s hfm) ih }
+end
 
 lemma lintegral_nnnorm_neg {f : α → β} :
   (∫⁻ (a : α), ↑(nnnorm ((-f) a))) = ∫⁻ (a : α), ↑(nnnorm ((f) a)) :=
@@ -521,7 +534,8 @@ lemma of_fun_eq_of_fun (f g : α → β) (hfm hfi hgm hgi) :
   of_fun f hfm hfi = of_fun g hgm hgi ↔ ∀ₘ a, f a = g a :=
 by { rw ← l1.eq_iff, simp only [of_fun_eq_mk, mk_eq_mk] }
 
-lemma of_fun_zero : of_fun (λa:α, (0:β)) (@measurable_const _ _ _ _ (0:β)) integrable_zero = 0 := rfl
+lemma of_fun_zero :
+  of_fun (λa:α, (0:β)) (@measurable_const _ _ _ _ (0:β)) (integrable_zero α β) = 0 := rfl
 
 lemma of_fun_add (f g : α → β) (hfm hfi hgm hgi) :
   of_fun (λa, f a + g a) (measurable.add hfm hgm) (integrable.add hfm hfi hgm hgi)

--- a/src/measure_theory/l1_space.lean
+++ b/src/measure_theory/l1_space.lean
@@ -115,7 +115,7 @@ end
 
 lemma integrable_of_le {f : α → β} {g : α → γ} (h : ∀a, ∥f a∥ ≤ ∥g a∥) (hg : integrable g) :
   integrable f :=
-integrable_of_le_ae (by filter_upwards [] h) hg
+integrable_of_le_ae (univ_mem_sets' h) hg
 
 lemma lintegral_nnnorm_eq_lintegral_edist (f : α → β) :
   (∫⁻ a, nnnorm (f a)) = ∫⁻ a, edist (f a) 0 :=

--- a/src/measure_theory/l1_space.lean
+++ b/src/measure_theory/l1_space.lean
@@ -184,7 +184,7 @@ lemma integrable.neg {f : α → β} : integrable f → integrable (λa, -f a) :
 assume hfi, calc _ = _ : lintegral_nnnorm_neg
                  ... < ⊤ : hfi
 
-lemma integrable_neg_iff (f : α → β) : integrable (λa, -f a) ↔ integrable f :=
+@[simp] lemma integrable_neg_iff (f : α → β) : integrable (λa, -f a) ↔ integrable f :=
 begin
   split,
   { assume h,

--- a/src/measure_theory/l1_space.lean
+++ b/src/measure_theory/l1_space.lean
@@ -113,6 +113,10 @@ begin
     ... < ⊤ : hg
 end
 
+lemma integrable_of_le {f : α → β} {g : α → γ} (h : ∀a, ∥f a∥ ≤ ∥g a∥) (hg : integrable g) :
+  integrable f :=
+integrable_of_le_ae (by filter_upwards [] h) hg
+
 lemma lintegral_nnnorm_eq_lintegral_edist (f : α → β) :
   (∫⁻ a, nnnorm (f a)) = ∫⁻ a, edist (f a) 0 :=
 by { congr, funext, rw edist_eq_coe_nnnorm }
@@ -149,38 +153,37 @@ lemma lintegral_nnnorm_add {f : α → β} {g : α → γ} (hf : measurable f) (
   (∫⁻ a, nnnorm (f a) + nnnorm (g a)) = (∫⁻ a, nnnorm (f a)) + ∫⁻ a, nnnorm (g a) :=
 lintegral_add (measurable.coe_nnnorm hf) (measurable.coe_nnnorm hg)
 
-lemma integrable.add {f g : α → β} (hfm : measurable f) (hgm : measurable g) :
-  integrable f → integrable g → integrable (f + g) :=
-assume hfi hgi,
-  calc
-    (∫⁻ (a : α), ↑(nnnorm ((f + g) a))) ≤ ∫⁻ (a : α), ↑(nnnorm (f a)) + ↑(nnnorm (g a)) :
-      lintegral_le_lintegral _ _
-        (assume a, by { simp only [coe_add.symm, coe_le_coe], exact nnnorm_add_le _ _ })
-    ... = _ :
-      lintegral_nnnorm_add hfm hgm
-    ... < ⊤ : add_lt_top.2 ⟨hfi, hgi⟩
+lemma integrable.add {f g : α → β} (hfm : measurable f) (hfi : integrable f) (hgm : measurable g)
+  (hgi : integrable g): integrable (λa, f a + g a) :=
+calc
+  (∫⁻ (a : α), ↑(nnnorm ((f + g) a))) ≤ ∫⁻ (a : α), ↑(nnnorm (f a)) + ↑(nnnorm (g a)) :
+    lintegral_le_lintegral _ _
+      (assume a, by { simp only [coe_add.symm, coe_le_coe], exact nnnorm_add_le _ _ })
+  ... = _ :
+    lintegral_nnnorm_add hfm hgm
+  ... < ⊤ : add_lt_top.2 ⟨hfi, hgi⟩
 
 lemma lintegral_nnnorm_neg {f : α → β} :
   (∫⁻ (a : α), ↑(nnnorm ((-f) a))) = ∫⁻ (a : α), ↑(nnnorm ((f) a)) :=
 lintegral_congr_ae $ by { filter_upwards [], simp }
 
-lemma integrable.neg {f : α → β} : integrable f → integrable (-f) :=
+lemma integrable.neg {f : α → β} : integrable f → integrable (λa, -f a) :=
 assume hfi, calc _ = _ : lintegral_nnnorm_neg
                  ... < ⊤ : hfi
 
-lemma integrable_neg_iff (f : α → β) : integrable (-f) ↔ integrable f :=
+lemma integrable_neg_iff (f : α → β) : integrable (λa, -f a) ↔ integrable f :=
 begin
   split,
   { assume h,
     have := integrable.neg h,
-    rwa _root_.neg_neg at this },
+    simp only [_root_.neg_neg] at this,
+    assumption },
   exact integrable.neg
 end
 
-lemma integrable.sub {f g : α → β} (hf : measurable f) (hg : measurable g) :
-  integrable f → integrable g → integrable (f - g) :=
-λ hfi hgi,
-  by { rw sub_eq_add_neg, refine integrable.add hf (measurable.neg hg) hfi (integrable.neg hgi) }
+lemma integrable.sub {f g : α → β} (hfm : measurable f) (hfi : integrable f) (hgm : measurable g)
+  (hgi : integrable g) : integrable (λa, f a - g a) :=
+by { simp only [sub_eq_add_neg], exact hfi.add hfm (measurable.neg hgm) (integrable.neg hgi) }
 
 lemma integrable.norm {f : α → β} (hfi : integrable f) : integrable (λa, ∥f a∥) :=
 have eq : (λa, (nnnorm ∥f a∥ : ennreal)) = λa, (nnnorm (f a) : ennreal),
@@ -344,7 +347,7 @@ end pos_part
 section normed_space
 variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 β]
 
-lemma integrable.smul (c : 𝕜) {f : α → β} : integrable f → integrable (c • f) :=
+lemma integrable.smul (c : 𝕜) {f : α → β} : integrable f → integrable (λa, c • f a) :=
 begin
   simp only [integrable], assume hfi,
   calc
@@ -365,12 +368,13 @@ begin
     end
 end
 
-lemma integrable_smul_iff {c : 𝕜} (hc : c ≠ 0) (f : α → β) : integrable (c • f) ↔ integrable f :=
+lemma integrable_smul_iff {c : 𝕜} (hc : c ≠ 0) (f : α → β) : integrable (λa, c • f a) ↔ integrable f :=
 begin
   split,
   { assume h,
     have := integrable.smul c⁻¹ h,
-    rwa [smul_smul, inv_mul_cancel hc, one_smul] at this },
+    simp only [smul_smul, inv_mul_cancel hc, one_smul] at this,
+    assumption },
   exact integrable.smul _
 end
 
@@ -398,15 +402,21 @@ lemma integrable_zero : integrable (0 : α →ₘ β) := mem_ball_self coe_lt_to
 lemma integrable.add : ∀ {f g : α →ₘ β}, integrable f → integrable g → integrable (f + g) :=
 begin
   rintros ⟨f, hf⟩ ⟨g, hg⟩,
-  have := measure_theory.integrable.add hf hg,
-  simpa [mem_ball, zero_def]
+  simp only [mem_ball, zero_def, mk_add_mk, integrable_mk, quot_mk_eq_mk],
+  assume hfi hgi,
+  exact hfi.add hf hg hgi
 end
 
 lemma integrable.neg : ∀ {f : α →ₘ β}, integrable f → integrable (-f) :=
 by { rintros ⟨f, hf⟩, have := measure_theory.integrable.neg, simpa }
 
 lemma integrable.sub : ∀ {f g : α →ₘ β}, integrable f → integrable g → integrable (f - g) :=
-by { rintros ⟨f, hf⟩ ⟨g, hg⟩, have := measure_theory.integrable.sub hf hg, simpa [mem_ball, zero_def] }
+begin
+  rintros ⟨f, hfm⟩ ⟨g, hgm⟩,
+  simp only [mem_ball, zero_def, mk_sub_mk, integrable_mk, quot_mk_eq_mk],
+  assume hfi hgi,
+  exact hfi.sub hfm hgm hgi
+end
 
 protected lemma is_add_subgroup : is_add_subgroup (ball (0 : α →ₘ β) ⊤) :=
 { zero_mem := integrable_zero,
@@ -515,18 +525,18 @@ lemma of_fun_eq_of_fun (f g : α → β) (hfm hfi hgm hgi) :
   of_fun f hfm hfi = of_fun g hgm hgi ↔ ∀ₘ a, f a = g a :=
 by { rw ← l1.eq_iff, simp only [of_fun_eq_mk, mk_eq_mk] }
 
-lemma of_fun_zero : of_fun (0 : α → β) (@measurable_const _ _ _ _ (0:β)) integrable_zero = 0 := rfl
+lemma of_fun_zero : of_fun (λa:α, (0:β)) (@measurable_const _ _ _ _ (0:β)) integrable_zero = 0 := rfl
 
 lemma of_fun_add (f g : α → β) (hfm hfi hgm hgi) :
-  of_fun (f + g) (measurable.add hfm hgm) (integrable.add hfm hgm hfi hgi)
+  of_fun (λa, f a + g a) (measurable.add hfm hgm) (integrable.add hfm hfi hgm hgi)
     = of_fun f hfm hfi + of_fun g hgm hgi :=
 rfl
 
 lemma of_fun_neg (f : α → β) (hfm hfi) :
-  of_fun (-f) (measurable.neg hfm) (integrable.neg hfi) = - of_fun f hfm hfi := rfl
+  of_fun (λa, - f a) (measurable.neg hfm) (integrable.neg hfi) = - of_fun f hfm hfi := rfl
 
 lemma of_fun_sub (f g : α → β) (hfm hfi hgm hgi) :
-  of_fun (f - g) (measurable.sub hfm hgm) (integrable.sub hfm hgm hfi hgi)
+  of_fun (λa, f a - g a) (measurable.sub hfm hgm) (integrable.sub hfm hfi hgm hgi)
     = of_fun f hfm hfi - of_fun g hgm hgi :=
 rfl
 
@@ -540,7 +550,7 @@ by { rw [norm_of_fun, lintegral_norm_eq_lintegral_edist] }
 variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 β]
 
 lemma of_fun_smul (f : α → β) (hfm hfi) (k : 𝕜) :
-  of_fun (k • f) (measurable.smul _ hfm) (integrable.smul _ hfi) = k • of_fun f hfm hfi := rfl
+  of_fun (λa, k • f a) (measurable.smul _ hfm) (integrable.smul _ hfi) = k • of_fun f hfm hfi := rfl
 
 end of_fun
 

--- a/src/measure_theory/l1_space.lean
+++ b/src/measure_theory/l1_space.lean
@@ -101,7 +101,7 @@ begin
   rwa ← this
 end
 
-lemma integrable_iff_of_ae_eq {f g : α → β} (h : ∀ₘ a, f a = g a) : integrable f ↔ integrable g :=
+lemma integrable_congr_ae {f g : α → β} (h : ∀ₘ a, f a = g a) : integrable f ↔ integrable g :=
 iff.intro (λhf, integrable_of_ae_eq hf h) (λhg, integrable_of_ae_eq hg (all_ae_eq_symm h))
 
 lemma integrable_of_le_ae {f : α → β} {g : α → γ} (h : ∀ₘ a, ∥f a∥ ≤ ∥g a∥) (hg : integrable g) :
@@ -175,9 +175,7 @@ lemma integrable_neg_iff (f : α → β) : integrable (λa, -f a) ↔ integrable
 begin
   split,
   { assume h,
-    have := integrable.neg h,
-    simp only [_root_.neg_neg] at this,
-    assumption },
+    simpa only [_root_.neg_neg] using h.neg },
   exact integrable.neg
 end
 
@@ -372,9 +370,7 @@ lemma integrable_smul_iff {c : 𝕜} (hc : c ≠ 0) (f : α → β) : integrable
 begin
   split,
   { assume h,
-    have := integrable.smul c⁻¹ h,
-    simp only [smul_smul, inv_mul_cancel hc, one_smul] at this,
-    assumption },
+    simpa only [smul_smul, inv_mul_cancel hc, one_smul] using h.smul c⁻¹ },
   exact integrable.smul _
 end
 
@@ -625,7 +621,7 @@ section pos_part
 def pos_part (f : α →₁ ℝ) : α →₁ ℝ :=
 ⟨ ae_eq_fun.pos_part f,
   begin
-    rw [ae_eq_fun.integrable_to_fun, integrable_iff_of_ae_eq (pos_part_to_fun _)],
+    rw [ae_eq_fun.integrable_to_fun, integrable_congr_ae (pos_part_to_fun _)],
     exact integrable.max_zero f.integrable
   end ⟩
 

--- a/src/measure_theory/set_integral.lean
+++ b/src/measure_theory/set_integral.lean
@@ -259,7 +259,7 @@ begin
   { filter_upwards [] tendsto_indicator_of_monotone _ h_mono _ }
 end
 
-lemma tendsto_integral_on_of_decreasing (s : ℕ → set α) (f : α → β) (hsm : ∀i, is_measurable (s i))
+lemma tendsto_integral_on_of_antimono (s : ℕ → set α) (f : α → β) (hsm : ∀i, is_measurable (s i))
   (h_mono : ∀i j, i ≤ j → s j ⊆ s i) (hfm : measurable_on (s 0) f) (hfi : integrable_on (s 0) f) :
   tendsto (λi, integral_on (s i) f) at_top (nhds (integral_on (Inter s) f)) :=
 let bound : α → ℝ := indicator (s 0) (λa, ∥f a∥) in
@@ -272,7 +272,7 @@ begin
     assume a,
     rw [norm_indicator_eq_indicator_norm],
     refine indicator_le_indicator_of_subset (h_mono _ _ (zero_le _)) (λa, norm_nonneg _) _ },
-  { filter_upwards [] tendsto_indicator_of_decreasing _ h_mono _ }
+  { filter_upwards [] tendsto_indicator_of_antimono _ h_mono _ }
 end
 
 -- TODO : prove the following proposition

--- a/src/measure_theory/set_integral.lean
+++ b/src/measure_theory/set_integral.lean
@@ -292,7 +292,7 @@ suffices h : tendsto (λn:finset ℕ, n.sum (λ i, ∫ a in s i, f a)) at_top (�
 begin
   have : (λn:finset ℕ, n.sum (λ i, ∫ a in s i, f a)) = λn:finset ℕ, ∫ a in (⋃i∈n, s i), f a,
   { funext,
-    rw [← integral_finset_sum, indicator_finset_Union],
+    rw [← integral_finset_sum, indicator_finset_bUnion],
     { assume i hi j hj hij, exact hd i j hij },
     { assume i, refine hfm.subset (hm _) (subset_Union _ _) },
     { assume i, refine hfi.subset (subset_Union _ _) } },

--- a/src/measure_theory/set_integral.lean
+++ b/src/measure_theory/set_integral.lean
@@ -6,6 +6,7 @@ Authors: Zhouhang Zhou
 
 import measure_theory.bochner_integration
 import measure_theory.indicator_function
+import measure_theory.lebesgue_measure
 
 /-!
 # Set integral
@@ -156,58 +157,52 @@ section integral_on
 variables [measure_space α]
   [normed_group β] [second_countable_topology β] [normed_space ℝ β] [complete_space β]
   (s t : set α) {f g : α → β}
+  {a b : ℝ} {h : ℝ → β}
 
-/-- `integral_on s f` is the integral of `f` over the set `s`. -/
-@[reducible]
-def integral_on (f : α → β) : β := integral (indicator s f)
+notation `∫` binders ` in ` s `, ` r:(scoped f, integral (indicator s f)) := r
 
 variables (β)
-@[simp] lemma integral_on_zero (s : set α) : integral_on s (λx, (0:β)) = 0 :=
-by { rw [integral_on, indicator_zero], apply integral_zero }
+@[simp] lemma integral_on_zero (s : set α) : (∫ a in s, (0:β)) = 0 :=
+by rw [indicator_zero, integral_zero]
 variables {β}
 
-lemma integral_on_congr (h : ∀ x ∈ s, f x = g x) : integral_on s f = integral_on s g :=
-by { simp only [integral_on, indicator_congr h] }
+lemma integral_on_congr (h : ∀ x ∈ s, f x = g x) : (∫ a in s, f a) = (∫ a in s, g a) :=
+by simp only [indicator_congr h]
 
 lemma integral_on_congr_of_ae_eq (hf : measurable_on s f) (hg : measurable_on s g)
-  (h : ∀ₘ x, x ∈ s → f x = g x) : integral_on s f = integral_on s g :=
-begin
-  apply integral_congr_ae,
-  { assumption },
-  { assumption },
-  exact indicator_congr_ae h
-end
+  (h : ∀ₘ x, x ∈ s → f x = g x) : (∫ a in s, f a) = (∫ a in s, g a) :=
+integral_congr_ae hf hg (indicator_congr_ae h)
 
 lemma integral_on_congr_of_set (hsm : measurable_on s f) (htm : measurable_on t f)
-  (h : ∀ₘ x, x ∈ s ↔ x ∈ t) : integral_on s f = integral_on t f :=
+  (h : ∀ₘ x, x ∈ s ↔ x ∈ t) : (∫ a in s, f a) = (∫ a in t, f a) :=
 integral_congr_ae hsm htm $ indicator_congr_of_set h
 
-lemma integral_on_smul (r : ℝ) (f : α → β) : integral_on s (λx, r • (f x)) = r • integral_on s f :=
-by { simp only [integral_on], rw [← integral_smul, indicator_smul] }
+lemma integral_on_smul (r : ℝ) (f : α → β) : (∫ a in s, r • (f a)) = r • (∫ a in s, f a) :=
+by rw [← integral_smul, indicator_smul]
 
-lemma integral_on_mul_left (r : ℝ) (f : α → ℝ) : integral_on s (λx, r * (f x)) = r * integral_on s f :=
+lemma integral_on_mul_left (r : ℝ) (f : α → ℝ) : (∫ a in s, r * (f a)) = r * (∫ a in s, f a) :=
 integral_on_smul s r f
 
-lemma integral_on_mul_right (r : ℝ) (f : α → ℝ) : integral_on s (λx, (f x) * r) = integral_on s f * r :=
+lemma integral_on_mul_right (r : ℝ) (f : α → ℝ) : (∫ a in s, (f a) * r) = (∫ a in s, f a) * r :=
 by { simp only [mul_comm], exact integral_on_mul_left s r f }
 
-lemma integral_on_div (r : ℝ) (f : α → ℝ) : integral_on s (λx, (f x) / r) = integral_on s f / r :=
+lemma integral_on_div (r : ℝ) (f : α → ℝ) : (∫ a in s, (f a) / r) = (∫ a in s, f a) / r :=
 by { simp only [div_eq_mul_inv], apply integral_on_mul_right }
 
 lemma integral_on_add (hfm : measurable_on s f) (hfi : integrable_on s f) (hgm : measurable_on s g)
-  (hgi : integrable_on s g) : integral_on s (λa, f a + g a) = integral_on s f + integral_on s g :=
-by { simp only [integral_on, indicator_add], exact integral_add hfm hfi hgm hgi }
+  (hgi : integrable_on s g) : (∫ a in s, f a + g a) = (∫ a in s, f a) + (∫ a in s, g a) :=
+by { simp only [indicator_add], exact integral_add hfm hfi hgm hgi }
 
-lemma integral_on_neg (f : α → β) : integral_on s (λa, -f a) = - integral_on s f :=
-by { simp only [integral_on, indicator_neg], exact integral_neg _ }
+lemma integral_on_neg (f : α → β) : (∫ a in s, -f a) = - (∫ a in s, f a) :=
+by { simp only [indicator_neg], exact integral_neg _ }
 
 lemma integral_on_sub (hfm : measurable_on s f) (hfi : integrable_on s f) (hgm : measurable_on s g)
-  (hgi : integrable_on s g) : integral_on s (λa, f a - g a) = integral_on s f - integral_on s g :=
-by { simp only [integral_on, indicator_sub], exact integral_sub hfm hfi hgm hgi }
+  (hgi : integrable_on s g) : (∫ a in s, f a - g a) = (∫ a in s, f a) - (∫ a in s, g a) :=
+by { simp only [indicator_sub], exact integral_sub hfm hfi hgm hgi }
 
 lemma integral_on_le_integral_on_ae {f g : α → ℝ} (hfm : measurable_on s f) (hfi : integrable_on s f)
   (hgm : measurable_on s g) (hgi : integrable_on s g) (h : ∀ₘ a, a ∈ s → f a ≤ g a) :
-  integral_on s f ≤ integral_on s g :=
+  (∫ a in s, f a) ≤ (∫ a in s, g a) :=
 begin
   apply integral_le_integral_ae hfm hfi hgm hgi,
   apply indicator_le_indicator_ae,
@@ -216,19 +211,18 @@ end
 
 lemma integral_on_le_integral_on {f g : α → ℝ} (hfm : measurable_on s f) (hfi : integrable_on s f)
   (hgm : measurable_on s g) (hgi : integrable_on s g) (h : ∀ a, a ∈ s → f a ≤ g a) :
-  integral_on s f ≤ integral_on s g :=
+  (∫ a in s, f a) ≤ (∫ a in s, g a) :=
 integral_on_le_integral_on_ae _ hfm hfi hgm hgi $ by filter_upwards [] h
 
 lemma integral_on_union (hsm : measurable_on s f) (hsi : integrable_on s f)
   (htm : measurable_on t f) (hti : integrable_on t f) (h : disjoint s t) :
-  integral_on (s ∪ t) f = integral_on s f + integral_on t f :=
-by { simp only [integral_on], rw [indicator_union_of_disjoint h, integral_add hsm hsi htm hti] }
+  (∫ a in (s ∪ t), f a) = (∫ a in s, f a) + (∫ a in t, f a) :=
+by { rw [indicator_union_of_disjoint h, integral_add hsm hsi htm hti] }
 
 lemma integral_on_union_ae (hs : is_measurable s) (ht : is_measurable t) (hsm : measurable_on s f)
   (hsi : integrable_on s f) (htm : measurable_on t f) (hti : integrable_on t f) (h : ∀ₘ a, a ∉ s ∩ t) :
-  integral_on (s ∪ t) f = integral_on s f + integral_on t f :=
+  (∫ a in (s ∪ t), f a) = (∫ a in s, f a) + (∫ a in t, f a) :=
 begin
-  simp only [integral_on],
   have := integral_congr_ae _ _ (indicator_union_ae h f),
   rw [this, integral_add hsm hsi htm hti],
   { exact hsm.union hs ht htm },
@@ -237,7 +231,7 @@ end
 
 lemma tendsto_integral_on_of_monotone {s : ℕ → set α} {f : α → β} (hsm : ∀i, is_measurable (s i))
   (h_mono : monotone s) (hfm : measurable_on (Union s) f) (hfi : integrable_on (Union s) f) :
-  tendsto (λi, integral_on (s i) f) at_top (nhds (integral_on (Union s) f)) :=
+  tendsto (λi, ∫ a in (s i), f a) at_top (nhds (∫ a in (Union s), f a)) :=
 let bound : α → ℝ := indicator (Union s) (λa, ∥f a∥) in
 begin
   apply tendsto_integral_of_dominated_convergence,
@@ -253,7 +247,7 @@ end
 
 lemma tendsto_integral_on_of_antimono (s : ℕ → set α) (f : α → β) (hsm : ∀i, is_measurable (s i))
   (h_mono : ∀i j, i ≤ j → s j ⊆ s i) (hfm : measurable_on (s 0) f) (hfi : integrable_on (s 0) f) :
-  tendsto (λi, integral_on (s i) f) at_top (nhds (integral_on (Inter s) f)) :=
+  tendsto (λi, ∫ a in (s i), f a) at_top (nhds (∫ a in (Inter s), f a)) :=
 let bound : α → ℝ := indicator (s 0) (λa, ∥f a∥) in
 begin
   apply tendsto_integral_of_dominated_convergence,

--- a/src/measure_theory/set_integral.lean
+++ b/src/measure_theory/set_integral.lean
@@ -47,7 +47,6 @@ lemma is_measurable.inter_preimage {B : set β}
   (hs : is_measurable s) (hB : is_measurable B) (hf : measurable_on s f):
   is_measurable (s ∩ f ⁻¹' B) :=
 begin
-  rw [measurable_on] at hf,
   replace hf : is_measurable ((indicator s f)⁻¹' B) := hf B hB,
   rw indicator_preimage at hf,
   replace hf := hf.diff _,
@@ -85,26 +84,21 @@ variables [measure_space α] [normed_group β] {s t : set α} {f g : α → β}
 @[reducible]
 def integrable_on (s : set α) (f : α → β) : Prop := integrable (indicator s f)
 
-lemma integrable_on_iff (h : ∀x, x ∈ s → f x = g x) : integrable_on s f ↔ integrable_on s g :=
+lemma integrable_on_congr (h : ∀x, x ∈ s → f x = g x) : integrable_on s f ↔ integrable_on s g :=
 by simp only [integrable_on, indicator_congr h]
 
-lemma integrable_on_iff_of_ae_eq (h : ∀ₘx, x ∈ s → f x = g x) :
+lemma integrable_on_congr_ae (h : ∀ₘx, x ∈ s → f x = g x) :
   integrable_on s f ↔ integrable_on s g :=
-by { simp only [integrable_on], apply integrable_iff_of_ae_eq, exact indicator_congr_ae h }
+by { apply integrable_congr_ae, exact indicator_congr_ae h }
 
 lemma integrable_on_empty : integrable_on ∅ f :=
 by { simp only [integrable_on, indicator_empty], exact integrable_zero }
 
 lemma integrable_on_of_integrable (s : set α) (hf : integrable f) : integrable_on s f :=
-by { simp only [integrable_on], refine integrable_of_le (λa, _) hf, apply norm_indicator_le_norm_self }
+by { refine integrable_of_le (λa, _) hf, apply norm_indicator_le_norm_self }
 
 lemma integrable_on.subset (h : s ⊆ t) : integrable_on t f → integrable_on s f :=
-begin
-  simp only [integrable_on],
-  apply integrable_of_le_ae,
-  filter_upwards [],
-  exact norm_indicator_le_of_subset h _
-end
+by { apply integrable_of_le_ae, filter_upwards [] norm_indicator_le_of_subset h _ }
 
 variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 β]
 
@@ -178,7 +172,6 @@ by { simp only [integral_on, indicator_congr h] }
 lemma integral_on_congr_of_ae_eq (hf : measurable_on s f) (hg : measurable_on s g)
   (h : ∀ₘ x, x ∈ s → f x = g x) : integral_on s f = integral_on s g :=
 begin
-  simp only [integral_on],
   apply integral_congr_ae,
   { assumption },
   { assumption },
@@ -216,7 +209,6 @@ lemma integral_on_le_integral_on_ae {f g : α → ℝ} (hfm : measurable_on s f)
   (hgm : measurable_on s g) (hgi : integrable_on s g) (h : ∀ₘ a, a ∈ s → f a ≤ g a) :
   integral_on s f ≤ integral_on s g :=
 begin
-  simp only [integral_on],
   apply integral_le_integral_ae hfm hfi hgm hgi,
   apply indicator_le_indicator_ae,
   exact h
@@ -256,7 +248,7 @@ begin
     assume a,
     rw [norm_indicator_eq_indicator_norm],
     exact indicator_le_indicator_of_subset (subset_Union _ _) (λa, norm_nonneg _) _ },
-  { filter_upwards [] tendsto_indicator_of_monotone _ h_mono _ }
+  { filter_upwards [] λa, le_trans (tendsto_indicator_of_monotone _ h_mono _ _) (pure_le_nhds _) }
 end
 
 lemma tendsto_integral_on_of_antimono (s : ℕ → set α) (f : α → β) (hsm : ∀i, is_measurable (s i))
@@ -272,7 +264,7 @@ begin
     assume a,
     rw [norm_indicator_eq_indicator_norm],
     refine indicator_le_indicator_of_subset (h_mono _ _ (zero_le _)) (λa, norm_nonneg _) _ },
-  { filter_upwards [] tendsto_indicator_of_antimono _ h_mono _ }
+  { filter_upwards [] λa, le_trans (tendsto_indicator_of_antimono _ h_mono _ _) (pure_le_nhds _) }
 end
 
 -- TODO : prove the following proposition

--- a/src/measure_theory/set_integral.lean
+++ b/src/measure_theory/set_integral.lean
@@ -1,0 +1,285 @@
+/-
+Copyright (c) 2020 Zhouhang Zhou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zhouhang Zhou
+-/
+
+import measure_theory.bochner_integration
+import measure_theory.indicator_function
+
+/-!
+# Set integral
+
+Integrate a function over a subset of a measure space.
+
+## Main definition
+
+`measurable_on`, `integrable_on`, `integral_on`
+
+## Tags
+
+indicator, characteristic
+-/
+
+noncomputable theory
+open_locale classical topological_space
+open set lattice filter topological_space ennreal emetric measure_theory
+
+set_option class.instance_max_depth 50
+
+universes u v w
+variables {α : Type u} {β : Type v} {γ : Type w}
+
+section measurable_on
+variables [measurable_space α] [measurable_space β] [has_zero β] {s : set α} {f : α → β}
+
+/-- `measurable_on s f` means `f` is measurable over the set `s`. -/
+@[reducible]
+def measurable_on (s : set α) (f : α → β) : Prop := measurable (indicator s f)
+
+lemma measurable_on_univ (hf : measurable f) : measurable_on univ f :=
+hf.if is_measurable.univ measurable_const
+
+lemma measurable_on_of_measurable (hs : is_measurable s) (hf : measurable f) : measurable_on s f :=
+hf.if hs measurable_const
+
+lemma is_measurable.inter_preimage {B : set β}
+  (hs : is_measurable s) (hB : is_measurable B) (hf : measurable_on s f):
+  is_measurable (s ∩ f ⁻¹' B) :=
+begin
+  rw [measurable_on] at hf,
+  replace hf : is_measurable ((indicator s f)⁻¹' B) := hf B hB,
+  rw indicator_preimage at hf,
+  replace hf := hf.diff _,
+  rwa union_diff_cancel_right at hf,
+  { assume a, simp {contextual := tt} },
+  exact hs.compl.inter (measurable_const.preimage hB)
+end
+
+lemma measurable_on.subset {t : set α} (hs : is_measurable s) (h : s ⊆ t) (hf : measurable_on t f) :
+  measurable_on s f :=
+begin
+  have : measurable_on s (indicator t f) := measurable_on_of_measurable hs hf,
+  simp only [measurable_on, indicator_indicator] at this,
+  rwa [inter_eq_self_of_subset_left h] at this,
+end
+
+lemma measurable_on.union {β} [measurable_space β] [add_monoid β] {t : set α} {f : α → β}
+  (hs : is_measurable s) (ht : is_measurable t) (hsm : measurable_on s f) (htm : measurable_on t f) :
+  measurable_on (s ∪ t) f :=
+begin
+  assume B hB,
+  show is_measurable ((indicator (s ∪ t) f)⁻¹' B),
+  rw indicator_preimage,
+  refine is_measurable.union _ ((hs.union ht).compl.inter (measurable_const.preimage hB)),
+  simp only [union_inter_distrib_right],
+  exact (hs.inter_preimage hB hsm).union (ht.inter_preimage hB htm)
+end
+
+end measurable_on
+
+section integrable_on
+variables [measure_space α] [normed_group β] {s t : set α} {f g : α → β}
+
+/-- `integrable_on s f` means `f` is integrable over the set `s`. -/
+@[reducible]
+def integrable_on (s : set α) (f : α → β) : Prop := integrable (indicator s f)
+
+lemma integrable_on_congr (h : ∀x, x ∈ s → f x = g x) : integrable_on s f ↔ integrable_on s g :=
+by simp only [integrable_on, indicator_congr h]
+
+-- change the name of integrable_iff_of_ae_eq
+lemma integrable_on_congr_of_ae_eq (h : ∀ₘx, x ∈ s → f x = g x) :
+  integrable_on s f ↔ integrable_on s g :=
+by { simp only [integrable_on], apply integrable_iff_of_ae_eq, exact indicator_congr_ae h }
+
+lemma integrable_on_empty : integrable_on ∅ f :=
+by { simp only [integrable_on, indicator_empty], exact integrable_zero }
+
+lemma integrable_on_of_integrable (s : set α) (hf : integrable f) : integrable_on s f :=
+by { simp only [integrable_on], refine integrable_of_le (λa, _) hf, apply norm_indicator_le_norm_self }
+
+lemma integrable_on.subset (h : s ⊆ t) : integrable_on t f → integrable_on s f :=
+begin
+  simp only [integrable_on],
+  apply integrable_of_le_ae,
+  filter_upwards [],
+  exact norm_indicator_le_of_subset h _
+end
+
+variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 β]
+
+lemma integrable_on.smul (s : set α) (c : 𝕜) {f : α → β} : integrable_on s f → integrable_on s (λa, c • f a) :=
+by { simp only [integrable_on, indicator_smul], apply integrable.smul }
+
+lemma integrable_on.mul_left (s : set α) (r : ℝ) {f : α → ℝ} (hf : integrable_on s f) :
+  integrable_on s (λa, r * f a) :=
+by { simp only [smul_eq_mul.symm], exact hf.smul s r }
+
+lemma integrable_on.mul_right (s : set α) (r : ℝ) {f : α → ℝ} (hf : integrable_on s f) :
+  integrable_on s (λa, f a * r) :=
+by { simp only [mul_comm], exact hf.mul_left _ _ }
+
+lemma integrable_on.divide (s : set α) (r : ℝ) {f : α → ℝ} (hf : integrable_on s f) :
+  integrable_on s (λa, f a / r) :=
+by { simp only [div_eq_mul_inv], exact hf.mul_right _ _ }
+
+lemma integrable_on.add (hfm : measurable_on s f) (hfi : integrable_on s f) (hgm : measurable_on s g)
+  (hgi : integrable_on s g) : integrable_on s (λa, f a + g a) :=
+by { rw [integrable_on, indicator_add], exact hfi.add hfm hgm hgi }
+
+lemma integrable_on.neg (hf : integrable_on s f) : integrable_on s (λa, -f a) :=
+by { rw [integrable_on, indicator_neg], exact hf.neg }
+
+lemma integrable_on.sub (hfm : measurable_on s f) (hfi : integrable_on s f) (hgm : measurable_on s g)
+  (hgi : integrable_on s g) : integrable_on s (λa, f a - g a) :=
+by { rw [integrable_on, indicator_sub], exact hfi.sub hfm hgm hgi }
+
+lemma integrable_on.union (hs : is_measurable s) (ht : is_measurable t) (hsm : measurable_on s f)
+  (hsi : integrable_on s f) (htm : measurable_on t f) (hti : integrable_on t f) :
+  integrable_on (s ∪ t) f :=
+begin
+  rw ← union_diff_self,
+  rw [integrable_on, indicator_union_of_disjoint],
+  { refine integrable.add hsm hsi (htm.subset _ _) (hti.subset _),
+    { exact ht.diff hs },
+    { exact diff_subset _ _ },
+    { exact diff_subset _ _ } },
+  exact disjoint_diff
+end
+
+lemma integrable_on_norm_iff (s : set α) (f : α → β) :
+  integrable_on s (λa, ∥f a∥) ↔ integrable_on s f :=
+begin
+  simp only [integrable_on],
+  convert integrable_norm_iff (indicator s f),
+  funext,
+  rw norm_indicator_eq_indicator_norm,
+end
+
+end integrable_on
+
+section integral_on
+variables [measure_space α]
+  [normed_group β] [second_countable_topology β] [normed_space ℝ β] [complete_space β]
+  (s t : set α) {f g : α → β}
+
+/-- `integral_on s f` is the integral of `f` over the set `s`. -/
+@[reducible]
+def integral_on (f : α → β) : β := integral (indicator s f)
+
+variables (β)
+@[simp] lemma integral_on_zero (s : set α) : integral_on s (λx, (0:β)) = 0 :=
+by { rw [integral_on, indicator_zero], apply integral_zero }
+variables {β}
+
+lemma integral_on_congr (h : ∀ x ∈ s, f x = g x) : integral_on s f = integral_on s g :=
+by { simp only [integral_on, indicator_congr h] }
+
+lemma integral_on_congr_of_ae_eq (hf : measurable_on s f) (hg : measurable_on s g)
+  (h : ∀ₘ x, x ∈ s → f x = g x) : integral_on s f = integral_on s g :=
+begin
+  simp only [integral_on],
+  apply integral_congr_ae,
+  { assumption },
+  { assumption },
+  exact indicator_congr_ae h
+end
+
+lemma integral_on_congr_of_set (hsm : measurable_on s f) (htm : measurable_on t f)
+  (h : ∀ₘ x, x ∈ s ↔ x ∈ t) : integral_on s f = integral_on t f :=
+integral_congr_ae hsm htm $ indicator_congr_of_set h
+
+lemma integral_on_smul (r : ℝ) (f : α → β) : integral_on s (λx, r • (f x)) = r • integral_on s f :=
+by { simp only [integral_on], rw [← integral_smul, indicator_smul] }
+
+lemma integral_on_mul_left (r : ℝ) (f : α → ℝ) : integral_on s (λx, r * (f x)) = r * integral_on s f :=
+integral_on_smul s r f
+
+lemma integral_on_mul_right (r : ℝ) (f : α → ℝ) : integral_on s (λx, (f x) * r) = integral_on s f * r :=
+by { simp only [mul_comm], exact integral_on_mul_left s r f }
+
+lemma integral_on_div (r : ℝ) (f : α → ℝ) : integral_on s (λx, (f x) / r) = integral_on s f / r :=
+by { simp only [div_eq_mul_inv], apply integral_on_mul_right }
+
+lemma integral_on_add (hfm : measurable_on s f) (hfi : integrable_on s f) (hgm : measurable_on s g)
+  (hgi : integrable_on s g) : integral_on s (λa, f a + g a) = integral_on s f + integral_on s g :=
+by { simp only [integral_on, indicator_add], exact integral_add hfm hfi hgm hgi }
+
+lemma integral_on_neg (f : α → β) : integral_on s (λa, -f a) = - integral_on s f :=
+by { simp only [integral_on, indicator_neg], exact integral_neg _ }
+
+lemma integral_on_sub (hfm : measurable_on s f) (hfi : integrable_on s f) (hgm : measurable_on s g)
+  (hgi : integrable_on s g) : integral_on s (λa, f a - g a) = integral_on s f - integral_on s g :=
+by { simp only [integral_on, indicator_sub], exact integral_sub hfm hfi hgm hgi }
+
+lemma integral_on_le_integral_on_ae {f g : α → ℝ} (hfm : measurable_on s f) (hfi : integrable_on s f)
+  (hgm : measurable_on s g) (hgi : integrable_on s g) (h : ∀ₘ a, a ∈ s → f a ≤ g a) :
+  integral_on s f ≤ integral_on s g :=
+begin
+  simp only [integral_on],
+  apply integral_le_integral_ae hfm hfi hgm hgi,
+  apply indicator_le_indicator_ae,
+  exact h
+end
+
+lemma integral_on_le_integral_on {f g : α → ℝ} (hfm : measurable_on s f) (hfi : integrable_on s f)
+  (hgm : measurable_on s g) (hgi : integrable_on s g) (h : ∀ a, a ∈ s → f a ≤ g a) :
+  integral_on s f ≤ integral_on s g :=
+integral_on_le_integral_on_ae _ hfm hfi hgm hgi $ by filter_upwards [] h
+
+lemma integral_on_union (hsm : measurable_on s f) (hsi : integrable_on s f)
+  (htm : measurable_on t f) (hti : integrable_on t f) (h : disjoint s t) :
+  integral_on (s ∪ t) f = integral_on s f + integral_on t f :=
+by { simp only [integral_on], rw [indicator_union_of_disjoint h, integral_add hsm hsi htm hti] }
+
+lemma integral_on_union_ae (hs : is_measurable s) (ht : is_measurable t) (hsm : measurable_on s f)
+  (hsi : integrable_on s f) (htm : measurable_on t f) (hti : integrable_on t f) (h : ∀ₘ a, a ∉ s ∩ t) :
+  integral_on (s ∪ t) f = integral_on s f + integral_on t f :=
+begin
+  simp only [integral_on],
+  have := integral_congr_ae _ _ (indicator_union_ae h f),
+  rw [this, integral_add hsm hsi htm hti],
+  { exact hsm.union hs ht htm },
+  { exact hsm.add htm }
+end
+
+lemma tendsto_integral_on_of_monotone {s : ℕ → set α} {f : α → β} (hsm : ∀i, is_measurable (s i))
+  (h_mono : monotone s) (hfm : measurable_on (Union s) f) (hfi : integrable_on (Union s) f) :
+  tendsto (λi, integral_on (s i) f) at_top (nhds (integral_on (Union s) f)) :=
+let bound : α → ℝ := indicator (Union s) (λa, ∥f a∥) in
+begin
+  apply tendsto_integral_of_dominated_convergence,
+  { assume i, exact hfm.subset (hsm i) (subset_Union _ _) },
+  { assumption },
+  { show integrable_on (Union s) (λa, ∥f a∥), rwa integrable_on_norm_iff },
+  { assume i, apply all_ae_of_all,
+    assume a,
+    rw [norm_indicator_eq_indicator_norm],
+    exact indicator_le_indicator_of_subset (subset_Union _ _) (λa, norm_nonneg _) _ },
+  { filter_upwards [] tendsto_indicator_of_monotone _ h_mono _ }
+end
+
+lemma tendsto_integral_on_of_decreasing (s : ℕ → set α) (f : α → β) (hsm : ∀i, is_measurable (s i))
+  (h_mono : ∀i j, i ≤ j → s j ⊆ s i) (hfm : measurable_on (s 0) f) (hfi : integrable_on (s 0) f) :
+  tendsto (λi, integral_on (s i) f) at_top (nhds (integral_on (Inter s) f)) :=
+let bound : α → ℝ := indicator (s 0) (λa, ∥f a∥) in
+begin
+  apply tendsto_integral_of_dominated_convergence,
+  { assume i, refine hfm.subset (hsm i) (h_mono _ _ (zero_le _)) },
+  { exact hfm.subset (is_measurable.Inter hsm) (Inter_subset _ _) },
+  { show integrable_on (s 0) (λa, ∥f a∥), rwa integrable_on_norm_iff },
+  { assume i, apply all_ae_of_all,
+    assume a,
+    rw [norm_indicator_eq_indicator_norm],
+    refine indicator_le_indicator_of_subset (h_mono _ _ (zero_le _)) (λa, norm_nonneg _) _ },
+  { filter_upwards [] tendsto_indicator_of_decreasing _ h_mono _ }
+end
+
+-- TODO : prove the following proposition
+
+-- lemma integral_on_Union (s : ℕ → set α) (f : α → β) (hm : ∀i, is_measurable (s i))
+--   (hd : pairwise (disjoint on s)) (hf : integrable_on (Union s) f) :
+--   integral_on (Union s) f = ∑i, integral_on (s i) f := sorry
+
+end integral_on

--- a/src/measure_theory/set_integral.lean
+++ b/src/measure_theory/set_integral.lean
@@ -40,7 +40,7 @@ def measurable_on (s : set α) (f : α → β) : Prop := measurable (indicator s
 lemma measurable_on_univ (hf : measurable f) : measurable_on univ f :=
 hf.if is_measurable.univ measurable_const
 
-lemma measurable_on_of_measurable (hs : is_measurable s) (hf : measurable f) : measurable_on s f :=
+lemma measurable.measurable_on (hs : is_measurable s) (hf : measurable f) : measurable_on s f :=
 hf.if hs measurable_const
 
 lemma is_measurable.inter_preimage {B : set β}
@@ -59,7 +59,7 @@ end
 lemma measurable_on.subset {t : set α} (hs : is_measurable s) (h : s ⊆ t) (hf : measurable_on t f) :
   measurable_on s f :=
 begin
-  have : measurable_on s (indicator t f) := measurable_on_of_measurable hs hf,
+  have : measurable_on s (indicator t f) := measurable.measurable_on hs hf,
   simp only [measurable_on, indicator_indicator] at this,
   rwa [inter_eq_self_of_subset_left h] at this,
 end
@@ -85,11 +85,10 @@ variables [measure_space α] [normed_group β] {s t : set α} {f g : α → β}
 @[reducible]
 def integrable_on (s : set α) (f : α → β) : Prop := integrable (indicator s f)
 
-lemma integrable_on_congr (h : ∀x, x ∈ s → f x = g x) : integrable_on s f ↔ integrable_on s g :=
+lemma integrable_on_iff (h : ∀x, x ∈ s → f x = g x) : integrable_on s f ↔ integrable_on s g :=
 by simp only [integrable_on, indicator_congr h]
 
--- change the name of integrable_iff_of_ae_eq
-lemma integrable_on_congr_of_ae_eq (h : ∀ₘx, x ∈ s → f x = g x) :
+lemma integrable_on_iff_of_ae_eq (h : ∀ₘx, x ∈ s → f x = g x) :
   integrable_on s f ↔ integrable_on s g :=
 by { simp only [integrable_on], apply integrable_iff_of_ae_eq, exact indicator_congr_ae h }
 

--- a/src/measure_theory/set_integral.lean
+++ b/src/measure_theory/set_integral.lean
@@ -110,7 +110,7 @@ lemma integrable_on_congr_ae (h : ∀ₘx, x ∈ s → f x = g x) :
 by { apply integrable_congr_ae, exact indicator_congr_ae h }
 
 lemma integrable_on_empty : integrable_on ∅ f :=
-by { simp only [integrable_on, indicator_empty], exact integrable_zero }
+by { simp only [integrable_on, indicator_empty], apply integrable_zero }
 
 lemma integrable_on_of_integrable (s : set α) (hf : integrable f) : integrable_on s f :=
 by { refine integrable_of_le (λa, _) hf, apply norm_indicator_le_norm_self }
@@ -282,10 +282,36 @@ begin
   { filter_upwards [] λa, le_trans (tendsto_indicator_of_antimono _ h_mono _ _) (pure_le_nhds _) }
 end
 
--- TODO : prove the following proposition
-
--- lemma integral_on_Union (s : ℕ → set α) (f : α → β) (hm : ∀i, is_measurable (s i))
---   (hd : pairwise (disjoint on s)) (hf : integrable_on (Union s) f) :
---   integral_on (Union s) f = ∑i, integral_on (s i) f := sorry
+-- TODO : prove this for an encodable type
+-- by proving an encodable version of `filter.has_countable_basis_at_top_finset_nat`
+lemma integral_on_Union (s : ℕ → set α) (f : α → β) (hm : ∀i, is_measurable (s i))
+  (hd : ∀ i j, i ≠ j → s i ∩ s j = ∅) (hfm : measurable_on (Union s) f) (hfi : integrable_on (Union s) f) :
+  (∫ a in (Union s), f a) = ∑i, ∫ a in s i, f a :=
+suffices h : tendsto (λn:finset ℕ, n.sum (λ i, ∫ a in s i, f a)) at_top (𝓝 $ (∫ a in (Union s), f a)),
+  by { rwa tsum_eq_has_sum },
+begin
+  have : (λn:finset ℕ, n.sum (λ i, ∫ a in s i, f a)) = λn:finset ℕ, ∫ a in (⋃i∈n, s i), f a,
+  { funext,
+    rw [← integral_finset_sum, indicator_finset_Union],
+    { assume i hi j hj hij, exact hd i j hij },
+    { assume i, refine hfm.subset (hm _) (subset_Union _ _) },
+    { assume i, refine hfi.subset (subset_Union _ _) } },
+  rw this,
+  refine tendsto_integral_filter_of_dominated_convergence _ _ _ _ _ _ _,
+  { exact indicator (Union s) (λ a, ∥f a∥) },
+  { exact has_countable_basis_at_top_finset_nat },
+  { refine univ_mem_sets' (λ n, _),
+    simp only [mem_set_of_eq],
+    refine hfm.subset (is_measurable.Union (λ i, is_measurable.Union_Prop (λh, hm _)))
+      (bUnion_subset_Union _ _), },
+  { assumption },
+  { refine univ_mem_sets' (λ n, univ_mem_sets' $ _),
+    simp only [mem_set_of_eq],
+    assume a,
+    rw ← norm_indicator_eq_indicator_norm,
+    refine norm_indicator_le_of_subset (bUnion_subset_Union _ _) _ _ },
+  { rw [← integrable_on, integrable_on_norm_iff], assumption },
+  { filter_upwards [] λa, le_trans (tendsto_indicator_bUnion_finset _ _ _) (pure_le_nhds _) }
+end
 
 end integral_on

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -100,6 +100,31 @@ begin
   ... = _ : by simp [-infi_infi_eq_right, infi_and]
 end
 
+-- TODO : prove this for a encodable type
+lemma has_countable_basis_at_top_finset_nat : has_countable_basis (@at_top (finset ℕ) _) :=
+begin
+  rw has_countable_basis_iff_mono_seq',
+  use λi, {N : finset ℕ | ∃ n, i ≤ n ∧ finset.range n ⊆ N},
+  split,
+  { assume i j hij,
+    assume N, simp only [and_imp, mem_set_of_eq, exists_imp_distrib],
+    exact assume k hjk kN, ⟨k, ⟨le_trans hij hjk, kN⟩⟩ },
+  assume s, split,
+  { simp only [mem_at_top_sets, ge_iff_le, nonempty_of_inhabited, finset.le_iff_subset,
+      exists_imp_distrib],
+    assume M hM,
+    rcases finset.exists_nat_subset_range M with ⟨i, Mi⟩,
+    use i,
+    assume N, simp only [and_imp, mem_set_of_eq, exists_imp_distrib],
+    assume k hk kN,
+    refine hM _ (finset.subset.trans Mi (finset.subset.trans _ kN)),
+    rwa finset.range_subset },
+  simp only [mem_at_top_sets, ge_iff_le, nonempty_of_inhabited, finset.le_iff_subset, exists_imp_distrib],
+  refine λ i hsub, ⟨finset.range i, λN iN, hsub _⟩,
+  rw mem_set_of_eq,
+  refine ⟨i, ⟨le_refl _, iN⟩⟩
+end
+
 lemma has_countable_basis.tendsto_iff_seq_tendsto {f : α → β} {k : filter α} {l : filter β}
   (hcb : k.has_countable_basis) :
   tendsto f k l ↔ (∀ x : ℕ → α, tendsto x at_top k → tendsto (f ∘ x) at_top l) :=

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -103,26 +103,21 @@ end
 -- TODO : prove this for a encodable type
 lemma has_countable_basis_at_top_finset_nat : has_countable_basis (@at_top (finset ℕ) _) :=
 begin
-  rw has_countable_basis_iff_mono_seq',
-  use λi, {N : finset ℕ | ∃ n, i ≤ n ∧ finset.range n ⊆ N},
-  split,
-  { assume i j hij,
-    assume N, simp only [and_imp, mem_set_of_eq, exists_imp_distrib],
-    exact assume k hjk kN, ⟨k, ⟨le_trans hij hjk, kN⟩⟩ },
-  assume s, split,
-  { simp only [mem_at_top_sets, ge_iff_le, nonempty_of_inhabited, finset.le_iff_subset,
-      exists_imp_distrib],
-    assume M hM,
-    rcases finset.exists_nat_subset_range M with ⟨i, Mi⟩,
-    use i,
-    assume N, simp only [and_imp, mem_set_of_eq, exists_imp_distrib],
-    assume k hk kN,
-    refine hM _ (finset.subset.trans Mi (finset.subset.trans _ kN)),
-    rwa finset.range_subset },
-  simp only [mem_at_top_sets, ge_iff_le, nonempty_of_inhabited, finset.le_iff_subset, exists_imp_distrib],
-  refine λ i hsub, ⟨finset.range i, λN iN, hsub _⟩,
-  rw mem_set_of_eq,
-  refine ⟨i, ⟨le_refl _, iN⟩⟩
+  refine has_countable_basis_of_seq _ (λi, Ici (finset.range i)) (le_antisymm _ _),
+  { rw [at_top, le_infi_iff],
+    assume i,
+    refine infi_le_of_le (finset.range i) _,
+    simp only [mem_principal_sets, le_principal_iff, finset.le_iff_subset],
+    assume N,
+    simp only [imp_self, set.mem_Ici, set.mem_set_of_eq, finset.le_iff_subset] },
+  { rw [at_top, le_infi_iff],
+    assume N,
+    rcases finset.exists_nat_subset_range N with ⟨i, Ni⟩,
+    refine infi_le_of_le i _,
+    simp only [mem_principal_sets, le_principal_iff, finset.le_iff_subset],
+    assume M,
+    simp only [mem_set_of_eq, mem_Ici, finset.le_iff_subset],
+    refine finset.subset.trans Ni },
 end
 
 lemma has_countable_basis.tendsto_iff_seq_tendsto {f : α → β} {k : filter α} {l : filter β}

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -103,21 +103,14 @@ end
 -- TODO : prove this for a encodable type
 lemma has_countable_basis_at_top_finset_nat : has_countable_basis (@at_top (finset ℕ) _) :=
 begin
-  refine has_countable_basis_of_seq _ (λi, Ici (finset.range i)) (le_antisymm _ _),
-  { rw [at_top, le_infi_iff],
-    assume i,
-    refine infi_le_of_le (finset.range i) _,
-    simp only [mem_principal_sets, le_principal_iff, finset.le_iff_subset],
-    assume N,
-    simp only [imp_self, set.mem_Ici, set.mem_set_of_eq, finset.le_iff_subset] },
-  { rw [at_top, le_infi_iff],
-    assume N,
-    rcases finset.exists_nat_subset_range N with ⟨i, Ni⟩,
-    refine infi_le_of_le i _,
-    simp only [mem_principal_sets, le_principal_iff, finset.le_iff_subset],
-    assume M,
-    simp only [mem_set_of_eq, mem_Ici, finset.le_iff_subset],
-    refine finset.subset.trans Ni },
+  refine has_countable_basis_of_seq _ (λN, Ici (finset.range N)) (eq_infi_of_mem_sets_iff_exists_mem _),
+  assume s,
+  rw mem_at_top_sets,
+  refine ⟨_, λ ⟨N, hN⟩, ⟨finset.range N, hN⟩⟩,
+  rintros ⟨t, ht⟩,
+  rcases mem_at_top_sets.1 (tendsto_finset_range (mem_at_top t)) with ⟨N, hN⟩,
+  simp only [preimage, mem_set_of_eq] at hN,
+  exact ⟨N, mem_principal_sets.2 $ λ t' ht', ht t' $ le_trans (hN _ $ le_refl N) ht'⟩
 end
 
 lemma has_countable_basis.tendsto_iff_seq_tendsto {f : α → β} {k : filter α} {l : filter β}


### PR DESCRIPTION
Indicator functions and integrals over subsets, ref #1853.

I implemented indicator functions a bit differently. 
```lean
def indicator (s : set α) (f : α → β) : α → β := λ x, if x ∈ s then f x else 0
```

Also, I turned on classical and non-computable because sometimes the typeclass inference system find `decidable_union` on one hand and `classical.prop_decidable` on the other hand. I think for people who care about decidability they can just use if-then-else.

Finally, I don't know how to prove `integral_on_Union`
```lean
integral_on (Union s) f = ∑i, integral_on (s i) f
```
with a pairwise disjoint family of sets `s : ℕ → set α`. It should have been easy, except `tsum` is not the usual sum.


P.S. I also changed things like `integral (f + g)` to `integral (λa, f a + g a)`. 

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)