### PR TITLE
doc(geometry/manifold): fix markdown

### DIFF
--- a/src/geometry/manifold/manifold.lean
+++ b/src/geometry/manifold/manifold.lean
@@ -41,7 +41,7 @@ inverse, to which the change of coordinates should belong.
 * `atlas H M`              : when `M` is a manifold modelled on `H`, the atlas of this manifold
                              structure, i.e., the set of charts
 * `structomorph G M M'`    : the set of diffeomorphisms between the manifolds `M` and `M'` for the
-                             groupoid G. We avoid the word diffeomorphisms, keeping it for the
+                             groupoid `G`. We avoid the word diffeomorphisms, keeping it for the
                              smooth category.
 
 As a basic example, we give the instance

--- a/src/geometry/manifold/manifold.lean
+++ b/src/geometry/manifold/manifold.lean
@@ -33,7 +33,7 @@ inverse, to which the change of coordinates should belong.
                              maps)
 * `continuous_groupoid H`  : the groupoid of all local homeomorphisms of `H`
 
-* `manifold H M`           : manifold structure on M modelled on H, given by an atlas of local
+* `manifold H M`           : manifold structure on `M` modelled on `H`, given by an atlas of local
                              homeomorphisms from M to H whose sources cover M. This is a type class.
 * `has_groupoid M G`       : when `G` is a structure groupoid on `H` and `M` is a manifold modelled on
                              `H`, require that all coordinate changes belong to `G`. This is a type

--- a/src/geometry/manifold/manifold.lean
+++ b/src/geometry/manifold/manifold.lean
@@ -34,7 +34,7 @@ inverse, to which the change of coordinates should belong.
 * `continuous_groupoid H`  : the groupoid of all local homeomorphisms of `H`
 
 * `manifold H M`           : manifold structure on `M` modelled on `H`, given by an atlas of local
-                             homeomorphisms from M to H whose sources cover M. This is a type class.
+                             homeomorphisms from `M` to `H` whose sources cover `M`. This is a type class.
 * `has_groupoid M G`       : when `G` is a structure groupoid on `H` and `M` is a manifold modelled on
                              `H`, require that all coordinate changes belong to `G`. This is a type
                              class

--- a/src/geometry/manifold/manifold.lean
+++ b/src/geometry/manifold/manifold.lean
@@ -24,25 +24,25 @@ notion of structure groupoid, i.e., a set of local homeomorphisms stable under c
 inverse, to which the change of coordinates should belong.
 
 ## Main definitions
-`structure_groupoid H`   : a subset of local homeomorphisms of `H` stable under composition, inverse
-                           and restriction (ex: local diffeos)
-`pregroupoid H`          : a subset of local homeomorphisms of `H` stable under composition and
-                           restriction, but not inverse (ex: smooth maps)
-`groupoid_of_pregroupoid`: construct a groupoid from a pregroupoid, by requiring that a map and its
-                           inverse both belong to the pregroupoid (ex: construct diffeos from smooth
-                           maps)
-`continuous_groupoid H`  : the groupoid of all local homeomorphisms of `H`
+* `structure_groupoid H`   : a subset of local homeomorphisms of `H` stable under composition, inverse
+                             and restriction (ex: local diffeos)
+* `pregroupoid H`          : a subset of local homeomorphisms of `H` stable under composition and
+                             restriction, but not inverse (ex: smooth maps)
+* `groupoid_of_pregroupoid`: construct a groupoid from a pregroupoid, by requiring that a map and its
+                             inverse both belong to the pregroupoid (ex: construct diffeos from smooth
+                             maps)
+* `continuous_groupoid H`  : the groupoid of all local homeomorphisms of `H`
 
-`manifold H M`           : manifold structure on M modelled on H, given by an atlas of local
-                           homeomorphisms from M to H whose sources cover M. This is a type class.
-`has_groupoid M G`       : when `G` is a structure groupoid on `H` and `M` is a manifold modelled on
-                           `H`, require that all coordinate changes belong to `G`. This is a type
-                           class
-`atlas H M`              : when `M` is a manifold modelled on `H`, the atlas of this manifold
-                           structure, i.e., the set of charts
-`structomorph G M M'`    : the set of diffeomorphisms between the manifolds M and M' for the
-                           groupoid G. We avoid the word diffeomorphisms, keeping it for the
-                           smooth category.
+* `manifold H M`           : manifold structure on M modelled on H, given by an atlas of local
+                             homeomorphisms from M to H whose sources cover M. This is a type class.
+* `has_groupoid M G`       : when `G` is a structure groupoid on `H` and `M` is a manifold modelled on
+                             `H`, require that all coordinate changes belong to `G`. This is a type
+                             class
+* `atlas H M`              : when `M` is a manifold modelled on `H`, the atlas of this manifold
+                             structure, i.e., the set of charts
+* `structomorph G M M'`    : the set of diffeomorphisms between the manifolds M and M' for the
+                             groupoid G. We avoid the word diffeomorphisms, keeping it for the
+                             smooth category.
 
 As a basic example, we give the instance
 `instance manifold_model_space (H : Type*) [topological_space H] : manifold H H`

--- a/src/geometry/manifold/manifold.lean
+++ b/src/geometry/manifold/manifold.lean
@@ -40,7 +40,7 @@ inverse, to which the change of coordinates should belong.
                              class
 * `atlas H M`              : when `M` is a manifold modelled on `H`, the atlas of this manifold
                              structure, i.e., the set of charts
-* `structomorph G M M'`    : the set of diffeomorphisms between the manifolds M and M' for the
+* `structomorph G M M'`    : the set of diffeomorphisms between the manifolds `M` and `M'` for the
                              groupoid G. We avoid the word diffeomorphisms, keeping it for the
                              smooth category.
 


### PR DESCRIPTION
Fixes some doc formatting, but mainly to test the new CI...

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
