### PR TITLE
[Merged by Bors] - feat(category_theory):  creation of limits and reflection of isomorphisms

### DIFF
--- a/src/category_theory/adjunction/limits.lean
+++ b/src/category_theory/adjunction/limits.lean
@@ -113,6 +113,19 @@ omit adj
 instance is_equivalence_preserves_limits (E : D ⥤ C) [is_equivalence E] : preserves_limits E :=
 right_adjoint_preserves_limits E.inv.adjunction
 
+@[priority 100] -- see Note [lower instance priority]
+instance is_equivalence_reflects_limits (E : D ⥤ C) [is_equivalence E] : reflects_limits E :=
+{ reflects_limits_of_shape := λ J 𝒥, by exactI
+  { reflects_limit := λ K,
+    { reflects := λ c t,
+      begin
+        have l: is_limit (E.inv.map_cone (E.map_cone c)) := preserves_limit.preserves t,
+        convert is_limit.map_cone_equiv E.fun_inv_id l,
+        rw functor.comp_id,
+        cases c, cases c_π, dsimp [functor.map_cone, cones.functoriality],
+        congr; rw functor.comp_id
+      end } } }
+
 -- verify the preserve_limits instance works as expected:
 example (E : D ⥤ C) [is_equivalence E]
   (c : cone K) [h : is_limit c] : is_limit (E.map_cone c) :=

--- a/src/category_theory/adjunction/limits.lean
+++ b/src/category_theory/adjunction/limits.lean
@@ -121,9 +121,10 @@ instance is_equivalence_reflects_limits (E : D ⥤ C) [is_equivalence E] : refle
       begin
         have l: is_limit (E.inv.map_cone (E.map_cone c)) := preserves_limit.preserves t,
         convert is_limit.map_cone_equiv E.fun_inv_id l,
-        rw functor.comp_id,
-        cases c, cases c_π, dsimp [functor.map_cone, cones.functoriality],
-        congr; rw functor.comp_id
+        { rw functor.comp_id },
+        { cases c,
+          cases c_π,
+          congr; rw functor.comp_id }
       end } } }
 
 -- verify the preserve_limits instance works as expected:

--- a/src/category_theory/adjunction/limits.lean
+++ b/src/category_theory/adjunction/limits.lean
@@ -25,19 +25,19 @@ section preservation_colimits
 variables {J : Type v} [small_category J] (K : J ⥤ C)
 
 def functoriality_right_adjoint : cocone (K ⋙ F) ⥤ cocone K :=
-(cocones.functoriality G) ⋙
+(cocones.functoriality _ G) ⋙
   (cocones.precompose (K.right_unitor.inv ≫ (whisker_left K adj.unit) ≫ (associator _ _ _).inv))
 
 local attribute [reducible] functoriality_right_adjoint
 
-@[simps] def functoriality_unit : 𝟭 (cocone K) ⟶ cocones.functoriality F ⋙ functoriality_right_adjoint adj K :=
+@[simps] def functoriality_unit : 𝟭 (cocone K) ⟶ cocones.functoriality _ F ⋙ functoriality_right_adjoint adj K :=
 { app := λ c, { hom := adj.unit.app c.X } }
 
-@[simps] def functoriality_counit : functoriality_right_adjoint adj K ⋙ cocones.functoriality F ⟶ 𝟭 (cocone (K ⋙ F)) :=
+@[simps] def functoriality_counit : functoriality_right_adjoint adj K ⋙ cocones.functoriality _ F ⟶ 𝟭 (cocone (K ⋙ F)) :=
 { app := λ c, { hom := adj.counit.app c.X } }
 
 def functoriality_is_left_adjoint :
-  is_left_adjoint (@cocones.functoriality _ _ _ _ K _ _ F) :=
+  is_left_adjoint (cocones.functoriality K F) :=
 { right := functoriality_right_adjoint adj K,
   adj := mk_of_unit_counit
   { unit := functoriality_unit adj K,
@@ -80,19 +80,19 @@ section preservation_limits
 variables {J : Type v} [small_category J] (K : J ⥤ D)
 
 def functoriality_left_adjoint : cone (K ⋙ G) ⥤ cone K :=
-(cones.functoriality F) ⋙ (cones.postcompose
+(cones.functoriality _ F) ⋙ (cones.postcompose
     ((associator _ _ _).hom ≫ (whisker_left K adj.counit) ≫ K.right_unitor.hom))
 
 local attribute [reducible] functoriality_left_adjoint
 
-@[simps] def functoriality_unit' : 𝟭 (cone (K ⋙ G)) ⟶ functoriality_left_adjoint adj K ⋙ cones.functoriality G :=
+@[simps] def functoriality_unit' : 𝟭 (cone (K ⋙ G)) ⟶ functoriality_left_adjoint adj K ⋙ cones.functoriality _ G :=
 { app := λ c, { hom := adj.unit.app c.X, } }
 
-@[simps] def functoriality_counit' : cones.functoriality G ⋙ functoriality_left_adjoint adj K ⟶ 𝟭 (cone K) :=
+@[simps] def functoriality_counit' : cones.functoriality _ G ⋙ functoriality_left_adjoint adj K ⟶ 𝟭 (cone K) :=
 { app := λ c, { hom := adj.counit.app c.X, } }
 
 def functoriality_is_right_adjoint :
-  is_right_adjoint (@cones.functoriality _ _ _ _ K _ _ G) :=
+  is_right_adjoint (cones.functoriality K G) :=
 { left := functoriality_left_adjoint adj K,
   adj := mk_of_unit_counit
   { unit := functoriality_unit' adj K,

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -314,10 +314,10 @@ let α : (F ⋙ H) ⋙ inv H ⟶ F :=
 { X := t.X,
   π := ((category_theory.cones J C).map α).app (op t.X) t.π }
 
-def map_cone_morphism   {c c' : cone F}   (f : cone_morphism c c')   :
-  cone_morphism   (H.map_cone c)   (H.map_cone c')   := (cones.functoriality F H).map f
-def map_cocone_morphism {c c' : cocone F} (f : cocone_morphism c c') :
-  cocone_morphism (H.map_cocone c) (H.map_cocone c') := (cocones.functoriality F H).map f
+def map_cone_morphism   {c c' : cone F}   (f : c ⟶ c')   :
+  (H.map_cone c) ⟶ (H.map_cone c') := (cones.functoriality F H).map f
+def map_cocone_morphism {c c' : cocone F} (f : c ⟶ c') :
+  (H.map_cocone c) ⟶ (H.map_cocone c') := (cocones.functoriality F H).map f
 
 @[simp] lemma map_cone_π (c : cone F) (j : J) :
   (map_cone H c).π.app j = H.map (c.π.app j) := rfl

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -309,6 +309,7 @@ def map_cocone (c : cocone F) : cocone (F ⋙ H) := (cocones.functoriality H).ob
 @[simp] lemma map_cone_X (c : cone F) : (H.map_cone c).X = H.obj c.X := rfl
 @[simp] lemma map_cocone_X (c : cocone F) : (H.map_cocone c).X = H.obj c.X := rfl
 
+@[simps]
 def map_cone_inv [is_equivalence H]
   (c : cone (F ⋙ H)) : cone F :=
 let t := (inv H).map_cone c in
@@ -316,8 +317,6 @@ let α : (F ⋙ H) ⋙ inv H ⟶ F :=
   ((whisker_left F is_equivalence.unit_iso.inv) : F ⋙ (H ⋙ inv H) ⟶ _) ≫ (functor.right_unitor _).hom in
 { X := t.X,
   π := ((category_theory.cones J C).map α).app (op t.X) t.π }
-
-@[simp] lemma map_cone_inv_X [is_equivalence H] (c : cone (F ⋙ H)) : (H.map_cone_inv c).X = (inv H).obj c.X := rfl
 
 def map_cone_morphism   {c c' : cone F}   (f : cone_morphism c c')   :
   cone_morphism   (H.map_cone c)   (H.map_cone c')   := (cones.functoriality H).map f
@@ -328,6 +327,21 @@ def map_cocone_morphism {c c' : cocone F} (f : cocone_morphism c c') :
   (map_cone H c).π.app j = H.map (c.π.app j) := rfl
 @[simp] lemma map_cocone_ι (c : cocone F) (j : J) :
   (map_cocone H c).ι.app j = H.map (c.ι.app j) := rfl
+
+/-- `map_cone` is the left inverse to `map_cone_inv`. -/
+def map_cone_map_cone_inv {F : J ⥤ D} (H : D ⥤ C) [is_equivalence H] (c : cone (F ⋙ H)) :
+  map_cone H (map_cone_inv H c) ≅ c :=
+begin
+  apply cones.ext _ (λ j, _),
+  { exact H.inv_fun_id.app c.X },
+  { dsimp,
+    erw [comp_id, ← H.inv_fun_id.hom.naturality (c.π.app j), comp_map, H.map_comp],
+    congr' 1,
+    erw [← cancel_epi (H.inv_fun_id.inv.app (H.obj (F.obj j))), nat_iso.inv_hom_id_app,
+         ← (functor.as_equivalence H).functor_unit _, ← H.map_comp, nat_iso.hom_inv_id_app,
+         H.map_id],
+    refl }
+end
 
 end functor
 

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -213,9 +213,7 @@ variable (F)
 @[simps]
 def forget : cone F ⥤ C :=
 { obj := λ t, t.X, map := λ s t f, f.hom }
-end
 
-section
 variables {D : Type u'} [𝒟 : category.{v} D]
 include 𝒟
 
@@ -276,9 +274,7 @@ variable (F)
 @[simps]
 def forget : cocone F ⥤ C :=
 { obj := λ t, t.X, map := λ s t f, f.hom }
-end
 
-section
 variables {D : Type u'} [𝒟 : category.{v} D]
 include 𝒟
 
@@ -302,9 +298,9 @@ variables {F : J ⥤ C} {G : J ⥤ C} (H : C ⥤ D)
 open category_theory.limits
 
 /-- The image of a cone in C under a functor G : C ⥤ D is a cone in D. -/
-def map_cone   (c : cone F)   : cone (F ⋙ H)   := (cones.functoriality H).obj c
+def map_cone   (c : cone F)   : cone (F ⋙ H)   := (cones.functoriality F H).obj c
 /-- The image of a cocone in C under a functor G : C ⥤ D is a cocone in D. -/
-def map_cocone (c : cocone F) : cocone (F ⋙ H) := (cocones.functoriality H).obj c
+def map_cocone (c : cocone F) : cocone (F ⋙ H) := (cocones.functoriality F H).obj c
 
 @[simp] lemma map_cone_X (c : cone F) : (H.map_cone c).X = H.obj c.X := rfl
 @[simp] lemma map_cocone_X (c : cocone F) : (H.map_cocone c).X = H.obj c.X := rfl
@@ -319,9 +315,9 @@ let α : (F ⋙ H) ⋙ inv H ⟶ F :=
   π := ((category_theory.cones J C).map α).app (op t.X) t.π }
 
 def map_cone_morphism   {c c' : cone F}   (f : cone_morphism c c')   :
-  cone_morphism   (H.map_cone c)   (H.map_cone c')   := (cones.functoriality H).map f
+  cone_morphism   (H.map_cone c)   (H.map_cone c')   := (cones.functoriality F H).map f
 def map_cocone_morphism {c c' : cocone F} (f : cocone_morphism c c') :
-  cocone_morphism (H.map_cocone c) (H.map_cocone c') := (cocones.functoriality H).map f
+  cocone_morphism (H.map_cocone c) (H.map_cocone c') := (cocones.functoriality F H).map f
 
 @[simp] lemma map_cone_π (c : cone F) (j : J) :
   (map_cone H c).π.app j = H.map (c.π.app j) := rfl

--- a/src/category_theory/limits/creates.lean
+++ b/src/category_theory/limits/creates.lean
@@ -1,0 +1,301 @@
+/-
+Copyright (c) 2020 Bhavik Mehta. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Bhavik Mehta
+-/
+import category_theory.limits.limits
+import category_theory.limits.preserves
+import category_theory.monad.adjunction
+import category_theory.adjunction.limits
+import category_theory.reflect_isomorphisms
+
+open category_theory category_theory.limits
+
+namespace category_theory
+
+universes v u₁ u₂ u₃
+
+variables {C : Type u₁} [𝒞 : category.{v} C]
+include 𝒞
+
+section creates
+variables {D : Type u₂} [𝒟 : category.{v} D]
+include 𝒟
+
+variables {J : Type v} [small_category J] {K : J ⥤ C}
+
+/--
+Define the lift of a cone: For a cone `c` for `K ⋙ F`, give a cone for `K`
+which is a lift of `c`, i.e. the image of it under `F` is (iso) to `c`.
+
+We will then use this as part of the definition of creation of limits:
+every limit cone has a lift.
+
+Note this definition is really only useful when `c` is a limit already.
+-/
+structure liftable_cone (K : J ⥤ C) (F : C ⥤ D) (c : cone (K ⋙ F)) :=
+(lifted_cone : cone K)
+(valid_lift : F.map_cone lifted_cone ≅ c)
+
+structure liftable_cocone (K : J ⥤ C) (F : C ⥤ D) (c : cocone (K ⋙ F)) :=
+(lifted_cocone : cocone K)
+(valid_lift : F.map_cocone lifted_cocone ≅ c)
+
+/--
+Definition 3.3.1 of [Riehl].
+We say that `F` creates limits of `K` if, given any limit cone `c` for `K ⋙ F`
+(i.e. below) we can lift it to a cone above, and further that `F` reflects
+limits for `K`.
+
+Note this is equivalent to Riehl's definition - the missing part here appears
+to be that the lifted cone is not a limit, but the `extends reflects_limit K F`
+is (proved in `lifted_limit_is_limit`).
+
+If `F` reflects isomorphisms, it suffices to show only that the lifted cone is
+a limit - see `creates_limit_of_reflects_iso`.
+-/
+class creates_limit (K : J ⥤ C) (F : C ⥤ D) extends reflects_limit K F : Type (max u₁ u₂ v) :=
+(lifts : Π c, is_limit c → liftable_cone K F c)
+
+class creates_limits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) : Type (max u₁ u₂ v) :=
+(creates_limit : Π {K : J ⥤ C}, creates_limit K F)
+
+class creates_limits (F : C ⥤ D) : Type (max u₁ u₂ (v+1)) :=
+(creates_limits_of_shape : Π {J : Type v} {𝒥 : small_category J}, by exactI creates_limits_of_shape J F)
+
+class creates_colimit (K : J ⥤ C) (F : C ⥤ D) extends reflects_colimit K F : Type (max u₁ u₂ v) :=
+(lifts : Π c, is_colimit c → liftable_cocone K F c)
+
+class creates_colimits_of_shape (J : Type v) [small_category J] (F : C ⥤ D) : Type (max u₁ u₂ v) :=
+(creates_colimit : Π {K : J ⥤ C}, creates_colimit K F)
+
+class creates_colimits (F : C ⥤ D) : Type (max u₁ u₂ (v+1)) :=
+(creates_colimits_of_shape : Π {J : Type v} {𝒥 : small_category J}, by exactI creates_colimits_of_shape J F)
+
+def lift_limit {K : J ⥤ C} {F : C ⥤ D} [i : creates_limit K F] {c : cone (K ⋙ F)} (t : is_limit c) : cone K :=
+(creates_limit.lifts c t).lifted_cone
+
+def lifted_limit_maps_to_original {K : J ⥤ C} (F : C ⥤ D) [i : creates_limit K F] {c : cone (K ⋙ F)} (t : is_limit c) :
+  F.map_cone (lift_limit t) ≅ c :=
+(creates_limit.lifts c t).valid_lift
+
+def lifted_limit_is_limit {K : J ⥤ C} {F : C ⥤ D} [i : creates_limit K F] {c : cone (K ⋙ F)} (t : is_limit c) :
+  is_limit (lift_limit t) :=
+reflects_limit.reflects (is_limit.of_iso_limit t (lifted_limit_maps_to_original F t).symm)
+
+-- TODO: reflects iso is equivalent to reflecting limits of shape 1
+
+def map_cone_equiv {F G : C ⥤ D} (h : F ≅ G) {c : cone K} (t : is_limit (F.map_cone c)) : is_limit (G.map_cone c) :=
+{ lift := λ s, t.lift ((cones.postcompose (iso_whisker_left K h).inv).obj s) ≫ h.hom.app c.X,
+  fac' := λ s j,
+  begin
+    slice_lhs 2 3 {erw ← h.hom.naturality (c.π.app j)},
+    slice_lhs 1 2 {erw t.fac ((cones.postcompose (iso_whisker_left K h).inv).obj s) j},
+    dsimp,
+    slice_lhs 2 3 {rw nat_iso.inv_hom_id_app},
+    rw category.comp_id,
+  end,
+  uniq' := λ s m J,
+  begin
+    rw ← cancel_mono (h.inv.app c.X),
+    apply t.hom_ext,
+    intro j,
+    dsimp,
+    slice_lhs 2 3 {erw ← h.inv.naturality (c.π.app j)},
+    slice_lhs 1 2 {erw J j},
+    conv_rhs {congr, rw category.assoc, rw nat_iso.hom_inv_id_app},
+    rw category.comp_id,
+    erw t.fac ((cones.postcompose (iso_whisker_left K h).inv).obj s) j,
+    refl
+  end }
+
+@[priority 100] -- see Note [lower instance priority]
+instance is_equivalence_reflects_limits (H : D ⥤ C) [is_equivalence H] : reflects_limits H :=
+{ reflects_limits_of_shape := λ J 𝒥, by exactI
+  { reflects_limit := λ K,
+    { reflects := λ c t,
+      begin
+        have l: is_limit (H.inv.map_cone (H.map_cone c)) := preserves_limit.preserves t,
+        convert map_cone_equiv H.fun_inv_id l,
+        rw functor.comp_id,
+        cases c, cases c_π, dsimp [functor.map_cone, cones.functoriality],
+        congr; rw functor.comp_id
+      end } } }
+
+/--
+A helper to show a functor creates limits. In particular, if we can show
+that for any limit cone `c` for `K ⋙ F`, there is a lift of it which is
+a limit and `F` reflects isomorphisms, then `F` creates limits.
+Usually, `F` creating limits says that _any_ lift of `c` is a limit, but
+here we only need to show that our particular lift of `c` is a limit.
+-/
+structure lifts_to_limit (K : J ⥤ C) (F : C ⥤ D) (c : cone (K ⋙ F)) (t : is_limit c) :=
+(lifted : liftable_cone K F c)
+(makes_limit : is_limit lifted.lifted_cone)
+
+/--
+If `F` reflects isomorphisms and we can lift any limit cone to a limit cone,
+then `F` creates limits.
+-/
+def creates_limit_of_reflects_iso {K : J ⥤ C} {F : C ⥤ D} [reflects_isomorphisms F]
+  (h : Π c t, lifts_to_limit K F c t) :
+  creates_limit K F :=
+{ lifts := λ c t, (h c t).lifted,
+  to_reflects_limit :=
+  { reflects := λ (d : cone K) (hd : is_limit (F.map_cone d)),
+    begin
+      let d' : cone K := (h (F.map_cone d) hd).lifted.lifted_cone,
+      let hd'₁ : F.map_cone d' ≅ F.map_cone d := (h (F.map_cone d) hd).lifted.valid_lift,
+      let hd'₂ : is_limit d' := (h (F.map_cone d) hd).makes_limit,
+      let f : d ⟶ d' := hd'₂.lift_cone_morphism d,
+      have: F.map_cone_morphism f = hd'₁.inv := (hd.of_iso_limit hd'₁.symm).uniq_cone_morphism,
+      have: @is_iso _ cone.category _ _ (functor.map_cone_morphism F f),
+        rw this, apply_instance,
+      haveI: is_iso ((cones.functoriality F).map f) := this,
+      haveI := is_iso_of_reflects_iso f (cones.functoriality F),
+      exact is_limit.of_iso_limit hd'₂ (as_iso f).symm,
+    end } }
+
+def map_cone_map_cone_inv (F : J ⥤ D) (H : D ⥤ C) [is_equivalence H] (c : cone (F ⋙ H)) :
+  functor.map_cone H (functor.map_cone_inv H c) ≅ c :=
+begin
+  apply cones.ext _ (λ j, _),
+  exact (functor.as_equivalence H).counit_iso.app c.X,
+  dsimp [functor.map_cone_inv, functor.as_equivalence, functor.inv],
+  erw category.comp_id,
+  erw ← H.inv_fun_id.hom.naturality (c.π.app j),
+  rw functor.comp_map, rw H.map_comp,
+  congr' 1,
+  rw ← cancel_epi (H.inv_fun_id.inv.app (H.obj (F.obj j))),
+  erw nat_iso.inv_hom_id_app,
+  erw ← (functor.as_equivalence H).functor_unit _,
+  erw ← H.map_comp,
+  erw nat_iso.hom_inv_id_app,
+  rw H.map_id, refl
+end
+
+@[priority 100] -- see Note [lower instance priority]
+instance is_equivalence_creates_limits (H : D ⥤ C) [is_equivalence H] : creates_limits H :=
+{ creates_limits_of_shape := λ J 𝒥, by exactI
+  { creates_limit := λ F,
+    { lifts := λ c t,
+      { lifted_cone := H.map_cone_inv c,
+        valid_lift := map_cone_map_cone_inv F H c } } } }
+
+section comp
+
+variables {E : Type u₃} [ℰ : category.{v} E]
+variables (F : C ⥤ D) (G : D ⥤ E)
+
+instance comp_creates_limit [i₁ : creates_limit K F] [i₂ : creates_limit (K ⋙ F) G] :
+  creates_limit K (F ⋙ G) :=
+{ lifts := λ c t,
+  { lifted_cone := lift_limit (lifted_limit_is_limit t),
+    valid_lift := (cones.functoriality G).map_iso (lifted_limit_maps_to_original F (lifted_limit_is_limit t)) ≪≫ (lifted_limit_maps_to_original G t),
+  } }
+
+end comp
+
+end creates
+
+namespace monad
+
+variables {T : C ⥤ C} [monad.{v} T]
+
+namespace impl
+variables {J : Type v} [𝒥 : small_category J]
+include 𝒥
+
+variables (D : J ⥤ algebra T) (c : cone (D ⋙ forget T)) (t : is_limit c)
+
+@[simps] def γ : (D ⋙ forget T ⋙ T) ⟶ (D ⋙ forget T) := { app := λ j, (D.obj j).a }
+
+@[simps] def new_cone : cone (D ⋙ forget T) :=
+{ X := T.obj c.X,
+  π := (functor.const_comp _ _ T).inv ≫ whisker_right c.π T ≫ (γ D) }
+
+@[simps] def cone_point : algebra T :=
+{ A := c.X,
+  a := t.lift (new_cone D c),
+  unit' :=
+  begin
+    apply t.hom_ext,
+    intro j,
+    rw [category.assoc], rw t.fac (new_cone D c),
+    dsimp, rw category.id_comp, rw ← category.assoc,
+    rw ← (η_ T).naturality, rw category.id_comp, rw functor.id_map,
+    rw category.assoc, rw (D.obj j).unit, erw category.comp_id
+  end,
+  assoc' :=
+  begin
+    apply t.hom_ext,
+    intro j,
+    rw category.assoc,
+    rw category.assoc,
+
+    rw t.fac (new_cone D c),
+    dsimp,
+    erw [category.id_comp],
+    slice_lhs 1 2 {rw ← (μ_ T).naturality},
+    slice_lhs 2 3 {rw (D.obj j).assoc},
+    slice_rhs 1 2 {rw ← T.map_comp},
+    rw t.fac (new_cone D c),
+    dsimp,
+    erw category.id_comp,
+    rw T.map_comp,
+    simp
+  end }
+
+@[simps] def lifted_cone : cone D :=
+{ X := cone_point D c t,
+  π :=
+  { app := λ j, { f := c.π.app j },
+    naturality' := λ X Y f, by { ext1, dsimp, erw c.w f, simp } } }
+
+@[simps]
+def lifted_cone_is_limit : is_limit (lifted_cone D c t) :=
+{ lift := λ s,
+  { f := t.lift ((forget T).map_cone s),
+    h' :=
+    begin
+      apply t.hom_ext, intro j,
+      have := t.fac ((forget T).map_cone s),
+      slice_rhs 2 3 {rw t.fac ((forget T).map_cone s) j},
+      dsimp,
+      slice_lhs 2 3 {rw t.fac (new_cone D c) j},
+      dsimp,
+      rw category.id_comp,
+      slice_lhs 1 2 {rw ← T.map_comp},
+      rw t.fac ((forget T).map_cone s) j,
+      exact (s.π.app j).h
+    end },
+  uniq' := λ s m J,
+  begin
+    ext1,
+    apply t.hom_ext,
+    intro j,
+    simpa [t.fac (functor.map_cone (forget T) s) j] using congr_arg algebra.hom.f (J j),
+  end }
+
+def lifted_cone_hits_original : (forget T).map_cone (lifted_cone D c t) = c :=
+begin
+  cases c,
+  cases c_π,
+  dsimp [functor.map_cone, cones.functoriality],
+  congr
+end
+
+end impl
+
+def forget_really_creates_limits : creates_limits (forget T) :=
+{ creates_limits_of_shape := λ J 𝒥, by exactI
+  { creates_limit := λ D,
+    creates_limit_of_reflects_iso (λ c t,
+    { lifted :=
+      { lifted_cone := impl.lifted_cone D c t,
+        valid_lift := eq_to_iso (impl.lifted_cone_hits_original _ _ _) },
+      makes_limit := impl.lifted_cone_is_limit _ _ _} ) } }
+
+end monad
+
+end category_theory

--- a/src/category_theory/limits/creates.lean
+++ b/src/category_theory/limits/creates.lean
@@ -223,6 +223,14 @@ def lifts_to_limit_of_creates (K : J ⥤ C) (F : C ⥤ D) [creates_limit K F] (c
   valid_lift := lifted_limit_maps_to_original t,
   makes_limit := lifted_limit_is_limit t }
 
+-- For the inhabited linter later.
+/-- If F creates the colimit of K, any cocone lifts to a colimit. -/
+def lifts_to_colimit_of_creates (K : J ⥤ C) (F : C ⥤ D) [creates_colimit K F] (c : cocone (K ⋙ F)) (t : is_colimit c) :
+  lifts_to_colimit K F c t :=
+{ lifted_cocone := lift_colimit t,
+  valid_lift := lifted_colimit_maps_to_original t,
+  makes_colimit := lifted_colimit_is_colimit t }
+
 @[priority 100] -- see Note [lower instance priority]
 instance is_equivalence_creates_limits (H : D ⥤ C) [is_equivalence H] : creates_limits H :=
 { creates_limits_of_shape := λ J 𝒥, by exactI
@@ -267,7 +275,9 @@ include 𝒟
 instance inhabited_lifts_to_limit (K : J ⥤ C) (F : C ⥤ D) [creates_limit K F] (c : cone (K ⋙ F)) (t : is_limit c) :
   inhabited (lifts_to_limit _ _ _ t) :=
 ⟨lifts_to_limit_of_creates K F c t⟩
-
+instance inhabited_lifts_to_colimit (K : J ⥤ C) (F : C ⥤ D) [creates_colimit K F] (c : cocone (K ⋙ F)) (t : is_colimit c) :
+  inhabited (lifts_to_colimit _ _ _ t) :=
+⟨lifts_to_colimit_of_creates K F c t⟩
 
 section comp
 

--- a/src/category_theory/limits/creates.lean
+++ b/src/category_theory/limits/creates.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
 import category_theory.limits.limits
-import category_theory.limits.preserves
-import category_theory.monad.adjunction
 import category_theory.adjunction.limits
 import category_theory.reflect_isomorphisms
 
@@ -157,8 +155,8 @@ def creates_limit_of_reflects_iso {K : J ⥤ C} {F : C ⥤ D} [reflects_isomorph
       have : F.map_cone_morphism f = hd'₁.inv := (hd.of_iso_limit hd'₁.symm).uniq_cone_morphism,
       have : @is_iso _ cone.category _ _ (functor.map_cone_morphism F f),
         rw this, apply_instance,
-      haveI : is_iso ((cones.functoriality F).map f) := this,
-      haveI := is_iso_of_reflects_iso f (cones.functoriality F),
+      haveI : is_iso ((cones.functoriality K F).map f) := this,
+      haveI := is_iso_of_reflects_iso f (cones.functoriality K F),
       exact is_limit.of_iso_limit hd'₂ (as_iso f).symm,
     end } }
 
@@ -179,7 +177,7 @@ instance comp_creates_limit [i₁ : creates_limit K F] [i₂ : creates_limit (K 
   creates_limit K (F ⋙ G) :=
 { lifts := λ c t,
   { lifted_cone := lift_limit (lifted_limit_is_limit t),
-    valid_lift := (cones.functoriality G).map_iso (lifted_limit_maps_to_original F (lifted_limit_is_limit t)) ≪≫ (lifted_limit_maps_to_original G t),
+    valid_lift := (cones.functoriality (K ⋙ F) G).map_iso (lifted_limit_maps_to_original F (lifted_limit_is_limit t)) ≪≫ (lifted_limit_maps_to_original G t),
   } }
 
 end comp

--- a/src/category_theory/limits/creates.lean
+++ b/src/category_theory/limits/creates.lean
@@ -193,8 +193,7 @@ def creates_limit_of_reflects_iso {K : J ⥤ C} {F : C ⥤ D} [reflects_isomorph
       let f : d ⟶ d' := hd'.lift_cone_morphism d,
       have : (cones.functoriality K F).map f = i.inv := (hd.of_iso_limit i.symm).uniq_cone_morphism,
       haveI : is_iso ((cones.functoriality K F).map f) := (by { rw this, apply_instance }),
-      -- We could omit this line, but perhaps it's helpful.
-      haveI : is_iso f := category_theory.is_iso_of_reflects_iso f (cones.functoriality K F),
+      haveI : is_iso f := is_iso_of_reflects_iso f (cones.functoriality K F),
       exact is_limit.of_iso_limit hd' (as_iso f).symm,
     end } }
 
@@ -216,8 +215,7 @@ def creates_colimit_of_reflects_iso {K : J ⥤ C} {F : C ⥤ D} [reflects_isomor
       let f : d' ⟶ d := hd'.desc_cocone_morphism d,
       have : (cocones.functoriality K F).map f = i.hom := (hd.of_iso_colimit i.symm).uniq_cocone_morphism,
       haveI : is_iso ((cocones.functoriality K F).map f) := (by { rw this, apply_instance }),
-      -- We could omit this line, but perhaps it's helpful.
-      haveI := category_theory.is_iso_of_reflects_iso f (cocones.functoriality K F),
+      haveI := is_iso_of_reflects_iso f (cocones.functoriality K F),
       exact is_colimit.of_iso_colimit hd' (as_iso f),
     end } }
 

--- a/src/category_theory/limits/creates.lean
+++ b/src/category_theory/limits/creates.lean
@@ -111,17 +111,20 @@ def lift_limit {K : J ⥤ C} {F : C ⥤ D} [creates_limit K F] {c : cone (K ⋙ 
 (creates_limit.lifts c t).lifted_cone
 
 /-- The lifted cone has an image isomorphic to the original cone. -/
-def lifted_limit_maps_to_original {K : J ⥤ C} {F : C ⥤ D} [creates_limit K F] {c : cone (K ⋙ F)} (t : is_limit c) :
+def lifted_limit_maps_to_original {K : J ⥤ C} {F : C ⥤ D}
+  [creates_limit K F] {c : cone (K ⋙ F)} (t : is_limit c) :
   F.map_cone (lift_limit t) ≅ c :=
 (creates_limit.lifts c t).valid_lift
 
 /-- The lifted cone is a limit. -/
-def lifted_limit_is_limit {K : J ⥤ C} {F : C ⥤ D} [creates_limit K F] {c : cone (K ⋙ F)} (t : is_limit c) :
+def lifted_limit_is_limit {K : J ⥤ C} {F : C ⥤ D}
+  [creates_limit K F] {c : cone (K ⋙ F)} (t : is_limit c) :
   is_limit (lift_limit t) :=
 reflects_limit.reflects (is_limit.of_iso_limit t (lifted_limit_maps_to_original t).symm)
 
 /-- If `F` creates the limit of `K` and `K ⋙ F` has a limit, then `K` has a limit. -/
-def has_limit_of_created (K : J ⥤ C) (F : C ⥤ D) [has_limit (K ⋙ F)] [creates_limit K F] : has_limit K :=
+def has_limit_of_created (K : J ⥤ C) (F : C ⥤ D)
+  [has_limit (K ⋙ F)] [creates_limit K F] : has_limit K :=
 { cone := lift_limit (limit.is_limit (K ⋙ F)),
   is_limit := lifted_limit_is_limit _ }
 
@@ -133,17 +136,20 @@ def lift_colimit {K : J ⥤ C} {F : C ⥤ D} [creates_colimit K F] {c : cocone (
 (creates_colimit.lifts c t).lifted_cocone
 
 /-- The lifted cocone has an image isomorphic to the original cocone. -/
-def lifted_colimit_maps_to_original {K : J ⥤ C} {F : C ⥤ D} [creates_colimit K F] {c : cocone (K ⋙ F)} (t : is_colimit c) :
+def lifted_colimit_maps_to_original {K : J ⥤ C} {F : C ⥤ D}
+  [creates_colimit K F] {c : cocone (K ⋙ F)} (t : is_colimit c) :
   F.map_cocone (lift_colimit t) ≅ c :=
 (creates_colimit.lifts c t).valid_lift
 
 /-- The lifted cocone is a colimit. -/
-def lifted_colimit_is_colimit {K : J ⥤ C} {F : C ⥤ D} [creates_colimit K F] {c : cocone (K ⋙ F)} (t : is_colimit c) :
+def lifted_colimit_is_colimit {K : J ⥤ C} {F : C ⥤ D}
+  [creates_colimit K F] {c : cocone (K ⋙ F)} (t : is_colimit c) :
   is_colimit (lift_colimit t) :=
 reflects_colimit.reflects (is_colimit.of_iso_colimit t (lifted_colimit_maps_to_original t).symm)
 
 /-- If `F` creates the limit of `K` and `K ⋙ F` has a limit, then `K` has a limit. -/
-def has_colimit_of_created (K : J ⥤ C) (F : C ⥤ D) [has_colimit (K ⋙ F)] [creates_colimit K F] : has_colimit K :=
+def has_colimit_of_created (K : J ⥤ C) (F : C ⥤ D)
+  [has_colimit (K ⋙ F)] [creates_colimit K F] : has_colimit K :=
 { cocone := lift_colimit (colimit.is_colimit (K ⋙ F)),
   is_colimit := lifted_colimit_is_colimit _ }
 
@@ -154,7 +160,8 @@ a limit and `F` reflects isomorphisms, then `F` creates limits.
 Usually, `F` creating limits says that _any_ lift of `c` is a limit, but
 here we only need to show that our particular lift of `c` is a limit.
 -/
-structure lifts_to_limit (K : J ⥤ C) (F : C ⥤ D) (c : cone (K ⋙ F)) (t : is_limit c) extends liftable_cone K F c :=
+structure lifts_to_limit (K : J ⥤ C) (F : C ⥤ D) (c : cone (K ⋙ F)) (t : is_limit c)
+  extends liftable_cone K F c :=
 (makes_limit : is_limit lifted_cone)
 
 /--
@@ -164,7 +171,8 @@ a limit and `F` reflects isomorphisms, then `F` creates colimits.
 Usually, `F` creating colimits says that _any_ lift of `c` is a colimit, but
 here we only need to show that our particular lift of `c` is a colimit.
 -/
-structure lifts_to_colimit (K : J ⥤ C) (F : C ⥤ D) (c : cocone (K ⋙ F)) (t : is_colimit c) extends liftable_cocone K F c :=
+structure lifts_to_colimit (K : J ⥤ C) (F : C ⥤ D) (c : cocone (K ⋙ F)) (t : is_colimit c)
+  extends liftable_cocone K F c :=
 (makes_colimit : is_colimit lifted_cocone)
 
 /--
@@ -180,15 +188,14 @@ def creates_limit_of_reflects_iso {K : J ⥤ C} {F : C ⥤ D} [reflects_isomorph
   { reflects := λ (d : cone K) (hd : is_limit (F.map_cone d)),
     begin
       let d' : cone K := (h (F.map_cone d) hd).to_liftable_cone.lifted_cone,
-      let hd'₁ : F.map_cone d' ≅ F.map_cone d := (h (F.map_cone d) hd).to_liftable_cone.valid_lift,
-      let hd'₂ : is_limit d' := (h (F.map_cone d) hd).makes_limit,
-      let f : d ⟶ d' := hd'₂.lift_cone_morphism d,
-      have : F.map_cone_morphism f = hd'₁.inv := (hd.of_iso_limit hd'₁.symm).uniq_cone_morphism,
-      have : @is_iso _ cone.category _ _ (F.map_cone_morphism f),
-        rw this, apply_instance,
-      haveI : is_iso ((cones.functoriality K F).map f) := this,
-      haveI := is_iso_of_reflects_iso f (cones.functoriality K F),
-      exact is_limit.of_iso_limit hd'₂ (as_iso f).symm,
+      let i : F.map_cone d' ≅ F.map_cone d := (h (F.map_cone d) hd).to_liftable_cone.valid_lift,
+      let hd' : is_limit d' := (h (F.map_cone d) hd).makes_limit,
+      let f : d ⟶ d' := hd'.lift_cone_morphism d,
+      have : (cones.functoriality K F).map f = i.inv := (hd.of_iso_limit i.symm).uniq_cone_morphism,
+      haveI : is_iso ((cones.functoriality K F).map f) := (by { rw this, apply_instance }),
+      -- We could omit this line, but perhaps it's helpful.
+      haveI : is_iso f := category_theory.is_iso_of_reflects_iso f (cones.functoriality K F),
+      exact is_limit.of_iso_limit hd' (as_iso f).symm,
     end } }
 
 /--
@@ -204,20 +211,20 @@ def creates_colimit_of_reflects_iso {K : J ⥤ C} {F : C ⥤ D} [reflects_isomor
   { reflects := λ (d : cocone K) (hd : is_colimit (F.map_cocone d)),
     begin
       let d' : cocone K := (h (F.map_cocone d) hd).to_liftable_cocone.lifted_cocone,
-      let hd'₁ : F.map_cocone d' ≅ F.map_cocone d := (h (F.map_cocone d) hd).to_liftable_cocone.valid_lift,
-      let hd'₂ : is_colimit d' := (h (F.map_cocone d) hd).makes_colimit,
-      let f : d' ⟶ d := hd'₂.desc_cocone_morphism d,
-      have : F.map_cocone_morphism f = hd'₁.hom := (hd.of_iso_colimit hd'₁.symm).uniq_cocone_morphism,
-      have : @is_iso _ cocone.category _ _ (F.map_cocone_morphism f),
-        rw this, apply_instance,
-      haveI : is_iso ((cocones.functoriality K F).map f) := this,
-      haveI := is_iso_of_reflects_iso f (cocones.functoriality K F),
-      exact is_colimit.of_iso_colimit hd'₂ (as_iso f),
+      let i : F.map_cocone d' ≅ F.map_cocone d := (h (F.map_cocone d) hd).to_liftable_cocone.valid_lift,
+      let hd' : is_colimit d' := (h (F.map_cocone d) hd).makes_colimit,
+      let f : d' ⟶ d := hd'.desc_cocone_morphism d,
+      have : (cocones.functoriality K F).map f = i.hom := (hd.of_iso_colimit i.symm).uniq_cocone_morphism,
+      haveI : is_iso ((cocones.functoriality K F).map f) := (by { rw this, apply_instance }),
+      -- We could omit this line, but perhaps it's helpful.
+      haveI := category_theory.is_iso_of_reflects_iso f (cocones.functoriality K F),
+      exact is_colimit.of_iso_colimit hd' (as_iso f),
     end } }
 
 -- For the inhabited linter later.
 /-- If F creates the limit of K, any cone lifts to a limit. -/
-def lifts_to_limit_of_creates (K : J ⥤ C) (F : C ⥤ D) [creates_limit K F] (c : cone (K ⋙ F)) (t : is_limit c) :
+def lifts_to_limit_of_creates (K : J ⥤ C) (F : C ⥤ D)
+  [creates_limit K F] (c : cone (K ⋙ F)) (t : is_limit c) :
   lifts_to_limit K F c t :=
 { lifted_cone := lift_limit t,
   valid_lift := lifted_limit_maps_to_original t,
@@ -225,7 +232,8 @@ def lifts_to_limit_of_creates (K : J ⥤ C) (F : C ⥤ D) [creates_limit K F] (c
 
 -- For the inhabited linter later.
 /-- If F creates the colimit of K, any cocone lifts to a colimit. -/
-def lifts_to_colimit_of_creates (K : J ⥤ C) (F : C ⥤ D) [creates_colimit K F] (c : cocone (K ⋙ F)) (t : is_colimit c) :
+def lifts_to_colimit_of_creates (K : J ⥤ C) (F : C ⥤ D)
+  [creates_colimit K F] (c : cocone (K ⋙ F)) (t : is_colimit c) :
   lifts_to_colimit K F c t :=
 { lifted_cocone := lift_colimit t,
   valid_lift := lifted_colimit_maps_to_original t,
@@ -272,10 +280,12 @@ instance inhabited_liftable_cocone (c : cocone (K ⋙ 𝟭 C)) : inhabited (lift
 include 𝒟
 
 /-- Satisfy the inhabited linter -/
-instance inhabited_lifts_to_limit (K : J ⥤ C) (F : C ⥤ D) [creates_limit K F] (c : cone (K ⋙ F)) (t : is_limit c) :
+instance inhabited_lifts_to_limit (K : J ⥤ C) (F : C ⥤ D)
+  [creates_limit K F] (c : cone (K ⋙ F)) (t : is_limit c) :
   inhabited (lifts_to_limit _ _ _ t) :=
 ⟨lifts_to_limit_of_creates K F c t⟩
-instance inhabited_lifts_to_colimit (K : J ⥤ C) (F : C ⥤ D) [creates_colimit K F] (c : cocone (K ⋙ F)) (t : is_colimit c) :
+instance inhabited_lifts_to_colimit (K : J ⥤ C) (F : C ⥤ D)
+  [creates_colimit K F] (c : cocone (K ⋙ F)) (t : is_colimit c) :
   inhabited (lifts_to_colimit _ _ _ t) :=
 ⟨lifts_to_colimit_of_creates K F c t⟩
 
@@ -288,7 +298,9 @@ instance comp_creates_limit [i₁ : creates_limit K F] [i₂ : creates_limit (K 
   creates_limit K (F ⋙ G) :=
 { lifts := λ c t,
   { lifted_cone := lift_limit (lifted_limit_is_limit t),
-    valid_lift := (cones.functoriality (K ⋙ F) G).map_iso (lifted_limit_maps_to_original (lifted_limit_is_limit t)) ≪≫ (lifted_limit_maps_to_original t),
+    valid_lift := (cones.functoriality (K ⋙ F) G).map_iso
+      (lifted_limit_maps_to_original (lifted_limit_is_limit t)) ≪≫
+      (lifted_limit_maps_to_original t),
   } }
 
 end comp

--- a/src/category_theory/limits/limits.lean
+++ b/src/category_theory/limits/limits.lean
@@ -137,6 +137,31 @@ def of_faithful {t : cone F} {D : Type u'} [category.{v} D] (G : C ⥤ D) [faith
     apply G.map_comp
   end }
 
+def map_cone_equiv {D : Type u'} [category.{v} D] {K : J ⥤ C} {F G : C ⥤ D} (h : F ≅ G) {c : cone K}
+  (t : is_limit (F.map_cone c)) : is_limit (G.map_cone c) :=
+{ lift := λ s, t.lift ((cones.postcompose (iso_whisker_left K h).inv).obj s) ≫ h.hom.app c.X,
+  fac' := λ s j,
+  begin
+    slice_lhs 2 3 {erw ← h.hom.naturality (c.π.app j)},
+    slice_lhs 1 2 {erw t.fac ((cones.postcompose (iso_whisker_left K h).inv).obj s) j},
+    dsimp,
+    slice_lhs 2 3 {rw nat_iso.inv_hom_id_app},
+    rw category.comp_id,
+  end,
+  uniq' := λ s m J,
+  begin
+    rw ← cancel_mono (h.inv.app c.X),
+    apply t.hom_ext,
+    intro j,
+    dsimp,
+    slice_lhs 2 3 {erw ← h.inv.naturality (c.π.app j)},
+    slice_lhs 1 2 {erw J j},
+    conv_rhs {congr, rw category.assoc, rw nat_iso.hom_inv_id_app},
+    rw category.comp_id,
+    erw t.fac ((cones.postcompose (iso_whisker_left K h).inv).obj s) j,
+    refl
+  end }
+
 /--
 A cone is a limit cone exactly if
 there is a unique cone morphism from any other cone.

--- a/src/category_theory/limits/limits.lean
+++ b/src/category_theory/limits/limits.lean
@@ -160,10 +160,8 @@ def map_cone_equiv {D : Type u'} [category.{v} D] {K : J ⥤ C} {F G : C ⥤ D} 
     dsimp,
     slice_lhs 2 3 {erw ← h.inv.naturality (c.π.app j)},
     slice_lhs 1 2 {erw J j},
-    conv_rhs {congr, rw category.assoc, rw nat_iso.hom_inv_id_app},
-    rw category.comp_id,
-    erw t.fac ((cones.postcompose (iso_whisker_left K h).inv).obj s) j,
-    refl
+    conv_rhs {congr, rw [category.assoc, nat_iso.hom_inv_id_app, comp_id]},
+    apply (t.fac ((cones.postcompose (iso_whisker_left K h).inv).obj s) j).symm
   end }
 
 /--

--- a/src/category_theory/limits/limits.lean
+++ b/src/category_theory/limits/limits.lean
@@ -137,6 +137,10 @@ def of_faithful {t : cone F} {D : Type u'} [category.{v} D] (G : C ⥤ D) [faith
     apply G.map_comp
   end }
 
+/--
+If `F` and `G` are naturally isomorphic, then `F.map_cone c` being a limit implies
+`G.map_cone c` is also a limit.
+-/
 def map_cone_equiv {D : Type u'} [category.{v} D] {K : J ⥤ C} {F G : C ⥤ D} (h : F ≅ G) {c : cone K}
   (t : is_limit (F.map_cone c)) : is_limit (G.map_cone c) :=
 { lift := λ s, t.lift ((cones.postcompose (iso_whisker_left K h).inv).obj s) ≫ h.hom.app c.X,

--- a/src/category_theory/limits/shapes/images.lean
+++ b/src/category_theory/limits/shapes/images.lean
@@ -69,6 +69,8 @@ structure mono_factorisation (f : X ⟶ Y) :=
 restate_axiom mono_factorisation.fac'
 attribute [simp, reassoc] mono_factorisation.fac
 
+attribute [instance] mono_factorisation.m_mono
+
 namespace mono_factorisation
 
 /-- The obvious factorisation of a monomorphism through itself. -/
@@ -127,8 +129,8 @@ must factor through isomorphic objects. -/
 def iso_ext {F F' : mono_factorisation f} (hF : is_image F) (hF' : is_image F') : F.I ≅ F'.I :=
 { hom := hF.lift F',
   inv := hF'.lift F,
-  hom_inv_id' := begin haveI := F.m_mono, apply (cancel_mono F.m).1, simp end,
-  inv_hom_id' := begin haveI := F'.m_mono, apply (cancel_mono F'.m).1, simp end }
+  hom_inv_id' := (cancel_mono F.m).1 (by simp),
+  inv_hom_id' := (cancel_mono F'.m).1 (by simp) }
 
 end is_image
 
@@ -187,12 +189,7 @@ end
 lemma has_image.uniq
   (F' : mono_factorisation f) (l : image f ⟶ F'.I) (w : l ≫ F'.m = image.ι f) :
   l = image.lift F' :=
-begin
-  haveI := F'.m_mono,
-  apply (cancel_mono F'.m).1,
-  rw w,
-  simp,
-end
+(cancel_mono F'.m).1 (by simp [w])
 end
 
 section
@@ -260,8 +257,8 @@ image.lift.{v}
 
 instance (h : f = f') : is_iso (image.eq_to_hom h) :=
 { inv := image.eq_to_hom h.symm,
-  hom_inv_id' := begin apply (cancel_mono (image.ι f)).1, simp [image.eq_to_hom], end,
-  inv_hom_id' := begin apply (cancel_mono (image.ι f')).1, simp [image.eq_to_hom], end, }
+  hom_inv_id' := (cancel_mono (image.ι f)).1 (by simp [image.eq_to_hom]),
+  inv_hom_id' := (cancel_mono (image.ι f')).1 (by simp [image.eq_to_hom]), }
 
 /-- An equation between morphisms gives an isomorphism between the images. -/
 def image.eq_to_iso (h : f = f') : image f ≅ image f' := as_iso (image.eq_to_hom h)

--- a/src/category_theory/monad/algebra.lean
+++ b/src/category_theory/monad/algebra.lean
@@ -5,6 +5,7 @@ Authors: Scott Morrison, Bhavik Mehta
 -/
 import category_theory.monad.basic
 import category_theory.adjunction.basic
+import category_theory.reflect_isomorphisms
 
 /-!
 # Eilenberg-Moore (co)algebras for a (co)monad
@@ -115,6 +116,20 @@ adjunction.mk_of_hom_equiv
       erw [←category.assoc, ←(η_ T).naturality, functor.id_map,
             category.assoc, Y.unit, comp_id],
     end }}
+
+def algebra_iso_of_iso {A B : algebra T} (f : A ⟶ B) [i : is_iso f.f] : is_iso f :=
+{ inv :=
+  { f := i.inv,
+    h' :=
+    begin
+      erw (as_iso f.f).eq_comp_inv,
+      slice_lhs 2 3 {erw ← f.h},
+      slice_lhs 1 2 {rw ← T.map_comp},
+      rw [is_iso.inv_hom_id, T.map_id, category.id_comp]
+    end } }
+
+instance forget_reflects_iso : reflects_isomorphisms (forget T) :=
+{ reflects := λ A B, algebra_iso_of_iso T }
 
 end monad
 

--- a/src/category_theory/monad/algebra.lean
+++ b/src/category_theory/monad/algebra.lean
@@ -117,6 +117,7 @@ adjunction.mk_of_hom_equiv
             category.assoc, Y.unit, comp_id],
     end }}
 
+/-- Given an algebra morphism whose carrier part is an isomorphism, we get an algebra isomorphism. -/
 def algebra_iso_of_iso {A B : algebra T} (f : A ⟶ B) [i : is_iso f.f] : is_iso f :=
 { inv :=
   { f := i.inv,

--- a/src/category_theory/monad/limits.lean
+++ b/src/category_theory/monad/limits.lean
@@ -91,6 +91,7 @@ def lifted_cone_is_limit : is_limit (lifted_cone D c t) :=
 
 end forget_creates_limits
 
+omit 𝒥
 -- Theorem 5.6.5 from [Riehl][riehl2017]
 /-- The forgetful functor from the Eilenberg-Moore category creates limits. -/
 instance forget_creates_limits : creates_limits (forget T) :=
@@ -101,6 +102,7 @@ instance forget_creates_limits : creates_limits (forget T) :=
       { lifted_cone := forget_creates_limits.lifted_cone D c t,
         valid_lift := cones.ext (iso.refl _) (λ j, (id_comp _).symm) },
       makes_limit := forget_creates_limits.lifted_cone_is_limit _ _ _} ) } }
+include 𝒥
 
 def has_limit_of_comp_forget_has_limit (D : J ⥤ algebra T) [has_limit (D ⋙ forget T)] : has_limit D :=
 has_limit_of_created D (forget T)

--- a/src/category_theory/monad/limits.lean
+++ b/src/category_theory/monad/limits.lean
@@ -1,10 +1,11 @@
 /-
 Copyright (c) 2019 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Scott MorrisoE
+Authors: Scott Morrison, Bhavik Mehta
 -/
 import category_theory.monad.adjunction
 import category_theory.adjunction.limits
+import category_theory.limits.creates
 
 namespace category_theory
 open category
@@ -22,66 +23,87 @@ variables {J : Type v₁} [𝒥 : small_category J]
 include 𝒥
 
 namespace forget_creates_limits
-variables (D : J ⥤ algebra T) [has_limit.{v₁} (D ⋙ forget T)]
+
+variables (D : J ⥤ algebra T) (c : cone (D ⋙ forget T)) (t : is_limit c)
 
 @[simps] def γ : (D ⋙ forget T ⋙ T) ⟶ (D ⋙ forget T) := { app := λ j, (D.obj j).a }
 
-@[simps] def c : cone (D ⋙ forget T) :=
-{ X := T.obj (limit (D ⋙ forget T)),
-  π := (functor.const_comp _ _ T).inv ≫ whisker_right (limit.cone (D ⋙ forget T)).π T ≫ (γ D) }
+@[simps] def new_cone : cone (D ⋙ forget T) :=
+{ X := T.obj c.X,
+  π := (functor.const_comp _ _ T).inv ≫ whisker_right c.π T ≫ (γ D) }
 
-@[simps] def cone_point (D : J ⥤ algebra T) [has_limit.{v₁} (D ⋙ forget T)] : algebra T :=
-{ A := limit (D ⋙ forget T),
-  a := limit.lift _ (c D),
+@[simps] def cone_point : algebra T :=
+{ A := c.X,
+  a := t.lift (new_cone D c),
   unit' :=
   begin
-    ext1,
-    rw [category.assoc, limit.lift_π],
+    apply t.hom_ext,
+    intro j,
+    erw [category.assoc, t.fac (new_cone D c), id_comp],
     dsimp,
-    erw [id_comp, ←category.assoc, ←nat_trans.naturality,
-        id_comp, category.assoc, algebra.unit, comp_id],
-    refl,
+    erw [id_comp, ← category.assoc, ← (η_ T).naturality, functor.id_map, category.assoc,
+         (D.obj j).unit, comp_id],
   end,
   assoc' :=
   begin
+    apply t.hom_ext,
+    intro j,
+    rw [category.assoc, category.assoc, t.fac (new_cone D c)],
+    dsimp,
+    erw id_comp,
+    slice_lhs 1 2 {rw ← (μ_ T).naturality},
+    slice_lhs 2 3 {rw (D.obj j).assoc},
+    slice_rhs 1 2 {rw ← T.map_comp},
+    rw t.fac (new_cone D c),
+    dsimp,
+    erw [id_comp, T.map_comp, category.assoc]
+  end }
+
+@[simps] def lifted_cone : cone D :=
+{ X := cone_point D c t,
+  π := { app := λ j, { f := c.π.app j },
+         naturality' := λ X Y f, by { ext1, dsimp, erw c.w f, simp } } }
+
+@[simps]
+def lifted_cone_is_limit : is_limit (lifted_cone D c t) :=
+{ lift := λ s,
+  { f := t.lift ((forget T).map_cone s),
+    h' :=
+    begin
+      apply t.hom_ext, intro j,
+      have := t.fac ((forget T).map_cone s),
+      slice_rhs 2 3 {rw t.fac ((forget T).map_cone s) j},
+      dsimp,
+      slice_lhs 2 3 {rw t.fac (new_cone D c) j},
+      dsimp,
+      rw category.id_comp,
+      slice_lhs 1 2 {rw ← T.map_comp},
+      rw t.fac ((forget T).map_cone s) j,
+      exact (s.π.app j).h
+    end },
+  uniq' := λ s m J,
+  begin
     ext1,
-    dsimp,
-    simp only [limit.lift_π, γ_app, c_π, limit.cone_π, functor.const_comp, whisker_right_app,
-                nat_trans.comp_app, category.assoc],
-    dsimp,
-    simp only [id_comp],
-    conv { to_rhs,
-      rw [←category.assoc, ←T.map_comp, limit.lift_π],
-      dsimp [c],
-      rw [id_comp], },
-    conv { to_lhs,
-      rw [←category.assoc, ←nat_trans.naturality, category.assoc],
-      erw [algebra.assoc (D.obj j), ←category.assoc, ←T.map_comp], },
+    apply t.hom_ext,
+    intro j,
+    simpa [t.fac (functor.map_cone (forget T) s) j] using congr_arg algebra.hom.f (J j),
   end }
 
 end forget_creates_limits
 
 -- Theorem 5.6.5 from [Riehl][riehl2017]
 /-- The forgetful functor from the Eilenberg-Moore category creates limits. -/
-def forget_creates_limits (D : J ⥤ algebra T) [has_limit (D ⋙ forget T)] : has_limit D :=
-{ cone :=
-  { X := forget_creates_limits.cone_point D,
-    π :=
-    { app := λ j, { f := limit.π (D ⋙ forget T) j },
-      naturality' := λ X Y f, by { ext, dsimp, erw [id_comp, limit.w] } } },
-  is_limit :=
-  { lift := λ s,
-    { f := limit.lift _ ((forget T).map_cone s),
-      h' :=
-      begin
-        ext, dsimp,
-        simp only [limit.lift_π, limit.cone_π, forget_map, id_comp, functor.const_comp,
-                    whisker_right_app, nat_trans.comp_app, category.assoc, functor.map_cone_π],
-        dsimp,
-        rw [id_comp, ←category.assoc, ←T.map_comp],
-        simp only [limit.lift_π, monad.forget_map, algebra.hom.h, functor.map_cone_π],
-      end },
-    uniq' := λ s m w, by { ext1, ext1, simpa using congr_arg algebra.hom.f (w j) } } }
+instance forget_creates_limits : creates_limits (forget T) :=
+{ creates_limits_of_shape := λ J 𝒥, by exactI
+  { creates_limit := λ D,
+    creates_limit_of_reflects_iso (λ c t,
+    { lifted :=
+      { lifted_cone := forget_creates_limits.lifted_cone D c t,
+        valid_lift := cones.ext (iso.refl _) (λ j, (id_comp _).symm) },
+      makes_limit := forget_creates_limits.lifted_cone_is_limit _ _ _} ) } }
+
+def has_limit_of_comp_forget_has_limit (D : J ⥤ algebra T) [has_limit (D ⋙ forget T)] : has_limit D :=
+has_limit_of_created D (forget T)
 
 namespace forget_creates_colimits
 -- Let's hide the implementation details in a namespace
@@ -213,7 +235,7 @@ instance comp_comparison_forget_has_limit
 instance comp_comparison_has_limit
   (F : J ⥤ D) (R : D ⥤ C) [monadic_right_adjoint R] [has_limit.{v₁} (F ⋙ R)] :
   has_limit (F ⋙ monad.comparison R) :=
-monad.forget_creates_limits (F ⋙ monad.comparison R)
+monad.has_limit_of_comp_forget_has_limit (F ⋙ monad.comparison R)
 
 /-- Any monadic functor creates limits. -/
 def monadic_creates_limits (F : J ⥤ D) (R : D ⥤ C) [monadic_right_adjoint R] [has_limit.{v₁} (F ⋙ R)] :

--- a/src/category_theory/monad/limits.lean
+++ b/src/category_theory/monad/limits.lean
@@ -103,10 +103,9 @@ instance forget_creates_limits : creates_limits (forget T) :=
 { creates_limits_of_shape := λ J 𝒥, by exactI
   { creates_limit := λ D,
     creates_limit_of_reflects_iso (λ c t,
-    { lifted :=
-      { lifted_cone := forget_creates_limits.lifted_cone D c t,
-        valid_lift := cones.ext (iso.refl _) (λ j, (id_comp _).symm) },
-      makes_limit := forget_creates_limits.lifted_cone_is_limit _ _ _} ) } }
+    { lifted_cone := forget_creates_limits.lifted_cone D c t,
+      valid_lift := cones.ext (iso.refl _) (λ j, (id_comp _).symm),
+      makes_limit := forget_creates_limits.lifted_cone_is_limit _ _ _ } ) } }
 include 𝒥
 
 def has_limit_of_comp_forget_has_limit (D : J ⥤ algebra T) [has_limit (D ⋙ forget T)] : has_limit D :=

--- a/src/category_theory/monad/limits.lean
+++ b/src/category_theory/monad/limits.lean
@@ -26,12 +26,15 @@ namespace forget_creates_limits
 
 variables (D : J ⥤ algebra T) (c : cone (D ⋙ forget T)) (t : is_limit c)
 
+/-- (Impl) The natural transformation used to define the new cone -/
 @[simps] def γ : (D ⋙ forget T ⋙ T) ⟶ (D ⋙ forget T) := { app := λ j, (D.obj j).a }
 
+/-- (Impl) This new cone is used to construct the algebra structure -/
 @[simps] def new_cone : cone (D ⋙ forget T) :=
 { X := T.obj c.X,
   π := (functor.const_comp _ _ T).inv ≫ whisker_right c.π T ≫ (γ D) }
 
+/-- The algebra structure which will be the apex of the new limit cone for `D`. -/
 @[simps] def cone_point : algebra T :=
 { A := c.X,
   a := t.lift (new_cone D c),
@@ -59,11 +62,13 @@ variables (D : J ⥤ algebra T) (c : cone (D ⋙ forget T)) (t : is_limit c)
     erw [id_comp, T.map_comp, category.assoc]
   end }
 
+/-- (Impl) Construct the lifted cone in `algebra T` which will be limiting. -/
 @[simps] def lifted_cone : cone D :=
 { X := cone_point D c t,
   π := { app := λ j, { f := c.π.app j },
          naturality' := λ X Y f, by { ext1, dsimp, erw c.w f, simp } } }
 
+/-- (Impl) Prove that the lifted cone is limiting. -/
 @[simps]
 def lifted_cone_is_limit : is_limit (lifted_cone D c t) :=
 { lift := λ s,

--- a/src/category_theory/reflect_isomorphisms.lean
+++ b/src/category_theory/reflect_isomorphisms.lean
@@ -27,10 +27,8 @@ Note that we do not assume or require that `F` is faithful.
 class reflects_isomorphisms (F : C ⥤ D) :=
 (reflects : Π {A B : C} (f : A ⟶ B) [is_iso (F.map f)], is_iso f)
 
--- TODO: reflects iso is equivalent to reflecting limits of shape 1 (punit)
-
 /-- If `F` reflects isos and `F.map f` is an iso, then `f` is an iso. -/
-instance is_iso_of_reflects_iso {A B : C} (f : A ⟶ B) (F : C ⥤ D)
+def is_iso_of_reflects_iso {A B : C} (f : A ⟶ B) (F : C ⥤ D)
   [is_iso (F.map f)] [reflects_isomorphisms F] :
   is_iso f :=
 reflects_isomorphisms.reflects F f

--- a/src/category_theory/reflect_isomorphisms.lean
+++ b/src/category_theory/reflect_isomorphisms.lean
@@ -27,6 +27,8 @@ Note that we do not assume or require that `F` is faithful.
 class reflects_isomorphisms (F : C ⥤ D) :=
 (reflects : Π {A B : C} (f : A ⟶ B) [is_iso (F.map f)], is_iso f)
 
+-- TODO: reflects iso is equivalent to reflecting limits of shape 1 (punit)
+
 -- Having this as an instance seems to break resolution, so let's not.
 /-- If `F` reflects isos and `F.map f` is an iso, then `f` is an iso. -/
 def is_iso_of_reflects_iso {A B : C} (f : A ⟶ B) (F : C ⥤ D)
@@ -61,7 +63,6 @@ def cocone_iso_of_hom_iso {K : J ⥤ C} {c d : cocone K} (f : c ⟶ d) [i : is_i
 variables {D : Type u₂} [𝒟 : category.{v₁} D]
 include 𝒟
 
--- TODO: should cones.functoriality take K as an explicit argument? I think so...
 /--
 If `F` reflects isomorphisms, then `cones.functoriality F` reflects isomorphisms
 as well.

--- a/src/category_theory/reflect_isomorphisms.lean
+++ b/src/category_theory/reflect_isomorphisms.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2020 Bhavik Mehta. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Bhavik Mehta
+-/
+import category_theory.limits.limits
+import category_theory.limits.preserves
+
+open category_theory category_theory.limits
+
+namespace category_theory
+
+universes v₁ v₂ u₁ u₂
+
+variables {C : Type u₁} [𝒞 : category.{v₁} C]
+include 𝒞
+
+section reflects_iso
+variables {D : Type u₂} [𝒟 : category.{v₂} D]
+include 𝒟
+
+/--
+Define what it means for a functor `F : C ⥤ D` to reflect isomorphisms: for any
+morphism `f : A ⟶ B`, if `F.map f` is an isomorphism then `f` is as well.
+Note that we do not assume or require that `F` is faithful.
+-/
+class reflects_isomorphisms (F : C ⥤ D) :=
+(reflects : Π {A B : C} (f : A ⟶ B) [is_iso (F.map f)], is_iso f)
+
+-- Having this as an instance seems to break resolution, so let's not.
+/-- If `F` reflects isos and `F.map f` is an iso, then `f` is an iso. -/
+def is_iso_of_reflects_iso {A B : C} (f : A ⟶ B) (F : C ⥤ D)
+  [h : reflects_isomorphisms F] [is_iso (F.map f)] :
+  is_iso f :=
+reflects_isomorphisms.reflects F f
+
+end reflects_iso
+
+variables {J : Type v₁} [small_category J] {K : J ⥤ C}
+
+/--
+Given a cone morphism whose object part is an isomorphism, produce an
+isomorphism of cones.
+-/
+def cone_iso_of_hom_iso {K : J ⥤ C} {c d : cone K} (f : c ⟶ d) [i : is_iso f.hom] :
+  is_iso f :=
+{ inv :=
+  { hom := i.inv,
+    w' := λ j, (as_iso f.hom).inv_comp_eq.2 (f.w j).symm } }
+
+/--
+Given a cocone morphism whose object part is an isomorphism, produce an
+isomorphism of cocones.
+-/
+def cocone_iso_of_hom_iso {K : J ⥤ C} {c d : cocone K} (f : c ⟶ d) [i : is_iso f.hom] :
+  is_iso f :=
+{ inv :=
+  { hom := i.inv,
+    w' := λ j, (as_iso f.hom).comp_inv_eq.2 (f.w j).symm } }
+
+variables {D : Type u₂} [𝒟 : category.{v₁} D]
+include 𝒟
+
+-- TODO: should cones.functoriality take K as an explicit argument? I think so...
+/--
+If `F` reflects isomorphisms, then `cones.functoriality F` reflects isomorphisms
+as well.
+-/
+instance reflects_cone_isomorphism (F : C ⥤ D) [reflects_isomorphisms F] (K : J ⥤ C) :
+  reflects_isomorphisms (@cones.functoriality _ _ _ _ K _ _ F) :=
+begin
+  constructor,
+  introsI,
+  haveI : is_iso (F.map f.hom) := (cones.forget (K ⋙ F)).map_is_iso ((cones.functoriality F).map f),
+  haveI := reflects_isomorphisms.reflects F f.hom,
+  apply cone_iso_of_hom_iso
+end
+
+/--
+If `F` reflects isomorphisms, then `cocones.functoriality F` reflects isomorphisms
+as well.
+-/
+instance reflects_cocone_isomorphism (F : C ⥤ D) [reflects_isomorphisms F] (K : J ⥤ C) :
+  reflects_isomorphisms (@cocones.functoriality _ _ _ _ K _ _ F) :=
+begin
+  constructor,
+  introsI,
+  haveI : is_iso (F.map f.hom) := (cocones.forget (K ⋙ F)).map_is_iso ((cocones.functoriality F).map f),
+  haveI := reflects_isomorphisms.reflects F f.hom,
+  apply cocone_iso_of_hom_iso
+end
+
+
+end category_theory

--- a/src/category_theory/reflect_isomorphisms.lean
+++ b/src/category_theory/reflect_isomorphisms.lean
@@ -29,10 +29,9 @@ class reflects_isomorphisms (F : C ⥤ D) :=
 
 -- TODO: reflects iso is equivalent to reflecting limits of shape 1 (punit)
 
--- Having this as an instance seems to break resolution, so let's not.
 /-- If `F` reflects isos and `F.map f` is an iso, then `f` is an iso. -/
-def is_iso_of_reflects_iso {A B : C} (f : A ⟶ B) (F : C ⥤ D)
-  [h : reflects_isomorphisms F] [is_iso (F.map f)] :
+instance is_iso_of_reflects_iso {A B : C} (f : A ⟶ B) (F : C ⥤ D)
+  [is_iso (F.map f)] [reflects_isomorphisms F] :
   is_iso f :=
 reflects_isomorphisms.reflects F f
 

--- a/src/category_theory/reflect_isomorphisms.lean
+++ b/src/category_theory/reflect_isomorphisms.lean
@@ -67,11 +67,11 @@ If `F` reflects isomorphisms, then `cones.functoriality F` reflects isomorphisms
 as well.
 -/
 instance reflects_cone_isomorphism (F : C ⥤ D) [reflects_isomorphisms F] (K : J ⥤ C) :
-  reflects_isomorphisms (@cones.functoriality _ _ _ _ K _ _ F) :=
+  reflects_isomorphisms (cones.functoriality K F) :=
 begin
   constructor,
   introsI,
-  haveI : is_iso (F.map f.hom) := (cones.forget (K ⋙ F)).map_is_iso ((cones.functoriality F).map f),
+  haveI : is_iso (F.map f.hom) := (cones.forget (K ⋙ F)).map_is_iso ((cones.functoriality K F).map f),
   haveI := reflects_isomorphisms.reflects F f.hom,
   apply cone_iso_of_hom_iso
 end
@@ -81,11 +81,11 @@ If `F` reflects isomorphisms, then `cocones.functoriality F` reflects isomorphis
 as well.
 -/
 instance reflects_cocone_isomorphism (F : C ⥤ D) [reflects_isomorphisms F] (K : J ⥤ C) :
-  reflects_isomorphisms (@cocones.functoriality _ _ _ _ K _ _ F) :=
+  reflects_isomorphisms (cocones.functoriality K F) :=
 begin
   constructor,
   introsI,
-  haveI : is_iso (F.map f.hom) := (cocones.forget (K ⋙ F)).map_is_iso ((cocones.functoriality F).map f),
+  haveI : is_iso (F.map f.hom) := (cocones.forget (K ⋙ F)).map_is_iso ((cocones.functoriality K F).map f),
   haveI := reflects_isomorphisms.reflects F f.hom,
   apply cocone_iso_of_hom_iso
 end


### PR DESCRIPTION
Define creation of limits and reflection of isomorphisms.

Part 2 of a sequence of PRs aiming to resolve my TODO [here](https://github.com/leanprover-community/mathlib/blob/cf89963e14cf535783cefba471247ae4470fa8c3/src/category_theory/limits/over.lean#L143) - that the forgetful functor from the over category creates connected limits.

Remaining:

- [x] Add an instance or def which gives that if `F` creates limits and `K ⋙ F` `has_limit` then `has_limit K` as well.
- [x] Move the forget creates limits proof to limits/over, and remove the existing proof since this one is strictly stronger - make sure to keep the statement there though using the previous point.
- [x] Add more docstrings

Probably relevant to @semorrison and @TwoFX.

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
