### PR TITLE
feat(data/nat/basic): two identities for `choose`

### DIFF
--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -1145,6 +1145,27 @@ begin
   rw [← nat.sub_eq_of_eq_add e, mul_comm, ← nat.mul_sub_left_distrib, nat.add_sub_add_right]
 end
 
+@[simp] lemma choose_succ_self_right : ∀ (n:ℕ), (n+1).choose n = n+1
+| 0     := rfl
+| (n+1) := by rw [nat.choose_succ_succ, nat.choose_succ_self_right, nat.choose_self]
+
+lemma choose_mul_succ_eq (n k : ℕ) :
+  (n.choose k) * (n + 1) = ((n+1).choose k) * (n + 1 - k) :=
+begin
+  induction k with k ih, { simp },
+  by_cases hk : n < k + 1,
+  { rw [nat.choose_eq_zero_of_lt hk, nat.sub_eq_zero_of_le hk, zero_mul, mul_zero] },
+  push_neg at hk,
+  replace hk : k + 1 ≤ n + 1 := le_add_right hk,
+  rw [nat.choose_succ_succ],
+  rw [add_mul, nat.succ_sub_succ],
+  rw [← nat.choose_succ_right_eq],
+  rw [← nat.succ_sub_succ, nat.mul_sub_left_distrib],
+  symmetry,
+  apply nat.add_sub_cancel',
+  exact nat.mul_le_mul_left _ hk,
+end
+
 section find_greatest
 
 /-- `find_greatest P b` is the largest `i ≤ bound` such that `P i` holds, or `0` if no such `i`

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -1147,23 +1147,23 @@ end
 
 @[simp] lemma choose_succ_self_right : ∀ (n:ℕ), (n+1).choose n = n+1
 | 0     := rfl
-| (n+1) := by rw [nat.choose_succ_succ, nat.choose_succ_self_right, nat.choose_self]
+| (n+1) := by rw [choose_succ_succ, choose_succ_self_right, choose_self]
 
 lemma choose_mul_succ_eq (n k : ℕ) :
   (n.choose k) * (n + 1) = ((n+1).choose k) * (n + 1 - k) :=
 begin
   induction k with k ih, { simp },
   by_cases hk : n < k + 1,
-  { rw [nat.choose_eq_zero_of_lt hk, nat.sub_eq_zero_of_le hk, zero_mul, mul_zero] },
+  { rw [choose_eq_zero_of_lt hk, sub_eq_zero_of_le hk, zero_mul, mul_zero] },
   push_neg at hk,
-  replace hk : k + 1 ≤ n + 1 := le_add_right hk,
-  rw [nat.choose_succ_succ],
-  rw [add_mul, nat.succ_sub_succ],
-  rw [← nat.choose_succ_right_eq],
-  rw [← nat.succ_sub_succ, nat.mul_sub_left_distrib],
+  replace hk : k + 1 ≤ n + 1 := _root_.le_add_right hk,
+  rw [choose_succ_succ],
+  rw [add_mul, succ_sub_succ],
+  rw [← choose_succ_right_eq],
+  rw [← succ_sub_succ, nat.mul_sub_left_distrib],
   symmetry,
   apply nat.add_sub_cancel',
-  exact nat.mul_le_mul_left _ hk,
+  exact mul_le_mul_left _ hk,
 end
 
 section find_greatest


### PR DESCRIPTION
Add two missing identities for `choose`:

```lean
@[simp] lemma choose_succ_self_right : ∀ (n:ℕ), (n+1).choose n = n+1

lemma choose_mul_succ_eq (n k : ℕ) :
  (n.choose k) * (n + 1) = ((n+1).choose k) * (n + 1 - k) :=
```