### PR TITLE
doc(docs/install/*): emphasize projects link

### DIFF
--- a/docs/install/debian_details.md
+++ b/docs/install/debian_details.md
@@ -43,4 +43,6 @@ reading the bash script that will be downloaded below:
   sudo pip3 install mathlibtools
   ```
 
-You can now read instructions about creating and working on [Lean projects](project.md)
+Note however that you cannot use mathlib, and in particular any imports,
+in the file `test.lean` created above. If you want to use mathlib you should
+now read instructions about creating and working on [Lean projects](project.md).

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -36,4 +36,8 @@ All commands below should be typed inside a terminal.
   sudo pip3 install mathlibtools
   ```
 
-You can now read instructions about creating and working on [Lean projects](project.md)
+Note however that you cannot use mathlib, and in particular any imports,
+in the file `test.lean` created above. If you want to use mathlib you
+should now read instructions about creating and working on
+[Lean projects](project.md).
+

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -58,4 +58,7 @@ This document describes using VS Code (for emacs, look at https://github.com/lea
    A green line should appear underneath `#eval 1+1`, and hovering the mouse over it you should see `2`
    displayed.
 
-You can now read instructions about creating and working on [Lean projects](project.md)
+Note however that you cannot use mathlib, and in particular any imports,
+in the file `test.lean` created above. If you want to use mathlib you should
+now read instructions about creating and working on [Lean projects](project.md).
+


### PR DESCRIPTION
I foolishly only changed the windows documentation when clarifying that users needed to create projects to get mathlib working. This changes the other OS instructions.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
