### PR TITLE
fix(tactic/tauto): fix typos

### DIFF
--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -1178,7 +1178,7 @@ Transforms the goal into its contrapositive.
 This tactic (with shorthand `tauto`) breaks down assumptions of the form `_ ∧ _`, `_ ∨ _`, `_ ↔ _` and `∃ _, _`
 and splits a goal of the form `_ ∧ _`, `_ ↔ _` or `∃ _, _` until it can be discharged
 using `reflexivity` or `solve_by_elim`. This is a finishing tactic: it
-either closes the goal of raises an error.
+either closes the goal or raises an error.
 
 The variants `tautology!` or `tauto!` use the law of excluded middle.
 

--- a/src/tactic/tauto.lean
+++ b/src/tactic/tauto.lean
@@ -212,7 +212,7 @@ local postfix `?`:9001 := optional
 `tautology` breaks down assumptions of the form `_ ∧ _`, `_ ∨ _`, `_ ↔ _` and `∃ _, _`
 and splits a goal of the form `_ ∧ _`, `_ ↔ _` or `∃ _, _` until it can be discharged
 using `reflexivity` or `solve_by_elim`.
-This is a finishing tactic: it either closes the goal of raises an error.
+This is a finishing tactic: it either closes the goal or raises an error.
 The variant `tautology!` uses the law of excluded middle.
 -/
 meta def tautology (c : parse $ (tk "!")?) := tactic.tautology c.is_some
@@ -223,7 +223,7 @@ meta def tautology (c : parse $ (tk "!")?) := tactic.tautology c.is_some
 `tauto` breaks down assumptions of the form `_ ∧ _`, `_ ∨ _`, `_ ↔ _` and `∃ _, _`
 and splits a goal of the form `_ ∧ _`, `_ ↔ _` or `∃ _, _` until it can be discharged
 using `reflexivity` or `solve_by_elim`.
-This is a finishing tactic: it either closes the goal of raises an error.
+This is a finishing tactic: it either closes the goal or raises an error.
 The variant `tauto!` uses the law of excluded middle.
 -/
 meta def tauto (c : parse $ (tk "!")?) := tautology c


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)

---

Just fixing a typo I ran into.