### PR TITLE
feat(tactic/lint): check that left-hand side of all simp lemmas is in simp-normal form

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -115,6 +115,7 @@ The following linters are run by default:
 8.  `impossible_instance` checks for instances that can never fire.
 9.  `incorrect_type_class_argument` checks for arguments in [square brackets] that are not classes.
 10. `dangerous_instance` checks for instances that generate type-class problems with metavariables.
+11. `simp_nf` checks that arguments of the left-hand side of simp lemmas are in simp-normal form.
 
 Another linter, `doc_blame_thm`, checks for missing doc strings on lemmas and theorems.
 This is not run by default.

--- a/scripts/mk_all.sh
+++ b/scripts/mk_all.sh
@@ -40,5 +40,5 @@ cat <<EOT >> lint_mathlib.lean
 open nat -- need to do something before running a command
 
 #lint_mathlib- only unused_arguments dup_namespace doc_blame ge_or_gt def_lemma instance_priority
-  impossible_instance incorrect_type_class_argument dangerous_instance inhabited_nonempty
+  impossible_instance incorrect_type_class_argument dangerous_instance inhabited_nonempty simp_nf
 EOT

--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -626,20 +626,13 @@ lemma sum_mul : s.sum f * b = s.sum (λx, f x * b) :=
 lemma mul_sum : b * s.sum f = s.sum (λx, b * f x) :=
 (s.sum_hom _).symm
 
-@[simp] lemma sum_mul_boole [decidable_eq α] (s : finset α) (f : α → β) (a : α) :
+lemma sum_mul_boole [decidable_eq α] (s : finset α) (f : α → β) (a : α) :
   s.sum (λ x, (f x * ite (a = x) 1 0)) = ite (a ∈ s) (f a) 0 :=
-begin
-  convert sum_ite_eq s a f,
-  funext,
-  split_ifs with h; simp [h],
-end
-@[simp] lemma sum_boole_mul [decidable_eq α] (s : finset α) (f : α → β) (a : α) :
+by simp
+
+lemma sum_boole_mul [decidable_eq α] (s : finset α) (f : α → β) (a : α) :
   s.sum (λ x, (ite (a = x) 1 0) * f x) = ite (a ∈ s) (f a) 0 :=
-begin
-  convert sum_ite_eq s a f,
-  funext,
-  split_ifs with h; simp [h],
-end
+by simp
 
 end semiring
 
@@ -920,7 +913,7 @@ namespace with_top
 open finset
 variables [decidable_eq α]
 
-/-- sum of finte numbers is still finite -/
+/-- sum of finite numbers is still finite -/
 lemma sum_lt_top [ordered_comm_monoid β] {s : finset α} {f : α → with_top β} :
   (∀a∈s, f a < ⊤) → s.sum f < ⊤ :=
 finset.induction_on s (by { intro h, rw sum_empty, exact coe_lt_top _ })
@@ -931,7 +924,7 @@ finset.induction_on s (by { intro h, rw sum_empty, exact coe_lt_top _ })
     { apply ih, intros a ha, apply h, apply mem_insert_of_mem ha }
   end)
 
-/-- sum of finte numbers is still finite -/
+/-- sum of finite numbers is still finite -/
 lemma sum_lt_top_iff [canonically_ordered_monoid β] {s : finset α} {f : α → with_top β} :
   s.sum f < ⊤ ↔ (∀a∈s, f a < ⊤) :=
 iff.intro (λh a ha, lt_of_le_of_lt (single_le_sum (λa ha, zero_le _) ha) h) sum_lt_top

--- a/src/algebra/field.lean
+++ b/src/algebra/field.lean
@@ -46,8 +46,6 @@ def mk0 (a : α) (ha : a ≠ 0) : units α :=
 
 @[simp] theorem mk0_val (ha : a ≠ 0) : (mk0 a ha : α) = a := rfl
 
-@[simp] theorem mk0_inv (ha : a ≠ 0) : ((mk0 a ha)⁻¹ : α) = a⁻¹ := rfl
-
 @[simp] lemma mk0_coe (u : units α) (h : (u : α) ≠ 0) : mk0 (u : α) h = u :=
 units.ext rfl
 

--- a/src/algebra/group_power.lean
+++ b/src/algebra/group_power.lean
@@ -198,8 +198,8 @@ localized "infix ` •ℤ `:70 := gsmul" in smul
 @[simp] theorem gpow_coe_nat (a : G) (n : ℕ) : a ^ (n:ℤ) = a ^ n := rfl
 @[simp] theorem gsmul_coe_nat (a : A) (n : ℕ) : (n:ℤ) • a = n •ℕ a := rfl
 
-@[simp] theorem gpow_of_nat (a : G) (n : ℕ) : a ^ of_nat n = a ^ n := rfl
-@[simp] theorem gsmul_of_nat (a : A) (n : ℕ) : of_nat n • a = n •ℕ a := rfl
+theorem gpow_of_nat (a : G) (n : ℕ) : a ^ of_nat n = a ^ n := rfl
+theorem gsmul_of_nat (a : A) (n : ℕ) : of_nat n • a = n •ℕ a := rfl
 
 @[simp] theorem gpow_neg_succ (a : G) (n : ℕ) : a ^ -[1+n] = (a ^ n.succ)⁻¹ := rfl
 @[simp] theorem gsmul_neg_succ (a : A) (n : ℕ) : -[1+n] • a = - (n.succ •ℕ a) := rfl
@@ -231,11 +231,7 @@ theorem gpow_neg_one (x : G) : x ^ (-1:ℤ) = x⁻¹ := congr_arg has_inv.inv $ 
 theorem neg_one_gsmul (x : A) : (-1:ℤ) • x = -x := congr_arg has_neg.neg $ add_monoid.one_smul x
 
 theorem gsmul_one [has_one A] (n : ℤ) : n • (1 : A) = n :=
-begin
-cases n,
-  { rw [gsmul_of_nat, add_monoid.smul_one, int.cast_of_nat] },
-  { rw [gsmul_neg_succ, add_monoid.smul_one, int.cast_neg_succ_of_nat, nat.cast_succ] }
-end
+by cases n; simp
 
 theorem inv_gpow (a : G) : ∀n:ℤ, a⁻¹ ^ n = (a ^ n)⁻¹
 | (n : ℕ) := inv_pow a n
@@ -419,7 +415,7 @@ end
 @[field_simps] theorem pow_ne_zero [domain R] {a : R} (n : ℕ) (h : a ≠ 0) : a ^ n ≠ 0 :=
 mt pow_eq_zero h
 
-@[simp] theorem one_div_pow [division_ring R] {a : R} (ha : a ≠ 0) (n : ℕ) : (1 / a) ^ n = 1 / a ^ n :=
+theorem one_div_pow [division_ring R] {a : R} (ha : a ≠ 0) (n : ℕ) : (1 / a) ^ n = 1 / a ^ n :=
 by induction n with n ih; [exact (div_one _).symm,
   rw [pow_succ', ih, division_ring.one_div_mul_one_div (pow_ne_zero _ ha) ha]]; refl
 

--- a/src/algebra/ring.lean
+++ b/src/algebra/ring.lean
@@ -60,6 +60,10 @@ theorem bit0_eq_two_mul (n : α) : bit0 n = 2 * n :=
   a * (if P then 1 else 0) = if P then a else 0 :=
 by split_ifs; simp
 
+@[simp] lemma ite_mul {α} [semiring α] (P : Prop) [decidable P] (a : α) :
+  (if P then 1 else 0) * a = if P then a else 0 :=
+by split_ifs; simp
+
 variable (α)
 
 /-- Either zero and one are nonequal in a semiring, or the semiring is the zero ring. -/

--- a/src/algebraic_geometry/prime_spectrum.lean
+++ b/src/algebraic_geometry/prime_spectrum.lean
@@ -171,9 +171,13 @@ lemma subset_zero_locus_vanishing_ideal (t : set (prime_spectrum R)) :
   t ⊆ zero_locus (vanishing_ideal t) :=
 (gc R).l_u_le t
 
-@[simp] lemma zero_locus_bot :
+lemma zero_locus_bot :
   zero_locus ((⊥ : ideal R) : set R) = set.univ :=
 (gc R).l_bot
+
+@[simp] lemma zero_locus_singleton_zero :
+  zero_locus ({0} : set R) = set.univ :=
+zero_locus_bot
 
 @[simp] lemma zero_locus_empty :
   zero_locus (∅ : set R) = set.univ :=

--- a/src/analysis/normed_space/multilinear.lean
+++ b/src/analysis/normed_space/multilinear.lean
@@ -841,10 +841,15 @@ variable {𝕜}
   (f : continuous_multilinear_map 𝕜 (λ (i : fin 0), G) E₂) :
   f.uncurry0 = f 0 := rfl
 
-@[simp] lemma continuous_multilinear_map.uncurry0_curry0
+@[simp] lemma continuous_multilinear_map.apply_zero_curry0
+  (f : continuous_multilinear_map 𝕜 (λ (i : fin 0), G) E₂) {x : fin 0 → G} :
+  continuous_multilinear_map.curry0 𝕜 G (f x) = f :=
+by { ext m, simp [(subsingleton.elim _ _ : x = m)] }
+
+lemma continuous_multilinear_map.uncurry0_curry0
   (f : continuous_multilinear_map 𝕜 (λ (i : fin 0), G) E₂) :
   continuous_multilinear_map.curry0 𝕜 G (f.uncurry0) = f :=
-by { ext m, have : m = 0 := zero_eq_dist.mp rfl, rw this, refl }
+by simp
 
 variables (𝕜 G)
 @[simp] lemma continuous_multilinear_map.curry0_uncurry0 (x : E₂) :
@@ -859,14 +864,20 @@ begin
 end
 
 variables {𝕜 G}
-@[simp] lemma continuous_multilinear_map.curry0_norm
-  (f : continuous_multilinear_map 𝕜 (λ (i : fin 0), G) E₂) : ∥f.uncurry0∥ = ∥f∥ :=
+@[simp] lemma continuous_multilinear_map.fin0_apply_norm
+  (f : continuous_multilinear_map 𝕜 (λ (i : fin 0), G) E₂) {x : fin 0 → G} :
+  ∥f x∥ = ∥f∥ :=
 begin
+  have : x = 0 := subsingleton.elim _ _, subst this,
   refine le_antisymm (by simpa using f.le_op_norm 0) _,
   have : ∥continuous_multilinear_map.curry0 𝕜 G (f.uncurry0)∥ ≤ ∥f.uncurry0∥ :=
     continuous_multilinear_map.op_norm_le_bound _ (norm_nonneg _) (λm, by simp),
-  simpa [-continuous_multilinear_map.uncurry0_apply]
+  simpa
 end
+
+lemma continuous_multilinear_map.curry0_norm
+  (f : continuous_multilinear_map 𝕜 (λ (i : fin 0), G) E₂) : ∥f.uncurry0∥ = ∥f∥ :=
+by simp
 
 variables (𝕜 G E₂)
 /-- The linear isomorphism between elements of a normed space, and continuous multilinear maps in

--- a/src/category_theory/const.lean
+++ b/src/category_theory/const.lean
@@ -62,16 +62,10 @@ include 𝒟
 /-- These are actually equal, of course, but not definitionally equal
   (the equality requires F.map (𝟙 _) = 𝟙 _). A natural isomorphism is
   more convenient than an equality between functors (compare id_to_iso). -/
-@[simp] def const_comp (X : C) (F : C ⥤ D) :
+@[simps] def const_comp (X : C) (F : C ⥤ D) :
   (const J).obj X ⋙ F ≅ (const J).obj (F.obj X) :=
 { hom := { app := λ _, 𝟙 _ },
   inv := { app := λ _, 𝟙 _ } }
-
-@[simp] lemma const_comp_hom_app (X : C) (F : C ⥤ D) (j : J) :
-  (const_comp J X F).hom.app j = 𝟙 _ := rfl
-
-@[simp] lemma const_comp_inv_app (X : C) (F : C ⥤ D) (j : J) :
-  (const_comp J X F).inv.app j = 𝟙 _ := rfl
 
 end
 

--- a/src/category_theory/equivalence.lean
+++ b/src/category_theory/equivalence.lean
@@ -49,12 +49,12 @@ lemma counit_def (e : C ≌ D) : e.counit_iso.hom = e.counit := rfl
 lemma unit_inv_def (e : C ≌ D) : e.unit_iso.inv = e.unit_inv := rfl
 lemma counit_inv_def (e : C ≌ D) : e.counit_iso.inv = e.counit_inv := rfl
 
-@[simp] lemma functor_unit_comp (e : C ≌ D) (X : C) : e.functor.map (e.unit.app X) ≫
-  e.counit.app (e.functor.obj X) = 𝟙 (e.functor.obj X) :=
+@[simp] lemma functor_unit_comp (e : C ≌ D) (X : C) : e.functor.map (e.unit_iso.hom.app X) ≫
+  e.counit_iso.hom.app (e.functor.obj X) = 𝟙 (e.functor.obj X) :=
 e.functor_unit_iso_comp X
 
 @[simp] lemma counit_inv_functor_comp (e : C ≌ D) (X : C) :
-  e.counit_inv.app (e.functor.obj X) ≫ e.functor.map (e.unit_inv.app X) = 𝟙 (e.functor.obj X) :=
+  e.counit_iso.inv.app (e.functor.obj X) ≫ e.functor.map (e.unit_iso.inv.app X) = 𝟙 (e.functor.obj X) :=
 begin
   erw [iso.inv_eq_inv
     (e.functor.map_iso (e.unit_iso.app X) ≪≫ e.counit_iso.app (e.functor.obj X)) (iso.refl _)],
@@ -72,7 +72,7 @@ by { erw [←iso.hom_comp_eq_id (e.functor.map_iso (e.unit_iso.app X)), functor_
 /-- The other triangle equality. The proof follows the following proof in Globular:
   http://globular.science/1905.001 -/
 @[simp] lemma unit_inverse_comp (e : C ≌ D) (Y : D) :
-  e.unit.app (e.inverse.obj Y) ≫ e.inverse.map (e.counit.app Y) = 𝟙 (e.inverse.obj Y) :=
+  e.unit_iso.hom.app (e.inverse.obj Y) ≫ e.inverse.map (e.counit_iso.hom.app Y) = 𝟙 (e.inverse.obj Y) :=
 begin
   rw [←id_comp _ (e.inverse.map _), ←map_id e.inverse, ←counit_inv_functor_comp, map_comp,
       ←iso.hom_inv_id_assoc (e.unit_iso.app _) (e.inverse.map (e.functor.map _)),
@@ -93,7 +93,7 @@ begin
 end
 
 @[simp] lemma inverse_counit_inv_comp (e : C ≌ D) (Y : D) :
-  e.inverse.map (e.counit_inv.app Y) ≫ e.unit_inv.app (e.inverse.obj Y) = 𝟙 (e.inverse.obj Y) :=
+  e.inverse.map (e.counit_iso.inv.app Y) ≫ e.unit_iso.inv.app (e.inverse.obj Y) = 𝟙 (e.inverse.obj Y) :=
 begin
   erw [iso.inv_eq_inv
     (e.unit_iso.app (e.inverse.obj Y) ≪≫ e.inverse.map_iso (e.counit_iso.app Y)) (iso.refl _)],

--- a/src/category_theory/functor.lean
+++ b/src/category_theory/functor.lean
@@ -41,7 +41,7 @@ infixr ` ⥤ `:26 := functor       -- type as \func --
 restate_axiom functor.map_id'
 attribute [simp] functor.map_id
 restate_axiom functor.map_comp'
-attribute [simp, reassoc] functor.map_comp
+attribute [reassoc, simp] functor.map_comp
 
 namespace functor
 

--- a/src/category_theory/functor_category.lean
+++ b/src/category_theory/functor_category.lean
@@ -14,6 +14,7 @@ open nat_trans category category_theory.functor
 variables (C : Type u₁) [𝒞 : category.{v₁} C] (D : Type u₂) [𝒟 : category.{v₂} D]
 include 𝒞 𝒟
 
+local attribute [simp] vcomp_app
 /--
 `functor.category C D` gives the category structure on functors and natural transformations
 between categories `C` and `D`.
@@ -34,6 +35,9 @@ variables {F G H I : C ⥤ D}
 namespace nat_trans
 
 @[simp] lemma vcomp_eq_comp (α : F ⟶ G) (β : G ⟶ H) : vcomp α β = α ≫ β := rfl
+
+@[simp] lemma vcomp_app' (α : F ⟶ G) (β : G ⟶ H) (X : C) :
+  (α ≫ β).app X = (α.app X) ≫ (β.app X) := rfl
 
 lemma congr_app {α β : F ⟶ G} (h : α = β) (X : C) : α.app X = β.app X := by rw h
 @[simp] lemma id_app (F : C ⥤ D) (X : C) : (𝟙 F : F ⟶ F).app X = 𝟙 (F.obj X) := rfl

--- a/src/category_theory/isomorphism.lean
+++ b/src/category_theory/isomorphism.lean
@@ -265,13 +265,13 @@ is_iso.of_iso $ F.map_iso (as_iso f)
   F.map (inv f) = inv (F.map f) :=
 rfl
 
-@[simp] lemma map_hom_inv (F : C ⥤ D) {X Y : C} (f : X ⟶ Y) [is_iso f] :
+lemma map_hom_inv (F : C ⥤ D) {X Y : C} (f : X ⟶ Y) [is_iso f] :
   F.map f ≫ F.map (inv f) = 𝟙 (F.obj X) :=
-by rw [map_inv, is_iso.hom_inv_id]
+by simp
 
-@[simp] lemma map_inv_hom (F : C ⥤ D) {X Y : C} (f : X ⟶ Y) [is_iso f] :
+lemma map_inv_hom (F : C ⥤ D) {X Y : C} (f : X ⟶ Y) [is_iso f] :
   F.map (inv f) ≫ F.map f = 𝟙 (F.obj Y) :=
-by rw [map_inv, is_iso.inv_hom_id]
+by simp
 
 end functor
 

--- a/src/category_theory/limits/limits.lean
+++ b/src/category_theory/limits/limits.lean
@@ -462,9 +462,9 @@ def limit.cone_morphism {F : J ⥤ C} [has_limit F] (c : cone F) :
 
 @[simp] lemma limit.cone_morphism_hom {F : J ⥤ C} [has_limit F] (c : cone F) :
   (limit.cone_morphism c).hom = limit.lift F c := rfl
-@[simp] lemma limit.cone_morphism_π {F : J ⥤ C} [has_limit F] (c : cone F) (j : J) :
+lemma limit.cone_morphism_π {F : J ⥤ C} [has_limit F] (c : cone F) (j : J) :
   (limit.cone_morphism c).hom ≫ limit.π F j = c.π.app j :=
-by erw is_limit.fac
+by simp
 
 @[ext] lemma limit.hom_ext {F : J ⥤ C} [has_limit F] {X : C} {f f' : X ⟶ limit F}
   (w : ∀ j, f ≫ limit.π F j = f' ≫ limit.π F j) : f = f' :=
@@ -733,9 +733,9 @@ def colimit.cocone_morphism {F : J ⥤ C} [has_colimit F] (c : cocone F) :
 
 @[simp] lemma colimit.cocone_morphism_hom {F : J ⥤ C} [has_colimit F] (c : cocone F) :
   (colimit.cocone_morphism c).hom = colimit.desc F c := rfl
-@[simp] lemma colimit.ι_cocone_morphism {F : J ⥤ C} [has_colimit F] (c : cocone F) (j : J) :
+lemma colimit.ι_cocone_morphism {F : J ⥤ C} [has_colimit F] (c : cocone F) (j : J) :
   colimit.ι F j ≫ (colimit.cocone_morphism c).hom = c.ι.app j :=
-by erw is_colimit.fac
+by simp
 
 @[ext] lemma colimit.hom_ext {F : J ⥤ C} [has_colimit F] {X : C} {f f' : colimit F ⟶ X}
   (w : ∀ j, colimit.ι F j ≫ f = colimit.ι F j ≫ f') : f = f' :=

--- a/src/category_theory/limits/shapes/binary_products.lean
+++ b/src/category_theory/limits/shapes/binary_products.lean
@@ -132,10 +132,14 @@ local attribute [tidy] tactic.case_bash
 { hom := prod.lift prod.snd prod.fst,
   inv := prod.lift prod.snd prod.fst }
 
-/-- The braiding isomorphism is symmetric. -/
-@[simp] lemma prod.symmetry (P Q : C) :
-  (prod.braiding P Q).hom ≫ (prod.braiding Q P).hom = 𝟙 _ :=
+@[simp] lemma prod.symmetry' (P Q : C) :
+  prod.lift prod.snd prod.fst ≫ prod.lift prod.snd prod.fst = 𝟙 (P ⨯ Q) :=
 by tidy
+
+/-- The braiding isomorphism is symmetric. -/
+lemma prod.symmetry (P Q : C) :
+  (prod.braiding P Q).hom ≫ (prod.braiding Q P).hom = 𝟙 _ :=
+by simp
 
 /-- The associator isomorphism for binary products. -/
 @[simps] def prod.associator
@@ -191,10 +195,14 @@ local attribute [tidy] tactic.case_bash
 { hom := coprod.desc coprod.inr coprod.inl,
   inv := coprod.desc coprod.inr coprod.inl }
 
-/-- The braiding isomorphism is symmetric. -/
-@[simp] lemma coprod.symmetry (P Q : C) :
-  (coprod.braiding P Q).hom ≫ (coprod.braiding Q P).hom = 𝟙 _ :=
+@[simp] lemma coprod.symmetry' (P Q : C) :
+  coprod.desc coprod.inr coprod.inl ≫ coprod.desc coprod.inr coprod.inl = 𝟙 (P ⨿ Q) :=
 by tidy
+
+/-- The braiding isomorphism is symmetric. -/
+lemma coprod.symmetry (P Q : C) :
+  (coprod.braiding P Q).hom ≫ (coprod.braiding Q P).hom = 𝟙 _ :=
+by simp
 
 /-- The associator isomorphism for binary coproducts. -/
 @[simps] def coprod.associator

--- a/src/category_theory/limits/shapes/pullbacks.lean
+++ b/src/category_theory/limits/shapes/pullbacks.lean
@@ -163,9 +163,9 @@ def span {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) : walking_span.{v} ⥤ C :=
 @[simp] lemma span_map_snd {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) :
   (span f g).map walking_span.hom.snd = g := rfl
 
-@[simp] lemma cospan_map_id {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) (w : walking_cospan) :
+lemma cospan_map_id {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) (w : walking_cospan) :
   (cospan f g).map (walking_cospan.hom.id w) = 𝟙 _ := rfl
-@[simp] lemma span_map_id {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) (w : walking_span) :
+lemma span_map_id {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) (w : walking_span) :
   (span f g).map (walking_span.hom.id w) = 𝟙 _ := rfl
 
 

--- a/src/category_theory/natural_isomorphism.lean
+++ b/src/category_theory/natural_isomorphism.lean
@@ -63,10 +63,10 @@ begin
 end
 
 variables {X Y : C}
-@[simp] lemma naturality_1 (α : F ≅ G) (f : X ⟶ Y) :
+lemma naturality_1 (α : F ≅ G) (f : X ⟶ Y) :
   (α.inv.app X) ≫ (F.map f) ≫ (α.hom.app Y) = G.map f :=
 begin erw [naturality, ←category.assoc, is_iso.hom_inv_id, category.id_comp] end
-@[simp] lemma naturality_2 (α : F ≅ G) (f : X ⟶ Y) :
+lemma naturality_2 (α : F ≅ G) (f : X ⟶ Y) :
   (α.hom.app X) ≫ (G.map f) ≫ (α.inv.app Y) = F.map f :=
 begin erw [naturality, ←category.assoc, is_iso.hom_inv_id, category.id_comp] end
 

--- a/src/category_theory/natural_transformation.lean
+++ b/src/category_theory/natural_transformation.lean
@@ -58,7 +58,9 @@ def vcomp (α : nat_trans F G) (β : nat_trans G H) : nat_trans F H :=
     intros, simp, rw [←assoc, naturality, assoc, ←naturality],
   end }
 
-@[simp] lemma vcomp_app (α : nat_trans F G) (β : nat_trans G H) (X : C) :
+-- functor_category will rewrite (vcomp α β) to (α ≫ β), so this is not a
+-- suitable simp lemma.  We will declare the variant vcomp_app' there.
+lemma vcomp_app (α : nat_trans F G) (β : nat_trans G H) (X : C) :
   (vcomp α β).app X = (α.app X) ≫ (β.app X) := rfl
 
 end

--- a/src/data/equiv/denumerable.lean
+++ b/src/data/equiv/denumerable.lean
@@ -25,7 +25,7 @@ section
 variables {α : Type*} {β : Type*} [denumerable α] [denumerable β]
 open encodable
 
-@[simp] theorem decode_is_some (α) [denumerable α] (n : ℕ) :
+theorem decode_is_some (α) [denumerable α] (n : ℕ) :
   (decode α n).is_some :=
 option.is_some_iff_exists.2 $
 (decode_inv α n).imp $ λ a, Exists.fst

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -283,6 +283,10 @@ We can think of the type `Π(i : fin n), α i` as `n`-tuples of elements of poss
 operations, first about adding or removing elements at the beginning of a tuple.
 -/
 
+/-- There is exactly one tuple of size zero. -/
+instance tuple0_unique (α : fin 0 → Type u) : unique (Π i : fin 0, α i) :=
+{ default := fin_zero_elim', uniq := λ x, funext fin_zero_elim' }
+
 variables {α : fin (n+1) → Type u} (x : α 0) (q : Πi, α i) (p : Π(i : fin n), α (i.succ))
 (i : fin n) (y : α i.succ) (z : α 0)
 

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -166,7 +166,11 @@ classical.by_cases or.inl (λ h, or.inr (nonempty_of_ne_empty h))
 
 @[simp] lemma coe_empty : ↑(∅ : finset α) = (∅ : set α) := rfl
 
-/-- `singleton a` is the set `{a}` containing `a` and nothing else. -/
+/--
+`finset.singleton a` is the set `{a}` containing `a` and nothing else.
+
+This differs from `singleton a` in that it does not require a `decidable_eq` instance for `α`.
+-/
 def singleton (a : α) : finset α := ⟨_, nodup_singleton a⟩
 local prefix `ι`:90 := singleton
 
@@ -287,8 +291,11 @@ finset.induction h₁ h₂ s
 
 @[simp] theorem insert_empty_eq_singleton (a : α) : {a} = ι a := rfl
 
-@[simp] theorem insert_singleton_self_eq (a : α) : ({a, a} : finset α) = ι a :=
+theorem insert_singleton_self_eq (a : α) : ({a, a} : finset α) = ι a :=
 insert_eq_of_mem $ mem_singleton_self _
+
+@[simp] theorem insert_singleton_self_eq' {a : α} : insert a (ι a) = ι a :=
+insert_singleton_self_eq _
 
 /-! ### union -/
 
@@ -1749,9 +1756,11 @@ fold_empty
 @[simp] lemma sup_insert [decidable_eq β] {b : β} : (insert b s : finset β).sup f = f b ⊔ s.sup f :=
 fold_insert_idem
 
-@[simp] lemma sup_singleton [decidable_eq β] {b : β} : ({b} : finset β).sup f = f b :=
-calc _ = f b ⊔ (∅:finset β).sup f : sup_insert
-  ... = f b : sup_bot_eq
+@[simp] lemma sup_singleton' {b : β} : (singleton b).sup f = f b :=
+sup_singleton
+
+lemma sup_singleton [decidable_eq β] {b : β} : ({b} : finset β).sup f = f b :=
+sup_singleton
 
 lemma sup_union [decidable_eq β] : (s₁ ∪ s₂).sup f = s₁.sup f ⊔ s₂.sup f :=
 finset.induction_on s₁ (by rw [empty_union, sup_empty, bot_sup_eq]) $ λ a s has ih,
@@ -1832,9 +1841,11 @@ fold_empty
 @[simp] lemma inf_insert [decidable_eq β] {b : β} : (insert b s : finset β).inf f = f b ⊓ s.inf f :=
 fold_insert_idem
 
-@[simp] lemma inf_singleton [decidable_eq β] {b : β} : ({b} : finset β).inf f = f b :=
-calc _ = f b ⊓ (∅:finset β).inf f : inf_insert
-  ... = f b : inf_top_eq
+@[simp] lemma inf_singleton' {b : β} : (singleton b).inf f = f b :=
+inf_singleton
+
+lemma inf_singleton [decidable_eq β] {b : β} : ({b} : finset β).inf f = f b :=
+inf_singleton'
 
 lemma inf_union [decidable_eq β] : (s₁ ∪ s₂).inf f = s₁.inf f ⊓ s₂.inf f :=
 finset.induction_on s₁ (by rw [empty_union, inf_empty, top_inf_eq]) $ λ a s has ih,
@@ -1905,7 +1916,7 @@ theorem max_eq_sup_with_bot (s : finset α) :
 @[simp] theorem max_insert {a : α} {s : finset α} :
   (insert a s).max = option.lift_or_get max (some a) s.max := fold_insert_idem
 
-@[simp] theorem max_singleton {a : α} : finset.max {a} = some a := max_insert
+theorem max_singleton {a : α} : finset.max {a} = some a := max_insert
 
 @[simp] theorem max_singleton' {a : α} : finset.max (singleton a) = some a := max_singleton
 
@@ -1948,7 +1959,9 @@ theorem min_eq_inf_with_top (s : finset α) :
   (insert a s).min = option.lift_or_get min (some a) s.min :=
 fold_insert_idem
 
-@[simp] theorem min_singleton {a : α} : finset.min {a} = some a := min_insert
+theorem min_singleton {a : α} : finset.min {a} = some a := min_insert
+
+@[simp] theorem min_singleton' {a : α} : finset.min (singleton a) = some a := min_singleton
 
 theorem min_of_mem {s : finset α} {a : α} (h : a ∈ s) : ∃ b, b ∈ s.min :=
 (@inf_le (with_top α) _ _ _ _ _ h _ rfl).imp $ λ b, Exists.fst
@@ -2433,7 +2446,7 @@ variables [decidable_eq α]
 @[simp] theorem bUnion_singleton (a : α) (s : α → set β) : (⋃ x ∈ ({a} : finset α), s x) = s a :=
 supr_singleton
 
-@[simp] theorem supr_union {α} [complete_lattice α] {β} [decidable_eq β] {f : β → α} {s t : finset β} :
+theorem supr_union {α} [complete_lattice α] {β} [decidable_eq β] {f : β → α} {s t : finset β} :
   (⨆ x ∈ s ∪ t, f x) = (⨆x∈s, f x) ⊔ (⨆x∈t, f x) :=
 calc (⨆ x ∈ s ∪ t, f x) = (⨆ x, (⨆h : x∈s, f x) ⊔ (⨆h : x∈t, f x)) :
   congr_arg _ $ funext $ λ x, by { convert supr_or, rw finset.mem_union, rw finset.mem_union, refl, refl }

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1046,6 +1046,10 @@ let ⟨lb, Plb, al⟩ := exists_least_of_bdd Hbdd' Hinh' in
 
 /- cast (injection into groups with one) -/
 
+-- We use the int.has_coe instance for the simp-normal form.
+-- Increase the priority so that it is used preferentially.
+attribute [priority 1001] int.has_coe
+
 @[simp] theorem nat_cast_eq_coe_nat : ∀ n,
   @coe ℕ ℤ (@coe_to_lift _ _ (@coe_base _ _ nat.cast_coe)) n =
   @coe ℕ ℤ (@coe_to_lift _ _ (@coe_base _ _ int.has_coe)) n
@@ -1067,9 +1071,9 @@ protected def cast : ℤ → α
 
 @[simp, squash_cast] theorem cast_zero : ((0 : ℤ) : α) = 0 := rfl
 
-@[simp] theorem cast_of_nat (n : ℕ) : (of_nat n : α) = n := rfl
+theorem cast_of_nat (n : ℕ) : (of_nat n : α) = n := rfl
 @[simp, squash_cast] theorem cast_coe_nat (n : ℕ) : ((n : ℤ) : α) = n := rfl
-@[simp] theorem cast_coe_nat' (n : ℕ) :
+theorem cast_coe_nat' (n : ℕ) :
   (@coe ℕ ℤ (@coe_to_lift _ _ (@coe_base _ _ nat.cast_coe)) n : α) = n :=
 by simp
 

--- a/src/data/int/parity.lean
+++ b/src/data/int/parity.lean
@@ -12,7 +12,8 @@ namespace int
 @[simp] theorem mod_two_ne_one {n : int} : ¬ n % 2 = 1 ↔ n % 2 = 0 :=
 by cases mod_two_eq_zero_or_one n with h h; simp [h]
 
-@[simp] theorem mod_two_ne_zero {n : int} : ¬ n % 2 = 0 ↔ n % 2 = 1 :=
+local attribute [simp] -- euclidean_domain.mod_eq_zero uses (2 ∣ n) as normal form
+theorem mod_two_ne_zero {n : int} : ¬ n % 2 = 0 ↔ n % 2 = 1 :=
 by cases mod_two_eq_zero_or_one n with h h; simp [h]
 
 def even (n : int) : Prop := 2 ∣ n
@@ -28,6 +29,9 @@ theorem even_iff {n : int} : even n ↔ n % 2 = 0 :=
 
 lemma not_even_iff {n : ℤ} : ¬ even n ↔ n % 2 = 1 :=
 by rw [even_iff, mod_two_ne_zero]
+
+@[simp] theorem two_dvd_ne_zero {n : int} : ¬ 2 ∣ n ↔ n % 2 = 1 :=
+not_even_iff
 
 instance : decidable_pred even :=
 λ n, decidable_of_decidable_of_iff (by apply_instance) even_iff.symm

--- a/src/data/list/alist.lean
+++ b/src/data/list/alist.lean
@@ -192,7 +192,7 @@ by rw [list.to_alist,lookup,lookup_erase_dupkeys]
 by ext : 1; simp only [alist.insert_entries, list.kerase_cons_eq];
    constructor_matching* [_ ∧ _]; refl
 
-@[simp] theorem insert_insert_of_ne {a a'} {b : β a} {b' : β a'} (s : alist β) (h : a ≠ a') :
+theorem insert_insert_of_ne {a a'} {b : β a} {b' : β a'} (s : alist β) (h : a ≠ a') :
   ((s.insert a b).insert a' b').entries ~ ((s.insert a' b').insert a b).entries :=
 by simp only [insert_entries]; rw [kerase_cons_ne,kerase_cons_ne,kerase_comm];
    [apply perm.swap, exact h, exact h.symm]

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -244,7 +244,7 @@ bex.elim h (λ x xal px,
     (assume : x = a, begin rw ←this, left, exact px end)
     (assume : x ∈ l, or.inr (bex.intro x this px)))
 
-@[simp] theorem exists_mem_cons_iff (p : α → Prop) (a : α) (l : list α) :
+theorem exists_mem_cons_iff (p : α → Prop) (a : α) (l : list α) :
   (∃ x ∈ a :: l, p x) ↔ p a ∨ ∃ x ∈ l, p x :=
 iff.intro or_exists_of_exists_mem_cons
   (assume h, or.elim h (exists_mem_cons_of l) exists_mem_cons_of_exists)
@@ -463,24 +463,24 @@ append_bind _ _ _
 
 /- concat -/
 
-@[simp] theorem concat_nil (a : α) : concat [] a = [a] := rfl
+theorem concat_nil (a : α) : concat [] a = [a] := rfl
 
-@[simp] theorem concat_cons (a b : α) (l : list α) : concat (a :: l) b = a :: concat l b := rfl
-
-@[simp] theorem concat_ne_nil (a : α) (l : list α) : concat l a ≠ [] :=
-by induction l; intro h; contradiction
-
-@[simp] theorem concat_append (a : α) (l₁ l₂ : list α) : concat l₁ a ++ l₂ = l₁ ++ a :: l₂ :=
-by induction l₁; simp only [*, cons_append, concat]; split; refl
+theorem concat_cons (a b : α) (l : list α) : concat (a :: l) b = a :: concat l b := rfl
 
 @[simp] theorem concat_eq_append (a : α) (l : list α) : concat l a = l ++ [a] :=
 by induction l; simp only [*, concat]; split; refl
 
-@[simp] theorem length_concat (a : α) (l : list α) : length (concat l a) = succ (length l) :=
+theorem concat_ne_nil (a : α) (l : list α) : concat l a ≠ [] :=
+by simp
+
+theorem concat_append (a : α) (l₁ l₂ : list α) : concat l₁ a ++ l₂ = l₁ ++ a :: l₂ :=
+by simp
+
+theorem length_concat (a : α) (l : list α) : length (concat l a) = succ (length l) :=
 by simp only [concat_eq_append, length_append, length]
 
 theorem append_concat (a : α) (l₁ l₂ : list α) : l₁ ++ concat l₂ a = concat (l₁ ++ l₂) a :=
-by induction l₂ with b l₂ ih; simp only [concat_eq_append, nil_append, cons_append, append_assoc]
+by simp
 
 /- reverse -/
 
@@ -2131,8 +2131,8 @@ theorem count_singleton (a : α) : count a [a] = 1 := if_pos rfl
 @[simp] theorem count_append (a : α) : ∀ l₁ l₂, count a (l₁ ++ l₂) = count a l₁ + count a l₂ :=
 countp_append
 
-@[simp] theorem count_concat (a : α) (l : list α) : count a (concat l a) = succ (count a l) :=
-by rw [concat_eq_append, count_append, count_singleton]
+theorem count_concat (a : α) (l : list α) : count a (concat l a) = succ (count a l) :=
+by simp [-add_comm]
 
 theorem count_pos {a : α} {l : list α} : 0 < count a l ↔ a ∈ l :=
 by simp only [count, countp_pos, exists_prop, exists_eq_right']
@@ -2167,7 +2167,10 @@ end count
 
 @[simp] theorem suffix_append (l₁ l₂ : list α) : l₂ <:+ l₁ ++ l₂ := ⟨l₁, rfl⟩
 
-@[simp] theorem infix_append (l₁ l₂ l₃ : list α) : l₂ <:+: l₁ ++ l₂ ++ l₃ := ⟨l₁, l₃, rfl⟩
+theorem infix_append (l₁ l₂ l₃ : list α) : l₂ <:+: l₁ ++ l₂ ++ l₃ := ⟨l₁, l₃, rfl⟩
+
+@[simp] theorem infix_append' (l₁ l₂ l₃ : list α) : l₂ <:+: l₁ ++ (l₂ ++ l₃) :=
+by rw ← list.append_assoc; apply infix_append
 
 theorem nil_prefix (l : list α) : [] <+: l := ⟨l, rfl⟩
 
@@ -2179,8 +2182,7 @@ theorem nil_suffix (l : list α) : [] <:+ l := ⟨l, append_nil _⟩
 
 @[simp] theorem suffix_cons (a : α) : ∀ l, l <:+ a :: l := suffix_append [a]
 
-@[simp] theorem prefix_concat (a : α) (l) : l <+: concat l a :=
-by simp only [concat_eq_append, prefix_append]
+theorem prefix_concat (a : α) (l) : l <+: concat l a := by simp
 
 theorem infix_of_prefix {l₁ l₂ : list α} : l₁ <+: l₂ → l₁ <:+: l₂ :=
 λ⟨t, h⟩, ⟨[], t, h⟩

--- a/src/data/list/sigma.lean
+++ b/src/data/list/sigma.lean
@@ -473,7 +473,7 @@ def kinsert (a : α) (b : β a) (l : list (sigma β)) : list (sigma β) :=
 @[simp] theorem kinsert_def {a} {b : β a} {l : list (sigma β)} :
   kinsert a b l = ⟨a, b⟩ :: kerase a l := rfl
 
-@[simp] theorem mem_keys_kinsert {a a'} {b' : β a'} {l : list (sigma β)} :
+theorem mem_keys_kinsert {a a'} {b' : β a'} {l : list (sigma β)} :
   a ∈ (kinsert a' b' l).keys ↔ a = a' ∨ a ∈ l.keys :=
 by by_cases h : a = a'; simp [h]
 
@@ -485,13 +485,13 @@ theorem perm_kinsert {a} {b : β a} {l₁ l₂ : list (sigma β)} (nd₁ : l₁.
   (p : l₁ ~ l₂) : kinsert a b l₁ ~ kinsert a b l₂ :=
 perm.skip ⟨a, b⟩ $ perm_kerase nd₁ p
 
-@[simp] theorem lookup_kinsert {a} {b : β a} (l : list (sigma β)) :
+theorem lookup_kinsert {a} {b : β a} (l : list (sigma β)) :
   lookup a (kinsert a b l) = some b :=
 by simp only [kinsert, lookup_cons_eq]
 
-@[simp] theorem lookup_kinsert_ne {a a'} {b' : β a'} {l : list (sigma β)} (h : a ≠ a') :
+theorem lookup_kinsert_ne {a a'} {b' : β a'} {l : list (sigma β)} (h : a ≠ a') :
   lookup a (kinsert a' b' l) = lookup a l :=
-by simp [h, lookup_cons_ne _ ⟨a', b'⟩ h]
+by simp [h]
 
 /- kextract -/
 

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -607,7 +607,7 @@ quot.lift_on s (λ l : list α, (l.map f : multiset β))
 @[simp] theorem map_cons (f : α → β) (a s) : map f (a::s) = f a :: map f s :=
 quot.induction_on s $ λ l, rfl
 
-@[simp] lemma map_singleton (f : α → β) (a : α) : ({a} : multiset α).map f = {f a} := rfl
+lemma map_singleton (f : α → β) (a : α) : ({a} : multiset α).map f = {f a} := rfl
 
 @[simp] theorem map_add (f : α → β) (s t) : map f (s + t) = map f s + map f t :=
 quotient.induction_on₂ s t $ λ l₁ l₂, congr_arg coe $ map_append _ _ _
@@ -757,12 +757,12 @@ by simp [repeat, list.prod_repeat]
 @prod_repeat (multiplicative α) _
 attribute [to_additive] prod_repeat
 
-@[simp] lemma prod_map_one [comm_monoid γ] {m : multiset α} :
+lemma prod_map_one [comm_monoid γ] {m : multiset α} :
   prod (m.map (λa, (1 : γ))) = (1 : γ) :=
-multiset.induction_on m (by simp) (by simp)
-@[simp] lemma sum_map_zero [add_comm_monoid γ] {m : multiset α} :
+by simp
+lemma sum_map_zero [add_comm_monoid γ] {m : multiset α} :
   sum (m.map (λa, (0 : γ))) = (0 : γ) :=
-multiset.induction_on m (by simp) (by simp)
+by simp
 attribute [to_additive] prod_map_one
 
 @[simp, to_additive]
@@ -866,7 +866,7 @@ by simp [bind]
 by simp [bind]
 
 @[simp] theorem bind_zero (s : multiset α) : bind s (λa, 0 : α → multiset β) = 0 :=
-by simp [bind, -map_const, join]
+by simp [bind, join]
 
 @[simp] theorem bind_add (s : multiset α) (f g : α → multiset β) :
   bind s (λa, f a + g a) = bind s f + bind s g :=

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -802,6 +802,9 @@ lemma C_sub : (C (a - a') : mv_polynomial σ α) = C a - C a' := is_ring_hom.map
 
 @[simp] lemma C_neg : (C (-a) : mv_polynomial σ α) = -C a := is_ring_hom.map_neg _
 
+@[simp] lemma coeff_neg (m : σ →₀ ℕ) (p : mv_polynomial σ α) :
+  coeff m (-p) = -coeff m p := finsupp.neg_apply
+
 @[simp] lemma coeff_sub (m : σ →₀ ℕ) (p q : mv_polynomial σ α) :
   coeff m (p - q) = coeff m p - coeff m q := finsupp.sub_apply
 
@@ -936,6 +939,11 @@ eval₂_one _ _
 @[simp] lemma rename_add (f : β → γ) (p q : mv_polynomial β α) :
   rename f (p + q) = rename f p + rename f q :=
 eval₂_add _ _
+
+@[simp] lemma rename_neg {α} [comm_ring α]
+  (f : β → γ) (p : mv_polynomial β α) :
+  rename f (-p) = -rename f p :=
+eval₂_neg _ _ _
 
 @[simp] lemma rename_sub {α} [comm_ring α]
   (f : β → γ) (p q : mv_polynomial β α) :

--- a/src/data/option/basic.lean
+++ b/src/data/option/basic.lean
@@ -163,4 +163,13 @@ theorem lift_or_get_choice {f : α → α → α} (h : ∀ a b, f a b = a ∨ f 
 | none     (some b) := or.inr rfl
 | (some a) (some b) := by simpa [lift_or_get] using h a b
 
+@[simp] lemma lift_or_get_none_left {f} {b : option α} : lift_or_get f none b = b :=
+by cases b; refl
+
+@[simp] lemma lift_or_get_none_right {f} {a : option α} : lift_or_get f a none = a :=
+by cases a; refl
+
+@[simp] lemma lift_or_get_some_some {f} {a b : α} :
+  lift_or_get f (some a) (some b) = f a b := rfl
+
 end option

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -65,7 +65,7 @@ h hx
 
 @[simp] theorem mem_set_of_eq {a : α} {p : α → Prop} : a ∈ {a | p a} = p a := rfl
 
-@[simp] theorem nmem_set_of_eq {a : α} {P : α → Prop} : a ∉ {a : α | P a} = ¬ P a := rfl
+theorem nmem_set_of_eq {a : α} {P : α → Prop} : a ∉ {a : α | P a} = ¬ P a := rfl
 
 @[simp] theorem set_of_mem_eq {s : set α} : {x | x ∈ s} = s := rfl
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -845,7 +845,7 @@ assume x hx, h hx
 
 @[simp] theorem preimage_univ : f ⁻¹' univ = univ := rfl
 
-@[simp] theorem subset_preimage_univ {s : set α} : s ⊆ f ⁻¹' univ := subset_univ _
+theorem subset_preimage_univ {s : set α} : s ⊆ f ⁻¹' univ := subset_univ _
 
 @[simp] theorem preimage_inter {s t : set β} : f ⁻¹' (s ∩ t) = f ⁻¹' s ∩ f ⁻¹' t := rfl
 

--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -246,13 +246,12 @@ set.ext $ by simp
 theorem bInter_eq_Inter (s : set α) (t : α → set β) : (⋂ x ∈ s, t x) = (⋂ x : s, t x.1) :=
 set.ext $ by simp
 
-@[simp] theorem bInter_empty (u : α → set β) : (⋂ x ∈ (∅ : set α), u x) = univ :=
+theorem bInter_empty (u : α → set β) : (⋂ x ∈ (∅ : set α), u x) = univ :=
 show (⨅x ∈ (∅ : set α), u x) = ⊤, -- simplifier should be able to rewrite x ∈ ∅ to false.
   from infi_emptyset
 
-@[simp] theorem bInter_univ (u : α → set β) : (⋂ x ∈ @univ α, u x) = ⋂ x, u x :=
+theorem bInter_univ (u : α → set β) : (⋂ x ∈ @univ α, u x) = ⋂ x, u x :=
 infi_univ
-
 
 -- TODO(Jeremy): here is an artifact of the the encoding of bounded intersection:
 -- without dsimp, the next theorem fails to type check, because there is a lambda
@@ -277,10 +276,10 @@ theorem bInter_pair (a b : α) (s : α → set β) :
   (⋂ x ∈ ({a, b} : set α), s x) = s a ∩ s b :=
 by rw insert_of_has_insert; simp [inter_comm]
 
-@[simp] theorem bUnion_empty (s : α → set β) : (⋃ x ∈ (∅ : set α), s x) = ∅ :=
+theorem bUnion_empty (s : α → set β) : (⋃ x ∈ (∅ : set α), s x) = ∅ :=
 supr_emptyset
 
-@[simp] theorem bUnion_univ (s : α → set β) : (⋃ x ∈ @univ α, s x) = ⋃ x, s x :=
+theorem bUnion_univ (s : α → set β) : (⋃ x ∈ @univ α, s x) = ⋃ x, s x :=
 supr_univ
 
 @[simp] theorem bUnion_singleton (a : α) (s : α → set β) : (⋃ x ∈ ({a} : set α), s x) = s a :=

--- a/src/data/zsqrtd/basic.lean
+++ b/src/data/zsqrtd/basic.lean
@@ -28,8 +28,8 @@ section
 
   /-- Convert an integer to a `ℤ√d` -/
   def of_int (n : ℤ) : ℤ√d := ⟨n, 0⟩
-  @[simp] theorem of_int_re (n : ℤ) : (of_int n).re = n := rfl
-  @[simp] theorem of_int_im (n : ℤ) : (of_int n).im = 0 := rfl
+  theorem of_int_re (n : ℤ) : (of_int n).re = n := rfl
+  theorem of_int_im (n : ℤ) : (of_int n).im = 0 := rfl
 
   /-- The zero of the ring -/
   def zero : ℤ√d := of_int 0
@@ -138,7 +138,7 @@ section
   { cast_injective := λ m n, by simp [ext] }
 
   @[simp] theorem of_int_eq_coe (n : ℤ) : (of_int n : ℤ√d) = n :=
-  by simp [ext]
+  by simp [ext, of_int_re, of_int_im]
 
   @[simp] theorem smul_val (n x y : ℤ) : (n : ℤ√d) * ⟨x, y⟩ = ⟨n * x, n * y⟩ :=
   by simp [ext]

--- a/src/measure_theory/l1_space.lean
+++ b/src/measure_theory/l1_space.lean
@@ -144,7 +144,7 @@ lt_of_le_of_lt
   (lintegral_edist_triangle hfm hgm (measurable_const : measurable (λa, (0 : β))))
   (ennreal.add_lt_top.2 $ by { split; rw ← integrable_iff_edist; assumption })
 
-@[simp] lemma lintegral_nnnorm_zero : (∫⁻ a : α, nnnorm (0 : β)) = 0 := by simp
+lemma lintegral_nnnorm_zero : (∫⁻ a : α, nnnorm (0 : β)) = 0 := by simp
 
 variables (α β)
 @[simp] lemma integrable_zero : integrable (λa:α, (0:β)) :=

--- a/src/measure_theory/set_integral.lean
+++ b/src/measure_theory/set_integral.lean
@@ -185,8 +185,8 @@ lemma integral_on_non_integrable (h : ¬ integrable_on s f) : (∫ a in s, f a) 
 integral_non_integrable h
 
 variables (β)
-@[simp] lemma integral_on_zero (s : set α) : (∫ a in s, (0:β)) = 0 :=
-by rw [indicator_zero, integral_zero]
+lemma integral_on_zero (s : set α) : (∫ a in s, (0:β)) = 0 :=
+by simp
 variables {β}
 
 lemma integral_on_congr (h : ∀ a ∈ s, f a = g a) : (∫ a in s, f a) = (∫ a in s, g a) :=

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -560,22 +560,19 @@ calc Sup (set.image f s) = (⨆a, ⨆h : ∃b, b ∈ s ∧ f b = a, a) : Sup_eq_
 
 /- supr and infi under set constructions -/
 
-/- should work using the simplifier! -/
-@[simp] theorem infi_emptyset {f : β → α} : (⨅ x ∈ (∅ : set β), f x) = ⊤ :=
-le_antisymm le_top (le_infi $ assume x, le_infi false.elim)
+theorem infi_emptyset {f : β → α} : (⨅ x ∈ (∅ : set β), f x) = ⊤ :=
+by simp
 
-@[simp] theorem supr_emptyset {f : β → α} : (⨆ x ∈ (∅ : set β), f x) = ⊥ :=
-le_antisymm (supr_le $ assume x, supr_le false.elim) bot_le
+theorem supr_emptyset {f : β → α} : (⨆ x ∈ (∅ : set β), f x) = ⊥ :=
+by simp
 
-@[simp] theorem infi_univ {f : β → α} : (⨅ x ∈ (univ : set β), f x) = (⨅ x, f x) :=
-show (⨅ (x : β) (H : true), f x) = ⨅ (x : β), f x,
-  from congr_arg infi $ funext $ assume x, infi_const
+theorem infi_univ {f : β → α} : (⨅ x ∈ (univ : set β), f x) = (⨅ x, f x) :=
+by simp
 
-@[simp] theorem supr_univ {f : β → α} : (⨆ x ∈ (univ : set β), f x) = (⨆ x, f x) :=
-show (⨆ (x : β) (H : true), f x) = ⨆ (x : β), f x,
-  from congr_arg supr $ funext $ assume x, supr_const
+theorem supr_univ {f : β → α} : (⨆ x ∈ (univ : set β), f x) = (⨆ x, f x) :=
+by simp
 
-@[simp] theorem infi_union {f : β → α} {s t : set β} : (⨅ x ∈ s ∪ t, f x) = (⨅x∈s, f x) ⊓ (⨅x∈t, f x) :=
+theorem infi_union {f : β → α} {s t : set β} : (⨅ x ∈ s ∪ t, f x) = (⨅x∈s, f x) ⊓ (⨅x∈t, f x) :=
 calc (⨅ x ∈ s ∪ t, f x) = (⨅ x, (⨅h : x∈s, f x) ⊓ (⨅h : x∈t, f x)) : congr_arg infi $ funext $ assume x, infi_or
                     ... = (⨅x∈s, f x) ⊓ (⨅x∈t, f x) : infi_inf_eq
 
@@ -583,7 +580,7 @@ theorem infi_le_infi_of_subset {f : β → α} {s t : set β} (h : s ⊆ t) :
   (⨅ x ∈ t, f x) ≤ (⨅ x ∈ s, f x) :=
 by rw [(union_eq_self_of_subset_left h).symm, infi_union]; exact inf_le_left
 
-@[simp] theorem supr_union {f : β → α} {s t : set β} : (⨆ x ∈ s ∪ t, f x) = (⨆x∈s, f x) ⊔ (⨆x∈t, f x) :=
+theorem supr_union {f : β → α} {s t : set β} : (⨆ x ∈ s ∪ t, f x) = (⨆x∈s, f x) ⊔ (⨆x∈t, f x) :=
 calc (⨆ x ∈ s ∪ t, f x) = (⨆ x, (⨆h : x∈s, f x) ⊔ (⨆h : x∈t, f x)) : congr_arg supr $ funext $ assume x, supr_or
                     ... = (⨆x∈s, f x) ⊔ (⨆x∈t, f x) : supr_sup_eq
 
@@ -594,24 +591,22 @@ by rw [(union_eq_self_of_subset_left h).symm, supr_union]; exact le_sup_left
 @[simp] theorem insert_of_has_insert {α : Type*} (x : α) (a : set α) :
   has_insert.insert x a = insert x a := rfl
 
-@[simp] theorem infi_insert {f : β → α} {s : set β} {b : β} : (⨅ x ∈ insert b s, f x) = f b ⊓ (⨅x∈s, f x) :=
+theorem infi_insert {f : β → α} {s : set β} {b : β} : (⨅ x ∈ insert b s, f x) = f b ⊓ (⨅x∈s, f x) :=
 eq.trans infi_union $ congr_arg (λx:α, x ⊓ (⨅x∈s, f x)) infi_infi_eq_left
 
-@[simp] theorem supr_insert {f : β → α} {s : set β} {b : β} : (⨆ x ∈ insert b s, f x) = f b ⊔ (⨆x∈s, f x) :=
+theorem supr_insert {f : β → α} {s : set β} {b : β} : (⨆ x ∈ insert b s, f x) = f b ⊔ (⨆x∈s, f x) :=
 eq.trans supr_union $ congr_arg (λx:α, x ⊔ (⨆x∈s, f x)) supr_supr_eq_left
 
-@[simp] theorem infi_singleton {f : β → α} {b : β} : (⨅ x ∈ (singleton b : set β), f x) = f b :=
-show (⨅ x ∈ insert b (∅ : set β), f x) = f b,
-  by simp
+theorem infi_singleton {f : β → α} {b : β} : (⨅ x ∈ (singleton b : set β), f x) = f b :=
+by simp
 
-@[simp] theorem infi_pair {f : β → α} {a b : β} : (⨅ x ∈ ({a, b} : set β), f x) = f a ⊓ f b :=
+theorem infi_pair {f : β → α} {a b : β} : (⨅ x ∈ ({a, b} : set β), f x) = f a ⊓ f b :=
 by { rw [show {a, b} = (insert b {a} : set β), from rfl, infi_insert, inf_comm], simp }
 
-@[simp] theorem supr_singleton {f : β → α} {b : β} : (⨆ x ∈ (singleton b : set β), f x) = f b :=
-show (⨆ x ∈ insert b (∅ : set β), f x) = f b,
-  by simp
+theorem supr_singleton {f : β → α} {b : β} : (⨆ x ∈ (singleton b : set β), f x) = f b :=
+by simp
 
-@[simp] theorem supr_pair {f : β → α} {a b : β} : (⨆ x ∈ ({a, b} : set β), f x) = f a ⊔ f b :=
+theorem supr_pair {f : β → α} {a b : β} : (⨆ x ∈ ({a, b} : set β), f x) = f a ⊔ f b :=
 by { rw [show {a, b} = (insert b {a} : set β), from rfl, supr_insert, sup_comm], simp }
 
 lemma infi_image {γ} {f : β → γ} {g : γ → α} {t : set β} :

--- a/src/order/filter/filter_product.lean
+++ b/src/order/filter/filter_product.lean
@@ -31,6 +31,7 @@ namespace filter_product
 
 variables {α β φ} include φ
 
+/-- Equivalence class containing the given sequence -/
 def of_seq : (α → β) → β* := @quotient.mk' (α → β) (bigly_equal β φ)
 
 /-- Equivalence class containing the constant sequence of a term in β -/
@@ -272,14 +273,14 @@ theorem of_seq_fun (f g : α → β) (h : β → β) (H : ∀* n, f n = h (g n))
 theorem of_seq_fun₂ (f g₁ g₂ : α → β) (h : β → β → β) (H : ∀* n, f n = h (g₁ n) (g₂ n)) :
   of_seq f = (lift₂ h) (@of_seq _ _ φ g₁) (@of_seq _ _ φ g₂) := quotient.sound' H
 
-@[simp] lemma of_seq_zero [has_zero β] (f : α → β) : of_seq 0 = (0 : β*) := rfl
+@[simp] lemma of_seq_zero [has_zero β] : of_seq 0 = (0 : β*) := rfl
 
 @[simp] lemma of_seq_add [has_add β] (f g : α → β) :
   of_seq (f + g) = of_seq f + (of_seq g : β*) := rfl
 
 @[simp] lemma of_seq_neg [has_neg β] (f : α → β) : of_seq (-f) = - (of_seq f : β*) := rfl
 
-@[simp] lemma of_seq_one [has_one β] (f : α → β) : of_seq 1 = (1 : β*) := rfl
+@[simp] lemma of_seq_one [has_one β] : of_seq 1 = (1 : β*) := rfl
 
 @[simp] lemma of_seq_mul [has_mul β] (f g : α → β) :
   of_seq (f * g) = of_seq f * (of_seq g : β*) := rfl
@@ -471,7 +472,7 @@ begin
     λ i hi, (min_eq_right hi).symm),
 end
 
-lemma abs_def [decidable_linear_ordered_comm_group β] (U : is_ultrafilter φ) (x y : β*) :
+lemma abs_def [decidable_linear_ordered_comm_group β] (U : is_ultrafilter φ) (x : β*) :
   @abs _ (filter_product.decidable_linear_ordered_comm_group U) x = (lift abs) x :=
 quotient.induction_on' x $ λ a, by unfold abs; rw max_def;
 exact quotient.sound' (show ∀* i, abs _ = _, by simp)

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -126,7 +126,8 @@ def to_units (s : S) : units (localization α S) :=
   val_inv := quotient.sound $ r_of_eq $ mul_assoc _ _ _,
   inv_val := quotient.sound $ r_of_eq $ show s.val * 1 * 1 = 1 * (1 * s.val), by simp }
 
-@[simp] lemma to_units_coe (s : S) : ((to_units s) : localization α S) = s := rfl
+@[simp] lemma to_units_coe (s : S) :
+  ((to_units s) : localization α S) = ((s : α) : localization α S) := rfl
 
 section
 variables (α S) (x y : α) (n : ℕ)
@@ -160,8 +161,8 @@ is_unit_unit $ to_units ⟨s, ‹s ∈ S›⟩
 @[simp] lemma coe_mul : (↑(x * y) : localization α S) = x * y := of_mul _ _ _ _
 @[simp] lemma coe_neg : (↑(-x) : localization α S) = -x := of_neg _ _ _
 @[simp] lemma coe_pow : (↑(x ^ n) : localization α S) = x ^ n := of_pow _ _ _ _
-@[simp] lemma coe_is_unit (s : S) : is_unit (s : localization α S) := of_is_unit _ _ _
-@[simp] lemma coe_is_unit' (s ∈ S) : is_unit (s : localization α S) := of_is_unit' _ _ _ ‹s ∈ S›
+@[simp] lemma coe_is_unit (s : S) : is_unit ((s : α) : localization α S) := of_is_unit _ _ _
+@[simp] lemma coe_is_unit' (s ∈ S) : is_unit ((s : α) : localization α S) := of_is_unit' _ _ _ ‹s ∈ S›
 end
 
 @[simp] lemma mk_self {x : α} {hx : x ∈ S} :
@@ -177,7 +178,10 @@ by cases s; exact mk_self
   (mk s.1 s : localization α S) = 1 :=
 mk_self'
 
-@[simp] lemma coe_mul_mk (x y : α) (s : S) :
+-- This lemma does not apply with simp, since (mk r s) simplifies to (r * s⁻¹).
+-- However, it could apply with dsimp.
+@[simp, nolint /- simp_nf -/]
+lemma coe_mul_mk (x y : α) (s : S) :
   ↑x * mk y s = mk (x * y) s :=
 quotient.sound $ r_of_eq $ by rw one_mul
 
@@ -185,7 +189,10 @@ lemma mk_eq_mul_mk_one (r : α) (s : S) :
   mk r s = r * mk 1 s :=
 by rw [coe_mul_mk, mul_one]
 
-@[simp] lemma mk_mul_mk (x y : α) (s t : S) :
+-- This lemma does not apply with simp, since (mk r s) simplifies to (r * s⁻¹).
+-- However, it could apply with dsimp.
+@[simp, nolint /- simp_nf -/]
+lemma mk_mul_mk (x y : α) (s t : S) :
   mk x s * mk y t = mk (x * y) (s * t) := rfl
 
 @[simp] lemma mk_mul_cancel_left (r : α) (s : S) :
@@ -258,7 +265,10 @@ instance lift.is_ring_hom (h : ∀ s ∈ S, is_unit (f s)) :
   is_ring_hom (lift f h) :=
 lift'.is_ring_hom _ _ _
 
-@[simp] lemma lift'_mk (g : S → units β) (hg : ∀ s, (g s : β) = f s) (r : α) (s : S) :
+-- This lemma does not apply with simp, since (mk r s) simplifies to (r * s⁻¹).
+-- However, it could apply with dsimp.
+@[simp, nolint /- simp_nf -/]
+lemma lift'_mk (g : S → units β) (hg : ∀ s, (g s : β) = f s) (r : α) (s : S) :
   lift' f g hg (mk r s) = f r * ↑(g s)⁻¹ := rfl
 
 @[simp] lemma lift'_of (g : S → units β) (hg : ∀ s, (g s : β) = f s) (a : α) :

--- a/src/ring_theory/power_series.lean
+++ b/src/ring_theory/power_series.lean
@@ -155,9 +155,9 @@ begin
   rw [coeff_mul, finset.sum_eq_single ((0 : σ →₀ ℕ), n)];
   simp [mem_antidiagonal_support, coeff_one],
   show ∀ (i j : σ →₀ ℕ), i + j = n → (i = 0 → j ≠ n) →
-    (if (i = 0) then 1 else 0) * (coeff α j) φ = 0,
+    (if i = 0 then coeff α j φ else 0) = 0,
   intros i j hij h,
-  rw [if_neg, zero_mul],
+  rw [if_neg],
   contrapose! h,
   simpa [h] using hij,
 end

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -482,7 +482,7 @@ eq.symm $ quot.sound ⟨order_iso.of_surjective
 
 @[simp] theorem typein_apply {α β} {r : α → α → Prop} {s : β → β → Prop}
   [is_well_order α r] [is_well_order β s] (f : r ≼i s) (a : α) :
-  ordinal.typein s (f a) = ordinal.typein r a :=
+  ordinal.typein s ((f : r ≼o s) a) = ordinal.typein r a :=
 eq.symm $ quotient.sound ⟨order_iso.of_surjective
   (order_embedding.cod_restrict _
     ((subrel.order_embedding _ _).trans f)

--- a/src/set_theory/zfc.lean
+++ b/src/set_theory/zfc.lean
@@ -247,7 +247,7 @@ def eval_aux : Π {n}, { f : resp n → arity Set.{u} n // ∀ (a b : resp n), r
 /-- An equivalence-respecting function yields an n-ary Set function. -/
 def eval (n) : resp n → arity Set.{u} n := eval_aux.1
 
-@[simp] theorem eval_val {n f x} : (@eval (n+1) f : Set → arity Set n) ⟦x⟧ = eval n (resp.f f x) := rfl
+theorem eval_val {n f x} : (@eval (n+1) f : Set → arity Set n) ⟦x⟧ = eval n (resp.f f x) := rfl
 
 end resp
 
@@ -283,7 +283,7 @@ noncomputable def all_definable : Π {n} (F : arity Set.{u} n), definable n F
       rw @quotient.sound pSet _ _ _ h,
       exact (definable.resp (F ⟦y⟧)).2 },
     exact funext (λq, quotient.induction_on q $ λx,
-      by simp [resp.f]; exact @definable.eq _ (F ⟦x⟧) (I ⟦x⟧))
+      by simp [resp.eval_val, resp.f]; exact @definable.eq _ (F ⟦x⟧) (I ⟦x⟧))
   end
 
 end classical
@@ -294,6 +294,10 @@ open pSet
 def mk : pSet → Set := quotient.mk
 
 @[simp] theorem mk_eq (x : pSet) : @eq Set ⟦x⟧ (mk x) := rfl
+
+@[simp] lemma eval_mk {n f x} :
+  (@resp.eval (n+1) f : Set → arity Set n) (mk x) = resp.eval n (resp.f f x) :=
+rfl
 
 def mem : Set → Set → Prop :=
 quotient.lift₂ pSet.mem

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -10,6 +10,7 @@ namespace expr
 open tactic
 
 attribute [derive has_reflect] binder_info
+attribute [derive decidable_eq] binder_info congr_arg_kind
 
 /-- Given an expr `α` representing a type with numeral structure,
 `of_nat α n` creates the `α`-valued numeral expression corresponding to `n`. -/

--- a/src/tactic/lint.lean
+++ b/src/tactic/lint.lean
@@ -486,8 +486,12 @@ reset_instance_cache,
 intros,
 lhs ← target >>= simp_lhs,
 sls ← simp_lemmas.mk_default,
--- remove commutativity lemmas since they may not apply to substitution instances of the lhs
-let sls := sls.erase [``add_comm, ``bool.bor_comm, ``bool.band_comm, ``bool.bxor_comm],
+let sls := sls.erase [
+  -- remove commutativity lemmas since they may not apply to substitution instances of the lhs
+  ``add_comm, ``bool.bor_comm, ``bool.band_comm, ``bool.bxor_comm,
+  -- TODO: remove once we have moved to Lean 3.6
+  ``sub_eq_add_neg
+  ],
 let as := lhs.get_app_args,
 cgr ← mk_specialized_congr_lemma_simp lhs,
 some (a', i, prf) ← tactic.first (as.map_with_index $ λ i a, do

--- a/src/tactic/lint.lean
+++ b/src/tactic/lint.lean
@@ -24,6 +24,7 @@ The following linters are run by default:
 8.  `impossible_instance` checks for instances that can never fire.
 9.  `incorrect_type_class_argument` checks for arguments in [square brackets] that are not classes.
 10. `dangerous_instance` checks for instances that generate type-class problems with metavariables.
+11. `simp_nf` checks that arguments of the left-hand side of simp lemmas are in simp-normal form.
 
 Another linter, `doc_blame_thm`, checks for missing doc strings on lemmas and theorems.
 This is not run by default.

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -511,13 +511,21 @@ continuous_linear_map.ext e.apply_symm_apply
   (e.symm : M₂ →L[R] M).comp (e : M →L[R] M₂) = continuous_linear_map.id :=
 continuous_linear_map.ext e.symm_apply_apply
 
-@[simp] lemma symm_comp_self (e : M ≃L[R] M₂) :
+lemma symm_comp_self (e : M ≃L[R] M₂) :
   (e.symm : M₂ → M) ∘ (e : M → M₂) = id :=
 by{ ext x, exact symm_apply_apply e x }
 
-@[simp] lemma self_comp_symm (e : M ≃L[R] M₂) :
+lemma self_comp_symm (e : M ≃L[R] M₂) :
   (e : M → M₂) ∘ (e.symm : M₂ → M) = id :=
 by{ ext x, exact apply_symm_apply e x }
+
+@[simp] lemma symm_comp_self' (e : M ≃L[R] M₂) :
+  ((e.symm : M₂ →L[R] M) : M₂ → M) ∘ ((e : M →L[R] M₂) : M → M₂) = id :=
+symm_comp_self e
+
+@[simp] lemma self_comp_symm' (e : M ≃L[R] M₂) :
+  ((e : M →L[R] M₂) : M → M₂) ∘ ((e.symm : M₂ →L[R] M) : M₂ → M) = id :=
+self_comp_symm e
 
 @[simp] theorem symm_symm (e : M ≃L[R] M₂) : e.symm.symm = e :=
 by { ext x, refl }

--- a/src/topology/local_homeomorph.lean
+++ b/src/topology/local_homeomorph.lean
@@ -90,10 +90,11 @@ protected def symm : local_homeomorph β α :=
   ..e.to_local_equiv.symm }
 
 @[simp] lemma symm_to_local_equiv : e.symm.to_local_equiv = e.to_local_equiv.symm := rfl
-@[simp] lemma symm_to_fun : e.symm.to_fun = e.inv_fun := rfl
-@[simp] lemma symm_inv_fun : e.symm.inv_fun = e.to_fun := rfl
-@[simp] lemma symm_source : e.symm.source = e.target := rfl
-@[simp] lemma symm_target : e.symm.target = e.source := rfl
+-- The following lemmas are already simp via local_equiv
+lemma symm_to_fun : e.symm.to_fun = e.inv_fun := rfl
+lemma symm_inv_fun : e.symm.inv_fun = e.to_fun := rfl
+lemma symm_source : e.symm.source = e.target := rfl
+lemma symm_target : e.symm.target = e.source := rfl
 @[simp] lemma symm_symm : e.symm.symm = e := eq_of_local_equiv_eq $ by simp
 
 /-- A local homeomorphism is continuous at any point of its source -/
@@ -160,11 +161,12 @@ protected def restr_open (s : set α) (hs : is_open s) :
   continuous_inv_fun := e.continuous_inv_fun.mono (inter_subset_left _ _),
   ..e.to_local_equiv.restr s}
 
-@[simp] lemma restr_open_source (s : set α) (hs : is_open s) :
-  (e.restr_open s hs).source = e.source ∩ s := rfl
-
 @[simp] lemma restr_open_to_local_equiv (s : set α) (hs : is_open s) :
   (e.restr_open s hs).to_local_equiv = e.to_local_equiv.restr s := rfl
+
+-- Already simp via local_equiv
+lemma restr_open_source (s : set α) (hs : is_open s) :
+  (e.restr_open s hs).source = e.source ∩ s := rfl
 
 /-- Restricting a local homeomorphism `e` to `e.source ∩ interior s`. We use the interior to make
 sure that the restriction is well defined whatever the set s, since local homeomorphisms are by
@@ -173,13 +175,14 @@ restriction of local equivalences -/
 protected def restr (s : set α) : local_homeomorph α β :=
 e.restr_open (interior s) is_open_interior
 
-@[simp] lemma restr_to_fun (s : set α)  : (e.restr s).to_fun = e.to_fun := rfl
-@[simp] lemma restr_inv_fun (s : set α) : (e.restr s).inv_fun = e.inv_fun := rfl
-@[simp] lemma restr_source (s : set α)  : (e.restr s).source = e.source ∩ interior s := rfl
-@[simp] lemma restr_target (s : set α) :
-  (e.restr s).target = e.target ∩ e.inv_fun ⁻¹' (interior s) := rfl
 @[simp] lemma restr_to_local_equiv (s : set α) :
   (e.restr s).to_local_equiv = (e.to_local_equiv).restr (interior s) := rfl
+-- The following lemmas are already simp via local_equiv
+lemma restr_to_fun (s : set α)  : (e.restr s).to_fun = e.to_fun := rfl
+lemma restr_inv_fun (s : set α) : (e.restr s).inv_fun = e.inv_fun := rfl
+lemma restr_source (s : set α)  : (e.restr s).source = e.source ∩ interior s := rfl
+lemma restr_target (s : set α) :
+  (e.restr s).target = e.target ∩ e.inv_fun ⁻¹' (interior s) := rfl
 
 lemma restr_source' (s : set α) (hs : is_open s) : (e.restr s).source = e.source ∩ s :=
 by rw [e.restr_source, interior_eq_of_open hs]
@@ -212,12 +215,13 @@ end
 protected def refl (α : Type*) [topological_space α] : local_homeomorph α α :=
 (homeomorph.refl α).to_local_homeomorph
 
-@[simp] lemma refl_source  : (local_homeomorph.refl α).source = univ := rfl
-@[simp] lemma refl_target  : (local_homeomorph.refl α).target = univ := rfl
-@[simp] lemma refl_symm    : (local_homeomorph.refl α).symm = local_homeomorph.refl α := rfl
-@[simp] lemma refl_to_fun  : (local_homeomorph.refl α).to_fun = id := rfl
-@[simp] lemma refl_inv_fun : (local_homeomorph.refl α).inv_fun = id := rfl
 @[simp] lemma refl_local_equiv : (local_homeomorph.refl α).to_local_equiv = local_equiv.refl α := rfl
+-- The corresponding lemmas for local_equiv are already marked simp.
+lemma refl_source  : (local_homeomorph.refl α).source = univ := rfl
+lemma refl_target  : (local_homeomorph.refl α).target = univ := rfl
+@[simp] lemma refl_symm    : (local_homeomorph.refl α).symm = local_homeomorph.refl α := rfl
+lemma refl_to_fun  : (local_homeomorph.refl α).to_fun = id := rfl
+lemma refl_inv_fun : (local_homeomorph.refl α).inv_fun = id := rfl
 
 section
 variables {s : set α} (hs : is_open s)
@@ -230,12 +234,13 @@ def of_set (s : set α) (hs : is_open s) : local_homeomorph α α :=
   continuous_inv_fun := continuous_id.continuous_on,
   ..local_equiv.of_set s }
 
-@[simp] lemma of_set_source  : (of_set s hs).source = s := rfl
-@[simp] lemma of_set_target  : (of_set s hs).target = s := rfl
-@[simp] lemma of_set_to_fun  : (of_set s hs).to_fun = id := rfl
-@[simp] lemma of_set_inv_fun : (of_set s hs).inv_fun = id := rfl
-@[simp] lemma of_set_symm    : (of_set s hs).symm = of_set s hs := rfl
 @[simp] lemma of_set_to_local_equiv : (of_set s hs).to_local_equiv = local_equiv.of_set s := rfl
+-- The following lemmas are simp via local_equiv:
+lemma of_set_source  : (of_set s hs).source = s := rfl
+lemma of_set_target  : (of_set s hs).target = s := rfl
+lemma of_set_to_fun  : (of_set s hs).to_fun = id := rfl
+lemma of_set_inv_fun : (of_set s hs).inv_fun = id := rfl
+lemma of_set_symm    : (of_set s hs).symm = of_set s hs := rfl
 
 end
 
@@ -264,9 +269,9 @@ protected def trans : local_homeomorph α γ :=
 
 @[simp] lemma trans_to_local_equiv :
   (e.trans e').to_local_equiv = e.to_local_equiv.trans e'.to_local_equiv := rfl
-
-@[simp] lemma trans_to_fun : (e.trans e').to_fun = e'.to_fun ∘ e.to_fun := rfl
-@[simp] lemma trans_inv_fun : (e.trans e').inv_fun = e.inv_fun ∘ e'.inv_fun := rfl
+-- The following lemmas are already simp via local_equiv
+lemma trans_to_fun : (e.trans e').to_fun = e'.to_fun ∘ e.to_fun := rfl
+lemma trans_inv_fun : (e.trans e').inv_fun = e.inv_fun ∘ e'.inv_fun := rfl
 
 lemma trans_symm_eq_symm_trans_symm : (e.trans e').symm = e'.symm.trans e.symm :=
 by cases e; cases e'; refl
@@ -417,16 +422,18 @@ def prod (e : local_homeomorph α β) (e' : local_homeomorph γ δ) : local_home
 @[simp] lemma prod_to_local_equiv (e : local_homeomorph α β) (e' : local_homeomorph γ δ) :
   (e.prod e').to_local_equiv = e.to_local_equiv.prod e'.to_local_equiv := rfl
 
-@[simp] lemma prod_source (e : local_homeomorph α β) (e' : local_homeomorph γ δ) :
+-- The following lemmas are simp via local_equiv:
+
+lemma prod_source (e : local_homeomorph α β) (e' : local_homeomorph γ δ) :
   (e.prod e').source = set.prod e.source e'.source := rfl
 
-@[simp] lemma prod_target (e : local_homeomorph α β) (e' : local_homeomorph γ δ) :
+lemma prod_target (e : local_homeomorph α β) (e' : local_homeomorph γ δ) :
   (e.prod e').target = set.prod e.target e'.target := rfl
 
-@[simp] lemma prod_to_fun (e : local_homeomorph α β) (e' : local_homeomorph γ δ) :
+lemma prod_to_fun (e : local_homeomorph α β) (e' : local_homeomorph γ δ) :
   (e.prod e').to_fun = (λp, (e.to_fun p.1, e'.to_fun p.2)) := rfl
 
-@[simp] lemma prod_inv_fun (e : local_homeomorph α β) (e' : local_homeomorph γ δ) :
+lemma prod_inv_fun (e : local_homeomorph α β) (e' : local_homeomorph γ δ) :
   (e.prod e').inv_fun = (λp, (e.inv_fun p.1, e'.inv_fun p.2)) := rfl
 
 end prod

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -1360,10 +1360,12 @@ diam_subsingleton subsingleton_empty
 @[simp] lemma diam_singleton : diam ({x} : set α) = 0 :=
 diam_subsingleton subsingleton_singleton
 
-@[simp] lemma diam_pair : diam ({x, y} : set α) = dist x y :=
+-- Does not work as a simp-lemma, since {x, y} reduces to (insert y {x})
+lemma diam_pair : diam ({x, y} : set α) = dist x y :=
 by simp only [diam, emetric.diam_pair, dist_edist]
 
-@[simp] lemma diam_triple :
+-- Does not work as a simp-lemma, since {x, y} reduces to (insert z (insert y {x}))
+lemma diam_triple :
   metric.diam ({x, y, z} : set α) = max (dist x y) (max (dist y z) (dist x z)) :=
 begin
   simp only [metric.diam, emetric.diam_triple, dist_edist],

--- a/test/lint_simp_nf.lean
+++ b/test/lint_simp_nf.lean
@@ -1,0 +1,56 @@
+import tactic.lint
+
+def f : ℕ → ℕ := default _
+def c : ℕ := default _
+def d : ℕ := default _
+
+@[simp] lemma c_eq_d : c = d := rfl
+
+-- The following lemma never applies when using simp, because c is first rewritten to d
+@[simp] lemma f_c : f c = 0 := rfl
+
+example : f c = 0 :=
+begin
+  simp,
+  guard_target f d = 0, -- does not apply f_c
+  refl
+end
+
+open tactic
+#eval do
+decl ← get_decl ``f_c,
+res ← linter.simp_nf.test decl,
+-- linter complains
+guard $ res.is_some
+
+
+
+
+
+-- TODO: there are some issues with `coe_to_fun` due to
+-- the implementation using `mk_specialized_congr_lemma_simp`
+
+structure morphism :=
+(f : ℕ → ℕ)
+
+instance : has_coe_to_fun morphism :=
+⟨_, morphism.f⟩
+
+def h : morphism := ⟨default _⟩
+
+-- Also never applies
+@[simp] lemma h_c : h c = 0 := rfl
+
+example : h c = 0 :=
+begin
+  simp,
+  guard_target h d = 0, -- does not apply h_c
+  refl
+end
+
+open tactic
+#eval do
+decl ← get_decl ``h_c,
+res ← linter.simp_nf.test decl,
+-- TODO: linter should complain
+guard $ res.is_none


### PR DESCRIPTION
Motivation: suppose you write a simp lemma `0 ≤ of_nat n`.  You then try it out only to find out that it doesn't work.  What happened?  There is another simp lemma rewriting `of_nat n` to `↑n`, and your nice lemma never has a chance to apply.

What was wrong with the lemma?  The term `of_nat n` was not in simp-normal form, it is simplified to `↑n`.

This PR introduces a linter to detect such simp lemmas, concretely it checks that all arguments of the left-hand side of the simp lemma are in simp-normal form.  It also fixes a large number of these issues across mathlib.

The error message from the linter is hopefully enlightening enough:
```lean
-- ring_theory/algebra.lean
#print algebra.map_sub /- Argument #5 of left-hand side (algebra_map A (r - s)) reduces from
  r - s
to
  r + -s
using 
  [sub_eq_add_neg] -/
```

There is maybe an argument to be made that some of the simp-normal forms should be chosen differently.  I tried to keep the existing simp-normal forms as far as possible, and only remove/fix lemmas that could never apply.  If you want to change the simp NFs, I'd prefer to do this in follow-up PRs.
 * Subtraction is the single largest source of issues.  The lemma `sub_eq_add_neg` rewrites `a - b` to `a + -b`.  Hence no lemma with a `-` on the left-hand side ever worked as a simp lemma.
 * Multisets use `0` and `+` instead of `∅` and `∪`.  Therefore you can't use the built-in set notation on the lhs of simp lemmas.
 * Finsets have their special `finset.singleton`, so you can't have `{a}` on the lhs of a simp lemma.
 * I'm getting really annoyed by coercions as type classes.  As you probably know, we have two different coercions from `ℕ` to `ℤ`.  And of course half of the lemmas used the wrong coercion on the lhs.  To make it even worse, the error message you get from the linter is `↑n reduces to ↑n`. :angry: 
 * You can't use `⋃ x ∈ A ∪ B, ...` on the lhs of a simp lemma, because `x ∈ A ∪ B` simplifies to `x ∈ A ∨ x ∈ B`.
 * You can't use `∃ x ∈ A, ...` either.  By now you can probably guess why.

I have a few more linters for simp lemmas in the works: [no local constants as head symbols](https://github.com/leanprover-community/mathlib/tree/simp-lc-lint), [simp lemmas that can be proven by simp](https://github.com/leanprover-community/mathlib/tree/simp-red-lint), and [local confluence](https://github.com/leanprover-community/mathlib/tree/simp-nonconfl-lint).