### PR TITLE
chore(category_theory/functor): make arguments implicit

### DIFF
--- a/src/category_theory/functor.lean
+++ b/src/category_theory/functor.lean
@@ -78,7 +78,7 @@ def comp (F : C ⥤ D) (G : D ⥤ E) : C ⥤ E :=
 infixr ` ⋙ `:80 := comp
 
 @[simp] lemma comp_obj (F : C ⥤ D) (G : D ⥤ E) (X : C) : (F ⋙ G).obj X = G.obj (F.obj X) := rfl
-@[simp] lemma comp_map (F : C ⥤ D) (G : D ⥤ E) (X Y : C) (f : X ⟶ Y) :
+@[simp] lemma comp_map (F : C ⥤ D) (G : D ⥤ E) {X Y : C} (f : X ⟶ Y) :
   (F ⋙ G).map f = G.map (F.map f) := rfl
 
 omit ℰ


### PR DESCRIPTION
Some arguments of a lemma were unnecessarily explicit.

Perhaps we never actually use this lemma outside of `simp` sets, so no other changes required? We'll see what CI says.