### PR TITLE
fix(.github/workflows/build): set pipefail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,14 @@ jobs:
 
       - name: install elan
         run: |
+          set -o pipefail
           curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh -s -- --default-toolchain none -y
           ~/.elan/bin/elan override set ${{ matrix.lean_version }}
           ~/.elan/bin/lean --version
           echo "::add-path::$HOME/.elan/bin"
       - name: install olean-rs
         run: |
+          set -o pipefail
           OLEAN_RS=https://github.com/cipher1024/olean-rs/releases
           latest=$(curl -sSf "$OLEAN_RS/latest" | cut -d'"' -f2 | awk -F/ '{print $NF}')
           mkdir ~/scripts
@@ -53,8 +55,8 @@ jobs:
 
       - name: tests
         run: |
-          leanpkg test | cat
-          lean --make docs archive | cat
+          set -o pipefail
+          lean --make docs archive test | cat
 
       - name: lint
         run: |


### PR DESCRIPTION
Without `pipefail`, the shell command `false | cat` terminates successfully.

The `test` step currently succeeds even though `archive` doesn't build.  See https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/github.20actions/near/186678100

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
