### PR TITLE
feat(linear_algebra): The Special linear group SL(n, R)

### DIFF
--- a/src/algebra/module.lean
+++ b/src/algebra/module.lean
@@ -166,6 +166,8 @@ instance : has_coe_to_fun (β →ₗ[α] γ) := ⟨_, to_fun⟩
 @[simp] lemma coe_mk (f : β → γ) (h₁ h₂) :
   ((linear_map.mk f h₁ h₂ : β →ₗ[α] γ) : β → γ) = f := rfl
 
+@[simp] lemma to_fun_eq_coe (f : β →ₗ[α] γ) : f.to_fun = ⇑f := rfl
+
 theorem is_linear : is_linear_map α f := {..f}
 
 @[ext] theorem ext {f g : β →ₗ[α] γ} (H : ∀ x, f x = g x) : f = g :=

--- a/src/data/fintype.lean
+++ b/src/data/fintype.lean
@@ -724,6 +724,15 @@ lemma fintype.card_equiv [fintype α] [fintype β] (e : α ≃ β) :
   fintype.card (α ≃ β) = (fintype.card α).fact :=
 fintype.card_congr (equiv_congr (equiv.refl α) e) ▸ fintype.card_perm
 
+lemma univ_eq_singleton_of_card_one [fintype α] (x : α) (h : fintype.card α = 1) :
+  (univ : finset α) = finset.singleton x :=
+begin
+  apply symm,
+  apply eq_of_subset_of_card_le (subset_univ (finset.singleton x)),
+  apply le_of_eq,
+  simp [h, finset.card_univ]
+end
+
 end equiv
 
 namespace fintype

--- a/src/data/fintype.lean
+++ b/src/data/fintype.lean
@@ -724,7 +724,7 @@ lemma fintype.card_equiv [fintype α] [fintype β] (e : α ≃ β) :
   fintype.card (α ≃ β) = (fintype.card α).fact :=
 fintype.card_congr (equiv_congr (equiv.refl α) e) ▸ fintype.card_perm
 
-lemma univ_eq_singleton_of_card_one [fintype α] (x : α) (h : fintype.card α = 1) :
+lemma univ_eq_singleton_of_card_one {α} [fintype α] (x : α) (h : fintype.card α = 1) :
   (univ : finset α) = finset.singleton x :=
 begin
   apply symm,

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -284,6 +284,9 @@ begin
   { rw [diagonal_val_eq] }
 end
 
+@[simp] lemma mul_vec_one [decidable_eq m] (v : m → α) : mul_vec 1 v = v :=
+by { ext, rw [←diagonal_one, mul_vec_diagonal, one_mul] }
+
 lemma vec_mul_vec_eq (w : m → α) (v : n → α) :
   vec_mul_vec w v = (col w) ⬝ (row v) :=
 by simp [matrix.mul]; refl

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -230,7 +230,7 @@ section comm_ring
 variables [comm_ring α]
 
 lemma smul_eq_diagonal_mul [decidable_eq m] (M : matrix m n α) (a : α) :
-a • M = diagonal (λ _, a) ⬝ M :=
+  a • M = diagonal (λ _, a) ⬝ M :=
 by { ext, simp }
 
 lemma smul_eq_mul_diagonal [decidable_eq n] (M : matrix m n α) (a : α) :

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -229,6 +229,14 @@ instance {β : Type w} [ring α] [add_comm_group β] [module α β] :
 section comm_ring
 variables [comm_ring α]
 
+lemma smul_eq_diagonal_mul [decidable_eq m] (M : matrix m n α) (a : α) :
+a • M = diagonal (λ _, a) ⬝ M :=
+by { ext, simp }
+
+lemma smul_eq_mul_diagonal [decidable_eq n] (M : matrix m n α) (a : α) :
+  a • M = M ⬝ diagonal (λ _, a) :=
+by { ext, simp [mul_comm] }
+
 @[simp] lemma mul_smul (M : matrix m n α) (a : α) (N : matrix n l α) : M ⬝ (a • N) = a • M ⬝ N :=
 begin
   ext i j,

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -144,11 +144,34 @@ end
 lemma det_permute (σ : perm n) (M : matrix n n R) : matrix.det (λ i, M (σ i)) = σ.sign * M.det :=
 by rw [←det_permutation, ←det_mul, pequiv.to_pequiv_mul_matrix]
 
+@[simp] lemma det_smul {A : matrix n n R} {c : R} : det (c • A) = c ^ fintype.card n * det A :=
+calc det (c • A) = det (matrix.mul (diagonal (λ _, c)) A) : by rw [smul_eq_diagonal_mul]
+             ... = det (diagonal (λ _, c)) * det A        : det_mul _ _
+             ... = c ^ fintype.card n * det A             : by simp [card_univ]
+
 section det_zero
 /-! ### `det_zero` section
 
   Prove that a matrix with a repeated column has determinant equal to zero.
 -/
+
+lemma det_eq_one_of_card_eq_zero {A : matrix n n R} (h : fintype.card n = 0) : det A = 1 :=
+begin
+  have perm_eq : (univ : finset (perm n)) = finset.singleton 1 :=
+    univ_eq_singleton_of_card_one (1 : perm n) (by simp [card_univ, fintype.card_perm, h]),
+  simp [det, card_eq_zero.mp h, perm_eq],
+end
+
+lemma det_eq_zero_of_column_eq_zero {A : matrix n n R} (i : n) (h : ∀ j, A i j = 0) : det A = 0 :=
+begin
+  rw [←det_transpose, det],
+  convert @sum_const_zero _ _ (univ : finset (perm n)) _,
+  ext σ,
+  convert mul_zero ↑(sign σ),
+  apply prod_eq_zero (mem_univ i),
+  rw [transpose_val],
+  apply h
+end
 
 /--
   `mod_swap i j` contains permutations up to swapping `i` and `j`.

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -40,6 +40,13 @@ by rw [← diagonal_zero, det_diagonal, finset.prod_const, ← fintype.card,
 @[simp] lemma det_one : det (1 : matrix n n R) = 1 :=
 by rw [← diagonal_one]; simp [-diagonal_one]
 
+lemma det_eq_one_of_card_eq_zero {A : matrix n n R} (h : fintype.card n = 0) : det A = 1 :=
+begin
+  have perm_eq : (univ : finset (perm n)) = finset.singleton 1 :=
+  univ_eq_singleton_of_card_one (1 : perm n) (by simp [card_univ, fintype.card_perm, h]),
+  simp [det, card_eq_zero.mp h, perm_eq],
+end
+
 lemma det_mul_aux {M N : matrix n n R} {p : n → n} (H : ¬bijective p) :
   univ.sum (λ σ : perm n, (ε σ) * (univ.prod (λ x, M (σ x) (p x) * N (p x) x))) = 0 :=
 begin
@@ -154,13 +161,6 @@ section det_zero
 
   Prove that a matrix with a repeated column has determinant equal to zero.
 -/
-
-lemma det_eq_one_of_card_eq_zero {A : matrix n n R} (h : fintype.card n = 0) : det A = 1 :=
-begin
-  have perm_eq : (univ : finset (perm n)) = finset.singleton 1 :=
-    univ_eq_singleton_of_card_one (1 : perm n) (by simp [card_univ, fintype.card_perm, h]),
-  simp [det, card_eq_zero.mp h, perm_eq],
-end
 
 lemma det_eq_zero_of_column_eq_zero {A : matrix n n R} (i : n) (h : ∀ j, A i j = 0) : det A = 0 :=
 begin

--- a/src/linear_algebra/dual.lean
+++ b/src/linear_algebra/dual.lean
@@ -145,7 +145,7 @@ begin
     apply h.ext,
     { intros i,
       rw [h.to_dual_eq_repr _ i, repr_total h],
-      { simpa },
+      { refl },
       { rw [finsupp.mem_supported],
         exact λ _ _, set.mem_univ _ } } },
   { intros a _,

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -100,6 +100,9 @@ begin
   rw [mul_assoc]
 end
 
+@[simp] lemma to_lin_one [decidable_eq n] : (1 : matrix n n R).to_lin = linear_map.id :=
+by { ext, simp }
+
 end matrix
 
 namespace linear_map

--- a/src/linear_algebra/nonsingular_inverse.lean
+++ b/src/linear_algebra/nonsingular_inverse.lean
@@ -50,6 +50,9 @@ variables {n : Type u} [fintype n] [decidable_eq n] {α : Type v}
 open_locale matrix
 open equiv equiv.perm finset
 
+-- Increase max depth to allow inference of `mul_action α (matrix n n α)`.
+set_option class.instance_max_depth 60
+
 section update
 
 /-- Update, i.e. replace the `i`th column of matrix `A` with the values in `b`. -/
@@ -274,6 +277,11 @@ calc adjugate A ⬝ A = (Aᵀ ⬝ (adjugate Aᵀ))ᵀ :
   by rw [←adjugate_transpose, ←transpose_mul, transpose_transpose]
 ... = A.det • 1 : by rw [mul_adjugate (Aᵀ), det_transpose, transpose_smul, transpose_one]
 
+set_option class.instance_max_depth 60
+lemma det_adjugate_eq_one {A : matrix n n α} (h : A.det = 1) : (adjugate A).det = 1 :=
+calc (adjugate A).det = (adjugate A ⬝ A).det : by rw [det_mul, h, mul_one]
+                  ... = 1                    : by rw [adjugate_mul, h, one_smul, det_one]
+
 end adjugate
 
 section inv
@@ -297,17 +305,10 @@ lemma nonsing_inv_val (A : matrix n n α) (i j : n) :
 lemma transpose_nonsing_inv (A : matrix n n α) : (A.nonsing_inv)ᵀ = (Aᵀ).nonsing_inv :=
 by {ext, simp [transpose_val, nonsing_inv_val, det_transpose, (adjugate_transpose A).symm]}
 
-section
-
--- Increase max depth to allow inference of `mul_action α (matrix n n α)`.
-set_option class.instance_max_depth 60
-
 /-- The `nonsing_inv` of `A` is a right inverse. -/
 theorem mul_nonsing_inv (A : matrix n n α) (inv_mul_cancel : A.det⁻¹ * A.det = 1) :
   A ⬝ nonsing_inv A = 1 :=
-by erw [mul_smul, mul_adjugate, smul_smul, inv_mul_cancel, @one_smul _ _ _ (pi.mul_action _)]
-
-end
+by erw [mul_smul, mul_adjugate, smul_smul, inv_mul_cancel, one_smul]
 
 /-- The `nonsing_inv` of `A` is a left inverse. -/
 theorem nonsing_inv_mul (A : matrix n n α) (inv_mul_cancel : A.det⁻¹ * A.det = 1) :

--- a/src/linear_algebra/nonsingular_inverse.lean
+++ b/src/linear_algebra/nonsingular_inverse.lean
@@ -277,10 +277,10 @@ calc adjugate A ⬝ A = (Aᵀ ⬝ (adjugate Aᵀ))ᵀ :
   by rw [←adjugate_transpose, ←transpose_mul, transpose_transpose]
 ... = A.det • 1 : by rw [mul_adjugate (Aᵀ), det_transpose, transpose_smul, transpose_one]
 
-set_option class.instance_max_depth 60
 lemma det_adjugate_eq_one {A : matrix n n α} (h : A.det = 1) : (adjugate A).det = 1 :=
-calc (adjugate A).det = (adjugate A ⬝ A).det : by rw [det_mul, h, mul_one]
-                  ... = 1                    : by rw [adjugate_mul, h, one_smul, det_one]
+calc (adjugate A).det = (adjugate A).det * A.det : by simp [h]
+                  ... = (adjugate A ⬝ A).det     : (det_mul _ _).symm
+                  ... = 1                        : by rw [adjugate_mul, h, one_smul, det_one]
 
 end adjugate
 

--- a/src/linear_algebra/nonsingular_inverse.lean
+++ b/src/linear_algebra/nonsingular_inverse.lean
@@ -5,6 +5,7 @@
 
   Inverses for nonsingular square matrices.
 -/
+import algebra.associated
 import algebra.big_operators
 import data.matrix.basic
 import linear_algebra.determinant
@@ -310,10 +311,10 @@ calc (adjugate A).det
     = A.det ^ (fintype.card n - 1) : det_adjugate_of_cancel (λ b hb, by simpa [h] using hb)
 ... = 1                            : by rw [h, one_pow]
 
-lemma det_adjugate_of_invertible {A : matrix n n α} :
-  (∃ a, a * A.det = 1) → (adjugate A).det = A.det ^ (fintype.card n - 1) :=
+lemma det_adjugate_of_is_unit {A : matrix n n α} (h : is_unit A.det) :
+  (adjugate A).det = A.det ^ (fintype.card n - 1) :=
 begin
-  rintro ⟨a, ha⟩,
+  rcases is_unit_iff_exists_inv'.mp h with ⟨a, ha⟩,
   by_cases card_lt_zero : fintype.card n ≤ 0,
   { have h : fintype.card n = 0 := by linarith,
     simp [det_eq_one_of_card_eq_zero h] },

--- a/src/linear_algebra/nonsingular_inverse.lean
+++ b/src/linear_algebra/nonsingular_inverse.lean
@@ -280,6 +280,14 @@ calc adjugate A ⬝ A = (Aᵀ ⬝ (adjugate Aᵀ))ᵀ :
   by rw [←adjugate_transpose, ←transpose_mul, transpose_transpose]
 ... = A.det • 1 : by rw [mul_adjugate (Aᵀ), det_transpose, transpose_smul, transpose_one]
 
+/-- `det_adjugate_of_cancel` is an auxiliary lemma for computing `(adjugate A).det`,
+  used in `det_adjugate_eq_one` and `det_adjugate_of_is_unit`.
+
+  The formula for the determinant of the adjugate of an `n` by `n` matrix `A`
+  is in general `(adjugate A).det = A.det ^ (n - 1)`, but the proof differs in several cases.
+  This lemma `det_adjugate_of_cancel` covers the case that `det A` cancels
+  on the left of the equation `A.det * b = A.det ^ n`.
+-/
 lemma det_adjugate_of_cancel {A : matrix n n α}
   (h : ∀ b, A.det * b = A.det ^ fintype.card n → b = A.det ^ (fintype.card n - 1)) :
   (adjugate A).det = A.det ^ (fintype.card n - 1) :=
@@ -311,6 +319,12 @@ calc (adjugate A).det
     = A.det ^ (fintype.card n - 1) : det_adjugate_of_cancel (λ b hb, by simpa [h] using hb)
 ... = 1                            : by rw [h, one_pow]
 
+/-- `det_adjugate_of_is_unit` gives the formula for `(adjugate A).det` if `A.det` has an inverse.
+
+  The formula for the determinant of the adjugate of an `n` by `n` matrix `A`
+  is in general `(adjugate A).det = A.det ^ (n - 1)`, but the proof differs in several cases.
+  This lemma `det_adjugate_of_is_unit` covers the case that `det A` has an inverse.
+-/
 lemma det_adjugate_of_is_unit {A : matrix n n α} (h : is_unit A.det) :
   (adjugate A).det = A.det ^ (fintype.card n - 1) :=
 begin

--- a/src/linear_algebra/special_linear_group.lean
+++ b/src/linear_algebra/special_linear_group.lean
@@ -1,0 +1,121 @@
+/-
+  Copyright (c) 2020 Anne Baanen. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Author: Anne Baanen.
+
+  The Special Linear group `special_linear_group(n, R)`.
+-/
+import linear_algebra.basic
+import linear_algebra.matrix
+import linear_algebra.nonsingular_inverse
+import tactic.norm_cast
+
+/-!
+# The Special Linear group `special_linear_group(n, R)`
+
+This file defines the elements of the Special Linear group `special_linear_group n R`,
+also written `special_linear_group(n, R)` or `SLₙ(R)`, consisting of all `n` by `n`
+`R`-matrices with determinant `1`.
+
+## Implementation notes
+The inverse operation in the `special_linear_group` is defined to be the adjugate
+matrix, so that `special_linear_group n R` has a group structure for all `comm_ring R`.
+
+We define the elements of `special_linear_group` to be matrices, since we need to
+compute their determinant. This is in contrast with `general_linear_group R M`,
+which consists of invertible `R`-linear maps on `M`.
+
+## Tags
+
+matrix group, group, matrix inverse
+-/
+
+namespace matrix
+universes u v
+open_locale matrix
+open linear_map
+
+set_option class.instance_max_depth 60
+
+section
+
+variables (n : Type u) [fintype n] [decidable_eq n] (R : Type v) [comm_ring R]
+
+/-- `special_linear_group n R` is the group of `n` by `n` `R`-matrices with determinant equal to 1. -/
+def special_linear_group := { A : matrix n n R // A.det = 1 }
+
+end
+
+namespace special_linear_group
+
+variables {n : Type u} [fintype n] [decidable_eq n] {R : Type v} [comm_ring R]
+
+lemma ext_iff (A B : special_linear_group n R) : A = B ↔ (∀ i j, A.1 i j = B.1 i j) :=
+iff.trans subtype.ext ⟨(λ h i j, by rw h), matrix.ext⟩
+
+@[ext]
+lemma ext (A B : special_linear_group n R) : (∀ i j, A.1 i j = B.1 i j) → A = B :=
+(special_linear_group.ext_iff A B).mpr
+
+instance has_inv : has_inv (special_linear_group n R) := ⟨λ A, ⟨adjugate A.1, det_adjugate_eq_one A.2⟩⟩
+
+instance has_mul : has_mul (special_linear_group n R) :=
+⟨λ A B, ⟨A.1 ⬝ B.1, by rw [det_mul, A.2, B.2, one_mul]⟩⟩
+
+instance has_one : has_one (special_linear_group n R) := ⟨⟨1, det_one⟩⟩
+
+instance : inhabited (special_linear_group n R) := ⟨1⟩
+
+@[simp] lemma inv_val (A : special_linear_group n R) : A⁻¹.val = adjugate A.val := rfl
+
+@[simp] lemma mul_val (A B : special_linear_group n R) : (A * B).val = A.val ⬝ B.val := rfl
+
+@[simp] lemma one_val : (1 : special_linear_group n R).val = 1 := rfl
+
+instance group : group (special_linear_group n R) :=
+{ mul_assoc := λ A B C, by { ext, simp [mul_val, matrix.mul_assoc] },
+  one_mul := λ A, by { ext, simp },
+  mul_one := λ A, by { ext, simp },
+  mul_left_inv := λ A, by { ext, simp [adjugate_mul, A.2] },
+  ..special_linear_group.has_mul,
+  ..special_linear_group.has_one,
+  ..special_linear_group.has_inv,
+}
+
+/-- `to_linear_equiv A` is matrix multiplication of vectors by `A.val`, as a linear equivalence. -/
+def to_linear_equiv (A : special_linear_group n R) : (n → R) ≃ₗ[R] (n → R) :=
+{ inv_fun := A⁻¹.val.to_lin,
+  left_inv := λ x, calc
+    (A⁻¹.val.to_lin.comp A.val.to_lin) x
+        = ((A⁻¹ * A).val.to_lin : (n → R) → (n → R)) x : by rw [←mul_to_lin, mul_val]
+    ... = x : by simp,
+  right_inv := λ x, calc
+    (A.val.to_lin.comp A⁻¹.val.to_lin) x
+        = ((A * A⁻¹).val.to_lin : (n → R) → (n → R)) x : by rw [←mul_to_lin, mul_val]
+    ... = x : by simp,
+  ..A.val.to_lin
+}
+
+instance coe_GL : has_coe (special_linear_group n R) (general_linear_group R (n → R)) :=
+⟨λ A, general_linear_group.of_linear_equiv (to_linear_equiv A)⟩
+
+lemma coe_coe (A : special_linear_group n R) :
+  (@coe (units _) _ _ (A : general_linear_group R (n → R))) = A.val.to_lin := rfl
+
+@[simp, elim_cast]
+lemma coe_GL_one : ((1 : special_linear_group n R) : general_linear_group R (n → R)) = 1 :=
+by { ext v i, rw [coe_coe, one_val, to_lin_one], refl }
+
+@[simp, move_cast]
+lemma coe_GL_mul (A B : special_linear_group n R) :
+  (↑(A * B) : general_linear_group R (n → R)) = ↑A * ↑B :=
+by { ext v i, rw [coe_coe, mul_val, mul_to_lin], refl }
+
+/-- `special_linear_group.to_GL` is the embedding from `special_linear_group n R`
+  to `general_linear_group n R`. -/
+def to_GL : (special_linear_group n R) →* (general_linear_group R (n → R)) :=
+⟨λ A, ↑A, by norm_cast, by { intros, norm_cast }⟩
+
+end special_linear_group
+
+end matrix

--- a/src/linear_algebra/special_linear_group.lean
+++ b/src/linear_algebra/special_linear_group.lean
@@ -3,7 +3,7 @@
   Released under Apache 2.0 license as described in the file LICENSE.
   Author: Anne Baanen.
 
-  The Special Linear group $$SL(n, R)$$.
+  The Special Linear group $SL(n, R)$
 -/
 import linear_algebra.basic
 import linear_algebra.matrix
@@ -11,11 +11,19 @@ import linear_algebra.nonsingular_inverse
 import tactic.norm_cast
 
 /-!
-# The Special Linear group $$SL(n, R)$$
+# The Special Linear group $SL(n, R)$
 
 This file defines the elements of the Special Linear group `special_linear_group n R`,
-also written `special_linear_group(n, R)` or `SLₙ(R)`, consisting of all `n` by `n`
-`R`-matrices with determinant `1`.
+also written `SL(n, R)` or `SLₙ(R)`, consisting of all `n` by `n` `R`-matrices with
+determinant `1`.  In addition, we define the group structure on `special_linear_group n R`
+and the embedding into the general linear group `general_linear_group R (n → R)`
+(i.e. `GL(n, R)` or `GLₙ(R)`).
+
+## Main definitions
+
+ * `matrix.special_linear_group` is the set of matrices with determinant 1
+ * `matrix.special_linear_group.group` gives the group structure (under multiplication)
+ * `matrix.special_linear_group.to_GL` is the embedding `SLₙ(R) → GLₙ(R)`
 
 ## Implementation notes
 The inverse operation in the `special_linear_group` is defined to be the adjugate
@@ -24,6 +32,10 @@ matrix, so that `special_linear_group n R` has a group structure for all `comm_r
 We define the elements of `special_linear_group` to be matrices, since we need to
 compute their determinant. This is in contrast with `general_linear_group R M`,
 which consists of invertible `R`-linear maps on `M`.
+
+## References
+
+ * https://en.wikipedia.org/wiki/Special_linear_group
 
 ## Tags
 

--- a/src/linear_algebra/special_linear_group.lean
+++ b/src/linear_algebra/special_linear_group.lean
@@ -60,7 +60,7 @@ lemma ext (A B : special_linear_group n R) : (∀ i j, A.1 i j = B.1 i j) → A 
 instance has_inv : has_inv (special_linear_group n R) := ⟨λ A, ⟨adjugate A.1, det_adjugate_eq_one A.2⟩⟩
 
 instance has_mul : has_mul (special_linear_group n R) :=
-⟨λ A B, ⟨A.1 ⬝ B.1, by rw [det_mul, A.2, B.2, one_mul]⟩⟩
+⟨λ A B, ⟨A.1 ⬝ B.1, by erw [det_mul, A.2, B.2, one_mul]⟩⟩
 
 instance has_one : has_one (special_linear_group n R) := ⟨⟨1, det_one⟩⟩
 

--- a/src/linear_algebra/special_linear_group.lean
+++ b/src/linear_algebra/special_linear_group.lean
@@ -103,8 +103,7 @@ instance group : group (special_linear_group n R) :=
   mul_left_inv := λ A, by { ext, simp [adjugate_mul, A.2] },
   ..special_linear_group.has_mul,
   ..special_linear_group.has_one,
-  ..special_linear_group.has_inv,
-}
+  ..special_linear_group.has_inv }
 
 /-- `to_linear_equiv A` is matrix multiplication of vectors by `A.val`, as a linear equivalence. -/
 def to_linear_equiv (A : special_linear_group n R) : (n → R) ≃ₗ[R] (n → R) :=
@@ -117,8 +116,7 @@ def to_linear_equiv (A : special_linear_group n R) : (n → R) ≃ₗ[R] (n → 
     (A.val.to_lin.comp A⁻¹.val.to_lin) x
         = ((A * A⁻¹).val.to_lin : (n → R) → (n → R)) x : by rw [←mul_to_lin, mul_val]
     ... = x : by simp,
-  ..A.val.to_lin
-}
+  ..A.val.to_lin }
 
 /-- `to_GL` is the map from the special linear group to the general linear group -/
 def to_GL (A : special_linear_group n R) : general_linear_group R (n → R) :=

--- a/src/linear_algebra/special_linear_group.lean
+++ b/src/linear_algebra/special_linear_group.lean
@@ -21,7 +21,7 @@ and the embedding into the general linear group `general_linear_group R (n → R
 
 ## Main definitions
 
- * `matrix.special_linear_group` is the set of matrices with determinant 1
+ * `matrix.special_linear_group` is the type of matrices with determinant 1
  * `matrix.special_linear_group.group` gives the group structure (under multiplication)
  * `matrix.special_linear_group.to_GL` is the embedding `SLₙ(R) → GLₙ(R)`
 

--- a/src/linear_algebra/special_linear_group.lean
+++ b/src/linear_algebra/special_linear_group.lean
@@ -3,7 +3,7 @@
   Released under Apache 2.0 license as described in the file LICENSE.
   Author: Anne Baanen.
 
-  The Special Linear group `special_linear_group(n, R)`.
+  The Special Linear group $$SL(n, R)$$.
 -/
 import linear_algebra.basic
 import linear_algebra.matrix
@@ -11,7 +11,7 @@ import linear_algebra.nonsingular_inverse
 import tactic.norm_cast
 
 /-!
-# The Special Linear group `special_linear_group(n, R)`
+# The Special Linear group $$SL(n, R)$$
 
 This file defines the elements of the Special Linear group `special_linear_group n R`,
 also written `special_linear_group(n, R)` or `SLₙ(R)`, consisting of all `n` by `n`
@@ -53,8 +53,7 @@ variables {n : Type u} [fintype n] [decidable_eq n] {R : Type v} [comm_ring R]
 lemma ext_iff (A B : special_linear_group n R) : A = B ↔ (∀ i j, A.1 i j = B.1 i j) :=
 iff.trans subtype.ext ⟨(λ h i j, by rw h), matrix.ext⟩
 
-@[ext]
-lemma ext (A B : special_linear_group n R) : (∀ i j, A.1 i j = B.1 i j) → A = B :=
+@[ext] lemma ext (A B : special_linear_group n R) : (∀ i j, A.1 i j = B.1 i j) → A = B :=
 (special_linear_group.ext_iff A B).mpr
 
 instance has_inv : has_inv (special_linear_group n R) := ⟨λ A, ⟨adjugate A.1, det_adjugate_eq_one A.2⟩⟩
@@ -100,7 +99,8 @@ instance coe_GL : has_coe (special_linear_group n R) (general_linear_group R (n 
 ⟨λ A, general_linear_group.of_linear_equiv (to_linear_equiv A)⟩
 
 lemma coe_coe (A : special_linear_group n R) :
-  (@coe (units _) _ _ (A : general_linear_group R (n → R))) = A.val.to_lin := rfl
+  (@coe (units _) _ _ (A : general_linear_group R (n → R))) = A.val.to_lin :=
+rfl
 
 @[simp, elim_cast]
 lemma coe_GL_one : ((1 : special_linear_group n R) : general_linear_group R (n → R)) = 1 :=


### PR DESCRIPTION
Definitions for the special linear group SL(n, R) (as `matrix.special_linear_group n R`), its group structure and the embedding SL(n, R) → GL(n, R) (as `matrix.special_linear_group.to_GL`).

Although this PR makes use of `matrix.det_mul`, whose type is changed in #1959, the two PRs should be able to be merged in either order since it is only invoked up to definitional equality.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
