### PR TITLE
reflexive transitive closure is symmetric of original

### DIFF
--- a/src/logic/relation.lean
+++ b/src/logic/relation.lean
@@ -106,7 +106,7 @@ begin
   case refl_trans_gen.tail : c d hbc hcd hac { exact hac.tail hcd }
 end
 
-lemma symmetry (h : symmetric r) : symmetric (refl_trans_gen r) :=
+lemma symmetric (h : symmetric r) : symmetric (refl_trans_gen r) :=
 begin
   intros x y h,
   induction h with z w a b c,

--- a/src/logic/relation.lean
+++ b/src/logic/relation.lean
@@ -106,6 +106,14 @@ begin
   case refl_trans_gen.tail : c d hbc hcd hac { exact hac.tail hcd }
 end
 
+lemma symmetry (h : symmetric r) : symmetric (refl_trans_gen r) :=
+begin
+  intros x y h,
+  induction h with z w a b c,
+  refl,
+  apply relation.refl_trans_gen.head (h b) c,
+end
+
 lemma cases_tail : refl_trans_gen r a b → b = a ∨ (∃c, refl_trans_gen r a c ∧ r c b) :=
 (cases_tail_iff r a b).1
 

--- a/src/logic/relation.lean
+++ b/src/logic/relation.lean
@@ -110,8 +110,8 @@ lemma symmetric (h : symmetric r) : symmetric (refl_trans_gen r) :=
 begin
   intros x y h,
   induction h with z w a b c,
-  refl,
-  apply relation.refl_trans_gen.head (h b) c,
+  { refl },
+  { apply relation.refl_trans_gen.head (h b) c }
 end
 
 lemma cases_tail : refl_trans_gen r a b → b = a ∨ (∃c, refl_trans_gen r a c ∧ r c b) :=


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
