### PR TITLE
refactor(order/bounds): use dot notation, reorder, prove more properties

### DIFF
--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -449,19 +449,14 @@ variables [semilattice_sup α] [nonempty α] {s : set α}
 
 /--A finite set is bounded above.-/
 lemma bdd_above_finite (hs : finite s) : bdd_above s :=
-finite.induction_on hs bdd_above_empty $ λ a s _ _, bdd_above_insert.2
+finite.induction_on hs bdd_above_empty $ λ a s _ _ h, h.insert a
 
 /--A finite union of sets which are all bounded above is still bounded above.-/
 lemma bdd_above_finite_union {I : set β} {S : β → set α} (H : finite I) :
-(bdd_above (⋃i∈I, S i)) ↔ (∀i ∈ I, bdd_above (S i)) :=
-⟨λ (bdd : bdd_above (⋃i∈I, S i)) i (hi : i ∈ I),
-  bdd_above_subset (subset_bUnion_of_mem hi) bdd,
-show (∀i ∈ I, bdd_above (S i)) → (bdd_above (⋃i∈I, S i)), from
+  (bdd_above (⋃i∈I, S i)) ↔ (∀i ∈ I, bdd_above (S i)) :=
 finite.induction_on H
-  (λ _, by rw bUnion_empty; exact bdd_above_empty)
-  (λ x s hn hf IH h, by simp only [
-      set.mem_insert_iff, or_imp_distrib, forall_and_distrib, forall_eq] at h;
-    rw [set.bUnion_insert, bdd_above_union]; exact ⟨h.1, IH h.2⟩)⟩
+  (by simp only [bUnion_empty, bdd_above_empty, ball_empty_iff])
+  (λ a s ha _ hs, by simp only [bUnion_insert, ball_insert_iff, bdd_above_union, hs])
 
 end
 
@@ -471,19 +466,12 @@ variables [semilattice_inf α] [nonempty α] {s : set α}
 
 /--A finite set is bounded below.-/
 lemma bdd_below_finite (hs : finite s) : bdd_below s :=
-finite.induction_on hs bdd_below_empty $ λ a s _ _, bdd_below_insert.2
+finite.induction_on hs bdd_below_empty $ λ a s _ _ h, h.insert a
 
 /--A finite union of sets which are all bounded below is still bounded below.-/
 lemma bdd_below_finite_union {I : set β} {S : β → set α} (H : finite I) :
-(bdd_below (⋃i∈I, S i)) ↔ (∀i ∈ I, bdd_below (S i)) :=
-⟨λ (bdd : bdd_below (⋃i∈I, S i)) i (hi : i ∈ I),
-  bdd_below_subset (subset_bUnion_of_mem hi) bdd,
-show (∀i ∈ I, bdd_below (S i)) → (bdd_below (⋃i∈I, S i)), from
-finite.induction_on H
-  (λ _, by rw bUnion_empty; exact bdd_below_empty)
-  (λ x s hn hf IH h, by simp only [
-      set.mem_insert_iff, or_imp_distrib, forall_and_distrib, forall_eq] at h;
-    rw [set.bUnion_insert, bdd_below_union]; exact ⟨h.1, IH h.2⟩)⟩
+  (bdd_below (⋃i∈I, S i)) ↔ (∀i ∈ I, bdd_below (S i)) :=
+@bdd_above_finite_union (order_dual α) _ _ _ _ _ H
 
 end
 

--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -383,10 +383,10 @@ theorem sInter_union (S T : set (set α)) : ⋂₀ (S ∪ T) = ⋂₀ S ∩ ⋂�
 @[simp] theorem sInter_insert (s : set α) (T : set (set α)) : ⋂₀ (insert s T) = s ∩ ⋂₀ T := Inf_insert
 
 theorem sUnion_pair (s t : set α) : ⋃₀ {s, t} = s ∪ t :=
-(sUnion_insert _ _).trans $ by rw [union_comm, sUnion_singleton]
+Sup_pair
 
 theorem sInter_pair (s t : set α) : ⋂₀ {s, t} = s ∩ t :=
-(sInter_insert _ _).trans $ by rw [inter_comm, sInter_singleton]
+Inf_pair
 
 @[simp] theorem sUnion_image (f : α → set β) (s : set α) : ⋃₀ (f '' s) = ⋃ x ∈ s, f x := Sup_image
 

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -137,6 +137,7 @@ end monotone
 def order_dual (α : Type*) := α
 
 namespace order_dual
+instance (α : Type*) [h : nonempty α] : nonempty (order_dual α) := h
 instance (α : Type*) [has_le α] : has_le (order_dual α) := ⟨λx y:α, y ≤ x⟩
 instance (α : Type*) [has_lt α] : has_lt (order_dual α) := ⟨λx y:α, y < x⟩
 

--- a/src/order/bounds.lean
+++ b/src/order/bounds.lean
@@ -93,7 +93,7 @@ lemma is_lub.of_subset_of_superset {s t p : set α} (hs : is_lub s a) (hp : is_l
   (hst : s ⊆ t) (htp : t ⊆ p) : is_lub t a :=
 ⟨upper_bounds_mono_set htp hp.1, lower_bounds_mono_set (upper_bounds_mono_set hst) hs.2⟩
 
-/-- If `a` is a greatest lower bound for sets `s` and `p`, the it is a greater lower bound for any
+/-- If `a` is a greatest lower bound for sets `s` and `p`, then it is a greater lower bound for any
 set `t`, `s ⊆ t ⊆ p`. -/
 lemma is_glb.of_subset_of_superset {s t p : set α} (hs : is_glb s a) (hp : is_glb p a)
   (hst : s ⊆ t) (htp : t ⊆ p) : is_glb t a :=

--- a/src/order/bounds.lean
+++ b/src/order/bounds.lean
@@ -15,7 +15,7 @@ In this file we define:
   (resp., lower) bounds of `s` is nonempty;
 * `is_least s a`, `is_greatest s a` : `a` is a least (resp., greatest) element of `s`;
   for a partial order, it is unique if exists;
-* `is_lub s a`, `is_glb s a` : `a` is a least upper boundary (resp., a greatest lower boundary)
+* `is_lub s a`, `is_glb s a` : `a` is a least upper bound (resp., a greatest lower bound)
   of `s`; for a partial order, it is unique if exists.
 
 We also prove various lemmas about monotonicity, behaviour under `∪`, `∩`, `insert`, and provide
@@ -87,13 +87,17 @@ nonempty.mono $ upper_bounds_mono_set h
 lemma bdd_below.mono ⦃s t : set α⦄ (h : s ⊆ t) : bdd_below t → bdd_below s :=
 nonempty.mono $ lower_bounds_mono_set h
 
-lemma is_lub.squeeze {s t p : set α} (hs : is_lub s a) (hp : is_lub p a)
+/-- If `a` is a least upper bound for sets `s` and `p`, the it is a least upper bound for any
+set `t`, `s ⊆ t ⊆ p`. -/
+lemma is_lub.of_subset_of_superset {s t p : set α} (hs : is_lub s a) (hp : is_lub p a)
   (hst : s ⊆ t) (htp : t ⊆ p) : is_lub t a :=
 ⟨upper_bounds_mono_set htp hp.1, lower_bounds_mono_set (upper_bounds_mono_set hst) hs.2⟩
 
-lemma is_glb.squeeze {s t p : set α} (hs : is_glb s a) (hp : is_glb p a)
+/-- If `a` is a greatest lower bound for sets `s` and `p`, the it is a greater lower bound for any
+set `t`, `s ⊆ t ⊆ p`. -/
+lemma is_glb.of_subset_of_superset {s t p : set α} (hs : is_glb s a) (hp : is_glb p a)
   (hst : s ⊆ t) (htp : t ⊆ p) : is_glb t a :=
-@is_lub.squeeze (order_dual α) _ a s t p hs hp hst htp
+@is_lub.of_subset_of_superset (order_dual α) _ a s t p hs hp hst htp
 
 /-!
 ### Conversions
@@ -204,8 +208,8 @@ lemma bdd_below_union [semilattice_inf γ] {s t : set γ} :
   bdd_below (s ∪ t) ↔ bdd_below s ∧ bdd_below t :=
 @bdd_above_union (order_dual γ) _ s t
 
-/-- If `a` is the least upper boundary of `s` and `b` is the least upper boundary of `t`,
-then `a ⊔ b` is the least upper boundary of `s ∪ t`. -/
+/-- If `a` is the least upper bound of `s` and `b` is the least upper bound of `t`,
+then `a ⊔ b` is the least upper bound of `s ∪ t`. -/
 lemma is_lub.union [semilattice_sup γ] {a b : γ} {s t : set γ}
   (hs : is_lub s a) (ht : is_lub t b) :
   is_lub (s ∪ t) (a ⊔ b) :=
@@ -213,8 +217,8 @@ lemma is_lub.union [semilattice_sup γ] {a b : γ} {s t : set γ}
   assume c hc, sup_le
     (hs.right $ assume d hd, hc $ or.inl hd) (ht.right $ assume d hd, hc $ or.inr hd)⟩
 
-/-- If `a` is the greatest lower boundary of `s` and `b` is the greatest lower boundary of `t`,
-then `a ⊓ b` is the greatest lower boundary of `s ∪ t`. -/
+/-- If `a` is the greatest lower bound of `s` and `b` is the greatest lower bound of `t`,
+then `a ⊓ b` is the greatest lower bound of `s ∪ t`. -/
 lemma is_glb.union [semilattice_inf γ] {a₁ a₂ : γ} {s t : set γ}
   (hs : is_glb s a₁) (ht : is_glb t a₂) :
   is_glb (s ∪ t) (a₁ ⊓ a₂) :=
@@ -362,7 +366,8 @@ lemma lower_bounds_Ioo {a b : γ} (hab : a < b) : lower_bounds (Ioo a b) = Iic a
 (is_glb_Ioo hab).lower_bounds_eq
 
 lemma is_glb_Ioc {a b : γ} (hab : a < b) : is_glb (Ioc a b) a :=
-(is_glb_Ioo hab).squeeze (is_glb_Icc $ le_of_lt hab) Ioo_subset_Ioc_self Ioc_subset_Icc_self
+(is_glb_Ioo hab).of_subset_of_superset (is_glb_Icc $ le_of_lt hab)
+  Ioo_subset_Ioc_self Ioc_subset_Icc_self
 
 lemma lower_bound_Ioc {a b : γ} (hab : a < b) : lower_bounds (Ioc a b) = Iic a :=
 (is_glb_Ioc hab).lower_bounds_eq
@@ -497,11 +502,11 @@ lemma lower_bounds_insert (a : α) (s : set α) :
 by rw [insert_eq, lower_bounds_union, lower_bounds_singleton]
 
 /-- When there is a global maximum, every set is bounded above. -/
-@[simp] lemma bdd_above_top [order_top γ] (s : set γ) : bdd_above s :=
+@[simp] protected lemma order_top.bdd_above [order_top γ] (s : set γ) : bdd_above s :=
 ⟨⊤, assume a ha, order_top.le_top a⟩
 
 /-- When there is a global minimum, every set is bounded below. -/
-@[simp] lemma bdd_below_bot [order_bot γ] (s : set γ) : bdd_below s :=
+@[simp] protected lemma order_bot.bdd_below [order_bot γ] (s : set γ) : bdd_below s :=
 ⟨⊥, assume a ha, order_bot.bot_le a⟩
 
 /-!
@@ -586,24 +591,44 @@ lemma is_glb_lt_iff (h : is_glb s a) : a < b ↔ ∃ c ∈ s, c < b :=
 
 end linear_order
 
-section image
+/-!
+### Images of upper/lower bounds under monotone functions
+-/
+
+namespace monotone
 
 variables [preorder α] [preorder β] {f : α → β} (Hf : monotone f) {a : α} {s : set α}
 
-lemma monotone.mem_upper_bounds_image (Ha : a ∈ upper_bounds s) :
+lemma mem_upper_bounds_image (Ha : a ∈ upper_bounds s) :
   f a ∈ upper_bounds (f '' s) :=
 ball_image_of_ball (assume x H, Hf (Ha ‹x ∈ s›))
 
-lemma monotone.mem_lower_bounds_image (Ha : a ∈ lower_bounds s) :
+lemma mem_lower_bounds_image (Ha : a ∈ lower_bounds s) :
   f a ∈ lower_bounds (f '' s) :=
 ball_image_of_ball (assume x H, Hf (Ha ‹x ∈ s›))
 
-/--The image under a monotone function of a set which is bounded above is bounded above-/
-lemma monotone.map_bdd_above (hf : monotone f) : bdd_above s → bdd_above (f '' s)
+/-- The image under a monotone function of a set which is bounded above is bounded above. -/
+lemma map_bdd_above (hf : monotone f) : bdd_above s → bdd_above (f '' s)
 | ⟨C, hC⟩ := ⟨f C, hf.mem_upper_bounds_image hC⟩
 
-/--The image under a monotone function of a set which is bounded below is bounded below-/
-lemma monotone.map_bdd_below (hf : monotone f) : bdd_below s → bdd_below (f '' s)
+/-- The image under a monotone function of a set which is bounded below is bounded below. -/
+lemma map_bdd_below (hf : monotone f) : bdd_below s → bdd_below (f '' s)
 | ⟨C, hC⟩ := ⟨f C, hf.mem_lower_bounds_image hC⟩
 
-end image
+/-- A monotone map sends a least element of a set to a least element of its image. -/
+lemma map_is_least (Ha : is_least s a) : is_least (f '' s) (f a) :=
+⟨mem_image_of_mem _ Ha.1, Hf.mem_lower_bounds_image Ha.2⟩
+
+/-- A monotone map sends a greatest element of a set to a greatest element of its image. -/
+lemma map_is_greatest (Ha : is_greatest s a) : is_greatest (f '' s) (f a) :=
+⟨mem_image_of_mem _ Ha.1, Hf.mem_upper_bounds_image Ha.2⟩
+
+lemma is_lub_image_le (Ha : is_lub s a) {b : β} (Hb : is_lub (f '' s) b) :
+  b ≤ f a :=
+Hb.2 (Hf.mem_upper_bounds_image Ha.1)
+
+lemma le_is_glb_image_le (Ha : is_glb s a) {b : β} (Hb : is_glb (f '' s) b) :
+  f a ≤ b :=
+Hb.2 (Hf.mem_lower_bounds_image Ha.1)
+
+end monotone

--- a/src/order/bounds.lean
+++ b/src/order/bounds.lean
@@ -1,378 +1,592 @@
 /-
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Johannes Hölzl
-
-(Least / Greatest) upper / lower bounds
+Authors: Johannes Hölzl, Yury Kudryashov
 -/
 import algebra.order_functions data.set.intervals.basic
 open set lattice
 
 universes u v w x
-variables {α : Type u} {β : Type v} {γ : Type w} {ι : Sort x} {a a₁ a₂ : α} {b b₁ b₂ : β} {s t : set α}
+variables {α : Type u} {β : Type v} {γ : Type w} {ι : Sort x}
 
-section preorder
+section
+variables [preorder α] [preorder β] {s t : set α} {a b : α}
 
-variables [preorder α] [preorder β] {f : α → β}
+/-!
+### Definitions
+-/
 
 /-- The set of upper bounds of a set. -/
 def upper_bounds (s : set α) : set α := { x | ∀ ⦃a⦄, a ∈ s →  a ≤ x }
 /-- The set of lower bounds of a set. -/
 def lower_bounds (s : set α) : set α := { x | ∀ ⦃a⦄, a ∈ s → x ≤ a }
+
+/-- A set is bounded above if there exists an upper bound. -/
+def bdd_above (s : set α) := (upper_bounds s).nonempty
+/-- A set is bounded below if there exists a lower bound. -/
+def bdd_below (s : set α) := (lower_bounds s).nonempty
+
 /-- `a` is a least element of a set `s`; for a partial order, it is unique if exists. -/
 def is_least (s : set α) (a : α) : Prop := a ∈ s ∧ a ∈ lower_bounds s
 /-- `a` is a greatest element of a set `s`; for a partial order, it is unique if exists -/
 def is_greatest (s : set α) (a : α) : Prop := a ∈ s ∧ a ∈ upper_bounds s
+
 /-- `a` is a least upper bound of a set `s`; for a partial order, it is unique if exists. -/
 def is_lub (s : set α) : α → Prop := is_least (upper_bounds s)
 /-- `a` is a greatest lower bound of a set `s`; for a partial order, it is unique if exists. -/
 def is_glb (s : set α) : α → Prop := is_greatest (lower_bounds s)
 
-lemma upper_bounds_mono (h₁ : a₁ ≤ a₂) (h₂ : a₁ ∈ upper_bounds s) : a₂ ∈ upper_bounds s :=
-λ a h, le_trans (h₂ h) h₁
+/-!
+### Monotonicity
+-/
 
-lemma lower_bounds_mono (h₁ : a₂ ≤ a₁) (h₂ : a₁ ∈ lower_bounds s) : a₂ ∈ lower_bounds s :=
-λ a h, le_trans h₁ (h₂ h)
+lemma upper_bounds_mono_set ⦃s t : set α⦄ (hst : s ⊆ t) :
+  upper_bounds t ⊆ upper_bounds s :=
+λ b hb x h, hb $ hst h
 
-lemma mem_upper_bounds_image (Hf : monotone f) (Ha : a ∈ upper_bounds s) :
-  f a ∈ upper_bounds (f '' s) :=
-ball_image_of_ball (assume x H, Hf (Ha ‹x ∈ s›))
+lemma lower_bounds_mono_set ⦃s t : set α⦄ (hst : s ⊆ t) :
+  lower_bounds t ⊆ lower_bounds s :=
+λ b hb x h, hb $ hst h
 
-lemma mem_lower_bounds_image (Hf : monotone f) (Ha : a ∈ lower_bounds s) :
-  f a ∈ lower_bounds (f '' s) :=
-ball_image_of_ball (assume x H, Hf (Ha ‹x ∈ s›))
+lemma upper_bounds_mono_mem ⦃a b⦄ (hab : a ≤ b) : a ∈ upper_bounds s → b ∈ upper_bounds s :=
+λ ha x h, le_trans (ha h) hab
 
-lemma is_lub_singleton {a : α} : is_lub {a} a :=
-by simp [is_lub, is_least, upper_bounds, lower_bounds] {contextual := tt}
+lemma lower_bounds_mono_mem ⦃a b⦄ (hab : a ≤ b) : b ∈ lower_bounds s → a ∈ lower_bounds s :=
+λ hb x h, le_trans hab (hb h)
 
-lemma is_glb_singleton {a : α} : is_glb {a} a :=
-by simp [is_glb, is_greatest, upper_bounds, lower_bounds] {contextual := tt}
+lemma upper_bounds_mono ⦃s t : set α⦄ (hst : s ⊆ t) ⦃a b⦄ (hab : a ≤ b) :
+  a ∈ upper_bounds t → b ∈ upper_bounds s :=
+λ ha, upper_bounds_mono_set hst $ upper_bounds_mono_mem hab ha
 
-lemma is_glb_Ici : is_glb (Ici a) a :=
-⟨λx hx, hx, λy hy, hy left_mem_Ici⟩
+lemma lower_bounds_mono ⦃s t : set α⦄ (hst : s ⊆ t) ⦃a b⦄ (hab : a ≤ b) :
+  b ∈ lower_bounds t → a ∈ lower_bounds s :=
+λ hb, lower_bounds_mono_set hst $ lower_bounds_mono_mem hab hb
 
-lemma is_glb_Icc (h : a₁ ≤ a₂) : is_glb (Icc a₁ a₂) a₁ :=
-⟨λx hx, hx.1, λy hy, hy (left_mem_Icc.mpr h)⟩
+/-- If `s ⊆ t` and `t` is bounded above, then so is `s`. -/
+lemma bdd_above.mono ⦃s t : set α⦄ (h : s ⊆ t) : bdd_above t → bdd_above s :=
+nonempty.mono $ upper_bounds_mono_set h
 
-lemma is_glb_Ico (h : a₁ < a₂) : is_glb (Ico a₁ a₂) a₁ :=
-⟨λx hx, hx.1, λy hy, hy (left_mem_Ico.mpr h)⟩
+/-- If `s ⊆ t` and `t` is bounded below, then so is `s`. -/
+lemma bdd_below.mono ⦃s t : set α⦄ (h : s ⊆ t) : bdd_below t → bdd_below s :=
+nonempty.mono $ lower_bounds_mono_set h
 
-lemma is_lub_Iic : is_lub (Iic a) a :=
-⟨λx hx, hx, λy hy, hy right_mem_Iic⟩
+lemma is_lub.squeeze {s t p : set α} (hs : is_lub s a) (hp : is_lub p a)
+  (hst : s ⊆ t) (htp : t ⊆ p) : is_lub t a :=
+⟨upper_bounds_mono_set htp hp.1, lower_bounds_mono_set (upper_bounds_mono_set hst) hs.2⟩
 
-lemma is_lub_Icc (h : a₁ ≤ a₂) : is_lub (Icc a₁ a₂) a₂ :=
-⟨λx hx, hx.2, λy hy, hy (right_mem_Icc.mpr h)⟩
+lemma is_glb.squeeze {s t p : set α} (hs : is_glb s a) (hp : is_glb p a)
+  (hst : s ⊆ t) (htp : t ⊆ p) : is_glb t a :=
+@is_lub.squeeze (order_dual α) _ a s t p hs hp hst htp
 
-lemma is_lub_Ioc (h : a₁ < a₂) : is_lub (Ioc a₁ a₂) a₂ :=
-⟨λx hx, hx.2, λy hy, hy (right_mem_Ioc.mpr h)⟩
+/-!
+### Conversions
+-/
 
-end preorder
+lemma is_least.is_glb (h : is_least s a) : is_glb s a := ⟨h.2, λ b hb, hb h.1⟩
 
-section partial_order
-variables [partial_order α]
+lemma is_greatest.is_lub (h : is_greatest s a) : is_lub s a := ⟨h.2, λ b hb, hb h.1⟩
 
-lemma eq_of_is_least_of_is_least (Ha : is_least s a₁) (Hb : is_least s a₂) : a₁ = a₂ :=
-le_antisymm (Ha.right Hb.left) (Hb.right Ha.left)
+lemma is_lub.upper_bounds_eq (h : is_lub s a) : upper_bounds s = Ici a :=
+set.ext $ λ b, ⟨λ hb, h.2 hb, λ hb, upper_bounds_mono_mem hb h.1⟩
 
-lemma is_least_iff_eq_of_is_least (Ha : is_least s a₁) : is_least s a₂ ↔ a₁ = a₂ :=
-iff.intro (eq_of_is_least_of_is_least Ha) (assume h, h ▸ Ha)
+lemma is_glb.lower_bounds_eq (h : is_glb s a) : lower_bounds s = Iic a :=
+@is_lub.upper_bounds_eq (order_dual α) _ _ _ h
 
-lemma eq_of_is_greatest_of_is_greatest (Ha : is_greatest s a₁) (Hb : is_greatest s a₂) : a₁ = a₂ :=
-le_antisymm (Hb.right Ha.left) (Ha.right Hb.left)
+lemma is_least.lower_bounds_eq (h : is_least s a) : lower_bounds s = Iic a :=
+h.is_glb.lower_bounds_eq
 
-lemma is_greatest_iff_eq_of_is_greatest (Ha : is_greatest s a₁) : is_greatest s a₂ ↔ a₁ = a₂ :=
-iff.intro (eq_of_is_greatest_of_is_greatest Ha) (assume h, h ▸ Ha)
+lemma is_greatest.upper_bounds_eq (h : is_greatest s a) : upper_bounds s = Ici a :=
+h.is_lub.upper_bounds_eq
 
-lemma eq_of_is_lub_of_is_lub : is_lub s a₁ → is_lub s a₂ → a₁ = a₂ :=
-eq_of_is_least_of_is_least
+/-- If `s` has a least upper bound, then it is bounded above. -/
+lemma is_lub.bdd_above (h : is_lub s a) : bdd_above s := ⟨a, h.1⟩
 
-lemma is_lub_iff_eq_of_is_lub : is_lub s a₁ → (is_lub s a₂ ↔ a₁ = a₂) :=
-is_least_iff_eq_of_is_least
+/-- If `s` has a greatest lower bound, then it is bounded below. -/
+lemma is_glb.bdd_below (h : is_glb s a) : bdd_below s := ⟨a, h.1⟩
 
-lemma is_lub_le_iff (h : is_lub s a₁) : a₁ ≤ a₂ ↔ a₂ ∈ upper_bounds s :=
-⟨λ hl, upper_bounds_mono hl h.1, λ hr, h.2 hr⟩
+/-- If `s` has a greatest element, then it is bounded above. -/
+lemma is_greatest.bdd_above (h : is_greatest s a) : bdd_above s := ⟨a, h.2⟩
 
-lemma le_is_glb_iff (h : is_glb s a₁) : a₂ ≤ a₁ ↔ a₂ ∈ lower_bounds s :=
-⟨λ hl, lower_bounds_mono hl h.1, λ hr, h.2 hr⟩
+/-- If `s` has a least element, then it is bounded below. -/
+lemma is_least.bdd_below (h : is_least s a) : bdd_below s := ⟨a, h.2⟩
 
-lemma eq_of_is_glb_of_is_glb : is_glb s a₁ → is_glb s a₂ → a₁ = a₂ :=
-eq_of_is_greatest_of_is_greatest
+lemma is_least.nonempty (h : is_least s a) : s.nonempty := ⟨a, h.1⟩
 
-lemma is_glb_iff_eq_of_is_glb : is_glb s a₁ → (is_glb s a₂ ↔ a₁ = a₂) :=
-is_greatest_iff_eq_of_is_greatest
+lemma is_greatest.nonempty (h : is_greatest s a) : s.nonempty := ⟨a, h.1⟩
 
-lemma nonempty_of_is_lub [no_bot_order α] (hs : is_lub s a) : s.nonempty :=
-let ⟨a', ha'⟩ := no_bot a in
-ne_empty_iff_nonempty.1 $ assume h,
-have a ≤ a', from hs.right (by simp [upper_bounds, h]),
-lt_irrefl a $ lt_of_le_of_lt this ha'
+/-!
+### Union and intersection
+-/
 
-lemma nonempty_of_is_glb [no_top_order α] (hs : is_glb s a) : s.nonempty :=
-let ⟨a', ha'⟩ := no_top a in
-ne_empty_iff_nonempty.1 $ assume h,
-have a' ≤ a, from hs.right (by simp [lower_bounds, h]),
-lt_irrefl a $ lt_of_lt_of_le ha' this
+@[simp] lemma upper_bounds_union : upper_bounds (s ∪ t) = upper_bounds s ∩ upper_bounds t :=
+subset.antisymm
+  (λ b hb, ⟨λ x hx, hb (or.inl hx), λ x hx, hb (or.inr hx)⟩)
+  (λ b hb x hx, hx.elim (λ hs, hb.1 hs) (λ ht, hb.2 ht))
 
-end partial_order
+@[simp] lemma lower_bounds_union : lower_bounds (s ∪ t) = lower_bounds s ∩ lower_bounds t :=
+@upper_bounds_union (order_dual α) _ s t
 
-section lattice
+lemma union_upper_bounds_subset_upper_bounds_inter :
+  upper_bounds s ∪ upper_bounds t ⊆ upper_bounds (s ∩ t) :=
+union_subset
+  (upper_bounds_mono_set $ inter_subset_left _ _)
+  (upper_bounds_mono_set $ inter_subset_right _ _)
 
-lemma is_glb_empty [order_top α] : is_glb ∅ (⊤:α) :=
-by simp [is_glb, is_greatest, lower_bounds, upper_bounds]
+lemma union_lower_bounds_subset_lower_bounds_inter :
+  lower_bounds s ∪ lower_bounds t ⊆ lower_bounds (s ∩ t) :=
+@union_upper_bounds_subset_upper_bounds_inter (order_dual α) _ s t
 
-lemma is_lub_empty [order_bot α] : is_lub ∅ (⊥:α) :=
-by simp [is_lub, is_least, lower_bounds, upper_bounds]
+lemma is_least_union_iff {a : α} {s t : set α} :
+  is_least (s ∪ t) a ↔ (is_least s a ∧ a ∈ lower_bounds t ∨ a ∈ lower_bounds s ∧ is_least t a) :=
+by simp [is_least, lower_bounds_union, or_and_distrib_right, and_comm (a ∈ t), and_assoc]
 
-lemma is_lub_union_sup [semilattice_sup α] (hs : is_lub s a₁) (ht : is_lub t a₂) :
-  is_lub (s ∪ t) (a₁ ⊔ a₂) :=
+lemma is_greatest_union_iff :
+  is_greatest (s ∪ t) a ↔ (is_greatest s a ∧ a ∈ upper_bounds t ∨
+    a ∈ upper_bounds s ∧ is_greatest t a) :=
+@is_least_union_iff (order_dual α) _ a s t
+
+/-- If `s` is bounded, then so is `s ∩ t` -/
+lemma bdd_above.inter_of_left (h : bdd_above s) : bdd_above (s ∩ t) :=
+h.mono $ inter_subset_left s t
+
+/-- If `t` is bounded, then so is `s ∩ t` -/
+lemma bdd_above.inter_of_right (h : bdd_above t) : bdd_above (s ∩ t) :=
+h.mono $ inter_subset_right s t
+
+/-- If `s` is bounded, then so is `s ∩ t` -/
+lemma bdd_below.inter_of_left (h : bdd_below s) : bdd_below (s ∩ t) :=
+h.mono $ inter_subset_left s t
+
+/-- If `t` is bounded, then so is `s ∩ t` -/
+lemma bdd_below.inter_of_right (h : bdd_below t) : bdd_below (s ∩ t) :=
+h.mono $ inter_subset_right s t
+
+/-- If `s` and `t` are bounded above sets in a `semilattice_sup`, then so is `s ∪ t`. -/
+lemma bdd_above.union [semilattice_sup γ] {s t : set γ} :
+  bdd_above s → bdd_above t → bdd_above (s ∪ t) :=
+begin
+  rintros ⟨bs, hs⟩ ⟨bt, ht⟩,
+  use bs ⊔ bt,
+  rw upper_bounds_union,
+  exact ⟨upper_bounds_mono_mem le_sup_left hs,
+    upper_bounds_mono_mem le_sup_right ht⟩
+end
+
+/-- The union of two sets is bounded above if and only if each of the sets is. -/
+lemma bdd_above_union [semilattice_sup γ] {s t : set γ} :
+  bdd_above (s ∪ t) ↔ bdd_above s ∧ bdd_above t :=
+⟨λ h, ⟨h.mono $ subset_union_left s t, h.mono $ subset_union_right s t⟩,
+  λ h, h.1.union h.2⟩
+
+lemma bdd_below.union [semilattice_inf γ] {s t : set γ} :
+  bdd_below s → bdd_below t → bdd_below (s ∪ t) :=
+@bdd_above.union (order_dual γ) _ s t
+
+/--The union of two sets is bounded above if and only if each of the sets is.-/
+lemma bdd_below_union [semilattice_inf γ] {s t : set γ} :
+  bdd_below (s ∪ t) ↔ bdd_below s ∧ bdd_below t :=
+@bdd_above_union (order_dual γ) _ s t
+
+/-- If `a` is the least upper boundary of `s` and `b` is the least upper boundary of `t`,
+then `a ⊔ b` is the least upper boundary of `s ∪ t`. -/
+lemma is_lub.union [semilattice_sup γ] {a b : γ} {s t : set γ}
+  (hs : is_lub s a) (ht : is_lub t b) :
+  is_lub (s ∪ t) (a ⊔ b) :=
 ⟨assume c h, h.cases_on (λ h, le_sup_left_of_le $ hs.left h) (λ h, le_sup_right_of_le $ ht.left h),
   assume c hc, sup_le
     (hs.right $ assume d hd, hc $ or.inl hd) (ht.right $ assume d hd, hc $ or.inr hd)⟩
 
-lemma is_glb_union_inf [semilattice_inf α] (hs : is_glb s a₁) (ht : is_glb t a₂) :
+/-- If `a` is the greatest lower boundary of `s` and `b` is the greatest lower boundary of `t`,
+then `a ⊓ b` is the greatest lower boundary of `s ∪ t`. -/
+lemma is_glb.union [semilattice_inf γ] {a₁ a₂ : γ} {s t : set γ}
+  (hs : is_glb s a₁) (ht : is_glb t a₂) :
   is_glb (s ∪ t) (a₁ ⊓ a₂) :=
-⟨assume c h, h.cases_on (λ h, inf_le_left_of_le $ hs.left h) (λ h, inf_le_right_of_le $ ht.left h),
-  assume c hc, le_inf
-    (hs.right $ assume d hd, hc $ or.inl hd) (ht.right $ assume d hd, hc $ or.inr hd)⟩
+@is_lub.union (order_dual γ) _ _ _ _ _ hs ht
 
-lemma is_lub_insert_sup [semilattice_sup α] (h : is_lub s a₁) : is_lub (insert a₂ s) (a₂ ⊔ a₁) :=
-by rw [insert_eq]; exact is_lub_union_sup is_lub_singleton h
+/-- If `a` is the least element of `s` and `b` is the least element of `t`,
+then `min a b` is the least element of `s ∪ t`. -/
+lemma is_least.union [decidable_linear_order γ] {a b : γ} {s t : set γ}
+  (ha : is_least s a) (hb : is_least t b) : is_least (s ∪ t) (min a b) :=
+⟨by cases (le_total a b) with h h; simp [h, ha.1, hb.1],
+  (ha.is_glb.union hb.is_glb).1⟩
 
-lemma is_lub_iff_sup_eq [semilattice_sup α] : is_lub {a₁, a₂} a ↔ a₂ ⊔ a₁ = a :=
-is_lub_iff_eq_of_is_lub $ is_lub_insert_sup $ is_lub_singleton
+/-- If `a` is the greatest element of `s` and `b` is the greatest element of `t`,
+then `max a b` is the greatest element of `s ∪ t`. -/
+lemma is_greatest.union [decidable_linear_order γ] {a b : γ} {s t : set γ}
+  (ha : is_greatest s a) (hb : is_greatest t b) : is_greatest (s ∪ t) (max a b) :=
+⟨by cases (le_total a b) with h h; simp [h, ha.1, hb.1],
+  (ha.is_lub.union hb.is_lub).1⟩
 
-lemma is_glb_insert_inf [semilattice_inf α] (h : is_glb s a₁) : is_glb (insert a₂ s) (a₂ ⊓ a₁) :=
-by rw [insert_eq]; exact is_glb_union_inf is_glb_singleton h
+/-!
+### Specific sets
 
-lemma is_glb_iff_inf_eq [semilattice_inf α] : is_glb {a₁, a₂} a ↔ a₂ ⊓ a₁ = a :=
-is_glb_iff_eq_of_is_glb $ is_glb_insert_inf $ is_glb_singleton
+#### Unbounded intervals
+-/
 
-end lattice
 
-section linear_order
-variables [linear_order α]
+lemma is_least_Ici : is_least (Ici a) a := ⟨left_mem_Ici, λ x, id⟩
 
-lemma lt_is_lub_iff (h : is_lub s a₁) : a₂ < a₁ ↔ ∃ a ∈ s, a₂ < a :=
-by haveI := classical.dec;
-   simpa [upper_bounds, not_ball] using
-   not_congr (@is_lub_le_iff _ _ a₂ _ _ h)
+lemma is_greatest_Iic : is_greatest (Iic a) a := ⟨right_mem_Iic, λ x, id⟩
 
-lemma is_glb_lt_iff (h : is_glb s a₁) : a₁ < a₂ ↔ ∃ a ∈ s, a < a₂ :=
-by haveI := classical.dec;
-   simpa [lower_bounds, not_ball] using
-   not_congr (@le_is_glb_iff _ _ a₂ _ _ h)
+lemma is_lub_Iic : is_lub (Iic a) a := is_greatest_Iic.is_lub
 
-variables [densely_ordered α]
+lemma is_glb_Ici : is_glb (Ici a) a := is_least_Ici.is_glb
 
-lemma is_glb_Ioi : is_glb (Ioi a) a :=
-begin
-  refine ⟨λx hx, le_of_lt hx, λy hy, _⟩,
-  cases le_or_lt y a with h h, { exact h },
-  rcases dense h with ⟨z, az, zy⟩,
-  exact absurd zy (not_lt_of_le (hy az))
+lemma upper_bounds_Iic : upper_bounds (Iic a) = Ici a := is_lub_Iic.upper_bounds_eq
+
+lemma lower_bounds_Ici : lower_bounds (Ici a) = Iic a := is_glb_Ici.lower_bounds_eq
+
+lemma bdd_above_Iic : bdd_above (Iic a) := is_lub_Iic.bdd_above
+
+lemma bdd_below_Ici : bdd_below (Ici a) := is_glb_Ici.bdd_below
+
+lemma bdd_above_Iio : bdd_above (Iio a) := ⟨a, λ x hx, le_of_lt hx⟩
+
+lemma bdd_below_Ioi : bdd_below (Ioi a) := ⟨a, λ x hx, le_of_lt hx⟩
+
+section
+
+variables [linear_order γ] [densely_ordered γ]
+
+lemma is_lub_Iio {a : γ} : is_lub (Iio a) a :=
+⟨λ x hx, le_of_lt hx, λ y hy, le_of_forall_ge_of_dense hy⟩
+
+lemma is_glb_Ioi {a : γ} : is_glb (Ioi a) a := @is_lub_Iio (order_dual γ) _ _ a
+
+lemma upper_bounds_Iio {a : γ} : upper_bounds (Iio a) = Ici a := is_lub_Iio.upper_bounds_eq
+
+lemma lower_bounds_Ioi {a : γ} : lower_bounds (Ioi a) = Iic a := is_glb_Ioi.lower_bounds_eq
+
 end
 
-lemma is_lub_Iio : is_lub (Iio a) a :=
-begin
-  refine ⟨λx hx, le_of_lt hx, λy hy, _⟩,
-  classical; by_contradiction h,
-  rcases dense (not_le.1 h) with ⟨z, az, zy⟩,
-  exact lt_irrefl _ (lt_of_lt_of_le az (hy zy)),
-end
+/-!
+#### Singleton
+-/
 
-local attribute [instance] classical.DLO
+lemma is_greatest_singleton : is_greatest {a} a :=
+⟨mem_singleton a, λ x hx, le_of_eq $ eq_of_mem_singleton hx⟩
 
-lemma is_glb_Ioo (hab : a₁ < a₂) : is_glb (Ioo a₁ a₂) a₁ :=
+lemma is_least_singleton : is_least {a} a :=
+@is_greatest_singleton (order_dual α) _ a
+
+lemma is_lub_singleton : is_lub {a} a := is_greatest_singleton.is_lub
+
+lemma is_glb_singleton : is_glb {a} a := is_least_singleton.is_glb
+
+lemma bdd_above_singleton : bdd_above ({a} : set α) := is_lub_singleton.bdd_above
+
+lemma bdd_below_singleton : bdd_below ({a} : set α) := is_glb_singleton.bdd_below
+
+lemma upper_bounds_singleton : upper_bounds {a} = Ici a := is_lub_singleton.upper_bounds_eq
+
+lemma lower_bounds_singleton : lower_bounds {a} = Iic a := is_glb_singleton.lower_bounds_eq
+
+/-!
+#### Bounded intervals
+-/
+
+lemma bdd_above_Icc : bdd_above (Icc a b) := ⟨b, λ _, and.right⟩
+
+lemma bdd_above_Ico : bdd_above (Ico a b) := bdd_above_Icc.mono Ico_subset_Icc_self
+
+lemma bdd_above_Ioc : bdd_above (Ioc a b) := bdd_above_Icc.mono Ioc_subset_Icc_self
+
+lemma bdd_above_Ioo : bdd_above (Ioo a b) := bdd_above_Icc.mono Ioo_subset_Icc_self
+
+lemma is_greatest_Icc (h : a ≤ b) : is_greatest (Icc a b) b :=
+⟨right_mem_Icc.2 h, λ x, and.right⟩
+
+lemma is_lub_Icc (h : a ≤ b) : is_lub (Icc a b) b := (is_greatest_Icc h).is_lub
+
+lemma upper_bounds_Icc (h : a ≤ b) : upper_bounds (Icc a b) = Ici b :=
+(is_lub_Icc h).upper_bounds_eq
+
+lemma is_least_Icc (h : a ≤ b) : is_least (Icc a b) a :=
+⟨left_mem_Icc.2 h, λ x, and.left⟩
+
+lemma is_glb_Icc (h : a ≤ b) : is_glb (Icc a b) a := (is_least_Icc h).is_glb
+
+lemma lower_bounds_Icc (h : a ≤ b) : lower_bounds (Icc a b) = Iic a :=
+(is_glb_Icc h).lower_bounds_eq
+
+lemma is_greatest_Ioc (h : a < b) : is_greatest (Ioc a b) b :=
+⟨right_mem_Ioc.2 h, λ x, and.right⟩
+
+lemma is_lub_Ioc (h : a < b) : is_lub (Ioc a b) b :=
+(is_greatest_Ioc h).is_lub
+
+lemma upper_bounds_Ioc (h : a < b) : upper_bounds (Ioc a b) = Ici b :=
+(is_lub_Ioc h).upper_bounds_eq
+
+lemma is_least_Ico (h : a < b) : is_least (Ico a b) a :=
+⟨left_mem_Ico.2 h, λ x, and.left⟩
+
+lemma is_glb_Ico (h : a < b) : is_glb (Ico a b) a :=
+(is_least_Ico h).is_glb
+
+lemma lower_bounds_Ico (h : a < b) : lower_bounds (Ico a b) = Iic a :=
+(is_glb_Ico h).lower_bounds_eq
+
+section
+
+variables [linear_order γ] [densely_ordered γ]
+
+lemma is_glb_Ioo {a b : γ} (hab : a < b) : is_glb (Ioo a b) a :=
 begin
   refine ⟨λx hx, le_of_lt hx.1, λy hy, le_of_not_lt $ λ h, _⟩,
-  have : a₁ < min a₂ y, by { rw lt_min_iff, exact ⟨hab, h⟩ },
+  letI := classical.DLO γ,
+  have : a < min b y, by { rw lt_min_iff, exact ⟨hab, h⟩ },
   rcases dense this with ⟨z, az, zy⟩,
   rw lt_min_iff at zy,
   exact lt_irrefl _ (lt_of_le_of_lt (hy ⟨az, zy.1⟩) zy.2)
 end
 
-lemma is_glb_Ioc (hab : a₁ < a₂) : is_glb (Ioc a₁ a₂) a₁ :=
-begin
-  refine ⟨λx hx, le_of_lt hx.1, λy hy, le_of_not_lt $ λ h, _⟩,
-  have : a₁ < min a₂ y, by { rw lt_min_iff, exact ⟨hab, h⟩ },
-  rcases dense this with ⟨z, az, zy⟩,
-  rw lt_min_iff at zy,
-  exact lt_irrefl _ (lt_of_le_of_lt (hy ⟨az, le_of_lt zy.1⟩) zy.2)
+lemma lower_bounds_Ioo {a b : γ} (hab : a < b) : lower_bounds (Ioo a b) = Iic a :=
+(is_glb_Ioo hab).lower_bounds_eq
+
+lemma is_glb_Ioc {a b : γ} (hab : a < b) : is_glb (Ioc a b) a :=
+(is_glb_Ioo hab).squeeze (is_glb_Icc $ le_of_lt hab) Ioo_subset_Ioc_self Ioc_subset_Icc_self
+
+lemma lower_bound_Ioc {a b : γ} (hab : a < b) : lower_bounds (Ioc a b) = Iic a :=
+(is_glb_Ioc hab).lower_bounds_eq
+
+lemma is_lub_Ioo {a b : γ} (hab : a < b) : is_lub (Ioo a b) b :=
+by simpa only [dual_Ioo] using @is_glb_Ioo (order_dual γ) _ _ b a hab
+
+lemma upper_bounds_Ioo {a b : γ} (hab : a < b) : upper_bounds (Ioo a b) = Ici b :=
+(is_lub_Ioo hab).upper_bounds_eq
+
+lemma is_lub_Ico {a b : γ} (hab : a < b) : is_lub (Ico a b) b :=
+by simpa only [dual_Ioc] using @is_glb_Ioc (order_dual γ) _ _ b a hab
+
+lemma upper_bounds_Ico {a b : γ} (hab : a < b) : upper_bounds (Ico a b) = Ici b :=
+(is_lub_Ico hab).upper_bounds_eq
+
 end
 
-lemma is_lub_Ioo (hab : a₁ < a₂) : is_lub (Ioo a₁ a₂) a₂ :=
-begin
-  refine ⟨λx hx, le_of_lt hx.2, λy hy, le_of_not_lt $ λ h, _⟩,
-  have : max a₁ y < a₂, by { rw max_lt_iff, exact ⟨hab, h⟩ },
-  rcases dense this with ⟨z, az, zy⟩,
-  rw max_lt_iff at az,
-  exact lt_irrefl _ (lt_of_lt_of_le az.2 (hy ⟨az.1, zy⟩))
+lemma bdd_below_iff_subset_Ici : bdd_below s ↔ ∃ a, s ⊆ Ici a := iff.rfl
+
+lemma bdd_above_iff_subset_Iic : bdd_above s ↔ ∃ a, s ⊆ Iic a := iff.rfl
+
+lemma bdd_below_bdd_above_iff_subset_Icc : bdd_below s ∧ bdd_above s ↔ ∃ a b, s ⊆ Icc a b :=
+by simp only [Ici_inter_Iic.symm, subset_inter_iff, bdd_below_iff_subset_Ici,
+  bdd_above_iff_subset_Iic, exists_and_distrib_left, exists_and_distrib_right]
+
+/-!
+### Univ
+-/
+
+lemma order_top.upper_bounds_univ [order_top γ] : upper_bounds (univ : set γ) = {⊤} :=
+set.ext $ λ b, iff.trans ⟨λ hb, top_unique $ hb trivial, λ hb x hx, hb.symm ▸ le_top⟩
+  mem_singleton_iff.symm
+
+lemma is_greatest_univ [order_top γ] : is_greatest (univ : set γ) ⊤ :=
+by simp only [is_greatest, order_top.upper_bounds_univ, mem_univ, mem_singleton, true_and]
+
+lemma is_lub_univ [order_top γ] : is_lub (univ : set γ) ⊤ :=
+is_greatest_univ.is_lub
+
+lemma order_bot.lower_bounds_univ [order_bot γ] : lower_bounds (univ : set γ) = {⊥} :=
+@order_top.upper_bounds_univ (order_dual γ) _
+
+lemma is_least_univ [order_bot γ] : is_least (univ : set γ) ⊥ :=
+@is_greatest_univ (order_dual γ) _
+
+lemma is_glb_univ [order_bot γ] : is_glb (univ : set γ) ⊥ :=
+is_least_univ.is_glb
+
+lemma no_top_order.upper_bounds_univ [no_top_order α] : upper_bounds (univ : set α) = ∅ :=
+eq_empty_of_subset_empty $ λ b hb, let ⟨x, hx⟩ := no_top b in
+not_le_of_lt hx (hb trivial)
+
+lemma no_bot_order.lower_bounds_univ [no_bot_order α] : lower_bounds (univ : set α) = ∅ :=
+@no_top_order.upper_bounds_univ (order_dual α) _ _
+
+/-!
+### Empty set
+-/
+
+@[simp] lemma upper_bounds_empty : upper_bounds (∅ : set α) = univ :=
+by simp only [upper_bounds, eq_univ_iff_forall, mem_set_of_eq, ball_empty_iff, forall_true_iff]
+
+@[simp] lemma lower_bounds_empty : lower_bounds (∅ : set α) = univ :=
+by simp only [lower_bounds, eq_univ_iff_forall, mem_set_of_eq, ball_empty_iff, forall_true_iff]
+
+@[simp] lemma bdd_above_empty [nonempty α] : bdd_above (∅ : set α) :=
+by simp only [bdd_above, upper_bounds_empty, univ_nonempty]
+
+@[simp] lemma bdd_below_empty [nonempty α] : bdd_below (∅ : set α) :=
+by simp only [bdd_below, lower_bounds_empty, univ_nonempty]
+
+lemma is_glb_empty [order_top γ] : is_glb ∅ (⊤:γ) :=
+by simp only [is_glb, lower_bounds_empty, is_greatest_univ]
+
+lemma is_lub_empty [order_bot γ] : is_lub ∅ (⊥:γ) :=
+@is_glb_empty (order_dual γ) _
+
+lemma is_lub.nonempty [no_bot_order α] (hs : is_lub s a) : s.nonempty :=
+let ⟨a', ha'⟩ := no_bot a in
+ne_empty_iff_nonempty.1 $ assume h,
+have a ≤ a', from hs.right $ by simp only [h, upper_bounds_empty],
+not_le_of_lt ha' this
+
+lemma is_glb.nonempty [no_top_order α] (hs : is_glb s a) : s.nonempty :=
+@is_lub.nonempty (order_dual α) _ _ _ _ hs
+
+/-!
+### insert
+-/
+
+/-- Adding a point to a set preserves its boundedness above. -/
+@[simp] lemma bdd_above_insert [semilattice_sup γ] (a : γ) {s : set γ} :
+  bdd_above (insert a s) ↔ bdd_above s :=
+by simp only [insert_eq, bdd_above_union, bdd_above_singleton, true_and]
+
+lemma bdd_above.insert [semilattice_sup γ] (a : γ) {s : set γ} (hs : bdd_above s) :
+  bdd_above (insert a s) :=
+(bdd_above_insert a).2 hs
+
+/--Adding a point to a set preserves its boundedness below.-/
+@[simp] lemma bdd_below_insert [semilattice_inf γ] (a : γ) {s : set γ} :
+  bdd_below (insert a s) ↔ bdd_below s :=
+by simp only [insert_eq, bdd_below_union, bdd_below_singleton, true_and]
+
+lemma bdd_below.insert [semilattice_inf γ] (a : γ) {s : set γ} (hs : bdd_below s) :
+  bdd_below (insert a s) :=
+(bdd_below_insert a).2 hs
+
+lemma is_lub.insert [semilattice_sup γ] (a) {b} {s : set γ} (hs : is_lub s b) :
+  is_lub (insert a s) (a ⊔ b) :=
+by { rw insert_eq, exact is_lub_singleton.union hs }
+
+lemma is_glb.insert [semilattice_inf γ] (a) {b} {s : set γ} (hs : is_glb s b) :
+  is_glb (insert a s) (a ⊓ b) :=
+by { rw insert_eq, exact is_glb_singleton.union hs }
+
+lemma is_greatest.insert [decidable_linear_order γ] (a) {b} {s : set γ} (hs : is_greatest s b) :
+  is_greatest (insert a s) (max a b) :=
+by { rw insert_eq, exact is_greatest_singleton.union hs }
+
+lemma is_least.insert [decidable_linear_order γ] (a) {b} {s : set γ} (hs : is_least s b) :
+  is_least (insert a s) (min a b) :=
+by { rw insert_eq, exact is_least_singleton.union hs }
+
+lemma upper_bounds_insert (a : α) (s : set α) :
+  upper_bounds (insert a s) = Ici a ∩ upper_bounds s :=
+by rw [insert_eq, upper_bounds_union, upper_bounds_singleton]
+
+lemma lower_bounds_insert (a : α) (s : set α) :
+  lower_bounds (insert a s) = Iic a ∩ lower_bounds s :=
+by rw [insert_eq, lower_bounds_union, lower_bounds_singleton]
+
+/-- When there is a global maximum, every set is bounded above. -/
+@[simp] lemma bdd_above_top [order_top γ] (s : set γ) : bdd_above s :=
+⟨⊤, assume a ha, order_top.le_top a⟩
+
+/-- When there is a global minimum, every set is bounded below. -/
+@[simp] lemma bdd_below_bot [order_bot γ] (s : set γ) : bdd_below s :=
+⟨⊥, assume a ha, order_bot.bot_le a⟩
+
+/-!
+### Pair
+-/
+
+lemma is_lub_pair [semilattice_sup γ] {a b : γ} : is_lub {a, b} (a ⊔ b) :=
+by { rw sup_comm, exact is_lub_singleton.insert _}
+
+lemma is_glb_pair [semilattice_inf γ] {a b : γ} : is_glb {a, b} (a ⊓ b) :=
+by { rw inf_comm, exact is_glb_singleton.insert _ }
+
+lemma is_least_pair [decidable_linear_order γ] {a b : γ} : is_least {a, b} (min a b) :=
+by { rw min_comm, exact is_least_singleton.insert _ }
+
+lemma is_greatest_pair [decidable_linear_order γ] {a b : γ} : is_greatest {a, b} (max a b) :=
+by { rw max_comm, exact is_greatest_singleton.insert _ }
+
 end
 
-lemma is_lub_Ico (hab : a₁ < a₂) : is_lub (Ico a₁ a₂) a₂ :=
-begin
-  refine ⟨λx hx, le_of_lt hx.2, λy hy, le_of_not_lt $ λ h, _⟩,
-  have : max a₁ y < a₂, by { rw max_lt_iff, exact ⟨hab, h⟩ },
-  rcases dense this with ⟨z, az, zy⟩,
-  rw max_lt_iff at az,
-  exact lt_irrefl _ (lt_of_lt_of_le az.2 (hy ⟨le_of_lt az.1, zy⟩))
-end
-
-end linear_order
+/-!
+### (In)equalities with the least upper bound and the greatest lower bound
+-/
 
 section preorder
-variables [preorder α] [preorder β]
+variables [preorder α] {s : set α} {a b : α}
 
-/-- A set is bounded above if there exists an upper bound. -/
-def bdd_above (s : set α) := ∃x, x ∈ upper_bounds s
+lemma lower_bounds_le_upper_bounds (ha : a ∈ lower_bounds s) (hb : b ∈ upper_bounds s) :
+  s.nonempty → a ≤ b
+| ⟨c, hc⟩ := le_trans (ha hc) (hb hc)
 
-/-- A set is bounded below if there exists a lower bound. -/
-def bdd_below (s : set α) := ∃x, x ∈ lower_bounds s
+lemma is_glb_le_is_lub (ha : is_glb s a) (hb : is_lub s b) (hs : s.nonempty) : a ≤ b :=
+lower_bounds_le_upper_bounds ha.1 hb.1 hs
 
-/-Introduction rules for boundedness above and below.
-Most of the time, it is more efficient to use ⟨w, P⟩ where P is a proof
-that all elements of the set are bounded by w. However, they are sometimes handy.-/
-lemma bdd_above.mk (a : α) (H : a ∈ upper_bounds s) : bdd_above s := ⟨a, H⟩
-lemma bdd_below.mk (a : α) (H : a ∈ lower_bounds s) : bdd_below s := ⟨a, H⟩
+lemma is_lub_lt_iff (ha : is_lub s a) : a < b ↔ ∃ c ∈ upper_bounds s, c < b :=
+⟨λ hb, ⟨a, ha.1, hb⟩, λ ⟨c, hcs, hcb⟩, lt_of_le_of_lt (ha.2 hcs) hcb⟩
 
-/-Empty sets and singletons are trivially bounded. For finite sets, we need
-a notion of maximum and minimum, i.e., a lattice structure, see later on.-/
-@[simp] lemma bdd_above_empty : ∀ [nonempty α], bdd_above (∅ : set α)
-| ⟨x⟩ := ⟨x, by simp [upper_bounds]⟩
-
-@[simp] lemma bdd_below_empty : ∀ [nonempty α], bdd_below (∅ : set α)
-| ⟨x⟩ := ⟨x, by simp [lower_bounds]⟩
-
-@[simp] lemma bdd_above_singleton : bdd_above ({a} : set α) :=
-⟨a, by simp only [upper_bounds, set.mem_set_of_eq, set.mem_singleton_iff, forall_eq]⟩
-
-@[simp] lemma bdd_below_singleton : bdd_below ({a} : set α) :=
-⟨a, by simp only [lower_bounds, set.mem_set_of_eq, set.mem_singleton_iff, forall_eq]⟩
-
-/-If a set is included in another one, boundedness of the second implies boundedness
-of the first-/
-lemma bdd_above_subset (st : s ⊆ t) : bdd_above t → bdd_above s
-| ⟨w, hw⟩ := ⟨w, λ y ys, hw (st ys)⟩
-
-lemma bdd_below_subset (st : s ⊆ t) : bdd_below t → bdd_below s
-| ⟨w, hw⟩ := ⟨w, λ y ys, hw (st ys)⟩
-
-/- Boundedness of intersections of sets, in different guises, deduced from the
-monotonicity of boundedness.-/
-lemma bdd_above_inter_left : bdd_above s → bdd_above (s ∩ t) :=
-bdd_above_subset (set.inter_subset_left _ _)
-
-lemma bdd_above_inter_right : bdd_above t → bdd_above (s ∩ t) :=
-bdd_above_subset (set.inter_subset_right _ _)
-
-lemma bdd_below_inter_left : bdd_below s → bdd_below (s ∩ t) :=
-bdd_below_subset (set.inter_subset_left _ _)
-
-lemma bdd_below_inter_right : bdd_below t → bdd_below (s ∩ t) :=
-bdd_below_subset (set.inter_subset_right _ _)
-
-/--The image under a monotone function of a set which is bounded above is bounded above-/
-lemma bdd_above_of_bdd_above_of_monotone {f : α → β} (hf : monotone f) : bdd_above s → bdd_above (f '' s)
-| ⟨C, hC⟩ := ⟨f C, by rintro y ⟨x, x_bnd, rfl⟩; exact hf (hC x_bnd)⟩
-
-/--The image under a monotone function of a set which is bounded below is bounded below-/
-lemma bdd_below_of_bdd_below_of_monotone {f : α → β} (hf : monotone f) : bdd_below s → bdd_below (f '' s)
-| ⟨C, hC⟩ := ⟨f C, by rintro y ⟨x, x_bnd, rfl⟩; exact hf (hC x_bnd)⟩
-
-lemma bdd_below_iff_subset_Ici (s : set α) : bdd_below s ↔ ∃ a, s ⊆ Ici a := iff.rfl
-
-lemma bdd_above_iff_subset_Iic (s : set α) : bdd_above s ↔ ∃ a, s ⊆ Iic a := iff.rfl
-
-lemma bdd_below_bdd_above_iff_subset_Icc (s : set α) :
-  bdd_below s ∧ bdd_above s ↔ ∃ a b, s ⊆ Icc a b :=
-by simp [Ici_inter_Iic.symm, subset_inter_iff, bdd_below_iff_subset_Ici, bdd_above_iff_subset_Iic]
+lemma lt_is_glb_iff (ha : is_glb s a) : b < a ↔ ∃ c ∈ lower_bounds s, b < c :=
+@is_lub_lt_iff (order_dual α) _ s _ _ ha
 
 end preorder
 
-/--When there is a global maximum, every set is bounded above.-/
-@[simp] lemma bdd_above_top [order_top α] (s : set α) : bdd_above s :=
-⟨⊤, assume a ha, order_top.le_top a⟩
+section partial_order
+variables [partial_order α] {s : set α} {a b : α}
 
-/--When there is a global minimum, every set is bounded below.-/
-@[simp] lemma bdd_below_bot [order_bot α] (s : set α) : bdd_below s :=
-⟨⊥, assume a ha, order_bot.bot_le a⟩
+lemma is_least.unique (Ha : is_least s a) (Hb : is_least s b) : a = b :=
+le_antisymm (Ha.right Hb.left) (Hb.right Ha.left)
 
-/-When there is a max (i.e., in the class semilattice_sup), then the union of
-two bounded sets is bounded, by the maximum of the bounds for the two sets.
-With this, we deduce that finite sets are bounded by induction, and that a finite
-union of bounded sets is bounded.-/
-section semilattice_sup
-variables [semilattice_sup α]
+lemma is_least.is_least_iff_eq (Ha : is_least s a) : is_least s b ↔ a = b :=
+iff.intro Ha.unique (assume h, h ▸ Ha)
 
-/--The union of two sets is bounded above if and only if each of the sets is.-/
-@[simp] lemma bdd_above_union : bdd_above (s ∪ t) ↔ bdd_above s ∧ bdd_above t :=
-⟨show bdd_above (s ∪ t) → (bdd_above s ∧ bdd_above t), from
-  assume : bdd_above (s ∪ t),
-  have S : bdd_above s, by apply bdd_above_subset _ ‹bdd_above (s ∪ t)›; simp only [set.subset_union_left],
-  have T : bdd_above t, by apply bdd_above_subset _ ‹bdd_above (s ∪ t)›; simp only [set.subset_union_right],
-  and.intro S T,
-show (bdd_above s ∧ bdd_above t) → bdd_above (s ∪ t), from
-  assume H : bdd_above s ∧ bdd_above t,
-  let ⟨⟨ws, hs⟩, ⟨wt, ht⟩⟩ := H in
-    /-hs : ∀ (y : α), y ∈ s → y ≤ ws      ht : ∀ (y : α), y ∈ s → y ≤ wt-/
-  have Bs : ∀b∈s, b ≤ ws ⊔ wt,
-    by intros; apply le_trans (hs ‹b ∈ s›) _; simp only [lattice.le_sup_left],
-  have Bt : ∀b∈t, b ≤ ws ⊔ wt,
-    by intros; apply le_trans (ht ‹b ∈ t›) _; simp only [lattice.le_sup_right],
-  show bdd_above (s ∪ t),
-    begin
-    apply bdd_above.mk (ws ⊔ wt),
-    intros b H_1,
-    cases H_1,
-    apply Bs _ ‹b ∈ s›,
-    apply Bt _ ‹b ∈ t›,
-    end⟩
+lemma is_greatest.unique (Ha : is_greatest s a) (Hb : is_greatest s b) : a = b :=
+le_antisymm (Hb.right Ha.left) (Ha.right Hb.left)
 
-/--Adding a point to a set preserves its boundedness above.-/
-@[simp] lemma bdd_above_insert : bdd_above (insert a s) ↔ bdd_above s :=
-⟨bdd_above_subset (by simp only [set.subset_insert]),
- λ h, by rw [insert_eq, bdd_above_union]; exact ⟨bdd_above_singleton, h⟩⟩
+lemma is_greatest.is_greatest_iff_eq (Ha : is_greatest s a) : is_greatest s b ↔ a = b :=
+iff.intro Ha.unique (assume h, h ▸ Ha)
 
-end semilattice_sup
+lemma is_lub.unique (Ha : is_lub s a) (Hb : is_lub s b) : a = b :=
+Ha.unique Hb
 
+lemma is_glb.unique (Ha : is_glb s a) (Hb : is_glb s b) : a = b :=
+Ha.unique Hb
 
-/-When there is a min (i.e., in the class semilattice_inf), then the union of
-two sets which are bounded from below is bounded from below, by the minimum of
-the bounds for the two sets. With this, we deduce that finite sets are
-bounded below by induction, and that a finite union of sets which are bounded below
-is still bounded below.-/
+lemma is_lub_le_iff (h : is_lub s a) : a ≤ b ↔ b ∈ upper_bounds s :=
+by { rw h.upper_bounds_eq, refl }
 
-section semilattice_inf
-variables [semilattice_inf α]
+lemma le_is_glb_iff (h : is_glb s a) : b ≤ a ↔ b ∈ lower_bounds s :=
+by { rw h.lower_bounds_eq, refl }
 
-/--The union of two sets is bounded below if and only if each of the sets is.-/
-@[simp] lemma bdd_below_union : bdd_below (s ∪ t) ↔ bdd_below s ∧ bdd_below t :=
-⟨show bdd_below (s ∪ t) → (bdd_below s ∧ bdd_below t), from
-  assume : bdd_below (s ∪ t),
-  have S : bdd_below s, by apply bdd_below_subset _ ‹bdd_below (s ∪ t)›; simp only [set.subset_union_left],
-  have T : bdd_below t, by apply bdd_below_subset _ ‹bdd_below (s ∪ t)›; simp only [set.subset_union_right],
-  and.intro S T,
-show (bdd_below s ∧ bdd_below t) → bdd_below (s ∪ t), from
-  assume H : bdd_below s ∧ bdd_below t,
-  let ⟨⟨ws, hs⟩, ⟨wt, ht⟩⟩ := H in
-    /-hs : ∀ (y : α), y ∈ s → ws ≤ y      ht : ∀ (y : α), y ∈ s → wt ≤ y-/
-  have Bs : ∀b∈s, ws ⊓ wt ≤ b,
-    by intros; apply le_trans _ (hs ‹b ∈ s›); simp only [lattice.inf_le_left],
-  have Bt : ∀b∈t, ws ⊓ wt ≤ b,
-    by intros; apply le_trans _ (ht ‹b ∈ t›); simp only [lattice.inf_le_right],
-  show bdd_below (s ∪ t),
-    begin
-    apply bdd_below.mk (ws ⊓ wt),
-    intros b H_1,
-    cases H_1,
-    apply Bs _ ‹b ∈ s›,
-    apply Bt _ ‹b ∈ t›,
-    end⟩
+end partial_order
 
-/--Adding a point to a set preserves its boundedness below.-/
-@[simp] lemma bdd_below_insert : bdd_below (insert a s) ↔ bdd_below s :=
-⟨show bdd_below (insert a s) → bdd_below s, from bdd_below_subset (by simp only [set.subset_insert]),
- show bdd_below s → bdd_below (insert a s),
-   by rw[insert_eq]; simp only [bdd_below_singleton, bdd_below_union, and_self, forall_true_iff] {contextual := tt}⟩
+section linear_order
+variables [linear_order α] {s : set α} {a b : α}
 
-end semilattice_inf
+lemma lt_is_lub_iff (h : is_lub s a) : b < a ↔ ∃ c ∈ s, b < c :=
+by haveI := classical.dec;
+   simpa [upper_bounds, not_ball] using
+   not_congr (@is_lub_le_iff _ _ _ _ b h)
+
+lemma is_glb_lt_iff (h : is_glb s a) : a < b ↔ ∃ c ∈ s, c < b :=
+@lt_is_lub_iff (order_dual α) _ _ _ _ h
+
+end linear_order
+
+section image
+
+variables [preorder α] [preorder β] {f : α → β} (Hf : monotone f) {a : α} {s : set α}
+
+lemma monotone.mem_upper_bounds_image (Ha : a ∈ upper_bounds s) :
+  f a ∈ upper_bounds (f '' s) :=
+ball_image_of_ball (assume x H, Hf (Ha ‹x ∈ s›))
+
+lemma monotone.mem_lower_bounds_image (Ha : a ∈ lower_bounds s) :
+  f a ∈ lower_bounds (f '' s) :=
+ball_image_of_ball (assume x H, Hf (Ha ‹x ∈ s›))
+
+/--The image under a monotone function of a set which is bounded above is bounded above-/
+lemma monotone.map_bdd_above (hf : monotone f) : bdd_above s → bdd_above (f '' s)
+| ⟨C, hC⟩ := ⟨f C, hf.mem_upper_bounds_image hC⟩
+
+/--The image under a monotone function of a set which is bounded below is bounded below-/
+lemma monotone.map_bdd_below (hf : monotone f) : bdd_below s → bdd_below (f '' s)
+| ⟨C, hC⟩ := ⟨f C, hf.mem_lower_bounds_image hC⟩
+
+end image

--- a/src/order/bounds.lean
+++ b/src/order/bounds.lean
@@ -87,7 +87,7 @@ nonempty.mono $ upper_bounds_mono_set h
 lemma bdd_below.mono ⦃s t : set α⦄ (h : s ⊆ t) : bdd_below t → bdd_below s :=
 nonempty.mono $ lower_bounds_mono_set h
 
-/-- If `a` is a least upper bound for sets `s` and `p`, the it is a least upper bound for any
+/-- If `a` is a least upper bound for sets `s` and `p`, then it is a least upper bound for any
 set `t`, `s ⊆ t ⊆ p`. -/
 lemma is_lub.of_subset_of_superset {s t p : set α} (hs : is_lub s a) (hp : is_lub p a)
   (hst : s ⊆ t) (htp : t ⊆ p) : is_lub t a :=

--- a/src/order/bounds.lean
+++ b/src/order/bounds.lean
@@ -4,6 +4,23 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Yury Kudryashov
 -/
 import algebra.order_functions data.set.intervals.basic
+/-!
+
+# Upper / lower bounds
+
+In this file we define:
+
+* `upper_bounds`, `lower_bounds` : the set of upper bounds (resp., lower bounds) of a set;
+* `bdd_above s`, `bdd_below s` : the set `s` is bounded above (resp., below), i.e., the set of upper
+  (resp., lower) bounds of `s` is nonempty;
+* `is_least s a`, `is_greatest s a` : `a` is a least (resp., greatest) element of `s`;
+  for a partial order, it is unique if exists;
+* `is_lub s a`, `is_glb s a` : `a` is a least upper boundary (resp., a greatest lower boundary)
+  of `s`; for a partial order, it is unique if exists.
+
+We also prove various lemmas about monotonicity, behaviour under `∪`, `∩`, `insert`, and provide
+formulas for `∅`, `univ`, and intervals.
+-/
 open set lattice
 
 universes u v w x

--- a/src/order/complete_boolean_algebra.lean
+++ b/src/order/complete_boolean_algebra.lean
@@ -92,11 +92,7 @@ end complete_distrib_lattice
 
 @[priority 100] -- see Note [lower instance priority]
 instance [d : complete_distrib_lattice α] : bounded_distrib_lattice α :=
-{ le_sup_inf := assume x y z,
-    calc (x ⊔ y) ⊓ (x ⊔ z) ≤ (⨅ b ∈ ({z, y} : set α), x ⊔ b) :
-        by simp [or_imp_distrib] {contextual := tt}
-      ... = x ⊔ Inf {z, y} : sup_Inf_eq.symm
-      ... = x ⊔ y ⊓ z : by rw insert_of_has_insert; simp,
+{ le_sup_inf := λ x y z, by rw [← Inf_pair, ← Inf_pair, sup_Inf_eq, ← Inf_image, set.image_pair],
   ..d }
 
 section prio

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -60,14 +60,18 @@ theorem le_Inf : (∀b∈s, a ≤ b) → a ≤ Inf s := complete_lattice.le_Inf 
 
 lemma is_lub_Sup (s : set α) : is_lub s (Sup s) := ⟨assume x, le_Sup, assume x, Sup_le⟩
 
+-- Use `private lemma` + `alias` to escape `namespace lattice` without closing it
+
 private lemma is_lub.Sup_eq (h : is_lub s a) : Sup s = a := (is_lub_Sup s).unique h
 
+/-- If `a` is the least upper bound of `s`, then `Sup s = a` -/
 alias is_lub.Sup_eq ← is_lub.Sup_eq
 
 lemma is_glb_Inf (s : set α) : is_glb s (Inf s) := ⟨assume a, Inf_le, assume a, le_Inf⟩
 
 private lemma is_glb.Inf_eq (h : is_glb s a) : Inf s = a := (is_glb_Inf s).unique h
 
+/-- If `a` is the greatest lower bound of `s`, then `Inf s = a` -/
 alias is_glb.Inf_eq ← is_glb.Inf_eq
 
 theorem le_Sup_of_le (hb : b ∈ s) (h : a ≤ b) : a ≤ Sup s :=

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl
 
 Theory of complete lattices.
 -/
-import order.bounded_lattice order.bounds data.set.basic tactic.pi_instances
+import order.bounded_lattice order.bounds data.set.basic tactic.pi_instances tactic.alias
 
 set_option old_structure_cmd true
 open set
@@ -58,13 +58,17 @@ theorem Sup_le : (∀b∈s, b ≤ a) → Sup s ≤ a := complete_lattice.Sup_le 
 
 theorem le_Inf : (∀b∈s, a ≤ b) → a ≤ Inf s := complete_lattice.le_Inf s a
 
-lemma is_lub_Sup : is_lub s (Sup s) := ⟨assume x, le_Sup, assume x, Sup_le⟩
+lemma is_lub_Sup (s : set α) : is_lub s (Sup s) := ⟨assume x, le_Sup, assume x, Sup_le⟩
 
-lemma is_lub_iff_Sup_eq : is_lub s a ↔ Sup s = a := is_lub_iff_eq_of_is_lub is_lub_Sup
+private lemma is_lub.Sup_eq (h : is_lub s a) : Sup s = a := (is_lub_Sup s).unique h
 
-lemma is_glb_Inf : is_glb s (Inf s) := ⟨assume a, Inf_le, assume a, le_Inf⟩
+alias is_lub.Sup_eq ← is_lub.Sup_eq
 
-lemma is_glb_iff_Inf_eq : is_glb s a ↔ Inf s = a := is_glb_iff_eq_of_is_glb is_glb_Inf
+lemma is_glb_Inf (s : set α) : is_glb s (Inf s) := ⟨assume a, Inf_le, assume a, le_Inf⟩
+
+private lemma is_glb.Inf_eq (h : is_glb s a) : Inf s = a := (is_glb_Inf s).unique h
+
+alias is_glb.Inf_eq ← is_glb.Inf_eq
 
 theorem le_Sup_of_le (hb : b ∈ s) (h : a ≤ b) : a ≤ Sup s :=
 le_trans h (le_Sup hb)
@@ -79,31 +83,17 @@ theorem Inf_le_Inf (h : s ⊆ t) : Inf t ≤ Inf s :=
 le_Inf (assume a, assume ha : a ∈ s, Inf_le $ h ha)
 
 @[simp] theorem Sup_le_iff : Sup s ≤ a ↔ (∀b ∈ s, b ≤ a) :=
-⟨assume : Sup s ≤ a, assume b, assume : b ∈ s,
-  le_trans (le_Sup ‹b ∈ s›) ‹Sup s ≤ a›,
-  Sup_le⟩
+is_lub_le_iff (is_lub_Sup s)
 
 @[simp] theorem le_Inf_iff : a ≤ Inf s ↔ (∀b ∈ s, a ≤ b) :=
-⟨assume : a ≤ Inf s, assume b, assume : b ∈ s,
-  le_trans ‹a ≤ Inf s› (Inf_le ‹b ∈ s›),
-  le_Inf⟩
+le_is_glb_iff (is_glb_Inf s)
 
--- how to state this? instead a parameter `a`, use `∃a, a ∈ s` or `s ≠ ∅`?
-theorem Inf_le_Sup (h : a ∈ s) : Inf s ≤ Sup s :=
-by have := le_Sup h; finish
---Inf_le_of_le h (le_Sup h)
+theorem Inf_le_Sup (hs : s.nonempty) : Inf s ≤ Sup s :=
+is_glb_le_is_lub (is_glb_Inf s) (is_lub_Sup s) hs
 
 -- TODO: it is weird that we have to add union_def
 theorem Sup_union {s t : set α} : Sup (s ∪ t) = Sup s ⊔ Sup t :=
-le_antisymm
-  (by finish)
-  (sup_le (Sup_le_Sup $ subset_union_left _ _) (Sup_le_Sup $ subset_union_right _ _))
-
-/- old proof:
-le_antisymm
-  (Sup_le $ assume a h, or.rec_on h (le_sup_left_of_le ∘ le_Sup) (le_sup_right_of_le ∘ le_Sup))
-  (sup_le (Sup_le_Sup $ subset_union_left _ _) (Sup_le_Sup $ subset_union_right _ _))
--/
+((is_lub_Sup s).union (is_lub_Sup t)).Sup_eq
 
 theorem Sup_inter_le {s t : set α} : Sup (s ∩ t) ≤ Sup s ⊓ Sup t :=
 by finish
@@ -112,15 +102,7 @@ by finish
 -/
 
 theorem Inf_union {s t : set α} : Inf (s ∪ t) = Inf s ⊓ Inf t :=
-le_antisymm
-  (le_inf (Inf_le_Inf $ subset_union_left _ _) (Inf_le_Inf $ subset_union_right _ _))
-  (by finish)
-
-/- old proof:
-le_antisymm
-  (le_inf (Inf_le_Inf $ subset_union_left _ _) (Inf_le_Inf $ subset_union_right _ _))
-  (le_Inf $ assume a h, or.rec_on h (inf_le_left_of_le ∘ Inf_le) (inf_le_right_of_le ∘ Inf_le))
--/
+((is_glb_Inf s).union (is_glb_Inf t)).Inf_eq
 
 theorem le_Inf_inter {s t : set α} : Inf s ⊔ Inf t ≤ Inf (s ∩ t) :=
 by finish
@@ -129,40 +111,35 @@ le_Inf (assume a ⟨a_s, a_t⟩, sup_le (Inf_le a_s) (Inf_le a_t))
 -/
 
 @[simp] theorem Sup_empty : Sup ∅ = (⊥ : α) :=
-le_antisymm (by finish) (by finish)
--- le_antisymm (Sup_le (assume _, false.elim)) bot_le
+is_lub_empty.Sup_eq
 
 @[simp] theorem Inf_empty : Inf ∅ = (⊤ : α) :=
-le_antisymm (by finish) (by finish)
---le_antisymm le_top (le_Inf (assume _, false.elim))
+(@is_glb_empty α _).Inf_eq
 
 @[simp] theorem Sup_univ : Sup univ = (⊤ : α) :=
-le_antisymm (by finish) (le_Sup ⟨⟩) -- finish fails because ⊤ ≤ a simplifies to a = ⊤
---le_antisymm le_top (le_Sup ⟨⟩)
+(@is_lub_univ α _).Sup_eq
 
 @[simp] theorem Inf_univ : Inf univ = (⊥ : α) :=
-le_antisymm (Inf_le ⟨⟩) bot_le
+is_glb_univ.Inf_eq
 
 -- TODO(Jeremy): get this automatically
 @[simp] theorem Sup_insert {a : α} {s : set α} : Sup (insert a s) = a ⊔ Sup s :=
-have Sup {b | b = a} = a,
-  from le_antisymm (Sup_le $ assume b b_eq, b_eq ▸ le_refl _) (le_Sup rfl),
-calc Sup (insert a s) = Sup {b | b = a} ⊔ Sup s : Sup_union
-                  ... = a ⊔ Sup s : by rw [this]
+((is_lub_Sup s).insert a).Sup_eq
 
 @[simp] theorem Inf_insert {a : α} {s : set α} : Inf (insert a s) = a ⊓ Inf s :=
-have Inf {b | b = a} = a,
-  from le_antisymm (Inf_le rfl) (le_Inf $ assume b b_eq, b_eq ▸ le_refl _),
-calc Inf (insert a s) = Inf {b | b = a} ⊓ Inf s : Inf_union
-                  ... = a ⊓ Inf s : by rw [this]
+((is_glb_Inf s).insert a).Inf_eq
 
 @[simp] theorem Sup_singleton {a : α} : Sup {a} = a :=
-by finish [singleton_def]
---eq.trans Sup_insert $ by simp
+is_lub_singleton.Sup_eq
 
 @[simp] theorem Inf_singleton {a : α} : Inf {a} = a :=
-by finish [singleton_def]
---eq.trans Inf_insert $ by simp
+is_glb_singleton.Inf_eq
+
+theorem Sup_pair {a b : α} : Sup {a, b} = a ⊔ b :=
+(@is_lub_pair α _ a b).Sup_eq
+
+theorem Inf_pair {a b : α} : Inf {a, b} = a ⊓ b :=
+(@is_glb_pair α _ a b).Inf_eq
 
 @[simp] theorem Inf_eq_top : Inf s = ⊤ ↔ (∀a∈s, a = ⊤) :=
 iff.intro
@@ -180,20 +157,10 @@ section complete_linear_order
 variables [complete_linear_order α] {s t : set α} {a b : α}
 
 lemma Inf_lt_iff : Inf s < b ↔ (∃a∈s, a < b) :=
-iff.intro
-  (assume : Inf s < b, classical.by_contradiction $ assume : ¬ (∃a∈s, a < b),
-    have b ≤ Inf s,
-      from le_Inf $ assume a ha, le_of_not_gt $ assume h, this ⟨a, ha, h⟩,
-    lt_irrefl b (lt_of_le_of_lt ‹b ≤ Inf s› ‹Inf s < b›))
-  (assume ⟨a, ha, h⟩, lt_of_le_of_lt (Inf_le ha) h)
+is_glb_lt_iff (is_glb_Inf s)
 
 lemma lt_Sup_iff : b < Sup s ↔ (∃a∈s, b < a) :=
-iff.intro
-  (assume : b < Sup s, classical.by_contradiction $ assume : ¬ (∃a∈s, b < a),
-    have Sup s ≤ b,
-      from Sup_le $ assume a ha, le_of_not_gt $ assume h, this ⟨a, ha, h⟩,
-    lt_irrefl b (lt_of_lt_of_le ‹b < Sup s› ‹Sup s ≤ b›))
-  (assume ⟨a, ha, h⟩, lt_of_lt_of_le h $ le_Sup ha)
+lt_is_lub_iff (is_lub_Sup s)
 
 lemma Sup_eq_top : Sup s = ⊤ ↔ (∀b<⊤, ∃a∈s, b < a) :=
 iff.intro
@@ -210,14 +177,10 @@ iff.intro
     lt_irrefl a $ lt_of_lt_of_le h (Inf_le ha))
 
 lemma lt_supr_iff {ι : Sort*} {f : ι → α} : a < supr f ↔ (∃i, a < f i) :=
-iff.trans lt_Sup_iff $ iff.intro
-  (assume ⟨a', ⟨i, rfl⟩, ha⟩, ⟨i, ha⟩)
-  (assume ⟨i, hi⟩, ⟨f i, ⟨i, rfl⟩, hi⟩)
+lt_Sup_iff.trans exists_range_iff
 
 lemma infi_lt_iff {ι : Sort*} {f : ι → α} : infi f < a ↔ (∃i, f i < a) :=
-iff.trans Inf_lt_iff $ iff.intro
-  (assume ⟨a', ⟨i, rfl⟩, ha⟩, ⟨i, ha⟩)
-  (assume ⟨i, hi⟩, ⟨f i, ⟨i, rfl⟩, hi⟩)
+Inf_lt_iff.trans exists_range_iff
 
 end complete_linear_order
 
@@ -240,13 +203,17 @@ le_Sup ⟨i, rfl⟩
 le_Sup ⟨i, rfl⟩
 -/
 
-lemma is_lub_supr : is_lub (range s) (⨆j, s j) := is_lub_Sup
+lemma is_lub_supr : is_lub (range s) (⨆j, s j) := is_lub_Sup _
 
-lemma is_lub_iff_supr_eq : is_lub (range s) a ↔ (⨆j, s j) = a := is_lub_iff_eq_of_is_lub is_lub_supr
+private lemma is_lub.supr_eq (h : is_lub (range s) a) : (⨆j, s j) = a := h.Sup_eq
 
-lemma is_glb_infi : is_glb (range s) (⨅j, s j) := is_glb_Inf
+alias is_lub.supr_eq ← is_lub.supr_eq
 
-lemma is_glb_iff_infi_eq : is_glb (range s) a ↔ (⨅j, s j) = a := is_glb_iff_eq_of_is_glb is_glb_infi
+lemma is_glb_infi : is_glb (range s) (⨅j, s j) := is_glb_Inf _
+
+private lemma is_glb.infi_eq (h : is_glb (range s) a) : (⨅j, s j) = a := h.Inf_eq
+
+alias is_glb.infi_eq ← is_glb.infi_eq
 
 theorem le_supr_of_le (i : ι) (h : a ≤ s i) : a ≤ supr s :=
 le_trans h (le_supr _ i)
@@ -264,7 +231,7 @@ theorem supr_le_supr_const (h : ι → ι₂) : (⨆ i:ι, a) ≤ (⨆ j:ι₂, 
 supr_le $ le_supr _ ∘ h
 
 @[simp] theorem supr_le_iff : supr s ≤ a ↔ (∀i, s i ≤ a) :=
-⟨assume : supr s ≤ a, assume i, le_trans (le_supr _ _) this, supr_le⟩
+(is_lub_le_iff is_lub_supr).trans forall_range_iff
 
 -- TODO: finish doesn't do well here.
 @[congr] theorem supr_congr_Prop {α : Type u} [has_Sup α] {p q : Prop} {f₁ : p → α} {f₂ : q → α}
@@ -324,11 +291,11 @@ begin
   exact λ⟨h, W⟩, ⟨pq.2 h, eq.trans (f h) W⟩
 end
 
-@[simp] theorem infi_const {a : α} : ∀[nonempty ι], (⨅ b:ι, a) = a
-| ⟨i⟩ := le_antisymm (Inf_le ⟨i, rfl⟩) (by finish)
+@[simp] theorem infi_const [nonempty ι] {a : α} : (⨅ b:ι, a) = a :=
+by rw [infi, range_const, Inf_singleton]
 
-@[simp] theorem supr_const {a : α} : ∀[nonempty ι], (⨆ b:ι, a) = a
-| ⟨i⟩ := le_antisymm (by finish) (le_Sup ⟨i, rfl⟩)
+@[simp] theorem supr_const [nonempty ι] {a : α} : (⨆ b:ι, a) = a :=
+by rw [supr, range_const, Sup_singleton]
 
 @[simp] lemma infi_top : (⨅i:ι, ⊤ : α) = ⊤ :=
 top_unique $ le_infi $ assume i, le_refl _
@@ -796,12 +763,7 @@ variables [complete_lattice α] [complete_lattice β]
 def ord_continuous (f : α → β) := ∀s : set α, f (Sup s) = (⨆i∈s, f i)
 
 lemma ord_continuous_sup {f : α → β} {a₁ a₂ : α} (hf : ord_continuous f) : f (a₁ ⊔ a₂) = f a₁ ⊔ f a₂ :=
-have h : f (Sup {a₁, a₂}) = (⨆i∈({a₁, a₂} : set α), f i), from hf _,
-have h₁ : {a₁, a₂} = (insert a₂ {a₁} : set α), from rfl,
-begin
-  rw [h₁, Sup_insert, Sup_singleton, sup_comm] at h,
-  rw [h, supr_insert, supr_singleton, sup_comm]
-end
+by rw [← Sup_pair, ← Sup_pair, hf {a₁, a₂}, ← Sup_image, image_pair]
 
 lemma ord_continuous_mono {f : α → β} (hf : ord_continuous f) : monotone f :=
 assume a₁ a₂ h,

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -135,15 +135,17 @@ lemma is_lub_cSup (ne : s.nonempty) (H : bdd_above s) : is_lub s (Sup s) :=
 lemma is_glb_cInf (ne : s.nonempty) (H : bdd_below s) : is_glb s (Inf s) :=
 ⟨assume x, cInf_le H, assume x, le_cInf ne⟩
 
+-- Use `private lemma` + `alias` to escape `namespace lattice` without closing it
+
 private lemma is_lub.cSup_eq (H : is_lub s a) (ne : s.nonempty) : Sup s = a :=
 (is_lub_cSup ne ⟨a, H.1⟩).unique H
 
 alias is_lub.cSup_eq ← is_lub.cSup_eq
 
-/-- A greatest element of a set is the supremum of this set. -/
 private lemma is_greatest.cSup_eq (H : is_greatest s a) : Sup s = a :=
 H.is_lub.cSup_eq H.nonempty
 
+/-- A greatest element of a set is the supremum of this set. -/
 alias is_greatest.cSup_eq ← is_greatest.cSup_eq
 
 private lemma is_glb.cInf_eq (H : is_glb s a) (ne : s.nonempty) : Inf s = a :=
@@ -151,10 +153,10 @@ private lemma is_glb.cInf_eq (H : is_glb s a) (ne : s.nonempty) : Inf s = a :=
 
 alias is_glb.cInf_eq ← is_glb.cInf_eq
 
-/-- A least element of a set is the infimum of this set. -/
 private lemma is_least.cInf_eq (H : is_least s a) : Inf s = a :=
 H.is_glb.cInf_eq H.nonempty
 
+/-- A least element of a set is the infimum of this set. -/
 alias is_least.cInf_eq ← is_least.cInf_eq
 
 theorem cSup_le_iff (hb : bdd_above s) (ne : s.nonempty) : Sup s ≤ a ↔ (∀b ∈ s, b ≤ a) :=

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -3,8 +3,13 @@ Copyright (c) 2018 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 Adapted from the corresponding theory for complete lattices.
+-/
 
-Theory of conditionally complete lattices.
+import
+  order.lattice order.complete_lattice order.bounds
+  tactic.finish data.set.finite
+/-!
+# Theory of conditionally complete lattices.
 
 A conditionally complete lattice is a lattice in which every non-empty bounded subset s
 has a least upper bound and a greatest lower bound, denoted below by Sup s and Inf s.
@@ -22,9 +27,6 @@ Inf_le is a statement in complete lattices ensuring Inf s ≤ x, while cInf_le i
 statement in conditionally complete lattices with an additional assumption that s is
 bounded below.
 -/
-import
-  order.lattice order.complete_lattice order.bounds
-  tactic.finish data.set.finite
 
 set_option old_structure_cmd true
 
@@ -127,27 +129,47 @@ cSup_le ‹_› (assume (a) (ha : a ∈ s), le_cSup ‹bdd_above t› (h ha))
 theorem cInf_le_cInf (_ : bdd_below t) (_ : s.nonempty) (h : s ⊆ t) : Inf t ≤ Inf s :=
 le_cInf ‹_› (assume (a) (ha : a ∈ s), cInf_le ‹bdd_below t› (h ha))
 
-theorem cSup_le_iff (_ : bdd_above s) (_ : s.nonempty) : Sup s ≤ a ↔ (∀b ∈ s, b ≤ a) :=
-⟨assume (_ : Sup s ≤ a) (b) (_ : b ∈ s),
-  le_trans (le_cSup ‹bdd_above s› ‹b ∈ s›) ‹Sup s ≤ a›,
-  cSup_le ‹_›⟩
+lemma is_lub_cSup (ne : s.nonempty) (H : bdd_above s) : is_lub s (Sup s) :=
+⟨assume x, le_cSup H, assume x, cSup_le ne⟩
 
-theorem le_cInf_iff (_ : bdd_below s) (_ : s.nonempty) : a ≤ Inf s ↔ (∀b ∈ s, a ≤ b) :=
-⟨assume (_ : a ≤ Inf s) (b) (_ : b ∈ s),
-  le_trans ‹a ≤ Inf s› (cInf_le ‹bdd_below s› ‹b ∈ s›),
-  le_cInf ‹_›⟩
+lemma is_glb_cInf (ne : s.nonempty) (H : bdd_below s) : is_glb s (Inf s) :=
+⟨assume x, cInf_le H, assume x, le_cInf ne⟩
+
+private lemma is_lub.cSup_eq (H : is_lub s a) (ne : s.nonempty) : Sup s = a :=
+(is_lub_cSup ne ⟨a, H.1⟩).unique H
+
+alias is_lub.cSup_eq ← is_lub.cSup_eq
+
+/-- A greatest element of a set is the supremum of this set. -/
+private lemma is_greatest.cSup_eq (H : is_greatest s a) : Sup s = a :=
+H.is_lub.cSup_eq H.nonempty
+
+alias is_greatest.cSup_eq ← is_greatest.cSup_eq
+
+private lemma is_glb.cInf_eq (H : is_glb s a) (ne : s.nonempty) : Inf s = a :=
+(is_glb_cInf ne ⟨a, H.1⟩).unique H
+
+alias is_glb.cInf_eq ← is_glb.cInf_eq
+
+/-- A least element of a set is the infimum of this set. -/
+private lemma is_least.cInf_eq (H : is_least s a) : Inf s = a :=
+H.is_glb.cInf_eq H.nonempty
+
+alias is_least.cInf_eq ← is_least.cInf_eq
+
+theorem cSup_le_iff (hb : bdd_above s) (ne : s.nonempty) : Sup s ≤ a ↔ (∀b ∈ s, b ≤ a) :=
+is_lub_le_iff (is_lub_cSup ne hb)
+
+theorem le_cInf_iff (hb : bdd_below s) (ne : s.nonempty) : a ≤ Inf s ↔ (∀b ∈ s, a ≤ b) :=
+le_is_glb_iff (is_glb_cInf ne hb)
 
 lemma cSup_lower_bounds_eq_cInf {s : set α} (h : bdd_below s) (hs : s.nonempty) :
   Sup (lower_bounds s) = Inf s :=
-le_antisymm
-  (cSup_le h $ assume a ha, le_cInf hs ha)
-  (le_cSup (hs.mono $ λ a ha y hy, hy ha) $ assume x hx, cInf_le h hx)
+(is_lub_cSup h $ hs.mono $ λ x hx y hy, hy hx).unique (is_glb_cInf hs h).is_lub
 
 lemma cInf_upper_bounds_eq_cSup {s : set α} (h : bdd_above s) (hs : s.nonempty) :
   Inf (upper_bounds s) = Sup s :=
-le_antisymm
-  (cInf_le (hs.mono $ assume a ha y hy, hy ha) $ assume x hx, le_cSup h hx)
-  (le_cInf h $ assume a ha, cSup_le hs ha)
+(is_glb_cInf h $ hs.mono $ λ x hx y hy, hy hx).unique (is_lub_cSup hs h).is_glb
 
 /--Introduction rule to prove that b is the supremum of s: it suffices to check that b
 is larger than all elements of s, and that this is not the case of any w<b.-/
@@ -173,20 +195,6 @@ have ¬(b < Inf s) :=
   show false, by finish [lt_irrefl (Inf s)],
 show Inf s = b, by finish
 
-/--When an element a of a set s is larger than all other elements of the set, it is Sup s-/
-theorem cSup_of_mem_of_le (_ : a ∈ s) (_ : ∀w∈s, w ≤ a) : Sup s = a :=
-have bdd_above s := ⟨a, by assumption⟩,
-have A : a ≤ Sup s := le_cSup ‹bdd_above s› ‹a ∈ s›,
-have B : Sup s ≤ a := cSup_le ⟨a, ‹_›⟩ ‹∀w∈s, w ≤ a›,
-le_antisymm B A
-
-/--When an element a of a set s is smaller than all other elements of the set, it is Inf s-/
-theorem cInf_of_mem_of_le (_ : a ∈ s) (_ : ∀w∈s, a ≤ w) : Inf s = a :=
-have bdd_below s := ⟨a, by assumption⟩,
-have A : Inf s ≤ a := cInf_le ‹bdd_below s› ‹a ∈ s›,
-have B : a ≤ Inf s := le_cInf ⟨a, ‹_›⟩ ‹∀w∈s, a ≤ w›,
-le_antisymm A B
-
 /--b < Sup s when there is an element a in s with b < a, when s is bounded above.
 This is essentially an iff, except that the assumptions for the two implications are
 slightly different (one needs boundedness above for one direction, nonemptiness and linear
@@ -200,76 +208,38 @@ This is essentially an iff, except that the assumptions for the two implications
 slightly different (one needs boundedness below for one direction, nonemptiness and linear
 order for the other one), so we formulate separately the two implications, contrary to
 the complete_lattice case.-/
-
 lemma cInf_lt_of_lt (_ : bdd_below s) (_ : a ∈ s) (_ : a < b) : Inf s < b :=
 lt_of_le_of_lt (cInf_le ‹bdd_below s› ‹a ∈ s›) ‹a < b›
 
 /--The supremum of a singleton is the element of the singleton-/
 @[simp] theorem cSup_singleton (a : α) : Sup {a} = a :=
-cSup_of_mem_of_le (mem_singleton a)
-  (λ b hb, set.eq_of_mem_singleton hb ▸ le_refl b)
+is_greatest_singleton.cSup_eq
 
 /--The infimum of a singleton is the element of the singleton-/
 @[simp] theorem cInf_singleton (a : α) : Inf {a} = a :=
-cInf_of_mem_of_le (mem_singleton a)
-  (λ b hb, set.eq_of_mem_singleton hb ▸ le_refl b)
+is_least_singleton.cInf_eq
 
 /--If a set is bounded below and above, and nonempty, its infimum is less than or equal to
 its supremum.-/
-theorem cInf_le_cSup (_ : bdd_below s) (_ : bdd_above s) (_ : s.nonempty) : Inf s ≤ Sup s :=
-let ⟨w, hw⟩ := ‹s.nonempty› in   /-hw : w ∈ s-/
-have Inf s ≤ w := cInf_le ‹bdd_below s› ‹w ∈ s›,
-have w ≤ Sup s := le_cSup ‹bdd_above s› ‹w ∈ s›,
-le_trans ‹Inf s ≤ w› ‹w ≤ Sup s›
+theorem cInf_le_cSup (hb : bdd_below s) (ha : bdd_above s) (ne : s.nonempty) : Inf s ≤ Sup s :=
+is_glb_le_is_lub (is_glb_cInf ne hb) (is_lub_cSup ne ha) ne
 
 /--The sup of a union of two sets is the max of the suprema of each subset, under the assumptions
 that all sets are bounded above and nonempty.-/
-theorem cSup_union (_ : bdd_above s) (sne : s.nonempty) (_ : bdd_above t) (tne : t.nonempty) :
-Sup (s ∪ t) = Sup s ⊔ Sup t :=
-have A : Sup (s ∪ t) ≤ Sup s ⊔ Sup t :=
-  have (s ∪ t).nonempty := sne.inl,
-  have F : ∀b∈ s∪t, b ≤ Sup s ⊔ Sup t :=
-    begin
-      intros,
-      cases H,
-      apply le_trans (le_cSup ‹bdd_above s› ‹b ∈ s›) _, simp only [lattice.le_sup_left],
-      apply le_trans (le_cSup ‹bdd_above t› ‹b ∈ t›) _, simp only [lattice.le_sup_right]
-    end,
-  cSup_le this F,
-have B : Sup s ⊔ Sup t ≤ Sup (s ∪ t) :=
-  have Sup s ≤ Sup (s ∪ t),
-    from cSup_le_cSup (bdd_above_union.2 ⟨‹_›, ‹_›⟩) sne (set.subset_union_left _ _),
-  have Sup t ≤ Sup (s ∪ t),
-    from cSup_le_cSup (bdd_above_union.2 ⟨‹_›, ‹_›⟩) tne (set.subset_union_right _ _),
-  by simp only [lattice.sup_le_iff]; split; assumption,
-le_antisymm A B
+theorem cSup_union (hs : bdd_above s) (sne : s.nonempty) (ht : bdd_above t) (tne : t.nonempty) :
+  Sup (s ∪ t) = Sup s ⊔ Sup t :=
+((is_lub_cSup sne hs).union (is_lub_cSup tne ht)).cSup_eq sne.inl
 
 /--The inf of a union of two sets is the min of the infima of each subset, under the assumptions
 that all sets are bounded below and nonempty.-/
-theorem cInf_union (_ : bdd_below s) (sne : s.nonempty) (_ : bdd_below t) (tne : t.nonempty) :
-Inf (s ∪ t) = Inf s ⊓ Inf t :=
-have A : Inf s ⊓ Inf t ≤ Inf (s ∪ t) :=
-  have (s ∪ t).nonempty, from sne.inl,
-  have F : ∀b∈ s∪t, Inf s ⊓ Inf t ≤ b :=
-    begin
-      intros,
-      cases H,
-      apply le_trans _ (cInf_le ‹bdd_below s› ‹b ∈ s›), simp only [lattice.inf_le_left],
-      apply le_trans _ (cInf_le ‹bdd_below t› ‹b ∈ t›), simp only [lattice.inf_le_right]
-    end,
-  le_cInf this F,
-have B : Inf (s ∪ t) ≤ Inf s ⊓ Inf t  :=
-  have Inf (s ∪ t) ≤ Inf s,
-    from cInf_le_cInf (bdd_below_union.2 ⟨‹_›, ‹_›⟩) sne (set.subset_union_left _ _),
-  have Inf (s ∪ t) ≤ Inf t,
-    from cInf_le_cInf (bdd_below_union.2 ⟨‹_›, ‹_›⟩) tne (set.subset_union_right _ _),
-  by simp only [lattice.le_inf_iff]; split; assumption; assumption,
-le_antisymm B A
+theorem cInf_union (hs : bdd_below s) (sne : s.nonempty) (ht : bdd_below t) (tne : t.nonempty) :
+  Inf (s ∪ t) = Inf s ⊓ Inf t :=
+((is_glb_cInf sne hs).union (is_glb_cInf tne ht)).cInf_eq sne.inl
 
 /--The supremum of an intersection of two sets is bounded by the minimum of the suprema of each
 set, if all sets are bounded above and nonempty.-/
 theorem cSup_inter_le (_ : bdd_above s) (_ : bdd_above t) (hst : (s ∩ t).nonempty) :
-Sup (s ∩ t) ≤ Sup s ⊓ Sup t :=
+  Sup (s ∩ t) ≤ Sup s ⊓ Sup t :=
 begin
   apply cSup_le hst, simp only [lattice.le_inf_iff, and_imp, set.mem_inter_eq], intros b _ _, split,
   apply le_cSup ‹bdd_above s› ‹b ∈ s›,
@@ -288,25 +258,17 @@ end
 
 /-- The supremum of insert a s is the maximum of a and the supremum of s, if s is
 nonempty and bounded above.-/
-theorem cSup_insert (_ : bdd_above s) (sne : s.nonempty) : Sup (insert a s) = a ⊔ Sup s :=
-calc Sup (insert a s)
-        = Sup ({a} ∪ s)   : by rw [insert_eq]
-    ... = Sup {a} ⊔ Sup s : by apply cSup_union _ _ ‹bdd_above s› sne; simp only [ne.def, not_false_iff, set.singleton_nonempty, bdd_above_singleton]
-    ... = a ⊔ Sup s       : by simp only [eq_self_iff_true, lattice.cSup_singleton]
+theorem cSup_insert (hs : bdd_above s) (sne : s.nonempty) : Sup (insert a s) = a ⊔ Sup s :=
+((is_lub_cSup sne hs).insert a).cSup_eq (insert_nonempty a s)
 
 /-- The infimum of insert a s is the minimum of a and the infimum of s, if s is
 nonempty and bounded below.-/
-theorem cInf_insert (_ : bdd_below s) (sne : s.nonempty) : Inf (insert a s) = a ⊓ Inf s :=
-calc Inf (insert a s)
-        = Inf ({a} ∪ s)   : by rw [insert_eq]
-    ... = Inf {a} ⊓ Inf s : by apply cInf_union _ _ ‹bdd_below s› sne; simp only [ne.def, not_false_iff, set.singleton_nonempty, bdd_below_singleton]
-    ... = a ⊓ Inf s       : by simp only [eq_self_iff_true, lattice.cInf_singleton]
+theorem cInf_insert (hs : bdd_below s) (sne : s.nonempty) : Inf (insert a s) = a ⊓ Inf s :=
+((is_glb_cInf sne hs).insert a).cInf_eq (insert_nonempty a s)
 
-@[simp] lemma cInf_interval : Inf {b | a ≤ b} = a :=
-cInf_of_mem_of_le (by simp only [set.mem_set_of_eq]) (λw Hw, by simp only [set.mem_set_of_eq] at Hw; apply Hw)
+@[simp] lemma cInf_Ici : Inf (Ici a) = a := is_least_Ici.cInf_eq
 
-@[simp] lemma cSup_interval : Sup {b | b ≤ a} = a :=
-cSup_of_mem_of_le (by simp only [set.mem_set_of_eq]) (λw Hw, by simp only [set.mem_set_of_eq] at Hw; apply Hw)
+@[simp] lemma cSup_Iic : Sup (Iic a) = a := is_greatest_Iic.cSup_eq
 
 /--The indexed supremum of two functions are comparable if the functions are pointwise comparable-/
 lemma csupr_le_csupr {f g : ι → α} (B : bdd_above (range g)) (H : ∀x, f x ≤ g x) :
@@ -354,27 +316,11 @@ le_cInf (range_nonempty f) (by rwa forall_range_iff)
 lemma cinfi_le {f : ι → α} (H : bdd_below (range f)) {c : ι} : infi f ≤ f c :=
 cInf_le H (mem_range_self _)
 
-lemma is_lub_cSup {s : set α} (ne : s.nonempty) (H : bdd_above s) : is_lub s (Sup s) :=
-⟨assume x, le_cSup H, assume x, cSup_le ne⟩
-
-lemma is_glb_cInf {s : set α} (ne : s.nonempty) (H : bdd_below s) : is_glb s (Inf s) :=
-⟨assume x, cInf_le H, assume x, le_cInf ne⟩
-
 @[simp] theorem cinfi_const [hι : nonempty ι] {a : α} : (⨅ b:ι, a) = a :=
-begin
-  refine hι.elim (λ x, _),
-  refine le_antisymm (@cinfi_le _ _ _ _ _ x) (le_cinfi (λi, _root_.le_refl _)),
-  rw range_const,
-  exact bdd_below_singleton
-end
+by rw [infi, range_const, cInf_singleton]
 
 @[simp] theorem csupr_const [hι : nonempty ι] {a : α} : (⨆ b:ι, a) = a :=
-begin
-  refine hι.elim (λ x, _),
-  refine le_antisymm (csupr_le (λi, _root_.le_refl _)) (@le_csupr _ _ _ (λ b:ι, a) _ x),
-  rw range_const,
-  exact bdd_above_singleton
-end
+by rw [supr, range_const, cSup_singleton]
 
 end conditionally_complete_lattice
 

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -534,7 +534,7 @@ let ⟨x, hx⟩ := hs in
 have (⨅a∈s, ↑a : with_top α) ≤ x, from infi_le_of_le x $ infi_le_of_le hx $ _root_.le_refl _,
 let ⟨r, r_eq, hr⟩ := (le_coe_iff _ _).1 this in
 le_antisymm
-  (le_infi $ assume a, le_infi $ assume ha, coe_le_coe.2 $ cInf_le (bdd_below_bot s) ha)
+  (le_infi $ assume a, le_infi $ assume ha, coe_le_coe.2 $ cInf_le (orter_bot.bdd_below s) ha)
   begin
     refine (r_eq.symm ▸ coe_le_coe.2 $ le_cInf hs $ assume a has, coe_le_coe.1 $ _),
     refine (r_eq ▸ infi_le_of_le a _),

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -534,7 +534,7 @@ let ⟨x, hx⟩ := hs in
 have (⨅a∈s, ↑a : with_top α) ≤ x, from infi_le_of_le x $ infi_le_of_le hx $ _root_.le_refl _,
 let ⟨r, r_eq, hr⟩ := (le_coe_iff _ _).1 this in
 le_antisymm
-  (le_infi $ assume a, le_infi $ assume ha, coe_le_coe.2 $ cInf_le (orter_bot.bdd_below s) ha)
+  (le_infi $ assume a, le_infi $ assume ha, coe_le_coe.2 $ cInf_le (order_bot.bdd_below s) ha)
   begin
     refine (r_eq.symm ▸ coe_le_coe.2 $ le_cInf hs $ assume a has, coe_le_coe.1 $ _),
     refine (r_eq ▸ infi_le_of_le a _),

--- a/src/order/galois_connection.lean
+++ b/src/order/galois_connection.lean
@@ -57,11 +57,11 @@ lemma lower_bounds_u_image_subset {s : set β} : lower_bounds (u '' s) ⊆ l ⁻
 assume a ha c, assume : c ∈ s, gc.l_le (ha (mem_image_of_mem _ ‹c ∈ s›))
 
 lemma is_lub_l_image {s : set α} {a : α} (h : is_lub s a) : is_lub (l '' s) (l a) :=
-⟨mem_upper_bounds_image gc.monotone_l $ and.elim_left ‹is_lub s a›,
+⟨gc.monotone_l.mem_upper_bounds_image $ and.elim_left ‹is_lub s a›,
   assume b hb, gc.l_le $ and.elim_right ‹is_lub s a› $ gc.upper_bounds_l_image_subset hb⟩
 
 lemma is_glb_u_image {s : set β} {b : β} (h : is_glb s b) : is_glb (u '' s) (u b) :=
-⟨mem_lower_bounds_image gc.monotone_u $ and.elim_left ‹is_glb s b›,
+⟨gc.monotone_u.mem_lower_bounds_image $ and.elim_left ‹is_glb s b›,
   assume a ha, gc.le_u $ and.elim_right ‹is_glb s b› $ gc.lower_bounds_u_image_subset ha⟩
 
 lemma is_glb_l {a : α} : is_glb { b | a ≤ u b } (l a) :=
@@ -89,7 +89,7 @@ variables [order_top α] [order_top β] {l : α → β} {u : β → α} (gc : ga
 include gc
 
 lemma u_top : u ⊤ = ⊤ :=
-eq_of_is_glb_of_is_glb (gc.is_glb_u_image is_glb_empty) $ by simp [is_glb_empty, image_empty]
+(gc.is_glb_u_image is_glb_empty).unique $ by simp only [is_glb_empty, image_empty]
 
 end order_top
 
@@ -98,7 +98,7 @@ variables [order_bot α] [order_bot β] {l : α → β} {u : β → α} (gc : ga
 include gc
 
 lemma l_bot : l ⊥ = ⊥ :=
-eq_of_is_lub_of_is_lub (gc.is_lub_l_image is_lub_empty) $ by simp [is_lub_empty, image_empty]
+(gc.is_lub_l_image is_lub_empty).unique $ by simp only [is_lub_empty, image_empty]
 
 end order_bot
 
@@ -107,9 +107,7 @@ variables [semilattice_sup α] [semilattice_sup β] {l : α → β} {u : β → 
 include gc
 
 lemma l_sup : l (a₁ ⊔ a₂) = l a₁ ⊔ l a₂ :=
-have {l a₂, l a₁} = l '' {a₂, a₁}, by simp [image_insert_eq, image_singleton],
-eq.symm $ is_lub_iff_sup_eq.mp $
-  by rw [this]; exact gc.is_lub_l_image (is_lub_insert_sup is_lub_singleton)
+(gc.is_lub_l_image is_lub_pair).unique $ by simp only [image_pair, is_lub_pair]
 
 end semilattice_sup
 
@@ -118,9 +116,7 @@ variables [semilattice_inf α] [semilattice_inf β] {l : α → β} {u : β → 
 include gc
 
 lemma u_inf : u (b₁ ⊓ b₂) = u b₁ ⊓ u b₂ :=
-have {u b₂, u b₁} = u '' {b₂, b₁}, by simp [image_insert_eq, image_singleton],
-eq.symm $ is_glb_iff_inf_eq.mp $
-  by rw [this]; exact gc.is_glb_u_image (is_glb_insert_inf is_glb_singleton)
+(gc.is_glb_u_image is_glb_pair).unique $ by simp only [image_pair, is_glb_pair]
 
 end semilattice_inf
 
@@ -129,12 +125,12 @@ variables [complete_lattice α] [complete_lattice β] {l : α → β} {u : β �
 include gc
 
 lemma l_supr {f : ι → α} : l (supr f) = (⨆i, l (f i)) :=
-eq.symm $ is_lub_iff_supr_eq.mp $ show is_lub (range (l ∘ f)) (l (supr f)),
-  by rw [range_comp, ← Sup_range]; exact gc.is_lub_l_image is_lub_Sup
+eq.symm $ is_lub.supr_eq $ show is_lub (range (l ∘ f)) (l (supr f)),
+  by rw [range_comp, ← Sup_range]; exact gc.is_lub_l_image (is_lub_Sup _)
 
 lemma u_infi {f : ι → β} : u (infi f) = (⨅i, u (f i)) :=
-eq.symm $ is_glb_iff_infi_eq.mp $ show is_glb (range (u ∘ f)) (u (infi f)),
-  by rw [range_comp, ← Inf_range]; exact gc.is_glb_u_image is_glb_Inf
+eq.symm $ is_glb.infi_eq $ show is_glb (range (u ∘ f)) (u (infi f)),
+  by rw [range_comp, ← Inf_range]; exact gc.is_glb_u_image (is_glb_Inf _)
 
 end complete_lattice
 

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -1092,27 +1092,26 @@ variables [complete_linear_order α] [topological_space α] [order_topology α]
 
 lemma Sup_mem_closure {α : Type u} [topological_space α] [complete_linear_order α] [order_topology α]
   {s : set α} (hs : s.nonempty) : Sup s ∈ closure s :=
-mem_closure_of_is_lub is_lub_Sup hs
+mem_closure_of_is_lub (is_lub_Sup _) hs
 
 lemma Inf_mem_closure {α : Type u} [topological_space α] [complete_linear_order α] [order_topology α]
   {s : set α} (hs : s.nonempty) : Inf s ∈ closure s :=
-mem_closure_of_is_glb is_glb_Inf hs
+mem_closure_of_is_glb (is_glb_Inf _) hs
 
 lemma Sup_mem_of_is_closed {α : Type u} [topological_space α] [complete_linear_order α] [order_topology α]
   {s : set α} (hs : s.nonempty) (hc : is_closed s) : Sup s ∈ s :=
-mem_of_is_lub_of_is_closed  is_lub_Sup hs hc
+mem_of_is_lub_of_is_closed (is_lub_Sup _) hs hc
 
 lemma Inf_mem_of_is_closed {α : Type u} [topological_space α] [complete_linear_order α] [order_topology α]
   {s : set α} (hs : s.nonempty) (hc : is_closed s) : Inf s ∈ s :=
-mem_of_is_glb_of_is_closed  is_glb_Inf hs hc
+mem_of_is_glb_of_is_closed (is_glb_Inf _) hs hc
 
 /-- A continuous monotone function sends supremum to supremum for nonempty sets. -/
 lemma Sup_of_continuous' {f : α → β} (Mf : continuous f) (Cf : monotone f)
   {s : set α} (hs : s.nonempty) : f (Sup s) = Sup (f '' s) :=
 --This is a particular case of the more general is_lub_of_is_lub_of_tendsto
-(is_lub_iff_Sup_eq.1
-  (is_lub_of_is_lub_of_tendsto (λ x hx y hy xy, Cf xy) is_lub_Sup hs $
-    tendsto_le_left inf_le_left (Mf.tendsto _))).symm
+(is_lub_of_is_lub_of_tendsto (λ x hx y hy xy, Cf xy) (is_lub_Sup _) hs $
+  tendsto_le_left inf_le_left (Mf.tendsto _)).Sup_eq.symm
 
 /-- A continuous monotone function sending bot to bot sends supremum to supremum. -/
 lemma Sup_of_continuous {f : α → β} (Mf : continuous f) (Cf : monotone f)
@@ -1136,9 +1135,8 @@ by rw [supr, Sup_of_continuous Mf Cf fbot, ← range_comp, supr]
 /-- A continuous monotone function sends infimum to infimum for nonempty sets. -/
 lemma Inf_of_continuous' {f : α → β} (Mf : continuous f) (Cf : monotone f)
   {s : set α} (hs : s.nonempty) : f (Inf s) = Inf (f '' s) :=
-(is_glb_iff_Inf_eq.1
-  (is_glb_of_is_glb_of_tendsto (λ x hx y hy xy, Cf xy) is_glb_Inf hs $
-    tendsto_le_left inf_le_left (Mf.tendsto _))).symm
+(is_glb_of_is_glb_of_tendsto (λ x hx y hy xy, Cf xy) (is_glb_Inf _) hs $
+  tendsto_le_left inf_le_left (Mf.tendsto _)).Inf_eq.symm
 
 /-- A continuous monotone function sending top to top sends infimum to infimum. -/
 lemma Inf_of_continuous {f : α → β} (Mf : continuous f) (Cf : monotone f)
@@ -1188,8 +1186,7 @@ lattices, under a boundedness assumption. -/
 lemma cSup_of_cSup_of_monotone_of_continuous {f : α → β} (Mf : continuous f) (Cf : monotone f)
   {s : set α} (ne : s.nonempty) (H : bdd_above s) : f (Sup s) = Sup (f '' s) :=
 begin
-  refine (is_lub_iff_eq_of_is_lub _).1
-    (is_lub_cSup (ne.image f) (bdd_above_of_bdd_above_of_monotone Cf H)),
+  refine ((is_lub_cSup (ne.image f) (Cf.map_bdd_above H)).unique _).symm,
   refine is_lub_of_is_lub_of_tendsto (λx hx y hy xy, Cf xy) (is_lub_cSup ne H) ne _,
   exact tendsto_le_left inf_le_left (Mf.tendsto _)
 end
@@ -1205,8 +1202,7 @@ lattices, under a boundedness assumption. -/
 lemma cInf_of_cInf_of_monotone_of_continuous {f : α → β} (Mf : continuous f) (Cf : monotone f)
   {s : set α} (ne : s.nonempty) (H : bdd_below s) : f (Inf s) = Inf (f '' s) :=
 begin
-  refine (is_glb_iff_eq_of_is_glb _).1
-    (is_glb_cInf (ne.image _) (bdd_below_of_bdd_below_of_monotone Cf H)),
+  refine ((is_glb_cInf (ne.image _) (Cf.map_bdd_below H)).unique _).symm,
   refine is_glb_of_is_glb_of_tendsto (λx hx y hy xy, Cf xy) (is_glb_cInf ne H) ne _,
   exact tendsto_le_left inf_le_left (Mf.tendsto _)
 end

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -292,11 +292,11 @@ ennreal.inv_top ▸ ennreal.tendsto_inv_iff.2 tendsto_nat_nhds_top
 
 lemma Sup_add {s : set ennreal} (hs : s.nonempty) : Sup s + a = ⨆b∈s, b + a :=
 have Sup ((λb, b + a) '' s) = Sup s + a,
-  from is_lub_iff_Sup_eq.mp $ is_lub_of_is_lub_of_tendsto
+  from is_lub.Sup_eq (is_lub_of_is_lub_of_tendsto
     (assume x _ y _ h, add_le_add' h (le_refl _))
-    is_lub_Sup
+    (is_lub_Sup s)
     hs
-    (tendsto.add (tendsto_id' inf_le_left) tendsto_const_nhds),
+    (tendsto.add (tendsto_id' inf_le_left) tendsto_const_nhds)),
 by simp [Sup_image, -add_comm] at this; exact this.symm
 
 lemma supr_add {ι : Sort*} {s : ι → ennreal} [h : nonempty ι] : supr s + a = ⨆b, s b + a :=
@@ -355,9 +355,9 @@ begin
     have s₁ : Sup s ≠ 0 :=
       zero_lt_iff_ne_zero.1 (lt_of_lt_of_le (zero_lt_iff_ne_zero.2 hx0) (le_Sup hx)),
     have : Sup ((λb, a * b) '' s) = a * Sup s :=
-      is_lub_iff_Sup_eq.mp (is_lub_of_is_lub_of_tendsto
+      is_lub.Sup_eq (is_lub_of_is_lub_of_tendsto
         (assume x _ y _ h, canonically_ordered_semiring.mul_le_mul (le_refl _) h)
-        is_lub_Sup
+        (is_lub_Sup _)
         ⟨x, hx⟩
         (ennreal.tendsto.const_mul (tendsto_id' inf_le_left) (or.inl s₁))),
     rw [this.symm, Sup_image] }
@@ -385,7 +385,7 @@ lemma sub_supr {ι : Sort*} [hι : nonempty ι] {b : ι → ennreal} (hr : a < �
 let ⟨i⟩ := hι in
 let ⟨r, eq, _⟩ := lt_iff_exists_coe.mp hr in
 have Inf ((λb, ↑r - b) '' range b) = ↑r - (⨆i, b i),
-  from is_glb_iff_Inf_eq.mp $ is_glb_of_is_lub_of_tendsto
+  from is_glb.Inf_eq $ is_glb_of_is_lub_of_tendsto
     (assume x _ y _, sub_le_sub (le_refl _))
     is_lub_supr
     ⟨_, i, rfl⟩


### PR DESCRIPTION
Also make parts of `complete_lattice` and
`conditionally_complete_lattice` use these lemmas.

Please review `order/bounds` as a new file. It will be easier than analysing the diff.
Needs a module docstring.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)