### PR TITLE
fix(algebra/category): make has_coe_to_sort instances for bundled categories reducible

### DIFF
--- a/src/algebra/category/CommRing/basic.lean
+++ b/src/algebra/category/CommRing/basic.lean
@@ -84,7 +84,7 @@ local attribute [reducible] Ring
 see Note [reducible has_coe_to_sort instances for bundled categories].
 -/
 @[reducible]
-instance : has_coe_to_sort Ring := infer_instance -- short-circuit type class inference
+instance : has_coe_to_sort Ring := by apply_instance -- short-circuit type class inference
 
 instance (R : Ring) : ring R := R.str
 

--- a/src/algebra/category/CommRing/basic.lean
+++ b/src/algebra/category/CommRing/basic.lean
@@ -22,7 +22,8 @@ along with the relevant forgetful functors between them.
 
 ## Implementation notes
 
-See the note [locally reducible category instances].
+See the note [locally reducible category instances] and
+the note [reducible has_coe_to_sort instances for bundled categories].
 
 -/
 
@@ -42,6 +43,11 @@ instance : inhabited SemiRing := ⟨of punit⟩
 
 local attribute [reducible] SemiRing
 
+/--
+`has_coe_to_sort` instances for bundled categories must be `[reducible]`,
+see Note [reducible has_coe_to_sort instances for bundled categories].
+-/
+@[reducible]
 instance : has_coe_to_sort SemiRing := infer_instance -- short-circuit type class inference
 
 instance (R : SemiRing) : semiring R := R.str
@@ -73,6 +79,11 @@ instance : inhabited Ring := ⟨of punit⟩
 
 local attribute [reducible] Ring
 
+/--
+`has_coe_to_sort` instances for bundled categories must be `[reducible]`,
+see Note [reducible has_coe_to_sort instances for bundled categories].
+-/
+@[reducible]
 instance : has_coe_to_sort Ring := infer_instance -- short-circuit type class inference
 
 instance (R : Ring) : ring R := R.str
@@ -100,6 +111,11 @@ instance : inhabited CommSemiRing := ⟨of punit⟩
 
 local attribute [reducible] CommSemiRing
 
+/--
+`has_coe_to_sort` instances for bundled categories must be `[reducible]`,
+see Note [reducible has_coe_to_sort instances for bundled categories].
+-/
+@[reducible]
 instance : has_coe_to_sort CommSemiRing := infer_instance -- short-circuit type class inference
 
 instance (R : CommSemiRing) : comm_semiring R := R.str
@@ -128,6 +144,11 @@ instance : inhabited CommRing := ⟨of punit⟩
 
 local attribute [reducible] CommRing
 
+/--
+`has_coe_to_sort` instances for bundled categories must be `[reducible]`,
+see Note [reducible has_coe_to_sort instances for bundled categories].
+-/
+@[reducible]
 instance : has_coe_to_sort CommRing := infer_instance -- short-circuit type class inference
 
 instance (R : CommRing) : comm_ring R := R.str
@@ -142,6 +163,14 @@ has_forget₂.mk' (λ R : CommRing, CommSemiRing.of R) (λ R, rfl) (λ R₁ R₂
 
 end CommRing
 
+/--
+We verify that `has_coe_to_sort` instances for bundled categories have been correctly marked `reducible`,
+so that `simp` lemmas for morphisms work.
+
+See Note [reducible has_coe_to_sort instances for bundled categories].
+-/
+example {R S : CommRing} (i : R ⟶ S) (r : R) (h : r = 0) : i r = 0 :=
+by simp [h]
 
 namespace ring_equiv
 

--- a/src/algebra/category/CommRing/basic.lean
+++ b/src/algebra/category/CommRing/basic.lean
@@ -45,7 +45,7 @@ local attribute [reducible] SemiRing
 
 /--
 `has_coe_to_sort` instances for bundled categories must be `[reducible]`,
-see Note [reducible has_coe_to_sort instances for bundled categories].
+see note [reducible has_coe_to_sort instances for bundled categories].
 -/
 @[reducible]
 instance : has_coe_to_sort SemiRing := infer_instance -- short-circuit type class inference
@@ -81,7 +81,7 @@ local attribute [reducible] Ring
 
 /--
 `has_coe_to_sort` instances for bundled categories must be `[reducible]`,
-see Note [reducible has_coe_to_sort instances for bundled categories].
+see note [reducible has_coe_to_sort instances for bundled categories].
 -/
 @[reducible]
 instance : has_coe_to_sort Ring := infer_instance -- short-circuit type class inference
@@ -113,7 +113,7 @@ local attribute [reducible] CommSemiRing
 
 /--
 `has_coe_to_sort` instances for bundled categories must be `[reducible]`,
-see Note [reducible has_coe_to_sort instances for bundled categories].
+see note [reducible has_coe_to_sort instances for bundled categories].
 -/
 @[reducible]
 instance : has_coe_to_sort CommSemiRing := infer_instance -- short-circuit type class inference
@@ -146,7 +146,7 @@ local attribute [reducible] CommRing
 
 /--
 `has_coe_to_sort` instances for bundled categories must be `[reducible]`,
-see Note [reducible has_coe_to_sort instances for bundled categories].
+see note [reducible has_coe_to_sort instances for bundled categories].
 -/
 @[reducible]
 instance : has_coe_to_sort CommRing := infer_instance -- short-circuit type class inference
@@ -167,7 +167,7 @@ end CommRing
 We verify that `has_coe_to_sort` instances for bundled categories have been correctly marked `reducible`,
 so that `simp` lemmas for morphisms work.
 
-See Note [reducible has_coe_to_sort instances for bundled categories].
+See note [reducible has_coe_to_sort instances for bundled categories].
 -/
 example {R S : CommRing} (i : R ⟶ S) (r : R) (h : r = 0) : i r = 0 :=
 by simp [h]

--- a/src/algebra/category/Group/basic.lean
+++ b/src/algebra/category/Group/basic.lean
@@ -21,7 +21,8 @@ along with the relevant forgetful functors between them, and to the bundled mono
 
 ## Implementation notes
 
-See the note [locally reducible category instances].
+See the note [locally reducible category instances]
+and the note [reducible has_coe_to_sort instances for bundled categories].
 -/
 
 universes u v
@@ -39,7 +40,11 @@ namespace Group
 
 local attribute [reducible] Group
 
-@[to_additive]
+/--
+`has_coe_to_sort` instances for bundled categories must be `[reducible]`,
+see Note [reducible has_coe_to_sort instances for bundled categories].
+-/
+@[reducible, to_additive]
 instance : has_coe_to_sort Group := infer_instance -- short-circuit type class inference
 
 @[to_additive add_group]
@@ -88,7 +93,11 @@ namespace CommGroup
 
 local attribute [reducible] CommGroup
 
-@[to_additive]
+/--
+`has_coe_to_sort` instances for bundled categories must be `[reducible]`,
+see Note [reducible has_coe_to_sort instances for bundled categories].
+-/
+@[reducible, to_additive]
 instance : has_coe_to_sort CommGroup := infer_instance -- short-circuit type class inference
 
 @[to_additive add_comm_group_instance]
@@ -122,6 +131,16 @@ instance has_forget_to_CommMon : has_forget₂ CommGroup CommMon :=
 induced_category.has_forget₂ (λ G : CommGroup, CommMon.of G)
 
 end CommGroup
+
+/--
+We verify that `has_coe_to_sort` instances for bundled categories have been correctly marked `reducible`,
+so that `simp` lemmas for morphisms work.
+
+See Note [reducible has_coe_to_sort instances for bundled categories].
+-/
+@[to_additive]
+example {R S : CommGroup} (i : R ⟶ S) (r : R) (h : r = 1) : i r = 1 :=
+by simp [h]
 
 namespace AddCommGroup
 

--- a/src/algebra/category/Group/basic.lean
+++ b/src/algebra/category/Group/basic.lean
@@ -42,7 +42,7 @@ local attribute [reducible] Group
 
 /--
 `has_coe_to_sort` instances for bundled categories must be `[reducible]`,
-see Note [reducible has_coe_to_sort instances for bundled categories].
+see note [reducible has_coe_to_sort instances for bundled categories].
 -/
 @[reducible, to_additive]
 instance : has_coe_to_sort Group := infer_instance -- short-circuit type class inference
@@ -95,7 +95,7 @@ local attribute [reducible] CommGroup
 
 /--
 `has_coe_to_sort` instances for bundled categories must be `[reducible]`,
-see Note [reducible has_coe_to_sort instances for bundled categories].
+see note [reducible has_coe_to_sort instances for bundled categories].
 -/
 @[reducible, to_additive]
 instance : has_coe_to_sort CommGroup := infer_instance -- short-circuit type class inference
@@ -136,7 +136,7 @@ end CommGroup
 We verify that `has_coe_to_sort` instances for bundled categories have been correctly marked `reducible`,
 so that `simp` lemmas for morphisms work.
 
-See Note [reducible has_coe_to_sort instances for bundled categories].
+See note [reducible has_coe_to_sort instances for bundled categories].
 -/
 @[to_additive]
 example {R S : CommGroup} (i : R ⟶ S) (r : R) (h : r = 1) : i r = 1 :=

--- a/src/algebra/category/Mon/basic.lean
+++ b/src/algebra/category/Mon/basic.lean
@@ -21,11 +21,8 @@ along with the relevant forgetful functors between them.
 
 ## Implementation notes
 
-See Note [locally reducible category instances]
-
-TODO: Probably @[derive] should be able to create instances of the
-required form (without `id`), and then we could use that instead of
-this obscure `local attribute [reducible]` method.
+See the note [locally reducible category instances]
+and the note [reducible has_coe_to_sort instances for bundled categories].
 -/
 
 /--
@@ -44,6 +41,13 @@ to functions, for example. It's especially important that the `has_coe_to_sort`
 instance not contain an extra `id` as we want the `semiring ↥R` instance to
 also apply to `semiring R.α` (it seems to be impractical to guarantee that
 we always access `R.α` through the coercion rather than directly).
+
+TODO: Probably @[derive] should be able to create instances of the
+required form (without `id`), and then we could use that instead of
+this obscure `local attribute [reducible]` method.
+
+See also Note [reducible has_coe_to_sort instances for bundled categories],
+explaining why the `has_coe_to_sort` instances themselves must be `[reducible]`.
 -/
 library_note "locally reducible category instances"
 
@@ -69,7 +73,11 @@ instance : inhabited Mon :=
 
 local attribute [reducible] Mon
 
-@[to_additive]
+/--
+`has_coe_to_sort` instances for bundled categories must be `[reducible]`,
+see Note [reducible has_coe_to_sort instances for bundled categories].
+-/
+@[reducible, to_additive]
 instance : has_coe_to_sort Mon := infer_instance -- short-circuit type class inference
 
 @[to_additive add_monoid]
@@ -102,7 +110,11 @@ instance : inhabited CommMon :=
 
 local attribute [reducible] CommMon
 
-@[to_additive]
+/--
+`has_coe_to_sort` instances for bundled categories must be `[reducible]`,
+see Note [reducible has_coe_to_sort instances for bundled categories].
+-/
+@[reducible, to_additive]
 instance : has_coe_to_sort CommMon := infer_instance -- short-circuit type class inference
 
 @[to_additive add_comm_monoid]

--- a/src/algebra/category/Mon/basic.lean
+++ b/src/algebra/category/Mon/basic.lean
@@ -46,7 +46,7 @@ TODO: Probably @[derive] should be able to create instances of the
 required form (without `id`), and then we could use that instead of
 this obscure `local attribute [reducible]` method.
 
-See also Note [reducible has_coe_to_sort instances for bundled categories],
+See also note [reducible has_coe_to_sort instances for bundled categories],
 explaining why the `has_coe_to_sort` instances themselves must be `[reducible]`.
 -/
 library_note "locally reducible category instances"
@@ -75,7 +75,7 @@ local attribute [reducible] Mon
 
 /--
 `has_coe_to_sort` instances for bundled categories must be `[reducible]`,
-see Note [reducible has_coe_to_sort instances for bundled categories].
+see note [reducible has_coe_to_sort instances for bundled categories].
 -/
 @[reducible, to_additive]
 instance : has_coe_to_sort Mon := infer_instance -- short-circuit type class inference
@@ -112,7 +112,7 @@ local attribute [reducible] CommMon
 
 /--
 `has_coe_to_sort` instances for bundled categories must be `[reducible]`,
-see Note [reducible has_coe_to_sort instances for bundled categories].
+see note [reducible has_coe_to_sort instances for bundled categories].
 -/
 @[reducible, to_additive]
 instance : has_coe_to_sort CommMon := infer_instance -- short-circuit type class inference

--- a/src/category_theory/concrete_category/bundled.lean
+++ b/src/category_theory/concrete_category/bundled.lean
@@ -31,8 +31,22 @@ namespace bundled
 -- Usually explicit instances will provide their own version of this, e.g. `Mon.of` and `Top.of`.
 def of {c : Type u → Type v} (α : Type u) [str : c α] : bundled c := ⟨α, str⟩
 
+/--
+In order for simp lemmas for bundled morphisms to apply correctly,
+it seems to be necessary for all the `has_coe_to_sort` instances for bundled categories
+to be marked `[reducible]`.
+
+Examples verifying correct behaviour are also marked with this Note [reducible has_coe_to_sort instances for bundled categories].
+-/
+library_note "has_coe_to_sort reducible"
+
+/--
+has_coe_to_sort instances for bundled categories must be reducible, see Note [reducible has_coe_to_sort instances for bundled categories].
+-/
+@[reducible]
 instance : has_coe_to_sort (bundled c) :=
 { S := Type u, coe := bundled.α }
+
 
 /-
 `bundled.map` is reducible so that, if we define a category

--- a/src/category_theory/concrete_category/bundled.lean
+++ b/src/category_theory/concrete_category/bundled.lean
@@ -5,6 +5,7 @@ Authors: Scott Morrison, Johannes Hölzl, Reid Barton, Sean Leather
 
 Bundled types.
 -/
+import tactic.doc_commands
 
 /-!
 `bundled c` provides a uniform structure for bundling a type equipped with a type class.
@@ -36,12 +37,14 @@ In order for simp lemmas for bundled morphisms to apply correctly,
 it seems to be necessary for all the `has_coe_to_sort` instances for bundled categories
 to be marked `[reducible]`.
 
-Examples verifying correct behaviour are also marked with this Note [reducible has_coe_to_sort instances for bundled categories].
+Examples verifying correct behaviour are also marked with this
+note [reducible has_coe_to_sort instances for bundled categories].
 -/
-library_note "has_coe_to_sort reducible"
+library_note "reducible has_coe_to_sort instances for bundled categories"
 
 /--
-has_coe_to_sort instances for bundled categories must be reducible, see Note [reducible has_coe_to_sort instances for bundled categories].
+has_coe_to_sort instances for bundled categories must be reducible,
+see note [reducible has_coe_to_sort instances for bundled categories].
 -/
 @[reducible]
 instance : has_coe_to_sort (bundled c) :=

--- a/src/category_theory/concrete_category/bundled.lean
+++ b/src/category_theory/concrete_category/bundled.lean
@@ -5,6 +5,7 @@ Authors: Scott Morrison, Johannes Hölzl, Reid Barton, Sean Leather
 
 Bundled types.
 -/
+import tactic.doc_commands
 
 /-!
 `bundled c` provides a uniform structure for bundling a type equipped with a type class.

--- a/src/category_theory/concrete_category/bundled.lean
+++ b/src/category_theory/concrete_category/bundled.lean
@@ -5,7 +5,6 @@ Authors: Scott Morrison, Johannes Hölzl, Reid Barton, Sean Leather
 
 Bundled types.
 -/
-import tactic.doc_commands
 
 /-!
 `bundled c` provides a uniform structure for bundling a type equipped with a type class.

--- a/src/category_theory/full_subcategory.lean
+++ b/src/category_theory/full_subcategory.lean
@@ -48,7 +48,8 @@ def induced_category : Type u₁ := C
 variables {D}
 
 /--
-has_coe_to_sort instances for bundled categories must be reducible, see Note [reducible has_coe_to_sort instances for bundled categories].
+has_coe_to_sort instances for bundled categories must be reducible,
+see note [reducible has_coe_to_sort instances for bundled categories].
 -/
 @[reducible]
 instance induced_category.has_coe_to_sort [has_coe_to_sort D] :

--- a/src/category_theory/full_subcategory.lean
+++ b/src/category_theory/full_subcategory.lean
@@ -47,6 +47,10 @@ def induced_category : Type u₁ := C
 
 variables {D}
 
+/--
+has_coe_to_sort instances for bundled categories must be reducible, see Note [reducible has_coe_to_sort instances for bundled categories].
+-/
+@[reducible]
 instance induced_category.has_coe_to_sort [has_coe_to_sort D] :
   has_coe_to_sort (induced_category D F) :=
 ⟨_, λ c, ↥(F c)⟩


### PR DESCRIPTION
See discussion at https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/unbearable.20unhappiness.20of.20.60simp.60.20not.20working

I have added a `library note` explaining this issue, and put in two `example`s that ensure correct behaviour.