### PR TITLE
fix(scripts/deploy_nightly): token is now just the PAT, need to add user

### DIFF
--- a/scripts/deploy_nightly.sh
+++ b/scripts/deploy_nightly.sh
@@ -1,7 +1,8 @@
 set -e				# fail on error
 
-git remote add mathlib "https://$GITHUB_TOKEN@github.com/leanprover-community/mathlib.git"
-git remote add nightly "https://$GITHUB_TOKEN@github.com/leanprover-community/mathlib-nightly.git"
+GITHUB_USER=leanprover-mathlib-bot
+git remote add mathlib "https://$GITHUB_USER:$GITHUB_TOKEN@github.com/leanprover-community/mathlib.git"
+git remote add nightly "https://$GITHUB_USER:$GITHUB_TOKEN@github.com/leanprover-community/mathlib-nightly.git"
 
 # After this point, we don't use any secrets in commands.
 set -x				# echo commands


### PR DESCRIPTION
This should fix the nightlies.

Previously, the `GITHUB_TOKEN` environment variable was set to `leanprover-mathlib-bot:XXXXXXXXX` (i.e., containing not just the token but also the username).  Now it is just the `XXXXXXXXX` token, this PR prepends the username.

(Unfortunately this is just my best guess of what's going on.  I don't see the contents of the github actions secret, and I can't test this without pushing to mathlib either.)