### PR TITLE
[Merged by Bors] - refactor(data/nat/fib): simplify proof of fib_succ_succ

### DIFF
--- a/src/data/nat/fib.lean
+++ b/src/data/nat/fib.lean
@@ -32,8 +32,11 @@ fib, fibonacci
 
 namespace nat
 
+/-- Auxiliary function used in the definition of `fib_aux_stream`. -/
+private def fib_aux_step : (ℕ × ℕ) → (ℕ × ℕ) := λ p, ⟨p.snd, p.fst + p.snd⟩
+
 /-- Auxiliary stream creating Fibonacci pairs `⟨Fₙ, Fₙ₊₁⟩`. -/
-private def fib_aux_stream : stream (ℕ × ℕ) := stream.iterate (λ p, ⟨p.snd, p.fst + p.snd⟩) ⟨0, 1⟩
+private def fib_aux_stream : stream (ℕ × ℕ) := stream.iterate fib_aux_step ⟨0, 1⟩
 
 /--
 Implementation of the fibonacci sequence satisfying
@@ -47,23 +50,16 @@ def fib (n : ℕ) : ℕ := (fib_aux_stream n).fst
 @[simp] lemma fib_zero : fib 0 = 0 := rfl
 @[simp] lemma fib_one : fib 1 = 1 := rfl
 
-private lemma fib_recurrence_aux {n : ℕ} : (fib_aux_stream (n + 1)).fst = (fib_aux_stream n).snd :=
+private lemma fib_aux_stream_succ {n : ℕ} :
+    fib_aux_stream (n + 1) = fib_aux_step (fib_aux_stream n) :=
 begin
-  change (stream.nth (n + 1) $ stream.iterate _ (0, 1)).fst = _,
-  rw [stream.nth_succ_iterate, stream.map_iterate, stream.nth_map, fib_aux_stream]
+  change (stream.nth _ $ stream.iterate _ _) = fib_aux_step (stream.nth _ $ stream.iterate _ _),
+  rw [stream.nth_succ_iterate, stream.map_iterate, stream.nth_map]
 end
 
 /-- Shows that `fib` indeed satisfies the Fibonacci recurrence `Fₙ₊₂ = Fₙ + Fₙ₊₁.` -/
 lemma fib_succ_succ {n : ℕ} : fib (n + 2) = fib n + fib (n + 1) :=
-begin
-  rw [fib, fib_recurrence_aux],
-  change (stream.nth (n + 1) $ stream.iterate (λ p, _) (0, 1)).snd = _,
-  rw [stream.nth_succ_iterate, stream.map_iterate, stream.nth_map],
-  suffices : (fib_aux_stream n).snd = (stream.iterate (λ p, _) (0, 1) (n + 1)).fst, by
-    simpa only [fib, fib.aux_stream],
-  rw ←fib_recurrence_aux,
-  refl
-end
+by simp only [fib, fib_aux_stream_succ, fib_aux_step]
 
 lemma fib_pos {n : ℕ} (n_pos : 0 < n) : 0 < fib n :=
 begin

--- a/src/data/nat/fib.lean
+++ b/src/data/nat/fib.lean
@@ -53,7 +53,8 @@ def fib (n : ℕ) : ℕ := (fib_aux_stream n).fst
 private lemma fib_aux_stream_succ {n : ℕ} :
     fib_aux_stream (n + 1) = fib_aux_step (fib_aux_stream n) :=
 begin
-  change (stream.nth _ $ stream.iterate _ _) = fib_aux_step (stream.nth _ $ stream.iterate _ _),
+  change (stream.nth (n + 1) $ stream.iterate fib_aux_step ⟨0, 1⟩) =
+      fib_aux_step (stream.nth n $ stream.iterate fib_aux_step ⟨0, 1⟩),
   rw [stream.nth_succ_iterate, stream.map_iterate, stream.nth_map]
 end
 


### PR DESCRIPTION
By tweaking some of the lemmas, I managed to shorten `fib_succ_succ` from 7 complicated lines to a single call to `simp`.

An alternative expression would be:

```lean
unfold fib,
repeat { rw fib_aux_stream_succ },
unfold fib_aux_step,
```

I can change to that if you think the `simp` is too pithy.

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
