### PR TITLE
feat(ci): update nolints.txt after master builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
           DEPLOY_NIGHTLY_GITHUB_TOKEN: ${{ secrets.DEPLOY_NIGHTLY_GITHUB_TOKEN }}
 
       - name: update nolints.txt
-        if: github.repository == 'robertylewis/mathlib' && github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.lean_version == 'leanprover-community/lean:nightly'
+        if: github.repository == 'leanprover-community/mathlib' && github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.lean_version == 'leanprover-community/lean:nightly'
         run:
           ./scripts/update_nolints.sh
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
           DEPLOY_NIGHTLY_GITHUB_TOKEN: ${{ secrets.DEPLOY_NIGHTLY_GITHUB_TOKEN }}
 
       - name: update nolints.txt
-        if: github.repository == 'leanprover-community/mathlib' && github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.lean_version == 'leanprover-community/lean:nightly'
+        if: github.repository == 'leanprover-community/mathlib' && github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.lean_version == 'leanprover-community/lean:3.5.1'
         run:
           ./scripts/update_nolints.sh
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,3 +71,10 @@ jobs:
           ./scripts/deploy_docs.sh
         env:
           DEPLOY_NIGHTLY_GITHUB_TOKEN: ${{ secrets.DEPLOY_NIGHTLY_GITHUB_TOKEN }}
+
+      - name: update nolints.txt
+        if: github.repository == 'robertylewis/mathlib' && github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.lean_version == 'leanprover-community/lean:nightly'
+        run:
+          ./scripts/update_nolints.sh
+        env:
+          DEPLOY_NIGHTLY_GITHUB_TOKEN: ${{ secrets.DEPLOY_NIGHTLY_GITHUB_TOKEN }}

--- a/scripts/update_nolints.sh
+++ b/scripts/update_nolints.sh
@@ -3,11 +3,6 @@ DEPLOY_NIGHTLY_GITHUB_USER=leanprover-community-bot
 set -e
 set -x
 
-# By default, github actions overrides the credentials used to access any
-# github url so that it uses the github-actions[bot] user.  We want to access
-# github using a different username.
-git config --unset http.https://github.com/.extraheader
-
 cd scripts
 ./mk_all.sh
 lean --run mk_nolint.lean

--- a/scripts/update_nolints.sh
+++ b/scripts/update_nolints.sh
@@ -13,7 +13,7 @@ cd scripts
 lean --run mk_nolint.lean
 ./rm_all.sh
 
-git remote add origin-bot "https://$DEPLOY_NIGHTLY_GITHUB_USER:$DEPLOY_NIGHTLY_GITHUB_TOKEN@github.com/robertylewis/mathlib.git"
+git remote add origin-bot "https://$DEPLOY_NIGHTLY_GITHUB_USER:$DEPLOY_NIGHTLY_GITHUB_TOKEN@github.com/leanprover-community/mathlib.git"
 git config user.email "leanprover.community@gmail.com"
 git config user.name "leanprover-community-bot"
 git add nolints.txt

--- a/scripts/update_nolints.sh
+++ b/scripts/update_nolints.sh
@@ -17,5 +17,5 @@ git remote add origin-bot "https://$DEPLOY_NIGHTLY_GITHUB_USER:$DEPLOY_NIGHTLY_G
 git config user.email "leanprover.community@gmail.com"
 git config user.name "leanprover-community-bot"
 git add nolints.txt
-git commit -m "chore(scripts): update nolints.txt"
-git push origin-bot HEAD:master
+git commit -m "chore(scripts): update nolints.txt" || true
+git push origin-bot HEAD:master || true

--- a/scripts/update_nolints.sh
+++ b/scripts/update_nolints.sh
@@ -1,0 +1,21 @@
+DEPLOY_NIGHTLY_GITHUB_USER=leanprover-community-bot
+
+set -e
+set -x
+
+# By default, github actions overrides the credentials used to access any
+# github url so that it uses the github-actions[bot] user.  We want to access
+# github using a different username.
+git config --unset http.https://github.com/.extraheader
+
+cd scripts
+./mk_all.sh
+lean --run mk_nolint.lean
+./rm_all.sh
+
+git remote add origin-bot "https://$DEPLOY_NIGHTLY_GITHUB_USER:$DEPLOY_NIGHTLY_GITHUB_TOKEN@github.com/robertylewis/mathlib.git"
+git config user.email "leanprover.community@gmail.com"
+git config user.name "leanprover-community-bot"
+git add nolints.txt
+git commit -m "chore(scripts): update nolints.txt"
+git push origin-bot HEAD:master


### PR DESCRIPTION
I've been doing this on occasion by hand, since there's no big need to keep `nolints.txt` minimal. But adding it to CI saves time in the long run.

A test build [here](https://github.com/robertylewis/mathlib/runs/439852847) should succeed and not make any changes, since `nolints.txt` is up to date. A build [here](https://github.com/robertylewis/mathlib/runs/439411407?check_suite_focus=true) made a successful update (but I force pushed over the evidence).

Look forward to a new mathlib contributor, trusty old @leanprover-community-bot ! 

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
