### PR TITLE
feat(ci): upload all branch builds to Azure server

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,12 @@ jobs:
           ~/.elan/bin/lean --version
           echo "::add-path::$HOME/.elan/bin"
 
+      - name: install azcopy
+        run: |
+          cd /usr/local/bin
+          wget -q https://aka.ms/downloadazcopy-v10-linux -O - | sudo tar zxf - --strip-components 1 --wildcards '*/azcopy'
+          sudo chmod 755 /usr/local/bin/azcopy
+
       - name: leanpkg build
         run: leanpkg build | python scripts/detect_errors.py
 
@@ -43,14 +49,8 @@ jobs:
         env:
           DEPLOY_NIGHTLY_GITHUB_TOKEN: ${{ secrets.DEPLOY_NIGHTLY_GITHUB_TOKEN }}
 
-      - name: install azcopy
-        run: |
-          cd /usr/local/bin
-          wget -q https://aka.ms/downloadazcopy-v10-linux -O - | sudo tar zxf - --strip-components 1 --wildcards '*/azcopy'
-          sudo chmod 755 /usr/local/bin/azcopy
-
       - name: push release to azure
-        if: github.repository == 'leanprover-community/mathlib' && github.event_name == 'push' && matrix.lean_version == 'leanprover-community/lean:3.5.1'
+        if: always() && github.repository == 'leanprover-community/mathlib' && github.event_name == 'push' && matrix.lean_version == 'leanprover-community/lean:3.5.1'
         run: |
           archive_name="$(git rev-parse HEAD).tar.gz"
           tar czf "$archive_name" src

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           archive_name="$(git rev-parse HEAD).tar.gz"
           tar czf "$archive_name" src
-          azcopy copy "$archive_name" "${{ secrets.AZURE_SAS_TOKEN }} --block-size-mb 99"
+          azcopy copy "$archive_name" "${{ secrets.AZURE_SAS_TOKEN }}" --block-size-mb 99
 
       - name: tests
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,19 @@ jobs:
         env:
           DEPLOY_NIGHTLY_GITHUB_TOKEN: ${{ secrets.DEPLOY_NIGHTLY_GITHUB_TOKEN }}
 
+      - name: install azcopy
+        run: |
+          cd /usr/local/bin
+          wget -q https://aka.ms/downloadazcopy-v10-linux -O - | sudo tar zxf - --strip-components 1 --wildcards '*/azcopy'
+          sudo chmod 755 /usr/local/bin/azcopy
+
+      - name: push release to azure
+        if: github.repository == 'leanprover-community/mathlib' && github.event_name == 'push' && matrix.lean_version == 'leanprover-community/lean:3.5.1'
+        run: |
+          archive_name="$(git rev-parse HEAD).tar.gz"
+          tar czf "$archive_name" src
+          azcopy copy "$archive_name" "${{ secrets.AZURE_SAS_TOKEN }} --block-size-mb 99"
+
       - name: tests
         run: |
           set -o pipefail


### PR DESCRIPTION
The artifacts from every build (successful or not) of a leanprover-community/mathlib branch will get uploaded to the cloud. Forthcoming changes to `cache-olean`/`update-mathlib` will retrieve these.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
