### PR TITLE
[Merged by Bors] - chore(category_theory/limits): remove dependency on concrete_categories

### DIFF
--- a/src/algebra/category/CommRing/colimits.lean
+++ b/src/algebra/category/CommRing/colimits.lean
@@ -5,6 +5,7 @@ Authors: Scott Morrison
 -/
 import algebra.category.CommRing.basic
 import category_theory.limits.limits
+import category_theory.limits.concrete_category
 
 /-!
 # The category of commutative rings has all colimits.

--- a/src/algebra/category/Group/colimits.lean
+++ b/src/algebra/category/Group/colimits.lean
@@ -5,6 +5,7 @@ Authors: Scott Morrison
 -/
 import algebra.category.Group.basic
 import category_theory.limits.limits
+import category_theory.limits.concrete_category
 
 /-!
 # The category of additive commutative groups has all colimits.

--- a/src/algebra/category/Mon/colimits.lean
+++ b/src/algebra/category/Mon/colimits.lean
@@ -5,6 +5,7 @@ Authors: Scott Morrison
 -/
 import algebra.category.Mon.basic
 import category_theory.limits.limits
+import category_theory.limits.concrete_category
 
 /-!
 # The category of monoids has all colimits.

--- a/src/category_theory/differential_object.lean
+++ b/src/category_theory/differential_object.lean
@@ -5,6 +5,7 @@ Authors: Scott Morrison
 -/
 import category_theory.limits.shapes.zero
 import category_theory.shift
+import category_theory.concrete_category
 
 /-!
 # Differential objects in a category.

--- a/src/category_theory/graded_object.lean
+++ b/src/category_theory/graded_object.lean
@@ -5,6 +5,7 @@ Authors: Scott Morrison
 -/
 import category_theory.shift
 import category_theory.limits.shapes.zero
+import category_theory.concrete_category
 
 /-!
 # The category of graded objects

--- a/src/category_theory/limits/concrete_category.lean
+++ b/src/category_theory/limits/concrete_category.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2017 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import category_theory.limits.cones
+import category_theory.concrete_category.bundled_hom
+
+/-!
+# Facts about limits of functors into concrete categories
+-/
+
+universes u
+
+open category_theory
+
+namespace category_theory.limits
+
+-- We now prove a lemma about naturality of cones over functors into bundled categories.
+namespace cone
+
+variables {J : Type u} [small_category J]
+variables {C : Type (u+1)} [large_category C] [𝒞 : concrete_category C]
+include 𝒞
+
+local attribute [instance] concrete_category.has_coe_to_sort
+local attribute [instance] concrete_category.has_coe_to_fun
+
+/-- Naturality of a cone over functors to a concrete category. -/
+@[simp] lemma naturality_concrete {G : J ⥤ C} (s : cone G) {j j' : J} (f : j ⟶ j') (x : s.X) :
+   (G.map f) ((s.π.app j) x) = (s.π.app j') x :=
+begin
+  convert congr_fun (congr_arg (λ k : s.X ⟶ G.obj j', (k : s.X → G.obj j')) (s.π.naturality f).symm) x;
+  { dsimp, simp },
+end
+
+end cone
+
+namespace cocone
+
+variables {J : Type u} [small_category J]
+variables {C : Type (u+1)} [large_category C] [𝒞 : concrete_category C]
+include 𝒞
+
+local attribute [instance] concrete_category.has_coe_to_sort
+local attribute [instance] concrete_category.has_coe_to_fun
+
+/-- Naturality of a cocone over functors into a concrete category. -/
+@[simp] lemma naturality_concrete {G : J ⥤ C} (s : cocone G) {j j' : J} (f : j ⟶ j') (x : G.obj j) :
+  (s.ι.app j') ((G.map f) x) = (s.ι.app j) x :=
+begin
+  convert congr_fun (congr_arg (λ k : G.obj j ⟶ s.X, (k : G.obj j → s.X)) (s.ι.naturality f)) x;
+  { dsimp, simp },
+end
+
+end cocone
+
+end category_theory.limits

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -5,7 +5,6 @@ Authors: Stephen Morgan, Scott Morrison, Floris van Doorn
 -/
 import category_theory.const
 import category_theory.yoneda
-import category_theory.concrete_category.bundled_hom
 import category_theory.equivalence
 
 universes v u u' -- declare the `v`'s first; see `category_theory.category` for an explanation
@@ -137,27 +136,6 @@ rfl
 { X := c.X,
   π := whisker_left E c.π }
 
--- We now prove a lemma about naturality of cones over functors into bundled categories.
-section
-
-omit 𝒞
-variables {J' : Type u} [small_category J']
-variables {C' : Type (u+1)} [large_category C'] [𝒞' : concrete_category C']
-include 𝒞'
-
-local attribute [instance] concrete_category.has_coe_to_sort
-local attribute [instance] concrete_category.has_coe_to_fun
-
-/-- Naturality of a cone over functors to a concrete category. -/
-@[simp] lemma naturality_concrete {G : J' ⥤ C'} (s : cone G) {j j' : J'} (f : j ⟶ j') (x : s.X) :
-   (G.map f) ((s.π.app j) x) = (s.π.app j') x :=
-begin
-  convert congr_fun (congr_arg (λ k : s.X ⟶ G.obj j', (k : s.X → G.obj j')) (s.π.naturality f).symm) x;
-  { dsimp, simp },
-end
-
-end
-
 end cone
 
 namespace cocone
@@ -183,26 +161,6 @@ rfl
 @[simps] def whisker {K : Type v} [small_category K] (E : K ⥤ J) (c : cocone F) : cocone (E ⋙ F) :=
 { X := c.X,
   ι := whisker_left E c.ι }
-
--- We now prove a lemma about naturality of cocones over functors into bundled categories.
-section
-omit 𝒞
-variables {J' : Type u} [small_category J']
-variables {C' : Type (u+1)} [large_category C'] [𝒞' : concrete_category C']
-include 𝒞'
-
-local attribute [instance] concrete_category.has_coe_to_sort
-local attribute [instance] concrete_category.has_coe_to_fun
-
-/-- Naturality of a cocone over functors into a concrete category. -/
-@[simp] lemma naturality_concrete {G : J' ⥤ C'} (s : cocone G) {j j' : J'} (f : j ⟶ j') (x : G.obj j) :
-  (s.ι.app j') ((G.map f) x) = (s.ι.app j) x :=
-begin
-  convert congr_fun (congr_arg (λ k : G.obj j ⟶ s.X, (k : G.obj j → s.X)) (s.ι.naturality f)) x;
-  { dsimp, simp },
-end
-
-end
 
 end cocone
 


### PR DESCRIPTION
Just move some content around, so that `category_theory/limits/cones.lean` doesn't need to depend on the development of `concrete_category`.