### PR TITLE
feat(data/mv_polynomial): add pderivative_eq_zero_of_not_mem_vars

### DIFF
--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -755,16 +755,13 @@ lemma mem_support_not_mem_vars_zero {f : mv_polynomial σ α} {x : σ →₀ ℕ
 begin
   rw [vars, multiset.mem_to_finset] at h,
   rw ←not_mem_support_iff,
-  by_contradiction,
-  have : v ∈ degrees f,
-  { unfold degrees,
-    rw (show f.support = insert x f.support, from eq.symm $ finset.insert_eq_of_mem H),
-    rw finset.sup_insert,
-    simp only [multiset.mem_union, multiset.sup_eq_union],
-    left,
-    rw [←to_finset_to_multiset, multiset.mem_to_finset] at a,
-    exact a },
-  contradiction,
+  contrapose! h,
+  unfold degrees,
+  rw (show f.support = insert x f.support, from eq.symm $ finset.insert_eq_of_mem H),
+  rw finset.sup_insert,
+  simp only [multiset.mem_union, multiset.sup_eq_union],
+  left,
+  rwa [←to_finset_to_multiset, multiset.mem_to_finset] at h,
 end
 
 end vars
@@ -1454,14 +1451,10 @@ lemma pderivative_eq_zero_of_not_mem_vars {v : S} {f : mv_polynomial S R} (h : v
   pderivative v f = 0 :=
 begin
   change (pderivative.add_monoid_hom R v) f = 0,
-  rw f.as_sum,
-  rw add_monoid_hom.map_sum,
-  simp,
-  conv_lhs {
-    apply_congr,
-    skip,
-    rw (mem_support_not_mem_vars_zero H h) },
-  simp,
+  rw [f.as_sum, add_monoid_hom.map_sum],
+  apply finset.sum_eq_zero,
+  intros,
+  simp [mem_support_not_mem_vars_zero H h],
 end
 
 lemma pderivative_monomial_single {a : R} {v : S} {n : ℕ} :

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -750,6 +750,24 @@ by rw [vars, degrees_C, multiset.to_finset_zero]
 @[simp] lemma vars_X (h : 0 ≠ (1 : α)) : (X n : mv_polynomial σ α).vars = {n} :=
 by rw [X, vars_monomial h.symm, finsupp.support_single_ne_zero zero_ne_one.symm]
 
+lemma mem_support_not_mem_vars_zero {f : mv_polynomial σ α} {x : σ →₀ ℕ} (H : x ∈ f.support) {v : σ} (h : v ∉ vars f) :
+  x v = 0 :=
+begin
+  rw [vars, multiset.mem_to_finset] at h,
+  rw ←not_mem_support_iff,
+  by_contradiction,
+  have : v ∈ degrees f := begin
+    unfold degrees,
+    rw (show f.support = insert x f.support, from eq.symm $ finset.insert_eq_of_mem H),
+    rw finset.sup_insert,
+    simp only [multiset.mem_union, multiset.sup_eq_union],
+    left,
+    rw [←to_finset_to_multiset, multiset.mem_to_finset] at a,
+    exact a
+  end,
+  contradiction,
+end
+
 end vars
 
 section degree_of
@@ -1433,25 +1451,6 @@ lemma pderivative.add_monoid_hom_apply (v : S) (p : mv_polynomial S R) :
 rfl
 end
 
-private lemma pderivative_eq_zero_of_not_mem_vars_aux {v : S} {f : mv_polynomial S R}
-  (h : v ∉ vars f) (x : S →₀ ℕ) (H : x ∈ f.support) :
-  x v = 0 :=
-begin
-  rw [vars, multiset.mem_to_finset] at h,
-  rw ←not_mem_support_iff,
-  by_contradiction,
-  have : v ∈ degrees f := begin
-    unfold degrees,
-    rw (show f.support = insert x f.support, from eq.symm $ finset.insert_eq_of_mem H),
-    rw finset.sup_insert,
-    simp only [multiset.mem_union, multiset.sup_eq_union],
-    left,
-    rw [←to_finset_to_multiset, multiset.mem_to_finset] at a,
-    exact a
-  end,
-  contradiction,
-end
-
 lemma pderivative_eq_zero_of_not_mem_vars {v : S} {f : mv_polynomial S R} (h : v ∉ f.vars) :
   pderivative v f = 0 :=
 begin
@@ -1462,7 +1461,7 @@ begin
   conv_lhs {
     apply_congr,
     skip,
-    rw (show x v = 0, from pderivative_eq_zero_of_not_mem_vars_aux h x H) },
+    rw (mem_support_not_mem_vars_zero H h) },
   simp,
 end
 

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -756,15 +756,14 @@ begin
   rw [vars, multiset.mem_to_finset] at h,
   rw ←not_mem_support_iff,
   by_contradiction,
-  have : v ∈ degrees f := begin
-    unfold degrees,
+  have : v ∈ degrees f,
+  { unfold degrees,
     rw (show f.support = insert x f.support, from eq.symm $ finset.insert_eq_of_mem H),
     rw finset.sup_insert,
     simp only [multiset.mem_union, multiset.sup_eq_union],
     left,
     rw [←to_finset_to_multiset, multiset.mem_to_finset] at a,
-    exact a
-  end,
+    exact a },
   contradiction,
 end
 

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -1420,6 +1420,8 @@ show pderivative v (C 0 : mv_polynomial S R) = 0, from pderivative_C
 
 section
 variables (R)
+
+/-- `pderivative : S → mv_polynomial S R → mv_polynomial S R` as an `add_monoid_hom`  -/
 def pderivative.add_monoid_hom (v : S) : mv_polynomial S R →+ mv_polynomial S R :=
 { to_fun := pderivative v,
   map_zero' := pderivative_zero,

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -1440,14 +1440,15 @@ begin
   rw [vars, multiset.mem_to_finset] at h,
   rw ←not_mem_support_iff,
   by_contradiction,
-  have : v ∈ degrees f,
-  { unfold degrees,
+  have : v ∈ degrees f := begin
+    unfold degrees,
     rw (show f.support = insert x f.support, from eq.symm $ finset.insert_eq_of_mem H),
     rw finset.sup_insert,
     simp only [multiset.mem_union, multiset.sup_eq_union],
     left,
     rw [←to_finset_to_multiset, multiset.mem_to_finset] at a,
-    exact a },
+    exact a
+  end,
   contradiction,
 end
 
@@ -1461,8 +1462,7 @@ begin
   conv_lhs {
     apply_congr,
     skip,
-    rw (show x v = 0, from pderivative_eq_zero_of_not_mem_vars_aux h x H),
-  },
+    rw (show x v = 0, from pderivative_eq_zero_of_not_mem_vars_aux h x H) },
   simp,
 end
 


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [X] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [X] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [X] make sure definitions and lemmas are put in the right files
  * [X] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

Added the missing lemma from the previous PR:

```lean
lemma pderivative_eq_zero_of_not_mem_vars {v : S} {f : mv_polynomial S R} (h : v ∉ f.vars) :
  pderivative v f = 0 :=
```