### PR TITLE
[Merged by Bors] - feat(category_theory/limits): special shapes API cleanup

### DIFF
--- a/src/algebra/category/Module/basic.lean
+++ b/src/algebra/category/Module/basic.lean
@@ -157,8 +157,8 @@ def kernel_is_limit : is_limit (kernel_cone f) :=
   begin
     rw [coe_comp, function.comp_app, ←linear_map.comp_apply],
     cases j,
-    { erw @linear_map.subtype_comp_cod_restrict _ _ _ _ _ _ _ _ (fork.ι s) f.ker _, refl },
-    { rw [←cone_parallel_pair_right, ←cone_parallel_pair_right], refl }
+    { erw @linear_map.subtype_comp_cod_restrict _ _ _ _ _ _ _ _ (fork.ι s) f.ker _ },
+    { rw [←fork.app_zero_left, ←fork.app_zero_left], refl }
   end,
   uniq' := λ s m h, linear_map.ext $ λ x, subtype.ext.2 $
     have h₁ : (m ≫ (kernel_cone f).π.app zero).to_fun = (s.π.app zero).to_fun,

--- a/src/category_theory/limits/shapes/binary_products.lean
+++ b/src/category_theory/limits/shapes/binary_products.lean
@@ -242,7 +242,7 @@ variables (C)
 class has_binary_products :=
 (has_limits_of_shape : has_limits_of_shape.{v} (discrete walking_pair) C)
 
-/-- `has_binary_coproduct` represents a choice of coproduct for every pair of objects. -/
+/-- `has_binary_coproducts` represents a choice of coproduct for every pair of objects. -/
 class has_binary_coproducts :=
 (has_colimits_of_shape : has_colimits_of_shape.{v} (discrete walking_pair) C)
 

--- a/src/category_theory/limits/shapes/binary_products.lean
+++ b/src/category_theory/limits/shapes/binary_products.lean
@@ -130,6 +130,20 @@ def binary_cofan.mk {P : C} (ι₁ : X ⟶ P) (ι₂ : Y ⟶ P) : binary_cofan X
 @[simp] lemma binary_cofan.mk_ι_app_right {P : C} (ι₁ : X ⟶ P) (ι₂ : Y ⟶ P) :
   (binary_cofan.mk ι₁ ι₂).ι.app walking_pair.right = ι₂ := rfl
 
+/-- If `s` is a limit binary fan over `X` and `Y`, then every pair of morphisms `f : W ⟶ X` and
+    `g : W ⟶ Y` induces a morphism `l : W ⟶ s.X` satisfying `l ≫ s.fst = f` and `l ≫ s.snd = g`.
+    -/
+def binary_fan.is_limit.lift' {W X Y : C} {s : binary_fan X Y} (h : is_limit s) (f : W ⟶ X)
+  (g : W ⟶ Y) : {l : W ⟶ s.X // l ≫ s.fst = f ∧ l ≫ s.snd = g} :=
+⟨h.lift $ binary_fan.mk f g, h.fac _ _, h.fac _ _⟩
+
+/-- If `s` is a colimit binary cofan over `X` and `Y`,, then every pair of morphisms `f : X ⟶ W` and
+    `g : Y ⟶ W` induces a morphism `l : s.X ⟶ W` satisfying `s.inl ≫ l = f` and `s.inr ≫ l = g`.
+    -/
+def binary_cofan.is_colimit.desc' {W X Y : C} {s : binary_cofan X Y} (h : is_colimit s) (f : X ⟶ W)
+  (g : Y ⟶ W) : {l : s.X ⟶ W // s.inl ≫ l = f ∧ s.inr ≫ l = g} :=
+⟨h.desc $ binary_cofan.mk f g, h.fac _ _, h.fac _ _⟩
+
 /-- If we have chosen a product of `X` and `Y`, we can access it using `prod X Y` or
     `X ⨯ Y`. -/
 abbreviation prod (X Y : C) [has_limit (pair X Y)] := limit (pair X Y)
@@ -235,6 +249,22 @@ lim.map (map_pair f g)
 abbreviation coprod.map {W X Y Z : C} [has_colimits_of_shape.{v} (discrete walking_pair) C]
   (f : W ⟶ Y) (g : X ⟶ Z) : W ⨿ X ⟶ Y ⨿ Z :=
 colim.map (map_pair f g)
+
+@[reassoc]
+lemma prod.map_fst {W X Y Z : C} [has_limits_of_shape.{v} (discrete walking_pair) C]
+  (f : W ⟶ Y) (g : X ⟶ Z) : prod.map f g ≫ prod.fst = prod.fst ≫ f := by simp
+
+@[reassoc]
+lemma prod.map_snd {W X Y Z : C} [has_limits_of_shape.{v} (discrete walking_pair) C]
+  (f : W ⟶ Y) (g : X ⟶ Z) : prod.map f g ≫ prod.snd = prod.snd ≫ g := by simp
+
+@[reassoc]
+lemma coprod.inl_map {W X Y Z : C} [has_colimits_of_shape.{v} (discrete walking_pair) C]
+  (f : W ⟶ Y) (g : X ⟶ Z) : coprod.inl ≫ coprod.map f g = f ≫ coprod.inl := by simp
+
+@[reassoc]
+lemma coprod.inr_map {W X Y Z : C} [has_colimits_of_shape.{v} (discrete walking_pair) C]
+  (f : W ⟶ Y) (g : X ⟶ Z) : coprod.inr ≫ coprod.map f g = g ≫ coprod.inr := by simp
 
 variables (C)
 

--- a/src/category_theory/limits/shapes/constructions/pullbacks.lean
+++ b/src/category_theory/limits/shapes/constructions/pullbacks.lean
@@ -33,9 +33,9 @@ let π₁ : X ⨯ Y ⟶ X := prod.fst, π₂ : X ⨯ Y ⟶ Y := prod.snd, e := e
       (s.π.app walking_cospan.right)) $ by
         rw [←category.assoc, limit.lift_π, ←category.assoc, limit.lift_π];
         exact pullback_cone.condition _)
-    (by simp) (by simp) $ λ s m h, by
-      ext; simp only [limit.lift_π, fork.of_ι_app_zero, category.assoc];
-      exact walking_pair.cases_on j (h walking_cospan.left) (h walking_cospan.right) }
+    (by simp) (by simp) $ λ s m h, by { ext,
+      { simpa using h walking_cospan.left },
+      { simpa using h walking_cospan.right } } }
 
 section
 
@@ -65,9 +65,9 @@ let ι₁ : Y ⟶ Y ⨿ Z := coprod.inl, ι₂ : Z ⟶ Y ⨿ Z := coprod.inr,
       (s.ι.app walking_span.right)) $ by
         rw [category.assoc, colimit.ι_desc, category.assoc, colimit.ι_desc];
         exact pushout_cocone.condition _)
-    (by simp) (by simp) $ λ s m h, by
-      ext; simp only [colimit.ι_desc, cofork.of_π_app_one]; rw [←category.assoc];
-      exact walking_pair.cases_on j (h walking_span.left) (h walking_span.right) }
+    (by simp) (by simp) $ λ s m h, by { ext,
+      { simpa using h walking_span.left },
+      { simpa using h walking_span.right } } }
 
 section
 

--- a/src/category_theory/limits/shapes/kernels.lean
+++ b/src/category_theory/limits/shapes/kernels.lean
@@ -63,11 +63,17 @@ variables {f}
 by erw [fork.condition, has_zero_morphisms.comp_zero]
 
 @[simp] lemma kernel_fork.app_one (s : kernel_fork f) : s.π.app one = 0 :=
-by erw [←cone_parallel_pair_left, kernel_fork.condition]; refl
+by rw [←fork.app_zero_left, kernel_fork.condition]
 
 /-- A morphism `ι` satisfying `ι ≫ f = 0` determines a kernel fork over `f`. -/
 abbreviation kernel_fork.of_ι {Z : C} (ι : Z ⟶ X) (w : ι ≫ f = 0) : kernel_fork f :=
 fork.of_ι ι $ by rw [w, has_zero_morphisms.comp_zero]
+
+/-- If `s` is a limit kernel fork and `k : W ⟶ X` satisfies ``k ≫ f = 0`, then there is some
+    `l : W ⟶ s.X` sich that `l ≫ fork.ι s = k`. -/
+def kernel_fork.is_limit.lift' {s : kernel_fork f} (hs : is_limit s) {W : C} (k : W ⟶ X)
+  (h : k ≫ f = 0) : {l : W ⟶ s.X // l ≫ fork.ι s = k} :=
+⟨hs.lift $ kernel_fork.of_ι _ h, hs.fac _ _⟩
 
 end
 
@@ -83,14 +89,24 @@ abbreviation kernel.ι : kernel f ⟶ X := equalizer.ι f 0
 @[simp, reassoc] lemma kernel.condition : kernel.ι f ≫ f = 0 :=
 kernel_fork.condition _
 
-/-- Given any morphism `k` so `k ≫ f = 0`, `k` factors through `kernel f`. -/
+/-- Given any morphism `k : W ⟶ X` satisfying `k ≫ f = 0`, `k` factors through `kernel.ι f`
+    via `kernel.lift : W ⟶ kernel f`. -/
 abbreviation kernel.lift {W : C} (k : W ⟶ X) (h : k ≫ f = 0) : W ⟶ kernel f :=
 limit.lift (parallel_pair f 0) (kernel_fork.of_ι k h)
+
+@[simp, reassoc]
+lemma kernel.lift_ι {W : C} (k : W ⟶ X) (h : k ≫ f = 0) : kernel.lift f k h ≫ kernel.ι f = k :=
+limit.lift_π _ _
+
+/-- Any morphism `k : W ⟶ X` satisfying `k ≫ f = 0` induces a morphism `l : W ⟶ kernel f` such that
+    `l ≫ kernel.ι f = k`. -/
+def kernel.lift' {W : C} (k : W ⟶ X) (h : k ≫ f = 0) : {l : W ⟶ kernel f // l ≫ kernel.ι f = k} :=
+⟨kernel.lift f k h, kernel.lift_ι _ _ _⟩
 
 /-- Every kernel of the zero morphism is an isomorphism -/
 def kernel.ι_zero_is_iso [has_limit (parallel_pair (0 : X ⟶ Y) 0)] :
   is_iso (kernel.ι (0 : X ⟶ Y)) :=
-by { apply limit_cone_parallel_pair_self_is_iso, apply limit.is_limit }
+limit_cone_parallel_pair_self_is_iso _ _ (limit.is_limit _)
 
 end
 
@@ -143,14 +159,20 @@ abbreviation cokernel_cofork := cofork f 0
 variables {f}
 
 @[simp, reassoc] lemma cokernel_cofork.condition (s : cokernel_cofork f) : f ≫ cofork.π s = 0 :=
-by erw [cofork.condition, has_zero_morphisms.zero_comp]
+by rw [cofork.condition, has_zero_morphisms.zero_comp]
 
 @[simp] lemma cokernel_cofork.app_zero (s : cokernel_cofork f) : s.ι.app zero = 0 :=
-by erw [←cocone_parallel_pair_left, cokernel_cofork.condition]; refl
+by rw [←cofork.left_app_one, cokernel_cofork.condition]
 
 /-- A morphism `π` satisfying `f ≫ π = 0` determines a cokernel cofork on `f`. -/
 abbreviation cokernel_cofork.of_π {Z : C} (π : Y ⟶ Z) (w : f ≫ π = 0) : cokernel_cofork f :=
 cofork.of_π π $ by rw [w, has_zero_morphisms.zero_comp]
+
+/-- If `s` is a colimit cokernel cofork, then every `k : Y ⟶ W` satisfying `f ≫ k = 0` induces
+    `l : s.X ⟶ W` such that `cofork.π s ≫ l = k`. -/
+def cokernel_cofork.is_limit.desc' {s : cokernel_cofork f} (hs : is_colimit s) {W : C} (k : Y ⟶ W)
+  (h : f ≫ k = 0) : {l : s.X ⟶ W // cofork.π s ≫ l = k} :=
+⟨hs.desc $ cokernel_cofork.of_π _ h, hs.fac _ _⟩
 
 end
 
@@ -169,6 +191,16 @@ cokernel_cofork.condition _
 /-- Given any morphism `k` so `f ≫ k = 0`, `k` factors through `cokernel f`. -/
 abbreviation cokernel.desc {W : C} (k : Y ⟶ W) (h : f ≫ k = 0) : cokernel f ⟶ W :=
 colimit.desc (parallel_pair f 0) (cokernel_cofork.of_π k h)
+
+@[simp, reassoc]
+lemma cokernel.π_desc {W : C} (k : Y ⟶ W) (h : f ≫ k = 0) :
+  cokernel.π f ≫ cokernel.desc f k h = k :=
+colimit.ι_desc _ _
+
+def cokernel.desc' {W : C} (k : Y ⟶ W) (h : f ≫ k = 0) :
+  {l : cokernel f ⟶ W // cokernel.π f ≫ l = k} :=
+⟨cokernel.desc f k h, cokernel.π_desc _ _ _⟩
+
 end
 
 section has_zero_object

--- a/src/category_theory/limits/shapes/kernels.lean
+++ b/src/category_theory/limits/shapes/kernels.lean
@@ -188,7 +188,8 @@ abbreviation cokernel.π : Y ⟶ cokernel f := coequalizer.π f 0
 @[simp, reassoc] lemma cokernel.condition : f ≫ cokernel.π f = 0 :=
 cokernel_cofork.condition _
 
-/-- Given any morphism `k` so `f ≫ k = 0`, `k` factors through `cokernel f`. -/
+/-- Given any morphism `k : Y ⟶ W` such that `f ≫ k = 0`, `k` factors through `cokernel.π f`
+    via `cokernel.desc : cokernel f ⟶ W`. -/
 abbreviation cokernel.desc {W : C} (k : Y ⟶ W) (h : f ≫ k = 0) : cokernel f ⟶ W :=
 colimit.desc (parallel_pair f 0) (cokernel_cofork.of_π k h)
 
@@ -197,6 +198,8 @@ lemma cokernel.π_desc {W : C} (k : Y ⟶ W) (h : f ≫ k = 0) :
   cokernel.π f ≫ cokernel.desc f k h = k :=
 colimit.ι_desc _ _
 
+/-- Any morphism `k : Y ⟶ W` satisfying `f ≫ k = 0` induces `l : cokernel f ⟶ W` such that
+    `cokernel.π f ≫ l = k`. -/
 def cokernel.desc' {W : C} (k : Y ⟶ W) (h : f ≫ k = 0) :
   {l : cokernel f ⟶ W // cokernel.π f ≫ l = k} :=
 ⟨cokernel.desc f k h, cokernel.π_desc _ _ _⟩

--- a/src/category_theory/limits/shapes/pullbacks.lean
+++ b/src/category_theory/limits/shapes/pullbacks.lean
@@ -30,10 +30,10 @@ universes v u
 local attribute [tidy] tactic.case_bash
 
 /-- The type of objects for the diagram indexing a pullback. -/
-@[derive decidable_eq] inductive walking_cospan : Type v
+@[derive decidable_eq, derive inhabited] inductive walking_cospan : Type v
 | left | right | one
 /-- The type of objects for the diagram indexing a pushout. -/
-@[derive decidable_eq] inductive walking_span : Type v
+@[derive decidable_eq, derive inhabited] inductive walking_span : Type v
 | zero | left | right
 
 instance fintype_walking_cospan : fintype walking_cospan :=
@@ -47,10 +47,14 @@ instance fintype_walking_span : fintype walking_span :=
 namespace walking_cospan
 
 /-- The arrows in a pullback diagram. -/
-@[derive _root_.decidable_eq] inductive hom : walking_cospan → walking_cospan → Type v
+@[derive decidable_eq] inductive hom : walking_cospan → walking_cospan → Type v
 | inl : hom left one
 | inr : hom right one
 | id : Π X : walking_cospan.{v}, hom X X
+
+/-- Satisfying the inhabited linter -/
+instance hom.inhabited : inhabited (hom left one) :=
+{ default := hom.inl }
 
 open hom
 
@@ -61,6 +65,7 @@ instance fintype_walking_cospan_hom (j j' : walking_cospan) : fintype (hom j j')
     (walking_cospan.rec_on j' ∅ ∅ [hom.id one].to_finset),
   complete := by tidy }
 
+/-- Composition of morphisms in the category indexing a pullback. -/
 def hom.comp : Π (X Y Z : walking_cospan) (f : hom X Y) (g : hom Y Z), hom X Z
 | _ _ _ (id _) h := h
 | _ _ _ inl    (id one) := inl
@@ -89,10 +94,13 @@ end walking_cospan
 namespace walking_span
 
 /-- The arrows in a pushout diagram. -/
-@[derive _root_.decidable_eq] inductive hom : walking_span → walking_span → Type v
+@[derive decidable_eq] inductive hom : walking_span → walking_span → Type v
 | fst : hom zero left
 | snd : hom zero right
 | id : Π X : walking_span.{v}, hom X X
+
+instance hom.inhabited : inhabited (hom zero left) :=
+{ default := hom.fst }
 
 open hom
 
@@ -103,6 +111,7 @@ instance fintype_walking_span_hom (j j' : walking_span) : fintype (hom j j') :=
     (walking_span.rec_on j' ∅ ∅ [hom.id right].to_finset),
   complete := by tidy }
 
+/-- Composition of morphisms in the category indexing a pushout. -/
 def hom.comp : Π (X Y Z : walking_span) (f : hom X Y) (g : hom Y Z), hom X Z
   | _ _ _ (id _) h := h
   | _ _ _ fst    (id left) := fst
@@ -203,14 +212,21 @@ variables {X Y Z : C}
 
 attribute [simp] walking_cospan.hom_id walking_span.hom_id
 
+/-- A pullback cone is just a cone on the cospan formed by two morphisms `f : X ⟶ Z` and
+    `g : Y ⟶ Z`.-/
 abbreviation pullback_cone (f : X ⟶ Z) (g : Y ⟶ Z) := cone (cospan f g)
 
 namespace pullback_cone
 variables {f : X ⟶ Z} {g : Y ⟶ Z}
 
+/-- The first projection of a pullback cone. -/
 abbreviation fst (t : pullback_cone f g) : t.X ⟶ X := t.π.app left
+
+/-- The second projection of a pullback cone. -/
 abbreviation snd (t : pullback_cone f g) : t.X ⟶ Y := t.π.app right
 
+/-- A pullback cone on `f` and `g` is determined by morphisms `fst : W ⟶ X` and `snd : W ⟶ Y`
+    such that `fst ≫ f = snd ≫ g`. -/
 def mk {W : C} (fst : W ⟶ X) (snd : W ⟶ Y) (eq : fst ≫ f = snd ≫ g) : pullback_cone f g :=
 { X := W,
   π :=
@@ -232,14 +248,24 @@ end
 /-- To check whether a morphism is equalized by the maps of a pullback cone, it suffices to check
   it for `fst t` and `snd t` -/
 lemma equalizer_ext (t : pullback_cone f g) {W : C} {k l : W ⟶ t.X}
-  (h₀ : k ≫ fst t = l ≫ fst t)
-  (h₁ : k ≫ snd t = l ≫ snd t) :
+  (h₀ : k ≫ fst t = l ≫ fst t) (h₁ : k ≫ snd t = l ≫ snd t) :
   ∀ (j : walking_cospan), k ≫ t.π.app j = l ≫ t.π.app j
 | left := h₀
 | right := h₁
 | one := calc k ≫ t.π.app one = k ≫ t.π.app left ≫ (cospan f g).map inl : by rw ←t.w
     ... = l ≫ t.π.app left ≫ (cospan f g).map inl : by rw [←category.assoc, h₀, category.assoc]
     ... = l ≫ t.π.app one : by rw t.w
+
+lemma is_limit.hom_ext {t : pullback_cone f g} (ht : is_limit t) {W : C} {k l : W ⟶ t.X}
+  (h₀ : k ≫ fst t = l ≫ fst t) (h₁ : k ≫ snd t = l ≫ snd t) : k = l :=
+ht.hom_ext $ equalizer_ext _ h₀ h₁
+
+/-- If `t` is a limit pullback cone over `f` and `g` and `h : W ⟶ X` and `k : W ⟶ Y` are such that
+    `h ≫ f = k ≫ g`, then we have `l : W ⟶ t.X` satisfying `l ≫ fst t = h` and `l ≫ snd t = k`.
+    -/
+def is_limit.lift' {t : pullback_cone f g} (ht : is_limit t) {W : C} (h : W ⟶ X) (k : W ⟶ Y)
+  (w : h ≫ f = k ≫ g) : {l : W ⟶ t.X // l ≫ fst t = h ∧ l ≫ snd t = k} :=
+⟨ht.lift $ pullback_cone.mk _ _ w, ht.fac _ _, ht.fac _ _⟩
 
 /-- This is a slightly more convenient method to verify that a pullback cone is a limit cone. It
     only asks for a proof of facts that carry any mathematical content -/
@@ -256,15 +282,22 @@ def is_limit.mk (t : pullback_cone f g) (lift : Π (s : cone (cospan f g)), s.X 
 
 end pullback_cone
 
+/-- A pushout cocone is just a cocone on the span formed by two morphisms `f : X ⟶ Y` and
+    `g : X ⟶ Z`.-/
 abbreviation pushout_cocone (f : X ⟶ Y) (g : X ⟶ Z) := cocone (span f g)
 
 namespace pushout_cocone
 
 variables {f : X ⟶ Y} {g : X ⟶ Z}
 
+/-- The first inclusion of a pushout cocone. -/
 abbreviation inl (t : pushout_cocone f g) : Y ⟶ t.X := t.ι.app left
+
+/-- The second inclusion of a pushout cocone. -/
 abbreviation inr (t : pushout_cocone f g) : Z ⟶ t.X := t.ι.app right
 
+/-- A pushout cocone on `f` and `g` is determined by morphisms `inl : Y ⟶ W` and `inr : Z ⟶ W` such
+    that `f ≫ inl = g ↠ inr`. -/
 def mk {W : C} (inl : Y ⟶ W) (inr : Z ⟶ W) (eq : f ≫ inl = g ≫ inr) : pushout_cocone f g :=
 { X := W,
   ι :=
@@ -286,14 +319,24 @@ end
 /-- To check whether a morphism is coequalized by the maps of a pushout cocone, it suffices to check
   it for `inl t` and `inr t` -/
 lemma coequalizer_ext (t : pushout_cocone f g) {W : C} {k l : t.X ⟶ W}
-  (h₀ : inl t ≫ k = inl t ≫ l)
-  (h₁ : inr t ≫ k = inr t ≫ l) :
+  (h₀ : inl t ≫ k = inl t ≫ l) (h₁ : inr t ≫ k = inr t ≫ l) :
   ∀ (j : walking_span), t.ι.app j ≫ k = t.ι.app j ≫ l
 | left := h₀
 | right := h₁
 | zero := calc t.ι.app zero ≫ k = ((span f g).map fst ≫ t.ι.app left) ≫ k : by rw ←t.w
     ... = ((span f g).map fst ≫ t.ι.app left) ≫ l : by rw [category.assoc, h₀, ←category.assoc]
     ... = t.ι.app zero ≫ l : by rw t.w
+
+lemma is_colimit.hom_ext {t : pushout_cocone f g} (ht : is_colimit t) {W : C} {k l : t.X ⟶ W}
+  (h₀ : inl t ≫ k = inl t ≫ l) (h₁ : inr t ≫ k = inr t ≫ l) : k = l :=
+ht.hom_ext $ coequalizer_ext _ h₀ h₁
+
+/-- If `t` is a colimit pushout cocone over `f` and `g` and `h : Y ⟶ W` and `k : Z ⟶ W` are
+    morphisms satisfying `f ≫ h = g ≫ k`, then we have a factorization `l : t.X ⟶ W` such that
+    `inl t ≫ l = h` and `inr t ≫ l = k`. -/
+def is_colimit.desc' {t : pushout_cocone f g} (ht : is_colimit t) {W : C} (h : Y ⟶ W) (k : Z ⟶ W)
+  (w : f ≫ h = g ≫ k) : {l : t.X ⟶ W // inl t ≫ l = h ∧ inr t ≫ l = k } :=
+⟨ht.desc $ pushout_cocone.mk _ _ w, ht.fac _ _, ht.fac _ _⟩
 
 /-- This is a slightly more convenient method to verify that a pushout cocone is a colimit cocone.
     It only asks for a proof of facts that carry any mathematical content -/
@@ -310,6 +353,13 @@ def is_colimit.mk (t : pushout_cocone f g) (desc : Π (s : cocone (span f g)), t
 
 end pushout_cocone
 
+/-- This is a helper construction that can be useful when verifying that a category has all
+    pullbacks. Given `F : walking_cospan ⥤ C`, which is really the same as
+    `cospan (F.map inl) (F.map inr)`, and a pullback cone on `F.map inl` and `F.map inr`, we
+    get a cone on `F`.
+
+    If you're thinking about using this, have a look at `has_pullbacks_of_has_limit_cospan`,
+    which you may find to be an easier way of achieving your goal. -/
 def cone.of_pullback_cone
   {F : walking_cospan.{v} ⥤ C} (t : pullback_cone (F.map inl) (F.map inr)) : cone F :=
 { X := t.X,
@@ -326,6 +376,13 @@ def cone.of_pullback_cone
   {F : walking_cospan.{v} ⥤ C} (t : pullback_cone (F.map inl) (F.map inr)) (j) :
   (cone.of_pullback_cone t).π.app j = t.π.app j ≫ eq_to_hom (by tidy) := rfl
 
+/-- This is a helper construction that can be useful when verifying that a category has all
+    pushout. Given `F : walking_span ⥤ C`, which is really the same as
+    `span (F.map fst) (F.mal snd)`, and a pushout cocone on `F.map fst` and `F.map snd`,
+    we get a cocone on `F`.
+
+    If you're thinking about using this, have a look at `has_pushouts_of_has_colimit_span`, which
+    you may find to be an easiery way of achieving your goal.  -/
 def cocone.of_pushout_cocone
   {F : walking_span.{v} ⥤ C} (t : pushout_cocone (F.map fst) (F.map snd)) : cocone F :=
 { X := t.X,
@@ -342,6 +399,8 @@ def cocone.of_pushout_cocone
   {F : walking_span.{v} ⥤ C} (t : pushout_cocone (F.map fst) (F.map snd)) (j) :
   (cocone.of_pushout_cocone t).ι.app j = eq_to_hom (by tidy) ≫ t.ι.app j := rfl
 
+/-- Given `F : walking_cospan ⥤ C`, which is really the same as `cospan (F.map inl) (F.map inr)`,
+    and a cone on `F`, we get a pullback cone on `F.map inl` and `F.map inr`. -/
 def pullback_cone.of_cone
   {F : walking_cospan.{v} ⥤ C} (t : cone F) : pullback_cone (F.map inl) (F.map inr) :=
 { X := t.X,
@@ -350,6 +409,8 @@ def pullback_cone.of_cone
 @[simp] lemma pullback_cone.of_cone_π {F : walking_cospan.{v} ⥤ C} (t : cone F) (j) :
   (pullback_cone.of_cone t).π.app j = t.π.app j ≫ eq_to_hom (by tidy) := rfl
 
+/-- Given `F : walking_span ⥤ C`, which is really the same as `span (F.map fst) (F.map snd)`,
+    and a cocone on `F`, we get a pushout cocone on `F.map fst` and `F.map snd`. -/
 def pushout_cocone.of_cocone
   {F : walking_span.{v} ⥤ C} (t : cocone F) : pushout_cocone (F.map fst) (F.map snd) :=
 { X := t.X,
@@ -365,21 +426,71 @@ limit (cospan f g)
 abbreviation pushout {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) [has_colimit (span f g)] :=
 colimit (span f g)
 
-abbreviation pullback.fst {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} [has_limit (cospan f g)] : pullback f g ⟶ X :=
+/-- The first projection of the pullback of `f` and `g`. -/
+abbreviation pullback.fst {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} [has_limit (cospan f g)] :
+  pullback f g ⟶ X :=
 limit.π (cospan f g) walking_cospan.left
-abbreviation pullback.snd {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} [has_limit (cospan f g)] : pullback f g ⟶ Y :=
+
+/-- The second projection of the pullback of `f` and `g`. -/
+abbreviation pullback.snd {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} [has_limit (cospan f g)] :
+  pullback f g ⟶ Y :=
 limit.π (cospan f g) walking_cospan.right
-abbreviation pushout.inl {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} [has_colimit (span f g)] : Y ⟶ pushout f g :=
+
+/-- The first inclusion into the pushout of `f` and `g`. -/
+abbreviation pushout.inl {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} [has_colimit (span f g)] :
+  Y ⟶ pushout f g :=
 colimit.ι (span f g) walking_span.left
-abbreviation pushout.inr {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} [has_colimit (span f g)] : Z ⟶ pushout f g :=
+
+/-- The second inclusion into the pushout of `f` and `g`. -/
+abbreviation pushout.inr {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} [has_colimit (span f g)] :
+  Z ⟶ pushout f g :=
 colimit.ι (span f g) walking_span.right
 
+/-- A pair of morphisms `h : W ⟶ X` and `k : W ⟶ Y` satisfying `h ≫ f = k ≫ g` induces a morphism
+    `pullback.lift : W ⟶ pullback f g`. -/
 abbreviation pullback.lift {W X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} [has_limit (cospan f g)]
   (h : W ⟶ X) (k : W ⟶ Y) (w : h ≫ f = k ≫ g) : W ⟶ pullback f g :=
 limit.lift _ (pullback_cone.mk h k w)
+
+/-- A pair of morphisms `h : Y ⟶ W` and `k : Z ⟶ W` satisfying `f ≫ h = g ≫ k` induces a morphism
+    `pushout.desc : pushout f g ⟶ W`. -/
 abbreviation pushout.desc {W X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} [has_colimit (span f g)]
   (h : Y ⟶ W) (k : Z ⟶ W) (w : f ≫ h = g ≫ k) : pushout f g ⟶ W :=
 colimit.desc _ (pushout_cocone.mk h k w)
+
+@[simp, reassoc]
+lemma pullback.lift_fst {W X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} [has_limit (cospan f g)]
+  (h : W ⟶ X) (k : W ⟶ Y) (w : h ≫ f = k ≫ g) : pullback.lift h k w ≫ pullback.fst = h :=
+limit.lift_π _ _
+
+@[simp, reassoc]
+lemma pullback.lift_snd {W X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} [has_limit (cospan f g)]
+  (h : W ⟶ X) (k : W ⟶ Y) (w : h ≫ f = k ≫ g) : pullback.lift h k w ≫ pullback.snd = k :=
+limit.lift_π _ _
+
+@[simp, reassoc]
+lemma pushout.inl_desc {W X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} [has_colimit (span f g)]
+  (h : Y ⟶ W) (k : Z ⟶ W) (w : f ≫ h = g ≫ k) : pushout.inl ≫ pushout.desc h k w = h :=
+colimit.ι_desc _ _
+
+@[simp, reassoc]
+lemma pushout.inr_desc {W X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} [has_colimit (span f g)]
+  (h : Y ⟶ W) (k : Z ⟶ W) (w : f ≫ h = g ≫ k) : pushout.inr ≫ pushout.desc h k w = k :=
+colimit.ι_desc _ _
+
+/-- A pair of morphisms `h : W ⟶ X` and `k : W ⟶ Y` satisfying `h ≫ f = k ≫ g` induces a morphism
+    `l : W ⟶ pullback f g` such that `l ≫ pullback.fst = h` and `l ≫ pullback.snd = k`. -/
+def pullback.lift' {W X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} [has_limit (cospan f g)]
+  (h : W ⟶ X) (k : W ⟶ Y) (w : h ≫ f = k ≫ g) :
+  {l : W ⟶ pullback f g // l ≫ pullback.fst = h ∧ l ≫ pullback.snd = k} :=
+⟨pullback.lift h k w, pullback.lift_fst _ _ _, pullback.lift_snd _ _ _⟩
+
+/-- A pair of morphisms `h : Y ⟶ W` and `k : Z ⟶ W` satisfying `f ≫ h = g ≫ k` induces a morphism
+    `l : pushout f g ⟶ W` such that `pushout.inl ≫ l = h` and `pushout.inr ≫ l = k`. -/
+def pullback.desc' {W X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} [has_colimit (span f g)]
+  (h : Y ⟶ W) (k : Z ⟶ W) (w : f ≫ h = g ≫ k) :
+  {l : pushout f g ⟶ W // pushout.inl ≫ l = h ∧ pushout.inr ≫ l = k} :=
+⟨pushout.desc h k w, pushout.inl_desc _ _ _, pushout.inr_desc _ _ _⟩
 
 lemma pullback.condition {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} [has_limit (cospan f g)] :
   (pullback.fst : pullback f g ⟶ X) ≫ f = pullback.snd ≫ g :=


### PR DESCRIPTION
This is the 2.5th PR in a series of most likely three PRs about the cohomology functor. This PR has nothing to do with cohomology, but I'm going to need a lemma from this pull request in the final PR in the series.

In this PR, I
* perform various documentation and cleanup tasks
* add lemmas similar to the ones seen in #2396 for equalizers, kernels and pullbacks (NB: these are not needed for biproducts since the `simp` and `ext` lemmas for products and coproducts readily fire)
* generalize `prod.hom_ext` to the situation where we have a `binary_fan X Y` and an `is_limit` for that specific fan (and similar for the other shapes)
* add "bundled" versions of lift and desc. Here is the most important example:
```lean
def kernel.lift' {W : C} (k : W ⟶ X) (h : k ≫ f = 0) : {l : W ⟶ kernel f // l ≫ kernel.ι f = k} :=
⟨kernel.lift f k h, kernel.lift_ι _ _ _⟩
```
This definition doesn't really do anything by itself, but it makes proofs comforable and readable. For example, if you say `obtain ⟨t, ht⟩ := kernel.lift' g p hpg`, then the interesting property of `t` is right there in the tactic view, which I find helpful in keeping track of things when a proof invokes a lot of universal properties.

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
