### PR TITLE
[Merged by Bors] - fix(.github/workflows/add_label): add missing outputs

### DIFF
--- a/.github/workflows/add_label.yml
+++ b/.github/workflows/add_label.yml
@@ -30,7 +30,7 @@ jobs:
 
       # we skip the rest if this PR is from a fork,
       # since the GITHUB_TOKEN doesn't have write perms
-      - if: steps.parse_pr_head.head_user == 'leanprover-community'
+      - if: steps.parse_pr_head.outputs.head_user == 'leanprover-community'
         uses: octokit/request-action@v2.x
         name: Get comment author
         id: get_user
@@ -42,7 +42,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Parse steps.get_user.outputs.data, since it is a string
-      - if: steps.parse_pr_head.head_user == 'leanprover-community'
+      - if: steps.parse_pr_head.outputs.head_user == 'leanprover-community'
         id: parse_user
         name: Parse comment author permission
         uses: gr2m/get-json-paths-action@v1.x
@@ -50,7 +50,7 @@ jobs:
           json: ${{ steps.get_user.outputs.data }}
           permission: 'permission'
 
-      - if: (steps.parse_pr_head.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
+      - if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
         uses: octokit/request-action@v2.x
         id: add_label
         name: Add label


### PR DESCRIPTION
I hope this fixes the `add_label` workflow.

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as
that text will become the commit message. You are also encouraged to append the following
[co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors)
if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our
[notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md)
for information on our merging workflow.
