### PR TITLE
fix(*): remove loopy simp lemmas

### DIFF
--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -263,7 +263,10 @@ rfl
   (e₁.trans e₂).conj = e₁.conj.trans e₂.conj :=
 rfl
 
-@[simp] lemma conj_comp (e : α ≃ β) (f₁ f₂ : α → α) :
+-- This should not be a simp lemma as long as `(∘)` is reducible:
+-- when `(∘)` is reducible, Lean can unify `f₁ ∘ f₂` with any `g` using
+-- `f₁ := g` and `f₂ := λ x, x`.  This causes nontermination.
+lemma conj_comp (e : α ≃ β) (f₁ f₂ : α → α) :
   e.conj (f₁ ∘ f₂) = (e.conj f₁) ∘ (e.conj f₂) :=
 by apply arrow_congr_comp
 

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -140,10 +140,13 @@ namespace order_dual
 instance (α : Type*) [has_le α] : has_le (order_dual α) := ⟨λx y:α, y ≤ x⟩
 instance (α : Type*) [has_lt α] : has_lt (order_dual α) := ⟨λx y:α, y < x⟩
 
-@[simp] lemma dual_le [has_le α] {a b : α} :
+-- `dual_le` and `dual_lt` should not be simp lemmas:
+-- they cause a loop since `α` and `order_dual α` are definitionally equal
+
+lemma dual_le [has_le α] {a b : α} :
   @has_le.le (order_dual α) _ a b ↔ @has_le.le α _ b a := iff.rfl
 
-@[simp] lemma dual_lt [has_lt α] {a b : α} :
+lemma dual_lt [has_lt α] {a b : α} :
   @has_lt.lt (order_dual α) _ a b ↔ @has_lt.lt α _ b a := iff.rfl
 
 instance (α : Type*) [preorder α] : preorder (order_dual α) :=


### PR DESCRIPTION
Remove the simp attribute from two lemmas because they create loops in the simplifier:
```lean
-- loops due to order_dual.dual_le
example (x y : punit) : x ≤ y := by simp

-- loops due to equiv.conj_comp
example {α β} (e : α ≃ β) (f : α → α) (x : β) :
  e.conj f x = (e $ f $ e.symm x) :=
by simp
```
