### PR TITLE
feat(linter): include linter name in report

### DIFF
--- a/src/tactic/lint.lean
+++ b/src/tactic/lint.lean
@@ -752,7 +752,7 @@ formatted_results ← results.mmap $ λ ⟨linter_name, linter, results⟩,
       end,
     pure $ report_str ++ "/- " ++ linter.errors_found ++ ": -/\n" ++ warnings
   else
-    pure $ if verbose then report_str ++ "/- OK: " ++ linter.no_errors_found ++ ". -/" else format.nil,
+    pure $ if verbose then "/- OK: " ++ linter.no_errors_found ++ ". -/" else format.nil,
 let s := format.intercalate "\n\n" (formatted_results.filter (λ f, ¬ f.is_nil)),
 let s := if ¬ verbose then s else
   "/- Checking " ++ l.length ++ " declarations " ++ where_desc ++ " -/\n\n" ++ s,

--- a/src/tactic/lint.lean
+++ b/src/tactic/lint.lean
@@ -744,14 +744,15 @@ meta def lint_aux (l : list declaration) (group_by_filename : option nat)
   tactic (name_set × format) := do
 results ← lint_core l checks,
 formatted_results ← results.mmap $ λ ⟨linter_name, linter, results⟩,
+  let report_str : format := to_fmt "/- The `" ++ to_fmt linter_name ++ "` linter reports: -/\n" in
   if ¬ results.empty then do
     warnings ← match group_by_filename with
       | none := print_warnings results
       | some dropped := grouped_by_filename results dropped print_warnings
       end,
-    pure $ to_fmt "/- " ++ linter.errors_found ++ ": -/\n" ++ warnings
+    pure $ report_str ++ "/- " ++ linter.errors_found ++ ": -/\n" ++ warnings
   else
-    pure $ if verbose then "/- OK: " ++ linter.no_errors_found ++ ". -/" else format.nil,
+    pure $ if verbose then report_str ++ "/- OK: " ++ linter.no_errors_found ++ ". -/" else format.nil,
 let s := format.intercalate "\n\n" (formatted_results.filter (λ f, ¬ f.is_nil)),
 let s := if ¬ verbose then s else
   "/- Checking " ++ l.length ++ " declarations " ++ where_desc ++ " -/\n\n" ++ s,


### PR DESCRIPTION
I wasn't sure of the cleanest way to do this. For now it's printing an extra line for each linter:
```
/- The `dup_namespace` linter reports: -/
/- OK: No declarations have a duplicate namespace. -/
```
I'm happy to change the formatting if anyone cares.

Closes #2098.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
