### PR TITLE
[Merged by Bors] - feat(data/finset): existence of a smaller set

### DIFF
--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -2556,19 +2556,19 @@ Given a set A and a set B inside it, we can shrink A to any appropriate size, an
 inside it.
 -/
 lemma exists_intermediate_set {A B : finset α} (i : ℕ)
-  (h₁ : card A ≥ i + card B) (h₂ : B ⊆ A) :
+  (h₁ : i + card B ≤ card A) (h₂ : B ⊆ A) :
   ∃ (C : finset α), B ⊆ C ∧ C ⊆ A ∧ card C = i + card B :=
 begin
   rcases nat.le.dest h₁ with ⟨k, _⟩,
   clear h₁,
   induction k with k ih generalizing A,
   { exact ⟨A, h₂, subset.refl _, h.symm⟩ },
-  { have: (A \ B).nonempty,
+  { have : (A \ B).nonempty,
     { rw [← card_pos, card_sdiff h₂, ← h, nat.add_right_comm,
           nat.add_sub_cancel, nat.add_succ],
       apply nat.succ_pos },
     rcases this with ⟨a, ha⟩,
-    have z: i + card B + k = card (erase A a),
+    have z : i + card B + k = card (erase A a),
     { rw [card_erase_of_mem, ← h, nat.add_succ, nat.pred_succ],
       rw mem_sdiff at ha,
       exact ha.1 },
@@ -2582,12 +2582,9 @@ begin
 end
 
 /-- We can shrink A to any smaller size. -/
-lemma exists_smaller_set (A : finset α) (i : ℕ) (h₁ : card A ≥ i) :
+lemma exists_smaller_set (A : finset α) (i : ℕ) (h₁ : i ≤ card A) :
   ∃ (B : finset α), B ⊆ A ∧ card B = i :=
-begin
-  obtain ⟨B, _, x₁, x₂⟩ := exists_intermediate_set i (by simpa) (empty_subset A),
-  exact ⟨B, x₁, x₂⟩,
-end
+let ⟨B, _, x₁, x₂⟩ := exists_intermediate_set i (by simpa) (empty_subset A) in ⟨B, x₁, x₂⟩
 
 end disjoint
 

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -2551,6 +2551,8 @@ lemma disjoint_iff_disjoint_coe {α : Type*} {a b : finset α} [decidable_eq α]
   disjoint a b ↔ disjoint (↑a : set α) (↑b : set α) :=
 by { rw [finset.disjoint_left, set.disjoint_left], refl }
 
+end disjoint
+
 /--
 Given a set A and a set B inside it, we can shrink A to any appropriate size, and keep B
 inside it.
@@ -2559,6 +2561,7 @@ lemma exists_intermediate_set {A B : finset α} (i : ℕ)
   (h₁ : i + card B ≤ card A) (h₂ : B ⊆ A) :
   ∃ (C : finset α), B ⊆ C ∧ C ⊆ A ∧ card C = i + card B :=
 begin
+  classical,
   rcases nat.le.dest h₁ with ⟨k, _⟩,
   clear h₁,
   induction k with k ih generalizing A,
@@ -2585,8 +2588,6 @@ end
 lemma exists_smaller_set (A : finset α) (i : ℕ) (h₁ : i ≤ card A) :
   ∃ (B : finset α), B ⊆ A ∧ card B = i :=
 let ⟨B, _, x₁, x₂⟩ := exists_intermediate_set i (by simpa) (empty_subset A) in ⟨B, x₁, x₂⟩
-
-end disjoint
 
 instance [has_repr α] : has_repr (finset α) := ⟨λ s, repr s.1⟩
 

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -2580,8 +2580,7 @@ begin
     { rintros t th,
       apply mem_erase_of_ne_of_mem _ (h₂ th),
       rintro rfl,
-      rw mem_sdiff at ha,
-      tauto } }
+      exact not_mem_sdiff_of_mem_right th ha } }
 end
 
 /-- We can shrink A to any smaller size. -/

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -2551,6 +2551,44 @@ lemma disjoint_iff_disjoint_coe {α : Type*} {a b : finset α} [decidable_eq α]
   disjoint a b ↔ disjoint (↑a : set α) (↑b : set α) :=
 by { rw [finset.disjoint_left, set.disjoint_left], refl }
 
+/--
+Given a set A and a set B inside it, we can shrink A to any appropriate size, and keep B
+inside it.
+-/
+lemma exists_intermediate_set {A B : finset α} (i : ℕ)
+  (h₁ : card A ≥ i + card B) (h₂ : B ⊆ A) :
+  ∃ (C : finset α), B ⊆ C ∧ C ⊆ A ∧ card C = i + card B :=
+begin
+  rcases nat.le.dest h₁ with ⟨k, _⟩,
+  clear h₁,
+  induction k with k ih generalizing A,
+  { exact ⟨A, h₂, subset.refl _, h.symm⟩ },
+  { have: (A \ B).nonempty,
+    { rw [← card_pos, card_sdiff h₂, ← h, nat.add_right_comm,
+          nat.add_sub_cancel, nat.add_succ],
+      apply nat.succ_pos },
+    rcases this with ⟨a, ha⟩,
+    have z: i + card B + k = card (erase A a),
+    { rw [card_erase_of_mem, ← h, nat.add_succ, nat.pred_succ],
+      rw mem_sdiff at ha,
+      exact ha.1 },
+    rcases ih _ z with ⟨B', hB', B'subA', cards⟩,
+    { exact ⟨B', hB', trans B'subA' (erase_subset _ _), cards⟩ },
+    { rintros t th,
+      apply mem_erase_of_ne_of_mem _ (h₂ th),
+      rintro rfl,
+      rw mem_sdiff at ha,
+      tauto } }
+end
+
+/-- We can shrink A to any smaller size. -/
+lemma exists_smaller_set (A : finset α) (i : ℕ) (h₁ : card A ≥ i) :
+  ∃ (B : finset α), B ⊆ A ∧ card B = i :=
+begin
+  obtain ⟨B, _, x₁, x₂⟩ := exists_intermediate_set i (by simpa) (empty_subset A),
+  exact ⟨B, x₁, x₂⟩,
+end
+
 end disjoint
 
 instance [has_repr α] : has_repr (finset α) := ⟨λ s, repr s.1⟩


### PR DESCRIPTION
Show the existence of a smaller finset contained in a given finset.

The next in my series of lemmas for my combinatorics project.

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
