### PR TITLE
feat(data/monoid_algebra): k →+* monoid_algebra k G

### DIFF
--- a/src/data/finsupp.lean
+++ b/src/data/finsupp.lean
@@ -1345,6 +1345,47 @@ instance [semiring γ] [add_comm_monoid β] [semimodule γ β] : semimodule γ (
 instance [ring γ] [add_comm_group β] [module γ β] : module γ (α →₀ β) :=
 { ..finsupp.semimodule α β }
 
+section
+variables {α β}
+
+/--
+`finsupp.single.add_monoid_hom a` is the additive homomorphism `β →+ (α →₀ β)`,
+including `β` as functions supported at `a`.
+-/
+def single.add_monoid_hom [add_monoid β] (a : α) : β →+ (α →₀ β) :=
+{ to_fun := λ b, single a b,
+  map_zero' := by simp,
+  map_add' := by simp, }
+
+@[simp]
+lemma single.add_monoid_hom_apply [add_monoid β] (a : α) (b : β) :
+  (single.add_monoid_hom a : β →+ (α →₀ β)) b = single a b := rfl
+
+/--
+`finsupp.single.linear_map a` is the linear map `β →ₗ[γ] (α →₀ β)`,
+including `β` as functions supported at `a`.
+-/
+def single.linear_map [ring γ] [add_comm_group β] [module γ β] (a : α) : β →ₗ[γ] (α →₀ β) :=
+{ to_fun := λ b, single a b,
+  add := by simp,
+  smul := λ c x,
+  begin
+    ext a',
+    -- This is just gross.
+    -- * We need `h` in one branch, but `h.symm` in the other.
+    -- * We need to rewrite by `←ne.def`.
+    by_cases h : a = a',
+    { simp [h.symm], },
+    { rw ←ne.def at h, simp [h], },
+  end, }
+
+@[simp]
+lemma single.linear_map_apply [ring γ] [add_comm_group β] [module γ β] (a : α) (b : β) :
+  (single.linear_map a : β →ₗ[γ] (α →₀ β)) b = single a b := rfl
+
+end
+
+
 instance [field γ] [add_comm_group β] [vector_space γ β] : vector_space γ (α →₀ β) :=
 { ..finsupp.module α β }
 

--- a/src/data/finsupp.lean
+++ b/src/data/finsupp.lean
@@ -1351,6 +1351,8 @@ variables {α β}
 /--
 `finsupp.single.add_monoid_hom a` is the additive homomorphism `β →+ (α →₀ β)`,
 including `β` as functions supported at `a`.
+
+See also `finsupp.lsingle` for the version as a linear map.
 -/
 def single.add_monoid_hom [add_monoid β] (a : α) : β →+ (α →₀ β) :=
 { to_fun := λ b, single a b,
@@ -1360,28 +1362,6 @@ def single.add_monoid_hom [add_monoid β] (a : α) : β →+ (α →₀ β) :=
 @[simp]
 lemma single.add_monoid_hom_apply [add_monoid β] (a : α) (b : β) :
   (single.add_monoid_hom a : β →+ (α →₀ β)) b = single a b := rfl
-
-/--
-`finsupp.single.linear_map a` is the linear map `β →ₗ[γ] (α →₀ β)`,
-including `β` as functions supported at `a`.
--/
-def single.linear_map [ring γ] [add_comm_group β] [module γ β] (a : α) : β →ₗ[γ] (α →₀ β) :=
-{ to_fun := λ b, single a b,
-  add := by simp,
-  smul := λ c x,
-  begin
-    ext a',
-    -- This is just gross.
-    -- * We need `h` in one branch, but `h.symm` in the other.
-    -- * We need to rewrite by `←ne.def`.
-    by_cases h : a = a',
-    { simp [h.symm], },
-    { rw ←ne.def at h, simp [h], },
-  end, }
-
-@[simp]
-lemma single.linear_map_apply [ring γ] [add_comm_group β] [module γ β] (a : α) (b : β) :
-  (single.linear_map a : β →ₗ[γ] (α →₀ β)) b = single a b := rfl
 
 end
 

--- a/src/data/monoid_algebra.lean
+++ b/src/data/monoid_algebra.lean
@@ -164,6 +164,54 @@ lemma single_mul_single [semiring k] [monoid G] {a₁ a₂ : G} {b₁ b₂ : k} 
 (sum_single_index (by simp only [_root_.zero_mul, single_zero, sum_zero])).trans
   (sum_single_index (by rw [_root_.mul_zero, single_zero]))
 
+/--
+The ring homomorphism `k →+* monoid_algebra k G`,
+including `k` as functions supported at `1 : G`.
+-/
+def single_one.ring_hom [semiring k] [monoid G] : k →+* monoid_algebra k G :=
+{ map_one' := rfl,
+  map_mul' := λ x y, begin convert single_mul_single.symm, simp, refl, end,
+  ..(finsupp.single.add_monoid_hom 1 ) }
+
+@[simp]
+lemma single_one.ring_hom_apply [semiring k] [monoid G] (x : k) :
+  (single_one.ring_hom : k →+* monoid_algebra k G) x = single 1 x := rfl
+
+lemma single_one.central [comm_semiring k] [monoid G] (r : k) (f : monoid_algebra k G) :
+  f * (monoid_algebra.single_one.ring_hom : k →+* monoid_algebra k G) r =
+    (monoid_algebra.single_one.ring_hom : k →+* monoid_algebra k G) r * f :=
+begin
+  ext,
+  -- It would be nice if this next step worked by `simp`.
+  dsimp [monoid_algebra.single_one.ring_hom, finsupp.single.add_monoid_hom],
+  simp only [monoid_algebra.mul_apply],
+  conv_lhs { rw [finsupp.sum_comm], },
+  rw [finsupp.sum_single_index],
+  { rw [finsupp.sum_single_index],
+    { simp only [mul_one, one_mul, finsupp.sum_ite_eq'], -- In Lean 3.8 this will hopefully handle the `sum_ite_eq'` below.
+      convert finsupp.sum_ite_eq' f a (λ x v, v * r),
+      funext, congr,
+      convert finsupp.sum_ite_eq' f a (λ x v, r * v) using 1,
+      { congr, funext, congr, },
+      { congr' 1, apply mul_comm, }, },
+    simp, },
+  { simp, }
+end.
+
+lemma module_smul_eq [semiring k] [monoid G] (r : k) (f : monoid_algebra k G) (w) :
+  finsupp.map_range (λ x, r • x) w f = (finsupp.single 1 r * f : monoid_algebra k G) :=
+begin
+  ext,
+  rw [monoid_algebra.mul_apply],
+  rw [finsupp.sum_single_index],
+  { simp only [one_mul, smul_eq_mul, finsupp.map_range_apply, finsupp.sum_ite_eq'],
+    symmetry,
+    convert finsupp.sum_ite_eq' f a (λ x v, r * v) using 1,
+    { congr, funext, congr, },
+    { simp, classical, split_ifs, simp [h], }, },
+  { simp, }
+end
+
 universe ui
 variable {ι : Type ui}
 
@@ -263,6 +311,13 @@ lemma mul_def {f g : add_monoid_algebra k G} :
   f * g = (f.sum $ λa₁ b₁, g.sum $ λa₂ b₂, single (a₁ + a₂) (b₁ * b₂)) :=
 rfl
 
+lemma mul_apply (f g : add_monoid_algebra k G) (x : G) :
+  (f * g) x = (f.sum $ λa₁ b₁, g.sum $ λa₂ b₂, if a₁ + a₂ = x then b₁ * b₂ else 0) :=
+begin
+  rw [mul_def],
+  simp only [sum_apply, single_apply],
+end
+
 lemma support_mul (a b : add_monoid_algebra k G) :
   (a * b).support ⊆ a.support.bind (λa₁, b.support.bind $ λa₂, {a₁ + a₂}) :=
 subset.trans support_sum $ bind_mono $ assume a₁ _,
@@ -342,6 +397,54 @@ lemma single_mul_single [semiring k] [add_monoid G] {a₁ a₂ : G} {b₁ b₂ :
   (single a₁ b₁ : add_monoid_algebra k G) * single a₂ b₂ = single (a₁ + a₂) (b₁ * b₂) :=
 (sum_single_index (by simp only [_root_.zero_mul, single_zero, sum_zero])).trans
   (sum_single_index (by rw [_root_.mul_zero, single_zero]))
+
+/--
+The ring homomorphism `k →+* add_monoid_algebra k G`,
+including `k` as functions supported at `0 : G`.
+-/
+def single_one.ring_hom [semiring k] [add_monoid G] : k →+* add_monoid_algebra k G :=
+{ map_one' := rfl,
+  map_mul' := λ x y, begin convert single_mul_single.symm, simp, refl, end,
+  ..(finsupp.single.add_monoid_hom 0 ) }
+
+@[simp]
+lemma single_one.ring_hom_apply [semiring k] [add_monoid G] (x : k) :
+  (single_one.ring_hom : k →+* add_monoid_algebra k G) x = single 0 x := rfl
+
+lemma single_one.central [comm_semiring k] [add_monoid G] (r : k) (f : add_monoid_algebra k G) :
+  f * (add_monoid_algebra.single_one.ring_hom : k →+* add_monoid_algebra k G) r =
+    (add_monoid_algebra.single_one.ring_hom : k →+* add_monoid_algebra k G) r * f :=
+begin
+  ext,
+  -- It would be nice if this next step worked by `simp`.
+  dsimp [add_monoid_algebra.single_one.ring_hom, finsupp.single.add_monoid_hom],
+  simp only [add_monoid_algebra.mul_apply],
+  conv_lhs { rw [finsupp.sum_comm], },
+  rw [finsupp.sum_single_index],
+  { rw [finsupp.sum_single_index],
+    { simp only [add_zero, zero_add, finsupp.sum_ite_eq'], -- In Lean 3.8 this will hopefully handle the `sum_ite_eq'` below.
+      convert finsupp.sum_ite_eq' f a (λ x v, v * r),
+      funext, congr,
+      convert finsupp.sum_ite_eq' f a (λ x v, r * v) using 1,
+      { congr, funext, congr, },
+      { congr' 1, apply mul_comm, }, },
+    simp, },
+  { simp, }
+end.
+
+lemma module_smul_eq [semiring k] [add_monoid G] (r : k) (f : add_monoid_algebra k G) (w) :
+  finsupp.map_range (λ x, r • x) w f = (finsupp.single 0 r * f : add_monoid_algebra k G) :=
+begin
+  ext,
+  rw [add_monoid_algebra.mul_apply],
+  rw [finsupp.sum_single_index],
+  { simp only [zero_add, smul_eq_mul, finsupp.map_range_apply, finsupp.sum_ite_eq'],
+    symmetry,
+    convert finsupp.sum_ite_eq' f a (λ x v, r * v) using 1,
+    { congr, funext, congr, },
+    { simp, classical, split_ifs, simp [h], }, },
+  { simp, }
+end
 
 universe ui
 variable {ι : Type ui}

--- a/src/data/monoid_algebra.lean
+++ b/src/data/monoid_algebra.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Scott Morrison
 -/
 import data.finsupp
+import ring_theory.algebra
 
 /-!
 # Monoid algebras
@@ -77,7 +78,7 @@ lemma mul_apply (f g : monoid_algebra k G) (x : G) :
   (f * g) x = (f.sum $ λa₁ b₁, g.sum $ λa₂ b₂, if a₁ * a₂ = x then b₁ * b₂ else 0) :=
 begin
   rw [mul_def],
-  simp only [sum_apply, single_apply],
+  simp only [finsupp.sum_apply, single_apply],
 end
 end
 
@@ -178,22 +179,22 @@ lemma single_one.ring_hom_apply [semiring k] [monoid G] (x : k) :
   (single_one.ring_hom : k →+* monoid_algebra k G) x = single 1 x := rfl
 
 lemma single_one.central [comm_semiring k] [monoid G] (r : k) (f : monoid_algebra k G) :
-  f * (monoid_algebra.single_one.ring_hom : k →+* monoid_algebra k G) r =
-    (monoid_algebra.single_one.ring_hom : k →+* monoid_algebra k G) r * f :=
+  (monoid_algebra.single_one.ring_hom : k →+* monoid_algebra k G) r * f =
+    f * (monoid_algebra.single_one.ring_hom : k →+* monoid_algebra k G) r:=
 begin
   ext,
   -- It would be nice if this next step worked by `simp`.
   dsimp [monoid_algebra.single_one.ring_hom, finsupp.single.add_monoid_hom],
   simp only [monoid_algebra.mul_apply],
-  conv_lhs { rw [finsupp.sum_comm], },
+  conv_rhs { rw [finsupp.sum_comm], },
   rw [finsupp.sum_single_index],
   { rw [finsupp.sum_single_index],
     { simp only [mul_one, one_mul],
       -- I had hoped that in Lean 3.8 `simp only [finsupp.sum_ite_eq']` would work here,
       -- but it doesn't, and we have to muck about.
-      convert finsupp.sum_ite_eq' f a (λ x v, v * r),
+      convert finsupp.sum_ite_eq' f a (λ x v, r * v),
       funext, congr,
-      convert finsupp.sum_ite_eq' f a (λ x v, r * v) using 1,
+      convert finsupp.sum_ite_eq' f a (λ x v, v * r) using 1,
       { congr, funext, congr, },
       { congr' 1, apply mul_comm, }, },
     simp, },
@@ -213,6 +214,13 @@ begin
     { simp, classical, split_ifs, simp [h], }, },
   { simp, }
 end
+
+/-- The monoid algebra R[G] is an algebra over R. -/
+instance algebra [comm_semiring k] [monoid G] : algebra k (monoid_algebra k G) :=
+{ commutes' := single_one.central,
+  smul_def' := λ r f, module_smul_eq r f (by simp),
+  .. (single_one.ring_hom : k →+* monoid_algebra k G),
+  .. monoid_algebra.semimodule }
 
 universe ui
 variable {ι : Type ui}
@@ -317,7 +325,7 @@ lemma mul_apply (f g : add_monoid_algebra k G) (x : G) :
   (f * g) x = (f.sum $ λa₁ b₁, g.sum $ λa₂ b₂, if a₁ + a₂ = x then b₁ * b₂ else 0) :=
 begin
   rw [mul_def],
-  simp only [sum_apply, single_apply],
+  simp only [finsupp.sum_apply, single_apply],
 end
 
 lemma support_mul (a b : add_monoid_algebra k G) :
@@ -414,22 +422,22 @@ lemma single_one.ring_hom_apply [semiring k] [add_monoid G] (x : k) :
   (single_one.ring_hom : k →+* add_monoid_algebra k G) x = single 0 x := rfl
 
 lemma single_one.central [comm_semiring k] [add_monoid G] (r : k) (f : add_monoid_algebra k G) :
-  f * (add_monoid_algebra.single_one.ring_hom : k →+* add_monoid_algebra k G) r =
-    (add_monoid_algebra.single_one.ring_hom : k →+* add_monoid_algebra k G) r * f :=
+  (add_monoid_algebra.single_one.ring_hom : k →+* add_monoid_algebra k G) r * f
+    = f * (add_monoid_algebra.single_one.ring_hom : k →+* add_monoid_algebra k G) r :=
 begin
   ext,
   -- It would be nice if this next step worked by `simp`.
   dsimp [add_monoid_algebra.single_one.ring_hom, finsupp.single.add_monoid_hom],
   simp only [add_monoid_algebra.mul_apply],
-  conv_lhs { rw [finsupp.sum_comm], },
+  conv_rhs { rw [finsupp.sum_comm], },
   rw [finsupp.sum_single_index],
   { rw [finsupp.sum_single_index],
     { simp only [add_zero, zero_add, finsupp.sum_ite_eq'],
       -- As in the multiplicative version,
       -- it's unfortunate `simp only [finsupp.sum_ite_eq']` doesn't work.
-      convert finsupp.sum_ite_eq' f a (λ x v, v * r),
+      convert finsupp.sum_ite_eq' f a (λ x v, r * v),
       funext, congr,
-      convert finsupp.sum_ite_eq' f a (λ x v, r * v) using 1,
+      convert finsupp.sum_ite_eq' f a (λ x v, v * r) using 1,
       { congr, funext, congr, },
       { congr' 1, apply mul_comm, }, },
     simp, },
@@ -449,6 +457,14 @@ begin
     { simp, classical, split_ifs, simp [h], }, },
   { simp, }
 end
+
+/-- The monoid algebra R[G] is an algebra over R. -/
+instance algebra [comm_semiring k] [add_monoid G] :
+  algebra k (add_monoid_algebra k G) :=
+{ commutes' := single_one.central,
+  smul_def' := λ r f, module_smul_eq r f (by simp),
+  .. (single_one.ring_hom : k →+* add_monoid_algebra k G),
+  .. add_monoid_algebra.semimodule }
 
 universe ui
 variable {ι : Type ui}

--- a/src/data/monoid_algebra.lean
+++ b/src/data/monoid_algebra.lean
@@ -188,7 +188,9 @@ begin
   conv_lhs { rw [finsupp.sum_comm], },
   rw [finsupp.sum_single_index],
   { rw [finsupp.sum_single_index],
-    { simp only [mul_one, one_mul, finsupp.sum_ite_eq'], -- In Lean 3.8 this will hopefully handle the `sum_ite_eq'` below.
+    { simp only [mul_one, one_mul],
+      -- I had hoped that in Lean 3.8 `simp only [finsupp.sum_ite_eq']` would work here,
+      -- but it doesn't, and we have to muck about.
       convert finsupp.sum_ite_eq' f a (λ x v, v * r),
       funext, congr,
       convert finsupp.sum_ite_eq' f a (λ x v, r * v) using 1,
@@ -422,7 +424,9 @@ begin
   conv_lhs { rw [finsupp.sum_comm], },
   rw [finsupp.sum_single_index],
   { rw [finsupp.sum_single_index],
-    { simp only [add_zero, zero_add, finsupp.sum_ite_eq'], -- In Lean 3.8 this will hopefully handle the `sum_ite_eq'` below.
+    { simp only [add_zero, zero_add, finsupp.sum_ite_eq'],
+      -- As in the multiplicative version,
+      -- it's unfortunate `simp only [finsupp.sum_ite_eq']` doesn't work.
       convert finsupp.sum_ite_eq' f a (λ x v, v * r),
       funext, congr,
       convert finsupp.sum_ite_eq' f a (λ x v, r * v) using 1,

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -4,8 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Johan Commelin, Mario Carneiro, Shing Tak Lam
 -/
 
-import algebra.ring
-import data.finsupp data.polynomial data.equiv.ring data.equiv.fin
+import data.polynomial data.equiv.ring data.equiv.fin
 import tactic.omega
 
 /-!
@@ -991,9 +990,7 @@ section aeval
 
 /-- The algebra of multivariate polynomials. -/
 instance mv_polynomial (R : Type u) [comm_ring R] (σ : Type v) : algebra R (mv_polynomial σ R) :=
-{ commutes' := λ _ _, mul_comm _ _,
-  smul_def' := λ c p, (mv_polynomial.C_mul' c p).symm,
-  .. ring_hom.of mv_polynomial.C, .. mv_polynomial.module }
+add_monoid_algebra.algebra
 
 variables (R : Type u) (A : Type v) (f : σ → A)
 variables [comm_ring R] [comm_ring A] [algebra R A]

--- a/src/data/polynomial.lean
+++ b/src/data/polynomial.lean
@@ -5,7 +5,7 @@ Authors: Chris Hughes, Johannes Hölzl, Scott Morrison, Jens Wagemaker
 
 Theory of univariate polynomials, represented as `add_monoid_algebra α ℕ`, where α is a commutative semiring.
 -/
-import data.monoid_algebra ring_theory.algebra
+import data.monoid_algebra
 import algebra.gcd_domain ring_theory.euclidean_domain ring_theory.multiplicity
 import tactic.ring_exp
 
@@ -1353,9 +1353,7 @@ is_ring_hom.map_sub _
 section aeval
 /-- `R[X]` is the generator of the category `R-Alg`. -/
 instance polynomial (R : Type u) [comm_semiring R] : algebra R (polynomial R) :=
-{ commutes' := λ _ _, mul_comm _ _,
-  smul_def' := λ c p, (polynomial.C_mul' c p).symm,
-  .. polynomial.semimodule, .. ring_hom.of polynomial.C, }
+add_monoid_algebra.algebra
 
 variables (R : Type u) (A : Type v)
 variables [comm_ring R] [comm_ring A] [algebra R A]


### PR DESCRIPTION
The ring homomorphism `k →+* monoid_algebra k G`, given by including in as functions supported at the multiplicative identity of `G`, and a few associated lemmas.