### PR TITLE
chore(category_theory): remove functor.of

### DIFF
--- a/src/category_theory/comma.lean
+++ b/src/category_theory/comma.lean
@@ -220,7 +220,7 @@ def forget : (over X) ⥤ T := comma.fst _ _
 @[simp] lemma forget_obj {U : over X} : forget.obj U = U.left := rfl
 @[simp] lemma forget_map {U V : over X} {f : U ⟶ V} : forget.map f = f.left := rfl
 
-def map {Y : T} (f : X ⟶ Y) : over X ⥤ over Y := comma.map_right _ $ functor.of.map f
+def map {Y : T} (f : X ⟶ Y) : over X ⥤ over Y := comma.map_right _ $ (functor.const punit).map f
 
 section
 variables {Y : T} {f : X ⟶ Y} {U V : over X} {g : U ⟶ V}
@@ -283,7 +283,7 @@ def forget : (under X) ⥤ T := comma.snd _ _
 @[simp] lemma forget_obj {U : under X} : forget.obj U = U.right := rfl
 @[simp] lemma forget_map {U V : under X} {f : U ⟶ V} : forget.map f = f.right := rfl
 
-def map {Y : T} (f : X ⟶ Y) : under Y ⥤ under X := comma.map_left _ $ functor.of.map f
+def map {Y : T} (f : X ⟶ Y) : under Y ⥤ under X := comma.map_left _ $ (functor.const punit).map f
 
 section
 variables {Y : T} {f : X ⟶ Y} {U V : under Y} {g : U ⟶ V}

--- a/src/category_theory/comma.lean
+++ b/src/category_theory/comma.lean
@@ -181,7 +181,7 @@ end comma
 omit 𝒜 ℬ
 
 @[derive category]
-def over (X : T) := comma.{v₃ 0 v₃} (𝟭 T) (functor.of.obj X)
+def over (X : T) := comma.{v₃ 0 v₃} (𝟭 T) ((functor.const punit).obj X)
 
 namespace over
 
@@ -244,7 +244,7 @@ end
 end over
 
 @[derive category]
-def under (X : T) := comma.{0 v₃ v₃} (functor.of.obj X) (𝟭 T)
+def under (X : T) := comma.{0 v₃ v₃} ((functor.const punit).obj X) (𝟭 T)
 
 namespace under
 

--- a/src/category_theory/elements.lean
+++ b/src/category_theory/elements.lean
@@ -58,7 +58,7 @@ def π : F.elements ⥤ C :=
 @[simp] lemma π_map {X Y : F.elements} (f : X ⟶ Y) : (π F).map f = f.val := rfl
 
 /-- The forward direction of the equivalence `F.elements ≅ (*, F)`. -/
-def to_comma : F.elements ⥤ comma (functor.of.obj punit) F :=
+def to_comma : F.elements ⥤ comma ((functor.const punit).obj punit) F :=
 { obj := λ X, { left := punit.star, right := X.1, hom := λ _, X.2 },
   map := λ X Y f, { right := f.val } }
 
@@ -68,7 +68,7 @@ def to_comma : F.elements ⥤ comma (functor.of.obj punit) F :=
   (to_comma F).map f = { right := f.val } := rfl
 
 /-- The reverse direction of the equivalence `F.elements ≅ (*, F)`. -/
-def from_comma : comma (functor.of.obj punit) F ⥤ F.elements :=
+def from_comma : comma ((functor.const punit).obj punit) F ⥤ F.elements :=
 { obj := λ X, ⟨X.right, X.hom (punit.star)⟩,
   map := λ X Y f, ⟨f.right, congr_fun f.w'.symm punit.star⟩ }
 
@@ -79,7 +79,7 @@ def from_comma : comma (functor.of.obj punit) F ⥤ F.elements :=
 
 /-- The equivalence between the category of elements `F.elements`
     and the comma category `(*, F)`. -/
-def comma_equivalence : F.elements ≌ comma (functor.of.obj punit) F :=
+def comma_equivalence : F.elements ≌ comma ((functor.const punit).obj punit) F :=
 equivalence.mk (to_comma F) (from_comma F)
   (nat_iso.of_components (λ X, eq_to_iso (by tidy)) (by tidy))
   (nat_iso.of_components

--- a/src/category_theory/punit.lean
+++ b/src/category_theory/punit.lean
@@ -18,16 +18,6 @@ namespace functor
 variables {C : Type u} [𝒞 : category.{v} C]
 include 𝒞
 
-/-- The constant functor. For `X : C`, `of.obj X` is the functor `punit ⥤ C`
-  that maps `punit.star` to `X`. -/
-def of : C ⥤ (punit.{w+1} ⥤ C) := const punit
-
-namespace of
-@[simp] lemma obj_obj (X : C) : (of.obj X).obj = λ _, X := rfl
-@[simp] lemma obj_map (X : C) : (of.obj X).map = λ _ _ _, 𝟙 X := rfl
-@[simp] lemma map_app {X Y : C} (f : X ⟶ Y) : (of.map f).app = λ _, f := rfl
-end of
-
 def star : C ⥤ punit.{w+1} := (const C).obj punit.star
 @[simp] lemma star_obj (X : C) : star.obj X = punit.star := rfl
 @[simp] lemma star_map {X Y : C} (f : X ⟶ Y) : star.map f = 𝟙 _ := rfl


### PR DESCRIPTION
Removes `functor.of`, which was just a shorthand for `functor.const punit`. It wasn't used much, and I think was just cruft.

Also, I'll at some point PR some work on `functorial`, a typeclass saying that a fixed function-on-objects is functorial, which seems to be really helpful when talking about lax monoidal functors, and enriched categories, etc. (I still would like to be able to do homological algebra properly. :-)

Once we have `functorial`, it will be natural to have `functor.of` be the construction that takes the function-on-objects and lifts it to a bundled `Functor`. So I'm getting rid of this one first.