### PR TITLE
chore(data/int/basic): change instance order

### DIFF
--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1070,7 +1070,7 @@ section cast
 variables {α : Type*}
 
 section
-variables [has_neg α] [has_zero α] [has_one α] [has_add α]
+variables [has_zero α] [has_one α] [has_add α] [has_neg α]
 
 /-- Canonical homomorphism from the integers to any ring(-like) structure `α` -/
 protected def cast : ℤ → α


### PR DESCRIPTION
Since Lean 3.7, the instances are not searched in the same order, so we should revert #877. See https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Lean.203.2E7.2E0.20released!/near/190534276