### PR TITLE
[Merged by Bors] - feat(data/nat): Results about nat.choose

### DIFF
--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -12,7 +12,7 @@ This files has some basic lemmas about natural numbers, definition of the `choic
 and extra recursors:
 
 * `le_rec_on`, `le_induction`: recursion and induction principles starting at non-zero numbers.
-* `decreasing_induction` : recursion gowing downwards.
+* `decreasing_induction` : recursion growing downwards.
 * `strong_rec'` : recursion based on strong inequalities.
 -/
 
@@ -1204,6 +1204,9 @@ by rw [←choose_mul_fact_mul_fact hk, mul_assoc]; exact dvd_mul_left _ _
 
 @[simp] lemma choose_symm {n k : ℕ} (hk : k ≤ n) : choose n (n-k) = choose n k :=
 by rw [choose_eq_fact_div_fact hk, choose_eq_fact_div_fact (sub_le _ _), nat.sub_sub_self hk, mul_comm]
+
+lemma choose_symm' {n a b : ℕ} (h : n = a + b) : nat.choose n a = nat.choose n b :=
+by { convert nat.choose_symm (nat.le_add_left _ _), rw nat.add_sub_cancel}
 
 lemma choose_succ_right_eq (n k : ℕ) : choose n (k + 1) * (k + 1) = choose n k * (n - k) :=
 begin

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -1205,8 +1205,11 @@ by rw [←choose_mul_fact_mul_fact hk, mul_assoc]; exact dvd_mul_left _ _
 @[simp] lemma choose_symm {n k : ℕ} (hk : k ≤ n) : choose n (n-k) = choose n k :=
 by rw [choose_eq_fact_div_fact hk, choose_eq_fact_div_fact (sub_le _ _), nat.sub_sub_self hk, mul_comm]
 
-lemma choose_symm' {n a b : ℕ} (h : n = a + b) : nat.choose n a = nat.choose n b :=
+lemma choose_symm_of_eq_add {n a b : ℕ} (h : n = a + b) : nat.choose n a = nat.choose n b :=
 by { convert nat.choose_symm (nat.le_add_left _ _), rw nat.add_sub_cancel}
+
+lemma choose_symm_add {a b : ℕ} : choose (a+b) a = choose (a+b) b :=
+choose_symm_of_eq_add rfl
 
 lemma choose_succ_right_eq (n k : ℕ) : choose n (k + 1) * (k + 1) = choose n k * (n - k) :=
 begin

--- a/src/data/nat/choose.lean
+++ b/src/data/nat/choose.lean
@@ -8,6 +8,7 @@ import algebra.big_operators algebra.commute
 
 open nat
 
+/-- Based on Jeremy Avigad's choose file in lean 2 -/
 lemma nat.prime.dvd_choose {p k : ℕ} (hk : 0 < k) (hkp : k < p) (hp : prime p) : p ∣ choose p k :=
 have h₁ : p ∣ fact p, from hp.dvd_fact.2 (le_refl _),
 have h₂ : ¬p ∣ fact k, from mt hp.dvd_fact.1 (not_le_of_gt hkp),
@@ -36,7 +37,7 @@ decreasing_induction
   (λ _ k a,
       (eq_or_lt_of_le a).elim
         (λ t, t.symm ▸ le_refl _)
-        (λ h, trans (dominate_choose_lt h) (k h)))
+        (λ h, trans (choose_le_succ_of_lt_half_left h) (k h)))
   hr (λ _, le_refl _) hr
 
 /-- `choose n r` is maximised when `r` is `n/2`. -/
@@ -44,15 +45,15 @@ lemma choose_le_middle {r n : ℕ} : nat.choose n r ≤ nat.choose n (n/2) :=
 begin
   cases le_or_gt r n with b b,
   { cases le_or_lt r (n/2) with a h,
-    { apply dominate_choose_lt' a },
-    { rw ← nat.choose_symm b,
-      apply dominate_choose_lt',
-      rw [nat.div_lt_iff_lt_mul' zero_lt_two] at h,
-      rw [nat.le_div_iff_mul_le' zero_lt_two, nat.mul_sub_right_distrib, nat.sub_le_iff,
+    { apply choose_le_middle_of_le_half_left a },
+    { rw ← choose_symm b,
+      apply choose_le_middle_of_le_half_left,
+      rw [div_lt_iff_lt_mul' zero_lt_two] at h,
+      rw [le_div_iff_mul_le' zero_lt_two, nat.mul_sub_right_distrib, nat.sub_le_iff,
           mul_two, nat.add_sub_cancel],
       exact le_of_lt h } },
   { rw nat.choose_eq_zero_of_lt b,
-    apply zero_le }
+    apply nat.zero_le }
 end
 
 section binomial
@@ -60,7 +61,10 @@ open finset
 
 variables {α : Type*}
 
-/-- A version of the binomial theorem for noncommutative semirings. -/
+/--
+A version of the binomial theorem for noncommutative semirings.
+Based on Jeremy Avigad's choose file in lean 2
+-/
 theorem commute.add_pow [semiring α] {x y : α} (h : commute x y) (n : ℕ) :
   (x + y) ^ n = (range (succ n)).sum (λ m, x ^ m * y ^ (n - m) * choose n m) :=
 begin

--- a/src/data/nat/choose.lean
+++ b/src/data/nat/choose.lean
@@ -8,7 +8,6 @@ import algebra.big_operators algebra.commute
 
 open nat
 
-/-- Based on Jeremy Avigad's choose file in lean 2 -/
 lemma nat.prime.dvd_choose {p k : ℕ} (hk : 0 < k) (hkp : k < p) (hp : prime p) : p ∣ choose p k :=
 have h₁ : p ∣ fact p, from hp.dvd_fact.2 (le_refl _),
 have h₂ : ¬p ∣ fact k, from mt hp.dvd_fact.1 (not_le_of_gt hkp),
@@ -27,11 +26,8 @@ begin
   exact lt_of_lt_of_le (mul_lt_mul_of_pos_right h zero_lt_two) (nat.div_mul_le_self n 2),
 end
 
-/--
-Show that for small values of the right argument, the middle value is largest.
-You probably want `choose_le_middle` instead of this.
--/
-lemma choose_le_middle_of_le_half_left {n r : ℕ} (hr : r ≤ n/2) :
+/-- Show that for small values of the right argument, the middle value is largest. -/
+private lemma choose_le_middle_of_le_half_left {n r : ℕ} (hr : r ≤ n/2) :
   choose n r ≤ choose n (n/2) :=
 decreasing_induction
   (λ _ k a,
@@ -61,10 +57,7 @@ open finset
 
 variables {α : Type*}
 
-/--
-A version of the binomial theorem for noncommutative semirings.
-Based on Jeremy Avigad's choose file in lean 2
--/
+/-- A version of the binomial theorem for noncommutative semirings. -/
 theorem commute.add_pow [semiring α] {x y : α} (h : commute x y) (n : ℕ) :
   (x + y) ^ n = (range (succ n)).sum (λ m, x ^ m * y ^ (n - m) * choose n m) :=
 begin

--- a/src/data/nat/choose.lean
+++ b/src/data/nat/choose.lean
@@ -1,8 +1,7 @@
 /-
 Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Chris Hughes
-Mostly based on Jeremy Avigad's choose file in lean 2
+Authors: Chris Hughes, Bhavik Mehta
 -/
 import data.nat.basic data.nat.prime
 import algebra.big_operators algebra.commute
@@ -15,6 +14,46 @@ have h₂ : ¬p ∣ fact k, from mt hp.dvd_fact.1 (not_le_of_gt hkp),
 have h₃ : ¬p ∣ fact (p - k), from mt hp.dvd_fact.1 (not_le_of_gt (nat.sub_lt_self hp.pos hk)),
 by rw [← choose_mul_fact_mul_fact (le_of_lt hkp), mul_assoc, hp.dvd_mul, hp.dvd_mul] at h₁;
   exact h₁.resolve_right (not_or_distrib.2 ⟨h₂, h₃⟩)
+
+/-- Show that choose is increasing for small values of the right argument. -/
+lemma choose_le_succ_of_lt_half_left {r n : ℕ} (h : r < n/2) :
+  choose n r ≤ choose n (r+1) :=
+begin
+  refine le_of_mul_le_mul_right _ (nat.lt_sub_left_of_add_lt (lt_of_lt_of_le h (nat.div_le_self n 2))),
+  rw ← choose_succ_right_eq,
+  apply nat.mul_le_mul_left,
+  rw [← nat.lt_iff_add_one_le, nat.lt_sub_left_iff_add_lt, ← mul_two],
+  exact lt_of_lt_of_le (mul_lt_mul_of_pos_right h zero_lt_two) (nat.div_mul_le_self n 2),
+end
+
+/--
+Show that for small values of the right argument, the middle value is largest.
+You probably want `choose_le_middle` instead of this.
+-/
+lemma choose_le_middle_of_le_half_left {n r : ℕ} (hr : r ≤ n/2) :
+  choose n r ≤ choose n (n/2) :=
+decreasing_induction
+  (λ _ k a,
+      (eq_or_lt_of_le a).elim
+        (λ t, t.symm ▸ le_refl _)
+        (λ h, trans (dominate_choose_lt h) (k h)))
+  hr (λ _, le_refl _) hr
+
+/-- `choose n r` is maximised when `r` is `n/2`. -/
+lemma choose_le_middle {r n : ℕ} : nat.choose n r ≤ nat.choose n (n/2) :=
+begin
+  cases le_or_gt r n with b b,
+  { cases le_or_lt r (n/2) with a h,
+    { apply dominate_choose_lt' a },
+    { rw ← nat.choose_symm b,
+      apply dominate_choose_lt',
+      rw [nat.div_lt_iff_lt_mul' zero_lt_two] at h,
+      rw [nat.le_div_iff_mul_le' zero_lt_two, nat.mul_sub_right_distrib, nat.sub_le_iff,
+          mul_two, nat.add_sub_cancel],
+      exact le_of_lt h } },
+  { rw nat.choose_eq_zero_of_lt b,
+    apply zero_le }
+end
 
 section binomial
 open finset


### PR DESCRIPTION
A convenience lemma for symmetry of choose and inequalities about choose.

More results from my combinatorics project.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
