### PR TITLE
feat(data/equiv/local_equiv): construct from `bij_on` or `inj_on`

### DIFF
--- a/src/data/equiv/local_equiv.lean
+++ b/src/data/equiv/local_equiv.lean
@@ -96,8 +96,8 @@ variables (e : local_equiv α β) (e' : local_equiv β γ)
 
 /-- Associating to a local_equiv an equiv between the source and the target -/
 protected def to_equiv : equiv (e.source) (e.target) :=
-{ to_fun    := λ⟨x, hx⟩, ⟨e.to_fun x, e.map_source hx⟩,
-  inv_fun   := λ⟨y, hy⟩, ⟨e.inv_fun y, e.map_target hy⟩,
+{ to_fun    := λ x, ⟨e.to_fun x, e.map_source x.mem⟩,
+  inv_fun   := λ y, ⟨e.inv_fun y, e.map_target y.mem⟩,
   left_inv  := λ⟨x, hx⟩, subtype.eq $ e.left_inv hx,
   right_inv := λ⟨y, hy⟩, subtype.eq $ e.right_inv hy }
 
@@ -500,6 +500,30 @@ def prod (e : local_equiv α β) (e' : local_equiv γ δ) : local_equiv (α × �
 end prod
 
 end local_equiv
+
+namespace set
+
+-- All arguments are explicit to avoid missing information in the pretty printer output
+/-- A bijection between two sets `s : set α` and `t : set β` provides a local equivalence
+between `α` and `β`. -/
+noncomputable def bij_on.to_local_equiv [nonempty α] (f : α → β) (s : set α) (t : set β)
+  (hf : bij_on f s t) :
+  local_equiv α β :=
+{ to_fun := f,
+  inv_fun := inv_fun_on f s,
+  source := s,
+  target := t,
+  map_source := hf.maps_to,
+  map_target := hf.surj_on.maps_to_inv_fun_on,
+  left_inv := hf.inv_on_inv_fun_on.1,
+  right_inv := hf.inv_on_inv_fun_on.2 }
+
+/-- A map injective on a subset of its domain provides a local equivalence. -/
+noncomputable def inj_on.to_local_equiv [nonempty α] (f : α → β) (s : set α) (hf : inj_on f s) :
+  local_equiv α β :=
+hf.bij_on_image.to_local_equiv f s (f '' s)
+
+end set
 
 namespace equiv
 /- equivs give rise to local_equiv. We set up simp lemmas to reduce most properties of the local

--- a/src/data/equiv/local_equiv.lean
+++ b/src/data/equiv/local_equiv.lean
@@ -506,7 +506,7 @@ namespace set
 -- All arguments are explicit to avoid missing information in the pretty printer output
 /-- A bijection between two sets `s : set α` and `t : set β` provides a local equivalence
 between `α` and `β`. -/
-noncomputable def bij_on.to_local_equiv [nonempty α] (f : α → β) (s : set α) (t : set β)
+@[simps] noncomputable def bij_on.to_local_equiv [nonempty α] (f : α → β) (s : set α) (t : set β)
   (hf : bij_on f s t) :
   local_equiv α β :=
 { to_fun := f,
@@ -519,7 +519,8 @@ noncomputable def bij_on.to_local_equiv [nonempty α] (f : α → β) (s : set �
   right_inv := hf.inv_on_inv_fun_on.2 }
 
 /-- A map injective on a subset of its domain provides a local equivalence. -/
-noncomputable def inj_on.to_local_equiv [nonempty α] (f : α → β) (s : set α) (hf : inj_on f s) :
+@[simp] noncomputable def inj_on.to_local_equiv [nonempty α] (f : α → β) (s : set α)
+  (hf : inj_on f s) :
   local_equiv α β :=
 hf.bij_on_image.to_local_equiv f s (f '' s)
 

--- a/src/data/set/function.lean
+++ b/src/data/set/function.lean
@@ -150,7 +150,7 @@ lemma inj_on_iff_injective : inj_on f s ↔ injective (restrict f s) :=
 ⟨λ H a b h, subtype.eq $ H a.2 b.2 h,
  λ H a b as bs h, congr_arg subtype.val $ @H ⟨a, as⟩ ⟨b, bs⟩ h⟩
 
-lemma inj_on.inv_fun_on_image [inhabited α] (h : inj_on f s₂) (ht : s₁ ⊆ s₂) :
+lemma inj_on.inv_fun_on_image [nonempty α] (h : inj_on f s₂) (ht : s₁ ⊆ s₂) :
   (inv_fun_on f s₂) '' (f '' s₁) = s₁ :=
 begin
   have : eq_on ((inv_fun_on f s₂) ∘ f) id s₁, from λz hz, inv_fun_on_eq' h (ht hz),
@@ -331,19 +331,19 @@ theorem inv_on.bij_on (h : inv_on f' f s t) (hf : maps_to f s t) (hf' : maps_to 
 
 /-! ### `inv_fun_on` is a left/right inverse -/
 
-theorem inj_on.left_inv_on_inv_fun_on [inhabited α] (h : inj_on f s) :
+theorem inj_on.left_inv_on_inv_fun_on [nonempty α] (h : inj_on f s) :
   left_inv_on (inv_fun_on f s) f s :=
 λ x hx, inv_fun_on_eq' h hx
 
-theorem surj_on.right_inv_on_inv_fun_on [inhabited α] (h : surj_on f s t) :
+theorem surj_on.right_inv_on_inv_fun_on [nonempty α] (h : surj_on f s t) :
   right_inv_on (inv_fun_on f s) f t :=
 λ y hy, inv_fun_on_eq $ mem_image_iff_bex.1 $ h hy
 
-theorem bij_on.inv_on_inv_fun_on [inhabited α] (h : bij_on f s t) :
+theorem bij_on.inv_on_inv_fun_on [nonempty α] (h : bij_on f s t) :
   inv_on (inv_fun_on f s) f s t :=
 ⟨h.inj_on.left_inv_on_inv_fun_on, h.surj_on.right_inv_on_inv_fun_on⟩
 
-theorem surj_on.inv_on_inv_fun_on [inhabited α] (h : surj_on f s t) :
+theorem surj_on.inv_on_inv_fun_on [nonempty α] (h : surj_on f s t) :
   inv_on (inv_fun_on f s) f (inv_fun_on f s '' t) t :=
 begin
   refine ⟨_, h.right_inv_on_inv_fun_on⟩,
@@ -351,11 +351,11 @@ begin
   rw [h.right_inv_on_inv_fun_on hy]
 end
 
-theorem surj_on.maps_to_inv_fun_on [inhabited α] (h : surj_on f s t) :
+theorem surj_on.maps_to_inv_fun_on [nonempty α] (h : surj_on f s t) :
   maps_to (inv_fun_on f s) t s :=
 λ y hy, mem_preimage.2 $ inv_fun_on_mem $ mem_image_iff_bex.1 $ h hy
 
-theorem surj_on.bij_on_subset [inhabited α] (h : surj_on f s t) :
+theorem surj_on.bij_on_subset [nonempty α] (h : surj_on f s t) :
   bij_on f (inv_fun_on f s '' t) t :=
 begin
   refine h.inv_on_inv_fun_on.bij_on _ (maps_to_image _ _),
@@ -370,7 +370,7 @@ begin
   { rcases eq_empty_or_nonempty t with rfl|ht,
     { exact λ _, ⟨∅, empty_subset _, bij_on_empty f⟩ },
     { assume h,
-      haveI : inhabited α := ⟨classical.some (h.comap_nonempty ht)⟩,
+      haveI : nonempty α := ⟨classical.some (h.comap_nonempty ht)⟩,
       exact ⟨_, h.maps_to_inv_fun_on.image_subset, h.bij_on_subset⟩ }},
   { rintros ⟨s', hs', hfs'⟩,
     exact hfs'.surj_on.mono hs' (subset.refl _) }


### PR DESCRIPTION
Also fix usage of `nonempty` vs `inhabited` in `set/function`. Linter
didn't catch these bugs because the types use the `.to_nonempty`
projection of the `[inhabited]` arguments.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)