### PR TITLE
feat(tactic/lint): support @[nolint unused_arguments]

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -140,7 +140,8 @@ A linter defined with the name `linter.my_new_check` can be run with `#lint my_n
 or `lint only my_new_check`.
 If you add the attribute `@[linter]` to `linter.my_new_check` it will run by default.
 
-Adding the attribute `@[nolint]` to a declaration omits it from all linter checks.
+Adding the attribute `@[nolint doc_blame unused_arguments]` to a declaration
+omits it from only the specified linter checks.
 
 ## mk_simp_attribute
 

--- a/scripts/mk_all.sh
+++ b/scripts/mk_all.sh
@@ -36,9 +36,5 @@ EOT
 fi
 
 cat <<EOT >> lint_mathlib.lean
-
-open nat -- need to do something before running a command
-
-#lint_mathlib- only unused_arguments dup_namespace doc_blame ge_or_gt def_lemma instance_priority
-  impossible_instance incorrect_type_class_argument dangerous_instance inhabited_nonempty simp_nf
+#eval lint_mathlib_ci
 EOT

--- a/scripts/nolints.txt
+++ b/scripts/nolints.txt
@@ -1,3210 +1,4086 @@
 import .all
 run_cmd tactic.skip
-apply_nolint
-AddCommGroup
-AddCommGroup.of
-AddCommMon
-AddCommMon.of
-AddGroup
-AddGroup.of
-AddMon
-AddMon.of
-Cauchy.extend
-Cauchy.gen
-Class
-CommRing.colimits.cocone_fun
-CommRing.colimits.cocone_morphism
-CommRing.colimits.colimit
-CommRing.colimits.colimit_cocone
-CommRing.colimits.colimit_is_colimit
-CommRing.colimits.colimit_type
-CommRing.colimits.desc_fun
-CommRing.colimits.desc_fun_lift
-CommRing.colimits.desc_morphism
-CommRing.colimits.prequotient
-CommRing.colimits.relation
-CpltSepUniformSpace.to_UniformSpace
-Gromov_Hausdorff.candidates_b_dist
-Meas
-Mon.colimits.cocone_fun
-Mon.colimits.cocone_morphism
-Mon.colimits.colimit
-Mon.colimits.colimit_cocone
-Mon.colimits.colimit_is_colimit
-Mon.colimits.colimit_type
-Mon.colimits.desc_fun
-Mon.colimits.desc_fun_lift
-Mon.colimits.desc_morphism
-Mon.colimits.prequotient
-Mon.colimits.relation
-Set.map_definable_aux
-Set.mem
-Set.mk
-Set.subset
-Top.colimit
-Top.colimit_is_colimit
-Top.limit
-Top.limit_is_limit
-Top.presheaf
-Top.presheaf.pushforward
-Top.presheaf.pushforward.comp
-Top.presheaf.pushforward.id
-Top.presheaf.pushforward_eq
-Top.presheaf.stalk_pushforward
-Well_order
-abelianization
-abelianization.lift
-abelianization.lift.unique
-abelianization.of
-abv_sum_le_sum_abv
-add_comm_group.is_Z_bilin
-add_con.to_setoid
-add_equiv.mk'
-add_equiv.refl
-add_equiv.symm
-add_equiv.to_add_monoid_hom
-add_equiv.to_equiv
-add_equiv.trans
-add_group.closure
-add_group.in_closure
-add_monoid.smul
-add_monoid_hom.add
-add_monoid_hom.comp
-add_monoid_hom.id
-add_monoid_hom.mk'
-add_monoid_hom.neg
-add_monoid_hom.zero
-additive
-adjoin_root
-adjoin_root.lift
-adjoin_root.mk
-adjoin_root.of
-adjoin_root.root
-alg_hom.comp
-alg_hom.id
-alg_hom.range
-alg_hom.to_ring_hom
-algebra.adjoin
-algebra.adjoin_eq_range
-algebra.adjoin_singleton_eq_range
-algebra.comap.comm_ring
-algebra.comap.has_scalar
-algebra.comap.of_comap
-algebra.comap.ring
-algebra.comap.to_comap
-algebra.gi
-algebra.lmul_left
-algebra.lmul_right
-algebra.of_id
-algebra.to_comap
-algebra.to_top
-algebra_map
-algebraic_geometry.PresheafedSpace.comp
-algebraic_geometry.PresheafedSpace.id
-algebraic_geometry.PresheafedSpace.stalk
-algebraic_geometry.PresheafedSpace.stalk_map
-alist.disjoint
-alist.foldl
-applicative_transformation
-apply_fun_name
-archimedean
-archimedean.floor_ring
-associated.setoid
-associates
-associates.factor_set
-associates.factor_set.coe_add
-associates.factor_set.prod
-associates.factors
-associates.factors'
-associates.mk
-associates.out
-associates.prime
-associates.unique'
-associates_int_equiv_nat
-auto.add_conjuncts
-auto.add_simps
-auto.auto_config
-auto.case_hyp
-auto.case_option
-auto.case_some_hyp
-auto.case_some_hyp_aux
-auto.classical_normalize_lemma_names
-auto.common_normalize_lemma_names
-auto.do_subst
-auto.do_substs
-auto.eelim
-auto.eelims
-auto.mk_hinst_lemmas
-auto.normalize_hyp
-auto.normalize_hyps
-auto.normalize_negations
-auto.preprocess_goal
-auto.preprocess_hyps
-auto.split_hyp
-auto.split_hyps
-auto.split_hyps_aux
-auto.whnf_reducible
-auto_cases_at
-bicompl.bitraverse
-bicompr.bitraverse
-bifunctor
-bifunctor.fst
-bifunctor.snd
-bilin_form.bilin_linear_map_equiv
-bilin_form.to_linear_map
-binder_eq_elim
-binder_eq_elim.check
-binder_eq_elim.check_eq
-binder_eq_elim.old_conv
-binder_eq_elim.pull
-binder_eq_elim.push
-bisequence
-bitraversable
-bounded_continuous_function.dist_eq
-bounded_continuous_function.dist_set_exists
-buffer.list_equiv_buffer
-can_lift_attr
-canonically_ordered_comm_semiring
-card_subgroup_dvd_card
-card_trivial
-cardinal.aleph'.order_iso
-cardinal.aleph_idx.initial_seg
-cardinal.aleph_idx.order_iso
-cardinal.cantor_function
-cardinal.cantor_function_aux
-cardinal.ord.order_embedding
-cast_num
-cast_pos_num
-cast_znum
-category_theory.Aut
-category_theory.Kleisli
-category_theory.Kleisli.comp_def
-category_theory.Kleisli.id_def
-category_theory.Kleisli.mk
-category_theory.adjunction.adjunction_of_equiv_left
-category_theory.adjunction.adjunction_of_equiv_right
-category_theory.adjunction.cocones_iso
-category_theory.adjunction.comp
-category_theory.adjunction.cones_iso
-category_theory.adjunction.core_hom_equiv
-category_theory.adjunction.core_unit_counit
-category_theory.adjunction.functoriality_counit
-category_theory.adjunction.functoriality_counit'
-category_theory.adjunction.functoriality_is_left_adjoint
-category_theory.adjunction.functoriality_is_right_adjoint
-category_theory.adjunction.functoriality_left_adjoint
-category_theory.adjunction.functoriality_right_adjoint
-category_theory.adjunction.functoriality_unit
-category_theory.adjunction.functoriality_unit'
-category_theory.adjunction.has_colimit_of_comp_equivalence
-category_theory.adjunction.has_limit_of_comp_equivalence
-category_theory.adjunction.id
-category_theory.adjunction.left_adjoint_of_equiv
-category_theory.adjunction.mk_of_hom_equiv
-category_theory.adjunction.mk_of_unit_counit
-category_theory.adjunction.right_adjoint_of_equiv
-category_theory.as_iso
-category_theory.category_struct
-category_theory.comma
-category_theory.comma.fst
-category_theory.comma.map_left
-category_theory.comma.map_left_comp
-category_theory.comma.map_left_id
-category_theory.comma.map_right
-category_theory.comma.map_right_comp
-category_theory.comma.map_right_id
-category_theory.comma.nat_trans
-category_theory.comma.snd
-category_theory.comma_morphism
-category_theory.core
-category_theory.core.forget_functor_to_core
-category_theory.core.inclusion
-category_theory.coyoneda
-category_theory.coyoneda.is_iso
-category_theory.curry
-category_theory.curry_obj
-category_theory.currying
-category_theory.discrete
-category_theory.discrete.lift
-category_theory.discrete.opposite
-category_theory.epi
-category_theory.eq_to_hom
-category_theory.eq_to_iso
-category_theory.equivalence.adjointify_η
-category_theory.equivalence.counit
-category_theory.equivalence.counit_inv
-category_theory.equivalence.equivalence_of_fully_faithfully_ess_surj
-category_theory.equivalence.ess_surj_of_equivalence
-category_theory.equivalence.fun_inv_id_assoc
-category_theory.equivalence.inv_fun_id_assoc
-category_theory.equivalence.mk
-category_theory.equivalence.refl
-category_theory.equivalence.symm
-category_theory.equivalence.to_adjunction
-category_theory.equivalence.trans
-category_theory.equivalence.unit
-category_theory.equivalence.unit_inv
-category_theory.ess_surj
-category_theory.ess_surj.iso
-category_theory.evaluation
-category_theory.evaluation_uncurried
-category_theory.full_subcategory_inclusion
-category_theory.functor.adjunction
-category_theory.functor.as_equivalence
-category_theory.functor.associator
-category_theory.functor.const
-category_theory.functor.const.op_obj_op
-category_theory.functor.const.op_obj_unop
-category_theory.functor.flip
-category_theory.functor.fun_inv_id
-category_theory.functor.fun_obj_preimage_iso
-category_theory.functor.inv
-category_theory.functor.inv_fun_id
-category_theory.functor.left_op
-category_theory.functor.left_unitor
-category_theory.functor.map_cocone_morphism
-category_theory.functor.map_cone_inv
-category_theory.functor.map_cone_morphism
-category_theory.functor.map_iso
-category_theory.functor.obj_preimage
-category_theory.functor.of_function
-category_theory.functor.op
-category_theory.functor.op_hom
-category_theory.functor.op_inv
-category_theory.functor.right_op
-category_theory.functor.right_unitor
-category_theory.functor.sections
-category_theory.functor.star
-category_theory.functor.to_cocone
-category_theory.functor.to_cone
-category_theory.functor.ulift_down
-category_theory.functor.ulift_down_up
-category_theory.functor.ulift_up
-category_theory.functor.ulift_up_down
-category_theory.functor.unop
-category_theory.has_hom
-category_theory.has_hom.hom.op
-category_theory.has_hom.hom.unop
-category_theory.has_limits_of_reflective
-category_theory.hom_of_element
-category_theory.induced_category
-category_theory.induced_functor
-category_theory.is_equivalence.mk
-category_theory.is_iso_of_fully_faithful
-category_theory.is_iso_of_op
-category_theory.is_left_adjoint
-category_theory.is_right_adjoint
-category_theory.iso
-category_theory.iso.hom_congr
-category_theory.iso.op
-category_theory.iso.refl
-category_theory.iso.symm
-category_theory.iso.to_equiv
-category_theory.iso.trans
-category_theory.iso_whisker_left
-category_theory.iso_whisker_right
-category_theory.large_groupoid
-category_theory.left_adjoint
-category_theory.limits.binary_cofan
-category_theory.limits.binary_cofan.mk
-category_theory.limits.binary_fan
-category_theory.limits.binary_fan.mk
-category_theory.limits.cocone.equiv
-category_theory.limits.cocone.extensions
-category_theory.limits.cocone.of_cofork
-category_theory.limits.cocone.of_pushout_cocone
-category_theory.limits.cocone.whisker
-category_theory.limits.cocone_left_op_of_cone
-category_theory.limits.cocone_morphism
-category_theory.limits.cocone_of_cone_left_op
-category_theory.limits.cocones.forget
-category_theory.limits.cocones.functoriality
-category_theory.limits.cocones.precompose
-category_theory.limits.cocones.precompose_comp
-category_theory.limits.cocones.precompose_equivalence
-category_theory.limits.cocones.precompose_id
-category_theory.limits.coequalizer
-category_theory.limits.coequalizer.desc
-category_theory.limits.coequalizer.π
-category_theory.limits.cofan
-category_theory.limits.cofan.mk
-category_theory.limits.cofork
-category_theory.limits.cofork.of_cocone
-category_theory.limits.cofork.of_π
-category_theory.limits.cofork.π
-category_theory.limits.colim_coyoneda
-category_theory.limits.colimit
-category_theory.limits.colimit.cocone
-category_theory.limits.colimit.cocone_morphism
-category_theory.limits.colimit.desc
-category_theory.limits.colimit.hom_iso
-category_theory.limits.colimit.hom_iso'
-category_theory.limits.colimit.is_colimit
-category_theory.limits.colimit.post
-category_theory.limits.colimit.pre
-category_theory.limits.colimit.ι
-category_theory.limits.cone.equiv
-category_theory.limits.cone.extensions
-category_theory.limits.cone.of_fork
-category_theory.limits.cone.of_pullback_cone
-category_theory.limits.cone.whisker
-category_theory.limits.cone_left_op_of_cocone
-category_theory.limits.cone_morphism
-category_theory.limits.cone_of_cocone_left_op
-category_theory.limits.cones.forget
-category_theory.limits.cones.functoriality
-category_theory.limits.cones.postcompose
-category_theory.limits.cones.postcompose_comp
-category_theory.limits.cones.postcompose_equivalence
-category_theory.limits.cones.postcompose_id
-category_theory.limits.coprod
-category_theory.limits.coprod.desc
-category_theory.limits.coprod.inl
-category_theory.limits.coprod.inr
-category_theory.limits.coprod.map
-category_theory.limits.equalizer
-category_theory.limits.equalizer.lift
-category_theory.limits.equalizer.ι
-category_theory.limits.evaluate_functor_category_colimit_cocone
-category_theory.limits.evaluate_functor_category_limit_cone
-category_theory.limits.fan
-category_theory.limits.fan.mk
-category_theory.limits.fork
-category_theory.limits.fork.of_cone
-category_theory.limits.fork.of_ι
-category_theory.limits.fork.ι
-category_theory.limits.functor_category_colimit_cocone
-category_theory.limits.functor_category_is_colimit_cocone
-category_theory.limits.functor_category_is_limit_cone
-category_theory.limits.functor_category_limit_cone
-category_theory.limits.has_binary_coproducts
-category_theory.limits.has_binary_products
-category_theory.limits.has_colimit_of_equivalence_comp
-category_theory.limits.has_colimit_of_iso
-category_theory.limits.has_colimits_of_shape_of_equivalence
-category_theory.limits.has_coproducts
-category_theory.limits.has_finite_colimits
-category_theory.limits.has_finite_coproducts
-category_theory.limits.has_finite_limits
-category_theory.limits.has_finite_products
-category_theory.limits.has_limit_of_equivalence_comp
-category_theory.limits.has_limit_of_iso
-category_theory.limits.has_limits_of_shape_of_equivalence
-category_theory.limits.has_products
-category_theory.limits.has_pullbacks
-category_theory.limits.has_pushouts
-category_theory.limits.initial
-category_theory.limits.is_colimit.desc_cocone_morphism
-category_theory.limits.is_colimit.hom_iso'
-category_theory.limits.is_colimit.iso_unique_cocone_morphism
-category_theory.limits.is_colimit.mk_cocone_morphism
-category_theory.limits.is_colimit.of_iso_colimit
-category_theory.limits.is_limit.hom_iso'
-category_theory.limits.is_limit.iso_unique_cone_morphism
-category_theory.limits.is_limit.lift_cone_morphism
-category_theory.limits.is_limit.mk_cone_morphism
-category_theory.limits.is_limit.of_iso_limit
-category_theory.limits.lim_yoneda
-category_theory.limits.limit
-category_theory.limits.limit.cone
-category_theory.limits.limit.cone_morphism
-category_theory.limits.limit.hom_iso
-category_theory.limits.limit.hom_iso'
-category_theory.limits.limit.is_limit
-category_theory.limits.limit.lift
-category_theory.limits.limit.post
-category_theory.limits.limit.pre
-category_theory.limits.limit.π
-category_theory.limits.map_pair
-category_theory.limits.pair
-category_theory.limits.pair_function
-category_theory.limits.parallel_pair
-category_theory.limits.pi.lift
-category_theory.limits.pi.map
-category_theory.limits.pi.π
-category_theory.limits.preserves_colimit
-category_theory.limits.preserves_colimits
-category_theory.limits.preserves_colimits_of_shape
-category_theory.limits.preserves_limit
-category_theory.limits.preserves_limits
-category_theory.limits.preserves_limits_of_shape
-category_theory.limits.prod
-category_theory.limits.prod.fst
-category_theory.limits.prod.lift
-category_theory.limits.prod.map
-category_theory.limits.prod.snd
-category_theory.limits.pullback.fst
-category_theory.limits.pullback.lift
-category_theory.limits.pullback.snd
-category_theory.limits.pullback_cone
-category_theory.limits.pullback_cone.fst
-category_theory.limits.pullback_cone.mk
-category_theory.limits.pullback_cone.of_cone
-category_theory.limits.pullback_cone.snd
-category_theory.limits.pushout.desc
-category_theory.limits.pushout.inl
-category_theory.limits.pushout.inr
-category_theory.limits.pushout_cocone
-category_theory.limits.pushout_cocone.inl
-category_theory.limits.pushout_cocone.inr
-category_theory.limits.pushout_cocone.mk
-category_theory.limits.pushout_cocone.of_cocone
-category_theory.limits.reflects_colimit
-category_theory.limits.reflects_colimits
-category_theory.limits.reflects_colimits_of_shape
-category_theory.limits.reflects_limit
-category_theory.limits.reflects_limits
-category_theory.limits.reflects_limits_of_shape
-category_theory.limits.sigma.desc
-category_theory.limits.sigma.map
-category_theory.limits.sigma.ι
-category_theory.limits.terminal
-category_theory.limits.types.colimit
-category_theory.limits.types.colimit_is_colimit
-category_theory.limits.types.limit
-category_theory.limits.types.limit_is_limit
-category_theory.limits.types.types_colimit_pre
-category_theory.limits.walking_cospan.hom.comp
-category_theory.limits.walking_parallel_pair_hom.comp
-category_theory.limits.walking_span.hom.comp
-category_theory.monad
-category_theory.monad.algebra.hom
-category_theory.monad.algebra.hom.comp
-category_theory.monad.algebra.hom.id
-category_theory.monad.comparison
-category_theory.monad.comparison_forget
-category_theory.monad.forget
-category_theory.monad.forget_creates_limits
-category_theory.monad.forget_creates_limits.c
-category_theory.monad.forget_creates_limits.cone_point
-category_theory.monad.forget_creates_limits.γ
-category_theory.monad.free
-category_theory.monadic_creates_limits
-category_theory.mono
-category_theory.monoidal_functor.ε_iso
-category_theory.monoidal_functor.μ_iso
-category_theory.nat_iso.hcomp
-category_theory.nat_iso.is_iso_app_of_is_iso
-category_theory.nat_iso.is_iso_of_is_iso_app
-category_theory.nat_iso.of_components
-category_theory.nat_iso.of_isos
-category_theory.nat_iso.op
-category_theory.nat_trans.left_op
-category_theory.nat_trans.of_function
-category_theory.nat_trans.of_homs
-category_theory.nat_trans.on_presheaf
-category_theory.nat_trans.op
-category_theory.nat_trans.right_op
-category_theory.nat_trans.unop
-category_theory.obviously'
-category_theory.op_op
-category_theory.over
-category_theory.over.colimit
-category_theory.over.forget
-category_theory.over.forget_colimit_is_colimit
-category_theory.over.hom_mk
-category_theory.over.map
-category_theory.over.mk
-category_theory.over.post
-category_theory.prod.associativity
-category_theory.prod.associator
-category_theory.prod.braiding
-category_theory.prod.inverse_associator
-category_theory.prod.swap
-category_theory.prod.symmetry
-category_theory.representable
-category_theory.right_adjoint
-category_theory.single_obj
-category_theory.single_obj.star
-category_theory.small_groupoid
-category_theory.sum.associativity
-category_theory.sum.associator
-category_theory.sum.inverse_associator
-category_theory.ulift_functor
-category_theory.ulift_trivial
-category_theory.uncurry
-category_theory.under
-category_theory.under.forget
-category_theory.under.forget_limit_is_limit
-category_theory.under.hom_mk
-category_theory.under.limit
-category_theory.under.map
-category_theory.under.mk
-category_theory.under.post
-category_theory.whisker_left
-category_theory.whisker_right
-category_theory.whiskering_left
-category_theory.whiskering_right
-category_theory.yoneda
-category_theory.yoneda.is_iso
-category_theory.yoneda_evaluation
-category_theory.yoneda_lemma
-category_theory.yoneda_pairing
-category_theory.yoneda_sections
-category_theory.yoneda_sections_small
-cau_seq
-cau_seq.abv_pos_of_not_lim_zero
-cau_seq.bounded'
-cau_seq.cauchy
-cau_seq.cauchy₂
-cau_seq.cauchy₃
-cau_seq.completion.Cauchy
-cau_seq.completion.discrete_field
-cau_seq.completion.mk
-cau_seq.completion.of_rat
-cau_seq.equiv_def₃
-cau_seq.inv
-cau_seq.inv_aux
-cau_seq.is_complete
-cau_seq.lim
-cau_seq.lim_zero
-cau_seq.of_eq
-cauchy_product
-cauchy_seq_bdd
-centralizer.add_submonoid
-cfilter.to_realizer
-classical.DLO
-classical.all_definable
-classical.exists_cases
-comm_ring.anti_equiv_to_equiv
-comm_ring.equiv_to_anti_equiv
-commutator
-comp.seq
-compact.realizer
-completion
-complex
-complex.I
-complex.abs
-complex.cau_seq_abs
-complex.cau_seq_conj
-complex.cau_seq_im
-complex.cau_seq_re
-complex.conj
-complex.cos
-complex.cosh
-complex.exp
-complex.exp'
-complex.lim_aux
-complex.norm_sq
-complex.of_real
-complex.real_prod_equiv
-complex.sin
-complex.sinh
-complex.tan
-complex.tanh
-computable
-computable_pred
-computable₂
-computation.bind.F
-computation.bind.G
-computation.bisim_o
-computation.cases_on
-computation.corec.F
-computation.is_bisimulation
-computation.lift_rel_aux
-computation.map_congr
-computation.mem
-computation.mem_rec_on
-computation.parallel.aux1
-computation.parallel.aux2
-computation.parallel_rec
-computation.terminates_rec_on
-con.to_setoid
-const.bitraverse
-constr_smul
-cont
-cont_t
-cont_t.map
-cont_t.monad_lift
-cont_t.run
-cont_t.with_cont_t
-continuous.comap
-continuous_map
-continuous_map.coev
-continuous_map.compact_open.gen
-continuous_map.ev
-continuous_map.induced
-conv.discharge_eq_lhs
-conv.interactive.erw
-conv.interactive.norm_cast
-conv.interactive.norm_num
-conv.interactive.norm_num1
-conv.interactive.ring
-conv.interactive.ring2
-conv.repeat_count
-conv.repeat_with_results
-conv.replace_lhs
-conv.slice
-conv.slice_lhs
-conv.slice_rhs
-ctop.realizer.id
-ctop.realizer.nhds
-ctop.realizer.nhds_F
-ctop.realizer.nhds_σ
-ctop.realizer.of_equiv
-ctop.to_realizer
-decidable.lt_by_cases
-decidable_linear_order.lift
-decidable_linear_order_of_is_well_order
-decidable_of_bool
-decidable_of_iff
-decidable_of_iff'
-decidable_zero_symm
-declaration.update_with_fun
-dense_or_discrete
-denumerable.equiv₂
-denumerable.eqv
-denumerable.lower
-denumerable.lower'
-denumerable.mk'
-denumerable.of_encodable_of_infinite
-denumerable.of_equiv
-denumerable.of_nat
-denumerable.pair
-denumerable.raise
-denumerable.raise'
-denumerable.raise'_finset
-dfinsupp
-dfinsupp.decidable_eq
-dfinsupp.erase
-dfinsupp.lmk
-dfinsupp.lsingle
-dfinsupp.map_range_def
-dfinsupp.map_range_single
-dfinsupp.mk
-dfinsupp.pre
-dfinsupp.single
-dfinsupp.subtype_domain_sum
-dfinsupp.sum_apply
-dfinsupp.support
-dfinsupp.to_has_scalar
-dfinsupp.to_module
-dfinsupp.zip_with
-dfinsupp.zip_with_def
-dioph.pell_dioph
-dioph.xn_dioph
-direct_sum
-direct_sum.component
-direct_sum.id
-direct_sum.lid
-direct_sum.lmk
-direct_sum.lof
-direct_sum.lset_to_set
-direct_sum.mk
-direct_sum.of
-direct_sum.set_to_set
-direct_sum.to_group
-direct_sum.to_module
-directed_order
-dlist.join
-dlist.list_equiv_dlist
-eckmann_hilton.comm_group
-eckmann_hilton.comm_monoid
-eckmann_hilton.is_unital
-emetric.cauchy_iff
-emetric.cauchy_seq_iff
-emetric.cauchy_seq_iff'
-emetric.exists_ball_subset_ball
-emetric.is_open_iff
-emetric.mem_nhds_iff
-emetric.nhds_eq
-emetric.tendsto_at_top
-emetric.tendsto_nhds
-emetric.totally_bounded_iff
-emetric.totally_bounded_iff'
-emetric.uniform_continuous_iff
-emetric.uniform_embedding_iff
-emetric.uniform_embedding_iff'
-empty.elim
-enat
-encodable.choose
-encodable.choose_x
-encodable.decidable_eq_of_encodable
-encodable.decidable_range_encode
-encodable.decode2
-encodable.decode_list
-encodable.decode_multiset
-encodable.decode_sigma
-encodable.decode_subtype
-encodable.decode_sum
-encodable.encodable_of_list
-encodable.encode_list
-encodable.encode_multiset
-encodable.encode_sigma
-encodable.encode_subtype
-encodable.encode_sum
-encodable.equiv_range_encode
-encodable.fintype_arrow
-encodable.fintype_pi
-encodable.of_inj
-encodable.of_left_injection
-encodable.of_left_inverse
-encodable.trunc_encodable_of_fintype
-ennreal.ennreal_equiv_nnreal
-ennreal.ennreal_equiv_sum
-ennreal.nhds_of_ne_top
-ennreal.tendsto_at_top
-ennreal.tendsto_nhds
-equiv.Pi_congr_right
-equiv.Pi_curry
-equiv.Prop_equiv_bool
-equiv.add_comm_group
-equiv.add_comm_monoid
-equiv.add_comm_semigroup
-equiv.add_group
-equiv.add_left
-equiv.add_monoid
-equiv.add_right
-equiv.add_semigroup
-equiv.array_equiv_fin
-equiv.arrow_arrow_equiv_prod_arrow
-equiv.arrow_congr
-equiv.arrow_prod_equiv_prod_arrow
-equiv.arrow_punit_equiv_punit
-equiv.bool_equiv_punit_sum_punit
-equiv.bool_prod_equiv_sum
-equiv.bool_prod_nat_equiv_nat
-equiv.cast
-equiv.comm_group
-equiv.comm_monoid
-equiv.comm_ring
-equiv.comm_semigroup
-equiv.comm_semiring
-equiv.conj
-equiv.d_array_equiv_fin
-equiv.decidable_eq
-equiv.decidable_eq_of_equiv
-equiv.discrete_field
-equiv.division_ring
-equiv.domain
-equiv.empty_arrow_equiv_punit
-equiv.empty_equiv_pempty
-equiv.empty_of_not_nonempty
-equiv.empty_prod
-equiv.empty_sum
-equiv.equiv_congr
-equiv.equiv_empty
-equiv.equiv_pempty
-equiv.false_arrow_equiv_punit
-equiv.false_equiv_empty
-equiv.false_equiv_pempty
-equiv.field
-equiv.fin_equiv_subtype
-equiv.functor
-equiv.group
-equiv.has_add
-equiv.has_inv
-equiv.has_mul
-equiv.has_neg
-equiv.has_one
-equiv.has_zero
-equiv.inhabited_of_equiv
-equiv.int_equiv_nat
-equiv.int_equiv_nat_sum_nat
-equiv.integral_domain
-equiv.inv
-equiv.is_lawful_traversable
-equiv.is_lawful_traversable'
-equiv.list_equiv_of_equiv
-equiv.list_equiv_self_of_equiv_nat
-equiv.list_nat_equiv_nat
-equiv.map
-equiv.monoid
-equiv.mul_left
-equiv.mul_right
-equiv.nat_equiv_nat_sum_punit
-equiv.nat_prod_nat_equiv_nat
-equiv.nat_sum_nat_equiv_nat
-equiv.nat_sum_punit_equiv_nat
-equiv.neg
-equiv.nonzero_comm_ring
-equiv.of_bijective
-equiv.option_equiv_sum_punit
-equiv.pempty_arrow_equiv_punit
-equiv.pempty_equiv_pempty
-equiv.pempty_of_not_nonempty
-equiv.pempty_prod
-equiv.pempty_sum
-equiv.perm.card_support_swap
-equiv.perm.cycle_factors
-equiv.perm.cycle_factors_aux
-equiv.perm.cycle_of
-equiv.perm.disjoint
-equiv.perm.eq_swap_of_is_cycle_of_apply_apply_eq_self
-equiv.perm.is_cycle
-equiv.perm.is_cycle_swap
-equiv.perm.is_cycle_swap_mul_aux₁
-equiv.perm.is_swap
-equiv.perm.of_subtype
-equiv.perm.same_cycle
-equiv.perm.sign_aux
-equiv.perm.sign_aux2
-equiv.perm.sign_aux3
-equiv.perm.sign_bij_aux
-equiv.perm.sign_cycle
-equiv.perm.subtype_perm
-equiv.perm.support
-equiv.perm.support_swap
-equiv.perm.swap_factors_aux
-equiv.perm.trunc_swap_factors
-equiv.perm_congr
-equiv.pi_equiv_subtype_sigma
-equiv.plift
-equiv.pnat_equiv_nat
-equiv.prod_assoc
-equiv.prod_comm
-equiv.prod_congr
-equiv.prod_empty
-equiv.prod_equiv_of_equiv_nat
-equiv.prod_pempty
-equiv.prod_punit
-equiv.prod_sum_distrib
-equiv.prop_equiv_punit
-equiv.psigma_equiv_sigma
-equiv.psum_equiv_sum
-equiv.punit_arrow_equiv
-equiv.punit_equiv_punit
-equiv.punit_prod
-equiv.refl
-equiv.ring
-equiv.semigroup
-equiv.semiring
-equiv.set.congr
-equiv.set.empty
-equiv.set.image
-equiv.set.image_of_inj_on
-equiv.set.insert
-equiv.set.of_eq
-equiv.set.pempty
-equiv.set.prod
-equiv.set.range
-equiv.set.sep
-equiv.set.singleton
-equiv.set.sum_compl
-equiv.set.union
-equiv.set.union'
-equiv.set.union_sum_inter
-equiv.set.univ
-equiv.set_congr
-equiv.sigma_congr_left
-equiv.sigma_congr_right
-equiv.sigma_equiv_prod
-equiv.sigma_equiv_prod_of_equiv
-equiv.sigma_preimage_equiv
-equiv.sigma_prod_distrib
-equiv.sigma_subtype_preimage_equiv
-equiv.sigma_subtype_preimage_equiv_subtype
-equiv.subtype_congr
-equiv.subtype_congr_prop
-equiv.subtype_congr_right
-equiv.subtype_equiv_of_subtype'
-equiv.subtype_pi_equiv_pi
-equiv.subtype_quotient_equiv_quotient_subtype
-equiv.subtype_subtype_equiv_subtype_exists
-equiv.subtype_subtype_equiv_subtype_inter
-equiv.sum_arrow_equiv_prod_arrow
-equiv.sum_assoc
-equiv.sum_comm
-equiv.sum_congr
-equiv.sum_empty
-equiv.sum_equiv_sigma_bool
-equiv.sum_pempty
-equiv.sum_prod_distrib
-equiv.swap_core
-equiv.symm
-equiv.to_embedding
-equiv.to_iso
-equiv.to_pequiv
-equiv.trans
-equiv.traversable
-equiv.traverse
-equiv.true_equiv_punit
-equiv.ulift
-equiv.unique_congr
-equiv.unique_of_equiv
-equiv.units_equiv_ne_zero
-equiv.vector_equiv_array
-equiv.vector_equiv_fin
-equiv.zero_ne_one_class
-equiv_of_dim_eq_dim
-equiv_of_unique_of_unique
-equiv_punit_of_unique
-equiv_type_constr
-erased.bind
-erased.choice
-erased.equiv
-erased.join
-erased.mk
-erased.out
-erased.out_type
-euclidean_domain
-euclidean_domain.gcd
-euclidean_domain.lcm
-euclidean_domain.xgcd_aux
-except_t.call_cc
-except_t.mk_label
-except_t.pass_aux
-exists.classical_rec_on
-exists_eq_elim
-exists_forall_ge_and
-exists_gpow_eq_one
-exists_pow_eq_one
-expr.flip_eq
-expr.flip_iff
-expr.get_pis
-ext_param
-ext_param_type
-field.closure
-field.direct_limit.discrete_field
-field.direct_limit.field
-field.direct_limit.inv
-filter
-filter.Liminf
-filter.Limsup
-filter.gi_generate
-filter.hyperfilter
-filter.is_bounded_default
-filter.is_bounded_ge_of_bot
-filter.is_bounded_under
-filter.is_bounded_under_inf
-filter.is_cobounded_ge_of_top
-filter.is_cobounded_under
-filter.is_trans_ge
-filter.liminf
-filter.liminf_eq_supr_infi_of_nat
-filter.limsup
-filter.limsup_eq_infi_supr_of_nat
-filter.mem_at_top_sets
-filter.mk_of_closure
-filter.monad
-filter.pcomap'
-filter.pmap
-filter.pointwise_add
-filter.pointwise_add_add_monoid
-filter.pointwise_mul
-filter.pointwise_mul_monoid
-filter.pointwise_one
-filter.pointwise_zero
-filter.ptendsto
-filter.ptendsto'
-filter.rcomap
-filter.rcomap'
-filter.realizer.of_eq
-filter.rmap
-filter.rtendsto
-filter.rtendsto'
-filter.tendsto_at_top'
-filter.tendsto_at_top_at_bot
-filter.tendsto_at_top_principal
-filter.ultrafilter.bind
-filter.ultrafilter.map
-filter.ultrafilter.pure
-fin.add_nat_val
-fin.cases
-fin.clamp
-fin.succ_rec
-fin.succ_rec_on
-fin2.cases'
-fin2.elim0
-fin_dim_vectorspace_equiv
-fin_one_equiv
-fin_prod_fin_equiv
-fin_two_equiv
-fin_zero_elim'
-fin_zero_equiv
-find_cmd
-finite_field.field_of_integral_domain
-finmap.all
-finmap.any
-finmap.disjoint
-finmap.foldl
-finmap.sdiff
-finset.attach_fin
-finset.choose
-finset.choose_x
-finset.empty
-finset.insert_none
-finset.map
-finset.map_embedding
-finset.max
-finset.max'
-finset.min
-finset.min'
-finset.pi
-finset.pi.cons
-finset.pi.empty
-finset.powerset_len
-finset.preimage
-finset.prod_ite
-finset.strong_induction_on
-finset.subtype
-finset.sum
-finset.sum_ite
-finsets
-finsupp.antidiagonal
-finsupp.comap_domain
-finsupp.congr
-finsupp.curry
-finsupp.dom_congr
-finsupp.dom_lcongr
-finsupp.equiv_fun_on_fintype
-finsupp.equiv_multiset
-finsupp.erase
-finsupp.finsupp_prod_equiv
-finsupp.frange
-finsupp.lapply
-finsupp.lmap_domain
-finsupp.lsingle
-finsupp.lsubtype_domain
-finsupp.lsum
-finsupp.of_multiset
-finsupp.restrict_dom
-finsupp.restrict_support_equiv
-finsupp.split
-finsupp.split_comp
-finsupp.split_support
-finsupp.supported
-finsupp.supported_eq_span_single
-finsupp.supported_equiv_finsupp
-finsupp.to_multiset
-finsupp.total_on
-finsupp.uncurry
-fintype.bij_inv
-fintype.choose
-fintype.choose_x
-fintype.fintype_prod_left
-fintype.fintype_prod_right
-fintype.of_injective
-fintype.of_subsingleton
-fintype.subtype
-fintype_perm
-flip.bitraverse
-forall_eq_elim
-fp.div_nat_lt_two_pow
-fp.emax
-fp.emin
-fp.float
-fp.float.add
-fp.float.div
-fp.float.is_finite
-fp.float.is_zero
-fp.float.mul
-fp.float.neg
-fp.float.sign
-fp.float.sign'
-fp.float.sub
-fp.float.zero
-fp.float_cfg
-fp.next_dn
-fp.next_dn_pos
-fp.next_up
-fp.next_up_pos
-fp.of_pos_rat_dn
-fp.of_rat
-fp.of_rat_dn
-fp.of_rat_up
-fp.prec
-fp.rmode
-fp.to_rat
-fp.valid_finite
-free_abelian_group
-free_abelian_group.lift
-free_abelian_group.lift.universal
-free_abelian_group.of
-free_add_monoid
-free_comm_ring
-free_comm_ring.is_supported
-free_comm_ring.lift
-free_comm_ring.map
-free_comm_ring.of
-free_comm_ring.restriction
-free_comm_ring_equiv_mv_polynomial_int
-free_comm_ring_pempty_equiv_int
-free_comm_ring_punit_equiv_polynomial_int
-free_group.free_group_empty_equiv_unit
-free_group.free_group_unit_equiv_int
-free_group.map.aux
-free_group.mk
-free_group.to_group.aux
-free_magma
-free_magma.length
-free_magma.lift
-free_magma.map
-free_magma.repr'
-free_magma.traverse
-free_monoid
-free_ring
-free_ring.lift
-free_ring.map
-free_ring.of
-free_ring.subsingleton_equiv_free_comm_ring
-free_ring.to_free_comm_ring
-free_ring_pempty_equiv_int
-free_ring_punit_equiv_polynomial_int
-free_semigroup
-free_semigroup.lift
-free_semigroup.lift'
-free_semigroup.map
-free_semigroup.of
-free_semigroup.traverse
-free_semigroup.traverse'
-free_semigroup_free_magma
-function.bicompl
-function.bicompr
-function.embedding
-function.embedding.Pi_congr_right
-function.embedding.arrow_congr_left
-function.embedding.arrow_congr_right
-function.embedding.congr
-function.embedding.equiv_of_surjective
-function.embedding.image
-function.embedding.of_not_nonempty
-function.embedding.of_surjective
-function.embedding.prod_congr
-function.embedding.refl
-function.embedding.set_value
-function.embedding.sigma_congr_right
-function.embedding.subtype
-function.embedding.subtype_map
-function.embedding.sum_congr
-function.embedding.trans
-function.injective.decidable_eq
-function.involutive.to_equiv
-function.restrict
-function.uncurry'
-functor.add_const
-functor.add_const.mk
-functor.add_const.run
-functor.comp.map
-functor.comp.mk
-functor.comp.run
-functor.const.mk
-functor.const.mk'
-functor.const.run
-functor.map_equiv
-gaussian_int
-gaussian_int.div
-gaussian_int.mod
-gaussian_int.to_complex
-ge.is_antisymm
-ge.is_linear_order
-ge.is_partial_order
-ge.is_preorder
-ge.is_refl
-ge.is_total
-ge.is_total_preorder
-ge.is_trans
-ge_from_le
-ge_iff_le
-ge_of_eq
-get_ext_subject
-gmultiples
-gpowers
-group.in_closure
-gsmul
-gt.is_antisymm
-gt.is_asymm
-gt.is_irrefl
-gt.is_strict_order
-gt.is_trans
-gt.is_trichotomous
-gt_from_lt
-gt_iff_lt
-gt_of_mul_lt_mul_neg_right
-has_edist
-has_inner
-hash_map.mk_as_list
-hash_map.valid.modify
-hidden
-holor.assoc_left
-holor.assoc_right
-holor_index.assoc_left
-holor_index.assoc_right
-holor_index.drop
-holor_index.take
-homemorph.to_measurable_equiv
-homeomorph.add_left
-homeomorph.add_right
-homeomorph.homeomorph_of_continuous_open
-homeomorph.inv
-homeomorph.mul_left
-homeomorph.mul_right
-homeomorph.neg
-homeomorph.prod_assoc
-homeomorph.prod_comm
-homeomorph.prod_congr
-homeomorph.refl
-homeomorph.sigma_prod_distrib
-homeomorph.symm
-homeomorph.trans
-hyperreal.gt_of_neg_of_infinitesimal
-hyperreal.infinite_pos_def
-hyperreal.infinite_pos_iff_infinite_and_pos
-hyperreal.infinite_pos_iff_infinitesimal_inv_pos
-hyperreal.infinitesimal_def
-hyperreal.infinitesimal_pos_iff_infinite_pos_inv
-hyperreal.is_st_iff_abs_sub_lt_delta
-hyperreal.lt_neg_of_pos_of_infinitesimal
-hyperreal.pos_of_infinite_pos
-id.mk
-ideal
-ideal.closure
-ideal.is_coprime
-ideal.is_maximal
-ideal.is_prime
-ideal.is_principal
-ideal.is_principal.generator
-ideal.le_order_embedding_of_surjective
-ideal.lt_order_embedding_of_surjective
-ideal.map
-ideal.quotient
-ideal.quotient.lift
-ideal.quotient.map_mk
-ideal.quotient.mk
-ideal.quotient.nonzero_comm_ring
-ideal.quotient_inf_to_pi_quotient
-ideal.span
-inducing
-infi_eq_elim
-infi_real_pos_eq_infi_nnreal_pos
-infinite
-infinite.nat_embedding
-initial_seg.le_add
-initial_seg.le_lt
-initial_seg.lt_or_eq
-int.bit_cases_on
-int.div_eq_div_of_mul_eq_mul
-int.eq_mul_div_of_mul_eq_mul_of_dvd_left
-int.even
-int.induction_on'
-int.modeq
-int.of_snum
-int.range
-int.shift2
-int.to_nat'
-integral_closure
-irrational
-is_absolute_value.mem_uniformity
-is_add_group_hom.ker
-is_add_group_hom.to_linear_map
-is_add_subgroup.add_center
-is_add_subgroup.add_normalizer
-is_add_subgroup.group_equiv_quotient_times_subgroup
-is_add_subgroup.left_coset_equiv_subgroup
-is_add_subgroup.normalizer_is_add_subgroup
-is_add_subgroup.trivial
-is_basis.coord_fun
-is_basis.repr
-is_basis.to_dual_flip
-is_cau_seq.cauchy₂
-is_cau_seq.cauchy₃
-is_cau_series_of_abv_le_cau
-is_closed_map
-is_comm_applicative
-is_conj
-is_cyclic
-is_cyclic.comm_group
-is_group_hom.ker
-is_integral
-is_lawful_bifunctor
-is_lawful_bitraversable
-is_lawful_monad_cont
-is_lawful_traversable
-is_linear_map
-is_linear_map.mk'
-is_local_ring
-is_local_ring_hom
-is_noetherian
-is_noetherian_iff_well_founded
-is_noetherian_ring
-is_null_measurable
-is_ring_anti_hom
-is_ring_hom.ker
-is_ring_hom.to_module
-is_subfield
-is_subgroup.center
-is_subgroup.group_equiv_quotient_times_subgroup
-is_subgroup.left_coset_equiv_subgroup
-is_subgroup.normalizer
-is_subgroup.normalizer_is_subgroup
-lattice.Inf_eq_bot
-lattice.complete_lattice.copy
-lattice.conditionally_complete_linear_order
-lattice.conditionally_complete_linear_order_bot
-lattice.fixed_points
-lattice.fixed_points.next
-lattice.fixed_points.next_fixed
-lattice.fixed_points.prev
-lattice.fixed_points.prev_fixed
-lattice.infi_eq_bot
-lazy_list.list_equiv_lazy_list
-lazy_list.traverse
-lean.parser.get_includes
-lean.parser.get_namespace
-lean.parser.get_variables
-lebesgue_number_lemma_of_metric
-lebesgue_number_lemma_of_metric_sUnion
-left_add_coset
-left_add_coset_equiv
-left_coset
-left_coset_equiv
-lex
-linarith.add_exprs
-linarith.add_exprs_aux
-linarith.add_neg_eq_pfs
-linarith.cast_expr
-linarith.comp.add
-linarith.comp.coeff_of
-linarith.comp.is_contr
-linarith.comp.lt
-linarith.comp.scale
-linarith.comp_source
-linarith.comp_source.flatten
-linarith.comp_source.to_string
-linarith.elab_arg_list
-linarith.elim_all_vars
-linarith.elim_with_set
-linarith.expr_contains
-linarith.find_cancel_factor
-linarith.find_contr
-linarith.get_comps
-linarith.get_contr_lemma_name
-linarith.get_nat_comps
-linarith.get_rel_sides
-linarith.get_var_list
-linarith.get_vars
-linarith.guard_is_nat_prop
-linarith.guard_is_strict_int_prop
-linarith.ineq
-linarith.ineq.is_lt
-linarith.ineq.max
-linarith.ineq.to_string
-linarith.ineq_const_mul_nm
-linarith.ineq_const_nm
-linarith.ineq_pf_tp
-linarith.is_nat_int_coe
-linarith.is_numeric
-linarith.linarith_config
-linarith.linarith_monad
-linarith.linarith_monad.run
-linarith.list.mfind
-linarith.map_lt
-linarith.map_of_expr_mul_aux
-linarith.mk_cast_eq_and_nonneg_prfs
-linarith.mk_coe_nat_nonneg_prf
-linarith.mk_coe_nat_nonneg_prfs
-linarith.mk_int_pfs_of_nat_pf
-linarith.mk_lt_zero_pf_aux
-linarith.mk_neg_one_lt_zero_pf
-linarith.mk_non_strict_int_pf_of_strict_int_pf
-linarith.mk_prod_prf
-linarith.mk_single_comp_zero_pf
-linarith.monad.elim_var
-linarith.mul_eq
-linarith.mul_expr
-linarith.norm_hyp
-linarith.norm_hyp_aux
-linarith.parse_into_comp_and_expr
-linarith.partition_by_type
-linarith.partition_by_type_aux
-linarith.pcomp
-linarith.pcomp.add
-linarith.pcomp.is_contr
-linarith.pcomp.scale
-linarith.pelim_var
-linarith.preferred_type_of_goal
-linarith.rb_map.find_defeq
-linarith.rearr_comp
-linarith.rem_neg
-linarith.replace_nat_pfs
-linarith.replace_strict_int_pfs
-linarith.term_of_ineq_prf
-linarith.to_comp
-linarith.to_comp_fold
-linarith.update
-linarith.validate
-linear_equiv.to_equiv
-linear_equiv.to_linear_map
-linear_equiv_matrix
-linear_independent_monoid_hom
-linear_map
-linear_map.comp
-linear_map.compl₂
-linear_map.compr₂
-linear_map.flip
-linear_map.id
-linear_map.lcomp
-linear_map.lflip
-linear_map.llcomp
-linear_map.lsmul
-linear_map.map_finsupp_total
-linear_map.mk₂
-linear_map.to_bilin
-linear_order.lift
-list.choose
-list.choose_x
-list.comp_traverse
-list.erase_dupkeys
-list.erasep
-list.extractp
-list.find_indexes_aux
-list.forall₂
-list.func.add
-list.func.equiv
-list.func.get
-list.func.neg
-list.func.pointwise
-list.func.set
-list.func.sub
-list.head'
-list.insert_nth
-list.kextract
-list.kreplace
-list.lex
-list.map_head
-list.map_last
-list.map_with_index
-list.map_with_index_core
-list.mem_ext
-list.mmap_accuml
-list.mmap_accumr
-list.mpartition
-list.nodupkeys
-list.of_fn
-list.of_fn_aux
-list.of_fn_nth_val
-list.pairwise_gt_iota
-list.partition_map
-list.permutations_aux
-list.permutations_aux.rec
-list.permutations_aux2
-list.reduce_option
-list.reverse_rec_on
-list.revzip
-list.scanr_aux
-list.split_on_p_aux
-list.sublists'_aux
-list.sublists_aux
-list.sublists_aux₁
-list.sublists_len
-list.sublists_len_aux
-list.take'
-list.tfae
-list.to_alist
-list.to_finmap
-list.transpose_aux
-list.traverse
-lists
-lists.atom
-lists.induction_mut
-lists.is_list
-lists.mem
-lists.of'
-lists.of_list
-lists.to_list
-lists'
-lists'.cons
-lists'.of_list
-lists'.to_list
-loc.to_string
-loc.to_string_aux
-local_of_is_local_ring
-local_of_nonunits_ideal
-local_of_unique_max_ideal
-local_of_unit_or_unit_one_sub
-local_ring
-local_ring.nonunits_ideal
-local_ring.residue_field
-local_ring.residue_field.map
-localization.at_prime
-localization.away
-localization.away.inv_self
-localization.away.lift
-localization.away_to_away_right
-localization.equiv_of_equiv
-localization.fraction_ring.eq_zero_of_ne_zero_of_mul_eq_zero
-localization.fraction_ring.equiv_of_equiv
-localization.fraction_ring.inv_aux
-localization.fraction_ring.map
-localization.le_order_embedding
-localization.lift
-localization.lift'
-localization.map
-localization.mk
-localization.non_zero_divisors
-localization.r
-localized_attr
-localized_cmd
-locally_finite.realizer
-magma.free_semigroup
-magma.free_semigroup.lift
-magma.free_semigroup.map
-magma.free_semigroup.of
-magma.free_semigroup.r
-manifold_core.local_homeomorph
-manifold_core.to_manifold
-matrix
-matrix.col
-matrix.diagonal
-matrix.minor
-matrix.mul
-matrix.mul_vec
-matrix.row
-matrix.sub_down
-matrix.sub_down_left
-matrix.sub_down_right
-matrix.sub_left
-matrix.sub_right
-matrix.sub_up
-matrix.sub_up_left
-matrix.sub_up_right
-matrix.transpose
-matrix.vec_mul
-matrix.vec_mul_vec
-measurable_equiv.cast
-measurable_equiv.prod_comm
-measurable_equiv.prod_congr
-measurable_equiv.prod_sum_distrib
-measurable_equiv.refl
-measurable_equiv.set.image
-measurable_equiv.set.prod
-measurable_equiv.set.range
-measurable_equiv.set.range_inl
-measurable_equiv.set.range_inr
-measurable_equiv.set.singleton
-measurable_equiv.set.univ
-measurable_equiv.sum_congr
-measurable_equiv.sum_prod_distrib
-measurable_equiv.sum_prod_sum
-measurable_equiv.symm
-measurable_equiv.trans
-measurable_space
-measurable_space.dynkin_system.generate
-measurable_space.dynkin_system.of_measurable_space
-measurable_space.dynkin_system.restrict_on
-measurable_space.dynkin_system.to_measurable_space
-measurable_space.gi_generate_from
-measurable_space.mk_of_closure
-measure_theory.ae_eq_fun.add
-measure_theory.ae_eq_fun.neg
-measure_theory.ae_eq_fun.smul
-measure_theory.lintegral_eq_nnreal
-measure_theory.measure
-measure_theory.measure.integral
-measure_theory.measure.is_complete
-measure_theory.measure.map
-measure_theory.measure.of_measurable
-measure_theory.measure.with_density
-measure_theory.measure'
-measure_theory.outer_measure
-measure_theory.outer_measure.Inf_gen
-measure_theory.outer_measure.map
-measure_theory.outer_measure.sum
-measure_theory.outer_measure.to_measure
-measure_theory.outer_measure.trim
-measure_theory.simple_func.eapprox
-measure_theory.simple_func.fin_vol_supp
-measure_theory.simple_func.ite
-measure_theory.volume
-mem_uniformity_edist
-metric.cauchy_iff
-metric.cauchy_seq_iff
-metric.cauchy_seq_iff'
-metric.completion.mem_uniformity_dist
-metric.completion.uniformity_dist
-metric.completion.uniformity_dist'
-metric.continuous_iff
-metric.continuous_iff'
-metric.exists_ball_subset_ball
-metric.glue_premetric
-metric.glue_space
-metric.is_open_iff
-metric.mem_closure_range_iff
-metric.mem_nhds_iff
-metric.mem_of_closed'
-metric.mem_uniformity_dist
-metric.pos_of_mem_ball
-metric.sum.dist
-metric.tendsto_at_top
-metric.tendsto_nhds
-metric.to_glue_l
-metric.to_glue_r
-metric.totally_bounded_iff
-metric.uniform_continuous_iff
-metric.uniform_embedding_iff
-metric.uniform_embedding_iff'
-metric_space.induced
-metric_space.replace_uniformity
-module.End
-module.core
-module.direct_limit
-module.direct_limit.totalize
-module.of_core
-monad_cont
-monad_cont.goto
-monad_cont.label
-monoid.foldl.get
-monoid.foldl.mk
-monoid.foldl.of_free_monoid
-monoid.foldr
-monoid.foldr.get
-monoid.foldr.mk
-monoid.foldr.of_free_monoid
-monoid.mfoldl
-monoid.mfoldl.get
-monoid.mfoldl.mk
-monoid.mfoldl.of_free_monoid
-monoid.mfoldr
-monoid.mfoldr.get
-monoid.mfoldr.mk
-monoid.mfoldr.of_free_monoid
-monoid_hom.one
-monotonicity
-mtry
-mul_action.comp_hom
-mul_action.fixed_points
-mul_action.mul_left_cosets
-mul_action.orbit
-mul_action.orbit_equiv_quotient_stabilizer
-mul_action.orbit_rel
-mul_action.stabilizer
-mul_action.to_perm
-mul_equiv.to_equiv
-multiplicative
-multiplicity.finite
-multiplicity.finite_mul_aux
-multiset.choose
-multiset.choose_x
-multiset.decidable_exists_multiset
-multiset.decidable_forall_multiset
-multiset.le_inf
-multiset.length_ndinsert_of_mem
-multiset.length_ndinsert_of_not_mem
-multiset.pi.cons
-multiset.pi.empty
-multiset.powerset
-multiset.powerset_aux
-multiset.powerset_aux'
-multiset.powerset_len
-multiset.powerset_len_aux
-multiset.rec_on
-multiset.sections
-multiset.strong_induction_on
-multiset.subsingleton_equiv
-multiset.sum
-multiset.sup_le
-multiset.to_finsupp
-multiset.traverse
-mv_polynomial.R
-mv_polynomial.evalᵢ
-mv_polynomial.evalₗ
-mv_polynomial.indicator
-mv_polynomial.restrict_degree
-mv_polynomial.restrict_total_degree
-mv_power_series.inv
-mv_power_series.trunc_fun
-mzip_with
-mzip_with'
-name.last_string
-nat.cases
-nat.elim
-nat.min_fac_aux
-nat.modeq.chinese_remainder
-nat.partrec
-nat.partrec.code
-nat.partrec.code.const
-nat.partrec.code.curry
-nat.partrec.code.encode_code
-nat.partrec.code.eval
-nat.partrec.code.evaln
-nat.partrec.code.id
-nat.partrec.code.of_nat_code
-nat.partrec'.vec
-nat.primrec'.vec
-nat.rfind
-nat.rfind_opt
-nat.rfind_x
-nat.sqrt_aux
-nat.subtype.denumerable
-nat.subtype.of_nat
-nat.subtype.succ
-nat.to_pexpr
-nat.totient
-nat.unpaired
-nat.xgcd_aux
-nnreal.of_real
-nonempty_interior_of_Union_of_closed
-nonneg_comm_group.to_decidable_linear_ordered_comm_group
-nonneg_ring.to_linear_nonneg_ring
-nonunits
-norm_cast.derive
-norm_num.derive
-norm_num.derive1
-norm_num.eval_div_ext
-norm_num.eval_ineq
-norm_num.eval_pow
-norm_num.eval_prime
-norm_num.min_fac_helper
-norm_num.prove_lt
-norm_num.prove_min_fac
-norm_num.prove_non_prime
-norm_num.prove_pos
-normal_add_subgroup
-normal_of_eq_add_cosets
-normal_of_eq_cosets
-normal_subgroup
-normalize
-normed_group.tendsto_nhds_zero
-not.elim
-null_measurable
-num.add
-num.bit
-num.bit0
-num.bit1
-num.cmp
-num.cmp_to_nat
-num.div
-num.div2
-num.gcd
-num.gcd_aux
-num.land
-num.ldiff
-num.lor
-num.lxor
-num.mod
-num.mul
-num.nat_size
-num.of_nat'
-num.of_znum
-num.of_znum'
-num.one_bits
-num.ppred
-num.pred
-num.psub
-num.shiftl
-num.shiftr
-num.size
-num.sub
-num.sub'
-num.succ
-num.succ'
-num.test_bit
-num.to_znum
-num.to_znum_neg
-num.transfer
-num.transfer_rw
-nzsnum.bit0
-nzsnum.bit1
-nzsnum.drec'
-nzsnum.head
-nzsnum.not
-nzsnum.sign
-nzsnum.tail
-obviously.attr
-old_conv
-old_conv.apply
-old_conv.apply'
-old_conv.apply_lemmas
-old_conv.apply_lemmas_core
-old_conv.apply_propext_lemmas
-old_conv.apply_propext_lemmas_core
-old_conv.apply_propext_simp_set
-old_conv.apply_simp_set
-old_conv.applyc
-old_conv.bind
-old_conv.bottom_up
-old_conv.change
-old_conv.congr
-old_conv.congr_arg
-old_conv.congr_binder
-old_conv.congr_core
-old_conv.congr_fun
-old_conv.congr_rule
-old_conv.conversion
-old_conv.current_relation
-old_conv.dsimp
-old_conv.execute
-old_conv.fail
-old_conv.failed
-old_conv.find
-old_conv.find_pattern
-old_conv.findp
-old_conv.first
-old_conv.funext
-old_conv.funext'
-old_conv.head_beta
-old_conv.interactive.change
-old_conv.interactive.dsimp
-old_conv.interactive.find
-old_conv.interactive.itactic
-old_conv.interactive.trace_state
-old_conv.interactive.whnf
-old_conv.istep
-old_conv.lhs
-old_conv.lift_tactic
-old_conv.map
-old_conv.match_expr
-old_conv.match_pattern
-old_conv.mk_match_expr
-old_conv.orelse
-old_conv.propext'
-old_conv.pure
-old_conv.repeat
-old_conv.save_info
-old_conv.seq
-old_conv.skip
-old_conv.step
-old_conv.to_tactic
-old_conv.top_down
-old_conv.trace
-old_conv.trace_lhs
-old_conv.whnf
-old_conv_result
-omega.abort
-omega.add_ee
-omega.cancel
-omega.clause
-omega.clause.append
-omega.clause.holds
-omega.clause.sat
-omega.clause.unsat
-omega.clauses.sat
-omega.clauses.unsat
-omega.clear_unused_hyp
-omega.clear_unused_hyps
-omega.coeffs.val
-omega.coeffs.val_between
-omega.coeffs.val_except
-omega.coeffs_reduce
-omega.ee
-omega.ee.repr
-omega.ee_commit
-omega.ee_state
-omega.elim_eq
-omega.elim_eqs
-omega.elim_var
-omega.elim_var_aux
-omega.eq_elim
-omega.eqelim
-omega.factor
-omega.find_ees
-omega.find_min_coeff
-omega.find_min_coeff_core
-omega.find_neg_const
-omega.find_scalars
-omega.find_scalars_core
-omega.form_domain
-omega.form_wf
-omega.gcd
-omega.get_ees
-omega.get_eqs
-omega.get_gcd
-omega.get_les
-omega.goal_domain
-omega.goal_domain_aux
-omega.head_eq
-omega.int.canonize
-omega.int.desugar
-omega.int.dnf
-omega.int.dnf_core
-omega.int.form
-omega.int.form.equiv
-omega.int.form.fresh_index
-omega.int.form.holds
-omega.int.form.implies
-omega.int.form.induce
-omega.int.form.repr
-omega.int.form.sat
-omega.int.form.unsat
-omega.int.form.valid
-omega.int.is_nnf
-omega.int.neg_elim
-omega.int.neg_free
-omega.int.nnf
-omega.int.preterm
-omega.int.preterm.add_one
-omega.int.preterm.fresh_index
-omega.int.preterm.repr
-omega.int.preterm.val
-omega.int.prove_lia
-omega.int.prove_univ_close
-omega.int.push_neg
-omega.int.to_form
-omega.int.to_form_core
-omega.int.to_preterm
-omega.int.univ_close
-omega.is_lia_form
-omega.is_lia_term
-omega.is_lna_form
-omega.is_lna_term
-omega.lin_comb
-omega.nat.bools.or
-omega.nat.canonize
-omega.nat.desugar
-omega.nat.dnf
-omega.nat.dnf_core
-omega.nat.form
-omega.nat.form.equiv
-omega.nat.form.fresh_index
-omega.nat.form.holds
-omega.nat.form.implies
-omega.nat.form.induce
-omega.nat.form.neg_free
-omega.nat.form.repr
-omega.nat.form.sat
-omega.nat.form.sub_free
-omega.nat.form.sub_subst
-omega.nat.form.sub_terms
-omega.nat.form.unsat
-omega.nat.form.valid
-omega.nat.is_diff
-omega.nat.is_nnf
-omega.nat.neg_elim
-omega.nat.neg_elim_core
-omega.nat.nnf
-omega.nat.nonneg_consts
-omega.nat.nonneg_consts_core
-omega.nat.nonnegate
-omega.nat.preterm
-omega.nat.preterm.add_one
-omega.nat.preterm.fresh_index
-omega.nat.preterm.induce
-omega.nat.preterm.prove_sub_free
-omega.nat.preterm.repr
-omega.nat.preterm.sub_free
-omega.nat.preterm.sub_subst
-omega.nat.preterm.sub_terms
-omega.nat.preterm.val
-omega.nat.prove_lna
-omega.nat.prove_neg_free
-omega.nat.prove_sub_free
-omega.nat.prove_univ_close
-omega.nat.prove_unsat_neg_free
-omega.nat.prove_unsat_sub_free
-omega.nat.push_neg
-omega.nat.sub_elim
-omega.nat.sub_elim_core
-omega.nat.sub_fresh_index
-omega.nat.term.vars
-omega.nat.term.vars_core
-omega.nat.terms.vars
-omega.nat.to_form
-omega.nat.to_form_core
-omega.nat.to_preterm
-omega.nat.univ_close
-omega.preprocess
-omega.prove_forall_mem_eq_zero
-omega.prove_neg
-omega.prove_unsat
-omega.prove_unsat_ef
-omega.prove_unsat_lin_comb
-omega.prove_unsats
-omega.rev_lia
-omega.rev_lna
-omega.revert_cond
-omega.revert_cond_all
-omega.rhs
-omega.run
-omega.select_domain
-omega.set_ees
-omega.set_eqs
-omega.set_les
-omega.sgm
-omega.subst
-omega.sym_sym
-omega.symdiv
-omega.symmod
-omega.term
-omega.term.add
-omega.term.div
-omega.term.fresh_index
-omega.term.mul
-omega.term.neg
-omega.term.sub
-omega.term.to_string
-omega.term.val
-omega.term_domain
-omega.terms.fresh_index
-omega.trisect
-omega.type_domain
-omega.unsat_lin_comb
-omega.update
-omega.update_zero
-omega_int
-omega_nat
-onote.oadd_lt_oadd_1
-onote.oadd_lt_oadd_2
-onote.oadd_lt_oadd_3
-onote.power_aux
-onote.to_string_aux1
-open_add_subgroup
-open_add_subgroup.sum
-open_locale_cmd
-open_subgroup.prod
-opposite.op
-opposite.op_induction
-opposite.unop
-opt_minus
-option.cases_on'
-option.comp_traverse
-option.lift_or_get
-option.rel
-option.to_list
-option.traverse
-option_t.call_cc
-option_t.mk_label
-option_t.pass_aux
-order_embedding.collapse_F
-order_embedding.lt_embedding_of_le_embedding
-order_embedding.nat_gt
-order_embedding.nat_lt
-order_embedding.refl
-order_embedding.trans
-order_embedding.well_founded_iff_no_descending_seq
-order_iso.of_surjective
-order_iso.prod_lex_congr
-order_iso.refl
-order_iso.sum_lex_congr
-order_iso.symm
-order_iso.to_order_embedding
-order_iso.trans
-order_of_pos
-ordering.compares.eq_gt
-ordinal.CNF_rec
-ordinal.CNF_sorted
-ordinal.initial_seg_out
-ordinal.lift.initial_seg
-ordinal.lift.principal_seg
-ordinal.limit_rec_on
-ordinal.order_iso_out
-ordinal.principal_seg_out
-ordinal.typein.principal_seg
-ordinal.typein_iso
-pSet.definable.eq_mk
-pSet.definable.resp
-pSet.resp.equiv
-pSet.resp.eval_aux
-pSet.resp.f
-pSet.subset
-padic.complete'
-padic.exi_rat_seq_conv
-padic.lim_seq
-padic_norm.neg
-padic_norm_e.defn
-padic_norm_e.nonneg
-padic_norm_e.rat_norm
-padic_norm_z
-padic_seq
-padic_seq.norm_nonneg
-partial_order.lift
-partrec
-partrec₂
-pell.az
-pell.eq_pow_of_pell
-pell.matiyasevic
-pell.x_pos
-pell.x_sub_y_dvd_pow_lem
-pell.xz
-pell.yz
-pempty.elim
-pequiv.matrix_mul_apply
-pequiv.mul_matrix_apply
-pequiv.of_set
-pequiv.refl
-pequiv.single
-pequiv.single_mul_single_right
-pequiv.symm
-pequiv.to_matrix
-pequiv.trans
-pequiv.trans_single_of_eq_none
-perfect_closure.UMP
-perfect_closure.eq_iff'
-perfect_closure.frobenius_equiv
-perfect_closure.has_inv
-perfect_closure.of
-perfect_closure.r
-perms_of_finset
-perms_of_list
-pexpr.get_uninst_pis
-pfun.core
-pfun.equiv_subtype
-pfun.fix
-pfun.fix_induction
-pfun.graph'
-pfun.image
-pfun.preimage
-pfun.res
-pgame.add_lt_add
-pgame.numeric.lt_move_right
-pgame.numeric.move_left_lt
-pi.lex
-pi.linear_independent_std_basis
-pilex
-pmf.bernoulli
-pmf.bind
-pmf.map
-pmf.of_fintype
-pmf.of_multiset
-pmf.pure
-pmf.seq
-pmf.support
-pnat.div
-pnat.div_exact
-pnat.gcd
-pnat.gcd_a'
-pnat.gcd_b'
-pnat.gcd_d
-pnat.gcd_w
-pnat.gcd_x
-pnat.gcd_y
-pnat.gcd_z
-pnat.lcm
-pnat.mod
-pnat.mod_div
-pnat.prime
-pnat.xgcd
-pnat.xgcd_type.a
-pnat.xgcd_type.b
-pnat.xgcd_type.finish
-pnat.xgcd_type.flip
-pnat.xgcd_type.is_reduced'
-pnat.xgcd_type.is_special'
-pnat.xgcd_type.mk'
-pnat.xgcd_type.q
-pnat.xgcd_type.qp
-pnat.xgcd_type.r
-pnat.xgcd_type.succ₂
-pnat.xgcd_type.v
-pnat.xgcd_type.w
-pnat.xgcd_type.z
-polynomial.binom_expansion
-polynomial.coeff_coe_to_fun
-polynomial.comp
-polynomial.decidable_dvd_monic
-polynomial.div
-polynomial.div_mod_by_monic_aux
-polynomial.eval_sub_factor
-polynomial.eval₂_zero
-polynomial.lcoeff
-polynomial.map_injective
-polynomial.mod
-polynomial.monomial
-polynomial.nonzero_comm_ring.of_polynomial_ne
-polynomial.nonzero_comm_semiring.of_polynomial_ne
-polynomial.pow_add_expansion
-polynomial.pow_sub_pow_factor
-polynomial.rec_on_horner
-polynomial.root_multiplicity
-polynomial.splits
-polynomial.tendsto_infinity
-pos_num.add
-pos_num.bit
-pos_num.cmp
-pos_num.cmp_to_nat
-pos_num.div'
-pos_num.divmod
-pos_num.divmod_aux
-pos_num.is_one
-pos_num.land
-pos_num.ldiff
-pos_num.lor
-pos_num.lxor
-pos_num.mod'
-pos_num.mul
-pos_num.nat_size
-pos_num.of_nat
-pos_num.of_nat_succ
-pos_num.of_znum
-pos_num.of_znum'
-pos_num.one_bits
-pos_num.pred
-pos_num.pred'
-pos_num.shiftl
-pos_num.shiftr
-pos_num.size
-pos_num.sqrt_aux
-pos_num.sqrt_aux1
-pos_num.sub
-pos_num.sub'
-pos_num.succ
-pos_num.test_bit
-pos_num.transfer
-pos_num.transfer_rw
-power_series.inv
-power_series.inv.aux
-power_series.mk
-power_series.order_add_ge
-power_series.order_ge
-power_series.order_ge_nat
-power_series.order_mul_ge
-premetric_space
-preorder.lift
-primcodable.of_equiv
-primcodable.subtype
-prime_multiset.of_nat_multiset
-prime_multiset.of_pnat_list
-prime_multiset.of_pnat_multiset
-prime_multiset.prod
-prime_multiset.to_pnat_multiset
-principal_ideal_domain
-principal_ideal_domain.factors
-principal_seg
-principal_seg.equiv_lt
-principal_seg.lt_equiv
-principal_seg.lt_le
-principal_seg.top_lt_top
-principal_seg.trans
-principal_seg.trans_top
-prod.bitraverse
-prod.lex.decidable
-push_neg.normalize_negations
-push_neg.push_neg_at_goal
-push_neg.push_neg_at_hyp
-push_neg.whnf_reducible
-quot.hrec_on₂
-quotient.choice
-quotient.fin_choice
-quotient.fin_choice_aux
-quotient.hrec_on₂
-quotient.lift_on'
-quotient.lift_on₂'
-quotient.mk'
-quotient.out'
-quotient_add_group.eq_class_eq_left_coset
-quotient_add_group.inhabited
-quotient_add_group.ker_lift
-quotient_add_group.left_rel
-quotient_add_group.lift
-quotient_add_group.map
-quotient_add_group.mk
-quotient_add_group.quotient
-quotient_add_group.quotient_ker_equiv_of_surjective
-quotient_add_group.quotient_ker_equiv_range
-quotient_group.eq_class_eq_left_coset
-quotient_group.fintype
-quotient_group.inhabited
-quotient_group.left_rel
-quotient_group.lift
-quotient_group.map
-quotient_group.mk
-quotient_group.preimage_mk_equiv_subgroup_times_set
-quotient_group.quotient_ker_equiv_of_surjective
-quotient_group.quotient_ker_equiv_range
-rank
-rat.add
-rat.inv
-rat.le
-rat.mul
-rat.neg
-rat.nonneg
-rat.num_denom_cases_on
-rat.num_denom_cases_on'
-rat.repr
-rat.sqrt
-rat_add_continuous_lemma
-rat_inv_continuous_lemma
-rat_mul_continuous_lemma
-re_pred
-reader_t.call_cc
-reader_t.mk_label
-real
-real.Inf
-real.Sup
-real.comm_ring_aux
-real.cos
-real.cosh
-real.exp
-real.le
-real.mk
-real.of_rat
-real.pi_gt_314
-real.pi_gt_sqrt_two_add_series
-real.pi_gt_three
-real.sin
-real.sinh
-real.sqrt
-real.sqrt_aux
-real.sqrt_two_add_series_nonneg
-real.sqrt_two_add_series_zero_nonneg
-real.tan
-real.tanh
-relation.comp
-relation.join
-relation.map
-relator.bi_total
-relator.bi_unique
-relator.left_total
-relator.left_unique
-relator.lift_fun
-relator.right_total
-relator.right_unique
-restate_axiom_cmd
-right_add_coset
-right_coset
-ring.closure
-ring.direct_limit
-ring_anti_equiv.refl
-ring_equiv
-ring_equiv.to_add_equiv
-ring_equiv.to_equiv
-ring_equiv.to_mul_equiv
-ring_hom.to_add_monoid_hom
-ring_hom.to_monoid_hom
-ring_invo.id
-ring_invo.to_ring_anti_equiv
-roption.equiv_option
-roption.get_or_else
-roption.restrict
-saturate_fun
-semiquot.bind
-semiquot.get
-semiquot.is_pure
-semiquot.map
-separated
-seq.bisim_o
-seq.cases_on
-seq.corec.F
-seq.is_bisimulation
-seq.mem
-sequence
-set.Union_eq_sigma_of_disjoint
-set.add_comm_monoid
-set.bUnion_eq_sigma_of_disjoint
-set.centralizer.add_submonoid
-set.comm_monoid
-set.countable.to_encodable
-set.enumerate
-set.fintype_bUnion
-set.fintype_bind
-set.fintype_insert'
-set.fintype_of_fintype_image
-set.fintype_subset
-set.kern_image
-set.pairwise_disjoint
-set.pointwise_add
-set.pointwise_add_add_monoid
-set.pointwise_add_add_semigroup
-set.pointwise_add_fintype
-set.pointwise_inv
-set.pointwise_mul
-set.pointwise_mul_comm_semiring
-set.pointwise_mul_fintype
-set.pointwise_mul_monoid
-set.pointwise_mul_semigroup
-set.pointwise_mul_semiring
-set.pointwise_neg
-set.pointwise_one
-set.pointwise_zero
-set.seq
-set.sigma_to_Union
-set_fintype
-setoid.is_partition
-side
-side.other
-side.to_string
-simple_add_group
-simple_group
-snum.add
-snum.bit
-snum.bit0
-snum.bit1
-snum.bits
-snum.cadd
-snum.czadd
-snum.drec'
-snum.head
-snum.mul
-snum.neg
-snum.not
-snum.pred
-snum.rec'
-snum.sign
-snum.sub
-snum.succ
-snum.tail
-snum.test_bit
-state_t.call_cc
-state_t.mk_label
-strict_order.cof
-string.ltb
-string.map_tokens
-string.over_list
-string.split_on
-subalgebra
-subalgebra.comap
-subalgebra.fg
-subalgebra.to_submodule
-subalgebra.under
-subalgebra.val
-subgroup_units_cyclic
-submodule.annihilator
-submodule.colon
-submodule.fg
-submodule.subtype
-subrel.order_embedding
-succeeds
-sum.bind
-sum.bitraverse
-sum.comp_traverse
-sum.elim
-sum.map
-sum.traverse
-sum.traverse_map
-sum_fin_sum_equiv
-summable_iff_vanishing_norm
-supr_eq_elim
-surreal.add
-swap_right
-sylow.fixed_points_mul_left_cosets_equiv_quotient
-sylow.mk_vector_prod_eq_one
-sylow.rotate_vectors_prod_eq_one
-sylow.vectors_prod_eq_one
-tactic.abel.add_g
-tactic.abel.cache
-tactic.abel.cache.app
-tactic.abel.cache.iapp
-tactic.abel.cache.int_to_expr
-tactic.abel.cache.mk_app
-tactic.abel.cache.mk_term
-tactic.abel.eval
-tactic.abel.eval'
-tactic.abel.eval_add
-tactic.abel.eval_atom
-tactic.abel.eval_neg
-tactic.abel.eval_smul
-tactic.abel.mk_cache
-tactic.abel.normal_expr
-tactic.abel.normal_expr.e
-tactic.abel.normal_expr.pp
-tactic.abel.normal_expr.refl_conv
-tactic.abel.normal_expr.term'
-tactic.abel.normal_expr.to_list
-tactic.abel.normal_expr.to_string
-tactic.abel.normal_expr.zero'
-tactic.abel.normalize
-tactic.abel.normalize_mode
-tactic.abel.smul
-tactic.abel.smulg
-tactic.abel.term
-tactic.abel.termg
-tactic.abstract_if_success
-tactic.add_coinductive_predicate
-tactic.add_coinductive_predicate.coind_pred
-tactic.add_coinductive_predicate.coind_pred.add_theorem
-tactic.add_coinductive_predicate.coind_pred.construct
-tactic.add_coinductive_predicate.coind_pred.corec_functional
-tactic.add_coinductive_predicate.coind_pred.destruct
-tactic.add_coinductive_predicate.coind_pred.func
-tactic.add_coinductive_predicate.coind_pred.func_g
-tactic.add_coinductive_predicate.coind_pred.f₁_l
-tactic.add_coinductive_predicate.coind_pred.f₂_l
-tactic.add_coinductive_predicate.coind_pred.impl_locals
-tactic.add_coinductive_predicate.coind_pred.impl_params
-tactic.add_coinductive_predicate.coind_pred.le
-tactic.add_coinductive_predicate.coind_pred.mono
-tactic.add_coinductive_predicate.coind_pred.pred
-tactic.add_coinductive_predicate.coind_pred.pred_g
-tactic.add_coinductive_predicate.coind_pred.rec'
-tactic.add_coinductive_predicate.coind_pred.u_params
-tactic.add_coinductive_predicate.coind_rule
-tactic.add_edge
-tactic.add_refl
-tactic.add_symm_proof
-tactic.alias.alias_attr
-tactic.alias.alias_cmd
-tactic.alias.alias_direct
-tactic.alias.alias_iff
-tactic.alias.get_alias_target
-tactic.alias.get_lambda_body
-tactic.alias.make_left_right
-tactic.alias.mk_iff_mp_app
-tactic.all_rewrites_using
-tactic.ancestor_attr
-tactic.apply_mod_cast
-tactic.assert_fresh
-tactic.assertv_fresh
-tactic.assoc_refl
-tactic.assoc_refl'
-tactic.assoc_rewrite
-tactic.assoc_rewrite_hyp
-tactic.assoc_rewrite_intl
-tactic.assoc_rewrite_target
-tactic.assoc_root
-tactic.assumption_mod_cast
-tactic.assumption_symm
-tactic.assumption_with
-tactic.calculated_Prop
-tactic.chain
-tactic.chain_core
-tactic.chain_eq_trans
-tactic.coinductive_predicate
-tactic.constr_to_prop
-tactic.contradiction_symm
-tactic.contradiction_with
-tactic.def_replacer_cmd
-tactic.derive_field
-tactic.derive_field_subtype
-tactic.derive_reassoc_proof
-tactic.elide.replace
-tactic.elide.unelide
-tactic.enum_assoc_subexpr
-tactic.enum_assoc_subexpr'
-tactic.exact_mod_cast
-tactic.explode
-tactic.explode.append_dep
-tactic.explode.args
-tactic.explode.core
-tactic.explode.entries
-tactic.explode.entries.add
-tactic.explode.entries.find
-tactic.explode.entries.head
-tactic.explode.entries.size
-tactic.explode.entry
-tactic.explode.format_aux
-tactic.explode.head'
-tactic.explode.may_be_proof
-tactic.explode.pad_right
-tactic.explode.status
-tactic.explode_cmd
-tactic.explode_expr
-tactic.expr_list_to_list_expr
-tactic.ext
-tactic.ext1
-tactic.ext_parse
-tactic.ext_patt
-tactic.fill_args
-tactic.fin_cases_at
-tactic.fin_cases_at_aux
-tactic.find_ancestors
-tactic.find_eq_type
-tactic.find_if_cond
-tactic.find_if_cond_at
-tactic.flatten
-tactic.generalize_proofs
-tactic.get_ancestors
-tactic.get_lift_prf
-tactic.get_nth_rewrite
-tactic.goals
-tactic.interactive.abel.mode
-tactic.interactive.ac_mono_ctx
-tactic.interactive.ac_mono_ctx.to_tactic_format
-tactic.interactive.ac_mono_ctx'
-tactic.interactive.ac_mono_ctx'.map
-tactic.interactive.ac_mono_ctx'.traverse
-tactic.interactive.ac_mono_ctx_ne
-tactic.interactive.ac_monotonicity_goal
-tactic.interactive.ac_refine
-tactic.interactive.apply_iff_congr_core
-tactic.interactive.apply_normed
-tactic.interactive.apply_rel
-tactic.interactive.arity
-tactic.interactive.as_goal
-tactic.interactive.assert_or_rule
-tactic.interactive.auto_simp_lemma
-tactic.interactive.best_match
-tactic.interactive.bin_op
-tactic.interactive.bin_op_left
-tactic.interactive.bin_op_right
-tactic.interactive.check_ac
-tactic.interactive.clean_ids
-tactic.interactive.coinduction
-tactic.interactive.collect_struct
-tactic.interactive.collect_struct'
-tactic.interactive.compact_decl
-tactic.interactive.compact_decl_aux
-tactic.interactive.compare
-tactic.interactive.congr_core'
-tactic.interactive.conv_lhs
-tactic.interactive.conv_rhs
-tactic.interactive.convert_to_core
-tactic.interactive.delete_expr
-tactic.interactive.derive_functor
-tactic.interactive.derive_lawful_functor
-tactic.interactive.derive_lawful_traversable
-tactic.interactive.derive_traverse
-tactic.interactive.field
-tactic.interactive.filter_instances
-tactic.interactive.find
-tactic.interactive.find_lemma
-tactic.interactive.find_one_difference
-tactic.interactive.find_rule
-tactic.interactive.fold_assoc
-tactic.interactive.fold_assoc1
-tactic.interactive.format_names
-tactic.interactive.functor_derive_handler
-tactic.interactive.functor_derive_handler'
-tactic.interactive.get_current_field
-tactic.interactive.get_equations_of
-tactic.interactive.get_monotonicity_lemmas
-tactic.interactive.get_operator
-tactic.interactive.guard_class
-tactic.interactive.guard_expr_eq'
-tactic.interactive.guard_hyp_nums
-tactic.interactive.guard_tags
-tactic.interactive.hide_meta_vars'
-tactic.interactive.higher_order_derive_handler
-tactic.interactive.last_two
-tactic.interactive.lawful_functor_derive_handler
-tactic.interactive.lawful_functor_derive_handler'
-tactic.interactive.lawful_traversable_derive_handler
-tactic.interactive.lawful_traversable_derive_handler'
-tactic.interactive.list.minimum_on
-tactic.interactive.list_cast_of
-tactic.interactive.list_cast_of_aux
-tactic.interactive.loc.get_local_pp_names
-tactic.interactive.loc.get_local_uniq_names
-tactic.interactive.match_ac
-tactic.interactive.match_ac'
-tactic.interactive.match_chaining_rules
-tactic.interactive.match_imp
-tactic.interactive.match_prefix
-tactic.interactive.match_rule
-tactic.interactive.mk_congr_args
-tactic.interactive.mk_congr_law
-tactic.interactive.mk_fun_app
-tactic.interactive.mk_mapp'
-tactic.interactive.mk_mapp_aux'
-tactic.interactive.mk_one_instance
-tactic.interactive.mk_paragraph_aux
-tactic.interactive.mk_pattern
-tactic.interactive.mk_rel
-tactic.interactive.mono_aux
-tactic.interactive.mono_cfg
-tactic.interactive.mono_function
-tactic.interactive.mono_function.to_tactic_format
-tactic.interactive.mono_head_candidates
-tactic.interactive.mono_key
-tactic.interactive.mono_law
-tactic.interactive.mono_law.to_tactic_format
-tactic.interactive.mono_selection
-tactic.interactive.monotoncity.check
-tactic.interactive.monotoncity.check_rel
-tactic.interactive.monotonicity.attr
-tactic.interactive.obtain_parse
-tactic.interactive.old_conv
-tactic.interactive.one_line
-tactic.interactive.op_induction
-tactic.interactive.parse_ac_mono_function
-tactic.interactive.parse_ac_mono_function'
-tactic.interactive.parse_assoc_chain
-tactic.interactive.parse_assoc_chain'
-tactic.interactive.parse_config
-tactic.interactive.parse_list
-tactic.interactive.pi_head
-tactic.interactive.rec.to_tactic_format
-tactic.interactive.record_lit
-tactic.interactive.refine_one
-tactic.interactive.refine_recursively
-tactic.interactive.rep_arity
-tactic.interactive.repeat_or_not
-tactic.interactive.repeat_until
-tactic.interactive.return_cast
-tactic.interactive.revert_all
-tactic.interactive.ring.mode
-tactic.interactive.same_function
-tactic.interactive.same_function_aux
-tactic.interactive.same_operator
-tactic.interactive.side
-tactic.interactive.side_conditions
-tactic.interactive.simp_functor
-tactic.interactive.solve_mvar
-tactic.interactive.source_fields
-tactic.interactive.squeeze_simp
-tactic.interactive.squeeze_simpa
-tactic.interactive.tfae_have
-tactic.interactive.traversable_derive_handler
-tactic.interactive.traversable_derive_handler'
-tactic.interactive.traversable_law_starter
-tactic.interactive.traverse_constructor
-tactic.interactive.traverse_field
-tactic.interactive.unify_with_instance
-tactic.interactive.with_prefix
-tactic.interactive.work_on_goal
-tactic.library_search_hole_cmd
-tactic.list_Pi
-tactic.list_Sigma
-tactic.local_cache.internal.block_local.clear
-tactic.local_cache.internal.block_local.get_name
-tactic.local_cache.internal.block_local.present
-tactic.local_cache.internal.block_local.try_get_name
-tactic.local_cache.internal.cache_scope
-tactic.local_cache.internal.def_local.FNV_OFFSET_BASIS
-tactic.local_cache.internal.def_local.FNV_PRIME
-tactic.local_cache.internal.def_local.RADIX
-tactic.local_cache.internal.def_local.apply_tag
-tactic.local_cache.internal.def_local.clear
-tactic.local_cache.internal.def_local.get_name
-tactic.local_cache.internal.def_local.get_root_name
-tactic.local_cache.internal.def_local.get_tag_with_status
-tactic.local_cache.internal.def_local.hash_byte
-tactic.local_cache.internal.def_local.hash_context
-tactic.local_cache.internal.def_local.hash_string
-tactic.local_cache.internal.def_local.is_name_dead
-tactic.local_cache.internal.def_local.kill_name
-tactic.local_cache.internal.def_local.mk_dead_name
-tactic.local_cache.internal.def_local.present
-tactic.local_cache.internal.def_local.try_get_name
-tactic.local_cache.internal.load_data
-tactic.local_cache.internal.mk_full_namespace
-tactic.local_cache.internal.poke_data
-tactic.local_cache.internal.run_once_under_name
-tactic.local_cache.internal.save_data
-tactic.match_assoc_pattern
-tactic.match_assoc_pattern'
-tactic.match_fn
-tactic.merge_list
-tactic.mk_assoc
-tactic.mk_assoc_instance
-tactic.mk_assoc_pattern
-tactic.mk_assoc_pattern'
-tactic.mk_congr_arg_using_dsimp'
-tactic.mk_eq_proof
-tactic.mk_iff
-tactic.mk_replacer
-tactic.mk_replacer₁
-tactic.mk_replacer₂
-tactic.mllist
-tactic.mllist.append
-tactic.mllist.bind_
-tactic.mllist.concat
-tactic.mllist.empty
-tactic.mllist.enum
-tactic.mllist.enum_from
-tactic.mllist.filter
-tactic.mllist.filter_map
-tactic.mllist.fix
-tactic.mllist.fixl
-tactic.mllist.fixl_with
-tactic.mllist.force
-tactic.mllist.head
-tactic.mllist.join
-tactic.mllist.m_of_list
-tactic.mllist.map
-tactic.mllist.mfilter
-tactic.mllist.mfilter_map
-tactic.mllist.mfirst
-tactic.mllist.mmap
-tactic.mllist.monad_lift
-tactic.mllist.of_list
-tactic.mllist.range
-tactic.mllist.squash
-tactic.mllist.take
-tactic.mllist.uncons
-tactic.modify_ref
-tactic.mono
-tactic.op_induction
-tactic.op_induction.find_opposite_hyp
-tactic.op_induction.is_opposite
-tactic.op_induction'
-tactic.perform_nth_rewrite
-tactic.prove_eqv_target
-tactic.rcases.continue
-tactic.rcases.process_constructors
-tactic.rcases_core
-tactic.rcases_hint
-tactic.rcases_hint.continue
-tactic.rcases_hint.process_constructors
-tactic.rcases_hint_core
-tactic.rcases_parse_depth
-tactic.rcases_patt
-tactic.rcases_patt.format
-tactic.rcases_patt.invert
-tactic.rcases_patt.invert'
-tactic.rcases_patt.invert_list
-tactic.rcases_patt.invert_many
-tactic.rcases_patt.merge
-tactic.rcases_patt.name
-tactic.rcases_patt_inverted.format
-tactic.rcases_patt_inverted.format_list
-tactic.rcases_patt_inverted.invert
-tactic.rcases_patt_inverted.invert_list
-tactic.rcases_patt_parse
-tactic.rcases_patt_parse_core
-tactic.rcases_patt_parse_list
-tactic.reduce_ifs_at
-tactic.refl_conv
-tactic.repeat_count
-tactic.repeat_with_results
-tactic.replaceable_attr
-tactic.replacer
-tactic.replacer_attr
-tactic.replacer_core
-tactic.rewrite_all.cfg
-tactic.rewrite_all.congr.app_map
-tactic.rewrite_all.congr.expr_lens
-tactic.rewrite_all.congr.expr_lens.congr
-tactic.rewrite_all.congr.expr_lens.replace
-tactic.rewrite_all.congr.expr_lens.to_sides
-tactic.rewrite_all.congr.expr_lens.to_tactic_string
-tactic.rewrite_all.congr.rewrite_all
-tactic.rewrite_all.congr.rewrite_all_lazy
-tactic.rewrite_all.congr.rewrite_at_lens
-tactic.rewrite_all.congr.rewrite_is_of_entire
-tactic.rewrite_all.congr.rewrite_without_new_mvars
-tactic.rewrite_all.tracked_rewrite
-tactic.rewrite_all.tracked_rewrite.eval
-tactic.rewrite_all.tracked_rewrite.replace_target
-tactic.rewrite_all.tracked_rewrite.replace_target_lhs
-tactic.rewrite_all.tracked_rewrite.replace_target_rhs
-tactic.ring.add_atom
-tactic.ring.cache
-tactic.ring.cache.cs_app
-tactic.ring.eval
-tactic.ring.eval'
-tactic.ring.eval_add
-tactic.ring.eval_atom
-tactic.ring.eval_const_mul
-tactic.ring.eval_horner
-tactic.ring.eval_mul
-tactic.ring.eval_neg
-tactic.ring.eval_pow
-tactic.ring.get_atom
-tactic.ring.get_cache
-tactic.ring.get_transparency
-tactic.ring.horner
-tactic.ring.horner_expr
-tactic.ring.horner_expr.e
-tactic.ring.horner_expr.pp
-tactic.ring.horner_expr.refl_conv
-tactic.ring.horner_expr.to_string
-tactic.ring.horner_expr.xadd'
-tactic.ring.lift
-tactic.ring.normalize
-tactic.ring.normalize_mode
-tactic.ring.ring_m
-tactic.ring.ring_m.mk_app
-tactic.ring.ring_m.run
-tactic.ring2.horner_expr.add
-tactic.ring2.horner_expr.add_aux
-tactic.ring2.horner_expr.add_const
-tactic.ring2.horner_expr.inv
-tactic.ring2.horner_expr.mul
-tactic.ring2.horner_expr.mul_aux
-tactic.ring2.horner_expr.mul_const
-tactic.ring2.horner_expr.neg
-tactic.ring2.horner_expr.pow
-tactic.ring2.horner_expr.to_string
-tactic.rintro
-tactic.rintro_hint
-tactic.rintro_parse
-tactic.root
-tactic.select
-tactic.split_if1
-tactic.split_ifs
-tactic.suggest.decl_data
-tactic.symm_eq
-tactic.symmetry_hyp
-tactic.tauto_state
-tactic.tautology
-tactic.tfae.arrow
-tactic.tfae.mk_implication
-tactic.tfae.mk_name
-tactic.tidy
-tactic.tidy.cfg
-tactic.tidy.core
-tactic.tidy.default_tactics
-tactic.tidy.ext1_wrapper
-tactic.tidy.name_to_tactic
-tactic.tidy.run_tactics
-tactic.tidy.tidy_attribute
-tactic.tidy_hole_cmd
-tactic.to_texpr
-tactic.trace_output
-tactic.trans_conv
-tactic.transfer
-tactic.transport_with_prefix_dict
-tactic.transport_with_prefix_fun
-tactic.try_intros
-tactic.unify_prefix
-tactic.unprime
-tactic.using_texpr
-tactic.valid_types
-tactic.wlog
-tensor_product
-tensor_product.assoc
-tensor_product.congr
-tensor_product.curry
-tensor_product.direct_sum
-tensor_product.lcurry
-tensor_product.lift
-tensor_product.lift.equiv
-tensor_product.lift_aux
-tensor_product.map
-tensor_product.mk
-tensor_product.relators
-tensor_product.smul.aux
-tensor_product.tmul
-tensor_product.uncurry
-times_cont_diff.times_cont_diff_fderiv_apply
-to_additive.attr
-to_additive.aux_attr
-to_additive.guess_name
-to_additive.map_namespace
-to_additive.parser
-to_additive.proceed_fields
-to_additive.target_name
-to_additive.tokens_dict
-to_additive.value_type
-topological_add_group.to_uniform_space
-topological_space.open_nhds
-topological_space.open_nhds.inclusion
-topological_space.open_nhds.inclusion_map_iso
-topological_space.open_nhds.map
-topological_space.opens.gi
-topological_space.opens.interior
-topological_space.opens.is_basis
-topological_space.opens.map_comp
-topological_space.opens.map_id
-topological_space.opens.map_iso
-topological_space.opens.to_Top
-topological_space.seq_tendsto_iff
-transfer.analyse_decls
-transfer.compute_transfer
-traversable
-traversable.fold_map
-traversable.foldl
-traversable.foldr
-traversable.free.map
-traversable.free.mk
-traversable.length
-traversable.map_fold
-traversable.mfoldl
-traversable.mfoldl.unop_of_free_monoid
-traversable.mfoldr
-traversable.pure_transformation
-tree
-tree.map
-tree.repr
-trunc.bind
-trunc.lift_on
-trunc.map
-trunc.rec
-trunc.rec_on
-trunc.rec_on_subsingleton
-turing.TM0.cfg.inhabited
-turing.TM0.cfg.map
-turing.TM0.machine
-turing.TM0.machine.map
-turing.TM0.machine.map_respects
-turing.TM0.machine.map_step
-turing.TM0.stmt.inhabited
-turing.TM0.stmt.map
-turing.TM0to1.tr
-turing.TM0to1.tr_cfg
-turing.TM0to1.Λ'
-turing.TM1.cfg.inhabited
-turing.TM1.eval
-turing.TM1.init
-turing.TM1.step
-turing.TM1.stmts
-turing.TM1.stmts₁
-turing.TM1.supports_stmt
-turing.TM1to0.tr
-turing.TM1to0.tr_aux
-turing.TM1to0.tr_cfg
-turing.TM1to0.tr_eval
-turing.TM1to0.tr_stmts
-turing.TM1to0.Λ'
-turing.TM1to1.move
-turing.TM1to1.read
-turing.TM1to1.read_aux
-turing.TM1to1.step_aux_move
-turing.TM1to1.step_aux_write
-turing.TM1to1.supports_stmt_move
-turing.TM1to1.supports_stmt_write
-turing.TM1to1.tr
-turing.TM1to1.tr_cfg
-turing.TM1to1.tr_normal
-turing.TM1to1.tr_supp
-turing.TM1to1.tr_tape
-turing.TM1to1.tr_tape'
-turing.TM1to1.tr_tape_drop_right
-turing.TM1to1.write
-turing.TM1to1.writes
-turing.TM1to1.Λ'
-turing.TM2.cfg
-turing.TM2.cfg.inhabited
-turing.TM2.eval
-turing.TM2.init
-turing.TM2.reaches
-turing.TM2.step
-turing.TM2.step_aux
-turing.TM2.stmts
-turing.TM2.stmts₁
-turing.TM2.supports
-turing.TM2.supports_stmt
-turing.TM2to1.st_act
-turing.TM2to1.st_run
-turing.TM2to1.st_var
-turing.TM2to1.st_write
-turing.TM2to1.stackel
-turing.TM2to1.stackel.get
-turing.TM2to1.stackel.is_bottom
-turing.TM2to1.stackel.is_top
-turing.TM2to1.stackel_equiv
-turing.TM2to1.stmt_st_rec
-turing.TM2to1.tr
-turing.TM2to1.tr_cfg
-turing.TM2to1.tr_init
-turing.TM2to1.tr_normal
-turing.TM2to1.tr_st_act
-turing.TM2to1.tr_stk
-turing.TM2to1.tr_stmts₁
-turing.TM2to1.tr_supp
-turing.TM2to1.Γ'
-turing.TM2to1.Λ'
-turing.dwrite
-turing.eval
-turing.frespects
-turing.pointed_map
-turing.reaches
-turing.reaches₀
-turing.reaches₁
-turing.respects
-turing.tape
-turing.tape.map
-turing.tape.mk
-turing.tape.mk'
-turing.tape.move
-turing.tape.nth
-turing.tape.write
-uniform_continuous₂
-uniform_embedding
-uniform_inducing
-uniform_space.completion.completion_separation_quotient_equiv
-uniform_space.completion.cpkg
-uniform_space.completion.extension₂
-uniform_space.completion.map₂
-uniform_space.mk'
-uniform_space.sep_quot_equiv_ring_quot
-uniform_space.separation_quotient
-uniform_space.separation_quotient.lift
-uniform_space.separation_quotient.map
-uniform_space.separation_setoid
-uniformity_dist_of_mem_uniformity
-uniformity_edist
-unique
-unique.of_surjective
-unique_factorization_domain.exists_mem_factors_of_dvd
-unique_factorization_domain.of_unique_irreducible_factorization
-unique_irreducible_factorization
-unique_unique_equiv
-units.inv'
-units.map_equiv
-units.mk_of_mul_eq_one
-units.mul
-vector.insert_nth
-vector.m_of_fn
-vector.mmap
-vector.reverse
-vector.to_array
-vector.traverse
-vector.traverse_def
-vector3.cons_elim
-vector3.nil_elim
-vector3.rec_on
-vector_space.dim
-well_founded.succ
-well_founded.sup
-well_founded_submodule_gt
-where.binder_less_important
-where.binder_priority
-where.collect_by
-where.collect_by_aux
-where.collect_implicit_names
-where.compile_variable_list
-where.fetch_potential_variable_names
-where.find_var
-where.format_variable
-where.get_all_in_namespace
-where.get_def_variables
-where.get_includes_core
-where.get_namespace_core
-where.get_opens
-where.get_variables_core
-where.inflate
-where.is_in_namespace_nonsynthetic
-where.is_variable_name
-where.mk_flag
-where.resolve_var
-where.resolve_vars
-where.resolve_vars_aux
-where.select_for_which
-where.sort_variable_list
-where.strip_namespace
-where.strip_pi_binders
-where.strip_pi_binders_aux
-where.trace_end
-where.trace_includes
-where.trace_namespace
-where.trace_nl
-where.trace_opens
-where.trace_variables
-where.trace_where
-where.where_cmd
-with_bot
-with_one
-with_one.lift
-with_one.map
-with_top
-with_top.canonically_ordered_comm_semiring
-with_top.coe_eq_zero
-with_top.coe_zero
-with_top.has_one
-with_top.top_ne_zero
-with_top.zero_ne_top
-with_zero
-with_zero.div
-with_zero.inv
-with_zero.lift
-with_zero.map
-with_zero.ordered_comm_monoid
-writer
-writer_t
-writer_t.adapt
-writer_t.bind
-writer_t.call_cc
-writer_t.ext
-writer_t.lift
-writer_t.listen
-writer_t.mk_label
-writer_t.monad_cont
-writer_t.monad_except
-writer_t.monad_map
-writer_t.pass
-writer_t.pure
-writer_t.tell
-wseq.bisim_o
-wseq.cases_on
-wseq.destruct_append.aux
-wseq.destruct_join.aux
-wseq.drop.aux
-wseq.lift_rel_o
-wseq.mem
-wseq.tail.aux
-wseq.think_congr
-zmod
-zmod.cast
-zmod.units_equiv_coprime
-zmodp
-zmodp.legendre_sym
-znum.abs
-znum.add
-znum.bit0
-znum.bit1
-znum.bitm1
-znum.cmp
-znum.cmp_to_int
-znum.div
-znum.gcd
-znum.mod
-znum.mul
-znum.of_int'
-znum.pred
-znum.succ
-znum.transfer
-znum.transfer_rw
-znum.zneg
-zsqrtd.le
-zsqrtd.lt
-zsqrtd.norm
+
+-- algebra/archimedean.lean
+apply_nolint archimedean doc_blame
+apply_nolint archimedean.floor_ring doc_blame
+
+-- algebra/associated.lean
+apply_nolint associated.setoid doc_blame
+apply_nolint associates doc_blame
+apply_nolint associates.mk doc_blame
+apply_nolint associates.prime doc_blame
+
+-- algebra/big_operators.lean
+apply_nolint finset.prod_ite unused_arguments
+apply_nolint finset.sum doc_blame
+apply_nolint finset.sum_ite unused_arguments
+
+-- algebra/category/CommRing/colimits.lean
+apply_nolint CommRing.colimits.cocone_fun doc_blame
+apply_nolint CommRing.colimits.cocone_morphism doc_blame
+apply_nolint CommRing.colimits.colimit doc_blame
+apply_nolint CommRing.colimits.colimit_cocone doc_blame
+apply_nolint CommRing.colimits.colimit_is_colimit doc_blame
+apply_nolint CommRing.colimits.colimit_type doc_blame has_inhabited_instance
+apply_nolint CommRing.colimits.desc_fun doc_blame
+apply_nolint CommRing.colimits.desc_fun_lift doc_blame
+apply_nolint CommRing.colimits.desc_morphism doc_blame
+apply_nolint CommRing.colimits.prequotient doc_blame has_inhabited_instance
+apply_nolint CommRing.colimits.relation doc_blame
+
+-- algebra/category/Group.lean
+apply_nolint AddCommGroup doc_blame
+apply_nolint AddCommGroup.of doc_blame
+apply_nolint AddGroup doc_blame
+apply_nolint AddGroup.of doc_blame
+
+-- algebra/category/Mon/basic.lean
+apply_nolint AddCommMon doc_blame
+apply_nolint AddCommMon.of doc_blame
+apply_nolint AddMon doc_blame
+apply_nolint AddMon.of doc_blame
+
+-- algebra/category/Mon/colimits.lean
+apply_nolint Mon.colimits.cocone_fun doc_blame
+apply_nolint Mon.colimits.cocone_morphism doc_blame
+apply_nolint Mon.colimits.colimit doc_blame
+apply_nolint Mon.colimits.colimit_cocone doc_blame
+apply_nolint Mon.colimits.colimit_is_colimit doc_blame
+apply_nolint Mon.colimits.colimit_type doc_blame has_inhabited_instance
+apply_nolint Mon.colimits.desc_fun doc_blame
+apply_nolint Mon.colimits.desc_fun_lift doc_blame
+apply_nolint Mon.colimits.desc_morphism doc_blame
+apply_nolint Mon.colimits.prequotient doc_blame has_inhabited_instance
+apply_nolint Mon.colimits.relation doc_blame
+
+-- algebra/commute.lean
+apply_nolint centralizer.add_submonoid doc_blame
+apply_nolint set.centralizer.add_submonoid doc_blame
+
+-- algebra/direct_limit.lean
+apply_nolint add_comm_group.direct_limit has_inhabited_instance
+apply_nolint field.direct_limit.discrete_field doc_blame
+apply_nolint field.direct_limit.field doc_blame
+apply_nolint field.direct_limit.inv doc_blame
+apply_nolint module.direct_limit unused_arguments has_inhabited_instance
+apply_nolint module.direct_limit.totalize unused_arguments doc_blame
+apply_nolint ring.direct_limit unused_arguments has_inhabited_instance
+
+-- algebra/direct_sum.lean
+apply_nolint direct_sum unused_arguments doc_blame
+apply_nolint direct_sum.id doc_blame
+apply_nolint direct_sum.mk doc_blame
+apply_nolint direct_sum.of doc_blame
+apply_nolint direct_sum.set_to_set doc_blame
+apply_nolint direct_sum.to_group doc_blame
+
+-- algebra/euclidean_domain.lean
+apply_nolint euclidean_domain doc_blame
+apply_nolint euclidean_domain.gcd doc_blame
+apply_nolint euclidean_domain.lcm doc_blame
+apply_nolint euclidean_domain.xgcd_aux doc_blame
+
+-- algebra/free.lean
+apply_nolint free_magma doc_blame
+apply_nolint free_magma.length doc_blame
+apply_nolint free_magma.lift doc_blame
+apply_nolint free_magma.map doc_blame
+apply_nolint free_magma.repr' doc_blame
+apply_nolint free_magma.traverse doc_blame
+apply_nolint free_semigroup doc_blame
+apply_nolint free_semigroup.lift doc_blame
+apply_nolint free_semigroup.lift' doc_blame
+apply_nolint free_semigroup.map doc_blame
+apply_nolint free_semigroup.of doc_blame
+apply_nolint free_semigroup.traverse doc_blame
+apply_nolint free_semigroup.traverse' doc_blame
+apply_nolint free_semigroup_free_magma doc_blame
+apply_nolint magma.free_semigroup doc_blame
+apply_nolint magma.free_semigroup.lift doc_blame
+apply_nolint magma.free_semigroup.map doc_blame
+apply_nolint magma.free_semigroup.of doc_blame
+apply_nolint magma.free_semigroup.r doc_blame
+
+-- algebra/gcd_domain.lean
+apply_nolint associates.out doc_blame
+apply_nolint associates_int_equiv_nat doc_blame
+apply_nolint normalize doc_blame
+
+-- algebra/group/conj.lean
+apply_nolint is_conj doc_blame
+
+-- algebra/group/free_monoid.lean
+apply_nolint free_add_monoid doc_blame
+apply_nolint free_monoid doc_blame
+
+-- algebra/group/hom.lean
+apply_nolint add_monoid_hom.add doc_blame
+apply_nolint add_monoid_hom.comp doc_blame
+apply_nolint add_monoid_hom.id doc_blame
+apply_nolint add_monoid_hom.mk' doc_blame
+apply_nolint add_monoid_hom.neg doc_blame
+apply_nolint add_monoid_hom.zero doc_blame
+apply_nolint monoid_hom.one doc_blame
+
+-- algebra/group/to_additive.lean
+apply_nolint to_additive.attr doc_blame
+apply_nolint to_additive.aux_attr doc_blame
+apply_nolint to_additive.guess_name doc_blame
+apply_nolint to_additive.map_namespace doc_blame
+apply_nolint to_additive.parser doc_blame
+apply_nolint to_additive.proceed_fields doc_blame
+apply_nolint to_additive.target_name doc_blame
+apply_nolint to_additive.tokens_dict doc_blame
+apply_nolint to_additive.value_type doc_blame
+
+-- algebra/group/type_tags.lean
+apply_nolint additive doc_blame
+apply_nolint multiplicative doc_blame
+
+-- algebra/group/units.lean
+apply_nolint units.inv' doc_blame
+apply_nolint units.mk_of_mul_eq_one doc_blame
+apply_nolint units.mul doc_blame
+
+-- algebra/group/with_one.lean
+apply_nolint with_one doc_blame
+apply_nolint with_one.lift doc_blame
+apply_nolint with_one.map doc_blame
+apply_nolint with_zero doc_blame
+apply_nolint with_zero.div doc_blame
+apply_nolint with_zero.inv doc_blame
+apply_nolint with_zero.lift doc_blame
+apply_nolint with_zero.map doc_blame
+
+-- algebra/group_power.lean
+apply_nolint add_monoid.smul doc_blame
+apply_nolint gsmul doc_blame
+
+-- algebra/lie_algebra.lean
+apply_nolint lie_algebra.morphism has_inhabited_instance
+apply_nolint lie_subalgebra has_inhabited_instance
+apply_nolint lie_submodule has_inhabited_instance
+
+-- algebra/module.lean
+apply_nolint ideal doc_blame
+apply_nolint is_add_group_hom.to_linear_map doc_blame
+apply_nolint is_linear_map doc_blame
+apply_nolint is_linear_map.mk' doc_blame
+apply_nolint is_ring_hom.to_module doc_blame
+apply_nolint linear_map doc_blame
+apply_nolint linear_map.comp doc_blame
+apply_nolint linear_map.id doc_blame
+apply_nolint module.End doc_blame
+apply_nolint module.core doc_blame has_inhabited_instance
+apply_nolint module.of_core doc_blame
+apply_nolint submodule.subtype doc_blame
+
+-- algebra/order.lean
+apply_nolint decidable.lt_by_cases doc_blame
+apply_nolint ge_iff_le ge_or_gt
+apply_nolint gt_iff_lt ge_or_gt
+apply_nolint ordering.compares.eq_gt ge_or_gt
+
+-- algebra/ordered_group.lean
+apply_nolint nonneg_comm_group.to_decidable_linear_ordered_comm_group doc_blame
+apply_nolint with_zero.ordered_comm_monoid doc_blame
+
+-- algebra/ordered_ring.lean
+apply_nolint canonically_ordered_comm_semiring doc_blame
+apply_nolint nonneg_ring.to_linear_nonneg_ring doc_blame
+apply_nolint with_top.canonically_ordered_comm_semiring unused_arguments
+apply_nolint with_top.coe_eq_zero unused_arguments
+apply_nolint with_top.coe_zero unused_arguments
+apply_nolint with_top.has_one unused_arguments
+apply_nolint with_top.top_ne_zero unused_arguments
+apply_nolint with_top.zero_ne_top unused_arguments
+
+-- algebra/pointwise.lean
+apply_nolint set.add_comm_monoid doc_blame
+apply_nolint set.comm_monoid doc_blame
+apply_nolint set.pointwise_add doc_blame
+apply_nolint set.pointwise_add_add_monoid doc_blame
+apply_nolint set.pointwise_add_add_semigroup doc_blame
+apply_nolint set.pointwise_add_fintype doc_blame
+apply_nolint set.pointwise_inv doc_blame
+apply_nolint set.pointwise_mul doc_blame
+apply_nolint set.pointwise_mul_comm_semiring doc_blame
+apply_nolint set.pointwise_mul_fintype doc_blame
+apply_nolint set.pointwise_mul_monoid doc_blame
+apply_nolint set.pointwise_mul_semigroup doc_blame
+apply_nolint set.pointwise_mul_semiring doc_blame
+apply_nolint set.pointwise_neg doc_blame
+apply_nolint set.pointwise_one doc_blame
+apply_nolint set.pointwise_zero doc_blame
+
+-- algebra/ring.lean
+apply_nolint ring_hom has_inhabited_instance
+apply_nolint ring_hom.to_add_monoid_hom doc_blame
+apply_nolint ring_hom.to_monoid_hom doc_blame
+
+-- algebraic_geometry/presheafed_space.lean
+apply_nolint algebraic_geometry.PresheafedSpace has_inhabited_instance
+apply_nolint algebraic_geometry.PresheafedSpace.comp doc_blame
+apply_nolint algebraic_geometry.PresheafedSpace.hom has_inhabited_instance
+apply_nolint algebraic_geometry.PresheafedSpace.id doc_blame
+apply_nolint category_theory.nat_trans.on_presheaf doc_blame
+
+-- algebraic_geometry/prime_spectrum.lean
+apply_nolint prime_spectrum has_inhabited_instance
+
+-- algebraic_geometry/stalks.lean
+apply_nolint algebraic_geometry.PresheafedSpace.stalk doc_blame
+apply_nolint algebraic_geometry.PresheafedSpace.stalk_map doc_blame
+
+-- analysis/calculus/times_cont_diff.lean
+apply_nolint times_cont_diff.times_cont_diff_fderiv_apply unused_arguments
+
+-- analysis/normed_space/basic.lean
+apply_nolint normed_group.tendsto_nhds_zero ge_or_gt
+apply_nolint summable_iff_vanishing_norm ge_or_gt
+
+-- analysis/normed_space/real_inner_product.lean
+apply_nolint has_inner doc_blame
+
+-- category/applicative.lean
+apply_nolint comp.seq doc_blame
+
+-- category/basic.lean
+apply_nolint is_comm_applicative doc_blame
+apply_nolint list.mmap_accuml doc_blame
+apply_nolint list.mmap_accumr doc_blame
+apply_nolint list.mpartition doc_blame
+apply_nolint mtry doc_blame
+apply_nolint mzip_with doc_blame
+apply_nolint mzip_with' doc_blame
+apply_nolint succeeds doc_blame
+apply_nolint sum.bind doc_blame
+
+-- category/bifunctor.lean
+apply_nolint bifunctor doc_blame
+apply_nolint bifunctor.fst doc_blame
+apply_nolint bifunctor.snd doc_blame
+apply_nolint is_lawful_bifunctor doc_blame
+
+-- category/bitraversable/basic.lean
+apply_nolint bisequence doc_blame
+apply_nolint bitraversable doc_blame
+apply_nolint is_lawful_bitraversable doc_blame
+
+-- category/bitraversable/instances.lean
+apply_nolint bicompl.bitraverse doc_blame
+apply_nolint bicompr.bitraverse doc_blame
+apply_nolint const.bitraverse unused_arguments doc_blame
+apply_nolint flip.bitraverse doc_blame
+apply_nolint prod.bitraverse doc_blame
+apply_nolint sum.bitraverse doc_blame
+
+-- category/fold.lean
+apply_nolint monoid.foldl.get doc_blame
+apply_nolint monoid.foldl.mk doc_blame
+apply_nolint monoid.foldl.of_free_monoid doc_blame
+apply_nolint monoid.foldr doc_blame
+apply_nolint monoid.foldr.get doc_blame
+apply_nolint monoid.foldr.mk doc_blame
+apply_nolint monoid.foldr.of_free_monoid doc_blame
+apply_nolint monoid.mfoldl doc_blame
+apply_nolint monoid.mfoldl.get doc_blame
+apply_nolint monoid.mfoldl.mk doc_blame
+apply_nolint monoid.mfoldl.of_free_monoid doc_blame
+apply_nolint monoid.mfoldr doc_blame
+apply_nolint monoid.mfoldr.get doc_blame
+apply_nolint monoid.mfoldr.mk doc_blame
+apply_nolint monoid.mfoldr.of_free_monoid doc_blame
+apply_nolint traversable.fold_map doc_blame
+apply_nolint traversable.foldl doc_blame
+apply_nolint traversable.foldr doc_blame
+apply_nolint traversable.free.map doc_blame
+apply_nolint traversable.free.mk doc_blame
+apply_nolint traversable.length doc_blame
+apply_nolint traversable.map_fold doc_blame
+apply_nolint traversable.mfoldl doc_blame
+apply_nolint traversable.mfoldl.unop_of_free_monoid unused_arguments
+apply_nolint traversable.mfoldr doc_blame
+
+-- category/functor.lean
+apply_nolint functor.add_const doc_blame has_inhabited_instance
+apply_nolint functor.add_const.mk doc_blame
+apply_nolint functor.add_const.run doc_blame
+apply_nolint functor.comp has_inhabited_instance
+apply_nolint functor.comp.map doc_blame
+apply_nolint functor.comp.mk doc_blame
+apply_nolint functor.comp.run doc_blame
+apply_nolint functor.const has_inhabited_instance
+apply_nolint functor.const.mk doc_blame
+apply_nolint functor.const.mk' doc_blame
+apply_nolint functor.const.run doc_blame
+apply_nolint id.mk doc_blame
+
+-- category/monad/cont.lean
+apply_nolint cont doc_blame
+apply_nolint cont_t doc_blame has_inhabited_instance
+apply_nolint cont_t.map doc_blame
+apply_nolint cont_t.monad_lift doc_blame
+apply_nolint cont_t.run doc_blame
+apply_nolint cont_t.with_cont_t doc_blame
+apply_nolint except_t.call_cc doc_blame
+apply_nolint except_t.mk_label doc_blame
+apply_nolint is_lawful_monad_cont doc_blame
+apply_nolint monad_cont doc_blame
+apply_nolint monad_cont.goto doc_blame
+apply_nolint monad_cont.label doc_blame has_inhabited_instance
+apply_nolint option_t.call_cc doc_blame
+apply_nolint option_t.mk_label doc_blame
+apply_nolint reader_t.call_cc doc_blame
+apply_nolint reader_t.mk_label doc_blame
+apply_nolint state_t.call_cc doc_blame
+apply_nolint state_t.mk_label unused_arguments doc_blame
+apply_nolint writer_t.call_cc doc_blame
+apply_nolint writer_t.mk_label doc_blame
+apply_nolint writer_t.monad_cont unused_arguments
+
+-- category/monad/writer.lean
+apply_nolint except_t.pass_aux doc_blame
+apply_nolint option_t.pass_aux doc_blame
+apply_nolint swap_right doc_blame
+apply_nolint writer doc_blame
+apply_nolint writer_t doc_blame has_inhabited_instance
+apply_nolint writer_t.adapt doc_blame
+apply_nolint writer_t.bind doc_blame
+apply_nolint writer_t.ext unused_arguments
+apply_nolint writer_t.lift doc_blame
+apply_nolint writer_t.listen doc_blame
+apply_nolint writer_t.monad_except unused_arguments
+apply_nolint writer_t.monad_map unused_arguments doc_blame
+apply_nolint writer_t.pass doc_blame
+apply_nolint writer_t.pure doc_blame
+apply_nolint writer_t.tell doc_blame
+
+-- category/traversable/basic.lean
+apply_nolint applicative_transformation doc_blame has_inhabited_instance
+apply_nolint is_lawful_traversable doc_blame
+apply_nolint sequence doc_blame
+apply_nolint sum.traverse doc_blame
+apply_nolint traversable doc_blame
+
+-- category/traversable/derive.lean
+apply_nolint tactic.interactive.derive_functor doc_blame
+apply_nolint tactic.interactive.derive_lawful_functor doc_blame
+apply_nolint tactic.interactive.derive_lawful_traversable doc_blame
+apply_nolint tactic.interactive.derive_traverse doc_blame
+apply_nolint tactic.interactive.functor_derive_handler doc_blame
+apply_nolint tactic.interactive.functor_derive_handler' doc_blame
+apply_nolint tactic.interactive.get_equations_of doc_blame
+apply_nolint tactic.interactive.guard_class doc_blame
+apply_nolint tactic.interactive.higher_order_derive_handler doc_blame
+apply_nolint tactic.interactive.lawful_functor_derive_handler doc_blame
+apply_nolint tactic.interactive.lawful_functor_derive_handler' doc_blame
+apply_nolint tactic.interactive.lawful_traversable_derive_handler doc_blame
+apply_nolint tactic.interactive.lawful_traversable_derive_handler' doc_blame
+apply_nolint tactic.interactive.mk_mapp' doc_blame
+apply_nolint tactic.interactive.mk_mapp_aux' doc_blame
+apply_nolint tactic.interactive.mk_one_instance doc_blame
+apply_nolint tactic.interactive.simp_functor doc_blame
+apply_nolint tactic.interactive.traversable_derive_handler doc_blame
+apply_nolint tactic.interactive.traversable_derive_handler' doc_blame
+apply_nolint tactic.interactive.traversable_law_starter doc_blame
+apply_nolint tactic.interactive.traverse_constructor unused_arguments
+apply_nolint tactic.interactive.traverse_field unused_arguments
+apply_nolint tactic.interactive.with_prefix doc_blame
+
+-- category/traversable/equiv.lean
+apply_nolint equiv.functor doc_blame
+apply_nolint equiv.is_lawful_traversable doc_blame
+apply_nolint equiv.is_lawful_traversable' doc_blame
+apply_nolint equiv.map doc_blame
+apply_nolint equiv.traversable doc_blame
+apply_nolint equiv.traverse doc_blame
+
+-- category/traversable/instances.lean
+apply_nolint list.comp_traverse unused_arguments
+apply_nolint option.comp_traverse unused_arguments
+apply_nolint sum.comp_traverse unused_arguments
+apply_nolint sum.traverse_map unused_arguments
+
+-- category/traversable/lemmas.lean
+apply_nolint traversable.pure_transformation doc_blame
+
+-- category_theory/adjunction/basic.lean
+apply_nolint category_theory.adjunction has_inhabited_instance
+apply_nolint category_theory.adjunction.adjunction_of_equiv_left doc_blame
+apply_nolint category_theory.adjunction.adjunction_of_equiv_right doc_blame
+apply_nolint category_theory.adjunction.comp doc_blame
+apply_nolint category_theory.adjunction.core_hom_equiv doc_blame has_inhabited_instance
+apply_nolint category_theory.adjunction.core_unit_counit doc_blame has_inhabited_instance
+apply_nolint category_theory.adjunction.id doc_blame
+apply_nolint category_theory.adjunction.left_adjoint_of_equiv doc_blame
+apply_nolint category_theory.adjunction.mk_of_hom_equiv doc_blame
+apply_nolint category_theory.adjunction.mk_of_unit_counit doc_blame
+apply_nolint category_theory.adjunction.right_adjoint_of_equiv doc_blame
+apply_nolint category_theory.equivalence.to_adjunction doc_blame
+apply_nolint category_theory.functor.adjunction doc_blame
+apply_nolint category_theory.is_left_adjoint doc_blame
+apply_nolint category_theory.is_right_adjoint doc_blame
+apply_nolint category_theory.left_adjoint doc_blame
+apply_nolint category_theory.right_adjoint doc_blame
+
+-- category_theory/adjunction/limits.lean
+apply_nolint category_theory.adjunction.cocones_iso doc_blame
+apply_nolint category_theory.adjunction.cones_iso doc_blame
+apply_nolint category_theory.adjunction.functoriality_counit doc_blame
+apply_nolint category_theory.adjunction.functoriality_counit' doc_blame
+apply_nolint category_theory.adjunction.functoriality_is_left_adjoint doc_blame
+apply_nolint category_theory.adjunction.functoriality_is_right_adjoint doc_blame
+apply_nolint category_theory.adjunction.functoriality_left_adjoint doc_blame
+apply_nolint category_theory.adjunction.functoriality_right_adjoint doc_blame
+apply_nolint category_theory.adjunction.functoriality_unit doc_blame
+apply_nolint category_theory.adjunction.functoriality_unit' doc_blame
+apply_nolint category_theory.adjunction.has_colimit_of_comp_equivalence doc_blame
+apply_nolint category_theory.adjunction.has_limit_of_comp_equivalence doc_blame
+
+-- category_theory/category/Cat.lean
+apply_nolint category_theory.Cat has_inhabited_instance
+
+-- category_theory/category/Kleisli.lean
+apply_nolint category_theory.Kleisli unused_arguments doc_blame has_inhabited_instance
+apply_nolint category_theory.Kleisli.comp_def unused_arguments
+apply_nolint category_theory.Kleisli.id_def unused_arguments
+apply_nolint category_theory.Kleisli.mk doc_blame has_inhabited_instance
+
+-- category_theory/category/default.lean
+apply_nolint category_theory.category_struct doc_blame
+apply_nolint category_theory.epi doc_blame
+apply_nolint category_theory.has_hom doc_blame
+apply_nolint category_theory.mono doc_blame
+apply_nolint category_theory.obviously' doc_blame
+apply_nolint obviously.attr doc_blame
+
+-- category_theory/comma.lean
+apply_nolint category_theory.comma doc_blame has_inhabited_instance
+apply_nolint category_theory.comma.fst doc_blame
+apply_nolint category_theory.comma.map_left doc_blame
+apply_nolint category_theory.comma.map_left_comp doc_blame
+apply_nolint category_theory.comma.map_left_id doc_blame
+apply_nolint category_theory.comma.map_right doc_blame
+apply_nolint category_theory.comma.map_right_comp doc_blame
+apply_nolint category_theory.comma.map_right_id doc_blame
+apply_nolint category_theory.comma.nat_trans doc_blame
+apply_nolint category_theory.comma.snd doc_blame
+apply_nolint category_theory.comma_morphism doc_blame has_inhabited_instance
+apply_nolint category_theory.over doc_blame has_inhabited_instance
+apply_nolint category_theory.over.forget doc_blame
+apply_nolint category_theory.over.hom_mk doc_blame
+apply_nolint category_theory.over.map doc_blame
+apply_nolint category_theory.over.mk doc_blame
+apply_nolint category_theory.over.post doc_blame
+apply_nolint category_theory.under doc_blame has_inhabited_instance
+apply_nolint category_theory.under.forget doc_blame
+apply_nolint category_theory.under.hom_mk doc_blame
+apply_nolint category_theory.under.map doc_blame
+apply_nolint category_theory.under.mk doc_blame
+apply_nolint category_theory.under.post doc_blame
+
+-- category_theory/concrete_category/bundled.lean
+apply_nolint category_theory.bundled has_inhabited_instance
+
+-- category_theory/conj.lean
+apply_nolint category_theory.iso.hom_congr doc_blame
+
+-- category_theory/const.lean
+apply_nolint category_theory.functor.const doc_blame
+apply_nolint category_theory.functor.const.op_obj_op doc_blame
+apply_nolint category_theory.functor.const.op_obj_unop doc_blame
+
+-- category_theory/core.lean
+apply_nolint category_theory.core doc_blame has_inhabited_instance
+apply_nolint category_theory.core.forget_functor_to_core doc_blame
+apply_nolint category_theory.core.inclusion doc_blame
+
+-- category_theory/currying.lean
+apply_nolint category_theory.curry doc_blame
+apply_nolint category_theory.curry_obj doc_blame
+apply_nolint category_theory.currying doc_blame
+apply_nolint category_theory.uncurry doc_blame
+
+-- category_theory/discrete_category.lean
+apply_nolint category_theory.discrete doc_blame
+apply_nolint category_theory.discrete.lift doc_blame
+apply_nolint category_theory.discrete.opposite doc_blame
+apply_nolint category_theory.functor.of_function doc_blame
+apply_nolint category_theory.nat_iso.of_isos doc_blame
+apply_nolint category_theory.nat_trans.of_function doc_blame
+apply_nolint category_theory.nat_trans.of_homs doc_blame
+
+-- category_theory/elements.lean
+apply_nolint category_theory.functor.elements has_inhabited_instance
+
+-- category_theory/endomorphism.lean
+apply_nolint category_theory.Aut doc_blame has_inhabited_instance
+apply_nolint category_theory.End has_inhabited_instance
+
+-- category_theory/eq_to_hom.lean
+apply_nolint category_theory.eq_to_hom doc_blame
+apply_nolint category_theory.eq_to_iso doc_blame
+
+-- category_theory/equivalence.lean
+apply_nolint category_theory.equivalence has_inhabited_instance
+apply_nolint category_theory.equivalence.adjointify_η doc_blame
+apply_nolint category_theory.equivalence.counit doc_blame
+apply_nolint category_theory.equivalence.counit_inv doc_blame
+apply_nolint category_theory.equivalence.equivalence_of_fully_faithfully_ess_surj doc_blame
+apply_nolint category_theory.equivalence.ess_surj_of_equivalence doc_blame
+apply_nolint category_theory.equivalence.fun_inv_id_assoc doc_blame
+apply_nolint category_theory.equivalence.inv_fun_id_assoc doc_blame
+apply_nolint category_theory.equivalence.mk doc_blame
+apply_nolint category_theory.equivalence.refl doc_blame
+apply_nolint category_theory.equivalence.symm doc_blame
+apply_nolint category_theory.equivalence.trans doc_blame
+apply_nolint category_theory.equivalence.unit doc_blame
+apply_nolint category_theory.equivalence.unit_inv doc_blame
+apply_nolint category_theory.ess_surj doc_blame
+apply_nolint category_theory.ess_surj.iso doc_blame
+apply_nolint category_theory.functor.as_equivalence doc_blame
+apply_nolint category_theory.functor.fun_inv_id doc_blame
+apply_nolint category_theory.functor.fun_obj_preimage_iso doc_blame
+apply_nolint category_theory.functor.inv doc_blame
+apply_nolint category_theory.functor.inv_fun_id doc_blame
+apply_nolint category_theory.functor.obj_preimage doc_blame
+apply_nolint category_theory.is_equivalence.mk doc_blame
+
+-- category_theory/full_subcategory.lean
+apply_nolint category_theory.full_subcategory_inclusion doc_blame
+apply_nolint category_theory.induced_category unused_arguments doc_blame has_inhabited_instance
+apply_nolint category_theory.induced_functor doc_blame
+
+-- category_theory/fully_faithful.lean
+apply_nolint category_theory.is_iso_of_fully_faithful doc_blame
+
+-- category_theory/functor.lean
+apply_nolint category_theory.functor has_inhabited_instance
+apply_nolint category_theory.functor.ulift_down doc_blame
+apply_nolint category_theory.functor.ulift_up doc_blame
+
+-- category_theory/functor_category.lean
+apply_nolint category_theory.functor.flip doc_blame
+
+-- category_theory/groupoid.lean
+apply_nolint category_theory.large_groupoid doc_blame
+apply_nolint category_theory.small_groupoid doc_blame
+
+-- category_theory/isomorphism.lean
+apply_nolint category_theory.as_iso doc_blame
+apply_nolint category_theory.functor.map_iso doc_blame
+apply_nolint category_theory.iso doc_blame has_inhabited_instance
+apply_nolint category_theory.iso.refl doc_blame
+apply_nolint category_theory.iso.symm doc_blame
+apply_nolint category_theory.iso.trans doc_blame
+
+-- category_theory/limits/cones.lean
+apply_nolint category_theory.functor.map_cocone_morphism doc_blame
+apply_nolint category_theory.functor.map_cone_inv doc_blame
+apply_nolint category_theory.functor.map_cone_morphism doc_blame
+apply_nolint category_theory.limits.cocone has_inhabited_instance
+apply_nolint category_theory.limits.cocone.equiv doc_blame
+apply_nolint category_theory.limits.cocone.extensions doc_blame
+apply_nolint category_theory.limits.cocone.whisker doc_blame
+apply_nolint category_theory.limits.cocone_left_op_of_cone doc_blame
+apply_nolint category_theory.limits.cocone_morphism doc_blame has_inhabited_instance
+apply_nolint category_theory.limits.cocone_of_cone_left_op doc_blame
+apply_nolint category_theory.limits.cocones.forget doc_blame
+apply_nolint category_theory.limits.cocones.functoriality doc_blame
+apply_nolint category_theory.limits.cocones.precompose doc_blame
+apply_nolint category_theory.limits.cocones.precompose_comp doc_blame
+apply_nolint category_theory.limits.cocones.precompose_equivalence doc_blame
+apply_nolint category_theory.limits.cocones.precompose_id doc_blame
+apply_nolint category_theory.limits.cone has_inhabited_instance
+apply_nolint category_theory.limits.cone.equiv doc_blame
+apply_nolint category_theory.limits.cone.extensions doc_blame
+apply_nolint category_theory.limits.cone.whisker doc_blame
+apply_nolint category_theory.limits.cone_left_op_of_cocone doc_blame
+apply_nolint category_theory.limits.cone_morphism doc_blame has_inhabited_instance
+apply_nolint category_theory.limits.cone_of_cocone_left_op doc_blame
+apply_nolint category_theory.limits.cones.forget doc_blame
+apply_nolint category_theory.limits.cones.functoriality doc_blame
+apply_nolint category_theory.limits.cones.postcompose doc_blame
+apply_nolint category_theory.limits.cones.postcompose_comp doc_blame
+apply_nolint category_theory.limits.cones.postcompose_equivalence doc_blame
+apply_nolint category_theory.limits.cones.postcompose_id doc_blame
+
+-- category_theory/limits/functor_category.lean
+apply_nolint category_theory.limits.evaluate_functor_category_colimit_cocone doc_blame
+apply_nolint category_theory.limits.evaluate_functor_category_limit_cone doc_blame
+apply_nolint category_theory.limits.functor_category_colimit_cocone doc_blame
+apply_nolint category_theory.limits.functor_category_is_colimit_cocone doc_blame
+apply_nolint category_theory.limits.functor_category_is_limit_cone doc_blame
+apply_nolint category_theory.limits.functor_category_limit_cone doc_blame
+
+-- category_theory/limits/limits.lean
+apply_nolint category_theory.limits.colim_coyoneda doc_blame
+apply_nolint category_theory.limits.colimit doc_blame
+apply_nolint category_theory.limits.colimit.cocone doc_blame
+apply_nolint category_theory.limits.colimit.cocone_morphism doc_blame
+apply_nolint category_theory.limits.colimit.desc doc_blame
+apply_nolint category_theory.limits.colimit.hom_iso doc_blame
+apply_nolint category_theory.limits.colimit.hom_iso' doc_blame
+apply_nolint category_theory.limits.colimit.is_colimit doc_blame
+apply_nolint category_theory.limits.colimit.post doc_blame
+apply_nolint category_theory.limits.colimit.pre doc_blame
+apply_nolint category_theory.limits.colimit.ι doc_blame
+apply_nolint category_theory.limits.has_colimit_of_equivalence_comp doc_blame
+apply_nolint category_theory.limits.has_colimit_of_iso doc_blame
+apply_nolint category_theory.limits.has_colimits_of_shape_of_equivalence doc_blame
+apply_nolint category_theory.limits.has_limit_of_equivalence_comp doc_blame
+apply_nolint category_theory.limits.has_limit_of_iso doc_blame
+apply_nolint category_theory.limits.has_limits_of_shape_of_equivalence doc_blame
+apply_nolint category_theory.limits.is_colimit has_inhabited_instance
+apply_nolint category_theory.limits.is_colimit.desc_cocone_morphism doc_blame
+apply_nolint category_theory.limits.is_colimit.hom_iso' doc_blame
+apply_nolint category_theory.limits.is_colimit.iso_unique_cocone_morphism doc_blame
+apply_nolint category_theory.limits.is_colimit.mk_cocone_morphism doc_blame
+apply_nolint category_theory.limits.is_colimit.of_iso_colimit doc_blame
+apply_nolint category_theory.limits.is_limit has_inhabited_instance
+apply_nolint category_theory.limits.is_limit.hom_iso' doc_blame
+apply_nolint category_theory.limits.is_limit.iso_unique_cone_morphism doc_blame
+apply_nolint category_theory.limits.is_limit.lift_cone_morphism doc_blame
+apply_nolint category_theory.limits.is_limit.mk_cone_morphism doc_blame
+apply_nolint category_theory.limits.is_limit.of_iso_limit doc_blame
+apply_nolint category_theory.limits.lim_yoneda doc_blame
+apply_nolint category_theory.limits.limit doc_blame
+apply_nolint category_theory.limits.limit.cone doc_blame
+apply_nolint category_theory.limits.limit.cone_morphism doc_blame
+apply_nolint category_theory.limits.limit.hom_iso doc_blame
+apply_nolint category_theory.limits.limit.hom_iso' doc_blame
+apply_nolint category_theory.limits.limit.is_limit doc_blame
+apply_nolint category_theory.limits.limit.lift doc_blame
+apply_nolint category_theory.limits.limit.post doc_blame
+apply_nolint category_theory.limits.limit.pre doc_blame
+apply_nolint category_theory.limits.limit.π doc_blame
+
+-- category_theory/limits/over.lean
+apply_nolint category_theory.functor.to_cocone doc_blame
+apply_nolint category_theory.functor.to_cone doc_blame
+apply_nolint category_theory.over.colimit doc_blame
+apply_nolint category_theory.over.forget_colimit_is_colimit doc_blame
+apply_nolint category_theory.under.forget_limit_is_limit doc_blame
+apply_nolint category_theory.under.limit doc_blame
+
+-- category_theory/limits/preserves.lean
+apply_nolint category_theory.limits.preserves_colimit doc_blame
+apply_nolint category_theory.limits.preserves_colimits doc_blame
+apply_nolint category_theory.limits.preserves_colimits_of_shape doc_blame
+apply_nolint category_theory.limits.preserves_limit doc_blame
+apply_nolint category_theory.limits.preserves_limits doc_blame
+apply_nolint category_theory.limits.preserves_limits_of_shape doc_blame
+apply_nolint category_theory.limits.reflects_colimit doc_blame
+apply_nolint category_theory.limits.reflects_colimits doc_blame
+apply_nolint category_theory.limits.reflects_colimits_of_shape doc_blame
+apply_nolint category_theory.limits.reflects_limit doc_blame
+apply_nolint category_theory.limits.reflects_limits doc_blame
+apply_nolint category_theory.limits.reflects_limits_of_shape doc_blame
+
+-- category_theory/limits/shapes/binary_products.lean
+apply_nolint category_theory.limits.binary_cofan doc_blame
+apply_nolint category_theory.limits.binary_cofan.mk doc_blame
+apply_nolint category_theory.limits.binary_fan doc_blame
+apply_nolint category_theory.limits.binary_fan.mk doc_blame
+apply_nolint category_theory.limits.coprod doc_blame
+apply_nolint category_theory.limits.coprod.desc doc_blame
+apply_nolint category_theory.limits.coprod.inl doc_blame
+apply_nolint category_theory.limits.coprod.inr doc_blame
+apply_nolint category_theory.limits.coprod.map doc_blame
+apply_nolint category_theory.limits.has_binary_coproducts doc_blame
+apply_nolint category_theory.limits.has_binary_products doc_blame
+apply_nolint category_theory.limits.map_pair doc_blame
+apply_nolint category_theory.limits.pair doc_blame
+apply_nolint category_theory.limits.pair_function doc_blame
+apply_nolint category_theory.limits.prod doc_blame
+apply_nolint category_theory.limits.prod.fst doc_blame
+apply_nolint category_theory.limits.prod.lift doc_blame
+apply_nolint category_theory.limits.prod.map doc_blame
+apply_nolint category_theory.limits.prod.snd doc_blame
+apply_nolint category_theory.limits.walking_pair has_inhabited_instance
+
+-- category_theory/limits/shapes/equalizers.lean
+apply_nolint category_theory.limits.cocone.of_cofork doc_blame
+apply_nolint category_theory.limits.coequalizer doc_blame
+apply_nolint category_theory.limits.coequalizer.desc doc_blame
+apply_nolint category_theory.limits.coequalizer.π doc_blame
+apply_nolint category_theory.limits.cofork doc_blame
+apply_nolint category_theory.limits.cofork.of_cocone doc_blame
+apply_nolint category_theory.limits.cofork.of_π doc_blame
+apply_nolint category_theory.limits.cofork.π doc_blame
+apply_nolint category_theory.limits.cone.of_fork doc_blame
+apply_nolint category_theory.limits.equalizer doc_blame
+apply_nolint category_theory.limits.equalizer.lift doc_blame
+apply_nolint category_theory.limits.equalizer.ι doc_blame
+apply_nolint category_theory.limits.fork doc_blame
+apply_nolint category_theory.limits.fork.of_cone doc_blame
+apply_nolint category_theory.limits.fork.of_ι doc_blame
+apply_nolint category_theory.limits.fork.ι doc_blame
+apply_nolint category_theory.limits.parallel_pair doc_blame
+apply_nolint category_theory.limits.walking_parallel_pair has_inhabited_instance
+apply_nolint category_theory.limits.walking_parallel_pair_hom has_inhabited_instance
+apply_nolint category_theory.limits.walking_parallel_pair_hom.comp doc_blame
+
+-- category_theory/limits/shapes/finite_limits.lean
+apply_nolint category_theory.limits.has_finite_colimits doc_blame
+apply_nolint category_theory.limits.has_finite_limits doc_blame
+
+-- category_theory/limits/shapes/finite_products.lean
+apply_nolint category_theory.limits.has_finite_coproducts doc_blame
+apply_nolint category_theory.limits.has_finite_products doc_blame
+
+-- category_theory/limits/shapes/products.lean
+apply_nolint category_theory.limits.cofan doc_blame
+apply_nolint category_theory.limits.cofan.mk doc_blame
+apply_nolint category_theory.limits.fan doc_blame
+apply_nolint category_theory.limits.fan.mk doc_blame
+apply_nolint category_theory.limits.has_coproducts doc_blame
+apply_nolint category_theory.limits.has_products doc_blame
+apply_nolint category_theory.limits.pi.lift doc_blame
+apply_nolint category_theory.limits.pi.map doc_blame
+apply_nolint category_theory.limits.pi.π doc_blame
+apply_nolint category_theory.limits.sigma.desc doc_blame
+apply_nolint category_theory.limits.sigma.map doc_blame
+apply_nolint category_theory.limits.sigma.ι doc_blame
+
+-- category_theory/limits/shapes/pullbacks.lean
+apply_nolint category_theory.limits.cocone.of_pushout_cocone doc_blame
+apply_nolint category_theory.limits.cone.of_pullback_cone doc_blame
+apply_nolint category_theory.limits.has_pullbacks doc_blame
+apply_nolint category_theory.limits.has_pushouts doc_blame
+apply_nolint category_theory.limits.pullback.fst doc_blame
+apply_nolint category_theory.limits.pullback.lift doc_blame
+apply_nolint category_theory.limits.pullback.snd doc_blame
+apply_nolint category_theory.limits.pullback_cone doc_blame
+apply_nolint category_theory.limits.pullback_cone.fst doc_blame
+apply_nolint category_theory.limits.pullback_cone.mk doc_blame
+apply_nolint category_theory.limits.pullback_cone.of_cone doc_blame
+apply_nolint category_theory.limits.pullback_cone.snd doc_blame
+apply_nolint category_theory.limits.pushout.desc doc_blame
+apply_nolint category_theory.limits.pushout.inl doc_blame
+apply_nolint category_theory.limits.pushout.inr doc_blame
+apply_nolint category_theory.limits.pushout_cocone doc_blame
+apply_nolint category_theory.limits.pushout_cocone.inl doc_blame
+apply_nolint category_theory.limits.pushout_cocone.inr doc_blame
+apply_nolint category_theory.limits.pushout_cocone.mk doc_blame
+apply_nolint category_theory.limits.pushout_cocone.of_cocone doc_blame
+apply_nolint category_theory.limits.walking_cospan has_inhabited_instance
+apply_nolint category_theory.limits.walking_cospan.hom has_inhabited_instance
+apply_nolint category_theory.limits.walking_cospan.hom.comp doc_blame
+apply_nolint category_theory.limits.walking_span has_inhabited_instance
+apply_nolint category_theory.limits.walking_span.hom has_inhabited_instance
+apply_nolint category_theory.limits.walking_span.hom.comp doc_blame
+
+-- category_theory/limits/shapes/terminal.lean
+apply_nolint category_theory.limits.initial doc_blame
+apply_nolint category_theory.limits.terminal doc_blame
+
+-- category_theory/limits/types.lean
+apply_nolint category_theory.limits.types.colimit doc_blame
+apply_nolint category_theory.limits.types.colimit_is_colimit doc_blame
+apply_nolint category_theory.limits.types.limit doc_blame
+apply_nolint category_theory.limits.types.limit_is_limit doc_blame
+apply_nolint category_theory.limits.types.types_colimit_pre unused_arguments
+
+-- category_theory/monad/adjunction.lean
+apply_nolint category_theory.monad.comparison doc_blame
+apply_nolint category_theory.monad.comparison_forget doc_blame
+
+-- category_theory/monad/algebra.lean
+apply_nolint category_theory.monad.algebra has_inhabited_instance
+apply_nolint category_theory.monad.algebra.hom doc_blame has_inhabited_instance
+apply_nolint category_theory.monad.algebra.hom.comp doc_blame
+apply_nolint category_theory.monad.algebra.hom.id doc_blame
+apply_nolint category_theory.monad.forget doc_blame
+apply_nolint category_theory.monad.free doc_blame
+
+-- category_theory/monad/basic.lean
+apply_nolint category_theory.monad doc_blame
+
+-- category_theory/monad/limits.lean
+apply_nolint category_theory.has_limits_of_reflective doc_blame
+apply_nolint category_theory.monad.forget_creates_limits doc_blame
+apply_nolint category_theory.monad.forget_creates_limits.c doc_blame
+apply_nolint category_theory.monad.forget_creates_limits.cone_point doc_blame
+apply_nolint category_theory.monad.forget_creates_limits.γ unused_arguments doc_blame
+apply_nolint category_theory.monadic_creates_limits doc_blame
+
+-- category_theory/monoidal/functor.lean
+apply_nolint category_theory.lax_monoidal_functor has_inhabited_instance
+apply_nolint category_theory.monoidal_functor has_inhabited_instance
+apply_nolint category_theory.monoidal_functor.ε_iso doc_blame
+apply_nolint category_theory.monoidal_functor.μ_iso doc_blame
+
+-- category_theory/natural_isomorphism.lean
+apply_nolint category_theory.functor.ulift_down_up doc_blame
+apply_nolint category_theory.functor.ulift_up_down doc_blame
+apply_nolint category_theory.nat_iso.hcomp doc_blame
+apply_nolint category_theory.nat_iso.is_iso_app_of_is_iso doc_blame
+apply_nolint category_theory.nat_iso.is_iso_of_is_iso_app doc_blame
+apply_nolint category_theory.nat_iso.of_components doc_blame
+
+-- category_theory/natural_transformation.lean
+apply_nolint category_theory.nat_trans has_inhabited_instance
+
+-- category_theory/opposites.lean
+apply_nolint category_theory.functor.left_op doc_blame
+apply_nolint category_theory.functor.op doc_blame
+apply_nolint category_theory.functor.op_hom doc_blame
+apply_nolint category_theory.functor.op_inv doc_blame
+apply_nolint category_theory.functor.right_op doc_blame
+apply_nolint category_theory.functor.unop doc_blame
+apply_nolint category_theory.has_hom.hom.op doc_blame
+apply_nolint category_theory.has_hom.hom.unop doc_blame
+apply_nolint category_theory.is_iso_of_op doc_blame
+apply_nolint category_theory.iso.op doc_blame
+apply_nolint category_theory.nat_iso.op doc_blame
+apply_nolint category_theory.nat_trans.left_op doc_blame
+apply_nolint category_theory.nat_trans.op doc_blame
+apply_nolint category_theory.nat_trans.right_op doc_blame
+apply_nolint category_theory.nat_trans.unop doc_blame
+apply_nolint category_theory.op_op doc_blame
+
+-- category_theory/products/associator.lean
+apply_nolint category_theory.prod.associativity doc_blame
+apply_nolint category_theory.prod.associator doc_blame
+apply_nolint category_theory.prod.inverse_associator doc_blame
+
+-- category_theory/products/basic.lean
+apply_nolint category_theory.evaluation doc_blame
+apply_nolint category_theory.evaluation_uncurried doc_blame
+apply_nolint category_theory.prod.braiding doc_blame
+apply_nolint category_theory.prod.swap doc_blame
+apply_nolint category_theory.prod.symmetry doc_blame
+
+-- category_theory/punit.lean
+apply_nolint category_theory.functor.star doc_blame
+
+-- category_theory/single_obj.lean
+apply_nolint category_theory.single_obj unused_arguments has_inhabited_instance
+apply_nolint category_theory.single_obj.star doc_blame
+
+-- category_theory/sums/associator.lean
+apply_nolint category_theory.sum.associativity doc_blame
+apply_nolint category_theory.sum.associator doc_blame
+apply_nolint category_theory.sum.inverse_associator doc_blame
+
+-- category_theory/types.lean
+apply_nolint category_theory.functor.sections doc_blame
+apply_nolint category_theory.hom_of_element doc_blame
+apply_nolint category_theory.iso.to_equiv doc_blame
+apply_nolint category_theory.ulift_functor doc_blame
+apply_nolint category_theory.ulift_trivial doc_blame
+apply_nolint equiv.to_iso doc_blame
+
+-- category_theory/whiskering.lean
+apply_nolint category_theory.functor.associator doc_blame
+apply_nolint category_theory.functor.left_unitor doc_blame
+apply_nolint category_theory.functor.right_unitor doc_blame
+apply_nolint category_theory.iso_whisker_left doc_blame
+apply_nolint category_theory.iso_whisker_right doc_blame
+apply_nolint category_theory.whisker_left doc_blame
+apply_nolint category_theory.whisker_right doc_blame
+apply_nolint category_theory.whiskering_left doc_blame
+apply_nolint category_theory.whiskering_right doc_blame
+
+-- category_theory/yoneda.lean
+apply_nolint category_theory.coyoneda doc_blame
+apply_nolint category_theory.coyoneda.is_iso doc_blame
+apply_nolint category_theory.representable doc_blame
+apply_nolint category_theory.yoneda doc_blame
+apply_nolint category_theory.yoneda.is_iso doc_blame
+apply_nolint category_theory.yoneda_evaluation doc_blame
+apply_nolint category_theory.yoneda_lemma doc_blame
+apply_nolint category_theory.yoneda_pairing doc_blame
+apply_nolint category_theory.yoneda_sections doc_blame
+apply_nolint category_theory.yoneda_sections_small doc_blame
+
+-- computability/halting.lean
+apply_nolint computable_pred doc_blame
+apply_nolint nat.partrec'.vec doc_blame
+apply_nolint re_pred doc_blame
+
+-- computability/partrec.lean
+apply_nolint computable doc_blame
+apply_nolint computable₂ doc_blame
+apply_nolint nat.partrec doc_blame
+apply_nolint nat.rfind doc_blame
+apply_nolint nat.rfind_opt doc_blame
+apply_nolint nat.rfind_x doc_blame
+apply_nolint partrec doc_blame
+apply_nolint partrec₂ doc_blame
+
+-- computability/partrec_code.lean
+apply_nolint nat.partrec.code doc_blame
+apply_nolint nat.partrec.code.const doc_blame
+apply_nolint nat.partrec.code.curry doc_blame
+apply_nolint nat.partrec.code.encode_code doc_blame
+apply_nolint nat.partrec.code.eval doc_blame
+apply_nolint nat.partrec.code.evaln doc_blame
+apply_nolint nat.partrec.code.id doc_blame
+apply_nolint nat.partrec.code.of_nat_code doc_blame
+
+-- computability/primrec.lean
+apply_nolint nat.cases doc_blame
+apply_nolint nat.elim doc_blame
+apply_nolint nat.primrec'.vec doc_blame
+apply_nolint nat.unpaired doc_blame
+apply_nolint primcodable.of_equiv doc_blame
+apply_nolint primcodable.subtype doc_blame
+
+-- computability/turing_machine.lean
+apply_nolint turing.TM0.cfg.inhabited unused_arguments
+apply_nolint turing.TM0.cfg.map doc_blame
+apply_nolint turing.TM0.machine unused_arguments
+apply_nolint turing.TM0.machine.map doc_blame
+apply_nolint turing.TM0.machine.map_respects unused_arguments
+apply_nolint turing.TM0.machine.map_step unused_arguments
+apply_nolint turing.TM0.stmt.inhabited unused_arguments
+apply_nolint turing.TM0.stmt.map doc_blame
+apply_nolint turing.TM0to1.tr doc_blame
+apply_nolint turing.TM0to1.tr_cfg doc_blame
+apply_nolint turing.TM0to1.Λ' doc_blame
+apply_nolint turing.TM1.cfg.inhabited unused_arguments
+apply_nolint turing.TM1.eval doc_blame
+apply_nolint turing.TM1.init doc_blame
+apply_nolint turing.TM1.step doc_blame
+apply_nolint turing.TM1.stmts doc_blame
+apply_nolint turing.TM1.stmts₁ unused_arguments doc_blame
+apply_nolint turing.TM1.supports_stmt unused_arguments doc_blame
+apply_nolint turing.TM1to0.tr doc_blame
+apply_nolint turing.TM1to0.tr_aux doc_blame
+apply_nolint turing.TM1to0.tr_cfg doc_blame
+apply_nolint turing.TM1to0.tr_eval unused_arguments
+apply_nolint turing.TM1to0.tr_stmts doc_blame
+apply_nolint turing.TM1to0.Λ' unused_arguments doc_blame
+apply_nolint turing.TM1to1.move doc_blame
+apply_nolint turing.TM1to1.read doc_blame
+apply_nolint turing.TM1to1.read_aux doc_blame
+apply_nolint turing.TM1to1.step_aux_move unused_arguments
+apply_nolint turing.TM1to1.step_aux_write unused_arguments
+apply_nolint turing.TM1to1.supports_stmt_move unused_arguments
+apply_nolint turing.TM1to1.supports_stmt_write unused_arguments
+apply_nolint turing.TM1to1.tr doc_blame
+apply_nolint turing.TM1to1.tr_cfg doc_blame
+apply_nolint turing.TM1to1.tr_normal doc_blame
+apply_nolint turing.TM1to1.tr_supp doc_blame
+apply_nolint turing.TM1to1.tr_tape doc_blame
+apply_nolint turing.TM1to1.tr_tape' unused_arguments doc_blame
+apply_nolint turing.TM1to1.tr_tape_drop_right unused_arguments inhabited_nonempty
+apply_nolint turing.TM1to1.write doc_blame
+apply_nolint turing.TM1to1.writes doc_blame
+apply_nolint turing.TM1to1.Λ' doc_blame
+apply_nolint turing.TM2.cfg doc_blame
+apply_nolint turing.TM2.cfg.inhabited unused_arguments
+apply_nolint turing.TM2.eval doc_blame
+apply_nolint turing.TM2.init doc_blame
+apply_nolint turing.TM2.reaches doc_blame
+apply_nolint turing.TM2.step doc_blame
+apply_nolint turing.TM2.step_aux doc_blame
+apply_nolint turing.TM2.stmts doc_blame
+apply_nolint turing.TM2.stmts₁ unused_arguments doc_blame
+apply_nolint turing.TM2.supports doc_blame
+apply_nolint turing.TM2.supports_stmt unused_arguments doc_blame
+apply_nolint turing.TM2to1.st_act doc_blame
+apply_nolint turing.TM2to1.st_run unused_arguments doc_blame
+apply_nolint turing.TM2to1.st_var doc_blame
+apply_nolint turing.TM2to1.st_write doc_blame
+apply_nolint turing.TM2to1.stackel doc_blame
+apply_nolint turing.TM2to1.stackel.get doc_blame
+apply_nolint turing.TM2to1.stackel.is_bottom doc_blame
+apply_nolint turing.TM2to1.stackel.is_top doc_blame
+apply_nolint turing.TM2to1.stackel_equiv doc_blame
+apply_nolint turing.TM2to1.stmt_st_rec doc_blame
+apply_nolint turing.TM2to1.tr doc_blame
+apply_nolint turing.TM2to1.tr_cfg doc_blame
+apply_nolint turing.TM2to1.tr_init doc_blame
+apply_nolint turing.TM2to1.tr_normal doc_blame
+apply_nolint turing.TM2to1.tr_st_act doc_blame
+apply_nolint turing.TM2to1.tr_stk unused_arguments doc_blame
+apply_nolint turing.TM2to1.tr_stmts₁ unused_arguments doc_blame
+apply_nolint turing.TM2to1.tr_supp doc_blame
+apply_nolint turing.TM2to1.Γ' doc_blame
+apply_nolint turing.TM2to1.Λ' doc_blame
+apply_nolint turing.dwrite doc_blame
+apply_nolint turing.eval doc_blame
+apply_nolint turing.frespects doc_blame
+apply_nolint turing.pointed_map doc_blame
+apply_nolint turing.reaches doc_blame
+apply_nolint turing.reaches₀ doc_blame
+apply_nolint turing.reaches₁ doc_blame
+apply_nolint turing.respects doc_blame
+apply_nolint turing.tape doc_blame
+apply_nolint turing.tape.map doc_blame
+apply_nolint turing.tape.mk doc_blame
+apply_nolint turing.tape.mk' doc_blame
+apply_nolint turing.tape.move doc_blame
+apply_nolint turing.tape.nth doc_blame
+apply_nolint turing.tape.write doc_blame
+
+-- data/W.lean
+apply_nolint W has_inhabited_instance
+
+-- data/analysis/filter.lean
+apply_nolint cfilter has_inhabited_instance
+apply_nolint cfilter.to_realizer doc_blame
+apply_nolint filter.realizer has_inhabited_instance
+apply_nolint filter.realizer.of_eq doc_blame
+
+-- data/analysis/topology.lean
+apply_nolint compact.realizer unused_arguments doc_blame has_inhabited_instance
+apply_nolint ctop has_inhabited_instance
+apply_nolint ctop.realizer has_inhabited_instance
+apply_nolint ctop.realizer.id doc_blame
+apply_nolint ctop.realizer.nhds doc_blame
+apply_nolint ctop.realizer.nhds_F unused_arguments
+apply_nolint ctop.realizer.nhds_σ unused_arguments
+apply_nolint ctop.realizer.of_equiv doc_blame
+apply_nolint ctop.to_realizer doc_blame
+apply_nolint locally_finite.realizer doc_blame has_inhabited_instance
+
+-- data/array/lemmas.lean
+apply_nolint equiv.array_equiv_fin doc_blame
+apply_nolint equiv.d_array_equiv_fin doc_blame
+apply_nolint equiv.vector_equiv_array doc_blame
+apply_nolint equiv.vector_equiv_fin doc_blame
+
+-- data/buffer/basic.lean
+apply_nolint buffer.list_equiv_buffer doc_blame
+
+-- data/complex/basic.lean
+apply_nolint complex doc_blame
+apply_nolint complex.I doc_blame
+apply_nolint complex.abs doc_blame
+apply_nolint complex.cau_seq_abs doc_blame
+apply_nolint complex.cau_seq_conj doc_blame
+apply_nolint complex.cau_seq_im doc_blame
+apply_nolint complex.cau_seq_re doc_blame
+apply_nolint complex.conj doc_blame
+apply_nolint complex.lim_aux doc_blame
+apply_nolint complex.norm_sq doc_blame
+apply_nolint complex.of_real doc_blame
+apply_nolint complex.real_prod_equiv doc_blame
+
+-- data/complex/exponential.lean
+apply_nolint abv_sum_le_sum_abv unused_arguments
+apply_nolint cauchy_product ge_or_gt
+apply_nolint complex.cos doc_blame
+apply_nolint complex.cosh doc_blame
+apply_nolint complex.exp doc_blame
+apply_nolint complex.exp' doc_blame
+apply_nolint complex.sin doc_blame
+apply_nolint complex.sinh doc_blame
+apply_nolint complex.tan doc_blame
+apply_nolint complex.tanh doc_blame
+apply_nolint is_cau_series_of_abv_le_cau unused_arguments
+apply_nolint real.cos doc_blame
+apply_nolint real.cosh doc_blame
+apply_nolint real.exp doc_blame
+apply_nolint real.sin doc_blame
+apply_nolint real.sinh doc_blame
+apply_nolint real.tan doc_blame
+apply_nolint real.tanh doc_blame
+
+-- data/dfinsupp.lean
+apply_nolint decidable_zero_symm doc_blame
+apply_nolint dfinsupp doc_blame
+apply_nolint dfinsupp.decidable_eq unused_arguments
+apply_nolint dfinsupp.erase doc_blame
+apply_nolint dfinsupp.lmk doc_blame
+apply_nolint dfinsupp.lsingle doc_blame
+apply_nolint dfinsupp.map_range_def unused_arguments
+apply_nolint dfinsupp.map_range_single unused_arguments
+apply_nolint dfinsupp.mk doc_blame
+apply_nolint dfinsupp.pre doc_blame has_inhabited_instance
+apply_nolint dfinsupp.single doc_blame
+apply_nolint dfinsupp.subtype_domain_sum unused_arguments
+apply_nolint dfinsupp.sum_apply unused_arguments
+apply_nolint dfinsupp.support doc_blame
+apply_nolint dfinsupp.to_has_scalar doc_blame
+apply_nolint dfinsupp.to_module doc_blame
+apply_nolint dfinsupp.zip_with doc_blame
+apply_nolint dfinsupp.zip_with_def unused_arguments
+
+-- data/dlist/basic.lean
+apply_nolint dlist.join doc_blame
+
+-- data/dlist/instances.lean
+apply_nolint dlist.list_equiv_dlist doc_blame
+
+-- data/equiv/algebra.lean
+apply_nolint add_equiv has_inhabited_instance
+apply_nolint add_equiv.mk' doc_blame
+apply_nolint add_equiv.refl doc_blame
+apply_nolint add_equiv.symm doc_blame
+apply_nolint add_equiv.to_add_monoid_hom doc_blame
+apply_nolint add_equiv.to_equiv doc_blame
+apply_nolint add_equiv.trans doc_blame
+apply_nolint equiv.add_comm_group doc_blame
+apply_nolint equiv.add_comm_monoid doc_blame
+apply_nolint equiv.add_comm_semigroup doc_blame
+apply_nolint equiv.add_group doc_blame
+apply_nolint equiv.add_left doc_blame
+apply_nolint equiv.add_monoid doc_blame
+apply_nolint equiv.add_right doc_blame
+apply_nolint equiv.add_semigroup doc_blame
+apply_nolint equiv.comm_group doc_blame
+apply_nolint equiv.comm_monoid doc_blame
+apply_nolint equiv.comm_ring doc_blame
+apply_nolint equiv.comm_semigroup doc_blame
+apply_nolint equiv.comm_semiring doc_blame
+apply_nolint equiv.discrete_field doc_blame
+apply_nolint equiv.division_ring doc_blame
+apply_nolint equiv.domain doc_blame
+apply_nolint equiv.field doc_blame
+apply_nolint equiv.group doc_blame
+apply_nolint equiv.has_add doc_blame
+apply_nolint equiv.has_inv doc_blame
+apply_nolint equiv.has_mul doc_blame
+apply_nolint equiv.has_neg doc_blame
+apply_nolint equiv.has_one doc_blame
+apply_nolint equiv.has_zero doc_blame
+apply_nolint equiv.integral_domain doc_blame
+apply_nolint equiv.inv doc_blame
+apply_nolint equiv.monoid doc_blame
+apply_nolint equiv.mul_left doc_blame
+apply_nolint equiv.mul_right doc_blame
+apply_nolint equiv.neg doc_blame
+apply_nolint equiv.nonzero_comm_ring doc_blame
+apply_nolint equiv.ring doc_blame
+apply_nolint equiv.semigroup doc_blame
+apply_nolint equiv.semiring doc_blame
+apply_nolint equiv.units_equiv_ne_zero doc_blame
+apply_nolint equiv.zero_ne_one_class doc_blame
+apply_nolint mul_equiv has_inhabited_instance
+apply_nolint mul_equiv.to_equiv doc_blame
+apply_nolint ring_equiv doc_blame has_inhabited_instance
+apply_nolint ring_equiv.to_add_equiv doc_blame
+apply_nolint ring_equiv.to_equiv doc_blame
+apply_nolint ring_equiv.to_mul_equiv doc_blame
+apply_nolint units.map_equiv doc_blame
+
+-- data/equiv/basic.lean
+apply_nolint equiv has_inhabited_instance
+apply_nolint equiv.Pi_congr_right doc_blame
+apply_nolint equiv.Pi_curry doc_blame
+apply_nolint equiv.Prop_equiv_bool doc_blame
+apply_nolint equiv.arrow_arrow_equiv_prod_arrow doc_blame
+apply_nolint equiv.arrow_congr doc_blame
+apply_nolint equiv.arrow_prod_equiv_prod_arrow doc_blame
+apply_nolint equiv.arrow_punit_equiv_punit doc_blame
+apply_nolint equiv.bool_equiv_punit_sum_punit doc_blame
+apply_nolint equiv.bool_prod_equiv_sum doc_blame
+apply_nolint equiv.cast doc_blame
+apply_nolint equiv.conj doc_blame
+apply_nolint equiv.decidable_eq doc_blame
+apply_nolint equiv.decidable_eq_of_equiv doc_blame
+apply_nolint equiv.empty_arrow_equiv_punit doc_blame
+apply_nolint equiv.empty_equiv_pempty doc_blame
+apply_nolint equiv.empty_of_not_nonempty doc_blame
+apply_nolint equiv.empty_prod doc_blame
+apply_nolint equiv.empty_sum doc_blame
+apply_nolint equiv.equiv_congr doc_blame
+apply_nolint equiv.equiv_empty doc_blame
+apply_nolint equiv.equiv_pempty doc_blame
+apply_nolint equiv.false_arrow_equiv_punit doc_blame
+apply_nolint equiv.false_equiv_empty doc_blame
+apply_nolint equiv.false_equiv_pempty doc_blame
+apply_nolint equiv.fin_equiv_subtype doc_blame
+apply_nolint equiv.inhabited_of_equiv doc_blame
+apply_nolint equiv.int_equiv_nat_sum_nat doc_blame
+apply_nolint equiv.list_equiv_of_equiv doc_blame
+apply_nolint equiv.nat_equiv_nat_sum_punit doc_blame
+apply_nolint equiv.nat_sum_punit_equiv_nat doc_blame
+apply_nolint equiv.of_bijective doc_blame
+apply_nolint equiv.option_equiv_sum_punit doc_blame
+apply_nolint equiv.pempty_arrow_equiv_punit doc_blame
+apply_nolint equiv.pempty_equiv_pempty doc_blame
+apply_nolint equiv.pempty_of_not_nonempty doc_blame
+apply_nolint equiv.pempty_prod doc_blame
+apply_nolint equiv.pempty_sum doc_blame
+apply_nolint equiv.perm_congr doc_blame
+apply_nolint equiv.pi_equiv_subtype_sigma doc_blame
+apply_nolint equiv.plift doc_blame
+apply_nolint equiv.prod_assoc doc_blame
+apply_nolint equiv.prod_comm doc_blame
+apply_nolint equiv.prod_congr doc_blame
+apply_nolint equiv.prod_empty doc_blame
+apply_nolint equiv.prod_pempty doc_blame
+apply_nolint equiv.prod_punit doc_blame
+apply_nolint equiv.prod_sum_distrib doc_blame
+apply_nolint equiv.prop_equiv_punit doc_blame
+apply_nolint equiv.psigma_equiv_sigma doc_blame
+apply_nolint equiv.psum_equiv_sum doc_blame
+apply_nolint equiv.punit_arrow_equiv doc_blame
+apply_nolint equiv.punit_equiv_punit doc_blame
+apply_nolint equiv.punit_prod doc_blame
+apply_nolint equiv.refl doc_blame
+apply_nolint equiv.set.congr doc_blame
+apply_nolint equiv.set.empty doc_blame
+apply_nolint equiv.set.image doc_blame
+apply_nolint equiv.set.image_of_inj_on doc_blame
+apply_nolint equiv.set.insert doc_blame
+apply_nolint equiv.set.of_eq doc_blame
+apply_nolint equiv.set.pempty doc_blame
+apply_nolint equiv.set.prod doc_blame
+apply_nolint equiv.set.range doc_blame
+apply_nolint equiv.set.sep doc_blame
+apply_nolint equiv.set.singleton doc_blame
+apply_nolint equiv.set.sum_compl doc_blame
+apply_nolint equiv.set.union doc_blame
+apply_nolint equiv.set.union' doc_blame
+apply_nolint equiv.set.union_sum_inter doc_blame
+apply_nolint equiv.set.univ doc_blame
+apply_nolint equiv.set_congr doc_blame
+apply_nolint equiv.sigma_congr_left doc_blame
+apply_nolint equiv.sigma_congr_right doc_blame
+apply_nolint equiv.sigma_equiv_prod doc_blame
+apply_nolint equiv.sigma_equiv_prod_of_equiv doc_blame
+apply_nolint equiv.sigma_preimage_equiv doc_blame
+apply_nolint equiv.sigma_prod_distrib doc_blame
+apply_nolint equiv.sigma_subtype_preimage_equiv doc_blame
+apply_nolint equiv.sigma_subtype_preimage_equiv_subtype doc_blame
+apply_nolint equiv.subtype_congr doc_blame
+apply_nolint equiv.subtype_congr_prop doc_blame
+apply_nolint equiv.subtype_congr_right doc_blame
+apply_nolint equiv.subtype_equiv_of_subtype' doc_blame
+apply_nolint equiv.subtype_pi_equiv_pi doc_blame
+apply_nolint equiv.subtype_quotient_equiv_quotient_subtype doc_blame
+apply_nolint equiv.subtype_subtype_equiv_subtype_exists doc_blame
+apply_nolint equiv.subtype_subtype_equiv_subtype_inter doc_blame
+apply_nolint equiv.sum_arrow_equiv_prod_arrow doc_blame
+apply_nolint equiv.sum_assoc doc_blame
+apply_nolint equiv.sum_comm doc_blame
+apply_nolint equiv.sum_congr doc_blame
+apply_nolint equiv.sum_empty doc_blame
+apply_nolint equiv.sum_equiv_sigma_bool doc_blame
+apply_nolint equiv.sum_pempty doc_blame
+apply_nolint equiv.sum_prod_distrib doc_blame
+apply_nolint equiv.swap_core doc_blame
+apply_nolint equiv.symm doc_blame
+apply_nolint equiv.trans doc_blame
+apply_nolint equiv.true_equiv_punit doc_blame
+apply_nolint equiv.ulift doc_blame
+apply_nolint equiv.unique_congr doc_blame
+apply_nolint equiv.unique_of_equiv doc_blame
+apply_nolint equiv_of_unique_of_unique doc_blame
+apply_nolint equiv_punit_of_unique doc_blame
+apply_nolint function.involutive.to_equiv doc_blame
+apply_nolint unique_unique_equiv doc_blame
+
+-- data/equiv/denumerable.lean
+apply_nolint denumerable.equiv₂ doc_blame
+apply_nolint denumerable.eqv doc_blame
+apply_nolint denumerable.mk' doc_blame
+apply_nolint denumerable.of_encodable_of_infinite doc_blame
+apply_nolint denumerable.of_equiv doc_blame
+apply_nolint denumerable.of_nat doc_blame
+apply_nolint denumerable.pair doc_blame
+apply_nolint nat.subtype.denumerable doc_blame
+apply_nolint nat.subtype.of_nat doc_blame
+apply_nolint nat.subtype.succ doc_blame
+
+-- data/equiv/encodable.lean
+apply_nolint encodable.choose doc_blame
+apply_nolint encodable.choose_x doc_blame
+apply_nolint encodable.decidable_eq_of_encodable doc_blame
+apply_nolint encodable.decidable_range_encode doc_blame
+apply_nolint encodable.decode2 doc_blame
+apply_nolint encodable.decode_sigma doc_blame
+apply_nolint encodable.decode_subtype doc_blame
+apply_nolint encodable.decode_sum doc_blame
+apply_nolint encodable.encode_sigma doc_blame
+apply_nolint encodable.encode_subtype doc_blame
+apply_nolint encodable.encode_sum doc_blame
+apply_nolint encodable.equiv_range_encode doc_blame
+apply_nolint encodable.of_inj doc_blame
+apply_nolint encodable.of_left_injection doc_blame
+apply_nolint encodable.of_left_inverse doc_blame
+
+-- data/equiv/fin.lean
+apply_nolint fin_one_equiv doc_blame
+apply_nolint fin_prod_fin_equiv doc_blame
+apply_nolint fin_two_equiv doc_blame
+apply_nolint fin_zero_equiv doc_blame
+apply_nolint sum_fin_sum_equiv doc_blame
+
+-- data/equiv/functor.lean
+apply_nolint functor.map_equiv doc_blame
+
+-- data/equiv/list.lean
+apply_nolint denumerable.lower doc_blame
+apply_nolint denumerable.lower' doc_blame
+apply_nolint denumerable.raise doc_blame
+apply_nolint denumerable.raise' doc_blame
+apply_nolint denumerable.raise'_finset doc_blame
+apply_nolint encodable.decode_list doc_blame
+apply_nolint encodable.decode_multiset doc_blame
+apply_nolint encodable.encodable_of_list doc_blame
+apply_nolint encodable.encode_list doc_blame
+apply_nolint encodable.encode_multiset doc_blame
+apply_nolint encodable.fintype_arrow doc_blame
+apply_nolint encodable.fintype_pi doc_blame
+apply_nolint encodable.trunc_encodable_of_fintype doc_blame
+apply_nolint equiv.list_equiv_self_of_equiv_nat doc_blame
+apply_nolint equiv.list_nat_equiv_nat doc_blame
+
+-- data/equiv/local_equiv.lean
+apply_nolint local_equiv has_inhabited_instance
+
+-- data/equiv/nat.lean
+apply_nolint equiv.bool_prod_nat_equiv_nat doc_blame
+apply_nolint equiv.int_equiv_nat doc_blame
+apply_nolint equiv.nat_prod_nat_equiv_nat doc_blame
+apply_nolint equiv.nat_sum_nat_equiv_nat doc_blame
+apply_nolint equiv.pnat_equiv_nat doc_blame
+apply_nolint equiv.prod_equiv_of_equiv_nat doc_blame
+
+-- data/erased.lean
+apply_nolint erased.bind doc_blame
+apply_nolint erased.choice doc_blame
+apply_nolint erased.equiv doc_blame
+apply_nolint erased.join doc_blame
+apply_nolint erased.mk doc_blame
+apply_nolint erased.out doc_blame
+apply_nolint erased.out_type doc_blame
+
+-- data/fin.lean
+apply_nolint fin.add_nat_val unused_arguments
+apply_nolint fin.cases doc_blame
+apply_nolint fin.clamp doc_blame
+apply_nolint fin.succ_rec doc_blame
+apply_nolint fin.succ_rec_on doc_blame
+apply_nolint fin_zero_elim' doc_blame
+
+-- data/finmap.lean
+apply_nolint finmap.all doc_blame
+apply_nolint finmap.any doc_blame
+apply_nolint finmap.disjoint unused_arguments doc_blame
+apply_nolint finmap.foldl unused_arguments
+apply_nolint finmap.sdiff doc_blame
+apply_nolint list.to_finmap doc_blame
+
+-- data/finset.lean
+apply_nolint finset.attach_fin doc_blame
+apply_nolint finset.choose doc_blame
+apply_nolint finset.choose_x doc_blame
+apply_nolint finset.empty doc_blame
+apply_nolint finset.map doc_blame
+apply_nolint finset.map_embedding doc_blame
+apply_nolint finset.max doc_blame
+apply_nolint finset.max' doc_blame
+apply_nolint finset.min doc_blame
+apply_nolint finset.min' doc_blame
+apply_nolint finset.pi doc_blame
+apply_nolint finset.pi.cons doc_blame
+apply_nolint finset.pi.empty doc_blame
+apply_nolint finset.powerset_len doc_blame
+apply_nolint finset.strong_induction_on doc_blame
+apply_nolint finset.subtype doc_blame
+
+-- data/finsupp.lean
+apply_nolint finsupp.antidiagonal doc_blame
+apply_nolint finsupp.comap_domain doc_blame
+apply_nolint finsupp.curry doc_blame
+apply_nolint finsupp.dom_congr doc_blame
+apply_nolint finsupp.equiv_fun_on_fintype doc_blame
+apply_nolint finsupp.equiv_multiset doc_blame
+apply_nolint finsupp.erase doc_blame
+apply_nolint finsupp.finsupp_prod_equiv doc_blame
+apply_nolint finsupp.frange doc_blame
+apply_nolint finsupp.of_multiset doc_blame
+apply_nolint finsupp.restrict_support_equiv doc_blame
+apply_nolint finsupp.split doc_blame
+apply_nolint finsupp.split_comp doc_blame
+apply_nolint finsupp.split_support doc_blame
+apply_nolint finsupp.to_multiset doc_blame
+apply_nolint finsupp.uncurry doc_blame
+apply_nolint multiset.to_finsupp doc_blame
+
+-- data/fintype.lean
+apply_nolint finset.insert_none doc_blame
+apply_nolint fintype.bij_inv unused_arguments
+apply_nolint fintype.choose doc_blame
+apply_nolint fintype.choose_x unused_arguments doc_blame
+apply_nolint fintype.fintype_prod_left doc_blame
+apply_nolint fintype.fintype_prod_right doc_blame
+apply_nolint fintype.of_injective doc_blame
+apply_nolint fintype.of_subsingleton doc_blame
+apply_nolint fintype.subtype doc_blame
+apply_nolint fintype_perm doc_blame
+apply_nolint infinite doc_blame
+apply_nolint infinite.nat_embedding doc_blame
+apply_nolint perms_of_finset doc_blame
+apply_nolint perms_of_list doc_blame
+apply_nolint quotient.fin_choice doc_blame
+apply_nolint quotient.fin_choice_aux doc_blame
+apply_nolint set_fintype doc_blame
+
+-- data/fp/basic.lean
+apply_nolint fp.div_nat_lt_two_pow unused_arguments doc_blame
+apply_nolint fp.emax doc_blame
+apply_nolint fp.emin doc_blame
+apply_nolint fp.float doc_blame
+apply_nolint fp.float.add doc_blame
+apply_nolint fp.float.div doc_blame
+apply_nolint fp.float.is_finite doc_blame
+apply_nolint fp.float.is_zero doc_blame
+apply_nolint fp.float.mul doc_blame
+apply_nolint fp.float.neg doc_blame
+apply_nolint fp.float.sign doc_blame
+apply_nolint fp.float.sign' doc_blame
+apply_nolint fp.float.sub doc_blame
+apply_nolint fp.float.zero doc_blame
+apply_nolint fp.float_cfg doc_blame
+apply_nolint fp.next_dn doc_blame
+apply_nolint fp.next_dn_pos doc_blame
+apply_nolint fp.next_up doc_blame
+apply_nolint fp.next_up_pos doc_blame
+apply_nolint fp.of_pos_rat_dn doc_blame
+apply_nolint fp.of_rat doc_blame
+apply_nolint fp.of_rat_dn doc_blame
+apply_nolint fp.of_rat_up doc_blame
+apply_nolint fp.prec doc_blame
+apply_nolint fp.rmode doc_blame
+apply_nolint fp.to_rat doc_blame
+apply_nolint fp.valid_finite doc_blame
+apply_nolint int.shift2 doc_blame
+
+-- data/hash_map.lean
+apply_nolint hash_map has_inhabited_instance
+apply_nolint hash_map.mk_as_list unused_arguments
+apply_nolint hash_map.valid.modify ge_or_gt
+
+-- data/holor.lean
+apply_nolint holor.assoc_left doc_blame
+apply_nolint holor.assoc_right doc_blame
+apply_nolint holor_index has_inhabited_instance
+apply_nolint holor_index.assoc_left doc_blame
+apply_nolint holor_index.assoc_right doc_blame
+apply_nolint holor_index.drop doc_blame
+apply_nolint holor_index.take doc_blame
+
+-- data/int/basic.lean
+apply_nolint int.bit_cases_on doc_blame
+apply_nolint int.div_eq_div_of_mul_eq_mul unused_arguments
+apply_nolint int.eq_mul_div_of_mul_eq_mul_of_dvd_left unused_arguments
+apply_nolint int.induction_on' doc_blame
+apply_nolint int.range doc_blame
+apply_nolint int.to_nat' doc_blame
+
+-- data/int/gcd.lean
+apply_nolint nat.xgcd_aux doc_blame
+
+-- data/int/modeq.lean
+apply_nolint int.modeq doc_blame
+
+-- data/int/parity.lean
+apply_nolint int.even doc_blame
+
+-- data/lazy_list2.lean
+apply_nolint lazy_list.list_equiv_lazy_list doc_blame
+apply_nolint lazy_list.traverse doc_blame
+
+-- data/list/alist.lean
+apply_nolint alist.disjoint unused_arguments doc_blame
+apply_nolint alist.foldl unused_arguments
+apply_nolint list.to_alist doc_blame
+
+-- data/list/basic.lean
+apply_nolint list.lex doc_blame
+apply_nolint list.pairwise_gt_iota ge_or_gt
+apply_nolint list.reverse_rec_on doc_blame
+apply_nolint list.sublists_len doc_blame
+apply_nolint list.sublists_len_aux doc_blame
+
+-- data/list/defs.lean
+apply_nolint list.choose doc_blame
+apply_nolint list.choose_x doc_blame
+apply_nolint list.erasep doc_blame
+apply_nolint list.extractp doc_blame
+apply_nolint list.find_indexes_aux doc_blame
+apply_nolint list.forall₂ doc_blame
+apply_nolint list.func.add doc_blame
+apply_nolint list.func.equiv doc_blame
+apply_nolint list.func.get doc_blame
+apply_nolint list.func.neg doc_blame
+apply_nolint list.func.pointwise doc_blame
+apply_nolint list.func.set doc_blame
+apply_nolint list.func.sub doc_blame
+apply_nolint list.head' doc_blame
+apply_nolint list.insert_nth doc_blame
+apply_nolint list.map_head doc_blame
+apply_nolint list.map_last doc_blame
+apply_nolint list.map_with_index doc_blame
+apply_nolint list.map_with_index_core doc_blame
+apply_nolint list.of_fn doc_blame
+apply_nolint list.of_fn_aux doc_blame
+apply_nolint list.of_fn_nth_val doc_blame
+apply_nolint list.partition_map doc_blame
+apply_nolint list.permutations_aux doc_blame
+apply_nolint list.permutations_aux.rec doc_blame
+apply_nolint list.permutations_aux2 doc_blame
+apply_nolint list.reduce_option doc_blame
+apply_nolint list.revzip doc_blame
+apply_nolint list.scanr_aux doc_blame
+apply_nolint list.split_on_p_aux doc_blame
+apply_nolint list.sublists'_aux doc_blame
+apply_nolint list.sublists_aux doc_blame
+apply_nolint list.sublists_aux₁ doc_blame
+apply_nolint list.take' doc_blame
+apply_nolint list.tfae doc_blame
+apply_nolint list.transpose_aux doc_blame
+apply_nolint list.traverse doc_blame
+
+-- data/list/sigma.lean
+apply_nolint list.erase_dupkeys doc_blame
+apply_nolint list.kextract doc_blame
+apply_nolint list.kreplace doc_blame
+apply_nolint list.mem_ext unused_arguments
+apply_nolint list.nodupkeys doc_blame
+
+-- data/matrix/basic.lean
+apply_nolint matrix unused_arguments doc_blame
+apply_nolint matrix.col doc_blame
+apply_nolint matrix.diagonal doc_blame
+apply_nolint matrix.minor doc_blame
+apply_nolint matrix.mul doc_blame
+apply_nolint matrix.mul_vec doc_blame
+apply_nolint matrix.row doc_blame
+apply_nolint matrix.sub_down doc_blame
+apply_nolint matrix.sub_down_left doc_blame
+apply_nolint matrix.sub_down_right doc_blame
+apply_nolint matrix.sub_left doc_blame
+apply_nolint matrix.sub_right doc_blame
+apply_nolint matrix.sub_up doc_blame
+apply_nolint matrix.sub_up_left doc_blame
+apply_nolint matrix.sub_up_right doc_blame
+apply_nolint matrix.transpose doc_blame
+apply_nolint matrix.vec_mul doc_blame
+apply_nolint matrix.vec_mul_vec doc_blame
+
+-- data/matrix/pequiv.lean
+apply_nolint pequiv.matrix_mul_apply unused_arguments
+apply_nolint pequiv.mul_matrix_apply unused_arguments
+apply_nolint pequiv.single_mul_single_right unused_arguments
+apply_nolint pequiv.to_matrix unused_arguments
+
+-- data/mllist.lean
+apply_nolint tactic.mllist doc_blame
+apply_nolint tactic.mllist.append unused_arguments doc_blame
+apply_nolint tactic.mllist.bind_ doc_blame
+apply_nolint tactic.mllist.concat doc_blame
+apply_nolint tactic.mllist.empty doc_blame
+apply_nolint tactic.mllist.enum doc_blame
+apply_nolint tactic.mllist.enum_from unused_arguments doc_blame
+apply_nolint tactic.mllist.filter unused_arguments doc_blame
+apply_nolint tactic.mllist.filter_map unused_arguments doc_blame
+apply_nolint tactic.mllist.fix doc_blame
+apply_nolint tactic.mllist.fixl doc_blame
+apply_nolint tactic.mllist.fixl_with doc_blame
+apply_nolint tactic.mllist.force unused_arguments doc_blame
+apply_nolint tactic.mllist.head unused_arguments doc_blame
+apply_nolint tactic.mllist.join unused_arguments doc_blame
+apply_nolint tactic.mllist.m_of_list unused_arguments doc_blame
+apply_nolint tactic.mllist.map unused_arguments doc_blame
+apply_nolint tactic.mllist.mfilter unused_arguments doc_blame
+apply_nolint tactic.mllist.mfilter_map unused_arguments doc_blame
+apply_nolint tactic.mllist.mfirst unused_arguments doc_blame
+apply_nolint tactic.mllist.mmap unused_arguments doc_blame
+apply_nolint tactic.mllist.monad_lift unused_arguments doc_blame
+apply_nolint tactic.mllist.of_list unused_arguments doc_blame
+apply_nolint tactic.mllist.range doc_blame
+apply_nolint tactic.mllist.squash doc_blame
+apply_nolint tactic.mllist.take unused_arguments doc_blame
+apply_nolint tactic.mllist.uncons unused_arguments doc_blame
+
+-- data/multiset.lean
+apply_nolint multiset.choose doc_blame
+apply_nolint multiset.choose_x doc_blame
+apply_nolint multiset.decidable_exists_multiset doc_blame
+apply_nolint multiset.decidable_forall_multiset doc_blame
+apply_nolint multiset.le_inf unused_arguments
+apply_nolint multiset.length_ndinsert_of_mem unused_arguments
+apply_nolint multiset.length_ndinsert_of_not_mem unused_arguments
+apply_nolint multiset.pi.cons doc_blame
+apply_nolint multiset.pi.empty unused_arguments doc_blame
+apply_nolint multiset.powerset doc_blame
+apply_nolint multiset.powerset_aux doc_blame
+apply_nolint multiset.powerset_aux' doc_blame
+apply_nolint multiset.powerset_len doc_blame
+apply_nolint multiset.powerset_len_aux doc_blame
+apply_nolint multiset.rec_on doc_blame
+apply_nolint multiset.sections doc_blame
+apply_nolint multiset.strong_induction_on doc_blame
+apply_nolint multiset.subsingleton_equiv doc_blame
+apply_nolint multiset.sum doc_blame
+apply_nolint multiset.sup_le unused_arguments
+apply_nolint multiset.traverse doc_blame
+
+-- data/nat/enat.lean
+apply_nolint enat doc_blame
+
+-- data/nat/modeq.lean
+apply_nolint nat.modeq.chinese_remainder doc_blame
+
+-- data/nat/prime.lean
+apply_nolint nat.min_fac_aux doc_blame
+
+-- data/nat/sqrt.lean
+apply_nolint nat.sqrt_aux doc_blame
+
+-- data/nat/totient.lean
+apply_nolint nat.totient doc_blame
+
+-- data/num/basic.lean
+apply_nolint cast_num doc_blame
+apply_nolint cast_pos_num unused_arguments doc_blame
+apply_nolint cast_znum doc_blame
+apply_nolint int.of_snum doc_blame
+apply_nolint num.add doc_blame
+apply_nolint num.bit doc_blame
+apply_nolint num.bit0 doc_blame
+apply_nolint num.bit1 doc_blame
+apply_nolint num.cmp doc_blame
+apply_nolint num.div doc_blame
+apply_nolint num.div2 doc_blame
+apply_nolint num.gcd doc_blame
+apply_nolint num.gcd_aux doc_blame
+apply_nolint num.mod doc_blame
+apply_nolint num.mul doc_blame
+apply_nolint num.nat_size doc_blame
+apply_nolint num.of_nat' doc_blame
+apply_nolint num.of_znum doc_blame
+apply_nolint num.of_znum' doc_blame
+apply_nolint num.ppred doc_blame
+apply_nolint num.pred doc_blame
+apply_nolint num.psub doc_blame
+apply_nolint num.size doc_blame
+apply_nolint num.sub doc_blame
+apply_nolint num.sub' doc_blame
+apply_nolint num.succ doc_blame
+apply_nolint num.succ' doc_blame
+apply_nolint num.to_znum doc_blame
+apply_nolint num.to_znum_neg doc_blame
+apply_nolint nzsnum.bit0 doc_blame
+apply_nolint nzsnum.bit1 doc_blame
+apply_nolint nzsnum.drec' doc_blame
+apply_nolint nzsnum.head doc_blame
+apply_nolint nzsnum.not doc_blame
+apply_nolint nzsnum.sign doc_blame
+apply_nolint nzsnum.tail doc_blame
+apply_nolint pos_num.add doc_blame
+apply_nolint pos_num.bit doc_blame
+apply_nolint pos_num.cmp doc_blame
+apply_nolint pos_num.div' doc_blame
+apply_nolint pos_num.divmod doc_blame
+apply_nolint pos_num.divmod_aux doc_blame
+apply_nolint pos_num.is_one doc_blame
+apply_nolint pos_num.mod' doc_blame
+apply_nolint pos_num.mul doc_blame
+apply_nolint pos_num.nat_size doc_blame
+apply_nolint pos_num.of_nat doc_blame
+apply_nolint pos_num.of_nat_succ doc_blame
+apply_nolint pos_num.of_znum doc_blame
+apply_nolint pos_num.of_znum' doc_blame
+apply_nolint pos_num.pred doc_blame
+apply_nolint pos_num.pred' doc_blame
+apply_nolint pos_num.size doc_blame
+apply_nolint pos_num.sqrt_aux doc_blame
+apply_nolint pos_num.sqrt_aux1 doc_blame
+apply_nolint pos_num.sub doc_blame
+apply_nolint pos_num.sub' doc_blame
+apply_nolint pos_num.succ doc_blame
+apply_nolint snum.add doc_blame
+apply_nolint snum.bit doc_blame
+apply_nolint snum.bit0 doc_blame
+apply_nolint snum.bit1 doc_blame
+apply_nolint snum.bits doc_blame
+apply_nolint snum.cadd doc_blame
+apply_nolint snum.czadd doc_blame
+apply_nolint snum.drec' doc_blame
+apply_nolint snum.head doc_blame
+apply_nolint snum.mul doc_blame
+apply_nolint snum.neg doc_blame
+apply_nolint snum.not doc_blame
+apply_nolint snum.pred doc_blame
+apply_nolint snum.rec' doc_blame
+apply_nolint snum.sign doc_blame
+apply_nolint snum.sub doc_blame
+apply_nolint snum.succ doc_blame
+apply_nolint snum.tail doc_blame
+apply_nolint snum.test_bit doc_blame
+apply_nolint znum.abs doc_blame
+apply_nolint znum.add doc_blame
+apply_nolint znum.bit0 doc_blame
+apply_nolint znum.bit1 doc_blame
+apply_nolint znum.bitm1 doc_blame
+apply_nolint znum.cmp doc_blame
+apply_nolint znum.div doc_blame
+apply_nolint znum.gcd doc_blame
+apply_nolint znum.mod doc_blame
+apply_nolint znum.mul doc_blame
+apply_nolint znum.of_int' doc_blame
+apply_nolint znum.pred doc_blame
+apply_nolint znum.succ doc_blame
+apply_nolint znum.zneg doc_blame
+
+-- data/num/bitwise.lean
+apply_nolint num.land doc_blame
+apply_nolint num.ldiff doc_blame
+apply_nolint num.lor doc_blame
+apply_nolint num.lxor doc_blame
+apply_nolint num.one_bits doc_blame
+apply_nolint num.shiftl doc_blame
+apply_nolint num.shiftr doc_blame
+apply_nolint num.test_bit doc_blame
+apply_nolint pos_num.land doc_blame
+apply_nolint pos_num.ldiff doc_blame
+apply_nolint pos_num.lor doc_blame
+apply_nolint pos_num.lxor doc_blame
+apply_nolint pos_num.one_bits doc_blame
+apply_nolint pos_num.shiftl doc_blame
+apply_nolint pos_num.shiftr doc_blame
+apply_nolint pos_num.test_bit doc_blame
+
+-- data/num/lemmas.lean
+apply_nolint num.cmp_to_nat ge_or_gt
+apply_nolint num.transfer doc_blame
+apply_nolint num.transfer_rw doc_blame
+apply_nolint pos_num.cmp_to_nat ge_or_gt
+apply_nolint pos_num.transfer doc_blame
+apply_nolint pos_num.transfer_rw doc_blame
+apply_nolint znum.cmp_to_int ge_or_gt
+apply_nolint znum.transfer doc_blame
+apply_nolint znum.transfer_rw doc_blame
+
+-- data/opposite.lean
+apply_nolint opposite.op doc_blame
+apply_nolint opposite.op_induction doc_blame
+apply_nolint opposite.unop doc_blame
+apply_nolint tactic.interactive.op_induction doc_blame
+apply_nolint tactic.op_induction doc_blame
+apply_nolint tactic.op_induction' doc_blame
+apply_nolint tactic.op_induction.find_opposite_hyp doc_blame
+apply_nolint tactic.op_induction.is_opposite doc_blame
+
+-- data/option/defs.lean
+apply_nolint option.lift_or_get doc_blame
+apply_nolint option.rel doc_blame
+apply_nolint option.to_list doc_blame
+apply_nolint option.traverse doc_blame
+
+-- data/padics/padic_integers.lean
+apply_nolint padic_norm_z doc_blame
+
+-- data/padics/padic_norm.lean
+apply_nolint padic_norm.neg unused_arguments
+
+-- data/padics/padic_numbers.lean
+apply_nolint padic.complete' ge_or_gt
+apply_nolint padic.exi_rat_seq_conv ge_or_gt
+apply_nolint padic.lim_seq doc_blame
+apply_nolint padic_norm_e.defn ge_or_gt
+apply_nolint padic_norm_e.nonneg ge_or_gt
+apply_nolint padic_norm_e.rat_norm doc_blame
+apply_nolint padic_seq unused_arguments
+apply_nolint padic_seq.norm_nonneg ge_or_gt
+
+-- data/pequiv.lean
+apply_nolint equiv.to_pequiv doc_blame
+apply_nolint pequiv has_inhabited_instance
+apply_nolint pequiv.of_set doc_blame
+apply_nolint pequiv.refl doc_blame
+apply_nolint pequiv.single doc_blame
+apply_nolint pequiv.symm doc_blame
+apply_nolint pequiv.trans doc_blame
+apply_nolint pequiv.trans_single_of_eq_none unused_arguments
+
+-- data/pfun.lean
+apply_nolint pfun.core doc_blame
+apply_nolint pfun.equiv_subtype doc_blame
+apply_nolint pfun.fix doc_blame
+apply_nolint pfun.fix_induction doc_blame
+apply_nolint pfun.graph' doc_blame
+apply_nolint pfun.image doc_blame
+apply_nolint pfun.preimage doc_blame
+apply_nolint pfun.res doc_blame
+apply_nolint roption.equiv_option doc_blame
+apply_nolint roption.get_or_else doc_blame
+apply_nolint roption.restrict doc_blame
+
+-- data/pnat/basic.lean
+apply_nolint pnat.div doc_blame
+apply_nolint pnat.div_exact unused_arguments doc_blame
+apply_nolint pnat.gcd doc_blame
+apply_nolint pnat.lcm doc_blame
+apply_nolint pnat.mod doc_blame
+apply_nolint pnat.mod_div doc_blame
+apply_nolint pnat.prime doc_blame
+
+-- data/pnat/factors.lean
+apply_nolint prime_multiset.of_nat_multiset doc_blame
+apply_nolint prime_multiset.of_pnat_list doc_blame
+apply_nolint prime_multiset.of_pnat_multiset doc_blame
+apply_nolint prime_multiset.prod doc_blame
+apply_nolint prime_multiset.to_pnat_multiset doc_blame
+
+-- data/pnat/xgcd.lean
+apply_nolint pnat.gcd_a' doc_blame
+apply_nolint pnat.gcd_b' doc_blame
+apply_nolint pnat.gcd_d doc_blame
+apply_nolint pnat.gcd_w doc_blame
+apply_nolint pnat.gcd_x doc_blame
+apply_nolint pnat.gcd_y doc_blame
+apply_nolint pnat.gcd_z doc_blame
+apply_nolint pnat.xgcd doc_blame
+apply_nolint pnat.xgcd_type.a doc_blame
+apply_nolint pnat.xgcd_type.b doc_blame
+apply_nolint pnat.xgcd_type.finish doc_blame
+apply_nolint pnat.xgcd_type.flip doc_blame
+apply_nolint pnat.xgcd_type.is_reduced' doc_blame
+apply_nolint pnat.xgcd_type.is_special' doc_blame
+apply_nolint pnat.xgcd_type.mk' doc_blame
+apply_nolint pnat.xgcd_type.q doc_blame
+apply_nolint pnat.xgcd_type.qp doc_blame
+apply_nolint pnat.xgcd_type.r doc_blame
+apply_nolint pnat.xgcd_type.succ₂ doc_blame
+apply_nolint pnat.xgcd_type.v doc_blame
+apply_nolint pnat.xgcd_type.w doc_blame
+apply_nolint pnat.xgcd_type.z doc_blame
+
+-- data/polynomial.lean
+apply_nolint polynomial.binom_expansion doc_blame
+apply_nolint polynomial.coeff_coe_to_fun doc_blame
+apply_nolint polynomial.comp doc_blame
+apply_nolint polynomial.decidable_dvd_monic doc_blame
+apply_nolint polynomial.div doc_blame
+apply_nolint polynomial.div_mod_by_monic_aux doc_blame
+apply_nolint polynomial.eval_sub_factor doc_blame
+apply_nolint polynomial.eval₂_zero unused_arguments
+apply_nolint polynomial.lcoeff doc_blame
+apply_nolint polynomial.map_injective unused_arguments
+apply_nolint polynomial.mod doc_blame
+apply_nolint polynomial.nonzero_comm_ring.of_polynomial_ne doc_blame
+apply_nolint polynomial.nonzero_comm_semiring.of_polynomial_ne doc_blame
+apply_nolint polynomial.pow_add_expansion doc_blame
+apply_nolint polynomial.pow_sub_pow_factor doc_blame
+apply_nolint polynomial.rec_on_horner doc_blame
+apply_nolint polynomial.root_multiplicity doc_blame
+
+-- data/prod.lean
+apply_nolint prod.lex.decidable unused_arguments
+
+-- data/quot.lean
+apply_nolint quot.hrec_on₂ doc_blame
+apply_nolint quotient.choice doc_blame
+apply_nolint quotient.hrec_on₂ doc_blame
+apply_nolint quotient.lift_on' doc_blame
+apply_nolint quotient.lift_on₂' doc_blame
+apply_nolint quotient.mk' doc_blame
+apply_nolint quotient.out' doc_blame
+apply_nolint trunc.bind doc_blame
+apply_nolint trunc.lift_on doc_blame
+apply_nolint trunc.map doc_blame
+apply_nolint trunc.rec doc_blame
+apply_nolint trunc.rec_on doc_blame
+apply_nolint trunc.rec_on_subsingleton doc_blame
+
+-- data/rat/basic.lean
+apply_nolint rat.add doc_blame
+apply_nolint rat.inv doc_blame
+apply_nolint rat.mul doc_blame
+apply_nolint rat.neg doc_blame
+apply_nolint rat.num_denom_cases_on doc_blame
+apply_nolint rat.num_denom_cases_on' doc_blame
+apply_nolint rat.repr doc_blame
+
+-- data/rat/order.lean
+apply_nolint rat.le doc_blame
+apply_nolint rat.nonneg doc_blame
+apply_nolint rat.sqrt doc_blame
+
+-- data/real/basic.lean
+apply_nolint real doc_blame
+apply_nolint real.Inf doc_blame
+apply_nolint real.Sup doc_blame
+apply_nolint real.comm_ring_aux doc_blame
+apply_nolint real.le doc_blame
+apply_nolint real.mk doc_blame
+apply_nolint real.of_rat doc_blame
+apply_nolint real.sqrt doc_blame
+apply_nolint real.sqrt_aux doc_blame
+
+-- data/real/cardinality.lean
+apply_nolint cardinal.cantor_function doc_blame
+apply_nolint cardinal.cantor_function_aux doc_blame
+
+-- data/real/cau_seq.lean
+apply_nolint cau_seq doc_blame
+apply_nolint cau_seq.abv_pos_of_not_lim_zero ge_or_gt
+apply_nolint cau_seq.bounded' ge_or_gt
+apply_nolint cau_seq.cauchy ge_or_gt
+apply_nolint cau_seq.cauchy₂ ge_or_gt
+apply_nolint cau_seq.cauchy₃ ge_or_gt
+apply_nolint cau_seq.equiv_def₃ ge_or_gt
+apply_nolint cau_seq.inv doc_blame
+apply_nolint cau_seq.inv_aux ge_or_gt
+apply_nolint cau_seq.lim_zero unused_arguments
+apply_nolint cau_seq.of_eq doc_blame
+apply_nolint exists_forall_ge_and ge_or_gt
+apply_nolint is_cau_seq.cauchy₂ ge_or_gt
+apply_nolint is_cau_seq.cauchy₃ ge_or_gt
+apply_nolint rat_add_continuous_lemma ge_or_gt
+apply_nolint rat_inv_continuous_lemma ge_or_gt
+apply_nolint rat_mul_continuous_lemma ge_or_gt
+
+-- data/real/cau_seq_completion.lean
+apply_nolint cau_seq.completion.Cauchy doc_blame
+apply_nolint cau_seq.completion.discrete_field doc_blame
+apply_nolint cau_seq.completion.mk doc_blame
+apply_nolint cau_seq.completion.of_rat doc_blame
+apply_nolint cau_seq.is_complete doc_blame
+apply_nolint cau_seq.lim doc_blame
+
+-- data/real/ereal.lean
+apply_nolint ereal has_inhabited_instance
+
+-- data/real/hyperreal.lean
+apply_nolint hyperreal.gt_of_neg_of_infinitesimal ge_or_gt
+apply_nolint hyperreal.infinite_pos_def ge_or_gt
+apply_nolint hyperreal.infinite_pos_iff_infinite_and_pos ge_or_gt
+apply_nolint hyperreal.infinite_pos_iff_infinitesimal_inv_pos ge_or_gt
+apply_nolint hyperreal.infinitesimal_def ge_or_gt
+apply_nolint hyperreal.infinitesimal_pos_iff_infinite_pos_inv ge_or_gt
+apply_nolint hyperreal.is_st_iff_abs_sub_lt_delta ge_or_gt
+apply_nolint hyperreal.lt_neg_of_pos_of_infinitesimal ge_or_gt
+apply_nolint hyperreal.pos_of_infinite_pos ge_or_gt
+
+-- data/real/irrational.lean
+apply_nolint irrational doc_blame
+
+-- data/real/nnreal.lean
+apply_nolint nnreal.of_real doc_blame
+
+-- data/real/pi.lean
+apply_nolint real.pi_gt_314 ge_or_gt
+apply_nolint real.pi_gt_sqrt_two_add_series ge_or_gt
+apply_nolint real.pi_gt_three ge_or_gt
+apply_nolint real.sqrt_two_add_series_nonneg ge_or_gt
+apply_nolint real.sqrt_two_add_series_zero_nonneg ge_or_gt
+
+-- data/semiquot.lean
+apply_nolint semiquot.bind doc_blame
+apply_nolint semiquot.get doc_blame
+apply_nolint semiquot.is_pure doc_blame
+apply_nolint semiquot.map doc_blame
+
+-- data/seq/computation.lean
+apply_nolint computation.bind.F doc_blame
+apply_nolint computation.bind.G doc_blame
+apply_nolint computation.bisim_o doc_blame
+apply_nolint computation.cases_on doc_blame
+apply_nolint computation.corec.F doc_blame
+apply_nolint computation.is_bisimulation doc_blame
+apply_nolint computation.lift_rel_aux doc_blame
+apply_nolint computation.map_congr unused_arguments
+apply_nolint computation.mem doc_blame
+apply_nolint computation.mem_rec_on doc_blame
+apply_nolint computation.terminates_rec_on doc_blame
+
+-- data/seq/parallel.lean
+apply_nolint computation.parallel.aux1 doc_blame
+apply_nolint computation.parallel.aux2 doc_blame
+apply_nolint computation.parallel_rec doc_blame
+
+-- data/seq/seq.lean
+apply_nolint seq.bisim_o doc_blame
+apply_nolint seq.cases_on doc_blame
+apply_nolint seq.corec.F doc_blame
+apply_nolint seq.is_bisimulation doc_blame
+apply_nolint seq.mem doc_blame
+
+-- data/seq/wseq.lean
+apply_nolint wseq.bisim_o doc_blame
+apply_nolint wseq.cases_on doc_blame
+apply_nolint wseq.destruct_append.aux doc_blame
+apply_nolint wseq.destruct_join.aux doc_blame
+apply_nolint wseq.drop.aux doc_blame
+apply_nolint wseq.lift_rel_o doc_blame
+apply_nolint wseq.mem doc_blame
+apply_nolint wseq.tail.aux doc_blame
+apply_nolint wseq.think_congr unused_arguments
+
+-- data/set/countable.lean
+apply_nolint set.countable.to_encodable doc_blame
+
+-- data/set/enumerate.lean
+apply_nolint set.enumerate doc_blame
+
+-- data/set/finite.lean
+apply_nolint finset.preimage doc_blame
+apply_nolint set.fintype_bUnion doc_blame
+apply_nolint set.fintype_bind doc_blame
+apply_nolint set.fintype_insert' doc_blame
+apply_nolint set.fintype_of_fintype_image doc_blame
+apply_nolint set.fintype_subset doc_blame
+
+-- data/set/lattice.lean
+apply_nolint set.Union_eq_sigma_of_disjoint doc_blame
+apply_nolint set.bUnion_eq_sigma_of_disjoint doc_blame
+apply_nolint set.kern_image doc_blame
+apply_nolint set.pairwise_disjoint doc_blame
+apply_nolint set.seq doc_blame
+apply_nolint set.sigma_to_Union doc_blame
+
+-- data/setoid.lean
+apply_nolint setoid.is_partition doc_blame
+
+-- data/string/basic.lean
+apply_nolint string.ltb doc_blame
+
+-- data/string/defs.lean
+apply_nolint string.map_tokens doc_blame
+apply_nolint string.over_list doc_blame
+apply_nolint string.split_on doc_blame
+
+-- data/sum.lean
+apply_nolint sum.elim doc_blame
+apply_nolint sum.map doc_blame
+
+-- data/tree.lean
+apply_nolint tree doc_blame
+apply_nolint tree.map doc_blame
+apply_nolint tree.repr doc_blame
+
+-- data/vector2.lean
+apply_nolint vector.insert_nth doc_blame
+apply_nolint vector.m_of_fn doc_blame
+apply_nolint vector.mmap doc_blame
+apply_nolint vector.reverse doc_blame
+apply_nolint vector.to_array doc_blame
+apply_nolint vector.traverse doc_blame
+apply_nolint vector.traverse_def unused_arguments
+
+-- data/zmod/basic.lean
+apply_nolint zmod doc_blame
+apply_nolint zmod.cast doc_blame
+apply_nolint zmod.units_equiv_coprime doc_blame
+apply_nolint zmodp doc_blame
+
+-- data/zmod/quadratic_reciprocity.lean
+apply_nolint zmodp.legendre_sym doc_blame
+
+-- data/zsqrtd/basic.lean
+apply_nolint zsqrtd.le doc_blame
+apply_nolint zsqrtd.lt doc_blame
+apply_nolint zsqrtd.norm doc_blame
+
+-- data/zsqrtd/gaussian_int.lean
+apply_nolint gaussian_int doc_blame
+apply_nolint gaussian_int.div doc_blame
+apply_nolint gaussian_int.mod doc_blame
+apply_nolint gaussian_int.to_complex doc_blame
+
+-- field_theory/finite.lean
+apply_nolint finite_field.field_of_integral_domain doc_blame
+apply_nolint subgroup_units_cyclic unused_arguments
+
+-- field_theory/mv_polynomial.lean
+apply_nolint mv_polynomial.R unused_arguments doc_blame
+apply_nolint mv_polynomial.evalᵢ doc_blame
+apply_nolint mv_polynomial.evalₗ unused_arguments doc_blame
+apply_nolint mv_polynomial.indicator doc_blame
+apply_nolint mv_polynomial.restrict_degree doc_blame
+apply_nolint mv_polynomial.restrict_total_degree doc_blame
+
+-- field_theory/perfect_closure.lean
+apply_nolint perfect_closure.UMP doc_blame
+apply_nolint perfect_closure.eq_iff' unused_arguments
+apply_nolint perfect_closure.frobenius_equiv doc_blame
+apply_nolint perfect_closure.has_inv unused_arguments
+apply_nolint perfect_closure.of doc_blame
+apply_nolint perfect_closure.r doc_blame
+
+-- field_theory/splitting_field.lean
+apply_nolint polynomial.splits unused_arguments
+
+-- field_theory/subfield.lean
+apply_nolint field.closure doc_blame
+apply_nolint is_subfield doc_blame
+
+-- geometry/manifold/basic_smooth_bundle.lean
+apply_nolint basic_smooth_bundle_core has_inhabited_instance
+apply_nolint tangent_bundle has_inhabited_instance
+apply_nolint tangent_space has_inhabited_instance
+
+-- geometry/manifold/manifold.lean
+apply_nolint manifold_core has_inhabited_instance
+apply_nolint manifold_core.local_homeomorph doc_blame
+apply_nolint manifold_core.to_manifold doc_blame
+apply_nolint pregroupoid has_inhabited_instance
+apply_nolint structomorph has_inhabited_instance
+apply_nolint structure_groupoid has_inhabited_instance
+
+-- geometry/manifold/real_instances.lean
+apply_nolint euclidean_half_space has_inhabited_instance
+apply_nolint euclidean_quadrant has_inhabited_instance
+apply_nolint euclidean_space has_inhabited_instance
+
+-- geometry/manifold/smooth_manifold_with_corners.lean
+apply_nolint model_with_corners has_inhabited_instance
+
+-- group_theory/abelianization.lean
+apply_nolint abelianization doc_blame
+apply_nolint abelianization.lift doc_blame
+apply_nolint abelianization.lift.unique unused_arguments
+apply_nolint abelianization.of doc_blame
+apply_nolint commutator doc_blame
+
+-- group_theory/congruence.lean
+apply_nolint add_con.to_setoid doc_blame
+apply_nolint con.to_setoid doc_blame
+
+-- group_theory/coset.lean
+apply_nolint is_add_subgroup.group_equiv_quotient_times_subgroup doc_blame
+apply_nolint is_add_subgroup.left_coset_equiv_subgroup doc_blame
+apply_nolint is_subgroup.group_equiv_quotient_times_subgroup doc_blame
+apply_nolint is_subgroup.left_coset_equiv_subgroup doc_blame
+apply_nolint left_add_coset doc_blame
+apply_nolint left_add_coset_equiv doc_blame
+apply_nolint left_coset doc_blame
+apply_nolint left_coset_equiv doc_blame
+apply_nolint normal_of_eq_add_cosets unused_arguments
+apply_nolint normal_of_eq_cosets unused_arguments
+apply_nolint quotient_add_group.eq_class_eq_left_coset unused_arguments
+apply_nolint quotient_add_group.inhabited unused_arguments
+apply_nolint quotient_add_group.left_rel doc_blame
+apply_nolint quotient_add_group.mk doc_blame
+apply_nolint quotient_add_group.quotient doc_blame
+apply_nolint quotient_group.eq_class_eq_left_coset unused_arguments
+apply_nolint quotient_group.inhabited unused_arguments
+apply_nolint quotient_group.left_rel doc_blame
+apply_nolint quotient_group.mk doc_blame
+apply_nolint quotient_group.preimage_mk_equiv_subgroup_times_set doc_blame
+apply_nolint right_add_coset doc_blame
+apply_nolint right_coset doc_blame
+
+-- group_theory/eckmann_hilton.lean
+apply_nolint eckmann_hilton.comm_group unused_arguments doc_blame
+apply_nolint eckmann_hilton.comm_monoid doc_blame
+apply_nolint eckmann_hilton.is_unital doc_blame
+
+-- group_theory/free_abelian_group.lean
+apply_nolint free_abelian_group doc_blame
+apply_nolint free_abelian_group.lift doc_blame
+apply_nolint free_abelian_group.lift.universal doc_blame
+apply_nolint free_abelian_group.of doc_blame
+
+-- group_theory/free_group.lean
+apply_nolint free_group.free_group_empty_equiv_unit doc_blame
+apply_nolint free_group.free_group_unit_equiv_int doc_blame
+apply_nolint free_group.map.aux doc_blame
+apply_nolint free_group.mk doc_blame
+apply_nolint free_group.to_group.aux doc_blame
+
+-- group_theory/group_action.lean
+apply_nolint mul_action.comp_hom doc_blame
+apply_nolint mul_action.fixed_points doc_blame
+apply_nolint mul_action.mul_left_cosets doc_blame
+apply_nolint mul_action.orbit doc_blame
+apply_nolint mul_action.orbit_equiv_quotient_stabilizer doc_blame
+apply_nolint mul_action.orbit_rel doc_blame
+apply_nolint mul_action.stabilizer doc_blame
+apply_nolint mul_action.to_perm doc_blame
+
+-- group_theory/order_of_element.lean
+apply_nolint card_subgroup_dvd_card unused_arguments
+apply_nolint card_trivial unused_arguments
+apply_nolint exists_gpow_eq_one unused_arguments
+apply_nolint exists_pow_eq_one ge_or_gt
+apply_nolint is_cyclic doc_blame
+apply_nolint is_cyclic.comm_group doc_blame
+apply_nolint order_of_pos ge_or_gt
+apply_nolint quotient_group.fintype unused_arguments
+
+-- group_theory/perm/cycles.lean
+apply_nolint equiv.perm.cycle_factors doc_blame
+apply_nolint equiv.perm.cycle_factors_aux doc_blame
+apply_nolint equiv.perm.cycle_of doc_blame
+apply_nolint equiv.perm.same_cycle doc_blame
+
+-- group_theory/perm/sign.lean
+apply_nolint equiv.perm.card_support_swap unused_arguments
+apply_nolint equiv.perm.disjoint doc_blame
+apply_nolint equiv.perm.eq_swap_of_is_cycle_of_apply_apply_eq_self unused_arguments
+apply_nolint equiv.perm.is_cycle doc_blame
+apply_nolint equiv.perm.is_cycle_swap unused_arguments
+apply_nolint equiv.perm.is_cycle_swap_mul_aux₁ unused_arguments
+apply_nolint equiv.perm.is_swap doc_blame
+apply_nolint equiv.perm.of_subtype doc_blame
+apply_nolint equiv.perm.sign_aux doc_blame
+apply_nolint equiv.perm.sign_aux2 doc_blame
+apply_nolint equiv.perm.sign_aux3 doc_blame
+apply_nolint equiv.perm.sign_bij_aux doc_blame
+apply_nolint equiv.perm.sign_cycle unused_arguments
+apply_nolint equiv.perm.subtype_perm doc_blame
+apply_nolint equiv.perm.support doc_blame
+apply_nolint equiv.perm.support_swap unused_arguments
+apply_nolint equiv.perm.swap_factors_aux doc_blame
+apply_nolint equiv.perm.trunc_swap_factors doc_blame
+
+-- group_theory/presented_group.lean
+apply_nolint presented_group has_inhabited_instance
+
+-- group_theory/quotient_group.lean
+apply_nolint quotient_add_group.ker_lift doc_blame
+apply_nolint quotient_add_group.lift doc_blame
+apply_nolint quotient_add_group.map doc_blame
+apply_nolint quotient_add_group.quotient_ker_equiv_of_surjective doc_blame
+apply_nolint quotient_add_group.quotient_ker_equiv_range doc_blame
+apply_nolint quotient_group.lift doc_blame
+apply_nolint quotient_group.map doc_blame
+apply_nolint quotient_group.quotient_ker_equiv_of_surjective doc_blame
+apply_nolint quotient_group.quotient_ker_equiv_range doc_blame
+
+-- group_theory/subgroup.lean
+apply_nolint add_group.closure doc_blame
+apply_nolint add_group.in_closure doc_blame
+apply_nolint gmultiples doc_blame
+apply_nolint gpowers doc_blame
+apply_nolint group.in_closure doc_blame
+apply_nolint is_add_group_hom.ker unused_arguments doc_blame
+apply_nolint is_add_subgroup.add_center doc_blame
+apply_nolint is_add_subgroup.add_normalizer doc_blame
+apply_nolint is_add_subgroup.normalizer_is_add_subgroup unused_arguments
+apply_nolint is_add_subgroup.trivial doc_blame
+apply_nolint is_group_hom.ker unused_arguments doc_blame
+apply_nolint is_subgroup.center doc_blame
+apply_nolint is_subgroup.normalizer doc_blame
+apply_nolint is_subgroup.normalizer_is_subgroup unused_arguments
+apply_nolint normal_add_subgroup doc_blame
+apply_nolint normal_subgroup doc_blame
+apply_nolint simple_add_group doc_blame
+apply_nolint simple_group doc_blame
+
+-- group_theory/sylow.lean
+apply_nolint sylow.fixed_points_mul_left_cosets_equiv_quotient doc_blame
+apply_nolint sylow.mk_vector_prod_eq_one doc_blame
+apply_nolint sylow.rotate_vectors_prod_eq_one doc_blame
+apply_nolint sylow.vectors_prod_eq_one doc_blame
+
+-- linear_algebra/basic.lean
+apply_nolint linear_equiv has_inhabited_instance
+apply_nolint linear_equiv.to_equiv doc_blame
+apply_nolint linear_equiv.to_linear_map doc_blame
+
+-- linear_algebra/basis.lean
+apply_nolint constr_smul unused_arguments
+apply_nolint is_basis.repr doc_blame
+apply_nolint linear_independent_monoid_hom unused_arguments
+apply_nolint pi.linear_independent_std_basis unused_arguments
+
+-- linear_algebra/bilinear_form.lean
+apply_nolint bilin_form.bilin_linear_map_equiv doc_blame
+apply_nolint bilin_form.to_linear_map doc_blame
+apply_nolint linear_map.to_bilin doc_blame
+
+-- linear_algebra/dimension.lean
+apply_nolint rank doc_blame
+apply_nolint vector_space.dim doc_blame
+
+-- linear_algebra/direct_sum_module.lean
+apply_nolint direct_sum.component doc_blame
+apply_nolint direct_sum.lid doc_blame
+apply_nolint direct_sum.lmk doc_blame
+apply_nolint direct_sum.lof doc_blame
+apply_nolint direct_sum.lset_to_set doc_blame
+apply_nolint direct_sum.to_module doc_blame
+
+-- linear_algebra/dual.lean
+apply_nolint dual_pair has_inhabited_instance
+apply_nolint is_basis.coord_fun doc_blame
+apply_nolint is_basis.to_dual_flip doc_blame
+
+-- linear_algebra/finsupp.lean
+apply_nolint finsupp.congr doc_blame
+apply_nolint finsupp.dom_lcongr doc_blame
+apply_nolint finsupp.lapply doc_blame
+apply_nolint finsupp.lmap_domain doc_blame
+apply_nolint finsupp.lsingle doc_blame
+apply_nolint finsupp.lsubtype_domain doc_blame
+apply_nolint finsupp.lsum doc_blame
+apply_nolint finsupp.restrict_dom doc_blame
+apply_nolint finsupp.supported doc_blame
+apply_nolint finsupp.supported_eq_span_single unused_arguments
+apply_nolint finsupp.supported_equiv_finsupp doc_blame
+apply_nolint finsupp.total_on doc_blame
+apply_nolint linear_map.map_finsupp_total unused_arguments
+
+-- linear_algebra/finsupp_vector_space.lean
+apply_nolint equiv_of_dim_eq_dim doc_blame
+apply_nolint fin_dim_vectorspace_equiv doc_blame
+
+-- linear_algebra/matrix.lean
+apply_nolint linear_equiv_matrix unused_arguments
+
+-- linear_algebra/tensor_product.lean
+apply_nolint linear_map.compl₂ doc_blame
+apply_nolint linear_map.compr₂ doc_blame
+apply_nolint linear_map.flip doc_blame
+apply_nolint linear_map.lcomp doc_blame
+apply_nolint linear_map.lflip doc_blame
+apply_nolint linear_map.llcomp doc_blame
+apply_nolint linear_map.lsmul doc_blame
+apply_nolint linear_map.mk₂ doc_blame
+apply_nolint tensor_product doc_blame
+apply_nolint tensor_product.assoc doc_blame
+apply_nolint tensor_product.congr doc_blame
+apply_nolint tensor_product.curry doc_blame
+apply_nolint tensor_product.direct_sum doc_blame
+apply_nolint tensor_product.lcurry doc_blame
+apply_nolint tensor_product.lift doc_blame
+apply_nolint tensor_product.lift.equiv doc_blame
+apply_nolint tensor_product.lift_aux doc_blame
+apply_nolint tensor_product.map doc_blame
+apply_nolint tensor_product.mk doc_blame
+apply_nolint tensor_product.relators doc_blame
+apply_nolint tensor_product.smul.aux doc_blame
+apply_nolint tensor_product.tmul doc_blame
+apply_nolint tensor_product.uncurry doc_blame
+
+-- logic/basic.lean
+apply_nolint classical.exists_cases doc_blame
+apply_nolint decidable_of_bool doc_blame
+apply_nolint decidable_of_iff doc_blame
+apply_nolint decidable_of_iff' doc_blame
+apply_nolint empty.elim doc_blame
+apply_nolint exists.classical_rec_on doc_blame
+apply_nolint hidden doc_blame
+apply_nolint not.elim doc_blame
+apply_nolint pempty.elim doc_blame
+
+-- logic/embedding.lean
+apply_nolint equiv.to_embedding doc_blame
+apply_nolint function.embedding doc_blame has_inhabited_instance
+apply_nolint function.embedding.Pi_congr_right doc_blame
+apply_nolint function.embedding.arrow_congr_left doc_blame
+apply_nolint function.embedding.arrow_congr_right doc_blame
+apply_nolint function.embedding.congr doc_blame
+apply_nolint function.embedding.equiv_of_surjective doc_blame
+apply_nolint function.embedding.image doc_blame
+apply_nolint function.embedding.of_not_nonempty doc_blame
+apply_nolint function.embedding.of_surjective doc_blame
+apply_nolint function.embedding.prod_congr doc_blame
+apply_nolint function.embedding.refl doc_blame
+apply_nolint function.embedding.set_value doc_blame
+apply_nolint function.embedding.sigma_congr_right doc_blame
+apply_nolint function.embedding.subtype doc_blame
+apply_nolint function.embedding.subtype_map doc_blame
+apply_nolint function.embedding.sum_congr doc_blame
+apply_nolint function.embedding.trans doc_blame
+
+-- logic/function.lean
+apply_nolint function.bicompl doc_blame
+apply_nolint function.bicompr doc_blame
+apply_nolint function.injective.decidable_eq doc_blame
+apply_nolint function.restrict doc_blame
+apply_nolint function.uncurry' doc_blame
+
+-- logic/relation.lean
+apply_nolint relation.comp doc_blame
+apply_nolint relation.join doc_blame
+apply_nolint relation.map doc_blame
+
+-- logic/relator.lean
+apply_nolint relator.bi_total doc_blame
+apply_nolint relator.bi_unique doc_blame
+apply_nolint relator.left_total doc_blame
+apply_nolint relator.left_unique doc_blame
+apply_nolint relator.lift_fun doc_blame
+apply_nolint relator.right_total doc_blame
+apply_nolint relator.right_unique doc_blame
+
+-- logic/unique.lean
+apply_nolint unique doc_blame
+apply_nolint unique.of_surjective doc_blame
+
+-- measure_theory/ae_eq_fun.lean
+apply_nolint measure_theory.ae_eq_fun.add doc_blame
+apply_nolint measure_theory.ae_eq_fun.neg doc_blame
+apply_nolint measure_theory.ae_eq_fun.smul doc_blame
+
+-- measure_theory/borel_space.lean
+apply_nolint ennreal.ennreal_equiv_nnreal doc_blame
+apply_nolint ennreal.ennreal_equiv_sum doc_blame
+apply_nolint homemorph.to_measurable_equiv doc_blame
+
+-- measure_theory/category/Meas.lean
+apply_nolint Meas doc_blame
+
+-- measure_theory/integration.lean
+apply_nolint measure_theory.lintegral_eq_nnreal ge_or_gt
+apply_nolint measure_theory.measure.integral doc_blame
+apply_nolint measure_theory.measure.with_density doc_blame
+apply_nolint measure_theory.simple_func.eapprox doc_blame
+apply_nolint measure_theory.simple_func.fin_vol_supp doc_blame
+apply_nolint measure_theory.simple_func.ite doc_blame
+
+-- measure_theory/measurable_space.lean
+apply_nolint measurable_equiv has_inhabited_instance
+apply_nolint measurable_equiv.cast doc_blame
+apply_nolint measurable_equiv.prod_comm doc_blame
+apply_nolint measurable_equiv.prod_congr doc_blame
+apply_nolint measurable_equiv.prod_sum_distrib doc_blame
+apply_nolint measurable_equiv.refl doc_blame
+apply_nolint measurable_equiv.set.image doc_blame
+apply_nolint measurable_equiv.set.prod doc_blame
+apply_nolint measurable_equiv.set.range doc_blame
+apply_nolint measurable_equiv.set.range_inl doc_blame
+apply_nolint measurable_equiv.set.range_inr doc_blame
+apply_nolint measurable_equiv.set.singleton doc_blame
+apply_nolint measurable_equiv.set.univ doc_blame
+apply_nolint measurable_equiv.sum_congr doc_blame
+apply_nolint measurable_equiv.sum_prod_distrib doc_blame
+apply_nolint measurable_equiv.sum_prod_sum doc_blame
+apply_nolint measurable_equiv.symm doc_blame
+apply_nolint measurable_equiv.trans doc_blame
+apply_nolint measurable_space doc_blame
+apply_nolint measurable_space.dynkin_system.generate doc_blame
+apply_nolint measurable_space.dynkin_system.of_measurable_space doc_blame
+apply_nolint measurable_space.dynkin_system.restrict_on doc_blame
+apply_nolint measurable_space.dynkin_system.to_measurable_space doc_blame
+apply_nolint measurable_space.gi_generate_from doc_blame
+apply_nolint measurable_space.mk_of_closure doc_blame
+
+-- measure_theory/measure_space.lean
+apply_nolint completion doc_blame
+apply_nolint is_null_measurable doc_blame
+apply_nolint measure_theory.measure doc_blame
+apply_nolint measure_theory.measure' unused_arguments
+apply_nolint measure_theory.measure.is_complete doc_blame
+apply_nolint measure_theory.measure.map doc_blame
+apply_nolint measure_theory.measure.of_measurable doc_blame
+apply_nolint measure_theory.outer_measure.to_measure doc_blame
+apply_nolint measure_theory.outer_measure.trim doc_blame
+apply_nolint measure_theory.volume doc_blame
+apply_nolint null_measurable doc_blame
+
+-- measure_theory/outer_measure.lean
+apply_nolint measure_theory.outer_measure doc_blame
+apply_nolint measure_theory.outer_measure.Inf_gen doc_blame
+apply_nolint measure_theory.outer_measure.map doc_blame
+apply_nolint measure_theory.outer_measure.sum doc_blame
+
+-- measure_theory/probability_mass_function.lean
+apply_nolint pmf.bernoulli doc_blame
+apply_nolint pmf.bind doc_blame
+apply_nolint pmf.map doc_blame
+apply_nolint pmf.of_fintype doc_blame
+apply_nolint pmf.of_multiset doc_blame
+apply_nolint pmf.pure doc_blame
+apply_nolint pmf.seq doc_blame
+apply_nolint pmf.support doc_blame
+
+-- meta/coinductive_predicates.lean
+apply_nolint monotonicity doc_blame
+apply_nolint tactic.add_coinductive_predicate doc_blame
+apply_nolint tactic.add_coinductive_predicate.coind_pred doc_blame
+apply_nolint tactic.add_coinductive_predicate.coind_pred.add_theorem doc_blame
+apply_nolint tactic.add_coinductive_predicate.coind_pred.construct doc_blame
+apply_nolint tactic.add_coinductive_predicate.coind_pred.corec_functional doc_blame
+apply_nolint tactic.add_coinductive_predicate.coind_pred.destruct doc_blame
+apply_nolint tactic.add_coinductive_predicate.coind_pred.func doc_blame
+apply_nolint tactic.add_coinductive_predicate.coind_pred.func_g doc_blame
+apply_nolint tactic.add_coinductive_predicate.coind_pred.f₁_l doc_blame
+apply_nolint tactic.add_coinductive_predicate.coind_pred.f₂_l doc_blame
+apply_nolint tactic.add_coinductive_predicate.coind_pred.impl_locals doc_blame
+apply_nolint tactic.add_coinductive_predicate.coind_pred.impl_params doc_blame
+apply_nolint tactic.add_coinductive_predicate.coind_pred.le doc_blame
+apply_nolint tactic.add_coinductive_predicate.coind_pred.mono doc_blame
+apply_nolint tactic.add_coinductive_predicate.coind_pred.pred doc_blame
+apply_nolint tactic.add_coinductive_predicate.coind_pred.pred_g doc_blame
+apply_nolint tactic.add_coinductive_predicate.coind_pred.rec' doc_blame
+apply_nolint tactic.add_coinductive_predicate.coind_pred.u_params doc_blame
+apply_nolint tactic.add_coinductive_predicate.coind_rule doc_blame
+apply_nolint tactic.coinductive_predicate doc_blame
+apply_nolint tactic.interactive.coinduction doc_blame
+apply_nolint tactic.mono doc_blame
+
+-- meta/expr.lean
+apply_nolint declaration.update_with_fun doc_blame
+apply_nolint name.last_string doc_blame
+
+-- number_theory/dioph.lean
+apply_nolint dioph.pell_dioph ge_or_gt
+apply_nolint dioph.xn_dioph ge_or_gt
+apply_nolint fin2 has_inhabited_instance
+apply_nolint fin2.cases' doc_blame
+apply_nolint fin2.elim0 doc_blame
+apply_nolint poly has_inhabited_instance
+apply_nolint vector3 has_inhabited_instance
+apply_nolint vector3.cons_elim doc_blame
+apply_nolint vector3.nil_elim doc_blame
+apply_nolint vector3.rec_on doc_blame
+
+-- number_theory/pell.lean
+apply_nolint pell.az unused_arguments doc_blame
+apply_nolint pell.eq_pow_of_pell ge_or_gt
+apply_nolint pell.matiyasevic ge_or_gt
+apply_nolint pell.x_pos ge_or_gt
+apply_nolint pell.x_sub_y_dvd_pow_lem unused_arguments
+apply_nolint pell.xz doc_blame
+apply_nolint pell.yz doc_blame
+
+-- order/basic.lean
+apply_nolint classical.DLO doc_blame
+apply_nolint decidable_linear_order.lift doc_blame
+apply_nolint decidable_linear_order_of_is_well_order doc_blame
+apply_nolint dense_or_discrete ge_or_gt
+apply_nolint directed_order doc_blame
+apply_nolint ge.is_antisymm ge_or_gt
+apply_nolint ge.is_linear_order ge_or_gt
+apply_nolint ge.is_partial_order ge_or_gt
+apply_nolint ge.is_preorder ge_or_gt
+apply_nolint ge.is_refl ge_or_gt
+apply_nolint ge.is_total ge_or_gt
+apply_nolint ge.is_total_preorder ge_or_gt
+apply_nolint ge.is_trans ge_or_gt
+apply_nolint ge_of_eq ge_or_gt
+apply_nolint gt.is_antisymm ge_or_gt
+apply_nolint gt.is_asymm ge_or_gt
+apply_nolint gt.is_irrefl ge_or_gt
+apply_nolint gt.is_strict_order ge_or_gt
+apply_nolint gt.is_trans ge_or_gt
+apply_nolint gt.is_trichotomous ge_or_gt
+apply_nolint linear_order.lift doc_blame
+apply_nolint partial_order.lift doc_blame
+apply_nolint preorder.lift doc_blame
+apply_nolint well_founded.succ doc_blame
+apply_nolint well_founded.sup doc_blame
+
+-- order/bounded_lattice.lean
+apply_nolint with_bot doc_blame
+apply_nolint with_top doc_blame
+
+-- order/complete_lattice.lean
+apply_nolint lattice.Inf_eq_bot ge_or_gt
+apply_nolint lattice.infi_eq_bot ge_or_gt
+
+-- order/conditionally_complete_lattice.lean
+apply_nolint lattice.conditionally_complete_linear_order doc_blame
+apply_nolint lattice.conditionally_complete_linear_order_bot doc_blame
+
+-- order/filter/basic.lean
+apply_nolint filter doc_blame
+apply_nolint filter.gi_generate doc_blame
+apply_nolint filter.hyperfilter doc_blame
+apply_nolint filter.mk_of_closure doc_blame
+apply_nolint filter.monad doc_blame
+apply_nolint filter.ultrafilter.bind doc_blame
+apply_nolint filter.ultrafilter.map doc_blame
+apply_nolint filter.ultrafilter.pure doc_blame
+apply_nolint lattice.complete_lattice.copy doc_blame
+
+-- order/filter/partial.lean
+apply_nolint filter.pcomap' doc_blame
+apply_nolint filter.pmap doc_blame
+apply_nolint filter.ptendsto doc_blame
+apply_nolint filter.ptendsto' doc_blame
+apply_nolint filter.rcomap doc_blame
+apply_nolint filter.rcomap' doc_blame
+apply_nolint filter.rmap doc_blame
+apply_nolint filter.rtendsto doc_blame
+apply_nolint filter.rtendsto' doc_blame
+
+-- order/filter/pointwise.lean
+apply_nolint filter.pointwise_add doc_blame
+apply_nolint filter.pointwise_add_add_monoid doc_blame
+apply_nolint filter.pointwise_mul doc_blame
+apply_nolint filter.pointwise_mul_monoid doc_blame
+apply_nolint filter.pointwise_one doc_blame
+apply_nolint filter.pointwise_zero doc_blame
+
+-- order/fixed_points.lean
+apply_nolint lattice.fixed_points doc_blame
+apply_nolint lattice.fixed_points.next doc_blame
+apply_nolint lattice.fixed_points.next_fixed doc_blame
+apply_nolint lattice.fixed_points.prev doc_blame
+apply_nolint lattice.fixed_points.prev_fixed doc_blame
+
+-- order/galois_connection.lean
+apply_nolint galois_insertion has_inhabited_instance
+
+-- order/lexicographic.lean
+apply_nolint lex doc_blame
+
+-- order/liminf_limsup.lean
+apply_nolint filter.Liminf doc_blame
+apply_nolint filter.Limsup doc_blame
+apply_nolint filter.is_bounded_default doc_blame
+apply_nolint filter.is_bounded_ge_of_bot ge_or_gt
+apply_nolint filter.is_bounded_under doc_blame
+apply_nolint filter.is_bounded_under_inf ge_or_gt
+apply_nolint filter.is_cobounded_ge_of_top ge_or_gt
+apply_nolint filter.is_cobounded_under doc_blame
+apply_nolint filter.is_trans_ge ge_or_gt
+apply_nolint filter.liminf doc_blame
+apply_nolint filter.liminf_eq_supr_infi_of_nat ge_or_gt
+apply_nolint filter.limsup doc_blame
+apply_nolint filter.limsup_eq_infi_supr_of_nat ge_or_gt
+
+-- order/order_iso.lean
+apply_nolint order_embedding has_inhabited_instance
+apply_nolint order_embedding.lt_embedding_of_le_embedding doc_blame
+apply_nolint order_embedding.nat_gt ge_or_gt doc_blame
+apply_nolint order_embedding.nat_lt doc_blame
+apply_nolint order_embedding.refl doc_blame
+apply_nolint order_embedding.trans doc_blame
+apply_nolint order_embedding.well_founded_iff_no_descending_seq ge_or_gt
+apply_nolint order_iso has_inhabited_instance
+apply_nolint order_iso.of_surjective doc_blame
+apply_nolint order_iso.prod_lex_congr doc_blame
+apply_nolint order_iso.refl doc_blame
+apply_nolint order_iso.sum_lex_congr doc_blame
+apply_nolint order_iso.symm doc_blame
+apply_nolint order_iso.to_order_embedding doc_blame
+apply_nolint order_iso.trans doc_blame
+apply_nolint subrel.order_embedding doc_blame
+
+-- order/pilex.lean
+apply_nolint pi.lex doc_blame
+apply_nolint pilex doc_blame
+
+-- ring_theory/adjoin.lean
+apply_nolint algebra.adjoin_eq_range unused_arguments
+apply_nolint algebra.adjoin_singleton_eq_range unused_arguments
+apply_nolint subalgebra.fg doc_blame
+
+-- ring_theory/adjoin_root.lean
+apply_nolint adjoin_root doc_blame
+apply_nolint adjoin_root.lift doc_blame
+apply_nolint adjoin_root.mk doc_blame
+apply_nolint adjoin_root.of doc_blame
+apply_nolint adjoin_root.root doc_blame
+
+-- ring_theory/algebra.lean
+apply_nolint alg_hom has_inhabited_instance
+apply_nolint alg_hom.comp doc_blame
+apply_nolint alg_hom.id doc_blame
+apply_nolint alg_hom.range doc_blame
+apply_nolint alg_hom.to_ring_hom doc_blame
+apply_nolint algebra.adjoin doc_blame
+apply_nolint algebra.comap has_inhabited_instance
+apply_nolint algebra.comap.comm_ring unused_arguments
+apply_nolint algebra.comap.has_scalar unused_arguments
+apply_nolint algebra.comap.of_comap doc_blame
+apply_nolint algebra.comap.ring unused_arguments
+apply_nolint algebra.comap.to_comap doc_blame
+apply_nolint algebra.gi doc_blame
+apply_nolint algebra.lmul_left doc_blame
+apply_nolint algebra.lmul_right doc_blame
+apply_nolint algebra.of_id doc_blame
+apply_nolint algebra.to_comap doc_blame
+apply_nolint algebra.to_top doc_blame
+apply_nolint algebra_map doc_blame
+apply_nolint subalgebra doc_blame
+apply_nolint subalgebra.comap doc_blame
+apply_nolint subalgebra.to_submodule doc_blame
+apply_nolint subalgebra.under doc_blame
+apply_nolint subalgebra.val doc_blame
+
+-- ring_theory/free_comm_ring.lean
+apply_nolint free_comm_ring doc_blame
+apply_nolint free_comm_ring.is_supported doc_blame
+apply_nolint free_comm_ring.lift doc_blame
+apply_nolint free_comm_ring.map doc_blame
+apply_nolint free_comm_ring.of doc_blame
+apply_nolint free_comm_ring.restriction doc_blame
+apply_nolint free_comm_ring_equiv_mv_polynomial_int doc_blame
+apply_nolint free_comm_ring_pempty_equiv_int doc_blame
+apply_nolint free_comm_ring_punit_equiv_polynomial_int doc_blame
+apply_nolint free_ring.subsingleton_equiv_free_comm_ring doc_blame
+apply_nolint free_ring.to_free_comm_ring doc_blame
+apply_nolint free_ring_pempty_equiv_int doc_blame
+apply_nolint free_ring_punit_equiv_polynomial_int doc_blame
+
+-- ring_theory/free_ring.lean
+apply_nolint free_ring doc_blame
+apply_nolint free_ring.lift doc_blame
+apply_nolint free_ring.map doc_blame
+apply_nolint free_ring.of doc_blame
+
+-- ring_theory/ideal_operations.lean
+apply_nolint ideal.le_order_embedding_of_surjective doc_blame
+apply_nolint ideal.lt_order_embedding_of_surjective doc_blame
+apply_nolint ideal.map unused_arguments doc_blame
+apply_nolint ideal.quotient_inf_to_pi_quotient doc_blame
+apply_nolint is_ring_hom.ker doc_blame
+apply_nolint submodule.annihilator doc_blame
+apply_nolint submodule.colon doc_blame
+
+-- ring_theory/ideals.lean
+apply_nolint ideal.is_coprime doc_blame
+apply_nolint ideal.is_maximal doc_blame
+apply_nolint ideal.is_prime doc_blame
+apply_nolint ideal.quotient doc_blame has_inhabited_instance
+apply_nolint ideal.quotient.lift doc_blame
+apply_nolint ideal.quotient.map_mk doc_blame
+apply_nolint ideal.quotient.mk doc_blame
+apply_nolint ideal.quotient.nonzero_comm_ring doc_blame
+apply_nolint ideal.span doc_blame
+apply_nolint is_local_ring doc_blame
+apply_nolint is_local_ring_hom doc_blame
+apply_nolint local_of_is_local_ring doc_blame
+apply_nolint local_of_nonunits_ideal doc_blame
+apply_nolint local_of_unique_max_ideal doc_blame
+apply_nolint local_of_unit_or_unit_one_sub doc_blame
+apply_nolint local_ring doc_blame
+apply_nolint local_ring.nonunits_ideal doc_blame
+apply_nolint local_ring.residue_field doc_blame has_inhabited_instance
+apply_nolint local_ring.residue_field.map doc_blame
+apply_nolint nonunits doc_blame
+
+-- ring_theory/integral_closure.lean
+apply_nolint integral_closure doc_blame
+apply_nolint is_integral doc_blame
+
+-- ring_theory/localization.lean
+apply_nolint localization.at_prime doc_blame
+apply_nolint localization.away doc_blame
+apply_nolint localization.away.inv_self doc_blame
+apply_nolint localization.away.lift doc_blame
+apply_nolint localization.away_to_away_right doc_blame
+apply_nolint localization.equiv_of_equiv doc_blame
+apply_nolint localization.fraction_ring.eq_zero_of_ne_zero_of_mul_eq_zero unused_arguments
+apply_nolint localization.fraction_ring.equiv_of_equiv doc_blame
+apply_nolint localization.fraction_ring.inv_aux doc_blame
+apply_nolint localization.fraction_ring.map doc_blame
+apply_nolint localization.le_order_embedding doc_blame
+apply_nolint localization.lift doc_blame
+apply_nolint localization.lift' doc_blame
+apply_nolint localization.map doc_blame
+apply_nolint localization.mk doc_blame
+apply_nolint localization.non_zero_divisors doc_blame
+apply_nolint localization.r unused_arguments doc_blame
+
+-- ring_theory/maps.lean
+apply_nolint comm_ring.anti_equiv_to_equiv doc_blame
+apply_nolint comm_ring.equiv_to_anti_equiv doc_blame
+apply_nolint is_ring_anti_hom doc_blame
+apply_nolint ring_anti_equiv has_inhabited_instance
+apply_nolint ring_anti_equiv.refl doc_blame
+apply_nolint ring_invo.id doc_blame
+apply_nolint ring_invo.to_ring_anti_equiv doc_blame
+
+-- ring_theory/multiplicity.lean
+apply_nolint multiplicity.finite doc_blame
+apply_nolint multiplicity.finite_mul_aux unused_arguments
+
+-- ring_theory/noetherian.lean
+apply_nolint is_noetherian doc_blame
+apply_nolint is_noetherian_iff_well_founded ge_or_gt
+apply_nolint is_noetherian_ring doc_blame
+apply_nolint submodule.fg doc_blame
+apply_nolint well_founded_submodule_gt ge_or_gt
+
+-- ring_theory/power_series.lean
+apply_nolint mv_power_series.inv doc_blame
+apply_nolint mv_power_series.trunc_fun doc_blame
+apply_nolint polynomial.monomial doc_blame
+apply_nolint power_series.inv doc_blame
+apply_nolint power_series.inv.aux doc_blame
+apply_nolint power_series.mk unused_arguments
+apply_nolint power_series.order_add_ge ge_or_gt
+apply_nolint power_series.order_ge ge_or_gt
+apply_nolint power_series.order_ge_nat ge_or_gt
+apply_nolint power_series.order_mul_ge ge_or_gt
+
+-- ring_theory/principal_ideal_domain.lean
+apply_nolint ideal.is_principal doc_blame
+apply_nolint ideal.is_principal.generator doc_blame
+apply_nolint principal_ideal_domain doc_blame
+apply_nolint principal_ideal_domain.factors doc_blame
+
+-- ring_theory/subring.lean
+apply_nolint ring.closure doc_blame
+
+-- ring_theory/unique_factorization_domain.lean
+apply_nolint associates.factor_set unused_arguments
+apply_nolint associates.factor_set.coe_add unused_arguments
+apply_nolint associates.factor_set.prod unused_arguments doc_blame
+apply_nolint associates.factors doc_blame
+apply_nolint associates.factors' unused_arguments doc_blame
+apply_nolint associates.unique' unused_arguments
+apply_nolint unique_factorization_domain.exists_mem_factors_of_dvd unused_arguments
+apply_nolint unique_factorization_domain.of_unique_irreducible_factorization doc_blame
+apply_nolint unique_irreducible_factorization doc_blame has_inhabited_instance
+
+-- set_theory/cofinality.lean
+apply_nolint strict_order.cof doc_blame
+
+-- set_theory/lists.lean
+apply_nolint finsets doc_blame
+apply_nolint lists doc_blame
+apply_nolint lists' doc_blame
+apply_nolint lists'.cons doc_blame
+apply_nolint lists'.of_list doc_blame
+apply_nolint lists'.to_list doc_blame
+apply_nolint lists.atom doc_blame
+apply_nolint lists.induction_mut doc_blame
+apply_nolint lists.is_list doc_blame
+apply_nolint lists.mem doc_blame
+apply_nolint lists.of' doc_blame
+apply_nolint lists.of_list doc_blame
+apply_nolint lists.to_list doc_blame
+
+-- set_theory/ordinal.lean
+apply_nolint Well_order doc_blame
+apply_nolint cardinal.aleph'.order_iso doc_blame
+apply_nolint cardinal.aleph_idx.initial_seg doc_blame
+apply_nolint cardinal.aleph_idx.order_iso doc_blame
+apply_nolint cardinal.ord.order_embedding doc_blame
+apply_nolint initial_seg has_inhabited_instance
+apply_nolint initial_seg.le_add doc_blame
+apply_nolint initial_seg.le_lt doc_blame
+apply_nolint initial_seg.lt_or_eq doc_blame
+apply_nolint order_embedding.collapse_F doc_blame
+apply_nolint ordinal.CNF_rec doc_blame
+apply_nolint ordinal.CNF_sorted ge_or_gt
+apply_nolint ordinal.initial_seg_out doc_blame
+apply_nolint ordinal.lift.initial_seg doc_blame
+apply_nolint ordinal.lift.principal_seg doc_blame
+apply_nolint ordinal.limit_rec_on doc_blame
+apply_nolint ordinal.order_iso_out doc_blame
+apply_nolint ordinal.principal_seg_out doc_blame
+apply_nolint ordinal.typein.principal_seg doc_blame
+apply_nolint ordinal.typein_iso doc_blame
+apply_nolint principal_seg doc_blame has_inhabited_instance
+apply_nolint principal_seg.equiv_lt doc_blame
+apply_nolint principal_seg.lt_equiv doc_blame
+apply_nolint principal_seg.lt_le doc_blame
+apply_nolint principal_seg.top_lt_top unused_arguments
+apply_nolint principal_seg.trans doc_blame
+apply_nolint principal_seg.trans_top unused_arguments
+
+-- set_theory/ordinal_notation.lean
+apply_nolint onote.oadd_lt_oadd_1 unused_arguments
+apply_nolint onote.oadd_lt_oadd_2 unused_arguments
+apply_nolint onote.oadd_lt_oadd_3 unused_arguments
+apply_nolint onote.power_aux doc_blame
+apply_nolint onote.to_string_aux1 doc_blame
+
+-- set_theory/pgame.lean
+apply_nolint pgame.left_moves has_inhabited_instance
+apply_nolint pgame.relabelling has_inhabited_instance
+apply_nolint pgame.restricted has_inhabited_instance
+apply_nolint pgame.right_moves has_inhabited_instance
+
+-- set_theory/surreal.lean
+apply_nolint pgame.add_lt_add unused_arguments
+apply_nolint pgame.inv_ty has_inhabited_instance
+apply_nolint pgame.numeric.lt_move_right unused_arguments
+apply_nolint pgame.numeric.move_left_lt unused_arguments
+apply_nolint surreal.add doc_blame
+
+-- set_theory/zfc.lean
+apply_nolint Class doc_blame
+apply_nolint Set.map_definable_aux unused_arguments
+apply_nolint Set.mem doc_blame
+apply_nolint Set.mk doc_blame
+apply_nolint Set.subset doc_blame
+apply_nolint classical.all_definable doc_blame
+apply_nolint pSet.definable.eq_mk doc_blame
+apply_nolint pSet.definable.resp doc_blame
+apply_nolint pSet.resp.equiv doc_blame
+apply_nolint pSet.resp.eval_aux doc_blame
+apply_nolint pSet.resp.f doc_blame
+apply_nolint pSet.subset doc_blame
+apply_nolint pSet.type has_inhabited_instance
+
+-- tactic/abel.lean
+apply_nolint tactic.abel.add_g doc_blame
+apply_nolint tactic.abel.cache doc_blame
+apply_nolint tactic.abel.cache.app doc_blame
+apply_nolint tactic.abel.cache.iapp doc_blame
+apply_nolint tactic.abel.cache.int_to_expr doc_blame
+apply_nolint tactic.abel.cache.mk_app doc_blame
+apply_nolint tactic.abel.cache.mk_term doc_blame
+apply_nolint tactic.abel.eval doc_blame
+apply_nolint tactic.abel.eval' doc_blame
+apply_nolint tactic.abel.eval_add doc_blame
+apply_nolint tactic.abel.eval_atom doc_blame
+apply_nolint tactic.abel.eval_neg doc_blame
+apply_nolint tactic.abel.eval_smul doc_blame
+apply_nolint tactic.abel.mk_cache doc_blame
+apply_nolint tactic.abel.normal_expr doc_blame
+apply_nolint tactic.abel.normal_expr.e doc_blame
+apply_nolint tactic.abel.normal_expr.pp doc_blame
+apply_nolint tactic.abel.normal_expr.refl_conv doc_blame
+apply_nolint tactic.abel.normal_expr.term' doc_blame
+apply_nolint tactic.abel.normal_expr.to_list doc_blame
+apply_nolint tactic.abel.normal_expr.to_string doc_blame
+apply_nolint tactic.abel.normal_expr.zero' doc_blame
+apply_nolint tactic.abel.normalize doc_blame
+apply_nolint tactic.abel.normalize_mode doc_blame
+apply_nolint tactic.abel.smul doc_blame
+apply_nolint tactic.abel.smulg doc_blame
+apply_nolint tactic.abel.term doc_blame
+apply_nolint tactic.abel.termg doc_blame
+apply_nolint tactic.interactive.abel.mode doc_blame
+
+-- tactic/algebra.lean
+apply_nolint tactic.ancestor_attr doc_blame
+apply_nolint tactic.find_ancestors doc_blame
+apply_nolint tactic.get_ancestors doc_blame
+
+-- tactic/alias.lean
+apply_nolint tactic.alias.alias_attr doc_blame
+apply_nolint tactic.alias.alias_cmd doc_blame
+apply_nolint tactic.alias.alias_direct doc_blame
+apply_nolint tactic.alias.alias_iff doc_blame
+apply_nolint tactic.alias.get_alias_target doc_blame
+apply_nolint tactic.alias.get_lambda_body doc_blame
+apply_nolint tactic.alias.make_left_right doc_blame
+apply_nolint tactic.alias.mk_iff_mp_app doc_blame
+
+-- tactic/apply_fun.lean
+apply_nolint apply_fun_name doc_blame
+
+-- tactic/auto_cases.lean
+apply_nolint auto_cases_at doc_blame
+
+-- tactic/chain.lean
+apply_nolint tactic.abstract_if_success doc_blame
+apply_nolint tactic.chain doc_blame
+apply_nolint tactic.chain_core doc_blame
+apply_nolint tactic.interactive.work_on_goal doc_blame
+apply_nolint tactic.trace_output unused_arguments doc_blame
+
+-- tactic/converter/binders.lean
+apply_nolint binder_eq_elim doc_blame
+apply_nolint binder_eq_elim.check doc_blame
+apply_nolint binder_eq_elim.check_eq unused_arguments doc_blame
+apply_nolint binder_eq_elim.old_conv doc_blame
+apply_nolint binder_eq_elim.pull doc_blame
+apply_nolint binder_eq_elim.push doc_blame
+apply_nolint exists_eq_elim doc_blame
+apply_nolint forall_eq_elim doc_blame
+apply_nolint infi_eq_elim doc_blame
+apply_nolint old_conv.apply doc_blame
+apply_nolint old_conv.apply' doc_blame
+apply_nolint old_conv.applyc doc_blame
+apply_nolint old_conv.congr_arg doc_blame
+apply_nolint old_conv.congr_binder doc_blame
+apply_nolint old_conv.congr_fun doc_blame
+apply_nolint old_conv.congr_rule doc_blame
+apply_nolint old_conv.current_relation doc_blame
+apply_nolint old_conv.funext' doc_blame
+apply_nolint old_conv.head_beta doc_blame
+apply_nolint old_conv.propext' doc_blame
+apply_nolint supr_eq_elim doc_blame
+
+-- tactic/converter/interactive.lean
+apply_nolint conv.discharge_eq_lhs doc_blame
+apply_nolint conv.interactive.erw doc_blame
+apply_nolint conv.replace_lhs doc_blame
+apply_nolint old_conv.execute doc_blame
+apply_nolint old_conv.interactive.change doc_blame
+apply_nolint old_conv.interactive.dsimp doc_blame
+apply_nolint old_conv.interactive.find doc_blame
+apply_nolint old_conv.interactive.itactic doc_blame
+apply_nolint old_conv.interactive.trace_state doc_blame
+apply_nolint old_conv.interactive.whnf doc_blame
+apply_nolint old_conv.istep unused_arguments doc_blame
+apply_nolint old_conv.save_info doc_blame
+apply_nolint old_conv.step doc_blame
+apply_nolint tactic.interactive.conv_lhs doc_blame
+apply_nolint tactic.interactive.conv_rhs doc_blame
+apply_nolint tactic.interactive.find doc_blame
+apply_nolint tactic.interactive.old_conv doc_blame
+
+-- tactic/converter/old_conv.lean
+apply_nolint old_conv doc_blame
+apply_nolint old_conv.apply_lemmas doc_blame
+apply_nolint old_conv.apply_lemmas_core doc_blame
+apply_nolint old_conv.apply_propext_lemmas doc_blame
+apply_nolint old_conv.apply_propext_lemmas_core doc_blame
+apply_nolint old_conv.apply_propext_simp_set doc_blame
+apply_nolint old_conv.apply_simp_set doc_blame
+apply_nolint old_conv.bind doc_blame
+apply_nolint old_conv.bottom_up doc_blame
+apply_nolint old_conv.change doc_blame
+apply_nolint old_conv.congr doc_blame
+apply_nolint old_conv.congr_core doc_blame
+apply_nolint old_conv.conversion doc_blame
+apply_nolint old_conv.dsimp doc_blame
+apply_nolint old_conv.fail doc_blame
+apply_nolint old_conv.failed doc_blame
+apply_nolint old_conv.find doc_blame
+apply_nolint old_conv.find_pattern doc_blame
+apply_nolint old_conv.findp doc_blame
+apply_nolint old_conv.first doc_blame
+apply_nolint old_conv.funext doc_blame
+apply_nolint old_conv.lhs doc_blame
+apply_nolint old_conv.lift_tactic doc_blame
+apply_nolint old_conv.map doc_blame
+apply_nolint old_conv.match_expr doc_blame
+apply_nolint old_conv.match_pattern doc_blame
+apply_nolint old_conv.mk_match_expr doc_blame
+apply_nolint old_conv.orelse doc_blame
+apply_nolint old_conv.pure doc_blame
+apply_nolint old_conv.repeat doc_blame
+apply_nolint old_conv.seq doc_blame
+apply_nolint old_conv.skip doc_blame
+apply_nolint old_conv.to_tactic doc_blame
+apply_nolint old_conv.top_down doc_blame
+apply_nolint old_conv.trace doc_blame
+apply_nolint old_conv.trace_lhs doc_blame
+apply_nolint old_conv.whnf doc_blame
+apply_nolint old_conv_result doc_blame
+
+-- tactic/core.lean
+apply_nolint tactic.symmetry_hyp unused_arguments
+
+-- tactic/elide.lean
+apply_nolint tactic.elide.replace doc_blame
+apply_nolint tactic.elide.unelide doc_blame
+
+-- tactic/explode.lean
+apply_nolint tactic.explode doc_blame
+apply_nolint tactic.explode.append_dep doc_blame
+apply_nolint tactic.explode.args doc_blame
+apply_nolint tactic.explode.core doc_blame
+apply_nolint tactic.explode.entries doc_blame
+apply_nolint tactic.explode.entries.add doc_blame
+apply_nolint tactic.explode.entries.find doc_blame
+apply_nolint tactic.explode.entries.head doc_blame
+apply_nolint tactic.explode.entries.size doc_blame
+apply_nolint tactic.explode.entry doc_blame
+apply_nolint tactic.explode.format_aux doc_blame
+apply_nolint tactic.explode.head' doc_blame
+apply_nolint tactic.explode.may_be_proof doc_blame
+apply_nolint tactic.explode.pad_right doc_blame
+apply_nolint tactic.explode.status doc_blame
+apply_nolint tactic.explode_cmd doc_blame
+apply_nolint tactic.explode_expr doc_blame
+
+-- tactic/ext.lean
+apply_nolint equiv_type_constr doc_blame
+apply_nolint ext_param doc_blame
+apply_nolint ext_param_type doc_blame
+apply_nolint get_ext_subject doc_blame
+apply_nolint opt_minus doc_blame
+apply_nolint saturate_fun doc_blame
+apply_nolint tactic.ext doc_blame
+apply_nolint tactic.ext1 doc_blame
+apply_nolint tactic.try_intros doc_blame
+
+-- tactic/fin_cases.lean
+apply_nolint tactic.expr_list_to_list_expr doc_blame
+apply_nolint tactic.fin_cases_at doc_blame
+apply_nolint tactic.fin_cases_at_aux doc_blame
+
+-- tactic/find.lean
+apply_nolint expr.get_pis doc_blame
+apply_nolint find_cmd doc_blame
+apply_nolint pexpr.get_uninst_pis doc_blame
+
+-- tactic/finish.lean
+apply_nolint auto.add_conjuncts doc_blame
+apply_nolint auto.add_simps doc_blame
+apply_nolint auto.auto_config doc_blame
+apply_nolint auto.case_hyp doc_blame
+apply_nolint auto.case_option doc_blame
+apply_nolint auto.case_some_hyp doc_blame
+apply_nolint auto.case_some_hyp_aux doc_blame
+apply_nolint auto.classical_normalize_lemma_names doc_blame
+apply_nolint auto.common_normalize_lemma_names doc_blame
+apply_nolint auto.do_subst doc_blame
+apply_nolint auto.do_substs doc_blame
+apply_nolint auto.eelim doc_blame
+apply_nolint auto.eelims doc_blame
+apply_nolint auto.mk_hinst_lemmas doc_blame
+apply_nolint auto.normalize_hyp doc_blame
+apply_nolint auto.normalize_hyps doc_blame
+apply_nolint auto.normalize_negations doc_blame
+apply_nolint auto.preprocess_goal doc_blame
+apply_nolint auto.preprocess_hyps doc_blame
+apply_nolint auto.split_hyp doc_blame
+apply_nolint auto.split_hyps doc_blame
+apply_nolint auto.split_hyps_aux doc_blame
+apply_nolint auto.whnf_reducible doc_blame
+apply_nolint tactic.assert_fresh doc_blame
+apply_nolint tactic.assertv_fresh doc_blame
+apply_nolint tactic.interactive.revert_all doc_blame
+
+-- tactic/generalize_proofs.lean
+apply_nolint tactic.generalize_proofs doc_blame
+
+-- tactic/interactive.lean
+apply_nolint tactic.interactive.apply_iff_congr_core doc_blame
+apply_nolint tactic.interactive.clean_ids doc_blame
+apply_nolint tactic.interactive.collect_struct doc_blame
+apply_nolint tactic.interactive.collect_struct' doc_blame
+apply_nolint tactic.interactive.compact_decl doc_blame
+apply_nolint tactic.interactive.compact_decl_aux doc_blame
+apply_nolint tactic.interactive.congr_core' doc_blame
+apply_nolint tactic.interactive.convert_to_core doc_blame
+apply_nolint tactic.interactive.field doc_blame
+apply_nolint tactic.interactive.format_names doc_blame
+apply_nolint tactic.interactive.get_current_field doc_blame
+apply_nolint tactic.interactive.guard_expr_eq' doc_blame
+apply_nolint tactic.interactive.guard_hyp_nums doc_blame
+apply_nolint tactic.interactive.guard_tags doc_blame
+apply_nolint tactic.interactive.list_cast_of doc_blame
+apply_nolint tactic.interactive.list_cast_of_aux doc_blame
+apply_nolint tactic.interactive.loc.get_local_pp_names doc_blame
+apply_nolint tactic.interactive.loc.get_local_uniq_names doc_blame
+apply_nolint tactic.interactive.mk_paragraph_aux doc_blame
+apply_nolint tactic.interactive.refine_one doc_blame
+apply_nolint tactic.interactive.refine_recursively doc_blame
+apply_nolint tactic.interactive.return_cast doc_blame
+apply_nolint tactic.interactive.source_fields doc_blame
+
+-- tactic/lift.lean
+apply_nolint can_lift_attr doc_blame
+apply_nolint tactic.get_lift_prf doc_blame
+apply_nolint tactic.to_texpr doc_blame
+apply_nolint tactic.using_texpr doc_blame
+
+-- tactic/linarith.lean
+apply_nolint linarith.add_exprs doc_blame
+apply_nolint linarith.add_exprs_aux doc_blame
+apply_nolint linarith.add_neg_eq_pfs doc_blame
+apply_nolint linarith.cast_expr doc_blame
+apply_nolint linarith.comp.add doc_blame
+apply_nolint linarith.comp.coeff_of doc_blame
+apply_nolint linarith.comp.is_contr doc_blame
+apply_nolint linarith.comp.lt doc_blame
+apply_nolint linarith.comp.scale doc_blame
+apply_nolint linarith.comp_source doc_blame
+apply_nolint linarith.comp_source.flatten doc_blame
+apply_nolint linarith.comp_source.to_string doc_blame
+apply_nolint linarith.elab_arg_list doc_blame
+apply_nolint linarith.elim_all_vars doc_blame
+apply_nolint linarith.elim_with_set doc_blame
+apply_nolint linarith.expr_contains doc_blame
+apply_nolint linarith.find_cancel_factor doc_blame
+apply_nolint linarith.find_contr doc_blame
+apply_nolint linarith.get_comps doc_blame
+apply_nolint linarith.get_contr_lemma_name doc_blame
+apply_nolint linarith.get_nat_comps doc_blame
+apply_nolint linarith.get_rel_sides doc_blame
+apply_nolint linarith.get_var_list doc_blame
+apply_nolint linarith.get_vars doc_blame
+apply_nolint linarith.guard_is_nat_prop doc_blame
+apply_nolint linarith.guard_is_strict_int_prop doc_blame
+apply_nolint linarith.ineq doc_blame
+apply_nolint linarith.ineq.is_lt doc_blame
+apply_nolint linarith.ineq.max doc_blame
+apply_nolint linarith.ineq.to_string doc_blame
+apply_nolint linarith.ineq_const_mul_nm doc_blame
+apply_nolint linarith.ineq_const_nm doc_blame
+apply_nolint linarith.ineq_pf_tp doc_blame
+apply_nolint linarith.is_nat_int_coe doc_blame
+apply_nolint linarith.is_numeric doc_blame
+apply_nolint linarith.linarith_config doc_blame
+apply_nolint linarith.linarith_monad doc_blame
+apply_nolint linarith.linarith_monad.run doc_blame
+apply_nolint linarith.list.mfind doc_blame
+apply_nolint linarith.map_lt doc_blame
+apply_nolint linarith.map_of_expr_mul_aux doc_blame
+apply_nolint linarith.mk_cast_eq_and_nonneg_prfs doc_blame
+apply_nolint linarith.mk_coe_nat_nonneg_prf doc_blame
+apply_nolint linarith.mk_coe_nat_nonneg_prfs doc_blame
+apply_nolint linarith.mk_int_pfs_of_nat_pf doc_blame
+apply_nolint linarith.mk_lt_zero_pf_aux doc_blame
+apply_nolint linarith.mk_neg_one_lt_zero_pf doc_blame
+apply_nolint linarith.mk_non_strict_int_pf_of_strict_int_pf doc_blame
+apply_nolint linarith.mk_prod_prf doc_blame
+apply_nolint linarith.mk_single_comp_zero_pf doc_blame
+apply_nolint linarith.monad.elim_var doc_blame
+apply_nolint linarith.mul_eq unused_arguments
+apply_nolint linarith.mul_expr doc_blame
+apply_nolint linarith.norm_hyp doc_blame
+apply_nolint linarith.norm_hyp_aux doc_blame
+apply_nolint linarith.parse_into_comp_and_expr doc_blame
+apply_nolint linarith.partition_by_type doc_blame
+apply_nolint linarith.partition_by_type_aux doc_blame
+apply_nolint linarith.pcomp doc_blame
+apply_nolint linarith.pcomp.add doc_blame
+apply_nolint linarith.pcomp.is_contr doc_blame
+apply_nolint linarith.pcomp.scale doc_blame
+apply_nolint linarith.pelim_var doc_blame
+apply_nolint linarith.preferred_type_of_goal doc_blame
+apply_nolint linarith.rb_map.find_defeq doc_blame
+apply_nolint linarith.rearr_comp doc_blame
+apply_nolint linarith.rem_neg doc_blame
+apply_nolint linarith.replace_nat_pfs doc_blame
+apply_nolint linarith.replace_strict_int_pfs doc_blame
+apply_nolint linarith.term_of_ineq_prf doc_blame
+apply_nolint linarith.to_comp doc_blame
+apply_nolint linarith.to_comp_fold doc_blame
+apply_nolint linarith.update doc_blame
+apply_nolint linarith.validate doc_blame
+apply_nolint nat.to_pexpr doc_blame
+
+-- tactic/local_cache.lean
+apply_nolint tactic.local_cache.internal.block_local.clear doc_blame
+apply_nolint tactic.local_cache.internal.block_local.get_name doc_blame
+apply_nolint tactic.local_cache.internal.block_local.present doc_blame
+apply_nolint tactic.local_cache.internal.block_local.try_get_name doc_blame
+apply_nolint tactic.local_cache.internal.cache_scope doc_blame
+apply_nolint tactic.local_cache.internal.def_local.FNV_OFFSET_BASIS doc_blame
+apply_nolint tactic.local_cache.internal.def_local.FNV_PRIME doc_blame
+apply_nolint tactic.local_cache.internal.def_local.RADIX doc_blame
+apply_nolint tactic.local_cache.internal.def_local.apply_tag doc_blame
+apply_nolint tactic.local_cache.internal.def_local.clear doc_blame
+apply_nolint tactic.local_cache.internal.def_local.get_name doc_blame
+apply_nolint tactic.local_cache.internal.def_local.get_root_name doc_blame
+apply_nolint tactic.local_cache.internal.def_local.get_tag_with_status doc_blame
+apply_nolint tactic.local_cache.internal.def_local.hash_byte doc_blame
+apply_nolint tactic.local_cache.internal.def_local.hash_context doc_blame
+apply_nolint tactic.local_cache.internal.def_local.hash_string doc_blame
+apply_nolint tactic.local_cache.internal.def_local.is_name_dead doc_blame
+apply_nolint tactic.local_cache.internal.def_local.kill_name doc_blame
+apply_nolint tactic.local_cache.internal.def_local.mk_dead_name doc_blame
+apply_nolint tactic.local_cache.internal.def_local.present doc_blame
+apply_nolint tactic.local_cache.internal.def_local.try_get_name doc_blame
+apply_nolint tactic.local_cache.internal.load_data unused_arguments doc_blame
+apply_nolint tactic.local_cache.internal.mk_full_namespace doc_blame
+apply_nolint tactic.local_cache.internal.poke_data doc_blame
+apply_nolint tactic.local_cache.internal.run_once_under_name doc_blame
+apply_nolint tactic.local_cache.internal.save_data unused_arguments doc_blame
+
+-- tactic/localized.lean
+apply_nolint localized_attr doc_blame
+apply_nolint localized_cmd unused_arguments
+apply_nolint open_locale_cmd unused_arguments
+
+-- tactic/mk_iff_of_inductive_prop.lean
+apply_nolint tactic.constr_to_prop doc_blame
+apply_nolint tactic.mk_iff doc_blame
+apply_nolint tactic.select doc_blame
+
+-- tactic/monotonicity/basic.lean
+apply_nolint tactic.interactive.compare doc_blame
+apply_nolint tactic.interactive.filter_instances doc_blame
+apply_nolint tactic.interactive.find_one_difference doc_blame
+apply_nolint tactic.interactive.get_monotonicity_lemmas doc_blame
+apply_nolint tactic.interactive.get_operator doc_blame
+apply_nolint tactic.interactive.last_two doc_blame
+apply_nolint tactic.interactive.match_imp doc_blame
+apply_nolint tactic.interactive.mono_cfg doc_blame
+apply_nolint tactic.interactive.mono_head_candidates doc_blame
+apply_nolint tactic.interactive.mono_key doc_blame
+apply_nolint tactic.interactive.mono_selection doc_blame
+apply_nolint tactic.interactive.monotoncity.check unused_arguments doc_blame
+apply_nolint tactic.interactive.monotoncity.check_rel unused_arguments doc_blame
+apply_nolint tactic.interactive.monotonicity.attr doc_blame
+apply_nolint tactic.interactive.same_operator doc_blame
+apply_nolint tactic.interactive.side doc_blame
+
+-- tactic/monotonicity/interactive.lean
+apply_nolint tactic.interactive.ac_mono_ctx doc_blame
+apply_nolint tactic.interactive.ac_mono_ctx' doc_blame
+apply_nolint tactic.interactive.ac_mono_ctx'.map doc_blame
+apply_nolint tactic.interactive.ac_mono_ctx'.traverse doc_blame
+apply_nolint tactic.interactive.ac_mono_ctx.to_tactic_format doc_blame
+apply_nolint tactic.interactive.ac_mono_ctx_ne doc_blame
+apply_nolint tactic.interactive.ac_monotonicity_goal doc_blame
+apply_nolint tactic.interactive.ac_refine doc_blame
+apply_nolint tactic.interactive.apply_rel doc_blame
+apply_nolint tactic.interactive.arity doc_blame
+apply_nolint tactic.interactive.as_goal doc_blame
+apply_nolint tactic.interactive.assert_or_rule doc_blame
+apply_nolint tactic.interactive.best_match doc_blame
+apply_nolint tactic.interactive.bin_op doc_blame
+apply_nolint tactic.interactive.bin_op_left doc_blame
+apply_nolint tactic.interactive.bin_op_right doc_blame
+apply_nolint tactic.interactive.check_ac doc_blame
+apply_nolint tactic.interactive.delete_expr doc_blame
+apply_nolint tactic.interactive.find_lemma doc_blame
+apply_nolint tactic.interactive.find_rule doc_blame
+apply_nolint tactic.interactive.fold_assoc doc_blame
+apply_nolint tactic.interactive.fold_assoc1 doc_blame
+apply_nolint tactic.interactive.hide_meta_vars' doc_blame
+apply_nolint tactic.interactive.list.minimum_on doc_blame
+apply_nolint tactic.interactive.match_ac unused_arguments doc_blame
+apply_nolint tactic.interactive.match_ac' doc_blame
+apply_nolint tactic.interactive.match_chaining_rules doc_blame
+apply_nolint tactic.interactive.match_prefix doc_blame
+apply_nolint tactic.interactive.match_rule doc_blame
+apply_nolint tactic.interactive.mk_congr_args doc_blame
+apply_nolint tactic.interactive.mk_congr_law doc_blame
+apply_nolint tactic.interactive.mk_fun_app doc_blame
+apply_nolint tactic.interactive.mk_pattern doc_blame
+apply_nolint tactic.interactive.mk_rel doc_blame
+apply_nolint tactic.interactive.mono_aux unused_arguments doc_blame
+apply_nolint tactic.interactive.mono_function doc_blame
+apply_nolint tactic.interactive.mono_function.to_tactic_format doc_blame
+apply_nolint tactic.interactive.mono_law doc_blame
+apply_nolint tactic.interactive.mono_law.to_tactic_format doc_blame
+apply_nolint tactic.interactive.one_line doc_blame
+apply_nolint tactic.interactive.parse_ac_mono_function doc_blame
+apply_nolint tactic.interactive.parse_ac_mono_function' doc_blame
+apply_nolint tactic.interactive.parse_assoc_chain doc_blame
+apply_nolint tactic.interactive.parse_assoc_chain' doc_blame
+apply_nolint tactic.interactive.pi_head doc_blame
+apply_nolint tactic.interactive.rep_arity doc_blame
+apply_nolint tactic.interactive.repeat_or_not doc_blame
+apply_nolint tactic.interactive.repeat_until doc_blame
+apply_nolint tactic.interactive.same_function doc_blame
+apply_nolint tactic.interactive.same_function_aux doc_blame
+apply_nolint tactic.interactive.side_conditions doc_blame
+apply_nolint tactic.interactive.solve_mvar doc_blame
+apply_nolint tactic.interactive.unify_with_instance doc_blame
+
+-- tactic/monotonicity/lemmas.lean
+apply_nolint gt_of_mul_lt_mul_neg_right ge_or_gt
+
+-- tactic/norm_cast.lean
+apply_nolint conv.interactive.norm_cast doc_blame
+apply_nolint expr.flip_eq doc_blame
+apply_nolint expr.flip_iff doc_blame
+apply_nolint ge_from_le ge_or_gt
+apply_nolint gt_from_lt ge_or_gt
+apply_nolint norm_cast.derive doc_blame
+apply_nolint tactic.apply_mod_cast doc_blame
+apply_nolint tactic.assumption_mod_cast doc_blame
+apply_nolint tactic.exact_mod_cast doc_blame
+
+-- tactic/norm_num.lean
+apply_nolint conv.interactive.norm_num doc_blame
+apply_nolint conv.interactive.norm_num1 doc_blame
+apply_nolint norm_num.derive doc_blame
+apply_nolint norm_num.derive1 doc_blame
+apply_nolint norm_num.eval_div_ext doc_blame
+apply_nolint norm_num.eval_ineq doc_blame
+apply_nolint norm_num.eval_pow doc_blame
+apply_nolint norm_num.eval_prime doc_blame
+apply_nolint norm_num.min_fac_helper doc_blame
+apply_nolint norm_num.prove_lt unused_arguments doc_blame
+apply_nolint norm_num.prove_min_fac doc_blame
+apply_nolint norm_num.prove_non_prime doc_blame
+apply_nolint norm_num.prove_pos doc_blame
+apply_nolint tactic.interactive.apply_normed doc_blame
+apply_nolint tactic.refl_conv doc_blame
+apply_nolint tactic.trans_conv doc_blame
+
+-- tactic/omega/clause.lean
+apply_nolint omega.clause doc_blame
+apply_nolint omega.clause.append doc_blame
+apply_nolint omega.clause.holds doc_blame
+apply_nolint omega.clause.sat doc_blame
+apply_nolint omega.clause.unsat doc_blame
+apply_nolint omega.clauses.sat doc_blame
+apply_nolint omega.clauses.unsat doc_blame
+
+-- tactic/omega/coeffs.lean
+apply_nolint omega.coeffs.val doc_blame
+apply_nolint omega.coeffs.val_between doc_blame
+apply_nolint omega.coeffs.val_except doc_blame
+
+-- tactic/omega/eq_elim.lean
+apply_nolint omega.cancel doc_blame
+apply_nolint omega.coeffs_reduce doc_blame
+apply_nolint omega.ee doc_blame
+apply_nolint omega.ee.repr doc_blame
+apply_nolint omega.eq_elim doc_blame
+apply_nolint omega.rhs doc_blame
+apply_nolint omega.sgm doc_blame
+apply_nolint omega.subst doc_blame
+apply_nolint omega.sym_sym doc_blame
+apply_nolint omega.symdiv doc_blame
+apply_nolint omega.symmod doc_blame
+
+-- tactic/omega/find_ees.lean
+apply_nolint omega.abort doc_blame
+apply_nolint omega.add_ee doc_blame
+apply_nolint omega.ee_commit doc_blame
+apply_nolint omega.ee_state doc_blame
+apply_nolint omega.elim_eq doc_blame
+apply_nolint omega.elim_eqs doc_blame
+apply_nolint omega.eqelim doc_blame
+apply_nolint omega.factor doc_blame
+apply_nolint omega.find_ees doc_blame
+apply_nolint omega.find_min_coeff doc_blame
+apply_nolint omega.find_min_coeff_core doc_blame
+apply_nolint omega.gcd doc_blame
+apply_nolint omega.get_ees doc_blame
+apply_nolint omega.get_eqs doc_blame
+apply_nolint omega.get_gcd doc_blame
+apply_nolint omega.get_les doc_blame
+apply_nolint omega.head_eq doc_blame
+apply_nolint omega.run doc_blame
+apply_nolint omega.set_ees doc_blame
+apply_nolint omega.set_eqs doc_blame
+apply_nolint omega.set_les doc_blame
+
+-- tactic/omega/find_scalars.lean
+apply_nolint omega.elim_var doc_blame
+apply_nolint omega.elim_var_aux doc_blame
+apply_nolint omega.find_neg_const doc_blame
+apply_nolint omega.find_scalars doc_blame
+apply_nolint omega.find_scalars_core doc_blame
+apply_nolint omega.trisect doc_blame
+
+-- tactic/omega/int/dnf.lean
+apply_nolint omega.int.dnf doc_blame
+apply_nolint omega.int.dnf_core doc_blame
+apply_nolint omega.int.is_nnf doc_blame
+apply_nolint omega.int.neg_elim doc_blame
+apply_nolint omega.int.neg_free doc_blame
+apply_nolint omega.int.nnf doc_blame
+apply_nolint omega.int.push_neg doc_blame
+
+-- tactic/omega/int/form.lean
+apply_nolint omega.int.form doc_blame
+apply_nolint omega.int.form.equiv doc_blame
+apply_nolint omega.int.form.fresh_index doc_blame
+apply_nolint omega.int.form.holds doc_blame
+apply_nolint omega.int.form.implies doc_blame
+apply_nolint omega.int.form.induce doc_blame
+apply_nolint omega.int.form.repr doc_blame
+apply_nolint omega.int.form.sat doc_blame
+apply_nolint omega.int.form.unsat doc_blame
+apply_nolint omega.int.form.valid doc_blame
+apply_nolint omega.int.univ_close doc_blame
+
+-- tactic/omega/int/main.lean
+apply_nolint omega.int.desugar doc_blame
+apply_nolint omega.int.prove_lia doc_blame
+apply_nolint omega.int.prove_univ_close doc_blame
+apply_nolint omega.int.to_form doc_blame
+apply_nolint omega.int.to_form_core doc_blame
+apply_nolint omega.int.to_preterm doc_blame
+apply_nolint omega_int doc_blame
+
+-- tactic/omega/int/preterm.lean
+apply_nolint omega.int.canonize doc_blame
+apply_nolint omega.int.preterm doc_blame
+apply_nolint omega.int.preterm.add_one doc_blame
+apply_nolint omega.int.preterm.fresh_index doc_blame
+apply_nolint omega.int.preterm.repr doc_blame
+apply_nolint omega.int.preterm.val doc_blame
+
+-- tactic/omega/lin_comb.lean
+apply_nolint omega.lin_comb doc_blame
+apply_nolint omega.unsat_lin_comb doc_blame
+
+-- tactic/omega/main.lean
+apply_nolint omega.clear_unused_hyp doc_blame
+apply_nolint omega.clear_unused_hyps doc_blame
+apply_nolint omega.form_domain doc_blame
+apply_nolint omega.form_wf doc_blame
+apply_nolint omega.goal_domain doc_blame
+apply_nolint omega.goal_domain_aux doc_blame
+apply_nolint omega.is_lia_form doc_blame
+apply_nolint omega.is_lia_term doc_blame
+apply_nolint omega.is_lna_form doc_blame
+apply_nolint omega.is_lna_term doc_blame
+apply_nolint omega.preprocess doc_blame
+apply_nolint omega.rev_lia doc_blame
+apply_nolint omega.rev_lna doc_blame
+apply_nolint omega.revert_cond doc_blame
+apply_nolint omega.revert_cond_all doc_blame
+apply_nolint omega.select_domain doc_blame
+apply_nolint omega.term_domain doc_blame
+apply_nolint omega.type_domain doc_blame
+
+-- tactic/omega/misc.lean
+apply_nolint omega.update doc_blame
+apply_nolint omega.update_zero doc_blame
+
+-- tactic/omega/nat/dnf.lean
+apply_nolint omega.nat.bools.or doc_blame
+apply_nolint omega.nat.dnf doc_blame
+apply_nolint omega.nat.dnf_core doc_blame
+apply_nolint omega.nat.nonneg_consts doc_blame
+apply_nolint omega.nat.nonneg_consts_core doc_blame
+apply_nolint omega.nat.nonnegate doc_blame
+apply_nolint omega.nat.term.vars doc_blame
+apply_nolint omega.nat.term.vars_core doc_blame
+apply_nolint omega.nat.terms.vars doc_blame
+
+-- tactic/omega/nat/form.lean
+apply_nolint omega.nat.form doc_blame
+apply_nolint omega.nat.form.equiv doc_blame
+apply_nolint omega.nat.form.fresh_index doc_blame
+apply_nolint omega.nat.form.holds doc_blame
+apply_nolint omega.nat.form.implies doc_blame
+apply_nolint omega.nat.form.induce doc_blame
+apply_nolint omega.nat.form.neg_free doc_blame
+apply_nolint omega.nat.form.repr doc_blame
+apply_nolint omega.nat.form.sat doc_blame
+apply_nolint omega.nat.form.sub_free doc_blame
+apply_nolint omega.nat.form.unsat doc_blame
+apply_nolint omega.nat.form.valid doc_blame
+apply_nolint omega.nat.univ_close doc_blame
+
+-- tactic/omega/nat/main.lean
+apply_nolint omega.nat.desugar doc_blame
+apply_nolint omega.nat.preterm.prove_sub_free doc_blame
+apply_nolint omega.nat.prove_lna doc_blame
+apply_nolint omega.nat.prove_neg_free doc_blame
+apply_nolint omega.nat.prove_sub_free doc_blame
+apply_nolint omega.nat.prove_univ_close doc_blame
+apply_nolint omega.nat.prove_unsat_neg_free doc_blame
+apply_nolint omega.nat.prove_unsat_sub_free doc_blame
+apply_nolint omega.nat.to_form doc_blame
+apply_nolint omega.nat.to_form_core doc_blame
+apply_nolint omega.nat.to_preterm doc_blame
+apply_nolint omega_nat doc_blame
+
+-- tactic/omega/nat/neg_elim.lean
+apply_nolint omega.nat.is_nnf doc_blame
+apply_nolint omega.nat.neg_elim doc_blame
+apply_nolint omega.nat.neg_elim_core doc_blame
+apply_nolint omega.nat.nnf doc_blame
+apply_nolint omega.nat.push_neg doc_blame
+
+-- tactic/omega/nat/preterm.lean
+apply_nolint omega.nat.canonize doc_blame
+apply_nolint omega.nat.preterm doc_blame
+apply_nolint omega.nat.preterm.add_one doc_blame
+apply_nolint omega.nat.preterm.fresh_index doc_blame
+apply_nolint omega.nat.preterm.induce doc_blame
+apply_nolint omega.nat.preterm.repr doc_blame
+apply_nolint omega.nat.preterm.sub_free doc_blame
+apply_nolint omega.nat.preterm.val doc_blame
+
+-- tactic/omega/nat/sub_elim.lean
+apply_nolint omega.nat.form.sub_subst doc_blame
+apply_nolint omega.nat.form.sub_terms doc_blame
+apply_nolint omega.nat.is_diff doc_blame
+apply_nolint omega.nat.preterm.sub_subst doc_blame
+apply_nolint omega.nat.preterm.sub_terms doc_blame
+apply_nolint omega.nat.sub_elim doc_blame
+apply_nolint omega.nat.sub_elim_core doc_blame
+apply_nolint omega.nat.sub_fresh_index doc_blame
+
+-- tactic/omega/prove_unsats.lean
+apply_nolint omega.prove_forall_mem_eq_zero doc_blame
+apply_nolint omega.prove_neg doc_blame
+apply_nolint omega.prove_unsat doc_blame
+apply_nolint omega.prove_unsat_ef doc_blame
+apply_nolint omega.prove_unsat_lin_comb doc_blame
+apply_nolint omega.prove_unsats doc_blame
+
+-- tactic/omega/term.lean
+apply_nolint omega.term doc_blame
+apply_nolint omega.term.add doc_blame
+apply_nolint omega.term.div doc_blame
+apply_nolint omega.term.fresh_index doc_blame
+apply_nolint omega.term.mul doc_blame
+apply_nolint omega.term.neg doc_blame
+apply_nolint omega.term.sub doc_blame
+apply_nolint omega.term.to_string doc_blame
+apply_nolint omega.term.val doc_blame
+apply_nolint omega.terms.fresh_index doc_blame
+
+-- tactic/pi_instances.lean
+apply_nolint tactic.derive_field doc_blame
+
+-- tactic/push_neg.lean
+apply_nolint push_neg.normalize_negations doc_blame
+apply_nolint push_neg.push_neg_at_goal doc_blame
+apply_nolint push_neg.push_neg_at_hyp doc_blame
+apply_nolint push_neg.whnf_reducible doc_blame
+
+-- tactic/rcases.lean
+apply_nolint tactic.ext_parse doc_blame
+apply_nolint tactic.ext_patt doc_blame
+apply_nolint tactic.goals doc_blame
+apply_nolint tactic.interactive.obtain_parse doc_blame
+apply_nolint tactic.list_Pi doc_blame
+apply_nolint tactic.list_Sigma doc_blame
+apply_nolint tactic.merge_list doc_blame
+apply_nolint tactic.rcases.continue doc_blame
+apply_nolint tactic.rcases.process_constructors doc_blame
+apply_nolint tactic.rcases_core doc_blame
+apply_nolint tactic.rcases_hint doc_blame
+apply_nolint tactic.rcases_hint.continue doc_blame
+apply_nolint tactic.rcases_hint.process_constructors doc_blame
+apply_nolint tactic.rcases_hint_core doc_blame
+apply_nolint tactic.rcases_parse_depth doc_blame
+apply_nolint tactic.rcases_patt doc_blame
+apply_nolint tactic.rcases_patt.format doc_blame
+apply_nolint tactic.rcases_patt.invert doc_blame
+apply_nolint tactic.rcases_patt.invert' doc_blame
+apply_nolint tactic.rcases_patt.invert_list doc_blame
+apply_nolint tactic.rcases_patt.invert_many doc_blame
+apply_nolint tactic.rcases_patt.merge doc_blame
+apply_nolint tactic.rcases_patt.name doc_blame
+apply_nolint tactic.rcases_patt_inverted.format doc_blame
+apply_nolint tactic.rcases_patt_inverted.format_list doc_blame
+apply_nolint tactic.rcases_patt_inverted.invert doc_blame
+apply_nolint tactic.rcases_patt_inverted.invert_list doc_blame
+apply_nolint tactic.rcases_patt_parse doc_blame
+apply_nolint tactic.rcases_patt_parse_core doc_blame
+apply_nolint tactic.rcases_patt_parse_list doc_blame
+apply_nolint tactic.rintro doc_blame
+apply_nolint tactic.rintro_hint doc_blame
+apply_nolint tactic.rintro_parse doc_blame
+
+-- tactic/reassoc_axiom.lean
+apply_nolint tactic.calculated_Prop unused_arguments doc_blame
+apply_nolint tactic.derive_reassoc_proof doc_blame
+
+-- tactic/replacer.lean
+apply_nolint tactic.def_replacer_cmd unused_arguments
+apply_nolint tactic.mk_replacer doc_blame
+apply_nolint tactic.mk_replacer₁ doc_blame
+apply_nolint tactic.mk_replacer₂ doc_blame
+apply_nolint tactic.replaceable_attr doc_blame
+apply_nolint tactic.replacer doc_blame
+apply_nolint tactic.replacer_attr doc_blame
+apply_nolint tactic.replacer_core doc_blame
+apply_nolint tactic.unprime doc_blame
+apply_nolint tactic.valid_types doc_blame
+
+-- tactic/restate_axiom.lean
+apply_nolint restate_axiom_cmd unused_arguments doc_blame
+
+-- tactic/rewrite.lean
+apply_nolint tactic.assoc_refl doc_blame
+apply_nolint tactic.assoc_refl' doc_blame
+apply_nolint tactic.assoc_rewrite doc_blame
+apply_nolint tactic.assoc_rewrite_hyp doc_blame
+apply_nolint tactic.assoc_rewrite_intl doc_blame
+apply_nolint tactic.assoc_rewrite_target doc_blame
+apply_nolint tactic.assoc_root doc_blame
+apply_nolint tactic.chain_eq_trans doc_blame
+apply_nolint tactic.enum_assoc_subexpr doc_blame
+apply_nolint tactic.enum_assoc_subexpr' doc_blame
+apply_nolint tactic.fill_args doc_blame
+apply_nolint tactic.flatten doc_blame
+apply_nolint tactic.match_assoc_pattern doc_blame
+apply_nolint tactic.match_assoc_pattern' doc_blame
+apply_nolint tactic.match_fn doc_blame
+apply_nolint tactic.mk_assoc doc_blame
+apply_nolint tactic.mk_assoc_instance doc_blame
+apply_nolint tactic.mk_assoc_pattern doc_blame
+apply_nolint tactic.mk_assoc_pattern' doc_blame
+apply_nolint tactic.mk_eq_proof doc_blame
+apply_nolint tactic.unify_prefix doc_blame
+
+-- tactic/rewrite_all/basic.lean
+apply_nolint side doc_blame
+apply_nolint side.other doc_blame
+apply_nolint side.to_string doc_blame
+apply_nolint tactic.rewrite_all.cfg doc_blame
+apply_nolint tactic.rewrite_all.tracked_rewrite doc_blame
+apply_nolint tactic.rewrite_all.tracked_rewrite.eval doc_blame
+apply_nolint tactic.rewrite_all.tracked_rewrite.replace_target doc_blame
+apply_nolint tactic.rewrite_all.tracked_rewrite.replace_target_lhs doc_blame
+apply_nolint tactic.rewrite_all.tracked_rewrite.replace_target_rhs doc_blame
+
+-- tactic/rewrite_all/congr.lean
+apply_nolint tactic.mk_congr_arg_using_dsimp' doc_blame
+apply_nolint tactic.rewrite_all.congr.app_map doc_blame
+apply_nolint tactic.rewrite_all.congr.expr_lens doc_blame
+apply_nolint tactic.rewrite_all.congr.expr_lens.congr doc_blame
+apply_nolint tactic.rewrite_all.congr.expr_lens.replace doc_blame
+apply_nolint tactic.rewrite_all.congr.expr_lens.to_sides doc_blame
+apply_nolint tactic.rewrite_all.congr.expr_lens.to_tactic_string doc_blame
+apply_nolint tactic.rewrite_all.congr.rewrite_all doc_blame
+apply_nolint tactic.rewrite_all.congr.rewrite_all_lazy doc_blame
+apply_nolint tactic.rewrite_all.congr.rewrite_at_lens doc_blame
+apply_nolint tactic.rewrite_all.congr.rewrite_is_of_entire doc_blame
+apply_nolint tactic.rewrite_all.congr.rewrite_without_new_mvars doc_blame
+
+-- tactic/rewrite_all/default.lean
+apply_nolint tactic.all_rewrites_using doc_blame
+apply_nolint tactic.get_nth_rewrite doc_blame
+apply_nolint tactic.perform_nth_rewrite doc_blame
+
+-- tactic/ring.lean
+apply_nolint conv.interactive.ring doc_blame
+apply_nolint tactic.interactive.ring.mode doc_blame
+apply_nolint tactic.ring.add_atom doc_blame
+apply_nolint tactic.ring.cache doc_blame
+apply_nolint tactic.ring.cache.cs_app doc_blame
+apply_nolint tactic.ring.eval doc_blame
+apply_nolint tactic.ring.eval' doc_blame
+apply_nolint tactic.ring.eval_add doc_blame
+apply_nolint tactic.ring.eval_atom doc_blame
+apply_nolint tactic.ring.eval_const_mul doc_blame
+apply_nolint tactic.ring.eval_horner doc_blame
+apply_nolint tactic.ring.eval_mul doc_blame
+apply_nolint tactic.ring.eval_neg doc_blame
+apply_nolint tactic.ring.eval_pow doc_blame
+apply_nolint tactic.ring.get_atom doc_blame
+apply_nolint tactic.ring.get_cache doc_blame
+apply_nolint tactic.ring.get_transparency doc_blame
+apply_nolint tactic.ring.horner doc_blame
+apply_nolint tactic.ring.horner_expr doc_blame
+apply_nolint tactic.ring.horner_expr.e doc_blame
+apply_nolint tactic.ring.horner_expr.pp doc_blame
+apply_nolint tactic.ring.horner_expr.refl_conv doc_blame
+apply_nolint tactic.ring.horner_expr.to_string doc_blame
+apply_nolint tactic.ring.horner_expr.xadd' doc_blame
+apply_nolint tactic.ring.lift doc_blame
+apply_nolint tactic.ring.normalize doc_blame
+apply_nolint tactic.ring.normalize_mode doc_blame
+apply_nolint tactic.ring.ring_m doc_blame
+apply_nolint tactic.ring.ring_m.mk_app doc_blame
+apply_nolint tactic.ring.ring_m.run doc_blame
+
+-- tactic/ring2.lean
+apply_nolint conv.interactive.ring2 doc_blame
+apply_nolint tactic.ring2.horner_expr.add doc_blame
+apply_nolint tactic.ring2.horner_expr.add_aux doc_blame
+apply_nolint tactic.ring2.horner_expr.add_const doc_blame
+apply_nolint tactic.ring2.horner_expr.inv unused_arguments doc_blame
+apply_nolint tactic.ring2.horner_expr.mul doc_blame
+apply_nolint tactic.ring2.horner_expr.mul_aux doc_blame
+apply_nolint tactic.ring2.horner_expr.mul_const doc_blame
+apply_nolint tactic.ring2.horner_expr.neg doc_blame
+apply_nolint tactic.ring2.horner_expr.pow doc_blame
+apply_nolint tactic.ring2.horner_expr.to_string doc_blame
+
+-- tactic/scc.lean
+apply_nolint tactic.prove_eqv_target doc_blame
+
+-- tactic/slice.lean
+apply_nolint conv.repeat_count doc_blame
+apply_nolint conv.repeat_with_results doc_blame
+apply_nolint conv.slice doc_blame
+apply_nolint conv.slice_lhs doc_blame
+apply_nolint conv.slice_rhs doc_blame
+apply_nolint tactic.repeat_count doc_blame
+apply_nolint tactic.repeat_with_results doc_blame
+
+-- tactic/split_ifs.lean
+apply_nolint tactic.find_if_cond doc_blame
+apply_nolint tactic.find_if_cond_at doc_blame
+apply_nolint tactic.reduce_ifs_at doc_blame
+apply_nolint tactic.split_if1 doc_blame
+apply_nolint tactic.split_ifs doc_blame
+
+-- tactic/squeeze.lean
+apply_nolint loc.to_string doc_blame
+apply_nolint loc.to_string_aux doc_blame
+apply_nolint tactic.interactive.auto_simp_lemma doc_blame
+apply_nolint tactic.interactive.parse_config doc_blame
+apply_nolint tactic.interactive.rec.to_tactic_format doc_blame
+apply_nolint tactic.interactive.record_lit doc_blame
+apply_nolint tactic.interactive.squeeze_simp doc_blame
+apply_nolint tactic.interactive.squeeze_simpa doc_blame
+
+-- tactic/subtype_instance.lean
+apply_nolint tactic.derive_field_subtype doc_blame
+
+-- tactic/suggest.lean
+apply_nolint tactic.library_search_hole_cmd doc_blame
+apply_nolint tactic.suggest.decl_data doc_blame
+
+-- tactic/tauto.lean
+apply_nolint tactic.add_edge doc_blame
+apply_nolint tactic.add_refl doc_blame
+apply_nolint tactic.add_symm_proof doc_blame
+apply_nolint tactic.assumption_symm doc_blame
+apply_nolint tactic.assumption_with doc_blame
+apply_nolint tactic.contradiction_symm doc_blame
+apply_nolint tactic.contradiction_with doc_blame
+apply_nolint tactic.find_eq_type doc_blame
+apply_nolint tactic.modify_ref doc_blame
+apply_nolint tactic.root doc_blame
+apply_nolint tactic.symm_eq doc_blame
+apply_nolint tactic.tauto_state doc_blame
+apply_nolint tactic.tautology doc_blame
+
+-- tactic/tfae.lean
+apply_nolint tactic.interactive.parse_list doc_blame
+apply_nolint tactic.interactive.tfae_have unused_arguments
+apply_nolint tactic.tfae.arrow doc_blame
+apply_nolint tactic.tfae.mk_implication doc_blame
+apply_nolint tactic.tfae.mk_name doc_blame
+
+-- tactic/tidy.lean
+apply_nolint tactic.tidy doc_blame
+apply_nolint tactic.tidy.cfg doc_blame
+apply_nolint tactic.tidy.core doc_blame
+apply_nolint tactic.tidy.default_tactics doc_blame
+apply_nolint tactic.tidy.ext1_wrapper doc_blame
+apply_nolint tactic.tidy.name_to_tactic doc_blame
+apply_nolint tactic.tidy.run_tactics doc_blame
+apply_nolint tactic.tidy.tidy_attribute doc_blame
+apply_nolint tactic.tidy_hole_cmd doc_blame
+
+-- tactic/transfer.lean
+apply_nolint tactic.transfer doc_blame
+apply_nolint transfer.analyse_decls doc_blame
+apply_nolint transfer.compute_transfer doc_blame
+
+-- tactic/transport.lean
+apply_nolint tactic.transport_with_prefix_dict doc_blame
+apply_nolint tactic.transport_with_prefix_fun doc_blame
+
+-- tactic/where.lean
+apply_nolint lean.parser.get_includes doc_blame
+apply_nolint lean.parser.get_namespace doc_blame
+apply_nolint lean.parser.get_variables doc_blame
+apply_nolint where.binder_less_important doc_blame
+apply_nolint where.binder_priority doc_blame
+apply_nolint where.collect_by doc_blame
+apply_nolint where.collect_by_aux doc_blame
+apply_nolint where.collect_implicit_names doc_blame
+apply_nolint where.compile_variable_list doc_blame
+apply_nolint where.fetch_potential_variable_names doc_blame
+apply_nolint where.find_var doc_blame
+apply_nolint where.format_variable doc_blame
+apply_nolint where.get_all_in_namespace doc_blame
+apply_nolint where.get_def_variables doc_blame
+apply_nolint where.get_includes_core doc_blame
+apply_nolint where.get_namespace_core doc_blame
+apply_nolint where.get_opens doc_blame
+apply_nolint where.get_variables_core doc_blame
+apply_nolint where.inflate doc_blame
+apply_nolint where.is_in_namespace_nonsynthetic doc_blame
+apply_nolint where.is_variable_name doc_blame
+apply_nolint where.mk_flag doc_blame
+apply_nolint where.resolve_var doc_blame
+apply_nolint where.resolve_vars doc_blame
+apply_nolint where.resolve_vars_aux doc_blame
+apply_nolint where.select_for_which doc_blame
+apply_nolint where.sort_variable_list doc_blame
+apply_nolint where.strip_namespace doc_blame
+apply_nolint where.strip_pi_binders doc_blame
+apply_nolint where.strip_pi_binders_aux doc_blame
+apply_nolint where.trace_end doc_blame
+apply_nolint where.trace_includes doc_blame
+apply_nolint where.trace_namespace doc_blame
+apply_nolint where.trace_nl doc_blame
+apply_nolint where.trace_opens doc_blame
+apply_nolint where.trace_variables doc_blame
+apply_nolint where.trace_where doc_blame
+apply_nolint where.where_cmd unused_arguments doc_blame
+
+-- tactic/wlog.lean
+apply_nolint tactic.wlog doc_blame
+
+-- topology/algebra/group.lean
+apply_nolint homeomorph.add_left doc_blame
+apply_nolint homeomorph.add_right doc_blame
+apply_nolint homeomorph.inv doc_blame
+apply_nolint homeomorph.mul_left doc_blame
+apply_nolint homeomorph.mul_right doc_blame
+apply_nolint homeomorph.neg doc_blame
+
+-- topology/algebra/infinite_sum.lean
+apply_nolint option.cases_on' doc_blame
+
+-- topology/algebra/module.lean
+apply_nolint continuous_linear_equiv has_inhabited_instance
+
+-- topology/algebra/open_subgroup.lean
+apply_nolint open_add_subgroup doc_blame
+apply_nolint open_add_subgroup.sum doc_blame
+apply_nolint open_subgroup.prod doc_blame
+
+-- topology/algebra/polynomial.lean
+apply_nolint polynomial.tendsto_infinity ge_or_gt
+
+-- topology/algebra/ring.lean
+apply_nolint ideal.closure doc_blame
+
+-- topology/algebra/uniform_group.lean
+apply_nolint add_comm_group.is_Z_bilin doc_blame
+apply_nolint topological_add_group.to_uniform_space doc_blame
+
+-- topology/algebra/uniform_ring.lean
+apply_nolint uniform_space.sep_quot_equiv_ring_quot doc_blame
+
+-- topology/bounded_continuous_function.lean
+apply_nolint bounded_continuous_function.dist_eq ge_or_gt
+apply_nolint bounded_continuous_function.dist_set_exists ge_or_gt
+
+-- topology/category/Top/limits.lean
+apply_nolint Top.colimit doc_blame
+apply_nolint Top.colimit_is_colimit doc_blame
+apply_nolint Top.limit doc_blame
+apply_nolint Top.limit_is_limit doc_blame
+
+-- topology/category/Top/open_nhds.lean
+apply_nolint topological_space.open_nhds doc_blame has_inhabited_instance
+apply_nolint topological_space.open_nhds.inclusion doc_blame
+apply_nolint topological_space.open_nhds.inclusion_map_iso doc_blame
+apply_nolint topological_space.open_nhds.map doc_blame
+
+-- topology/category/Top/opens.lean
+apply_nolint topological_space.opens.map_comp doc_blame
+apply_nolint topological_space.opens.map_id doc_blame
+apply_nolint topological_space.opens.map_iso doc_blame
+apply_nolint topological_space.opens.to_Top doc_blame
+
+-- topology/category/TopCommRing.lean
+apply_nolint TopCommRing has_inhabited_instance
+
+-- topology/category/UniformSpace.lean
+apply_nolint CpltSepUniformSpace has_inhabited_instance
+apply_nolint CpltSepUniformSpace.to_UniformSpace doc_blame
+
+-- topology/compact_open.lean
+apply_nolint continuous_map doc_blame
+apply_nolint continuous_map.coev doc_blame
+apply_nolint continuous_map.compact_open.gen doc_blame
+apply_nolint continuous_map.ev doc_blame
+apply_nolint continuous_map.induced doc_blame
+
+-- topology/homeomorph.lean
+apply_nolint homeomorph has_inhabited_instance
+apply_nolint homeomorph.homeomorph_of_continuous_open doc_blame
+apply_nolint homeomorph.prod_assoc doc_blame
+apply_nolint homeomorph.prod_comm doc_blame
+apply_nolint homeomorph.prod_congr doc_blame
+apply_nolint homeomorph.refl doc_blame
+apply_nolint homeomorph.sigma_prod_distrib doc_blame
+apply_nolint homeomorph.symm doc_blame
+apply_nolint homeomorph.trans doc_blame
+
+-- topology/instances/ennreal.lean
+apply_nolint ennreal.nhds_of_ne_top ge_or_gt
+apply_nolint ennreal.tendsto_at_top ge_or_gt
+apply_nolint ennreal.tendsto_nhds ge_or_gt
+apply_nolint infi_real_pos_eq_infi_nnreal_pos ge_or_gt
+
+-- topology/local_homeomorph.lean
+apply_nolint local_homeomorph has_inhabited_instance
+
+-- topology/maps.lean
+apply_nolint inducing doc_blame
+apply_nolint is_closed_map doc_blame
+
+-- topology/metric_space/baire.lean
+apply_nolint nonempty_interior_of_Union_of_closed ge_or_gt
+
+-- topology/metric_space/basic.lean
+apply_nolint cauchy_seq_bdd ge_or_gt
+apply_nolint lebesgue_number_lemma_of_metric ge_or_gt
+apply_nolint lebesgue_number_lemma_of_metric_sUnion ge_or_gt
+apply_nolint metric.cauchy_iff ge_or_gt
+apply_nolint metric.cauchy_seq_iff ge_or_gt
+apply_nolint metric.cauchy_seq_iff' ge_or_gt
+apply_nolint metric.continuous_iff ge_or_gt
+apply_nolint metric.continuous_iff' ge_or_gt
+apply_nolint metric.exists_ball_subset_ball ge_or_gt
+apply_nolint metric.is_open_iff ge_or_gt
+apply_nolint metric.mem_closure_range_iff ge_or_gt
+apply_nolint metric.mem_nhds_iff ge_or_gt
+apply_nolint metric.mem_of_closed' ge_or_gt
+apply_nolint metric.mem_uniformity_dist ge_or_gt
+apply_nolint metric.pos_of_mem_ball ge_or_gt
+apply_nolint metric.tendsto_at_top ge_or_gt
+apply_nolint metric.tendsto_nhds ge_or_gt
+apply_nolint metric.totally_bounded_iff ge_or_gt
+apply_nolint metric.uniform_continuous_iff ge_or_gt
+apply_nolint metric.uniform_embedding_iff ge_or_gt
+apply_nolint metric.uniform_embedding_iff' ge_or_gt
+apply_nolint metric_space.induced doc_blame
+apply_nolint metric_space.replace_uniformity doc_blame
+
+-- topology/metric_space/completion.lean
+apply_nolint metric.completion.mem_uniformity_dist ge_or_gt
+apply_nolint metric.completion.uniformity_dist ge_or_gt
+apply_nolint metric.completion.uniformity_dist' ge_or_gt
+
+-- topology/metric_space/emetric_space.lean
+apply_nolint emetric.cauchy_iff ge_or_gt
+apply_nolint emetric.cauchy_seq_iff ge_or_gt
+apply_nolint emetric.cauchy_seq_iff' ge_or_gt
+apply_nolint emetric.exists_ball_subset_ball ge_or_gt
+apply_nolint emetric.is_open_iff ge_or_gt
+apply_nolint emetric.mem_nhds_iff ge_or_gt
+apply_nolint emetric.nhds_eq ge_or_gt
+apply_nolint emetric.tendsto_at_top ge_or_gt
+apply_nolint emetric.tendsto_nhds ge_or_gt
+apply_nolint emetric.totally_bounded_iff ge_or_gt
+apply_nolint emetric.totally_bounded_iff' ge_or_gt
+apply_nolint emetric.uniform_continuous_iff ge_or_gt
+apply_nolint emetric.uniform_embedding_iff ge_or_gt
+apply_nolint emetric.uniform_embedding_iff' ge_or_gt
+apply_nolint has_edist doc_blame
+apply_nolint mem_uniformity_edist ge_or_gt
+apply_nolint uniformity_dist_of_mem_uniformity ge_or_gt
+apply_nolint uniformity_edist ge_or_gt
+
+-- topology/metric_space/gluing.lean
+apply_nolint metric.glue_premetric doc_blame
+apply_nolint metric.glue_space doc_blame
+apply_nolint metric.sum.dist doc_blame
+apply_nolint metric.to_glue_l doc_blame
+apply_nolint metric.to_glue_r doc_blame
+
+-- topology/metric_space/gromov_hausdorff.lean
+apply_nolint Gromov_Hausdorff.GH_space.rep has_inhabited_instance
+apply_nolint Gromov_Hausdorff.aux_gluing_struct has_inhabited_instance
+
+-- topology/metric_space/gromov_hausdorff_realized.lean
+apply_nolint Gromov_Hausdorff.candidates_b_dist doc_blame
+apply_nolint Gromov_Hausdorff.optimal_GH_coupling has_inhabited_instance
+
+-- topology/metric_space/isometry.lean
+apply_nolint isometric has_inhabited_instance
+
+-- topology/metric_space/premetric_space.lean
+apply_nolint premetric_space doc_blame
+
+-- topology/opens.lean
+apply_nolint continuous.comap doc_blame
+apply_nolint topological_space.closeds has_inhabited_instance
+apply_nolint topological_space.nonempty_compacts has_inhabited_instance
+apply_nolint topological_space.opens.gi doc_blame
+apply_nolint topological_space.opens.interior doc_blame
+apply_nolint topological_space.opens.is_basis doc_blame
+
+-- topology/sequences.lean
+apply_nolint topological_space.seq_tendsto_iff ge_or_gt
+
+-- topology/sheaves/presheaf.lean
+apply_nolint Top.presheaf doc_blame has_inhabited_instance
+apply_nolint Top.presheaf.pushforward doc_blame
+apply_nolint Top.presheaf.pushforward.comp doc_blame
+apply_nolint Top.presheaf.pushforward.id doc_blame
+apply_nolint Top.presheaf.pushforward_eq doc_blame
+
+-- topology/sheaves/stalks.lean
+apply_nolint Top.presheaf.stalk_pushforward doc_blame
+
+-- topology/topological_fiber_bundle.lean
+apply_nolint bundle_trivialization has_inhabited_instance
+apply_nolint topological_fiber_bundle_core has_inhabited_instance
+apply_nolint topological_fiber_bundle_core.base has_inhabited_instance
+apply_nolint topological_fiber_bundle_core.fiber has_inhabited_instance
+apply_nolint topological_fiber_bundle_core.index has_inhabited_instance
+apply_nolint topological_fiber_bundle_core.total_space has_inhabited_instance
+
+-- topology/uniform_space/absolute_value.lean
+apply_nolint is_absolute_value.mem_uniformity ge_or_gt
+
+-- topology/uniform_space/basic.lean
+apply_nolint uniform_continuous₂ doc_blame
+apply_nolint uniform_space.mk' doc_blame
+
+-- topology/uniform_space/completion.lean
+apply_nolint Cauchy.extend doc_blame
+apply_nolint Cauchy.gen doc_blame
+apply_nolint uniform_space.completion.completion_separation_quotient_equiv doc_blame
+apply_nolint uniform_space.completion.cpkg doc_blame
+apply_nolint uniform_space.completion.extension₂ doc_blame
+apply_nolint uniform_space.completion.map₂ doc_blame
+
+-- topology/uniform_space/separation.lean
+apply_nolint separated doc_blame
+apply_nolint uniform_space.separation_quotient doc_blame
+apply_nolint uniform_space.separation_quotient.lift doc_blame
+apply_nolint uniform_space.separation_quotient.map doc_blame
+apply_nolint uniform_space.separation_setoid doc_blame
+
+-- topology/uniform_space/uniform_embedding.lean
+apply_nolint uniform_embedding doc_blame
+apply_nolint uniform_inducing doc_blame

--- a/src/category/functor.lean
+++ b/src/category/functor.lean
@@ -42,7 +42,8 @@ def id.mk {α : Sort u} : α → id α := id
 
 namespace functor
 
-@[nolint] def const (α : Type*) (β : Type*) := α
+@[nolint unused_arguments doc_blame]
+def const (α : Type*) (β : Type*) := α
 
 @[pattern] def const.mk {α β} (x : α) : const α β := x
 
@@ -54,7 +55,8 @@ namespace const
 
 protected lemma ext {α β} {x y : const α β} (h : x.run = y.run) : x = y := h
 
-@[nolint] protected def map {γ α β} (f : α → β) (x : const γ β) : const γ α := x
+@[nolint unused_arguments doc_blame]
+protected def map {γ α β} (f : α → β) (x : const γ β) : const γ α := x
 
 instance {γ} : functor (const γ) :=
 { map := @const.map γ }

--- a/src/category/functor.lean
+++ b/src/category/functor.lean
@@ -42,7 +42,8 @@ def id.mk {α : Sort u} : α → id α := id
 
 namespace functor
 
-@[nolint unused_arguments doc_blame]
+/-- `const α` is the constant functor, mapping every type to `α` -/
+@[nolint unused_arguments]
 def const (α : Type*) (β : Type*) := α
 
 @[pattern] def const.mk {α β} (x : α) : const α β := x
@@ -55,7 +56,8 @@ namespace const
 
 protected lemma ext {α β} {x y : const α β} (h : x.run = y.run) : x = y := h
 
-@[nolint unused_arguments doc_blame]
+/-- The map operation of the `const γ` functor. -/
+@[nolint unused_arguments]
 protected def map {γ α β} (f : α → β) (x : const γ β) : const γ α := x
 
 instance {γ} : functor (const γ) :=

--- a/src/category/monad/writer.lean
+++ b/src/category/monad/writer.lean
@@ -151,10 +151,11 @@ variables {ω ω' : Type u} {m m' : Type u → Type v}
 /-- Transitivity.
 
 This instance generates the type-class problem bundled_hom ?m (which is why this is marked as
-`[nolint]`). Currently that is not a problem, as there are almost no instances of `bundled_hom`.
+`[nolint dangerous_instance]`). Currently that is not a problem, as there are almost no instances
+of `bundled_hom`.
 
 see Note [lower instance priority] -/
-@[nolint, priority 100]
+@[nolint dangerous_instance, priority 100]
 instance monad_writer_adapter_trans {n n' : Type u → Type v} [monad_functor m m' n n']
   [monad_writer_adapter ω ω' m m'] : monad_writer_adapter ω ω' n n' :=
 ⟨λ α f, monad_map (λ α, (adapt_writer f : m α → m' α))⟩

--- a/src/category_theory/concrete_category/bundled_hom.lean
+++ b/src/category_theory/concrete_category/bundled_hom.lean
@@ -48,7 +48,7 @@ include 𝒞
 
 This instance generates the type-class problem bundled_hom ?m (which is why this is marked as
 `[nolint]`). Currently that is not a problem, as there are almost no instances of `bundled_hom`. -/
-@[nolint] instance category : category (bundled c) :=
+@[nolint dangerous_instance] instance category : category (bundled c) :=
 by refine
 { hom := λ X Y, @hom X.1 Y.1 X.str Y.str,
   id := λ X, @bundled_hom.id c hom 𝒞 X X.str,
@@ -63,7 +63,7 @@ intros; apply 𝒞.hom_ext;
 
 This instance generates the type-class problem bundled_hom ?m (which is why this is marked as
 `[nolint]`). Currently that is not a problem, as there are almost no instances of `bundled_hom`. -/
-@[nolint] instance : concrete_category (bundled c) :=
+@[nolint dangerous_instance] instance : concrete_category (bundled c) :=
 { forget := { obj := λ X, X,
               map := λ X Y f, 𝒞.to_fun X.str Y.str f,
               map_id' := λ X, 𝒞.id_to_fun X.str,

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -513,6 +513,10 @@ meta def mfold {α : Type} {m : Type → Type} [monad m] (e : environment) (x : 
 e.fold (return x) (λ d t, t >>= fn d)
 
 /-- Filters all declarations in the environment. -/
+meta def filter (e : environment) (test : declaration → bool) : list declaration :=
+e.fold [] $ λ d ds, if test d then d::ds else ds
+
+/-- Filters all declarations in the environment. -/
 meta def mfilter (e : environment) (test : declaration → tactic bool) : tactic (list declaration) :=
 e.mfold [] $ λ d ds, do b ← test d, return $ if b then d::ds else ds
 

--- a/src/meta/rb_map.lean
+++ b/src/meta/rb_map.lean
@@ -112,6 +112,10 @@ protected meta def of_list {key : Type} {data : Type} [has_lt key]
 | []           := rb_lmap.mk key data
 | ((k, v)::ls) := (of_list ls).insert k v
 
+/-- Returns the list of values of an `rb_lmap`. -/
+protected meta def values {key data} (m : rb_lmap key data) : list data :=
+m.fold [] (λ _, (++))
+
 end rb_lmap
 end native
 

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -18,7 +18,7 @@ section
 
   /-- The Pell sequences, defined together in mutual recursion. -/
   -- TODO(lint): Fix double namespace issue
-  @[nolint] def pell : ℕ → ℕ × ℕ :=
+  @[nolint dup_namespace] def pell : ℕ → ℕ × ℕ :=
   λn, nat.rec_on n (1, 0) (λn xy, (xy.1*a + d*xy.2, xy.1 + xy.2*a))
 
   /-- The Pell `x` sequence. -/

--- a/src/order/filter/bases.lean
+++ b/src/order/filter/bases.lean
@@ -124,7 +124,7 @@ lemma has_basis.eq_infi (h : l.has_basis (λ _, true) s) :
   l = ⨅ i, principal (s i) :=
 by simpa only [infi_true] using h.eq_binfi
 
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 lemma has_basis_infi_principal {s : ι → set α} (h : directed (≥) s) (ne : nonempty ι) :
   (⨅ i, principal (s i)).has_basis (λ _, true) s :=
 begin
@@ -133,7 +133,7 @@ begin
   exact λ _ _, principal_mono.2
 end
 
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 lemma has_basis_binfi_principal {s : β → set α} {S : set β} (h : directed_on (s ⁻¹'o (≥)) S)
   (ne : S.nonempty) :
   (⨅ i ∈ S, principal (s i)).has_basis (λ i, i ∈ S) s :=

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -452,7 +452,7 @@ lemma mem_infi {f : ι → filter α} (h : directed (≥) f) (ne : nonempty ι) 
   s ∈ infi f ↔ ∃ i, s ∈ f i :=
 by simp only [infi_sets_eq h ne, mem_Union]
 
-@[nolint] -- Intentional use of `≥`
+@[nolint ge_or_gt] -- Intentional use of `≥`
 lemma binfi_sets_eq {f : β → filter α} {s : set β}
   (h : directed_on (f ⁻¹'o (≥)) s) (ne : s.nonempty) :
   (⨅ i∈s, f i).sets = (⋃ i ∈ s, (f i).sets) :=
@@ -463,7 +463,7 @@ calc (⨅ i ∈ s, f i).sets  = (⨅ t : {t // t ∈ s}, (f t.val)).sets : by rw
     ⟨⟨i, hi⟩⟩
   ... = (⨆ t ∈ {t | t ∈ s}, (f t).sets) : by rw [supr_subtype]; refl
 
-@[nolint] -- Intentional use of `≥`
+@[nolint ge_or_gt] -- Intentional use of `≥`
 lemma mem_binfi {f : β → filter α} {s : set β}
   (h : directed_on (f ⁻¹'o (≥)) s) (ne : s.nonempty) {t : set α} :
   t ∈ (⨅ i∈s, f i) ↔ ∃ i ∈ s, t ∈ f i :=
@@ -1666,7 +1666,8 @@ infi_ne_bot_of_directed (by apply_instance)
     mem_principal_sets, and_self, sup_le_iff, forall_true_iff] {contextual := tt}⟩)
   (assume a, principal_ne_bot_iff.2 nonempty_Ici)
 
-@[simp] lemma mem_at_top_sets [nonempty α] [semilattice_sup α] {s : set α} :
+@[simp, nolint ge_or_gt]
+lemma mem_at_top_sets [nonempty α] [semilattice_sup α] {s : set α} :
   s ∈ (at_top : filter α) ↔ ∃a:α, ∀b≥a, b ∈ s :=
 let ⟨a⟩ := ‹nonempty α› in
 iff.intro
@@ -1676,22 +1677,22 @@ iff.intro
     (assume s₁ s₂ h ⟨a, ha⟩, ⟨a, assume b hb, h $ ha _ hb⟩))
   (assume ⟨a, h⟩, mem_infi_sets a $ assume x, h x)
 
-@[nolint] -- ≥
+@[nolint ge_or_gt]
 lemma eventually_at_top {α} [semilattice_sup α] [nonempty α] {p : α → Prop} :
   (∀ᶠ x in at_top, p x) ↔ (∃ a, ∀ b ≥ a, p b) :=
 by simp only [filter.eventually, filter.mem_at_top_sets, mem_set_of_eq]
 
-@[nolint] -- ≥
+@[nolint ge_or_gt]
 lemma eventually.exists_forall_of_at_top {α} [semilattice_sup α] [nonempty α] {p : α → Prop}
   (h : ∀ᶠ x in at_top, p x) : ∃ a, ∀ b ≥ a, p b :=
 eventually_at_top.mp h
 
-@[nolint] -- ≥
+@[nolint ge_or_gt]
 lemma frequently_at_top {α} [semilattice_sup α] [nonempty α] {p : α → Prop} :
   (∃ᶠ x in at_top, p x) ↔ (∀ a, ∃ b ≥ a, p b) :=
 by simp only [filter.frequently, eventually_at_top, not_exists, not_forall, not_not]
 
-@[nolint] -- ≥
+@[nolint ge_or_gt]
 lemma frequently.forall_exists_of_at_top {α} [semilattice_sup α] [nonempty α] {p : α → Prop}
   (h : ∃ᶠ x in at_top, p x) : ∀ a, ∃ b ≥ a, p b :=
 frequently_at_top.mp h
@@ -1801,10 +1802,12 @@ tendsto_at_top_add_right_of_le' l C hf (univ_mem_sets' $ λ _, le_refl C)
 
 end ordered_group
 
+@[nolint ge_or_gt]
 lemma tendsto_at_top' [nonempty α] [semilattice_sup α] (f : α → β) (l : filter β) :
   tendsto f at_top l ↔ (∀s ∈ l, ∃a, ∀b≥a, f b ∈ s) :=
 by simp only [tendsto_def, mem_at_top_sets]; refl
 
+@[nolint ge_or_gt]
 theorem tendsto_at_top_principal [nonempty β] [semilattice_sup β] {f : β → α} {s : set α} :
   tendsto f at_top (principal s) ↔ ∃N, ∀n≥N, f n ∈ s :=
 by rw [tendsto_iff_comap, comap_principal, le_principal_iff, mem_at_top_sets]; refl
@@ -1828,6 +1831,7 @@ lemma tendsto_at_top_at_top [nonempty α] [semilattice_sup α] [preorder β] (f 
   tendsto f at_top at_top ↔ ∀ b : β, ∃ i : α, ∀ a : α, i ≤ a → b ≤ f a :=
 iff.trans tendsto_infi $ forall_congr $ assume b, tendsto_at_top_principal
 
+@[nolint ge_or_gt]
 lemma tendsto_at_top_at_bot [nonempty α] [decidable_linear_order α] [preorder β] (f : α → β) :
   tendsto f at_top at_bot ↔ ∀ (b : β), ∃ (i : α), ∀ (a : α), i ≤ a → b ≥ f a :=
 @tendsto_at_top_at_top α (order_dual β) _ _ _ f

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -267,7 +267,7 @@ section prio
 set_option default_priority 100 -- see Note [default priority]
 /-- A lattice is a join-semilattice which is also a meet-semilattice. -/
 -- TODO(lint): Fix double namespace issue
-@[nolint] class lattice (α : Type u) extends semilattice_sup α, semilattice_inf α
+@[nolint dup_namespace] class lattice (α : Type u) extends semilattice_sup α, semilattice_inf α
 end prio
 
 section lattice

--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -273,7 +273,7 @@ include R S A
     `algebra ?m_1 A -/
 /- The `nolint` attribute is added because it has unused arguments `R` and `S`, but these are necessary for synthesizing the
      appropriate type classes -/
-@[nolint] def comap : Type w := A
+@[nolint unused_arguments] def comap : Type w := A
 def comap.to_comap : A → comap R S A := id
 def comap.of_comap : comap R S A → A := id
 
@@ -431,7 +431,7 @@ iff.rfl
 by cases S; cases T; congr; ext x; exact h x
 
 theorem ext_iff {S T : subalgebra R A} : S = T ↔ ∀ x : A, x ∈ S ↔ x ∈ T :=
-⟨λ h x, by rw h, ext⟩ 
+⟨λ h x, by rw h, ext⟩
 
 variables (S : subalgebra R A)
 

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -180,7 +180,7 @@ mk_self'
 
 -- This lemma does not apply with simp, since (mk r s) simplifies to (r * s⁻¹).
 -- However, it could apply with dsimp.
-@[simp, nolint /- simp_nf -/]
+@[simp, nolint simp_nf]
 lemma coe_mul_mk (x y : α) (s : S) :
   ↑x * mk y s = mk (x * y) s :=
 quotient.sound $ r_of_eq $ by rw one_mul
@@ -191,7 +191,7 @@ by rw [coe_mul_mk, mul_one]
 
 -- This lemma does not apply with simp, since (mk r s) simplifies to (r * s⁻¹).
 -- However, it could apply with dsimp.
-@[simp, nolint /- simp_nf -/]
+@[simp, nolint simp_nf]
 lemma mk_mul_mk (x y : α) (s t : S) :
   mk x s * mk y t = mk (x * y) (s * t) := rfl
 
@@ -267,7 +267,7 @@ lift'.is_ring_hom _ _ _
 
 -- This lemma does not apply with simp, since (mk r s) simplifies to (r * s⁻¹).
 -- However, it could apply with dsimp.
-@[simp, nolint /- simp_nf -/]
+@[simp, nolint simp_nf]
 lemma lift'_mk (g : S → units β) (hg : ∀ s, (g s : β) = f s) (r : α) (s : S) :
   lift' f g hg (mk r s) = f r * ↑(g s)⁻¹ := rfl
 

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -1570,8 +1570,8 @@ instance : has_div ordinal := ⟨ordinal.div⟩
 
 @[simp] theorem div_zero (a : ordinal) : a / 0 = 0 := dif_pos rfl
 
--- TODO(lint): This should be a theorem but Lean fails to synthesize the placeholder
-@[nolint] def div_def (a) {b : ordinal} (h : b ≠ 0) :
+@[nolint def_lemma doc_blame] -- TODO: This should be a theorem but Lean fails to synthesize the placeholder
+def div_def (a) {b : ordinal} (h : b ≠ 0) :
   a / b = omin {o | a < b * succ o} _ := dif_neg h
 
 theorem lt_mul_succ_div (a) {b : ordinal} (h : b ≠ 0) : a < b * succ (a / b) :=
@@ -1746,8 +1746,8 @@ begin
   exact ordinal.min_le (λ i:ι α, ⟦⟨α, i.1, i.2⟩⟧) ⟨_, _⟩
 end
 
--- TODO(lint): This should be a theorem but Lean fails to synthesize the placeholders
-@[nolint] def ord_eq_min (α : Type u) : ord (mk α) =
+@[nolint def_lemma doc_blame] -- TODO: This should be a theorem but Lean fails to synthesize the placeholder
+def ord_eq_min (α : Type u) : ord (mk α) =
   @ordinal.min _ _ (λ i:{r // is_well_order α r}, ⟦⟨α, i.1, i.2⟩⟧) := rfl
 
 theorem ord_eq (α) : ∃ (r : α → α → Prop) [wo : is_well_order α r],

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -112,10 +112,15 @@ end lean.parser
 
 namespace format
 
+/-- `join' [a,b,c]` produces the format object `abc`.
+It differs from `format.join` by using `format.nil` instead of `""` for the empty list. -/
+meta def join' (xs : list format) : format :=
+xs.foldl compose nil
+
 /-- `intercalate x [a, b, c]` produces the format object `a.x.b.x.c`,
 where `.` represents `format.join`. -/
 meta def intercalate (x : format) : list format → format :=
-format.join ∘ list.intersperse x
+join' ∘ list.intersperse x
 
 end format
 

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -132,7 +132,8 @@ private meta def generalize_arg_p_aux : pexpr → parser (pexpr × name)
 private meta def generalize_arg_p : parser (pexpr × name) :=
 with_desc "expr = id" $ parser.pexpr 0 >>= generalize_arg_p_aux
 
-@[nolint] lemma {u} generalize_a_aux {α : Sort u}
+@[nolint def_lemma]
+lemma {u} generalize_a_aux {α : Sort u}
   (h : ∀ x : Sort u, (α → x) → x) : α := h α id
 
 /--

--- a/src/tactic/linarith.lean
+++ b/src/tactic/linarith.lean
@@ -755,13 +755,14 @@ do l' ← replace_nat_pfs l,
    ls ← list.reduce_option <$> l''.mmap (λ h, (do s ← norm_hyp h, return (some s)) <|> return none)
           >>= partition_by_type,
    pref_type ← (unify pref_type.iget `(ℕ) >> return (some `(ℤ) : option expr)) <|> return pref_type,
-   match cfg.restrict_type, ls.values, pref_type with
+   match cfg.restrict_type, rb_map.values ls, pref_type with
    | some rtp, _, _ :=
       do m ← mk_mvar, unify `(some %%m : option Type) cfg.restrict_type_reflect, m ← instantiate_mvars m,
          prove_false_by_linarith1 cfg (ls.ifind m)
    | none, [ls'], _ := prove_false_by_linarith1 cfg ls'
    | none, ls', none := try_linarith_on_lists cfg ls'
-   | none, _, (some t) := prove_false_by_linarith1 cfg (ls.ifind t) <|> try_linarith_on_lists cfg (ls.erase t).values
+   | none, _, (some t) := prove_false_by_linarith1 cfg (ls.ifind t) <|>
+      try_linarith_on_lists cfg (rb_map.values (ls.erase t))
    end
 
 end normalize

--- a/src/tactic/lint.lean
+++ b/src/tactic/lint.lean
@@ -49,7 +49,8 @@ A linter defined with the name `linter.my_new_check` can be run with `#lint my_n
 or `lint only my_new_check`.
 If you add the attribute `@[linter]` to `linter.my_new_check` it will run by default.
 
-Adding the attribute `@[nolint]` to a declaration omits it from all linter checks.
+Adding the attribute `@[nolint doc_blame unused_arguments]` to a declaration
+omits it from only the specified linter checks.
 
 ## Tags
 sanity check, lint, cleanup, command, tactic
@@ -63,17 +64,40 @@ reserve notation `#lint_mathlib`
 reserve notation `#lint_all`
 reserve notation `#list_linters`
 
-run_cmd tactic.skip -- apparently doc strings can't come directly after `reserve notation`
+setup_tactic_parser
+
+-- Manual constant subexpression elimination for performance.
+private meta def linter_ns := `linter
+private meta def nolint_infix := `_nolint
+
+/--
+Computes the declaration name used to store the nolint attribute data.
+
+Retrieving the parameters for user attributes is *extremely* slow.
+Hence we store the parameters of the nolint attribute as declarations
+in the environment.  E.g. for `@[nolint foo] def bar := _` we add the
+following declaration:
+
+```lean
+meta def bar._nolint.foo : unit := ()
+```
+-/
+private meta def mk_nolint_decl_name (decl : name) (linter : name) : name :=
+(decl ++ nolint_infix) ++ linter
 
 /-- Defines the user attribute `nolint` for skipping `#lint` -/
 @[user_attribute]
-meta def nolint_attr : user_attribute :=
+meta def nolint_attr : user_attribute _ (list name) :=
 { name := "nolint",
-  descr := "Do not report this declaration in any of the tests of `#lint`" }
-
-attribute [nolint] imp_intro
-  classical.dec classical.dec_pred classical.dec_rel classical.dec_eq
-  pempty -- has no inhabited instance
+  descr := "Do not report this declaration in any of the tests of `#lint`",
+  after_set := some $ λ n _ _, (do
+    ls@(_::_) ← nolint_attr.get_param n
+      | fail "you need to specify at least one linter to disable",
+    ls.mmap' $ λ l, do
+      get_decl (linter_ns ++ l) <|> fail ("unknown linter: " ++ to_string l),
+      try $ add_decl $ declaration.defn (mk_nolint_decl_name n l) []
+        `(unit) `(unit.star) (default _) ff),
+  parser := ident* }
 
 /--
 A linting test for the `#lint` command.
@@ -94,8 +118,9 @@ meta structure linter :=
 
 /-- Takes a list of names that resolve to declarations of type `linter`,
 and produces a list of linters. -/
-meta def get_linters (l : list name) : tactic (list linter) :=
-l.mmap (λ n, mk_const n >>= eval_expr linter <|> fail format!"invalid linter: {n}")
+meta def get_linters (l : list name) : tactic (list (name × linter)) :=
+l.mmap (λ n, prod.mk n.last <$> (mk_const n >>= eval_expr linter)
+  <|> fail format!"invalid linter: {n}")
 
 /-- Defines the user attribute `linter` for adding a linter to the default set.
 Linters should be defined in the `linter` namespace.
@@ -108,44 +133,6 @@ meta def linter_attr : user_attribute unit unit :=
   descr := "Use this declaration as a linting test in #lint",
   after_set := some $ λ nm _ _,
                 mk_const nm >>= infer_type >>= unify `(linter) }
-
-setup_tactic_parser
-universe variable v
-
-/-- Find all declarations in `l` where tac returns `some x` and list them. -/
-meta def fold_over_with_cond {α} (l : list declaration) (tac : declaration → tactic (option α)) :
-  tactic (list (declaration × α)) :=
-l.mmap_filter $ λ d, option.map (λ x, (d, x)) <$> tac d
-
-/-- Find all declarations in `l` where tac returns `some x` and sort the resulting list by file name. -/
-meta def fold_over_with_cond_sorted {α} (l : list declaration)
-  (tac : declaration → tactic (option α)) : tactic (list (string × list (declaration × α))) := do
-  e ← get_env,
-  ds ← fold_over_with_cond l tac,
-  let ds₂ := rb_lmap.of_list (ds.map (λ x, ((e.decl_olean x.1.to_name).iget, x))),
-  return $ ds₂.to_list
-
-/-- Make the output of `fold_over_with_cond` printable, in the following form:
-      `#print <name> <open multiline comment> <elt of α> <close multiline comment>` -/
-meta def print_decls {α} [has_to_format α] (ds : list (declaration × α)) : format :=
-ds.foldl
-  (λ f x, f ++ "\n" ++ to_fmt "#print " ++ to_fmt x.1.to_name ++ " /- " ++ to_fmt x.2 ++ " -/")
-  format.nil
-
-/-- Make the output of `fold_over_with_cond_sorted` printable, with the file path + name inserted.-/
-meta def print_decls_sorted {α} [has_to_format α] (ds : list (string × list (declaration × α))) :
-  format :=
-ds.foldl
-  (λ f x, f ++ "\n\n" ++ to_fmt "-- " ++ to_fmt x.1 ++ print_decls x.2)
-  format.nil
-
-/-- Same as `print_decls_sorted`, but removing the first `n` characters from the string.
-  Useful for omitting the mathlib directory from the output. -/
-meta def print_decls_sorted_mathlib {α} [has_to_format α] (n : ℕ)
-  (ds : list (string × list (declaration × α))) : format :=
-ds.foldl
-  (λ f x, f ++ "\n\n" ++ to_fmt "-- " ++ to_fmt (x.1.popn n) ++ print_decls x.2)
-  format.nil
 
 /-- Pretty prints a list of arguments of a declaration. Assumes `l` is a list of argument positions
   and binders (or any other element that can be pretty printed).
@@ -532,53 +519,101 @@ If `use_only` is true, it only uses the linters in `extra`.
 Otherwise, it uses all linters in the environment tagged with `@[linter]`.
 If `slow` is false, it only uses the fast default tests. -/
 meta def get_checks (slow : bool) (extra : list name) (use_only : bool) :
-  tactic (list linter) := do
+  tactic (list (name × linter)) := do
   default ← if use_only then return [] else attribute.get_instances `linter >>= get_linters,
-  let default := if slow then default else default.filter (λ l, l.is_fast),
+  let default := if slow then default else default.filter (λ l, l.2.is_fast),
   list.append default <$> get_linters extra
 
-/-- If `verbose` is true, return `old ++ new`, else return `old`. -/
-private meta def append_when (verbose : bool) (old new : format) : format :=
-cond verbose (old ++ new) old
+/-- `should_be_linted linter decl` returns true if `decl` should be checked
+using `linter`, i.e., if there is no `nolint` attribute. -/
+meta def should_be_linted (linter : name) (decl : name) : tactic bool := do
+e ← get_env,
+pure $ ¬ e.contains (mk_nolint_decl_name decl linter)
 
-private meta def check_fold (printer : (declaration → tactic (option string)) → tactic (name_set × format))
-(verbose : bool) : name_set × format → linter → tactic (name_set × format)
-| (ns, s) ⟨tac, ok_string, warning_string, _⟩ :=
-do (new_ns, f) ← printer tac,
-   if f.is_nil then return $ (ns, append_when verbose s format!"/- OK: {ok_string}. -/\n")
-  else return $ (ns.union new_ns, s ++ format!"/- {warning_string}: -/" ++ f ++ "\n\n")
+/--
+`lint_core decls checks` applies the linters `checks` to the list of declarations `decls`.
+The resulting list has one element for each linter, containing the linter as
+well as a map from declaration name to warning.
+-/
+meta def lint_core (decls : list declaration) (checks : list (name × linter)) :
+  tactic (list (name × linter × rb_map name string)) :=
+checks.mmap $ λ ⟨linter_name, linter⟩, do
+results ← decls.mfoldl (λ (results : rb_map name string) decl, do
+  tt ← should_be_linted linter_name decl.to_name | pure results,
+  some linter_warning ← linter.test decl | pure results,
+  pure $ results.insert decl.to_name linter_warning) mk_rb_map,
+pure (linter_name, linter, results)
+
+/-- Sorts a map with declaration keys as names by line number. -/
+meta def sort_results {α} (results : rb_map name α) : tactic (list (name × α)) := do
+e ← get_env,
+pure $ list.reverse $ rb_lmap.values $ rb_lmap.of_list $
+  results.fold [] $ λ decl linter_warning results,
+    (((e.decl_pos decl).get_or_else ⟨0,0⟩).line, (decl, linter_warning)) :: results
+
+/-- Formats a linter warning as `#print` command with comment. -/
+meta def print_warning (decl_name : name) (warning : string) : format :=
+"#print " ++ to_fmt decl_name ++ " /- " ++ warning ++ " -/"
+
+/-- Formats a map of linter warnings using `print_warning`, sorted by line number. -/
+meta def print_warnings (results : rb_map name string) : tactic format := do
+results ← sort_results results,
+pure $ format.intercalate format.line $ results.map $
+  λ ⟨decl_name, warning⟩, print_warning decl_name warning
+
+/--
+Formats a map of linter warnings grouped by filename with `-- filename` comments.
+The first `drop_fn_chars` characters are stripped from the filename.
+-/
+meta def grouped_by_filename (results : rb_map name string) (drop_fn_chars := 0)
+  (formatter: rb_map name string → tactic format) : tactic format := do
+e ← get_env,
+let results := results.fold (rb_map.mk string (rb_map name string)) $
+  λ decl_name linter_warning results,
+    let fn := (e.decl_olean decl_name).get_or_else "" in
+    results.insert fn (((results.find fn).get_or_else mk_rb_map).insert
+      decl_name linter_warning),
+format.intercalate "\n\n" <$> results.to_list.reverse.mmap (λ ⟨fn, results⟩, do
+  formatted ← formatter results,
+  pure $ "-- " ++ fn.popn drop_fn_chars ++ "\n" ++ formatted)
 
 /-- The common denominator of `#lint[|mathlib|all]`.
-  The different commands have different configurations for `l`, `printer` and `where_desc`.
+  The different commands have different configurations for `l`,
+  `group_by_filename` and `where_desc`.
   If `slow` is false, doesn't do the checks that take a lot of time.
   If `verbose` is false, it will suppress messages from passing checks.
   By setting `checks` you can customize which checks are performed.
 
   Returns a `name_set` containing the names of all declarations that fail any check in `check`,
   and a `format` object describing the failures. -/
-meta def lint_aux (l : list declaration)
-  (printer : (declaration → tactic (option string)) → tactic (name_set × format))
-  (where_desc : string) (slow verbose : bool) (checks : list linter) : tactic (name_set × format) := do
-  let s : format := append_when verbose format.nil "/- Note: This command is still in development. -/\n",
-  let s := append_when verbose s format!"/- Checking {l.length} declarations {where_desc} -/\n\n",
-  (ns, s) ← checks.mfoldl (check_fold printer verbose) (mk_name_set, s),
-  return $ (ns, if slow then s else append_when verbose s "/- (slow tests skipped) -/\n")
+meta def lint_aux (l : list declaration) (group_by_filename : option nat)
+    (where_desc : string) (slow verbose : bool) (checks : list (name × linter)) :
+  tactic (name_set × format) := do
+results ← lint_core l checks,
+formatted_results ← results.mmap $ λ ⟨linter_name, linter, results⟩,
+  if ¬ results.empty then do
+    warnings ← match group_by_filename with
+      | none := print_warnings results
+      | some dropped := grouped_by_filename results dropped print_warnings
+      end,
+    pure $ to_fmt "/- " ++ linter.errors_found ++ ": -/\n" ++ warnings
+  else
+    pure $ if verbose then "/- OK: " ++ linter.no_errors_found ++ ". -/" else format.nil,
+let s := format.intercalate "\n\n" (formatted_results.filter (λ f, ¬ f.is_nil)),
+let s := if ¬ verbose then s else
+  "/- Checking " ++ l.length ++ " declarations " ++ where_desc ++ " -/\n\n" ++ s,
+let s := if slow then s else s ++ "/- (slow tests skipped) -/\n",
+let ns := name_set.of_list (do (_,_,rs) ← results, rs.keys),
+pure (ns, s)
 
 /-- Return the message printed by `#lint` and a `name_set` containing all declarations that fail. -/
 meta def lint (slow : bool := tt) (verbose : bool := tt) (extra : list name := [])
   (use_only : bool := ff) : tactic (name_set × format) := do
   checks ← get_checks slow extra use_only,
   e ← get_env,
-  l ← e.mfilter (λ d,
-    if e.in_current_file' d.to_name ∧ ¬ d.to_name.is_internal ∧ ¬ d.is_auto_generated e
-    then bnot <$> has_attribute' `nolint d.to_name else return ff),
-  lint_aux l (λ t, do lst ← fold_over_with_cond l t, return
-                      (name_set.of_list (lst.map (declaration.to_name ∘ prod.fst)), print_decls lst))
-    "in the current file" slow verbose checks
-
-private meta def name_list_of_decl_lists (l : list (string × list (declaration × string))) :
-  name_set :=
-name_set.of_list $ list.join $ l.map $ λ ⟨_, l'⟩, l'.map $ declaration.to_name ∘ prod.fst
+  let l := e.filter (λ d,
+    e.in_current_file' d.to_name ∧ ¬ d.to_name.is_internal ∧ ¬ d.is_auto_generated e),
+  lint_aux l none "in the current file" slow verbose checks
 
 /-- Return the message printed by `#lint_mathlib` and a `name_set` containing all declarations that fail. -/
 meta def lint_mathlib (slow : bool := tt) (verbose : bool := tt) (extra : list name := [])
@@ -588,24 +623,18 @@ meta def lint_mathlib (slow : bool := tt) (verbose : bool := tt) (extra : list n
   ml ← get_mathlib_dir,
   /- note: we don't separate out some of these tests in `lint_aux` because that causes a
     performance hit. That is also the reason for the current formulation using if then else. -/
-  l ← e.mfilter (λ d,
-    if e.is_prefix_of_file ml d.to_name ∧ ¬ d.to_name.is_internal ∧ ¬ d.is_auto_generated e
-    then bnot <$> has_attribute' `nolint d.to_name else return ff),
+  let l := e.filter (λ d,
+    e.is_prefix_of_file ml d.to_name ∧ ¬ d.to_name.is_internal ∧ ¬ d.is_auto_generated e),
   let ml' := ml.length,
-  lint_aux l (λ t, do lst ← fold_over_with_cond_sorted l t,
-     return (name_list_of_decl_lists lst, print_decls_sorted_mathlib ml' lst))
-    "in mathlib (only in imported files)" slow verbose checks
+  lint_aux l ml' "in mathlib (only in imported files)" slow verbose checks
 
 /-- Return the message printed by `#lint_all` and a `name_set` containing all declarations that fail. -/
 meta def lint_all (slow : bool := tt) (verbose : bool := tt) (extra : list name := [])
   (use_only : bool := ff) : tactic (name_set × format) := do
   checks ← get_checks slow extra use_only,
   e ← get_env,
-  l ← e.mfilter (λ d, if ¬ d.to_name.is_internal ∧ ¬ d.is_auto_generated e
-    then bnot <$> has_attribute' `nolint d.to_name else return ff),
-  lint_aux l (λ t, do lst ← fold_over_with_cond_sorted l t,
-    return (name_list_of_decl_lists lst, print_decls_sorted lst))
-    "in all imported files (including this one)" slow verbose checks
+  let l := e.filter (λ d, ¬ d.to_name.is_internal ∧ ¬ d.is_auto_generated e),
+  lint_aux l (some 0) "in all imported files (including this one)" slow verbose checks
 
 /-- Parses an optional `only`, followed by a sequence of zero or more identifiers.
 Prepends `linter.` to each of these identifiers. -/
@@ -619,10 +648,10 @@ do silent ← optional (tk "-"),
    fast_only ← optional (tk "*"),
    silent ← if silent.is_some then return silent else optional (tk "-"), -- allow either order of *-
    (use_only, extra) ← parse_lint_additions,
-   (_, s) ← scope fast_only.is_none silent.is_none extra use_only,
-   when (¬ s.is_nil) $ do
-     trace s,
-     when silent.is_some $ fail "Linting did not succeed"
+   (failed, s) ← scope fast_only.is_none silent.is_none extra use_only,
+   when (¬ s.is_nil) $ trace s,
+   when (silent.is_some ∧ ¬ failed.empty) $
+    fail "Linting did not succeed"
 
 /-- The command `#lint` at the bottom of a file will warn you about some common mistakes
 in that file. Usage: `#lint`, `#lint linter_1 linter_2`, `#lint only linter_1 linter_2`.
@@ -665,9 +694,13 @@ let ns := env.decl_filter_map $ λ dcl,
 /-- Tries to apply the `nolint` attribute to a list of declarations. Always succeeds, even if some
 of the declarations don't exist. -/
 meta def apply_nolint_tac (decls : list name) : tactic unit :=
-decls.mmap' (λ d, try (nolint_attr.set d () tt))
+decls.mmap' (λ d, try (nolint_attr.set d [] tt))
 
 /-- `apply_nolint id1 id2 ...` tries to apply the `nolint` attribute to `id1`, `id2`, ...
 It will always succeed, even if some of the declarations do not exist. -/
 @[user_command] meta def apply_nolint_cmd (_ : parse $ tk "apply_nolint") : parser unit :=
 ident_* >>= ↑apply_nolint_tac
+
+attribute [nolint unused_arguments] imp_intro
+attribute [nolint def_lemma] classical.dec classical.dec_pred classical.dec_rel classical.dec_eq
+attribute [nolint has_inhabited_instance] pempty

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -357,7 +357,7 @@ from le_antisymm
     | _, h, (or.inr rfl) := inf_le_right_of_le $ infi_le_of_le b $ infi_le _ h
     end)
 
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 lemma tendsto_order {f : β → α} {a : α} {x : filter β} :
   tendsto f x (𝓝 a) ↔ (∀ a' < a, ∀ᶠ b in x, a' < f b) ∧ (∀ a' > a, ∀ᶠ b in x, f b < a') :=
 by simp [nhds_eq_order a, tendsto_inf, tendsto_infi, tendsto_principal]
@@ -399,7 +399,7 @@ from (tendsto_infi.2 $ assume l, tendsto_infi.2 $ assume hl,
 
 end partial_order
 
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 theorem induced_order_topology' {α : Type u} {β : Type v}
   [partial_order α] [ta : topological_space β] [partial_order β] [order_topology β]
   (f : α → β) (hf : ∀ {x y}, f x < f y ↔ x < y)
@@ -1403,11 +1403,11 @@ lemma is_bounded_under_le_of_tendsto {f : filter β} {u : β → α} {a : α}
   (h : tendsto u f (𝓝 a)) : f.is_bounded_under (≤) u :=
 is_bounded_of_le h (is_bounded_le_nhds a)
 
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 lemma is_cobounded_ge_nhds (a : α) : (𝓝 a).is_cobounded (≥) :=
 is_cobounded_of_is_bounded nhds_ne_bot (is_bounded_le_nhds a)
 
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 lemma is_cobounded_under_ge_of_tendsto {f : filter β} {u : β → α} {a : α}
   (hf : f ≠ ⊥) (h : tendsto u f (𝓝 a)) : f.is_cobounded_under (≥) u :=
 is_cobounded_of_is_bounded (map_ne_bot hf) (is_bounded_under_le_of_tendsto h)
@@ -1417,14 +1417,14 @@ end order_closed_topology
 section order_closed_topology
 variables [semilattice_inf α] [topological_space α] [order_topology α]
 
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 lemma is_bounded_ge_nhds (a : α) : (𝓝 a).is_bounded (≥) :=
 match forall_le_or_exists_lt_inf a with
 | or.inl h := ⟨a, eventually_of_forall _ h⟩
 | or.inr ⟨b, hb⟩ := ⟨b, le_mem_nhds hb⟩
 end
 
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 lemma is_bounded_under_ge_of_tendsto {f : filter β} {u : β → α} {a : α}
   (h : tendsto u f (𝓝 a)) : f.is_bounded_under (≥) u :=
 is_bounded_of_le h (is_bounded_ge_nhds a)
@@ -1446,7 +1446,7 @@ theorem lt_mem_sets_of_Limsup_lt {f : filter α} {b} (h : f.is_bounded (≤)) (l
 let ⟨c, (h : ∀ᶠ a in f, a ≤ c), hcb⟩ := exists_lt_of_cInf_lt h l in
 mem_sets_of_superset h $ assume a hac, lt_of_le_of_lt hac hcb
 
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 theorem gt_mem_sets_of_Liminf_gt : ∀ {f : filter α} {b}, f.is_bounded (≥) → f.Liminf > b →
   ∀ᶠ a in f, a > b :=
 @lt_mem_sets_of_Limsup_lt (order_dual α) _
@@ -1455,7 +1455,7 @@ variables [topological_space α] [order_topology α]
 
 /-- If the liminf and the limsup of a filter coincide, then this filter converges to
 their common value, at least if the filter is eventually bounded above and below. -/
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 theorem le_nhds_of_Limsup_eq_Liminf {f : filter α} {a : α}
   (hl : f.is_bounded (≤)) (hg : f.is_bounded (≥)) (hs : f.Limsup = a) (hi : f.Liminf = a) :
   f ≤ 𝓝 a :=
@@ -1520,7 +1520,7 @@ end liminf_limsup
 
 end order_topology
 
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 lemma order_topology_of_nhds_abs
   {α : Type*} [decidable_linear_ordered_comm_group α] [topological_space α]
   (h_nhds : ∀a:α, 𝓝 a = (⨅r>0, principal {b | abs (a - b) < r})) : order_topology α :=
@@ -1577,7 +1577,7 @@ tendsto_at_top_mono _ (λ n, le_abs_self _) tendsto_id
 
 local notation `|` x `|` := abs x
 
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 lemma decidable_linear_ordered_comm_group.tendsto_nhds
   [decidable_linear_ordered_comm_group α] [topological_space α] [order_topology α] {β : Type*}
   (f : β → α) (x : filter β) (a : α) :

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -466,31 +466,31 @@ theorem nhds_within_basis_ball {s : set α} :
   (nhds_within x s).has_basis (λ ε:ℝ, 0 < ε) (λ ε, ball x ε ∩ s) :=
 nhds_within_has_basis nhds_basis_ball s
 
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 theorem mem_nhds_within_iff {t : set α} : s ∈ nhds_within x t ↔ ∃ε>0, ball x ε ∩ t ⊆ s :=
 nhds_within_basis_ball.mem_iff
 
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 theorem tendsto_nhds_within_nhds_within [metric_space β] {t : set β} {f : α → β} {a b} :
   tendsto f (nhds_within a s) (nhds_within b t) ↔
     ∀ ε > 0, ∃ δ > 0, ∀{x:α}, x ∈ s → dist x a < δ → f x ∈ t ∧ dist (f x) b < ε :=
 (nhds_within_basis_ball.tendsto_iff nhds_within_basis_ball).trans $
   by simp only [inter_comm, mem_inter_iff, and_imp, mem_ball]
 
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 theorem tendsto_nhds_within_nhds [metric_space β] {f : α → β} {a b} :
   tendsto f (nhds_within a s) (𝓝 b) ↔
     ∀ ε > 0, ∃ δ > 0, ∀{x:α}, x ∈ s → dist x a < δ → dist (f x) b < ε :=
 by { rw [← nhds_within_univ, tendsto_nhds_within_nhds_within],
   simp only [mem_univ, true_and] }
 
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 theorem tendsto_nhds_nhds [metric_space β] {f : α → β} {a b} :
   tendsto f (𝓝 a) (𝓝 b) ↔
     ∀ ε > 0, ∃ δ > 0, ∀{x:α}, dist x a < δ → dist (f x) b < ε :=
 nhds_basis_ball.tendsto_iff nhds_basis_ball
 
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 theorem continuous_at_iff [metric_space β] {f : α → β} {a : α} :
   continuous_at f a ↔
     ∀ ε > 0, ∃ δ > 0, ∀{x:α}, dist x a < δ → dist (f x) (f a) < ε :=
@@ -543,7 +543,7 @@ begin
     rwa [edist_dist, ennreal.of_real_lt_of_real_iff ε0'] }
 end
 
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 theorem metric.uniformity_edist : 𝓤 α = (⨅ ε>0, principal {p:α×α | edist p.1 p.2 < ε}) :=
 metric.uniformity_basis_edist.eq_binfi
 
@@ -921,7 +921,7 @@ theorem is_closed_ball : is_closed (closed_ball x ε) :=
 is_closed_le (continuous_dist continuous_id continuous_const) continuous_const
 
 /-- ε-characterization of the closure in metric spaces-/
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 theorem mem_closure_iff {α : Type u} [metric_space α] {s : set α} {a : α} :
   a ∈ closure s ↔ ∀ε>0, ∃b ∈ s, dist a b < ε :=
 (mem_closure_iff_nhds_basis nhds_basis_ball).trans $

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -540,7 +540,7 @@ theorem ball_mem_nhds (x : α) {ε : ennreal} (ε0 : 0 < ε) : ball x ε ∈ �
 mem_nhds_sets is_open_ball (mem_ball_self ε0)
 
 /-- ε-characterization of the closure in emetric spaces -/
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 theorem mem_closure_iff :
   x ∈ closure s ↔ ∀ε>0, ∃y ∈ s, edist x y < ε :=
 (mem_closure_iff_nhds_basis nhds_basis_eball).trans $

--- a/src/topology/topological_fiber_bundle.lean
+++ b/src/topology/topological_fiber_bundle.lean
@@ -255,14 +255,17 @@ variables [topological_space B] [topological_space F] (Z : topological_fiber_bun
 include Z
 
 /-- The index set of a topological fiber bundle core, as a convenience function for dot notation -/
-@[nolint] def index := ι
+@[nolint unused_arguments]
+def index := ι
 
 /-- The base space of a topological fiber bundle core, as a convenience function for dot notation -/
-@[nolint] def base := B
+@[nolint unused_arguments]
+def base := B
 
 /-- The fiber of a topological fiber bundle core, as a convenience function for dot notation and
 typeclass inference -/
-@[nolint] def fiber (x : B) := F
+@[nolint unused_arguments]
+def fiber (x : B) := F
 
 instance topological_space_fiber (x : B) : topological_space (Z.fiber x) :=
 by { dsimp [fiber], apply_instance }
@@ -270,7 +273,8 @@ by { dsimp [fiber], apply_instance }
 /-- Total space of a topological bundle created from core. It is equal to `B × F`, but as it is
 not marked as reducible, typeclass inference will not infer the wrong topology, and will use the
 instance `topological_fiber_bundle_core.to_topological_space` with the right topology. -/
-@[nolint] def total_space := B × F
+@[nolint unused_arguments]
+def total_space := B × F
 
 /-- The projection from the total space of a topological fiber bundle core, on its base. -/
 @[simp] def proj : Z.total_space → B := λp, p.1

--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -132,7 +132,7 @@ lemma cauchy_seq_iff_tendsto [nonempty β] [semilattice_sup β] {u : β → α} 
 cauchy_map_iff.trans $ (and_iff_right at_top_ne_bot).trans $
   by simp only [prod_at_top_at_top_eq, prod.map_def]
 
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 lemma filter.has_basis.cauchy_seq_iff {γ} [nonempty β] [semilattice_sup β] {u : β → α}
   {p : γ → Prop} {s : γ → set (α × α)} (h : (𝓤 α).has_basis p s) :
   cauchy_seq u ↔ ∀ i, p i → ∃N, ∀m n≥N, (u m, u n) ∈ s i :=
@@ -143,7 +143,7 @@ begin
     mem_prod_eq, mem_set_of_eq, mem_Ici, and_imp, prod.map]
 end
 
-@[nolint] -- see Note [nolint_ge]
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 lemma filter.has_basis.cauchy_seq_iff' {γ} [nonempty β] [semilattice_sup β] {u : β → α}
   {p : γ → Prop} {s : γ → set (α × α)} (H : (𝓤 α).has_basis p s) :
   cauchy_seq u ↔ ∀ i, p i → ∃N, ∀n≥N, (u n, u N) ∈ s i :=


### PR DESCRIPTION
We have so many linters now and `@[nolint]` disables all of them.  This PR adds parameters to the `nolint` attribute so that you can selectively disable some lints only:
```lean
@[nolint def_lemma] -- TODO: This should be a theorem but Lean fails to synthesize the placeholder
def div_def (a) {b : ordinal} (h : b ≠ 0) :
```

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
