### PR TITLE
feat(category_theory/limits): the isomorphism expressing preservation of chosen limits

### DIFF
--- a/src/category_theory/limits/limits.lean
+++ b/src/category_theory/limits/limits.lean
@@ -256,7 +256,7 @@ def unique_up_to_iso {s t : cocone F} (P : is_colimit s) (Q : is_colimit t) : s 
   hom_inv_id' := P.uniq_cocone_morphism,
   inv_hom_id' := Q.uniq_cocone_morphism }
 
-/-- Limits of `F` are unique up to isomorphism. -/
+/-- Colimits of `F` are unique up to isomorphism. -/
 -- We may later want to prove the coherence of these isomorphisms.
 def cone_point_unique_up_to_iso {s t : cocone F} (P : is_colimit s) (Q : is_colimit t) : s.X ≅ t.X :=
 (cocones.forget F).map_iso (unique_up_to_iso P Q)

--- a/src/category_theory/limits/limits.lean
+++ b/src/category_theory/limits/limits.lean
@@ -63,6 +63,11 @@ def unique_up_to_iso {s t : cone F} (P : is_limit s) (Q : is_limit t) : s ≅ t 
   hom_inv_id' := P.uniq_cone_morphism,
   inv_hom_id' := Q.uniq_cone_morphism }
 
+/-- Limits of `F` are unique up to isomorphism. -/
+-- We may later want to prove the coherence of these isomorphisms.
+def cone_point_unique_up_to_iso {s t : cone F} (P : is_limit s) (Q : is_limit t) : s.X ≅ t.X :=
+(cones.forget F).map_iso (unique_up_to_iso P Q)
+
 def of_iso_limit {r t : cone F} (P : is_limit r) (i : r ≅ t) : is_limit t :=
 is_limit.mk_cone_morphism
   (λ s, P.lift_cone_morphism s ≫ i.hom)
@@ -250,6 +255,11 @@ def unique_up_to_iso {s t : cocone F} (P : is_colimit s) (Q : is_colimit t) : s 
   inv := Q.desc_cocone_morphism s,
   hom_inv_id' := P.uniq_cocone_morphism,
   inv_hom_id' := Q.uniq_cocone_morphism }
+
+/-- Limits of `F` are unique up to isomorphism. -/
+-- We may later want to prove the coherence of these isomorphisms.
+def cone_point_unique_up_to_iso {s t : cocone F} (P : is_colimit s) (Q : is_colimit t) : s.X ≅ t.X :=
+(cocones.forget F).map_iso (unique_up_to_iso P Q)
 
 def of_iso_colimit {r t : cocone F} (P : is_colimit r) (i : r ≅ t) : is_colimit t :=
 is_colimit.mk_cocone_morphism

--- a/src/category_theory/limits/preserves.lean
+++ b/src/category_theory/limits/preserves.lean
@@ -49,6 +49,15 @@ class preserves_limit (K : J ⥤ C) (F : C ⥤ D) : Type (max u₁ u₂ v) :=
 class preserves_colimit (K : J ⥤ C) (F : C ⥤ D) : Type (max u₁ u₂ v) :=
 (preserves : Π {c : cocone K}, is_colimit c → is_colimit (F.map_cocone c))
 
+/-- A functor which preserves limits preserves chosen limits up to isomorphism. -/
+def preserves_limit_iso (K : J ⥤ C) [has_limit.{v} K] (F : C ⥤ D) [has_limit.{v} (K ⋙ F)] [preserves_limit K F] :
+  F.obj (limit K) ≅ limit (K ⋙ F) :=
+is_limit.cone_point_unique_up_to_iso (preserves_limit.preserves F (limit.is_limit K)) (limit.is_limit (K ⋙ F))
+/-- A functor which preserves colimits preserves chosen colimits up to isomorphism. -/
+def preserves_colimit_iso (K : J ⥤ C) [has_colimit.{v} K] (F : C ⥤ D) [has_colimit.{v} (K ⋙ F)] [preserves_colimit K F] :
+  F.obj (colimit K) ≅ colimit (K ⋙ F) :=
+is_colimit.cone_point_unique_up_to_iso (preserves_colimit.preserves F (colimit.is_colimit K)) (colimit.is_colimit (K ⋙ F))
+
 class preserves_limits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) : Type (max u₁ u₂ v) :=
 (preserves_limit : Π {K : J ⥤ C}, preserves_limit K F)
 class preserves_colimits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) : Type (max u₁ u₂ v) :=


### PR DESCRIPTION
The type class `preserves_limits` is written in terms of the `is_limits` data, but had not been related to the `has_limits` typeclass, which expresses a particular chosen limit for a functor.

The function `preserves_limit_iso` gives the isomorphism between the image of the chosen limit, `F.obj (limit K)`, and the chosen limit of the composed functor, `limit (K ⋙ F)`.