### PR TITLE
chore(scripts/deploy_docs.sh): skip gen_docs if already built

### DIFF
--- a/scripts/deploy_docs.sh
+++ b/scripts/deploy_docs.sh
@@ -19,7 +19,7 @@ echo -e "builtin_path\npath ./src\npath ../src" > leanpkg.path
 git clone "https://$DEPLOY_NIGHTLY_GITHUB_USER:$DEPLOY_NIGHTLY_GITHUB_TOKEN@github.com/leanprover-community/mathlib_docs.git"
 
 # skip if docs for this commit have already been generated
-if [[ "$(git log -1 --pretty=format:%h)" == *"$git_hash" ]]; then
+if [[ "$(git log -1 --pretty=format:%s)" == *"$git_hash" ]]; then
   exit 0
 fi
 

--- a/scripts/deploy_docs.sh
+++ b/scripts/deploy_docs.sh
@@ -5,6 +5,9 @@ set -x
 
 lean_version="$(sed '/^lean_version/!d;s/.*"\(.*\)".*/\1/' leanpkg.toml)"
 
+# Note that since update_nolints.sh runs before this script, 
+# git_hash could refer to that "update nolints" commit,
+# and thus we might be building docs for a future commit
 git_hash="$(git log -1 --pretty=format:%h)"
 git clone https://github.com/leanprover-community/doc-gen.git
 cd doc-gen
@@ -14,6 +17,12 @@ sed -i "s/rev = \"\S*\"/rev = \"$git_hash\"/" leanpkg.toml
 
 echo -e "builtin_path\npath ./src\npath ../src" > leanpkg.path
 git clone "https://$DEPLOY_NIGHTLY_GITHUB_USER:$DEPLOY_NIGHTLY_GITHUB_TOKEN@github.com/leanprover-community/mathlib_docs.git"
+
+# skip if docs for this commit have already been generated
+if [[ "$(git log -1 --pretty=format:%h)" == *"$git_hash" ]]; then
+  exit 0
+fi
+
 rm -rf mathlib_docs/docs/
 
 # Force doc_gen project to match the Lean version used in CI.


### PR DESCRIPTION
A recent build on the master branch (corresponding to a nolints update commit) [failed](https://github.com/leanprover-community/mathlib/runs/540702216#step:19:49) because the build from the previous commit already generated the docs for this commit. This occurred because #2250 moved the "update nolints" step before "generate docs", and hence made it possible for the variable `git_hash` in `deploy_docs.sh` to refer to a "future" commit.

After this change, `deploy_docs.sh` will check whether the docs corresponding to the commit at `git_hash` have already been built (I think checking the most recent `mathlib_docs` commit should be fine?) and exits gracefully if so.