### PR TITLE
chore(linear_algebra/*): rename copair, pair to coprod, prod

### DIFF
--- a/archive/sensitivity.lean
+++ b/archive/sensitivity.lean
@@ -254,7 +254,7 @@ noncomputable def f : Π n, V n →ₗ[ℝ] V n
              (linear_map.coprod (f n) linear_map.id)
              (linear_map.coprod linear_map.id (-f n))
 
-/-! The preceding definition use linear map constructions to automatically
+/-! The preceding definition uses linear map constructions to automatically
 get that `f` is linear, but its values are somewhat buried as a side-effect.
 The next two lemmas unbury them. -/
 

--- a/archive/sensitivity.lean
+++ b/archive/sensitivity.lean
@@ -1,5 +1,6 @@
 /-
-Copyright (c) 2019 Reid Barton, Johan Commelin, Jesse Han, Chris Hughes, Robert Y. Lewis, and Patrick Massot. All rights reserved.
+Copyright (c) 2019 Reid Barton, Johan Commelin, Jesse Han, Chris Hughes, Robert Y. Lewis, and
+Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Reid Barton, Johan Commelin, Jesse Han, Chris Hughes, Robert Y. Lewis, and Patrick Massot
 -/
@@ -11,6 +12,8 @@ import linear_algebra.dual
 import analysis.normed_space.basic
 
 /-!
+# Huang's sensitivity theorem
+
 A formalization of Hao Huang's sensitivity theorem: in the hypercube of
 dimension n ≥ 1, if one colors more than half the vertices then at least one
 vertex has at least √n colored neighbors.
@@ -29,8 +32,8 @@ The project was developed at https://github.com/leanprover-community/lean-sensit
 and is now archived at https://github.com/leanprover-community/mathlib/blob/master/archive/sensitivity.lean
 -/
 
--- The next two lines assert we do not want to give a constructive proof,
--- but rather use classical logic.
+/-! The next two lines assert we do not want to give a constructive proof,
+but rather use classical logic. -/
 noncomputable theory
 open_locale classical
 
@@ -39,38 +42,35 @@ notation `√` := real.sqrt
 
 open function bool linear_map fintype finite_dimensional dual_pair
 
-/- -------------------------------------------------------------------------\
-|  The hypercube.                                                           |
-\---------------------------------------------------------------------------/
+/-! ### The hypercube
 
-/-
 Notations:
-ℕ denotes natural numbers (including zero).
-fin n = {0, ⋯ , n - 1}.
-bool = {tt, ff}.
+- `ℕ` denotes natural numbers (including zero).
+- `fin n` = {0, ⋯ , n - 1}.
+- `bool` = {`tt`, `ff`}.
 -/
 
 /-- The hypercube in dimension n. -/
 @[derive [inhabited, fintype]] def Q (n : ℕ) := fin n → bool
 
-/-- The projection from Q (n + 1) to Q n forgetting the first value
+/-- The projection from `Q (n + 1)` to `Q n` forgetting the first value
 (ie. the image of zero). -/
 def π {n : ℕ} : Q (n + 1) → Q n := λ p, p ∘ fin.succ
 
 namespace Q
--- n will always denote a natural number.
+/-! `n` will always denote a natural number. -/
 variable (n : ℕ)
 
-/-- Q 0 has a unique element. -/
+/-- `Q 0` has a unique element. -/
 instance : unique (Q 0) :=
 ⟨⟨λ _, tt⟩, by { intro, ext x, fin_cases x }⟩
 
-/-- Q n has 2^n elements. -/
+/-- `Q n` has 2^n elements. -/
 lemma card : card (Q n) = 2^n :=
 by simp [Q]
 
--- Until the end of this namespace, n will be an implicit argument (still
--- a natural number).
+/-! Until the end of this namespace, `n` will be an implicit argument (still
+a natural number). -/
 variable {n}
 
 lemma succ_n_eq (p q : Q (n+1)) : p = q ↔ (p 0 = q 0 ∧ π p = π q) :=
@@ -85,16 +85,16 @@ begin
       convert congr_fun h (fin.pred x hx) } }
 end
 
-/-- The adjacency relation defining the graph structure on Q n:
-p.adjacent q if there is an edge from p to q in Q n -/
+/-- The adjacency relation defining the graph structure on `Q n`:
+`p.adjacent q` if there is an edge from `p` to `q` in `Q n`. -/
 def adjacent {n : ℕ} (p : Q n) : set (Q n) := λ q, ∃! i, p i ≠ q i
 
-/-- In Q 0, no two vertices are adjacent. -/
+/-- In `Q 0`, no two vertices are adjacent. -/
 lemma not_adjacent_zero (p q : Q 0) : ¬ p.adjacent q :=
 by rintros ⟨v, _⟩; apply fin_zero_elim v
 
-/-- If p and q in Q (n+1) have different values at zero then they are adjacent
-iff their projections to Q n are equal. -/
+/-- If `p` and `q` in `Q (n+1)` have different values at zero then they are adjacent
+iff their projections to `Q n` are equal. -/
 lemma adj_iff_proj_eq {p q : Q (n+1)} (h₀ : p 0 ≠ q 0) :
   p.adjacent q ↔ π p = π q :=
 begin
@@ -111,8 +111,8 @@ begin
     apply congr_fun heq }
 end
 
-/-- If p and q in Q (n+1) have the same value at zero then they are adjacent
-iff their projections to Q n are adjacent. -/
+/-- If `p` and `q` in `Q (n+1)` have the same value at zero then they are adjacent
+iff their projections to `Q n` are adjacent. -/
 lemma adj_iff_proj_adj {p q : Q (n+1)} (h₀ : p 0 = q 0) :
   p.adjacent q ↔ (π p).adjacent (π q) :=
 begin
@@ -141,9 +141,7 @@ by simp only [adjacent, ne_comm]
 
 end Q
 
-/- -------------------------------------------------------------------------\
-|  The vector space.                                                        |
-\---------------------------------------------------------------------------/
+/-! ### The vector space -/
 
 /-- The free vector space on vertices of a hypercube, defined inductively. -/
 def V : ℕ → Type
@@ -153,7 +151,7 @@ def V : ℕ → Type
 namespace V
 variables (n : ℕ)
 
--- V n is a real vector space whose equality relation is computable.
+/-! `V n` is a real vector space whose equality relation is computable. -/
 
 instance : decidable_eq (V n) :=
 by { induction n ; { dunfold V, resetI, apply_instance } }
@@ -164,8 +162,8 @@ by { induction n ; { dunfold V, resetI, apply_instance } }
 instance : vector_space ℝ (V n) :=
 by { induction n ; { dunfold V, resetI, apply_instance } }
 
--- The next five definitions are short circuits helping Lean to quickly find
--- relevant structures on V n
+/-! The next five definitions are short circuits helping Lean to quickly find
+relevant structures on `V n` -/
 def module : module ℝ (V n) := by apply_instance
 def add_comm_semigroup : add_comm_semigroup (V n) := by apply_instance
 def add_comm_monoid : add_comm_monoid (V n) := by apply_instance
@@ -177,14 +175,14 @@ end V
 local attribute [instance, priority 100000]
   V.module V.add_comm_semigroup V.add_comm_monoid V.has_scalar V.has_add
 
-/-- The basis of V indexed by the hypercube, defined inductively. -/
+/-- The basis of `V` indexed by the hypercube, defined inductively. -/
 noncomputable def e : Π {n}, Q n → V n
 | 0     := λ _, (1:ℝ)
 | (n+1) := λ x, cond (x 0) (e (π x), 0) (0, e (π x))
 
 @[simp] lemma e_zero_apply (x : Q 0) : e x = (1 : ℝ) := rfl
 
-/-- The dual basis to e, defined inductively. -/
+/-- The dual basis to `e`, defined inductively. -/
 noncomputable def ε : Π {n : ℕ} (p : Q n), V n →ₗ[ℝ] ℝ
 | 0 _ := linear_map.id
 | (n+1) p := cond (p 0) ((ε $ π p).comp $ linear_map.fst _ _ _) ((ε $ π p).comp $ linear_map.snd _ _ _)
@@ -210,7 +208,7 @@ begin
         simp [this] } } }
 end
 
-/-- Any vector in V n annihilated by all ε p's is zero. -/
+/-- Any vector in `V n` annihilated by all `ε p`'s is zero. -/
 lemma epsilon_total {v : V n} (h : ∀ p : Q n, (ε p) v = 0) : v = 0 :=
 begin
   induction n with n ih,
@@ -225,14 +223,14 @@ begin
       rwa show p = π q, by { ext, simp [q, fin.succ_ne_zero, π] } } }
 end
 
-/-- e and ε are dual families of vectors. It implies that e is indeed a basis
-and ε computes coefficients of decompositions of vectors on that basis. -/
+/-- `e` and `ε` are dual families of vectors. It implies that `e` is indeed a basis
+and `ε` computes coefficients of decompositions of vectors on that basis. -/
 def dual_pair_e_ε (n : ℕ) : dual_pair (@e n) (@ε n) :=
 { eval := duality,
   total := @epsilon_total _ }
 
--- We will now derive the dimension of V, first as a cardinal in dim_V and,
--- since this cardinal is finite, as a natural number in findim_V
+/-! We will now derive the dimension of `V`, first as a cardinal in `dim_V` and,
+since this cardinal is finite, as a natural number in `findim_V` -/
 
 lemma dim_V : vector_space.dim ℝ (V n) = 2^n :=
 have vector_space.dim ℝ (V n) = ↑(2^n : ℕ),
@@ -246,21 +244,19 @@ lemma findim_V : findim ℝ (V n) = 2^n :=
 have _ := @dim_V n,
 by rw ←findim_eq_dim at this; assumption_mod_cast
 
-/- -------------------------------------------------------------------------\
-|  The linear map.                                                          |
-\---------------------------------------------------------------------------/
+/-! ### The linear map -/
 
-/-- The linear operator f_n corresponding to Huang's matrix A_n,
-defined inductively as a ℝ-linear map from V n to V n. -/
+/-- The linear operator $f_n$ corresponding to Huang's matrix $A_n$,
+defined inductively as a ℝ-linear map from `V n` to `V n`. -/
 noncomputable def f : Π n, V n →ₗ[ℝ] V n
 | 0 := 0
-| (n+1) := linear_map.pair
-             (linear_map.copair (f n) linear_map.id)
-             (linear_map.copair linear_map.id (-f n))
+| (n+1) := linear_map.prod
+             (linear_map.coprod (f n) linear_map.id)
+             (linear_map.coprod linear_map.id (-f n))
 
--- The preceding definition use linear map constructions to automatically
--- get that f is linear, but its values are somewhat buried as a side-effect.
--- The next two lemmas unbury them.
+/-! The preceding definition use linear map constructions to automatically
+get that `f` is linear, but its values are somewhat buried as a side-effect.
+The next two lemmas unbury them. -/
 
 @[simp] lemma f_zero : f 0 = 0 := rfl
 
@@ -269,14 +265,14 @@ lemma f_succ_apply (v : V (n+1)) :
 begin
   cases v,
   rw f,
-  simp only [linear_map.id_apply, linear_map.pair_apply, prod.mk.inj_iff,
-    linear_map.neg_apply, sub_eq_add_neg, linear_map.copair_apply],
+  simp only [linear_map.id_apply, linear_map.prod_apply, prod.mk.inj_iff,
+    linear_map.neg_apply, sub_eq_add_neg, linear_map.coprod_apply],
   exact ⟨rfl, rfl⟩
 end
 
--- In the next statement, the explicit conversion (n : ℝ) of n to a real number
--- is necessary since otherwise `n • v` refers to the multiplication defined
--- using only the addition of V.
+/-! In the next statement, the explicit conversion `(n : ℝ)` of `n` to a real number
+is necessary since otherwise `n • v` refers to the multiplication defined
+using only the addition of `V`. -/
 
 lemma f_squared : ∀ v : V n, (f n) (f n v) = (n : ℝ) • v :=
 begin
@@ -285,8 +281,8 @@ begin
   { cases v, simp [f_succ_apply, IH, add_smul], abel }
 end
 
--- We now compute the matrix of f in the e basis (p is the line index,
--- q the column index.)
+/-! We now compute the matrix of `f` in the `e` basis (p is the line index,
+`q` the column index). -/
 
 lemma f_matrix :
   ∀ p q : Q n, |ε q (f n (e p))| = if q.adjacent p then 1 else 0 :=
@@ -307,14 +303,14 @@ begin
       congr' 1 } }
 end
 
-/-- The linear operator g_m corresponding to Knuth's matrix B_m. -/
+/-- The linear operator $g_m$ corresponding to Knuth's matrix $B_m$. -/
 noncomputable def g (m : ℕ) : V m →ₗ[ℝ] V (m+1) :=
-linear_map.pair (f m + √(m+1) • linear_map.id) linear_map.id
+linear_map.prod (f m + √(m+1) • linear_map.id) linear_map.id
 
--- in the following lemmas, m will denote a natural number
+/-! In the following lemmas, `m` will denote a natural number. -/
 variables {m : ℕ}
 
--- again we unpack what are the values of g
+/-! Again we unpack what are the values of `g`. -/
 lemma g_apply : ∀ v, g m v = (f m v + √(m+1) • v, v) :=
 by delta g; simp
 
@@ -322,7 +318,7 @@ lemma g_injective : injective (g m) :=
 begin
   rw g,
   intros x₁ x₂ h,
-  simp only [linear_map.pair_apply, linear_map.id_apply, prod.mk.inj_iff] at h,
+  simp only [linear_map.prod_apply, linear_map.id_apply, prod.mk.inj_iff] at h,
   exact h.right
 end
 
@@ -336,28 +332,26 @@ begin
   abel
 end
 
-/- -------------------------------------------------------------------------\
-|  The main proof.                                                          |
-\---------------------------------------------------------------------------/
+/-! ### The main proof
 
--- In this section, in order to enforce that n is positive, we write it as
--- m + 1 for some natural number m.
+In this section, in order to enforce that `n` is positive, we write it as
+`m + 1` for some natural number `m`. -/
 
--- dim X will denote the dimension of a subspace X as a cardinal
+/-! `dim X` will denote the dimension of a subspace `X` as a cardinal. -/
 notation `dim` X:70 := vector_space.dim ℝ ↥X
--- fdim X will denote the (finite) dimension of a subspace X as a natural number
+/-! `fdim X` will denote the (finite) dimension of a subspace `X` as a natural number. -/
 notation `fdim` := findim ℝ
 
--- Span S will denote the ℝ-subspace spanned by S
+/-! `Span S` will denote the ℝ-subspace spanned by `S`. -/
 notation `Span` := submodule.span ℝ
 
--- Card X will denote the cardinal of a subset of a finite type, as a
--- natural number.
+/-! `Card X` will denote the cardinal of a subset of a finite type, as a
+natural number. -/
 notation `Card` X:70 := X.to_finset.card
 
--- In the following, ⊓ and ⊔ will denote intersection and sums of ℝ-subspaces,
--- equipped with their subspace structures. The notations come from the general
--- theory of lattices, with inf and sup (also known as meet and join).
+/-! In the following, `⊓` and `⊔` will denote intersection and sums of ℝ-subspaces,
+equipped with their subspace structures. The notations come from the general
+theory of lattices, with inf and sup (also known as meet and join). -/
 
 /-- If a subset H of Q (m+1) has cardinal at least 2^m + 1 then the
 subspace of V (m+1) spanned by the corresponding basis vectors non-trivially

--- a/archive/sensitivity.lean
+++ b/archive/sensitivity.lean
@@ -22,7 +22,7 @@ A fun summer collaboration by
 Reid Barton, Johan Commelin, Jesse Han, Chris Hughes, Robert Y. Lewis, and Patrick Massot,
 based on Don Knuth's account of the story
 (https://www.cs.stanford.edu/~knuth/papers/huang.pdf),
-using the Lean theorem prover (http://leanprover.github.io/),
+using the Lean theorem prover (https://leanprover.github.io/),
 by Leonardo de Moura at Microsoft Research, and his collaborators
 (https://leanprover.github.io/people/),
 and using Lean's user maintained mathematics library
@@ -50,7 +50,7 @@ Notations:
 - `bool` = {`tt`, `ff`}.
 -/
 
-/-- The hypercube in dimension n. -/
+/-- The hypercube in dimension `n`. -/
 @[derive [inhabited, fintype]] def Q (n : ℕ) := fin n → bool
 
 /-- The projection from `Q (n + 1)` to `Q n` forgetting the first value
@@ -163,7 +163,7 @@ instance : vector_space ℝ (V n) :=
 by { induction n ; { dunfold V, resetI, apply_instance } }
 
 /-! The next five definitions are short circuits helping Lean to quickly find
-relevant structures on `V n` -/
+relevant structures on `V n`. -/
 def module : module ℝ (V n) := by apply_instance
 def add_comm_semigroup : add_comm_semigroup (V n) := by apply_instance
 def add_comm_monoid : add_comm_monoid (V n) := by apply_instance
@@ -281,7 +281,7 @@ begin
   { cases v, simp [f_succ_apply, IH, add_smul], abel }
 end
 
-/-! We now compute the matrix of `f` in the `e` basis (p is the line index,
+/-! We now compute the matrix of `f` in the `e` basis (`p` is the line index,
 `q` the column index). -/
 
 lemma f_matrix :
@@ -332,7 +332,8 @@ begin
   abel
 end
 
-/-! ### The main proof
+/-!
+### The main proof
 
 In this section, in order to enforce that `n` is positive, we write it as
 `m + 1` for some natural number `m`. -/
@@ -353,9 +354,9 @@ notation `Card` X:70 := X.to_finset.card
 equipped with their subspace structures. The notations come from the general
 theory of lattices, with inf and sup (also known as meet and join). -/
 
-/-- If a subset H of Q (m+1) has cardinal at least 2^m + 1 then the
-subspace of V (m+1) spanned by the corresponding basis vectors non-trivially
-intersects the range of g m. -/
+/-- If a subset `H` of `Q (m+1)` has cardinal at least `2^m + 1` then the
+subspace of `V (m+1)` spanned by the corresponding basis vectors non-trivially
+intersects the range of `g m`. -/
 lemma exists_eigenvalue (H : set (Q (m + 1))) (hH : Card H ≥ 2^m + 1) :
   ∃ y ∈ Span (e '' H) ⊓ (g m).range, y ≠ (0 : _) :=
 begin

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1513,7 +1513,7 @@ variables [module R M] [module R M₂] [module R M₃]
 variables (f : M →ₗ[R] M₂)
 
 /-- The first isomorphism law for modules. The quotient of `M` by the kernel of `f` is linearly
-equivalent to the range of `f`.  -/
+equivalent to the range of `f`. -/
 noncomputable def quot_ker_equiv_range : f.ker.quotient ≃ₗ[R] f.range :=
 have hr : ∀ x : f.range, ∃ y, f y = ↑x := λ x, x.2.imp $ λ _, and.right,
 let F : f.ker.quotient →ₗ[R] f.range :=
@@ -1558,6 +1558,17 @@ noncomputable def sup_quotient_equiv_quotient_inf (p p' : submodule R M) :
       use [⟨y, hy⟩, trivial], apply (submodule.quotient.eq _).2,
       change y - (y + z) ∈ p', rwa [sub_add_eq_sub_sub, sub_self, zero_sub, neg_mem_iff]
     end }
+
+section prod
+
+lemma is_linear_map_prod_iso {R M M₂ M₃ : Type*}
+  [comm_ring R] [add_comm_group M] [add_comm_group M₂]
+  [add_comm_group M₃] [module R M] [module R M₂] [module R M₃] :
+  is_linear_map R (λ(p : (M →ₗ[R] M₂) × (M →ₗ[R] M₃)),
+    (linear_map.prod p.1 p.2 : (M →ₗ[R] (M₂ × M₃)))) :=
+⟨λu v, rfl, λc u, rfl⟩
+
+end prod
 
 section pi
 universe i

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1316,6 +1316,7 @@ section
 set_option old_structure_cmd true
 
 /-- A linear equivalence is an invertible linear map. -/
+@[nolint doc_blame has_inhabited_instance]
 structure linear_equiv (R : Type u) (M : Type v) (M₂ : Type w)
   [ring R] [add_comm_group M] [add_comm_group M₂] [module R M] [module R M₂]
   extends M →ₗ[R] M₂, M ≃ M₂

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -18,7 +18,7 @@ Many of the relevant definitions, including `module`, `submodule`, and `linear_m
 
 ## Main definitions
 
-* Many constructors for linear maps, including `pair` and `copair`
+* Many constructors for linear maps, including `prod` and `coprod`
 * `submodule.span s` is defined to be the smallest submodule containing the set `s`.
 * If `p` is a submodule of `M`, `submodule.quotient p` is the quotient of `M` with respect to `p`:
   that is, elements of `M` are identified if their difference is in `p`. This is itself a module.
@@ -43,7 +43,7 @@ Many of the relevant definitions, including `module`, `submodule`, and `linear_m
 ## Implementation notes
 
 We note that, when constructing linear maps, it is convenient to use operations defined on bundled
-maps (`pair`, `copair`, arithmetic operations like `+`) instead of defining a function and proving
+maps (`prod`, `coprod`, arithmetic operations like `+`) instead of defining a function and proving
 it is linear.
 
 ## Tags
@@ -220,20 +220,22 @@ end
 @[simp] theorem fst_apply (x : M × M₂) : fst R M M₂ x = x.1 := rfl
 @[simp] theorem snd_apply (x : M × M₂) : snd R M M₂ x = x.2 := rfl
 
-/-- The pair of two linear maps is a linear map. -/
-def pair (f : M →ₗ[R] M₂) (g : M →ₗ[R] M₃) : M →ₗ[R] M₂ × M₃ :=
-⟨λ x, (f x, g x), λ x y, by simp, λ x y, by simp⟩
+/-- The prod of two linear maps is a linear map. -/
+def prod (f : M →ₗ[R] M₂) (g : M →ₗ[R] M₃) : M →ₗ[R] M₂ × M₃ :=
+{ to_fun := λ x, (f x, g x),
+  add := λ x y, by simp only [prod.mk_add_mk, map_add],
+  smul := λ c x, by simp only [prod.smul_mk, map_smul] }
 
-@[simp] theorem pair_apply (f : M →ₗ[R] M₂) (g : M →ₗ[R] M₃) (x : M) :
-  pair f g x = (f x, g x) := rfl
+@[simp] theorem prod_apply (f : M →ₗ[R] M₂) (g : M →ₗ[R] M₃) (x : M) :
+  prod f g x = (f x, g x) := rfl
 
-@[simp] theorem fst_pair (f : M →ₗ[R] M₂) (g : M →ₗ[R] M₃) :
-  (fst R M₂ M₃).comp (pair f g) = f := by ext; refl
+@[simp] theorem fst_prod (f : M →ₗ[R] M₂) (g : M →ₗ[R] M₃) :
+  (fst R M₂ M₃).comp (prod f g) = f := by ext; refl
 
-@[simp] theorem snd_pair (f : M →ₗ[R] M₂) (g : M →ₗ[R] M₃) :
-  (snd R M₂ M₃).comp (pair f g) = g := by ext; refl
+@[simp] theorem snd_prod (f : M →ₗ[R] M₂) (g : M →ₗ[R] M₃) :
+  (snd R M₂ M₃).comp (prod f g) = g := by ext; refl
 
-@[simp] theorem pair_fst_snd : pair (fst R M M₂) (snd R M M₂) = linear_map.id :=
+@[simp] theorem pair_fst_snd : prod (fst R M M₂) (snd R M M₂) = linear_map.id :=
 by ext; refl
 
 section
@@ -250,29 +252,34 @@ end
 @[simp] theorem inl_apply (x : M) : inl R M M₂ x = (x, 0) := rfl
 @[simp] theorem inr_apply (x : M₂) : inr R M M₂ x = (0, x) := rfl
 
-/-- The copair function `λ x : M × M₂, f x.1 + g x.2` is a linear map. -/
-def copair (f : M →ₗ[R] M₃) (g : M₂ →ₗ[R] M₃) : M × M₂ →ₗ[R] M₃ :=
-⟨λ x, f x.1 + g x.2, λ x y, by simp; cc, λ x y, by simp [smul_add]⟩
+/-- The coprod function `λ x : M × M₂, f x.1 + g x.2` is a linear map. -/
+def coprod (f : M →ₗ[R] M₃) (g : M₂ →ₗ[R] M₃) : M × M₂ →ₗ[R] M₃ :=
+{ to_fun := λ x, f x.1 + g x.2,
+  add := λ x y, by simp only [map_add, prod.snd_add, prod.fst_add]; cc,
+  smul := λ x y, by simp only [smul_add, prod.smul_snd, prod.smul_fst, map_smul] }
 
-@[simp] theorem copair_apply (f : M →ₗ[R] M₃) (g : M₂ →ₗ[R] M₃) (x : M) (y : M₂) :
-  copair f g (x, y) = f x + g y := rfl
+@[simp] theorem coprod_apply (f : M →ₗ[R] M₃) (g : M₂ →ₗ[R] M₃) (x : M) (y : M₂) :
+  coprod f g (x, y) = f x + g y := rfl
 
-@[simp] theorem copair_inl (f : M →ₗ[R] M₃) (g : M₂ →ₗ[R] M₃) :
-  (copair f g).comp (inl R M M₂) = f := by ext; simp
+@[simp] theorem coprod_inl (f : M →ₗ[R] M₃) (g : M₂ →ₗ[R] M₃) :
+  (coprod f g).comp (inl R M M₂) = f :=
+by ext; simp only [map_zero, add_zero, coprod_apply, inl_apply, comp_apply]
 
-@[simp] theorem copair_inr (f : M →ₗ[R] M₃) (g : M₂ →ₗ[R] M₃) :
-  (copair f g).comp (inr R M M₂) = g := by ext; simp
+@[simp] theorem coprod_inr (f : M →ₗ[R] M₃) (g : M₂ →ₗ[R] M₃) :
+  (coprod f g).comp (inr R M M₂) = g :=
+by ext; simp only [map_zero, coprod_apply, inr_apply, zero_add, comp_apply]
 
-@[simp] theorem copair_inl_inr : copair (inl R M M₂) (inr R M M₂) = linear_map.id :=
-by ext ⟨x, y⟩; simp
+@[simp] theorem coprod_inl_inr : coprod (inl R M M₂) (inr R M M₂) = linear_map.id :=
+by ext ⟨x, y⟩; simp only [prod.mk_add_mk, add_zero, id_apply, coprod_apply,
+  inl_apply, inr_apply, zero_add]
 
-theorem fst_eq_copair : fst R M M₂ = copair linear_map.id 0 := by ext ⟨x, y⟩; simp
+theorem fst_eq_coprod : fst R M M₂ = coprod linear_map.id 0 := by ext ⟨x, y⟩; simp
 
-theorem snd_eq_copair : snd R M M₂ = copair 0 linear_map.id := by ext ⟨x, y⟩; simp
+theorem snd_eq_coprod : snd R M M₂ = coprod 0 linear_map.id := by ext ⟨x, y⟩; simp
 
-theorem inl_eq_pair : inl R M M₂ = pair linear_map.id 0 := rfl
+theorem inl_eq_prod : inl R M M₂ = prod linear_map.id 0 := rfl
 
-theorem inr_eq_pair : inr R M M₂ = pair 0 linear_map.id := rfl
+theorem inr_eq_prod : inr R M M₂ = prod 0 linear_map.id := rfl
 
 end
 
@@ -291,8 +298,8 @@ instance : module R (M →ₗ[R] M₂) :=
 module.of_core $ by refine { smul := (•), ..};
   intros; ext; simp [smul_add, add_smul, smul_smul]
 
-/-- Composition by `f : M₂ → M₃` is a linear map from the space of linear maps `M → M₂` to the space of
-linear maps `M₂ → M₃`. -/
+/-- Composition by `f : M₂ → M₃` is a linear map from the space of linear maps `M → M₂`
+to the space of linear maps `M₂ → M₃`. -/
 def comp_right (f : M₂ →ₗ[R] M₃) : (M →ₗ[R] M₂) →ₗ[R] (M →ₗ[R] M₃) :=
 ⟨linear_map.comp f,
 λ _ _, linear_map.ext $ λ _, f.2 _ _,
@@ -824,7 +831,8 @@ by simpa using (quotient.eq p : mk x = 0 ↔ _)
 
 instance : has_add (quotient p) :=
 ⟨λ a b, quotient.lift_on₂' a b (λ a b, mk (a + b)) $
- λ a₁ a₂ b₁ b₂ h₁ h₂, (quotient.eq p).2 $ by simpa [sub_eq_add_neg, add_left_comm, add_comm] using add_mem p h₁ h₂⟩
+  λ a₁ a₂ b₁ b₂ h₁ h₂, (quotient.eq p).2 $
+    by simpa [sub_eq_add_neg, add_left_comm, add_comm] using add_mem p h₁ h₂⟩
 
 @[simp] theorem mk_add : (mk (x + y) : quotient p) = mk x + mk y := rfl
 
@@ -1031,14 +1039,17 @@ theorem map_le_map_iff {f : M →ₗ[R] M₂} (hf : ker f = ⊥) {p p'} : map f 
 theorem map_injective {f : M →ₗ[R] M₂} (hf : ker f = ⊥) : injective (map f) :=
 λ p p' h, le_antisymm ((map_le_map_iff hf).1 (le_of_eq h)) ((map_le_map_iff hf).1 (ge_of_eq h))
 
-theorem comap_le_comap_iff {f : M →ₗ[R] M₂} (hf : range f = ⊤) {p p'} : comap f p ≤ comap f p' ↔ p ≤ p' :=
+theorem comap_le_comap_iff {f : M →ₗ[R] M₂} (hf : range f = ⊤) {p p'} :
+  comap f p ≤ comap f p' ↔ p ≤ p' :=
 ⟨λ H x hx, by rcases range_eq_top.1 hf x with ⟨y, hy, rfl⟩; exact H hx, comap_mono⟩
 
 theorem comap_injective {f : M →ₗ[R] M₂} (hf : range f = ⊤) : injective (comap f) :=
-λ p p' h, le_antisymm ((comap_le_comap_iff hf).1 (le_of_eq h)) ((comap_le_comap_iff hf).1 (ge_of_eq h))
+λ p p' h, le_antisymm ((comap_le_comap_iff hf).1 (le_of_eq h))
+  ((comap_le_comap_iff hf).1 (ge_of_eq h))
 
-theorem map_copair_prod (f : M →ₗ[R] M₃) (g : M₂ →ₗ[R] M₃) (p : submodule R M) (q : submodule R M₂) :
-  map (copair f g) (p.prod q) = map f p ⊔ map g q :=
+theorem map_coprod_prod (f : M →ₗ[R] M₃) (g : M₂ →ₗ[R] M₃)
+  (p : submodule R M) (q : submodule R M₂) :
+  map (coprod f g) (p.prod q) = map f p ⊔ map g q :=
 begin
   refine le_antisymm _ (sup_le (map_le_iff_le_comap.2 _) (map_le_iff_le_comap.2 _)),
   { rw le_def', rintro _ ⟨x, ⟨h₁, h₂⟩, rfl⟩,
@@ -1047,8 +1058,9 @@ begin
   { exact λ x hx, ⟨(0, x), by simp [hx]⟩ }
 end
 
-theorem comap_pair_prod (f : M →ₗ[R] M₂) (g : M →ₗ[R] M₃) (p : submodule R M₂) (q : submodule R M₃) :
-  comap (pair f g) (p.prod q) = comap f p ⊓ comap g q :=
+theorem comap_prod_prod (f : M →ₗ[R] M₂) (g : M →ₗ[R] M₃)
+  (p : submodule R M₂) (q : submodule R M₃) :
+  comap (prod f g) (p.prod q) = comap f p ⊓ comap g q :=
 submodule.ext $ λ x, iff.rfl
 
 theorem prod_eq_inf_comap (p : submodule R M) (q : submodule R M₂) :
@@ -1057,15 +1069,15 @@ submodule.ext $ λ x, iff.rfl
 
 theorem prod_eq_sup_map (p : submodule R M) (q : submodule R M₂) :
   p.prod q = p.map (linear_map.inl R M M₂) ⊔ q.map (linear_map.inr R M M₂) :=
-by rw [← map_copair_prod, copair_inl_inr, map_id]
+by rw [← map_coprod_prod, coprod_inl_inr, map_id]
 
 lemma span_inl_union_inr {s : set M} {t : set M₂} :
   span R (prod.inl '' s ∪ prod.inr '' t) = (span R s).prod (span R t) :=
 by rw [span_union, prod_eq_sup_map, ← span_image, ← span_image]; refl
 
-lemma ker_pair (f : M →ₗ[R] M₂) (g : M →ₗ[R] M₃) :
-  ker (pair f g) = ker f ⊓ ker g :=
-by rw [ker, ← prod_bot, comap_pair_prod]; refl
+lemma ker_prod (f : M →ₗ[R] M₂) (g : M →ₗ[R] M₃) :
+  ker (prod f g) = ker f ⊓ ker g :=
+by rw [ker, ← prod_bot, comap_prod_prod]; refl
 
 end linear_map
 
@@ -1172,7 +1184,8 @@ def map_subtype.lt_order_embedding :
 (map_subtype.le_order_embedding p).lt_embedding_of_le_embedding
 
 @[simp] theorem map_inl : p.map (inl R M M₂) = prod p ⊥ :=
-by ext ⟨x, y⟩; simp [and.left_comm, eq_comm]
+by ext ⟨x, y⟩; simp only [and.left_comm, eq_comm, mem_map, prod.mk.inj_iff, inl_apply, mem_bot,
+  exists_eq_left', mem_prod]
 
 @[simp] theorem map_inr : q.map (inr R M M₂) = prod ⊥ q :=
 by ext ⟨x, y⟩; simp [and.left_comm, eq_comm]
@@ -1350,7 +1363,8 @@ def trans (e₁ : M ≃ₗ[R] M₂) (e₂ : M₂ ≃ₗ[R] M₃) : M ≃ₗ[R] M
 /-- A linear equivalence is an additive equivalence. -/
 def to_add_equiv (e : M ≃ₗ[R] M₂) : M ≃+ M₂ := { map_add' := e.add, .. e }
 
-@[simp] theorem trans_apply (e₁ : M ≃ₗ[R] M₂) (e₂ : M₂ ≃ₗ[R] M₃) (c : M) : (e₁.trans e₂) c = e₂ (e₁ c) := rfl
+@[simp] theorem trans_apply (e₁ : M ≃ₗ[R] M₂) (e₂ : M₂ ≃ₗ[R] M₃) (c : M) :
+  (e₁.trans e₂) c = e₂ (e₁ c) := rfl
 @[simp] theorem apply_symm_apply (e : M ≃ₗ[R] M₂) (c : M₂) : e (e.symm c) = c := e.6 c
 @[simp] theorem symm_apply_apply (e : M ≃ₗ[R] M₂) (b : M) : e.symm (e b) = b := e.5 b
 
@@ -1368,7 +1382,8 @@ e.to_add_equiv.map_ne_zero_iff
 
 @[simp] theorem symm_symm (e : M ≃ₗ[R] M₂) : e.symm.symm = e := by { cases e, refl }
 
-@[simp] theorem symm_symm_apply (e : M ≃ₗ[R] M₂) (x : M) : e.symm.symm x = e x := by { cases e, refl }
+@[simp] theorem symm_symm_apply (e : M ≃ₗ[R] M₂) (x : M) : e.symm.symm x = e x :=
+by { cases e, refl }
 
 /-- A bijective linear map is a linear equivalence. Here, bijectivity is described by saying that
 the kernel of `f` is `{0}` and the range is the universal set. -/
@@ -1463,8 +1478,8 @@ def arrow_congr {R M₁ M₂ M₂₁ M₂₂ : Sort*} [comm_ring R]
 M into M₃ are linearly isomorphic. -/
 def congr_right (f : M₂ ≃ₗ[R] M₃) : (M →ₗ[R] M₂) ≃ₗ (M →ₗ M₃) := arrow_congr (linear_equiv.refl M) f
 
-/-- If M and M₂ are linearly isomorphic then the two spaces of linear maps from M and M₂ to themselves
-are linearly isomorphic. -/
+/-- If M and M₂ are linearly isomorphic then the two spaces of linear maps from M and M₂ to
+themselves are linearly isomorphic. -/
 def conj (e : M ≃ₗ[R] M₂) : (module.End R M) ≃ₗ[R] (module.End R M₂) := arrow_congr e e
 
 end comm_ring
@@ -1543,27 +1558,6 @@ noncomputable def sup_quotient_equiv_quotient_inf (p p' : submodule R M) :
       use [⟨y, hy⟩, trivial], apply (submodule.quotient.eq _).2,
       change y - (y + z) ∈ p', rwa [sub_add_eq_sub_sub, sub_self, zero_sub, neg_mem_iff]
     end }
-
-section prod
-
-/-- The cartesian product of two linear maps as a linear map. -/
-def prod {R M M₂ M₃ : Type*} [ring R] [add_comm_group M] [add_comm_group M₂] [add_comm_group M₃]
-  [module R M] [module R M₂] [module R M₃]
-  (f₁ : M →ₗ[R] M₂) (f₂ : M →ₗ[R] M₃) : M →ₗ[R] (M₂ × M₃) :=
-{ to_fun := λx, (f₁ x, f₂ x),
-  add := λx y, begin
-    change (f₁ (x + y), f₂ (x+y)) = (f₁ x, f₂ x) + (f₁ y, f₂ y),
-    simp only [linear_map.map_add],
-    refl
-  end,
-  smul := λc x, by simp only [linear_map.map_smul] }
-
-lemma is_linear_map_prod_iso {R M M₂ M₃ : Type*} [comm_ring R] [add_comm_group M] [add_comm_group M₂]
-  [add_comm_group M₃] [module R M] [module R M₂] [module R M₃] :
-  is_linear_map R (λ(p : (M →ₗ[R] M₂) × (M →ₗ[R] M₃)), (linear_map.prod p.1 p.2 : (M →ₗ[R] (M₂ × M₃)))) :=
-⟨λu v, rfl, λc u, rfl⟩
-
-end prod
 
 section pi
 universe i

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -72,7 +72,6 @@ variables {v : ι → M}
 variables [ring R] [add_comm_group M] [add_comm_group M']
 variables [module R M] [module R M']
 variables {a b : R} {x y : M}
-include R
 
 variables (R) (v)
 /-- Linearly independent family of vectors -/
@@ -737,7 +736,7 @@ end
 lemma is_basis.injective (hv : is_basis R v) (zero_ne_one : (0 : R) ≠ 1) : injective v :=
   λ x y h, linear_independent.injective zero_ne_one hv.1 h
 
-/- Given a basis, any vector can be written as a linear combination of the basis vectors. They are
+/-- Given a basis, any vector can be written as a linear combination of the basis vectors. They are
 given by this linear map. This is one direction of `module_equiv_finsupp`. -/
 def is_basis.repr : M →ₗ (ι →₀ R) :=
 (hv.1.repr).comp (linear_map.id.cod_restrict _ hv.mem_span)
@@ -808,9 +807,8 @@ lemma constr_sub {g f : ι → M'} (hs : is_basis R v) :
 by simp [sub_eq_add_neg, constr_add, constr_neg]
 
 -- this only works on functions if `R` is a commutative ring
-lemma constr_smul {ι R M M'} [comm_ring R]
-  [add_comm_group M] [add_comm_group M'] [module R M] [module R M']
-  {v : ι → R} {f : ι → M'} {a : R} (hv : is_basis R v) {b : M} :
+lemma constr_smul {ι R M} [comm_ring R] [add_comm_group M] [module R M]
+  {v : ι → R} {f : ι → M} {a : R} (hv : is_basis R v) :
   hv.constr (λb, a • f b) = a • hv.constr f :=
 constr_eq hv $ by simp [constr_basis hv] {contextual := tt}
 
@@ -823,8 +821,8 @@ by rw [is_basis.constr, linear_map.range_comp, linear_map.range_comp, is_basis.r
 def module_equiv_finsupp (hv : is_basis R v) : M ≃ₗ[R] ι →₀ R :=
 (hv.1.total_equiv.trans (linear_equiv.of_top _ hv.2)).symm
 
-/-- Isomorphism between the two modules, given two modules M and M' with respective bases v and v'
-   and a bijection between the two bases. -/
+/-- Isomorphism between the two modules, given two modules `M` and `M'` with respective bases
+`v` and `v'` and a bijection between the two bases. -/
 def equiv_of_is_basis {v : ι → M} {v' : ι' → M'} {f : M → M'} {g : M' → M}
   (hv : is_basis R v) (hv' : is_basis R v')
   (hf : ∀i, f (v i) ∈ range v') (hg : ∀i, g (v' i) ∈ range v)
@@ -919,7 +917,8 @@ end
 open fintype
 variables [fintype ι] (h : is_basis R v)
 
-/-- A module over R with a finite basis is linearly equivalent to functions from its basis to R. -/
+/-- A module over `R` with a finite basis is linearly equivalent to functions from its basis to `R`.
+-/
 def equiv_fun_basis  : M ≃ₗ[R] (ι → R) :=
 linear_equiv.trans (module_equiv_finsupp h)
   { to_fun := finsupp.to_fun,
@@ -1200,7 +1199,7 @@ open set linear_map
 
 section module
 variables {η : Type*} {ιs : η → Type*} {Ms : η → Type*}
-variables [ring R] [∀i, add_comm_group (Ms i)] [∀i, module R (Ms i)] [fintype η]
+variables [ring R] [∀i, add_comm_group (Ms i)] [∀i, module R (Ms i)]
 
 lemma linear_independent_std_basis
   (v : Πj, ιs j → (Ms j)) (hs : ∀i, linear_independent R (v i)) :
@@ -1232,6 +1231,8 @@ begin
     refine disjoint_mono h₁ h₂
       (disjoint_std_basis_std_basis _ _ _ _ h₃), }
 end
+
+variable [fintype η]
 
 lemma is_basis_std_basis (s : Πj, ιs j → (Ms j)) (hs : ∀j, is_basis R (s j)) :
   is_basis R (λ (ji : Σ j, ιs j), std_basis R Ms ji.1 (s ji.1 ji.2)) :=

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -17,17 +17,17 @@ It is inspired by Isabelle/HOL's linear algebra, and hence indirectly by HOL Lig
 
 ## Main definitions
 
-All definitions are given for families of vectors, i.e. `v : ι → M` where M is the module or
-vectorspace and `ι : Type*` is an arbitrary indexing type.
+All definitions are given for families of vectors, i.e. `v : ι → M` where `M` is the module or
+vector space and `ι : Type*` is an arbitrary indexing type.
 
-* `linear_independent R v` states that the elements of the family `v` are linear independent
+* `linear_independent R v` states that the elements of the family `v` are linearly independent.
 
 * `linear_independent.repr hv x` returns the linear combination representing `x : span R (range v)`
-  on the linear independent vectors `v`, given `hv : linear_independent R v`
+  on the linearly independent vectors `v`, given `hv : linear_independent R v`
   (using classical choice). `linear_independent.repr hv` is provided as a linear map.
 
-* `is_basis R v` states that the vector family `v` is a basis, i.e. it is linear independent and
-  spans the entire space
+* `is_basis R v` states that the vector family `v` is a basis, i.e. it is linearly independent and
+  spans the entire space.
 
 * `is_basis.repr hv x` is the basis version of `linear_independent.repr hv x`. It returns the
   linear combination representing `x : M` on a basis `v` of `M` (using classical choice).
@@ -47,7 +47,7 @@ vectorspace and `ι : Type*` is an arbitrary indexing type.
 
 We use families instead of sets because it allows us to say that two identical vectors are linearly
 dependent. For bases, this is useful as well because we can easily derive ordered bases by using an
-ordered index type ι.
+ordered index type `ι`.
 
 If you want to use sets, use the family `(λ x, x : s → M)` given a set `s : set M`. The lemmas
 `linear_independent.to_subtype_range` and `linear_independent.of_subtype_range` connect those two
@@ -170,7 +170,7 @@ begin
 end
 
 section subtype
-/- The following lemmas use the subtype defined by a set in M as the index set ι. -/
+/-! The following lemmas use the subtype defined by a set in `M` as the index set `ι`. -/
 
 theorem linear_independent_comp_subtype {s : set ι} :
   linear_independent R (v ∘ subtype.val : s → M) ↔
@@ -243,7 +243,8 @@ begin
     { unfold maps_to },
     { apply (linear_independent.injective zero_eq_one hv).inj_on },
     intros x hx,
-    rcases mem_range.1 (((finsupp.mem_supported _ _).1 hl₁ : ↑(l.support) ⊆ range v) hx) with ⟨i, hi⟩,
+    rcases mem_range.1 (((finsupp.mem_supported _ _).1 hl₁ : ↑(l.support) ⊆ range v) hx)
+      with ⟨i, hi⟩,
     rw mem_image,
     use i,
     rw [mem_preimage, hi],
@@ -434,10 +435,13 @@ end subtype
 section repr
 variables (hv : linear_independent R v)
 
-/-- Canonical isomorphism between linear combinations and the span of linearly independent vectors. -/
-def linear_independent.total_equiv (hv : linear_independent R v) : (ι →₀ R) ≃ₗ[R] span R (range v) :=
+/-- Canonical isomorphism between linear combinations and the span of linearly independent vectors.
+-/
+def linear_independent.total_equiv (hv : linear_independent R v) :
+  (ι →₀ R) ≃ₗ[R] span R (range v) :=
 begin
-apply linear_equiv.of_bijective (linear_map.cod_restrict (span R (range v)) (finsupp.total ι M R v) _),
+apply linear_equiv.of_bijective
+  (linear_map.cod_restrict (span R (range v)) (finsupp.total ι M R v) _),
 { rw linear_map.ker_cod_restrict,
   apply hv },
 { rw [linear_map.range, linear_map.map_cod_restrict, ← linear_map.range_le_iff_comap,
@@ -452,16 +456,17 @@ end
 
 /-- Linear combination representing a vector in the span of linearly independent vectors.
 
-   Given a family of linearly independent vectors, we can represent any vector in their span as
-   a linear combination of these vectors. These are provided by this linear map.
-   It is simply one direction of `linear_independent.total_equiv` -/
+Given a family of linearly independent vectors, we can represent any vector in their span as
+a linear combination of these vectors. These are provided by this linear map.
+It is simply one direction of `linear_independent.total_equiv`. -/
 def linear_independent.repr (hv : linear_independent R v) :
   span R (range v) →ₗ[R] ι →₀ R := hv.total_equiv.symm
 
 lemma linear_independent.total_repr (x) : finsupp.total ι M R v (hv.repr x) = x :=
 subtype.coe_ext.1 (linear_equiv.apply_symm_apply hv.total_equiv x)
 
-lemma linear_independent.total_comp_repr : (finsupp.total ι M R v).comp hv.repr = submodule.subtype _ :=
+lemma linear_independent.total_comp_repr :
+  (finsupp.total ι M R v).comp hv.repr = submodule.subtype _ :=
 linear_map.ext $ hv.total_repr
 
 lemma linear_independent.repr_ker : hv.repr.ker = ⊥ :=
@@ -491,6 +496,7 @@ begin
   simp [finsupp.total_single, hx]
 end
 
+-- TODO: why is this so slow?
 lemma linear_independent_iff_not_smul_mem_span :
   linear_independent R v ↔ (∀ (i : ι) (a : R), a • (v i) ∈ span R (v '' (univ \ {i})) → a = 0) :=
 ⟨ λ hv i a ha, begin
@@ -500,7 +506,7 @@ lemma linear_independent_iff_not_smul_mem_span :
   by_contra hn,
   exact (not_mem_of_mem_diff (hl $ by simp [hn])) (mem_singleton _),
 end, λ H, linear_independent_iff.2 $ λ l hl, begin
-  ext i, simp,
+  ext i, simp only [finsupp.zero_apply],
   by_contra hn,
   refine hn (H i _ _),
   refine (finsupp.mem_span_iff_total _).2 ⟨finsupp.single i (l i) - l, _, _⟩,
@@ -534,7 +540,8 @@ begin
   have l_eq : l = _ := linear_map.ker_eq_bot.1 hv h_total_eq,
   dsimp only [l] at l_eq,
   rw ←finsupp.emb_domain_eq_map_domain at l_eq,
-  rcases finsupp.single_of_emb_domain_single (repr ⟨v i, _⟩) f i (1 : R) zero_ne_one.symm l_eq with ⟨i', hi'⟩,
+  rcases finsupp.single_of_emb_domain_single (repr ⟨v i, _⟩) f i (1 : R) zero_ne_one.symm l_eq
+    with ⟨i', hi'⟩,
   use i',
   exact hi'.2
 end
@@ -571,7 +578,8 @@ begin
   exact λ _, rfl,
 end
 
-lemma linear_independent.image_subtype {s : set M} {f : M →ₗ M'} (hs : linear_independent R (λ x, x : s → M))
+lemma linear_independent.image_subtype {s : set M} {f : M →ₗ M'}
+  (hs : linear_independent R (λ x, x : s → M))
   (hf_inj : disjoint (span R s) f.ker) : linear_independent R (λ x, x : f '' s → M') :=
 begin
   rw [disjoint, ← set.image_id s, finsupp.span_eq_map_total, map_inf_eq_map_inf_comap,
@@ -580,7 +588,8 @@ begin
   rw [linear_independent_subtype_disjoint, disjoint, ← finsupp.lmap_domain_supported _ _ f, map_inf_eq_map_inf_comap,
       map_le_iff_le_comap, ← ker_comp],
   rw [@finsupp.lmap_domain_total _ _ R _ _ _, ker_comp],
-  { exact le_trans (le_inf inf_le_left hf_inj) (le_trans (linear_independent_subtype_disjoint.1 hs) bot_le) },
+  { exact le_trans (le_inf inf_le_left hf_inj)
+    (le_trans (linear_independent_subtype_disjoint.1 hs) bot_le) },
   { simp }
 end
 
@@ -729,7 +738,7 @@ lemma is_basis.injective (hv : is_basis R v) (zero_ne_one : (0 : R) ≠ 1) : inj
   λ x y h, linear_independent.injective zero_ne_one hv.1 h
 
 /- Given a basis, any vector can be written as a linear combination of the basis vectors. They are
-   given by this linear map. This is one direction of `module_equiv_finsupp` -/
+given by this linear map. This is one direction of `module_equiv_finsupp`. -/
 def is_basis.repr : M →ₗ (ι →₀ R) :=
 (hv.1.repr).comp (linear_map.id.cod_restrict _ hv.mem_span)
 
@@ -817,22 +826,26 @@ def module_equiv_finsupp (hv : is_basis R v) : M ≃ₗ[R] ι →₀ R :=
 /-- Isomorphism between the two modules, given two modules M and M' with respective bases v and v'
    and a bijection between the two bases. -/
 def equiv_of_is_basis {v : ι → M} {v' : ι' → M'} {f : M → M'} {g : M' → M}
-  (hv : is_basis R v) (hv' : is_basis R v') (hf : ∀i, f (v i) ∈ range v') (hg : ∀i, g (v' i) ∈ range v)
+  (hv : is_basis R v) (hv' : is_basis R v')
+  (hf : ∀i, f (v i) ∈ range v') (hg : ∀i, g (v' i) ∈ range v)
   (hgf : ∀i, g (f (v i)) = v i) (hfg : ∀i, f (g (v' i)) = v' i) :
   M ≃ₗ M' :=
 { inv_fun := hv'.constr (g ∘ v'),
   left_inv :=
     have (hv'.constr (g ∘ v')).comp (hv.constr (f ∘ v)) = linear_map.id,
-    from hv.ext $ λ i, exists.elim (hf i) (λ i' hi', by simp [constr_basis, hi'.symm]; rw [hi', hgf]),
+    from hv.ext $ λ i, exists.elim (hf i)
+      (λ i' hi', by simp [constr_basis, hi'.symm]; rw [hi', hgf]),
     λ x, congr_arg (λ h:M →ₗ[R] M, h x) this,
   right_inv :=
     have (hv.constr (f ∘ v)).comp (hv'.constr (g ∘ v')) = linear_map.id,
-    from hv'.ext $ λ i', exists.elim (hg i') (λ i hi, by simp [constr_basis, hi.symm]; rw [hi, hfg]),
+    from hv'.ext $ λ i', exists.elim (hg i')
+      (λ i hi, by simp [constr_basis, hi.symm]; rw [hi, hfg]),
     λ y, congr_arg (λ h:M' →ₗ[R] M', h y) this,
   ..hv.constr (f ∘ v) }
 
 lemma is_basis_inl_union_inr {v : ι → M} {v' : ι' → M'}
-  (hv : is_basis R v) (hv' : is_basis R v') : is_basis R (sum.elim (inl R M M' ∘ v) (inr R M M' ∘ v')) :=
+  (hv : is_basis R v) (hv' : is_basis R v') :
+  is_basis R (sum.elim (inl R M M' ∘ v) (inr R M M' ∘ v')) :=
 begin
   split,
   apply linear_independent_inl_union_inr' hv.1 hv'.1,
@@ -894,7 +907,8 @@ lemma is_basis_empty (h_empty : ¬ nonempty ι) (h : ∀x:M, x = 0) : is_basis R
 ⟨ linear_independent_empty_type h_empty,
   eq_top_iff'.2 $ assume x, (h x).symm ▸ submodule.zero_mem _ ⟩
 
-lemma is_basis_empty_bot (h_empty : ¬ nonempty ι) : is_basis R (λ _ : ι, (0 : (⊥ : submodule R M))) :=
+lemma is_basis_empty_bot (h_empty : ¬ nonempty ι) :
+  is_basis R (λ _ : ι, (0 : (⊥ : submodule R M))) :=
 begin
   apply is_basis_empty h_empty,
   intro x,
@@ -962,7 +976,8 @@ end
 
 end
 
-lemma linear_independent_iff_not_mem_span : linear_independent K v ↔ (∀i, v i ∉ span K (v '' (univ \ {i}))) :=
+lemma linear_independent_iff_not_mem_span :
+  linear_independent K v ↔ (∀i, v i ∉ span K (v '' (univ \ {i}))) :=
 begin
   apply linear_independent_iff_not_smul_mem_span.trans,
   split,
@@ -986,7 +1001,8 @@ begin
   exact h this.symm
 end
 
-lemma linear_independent_singleton {x : V} (hx : x ≠ 0) : linear_independent K (λ x, x : ({x} : set V) → V) :=
+lemma linear_independent_singleton {x : V} (hx : x ≠ 0) :
+  linear_independent K (λ x, x : ({x} : set V) → V) :=
 begin
   apply @linear_independent_unique _ _ _ _ _ _ _ _ _,
   apply set.unique_singleton,
@@ -1113,7 +1129,8 @@ begin
   rcases exists_is_basis K V with ⟨B, hB⟩,
   have hB₀ : _ := hB.1.to_subtype_range,
   have : linear_independent K (λ x, x : f '' B → V'),
-  { have h₁ := hB₀.image_subtype (show disjoint (span K (range (λ i : B, i.val))) (linear_map.ker f), by simp [hf_inj]),
+  { have h₁ := hB₀.image_subtype
+      (show disjoint (span K (range (λ i : B, i.val))) (linear_map.ker f), by simp [hf_inj]),
     have h₂ : range (λ (i : B), i.val) = B := subtype.range_val B,
     rwa h₂ at h₁ },
   rcases exists_subset_is_basis this with ⟨C, BC, hC⟩,
@@ -1154,8 +1171,8 @@ begin
   have mkf : ∀ x, submodule.quotient.mk (f x) = x := linear_map.ext_iff.1 hf,
   have fp : ∀ x, x - f (p.mkq x) ∈ p :=
     λ x, (submodule.quotient.eq p).1 (mkf (p.mkq x)).symm,
-  refine ⟨linear_equiv.of_linear (f.copair p.subtype)
-    (p.mkq.pair (cod_restrict p (linear_map.id - f.comp p.mkq) fp))
+  refine ⟨linear_equiv.of_linear (f.coprod p.subtype)
+    (p.mkq.prod (cod_restrict p (linear_map.id - f.comp p.mkq) fp))
     (by ext; simp) _⟩,
   ext ⟨⟨x⟩, y, hy⟩; simp,
   { apply (submodule.quotient.eq p).2,

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -37,6 +37,8 @@ include K
 open submodule function set
 
 variables (K V)
+
+/-- the dimension of a vector space, defined as a term of type `cardinal` -/
 def vector_space.dim : cardinal :=
 cardinal.min
   (nonempty_subtype.2 (@exists_is_basis K V _ _ _))
@@ -121,6 +123,7 @@ by rw [←h.mk_range_eq_dim, cardinal.mk_range_eq_of_inj (h.injective zero_ne_on
 
 variables [add_comm_group V₂] [vector_space K V₂]
 
+/-- Two linearly equivalent vector spaces have the same dimension. -/
 theorem linear_equiv.dim_eq (f : V ≃ₗ[K] V₂) :
   dim K V = dim K V₂ :=
 by letI := classical.dec_eq V;
@@ -353,6 +356,7 @@ end
 
 section rank
 
+/-- `rank f` is the rank of a `linear_map f`, defined as the dimension of `f.range`. -/
 def rank (f : V →ₗ[K] V₂) : cardinal := dim K f.range
 
 lemma rank_le_domain (f : V →ₗ[K] V₂) : rank f ≤ dim K V :=

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -2,11 +2,25 @@
 Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Mario Carneiro, Johannes Hölzl, Sander Dahmen
-
-Dimension of modules and vector spaces.
 -/
 import linear_algebra.basis
 import set_theory.ordinal
+/-!
+# Dimension of modules and vector spaces
+
+## Main definitions
+
+* The dimension of a vector space is defined as `vector_space.dim : cardinal`.
+
+## Main statements
+
+* `mk_eq_mk_of_basis`: the dimension theorem, any two bases of the same vector space have the same
+  cardinality.
+* `dim_quotient_add_dim`: if V' is a submodule of V, then dim (V/V') + dim V' = dim V.
+* `dim_range_add_dim_ker`: the rank-nullity theorem.
+
+-/
+
 noncomputable theory
 
 universes u u' u'' v v' w w'
@@ -225,7 +239,7 @@ variables [add_comm_group V₄] [vector_space K V₄]
 set_option class.instance_max_depth 70
 open linear_map
 
-/-- This is mostly an auxiliary lemma for `dim_sup_add_dim_inf_eq` -/
+/-- This is mostly an auxiliary lemma for `dim_sup_add_dim_inf_eq`. -/
 lemma dim_add_dim_split
   (db : V₃ →ₗ[K] V) (eb : V₄ →ₗ[K] V) (cd : V₂ →ₗ[K] V₃) (ce : V₂ →ₗ[K] V₄)
   (hde : ⊤ ≤ db.range ⊔ eb.range)
@@ -233,25 +247,27 @@ lemma dim_add_dim_split
   (eq : db.comp cd = eb.comp ce)
   (eq₂ : ∀d e, db d = eb e → (∃c, cd c = d ∧ ce c = e)) :
   dim K V + dim K V₂ = dim K V₃ + dim K V₄ :=
-have hf : surjective (copair db eb),
+have hf : surjective (coprod db eb),
 begin
   refine (range_eq_top.1 $ top_unique $ _),
-  rwa [← map_top, ← prod_top, map_copair_prod]
+  rwa [← map_top, ← prod_top, map_coprod_prod]
 end,
 begin
   conv {to_rhs, rw [← dim_prod, dim_eq_surjective _ hf] },
   congr' 1,
   apply linear_equiv.dim_eq,
   fapply linear_equiv.of_bijective,
-  { refine cod_restrict _ (pair cd (- ce)) _,
+  { refine cod_restrict _ (prod cd (- ce)) _,
     { assume c,
-      simp [add_eq_zero_iff_eq_neg],
+      simp only [add_eq_zero_iff_eq_neg, prod_apply, mem_ker,
+        coprod_apply, neg_neg, map_neg, neg_apply],
       exact linear_map.ext_iff.1 eq c } },
-  { rw [ker_cod_restrict, ker_pair, hgd, bot_inf_eq] },
+  { rw [ker_cod_restrict, ker_prod, hgd, bot_inf_eq] },
   { rw [eq_top_iff, range_cod_restrict, ← map_le_iff_le_comap, map_top, range_subtype],
     rintros ⟨d, e⟩,
     have h := eq₂ d (-e),
-    simp [add_eq_zero_iff_eq_neg] at ⊢ h,
+    simp only [add_eq_zero_iff_eq_neg, prod_apply, mem_ker, mem_coe, prod.mk.inj_iff,
+      coprod_apply, map_neg, neg_apply, linear_map.mem_range] at ⊢ h,
     assume hde,
     rcases h hde with ⟨c, h₁, h₂⟩,
     refine ⟨c, h₁, _⟩,


### PR DESCRIPTION
Fixes #2172. Here's @urkud's list from that issue:

* [x] rename `linear_map.copair` to `linear_map.coprod`;
* [x] leave only one of `linear_map.prod` and `linear_map.pair` under the name `linear_map.prod`;
* [x] merge lemmas about `linear_map.pair` and `linear_map.prod`, probably we have quite a few duplicates; 
* [x] fix compile of all other files.

I also sped up a small number of slow proofs with `squeeze_simp`, split some long lines and added a very basic module docstring to `linear_algebra.dimension`.