### PR TITLE
fix(scripts/deploy_docs): remove last trace of nightly builds

### DIFF
--- a/scripts/deploy_docs.sh
+++ b/scripts/deploy_docs.sh
@@ -10,7 +10,7 @@ sed -i "s/rev = \"\S*\"/rev = \"$git_hash\"/" leanpkg.toml
 echo -e "builtin_path\npath ./src\npath ../src" > leanpkg.path
 git clone "https://$DEPLOY_NIGHTLY_GITHUB_USER:$DEPLOY_NIGHTLY_GITHUB_TOKEN@github.com/leanprover-community/mathlib_docs.git"
 rm -rf mathlib_docs/docs/
-elan override set leanprover-community/lean:nightly
+elan override set leanprover-community/lean:3.5.1
 python3 -m pip install --upgrade pip
 pip3 install markdown2 toml
 ./gen_docs -w -r "../" -t "mathlib_docs/docs/"


### PR DESCRIPTION
This is why the last couple doc builds on master took an hour.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
