### PR TITLE
[Merged by Bors] - feat(category_theory/limits/over): over category has connected limits

### DIFF
--- a/src/category_theory/adjunction/limits.lean
+++ b/src/category_theory/adjunction/limits.lean
@@ -5,6 +5,7 @@ Authors: Reid Barton, Johan Commelin
 -/
 import category_theory.adjunction.basic
 import category_theory.limits.preserves
+import category_theory.limits.creates
 
 open opposite
 
@@ -126,6 +127,14 @@ instance is_equivalence_reflects_limits (E : D ⥤ C) [is_equivalence E] : refle
           cases c_π,
           congr; rw functor.comp_id }
       end } } }
+
+@[priority 100] -- see Note [lower instance priority]
+instance is_equivalence_creates_limits (H : D ⥤ C) [is_equivalence H] : creates_limits H :=
+{ creates_limits_of_shape := λ J 𝒥, by exactI
+  { creates_limit := λ F,
+    { lifts := λ c t,
+      { lifted_cone := H.map_cone_inv c,
+        valid_lift := H.map_cone_map_cone_inv c } } } }
 
 -- verify the preserve_limits instance works as expected:
 example (E : D ⥤ C) [is_equivalence E]

--- a/src/category_theory/comma.lean
+++ b/src/category_theory/comma.lean
@@ -331,14 +331,9 @@ variables {Y : T} {f : X ⟶ Y} {U V : over X} {g : U ⟶ V}
 @[simp] lemma map_map_left : ((map f).map g).left = g.left := rfl
 end
 
--- TODO: Tidy this proof?
--- I'd like to write
--- { reflects := λ X Y f t, by exactI
---   { inv := over.hom_mk t.inv ((as_iso (forget.map f)).inv_comp_eq.2 (over.w f).symm) } }
--- but it times out for some reason
 instance forget_reflects_iso : reflects_isomorphisms (forget : over X ⥤ T) :=
-{ reflects := λ X Y f t,
-  { inv := over.hom_mk t.inv (by { exact (@as_iso _ _ _ _ (forget.map f) t).inv_comp_eq.2 (over.w f).symm }) } }
+{ reflects := λ X Y f t, by exactI
+  { inv := over.hom_mk t.inv ((as_iso (forget.map f)).inv_comp_eq.2 (over.w f).symm) } }
 
 section iterated_slice
 variables (f : over X)

--- a/src/category_theory/comma.lean
+++ b/src/category_theory/comma.lean
@@ -6,6 +6,7 @@ Authors: Scott Morrison, Johan Commelin, Bhavik Mehta
 import category_theory.isomorphism
 import category_theory.equivalence
 import category_theory.punit
+import category_theory.reflect_isomorphisms
 
 /-!
 # Comma categories
@@ -329,6 +330,15 @@ variables {Y : T} {f : X ⟶ Y} {U V : over X} {g : U ⟶ V}
 @[simp] lemma map_obj_hom  : ((map f).obj U).hom  = U.hom ≫ f := rfl
 @[simp] lemma map_map_left : ((map f).map g).left = g.left := rfl
 end
+
+-- TODO: Tidy this proof?
+-- I'd like to write
+-- { reflects := λ X Y f t, by exactI
+--   { inv := over.hom_mk t.inv ((as_iso (forget.map f)).inv_comp_eq.2 (over.w f).symm) } }
+-- but it times out for some reason
+instance forget_reflects_iso : reflects_isomorphisms (forget : over X ⥤ T) :=
+{ reflects := λ X Y f t,
+  { inv := over.hom_mk t.inv (by { exact (@as_iso _ _ _ _ (forget.map f) t).inv_comp_eq.2 (over.w f).symm }) } }
 
 section iterated_slice
 variables (f : over X)

--- a/src/category_theory/connected.lean
+++ b/src/category_theory/connected.lean
@@ -221,4 +221,41 @@ lemma nat_trans_from_connected [conn : connected J] {X Y : C}
   (λ j, α.app j)
   (λ _ _ f, (by { have := α.naturality f, erw [id_comp, comp_id] at this, exact this.symm }))
 
+section examples
+instance cospan_inhabited : inhabited walking_cospan := ⟨walking_cospan.one⟩
+
+instance cospan_connected : connected (walking_cospan) :=
+begin
+  apply connected.of_induct,
+  introv _ t,
+  cases j,
+  { rwa t walking_cospan.hom.inl },
+  { rwa t walking_cospan.hom.inr },
+  { assumption }
+end
+
+instance span_inhabited : inhabited walking_span := ⟨walking_span.zero⟩
+
+instance span_connected : connected (walking_span) :=
+begin
+  apply connected.of_induct,
+  introv _ t,
+  cases j,
+  { assumption },
+  { rwa ← t walking_span.hom.fst },
+  { rwa ← t walking_span.hom.snd },
+end
+
+instance parallel_pair_inhabited : inhabited walking_parallel_pair := ⟨walking_parallel_pair.one⟩
+
+instance parallel_pair_connected : connected (walking_parallel_pair) :=
+begin
+  apply connected.of_induct,
+  introv _ t, cases j,
+  { rwa t walking_parallel_pair_hom.left },
+  { assumption }
+end
+
+end examples
+
 end category_theory

--- a/src/category_theory/connected.lean
+++ b/src/category_theory/connected.lean
@@ -221,6 +221,7 @@ lemma nat_trans_from_connected [conn : connected J] {X Y : C}
   (λ j, α.app j)
   (λ _ _ f, (by { have := α.naturality f, erw [id_comp, comp_id] at this, exact this.symm }))
 
+omit 𝒞 𝒥
 section examples
 instance cospan_inhabited : inhabited walking_cospan := ⟨walking_cospan.one⟩
 

--- a/src/category_theory/connected.lean
+++ b/src/category_theory/connected.lean
@@ -4,10 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
 
-import category_theory.limits.shapes.pullbacks
-import category_theory.limits.shapes.binary_products
-import category_theory.limits.shapes.equalizers
-import category_theory.limits.preserves
+import category_theory.const
+import category_theory.discrete_category
+import category_theory.eq_to_hom
 
 /-!
 # Connected category
@@ -44,7 +43,7 @@ category is preserved by the functor `(X × -)`.
 
 universes v₁ v₂ u₁ u₂
 
-open category_theory category_theory.category category_theory.limits
+open category_theory.category
 namespace category_theory
 
 section connected
@@ -220,43 +219,5 @@ lemma nat_trans_from_connected [conn : connected J] {X Y : C}
   (X ⟶ Y)
   (λ j, α.app j)
   (λ _ _ f, (by { have := α.naturality f, erw [id_comp, comp_id] at this, exact this.symm }))
-
-omit 𝒞 𝒥
-section examples
-instance cospan_inhabited : inhabited walking_cospan := ⟨walking_cospan.one⟩
-
-instance cospan_connected : connected (walking_cospan) :=
-begin
-  apply connected.of_induct,
-  introv _ t,
-  cases j,
-  { rwa t walking_cospan.hom.inl },
-  { rwa t walking_cospan.hom.inr },
-  { assumption }
-end
-
-instance span_inhabited : inhabited walking_span := ⟨walking_span.zero⟩
-
-instance span_connected : connected (walking_span) :=
-begin
-  apply connected.of_induct,
-  introv _ t,
-  cases j,
-  { assumption },
-  { rwa ← t walking_span.hom.fst },
-  { rwa ← t walking_span.hom.snd },
-end
-
-instance parallel_pair_inhabited : inhabited walking_parallel_pair := ⟨walking_parallel_pair.one⟩
-
-instance parallel_pair_connected : connected (walking_parallel_pair) :=
-begin
-  apply connected.of_induct,
-  introv _ t, cases j,
-  { rwa t walking_parallel_pair_hom.left },
-  { assumption }
-end
-
-end examples
 
 end category_theory

--- a/src/category_theory/limits/connected.lean
+++ b/src/category_theory/limits/connected.lean
@@ -25,6 +25,43 @@ universes v₁ v₂ u₁ u₂
 open category_theory category_theory.category category_theory.limits
 namespace category_theory
 
+section examples
+instance cospan_inhabited : inhabited walking_cospan := ⟨walking_cospan.one⟩
+
+instance cospan_connected : connected (walking_cospan) :=
+begin
+  apply connected.of_induct,
+  introv _ t,
+  cases j,
+  { rwa t walking_cospan.hom.inl },
+  { rwa t walking_cospan.hom.inr },
+  { assumption }
+end
+
+instance span_inhabited : inhabited walking_span := ⟨walking_span.zero⟩
+
+instance span_connected : connected (walking_span) :=
+begin
+  apply connected.of_induct,
+  introv _ t,
+  cases j,
+  { assumption },
+  { rwa ← t walking_span.hom.fst },
+  { rwa ← t walking_span.hom.snd },
+end
+
+instance parallel_pair_inhabited : inhabited walking_parallel_pair := ⟨walking_parallel_pair.one⟩
+
+instance parallel_pair_connected : connected (walking_parallel_pair) :=
+begin
+  apply connected.of_induct,
+  introv _ t,
+  cases j,
+  { rwa t walking_parallel_pair_hom.left },
+  { assumption }
+end
+end examples
+
 local attribute [tidy] tactic.case_bash
 
 variables {C : Type u₂} [𝒞 : category.{v₂} C]

--- a/src/category_theory/limits/connected.lean
+++ b/src/category_theory/limits/connected.lean
@@ -25,43 +25,6 @@ universes v₁ v₂ u₁ u₂
 open category_theory category_theory.category category_theory.limits
 namespace category_theory
 
-section examples
-instance cospan_inhabited : inhabited walking_cospan := ⟨walking_cospan.one⟩
-
-instance cospan_connected : connected (walking_cospan) :=
-begin
-  apply connected.of_induct,
-  introv _ t,
-  cases j,
-  { rwa t walking_cospan.hom.inl },
-  { rwa t walking_cospan.hom.inr },
-  { assumption }
-end
-
-instance span_inhabited : inhabited walking_span := ⟨walking_span.zero⟩
-
-instance span_connected : connected (walking_span) :=
-begin
-  apply connected.of_induct,
-  introv _ t,
-  cases j,
-  { assumption },
-  { rwa ← t walking_span.hom.fst },
-  { rwa ← t walking_span.hom.snd },
-end
-
-instance parallel_pair_inhabited : inhabited walking_parallel_pair := ⟨walking_parallel_pair.one⟩
-
-instance parallel_pair_connected : connected (walking_parallel_pair) :=
-begin
-  apply connected.of_induct,
-  introv _ t, cases j,
-  { rwa t walking_parallel_pair_hom.left },
-  { assumption }
-end
-
-end examples
-
 local attribute [tidy] tactic.case_bash
 
 variables {C : Type u₂} [𝒞 : category.{v₂} C]

--- a/src/category_theory/limits/creates.lean
+++ b/src/category_theory/limits/creates.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
 import category_theory.limits.limits
-import category_theory.adjunction.limits
+-- import category_theory.adjunction.limits
 import category_theory.reflect_isomorphisms
 
 open category_theory category_theory.limits
@@ -236,14 +236,6 @@ def lifts_to_colimit_of_creates (K : J ⥤ C) (F : C ⥤ D)
 { lifted_cocone := lift_colimit t,
   valid_lift := lifted_colimit_maps_to_original t,
   makes_colimit := lifted_colimit_is_colimit t }
-
-@[priority 100] -- see Note [lower instance priority]
-instance is_equivalence_creates_limits (H : D ⥤ C) [is_equivalence H] : creates_limits H :=
-{ creates_limits_of_shape := λ J 𝒥, by exactI
-  { creates_limit := λ F,
-    { lifts := λ c t,
-      { lifted_cone := H.map_cone_inv c,
-        valid_lift := H.map_cone_map_cone_inv c } } } }
 
 omit 𝒟
 /-- Any cone lifts through the identity functor. -/

--- a/src/category_theory/limits/creates.lean
+++ b/src/category_theory/limits/creates.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
 import category_theory.limits.limits
--- import category_theory.adjunction.limits
 import category_theory.reflect_isomorphisms
 
 open category_theory category_theory.limits

--- a/src/category_theory/limits/limits.lean
+++ b/src/category_theory/limits/limits.lean
@@ -31,7 +31,7 @@ structure is_limit (t : cone F) :=
   m = lift s . obviously)
 
 restate_axiom is_limit.fac'
-attribute [simp] is_limit.fac
+attribute [simp, reassoc] is_limit.fac
 restate_axiom is_limit.uniq'
 
 namespace is_limit

--- a/src/category_theory/limits/over.lean
+++ b/src/category_theory/limits/over.lean
@@ -144,12 +144,20 @@ instance (B : C) : has_terminal.{v} (over B) :=
 
 namespace creates
 
+/--
+(Impl) Given a diagram in the over category, produce a natural transformation from the
+diagram legs to the specific object.
+-/
 def nat_trans_in_over {B : C} (F : J ⥤ over B) :
   F ⋙ forget ⟶ (category_theory.functor.const J).obj B :=
 { app := λ j, (F.obj j).hom }
 
 local attribute [tidy] tactic.case_bash
 
+/--
+(Impl) Given a cone in the base category, raise it to a cone in the over category. Note this is
+where the connected assumption is used.
+-/
 @[simps]
 def raise_cone [connected J] {B : C} {F : J ⥤ over B} (c : cone (F ⋙ forget)) :
   cone F :=

--- a/src/category_theory/limits/over.lean
+++ b/src/category_theory/limits/over.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Reid Barton, Bhavik Mehta
 -/
 import category_theory.comma
-import category_theory.connected
+import category_theory.limits.connected
 import category_theory.limits.creates
+import category_theory.limits.limits
 import category_theory.limits.preserves
 import category_theory.limits.shapes.pullbacks
 import category_theory.limits.shapes.binary_products
@@ -142,7 +143,7 @@ instance (B : C) : has_terminal.{v} (over B) :=
               rwa [category.comp_id, category.comp_id] at this
             end } } } }
 
-namespace creates
+namespace creates_connected
 
 /--
 (Impl) Given a diagram in the over category, produce a natural transformation from the
@@ -177,15 +178,15 @@ def raised_cone_is_limit [connected J] {B : C} {F : J ⥤ over B} {c : cone (F �
                (by { dsimp, simp }),
   uniq' := λ s m K, by { ext1, apply t.hom_ext, intro j, simp [← K j] } }
 
-end creates
+end creates_connected
 
 /-- The forgetful functor from the over category creates any connected limit. -/
 instance forget_creates_connected_limits [connected J] {B : C} : creates_limits_of_shape J (forget : over B ⥤ C) :=
 { creates_limit := λ K,
     creates_limit_of_reflects_iso (λ c t,
-      { lifted_cone := creates.raise_cone c,
-        valid_lift := eq_to_iso (creates.raised_cone_lowers_to_original c t),
-        makes_limit := creates.raised_cone_is_limit t } ) }
+      { lifted_cone := creates_connected.raise_cone c,
+        valid_lift := eq_to_iso (creates_connected.raised_cone_lowers_to_original c t),
+        makes_limit := creates_connected.raised_cone_is_limit t } ) }
 
 /-- The over category has any connected limit which the original category has. -/
 instance has_connected_limits {B : C} [connected J] [has_limits_of_shape J C] : has_limits_of_shape J (over B) :=

--- a/src/category_theory/limits/over.lean
+++ b/src/category_theory/limits/over.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Reid Barton, Bhavik Mehta
 -/
 import category_theory.comma
+import category_theory.connected
+import category_theory.limits.creates
 import category_theory.limits.preserves
 import category_theory.limits.shapes.pullbacks
 import category_theory.limits.shapes.binary_products
@@ -140,51 +142,54 @@ instance (B : C) : has_terminal.{v} (over B) :=
               rwa [category.comp_id, category.comp_id] at this
             end } } } }
 
--- TODO: this should work for any connected limit, not just pullbacks
-/-- Given pullbacks in C, we have pullbacks in C/B -/
-instance {B : C} [has_pullbacks.{v} C] : has_pullbacks.{v} (over B) :=
-{ has_limits_of_shape :=
-  { has_limit := λ F,
-    let X : over B := F.obj walking_cospan.one in
-    let Y : over B := F.obj walking_cospan.left in
-    let Z : over B := F.obj walking_cospan.right in
-    let f : Y ⟶ X := (F.map walking_cospan.hom.inl) in
-    let g : Z ⟶ X := (F.map walking_cospan.hom.inr) in
-    let L : over B := over.mk (pullback.fst ≫ Y.hom : pullback f.left g.left ⟶ B) in
-    let π₁ : L ⟶ Y := over.hom_mk pullback.fst in
-    let π₂ : L ⟶ Z := @over.hom_mk _ _ _ L Z (pullback.snd : L.left ⟶ Z.left)
-      (by {dsimp, rw [← over.w f, ← category.assoc, pullback.condition, category.assoc, over.w g]}) in
-    { cone := cone.of_pullback_cone (pullback_cone.mk π₁ π₂
-        (by { ext, rw [over.comp_left, over.hom_mk_left, pullback.condition], refl, })),
-      is_limit :=
-      { lift := λ s,
-      begin
-        apply over.hom_mk _ _,
-        { apply pullback.lift (s.π.app walking_cospan.left).left (s.π.app walking_cospan.right).left,
-          rw [← over.comp_left, ← over.comp_left, s.w, s.w], },
-        { show pullback.lift _ _ _ ≫ (pullback.fst ≫ Y.hom) = (s.X).hom,
-          rw [limit.lift_π_assoc, pullback_cone.mk_π_app_left, over.w], refl, }
-       end,
-       fac' := λ s j,
-       begin
-        ext1, dsimp,
-        cases j; simp only [limit.lift_π, limit.lift_π_assoc, over.hom_mk_left, over.id_left,
-          over.comp_left, pullback_cone.mk_π_app_one, pullback_cone.mk_π_app_left,
-          pullback_cone.mk_π_app_right, eq_to_hom_refl, category.comp_id],
-        rw [← over.comp_left, ← s.w walking_cospan.hom.inl],
-       end,
-       uniq' := λ s m J, over.over_morphism.ext
-       begin
-        simp only [over.hom_mk_left],
-        apply pullback.hom_ext,
-        { rw [limit.lift_π, pullback_cone.mk_π_app_left, ←(J walking_cospan.left)],
-          dsimp,
-          rw [category.comp_id], },
-        { rw [limit.lift_π, pullback_cone.mk_π_app_right, ←(J walking_cospan.right)],
-          dsimp,
-          rw [category.comp_id], }
-       end } },
-  } }
+namespace creates
+
+def nat_trans_in_over {B : C} (F : J ⥤ over B) :
+  F ⋙ forget ⟶ (category_theory.functor.const J).obj B :=
+{ app := λ j, (F.obj j).hom }
+
+local attribute [tidy] tactic.case_bash
+
+@[simps]
+def raise_cone [connected J] {B : C} {F : J ⥤ over B} (c : cone (F ⋙ forget)) :
+  cone F :=
+{ X := over.mk (c.π.app (default J) ≫ (F.obj (default J)).hom),
+  π :=
+  { app := λ j, over.hom_mk (c.π.app j) (nat_trans_from_connected (c.π ≫ nat_trans_in_over F) j) } }
+
+lemma raised_cone_lowers_to_original [connected J] {B : C} {F : J ⥤ over B}
+  (c : cone (F ⋙ forget)) (t : is_limit c) :
+  forget.map_cone (raise_cone c) = c :=
+by tidy
+
+/-- (Impl) Show that the raised cone is a limit. -/
+def raised_cone_is_limit [connected J] {B : C} {F : J ⥤ over B} {c : cone (F ⋙ forget)} (t : is_limit c) :
+  is_limit (raise_cone c) :=
+{ lift := λ s, over.hom_mk (t.lift (forget.map_cone s))
+               (by { dsimp, simp }),
+  uniq' := λ s m K, by { ext1, apply t.hom_ext, intro j, simp [← K j] } }
+
+end creates
+
+/-- The forgetful functor from the over category creates any connected limit. -/
+instance forget_creates_connected_limits [connected J] {B : C} : creates_limits_of_shape J (forget : over B ⥤ C) :=
+{ creates_limit := λ K,
+    creates_limit_of_reflects_iso (λ c t,
+      { lifted_cone := creates.raise_cone c,
+        valid_lift := eq_to_iso (creates.raised_cone_lowers_to_original c t),
+        makes_limit := creates.raised_cone_is_limit t } ) }
+
+/-- The over category has any connected limit which the original category has. -/
+instance has_connected_limits {B : C} [connected J] [has_limits_of_shape J C] : has_limits_of_shape J (over B) :=
+{ has_limit := λ F, has_limit_of_created F (forget : over B ⥤ C) }
+
+/-- Make sure we can derive pullbacks in `over B`. -/
+example {B : C} [has_pullbacks.{v} C] : has_pullbacks.{v} (over B) :=
+{ has_limits_of_shape := infer_instance }
+
+/-- Make sure we can derive equalizers in `over B`. -/
+example {B : C} [has_equalizers.{v} C] : has_equalizers.{v} (over B) :=
+{ has_limits_of_shape := infer_instance }
 
 /-- Given pullbacks in C, we have binary products in any over category -/
 instance over_has_prods_of_pullback [has_pullbacks.{v} C] (B : C) :


### PR DESCRIPTION
Show that the forgetful functor from the over category creates connected limits.

The key consequence of this is that the over category has equalizers, which we will use to show that it has all (finite) limits if the base category does.

I've also moved the connected category examples into `category_theory/connected.lean`.
Also I removed the proof of
`instance {B : C} [has_pullbacks.{v} C] : has_pullbacks.{v} (over B)`
which I wrote and semorrison massively improved, as the new instances generalise it. 

I also added a `reassoc` for `is_limit.fac`, which simplified one of the proofs I had.

TO CONTRIBUTORS:

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)