### PR TITLE
fix(scripts/mk_nolint): fix error introduced by #2090

### DIFF
--- a/scripts/mk_nolint.lean
+++ b/scripts/mk_nolint.lean
@@ -26,7 +26,7 @@ open native
 
 /-- Runs when called with `lean --run` -/
 meta def main : io unit := do
-e ← run_tactic get_env,
+e ← run_tactic tactic.get_env,
 decls ← run_tactic lint_mathlib_decls,
 let non_auto_decls := decls.filter (λ d, ¬ d.to_name.is_internal ∧ ¬ d.is_auto_generated e),
 linters ← run_tactic $ get_linters mathlib_linters,


### PR DESCRIPTION
`mk_nolint.lean` was changed in #2090 but didn't compile.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
