### PR TITLE
[Merged by Bors] - feat(tactic/lint): lint for missing has_coe_to_fun instances

### DIFF
--- a/src/algebraic_geometry/presheafed_space.lean
+++ b/src/algebraic_geometry/presheafed_space.lean
@@ -124,12 +124,18 @@ variables {C}
 instance {X Y : PresheafedSpace.{v} C} : has_coe (X ⟶ Y) (X.to_Top ⟶ Y.to_Top) :=
 { coe := λ α, α.f }
 
+-- see Note [function coercion]
+instance {X Y : PresheafedSpace.{v} C} : has_coe_to_fun (X ⟶ Y) :=
+⟨λ _, X.to_Top → Y.to_Top, λ h, h⟩
+
 @[simp] lemma hom_mk_coe {X Y : PresheafedSpace.{v} C} (f) (c) :
   (({ f := f, c := c } : X ⟶ Y) : (X : Top.{v}) ⟶ (Y : Top.{v})) = f := rfl
 @[simp] lemma f_as_coe {X Y : PresheafedSpace.{v} C} (α : X ⟶ Y) :
   α.f = (α : (X : Top.{v}) ⟶ (Y : Top.{v})) := rfl
 @[simp] lemma id_coe (X : PresheafedSpace.{v} C) :
   (((𝟙 X) : X ⟶ X) : (X : Top.{v}) ⟶ X) = 𝟙 (X : Top.{v}) := rfl
+@[simp] lemma id_coe_fn (X : PresheafedSpace.{v} C) :
+  (((𝟙 X) : X ⟶ X) : (X : Top.{v}) → X) = 𝟙 (X : Top.{v}) := rfl
 @[simp] lemma comp_coe {X Y Z : PresheafedSpace.{v} C} (α : X ⟶ Y) (β : Y ⟶ Z) :
   ((α ≫ β : X ⟶ Z) : (X : Top.{v}) ⟶ Z) = (α : (X : Top.{v}) ⟶ Y) ≫ (β : Y ⟶ Z) := rfl
 

--- a/src/tactic/abel.lean
+++ b/src/tactic/abel.lean
@@ -67,6 +67,7 @@ meta def normal_expr.e : normal_expr → expr
 | (normal_expr.nterm e _ _ _) := e
 
 meta instance : has_coe normal_expr expr := ⟨normal_expr.e⟩
+meta instance : has_coe_to_fun normal_expr := ⟨_, λ e, ((e : expr) : expr → expr)⟩
 
 meta def normal_expr.term' (c : cache) (n : expr × ℤ) (x : expr) (a : normal_expr) : normal_expr :=
 normal_expr.nterm (c.mk_term n.1 x a) n x a

--- a/src/tactic/lint/default.lean
+++ b/src/tactic/lint/default.lean
@@ -44,6 +44,7 @@ The following linters are run by default:
 16. `simp_comm` checks that no commutativity lemmas (such as `add_comm`) are marked simp.
 17. `decidable_classical` checks for `decidable` hypotheses that are used in the proof of a proposition but not
     in the statement, and could be removed using `classical`.
+18. `has_coe_to_fun` checks that every type that coerces to a function has a direct `has_coe_to_fun` instance.
 
 Another linter, `doc_blame_thm`, checks for missing doc strings on lemmas and theorems.
 This is not run by default.

--- a/src/tactic/ring.lean
+++ b/src/tactic/ring.lean
@@ -73,6 +73,7 @@ meta def horner_expr.e : horner_expr → expr
 | (horner_expr.xadd e _ _ _ _) := e
 
 meta instance : has_coe horner_expr expr := ⟨horner_expr.e⟩
+meta instance : has_coe_to_fun horner_expr := ⟨_, λ e, ((e : expr) : expr → expr)⟩
 
 meta def horner_expr.xadd' (c : cache) (a : horner_expr)
   (x : expr × ℕ) (n : expr × ℕ) (b : horner_expr) : horner_expr :=

--- a/test/lint_coe_to_fun.lean
+++ b/test/lint_coe_to_fun.lean
@@ -1,0 +1,33 @@
+import tactic.lint
+
+-- see Note [function coercion]
+
+structure equiv (α β : Sort*) :=
+(to_fun : α → β)
+(inv_fun : β → α)
+
+instance {α β} : has_coe_to_fun (equiv α β) :=
+⟨λ _, α → β, equiv.to_fun⟩
+
+structure sparkling_equiv (α β) extends equiv α β
+
+instance {α β} : has_coe (sparkling_equiv α β) (equiv α β) :=
+⟨sparkling_equiv.to_equiv⟩
+
+-- should complain
+open tactic
+#eval do
+decl ← get_decl ``sparkling_equiv,
+res ← linter.has_coe_to_fun.test decl,
+-- linter complains
+guard res.is_some
+
+instance {α β} : has_coe_to_fun (sparkling_equiv α β) :=
+⟨λ _, α → β, λ f, f.to_equiv.to_fun⟩
+
+-- prima!
+#eval do
+decl ← get_decl ``sparkling_equiv,
+res ← linter.has_coe_to_fun.test decl,
+-- linter doesn't complain
+guard res.is_none


### PR DESCRIPTION
Enforces the library note "function coercion":
https://github.com/leanprover-community/mathlib/blob/715be9f7466f30f1d4cbff4e870530af43767fba/src/logic/basic.lean#L69-L94

See #2434 for a recent PR where this issue popped up.

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
