### PR TITLE
feat(order/filter/basic): prove `@cofinite ℕ = at_top`

### DIFF
--- a/src/algebra/char_p.lean
+++ b/src/algebra/char_p.lean
@@ -125,7 +125,7 @@ calc (k : α) = ↑(k % p + p * (k / p)) : by rw [nat.mod_add_div]
 theorem char_ne_zero_of_fintype (p : ℕ) [hc : char_p α p] [fintype α] : p ≠ 0 :=
 assume h : p = 0,
 have char_zero α := @char_p_to_char_zero α _ (h ▸ hc),
-absurd (@nat.cast_injective α _ _ this) (@set.not_injective_nat_fintype α _ _)
+absurd (@nat.cast_injective α _ _ this) (not_injective_infinite_fintype coe)
 
 end
 

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -608,7 +608,7 @@ def subtype_univ_equiv' {α : Type u} {p : α → Prop} (h : ∀ x, p x) :
   subtype p ≃ α :=
 ⟨λ x, x, λ x, ⟨x, h x⟩, λ x, subtype.eq rfl, λ x, rfl⟩
 
-/-- If a proposition holds for all elements, then the subtype is
+/-- The subtype for the universal set is
 equivalent to the original type. -/
 def subtype_univ_equiv (α : Type u) :
   @set.univ α ≃ α :=

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -604,15 +604,9 @@ assume x,
 
 /-- If a proposition holds for all elements, then the subtype is
 equivalent to the original type. -/
-def subtype_univ_equiv' {α : Type u} {p : α → Prop} (h : ∀ x, p x) :
+def subtype_univ_equiv {α : Type u} {p : α → Prop} (h : ∀ x, p x) :
   subtype p ≃ α :=
 ⟨λ x, x, λ x, ⟨x, h x⟩, λ x, subtype.eq rfl, λ x, rfl⟩
-
-/-- The subtype for the universal set is
-equivalent to the original type. -/
-def subtype_univ_equiv (α : Type u) :
-  @set.univ α ≃ α :=
-subtype_univ_equiv' $ λ _, trivial
 
 /-- A subtype of a sigma-type is a sigma-type over a subtype. -/
 def subtype_sigma_equiv {α : Type u} (p : α → Type v) (q : α → Prop) :
@@ -627,7 +621,7 @@ if the fiber is empty outside of the subset -/
 def sigma_subtype_equiv_of_subset {α : Type u} (p : α → Type v) (q : α → Prop)
   (h : ∀ x, p x → q x) :
   (Σ x : subtype q, p x) ≃ Σ x : α, p x :=
-(subtype_sigma_equiv p q).symm.trans $ subtype_univ_equiv' $ λ x, h x.1 x.2
+(subtype_sigma_equiv p q).symm.trans $ subtype_univ_equiv $ λ x, h x.1 x.2
 
 def sigma_subtype_preimage_equiv {α : Type u} {β : Type v} (f : α → β) (p : β → Prop)
   (h : ∀ x, p (f x)) :

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -604,9 +604,15 @@ assume x,
 
 /-- If a proposition holds for all elements, then the subtype is
 equivalent to the original type. -/
-def subtype_univ_equiv {α : Type u} {p : α → Prop} (h : ∀ x, p x) :
+def subtype_univ_equiv' {α : Type u} {p : α → Prop} (h : ∀ x, p x) :
   subtype p ≃ α :=
 ⟨λ x, x, λ x, ⟨x, h x⟩, λ x, subtype.eq rfl, λ x, rfl⟩
+
+/-- If a proposition holds for all elements, then the subtype is
+equivalent to the original type. -/
+def subtype_univ_equiv (α : Type u) :
+  @set.univ α ≃ α :=
+subtype_univ_equiv' $ λ _, trivial
 
 /-- A subtype of a sigma-type is a sigma-type over a subtype. -/
 def subtype_sigma_equiv {α : Type u} (p : α → Type v) (q : α → Prop) :
@@ -621,7 +627,7 @@ if the fiber is empty outside of the subset -/
 def sigma_subtype_equiv_of_subset {α : Type u} (p : α → Type v) (q : α → Prop)
   (h : ∀ x, p x → q x) :
   (Σ x : subtype q, p x) ≃ Σ x : α, p x :=
-(subtype_sigma_equiv p q).symm.trans $ subtype_univ_equiv $ λ x, h x.1 x.2
+(subtype_sigma_equiv p q).symm.trans $ subtype_univ_equiv' $ λ x, h x.1 x.2
 
 def sigma_subtype_preimage_equiv {α : Type u} {β : Type v} (f : α → β) (p : β → Prop)
   (h : ∀ x, p (f x)) :

--- a/src/data/fintype.lean
+++ b/src/data/fintype.lean
@@ -795,9 +795,20 @@ noncomputable def nat_embedding (α : Type*) [infinite α] : ℕ ↪ α :=
 
 end infinite
 
+lemma not_injective_infinite_fintype [infinite α] [fintype β] (f : α → β) :
+  ¬ injective f :=
+assume (hf : injective f),
+have H : fintype α := fintype.of_injective f hf,
+infinite.not_fintype H
+
+lemma not_surjective_fintype_infinite [fintype α] [infinite β] (f : α → β) :
+  ¬ surjective f :=
+assume (hf : surjective f),
+have H : infinite α := infinite.of_surjective f hf,
+@infinite.not_fintype _ H infer_instance
+
 instance nat.infinite : infinite ℕ :=
-⟨λ ⟨s, hs⟩, not_le_of_gt (nat.lt_succ_self (s.sum id)) $
-  @finset.single_le_sum _ _ _ id _ _ (λ _ _, nat.zero_le _) _ (hs _)⟩
+⟨λ ⟨s, hs⟩, finset.not_mem_range_self $ s.subset_range_sup_succ (hs _)⟩
 
 instance int.infinite : infinite ℤ :=
 infinite.of_injective int.of_nat (λ _ _, int.of_nat_inj)

--- a/src/data/real/hyperreal.lean
+++ b/src/data/real/hyperreal.lean
@@ -8,9 +8,7 @@ Construction of the hyperreal numbers as an ultraproduct of real sequences.
 import data.real.basic algebra.field order.filter.filter_product analysis.specific_limits
 
 open filter filter.filter_product
-open_locale topological_space
-
-local attribute [instance] classical.prop_decidable -- TODO: use "open_locale classical"
+open_locale topological_space classical
 
 /-- Hyperreal numbers on the ultrafilter extending the cofinite filter -/
 @[reducible] def hyperreal := filter.filterprod ℝ (@hyperfilter ℕ)
@@ -19,7 +17,7 @@ namespace hyperreal
 
 notation `ℝ*` := hyperreal
 
-private def U := is_ultrafilter_hyperfilter set.infinite_univ_nat
+private def U : is_ultrafilter (@hyperfilter ℕ) := is_ultrafilter_hyperfilter
 noncomputable instance : discrete_linear_ordered_field ℝ* :=
 filter_product.discrete_linear_ordered_field U
 
@@ -43,8 +41,7 @@ begin
   rw lt_def U,
   show {i : ℕ | (0 : ℝ) < i⁻¹} ∈ hyperfilter.sets,
   simp only [inv_pos', nat.cast_pos],
-  exact mem_hyperfilter_of_finite_compl set.infinite_univ_nat
-    (by convert set.finite_singleton _),
+  exact mem_hyperfilter_of_finite_compl (by convert set.finite_singleton _),
 end
 
 lemma epsilon_ne_zero : ε ≠ 0 := ne_of_gt epsilon_pos
@@ -63,7 +60,7 @@ begin
   have hs : -{i : ℕ | f i < r} ⊆ {i : ℕ | i ≤ N} :=
     λ i hi1, le_of_lt (by simp only [lt_iff_not_ge];
     exact λ hi2, hi1 (lt_of_le_of_lt (le_abs_self _) (hf' i hi2)) : i < N),
-  exact mem_hyperfilter_of_finite_compl set.infinite_univ_nat
+  exact mem_hyperfilter_of_finite_compl
     (set.finite_subset (set.finite_le_nat N) hs)
 end
 
@@ -400,7 +397,7 @@ Exists.cases_on (hf' (r + 1)) $ λ i hi,
   have hS : - {a : ℕ | r < f a} ⊆ {a : ℕ | a ≤ i} :=
     by simp only [set.compl_set_of, not_lt];
     exact λ a har, le_of_lt (hi' a (lt_of_le_of_lt har (lt_add_one _))),
-  (lt_def U).mpr $ mem_hyperfilter_of_finite_compl set.infinite_univ_nat $
+  (lt_def U).mpr $ mem_hyperfilter_of_finite_compl $
   set.finite_subset (set.finite_le_nat _) hS
 
 theorem infinite_neg_of_tendsto_bot {f : ℕ → ℝ} (hf : tendsto f at_top at_bot) :
@@ -412,7 +409,7 @@ Exists.cases_on (hf' (r - 1)) $ λ i hi,
   have hS : - {a : ℕ | f a < r} ⊆ {a : ℕ | a ≤ i} :=
     by simp only [set.compl_set_of, not_lt];
     exact λ a har, le_of_lt (hi' a (lt_of_lt_of_le (sub_one_lt _) har)),
-  (lt_def U).mpr $ mem_hyperfilter_of_finite_compl set.infinite_univ_nat $
+  (lt_def U).mpr $ mem_hyperfilter_of_finite_compl $
   set.finite_subset (set.finite_le_nat _) hS
 
 lemma not_infinite_neg {x : ℝ*} : ¬ infinite x → ¬ infinite (-x) :=
@@ -626,7 +623,7 @@ begin
   convert infinite_pos_iff_infinitesimal_inv_pos,
   all_goals { by_cases h : x = 0,
     rw [h, inv_zero, inv_zero],
-    exact (division_ring.inv_inv h).symm }
+    exact (division_ring.inv_inv $ show x ≠ 0, from h).symm }
 end
 
 lemma infinitesimal_neg_iff_infinite_neg_inv {x : ℝ*} :
@@ -635,7 +632,7 @@ begin
   convert infinite_neg_iff_infinitesimal_inv_neg,
   all_goals { by_cases h : x = 0,
     rw [h, inv_zero, inv_zero],
-    exact (division_ring.inv_inv h).symm }
+    exact (division_ring.inv_inv $ show x ≠ 0, from h).symm }
 end
 
 theorem infinitesimal_iff_infinite_inv {x : ℝ*} (h : x ≠ 0) : infinitesimal x ↔ infinite x⁻¹ :=

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -163,9 +163,16 @@ theorem finite_pure (a : α) : finite (pure a : set α) :=
 ⟨set.fintype_pure a⟩
 
 instance fintype_univ [fintype α] : fintype (@univ α) :=
-fintype.of_finset finset.univ $ λ _, iff_true_intro (finset.mem_univ _)
+fintype.of_equiv α $ (equiv.subtype_univ_equiv α).symm
 
 theorem finite_univ [fintype α] : finite (@univ α) := ⟨set.fintype_univ⟩
+
+theorem infinite_univ_iff : (@univ α).infinite ↔ _root_.infinite α :=
+⟨λ h₁, ⟨λ h₂, h₁ $ @finite_univ α h₂⟩,
+  λ ⟨h₁⟩ ⟨h₂⟩, h₁ $ @fintype.of_equiv _ _ h₂ $ equiv.subtype_univ_equiv _⟩
+
+theorem infinite_univ [h : _root_.infinite α] : infinite (@univ α) :=
+infinite_univ_iff.2 h
 
 instance fintype_union [decidable_eq α] (s t : set α) [fintype s] [fintype t] : fintype (s ∪ t : set α) :=
 fintype.of_finset (s.to_finset ∪ t.to_finset) $ by simp
@@ -374,24 +381,6 @@ by { rw range_subset_iff, assume x, simp [nat.lt_succ_iff, nat.find_greatest_le]
 lemma finite_range_find_greatest {P : α → ℕ → Prop} [∀ x, decidable_pred (P x)] {b : ℕ} :
   finite (range (λ x, nat.find_greatest (P x) b)) :=
 finite_subset (finset.finite_to_set $ finset.range (b + 1)) range_find_greatest_subset
-
-lemma infinite_univ_nat : infinite (univ : set ℕ) :=
-assume (h : finite (univ : set ℕ)),
-let ⟨n, hn⟩ := finset.exists_nat_subset_range h.to_finset in
-have n ∈ finset.range n, from finset.subset_iff.mpr hn $ by simp,
-by simp * at *
-
-lemma not_injective_nat_fintype [fintype α] {f : ℕ → α} : ¬ injective f :=
-assume (h : injective f),
-have finite (f '' univ),
-  from finite_subset (finset.finite_to_set $ fintype.elems α) (assume a h, fintype.complete a),
-have finite (univ : set ℕ), from finite_of_finite_image (set.inj_on_of_injective _ h) this,
-infinite_univ_nat this
-
-lemma not_injective_int_fintype [fintype α] {f : ℤ → α} : ¬ injective f :=
-assume hf,
-have injective (f ∘ (coe : ℕ → ℤ)), from injective_comp hf $ assume i j, int.of_nat_inj,
-not_injective_nat_fintype this
 
 lemma card_lt_card {s t : set α} [fintype s] [fintype t] (h : s ⊂ t) :
   fintype.card s < fintype.card t :=

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -163,13 +163,13 @@ theorem finite_pure (a : α) : finite (pure a : set α) :=
 ⟨set.fintype_pure a⟩
 
 instance fintype_univ [fintype α] : fintype (@univ α) :=
-fintype.of_equiv α $ (equiv.subtype_univ_equiv α).symm
+fintype.of_equiv α $ (equiv.set.univ α).symm
 
 theorem finite_univ [fintype α] : finite (@univ α) := ⟨set.fintype_univ⟩
 
 theorem infinite_univ_iff : (@univ α).infinite ↔ _root_.infinite α :=
 ⟨λ h₁, ⟨λ h₂, h₁ $ @finite_univ α h₂⟩,
-  λ ⟨h₁⟩ ⟨h₂⟩, h₁ $ @fintype.of_equiv _ _ h₂ $ equiv.subtype_univ_equiv _⟩
+  λ ⟨h₁⟩ ⟨h₂⟩, h₁ $ @fintype.of_equiv _ _ h₂ $ equiv.set.univ _⟩
 
 theorem infinite_univ [h : _root_.infinite α] : infinite (@univ α) :=
 infinite_univ_iff.2 h

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -67,8 +67,8 @@ fintype.card_eq_one_iff.2
   ⟨⟨(1 : α), by simp⟩, λ ⟨y, hy⟩, subtype.eq $ is_subgroup.mem_trivial.1 hy⟩
 
 lemma exists_gpow_eq_one (a : α) : ∃i≠0, a ^ (i:ℤ) = 1 :=
-have ¬ injective (λi, a ^ i),
-  from not_injective_int_fintype,
+have ¬ injective (λi:ℤ, a ^ i),
+  from not_injective_infinite_fintype _,
 let ⟨i, j, a_eq, ne⟩ := show ∃(i j : ℤ), a ^ i = a ^ j ∧ i ≠ j,
   by rw [injective] at this; simpa [classical.not_forall] in
 have a ^ (i - j) = 1,

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -756,10 +756,15 @@ def cofinite : filter α :=
   inter_sets       := assume s t (hs : finite (-s)) (ht : finite (-t)),
     by simp only [compl_inter, finite_union, ht, hs, mem_set_of_eq] }
 
-lemma cofinite_ne_bot (hi : set.infinite (@set.univ α)) : @cofinite α ≠ ⊥ :=
-forall_sets_ne_empty_iff_ne_bot.mp
-  $ λ s hs hn, by change set.finite _ at hs;
-    rw [hn, set.compl_empty] at hs; exact hi hs
+@[simp] lemma mem_cofinite {s : set α} : s ∈ (@cofinite α) ↔ finite (-s) := iff.rfl
+
+lemma cofinite_ne_bot [infinite α] : @cofinite α ≠ ⊥ :=
+mt empty_in_sets_eq_bot.mpr $ by { simp only [mem_cofinite, compl_empty], exact infinite_univ }
+
+lemma frequently_cofinite_iff_infinite {p : α → Prop} :
+  (∃ᶠ x in cofinite, p x) ↔ set.infinite {x | p x} :=
+by simp only [filter.frequently, filter.eventually, mem_cofinite, compl_set_of, not_not,
+  set.infinite]
 
 /-- The monadic bind operation on filter is defined the usual way in terms of `map` and `join`.
 
@@ -1990,28 +1995,28 @@ instance ultrafilter.monad : monad ultrafilter := { map := @ultrafilter.map }
 
 noncomputable def hyperfilter : filter α := ultrafilter_of cofinite
 
-lemma hyperfilter_le_cofinite (hi : set.infinite (@set.univ α)) : @hyperfilter α ≤ cofinite :=
-(ultrafilter_of_spec (cofinite_ne_bot hi)).1
+lemma hyperfilter_le_cofinite : @hyperfilter α ≤ cofinite :=
+ultrafilter_of_le
 
-lemma is_ultrafilter_hyperfilter (hi : set.infinite (@set.univ α)) : is_ultrafilter (@hyperfilter α) :=
-(ultrafilter_of_spec (cofinite_ne_bot hi)).2
+lemma is_ultrafilter_hyperfilter [infinite α] : is_ultrafilter (@hyperfilter α) :=
+(ultrafilter_of_spec cofinite_ne_bot).2
 
-theorem nmem_hyperfilter_of_finite (hi : set.infinite (@set.univ α)) {s : set α} (hf : set.finite s) :
+theorem nmem_hyperfilter_of_finite [infinite α] {s : set α} (hf : s.finite) :
   s ∉ @hyperfilter α :=
 λ hy,
 have hx : -s ∉ hyperfilter :=
-  λ hs, (ultrafilter_iff_compl_mem_iff_not_mem.mp (is_ultrafilter_hyperfilter hi) s).mp hs hy,
+  λ hs, (ultrafilter_iff_compl_mem_iff_not_mem.mp is_ultrafilter_hyperfilter s).mp hs hy,
 have ht : -s ∈ cofinite.sets := by show -s ∈ {s | _}; rwa [set.mem_set_of_eq, lattice.neg_neg],
-hx $ hyperfilter_le_cofinite hi ht
+hx $ hyperfilter_le_cofinite ht
 
-theorem compl_mem_hyperfilter_of_finite (hi : set.infinite (@set.univ α)) {s : set α} (hf : set.finite s) :
+theorem compl_mem_hyperfilter_of_finite [infinite α] {s : set α} (hf : set.finite s) :
   -s ∈ @hyperfilter α :=
-(ultrafilter_iff_compl_mem_iff_not_mem.mp (is_ultrafilter_hyperfilter hi) s).mpr $
-nmem_hyperfilter_of_finite hi hf
+(ultrafilter_iff_compl_mem_iff_not_mem.mp is_ultrafilter_hyperfilter s).mpr $
+nmem_hyperfilter_of_finite hf
 
-theorem mem_hyperfilter_of_finite_compl (hi : set.infinite (@set.univ α)) {s : set α} (hf : set.finite (-s)) :
+theorem mem_hyperfilter_of_finite_compl [infinite α] {s : set α} (hf : set.finite (-s)) :
   s ∈ @hyperfilter α :=
-have h : _ := compl_mem_hyperfilter_of_finite hi hf,
+have h : _ := compl_mem_hyperfilter_of_finite hf,
 by rwa [lattice.neg_neg] at h
 
 section
@@ -2072,3 +2077,28 @@ lemma sequence_mono :
 | (a::as) (b::bs) (forall₂.cons h hs) := seq_mono (map_mono h) (sequence_mono as bs hs)
 
 end filter
+
+open filter
+
+lemma set.infinite_iff_frequently_cofinite {α : Type u} {s : set α} :
+  set.infinite s ↔ (∃ᶠ x in cofinite, x ∈ s) :=
+frequently_cofinite_iff_infinite.symm
+
+/-- For natural numbers the filters `cofinite` and `at_top` coincide. -/
+lemma nat.cofinite_eq_at_top : @cofinite ℕ = at_top :=
+begin
+  ext s,
+  simp only [mem_cofinite, mem_at_top_sets],
+  split,
+  { assume hs,
+    use (hs.to_finset.sup id) + 1,
+    assume b hb,
+    by_contradiction hbs,
+    have := hs.to_finset.subset_range_sup_succ (finite.mem_to_finset.2 hbs),
+    exact not_lt_of_le hb (finset.mem_range.1 this) },
+  { rintros ⟨N, hN⟩,
+    apply finite_subset (finite_lt_nat N),
+    assume n hn,
+    change n < N,
+    exact lt_of_not_ge (λ hn', hn $ hN n hn') }
+end


### PR DESCRIPTION
Also generalize `not_injective_(nat/int)_fintype`, and use `[infinite
α]` instead of `set.infinite (@univ α)` as an argument.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)