### PR TITLE
chore(algebra/category/CommRing/limits): avoid `is_ring_hom`

### DIFF
--- a/src/algebra/category/CommRing/limits.lean
+++ b/src/algebra/category/CommRing/limits.lean
@@ -88,11 +88,14 @@ instance limit_comm_ring (F : J ⥤ CommRing.{u}) :
 @subtype.comm_ring ((Π (j : J), (F ⋙ forget _).obj j)) (by apply_instance) _
   (by convert (CommRing.sections_subring F))
 
-instance limit_π_is_ring_hom (F : J ⥤ CommRing.{u}) (j) :
-  is_ring_hom (limit.π (F ⋙ forget CommRing) j) :=
-{ map_one := by { simp only [types.types_limit_π], refl },
-  map_mul := λ x y, by { simp only [types.types_limit_π], refl },
-  map_add := λ x y, by { simp only [types.types_limit_π], refl } }
+/-- `limit.π (F ⋙ forget CommRing) j` as a `ring_hom`. -/
+def limit_π_ring_hom (F : J ⥤ CommRing.{u}) (j) :
+  limit (F ⋙ forget CommRing) →+* (F ⋙ forget CommRing).obj j :=
+{ to_fun := limit.π (F ⋙ forget CommRing) j,
+  map_one' := by { simp only [types.types_limit_π], refl },
+  map_zero' := by { simp only [types.types_limit_π], refl },
+  map_mul' := λ x y, by { simp only [types.types_limit_π], refl },
+  map_add' := λ x y, by { simp only [types.types_limit_π], refl } }
 
 namespace CommRing_has_limits
 -- The next two definitions are used in the construction of `has_limits CommRing`.
@@ -106,7 +109,7 @@ Construction of a limit cone in `CommRing`.
 def limit (F : J ⥤ CommRing.{u}) : cone F :=
 { X := ⟨limit (F ⋙ forget _), by apply_instance⟩,
   π :=
-  { app := λ j, ring_hom.of $ limit.π (F ⋙ forget _) j,
+  { app := limit_π_ring_hom F,
     naturality' := λ j j' f,
       ring_hom.coe_inj ((limit.cone (F ⋙ forget _)).π.naturality f) } }
 


### PR DESCRIPTION
define a `ring_hom` instead

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)