### PR TITLE
feat(algebra/category/Group): the free-forgetful adjunction for AddCommGroup

### DIFF
--- a/src/algebra/category/Group/adjunctions.lean
+++ b/src/algebra/category/Group/adjunctions.lean
@@ -38,14 +38,12 @@ def free : Type u ⥤ AddCommGroup.{u} :=
 @[simp] lemma free_map_coe {α β : Type u} {f : α → β} (x : free_abelian_group α) :
   (free.map f) x = f <$> x := rfl
 
-local attribute [ext] add_monoid_hom.ext -- TODO mark this globally?
-
 /--
 The free-forgetful adjunction for abelian groups.
 -/
 def adj : free ⊣ forget AddCommGroup :=
 adjunction.mk_of_hom_equiv
 { hom_equiv := λ X G, free_abelian_group.hom_equiv X G,
-  hom_equiv_naturality_left_symm' := by {intros, ext, dsimp at *, simp,} }
+  hom_equiv_naturality_left_symm' := by {intros, ext, dsimp at *, simp [free_abelian_group.lift_comp],} }
 
 end AddCommGroup

--- a/src/algebra/category/Group/adjunctions.lean
+++ b/src/algebra/category/Group/adjunctions.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2019 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison, Johannes Hölzl
+-/
+import algebra.category.Group
+import category_theory.adjunction.basic
+import group_theory.free_abelian_group
+
+/-!
+The free abelian group on a type is the left adjoint of the
+forgetful functor from abelian groups to types.
+-/
+
+noncomputable theory
+
+universe u
+
+open category_theory
+
+namespace AddCommGroup
+
+open_locale classical
+
+/--
+The free functor `Type u ⥤ AddCommGroup.{u}` sending a type `X` to the
+free abelian group with generators `x : X`.
+-/
+def free : Type u ⥤ AddCommGroup.{u} :=
+{ obj := λ α, of (free_abelian_group α),
+  map := λ X Y f, add_monoid_hom.of (λ x : free_abelian_group X, f <$> x),
+  map_id' := λ X, add_monoid_hom.ext $ by simp,
+  map_comp' := λ X Y Z f g, add_monoid_hom.ext $ by { intro x, simp [is_lawful_functor.comp_map], } }
+
+@[simp] lemma free_obj_coe {α : Type u} :
+  (free.obj α : Type u) = (free_abelian_group α) := rfl
+
+@[simp] lemma free_map_coe {α β : Type u} {f : α → β} (x : free_abelian_group α) :
+  (free.map f) x = f <$> x := rfl
+
+local attribute [ext] add_monoid_hom.ext -- TODO mark this globally?
+
+/--
+The free-forgetful adjunction for abelian groups.
+-/
+def adj : free ⊣ forget AddCommGroup :=
+adjunction.mk_of_hom_equiv
+{ hom_equiv := λ X G, free_abelian_group.hom_equiv X G,
+  hom_equiv_naturality_left_symm' := by {intros, ext, dsimp at *, simp,} }
+
+end AddCommGroup

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -84,9 +84,11 @@ lemma coe_mk (f : M → N) (h1 hmul) : ⇑(monoid_hom.mk f h1 hmul) = f := rfl
 lemma coe_inj ⦃f g : M →* N⦄ (h : (f : M → N) = g) : f = g :=
 by cases f; cases g; cases h; refl
 
-@[ext, to_additive]
+@[ext]
 lemma ext ⦃f g : M →* N⦄ (h : ∀ x, f x = g x) : f = g :=
 coe_inj (funext h)
+
+attribute [ext] _root_.add_monoid_hom.ext
 
 @[to_additive]
 lemma ext_iff {f g : M →* N} : f = g ↔ ∀ x, f x = g x :=

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -84,7 +84,7 @@ lemma coe_mk (f : M → N) (h1 hmul) : ⇑(monoid_hom.mk f h1 hmul) = f := rfl
 lemma coe_inj ⦃f g : M →* N⦄ (h : (f : M → N) = g) : f = g :=
 by cases f; cases g; cases h; refl
 
-@[ext]
+@[ext, to_additive]
 lemma ext ⦃f g : M →* N⦄ (h : ∀ x, f x = g x) : f = g :=
 coe_inj (funext h)
 

--- a/src/group_theory/free_abelian_group.lean
+++ b/src/group_theory/free_abelian_group.lean
@@ -84,8 +84,8 @@ end lift
 
 section
 variables (X : Type*) (G : Type*) [add_comm_group G]
-local attribute [ext] add_monoid_hom.ext
 
+/-- The bijection underlying the free-forgetful adjunction for abelian groups.-/
 def hom_equiv : (free_abelian_group X →+ G) ≃ (X → G) :=
 { to_fun := λ f, f.1 ∘ of,
   inv_fun := λ f, add_monoid_hom.of (lift f),
@@ -164,7 +164,7 @@ lift.sub _ _ _
 
 @[simp] lemma map_of (f : α → β) (y : α) : f <$> of y = of (f y) := rfl
 
-@[simp] lemma lift_comp {α} {β} {γ} [add_comm_group γ]
+lemma lift_comp {α} {β} {γ} [add_comm_group γ]
   (f : α → β)
   (g : β → γ)
   (x : free_abelian_group α) :

--- a/src/group_theory/free_abelian_group.lean
+++ b/src/group_theory/free_abelian_group.lean
@@ -165,9 +165,7 @@ lift.sub _ _ _
 @[simp] lemma map_of (f : α → β) (y : α) : f <$> of y = of (f y) := rfl
 
 lemma lift_comp {α} {β} {γ} [add_comm_group γ]
-  (f : α → β)
-  (g : β → γ)
-  (x : free_abelian_group α) :
+  (f : α → β) (g : β → γ) (x : free_abelian_group α) :
   lift (g ∘ f) x = lift g (f <$> x) :=
 begin
   apply free_abelian_group.induction_on x,

--- a/src/group_theory/free_abelian_group.lean
+++ b/src/group_theory/free_abelian_group.lean
@@ -80,14 +80,24 @@ begin
   simp only [(∘), lift.of]
 end
 
-def universal : (α → β) ≃ { f : free_abelian_group α → β // is_add_group_hom f } :=
-{ to_fun := λ f, ⟨_, lift.is_add_group_hom f⟩,
-  inv_fun := λ f, f.1 ∘ of,
-  left_inv := λ f, funext $ λ x, lift.of f x,
-  right_inv := λ f, subtype.eq $ funext $ λ x, eq.symm $ by letI := f.2; from
-    lift.unique _ _ (λ _, rfl) }
-
 end lift
+
+section
+variables (X : Type*) (G : Type*) [add_comm_group G]
+local attribute [ext] add_monoid_hom.ext
+
+def hom_equiv : (free_abelian_group X →+ G) ≃ (X → G) :=
+{ to_fun := λ f, f.1 ∘ of,
+  inv_fun := λ f, add_monoid_hom.of (lift f),
+  left_inv := λ f, begin ext, simp, exact (lift.unique _ _ (λ x, rfl)).symm, end,
+  right_inv := λ f, funext $ λ x, lift.of f x }
+
+@[simp]
+lemma hom_equiv_apply (f) (x) : ((hom_equiv X G) f) x = f (of x) := rfl
+@[simp]
+lemma hom_equiv_symm_apply (f) (x) : ((hom_equiv X G).symm f) x = (lift f) x := rfl
+
+end
 
 local attribute [instance] quotient_group.left_rel normal_subgroup.to_is_subgroup
 
@@ -151,6 +161,21 @@ lift.neg _ _
 
 @[simp] lemma map_sub (f : α → β) (x y : free_abelian_group α) : f <$> (x - y) = f <$> x - f <$> y :=
 lift.sub _ _ _
+
+@[simp] lemma map_of (f : α → β) (y : α) : f <$> of y = of (f y) := rfl
+
+@[simp] lemma lift_comp {α} {β} {γ} [add_comm_group γ]
+  (f : α → β)
+  (g : β → γ)
+  (x : free_abelian_group α) :
+  lift (g ∘ f) x = lift g (f <$> x) :=
+begin
+  apply free_abelian_group.induction_on x,
+  { simp only [lift.zero, map_zero], },
+  { intro y, simp [lift.of, map_of, function.comp_app], },
+  { intros x w, simp only [w, neg_inj', lift.neg, map_neg], },
+  { intros x y w₁ w₂, simp only [w₁, w₂, lift.add, add_right_inj, map_add], },
+end
 
 @[simp] lemma pure_bind (f : α → free_abelian_group β) (x) : pure x >>= f = f x :=
 lift.of _ _


### PR DESCRIPTION
Again, this is mostly just wrapping up @kckennylau's work on free abelian groups in the adjunction API, and patching the inevitable small gaps.