### PR TITLE
feat(analysis/calculus/tangent_cone): prove that all intervals are `unique_diff_on`

### DIFF
--- a/src/analysis/calculus/tangent_cone.lean
+++ b/src/analysis/calculus/tangent_cone.lean
@@ -255,6 +255,9 @@ by { rw [unique_diff_within_at, tangent_cone_univ], simp }
 lemma unique_diff_on_univ : unique_diff_on 𝕜 (univ : set E) :=
 λx hx, unique_diff_within_at_univ
 
+lemma unique_diff_on_empty : unique_diff_on 𝕜 (∅ : set E) :=
+λ x hx, hx.elim
+
 lemma unique_diff_within_at.mono_nhds (h : unique_diff_within_at 𝕜 s x)
   (st : nhds_within x s ≤ nhds_within x t) :
   unique_diff_within_at 𝕜 t x :=
@@ -347,22 +350,26 @@ lemma unique_diff_on_Iic (a : ℝ) : unique_diff_on ℝ (Iic a) :=
 unique_diff_on_convex (convex_Iic a) $ by simp only [interior_Iic, nonempty_Iio]
 
 lemma unique_diff_on_Ioi (a : ℝ) : unique_diff_on ℝ (Ioi a) :=
-unique_diff_on_convex (convex_Ioi a) $ by simp only [interior_Ioi, nonempty_Ioi]
+is_open_Ioi.unique_diff_on
 
 lemma unique_diff_on_Iio (a : ℝ) : unique_diff_on ℝ (Iio a) :=
-unique_diff_on_convex (convex_Iio a) $ by simp only [interior_Iio, nonempty_Iio]
+is_open_Iio.unique_diff_on
 
 lemma unique_diff_on_Icc {a b : ℝ} (hab : a < b) : unique_diff_on ℝ (Icc a b) :=
 unique_diff_on_convex (convex_Icc a b) $ by simp only [interior_Icc, nonempty_Ioo, hab]
 
-lemma unique_diff_on_Ico {a b : ℝ} (hab : a < b) : unique_diff_on ℝ (Ico a b) :=
-unique_diff_on_convex (convex_Ico a b) $ by simp only [interior_Ico, nonempty_Ioo, hab]
+lemma unique_diff_on_Ico (a b : ℝ) : unique_diff_on ℝ (Ico a b) :=
+if hab : a < b
+then unique_diff_on_convex (convex_Ico a b) $ by simp only [interior_Ico, nonempty_Ioo, hab]
+else by simp only [Ico_eq_empty (le_of_not_lt hab), unique_diff_on_empty]
 
-lemma unique_diff_on_Ioc {a b : ℝ} (hab : a < b) : unique_diff_on ℝ (Ioc a b) :=
-unique_diff_on_convex (convex_Ioc a b) $ by simp only [interior_Ioc, nonempty_Ioo, hab]
+lemma unique_diff_on_Ioc (a b : ℝ) : unique_diff_on ℝ (Ioc a b) :=
+if hab : a < b
+then unique_diff_on_convex (convex_Ioc a b) $ by simp only [interior_Ioc, nonempty_Ioo, hab]
+else by simp only [Ioc_eq_empty (le_of_not_lt hab), unique_diff_on_empty]
 
-lemma unique_diff_on_Ioo {a b : ℝ} (hab : a < b) : unique_diff_on ℝ (Ioo a b) :=
-unique_diff_on_convex (convex_Ioo a b) $ by simp only [interior_Ioo, nonempty_Ioo, hab]
+lemma unique_diff_on_Ioo (a b : ℝ) : unique_diff_on ℝ (Ioo a b) :=
+is_open_Ioo.unique_diff_on
 
 /-- The real interval `[0, 1]` is a set of unique differentiability. -/
 lemma unique_diff_on_Icc_zero_one : unique_diff_on ℝ (Icc (0:ℝ) 1) :=

--- a/src/analysis/calculus/tangent_cone.lean
+++ b/src/analysis/calculus/tangent_cone.lean
@@ -340,13 +340,32 @@ begin
   exact mem_tangent_cone_of_segment_subset (conv.segment_subset xs zs)
 end
 
+lemma unique_diff_on_Ici (a : ℝ) : unique_diff_on ℝ (Ici a) :=
+unique_diff_on_convex (convex_Ici a) $ by simp only [interior_Ici, nonempty_Ioi]
+
+lemma unique_diff_on_Iic (a : ℝ) : unique_diff_on ℝ (Iic a) :=
+unique_diff_on_convex (convex_Iic a) $ by simp only [interior_Iic, nonempty_Iio]
+
+lemma unique_diff_on_Ioi (a : ℝ) : unique_diff_on ℝ (Ioi a) :=
+unique_diff_on_convex (convex_Ioi a) $ by simp only [interior_Ioi, nonempty_Ioi]
+
+lemma unique_diff_on_Iio (a : ℝ) : unique_diff_on ℝ (Iio a) :=
+unique_diff_on_convex (convex_Iio a) $ by simp only [interior_Iio, nonempty_Iio]
+
+lemma unique_diff_on_Icc {a b : ℝ} (hab : a < b) : unique_diff_on ℝ (Icc a b) :=
+unique_diff_on_convex (convex_Icc a b) $ by simp only [interior_Icc, nonempty_Ioo, hab]
+
+lemma unique_diff_on_Ico {a b : ℝ} (hab : a < b) : unique_diff_on ℝ (Ico a b) :=
+unique_diff_on_convex (convex_Ico a b) $ by simp only [interior_Ico, nonempty_Ioo, hab]
+
+lemma unique_diff_on_Ioc {a b : ℝ} (hab : a < b) : unique_diff_on ℝ (Ioc a b) :=
+unique_diff_on_convex (convex_Ioc a b) $ by simp only [interior_Ioc, nonempty_Ioo, hab]
+
+lemma unique_diff_on_Ioo {a b : ℝ} (hab : a < b) : unique_diff_on ℝ (Ioo a b) :=
+unique_diff_on_convex (convex_Ioo a b) $ by simp only [interior_Ioo, nonempty_Ioo, hab]
+
 /-- The real interval `[0, 1]` is a set of unique differentiability. -/
 lemma unique_diff_on_Icc_zero_one : unique_diff_on ℝ (Icc (0:ℝ) 1) :=
-begin
-  apply unique_diff_on_convex (convex_Icc 0 1),
-  have : (1/(2:ℝ)) ∈ interior (Icc (0:ℝ) 1) :=
-    mem_interior.2 ⟨Ioo (0:ℝ) 1, Ioo_subset_Icc_self, is_open_Ioo, by norm_num, by norm_num⟩,
-  exact ⟨_, this⟩
-end
+unique_diff_on_Icc zero_lt_one
 
 end unique_diff


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)