### PR TITLE
[Merged by Bors] - chore(*): futureproof import syntax

### DIFF
--- a/src/analysis/analytic/basic.lean
+++ b/src/analysis/analytic/basic.lean
@@ -5,7 +5,7 @@ Authors: Sébastien Gouëzel
 -/
 
 import analysis.calculus.times_cont_diff tactic.omega analysis.complex.exponential
-analysis.specific_limits
+  analysis.specific_limits
 
 /-!
 # Analytic functions

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -5,7 +5,7 @@ Author: Sébastien Gouëzel
 -/
 
 import topology.metric_space.closeds set_theory.cardinal topology.metric_space.gromov_hausdorff_realized
-topology.metric_space.completion
+  topology.metric_space.completion
 
 /-!
 # Gromov-Hausdorff distance

--- a/src/topology/metric_space/gromov_hausdorff_realized.lean
+++ b/src/topology/metric_space/gromov_hausdorff_realized.lean
@@ -8,7 +8,7 @@ their Hausdorff distance. This construction is instrumental to study the Gromov-
 distance between nonempty compact metric spaces -/
 
 import topology.bounded_continuous_function topology.metric_space.gluing
-topology.metric_space.hausdorff_distance
+  topology.metric_space.hausdorff_distance
 
 noncomputable theory
 open_locale classical

--- a/src/topology/metric_space/isometry.lean
+++ b/src/topology/metric_space/isometry.lean
@@ -6,7 +6,7 @@ Authors: Sébastien Gouëzel
 -/
 
 import topology.metric_space.basic
-topology.bounded_continuous_function analysis.normed_space.basic topology.opens
+  topology.bounded_continuous_function analysis.normed_space.basic topology.opens
 
 /-!
 # Isometries


### PR DESCRIPTION
The next community version of Lean will treat a line starting in the first column
after an import as a new command, not a continuation of the import.



TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
