### PR TITLE
chore(*): bump Lean version to 3.5.1c

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         lean_version:
-          - 3.4.2
+          - leanprover-community/lean:3.5.0
           - leanprover-community/lean:nightly
       fail-fast: false
     steps:
@@ -39,7 +39,7 @@ jobs:
           path: ..
 
       - name: push release to mathlib-nightly
-        if: github.repository == 'leanprover-community/mathlib' && github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.lean_version == '3.4.2'
+        if: github.repository == 'leanprover-community/mathlib' && github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.lean_version == 'leanprover-community/lean:3.5.0'
         run: ./scripts/deploy_nightly.sh
         env:
           DEPLOY_NIGHTLY_GITHUB_TOKEN: ${{ secrets.DEPLOY_NIGHTLY_GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         lean_version:
-          - leanprover-community/lean:3.5.0
+          - leanprover-community/lean:3.5.1
           - leanprover-community/lean:nightly
       fail-fast: false
     steps:
@@ -39,7 +39,7 @@ jobs:
           path: ..
 
       - name: push release to mathlib-nightly
-        if: github.repository == 'leanprover-community/mathlib' && github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.lean_version == 'leanprover-community/lean:3.5.0'
+        if: github.repository == 'leanprover-community/mathlib' && github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.lean_version == 'leanprover-community/lean:3.5.1'
         run: ./scripts/deploy_nightly.sh
         env:
           DEPLOY_NIGHTLY_GITHUB_TOKEN: ${{ secrets.DEPLOY_NIGHTLY_GITHUB_TOKEN }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,7 @@
 pull_request_rules:
   - name: automatic merge on CI success and review - pr
     conditions:
-      - status-success=Build mathlib (leanprover-community/lean:3.5.0)
+      - status-success=Build mathlib (leanprover-community/lean:3.5.1)
       - status-success=Build mathlib (leanprover-community/lean:nightly)
       - "#changes-requested-reviews-by=0"
       - base=master
@@ -18,7 +18,7 @@ pull_request_rules:
  # the "push" build to complete before a merge
   - name: automatic merge on CI success and review - push
     conditions:
-      - status-success=Build mathlib (leanprover-community/lean:3.5.0)
+      - status-success=Build mathlib (leanprover-community/lean:3.5.1)
       - status-success=Build mathlib (leanprover-community/lean:nightly)
       - "#changes-requested-reviews-by=0"
       - base=master

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,7 @@
 pull_request_rules:
   - name: automatic merge on CI success and review - pr
     conditions:
-      - status-success=Build mathlib (3.4.2)
+      - status-success=Build mathlib (leanprover-community/lean:3.5.0)
       - status-success=Build mathlib (leanprover-community/lean:nightly)
       - "#changes-requested-reviews-by=0"
       - base=master
@@ -18,7 +18,7 @@ pull_request_rules:
  # the "push" build to complete before a merge
   - name: automatic merge on CI success and review - push
     conditions:
-      - status-success=Build mathlib (3.4.2)
+      - status-success=Build mathlib (leanprover-community/lean:3.5.0)
       - status-success=Build mathlib (leanprover-community/lean:nightly)
       - "#changes-requested-reviews-by=0"
       - base=master
@@ -44,7 +44,7 @@ pull_request_rules:
         method: squash
         strict: smart
         strict_method: merge
-  
+
  # In practice this turns out to be really annoying.
  # - name: remove outdated reviews
  #   conditions:

--- a/docs/contribute/index.md
+++ b/docs/contribute/index.md
@@ -17,14 +17,14 @@ to make the process of contributing as smooth as possible.
 3. Create a pull request from a feature branch on your personal fork,
    as explained in the link above, or from a branch of the main repository if you have commit access (you can ask for access on Zulip).
 4. If you've made a lot of changes/additions, try to make many PRs containing small, self-contained pieces. This helps you get feedback as you go along, and it is much easier to review. This is especially important for new contributors.
-5. If you checkout the remote branch `lean-3.4.2` you can fetch the `.olean` binaries using the command
+5. If you checkout the remote branch `lean-3.5.0` you can fetch the `.olean` binaries using the command
    ```
    cache-olean --fetch
    ```
    - You can do this by running the following commands (anywhere in the `mathlib` repository).
    ```
    git fetch --all
-   git checkout origin/lean-3.4.2
+   git checkout origin/lean-3.5.0
    cache-olean --fetch
    git checkout -b my_new_feature
    ```

--- a/docs/contribute/index.md
+++ b/docs/contribute/index.md
@@ -17,14 +17,14 @@ to make the process of contributing as smooth as possible.
 3. Create a pull request from a feature branch on your personal fork,
    as explained in the link above, or from a branch of the main repository if you have commit access (you can ask for access on Zulip).
 4. If you've made a lot of changes/additions, try to make many PRs containing small, self-contained pieces. This helps you get feedback as you go along, and it is much easier to review. This is especially important for new contributors.
-5. If you checkout the remote branch `lean-3.5.0` you can fetch the `.olean` binaries using the command
+5. If you checkout the remote branch `lean-3.5.1` you can fetch the `.olean` binaries using the command
    ```
    cache-olean --fetch
    ```
    - You can do this by running the following commands (anywhere in the `mathlib` repository).
    ```
    git fetch --all
-   git checkout origin/lean-3.5.0
+   git checkout origin/lean-3.5.1
    cache-olean --fetch
    git checkout -b my_new_feature
    ```

--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mathlib"
 version = "0.1"
-lean_version = "3.4.2"
+lean_version = "leanprover-community/lean:3.5.0"
 path = "src"
 
 [dependencies]

--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mathlib"
 version = "0.1"
-lean_version = "leanprover-community/lean:3.5.0"
+lean_version = "leanprover-community/lean:3.5.1"
 path = "src"
 
 [dependencies]

--- a/scripts/deploy_nightly.sh
+++ b/scripts/deploy_nightly.sh
@@ -36,7 +36,7 @@ fi
 
 # Try to update the lean-x.y.z branch on mathlib. This could fail if
 # a subsequent commit has already pushed an update.
-LEAN_VERSION="lean-3.4.2"
+LEAN_VERSION="lean-3.5.0"
 
 git push mathlib HEAD:refs/heads/$LEAN_VERSION || \
     echo "mathlib rejected push to branch $LEAN_VERSION; maybe it already has a later version?" >&2

--- a/scripts/deploy_nightly.sh
+++ b/scripts/deploy_nightly.sh
@@ -36,7 +36,7 @@ fi
 
 # Try to update the lean-x.y.z branch on mathlib. This could fail if
 # a subsequent commit has already pushed an update.
-LEAN_VERSION="lean-3.5.0"
+LEAN_VERSION="lean-3.5.1"
 
 git push mathlib HEAD:refs/heads/$LEAN_VERSION || \
     echo "mathlib rejected push to branch $LEAN_VERSION; maybe it already has a later version?" >&2

--- a/src/algebra/ring.lean
+++ b/src/algebra/ring.lean
@@ -483,7 +483,7 @@ def nonzero_comm_semiring.of_ne [comm_semiring α] {x y : α} (h : x ≠ y) : no
   zero_ne_one := λ h01, h $ by rw [← one_mul x, ← one_mul y, ← h01, zero_mul, zero_mul],
   ..show comm_semiring α, by apply_instance }
 
-/-- this is needed for compatibility between Lean 3.4.2 and Lean 3.5.0c -/
+/-- this is needed for compatibility between Lean 3.4.2 and Lean 3.5.1c -/
 def has_div_of_division_ring [division_ring α] : has_div α := division_ring_has_div
 
 section prio

--- a/src/tactic/squeeze.lean
+++ b/src/tactic/squeeze.lean
@@ -34,7 +34,7 @@ do
     | _ := s
     end) s
 
-/-- Polyfill instance for Lean versions <3.5.0c -/
+/-- Polyfill instance for Lean versions <3.5.1c -/
 -- TODO: when Lean 3.4 support is dropped, this instance can be removed
 @[priority 1]
 meta instance : has_to_tactic_format simp_arg_type := ⟨λ a, match a with


### PR DESCRIPTION
Moving to the community version will allow us to take advantages of bug fixes, tactic improvements, renamings, etc.

3.5.1c is backward compatible with 3.4.2, and as of this PR, mathlib compiles on both versions. This may not be the case for future versions.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/moving.20mathlib.20to.203.2E5c)

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
