### PR TITLE
feat(data/list/basic): add sum lemmas

### DIFF
--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -249,7 +249,7 @@ def left_mul {R : Type*} [semiring R] (r : R) : R →+ R :=
   map_zero' := mul_zero r,
   map_add' := mul_add r }
 
-/-- Right multiplication by an element of a (semi)ring is an add_monoid_hom -/
+/-- Right multiplication by an element of a (semi)ring is an `add_monoid_hom` -/
 def right_mul {R : Type*} [semiring R] (r : R) : R →+ R :=
 { to_fun := λ a, a * r,
   map_zero' := zero_mul r,

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -130,7 +130,9 @@ def comp (hnp : N →* P) (hmn : M →* N) : M →* P :=
 /-- Given a monoid homomorphism `f : M →* N` and a set `S ⊆ M` such that `f` maps elements of
     `S` to invertible elements of `N`, any monoid homomorphism `g : N →* P` maps elements of
     `f(S)` to invertible elements of `P`. -/
-@[to_additive "Given an add_monoid homomorphism `f : M →+ N` and a set `S ⊆ M` such that `f` maps elements of `S` to invertible elements of `N`, any add_monoid homomorphism `g : N →+ P` maps elements of `f(S)` to invertible elements of `P`."]
+@[to_additive "Given an add_monoid homomorphism `f : M →+ N` and a set `S ⊆ M` such that `f` maps
+elements of `S` to invertible elements of `N`, any add_monoid homomorphism `g : N →+ P` maps
+elements of `f(S)` to invertible elements of `P`."]
 lemma exists_inv_of_comp_exists_inv {S : set M} {f : M →* N}
   (hf : ∀ s ∈ S, ∃ b, f s * b = 1) (g : N →* P) (s ∈ S) :
   ∃ x : P, g.comp f s * x = 1 :=
@@ -235,6 +237,22 @@ instance {M G} [monoid M] [comm_group G] : comm_group (M →* G) :=
 
 end monoid_hom
 
+namespace add_monoid_hom
+
 /-- Additive group homomorphisms preserve subtraction. -/
-@[simp] theorem add_monoid_hom.map_sub {G H} [add_group G] [add_group H] (f : G →+ H) (g h : G) :
+@[simp] theorem map_sub {G H} [add_group G] [add_group H] (f : G →+ H) (g h : G) :
   f (g - h) = (f g) - (f h) := f.map_add_neg g h
+
+/-- Left multiplication by an element of a (semi)ring is an add_monoid_hom -/
+def left_mul {R : Type*} [semiring R] (r : R) : R →+ R :=
+{ to_fun := (*) r,
+  map_zero' := mul_zero r,
+  map_add' := mul_add r }
+
+/-- Right multiplication by an element of a (semi)ring is an add_monoid_hom -/
+def right_mul {R : Type*} [semiring R] (r : R) : R →+ R :=
+{ to_fun := λ a, a * r,
+  map_zero' := zero_mul r,
+  map_add' := λ _ _, add_mul _ _ r }
+
+end add_monoid_hom

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -243,7 +243,7 @@ namespace add_monoid_hom
 @[simp] theorem map_sub {G H} [add_group G] [add_group H] (f : G →+ H) (g h : G) :
   f (g - h) = (f g) - (f h) := f.map_add_neg g h
 
-/-- Left multiplication by an element of a (semi)ring is an add_monoid_hom -/
+/-- Left multiplication by an element of a (semi)ring is an `add_monoid_hom` -/
 def left_mul {R : Type*} [semiring R] (r : R) : R →+ R :=
 { to_fun := (*) r,
   map_zero' := mul_zero r,

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -244,13 +244,13 @@ namespace add_monoid_hom
   f (g - h) = (f g) - (f h) := f.map_add_neg g h
 
 /-- Left multiplication by an element of a (semi)ring is an `add_monoid_hom` -/
-def left_mul {R : Type*} [semiring R] (r : R) : R →+ R :=
+def mul_left {R : Type*} [semiring R] (r : R) : R →+ R :=
 { to_fun := (*) r,
   map_zero' := mul_zero r,
   map_add' := mul_add r }
 
 /-- Right multiplication by an element of a (semi)ring is an `add_monoid_hom` -/
-def right_mul {R : Type*} [semiring R] (r : R) : R →+ R :=
+def mul_right {R : Type*} [semiring R] (r : R) : R →+ R :=
 { to_fun := λ a, a * r,
   map_zero' := zero_mul r,
   map_add' := λ _ _, add_mul _ _ r }

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -4540,6 +4540,33 @@ theorem prod_range_succ {α : Type u} [monoid α] (f : ℕ → α) (n : ℕ) :
 by rw [range_concat, map_append, map_singleton,
   prod_append, prod_cons, prod_nil, mul_one]
 
+@[to_additive]
+theorem prod_range_succ' {α : Type u} [monoid α] (f : ℕ → α) (n : ℕ) :
+  ((range n.succ).map f).prod = f 0 * ((range n).map (λ i, f (succ i))).prod :=
+begin
+  induction n with d hd,
+  { show 1 * f 0 = f 0 * 1, rw [one_mul, mul_one]},
+  { rw [list.prod_range_succ, hd, mul_assoc, ←list.prod_range_succ]},
+end
+
+theorem list.sum_map_mul_left {α : Type u} [semiring α] {β : Type*} (L : list β)
+  (f : β → α) (r : α) (L : list β) :
+  (L.map (λ b, r * f b)).sum = r * (L.map f).sum :=
+begin
+  induction L with b L hL,
+  { exact (mul_zero r).symm},
+  { simp [mul_add, hL]}
+end
+
+theorem list.sum_map_mul_right {α : Type*} [semiring α] {β : Type*} (L : list β)
+  (f : β → α) (r : α) (L : list β) :
+  (L.map (λ b, f b * r)).sum = (L.map f).sum * r :=
+begin
+  induction L with b L hL,
+  { exact (zero_mul r).symm},
+  { simp [add_mul, hL]}
+end
+
 /--
 `Ico n m` is the list of natural numbers `n ≤ x < m`.
 (Ico stands for "interval, closed-open".)

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -4561,8 +4561,8 @@ begin
   { rw [list.prod_range_succ, hd, mul_assoc, ←list.prod_range_succ]},
 end
 
-theorem list.sum_map_mul_left {α : Type u} [semiring α] {β : Type*} (L : list β)
-  (f : β → α) (r : α) (L : list β) :
+theorem sum_map_mul_left {α : Type u} [semiring α] {β : Type*} (L : list β)
+  (f : β → α) (r : α) :
   (L.map (λ b, r * f b)).sum = r * (L.map f).sum :=
 begin
   induction L with b L hL,
@@ -4570,8 +4570,8 @@ begin
   { simp [mul_add, hL]}
 end
 
-theorem list.sum_map_mul_right {α : Type*} [semiring α] {β : Type*} (L : list β)
-  (f : β → α) (r : α) (L : list β) :
+theorem sum_map_mul_right {α : Type*} [semiring α] {β : Type*} (L : list β)
+  (f : β → α) (r : α) :
   (L.map (λ b, f b * r)).sum = (L.map f).sum * r :=
 begin
   induction L with b L hL,

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -4564,25 +4564,6 @@ begin
   { rw [list.prod_range_succ, hd, mul_assoc, ←list.prod_range_succ]},
 end
 
-@[to_additive]
-theorem prod_map_hom {α β γ : Type*} [monoid β] [monoid γ] (L : list α) (f : α → β) (g : β →* γ) :
-  (L.map (g ∘ f)).prod = g ((L.map f).prod) :=
-begin
-  induction L with b L hL,
-  { exact g.map_one.symm},
-  { simp [g.map_mul, hL]}
-end
-
-theorem sum_map_mul_left {α : Type u} [semiring α] {β : Type*} (L : list β)
-  (f : β → α) (r : α) :
-  (L.map (λ b, r * f b)).sum = r * (L.map f).sum :=
-sum_map_hom L f $ add_monoid_hom.left_mul r
-
-theorem sum_map_mul_right {α : Type*} [semiring α] {β : Type*} (L : list β)
-  (f : β → α) (r : α) :
-  (L.map (λ b, f b * r)).sum = (L.map f).sum * r :=
-sum_map_hom L f $ add_monoid_hom.right_mul r
-
 /--
 `Ico n m` is the list of natural numbers `n ≤ x < m`.
 (Ico stands for "interval, closed-open".)
@@ -5275,3 +5256,22 @@ theorem option.to_list_nodup {α} : ∀ o : option α, o.to_list.nodup
 theorem monoid_hom.map_list_prod {α β : Type*} [monoid α] [monoid β] (f : α →* β) (l : list α) :
   f l.prod = (l.map f).prod :=
 (l.prod_hom f).symm
+
+namespace list
+
+@[to_additive]
+theorem prod_map_hom {α β γ : Type*} [monoid β] [monoid γ] (L : list α) (f : α → β) (g : β →* γ) :
+  (L.map (g ∘ f)).prod = g ((L.map f).prod) :=
+by rw g.map_list_prod; exact congr_arg _ (map_map _ _ _).symm
+
+theorem sum_map_mul_left {α : Type*} [semiring α] {β : Type*} (L : list β)
+  (f : β → α) (r : α) :
+  (L.map (λ b, r * f b)).sum = r * (L.map f).sum :=
+sum_map_hom L f $ add_monoid_hom.mul_left r
+
+theorem sum_map_mul_right {α : Type*} [semiring α] {β : Type*} (L : list β)
+  (f : β → α) (r : α) :
+  (L.map (λ b, f b * r)).sum = (L.map f).sum * r :=
+sum_map_hom L f $ add_monoid_hom.mul_right r
+
+end list

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -4552,7 +4552,10 @@ theorem prod_range_succ {α : Type u} [monoid α] (f : ℕ → α) (n : ℕ) :
 by rw [range_concat, map_append, map_singleton,
   prod_append, prod_cons, prod_nil, mul_one]
 
-@[to_additive]
+/-- A variant of `prod_range_succ` which pulls off the first
+    term in the product rather than the last.-/
+@[to_additive "A variant of `sum_range_succ` which pulls off the first term in the sum
+  rather than the last."]
 theorem prod_range_succ' {α : Type u} [monoid α] (f : ℕ → α) (n : ℕ) :
   ((range n.succ).map f).prod = f 0 * ((range n).map (λ i, f (succ i))).prod :=
 begin
@@ -4561,23 +4564,24 @@ begin
   { rw [list.prod_range_succ, hd, mul_assoc, ←list.prod_range_succ]},
 end
 
+@[to_additive]
+theorem prod_map_hom {α β γ : Type*} [monoid β] [monoid γ] (L : list α) (f : α → β) (g : β →* γ) :
+  (L.map (g ∘ f)).prod = g ((L.map f).prod) :=
+begin
+  induction L with b L hL,
+  { exact g.map_one.symm},
+  { simp [g.map_mul, hL]}
+end
+
 theorem sum_map_mul_left {α : Type u} [semiring α] {β : Type*} (L : list β)
   (f : β → α) (r : α) :
   (L.map (λ b, r * f b)).sum = r * (L.map f).sum :=
-begin
-  induction L with b L hL,
-  { exact (mul_zero r).symm},
-  { simp [mul_add, hL]}
-end
+sum_map_hom L f $ add_monoid_hom.left_mul r
 
 theorem sum_map_mul_right {α : Type*} [semiring α] {β : Type*} (L : list β)
   (f : β → α) (r : α) :
   (L.map (λ b, f b * r)).sum = (L.map f).sum * r :=
-begin
-  induction L with b L hL,
-  { exact (zero_mul r).symm},
-  { simp [add_mul, hL]}
-end
+sum_map_hom L f $ add_monoid_hom.right_mul r
 
 /--
 `Ico n m` is the list of natural numbers `n ≤ x < m`.


### PR DESCRIPTION
TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

We have these sorts of lemmas for finset but because of [Kenny's kata](https://www.codewars.com/kata/5e8b9787c2eb9f0029aa73a0) (codewars.com) I needed them for lists. 