### PR TITLE
fix(tactic/squeeze): compatibility with `simp [<-...]`

### DIFF
--- a/src/tactic/squeeze.lean
+++ b/src/tactic/squeeze.lean
@@ -21,7 +21,9 @@ meta def loc.to_string : loc → string
 namespace tactic
 namespace interactive
 
-/-- Erase names in the set which occur as a constant in the arguments. -/
+/--
+  `erase_simp_args hs s` removes from `s` each name `n` such that `const n` is an element of `hs`
+-/
 meta def erase_simp_args (hs : list simp_arg_type) (s : name_set) : tactic name_set :=
 do
   -- TODO: when Lean 3.4 support is dropped, use `decode_simp_arg_list_with_symm` on the next line:


### PR DESCRIPTION
On the Lean community edition, I made [a pull request](https://github.com/leanprover-community/lean/pull/100) (with the help of @gebner) that makes it possible to apply `simp` lemmas in reverse. Since the structure of `simp` arguments changed and `squeeze_simp` pattern-matches on them, some small fixes are required to make `squeeze_simp` compatible with Lean 3.5.0c while still keeping it compatible with Lean 3.4.2.

The first fix allows us to remove one instance of pattern-matching by calling `decode_simp_arg_list` instead. This requires a few tweaks in calling convention (putting it in the `tactic` monad), but otherwise no big differences.
The second fix is to add a `has_to_tactic_format simp_arg_type` instance in core Lean, which avoids the need for keeping the definition in `squeeze_simp` up to date. A low-priority instance is still needed as a polyfill for older Lean versions.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] other steps are not applicable

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
