### PR TITLE
[Merged by Bors] - feat(library_search): (efficiently) try calling symmetry before searching the library

### DIFF
--- a/test/library_search/basic.lean
+++ b/test/library_search/basic.lean
@@ -43,9 +43,8 @@ by library_search -- says: `exact nat.le.intro rfl`
 example (n m k : ℕ) : n * (m - k) = n * m - n * k :=
 by library_search -- says: `exact nat.mul_sub_left_distrib n m k`
 
--- TODO this doesn't work yet, and would require `library_search` to use `symmetry`
--- example (n m k : ℕ) : n * m - n * k = n * (m - k) :=
--- by library_search -- says: `exact eq.symm (nat.mul_sub_left_distrib n m k)`
+example (n m k : ℕ) : n * m - n * k = n * (m - k) :=
+by library_search -- says: `exact eq.symm (nat.mul_sub_left_distrib n m k)`
 
 example {n m : ℕ} (h : m < n) : m ≤ n - 1 :=
 by library_search -- says: `exact nat.le_pred_of_lt h`


### PR DESCRIPTION
This fixes a gap in `library_search` we've known about for a long time: it misses lemmas stated "the other way round" than what you were looking for.

This PR fixes that. I cache the `tactic_state` after calling `symmetry`, so it is only called once, regardless of how much of the library we're searching.

When `library_search` was already succeeding, it should still succeed, with the same run time.
When it was failing, it will now either succeed (because it found a lemma after calling `symmetry`), or fail (in the same time, if `symmetry` fails, or approximately twice the time, if `symmetry` succeeds). I think this is a reasonable time trade-off for better search results.