### PR TITLE
feat(analysis/calculus/fderiv): define `has_strict_fderiv_at`

### DIFF
--- a/src/algebra/pi_instances.lean
+++ b/src/algebra/pi_instances.lean
@@ -250,6 +250,8 @@ lemma snd.is_monoid_hom [monoid α] [monoid β] : is_monoid_hom (prod.snd : α �
 
 @[simp] lemma fst_sub [add_group α] [add_group β] : (p - q).1 = p.1 - q.1 := rfl
 @[simp] lemma snd_sub [add_group α] [add_group β] : (p - q).2 = p.2 - q.2 := rfl
+@[simp] lemma mk_sub_mk [add_group α] [add_group β] {a₁ a₂ : α} {b₁ b₂ : β} :
+  (a₁, b₁) - (a₂, b₂) = (a₁ - a₂, b₁ - b₂) := rfl
 
 /-- Given monoids `α, β`, the natural projection homomorphism from `α × β` to `α`. -/
 @[to_additive prod.add_monoid_hom.fst "Given add_monoids `α, β`, the natural projection homomorphism from `α × β` to `α`."]

--- a/src/analysis/asymptotics.lean
+++ b/src/analysis/asymptotics.lean
@@ -407,6 +407,12 @@ lemma is_O_fst_prod : is_O f' (λ x, (f' x, g' x)) l := is_O_with_fst_prod.is_O
 
 lemma is_O_snd_prod : is_O g' (λ x, (f' x, g' x)) l := is_O_with_snd_prod.is_O
 
+lemma is_O_fst_prod' {f' : α → E' × F'} : is_O (λ x, (f' x).1) f' l :=
+is_O_fst_prod
+
+lemma is_O_snd_prod' {f' : α → E' × F'} : is_O (λ x, (f' x).2) f' l :=
+is_O_snd_prod
+
 section
 
 variables (f' k')

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -291,6 +291,10 @@ lemma has_fderiv_at.differentiable_at (h : has_fderiv_at f f' x) : differentiabl
   has_fderiv_within_at f f' univ x ↔ has_fderiv_at f f' x :=
 by { simp only [has_fderiv_within_at, nhds_within_univ], refl }
 
+lemma has_fderiv_at_filter.is_O_sub (h : has_fderiv_at_filter f f' x L) :
+  is_O (λ x', f x' - f x) (λ x', x' - x) L :=
+h.is_O.congr_of_sub.2 (f'.is_O_sub _ _)
+
 /-- Directional derivative agrees with `has_fderiv`. -/
 lemma has_fderiv_at.lim (hf : has_fderiv_at f f' x) (v : E) {α : Type*} {c : α → 𝕜}
   {l : filter α} (hc : tendsto (λ n, ∥c n∥) l at_top) :
@@ -460,6 +464,44 @@ begin
 end
 
 end fderiv_properties
+
+section continuous
+/-! ### Deducing continuity from differentiability -/
+
+theorem has_fderiv_at_filter.tendsto_nhds
+  (hL : L ≤ 𝓝 x) (h : has_fderiv_at_filter f f' x L) :
+  tendsto f L (𝓝 (f x)) :=
+begin
+  have : tendsto (λ x', f x' - f x) L (𝓝 0),
+  { refine h.is_O_sub.trans_tendsto (tendsto_le_left hL _),
+    rw ← sub_self x, exact tendsto_id.sub tendsto_const_nhds },
+  have := tendsto.add this tendsto_const_nhds,
+  rw zero_add (f x) at this,
+  exact this.congr (by simp)
+end
+
+theorem has_fderiv_within_at.continuous_within_at
+  (h : has_fderiv_within_at f f' s x) : continuous_within_at f s x :=
+has_fderiv_at_filter.tendsto_nhds inf_le_left h
+
+theorem has_fderiv_at.continuous_at (h : has_fderiv_at f f' x) :
+  continuous_at f x :=
+has_fderiv_at_filter.tendsto_nhds (le_refl _) h
+
+lemma differentiable_within_at.continuous_within_at (h : differentiable_within_at 𝕜 f s x) :
+  continuous_within_at f s x :=
+let ⟨f', hf'⟩ := h in hf'.continuous_within_at
+
+lemma differentiable_at.continuous_at (h : differentiable_at 𝕜 f x) : continuous_at f x :=
+let ⟨f', hf'⟩ := h in hf'.continuous_at
+
+lemma differentiable_on.continuous_on (h : differentiable_on 𝕜 f s) : continuous_on f s :=
+λx hx, (h x hx).continuous_within_at
+
+lemma differentiable.continuous (h : differentiable 𝕜 f) : continuous f :=
+continuous_iff_continuous_at.2 $ λx, (h x).continuous_at
+
+end continuous
 
 section congr
 /-! ### congr properties of the derivative -/
@@ -658,17 +700,41 @@ There are currently two variants of these in mathlib, the bundled version
 (named `continuous_linear_map`, and denoted `E →L[𝕜] F`), and the unbundled version (with a
 predicate `is_bounded_linear_map`). We give statements for both versions. -/
 
+protected lemma continuous_linear_map.has_fderiv_at_filter :
+  has_fderiv_at_filter e e x L :=
+(is_o_zero _ _).congr_left $ λ x, by simp only [e.map_sub, sub_self]
+
+protected lemma continuous_linear_map.has_fderiv_within_at : has_fderiv_within_at e e s x :=
+e.has_fderiv_at_filter
+
+protected lemma continuous_linear_map.has_fderiv_at : has_fderiv_at e e x :=
+e.has_fderiv_at_filter
+
+protected lemma continuous_linear_map.differentiable_at : differentiable_at 𝕜 e x :=
+e.has_fderiv_at.differentiable_at
+
+protected lemma continuous_linear_map.differentiable_within_at : differentiable_within_at 𝕜 e s x :=
+e.differentiable_at.differentiable_within_at
+
+protected lemma continuous_linear_map.fderiv : fderiv 𝕜 e x = e :=
+e.has_fderiv_at.fderiv
+
+protected lemma continuous_linear_map.fderiv_within (hxs : unique_diff_within_at 𝕜 s x) :
+  fderiv_within 𝕜 e s x = e :=
+begin
+  rw differentiable_at.fderiv_within e.differentiable_at hxs,
+  exact e.fderiv
+end
+
+protected lemma continuous_linear_map.differentiable : differentiable 𝕜 e :=
+λx, e.differentiable_at
+
+protected lemma continuous_linear_map.differentiable_on : differentiable_on 𝕜 e s :=
+e.differentiable.differentiable_on
+
 lemma is_bounded_linear_map.has_fderiv_at_filter (h : is_bounded_linear_map 𝕜 f) :
   has_fderiv_at_filter f h.to_continuous_linear_map x L :=
-begin
-  have : (λ (x' : E), f x' - f x - h.to_continuous_linear_map (x' - x)) = λx', 0,
-  { ext,
-    have : ∀a, h.to_continuous_linear_map a = f a := λa, rfl,
-    simp,
-    simp [this] },
-  rw [has_fderiv_at_filter, this],
-  exact asymptotics.is_o_zero _ _
-end
+h.to_continuous_linear_map.has_fderiv_at_filter
 
 lemma is_bounded_linear_map.has_fderiv_within_at (h : is_bounded_linear_map 𝕜 f) :
   has_fderiv_within_at f h.to_continuous_linear_map s x :=
@@ -705,534 +771,7 @@ lemma is_bounded_linear_map.differentiable_on (h : is_bounded_linear_map 𝕜 f)
   differentiable_on 𝕜 f s :=
 h.differentiable.differentiable_on
 
-lemma continuous_linear_map.has_fderiv_at_filter :
-  has_fderiv_at_filter e e x L :=
-begin
-  have : (λ (x' : E), e x' - e x - e (x' - x)) = λx', 0, by { ext, simp },
-  rw [has_fderiv_at_filter, this],
-  exact asymptotics.is_o_zero _ _
-end
-
-protected lemma continuous_linear_map.has_fderiv_within_at : has_fderiv_within_at e e s x :=
-e.has_fderiv_at_filter
-
-protected lemma continuous_linear_map.has_fderiv_at : has_fderiv_at e e x :=
-e.has_fderiv_at_filter
-
-protected lemma continuous_linear_map.differentiable_at : differentiable_at 𝕜 e x :=
-e.has_fderiv_at.differentiable_at
-
-protected lemma continuous_linear_map.differentiable_within_at : differentiable_within_at 𝕜 e s x :=
-e.differentiable_at.differentiable_within_at
-
-protected lemma continuous_linear_map.fderiv : fderiv 𝕜 e x = e :=
-e.has_fderiv_at.fderiv
-
-protected lemma continuous_linear_map.fderiv_within (hxs : unique_diff_within_at 𝕜 s x) :
-  fderiv_within 𝕜 e s x = e :=
-begin
-  rw differentiable_at.fderiv_within e.differentiable_at hxs,
-  exact e.fderiv
-end
-
-protected lemma continuous_linear_map.differentiable : differentiable 𝕜 e :=
-λx, e.differentiable_at
-
-protected lemma continuous_linear_map.differentiable_on : differentiable_on 𝕜 e s :=
-e.differentiable.differentiable_on
-
 end continuous_linear_map
-
-section const_smul
-/-! ### Derivative of a function multiplied by a constant -/
-theorem has_fderiv_at_filter.const_smul (h : has_fderiv_at_filter f f' x L) (c : 𝕜) :
-  has_fderiv_at_filter (λ x, c • f x) (c • f') x L :=
-(is_o_const_smul_left h c).congr_left $ λ x, by simp [smul_sub]
-
-theorem has_fderiv_within_at.const_smul (h : has_fderiv_within_at f f' s x) (c : 𝕜) :
-  has_fderiv_within_at (λ x, c • f x) (c • f') s x :=
-h.const_smul c
-
-theorem has_fderiv_at.const_smul (h : has_fderiv_at f f' x) (c : 𝕜) :
-  has_fderiv_at (λ x, c • f x) (c • f') x :=
-h.const_smul c
-
-lemma differentiable_within_at.const_smul (h : differentiable_within_at 𝕜 f s x) (c : 𝕜) :
-  differentiable_within_at 𝕜 (λy, c • f y) s x :=
-(h.has_fderiv_within_at.const_smul c).differentiable_within_at
-
-lemma differentiable_at.const_smul (h : differentiable_at 𝕜 f x) (c : 𝕜) :
-  differentiable_at 𝕜 (λy, c • f y) x :=
-(h.has_fderiv_at.const_smul c).differentiable_at
-
-lemma differentiable_on.const_smul (h : differentiable_on 𝕜 f s) (c : 𝕜) :
-  differentiable_on 𝕜 (λy, c • f y) s :=
-λx hx, (h x hx).const_smul c
-
-lemma differentiable.const_smul (h : differentiable 𝕜 f) (c : 𝕜) :
-  differentiable 𝕜 (λy, c • f y) :=
-λx, (h x).const_smul c
-
-lemma fderiv_within_const_smul (hxs : unique_diff_within_at 𝕜 s x)
-  (h : differentiable_within_at 𝕜 f s x) (c : 𝕜) :
-  fderiv_within 𝕜 (λy, c • f y) s x = c • fderiv_within 𝕜 f s x :=
-(h.has_fderiv_within_at.const_smul c).fderiv_within hxs
-
-lemma fderiv_const_smul (h : differentiable_at 𝕜 f x) (c : 𝕜) :
-  fderiv 𝕜 (λy, c • f y) x = c • fderiv 𝕜 f x :=
-(h.has_fderiv_at.const_smul c).fderiv
-
-end const_smul
-
-section add
-/-! ### Derivative of the sum of two functions -/
-
-theorem has_fderiv_at_filter.add
-  (hf : has_fderiv_at_filter f f' x L) (hg : has_fderiv_at_filter g g' x L) :
-  has_fderiv_at_filter (λ y, f y + g y) (f' + g') x L :=
-(hf.add hg).congr_left $ λ _, by simp [sub_eq_add_neg]; abel
-
-theorem has_fderiv_within_at.add
-  (hf : has_fderiv_within_at f f' s x) (hg : has_fderiv_within_at g g' s x) :
-  has_fderiv_within_at (λ y, f y + g y) (f' + g') s x :=
-hf.add hg
-
-theorem has_fderiv_at.add
-  (hf : has_fderiv_at f f' x) (hg : has_fderiv_at g g' x) :
-  has_fderiv_at (λ x, f x + g x) (f' + g') x :=
-hf.add hg
-
-lemma differentiable_within_at.add
-  (hf : differentiable_within_at 𝕜 f s x) (hg : differentiable_within_at 𝕜 g s x) :
-  differentiable_within_at 𝕜 (λ y, f y + g y) s x :=
-(hf.has_fderiv_within_at.add hg.has_fderiv_within_at).differentiable_within_at
-
-lemma differentiable_at.add
-  (hf : differentiable_at 𝕜 f x) (hg : differentiable_at 𝕜 g x) :
-  differentiable_at 𝕜 (λ y, f y + g y) x :=
-(hf.has_fderiv_at.add hg.has_fderiv_at).differentiable_at
-
-lemma differentiable_on.add
-  (hf : differentiable_on 𝕜 f s) (hg : differentiable_on 𝕜 g s) :
-  differentiable_on 𝕜 (λy, f y + g y) s :=
-λx hx, (hf x hx).add (hg x hx)
-
-lemma differentiable.add
-  (hf : differentiable 𝕜 f) (hg : differentiable 𝕜 g) :
-  differentiable 𝕜 (λy, f y + g y) :=
-λx, (hf x).add (hg x)
-
-lemma fderiv_within_add (hxs : unique_diff_within_at 𝕜 s x)
-  (hf : differentiable_within_at 𝕜 f s x) (hg : differentiable_within_at 𝕜 g s x) :
-  fderiv_within 𝕜 (λy, f y + g y) s x = fderiv_within 𝕜 f s x + fderiv_within 𝕜 g s x :=
-(hf.has_fderiv_within_at.add hg.has_fderiv_within_at).fderiv_within hxs
-
-lemma fderiv_add
-  (hf : differentiable_at 𝕜 f x) (hg : differentiable_at 𝕜 g x) :
-  fderiv 𝕜 (λy, f y + g y) x = fderiv 𝕜 f x + fderiv 𝕜 g x :=
-(hf.has_fderiv_at.add hg.has_fderiv_at).fderiv
-
-theorem has_fderiv_at_filter.add_const
-  (hf : has_fderiv_at_filter f f' x L) (c : F) :
-  has_fderiv_at_filter (λ y, f y + c) f' x L :=
-add_zero f' ▸ hf.add (has_fderiv_at_filter_const _ _ _)
-
-theorem has_fderiv_within_at.add_const
-  (hf : has_fderiv_within_at f f' s x) (c : F) :
-  has_fderiv_within_at (λ y, f y + c) f' s x :=
-hf.add_const c
-
-theorem has_fderiv_at.add_const
-  (hf : has_fderiv_at f f' x) (c : F):
-  has_fderiv_at (λ x, f x + c) f' x :=
-hf.add_const c
-
-lemma differentiable_within_at.add_const
-  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
-  differentiable_within_at 𝕜 (λ y, f y + c) s x :=
-(hf.has_fderiv_within_at.add_const c).differentiable_within_at
-
-lemma differentiable_at.add_const
-  (hf : differentiable_at 𝕜 f x) (c : F) :
-  differentiable_at 𝕜 (λ y, f y + c) x :=
-(hf.has_fderiv_at.add_const c).differentiable_at
-
-lemma differentiable_on.add_const
-  (hf : differentiable_on 𝕜 f s) (c : F) :
-  differentiable_on 𝕜 (λy, f y + c) s :=
-λx hx, (hf x hx).add_const c
-
-lemma differentiable.add_const
-  (hf : differentiable 𝕜 f) (c : F) :
-  differentiable 𝕜 (λy, f y + c) :=
-λx, (hf x).add_const c
-
-lemma fderiv_within_add_const (hxs : unique_diff_within_at 𝕜 s x)
-  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
-  fderiv_within 𝕜 (λy, f y + c) s x = fderiv_within 𝕜 f s x :=
-(hf.has_fderiv_within_at.add_const c).fderiv_within hxs
-
-lemma fderiv_add_const
-  (hf : differentiable_at 𝕜 f x) (c : F) :
-  fderiv 𝕜 (λy, f y + c) x = fderiv 𝕜 f x :=
-(hf.has_fderiv_at.add_const c).fderiv
-
-theorem has_fderiv_at_filter.const_add
-  (hf : has_fderiv_at_filter f f' x L) (c : F) :
-  has_fderiv_at_filter (λ y, c + f y) f' x L :=
-zero_add f' ▸ (has_fderiv_at_filter_const _ _ _).add hf
-
-theorem has_fderiv_within_at.const_add
-  (hf : has_fderiv_within_at f f' s x) (c : F) :
-  has_fderiv_within_at (λ y, c + f y) f' s x :=
-hf.const_add c
-
-theorem has_fderiv_at.const_add
-  (hf : has_fderiv_at f f' x) (c : F):
-  has_fderiv_at (λ x, c + f x) f' x :=
-hf.const_add c
-
-lemma differentiable_within_at.const_add
-  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
-  differentiable_within_at 𝕜 (λ y, c + f y) s x :=
-(hf.has_fderiv_within_at.const_add c).differentiable_within_at
-
-lemma differentiable_at.const_add
-  (hf : differentiable_at 𝕜 f x) (c : F) :
-  differentiable_at 𝕜 (λ y, c + f y) x :=
-(hf.has_fderiv_at.const_add c).differentiable_at
-
-lemma differentiable_on.const_add
-  (hf : differentiable_on 𝕜 f s) (c : F) :
-  differentiable_on 𝕜 (λy, c + f y) s :=
-λx hx, (hf x hx).const_add c
-
-lemma differentiable.const_add
-  (hf : differentiable 𝕜 f) (c : F) :
-  differentiable 𝕜 (λy, c + f y) :=
-λx, (hf x).const_add c
-
-lemma fderiv_within_const_add (hxs : unique_diff_within_at 𝕜 s x)
-  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
-  fderiv_within 𝕜 (λy, c + f y) s x = fderiv_within 𝕜 f s x :=
-(hf.has_fderiv_within_at.const_add c).fderiv_within hxs
-
-lemma fderiv_const_add
-  (hf : differentiable_at 𝕜 f x) (c : F) :
-  fderiv 𝕜 (λy, c + f y) x = fderiv 𝕜 f x :=
-(hf.has_fderiv_at.const_add c).fderiv
-
-end add
-
-section neg
-/-! ### Derivative of the negative of a function -/
-
-theorem has_fderiv_at_filter.neg (h : has_fderiv_at_filter f f' x L) :
-  has_fderiv_at_filter (λ x, -f x) (-f') x L :=
-(h.const_smul (-1:𝕜)).congr (by simp) (by simp)
-
-theorem has_fderiv_within_at.neg (h : has_fderiv_within_at f f' s x) :
-  has_fderiv_within_at (λ x, -f x) (-f') s x :=
-h.neg
-
-theorem has_fderiv_at.neg (h : has_fderiv_at f f' x) :
-  has_fderiv_at (λ x, -f x) (-f') x :=
-h.neg
-
-lemma differentiable_within_at.neg (h : differentiable_within_at 𝕜 f s x) :
-  differentiable_within_at 𝕜 (λy, -f y) s x :=
-h.has_fderiv_within_at.neg.differentiable_within_at
-
-lemma differentiable_at.neg (h : differentiable_at 𝕜 f x) :
-  differentiable_at 𝕜 (λy, -f y) x :=
-h.has_fderiv_at.neg.differentiable_at
-
-lemma differentiable_on.neg (h : differentiable_on 𝕜 f s) :
-  differentiable_on 𝕜 (λy, -f y) s :=
-λx hx, (h x hx).neg
-
-lemma differentiable.neg (h : differentiable 𝕜 f) :
-  differentiable 𝕜 (λy, -f y) :=
-λx, (h x).neg
-
-lemma fderiv_within_neg (hxs : unique_diff_within_at 𝕜 s x)
-  (h : differentiable_within_at 𝕜 f s x) :
-  fderiv_within 𝕜 (λy, -f y) s x = - fderiv_within 𝕜 f s x :=
-h.has_fderiv_within_at.neg.fderiv_within hxs
-
-lemma fderiv_neg (h : differentiable_at 𝕜 f x) :
-  fderiv 𝕜 (λy, -f y) x = - fderiv 𝕜 f x :=
-h.has_fderiv_at.neg.fderiv
-
-end neg
-
-section sub
-/-! ### Derivative of the difference of two functions -/
-
-theorem has_fderiv_at_filter.sub
-  (hf : has_fderiv_at_filter f f' x L) (hg : has_fderiv_at_filter g g' x L) :
-  has_fderiv_at_filter (λ x, f x - g x) (f' - g') x L :=
-hf.add hg.neg
-
-theorem has_fderiv_within_at.sub
-  (hf : has_fderiv_within_at f f' s x) (hg : has_fderiv_within_at g g' s x) :
-  has_fderiv_within_at (λ x, f x - g x) (f' - g') s x :=
-hf.sub hg
-
-theorem has_fderiv_at.sub
-  (hf : has_fderiv_at f f' x) (hg : has_fderiv_at g g' x) :
-  has_fderiv_at (λ x, f x - g x) (f' - g') x :=
-hf.sub hg
-
-lemma differentiable_within_at.sub
-  (hf : differentiable_within_at 𝕜 f s x) (hg : differentiable_within_at 𝕜 g s x) :
-  differentiable_within_at 𝕜 (λ y, f y - g y) s x :=
-(hf.has_fderiv_within_at.sub hg.has_fderiv_within_at).differentiable_within_at
-
-lemma differentiable_at.sub
-  (hf : differentiable_at 𝕜 f x) (hg : differentiable_at 𝕜 g x) :
-  differentiable_at 𝕜 (λ y, f y - g y) x :=
-(hf.has_fderiv_at.sub hg.has_fderiv_at).differentiable_at
-
-lemma differentiable_on.sub
-  (hf : differentiable_on 𝕜 f s) (hg : differentiable_on 𝕜 g s) :
-  differentiable_on 𝕜 (λy, f y - g y) s :=
-λx hx, (hf x hx).sub (hg x hx)
-
-lemma differentiable.sub
-  (hf : differentiable 𝕜 f) (hg : differentiable 𝕜 g) :
-  differentiable 𝕜 (λy, f y - g y) :=
-λx, (hf x).sub (hg x)
-
-lemma fderiv_within_sub (hxs : unique_diff_within_at 𝕜 s x)
-  (hf : differentiable_within_at 𝕜 f s x) (hg : differentiable_within_at 𝕜 g s x) :
-  fderiv_within 𝕜 (λy, f y - g y) s x = fderiv_within 𝕜 f s x - fderiv_within 𝕜 g s x :=
-(hf.has_fderiv_within_at.sub hg.has_fderiv_within_at).fderiv_within hxs
-
-lemma fderiv_sub
-  (hf : differentiable_at 𝕜 f x) (hg : differentiable_at 𝕜 g x) :
-  fderiv 𝕜 (λy, f y - g y) x = fderiv 𝕜 f x - fderiv 𝕜 g x :=
-(hf.has_fderiv_at.sub hg.has_fderiv_at).fderiv
-
-theorem has_fderiv_at_filter.is_O_sub (h : has_fderiv_at_filter f f' x L) :
-is_O (λ x', f x' - f x) (λ x', x' - x) L :=
-h.is_O.congr_of_sub.2 (f'.is_O_sub _ _)
-
-theorem has_fderiv_at_filter.sub_const
-  (hf : has_fderiv_at_filter f f' x L) (c : F) :
-  has_fderiv_at_filter (λ x, f x - c) f' x L :=
-hf.add_const (-c)
-
-theorem has_fderiv_within_at.sub_const
-  (hf : has_fderiv_within_at f f' s x) (c : F) :
-  has_fderiv_within_at (λ x, f x - c) f' s x :=
-hf.sub_const c
-
-theorem has_fderiv_at.sub_const
-  (hf : has_fderiv_at f f' x) (c : F) :
-  has_fderiv_at (λ x, f x - c) f' x :=
-hf.sub_const c
-
-lemma differentiable_within_at.sub_const
-  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
-  differentiable_within_at 𝕜 (λ y, f y - c) s x :=
-(hf.has_fderiv_within_at.sub_const c).differentiable_within_at
-
-lemma differentiable_at.sub_const
-  (hf : differentiable_at 𝕜 f x) (c : F) :
-  differentiable_at 𝕜 (λ y, f y - c) x :=
-(hf.has_fderiv_at.sub_const c).differentiable_at
-
-lemma differentiable_on.sub_const
-  (hf : differentiable_on 𝕜 f s) (c : F) :
-  differentiable_on 𝕜 (λy, f y - c) s :=
-λx hx, (hf x hx).sub_const c
-
-lemma differentiable.sub_const
-  (hf : differentiable 𝕜 f) (c : F) :
-  differentiable 𝕜 (λy, f y - c) :=
-λx, (hf x).sub_const c
-
-lemma fderiv_within_sub_const (hxs : unique_diff_within_at 𝕜 s x)
-  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
-  fderiv_within 𝕜 (λy, f y - c) s x = fderiv_within 𝕜 f s x :=
-(hf.has_fderiv_within_at.sub_const c).fderiv_within hxs
-
-lemma fderiv_sub_const
-  (hf : differentiable_at 𝕜 f x) (c : F) :
-  fderiv 𝕜 (λy, f y - c) x = fderiv 𝕜 f x :=
-(hf.has_fderiv_at.sub_const c).fderiv
-
-theorem has_fderiv_at_filter.const_sub
-  (hf : has_fderiv_at_filter f f' x L) (c : F) :
-  has_fderiv_at_filter (λ x, c - f x) (-f') x L :=
-hf.neg.const_add c
-
-theorem has_fderiv_within_at.const_sub
-  (hf : has_fderiv_within_at f f' s x) (c : F) :
-  has_fderiv_within_at (λ x, c - f x) (-f') s x :=
-hf.const_sub c
-
-theorem has_fderiv_at.const_sub
-  (hf : has_fderiv_at f f' x) (c : F) :
-  has_fderiv_at (λ x, c - f x) (-f') x :=
-hf.const_sub c
-
-lemma differentiable_within_at.const_sub
-  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
-  differentiable_within_at 𝕜 (λ y, c - f y) s x :=
-(hf.has_fderiv_within_at.const_sub c).differentiable_within_at
-
-lemma differentiable_at.const_sub
-  (hf : differentiable_at 𝕜 f x) (c : F) :
-  differentiable_at 𝕜 (λ y, c - f y) x :=
-(hf.has_fderiv_at.const_sub c).differentiable_at
-
-lemma differentiable_on.const_sub
-  (hf : differentiable_on 𝕜 f s) (c : F) :
-  differentiable_on 𝕜 (λy, c - f y) s :=
-λx hx, (hf x hx).const_sub c
-
-lemma differentiable.const_sub
-  (hf : differentiable 𝕜 f) (c : F) :
-  differentiable 𝕜 (λy, c - f y) :=
-λx, (hf x).const_sub c
-
-lemma fderiv_within_const_sub (hxs : unique_diff_within_at 𝕜 s x)
-  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
-  fderiv_within 𝕜 (λy, c - f y) s x = -fderiv_within 𝕜 f s x :=
-(hf.has_fderiv_within_at.const_sub c).fderiv_within hxs
-
-lemma fderiv_const_sub
-  (hf : differentiable_at 𝕜 f x) (c : F) :
-  fderiv 𝕜 (λy, c - f y) x = -fderiv 𝕜 f x :=
-(hf.has_fderiv_at.const_sub c).fderiv
-
-end sub
-
-section continuous
-/-! ### Deducing continuity from differentiability -/
-
-theorem has_fderiv_at_filter.tendsto_nhds
-  (hL : L ≤ 𝓝 x) (h : has_fderiv_at_filter f f' x L) :
-  tendsto f L (𝓝 (f x)) :=
-begin
-  have : tendsto (λ x', f x' - f x) L (𝓝 0),
-  { refine h.is_O_sub.trans_tendsto (tendsto_le_left hL _),
-    rw ← sub_self x, exact tendsto_id.sub tendsto_const_nhds },
-  have := tendsto.add this tendsto_const_nhds,
-  rw zero_add (f x) at this,
-  exact this.congr (by simp)
-end
-
-theorem has_fderiv_within_at.continuous_within_at
-  (h : has_fderiv_within_at f f' s x) : continuous_within_at f s x :=
-has_fderiv_at_filter.tendsto_nhds inf_le_left h
-
-theorem has_fderiv_at.continuous_at (h : has_fderiv_at f f' x) :
-  continuous_at f x :=
-has_fderiv_at_filter.tendsto_nhds (le_refl _) h
-
-lemma differentiable_within_at.continuous_within_at (h : differentiable_within_at 𝕜 f s x) :
-  continuous_within_at f s x :=
-let ⟨f', hf'⟩ := h in hf'.continuous_within_at
-
-lemma differentiable_at.continuous_at (h : differentiable_at 𝕜 f x) : continuous_at f x :=
-let ⟨f', hf'⟩ := h in hf'.continuous_at
-
-lemma differentiable_on.continuous_on (h : differentiable_on 𝕜 f s) : continuous_on f s :=
-λx hx, (h x hx).continuous_within_at
-
-lemma differentiable.continuous (h : differentiable 𝕜 f) : continuous f :=
-continuous_iff_continuous_at.2 $ λx, (h x).continuous_at
-
-end continuous
-
-section bilinear_map
-/-! ### Derivative of a bounded bilinear map -/
-
-variables {b : E × F → G} {u : set (E × F) }
-
-open normed_field
-
-lemma is_bounded_bilinear_map.has_fderiv_at (h : is_bounded_bilinear_map 𝕜 b) (p : E × F) :
-  has_fderiv_at b (h.deriv p) p :=
-begin
-  have : (λ (x : E × F), b x - b p - (h.deriv p) (x - p)) = (λx, b (x.1 - p.1, x.2 - p.2)),
-  { ext x,
-    delta is_bounded_bilinear_map.deriv,
-    change b x - b p - (b (p.1, x.2-p.2) + b (x.1-p.1, p.2))
-           = b (x.1 - p.1, x.2 - p.2),
-    have : b x = b (x.1, x.2), by { cases x, refl },
-    rw this,
-    have : b p = b (p.1, p.2), by { cases p, refl },
-    rw this,
-    simp only [h.map_sub_left, h.map_sub_right],
-    abel },
-  rw [has_fderiv_at, has_fderiv_at_filter, this],
-  rcases h.bound with ⟨C, Cpos, hC⟩,
-  have A : asymptotics.is_O (λx : E × F, b (x.1 - p.1, x.2 - p.2))
-    (λx, ∥x - p∥ * ∥x - p∥) (𝓝 p) :=
-  ⟨C, filter.univ_mem_sets' (λx, begin
-    simp only [mem_set_of_eq, norm_mul, norm_norm],
-    calc ∥b (x.1 - p.1, x.2 - p.2)∥ ≤ C * ∥x.1 - p.1∥ * ∥x.2 - p.2∥ : hC _ _
-    ... ≤ C * ∥x-p∥ * ∥x-p∥ : by apply_rules [mul_le_mul, le_max_left, le_max_right, norm_nonneg,
-      le_of_lt Cpos, le_refl, mul_nonneg, norm_nonneg, norm_nonneg]
-    ... = C * (∥x-p∥ * ∥x-p∥) : mul_assoc _ _ _ end)⟩,
-  have B : asymptotics.is_o (λ (x : E × F), ∥x - p∥ * ∥x - p∥)
-    (λx, 1 * ∥x - p∥) (𝓝 p),
-  { refine asymptotics.is_o.mul_is_O (asymptotics.is_o.norm_left _) (asymptotics.is_O_refl _ _),
-    apply (asymptotics.is_o_one_iff ℝ).2,
-    rw [← sub_self p],
-    exact tendsto_id.sub tendsto_const_nhds },
-  simp only [one_mul, asymptotics.is_o_norm_right] at B,
-  exact A.trans_is_o B
-end
-
-lemma is_bounded_bilinear_map.has_fderiv_within_at (h : is_bounded_bilinear_map 𝕜 b) (p : E × F) :
-  has_fderiv_within_at b (h.deriv p) u p :=
-(h.has_fderiv_at p).has_fderiv_within_at
-
-lemma is_bounded_bilinear_map.differentiable_at (h : is_bounded_bilinear_map 𝕜 b) (p : E × F) :
-  differentiable_at 𝕜 b p :=
-(h.has_fderiv_at p).differentiable_at
-
-lemma is_bounded_bilinear_map.differentiable_within_at (h : is_bounded_bilinear_map 𝕜 b) (p : E × F) :
-  differentiable_within_at 𝕜 b u p :=
-(h.differentiable_at p).differentiable_within_at
-
-lemma is_bounded_bilinear_map.fderiv (h : is_bounded_bilinear_map 𝕜 b) (p : E × F) :
-  fderiv 𝕜 b p = h.deriv p :=
-has_fderiv_at.fderiv (h.has_fderiv_at p)
-
-lemma is_bounded_bilinear_map.fderiv_within (h : is_bounded_bilinear_map 𝕜 b) (p : E × F)
-  (hxs : unique_diff_within_at 𝕜 u p) : fderiv_within 𝕜 b u p = h.deriv p :=
-begin
-  rw differentiable_at.fderiv_within (h.differentiable_at p) hxs,
-  exact h.fderiv p
-end
-
-lemma is_bounded_bilinear_map.differentiable (h : is_bounded_bilinear_map 𝕜 b) :
-  differentiable 𝕜 b :=
-λx, h.differentiable_at x
-
-lemma is_bounded_bilinear_map.differentiable_on (h : is_bounded_bilinear_map 𝕜 b) :
-  differentiable_on 𝕜 b u :=
-h.differentiable.differentiable_on
-
-lemma is_bounded_bilinear_map.continuous (h : is_bounded_bilinear_map 𝕜 b) :
-  continuous b :=
-h.differentiable.continuous
-
-lemma is_bounded_bilinear_map.continuous_left (h : is_bounded_bilinear_map 𝕜 b) {f : F} :
-  continuous (λe, b (e, f)) :=
-h.continuous.comp (continuous_id.prod_mk continuous_const)
-
-lemma is_bounded_bilinear_map.continuous_right (h : is_bounded_bilinear_map 𝕜 b) {e : E} :
-  continuous (λf, b (e, f)) :=
-h.continuous.comp (continuous_const.prod_mk continuous_id)
-
-end bilinear_map
 
 section cartesian_product
 /-! ### Derivative of the cartesian product of two functions -/
@@ -1242,13 +781,7 @@ variables {f₂ : E → G} {f₂' : E →L[𝕜] G}
 lemma has_fderiv_at_filter.prod
   (hf₁ : has_fderiv_at_filter f₁ f₁' x L) (hf₂ : has_fderiv_at_filter f₂ f₂' x L) :
   has_fderiv_at_filter (λx, (f₁ x, f₂ x)) (continuous_linear_map.prod f₁' f₂') x L :=
-begin
-  have : (λ (x' : E), (f₁ x', f₂ x') - (f₁ x, f₂ x) - (continuous_linear_map.prod f₁' f₂') (x' -x)) =
-           (λ (x' : E), (f₁ x' - f₁ x - f₁' (x' - x), f₂ x' - f₂ x - f₂' (x' - x))) := rfl,
-  rw [has_fderiv_at_filter, this],
-  rw [asymptotics.is_o_prod_left],
-  exact ⟨hf₁, hf₂⟩
-end
+hf₁.prod_left hf₂
 
 lemma has_fderiv_within_at.prod
   (hf₁ : has_fderiv_within_at f₁ f₁' s x) (hf₂ : has_fderiv_within_at f₂ f₂' s x) :
@@ -1420,6 +953,455 @@ lemma differentiable.comp_differentiable_on {g : F → G} (hg : differentiable �
 (differentiable_on_univ.2 hg).comp hf (by simp)
 
 end composition
+
+section const_smul
+/-! ### Derivative of a function multiplied by a constant -/
+theorem has_fderiv_at_filter.const_smul (h : has_fderiv_at_filter f f' x L) (c : 𝕜) :
+  has_fderiv_at_filter (λ x, c • f x) (c • f') x L :=
+(is_o_const_smul_left h c).congr_left $ λ x, by simp [smul_sub]
+
+theorem has_fderiv_within_at.const_smul (h : has_fderiv_within_at f f' s x) (c : 𝕜) :
+  has_fderiv_within_at (λ x, c • f x) (c • f') s x :=
+h.const_smul c
+
+theorem has_fderiv_at.const_smul (h : has_fderiv_at f f' x) (c : 𝕜) :
+  has_fderiv_at (λ x, c • f x) (c • f') x :=
+h.const_smul c
+
+lemma differentiable_within_at.const_smul (h : differentiable_within_at 𝕜 f s x) (c : 𝕜) :
+  differentiable_within_at 𝕜 (λy, c • f y) s x :=
+(h.has_fderiv_within_at.const_smul c).differentiable_within_at
+
+lemma differentiable_at.const_smul (h : differentiable_at 𝕜 f x) (c : 𝕜) :
+  differentiable_at 𝕜 (λy, c • f y) x :=
+(h.has_fderiv_at.const_smul c).differentiable_at
+
+lemma differentiable_on.const_smul (h : differentiable_on 𝕜 f s) (c : 𝕜) :
+  differentiable_on 𝕜 (λy, c • f y) s :=
+λx hx, (h x hx).const_smul c
+
+lemma differentiable.const_smul (h : differentiable 𝕜 f) (c : 𝕜) :
+  differentiable 𝕜 (λy, c • f y) :=
+λx, (h x).const_smul c
+
+lemma fderiv_within_const_smul (hxs : unique_diff_within_at 𝕜 s x)
+  (h : differentiable_within_at 𝕜 f s x) (c : 𝕜) :
+  fderiv_within 𝕜 (λy, c • f y) s x = c • fderiv_within 𝕜 f s x :=
+(h.has_fderiv_within_at.const_smul c).fderiv_within hxs
+
+lemma fderiv_const_smul (h : differentiable_at 𝕜 f x) (c : 𝕜) :
+  fderiv 𝕜 (λy, c • f y) x = c • fderiv 𝕜 f x :=
+(h.has_fderiv_at.const_smul c).fderiv
+
+end const_smul
+
+section add
+/-! ### Derivative of the sum of two functions -/
+
+theorem has_fderiv_at_filter.add
+  (hf : has_fderiv_at_filter f f' x L) (hg : has_fderiv_at_filter g g' x L) :
+  has_fderiv_at_filter (λ y, f y + g y) (f' + g') x L :=
+(hf.add hg).congr_left $ λ _, by simp; abel
+
+theorem has_fderiv_within_at.add
+  (hf : has_fderiv_within_at f f' s x) (hg : has_fderiv_within_at g g' s x) :
+  has_fderiv_within_at (λ y, f y + g y) (f' + g') s x :=
+hf.add hg
+
+theorem has_fderiv_at.add
+  (hf : has_fderiv_at f f' x) (hg : has_fderiv_at g g' x) :
+  has_fderiv_at (λ x, f x + g x) (f' + g') x :=
+hf.add hg
+
+lemma differentiable_within_at.add
+  (hf : differentiable_within_at 𝕜 f s x) (hg : differentiable_within_at 𝕜 g s x) :
+  differentiable_within_at 𝕜 (λ y, f y + g y) s x :=
+(hf.has_fderiv_within_at.add hg.has_fderiv_within_at).differentiable_within_at
+
+lemma differentiable_at.add
+  (hf : differentiable_at 𝕜 f x) (hg : differentiable_at 𝕜 g x) :
+  differentiable_at 𝕜 (λ y, f y + g y) x :=
+(hf.has_fderiv_at.add hg.has_fderiv_at).differentiable_at
+
+lemma differentiable_on.add
+  (hf : differentiable_on 𝕜 f s) (hg : differentiable_on 𝕜 g s) :
+  differentiable_on 𝕜 (λy, f y + g y) s :=
+λx hx, (hf x hx).add (hg x hx)
+
+lemma differentiable.add
+  (hf : differentiable 𝕜 f) (hg : differentiable 𝕜 g) :
+  differentiable 𝕜 (λy, f y + g y) :=
+λx, (hf x).add (hg x)
+
+lemma fderiv_within_add (hxs : unique_diff_within_at 𝕜 s x)
+  (hf : differentiable_within_at 𝕜 f s x) (hg : differentiable_within_at 𝕜 g s x) :
+  fderiv_within 𝕜 (λy, f y + g y) s x = fderiv_within 𝕜 f s x + fderiv_within 𝕜 g s x :=
+(hf.has_fderiv_within_at.add hg.has_fderiv_within_at).fderiv_within hxs
+
+lemma fderiv_add
+  (hf : differentiable_at 𝕜 f x) (hg : differentiable_at 𝕜 g x) :
+  fderiv 𝕜 (λy, f y + g y) x = fderiv 𝕜 f x + fderiv 𝕜 g x :=
+(hf.has_fderiv_at.add hg.has_fderiv_at).fderiv
+
+theorem has_fderiv_at_filter.add_const
+  (hf : has_fderiv_at_filter f f' x L) (c : F) :
+  has_fderiv_at_filter (λ y, f y + c) f' x L :=
+add_zero f' ▸ hf.add (has_fderiv_at_filter_const _ _ _)
+
+theorem has_fderiv_within_at.add_const
+  (hf : has_fderiv_within_at f f' s x) (c : F) :
+  has_fderiv_within_at (λ y, f y + c) f' s x :=
+hf.add_const c
+
+theorem has_fderiv_at.add_const
+  (hf : has_fderiv_at f f' x) (c : F):
+  has_fderiv_at (λ x, f x + c) f' x :=
+hf.add_const c
+
+lemma differentiable_within_at.add_const
+  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
+  differentiable_within_at 𝕜 (λ y, f y + c) s x :=
+(hf.has_fderiv_within_at.add_const c).differentiable_within_at
+
+lemma differentiable_at.add_const
+  (hf : differentiable_at 𝕜 f x) (c : F) :
+  differentiable_at 𝕜 (λ y, f y + c) x :=
+(hf.has_fderiv_at.add_const c).differentiable_at
+
+lemma differentiable_on.add_const
+  (hf : differentiable_on 𝕜 f s) (c : F) :
+  differentiable_on 𝕜 (λy, f y + c) s :=
+λx hx, (hf x hx).add_const c
+
+lemma differentiable.add_const
+  (hf : differentiable 𝕜 f) (c : F) :
+  differentiable 𝕜 (λy, f y + c) :=
+λx, (hf x).add_const c
+
+lemma fderiv_within_add_const (hxs : unique_diff_within_at 𝕜 s x)
+  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
+  fderiv_within 𝕜 (λy, f y + c) s x = fderiv_within 𝕜 f s x :=
+(hf.has_fderiv_within_at.add_const c).fderiv_within hxs
+
+lemma fderiv_add_const
+  (hf : differentiable_at 𝕜 f x) (c : F) :
+  fderiv 𝕜 (λy, f y + c) x = fderiv 𝕜 f x :=
+(hf.has_fderiv_at.add_const c).fderiv
+
+theorem has_fderiv_at_filter.const_add
+  (hf : has_fderiv_at_filter f f' x L) (c : F) :
+  has_fderiv_at_filter (λ y, c + f y) f' x L :=
+zero_add f' ▸ (has_fderiv_at_filter_const _ _ _).add hf
+
+theorem has_fderiv_within_at.const_add
+  (hf : has_fderiv_within_at f f' s x) (c : F) :
+  has_fderiv_within_at (λ y, c + f y) f' s x :=
+hf.const_add c
+
+theorem has_fderiv_at.const_add
+  (hf : has_fderiv_at f f' x) (c : F):
+  has_fderiv_at (λ x, c + f x) f' x :=
+hf.const_add c
+
+lemma differentiable_within_at.const_add
+  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
+  differentiable_within_at 𝕜 (λ y, c + f y) s x :=
+(hf.has_fderiv_within_at.const_add c).differentiable_within_at
+
+lemma differentiable_at.const_add
+  (hf : differentiable_at 𝕜 f x) (c : F) :
+  differentiable_at 𝕜 (λ y, c + f y) x :=
+(hf.has_fderiv_at.const_add c).differentiable_at
+
+lemma differentiable_on.const_add
+  (hf : differentiable_on 𝕜 f s) (c : F) :
+  differentiable_on 𝕜 (λy, c + f y) s :=
+λx hx, (hf x hx).const_add c
+
+lemma differentiable.const_add
+  (hf : differentiable 𝕜 f) (c : F) :
+  differentiable 𝕜 (λy, c + f y) :=
+λx, (hf x).const_add c
+
+lemma fderiv_within_const_add (hxs : unique_diff_within_at 𝕜 s x)
+  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
+  fderiv_within 𝕜 (λy, c + f y) s x = fderiv_within 𝕜 f s x :=
+(hf.has_fderiv_within_at.const_add c).fderiv_within hxs
+
+lemma fderiv_const_add
+  (hf : differentiable_at 𝕜 f x) (c : F) :
+  fderiv 𝕜 (λy, c + f y) x = fderiv 𝕜 f x :=
+(hf.has_fderiv_at.const_add c).fderiv
+
+end add
+
+section neg
+/-! ### Derivative of the negative of a function -/
+
+theorem has_fderiv_at_filter.neg (h : has_fderiv_at_filter f f' x L) :
+  has_fderiv_at_filter (λ x, -f x) (-f') x L :=
+(-1 : F →L[𝕜] F).has_fderiv_at_filter.comp x h
+
+theorem has_fderiv_within_at.neg (h : has_fderiv_within_at f f' s x) :
+  has_fderiv_within_at (λ x, -f x) (-f') s x :=
+h.neg
+
+theorem has_fderiv_at.neg (h : has_fderiv_at f f' x) :
+  has_fderiv_at (λ x, -f x) (-f') x :=
+h.neg
+
+lemma differentiable_within_at.neg (h : differentiable_within_at 𝕜 f s x) :
+  differentiable_within_at 𝕜 (λy, -f y) s x :=
+h.has_fderiv_within_at.neg.differentiable_within_at
+
+lemma differentiable_at.neg (h : differentiable_at 𝕜 f x) :
+  differentiable_at 𝕜 (λy, -f y) x :=
+h.has_fderiv_at.neg.differentiable_at
+
+lemma differentiable_on.neg (h : differentiable_on 𝕜 f s) :
+  differentiable_on 𝕜 (λy, -f y) s :=
+λx hx, (h x hx).neg
+
+lemma differentiable.neg (h : differentiable 𝕜 f) :
+  differentiable 𝕜 (λy, -f y) :=
+λx, (h x).neg
+
+lemma fderiv_within_neg (hxs : unique_diff_within_at 𝕜 s x)
+  (h : differentiable_within_at 𝕜 f s x) :
+  fderiv_within 𝕜 (λy, -f y) s x = - fderiv_within 𝕜 f s x :=
+h.has_fderiv_within_at.neg.fderiv_within hxs
+
+lemma fderiv_neg (h : differentiable_at 𝕜 f x) :
+  fderiv 𝕜 (λy, -f y) x = - fderiv 𝕜 f x :=
+h.has_fderiv_at.neg.fderiv
+
+end neg
+
+section sub
+/-! ### Derivative of the difference of two functions -/
+
+theorem has_fderiv_at_filter.sub
+  (hf : has_fderiv_at_filter f f' x L) (hg : has_fderiv_at_filter g g' x L) :
+  has_fderiv_at_filter (λ x, f x - g x) (f' - g') x L :=
+hf.add hg.neg
+
+theorem has_fderiv_within_at.sub
+  (hf : has_fderiv_within_at f f' s x) (hg : has_fderiv_within_at g g' s x) :
+  has_fderiv_within_at (λ x, f x - g x) (f' - g') s x :=
+hf.sub hg
+
+theorem has_fderiv_at.sub
+  (hf : has_fderiv_at f f' x) (hg : has_fderiv_at g g' x) :
+  has_fderiv_at (λ x, f x - g x) (f' - g') x :=
+hf.sub hg
+
+lemma differentiable_within_at.sub
+  (hf : differentiable_within_at 𝕜 f s x) (hg : differentiable_within_at 𝕜 g s x) :
+  differentiable_within_at 𝕜 (λ y, f y - g y) s x :=
+(hf.has_fderiv_within_at.sub hg.has_fderiv_within_at).differentiable_within_at
+
+lemma differentiable_at.sub
+  (hf : differentiable_at 𝕜 f x) (hg : differentiable_at 𝕜 g x) :
+  differentiable_at 𝕜 (λ y, f y - g y) x :=
+(hf.has_fderiv_at.sub hg.has_fderiv_at).differentiable_at
+
+lemma differentiable_on.sub
+  (hf : differentiable_on 𝕜 f s) (hg : differentiable_on 𝕜 g s) :
+  differentiable_on 𝕜 (λy, f y - g y) s :=
+λx hx, (hf x hx).sub (hg x hx)
+
+lemma differentiable.sub
+  (hf : differentiable 𝕜 f) (hg : differentiable 𝕜 g) :
+  differentiable 𝕜 (λy, f y - g y) :=
+λx, (hf x).sub (hg x)
+
+lemma fderiv_within_sub (hxs : unique_diff_within_at 𝕜 s x)
+  (hf : differentiable_within_at 𝕜 f s x) (hg : differentiable_within_at 𝕜 g s x) :
+  fderiv_within 𝕜 (λy, f y - g y) s x = fderiv_within 𝕜 f s x - fderiv_within 𝕜 g s x :=
+(hf.has_fderiv_within_at.sub hg.has_fderiv_within_at).fderiv_within hxs
+
+lemma fderiv_sub
+  (hf : differentiable_at 𝕜 f x) (hg : differentiable_at 𝕜 g x) :
+  fderiv 𝕜 (λy, f y - g y) x = fderiv 𝕜 f x - fderiv 𝕜 g x :=
+(hf.has_fderiv_at.sub hg.has_fderiv_at).fderiv
+
+theorem has_fderiv_at_filter.sub_const
+  (hf : has_fderiv_at_filter f f' x L) (c : F) :
+  has_fderiv_at_filter (λ x, f x - c) f' x L :=
+hf.add_const (-c)
+
+theorem has_fderiv_within_at.sub_const
+  (hf : has_fderiv_within_at f f' s x) (c : F) :
+  has_fderiv_within_at (λ x, f x - c) f' s x :=
+hf.sub_const c
+
+theorem has_fderiv_at.sub_const
+  (hf : has_fderiv_at f f' x) (c : F) :
+  has_fderiv_at (λ x, f x - c) f' x :=
+hf.sub_const c
+
+lemma differentiable_within_at.sub_const
+  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
+  differentiable_within_at 𝕜 (λ y, f y - c) s x :=
+(hf.has_fderiv_within_at.sub_const c).differentiable_within_at
+
+lemma differentiable_at.sub_const
+  (hf : differentiable_at 𝕜 f x) (c : F) :
+  differentiable_at 𝕜 (λ y, f y - c) x :=
+(hf.has_fderiv_at.sub_const c).differentiable_at
+
+lemma differentiable_on.sub_const
+  (hf : differentiable_on 𝕜 f s) (c : F) :
+  differentiable_on 𝕜 (λy, f y - c) s :=
+λx hx, (hf x hx).sub_const c
+
+lemma differentiable.sub_const
+  (hf : differentiable 𝕜 f) (c : F) :
+  differentiable 𝕜 (λy, f y - c) :=
+λx, (hf x).sub_const c
+
+lemma fderiv_within_sub_const (hxs : unique_diff_within_at 𝕜 s x)
+  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
+  fderiv_within 𝕜 (λy, f y - c) s x = fderiv_within 𝕜 f s x :=
+(hf.has_fderiv_within_at.sub_const c).fderiv_within hxs
+
+lemma fderiv_sub_const
+  (hf : differentiable_at 𝕜 f x) (c : F) :
+  fderiv 𝕜 (λy, f y - c) x = fderiv 𝕜 f x :=
+(hf.has_fderiv_at.sub_const c).fderiv
+
+theorem has_fderiv_at_filter.const_sub
+  (hf : has_fderiv_at_filter f f' x L) (c : F) :
+  has_fderiv_at_filter (λ x, c - f x) (-f') x L :=
+hf.neg.const_add c
+
+theorem has_fderiv_within_at.const_sub
+  (hf : has_fderiv_within_at f f' s x) (c : F) :
+  has_fderiv_within_at (λ x, c - f x) (-f') s x :=
+hf.const_sub c
+
+theorem has_fderiv_at.const_sub
+  (hf : has_fderiv_at f f' x) (c : F) :
+  has_fderiv_at (λ x, c - f x) (-f') x :=
+hf.const_sub c
+
+lemma differentiable_within_at.const_sub
+  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
+  differentiable_within_at 𝕜 (λ y, c - f y) s x :=
+(hf.has_fderiv_within_at.const_sub c).differentiable_within_at
+
+lemma differentiable_at.const_sub
+  (hf : differentiable_at 𝕜 f x) (c : F) :
+  differentiable_at 𝕜 (λ y, c - f y) x :=
+(hf.has_fderiv_at.const_sub c).differentiable_at
+
+lemma differentiable_on.const_sub
+  (hf : differentiable_on 𝕜 f s) (c : F) :
+  differentiable_on 𝕜 (λy, c - f y) s :=
+λx hx, (hf x hx).const_sub c
+
+lemma differentiable.const_sub
+  (hf : differentiable 𝕜 f) (c : F) :
+  differentiable 𝕜 (λy, c - f y) :=
+λx, (hf x).const_sub c
+
+lemma fderiv_within_const_sub (hxs : unique_diff_within_at 𝕜 s x)
+  (hf : differentiable_within_at 𝕜 f s x) (c : F) :
+  fderiv_within 𝕜 (λy, c - f y) s x = -fderiv_within 𝕜 f s x :=
+(hf.has_fderiv_within_at.const_sub c).fderiv_within hxs
+
+lemma fderiv_const_sub
+  (hf : differentiable_at 𝕜 f x) (c : F) :
+  fderiv 𝕜 (λy, c - f y) x = -fderiv 𝕜 f x :=
+(hf.has_fderiv_at.const_sub c).fderiv
+
+end sub
+
+section bilinear_map
+/-! ### Derivative of a bounded bilinear map -/
+
+variables {b : E × F → G} {u : set (E × F) }
+
+open normed_field
+
+lemma is_bounded_bilinear_map.has_fderiv_at (h : is_bounded_bilinear_map 𝕜 b) (p : E × F) :
+  has_fderiv_at b (h.deriv p) p :=
+begin
+  have : (λ (x : E × F), b x - b p - (h.deriv p) (x - p)) = (λx, b (x.1 - p.1, x.2 - p.2)),
+  { ext x,
+    delta is_bounded_bilinear_map.deriv,
+    change b x - b p - (b (p.1, x.2-p.2) + b (x.1-p.1, p.2))
+           = b (x.1 - p.1, x.2 - p.2),
+    have : b x = b (x.1, x.2), by { cases x, refl },
+    rw this,
+    have : b p = b (p.1, p.2), by { cases p, refl },
+    rw this,
+    simp only [h.map_sub_left, h.map_sub_right],
+    abel },
+  rw [has_fderiv_at, has_fderiv_at_filter, this],
+  rcases h.bound with ⟨C, Cpos, hC⟩,
+  have A : asymptotics.is_O (λx : E × F, b (x.1 - p.1, x.2 - p.2))
+    (λx, ∥x - p∥ * ∥x - p∥) (𝓝 p) :=
+  ⟨C, filter.univ_mem_sets' (λx, begin
+    simp only [mem_set_of_eq, norm_mul, norm_norm],
+    calc ∥b (x.1 - p.1, x.2 - p.2)∥ ≤ C * ∥x.1 - p.1∥ * ∥x.2 - p.2∥ : hC _ _
+    ... ≤ C * ∥x-p∥ * ∥x-p∥ : by apply_rules [mul_le_mul, le_max_left, le_max_right, norm_nonneg,
+      le_of_lt Cpos, le_refl, mul_nonneg, norm_nonneg, norm_nonneg]
+    ... = C * (∥x-p∥ * ∥x-p∥) : mul_assoc _ _ _ end)⟩,
+  have B : asymptotics.is_o (λ (x : E × F), ∥x - p∥ * ∥x - p∥)
+    (λx, 1 * ∥x - p∥) (𝓝 p),
+  { refine asymptotics.is_o.mul_is_O (asymptotics.is_o.norm_left _) (asymptotics.is_O_refl _ _),
+    apply (asymptotics.is_o_one_iff ℝ).2,
+    rw [← sub_self p],
+    exact tendsto_id.sub tendsto_const_nhds },
+  simp only [one_mul, asymptotics.is_o_norm_right] at B,
+  exact A.trans_is_o B
+end
+
+lemma is_bounded_bilinear_map.has_fderiv_within_at (h : is_bounded_bilinear_map 𝕜 b) (p : E × F) :
+  has_fderiv_within_at b (h.deriv p) u p :=
+(h.has_fderiv_at p).has_fderiv_within_at
+
+lemma is_bounded_bilinear_map.differentiable_at (h : is_bounded_bilinear_map 𝕜 b) (p : E × F) :
+  differentiable_at 𝕜 b p :=
+(h.has_fderiv_at p).differentiable_at
+
+lemma is_bounded_bilinear_map.differentiable_within_at (h : is_bounded_bilinear_map 𝕜 b) (p : E × F) :
+  differentiable_within_at 𝕜 b u p :=
+(h.differentiable_at p).differentiable_within_at
+
+lemma is_bounded_bilinear_map.fderiv (h : is_bounded_bilinear_map 𝕜 b) (p : E × F) :
+  fderiv 𝕜 b p = h.deriv p :=
+has_fderiv_at.fderiv (h.has_fderiv_at p)
+
+lemma is_bounded_bilinear_map.fderiv_within (h : is_bounded_bilinear_map 𝕜 b) (p : E × F)
+  (hxs : unique_diff_within_at 𝕜 u p) : fderiv_within 𝕜 b u p = h.deriv p :=
+begin
+  rw differentiable_at.fderiv_within (h.differentiable_at p) hxs,
+  exact h.fderiv p
+end
+
+lemma is_bounded_bilinear_map.differentiable (h : is_bounded_bilinear_map 𝕜 b) :
+  differentiable 𝕜 b :=
+λx, h.differentiable_at x
+
+lemma is_bounded_bilinear_map.differentiable_on (h : is_bounded_bilinear_map 𝕜 b) :
+  differentiable_on 𝕜 b u :=
+h.differentiable.differentiable_on
+
+lemma is_bounded_bilinear_map.continuous (h : is_bounded_bilinear_map 𝕜 b) :
+  continuous b :=
+h.differentiable.continuous
+
+lemma is_bounded_bilinear_map.continuous_left (h : is_bounded_bilinear_map 𝕜 b) {f : F} :
+  continuous (λe, b (e, f)) :=
+h.continuous.comp (continuous_id.prod_mk continuous_const)
+
+lemma is_bounded_bilinear_map.continuous_right (h : is_bounded_bilinear_map 𝕜 b) {e : E} :
+  continuous (λf, b (e, f)) :=
+h.continuous.comp (continuous_const.prod_mk continuous_id)
+
+end bilinear_map
 
 section smul
 /-! ### Derivative of the product of a scalar-valued function and a vector-valued function -/

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -23,7 +23,11 @@ Finally,
 
   `has_strict_fderiv_at f f' x`
 
-means that `f : E → F` has derivative `f' : E →L[𝕜] F` in the sense of strict differentiability.
+means that `f : E → F` has derivative `f' : E →L[𝕜] F` in the sense of strict differentiability,
+i.e., `f y - f z - f'(y - z) = o(y - z)` as `y, z → x`. This notion is used in the inverse
+function theorem, and is defined here only to avoid proving theorems like
+`is_bounded_bilinear_map.has_fderiv_at` twice: first for `has_fderiv_at`, then for
+`has_strict_fderiv_at`.
 
 ## Main results
 
@@ -726,9 +730,9 @@ There are currently two variants of these in mathlib, the bundled version
 (named `continuous_linear_map`, and denoted `E →L[𝕜] F`), and the unbundled version (with a
 predicate `is_bounded_linear_map`). We give statements for both versions. -/
 
-protected theorem continuous_linear_map.has_strict_fderiv_at (f : E →L[𝕜] F) {x : E} :
-  has_strict_fderiv_at f f x :=
-(is_o_zero _ _).congr_left $ λ x, by simp only [f.map_sub, sub_self]
+protected theorem continuous_linear_map.has_strict_fderiv_at {x : E} :
+  has_strict_fderiv_at e e x :=
+(is_o_zero _ _).congr_left $ λ x, by simp only [e.map_sub, sub_self]
 
 protected lemma continuous_linear_map.has_fderiv_at_filter :
   has_fderiv_at_filter e e x L :=

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -108,7 +108,7 @@ def has_fderiv_at (f : E → F) (f' : E →L[𝕜] F) (x : E) :=
 has_fderiv_at_filter f f' x (𝓝 x)
 
 /-- A function `f` has derivative `f'` at `a` in the sense of *strict differentiability*
-if `f x - f y - f' (x - y) = o(x - y)` as `x, y → a`. This forrm of differentiability is required,
+if `f x - f y - f' (x - y) = o(x - y)` as `x, y → a`. This form of differentiability is required,
 e.g., by the inverse function theorem. Any `C^1` function on a vector space over `ℝ` is strictly
 differentiable but this definition works, e.g., for vector spaces over `p`-adic numbers. -/
 def has_strict_fderiv_at (f : E → F) (f' : E →L[𝕜] F) (x : E) :=

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -1796,10 +1796,9 @@ variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 
 /-- The image of a tangent cone under the differential of a map is included in the tangent cone to
 the image. -/
-lemma has_fderiv_within_at.image_tangent_cone_subset {x : E} (h : has_fderiv_within_at f f' s x) :
-  f' '' (tangent_cone_at 𝕜 s x) ⊆ tangent_cone_at 𝕜 (f '' s) (f x) :=
+lemma has_fderiv_within_at.maps_to_tangent_cone {x : E} (h : has_fderiv_within_at f f' s x) :
+  maps_to f' (tangent_cone_at 𝕜 s x) (tangent_cone_at 𝕜 (f '' s) (f x)) :=
 begin
-  rw image_subset_iff,
   rintros v ⟨c, d, dtop, clim, cdlim⟩,
   refine ⟨c, (λn, f (x + d n) - f x), mem_sets_of_superset dtop _, clim, h.lim at_top dtop clim cdlim⟩,
   simp [-mem_image, mem_image_of_mem] {contextual := tt}
@@ -1812,16 +1811,11 @@ lemma has_fderiv_within_at.unique_diff_within_at {x : E} (h : has_fderiv_within_
   (hs : unique_diff_within_at 𝕜 s x) (h' : closure (range f') = univ) :
   unique_diff_within_at 𝕜 (f '' s) (f x) :=
 begin
-  have A : ∀v ∈ tangent_cone_at 𝕜 s x, f' v ∈ tangent_cone_at 𝕜 (f '' s) (f x),
-  { assume v hv,
-    have := h.image_tangent_cone_subset,
-    rw image_subset_iff at this,
-    exact this hv },
   have B : ∀v ∈ (submodule.span 𝕜 (tangent_cone_at 𝕜 s x) : set E),
     f' v ∈ (submodule.span 𝕜 (tangent_cone_at 𝕜 (f '' s) (f x)) : set F),
   { assume v hv,
     apply submodule.span_induction hv,
-    { exact λ w hw, submodule.subset_span (A w hw) },
+    { exact λ w hw, submodule.subset_span (h.maps_to_tangent_cone hw) },
     { simp },
     { assume w₁ w₂ hw₁ hw₂,
       rw continuous_linear_map.map_add,

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -19,6 +19,12 @@ is restricted to `s`. We also have
 
   `has_fderiv_at f f' x := has_fderiv_within_at f f' x univ`
 
+Finally,
+
+  `has_strict_fderiv_at f f' x`
+
+means that `f : E → F` has derivative `f' : E →L[𝕜] F` in the sense of strict differentiability.
+
 ## Main results
 
 In addition to the definition and basic properties of the derivative, this file contains the
@@ -100,6 +106,13 @@ has_fderiv_at_filter f f' x (nhds_within x s)
 `f x' = f x + f' (x' - x) + o (x' - x)` when `x'` tends to `x`. -/
 def has_fderiv_at (f : E → F) (f' : E →L[𝕜] F) (x : E) :=
 has_fderiv_at_filter f f' x (𝓝 x)
+
+/-- A function `f` has derivative `f'` at `a` in the sense of *strict differentiability*
+if `f x - f y - f' (x - y) = o(x - y)` as `x, y → a`. This forrm of differentiability is required,
+e.g., by the inverse function theorem. Any `C^1` function on a vector space over `ℝ` is strictly
+differentiable but this definition works, e.g., for vector spaces over `p`-adic numbers. -/
+def has_strict_fderiv_at (f : E → F) (f' : E →L[𝕜] F) (x : E) :=
+is_o (λ p : E × E, f p.1 - f p.2 - f' (p.1 - p.2)) (λ p : E × E, p.1 - p.2) (𝓝 (x, x))
 
 variables (𝕜)
 
@@ -291,9 +304,21 @@ lemma has_fderiv_at.differentiable_at (h : has_fderiv_at f f' x) : differentiabl
   has_fderiv_within_at f f' univ x ↔ has_fderiv_at f f' x :=
 by { simp only [has_fderiv_within_at, nhds_within_univ], refl }
 
+lemma has_strict_fderiv_at.is_O_sub (hf : has_strict_fderiv_at f f' x) :
+  is_O (λ p : E × E, f p.1 - f p.2) (λ p : E × E, p.1 - p.2) (𝓝 (x, x)) :=
+hf.is_O.congr_of_sub.2 (f'.is_O_comp _ _)
+
 lemma has_fderiv_at_filter.is_O_sub (h : has_fderiv_at_filter f f' x L) :
   is_O (λ x', f x' - f x) (λ x', x' - x) L :=
 h.is_O.congr_of_sub.2 (f'.is_O_sub _ _)
+
+lemma has_strict_fderiv_at.has_fderiv_at (hf : has_strict_fderiv_at f f' x) :
+  has_fderiv_at f f' x :=
+λ c hc, tendsto_id.prod_mk_nhds tendsto_const_nhds (hf hc)
+
+lemma has_strict_fderiv_at.differentiable_at (hf : has_strict_fderiv_at f f' x) :
+  differentiable_at 𝕜 f x :=
+hf.has_fderiv_at.differentiable_at
 
 /-- Directional derivative agrees with `has_fderiv`. -/
 lemma has_fderiv_at.lim (hf : has_fderiv_at f f' x) (v : E) {α : Type*} {c : α → 𝕜}
@@ -501,24 +526,32 @@ lemma differentiable_on.continuous_on (h : differentiable_on 𝕜 f s) : continu
 lemma differentiable.continuous (h : differentiable 𝕜 f) : continuous f :=
 continuous_iff_continuous_at.2 $ λx, (h x).continuous_at
 
+lemma has_strict_fderiv_at.continuous_at (hf : has_strict_fderiv_at f f' x) :
+  continuous_at f x :=
+hf.has_fderiv_at.continuous_at
+
 end continuous
 
 section congr
 /-! ### congr properties of the derivative -/
 
+theorem has_strict_fderiv_at_congr_of_mem_sets (h : ∀ᶠ y in 𝓝 x, f₀ y = f₁ y)
+  (h' : ∀ y, f₀' y = f₁' y) :
+  has_strict_fderiv_at f₀ f₀' x ↔ has_strict_fderiv_at f₁ f₁' x :=
+begin
+  refine is_o_congr ((h.prod_mk_nhds h).mono _) (eventually_of_forall _ $ λ _, rfl),
+  rintros p ⟨hp₁, hp₂⟩,
+  simp only [*]
+end
+
 theorem has_fderiv_at_filter_congr_of_mem_sets
   (hx : f₀ x = f₁ x) (h₀ : ∀ᶠ x in L, f₀ x = f₁ x) (h₁ : ∀ x, f₀' x = f₁' x) :
   has_fderiv_at_filter f₀ f₀' x L ↔ has_fderiv_at_filter f₁ f₁' x L :=
-by { rw (ext h₁), exact is_o_congr
-  (by filter_upwards [h₀] λ x (h : _ = _), by simp [h, hx])
-  (univ_mem_sets' $ λ _, rfl) }
+is_o_congr (h₀.mono $ λ y hy, by simp only [hy, h₁, hx]) (eventually_of_forall _ $ λ _, rfl)
 
 lemma has_fderiv_at_filter.congr_of_mem_sets (h : has_fderiv_at_filter f f' x L)
   (hL : ∀ᶠ x in L, f₁ x = f x) (hx : f₁ x = f x) : has_fderiv_at_filter f₁ f' x L :=
-begin
-  apply (has_fderiv_at_filter_congr_of_mem_sets hx hL _).2 h,
-  exact λx, rfl
-end
+(has_fderiv_at_filter_congr_of_mem_sets hx hL $ λ _, rfl).2 h
 
 lemma has_fderiv_within_at.congr_mono (h : has_fderiv_within_at f f' s x) (ht : ∀x ∈ t, f₁ x = f x)
   (hx : f₁ x = f x) (h₁ : t ⊆ s) : has_fderiv_within_at f₁ f' t x :=
@@ -574,24 +607,13 @@ lemma differentiable_within_at.fderiv_within_congr_mono (h : differentiable_with
 lemma fderiv_within_congr_of_mem_nhds_within (hs : unique_diff_within_at 𝕜 s x)
   (hL : ∀ᶠ y in nhds_within x s, f₁ y = f y) (hx : f₁ x = f x) :
   fderiv_within 𝕜 f₁ s x = fderiv_within 𝕜 f s x :=
-begin
-  by_cases h : differentiable_within_at 𝕜 f s x ∨ differentiable_within_at 𝕜 f₁ s x,
-  { cases h,
-    { apply has_fderiv_within_at.fderiv_within _ hs,
-      exact has_fderiv_at_filter.congr_of_mem_sets h.has_fderiv_within_at hL hx },
-    { symmetry,
-      apply has_fderiv_within_at.fderiv_within _ hs,
-      apply has_fderiv_at_filter.congr_of_mem_sets h.has_fderiv_within_at _ hx.symm,
-      convert hL,
-      ext y,
-      exact eq_comm } },
-  { push_neg at h,
-    have A : fderiv_within 𝕜 f s x = 0,
-      by { unfold differentiable_within_at at h, simp [fderiv_within, h] },
-    have A₁ : fderiv_within 𝕜 f₁ s x = 0,
-      by { unfold differentiable_within_at at h, simp [fderiv_within, h] },
-    rw [A, A₁] }
-end
+if h : differentiable_within_at 𝕜 f s x
+then has_fderiv_within_at.fderiv_within (h.has_fderiv_within_at.congr_of_mem_sets hL hx) hs
+else
+  have h' : ¬ differentiable_within_at 𝕜 f₁ s x,
+  from mt (λ h, h.congr_of_mem_nhds_within (hL.mono $ λ x, eq.symm) hx.symm) h,
+  by rw [fderiv_within_zero_of_not_differentiable_within_at h,
+    fderiv_within_zero_of_not_differentiable_within_at h']
 
 lemma fderiv_within_congr (hs : unique_diff_within_at 𝕜 s x)
   (hL : ∀y∈s, f₁ y = f y) (hx : f₁ x = f x) :
@@ -654,6 +676,10 @@ end id
 section const
 /-! ### derivative of a constant function -/
 
+theorem has_strict_fderiv_at_const (c : F) (x : E) :
+  has_strict_fderiv_at (λ _, c) (0 : E →L[𝕜] F) x :=
+(is_o_zero _ _).congr_left $ λ _, by simp only [zero_apply, sub_self]
+
 theorem has_fderiv_at_filter_const (c : F) (x : E) (L : filter E) :
   has_fderiv_at_filter (λ x, c) (0 : E →L[𝕜] F) x L :=
 (is_o_zero _ _).congr_left $ λ _, by simp only [zero_apply, sub_self]
@@ -699,6 +725,10 @@ section continuous_linear_map
 There are currently two variants of these in mathlib, the bundled version
 (named `continuous_linear_map`, and denoted `E →L[𝕜] F`), and the unbundled version (with a
 predicate `is_bounded_linear_map`). We give statements for both versions. -/
+
+protected theorem continuous_linear_map.has_strict_fderiv_at (f : E →L[𝕜] F) {x : E} :
+  has_strict_fderiv_at f f x :=
+(is_o_zero _ _).congr_left $ λ x, by simp only [f.map_sub, sub_self]
 
 protected lemma continuous_linear_map.has_fderiv_at_filter :
   has_fderiv_at_filter e e x L :=
@@ -777,6 +807,11 @@ section cartesian_product
 /-! ### Derivative of the cartesian product of two functions -/
 
 variables {f₂ : E → G} {f₂' : E →L[𝕜] G}
+
+lemma has_strict_fderiv_at.prod
+  (hf₁ : has_strict_fderiv_at f₁ f₁' x) (hf₂ : has_strict_fderiv_at f₂ f₂' x) :
+  has_strict_fderiv_at (λx, (f₁ x, f₂ x)) (continuous_linear_map.prod f₁' f₂') x :=
+hf₁.prod_left hf₂
 
 lemma has_fderiv_at_filter.prod
   (hf₁ : has_fderiv_at_filter f₁ f₁' x L) (hf₂ : has_fderiv_at_filter f₂ f₂' x L) :
@@ -952,13 +987,25 @@ lemma differentiable.comp_differentiable_on {g : F → G} (hg : differentiable �
   differentiable_on 𝕜 (g ∘ f) s :=
 (differentiable_on_univ.2 hg).comp hf (by simp)
 
+/-- The chain rule for derivatives in the sense of strict differentiability. -/
+lemma has_strict_fderiv_at.comp {g : F → G} {g' : F →L[𝕜] G}
+  (hg : has_strict_fderiv_at g g' (f x)) (hf : has_strict_fderiv_at f f' x) :
+  has_strict_fderiv_at (λ x, g (f x)) (g'.comp f') x :=
+((hg.comp_tendsto (hf.continuous_at.prod_map' hf.continuous_at)).trans_is_O hf.is_O_sub).triangle $
+  by simpa only [g'.map_sub, f'.coe_comp'] using (g'.is_O_comp _ _).trans_is_o hf
+
 end composition
 
 section const_smul
 /-! ### Derivative of a function multiplied by a constant -/
+
+theorem has_strict_fderiv_at.const_smul (h : has_strict_fderiv_at f f' x) (c : 𝕜) :
+  has_strict_fderiv_at (λ x, c • f x) (c • f') x :=
+(c • (1 : F →L[𝕜] F)).has_strict_fderiv_at.comp x h
+
 theorem has_fderiv_at_filter.const_smul (h : has_fderiv_at_filter f f' x L) (c : 𝕜) :
   has_fderiv_at_filter (λ x, c • f x) (c • f') x L :=
-(is_o_const_smul_left h c).congr_left $ λ x, by simp [smul_sub]
+(c • (1 : F →L[𝕜] F)).has_fderiv_at_filter.comp x h
 
 theorem has_fderiv_within_at.const_smul (h : has_fderiv_within_at f f' s x) (c : 𝕜) :
   has_fderiv_within_at (λ x, c • f x) (c • f') s x :=
@@ -997,6 +1044,11 @@ end const_smul
 
 section add
 /-! ### Derivative of the sum of two functions -/
+
+theorem has_strict_fderiv_at.add (hf : has_strict_fderiv_at f f' x)
+  (hg : has_strict_fderiv_at g g' x) :
+  has_strict_fderiv_at (λ y, f y + g y) (f' + g') x :=
+(hf.add hg).congr_left $ λ y, by simp; abel
 
 theorem has_fderiv_at_filter.add
   (hf : has_fderiv_at_filter f f' x L) (hg : has_fderiv_at_filter g g' x L) :
@@ -1043,6 +1095,10 @@ lemma fderiv_add
   fderiv 𝕜 (λy, f y + g y) x = fderiv 𝕜 f x + fderiv 𝕜 g x :=
 (hf.has_fderiv_at.add hg.has_fderiv_at).fderiv
 
+theorem has_strict_fderiv_at.add_const (hf : has_strict_fderiv_at f f' x) (c : F) :
+  has_strict_fderiv_at (λ y, f y + c) f' x :=
+add_zero f' ▸ hf.add (has_strict_fderiv_at_const _ _)
+
 theorem has_fderiv_at_filter.add_const
   (hf : has_fderiv_at_filter f f' x L) (c : F) :
   has_fderiv_at_filter (λ y, f y + c) f' x L :=
@@ -1087,6 +1143,10 @@ lemma fderiv_add_const
   (hf : differentiable_at 𝕜 f x) (c : F) :
   fderiv 𝕜 (λy, f y + c) x = fderiv 𝕜 f x :=
 (hf.has_fderiv_at.add_const c).fderiv
+
+theorem has_strict_fderiv_at.const_add (hf : has_strict_fderiv_at f f' x) (c : F) :
+  has_strict_fderiv_at (λ y, c + f y) f' x :=
+zero_add f' ▸ (has_strict_fderiv_at_const _ _).add hf
 
 theorem has_fderiv_at_filter.const_add
   (hf : has_fderiv_at_filter f f' x L) (c : F) :
@@ -1138,6 +1198,10 @@ end add
 section neg
 /-! ### Derivative of the negative of a function -/
 
+theorem has_strict_fderiv_at.neg (h : has_strict_fderiv_at f f' x) :
+  has_strict_fderiv_at (λ x, -f x) (-f') x :=
+(-1 : F →L[𝕜] F).has_strict_fderiv_at.comp x h
+
 theorem has_fderiv_at_filter.neg (h : has_fderiv_at_filter f f' x L) :
   has_fderiv_at_filter (λ x, -f x) (-f') x L :=
 (-1 : F →L[𝕜] F).has_fderiv_at_filter.comp x h
@@ -1179,6 +1243,11 @@ end neg
 
 section sub
 /-! ### Derivative of the difference of two functions -/
+
+theorem has_strict_fderiv_at.sub
+  (hf : has_strict_fderiv_at f f' x) (hg : has_strict_fderiv_at g g' x) :
+  has_strict_fderiv_at (λ x, f x - g x) (f' - g') x :=
+hf.add hg.neg
 
 theorem has_fderiv_at_filter.sub
   (hf : has_fderiv_at_filter f f' x L) (hg : has_fderiv_at_filter g g' x L) :
@@ -1225,6 +1294,11 @@ lemma fderiv_sub
   fderiv 𝕜 (λy, f y - g y) x = fderiv 𝕜 f x - fderiv 𝕜 g x :=
 (hf.has_fderiv_at.sub hg.has_fderiv_at).fderiv
 
+theorem has_strict_fderiv_at.sub_const
+  (hf : has_strict_fderiv_at f f' x) (c : F) :
+  has_strict_fderiv_at (λ x, f x - c) f' x :=
+hf.add_const (-c)
+
 theorem has_fderiv_at_filter.sub_const
   (hf : has_fderiv_at_filter f f' x L) (c : F) :
   has_fderiv_at_filter (λ x, f x - c) f' x L :=
@@ -1269,6 +1343,11 @@ lemma fderiv_sub_const
   (hf : differentiable_at 𝕜 f x) (c : F) :
   fderiv 𝕜 (λy, f y - c) x = fderiv 𝕜 f x :=
 (hf.has_fderiv_at.sub_const c).fderiv
+
+theorem has_strict_fderiv_at.const_sub
+  (hf : has_strict_fderiv_at f f' x) (c : F) :
+  has_strict_fderiv_at (λ x, c - f x) (-f') x :=
+hf.neg.const_add c
 
 theorem has_fderiv_at_filter.const_sub
   (hf : has_fderiv_at_filter f f' x L) (c : F) :
@@ -1324,39 +1403,35 @@ variables {b : E × F → G} {u : set (E × F) }
 
 open normed_field
 
+lemma is_bounded_bilinear_map.has_strict_fderiv_at (h : is_bounded_bilinear_map 𝕜 b) (p : E × F) :
+  has_strict_fderiv_at b (h.deriv p) p :=
+begin
+  rw has_strict_fderiv_at,
+  set T := (E × F) × (E × F),
+  have : is_o (λ q : T, b (q.1 - q.2)) (λ q : T, ∥q.1 - q.2∥ * 1) (𝓝 (p, p)),
+  { refine (h.is_O'.comp_tendsto le_top).trans_is_o _,
+    simp only [(∘)],
+    refine (is_O_refl (λ q : T, ∥q.1 - q.2∥) _).mul_is_o (is_o.norm_left $ (is_o_one_iff _).2 _),
+    rw [← sub_self p],
+    exact continuous_at_fst.sub continuous_at_snd },
+  simp only [mul_one, is_o_norm_right] at this,
+  refine (is_o.congr_of_sub _).1 this, clear this,
+  convert_to is_o (λ q : T, h.deriv (p - q.2) (q.1 - q.2)) (λ q : T, q.1 - q.2) (𝓝 (p, p)),
+  { ext q,
+    rcases q with ⟨⟨x₁, y₁⟩, ⟨x₂, y₂⟩⟩, rcases p with ⟨x, y⟩,
+    simp only [is_bounded_bilinear_map_deriv_coe, prod.mk_sub_mk, h.map_sub_left, h.map_sub_right],
+    abel },
+  have : is_o (λ q : T, p - q.2) (λ q, (1:ℝ)) (𝓝 (p, p)),
+    from (is_o_one_iff _).2 (sub_self p ▸ tendsto_const_nhds.sub continuous_at_snd),
+  apply is_bounded_bilinear_map_apply.is_O_comp.trans_is_o,
+  refine is_o.trans_is_O _ (is_O_const_mul_self 1 _ _).of_norm_right,
+  refine is_o.mul_is_O _ (is_O_refl _ _),
+  exact (((h.is_bounded_linear_map_deriv.is_O_id ⊤).comp_tendsto le_top).trans_is_o this).norm_left
+end
+
 lemma is_bounded_bilinear_map.has_fderiv_at (h : is_bounded_bilinear_map 𝕜 b) (p : E × F) :
   has_fderiv_at b (h.deriv p) p :=
-begin
-  have : (λ (x : E × F), b x - b p - (h.deriv p) (x - p)) = (λx, b (x.1 - p.1, x.2 - p.2)),
-  { ext x,
-    delta is_bounded_bilinear_map.deriv,
-    change b x - b p - (b (p.1, x.2-p.2) + b (x.1-p.1, p.2))
-           = b (x.1 - p.1, x.2 - p.2),
-    have : b x = b (x.1, x.2), by { cases x, refl },
-    rw this,
-    have : b p = b (p.1, p.2), by { cases p, refl },
-    rw this,
-    simp only [h.map_sub_left, h.map_sub_right],
-    abel },
-  rw [has_fderiv_at, has_fderiv_at_filter, this],
-  rcases h.bound with ⟨C, Cpos, hC⟩,
-  have A : asymptotics.is_O (λx : E × F, b (x.1 - p.1, x.2 - p.2))
-    (λx, ∥x - p∥ * ∥x - p∥) (𝓝 p) :=
-  ⟨C, filter.univ_mem_sets' (λx, begin
-    simp only [mem_set_of_eq, norm_mul, norm_norm],
-    calc ∥b (x.1 - p.1, x.2 - p.2)∥ ≤ C * ∥x.1 - p.1∥ * ∥x.2 - p.2∥ : hC _ _
-    ... ≤ C * ∥x-p∥ * ∥x-p∥ : by apply_rules [mul_le_mul, le_max_left, le_max_right, norm_nonneg,
-      le_of_lt Cpos, le_refl, mul_nonneg, norm_nonneg, norm_nonneg]
-    ... = C * (∥x-p∥ * ∥x-p∥) : mul_assoc _ _ _ end)⟩,
-  have B : asymptotics.is_o (λ (x : E × F), ∥x - p∥ * ∥x - p∥)
-    (λx, 1 * ∥x - p∥) (𝓝 p),
-  { refine asymptotics.is_o.mul_is_O (asymptotics.is_o.norm_left _) (asymptotics.is_O_refl _ _),
-    apply (asymptotics.is_o_one_iff ℝ).2,
-    rw [← sub_self p],
-    exact tendsto_id.sub tendsto_const_nhds },
-  simp only [one_mul, asymptotics.is_o_norm_right] at B,
-  exact A.trans_is_o B
-end
+(h.has_strict_fderiv_at p).has_fderiv_at
 
 lemma is_bounded_bilinear_map.has_fderiv_within_at (h : is_bounded_bilinear_map 𝕜 b) (p : E × F) :
   has_fderiv_within_at b (h.deriv p) u p :=
@@ -1366,7 +1441,8 @@ lemma is_bounded_bilinear_map.differentiable_at (h : is_bounded_bilinear_map �
   differentiable_at 𝕜 b p :=
 (h.has_fderiv_at p).differentiable_at
 
-lemma is_bounded_bilinear_map.differentiable_within_at (h : is_bounded_bilinear_map 𝕜 b) (p : E × F) :
+lemma is_bounded_bilinear_map.differentiable_within_at (h : is_bounded_bilinear_map 𝕜 b)
+  (p : E × F) :
   differentiable_within_at 𝕜 b u p :=
 (h.differentiable_at p).differentiable_within_at
 
@@ -1408,20 +1484,22 @@ section smul
 
 variables {c : E → 𝕜} {c' : E →L[𝕜] 𝕜}
 
+theorem has_strict_fderiv_at.smul (hc : has_strict_fderiv_at c c' x)
+  (hf : has_strict_fderiv_at f f' x) :
+  has_strict_fderiv_at (λ y, c y • f y) (c x • f' + c'.smul_right (f x)) x :=
+(is_bounded_bilinear_map_smul.has_strict_fderiv_at (c x, f x)).comp x $
+  hc.prod hf
+
 theorem has_fderiv_within_at.smul
   (hc : has_fderiv_within_at c c' s x) (hf : has_fderiv_within_at f f' s x) :
   has_fderiv_within_at (λ y, c y • f y) (c x • f' + c'.smul_right (f x)) s x :=
-begin
-  have : is_bounded_bilinear_map 𝕜 (λ (p : 𝕜 × F), p.1 • p.2) := is_bounded_bilinear_map_smul,
-  exact has_fderiv_at.comp_has_fderiv_within_at x (this.has_fderiv_at (c x, f x)) (hc.prod hf)
-end
+(is_bounded_bilinear_map_smul.has_fderiv_at (c x, f x)).comp_has_fderiv_within_at x $
+  hc.prod hf
 
 theorem has_fderiv_at.smul (hc : has_fderiv_at c c' x) (hf : has_fderiv_at f f' x) :
   has_fderiv_at (λ y, c y • f y) (c x • f' + c'.smul_right (f x)) x :=
-begin
-  have : is_bounded_bilinear_map 𝕜 (λ (p : 𝕜 × F), p.1 • p.2) := is_bounded_bilinear_map_smul,
-  exact has_fderiv_at.comp x (this.has_fderiv_at (c x, f x)) (hc.prod hf)
-end
+(is_bounded_bilinear_map_smul.has_fderiv_at (c x, f x)).comp x $
+  hc.prod hf
 
 lemma differentiable_within_at.smul
   (hc : differentiable_within_at 𝕜 c s x) (hf : differentiable_within_at 𝕜 f s x) :
@@ -1451,22 +1529,17 @@ lemma fderiv_smul (hc : differentiable_at 𝕜 c x) (hf : differentiable_at 𝕜
     c x • fderiv 𝕜 f x + (fderiv 𝕜 c x).smul_right (f x) :=
 (hc.has_fderiv_at.smul hf.has_fderiv_at).fderiv
 
+theorem has_strict_fderiv_at.smul_const (hc : has_strict_fderiv_at c c' x) (f : F) :
+  has_strict_fderiv_at (λ y, c y • f) (c'.smul_right f) x :=
+by simpa only [smul_zero, zero_add] using hc.smul (has_strict_fderiv_at_const f x)
+
 theorem has_fderiv_within_at.smul_const (hc : has_fderiv_within_at c c' s x) (f : F) :
   has_fderiv_within_at (λ y, c y • f) (c'.smul_right f) s x :=
-begin
-  convert hc.smul (has_fderiv_within_at_const f x s),
-  -- Help Lean find an instance
-  letI : distrib_mul_action 𝕜 (E →L[𝕜] F) :=
-    continuous_linear_map.module.to_distrib_mul_action,
-  rw [smul_zero, zero_add]
-end
+by simpa only [smul_zero, zero_add] using hc.smul (has_fderiv_within_at_const f x s)
 
 theorem has_fderiv_at.smul_const (hc : has_fderiv_at c c' x) (f : F) :
   has_fderiv_at (λ y, c y • f) (c'.smul_right f) x :=
-begin
-  rw [← has_fderiv_within_at_univ] at *,
-  exact hc.smul_const f
-end
+by simpa only [smul_zero, zero_add] using hc.smul (has_fderiv_at_const f x)
 
 lemma differentiable_within_at.smul_const
   (hc : differentiable_within_at 𝕜 c s x) (f : F) :
@@ -1503,26 +1576,19 @@ section mul
 set_option class.instance_max_depth 120
 variables {c d : E → 𝕜} {c' d' : E →L[𝕜] 𝕜}
 
+theorem has_strict_fderiv_at.mul
+  (hc : has_strict_fderiv_at c c' x) (hd : has_strict_fderiv_at d d' x) :
+  has_strict_fderiv_at (λ y, c y * d y) (c x • d' + d x • c') x :=
+by { convert hc.smul hd, ext z, apply mul_comm }
+
 theorem has_fderiv_within_at.mul
   (hc : has_fderiv_within_at c c' s x) (hd : has_fderiv_within_at d d' s x) :
   has_fderiv_within_at (λ y, c y * d y) (c x • d' + d x • c') s x :=
-begin
-  have : is_bounded_bilinear_map 𝕜 (λ (p : 𝕜 × 𝕜), p.1 * p.2) := is_bounded_bilinear_map_mul,
-  convert has_fderiv_at.comp_has_fderiv_within_at x (this.has_fderiv_at (c x, d x)) (hc.prod hd),
-  ext z,
-  change c x * d' z + d x * c' z = c x * d' z + c' z * d x,
-  ring
-end
+by { convert hc.smul hd, ext z, apply mul_comm }
 
 theorem has_fderiv_at.mul (hc : has_fderiv_at c c' x) (hd : has_fderiv_at d d' x) :
   has_fderiv_at (λ y, c y * d y) (c x • d' + d x • c') x :=
-begin
-  have : is_bounded_bilinear_map 𝕜 (λ (p : 𝕜 × 𝕜), p.1 * p.2) := is_bounded_bilinear_map_mul,
-  convert has_fderiv_at.comp x (this.has_fderiv_at (c x, d x)) (hc.prod hd),
-  ext z,
-  change c x * d' z + d x * c' z = c x * d' z + c' z * d x,
-  ring
-end
+by { convert hc.smul hd, ext z, apply mul_comm }
 
 lemma differentiable_within_at.mul
   (hc : differentiable_within_at 𝕜 c s x) (hd : differentiable_within_at 𝕜 d s x) :
@@ -1552,14 +1618,13 @@ lemma fderiv_mul (hc : differentiable_at 𝕜 c x) (hd : differentiable_at 𝕜 
     c x • fderiv 𝕜 d x + d x • fderiv 𝕜 c x :=
 (hc.has_fderiv_at.mul hd.has_fderiv_at).fderiv
 
-theorem has_fderiv_within_at.mul_const
-  (hc : has_fderiv_within_at c c' s x) (d : 𝕜) :
+theorem has_strict_fderiv_at.mul_const (hc : has_strict_fderiv_at c c' x) (d : 𝕜) :
+  has_strict_fderiv_at (λ y, c y * d) (d • c') x :=
+by simpa only [smul_zero, zero_add] using hc.mul (has_strict_fderiv_at_const d x)
+
+theorem has_fderiv_within_at.mul_const (hc : has_fderiv_within_at c c' s x) (d : 𝕜) :
   has_fderiv_within_at (λ y, c y * d) (d • c') s x :=
-begin
-  have := hc.mul (has_fderiv_within_at_const d x s),
-  letI : distrib_mul_action 𝕜 (E →L[𝕜] 𝕜) := continuous_linear_map.module.to_distrib_mul_action,
-  rwa [smul_zero, zero_add] at this
-end
+by simpa only [smul_zero, zero_add] using hc.mul (has_fderiv_within_at_const d x s)
 
 theorem has_fderiv_at.mul_const (hc : has_fderiv_at c c' x) (d : 𝕜) :
   has_fderiv_at (λ y, c y * d) (d • c') x :=
@@ -1593,6 +1658,13 @@ lemma fderiv_within_mul_const (hxs : unique_diff_within_at 𝕜 s x)
 lemma fderiv_mul_const (hc : differentiable_at 𝕜 c x) (d : 𝕜) :
   fderiv 𝕜 (λ y, c y * d) x = d • fderiv 𝕜 c x :=
 (hc.has_fderiv_at.mul_const d).fderiv
+
+theorem has_strict_fderiv_at.const_mul (hc : has_strict_fderiv_at c c' x) (d : 𝕜) :
+  has_strict_fderiv_at (λ y, d * c y) (d • c') x :=
+begin
+  simp only [mul_comm d],
+  exact hc.mul_const d,
+end
 
 theorem has_fderiv_within_at.const_mul
   (hc : has_fderiv_within_at c c' s x) (d : 𝕜) :
@@ -1641,6 +1713,10 @@ section continuous_linear_equiv
 /-! ### Differentiability of linear equivs, and invariance of differentiability -/
 
 variable (iso : E ≃L[𝕜] F)
+
+protected lemma continuous_linear_equiv.has_strict_fderiv_at :
+  has_strict_fderiv_at iso (iso : E →L[𝕜] F) x :=
+iso.to_continuous_linear_map.has_strict_fderiv_at
 
 protected lemma continuous_linear_equiv.has_fderiv_within_at :
   has_fderiv_within_at iso (iso : E →L[𝕜] F) s x :=
@@ -1709,6 +1785,13 @@ begin
   exact iso.symm.has_fderiv_at.comp_has_fderiv_within_at x H
 end
 
+lemma continuous_linear_equiv.comp_has_strict_fderiv_at_iff {f : G → E} {x : G} {f' : G →L[𝕜] E} :
+  has_strict_fderiv_at (iso ∘ f) ((iso : E →L[𝕜] F).comp f') x ↔ has_strict_fderiv_at f f' x :=
+begin
+  refine ⟨λ H, _, λ H, iso.has_strict_fderiv_at.comp x H⟩,
+  convert iso.symm.has_strict_fderiv_at.comp x H; ext z; apply (iso.symm_apply_apply _).symm
+end
+
 lemma continuous_linear_equiv.comp_has_fderiv_at_iff {f : G → E} {x : G} {f' : G →L[𝕜] E} :
   has_fderiv_at (iso ∘ f) ((iso : E →L[𝕜] F).comp f') x ↔ has_fderiv_at f f' x :=
 by rw [← has_fderiv_within_at_univ, ← has_fderiv_within_at_univ, iso.comp_has_fderiv_within_at_iff]
@@ -1717,14 +1800,8 @@ lemma continuous_linear_equiv.comp_has_fderiv_within_at_iff'
   {f : G → E} {s : set G} {x : G} {f' : G →L[𝕜] F} :
   has_fderiv_within_at (iso ∘ f) f' s x ↔
   has_fderiv_within_at f ((iso.symm : F →L[𝕜] E).comp f') s x :=
-begin
-  set g := (iso.symm : F →L[𝕜] E).comp f' with h,
-  have : f' = (iso : E →L[𝕜] F).comp g,
-    by rw [h, ← continuous_linear_map.comp_assoc, iso.coe_comp_coe_symm,
-           continuous_linear_map.id_comp],
-  rw this,
-  exact iso.comp_has_fderiv_within_at_iff
-end
+by rw [← iso.comp_has_fderiv_within_at_iff, ← continuous_linear_map.comp_assoc,
+  iso.coe_comp_coe_symm, continuous_linear_map.id_comp]
 
 lemma continuous_linear_equiv.comp_has_fderiv_at_iff' {f : G → E} {x : G} {f' : G →L[𝕜] F} :
   has_fderiv_at (iso ∘ f) f' x ↔ has_fderiv_at f ((iso.symm : F →L[𝕜] E).comp f') x :=
@@ -1737,11 +1814,10 @@ begin
   by_cases h : differentiable_within_at 𝕜 f s x,
   { rw [fderiv.comp_fderiv_within x iso.differentiable_at h hxs, iso.fderiv] },
   { have : ¬differentiable_within_at 𝕜 (iso ∘ f) s x,
-      by simp [-coe_fn_coe_base, iso.comp_differentiable_within_at_iff, h],
+      from mt iso.comp_differentiable_within_at_iff.1 h,
     rw [fderiv_within_zero_of_not_differentiable_within_at h,
-        fderiv_within_zero_of_not_differentiable_within_at this],
-    ext y,
-    simp [-coe_fn_coe_base] }
+        fderiv_within_zero_of_not_differentiable_within_at this,
+        continuous_linear_map.comp_zero] }
 end
 
 lemma continuous_linear_equiv.comp_fderiv {f : G → E} {x : G} :
@@ -1884,6 +1960,9 @@ variables (𝕜 : Type*) [nondiscrete_normed_field 𝕜]
 {f : E → F} {f' : E →L[𝕜'] F} {s : set E} {x : E}
 
 local attribute [instance] normed_space.restrict_scalars
+
+lemma has_strict_fderiv_at.restrict_scalars (h : has_strict_fderiv_at f f' x) :
+  has_strict_fderiv_at f (f'.restrict_scalars 𝕜) x := h
 
 lemma has_fderiv_at.restrict_scalars (h : has_fderiv_at f f' x) :
   has_fderiv_at f (f'.restrict_scalars 𝕜) x := h

--- a/src/analysis/normed_space/bounded_linear_maps.lean
+++ b/src/analysis/normed_space/bounded_linear_maps.lean
@@ -220,6 +220,20 @@ structure is_bounded_bilinear_map (f : E × F → G) : Prop :=
 variable {𝕜}
 variable {f : E × F → G}
 
+protected lemma is_bounded_bilinear_map.is_O (h : is_bounded_bilinear_map 𝕜 f) :
+  asymptotics.is_O f (λ p : E × F, ∥p.1∥ * ∥p.2∥) ⊤ :=
+let ⟨C, Cpos, hC⟩ := h.bound in
+⟨C, filter.eventually_of_forall ⊤ $ λ ⟨x, y⟩, by simpa [mul_assoc] using hC x y⟩
+
+lemma is_bounded_bilinear_map.is_O_comp {α : Type*} (H : is_bounded_bilinear_map 𝕜 f)
+  {g : α → E} {h : α → F} {l : filter α} :
+  asymptotics.is_O (λ x, f (g x, h x)) (λ x, ∥g x∥ * ∥h x∥) l :=
+H.is_O.comp_tendsto le_top
+
+protected lemma is_bounded_bilinear_map.is_O' (h : is_bounded_bilinear_map 𝕜 f) :
+  asymptotics.is_O f (λ p : E × F, ∥p∥ * ∥p∥) ⊤ :=
+h.is_O.trans (asymptotics.is_O_fst_prod'.norm_norm.mul asymptotics.is_O_snd_prod'.norm_norm)
+
 lemma is_bounded_bilinear_map.map_sub_left (h : is_bounded_bilinear_map 𝕜 f) {x y : E} {z : F} :
   f (x - y, z) = f (x, z) -  f(y, z) :=
 calc f (x - y, z) = f (x + (-1 : 𝕜) • y, z) : by simp [sub_eq_add_neg]

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -1371,6 +1371,11 @@ def tendsto (f : α → β) (l₁ : filter α) (l₂ : filter β) := l₁.map f 
 lemma tendsto_def {f : α → β} {l₁ : filter α} {l₂ : filter β} :
   tendsto f l₁ l₂ ↔ ∀ s ∈ l₂, f ⁻¹' s ∈ l₁ := iff.rfl
 
+lemma tendsto.eventually {f : α → β} {l₁ : filter α} {l₂ : filter β} {p : β → Prop}
+  (hf : tendsto f l₁ l₂) (h : ∀ᶠ y in l₂, p y) :
+  ∀ᶠ x in l₁, p (f x) :=
+hf h
+
 lemma tendsto_iff_comap {f : α → β} {l₁ : filter α} {l₂ : filter β} :
   tendsto f l₁ l₂ ↔ l₁ ≤ l₂.comap f :=
 map_le_iff_le_comap
@@ -1558,6 +1563,19 @@ tendsto_inf_right tendsto_comap
 lemma tendsto.prod_mk {f : filter α} {g : filter β} {h : filter γ} {m₁ : α → β} {m₂ : α → γ}
   (h₁ : tendsto m₁ f g) (h₂ : tendsto m₂ f h) : tendsto (λx, (m₁ x, m₂ x)) f (g ×ᶠ h) :=
 tendsto_inf.2 ⟨tendsto_comap_iff.2 h₁, tendsto_comap_iff.2 h₂⟩
+
+lemma eventually.prod_inl {la : filter α} {p : α → Prop} (h : ∀ᶠ x in la, p x) (lb : filter β) :
+  ∀ᶠ x in la ×ᶠ lb, p (x : α × β).1 :=
+tendsto_fst.eventually h
+
+lemma eventually.prod_inr {lb : filter β} {p : β → Prop} (h : ∀ᶠ x in lb, p x) (la : filter α) :
+  ∀ᶠ x in la ×ᶠ lb, p (x : α × β).2 :=
+tendsto_snd.eventually h
+
+lemma eventually.prod_mk {la : filter α} {pa : α → Prop} (ha : ∀ᶠ x in la, pa x)
+  {lb : filter β} {pb : β → Prop} (hb : ∀ᶠ y in lb, pb y) :
+  ∀ᶠ p in la ×ᶠ lb, pa (p : α × β).1 ∧ pb p.2 :=
+(ha.prod_inl lb).and (hb.prod_inr la)
 
 lemma prod_infi_left {f : ι → filter α} {g : filter β} (i : ι) :
   (⨅i, f i) ×ᶠ g = (⨅i, (f i) ×ᶠ g) :=

--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -32,7 +32,7 @@ product, sum, disjoint union, subspace, quotient space
 noncomputable theory
 
 open topological_space set filter
-open_locale classical topological_space
+open_locale classical topological_space filter
 
 universes u v w x
 variables {α : Type u} {β : Type v} {γ : Type w} {δ : Type x}
@@ -115,12 +115,31 @@ variables [topological_space α] [topological_space β] [topological_space γ] [
 lemma continuous_fst : continuous (@prod.fst α β) :=
 continuous_inf_dom_left continuous_induced_dom
 
+lemma continuous_at_fst {p : α × β} : continuous_at prod.fst p :=
+continuous_fst.continuous_at
+
 lemma continuous_snd : continuous (@prod.snd α β) :=
 continuous_inf_dom_right continuous_induced_dom
+
+lemma continuous_at_snd {p : α × β} : continuous_at prod.snd p :=
+continuous_snd.continuous_at
 
 lemma continuous.prod_mk {f : γ → α} {g : γ → β}
   (hf : continuous f) (hg : continuous g) : continuous (λx, prod.mk (f x) (g x)) :=
 continuous_inf_rng (continuous_induced_rng hf) (continuous_induced_rng hg)
+
+lemma filter.eventually.prod_inl_nhds {p : α → Prop} {a : α}  (h : ∀ᶠ x in 𝓝 a, p x) (b : β) :
+  ∀ᶠ x in 𝓝 (a, b), p (x : α × β).1 :=
+continuous_at_fst h
+
+lemma filter.eventually.prod_inr_nhds {p : β → Prop} {b : β} (h : ∀ᶠ x in 𝓝 b, p x) (a : α) :
+  ∀ᶠ x in 𝓝 (a, b), p (x : α × β).2 :=
+continuous_at_snd h
+
+lemma filter.eventually.prod_mk_nhds {pa : α → Prop} {a} (ha : ∀ᶠ x in 𝓝 a, pa x)
+  {pb : β → Prop} {b} (hb : ∀ᶠ y in 𝓝 b, pb y) :
+  ∀ᶠ p in 𝓝 (a, b), pa (p : α × β).1 ∧ pb p.2 :=
+(ha.prod_inl_nhds b).and (hb.prod_inr_nhds a)
 
 lemma continuous_swap : continuous (prod.swap : α × β → β × α) :=
 continuous.prod_mk continuous_snd continuous_fst
@@ -151,6 +170,18 @@ by rw [nhds_prod_eq]; exact filter.tendsto.prod_mk ha hb
 lemma continuous_at.prod {f : α → β} {g : α → γ} {x : α}
   (hf : continuous_at f x) (hg : continuous_at g x) : continuous_at (λx, (f x, g x)) x :=
 hf.prod_mk_nhds hg
+
+lemma continuous_at.prod_map {f : α → γ} {g : β → δ} {p : α × β}
+  (hf : continuous_at f p.fst) (hg : continuous_at g p.snd) :
+  continuous_at (λ p : α × β, (f p.1, g p.2)) p :=
+(hf.comp continuous_fst.continuous_at).prod (hg.comp continuous_snd.continuous_at)
+
+lemma continuous_at.prod_map' {f : α → γ} {g : β → δ} {x : α} {y : β}
+  (hf : continuous_at f x) (hg : continuous_at g y) :
+  continuous_at (λ p : α × β, (f p.1, g p.2)) (x, y) :=
+have hf : continuous_at f (x, y).fst, from hf,
+have hg : continuous_at g (x, y).snd, from hg,
+hf.prod_map hg
 
 lemma prod_generate_from_generate_from_eq {α : Type*} {β : Type*} {s : set (set α)} {t : set (set β)}
   (hs : ⋃₀ s = univ) (ht : ⋃₀ t = univ) :


### PR DESCRIPTION
Prove strict differentiability of all functions found in this file, cleanup.

TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)