### PR TITLE
fix(scripts/deploy_nightly): fill in blank env vars

### DIFF
--- a/scripts/deploy_nightly.sh
+++ b/scripts/deploy_nightly.sh
@@ -28,11 +28,13 @@ fi
 
 # Try to update the lean-x.y.z branch on mathlib. This could fail if
 # a subsequent commit has already pushed an update.
+LEAN_VERSION="3.4.2"
+
 git push mathlib HEAD:refs/heads/$LEAN_VERSION || \
     echo "mathlib rejected push to branch $LEAN_VERSION; maybe it already has a later version?" >&2
 
 # Push the commits to a branch on nightly and push a tag.
-git push nightly HEAD:"mathlib-$TRAVIS_BRANCH" || true
+git push nightly HEAD:"mathlib-master" || true
 git tag $MATHLIB_VERSION_STRING
 git push nightly tag $MATHLIB_VERSION_STRING
 

--- a/scripts/deploy_nightly.sh
+++ b/scripts/deploy_nightly.sh
@@ -28,7 +28,7 @@ fi
 
 # Try to update the lean-x.y.z branch on mathlib. This could fail if
 # a subsequent commit has already pushed an update.
-LEAN_VERSION="3.4.2"
+LEAN_VERSION="lean-3.4.2"
 
 git push mathlib HEAD:refs/heads/$LEAN_VERSION || \
     echo "mathlib rejected push to branch $LEAN_VERSION; maybe it already has a later version?" >&2


### PR DESCRIPTION
It appears that the authentication issue described [here](https://github.com/leanprover-community/mathlib/pull/1907#issuecomment-578408950) has been fixed. Now the run fails [here](https://github.com/leanprover-community/mathlib/runs/408650775#step:8:320) with the following:
```
++ git push mathlib HEAD:refs/heads/
fatal: invalid refspec 'HEAD:refs/heads/'
++ echo 'mathlib rejected push to branch ; maybe it already has a later version?'
mathlib rejected push to branch ; maybe it already has a later version?
++ git push nightly HEAD:mathlib-
remote: Permission to leanprover-community/mathlib-nightly.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/leanprover-community/mathlib-nightly.git/': The requested URL returned error: 403
++ true
++ git tag nightly-2020-01-25
++ git push nightly tag nightly-2020-01-25
remote: Permission to leanprover-community/mathlib-nightly.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/leanprover-community/mathlib-nightly.git/': The requested URL returned error: 403
##[error]Process completed with exit code 128.
```
From looking again at `scripts/deploy_nightly.sh`, the environment variables `LEAN_VERSION` and `TRAVIS_BRANCH` were not being set properly. This PR sets `LEAN_VERSION="lean-3.4.2"` and replaces `$TRAVIS_BRANCH` with `master`.

For comparison [see this successful Travis log](https://travis-ci.org/leanprover-community/mathlib/jobs/641267540#L557):
```
+git push mathlib HEAD:refs/heads/lean-3.4.2
To https://github.com/leanprover-community/mathlib.git
   aa6cc06f..69099f00  HEAD -> lean-3.4.2
+git push nightly HEAD:mathlib-master
To https://github.com/leanprover-community/mathlib-nightly.git
   aa6cc06f..69099f00  HEAD -> mathlib-master
+git tag nightly-2020-01-24
+git push nightly tag nightly-2020-01-24
To https://github.com/leanprover-community/mathlib-nightly.git
 * [new tag]           nightly-2020-01-24 -> nightly-2020-01-24
```


TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
