### PR TITLE
chore(ring_theory/algebra): generalize restrict_scalars to noncommutative algebras

### DIFF
--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -628,7 +628,7 @@ section restrict_scalars
 /- In this section, we describe restriction of scalars: if `S` is an algebra over `R`, then
 `S`-modules are also `R`-modules. -/
 
-variables (R : Type*) [comm_ring R] (S : Type*) [comm_ring S] [algebra R S]
+variables (R : Type*) [comm_ring R] (S : Type*) [ring S] [algebra R S]
 (E : Type*) [add_comm_group E] [module S E] {F : Type*} [add_comm_group F] [module S F]
 
 /-- When `E` is a module over a ring `S`, and `S` is an algebra over `R`, then `E` inherits a


### PR DESCRIPTION
`module.restrict_scalars` (which says that an R-algebra module is in particular an R-module) unnecessarily assumed the R-algebra was itself commutative. In typical applications (e.g. k[G]-mod) this is not true.