### PR TITLE
feat(tactic/simp_rw): support `<-` in `simp_rw`

### DIFF
--- a/src/tactic/simp_rw.lean
+++ b/src/tactic/simp_rw.lean
@@ -18,9 +18,8 @@ This module defines a tactic `simp_rw` which functions as a mix of `simp` and
 ## Implementation notes
 
 The tactic works by taking each rewrite rule in turn and applying `simp only` to
-it. It should be possible to support backwards rewriting in the tactic, i.e.
-`simp_rw [←lemma]`, but it will be more useful and not much more work to add
-support for this directly to `simp`.
+it. Arguments to `simp_rw` are of the format used by `rw` and are translated to
+their equivalents for `simp`.
 -/
 
 namespace tactic.interactive
@@ -33,7 +32,7 @@ rules and also under binders like `∀ x, ...`, `∃ x, ...` and `λ x, ...`.
 
 Usage:
   - `simp_rw [lemma_1, ..., lemma_n]` will rewrite the goal by applying the
-    lemmas in that order.
+    lemmas in that order. A lemma preceded by `←` is applied in the reverse direction.
   - `simp_rw [lemma_1, ..., lemma_n] at h₁ ... hₙ` will rewrite the given hypotheses.
   - `simp_rw [...] at ⊢ h₁ ... hₙ` rewrites the goal as well as the given hypotheses.
   - `simp_rw [...] at *` rewrites in the whole context: all hypotheses and the goal.
@@ -47,11 +46,12 @@ by simp_rw [set.image_subset_iff, set.subset_def]
 ```
 -/
 meta def simp_rw (q : parse rw_rules) (l : parse location) : tactic unit :=
-q.rules.mmap' (λ rule, if rule.symm
-  then fail "simp_rw [← ...] not supported: can only rewrite in forward direction"
-  else do
-    save_info rule.pos,
-    simp none tt [simp_arg_type.expr rule.rule] [] l) -- equivalent to `simp only [rule] at l`
+q.rules.mmap' (λ rule, do
+  let simp_arg := if rule.symm
+    then simp_arg_type.symm_expr rule.rule
+    else simp_arg_type.expr rule.rule,
+  save_info rule.pos,
+  simp none tt [simp_arg] [] l) -- equivalent to `simp only [rule] at l`
 
 add_tactic_doc
 { name       := "simp_rw",

--- a/test/simp_rw.lean
+++ b/test/simp_rw.lean
@@ -11,6 +11,9 @@ import data.set.basic
 -- `simp_rw` can perform rewrites under binders:
 example : (λ (x y : ℕ), x + y) = (λ x y, y + x) := by simp_rw [add_comm]
 
+-- `simp_rw` can apply reverse rules:
+example (f : ℕ → ℕ) {a b c : ℕ} (ha : f b = a) (hc : f b = c) : a = c := by simp_rw [← ha, hc]
+
 -- `simp_rw` performs rewrites in the given order (`simp` fails on this example):
 example {α β : Type} {f : α → β} {t : set β} :
   (∀ s, f '' s ⊆ t) = ∀ s : set α, ∀ x ∈ s, x ∈ f ⁻¹' t :=


### PR DESCRIPTION
Implement #2305. All `simp`-related tactics should now support `<-` to rewrite in the reverse direction.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [x] for tactics:
     * [x] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [x] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)
