### PR TITLE
[Merged by Bors] - chore(algebra/category): remove some [reducible] after Lean 3.8

### DIFF
--- a/src/algebra/category/CommRing/basic.lean
+++ b/src/algebra/category/CommRing/basic.lean
@@ -148,7 +148,7 @@ end CommRing
 
 -- This example verifies an improvement possible in Lean 3.8.
 -- Before that, to have `add_ring_hom.map_zero` usable by `simp` here,
--- we have to mark all the concrete category `has_coe_to_sort` instances reducible.
+-- we had to mark all the concrete category `has_coe_to_sort` instances reducible.
 -- Now, it just works.
 example {R S : CommRing} (i : R ⟶ S) (r : R) (h : r = 0) : i r = 0 :=
 by simp [h]

--- a/src/algebra/category/CommRing/basic.lean
+++ b/src/algebra/category/CommRing/basic.lean
@@ -22,8 +22,7 @@ along with the relevant forgetful functors between them.
 
 ## Implementation notes
 
-See the note [locally reducible category instances] and
-the note [reducible has_coe_to_sort instances for bundled categories].
+See the note [locally reducible category instances].
 
 -/
 
@@ -43,11 +42,6 @@ instance : inhabited SemiRing := ⟨of punit⟩
 
 local attribute [reducible] SemiRing
 
-/--
-`has_coe_to_sort` instances for bundled categories must be `[reducible]`,
-see note [reducible has_coe_to_sort instances for bundled categories].
--/
-@[reducible]
 instance : has_coe_to_sort SemiRing := infer_instance -- short-circuit type class inference
 
 instance (R : SemiRing) : semiring R := R.str
@@ -80,11 +74,6 @@ instance : inhabited Ring := ⟨of punit⟩
 
 local attribute [reducible] Ring
 
-/--
-`has_coe_to_sort` instances for bundled categories must be `[reducible]`,
-see note [reducible has_coe_to_sort instances for bundled categories].
--/
-@[reducible]
 instance : has_coe_to_sort Ring := by apply_instance -- short-circuit type class inference
 
 instance (R : Ring) : ring R := R.str
@@ -113,11 +102,6 @@ instance : inhabited CommSemiRing := ⟨of punit⟩
 
 local attribute [reducible] CommSemiRing
 
-/--
-`has_coe_to_sort` instances for bundled categories must be `[reducible]`,
-see note [reducible has_coe_to_sort instances for bundled categories].
--/
-@[reducible]
 instance : has_coe_to_sort CommSemiRing := infer_instance -- short-circuit type class inference
 
 instance (R : CommSemiRing) : comm_semiring R := R.str
@@ -147,11 +131,6 @@ instance : inhabited CommRing := ⟨of punit⟩
 
 local attribute [reducible] CommRing
 
-/--
-`has_coe_to_sort` instances for bundled categories must be `[reducible]`,
-see note [reducible has_coe_to_sort instances for bundled categories].
--/
-@[reducible]
 instance : has_coe_to_sort CommRing := infer_instance -- short-circuit type class inference
 
 instance (R : CommRing) : comm_ring R := R.str
@@ -167,12 +146,10 @@ has_forget₂.mk' (λ R : CommRing, CommSemiRing.of R) (λ R, rfl) (λ R₁ R₂
 
 end CommRing
 
-/--
-We verify that `has_coe_to_sort` instances for bundled categories have been correctly marked `reducible`,
-so that `simp` lemmas for morphisms work.
-
-See note [reducible has_coe_to_sort instances for bundled categories].
--/
+-- This example verifies an improvement possible in Lean 3.8.
+-- Before that, to have `add_ring_hom.map_zero` usable by `simp` here,
+-- we have to mark all the concrete category `has_coe_to_sort` instances reducible.
+-- Now, it just works.
 example {R S : CommRing} (i : R ⟶ S) (r : R) (h : r = 0) : i r = 0 :=
 by simp [h]
 

--- a/src/algebra/category/Group/basic.lean
+++ b/src/algebra/category/Group/basic.lean
@@ -21,8 +21,7 @@ along with the relevant forgetful functors between them, and to the bundled mono
 
 ## Implementation notes
 
-See the note [locally reducible category instances]
-and the note [reducible has_coe_to_sort instances for bundled categories].
+See the note [locally reducible category instances].
 -/
 
 universes u v
@@ -40,11 +39,7 @@ namespace Group
 
 local attribute [reducible] Group
 
-/--
-`has_coe_to_sort` instances for bundled categories must be `[reducible]`,
-see note [reducible has_coe_to_sort instances for bundled categories].
--/
-@[reducible, to_additive]
+@[to_additive]
 instance : has_coe_to_sort Group := infer_instance -- short-circuit type class inference
 
 @[to_additive add_group]
@@ -96,11 +91,7 @@ namespace CommGroup
 
 local attribute [reducible] CommGroup
 
-/--
-`has_coe_to_sort` instances for bundled categories must be `[reducible]`,
-see note [reducible has_coe_to_sort instances for bundled categories].
--/
-@[reducible, to_additive]
+@[to_additive]
 instance : has_coe_to_sort CommGroup := infer_instance -- short-circuit type class inference
 
 @[to_additive add_comm_group_instance]
@@ -137,12 +128,10 @@ induced_category.has_forget₂ (λ G : CommGroup, CommMon.of G)
 
 end CommGroup
 
-/--
-We verify that `has_coe_to_sort` instances for bundled categories have been correctly marked `reducible`,
-so that `simp` lemmas for morphisms work.
-
-See note [reducible has_coe_to_sort instances for bundled categories].
--/
+-- This example verifies an improvement possible in Lean 3.8.
+-- Before that, to have `monoid_hom.map_map` usable by `simp` here,
+-- we have to mark all the concrete category `has_coe_to_sort` instances reducible.
+-- Now, it just works.
 @[to_additive]
 example {R S : CommGroup} (i : R ⟶ S) (r : R) (h : r = 1) : i r = 1 :=
 by simp [h]

--- a/src/algebra/category/Group/basic.lean
+++ b/src/algebra/category/Group/basic.lean
@@ -130,7 +130,7 @@ end CommGroup
 
 -- This example verifies an improvement possible in Lean 3.8.
 -- Before that, to have `monoid_hom.map_map` usable by `simp` here,
--- we have to mark all the concrete category `has_coe_to_sort` instances reducible.
+-- we had to mark all the concrete category `has_coe_to_sort` instances reducible.
 -- Now, it just works.
 @[to_additive]
 example {R S : CommGroup} (i : R ⟶ S) (r : R) (h : r = 1) : i r = 1 :=

--- a/src/algebra/category/Mon/basic.lean
+++ b/src/algebra/category/Mon/basic.lean
@@ -21,8 +21,7 @@ along with the relevant forgetful functors between them.
 
 ## Implementation notes
 
-See the note [locally reducible category instances]
-and the note [reducible has_coe_to_sort instances for bundled categories].
+See the note [locally reducible category instances].
 -/
 
 /--
@@ -45,9 +44,6 @@ we always access `R.α` through the coercion rather than directly).
 TODO: Probably @[derive] should be able to create instances of the
 required form (without `id`), and then we could use that instead of
 this obscure `local attribute [reducible]` method.
-
-See also note [reducible has_coe_to_sort instances for bundled categories],
-explaining why the `has_coe_to_sort` instances themselves must be `[reducible]`.
 -/
 library_note "locally reducible category instances"
 
@@ -73,11 +69,7 @@ instance : inhabited Mon :=
 
 local attribute [reducible] Mon
 
-/--
-`has_coe_to_sort` instances for bundled categories must be `[reducible]`,
-see note [reducible has_coe_to_sort instances for bundled categories].
--/
-@[reducible, to_additive]
+@[to_additive]
 instance : has_coe_to_sort Mon := infer_instance -- short-circuit type class inference
 
 @[to_additive add_monoid]
@@ -113,11 +105,7 @@ instance : inhabited CommMon :=
 
 local attribute [reducible] CommMon
 
-/--
-`has_coe_to_sort` instances for bundled categories must be `[reducible]`,
-see note [reducible has_coe_to_sort instances for bundled categories].
--/
-@[reducible, to_additive]
+@[to_additive]
 instance : has_coe_to_sort CommMon := infer_instance -- short-circuit type class inference
 
 @[to_additive add_comm_monoid]

--- a/src/category_theory/concrete_category/bundled.lean
+++ b/src/category_theory/concrete_category/bundled.lean
@@ -32,21 +32,6 @@ namespace bundled
 -- Usually explicit instances will provide their own version of this, e.g. `Mon.of` and `Top.of`.
 def of {c : Type u → Type v} (α : Type u) [str : c α] : bundled c := ⟨α, str⟩
 
-/--
-In order for simp lemmas for bundled morphisms to apply correctly,
-it seems to be necessary for all the `has_coe_to_sort` instances for bundled categories
-to be marked `[reducible]`.
-
-Examples verifying correct behaviour are also marked with this
-note [reducible has_coe_to_sort instances for bundled categories].
--/
-library_note "reducible has_coe_to_sort instances for bundled categories"
-
-/--
-has_coe_to_sort instances for bundled categories must be reducible,
-see note [reducible has_coe_to_sort instances for bundled categories].
--/
-@[reducible]
 instance : has_coe_to_sort (bundled c) :=
 { S := Type u, coe := bundled.α }
 

--- a/src/category_theory/full_subcategory.lean
+++ b/src/category_theory/full_subcategory.lean
@@ -47,11 +47,6 @@ def induced_category : Type u₁ := C
 
 variables {D}
 
-/--
-has_coe_to_sort instances for bundled categories must be reducible,
-see note [reducible has_coe_to_sort instances for bundled categories].
--/
-@[reducible]
 instance induced_category.has_coe_to_sort [has_coe_to_sort D] :
   has_coe_to_sort (induced_category D F) :=
 ⟨_, λ c, ↥(F c)⟩


### PR DESCRIPTION
Now that Lean 3.8 has arrived, we can essentially revert #2290, but leave in the examples verifying that everything still works.

Lovely!