### PR TITLE
chore(tactic/norm_cast): reduce proof size

### DIFF
--- a/src/tactic/norm_cast.lean
+++ b/src/tactic/norm_cast.lean
@@ -67,12 +67,12 @@ to move casts toward the leaf nodes of the expression."
 /-- Called after the `move_cast` attribute is applied to a declaration. -/
 private meta def after_set (decl : name) (prio : ℕ) (pers : bool) : tactic unit :=
 do
-    (declaration.thm n l ty e) ← get_decl decl | failed,
+    declaration.thm n l ty _ ← get_decl decl,
     let tac := λ ty, (flip_eq ty <|> flip_iff ty),
     (ty', f) ← aux_after_set tac ty,
-    let e' := task.map f e,
+    let e' := f (expr.const n (l.map level.param)),
     let n' := new_name n,
-    add_decl (declaration.thm n' l ty' e'),
+    add_decl (declaration.thm n' l ty' (task.pure e')),
     simp_attr.push_cast.set decl () tt
 
 private meta def mk_cache : list name → tactic simp_lemmas :=


### PR DESCRIPTION
The `@[move_cast]` attribute generates an auxiliary `my_theorem.reversed` declaration.  At the moment, it copies the proof from `my_theorem`.  This PR replaces the duplicated proof by an ``expr.const `my_theorem ...``.

(I found this issue when looking through the evaluation results from the hammer, and noticed that there are a lot of easy to prove theorems with huge proofs.)

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
