### PR TITLE
fix(tactic/norm_num) Bugfix for norm num when testing divisibility of integers

### DIFF
--- a/src/tactic/norm_num.lean
+++ b/src/tactic/norm_num.lean
@@ -295,7 +295,10 @@ meta def eval_div_ext (simp : expr → tactic (expr × expr)) : expr → tactic 
   | _ := failed
   end,
   p₁ ← mk_app ``propext [@expr.const tt n [] e₁ e₂],
-  (e', p₂) ← simp `(%%e₂ % %%e₁ = 0),
+  (c, el) ← c.mk_app ``has_mod.mod [e₂, e₁],
+  (c, z) ← c.mk_app ``has_zero.zero [],
+  e ← mk_app ``eq [el, z],
+  (e', p₂) ← simp e,
   p' ← mk_eq_trans p₁ p₂,
   return (e', p')
 | _ := failed

--- a/test/norm_num.lean
+++ b/test/norm_num.lean
@@ -42,3 +42,6 @@ example (x : ℕ) : ℕ := begin
   let n : ℕ, {apply_normed (2^32 - 71)},
   exact n
 end
+
+
+example (h : (5 : ℤ) ∣ 2) : false := by norm_num at h


### PR DESCRIPTION
They were assumed nats somehow leading to
```lean
example (h : (5 : ℤ) ∣ 2) : false := by norm_num at h
```

giving
```
type mismatch at application
  has_mod.mod 2
term
  2
has type
  ℤ
but is expected to have type
  ℕ
```

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)
