### PR TITLE
[Merged by Bors] - feat(category_theory): functorial images

### DIFF
--- a/src/category_theory/comma.lean
+++ b/src/category_theory/comma.lean
@@ -32,6 +32,13 @@ Several important constructions are special cases of this construction.
   "coslice" or "under" category under the object `L` maps to.
 * If `L` and `R` both are the identity functor, then `comma L R` is the arrow category of `T`.
 
+## Main definitions
+
+* `comma L R`: the comma category of the functors `L` and `R`.
+* `over X`: the over category of the object `X`.
+* `under X`: the under category of the object `X`.
+* `arrow T`: the arrow category of the category `T`.
+
 ## References
 
 * https://ncatlab.org/nlab/show/comma+category
@@ -61,11 +68,11 @@ section
 omit 𝒜 ℬ
 
 -- Satisfying the inhabited linter
-instance comma.inhabited [inhabited T] : inhabited (comma.{v₃ v₃ v₃} (𝟭 T) (𝟭 T)) :=
+instance comma.inhabited [inhabited T] : inhabited (comma (𝟭 T) (𝟭 T)) :=
 { default :=
-  { left := inhabited.default T,
-    right := inhabited.default T,
-    hom := 𝟙 (inhabited.default T) } }
+  { left := default T,
+    right := default T,
+    hom := 𝟙 (default T) } }
 
 end
 
@@ -81,7 +88,7 @@ variables {L : A ⥤ T} {R : B ⥤ T}
 
 -- Satisfying the inhabited linter
 instance comma_morphism.inhabited [inhabited (comma L R)] :
-  inhabited (comma_morphism (inhabited.default (comma L R)) (inhabited.default (comma L R))) :=
+  inhabited (comma_morphism (default (comma L R)) (default (comma L R))) :=
 { default :=
   { left := 𝟙 _,
     right := 𝟙 _ } }
@@ -265,9 +272,9 @@ omit 𝒜 ℬ
 def over (X : T) := comma.{v₃ 0 v₃} (𝟭 T) ((functor.const punit).obj X)
 
 -- Satisfying the inhabited linter
-instance over.inhabited [inhabited T] : inhabited (over (inhabited.default T)) :=
+instance over.inhabited [inhabited T] : inhabited (over (default T)) :=
 { default :=
-  { left := (inhabited.default T),
+  { left := default T,
     hom := 𝟙 _ } }
 
 namespace over
@@ -386,9 +393,9 @@ end over
 def under (X : T) := comma.{0 v₃ v₃} ((functor.const punit).obj X) (𝟭 T)
 
 -- Satisfying the inhabited linter
-instance under.inhabited [inhabited T] : inhabited (under (inhabited.default T)) :=
+instance under.inhabited [inhabited T] : inhabited (under (default T)) :=
 { default :=
-  { right := inhabited.default T,
+  { right := default T,
     hom := 𝟙 _ } }
 
 namespace under
@@ -467,10 +474,7 @@ def arrow := comma.{v₃ v₃ v₃} (𝟭 T) (𝟭 T)
 
 -- Satisfying the inhabited linter
 instance arrow.inhabited [inhabited T] : inhabited (arrow T) :=
-{ default :=
-  { left := inhabited.default T,
-    right := inhabited.default T,
-    hom := 𝟙 (inhabited.default T) } }
+{ default := show comma (𝟭 T) (𝟭 T), from default (comma (𝟭 T) (𝟭 T)) }
 
 end
 

--- a/src/category_theory/comma.lean
+++ b/src/category_theory/comma.lean
@@ -120,6 +120,8 @@ namespace comma
 section
 variables {X Y Z : comma L R} {f : X ⟶ Y} {g : Y ⟶ Z}
 
+@[simp] lemma id_left  : ((𝟙 X) : comma_morphism X X).left = 𝟙 X.left := rfl
+@[simp] lemma id_right : ((𝟙 X) : comma_morphism X X).right = 𝟙 X.right := rfl
 @[simp] lemma comp_left  : (f ≫ g).left  = f.left ≫ g.left   := rfl
 @[simp] lemma comp_right : (f ≫ g).right = f.right ≫ g.right := rfl
 

--- a/src/category_theory/comma.lean
+++ b/src/category_theory/comma.lean
@@ -426,4 +426,30 @@ end
 
 end under
 
+section
+variables (T)
+
+/-- The arrow category of `T` has as objects all morphisms in `T` and as morphisms the commutative
+     squares. -/
+@[derive category]
+def arrow := comma.{v₃ v₃ v₃} (𝟭 T) (𝟭 T)
+
+end
+
+namespace arrow
+
+@[simp] lemma id_left (f : arrow T) : comma_morphism.left (𝟙 f) = 𝟙 (f.left) := rfl
+@[simp] lemma id_right (f : arrow T) : comma_morphism.right (𝟙 f) = 𝟙 (f.right) := rfl
+
+def mk {X Y : T} (f : X ⟶ Y) : arrow T :=
+⟨X, Y, f⟩
+
+def hom_mk {X Y : T} {f : X ⟶ Y} {P Q : T} {g : P ⟶ Q} {u : X ⟶ P} {v : Y ⟶ Q}
+  (w : u ≫ g = f ≫ v) : arrow.mk f ⟶ arrow.mk g :=
+{ left := u,
+  right := v,
+  w' := w }
+
+end arrow
+
 end category_theory

--- a/src/category_theory/comma.lean
+++ b/src/category_theory/comma.lean
@@ -7,6 +7,41 @@ import category_theory.isomorphism
 import category_theory.equivalence
 import category_theory.punit
 
+/-!
+# Comma categories
+
+A comma category is a construction in category theory, which builds a category out of two functors
+with a common codomain. Specifically, for functors `L : A ⥤ T` and `R : B ⥤ T`, an object in
+`comma L R` is a morphism `hom : L.obj left ⟶ R.obj right` for some objects `left : A` and
+`right : B`, and a morphism in `comma L R` between `hom : L.obj left ⟶ R.obj right` and
+`hom' : L.obj left' ⟶ R.obj right'` is a commutative square
+
+L.obj left   ⟶   L.obj left'
+      |               |
+  hom |               | hom'
+      ↓               ↓
+R.obj right  ⟶   R.obj right',
+
+where the top and bottom morphism come from morphisms `left ⟶ left'` and `right ⟶ right'`,
+respectively.
+
+Several important constructions are special cases of this construction.
+* If `L` is the identity functor and `R` is a constant functor, then `comma L R` is the "slice" or
+  "over" category over the object `R` maps to.
+* Conversely, if `L` is a constant functor and `R` is the identity functor, then `comma L R` is the
+  "coslice" or "under" category under the object `L` maps to.
+* If `L` and `R` both are the identity functor, then `comma L R` is the arrow category of `T`.
+
+## References
+
+* https://ncatlab.org/nlab/show/comma+category
+
+## Tags
+
+comma, slice, coslice, over, under, arrow
+-/
+
+
 namespace category_theory
 
 universes v₁ v₂ v₃ u₁ u₂ u₃ -- declare the `v`'s first; see `category_theory.category` for an explanation
@@ -15,6 +50,8 @@ variables {B : Type u₂} [ℬ : category.{v₂} B]
 variables {T : Type u₃} [𝒯 : category.{v₃} T]
 include 𝒜 ℬ 𝒯
 
+/-- The objects of the comma category category are triples of an object `left : A`, an object
+   `right : B` and a morphism `hom : L.obj left ⟶ R.obj right`.  -/
 structure comma (L : A ⥤ T) (R : B ⥤ T) : Type (max u₁ u₂ v₃) :=
 (left : A . obviously)
 (right : B . obviously)
@@ -22,6 +59,9 @@ structure comma (L : A ⥤ T) (R : B ⥤ T) : Type (max u₁ u₂ v₃) :=
 
 variables {L : A ⥤ T} {R : B ⥤ T}
 
+/-- A morphism between two objects in the comma category is a commutative square connecting the
+    morphisms coming from the two objects using morphisms in the image of the functors `L` and `R`.
+-/
 @[ext] structure comma_morphism (X Y : comma L R) :=
 (left : X.left ⟶ Y.left . obviously)
 (right : X.right ⟶ Y.right . obviously)
@@ -61,10 +101,12 @@ end
 
 variables (L) (R)
 
+/-- The functor sending an object `X` in the comma category to `X.left`. -/
 def fst : comma L R ⥤ A :=
 { obj := λ X, X.left,
   map := λ _ _ f, f.left }
 
+/-- The functor sending an object `X` in the comma category to `X.right`. -/
 def snd : comma L R ⥤ B :=
 { obj := λ X, X.right,
   map := λ _ _ f, f.right }
@@ -74,12 +116,17 @@ def snd : comma L R ⥤ B :=
 @[simp] lemma fst_map {X Y : comma L R} {f : X ⟶ Y} : (fst L R).map f = f.left := rfl
 @[simp] lemma snd_map {X Y : comma L R} {f : X ⟶ Y} : (snd L R).map f = f.right := rfl
 
+/-- We can interpret the commutative square constituting a morphism in the comma category as a
+    natural transformation between the functors `fst ⋙ L` and `snd ⋙ R` from the comma category
+    to `T`, where the components are given by the morphism that constitutes an object of the comma
+    category. -/
 def nat_trans : fst L R ⋙ L ⟶ snd L R ⋙ R :=
 { app := λ X, X.hom }
 
 section
 variables {L₁ L₂ L₃ : A ⥤ T} {R₁ R₂ R₃ : B ⥤ T}
 
+/-- A natural transformation `L₁ ⟶ L₂` induces a functor `comma L₂ R ⥤ comma L₁ R`. -/
 def map_left (l : L₁ ⟶ L₂) : comma L₂ R ⥤ comma L₁ R :=
 { obj := λ X,
   { left  := X.left,
@@ -99,6 +146,8 @@ variables {X Y : comma L₂ R} {f : X ⟶ Y} {l : L₁ ⟶ L₂}
 @[simp] lemma map_left_map_right : ((map_left R l).map f).right = f.right               := rfl
 end
 
+/-- The functor `comma L R ⥤ comma L R` induced by the identity natural transformation on `L` is
+    naturally isomorphic to the identity functor. -/
 def map_left_id : map_left R (𝟙 L) ≅ 𝟭 _ :=
 { hom :=
   { app := λ X, { left := 𝟙 _, right := 𝟙 _ } },
@@ -113,8 +162,11 @@ variables {X : comma L R}
 @[simp] lemma map_left_id_inv_app_right : (((map_left_id L R).inv).app X).right = 𝟙 (X.right) := rfl
 end
 
+/-- The functor `comma L₁ R ⥤ comma L₃ R` induced by the composition of two natural transformations
+    `l : L₁ ⟶ L₂` and `l' : L₂ ⟶ L₃` is naturally isomorphic to the composition of the two functors
+    induced by these natural transformations. -/
 def map_left_comp (l : L₁ ⟶ L₂) (l' : L₂ ⟶ L₃) :
-(map_left R (l ≫ l')) ≅ (map_left R l') ⋙ (map_left R l) :=
+  (map_left R (l ≫ l')) ≅ (map_left R l') ⋙ (map_left R l) :=
 { hom :=
   { app := λ X, { left := 𝟙 _, right := 𝟙 _ } },
   inv :=
@@ -128,6 +180,7 @@ variables {X : comma L₃ R} {l : L₁ ⟶ L₂} {l' : L₂ ⟶ L₃}
 @[simp] lemma map_left_comp_inv_app_right : (((map_left_comp R l l').inv).app X).right = 𝟙 (X.right) := rfl
 end
 
+/-- A natural transformation `R₁ ⟶ R₂` induces a functor `comma L R₁ ⥤ comma L R₂`. -/
 def map_right (r : R₁ ⟶ R₂) : comma L R₁ ⥤ comma L R₂ :=
 { obj := λ X,
   { left  := X.left,
@@ -147,6 +200,8 @@ variables {X Y : comma L R₁} {f : X ⟶ Y} {r : R₁ ⟶ R₂}
 @[simp] lemma map_right_map_right : ((map_right L r).map f).right = f.right                := rfl
 end
 
+/-- The functor `comma L R ⥤ comma L R` induced by the identity natural transformation on `R` is
+    naturally isomorphic to the identity functor. -/
 def map_right_id : map_right L (𝟙 R) ≅ 𝟭 _ :=
 { hom :=
   { app := λ X, { left := 𝟙 _, right := 𝟙 _ } },
@@ -161,7 +216,11 @@ variables {X : comma L R}
 @[simp] lemma map_right_id_inv_app_right : (((map_right_id L R).inv).app X).right = 𝟙 (X.right) := rfl
 end
 
-def map_right_comp (r : R₁ ⟶ R₂) (r' : R₂ ⟶ R₃) : (map_right L (r ≫ r')) ≅ (map_right L r) ⋙ (map_right L r') :=
+/-- The functor `comma L R₁ ⥤ comma L R₃` induced by the composition of the natural transformations
+    `r : R₁ ⟶ R₂` and `r' : R₂ ⟶ R₃` is naturally isomorphic to the composition of the functors
+    induced by these natural transformations. -/
+def map_right_comp (r : R₁ ⟶ R₂) (r' : R₂ ⟶ R₃) :
+  (map_right L (r ≫ r')) ≅ (map_right L r) ⋙ (map_right L r') :=
 { hom :=
   { app := λ X, { left := 𝟙 _, right := 𝟙 _ } },
   inv :=
@@ -181,6 +240,8 @@ end comma
 
 omit 𝒜 ℬ
 
+/-- The over category has as objects arrows in `T` with codomain `X` and as morphisms commutative
+    triangles. -/
 @[derive category]
 def over (X : T) := comma.{v₃ 0 v₃} (𝟭 T) ((functor.const punit).obj X)
 
@@ -202,12 +263,15 @@ by tidy
 @[simp, reassoc] lemma w {A B : over X} (f : A ⟶ B) : f.left ≫ B.hom = A.hom :=
 by have := f.w; tidy
 
+/-- To give an object in the over category, it suffices to give a morphism with codomain `X`. -/
 def mk {X Y : T} (f : Y ⟶ X) : over X :=
 { left := Y, hom := f }
 
 @[simp] lemma mk_left {X Y : T} (f : Y ⟶ X) : (mk f).left = Y := rfl
 @[simp] lemma mk_hom {X Y : T} (f : Y ⟶ X) : (mk f).hom = f := rfl
 
+/-- To give a morphism in the over category, it suffices to give an arrow fitting in a commutative
+    triangle. -/
 def hom_mk {U V : over X} (f : U.left ⟶ V.left) (w : f ≫ V.hom = U.hom . obviously) :
   U ⟶ V :=
 { left := f }
@@ -216,11 +280,13 @@ def hom_mk {U V : over X} (f : U.left ⟶ V.left) (w : f ≫ V.hom = U.hom . obv
   (hom_mk f).left = f :=
 rfl
 
+/-- The forgetful functor mapping an arrow to its domain. -/
 def forget : (over X) ⥤ T := comma.fst _ _
 
 @[simp] lemma forget_obj {U : over X} : forget.obj U = U.left := rfl
 @[simp] lemma forget_map {U V : over X} {f : U ⟶ V} : forget.map f = f.left := rfl
 
+/-- A morphism `f : X ⟶ Y` induces a functor `over X ⥤ over Y` in the obvious way. -/
 def map {Y : T} (f : X ⟶ Y) : over X ⥤ over Y := comma.map_right _ $ (functor.const punit).map f
 
 section
@@ -278,6 +344,7 @@ section
 variables {D : Type u₃} [𝒟 : category.{v₃} D]
 include 𝒟
 
+/-- A functor `F : T ⥤ D` induces a functor `over X ⥤ over (F.obj X)` in the obvious way. -/
 def post (F : T ⥤ D) : over X ⥤ over (F.obj X) :=
 { obj := λ Y, mk $ F.map Y.hom,
   map := λ Y₁ Y₂ f,
@@ -288,6 +355,8 @@ end
 
 end over
 
+/-- The under category has as objects arrows with domain `X` and as morphisms commutative
+    triangles. -/
 @[derive category]
 def under (X : T) := comma.{0 v₃ v₃} ((functor.const punit).obj X) (𝟭 T)
 
@@ -309,12 +378,15 @@ by tidy
 @[simp] lemma w {A B : under X} (f : A ⟶ B) : A.hom ≫ f.right = B.hom :=
 by have := f.w; tidy
 
+/-- To give an object in the under category, it suffices to give an arrow with domain `X`. -/
 def mk {X Y : T} (f : X ⟶ Y) : under X :=
 { right := Y, hom := f }
 
 @[simp] lemma mk_right {X Y : T} (f : X ⟶ Y) : (mk f).right = Y := rfl
 @[simp] lemma mk_hom {X Y : T} (f : X ⟶ Y) : (mk f).hom = f := rfl
 
+/-- To give a morphism in the under category, it suffices to give a morphism fitting in a
+    commutative triangle. -/
 def hom_mk {U V : under X} (f : U.right ⟶ V.right) (w : U.hom ≫ f = V.hom . obviously) :
   U ⟶ V :=
 { right := f }
@@ -323,11 +395,13 @@ def hom_mk {U V : under X} (f : U.right ⟶ V.right) (w : U.hom ≫ f = V.hom . 
   (hom_mk f).right = f :=
 rfl
 
+/-- The forgetful functor mapping an arrow to its domain. -/
 def forget : (under X) ⥤ T := comma.snd _ _
 
 @[simp] lemma forget_obj {U : under X} : forget.obj U = U.right := rfl
 @[simp] lemma forget_map {U V : under X} {f : U ⟶ V} : forget.map f = f.right := rfl
 
+/-- A morphism `X ⟶ Y` induces a functor `under Y ⥤ under X` in the obvious way. -/
 def map {Y : T} (f : X ⟶ Y) : under Y ⥤ under X := comma.map_left _ $ (functor.const punit).map f
 
 section
@@ -341,6 +415,7 @@ section
 variables {D : Type u₃} [𝒟 : category.{v₃} D]
 include 𝒟
 
+/-- A functor `F : T ⥤ D` induces a functor `under X ⥤ under (F.obj X)` in the obvious way. -/
 def post {X : T} (F : T ⥤ D) : under X ⥤ under (F.obj X) :=
 { obj := λ Y, mk $ F.map Y.hom,
   map := λ Y₁ Y₂ f,

--- a/src/category_theory/comma.lean
+++ b/src/category_theory/comma.lean
@@ -50,7 +50,7 @@ variables {B : Type u₂} [ℬ : category.{v₂} B]
 variables {T : Type u₃} [𝒯 : category.{v₃} T]
 include 𝒜 ℬ 𝒯
 
-/-- The objects of the comma category category are triples of an object `left : A`, an object
+/-- The objects of the comma category are triples of an object `left : A`, an object
    `right : B` and a morphism `hom : L.obj left ⟶ R.obj right`.  -/
 structure comma (L : A ⥤ T) (R : B ⥤ T) : Type (max u₁ u₂ v₃) :=
 (left : A . obviously)

--- a/src/category_theory/comma.lean
+++ b/src/category_theory/comma.lean
@@ -429,8 +429,8 @@ end under
 section
 variables (T)
 
-/-- The arrow category of `T` has as objects all morphisms in `T` and as morphisms the commutative
-     squares. -/
+/-- The arrow category of `T` has as objects all morphisms in `T` and as morphisms commutative
+     squares in `T`. -/
 @[derive category]
 def arrow := comma.{v₃ v₃ v₃} (𝟭 T) (𝟭 T)
 
@@ -441,9 +441,11 @@ namespace arrow
 @[simp] lemma id_left (f : arrow T) : comma_morphism.left (𝟙 f) = 𝟙 (f.left) := rfl
 @[simp] lemma id_right (f : arrow T) : comma_morphism.right (𝟙 f) = 𝟙 (f.right) := rfl
 
+/-- An object in the arrow category is simply a morphism in `T`. -/
 def mk {X Y : T} (f : X ⟶ Y) : arrow T :=
 ⟨X, Y, f⟩
 
+/-- A morphism in the arrow category is a commutative square. -/
 def hom_mk {X Y : T} {f : X ⟶ Y} {P Q : T} {g : P ⟶ Q} {u : X ⟶ P} {v : Y ⟶ Q}
   (w : u ≫ g = f ≫ v) : arrow.mk f ⟶ arrow.mk g :=
 { left := u,

--- a/src/category_theory/comma.lean
+++ b/src/category_theory/comma.lean
@@ -57,6 +57,18 @@ structure comma (L : A ⥤ T) (R : B ⥤ T) : Type (max u₁ u₂ v₃) :=
 (right : B . obviously)
 (hom : L.obj left ⟶ R.obj right)
 
+section
+omit 𝒜 ℬ
+
+-- Satisfying the inhabited linter
+instance comma.inhabited [inhabited T] : inhabited (comma.{v₃ v₃ v₃} (𝟭 T) (𝟭 T)) :=
+{ default :=
+  { left := inhabited.default T,
+    right := inhabited.default T,
+    hom := 𝟙 (inhabited.default T) } }
+
+end
+
 variables {L : A ⥤ T} {R : B ⥤ T}
 
 /-- A morphism between two objects in the comma category is a commutative square connecting the
@@ -66,6 +78,13 @@ variables {L : A ⥤ T} {R : B ⥤ T}
 (left : X.left ⟶ Y.left . obviously)
 (right : X.right ⟶ Y.right . obviously)
 (w' : L.map left ≫ Y.hom = X.hom ≫ R.map right . obviously)
+
+-- Satisfying the inhabited linter
+instance comma_morphism.inhabited [inhabited (comma L R)] :
+  inhabited (comma_morphism (inhabited.default (comma L R)) (inhabited.default (comma L R))) :=
+{ default :=
+  { left := 𝟙 _,
+    right := 𝟙 _ } }
 
 restate_axiom comma_morphism.w'
 attribute [simp] comma_morphism.w
@@ -245,6 +264,12 @@ omit 𝒜 ℬ
 @[derive category]
 def over (X : T) := comma.{v₃ 0 v₃} (𝟭 T) ((functor.const punit).obj X)
 
+-- Satisfying the inhabited linter
+instance over.inhabited [inhabited T] : inhabited (over (inhabited.default T)) :=
+{ default :=
+  { left := (inhabited.default T),
+    hom := 𝟙 _ } }
+
 namespace over
 
 variables {X : T}
@@ -360,6 +385,12 @@ end over
 @[derive category]
 def under (X : T) := comma.{0 v₃ v₃} ((functor.const punit).obj X) (𝟭 T)
 
+-- Satisfying the inhabited linter
+instance under.inhabited [inhabited T] : inhabited (under (inhabited.default T)) :=
+{ default :=
+  { right := inhabited.default T,
+    hom := 𝟙 _ } }
+
 namespace under
 
 variables {X : T}
@@ -434,6 +465,13 @@ variables (T)
 @[derive category]
 def arrow := comma.{v₃ v₃ v₃} (𝟭 T) (𝟭 T)
 
+-- Satisfying the inhabited linter
+instance arrow.inhabited [inhabited T] : inhabited (arrow T) :=
+{ default :=
+  { left := inhabited.default T,
+    right := inhabited.default T,
+    hom := 𝟙 (inhabited.default T) } }
+
 end
 
 namespace arrow
@@ -445,12 +483,32 @@ namespace arrow
 def mk {X Y : T} (f : X ⟶ Y) : arrow T :=
 ⟨X, Y, f⟩
 
-/-- A morphism in the arrow category is a commutative square. -/
-def hom_mk {X Y : T} {f : X ⟶ Y} {P Q : T} {g : P ⟶ Q} {u : X ⟶ P} {v : Y ⟶ Q}
+@[simp] lemma mk_hom {X Y : T} (f : X ⟶ Y) : (mk f).hom = f := rfl
+
+/-- A morphism in the arrow category is a commutative square connecting two objects of the arrow
+    category. -/
+def hom_mk {f g : arrow T} {u : f.left ⟶ g.left} {v : f.right ⟶ g.right}
+  (w : u ≫ g.hom = f.hom ≫ v) : f ⟶ g :=
+{ left := u,
+  right := v,
+  w' := w }
+
+@[simp] lemma hom_mk_left {f g : arrow T} {u : f.left ⟶ g.left} {v : f.right ⟶ g.right}
+  (w : u ≫ g.hom = f.hom ≫ v) : (hom_mk w).left = u := rfl
+@[simp] lemma hom_mk_right {f g : arrow T} {u : f.left ⟶ g.left} {v : f.right ⟶ g.right}
+  (w : u ≫ g.hom = f.hom ≫ v) : (hom_mk w).right = v := rfl
+
+/-- We can also build a morphism in the arrow category out of any commutative square in `T`. -/
+def hom_mk' {X Y : T} {f : X ⟶ Y} {P Q : T} {g : P ⟶ Q} {u : X ⟶ P} {v : Y ⟶ Q}
   (w : u ≫ g = f ≫ v) : arrow.mk f ⟶ arrow.mk g :=
 { left := u,
   right := v,
   w' := w }
+
+@[simp] lemma hom_mk'_left {X Y : T} {f : X ⟶ Y} {P Q : T} {g : P ⟶ Q} {u : X ⟶ P} {v : Y ⟶ Q}
+  (w : u ≫ g = f ≫ v) : (hom_mk' w).left = u := rfl
+@[simp] lemma hom_mk'_right {X Y : T} {f : X ⟶ Y} {P Q : T} {g : P ⟶ Q} {u : X ⟶ P} {v : Y ⟶ Q}
+  (w : u ≫ g = f ≫ v) : (hom_mk' w).right = v := rfl
 
 end arrow
 

--- a/src/category_theory/limits/shapes/images.lean
+++ b/src/category_theory/limits/shapes/images.lean
@@ -12,9 +12,33 @@ import category_theory.comma
 We define the categorical image of `f` as a factorisation `f = e ≫ m` through a monomorphism `m`,
 so that `m` factors through the `m'` in any other such factorisation.
 
+## Main definitions
+
+* A `mono_factorisation` is a factorisation `f = e ≫ m`, where `m` is a monomorphism
+* `is_image F` means that a given mono factorisation `F` has the universal property of the image.
+* `has_image f` means that we have chosen an image for the morphism `f : X ⟶ Y`.
+  * In this case, `image f` is the image object, `image.ι f : image f ⟶ Y` is the monomorphism `m`
+    of the factorisation and `factor_thru_image f : X ⟶ image f` is the morphism `e`.
+* `has_images C` means that every morphism in `C` has an image.
+* Let `f : X ⟶ Y` and `g : P ⟶ Q` be morphisms in `C`, which we will represent as objects of the
+  arrow category `arrow C`. Then `sq : f ⟶ g` is a commutative square in `C`. If `f` and `g` have
+  images, then `has_image_map sq` represents the fact that there is a morphism
+  `i : image f ⟶ image g` making the diagram
+
+  X ----→ image f ----→ Y
+  |         |           |
+  |         |           |
+  ↓         ↓           ↓
+  P ----→ image g ----→ Q
+
+  commute, where the top row is the image factorisation of `f`, the bottom row is the image
+  factorisation of `g`, and the outer rectangle is the commutative square `sq`.
+* If a category `has_images`, then `has_image_maps` means that every commutative square admits an
+  image map.
+
 ## Main statements
 
-* When `C` has equalizers, the morphism `m` is an epimorphism.
+* When `C` has equalizers, the morphism `e` appearing in an image factorisation is an epimorphism.
 
 ## Future work
 * TODO: coimages, and abelian categories.
@@ -347,9 +371,7 @@ variables (f)
 /-- The identity `image f ⟶ image f` fits into the commutative square represented by the identity
     morphism `𝟙 f` in the arrow category. -/
 def has_image_map_id : has_image_map (𝟙 f) :=
-{ map := 𝟙 (image f.hom),
-  factor_map' := by erw [arrow.id_left, category.id_comp, category.comp_id],
-  map_ι' := by erw [arrow.id_right, category.id_comp, category.comp_id] }
+{ map := 𝟙 (image f.hom) }
 
 @[simp]
 lemma image.map_id [has_image_map (𝟙 f)] : image.map (𝟙 f) = 𝟙 (image f.hom) :=
@@ -375,6 +397,7 @@ variables [has_images.{v} C] [has_image_maps.{v} C]
 
 /-- The functor from the arrow category of `C` to `C` itself that maps a morphism to its image
     and a commutative square to the induced morphism on images. -/
+@[simps]
 def im : arrow C ⥤ C :=
 { obj := λ f, image f.hom,
   map := λ _ _ st, image.map st,

--- a/src/category_theory/limits/shapes/images.lean
+++ b/src/category_theory/limits/shapes/images.lean
@@ -313,7 +313,7 @@ end
 variable [has_image_map sq]
 
 /-- The map on images induced by a commutative square. -/
-abbreviation image.map := has_image_map.map sq
+abbreviation image.map : image f.hom ⟶ image g.hom := has_image_map.map sq
 
 lemma image.factor_map :
   factor_thru_image f.hom ≫ image.map sq = sq.left ≫ factor_thru_image g.hom :=

--- a/src/category_theory/limits/shapes/images.lean
+++ b/src/category_theory/limits/shapes/images.lean
@@ -280,6 +280,13 @@ namespace category_theory.limits
 variables {C : Type u} [𝒞 : category.{v} C]
 include 𝒞
 
+section
+
+instance {X Y : C} (f : X ⟶ Y) [has_image f] : has_image (arrow.mk f).hom :=
+by { rw arrow.mk_hom, apply_instance }
+
+end
+
 section has_image_map
 variables {f g : arrow C} [has_image f.hom] [has_image g.hom] (sq : f ⟶ g)
 
@@ -313,19 +320,23 @@ lemma image.factor_map :
 by simp
 lemma image.map_ι : image.map sq ≫ image.ι g.hom = image.ι f.hom ≫ sq.right :=
 by simp
+lemma image.map_hom_mk'_ι {X Y P Q : C} {k : X ⟶ Y} [has_image k] {l : P ⟶ Q} [has_image l]
+  {m : X ⟶ P} {n : Y ⟶ Q} (w : m ≫ l = k ≫ n) [has_image_map (arrow.hom_mk' w)] :
+  image.map (arrow.hom_mk' w) ≫ image.ι l = image.ι k ≫ n :=
+image.map_ι _
 
 section
 variables {h : arrow C} [has_image h.hom] (sq' : g ⟶ h)
 variables [has_image_map sq']
 
 /-- Image maps for composable commutative squares induce an image map in the composite square. -/
-def image.map_comp : has_image_map (sq ≫ sq') :=
+def has_image_map_comp : has_image_map (sq ≫ sq') :=
 { map := image.map sq ≫ image.map sq' }
 
-@[simp]
-lemma image.map_comp_eq_comp_map [has_image_map (sq ≫ sq')] :
+-- This cannot be a simp lemma, see https://github.com/leanprover-community/lean/issues/181.
+lemma image.map_comp [has_image_map (sq ≫ sq')] :
   image.map (sq ≫ sq') = image.map sq ≫ image.map sq' :=
-show (has_image_map.map (sq ≫ sq')) = (image.map_comp sq sq').map, by congr
+show (has_image_map.map (sq ≫ sq')) = (has_image_map_comp sq sq').map, by congr
 
 end
 
@@ -334,14 +345,14 @@ variables (f)
 
 /-- The identity `image f ⟶ image f` fits into the commutative square represented by the identity
     morphism `𝟙 f` in the arrow category. -/
-def image.map_id : has_image_map (𝟙 f) :=
+def has_image_map_id : has_image_map (𝟙 f) :=
 { map := 𝟙 (image f.hom),
   factor_map' := by erw [arrow.id_left, category.id_comp, category.comp_id],
   map_ι' := by erw [arrow.id_right, category.id_comp, category.comp_id] }
 
 @[simp]
-lemma image.map_id_eq_id [has_image_map (𝟙 f)] : image.map (𝟙 f) = 𝟙 (image f.hom) :=
-show (image.map (𝟙 f)) = (image.map_id f).map, by congr
+lemma image.map_id [has_image_map (𝟙 f)] : image.map (𝟙 f) = 𝟙 (image f.hom) :=
+show (image.map (𝟙 f)) = (has_image_map_id f).map, by congr
 
 end
 
@@ -361,20 +372,12 @@ end
 section has_image_maps
 variables [has_images.{v} C] [has_image_maps.{v} C]
 
-set_option trace.simplify.rewrite true
-
 /-- The functor from the arrow category of `C` to `C` itself that maps a morphism to its image
     and a commutative square to the induced morphism on images. -/
 def im : arrow C ⥤ C :=
 { obj := λ f, image f.hom,
   map := λ _ _ st, image.map st,
-  map_id' := by tidy,
-  map_comp' :=
-  begin
-    intros,
-    -- simp does not work here?
-    rw image.map_comp_eq_comp_map,
-  end }
+  map_comp' := λ _ _ _ _ _, image.map_comp _ _ }
 
 end has_image_maps
 

--- a/src/category_theory/limits/shapes/images.lean
+++ b/src/category_theory/limits/shapes/images.lean
@@ -288,8 +288,7 @@ lemma image.pre_comp_comp {W : C} (h : Z ⟶ W)
 image.pre_comp f (g ≫ h) ≫ image.pre_comp g h = image.eq_to_hom (category.assoc C f g h).symm ≫ (image.pre_comp (f ≫ g) h) :=
 begin
   apply (cancel_mono (image.ι h)).1,
-  dsimp [image.pre_comp, image.eq_to_hom],
-  simp,
+  simp [image.pre_comp, image.eq_to_hom],
 end
 
 -- Note that in general we don't have the other comparison map you might expect

--- a/src/category_theory/limits/shapes/images.lean
+++ b/src/category_theory/limits/shapes/images.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Markus Himmel
 -/
 import category_theory.limits.shapes.equalizers
+import category_theory.comma
 
 /-!
 # Categorical images
@@ -271,5 +272,89 @@ end
 -- `image f ⟶ image (f ≫ g)`.
 
 end
+
+section has_image_map
+variables {f} [has_image f]
+variables {P Q : C} {g : P ⟶ Q} [has_image g] (sq : arrow.mk f ⟶ arrow.mk g)
+
+include sq
+
+class has_image_map :=
+(map : image f ⟶ image g)
+(factor_map' : factor_thru_image f ≫ map = sq.left ≫ factor_thru_image g . obviously)
+(map_ι' : map ≫ image.ι g = image.ι f ≫ sq.right . obviously)
+
+restate_axiom has_image_map.factor_map'
+restate_axiom has_image_map.map_ι'
+attribute [simp, reassoc] has_image_map.factor_map has_image_map.map_ι
+
+section
+local attribute [ext] has_image_map
+
+instance : subsingleton (has_image_map sq) :=
+subsingleton.intro $ λ a b, has_image_map.ext a b $ (cancel_mono (image.ι g)).1 $
+  by simp only [has_image_map.map_ι]
+
+end
+
+variable [has_image_map sq]
+
+abbreviation image.map := has_image_map.map sq
+
+lemma image.factor_map : factor_thru_image f ≫ image.map sq = sq.left ≫ factor_thru_image g :=
+by simp
+lemma image.map_ι : image.map sq ≫ image.ι g = image.ι f ≫ sq.right :=
+by simp
+
+section
+variables {R S : C} {h : R ⟶ S} [has_image h] (sq' : arrow.mk g ⟶ arrow.mk h)
+variables [has_image_map sq] [has_image_map sq']
+
+def image.map_comp : has_image_map (sq ≫ sq') :=
+{ map := image.map sq ≫ image.map sq' }
+
+@[simp]
+lemma image.map_comp_eq_comp_map [has_image_map (sq ≫ sq')] :
+  image.map (sq ≫ sq') = image.map sq ≫ image.map sq' :=
+show (has_image_map.map (sq ≫ sq')) = (image.map_comp sq sq').map, by congr
+
+end
+
+section
+
+--set_option pp.implicit true
+--set_option pp.notation false
+
+def image.map_id : has_image_map (𝟙 (arrow.mk f)) :=
+{ map := 𝟙 (image f),
+  factor_map' := begin
+    simp only [arrow.id_left, category.comp_id],
+    erw category.id_comp,
+  end,
+  map_ι' := begin
+    simp only [arrow.id_right, category.id_comp],
+    erw category.comp_id,
+  end }
+
+end
+
+end has_image_map
+
+/-section
+variables (C) [has_images.{v} C]
+
+class has_image_maps :=
+(has_image_map : Π {X Y P Q : C} {f : X ⟶ Y} {g : P ⟶ Q} {u : X ⟶ P} {v : Y ⟶ Q}
+  (w : f ≫ v = u ≫ g), has_image_map w)
+
+end
+
+section has_image_maps
+variables [has_images.{v} C] [has_image_maps.{v} C]
+
+--def im : arrow C ⥤ C
+
+
+end has_image_maps-/
 
 end category_theory.limits

--- a/src/category_theory/limits/shapes/images.lean
+++ b/src/category_theory/limits/shapes/images.lean
@@ -283,16 +283,15 @@ include 𝒞
 section
 
 instance {X Y : C} (f : X ⟶ Y) [has_image f] : has_image (arrow.mk f).hom :=
-by { rw arrow.mk_hom, apply_instance }
+show has_image f, by apply_instance
 
 end
 
 section has_image_map
-variables {f g : arrow C} [has_image f.hom] [has_image g.hom] (sq : f ⟶ g)
 
 /-- An image map is a morphism `image f → image g` fitting into a commutative square and satisfying
     the obvious commutativity conditions. -/
-class has_image_map :=
+class has_image_map {f g : arrow C} [has_image f.hom] [has_image g.hom] (sq : f ⟶ g) :=
 (map : image f.hom ⟶ image g.hom)
 (factor_map' : factor_thru_image f.hom ≫ map = sq.left ≫ factor_thru_image g.hom . obviously)
 (map_ι' : map ≫ image.ι g.hom = image.ι f.hom ≫ sq.right . obviously)
@@ -300,6 +299,8 @@ class has_image_map :=
 restate_axiom has_image_map.factor_map'
 restate_axiom has_image_map.map_ι'
 attribute [simp, reassoc] has_image_map.factor_map has_image_map.map_ι
+
+variables {f g : arrow C} [has_image f.hom] [has_image g.hom] (sq : f ⟶ g)
 
 section
 local attribute [ext] has_image_map

--- a/src/category_theory/limits/shapes/images.lean
+++ b/src/category_theory/limits/shapes/images.lean
@@ -235,8 +235,8 @@ image.lift.{v}
 
 instance (h : f = f') : is_iso (image.eq_to_hom h) :=
 { inv := image.eq_to_hom h.symm,
-  hom_inv_id' := begin apply (cancel_mono (image.ι f)).1, dsimp [image.eq_to_hom], simp, end,
-  inv_hom_id' := begin apply (cancel_mono (image.ι f')).1, dsimp [image.eq_to_hom], simp, end, }
+  hom_inv_id' := begin apply (cancel_mono (image.ι f)).1, simp [image.eq_to_hom], end,
+  inv_hom_id' := begin apply (cancel_mono (image.ι f')).1, simp [image.eq_to_hom], end, }
 
 /-- An equation between morphisms gives an isomorphism between the images. -/
 def image.eq_to_iso (h : f = f') : image f ≅ image f' := as_iso (image.eq_to_hom h)
@@ -347,9 +347,7 @@ variables (f)
 /-- The identity `image f ⟶ image f` fits into the commutative square represented by the identity
     morphism `𝟙 f` in the arrow category. -/
 def has_image_map_id : has_image_map (𝟙 f) :=
-{ map := 𝟙 (image f.hom),
-  factor_map' := by erw [arrow.id_left, category.id_comp, category.comp_id],
-  map_ι' := by erw [arrow.id_right, category.id_comp, category.comp_id] }
+{ map := 𝟙 (image f.hom) }
 
 @[simp]
 lemma image.map_id [has_image_map (𝟙 f)] : image.map (𝟙 f) = 𝟙 (image f.hom) :=


### PR DESCRIPTION
This is the first in a series of most likely three PRs about the cohomology functor. In this PR, I
* add documentation for `comma.lean`,
* introduce the arrow category as a special case of the comma construction, and
* introduce the notion of functorial images, which means that commutative squares induce morphisms on images making the obvious diagram commute.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)
