### PR TITLE
chore(category_theory/limits): remove limits.lean which is superseded by limits_of_products_and_equalizers.lean

### DIFF
--- a/src/category_theory/limits/shapes/constructions/limits.lean
+++ b/src/category_theory/limits/shapes/constructions/limits.lean
@@ -1,1 +1,0 @@
--- TODO construct limits from products and equalizers


### PR DESCRIPTION
Its cousin `finite_limits.lean` was removed in 65bf45c96a9c152d1508376a6a335d638869f32e, but this one wasn't.