### PR TITLE
chore(algebra/field*, field_theory/subfield): drop some `x ≠ 0`, use `division_ring`

### DIFF
--- a/src/algebra/field.lean
+++ b/src/algebra/field.lean
@@ -192,9 +192,6 @@ attribute [simp] inv_zero div_zero
 @[simp] lemma inv_eq_zero {a : α} : a⁻¹ = 0 ↔ a = 0 :=
 classical.by_cases (assume : a = 0, by simp [*])(assume : a ≠ 0, by simp [*, inv_ne_zero])
 
-lemma neg_inv' (a : α) : (-a)⁻¹ = - a⁻¹ :=
-neg_inv.symm
-
 end
 
 namespace ring_hom
@@ -210,12 +207,15 @@ lemma map_ne_zero : f x ≠ 0 ↔ x ≠ 0 :=
 lemma map_eq_zero : f x = 0 ↔ x = 0 :=
 by haveI := classical.dec; exact not_iff_not.1 f.map_ne_zero
 
-lemma map_inv' (h : x ≠ 0) : f x⁻¹ = (f x)⁻¹ :=
-(domain.mul_left_inj (f.map_ne_zero.2 h)).1 $
-by rw [mul_inv_cancel (f.map_ne_zero.2 h), ← f.map_mul, mul_inv_cancel h, f.map_one]
+lemma map_inv : f x⁻¹ = (f x)⁻¹ :=
+begin
+  classical, by_cases h : x = 0, by simp [h],
+  apply (domain.mul_left_inj (f.map_ne_zero.2 h)).1,
+  rw [mul_inv_cancel (f.map_ne_zero.2 h), ← f.map_mul, mul_inv_cancel h, f.map_one]
+end
 
-lemma map_div' (h : y ≠ 0) : f (x / y) = f x / f y :=
-(f.map_mul _ _).trans $ congr_arg _ $ f.map_inv' h
+lemma map_div : f (x / y) = f x / f y :=
+(f.map_mul _ _).trans $ congr_arg _ $ f.map_inv
 
 lemma injective : function.injective f :=
 f.injective_iff.2
@@ -225,17 +225,6 @@ f.injective_iff.2
 
 end
 
-section
-
-variables {β : Type*} [field α] [field β] (f : α →+* β) {x y : α}
-
-lemma map_inv : f x⁻¹ = (f x)⁻¹ :=
-classical.by_cases (by rintro rfl; simp only [map_zero f, inv_zero]) (map_inv' f)
-
-lemma map_div : f (x / y) = f x / f y :=
-(f.map_mul _ _).trans $ congr_arg _ $ map_inv f
-
-end
 end ring_hom
 
 namespace is_ring_hom
@@ -249,21 +238,11 @@ variables (f : α → β) [is_ring_hom f] {x y : α}
 
 @[simp] lemma map_eq_zero : f x = 0 ↔ x = 0 := (of f).map_eq_zero
 
-lemma map_inv' (h : x ≠ 0) : f x⁻¹ = (f x)⁻¹ := (of f).map_inv' h
-
-lemma map_div' (h : y ≠ 0) : f (x / y) = f x / f y := (of f).map_div' h
-
-lemma injective : function.injective f := (of f).injective
-
-end
-
-section
-variables {β : Type*} [field α] [field β]
-variables (f : α → β) [is_ring_hom f] {x y : α}
-
 lemma map_inv : f x⁻¹ = (f x)⁻¹ := (of f).map_inv
 
 lemma map_div : f (x / y) = f x / f y := (of f).map_div
+
+lemma injective : function.injective f := (of f).injective
 
 end
 

--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -60,29 +60,16 @@ pow_one a
 
 end field_power
 
-@[simp] lemma ring_hom.map_fpow {α β : Type*} [field α] [field β] (f : α →+* β)
-  (a : α) : ∀ (n : ℤ), f (a ^ n) = f a ^ n
+@[simp] lemma ring_hom.map_fpow {K L : Type*} [division_ring K] [division_ring L] (f : K →+* L)
+  (a : K) : ∀ (n : ℤ), f (a ^ n) = f a ^ n
 | (n : ℕ) := f.map_pow a n
-| -[1+n] := by simp [fpow_neg_succ_of_nat, f.map_pow, f.map_inv]
-
-lemma ring_hom.map_fpow' {K L : Type*} [division_ring K] [division_ring L] (f : K →+* L)
-  (a : K) (ha : a ≠ 0) : ∀ (n : ℤ), f (a ^ n) = f a ^ n
-| (n : ℕ) := f.map_pow a n
-| -[1+ n] :=
-begin
-  have : a^(n+1) ≠ 0 := mt pow_eq_zero ha,
-  simp [fpow_neg_succ_of_nat, f.map_pow, f.map_inv' this],
-end
+| -[1+n] := by simp only [fpow_neg_succ_of_nat, f.map_pow, f.map_div, f.map_one]
 
 namespace is_ring_hom
 
-lemma map_fpow {α β : Type*} [field α] [field β] (f : α → β) [is_ring_hom f]
-  (a : α) : ∀ (n : ℤ), f (a ^ n) = f a ^ n :=
+lemma map_fpow {K L : Type*} [division_ring K] [division_ring L] (f : K → L) [is_ring_hom f]
+  (a : K) : ∀ (n : ℤ), f (a ^ n) = f a ^ n :=
 (ring_hom.of f).map_fpow a
-
-lemma map_fpow' {K L : Type*} [division_ring K] [division_ring L] (f : K → L) [is_ring_hom f]
-  (a : K) (ha : a ≠ 0) : ∀ (n : ℤ), f (a ^ n) = f a ^ n :=
-(ring_hom.of f).map_fpow' a ha
 
 end is_ring_hom
 

--- a/src/field_theory/subfield.lean
+++ b/src/field_theory/subfield.lean
@@ -14,7 +14,7 @@ class is_subfield extends is_subring S : Prop :=
 (inv_mem : ∀ {x : F}, x ∈ S → x⁻¹ ∈ S)
 end prio
 
-instance is_subfield.field [decidable_eq F] [is_subfield S] : field S :=
+instance is_subfield.field [is_subfield S] : field S :=
 { inv := λ x, ⟨x⁻¹, is_subfield.inv_mem x.2⟩,
   zero_ne_one := λ h : 0 = 1, (@zero_ne_one F _) (subtype.ext.1 h),
   mul_inv_cancel := λ a ha, subtype.ext.2 (mul_inv_cancel

--- a/src/field_theory/subfield.lean
+++ b/src/field_theory/subfield.lean
@@ -11,13 +11,11 @@ variables {F : Type*} [field F] (S : set F)
 section prio
 set_option default_priority 100 -- see Note [default priority]
 class is_subfield extends is_subring S : Prop :=
-(inv_mem : ∀ {x : F}, x ≠ 0 → x ∈ S → x⁻¹ ∈ S)
+(inv_mem : ∀ {x : F}, x ∈ S → x⁻¹ ∈ S)
 end prio
 
 instance is_subfield.field [decidable_eq F] [is_subfield S] : field S :=
-{ inv := λ x, ⟨x⁻¹, if hx0 : x = 0
-    then by erw [hx0, inv_zero]; exact is_add_submonoid.zero_mem _
-    else is_subfield.inv_mem (λ h, hx0 $ subtype.ext.2 h) x.2⟩,
+{ inv := λ x, ⟨x⁻¹, is_subfield.inv_mem x.2⟩,
   zero_ne_one := λ h : 0 = 1, (@zero_ne_one F _) (subtype.ext.1 h),
   mul_inv_cancel := λ a ha, subtype.ext.2 (mul_inv_cancel
     (λ h, ha $ subtype.ext.2 h)),
@@ -33,17 +31,14 @@ instance univ.is_subfield : is_subfield (@set.univ F) :=
   If we specify it explicitly, then it doesn't complain. -/
 instance preimage.is_subfield {K : Type*} [field K]
   (f : F →+* K) (s : set K) [is_subfield s] : is_subfield (f ⁻¹' s) :=
-{ inv_mem := λ a ha0 (ha : f a ∈ s), show f a⁻¹ ∈ s,
-    by { rw [f.map_inv' ha0],
-         exact is_subfield.inv_mem (f.map_ne_zero.2 ha0) ha },
+{ inv_mem := λ a (ha : f a ∈ s), show f a⁻¹ ∈ s,
+    by { rw [f.map_inv],
+         exact is_subfield.inv_mem ha },
   ..is_ring_hom.is_subring_preimage f s }
 
 instance image.is_subfield {K : Type*} [field K]
   (f : F →+* K) (s : set F) [is_subfield s] : is_subfield (f '' s) :=
-{ inv_mem := λ a ha0 ⟨x, hx⟩,
-    have hx0 : x ≠ 0, from λ hx0, ha0 (hx.2 ▸ hx0.symm ▸ f.map_zero),
-    ⟨x⁻¹, is_subfield.inv_mem hx0 hx.1,
-    by { rw [← hx.2, f.map_inv' hx0], refl }⟩,
+{ inv_mem := λ a ⟨x, xmem, ha⟩, ⟨x⁻¹, is_subfield.inv_mem xmem, ha ▸ f.map_inv⟩,
   ..is_ring_hom.is_subring_image f s }
 
 instance range.is_subfield {K : Type*} [field K]
@@ -53,12 +48,12 @@ by { rw ← set.image_univ, apply_instance }
 namespace field
 
 def closure : set F :=
-{ x | ∃ y ∈ ring.closure S, ∃ z ∈ ring.closure S, z ≠ 0 ∧ y / z = x }
+{ x | ∃ y ∈ ring.closure S, ∃ z ∈ ring.closure S, y / z = x }
 
 variables {S}
 
 theorem ring_closure_subset : ring.closure S ⊆ closure S :=
-λ x hx, ⟨x, hx, 1, is_submonoid.one_mem _, one_ne_zero, div_one x⟩
+λ x hx, ⟨x, hx, 1, is_submonoid.one_mem _, div_one x⟩
 
 instance closure.is_submonoid : is_submonoid (closure S) :=
 { mul_mem := by rintros _  _ ⟨p, hp, q, hq, hq0, rfl⟩ ⟨r, hr, s, hs, hs0, rfl⟩;
@@ -66,23 +61,29 @@ instance closure.is_submonoid : is_submonoid (closure S) :=
           is_submonoid.mul_mem hp hr,
           q * s,
           is_submonoid.mul_mem hq hs,
-          mul_ne_zero hq0 hs0, (div_mul_div _ _ _ _).symm⟩,
+          (div_mul_div _ _ _ _).symm⟩,
   one_mem := ring_closure_subset $ is_submonoid.one_mem _ }
 
 instance closure.is_subfield : is_subfield (closure S) :=
+have h0 : (0:F) ∈ closure S, from ring_closure_subset $ is_add_submonoid.zero_mem _,
 { add_mem := begin
-    rintros _ _ ⟨p, hp, q, hq, hq0, rfl⟩ ⟨r, hr, s, hs, hs0, rfl⟩,
-    exact ⟨p * s + q * r, is_add_submonoid.add_mem (is_submonoid.mul_mem hp hs) (is_submonoid.mul_mem hq hr),
-      q * s, is_submonoid.mul_mem hq hs, mul_ne_zero hq0 hs0, (div_add_div p r hq0 hs0).symm⟩
+    intros a b ha hb,
+    rcases (id ha) with ⟨p, hp, q, hq, rfl⟩,
+    rcases (id hb) with ⟨r, hr, s, hs, rfl⟩,
+    classical, by_cases hq0 : q = 0, by simp [hb, hq0], by_cases hs0 : s = 0, by simp [ha, hs0],
+    exact ⟨p * s + q * r, is_add_submonoid.add_mem (is_submonoid.mul_mem hp hs)
+      (is_submonoid.mul_mem hq hr), q * s, is_submonoid.mul_mem hq hs,
+      (div_add_div p r hq0 hs0).symm⟩
   end,
-  zero_mem := ring_closure_subset $ is_add_submonoid.zero_mem _,
+  zero_mem := h0,
   neg_mem := begin
-    rintros _ ⟨p, hp, q, hq, hq0, rfl⟩,
-    exact ⟨-p, is_add_subgroup.neg_mem hp, q, hq, hq0, neg_div q p⟩
+    rintros _ ⟨p, hp, q, hq, rfl⟩,
+    exact ⟨-p, is_add_subgroup.neg_mem hp, q, hq, neg_div q p⟩
   end,
   inv_mem := begin
-    rintros _ hp0 ⟨p, hp, q, hq, hq0, rfl⟩,
-    exact ⟨q, hq, p, hp, (div_ne_zero_iff hq0).1 hp0, inv_div.symm⟩
+    rintros _ ⟨p, hp, q, hq, rfl⟩,
+    classical, by_cases hp0 : p = 0, by simp [hp0, h0],
+    exact ⟨q, hq, p, hp, inv_div.symm⟩
   end }
 
 theorem mem_closure {a : F} (ha : a ∈ S) : a ∈ closure S :=
@@ -93,7 +94,7 @@ theorem subset_closure : S ⊆ closure S :=
 
 theorem closure_subset {T : set F} [is_subfield T] (H : S ⊆ T) : closure S ⊆ T :=
 by rintros _ ⟨p, hp, q, hq, hq0, rfl⟩; exact is_submonoid.mul_mem (ring.closure_subset H hp)
-  (is_subfield.inv_mem hq0 $ ring.closure_subset H hq)
+  (is_subfield.inv_mem $ ring.closure_subset H hq)
 
 theorem closure_subset_iff (s t : set F) [is_subfield t] : closure s ⊆ t ↔ s ⊆ t :=
 ⟨set.subset.trans subset_closure, closure_subset⟩
@@ -107,6 +108,6 @@ lemma is_subfield_Union_of_directed {ι : Type*} [hι : nonempty ι]
   (s : ι → set F) [∀ i, is_subfield (s i)]
   (directed : ∀ i j, ∃ k, s i ⊆ s k ∧ s j ⊆ s k) :
   is_subfield (⋃i, s i) :=
-{ inv_mem := λ x hx0 hx, let ⟨i, hi⟩ := set.mem_Union.1 hx in
-    set.mem_Union.2 ⟨i, is_subfield.inv_mem hx0 hi⟩,
+{ inv_mem := λ x hx, let ⟨i, hi⟩ := set.mem_Union.1 hx in
+    set.mem_Union.2 ⟨i, is_subfield.inv_mem hi⟩,
   to_is_subring := is_subring_Union_of_directed s directed }


### PR DESCRIPTION
We have `0⁻¹=0` in `division_ring` now, so no need to assume `field`
in `ring_hom.map_inv` etc.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)