### PR TITLE
feat(tactic/linarith): split conjunctions in hypotheses

### DIFF
--- a/src/tactic/linarith.lean
+++ b/src/tactic/linarith.lean
@@ -461,6 +461,7 @@ meta structure linarith_config :=
 (restrict_type_reflect : reflected restrict_type . apply_instance)
 (exfalso : bool := tt)
 (transparency : transparency := reducible)
+(split_hypotheses : bool := tt)
 
 meta def ineq_pf_tp (pf : expr) : tactic expr :=
 do (_, z) ← infer_type pf >>= get_rel_sides,
@@ -880,6 +881,7 @@ let cfg :=
   if red.is_some then {cfg with transparency := semireducible, discharger := `[ring!]}
   else cfg in
 do t ← target,
+   when cfg.split_hypotheses (try auto.split_hyps),
    match get_contr_lemma_name t with
    | some nm := seq (applyc nm) $
      do t ← intro1, linarith.interactive_aux cfg (some t) restr.is_some hyps

--- a/src/tactic/linarith.lean
+++ b/src/tactic/linarith.lean
@@ -862,7 +862,7 @@ by linarith
 will fail, because `linarith` will not identify `x` and `id x`. `linarith!` will.
 This can sometimes be expensive.
 
-`linarith {discharger := tac, restrict_type := tp, exfalso := ff}` takes a config object with three
+`linarith {discharger := tac, restrict_type := tp, exfalso := ff}` takes a config object with five
 optional arguments:
 * `discharger` specifies a tactic to be used for reducing an algebraic equation in the
   proof stage. The default is `ring`. Other options currently include `ring SOP` or `simp` for basic
@@ -870,6 +870,10 @@ optional arguments:
 * `restrict_type` will only use hypotheses that are inequalities over `tp`. This is useful
   if you have e.g. both integer and rational valued inequalities in the local context, which can
   sometimes confuse the tactic.
+* `transparency` controls how hard `linarith` will try to match atoms to each other. By default
+  it will only unfold `reducible` definitions.
+* If `split_hypotheses` is true, `linarith` will split conjunctions in the context into separate
+  hypotheses.
 * If `exfalso` is false, `linarith` will fail when the goal is neither an inequality nor `false`.
   (True by default.)
 

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -96,6 +96,10 @@ example (x y : ℚ) (h : 6 + ((x + 4) * x + (6 + 3 * y) * y) = 3) (h' : (x + 4) 
   (h'' : (6 + 3 * y) * y ≥ 0)  : false :=
 by linarith
 
+example (x y : ℚ)
+  (h : 6 + ((x + 4) * x + (6 + 3 * y) * y) = 3 ∧ (x + 4) * x ≥ 0 ∧ (6 + 3 * y) * y ≥ 0) : false :=
+by linarith
+
 example (x y : ℕ) (h : 6 + ((x + 4) * x + (6 + 3 * y) * y) = 3) : false :=
 by linarith
 


### PR DESCRIPTION
Requested on Zulip: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/linarith.20and.20conjunctions/near/192818073

This adds an option to `linarith` to destroy conjunctions in the local context, enabled by default. I do not plan to bundle any more handling for logic into `linarith`!

`linarith` has grown a lot since it was first added and it's overdue to be refactored and better documented. This is on my list but won't happen in this PR.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)
