### PR TITLE
chore(group_theory/sub*) : rename type vars

### DIFF
--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -7,13 +7,13 @@ Authors: Johannes Hölzl, Mitchell Rowett, Scott Morrison, Johan Commelin, Mario
 import group_theory.submonoid
 open set function
 
-variables {α : Type*} {β : Type*} {a a₁ a₂ b c: α}
+variables {G : Type*} {H : Type*} {A : Type*} {a a₁ a₂ b c: G}
 
 section group
-variables [group α] [add_group β]
+variables [group G] [add_group A]
 
 @[to_additive]
-lemma injective_mul {a : α} : injective ((*) a) :=
+lemma injective_mul {a : G} : injective ((*) a) :=
 assume a₁ a₂ h,
 have a⁻¹ * a * a₁ = a⁻¹ * a * a₂, by rw [mul_assoc, mul_assoc, h],
 by rwa [inv_mul_self, one_mul, one_mul] at this
@@ -21,57 +21,57 @@ by rwa [inv_mul_self, one_mul, one_mul] at this
 section prio
 set_option default_priority 100 -- see Note [default priority]
 /-- `s` is an additive subgroup: a set containing 0 and closed under addition and negation. -/
-class is_add_subgroup (s : set β) extends is_add_submonoid s : Prop :=
+class is_add_subgroup (s : set A) extends is_add_submonoid s : Prop :=
 (neg_mem {a} : a ∈ s → -a ∈ s)
 
 /-- `s` is a subgroup: a set containing 1 and closed under multiplication and inverse. -/
 @[to_additive is_add_subgroup]
-class is_subgroup (s : set α) extends is_submonoid s : Prop :=
+class is_subgroup (s : set G) extends is_submonoid s : Prop :=
 (inv_mem {a} : a ∈ s → a⁻¹ ∈ s)
 end prio
 
 instance additive.is_add_subgroup
-  (s : set α) [is_subgroup s] : @is_add_subgroup (additive α) _ s :=
+  (s : set G) [is_subgroup s] : @is_add_subgroup (additive G) _ s :=
 ⟨@is_subgroup.inv_mem _ _ _ _⟩
 
 theorem additive.is_add_subgroup_iff
-  {s : set α} : @is_add_subgroup (additive α) _ s ↔ is_subgroup s :=
-⟨by rintro ⟨⟨h₁, h₂⟩, h₃⟩; exact @is_subgroup.mk α _ _ ⟨h₁, @h₂⟩ @h₃,
+  {s : set G} : @is_add_subgroup (additive G) _ s ↔ is_subgroup s :=
+⟨by rintro ⟨⟨h₁, h₂⟩, h₃⟩; exact @is_subgroup.mk G _ _ ⟨h₁, @h₂⟩ @h₃,
   λ h, by resetI; apply_instance⟩
 
 instance multiplicative.is_subgroup
-  (s : set β) [is_add_subgroup s] : @is_subgroup (multiplicative β) _ s :=
+  (s : set A) [is_add_subgroup s] : @is_subgroup (multiplicative A) _ s :=
 ⟨@is_add_subgroup.neg_mem _ _ _ _⟩
 
 theorem multiplicative.is_subgroup_iff
-  {s : set β} : @is_subgroup (multiplicative β) _ s ↔ is_add_subgroup s :=
-⟨by rintro ⟨⟨h₁, h₂⟩, h₃⟩; exact @is_add_subgroup.mk β _ _ ⟨h₁, @h₂⟩ @h₃,
+  {s : set A} : @is_subgroup (multiplicative A) _ s ↔ is_add_subgroup s :=
+⟨by rintro ⟨⟨h₁, h₂⟩, h₃⟩; exact @is_add_subgroup.mk A _ _ ⟨h₁, @h₂⟩ @h₃,
   λ h, by resetI; apply_instance⟩
 
 @[to_additive add_group]
-instance subtype.group {s : set α} [is_subgroup s] : group s :=
-{ inv := λ x, ⟨(x:α)⁻¹, is_subgroup.inv_mem x.2⟩,
+instance subtype.group {s : set G} [is_subgroup s] : group s :=
+{ inv := λ x, ⟨(x:G)⁻¹, is_subgroup.inv_mem x.2⟩,
   mul_left_inv := λ x, subtype.eq $ mul_left_inv x.1,
   .. subtype.monoid }
 
 @[to_additive add_comm_group]
-instance subtype.comm_group {α : Type*} [comm_group α] {s : set α} [is_subgroup s] : comm_group s :=
+instance subtype.comm_group {G : Type*} [comm_group G] {s : set G} [is_subgroup s] : comm_group s :=
 { .. subtype.group, .. subtype.comm_monoid }
 
 @[simp, to_additive]
-lemma is_subgroup.coe_inv {s : set α} [is_subgroup s] (a : s) : ((a⁻¹ : s) : α) = a⁻¹ := rfl
+lemma is_subgroup.coe_inv {s : set G} [is_subgroup s] (a : s) : ((a⁻¹ : s) : G) = a⁻¹ := rfl
 
-@[simp] lemma is_subgroup.coe_gpow {s : set α} [is_subgroup s] (a : s) (n : ℤ) : ((a ^ n : s) : α) = a ^ n :=
+@[simp] lemma is_subgroup.coe_gpow {s : set G} [is_subgroup s] (a : s) (n : ℤ) : ((a ^ n : s) : G) = a ^ n :=
 by induction n; simp [is_submonoid.coe_pow a]
 
-@[simp] lemma is_add_subgroup.gsmul_coe {β : Type*} [add_group β] {s : set β} [is_add_subgroup s] (a : s) (n : ℤ) :
-  ((gsmul n a : s) : β) = gsmul n a :=
+@[simp] lemma is_add_subgroup.gsmul_coe {s : set A} [is_add_subgroup s] (a : s) (n : ℤ) :
+  ((gsmul n a : s) : A) = gsmul n a :=
 by induction n; simp [is_add_submonoid.smul_coe a]
 attribute [to_additive gsmul_coe] is_subgroup.coe_gpow
 
 @[to_additive of_add_neg]
-theorem is_subgroup.of_div (s : set α)
-  (one_mem : (1:α) ∈ s) (div_mem : ∀{a b:α}, a ∈ s → b ∈ s → a * b⁻¹ ∈ s) :
+theorem is_subgroup.of_div (s : set G)
+  (one_mem : (1:G) ∈ s) (div_mem : ∀{a b:G}, a ∈ s → b ∈ s → a * b⁻¹ ∈ s) :
   is_subgroup s :=
 have inv_mem : ∀a, a ∈ s → a⁻¹ ∈ s, from
   assume a ha,
@@ -83,24 +83,24 @@ have inv_mem : ∀a, a ∈ s → a⁻¹ ∈ s, from
     by simpa,
   one_mem := one_mem }
 
-theorem is_add_subgroup.of_sub (s : set β)
-  (zero_mem : (0:β) ∈ s) (sub_mem : ∀{a b:β}, a ∈ s → b ∈ s → a - b ∈ s) :
+theorem is_add_subgroup.of_sub (s : set A)
+  (zero_mem : (0:A) ∈ s) (sub_mem : ∀{a b:A}, a ∈ s → b ∈ s → a - b ∈ s) :
   is_add_subgroup s :=
 is_add_subgroup.of_add_neg s zero_mem (λ x y hx hy, sub_mem hx hy)
 
 @[to_additive]
-instance is_subgroup.inter (s₁ s₂ : set α) [is_subgroup s₁] [is_subgroup s₂] :
+instance is_subgroup.inter (s₁ s₂ : set G) [is_subgroup s₁] [is_subgroup s₂] :
   is_subgroup (s₁ ∩ s₂) :=
 { inv_mem := λ x hx, ⟨is_subgroup.inv_mem hx.1, is_subgroup.inv_mem hx.2⟩ }
 
 @[to_additive]
-instance is_subgroup.Inter {ι : Sort*} (s : ι → set α) [h : ∀ y : ι, is_subgroup (s y)] :
+instance is_subgroup.Inter {ι : Sort*} (s : ι → set G) [h : ∀ y : ι, is_subgroup (s y)] :
   is_subgroup (set.Inter s) :=
 { inv_mem := λ x h, set.mem_Inter.2 $ λ y, is_subgroup.inv_mem (set.mem_Inter.1 h y) }
 
 @[to_additive is_add_subgroup_Union_of_directed]
 lemma is_subgroup_Union_of_directed {ι : Type*} [hι : nonempty ι]
-  (s : ι → set α) [∀ i, is_subgroup (s i)]
+  (s : ι → set G) [∀ i, is_subgroup (s i)]
   (directed : ∀ i j, ∃ k, s i ⊆ s k ∧ s j ⊆ s k) :
   is_subgroup (⋃i, s i) :=
 { inv_mem := λ a ha,
@@ -108,43 +108,43 @@ lemma is_subgroup_Union_of_directed {ι : Type*} [hι : nonempty ι]
     set.mem_Union.2 ⟨i, is_subgroup.inv_mem hi⟩,
   to_is_submonoid := is_submonoid_Union_of_directed s directed }
 
-def gpowers (x : α) : set α := set.range ((^) x : ℤ → α)
-def gmultiples (x : β) : set β := set.range (λ i, gsmul i x)
+def gpowers (x : G) : set G := set.range ((^) x : ℤ → G)
+def gmultiples (x : A) : set A := set.range (λ i, gsmul i x)
 attribute [to_additive gmultiples] gpowers
 
-instance gpowers.is_subgroup (x : α) : is_subgroup (gpowers x) :=
+instance gpowers.is_subgroup (x : G) : is_subgroup (gpowers x) :=
 { one_mem := ⟨(0:ℤ), by simp⟩,
   mul_mem := assume x₁ x₂ ⟨i₁, h₁⟩ ⟨i₂, h₂⟩, ⟨i₁ + i₂, by simp [gpow_add, *]⟩,
   inv_mem := assume x₀ ⟨i, h⟩, ⟨-i, by simp [h.symm]⟩ }
 
-instance gmultiples.is_add_subgroup (x : β) : is_add_subgroup (gmultiples x) :=
+instance gmultiples.is_add_subgroup (x : A) : is_add_subgroup (gmultiples x) :=
 multiplicative.is_subgroup_iff.1 $ gpowers.is_subgroup _
 attribute [to_additive is_add_subgroup] gpowers.is_subgroup
 
-lemma is_subgroup.gpow_mem {a : α} {s : set α} [is_subgroup s] (h : a ∈ s) : ∀{i:ℤ}, a ^ i ∈ s
+lemma is_subgroup.gpow_mem {a : G} {s : set G} [is_subgroup s] (h : a ∈ s) : ∀{i:ℤ}, a ^ i ∈ s
 | (n : ℕ) := is_submonoid.pow_mem h
 | -[1+ n] := is_subgroup.inv_mem (is_submonoid.pow_mem h)
 
-lemma is_add_subgroup.gsmul_mem {a : β} {s : set β} [is_add_subgroup s] : a ∈ s → ∀{i:ℤ}, gsmul i a ∈ s :=
-@is_subgroup.gpow_mem (multiplicative β) _ _ _ _
+lemma is_add_subgroup.gsmul_mem {a : A} {s : set A} [is_add_subgroup s] : a ∈ s → ∀{i:ℤ}, gsmul i a ∈ s :=
+@is_subgroup.gpow_mem (multiplicative A) _ _ _ _
 
-lemma gpowers_subset {a : α} {s : set α} [is_subgroup s] (h : a ∈ s) : gpowers a ⊆ s :=
+lemma gpowers_subset {a : G} {s : set G} [is_subgroup s] (h : a ∈ s) : gpowers a ⊆ s :=
 λ x hx, match x, hx with _, ⟨i, rfl⟩ := is_subgroup.gpow_mem h end
 
-lemma gmultiples_subset {a : β} {s : set β} [is_add_subgroup s] (h : a ∈ s) : gmultiples a ⊆ s :=
-@gpowers_subset (multiplicative β) _ _ _ _ h
+lemma gmultiples_subset {a : A} {s : set A} [is_add_subgroup s] (h : a ∈ s) : gmultiples a ⊆ s :=
+@gpowers_subset (multiplicative A) _ _ _ _ h
 
 attribute [to_additive gmultiples_subset] gpowers_subset
 
-lemma mem_gpowers {a : α} : a ∈ gpowers a := ⟨1, by simp⟩
-lemma mem_gmultiples {a : β} : a ∈ gmultiples a := ⟨1, by simp⟩
+lemma mem_gpowers {a : G} : a ∈ gpowers a := ⟨1, by simp⟩
+lemma mem_gmultiples {a : A} : a ∈ gmultiples a := ⟨1, by simp⟩
 attribute [to_additive mem_gmultiples] mem_gpowers
 
 end group
 
 namespace is_subgroup
 open is_submonoid
-variables [group α] (s : set α) [is_subgroup s]
+variables [group G] (s : set G) [is_subgroup s]
 
 @[to_additive]
 lemma inv_mem_iff : a⁻¹ ∈ s ↔ a ∈ s :=
@@ -160,89 +160,89 @@ lemma mul_mem_cancel_right (h : a ∈ s) : a * b ∈ s ↔ b ∈ s :=
 
 end is_subgroup
 
-theorem is_add_subgroup.sub_mem {α} [add_group α] (s : set α) [is_add_subgroup s] (a b : α)
+theorem is_add_subgroup.sub_mem {A} [add_group A] (s : set A) [is_add_subgroup s] (a b : A)
   (ha : a ∈ s) (hb : b ∈ s) : a - b ∈ s :=
 is_add_submonoid.add_mem ha (is_add_subgroup.neg_mem hb)
 
 section prio
 set_option default_priority 100 -- see Note [default priority]
-class normal_add_subgroup [add_group α] (s : set α) extends is_add_subgroup s : Prop :=
-(normal : ∀ n ∈ s, ∀ g : α, g + n - g ∈ s)
+class normal_add_subgroup [add_group A] (s : set A) extends is_add_subgroup s : Prop :=
+(normal : ∀ n ∈ s, ∀ g : A, g + n - g ∈ s)
 
 @[to_additive normal_add_subgroup]
-class normal_subgroup [group α] (s : set α) extends is_subgroup s : Prop :=
-(normal : ∀ n ∈ s, ∀ g : α, g * n * g⁻¹ ∈ s)
+class normal_subgroup [group G] (s : set G) extends is_subgroup s : Prop :=
+(normal : ∀ n ∈ s, ∀ g : G, g * n * g⁻¹ ∈ s)
 end prio
 
 @[to_additive normal_add_subgroup_of_add_comm_group]
-lemma normal_subgroup_of_comm_group [comm_group α] (s : set α) [hs : is_subgroup s] :
+lemma normal_subgroup_of_comm_group [comm_group G] (s : set G) [hs : is_subgroup s] :
   normal_subgroup s :=
 { normal := λ n hn g, by rwa [mul_right_comm, mul_right_inv, one_mul],
   ..hs }
 
-instance additive.normal_add_subgroup [group α]
-  (s : set α) [normal_subgroup s] : @normal_add_subgroup (additive α) _ s :=
+instance additive.normal_add_subgroup [group G]
+  (s : set G) [normal_subgroup s] : @normal_add_subgroup (additive G) _ s :=
 ⟨@normal_subgroup.normal _ _ _ _⟩
 
-theorem additive.normal_add_subgroup_iff [group α]
-  {s : set α} : @normal_add_subgroup (additive α) _ s ↔ normal_subgroup s :=
+theorem additive.normal_add_subgroup_iff [group G]
+  {s : set G} : @normal_add_subgroup (additive G) _ s ↔ normal_subgroup s :=
 ⟨by rintro ⟨h₁, h₂⟩; exact
-    @normal_subgroup.mk α _ _ (additive.is_add_subgroup_iff.1 h₁) @h₂,
+    @normal_subgroup.mk G _ _ (additive.is_add_subgroup_iff.1 h₁) @h₂,
   λ h, by resetI; apply_instance⟩
 
-instance multiplicative.normal_subgroup [add_group α]
-  (s : set α) [normal_add_subgroup s] : @normal_subgroup (multiplicative α) _ s :=
+instance multiplicative.normal_subgroup [add_group A]
+  (s : set A) [normal_add_subgroup s] : @normal_subgroup (multiplicative A) _ s :=
 ⟨@normal_add_subgroup.normal _ _ _ _⟩
 
-theorem multiplicative.normal_subgroup_iff [add_group α]
-  {s : set α} : @normal_subgroup (multiplicative α) _ s ↔ normal_add_subgroup s :=
+theorem multiplicative.normal_subgroup_iff [add_group A]
+  {s : set A} : @normal_subgroup (multiplicative A) _ s ↔ normal_add_subgroup s :=
 ⟨by rintro ⟨h₁, h₂⟩; exact
-    @normal_add_subgroup.mk α _ _ (multiplicative.is_subgroup_iff.1 h₁) @h₂,
+    @normal_add_subgroup.mk A _ _ (multiplicative.is_subgroup_iff.1 h₁) @h₂,
   λ h, by resetI; apply_instance⟩
 
 namespace is_subgroup
-variable [group α]
+variable [group G]
 
 -- Normal subgroup properties
 @[to_additive]
-lemma mem_norm_comm {s : set α} [normal_subgroup s] {a b : α} (hab : a * b ∈ s) : b * a ∈ s :=
+lemma mem_norm_comm {s : set G} [normal_subgroup s] {a b : G} (hab : a * b ∈ s) : b * a ∈ s :=
 have h : a⁻¹ * (a * b) * a⁻¹⁻¹ ∈ s, from normal_subgroup.normal (a * b) hab a⁻¹,
 by simp at h; exact h
 
 @[to_additive]
-lemma mem_norm_comm_iff {s : set α} [normal_subgroup s] {a b : α} : a * b ∈ s ↔ b * a ∈ s :=
+lemma mem_norm_comm_iff {s : set G} [normal_subgroup s] {a b : G} : a * b ∈ s ↔ b * a ∈ s :=
 ⟨mem_norm_comm, mem_norm_comm⟩
 
 /-- The trivial subgroup -/
 @[to_additive]
-def trivial (α : Type*) [group α] : set α := {1}
+def trivial (G : Type*) [group G] : set G := {1}
 
 @[simp, to_additive]
-lemma mem_trivial [group α] {g : α} : g ∈ trivial α ↔ g = 1 :=
+lemma mem_trivial {g : G} : g ∈ trivial G ↔ g = 1 :=
 mem_singleton_iff
 
 @[to_additive]
-instance trivial_normal : normal_subgroup (trivial α) :=
+instance trivial_normal : normal_subgroup (trivial G) :=
 by refine {..}; simp [trivial] {contextual := tt}
 
 @[to_additive]
-lemma eq_trivial_iff {H : set α} [is_subgroup H] :
-  H = trivial α ↔ (∀ x ∈ H, x = (1 : α)) :=
+lemma eq_trivial_iff {s : set G} [is_subgroup s] :
+  s = trivial G ↔ (∀ x ∈ s, x = (1 : G)) :=
 by simp only [set.ext_iff, is_subgroup.mem_trivial];
-  exact ⟨λ h x, (h x).1, λ h x, ⟨h x, λ hx, hx.symm ▸ is_submonoid.one_mem H⟩⟩
+  exact ⟨λ h x, (h x).1, λ h x, ⟨h x, λ hx, hx.symm ▸ is_submonoid.one_mem s⟩⟩
 
 @[to_additive]
-instance univ_subgroup : normal_subgroup (@univ α) :=
+instance univ_subgroup : normal_subgroup (@univ G) :=
 by refine {..}; simp
 
 @[to_additive add_center]
-def center (α : Type*) [group α] : set α := {z | ∀ g, g * z = z * g}
+def center (G : Type*) [group G] : set G := {z | ∀ g, g * z = z * g}
 
 @[to_additive mem_add_center]
-lemma mem_center {a : α} : a ∈ center α ↔ ∀g, g * a = a * g := iff.rfl
+lemma mem_center {a : G} : a ∈ center G ↔ ∀g, g * a = a * g := iff.rfl
 
 @[to_additive add_center_normal]
-instance center_normal : normal_subgroup (center α) :=
+instance center_normal : normal_subgroup (center G) :=
 { one_mem := by simp [center],
   mul_mem := assume a b ha hb g,
     by rw [←mul_assoc, mem_center.2 ha g, mul_assoc, mem_center.2 hb g, ←mul_assoc],
@@ -257,11 +257,11 @@ instance center_normal : normal_subgroup (center α) :=
       ...               = g * n * g⁻¹ * h : by rw [mul_assoc g, ha g⁻¹, ←mul_assoc] }
 
 @[to_additive add_normalizer]
-def normalizer (s : set α) : set α :=
-{g : α | ∀ n, n ∈ s ↔ g * n * g⁻¹ ∈ s}
+def normalizer (s : set G) : set G :=
+{g : G | ∀ n, n ∈ s ↔ g * n * g⁻¹ ∈ s}
 
 @[to_additive normalizer_is_add_subgroup]
-instance normalizer_is_subgroup (s : set α) [is_subgroup s] : is_subgroup (normalizer s) :=
+instance normalizer_is_subgroup (s : set G) [is_subgroup s] : is_subgroup (normalizer s) :=
 { one_mem := by simp [normalizer],
   mul_mem := λ a b (ha : ∀ n, n ∈ s ↔ a * n * a⁻¹ ∈ s)
     (hb : ∀ n, n ∈ s ↔ b * n * b⁻¹ ∈ s) n,
@@ -271,18 +271,17 @@ instance normalizer_is_subgroup (s : set α) [is_subgroup s] : is_subgroup (norm
     simp [mul_assoc] }
 
 @[to_additive subset_add_normalizer]
-lemma subset_normalizer (s : set α) [is_subgroup s] : s ⊆ normalizer s :=
+lemma subset_normalizer (s : set G) [is_subgroup s] : s ⊆ normalizer s :=
 λ g hg n, by rw [is_subgroup.mul_mem_cancel_left _ ((is_subgroup.inv_mem_iff _).2 hg),
   is_subgroup.mul_mem_cancel_right _ hg]
 
-
 /-- Every subgroup is a normal subgroup of its normalizer -/
 @[to_additive add_normal_in_add_normalizer]
-instance normal_in_normalizer (s : set α) [is_subgroup s] :
+instance normal_in_normalizer (s : set G) [is_subgroup s] :
   normal_subgroup (subtype.val ⁻¹' s : set (normalizer s)) :=
-{ one_mem := show (1 : α) ∈ s, from is_submonoid.one_mem _,
-  mul_mem := λ a b ha hb, show (a * b : α) ∈ s, from is_submonoid.mul_mem ha hb,
-  inv_mem := λ a ha, show (a⁻¹ : α) ∈ s, from is_subgroup.inv_mem ha,
+{ one_mem := show (1 : G) ∈ s, from is_submonoid.one_mem _,
+  mul_mem := λ a b ha hb, show (a * b : G) ∈ s, from is_submonoid.mul_mem ha hb,
+  inv_mem := λ a ha, show (a⁻¹ : G) ∈ s, from is_subgroup.inv_mem ha,
   normal := λ a ha ⟨m, hm⟩, (hm a).1 ha }
 
 end is_subgroup
@@ -291,24 +290,24 @@ end is_subgroup
 namespace is_group_hom
 open is_submonoid is_subgroup
 open is_mul_hom (map_mul)
-variables [group α] [group β]
+variables [group G] [group H]
 
 @[to_additive]
-def ker (f : α → β) [is_group_hom f] : set α := preimage f (trivial β)
+def ker (f : G → H) [is_group_hom f] : set G := preimage f (trivial H)
 
 @[to_additive]
-lemma mem_ker (f : α → β) [is_group_hom f] {x : α} : x ∈ ker f ↔ f x = 1 :=
+lemma mem_ker (f : G → H) [is_group_hom f] {x : G} : x ∈ ker f ↔ f x = 1 :=
 mem_trivial
 
 @[to_additive]
-lemma one_ker_inv (f : α → β) [is_group_hom f] {a b : α} (h : f (a * b⁻¹) = 1) : f a = f b :=
+lemma one_ker_inv (f : G → H) [is_group_hom f] {a b : G} (h : f (a * b⁻¹) = 1) : f a = f b :=
 begin
   rw [map_mul f, map_inv f] at h,
   rw [←inv_inv (f b), eq_inv_of_mul_eq_one h]
 end
 
 @[to_additive]
-lemma one_ker_inv' (f : α → β) [is_group_hom f] {a b : α} (h : f (a⁻¹ * b) = 1) : f a = f b :=
+lemma one_ker_inv' (f : G → H) [is_group_hom f] {a b : G} (h : f (a⁻¹ * b) = 1) : f a = f b :=
 begin
   rw [map_mul f, map_inv f] at h,
   apply eq_of_inv_eq_inv,
@@ -316,33 +315,33 @@ begin
 end
 
 @[to_additive]
-lemma inv_ker_one (f : α → β) [is_group_hom f] {a b : α} (h : f a = f b) : f (a * b⁻¹) = 1 :=
+lemma inv_ker_one (f : G → H) [is_group_hom f] {a b : G} (h : f a = f b) : f (a * b⁻¹) = 1 :=
 have f a * (f b)⁻¹ = 1, by rw [h, mul_right_inv],
 by rwa [←map_inv f, ←map_mul f] at this
 
 @[to_additive]
-lemma inv_ker_one' (f : α → β) [is_group_hom f] {a b : α} (h : f a = f b) : f (a⁻¹ * b) = 1 :=
+lemma inv_ker_one' (f : G → H) [is_group_hom f] {a b : G} (h : f a = f b) : f (a⁻¹ * b) = 1 :=
 have (f a)⁻¹ * f b = 1, by rw [h, mul_left_inv],
 by rwa [←map_inv f, ←map_mul f] at this
 
 @[to_additive]
-lemma one_iff_ker_inv (f : α → β) [is_group_hom f] (a b : α) : f a = f b ↔ f (a * b⁻¹) = 1 :=
+lemma one_iff_ker_inv (f : G → H) [is_group_hom f] (a b : G) : f a = f b ↔ f (a * b⁻¹) = 1 :=
 ⟨inv_ker_one f, one_ker_inv f⟩
 
 @[to_additive]
-lemma one_iff_ker_inv' (f : α → β) [is_group_hom f] (a b : α) : f a = f b ↔ f (a⁻¹ * b) = 1 :=
+lemma one_iff_ker_inv' (f : G → H) [is_group_hom f] (a b : G) : f a = f b ↔ f (a⁻¹ * b) = 1 :=
 ⟨inv_ker_one' f, one_ker_inv' f⟩
 
 @[to_additive]
-lemma inv_iff_ker (f : α → β) [w : is_group_hom f] (a b : α) : f a = f b ↔ a * b⁻¹ ∈ ker f :=
+lemma inv_iff_ker (f : G → H) [w : is_group_hom f] (a b : G) : f a = f b ↔ a * b⁻¹ ∈ ker f :=
 by rw [mem_ker]; exact one_iff_ker_inv _ _ _
 
 @[to_additive]
-lemma inv_iff_ker' (f : α → β) [w : is_group_hom f] (a b : α) : f a = f b ↔ a⁻¹ * b ∈ ker f :=
+lemma inv_iff_ker' (f : G → H) [w : is_group_hom f] (a b : G) : f a = f b ↔ a⁻¹ * b ∈ ker f :=
 by rw [mem_ker]; exact one_iff_ker_inv' _ _ _
 
 @[to_additive image_add_subgroup]
-instance image_subgroup (f : α → β) [is_group_hom f] (s : set α) [is_subgroup s] :
+instance image_subgroup (f : G → H) [is_group_hom f] (s : set G) [is_subgroup s] :
   is_subgroup (f '' s) :=
 { mul_mem := assume a₁ a₂ ⟨b₁, hb₁, eq₁⟩ ⟨b₂, hb₂, eq₂⟩,
              ⟨b₁ * b₂, mul_mem hb₁ hb₂, by simp [eq₁, eq₂, map_mul f]⟩,
@@ -350,27 +349,27 @@ instance image_subgroup (f : α → β) [is_group_hom f] (s : set α) [is_subgro
   inv_mem := assume a ⟨b, hb, eq⟩, ⟨b⁻¹, inv_mem hb, by rw map_inv f; simp *⟩ }
 
 @[to_additive range_add_subgroup]
-instance range_subgroup (f : α → β) [is_group_hom f] : is_subgroup (set.range f) :=
+instance range_subgroup (f : G → H) [is_group_hom f] : is_subgroup (set.range f) :=
 @set.image_univ _ _ f ▸ is_group_hom.image_subgroup f set.univ
 
 local attribute [simp] one_mem inv_mem mul_mem normal_subgroup.normal
 
 @[to_additive]
-instance preimage (f : α → β) [is_group_hom f] (s : set β) [is_subgroup s] :
+instance preimage (f : G → H) [is_group_hom f] (s : set H) [is_subgroup s] :
   is_subgroup (f ⁻¹' s) :=
-by refine {..}; simp [map_mul f, map_one f, map_inv f, @inv_mem β _ s] {contextual:=tt}
+by refine {..}; simp [map_mul f, map_one f, map_inv f, @inv_mem H _ s] {contextual:=tt}
 
 @[to_additive]
-instance preimage_normal (f : α → β) [is_group_hom f] (s : set β) [normal_subgroup s] :
+instance preimage_normal (f : G → H) [is_group_hom f] (s : set H) [normal_subgroup s] :
   normal_subgroup (f ⁻¹' s) :=
 ⟨by simp [map_mul f, map_inv f] {contextual:=tt}⟩
 
 @[to_additive]
-instance normal_subgroup_ker (f : α → β) [is_group_hom f] : normal_subgroup (ker f) :=
-is_group_hom.preimage_normal f (trivial β)
+instance normal_subgroup_ker (f : G → H) [is_group_hom f] : normal_subgroup (ker f) :=
+is_group_hom.preimage_normal f (trivial H)
 
 @[to_additive]
-lemma inj_of_trivial_ker (f : α → β) [is_group_hom f] (h : ker f = trivial α) :
+lemma inj_of_trivial_ker (f : G → H) [is_group_hom f] (h : ker f = trivial G) :
   function.injective f :=
 begin
   intros a₁ a₂ hfa,
@@ -380,8 +379,8 @@ begin
 end
 
 @[to_additive]
-lemma trivial_ker_of_inj (f : α → β) [is_group_hom f] (h : function.injective f) :
-  ker f = trivial α :=
+lemma trivial_ker_of_inj (f : G → H) [is_group_hom f] (h : function.injective f) :
+  ker f = trivial G :=
 set.ext $ assume x, iff.intro
   (assume hx,
     suffices f x = f 1, by simpa using h this,
@@ -389,93 +388,93 @@ set.ext $ assume x, iff.intro
   (by simp [mem_ker, is_group_hom.map_one f] {contextual := tt})
 
 @[to_additive]
-lemma inj_iff_trivial_ker (f : α → β) [is_group_hom f] :
-  function.injective f ↔ ker f = trivial α :=
+lemma inj_iff_trivial_ker (f : G → H) [is_group_hom f] :
+  function.injective f ↔ ker f = trivial G :=
 ⟨trivial_ker_of_inj f, inj_of_trivial_ker f⟩
 
 @[to_additive]
-lemma trivial_ker_iff_eq_one (f : α → β) [is_group_hom f] :
-  ker f = trivial α ↔ ∀ x, f x = 1 → x = 1 :=
+lemma trivial_ker_iff_eq_one (f : G → H) [is_group_hom f] :
+  ker f = trivial G ↔ ∀ x, f x = 1 → x = 1 :=
 by rw set.ext_iff; simp [ker]; exact
 ⟨λ h x hx, (h x).1 hx, λ h x, ⟨h x, λ hx, by rw [hx, map_one f]⟩⟩
 
 end is_group_hom
 
 @[to_additive is_add_group_hom]
-instance subtype_val.is_group_hom [group α] {s : set α} [is_subgroup s] :
-  is_group_hom (subtype.val : s → α) := { ..subtype_val.is_monoid_hom }
+instance subtype_val.is_group_hom [group G] {s : set G} [is_subgroup s] :
+  is_group_hom (subtype.val : s → G) := { ..subtype_val.is_monoid_hom }
 
 @[to_additive is_add_group_hom]
-instance coe.is_group_hom [group α] {s : set α} [is_subgroup s] :
-  is_group_hom (coe : s → α) := { ..subtype_val.is_monoid_hom }
+instance coe.is_group_hom [group G] {s : set G} [is_subgroup s] :
+  is_group_hom (coe : s → G) := { ..subtype_val.is_monoid_hom }
 
 @[to_additive is_add_group_hom]
-instance subtype_mk.is_group_hom [group α] [group β] {s : set α}
-  [is_subgroup s] (f : β → α) [is_group_hom f] (h : ∀ x, f x ∈ s) :
+instance subtype_mk.is_group_hom [group G] [group H] {s : set G}
+  [is_subgroup s] (f : H → G) [is_group_hom f] (h : ∀ x, f x ∈ s) :
   is_group_hom (λ x, (⟨f x, h x⟩ : s)) := { ..subtype_mk.is_monoid_hom f h }
 
 @[to_additive is_add_group_hom]
-instance set_inclusion.is_group_hom [group α] {s t : set α}
+instance set_inclusion.is_group_hom [group G] {s t : set G}
   [is_subgroup s] [is_subgroup t] (h : s ⊆ t) : is_group_hom (set.inclusion h) :=
 subtype_mk.is_group_hom _ _
 
 namespace add_group
 
-variables [add_group α]
+variables [add_group A]
 
-inductive in_closure (s : set α) : α → Prop
-| basic {a : α} : a ∈ s → in_closure a
+inductive in_closure (s : set A) : A → Prop
+| basic {a : A} : a ∈ s → in_closure a
 | zero : in_closure 0
-| neg {a : α} : in_closure a → in_closure (-a)
-| add {a b : α} : in_closure a → in_closure b → in_closure (a + b)
+| neg {a : A} : in_closure a → in_closure (-a)
+| add {a b : A} : in_closure a → in_closure b → in_closure (a + b)
 
 end add_group
 
 namespace group
 open is_submonoid is_subgroup
 
-variables [group α] {s : set α}
+variables [group G] {s : set G}
 
 @[to_additive]
-inductive in_closure (s : set α) : α → Prop
-| basic {a : α} : a ∈ s → in_closure a
+inductive in_closure (s : set G) : G → Prop
+| basic {a : G} : a ∈ s → in_closure a
 | one : in_closure 1
-| inv {a : α} : in_closure a → in_closure a⁻¹
-| mul {a b : α} : in_closure a → in_closure b → in_closure (a * b)
+| inv {a : G} : in_closure a → in_closure a⁻¹
+| mul {a b : G} : in_closure a → in_closure b → in_closure (a * b)
 
 /-- `group.closure s` is the subgroup closed over `s`, i.e. the smallest subgroup containg s. -/
 @[to_additive]
-def closure (s : set α) : set α := {a | in_closure s a }
+def closure (s : set G) : set G := {a | in_closure s a }
 
 @[to_additive]
-lemma mem_closure {a : α} : a ∈ s → a ∈ closure s := in_closure.basic
+lemma mem_closure {a : G} : a ∈ s → a ∈ closure s := in_closure.basic
 
 @[to_additive is_add_subgroup]
-instance closure.is_subgroup (s : set α) : is_subgroup (closure s) :=
+instance closure.is_subgroup (s : set G) : is_subgroup (closure s) :=
 { one_mem := in_closure.one s, mul_mem := assume a b, in_closure.mul, inv_mem := assume a, in_closure.inv }
 
 @[to_additive]
-theorem subset_closure {s : set α} : s ⊆ closure s := λ a, mem_closure
+theorem subset_closure {s : set G} : s ⊆ closure s := λ a, mem_closure
 
 @[to_additive]
-theorem closure_subset {s t : set α} [is_subgroup t] (h : s ⊆ t) : closure s ⊆ t :=
+theorem closure_subset {s t : set G} [is_subgroup t] (h : s ⊆ t) : closure s ⊆ t :=
 assume a ha, by induction ha; simp [h _, *, one_mem, mul_mem, inv_mem_iff]
 
 @[to_additive]
-lemma closure_subset_iff (s t : set α) [is_subgroup t] : closure s ⊆ t ↔ s ⊆ t :=
+lemma closure_subset_iff (s t : set G) [is_subgroup t] : closure s ⊆ t ↔ s ⊆ t :=
 ⟨assume h b ha, h (mem_closure ha), assume h b ha, closure_subset h ha⟩
 
 @[to_additive]
-theorem closure_mono {s t : set α} (h : s ⊆ t) : closure s ⊆ closure t :=
+theorem closure_mono {s t : set G} (h : s ⊆ t) : closure s ⊆ closure t :=
 closure_subset $ set.subset.trans h subset_closure
 
 @[simp, to_additive closure_add_subgroup]
-lemma closure_subgroup (s : set α) [is_subgroup s] : closure s = s :=
+lemma closure_subgroup (s : set G) [is_subgroup s] : closure s = s :=
 set.subset.antisymm (closure_subset $ set.subset.refl s) subset_closure
 
 @[to_additive]
-theorem exists_list_of_mem_closure {s : set α} {a : α} (h : a ∈ closure s) :
-  (∃l:list α, (∀x∈l, x ∈ s ∨ x⁻¹ ∈ s) ∧ l.prod = a) :=
+theorem exists_list_of_mem_closure {s : set G} {a : G} (h : a ∈ closure s) :
+  (∃l:list G, (∀x∈l, x ∈ s ∨ x⁻¹ ∈ s) ∧ l.prod = a) :=
 in_closure.rec_on h
   (λ x hxs, ⟨[x], list.forall_mem_singleton.2 $ or.inl hxs, one_mul _⟩)
   ⟨[], list.forall_mem_nil _, rfl⟩
@@ -489,7 +488,7 @@ in_closure.rec_on h
     by rw [list.prod_append, HL2, HL4]⟩)
 
 @[to_additive]
-lemma image_closure [group β] (f : α → β) [is_group_hom f] (s : set α) :
+lemma image_closure [group H] (f : G → H) [is_group_hom f] (s : set G) :
   f '' closure s = closure (f '' s) :=
 le_antisymm
   begin
@@ -503,27 +502,27 @@ le_antisymm
   (closure_subset $ set.image_subset _ subset_closure)
 
 @[to_additive]
-theorem mclosure_subset {s : set α} : monoid.closure s ⊆ closure s :=
+theorem mclosure_subset {s : set G} : monoid.closure s ⊆ closure s :=
 monoid.closure_subset $ subset_closure
 
 @[to_additive]
-theorem mclosure_inv_subset {s : set α} : monoid.closure (has_inv.inv ⁻¹' s) ⊆ closure s :=
+theorem mclosure_inv_subset {s : set G} : monoid.closure (has_inv.inv ⁻¹' s) ⊆ closure s :=
 monoid.closure_subset $ λ x hx, inv_inv x ▸ (is_subgroup.inv_mem $ subset_closure hx)
 
 @[to_additive]
-theorem closure_eq_mclosure {s : set α} : closure s = monoid.closure (s ∪ has_inv.inv ⁻¹' s) :=
+theorem closure_eq_mclosure {s : set G} : closure s = monoid.closure (s ∪ has_inv.inv ⁻¹' s) :=
 set.subset.antisymm
   (@closure_subset _ _ _ (monoid.closure (s ∪ has_inv.inv ⁻¹' s))
     { inv_mem := λ x hx, monoid.in_closure.rec_on hx
       (λ x hx, or.cases_on hx (λ hx, monoid.subset_closure $ or.inr $ show x⁻¹⁻¹ ∈ s, from (inv_inv x).symm ▸ hx)
         (λ hx, monoid.subset_closure $ or.inl hx))
-      ((@one_inv α _).symm ▸ is_submonoid.one_mem _)
+      ((@one_inv G _).symm ▸ is_submonoid.one_mem _)
       (λ x y hx hy ihx ihy, (mul_inv_rev x y).symm ▸ is_submonoid.mul_mem ihy ihx) }
     (set.subset.trans (set.subset_union_left _ _) monoid.subset_closure))
   (monoid.closure_subset $ set.union_subset subset_closure $ λ x hx, inv_inv x ▸ (is_subgroup.inv_mem $ subset_closure hx))
 
 @[to_additive]
-theorem mem_closure_union_iff {α : Type*} [comm_group α] {s t : set α} {x : α} :
+theorem mem_closure_union_iff {G : Type*} [comm_group G] {s t : set G} {x : G} :
   x ∈ closure (s ∪ t) ↔ ∃ y ∈ closure s, ∃ z ∈ closure t, y * z = x :=
 begin
   simp only [closure_eq_mclosure, monoid.mem_closure_union_iff, exists_prop, preimage_union], split,
@@ -536,7 +535,7 @@ begin
 end
 
 @[to_additive gmultiples_eq_closure]
-theorem gpowers_eq_closure {a : α} : gpowers a = closure {a} :=
+theorem gpowers_eq_closure {a : G} : gpowers a = closure {a} :=
 subset.antisymm
   (gpowers_subset $ mem_closure $ by simp)
   (closure_subset $ by simp [mem_gpowers])
@@ -544,10 +543,10 @@ subset.antisymm
 end group
 
 namespace is_subgroup
-variable [group α]
+variable [group G]
 
 @[to_additive]
-lemma trivial_eq_closure : trivial α = group.closure ∅ :=
+lemma trivial_eq_closure : trivial G = group.closure ∅ :=
 subset.antisymm
   (by simp [set.subset_def, is_submonoid.one_mem])
   (group.closure_subset $ by simp)
@@ -558,40 +557,40 @@ end is_subgroup
 elements of s. It is the smallest normal subgroup containing s. -/
 
 namespace group
-variables {s : set α} [group α]
+variables {s : set G} [group G]
 
 /-- Given an element a, conjugates a is the set of conjugates. -/
-def conjugates (a : α) : set α := {b | is_conj a b}
+def conjugates (a : G) : set G := {b | is_conj a b}
 
-lemma mem_conjugates_self {a : α} : a ∈ conjugates a := is_conj_refl _
+lemma mem_conjugates_self {a : G} : a ∈ conjugates a := is_conj_refl _
 
 /-- Given a set s, conjugates_of_set s is the set of all conjugates of
 the elements of s. -/
-def conjugates_of_set (s : set α) : set α := ⋃ a ∈ s, conjugates a
+def conjugates_of_set (s : set G) : set G := ⋃ a ∈ s, conjugates a
 
-lemma mem_conjugates_of_set_iff {x : α} : x ∈ conjugates_of_set s ↔ ∃ a ∈ s, is_conj a x :=
+lemma mem_conjugates_of_set_iff {x : G} : x ∈ conjugates_of_set s ↔ ∃ a ∈ s, is_conj a x :=
 set.mem_bUnion_iff
 
 theorem subset_conjugates_of_set : s ⊆ conjugates_of_set s :=
-λ (x : α) (h : x ∈ s), mem_conjugates_of_set_iff.2 ⟨x, h, is_conj_refl _⟩
+λ (x : G) (h : x ∈ s), mem_conjugates_of_set_iff.2 ⟨x, h, is_conj_refl _⟩
 
-theorem conjugates_of_set_mono {s t : set α} (h : s ⊆ t) :
+theorem conjugates_of_set_mono {s t : set G} (h : s ⊆ t) :
   conjugates_of_set s ⊆ conjugates_of_set t :=
 set.bUnion_subset_bUnion_left h
 
-lemma conjugates_subset {t : set α} [normal_subgroup t] {a : α} (h : a ∈ t) : conjugates a ⊆ t :=
+lemma conjugates_subset {t : set G} [normal_subgroup t] {a : G} (h : a ∈ t) : conjugates a ⊆ t :=
 λ x ⟨c,w⟩,
 begin
   have H := normal_subgroup.normal a h c,
   rwa ←w,
 end
 
-theorem conjugates_of_set_subset {s t : set α} [normal_subgroup t] (h : s ⊆ t) :
+theorem conjugates_of_set_subset {s t : set G} [normal_subgroup t] (h : s ⊆ t) :
   conjugates_of_set s ⊆ t :=
 set.bUnion_subset (λ x H, conjugates_subset (h H))
 
 /-- The set of conjugates of s is closed under conjugation. -/
-lemma conj_mem_conjugates_of_set {x c : α} :
+lemma conj_mem_conjugates_of_set {x c : G} :
   x ∈ conjugates_of_set s → (c * x * c⁻¹ ∈ conjugates_of_set s) :=
 λ H,
 begin
@@ -601,7 +600,7 @@ end
 
 /-- The normal closure of a set s is the subgroup closure of all the conjugates of
 elements of s. It is the smallest normal subgroup containing s. -/
-def normal_closure (s : set α) : set α := closure (conjugates_of_set s)
+def normal_closure (s : set G) : set G := closure (conjugates_of_set s)
 
 theorem conjugates_of_set_subset_normal_closure : conjugates_of_set s ⊆ normal_closure s :=
 subset_closure
@@ -610,7 +609,7 @@ theorem subset_normal_closure : s ⊆ normal_closure s :=
 set.subset.trans subset_conjugates_of_set conjugates_of_set_subset_normal_closure
 
 /-- The normal closure of a set is a subgroup. -/
-instance normal_closure.is_subgroup (s : set α) : is_subgroup (normal_closure s) :=
+instance normal_closure.is_subgroup (s : set G) : is_subgroup (normal_closure s) :=
 closure.is_subgroup (conjugates_of_set s)
 
 /-- The normal closure of s is a normal subgroup. -/
@@ -627,7 +626,7 @@ begin
 end ⟩
 
 /-- The normal closure of s is the smallest normal subgroup containing s. -/
-theorem normal_closure_subset {s t : set α} [normal_subgroup t] (h : s ⊆ t) :
+theorem normal_closure_subset {s t : set G} [normal_subgroup t] (h : s ⊆ t) :
   normal_closure s ⊆ t :=
 λ a w,
 begin
@@ -638,42 +637,43 @@ begin
   {exact is_submonoid.mul_mem ihx ihy}
 end
 
-lemma normal_closure_subset_iff {s t : set α} [normal_subgroup t] : s ⊆ t ↔ normal_closure s ⊆ t :=
+lemma normal_closure_subset_iff {s t : set G} [normal_subgroup t] : s ⊆ t ↔ normal_closure s ⊆ t :=
 ⟨normal_closure_subset, set.subset.trans (subset_normal_closure)⟩
 
-theorem normal_closure_mono {s t : set α} : s ⊆ t → normal_closure s ⊆ normal_closure t :=
+theorem normal_closure_mono {s t : set G} : s ⊆ t → normal_closure s ⊆ normal_closure t :=
 λ h, normal_closure_subset (set.subset.trans h (subset_normal_closure))
 
 end group
 
 section simple_group
 
-class simple_group (α : Type*) [group α] : Prop :=
-(simple : ∀ (N : set α) [normal_subgroup N], N = is_subgroup.trivial α ∨ N = set.univ)
+class simple_group (G : Type*) [group G] : Prop :=
+(simple : ∀ (N : set G) [normal_subgroup N], N = is_subgroup.trivial G ∨ N = set.univ)
 
-class simple_add_group (α : Type*) [add_group α] : Prop :=
-(simple : ∀ (N : set α) [normal_add_subgroup N], N = is_add_subgroup.trivial α ∨ N = set.univ)
+class simple_add_group (A : Type*) [add_group A] : Prop :=
+(simple : ∀ (N : set A) [normal_add_subgroup N], N = is_add_subgroup.trivial A ∨ N = set.univ)
 
 attribute [to_additive simple_add_group] simple_group
 
-theorem additive.simple_add_group_iff [group α] :
-  simple_add_group (additive α) ↔ simple_group α :=
+theorem additive.simple_add_group_iff [group G] :
+  simple_add_group (additive G) ↔ simple_group G :=
 ⟨λ hs, ⟨λ N h, @simple_add_group.simple _ _ hs _ (by exactI additive.normal_add_subgroup_iff.2 h)⟩,
   λ hs, ⟨λ N h, @simple_group.simple _ _ hs _ (by exactI additive.normal_add_subgroup_iff.1 h)⟩⟩
 
-instance additive.simple_add_group [group α] [simple_group α] :
-  simple_add_group (additive α) := additive.simple_add_group_iff.2 (by apply_instance)
+instance additive.simple_add_group [group G] [simple_group G] :
+  simple_add_group (additive G) := additive.simple_add_group_iff.2 (by apply_instance)
 
-theorem multiplicative.simple_group_iff [add_group α] :
-  simple_group (multiplicative α) ↔ simple_add_group α :=
+theorem multiplicative.simple_group_iff [add_group A] :
+  simple_group (multiplicative A) ↔ simple_add_group A :=
 ⟨λ hs, ⟨λ N h, @simple_group.simple _ _ hs _ (by exactI multiplicative.normal_subgroup_iff.2 h)⟩,
   λ hs, ⟨λ N h, @simple_add_group.simple _ _ hs _ (by exactI multiplicative.normal_subgroup_iff.1 h)⟩⟩
 
-instance multiplicative.simple_group [add_group α] [simple_add_group α] :
-simple_group (multiplicative α) := multiplicative.simple_group_iff.2 (by apply_instance)
+instance multiplicative.simple_group [add_group A] [simple_add_group A] :
+simple_group (multiplicative A) := multiplicative.simple_group_iff.2 (by apply_instance)
 
-lemma simple_group_of_surjective [group α] [group β] [simple_group α] (f : α → β)
-  [is_group_hom f] (hf : function.surjective f) : simple_group β :=
+@[to_additive simple_add_group_of_surjective]
+lemma simple_group_of_surjective [group G] [group H] [simple_group G] (f : G → H)
+  [is_group_hom f] (hf : function.surjective f) : simple_group H :=
 ⟨λ H iH, have normal_subgroup (f ⁻¹' H), by resetI; apply_instance,
   begin
     resetI,
@@ -688,11 +688,5 @@ lemma simple_group_of_surjective [group α] [group β] [simple_group α] (f : α
       rw ← hy,
       exact h y }
   end⟩
-
-lemma simple_add_group_of_surjective [add_group α] [add_group β] [simple_add_group α] (f : α → β)
-  [is_add_group_hom f] (hf : function.surjective f) : simple_add_group β :=
-multiplicative.simple_group_iff.1 (@simple_group_of_surjective (multiplicative α) (multiplicative β) _ _ _ f _ hf)
-
-attribute [to_additive simple_add_group_of_surjective] simple_group_of_surjective
 
 end simple_group

--- a/src/group_theory/submonoid.lean
+++ b/src/group_theory/submonoid.lean
@@ -33,57 +33,57 @@ membership of a submonoid's underlying set.
 submonoid, submonoids, is_submonoid
 -/
 
-variables {α : Type*} [monoid α] {s : set α}
-variables {β : Type*} [add_monoid β] {t : set β}
+variables {M : Type*} [monoid M] {s : set M}
+variables {A : Type*} [add_monoid A] {t : set A}
 
 /-- `s` is an additive submonoid: a set containing 0 and closed under addition. -/
-class is_add_submonoid (s : set β) : Prop :=
-(zero_mem : (0:β) ∈ s)
+class is_add_submonoid (s : set A) : Prop :=
+(zero_mem : (0:A) ∈ s)
 (add_mem {a b} : a ∈ s → b ∈ s → a + b ∈ s)
 
 /-- `s` is a submonoid: a set containing 1 and closed under multiplication. -/
 @[to_additive is_add_submonoid]
-class is_submonoid (s : set α) : Prop :=
-(one_mem : (1:α) ∈ s)
+class is_submonoid (s : set M) : Prop :=
+(one_mem : (1:M) ∈ s)
 (mul_mem {a b} : a ∈ s → b ∈ s → a * b ∈ s)
 
 instance additive.is_add_submonoid
-  (s : set α) : ∀ [is_submonoid s], @is_add_submonoid (additive α) _ s
+  (s : set M) : ∀ [is_submonoid s], @is_add_submonoid (additive M) _ s
 | ⟨h₁, h₂⟩ := ⟨h₁, @h₂⟩
 
 theorem additive.is_add_submonoid_iff
-  {s : set α} : @is_add_submonoid (additive α) _ s ↔ is_submonoid s :=
+  {s : set M} : @is_add_submonoid (additive M) _ s ↔ is_submonoid s :=
 ⟨λ ⟨h₁, h₂⟩, ⟨h₁, @h₂⟩, λ h, by resetI; apply_instance⟩
 
 instance multiplicative.is_submonoid
-  (s : set β) : ∀ [is_add_submonoid s], @is_submonoid (multiplicative β) _ s
+  (s : set A) : ∀ [is_add_submonoid s], @is_submonoid (multiplicative A) _ s
 | ⟨h₁, h₂⟩ := ⟨h₁, @h₂⟩
 
 theorem multiplicative.is_submonoid_iff
-  {s : set β} : @is_submonoid (multiplicative β) _ s ↔ is_add_submonoid s :=
+  {s : set A} : @is_submonoid (multiplicative A) _ s ↔ is_add_submonoid s :=
 ⟨λ ⟨h₁, h₂⟩, ⟨h₁, @h₂⟩, λ h, by resetI; apply_instance⟩
 
-/-- The intersection of two submonoids of a monoid `α` is a submonoid of `α`. -/
-@[to_additive "The intersection of two `add_submonoid`s of an `add_monoid` `α` is an `add_submonoid` of α."]
-instance is_submonoid.inter (s₁ s₂ : set α) [is_submonoid s₁] [is_submonoid s₂] :
+/-- The intersection of two submonoids of a monoid `M` is a submonoid of `M`. -/
+@[to_additive "The intersection of two `add_submonoid`s of an `add_monoid` `M` is an `add_submonoid` of M."]
+instance is_submonoid.inter (s₁ s₂ : set M) [is_submonoid s₁] [is_submonoid s₂] :
   is_submonoid (s₁ ∩ s₂) :=
 { one_mem := ⟨is_submonoid.one_mem _, is_submonoid.one_mem _⟩,
   mul_mem := λ x y hx hy,
     ⟨is_submonoid.mul_mem hx.1 hy.1, is_submonoid.mul_mem hx.2 hy.2⟩ }
 
-/-- The intersection of an indexed set of submonoids of a monoid `α` is a submonoid of `α`. -/
-@[to_additive "The intersection of an indexed set of `add_submonoid`s of an `add_monoid` `α` is an `add_submonoid` of `α`."]
-instance is_submonoid.Inter {ι : Sort*} (s : ι → set α) [h : ∀ y : ι, is_submonoid (s y)] :
+/-- The intersection of an indexed set of submonoids of a monoid `M` is a submonoid of `M`. -/
+@[to_additive "The intersection of an indexed set of `add_submonoid`s of an `add_monoid` `M` is an `add_submonoid` of `M`."]
+instance is_submonoid.Inter {ι : Sort*} (s : ι → set M) [h : ∀ y : ι, is_submonoid (s y)] :
   is_submonoid (set.Inter s) :=
 { one_mem := set.mem_Inter.2 $ λ y, is_submonoid.one_mem (s y),
   mul_mem := λ x₁ x₂ h₁ h₂, set.mem_Inter.2 $
     λ y, is_submonoid.mul_mem (set.mem_Inter.1 h₁ y) (set.mem_Inter.1 h₂ y) }
 
-/-- The union of an indexed, directed, nonempty set of submonoids of a monoid `α` is a submonoid
-    of `α`. -/
-@[to_additive is_add_submonoid_Union_of_directed "The union of an indexed, directed, nonempty set of `add_submonoid`s of an `add_monoid` `α` is an `add_submonoid` of `α`. "]
+/-- The union of an indexed, directed, nonempty set of submonoids of a monoid `M` is a submonoid
+    of `M`. -/
+@[to_additive is_add_submonoid_Union_of_directed "The union of an indexed, directed, nonempty set of `add_submonoid`s of an `add_monoid` `M` is an `add_submonoid` of `M`. "]
 lemma is_submonoid_Union_of_directed {ι : Type*} [hι : nonempty ι]
-  (s : ι → set α) [∀ i, is_submonoid (s i)]
+  (s : ι → set M) [∀ i, is_submonoid (s i)]
   (directed : ∀ i j, ∃ k, s i ⊆ s k ∧ s j ⊆ s k) :
   is_submonoid (⋃i, s i) :=
 { one_mem := let ⟨i⟩ := hι in set.mem_Union.2 ⟨i, is_submonoid.one_mem _⟩,
@@ -96,88 +96,88 @@ lemma is_submonoid_Union_of_directed {ι : Type*} [hι : nonempty ι]
 section powers
 
 /-- The set of natural number powers `1, x, x², ...` of an element `x` of a monoid. -/
-def powers (x : α) : set α := {y | ∃ n:ℕ, x^n = y}
+def powers (x : M) : set M := {y | ∃ n:ℕ, x^n = y}
 /-- The set of natural number multiples `0, x, 2x, ...` of an element `x` of an `add_monoid`. -/
-def multiples (x : β) : set β := {y | ∃ n:ℕ, add_monoid.smul n x = y}
+def multiples (x : A) : set A := {y | ∃ n:ℕ, add_monoid.smul n x = y}
 attribute [to_additive multiples] powers
 
 /-- 1 is in the set of natural number powers of an element of a monoid. -/
-lemma powers.one_mem {x : α} : (1 : α) ∈ powers x := ⟨0, pow_zero _⟩
+lemma powers.one_mem {x : M} : (1 : M) ∈ powers x := ⟨0, pow_zero _⟩
 
 /-- 0 is in the set of natural number multiples of an element of an `add_monoid`. -/
-lemma multiples.zero_mem {x : β} : (0 : β) ∈ multiples x := ⟨0, add_monoid.zero_smul _⟩
+lemma multiples.zero_mem {x : A} : (0 : A) ∈ multiples x := ⟨0, add_monoid.zero_smul _⟩
 attribute [to_additive] powers.one_mem
 
 /-- An element of a monoid is in the set of that element's natural number powers. -/
-lemma powers.self_mem {x : α} : x ∈ powers x := ⟨1, pow_one _⟩
+lemma powers.self_mem {x : M} : x ∈ powers x := ⟨1, pow_one _⟩
 
 /-- An element of an `add_monoid` is in the set of that element's natural number multiples. -/
-lemma multiples.self_mem {x : β} : x ∈ multiples x := ⟨1, add_monoid.one_smul _⟩
+lemma multiples.self_mem {x : A} : x ∈ multiples x := ⟨1, add_monoid.one_smul _⟩
 attribute [to_additive] powers.self_mem
 
 /-- The set of natural number powers of an element of a monoid is closed under multiplication. -/
-lemma powers.mul_mem {x y z : α} : (y ∈ powers x) → (z ∈ powers x) → (y * z ∈ powers x) :=
+lemma powers.mul_mem {x y z : M} : (y ∈ powers x) → (z ∈ powers x) → (y * z ∈ powers x) :=
 λ ⟨n₁, h₁⟩ ⟨n₂, h₂⟩, ⟨n₁ + n₂, by simp only [pow_add, *]⟩
 
 /-- The set of natural number multiples of an element of an `add_monoid` is closed under
     addition. -/
-lemma multiples.add_mem {x y z : β} :
+lemma multiples.add_mem {x y z : A} :
   (y ∈ multiples x) → (z ∈ multiples x) → (y + z ∈ multiples x) :=
-@powers.mul_mem (multiplicative β) _ _ _ _
+@powers.mul_mem (multiplicative A) _ _ _ _
 attribute [to_additive] powers.mul_mem
 
-/-- The set of natural number powers of an element of a monoid `α` is a submonoid of `α`. -/
-@[to_additive is_add_submonoid "The set of natural number multiples of an element of an `add_monoid` `α` is an `add_submonoid` of `α`."]
-instance powers.is_submonoid (x : α) : is_submonoid (powers x) :=
+/-- The set of natural number powers of an element of a monoid `M` is a submonoid of `M`. -/
+@[to_additive is_add_submonoid "The set of natural number multiples of an element of an `add_monoid` `M` is an `add_submonoid` of `M`."]
+instance powers.is_submonoid (x : M) : is_submonoid (powers x) :=
 { one_mem := powers.one_mem,
   mul_mem := λ y z, powers.mul_mem }
 
 /-- A monoid is a submonoid of itself. -/
 @[to_additive is_add_submonoid "An `add_monoid` is an `add_submonoid` of itself."]
-instance univ.is_submonoid : is_submonoid (@set.univ α) := by split; simp
+instance univ.is_submonoid : is_submonoid (@set.univ M) := by split; simp
 
 /-- The preimage of a submonoid under a monoid hom is a submonoid of the domain. -/
 @[to_additive is_add_submonoid "The preimage of an `add_submonoid` under an `add_monoid` hom is an `add_submonoid` of the domain."]
-instance preimage.is_submonoid {γ : Type*} [monoid γ] (f : α → γ) [is_monoid_hom f]
-  (s : set γ) [is_submonoid s] : is_submonoid (f ⁻¹' s) :=
+instance preimage.is_submonoid {N : Type*} [monoid N] (f : M → N) [is_monoid_hom f]
+  (s : set N) [is_submonoid s] : is_submonoid (f ⁻¹' s) :=
 { one_mem := show f 1 ∈ s, by rw is_monoid_hom.map_one f; exact is_submonoid.one_mem s,
   mul_mem := λ a b (ha : f a ∈ s) (hb : f b ∈ s),
     show f (a * b) ∈ s, by rw is_monoid_hom.map_mul f; exact is_submonoid.mul_mem ha hb }
 
 /-- The image of a submonoid under a monoid hom is a submonoid of the codomain. -/
 @[instance, to_additive is_add_submonoid "The image of an `add_submonoid` under an `add_monoid` hom is an `add_submonoid` of the codomain."]
-lemma image.is_submonoid {γ : Type*} [monoid γ] (f : α → γ) [is_monoid_hom f]
-  (s : set α) [is_submonoid s] : is_submonoid (f '' s) :=
+lemma image.is_submonoid {γ : Type*} [monoid γ] (f : M → γ) [is_monoid_hom f]
+  (s : set M) [is_submonoid s] : is_submonoid (f '' s) :=
 { one_mem := ⟨1, is_submonoid.one_mem s, is_monoid_hom.map_one f⟩,
   mul_mem := λ a b ⟨x, hx⟩ ⟨y, hy⟩, ⟨x * y, is_submonoid.mul_mem hx.1 hy.1,
     by rw [is_monoid_hom.map_mul f, hx.2, hy.2]⟩ }
 
 /-- The image of a monoid hom is a submonoid of the codomain. -/
 @[to_additive is_add_submonoid "The image of an `add_monoid` hom is an `add_submonoid` of the codomain."]
-instance range.is_submonoid {γ : Type*} [monoid γ] (f : α → γ) [is_monoid_hom f] :
+instance range.is_submonoid {γ : Type*} [monoid γ] (f : M → γ) [is_monoid_hom f] :
   is_submonoid (set.range f) :=
 by rw ← set.image_univ; apply_instance
 
 /-- Submonoids are closed under natural powers. -/
-lemma is_submonoid.pow_mem {a : α} [is_submonoid s] (h : a ∈ s) : ∀ {n : ℕ}, a ^ n ∈ s
+lemma is_submonoid.pow_mem {a : M} [is_submonoid s] (h : a ∈ s) : ∀ {n : ℕ}, a ^ n ∈ s
 | 0 := is_submonoid.one_mem s
 | (n + 1) := is_submonoid.mul_mem h is_submonoid.pow_mem
 
 /-- An `add_submonoid` is closed under multiplication by naturals. -/
-lemma is_add_submonoid.smul_mem {a : β} [is_add_submonoid t] :
+lemma is_add_submonoid.smul_mem {a : A} [is_add_submonoid t] :
   ∀ (h : a ∈ t) {n : ℕ}, add_monoid.smul n a ∈ t :=
-@is_submonoid.pow_mem (multiplicative β) _ _ _ _
+@is_submonoid.pow_mem (multiplicative A) _ _ _ _
 attribute [to_additive smul_mem] is_submonoid.pow_mem
 
 /-- The set of natural number powers of an element of a submonoid is a subset of the submonoid. -/
-lemma is_submonoid.power_subset {a : α} [is_submonoid s] (h : a ∈ s) : powers a ⊆ s :=
+lemma is_submonoid.power_subset {a : M} [is_submonoid s] (h : a ∈ s) : powers a ⊆ s :=
 assume x ⟨n, hx⟩, hx ▸ is_submonoid.pow_mem h
 
 /-- The set of natural number multiples of an element of an `add_submonoid` is a subset of the
     `add_submonoid`. -/
-lemma is_add_submonoid.multiple_subset {a : β} [is_add_submonoid t] :
+lemma is_add_submonoid.multiple_subset {a : A} [is_add_submonoid t] :
   a ∈ t → multiples a ⊆ t :=
-@is_submonoid.power_subset (multiplicative β) _ _ _ _
+@is_submonoid.power_subset (multiplicative A) _ _ _ _
 attribute [to_additive multiple_subset] is_submonoid.power_subset
 
 end powers
@@ -186,7 +186,7 @@ namespace is_submonoid
 
 /-- The product of a list of elements of a submonoid is an element of the submonoid. -/
 @[to_additive "The sum of a list of elements of an `add_submonoid` is an element of the `add_submonoid`."]
-lemma list_prod_mem [is_submonoid s] : ∀{l : list α}, (∀x∈l, x ∈ s) → l.prod ∈ s
+lemma list_prod_mem [is_submonoid s] : ∀{l : list M}, (∀x∈l, x ∈ s) → l.prod ∈ s
 | []     h := one_mem s
 | (a::l) h :=
   suffices a * l.prod ∈ s, by simpa,
@@ -195,7 +195,7 @@ lemma list_prod_mem [is_submonoid s] : ∀{l : list α}, (∀x∈l, x ∈ s) →
 
 /-- The product of a multiset of elements of a submonoid of a `comm_monoid` is an element of the submonoid. -/
 @[to_additive "The sum of a multiset of elements of an `add_submonoid` of an `add_comm_monoid` is an element of the `add_submonoid`. "]
-lemma multiset_prod_mem {α} [comm_monoid α] (s : set α) [is_submonoid s] (m : multiset α) :
+lemma multiset_prod_mem {M} [comm_monoid M] (s : set M) [is_submonoid s] (m : multiset M) :
   (∀a∈m, a ∈ s) → m.prod ∈ s :=
 begin
   refine quotient.induction_on m (assume l hl, _),
@@ -205,8 +205,8 @@ end
 
 /-- The product of elements of a submonoid of a `comm_monoid` indexed by a `finset` is an element of the submonoid. -/
 @[to_additive "The sum of elements of an `add_submonoid` of an `add_comm_monoid` indexed by a `finset` is an element of the `add_submonoid`."]
-lemma finset_prod_mem {α β} [comm_monoid α] (s : set α) [is_submonoid s] (f : β → α) :
-  ∀(t : finset β), (∀b∈t, f b ∈ s) → t.prod f ∈ s
+lemma finset_prod_mem {M A} [comm_monoid M] (s : set M) [is_submonoid s] (f : A → M) :
+  ∀(t : finset A), (∀b∈t, f b ∈ s) → t.prod f ∈ s
 | ⟨m, hm⟩ hs :=
   begin
     refine multiset_prod_mem s _ _,
@@ -222,7 +222,7 @@ end is_submonoid
 
 /-- Submonoids are themselves monoids. -/
 @[to_additive add_monoid "An `add_submonoid` is itself an `add_monoid`."]
-instance subtype.monoid {s : set α} [is_submonoid s] : monoid s :=
+instance subtype.monoid {s : set M} [is_submonoid s] : monoid s :=
 { one := ⟨1, is_submonoid.one_mem s⟩,
   mul := λ x y, ⟨x * y, is_submonoid.mul_mem x.2 y.2⟩,
   mul_one := λ x, subtype.eq $ mul_one x.1,
@@ -231,44 +231,44 @@ instance subtype.monoid {s : set α} [is_submonoid s] : monoid s :=
 
 /-- Submonoids of commutative monoids are themselves commutative monoids. -/
 @[to_additive add_comm_monoid "An `add_submonoid` of a commutative `add_monoid` is itself a commutative `add_monoid`. "]
-instance subtype.comm_monoid {α} [comm_monoid α] {s : set α} [is_submonoid s] : comm_monoid s :=
+instance subtype.comm_monoid {M} [comm_monoid M] {s : set M} [is_submonoid s] : comm_monoid s :=
 { mul_comm := λ x y, subtype.eq $ mul_comm x.1 y.1,
   .. subtype.monoid }
 
 /-- Submonoids inherit the 1 of the monoid. -/
 @[simp, to_additive "An `add_submonoid` inherits the 0 of the `add_monoid`. "]
-lemma is_submonoid.coe_one [is_submonoid s] : ((1 : s) : α) = 1 := rfl
+lemma is_submonoid.coe_one [is_submonoid s] : ((1 : s) : M) = 1 := rfl
 
 /-- Submonoids inherit the multiplication of the monoid. -/
 @[simp, to_additive "An `add_submonoid` inherits the addition of the `add_monoid`. "]
-lemma is_submonoid.coe_mul [is_submonoid s] (a b : s) : ((a * b : s) : α) = a * b := rfl
+lemma is_submonoid.coe_mul [is_submonoid s] (a b : s) : ((a * b : s) : M) = a * b := rfl
 
 /-- Submonoids inherit the exponentiation by naturals of the monoid. -/
 @[simp] lemma is_submonoid.coe_pow [is_submonoid s] (a : s) (n : ℕ) :
-  ((a ^ n : s) : α) = a ^ n :=
+  ((a ^ n : s) : M) = a ^ n :=
 by induction n; simp [*, pow_succ]
 
 /-- An `add_submonoid` inherits the multiplication by naturals of the `add_monoid`. -/
-@[simp] lemma is_add_submonoid.smul_coe {β : Type*} [add_monoid β] {s : set β}
-  [is_add_submonoid s] (a : s) (n : ℕ) : ((add_monoid.smul n a : s) : β) = add_monoid.smul n a :=
+@[simp] lemma is_add_submonoid.smul_coe {A : Type*} [add_monoid A] {s : set A}
+  [is_add_submonoid s] (a : s) (n : ℕ) : ((add_monoid.smul n a : s) : A) = add_monoid.smul n a :=
 by {induction n, refl, simp [*, succ_smul]}
 
 attribute [to_additive smul_coe] is_submonoid.coe_pow
 
 /-- The natural injection from a submonoid into the monoid is a monoid hom. -/
 @[to_additive is_add_monoid_hom "The natural injection from an `add_submonoid` into the `add_monoid` is an `add_monoid` hom. "]
-instance subtype_val.is_monoid_hom [is_submonoid s] : is_monoid_hom (subtype.val : s → α) :=
+instance subtype_val.is_monoid_hom [is_submonoid s] : is_monoid_hom (subtype.val : s → M) :=
 { map_one := rfl, map_mul := λ _ _, rfl }
 
 /-- The natural injection from a submonoid into the monoid is a monoid hom. -/
 @[to_additive is_add_monoid_hom "The natural injection from an `add_submonoid` into the `add_monoid` is an `add_monoid` hom. "]
-instance coe.is_monoid_hom [is_submonoid s] : is_monoid_hom (coe : s → α) :=
+instance coe.is_monoid_hom [is_submonoid s] : is_monoid_hom (coe : s → M) :=
 subtype_val.is_monoid_hom
 
-/-- Given a monoid hom `f : γ → α` whose image is contained in a submonoid `s`, the induced map
+/-- Given a monoid hom `f : γ → M` whose image is contained in a submonoid `s`, the induced map
     from `γ` to `s` is a monoid hom. -/
-@[to_additive is_add_monoid_hom "Given an `add_monoid` hom `f : γ → α` whose image is contained in an `add_submonoid` s, the induced map from `γ` to `s` is an `add_monoid` hom."]
-instance subtype_mk.is_monoid_hom {γ : Type*} [monoid γ] [is_submonoid s] (f : γ → α)
+@[to_additive is_add_monoid_hom "Given an `add_monoid` hom `f : γ → M` whose image is contained in an `add_submonoid` s, the induced map from `γ` to `s` is an `add_monoid` hom."]
+instance subtype_mk.is_monoid_hom {γ : Type*} [monoid γ] [is_submonoid s] (f : γ → M)
   [is_monoid_hom f] (h : ∀ x, f x ∈ s) : is_monoid_hom (λ x, (⟨f x, h x⟩ : s)) :=
 { map_one := subtype.eq (is_monoid_hom.map_one f),
   map_mul := λ x y, subtype.eq (is_monoid_hom.map_mul f x y) }
@@ -276,7 +276,7 @@ instance subtype_mk.is_monoid_hom {γ : Type*} [monoid γ] [is_submonoid s] (f :
 /-- Given two submonoids `s` and `t` such that `s ⊆ t`, the natural injection from `s` into `t` is
     a monoid hom. -/
 @[to_additive is_add_monoid_hom "Given two `add_submonoid`s `s` and `t` such that `s ⊆ t`, the natural injection from `s` into `t` is an `add_monoid` hom."]
-instance set_inclusion.is_monoid_hom (t : set α) [is_submonoid s] [is_submonoid t] (h : s ⊆ t) :
+instance set_inclusion.is_monoid_hom (t : set M) [is_submonoid s] [is_submonoid t] (h : s ⊆ t) :
   is_monoid_hom (set.inclusion h) :=
 subtype_mk.is_monoid_hom _ _
 
@@ -284,10 +284,10 @@ namespace add_monoid
 
 /-- The inductively defined membership predicate for the submonoid generated by a subset of a
     monoid. -/
-inductive in_closure (s : set β) : β → Prop
-| basic {a : β} : a ∈ s → in_closure a
+inductive in_closure (s : set A) : A → Prop
+| basic {a : A} : a ∈ s → in_closure a
 | zero : in_closure 0
-| add {a b : β} : in_closure a → in_closure b → in_closure (a + b)
+| add {a b : A} : in_closure a → in_closure b → in_closure (a + b)
 
 end add_monoid
 
@@ -295,10 +295,10 @@ namespace monoid
 
 /-- The inductively defined membership predicate for the `add_submonoid` generated by a subset of an
     add_monoid. -/
-inductive in_closure (s : set α) : α → Prop
-| basic {a : α} : a ∈ s → in_closure a
+inductive in_closure (s : set M) : M → Prop
+| basic {a : M} : a ∈ s → in_closure a
 | one : in_closure 1
-| mul {a b : α} : in_closure a → in_closure b → in_closure (a * b)
+| mul {a b : M} : in_closure a → in_closure b → in_closure (a * b)
 
 attribute [to_additive] monoid.in_closure
 attribute [to_additive] monoid.in_closure.one
@@ -306,39 +306,39 @@ attribute [to_additive] monoid.in_closure.mul
 
 /-- The inductively defined submonoid generated by a subset of a monoid. -/
 @[to_additive "The inductively defined `add_submonoid` genrated by a subset of an `add_monoid`."]
-def closure (s : set α) : set α := {a | in_closure s a }
+def closure (s : set M) : set M := {a | in_closure s a }
 
 @[to_additive is_add_submonoid]
-instance closure.is_submonoid (s : set α) : is_submonoid (closure s) :=
+instance closure.is_submonoid (s : set M) : is_submonoid (closure s) :=
 { one_mem := in_closure.one s, mul_mem := assume a b, in_closure.mul }
 
 /-- A subset of a monoid is contained in the submonoid it generates. -/
 @[to_additive "A subset of an `add_monoid` is contained in the `add_submonoid` it generates."]
-theorem subset_closure {s : set α} : s ⊆ closure s :=
+theorem subset_closure {s : set M} : s ⊆ closure s :=
 assume a, in_closure.basic
 
 /-- The submonoid generated by a set is contained in any submonoid that contains the set. -/
 @[to_additive "The `add_submonoid` generated by a set is contained in any `add_submonoid` that contains the set."]
-theorem closure_subset {s t : set α} [is_submonoid t] (h : s ⊆ t) : closure s ⊆ t :=
+theorem closure_subset {s t : set M} [is_submonoid t] (h : s ⊆ t) : closure s ⊆ t :=
 assume a ha, by induction ha; simp [h _, *, is_submonoid.one_mem, is_submonoid.mul_mem]
 
-/-- Given subsets `t` and `s` of a monoid `α`, if `s ⊆ t`, the submonoid of `α` generated by `s` is
+/-- Given subsets `t` and `s` of a monoid `M`, if `s ⊆ t`, the submonoid of `M` generated by `s` is
     contained in the submonoid generated by `t`. -/
-@[to_additive "Given subsets `t` and `s` of an `add_monoid α`, if `s ⊆ t`, the `add_submonoid` of `M` generated by `s` is contained in the `add_submonoid` generated by `t`."]
-theorem closure_mono {s t : set α} (h : s ⊆ t) : closure s ⊆ closure t :=
+@[to_additive "Given subsets `t` and `s` of an `add_monoid M`, if `s ⊆ t`, the `add_submonoid` of `M` generated by `s` is contained in the `add_submonoid` generated by `t`."]
+theorem closure_mono {s t : set M} (h : s ⊆ t) : closure s ⊆ closure t :=
 closure_subset $ set.subset.trans h subset_closure
 
 /-- The submonoid generated by an element of a monoid equals the set of natural number powers of
     the element. -/
 @[to_additive "The `add_submonoid` generated by an element of an `add_monoid` equals the set of natural number multiples of the element."]
-theorem closure_singleton {x : α} : closure ({x} : set α) = powers x :=
+theorem closure_singleton {x : M} : closure ({x} : set M) = powers x :=
 set.eq_of_subset_of_subset (closure_subset $ set.singleton_subset_iff.2 $ powers.self_mem) $
   is_submonoid.power_subset $ set.singleton_subset_iff.1 $ subset_closure
 
 /-- The image under a monoid hom of the submonoid generated by a set equals the submonoid generated
     by the image of the set under the monoid hom. -/
 @[to_additive "The image under an `add_monoid` hom of the `add_submonoid` generated by a set equals the `add_submonoid` generated by the image of the set under the `add_monoid` hom."]
-lemma image_closure {β : Type*} [monoid β] (f : α → β) [is_monoid_hom f] (s : set α) :
+lemma image_closure {A : Type*} [monoid A] (f : M → A) [is_monoid_hom f] (s : set M) :
   f '' closure s = closure (f '' s) :=
 le_antisymm
   begin
@@ -350,11 +350,11 @@ le_antisymm
   end
   (closure_subset $ set.image_subset _ subset_closure)
 
-/-- Given an element `a` of the submonoid of a monoid `α` generated by a set `s`, there exists a list of
+/-- Given an element `a` of the submonoid of a monoid `M` generated by a set `s`, there exists a list of
     elements of `s` whose product is `a`. -/
-@[to_additive "Given an element `a` of the `add_submonoid` of an `add_monoid α` generated by a set `s`, there exists a list of elements of `s` whose sum is `a`."]
-theorem exists_list_of_mem_closure {s : set α} {a : α} (h : a ∈ closure s) :
-  (∃l:list α, (∀x∈l, x ∈ s) ∧ l.prod = a) :=
+@[to_additive "Given an element `a` of the `add_submonoid` of an `add_monoid M` generated by a set `s`, there exists a list of elements of `s` whose sum is `a`."]
+theorem exists_list_of_mem_closure {s : set M} {a : M} (h : a ∈ closure s) :
+  (∃l:list M, (∀x∈l, x ∈ s) ∧ l.prod = a) :=
 begin
   induction h,
   case in_closure.basic : a ha { existsi ([a]), simp [ha] },
@@ -368,11 +368,11 @@ begin
   }
 end
 
-/-- Given sets `s, t` of a commutative monoid `α`, `x ∈ α` is in the submonoid of `α` generated by
+/-- Given sets `s, t` of a commutative monoid `M`, `x ∈ M` is in the submonoid of `M` generated by
     `s ∪ t` iff there exists an element of the submonoid generated by `s` and an element of the
     submonoid generated by `t` whose product is `x`. -/
-@[to_additive "Given sets `s, t` of a commutative `add_monoid α`, `x ∈ α` is in the `add_submonoid` of `α` generated by `s ∪ t` iff there exists an element of the `add_submonoid` generated by `s` and an element of the `add_submonoid` generated by `t` whose sum is `x`."]
-theorem mem_closure_union_iff {α : Type*} [comm_monoid α] {s t : set α} {x : α} :
+@[to_additive "Given sets `s, t` of a commutative `add_monoid M`, `x ∈ M` is in the `add_submonoid` of `M` generated by `s ∪ t` iff there exists an element of the `add_submonoid` generated by `s` and an element of the `add_submonoid` generated by `t` whose sum is `x`."]
+theorem mem_closure_union_iff {M : Type*} [comm_monoid M] {s t : set M} {x : M} :
   x ∈ closure (s ∪ t) ↔ ∃ y ∈ closure s, ∃ z ∈ closure t, y * z = x :=
 ⟨λ hx, let ⟨L, HL1, HL2⟩ := exists_list_of_mem_closure hx in HL2 ▸
   list.rec_on L (λ _, ⟨1, is_submonoid.one_mem _, 1, is_submonoid.one_mem _, mul_one _⟩)
@@ -387,52 +387,52 @@ end monoid
 
 -- Bundled submonoids and `add_submonoid`s
 
-/-- A submonoid of a monoid `α` is a subset containing 1 and closed under multiplication. -/
-structure submonoid (α : Type*) [monoid α] :=
-(carrier : set α)
-(one_mem' : (1 : α) ∈ carrier)
+/-- A submonoid of a monoid `M` is a subset containing 1 and closed under multiplication. -/
+structure submonoid (M : Type*) [monoid M] :=
+(carrier : set M)
+(one_mem' : (1 : M) ∈ carrier)
 (mul_mem' {a b} : a ∈ carrier → b ∈ carrier → a * b ∈ carrier)
 
-/-- An additive submonoid of an additive monoid `α` is a subset containing 0 and
+/-- An additive submonoid of an additive monoid `M` is a subset containing 0 and
   closed under addition. -/
-structure add_submonoid (α : Type*) [add_monoid α] :=
-(carrier : set α)
-(zero_mem' : (0 : α) ∈ carrier)
+structure add_submonoid (M : Type*) [add_monoid M] :=
+(carrier : set M)
+(zero_mem' : (0 : M) ∈ carrier)
 (add_mem' {a b} : a ∈ carrier → b ∈ carrier → a + b ∈ carrier)
 
 attribute [to_additive add_submonoid] submonoid
 
-/-- Map from submonoids of monoid `α` to `add_submonoid`s of `additive α`. -/
-def submonoid.to_add_submonoid {α : Type*} [monoid α] (S : submonoid α) :
-  add_submonoid (additive α) :=
+/-- Map from submonoids of monoid `M` to `add_submonoid`s of `additive M`. -/
+def submonoid.to_add_submonoid {M : Type*} [monoid M] (S : submonoid M) :
+  add_submonoid (additive M) :=
 { carrier := S.carrier,
   zero_mem' := S.one_mem',
   add_mem' := S.mul_mem' }
 
-/-- Map from `add_submonoid`s of `additive α` to submonoids of `α`. -/
-def submonoid.of_add_submonoid {α : Type*} [monoid α] (S : add_submonoid (additive α)) :
-  submonoid α :=
+/-- Map from `add_submonoid`s of `additive M` to submonoids of `M`. -/
+def submonoid.of_add_submonoid {M : Type*} [monoid M] (S : add_submonoid (additive M)) :
+  submonoid M :=
 { carrier := S.carrier,
   one_mem' := S.zero_mem',
   mul_mem' := S.add_mem' }
 
-/-- Map from `add_submonoid`s of `add_monoid α` to submonoids of `multiplicative α`. -/
-def add_submonoid.to_submonoid {α : Type*} [add_monoid α] (S : add_submonoid α) :
-  submonoid (multiplicative α) :=
+/-- Map from `add_submonoid`s of `add_monoid M` to submonoids of `multiplicative M`. -/
+def add_submonoid.to_submonoid {M : Type*} [add_monoid M] (S : add_submonoid M) :
+  submonoid (multiplicative M) :=
 { carrier := S.carrier,
   one_mem' := S.zero_mem',
   mul_mem' := S.add_mem' }
 
-/-- Map from submonoids of `multiplicative α` to `add_submonoid`s of `add_monoid α`. -/
-def add_submonoid.of_submonoid {α : Type*} [add_monoid α] (S : submonoid (multiplicative α)) :
-  add_submonoid α :=
+/-- Map from submonoids of `multiplicative M` to `add_submonoid`s of `add_monoid M`. -/
+def add_submonoid.of_submonoid {M : Type*} [add_monoid M] (S : submonoid (multiplicative M)) :
+  add_submonoid M :=
 { carrier := S.carrier,
   zero_mem' := S.one_mem',
   add_mem' := S.mul_mem' }
 
-/-- Submonoids of monoid `α` are isomorphic to additive submonoids of `additive α`. -/
-def submonoid.add_submonoid_equiv (α : Type*) [monoid α] :
-submonoid α ≃ add_submonoid (additive α) :=
+/-- Submonoids of monoid `M` are isomorphic to additive submonoids of `additive M`. -/
+def submonoid.add_submonoid_equiv (M : Type*) [monoid M] :
+submonoid M ≃ add_submonoid (additive M) :=
 { to_fun := submonoid.to_add_submonoid,
   inv_fun := submonoid.of_add_submonoid,
   left_inv := λ x, by cases x; refl,
@@ -440,7 +440,7 @@ submonoid α ≃ add_submonoid (additive α) :=
 
 namespace submonoid
 
-variables {M : Type*} [monoid M] (S : submonoid M)
+variables (S : submonoid M)
 
 @[to_additive]
 instance : has_coe (submonoid M) (set M) := ⟨submonoid.carrier⟩
@@ -556,31 +556,31 @@ end submonoid
 
 namespace add_submonoid
 
-variables {M : Type*} [add_monoid M]  (S : add_submonoid M)
+variables (S : add_submonoid A)
 
 /-- The multiples `0, x, 2x, ...` of an element `x` of an `add_monoid M` are an `add_submonoid`. -/
-def multiples (x : M) : add_submonoid M :=
+def multiples (x : A) : add_submonoid A :=
 { carrier := {y | ∃ n:ℕ, add_monoid.smul n x = y},
   zero_mem' := ⟨0, add_monoid.zero_smul x⟩,
   add_mem' := by rintros x₁ x₂ ⟨n₁, rfl⟩ ⟨n₂, rfl⟩; exact ⟨n₁ + n₂, add_monoid.add_smul _ _ _ ⟩ }
 
 /-- An element `x` of an `add_monoid` is in the `add_submonoid` generated by `x`. -/
-lemma multiples.self_mem {x : M} : x ∈ multiples x := ⟨1, add_monoid.one_smul x⟩
+lemma multiples.self_mem {x : A} : x ∈ multiples x := ⟨1, add_monoid.one_smul x⟩
 
-lemma smul_mem {a : M} (h : a ∈ S) {n : ℕ} : add_monoid.smul n a ∈ S :=
+lemma smul_mem {a : A} (h : a ∈ S) {n : ℕ} : add_monoid.smul n a ∈ S :=
 submonoid.pow_mem (add_submonoid.to_submonoid S) h
 
-lemma multiples_subset {a : M} (h : a ∈ S) : multiples a ≤ S :=
+lemma multiples_subset {a : A} (h : a ∈ S) : multiples a ≤ S :=
 submonoid.powers_subset (add_submonoid.to_submonoid S) h
 
-@[simp] lemma coe_smul (a : S) (n : ℕ) : ((add_monoid.smul n a : S) : M) = add_monoid.smul n a :=
+@[simp] lemma coe_smul (a : S) (n : ℕ) : ((add_monoid.smul n a : S) : A) = add_monoid.smul n a :=
 submonoid.coe_pow (add_submonoid.to_submonoid S) a n
 
 end add_submonoid
 
 namespace submonoid
 
-variables {M : Type*} [monoid M] (S : submonoid M)
+variables (S : submonoid M)
 
 /-- The submonoid `M` of the monoid `M`. -/
 @[to_additive "The `add_submonoid M` of the `add_monoid M`."]
@@ -707,7 +707,7 @@ end submonoid
 
 namespace monoid_hom
 
-variables {M : Type*} [monoid M] (S : submonoid M)
+variables (S : submonoid M)
 
 open submonoid
 
@@ -737,7 +737,7 @@ end monoid_hom
 
 namespace submonoid
 
-variables {M : Type*} [monoid M] (S : submonoid M)
+variables (S : submonoid M)
 
 /-- Product of a list of elements in a submonoid is in the submonoid. -/
 @[to_additive "Sum of a list of elements in an `add_submonoid` is in the `add_submonoid`."]
@@ -776,14 +776,14 @@ end submonoid
 
 namespace monoid_hom
 
-variables {M : Type*} [monoid M] (S : submonoid M)
+variables (S : submonoid M)
 
 /-- Restriction of a monoid hom to a submonoid of the codomain. -/
 @[to_additive "Restriction of an `add_monoid` hom to an `add_submonoid` of the codomain."]
 def subtype_mk {N : Type*} [monoid N] (f : N →* M) (h : ∀ x, f x ∈ S) : N →* S :=
 { to_fun := λ n, ⟨f n, h n⟩,
-  map_one' := subtype.eq (is_monoid_hom.map_one f),
-  map_mul' := λ x y, subtype.eq (is_monoid_hom.map_mul f x y) }
+  map_one' := subtype.eq f.map_one,
+  map_mul' := λ x y, subtype.eq (f.map_mul x y) }
 
 /-- Restriction of a monoid hom to its range. -/
 @[to_additive "Restriction of an `add_monoid` hom to its range."]
@@ -806,7 +806,7 @@ end monoid_hom
 
 namespace monoid
 
-variables {M : Type*} [monoid M] (S : submonoid M)
+variables (S : submonoid M)
 
 open submonoid
 
@@ -901,7 +901,7 @@ open add_submonoid
 
 /-- The `add_submonoid` generated by an element of an `add_monoid` equals the set of natural number
     multiples of the element. -/
-theorem closure'_singleton {x : β} : closure' ({x} : set β) = multiples x :=
+theorem closure'_singleton {x : A} : closure' ({x} : set A) = multiples x :=
 ext' $ set.eq_of_subset_of_subset (closure'_le $ set.singleton_subset_iff.2 multiples.self_mem) $
 multiples_subset _ $ in_closure.basic $ set.mem_singleton x
 
@@ -909,7 +909,7 @@ end add_monoid
 
 namespace mul_equiv
 
-variables {M : Type*} [monoid M] {N : Type*} [monoid N] {S T : submonoid M}
+variables {S T : submonoid M}
 
 /-- Makes the identity isomorphism from a proof two submonoids of a multiplicative
     monoid are equal. -/


### PR DESCRIPTION
Use `M`, `G`, `A` instead of greek letters

Depends on #1981

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)