### PR TITLE
chore(analysis/normed_space/basic): rename `ne_mem_of_tendsto_norm_at_top`

### DIFF
--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -298,10 +298,9 @@ lemma has_fderiv_at.lim (hf : has_fderiv_at f f' x) (v : E) {α : Type*} {c : α
 begin
   refine (has_fderiv_within_at_univ.2 hf).lim _ (univ_mem_sets' (λ _, trivial)) hc _,
   assume U hU,
-  apply mem_sets_of_superset (ne_mem_of_tendsto_norm_at_top hc (0:𝕜)) _,
-  assume y hy,
-  rw [mem_preimage],
+  refine (eventually_ne_of_tendsto_norm_at_top hc (0:𝕜)).mono (λ y hy, _),
   convert mem_of_nhds hU,
+  dsimp only [],
   rw [← mul_smul, mul_inv_cancel hy, one_smul]
 end
 
@@ -359,7 +358,7 @@ by { ext, rw has_fderiv_at_unique h h.differentiable_at.has_fderiv_at }
 lemma has_fderiv_within_at.fderiv_within
   (h : has_fderiv_within_at f f' s x) (hxs : unique_diff_within_at 𝕜 s x) :
   fderiv_within 𝕜 f s x = f' :=
-by { ext, rw hxs.eq h h.differentiable_within_at.has_fderiv_within_at }
+(hxs.eq h h.differentiable_within_at.has_fderiv_within_at).symm
 
 /-- If `x` is not in the closure of `s`, then `f` has any derivative at `x` within `s`,
 as this statement is empty. -/

--- a/src/analysis/calculus/tangent_cone.lean
+++ b/src/analysis/calculus/tangent_cone.lean
@@ -101,8 +101,8 @@ begin
   have C : tendsto (λn, ∥c n∥⁻¹ * ∥c n • d n∥) l (𝓝 (0 * ∥y∥)) := A.mul B,
   rw zero_mul at C,
   have : ∀ᶠ n in l, ∥c n∥⁻¹ * ∥c n • d n∥ = ∥d n∥,
-  { apply mem_sets_of_superset (ne_mem_of_tendsto_norm_at_top hc 0) (λn hn, _),
-    rw [mem_set_of_eq, norm_smul, ← mul_assoc, inv_mul_cancel, one_mul],
+  { apply (eventually_ne_of_tendsto_norm_at_top hc 0).mono (λn hn, _),
+    rw [norm_smul, ← mul_assoc, inv_mul_cancel, one_mul],
     rwa [ne.def, norm_eq_zero] },
   have D : tendsto (λ n, ∥d n∥) l (𝓝 0) :=
     tendsto.congr' this C,

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -354,16 +354,14 @@ lemma filter.tendsto.nnnorm {β : Type*} {l : filter β} {f : β → α} {a : α
 tendsto.comp continuous_nnnorm.continuous_at h
 
 /-- If `∥y∥→∞`, then we can assume `y≠x` for any fixed `x`. -/
-lemma ne_mem_of_tendsto_norm_at_top {l : filter γ} {f : γ → α}
+lemma eventually_ne_of_tendsto_norm_at_top {l : filter γ} {f : γ → α}
   (h : tendsto (λ y, ∥f y∥) l at_top) (x : α) :
   ∀ᶠ y in l, f y ≠ x :=
 begin
   have : ∀ᶠ y in l, 1 + ∥x∥ ≤ ∥f y∥ := h (mem_at_top (1 + ∥x∥)),
-  apply mem_sets_of_superset this,
-  assume y hy hxy,
+  refine this.mono (λ y hy hxy, _),
   subst x,
-  simp at hy,
-  exact not_le_of_lt zero_lt_one hy
+  exact not_le_of_lt zero_lt_one (add_le_iff_nonpos_left.1 hy)
 end
 
 /-- A normed group is a uniform additive group, i.e., addition and subtraction are uniformly


### PR DESCRIPTION
It uses `∀ᶠ` now, so rename to `eventually_ne_of_tendsto_norm_at_top`.