### PR TITLE
fix(tactic/finish): fix one classical leak, document another

### DIFF
--- a/src/tactic/finish.lean
+++ b/src/tactic/finish.lean
@@ -465,15 +465,24 @@ meta def safe (s : simp_lemmas × list name) (ps : list pexpr)
 meta def finish (s : simp_lemmas × list name) (ps : list pexpr)
   (cfg : auto_config := {}) : tactic unit := safe_core s ps cfg case_option.force
 
-/--  `iclarify` is like `clarify`, but only uses intuitionistic logic. -/
+/--
+  `iclarify` is like `clarify`, but in some places restricts to intuitionistic logic.
+  Classical logic still leaks, so this tactic is deprecated.
+-/
 meta def iclarify (s : simp_lemmas × list name) (ps : list pexpr)
   (cfg : auto_config := {}) : tactic unit := clarify s ps {classical := ff, ..cfg}
 
-/-- `isafe` is like `safe`, but only uses intuitionistic logic. -/
+/--
+  `isafe` is like `safe`, but in some places restricts to intuitionistic logic.
+  Classical logic still leaks, so this tactic is deprecated.
+-/
 meta def isafe (s : simp_lemmas × list name) (ps : list pexpr)
   (cfg : auto_config := {}) : tactic unit := safe s ps {classical := ff, ..cfg}
 
-/-- `ifinish` is like `finish`, but only uses intuitionistic logic. -/
+/--
+  `ifinish` is like `finish`, but in some places restricts to intuitionistic logic.
+  Classical logic still leaks, so this tactic is deprecated.
+-/
 meta def ifinish (s : simp_lemmas × list name) (ps : list pexpr) (cfg : auto_config := {}) : tactic unit :=
   finish s ps {classical := ff, ..cfg}
 


### PR DESCRIPTION
The intuitionistic versions of these tactics leak classical logic, as described in #1922 . 

This PR fixes one leak (but not another one), documents the problem, and deprecates the use of the intuitionistic tactics in the docstrings.
