### PR TITLE
chore(*): use `ne_` instead of `neq_` in lemma names

### DIFF
--- a/scripts/nolints.txt
+++ b/scripts/nolints.txt
@@ -1004,8 +1004,10 @@ filter.filter_product.of_seq_one
 filter.filter_product.of_seq_zero
 filter.gi_generate
 filter.hyperfilter
-filter.infi_neq_bot_iff_of_directed
-filter.infi_neq_bot_of_directed
+filter.infi_ne_bot_iff_of_directed
+filter.infi_ne_bot_of_directed
+filter.infi_ne_bot_iff_of_directed'
+filter.infi_ne_bot_of_directed'
 filter.infi_sets_eq
 filter.infi_sets_eq'
 filter.is_bounded_default

--- a/src/order/bounded_lattice.lean
+++ b/src/order/bounded_lattice.lean
@@ -109,7 +109,7 @@ theorem eq_bot_iff : a = ⊥ ↔ a ≤ ⊥ :=
 @[simp] theorem not_lt_bot : ¬ a < ⊥ :=
 assume h, lt_irrefl a (lt_of_lt_of_le h bot_le)
 
-theorem neq_bot_of_le_neq_bot {a b : α} (hb : b ≠ ⊥) (hab : b ≤ a) : a ≠ ⊥ :=
+theorem ne_bot_of_le_ne_bot {a b : α} (hb : b ≠ ⊥) (hab : b ≤ a) : a ≠ ⊥ :=
 assume ha, hb $ bot_unique $ ha ▸ hab
 
 theorem eq_bot_mono (h : a ≤ b) (h₂ : b = ⊥) : a = ⊥ :=

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -401,13 +401,13 @@ exists_mem_of_ne_empty this
 lemma filter_eq_bot_of_not_nonempty {f : filter α} (ne : ¬ nonempty α) : f = ⊥ :=
 empty_in_sets_eq_bot.mp $ univ_mem_sets' $ assume x, false.elim (ne ⟨x⟩)
 
-lemma forall_sets_neq_empty_iff_neq_bot {f : filter α} :
+lemma forall_sets_ne_empty_iff_ne_bot {f : filter α} :
   (∀ (s : set α), s ∈ f → s ≠ ∅) ↔ f ≠ ⊥ :=
 by
   simp only [(@empty_in_sets_eq_bot α f).symm, ne.def];
   exact ⟨assume h hs, h _ hs rfl, assume h s hs eq, h $ eq ▸ hs⟩
 
-lemma mem_sets_of_neq_bot {f : filter α} {s : set α} (h : f ⊓ principal (-s) = ⊥) : s ∈ f :=
+lemma mem_sets_of_eq_bot {f : filter α} {s : set α} (h : f ⊓ principal (-s) = ⊥) : s ∈ f :=
 have ∅ ∈ f ⊓ principal (- s), from h.symm ▸ mem_bot_sets,
 let ⟨s₁, hs₁, s₂, (hs₂ : -s ⊆ s₂), (hs : s₁ ∩ s₂ ⊆ ∅)⟩ := this in
 by filter_upwards [hs₁] assume a ha, classical.by_contradiction $ assume ha', hs ⟨ha, hs₂ ha'⟩
@@ -757,7 +757,7 @@ def cofinite : filter α :=
     by simp only [compl_inter, finite_union, ht, hs, mem_set_of_eq] }
 
 lemma cofinite_ne_bot (hi : set.infinite (@set.univ α)) : @cofinite α ≠ ⊥ :=
-forall_sets_neq_empty_iff_neq_bot.mp
+forall_sets_ne_empty_iff_ne_bot.mp
   $ λ s hs hn, by change set.finite _ at hs;
     rw [hn, set.compl_empty] at hs; exact hi hs
 
@@ -957,28 +957,28 @@ theorem map_comap_of_surjective {f : α → β} (hf : function.surjective f) (l 
   map f (comap f l) = l :=
 le_antisymm map_comap_le (le_map_comap_of_surjective hf l)
 
-lemma comap_neq_bot {f : filter β} {m : α → β}
+lemma comap_ne_bot {f : filter β} {m : α → β}
   (hm : ∀t∈ f, ∃a, m a ∈ t) : comap m f ≠ ⊥ :=
-forall_sets_neq_empty_iff_neq_bot.mp $ assume s ⟨t, ht, t_s⟩,
+forall_sets_ne_empty_iff_ne_bot.mp $ assume s ⟨t, ht, t_s⟩,
   let ⟨a, (ha : a ∈ preimage m t)⟩ := hm t ht in
-  neq_bot_of_le_neq_bot (ne_empty_of_mem ha) t_s
+  ne_bot_of_le_ne_bot (ne_empty_of_mem ha) t_s
 
 lemma comap_ne_bot_of_range_mem {f : filter β} {m : α → β}
   (hf : f ≠ ⊥) (hm : range m ∈ f) : comap m f ≠ ⊥ :=
-comap_neq_bot $ assume t ht,
+comap_ne_bot $ assume t ht,
   let ⟨_, ha, a, rfl⟩ := inhabited_of_mem_sets hf (inter_mem_sets ht hm)
   in ⟨a, ha⟩
 
 lemma comap_inf_principal_ne_bot_of_image_mem {f : filter β} {m : α → β}
   (hf : f ≠ ⊥) {s : set α} (hs : m '' s ∈ f) : (comap m f ⊓ principal s) ≠ ⊥ :=
 begin
-  refine compl_compl s ▸ mt mem_sets_of_neq_bot _,
+  refine compl_compl s ▸ mt mem_sets_of_eq_bot _,
   rintros ⟨t, ht, hts⟩,
   rcases inhabited_of_mem_sets hf (inter_mem_sets hs ht) with ⟨_, ⟨x, hxs, rfl⟩, hxt⟩,
   exact absurd hxs (hts hxt)
 end
 
-lemma comap_neq_bot_of_surj {f : filter β} {m : α → β}
+lemma comap_ne_bot_of_surj {f : filter β} {m : α → β}
   (hf : f ≠ ⊥) (hm : function.surjective m) : comap m f ≠ ⊥ :=
 comap_ne_bot_of_range_mem hf $ univ_mem_sets' hm
 
@@ -1090,7 +1090,7 @@ by simp only [iff_self, pure_def, mem_principal_sets, singleton_subset_iff]
 lemma singleton_mem_pure_sets {a : α} : {a} ∈ (pure a : filter α) :=
 by simp only [mem_singleton, pure_def, mem_principal_sets, singleton_subset_iff]
 
-@[simp] lemma pure_neq_bot {α : Type u} {a : α} : pure a ≠ (⊥ : filter α) :=
+@[simp] lemma pure_ne_bot {α : Type u} {a : α} : pure a ≠ (⊥ : filter α) :=
 by simp only [pure, has_pure.pure, ne.def, not_false_iff, singleton_ne_empty, principal_eq_bot_iff]
 
 lemma mem_seq_sets_def {f : filter (α → β)} {g : filter α} {s : set β} :
@@ -1224,29 +1224,40 @@ show join (map f (principal s)) = (⨆x ∈ s, f x),
 
 end bind
 
-lemma infi_neq_bot_of_directed {f : ι → filter α}
-  (hn : nonempty α) (hd : directed (≥) f) (hb : ∀i, f i ≠ ⊥) : (infi f) ≠ ⊥ :=
-let ⟨x⟩ := hn in
-assume h, have he: ∅  ∈ (infi f), from h.symm ▸ (mem_bot_sets : ∅ ∈ (⊥ : filter α)),
-classical.by_cases
-  (assume : nonempty ι,
-    have ∃i, ∅ ∈ f i,
-      by rw [mem_infi hd this] at he; simp only [mem_Union] at he; assumption,
-    let ⟨i, hi⟩ := this in
-    hb i $ bot_unique $
-    assume s _, (f i).sets_of_superset hi $ empty_subset _)
-  (assume : ¬ nonempty ι,
-    have univ ⊆ (∅ : set α),
-    begin
-      rw [←principal_mono, principal_univ, principal_empty, ←h],
-      exact (le_infi $ assume i, false.elim $ this ⟨i⟩)
-    end,
-    this $ mem_univ x)
+/-- If `f : ι → filter α` is derected, `ι` is not empty, and `∀ i, f i ≠ ⊥`, then `infi f ≠ ⊥`.
+See also `infi_ne_bot_of_directed` for a version assuming `nonempty α` instead of `nonempty ι`. -/
+lemma infi_ne_bot_of_directed' {f : ι → filter α} (hn : nonempty ι)
+  (hd : directed (≥) f) (hb : ∀i, f i ≠ ⊥) : (infi f) ≠ ⊥ :=
+begin
+  intro h,
+  have he: ∅  ∈ (infi f), from h.symm ▸ (mem_bot_sets : ∅ ∈ (⊥ : filter α)),
+  obtain ⟨i, hi⟩ : ∃i, ∅ ∈ f i,
+    by rwa [mem_infi hd hn, mem_Union] at he,
+  exact hb i (empty_in_sets_eq_bot.1 hi)
+end
 
-lemma infi_neq_bot_iff_of_directed {f : ι → filter α}
+/-- If `f : ι → filter α` is derected, `α` is not empty, and `∀ i, f i ≠ ⊥`, then `infi f ≠ ⊥`.
+See also `infi_ne_bot_of_directed'` for a version assuming `nonempty ι` instead of `nonempty α`. -/
+lemma infi_ne_bot_of_directed {f : ι → filter α}
+  (hn : nonempty α) (hd : directed (≥) f) (hb : ∀i, f i ≠ ⊥) : (infi f) ≠ ⊥ :=
+if hι : nonempty ι then infi_ne_bot_of_directed' hι hd hb else
+assume h : infi f = ⊥,
+have univ ⊆ (∅ : set α),
+begin
+  rw [←principal_mono, principal_univ, principal_empty, ←h],
+  exact (le_infi $ assume i, false.elim $ hι ⟨i⟩)
+end,
+let ⟨x⟩ := hn in this (mem_univ x)
+
+lemma infi_ne_bot_iff_of_directed' {f : ι → filter α}
+  (hn : nonempty ι) (hd : directed (≥) f) : (infi f) ≠ ⊥ ↔ (∀i, f i ≠ ⊥) :=
+⟨assume ne_bot i, ne_bot_of_le_ne_bot ne_bot (infi_le _ i),
+  infi_ne_bot_of_directed' hn hd⟩
+
+lemma infi_ne_bot_iff_of_directed {f : ι → filter α}
   (hn : nonempty α) (hd : directed (≥) f) : (infi f) ≠ ⊥ ↔ (∀i, f i ≠ ⊥) :=
-⟨assume neq_bot i eq_bot, neq_bot $ bot_unique $ infi_le_of_le i $ eq_bot ▸ le_refl _,
-  infi_neq_bot_of_directed hn hd⟩
+⟨assume ne_bot i, ne_bot_of_le_ne_bot ne_bot (infi_le _ i),
+  infi_ne_bot_of_directed hn hd⟩
 
 lemma mem_infi_sets {f : ι → filter α} (i : ι) : ∀{s}, s ∈ f i → s ∈ ⨅i, f i :=
 show (⨅i, f i) ≤ f i, from infi_le _ _
@@ -1320,7 +1331,7 @@ le_trans h₂ h₁
 
 lemma tendsto.ne_bot {f : α → β} {x : filter α} {y : filter β} (h : tendsto f x y) (hx : x ≠ ⊥) :
   y ≠ ⊥ :=
-neq_bot_of_le_neq_bot (map_ne_bot hx) h
+ne_bot_of_le_ne_bot (map_ne_bot hx) h
 
 lemma tendsto_map {f : α → β} {x : filter α} : tendsto f x (map f x) := le_refl (map f x)
 
@@ -1539,7 +1550,7 @@ begin
     exact prod_bot }
 end
 
-lemma prod_neq_bot {f : filter α} {g : filter β} : filter.prod f g ≠ ⊥ ↔ (f ≠ ⊥ ∧ g ≠ ⊥) :=
+lemma prod_ne_bot {f : filter α} {g : filter β} : filter.prod f g ≠ ⊥ ↔ (f ≠ ⊥ ∧ g ≠ ⊥) :=
 by rw [(≠), prod_eq_bot, not_or_distrib]
 
 lemma tendsto_prod_iff {f : α × β → γ} {x : filter α} {y : filter β} {z : filter γ} :
@@ -1567,7 +1578,7 @@ lemma mem_at_top [preorder α] (a : α) : {b : α | a ≤ b} ∈ @at_top α _ :=
 mem_infi_sets a $ subset.refl _
 
 @[simp] lemma at_top_ne_bot [nonempty α] [semilattice_sup α] : (at_top : filter α) ≠ ⊥ :=
-infi_neq_bot_of_directed (by apply_instance)
+infi_ne_bot_of_directed (by apply_instance)
   (assume a b, ⟨a ⊔ b, by simp only [ge, le_principal_iff, forall_const, set_of_subset_set_of,
     mem_principal_sets, and_self, sup_le_iff, forall_true_iff] {contextual := tt}⟩)
   (assume a, by simp only [principal_eq_bot_iff, ne.def, principal_eq_bot_iff]; exact ne_empty_of_mem (le_refl a))
@@ -1828,7 +1839,7 @@ lemma ultrafilter_iff_compl_mem_iff_not_mem :
       hf.1 $ empty_in_sets_eq_bot.mp $ by convert f.inter_sets hs hns; rw [inter_compl_self],
     assume hs,
       have f ≤ principal (-s), from
-        le_of_ultrafilter hf $ assume h, hs $ mem_sets_of_neq_bot $
+        le_of_ultrafilter hf $ assume h, hs $ mem_sets_of_eq_bot $
           by simp only [h, eq_self_iff_true, lattice.neg_neg],
       by simp only [le_principal_iff] at this; assumption⟩,
  assume hf,
@@ -1889,7 +1900,7 @@ let
   top : τ          := ⟨f, h, le_refl f⟩,
   sup : Π(c:set τ), chain r c → τ :=
     λc hc, ⟨⨅a:{a:τ // a ∈ insert top c}, a.val.val,
-      infi_neq_bot_of_directed ⟨a⟩
+      infi_ne_bot_of_directed ⟨a⟩
         (directed_of_chain $ chain_insert hc $ assume ⟨b, _, hb⟩ _ _, or.inl hb)
         (assume ⟨⟨a, ha, _⟩, _⟩, ha),
       infi_le_of_le ⟨top, mem_insert _ _⟩ (le_refl _)⟩
@@ -2020,7 +2031,7 @@ lemma ultrafilter.eq_iff_val_le_val {u v : ultrafilter α} : u = v ↔ u.val ≤
  assume h, by rw subtype.ext; apply ultrafilter_unique v.property u.property.1 h⟩
 
 lemma exists_ultrafilter_iff (f : filter α) : (∃ (u : ultrafilter α), u.val ≤ f) ↔ f ≠ ⊥ :=
-⟨assume ⟨u, uf⟩, lattice.neq_bot_of_le_neq_bot u.property.1 uf,
+⟨assume ⟨u, uf⟩, lattice.ne_bot_of_le_ne_bot u.property.1 uf,
  assume h, let ⟨u, uf, hu⟩ := exists_ultrafilter h in ⟨⟨u, hu⟩, uf⟩⟩
 
 end ultrafilter

--- a/src/order/filter/lift.lean
+++ b/src/order/filter/lift.lean
@@ -135,22 +135,13 @@ theorem monotone_lift [preorder γ] {f : γ → filter α} {g : γ → set α �
   (hf : monotone f) (hg : monotone g) : monotone (λc, (f c).lift (g c)) :=
 assume a b h, lift_mono (hf h) (hg h)
 
-lemma lift_neq_bot_iff (hm : monotone g) : (f.lift g ≠ ⊥) ↔ (∀s∈f.sets, g s ≠ ⊥) :=
-classical.by_cases
-  (assume hn : nonempty β,
-    calc f.lift g ≠ ⊥ ↔ (⨅s : { s // s ∈ f.sets}, g s.val) ≠ ⊥ :
-      by simp only [filter.lift, infi_subtype, iff_self, ne.def]
-      ... ↔ (∀s:{ s // s ∈ f.sets}, g s.val ≠ ⊥) :
-        infi_neq_bot_iff_of_directed hn
-          (assume ⟨a, ha⟩ ⟨b, hb⟩, ⟨⟨a ∩ b, inter_mem_sets ha hb⟩,
-            hm $ inter_subset_left _ _, hm $ inter_subset_right _ _⟩)
-      ... ↔ (∀s∈f.sets, g s ≠ ⊥) : ⟨assume h s hs, h ⟨s, hs⟩, assume h ⟨s, hs⟩, h s hs⟩)
-  (assume hn : ¬ nonempty β,
-    have h₁ : f.lift g = ⊥, from filter_eq_bot_of_not_nonempty hn,
-    have h₂ : ∀s, g s = ⊥, from assume s, filter_eq_bot_of_not_nonempty hn,
-    calc (f.lift g ≠ ⊥) ↔ false : by simp only [h₁, iff_self, eq_self_iff_true, not_true, ne.def]
-      ... ↔ (∀s∈f.sets, false) : ⟨false.elim, assume h, h univ univ_mem_sets⟩
-      ... ↔ (∀s∈f.sets, g s ≠ ⊥) : by simp only [h₂, iff_self, eq_self_iff_true, not_true, ne.def])
+lemma lift_ne_bot_iff (hm : monotone g) : (f.lift g ≠ ⊥) ↔ (∀s∈f, g s ≠ ⊥) :=
+begin
+  rw [filter.lift, infi_subtype', infi_ne_bot_iff_of_directed', subtype.forall'],
+  { exact ⟨⟨univ, univ_mem_sets⟩⟩ },
+  { rintros ⟨s, hs⟩ ⟨t, ht⟩,
+    exact ⟨⟨s ∩ t, inter_mem_sets hs ht⟩, hm (inter_subset_left s t), hm (inter_subset_right s t)⟩ }
+end
 
 @[simp] lemma lift_const {f : filter α} {g : filter β} : f.lift (λx, g) = g :=
 le_antisymm (lift_le univ_mem_sets $ le_refl g) (le_lift $ assume s hs, le_refl g)
@@ -286,10 +277,10 @@ le_antisymm
     (infi_le_of_le univ $ infi_le_of_le univ_mem_sets $
     by simp only [le_principal_iff, inter_subset_right, mem_principal_sets, function.comp_app]; exact inter_subset_left _ _))
 
-lemma lift'_neq_bot_iff (hh : monotone h) : (f.lift' h ≠ ⊥) ↔ (∀s∈f.sets, h s ≠ ∅) :=
-calc (f.lift' h ≠ ⊥) ↔ (∀s∈f.sets, principal (h s) ≠ ⊥) :
-    lift_neq_bot_iff (monotone_principal.comp hh)
-  ... ↔ (∀s∈f.sets, h s ≠ ∅) : by simp only [principal_eq_bot_iff, iff_self, ne.def, principal_eq_bot_iff]
+lemma lift'_ne_bot_iff (hh : monotone h) : (f.lift' h ≠ ⊥) ↔ (∀s∈f, h s ≠ ∅) :=
+calc (f.lift' h ≠ ⊥) ↔ (∀s∈f, principal (h s) ≠ ⊥) :
+    lift_ne_bot_iff (monotone_principal.comp hh)
+  ... ↔ (∀s∈f, h s ≠ ∅) : by simp only [principal_eq_bot_iff, iff_self, ne.def, principal_eq_bot_iff]
 
 @[simp] lemma lift'_id {f : filter α} : f.lift' id = f :=
 lift_principal2

--- a/src/order/filter/pointwise.lean
+++ b/src/order/filter/pointwise.lean
@@ -75,7 +75,7 @@ lemma pointwise_mul_le_mul [monoid α] {f₁ f₂ g₁ g₂ : filter α} (hf : f
 @[to_additive]
 lemma pointwise_mul_ne_bot [monoid α] {f g : filter α} : f ≠ ⊥ → g ≠ ⊥ → f * g ≠ ⊥ :=
 begin
-  simp only [forall_sets_neq_empty_iff_neq_bot.symm],
+  simp only [forall_sets_ne_empty_iff_ne_bot.symm],
   rintros hf hg s ⟨a, ha, b, hb, ab⟩,
   rcases ne_empty_iff_exists_mem.1 (pointwise_mul_ne_empty (hf a ha) (hg b hb)) with ⟨x, hx⟩,
   exact ne_empty_iff_exists_mem.2 ⟨x, ab hx⟩

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -174,7 +174,7 @@ mem_at_top_sets.mpr $ exists.intro fsts $ assume bs (hbs : fsts ⊆ bs),
     from tendsto_finset_sum bs $
       assume c hc, tendsto_infi' c $ tendsto_infi' hc $ by apply tendsto.comp (hf c) tendsto_comap,
   have bs.sum g ∈ s,
-    from mem_of_closed_of_tendsto' this hsc $ forall_sets_neq_empty_iff_neq_bot.mp $
+    from mem_of_closed_of_tendsto' this hsc $ forall_sets_ne_empty_iff_ne_bot.mp $
       by simp [mem_inf_sets, exists_imp_distrib, and_imp, forall_and_distrib,
                filter.mem_infi_sets_finset, mem_comap_sets, skolem, mem_at_top_sets,
                and_comm];
@@ -183,7 +183,7 @@ mem_at_top_sets.mpr $ exists.intro fsts $ assume bs (hbs : fsts ⊆ bs),
         have (⋂b (h : b ∈ bs), (λp:(Πb, finset (γ b)), p b) ⁻¹' {cs' | cs b h ⊆ cs' }) ≤ (⨅b∈bs, p b),
           from infi_le_infi $ assume b, infi_le_infi $ assume hb,
             le_trans (set.preimage_mono $ hp' b hb) (hp b hb),
-        neq_bot_of_le_neq_bot (h _) (le_trans (set.inter_subset_inter (le_trans this hs₂) hs₃) hs₁),
+        ne_bot_of_le_ne_bot (h _) (le_trans (set.inter_subset_inter (le_trans this hs₂) hs₃) hs₁),
   hss' this
 
 lemma summable_sigma [regular_space α] {γ : β → Type*} {f : (Σb:β, γ b) → α}

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -861,7 +861,7 @@ variables [topological_space α] [topological_space β]
 lemma nhds_principal_ne_bot_of_is_lub {a : α} {s : set α} (ha : is_lub s a) (hs : s ≠ ∅) :
   𝓝 a ⊓ principal s ≠ ⊥ :=
 let ⟨a', ha'⟩ := exists_mem_of_ne_empty hs in
-forall_sets_neq_empty_iff_neq_bot.mp $ assume t ht,
+forall_sets_ne_empty_iff_ne_bot.mp $ assume t ht,
   let ⟨t₁, ht₁, t₂, ht₂, ht⟩ := mem_inf_sets.mp ht in
   by_cases
     (assume h : a = a',
@@ -1373,7 +1373,7 @@ is_bounded_of_le h (is_bounded_le_nhds a)
 
 @[nolint] -- see Note [nolint_ge]
 lemma is_cobounded_ge_nhds (a : α) : (𝓝 a).is_cobounded (≥) :=
-is_cobounded_of_is_bounded nhds_neq_bot (is_bounded_le_nhds a)
+is_cobounded_of_is_bounded nhds_ne_bot (is_bounded_le_nhds a)
 
 @[nolint] -- see Note [nolint_ge]
 lemma is_cobounded_under_ge_of_tendsto {f : filter β} {u : β → α} {a : α}
@@ -1398,7 +1398,7 @@ lemma is_bounded_under_ge_of_tendsto {f : filter β} {u : β → α} {a : α}
 is_bounded_of_le h (is_bounded_ge_nhds a)
 
 lemma is_cobounded_le_nhds (a : α) : (𝓝 a).is_cobounded (≤) :=
-is_cobounded_of_is_bounded nhds_neq_bot (is_bounded_ge_nhds a)
+is_cobounded_of_is_bounded nhds_ne_bot (is_bounded_ge_nhds a)
 
 lemma is_cobounded_under_le_of_tendsto {f : filter β} {u : β → α} {a : α}
   (hf : f ≠ ⊥) (h : tendsto u f (𝓝 a)) : f.is_cobounded_under (≤) u :=

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -400,11 +400,11 @@ begin
   rcases this with ⟨U₁, U₁_nhd, V₁, V₁_nhd, H⟩,
 
   have : ∃ x₁, x₁ ∈ U₁ := exists_mem_of_ne_empty
-    (forall_sets_neq_empty_iff_neq_bot.2 de.comap_nhds_neq_bot U₁ U₁_nhd),
+    (forall_sets_ne_empty_iff_ne_bot.2 de.comap_nhds_ne_bot U₁ U₁_nhd),
   rcases this with ⟨x₁, x₁_in⟩,
 
   have : ∃ y₁, y₁ ∈ V₁ := exists_mem_of_ne_empty
-    (forall_sets_neq_empty_iff_neq_bot.2 df.comap_nhds_neq_bot V₁ V₁_nhd),
+    (forall_sets_ne_empty_iff_ne_bot.2 df.comap_nhds_ne_bot V₁ V₁_nhd),
   rcases this with ⟨y₁, y₁_in⟩,
 
   rcases (extend_Z_bilin_aux de df hφ W_nhd x₀ y₁) with ⟨U₂, U₂_nhd, HU⟩,
@@ -441,7 +441,7 @@ begin
   rintro ⟨x₀, y₀⟩,
   split,
   { apply map_ne_bot,
-    apply comap_neq_bot,
+    apply comap_ne_bot,
 
     intros U h,
     rcases exists_mem_of_ne_empty (mem_closure_iff_nhds.1 ((de.prod df).dense (x₀, y₀)) U h)

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -288,7 +288,7 @@ let ⟨f, hf⟩ := this in
   have w : {s : set α // a ∈ s ∧ s ∈ b}, from ⟨t, ht₂, ht₁⟩,
   suffices (⨅ (x : {s // a ∈ s ∧ s ∈ b}), principal (x.val ∩ ⋃s (h₁ h₂ : s ∈ b), {f s h₂})) ≠ ⊥,
     by simpa only [closure_eq_nhds, nhds_eq, infi_inf w, inf_principal, mem_set_of_eq, mem_univ, iff_true],
-  infi_neq_bot_of_directed ⟨a⟩
+  infi_ne_bot_of_directed ⟨a⟩
     (assume ⟨s₁, has₁, hs₁⟩ ⟨s₂, has₂, hs₂⟩,
       have a ∈ s₁ ∩ s₂, from ⟨has₁, has₂⟩,
       let ⟨s₃, hs₃, has₃, hs⟩ := hb₃ _ hs₁ _ hs₂ _ this in

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -475,9 +475,7 @@ lemma tendsto_const_nhds {a : α} {f : filter β} : tendsto (λb:β, a) f (𝓝 
 tendsto_nhds.mpr $ assume s hs ha, univ_mem_sets' $ assume _, ha
 
 lemma pure_le_nhds : pure ≤ (𝓝 : α → filter α) :=
-assume a, by rw nhds_def; exact le_infi
-  (assume s, le_infi $ assume ⟨h₁, _⟩, principal_mono.mpr $
-    singleton_subset_iff.2 h₁)
+assume a s hs, mem_pure_sets.2 $ mem_of_nhds hs
 
 lemma tendsto_pure_nhds {α : Type*} [topological_space β] (f : α → β) (a : α) :
   tendsto f (pure a) (𝓝 (f a)) :=
@@ -486,11 +484,8 @@ begin
   exact pure_le_nhds (f a)
 end
 
-@[simp] lemma nhds_neq_bot {a : α} : 𝓝 a ≠ ⊥ :=
-assume : 𝓝 a = ⊥,
-have pure a = (⊥ : filter α),
-  from lattice.bot_unique $ this ▸ pure_le_nhds a,
-pure_neq_bot this
+@[simp] lemma nhds_ne_bot {a : α} : 𝓝 a ≠ ⊥ :=
+ne_bot_of_le_ne_bot pure_ne_bot (pure_le_nhds a)
 
 lemma interior_eq_nhds {s : set α} : interior s = {a | 𝓝 a ≤ principal s} :=
 set.ext $ λ x, by simp only [mem_interior, le_principal_iff, mem_nhds_sets_iff]; refl
@@ -556,11 +551,11 @@ lemma mem_of_closed_of_tendsto {f : β → α} {b : filter β} {a : α} {s : set
   (hb : b ≠ ⊥) (hf : tendsto f b (𝓝 a)) (hs : is_closed s) (h : f ⁻¹' s ∈ b) : a ∈ s :=
 have b.map f ≤ 𝓝 a ⊓ principal s,
   from le_trans (le_inf (le_refl _) (le_principal_iff.mpr h)) (inf_le_inf hf (le_refl _)),
-is_closed_iff_nhds.mp hs a $ neq_bot_of_le_neq_bot (map_ne_bot hb) this
+is_closed_iff_nhds.mp hs a $ ne_bot_of_le_ne_bot (map_ne_bot hb) this
 
 lemma mem_of_closed_of_tendsto' {f : β → α} {x : filter β} {a : α} {s : set α}
   (hf : tendsto f x (𝓝 a)) (hs : is_closed s) (h : x ⊓ principal (f ⁻¹' s) ≠ ⊥) : a ∈ s :=
-is_closed_iff_nhds.mp hs _ $ neq_bot_of_le_neq_bot (@map_ne_bot _ _ _ f h) $
+is_closed_iff_nhds.mp hs _ $ ne_bot_of_le_ne_bot (@map_ne_bot _ _ _ f h) $
   le_inf (le_trans (map_mono $ inf_le_left) hf) $
     le_trans (map_mono $ inf_le_right_of_le $ by simp only [comap_principal, le_principal_iff]; exact subset.refl _) (@map_comap_le _ _ _ f)
 
@@ -613,7 +608,7 @@ lemma locally_finite_subset
 assume a,
 let ⟨t, ht₁, ht₂⟩ := hf₂ a in
 ⟨t, ht₁, finite_subset ht₂ $ assume i hi,
-  neq_bot_of_le_neq_bot hi $ inter_subset_inter (hf i) $ subset.refl _⟩
+  ne_bot_of_le_ne_bot hi $ inter_subset_inter (hf i) $ subset.refl _⟩
 
 lemma is_closed_Union_of_locally_finite {f : β → set α}
   (h₁ : locally_finite f) (h₂ : ∀i, is_closed (f i)) : is_closed (⋃i, f i) :=
@@ -796,7 +791,7 @@ have ∀ (a : α), 𝓝 a ⊓ principal s ≠ ⊥ → 𝓝 (f a) ⊓ principal (
     from le_inf
       (le_trans (map_mono inf_le_left) $ by rw [continuous_iff_continuous_at] at h; exact h a)
       (le_trans (map_mono inf_le_right) $ by simp; exact subset.refl _),
-  neq_bot_of_le_neq_bot h₁ h₂,
+  ne_bot_of_le_ne_bot h₁ h₂,
 by simp [image_subset_iff, closure_eq_nhds]; assumption
 
 lemma mem_closure {s : set α} {t : set β} {f : α → β} {a : α}

--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -267,7 +267,7 @@ set.ext $ assume ⟨a, b⟩,
 have filter.prod (𝓝 a) (𝓝 b) ⊓ principal (set.prod s t) =
   filter.prod (𝓝 a ⊓ principal s) (𝓝 b ⊓ principal t),
   by rw [←prod_inf_prod, prod_principal_principal],
-by simp [closure_eq_nhds, nhds_prod_eq, this]; exact prod_neq_bot
+by simp [closure_eq_nhds, nhds_prod_eq, this]; exact prod_ne_bot
 
 lemma mem_closure2 {s : set α} {t : set β} {u : set γ} {f : α → β → γ} {a : α} {b : β}
   (hf : continuous (λp:α×β, f p.1 p.2)) (ha : a ∈ closure s) (hb : b ∈ closure t)

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -176,7 +176,7 @@ lemma mem_closure_iff_nhds_within_ne_bot {s : set α} {x : α} :
 begin
   split,
   { assume hx,
-    rw ← forall_sets_neq_empty_iff_neq_bot,
+    rw ← forall_sets_ne_empty_iff_ne_bot,
     assume o ho,
     rw mem_nhds_within at ho,
     rcases ho with ⟨u, u_open, xu, hu⟩,
@@ -188,7 +188,7 @@ begin
     have : u ∩ s ∈ nhds_within x s,
     { rw mem_nhds_within,
       exact ⟨u, u_open, xu, subset.refl _⟩ },
-    exact forall_sets_neq_empty_iff_neq_bot.2 h (u ∩ s) this }
+    exact forall_sets_ne_empty_iff_ne_bot.2 h (u ∩ s) this }
 end
 
 lemma nhds_within_ne_bot_of_mem {s : set α} {x : α} (hx : x ∈ s) :

--- a/src/topology/dense_embedding.lean
+++ b/src/topology/dense_embedding.lean
@@ -145,18 +145,18 @@ begin
   exact le_trans lim1 lim2,
 end
 
-protected lemma nhds_inf_neq_bot (di : dense_inducing i) {b : β} : 𝓝 b ⊓ principal (range i) ≠ ⊥ :=
+protected lemma nhds_inf_ne_bot (di : dense_inducing i) {b : β} : 𝓝 b ⊓ principal (range i) ≠ ⊥ :=
 begin
   convert di.dense b,
   simp [closure_eq_nhds]
 end
 
-lemma comap_nhds_neq_bot (di : dense_inducing i) {b : β} : comap i (𝓝 b) ≠ ⊥ :=
-forall_sets_neq_empty_iff_neq_bot.mp $
+lemma comap_nhds_ne_bot (di : dense_inducing i) {b : β} : comap i (𝓝 b) ≠ ⊥ :=
+forall_sets_ne_empty_iff_ne_bot.mp $
 assume s ⟨t, ht, (hs : i ⁻¹' t ⊆ s)⟩,
 have t ∩ range i ∈ 𝓝 b ⊓ principal (range i),
   from inter_mem_inf_sets ht (subset.refl _),
-let ⟨_, ⟨hx₁, y, rfl⟩⟩ := inhabited_of_mem_sets di.nhds_inf_neq_bot this in
+let ⟨_, ⟨hx₁, y, rfl⟩⟩ := inhabited_of_mem_sets di.nhds_inf_ne_bot this in
 subset_ne_empty hs $ ne_empty_of_mem hx₁
 
 variables [topological_space γ]
@@ -170,7 +170,7 @@ def extend (di : dense_inducing i) (f : α → γ) (b : β) : γ :=
 
 lemma extend_eq [t2_space γ] {b : β} {c : γ} {f : α → γ} (hf : map f (comap i (𝓝 b)) ≤ 𝓝 c) :
   di.extend f b = c :=
-@lim_eq _ _ (id _) _ _ _ (by simp; exact comap_nhds_neq_bot di) hf
+@lim_eq _ _ (id _) _ _ _ (by simp; exact comap_nhds_ne_bot di) hf
 
 lemma extend_e_eq [t2_space γ] {f : α → γ} (a : α) (hf : continuous_at f a) :
   di.extend f (i a) = f a :=
@@ -205,9 +205,9 @@ have h₂ : t ⊆ di.extend f ⁻¹' closure (f '' (i ⁻¹' t)), from
   show di.extend f b' ∈ closure (f '' (i ⁻¹' t)),
   begin
     rw [closure_eq_nhds],
-    apply neq_bot_of_le_neq_bot _ this,
+    apply ne_bot_of_le_ne_bot _ this,
     simp,
-    exact di.comap_nhds_neq_bot
+    exact di.comap_nhds_ne_bot
   end,
 (𝓝 b).sets_of_superset
   (show t ∈ 𝓝 b, from mem_nhds_sets ht₂ ht₃)

--- a/src/topology/order.lean
+++ b/src/topology/order.lean
@@ -549,7 +549,7 @@ lemma closure_induced [t : topological_space β] {f : α → β} {a : α} {s : s
 have comap f (𝓝 (f a) ⊓ principal (f '' s)) ≠ ⊥ ↔ 𝓝 (f a) ⊓ principal (f '' s) ≠ ⊥,
   from ⟨assume h₁ h₂, h₁ $ h₂.symm ▸ comap_bot,
     assume h,
-    forall_sets_neq_empty_iff_neq_bot.mp $
+    forall_sets_ne_empty_iff_ne_bot.mp $
       assume s₁ ⟨s₂, hs₂, (hs : f ⁻¹' s₂ ⊆ s₁)⟩,
       have f '' s ∈ 𝓝 (f a) ⊓ principal (f '' s),
         from mem_inf_sets_of_right $ by simp [subset.refl],

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -149,7 +149,7 @@ instance t2_space.t1_space [t2_space α] : t1_space α :=
 let ⟨u, v, hu, hv, hyu, hxv, huv⟩ := t2_separation (mt mem_singleton_of_eq hxy) in
 ⟨u, λ z hz1 hz2, ((ext_iff _ _).1 huv x).1 ⟨mem_singleton_iff.1 hz2 ▸ hz1, hxv⟩, hu, hyu⟩⟩
 
-lemma eq_of_nhds_neq_bot [ht : t2_space α] {x y : α} (h : 𝓝 x ⊓ 𝓝 y ≠ ⊥) : x = y :=
+lemma eq_of_nhds_ne_bot [ht : t2_space α] {x y : α} (h : 𝓝 x ⊓ 𝓝 y ≠ ⊥) : x = y :=
 classical.by_contradiction $ assume : x ≠ y,
 let ⟨u, v, hu, hv, hx, hy, huv⟩ := t2_space.t2 x y this in
 have u ∩ v ∈ 𝓝 x ⊓ 𝓝 y,
@@ -157,7 +157,7 @@ have u ∩ v ∈ 𝓝 x ⊓ 𝓝 y,
 h $ empty_in_sets_eq_bot.mp $ huv ▸ this
 
 lemma t2_iff_nhds : t2_space α ↔ ∀ {x y : α}, 𝓝 x ⊓ 𝓝 y ≠ ⊥ → x = y :=
-⟨assume h, by exactI λ x y, eq_of_nhds_neq_bot,
+⟨assume h, by exactI λ x y, eq_of_nhds_ne_bot,
  assume h, ⟨assume x y xy,
    have 𝓝 x ⊓ 𝓝 y = ⊥ := classical.by_contradiction (mt h xy),
    let ⟨u', hu', v', hv', u'v'⟩ := empty_in_sets_eq_bot.mpr this,
@@ -168,29 +168,29 @@ lemma t2_iff_nhds : t2_space α ↔ ∀ {x y : α}, 𝓝 x ⊓ 𝓝 y ≠ ⊥ �
 lemma t2_iff_ultrafilter :
   t2_space α ↔ ∀ f {x y : α}, is_ultrafilter f → f ≤ 𝓝 x → f ≤ 𝓝 y → x = y :=
 t2_iff_nhds.trans
-  ⟨assume h f x y u fx fy, h $ neq_bot_of_le_neq_bot u.1 (le_inf fx fy),
+  ⟨assume h f x y u fx fy, h $ ne_bot_of_le_ne_bot u.1 (le_inf fx fy),
    assume h x y xy,
      let ⟨f, hf, uf⟩ := exists_ultrafilter xy in
      h f uf (le_trans hf lattice.inf_le_left) (le_trans hf lattice.inf_le_right)⟩
 
 @[simp] lemma nhds_eq_nhds_iff {a b : α} [t2_space α] : 𝓝 a = 𝓝 b ↔ a = b :=
-⟨assume h, eq_of_nhds_neq_bot $ by rw [h, inf_idem]; exact nhds_neq_bot, assume h, h ▸ rfl⟩
+⟨assume h, eq_of_nhds_ne_bot $ by rw [h, inf_idem]; exact nhds_ne_bot, assume h, h ▸ rfl⟩
 
 @[simp] lemma nhds_le_nhds_iff {a b : α} [t2_space α] : 𝓝 a ≤ 𝓝 b ↔ a = b :=
-⟨assume h, eq_of_nhds_neq_bot $ by rw [inf_of_le_left h]; exact nhds_neq_bot, assume h, h ▸ le_refl _⟩
+⟨assume h, eq_of_nhds_ne_bot $ by rw [inf_of_le_left h]; exact nhds_ne_bot, assume h, h ▸ le_refl _⟩
 
 lemma tendsto_nhds_unique [t2_space α] {f : β → α} {l : filter β} {a b : α}
   (hl : l ≠ ⊥) (ha : tendsto f l (𝓝 a)) (hb : tendsto f l (𝓝 b)) : a = b :=
-eq_of_nhds_neq_bot $ neq_bot_of_le_neq_bot (map_ne_bot hl) $ le_inf ha hb
+eq_of_nhds_ne_bot $ ne_bot_of_le_ne_bot (map_ne_bot hl) $ le_inf ha hb
 
 section lim
 variables [inhabited α] [t2_space α] {f : filter α}
 
 lemma lim_eq {a : α} (hf : f ≠ ⊥) (h : f ≤ 𝓝 a) : lim f = a :=
-eq_of_nhds_neq_bot $ neq_bot_of_le_neq_bot hf $ le_inf (lim_spec ⟨_, h⟩) h
+eq_of_nhds_ne_bot $ ne_bot_of_le_ne_bot hf $ le_inf (lim_spec ⟨_, h⟩) h
 
 @[simp] lemma lim_nhds_eq {a : α} : lim (𝓝 a) = a :=
-lim_eq nhds_neq_bot (le_refl _)
+lim_eq nhds_ne_bot (le_refl _)
 
 @[simp] lemma lim_nhds_eq_of_closure {a : α} {s : set α} (h : a ∈ closure s) :
   lim (𝓝 a ⊓ principal s) = a :=
@@ -229,7 +229,7 @@ instance Pi.t2_space {α : Type*} {β : α → Type v} [t₂ : Πa, topological_
   separated_by_f (λz, z i) (infi_le _ i) hi⟩
 
 lemma is_closed_diagonal [t2_space α] : is_closed {p:α×α | p.1 = p.2} :=
-is_closed_iff_nhds.mpr $ assume ⟨a₁, a₂⟩ h, eq_of_nhds_neq_bot $ assume : 𝓝 a₁ ⊓ 𝓝 a₂ = ⊥, h $
+is_closed_iff_nhds.mpr $ assume ⟨a₁, a₂⟩ h, eq_of_nhds_ne_bot $ assume : 𝓝 a₁ ⊓ 𝓝 a₂ = ⊥, h $
   let ⟨t₁, ht₁, t₂, ht₂, (h' : t₁ ∩ t₂ ⊆ ∅)⟩ :=
     by rw [←empty_in_sets_eq_bot, mem_inf_sets] at this; exact this in
   begin
@@ -317,7 +317,7 @@ have ∃t, is_open t ∧ -s' ⊆ t ∧ 𝓝 a ⊓ principal t = ⊥,
   from regular_space.regular (is_closed_compl_iff.mpr h₂) (not_not_intro h₃),
 let ⟨t, ht₁, ht₂, ht₃⟩ := this in
 ⟨-t,
-  mem_sets_of_neq_bot $ by rwa [lattice.neg_neg],
+  mem_sets_of_eq_bot $ by rwa [lattice.neg_neg],
   subset.trans (compl_subset_comm.1 ht₂) h₁,
   is_closed_compl_iff.mpr ht₁⟩
 

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -33,7 +33,7 @@ lemma compact.inter_right {s t : set α} (hs : compact s) (ht : is_closed t) : c
 assume f hnf hstf,
 let ⟨a, hsa, (ha : f ⊓ 𝓝 a ≠ ⊥)⟩ := hs f hnf (le_trans hstf (le_principal_iff.2 (inter_subset_left _ _))) in
 have a ∈ t,
-  from ht.mem_of_nhds_within_ne_bot $ neq_bot_of_le_neq_bot (by { rw inf_comm at ha, exact ha }) $
+  from ht.mem_of_nhds_within_ne_bot $ ne_bot_of_le_ne_bot (by { rw inf_comm at ha, exact ha }) $
     inf_le_inf (le_refl _) (le_trans hstf (le_principal_iff.2 (inter_subset_right _ _))),
 ⟨a, ⟨hsa, this⟩, ha⟩
 
@@ -50,15 +50,15 @@ inter_eq_self_of_subset_right h ▸ hs.inter_right ht
 lemma compact.adherence_nhdset {s t : set α} {f : filter α}
   (hs : compact s) (hf₂ : f ≤ principal s) (ht₁ : is_open t) (ht₂ : ∀a∈s, 𝓝 a ⊓ f ≠ ⊥ → a ∈ t) :
   t ∈ f :=
-classical.by_cases mem_sets_of_neq_bot $
+classical.by_cases mem_sets_of_eq_bot $
   assume : f ⊓ principal (- t) ≠ ⊥,
   let ⟨a, ha, (hfa : f ⊓ principal (-t) ⊓ 𝓝 a ≠ ⊥)⟩ := hs _ this $ inf_le_left_of_le hf₂ in
   have a ∈ t,
-    from ht₂ a ha $ neq_bot_of_le_neq_bot hfa $ le_inf inf_le_right $ inf_le_left_of_le inf_le_left,
+    from ht₂ a ha $ ne_bot_of_le_ne_bot hfa $ le_inf inf_le_right $ inf_le_left_of_le inf_le_left,
   have nhds_within a (-t) ≠ ⊥,
-    from neq_bot_of_le_neq_bot hfa $ le_inf inf_le_right $ inf_le_left_of_le inf_le_right,
+    from ne_bot_of_le_ne_bot hfa $ le_inf inf_le_right $ inf_le_left_of_le inf_le_right,
   have ∀s∈ nhds_within a (-t), s ≠ ∅,
-    from forall_sets_neq_empty_iff_neq_bot.mpr this,
+    from forall_sets_ne_empty_iff_ne_bot.mpr this,
   have false,
     from this _ ⟨t, mem_nhds_sets ht₁ ‹a ∈ t›, -t, subset.refl _, subset.refl _⟩ (inter_compl_self _),
   by contradiction
@@ -75,7 +75,7 @@ lemma compact_iff_ultrafilter_le_nhds {s : set α} :
     hs (ultrafilter_of f) (ultrafilter_ultrafilter_of hf) (le_trans ultrafilter_of_le hfs) in
   have ultrafilter_of f ⊓ 𝓝 a ≠ ⊥,
     by simp only [inf_of_le_left, h]; exact (ultrafilter_ultrafilter_of hf).left,
-  ⟨a, ha, neq_bot_of_le_neq_bot this (inf_le_inf ultrafilter_of_le (le_refl _))⟩⟩
+  ⟨a, ha, ne_bot_of_le_ne_bot this (inf_le_inf ultrafilter_of_le (le_refl _))⟩⟩
 
 lemma compact.elim_finite_subcover {s : set α} {c : set (set α)}
   (hs : compact s) (hc₁ : ∀t∈c, is_open t) (hc₂ : s ⊆ ⋃₀ c) : ∃c'⊆c, finite c' ∧ s ⊆ ⋃₀ c' :=
@@ -87,7 +87,7 @@ classical.by_contradiction $ assume h,
     ⟨a, ha⟩ := @exists_mem_of_ne_empty α s
       (assume h', h (empty_subset _) finite_empty $ h'.symm ▸ empty_subset _)
   in
-  have f ≠ ⊥, from infi_neq_bot_of_directed ⟨a⟩
+  have f ≠ ⊥, from infi_ne_bot_of_directed ⟨a⟩
     (assume ⟨c₁, hc₁, hc'₁⟩ ⟨c₂, hc₂, hc'₂⟩, ⟨⟨c₁ ∪ c₂, union_subset hc₁ hc₂, finite_union hc'₁ hc'₂⟩,
       principal_mono.mpr $ diff_subset_diff_right $ sUnion_mono $ subset_union_left _ _,
       principal_mono.mpr $ diff_subset_diff_right $ sUnion_mono $ subset_union_right _ _⟩)
@@ -103,7 +103,7 @@ classical.by_contradiction $ assume h,
       principal_mono.mpr $
         show s - ⋃₀{t} ⊆ - t, begin rw sUnion_singleton; exact assume x ⟨_, hnt⟩, hnt end,
   have is_closed (- t), from is_open_compl_iff.mp $ by rw lattice.neg_neg; exact hc₁ t ht₁,
-  have a ∈ - t, from is_closed_iff_nhds.mp this _ $ neq_bot_of_le_neq_bot h $
+  have a ∈ - t, from is_closed_iff_nhds.mp this _ $ ne_bot_of_le_ne_bot h $
     le_inf inf_le_right (inf_le_left_of_le ‹f ≤ principal (- t)›),
   this ‹a ∈ t›
 
@@ -294,7 +294,7 @@ begin
   rcases hs (l.comap f ⊓ principal s) ne_bot inf_le_right with ⟨a, has, ha⟩,
   use [f a, mem_image_of_mem f has],
   rw [inf_assoc, @inf_comm _ _ _ (𝓝 a)] at ha,
-  exact neq_bot_of_le_neq_bot (@@map_ne_bot f ha) (tendsto_comap.inf $ hf a has)
+  exact ne_bot_of_le_ne_bot (@@map_ne_bot f ha) (tendsto_comap.inf $ hf a has)
 end
 
 lemma compact.image {s : set α} {f : α → β} (hs : compact s) (hf : continuous f) :

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -380,7 +380,7 @@ calc (a, b) ∈ closure t ↔ (𝓝 (a, b) ⊓ principal t ≠ ⊥) : by simp [c
   end
   ... ↔ (∀s ∈ 𝓤 α, ∃x, x ∈ set.prod {y : α | (a, y) ∈ s} {x : α | (x, b) ∈ s} ∩ t) :
   begin
-    rw [lift'_inf_principal_eq, lift'_neq_bot_iff],
+    rw [lift'_inf_principal_eq, lift'_ne_bot_iff],
     apply forall_congr, intro s, rw [ne_empty_iff_exists_mem],
     exact monotone_inter (monotone_prod monotone_preimage monotone_preimage) monotone_const
   end

--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -37,7 +37,7 @@ lemma cauchy_downwards {f g : filter α} (h_c : cauchy f) (hg : g ≠ ⊥) (h_le
 ⟨hg, le_trans (filter.prod_mono h_le h_le) h_c.right⟩
 
 lemma cauchy_nhds {a : α} : cauchy (𝓝 a) :=
-⟨nhds_neq_bot,
+⟨nhds_ne_bot,
   calc filter.prod (𝓝 a) (𝓝 a) =
     (𝓤 α).lift (λs:set (α×α), (𝓤 α).lift' (λt:set(α×α),
       set.prod {y : α | (y, a) ∈ s} {y : α | (a, y) ∈ t})) : nhds_nhds_eq_uniformity_uniformity_prod
@@ -82,7 +82,7 @@ begin
   -- Take `t ∈ f` such that `t × t ⊆ s`.
   rcases (cauchy_iff.1 hf).2 s hs with ⟨t, t_mem, ht⟩,
   use [t, t_mem, ht],
-  exact exists_mem_of_ne_empty (forall_sets_neq_empty_iff_neq_bot.2 adhs _
+  exact exists_mem_of_ne_empty (forall_sets_ne_empty_iff_ne_bot.2 adhs _
     (inter_mem_inf_sets t_mem (mem_nhds_left x hs)))
 end
 
@@ -151,7 +151,7 @@ end
 
 lemma cauchy_prod [uniform_space β] {f : filter α} {g : filter β} :
   cauchy f → cauchy g → cauchy (filter.prod f g)
-| ⟨f_proper, hf⟩ ⟨g_proper, hg⟩ := ⟨filter.prod_neq_bot.2 ⟨f_proper, g_proper⟩,
+| ⟨f_proper, hf⟩ ⟨g_proper, hg⟩ := ⟨filter.prod_ne_bot.2 ⟨f_proper, g_proper⟩,
   let p_α := λp:(α×β)×(α×β), (p.1.1, p.2.1), p_β := λp:(α×β)×(α×β), (p.1.2, p.2.2) in
   suffices (f.prod f).comap p_α ⊓ (g.prod g).comap p_β ≤ (𝓤 α).comap p_α ⊓ (𝓤 β).comap p_β,
     by simpa [uniformity_prod, filter.prod, filter.comap_inf, filter.comap_comap_comp, (∘),
@@ -199,7 +199,7 @@ lim_spec (complete_space.complete hf)
 lemma is_complete_of_is_closed [complete_space α] {s : set α}
   (h : is_closed s) : is_complete s :=
 λ f cf fs, let ⟨x, hx⟩ := complete_space.complete cf in
-⟨x, is_closed_iff_nhds.mp h x (neq_bot_of_le_neq_bot cf.left (le_inf hx fs)), hx⟩
+⟨x, is_closed_iff_nhds.mp h x (ne_bot_of_le_ne_bot cf.left (le_inf hx fs)), hx⟩
 
 /-- A set `s` is totally bounded if for every entourage `d` there is a finite
   set of points `t` such that every element of `s` is `d`-near to some element of `t`. -/
@@ -290,7 +290,7 @@ lemma totally_bounded_iff_filter {s : set α} :
       (assume h, hd_cover finite_empty $ h.symm ▸ empty_subset _)
   in
   have f ≠ ⊥,
-    from infi_neq_bot_of_directed ⟨a⟩
+    from infi_ne_bot_of_directed ⟨a⟩
       (assume ⟨t₁, ht₁⟩ ⟨t₂, ht₂⟩, ⟨⟨t₁ ∪ t₂, finite_union ht₁ ht₂⟩,
         principal_mono.mpr $ diff_subset_diff_right $ Union_subset_Union $
           assume t, Union_subset_Union_const or.inl,

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -176,7 +176,7 @@ have h_ex : ∀ s ∈ 𝓤 (Cauchy α), ∃y:α, (f, pure_cauchy y) ∈ s, from
   ⟨x, ht''₂ $ by dsimp [gen]; exact this⟩,
 begin
   simp [closure_eq_nhds, nhds_eq_uniformity, lift'_inf_principal_eq, set.inter_comm],
-  exact (lift'_neq_bot_iff $ monotone_inter monotone_const monotone_preimage).mpr
+  exact (lift'_ne_bot_iff $ monotone_inter monotone_const monotone_preimage).mpr
     (assume s hs,
       let ⟨y, hy⟩ := h_ex s hs in
       have pure_cauchy y ∈ range pure_cauchy ∩ {y : Cauchy α | (f, y) ∈ s},
@@ -280,7 +280,7 @@ begin
     have limc : ∀ (f : Cauchy α) (x ∈ f.1), lim f.1 ∈ closure x,
     { intros f x xf,
       rw closure_eq_nhds,
-      exact lattice.neq_bot_of_le_neq_bot f.2.1
+      exact lattice.ne_bot_of_le_ne_bot f.2.1
         (lattice.le_inf (le_nhds_lim_of_cauchy f.2) (le_principal_iff.2 xf)) },
     have := (closure_subset_iff_subset_of_is_closed dc).2 h,
     rw closure_prod_eq at this,
@@ -316,7 +316,7 @@ instance complete_space_separation [h : complete_space α] :
 ⟨assume f, assume hf : cauchy f,
   have cauchy (f.comap (λx, ⟦x⟧)), from
     cauchy_comap comap_quotient_le_uniformity hf $
-      comap_neq_bot_of_surj hf.left $ assume b, quotient.exists_rep _,
+      comap_ne_bot_of_surj hf.left $ assume b, quotient.exists_rep _,
   let ⟨x, (hx : f.comap (λx, ⟦x⟧) ≤ 𝓝 x)⟩ := complete_space.complete this in
   ⟨⟦x⟧, calc f = map (λx, ⟦x⟧) (f.comap (λx, ⟦x⟧)) :
       (map_comap $ univ_mem_sets' $ assume b, quotient.exists_rep _).symm

--- a/src/topology/uniform_space/uniform_embedding.lean
+++ b/src/topology/uniform_space/uniform_embedding.lean
@@ -110,13 +110,13 @@ let ⟨t₂, ht₂u, ht₂s, ht₂c⟩ := comp_symm_of_uniformity ht₁u in
 let ⟨t, htu, hts, htc⟩ := comp_symm_of_uniformity ht₂u in
 have preimage e {b' | (b, b') ∈ t₂} ∈ comap e (𝓝 b),
   from preimage_mem_comap $ mem_nhds_left b ht₂u,
-let ⟨a, (ha : (b, e a) ∈ t₂)⟩ := inhabited_of_mem_sets (he₂.comap_nhds_neq_bot) this in
+let ⟨a, (ha : (b, e a) ∈ t₂)⟩ := inhabited_of_mem_sets (he₂.comap_nhds_ne_bot) this in
 have ∀b' (s' : set (β × β)), (b, b') ∈ t → s' ∈ 𝓤 β →
   {y : β | (b', y) ∈ s'} ∩ e '' {a' : α | (a, a') ∈ s} ≠ ∅,
   from assume b' s' hb' hs',
   have preimage e {b'' | (b', b'') ∈ s' ∩ t} ∈ comap e (𝓝 b'),
     from preimage_mem_comap $ mem_nhds_left b' $ inter_mem_sets hs' htu,
-  let ⟨a₂, ha₂s', ha₂t⟩ := inhabited_of_mem_sets (he₂.comap_nhds_neq_bot) this in
+  let ⟨a₂, ha₂s', ha₂t⟩ := inhabited_of_mem_sets (he₂.comap_nhds_ne_bot) this in
   have (e a, e a₂) ∈ t₁,
     from ht₂c $ prod_mk_mem_comp_rel (ht₂s ha) $ htc $ prod_mk_mem_comp_rel hb' ha₂t,
   have e a₂ ∈ {b'':β | (b', b'') ∈ s'} ∩ e '' {a' | (a, a') ∈ s},
@@ -125,7 +125,7 @@ have ∀b' (s' : set (β × β)), (b, b') ∈ t → s' ∈ 𝓤 β →
 have ∀b', (b, b') ∈ t → 𝓝 b' ⊓ principal (e '' {a' | (a, a') ∈ s}) ≠ ⊥,
 begin
   intros b' hb',
-  rw [nhds_eq_uniformity, lift'_inf_principal_eq, lift'_neq_bot_iff],
+  rw [nhds_eq_uniformity, lift'_inf_principal_eq, lift'_ne_bot_iff],
   exact assume s, this b' s hb',
   exact monotone_inter monotone_preimage monotone_const
 end,
@@ -163,7 +163,7 @@ begin
     let f' := comap m f,
     have cf' : cauchy f',
     { have : comap m f ≠ ⊥,
-      { refine comap_neq_bot (λt ht, _),
+      { refine comap_ne_bot (λt ht, _),
         have A : t ∩ m '' s ∈ f := filter.inter_mem_sets ht fs,
         have : t ∩ m '' s ≠ ∅,
         { by_contradiction h,
@@ -202,9 +202,9 @@ have f ≤ g, from
   le_principal_iff.mpr $
   mem_sets_of_superset ht $ assume x hx, ⟨x, hx, refl_mem_uniformity hs⟩,
 
-have g ≠ ⊥, from neq_bot_of_le_neq_bot hf.left this,
+have g ≠ ⊥, from ne_bot_of_le_ne_bot hf.left this,
 
-have comap m g ≠ ⊥, from comap_neq_bot $ assume t ht,
+have comap m g ≠ ⊥, from comap_ne_bot $ assume t ht,
   let ⟨t', ht', ht_mem⟩ := (mem_lift_sets $ monotone_lift' monotone_const mp₀).mp ht in
   let ⟨t'', ht'', ht'_sub⟩ := (mem_lift'_sets mp₁).mp ht_mem in
   let ⟨x, (hx : x ∈ t'')⟩ := inhabited_of_mem_sets hf.left ht'' in
@@ -245,7 +245,7 @@ let ⟨x, (hx : map m (filter.comap m g) ≤ 𝓝 x)⟩ := h _ this in
 have map m (filter.comap m g) ⊓ 𝓝 x ≠ ⊥,
   from (le_nhds_iff_adhp_of_cauchy (cauchy_map hm.uniform_continuous this)).mp hx,
 have g ⊓ 𝓝 x ≠ ⊥,
-  from neq_bot_of_le_neq_bot this (inf_le_inf (assume s hs, ⟨s, hs, subset.refl _⟩) (le_refl _)),
+  from ne_bot_of_le_ne_bot this (inf_le_inf (assume s hs, ⟨s, hs, subset.refl _⟩) (le_refl _)),
 
 ⟨x, calc f ≤ g : by assumption
   ... ≤ 𝓝 x : le_nhds_of_cauchy_adhp ‹cauchy g› this⟩⟩
@@ -288,7 +288,7 @@ lemma uniformly_extend_exists [complete_space γ] (a : α) :
 let de := (h_e.dense_inducing h_dense) in
 have cauchy (𝓝 a), from cauchy_nhds,
 have cauchy (comap e (𝓝 a)), from
-  cauchy_comap (le_of_eq h_e.comap_uniformity) this de.comap_nhds_neq_bot,
+  cauchy_comap (le_of_eq h_e.comap_uniformity) this de.comap_nhds_ne_bot,
 have cauchy (map f (comap e (𝓝 a))), from
   cauchy_map h_f this,
 complete_space.complete this
@@ -352,7 +352,7 @@ let ⟨s, hs, hs_comp⟩ := (mem_lift'_sets $
 have h_pnt : ∀{a m}, m ∈ 𝓝 a → ∃c, c ∈ f '' preimage e m ∧ (c, ψ a) ∈ s ∧ (ψ a, c) ∈ s,
   from assume a m hm,
   have nb : map f (comap e (𝓝 a)) ≠ ⊥,
-    from map_ne_bot (h_e.dense_inducing h_dense).comap_nhds_neq_bot,
+    from map_ne_bot (h_e.dense_inducing h_dense).comap_nhds_ne_bot,
   have (f '' preimage e m) ∩ ({c | (c, ψ a) ∈ s } ∩ {c | (ψ a, c) ∈ s }) ∈ map f (comap e (𝓝 a)),
     from inter_mem_sets (image_mem_map $ preimage_mem_comap $ hm)
       (uniformly_extend_spec h_e h_dense h_f _ (inter_mem_sets (mem_nhds_right _ hs) (mem_nhds_left _ hs))),


### PR DESCRIPTION
One exception: `mem_sets_of_neq_bot` is now `mem_sets_of_eq_bot`
because it has an equality as an assumption.

Also add `filter.infi_ne_bot_(iff_?)of_directed'` with a different
`nonempty` assumption, and use it to simplify the proof of
`lift_ne_bot_iff`.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)