### PR TITLE
feat(data/traversable): improve support for instances for recursive types

### DIFF
--- a/test/examples.lean
+++ b/test/examples.lean
@@ -223,6 +223,9 @@ node
     [3,2])
   [1]
 
+/-- demonstrate the nested use of `traverse`. It traverses each node of the tree and
+in each node, traverses each list. For each `ℕ` visited, apply an action `ℕ -> state (list ℕ) unit`
+which adds its argument to the state. -/
 def ex : state (list ℕ) (my_tree $ list unit) :=
 do xs ← traverse (traverse $ λ a, modify $ list.cons a) x,
    pure xs

--- a/test/examples.lean
+++ b/test/examples.lean
@@ -206,6 +206,33 @@ meta structure meta_struct (α : Type u) : Type u :=
   (k : list (list α))
   (w : expr)
 
+@[derive [traversable,is_lawful_traversable]]
+inductive my_tree (α : Type)
+| leaf {} : my_tree
+| node : my_tree → my_tree → α → my_tree
+
+section
+open my_tree (hiding traverse)
+
+def x : my_tree (list nat) :=
+node
+  leaf
+  (node
+    (node leaf leaf [1,2,3])
+    leaf
+    [3,2])
+  [1]
+
+def ex : state (list ℕ) (my_tree $ list unit) :=
+do xs ← traverse (traverse $ λ a, modify $ list.cons a) x,
+   pure xs
+
+example : (ex.run []).1 = node leaf (node (node leaf leaf [(), (), ()]) leaf [(), ()]) [()] := rfl
+example : (ex.run []).2 = [1, 2, 3, 3, 2, 1] := rfl
+example : is_lawful_traversable my_tree := my_tree.is_lawful_traversable
+
+end
+
 /- tests of has_sep on finset -/
 
 


### PR DESCRIPTION
The new example didn't use to be supported. The recursive occurrences were assumed to occur last in each constructor.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] for tactics:
     * [x] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [x] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
