### PR TITLE
refactor(group_theory/submonoid): redefine `subtype.monoid` manually

### DIFF
--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -50,11 +50,13 @@ theorem multiplicative.is_subgroup_iff
 
 @[to_additive add_group]
 instance subtype.group {s : set α} [is_subgroup s] : group s :=
-by subtype_instance
+{ inv := λ x, ⟨(x:α)⁻¹, is_subgroup.inv_mem x.2⟩,
+  mul_left_inv := λ x, subtype.eq $ mul_left_inv x.1,
+  .. subtype.monoid }
 
 @[to_additive add_comm_group]
 instance subtype.comm_group {α : Type*} [comm_group α] {s : set α} [is_subgroup s] : comm_group s :=
-by subtype_instance
+{ .. subtype.group, .. subtype.comm_monoid }
 
 @[simp, to_additive]
 lemma is_subgroup.coe_inv {s : set α} [is_subgroup s] (a : s) : ((a⁻¹ : s) : α) = a⁻¹ := rfl

--- a/src/group_theory/submonoid.lean
+++ b/src/group_theory/submonoid.lean
@@ -6,7 +6,6 @@ Authors: Johannes Hölzl, Kenny Lau, Johan Commelin, Mario Carneiro, Kevin Buzza
 
 import algebra.big_operators
 import data.finset
-import tactic.subtype_instance
 import data.equiv.algebra
 
 /-!
@@ -218,15 +217,23 @@ lemma finset_prod_mem {α β} [comm_monoid α] (s : set α) [is_submonoid s] (f 
 
 end is_submonoid
 
+-- TODO: modify `subtype_instance` to produce this definition, then use it here
+--  and for `subtype.group`
+
 /-- Submonoids are themselves monoids. -/
 @[to_additive add_monoid "An `add_submonoid` is itself an `add_monoid`."]
 instance subtype.monoid {s : set α} [is_submonoid s] : monoid s :=
-by subtype_instance
+{ one := ⟨1, is_submonoid.one_mem s⟩,
+  mul := λ x y, ⟨x * y, is_submonoid.mul_mem x.2 y.2⟩,
+  mul_one := λ x, subtype.eq $ mul_one x.1,
+  one_mul := λ x, subtype.eq $ one_mul x.1,
+  mul_assoc := λ x y z, subtype.eq $ mul_assoc x.1 y.1 z.1 }
 
 /-- Submonoids of commutative monoids are themselves commutative monoids. -/
 @[to_additive add_comm_monoid "An `add_submonoid` of a commutative `add_monoid` is itself a commutative `add_monoid`. "]
 instance subtype.comm_monoid {α} [comm_monoid α] {s : set α} [is_submonoid s] : comm_monoid s :=
-by subtype_instance
+{ mul_comm := λ x y, subtype.eq $ mul_comm x.1 y.1,
+  .. subtype.monoid }
 
 /-- Submonoids inherit the 1 of the monoid. -/
 @[simp, to_additive "An `add_submonoid` inherits the 0 of the `add_monoid`. "]

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -121,7 +121,7 @@ begin
     rw ← p.support.sum_hom subtype.val,
     { refine finset.sum_congr rfl (λ n hn, _),
       change _ = _ * _,
-      rw is_semiring_hom.map_pow subtype.val, refl,
+      rw is_semiring_hom.map_pow coe, refl,
       split; intros; refl },
     refine { map_add := _, map_zero := _ }; intros; refl },
   refine is_integral_of_noetherian' H ⟨x, hx⟩

--- a/src/ring_theory/subring.lean
+++ b/src/ring_theory/subring.lean
@@ -20,7 +20,9 @@ class is_subring (S : set R) extends is_add_subgroup S, is_submonoid S : Prop.
 end prio
 
 instance subset.ring {S : set R} [is_subring S] : ring S :=
-by subtype_instance
+{ left_distrib := λ x y z, subtype.eq $ left_distrib x.1 y.1 z.1,
+  right_distrib := λ x y z, subtype.eq $ right_distrib x.1 y.1 z.1,
+  .. subtype.add_comm_group, .. subtype.monoid }
 
 instance subtype.ring {S : set R} [is_subring S] : ring (subtype S) := subset.ring
 
@@ -58,12 +60,17 @@ subtype_mk.is_ring_hom _ _
 variables {cR : Type u} [comm_ring cR]
 
 instance subset.comm_ring {S : set cR} [is_subring S] : comm_ring S :=
-by subtype_instance
+{ mul_comm := λ x y, subtype.eq $ mul_comm x.1 y.1,
+  .. subset.ring }
 
 instance subtype.comm_ring {S : set cR} [is_subring S] : comm_ring (subtype S) := subset.comm_ring
 
-instance subring.domain {D : Type*} [integral_domain D] (S : set D) [is_subring S] : integral_domain S :=
-by subtype_instance
+instance subring.domain {D : Type*} [integral_domain D] (S : set D) [is_subring S] :
+  integral_domain S :=
+{ zero_ne_one := mt subtype.ext.1 zero_ne_one,
+  eq_zero_or_eq_zero_of_mul_eq_zero := λ ⟨x, hx⟩ ⟨y, hy⟩,
+    by { simp only [subtype.ext, subtype.coe_mk], exact eq_zero_or_eq_zero_of_mul_eq_zero },
+  .. subset.comm_ring }
 
 instance is_subring.inter (S₁ S₂ : set R) [is_subring S₁] [is_subring S₂] :
   is_subring (S₁ ∩ S₂) :=


### PR DESCRIPTION
This way `group.to_monoid subtype.group` is defeq `subtype.monoid group.to_monoid`.

Motivated by [this discussion](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/action.20of.20subgroup.20inference.20issues), see also [this discussion](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/subtype.2E*.20diamonds)

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)