### PR TITLE
fix(ci): unshallow repo before pushing nightly tags

### DIFF
--- a/scripts/deploy_nightly.sh
+++ b/scripts/deploy_nightly.sh
@@ -12,6 +12,9 @@ set -x				# echo commands
 # github using a different username.
 git config --unset http.https://github.com/.extraheader
 
+# The checkout action produces a shallow repository from which we cannot push.
+git fetch --unshallow || true
+
 git fetch nightly --tags
 
 # Create a tag name based on the current date.


### PR DESCRIPTION
This should fix the `(shallow update not allowed)` error, and maybe also the failure to update the `mathlib-master` branch.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
