### PR TITLE
[Merged by Bors] - feat(category_theory/limits): strong epimorphisms and strong epi-mono factorizations

### DIFF
--- a/src/category_theory/comma.lean
+++ b/src/category_theory/comma.lean
@@ -516,6 +516,8 @@ def hom_mk' {X Y : T} {f : X ⟶ Y} {P Q : T} {g : P ⟶ Q} {u : X ⟶ P} {v : Y
 @[simp] lemma hom_mk'_right {X Y : T} {f : X ⟶ Y} {P Q : T} {g : P ⟶ Q} {u : X ⟶ P} {v : Y ⟶ Q}
   (w : u ≫ g = f ≫ v) : (hom_mk' w).right = v := rfl
 
+@[reassoc] lemma w {f g : arrow T} (sq : f ⟶ g) : sq.left ≫ g.hom = f.hom ≫ sq.right := sq.w
+
 /-- A lift of a commutative square is a diagonal morphism making the two triangles commute. -/
 @[ext] class has_lift {f g : arrow T} (sq : f ⟶ g) :=
 (lift : f.right ⟶ g.left)

--- a/src/category_theory/comma.lean
+++ b/src/category_theory/comma.lean
@@ -516,6 +516,46 @@ def hom_mk' {X Y : T} {f : X ⟶ Y} {P Q : T} {g : P ⟶ Q} {u : X ⟶ P} {v : Y
 @[simp] lemma hom_mk'_right {X Y : T} {f : X ⟶ Y} {P Q : T} {g : P ⟶ Q} {u : X ⟶ P} {v : Y ⟶ Q}
   (w : u ≫ g = f ≫ v) : (hom_mk' w).right = v := rfl
 
+/-- A lift of a commutative square is a diagonal morphism making the two triangles commute. -/
+@[ext] class has_lift {f g : arrow T} (sq : f ⟶ g) :=
+(lift : f.right ⟶ g.left)
+(fac_left : f.hom ≫ lift = sq.left)
+(fac_right : lift ≫ g.hom = sq.right)
+
+attribute [simp, reassoc] has_lift.fac_left has_lift.fac_right
+
+/-- If we have chosen a lift of a commutative square `sq`, we can access it by saying `lift sq`. -/
+abbreviation lift {f g : arrow T} (sq : f ⟶ g) [has_lift sq] : f.right ⟶ g.left :=
+has_lift.lift sq
+
+lemma lift.fac_left {f g : arrow T} (sq : f ⟶ g) [has_lift sq] : f.hom ≫ lift sq = sq.left :=
+by simp
+
+lemma lift.fac_right {f g : arrow T} (sq : f ⟶ g) [has_lift sq] : lift sq ≫ g.hom = sq.right :=
+by simp
+
+@[simp, reassoc]
+lemma lift_mk'_left {X Y P Q : T} {f : X ⟶ Y} {g : P ⟶ Q} {u : X ⟶ P} {v : Y ⟶ Q}
+  (h : u ≫ g = f ≫ v) [has_lift $ arrow.hom_mk' h] : f ≫ lift (arrow.hom_mk' h) = u :=
+by simp only [←arrow.mk_hom f, lift.fac_left, arrow.hom_mk'_left]
+
+@[simp, reassoc]
+lemma lift_mk'_right {X Y P Q : T} {f : X ⟶ Y} {g : P ⟶ Q} {u : X ⟶ P} {v : Y ⟶ Q}
+  (h : u ≫ g = f ≫ v) [has_lift $ arrow.hom_mk' h] : lift (arrow.hom_mk' h) ≫ g = v :=
+by simp only [←arrow.mk_hom g, lift.fac_right, arrow.hom_mk'_right]
+
+section
+
+instance subsingleton_lift_of_epi {f g : arrow T} (sq : f ⟶ g) [epi f.hom] :
+  subsingleton (has_lift sq) :=
+subsingleton.intro $ λ a b, has_lift.ext a b $ (cancel_epi f.hom).1 $ by simp
+
+instance subsingleton_lifting_of_mono {f g : arrow T} (sq : f ⟶ g) [mono g.hom] :
+  subsingleton (has_lift sq) :=
+subsingleton.intro $ λ a b, has_lift.ext a b $ (cancel_mono g.hom).1 $ by simp
+
+end
+
 end arrow
 
 end category_theory

--- a/src/category_theory/comma.lean
+++ b/src/category_theory/comma.lean
@@ -548,11 +548,11 @@ by simp only [←arrow.mk_hom g, lift.fac_right, arrow.hom_mk'_right]
 
 section
 
-instance subsingleton_lift_of_epi {f g : arrow T} (sq : f ⟶ g) [epi f.hom] :
+instance subsingleton_has_lift_of_epi {f g : arrow T} (sq : f ⟶ g) [epi f.hom] :
   subsingleton (has_lift sq) :=
 subsingleton.intro $ λ a b, has_lift.ext a b $ (cancel_epi f.hom).1 $ by simp
 
-instance subsingleton_lifting_of_mono {f g : arrow T} (sq : f ⟶ g) [mono g.hom] :
+instance subsingleton_has_lift_of_mono {f g : arrow T} (sq : f ⟶ g) [mono g.hom] :
   subsingleton (has_lift sq) :=
 subsingleton.intro $ λ a b, has_lift.ext a b $ (cancel_mono g.hom).1 $ by simp
 

--- a/src/category_theory/limits/shapes/images.lean
+++ b/src/category_theory/limits/shapes/images.lean
@@ -421,44 +421,35 @@ section strong_epi_mono_factorisation
 
 /-- A strong epi-mono factorisation is a decomposition `f = e ≫ m` with `e` a strong epimorphism
     and `m` a monomorphism. -/
-structure strong_epi_mono_factorisation {X Y : C} (f : X ⟶ Y) :=
-(I : C)
-(e : X ⟶ I)
-(m : I ⟶ Y)
-(fac : e ≫ m = f)
+structure strong_epi_mono_factorisation {X Y : C} (f : X ⟶ Y) extends mono_factorisation.{v} f :=
 [e_strong_epi : strong_epi e]
-[m_mono : mono m]
 
-attribute [instance] strong_epi_mono_factorisation.m_mono strong_epi_mono_factorisation.e_strong_epi
+attribute [instance] strong_epi_mono_factorisation.e_strong_epi
 
 /-- Satisfying the inhabited linter -/
 instance strong_epi_mono_factorisation_inhabited {X Y : C} (f : X ⟶ Y) [strong_epi f] :
   inhabited (strong_epi_mono_factorisation f) :=
-⟨⟨Y, f, 𝟙 Y, by simp⟩⟩
-
-/-- A strong epi-mono factorisation is in particular a mono factorisation. -/
-def strong_epi_mono_factorisation.to_mono_factorisation {X Y : C} {f : X ⟶ Y}
-  (F : strong_epi_mono_factorisation f) : mono_factorisation f :=
-⟨F.I, F.m, F.e, F.fac⟩
+⟨⟨⟨Y, 𝟙 Y, f, by simp⟩⟩⟩
 
 /-- A mono factorisation coming from a strong epi-mono factorisation always has the universal
     property of the image. -/
 def strong_epi_mono_factorisation.to_mono_is_image {X Y : C} {f : X ⟶ Y}
   (F : strong_epi_mono_factorisation f) : is_image F.to_mono_factorisation :=
-{ lift := λ G, arrow.lift $ arrow.hom_mk' $ show G.e ≫ G.m = F.e ≫ F.m, by rw [F.fac, G.fac] }
+{ lift := λ G, arrow.lift $ arrow.hom_mk' $
+    show G.e ≫ G.m = F.e ≫ F.m, by rw [F.to_mono_factorisation.fac, G.fac] }
 
 variable (C)
 
 /-- A category has strong epi-mono factorisations if every morphism admits a strong epi-mono
     factorisation. -/
 class has_strong_epi_mono_factorisations :=
-(has_fact : Π {X Y : C} (f : X ⟶ Y), strong_epi_mono_factorisation.{v} f)
+(has_fac : Π {X Y : C} (f : X ⟶ Y), strong_epi_mono_factorisation.{v} f)
 
 @[priority 100]
 instance has_images_of_has_strong_epi_mono_factorisations
   [has_strong_epi_mono_factorisations.{v} C] : has_images.{v} C :=
 { has_image := λ X Y f,
-  let F' := has_strong_epi_mono_factorisations.has_fact f in
+  let F' := has_strong_epi_mono_factorisations.has_fac f in
   { F := F'.to_mono_factorisation,
     is_image := F'.to_mono_is_image } }
 
@@ -483,7 +474,7 @@ section has_strong_epi_images
 instance has_strong_epi_images_of_has_strong_epi_mono_factorisations
   [has_strong_epi_mono_factorisations.{v} C] : has_strong_epi_images.{v} C :=
 { strong_factor_thru_image := λ X Y f,
-    (has_strong_epi_mono_factorisations.has_fact f).e_strong_epi }
+    (has_strong_epi_mono_factorisations.has_fac f).e_strong_epi }
 
 end has_strong_epi_images
 
@@ -496,28 +487,27 @@ variables [has_images.{v} C]
 instance has_image_maps_of_has_strong_epi_images [has_strong_epi_images.{v} C] :
   has_image_maps.{v} C :=
 { has_image_map := λ f g st,
-    let I := image (image.ι f.hom ≫ st.right),
-    I' := image (st.left ≫ factor_thru_image g.hom),
+    let I := image (image.ι f.hom ≫ st.right) in
+    let I' := image (st.left ≫ factor_thru_image g.hom),
     upper : strong_epi_mono_factorisation (f.hom ≫ st.right) :=
     { I := I,
       e := factor_thru_image f.hom ≫ factor_thru_image (image.ι f.hom ≫ st.right),
       m := image.ι (image.ι f.hom ≫ st.right),
-      fac := by simp,
       e_strong_epi := strong_epi_comp _ _,
-      m_mono := by apply_instance },
-    lower : strong_epi_mono_factorisation (f.hom ≫ st.right) :=
+      m_mono := by apply_instance } in
+    let lower : strong_epi_mono_factorisation (f.hom ≫ st.right) :=
     { I := I',
       e := factor_thru_image (st.left ≫ factor_thru_image g.hom),
       m := image.ι (st.left ≫ factor_thru_image g.hom) ≫ image.ι g.hom,
-      fac := by simp [arrow.w],
+      fac' := by simp [arrow.w],
       e_strong_epi := by apply_instance,
-      m_mono := mono_comp _ _ },
-    s : I ⟶ I' := is_image.lift upper.to_mono_is_image lower.to_mono_factorisation in
+      m_mono := mono_comp _ _ } in
+    let s : I ⟶ I' := is_image.lift upper.to_mono_is_image lower.to_mono_factorisation in
     { map := factor_thru_image (image.ι f.hom ≫ st.right) ≫ s ≫
         image.ι (st.left ≫ factor_thru_image g.hom),
-      factor_map' := by erw [←category.assoc, ←category.assoc,
+      factor_map' := by rw [←category.assoc, ←category.assoc,
         is_image.fac_lift upper.to_mono_is_image lower.to_mono_factorisation, image.fac],
-      map_ι' := by erw [category.assoc, category.assoc,
+      map_ι' := by rw [category.assoc, category.assoc,
         is_image.lift_fac upper.to_mono_is_image lower.to_mono_factorisation, image.fac] } }
 
 end has_strong_epi_images

--- a/src/category_theory/limits/shapes/images.lean
+++ b/src/category_theory/limits/shapes/images.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Markus Himmel
 -/
 import category_theory.limits.shapes.equalizers
+import category_theory.limits.shapes.strong_epi
 import category_theory.comma
 
 /-!
@@ -68,6 +69,7 @@ structure mono_factorisation (f : X ⟶ Y) :=
 
 restate_axiom mono_factorisation.fac'
 attribute [simp, reassoc] mono_factorisation.fac
+attribute [instance] mono_factorisation.m_mono
 
 namespace mono_factorisation
 
@@ -106,6 +108,10 @@ structure is_image (F : mono_factorisation f) :=
 
 restate_axiom is_image.lift_fac'
 attribute [simp, reassoc] is_image.lift_fac
+
+@[simp, reassoc] lemma is_image.fac_lift {F : mono_factorisation f} (hF : is_image F)
+  (F' : mono_factorisation f) : F.e ≫ hF.lift F' = F'.e :=
+(cancel_mono F'.m).1 $ by simp
 
 variable (f)
 
@@ -166,6 +172,9 @@ def image.lift (F' : mono_factorisation f) : image f ⟶ F'.I := (image.is_image
 @[simp, reassoc]
 lemma image.lift_fac (F' : mono_factorisation f) : image.lift F' ≫ F'.m = image.ι f :=
 (image.is_image f).lift_fac' F'
+@[simp, reassoc]
+lemma image.fac_lift (F' : mono_factorisation f) : factor_thru_image f ≫ image.lift F' = F'.e :=
+(image.is_image f).fac_lift F'
 
 -- TODO we could put a category structure on `mono_factorisation f`,
 -- with the morphisms being `g : I ⟶ I'` commuting with the `m`s
@@ -404,5 +413,110 @@ def im : arrow C ⥤ C :=
   map_comp' := λ _ _ _ _ _, image.map_comp _ _ }
 
 end has_image_maps
+
+section strong_epi_mono_factorisation
+
+/-- A strong epi-mono factorisation is a decomposition `f = e ≫ m` with `e` a strong epimorphism
+    and `m` a monomorphism. -/
+structure strong_epi_mono_factorisation {X Y : C} (f : X ⟶ Y) :=
+(I : C)
+(e : X ⟶ I)
+(m : I ⟶ Y)
+(fac : e ≫ m = f)
+[e_strong_epi : strong_epi e]
+[m_mono : mono m]
+
+attribute [instance] strong_epi_mono_factorisation.m_mono strong_epi_mono_factorisation.e_strong_epi
+
+/-- Satisfying the inhabited linter -/
+instance strong_epi_mono_factorisation_inhabited {X Y : C} (f : X ⟶ Y) [strong_epi f] :
+  inhabited (strong_epi_mono_factorisation f) :=
+⟨⟨Y, f, 𝟙 Y, by simp⟩⟩
+
+/-- A strong epi-mono factorisation is in particular a mono factorisation. -/
+def strong_epi_mono_factorisation.to_mono_factorisation {X Y : C} {f : X ⟶ Y}
+  (F : strong_epi_mono_factorisation f) : mono_factorisation f :=
+⟨F.I, F.m, F.e, F.fac⟩
+
+/-- A mono factorisation coming from a strong epi-mono factorisation always has the universal
+    property of the image. -/
+def strong_epi_mono_factorisation.to_mono_is_image {X Y : C} {f : X ⟶ Y}
+  (F : strong_epi_mono_factorisation f) : is_image F.to_mono_factorisation :=
+{ lift := λ G, arrow.lift $ arrow.hom_mk' $ show G.e ≫ G.m = F.e ≫ F.m, by rw [F.fac, G.fac] }
+
+variable (C)
+
+/-- A category has strong epi-mono factorisations if every morphism admits a strong epi-mono
+    factorisation. -/
+class has_strong_epi_mono_factorisations :=
+(has_fact : Π {X Y : C} (f : X ⟶ Y), strong_epi_mono_factorisation.{v} f)
+
+@[priority 100]
+instance has_images_of_has_strong_epi_mono_factorisations
+  [has_strong_epi_mono_factorisations.{v} C] : has_images.{v} C :=
+{ has_image := λ X Y f,
+  let F' := has_strong_epi_mono_factorisations.has_fact f in
+  { F := F'.to_mono_factorisation,
+    is_image := F'.to_mono_is_image } }
+
+end strong_epi_mono_factorisation
+
+section has_strong_epi_images
+variables (C) [has_images.{v} C]
+
+/-- A category has strong epi images if it has all images and `factor_thru_image f` is a strong
+    epimorphism for all `f`. -/
+class has_strong_epi_images :=
+(strong_factor_thru_image : Π {X Y : C} (f : X ⟶ Y), strong_epi.{v} (factor_thru_image f))
+
+attribute [instance] has_strong_epi_images.strong_factor_thru_image
+end has_strong_epi_images
+
+section has_strong_epi_images
+
+/-- If we constructed our images from strong epi-mono factorisations, then these images are
+    strong epi images. -/
+@[priority 100]
+instance has_strong_epi_images_of_has_strong_epi_mono_factorisations
+  [has_strong_epi_mono_factorisations.{v} C] : has_strong_epi_images.{v} C :=
+{ strong_factor_thru_image := λ X Y f,
+    (has_strong_epi_mono_factorisations.has_fact f).e_strong_epi }
+
+end has_strong_epi_images
+
+section has_strong_epi_images
+variables [has_images.{v} C]
+
+/-- A category with strong epi images has image maps. The construction is taken from Borceux,
+    Handbook of Categorical Algebra 1, Proposition 4.4.5. -/
+@[priority 100]
+instance has_image_maps_of_has_strong_epi_images [has_strong_epi_images.{v} C] :
+  has_image_maps.{v} C :=
+{ has_image_map := λ f g st,
+    let I := image (image.ι f.hom ≫ st.right),
+    I' := image (st.left ≫ factor_thru_image g.hom),
+    upper : strong_epi_mono_factorisation (f.hom ≫ st.right) :=
+    { I := I,
+      e := factor_thru_image f.hom ≫ factor_thru_image (image.ι f.hom ≫ st.right),
+      m := image.ι (image.ι f.hom ≫ st.right),
+      fac := by simp,
+      e_strong_epi := strong_epi_comp _ _,
+      m_mono := by apply_instance },
+    lower : strong_epi_mono_factorisation (f.hom ≫ st.right) :=
+    { I := I',
+      e := factor_thru_image (st.left ≫ factor_thru_image g.hom),
+      m := image.ι (st.left ≫ factor_thru_image g.hom) ≫ image.ι g.hom,
+      fac := by simp [arrow.w],
+      e_strong_epi := by apply_instance,
+      m_mono := mono_comp _ _ },
+    s : I ⟶ I' := is_image.lift upper.to_mono_is_image lower.to_mono_factorisation in
+    { map := factor_thru_image (image.ι f.hom ≫ st.right) ≫ s ≫
+        image.ι (st.left ≫ factor_thru_image g.hom),
+      factor_map' := by erw [←category.assoc, ←category.assoc,
+        is_image.fac_lift upper.to_mono_is_image lower.to_mono_factorisation, image.fac],
+      map_ι' := by erw [category.assoc, category.assoc,
+        is_image.lift_fac upper.to_mono_is_image lower.to_mono_factorisation, image.fac] } }
+
+end has_strong_epi_images
 
 end category_theory.limits

--- a/src/category_theory/limits/shapes/images.lean
+++ b/src/category_theory/limits/shapes/images.lean
@@ -36,10 +36,13 @@ so that `m` factors through the `m'` in any other such factorisation.
   factorisation of `g`, and the outer rectangle is the commutative square `sq`.
 * If a category `has_images`, then `has_image_maps` means that every commutative square admits an
   image map.
+* If a category `has_images`, then `has_strong_epi_images` means that the morphism to the image is
+  always a strong epimorphism.
 
 ## Main statements
 
 * When `C` has equalizers, the morphism `e` appearing in an image factorisation is an epimorphism.
+* When `C` has strong epi images, then these images admit image maps.
 
 ## Future work
 * TODO: coimages, and abelian categories.

--- a/src/category_theory/limits/shapes/kernels.lean
+++ b/src/category_theory/limits/shapes/kernels.lean
@@ -170,7 +170,7 @@ cofork.of_π π $ by rw [w, has_zero_morphisms.zero_comp]
 
 /-- If `s` is a colimit cokernel cofork, then every `k : Y ⟶ W` satisfying `f ≫ k = 0` induces
     `l : s.X ⟶ W` such that `cofork.π s ≫ l = k`. -/
-def cokernel_cofork.is_limit.desc' {s : cokernel_cofork f} (hs : is_colimit s) {W : C} (k : Y ⟶ W)
+def cokernel_cofork.is_colimit.desc' {s : cokernel_cofork f} (hs : is_colimit s) {W : C} (k : Y ⟶ W)
   (h : f ≫ k = 0) : {l : s.X ⟶ W // cofork.π s ≫ l = k} :=
 ⟨hs.desc $ cokernel_cofork.of_π _ h, hs.fac _ _⟩
 

--- a/src/category_theory/limits/shapes/pullbacks.lean
+++ b/src/category_theory/limits/shapes/pullbacks.lean
@@ -494,13 +494,11 @@ def pullback.desc' {W X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} [has_colimit (span 
 
 lemma pullback.condition {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} [has_limit (cospan f g)] :
   (pullback.fst : pullback f g ⟶ X) ≫ f = pullback.snd ≫ g :=
-(limit.w (cospan f g) walking_cospan.hom.inl).trans
-(limit.w (cospan f g) walking_cospan.hom.inr).symm
+pullback_cone.condition _
 
 lemma pushout.condition {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} [has_colimit (span f g)] :
   f ≫ (pushout.inl : Y ⟶ pushout f g) = g ≫ pushout.inr :=
-(colimit.w (span f g) walking_span.hom.fst).trans
-(colimit.w (span f g) walking_span.hom.snd).symm
+pushout_cocone.condition _
 
 /-- Two morphisms into a pullback are equal if their compositions with the pullback morphisms are
     equal -/

--- a/src/category_theory/limits/shapes/regular_mono.lean
+++ b/src/category_theory/limits/shapes/regular_mono.lean
@@ -5,6 +5,7 @@ Authors: Scott Morrison
 -/
 import category_theory.epi_mono
 import category_theory.limits.shapes.kernels
+import category_theory.limits.shapes.strong_epi
 
 /-!
 # Definitions and basic properties of regular and normal monomorphisms and epimorphisms.
@@ -15,7 +16,11 @@ A normal monomorphism is a morphism that is the kernel of some other morphism.
 We give the constructions
 * `split_mono → regular_mono`
 * `normal_mono → regular_mono`, and
-* `regular_mono → mono`.
+* `regular_mono → mono`
+as well as the dual constructions for regular and normal epimorphisms. Additionally, we give the
+construction
+* `regular_epi ⟶ strong_epi`.
+
 -/
 
 namespace category_theory
@@ -35,6 +40,8 @@ class regular_mono (f : X ⟶ Y) :=
 (w : f ≫ left = f ≫ right)
 (is_limit : is_limit (fork.of_ι f w))
 
+attribute [reassoc] regular_mono.w
+
 /-- Every regular monomorphism is a monomorphism. -/
 @[priority 100]
 instance regular_mono.mono (f : X ⟶ Y) [regular_mono f] : mono f :=
@@ -48,6 +55,15 @@ instance regular_mono.of_split_mono (f : X ⟶ Y) [split_mono f] : regular_mono 
   right := retraction f ≫ f,
   w     := by tidy,
   is_limit := split_mono_equalizes f }
+
+set_option pp.universes true
+
+/-- If `f` is a regular mono, then any map `k : W ⟶ Y` equalizing `regular_mono.left` and
+    `regular_mono.right` induces a morphism `l : W ⟶ X` such that `l ≫ f = k`. -/
+def regular_mono.lift' {W : C} (f : X ⟶ Y) [regular_mono f] (k : W ⟶ Y)
+  (h : k ≫ (regular_mono.left : Y ⟶ @regular_mono.Z _ _ _ _ f _) = k ≫ regular_mono.right) :
+  {l : W ⟶ X // l ≫ f = k} :=
+fork.is_limit.lift' regular_mono.is_limit _ h
 
 section
 variables [has_zero_morphisms.{v₁} C]
@@ -65,14 +81,22 @@ instance normal_mono.regular_mono (f : X ⟶ Y) [I : normal_mono f] : regular_mo
   right := 0,
   w := (by simpa using I.w),
   ..I }
-end
 
+/-- If `f` is a normal mono, then any map `k : W ⟶ Y` such that `k ≫ normal_mono.g = 0` induces
+    a morphism `l : W ⟶ X` such that `l ≫ f = k`. -/
+def normal_mono.lift' {W : C} (f : X ⟶ Y) [normal_mono f] (k : W ⟶ Y) (h : k ≫ normal_mono.g = 0) :
+  {l : W ⟶ X // l ≫ f = k} :=
+kernel_fork.is_limit.lift' normal_mono.is_limit _ h
+
+end
 /-- A regular epimorphism is a morphism which is the coequalizer of some parallel pair. -/
 class regular_epi (f : X ⟶ Y) :=
 (W : C)
 (left right : W ⟶ X)
 (w : left ≫ f = right ≫ f)
 (is_colimit : is_colimit (cofork.of_π f w))
+
+attribute [reassoc] regular_epi.w
 
 /-- Every regular epimorphism is an epimorphism. -/
 @[priority 100]
@@ -88,6 +112,25 @@ instance regular_epi.of_split_epi (f : X ⟶ Y) [split_epi f] : regular_epi f :=
   w     := by tidy,
   is_colimit := split_epi_coequalizes f }
 
+/-- If `f` is a regular epi, then every morphism `k : X ⟶ W` coequalizing `regular_epi.left` and
+    `regular_epi.right` induces `l : Y ⟶ W` such that `f ≫ l = k`. -/
+def regular_epi.desc' {W : C} (f : X ⟶ Y) [regular_epi f] (k : X ⟶ W)
+  (h : (regular_epi.left : regular_epi.W f ⟶ X) ≫ k = regular_epi.right ≫ k) :
+  {l : Y ⟶ W // f ≫ l = k} :=
+cofork.is_colimit.desc' (regular_epi.is_colimit) _ h
+
+instance strong_epi_of_regular_epi (f : X ⟶ Y) [regular_epi f] : strong_epi f :=
+{ epi := by apply_instance,
+  has_lift :=
+  begin
+    introsI,
+    have : (regular_epi.left : regular_epi.W f ⟶ X) ≫ u = regular_epi.right ≫ u,
+    { apply (cancel_mono z).1,
+      simp only [category.assoc, h, regular_epi.w_assoc] },
+    obtain ⟨t, ht⟩ := regular_epi.desc' f u this,
+    exact ⟨t, ht, (cancel_epi f).1
+      (by simp only [←category.assoc, ht, ←h, arrow.mk_hom, arrow.hom_mk'_right])⟩,
+  end }
 
 section
 variables [has_zero_morphisms.{v₁} C]
@@ -105,6 +148,13 @@ instance normal_epi.regular_epi (f : X ⟶ Y) [I : normal_epi f] : regular_epi f
   right := 0,
   w := (by simpa using I.w),
   ..I }
+
+/-- If `f` is a normal epi, then every morphism `k : X ⟶ W` satisfying `normal_epi.g ≫ k = 0`
+    induces `l : Y ⟶ W` such that `f ≫ l = k`. -/
+def normal_epi.desc' {W : C} (f : X ⟶ Y) [normal_epi f] (k : X ⟶ W) (h : normal_epi.g ≫ k = 0) :
+  {l : Y ⟶ W // f ≫ l = k} :=
+cokernel_cofork.is_colimit.desc' (normal_epi.is_colimit) _ h
+
 end
 
 end category_theory

--- a/src/category_theory/limits/shapes/regular_mono.lean
+++ b/src/category_theory/limits/shapes/regular_mono.lean
@@ -56,8 +56,6 @@ instance regular_mono.of_split_mono (f : X ⟶ Y) [split_mono f] : regular_mono 
   w     := by tidy,
   is_limit := split_mono_equalizes f }
 
-set_option pp.universes true
-
 /-- If `f` is a regular mono, then any map `k : W ⟶ Y` equalizing `regular_mono.left` and
     `regular_mono.right` induces a morphism `l : W ⟶ X` such that `l ≫ f = k`. -/
 def regular_mono.lift' {W : C} (f : X ⟶ Y) [regular_mono f] (k : W ⟶ Y)
@@ -119,6 +117,7 @@ def regular_epi.desc' {W : C} (f : X ⟶ Y) [regular_epi f] (k : X ⟶ W)
   {l : Y ⟶ W // f ≫ l = k} :=
 cofork.is_colimit.desc' (regular_epi.is_colimit) _ h
 
+@[priority 100]
 instance strong_epi_of_regular_epi (f : X ⟶ Y) [regular_epi f] : strong_epi f :=
 { epi := by apply_instance,
   has_lift :=

--- a/src/category_theory/limits/shapes/strong_epi.lean
+++ b/src/category_theory/limits/shapes/strong_epi.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2020 Markus Himmel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus Himmel
+-/
+import category_theory.comma
+
+/-!
+# Strong epimorphisms
+
+In this file, we define strong epimorphisms. A strong epimorphism is an epimorphism `f`, such
+that for every commutative square with `f` at the top and a monomorphism at the bottom, there is
+a diagonal morphism making the two triangles commute. This lift is necessarily unique (as shown in
+`comma.lean`).
+
+## Main results
+
+Besides the definition, we show that
+* the composition of two strong epimorphisms is a strong epimorphism,
+* the if `f ≫ g` is a strong epimorphism, then so is `g`,
+* if `f` is both a strong epimorphism and a monomorphism, then it is an isomorphism
+
+## Future work
+
+There is also the dual notion of strong monomorphism.
+
+## References
+
+* [F. Borceux, *Handbook of Categorical Algebra 1*][borceux-vol1]
+-/
+
+universes v u
+
+namespace category_theory
+variables {C : Type u} [𝒞 : category.{v} C]
+include 𝒞
+
+variables {P Q : C}
+
+/-- A strong epimorphism `f` is an epimorphism such that every commutative square with `f` at the
+    top and a monomorphism at the bottom has a lift. -/
+class strong_epi (f : P ⟶ Q) :=
+(epi : epi f)
+(has_lift : Π {X Y : C} {u : P ⟶ X} {v : Q ⟶ Y} {z : X ⟶ Y} [mono z] (h : u ≫ z = f ≫ v),
+  arrow.has_lift $ arrow.hom_mk' h)
+
+attribute [instance] strong_epi.has_lift
+
+@[priority 100]
+instance epi_of_strong_epi (f : P ⟶ Q) [strong_epi f] : epi f := strong_epi.epi
+
+section
+variables {R : C} (f : P ⟶ Q) (g : Q ⟶ R)
+
+/-- The composition of two strong epimorphisms is a strong epimorphism. -/
+def strong_epi_comp [strong_epi f] [strong_epi g] : strong_epi (f ≫ g) :=
+{ epi := epi_comp _ _,
+  has_lift :=
+  begin
+    introsI,
+    have h₀ : u ≫ z = f ≫ g ≫ v, by simpa [category.assoc] using h,
+    let w : Q ⟶ X := arrow.lift (arrow.hom_mk' h₀),
+    have h₁ : w ≫ z = g ≫ v, by rw arrow.lift_mk'_right,
+    exact ⟨(arrow.lift (arrow.hom_mk' h₁) : R ⟶ X), by simp, by simp⟩
+  end }
+
+
+/-- If `f ≫ g` is a strong epimorphism, then so is g. -/
+def strong_epi_of_strong_epi [epi (f ≫ g)] [strong_epi (f ≫ g)] : strong_epi g :=
+{ epi := epi_of_epi f g,
+  has_lift :=
+  begin
+    introsI,
+    have h₀ : (f ≫ u) ≫ z = (f ≫ g) ≫ v, by simp only [category.assoc, h],
+    exact ⟨(arrow.lift (arrow.hom_mk' h₀) : R ⟶ X), (cancel_mono z).1 (by simp [h]), by simp⟩,
+  end }
+
+end
+
+/-- A strong epimorphism that is a monomorphism is an isomorphism. -/
+def mono_strong_epi_is_iso (f : P ⟶ Q) [strong_epi f] [mono f] : is_iso f :=
+{ inv := arrow.lift $ arrow.hom_mk' $ show 𝟙 P ≫ f = f ≫ 𝟙 Q, by simp }
+
+end category_theory

--- a/src/category_theory/limits/shapes/strong_epi.lean
+++ b/src/category_theory/limits/shapes/strong_epi.lean
@@ -17,7 +17,7 @@ a diagonal morphism making the two triangles commute. This lift is necessarily u
 
 Besides the definition, we show that
 * the composition of two strong epimorphisms is a strong epimorphism,
-* the if `f ≫ g` is a strong epimorphism, then so is `g`,
+* if `f ≫ g` is a strong epimorphism, then so is `g`,
 * if `f` is both a strong epimorphism and a monomorphism, then it is an isomorphism
 
 ## Future work
@@ -63,7 +63,6 @@ def strong_epi_comp [strong_epi f] [strong_epi g] : strong_epi (f ≫ g) :=
     have h₁ : w ≫ z = g ≫ v, by rw arrow.lift_mk'_right,
     exact ⟨(arrow.lift (arrow.hom_mk' h₁) : R ⟶ X), by simp, by simp⟩
   end }
-
 
 /-- If `f ≫ g` is a strong epimorphism, then so is g. -/
 def strong_epi_of_strong_epi [epi (f ≫ g)] [strong_epi (f ≫ g)] : strong_epi g :=

--- a/src/category_theory/limits/shapes/strong_epi.lean
+++ b/src/category_theory/limits/shapes/strong_epi.lean
@@ -65,7 +65,7 @@ def strong_epi_comp [strong_epi f] [strong_epi g] : strong_epi (f ≫ g) :=
   end }
 
 /-- If `f ≫ g` is a strong epimorphism, then so is g. -/
-def strong_epi_of_strong_epi [epi (f ≫ g)] [strong_epi (f ≫ g)] : strong_epi g :=
+def strong_epi_of_strong_epi [strong_epi (f ≫ g)] : strong_epi g :=
 { epi := epi_of_epi f g,
   has_lift :=
   begin


### PR DESCRIPTION
This PR contains the changes I mentioned in #2374. It contains:

* the definition of a lift of a commutative square
* the definition of a strong epimorphism
* a proof that every regular epimorphism is strong
* the definition of a strong epi-mono factorization
* the class `has_strong_epi_images`
* the construction `has_strong_epi_images` -> `has_image_maps`
* a small number of changes which should have been part of #2423

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
