### PR TITLE
chore(analysis/normed_space/basic): implicit args

### DIFF
--- a/src/analysis/asymptotics.lean
+++ b/src/analysis/asymptotics.lean
@@ -862,7 +862,7 @@ by refine ((h.norm_left.const_mul_left (∥c'∥)).congr _ _ (λ _, rfl)).of_nor
 theorem is_O_const_smul_left_iff {c : 𝕜} (hc : c ≠ 0) :
   is_O (λ x, c • f' x) g l ↔ is_O f' g l :=
 begin
-  have cne0 : ∥c∥ ≠ 0, from mt (norm_eq_zero _).mp hc,
+  have cne0 : ∥c∥ ≠ 0, from mt norm_eq_zero.mp hc,
   rw [←is_O_norm_left], simp only [norm_smul],
   rw [is_O_const_mul_left_iff cne0, is_O_norm_left],
 end
@@ -877,7 +877,7 @@ end
 theorem is_o_const_smul_left_iff {c : 𝕜} (hc : c ≠ 0) :
   is_o (λ x, c • f' x) g l ↔ is_o f' g l :=
 begin
-  have cne0 : ∥c∥ ≠ 0, from mt (norm_eq_zero _).mp hc,
+  have cne0 : ∥c∥ ≠ 0, from mt norm_eq_zero.mp hc,
   rw [←is_o_norm_left], simp only [norm_smul],
   rw [is_o_const_mul_left_iff cne0, is_o_norm_left]
 end
@@ -885,7 +885,7 @@ end
 theorem is_O_const_smul_right {c : 𝕜} (hc : c ≠ 0) :
   is_O f (λ x, c • f' x) l ↔ is_O f f' l :=
 begin
-  have cne0 : ∥c∥ ≠ 0, from mt (norm_eq_zero _).mp hc,
+  have cne0 : ∥c∥ ≠ 0, from mt norm_eq_zero.mp hc,
   rw [←is_O_norm_right], simp only [norm_smul],
   rw [is_O_const_mul_right_iff cne0, is_O_norm_right]
 end
@@ -893,7 +893,7 @@ end
 theorem is_o_const_smul_right {c : 𝕜} (hc : c ≠ 0) :
   is_o f (λ x, c • f' x) l ↔ is_o f f' l :=
 begin
-  have cne0 : ∥c∥ ≠ 0, from mt (norm_eq_zero _).mp hc,
+  have cne0 : ∥c∥ ≠ 0, from mt norm_eq_zero.mp hc,
   rw [←is_o_norm_right], simp only [norm_smul],
   rw [is_o_const_mul_right_iff cne0, is_o_norm_right]
 end

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -977,8 +977,8 @@ begin
       0 < ∥(1:𝕜)∥ - ∥-h∥ : by rwa [norm_neg, sub_pos, ← dist_zero_right h, normed_field.norm_one]
       ... ≤ ∥1 - -h∥ : norm_sub_norm_le _ _
       ... = ∥1 + h∥ : by simp,
-    have : 1 + h ≠ 0 := (norm_pos_iff (1 + h)).mp this,
-    simp only [mem_set_of_eq, smul_eq_mul, inv_one],
+    have : 1 + h ≠ 0 := norm_pos_iff.mp this,
+    simp only [mem_set_of_eq, smul_eq_mul],
     field_simp [this, -add_comm],
     ring },
   { exact univ_mem_sets' mul_one }

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -231,7 +231,7 @@ theorem has_fderiv_at_filter_iff_tendsto :
   has_fderiv_at_filter f f' x L ↔
   tendsto (λ x', ∥x' - x∥⁻¹ * ∥f x' - f x - f' (x' - x)∥) L (𝓝 0) :=
 have h : ∀ x', ∥x' - x∥ = 0 → ∥f x' - f x - f' (x' - x)∥ = 0, from λ x' hx',
-  by { rw [sub_eq_zero.1 ((norm_eq_zero (x' - x)).1 hx')], simp },
+  by { rw [sub_eq_zero.1 (norm_eq_zero.1 hx')], simp },
 begin
   unfold has_fderiv_at_filter,
   rw [←is_o_norm_left, ←is_o_norm_right, is_o_iff_tendsto h],

--- a/src/analysis/calculus/tangent_cone.lean
+++ b/src/analysis/calculus/tangent_cone.lean
@@ -335,7 +335,7 @@ begin
     have ys : y ∈ s := interior_subset hy,
     have : ∃(δ : ℝ), 0<δ ∧ y + δ • v ∈ s,
     { by_cases h : ∥v∥ = 0,
-      { exact ⟨1, zero_lt_one, by simp [(norm_eq_zero _).1 h, ys]⟩ },
+      { exact ⟨1, zero_lt_one, by simp [norm_eq_zero.1 h, ys]⟩ },
       { rcases mem_interior.1 hy with ⟨u, us, u_open, yu⟩,
         rcases metric.is_open_iff.1 u_open y yu with ⟨ε, εpos, hε⟩,
         let δ := (ε/2) / ∥v∥,

--- a/src/analysis/normed_space/banach.lean
+++ b/src/analysis/normed_space/banach.lean
@@ -55,7 +55,7 @@ begin
       { rcases rescale_to_shell hc (half_pos εpos) hy with ⟨d, hd, ydle, leyd, dinv⟩,
         let δ := ∥d∥ * ∥y∥/4,
         have δpos : 0 < δ :=
-          div_pos (mul_pos ((norm_pos_iff _).2 hd) ((norm_pos_iff _).2 hy)) (by norm_num),
+          div_pos (mul_pos (norm_pos_iff.2 hd) (norm_pos_iff.2 hy)) (by norm_num),
         have : a + d • y ∈ ball a ε,
           by simp [dist_eq_norm, lt_of_le_of_lt ydle (half_lt_self εpos)],
         rcases metric.mem_closure_iff.1 (H this) _ δpos with ⟨z₁, z₁im, h₁⟩,

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -135,10 +135,10 @@ le_trans (dist_sub_sub_le g₁ g₂ h₁ h₂) (add_le_add H₁ H₂)
 @[simp] lemma norm_nonneg (g : α) : 0 ≤ ∥g∥ :=
 by { rw[←dist_zero_right], exact dist_nonneg }
 
-lemma norm_eq_zero (g : α) : ∥g∥ = 0 ↔ g = 0 :=
-by { rw[←dist_zero_right], exact dist_eq_zero }
+lemma norm_eq_zero {g : α} : ∥g∥ = 0 ↔ g = 0 :=
+dist_zero_right g ▸ dist_eq_zero
 
-@[simp] lemma norm_zero : ∥(0:α)∥ = 0 := (norm_eq_zero _).2 rfl
+@[simp] lemma norm_zero : ∥(0:α)∥ = 0 := norm_eq_zero.2 rfl
 
 lemma norm_sum_le {β} : ∀(s : finset β) (f : β → α), ∥s.sum f∥ ≤ s.sum (λa, ∥ f a ∥) :=
 finset.le_sum_of_subadditive norm norm_zero norm_add_le
@@ -147,10 +147,10 @@ lemma norm_sum_le_of_le {β} (s : finset β) {f : β → α} {n : β → ℝ} (h
   ∥s.sum f∥ ≤ s.sum n :=
 by { haveI := classical.dec_eq β, exact le_trans (norm_sum_le s f) (finset.sum_le_sum h) }
 
-lemma norm_pos_iff (g : α) : 0 < ∥ g ∥ ↔ g ≠ 0 :=
+lemma norm_pos_iff {g : α} : 0 < ∥ g ∥ ↔ g ≠ 0 :=
 dist_zero_right g ▸ dist_pos
 
-lemma norm_le_zero_iff (g : α) : ∥g∥ ≤ 0 ↔ g = 0 :=
+lemma norm_le_zero_iff {g : α} : ∥g∥ ≤ 0 ↔ g = 0 :=
 by { rw[←dist_zero_right], exact dist_le_zero }
 
 lemma norm_sub_le (g h : α) : ∥g - h∥ ≤ ∥g∥ + ∥h∥ :=
@@ -202,7 +202,7 @@ def nnnorm (a : α) : nnreal := ⟨norm a, norm_nonneg a⟩
 
 lemma nndist_eq_nnnorm (a b : α) : nndist a b = nnnorm (a - b) := nnreal.eq $ dist_eq_norm _ _
 
-lemma nnnorm_eq_zero (a : α) : nnnorm a = 0 ↔ a = 0 :=
+lemma nnnorm_eq_zero {a : α} : nnnorm a = 0 ↔ a = 0 :=
 by simp only [nnreal.eq_iff.symm, nnreal.coe_zero, coe_nnnorm, norm_eq_zero]
 
 @[simp] lemma nnnorm_zero : nnnorm (0 : α) = 0 :=
@@ -434,7 +434,7 @@ namespace normed_field
 have  ∥(1 : α)∥ * ∥(1 : α)∥ = ∥(1 : α)∥ * 1, by calc
  ∥(1 : α)∥ * ∥(1 : α)∥ = ∥(1 : α) * (1 : α)∥ : by rw normed_field.norm_mul'
                   ... = ∥(1 : α)∥ * 1 : by simp,
-eq_of_mul_eq_mul_left (ne_of_gt ((norm_pos_iff _).2 (by simp))) this
+eq_of_mul_eq_mul_left (ne_of_gt (norm_pos_iff.2 (by simp))) this
 
 @[simp] lemma norm_mul [normed_field α] (a b : α) : ∥a * b∥ = ∥a∥ * ∥b∥ :=
 normed_field.norm_mul' a b
@@ -453,7 +453,7 @@ eq.symm (s.prod_hom norm)
 if hb : b = 0 then by simp [hb] else
 begin
   apply eq_div_of_mul_eq,
-  { apply ne_of_gt, apply (norm_pos_iff _).mpr hb },
+  { apply ne_of_gt, apply norm_pos_iff.mpr hb },
   { rw [←normed_field.norm_mul, div_mul_cancel _ hb] }
 end
 
@@ -497,7 +497,7 @@ lemma tendsto_inv [normed_field α] {r : α} (r0 : r ≠ 0) : tendsto (λq, q⁻
 begin
   refine (nhds_basis_closed_ball.tendsto_iff nhds_basis_closed_ball).2 (λε εpos, _),
   let δ := min (ε/2 * ∥r∥^2) (∥r∥/2),
-  have norm_r_pos : 0 < ∥r∥ := (norm_pos_iff r).mpr r0,
+  have norm_r_pos : 0 < ∥r∥ := norm_pos_iff.mpr r0,
   have A : 0 < ε / 2 * ∥r∥ ^ 2 := mul_pos' (half_pos εpos) (pow_pos norm_r_pos 2),
   have δpos : 0 < δ, by simp [half_pos norm_r_pos, A],
   refine ⟨δ, δpos, λ x hx, _⟩,
@@ -513,7 +513,7 @@ begin
     ... = ∥x∥ : by simp,
   have norm_x_pos : 0 < ∥x∥ := lt_of_lt_of_le (half_pos norm_r_pos) rx,
   have : x⁻¹ - r⁻¹ = (r - x) * x⁻¹ * r⁻¹,
-    by rw [sub_mul, sub_mul, mul_inv_cancel ((norm_pos_iff x).mp norm_x_pos), one_mul, mul_comm,
+    by rw [sub_mul, sub_mul, mul_inv_cancel (norm_pos_iff.mp norm_x_pos), one_mul, mul_comm,
            ← mul_assoc, inv_mul_cancel r0, one_mul],
   calc dist x⁻¹ r⁻¹ = ∥x⁻¹ - r⁻¹∥ : dist_eq_norm _ _
   ... ≤ ∥r-x∥ * ∥x∥⁻¹ * ∥r∥⁻¹ : by rw [this, norm_mul, norm_mul, norm_inv, norm_inv]
@@ -644,7 +644,7 @@ up in applications. -/
 lemma rescale_to_shell {c : α} (hc : 1 < ∥c∥) {ε : ℝ} (εpos : 0 < ε) {x : E} (hx : x ≠ 0) :
   ∃d:α, d ≠ 0 ∧ ∥d • x∥ ≤ ε ∧ (ε/∥c∥ ≤ ∥d • x∥) ∧ (∥d∥⁻¹ ≤ ε⁻¹ * ∥c∥ * ∥x∥) :=
 begin
-  have xεpos : 0 < ∥x∥/ε := div_pos_of_pos_of_pos ((norm_pos_iff _).2 hx) εpos,
+  have xεpos : 0 < ∥x∥/ε := div_pos_of_pos_of_pos (norm_pos_iff.2 hx) εpos,
   rcases exists_int_pow_near xεpos hc with ⟨n, hn⟩,
   have cpos : 0 < ∥c∥ := lt_trans (zero_lt_one : (0 :ℝ) < 1) hc,
   have cnpos : 0 < ∥c^(n+1)∥ := by { rw norm_fpow, exact lt_trans xεpos hn.2 },

--- a/src/analysis/normed_space/multilinear.lean
+++ b/src/analysis/normed_space/multilinear.lean
@@ -330,7 +330,7 @@ begin
   split,
   { assume h,
     ext m,
-    simpa [h, (norm_le_zero_iff _).symm] using f.le_op_norm m },
+    simpa [h, norm_le_zero_iff.symm] using f.le_op_norm m },
   { assume h,
     apply le_antisymm (op_norm_le_bound f (le_refl _) (λm, _)) (op_norm_nonneg _),
     rw h,

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -211,7 +211,7 @@ lb_le_Inf _ bounds_nonempty (λ _ ⟨hx, _⟩, hx)
 theorem le_op_norm : ∥f x∥ ≤ ∥f∥ * ∥x∥ :=
 classical.by_cases
   (λ heq : x = 0, by { rw heq, simp })
-  (λ hne, have hlt : 0 < ∥x∥, from (norm_pos_iff _).2 hne,
+  (λ hne, have hlt : 0 < ∥x∥, from norm_pos_iff.2 hne,
     le_mul_of_div_le hlt ((le_Inf _ bounds_nonempty bounds_bdd_below).2
     (λ c ⟨_, hc⟩, div_le_of_le_mul hlt (by { rw mul_comm, apply hc }))))
 
@@ -242,7 +242,7 @@ Inf_le _ bounds_bdd_below
 /-- An operator is zero iff its norm vanishes. -/
 theorem op_norm_zero_iff : ∥f∥ = 0 ↔ f = 0 :=
 iff.intro
-  (λ hn, continuous_linear_map.ext (λ x, (norm_le_zero_iff _).1
+  (λ hn, continuous_linear_map.ext (λ x, norm_le_zero_iff.1
     (calc _ ≤ ∥f∥ * ∥x∥ : le_op_norm _ _
      ...     = _ : by rw [hn, zero_mul])))
   (λ hf, le_antisymm (Inf_le _ bounds_bdd_below

--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -132,7 +132,7 @@ lemma tendsto_pow_at_top_at_top_of_gt_1 {r : ℝ} (h : 1 < r) :
 
 lemma lim_norm_zero' {𝕜 : Type*} [normed_group 𝕜] :
   tendsto (norm : 𝕜 → ℝ) (nhds_within 0 {x | x ≠ 0}) (nhds_within 0 (set.Ioi 0)) :=
-lim_norm_zero.inf $ tendsto_principal_principal.2 $ λ x hx, (norm_pos_iff _).2 hx
+lim_norm_zero.inf $ tendsto_principal_principal.2 $ λ x hx, norm_pos_iff.2 hx
 
 lemma normed_field.tendsto_norm_inverse_nhds_within_0_at_top {𝕜 : Type*} [normed_field 𝕜] :
   tendsto (λ x:𝕜, ∥x⁻¹∥) (nhds_within 0 {x | x ≠ 0}) at_top :=

--- a/src/data/padics/hensel.lean
+++ b/src/data/padics/hensel.lean
@@ -100,7 +100,7 @@ private lemma deriv_norm_ne_zero : ∥F.derivative.eval a∥ ≠ 0 :=
 private lemma deriv_norm_pos : 0 < ∥F.derivative.eval a∥ :=
 lt_of_le_of_ne (norm_nonneg _) (ne.symm deriv_norm_ne_zero)
 
-private lemma deriv_ne_zero : F.derivative.eval a ≠ 0 := mt (norm_eq_zero _).2 deriv_norm_ne_zero
+private lemma deriv_ne_zero : F.derivative.eval a ≠ 0 := mt norm_eq_zero.2 deriv_norm_ne_zero
 
 private lemma T_def : T = ∥F.eval a∥ / ∥F.derivative.eval a∥^2 :=
 calc T = ∥(F.eval a).val∥ / ∥((F.derivative.eval a).val)^2∥ : normed_field.norm_div _ _
@@ -153,7 +153,7 @@ private def calc_eval_z'  {z z' z1 : ℤ_[p]} (hz' : z' = z - z1) {n} (hz : ih n
   {q : ℤ_[p] // F.eval z' = q * z1^2} :=
 have hdzne' : (↑(F.derivative.eval z) : ℚ_[p]) ≠ 0, from
   have hdzne : F.derivative.eval z ≠ 0,
-    from mt (norm_eq_zero _).2 (by rw hz.1; apply deriv_norm_ne_zero; assumption),
+    from mt norm_eq_zero.2 (by rw hz.1; apply deriv_norm_ne_zero; assumption),
   λ h, hdzne $ subtype.ext.2 h,
 let ⟨q, hq⟩ := F.binom_expansion z (-z1) in
 have ∥(↑(F.derivative.eval z) * (↑(F.eval z) / ↑(F.derivative.eval z)) : ℚ_[p])∥ ≤ 1,
@@ -237,10 +237,7 @@ include hnsol
 private lemma T_pos : T > 0 :=
 begin
   rw T_def,
-  apply div_pos_of_pos_of_pos,
-  { apply (norm_pos_iff _).2,
-    apply hnsol },
-  { exact deriv_sq_norm_pos hnorm }
+  exact div_pos_of_pos_of_pos (norm_pos_iff.2 hnsol) (deriv_sq_norm_pos hnorm)
 end
 
 private lemma newton_seq_succ_dist_weak (n : ℕ) :

--- a/src/data/padics/padic_numbers.lean
+++ b/src/data/padics/padic_numbers.lean
@@ -729,7 +729,7 @@ instance : normed_field ℚ_[p] :=
 
 instance : is_absolute_value (λ a : ℚ_[p], ∥a∥) :=
 { abv_nonneg := norm_nonneg,
-  abv_eq_zero := norm_eq_zero,
+  abv_eq_zero := λ _, norm_eq_zero,
   abv_add := norm_add_le,
   abv_mul := by simp [has_norm.norm, padic_norm_e.mul'] }
 

--- a/src/measure_theory/simple_func_dense.lean
+++ b/src/measure_theory/simple_func_dense.lean
@@ -184,7 +184,7 @@ end,
   ⟨0, λ n hn, show dist (F n x) (f x) < ε, by {rw [fx_eq_0, F_eq_0, dist_self], exact hε}⟩ )
 --second case : f x ≠ 0
 ( assume fx_ne_0 : f x ≠ 0,
-  let ⟨N₀, hN⟩ := exists_nat_one_div_lt (lt_min ((norm_pos_iff _).2 fx_ne_0) hε) in
+  let ⟨N₀, hN⟩ := exists_nat_one_div_lt (lt_min (norm_pos_iff.2 fx_ne_0) hε) in
   have norm_fx_gt : _ := (lt_min_iff.1 hN).1,
   have ε_gt : _ := (lt_min_iff.1 hN).2,
   have x_mem_Union_k_N₀ : x ∈ ⋃ k, A N₀ k :=

--- a/src/topology/metric_space/cau_seq_filter.lean
+++ b/src/topology/metric_space/cau_seq_filter.lean
@@ -48,7 +48,7 @@ variables [normed_field β]
 
 instance normed_field.is_absolute_value : is_absolute_value (norm : β → ℝ) :=
 { abv_nonneg := norm_nonneg,
-  abv_eq_zero := norm_eq_zero,
+  abv_eq_zero := λ _, norm_eq_zero,
   abv_add := norm_add_le,
   abv_mul := normed_field.norm_mul }
 


### PR DESCRIPTION
Arguments to these `iff`s should be implicit.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)