### PR TITLE
feat(tactic/lint): Three new linters, update illegal_constants

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -108,7 +108,7 @@ The following linters are run by default:
 1. `unused_arguments` checks for unused arguments in declarations.
 2. `def_lemma` checks whether a declaration is incorrectly marked as a def/lemma.
 3. `dup_namespce` checks whether a namespace is duplicated in the name of a declaration.
-4. `illegal_constant` checks whether ≥/> is used in the declaration.
+4. `ge_or_gt` checks whether ≥/> is used in the declaration.
 5. `instance_priority` checks that instances that always apply have priority below default.
 6. `doc_blame` checks for missing doc strings on definitions and constants.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -111,6 +111,10 @@ The following linters are run by default:
 4. `ge_or_gt` checks whether ≥/> is used in the declaration.
 5. `instance_priority` checks that instances that always apply have priority below default.
 6. `doc_blame` checks for missing doc strings on definitions and constants.
+7.  `has_inhabited_instance` checks whether every type has an associated `inhabited` instance.
+8.  `impossible_instance` checks for instances that can never fire.
+9.  `incorrect_type_class_argument` checks for arguments in [square brackets] that are not classes.
+10. `dangerous_instance` checks for instances that generate type-class problems with metavariables.
 
 Another linter, `doc_blame_thm`, checks for missing doc strings on lemmas and theorems.
 This is not run by default.

--- a/scripts/mk_all.sh
+++ b/scripts/mk_all.sh
@@ -40,5 +40,5 @@ cat <<EOT >> lint_mathlib.lean
 open nat -- need to do something before running a command
 
 #lint_mathlib- only unused_arguments dup_namespace doc_blame ge_or_gt def_lemma instance_priority
-  has_inhabited_instance impossible_instance incorrect_type_class_argument dangerous_instance
+  impossible_instance incorrect_type_class_argument dangerous_instance
 EOT

--- a/scripts/mk_all.sh
+++ b/scripts/mk_all.sh
@@ -39,5 +39,6 @@ cat <<EOT >> lint_mathlib.lean
 
 open nat -- need to do something before running a command
 
-#lint_mathlib- only unused_arguments dup_namespace doc_blame illegal_constants def_lemma instance_priority
+#lint_mathlib- only unused_arguments dup_namespace doc_blame ge_or_gt def_lemma instance_priority
+  has_inhabited_instance impossible_instance incorrect_type_class_argument dangerous_instance
 EOT

--- a/scripts/mk_nolint.lean
+++ b/scripts/mk_nolint.lean
@@ -25,7 +25,7 @@ open io io.fs
 /-- Defines the list of linters that will be considered. -/
 meta def active_linters :=
 [`linter.unused_arguments, `linter.dup_namespace, `linter.doc_blame,
- `linter.illegal_constants, `linter.def_lemma, `linter.instance_priority]
+ `linter.ge_or_gt, `linter.def_lemma, `linter.instance_priority]
 
 /-- Runs when called with `lean --run` -/
 meta def main : io unit :=

--- a/scripts/mk_nolint.lean
+++ b/scripts/mk_nolint.lean
@@ -25,7 +25,8 @@ open io io.fs
 /-- Defines the list of linters that will be considered. -/
 meta def active_linters :=
 [`linter.unused_arguments, `linter.dup_namespace, `linter.doc_blame,
- `linter.ge_or_gt, `linter.def_lemma, `linter.instance_priority]
+ `linter.ge_or_gt, `linter.def_lemma, `linter.instance_priority, `linter.has_inhabited_instance
+ `linter.impossible_instance, `linter.incorrect_type_class_argument, `linter.dangerous_instance]
 
 /-- Runs when called with `lean --run` -/
 meta def main : io unit :=

--- a/scripts/mk_nolint.lean
+++ b/scripts/mk_nolint.lean
@@ -25,7 +25,7 @@ open io io.fs
 /-- Defines the list of linters that will be considered. -/
 meta def active_linters :=
 [`linter.unused_arguments, `linter.dup_namespace, `linter.doc_blame,
- `linter.ge_or_gt, `linter.def_lemma, `linter.instance_priority, `linter.has_inhabited_instance
+ `linter.ge_or_gt, `linter.def_lemma, `linter.instance_priority, `linter.has_inhabited_instance,
  `linter.impossible_instance, `linter.incorrect_type_class_argument, `linter.dangerous_instance]
 
 /-- Runs when called with `lean --run` -/

--- a/scripts/mk_nolint.lean
+++ b/scripts/mk_nolint.lean
@@ -25,7 +25,7 @@ open io io.fs
 /-- Defines the list of linters that will be considered. -/
 meta def active_linters :=
 [`linter.unused_arguments, `linter.dup_namespace, `linter.doc_blame,
- `linter.ge_or_gt, `linter.def_lemma, `linter.instance_priority, `linter.has_inhabited_instance,
+ `linter.ge_or_gt, `linter.def_lemma, `linter.instance_priority, --`linter.has_inhabited_instance,
  `linter.impossible_instance, `linter.incorrect_type_class_argument, `linter.dangerous_instance]
 
 /-- Runs when called with `lean --run` -/

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -255,6 +255,8 @@ structure lie_subalgebra extends submodule R L :=
 instance lie_subalgebra_coe_submodule : has_coe (lie_subalgebra R L) (submodule R L) :=
 ⟨lie_subalgebra.to_submodule⟩
 
+/-- A Lie subalgebra forms a new Lie algebra.
+This cannot be an instance, since being a Lie subalgebra is (currently) not a class. -/
 def lie_subalgebra_lie_algebra (L' : lie_subalgebra R L) : lie_algebra R L' := {
   bracket  := λ x y, ⟨⁅x.val, y.val⁆, L'.lie_mem x.property y.property⟩,
   lie_add  := by { intros, apply set_coe.ext, apply lie_add, },

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -255,7 +255,7 @@ structure lie_subalgebra extends submodule R L :=
 instance lie_subalgebra_coe_submodule : has_coe (lie_subalgebra R L) (submodule R L) :=
 ⟨lie_subalgebra.to_submodule⟩
 
-instance lie_subalgebra_lie_algebra [L' : lie_subalgebra R L] : lie_algebra R L' := {
+def lie_subalgebra_lie_algebra (L' : lie_subalgebra R L) : lie_algebra R L' := {
   bracket  := λ x y, ⟨⁅x.val, y.val⁆, L'.lie_mem x.property y.property⟩,
   lie_add  := by { intros, apply set_coe.ext, apply lie_add, },
   add_lie  := by { intros, apply set_coe.ext, apply add_lie, },

--- a/src/category/monad/writer.lean
+++ b/src/category/monad/writer.lean
@@ -148,9 +148,15 @@ export monad_writer_adapter (adapt_writer)
 section
 variables {ω ω' : Type u} {m m' : Type u → Type v}
 
-/- marked as nolint, because it generates metavariables during type class resolution -/
-@[priority 100, nolint] -- see Note [lower instance priority]
-instance monad_writer_adapter_trans {n n' : Type u → Type v} [monad_functor m m' n n'] [monad_writer_adapter ω ω' m m'] : monad_writer_adapter ω ω' n n' :=
+/-- Transitivity.
+
+This instance generates the type-class problem bundled_hom ?m (which is why this is marked as
+`[nolint]`). Currently that is not a problem, as there are almost no instances of `bundled_hom`.
+
+see Note [lower instance priority] -/
+@[nolint, priority 100]
+instance monad_writer_adapter_trans {n n' : Type u → Type v} [monad_functor m m' n n']
+  [monad_writer_adapter ω ω' m m'] : monad_writer_adapter ω ω' n n' :=
 ⟨λ α f, monad_map (λ α, (adapt_writer f : m α → m' α))⟩
 
 instance [monad m] : monad_writer_adapter ω ω' (writer_t ω m) (writer_t ω' m) :=

--- a/src/category/monad/writer.lean
+++ b/src/category/monad/writer.lean
@@ -148,7 +148,8 @@ export monad_writer_adapter (adapt_writer)
 section
 variables {ω ω' : Type u} {m m' : Type u → Type v}
 
-@[priority 100] -- see Note [lower instance priority]
+/- marked as nolint, because it generates metavariables during type class resolution -/
+@[priority 100, nolint] -- see Note [lower instance priority]
 instance monad_writer_adapter_trans {n n' : Type u → Type v} [monad_functor m m' n n'] [monad_writer_adapter ω ω' m m'] : monad_writer_adapter ω ω' n n' :=
 ⟨λ α f, monad_map (λ α, (adapt_writer f : m α → m' α))⟩
 

--- a/src/category_theory/adjunction/limits.lean
+++ b/src/category_theory/adjunction/limits.lean
@@ -44,8 +44,7 @@ def functoriality_is_left_adjoint :
     counit := functoriality_counit adj K } }
 
 /-- A left adjoint preserves colimits. -/
-@[priority 100] -- see Note [lower instance priority]
-instance left_adjoint_preserves_colimits : preserves_colimits F :=
+def left_adjoint_preserves_colimits : preserves_colimits F :=
 { preserves_colimits_of_shape := λ J 𝒥,
   { preserves_colimit := λ F,
     by exactI
@@ -100,8 +99,7 @@ def functoriality_is_right_adjoint :
     counit := functoriality_counit' adj K } }
 
 /-- A right adjoint preserves limits. -/
-@[priority 100] -- see Note [lower instance priority]
-instance right_adjoint_preserves_limits : preserves_limits G :=
+def right_adjoint_preserves_limits : preserves_limits G :=
 { preserves_limits_of_shape := λ J 𝒥,
   { preserves_limit := λ K,
     by exactI

--- a/src/category_theory/adjunction/limits.lean
+++ b/src/category_theory/adjunction/limits.lean
@@ -56,7 +56,7 @@ omit adj
 
 @[priority 100] -- see Note [lower instance priority]
 instance is_equivalence_preserves_colimits (E : C ⥤ D) [is_equivalence E] : preserves_colimits E :=
-adjunction.left_adjoint_preserves_colimits E.adjunction
+left_adjoint_preserves_colimits E.adjunction
 
 -- verify the preserve_colimits instance works as expected:
 example (E : C ⥤ D) [is_equivalence E]
@@ -111,7 +111,7 @@ omit adj
 
 @[priority 100] -- see Note [lower instance priority]
 instance is_equivalence_preserves_limits (E : D ⥤ C) [is_equivalence E] : preserves_limits E :=
-adjunction.right_adjoint_preserves_limits E.inv.adjunction
+right_adjoint_preserves_limits E.inv.adjunction
 
 -- verify the preserve_limits instance works as expected:
 example (E : D ⥤ C) [is_equivalence E]

--- a/src/category_theory/concrete_category/bundled_hom.lean
+++ b/src/category_theory/concrete_category/bundled_hom.lean
@@ -45,7 +45,8 @@ variable [𝒞 : bundled_hom hom]
 include 𝒞
 
 /-- Every `@bundled_hom c _` defines a category with objects in `bundled c`. -/
-protected def category : category (bundled c) :=
+-- The linter `dangerous_instance` fails, because it generates the type-class problem bundled_hom ?m
+@[nolint] instance category : category (bundled c) :=
 by refine
 { hom := λ X Y, @hom X.1 Y.1 X.str Y.str,
   id := λ X, @bundled_hom.id c hom 𝒞 X X.str,
@@ -57,7 +58,8 @@ intros; apply 𝒞.hom_ext;
   simp only [𝒞.id_to_fun, 𝒞.comp_to_fun, function.left_id, function.right_id]
 
 /-- A category given by `bundled_hom` is a concrete category. -/
-protected def concrete_category : concrete_category (bundled c) :=
+-- The linter `dangerous_instance` fails, because it generates the type-class problem bundled_hom ?m
+@[nolint] instance : concrete_category (bundled c) :=
 { forget := { obj := λ X, X,
               map := λ X Y f, 𝒞.to_fun X.str Y.str f,
               map_id' := λ X, 𝒞.id_to_fun X.str,

--- a/src/category_theory/concrete_category/bundled_hom.lean
+++ b/src/category_theory/concrete_category/bundled_hom.lean
@@ -44,8 +44,10 @@ namespace bundled_hom
 variable [𝒞 : bundled_hom hom]
 include 𝒞
 
-/-- Every `@bundled_hom c _` defines a category with objects in `bundled c`. -/
--- The linter `dangerous_instance` fails, because it generates the type-class problem bundled_hom ?m
+/-- Every `@bundled_hom c _` defines a category with objects in `bundled c`.
+
+This instance generates the type-class problem bundled_hom ?m (which is why this is marked as
+`[nolint]`). Currently that is not a problem, as there are almost no instances of `bundled_hom`. -/
 @[nolint] instance category : category (bundled c) :=
 by refine
 { hom := λ X Y, @hom X.1 Y.1 X.str Y.str,
@@ -57,8 +59,10 @@ by refine
 intros; apply 𝒞.hom_ext;
   simp only [𝒞.id_to_fun, 𝒞.comp_to_fun, function.left_id, function.right_id]
 
-/-- A category given by `bundled_hom` is a concrete category. -/
--- The linter `dangerous_instance` fails, because it generates the type-class problem bundled_hom ?m
+/-- A category given by `bundled_hom` is a concrete category.
+
+This instance generates the type-class problem bundled_hom ?m (which is why this is marked as
+`[nolint]`). Currently that is not a problem, as there are almost no instances of `bundled_hom`. -/
 @[nolint] instance : concrete_category (bundled c) :=
 { forget := { obj := λ X, X,
               map := λ X Y f, 𝒞.to_fun X.str Y.str f,

--- a/src/category_theory/concrete_category/bundled_hom.lean
+++ b/src/category_theory/concrete_category/bundled_hom.lean
@@ -45,7 +45,7 @@ variable [𝒞 : bundled_hom hom]
 include 𝒞
 
 /-- Every `@bundled_hom c _` defines a category with objects in `bundled c`. -/
-instance : category (bundled c) :=
+protected def category : category (bundled c) :=
 by refine
 { hom := λ X Y, @hom X.1 Y.1 X.str Y.str,
   id := λ X, @bundled_hom.id c hom 𝒞 X X.str,
@@ -57,7 +57,7 @@ intros; apply 𝒞.hom_ext;
   simp only [𝒞.id_to_fun, 𝒞.comp_to_fun, function.left_id, function.right_id]
 
 /-- A category given by `bundled_hom` is a concrete category. -/
-instance concrete_category : concrete_category (bundled c) :=
+protected def concrete_category : concrete_category (bundled c) :=
 { forget := { obj := λ X, X,
               map := λ X Y f, 𝒞.to_fun X.str Y.str f,
               map_id' := λ X, 𝒞.id_to_fun X.str,

--- a/src/data/list/defs.lean
+++ b/src/data/list/defs.lean
@@ -13,6 +13,11 @@ open function nat
 universes u v w x
 variables {α : Type u} {β : Type v} {γ : Type w} {δ : Type x}
 
+/-- Returns whether a list is []. Returns a boolean even if `l = []` is not decidable. -/
+def is_nil {α} : list α → bool
+| [] := tt
+| _  := ff
+
 instance [decidable_eq α] : has_sdiff (list α) :=
 ⟨ list.diff ⟩
 
@@ -171,6 +176,16 @@ map_with_index_core f 0 as
 
      indexes_of a [a, b, a, a] = [0, 2, 3] -/
 def indexes_of [decidable_eq α] (a : α) : list α → list nat := find_indexes (eq a)
+
+/-- Auxilliary definition for `indexes_values`. -/
+def indexes_values_aux {α} (f : α → bool) : list α → ℕ → list (ℕ × α)
+| []      n := []
+| (x::xs) n := let ns := indexes_values_aux xs (n+1) in if f x then (n, x)::ns else ns
+
+/-- Returns `(l.find_indexes f).zip l`, i.e. pairs of `(n, x)` such that `f x = tt` and
+  `l.nth = some x`, in increasing order of first arguments. -/
+def indexes_values {α} (l : list α) (f : α → bool) : list (ℕ × α) :=
+indexes_values_aux f l 0
 
 /-- `countp p l` is the number of elements of `l` that satisfy `p`. -/
 def countp (p : α → Prop) [decidable_pred p] : list α → nat

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -382,6 +382,12 @@ meta def pi_codomain : expr → expr -- see note [open expressions]
 | (pi n bi d b) := pi_codomain b
 | e             := e
 
+/-- Get the body/value of a lambda-expression.
+  This definition doesn't instantiate bound variables, and therefore produces a term that is open. -/
+meta def lambda_body : expr → expr -- see note [open expressions]
+| (lam n bi d b) := lambda_body b
+| e             := e
+
 /-- Auxilliary defintion for `pi_binders`. -/
 -- see note [open expressions]
 meta def pi_binders_aux : list binder → expr → list binder × expr
@@ -438,6 +444,15 @@ meta def local_binding_info : expr → binder_info
 meta def is_default_local : expr → bool
 | (expr.local_const _ _ binder_info.default _) := tt
 | _ := ff
+
+/-- Checks whether local constant `l` occurs in expression `e` -/
+meta def has_local_constant (e l : expr) : bool :=
+e.has_local_in $ mk_name_set.insert l.local_uniq_name
+
+/-- Turns a local constant into a binder -/
+meta def to_binder : expr → binder
+| (local_const _ nm bi t) := ⟨nm, bi, t⟩
+| _                       := default binder
 
 end expr
 

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -445,7 +445,7 @@ meta def is_default_local : expr → bool
 | (expr.local_const _ _ binder_info.default _) := tt
 | _ := ff
 
-/-- Checks whether local constant `l` occurs in expression `e` -/
+/-- `has_local_constant e l` checks whether local constant `l` occurs in expression `e` -/
 meta def has_local_constant (e l : expr) : bool :=
 e.has_local_in $ mk_name_set.insert l.local_uniq_name
 

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -377,19 +377,21 @@ iterating through the expression. In one performance test `pi_binders` was more 
 quicker than `mk_local_pis` (when applied to the type of all imported declarations 100x)."
 
 /-- Get the codomain/target of a pi-type.
-  This definition doesn't instantiate bound variables, and therefore produces a term that is open.-/
-meta def pi_codomain : expr → expr -- see note [open expressions]
+  This definition doesn't instantiate bound variables, and therefore produces a term that is open.
+  See note [open expressions]. -/
+meta def pi_codomain : expr → expr
 | (pi n bi d b) := pi_codomain b
 | e             := e
 
 /-- Get the body/value of a lambda-expression.
-  This definition doesn't instantiate bound variables, and therefore produces a term that is open. -/
-meta def lambda_body : expr → expr -- see note [open expressions]
+  This definition doesn't instantiate bound variables, and therefore produces a term that is open.
+  See note [open expressions]. -/
+meta def lambda_body : expr → expr
 | (lam n bi d b) := lambda_body b
 | e             := e
 
-/-- Auxilliary defintion for `pi_binders`. -/
--- see note [open expressions]
+/-- Auxilliary defintion for `pi_binders`.
+  See note [open expressions]. -/
 meta def pi_binders_aux : list binder → expr → list binder × expr
 | es (pi n bi d b) := pi_binders_aux (⟨n, bi, d⟩::es) b
 | es e             := (es, e)
@@ -397,8 +399,9 @@ meta def pi_binders_aux : list binder → expr → list binder × expr
 /-- Get the binders and codomain of a pi-type.
   This definition doesn't instantiate bound variables, and therefore produces a term that is open.
   The.tactic `get_pi_binders` in `tactic.core` does the same, but also instantiates the
-  free variables -/
-meta def pi_binders (e : expr) : list binder × expr := -- see note [open expressions]
+  free variables.
+  See note [open expressions]. -/
+meta def pi_binders (e : expr) : list binder × expr :=
 let (es, e) := pi_binders_aux [] e in (es.reverse, e)
 
 /-- Auxilliary defintion for `get_app_fn_args`. -/

--- a/src/order/filter/filter_product.lean
+++ b/src/order/filter/filter_product.lean
@@ -415,7 +415,7 @@ protected noncomputable def discrete_linear_ordered_field [discrete_linear_order
 { ..filter_product.linear_ordered_field U, ..filter_product.decidable_linear_ordered_comm_ring U,
   ..filter_product.discrete_field U }
 
-protected def ordered_cancel_comm_monoid [ordered_cancel_comm_monoid β] : ordered_cancel_comm_monoid β* :=
+instance ordered_cancel_comm_monoid [ordered_cancel_comm_monoid β] : ordered_cancel_comm_monoid β* :=
 { add_le_add_left := λ x y hxy z, by revert hxy; exact quotient.induction_on₃' x y z
     (λ a b c hab, by filter_upwards [hab] λ i hi, by simpa),
   le_of_add_le_add_left := λ x y z, quotient.induction_on₃' x y z $ λ x y z h,

--- a/src/order/filter/filter_product.lean
+++ b/src/order/filter/filter_product.lean
@@ -189,7 +189,9 @@ instance [comm_ring β] : comm_ring β* :=
 { ..filter_product.ring,
   ..filter_product.comm_semigroup }
 
-instance [zero_ne_one_class β] (NT : φ ≠ ⊥) : zero_ne_one_class β* :=
+/-- If `φ ≠ ⊥` then `0 ≠ 1` in the ultraproduct.
+This cannot be an instance, since it depends on `φ ≠ ⊥`. -/
+protected def zero_ne_one_class [zero_ne_one_class β] (NT : φ ≠ ⊥) : zero_ne_one_class β* :=
 { zero_ne_one := λ c, have c' : _ := quotient.exact' c, by
   { change _ ∈ _ at c',
     simp only [set.set_of_false, zero_ne_one, empty_in_sets_eq_bot] at c',
@@ -197,6 +199,8 @@ instance [zero_ne_one_class β] (NT : φ ≠ ⊥) : zero_ne_one_class β* :=
   ..filter_product.has_zero,
   ..filter_product.has_one }
 
+/-- If `φ` is an ultrafilter then the ultraproduct is a division ring.
+This cannot be an instance, since it depends on `φ` being an ultrafilter. -/
 protected def division_ring [division_ring β] (U : is_ultrafilter φ) : division_ring β* :=
 { mul_inv_cancel := λ x, quotient.induction_on' x $ λ a hx, quotient.sound' $
     have hx1 : _ := (not_imp_not.mpr quotient.eq'.mpr) hx,
@@ -214,10 +218,14 @@ protected def division_ring [division_ring β] (U : is_ultrafilter φ) : divisio
   ..filter_product.has_inv,
   ..filter_product.zero_ne_one_class U.1 }
 
+/-- If `φ` is an ultrafilter then the ultraproduct is a field.
+This cannot be an instance, since it depends on `φ` being an ultrafilter. -/
 protected def field [field β] (U : is_ultrafilter φ) : field β* :=
 { ..filter_product.comm_ring,
   ..filter_product.division_ring U }
 
+/-- If `φ` is an ultrafilter then the ultraproduct is a discrete field.
+This cannot be an instance, since it depends on `φ` being an ultrafilter. -/
 protected noncomputable def discrete_field [discrete_field β] (U : is_ultrafilter φ) :
   discrete_field β* :=
 { inv_zero := quotient.sound' $ by show _ ∈ _;
@@ -240,6 +248,8 @@ instance [partial_order β] : partial_order β* :=
     show _ ∈ _, by rw hI; exact inter_sets _ hab hba
   ..filter_product.preorder }
 
+/-- If `φ` is an ultrafilter then the ultraproduct is a linear order.
+This cannot be an instance, since it depends on `φ` being an ultrafilter. -/
 protected def linear_order [linear_order β] (U : is_ultrafilter φ) : linear_order β* :=
 { le_total := λ x y, quotient.induction_on₂' x y $ λ a b,
     have hS : _ ⊆ {i | b i ≤ a i} := λ i, le_of_not_le,
@@ -364,6 +374,8 @@ by rw lt_def U; exact of_rel₂ U.1
 lemma lift_id : lift id = (id : β* → β*) :=
 funext $ λ x, quotient.induction_on' x $ by apply λ a, quotient.sound (setoid.refl _)
 
+/-- If `φ` is an ultrafilter then the ultraproduct is an ordered commutative group.
+This cannot be an instance, since it depends on `φ` being an ultrafilter. -/
 protected def ordered_comm_group [ordered_comm_group β] (U : is_ultrafilter φ) : ordered_comm_group β* :=
 { add_le_add_left := λ x y hxy z, by revert hxy; exact quotient.induction_on₃' x y z
     (λ a b c hab, by filter_upwards [hab] λ i hi, by simpa),
@@ -372,6 +384,8 @@ protected def ordered_comm_group [ordered_comm_group β] (U : is_ultrafilter φ)
     filter_upwards [hab] λ i hi, add_lt_add_left hi (c i)),
   ..filter_product.partial_order, ..filter_product.add_comm_group }
 
+/-- If `φ` is an ultrafilter then the ultraproduct is an ordered ring.
+This cannot be an instance, since it depends on `φ` being an ultrafilter. -/
 protected def ordered_ring [ordered_ring β] (U : is_ultrafilter φ) : ordered_ring β* :=
 { mul_nonneg := λ x y, quotient.induction_on₂' x y $
     λ a b ha hb, by filter_upwards [ha, hb] λ i, by simp only [set.mem_set_of_eq];
@@ -381,35 +395,49 @@ protected def ordered_ring [ordered_ring β] (U : is_ultrafilter φ) : ordered_r
   ..filter_product.ring, ..filter_product.ordered_comm_group U,
   ..filter_product.zero_ne_one_class U.1 }
 
+/-- If `φ` is an ultrafilter then the ultraproduct is a linear ordered ring.
+This cannot be an instance, since it depends on `φ` being an ultrafilter. -/
 protected def linear_ordered_ring [linear_ordered_ring β] (U : is_ultrafilter φ) :
   linear_ordered_ring β* :=
 { zero_lt_one := by rw lt_def U; show (∀* i, (0 : β) < 1); simp [zero_lt_one],
   ..filter_product.ordered_ring U, ..filter_product.linear_order U }
 
+/-- If `φ` is an ultrafilter then the ultraproduct is a linear ordered field.
+This cannot be an instance, since it depends on `φ` being an ultrafilter. -/
 protected def linear_ordered_field [linear_ordered_field β] (U : is_ultrafilter φ) :
   linear_ordered_field β* :=
 { ..filter_product.linear_ordered_ring U, ..filter_product.field U }
 
+/-- If `φ` is an ultrafilter then the ultraproduct is a linear ordered commutative ring.
+This cannot be an instance, since it depends on `φ` being an ultrafilter. -/
 protected def linear_ordered_comm_ring [linear_ordered_comm_ring β] (U : is_ultrafilter φ) :
   linear_ordered_comm_ring β* :=
 { ..filter_product.linear_ordered_ring U, ..filter_product.comm_monoid }
 
+/-- If `φ` is an ultrafilter then the ultraproduct is a decidable linear order.
+This cannot be an instance, since it depends on `φ` being an ultrafilter. -/
 protected noncomputable def decidable_linear_order [decidable_linear_order β] (U : is_ultrafilter φ) :
   decidable_linear_order β* :=
 { decidable_le := by apply_instance,
   ..filter_product.linear_order U }
 
+/-- If `φ` is an ultrafilter then the ultraproduct is a decidable linear ordered commutative group.
+This cannot be an instance, since it depends on `φ` being an ultrafilter. -/
 protected noncomputable def decidable_linear_ordered_comm_group
   [decidable_linear_ordered_comm_group β] (U : is_ultrafilter φ) :
   decidable_linear_ordered_comm_group β* :=
 { ..filter_product.ordered_comm_group U, ..filter_product.decidable_linear_order U }
 
+/-- If `φ` is an ultrafilter then the ultraproduct is a decidable linear ordered commutative ring.
+This cannot be an instance, since it depends on `φ` being an ultrafilter. -/
 protected noncomputable def decidable_linear_ordered_comm_ring
   [decidable_linear_ordered_comm_ring β] (U : is_ultrafilter φ) :
   decidable_linear_ordered_comm_ring β* :=
 { ..filter_product.linear_ordered_comm_ring U,
   ..filter_product.decidable_linear_ordered_comm_group U }
 
+/-- If `φ` is an ultrafilter then the ultraproduct is a discrete linear ordered field.
+This cannot be an instance, since it depends on `φ` being an ultrafilter. -/
 protected noncomputable def discrete_linear_ordered_field [discrete_linear_ordered_field β]
   (U : is_ultrafilter φ) : discrete_linear_ordered_field β* :=
 { ..filter_product.linear_ordered_field U, ..filter_product.decidable_linear_ordered_comm_ring U,

--- a/src/order/filter/filter_product.lean
+++ b/src/order/filter/filter_product.lean
@@ -197,7 +197,7 @@ instance [zero_ne_one_class β] (NT : φ ≠ ⊥) : zero_ne_one_class β* :=
   ..filter_product.has_zero,
   ..filter_product.has_one }
 
-instance [division_ring β] (U : is_ultrafilter φ) : division_ring β* :=
+protected def division_ring [division_ring β] (U : is_ultrafilter φ) : division_ring β* :=
 { mul_inv_cancel := λ x, quotient.induction_on' x $ λ a hx, quotient.sound' $
     have hx1 : _ := (not_imp_not.mpr quotient.eq'.mpr) hx,
     have hx2 : _ := (ultrafilter_iff_compl_mem_iff_not_mem.mp U _).mpr hx1,
@@ -214,11 +214,12 @@ instance [division_ring β] (U : is_ultrafilter φ) : division_ring β* :=
   ..filter_product.has_inv,
   ..filter_product.zero_ne_one_class U.1 }
 
-instance [field β] (U : is_ultrafilter φ) : field β* :=
+protected def field [field β] (U : is_ultrafilter φ) : field β* :=
 { ..filter_product.comm_ring,
   ..filter_product.division_ring U }
 
-noncomputable instance [discrete_field β] (U : is_ultrafilter φ) : discrete_field β* :=
+protected noncomputable def discrete_field [discrete_field β] (U : is_ultrafilter φ) :
+  discrete_field β* :=
 { inv_zero := quotient.sound' $ by show _ ∈ _;
     simp only [inv_zero, eq_self_iff_true, (set.univ_def).symm, univ_sets],
   has_decidable_eq := by apply_instance,
@@ -239,7 +240,7 @@ instance [partial_order β] : partial_order β* :=
     show _ ∈ _, by rw hI; exact inter_sets _ hab hba
   ..filter_product.preorder }
 
-instance [linear_order β] (U : is_ultrafilter φ) : linear_order β* :=
+protected def linear_order [linear_order β] (U : is_ultrafilter φ) : linear_order β* :=
 { le_total := λ x y, quotient.induction_on₂' x y $ λ a b,
     have hS : _ ⊆ {i | b i ≤ a i} := λ i, le_of_not_le,
     or.cases_on (mem_or_compl_mem_of_ultrafilter U {i | a i ≤ b i})
@@ -363,7 +364,7 @@ by rw lt_def U; exact of_rel₂ U.1
 lemma lift_id : lift id = (id : β* → β*) :=
 funext $ λ x, quotient.induction_on' x $ by apply λ a, quotient.sound (setoid.refl _)
 
-instance [ordered_comm_group β] (U : is_ultrafilter φ) : ordered_comm_group β* :=
+protected def ordered_comm_group [ordered_comm_group β] (U : is_ultrafilter φ) : ordered_comm_group β* :=
 { add_le_add_left := λ x y hxy z, by revert hxy; exact quotient.induction_on₃' x y z
     (λ a b c hab, by filter_upwards [hab] λ i hi, by simpa),
   add_lt_add_left := λ x y hxy z, by revert hxy; exact quotient.induction_on₃' x y z
@@ -371,7 +372,7 @@ instance [ordered_comm_group β] (U : is_ultrafilter φ) : ordered_comm_group β
     filter_upwards [hab] λ i hi, add_lt_add_left hi (c i)),
   ..filter_product.partial_order, ..filter_product.add_comm_group }
 
-instance [ordered_ring β] (U : is_ultrafilter φ) : ordered_ring β* :=
+protected def ordered_ring [ordered_ring β] (U : is_ultrafilter φ) : ordered_ring β* :=
 { mul_nonneg := λ x y, quotient.induction_on₂' x y $
     λ a b ha hb, by filter_upwards [ha, hb] λ i, by simp only [set.mem_set_of_eq];
     exact mul_nonneg,
@@ -380,36 +381,41 @@ instance [ordered_ring β] (U : is_ultrafilter φ) : ordered_ring β* :=
   ..filter_product.ring, ..filter_product.ordered_comm_group U,
   ..filter_product.zero_ne_one_class U.1 }
 
-instance [linear_ordered_ring β] (U : is_ultrafilter φ) : linear_ordered_ring β* :=
+protected def linear_ordered_ring [linear_ordered_ring β] (U : is_ultrafilter φ) :
+  linear_ordered_ring β* :=
 { zero_lt_one := by rw lt_def U; show (∀* i, (0 : β) < 1); simp [zero_lt_one],
   ..filter_product.ordered_ring U, ..filter_product.linear_order U }
 
-instance [linear_ordered_field β] (U : is_ultrafilter φ) : linear_ordered_field β* :=
+protected def linear_ordered_field [linear_ordered_field β] (U : is_ultrafilter φ) :
+  linear_ordered_field β* :=
 { ..filter_product.linear_ordered_ring U, ..filter_product.field U }
 
-instance [linear_ordered_comm_ring β] (U : is_ultrafilter φ) : linear_ordered_comm_ring β* :=
+protected def linear_ordered_comm_ring [linear_ordered_comm_ring β] (U : is_ultrafilter φ) :
+  linear_ordered_comm_ring β* :=
 { ..filter_product.linear_ordered_ring U, ..filter_product.comm_monoid }
 
-noncomputable instance [decidable_linear_order β] (U : is_ultrafilter φ) :
+protected noncomputable def decidable_linear_order [decidable_linear_order β] (U : is_ultrafilter φ) :
   decidable_linear_order β* :=
 { decidable_le := by apply_instance,
   ..filter_product.linear_order U }
 
-noncomputable instance [decidable_linear_ordered_comm_group β] (U : is_ultrafilter φ) :
+protected noncomputable def decidable_linear_ordered_comm_group
+  [decidable_linear_ordered_comm_group β] (U : is_ultrafilter φ) :
   decidable_linear_ordered_comm_group β* :=
 { ..filter_product.ordered_comm_group U, ..filter_product.decidable_linear_order U }
 
-noncomputable instance [decidable_linear_ordered_comm_ring β] (U : is_ultrafilter φ) :
+protected noncomputable def decidable_linear_ordered_comm_ring
+  [decidable_linear_ordered_comm_ring β] (U : is_ultrafilter φ) :
   decidable_linear_ordered_comm_ring β* :=
 { ..filter_product.linear_ordered_comm_ring U,
   ..filter_product.decidable_linear_ordered_comm_group U }
 
-noncomputable instance [discrete_linear_ordered_field β] (U : is_ultrafilter φ) :
-  discrete_linear_ordered_field β* :=
+protected noncomputable def discrete_linear_ordered_field [discrete_linear_ordered_field β]
+  (U : is_ultrafilter φ) : discrete_linear_ordered_field β* :=
 { ..filter_product.linear_ordered_field U, ..filter_product.decidable_linear_ordered_comm_ring U,
   ..filter_product.discrete_field U }
 
-instance [ordered_cancel_comm_monoid β] : ordered_cancel_comm_monoid β* :=
+protected def ordered_cancel_comm_monoid [ordered_cancel_comm_monoid β] : ordered_cancel_comm_monoid β* :=
 { add_le_add_left := λ x y hxy z, by revert hxy; exact quotient.induction_on₃' x y z
     (λ a b c hab, by filter_upwards [hab] λ i hi, by simpa),
   le_of_add_le_add_left := λ x y z, quotient.induction_on₃' x y z $ λ x y z h,

--- a/src/order/fixed_points.lean
+++ b/src/order/fixed_points.lean
@@ -170,6 +170,8 @@ Sup_le $ λ x hxA, (HA hxA) ▸ (hf $ le_Sup hxA)
 theorem f_le_Inf_of_fixed_points (A : set α) (HA : A ⊆ fixed_points f) : f (Inf A) ≤ Inf A :=
 le_Inf $ λ x hxA, (HA hxA) ▸ (hf $ Inf_le hxA)
 
+/-- The fixed points of `f` form a complete lattice.
+This cannot be an instance, since it depends on the monotonicity of `f`. -/
 protected def complete_lattice : complete_lattice (fixed_points f) :=
 { le           := λx y, x.1 ≤ y.1,
   le_refl      := λ x, le_refl x,

--- a/src/order/fixed_points.lean
+++ b/src/order/fixed_points.lean
@@ -170,7 +170,7 @@ Sup_le $ λ x hxA, (HA hxA) ▸ (hf $ le_Sup hxA)
 theorem f_le_Inf_of_fixed_points (A : set α) (HA : A ⊆ fixed_points f) : f (Inf A) ≤ Inf A :=
 le_Inf $ λ x hxA, (HA hxA) ▸ (hf $ Inf_le hxA)
 
-instance : complete_lattice (fixed_points f) :=
+protected def complete_lattice : complete_lattice (fixed_points f) :=
 { le           := λx y, x.1 ≤ y.1,
   le_refl      := λ x, le_refl x,
   le_trans     := λ x y z, le_trans,

--- a/src/order/pilex.lean
+++ b/src/order/pilex.lean
@@ -65,7 +65,7 @@ have lt_not_symm : ∀ {x y : pilex ι β}, ¬ (x < y ∧ y < x),
         (λ hyx, lt_irrefl (x i) (by simpa [hyx] using hi.2))⟩, by tauto⟩,
   ..pilex.has_lt }
 
-instance [linear_order ι] (wf : well_founded ((<) : ι → ι → Prop)) [∀ a, linear_order (β a)] :
+def [linear_order ι] (wf : well_founded ((<) : ι → ι → Prop)) [∀ a, linear_order (β a)] :
   linear_order (pilex ι β) :=
 { le_total := λ x y, by classical; exact
     or_iff_not_imp_left.2 (λ hxy, begin

--- a/src/order/pilex.lean
+++ b/src/order/pilex.lean
@@ -65,8 +65,8 @@ have lt_not_symm : ∀ {x y : pilex ι β}, ¬ (x < y ∧ y < x),
         (λ hyx, lt_irrefl (x i) (by simpa [hyx] using hi.2))⟩, by tauto⟩,
   ..pilex.has_lt }
 
-def [linear_order ι] (wf : well_founded ((<) : ι → ι → Prop)) [∀ a, linear_order (β a)] :
-  linear_order (pilex ι β) :=
+protected def pilex.linear_order [linear_order ι] (wf : well_founded ((<) : ι → ι → Prop))
+  [∀ a, linear_order (β a)] : linear_order (pilex ι β) :=
 { le_total := λ x y, by classical; exact
     or_iff_not_imp_left.2 (λ hxy, begin
       have := not_or_distrib.1 hxy,

--- a/src/order/pilex.lean
+++ b/src/order/pilex.lean
@@ -65,6 +65,8 @@ have lt_not_symm : ∀ {x y : pilex ι β}, ¬ (x < y ∧ y < x),
         (λ hyx, lt_irrefl (x i) (by simpa [hyx] using hi.2))⟩, by tauto⟩,
   ..pilex.has_lt }
 
+/-- `pilex` is a linear order if the original order is well-founded.
+This cannot be an instance, since it depends on the well-foundedness of `<`. -/
 protected def pilex.linear_order [linear_order ι] (wf : well_founded ((<) : ι → ι → Prop))
   [∀ a, linear_order (β a)] : linear_order (pilex ι β) :=
 { le_total := λ x y, by classical; exact

--- a/src/ring_theory/ideal_operations.lean
+++ b/src/ring_theory/ideal_operations.lean
@@ -446,7 +446,7 @@ theorem comap_ne_top (hK : K ≠ ⊤) : comap f K ≠ ⊤ :=
 (ne_top_iff_one _).2 $ by rw [mem_comap, is_ring_hom.map_one f];
   exact (ne_top_iff_one _).1 hK
 
-instance is_prime.comap {hK : K.is_prime} : (comap f K).is_prime :=
+instance is_prime.comap [hK : K.is_prime] : (comap f K).is_prime :=
 ⟨comap_ne_top _ hK.1, λ x y,
   by simp only [mem_comap, is_ring_hom.map_mul f]; apply hK.2⟩
 

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -437,6 +437,19 @@ meta def get_pi_binders_aux : list binder → expr → tactic (list binder × ex
 meta def get_pi_binders : expr → tactic (list binder × expr) | e :=
 do (es, e) ← get_pi_binders_aux [] e, return (es.reverse, e)
 
+/-- Auxilliary definition for `get_pi_binders_dep`. -/
+meta def get_pi_binders_dep_aux : ℕ → expr → tactic (list (ℕ × binder) × expr)
+| n (expr.pi nm bi d b) :=
+ do l ← mk_local' nm bi d,
+    (ls, r) ← get_pi_binders_dep_aux (n+1) (expr.instantiate_var b l),
+    return (if b.has_var then ls else (n, ⟨nm, bi, d⟩)::ls, r)
+| n e                  := return ([], e)
+
+/-- A variant of `get_pi_binders` that only returns the binders that do not occur in later
+  arguments or in the target. Also returns the argument position of each returned binder. -/
+meta def get_pi_binders_dep : expr → tactic (list (ℕ × binder) × expr) :=
+get_pi_binders_dep_aux 0
+
 /-- variation on `assert` where a (possibly incomplete)
     proof of the assertion is provided as a parameter.
 

--- a/src/tactic/lint.lean
+++ b/src/tactic/lint.lean
@@ -14,13 +14,16 @@ This file defines the following user commands to spot common mistakes in the cod
   imported files)
 
 The following linters are run by default:
-1. `unused_arguments` checks for unused arguments in declarations.
-2. `def_lemma` checks whether a declaration is incorrectly marked as a def/lemma.
-3. `dup_namespce` checks whether a namespace is duplicated in the name of a declaration.
-4. `ge_or_gt` checks whether ≥/> is used in the declaration.
-5. `instance_priority` checks that instances that always apply have priority below default.
-6. `doc_blame` checks for missing doc strings on definitions and constants.
-7. `has_inhabited_instance` checks whether every type has an associated `inhabited` instance.
+1.  `unused_arguments` checks for unused arguments in declarations.
+2.  `def_lemma` checks whether a declaration is incorrectly marked as a def/lemma.
+3.  `dup_namespce` checks whether a namespace is duplicated in the name of a declaration.
+4.  `ge_or_gt` checks whether ≥/> is used in the declaration.
+5.  `instance_priority` checks that instances that always apply have priority below default.
+6.  `doc_blame` checks for missing doc strings on definitions and constants.
+7.  `has_inhabited_instance` checks whether every type has an associated `inhabited` instance.
+8.  `impossible_instance` checks for instances that can never fire.
+9.  `incorrect_type_class_argument` checks for arguments in [square brackets] that are not classes.
+10. `dangerous_instance` checks for instances that generate type-class problems with metavariables.
 
 Another linter, `doc_blame_thm`, checks for missing doc strings on lemmas and theorems.
 This is not run by default.

--- a/src/tactic/lint.lean
+++ b/src/tactic/lint.lean
@@ -392,13 +392,16 @@ meta def impossible_instance (d : declaration) : tactic (option string) := do
   errors_found := "IMPOSSIBLE INSTANCES FOUND.\nThese instances have an argument that cannot be found during type-class resolution, and therefore can never succeed. Either mark the arguments with square brackets (if it is a class), or don't make it an instance" }
 
 /-- Checks whether the definition `nm` unfolds to a class. -/
-/- Note: Caching the result of `unfolds_to_class` by giving it an attribute (so that e.g. `vector_space` or `decidable_eq` would not be repeatedly unfold to check whether it is a class), did not speed up this tactic when executed on all of mathlib (and instead significantly slowed it down) -/
+/- Note: Caching the result of `unfolds_to_class` by giving it an attribute
+(so that e.g. `vector_space` or `decidable_eq` would not be repeatedly unfold to check whether it is
+a class), did not speed up this tactic when executed on all of mathlib (and instead significantly
+slowed it down) -/
 meta def unfolds_to_class : name → tactic bool | nm :=
 if nm = `has_reflect then return tt else
 succeeds $ has_attribute `class nm <|> do
   d ← get_decl nm,
   tt ← unfolds_to_class d.value.lambda_body.pi_codomain.get_app_fn.const_name,
-  return 0
+  return 0 -- We do anything that succeeds here. We return a `ℕ` because of `has_attribute`.
 
 /-- Checks whether an instance can never be applied. -/
 meta def incorrect_type_class_argument (d : declaration) : tactic (option string) := do

--- a/src/topology/algebra/uniform_ring.lean
+++ b/src/topology/algebra/uniform_ring.lean
@@ -96,7 +96,9 @@ universes u
 variables {β : Type u} [uniform_space β] [ring β] [uniform_add_group β] [topological_ring β]
           {f : α → β} [is_ring_hom f] (hf : continuous f)
 
-protected def is_ring_hom_extension [complete_space β] [separated β] :
+/-- The completion extension is a ring morphism.
+This cannot be an instance, since it depends on the continuity of `f`. -/
+protected lemma is_ring_hom_extension [complete_space β] [separated β] :
   is_ring_hom (completion.extension f) :=
 have hf : uniform_continuous f, from uniform_continuous_of_continuous hf,
 { map_one := by rw [← coe_one, extension_coe hf, is_ring_hom.map_one f],
@@ -120,7 +122,9 @@ instance top_ring_compl : topological_ring (completion α) :=
   continuous_mul := continuous_mul,
   continuous_neg := continuous_neg }
 
-protected def is_ring_hom_map : is_ring_hom (completion.map f) :=
+/-- The completion map is a ring morphism.
+This cannot be an instance, since it depends on the continuity of `f`. -/
+protected lemma is_ring_hom_map : is_ring_hom (completion.map f) :=
 (completion.is_ring_hom_extension $ (continuous_coe β).comp hf : _)
 
 variables (R : Type*) [comm_ring R] [uniform_space R] [uniform_add_group R] [topological_ring R]

--- a/src/topology/algebra/uniform_ring.lean
+++ b/src/topology/algebra/uniform_ring.lean
@@ -96,7 +96,7 @@ universes u
 variables {β : Type u} [uniform_space β] [ring β] [uniform_add_group β] [topological_ring β]
           {f : α → β} [is_ring_hom f] (hf : continuous f)
 
-instance is_ring_hom_extension [complete_space β] [separated β] :
+def is_ring_hom_extension [complete_space β] [separated β] :
   is_ring_hom (completion.extension f) :=
 have hf : uniform_continuous f, from uniform_continuous_of_continuous hf,
 { map_one := by rw [← coe_one, extension_coe hf, is_ring_hom.map_one f],
@@ -120,7 +120,7 @@ instance top_ring_compl : topological_ring (completion α) :=
   continuous_mul := continuous_mul,
   continuous_neg := continuous_neg }
 
-instance is_ring_hom_map : is_ring_hom (completion.map f) :=
+def is_ring_hom_map : is_ring_hom (completion.map f) :=
 (completion.is_ring_hom_extension $ (continuous_coe β).comp hf : _)
 
 variables (R : Type*) [comm_ring R] [uniform_space R] [uniform_add_group R] [topological_ring R]

--- a/src/topology/algebra/uniform_ring.lean
+++ b/src/topology/algebra/uniform_ring.lean
@@ -96,7 +96,7 @@ universes u
 variables {β : Type u} [uniform_space β] [ring β] [uniform_add_group β] [topological_ring β]
           {f : α → β} [is_ring_hom f] (hf : continuous f)
 
-def is_ring_hom_extension [complete_space β] [separated β] :
+protected def is_ring_hom_extension [complete_space β] [separated β] :
   is_ring_hom (completion.extension f) :=
 have hf : uniform_continuous f, from uniform_continuous_of_continuous hf,
 { map_one := by rw [← coe_one, extension_coe hf, is_ring_hom.map_one f],
@@ -120,7 +120,7 @@ instance top_ring_compl : topological_ring (completion α) :=
   continuous_mul := continuous_mul,
   continuous_neg := continuous_neg }
 
-def is_ring_hom_map : is_ring_hom (completion.map f) :=
+protected def is_ring_hom_map : is_ring_hom (completion.map f) :=
 (completion.is_ring_hom_extension $ (continuous_coe β).comp hf : _)
 
 variables (R : Type*) [comm_ring R] [uniform_space R] [uniform_add_group R] [topological_ring R]

--- a/test/expr.lean
+++ b/test/expr.lean
@@ -1,0 +1,11 @@
+import meta.expr
+
+open tactic
+
+run_cmd do
+  l ← mk_local' `l binder_info.default `(ℕ),
+  m ← mk_local' `m binder_info.default `(ℕ),
+  guard $ `(%%l + %%l = 3).has_local_constant l,
+  guard $ bnot $ `(%%l + %%l = 3).has_local_constant m,
+  guard $ `(%%l + %%m = 3).has_local_constant l,
+  guard $ `(%%l + %%m = 3).has_local_constant m

--- a/test/lint.lean
+++ b/test/lint.lean
@@ -4,7 +4,8 @@ def foo1 (n m : ℕ) : ℕ := n + 1
 def foo2 (n m : ℕ) : m = m := by refl
 lemma foo3 (n m : ℕ) : ℕ := n - m
 lemma foo.foo (n m : ℕ) : n ≥ n := le_refl n
-instance bar.bar : has_add ℕ := by apply_instance -- we don't check the name of instances
+instance bar.bar : has_add ℕ := by apply_instance  -- we don't check the name of instances
+lemma foo.bar (ε > 0) : ε = ε := rfl -- >/≥ is allowed in binders (and in fact, in all hypotheses)
 -- section
 -- local attribute [instance, priority 1001] classical.prop_decidable
 -- lemma foo4 : (if 3 = 3 then 1 else 2) = 1 := if_pos (by refl)
@@ -18,11 +19,12 @@ run_cmd do
   l ← e.mfilter (λ d, return $
     e.in_current_file' d.to_name && ¬ d.to_name.is_internal && ¬ d.is_auto_generated e),
   l2 ← fold_over_with_cond l (return ∘ check_unused_arguments),
-  guard $ l2.length = 3,
+  guard $ l2.length = 4,
   let l2 : list t := l2.map $ λ x, ⟨x.1.to_name, x.2⟩,
   guard $ (⟨`foo1, [2]⟩ : t) ∈ l2,
   guard $ (⟨`foo2, [1]⟩ : t) ∈ l2,
   guard $ (⟨`foo.foo, [2]⟩ : t) ∈ l2,
+  guard $ (⟨`foo.bar, [2]⟩ : t) ∈ l2,
   l2 ← fold_over_with_cond l incorrect_def_lemma,
   guard $ l2.length = 2,
   let l2 : list (name × _) := l2.map $ λ x, ⟨x.1.to_name, x.2⟩,

--- a/test/lint.lean
+++ b/test/lint.lean
@@ -55,3 +55,26 @@ meta def linter.dummy_linter : linter :=
 run_cmd do
   (_, s) ← lint tt tt [`linter.dummy_linter] tt,
   guard $ "/- found something: -/\n#print foo.foo /- gotcha! -/\n\n".is_suffix_of s.to_string
+
+instance impossible_instance_test {α β : Type} [add_group α] : has_add α := infer_instance
+
+run_cmd do
+  d ← get_decl `impossible_instance_test,
+  x ← impossible_instance d,
+  guard $ x = some "Impossible to infer argument 2: {β : Type}"
+
+def incorrect_type_class_argument_test {α : Type} (x : α) [x = x] [decidable_eq α] [group α] :
+  unit := ()
+
+run_cmd do
+  d ← get_decl `incorrect_type_class_argument_test,
+  x ← incorrect_type_class_argument d,
+  guard $ x = some "These are not classes. argument 3: [_inst_1 : x = x]"
+
+instance dangerous_instance_test {α β γ : Type} [ring α] [add_comm_group β] [has_coe α β]
+  [has_inv γ] : has_add β := infer_instance
+
+run_cmd do
+  d ← get_decl `dangerous_instance_test,
+  x ← dangerous_instance d,
+  guard $ x = some "The following arguments become metavariables. argument 1: {α : Type}, argument 3: {γ : Type}"

--- a/test/lint.lean
+++ b/test/lint.lean
@@ -31,7 +31,7 @@ run_cmd do
   l3 ← fold_over_with_cond l dup_namespace,
   guard $ l3.length = 1,
   guard $ ∃(x ∈ l3), (x : declaration × _).1.to_name = `foo.foo,
-  l4 ← fold_over_with_cond l illegal_constants_in_statement,
+  l4 ← fold_over_with_cond l ge_or_gt_in_statement,
   guard $ l4.length = 1,
   guard $ ∃(x ∈ l4), (x : declaration × _).1.to_name = `foo.foo,
   -- guard $ ∃(x ∈ l4), (x : declaration × _).1.to_name = `foo4,


### PR DESCRIPTION
* Implements two of the linters from #1924.
* Updates `illegal_constants` to only disallow `ge`/`gt` in the conclusion of declarations.
* Tries to fix newly introduced failures of the linter (likely I introduced some errors).

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
