### PR TITLE
fix(category_theory/limits): require explicit instances of has_zero_morphisms

### DIFF
--- a/src/algebra/category/Module/basic.lean
+++ b/src/algebra/category/Module/basic.lean
@@ -120,10 +120,18 @@ def linear_equiv_iso_Group_iso {X Y : Type u} [add_comm_group X] [add_comm_group
 
 namespace Module
 
+section zero_morphisms
+
+instance : has_zero_morphisms.{u} (Module R) :=
+{ has_zero := λ M N, ⟨0⟩,
+  comp_zero' := λ M N f Z, by ext; erw linear_map.zero_apply,
+  zero_comp' := λ M N Z f, by ext; erw [linear_map.comp_apply, linear_map.zero_apply,
+    linear_map.zero_apply, linear_map.map_zero] }
+
+end zero_morphisms
+
 section kernel
 variables {R} {M N : Module R} (f : M ⟶ N)
-
-local attribute [instance] has_zero_object.zero_morphisms_of_zero_object
 
 /-- The cone on the equalizer diagram of f and 0 induced by the kernel of f -/
 def kernel_cone : cone (parallel_pair f 0) :=
@@ -154,8 +162,6 @@ def kernel_is_limit : is_limit (kernel_cone f) :=
     by convert @congr_fun _ _ _ _ h₁ x }
 
 end kernel
-
-local attribute [instance] has_zero_object.zero_morphisms_of_zero_object
 
 instance : has_kernels.{u} (Module R) :=
 ⟨λ _ _ f, ⟨kernel_cone f, kernel_is_limit f⟩⟩

--- a/src/category_theory/limits/shapes/kernels.lean
+++ b/src/category_theory/limits/shapes/kernels.lean
@@ -98,7 +98,7 @@ section has_zero_object
 variables [has_zero_object.{v} C]
 
 local attribute [instance] has_zero_object.has_zero
-local attribute [instance] has_zero_object.zero_morphisms_of_zero_object
+variables [has_zero_morphisms.{v} C]
 
 /-- The morphism from the zero object determines a cone on a kernel diagram -/
 def kernel.zero_cone : cone (parallel_pair f 0) :=
@@ -175,7 +175,7 @@ section has_zero_object
 variables [has_zero_object.{v} C]
 
 local attribute [instance] has_zero_object.has_zero
-local attribute [instance] has_zero_object.zero_morphisms_of_zero_object
+variable [has_zero_morphisms.{v} C]
 
 /-- The morphism to the zero object determines a cocone on a cokernel diagram -/
 def cokernel.zero_cocone : cocone (parallel_pair f 0) :=
@@ -216,7 +216,7 @@ section has_zero_object
 variables [has_zero_object.{v} C]
 
 local attribute [instance] has_zero_object.has_zero
-local attribute [instance] has_zero_object.zero_morphisms_of_zero_object
+variables [has_zero_morphisms.{v} C]
 
 /-- The kernel of the cokernel of an epimorphism is an isomorphism -/
 instance kernel.of_cokernel_of_epi [has_colimit (parallel_pair f 0)]

--- a/src/category_theory/limits/shapes/kernels.lean
+++ b/src/category_theory/limits/shapes/kernels.lean
@@ -123,16 +123,16 @@ lemma kernel.ι_of_mono [has_limit (parallel_pair f 0)] [mono f] : kernel.ι f =
 by rw [←category.id_comp _ (kernel.ι f), ←iso.hom_inv_id (kernel.of_mono f), category.assoc,
   has_zero_object.zero_of_to_zero (kernel.of_mono f).hom, has_zero_morphisms.zero_comp]
 
+end has_zero_object
+
 section
-variables (X) (Y)
+variables (X) (Y) [has_zero_morphisms.{v} C]
 
 /-- The kernel morphism of a zero morphism is an isomorphism -/
 def kernel.ι_of_zero [has_limit (parallel_pair (0 : X ⟶ Y) 0)] : is_iso (kernel.ι (0 : X ⟶ Y)) :=
 equalizer.ι_of_self _
 
 end
-
-end has_zero_object
 
 section
 variables [has_zero_morphisms.{v} C]
@@ -175,6 +175,7 @@ section has_zero_object
 variables [has_zero_object.{v} C]
 
 local attribute [instance] has_zero_object.has_zero
+
 variable [has_zero_morphisms.{v} C]
 
 /-- The morphism to the zero object determines a cocone on a cokernel diagram -/
@@ -200,8 +201,10 @@ lemma cokernel.π_of_epi [has_colimit (parallel_pair f 0)] [epi f] : cokernel.π
 by rw [←category.comp_id _ (cokernel.π f), ←iso.hom_inv_id (cokernel.of_epi f), ←category.assoc,
   has_zero_object.zero_of_from_zero (cokernel.of_epi f).inv, has_zero_morphisms.comp_zero]
 
+end has_zero_object
+
 section
-variables (X) (Y)
+variables (X) (Y) [has_zero_morphisms.{v} C]
 
 /-- The cokernel of a zero morphism is an isomorphism -/
 def cokernel.π_of_zero [has_colimit (parallel_pair (0 : X ⟶ Y) 0)] :
@@ -210,7 +213,6 @@ coequalizer.π_of_self _
 
 end
 
-end has_zero_object
 
 section has_zero_object
 variables [has_zero_object.{v} C]

--- a/src/category_theory/limits/shapes/zero.lean
+++ b/src/category_theory/limits/shapes/zero.lean
@@ -109,14 +109,14 @@ begin
   rw (has_zero_object.unique_to.{v} X).uniq (0 : 0 ⟶ X)
 end
 
+end
+
 /-- A zero object is in particular initial. -/
 def has_initial_of_has_zero_object : has_initial.{v} C :=
 has_initial_of_unique 0
 /-- A zero object is in particular terminal. -/
 def has_terminal_of_has_zero_object : has_terminal.{v} C :=
 has_terminal_of_unique 0
-
-end
 
 end has_zero_object
 

--- a/src/category_theory/limits/shapes/zero.lean
+++ b/src/category_theory/limits/shapes/zero.lean
@@ -78,14 +78,22 @@ protected def has_zero : has_zero C :=
 local attribute [instance] has_zero_object.has_zero
 local attribute [instance] has_zero_object.unique_to has_zero_object.unique_from
 
-/-- A category with a zero object has zero morphisms. -/
+/-- A category with a zero object has zero morphisms.
+
+    It is rarely a good idea to use this. Many categories that have a zero object have zero
+    morphisms for some other reason, for example from additivity. Library code that uses
+    `zero_morphisms_of_zero_object` will then be incompatible with these categories because
+    the `has_zero_morphisms` instances will not be definitionally equal. For this reason library
+    code should generally ask for an instance of `has_zero_morphisms` separately, even if it already
+    asks for an instance of `has_zero_objects`. -/
 def zero_morphisms_of_zero_object : has_zero_morphisms.{v} C :=
 { has_zero := λ X Y,
   { zero := inhabited.default (X ⟶ 0) ≫ inhabited.default (0 ⟶ Y) },
   zero_comp' := λ X Y Z f, by { dunfold has_zero.zero, rw category.assoc, congr, },
   comp_zero' := λ X Y Z f, by { dunfold has_zero.zero, rw ←category.assoc, congr, }}
 
-local attribute [instance] zero_morphisms_of_zero_object
+section
+variable [has_zero_morphisms.{v} C]
 
 /--  An arrow ending in the zero object is zero -/
 lemma zero_of_to_zero {X : C} (f : X ⟶ 0) : f = 0 :=
@@ -107,6 +115,8 @@ has_initial_of_unique 0
 /-- A zero object is in particular terminal. -/
 def has_terminal_of_has_zero_object : has_terminal.{v} C :=
 has_terminal_of_unique 0
+
+end
 
 end has_zero_object
 


### PR DESCRIPTION
```lean
/-- A category with a zero object has zero morphisms.
    It is rarely a good idea to use this. Many categories that have a zero object have zero
    morphisms for some other reason, for example from additivity. Library code that uses
    `zero_morphisms_of_zero_object` will then be incompatible with these categories because
    the `has_zero_morphisms` instances will not be definitionally equal. For this reason library
    code should generally ask for an instance of `has_zero_morphisms` separately, even if it already
    asks for an instance of `has_zero_objects`. -/
def zero_morphisms_of_zero_object : has_zero_morphisms.{v} C :=
```

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
