### PR TITLE
fix(ci): adjust conditions for fixing steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
         run: leanpkg build | python scripts/detect_errors.py
 
       - name: configure git setup
+        if: always()
         run: |
           git remote add origin-bot "https://leanprover-community-bot:${{ secrets.DEPLOY_NIGHTLY_GITHUB_TOKEN }}@github.com/leanprover-community/mathlib.git"
           git config user.email "leanprover.community@gmail.com"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,11 +91,13 @@ jobs:
           python-version: 3.8
 
       - name: generate docs
-        if: github.repository == 'leanprover-community/mathlib' && github.event_name == 'push' && github.ref == 'refs/heads/master'
         run:
           ./scripts/deploy_docs.sh
         env:
           DEPLOY_NIGHTLY_GITHUB_TOKEN: ${{ secrets.DEPLOY_NIGHTLY_GITHUB_TOKEN }}
+          github_repo: ${{ github.repository }}
+          github_event: ${{ github.event_name }}
+          github_ref: ${{ github.ref }}
 
       - name: update nolints.txt
         if: github.repository == 'leanprover-community/mathlib' && github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/scripts/deploy_docs.sh
+++ b/scripts/deploy_docs.sh
@@ -24,7 +24,7 @@ python3 -m pip install --upgrade pip
 pip3 install markdown2 toml
 ./gen_docs -w -r "../" -t "mathlib_docs/docs/"
 
-if ["$github_repo" == "leanprover-community/mathlib" -a "$github_event" == "push" -a "$github_ref" == "refs/heads/master"]; then
+if [ "$github_repo" = "leanprover-community/mathlib" -a "$github_event" = "push" -a "$github_ref" = "refs/heads/master" ]; then
   cd mathlib_docs/docs
   git config user.email "leanprover.community@gmail.com"
   git config user.name "leanprover-community-bot"

--- a/scripts/deploy_docs.sh
+++ b/scripts/deploy_docs.sh
@@ -23,9 +23,12 @@ elan override set "leanprover-community/lean:$short_lean_version"
 python3 -m pip install --upgrade pip
 pip3 install markdown2 toml
 ./gen_docs -w -r "../" -t "mathlib_docs/docs/"
-cd mathlib_docs/docs
-git config user.email "leanprover.community@gmail.com"
-git config user.name "leanprover-community-bot"
-git add -A .
-git commit -m "automatic update to $git_hash"
-git push
+
+if ["$github_repo" == "leanprover-community/mathlib" -a "$github_event" == "push" -a "$github_ref" == "refs/heads/master"]; then
+  cd mathlib_docs/docs
+  git config user.email "leanprover.community@gmail.com"
+  git config user.name "leanprover-community-bot"
+  git add -A .
+  git commit -m "automatic update to $git_hash"
+  git push
+fi


### PR DESCRIPTION
Addressing #2079 and #2081. This (1) always configures git and (2) always runs doc_gen. It still only pushes the generated docs on master builds.

cc @gebner 

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
