### PR TITLE
doc(docs/install/project.md): mention that projects are git repositories

### DIFF
--- a/docs/install/project.md
+++ b/docs/install/project.md
@@ -1,9 +1,14 @@
 # Creating a Lean project
 
-Lean files are organized in projects called packages. The tool `leanproject`
-manages project creation and dependencies. We will now create a new
-project depending on mathlib. The following commands should be typed in a
-terminal.
+Lean files are organized in projects called packages. Projects are
+git repositories containing a `leanpkg.toml` file specifying the Lean
+version and all required dependencies alongside the `src/` subdirectory
+containing the Lean code. The tool
+[`leanproject`](https://github.com/leanprover-community/mathlib-tools)
+manages project creation and dependencies. 
+
+We will now create a new project depending on mathlib. The following
+commands should be typed in a terminal.
 
 * If you have not logged in since you installed Lean and mathlib, then
   you need to first type `source ~/.profile`.


### PR DESCRIPTION
See [zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/mathlib.20installation/near/191799189). 

Maybe this is still too subtle, please feel free to edit!