### PR TITLE
chore(ci): only run on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: continuous integration
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:

--- a/docs/contribute/index.md
+++ b/docs/contribute/index.md
@@ -16,6 +16,7 @@ to make the process of contributing as smooth as possible.
    - The [git commit conventions](https://github.com/leanprover-community/lean/blob/master/doc/commit_convention.md).
 3. Create a pull request from a feature branch on your personal fork,
    as explained in the link above, or from a branch of the main repository if you have commit access (you can ask for access on Zulip).
+   If you use an external repository, please make sure that repository has GitHub Actions enabled.
 4. If you've made a lot of changes/additions, try to make many PRs containing small, self-contained pieces. This helps you get feedback as you go along, and it is much easier to review. This is especially important for new contributors.
 5. You can use `leanproject get-cache` to fetch `.olean` binaries.
    ```


### PR DESCRIPTION
See the conversation here: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/github.20actions.3A.20can.20we.20cancelled.20obsolete.20builds.3F/near/191713302

I think the PR builds aren't doing anything for us, are they? They test a merge commit that will never be checked out, and Mergify makes sure that the one merge commit that matters gets tested (as a push build).

The PR builds only matter for PRs that come from an external repo with Actions disabled.
There are other reasons to avoid external PRs as much as possible, and if we get them, we can just ask the author to enable Actions. It's simple to do.
No configuration needed because the Actions config is part of the repo.


TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)
