### PR TITLE
feat(docs): install mathlibtools package with pip

### DIFF
--- a/docs/contribute/index.md
+++ b/docs/contribute/index.md
@@ -48,9 +48,8 @@ for more details.
 In the `mathlib` git repository, you can run the following in a terminal:
 
 ```sh
-$ curl https://raw.githubusercontent.com/leanprover-community/mathlib-tools/master/scripts/remote-install-update-mathlib.sh -sSf | bash
-$ source ~/.profile
-$ setup-lean-git-hooks
+sudo pip3 install mathlibtools
+setup-lean-git-hooks
 ```
 
 It will install scripts including `update-mathlib` and `cache-olean`

--- a/docs/install/debian_details.md
+++ b/docs/install/debian_details.md
@@ -5,15 +5,21 @@ for Lean and mathlib on Linux distributions derived from Debian (Debian itself,
 Ubuntu, LMDE,...). There is a quicker way described in the main
 [install page](install_debian.md) but it requires more trust.
 Of course you can get even more details about what is going on by
-reading the bash scripts that will be downloaded below:
-[elan_init](https://github.com/Kha/elan/blob/master/elan-init.sh) and
-[remote-install-update-mathlib](https://github.com/leanprover-community/mathlib-tools/blob/master/scripts/remote-install-update-mathlib.sh).
-All commands below should be typed inside a terminal.
+reading the bash script that will be downloaded below:
+[elan_init](https://github.com/Kha/elan/blob/master/elan-init.sh).
 
 * Lean itself doesn't depend on much infrastructure, but supporting tools
   needed by most users require `git`, `curl`, and `python`. So the first step is:
   ```bash
   sudo apt install git curl python3 python3-pip
+  ```
+
+* The next step installs a small tool called `elan` which will handle
+  updating Lean according to the needs of your current project (hit Enter
+  when a question is asked). It will live in `$HOME/.elan` and adds a
+  line to `$HOME/.profile`.
+  ```bash
+  curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh
   ```
 
 * There are two editors you can use with Lean, VS Code and emacs. The
@@ -31,21 +37,10 @@ All commands below should be typed inside a terminal.
 
   The alternative is to use Emacs, and its [lean-mode](https://github.com/leanprover/lean-mode).
 
-  Everything else will be installed in user-space (no sudo required).
-
-* The next step installs a small tool called `elan` which will handle
-  updating Lean according to the needs of your current project (hit Enter
-  when a question is asked). It will live in `$HOME/.elan` and add a
-  line to `$HOME/.profile`.
-  ```bash
-  curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh
-  ```
-
 * Then we install a small tool called `update-mathlib` that which will handle
   updating mathlib according to the needs of your current project.
-  It will live in `$HOME/.mathlib` and add a line to `$HOME/.profile`.
   ```bash
-  curl https://raw.githubusercontent.com/leanprover-community/mathlib-tools/master/scripts/remote-install-update-mathlib.sh -sSf | bash
+  sudo pip3 install mathlibtools
   ```
 
 You can now read instructions about creating and working on [Lean projects](project.md)

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -5,7 +5,16 @@ This document explains how to get started with Lean and mathlib on a generic Lin
 All commands below should be typed inside a terminal.
 
 * Lean itself doesn't depend on much infrastructure, but supporting tools
-  needed by most users require `git`, `curl`, and `python`. So the first step is to get those.
+  needed by most users require `git`, `curl`, and `python3` (on Debian and
+  Ubuntu also `python3-pip`). So the first step is to get those.
+
+* The next step installs a small tool called `elan` which will handle
+  updating Lean according to the needs of your current project (hit Enter
+  when a question is asked). It will live in `$HOME/.elan` and add a
+  line to `$HOME/.profile`.
+  ```bash
+  curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh
+  ```
 
 * You will also need a code editor that has a Lean plugin. The
   recommended choice is [Visual Studio Code](https://code.visualstudio.com/).
@@ -21,19 +30,10 @@ All commands below should be typed inside a terminal.
     A green line should appear underneath `#eval 1+1`, and hovering the mouse over it you should see `2`
     displayed.
 
-* The next step installs a small tool called `elan` which will handle
-  updating Lean according to the needs of your current project (hit Enter
-  when a question is asked). It will live in `$HOME/.elan` and add a
-  line to `$HOME/.profile`.
-  ```bash
-  curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh
-  ```
-
 * Then we install a small tool called `update-mathlib` that which will handle
   updating mathlib according to the needs of your current project.
-  It will live in `$HOME/.mathlib` and add a line to `$HOME/.profile`.
   ```bash
-  curl https://raw.githubusercontent.com/leanprover-community/mathlib-tools/master/scripts/remote-install-update-mathlib.sh -sSf | bash
+  sudo pip3 install mathlibtools
   ```
 
 You can now read instructions about creating and working on [Lean projects](project.md)

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -36,13 +36,11 @@ Installing mathlib supporting tools
 
 At a terminal, run the command
   ```bash
-  curl https://raw.githubusercontent.com/leanprover-community/mathlib-tools/master/scripts/remote-install-update-mathlib.sh -sSf | bash
+  brew install python3
+  sudo pip3 install mathlibtools
   ```
-If the script asks you whether you want to install `python3` and `pip3`, type `y`.
 
 This will install tools that, amongst other things, let you download compiled binaries for mathlib.
-
-Then run `source ~/.profile`, so that your environment knows about `update-mathlib`.
 
 Installing and configuring an editor
 ---

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -65,9 +65,8 @@ In order to use mathlib supporting tools, you need to [get python](https://www.p
 
 Then, at a terminal, run the command
   ```bash
-  curl https://raw.githubusercontent.com/leanprover-community/mathlib-tools/master/scripts/remote-install-update-mathlib.sh -sSf | bash
+  pip3 install mathlibtools
   ```
-Run `source ~/.profile` or close and reopen Git Bash.
 
 Installing and configuring an editor
 ---


### PR DESCRIPTION
This is the documentation part of https://github.com/leanprover-community/mathlib-tools/pull/12, which changes the `mathlib-tools` installation method from curlbash to `pip3 install`.