### PR TITLE
feat(category_theory/opposites): add nat_iso.unop

### DIFF
--- a/src/category_theory/opposites.lean
+++ b/src/category_theory/opposites.lean
@@ -220,6 +220,8 @@ variables {D : Type u₂} [𝒟 : category.{v₂} D]
 include 𝒟
 variables {F G : C ⥤ D}
 
+/-- The natural isomorphism between opposite functors `G.op ≅ F.op` induced by a natural
+isomorphism between the original functors `F ≅ G`. -/
 protected definition op (α : F ≅ G) : G.op ≅ F.op :=
 { hom := nat_trans.op α.hom,
   inv := nat_trans.op α.inv,
@@ -229,6 +231,8 @@ protected definition op (α : F ≅ G) : G.op ≅ F.op :=
 @[simp] lemma op_hom (α : F ≅ G) : (nat_iso.op α).hom = nat_trans.op α.hom := rfl
 @[simp] lemma op_inv (α : F ≅ G) : (nat_iso.op α).inv = nat_trans.op α.inv := rfl
 
+/-- The natural isomorphism between functors `G ≅ F` induced by a natural isomorphism
+between the opposite functors `F.op ≅ G.op`. -/
 protected definition unop (α : F.op ≅ G.op) : G ≅ F :=
 { hom := nat_trans.unop α.hom,
   inv := nat_trans.unop α.inv,

--- a/src/category_theory/opposites.lean
+++ b/src/category_theory/opposites.lean
@@ -229,6 +229,15 @@ protected definition op (α : F ≅ G) : G.op ≅ F.op :=
 @[simp] lemma op_hom (α : F ≅ G) : (nat_iso.op α).hom = nat_trans.op α.hom := rfl
 @[simp] lemma op_inv (α : F ≅ G) : (nat_iso.op α).inv = nat_trans.op α.inv := rfl
 
+protected definition unop (α : F.op ≅ G.op) : G ≅ F :=
+{ hom := nat_trans.unop α.hom,
+  inv := nat_trans.unop α.inv,
+  hom_inv_id' := begin ext, dsimp, rw ←unop_comp, rw inv_hom_id_app, refl, end,
+  inv_hom_id' := begin ext, dsimp, rw ←unop_comp, rw hom_inv_id_app, refl, end }
+
+@[simp] lemma unop_hom (α : F.op ≅ G.op) : (nat_iso.unop α).hom = nat_trans.unop α.hom := rfl
+@[simp] lemma unop_inv (α : F.op ≅ G.op) : (nat_iso.unop α).inv = nat_trans.unop α.inv := rfl
+
 end nat_iso
 
 end category_theory


### PR DESCRIPTION
I've added `nat_iso.unop` to `category_theory/opposites.lean`, analogously to the existing `nat_trans.unop`. This is basically a copy paste of `nat_iso.op` so hopefully fits all the style guidelines etc.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
