### PR TITLE
docs(data/mv_polynomial): add module docstring [ci skip]

### DIFF
--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -2,11 +2,71 @@
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Johan Commelin, Mario Carneiro
-
-Multivariate Polynomial
 -/
 import algebra.ring
 import data.finsupp data.polynomial data.equiv.algebra
+
+/-!
+# Multivariate polynomials
+
+This file defines polynomial rings over a base ring (or even semiring),
+with variables corresponding to the terms in a general type σ (which could
+be infinite). It then establishes a substantial interface for this definition.
+
+## Important definitions
+
+In the definitions below, we use the following notation:
+`σ : Type*` (indexing the variables)
+`R : Type*` `[comm_semiring R]` (the coefficients)
+`s : σ →₀ ℕ`, with corresponding monomial written X^s
+`a : R`,
+`n : σ`, with corresponding monomial X_n
+`p : mv_polynomial σ R`
+
+* `mv_polynomial σ R` : the type of polynomials with variables of type σ and coefficients
+  in the commutative semiring R
+
+* `monomial s a` is the monomial a * X^s
+
+* `C a` is the constant polynomial with value a
+
+* `X n` is the degree one monomial corresponding to n
+
+* `coeff s p` is the coefficient of s in p.
+
+ Evaluate a polynomial `p` given a valuation `g` of all the variables
+  and a ring hom `f` from the scalar ring to the target
+
+* `eval₂ p` : given a semiring homomorphism from R to another semiring S, and a map σ → S,
+  evaluates p at this data, returning a term of type D
+
+* `eval p` : given a map σ → R, evaluates p at this data, returning a term of type R
+
+* `map (f : R → S) p` : returns the multivariate polynomial obtained from p by the change of
+  coefficient semiring corresponding to f
+
+* `degrees p` : the multiset of variables representing the union of the multisets corresponding
+  to each non-zero monomial in p. For example if 7 ≠ 0 in R then
+  `degrees (x^2y + 7y^3) = {x,x,y,y,y}
+
+* `vars p` : the finset of variables occurring in p
+
+* `degree_of n p : ℕ` -- the total degree of p with respect to the variable n
+
+* `total_degree p : ℕ` -- the max size |s| of the multisets s whose monomials X^s occur in p.
+
+## Implementation notes
+
+Recall that if Y has a zero, then X →₀ Y is the type of functions from X to Y with finite
+support, i.e. such that only finitely many elements of X get sent to non-zero terms in Y.
+The definition of `mv_polynomial σ α` is `(σ →₀ ℕ) →₀ α` ; here σ →₀ ℕ denotes the space of all
+monomials in the variables, and the function to α sends a monomial to its coefficient in
+the polynomial being represented.
+
+## Tags
+
+polynomial, multivariate polynomial, multivariable polynomial
+-/
 
 noncomputable theory
 local attribute [instance, priority 100] classical.prop_decidable
@@ -26,7 +86,8 @@ variables {σ : Type*} {a a' a₁ a₂ : α} {e : ℕ} {n m : σ} {s : σ →₀
 section comm_semiring
 variables [comm_semiring α] {p q : mv_polynomial σ α}
 
-instance decidable_eq_mv_polynomial [decidable_eq σ] [decidable_eq α] : decidable_eq (mv_polynomial σ α) := finsupp.decidable_eq
+instance decidable_eq_mv_polynomial [decidable_eq σ] [decidable_eq α] :
+  decidable_eq (mv_polynomial σ α) := finsupp.decidable_eq
 instance : has_zero (mv_polynomial σ α) := finsupp.has_zero
 instance : has_one (mv_polynomial σ α) := finsupp.has_one
 instance : has_add (mv_polynomial σ α) := finsupp.has_add
@@ -39,7 +100,7 @@ def monomial (s : σ →₀ ℕ) (a : α) : mv_polynomial σ α := single s a
 /-- `C a` is the constant polynomial with value `a` -/
 def C (a : α) : mv_polynomial σ α := monomial 0 a
 
-/-- `X n` is the polynomial with value X_n -/
+/-- `X n` is the degree 1 monomial with value X_n -/
 def X (n : σ) : mv_polynomial σ α := monomial (single n 1) 1
 
 @[simp] lemma C_0 : C 0 = (0 : mv_polynomial σ α) := by simp [C, monomial]; refl

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -41,7 +41,7 @@ This will give rise to a monomial in `mv_polynomial σ R` which mathematicians m
 ### Definitions
 
 * `mv_polynomial σ R` : the type of polynomials with variables of type `σ` and coefficients
-  in the commutative semiring R
+  in the commutative semiring `R`
 
 * `monomial s a` : the monomial which mathematically would be denoted `a * X^s`
 

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -40,7 +40,7 @@ In the definitions below, we use the following notation:
 * `eval₂ p` : given a semiring homomorphism from R to another semiring S, and a map σ → S,
   evaluates p at this data, returning a term of type D
 
-* `eval p` : given a map σ → R, evaluates p at this data, returning a term of type R
+* `eval p` : given a map σ → R, evaluates p at this valuation, returning a term of type R
 
 * `map (f : R → S) p` : returns the multivariate polynomial obtained from p by the change of
   coefficient semiring corresponding to f

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -17,7 +17,7 @@ be infinite).
 
 Let `R` be a commutative ring (or a semiring) and let `σ` be an arbitrary
 type. This file creates the type `mv_polynomial σ R`, which mathematicians
-might denote $R[X_n : n\in\sigma]$. It is the type of multivariate
+might denote $R[X_i : i\in\sigma]$. It is the type of multivariate
 (a.k.a. multivariable) polynomials, with variables
 corresponding to the terms in `σ`, and coefficients in `R`.
 
@@ -25,9 +25,9 @@ In the definitions below, we use the following notation:
 `σ : Type*` (indexing the variables)
 `R : Type*` `[comm_semiring R]` (the coefficients)
 `s : σ →₀ ℕ`, a function from σ to ℕ which is zero away from a finite set.
-This will give rise to a monomial in `mv_polynomial σ R`
+This will give rise to a monomial in `mv_polynomial σ R` which mathematicians might call $X^s$
 `a : R`
-`n : σ`, with corresponding monomial `X n`
+`i : σ`, with corresponding monomial `X i` or $X_i$
 `p : mv_polynomial σ R`
 
 * `mv_polynomial σ R` : the type of polynomials with variables of type σ and coefficients
@@ -37,7 +37,7 @@ This will give rise to a monomial in `mv_polynomial σ R`
 
 * `C a` : the constant polynomial with value a
 
-* `X n` : the degree one monomial corresponding to n; mathematically this might be denoted $X_n$.
+* `X i` : the degree one monomial corresponding to i; mathematically this might be denoted $X_n$.
 
 * `coeff s p` : the coefficient of s in p.
 

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -3,6 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Johan Commelin, Mario Carneiro
 -/
+
 import algebra.ring
 import data.finsupp data.polynomial data.equiv.algebra
 
@@ -20,45 +21,55 @@ might denote `R[X_i : i ∈ σ]`. It is the type of multivariate
 (a.k.a. multivariable) polynomials, with variables
 corresponding to the terms in `σ`, and coefficients in `R`.
 
+### Notation
+
 In the definitions below, we use the following notation:
-`σ : Type*` (indexing the variables)
-`R : Type*` `[comm_semiring R]` (the coefficients)
-`s : σ →₀ ℕ`, a function from σ to ℕ which is zero away from a finite set.
+
++ `σ : Type*` (indexing the variables)
+
++ `R : Type*` `[comm_semiring R]` (the coefficients)
+
++ `s : σ →₀ ℕ`, a function from `σ` to `ℕ` which is zero away from a finite set.
 This will give rise to a monomial in `mv_polynomial σ R` which mathematicians might call `X^s`
-`a : R`
-`i : σ`, with corresponding monomial `X i`, often denoted `X_i` by mathematicians
-`p : mv_polynomial σ R`
+
++ `a : R`
+
++ `i : σ`, with corresponding monomial `X i`, often denoted `X_i` by mathematicians
+
++ `p : mv_polynomial σ R`
+
+### Definitions
 
 * `mv_polynomial σ R` : the type of polynomials with variables of type σ and coefficients
   in the commutative semiring R
 
 * `monomial s a` : the monomial which mathematically would be denoted `a * X^s`
 
-* `C a` : the constant polynomial with value a
+* `C a` : the constant polynomial with value `a`
 
-* `X i` : the degree one monomial corresponding to i; mathematically this might be denoted `X_i`.
+* `X i` : the degree one monomial corresponding to i; mathematically this might be denoted `Xᵢ`.
 
-* `coeff s p` : the coefficient of s in p.
+* `coeff s p` : the coefficient of `s` in `p`.
 
-* `eval₂ (f : R → S) (g : σ → S) p` : given a semiring homomorphism from R to another semiring S,
-  and a map σ → S, evaluates p at this valuation, returning a term of type `S`. Note that
-  `eval₂` can be made using `eval` and `map` (see below), and it has been suggested that sticking
-  to `eval` and `map` might make the code less brittle.
+* `eval₂ (f : R → S) (g : σ → S) p` : given a semiring homomorphism from `R` to another
+  semiring `S`, and a map `σ → S`, evaluates `p` at this valuation, returning a term of type `S`.
+  Note that `eval₂` can be made using `eval` and `map` (see below), and it has been suggested
+  that sticking to `eval` and `map` might make the code less brittle.
 
-* `eval (g : σ → R) p` : given a map σ → R, evaluates p at this valuation,
-  returning a term of type R
+* `eval (g : σ → R) p` : given a map `σ → R`, evaluates `p` at this valuation,
+  returning a term of type `R`
 
-* `map (f : R → S) p` : returns the multivariate polynomial obtained from p by the change of
-  coefficient semiring corresponding to f
+* `map (f : R → S) p` : returns the multivariate polynomial obtained from `p` by the change of
+  coefficient semiring corresponding to `f`
 
 * `degrees p` : the multiset of variables representing the union of the multisets corresponding
-  to each non-zero monomial in `p`. For example if 7 ≠ 0 in `R` and `p = x²y+7y³` then
+  to each non-zero monomial in `p`. For example if `7 ≠ 0` in `R` and `p = x²y+7y³` then
   `degrees p = {x, x, y, y, y}`
 
-* `vars p` : the finset of variables occurring in p. For example if `p = x⁴y+yz` then
+* `vars p` : the finset of variables occurring in `p`. For example if `p = x⁴y+yz` then
   `vars p = {x, y, z}`
 
-* `degree_of n p : ℕ` -- the total degree of p with respect to the variable n. For example
+* `degree_of n p : ℕ` -- the total degree of `p` with respect to the variable `n`. For example
   if `p = x⁴y+yz` then `degree_of y p = 1`.
 
 * `total_degree p : ℕ` -- the max of the sizes of the multisets `s` whose monomials `X^s` occur
@@ -67,7 +78,7 @@ This will give rise to a monomial in `mv_polynomial σ R` which mathematicians m
 ## Implementation notes
 
 Recall that if `Y` has a zero, then `X →₀ Y` is the type of functions from `X` to `Y` with finite
-support, i.e. such that only finitely many elements of X get sent to non-zero terms in Y.
+support, i.e. such that only finitely many elements of `X` get sent to non-zero terms in `Y`.
 The definition of `mv_polynomial σ α` is `(σ →₀ ℕ) →₀ α` ; here `σ →₀ ℕ` denotes the space of all
 monomials in the variables, and the function to α sends a monomial to its coefficient in
 the polynomial being represented.

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -10,14 +10,13 @@ import data.finsupp data.polynomial data.equiv.algebra
 # Multivariate polynomials
 
 This file defines polynomial rings over a base ring (or even semiring),
-with variables from a general type σ (which could
-be infinite).
+with variables from a general type `σ` (which could be infinite).
 
 ## Important definitions
 
 Let `R` be a commutative ring (or a semiring) and let `σ` be an arbitrary
 type. This file creates the type `mv_polynomial σ R`, which mathematicians
-might denote $R[X_i : i\in\sigma]$. It is the type of multivariate
+might denote `R[X_i : i ∈ σ]`. It is the type of multivariate
 (a.k.a. multivariable) polynomials, with variables
 corresponding to the terms in `σ`, and coefficients in `R`.
 
@@ -25,42 +24,45 @@ In the definitions below, we use the following notation:
 `σ : Type*` (indexing the variables)
 `R : Type*` `[comm_semiring R]` (the coefficients)
 `s : σ →₀ ℕ`, a function from σ to ℕ which is zero away from a finite set.
-This will give rise to a monomial in `mv_polynomial σ R` which mathematicians might call $X^s$
+This will give rise to a monomial in `mv_polynomial σ R` which mathematicians might call `X^s`
 `a : R`
-`i : σ`, with corresponding monomial `X i` or $X_i$
+`i : σ`, with corresponding monomial `X i`, often denoted `X_i` by mathematicians
 `p : mv_polynomial σ R`
 
 * `mv_polynomial σ R` : the type of polynomials with variables of type σ and coefficients
   in the commutative semiring R
 
-* `monomial s a` : the monomial which mathematically would be denoted $a * X^s$
+* `monomial s a` : the monomial which mathematically would be denoted `a * X^s`
 
 * `C a` : the constant polynomial with value a
 
-* `X i` : the degree one monomial corresponding to i; mathematically this might be denoted $X_n$.
+* `X i` : the degree one monomial corresponding to i; mathematically this might be denoted `X_i`.
 
 * `coeff s p` : the coefficient of s in p.
 
-* `eval₂ (f : R → S) (g : σ → S) p` : given a semiring homomorphism from R to another semiring S, and a map σ → S,
-  evaluates p at this valuation, returning a term of type `S`
+* `eval₂ (f : R → S) (g : σ → S) p` : given a semiring homomorphism from R to another semiring S,
+  and a map σ → S, evaluates p at this valuation, returning a term of type `S`. Note that
+  `eval₂` can be made using `eval` and `map` (see below), and it has been suggested that sticking
+  to `eval` and `map` might make the code less brittle.
 
-* `eval (g : σ → R) p` : given a map σ → R, evaluates p at this valuation, returning a term of type R
+* `eval (g : σ → R) p` : given a map σ → R, evaluates p at this valuation,
+  returning a term of type R
 
 * `map (f : R → S) p` : returns the multivariate polynomial obtained from p by the change of
   coefficient semiring corresponding to f
 
 * `degrees p` : the multiset of variables representing the union of the multisets corresponding
-  to each non-zero monomial in p. For example if 7 ≠ 0 in R and $p=x^2y+7y^3$ then
+  to each non-zero monomial in `p`. For example if 7 ≠ 0 in `R` and `p = x²y+7y³` then
   `degrees p = {x, x, y, y, y}`
 
-* `vars p` : the finset of variables occurring in p. For example if $p=x^4y+yz$ then
+* `vars p` : the finset of variables occurring in p. For example if `p = x⁴y+yz` then
   `vars p = {x, y, z}`
 
-* `degree_of n p : ℕ` -- the total degree of p with respect to the variable n. For example if $p=x^4y+yz$
-  then `degree_of y p = 1`.
+* `degree_of n p : ℕ` -- the total degree of p with respect to the variable n. For example
+  if `p = x⁴y+yz` then `degree_of y p = 1`.
 
-* `total_degree p : ℕ` -- the max of the sizes of the multisets `s` whose monomials $X^s$ occur in `p`.
-  For example if $p=x^4y+yz$ then `total_degree p = 5`.
+* `total_degree p : ℕ` -- the max of the sizes of the multisets `s` whose monomials `X^s` occur
+  in `p`. For example if `p = x⁴y+yz` then `total_degree p = 5`.
 
 ## Implementation notes
 

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -20,7 +20,7 @@ In the definitions below, we use the following notation:
 `R : Type*` `[comm_semiring R]` (the coefficients)
 `s : σ →₀ ℕ`, with corresponding monomial written X^s
 `a : R`,
-`n : σ`, with corresponding monomial X_n
+`n : σ`, with corresponding monomial `X n`
 `p : mv_polynomial σ R`
 
 * `mv_polynomial σ R` : the type of polynomials with variables of type σ and coefficients

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -59,7 +59,7 @@ In the definitions below, we use the following notation:
 
 Recall that if `Y` has a zero, then `X →₀ Y` is the type of functions from `X` to `Y` with finite
 support, i.e. such that only finitely many elements of X get sent to non-zero terms in Y.
-The definition of `mv_polynomial σ α` is `(σ →₀ ℕ) →₀ α` ; here σ →₀ ℕ denotes the space of all
+The definition of `mv_polynomial σ α` is `(σ →₀ ℕ) →₀ α` ; here `σ →₀ ℕ` denotes the space of all
 monomials in the variables, and the function to α sends a monomial to its coefficient in
 the polynomial being represented.
 

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -38,7 +38,7 @@ In the definitions below, we use the following notation:
   and a ring hom `f` from the scalar ring to the target
 
 * `eval₂ p` : given a semiring homomorphism from R to another semiring S, and a map σ → S,
-  evaluates p at this data, returning a term of type D
+  evaluates p at this valuation, returning a term of type `S`
 
 * `eval p` : given a map σ → R, evaluates p at this valuation, returning a term of type R
 

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -15,45 +15,52 @@ be infinite).
 
 ## Important definitions
 
+Let `R` be a commutative ring (or a semiring) and let `σ` be an arbitrary
+type. This file creates the type `mv_polynomial σ R`, which mathematicians
+might denote $R[X_n : n\in\sigma]$. It is the type of multivariate
+(a.k.a. multivariable) polynomials, with variables
+corresponding to the terms in `σ`, and coefficients in `R`.
+
 In the definitions below, we use the following notation:
 `σ : Type*` (indexing the variables)
 `R : Type*` `[comm_semiring R]` (the coefficients)
-`s : σ →₀ ℕ`, with corresponding monomial written X^s
-`a : R`,
+`s : σ →₀ ℕ`, a function from σ to ℕ which is zero away from a finite set.
+This will give rise to a monomial in `mv_polynomial σ R`
+`a : R`
 `n : σ`, with corresponding monomial `X n`
 `p : mv_polynomial σ R`
 
 * `mv_polynomial σ R` : the type of polynomials with variables of type σ and coefficients
   in the commutative semiring R
 
-* `monomial s a` is the monomial a * X^s
+* `monomial s a` : the monomial which mathematically would be denoted $a * X^s$
 
-* `C a` is the constant polynomial with value a
+* `C a` : the constant polynomial with value a
 
-* `X n` is the degree one monomial corresponding to n
+* `X n` : the degree one monomial corresponding to n; mathematically this might be denoted $X_n$.
 
-* `coeff s p` is the coefficient of s in p.
+* `coeff s p` : the coefficient of s in p.
 
- Evaluate a polynomial `p` given a valuation `g` of all the variables
-  and a ring hom `f` from the scalar ring to the target
-
-* `eval₂ p` : given a semiring homomorphism from R to another semiring S, and a map σ → S,
+* `eval₂ (f : R → S) (g : σ → S) p` : given a semiring homomorphism from R to another semiring S, and a map σ → S,
   evaluates p at this valuation, returning a term of type `S`
 
-* `eval p` : given a map σ → R, evaluates p at this valuation, returning a term of type R
+* `eval (g : σ → R) p` : given a map σ → R, evaluates p at this valuation, returning a term of type R
 
 * `map (f : R → S) p` : returns the multivariate polynomial obtained from p by the change of
   coefficient semiring corresponding to f
 
 * `degrees p` : the multiset of variables representing the union of the multisets corresponding
-  to each non-zero monomial in p. For example if 7 ≠ 0 in R then
-  `degrees (x^2y + 7y^3) = {x,x,y,y,y}
+  to each non-zero monomial in p. For example if 7 ≠ 0 in R and $p=x^2y+7y^3$ then
+  `degrees p = {x, x, y, y, y}`
 
-* `vars p` : the finset of variables occurring in p
+* `vars p` : the finset of variables occurring in p. For example if $p=x^4y+yz$ then
+  `vars p = {x, y, z}`
 
-* `degree_of n p : ℕ` -- the total degree of p with respect to the variable n
+* `degree_of n p : ℕ` -- the total degree of p with respect to the variable n. For example if $p=x^4y+yz$
+  then `degree_of y p = 1`.
 
-* `total_degree p : ℕ` -- the max size |s| of the multisets s whose monomials X^s occur in p.
+* `total_degree p : ℕ` -- the max of the sizes of the multisets `s` whose monomials $X^s$ occur in `p`.
+  For example if $p=x^4y+yz$ then `total_degree p = 5`.
 
 ## Implementation notes
 

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -11,7 +11,7 @@ import data.finsupp data.polynomial data.equiv.algebra
 
 This file defines polynomial rings over a base ring (or even semiring),
 with variables from a general type σ (which could
-be infinite). It then establishes a substantial interface for this definition.
+be infinite).
 
 ## Important definitions
 

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -120,7 +120,7 @@ def monomial (s : σ →₀ ℕ) (a : α) : mv_polynomial σ α := single s a
 /-- `C a` is the constant polynomial with value `a` -/
 def C (a : α) : mv_polynomial σ α := monomial 0 a
 
-/-- `X n` is the degree 1 monomial `1*n` -/
+/-- `X n` is the degree `1` monomial `1*n` -/
 def X (n : σ) : mv_polynomial σ α := monomial (single n 1) 1
 
 @[simp] lemma C_0 : C 0 = (0 : mv_polynomial σ α) := by simp [C, monomial]; refl

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -10,7 +10,7 @@ import data.finsupp data.polynomial data.equiv.algebra
 # Multivariate polynomials
 
 This file defines polynomial rings over a base ring (or even semiring),
-with variables corresponding to the terms in a general type σ (which could
+with variables from a general type σ (which could
 be infinite). It then establishes a substantial interface for this definition.
 
 ## Important definitions

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -40,7 +40,7 @@ This will give rise to a monomial in `mv_polynomial σ R` which mathematicians m
 
 ### Definitions
 
-* `mv_polynomial σ R` : the type of polynomials with variables of type σ and coefficients
+* `mv_polynomial σ R` : the type of polynomials with variables of type `σ` and coefficients
   in the commutative semiring R
 
 * `monomial s a` : the monomial which mathematically would be denoted `a * X^s`

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -57,7 +57,7 @@ In the definitions below, we use the following notation:
 
 ## Implementation notes
 
-Recall that if Y has a zero, then X →₀ Y is the type of functions from X to Y with finite
+Recall that if `Y` has a zero, then `X →₀ Y` is the type of functions from `X` to `Y` with finite
 support, i.e. such that only finitely many elements of X get sent to non-zero terms in Y.
 The definition of `mv_polynomial σ α` is `(σ →₀ ℕ) →₀ α` ; here σ →₀ ℕ denotes the space of all
 monomials in the variables, and the function to α sends a monomial to its coefficient in

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -100,7 +100,7 @@ def monomial (s : σ →₀ ℕ) (a : α) : mv_polynomial σ α := single s a
 /-- `C a` is the constant polynomial with value `a` -/
 def C (a : α) : mv_polynomial σ α := monomial 0 a
 
-/-- `X n` is the degree 1 monomial with value X_n -/
+/-- `X n` is the degree 1 monomial `1*n` -/
 def X (n : σ) : mv_polynomial σ α := monomial (single n 1) 1
 
 @[simp] lemma C_0 : C 0 = (0 : mv_polynomial σ α) := by simp [C, monomial]; refl


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)

---

I had to learn how to use `mv_polynomial` so I thought I'd add a module docstring. I also put a newline into a too-long line and clarified a docstring.
