### PR TITLE
fix(algebra/punit_instance): punit.smul_eq is marked simp and can be proved by simp

### DIFF
--- a/src/algebra/punit_instances.lean
+++ b/src/algebra/punit_instances.lean
@@ -74,7 +74,7 @@ intros; exact subsingleton.elim _ _
 @[simp, to_additive] lemma mul_eq : x * y = star := rfl
 @[simp] lemma neg_eq : -x = star := rfl
 @[simp, to_additive] lemma inv_eq : x⁻¹ = star := rfl
-@[simp] lemma smul_eq : x • y = star := rfl
+lemma smul_eq : x • y = star := rfl
 @[simp] lemma top_eq : (⊤ : punit) = star := rfl
 @[simp] lemma bot_eq : (⊥ : punit) = star := rfl
 @[simp] lemma sup_eq : x ⊔ y = star := rfl


### PR DESCRIPTION
The linter was failing on master.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [x] for tactics:
     * [x] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [x] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)
