### PR TITLE
feat(tactic): rewriting along equivalences

### DIFF
--- a/src/tactic/equiv_rw.lean
+++ b/src/tactic/equiv_rw.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2019 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import data.equiv.basic
+
+/-!
+# The `equiv_rw` tactic, which transports goals or hypotheses along equivalences.
+
+This is a very preliminary implementation.
+Really, we would like to be able to be able to rewrite under functors,
+but this will require more tooling.
+-/
+
+namespace tactic
+
+/--
+Attempt to replace the hypothesis with name `x : α`
+by transporting it along the equivalence in `e : α ≃ β`.
+-/
+meta def equiv_rw_hyp (x : name) (e : expr) : tactic unit :=
+do x' ← get_local x,
+   ty ← infer_type x',
+   -- We establish `h : x = e.symm (e x)`.
+   eq ← to_expr ``(%%x' = equiv.symm %%e (%%e %%x')),
+   prf ← to_expr ``((equiv.symm_apply_apply %%e %%x').symm),
+   h ← assertv_fresh eq prf,
+   -- Revert the new hypothesis, so it is also part of the goal.
+   revert h,
+   ex ← to_expr ``(%%e %%x'),
+   -- Now call `generalize`,
+   -- attempting to replace all occurrences of `e x`,
+   -- calling it for now `j : β`, with `k : x = e.symm j`.
+   generalize ex (by apply_opt_param) transparency.none,
+   j ← mk_fresh_name,
+   intro j,
+   k ← mk_fresh_name,
+   -- Finally, we subst along `k`, hopefully removing all the occurrences of the original `x`,
+   intro k >>= subst,
+   -- and then rename `j` back to `x`.
+   rename j x,
+   skip
+
+end tactic
+
+
+namespace tactic.interactive
+open lean.parser
+open interactive interactive.types
+open tactic
+
+local postfix `?`:9001 := optional
+
+/--
+`equiv_rw e at h`, where `h : α` is a hypothesis, and `e : α ≃ β`,
+will attempt to transport `h` along `e`, producing a new hypothesis `h : β`,
+with all occurrences of `h` in other hypotheses and the goal replaced with `e.symm h`.
+
+`equiv_rw e` is simply `apply e.inv_fun`, i.e. with `e : α ≃ β`, it turns a goal
+of `⊢ α` into `⊢ β`.
+-/
+-- PROJECT Can we `equiv_rw` under lawful (type-level) functors?
+-- PROJECT More generally, rewriting along isomorphisms, under functors.
+-- (See the `hygienic` branch of mathlib.)
+meta def equiv_rw (e : parse texpr) (loc : parse $ (tk "at" *> ident)?) : itactic :=
+do e ← to_expr e,
+   match loc with
+   | (some hyp) := tactic.equiv_rw_hyp hyp e
+   | none := do s ← to_expr ``(equiv.inv_fun %%e),
+                tactic.apply s,
+                skip
+   end
+
+add_tactic_doc
+{ name        := "equiv_rw",
+  category    := doc_category.tactic,
+  decl_names  := [`tactic.interactive.equiv_rw],
+  tags        := ["rewriting", "equiv", "transport"] }
+
+end tactic.interactive

--- a/src/tactic/equiv_rw.lean
+++ b/src/tactic/equiv_rw.lean
@@ -13,6 +13,18 @@ Really, we would like to be able to be able to rewrite under functors,
 but this will require more tooling.
 -/
 
+namespace functor
+
+/-- The functor sending a type `β` to the functions `α → β`. -/
+-- Note that this can't be found using typeclass search,
+-- because of the way matching handles functions.
+-- TODO Is this already in the library somewhere?
+def functions_from (α : Type*) : functor (λ β : Type*, α → β) :=
+{ map := λ β γ f g, f ∘ g }
+
+end functor
+
+
 namespace tactic
 
 /--
@@ -47,7 +59,9 @@ do x' ← get_local x,
 calling `apply functor.map` as many times as necessary first.
 -/
 meta def unroll_functors (t : tactic unit) :=
-t <|> (`[apply functor.map] >> unroll_functors)
+t <|>
+((`[apply functor.map] <|>
+  `[apply @functor.map _ (@functor.functions_from _)]) >> unroll_functors)
 
 end tactic
 
@@ -72,7 +86,10 @@ a goal of `⊢ option α` into `⊢ option β`.
 (Note that rewriting hypotheses does not understand functors.)
 -/
 -- PROJECT Rewriting hypotheses under functors.
--- PROJECT More generally, rewriting along isomorphisms, under functors.
+-- PROJECT
+-- Many constructions are not strictly functorial,
+-- but are functorial with respect to `≃`.
+-- PROJECT More generally, rewriting along categorical isomorphisms, under functors.
 -- (See the `hygienic` branch of mathlib.)
 meta def equiv_rw (e : parse texpr) (loc : parse $ (tk "at" *> ident)?) : itactic :=
 do e ← to_expr e,

--- a/test/equiv_rw.lean
+++ b/test/equiv_rw.lean
@@ -32,17 +32,16 @@ begin
   exact b,
 end
 
--- PROJECT
--- Much more ambitiously, we could analyse whether types have been constructed functorially,
--- and perform equiv_rw under functors.
--- PROJECT
--- Of course this applies in arbitrary categories, not just `Type`.
-example : is_lawful_functor option := by apply_instance
-
+-- We can rewrite the goal under functors.
 example {α β : Type} (e : α ≃ β) (b : β) : option α :=
 begin
-  -- equiv_rw e, -- fails, but could be made to work!
-  apply option.some,
   equiv_rw e,
-  exact b,
+  exact some b,
+end
+
+-- Even under multiple functors.
+example {α β : Type} (e : α ≃ β) (b : β) : list (option α) :=
+begin
+  equiv_rw e,
+  exact [none, some b],
 end

--- a/test/equiv_rw.lean
+++ b/test/equiv_rw.lean
@@ -32,6 +32,13 @@ begin
   exact b,
 end
 
+-- Fail if the equivalence can't be used.
+example {α β γ : Type} (e : β ≃ γ) (a : α) : α :=
+begin
+  success_if_fail { equiv_rw e },
+  exact a,
+end
+
 -- We can rewrite the goal under functors.
 example {α β : Type} (e : α ≃ β) (b : β) : option α :=
 begin
@@ -40,14 +47,28 @@ begin
 end
 
 -- Check that we can rewrite in the target position of function types.
-example {α β γ : Type} (e : α ≃ β) (b : γ → β) : γ → α :=
+example {α β γ : Type} (e : α ≃ β) (f : γ → β) : γ → α :=
 begin
   equiv_rw e,
-  exact b,
+  exact f,
+end
+
+-- Check that we can rewrite in the source position of function types.
+example {α β γ : Type} (e : α ≃ β) (f : β → γ) : α → γ :=
+begin
+  equiv_rw e,
+  exact f,
 end
 
 -- Rewriting under multiple functors.
 example {α β : Type} (e : α ≃ β) (b : β) : list (option α) :=
+begin
+  equiv_rw e,
+  exact [none, some b],
+end
+
+-- Rewriting the other way under multiple functors.
+example {α β : Type} (e : β ≃ α) (b : β) : list (option α) :=
 begin
   equiv_rw e,
   exact [none, some b],

--- a/test/equiv_rw.lean
+++ b/test/equiv_rw.lean
@@ -6,7 +6,8 @@ Authors: Scott Morrison
 import tactic.equiv_rw
 
 -- Rewriting a hypothesis along an equivalence.
-example {α β : Type} (e : α ≃ β) (f : α → ℕ) (h : ∀ b : β, f (e.symm b) = 0) (i : α) : f i = 0 :=
+example {α β : Type} (e : α ≃ β)
+  (f : α → ℕ) (h : ∀ b : β, f (e.symm b) = 0) (i : α) : f i = 0 :=
 begin
   equiv_rw e at i,
   apply h,
@@ -18,6 +19,8 @@ example {α β : Type} (e : α ≃ β) (Z : α → Type) (f : Π a, Z a → ℕ)
   (i : α) (x : Z i) : f i x = 0 :=
 begin
   equiv_rw e at i,
+  guard_hyp i := β,
+  guard_target f (e.symm i) x = 0,
   guard_hyp x := Z ((e.symm) i),
   exact h i x,
 end

--- a/test/equiv_rw.lean
+++ b/test/equiv_rw.lean
@@ -39,9 +39,23 @@ begin
   exact some b,
 end
 
--- Even under multiple functors.
+-- Check that we can rewrite in the target position of function types.
+example {α β γ : Type} (e : α ≃ β) (b : γ → β) : γ → α :=
+begin
+  equiv_rw e,
+  exact b,
+end
+
+-- Rewriting under multiple functors.
 example {α β : Type} (e : α ≃ β) (b : β) : list (option α) :=
 begin
   equiv_rw e,
   exact [none, some b],
+end
+
+-- Rewriting under multiple functors, including functions.
+example {α β γ : Type} (e : α ≃ β) (b : β) : γ → list (option α) :=
+begin
+  equiv_rw e,
+  exact (λ g, [none, some b]),
 end

--- a/test/equiv_rw.lean
+++ b/test/equiv_rw.lean
@@ -1,0 +1,40 @@
+import tactic.equiv_rw
+
+-- Rewriting a hypothesis along an equivalence.
+example {α β : Type} (e : α ≃ β) (f : α → ℕ) (h : ∀ b : β, f (e.symm b) = 0) (i : α) : f i = 0 :=
+begin
+  equiv_rw e at i,
+  apply h,
+end
+
+-- Check that dependent hypotheses are reverted and reintroduced.
+example {α β : Type} (e : α ≃ β) (Z : α → Type) (f : Π a, Z a → ℕ)
+  (h : ∀ (b : β) (x : Z (e.symm b)), f (e.symm b) x = 0)
+  (i : α) (x : Z i) : f i x = 0 :=
+begin
+  equiv_rw e at i,
+  guard_hyp x := Z ((e.symm) i),
+  exact h i x,
+end
+
+-- Rewriting the goal along an equivalence.
+example {α β : Type} (e : α ≃ β) (b : β) : α :=
+begin
+  equiv_rw e,
+  exact b,
+end
+
+-- PROJECT
+-- Much more ambitiously, we could analyse whether types have been constructed functorially,
+-- and perform eq_rw under functors.
+-- PROJECT
+-- Of course this applies in arbitrary categories, not just `Type`.
+example : is_lawful_functor option := by apply_instance
+
+example {α β : Type} (e : α ≃ β) (b : β) : option α :=
+begin
+  -- equiv_rw e, -- fails, but could be made to work!
+  apply option.some,
+  equiv_rw e,
+  exact b,
+end

--- a/test/equiv_rw.lean
+++ b/test/equiv_rw.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2019 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
 import tactic.equiv_rw
 
 -- Rewriting a hypothesis along an equivalence.

--- a/test/equiv_rw.lean
+++ b/test/equiv_rw.lean
@@ -34,7 +34,7 @@ end
 
 -- PROJECT
 -- Much more ambitiously, we could analyse whether types have been constructed functorially,
--- and perform eq_rw under functors.
+-- and perform equiv_rw under functors.
 -- PROJECT
 -- Of course this applies in arbitrary categories, not just `Type`.
 example : is_lawful_functor option := by apply_instance


### PR DESCRIPTION
From the doc-string:

```
/--
`equiv_rw e at h`, where `h : α` is a hypothesis, and `e : α ≃ β`,
will attempt to transport `h` along `e`, producing a new hypothesis `h : β`,
with all occurrences of `h` in other hypotheses and the goal replaced with `e.symm h`.

`equiv_rw e` tries `apply e.inv_fun`,
so with `e : α ≃ β`, it turns a goal of `⊢ α` into `⊢ β`.
It will also try rewriting under functors, so it can also turn
a goal of `⊢ option α` into `⊢ option β`.

(Note that rewriting hypotheses does not understand functors.)
-/
-- PROJECT Rewriting hypotheses under functors.
-- PROJECT More generally, rewriting along isomorphisms, under functors.
```
and from the tests:
```
example {α β : Type} (e : α ≃ β) (Z : α → Type) (f : Π a, Z a → ℕ)
  (h : ∀ (b : β) (x : Z (e.symm b)), f (e.symm b) x = 0)
  (i : α) (x : Z i) : f i x = 0 :=
begin
  equiv_rw e at i,
  guard_hyp i := β,
  guard_target f (e.symm i) x = 0,
  guard_hyp x := Z ((e.symm) i),
  exact h i x,
end
```
and
```
example {α β : Type} (e : α ≃ β) (b : β) : list (option α) :=
begin
  equiv_rw e,
  exact [none, some b],
end
```