### PR TITLE
refactor(group_theory/group_action, algebra/module): split

### DIFF
--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2015 Nathaniel Thomas. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro
+-/
+import tactic.cache group_theory.group_action.basic algebra.ring
+
+/-!
+# Modules over a ring.
+
+This file contains definitions of `semimodule`, `module`, and some basic lemmas that do not
+rely on `finset`s and/or `group_power`.
+-/
+
+universes u v w x
+variables {α : Type u} {β : Type v} {γ : Type w} {δ : Type x}
+
+section prio
+set_option default_priority 100 -- see Note [default priority]
+/-- A semimodule is a generalization of vector spaces to a scalar semiring.
+  It consists of a scalar semiring `α` and an additive monoid of "vectors" `β`,
+  connected by a "scalar multiplication" operation `r • x : β`
+  (where `r : α` and `x : β`) with some natural associativity and
+  distributivity axioms similar to those on a ring. -/
+class semimodule (α : Type u) (β : Type v) [semiring α]
+  [add_comm_monoid β] extends distrib_mul_action α β :=
+(add_smul : ∀(r s : α) (x : β), (r + s) • x = r • x + s • x)
+(zero_smul : ∀x : β, (0 : α) • x = 0)
+
+/-- A module is a generalization of vector spaces to a scalar ring.
+  It consists of a scalar ring `α` and an additive group of "vectors" `β`,
+  connected by a "scalar multiplication" operation `r • x : β`
+  (where `r : α` and `x : β`) with some natural associativity and
+  distributivity axioms similar to those on a ring. -/
+class module (α : Type u) (β : Type v) [ring α] [add_comm_group β] extends semimodule α β
+
+end prio
+
+structure module.core (α β) [ring α] [add_comm_group β] extends has_scalar α β :=
+(smul_add : ∀(r : α) (x y : β), r • (x + y) = r • x + r • y)
+(add_smul : ∀(r s : α) (x : β), (r + s) • x = r • x + s • x)
+(mul_smul : ∀(r s : α) (x : β), (r * s) • x = r • s • x)
+(one_smul : ∀x : β, (1 : α) • x = x)
+
+def module.of_core {α β} [ring α] [add_comm_group β] (M : module.core α β) : module α β :=
+by letI := M.to_has_scalar; exact
+{ zero_smul := λ x,
+    have (0 : α) • x + (0 : α) • x = (0 : α) • x + 0, by rw ← M.add_smul; simp,
+    add_left_cancel this,
+  smul_zero := λ r,
+    have r • (0:β) + r • 0 = r • 0 + 0, by rw ← M.smul_add; simp,
+    add_left_cancel this,
+  ..M }
+
+section semimodule
+
+variables [semiring α] [add_comm_monoid β] [semimodule α β] (r s : α) (x y : β)
+
+theorem add_smul : (r + s) • x = r • x + s • x := semimodule.add_smul r s x
+
+variables (α)
+@[simp] theorem zero_smul : (0 : α) • x = 0 := semimodule.zero_smul α x
+
+end semimodule
+
+section module
+variables [ring α] [add_comm_group β] [module α β] (r s : α) (x y : β)
+
+@[simp] theorem neg_smul : -r • x = - (r • x) :=
+eq_neg_of_add_eq_zero (by rw [← add_smul, add_left_neg, zero_smul])
+
+variables (α)
+theorem neg_one_smul (x : β) : (-1 : α) • x = -x := by simp
+variables {α}
+
+@[simp] theorem smul_neg : r • (-x) = -(r • x) :=
+by rw [← neg_one_smul α, ← mul_smul, mul_neg_one, neg_smul]
+
+theorem smul_sub (r : α) (x y : β) : r • (x - y) = r • x - r • y :=
+by simp [smul_add]; rw smul_neg
+
+theorem sub_smul (r s : α) (y : β) : (r - s) • y = r • y - s • y :=
+by simp [add_smul]
+
+end module
+

--- a/src/algebra/module/default.lean
+++ b/src/algebra/module/default.lean
@@ -2,8 +2,12 @@
 Copyright (c) 2015 Nathaniel Thomas. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro
+-/
 
-Modules over a ring.
+import algebra.module.basic algebra.big_operators group_theory.subgroup group_theory.group_action
+
+/-!
+# Modules over a ring.
 
 ## Implementation notes
 
@@ -11,42 +15,14 @@ Modules over a ring.
 Throughout the `linear_map` section implicit `{}` brackets are often used instead of type class `[]` brackets.
 This is done when the instances can be inferred because they are implicit arguments to the type `linear_map`.
 When they can be inferred from the type it is faster to use this method than to use type class inference
-
 -/
-
-import algebra.ring algebra.big_operators group_theory.subgroup group_theory.group_action
 open function
 
 universes u v w x
 variables {α : Type u} {β : Type v} {γ : Type w} {δ : Type x}
 
--- /-- Typeclass for types with a scalar multiplication operation, denoted `•` (`\bu`) -/
--- class has_scalar (α : Type u) (γ : Type v) := (smul : α → γ → γ)
-
--- infixr ` • `:73 := has_scalar.smul
-
-section prio
-set_option default_priority 100 -- see Note [default priority]
-/-- A semimodule is a generalization of vector spaces to a scalar semiring.
-  It consists of a scalar semiring `α` and an additive monoid of "vectors" `β`,
-  connected by a "scalar multiplication" operation `r • x : β`
-  (where `r : α` and `x : β`) with some natural associativity and
-  distributivity axioms similar to those on a ring. -/
-class semimodule (α : Type u) (β : Type v) [semiring α]
-  [add_comm_monoid β] extends distrib_mul_action α β :=
-(add_smul : ∀(r s : α) (x : β), (r + s) • x = r • x + s • x)
-(zero_smul : ∀x : β, (0 : α) • x = 0)
-end prio
-
 section semimodule
-variables [R:semiring α] [add_comm_monoid β] [semimodule α β] (r s : α) (x y : β)
-include R
-
-theorem add_smul : (r + s) • x = r • x + s • x := semimodule.add_smul r s x
-variables (α)
-@[simp] theorem zero_smul : (0 : α) • x = 0 := semimodule.zero_smul α x
-
-variable {α}
+variables [semiring α] [add_comm_monoid β] [semimodule α β] (r s : α) (x y : β)
 
 lemma semimodule.eq_zero_of_zero_eq_one (zero_eq_one : (0 : α) = 1) : x = 0 :=
 by rw [←one_smul α x, ←zero_eq_one, zero_smul]
@@ -69,53 +45,6 @@ show (λ r, r • x) (s.sum f) = s.sum (λ r, (f r) • x),
 from (finset.sum_hom _ _).symm
 
 end semimodule
-
-section prio
-set_option default_priority 100 -- see Note [default priority]
-/-- A module is a generalization of vector spaces to a scalar ring.
-  It consists of a scalar ring `α` and an additive group of "vectors" `β`,
-  connected by a "scalar multiplication" operation `r • x : β`
-  (where `r : α` and `x : β`) with some natural associativity and
-  distributivity axioms similar to those on a ring. -/
-class module (α : Type u) (β : Type v) [ring α] [add_comm_group β] extends semimodule α β
-end prio
-
-structure module.core (α β) [ring α] [add_comm_group β] extends has_scalar α β :=
-(smul_add : ∀(r : α) (x y : β), r • (x + y) = r • x + r • y)
-(add_smul : ∀(r s : α) (x : β), (r + s) • x = r • x + s • x)
-(mul_smul : ∀(r s : α) (x : β), (r * s) • x = r • s • x)
-(one_smul : ∀x : β, (1 : α) • x = x)
-
-def module.of_core {α β} [ring α] [add_comm_group β] (M : module.core α β) : module α β :=
-by letI := M.to_has_scalar; exact
-{ zero_smul := λ x,
-    have (0 : α) • x + (0 : α) • x = (0 : α) • x + 0, by rw ← M.add_smul; simp,
-    add_left_cancel this,
-  smul_zero := λ r,
-    have r • (0:β) + r • 0 = r • 0 + 0, by rw ← M.smul_add; simp,
-    add_left_cancel this,
-  ..M }
-
-section module
-variables [ring α] [add_comm_group β] [module α β] (r s : α) (x y : β)
-
-@[simp] theorem neg_smul : -r • x = - (r • x) :=
-eq_neg_of_add_eq_zero (by rw [← add_smul, add_left_neg, zero_smul])
-
-variables (α)
-theorem neg_one_smul (x : β) : (-1 : α) • x = -x := by simp
-variables {α}
-
-@[simp] theorem smul_neg : r • (-x) = -(r • x) :=
-by rw [← neg_one_smul α, ← mul_smul, mul_neg_one, neg_smul]
-
-theorem smul_sub (r : α) (x y : β) : r • (x - y) = r • x - r • y :=
-by simp [smul_add]; rw smul_neg
-
-theorem sub_smul (r s : α) (y : β) : (r - s) • y = r • y - s • y :=
-by simp [add_smul]
-
-end module
 
 instance semiring.to_semimodule [r : semiring α] : semimodule α α :=
 { smul := (*),

--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2018 Chris Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Hughes
+-/
+import tactic.split_ifs
+
+universes u v w
+variables {α : Type u} {β : Type v} {γ : Type w}
+
+/-- Typeclass for types with a scalar multiplication operation, denoted `•` (`\bu`) -/
+class has_scalar (α : Type u) (γ : Type v) := (smul : α → γ → γ)
+
+infixr ` • `:73 := has_scalar.smul
+
+section prio
+set_option default_priority 100 -- see Note [default priority]
+/-- Typeclass for multiplictive actions by monoids. This generalizes group actions. -/
+class mul_action (α : Type u) (β : Type v) [monoid α] extends has_scalar α β :=
+(one_smul : ∀ b : β, (1 : α) • b = b)
+(mul_smul : ∀ (x y : α) (b : β), (x * y) • b = x • y • b)
+end prio
+
+section
+variables [monoid α] [mul_action α β]
+
+theorem mul_smul (a₁ a₂ : α) (b : β) : (a₁ * a₂) • b = a₁ • a₂ • b := mul_action.mul_smul _ _ _
+
+lemma smul_smul (a₁ a₂ : α) (b : β) : a₁ • a₂ • b = (a₁ * a₂) • b := (mul_smul _ _ _).symm
+
+variable (α)
+@[simp] theorem one_smul (b : β) : (1 : α) • b = b := mul_action.one_smul α _
+
+variables {α} (p : Prop) [decidable p]
+
+lemma ite_smul (a₁ a₂ : α) (b : β) : (ite p a₁ a₂) • b = ite p (a₁ • b) (a₂ • b) :=
+by split_ifs; refl
+
+lemma smul_ite (a : α) (b₁ b₂ : β) : a • (ite p b₁ b₂) = ite p (a • b₁) (a • b₂) :=
+by split_ifs; refl
+
+end
+
+section prio
+set_option default_priority 100 -- see Note [default priority]
+/-- Typeclass for multiplicative actions on additive structures. This generalizes group modules. -/
+class distrib_mul_action (α : Type u) (β : Type v) [monoid α] [add_monoid β] extends mul_action α β :=
+(smul_add : ∀(r : α) (x y : β), r • (x + y) = r • x + r • y)
+(smul_zero {} : ∀(r : α), r • (0 : β) = 0)
+end prio
+
+variables [monoid α] [add_monoid β] [distrib_mul_action α β]
+
+theorem smul_add (a : α) (b₁ b₂ : β) : a • (b₁ + b₂) = a • b₁ + a • b₂ :=
+distrib_mul_action.smul_add _ _ _
+
+@[simp] theorem smul_zero (a : α) : a • (0 : β) = 0 :=
+distrib_mul_action.smul_zero _

--- a/src/group_theory/group_action/default.lean
+++ b/src/group_theory/group_action/default.lean
@@ -3,43 +3,10 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
-import data.set.finite group_theory.coset
+import group_theory.group_action.basic data.set.finite group_theory.coset
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
-
-/-- Typeclass for types with a scalar multiplication operation, denoted `•` (`\bu`) -/
-class has_scalar (α : Type u) (γ : Type v) := (smul : α → γ → γ)
-
-infixr ` • `:73 := has_scalar.smul
-
-section prio
-set_option default_priority 100 -- see Note [default priority]
-/-- Typeclass for multiplictive actions by monoids. This generalizes group actions. -/
-class mul_action (α : Type u) (β : Type v) [monoid α] extends has_scalar α β :=
-(one_smul : ∀ b : β, (1 : α) • b = b)
-(mul_smul : ∀ (x y : α) (b : β), (x * y) • b = x • y • b)
-end prio
-
-section
-variables [monoid α] [mul_action α β]
-
-theorem mul_smul (a₁ a₂ : α) (b : β) : (a₁ * a₂) • b = a₁ • a₂ • b := mul_action.mul_smul _ _ _
-
-lemma smul_smul (a₁ a₂ : α) (b : β) : a₁ • a₂ • b = (a₁ * a₂) • b := (mul_smul _ _ _).symm
-
-variable (α)
-@[simp] theorem one_smul (b : β) : (1 : α) • b = b := mul_action.one_smul α _
-
-variables {α} (p : Prop) [decidable p]
-
-lemma ite_smul (a₁ a₂ : α) (b : β) : (ite p a₁ a₂) • b = ite p (a₁ • b) (a₂ • b) :=
-by split_ifs; refl
-
-lemma smul_ite (a : α) (b₁ b₂ : β) : a • (ite p b₁ b₂) = ite p (a • b₁) (a • b₂) :=
-by split_ifs; refl
-
-end
 
 namespace mul_action
 
@@ -182,22 +149,8 @@ mul_action.comp_hom (quotient H) (subtype.val : I → α)
 
 end mul_action
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
-/-- Typeclass for multiplicative actions on additive structures. This generalizes group modules. -/
-class distrib_mul_action (α : Type u) (β : Type v) [monoid α] [add_monoid β] extends mul_action α β :=
-(smul_add : ∀(r : α) (x y : β), r • (x + y) = r • x + r • y)
-(smul_zero {} : ∀(r : α), r • (0 : β) = 0)
-end prio
-
 section
 variables [monoid α] [add_monoid β] [distrib_mul_action α β]
-
-theorem smul_add (a : α) (b₁ b₂ : β) : a • (b₁ + b₂) = a • b₁ + a • b₂ :=
-distrib_mul_action.smul_add _ _ _
-
-@[simp] theorem smul_zero (a : α) : a • (0 : β) = 0 :=
-distrib_mul_action.smul_zero _
 
 instance distrib_mul_action.is_add_monoid_hom (r : α) :
   is_add_monoid_hom ((•) r : β → β) :=


### PR DESCRIPTION
The files `group_theory/group_action/basic` and `algebra/module/basic`
do not rely on `group_power`.

I'm going to import then in `group_power`, see [this discussion](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60add_monoid.2Esmul.60.2C.20.60add_group.2Egsmul.60).

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)