### PR TITLE
feat(tactic/simp_rw): add `simp_rw` tactic, a mix of `simp` and `rw`

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -1377,14 +1377,20 @@ See also additional documentation of `using_well_founded` in
 
 ## simp_rw
 
-`simp_rw` is a version of `simp` which performs rewriting in the given order.
-Conversely, `simp_rw` is a version of `rw` that applies rewrite rules repeatedly
-and also under binders like `∀ x, ...`, `∃ x, ...` and `λ x, ...`.
+`simp_rw` functions as a mix of `simp` and `rw`. Like `rw`, it applies each
+rewrite rule in the given order, but like `simp` it repeatedly applies these
+rules and also under binders like `∀ x, ...`, `∃ x, ...` and `λ x, ...`.
 
 Usage:
   - `simp_rw [lemma_1, ..., lemma_n]` will rewrite the goal by applying the
     lemmas in that order.
-  - `simp_rw [lemma] at h` will rewrite hypothesis `h` using the given lemma.
+  - `simp_rw [lemma_1, ..., lemma_n] at h` will rewrite hypothesis `h` using the
+    given lemmas.
+
+For example, neither `simp` nor `rw` can solve the following, but `simp_rw` can:
+```lean
+example {α β : Type} {f : α → β} {t : set β} : (∀ s, f '' s ⊆ t) = ∀ s : set α, ∀ x ∈ s, x ∈ f ⁻¹' t :=
+by simp_rw [set.image_subset_iff, set.subset_def]
+```
 
 Lemmas passed to `simp_rw` must be expressions that are valid arguments to `simp`.
-Backwards rewriting, i.e. `simp_rw [←lemma]`, is not supported (yet).

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -1374,3 +1374,17 @@ See also additional documentation of `using_well_founded` in
 * `@[simps]` reduces let-expressions where necessary.
 * If one of the fields is a partially applied constructor, we will eta-expand it
   (this likely never happens).
+
+## simp_rw
+
+`simp_rw` is a version of `simp` which performs rewriting in the given order.
+Conversely, `simp_rw` is a version of `rw` that applies rewrite rules repeatedly
+and also under binders like `∀ x, ...`, `∃ x, ...` and `λ x, ...`.
+
+Usage:
+  - `simp_rw [lemma_1, ..., lemma_n]` will rewrite the goal by applying the
+    lemmas in that order.
+  - `simp_rw [lemma] at h` will rewrite hypothesis `h` using the given lemma.
+
+Lemmas passed to `simp_rw` must be expressions that are valid arguments to `simp`.
+Backwards rewriting, i.e. `simp_rw [←lemma]`, is not supported (yet).

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -1384,8 +1384,9 @@ rules and also under binders like `∀ x, ...`, `∃ x, ...` and `λ x, ...`.
 Usage:
   - `simp_rw [lemma_1, ..., lemma_n]` will rewrite the goal by applying the
     lemmas in that order.
-  - `simp_rw [lemma_1, ..., lemma_n] at h` will rewrite hypothesis `h` using the
-    given lemmas.
+  - `simp_rw [lemma_1, ..., lemma_n] at h₁ ... hₙ` will rewrite the given hypotheses.
+  - `simp_rw [...] at ⊢ h₁ ... hₙ` rewrites the goal as well as the given hypotheses.
+  - `simp_rw [...] at *` rewrites in the whole context: all hypotheses and the goal.
 
 For example, neither `simp` nor `rw` can solve the following, but `simp_rw` can:
 ```lean

--- a/src/tactic/default.lean
+++ b/src/tactic/default.lean
@@ -33,3 +33,4 @@ import
   tactic.apply_fun
   tactic.apply
   tactic.suggest
+  tactic.simp_rw

--- a/src/tactic/simp_rw.lean
+++ b/src/tactic/simp_rw.lean
@@ -30,8 +30,10 @@ open interactive interactive.types tactic
   and can also rewrite under binders like `λ x, ...`
 
   Usage:
-    - `simp_rw [lemma_1, ..., lemma_n]` will rewrite the goal by applying the lemmas in that order.
-    - `simp_rw [lemma_1, ..., lemma_n] at h` will rewrite hypothesis `h` using the given lemmas.
+    - `simp_rw [l₁, ..., lₙ]` will rewrite the goal by applying lemmas `l₁, ..., lₙ` in that order.
+    - `simp_rw [l₁, ..., lₙ] at h₁ ... hₙ` will rewrite hypotheses `h₁, ..., hₙ` in that order.
+      Include `⊢` to also rewrite the goal.
+    - `simp_rw [l₁, ..., lₙ] at *` will rewrite in the whole context.
 
   Lemmas passed to `simp_rw` must be expressions that are valid arguments to `simp`.
 -/

--- a/src/tactic/simp_rw.lean
+++ b/src/tactic/simp_rw.lean
@@ -7,6 +7,22 @@ The `simp_rw` tactic, a mix of `simp` and `rewrite`.
 -/
 import tactic.core
 
+/-!
+# The `simp_rw` tactic
+
+This module defines a tactic `simp_rw` which functions as a mix of `simp` and
+`rw`. Like `rw`, it applies each rewrite rule in the given order, but like
+`simp` it repeatedly applies these rules and also under binders like `∀ x, ...`,
+`∃ x, ...` and `λ x, ...`.
+
+## Implementation notes
+
+The tactic works by taking each rewrite rule in turn and applying `simp only` to
+it. It should be possible to support backwards rewriting in the tactic, i.e.
+`simp_rw [←lemma]`, but it will be more useful and not much more work to add
+support for this directly to `simp`.
+-/
+
 namespace tactic.interactive
 open interactive interactive.types tactic
 

--- a/src/tactic/simp_rw.lean
+++ b/src/tactic/simp_rw.lean
@@ -1,7 +1,9 @@
 /-
-  Copyright (c) 2020 Anne Baanen. All rights reserved.
-  Released under Apache 2.0 license as described in the file LICENSE.
-  Authors: Anne Baanen
+Copyright (c) 2020 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen
+
+The `simp_rw` tactic, a mix of `simp` and `rewrite`.
 -/
 import tactic.core
 

--- a/src/tactic/simp_rw.lean
+++ b/src/tactic/simp_rw.lean
@@ -1,0 +1,29 @@
+/-
+  Copyright (c) 2020 Anne Baanen. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Authors: Anne Baanen
+-/
+import tactic.core
+
+namespace tactic.interactive
+open interactive interactive.types tactic
+
+/-- `simp_rw` is a version of `simp` which performs rewriting in the given order.
+  Conversely, `simp_rw` is a version of `rw` that applies rewrite rules repeatedly and
+  also under binders like `∀ x, ...`, `∃ x, ...` and `λ x, ...`.
+
+  Usage:
+    - `simp_rw [lemma_1, ..., lemma_n]` will rewrite the goal by applying the lemmas in that order.
+    - `simp_rw [lemma] at h` will rewrite hypothesis `h` using the given lemma.
+
+  Lemmas passed to `simp_rw` must be expressions that are valid arguments to `simp`.
+  Backwards rewriting, i.e. `simp_rw [←lemma]`, is not supported (yet).
+-/
+meta def simp_rw (q : parse rw_rules) (l : parse location) : tactic unit :=
+q.rules.mmap' (λ rule, if rule.symm
+  then fail "simp_rw can only rewrite in forward direction"
+  else do
+    save_info rule.pos,
+    simp none tt [simp_arg_type.expr rule.rule] [] l) -- equivalent to `simp only [rule] at l`
+
+end tactic.interactive

--- a/src/tactic/simp_rw.lean
+++ b/src/tactic/simp_rw.lean
@@ -26,20 +26,18 @@ support for this directly to `simp`.
 namespace tactic.interactive
 open interactive interactive.types tactic
 
-/-- `simp_rw` is a version of `simp` which performs rewriting in the given order.
-  Conversely, `simp_rw` is a version of `rw` that applies rewrite rules repeatedly and
-  also under binders like `∀ x, ...`, `∃ x, ...` and `λ x, ...`.
+/-- `simp_rw` is a mix of `simp` and `rw`: it applies rewrite rules in the given order repeatedly,
+  and can also rewrite under binders like `λ x, ...`
 
   Usage:
     - `simp_rw [lemma_1, ..., lemma_n]` will rewrite the goal by applying the lemmas in that order.
-    - `simp_rw [lemma] at h` will rewrite hypothesis `h` using the given lemma.
+    - `simp_rw [lemma_1, ..., lemma_n] at h` will rewrite hypothesis `h` using the given lemmas.
 
   Lemmas passed to `simp_rw` must be expressions that are valid arguments to `simp`.
-  Backwards rewriting, i.e. `simp_rw [←lemma]`, is not supported (yet).
 -/
 meta def simp_rw (q : parse rw_rules) (l : parse location) : tactic unit :=
 q.rules.mmap' (λ rule, if rule.symm
-  then fail "simp_rw can only rewrite in forward direction"
+  then fail "simp_rw [← ...] not supported: can only rewrite in forward direction"
   else do
     save_info rule.pos,
     simp none tt [simp_arg_type.expr rule.rule] [] l) -- equivalent to `simp only [rule] at l`

--- a/test/rewrite.lean
+++ b/test/rewrite.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon
 -/
 import tactic.rewrite
-import data.set.basic
 
 open tactic
 example : ∀ x y z a b c : ℕ, true :=

--- a/test/rewrite.lean
+++ b/test/rewrite.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon
 -/
 import tactic.rewrite
+import data.set.basic
 
 open tactic
 example : ∀ x y z a b c : ℕ, true :=

--- a/test/simp_rw.lean
+++ b/test/simp_rw.lean
@@ -1,7 +1,9 @@
 /-
-  Copyright (c) 2020 Anne Baanen. All rights reserved.
-  Released under Apache 2.0 license as described in the file LICENSE.
-  Authors: Anne Baanen
+Copyright (c) 2020 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen
+
+A set of test cases for the `simp_rw` tactic.
 -/
 import tactic.simp_rw
 import data.set.basic

--- a/test/simp_rw.lean
+++ b/test/simp_rw.lean
@@ -1,0 +1,22 @@
+/-
+  Copyright (c) 2020 Anne Baanen. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Authors: Anne Baanen
+-/
+import tactic.simp_rw
+import data.set.basic
+
+-- `simp_rw` can perform rewrites under binders:
+example : (λ (x y : ℕ), x + y) = (λ x y, y + x) := by simp_rw [add_comm]
+
+-- `simp_rw` performs rewrites in the given order (`simp` fails on this example):
+example {α β : Type} {f : α → β} {t : set β} :
+  (∀ s, f '' s ⊆ t) = ∀ s : set α, ∀ x ∈ s, x ∈ f ⁻¹' t :=
+by simp_rw [set.image_subset_iff, set.subset_def]
+
+-- `simp_rw` applies rewrite rules multiple times:
+example (a b c d : ℕ) : a + (b + (c + d)) = ((d + c) + b) + a := by simp_rw [add_comm]
+
+-- `simp_rw` can also rewrite in assumptions:
+example (p : ℕ → Prop) (a b : ℕ) (h : p (a + b)) : p (b + a) :=
+by {simp_rw [add_comm a b] at h, exact h}

--- a/test/simp_rw.lean
+++ b/test/simp_rw.lean
@@ -22,3 +22,12 @@ example (a b c d : ℕ) : a + (b + (c + d)) = ((d + c) + b) + a := by simp_rw [a
 -- `simp_rw` can also rewrite in assumptions:
 example (p : ℕ → Prop) (a b : ℕ) (h : p (a + b)) : p (b + a) :=
 by {simp_rw [add_comm a b] at h, exact h}
+-- or explicitly rewrite at the goal:
+example (p : ℕ → Prop) (a b : ℕ) (h : p (a + b)) : p (b + a) :=
+by {simp_rw [add_comm b a] at ⊢, exact h}
+-- or at multiple assumptions:
+example (p : ℕ → Prop) (a b : ℕ) (h₁ : p (b + a) → p (a + b))  (h₂ : p (a + b)) : p (b + a) :=
+by {simp_rw [add_comm a b] at h₁ h₂, exact h₁ h₂}
+-- or everywhere:
+example (p : ℕ → Prop) (a b : ℕ) (h₁ : p (b + a) → p (a + b))  (h₂ : p (a + b)) : p (a + b) :=
+by {simp_rw [add_comm a b] at *, exact h₁ h₂}

--- a/test/tactics.lean
+++ b/test/tactics.lean
@@ -451,8 +451,8 @@ section ring_exp
   example (a b : ℤ) (n : ℕ) : (a + b)^(n + 2) = (a^2 + 2 * a * b + b^2) * (a + b)^n := by ring_exp
 end ring_exp
 
-section ring_exp
+section simp_rw
   example {α β : Type} {f : α → β} {t : set β} :
     (∀ s, f '' s ⊆ t) = ∀ s : set α, ∀ x ∈ s, x ∈ f ⁻¹' t :=
   by simp_rw [set.image_subset_iff, set.subset_def]
-end ring_exp
+end simp_rw

--- a/test/tactics.lean
+++ b/test/tactics.lean
@@ -5,7 +5,7 @@ Authors: Simon Hudon, Scott Morrison
 -/
 
 import tactic.interactive tactic.finish tactic.ext tactic.lift tactic.apply
-       tactic.reassoc_axiom tactic.tfae tactic.elide tactic.ring_exp
+       tactic.reassoc_axiom tactic.tfae tactic.elide tactic.ring_exp tactic.simp_rw
 
 example (m n p q : nat) (h : m + n = p) : true :=
 begin
@@ -449,4 +449,10 @@ end struct_eq
 
 section ring_exp
   example (a b : ℤ) (n : ℕ) : (a + b)^(n + 2) = (a^2 + 2 * a * b + b^2) * (a + b)^n := by ring_exp
+end ring_exp
+
+section ring_exp
+  example {α β : Type} {f : α → β} {t : set β} :
+    (∀ s, f '' s ⊆ t) = ∀ s : set α, ∀ x ∈ s, x ∈ f ⁻¹' t :=
+  by simp_rw [set.image_subset_iff, set.subset_def]
 end ring_exp


### PR DESCRIPTION
This is a combination of the `simp` and `rw` tactic, as discussed on Zulip: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/simp.20vs.20rw

More precisely, `simp_rw` is a version of `simp` which performs rewriting in the given order. Conversely, `simp_rw` is a version of `rw` that applies rewrite rules repeatedly and also under binders like `∀ x, ...`, `∃ x, ...` and `λ x, ...`.

For example, neither `simp` nor `rw` can solve the following, but `simp_rw` can:
```lean
example {α β : Type} {f : α → β} {t : set β} : (∀ s, f '' s ⊆ t) = ∀ s : set α, ∀ x ∈ s, x ∈ f ⁻¹' t :=
by simp_rw [set.image_subset_iff, set.subset_def]
```

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)