### PR TITLE
refactor(*): migrate some files to bundled ring homs

### DIFF
--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -37,6 +37,26 @@ protected def prod [comm_monoid β] (s : finset α) (f : α → β) : β := (s.1
 @[to_additive]
 theorem prod_eq_fold [comm_monoid β] (s : finset α) (f : α → β) : s.prod f = s.fold (*) 1 f := rfl
 
+end finset
+
+@[to_additive]
+lemma monoid_hom.map_prod [comm_monoid β] [comm_monoid γ] (g : β →* γ) (f : α → β) (s : finset α) :
+  g (s.prod f) = s.prod (λx, g (f x)) :=
+by simp only [finset.prod_eq_multiset_prod, g.map_multiset_prod, multiset.map_map]
+
+lemma ring_hom.map_prod [comm_semiring β] [comm_semiring γ]
+  (g : β →+* γ) (f : α → β) (s : finset α) :
+  g (s.prod f) = s.prod (λx, g (f x)) :=
+g.to_monoid_hom.map_prod f s
+
+lemma ring_hom.map_sum [comm_semiring β] [comm_semiring γ]
+  (g : β →+* γ) (f : α → β) (s : finset α) :
+  g (s.sum f) = s.sum (λx, g (f x)) :=
+g.to_add_monoid_hom.map_sum f s
+
+namespace finset
+variables {s s₁ s₂ : finset α} {a : α} {f g : α → β}
+
 section comm_monoid
 variables [comm_monoid β]
 
@@ -178,7 +198,7 @@ finset.induction_on s (by simp only [prod_empty, prod_const_one]) $
 @[to_additive]
 lemma prod_hom [comm_monoid γ] (s : finset α) {f : α → β} (g : β → γ) [is_monoid_hom g] :
   s.prod (λx, g (f x)) = g (s.prod f) :=
-by { delta finset.prod, rw [← multiset.map_map, multiset.prod_hom _ g] }
+((monoid_hom.of g).map_prod f s).symm
 
 @[to_additive]
 lemma prod_hom_rel [comm_monoid γ] {r : β → γ → Prop} {f : α → β} {g : α → γ} {s : finset α}
@@ -868,12 +888,6 @@ theorem inv_prod : ∀ l : list α, (prod l)⁻¹ = prod (map (λ x, x⁻¹) (re
 λ l, @is_group_anti_hom.map_prod _ _ _ _ _ inv_is_group_anti_hom l -- TODO there is probably a cleaner proof of this
 
 end group
-
-@[to_additive]
-lemma monoid_hom.map_prod [comm_monoid β] [comm_monoid γ] (g : β →* γ) (f : α → β) (s : finset α) :
-  g (s.prod f) = s.prod (λx, g (f x)) :=
-(s.prod_hom g).symm
-
 
 @[to_additive is_add_group_hom_finset_sum]
 lemma is_group_hom_finset_prod {α β γ} [group α] [comm_group β] (s : finset γ)

--- a/src/algebra/direct_limit.lean
+++ b/src/algebra/direct_limit.lean
@@ -439,34 +439,43 @@ open free_comm_ring
 variables (G f)
 /-- The universal property of the direct limit: maps from the components to another ring
 that respect the directed system structure (i.e. make some diagram commute) give rise
-to a unique map out of the direct limit. -/
-def lift : direct_limit G f → P :=
-ideal.quotient.lift _ (free_comm_ring.lift $ λ x, g x.1 x.2) begin
+to a unique map out of the direct limit.
+
+We don't use this function as the canonical form because Lean 3 fails to automatically coerce
+it to a function; use `lift` instead. -/
+def lift_hom : direct_limit G f →+* P :=
+ideal.quotient.lift _ (free_comm_ring.lift_hom $ λ x, g x.1 x.2) begin
   suffices : ideal.span _ ≤
-    ideal.comap (free_comm_ring.lift (λ (x : Σ (i : ι), G i), g (x.fst) (x.snd))) ⊥,
+    ideal.comap (free_comm_ring.lift_hom (λ (x : Σ (i : ι), G i), g (x.fst) (x.snd))) ⊥,
   { intros x hx, exact (mem_bot P).1 (this hx) },
   rw ideal.span_le, intros x hx,
   rw [mem_coe, ideal.mem_comap, mem_bot],
   rcases hx with ⟨i, j, hij, x, rfl⟩ | ⟨i, rfl⟩ | ⟨i, x, y, rfl⟩ | ⟨i, x, y, rfl⟩;
-  simp only [lift_sub, lift_of, Hg, lift_one, lift_add, lift_mul,
+  simp only [coe_lift_hom, lift_sub, lift_of, Hg, lift_one, lift_add, lift_mul,
       is_ring_hom.map_one (g i), is_ring_hom.map_add (g i), is_ring_hom.map_mul (g i), sub_self]
 end
+
+/-- The universal property of the direct limit: maps from the components to another ring
+that respect the directed system structure (i.e. make some diagram commute) give rise
+to a unique map out of the direct limit. -/
+def lift : direct_limit G f → P := lift_hom G f P g Hg
+
 variables {G f}
 omit Hg
 
-instance lift.is_ring_hom : is_ring_hom (lift G f P g Hg) :=
-⟨free_comm_ring.lift_one _,
-λ x y, quotient.induction_on₂' x y $ λ p q, free_comm_ring.lift_mul _ _ _,
-λ x y, quotient.induction_on₂' x y $ λ p q, free_comm_ring.lift_add _ _ _⟩
-
 @[simp] lemma lift_of (i x) : lift G f P g Hg (of G f i x) = g i x := free_comm_ring.lift_of _ _
-@[simp] lemma lift_zero : lift G f P g Hg 0 = 0 := is_ring_hom.map_zero _
-@[simp] lemma lift_one : lift G f P g Hg 1 = 1 := is_ring_hom.map_one _
-@[simp] lemma lift_add (x y) : lift G f P g Hg (x + y) = lift G f P g Hg x + lift G f P g Hg y := is_ring_hom.map_add _
-@[simp] lemma lift_neg (x) : lift G f P g Hg (-x) = -lift G f P g Hg x := is_ring_hom.map_neg _
-@[simp] lemma lift_sub (x y) : lift G f P g Hg (x - y) = lift G f P g Hg x - lift G f P g Hg y := is_ring_hom.map_sub _
-@[simp] lemma lift_mul (x y) : lift G f P g Hg (x * y) = lift G f P g Hg x * lift G f P g Hg y := is_ring_hom.map_mul _
-@[simp] lemma lift_pow (x) (n : ℕ) : lift G f P g Hg (x ^ n) = lift G f P g Hg x ^ n := is_semiring_hom.map_pow _ _ _
+@[simp] lemma lift_zero : lift G f P g Hg 0 = 0 := (lift_hom G f P g Hg).map_zero
+@[simp] lemma lift_one : lift G f P g Hg 1 = 1 := (lift_hom G f P g Hg).map_one
+@[simp] lemma lift_add (x y) : lift G f P g Hg (x + y) = lift G f P g Hg x + lift G f P g Hg y :=
+(lift_hom G f P g Hg).map_add x y
+@[simp] lemma lift_neg (x) : lift G f P g Hg (-x) = -lift G f P g Hg x :=
+(lift_hom G f P g Hg).map_neg x
+@[simp] lemma lift_sub (x y) : lift G f P g Hg (x - y) = lift G f P g Hg x - lift G f P g Hg y :=
+(lift_hom G f P g Hg).map_sub x y
+@[simp] lemma lift_mul (x y) : lift G f P g Hg (x * y) = lift G f P g Hg x * lift G f P g Hg y :=
+(lift_hom G f P g Hg).map_mul x y
+@[simp] lemma lift_pow (x) (n : ℕ) : lift G f P g Hg (x ^ n) = lift G f P g Hg x ^ n :=
+(lift_hom G f P g Hg).map_pow x n
 
 theorem lift_unique (F : direct_limit G f → P) [is_ring_hom F] (x) :
   F x = lift G f P (λ i x, F $ of G f i x) (λ i j hij x, by rw [of_f]) x :=

--- a/src/algebra/direct_limit.lean
+++ b/src/algebra/direct_limit.lean
@@ -460,6 +460,8 @@ that respect the directed system structure (i.e. make some diagram commute) give
 to a unique map out of the direct limit. -/
 def lift : direct_limit G f → P := lift_hom G f P g Hg
 
+instance lift_is_ring_hom : is_ring_hom (lift G f P g Hg) := (lift_hom G f P g Hg).is_ring_hom
+
 variables {G f}
 omit Hg
 

--- a/src/algebra/ring.lean
+++ b/src/algebra/ring.lean
@@ -359,6 +359,8 @@ def of (f : α → β) [is_semiring_hom f] : α →+* β :=
 
 @[simp] lemma coe_of (f : α → β) [is_semiring_hom f] : ⇑(of f) = f := rfl
 
+@[simp] lemma coe_mk (f : α → β) (h₁ h₂ h₃ h₄) : ⇑(⟨f, h₁, h₂, h₃, h₄⟩ : α →+* β) = f := rfl
+
 variables (f : α →+* β) {x y : α} {rα rβ}
 
 theorem coe_inj ⦃f g : α →+* β⦄ (h : (f : α → β) = g) : f = g :=

--- a/src/ring_theory/adjoin.lean
+++ b/src/ring_theory/adjoin.lean
@@ -170,7 +170,7 @@ variables [comm_ring R] [comm_ring A] [comm_ring B] [algebra R A] [algebra R B]
 
 instance alg_hom.is_noetherian_ring_range (f : A →ₐ[R] B) [is_noetherian_ring A] :
   is_noetherian_ring f.range :=
-is_noetherian_ring_range f
+is_noetherian_ring_range f.to_ring_hom
 
 variables [decidable_eq R] [decidable_eq A]
 

--- a/src/ring_theory/adjoin_root.lean
+++ b/src/ring_theory/adjoin_root.lean
@@ -50,9 +50,9 @@ quotient.sound' (mem_span_singleton.2 $ by simp)
 
 instance : is_ring_hom (coe : R → adjoin_root f) := (of f).is_ring_hom
 
-lemma mk_C (x : R) : mk f (C x) = x := rfl
+@[simp] lemma mk_C (x : R) : mk f (C x) = x := rfl
 
-lemma eval₂_root (f : polynomial R) : f.eval₂ coe (root f) = 0 :=
+@[simp] lemma eval₂_root (f : polynomial R) : f.eval₂ coe (root f) = 0 :=
 quotient.induction_on' (root f)
   (λ (g : polynomial R) (hg : mk f g = mk f X),
     show finsupp.sum f (λ (e : ℕ) (a : R), mk f (C a) * mk f g ^ e) = 0,

--- a/src/ring_theory/adjoin_root.lean
+++ b/src/ring_theory/adjoin_root.lean
@@ -12,17 +12,19 @@ noncomputable theory
 
 universes u v w
 
-variables {α : Type u} {β : Type v} {γ : Type w}
+variables {R : Type u} {S : Type v} {K : Type w}
 
 open polynomial ideal
 
-def adjoin_root [comm_ring α] (f : polynomial α) : Type u :=
-ideal.quotient (span {f} : ideal (polynomial α))
+/-- Adjoin a root of a polynomial `f` to a commutative ring `R`. We define the new ring
+as the quotient of `R` by the principal ideal of `f`. -/
+def adjoin_root [comm_ring R] (f : polynomial R) : Type u :=
+ideal.quotient (span {f} : ideal (polynomial R))
 
 namespace adjoin_root
 
 section comm_ring
-variables [comm_ring α] (f : polynomial α)
+variables [comm_ring R] (f : polynomial R)
 
 instance : comm_ring (adjoin_root f) := ideal.quotient.comm_ring _
 
@@ -30,78 +32,76 @@ instance : inhabited (adjoin_root f) := ⟨0⟩
 
 instance : decidable_eq (adjoin_root f) := classical.dec_eq _
 
-variable {f}
+/-- Ring homomorphism from `R[x]` to `adjoin_root f` sending `X` to the `root`. -/
+def mk : polynomial R →+* adjoin_root f := ideal.quotient.mk_hom _
 
-def mk : polynomial α → adjoin_root f := ideal.quotient.mk _
+/-- Embedding of the original ring `R` into `adjoin_root f`. -/
+def of : R →+* adjoin_root f := (mk f).comp (ring_hom.of C)
 
-def root : adjoin_root f := mk X
+/-- The adjoined root. -/
+def root : adjoin_root f := mk f X
 
-def of (x : α) : adjoin_root f := mk (C x)
+variables {f}
 
-instance adjoin_root.has_coe_t : has_coe_t α (adjoin_root f) := ⟨of⟩
+instance adjoin_root.has_coe_t : has_coe_t R (adjoin_root f) := ⟨of f⟩
 
-instance mk.is_ring_hom : is_ring_hom (mk : polynomial α → adjoin_root f) :=
-ideal.quotient.is_ring_hom_mk _
-
-@[simp] lemma mk_self : (mk f : adjoin_root f) = 0 :=
+@[simp] lemma mk_self : mk f f = 0 :=
 quotient.sound' (mem_span_singleton.2 $ by simp)
 
-instance : is_ring_hom (coe : α → adjoin_root f) :=
-@is_ring_hom.comp _ _ _ _ C _ _ _ mk mk.is_ring_hom
+instance : is_ring_hom (coe : R → adjoin_root f) := (of f).is_ring_hom
 
-lemma eval₂_root (f : polynomial α) : f.eval₂ coe (root : adjoin_root f) = 0 :=
-quotient.induction_on' (root : adjoin_root f)
-  (λ (g : polynomial α) (hg : mk g = mk X),
-    show finsupp.sum f (λ (e : ℕ) (a : α), mk (C a) * mk g ^ e) = 0,
-    by simp only [hg, (is_semiring_hom.map_pow (mk : polynomial α → adjoin_root f) _ _).symm,
-         (is_ring_hom.map_mul (mk : polynomial α → adjoin_root f)).symm];
-      rw [finsupp.sum, f.support.sum_hom (mk : polynomial α → adjoin_root f),
+lemma mk_C (x : R) : mk f (C x) = x := rfl
+
+lemma eval₂_root (f : polynomial R) : f.eval₂ coe (root f) = 0 :=
+quotient.induction_on' (root f)
+  (λ (g : polynomial R) (hg : mk f g = mk f X),
+    show finsupp.sum f (λ (e : ℕ) (a : R), mk f (C a) * mk f g ^ e) = 0,
+    by simp only [hg, ((mk f).map_pow _ _).symm, ((mk f).map_mul _ _).symm];
+      rw [finsupp.sum, ← (mk f).map_sum,
         show finset.sum _ _ = _, from sum_C_mul_X_eq _, mk_self])
-  (show (root : adjoin_root f) = mk X, from rfl)
+  (show (root f) = mk f X, from rfl)
 
-lemma is_root_root (f : polynomial α) : is_root (f.map coe) (root : adjoin_root f) :=
+lemma is_root_root (f : polynomial R) : is_root (f.map coe) (root f) :=
 by rw [is_root, eval_map, eval₂_root]
 
-variables [comm_ring β]
+variables [comm_ring S]
 
-def lift (i : α → β) [is_ring_hom i] (x : β) (h : f.eval₂ i x = 0) : (adjoin_root f) → β :=
-ideal.quotient.lift _ (eval₂ i x) $ λ g H,
+/-- Lift a ring homomorphism `i : R →+* S` to `adjoin_root f →+* S`. -/
+def lift (i : R →+* S) (x : S) (h : f.eval₂ i x = 0) : (adjoin_root f) →+* S :=
 begin
-  simp [mem_span_singleton] at H,
-  cases H with y H,
-  rw [H, eval₂_mul],
-  simp [h]
+  apply ideal.quotient.lift _ (ring_hom.of (eval₂ i x)),
+  intros g H,
+  rcases mem_span_singleton.1 H with ⟨y, hy⟩,
+  rw [hy, ring_hom.map_mul, ring_hom.coe_of, h, zero_mul]
 end
 
-variables {i : α → β} [is_ring_hom i] {a : β} {h : f.eval₂ i a = 0}
+variables {i : R →+* S} {a : S} {h : f.eval₂ i a = 0}
 
-@[simp] lemma lift_mk {g : polynomial α} : lift i a h (mk g) = g.eval₂ i a :=
-ideal.quotient.lift_mk
+@[simp] lemma lift_mk {g : polynomial R} : lift i a h (mk f g) = g.eval₂ i a :=
+ideal.quotient.lift_mk _ _ _
 
-@[simp] lemma lift_root : lift i a h root = a := by simp [root, h]
+@[simp] lemma lift_root : lift i a h (root f) = a := by simp [root, h]
 
-@[simp] lemma lift_of {x : α} : lift i a h x = i x :=
-by show lift i a h (ideal.quotient.mk _ (C x)) = i x;
-  convert ideal.quotient.lift_mk; simp
-
-instance is_ring_hom_lift : is_ring_hom (lift i a h) :=
-by unfold lift; apply_instance
+@[simp] lemma lift_of {x : R} : lift i a h x = i x :=
+by rw [← mk_C x, lift_mk, eval₂_C]
 
 end comm_ring
 
-variables [field α] {f : polynomial α} [irreducible f]
+variables [field K] {f : polynomial K} [irreducible f]
 
-instance is_maximal_span : is_maximal (span {f} : ideal (polynomial α)) :=
+instance is_maximal_span : is_maximal (span {f} : ideal (polynomial K)) :=
 principal_ideal_domain.is_maximal_of_irreducible ‹irreducible f›
 
 noncomputable instance field : field (adjoin_root f) :=
-ideal.quotient.field (span {f} : ideal (polynomial α))
+ideal.quotient.field (span {f} : ideal (polynomial K))
 
-lemma coe_injective : function.injective (coe : α → adjoin_root f) :=
-is_ring_hom.injective _
+lemma coe_injective : function.injective (coe : K → adjoin_root f) :=
+(of f).injective
 
-lemma mul_div_root_cancel (f : polynomial α) [irreducible f] :
-  (X - C (root : adjoin_root f)) * (f.map coe / (X - C root)) = f.map coe :=
+variable (f)
+
+lemma mul_div_root_cancel :
+  (X - C (root f)) * (f.map coe / (X - C (root f))) = f.map coe :=
 mul_div_eq_iff_is_root.2 $ is_root_root _
 
 end adjoin_root

--- a/src/ring_theory/free_comm_ring.lean
+++ b/src/ring_theory/free_comm_ring.lean
@@ -79,13 +79,14 @@ begin
   { intros y1 y2 ih1 ih2, rw [mul_add, lift_add, lift_add, mul_add, ih1, ih2] },
 end
 
-instance : is_ring_hom (lift f) :=
-{ map_one := lift_one f,
-  map_mul := lift_mul f,
-  map_add := lift_add f }
+/-- Lift of a map `f : α → β` to `free_comm_ring α` as a ring homomorphism.
+We don't use it as the canonical form because Lean fails to coerce it to a function. -/
+def lift_hom : free_comm_ring α →+* β := ⟨lift f, lift_one f, lift_mul f, lift_zero f, lift_add f⟩
+
+@[simp] lemma coe_lift_hom : ⇑(lift_hom f : free_comm_ring α →+* β) = lift f := rfl
 
 @[simp] lemma lift_pow (x) (n : ℕ) : lift f (x ^ n) = lift f x ^ n :=
-is_semiring_hom.map_pow _ x n
+(lift_hom f).map_pow _ _
 
 @[simp] lemma lift_comp_of (f : free_comm_ring α → β) [is_ring_hom f] : lift (f ∘ of) = f :=
 funext $ λ x, free_comm_ring.induction_on x
@@ -296,8 +297,6 @@ def free_comm_ring_equiv_mv_polynomial_int :
   free_comm_ring α ≃+* mv_polynomial α ℤ :=
 { to_fun  := free_comm_ring.lift $ λ a, mv_polynomial.X a,
   inv_fun := mv_polynomial.eval₂ coe free_comm_ring.of,
-  map_mul' := λ _ _, is_ring_hom.map_mul _,
-  map_add' := λ _ _, is_ring_hom.map_add _,
   left_inv :=
   begin
     intro x,
@@ -340,7 +339,8 @@ def free_comm_ring_equiv_mv_polynomial_int :
     { intros p a ih,
       rw [mv_polynomial.eval₂_mul, mv_polynomial.eval₂_X,
         free_comm_ring.lift_mul, free_comm_ring.lift_of, ih] }
-  end }
+  end,
+  .. free_comm_ring.lift_hom $ λ a, mv_polynomial.X a }
 
 def free_comm_ring_pempty_equiv_int : free_comm_ring pempty.{u+1} ≃+* ℤ :=
 ring_equiv.trans (free_comm_ring_equiv_mv_polynomial_int _) (mv_polynomial.pempty_ring_equiv _)

--- a/src/ring_theory/free_comm_ring.lean
+++ b/src/ring_theory/free_comm_ring.lean
@@ -43,6 +43,8 @@ section lift
 
 variables {β : Type v} [comm_ring β] (f : α → β)
 
+/-- Lift a map `α → R` to a ring homomorphism `free_comm_ring α → R`.
+For a version producing a bundled homomorphism, see `lift_hom`. -/
 def lift : free_comm_ring α → β :=
 free_abelian_group.lift $ λ s, (s.map f).prod
 
@@ -83,6 +85,8 @@ end
 We don't use it as the canonical form because Lean fails to coerce it to a function. -/
 def lift_hom : free_comm_ring α →+* β := ⟨lift f, lift_one f, lift_mul f, lift_zero f, lift_add f⟩
 
+instance : is_ring_hom (lift f) := (lift_hom f).is_ring_hom
+
 @[simp] lemma coe_lift_hom : ⇑(lift_hom f : free_comm_ring α →+* β) = lift f := rfl
 
 @[simp] lemma lift_pow (x) (n : ℕ) : lift f (x ^ n) = lift f x ^ n :=
@@ -99,17 +103,18 @@ end lift
 
 variables {β : Type v} (f : α → β)
 
-def map : free_comm_ring α → free_comm_ring β :=
-lift $ of ∘ f
+/-- A map `f : α → β` produces a ring homomorphism `free_comm_ring α → free_comm_ring β`. -/
+def map : free_comm_ring α →+* free_comm_ring β :=
+lift_hom $ of ∘ f
 
-@[simp] lemma map_zero : map f 0 = 0 := rfl
-@[simp] lemma map_one : map f 1 = 1 := rfl
-@[simp] lemma map_of (x : α) : map f (of x) = of (f x) := lift_of _ _
-@[simp] lemma map_add (x y) : map f (x + y) = map f x + map f y := lift_add _ _ _
-@[simp] lemma map_neg (x) : map f (-x) = -map f x := lift_neg _ _
-@[simp] lemma map_sub (x y) : map f (x - y) = map f x - map f y := lift_sub _ _ _
-@[simp] lemma map_mul (x y) : map f (x * y) = map f x * map f y := lift_mul _ _ _
-@[simp] lemma map_pow (x) (n : ℕ) : map f (x ^ n) = (map f x) ^ n := lift_pow _ _ _
+lemma map_zero : map f 0 = 0 := rfl
+lemma map_one : map f 1 = 1 := rfl
+lemma map_of (x : α) : map f (of x) = of (f x) := lift_of _ _
+lemma map_add (x y) : map f (x + y) = map f x + map f y := lift_add _ _ _
+lemma map_neg (x) : map f (-x) = -map f x := lift_neg _ _
+lemma map_sub (x y) : map f (x - y) = map f x - map f y := lift_sub _ _ _
+lemma map_mul (x y) : map f (x * y) = map f x * map f y := lift_mul _ _ _
+lemma map_pow (x) (n : ℕ) : map f (x ^ n) = (map f x) ^ n := lift_pow _ _ _
 
 def is_supported (x : free_comm_ring α) (s : set α) : Prop :=
 x ∈ ring.closure (of '' s)
@@ -184,7 +189,7 @@ assume hps : is_supported (of p) s, begin
 end
 
 theorem map_subtype_val_restriction {x} (s : set α) [decidable_pred s] (hxs : is_supported x s) :
-  map subtype.val (restriction s x) = x :=
+  map (subtype.val : s → α) (restriction s x) = x :=
 begin
   refine ring.in_closure.rec_on hxs _ _ _ _,
   { rw restriction_one, refl },

--- a/src/ring_theory/ideal_operations.lean
+++ b/src/ring_theory/ideal_operations.lean
@@ -563,6 +563,7 @@ variables {R : Type u} {S : Type v} [comm_ring R]
 section comm_ring
 variables [comm_ring S] (f : R →+* S)
 
+/-- Kernel of a ring homomorphism as an ideal of the domain. -/
 def ker : ideal R := ideal.comap f ⊥
 
 /-- An element is in the kernel if and only if it maps to zero.-/

--- a/src/ring_theory/ideals.lean
+++ b/src/ring_theory/ideals.lean
@@ -210,8 +210,8 @@ instance (I : ideal α) : comm_ring I.quotient :=
     λ a b c, congr_arg (mk _) (right_distrib a b c),
   ..submodule.quotient.add_comm_group I }
 
-instance is_ring_hom_mk (I : ideal α) : is_ring_hom (mk I) :=
-⟨rfl, λ _ _, rfl, λ _ _, rfl⟩
+/-- `ideal.quotient.mk` as a `ring_hom` -/
+def mk_hom (I : ideal α) : α →+* I.quotient := ⟨mk I, rfl, λ _ _, rfl, rfl, λ _ _, rfl⟩
 
 def map_mk (I J : ideal α) : ideal I.quotient :=
 { carrier := mk I '' J,
@@ -226,7 +226,15 @@ def map_mk (I J : ideal α) : ideal I.quotient :=
 @[simp] lemma mk_neg (I : ideal α) (a : α) : mk I (-a : α) = -mk I a := rfl
 @[simp] lemma mk_sub (I : ideal α) (a b : α) : mk I (a - b : α) = mk I a - mk I b := rfl
 @[simp] lemma mk_pow (I : ideal α) (a : α) (n : ℕ) : mk I (a ^ n : α) = mk I a ^ n :=
-by induction n; simp [*, pow_succ]
+(mk_hom I).map_pow a n
+
+lemma mk_prod {ι} (I : ideal α) (s : finset ι) (f : ι → α) :
+  mk I (s.prod f) = s.prod (λ i, mk I (f i)) :=
+(mk_hom I).map_prod f s
+
+lemma mk_sum {ι} (I : ideal α) (s : finset ι) (f : ι → α) :
+  mk I (s.sum f) = s.sum (λ i, mk I (f i)) :=
+(mk_hom I).map_sum f s
 
 lemma eq_zero_iff_mem {I : ideal α} : mk I a = 0 ↔ a ∈ I :=
 by conv {to_rhs, rw ← sub_zero a }; exact quotient.eq'
@@ -269,34 +277,23 @@ protected noncomputable def field (I : ideal α) [hI : I.is_maximal] : field I.q
 
 variable [comm_ring β]
 
-def lift (S : ideal α) (f : α → β) [is_ring_hom f] (H : ∀ (a : α), a ∈ S → f a = 0) :
-  quotient S → β :=
-λ x, quotient.lift_on' x f $ λ (a b) (h : _ ∈ _),
-eq_of_sub_eq_zero (by simpa only [is_ring_hom.map_sub f] using H _ h)
+/-- Given a ring homomorphism `f : α →+* β` sending all elements of an ideal to zero,
+lift it to the quotient by this ideal. -/
+def lift (S : ideal α) (f : α →+* β) (H : ∀ (a : α), a ∈ S → f a = 0) :
+  quotient S →+* β :=
+{ to_fun := λ x, quotient.lift_on' x f $ λ (a b) (h : _ ∈ _),
+    eq_of_sub_eq_zero $ by rw [← f.map_sub, H _ h],
+  map_one' := f.map_one,
+  map_zero' := f.map_zero,
+  map_add' := λ a₁ a₂, quotient.induction_on₂' a₁ a₂ f.map_add,
+  map_mul' := λ a₁ a₂, quotient.induction_on₂' a₁ a₂ f.map_mul }
 
-variables {S : ideal α} {f : α → β} [is_ring_hom f] {H : ∀ (a : α), a ∈ S → f a = 0}
-
-@[simp] lemma lift_mk : lift S f H (mk S a) = f a := rfl
-
-instance : is_ring_hom (lift S f H) :=
-{ map_one := by show lift S f H (mk S 1) = 1; simp [is_ring_hom.map_one f, - mk_one],
-  map_add := λ a₁ a₂, quotient.induction_on₂' a₁ a₂ $ λ a₁ a₂, begin
-    show lift S f H (mk S a₁ + mk S a₂) = lift S f H (mk S a₁) + lift S f H (mk S a₂),
-    have := ideal.quotient.is_ring_hom_mk S,
-    rw ← this.map_add,
-    show lift S f H (mk S (a₁ + a₂)) = lift S f H (mk S a₁) + lift S f H (mk S a₂),
-    simp only [lift_mk, is_ring_hom.map_add f],
-  end,
-  map_mul := λ a₁ a₂, quotient.induction_on₂' a₁ a₂ $ λ a₁ a₂, begin
-    show lift S f H (mk S a₁ * mk S a₂) = lift S f H (mk S a₁) * lift S f H (mk S a₂),
-    have := ideal.quotient.is_ring_hom_mk S,
-    rw ← this.map_mul,
-    show lift S f H (mk S (a₁ * a₂)) = lift S f H (mk S a₁) * lift S f H (mk S a₂),
-    simp only [lift_mk, is_ring_hom.map_mul f],
-  end }
+@[simp] lemma lift_mk (S : ideal α) (f : α →+* β) (H : ∀ (a : α), a ∈ S → f a = 0) :
+  lift S f H (mk S a) = f a := rfl
 
 end quotient
 
+/-- All ideals in a field are trivial. -/
 lemma eq_bot_or_top {K : Type u} [field K] (I : ideal K) :
   I = ⊥ ∨ I = ⊤ :=
 begin
@@ -316,6 +313,7 @@ classical.or_iff_not_imp_right.mp I.eq_bot_or_top h.1
 
 end ideal
 
+/-- The set of non-invertible elements of a monoid. -/
 def nonunits (α : Type u) [monoid α] : set α := { a | ¬is_unit a }
 
 @[simp] theorem mem_nonunits_iff [comm_monoid α] : a ∈ nonunits α ↔ ¬ is_unit a := iff.rfl
@@ -454,18 +452,18 @@ Imax.1 $ I.eq_top_of_is_unit_mem (I.add_mem xmemI ymemI) H
 
 section prio
 set_option default_priority 100 -- see Note [default priority]
-class is_local_ring_hom [comm_ring α] [comm_ring β] (f : α → β) extends is_ring_hom f : Prop :=
+class ring_hom.is_local [semiring α] [semiring β] (f : α →+* β) : Prop :=
 (map_nonunit : ∀ a, is_unit (f a) → is_unit a)
 end prio
 
-@[simp] lemma is_unit_of_map_unit [comm_ring α] [comm_ring β] (f : α → β) [is_local_ring_hom f]
+@[simp] lemma is_unit_of_map_unit [semiring α] [semiring β] (f : α →+* β) [ring_hom.is_local f]
   (a) (h : is_unit (f a)) : is_unit a :=
-is_local_ring_hom.map_nonunit a h
+ring_hom.is_local.map_nonunit a h
 
 section
 open local_ring
 variables [local_ring α] [local_ring β]
-variables (f : α → β) [is_local_ring_hom f]
+variables (f : α →+* β) [ring_hom.is_local f]
 
 lemma map_nonunit (a) (h : a ∈ nonunits_ideal α) : f a ∈ nonunits_ideal β :=
 λ H, h $ is_unit_of_map_unit f a H
@@ -484,18 +482,14 @@ noncomputable instance : field (residue_field α) :=
 ideal.quotient.field (nonunits_ideal α)
 
 variables {α β}
-noncomputable def map (f : α → β) [is_local_ring_hom f] :
-  residue_field α → residue_field β :=
-ideal.quotient.lift (nonunits_ideal α) (ideal.quotient.mk _ ∘ f) $
+noncomputable def map (f : α →+* β) [ring_hom.is_local f] :
+  residue_field α →+* residue_field β :=
+ideal.quotient.lift (nonunits_ideal α) ((ideal.quotient.mk_hom _).comp f) $
 λ a ha,
 begin
   erw ideal.quotient.eq_zero_iff_mem,
   exact map_nonunit f a ha
 end
-
-instance map.is_ring_hom (f : α → β) [is_local_ring_hom f] :
-  is_ring_hom (map f) :=
-ideal.quotient.is_ring_hom
 
 end residue_field
 

--- a/src/ring_theory/ideals.lean
+++ b/src/ring_theory/ideals.lean
@@ -452,18 +452,18 @@ Imax.1 $ I.eq_top_of_is_unit_mem (I.add_mem xmemI ymemI) H
 
 section prio
 set_option default_priority 100 -- see Note [default priority]
-class ring_hom.is_local [semiring α] [semiring β] (f : α →+* β) : Prop :=
+class is_local_ring_hom [semiring α] [semiring β] (f : α →+* β) : Prop :=
 (map_nonunit : ∀ a, is_unit (f a) → is_unit a)
 end prio
 
-@[simp] lemma is_unit_of_map_unit [semiring α] [semiring β] (f : α →+* β) [ring_hom.is_local f]
+@[simp] lemma is_unit_of_map_unit [semiring α] [semiring β] (f : α →+* β) [is_local_ring_hom f]
   (a) (h : is_unit (f a)) : is_unit a :=
-ring_hom.is_local.map_nonunit a h
+is_local_ring_hom.map_nonunit a h
 
 section
 open local_ring
 variables [local_ring α] [local_ring β]
-variables (f : α →+* β) [ring_hom.is_local f]
+variables (f : α →+* β) [is_local_ring_hom f]
 
 lemma map_nonunit (a) (h : a ∈ nonunits_ideal α) : f a ∈ nonunits_ideal β :=
 λ H, h $ is_unit_of_map_unit f a H
@@ -482,7 +482,7 @@ noncomputable instance : field (residue_field α) :=
 ideal.quotient.field (nonunits_ideal α)
 
 variables {α β}
-noncomputable def map (f : α →+* β) [ring_hom.is_local f] :
+noncomputable def map (f : α →+* β) [is_local_ring_hom f] :
   residue_field α →+* residue_field β :=
 ideal.quotient.lift (nonunits_ideal α) ((ideal.quotient.mk_hom _).comp f) $
 λ a ha,

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -18,6 +18,8 @@ variables (R : Type u) {A : Type v}
 variables [comm_ring R] [comm_ring A]
 variables [algebra R A]
 
+/-- An element `x` of an algebra `A` over a commutative ring `R` is said to be *integral*,
+if it is a root of some monic polynomial `p : polynomial R`. -/
 def is_integral (x : A) : Prop :=
 ∃ p : polynomial R, monic p ∧ aeval R A x p = 0
 

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -577,7 +577,7 @@ end fraction_ring
 section ideals
 
 theorem map_comap (J : ideal (localization α S)) :
-  ideal.map coe (ideal.comap (coe : α → localization α S) J) = J :=
+  ideal.map (ring_hom.of coe) (ideal.comap (ring_hom.of (coe : α → localization α S)) J) = J :=
 le_antisymm (ideal.map_le_iff_le_comap.2 (le_refl _)) $ λ x,
 localization.induction_on x $ λ r s hJ, (submodule.mem_coe _).2 $
 mul_one r ▸ coe_mul_mk r 1 s ▸ (ideal.mul_mem_right _ $ ideal.mem_map_of_mem $
@@ -587,7 +587,7 @@ by rwa [coe_coe, coe_mul_mk, mk_mul_cancel_left] at this)
 def le_order_embedding :
   ((≤) : ideal (localization α S) → ideal (localization α S) → Prop) ≼o
   ((≤) : ideal α → ideal α → Prop) :=
-{ to_fun := λ J, ideal.comap coe J,
+{ to_fun := λ J, ideal.comap (ring_hom.of coe) J,
   inj := function.injective_of_left_inverse (map_comap α),
   ord := λ J₁ J₂, ⟨ideal.comap_mono, λ hJ,
     map_comap α J₁ ▸ map_comap α J₂ ▸ ideal.map_mono hJ⟩ }

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -381,7 +381,7 @@ theorem is_noetherian_span_of_finite (R) {M} [ring R] [add_comm_group M] [module
 is_noetherian_of_fg_of_noetherian _ (submodule.fg_def.mpr ⟨A, hA, rfl⟩)
 
 theorem is_noetherian_ring_of_surjective (R) [comm_ring R] (S) [comm_ring S]
-  (f : R → S) [is_ring_hom f] (hf : function.surjective f)
+  (f : R →+* S) (hf : function.surjective f)
   [H : is_noetherian_ring R] : is_noetherian_ring S :=
 begin
   unfold is_noetherian_ring at H ⊢,
@@ -389,17 +389,14 @@ begin
   convert order_embedding.well_founded (order_embedding.rsymm (ideal.lt_order_embedding_of_surjective f hf)) H
 end
 
-instance is_noetherian_ring_range {R} [comm_ring R] {S} [comm_ring S] (f : R → S) [is_ring_hom f]
+instance is_noetherian_ring_range {R} [comm_ring R] {S} [comm_ring S] (f : R →+* S)
   [is_noetherian_ring R] : is_noetherian_ring (set.range f) :=
-@is_noetherian_ring_of_surjective R _ (set.range f) _ (λ x, ⟨f x, x, rfl⟩)
-  (⟨subtype.eq (is_ring_hom.map_one f),
-    λ _ _, subtype.eq (is_ring_hom.map_mul f),
-    λ _ _, subtype.eq (is_ring_hom.map_add f)⟩)
-  (λ ⟨x, y, hy⟩, ⟨y, subtype.eq hy⟩) _
+is_noetherian_ring_of_surjective R (set.range f) (f.cod_restrict (set.range f) set.mem_range_self)
+  set.surjective_onto_range
 
 theorem is_noetherian_ring_of_ring_equiv (R) [comm_ring R] {S} [comm_ring S]
   (f : R ≃+* S) [is_noetherian_ring R] : is_noetherian_ring S :=
-is_noetherian_ring_of_surjective R S f.1 f.to_equiv.surjective
+is_noetherian_ring_of_surjective R S f.to_ring_hom f.to_equiv.surjective
 
 namespace is_noetherian_ring
 

--- a/src/ring_theory/power_series.lean
+++ b/src/ring_theory/power_series.lean
@@ -642,26 +642,21 @@ end, congr_arg X⟩
 end nonzero_comm_ring
 
 section local_ring
-variables {β : Type*} [local_ring α] [local_ring β] (f : α →+* β) [is_local_ring_hom f]
+variables {β : Type*} [local_ring α] [local_ring β] (f : α →+* β) [ring_hom.is_local f]
 
 instance : local_ring (mv_power_series σ α) :=
 local_of_is_local_ring $ is_local_ring ⟨zero_ne_one, local_ring.is_local⟩
 
-instance map.is_local_ring_hom :
-  is_local_ring_hom (map σ f : mv_power_series σ α → mv_power_series σ β) :=
-{ map_one := (map σ f).map_one,
-  map_mul := (map σ f).map_mul,
-  map_add := (map σ f).map_add,
-  map_nonunit :=
-  begin
-    rintros φ ⟨ψ, h⟩,
-    replace h := congr_arg (constant_coeff σ β) h,
-    rw constant_coeff_map at h,
-    have : is_unit (constant_coeff σ β ↑ψ) := @is_unit_constant_coeff σ β _ (↑ψ) (is_unit_unit ψ),
-    rw ← h at this,
-    rcases is_unit_of_map_unit f _ this with ⟨c, hc⟩,
-    exact is_unit_of_mul_one φ (inv_of_unit φ c) (mul_inv_of_unit φ c hc)
-  end }
+instance map.is_local_ring_hom : ring_hom.is_local (map σ f) :=
+⟨begin
+  rintros φ ⟨ψ, h⟩,
+  replace h := congr_arg (constant_coeff σ β) h,
+  rw constant_coeff_map at h,
+  have : is_unit (constant_coeff σ β ↑ψ) := @is_unit_constant_coeff σ β _ (↑ψ) (is_unit_unit ψ),
+  rw ← h at this,
+  rcases is_unit_of_map_unit f _ this with ⟨c, hc⟩,
+  exact is_unit_of_mul_one φ (inv_of_unit φ c) (mul_inv_of_unit φ c hc)
+end⟩
 
 end local_ring
 
@@ -1190,13 +1185,13 @@ mv_power_series.is_local_ring h
 end local_ring
 
 section local_ring
-variables {β : Type*} [local_ring α] [local_ring β] (f : α →+* β) [is_local_ring_hom f]
+variables {β : Type*} [local_ring α] [local_ring β] (f : α →+* β) [ring_hom.is_local f]
 
 instance : local_ring (power_series α) :=
 mv_power_series.local_ring
 
 instance map.is_local_ring_hom :
-  is_local_ring_hom (map f) :=
+  ring_hom.is_local (map f) :=
 mv_power_series.map.is_local_ring_hom f
 
 end local_ring

--- a/src/ring_theory/power_series.lean
+++ b/src/ring_theory/power_series.lean
@@ -1159,10 +1159,10 @@ instance : integral_domain (power_series α) :=
  over an integral domain is a prime ideal.-/
 lemma span_X_is_prime : (ideal.span ({X} : set (power_series α))).is_prime :=
 begin
-  suffices : ideal.span ({X} : set (power_series α)) = is_ring_hom.ker (constant_coeff α),
-  { rw this, exact is_ring_hom.ker_is_prime _ },
+  suffices : ideal.span ({X} : set (power_series α)) = (constant_coeff α).ker,
+  { rw this, exact ring_hom.ker_is_prime _ },
   apply ideal.ext, intro φ,
-  rw [is_ring_hom.mem_ker, ideal.mem_span_singleton, X_dvd_iff]
+  rw [ring_hom.mem_ker, ideal.mem_span_singleton, X_dvd_iff]
 end
 
 /-- The variable of the power series ring over an integral domain is prime.-/

--- a/src/ring_theory/power_series.lean
+++ b/src/ring_theory/power_series.lean
@@ -642,12 +642,12 @@ end, congr_arg X⟩
 end nonzero_comm_ring
 
 section local_ring
-variables {β : Type*} [local_ring α] [local_ring β] (f : α →+* β) [ring_hom.is_local f]
+variables {β : Type*} [local_ring α] [local_ring β] (f : α →+* β) [is_local_ring_hom f]
 
 instance : local_ring (mv_power_series σ α) :=
 local_of_is_local_ring $ is_local_ring ⟨zero_ne_one, local_ring.is_local⟩
 
-instance map.is_local_ring_hom : ring_hom.is_local (map σ f) :=
+instance map.is_local_ring_hom : is_local_ring_hom (map σ f) :=
 ⟨begin
   rintros φ ⟨ψ, h⟩,
   replace h := congr_arg (constant_coeff σ β) h,
@@ -1185,13 +1185,13 @@ mv_power_series.is_local_ring h
 end local_ring
 
 section local_ring
-variables {β : Type*} [local_ring α] [local_ring β] (f : α →+* β) [ring_hom.is_local f]
+variables {β : Type*} [local_ring α] [local_ring β] (f : α →+* β) [is_local_ring_hom f]
 
 instance : local_ring (power_series α) :=
 mv_power_series.local_ring
 
 instance map.is_local_ring_hom :
-  ring_hom.is_local (map f) :=
+  is_local_ring_hom (map f) :=
 mv_power_series.map.is_local_ring_hom f
 
 end local_ring

--- a/src/ring_theory/subring.lean
+++ b/src/ring_theory/subring.lean
@@ -42,6 +42,16 @@ instance is_subring_set_range {R : Type u} {S : Type v} [ring R] [ring S]
 
 end is_ring_hom
 
+/-- Restrict the codomain of a ring homomorphism to a subring that includes the range. -/
+def ring_hom.cod_restrict {R : Type u} {S : Type v} [ring R] [ring S] (f : R →+* S)
+  (s : set S) [is_subring s] (h : ∀ x, f x ∈ s) :
+  R →+* s :=
+{ to_fun := λ x, ⟨f x, h x⟩,
+  map_add' := λ x y, subtype.eq $ f.map_add x y,
+  map_zero' := subtype.eq f.map_zero,
+  map_mul' := λ x y, subtype.eq $ f.map_mul x y,
+  map_one' := subtype.eq f.map_one }
+
 instance subtype_val.is_ring_hom {s : set R} [is_subring s] :
   is_ring_hom (subtype.val : s → R) :=
 { ..subtype_val.is_add_group_hom, ..subtype_val.is_monoid_hom }


### PR DESCRIPTION
What should I do with `is_local_ring_hom`? Should it remain a `class` or become a normal predicate?

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)