### PR TITLE
run lint+tests if build step succeeds (see #2250)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,11 @@ jobs:
           git_sha: "${{ github.sha }}"
 
       - name: leanpkg build
-        run: leanpkg build | python scripts/detect_errors.py
+        id: build
+        run: |
+          leanpkg build | python scripts/detect_errors.py
+          # if the build fails, `steps.build.output.status` will be `null`
+          echo "::set-output name=status::built"
 
       - name: configure git setup
         if: always()
@@ -91,18 +95,21 @@ jobs:
           path: ..
 
       - name: tests
+        # not sure why `success() ||` is needed here and in step `lint`...
+        if: success() || steps.build.outputs.status == 'built'
         run: |
           set -o pipefail
           lean --make docs archive roadmap test | cat
 
       - name: lint
+        if: success() || steps.build.outputs.status == 'built'
         run: |
           ./scripts/mk_all.sh
           lean --run scripts/lint_mathlib.lean
           mv nolints.txt scripts/nolints.txt
           ./scripts/rm_all.sh
           git diff
-          
+
       - name: update nolints.txt
         if: github.repository == 'leanprover-community/mathlib' && github.event_name == 'push' && github.ref == 'refs/heads/master'
         run:
@@ -123,5 +130,3 @@ jobs:
           github_repo: ${{ github.repository }}
           github_event: ${{ github.event_name }}
           github_ref: ${{ github.ref }}
-
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,14 +94,9 @@ jobs:
           name: ${{ steps.setup_precompiled.outputs.artifact_name }}
           path: ..
 
-      - name: tests
-        # not sure why `success() ||` is needed here and in step `lint`...
-        if: success() || steps.build.outputs.status == 'built'
-        run: |
-          set -o pipefail
-          lean --make docs archive roadmap test | cat
-
       - name: lint
+        # for some reason this gets skipped if an earlier (non-"build") step fails,
+        # unless we include `success() ||`
         if: success() || steps.build.outputs.status == 'built'
         run: |
           ./scripts/mk_all.sh
@@ -116,6 +111,13 @@ jobs:
           ./scripts/update_nolints.sh
         env:
           DEPLOY_NIGHTLY_GITHUB_TOKEN: ${{ secrets.DEPLOY_NIGHTLY_GITHUB_TOKEN }}
+
+      - name: tests
+        # see comment in the "lint" step
+        if: success() || steps.build.outputs.status == 'built'
+        run: |
+          set -o pipefail
+          lean --make docs archive roadmap test | cat
 
       - name: leanchecker
         run: |


### PR DESCRIPTION
This PR is a proposed change to #2250.  I didn't want to push directly to that branch in case I still had something wrong. Here are links to the tests I did in a mathlib fork:

- [Here](https://github.com/bryangingechen/mathlib/runs/538778138?check_suite_focus=true) it runs both the test and lint steps when the build succeeds.
- [Here](https://github.com/bryangingechen/mathlib/runs/538774733?check_suite_focus=true) it runs neither when the build is broken.
