### PR TITLE
[Merged by Bors] - fix(library_search): find id

### DIFF
--- a/src/tactic/suggest.lean
+++ b/src/tactic/suggest.lean
@@ -81,7 +81,7 @@ meta def match_head_symbol (hs : name) : expr → option head_symbol_match
                        end
 | (expr.app f _)    := match_head_symbol f
 | (expr.const n _)  := if list.mem hs (unfold_head_symbol n) then some ex else none
-| _ := none
+| _ := if hs = `_ then some ex else none
 
 meta structure decl_data :=
 (d : declaration)

--- a/test/library_search/basic.lean
+++ b/test/library_search/basic.lean
@@ -37,6 +37,9 @@ by library_search
 example (α : Prop) : α → α :=
 by library_search -- says: `exact id`
 
+example (p : Prop) [decidable p] : (¬¬p) → p :=
+by library_search -- says: `exact not_not.mp`
+
 example (a b : ℕ) : a + b = b + a :=
 by library_search -- says: `exact add_comm a b`
 

--- a/test/library_search/basic.lean
+++ b/test/library_search/basic.lean
@@ -34,6 +34,9 @@ lemma zero_lt_one (n : ℕ) (h : n = 0) : lt_one n := by subst h; dsimp [lt_one]
 example : lt_one 0 :=
 by library_search
 
+example (α : Prop) : α → α :=
+by library_search -- says: `exact id`
+
 example (a b : ℕ) : a + b = b + a :=
 by library_search -- says: `exact add_comm a b`
 

--- a/test/library_search/basic.lean
+++ b/test/library_search/basic.lean
@@ -43,6 +43,9 @@ by library_search -- says: `exact not_not.mp`
 example (a b : Prop) (h : a ∧ b) : a :=
 by library_search -- says: `exact h.left`
 
+example (P Q : Prop) [decidable P] [decidable Q]: (¬ Q → ¬ P) → (P → Q) :=
+by library_search -- says: `exact not_imp_not.mp`
+
 example (a b : ℕ) : a + b = b + a :=
 by library_search -- says: `exact add_comm a b`
 

--- a/test/library_search/basic.lean
+++ b/test/library_search/basic.lean
@@ -40,6 +40,9 @@ by library_search -- says: `exact id`
 example (p : Prop) [decidable p] : (¬¬p) → p :=
 by library_search -- says: `exact not_not.mp`
 
+example (a b : Prop) (h : a ∧ b) : a :=
+by library_search -- says: `exact h.left`
+
 example (a b : ℕ) : a + b = b + a :=
 by library_search -- says: `exact add_comm a b`
 


### PR DESCRIPTION
Previously `library_search` could not find theorems that did not have a head symbol (e.g. were function types with source and target both "variables all the way down"). Now it can, so it solves:

```lean
example (α : Prop) : α → α :=
by library_search -- says: `exact id`

example (p : Prop) [decidable p] : (¬¬p) → p :=
by library_search -- says: `exact not_not.mp`

example (a b : Prop) (h : a ∧ b) : a := 
by library_search -- says: `exact h.left`

example (P Q : Prop) [decidable P] [decidable Q]: (¬ Q → ¬ P) → (P → Q) :=
by library_search -- says: `exact not_imp_not.mp`
```