### PR TITLE
fix(tactic/core): remove all_goals option from apply_any

### DIFF
--- a/src/set_theory/pgame.lean
+++ b/src/set_theory/pgame.lean
@@ -5,7 +5,6 @@ Authors: Reid Barton, Mario Carneiro, Isabel Longbottom, Scott Morrison
 -/
 import data.equiv.basic logic.embedding
 import data.nat.cast
-import data.finset data.fintype
 
 /-!
 # Combinatorial (pre-)games.

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -691,14 +691,11 @@ ap e <|> (iff_mp e >>= ap) <|> (iff_mpr e >>= ap)
 Configuration options for `apply_any`:
 * `use_symmetry`: if `apply_any` fails to apply any lemma, call `symmetry` and try again.
 * `use_exfalso`: if `apply_any` fails to apply any lemma, call `exfalso` and try again.
-* `all_goals`: attempt to solve all goals simultaneously,
-    backtracking if a solution to one goal results in other goals being impossible.
 * `apply`: specify an alternative to `tactic.apply`; usually `apply := tactic.eapply`.
 -/
 meta structure apply_any_opt :=
 (use_symmetry : bool := tt)
 (use_exfalso : bool := tt)
-(all_goals : bool := tt)
 (apply : expr → tactic (list (name × expr)) := tactic.apply)
 
 /--
@@ -708,7 +705,6 @@ meta structure apply_any_opt :=
 `opt` has fields:
 * `use_symmetry`: if no lemma applies, call `symmetry` and try again. (Defaults to `tt`.)
 * `use_exfalso`: if no lemma applies, call `exfalso` and try again. (Defaults to `tt`.)
-* `all_goals`: attempt to apply the lemmas to each of the goals sequentially. (Defaults to `tt`.)
 * `apply`: use a tactic other than `tactic.apply` (e.g. `tactic.fapply` or `tactic.eapply`).
 
 `apply_any lemmas tac` calls the tactic `tac` after a successful application.
@@ -723,10 +719,8 @@ do
   let modes := [skip]
     ++ (if opt.use_symmetry then [symmetry] else [])
     ++ (if opt.use_exfalso then [exfalso] else []),
-  goals ← if opt.all_goals then list.range <$> num_goals else pure [0],
-  goals.any_of (λ g, do rotate g,
-    modes.any_of (λ m, do m,
-      lemmas.any_of (λ H, opt.apply H >> tac))) <|>
+  modes.any_of (λ m, do m,
+    lemmas.any_of (λ H, opt.apply H >> tac)) <|>
   fail "apply_any tactic failed; no lemma could be applied"
 
 /-- Try to apply a hypothesis from the local context to the goal. -/

--- a/src/tactic/solve_by_elim.lean
+++ b/src/tactic/solve_by_elim.lean
@@ -64,7 +64,7 @@ Configuration options for `solve_by_elim`.
    `accept` is passed the proof terms for the original goals,
    as reported by `get_goals` when `solve_by_elim` started.
    These proof terms may be metavariables (if no progress has been made on that goal)
-   or may contain metavariables at some leaf nodes 
+   or may contain metavariables at some leaf nodes
    (if the goal has been partially solved by previous `apply` steps).
    If the `accept` tactic fails `solve_by_elim` aborts searching this branch and backtracks.
    By default `accept := λ _, skip` always succeeds.


### PR DESCRIPTION
Fixes the -T50000 regression [just noticed](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/-T50000.20challenge/near/192139664) by Kevin.

#2245 introduced a regression, essentially breaking `set_theory/pgame.lean`. This wasn't caught by CI because it's a performance regression, which made `solve_by_elim` enormously slower on some tasks.

The problem was that I added an `all_goals` option to `apply_any`, which told it to try to apply one of its lemmas to any of the goals.

1. This is a useless feature, as `apply_any lemmas {all_goals := tt}` is equivalent to `any_goal {apply_any lemmas}`.
2. Worse, I set the default value of `all_goals` to true. In some situations, this now causes `solve_by_elim` to try solving unsolvable subgoals in all possible orders, causing a combinatorial slowdown.

This PR simply removes the `all_goals` option from `apply_any`. (See point 1!) Note that `solve_by_elim*`, which tries to solve all goals at once, still works exactly as before, and as expected --- as long as you expect that its behaviour is to first solve the first goal, then try to solve the second goal, backtracking to a different solution of the first goal if that fails, and so on.

The file `src/set_theory/pgame.lean` now compiles again all the way down to `-T6000`.

(I also took the opportunity to remove some unnecessary imports from this file, and I promise this is orthogonal to the slowdown issue!)