### PR TITLE
chore(*): reduce proof size

### DIFF
--- a/src/data/dfinsupp.lean
+++ b/src/data/dfinsupp.lean
@@ -564,7 +564,7 @@ local attribute [instance] dfinsupp.to_module
 lemma support_smul {γ : Type w} [ring γ] [Π i, add_comm_group (β i)] [Π i, module γ (β i)]
   [Π (i : ι), decidable_pred (eq (0 : β i))]
   {b : γ} {v : Π₀ i, β i} : (b • v).support ⊆ v.support :=
-λ x, by simp [dfinsupp.mem_support_iff, not_imp_not] {contextual := tt}
+support_map_range
 
 instance [decidable_eq ι] [Π i, has_zero (β i)] [Π i, decidable_eq (β i)] : decidable_eq (Π₀ i, β i) :=
 assume f g, decidable_of_iff (f.support = g.support ∧ (∀i∈f.support, f i = g i))

--- a/src/measure_theory/ae_eq_fun.lean
+++ b/src/measure_theory/ae_eq_fun.lean
@@ -223,7 +223,7 @@ lemma mk_le_mk [preorder β] {f g : α → β} (hf hg) : mk f hf ≤ mk g hg ↔
 iff.rfl
 
 lemma le_iff_to_fun_le [preorder β] {f g : α →ₘ β} : f ≤ g ↔ ∀ₘ a, f.to_fun a ≤ g.to_fun a :=
-by { conv_lhs { rw [self_eq_mk f, self_eq_mk g] }, rw mk_le_mk }
+lift_rel_iff_to_fun _ _ _
 
 instance [partial_order β] : partial_order (α →ₘ β) :=
 { le_antisymm :=


### PR DESCRIPTION
Make some proofs shorter by a few characters.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
