### PR TITLE
[Merged by Bors] - feat(algebra/lie_algebra): define equivalences, direct sums of Lie algebras

### DIFF
--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -214,13 +214,13 @@ def morphism.inverse (f : L₁ →ₗ⁅R⁆ L₂) (g : L₂ → L₁)
   calc g ⁅x, y⁆ = g ⁅f (g x), f (g y)⁆ : by { conv_lhs { rw [←h₂ x, ←h₂ y], }, }
             ... = g (f ⁅g x, g y⁆) : by rw map_lie
             ... = ⁅g x, g y⁆ : (h₁ _), },
-  ..(linear_map.inverse f.to_linear_map g h₁ h₂) }
+  ..linear_map.inverse f.to_linear_map g h₁ h₂ }
 
 end morphism_properties
 
 /-- An equivalence of Lie algebras is a morphism which is also a linear equivalence. We could
-instead define an equivalence to morphism which is also a (plain) equivalence. However it is more
-convenient to define via linear equivalence to get `.to_linear_equiv` for free. -/
+instead define an equivalence to be a morphism which is also a (plain) equivalence. However it is
+more convenient to define via linear equivalence to get `.to_linear_equiv` for free. -/
 @[nolint doc_blame has_inhabited_instance]
 structure equiv (R : Type u) (L : Type v) (L' : Type w)
   [comm_ring R] [lie_ring L] [lie_algebra R L] [lie_ring L'] [lie_algebra R L']

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -36,7 +36,7 @@ unbundled. Since they extend Lie rings, these are also partially unbundled.
 lie bracket, ring commutator, jacobi identity, lie ring, lie algebra
 -/
 
-universes u v
+universes u v w w₁
 
 /--
 A binary operation, intended use in Lie algebras and similar structures.
@@ -175,10 +175,10 @@ end prio
 
 namespace lie_algebra
 
-/--
-A morphism of Lie algebras is a linear map respecting the bracket operations.
--/
-structure morphism (R : Type u) (L : Type v) (L' : Type v)
+set_option old_structure_cmd true
+/-- A morphism of Lie algebras is a linear map respecting the bracket operations. -/
+@[nolint doc_blame has_inhabited_instance]
+structure morphism (R : Type u) (L : Type v) (L' : Type w)
   [comm_ring R] [lie_ring L] [lie_algebra R L] [lie_ring L'] [lie_algebra R L']
   extends linear_map R L L' :=
 (map_lie : ∀ {x y : L}, to_fun ⁅x, y⁆ = ⁅to_fun x, to_fun y⁆)
@@ -186,17 +186,98 @@ structure morphism (R : Type u) (L : Type v) (L' : Type v)
 infixr ` →ₗ⁅⁆ `:25 := morphism _
 notation L ` →ₗ⁅`:25 R:25 `⁆ `:0 L':0 := morphism R L L'
 
-instance (R : Type u) (L : Type v) (L' : Type v)
-    [comm_ring R] [lie_ring L] [lie_algebra R L] [lie_ring L'] [lie_algebra R L'] :
-  has_coe (L →ₗ⁅R⁆ L') (L →ₗ[R] L') := ⟨morphism.to_linear_map⟩
+section morphism_properties
 
-lemma map_lie {R : Type u} {L : Type v} {L' : Type v}
-    [comm_ring R] [lie_ring L] [lie_algebra R L] [lie_ring L'] [lie_algebra R L']
-  (f : L →ₗ⁅R⁆ L') (x y : L) : f ⁅x, y⁆ = ⁅f x, f y⁆ := morphism.map_lie f
+variables {R : Type u} {L₁ : Type v} {L₂ : Type w} {L₃ : Type w₁}
+variables [comm_ring R] [lie_ring L₁] [lie_ring L₂] [lie_ring L₃]
+variables [lie_algebra R L₁] [lie_algebra R L₂] [lie_algebra R L₃]
 
-@[simp] lemma map_lie' {R : Type u} {L : Type v} {L' : Type v}
-    [comm_ring R] [lie_ring L] [lie_algebra R L] [lie_ring L'] [lie_algebra R L']
-  (f : L →ₗ⁅R⁆ L') (x y : L) : (f : L →ₗ[R] L') ⁅x, y⁆ = ⁅f x, f y⁆ := morphism.map_lie f
+instance : has_coe (L₁ →ₗ⁅R⁆ L₂) (L₁ →ₗ[R] L₂) := ⟨morphism.to_linear_map⟩
+
+lemma map_lie (f : L₁ →ₗ⁅R⁆ L₂) (x y : L₁) : f ⁅x, y⁆ = ⁅f x, f y⁆ := morphism.map_lie f
+
+@[simp] lemma map_lie' (f : L₁ →ₗ⁅R⁆ L₂) (x y : L₁) : (f : L₁ →ₗ[R] L₂) ⁅x, y⁆ = ⁅f x, f y⁆ :=
+morphism.map_lie f
+
+/-- The composition of morphisms is a morphism. -/
+def morphism.comp (f : L₂ →ₗ⁅R⁆ L₃) (g : L₁ →ₗ⁅R⁆ L₂) : L₁ →ₗ⁅R⁆ L₃ :=
+{ map_lie := λ x y, by { change f (g ⁅x, y⁆) = ⁅f (g x), f (g y)⁆, rw [map_lie, map_lie], },
+  ..linear_map.comp f.to_linear_map g.to_linear_map }
+
+lemma morphism.comp_apply (f : L₂ →ₗ⁅R⁆ L₃) (g : L₁ →ₗ⁅R⁆ L₂) (x : L₁) :
+  f.comp g x = f (g x) := rfl
+
+/-- The inverse of a bijective morphism is a morphism. -/
+def morphism.inverse (f : L₁ →ₗ⁅R⁆ L₂) (g : L₂ → L₁)
+  (h₁ : function.left_inverse g f) (h₂ : function.right_inverse g f) : L₂ →ₗ⁅R⁆ L₁ :=
+{ map_lie := λ x y, by {
+  calc g ⁅x, y⁆ = g ⁅f (g x), f (g y)⁆ : by { conv_lhs { rw [←h₂ x, ←h₂ y], }, }
+            ... = g (f ⁅g x, g y⁆) : by rw map_lie
+            ... = ⁅g x, g y⁆ : (h₁ _), },
+  ..(linear_map.inverse f.to_linear_map g h₁ h₂) }
+
+end morphism_properties
+
+/-- An equivalence of Lie algebras is a morphism which is also a linear equivalence. We could
+instead define an equivalence to morphism which is also a (plain) equivalence. However it is more
+convenient to define via linear equivalence to get `.to_linear_equiv` for free. -/
+@[nolint doc_blame has_inhabited_instance]
+structure equiv (R : Type u) (L : Type v) (L' : Type w)
+  [comm_ring R] [lie_ring L] [lie_algebra R L] [lie_ring L'] [lie_algebra R L']
+  extends L →ₗ⁅R⁆ L', L ≃ₗ[R] L'
+
+notation L ` ≃ₗ⁅`:50 R `⁆ ` L' := equiv R L L'
+
+namespace equiv
+
+variables {R : Type u} {L₁ : Type v} {L₂ : Type w} {L₃ : Type w₁}
+variables [comm_ring R] [lie_ring L₁] [lie_ring L₂] [lie_ring L₃]
+variables [lie_algebra R L₁] [lie_algebra R L₂] [lie_algebra R L₃]
+
+/-- Lie algebra equivalences are reflexive. -/
+@[refl]
+def refl : L₁ ≃ₗ⁅R⁆ L₁ :=
+{ map_lie := λ x y, rfl, ..linear_equiv.refl _ _ }
+
+/-- Lie algebra equivalences are symmetric. -/
+@[symm]
+def symm (e : L₁ ≃ₗ⁅R⁆ L₂) : L₂ ≃ₗ⁅R⁆ L₁ :=
+{ ..morphism.inverse e.to_morphism e.inv_fun e.left_inv e.right_inv,
+  ..e.to_linear_equiv.symm }
+
+/-- Lie algebra equivalences are transitive. -/
+@[trans]
+def trans (e₁ : L₁ ≃ₗ⁅R⁆ L₂) (e₂ : L₂ ≃ₗ⁅R⁆ L₃) : L₁ ≃ₗ⁅R⁆ L₃ :=
+{ ..morphism.comp e₂.to_morphism e₁.to_morphism,
+  ..linear_equiv.trans e₁.to_linear_equiv e₂.to_linear_equiv }
+
+end equiv
+
+namespace direct_sum
+open dfinsupp
+
+variables {R : Type u} [comm_ring R]
+variables {ι : Type v} [decidable_eq ι] {L : ι → Type w}
+variables [Π i, lie_ring (L i)] [Π i, lie_algebra R (L i)]
+
+/-- The direct sum of Lie rings carries a natural Lie ring structure. -/
+instance : lie_ring (direct_sum ι L) := {
+  bracket  := zip_with (λ i, λ x y, ⁅x, y⁆) (λ i, lie_zero 0),
+  add_lie  := λ x y z, by { ext, simp only [zip_with_apply, add_apply, add_lie], },
+  lie_add  := λ x y z, by { ext, simp only [zip_with_apply, add_apply, lie_add], },
+  lie_self := λ x, by { ext, simp only [zip_with_apply, add_apply, lie_self, zero_apply], },
+  jacobi   := λ x y z, by { ext, simp only [zip_with_apply, add_apply, lie_ring.jacobi, zero_apply], },
+  ..(infer_instance : add_comm_group _) }
+
+@[simp] lemma bracket_apply {x y : direct_sum ι L} {i : ι} :
+  ⁅x, y⁆ i = ⁅x i, y i⁆ := zip_with_apply
+
+/-- The direct sum of Lie algebras carries a natural Lie algebra structure. -/
+instance : lie_algebra R (direct_sum ι L) :=
+{ lie_smul := λ c x y, by { ext, simp only [zip_with_apply, smul_apply, bracket_apply, lie_smul], },
+  ..(infer_instance : module R _) }
+
+end direct_sum
 
 variables {R : Type u} {L : Type v} [comm_ring R] [lie_ring L] [lie_algebra R L]
 

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -177,7 +177,6 @@ namespace lie_algebra
 
 set_option old_structure_cmd true
 /-- A morphism of Lie algebras is a linear map respecting the bracket operations. -/
-@[nolint doc_blame has_inhabited_instance]
 structure morphism (R : Type u) (L : Type v) (L' : Type w)
   [comm_ring R] [lie_ring L] [lie_algebra R L] [lie_ring L'] [lie_algebra R L']
   extends linear_map R L L' :=
@@ -198,6 +197,14 @@ lemma map_lie (f : L₁ →ₗ⁅R⁆ L₂) (x y : L₁) : f ⁅x, y⁆ = ⁅f x
 
 @[simp] lemma map_lie' (f : L₁ →ₗ⁅R⁆ L₂) (x y : L₁) : (f : L₁ →ₗ[R] L₂) ⁅x, y⁆ = ⁅f x, f y⁆ :=
 morphism.map_lie f
+
+/-- The constant 0 map is a Lie algebra morphism. -/
+instance : has_zero (L₁ →ₗ⁅R⁆ L₂) := ⟨{ map_lie := by simp, ..(0 : L₁ →ₗ[R] L₂)}⟩
+
+/-- The identity map is a Lie algebra morphism. -/
+instance : has_one (L₁ →ₗ⁅R⁆ L₁) := ⟨{ map_lie := by simp, ..(1 : L₁ →ₗ[R] L₁)}⟩
+
+instance : inhabited (L₁ →ₗ⁅R⁆ L₂) := ⟨0⟩
 
 /-- The composition of morphisms is a morphism. -/
 def morphism.comp (f : L₂ →ₗ⁅R⁆ L₃) (g : L₁ →ₗ⁅R⁆ L₂) : L₁ →ₗ⁅R⁆ L₃ :=
@@ -221,7 +228,6 @@ end morphism_properties
 /-- An equivalence of Lie algebras is a morphism which is also a linear equivalence. We could
 instead define an equivalence to be a morphism which is also a (plain) equivalence. However it is
 more convenient to define via linear equivalence to get `.to_linear_equiv` for free. -/
-@[nolint doc_blame has_inhabited_instance]
 structure equiv (R : Type u) (L : Type v) (L' : Type w)
   [comm_ring R] [lie_ring L] [lie_algebra R L] [lie_ring L'] [lie_algebra R L']
   extends L →ₗ⁅R⁆ L', L ≃ₗ[R] L'
@@ -234,10 +240,15 @@ variables {R : Type u} {L₁ : Type v} {L₂ : Type w} {L₃ : Type w₁}
 variables [comm_ring R] [lie_ring L₁] [lie_ring L₂] [lie_ring L₃]
 variables [lie_algebra R L₁] [lie_algebra R L₂] [lie_algebra R L₃]
 
+instance : has_one (L₁ ≃ₗ⁅R⁆ L₁) :=
+⟨{ map_lie := λ x y, by { change ((1 : L₁→ₗ[R] L₁) ⁅x, y⁆) = ⁅(1 : L₁→ₗ[R] L₁) x, (1 : L₁→ₗ[R] L₁) y⁆, simp, },
+  ..(1 : L₁ ≃ₗ[R] L₁)}⟩
+
+instance : inhabited (L₁ ≃ₗ⁅R⁆ L₁) := ⟨1⟩
+
 /-- Lie algebra equivalences are reflexive. -/
 @[refl]
-def refl : L₁ ≃ₗ⁅R⁆ L₁ :=
-{ map_lie := λ x y, rfl, ..linear_equiv.refl _ _ }
+def refl : L₁ ≃ₗ⁅R⁆ L₁ := 1
 
 /-- Lie algebra equivalences are symmetric. -/
 @[symm]

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -182,6 +182,8 @@ structure morphism (R : Type u) (L : Type v) (L' : Type w)
   extends linear_map R L L' :=
 (map_lie : ∀ {x y : L}, to_fun ⁅x, y⁆ = ⁅to_fun x, to_fun y⁆)
 
+attribute [nolint doc_blame] lie_algebra.morphism.to_linear_map
+
 infixr ` →ₗ⁅⁆ `:25 := morphism _
 notation L ` →ₗ⁅`:25 R:25 `⁆ `:0 L':0 := morphism R L L'
 
@@ -231,6 +233,9 @@ more convenient to define via linear equivalence to get `.to_linear_equiv` for f
 structure equiv (R : Type u) (L : Type v) (L' : Type w)
   [comm_ring R] [lie_ring L] [lie_algebra R L] [lie_ring L'] [lie_algebra R L']
   extends L →ₗ⁅R⁆ L', L ≃ₗ[R] L'
+
+attribute [nolint doc_blame] lie_algebra.equiv.to_morphism
+attribute [nolint doc_blame] lie_algebra.equiv.to_linear_equiv
 
 notation L ` ≃ₗ⁅`:50 R `⁆ ` L' := equiv R L L'
 


### PR DESCRIPTION
This pull request does two things:

1. Defines equivalences of Lie algebras (and proves that these do indeed form an equivalence relation)
2. Defines direct sums of Lie algebras

The intention is to knock another chip off https://github.com/leanprover-community/mathlib/issues/1093

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

There was a brief related discussion here:
https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/linter.20doc_blame.20with.20old_structure_cmd

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
