### PR TITLE
feat(category_theory/limits): Convenience methods for building limit (co)forks

### DIFF
--- a/src/category_theory/limits/shapes/equalizers.lean
+++ b/src/category_theory/limits/shapes/equalizers.lean
@@ -207,6 +207,33 @@ begin
   erw [t.w left, ← t.w right], refl
 end
 
+/-- This is a slightly more convenient method to verify that a fork is a limit cone. It
+    only asks for a proof of facts that carry any mathematical content -/
+def fork.is_limit.mk (t : fork f g)
+  (lift : Π (s : fork f g), s.X ⟶ t.X)
+  (fac : ∀ (s : fork f g), lift s ≫ fork.ι t = fork.ι s)
+  (uniq : ∀ (s : fork f g) (m : s.X ⟶ t.X)
+    (w : ∀ j : walking_parallel_pair, m ≫ t.π.app j = s.π.app j),
+  m = lift s) : is_limit t :=
+{ lift := lift,
+  fac' := λ s j, walking_parallel_pair.cases_on j (fac s) $
+    by erw [←s.w left, ←t.w left, ←category.assoc, fac]; refl,
+  uniq' := uniq }
+
+/-- This is a slightly more convenient method to verify that a cofork is a colimit cocone. It
+    only asks for a proof of facts that carry any mathematical content -/
+def cofork.is_colimit.mk (t : cofork f g)
+  (desc : Π (s : cofork f g), t.X ⟶ s.X)
+  (fac : ∀ (s : cofork f g),
+    cofork.π t ≫ desc s = cofork.π s)
+  (uniq : ∀ (s : cofork f g) (m : t.X ⟶ s.X)
+    (w : ∀ j : walking_parallel_pair, t.ι.app j ≫ m = s.ι.app j),
+  m = desc s) : is_colimit t :=
+{ desc := desc,
+  fac' := λ s j, walking_parallel_pair.cases_on j
+    (by erw [←s.w left, ←t.w left, category.assoc, fac]; refl) (fac s),
+  uniq' := uniq }
+
 section
 local attribute [ext] cone
 

--- a/src/category_theory/limits/shapes/equalizers.lean
+++ b/src/category_theory/limits/shapes/equalizers.lean
@@ -213,8 +213,8 @@ def fork.is_limit.mk (t : fork f g)
   (lift : Π (s : fork f g), s.X ⟶ t.X)
   (fac : ∀ (s : fork f g), lift s ≫ fork.ι t = fork.ι s)
   (uniq : ∀ (s : fork f g) (m : s.X ⟶ t.X)
-    (w : ∀ j : walking_parallel_pair, m ≫ t.π.app j = s.π.app j),
-  m = lift s) : is_limit t :=
+    (w : ∀ j : walking_parallel_pair, m ≫ t.π.app j = s.π.app j), m = lift s) :
+  is_limit t :=
 { lift := lift,
   fac' := λ s j, walking_parallel_pair.cases_on j (fac s) $
     by erw [←s.w left, ←t.w left, ←category.assoc, fac]; refl,
@@ -224,11 +224,10 @@ def fork.is_limit.mk (t : fork f g)
     only asks for a proof of facts that carry any mathematical content -/
 def cofork.is_colimit.mk (t : cofork f g)
   (desc : Π (s : cofork f g), t.X ⟶ s.X)
-  (fac : ∀ (s : cofork f g),
-    cofork.π t ≫ desc s = cofork.π s)
+  (fac : ∀ (s : cofork f g), cofork.π t ≫ desc s = cofork.π s)
   (uniq : ∀ (s : cofork f g) (m : t.X ⟶ s.X)
-    (w : ∀ j : walking_parallel_pair, t.ι.app j ≫ m = s.ι.app j),
-  m = desc s) : is_colimit t :=
+    (w : ∀ j : walking_parallel_pair, t.ι.app j ≫ m = s.ι.app j), m = desc s) :
+  is_colimit t :=
 { desc := desc,
   fac' := λ s j, walking_parallel_pair.cases_on j
     (by erw [←s.w left, ←t.w left, category.assoc, fac]; refl) (fac s),

--- a/src/category_theory/limits/shapes/kernels.lean
+++ b/src/category_theory/limits/shapes/kernels.lean
@@ -87,19 +87,11 @@ def kernel.zero_cone : cone (parallel_pair f 0) :=
 
 /-- The map from the zero object is a kernel of a monomorphism -/
 def kernel.is_limit_cone_zero_cone [mono f] : is_limit (kernel.zero_cone f) :=
-{ lift := λ s, 0,
-  fac' := λ s j,
-  begin
-    cases j,
-    { erw has_zero_morphisms.zero_comp,
-      convert (@zero_of_comp_mono _ _ _ _ _ _ _ f _ _).symm,
-      erw fork.condition,
-      convert has_zero_morphisms.comp_zero.{v} _ (s.π.app zero) _ },
-    { rw ←cone_parallel_pair_right s,
-      simp only [has_zero_morphisms.zero_comp],
-      convert (has_zero_morphisms.comp_zero.{v} _ (s.π.app zero) _).symm },
-  end,
-  uniq' := λ _ m _, has_zero_object.zero_of_to_zero m }
+fork.is_limit.mk _ (λ s, 0)
+  (λ s, by { erw has_zero_morphisms.zero_comp,
+    convert (@zero_of_comp_mono _ _ _ _ _ _ _ f _ _).symm,
+    exact kernel_fork.condition _ })
+  (λ _ _ _, has_zero_object.zero_of_to_zero _)
 
 /-- The kernel of a monomorphism is isomorphic to the zero object -/
 def kernel.of_mono [has_limit (parallel_pair f 0)] [mono f] : kernel f ≅ 0 :=
@@ -152,20 +144,11 @@ def cokernel.zero_cocone : cocone (parallel_pair f 0) :=
 
 /-- The morphism to the zero object is a cokernel of an epimorphism -/
 def cokernel.is_colimit_cocone_zero_cocone [epi f] : is_colimit (cokernel.zero_cocone f) :=
-{ desc := λ s, 0,
-  fac' := λ s j,
-  begin
-    cases j,
-    { erw [←cocone_parallel_pair_left s,
-        has_zero_morphisms.comp_zero _ ((cokernel.zero_cocone f).ι.app zero) _, cofork.condition,
-        has_zero_morphisms.zero_comp],
-      refl },
-    { erw has_zero_morphisms.zero_comp,
-      convert (@zero_of_comp_epi _ _ _ _ _ _ f _ _ _).symm,
-      erw [cofork.condition, has_zero_morphisms.zero_comp],
-      refl },
-  end,
-  uniq' := λ _ m _, has_zero_object.zero_of_from_zero m }
+cofork.is_colimit.mk _ (λ s, 0)
+  (λ s, by { erw has_zero_morphisms.zero_comp,
+    convert (@zero_of_comp_epi _ _ _ _ _ _ f _ _ _).symm,
+    exact cokernel_cofork.condition _ })
+  (λ _ _ _, has_zero_object.zero_of_from_zero _)
 
 /-- The cokernel of an epimorphism is isomorphic to the zero object -/
 def cokernel.of_epi [has_colimit (parallel_pair f 0)] [epi f] : cokernel f ≅ 0 :=

--- a/src/category_theory/limits/shapes/kernels.lean
+++ b/src/category_theory/limits/shapes/kernels.lean
@@ -52,6 +52,26 @@ include 𝒞
 variables {X Y : C} (f : X ⟶ Y)
 
 section
+variables [has_zero_morphisms.{v} C]
+
+/-- A kernel fork is just a fork where the second morphism is a zero morphism. -/
+abbreviation kernel_fork := fork f 0
+
+variables {f}
+
+@[simp, reassoc] lemma kernel_fork.condition (s : kernel_fork f) : fork.ι s ≫ f = 0 :=
+by erw [fork.condition, has_zero_morphisms.comp_zero]
+
+@[simp] lemma kernel_fork.app_one (s : kernel_fork f) : s.π.app one = 0 :=
+by erw [←cone_parallel_pair_left, kernel_fork.condition]; refl
+
+/-- A morphism `ι` satisfying `ι ≫ f = 0` determines a kernel fork over `f`. -/
+abbreviation kernel_fork.of_ι {Z : C} (ι : Z ⟶ X) (w : ι ≫ f = 0) : kernel_fork f :=
+fork.of_ι ι $ by rw [w, has_zero_morphisms.comp_zero]
+
+end
+
+section
 variables [has_zero_morphisms.{v} C] [has_limit (parallel_pair f 0)]
 
 /-- The kernel of a morphism, expressed as the equalizer with the 0 morphism. -/
@@ -61,11 +81,11 @@ abbreviation kernel : C := equalizer f 0
 abbreviation kernel.ι : kernel f ⟶ X := equalizer.ι f 0
 
 @[simp, reassoc] lemma kernel.condition : kernel.ι f ≫ f = 0 :=
-by simp [equalizer.condition]
+kernel_fork.condition _
 
 /-- Given any morphism `k` so `k ≫ f = 0`, `k` factors through `kernel f`. -/
 abbreviation kernel.lift {W : C} (k : W ⟶ X) (h : k ≫ f = 0) : W ⟶ kernel f :=
-limit.lift (parallel_pair f 0) (fork.of_ι k (by simpa))
+limit.lift (parallel_pair f 0) (kernel_fork.of_ι k h)
 
 /-- Every kernel of the zero morphism is an isomorphism -/
 def kernel.ι_zero_is_iso [has_limit (parallel_pair (0 : X ⟶ Y) 0)] :
@@ -123,6 +143,26 @@ end
 end has_zero_object
 
 section
+variables [has_zero_morphisms.{v} C]
+
+/-- A cokernel cofork is just a cofork where the second morphism is a zero morphism. -/
+abbreviation cokernel_cofork := cofork f 0
+
+variables {f}
+
+@[simp, reassoc] lemma cokernel_cofork.condition (s : cokernel_cofork f) : f ≫ cofork.π s = 0 :=
+by erw [cofork.condition, has_zero_morphisms.zero_comp]
+
+@[simp] lemma cokernel_cofork.app_zero (s : cokernel_cofork f) : s.ι.app zero = 0 :=
+by erw [←cocone_parallel_pair_left, cokernel_cofork.condition]; refl
+
+/-- A morphism `π` satisfying `f ≫ π = 0` determines a cokernel cofork on `f`. -/
+abbreviation cokernel_cofork.of_π {Z : C} (π : Y ⟶ Z) (w : f ≫ π = 0) : cokernel_cofork f :=
+cofork.of_π π $ by rw [w, has_zero_morphisms.zero_comp]
+
+end
+
+section
 variables [has_zero_morphisms.{v} C] [has_colimit (parallel_pair f 0)]
 
 /-- The cokernel of a morphism, expressed as the coequalizer with the 0 morphism. -/
@@ -132,11 +172,11 @@ abbreviation cokernel : C := coequalizer f 0
 abbreviation cokernel.π : Y ⟶ cokernel f := coequalizer.π f 0
 
 @[simp, reassoc] lemma cokernel.condition : f ≫ cokernel.π f = 0 :=
-by simp [coequalizer.condition]
+cokernel_cofork.condition _
 
 /-- Given any morphism `k` so `f ≫ k = 0`, `k` factors through `cokernel f`. -/
 abbreviation cokernel.desc {W : C} (k : Y ⟶ W) (h : f ≫ k = 0) : cokernel f ⟶ W :=
-colimit.desc (parallel_pair f 0) (cofork.of_π k (by simpa))
+colimit.desc (parallel_pair f 0) (cokernel_cofork.of_π k h)
 end
 
 section has_zero_object


### PR DESCRIPTION
This PR depends on #2156.

The same for pullback cones already appears in #2143.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
