### PR TITLE
feat(.github): cleanup old CI builds on the same branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,14 +3,6 @@ name: continuous integration
 on: [push, pull_request]
 
 jobs:
-  cleanup-runs:
-      runs-on: ubuntu-latest
-      steps:
-      - uses: semorrison/workflow-run-cleanup-action@v0.2.2
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
-
   build:
     name: Build mathlib
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,14 @@ name: continuous integration
 on: [push, pull_request]
 
 jobs:
+  cleanup-runs:
+      runs-on: ubuntu-latest
+      steps:
+      - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+
   build:
     name: Build mathlib
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,10 @@ on: [push, pull_request]
 
 jobs:
   cleanup-runs:
+      on: [push]
       runs-on: ubuntu-latest
       steps:
-      - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
+      - uses: semorrison/workflow-run-cleanup-action@v0.2.2
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on: [push, pull_request]
 
 jobs:
   cleanup-runs:
-      on: [push]
       runs-on: ubuntu-latest
       steps:
       - uses: semorrison/workflow-run-cleanup-action@v0.2.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,6 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
 
-
   build:
     name: Build mathlib
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
 
+
   build:
     name: Build mathlib
     runs-on: ubuntu-latest

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,0 +1,12 @@
+name: cancel CI for obsolete pushes
+
+on: [push]
+
+jobs:
+  cleanup-runs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: semorrison/workflow-run-cleanup-action@v0.2.2
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -6,7 +6,7 @@ jobs:
   cleanup-runs:
     runs-on: ubuntu-latest
     steps:
-    - uses: semorrison/workflow-run-cleanup-action@v0.2.2
+    - uses: semorrison/workflow-run-cleanup-action@master
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"


### PR DESCRIPTION
Add an extra job to the GitHub actions build, that cancels previous builds on the same branch (making an exception for `master` or any tags).

It seems to work out of the box.