### PR TITLE
[Merged by Bors] - feat(algebra/lie_algebra): quotients of Lie modules are Lie modules

### DIFF
--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -380,6 +380,23 @@ abbreviation mk : M → N.quotient := submodule.quotient.mk
 lemma is_quotient_mk (m : M) :
   quotient.mk' m = (mk m : N.quotient) := rfl
 
+/-- Given a Lie module $M$ over a Lie algebra $L$, together with a Lie submodule $N ⊆ M$, there
+is a natural linear map from $L$ to the endomorphisms of $M$ leaving $N$ invariant. -/
+def lie_submodule_invariant : L →ₗ[R] submodule.comap_submodule N.to_submodule N.to_submodule :=
+  linear_map.cod_restrict _ (_inst_6.to_linear_action.to_endo_map _ _ _) N.lie_mem -- FIXME _inst_6!
+
+instance lie_quotient_action : linear_action R L N.quotient :=
+  linear_action.of_endo_map _ _ _ (linear_map.comp (submodule.mapqₗ N N) lie_submodule_invariant)
+
+lemma lie_quotient_action_apply (z : L) (m : M) :
+  linear_action.act R z (mk m : N.quotient) = quotient.mk' (linear_action.act R z m) := rfl
+
+/-- The quotient of a Lie module by a Lie submodule, is a Lie module. -/
+instance lie_quotient_lie_module : lie_module R L N.quotient := {
+  lie_act := λ x y m', by { apply quotient.induction_on' m', intros m, rw is_quotient_mk,
+                            repeat { rw lie_quotient_action_apply, }, rw lie_act, refl, },
+  ..quotient.lie_quotient_action, }
+
 instance lie_quotient_has_bracket : has_bracket (quotient I) := ⟨by {
   intros x y,
   apply quotient.lift_on₂' x y (λ x' y', mk ⁅x', y'⁆),

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -380,8 +380,8 @@ abbreviation mk : M → N.quotient := submodule.quotient.mk
 lemma is_quotient_mk (m : M) :
   quotient.mk' m = (mk m : N.quotient) := rfl
 
-/-- Given a Lie module $M$ over a Lie algebra $L$, together with a Lie submodule $N ⊆ M$, there
-is a natural linear map from $L$ to the endomorphisms of $M$ leaving $N$ invariant. -/
+/-- Given a Lie module `M` over a Lie algebra `L`, together with a Lie submodule `N ⊆ M`, there
+is a natural linear map from `L` to the endomorphisms of `M` leaving `N` invariant. -/
 def lie_submodule_invariant : L →ₗ[R] submodule.comap_linear_maps N.to_submodule N.to_submodule :=
   linear_map.cod_restrict _ (α.to_linear_action.to_endo_map _ _ _) N.lie_mem
 
@@ -389,7 +389,7 @@ instance lie_quotient_action : linear_action R L N.quotient :=
   linear_action.of_endo_map _ _ _ (linear_map.comp (submodule.mapqₗ N N) lie_submodule_invariant)
 
 lemma lie_quotient_action_apply (z : L) (m : M) :
-  linear_action.act R z (mk m : N.quotient) = quotient.mk' (linear_action.act R z m) := rfl
+  linear_action.act R z (mk m : N.quotient) = mk (linear_action.act R z m) := rfl
 
 /-- The quotient of a Lie module by a Lie submodule, is a Lie module. -/
 instance lie_quotient_lie_module : lie_module R L N.quotient :=

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -382,7 +382,7 @@ lemma is_quotient_mk (m : M) :
 
 /-- Given a Lie module $M$ over a Lie algebra $L$, together with a Lie submodule $N ⊆ M$, there
 is a natural linear map from $L$ to the endomorphisms of $M$ leaving $N$ invariant. -/
-def lie_submodule_invariant : L →ₗ[R] submodule.comap_submodule N.to_submodule N.to_submodule :=
+def lie_submodule_invariant : L →ₗ[R] submodule.comap_linear_maps N.to_submodule N.to_submodule :=
   linear_map.cod_restrict _ (α.to_linear_action.to_endo_map _ _ _) N.lie_mem
 
 instance lie_quotient_action : linear_action R L N.quotient :=
@@ -392,8 +392,8 @@ lemma lie_quotient_action_apply (z : L) (m : M) :
   linear_action.act R z (mk m : N.quotient) = quotient.mk' (linear_action.act R z m) := rfl
 
 /-- The quotient of a Lie module by a Lie submodule, is a Lie module. -/
-instance lie_quotient_lie_module : lie_module R L N.quotient := {
-  lie_act := λ x y m', by { apply quotient.induction_on' m', intros m, rw is_quotient_mk,
+instance lie_quotient_lie_module : lie_module R L N.quotient :=
+{ lie_act := λ x y m', by { apply quotient.induction_on' m', intros m, rw is_quotient_mk,
                             repeat { rw lie_quotient_action_apply, }, rw lie_act, refl, },
   ..quotient.lie_quotient_action, }
 

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -382,11 +382,11 @@ lemma is_quotient_mk (m : M) :
 
 /-- Given a Lie module `M` over a Lie algebra `L`, together with a Lie submodule `N ⊆ M`, there
 is a natural linear map from `L` to the endomorphisms of `M` leaving `N` invariant. -/
-def lie_submodule_invariant : L →ₗ[R] submodule.comap_linear_maps N.to_submodule N.to_submodule :=
+def lie_submodule_invariant : L →ₗ[R] submodule.compatible_maps N.to_submodule N.to_submodule :=
   linear_map.cod_restrict _ (α.to_linear_action.to_endo_map _ _ _) N.lie_mem
 
 instance lie_quotient_action : linear_action R L N.quotient :=
-  linear_action.of_endo_map _ _ _ (linear_map.comp (submodule.mapqₗ N N) lie_submodule_invariant)
+  linear_action.of_endo_map _ _ _ (linear_map.comp (submodule.mapq_linear N N) lie_submodule_invariant)
 
 lemma lie_quotient_action_apply (z : L) (m : M) :
   linear_action.act R z (mk m : N.quotient) = mk (linear_action.act R z m) := rfl

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -359,7 +359,7 @@ end lie_module
 namespace lie_submodule
 
 variables {R : Type u} {L : Type v} [comm_ring R] [lie_ring L] [lie_algebra R L]
-variables {M : Type v} [add_comm_group M] [module R M] [lie_module R L M]
+variables {M : Type v} [add_comm_group M] [module R M] [α : lie_module R L M]
 variables (N : lie_submodule R L M) (I : lie_ideal R L)
 
 /--
@@ -383,7 +383,7 @@ lemma is_quotient_mk (m : M) :
 /-- Given a Lie module $M$ over a Lie algebra $L$, together with a Lie submodule $N ⊆ M$, there
 is a natural linear map from $L$ to the endomorphisms of $M$ leaving $N$ invariant. -/
 def lie_submodule_invariant : L →ₗ[R] submodule.comap_submodule N.to_submodule N.to_submodule :=
-  linear_map.cod_restrict _ (_inst_6.to_linear_action.to_endo_map _ _ _) N.lie_mem -- FIXME _inst_6!
+  linear_map.cod_restrict _ (α.to_linear_action.to_endo_map _ _ _) N.lie_mem
 
 instance lie_quotient_action : linear_action R L N.quotient :=
   linear_action.of_endo_map _ _ _ (linear_map.comp (submodule.mapqₗ N N) lie_submodule_invariant)

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1597,17 +1597,17 @@ begin
   apply submodule.add _ h.1 h.2,
 end
 
-/-- Given modules $M, N$ over a commutative ring, together with submodules $p ⊆ M$, $q ⊆ N$, the
-set of maps $\{f ∈ \Hom(M, N) | f(p) ⊆ q \}$ is a submodule of $\Hom(M, N)$. -/
+/-- Given modules `M`, `N` over a commutative ring, together with submodules `p ⊆ M`, `q ⊆ N`, the
+set of maps $\{f ∈ Hom(M, N) | f(p) ⊆ q \}$ is a submodule of `Hom(M, N)`. -/
 def comap_linear_maps : submodule R (M →ₗ[R] M₂) :=
 { carrier := λ f, p ≤ comap f q,
   zero    := by { change p ≤ comap 0 q, rw comap_zero, refine le_top, },
-  add     := λ f₁ f₂ h₁ h₂, by { apply le_trans _ (comap_add_le q f₁ f₂), rw le_inf_iff,
+  add     := λ f₁ f₂ h₁ h₂, by { apply le_trans _ (inf_comap_le_comap_add q f₁ f₂), rw le_inf_iff,
                                  exact ⟨h₁, h₂⟩, },
-  smul    := λ c f h, le_trans h (comap_smul_le q f c), }
+  smul    := λ c f h, le_trans h (comap_le_comap_smul q f c), }
 
-/-- Given modules $M, N$ over a commutative ring, together with submodules $p ⊆ M$, $q ⊆ N$, the
-natural map $\{f ∈ \Hom(M, N) | f(p) ⊆ q \} \to \Hom(M/p, N/q)$ is linear. -/
+/-- Given modules `M`, `N` over a commutative ring, together with submodules `p ⊆ M`, `q ⊆ N`, the
+natural map $\{f ∈ Hom(M, N) | f(p) ⊆ q \} \to Hom(M/p, N/q)$ is linear. -/
 def mapqₗ : comap_linear_maps p q →ₗ[R] p.quotient →ₗ[R] q.quotient :=
 { to_fun := λ f, mapq _ _ f.val f.property,
   add    := λ x y, by { ext m', apply quotient.induction_on' m', intros m, refl, },

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1577,7 +1577,7 @@ namespace submodule
 variables [comm_ring R] [add_comm_group M] [add_comm_group M₂] [module R M] [module R M₂]
 variables (p : submodule R M) (q : submodule R M₂)
 
-lemma comap_smul_le (f : M →ₗ[R] M₂) (c : R) :
+lemma comap_le_comap_smul (f : M →ₗ[R] M₂) (c : R) :
   comap f q ≤ comap (c • f) q :=
 begin
   rw le_def',

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1579,29 +1579,27 @@ variables (p : submodule R M) (q : submodule R M₂)
 
 lemma comap_smul_le (f : M →ₗ[R] M₂) (c : R) :
   comap f q ≤ comap (c • f) q :=
-begin -- FIXME scum proof!
-rw le_def',
-intros x hx,
-simp only [linear_map.smul_apply, mem_comap],
-rw mem_comap at hx,
-apply submodule.smul,
-assumption,
+begin
+  rw le_def',
+  intros m h,
+  change c • (f m) ∈ q,
+  change f m ∈ q at h,
+  apply submodule.smul _ _ h,
 end
 
 lemma comap_add_le (f₁ f₂ : M →ₗ[R] M₂) :
   comap f₁ q ⊓ comap f₂ q ≤ comap (f₁ + f₂) q :=
-begin -- FIXME scum proof!
-rw le_def',
-intros x hx,
-simp only [mem_comap, linear_map.add_apply],
-simp only [mem_inf, mem_comap] at hx,
-apply submodule.add; tauto,
+begin
+  rw le_def',
+  intros m h,
+  change f₁ m + f₂ m ∈ q,
+  change f₁ m ∈ q ∧ f₂ m ∈ q at h,
+  apply submodule.add _ h.1 h.2,
 end
 
 /-- Given modules $M, N$ over a commutative ring, together with submodules $p ⊆ M$, $q ⊆ N$, the
-set of linear maps preserving the submodules $\{f ∈ \Hom(M, N) | f(p) ⊆ q \}$ is a submodule of
-$\Hom(M, N)$. -/
-def comap_submodule : submodule R (M →ₗ[R] M₂) :=
+set of maps $\{f ∈ \Hom(M, N) | f(p) ⊆ q \}$ is a submodule of $\Hom(M, N)$. -/
+def comap_linear_maps : submodule R (M →ₗ[R] M₂) :=
 { carrier := λ f, p ≤ comap f q,
   zero    := by { change p ≤ comap 0 q, rw comap_zero, refine le_top, },
   add     := λ f₁ f₂ h₁ h₂, by { apply le_trans _ (comap_add_le q f₁ f₂), rw le_inf_iff,
@@ -1610,7 +1608,7 @@ def comap_submodule : submodule R (M →ₗ[R] M₂) :=
 
 /-- Given modules $M, N$ over a commutative ring, together with submodules $p ⊆ M$, $q ⊆ N$, the
 natural map $\{f ∈ \Hom(M, N) | f(p) ⊆ q \} \to \Hom(M/p, N/q)$ is linear. -/
-def mapqₗ : comap_submodule p q →ₗ[R] p.quotient →ₗ[R] q.quotient :=
+def mapqₗ : comap_linear_maps p q →ₗ[R] p.quotient →ₗ[R] q.quotient :=
 { to_fun := λ f, mapq _ _ f.val f.property,
   add    := λ x y, by { ext m', apply quotient.induction_on' m', intros m, refl, },
   smul   := λ c f, by { ext m', apply quotient.induction_on' m', intros m, refl, } }

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1599,7 +1599,7 @@ end
 
 /-- Given modules `M`, `M₂` over a commutative ring, together with submodules `p ⊆ M`, `q ⊆ M₂`, the
 set of maps $\{f ∈ Hom(M, M₂) | f(p) ⊆ q \}$ is a submodule of `Hom(M, M₂)`. -/
-def comap_linear_maps : submodule R (M →ₗ[R] M₂) :=
+def compatible_maps : submodule R (M →ₗ[R] M₂) :=
 { carrier := {f | p ≤ comap f q},
   zero    := by { change p ≤ comap 0 q, rw comap_zero, refine le_top, },
   add     := λ f₁ f₂ h₁ h₂, by { apply le_trans _ (inf_comap_le_comap_add q f₁ f₂), rw le_inf_iff,
@@ -1608,7 +1608,7 @@ def comap_linear_maps : submodule R (M →ₗ[R] M₂) :=
 
 /-- Given modules `M`, `M₂` over a commutative ring, together with submodules `p ⊆ M`, `q ⊆ M₂`, the
 natural map $\{f ∈ Hom(M, M₂) | f(p) ⊆ q \} \to Hom(M/p, M₂/q)$ is linear. -/
-def mapqₗ : comap_linear_maps p q →ₗ[R] p.quotient →ₗ[R] q.quotient :=
+def mapq_linear : compatible_maps p q →ₗ[R] p.quotient →ₗ[R] q.quotient :=
 { to_fun := λ f, mapq _ _ f.val f.property,
   add    := λ x y, by { ext m', apply quotient.induction_on' m', intros m, refl, },
   smul   := λ c f, by { ext m', apply quotient.induction_on' m', intros m, refl, } }

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1587,7 +1587,7 @@ begin
   apply submodule.smul _ _ h,
 end
 
-lemma comap_add_le (f₁ f₂ : M →ₗ[R] M₂) :
+lemma inf_comap_le_comap_add (f₁ f₂ : M →ₗ[R] M₂) :
   comap f₁ q ⊓ comap f₂ q ≤ comap (f₁ + f₂) q :=
 begin
   rw le_def',

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1572,6 +1572,51 @@ end field
 
 end linear_equiv
 
+namespace submodule
+
+variables [comm_ring R] [add_comm_group M] [add_comm_group M₂] [module R M] [module R M₂]
+variables (p : submodule R M) (q : submodule R M₂)
+
+lemma comap_smul_le (f : M →ₗ[R] M₂) (c : R) :
+  comap f q ≤ comap (c • f) q :=
+begin -- FIXME scum proof!
+rw le_def',
+intros x hx,
+simp only [linear_map.smul_apply, mem_comap],
+rw mem_comap at hx,
+apply submodule.smul,
+assumption,
+end
+
+lemma comap_add_le (f₁ f₂ : M →ₗ[R] M₂) :
+  comap f₁ q ⊓ comap f₂ q ≤ comap (f₁ + f₂) q :=
+begin -- FIXME scum proof!
+rw le_def',
+intros x hx,
+simp only [mem_comap, linear_map.add_apply],
+simp only [mem_inf, mem_comap] at hx,
+apply submodule.add; tauto,
+end
+
+/-- Given modules $M, N$ over a commutative ring, together with submodules $p ⊆ M$, $q ⊆ N$, the
+set of linear maps preserving the submodules $\{f ∈ \Hom(M, N) | f(p) ⊆ q \}$ is a submodule of
+$\Hom(M, N)$. -/
+def comap_submodule : submodule R (M →ₗ[R] M₂) :=
+{ carrier := λ f, p ≤ comap f q,
+  zero    := by { change p ≤ comap 0 q, rw comap_zero, refine le_top, },
+  add     := λ f₁ f₂ h₁ h₂, by { apply le_trans _ (comap_add_le q f₁ f₂), rw le_inf_iff,
+                                 exact ⟨h₁, h₂⟩, },
+  smul    := λ c f h, le_trans h (comap_smul_le q f c), }
+
+/-- Given modules $M, N$ over a commutative ring, together with submodules $p ⊆ M$, $q ⊆ N$, the
+natural map $\{f ∈ \Hom(M, N) | f(p) ⊆ q \} \to \Hom(M/p, N/q)$ is linear. -/
+def mapqₗ : comap_submodule p q →ₗ[R] p.quotient →ₗ[R] q.quotient :=
+{ to_fun := λ f, mapq _ _ f.val f.property,
+  add    := λ x y, by { ext m', apply quotient.induction_on' m', intros m, refl, },
+  smul   := λ c f, by { ext m', apply quotient.induction_on' m', intros m, refl, } }
+
+end submodule
+
 namespace equiv
 variables [ring R] [add_comm_group M] [module R M] [add_comm_group M₂] [module R M₂]
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1597,8 +1597,8 @@ begin
   apply submodule.add _ h.1 h.2,
 end
 
-/-- Given modules `M`, `N` over a commutative ring, together with submodules `p ⊆ M`, `q ⊆ N`, the
-set of maps $\{f ∈ Hom(M, N) | f(p) ⊆ q \}$ is a submodule of `Hom(M, N)`. -/
+/-- Given modules `M`, `M₂` over a commutative ring, together with submodules `p ⊆ M`, `q ⊆ M₂`, the
+set of maps $\{f ∈ Hom(M, M₂) | f(p) ⊆ q \}$ is a submodule of `Hom(M, M₂)`. -/
 def comap_linear_maps : submodule R (M →ₗ[R] M₂) :=
 { carrier := λ f, p ≤ comap f q,
   zero    := by { change p ≤ comap 0 q, rw comap_zero, refine le_top, },
@@ -1606,8 +1606,8 @@ def comap_linear_maps : submodule R (M →ₗ[R] M₂) :=
                                  exact ⟨h₁, h₂⟩, },
   smul    := λ c f h, le_trans h (comap_le_comap_smul q f c), }
 
-/-- Given modules `M`, `N` over a commutative ring, together with submodules `p ⊆ M`, `q ⊆ N`, the
-natural map $\{f ∈ Hom(M, N) | f(p) ⊆ q \} \to Hom(M/p, N/q)$ is linear. -/
+/-- Given modules `M`, `M₂` over a commutative ring, together with submodules `p ⊆ M`, `q ⊆ M₂`, the
+natural map $\{f ∈ Hom(M, M₂) | f(p) ⊆ q \} \to Hom(M/p, M₂/q)$ is linear. -/
 def mapqₗ : comap_linear_maps p q →ₗ[R] p.quotient →ₗ[R] q.quotient :=
 { to_fun := λ f, mapq _ _ f.val f.property,
   add    := λ x y, by { ext m', apply quotient.induction_on' m', intros m, refl, },

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1600,7 +1600,7 @@ end
 /-- Given modules `M`, `M₂` over a commutative ring, together with submodules `p ⊆ M`, `q ⊆ M₂`, the
 set of maps $\{f ∈ Hom(M, M₂) | f(p) ⊆ q \}$ is a submodule of `Hom(M, M₂)`. -/
 def comap_linear_maps : submodule R (M →ₗ[R] M₂) :=
-{ carrier := λ f, p ≤ comap f q,
+{ carrier := {f | p ≤ comap f q},
   zero    := by { change p ≤ comap 0 q, rw comap_zero, refine le_top, },
   add     := λ f₁ f₂ h₁ h₂, by { apply le_trans _ (inf_comap_le_comap_add q f₁ f₂), rw le_inf_iff,
                                  exact ⟨h₁, h₂⟩, },


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)
