### PR TITLE
chore(ci): update nolints before docs and leanchecker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,11 @@ jobs:
           git_sha: "${{ github.sha }}"
 
       - name: leanpkg build
-        run: leanpkg build | python scripts/detect_errors.py
+        id: build
+        run: |
+          leanpkg build | python scripts/detect_errors.py
+          # if the build fails, `steps.build.output.status` will be `null`
+          echo "::set-output name=status::built"
 
       - name: configure git setup
         if: always()
@@ -90,25 +94,30 @@ jobs:
           name: ${{ steps.setup_precompiled.outputs.artifact_name }}
           path: ..
 
-      - name: tests
-        run: |
-          set -o pipefail
-          lean --make docs archive roadmap test | cat
-
       - name: lint
+        # for some reason this gets skipped if an earlier (non-"build") step fails,
+        # unless we include `success() ||`
+        if: success() || steps.build.outputs.status == 'built'
         run: |
           ./scripts/mk_all.sh
           lean --run scripts/lint_mathlib.lean
           mv nolints.txt scripts/nolints.txt
           ./scripts/rm_all.sh
           git diff
-          
+
       - name: update nolints.txt
         if: github.repository == 'leanprover-community/mathlib' && github.event_name == 'push' && github.ref == 'refs/heads/master'
         run:
           ./scripts/update_nolints.sh
         env:
           DEPLOY_NIGHTLY_GITHUB_TOKEN: ${{ secrets.DEPLOY_NIGHTLY_GITHUB_TOKEN }}
+
+      - name: tests
+        # see comment in the "lint" step
+        if: success() || steps.build.outputs.status == 'built'
+        run: |
+          set -o pipefail
+          lean --make docs archive roadmap test | cat
 
       - name: leanchecker
         run: |
@@ -123,5 +132,3 @@ jobs:
           github_repo: ${{ github.repository }}
           github_event: ${{ github.event_name }}
           github_ref: ${{ github.ref }}
-
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,8 +95,6 @@ jobs:
           path: ..
 
       - name: lint
-        # for some reason this gets skipped if an earlier (non-"build") step fails,
-        # unless we include `success() ||`
         if: success() || steps.build.outputs.status == 'built'
         run: |
           ./scripts/mk_all.sh
@@ -113,7 +111,6 @@ jobs:
           DEPLOY_NIGHTLY_GITHUB_TOKEN: ${{ secrets.DEPLOY_NIGHTLY_GITHUB_TOKEN }}
 
       - name: tests
-        # see comment in the "lint" step
         if: success() || steps.build.outputs.status == 'built'
         run: |
           set -o pipefail

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,13 @@ jobs:
           mv nolints.txt scripts/nolints.txt
           ./scripts/rm_all.sh
           git diff
+          
+      - name: update nolints.txt
+        if: github.repository == 'leanprover-community/mathlib' && github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run:
+          ./scripts/update_nolints.sh
+        env:
+          DEPLOY_NIGHTLY_GITHUB_TOKEN: ${{ secrets.DEPLOY_NIGHTLY_GITHUB_TOKEN }}
 
       - name: leanchecker
         run: |
@@ -117,9 +124,4 @@ jobs:
           github_event: ${{ github.event_name }}
           github_ref: ${{ github.ref }}
 
-      - name: update nolints.txt
-        if: github.repository == 'leanprover-community/mathlib' && github.event_name == 'push' && github.ref == 'refs/heads/master'
-        run:
-          ./scripts/update_nolints.sh
-        env:
-          DEPLOY_NIGHTLY_GITHUB_TOKEN: ${{ secrets.DEPLOY_NIGHTLY_GITHUB_TOKEN }}
+


### PR DESCRIPTION
When @leanprover-community-bot jumps in to update `nolint.txt`, the build has to restart for the next PR in the queue. This PR makes that restart happen earlier, saving ~15 min of wasted CI time.

Better: there's really no need to update the file continuously (even though it's nice to see which commits fix linter errors). Once a day would be fine. We could use the same check as we do in the nightlies push step to just do it once a day. But this PR only makes the simple change for now.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)
