### PR TITLE
refactor(*): refactor `sum_smul`/`smul_sum`

### DIFF
--- a/src/algebra/module.lean
+++ b/src/algebra/module.lean
@@ -46,6 +46,8 @@ theorem add_smul : (r + s) • x = r • x + s • x := semimodule.add_smul r s 
 variables (α)
 @[simp] theorem zero_smul : (0 : α) • x = 0 := semimodule.zero_smul α x
 
+variable {α}
+
 lemma semimodule.eq_zero_of_zero_eq_one (zero_eq_one : (0 : α) = 1) : x = 0 :=
 by rw [←one_smul α x, ←zero_eq_one, zero_smul]
 

--- a/src/algebra/module.lean
+++ b/src/algebra/module.lean
@@ -46,19 +46,25 @@ theorem add_smul : (r + s) • x = r • x + s • x := semimodule.add_smul r s 
 variables (α)
 @[simp] theorem zero_smul : (0 : α) • x = 0 := semimodule.zero_smul α x
 
-lemma smul_smul : r • s • x = (r * s) • x := (mul_smul _ _ _).symm
-
-instance smul.is_add_monoid_hom {r : α} : is_add_monoid_hom (λ x : β, r • x) :=
-{ map_add := smul_add _, map_zero := smul_zero _ }
-
 lemma semimodule.eq_zero_of_zero_eq_one (zero_eq_one : (0 : α) = 1) : x = 0 :=
 by rw [←one_smul α x, ←zero_eq_one, zero_smul]
 
-/-- R-linearity of finite sums of elements of an R-semimodule. -/
-lemma finset.sum_smul {α : Type*} {R : Type*} [semiring R] {M : Type*} [add_comm_monoid M]
-  [semimodule R M] (s : finset α) (r : R) (f : α → M) :
-    s.sum (λ (x : α), (r • (f x))) = r • (s.sum f) :=
-s.sum_hom _
+instance smul.is_add_monoid_hom (x : β) : is_add_monoid_hom (λ r:α, r • x) :=
+{ map_zero := zero_smul _ x,
+  map_add := λ r₁ r₂, add_smul r₁ r₂ x }
+
+lemma list.sum_smul {l : list α} {x : β} : l.sum • x = (l.map (λ r, r • x)).sum :=
+show (λ r, r • x) l.sum = (l.map (λ r, r • x)).sum,
+from (list.sum_hom _ _).symm
+
+lemma multiset.sum_smul {l : multiset α} {x : β} : l.sum • x = (l.map (λ r, r • x)).sum :=
+show (λ r, r • x) l.sum = (l.map (λ r, r • x)).sum,
+from (multiset.sum_hom _ _).symm
+
+lemma finset.sum_smul {f : γ → α} {s : finset γ} {x : β} :
+  s.sum f • x = s.sum (λ r, (f r) • x) :=
+show (λ r, r • x) (s.sum f) = s.sum (λ r, (f r) • x),
+from (finset.sum_hom _ _).symm
 
 end semimodule
 
@@ -460,6 +466,10 @@ begin
     rw [add_smul, add_smul, one_smul, ih, one_smul] }
 end
 
+lemma nat.smul_def {M : Type*} [add_comm_monoid M] (n : ℕ) (x : M) :
+  n • x = add_monoid.smul n x :=
+rfl
+
 namespace finset
 
 lemma sum_const' {α : Type*} (R : Type*) [ring R] {β : Type*}
@@ -472,19 +482,12 @@ variables {M : Type*} [decidable_linear_ordered_cancel_comm_monoid M]
 
 theorem exists_card_smul_le_sum (hs : s.nonempty) :
   ∃ i ∈ s, s.card • f i ≤ s.sum f :=
-begin
-  apply exists_le_of_sum_le hs,
-  simp only [sum_smul, sum_const],
-  refl
-end
+exists_le_of_sum_le hs $ by rw [sum_const, ← nat.smul_def, smul_sum]
+
 
 theorem exists_card_smul_ge_sum (hs : s.nonempty) :
   ∃ i ∈ s, s.sum f ≤ s.card • f i :=
-begin
-  apply exists_le_of_sum_le hs,
-  simp only [sum_smul, sum_const],
-  refl
-end
+exists_le_of_sum_le hs $ by rw [sum_const, ← nat.smul_def, smul_sum]
 
 end finset
 

--- a/src/group_theory/group_action.lean
+++ b/src/group_theory/group_action.lean
@@ -26,6 +26,8 @@ variables [monoid α] [mul_action α β]
 
 theorem mul_smul (a₁ a₂ : α) (b : β) : (a₁ * a₂) • b = a₁ • a₂ • b := mul_action.mul_smul _ _ _
 
+lemma smul_smul (a₁ a₂ : α) (b : β) : a₁ • a₂ • b = (a₁ * a₂) • b := (mul_smul _ _ _).symm
+
 variable (α)
 @[simp] theorem one_smul (b : β) : (1 : α) • b = b := mul_action.one_smul α _
 
@@ -188,5 +190,27 @@ distrib_mul_action.smul_add _ _ _
 
 @[simp] theorem smul_zero (a : α) : a • (0 : β) = 0 :=
 distrib_mul_action.smul_zero _
+
+instance distrib_mul_action.is_add_monoid_hom (r : α) :
+  is_add_monoid_hom ((•) r : β → β) :=
+{ map_zero := smul_zero r,
+  map_add := smul_add r }
+
+lemma list.smul_sum {r : α} {l : list β} :
+  r • l.sum = (l.map ((•) r)).sum :=
+(list.sum_hom _ _).symm
+
+end
+
+section
+variables [monoid α] [add_comm_monoid β] [distrib_mul_action α β]
+
+lemma multiset.smul_sum {r : α} {s : multiset β} :
+  r • s.sum = (s.map ((•) r)).sum :=
+(multiset.sum_hom _ _).symm
+
+lemma finset.smul_sum {r : α} {f : γ → β} {s : finset γ} :
+  r • s.sum f = s.sum (λ x, r • f x) :=
+(finset.sum_hom _ _).symm
 
 end

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -367,7 +367,7 @@ instance : has_top (submodule R M) :=
 @[simp] lemma mem_top : x ∈ (⊤ : submodule R M) := trivial
 
 lemma eq_bot_of_zero_eq_one (zero_eq_one : (0 : R) = 1) : p = ⊥ :=
-by ext x; simp [semimodule.eq_zero_of_zero_eq_one _ x zero_eq_one]
+by ext x; simp [semimodule.eq_zero_of_zero_eq_one x zero_eq_one]
 
 instance : order_top (submodule R M) :=
 { top := ⊤,

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -59,27 +59,6 @@ universes u v w x y z u' v' w' y'
 variables {R : Type u} {K : Type u'} {M : Type v} {V : Type v'} {M₂ : Type w} {V₂ : Type w'}
 variables {M₃ : Type y} {V₃ : Type y'} {M₄ : Type z} {ι : Type x}
 
-namespace finset
-
-lemma smul_sum {α : Type u} {M : Type v} {R : Type w}
-  [ring R] [add_comm_group M] [module R M]
-  {s : finset α} {a : R} {f : α → M} :
-  a • (s.sum f) = s.sum (λc, a • f c) :=
-(s.sum_hom ((•) a)).symm
-
-lemma smul_sum' {α : Type u} {M : Type v} {R : Type w}
-  [ring R] [add_comm_group M] [module R M]
-  {s : finset α} {f : α → R} {x : M} :
-  (s.sum f) • x = s.sum (λa, (f a) • x) :=
-begin
--- TODO : where should I put this instance?
-  haveI : is_add_monoid_hom (λ (r : R), r • x) :=
-    { map_add := λ a b, add_smul _ _ _, map_zero := zero_smul _ _ },
-  exact (s.sum_hom (λ (r : R), r • x)).symm
-end
-
-end finset
-
 namespace finsupp
 
 lemma smul_sum {α : Type u} {β : Type v} {R : Type w} {M : Type y}

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -982,7 +982,7 @@ begin
   ext i,
   rw [unique.eq_default i, finsupp.zero_apply],
   by_contra hc,
-  have := smul_smul _ (l (default ι))⁻¹ (l (default ι)) (v (default ι)),
+  have := smul_smul (l (default ι))⁻¹ (l (default ι)) (v (default ι)),
   rw [finsupp.unique_single l, finsupp.total_single] at hl,
   rw [hl, inv_mul_cancel hc, smul_zero, one_smul] at this,
   exact h this.symm

--- a/src/linear_algebra/tensor_product.lean
+++ b/src/linear_algebra/tensor_product.lean
@@ -102,7 +102,7 @@ linear_map.comp (llcomp R N P Q g) f
 
 variables (R M)
 def lsmul : R →ₗ M →ₗ M :=
-mk₂ R (•) add_smul (λ _ _ _, eq.symm $ smul_smul _ _ _ _) smul_add
+mk₂ R (•) add_smul (λ _ _ _, mul_smul _ _ _) smul_add
 (λ r s m, by simp only [smul_smul, smul_eq_mul, mul_comm])
 variables {R M}
 

--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -247,7 +247,7 @@ begin
       apply hf,
       assumption }
   end
-  ... = s'.sum (λb, (ennreal.to_real (volume (f ⁻¹' {b}))) • (g (f a))) : by rw [finset.smul_sum']
+  ... = s'.sum (λb, (ennreal.to_real (volume (f ⁻¹' {b}))) • (g (f a))) : finset.sum_smul
   ... = s'.sum (λb, (ennreal.to_real (volume (f ⁻¹' {b}))) • (g b)) :
     finset.sum_congr rfl $ by { assume x, simp only [mem_filter], rintro ⟨_, h⟩, rw h }
 end

--- a/src/ring_theory/ideal_operations.lean
+++ b/src/ring_theory/ideal_operations.lean
@@ -134,10 +134,10 @@ le_antisymm (smul_le.2 $ λ r hrij n hn, let ⟨ri, hri, rj, hrj, hrijr⟩ := me
 theorem smul_assoc : (I • J) • N = I • (J • N) :=
 le_antisymm (smul_le.2 $ λ rs hrsij t htn,
   smul_induction_on hrsij
-  (λ r hr s hs, (@smul_eq_mul R _ r s).symm ▸ smul_smul _ r s t ▸ smul_mem_smul hr (smul_mem_smul hs htn))
+  (λ r hr s hs, (@smul_eq_mul R _ r s).symm ▸ smul_smul r s t ▸ smul_mem_smul hr (smul_mem_smul hs htn))
   ((zero_smul R t).symm ▸ submodule.zero_mem _)
   (λ x y, (add_smul x y t).symm ▸ submodule.add_mem _)
-  (λ r s h, (@smul_eq_mul R _ r s).symm ▸ smul_smul _ r s t ▸ submodule.smul_mem _ _ h))
+  (λ r s h, (@smul_eq_mul R _ r s).symm ▸ smul_smul r s t ▸ submodule.smul_mem _ _ h))
 (smul_le.2 $ λ r hr sn hsn, suffices J • N ≤ submodule.comap (r • linear_map.id) ((I • J) • N), from this hsn,
 smul_le.2 $ λ s hs n hn, show r • (s • n) ∈ (I • J) • N, from mul_smul r s n ▸ smul_mem_smul (smul_mem_smul hr hs) hn)
 


### PR DESCRIPTION
API changes:

* Define both `smul_sum` and `sum_smul` for `list`, `multiset`, and `finset`;
* new `finset.smul_sum` is the old `finset.smul_sum` or `_root_.sum_smul.symm`
* new `finset.sum_smul` is the old `finset.smul_sum'`
* new `smul_smul` doesn't need a `Type` argument
* some lemmas are generalized to a `semimodule` or a `distrib_mul_action`

Depends on #1903 (should be merged soon). The only commit on top of #1903 is https://github.com/leanprover-community/mathlib/pull/1910/commits/75a1d07446f2145b14c8dc045da8a6e542022f81

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
