### PR TITLE
refactor(group_theory/monoid_localization): rename, simplify proofs

### DIFF
--- a/src/group_theory/monoid_localization.lean
+++ b/src/group_theory/monoid_localization.lean
@@ -54,20 +54,21 @@ variables {X : Type*} [comm_monoid X] (Y : submonoid X) {Z : Type*} [comm_monoid
 
 namespace submonoid
 
+namespace monoid_localization
+
 /-- The congruence relation on `X × Y`, `X` a `comm_monoid` and `Y` a submonoid of `X`, whose
     quotient is the localization of `X` at `Y`, defined as the unique congruence relation on
     `X × Y` such that for any other congruence relation `s` on `X × Y` where for all `y ∈ Y`,
     `(1, 1) ∼ (y, y)` under `s`, we have that `(x₁, y₁) ∼ (x₂, y₂)` by `s` implies
     `(x₁, y₁) ∼ (x₂, y₂)` by `r`. -/
 @[to_additive "The congruence relation on `X × Y`, `X` an `add_comm_monoid` and `Y` an `add_submonoid` of `X`, whose quotient is the localization of `X` at `Y`, defined as the unique congruence relation on `X × Y` such that for any other congruence relation `s` on `X × Y` where for all `y ∈ Y`, `(0, 0) ∼ (y, y)` under `s`, we have that `(x₁, y₁) ∼ (x₂, y₂)` by `s` implies `(x₁, y₁) ∼ (x₂, y₂)` by `r`."]
-def localization.r (Y : submonoid X) : con (X × Y) :=
-lattice.Inf {c | ∀ y : Y, c 1 (y, y)}
+def r (Y : submonoid X) : con (X × Y) := lattice.Inf {c | ∀ y : Y, c 1 (y, y)}
 
 /-- An alternate form of the congruence relation on `X × Y`, `X` a `comm_monoid` and `Y` a
     submonoid of `X`, whose quotient is the localization of `X` at `Y`. Its equivalence to `r` can
     be useful for proofs. -/
 @[to_additive]
-def localization.r' : con (X × Y) :=
+def r' : con (X × Y) :=
 begin
   refine { r := λ a b : X × Y, ∃ c : Y, a.1 * b.2 * c = b.1 * a.2 * c,
     iseqv := ⟨λ a, ⟨1, rfl⟩, λ a b ⟨c, hc⟩, ⟨c, hc.symm⟩, _⟩,
@@ -88,7 +89,7 @@ end
 /-- The congruence relation used to localize a `comm_monoid` at a submonoid can be expressed
     equivalently as an infimum (see `submonoid.r`) or explicitly (see `submonoid.r'`). -/
 @[to_additive "The additive congruence relation used to localize an `add_comm_monoid` at a submonoid can be expressed equivalently as an infimum (see `add_submonoid.r`) or explicitly (see `add_submonoid.r'`)."]
-theorem localization.r_eq_r' : localization.r Y = localization.r' Y :=
+theorem r_eq_r' : r Y = r' Y :=
 le_antisymm (lattice.Inf_le $ λ _, ⟨1, by simp⟩) $
   lattice.le_Inf $ λ b H ⟨p, q⟩ y ⟨t, ht⟩,
     begin
@@ -99,64 +100,66 @@ le_antisymm (lattice.Inf_le $ λ _, ⟨1, by simp⟩) $
       refl
     end
 
+end monoid_localization
+
 /-- The localization of a `comm_monoid` at one of its submonoids. -/
 @[to_additive "The localization of an `add_comm_monoid` at one of its submonoids."]
-def localization := (localization.r Y).quotient
+def monoid_localization := (monoid_localization.r Y).quotient
 
 variables {X Y}
 
-namespace localization
+namespace monoid_localization
 
 /-- For all `y` in `Y`, a submonoid of a `comm_monoid` `X`, `(1, 1) ∼ (y, y)` under the relation
     defining the localization of `X` at `Y`. -/
 @[to_additive "For all `y` in `Y`, a submonoid of an `add_comm_monoid` `X`, `(0, 0) ∼ (y, y)` under the relation defining the localization of `X` at `Y`."]
-lemma one_rel (y : Y) : localization.r Y 1 (y, y) := λ b hb, hb y
+lemma one_rel (y : Y) : r Y 1 (y, y) := λ b hb, hb y
 
 /-- Given a `comm_monoid` `X` and submonoid `Y`, `mk` sends `x : X`, `y ∈ Y` to the equivalence
     class of `(x, y)` in the localization of `X` at `Y`. -/
 @[to_additive "Given an `add_comm_monoid` `X` and submonoid `Y`, `mk` sends `x : X`, `y ∈ Y` to the equivalence class of `(x, y)` in the localization of `X` at `Y`."]
-def mk (x : X) (y : Y) : Y.localization := (localization.r Y).mk' (x, y)
+def mk (x : X) (y : Y) : Y.monoid_localization := (r Y).mk' (x, y)
 
 @[elab_as_eliminator, to_additive]
-theorem ind {p : Y.localization → Prop} (H : ∀ (y : X × Y), p (mk y.1 y.2)) (x) : p x :=
+theorem ind {p : Y.monoid_localization → Prop} (H : ∀ (y : X × Y), p (mk y.1 y.2)) (x) : p x :=
 by rcases x; convert H x; exact prod.mk.eta.symm
 
 @[elab_as_eliminator, to_additive]
-theorem induction_on {p : Y.localization → Prop} (x)
+theorem induction_on {p : Y.monoid_localization → Prop} (x)
   (H : ∀ (y : X × Y), p (mk y.1 y.2)) : p x := ind H x
 
 @[elab_as_eliminator, to_additive]
-theorem induction_on₂ {p : Y.localization → Y.localization → Prop} (x y)
+theorem induction_on₂ {p : Y.monoid_localization → Y.monoid_localization → Prop} (x y)
   (H : ∀ (x y : X × Y), p (mk x.1 x.2) (mk y.1 y.2)) : p x y :=
 induction_on x $ λ x, induction_on y $ H x
 
 @[elab_as_eliminator, to_additive]
-theorem induction_on₃ {p : Y.localization → Y.localization → Y.localization → Prop} (x y z)
+theorem induction_on₃ {p : Y.monoid_localization → Y.monoid_localization → Y.monoid_localization → Prop} (x y z)
   (H : ∀ (x y z : X × Y), p (mk x.1 x.2) (mk y.1 y.2) (mk z.1 z.2)) : p x y z :=
 induction_on₂ x y $ λ x y, induction_on z $ H x y
 
 @[to_additive] lemma exists_rep (x) : ∃ y : X × Y, mk y.1 y.2 = x :=
 induction_on x $ λ y, ⟨y, rfl⟩
 
-@[to_additive] instance : comm_monoid Y.localization :=
-(localization.r Y).comm_monoid
+@[to_additive] instance : comm_monoid Y.monoid_localization :=
+(r Y).comm_monoid
 
-@[to_additive] instance : inhabited Y.localization := ⟨1⟩
+@[to_additive] instance : inhabited Y.monoid_localization := ⟨1⟩
 
 @[to_additive] protected lemma eq {a₁ b₁} {a₂ b₂ : Y} :
   mk a₁ a₂ = mk b₁ b₂ ↔ ∀ c : con (X × Y), (∀ y : Y, c 1 (y, y)) → c (a₁, a₂) (b₁, b₂) :=
-(localization.r Y).eq
+(r Y).eq
 
 @[to_additive] protected lemma eq' {a₁ b₁} {a₂ b₂ : Y} :
   mk a₁ a₂ = mk b₁ b₂ ↔ ∃ c : Y, a₁ * b₂ * c = b₁ * a₂ * c :=
-quotient.eq'.trans $ by { rw [localization.r_eq_r'], refl }
+quotient.eq'.trans $ by { rw [r_eq_r'], refl }
 
 @[to_additive] lemma mk_eq_of_eq {a₁ b₁ : X} {a₂ b₂ : Y} (h : a₁ * b₂ = b₁ * a₂) :
   mk a₁ a₂ = mk b₁ b₂ :=
-localization.eq'.2 $ ⟨1, by rw [← h, mul_comm a₁]⟩
+monoid_localization.eq'.2 $ ⟨1, by rw [← h, mul_comm a₁]⟩
 
 @[simp, to_additive] lemma mk_self' (x : Y) : mk (x : X) x = 1 :=
-localization.eq.2 $ λ c h, c.symm $ h x
+monoid_localization.eq.2 $ λ c h, c.symm $ h x
 
 @[simp, to_additive] lemma mk_self {x} (hx : x ∈ Y) : mk x ⟨x, hx⟩ = 1 :=
 mk_self' ⟨x, hx⟩
@@ -167,7 +170,7 @@ mk_self' ⟨x, hx⟩
 /-- Definition of the function on the localization of a `comm_monoid` at a submonoid induced by a
     function that is constant on the equivalence classes of the localization relation. -/
 @[simp, to_additive "Definition of the function on the localization of an `add_comm_monoid` at an `add_submonoid` induced by a function that is constant on the equivalence classes of the localization relation."]
-lemma lift_on_beta {β} (f : (X × Y) → β) (H : ∀ a b, localization.r Y a b → f a = f b) (x y) :
+lemma lift_on_beta {β} (f : (X × Y) → β) (H : ∀ a b, r Y a b → f a = f b) (x y) :
 con.lift_on (mk x y) f H = f (x, y) := rfl
 
 variable (Y)
@@ -176,12 +179,12 @@ variable (Y)
     `(x, 1)` in the localization of `X` at a submonoid. For a `comm_ring` localization, this is
     a ring homomorphism named `localization.of`. -/
 @[to_additive "Natural homomorphism sending `x : X`, `X` an `add_comm_monoid`, to the equivalence class of `(x, 0)` in the localization of `X` at a submonoid."]
-def of : X →* Y.localization :=
-(localization.r Y).mk'.comp ⟨λ x, (x, 1), refl 1, λ _ _, by simp only [prod.mk_mul_mk, one_mul]⟩
+def of : X →* Y.monoid_localization :=
+(r Y).mk'.comp ⟨λ x, (x, 1), refl 1, λ _ _, by simp only [prod.mk_mul_mk, one_mul]⟩
 
 variable {Y}
 
-@[to_additive] lemma of_ker_iff {x y} : con.ker (of Y) x y ↔ localization.r Y (x, 1) (y, 1) :=
+@[to_additive] lemma of_ker_iff {x y} : con.ker (of Y) x y ↔ r Y (x, 1) (y, 1) :=
 con.eq _
 
 @[to_additive] lemma of_eq_mk (x) : of Y x = mk x 1 := rfl
@@ -202,11 +205,11 @@ by rw [mul_comm, mk_mul_cancel_right]
 
 /-- Natural homomorphism sending `y ∈ Y`, `Y` a submonoid of a `comm_monoid` `X`, to the units of
     the localization of `X` at `Y`. -/
-def to_units (Y : submonoid X) : Y →* units Y.localization :=
+def to_units (Y : submonoid X) : Y →* units Y.monoid_localization :=
 ⟨λ y, ⟨mk y 1, mk 1 y, by simp, by simp⟩, by simp; refl,
  λ _ _, by ext; convert (of Y).map_mul _ _⟩
 
-@[simp] lemma to_units_mk (y) : (to_units Y y : Y.localization) = mk y 1 := rfl
+@[simp] lemma to_units_mk (y) : (to_units Y y : Y.monoid_localization) = mk y 1 := rfl
 
 @[simp] lemma mk_is_unit (y : Y) : is_unit (mk (y : X) (1 : Y)) :=
 is_unit_unit $ to_units Y y
@@ -222,7 +225,7 @@ is_unit_unit $ to_units Y y
 @[simp] lemma of_is_unit' (x) (hx : x ∈ Y) : is_unit (of Y x) :=
 is_unit_unit $ to_units Y ⟨x, hx⟩
 
-lemma to_units_map_inv (g : Y.localization →* Z) (y) :
+lemma to_units_map_inv (g : Y.monoid_localization →* Z) (y) :
   g ↑(to_units Y y)⁻¹ = ↑(units.map g (to_units Y y))⁻¹ :=
 by rw [←units.coe_map, (units.map g).map_inv]
 
@@ -263,20 +266,20 @@ variables {g}
     invertible elements of `Z`, the homomorphism from `X × Y` to `Z` sending `(x, y)` to
     `f(x) * f(y)⁻¹` is constant on the equivalence classes of the localization of `X` at `Y`. -/
 lemma r_le_ker_aux (H : ∀ y : Y, f y = g y) :
-  localization.r Y ≤ con.ker (aux f g H) :=
+  r Y ≤ con.ker (aux f g H) :=
 con.Inf_le _ _ (λ y, show f (1 : Y) * ↑(g 1)⁻¹ = f y * ↑(g y)⁻¹, by
   rw [H 1, H y]; simp [units.mul_inv])
 
 /-- Given a `comm_monoid` homomorphism `f : X → Z` mapping elements of a submonoid `Y` to
     invertible elements of `Z`, the homomorphism from the localization of `X` at `Y` sending
     `⟦(x, y)⟧` to `f(x) * f(y)⁻¹`. -/
-def lift' (g : Y → units Z) (H : ∀ y : Y, f y = g y) : Y.localization →* Z :=
-(localization.r Y).lift (aux f g H) $ r_le_ker_aux f H
+def lift' (g : Y → units Z) (H : ∀ y : Y, f y = g y) : Y.monoid_localization →* Z :=
+(r Y).lift (aux f g H) $ r_le_ker_aux f H
 
 /-- Given a `comm_monoid` homomorphism `f : X → Z` mapping elements of a submonoid `Y` to
     invertible elements of `Z`, the homomorphism from the localization of `X` at `Y` sending
     `⟦(x, y)⟧` to `f(x) * f(y)⁻¹`, where `f(y)⁻¹` is chosen nonconstructively. -/
-noncomputable def lift (H : ∀ y : Y, is_unit (f y)) : Y.localization →* Z :=
+noncomputable def lift (H : ∀ y : Y, is_unit (f y)) : Y.monoid_localization →* Z :=
 lift' f _ $ λ _, classical.some_spec $ H _
 
 variables {f}
@@ -316,7 +319,7 @@ by ext; exact lift'_of H _
 @[simp] lemma lift_comp_of (H : ∀ y : Y, is_unit (f y)) :
   (lift f H).comp (of Y) = f := lift'_comp_of _
 
-@[simp] lemma lift'_apply_of (f' : Y.localization →* Z)
+@[simp] lemma lift'_apply_of (f' : Y.monoid_localization →* Z)
   (H : ∀ y : Y, f'.comp (of Y) y = g y) : lift' (f'.comp (of Y)) _ H = f' :=
 begin
   ext x,
@@ -329,11 +332,11 @@ begin
   simp only [mul_one, mk_mul_cancel_right, one_mul],
 end
 
-@[simp] lemma lift_apply_of (g : Y.localization →* Z) :
+@[simp] lemma lift_apply_of (g : Y.monoid_localization →* Z) :
   lift (g.comp $ of Y) (λ y, is_unit_unit $ units.map g $ to_units Y y) = g :=
 lift'_apply_of _ _
 
-lemma funext (f g : Y.localization →* Z)
+lemma funext (f g : Y.monoid_localization →* Z)
   (h : ∀ a, f.comp (of Y) a = g.comp (of Y) a) : f = g :=
 begin
   rw [←lift_apply_of f, ←lift_apply_of g],
@@ -348,7 +351,7 @@ variables {W : submonoid Z} (f)
     `f(Y) ⊆ W`, the monoid homomorphism from the localization of `X` at `Y` to the localization of
     `Z` at `W` induced by the natural map from `Z` to the localization of `Z` at
     `W` composed with `f`. -/
-def map (hf : ∀ y : Y, f y ∈ W) : Y.localization →* W.localization :=
+def map (hf : ∀ y : Y, f y ∈ W) : Y.monoid_localization →* W.monoid_localization :=
 lift' ((of W).comp f) ((to_units W).comp $ (f.comp Y.subtype).subtype_mk W hf) $ λ y, rfl
 
 variables {f}
@@ -367,7 +370,7 @@ lemma map_mk (hf : ∀ y : Y, f y ∈ W) (x y) :
   map f hf (mk x y) = mk (f x) ⟨f y, hf y⟩ :=
 (lift'_mk _ _ _).trans (mk_eq _ _).symm
 
-@[simp] lemma map_id (x : Y.localization) :
+@[simp] lemma map_id (x : Y.monoid_localization) :
   map (monoid_hom.id X) (λ (y : Y), y.2) x = x :=
 induction_on x $ λ ⟨w, z⟩, by rw map_mk; exact congr_arg _ (subtype.eq' rfl)
 
@@ -385,5 +388,5 @@ lemma map_ext (g : X →* Z) (hf : ∀ y : Y, f y ∈ W) (hg : ∀ y : Y, g y �
   (h : f = g) (x) : map f hf x = map g hg x :=
 induction_on x $ λ _, by {rw [map_mk, map_mk], congr; rw h; refl}
 
-end localization
+end monoid_localization
 end submonoid

--- a/src/group_theory/monoid_localization.lean
+++ b/src/group_theory/monoid_localization.lean
@@ -6,7 +6,6 @@ Authors: Amelia Livingston
 
 import group_theory.congruence
 import algebra.associated
-import tactic.abel
 
 /-
 
@@ -50,7 +49,8 @@ There is only a multiplicative version for any lemma or definition relying on a 
 localization, monoid localization, quotient monoid, congruence relation
 
 -/
-variables {X : Type*}
+variables {X : Type*} [comm_monoid X] (Y : submonoid X) {Z : Type*} [comm_monoid Z]
+
 
 namespace submonoid
 
@@ -60,67 +60,49 @@ namespace submonoid
     `(1, 1) ∼ (y, y)` under `s`, we have that `(x₁, y₁) ∼ (x₂, y₂)` by `s` implies
     `(x₁, y₁) ∼ (x₂, y₂)` by `r`. -/
 @[to_additive "The congruence relation on `X × Y`, `X` an `add_comm_monoid` and `Y` an `add_submonoid` of `X`, whose quotient is the localization of `X` at `Y`, defined as the unique congruence relation on `X × Y` such that for any other congruence relation `s` on `X × Y` where for all `y ∈ Y`, `(0, 0) ∼ (y, y)` under `s`, we have that `(x₁, y₁) ∼ (x₂, y₂)` by `s` implies `(x₁, y₁) ∼ (x₂, y₂)` by `r`."]
-def r [comm_monoid X] (Y : submonoid X) : con (X × Y) :=
+def localization.r (Y : submonoid X) : con (X × Y) :=
 lattice.Inf {c | ∀ y : Y, c 1 (y, y)}
 
-end submonoid
-
-namespace add_submonoid
-
-variables [add_comm_monoid X]
-
-/-- An alternate form of the `add_monoid` localization relation, stated here for readability of the
+/-- An alternate form of the `monoid` localization relation, stated here for readability of the
     next few lemmas. -/
-private def r'.rel (Y : add_submonoid X) (a b : X × Y) :=
-∃ c : Y, (c : X) + (a.1 + b.2) = c + (b.1 + a.2)
+def localization.r'.rel (Y : submonoid X) (a b : X × Y) :=
+∃ c : Y, (c : X) * (a.1 * b.2) = c * (b.1 * a.2)
 
-lemma r'.transitive {Y : add_submonoid X} : transitive (r'.rel Y) :=
-λ a b c ⟨m, hm⟩ ⟨n, hn⟩, ⟨n + m + b.2,
+variable {Y}
+
+lemma localization.r'.transitive : transitive (localization.r'.rel Y) :=
+λ a b c ⟨m, hm⟩ ⟨n, hn⟩, ⟨n * m * b.2,
   calc
-    ↑n + ↑m + ↑b.2 + (a.1 + ↑c.2)
-      = ↑n + (↑m + (b.1 + ↑a.2)) + ↑c.2 : by rw ←hm; abel
-  ... = ↑m + (↑n + (c.1 + ↑b.2)) + ↑a.2 : by rw ←hn; abel
-  ... = ↑n + ↑m + ↑b.2 + (c.1 + ↑a.2) : by abel⟩
+    ↑n * ↑m * ↑b.2 * (a.1 * ↑c.2)
+      = ↑n * (↑m * (b.1 * ↑a.2)) * ↑c.2 : by { rw ←hm, ac_refl }
+  ... = ↑m * (↑n * (c.1 * ↑b.2)) * ↑a.2 : by { rw ←hn, ac_refl }
+  ... = ↑n * ↑m * ↑b.2 * (c.1 * ↑a.2) : by ac_refl ⟩
 
-lemma r'.add {Y : add_submonoid X} {a b c d} :
-  r'.rel Y a b → r'.rel Y c d → r'.rel Y (a + c) (b + d) :=
-λ ⟨m, hm⟩ ⟨n, hn⟩, ⟨m + n,
+lemma localization.r'.mul ⦃a b c d⦄ :
+  localization.r'.rel Y a b → localization.r'.rel Y c d → localization.r'.rel Y (a * c) (b * d) :=
+λ ⟨m, hm⟩ ⟨n, hn⟩, ⟨m * n,
   calc
-    ↑m + ↑n + (a.1 + c.1 + (↑b.2 + ↑d.2))
-      = ↑n + c.1 + (↑m + (b.1 + ↑a.2)) + ↑d.2 : by rw ←hm; abel
-  ... = (↑m + (b.1 + ↑a.2)) + (↑n + (d.1 + ↑c.2)) : by rw ←hn; abel
-  ... = ↑m + ↑n + (b.1 + d.1 + (↑a.2 + ↑c.2)) : by abel⟩
+    ↑m * ↑n * (a.1 * c.1 * (↑b.2 * ↑d.2))
+      = ↑n * c.1 * (↑m * (b.1 * ↑a.2)) * ↑d.2 : by { rw ←hm, ac_refl }
+  ... = (↑m * (b.1 * ↑a.2)) * (↑n * (d.1 * ↑c.2)) : by { rw ←hn, ac_refl }
+  ... = ↑m * ↑n * (b.1 * d.1 * (↑a.2 * ↑c.2)) : by ac_refl⟩
 
-/-- An alternate form of the congruence relation on `X × Y`, `X` an `add_comm_monoid` and `Y` an
-    `add_submonoid` of `X`, whose quotient is the localization of `X` at `Y`. Its equivalence to
-    `r` can be useful for proofs. -/
-def r' (Y : add_submonoid X) : add_con (X × Y) :=
-{ r := λ a b, ∃ c : Y, (c : X) + (a.1 + b.2) = c + (b.1 + a.2),
-  iseqv := ⟨λ _, ⟨0, rfl⟩, λ _ _ ⟨c, hc⟩, ⟨c, hc.symm⟩, r'.transitive⟩,
-  add' := λ a b c d, r'.add }
-
-end add_submonoid
-
-variables [comm_monoid X] (Y : submonoid X) {Z : Type*} [comm_monoid Z]
-
-namespace submonoid
+variable (Y)
 
 /-- An alternate form of the congruence relation on `X × Y`, `X` a `comm_monoid` and `Y` a
     submonoid of `X`, whose quotient is the localization of `X` at `Y`. Its equivalence to `r` can
     be useful for proofs. -/
-def r' : con (X × Y) :=
-{ r := λ a b, ∃ c : Y, (c : X) * (a.1 * b.2) = c * (b.1 * a.2),
-  iseqv := ⟨λ _, ⟨1, rfl⟩, λ _ _ ⟨c, hc⟩, ⟨c, hc.symm⟩,
-    @add_submonoid.r'.transitive (additive X) _ $ submonoid.to_add_submonoid Y⟩,
-  mul' := @add_submonoid.r'.add (additive X) _ $ submonoid.to_add_submonoid Y }
-
-attribute [to_additive add_submonoid.r'] submonoid.r'
+@[to_additive]
+def localization.r' : con (X × Y) :=
+{ r := localization.r'.rel Y,
+  iseqv := ⟨λ _, ⟨1, rfl⟩, λ _ _ ⟨c, hc⟩, ⟨c, hc.symm⟩, localization.r'.transitive⟩,
+  mul' := localization.r'.mul }
 
 /-- The congruence relation used to localize a `comm_monoid` at a submonoid can be expressed
     equivalently as an infimum (see `submonoid.r`) or explicitly (see `submonoid.r'`). -/
 @[to_additive "The additive congruence relation used to localize an `add_comm_monoid` at a submonoid can be expressed equivalently as an infimum (see `add_submonoid.r`) or explicitly (see `add_submonoid.r'`)."]
-theorem r_eq_r' : Y.r = Y.r' :=
-le_antisymm (lattice.Inf_le $ λ _, ⟨1, by norm_num⟩) $
+theorem localization.r_eq_r' : localization.r Y = localization.r' Y :=
+le_antisymm (lattice.Inf_le $ λ _, ⟨1, by simp⟩) $
   lattice.le_Inf $ λ b H x y ⟨t, ht⟩,
     begin
       rw [show x = (1 * x.1, 1 * x.2), by simp, show y = (1 * y.1, 1 * y.2), by simp],
@@ -132,62 +114,54 @@ le_antisymm (lattice.Inf_le $ λ _, ⟨1, by norm_num⟩) $
       exact b.mul (b.symm $ H $ t * x.2) (b.refl (y.1, y.2))
     end
 
-end submonoid
-
-variables (X)
-
 /-- The localization of a `comm_monoid` at one of its submonoids. -/
-@[to_additive add_monoid_localization "The localization of an `add_comm_monoid` at one of its submonoids."]
-def monoid_localization := Y.r.quotient
+@[to_additive "The localization of an `add_comm_monoid` at one of its submonoids."]
+def localization := (localization.r Y).quotient
 
 variables {X Y}
 
-namespace monoid_localization
+namespace localization
 
 /-- For all `y` in `Y`, a submonoid of a `comm_monoid` `X`, `(1, 1) ∼ (y, y)` under the relation
     defining the localization of `X` at `Y`. -/
 @[to_additive "For all `y` in `Y`, a submonoid of an `add_comm_monoid` `X`, `(0, 0) ∼ (y, y)` under the relation defining the localization of `X` at `Y`."]
-lemma one_rel (y : Y) : Y.r 1 (y, y) := by rw Y.r_eq_r'; use 1; norm_num
+lemma one_rel (y : Y) : localization.r Y 1 (y, y) := λ b hb, hb y
 
 /-- Given a `comm_monoid` `X` and submonoid `Y`, `mk` sends `x : X`, `y ∈ Y` to the equivalence
     class of `(x, y)` in the localization of `X` at `Y`. -/
 @[to_additive "Given an `add_comm_monoid` `X` and submonoid `Y`, `mk` sends `x : X`, `y ∈ Y` to the equivalence class of `(x, y)` in the localization of `X` at `Y`."]
-def mk (x : X) (y : Y) : monoid_localization X Y := Y.r.mk' (x, y)
+def mk (x : X) (y : Y) : Y.localization := (localization.r Y).mk' (x, y)
 
 @[elab_as_eliminator, to_additive]
-theorem ind {p : monoid_localization X Y → Prop}
-  (H : ∀ (y : X × Y), p (mk y.1 y.2)) (x) : p x :=
+theorem ind {p : Y.localization → Prop} (H : ∀ (y : X × Y), p (mk y.1 y.2)) (x) : p x :=
 by rcases x; convert H x; exact prod.mk.eta.symm
 
 @[elab_as_eliminator, to_additive]
-theorem induction_on {p : monoid_localization X Y → Prop} (x)
+theorem induction_on {p : Y.localization → Prop} (x)
   (H : ∀ (y : X × Y), p (mk y.1 y.2)) : p x := ind H x
 
 @[to_additive] lemma exists_rep (x) : ∃ y : X × Y, mk y.1 y.2 = x :=
 induction_on x $ λ y, ⟨y, rfl⟩
 
-@[to_additive] instance : has_mul (monoid_localization X Y) := Y.r.has_mul
+@[to_additive] instance : comm_monoid Y.localization :=
+(localization.r Y).comm_monoid
 
-@[to_additive] instance : comm_monoid (monoid_localization X Y) :=
-Y.r.comm_monoid
-
-@[to_additive] instance : inhabited (monoid_localization X Y) := ⟨1⟩
+@[to_additive] instance : inhabited Y.localization := ⟨1⟩
 
 @[to_additive] protected lemma eq {a₁ b₁} {a₂ b₂ : Y} :
   mk a₁ a₂ = mk b₁ b₂ ↔ ∀ c : con (X × Y), (∀ y : Y, c 1 (y, y)) → c (a₁, a₂) (b₁, b₂) :=
-Y.r.eq.trans $ iff.rfl
+(localization.r Y).eq
 
 @[to_additive] protected lemma eq' {a₁ b₁} {a₂ b₂ : Y} :
   mk a₁ a₂ = mk b₁ b₂ ↔ ∃ c : Y, (c : X) * (a₁ * b₂) = c * (b₁ * a₂) :=
-⟨λ h, let ⟨w, hw⟩ := show Y.r' (a₁, a₂) (b₁, b₂), by rw [←Y.r_eq_r', ←con.eq]; exact h in ⟨w, hw⟩,
- λ ⟨w, hw⟩, by erw [Y.r.eq, Y.r_eq_r']; exact ⟨w, hw⟩⟩
+quotient.eq'.trans $ by { rw [localization.r_eq_r'], refl }
 
 @[to_additive] lemma mk_eq_of_eq {a₁ b₁} {a₂ b₂ : Y} (h : (a₂ : X) * b₁ = b₂ * a₁) :
   mk a₁ a₂ = mk b₁ b₂ :=
-monoid_localization.eq'.2 $ ⟨1, by rw [mul_comm b₁, h, mul_comm a₁]⟩
+localization.eq'.2 $ ⟨1, by rw [mul_comm b₁, h, mul_comm a₁]⟩
 
 @[simp, to_additive] lemma mk_self' (x : Y) : mk (x : X) x = 1 :=
-monoid_localization.eq.2 $ λ c h, c.symm $ h x
+localization.eq.2 $ λ c h, c.symm $ h x
 
 @[simp, to_additive] lemma mk_self {x} (hx : x ∈ Y) : mk x ⟨x, hx⟩ = 1 :=
 mk_self' ⟨x, hx⟩
@@ -198,17 +172,21 @@ mk_self' ⟨x, hx⟩
 /-- Definition of the function on the localization of a `comm_monoid` at a submonoid induced by a
     function that is constant on the equivalence classes of the localization relation. -/
 @[simp, to_additive "Definition of the function on the localization of an `add_comm_monoid` at an `add_submonoid` induced by a function that is constant on the equivalence classes of the localization relation."]
-lemma lift_on_beta {β} (f : (X × Y) → β) (H : ∀ a b, Y.r a b → f a = f b) (x y) :
+lemma lift_on_beta {β} (f : (X × Y) → β) (H : ∀ a b, localization.r Y a b → f a = f b) (x y) :
 con.lift_on (mk x y) f H = f (x, y) := rfl
+
+variable (Y)
 
 /-- Natural homomorphism sending `x : X`, `X` a `comm_monoid`, to the equivalence class of
     `(x, 1)` in the localization of `X` at a submonoid. For a `comm_ring` localization, this is
     a ring homomorphism named `localization.of`. -/
 @[to_additive "Natural homomorphism sending `x : X`, `X` an `add_comm_monoid`, to the equivalence class of `(x, 0)` in the localization of `X` at a submonoid."]
-def of (Y) : X →* monoid_localization X Y :=
-Y.r.mk'.comp ⟨λ x, (x, 1), refl 1, λ _ _, by simp only [prod.mk_mul_mk, one_mul]⟩
+def of : X →* Y.localization :=
+(localization.r Y).mk'.comp ⟨λ x, (x, 1), refl 1, λ _ _, by simp only [prod.mk_mul_mk, one_mul]⟩
 
-@[to_additive] lemma of_ker_iff {x y} : con.ker (of Y) x y ↔ Y.r (x, 1) (y, 1) :=
+variable {Y}
+
+@[to_additive] lemma of_ker_iff {x y} : con.ker (of Y) x y ↔ localization.r Y (x, 1) (y, 1) :=
 con.eq _
 
 @[to_additive] lemma of_eq_mk (x) : of Y x = mk x 1 := rfl
@@ -229,11 +207,11 @@ by rw [mul_comm, mk_mul_cancel_right]
 
 /-- Natural homomorphism sending `y ∈ Y`, `Y` a submonoid of a `comm_monoid` `X`, to the units of
     the localization of `X` at `Y`. -/
-def to_units (Y : submonoid X) : Y →* units (monoid_localization X Y) :=
+def to_units (Y : submonoid X) : Y →* units Y.localization :=
 ⟨λ y, ⟨mk y 1, mk 1 y, by simp, by simp⟩, by simp; refl,
  λ _ _, by ext; convert (of Y).map_mul _ _⟩
 
-@[simp] lemma to_units_mk (y) : (to_units Y y : monoid_localization X Y) = mk y 1 := rfl
+@[simp] lemma to_units_mk (y) : (to_units Y y : Y.localization) = mk y 1 := rfl
 
 @[simp] lemma mk_is_unit (y : Y) : is_unit (mk (y : X) (1 : Y)) :=
 is_unit_unit $ to_units Y y
@@ -249,7 +227,7 @@ is_unit_unit $ to_units Y y
 @[simp] lemma of_is_unit' (x) (hx : x ∈ Y) : is_unit (of Y x) :=
 is_unit_unit $ to_units Y ⟨x, hx⟩
 
-lemma to_units_map_inv (g : monoid_localization X Y →* Z) (y) :
+lemma to_units_map_inv (g : Y.localization →* Z) (y) :
   g ↑(to_units Y y)⁻¹ = ↑(units.map g (to_units Y y))⁻¹ :=
 by rw [←units.coe_map, (units.map g).map_inv]
 
@@ -290,20 +268,20 @@ variables {g}
     invertible elements of `Z`, the homomorphism from `X × Y` to `Z` sending `(x, y)` to
     `f(x) * f(y)⁻¹` is constant on the equivalence classes of the localization of `X` at `Y`. -/
 lemma r_le_ker_aux (H : ∀ y : Y, f y = g y) :
-  Y.r ≤ con.ker (aux f g H) :=
+  localization.r Y ≤ con.ker (aux f g H) :=
 con.Inf_le _ _ (λ y, show f (1 : Y) * ↑(g 1)⁻¹ = f y * ↑(g y)⁻¹, by
   rw [H 1, H y]; simp [units.mul_inv])
 
 /-- Given a `comm_monoid` homomorphism `f : X → Z` mapping elements of a submonoid `Y` to
     invertible elements of `Z`, the homomorphism from the localization of `X` at `Y` sending
     `⟦(x, y)⟧` to `f(x) * f(y)⁻¹`. -/
-def lift' (g : Y → units Z) (H : ∀ y : Y, f y = g y) : monoid_localization X Y →* Z :=
-Y.r.lift (aux f g H) $ r_le_ker_aux f H
+def lift' (g : Y → units Z) (H : ∀ y : Y, f y = g y) : Y.localization →* Z :=
+(localization.r Y).lift (aux f g H) $ r_le_ker_aux f H
 
 /-- Given a `comm_monoid` homomorphism `f : X → Z` mapping elements of a submonoid `Y` to
     invertible elements of `Z`, the homomorphism from the localization of `X` at `Y` sending
     `⟦(x, y)⟧` to `f(x) * f(y)⁻¹`, where `f(y)⁻¹` is chosen nonconstructively. -/
-noncomputable def lift (H : ∀ y : Y, is_unit (f y)) : monoid_localization X Y →* Z :=
+noncomputable def lift (H : ∀ y : Y, is_unit (f y)) : Y.localization →* Z :=
 lift' f _ $ λ _, classical.some_spec $ H _
 
 variables {f}
@@ -343,7 +321,7 @@ by ext; exact lift'_of H _
 @[simp] lemma lift_comp_of (H : ∀ y : Y, is_unit (f y)) :
   (lift f H).comp (of Y) = f := lift'_comp_of _
 
-@[simp] lemma lift'_apply_of (f' : monoid_localization X Y →* Z)
+@[simp] lemma lift'_apply_of (f' : Y.localization →* Z)
   (H : ∀ y : Y, f'.comp (of Y) y = g y) : lift' (f'.comp (of Y)) _ H = f' :=
 begin
   ext x,
@@ -356,11 +334,11 @@ begin
   simp only [mul_one, mk_mul_cancel_right, one_mul],
 end
 
-@[simp] lemma lift_apply_of (g : monoid_localization X Y →* Z) :
+@[simp] lemma lift_apply_of (g : Y.localization →* Z) :
   lift (g.comp $ of Y) (λ y, is_unit_unit $ units.map g $ to_units Y y) = g :=
 lift'_apply_of _ _
 
-lemma  funext (f g : monoid_localization X Y →* Z)
+lemma funext (f g : Y.localization →* Z)
   (h : ∀ a, f.comp (of Y) a = g.comp (of Y) a) : f = g :=
 begin
   rw [←lift_apply_of f, ←lift_apply_of g],
@@ -375,7 +353,7 @@ variables {W : submonoid Z} (f)
     `f(Y) ⊆ W`, the monoid homomorphism from the localization of `X` at `Y` to the localization of
     `Z` at `W` induced by the natural map from `Z` to the localization of `Z` at
     `W` composed with `f`. -/
-def map (hf : ∀ y : Y, f y ∈ W) : monoid_localization X Y →* monoid_localization Z W :=
+def map (hf : ∀ y : Y, f y ∈ W) : Y.localization →* W.localization :=
 lift' ((of W).comp f) ((to_units W).comp $ (f.comp Y.subtype).subtype_mk W hf) $ λ y, rfl
 
 variables {f}
@@ -394,7 +372,7 @@ lemma map_mk (hf : ∀ y : Y, f y ∈ W) (x y) :
   map f hf (mk x y) = mk (f x) ⟨f y, hf y⟩ :=
 (lift'_mk _ _ _).trans (mk_eq _ _).symm
 
-@[simp] lemma map_id (x : monoid_localization X Y) :
+@[simp] lemma map_id (x : Y.localization) :
   map (monoid_hom.id X) (λ (y : Y), y.2) x = x :=
 induction_on x $ λ ⟨w, z⟩, by rw map_mk; exact congr_arg _ (subtype.eq' rfl)
 
@@ -412,4 +390,5 @@ lemma map_ext (g : X →* Z) (hf : ∀ y : Y, f y ∈ W) (hg : ∀ y : Y, g y �
   (h : f = g) (x) : map f hf x = map g hg x :=
 induction_on x $ λ _, by {rw [map_mk, map_mk], congr; rw h; refl}
 
-end monoid_localization
+end localization
+end submonoid


### PR DESCRIPTION
* rename `monoid_localization` to `submonoid.localization` to make
  `Y.localization` work;
* rename `submonoid.r` etc to `submonoid.localization.r` etc to avoid
  potential conflicts with other constructions;
* simplify proofs by using `ac_refl` instead of `abel`; this way
  we don't need to deal with `add_submonoid`s first.
  
TODO: update module docs, possibly rename variables to use different
letter ranges for monoids and submonoids.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)