### PR TITLE
fix(deprecated/group): remove dangerous instances

### DIFF
--- a/src/deprecated/group.lean
+++ b/src/deprecated/group.lean
@@ -286,27 +286,28 @@ h.map (monoid_hom.of f)
 
 end is_unit
 
-instance additive.is_add_hom [has_mul α] [has_mul β] (f : α → β) [is_mul_hom f] :
+lemma additive.is_add_hom [has_mul α] [has_mul β] (f : α → β) [is_mul_hom f] :
   @is_add_hom (additive α) (additive β) _ _ f :=
 { map_add := @is_mul_hom.map_mul α β _ _ f _ }
 
-instance multiplicative.is_mul_hom [has_add α] [has_add β] (f : α → β) [is_add_hom f] :
+lemma multiplicative.is_mul_hom [has_add α] [has_add β] (f : α → β) [is_add_hom f] :
   @is_mul_hom (multiplicative α) (multiplicative β) _ _ f :=
 { map_mul := @is_add_hom.map_add α β _ _ f _ }
 
-instance additive.is_add_monoid_hom [monoid α] [monoid β] (f : α → β) [is_monoid_hom f] :
+lemma additive.is_add_monoid_hom [monoid α] [monoid β] (f : α → β) [is_monoid_hom f] :
   @is_add_monoid_hom (additive α) (additive β) _ _ f :=
-{ map_zero := @is_monoid_hom.map_one α β _ _ f _ }
+{ map_zero := @is_monoid_hom.map_one α β _ _ f _,
+  ..additive.is_add_hom f }
 
-instance multiplicative.is_monoid_hom [add_monoid α] [add_monoid β] (f : α → β) [is_add_monoid_hom f] :
+lemma multiplicative.is_monoid_hom [add_monoid α] [add_monoid β] (f : α → β) [is_add_monoid_hom f] :
   @is_monoid_hom (multiplicative α) (multiplicative β) _ _ f :=
-{ map_one := @is_add_monoid_hom.map_zero α β _ _ f _ }
+{ map_one := @is_add_monoid_hom.map_zero α β _ _ f _,
+  ..multiplicative.is_mul_hom f }
 
-instance additive.is_add_group_hom [group α] [group β] (f : α → β) [is_group_hom f] :
+lemma additive.is_add_group_hom [group α] [group β] (f : α → β) [is_group_hom f] :
   @is_add_group_hom (additive α) (additive β) _ _ f :=
 { map_add := @is_mul_hom.map_mul α β _ _ f _ }
 
-instance multiplicative.is_group_hom [add_group α] [add_group β] (f : α → β) [is_add_group_hom f] :
+lemma multiplicative.is_group_hom [add_group α] [add_group β] (f : α → β) [is_add_group_hom f] :
   @is_group_hom (multiplicative α) (multiplicative β) _ _ f :=
 { map_mul := @is_add_hom.map_add α β _ _ f _ }
-

--- a/src/group_theory/quotient_group.lean
+++ b/src/group_theory/quotient_group.lean
@@ -159,10 +159,13 @@ variables {G : Type u} [_root_.add_group G] (N : set G) [normal_add_subgroup N] 
 variables (φ : G → H) [_root_.is_add_group_hom φ]
 
 noncomputable def quotient_ker_equiv_range : (quotient (ker φ)) ≃ set.range φ :=
-@quotient_group.quotient_ker_equiv_range (multiplicative G) _ (multiplicative H) _ φ _
+@quotient_group.quotient_ker_equiv_range (multiplicative G) _ (multiplicative H) _ φ
+  (multiplicative.is_group_hom _)
 
-noncomputable def quotient_ker_equiv_of_surjective (hφ : function.surjective φ) : (quotient (ker φ)) ≃ H :=
-@quotient_group.quotient_ker_equiv_of_surjective (multiplicative G) _ (multiplicative H) _ φ _ hφ
+noncomputable def quotient_ker_equiv_of_surjective (hφ : function.surjective φ) :
+  (quotient (ker φ)) ≃ H :=
+@quotient_group.quotient_ker_equiv_of_surjective (multiplicative G) _ (multiplicative H) _ φ
+  (multiplicative.is_group_hom _) hφ
 
 attribute [to_additive quotient_add_group.quotient_ker_equiv_range] quotient_group.quotient_ker_equiv_range
 attribute [to_additive quotient_add_group.quotient_ker_equiv_of_surjective] quotient_group.quotient_ker_equiv_of_surjective

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -30,23 +30,23 @@ class is_subgroup (s : set G) extends is_submonoid s : Prop :=
 (inv_mem {a} : a ∈ s → a⁻¹ ∈ s)
 end prio
 
-instance additive.is_add_subgroup
+lemma additive.is_add_subgroup
   (s : set G) [is_subgroup s] : @is_add_subgroup (additive G) _ s :=
 ⟨@is_subgroup.inv_mem _ _ _ _⟩
 
 theorem additive.is_add_subgroup_iff
   {s : set G} : @is_add_subgroup (additive G) _ s ↔ is_subgroup s :=
 ⟨by rintro ⟨⟨h₁, h₂⟩, h₃⟩; exact @is_subgroup.mk G _ _ ⟨h₁, @h₂⟩ @h₃,
-  λ h, by resetI; apply_instance⟩
+  λ h, by exactI additive.is_add_subgroup _⟩
 
-instance multiplicative.is_subgroup
+lemma multiplicative.is_subgroup
   (s : set A) [is_add_subgroup s] : @is_subgroup (multiplicative A) _ s :=
 ⟨@is_add_subgroup.neg_mem _ _ _ _⟩
 
 theorem multiplicative.is_subgroup_iff
   {s : set A} : @is_subgroup (multiplicative A) _ s ↔ is_add_subgroup s :=
 ⟨by rintro ⟨⟨h₁, h₂⟩, h₃⟩; exact @is_add_subgroup.mk A _ _ ⟨h₁, @h₂⟩ @h₃,
-  λ h, by resetI; apply_instance⟩
+  λ h, by exactI multiplicative.is_subgroup _⟩
 
 @[to_additive add_group]
 instance subtype.group {s : set G} [is_subgroup s] : group s :=
@@ -126,13 +126,13 @@ lemma is_subgroup.gpow_mem {a : G} {s : set G} [is_subgroup s] (h : a ∈ s) : �
 | -[1+ n] := is_subgroup.inv_mem (is_submonoid.pow_mem h)
 
 lemma is_add_subgroup.gsmul_mem {a : A} {s : set A} [is_add_subgroup s] : a ∈ s → ∀{i:ℤ}, gsmul i a ∈ s :=
-@is_subgroup.gpow_mem (multiplicative A) _ _ _ _
+@is_subgroup.gpow_mem (multiplicative A) _ _ _ (multiplicative.is_subgroup _)
 
 lemma gpowers_subset {a : G} {s : set G} [is_subgroup s] (h : a ∈ s) : gpowers a ⊆ s :=
 λ x hx, match x, hx with _, ⟨i, rfl⟩ := is_subgroup.gpow_mem h end
 
 lemma gmultiples_subset {a : A} {s : set A} [is_add_subgroup s] (h : a ∈ s) : gmultiples a ⊆ s :=
-@gpowers_subset (multiplicative A) _ _ _ _ h
+@gpowers_subset (multiplicative A) _ _ _ (multiplicative.is_subgroup _) h
 
 attribute [to_additive gmultiples_subset] gpowers_subset
 
@@ -180,25 +180,29 @@ lemma normal_subgroup_of_comm_group [comm_group G] (s : set G) [hs : is_subgroup
 { normal := λ n hn g, by rwa [mul_right_comm, mul_right_inv, one_mul],
   ..hs }
 
-instance additive.normal_add_subgroup [group G]
+lemma additive.normal_add_subgroup [group G]
   (s : set G) [normal_subgroup s] : @normal_add_subgroup (additive G) _ s :=
-⟨@normal_subgroup.normal _ _ _ _⟩
+@normal_add_subgroup.mk (additive G) _ _
+  (@additive.is_add_subgroup G _ _ _)
+  (@normal_subgroup.normal _ _ _ _)
 
 theorem additive.normal_add_subgroup_iff [group G]
   {s : set G} : @normal_add_subgroup (additive G) _ s ↔ normal_subgroup s :=
 ⟨by rintro ⟨h₁, h₂⟩; exact
     @normal_subgroup.mk G _ _ (additive.is_add_subgroup_iff.1 h₁) @h₂,
-  λ h, by resetI; apply_instance⟩
+  λ h, by exactI additive.normal_add_subgroup _⟩
 
-instance multiplicative.normal_subgroup [add_group A]
+lemma multiplicative.normal_subgroup [add_group A]
   (s : set A) [normal_add_subgroup s] : @normal_subgroup (multiplicative A) _ s :=
-⟨@normal_add_subgroup.normal _ _ _ _⟩
+@normal_subgroup.mk (multiplicative A) _ _
+  (@multiplicative.is_subgroup A _ _ _)
+  (@normal_add_subgroup.normal _ _ _ _)
 
 theorem multiplicative.normal_subgroup_iff [add_group A]
   {s : set A} : @normal_subgroup (multiplicative A) _ s ↔ normal_add_subgroup s :=
 ⟨by rintro ⟨h₁, h₂⟩; exact
     @normal_add_subgroup.mk A _ _ (multiplicative.is_subgroup_iff.1 h₁) @h₂,
-  λ h, by resetI; apply_instance⟩
+  λ h, by exactI multiplicative.normal_subgroup _⟩
 
 namespace is_subgroup
 variable [group G]
@@ -261,7 +265,7 @@ def normalizer (s : set G) : set G :=
 {g : G | ∀ n, n ∈ s ↔ g * n * g⁻¹ ∈ s}
 
 @[to_additive normalizer_is_add_subgroup]
-instance normalizer_is_subgroup (s : set G) [is_subgroup s] : is_subgroup (normalizer s) :=
+instance normalizer_is_subgroup (s : set G) : is_subgroup (normalizer s) :=
 { one_mem := by simp [normalizer],
   mul_mem := λ a b (ha : ∀ n, n ∈ s ↔ a * n * a⁻¹ ∈ s)
     (hb : ∀ n, n ∈ s ↔ b * n * b⁻¹ ∈ s) n,
@@ -290,14 +294,15 @@ end is_subgroup
 namespace is_group_hom
 open is_submonoid is_subgroup
 open is_mul_hom (map_mul)
-variables [group G] [group H]
 
 @[to_additive]
-def ker (f : G → H) [is_group_hom f] : set G := preimage f (trivial H)
+def ker [group H] (f : G → H) : set G := preimage f (trivial H)
 
 @[to_additive]
-lemma mem_ker (f : G → H) [is_group_hom f] {x : G} : x ∈ ker f ↔ f x = 1 :=
+lemma mem_ker [group H] (f : G → H) {x : G} : x ∈ ker f ↔ f x = 1 :=
 mem_trivial
+
+variables [group G] [group H]
 
 @[to_additive]
 lemma one_ker_inv (f : G → H) [is_group_hom f] {a b : G} (h : f (a * b⁻¹) = 1) : f a = f b :=


### PR DESCRIPTION
This turns some dangerous instances into lemmas.  A representative example is the following instance:

```lean
instance additive.is_add_hom [has_mul α] [has_mul β] (f : α → β) [is_mul_hom f] :
  @is_add_hom (additive α) (additive β) _ _ f := /- ... -/
```

Empirically, this instance seems to make type class resolution loop (together with `multiplicative.is_mul_hom`).  (The only reason it doesn't loop right now is because it is only used for types which do not have both `has_mul` and `has_add`.)  You wouldn't expect this instance to loop because `additive α` and `α` are not definitionally equal with reducible transparency.  However this doesn't seem to always work out in practice.  Treating `f` as a function with both types `f : α → β` and `f : additive α → additive β`, and then expecting Lean not to unify `α` and `additive α` doesn't seem to work for some reason that I don't completely understand.  We've had a similar issue recently with the simplifier: #2026 

Just removing these instances seems to be the easiest option, given that they're only used in two other files.

Alternatively, I think it would work if we used coercions.  That is, if we made `additive` irreducible and then set up the appropriate instances:
```lean
instance : has_coe (α → β) (additive α → additive β) := /- ... -/

instance additive.is_add_hom [has_mul α] [has_mul β] (f : α → β) [is_mul_hom f] :
  is_add_hom (f : additive α → additive β) := /- ... -/
```

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
