### PR TITLE
[Merged by Bors] - feat(analysis/calculus): let simp compute derivatives

### DIFF
--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -413,7 +413,7 @@ has_deriv_at_filter_const _ _ _
 theorem has_deriv_at_const : has_deriv_at (λ x, c) 0 x :=
 has_deriv_at_filter_const _ _ _
 
-@[simp] lemma deriv_const : deriv (λ x, c) x = 0 :=
+lemma deriv_const : deriv (λ x, c) x = 0 :=
 has_deriv_at.deriv (has_deriv_at_const x c)
 
 @[simp] lemma deriv_const' : deriv (λ x:𝕜, c) = λ x, 0 :=
@@ -644,7 +644,7 @@ lemma deriv_within_neg (hxs : unique_diff_within_at 𝕜 s x)
   deriv_within (λy, -f y) s x = - deriv_within f s x :=
 h.has_deriv_within_at.neg.deriv_within hxs
 
-@[simp] lemma deriv_neg : deriv (λy, -f y) x = - deriv f x :=
+lemma deriv_neg : deriv (λy, -f y) x = - deriv f x :=
 if h : differentiable_at 𝕜 f x then h.has_deriv_at.neg.deriv else
 have ¬differentiable_at 𝕜 (λ y, -f y) x, from λ h', by simpa only [neg_neg] using h'.neg,
 by simp only [deriv_zero_of_not_differentiable_at h,

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -374,11 +374,17 @@ has_deriv_at_filter_id _ _
 theorem has_deriv_at_id : has_deriv_at id 1 x :=
 has_deriv_at_filter_id _ _
 
+theorem has_deriv_at_id' : has_deriv_at (λ (x : 𝕜), x) 1 x :=
+has_deriv_at_filter_id _ _
+
 lemma deriv_id : deriv id x = 1 :=
 has_deriv_at.deriv (has_deriv_at_id x)
 
 @[simp] lemma deriv_id' : deriv (@id 𝕜) = λ _, 1 :=
 funext deriv_id
+
+@[simp] lemma deriv_id'' : deriv (λ x : 𝕜, x) x = 1 :=
+deriv_id x
 
 lemma deriv_within_id (hxs : unique_diff_within_at 𝕜 s x) : deriv_within id s x = 1 :=
 by { unfold deriv_within, rw fderiv_within_id, simp, assumption }
@@ -398,7 +404,7 @@ has_deriv_at_filter_const _ _ _
 theorem has_deriv_at_const : has_deriv_at (λ x, c) 0 x :=
 has_deriv_at_filter_const _ _ _
 
-lemma deriv_const : deriv (λ x, c) x = 0 :=
+@[simp] lemma deriv_const : deriv (λ x, c) x = 0 :=
 has_deriv_at.deriv (has_deriv_at_const x c)
 
 @[simp] lemma deriv_const' : deriv (λ x:𝕜, c) = λ x, 0 :=
@@ -476,7 +482,7 @@ lemma deriv_within_add (hxs : unique_diff_within_at 𝕜 s x)
   deriv_within (λy, f y + g y) s x = deriv_within f s x + deriv_within g s x :=
 (hf.has_deriv_within_at.add hg.has_deriv_within_at).deriv_within hxs
 
-lemma deriv_add
+@[simp] lemma deriv_add
   (hf : differentiable_at 𝕜 f x) (hg : differentiable_at 𝕜 g x) :
   deriv (λy, f y + g y) x = deriv f x + deriv g x :=
 (hf.has_deriv_at.add hg.has_deriv_at).deriv
@@ -629,7 +635,7 @@ lemma deriv_within_neg (hxs : unique_diff_within_at 𝕜 s x)
   deriv_within (λy, -f y) s x = - deriv_within f s x :=
 h.has_deriv_within_at.neg.deriv_within hxs
 
-lemma deriv_neg : deriv (λy, -f y) x = - deriv f x :=
+@[simp] lemma deriv_neg : deriv (λy, -f y) x = - deriv f x :=
 if h : differentiable_at 𝕜 f x then h.has_deriv_at.neg.deriv else
 have ¬differentiable_at 𝕜 (λ y, -f y) x, from λ h', by simpa only [neg_neg] using h'.neg,
 by simp only [deriv_zero_of_not_differentiable_at h,
@@ -663,7 +669,7 @@ lemma deriv_within_sub (hxs : unique_diff_within_at 𝕜 s x)
   deriv_within (λy, f y - g y) s x = deriv_within f s x - deriv_within g s x :=
 (hf.has_deriv_within_at.sub hg.has_deriv_within_at).deriv_within hxs
 
-lemma deriv_sub
+@[simp] lemma deriv_sub
   (hf : differentiable_at 𝕜 f x) (hg : differentiable_at 𝕜 g x) :
   deriv (λ y, f y - g y) x = deriv f x - deriv g x :=
 (hf.has_deriv_at.sub hg.has_deriv_at).deriv
@@ -958,7 +964,7 @@ lemma deriv_within_mul (hxs : unique_diff_within_at 𝕜 s x)
   deriv_within (λ y, c y * d y) s x = deriv_within c s x * d x + c x * deriv_within d s x :=
 (hc.has_deriv_within_at.mul hd.has_deriv_within_at).deriv_within hxs
 
-lemma deriv_mul (hc : differentiable_at 𝕜 c x) (hd : differentiable_at 𝕜 d x) :
+@[simp] lemma deriv_mul (hc : differentiable_at 𝕜 c x) (hd : differentiable_at 𝕜 d x) :
   deriv (λ y, c y * d y) x = deriv c x * d x + c x * deriv d x :=
 (hc.has_deriv_at.mul hd.has_deriv_at).deriv
 
@@ -1099,6 +1105,48 @@ begin
   exact fderiv_inv x_ne_zero
 end
 
+variables {c : 𝕜 → 𝕜} {c' : 𝕜}
+
+lemma has_deriv_within_at.inv
+  (hc : has_deriv_within_at c c' s x) (hx : c x ≠ 0) :
+  has_deriv_within_at (λ y, (c y)⁻¹) (- c' / (c x)^2) s x :=
+begin
+  convert (has_deriv_at_inv hx).comp_has_deriv_within_at x hc,
+  field_simp
+end
+
+lemma has_deriv_at.inv (hc : has_deriv_at c c' x) (hx : c x ≠ 0) :
+  has_deriv_at (λ y, (c y)⁻¹) (- c' / (c x)^2) x :=
+begin
+  rw ← has_deriv_within_at_univ at *,
+  exact hc.inv hx
+end
+
+lemma differentiable_within_at.inv (hc : differentiable_within_at 𝕜 c s x) (hx : c x ≠ 0) :
+  differentiable_within_at 𝕜 (λx, (c x)⁻¹) s x :=
+(hc.has_deriv_within_at.inv hx).differentiable_within_at
+
+@[simp] lemma differentiable_at.inv (hc : differentiable_at 𝕜 c x) (hx : c x ≠ 0) :
+  differentiable_at 𝕜 (λx, (c x)⁻¹) x :=
+(hc.has_deriv_at.inv hx).differentiable_at
+
+lemma differentiable_on.inv (hc : differentiable_on 𝕜 c s) (hx : ∀ x ∈ s, c x ≠ 0) :
+  differentiable_on 𝕜 (λx, (c x)⁻¹) s :=
+λx h, (hc x h).inv (hx x h)
+
+@[simp] lemma differentiable.inv (hc : differentiable 𝕜 c) (hx : ∀ x, c x ≠ 0) :
+  differentiable 𝕜 (λx, (c x)⁻¹) :=
+λx, (hc x).inv (hx x)
+
+lemma deriv_within_inv' (hc : differentiable_within_at 𝕜 c s x) (hx : c x ≠ 0)
+  (hxs : unique_diff_within_at 𝕜 s x) :
+  deriv_within (λx, (c x)⁻¹) s x = - (deriv_within c s x) / (c x)^2 :=
+(hc.has_deriv_within_at.inv hx).deriv_within hxs
+
+@[simp] lemma deriv_inv' (hc : differentiable_at 𝕜 c x) (hx : c x ≠ 0) :
+  deriv (λx, (c x)⁻¹) x = - (deriv c x) / (c x)^2 :=
+(hc.has_deriv_at.inv hx).deriv
+
 end inverse
 
 section division
@@ -1139,7 +1187,7 @@ lemma differentiable_on.div
 differentiable_on 𝕜 (λx, c x / d x) s :=
 λx h, (hc x h).div (hd x h) (hx x h)
 
-lemma differentiable.div
+@[simp] lemma differentiable.div
   (hc : differentiable 𝕜 c) (hd : differentiable 𝕜 d) (hx : ∀ x, d x ≠ 0) :
 differentiable 𝕜 (λx, c x / d x) :=
 λx, (hc x).div (hd x) (hx x)
@@ -1151,7 +1199,7 @@ lemma deriv_within_div
     = ((deriv_within c s x) * d x - c x * (deriv_within d s x)) / (d x)^2 :=
 ((hc.has_deriv_within_at).div (hd.has_deriv_within_at) hx).deriv_within hxs
 
-lemma deriv_div
+@[simp] lemma deriv_div
   (hc : differentiable_at 𝕜 c x) (hd : differentiable_at 𝕜 d x) (hx : d x ≠ 0) :
   deriv (λx, c x / d x) x = ((deriv c x) * d x - c x * (deriv d x)) / (d x)^2 :=
 ((hc.has_deriv_at).div (hd.has_deriv_at) hx).deriv
@@ -1239,7 +1287,7 @@ end polynomial
 
 section pow
 /-! ### Derivative of `x ↦ x^n` for `n : ℕ` -/
-variables {x : 𝕜} {s : set 𝕜}
+variables {x : 𝕜} {s : set 𝕜} {c : 𝕜 → 𝕜} {c' : 𝕜}
 variable {n : ℕ }
 
 lemma has_deriv_at_pow (n : ℕ) (x : 𝕜) : has_deriv_at (λx, x^n) ((n : 𝕜) * x^(n-1)) x :=
@@ -1289,6 +1337,39 @@ end
 lemma iter_deriv_pow {k : ℕ} :
   deriv^[k] (λx:𝕜, x^n) x = ((finset.range k).prod (λ i, n - i):ℕ) * x^(n-k) :=
 congr_fun iter_deriv_pow' x
+
+lemma has_deriv_within_at.pow (hc : has_deriv_within_at c c' s x) :
+  has_deriv_within_at (λ y, (c y)^n) ((n : 𝕜) * (c x)^(n-1) * c') s x :=
+(has_deriv_at_pow n (c x)).comp_has_deriv_within_at x hc
+
+lemma has_deriv_at.pow (hc : has_deriv_at c c' x) :
+  has_deriv_at (λ y, (c y)^n) ((n : 𝕜) * (c x)^(n-1) * c') x :=
+by { rw ← has_deriv_within_at_univ at *, exact hc.pow }
+
+lemma differentiable_within_at.pow (hc : differentiable_within_at 𝕜 c s x) :
+  differentiable_within_at 𝕜 (λx, (c x)^n) s x :=
+hc.has_deriv_within_at.pow.differentiable_within_at
+
+@[simp] lemma differentiable_at.pow (hc : differentiable_at 𝕜 c x) :
+  differentiable_at 𝕜 (λx, (c x)^n) x :=
+hc.has_deriv_at.pow.differentiable_at
+
+lemma differentiable_on.pow (hc : differentiable_on 𝕜 c s) :
+  differentiable_on 𝕜 (λx, (c x)^n) s :=
+λx h, (hc x h).pow
+
+@[simp] lemma differentiable.pow (hc : differentiable 𝕜 c) :
+  differentiable 𝕜 (λx, (c x)^n) :=
+λx, (hc x).pow
+
+lemma deriv_within_pow' (hc : differentiable_within_at 𝕜 c s x)
+  (hxs : unique_diff_within_at 𝕜 s x) :
+  deriv_within (λx, (c x)^n) s x = (n : 𝕜) * (c x)^(n-1) * (deriv_within c s x) :=
+hc.has_deriv_within_at.pow.deriv_within hxs
+
+@[simp] lemma deriv_pow'' (hc : differentiable_at 𝕜 c x) :
+  deriv (λx, (c x)^n) x = (n : 𝕜) * (c x)^(n-1) * (deriv c x) :=
+hc.has_deriv_at.pow.deriv
 
 end pow
 

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -57,11 +57,20 @@ For most binary operations we also define `const_op` and `op_const` theorems for
 the first or second argument is a constant. This makes writing chains of `has_deriv_at`'s easier,
 and they more frequently lead to the desired result.
 
+We set up the simplifier so that it can compute the derivative of simple functions. For instance,
+```lean
+example (x : ℝ) : deriv (λ x, cos (sin x) * exp x) x = (cos(sin(x))-sin(sin(x))*cos(x))*exp(x) :=
+by { simp, ring }
+```
+
 ## Implementation notes
 
 Most of the theorems are direct restatements of the corresponding theorems
 for Fréchet derivatives.
 
+The strategy to construct simp lemmas that give the simplifier the possibility to compute
+derivatives is the same as the one for differentiability statements, as explained in `fderiv.lean`.
+See the explanations there.
 -/
 
 universes u v w
@@ -1177,7 +1186,7 @@ lemma differentiable_within_at.div
 differentiable_within_at 𝕜 (λx, c x / d x) s x :=
 ((hc.has_deriv_within_at).div (hd.has_deriv_within_at) hx).differentiable_within_at
 
-lemma differentiable_at.div
+@[simp] lemma differentiable_at.div
   (hc : differentiable_at 𝕜 c x) (hd : differentiable_at 𝕜 d x) (hx : d x ≠ 0) :
 differentiable_at 𝕜 (λx, c x / d x) x :=
 ((hc.has_deriv_at).div (hd.has_deriv_at) hx).differentiable_at

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -658,13 +658,19 @@ has_fderiv_at_filter_id _ _
 theorem has_fderiv_at_id (x : E) : has_fderiv_at id (id : E →L[𝕜] E) x :=
 has_fderiv_at_filter_id _ _
 
-lemma differentiable_at_id : differentiable_at 𝕜 id x :=
+@[simp] lemma differentiable_at_id : differentiable_at 𝕜 id x :=
+(has_fderiv_at_id x).differentiable_at
+
+@[simp] lemma differentiable_at_id' : differentiable_at 𝕜 (λ x, x) x :=
 (has_fderiv_at_id x).differentiable_at
 
 lemma differentiable_within_at_id : differentiable_within_at 𝕜 id s x :=
 differentiable_at_id.differentiable_within_at
 
-lemma differentiable_id : differentiable 𝕜 (id : E → E) :=
+@[simp] lemma differentiable_id : differentiable 𝕜 (id : E → E) :=
+λx, differentiable_at_id
+
+@[simp] lemma differentiable_id' : differentiable 𝕜 (λ (x : E), x) :=
 λx, differentiable_at_id
 
 lemma differentiable_on_id : differentiable_on 𝕜 id s :=
@@ -701,7 +707,7 @@ theorem has_fderiv_at_const (c : F) (x : E) :
   has_fderiv_at (λ x, c) (0 : E →L[𝕜] F) x :=
 has_fderiv_at_filter_const _ _ _
 
-lemma differentiable_at_const (c : F) : differentiable_at 𝕜 (λx, c) x :=
+@[simp] lemma differentiable_at_const (c : F) : differentiable_at 𝕜 (λx, c) x :=
 ⟨0, has_fderiv_at_const c x⟩
 
 lemma differentiable_within_at_const (c : F) : differentiable_within_at 𝕜 (λx, c) s x :=
@@ -720,7 +726,7 @@ begin
   exact fderiv_const_apply _
 end
 
-lemma differentiable_const (c : F) : differentiable 𝕜 (λx : E, c) :=
+@[simp] lemma differentiable_const (c : F) : differentiable 𝕜 (λx : E, c) :=
 λx, differentiable_at_const _
 
 lemma differentiable_on_const (c : F) : differentiable_on 𝕜 (λx, c) s :=
@@ -749,7 +755,7 @@ e.has_fderiv_at_filter
 protected lemma continuous_linear_map.has_fderiv_at : has_fderiv_at e e x :=
 e.has_fderiv_at_filter
 
-protected lemma continuous_linear_map.differentiable_at : differentiable_at 𝕜 e x :=
+@[simp] protected lemma continuous_linear_map.differentiable_at : differentiable_at 𝕜 e x :=
 e.has_fderiv_at.differentiable_at
 
 protected lemma continuous_linear_map.differentiable_within_at : differentiable_within_at 𝕜 e s x :=
@@ -765,7 +771,7 @@ begin
   exact e.fderiv
 end
 
-protected lemma continuous_linear_map.differentiable : differentiable 𝕜 e :=
+@[simp]protected lemma continuous_linear_map.differentiable : differentiable 𝕜 e :=
 λx, e.differentiable_at
 
 protected lemma continuous_linear_map.differentiable_on : differentiable_on 𝕜 e s :=
@@ -976,6 +982,7 @@ lemma differentiable_within_at.prod
   differentiable_within_at 𝕜 (λx:E, (f₁ x, f₂ x)) s x :=
 (hf₁.has_fderiv_within_at.prod hf₂.has_fderiv_within_at).differentiable_within_at
 
+@[simp]
 lemma differentiable_at.prod (hf₁ : differentiable_at 𝕜 f₁ x) (hf₂ : differentiable_at 𝕜 f₂ x) :
   differentiable_at 𝕜 (λx:E, (f₁ x, f₂ x)) x :=
 (hf₁.has_fderiv_at.prod hf₂.has_fderiv_at).differentiable_at
@@ -984,6 +991,7 @@ lemma differentiable_on.prod (hf₁ : differentiable_on 𝕜 f₁ s) (hf₂ : di
   differentiable_on 𝕜 (λx:E, (f₁ x, f₂ x)) s :=
 λx hx, differentiable_within_at.prod (hf₁ x hx) (hf₂ x hx)
 
+@[simp]
 lemma differentiable.prod (hf₁ : differentiable 𝕜 f₁) (hf₂ : differentiable 𝕜 f₂) :
   differentiable 𝕜 (λx:E, (f₁ x, f₂ x)) :=
 λ x, differentiable_at.prod (hf₁ x) (hf₂ x)
@@ -1043,14 +1051,14 @@ h.fst
 lemma differentiable_at_fst : differentiable_at 𝕜 prod.fst p :=
 has_fderiv_at_fst.differentiable_at
 
-lemma differentiable_at.fst (h : differentiable_at 𝕜 f₂ x) :
+@[simp] lemma differentiable_at.fst (h : differentiable_at 𝕜 f₂ x) :
   differentiable_at 𝕜 (λ x, (f₂ x).1) x :=
 differentiable_at_fst.comp x h
 
 lemma differentiable_fst : differentiable 𝕜 (prod.fst : E × F → E) :=
 λ x, differentiable_at_fst
 
-lemma differentiable.fst (h : differentiable 𝕜 f₂) : differentiable 𝕜 (λ x, (f₂ x).1) :=
+@[simp] lemma differentiable.fst (h : differentiable 𝕜 f₂) : differentiable 𝕜 (λ x, (f₂ x).1) :=
 differentiable_fst.comp h
 
 lemma differentiable_within_at_fst {s : set (E × F)} : differentiable_within_at 𝕜 prod.fst s p :=
@@ -1120,14 +1128,14 @@ h.snd
 lemma differentiable_at_snd : differentiable_at 𝕜 prod.snd p :=
 has_fderiv_at_snd.differentiable_at
 
-lemma differentiable_at.snd (h : differentiable_at 𝕜 f₂ x) :
+@[simp] lemma differentiable_at.snd (h : differentiable_at 𝕜 f₂ x) :
   differentiable_at 𝕜 (λ x, (f₂ x).2) x :=
 differentiable_at_snd.comp x h
 
 lemma differentiable_snd : differentiable 𝕜 (prod.snd : E × F → F) :=
 λ x, differentiable_at_snd
 
-lemma differentiable.snd (h : differentiable 𝕜 f₂) : differentiable 𝕜 (λ x, (f₂ x).2) :=
+@[simp] lemma differentiable.snd (h : differentiable 𝕜 f₂) : differentiable 𝕜 (λ x, (f₂ x).2) :=
 differentiable_snd.comp h
 
 lemma differentiable_within_at_snd {s : set (E × F)} : differentiable_within_at 𝕜 prod.snd s p :=
@@ -1176,7 +1184,7 @@ theorem has_fderiv_at.prod_map (hf : has_fderiv_at f f' p.1)
   has_fderiv_at (λ p : E × G, (f p.1, f₂ p.2)) (f'.prod_map f₂') p :=
 (hf.comp p has_fderiv_at_fst).prod (hf₂.comp p has_fderiv_at_snd)
 
-theorem differentiable_at.prod_map (hf : differentiable_at 𝕜 f p.1)
+@[simp] theorem differentiable_at.prod_map (hf : differentiable_at 𝕜 f p.1)
   (hf₂ : differentiable_at 𝕜 f₂ p.2) :
   differentiable_at 𝕜 (λ p : E × G, (f p.1, f₂ p.2)) p :=
 (hf.comp p differentiable_at_fst).prod (hf₂.comp p differentiable_at_snd)
@@ -1259,7 +1267,7 @@ lemma differentiable_within_at.add
   differentiable_within_at 𝕜 (λ y, f y + g y) s x :=
 (hf.has_fderiv_within_at.add hg.has_fderiv_within_at).differentiable_within_at
 
-lemma differentiable_at.add
+@[simp] lemma differentiable_at.add
   (hf : differentiable_at 𝕜 f x) (hg : differentiable_at 𝕜 g x) :
   differentiable_at 𝕜 (λ y, f y + g y) x :=
 (hf.has_fderiv_at.add hg.has_fderiv_at).differentiable_at
@@ -1269,7 +1277,7 @@ lemma differentiable_on.add
   differentiable_on 𝕜 (λy, f y + g y) s :=
 λx hx, (hf x hx).add (hg x hx)
 
-lemma differentiable.add
+@[simp] lemma differentiable.add
   (hf : differentiable 𝕜 f) (hg : differentiable 𝕜 g) :
   differentiable 𝕜 (λy, f y + g y) :=
 λx, (hf x).add (hg x)
@@ -1407,7 +1415,7 @@ lemma differentiable_within_at.neg (h : differentiable_within_at 𝕜 f s x) :
   differentiable_within_at 𝕜 (λy, -f y) s x :=
 h.has_fderiv_within_at.neg.differentiable_within_at
 
-lemma differentiable_at.neg (h : differentiable_at 𝕜 f x) :
+@[simp] lemma differentiable_at.neg (h : differentiable_at 𝕜 f x) :
   differentiable_at 𝕜 (λy, -f y) x :=
 h.has_fderiv_at.neg.differentiable_at
 
@@ -1415,7 +1423,7 @@ lemma differentiable_on.neg (h : differentiable_on 𝕜 f s) :
   differentiable_on 𝕜 (λy, -f y) s :=
 λx hx, (h x hx).neg
 
-lemma differentiable.neg (h : differentiable 𝕜 f) :
+@[simp] lemma differentiable.neg (h : differentiable 𝕜 f) :
   differentiable 𝕜 (λy, -f y) :=
 λx, (h x).neg
 
@@ -1458,7 +1466,7 @@ lemma differentiable_within_at.sub
   differentiable_within_at 𝕜 (λ y, f y - g y) s x :=
 (hf.has_fderiv_within_at.sub hg.has_fderiv_within_at).differentiable_within_at
 
-lemma differentiable_at.sub
+@[simp] lemma differentiable_at.sub
   (hf : differentiable_at 𝕜 f x) (hg : differentiable_at 𝕜 g x) :
   differentiable_at 𝕜 (λ y, f y - g y) x :=
 (hf.has_fderiv_at.sub hg.has_fderiv_at).differentiable_at
@@ -1468,7 +1476,7 @@ lemma differentiable_on.sub
   differentiable_on 𝕜 (λy, f y - g y) s :=
 λx hx, (hf x hx).sub (hg x hx)
 
-lemma differentiable.sub
+@[simp] lemma differentiable.sub
   (hf : differentiable 𝕜 f) (hg : differentiable 𝕜 g) :
   differentiable 𝕜 (λy, f y - g y) :=
 λx, (hf x).sub (hg x)
@@ -1695,7 +1703,7 @@ lemma differentiable_within_at.smul
   differentiable_within_at 𝕜 (λ y, c y • f y) s x :=
 (hc.has_fderiv_within_at.smul hf.has_fderiv_within_at).differentiable_within_at
 
-lemma differentiable_at.smul (hc : differentiable_at 𝕜 c x) (hf : differentiable_at 𝕜 f x) :
+@[simp] lemma differentiable_at.smul (hc : differentiable_at 𝕜 c x) (hf : differentiable_at 𝕜 f x) :
   differentiable_at 𝕜 (λ y, c y • f y) x :=
 (hc.has_fderiv_at.smul hf.has_fderiv_at).differentiable_at
 
@@ -1703,7 +1711,7 @@ lemma differentiable_on.smul (hc : differentiable_on 𝕜 c s) (hf : differentia
   differentiable_on 𝕜 (λ y, c y • f y) s :=
 λx hx, (hc x hx).smul (hf x hx)
 
-lemma differentiable.smul (hc : differentiable 𝕜 c) (hf : differentiable 𝕜 f) :
+@[simp] lemma differentiable.smul (hc : differentiable 𝕜 c) (hf : differentiable 𝕜 f) :
   differentiable 𝕜 (λ y, c y • f y) :=
 λx, (hc x).smul (hf x)
 
@@ -1784,7 +1792,7 @@ lemma differentiable_within_at.mul
   differentiable_within_at 𝕜 (λ y, c y * d y) s x :=
 (hc.has_fderiv_within_at.mul hd.has_fderiv_within_at).differentiable_within_at
 
-lemma differentiable_at.mul (hc : differentiable_at 𝕜 c x) (hd : differentiable_at 𝕜 d x) :
+@[simp] lemma differentiable_at.mul (hc : differentiable_at 𝕜 c x) (hd : differentiable_at 𝕜 d x) :
   differentiable_at 𝕜 (λ y, c y * d y) x :=
 (hc.has_fderiv_at.mul hd.has_fderiv_at).differentiable_at
 
@@ -1792,7 +1800,7 @@ lemma differentiable_on.mul (hc : differentiable_on 𝕜 c s) (hd : differentiab
   differentiable_on 𝕜 (λ y, c y * d y) s :=
 λx hx, (hc x hx).mul (hd x hx)
 
-lemma differentiable.mul (hc : differentiable 𝕜 c) (hd : differentiable 𝕜 d) :
+@[simp] lemma differentiable.mul (hc : differentiable 𝕜 c) (hd : differentiable 𝕜 d) :
   differentiable 𝕜 (λ y, c y * d y) :=
 λx, (hc x).mul (hd x)
 

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -54,6 +54,24 @@ a linear function from `𝕜` to `E` with its value at `1`). Results on the Fré
 translated to this more elementary point of view on the derivative in the file `deriv.lean`. The
 derivative of polynomials is handled there, as it is naturally one-dimensional.
 
+The simplifier is set up to prove automatically that some functions are differentiable, or
+differentiable at a point (but not differentiable on a set or within a set at a point, as checking
+automatically that the good domains are mapped one to the other when using composition is not
+something the simplifier can easily do). This means that one can write
+`example (x : ℝ) : differentiable ℝ (λ x, sin (exp (3 + x^2)) - 5 * cos x) := by simp`.
+If there are divisions, one needs to supply to the simplifier proofs that the denominators do
+not vanish, as in
+```lean
+example (x : ℝ) (h : 1 + sin x ≠ 0) : differentiable_at ℝ (λ x, exp x / (1 + sin x)) x :=
+by simp [h]
+```
+Of course, these examples only work once `exp`, `cos` and `sin` have been shown to be
+differentiable, in `analysis.complex.exponential`.
+
+The simplifier is not set up to compute the Fréchet derivative of maps (as these are in general
+complicated multidimensional linear maps), but it will compute one-dimensional derivatives,
+see `deriv.lean`.
+
 ## Implementation details
 
 The derivative is defined in terms of the `is_o` relation, but also
@@ -72,6 +90,18 @@ directions span a dense subset of the whole space. The predicates `unique_diff_w
 they imply the uniqueness of the derivative. This is satisfied for open subsets, and in particular
 for `univ`. This uniqueness only holds when the field is non-discrete, which we request at the very
 beginning: otherwise, a derivative can be defined, but it has no interesting properties whatsoever.
+
+To make sure that the simplifier can prove automatically that functions are differentiable, we tag
+many lemmas with the `simp` attribute, for instance those saying that the sum of differentiable
+functions is differentiable, as well as their product, their cartesian product, and so on. A notable
+exception is the chain rule: we do not mark as a simp lemma the fact that, if `f` and `g` are
+differentiable, then their composition also is: `simp` would always be able to match this lemma,
+by taking `f` or `g` to be the identity. Instead, for every reasonable function (say, `exp`),
+we add a lemma that if `f` is differentiable then so is `(λ x, exp (f x))`. This means adding
+some boilerplate lemmas, but these can also be useful in their own right.
+
+Tests for this ability of the simplifier (with more examples) are provided in
+`tests/differentiable.lean`.
 
 ## Tags
 

--- a/src/analysis/complex/exponential.lean
+++ b/src/analysis/complex/exponential.lean
@@ -77,14 +77,43 @@ differentiable_exp.continuous
 
 end complex
 
-lemma has_deriv_at.cexp {f : ℂ → ℂ} {f' x : ℂ} (hf : has_deriv_at f f' x) :
-  has_deriv_at (complex.exp ∘ f) (complex.exp (f x) * f') x :=
+section
+variables {f : ℂ → ℂ} {f' x : ℂ} {s : set ℂ}
+
+lemma has_deriv_at.cexp (hf : has_deriv_at f f' x) :
+  has_deriv_at (λ x, complex.exp (f x)) (complex.exp (f x) * f') x :=
 (complex.has_deriv_at_exp (f x)).comp x hf
 
-lemma has_deriv_within_at.cexp {f : ℂ → ℂ} {f' x : ℂ} {s : set ℂ}
-  (hf : has_deriv_within_at f f' s x) :
-  has_deriv_within_at (complex.exp ∘ f) (complex.exp (f x) * f') s x :=
+lemma has_deriv_within_at.cexp (hf : has_deriv_within_at f f' s x) :
+  has_deriv_within_at (λ x, complex.exp (f x)) (complex.exp (f x) * f') s x :=
 (complex.has_deriv_at_exp (f x)).comp_has_deriv_within_at x hf
+
+lemma differentiable_within_at.cexp (hf : differentiable_within_at ℂ f s x) :
+  differentiable_within_at ℂ (λ x, complex.exp (f x)) s x :=
+hf.has_deriv_within_at.cexp.differentiable_within_at
+
+@[simp] lemma differentiable_at.cexp (hc : differentiable_at ℂ f x) :
+  differentiable_at ℂ (λx, complex.exp (f x)) x :=
+hc.has_deriv_at.cexp.differentiable_at
+
+lemma differentiable_on.cexp (hc : differentiable_on ℂ f s) :
+  differentiable_on ℂ (λx, complex.exp (f x)) s :=
+λx h, (hc x h).cexp
+
+@[simp] lemma differentiable.cexp (hc : differentiable ℂ f) :
+  differentiable ℂ (λx, complex.exp (f x)) :=
+λx, (hc x).cexp
+
+lemma deriv_within_cexp (hf : differentiable_within_at ℂ f s x)
+  (hxs : unique_diff_within_at ℂ s x) :
+  deriv_within (λx, complex.exp (f x)) s x = complex.exp (f x) * (deriv_within f s x) :=
+hf.has_deriv_within_at.cexp.deriv_within hxs
+
+@[simp] lemma deriv_cexp (hc : differentiable_at ℂ f x) :
+  deriv (λx, complex.exp (f x)) x = complex.exp (f x) * (deriv f x) :=
+hc.has_deriv_at.cexp.deriv
+
+end
 
 namespace complex
 
@@ -170,6 +199,155 @@ differentiable_cosh.continuous
 
 end complex
 
+section
+/-! Register lemmas for the derivatives of the composition of `complex.cos`, `complex.sin`,
+`complex.cosh` and `complex.sinh` with a differentiable function, for standalone use and use with
+`simp`. -/
+
+variables {f : ℂ → ℂ} {f' x : ℂ} {s : set ℂ}
+
+/-! `complex.cos`-/
+
+lemma has_deriv_at.ccos (hf : has_deriv_at f f' x) :
+  has_deriv_at (λ x, complex.cos (f x)) (- complex.sin (f x) * f') x :=
+(complex.has_deriv_at_cos (f x)).comp x hf
+
+lemma has_deriv_within_at.ccos (hf : has_deriv_within_at f f' s x) :
+  has_deriv_within_at (λ x, complex.cos (f x)) (- complex.sin (f x) * f') s x :=
+(complex.has_deriv_at_cos (f x)).comp_has_deriv_within_at x hf
+
+lemma differentiable_within_at.ccos (hf : differentiable_within_at ℂ f s x) :
+  differentiable_within_at ℂ (λ x, complex.cos (f x)) s x :=
+hf.has_deriv_within_at.ccos.differentiable_within_at
+
+@[simp] lemma differentiable_at.ccos (hc : differentiable_at ℂ f x) :
+  differentiable_at ℂ (λx, complex.cos (f x)) x :=
+hc.has_deriv_at.ccos.differentiable_at
+
+lemma differentiable_on.ccos (hc : differentiable_on ℂ f s) :
+  differentiable_on ℂ (λx, complex.cos (f x)) s :=
+λx h, (hc x h).ccos
+
+@[simp] lemma differentiable.ccos (hc : differentiable ℂ f) :
+  differentiable ℂ (λx, complex.cos (f x)) :=
+λx, (hc x).ccos
+
+lemma deriv_within_ccos (hf : differentiable_within_at ℂ f s x)
+  (hxs : unique_diff_within_at ℂ s x) :
+  deriv_within (λx, complex.cos (f x)) s x = - complex.sin (f x) * (deriv_within f s x) :=
+hf.has_deriv_within_at.ccos.deriv_within hxs
+
+@[simp] lemma deriv_ccos (hc : differentiable_at ℂ f x) :
+  deriv (λx, complex.cos (f x)) x = - complex.sin (f x) * (deriv f x) :=
+hc.has_deriv_at.ccos.deriv
+
+/-! `complex.sin`-/
+
+lemma has_deriv_at.csin (hf : has_deriv_at f f' x) :
+  has_deriv_at (λ x, complex.sin (f x)) (complex.cos (f x) * f') x :=
+(complex.has_deriv_at_sin (f x)).comp x hf
+
+lemma has_deriv_within_at.csin (hf : has_deriv_within_at f f' s x) :
+  has_deriv_within_at (λ x, complex.sin (f x)) (complex.cos (f x) * f') s x :=
+(complex.has_deriv_at_sin (f x)).comp_has_deriv_within_at x hf
+
+lemma differentiable_within_at.csin (hf : differentiable_within_at ℂ f s x) :
+  differentiable_within_at ℂ (λ x, complex.sin (f x)) s x :=
+hf.has_deriv_within_at.csin.differentiable_within_at
+
+@[simp] lemma differentiable_at.csin (hc : differentiable_at ℂ f x) :
+  differentiable_at ℂ (λx, complex.sin (f x)) x :=
+hc.has_deriv_at.csin.differentiable_at
+
+lemma differentiable_on.csin (hc : differentiable_on ℂ f s) :
+  differentiable_on ℂ (λx, complex.sin (f x)) s :=
+λx h, (hc x h).csin
+
+@[simp] lemma differentiable.csin (hc : differentiable ℂ f) :
+  differentiable ℂ (λx, complex.sin (f x)) :=
+λx, (hc x).csin
+
+lemma deriv_within_csin (hf : differentiable_within_at ℂ f s x)
+  (hxs : unique_diff_within_at ℂ s x) :
+  deriv_within (λx, complex.sin (f x)) s x = complex.cos (f x) * (deriv_within f s x) :=
+hf.has_deriv_within_at.csin.deriv_within hxs
+
+@[simp] lemma deriv_csin (hc : differentiable_at ℂ f x) :
+  deriv (λx, complex.sin (f x)) x = complex.cos (f x) * (deriv f x) :=
+hc.has_deriv_at.csin.deriv
+
+/-! `complex.cosh`-/
+
+lemma has_deriv_at.ccosh (hf : has_deriv_at f f' x) :
+  has_deriv_at (λ x, complex.cosh (f x)) (complex.sinh (f x) * f') x :=
+(complex.has_deriv_at_cosh (f x)).comp x hf
+
+lemma has_deriv_within_at.ccosh (hf : has_deriv_within_at f f' s x) :
+  has_deriv_within_at (λ x, complex.cosh (f x)) (complex.sinh (f x) * f') s x :=
+(complex.has_deriv_at_cosh (f x)).comp_has_deriv_within_at x hf
+
+lemma differentiable_within_at.ccosh (hf : differentiable_within_at ℂ f s x) :
+  differentiable_within_at ℂ (λ x, complex.cosh (f x)) s x :=
+hf.has_deriv_within_at.ccosh.differentiable_within_at
+
+@[simp] lemma differentiable_at.ccosh (hc : differentiable_at ℂ f x) :
+  differentiable_at ℂ (λx, complex.cosh (f x)) x :=
+hc.has_deriv_at.ccosh.differentiable_at
+
+lemma differentiable_on.ccosh (hc : differentiable_on ℂ f s) :
+  differentiable_on ℂ (λx, complex.cosh (f x)) s :=
+λx h, (hc x h).ccosh
+
+@[simp] lemma differentiable.ccosh (hc : differentiable ℂ f) :
+  differentiable ℂ (λx, complex.cosh (f x)) :=
+λx, (hc x).ccosh
+
+lemma deriv_within_ccosh (hf : differentiable_within_at ℂ f s x)
+  (hxs : unique_diff_within_at ℂ s x) :
+  deriv_within (λx, complex.cosh (f x)) s x = complex.sinh (f x) * (deriv_within f s x) :=
+hf.has_deriv_within_at.ccosh.deriv_within hxs
+
+@[simp] lemma deriv_ccosh (hc : differentiable_at ℂ f x) :
+  deriv (λx, complex.cosh (f x)) x = complex.sinh (f x) * (deriv f x) :=
+hc.has_deriv_at.ccosh.deriv
+
+/-! `complex.sinh`-/
+
+lemma has_deriv_at.csinh (hf : has_deriv_at f f' x) :
+  has_deriv_at (λ x, complex.sinh (f x)) (complex.cosh (f x) * f') x :=
+(complex.has_deriv_at_sinh (f x)).comp x hf
+
+lemma has_deriv_within_at.csinh (hf : has_deriv_within_at f f' s x) :
+  has_deriv_within_at (λ x, complex.sinh (f x)) (complex.cosh (f x) * f') s x :=
+(complex.has_deriv_at_sinh (f x)).comp_has_deriv_within_at x hf
+
+lemma differentiable_within_at.csinh (hf : differentiable_within_at ℂ f s x) :
+  differentiable_within_at ℂ (λ x, complex.sinh (f x)) s x :=
+hf.has_deriv_within_at.csinh.differentiable_within_at
+
+@[simp] lemma differentiable_at.csinh (hc : differentiable_at ℂ f x) :
+  differentiable_at ℂ (λx, complex.sinh (f x)) x :=
+hc.has_deriv_at.csinh.differentiable_at
+
+lemma differentiable_on.csinh (hc : differentiable_on ℂ f s) :
+  differentiable_on ℂ (λx, complex.sinh (f x)) s :=
+λx h, (hc x h).csinh
+
+@[simp] lemma differentiable.csinh (hc : differentiable ℂ f) :
+  differentiable ℂ (λx, complex.sinh (f x)) :=
+λx, (hc x).csinh
+
+lemma deriv_within_csinh (hf : differentiable_within_at ℂ f s x)
+  (hxs : unique_diff_within_at ℂ s x) :
+  deriv_within (λx, complex.sinh (f x)) s x = complex.cosh (f x) * (deriv_within f s x) :=
+hf.has_deriv_within_at.csinh.deriv_within hxs
+
+@[simp] lemma deriv_csinh (hc : differentiable_at ℂ f x) :
+  deriv (λx, complex.sinh (f x)) x = complex.cosh (f x) * (deriv f x) :=
+hc.has_deriv_at.csinh.deriv
+
+end
+
 namespace real
 
 variables {x y z : ℝ}
@@ -246,6 +424,162 @@ funext $ λ x, (has_deriv_at_cosh x).deriv
 
 lemma continuous_cosh : continuous cosh :=
 differentiable_cosh.continuous
+
+end real
+
+
+section
+/-! Register lemmas for the derivatives of the composition of `real.cos`, `real.sin`,
+`real.cosh` and `real.sinh` with a differentiable function, for standalone use and use with
+`simp`. -/
+
+variables {f : ℝ → ℝ} {f' x : ℝ} {s : set ℝ}
+
+/-! `real.cos`-/
+
+lemma has_deriv_at.cos (hf : has_deriv_at f f' x) :
+  has_deriv_at (λ x, real.cos (f x)) (- real.sin (f x) * f') x :=
+(real.has_deriv_at_cos (f x)).comp x hf
+
+lemma has_deriv_within_at.cos (hf : has_deriv_within_at f f' s x) :
+  has_deriv_within_at (λ x, real.cos (f x)) (- real.sin (f x) * f') s x :=
+(real.has_deriv_at_cos (f x)).comp_has_deriv_within_at x hf
+
+lemma differentiable_within_at.cos (hf : differentiable_within_at ℝ f s x) :
+  differentiable_within_at ℝ (λ x, real.cos (f x)) s x :=
+hf.has_deriv_within_at.cos.differentiable_within_at
+
+@[simp] lemma differentiable_at.cos (hc : differentiable_at ℝ f x) :
+  differentiable_at ℝ (λx, real.cos (f x)) x :=
+hc.has_deriv_at.cos.differentiable_at
+
+lemma differentiable_on.cos (hc : differentiable_on ℝ f s) :
+  differentiable_on ℝ (λx, real.cos (f x)) s :=
+λx h, (hc x h).cos
+
+@[simp] lemma differentiable.cos (hc : differentiable ℝ f) :
+  differentiable ℝ (λx, real.cos (f x)) :=
+λx, (hc x).cos
+
+lemma deriv_within_cos (hf : differentiable_within_at ℝ f s x)
+  (hxs : unique_diff_within_at ℝ s x) :
+  deriv_within (λx, real.cos (f x)) s x = - real.sin (f x) * (deriv_within f s x) :=
+hf.has_deriv_within_at.cos.deriv_within hxs
+
+@[simp] lemma deriv_cos (hc : differentiable_at ℝ f x) :
+  deriv (λx, real.cos (f x)) x = - real.sin (f x) * (deriv f x) :=
+hc.has_deriv_at.cos.deriv
+
+/-! `real.sin`-/
+
+lemma has_deriv_at.sin (hf : has_deriv_at f f' x) :
+  has_deriv_at (λ x, real.sin (f x)) (real.cos (f x) * f') x :=
+(real.has_deriv_at_sin (f x)).comp x hf
+
+lemma has_deriv_within_at.sin (hf : has_deriv_within_at f f' s x) :
+  has_deriv_within_at (λ x, real.sin (f x)) (real.cos (f x) * f') s x :=
+(real.has_deriv_at_sin (f x)).comp_has_deriv_within_at x hf
+
+lemma differentiable_within_at.sin (hf : differentiable_within_at ℝ f s x) :
+  differentiable_within_at ℝ (λ x, real.sin (f x)) s x :=
+hf.has_deriv_within_at.sin.differentiable_within_at
+
+@[simp] lemma differentiable_at.sin (hc : differentiable_at ℝ f x) :
+  differentiable_at ℝ (λx, real.sin (f x)) x :=
+hc.has_deriv_at.sin.differentiable_at
+
+lemma differentiable_on.sin (hc : differentiable_on ℝ f s) :
+  differentiable_on ℝ (λx, real.sin (f x)) s :=
+λx h, (hc x h).sin
+
+@[simp] lemma differentiable.sin (hc : differentiable ℝ f) :
+  differentiable ℝ (λx, real.sin (f x)) :=
+λx, (hc x).sin
+
+lemma deriv_within_sin (hf : differentiable_within_at ℝ f s x)
+  (hxs : unique_diff_within_at ℝ s x) :
+  deriv_within (λx, real.sin (f x)) s x = real.cos (f x) * (deriv_within f s x) :=
+hf.has_deriv_within_at.sin.deriv_within hxs
+
+@[simp] lemma deriv_sin (hc : differentiable_at ℝ f x) :
+  deriv (λx, real.sin (f x)) x = real.cos (f x) * (deriv f x) :=
+hc.has_deriv_at.sin.deriv
+
+/-! `real.cosh`-/
+
+lemma has_deriv_at.cosh (hf : has_deriv_at f f' x) :
+  has_deriv_at (λ x, real.cosh (f x)) (real.sinh (f x) * f') x :=
+(real.has_deriv_at_cosh (f x)).comp x hf
+
+lemma has_deriv_within_at.cosh (hf : has_deriv_within_at f f' s x) :
+  has_deriv_within_at (λ x, real.cosh (f x)) (real.sinh (f x) * f') s x :=
+(real.has_deriv_at_cosh (f x)).comp_has_deriv_within_at x hf
+
+lemma differentiable_within_at.cosh (hf : differentiable_within_at ℝ f s x) :
+  differentiable_within_at ℝ (λ x, real.cosh (f x)) s x :=
+hf.has_deriv_within_at.cosh.differentiable_within_at
+
+@[simp] lemma differentiable_at.cosh (hc : differentiable_at ℝ f x) :
+  differentiable_at ℝ (λx, real.cosh (f x)) x :=
+hc.has_deriv_at.cosh.differentiable_at
+
+lemma differentiable_on.cosh (hc : differentiable_on ℝ f s) :
+  differentiable_on ℝ (λx, real.cosh (f x)) s :=
+λx h, (hc x h).cosh
+
+@[simp] lemma differentiable.cosh (hc : differentiable ℝ f) :
+  differentiable ℝ (λx, real.cosh (f x)) :=
+λx, (hc x).cosh
+
+lemma deriv_within_cosh (hf : differentiable_within_at ℝ f s x)
+  (hxs : unique_diff_within_at ℝ s x) :
+  deriv_within (λx, real.cosh (f x)) s x = real.sinh (f x) * (deriv_within f s x) :=
+hf.has_deriv_within_at.cosh.deriv_within hxs
+
+@[simp] lemma deriv_cosh (hc : differentiable_at ℝ f x) :
+  deriv (λx, real.cosh (f x)) x = real.sinh (f x) * (deriv f x) :=
+hc.has_deriv_at.cosh.deriv
+
+/-! `real.sinh`-/
+
+lemma has_deriv_at.sinh (hf : has_deriv_at f f' x) :
+  has_deriv_at (λ x, real.sinh (f x)) (real.cosh (f x) * f') x :=
+(real.has_deriv_at_sinh (f x)).comp x hf
+
+lemma has_deriv_within_at.sinh (hf : has_deriv_within_at f f' s x) :
+  has_deriv_within_at (λ x, real.sinh (f x)) (real.cosh (f x) * f') s x :=
+(real.has_deriv_at_sinh (f x)).comp_has_deriv_within_at x hf
+
+lemma differentiable_within_at.sinh (hf : differentiable_within_at ℝ f s x) :
+  differentiable_within_at ℝ (λ x, real.sinh (f x)) s x :=
+hf.has_deriv_within_at.sinh.differentiable_within_at
+
+@[simp] lemma differentiable_at.sinh (hc : differentiable_at ℝ f x) :
+  differentiable_at ℝ (λx, real.sinh (f x)) x :=
+hc.has_deriv_at.sinh.differentiable_at
+
+lemma differentiable_on.sinh (hc : differentiable_on ℝ f s) :
+  differentiable_on ℝ (λx, real.sinh (f x)) s :=
+λx h, (hc x h).sinh
+
+@[simp] lemma differentiable.sinh (hc : differentiable ℝ f) :
+  differentiable ℝ (λx, real.sinh (f x)) :=
+λx, (hc x).sinh
+
+lemma deriv_within_sinh (hf : differentiable_within_at ℝ f s x)
+  (hxs : unique_diff_within_at ℝ s x) :
+  deriv_within (λx, real.sinh (f x)) s x = real.cosh (f x) * (deriv_within f s x) :=
+hf.has_deriv_within_at.sinh.deriv_within hxs
+
+@[simp] lemma deriv_sinh (hc : differentiable_at ℝ f x) :
+  deriv (λx, real.sinh (f x)) x = real.cosh (f x) * (deriv f x) :=
+hc.has_deriv_at.sinh.deriv
+
+end
+
+namespace real
+
+variables {x y z : ℝ}
 
 lemma exists_exp_eq_of_pos {x : ℝ} (hx : 0 < x) : ∃ y, exp y = x :=
 have ∀ {z:ℝ}, 1 ≤ z → z ∈ set.range exp,

--- a/src/analysis/complex/exponential.lean
+++ b/src/analysis/complex/exponential.lean
@@ -62,10 +62,10 @@ begin
       mul_le_mul_of_nonneg_left (abs_exp_sub_one_sub_id_le (le_of_lt hz)) (norm_nonneg _)
 end
 
-@[simp] lemma differentiable_exp : differentiable ℂ exp :=
+lemma differentiable_exp : differentiable ℂ exp :=
 λx, (has_deriv_at_exp x).differentiable_at
 
-@[simp] lemma differentiable_at_exp {x : ℂ} : differentiable_at ℂ exp x :=
+lemma differentiable_at_exp {x : ℂ} : differentiable_at ℂ exp x :=
 differentiable_exp x
 
 @[simp] lemma deriv_exp : deriv exp = exp :=
@@ -131,10 +131,10 @@ begin
       I_mul_I, mul_neg_one, sub_neg_eq_add, add_comm]
 end
 
-@[simp] lemma differentiable_sin : differentiable ℂ sin :=
+lemma differentiable_sin : differentiable ℂ sin :=
 λx, (has_deriv_at_sin x).differentiable_at
 
-@[simp] lemma differentiable_at_sin {x : ℂ} : differentiable_at ℂ sin x :=
+lemma differentiable_at_sin {x : ℂ} : differentiable_at ℂ sin x :=
 differentiable_sin x
 
 @[simp] lemma deriv_sin : deriv sin = cos :=
@@ -153,10 +153,10 @@ begin
   ring
 end
 
-@[simp] lemma differentiable_cos : differentiable ℂ cos :=
+lemma differentiable_cos : differentiable ℂ cos :=
 λx, (has_deriv_at_cos x).differentiable_at
 
-@[simp] lemma differentiable_at_cos {x : ℂ} : differentiable_at ℂ cos x :=
+lemma differentiable_at_cos {x : ℂ} : differentiable_at ℂ cos x :=
 differentiable_cos x
 
 lemma deriv_cos {x : ℂ} : deriv cos x = -sin x :=
@@ -180,10 +180,10 @@ begin
   rw [id, mul_neg_one, neg_neg]
 end
 
-@[simp] lemma differentiable_sinh : differentiable ℂ sinh :=
+lemma differentiable_sinh : differentiable ℂ sinh :=
 λx, (has_deriv_at_sinh x).differentiable_at
 
-@[simp] lemma differentiable_at_sinh {x : ℂ} : differentiable_at ℂ sinh x :=
+lemma differentiable_at_sinh {x : ℂ} : differentiable_at ℂ sinh x :=
 differentiable_sinh x
 
 @[simp] lemma deriv_sinh : deriv sinh = cosh :=
@@ -200,10 +200,10 @@ begin
   rw [id, mul_neg_one, sub_eq_add_neg]
 end
 
-@[simp] lemma differentiable_cosh : differentiable ℂ cosh :=
+lemma differentiable_cosh : differentiable ℂ cosh :=
 λx, (has_deriv_at_cosh x).differentiable_at
 
-@[simp] lemma differentiable_at_cosh {x : ℂ} : differentiable_at ℂ cos x :=
+lemma differentiable_at_cosh {x : ℂ} : differentiable_at ℂ cos x :=
 differentiable_cos x
 
 @[simp] lemma deriv_cosh : deriv cosh = sinh :=
@@ -370,10 +370,10 @@ variables {x y z : ℝ}
 lemma has_deriv_at_exp (x : ℝ) : has_deriv_at exp (exp x) x :=
 has_deriv_at_real_of_complex (complex.has_deriv_at_exp x)
 
-@[simp] lemma differentiable_exp : differentiable ℝ exp :=
+lemma differentiable_exp : differentiable ℝ exp :=
 λx, (has_deriv_at_exp x).differentiable_at
 
-@[simp] lemma differentiable_at_exp : differentiable_at ℝ exp x :=
+lemma differentiable_at_exp : differentiable_at ℝ exp x :=
 differentiable_exp x
 
 @[simp] lemma deriv_exp : deriv exp = exp :=
@@ -389,10 +389,10 @@ differentiable_exp.continuous
 lemma has_deriv_at_sin (x : ℝ) : has_deriv_at sin (cos x) x :=
 has_deriv_at_real_of_complex (complex.has_deriv_at_sin x)
 
-@[simp] lemma differentiable_sin : differentiable ℝ sin :=
+lemma differentiable_sin : differentiable ℝ sin :=
 λx, (has_deriv_at_sin x).differentiable_at
 
-@[simp] lemma differentiable_at_sin : differentiable_at ℝ sin x :=
+lemma differentiable_at_sin : differentiable_at ℝ sin x :=
 differentiable_sin x
 
 @[simp] lemma deriv_sin : deriv sin = cos :=
@@ -404,10 +404,10 @@ differentiable_sin.continuous
 lemma has_deriv_at_cos (x : ℝ) : has_deriv_at cos (-sin x) x :=
 (has_deriv_at_real_of_complex (complex.has_deriv_at_cos x) : _)
 
-@[simp] lemma differentiable_cos : differentiable ℝ cos :=
+lemma differentiable_cos : differentiable ℝ cos :=
 λx, (has_deriv_at_cos x).differentiable_at
 
-@[simp] lemma differentiable_at_cos : differentiable_at ℝ cos x :=
+lemma differentiable_at_cos : differentiable_at ℝ cos x :=
 differentiable_cos x
 
 lemma deriv_cos : deriv cos x = - sin x :=
@@ -428,10 +428,10 @@ by simp only [tan_eq_sin_div_cos]; exact
 lemma has_deriv_at_sinh (x : ℝ) : has_deriv_at sinh (cosh x) x :=
 has_deriv_at_real_of_complex (complex.has_deriv_at_sinh x)
 
-@[simp] lemma differentiable_sinh : differentiable ℝ sinh :=
+lemma differentiable_sinh : differentiable ℝ sinh :=
 λx, (has_deriv_at_sinh x).differentiable_at
 
-@[simp] lemma differentiable_at_sinh : differentiable_at ℝ sinh x :=
+lemma differentiable_at_sinh : differentiable_at ℝ sinh x :=
 differentiable_sinh x
 
 @[simp] lemma deriv_sinh : deriv sinh = cosh :=
@@ -443,10 +443,10 @@ differentiable_sinh.continuous
 lemma has_deriv_at_cosh (x : ℝ) : has_deriv_at cosh (sinh x) x :=
 has_deriv_at_real_of_complex (complex.has_deriv_at_cosh x)
 
-@[simp] lemma differentiable_cosh : differentiable ℝ cosh :=
+lemma differentiable_cosh : differentiable ℝ cosh :=
 λx, (has_deriv_at_cosh x).differentiable_at
 
-@[simp] lemma differentiable_at_cosh : differentiable_at ℝ cosh x :=
+lemma differentiable_at_cosh : differentiable_at ℝ cosh x :=
 differentiable_cosh x
 
 @[simp] lemma deriv_cosh : deriv cosh = sinh :=

--- a/src/analysis/complex/exponential.lean
+++ b/src/analysis/complex/exponential.lean
@@ -62,8 +62,11 @@ begin
       mul_le_mul_of_nonneg_left (abs_exp_sub_one_sub_id_le (le_of_lt hz)) (norm_nonneg _)
 end
 
-lemma differentiable_exp : differentiable ℂ exp :=
+@[simp] lemma differentiable_exp : differentiable ℂ exp :=
 λx, (has_deriv_at_exp x).differentiable_at
+
+@[simp] lemma differentiable_at_exp {x : ℂ} : differentiable_at ℂ exp x :=
+differentiable_exp x
 
 @[simp] lemma deriv_exp : deriv exp = exp :=
 funext $ λ x, (has_deriv_at_exp x).deriv
@@ -128,8 +131,11 @@ begin
       I_mul_I, mul_neg_one, sub_neg_eq_add, add_comm]
 end
 
-lemma differentiable_sin : differentiable ℂ sin :=
+@[simp] lemma differentiable_sin : differentiable ℂ sin :=
 λx, (has_deriv_at_sin x).differentiable_at
+
+@[simp] lemma differentiable_at_sin {x : ℂ} : differentiable_at ℂ sin x :=
+differentiable_sin x
 
 @[simp] lemma deriv_sin : deriv sin = cos :=
 funext $ λ x, (has_deriv_at_sin x).deriv
@@ -147,8 +153,11 @@ begin
   ring
 end
 
-lemma differentiable_cos : differentiable ℂ cos :=
+@[simp] lemma differentiable_cos : differentiable ℂ cos :=
 λx, (has_deriv_at_cos x).differentiable_at
+
+@[simp] lemma differentiable_at_cos {x : ℂ} : differentiable_at ℂ cos x :=
+differentiable_cos x
 
 lemma deriv_cos {x : ℂ} : deriv cos x = -sin x :=
 (has_deriv_at_cos x).deriv
@@ -171,8 +180,11 @@ begin
   rw [id, mul_neg_one, neg_neg]
 end
 
-lemma differentiable_sinh : differentiable ℂ sinh :=
+@[simp] lemma differentiable_sinh : differentiable ℂ sinh :=
 λx, (has_deriv_at_sinh x).differentiable_at
+
+@[simp] lemma differentiable_at_sinh {x : ℂ} : differentiable_at ℂ sinh x :=
+differentiable_sinh x
 
 @[simp] lemma deriv_sinh : deriv sinh = cosh :=
 funext $ λ x, (has_deriv_at_sinh x).deriv
@@ -188,8 +200,11 @@ begin
   rw [id, mul_neg_one, sub_eq_add_neg]
 end
 
-lemma differentiable_cosh : differentiable ℂ cosh :=
+@[simp] lemma differentiable_cosh : differentiable ℂ cosh :=
 λx, (has_deriv_at_cosh x).differentiable_at
+
+@[simp] lemma differentiable_at_cosh {x : ℂ} : differentiable_at ℂ cos x :=
+differentiable_cos x
 
 @[simp] lemma deriv_cosh : deriv cosh = sinh :=
 funext $ λ x, (has_deriv_at_cosh x).deriv
@@ -355,8 +370,11 @@ variables {x y z : ℝ}
 lemma has_deriv_at_exp (x : ℝ) : has_deriv_at exp (exp x) x :=
 has_deriv_at_real_of_complex (complex.has_deriv_at_exp x)
 
-lemma differentiable_exp : differentiable ℝ exp :=
+@[simp] lemma differentiable_exp : differentiable ℝ exp :=
 λx, (has_deriv_at_exp x).differentiable_at
+
+@[simp] lemma differentiable_at_exp : differentiable_at ℝ exp x :=
+differentiable_exp x
 
 @[simp] lemma deriv_exp : deriv exp = exp :=
 funext $ λ x, (has_deriv_at_exp x).deriv
@@ -371,8 +389,11 @@ differentiable_exp.continuous
 lemma has_deriv_at_sin (x : ℝ) : has_deriv_at sin (cos x) x :=
 has_deriv_at_real_of_complex (complex.has_deriv_at_sin x)
 
-lemma differentiable_sin : differentiable ℝ sin :=
+@[simp] lemma differentiable_sin : differentiable ℝ sin :=
 λx, (has_deriv_at_sin x).differentiable_at
+
+@[simp] lemma differentiable_at_sin : differentiable_at ℝ sin x :=
+differentiable_sin x
 
 @[simp] lemma deriv_sin : deriv sin = cos :=
 funext $ λ x, (has_deriv_at_sin x).deriv
@@ -383,8 +404,11 @@ differentiable_sin.continuous
 lemma has_deriv_at_cos (x : ℝ) : has_deriv_at cos (-sin x) x :=
 (has_deriv_at_real_of_complex (complex.has_deriv_at_cos x) : _)
 
-lemma differentiable_cos : differentiable ℝ cos :=
+@[simp] lemma differentiable_cos : differentiable ℝ cos :=
 λx, (has_deriv_at_cos x).differentiable_at
+
+@[simp] lemma differentiable_at_cos : differentiable_at ℝ cos x :=
+differentiable_cos x
 
 lemma deriv_cos : deriv cos x = - sin x :=
 (has_deriv_at_cos x).deriv
@@ -404,8 +428,11 @@ by simp only [tan_eq_sin_div_cos]; exact
 lemma has_deriv_at_sinh (x : ℝ) : has_deriv_at sinh (cosh x) x :=
 has_deriv_at_real_of_complex (complex.has_deriv_at_sinh x)
 
-lemma differentiable_sinh : differentiable ℝ sinh :=
+@[simp] lemma differentiable_sinh : differentiable ℝ sinh :=
 λx, (has_deriv_at_sinh x).differentiable_at
+
+@[simp] lemma differentiable_at_sinh : differentiable_at ℝ sinh x :=
+differentiable_sinh x
 
 @[simp] lemma deriv_sinh : deriv sinh = cosh :=
 funext $ λ x, (has_deriv_at_sinh x).deriv
@@ -416,8 +443,11 @@ differentiable_sinh.continuous
 lemma has_deriv_at_cosh (x : ℝ) : has_deriv_at cosh (sinh x) x :=
 has_deriv_at_real_of_complex (complex.has_deriv_at_cosh x)
 
-lemma differentiable_cosh : differentiable ℝ cosh :=
+@[simp] lemma differentiable_cosh : differentiable ℝ cosh :=
 λx, (has_deriv_at_cosh x).differentiable_at
+
+@[simp] lemma differentiable_at_cosh : differentiable_at ℝ cosh x :=
+differentiable_cosh x
 
 @[simp] lemma deriv_cosh : deriv cosh = sinh :=
 funext $ λ x, (has_deriv_at_cosh x).deriv
@@ -429,11 +459,46 @@ end real
 
 
 section
-/-! Register lemmas for the derivatives of the composition of `real.cos`, `real.sin`,
+/-! Register lemmas for the derivatives of the composition of `real.exp`, `real.cos`, `real.sin`,
 `real.cosh` and `real.sinh` with a differentiable function, for standalone use and use with
 `simp`. -/
 
 variables {f : ℝ → ℝ} {f' x : ℝ} {s : set ℝ}
+
+/-! `real.exp`-/
+
+lemma has_deriv_at.exp (hf : has_deriv_at f f' x) :
+  has_deriv_at (λ x, real.exp (f x)) (real.exp (f x) * f') x :=
+(real.has_deriv_at_exp (f x)).comp x hf
+
+lemma has_deriv_within_at.exp (hf : has_deriv_within_at f f' s x) :
+  has_deriv_within_at (λ x, real.exp (f x)) (real.exp (f x) * f') s x :=
+(real.has_deriv_at_exp (f x)).comp_has_deriv_within_at x hf
+
+lemma differentiable_within_at.exp (hf : differentiable_within_at ℝ f s x) :
+  differentiable_within_at ℝ (λ x, real.exp (f x)) s x :=
+hf.has_deriv_within_at.exp.differentiable_within_at
+
+@[simp] lemma differentiable_at.exp (hc : differentiable_at ℝ f x) :
+  differentiable_at ℝ (λx, real.exp (f x)) x :=
+hc.has_deriv_at.exp.differentiable_at
+
+lemma differentiable_on.exp (hc : differentiable_on ℝ f s) :
+  differentiable_on ℝ (λx, real.exp (f x)) s :=
+λx h, (hc x h).exp
+
+@[simp] lemma differentiable.exp (hc : differentiable ℝ f) :
+  differentiable ℝ (λx, real.exp (f x)) :=
+λx, (hc x).exp
+
+lemma deriv_within_exp (hf : differentiable_within_at ℝ f s x)
+  (hxs : unique_diff_within_at ℝ s x) :
+  deriv_within (λx, real.exp (f x)) s x = real.exp (f x) * (deriv_within f s x) :=
+hf.has_deriv_within_at.exp.deriv_within hxs
+
+@[simp] lemma deriv_exp (hc : differentiable_at ℝ f x) :
+  deriv (λx, real.exp (f x)) x = real.exp (f x) * (deriv f x) :=
+hc.has_deriv_at.exp.deriv
 
 /-! `real.cos`-/
 

--- a/src/analysis/convex/specific_functions.lean
+++ b/src/analysis/convex/specific_functions.lean
@@ -25,8 +25,7 @@ open real set
 
 /-- `exp` is convex on the whole real line -/
 lemma convex_on_exp : convex_on univ exp :=
-convex_on_univ_of_deriv2_nonneg differentiable_exp
-  (deriv_exp.symm ▸ differentiable_exp)
+convex_on_univ_of_deriv2_nonneg differentiable_exp (by simp)
   (assume x, (iter_deriv_exp 2).symm ▸ le_of_lt (exp_pos x))
 
 /-- `x^n`, `n : ℕ` is convex on the whole real line whenever `n` is even -/

--- a/test/differentiable.lean
+++ b/test/differentiable.lean
@@ -1,0 +1,17 @@
+import analysis.complex.exponential
+
+section
+open real
+
+example : differentiable ℝ (λ (x : ℝ), exp x) :=
+begin
+  simp
+end
+
+example : differentiable ℝ (λ (x : ℝ), exp (x^2)) :=
+begin
+  simp,
+end
+
+
+end

--- a/test/differentiable.lean
+++ b/test/differentiable.lean
@@ -1,17 +1,61 @@
 import analysis.complex.exponential
 
-section
-open real
+namespace real
 
 example : differentiable ℝ (λ (x : ℝ), exp x) :=
-begin
-  simp
-end
+by simp
 
-example : differentiable ℝ (λ (x : ℝ), exp (x^2)) :=
-begin
-  simp,
-end
+example : differentiable ℝ (λ (x : ℝ), exp ((sin x)^2) - exp (exp (cos (x - 3)))) :=
+by simp
+
+example (x : ℝ) : deriv (λ (x : ℝ), (cos x)^2 + (sin x)^2) x = 0 :=
+by { simp, ring }
+
+example (x : ℝ) : deriv (λ (x : ℝ), (1+x)^3 - x^3 - 3 * x^2 - 3 * x - 4) x = 0 :=
+by { simp, ring }
+
+example (x : ℝ) : deriv (λ x, cos (sin x) * exp x) x = (cos(sin(x))-sin(sin(x))*cos(x))*exp(x) :=
+by { simp, ring }
+
+example (x : ℝ) : differentiable_at ℝ (λ x, (cos x, x)) x := by simp
+
+example (x : ℝ) (h : 1 + sin x ≠ 0) : deriv (λ x, exp (cos x) / (1 + sin x)) x =
+  (-(exp (cos x) * sin x * (1 + sin x)) - exp (cos x) * cos x) / (1 + sin x) ^ 2 :=
+by simp [h]
+
+example (x : ℝ) : differentiable_at ℝ (λ x, (sin x) / (exp x)) x :=
+by simp [exp_ne_zero]
+
+example : differentiable ℝ (λ x, (sin x) / (exp x)) :=
+by simp [exp_ne_zero]
+
+end real
 
 
-end
+namespace complex
+
+example : differentiable ℂ  (λ (x : ℂ), exp x) :=
+by simp
+
+example : differentiable ℂ (λ (x : ℂ), exp ((sin x)^2) - exp (exp (cos (x - 3)))) :=
+by simp
+
+example (x : ℂ) : deriv (λ (x : ℂ), (cos x)^2 + (sin x)^2) x = 0 :=
+by { simp, ring }
+
+example (x : ℂ) : deriv (λ x, cos (sin x) * exp x) x = (cos(sin(x))-sin(sin(x))*cos(x))*exp(x) :=
+by { simp, ring }
+
+example (x : ℂ) : differentiable_at ℂ (λ x, (cos x, x)) x := by simp
+
+example (x : ℂ) (h : 1 + sin x ≠ 0) : deriv (λ x, exp (cos x) / (1 + sin x)) x =
+  (-(exp (cos x) * sin x * (1 + sin x)) - exp (cos x) * cos x) / (1 + sin x) ^ 2 :=
+by simp [h]
+
+example (x : ℂ) : differentiable_at ℂ (λ x, (sin x) / (exp x)) x :=
+by simp [exp_ne_zero]
+
+example : differentiable ℂ (λ x, (sin x) / (exp x)) :=
+by simp [exp_ne_zero]
+
+end complex


### PR DESCRIPTION
After this PR:
```lean
example (x : ℝ) : deriv (λ x, cos (sin x) * exp x) x = (cos(sin(x))-sin(sin(x))*cos(x))*exp(x) :=
by { simp, ring }
```

Excerpts from the docstrings:

The simplifier is set up to prove automatically that some functions are differentiable, or differentiable at a point (but not differentiable on a set or within a set at a point, as checking automatically that the good domains are mapped one to the other when using composition is not something the simplifier can easily do). This means that one can write
`example (x : ℝ) : differentiable ℝ (λ x, sin (exp (3 + x^2)) - 5 * cos x) := by simp`.
If there are divisions, one needs to supply to the simplifier proofs that the denominators do not vanish, as in
```lean
example (x : ℝ) (h : 1 + sin x ≠ 0) : differentiable_at ℝ (λ x, exp x / (1 + sin x)) x :=
by simp [h]
```
The simplifier is not set up to compute the Fréchet derivative of maps (as these are in general complicated multidimensional linear maps), but it will compute one-dimensional derivatives.

To make sure that the simplifier can prove automatically that functions are differentiable, we tag many lemmas with the `simp` attribute, for instance those saying that the sum of differentiable functions is differentiable, as well as their product, their cartesian product, and so on. A notable exception is the chain rule: we do not mark as a simp lemma the fact that, if `f` and `g` are differentiable, then their composition also is: `simp` would always be able to match this lemma, by taking `f` or `g` to be the identity. Instead, for every reasonable function (say, `exp`), we add a lemma that if `f` is differentiable then so is `(λ x, exp (f x))`. This means adding some boilerplate lemmas, but these can also be useful in their own right. 

Tests for this ability of the simplifier (with more examples) are provided in `tests/differentiable.lean`.

TO CONTRIBUTORS:

Just like #2419, but from a branch on `leanprover-community`.

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
