### PR TITLE
doc(docs/contribute/index.md): remove obsolete recommendation to use lean-3.7.2 branch

### DIFF
--- a/docs/contribute/index.md
+++ b/docs/contribute/index.md
@@ -18,12 +18,7 @@ to make the process of contributing as smooth as possible.
    as explained in the link above, or from a branch of the main repository if you have commit access (you can ask for access on Zulip).
 4. If you've made a lot of changes/additions, try to make many PRs containing small, self-contained pieces. This helps you get feedback as you go along, and it is much easier to review. This is especially important for new contributors.
 5. You can use `leanproject get-cache` to fetch `.olean` binaries.
-  The `.olean` binaries take two hours to generate, so they might not yet be available if you're on the master branch.
-  If you checkout the remote branch `lean-3.X.Y` (where `3.X.Y` stands for the version in mathlib's `leanpkg.toml`)
-  then you can always get olean binaries:
    ```
-   git fetch --all
-   git checkout origin/lean-3.X.Y
    leanproject get-cache
    git checkout -b my_new_feature
    ```


### PR DESCRIPTION
Just noticed this in #2203.  Since #2094 we no longer need to wait for oleans on the master branch, so there's no reason to recommend the `lean-*` branches anymore.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/test/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/contribute/code-review.md)
