### PR TITLE
Fix pullback ext naming

### DIFF
--- a/src/category_theory/limits/shapes/pullbacks.lean
+++ b/src/category_theory/limits/shapes/pullbacks.lean
@@ -215,7 +215,7 @@ end
 
 /-- To check whether a morphism is equalized by the maps of a pullback cone, it suffices to check
   it for `fst t` and `snd t` -/
-lemma equalizer_ext (t : pullback_cone f g) {W : C} {k l : W ⟶ t.X}
+lemma pullback_ext (t : pullback_cone f g) {W : C} {k l : W ⟶ t.X}
   (h₀ : k ≫ fst t = l ≫ fst t)
   (h₁ : k ≫ snd t = l ≫ snd t) :
   ∀ (j : walking_cospan), k ≫ t.π.app j = l ≫ t.π.app j
@@ -249,7 +249,7 @@ end
 
 /-- To check whether a morphism is coequalized by the maps of a pushout cocone, it suffices to check
   it for `inl t` and `inr t` -/
-lemma coequalizer_ext (t : pushout_cocone f g) {W : C} {k l : t.X ⟶ W}
+lemma pushout_ext (t : pushout_cocone f g) {W : C} {k l : t.X ⟶ W}
   (h₀ : inl t ≫ k = inl t ≫ l)
   (h₁ : inr t ≫ k = inr t ≫ l) :
   ∀ (j : walking_span), t.ι.app j ≫ k = t.ι.app j ≫ l


### PR DESCRIPTION
Extensionality lemmas for pullback and pushout were named wrong

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
