### PR TITLE
refactor(algebra/field): partially migrate to bundled homs

### DIFF
--- a/src/algebra/field.lean
+++ b/src/algebra/field.lean
@@ -214,34 +214,63 @@ end
 
 end
 
+namespace ring_hom
+
+section
+
+variables {β : Type*} [division_ring α] [division_ring β] (f : α →+* β) {x y : α}
+
+lemma map_ne_zero : f x ≠ 0 ↔ x ≠ 0 :=
+⟨mt $ λ h, h.symm ▸ f.map_zero,
+ λ x0 h, one_ne_zero $ by rw [← f.map_one, ← mul_inv_cancel x0, f.map_mul, h, zero_mul]⟩
+
+lemma map_eq_zero : f x = 0 ↔ x = 0 :=
+by haveI := classical.dec; exact not_iff_not.1 f.map_ne_zero
+
+lemma map_inv' (h : x ≠ 0) : f x⁻¹ = (f x)⁻¹ :=
+(domain.mul_left_inj (f.map_ne_zero.2 h)).1 $
+by rw [mul_inv_cancel (f.map_ne_zero.2 h), ← f.map_mul, mul_inv_cancel h, f.map_one]
+
+lemma map_div' (h : y ≠ 0) : f (x / y) = f x / f y :=
+(f.map_mul _ _).trans $ congr_arg _ $ f.map_inv' h
+
+lemma injective : function.injective f :=
+f.injective_iff.2
+  (λ a ha, classical.by_contradiction $ λ ha0,
+    by simpa [ha, f.map_mul, f.map_one, zero_ne_one]
+        using congr_arg f (mul_inv_cancel ha0))
+
+end
+
+section
+
+variables {β : Type*} [discrete_field α] [discrete_field β] (f : α →+* β) {x y : α}
+
+lemma map_inv : f x⁻¹ = (f x)⁻¹ :=
+classical.by_cases (by rintro rfl; simp only [map_zero f, inv_zero]) (map_inv' f)
+
+lemma map_div : f (x / y) = f x / f y :=
+(f.map_mul _ _).trans $ congr_arg _ $ map_inv f
+
+end
+end ring_hom
+
 namespace is_ring_hom
-open is_ring_hom
+open ring_hom (of)
 
 section
 variables {β : Type*} [division_ring α] [division_ring β]
 variables (f : α → β) [is_ring_hom f] {x y : α}
 
-lemma map_ne_zero : f x ≠ 0 ↔ x ≠ 0 :=
-⟨mt $ λ h, h.symm ▸ map_zero f,
- λ x0 h, one_ne_zero $ calc
-    1 = f (x * x⁻¹) : by rw [mul_inv_cancel x0, map_one f]
-  ... = 0 : by rw [map_mul f, h, zero_mul]⟩
+lemma map_ne_zero : f x ≠ 0 ↔ x ≠ 0 := (of f).map_ne_zero
 
-lemma map_eq_zero : f x = 0 ↔ x = 0 :=
-by haveI := classical.dec; exact not_iff_not.1 (map_ne_zero f)
+lemma map_eq_zero : f x = 0 ↔ x = 0 := (of f).map_eq_zero
 
-lemma map_inv' (h : x ≠ 0) : f x⁻¹ = (f x)⁻¹ :=
-(domain.mul_left_inj ((map_ne_zero f).2 h)).1 $
-by rw [mul_inv_cancel ((map_ne_zero f).2 h), ← map_mul f, mul_inv_cancel h, map_one f]
+lemma map_inv' (h : x ≠ 0) : f x⁻¹ = (f x)⁻¹ := (of f).map_inv' h
 
-lemma map_div' (h : y ≠ 0) : f (x / y) = f x / f y :=
-(map_mul f).trans $ congr_arg _ $ map_inv' f h
+lemma map_div' (h : y ≠ 0) : f (x / y) = f x / f y := (of f).map_div' h
 
-lemma injective : function.injective f :=
-(is_add_group_hom.injective_iff _).2
-  (λ a ha, classical.by_contradiction $ λ ha0,
-    by simpa [ha, is_ring_hom.map_mul f, is_ring_hom.map_one f, zero_ne_one]
-        using congr_arg f (mul_inv_cancel ha0))
+lemma injective : function.injective f := (of f).injective
 
 end
 
@@ -249,11 +278,9 @@ section
 variables {β : Type*} [discrete_field α] [discrete_field β]
 variables (f : α → β) [is_ring_hom f] {x y : α}
 
-lemma map_inv : f x⁻¹ = (f x)⁻¹ :=
-classical.by_cases (by rintro rfl; simp only [map_zero f, inv_zero]) (map_inv' f)
+lemma map_inv : f x⁻¹ = (f x)⁻¹ := (of f).map_inv
 
-lemma map_div : f (x / y) = f x / f y :=
-(map_mul f).trans $ congr_arg _ $ map_inv f
+lemma map_div : f (x / y) = f x / f y := (of f).map_div
 
 end
 

--- a/src/algebra/field.lean
+++ b/src/algebra/field.lean
@@ -262,9 +262,9 @@ section
 variables {β : Type*} [division_ring α] [division_ring β]
 variables (f : α → β) [is_ring_hom f] {x y : α}
 
-lemma map_ne_zero : f x ≠ 0 ↔ x ≠ 0 := (of f).map_ne_zero
+@[simp] lemma map_ne_zero : f x ≠ 0 ↔ x ≠ 0 := (of f).map_ne_zero
 
-lemma map_eq_zero : f x = 0 ↔ x = 0 := (of f).map_eq_zero
+@[simp] lemma map_eq_zero : f x = 0 ↔ x = 0 := (of f).map_eq_zero
 
 lemma map_inv' (h : x ≠ 0) : f x⁻¹ = (f x)⁻¹ := (of f).map_inv' h
 
@@ -278,9 +278,9 @@ section
 variables {β : Type*} [discrete_field α] [discrete_field β]
 variables (f : α → β) [is_ring_hom f] {x y : α}
 
-lemma map_inv : f x⁻¹ = (f x)⁻¹ := (of f).map_inv
+@[simp] lemma map_inv : f x⁻¹ = (f x)⁻¹ := (of f).map_inv
 
-lemma map_div : f (x / y) = f x / f y := (of f).map_div
+@[simp] lemma map_div : f (x / y) = f x / f y := (of f).map_div
 
 end
 

--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -60,7 +60,7 @@ pow_one a
 
 end field_power
 
-lemma ring_hom.map_fpow {α β : Type*} [discrete_field α] [discrete_field β] (f : α →+* β)
+@[simp] lemma ring_hom.map_fpow {α β : Type*} [discrete_field α] [discrete_field β] (f : α →+* β)
   (a : α) : ∀ (n : ℤ), f (a ^ n) = f a ^ n
 | (n : ℕ) := f.map_pow a n
 | -[1+n] := by simp [fpow_neg_succ_of_nat, f.map_pow, f.map_inv]

--- a/src/field_theory/subfield.lean
+++ b/src/field_theory/subfield.lean
@@ -35,23 +35,23 @@ instance univ.is_subfield : is_subfield (@set.univ F) :=
   `is_add_subgroup _` and `is_submonoid _` are chosen (which are not the default ones).
   If we specify it explicitly, then it doesn't complain. -/
 instance preimage.is_subfield {K : Type*} [discrete_field K]
-  (f : F → K) [is_ring_hom f] (s : set K) [is_subfield s] : is_subfield (f ⁻¹' s) :=
+  (f : F →+* K) (s : set K) [is_subfield s] : is_subfield (f ⁻¹' s) :=
 { inv_mem := λ a ha0 (ha : f a ∈ s), show f a⁻¹ ∈ s,
-    by { rw [is_ring_hom.map_inv' f ha0],
-         exact is_subfield.inv_mem ((is_ring_hom.map_ne_zero f).2 ha0) ha },
+    by { rw [f.map_inv' ha0],
+         exact is_subfield.inv_mem (f.map_ne_zero.2 ha0) ha },
   ..is_ring_hom.is_subring_preimage f s }
 
 instance image.is_subfield {K : Type*} [discrete_field K]
-  (f : F → K) [is_ring_hom f] (s : set F) [is_subfield s] : is_subfield (f '' s) :=
+  (f : F →+* K) (s : set F) [is_subfield s] : is_subfield (f '' s) :=
 { inv_mem := λ a ha0 ⟨x, hx⟩,
-    have hx0 : x ≠ 0, from λ hx0, ha0 (hx.2 ▸ hx0.symm ▸ is_ring_hom.map_zero f),
+    have hx0 : x ≠ 0, from λ hx0, ha0 (hx.2 ▸ hx0.symm ▸ f.map_zero),
     ⟨x⁻¹, is_subfield.inv_mem hx0 hx.1,
-    by { rw [← hx.2, is_ring_hom.map_inv' f hx0], refl }⟩,
+    by { rw [← hx.2, f.map_inv' hx0], refl }⟩,
   ..is_ring_hom.is_subring_image f s }
 
 instance range.is_subfield {K : Type*} [discrete_field K]
-  (f : F → K) [is_ring_hom f] : is_subfield (set.range f) :=
-by rw ← set.image_univ; apply_instance
+  (f : F →+* K) : is_subfield (set.range f) :=
+by { rw ← set.image_univ, apply_instance }
 
 namespace field
 


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)