### PR TITLE
feat(tactic/lint): add linter for simp lemmas whose lhs has a variable as head symbol

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ The following linters are run by default:
 10. `dangerous_instance` checks for instances that generate type-class problems with metavariables.
 11. `inhabited_nonempty` checks for `inhabited` instance arguments that should be changed to `nonempty`.
 12. `simp_nf` checks that arguments of the left-hand side of simp lemmas are in simp-normal form.
+13. `simp_var_head` checks that there are no variables as head symbol of left-hand sides of simp lemmas.
 
 Another linter, `doc_blame_thm`, checks for missing doc strings on lemmas and theorems.
 This is not run by default.

--- a/src/algebra/field.lean
+++ b/src/algebra/field.lean
@@ -276,9 +276,9 @@ section
 variables {β : Type*} [discrete_field α] [discrete_field β]
 variables (f : α → β) [is_ring_hom f] {x y : α}
 
-@[simp] lemma map_inv : f x⁻¹ = (f x)⁻¹ := (of f).map_inv
+lemma map_inv : f x⁻¹ = (f x)⁻¹ := (of f).map_inv
 
-@[simp] lemma map_div : f (x / y) = f x / f y := (of f).map_div
+lemma map_div : f (x / y) = f x / f y := (of f).map_div
 
 end
 

--- a/src/algebra/module.lean
+++ b/src/algebra/module.lean
@@ -245,16 +245,16 @@ end
 variables {f : β → γ} (lin : is_linear_map α f)
 include β γ lin
 
-@[simp] lemma map_zero : f (0 : β) = (0 : γ) :=
+lemma map_zero : f (0 : β) = (0 : γ) :=
 by rw [← zero_smul α (0 : β), lin.smul, zero_smul]
 
-@[simp] lemma map_add (x y : β) : f (x + y) = f x + f y :=
+lemma map_add (x y : β) : f (x + y) = f x + f y :=
 by rw [lin.add]
 
-@[simp] lemma map_neg (x : β) : f (- x) = - f x :=
+lemma map_neg (x : β) : f (- x) = - f x :=
 by rw [← neg_one_smul α, lin.smul, neg_one_smul]
 
-@[simp] lemma map_sub (x y : β) : f (x - y) = f x - f y :=
+lemma map_sub (x y : β) : f (x - y) = f x - f y :=
 by simp [lin.map_neg, lin.map_add]
 
 end is_linear_map
@@ -497,4 +497,3 @@ theorem exists_card_smul_ge_sum (hs : s.nonempty) :
 exists_le_of_sum_le hs $ by rw [sum_const, ← nat.smul_def, smul_sum]
 
 end finset
-

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -1818,7 +1818,7 @@ begin
   { rwa [find_cons_of_neg _ h, iff_true_intro h, true_and] }
 end
 
-@[simp] theorem find_some (H : find p l = some a) : p a :=
+theorem find_some (H : find p l = some a) : p a :=
 begin
   induction l with b l IH, {contradiction},
   by_cases h : p b,

--- a/test/lint_simp_var_head.lean
+++ b/test/lint_simp_var_head.lean
@@ -1,0 +1,24 @@
+import tactic.lint
+
+-- The following simp lemma has the variable `f` as head symbol of the left-hand side:
+@[simp] axiom const_zero_eq_zero (f : ℕ → ℕ) (x) : f x = 0
+
+example (f : ℕ → ℕ) : f 42 = 0 :=
+begin
+  -- Hence it doesn't work:
+  success_if_fail {simp},
+
+  -- BTW, rw doesn't work either:
+  success_if_fail {rw const_zero_eq_zero},
+
+  -- It only works if explicitly instantiate with `f`:
+  simp only [const_zero_eq_zero f]
+end
+
+
+open tactic
+#eval do
+decl ← get_decl ``const_zero_eq_zero,
+res ← linter.simp_var_head.test decl,
+-- linter complains
+guard $ res.is_some


### PR DESCRIPTION
Motivation: you write a very useful simp lemma `∀ f : ℕ → ℕ, ∀ x, f x = 0`.  But it doesn't work.  What happened?  The simplifier indexes each simp lemma by the head symbol of the left-hand side.  In this case it is `f`---however it is a fresh temporary meta variable created when adding the simp lemma to the simp set.  Since this meta variable does not occur anywhere else, the lemma will never fire.

This PR introduces a linter for such simp lemmas and fixes all issues in mathlib.