### PR TITLE
chore(tactic/basic,default): add missing tactics

### DIFF
--- a/src/tactic/basic.lean
+++ b/src/tactic/basic.lean
@@ -5,6 +5,9 @@ import
   tactic.converter.interactive
   tactic.core
   tactic.ext
+  tactic.elide
+  tactic.explode
+  tactic.find
   tactic.generalize_proofs
   tactic.interactive
   tactic.suggest
@@ -18,6 +21,7 @@ import
   tactic.restate_axiom
   tactic.rewrite
   tactic.lint
+  tactic.simp_rw
   tactic.simpa
   tactic.simps
   tactic.split_ifs

--- a/src/tactic/default.lean
+++ b/src/tactic/default.lean
@@ -32,5 +32,6 @@ import
   tactic.tfae
   tactic.apply_fun
   tactic.apply
-  tactic.suggest
-  tactic.simp_rw
+  tactic.pi_instances
+  tactic.fin_cases
+  tactic.reassoc_axiom -- most likely useful only for category_theory


### PR DESCRIPTION
Split from #1874. I found a few tactics and commands listed in `docs/tactics.md` that weren't in either `tactic.basic` or `tactic.default` so I added the ones that only imported `tactic.core` to `tactic.basic` and the others with more imports to `tactic.default`. I also moved `simp_rw` to `tactic.basic` for this reason.