### PR TITLE
add "Try this: " to squeeze_simp and suggest

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -412,12 +412,12 @@ begin suggest, sorry end
 prints the list,
 
 ```lean
-exact nat.lt.base n
-exact nat.lt_succ_self n
-refine not_le.mp _
-refine gt_iff_lt.mp _
-refine nat.lt.step _
-refine lt_of_not_ge _
+Try this: exact nat.lt.base n
+Try this: exact nat.lt_succ_self n
+Try this: refine not_le.mp _
+Try this: refine gt_iff_lt.mp _
+Try this: refine nat.lt.step _
+Try this: refine lt_of_not_ge _
 ...
 ```
 
@@ -430,7 +430,7 @@ current goal by applying a lemma from the library, then discharging any new goal
 Typical usage is:
 ```
 example (n m k : ℕ) : n * (m - k) = n * m - n * k :=
-by library_search -- exact nat.mul_sub_left_distrib n m k
+by library_search -- Try this: exact nat.mul_sub_left_distrib n m k
 ```
 
 `library_search` prints a trace message showing the proof it found, shown above as a comment.
@@ -812,7 +812,8 @@ with `squeeze_simp`:
 
 ```lean
 example : 0 + 1 = 1 + 0 := by squeeze_simp
--- prints: simp only [add_zero, eq_self_iff_true, zero_add]
+-- prints:
+-- Try this: simp only [add_zero, eq_self_iff_true, zero_add]
 ```
 
 `squeeze_simp` suggests a replacement which we can use instead of

--- a/src/tactic/hint.lean
+++ b/src/tactic/hint.lean
@@ -71,7 +71,7 @@ do hints ← tactic.hint,
      fail "no hints available"
    else
      do trace "the following tactics make progress:\n----",
-        hints.mmap' tactic.trace
+        hints.mmap' (λ s, tactic.trace format!"Try this: {s}")
 
 end interactive
 

--- a/src/tactic/rcases.lean
+++ b/src/tactic/rcases.lean
@@ -220,9 +220,9 @@ with rcases.continue : listΠ (rcases_patt × expr) → tactic goals
 -- top-level `cases` tactic, so there is no more work to do for it.
 | (_ :: l) := rcases.continue l
 
-/-- `rcases h e pat` performs case distinction on `e` using `pat` to 
-name the arising new variables and assumptions. If `h` is `some` name, 
-a new assumption `h : e = pat` will relate the expression `e` with the 
+/-- `rcases h e pat` performs case distinction on `e` using `pat` to
+name the arising new variables and assumptions. If `h` is `some` name,
+a new assumption `h : e = pat` will relate the expression `e` with the
 current pattern. -/
 meta def rcases (h : option name) (p : pexpr) (ids : listΣ (listΠ rcases_patt)) : tactic unit :=
 do e ← match h with
@@ -424,7 +424,7 @@ meta def rcases : parse rcases_parse → tactic unit
 | (p, sum.inr depth) := do
   patt ← tactic.rcases_hint p depth,
   pe ← pp p,
-  trace $ ↑"snippet: rcases " ++ pe ++ " with " ++ to_fmt patt
+  trace $ ↑"Try this: rcases " ++ pe ++ " with " ++ to_fmt patt
 
 /--
 The `rintro` tactic is a combination of the `intros` tactic with `rcases` to
@@ -443,7 +443,7 @@ meta def rintro : parse rintro_parse → tactic unit
 | (sum.inl l)  := tactic.rintro l
 | (sum.inr depth) := do
   ps ← tactic.rintro_hint depth,
-  trace $ ↑"snippet: rintro" ++ format.join (ps.map $ λ p,
+  trace $ ↑"Try this: rintro" ++ format.join (ps.map $ λ p,
     format.space ++ format.group (p.format tt))
 
 /-- Alias for `rintro`. -/

--- a/src/tactic/squeeze.lean
+++ b/src/tactic/squeeze.lean
@@ -97,7 +97,7 @@ do g ← main_goal,
    let attrs := if attr_names.empty then "" else string.join (list.intersperse " " (" with" :: attr_names.map to_string)),
    let loc := loc.to_string locat,
    let args := hs' ++ vs.to_list.map to_fmt,
-   trace format!"simp{use_iota_eqn} only {args}{attrs}{loc}{c}"
+   trace format!"Try this: simp{use_iota_eqn} only {args}{attrs}{loc}{c}"
 
 meta def squeeze_simpa
   (use_iota_eqn : parse (tk "!")?) (no_dflt : parse only_flag) (hs : parse simp_arg_list)
@@ -118,7 +118,7 @@ do g ← main_goal,
    let tgt' := tgt'.get_or_else "",
    hs ← hs.mmap pp,
    let args := hs ++ vs.to_list.map to_fmt,
-   trace format!"simpa{use_iota_eqn} only {args}{attrs}{tgt'}{c}"
+   trace format!"Try this: simpa{use_iota_eqn} only {args}{attrs}{tgt'}{c}"
 
 end interactive
 end tactic

--- a/src/tactic/suggest.lean
+++ b/src/tactic/suggest.lean
@@ -160,7 +160,9 @@ meta def tactic_statement (g : expr) : tactic string :=
 do g ← instantiate_mvars g,
    g ← head_beta g,
    r ← pp (replace_mvars g),
-   if g.has_meta_var then return (sformat!"refine {r}") else return (sformat!"exact {r}")
+   if g.has_meta_var
+   then return (sformat!"Try this: refine {r}")
+   else return (sformat!"Try this: exact {r}")
 
 /--
 Assuming that a goal `g` has been (partially) solved in the tactic_state `l`,

--- a/src/tactic/tidy.lean
+++ b/src/tactic/tidy.lean
@@ -60,7 +60,7 @@ meta def default_tactics : list (tactic string) :=
 
 meta structure cfg :=
 (trace_result : bool            := ff)
-(trace_result_prefix : string   := "/- `tidy` says -/ ")
+(trace_result_prefix : string   := "Try this: ")
 (tactics : list (tactic string) := default_tactics)
 
 declare_trace tidy
@@ -84,7 +84,7 @@ open lean.parser interactive
 The default list of tactics is stored in `tactic.tidy.default_tidy_tactics`.
 This list can be overridden using `tidy { tactics := ... }`.
 (The list must be a `list` of `tactic string`, so that `tidy?`
-can report a usable tactic script.) 
+can report a usable tactic script.)
 
 Tactics can also be added to the list by tagging them (locally) with the
 `[tidy]` attribute. -/

--- a/test/suggest.lean
+++ b/test/suggest.lean
@@ -17,58 +17,58 @@ end
 
 example (a : Prop) : a ∨ true :=
 begin
-  (do s ← suggest_scripts, guard $ s.head = "exact or.inr trivial"), exact or.inr trivial,
+  (do s ← suggest_scripts, guard $ s.head = "Try this: exact or.inr trivial"), exact or.inr trivial,
 end
 
 example {a a' : ℕ} (h : a == a') : a = a' :=
 begin
-  (do s ← suggest_scripts, guard $ s.head = "exact eq_of_heq h"), exact eq_of_heq h,
+  (do s ← suggest_scripts, guard $ s.head = "Try this: exact eq_of_heq h"), exact eq_of_heq h,
 end
 example {a b c : ℤ} (h₁ : a = b) (h₂ : b = c) : a = c :=
 begin
-  (do s ← suggest_scripts, guard $ "exact eq.trans h₁ h₂" ∈ s), exact eq.trans h₁ h₂,
+  (do s ← suggest_scripts, guard $ "Try this: exact eq.trans h₁ h₂" ∈ s), exact eq.trans h₁ h₂,
 end
 
 example (n : nat) : n + 0 = n :=
 begin
-  (do s ← suggest_scripts, guard $ s.head = "exact rfl"), exact rfl,
+  (do s ← suggest_scripts, guard $ s.head = "Try this: exact rfl"), exact rfl,
 end
 
 example (n : nat) : n < n + 1 :=
 begin
-  (do s ← suggest_scripts, guard $ s.head = "exact nat.lt.base n"),
+  (do s ← suggest_scripts, guard $ s.head = "Try this: exact nat.lt.base n"),
   exact nat.lt.base n
 end
 example (n : nat) : n < n + 2 :=
 begin
-  (do s ← suggest_scripts, guard $ "refine nat.lt.step _" ∈ s),
+  (do s ← suggest_scripts, guard $ "Try this: refine nat.lt.step _" ∈ s),
   refine nat.lt.step _, -- this wasn't the first result; humans still necessary :-(
-  (do s ← suggest_scripts, guard $ s.head = "exact nat.lt.base n"),
+  (do s ← suggest_scripts, guard $ s.head = "Try this: exact nat.lt.base n"),
   exact nat.lt.base n
 end
 
 example (a b : Prop) : (a ∨ true) ∧ (b ∨ true) :=
 begin
-  (do s ← suggest_scripts, guard $ "refine ⟨_, _⟩" ∈ s),
+  (do s ← suggest_scripts, guard $ "Try this: refine ⟨_, _⟩" ∈ s),
   refine ⟨_, _⟩, -- wasn't the first result, because it created two new goals
-  { (do s ← suggest_scripts, guard $ s.head = "exact or.inr trivial"),
+  { (do s ← suggest_scripts, guard $ s.head = "Try this: exact or.inr trivial"),
     exact or.inr trivial },
-  { (do s ← suggest_scripts, guard $ s.head = "exact or.inr trivial"),
+  { (do s ← suggest_scripts, guard $ s.head = "Try this: exact or.inr trivial"),
     exact or.inr trivial },
 end
 
 example (A B : Prop) (a : A) (b : unit → B) : A ∧ B :=
 begin
-  (do s ← suggest_scripts, guard $ s.head = "refine ⟨a, _⟩"),
+  (do s ← suggest_scripts, guard $ s.head = "Try this: refine ⟨a, _⟩"),
   refine ⟨a, _⟩,
   replace b := b (),
-  (do s ← suggest_scripts, guard $ s.head = "exact b"),
+  (do s ← suggest_scripts, guard $ s.head = "Try this: exact b"),
   exact b,
 end
 
 example {a b c : ℕ} (h₁ : a ≤ b) (h₂ : b ≤ c) : a ≤ c :=
 begin
-  (do s ← suggest_scripts, guard $ s.head = "exact le_trans h₁ h₂"),
+  (do s ← suggest_scripts, guard $ s.head = "Try this: exact le_trans h₁ h₂"),
   exact le_trans h₁ h₂
 end
 
@@ -77,7 +77,7 @@ example (a b c d e f : ℕ) (hab : a ≤ b) (hbc : b ≤ c) (hde : d ≤ e) (hef
   a ≤ c ∧ d ≤ f :=
 begin
   split,
-  (do s ← suggest_scripts, guard $ s.head = "exact le_trans hab hbc"),
+  (do s ← suggest_scripts, guard $ s.head = "Try this: exact le_trans hab hbc"),
   exact le_trans hab hbc,
   exact le_trans hde hef
 end

--- a/test/tidy.lean
+++ b/test/tidy.lean
@@ -44,8 +44,8 @@ open tactic
 
 def d : D :=
 begin
-  tidy,
-  -- /- obviously says -/ fsplit, work_on_goal 0 { fsplit, work_on_goal 0 { fsplit }, work_on_goal 1 { refl } }, work_on_goal 0 { fsplit, work_on_goal 0 { fsplit }, work_on_goal 1 { fsplit, work_on_goal 0 { fsplit }, work_on_goal 1 { refl } }, work_on_goal 1 { refl } }, refl
+  tidy?,
+  -- Try this: fsplit, work_on_goal 0 { fsplit, work_on_goal 0 { fsplit }, work_on_goal 1 { refl } }, work_on_goal 0 { fsplit, work_on_goal 0 { fsplit }, work_on_goal 1 { fsplit, work_on_goal 0 { fsplit }, work_on_goal 1 { refl } }, work_on_goal 1 { refl } }, refl
 end.
 
 def f : unit → unit → unit := by tidy -- intros a a_1, cases a_1, cases a, fsplit


### PR DESCRIPTION
Add the string "Try this:" to tactics that suggest other tactics (squeeze_simp, suggest) so that we can recognize this automatically and support in VSCode.

See also discussion in:
https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/VScode.20message.20window

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
