### PR TITLE
[Merged by Bors] - chore(algebra/module): replace typeclass arguments with inferred arguments

### DIFF
--- a/src/algebra/module.lean
+++ b/src/algebra/module.lean
@@ -277,11 +277,11 @@ end linear_map
 namespace linear_map
 variables [ring R] [add_comm_group M] [add_comm_group M₂]
 variables [add_comm_group M₃]
-variables {module_M : module R M} {module_M₂ : module R M₂} {module_M₃ : module R M₃} (f : M₂ →ₗ[R] M₃) (g : M →ₗ[R] M₂)
+variables {module_M : module R M} {module_M₂ : module R M₂} {module_M₃ : module R M₃}
+variables (f : M₂ →ₗ[R] M₃) (g : M →ₗ[R] M₂)
 
 /-- Composition of two linear maps is a linear map -/
-def comp :
-  M →ₗ[R] M₃ := ⟨f ∘ g, by simp, by simp⟩
+def comp : M →ₗ[R] M₃ := ⟨f ∘ g, by simp, by simp⟩
 
 @[simp] lemma comp_apply (x : M) : f.comp g x = f (g x) := rfl
 
@@ -443,8 +443,7 @@ by refine {to_fun := coe, ..}; simp [coe_smul]
 
 @[simp] theorem subtype_apply (x : p) : p.subtype x = x := rfl
 
-lemma subtype_eq_val :
-  ((submodule.subtype p) : p → M) = subtype.val := rfl
+lemma subtype_eq_val : ((submodule.subtype p) : p → M) = subtype.val := rfl
 
 end submodule
 

--- a/src/algebra/module.lean
+++ b/src/algebra/module.lean
@@ -441,7 +441,8 @@ by refine {to_fun := coe, ..}; simp [coe_smul]
 
 @[simp] theorem subtype_apply (x : p) : p.subtype x = x := rfl
 
-lemma subtype_eq_val : ((submodule.subtype p) : p → M) = subtype.val := rfl
+lemma subtype_eq_val :
+  ((submodule.subtype p) : p → M) = subtype.val := rfl
 
 end submodule
 

--- a/src/algebra/module.lean
+++ b/src/algebra/module.lean
@@ -387,29 +387,29 @@ lemma neg_mem (hx : x ∈ p) : -x ∈ p := by rw ← neg_one_smul R; exact p.smu
 lemma sub_mem (hx : x ∈ p) (hy : y ∈ p) : x - y ∈ p := p.add_mem hx (p.neg_mem hy)
 
 lemma neg_mem_iff : -x ∈ p ↔ x ∈ p :=
-⟨λ h, by simpa using p.neg_mem h, p.neg_mem⟩
+⟨λ h, by simpa using neg_mem p h, neg_mem p⟩
 
 lemma add_mem_iff_left (h₁ : y ∈ p) : x + y ∈ p ↔ x ∈ p :=
-⟨λ h₂, by simpa using p.sub_mem h₂ h₁, λ h₂, p.add_mem h₂ h₁⟩
+⟨λ h₂, by simpa using sub_mem _ h₂ h₁, λ h₂, add_mem _ h₂ h₁⟩
 
 lemma add_mem_iff_right (h₁ : x ∈ p) : x + y ∈ p ↔ y ∈ p :=
-⟨λ h₂, by simpa using p.sub_mem h₂ h₁, p.add_mem h₁⟩
+⟨λ h₂, by simpa using sub_mem _ h₂ h₁, add_mem _ h₁⟩
 
 lemma sum_mem {t : finset ι} {f : ι → M} :
   (∀c∈t, f c ∈ p) → t.sum f ∈ p :=
 begin
   classical,
-  exact finset.induction_on t (by simp [zero_mem]) (by simp [add_mem] {contextual := tt})
+  exact finset.induction_on t (by simp [p.zero_mem]) (by simp [p.add_mem] {contextual := tt})
 end
 
 lemma smul_mem_iff' (u : units R) : (u:R) • x ∈ p ↔ x ∈ p :=
 ⟨λ h, by simpa only [smul_smul, u.inv_mul, one_smul] using p.smul_mem ↑u⁻¹ h, p.smul_mem u⟩
 
-instance : has_add p := ⟨λx y, ⟨x.1 + y.1, p.add_mem x.2 y.2⟩⟩
-instance : has_zero p := ⟨⟨0, p.zero_mem⟩⟩
+instance : has_add p := ⟨λx y, ⟨x.1 + y.1, add_mem _ x.2 y.2⟩⟩
+instance : has_zero p := ⟨⟨0, zero_mem _⟩⟩
 instance : inhabited p := ⟨0⟩
-instance : has_neg p := ⟨λx, ⟨-x.1, p.neg_mem x.2⟩⟩
-instance : has_scalar R p := ⟨λ c x, ⟨c • x.1, p.smul_mem c x.2⟩⟩
+instance : has_neg p := ⟨λx, ⟨-x.1, neg_mem _ x.2⟩⟩
+instance : has_scalar R p := ⟨λ c x, ⟨c • x.1, smul_mem _ c x.2⟩⟩
 
 variables {p}
 @[simp, norm_cast] lemma coe_add (x y : p) : (↑(x + y) : M) = ↑x + ↑y := rfl

--- a/src/algebra/module.lean
+++ b/src/algebra/module.lean
@@ -214,24 +214,33 @@ notation β ` →ₗ[`:25 α:25 `] `:0 γ:0 := linear_map α β γ
 
 namespace linear_map
 
-variables [ring R] [add_comm_group M] [add_comm_group M₂] [add_comm_group M₃]
-variables [module R M] [module R M₂] [module R M₃]
+variables [ring R] [add_comm_group M] [add_comm_group M₂]
+
+section
+variables [module R M] [module R M₂]
 variables (f g : M →ₗ[R] M₂)
 
 instance : has_coe_to_fun (M →ₗ[R] M₂) := ⟨_, to_fun⟩
 
 @[simp] lemma coe_mk (f : M → M₂) (h₁ h₂) :
   ((linear_map.mk f h₁ h₂ : M →ₗ[R] M₂) : M → M₂) = f := rfl
+end
 
-@[simp] lemma to_fun_eq_coe (f : M →ₗ[R] M₂) : f.to_fun = ⇑f := rfl
+variables {module_M : module R M} {module_M₂ : module R M₂}
+variables (f g : M →ₗ[R] M₂)
+
+@[simp] lemma to_fun_eq_coe : f.to_fun = ⇑f := rfl
 
 theorem is_linear : is_linear_map R f := {..f}
 
-@[ext] theorem ext {f g : M →ₗ[R] M₂} (H : ∀ x, f x = g x) : f = g :=
+variables {f g}
+@[ext] theorem ext (H : ∀ x, f x = g x) : f = g :=
 by cases f; cases g; congr'; exact funext H
 
-theorem ext_iff {f g : M →ₗ[R] M₂} : f = g ↔ ∀ x, f x = g x :=
+theorem ext_iff : f = g ↔ ∀ x, f x = g x :=
 ⟨by { rintro rfl x, refl } , ext⟩
+
+variables (f g)
 
 @[simp] lemma map_add (x y : M) : f (x + y) = f x + f y := f.add x y
 
@@ -243,12 +252,12 @@ by rw [← zero_smul R, map_smul f 0 0, zero_smul]
 instance : is_add_group_hom f := { map_add := map_add f }
 
 /-- convert a linear map to an additive map -/
-def to_add_monoid_hom (f : M →ₗ[R] M₂) : M →+ M₂ :=
+def to_add_monoid_hom : M →+ M₂ :=
 { to_fun := f,
   map_zero' := f.map_zero,
   map_add' := f.map_add }
 
-@[simp] lemma to_add_monoid_hom_coe (f : M →ₗ[R] M₂) :
+@[simp] lemma to_add_monoid_hom_coe :
   ((f.to_add_monoid_hom) : M → M₂) = f := rfl
 
 @[simp] lemma map_neg (x : M) : f (- x) = - f x :=
@@ -261,15 +270,24 @@ f.to_add_monoid_hom.map_sub x y
   f (t.sum g) = t.sum (λi, f (g i)) :=
 f.to_add_monoid_hom.map_sum _ _
 
-/-- Composition of two linear maps is a linear map -/
-def comp (f : M₂ →ₗ[R] M₃) (g : M →ₗ[R] M₂) : M →ₗ[R] M₃ := ⟨f ∘ g, by simp, by simp⟩
+end linear_map
 
-@[simp] lemma comp_apply (f : M₂ →ₗ[R] M₃) (g : M →ₗ[R] M₂) (x : M) : f.comp g x = f (g x) := rfl
+namespace linear_map
+variables [ring R] [add_comm_group M] [add_comm_group M₂]
+variables [add_comm_group M₃]
+variables {module_M : module R M} {module_M₂ : module R M₂} {module_M₃ : module R M₃} (f : M₂ →ₗ[R] M₃) (g : M →ₗ[R] M₂)
+
+/-- Composition of two linear maps is a linear map -/
+def comp :
+  M →ₗ[R] M₃ := ⟨f ∘ g, by simp, by simp⟩
+
+@[simp] lemma comp_apply (x : M) : f.comp g x = f (g x) := rfl
 
 /-- Identity map as a `linear_map` -/
-def id : M →ₗ[R] M := ⟨id, λ _ _, rfl, λ _ _, rfl⟩
+def id {R} {M} [ring R] [add_comm_group M] [module R M] : M →ₗ[R] M := ⟨id, λ _ _, rfl, λ _ _, rfl⟩
 
-@[simp] lemma id_apply (x : M) : @id R M _ _ _ x = x := rfl
+@[simp] lemma id_apply {R} {M} [ring R] [add_comm_group M] [module R M] (x : M) :
+  @id R M _ _ _ x = x := rfl
 
 end linear_map
 
@@ -330,22 +348,31 @@ structure submodule (R : Type u) (M : Type v) [ring R]
 
 namespace submodule
 variables [ring R] [add_comm_group M] [add_comm_group M₂]
-variables [module R M] [module R M₂]
-variables (p p' : submodule R M)
-variables {r : R} {x y : M}
+
+section
+variables [module R M]
 
 instance : has_coe (submodule R M) (set M) := ⟨submodule.carrier⟩
 instance : has_mem M (submodule R M) := ⟨λ x p, x ∈ (p : set M)⟩
-@[simp] theorem mem_coe : x ∈ (p : set M) ↔ x ∈ p := iff.rfl
+end
 
-theorem ext' {s t : submodule R M} (h : (s : set M) = t) : s = t :=
-by cases s; cases t; congr'
+-- We can infer the module structure implicitly from the bundled submodule,
+-- rather than via typeclass resolution.
+variables {module_M : module R M}
+variables {p q : submodule R M}
+variables {r : R} {x y : M}
 
-protected theorem ext'_iff {s t : submodule R M}  : (s : set M) = t ↔ s = t :=
+theorem ext' (h : (p : set M) = q) : p = q :=
+by cases p; cases q; congr'
+
+protected theorem ext'_iff : (p : set M) = q ↔ p = q :=
 ⟨ext', λ h, h ▸ rfl⟩
 
-@[ext] theorem ext {s t : submodule R M}
-  (h : ∀ x, x ∈ s ↔ x ∈ t) : s = t := ext' $ set.ext h
+@[ext] theorem ext
+  (h : ∀ x, x ∈ p ↔ x ∈ q) : p = q := ext' $ set.ext h
+
+variables (p)
+@[simp] theorem mem_coe : x ∈ (p : set M) ↔ x ∈ p := iff.rfl
 
 @[simp] lemma zero_mem : (0 : M) ∈ p := p.zero
 
@@ -358,30 +385,31 @@ lemma neg_mem (hx : x ∈ p) : -x ∈ p := by rw ← neg_one_smul R; exact p.smu
 lemma sub_mem (hx : x ∈ p) (hy : y ∈ p) : x - y ∈ p := p.add_mem hx (p.neg_mem hy)
 
 lemma neg_mem_iff : -x ∈ p ↔ x ∈ p :=
-⟨λ h, by simpa using neg_mem p h, neg_mem p⟩
+⟨λ h, by simpa using p.neg_mem h, p.neg_mem⟩
 
 lemma add_mem_iff_left (h₁ : y ∈ p) : x + y ∈ p ↔ x ∈ p :=
-⟨λ h₂, by simpa using sub_mem _ h₂ h₁, λ h₂, add_mem _ h₂ h₁⟩
+⟨λ h₂, by simpa using p.sub_mem h₂ h₁, λ h₂, p.add_mem h₂ h₁⟩
 
 lemma add_mem_iff_right (h₁ : x ∈ p) : x + y ∈ p ↔ y ∈ p :=
-⟨λ h₂, by simpa using sub_mem _ h₂ h₁, add_mem _ h₁⟩
+⟨λ h₂, by simpa using p.sub_mem h₂ h₁, p.add_mem h₁⟩
 
 lemma sum_mem {t : finset ι} {f : ι → M} :
   (∀c∈t, f c ∈ p) → t.sum f ∈ p :=
 begin
   classical,
-  exact finset.induction_on t (by simp [p.zero_mem]) (by simp [p.add_mem] {contextual := tt})
+  exact finset.induction_on t (by simp [zero_mem]) (by simp [add_mem] {contextual := tt})
 end
 
 lemma smul_mem_iff' (u : units R) : (u:R) • x ∈ p ↔ x ∈ p :=
 ⟨λ h, by simpa only [smul_smul, u.inv_mul, one_smul] using p.smul_mem ↑u⁻¹ h, p.smul_mem u⟩
 
-instance : has_add p := ⟨λx y, ⟨x.1 + y.1, add_mem _ x.2 y.2⟩⟩
-instance : has_zero p := ⟨⟨0, zero_mem _⟩⟩
+instance : has_add p := ⟨λx y, ⟨x.1 + y.1, p.add_mem x.2 y.2⟩⟩
+instance : has_zero p := ⟨⟨0, p.zero_mem⟩⟩
 instance : inhabited p := ⟨0⟩
-instance : has_neg p := ⟨λx, ⟨-x.1, neg_mem _ x.2⟩⟩
-instance : has_scalar R p := ⟨λ c x, ⟨c • x.1, smul_mem _ c x.2⟩⟩
+instance : has_neg p := ⟨λx, ⟨-x.1, p.neg_mem x.2⟩⟩
+instance : has_scalar R p := ⟨λ c x, ⟨c • x.1, p.smul_mem c x.2⟩⟩
 
+variables {p}
 @[simp, norm_cast] lemma coe_add (x y : p) : (↑(x + y) : M) = ↑x + ↑y := rfl
 @[simp, norm_cast] lemma coe_zero : ((0 : p) : M) = 0 := rfl
 @[simp, norm_cast] lemma coe_neg (x : p) : ((-x : p) : M) = -x := rfl
@@ -401,6 +429,8 @@ instance submodule_is_add_subgroup : is_add_subgroup (p : set M) :=
 
 @[simp, norm_cast] lemma coe_sub (x y : p) : (↑(x - y) : M) = ↑x - ↑y := rfl
 
+variables (p)
+
 instance : module R p :=
 by refine {smul := (•), ..};
    { intros, apply set_coe.ext, simp [smul_add, add_smul, mul_smul] }
@@ -409,10 +439,9 @@ by refine {smul := (•), ..};
 protected def subtype : p →ₗ[R] M :=
 by refine {to_fun := coe, ..}; simp [coe_smul]
 
-@[simp] theorem subtype_apply (x : p) : p.subtype x = x := rfl
+lemma subtype_eq_val : ((submodule.subtype p) : p → M) = subtype.val := rfl
 
-lemma subtype_eq_val (p : submodule R M) :
-  ((submodule.subtype p) : p → M) = subtype.val := rfl
+@[simp] theorem subtype_apply (x : p) : p.subtype x = x := rfl
 
 end submodule
 

--- a/src/algebra/module.lean
+++ b/src/algebra/module.lean
@@ -439,9 +439,9 @@ by refine {smul := (•), ..};
 protected def subtype : p →ₗ[R] M :=
 by refine {to_fun := coe, ..}; simp [coe_smul]
 
-lemma subtype_eq_val : ((submodule.subtype p) : p → M) = subtype.val := rfl
-
 @[simp] theorem subtype_apply (x : p) : p.subtype x = x := rfl
+
+lemma subtype_eq_val : ((submodule.subtype p) : p → M) = subtype.val := rfl
 
 end submodule
 

--- a/src/algebra/module.lean
+++ b/src/algebra/module.lean
@@ -226,6 +226,8 @@ instance : has_coe_to_fun (M →ₗ[R] M₂) := ⟨_, to_fun⟩
   ((linear_map.mk f h₁ h₂ : M →ₗ[R] M₂) : M → M₂) = f := rfl
 end
 
+-- We can infer the module structure implicitly from the linear maps,
+-- rather than via typeclass resolution.
 variables {module_M : module R M} {module_M₂ : module R M₂}
 variables (f g : M →ₗ[R] M₂)
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1354,155 +1354,176 @@ notation M ` ≃ₗ[`:50 R `] ` M₂ := linear_equiv R M M₂
 namespace linear_equiv
 section ring
 variables [ring R] [add_comm_group M] [add_comm_group M₂] [add_comm_group M₃]
-variables [module R M] [module R M₂] [module R M₃]
+
+section
+variables [module R M] [module R M₂]
 include R
 
 instance : has_coe (M ≃ₗ[R] M₂) (M →ₗ[R] M₂) := ⟨to_linear_map⟩
 -- see Note [function coercion]
 instance : has_coe_to_fun (M ≃ₗ[R] M₂) := ⟨_, λ f, f.to_fun⟩
 
-@[simp] theorem coe_apply (e : M ≃ₗ[R] M₂) (b : M) : (e : M →ₗ[R] M₂) b = e b := rfl
-
 lemma to_equiv_injective : function.injective (to_equiv : (M ≃ₗ[R] M₂) → M ≃ M₂) :=
 λ ⟨_, _, _, _, _, _⟩ ⟨_, _, _, _, _, _⟩ h, linear_equiv.mk.inj_eq.mpr (equiv.mk.inj h)
+end
 
-@[ext] lemma ext {f g : M ≃ₗ[R] M₂} (h : (f : M → M₂) = g) : f = g :=
+section
+variables {module_M : module R M} {module_M₂ : module R M₂}
+variables (e e' : M ≃ₗ[R] M₂)
+
+@[simp] theorem coe_apply (b : M) : (e : M →ₗ[R] M₂) b = e b := rfl
+
+section
+variables {e e'}
+@[ext] lemma ext (h : (e : M → M₂) = e') : e = e' :=
 to_equiv_injective (equiv.eq_of_to_fun_eq h)
+end
 
 section
 variables (M R)
 
 /-- The identity map is a linear equivalence. -/
 @[refl]
-def refl : M ≃ₗ[R] M := { .. linear_map.id, .. equiv.refl M }
+def refl [module R M] : M ≃ₗ[R] M := { .. linear_map.id, .. equiv.refl M }
 end
 
-@[simp] lemma refl_apply (x : M) : refl R M x = x := rfl
+@[simp] lemma refl_apply [module R M] (x : M) : refl R M x = x := rfl
 
 /-- Linear equivalences are symmetric. -/
 @[symm]
-def symm (e : M ≃ₗ[R] M₂) : M₂ ≃ₗ[R] M :=
+def symm : M₂ ≃ₗ[R] M :=
 { .. e.to_linear_map.inverse e.inv_fun e.left_inv e.right_inv,
   .. e.to_equiv.symm }
 
+variables {module_M₃ : module R M₃} (e₁ : M ≃ₗ[R] M₂) (e₂ : M₂ ≃ₗ[R] M₃)
+
 /-- Linear equivalences are transitive. -/
 @[trans]
-def trans (e₁ : M ≃ₗ[R] M₂) (e₂ : M₂ ≃ₗ[R] M₃) : M ≃ₗ[R] M₃ :=
+def trans : M ≃ₗ[R] M₃ :=
 { .. e₂.to_linear_map.comp e₁.to_linear_map,
   .. e₁.to_equiv.trans e₂.to_equiv }
 
 /-- A linear equivalence is an additive equivalence. -/
-def to_add_equiv (e : M ≃ₗ[R] M₂) : M ≃+ M₂ := { map_add' := e.add, .. e }
+def to_add_equiv : M ≃+ M₂ := { map_add' := e.add, .. e }
 
-@[simp] theorem trans_apply (e₁ : M ≃ₗ[R] M₂) (e₂ : M₂ ≃ₗ[R] M₃) (c : M) :
+@[simp] theorem trans_apply (c : M) :
   (e₁.trans e₂) c = e₂ (e₁ c) := rfl
-@[simp] theorem apply_symm_apply (e : M ≃ₗ[R] M₂) (c : M₂) : e (e.symm c) = c := e.6 c
-@[simp] theorem symm_apply_apply (e : M ≃ₗ[R] M₂) (b : M) : e.symm (e b) = b := e.5 b
+@[simp] theorem apply_symm_apply (c : M₂) : e (e.symm c) = c := e.6 c
+@[simp] theorem symm_apply_apply (b : M) : e.symm (e b) = b := e.5 b
 
-@[simp] theorem map_add (e : M ≃ₗ[R] M₂) (a b : M) : e (a + b) = e a + e b := e.add a b
-@[simp] theorem map_zero (e : M ≃ₗ[R] M₂) : e 0 = 0 := e.to_linear_map.map_zero
-@[simp] theorem map_neg (e : M ≃ₗ[R] M₂) (a : M) : e (-a) = -e a := e.to_linear_map.map_neg a
-@[simp] theorem map_sub (e : M ≃ₗ[R] M₂) (a b : M) : e (a - b) = e a - e b :=
+@[simp] theorem map_add (a b : M) : e (a + b) = e a + e b := e.add a b
+@[simp] theorem map_zero : e 0 = 0 := e.to_linear_map.map_zero
+@[simp] theorem map_neg (a : M) : e (-a) = -e a := e.to_linear_map.map_neg a
+@[simp] theorem map_sub (a b : M) : e (a - b) = e a - e b :=
 e.to_linear_map.map_sub a b
-@[simp] theorem map_smul (e : M ≃ₗ[R] M₂) (c : R) (x : M) : e (c • x) = c • e x := e.smul c x
+@[simp] theorem map_smul (c : R) (x : M) : e (c • x) = c • e x := e.smul c x
 
-@[simp] theorem map_eq_zero_iff (e : M ≃ₗ[R] M₂) {x : M} : e x = 0 ↔ x = 0 :=
+@[simp] theorem map_eq_zero_iff {x : M} : e x = 0 ↔ x = 0 :=
 e.to_add_equiv.map_eq_zero_iff
-theorem map_ne_zero_iff (e : M ≃ₗ[R] M₂) {x : M} : e x ≠ 0 ↔ x ≠ 0 :=
+theorem map_ne_zero_iff {x : M} : e x ≠ 0 ↔ x ≠ 0 :=
 e.to_add_equiv.map_ne_zero_iff
 
-@[simp] theorem symm_symm (e : M ≃ₗ[R] M₂) : e.symm.symm = e := by { cases e, refl }
+@[simp] theorem symm_symm : e.symm.symm = e := by { cases e, refl }
 
-@[simp] theorem symm_symm_apply (e : M ≃ₗ[R] M₂) (x : M) : e.symm.symm x = e x :=
+@[simp] theorem symm_symm_apply (x : M) : e.symm.symm x = e x :=
 by { cases e, refl }
 
-protected lemma bijective (e : M ≃ₗ[R] M₂) : function.bijective e := e.to_equiv.bijective
-protected lemma injective (e : M ≃ₗ[R] M₂) : function.injective e := e.to_equiv.injective
-protected lemma surjective (e : M ≃ₗ[R] M₂) : function.surjective e := e.to_equiv.surjective
+protected lemma bijective : function.bijective e := e.to_equiv.bijective
+protected lemma injective : function.injective e := e.to_equiv.injective
+protected lemma surjective : function.surjective e := e.to_equiv.surjective
+end
 
 section prod
 
-variables [add_comm_group M₄] [module R M₄]
+variables [add_comm_group M₄]
+variables {module_M : module R M} {module_M₂ : module R M₂}
+variables {module_M₃ : module R M₃} {module_M₄ : module R M₄}
+variables (e₁ : M ≃ₗ[R] M₂) (e₂ : M₃ ≃ₗ[R] M₄)
 
 /-- Product of linear equivalences; the maps come from `equiv.prod_congr`. -/
-protected def prod (e : M ≃ₗ[R] M₂) (e' : M₃ ≃ₗ[R] M₄) :
-  (M × M₃) ≃ₗ[R] M₂ × M₄ :=
-{ add := λ x y, prod.ext (e.map_add _ _) (e'.map_add _ _),
-  smul := λ c x, prod.ext (e.map_smul c _) (e'.map_smul c _),
-  .. equiv.prod_congr e.to_equiv e'.to_equiv }
+protected def prod :
+  (M × M₃) ≃ₗ[R] (M₂ × M₄) :=
+{ add := λ x y, prod.ext (e₁.map_add _ _) (e₂.map_add _ _),
+  smul := λ c x, prod.ext (e₁.map_smul c _) (e₂.map_smul c _),
+  .. equiv.prod_congr e₁.to_equiv e₂.to_equiv }
 
-lemma prod_symm (e : M ≃ₗ[R] M₂) (e' : M₃ ≃ₗ[R] M₄) : (e.prod e').symm = e.symm.prod e'.symm := rfl
+lemma prod_symm : (e₁.prod e₂).symm = e₁.symm.prod e₂.symm := rfl
 
-@[simp] lemma prod_apply (e : M ≃ₗ[R] M₂) (e' : M₃ ≃ₗ[R] M₄) (p) :
-  e.prod e' p = (e p.1, e' p.2) := rfl
+@[simp] lemma prod_apply (p) :
+  e₁.prod e₂ p = (e₁ p.1, e₂ p.2) := rfl
 
-@[simp, norm_cast] lemma coe_prod (e : M ≃ₗ[R] M₂) (e' : M₃ ≃ₗ[R] M₄) :
-  (e.prod e' : (M × M₃) →ₗ[R] M₂ × M₄) = (e : M →ₗ[R] M₂).prod_map (e' : M₃ →ₗ[R] M₄) :=
+@[simp, norm_cast] lemma coe_prod :
+  (e₁.prod e₂ : (M × M₃) →ₗ[R] (M₂ × M₄)) = (e₁ : M →ₗ[R] M₂).prod_map (e₂ : M₃ →ₗ[R] M₄) :=
 rfl
 
-/-- Equivalence given by a block lower diagonal matrix. `e` and `e'` are diagonal square blocks,
+/-- Equivalence given by a block lower diagonal matrix. `e₁` and `e₂` are diagonal square blocks,
   and `f` is a rectangular block below the diagonal. -/
-protected def skew_prod (e : M ≃ₗ[R] M₂) (e' : M₃ ≃ₗ[R] M₄) (f : M →ₗ[R] M₄) :
+protected def skew_prod (f : M →ₗ[R] M₄) :
   (M × M₃) ≃ₗ[R] M₂ × M₄ :=
-{ inv_fun := λ p : M₂ × M₄, (e.symm p.1, e'.symm (p.2 - f (e.symm p.1))),
+{ inv_fun := λ p : M₂ × M₄, (e₁.symm p.1, e₂.symm (p.2 - f (e₁.symm p.1))),
   left_inv := λ p, by simp,
   right_inv := λ p, by simp,
-  .. ((e : M →ₗ[R] M₂).comp (linear_map.fst R M M₃)).prod
-    ((e' : M₃ →ₗ[R] M₄).comp (linear_map.snd R M M₃) +
+  .. ((e₁ : M →ₗ[R] M₂).comp (linear_map.fst R M M₃)).prod
+    ((e₂ : M₃ →ₗ[R] M₄).comp (linear_map.snd R M M₃) +
       f.comp (linear_map.fst R M M₃)) }
 
-@[simp] lemma skew_prod_apply (e : M ≃ₗ[R] M₂) (e' : M₃ ≃ₗ[R] M₄) (f : M →ₗ[R] M₄) (x) :
-  e.skew_prod e' f x = (e x.1, e' x.2 + f x.1) := rfl
+@[simp] lemma skew_prod_apply (f : M →ₗ[R] M₄) (x) :
+  e₁.skew_prod e₂ f x = (e₁ x.1, e₂ x.2 + f x.1) := rfl
 
-@[simp] lemma skew_prod_symm_apply (e : M ≃ₗ[R] M₂) (e' : M₃ ≃ₗ[R] M₄) (f : M →ₗ[R] M₄) (x) :
-  (e.skew_prod e' f).symm x = (e.symm x.1, e'.symm (x.2 - f (e.symm x.1))) := rfl
+@[simp] lemma skew_prod_symm_apply (f : M →ₗ[R] M₄) (x) :
+  (e₁.skew_prod e₂ f).symm x = (e₁.symm x.1, e₂.symm (x.2 - f (e₁.symm x.1))) := rfl
 
 end prod
 
+section
+variables {module_M : module R M} {module_M₂ : module R M₂}
+variables (f : M →ₗ[R] M₂)
+
 /-- A bijective linear map is a linear equivalence. Here, bijectivity is described by saying that
 the kernel of `f` is `{0}` and the range is the universal set. -/
-noncomputable def of_bijective
-  (f : M →ₗ[R] M₂) (hf₁ : f.ker = ⊥) (hf₂ : f.range = ⊤) : M ≃ₗ[R] M₂ :=
+noncomputable def of_bijective (hf₁ : f.ker = ⊥) (hf₂ : f.range = ⊤) : M ≃ₗ[R] M₂ :=
 { ..f, ..@equiv.of_bijective _ _ f
   ⟨linear_map.ker_eq_bot.1 hf₁, linear_map.range_eq_top.1 hf₂⟩ }
 
-@[simp] theorem of_bijective_apply (f : M →ₗ[R] M₂) {hf₁ hf₂} (x : M) :
+@[simp] theorem of_bijective_apply {hf₁ hf₂} (x : M) :
   of_bijective f hf₁ hf₂ x = f x := rfl
 
+variables (g : M₂ →ₗ[R] M)
+
 /-- If a linear map has an inverse, it is a linear equivalence. -/
-def of_linear (f : M →ₗ[R] M₂) (g : M₂ →ₗ[R] M)
-  (h₁ : f.comp g = linear_map.id) (h₂ : g.comp f = linear_map.id) : M ≃ₗ[R] M₂ :=
+def of_linear (h₁ : f.comp g = linear_map.id) (h₂ : g.comp f = linear_map.id) : M ≃ₗ[R] M₂ :=
 { inv_fun   := g,
   left_inv  := linear_map.ext_iff.1 h₂,
   right_inv := linear_map.ext_iff.1 h₁,
   ..f }
 
-@[simp] theorem of_linear_apply (f : M →ₗ[R] M₂) (g : M₂ →ₗ[R] M) {h₁ h₂}
-  (x : M) : of_linear f g h₁ h₂ x = f x := rfl
+@[simp] theorem of_linear_apply {h₁ h₂} (x : M) : of_linear f g h₁ h₂ x = f x := rfl
 
-@[simp] theorem of_linear_symm_apply (f : M →ₗ[R] M₂) (g : M₂ →ₗ[R] M) {h₁ h₂}
-  (x : M₂) : (of_linear f g h₁ h₂).symm x = g x := rfl
+@[simp] theorem of_linear_symm_apply {h₁ h₂} (x : M₂) : (of_linear f g h₁ h₂).symm x = g x := rfl
 
-@[simp] protected theorem ker (f : M ≃ₗ[R] M₂) : (f : M →ₗ[R] M₂).ker = ⊥ :=
-linear_map.ker_eq_bot.2 f.to_equiv.injective
+variables (e : M ≃ₗ[R] M₂)
 
-@[simp] protected theorem range (f : M ≃ₗ[R] M₂) : (f : M →ₗ[R] M₂).range = ⊤ :=
-linear_map.range_eq_top.2 f.to_equiv.surjective
+@[simp] protected theorem ker : (e : M →ₗ[R] M₂).ker = ⊥ :=
+linear_map.ker_eq_bot.2 e.to_equiv.injective
+
+@[simp] protected theorem range : (e : M →ₗ[R] M₂).range = ⊤ :=
+linear_map.range_eq_top.2 e.to_equiv.surjective
+
+variables (p : submodule R M)
 
 /-- The top submodule of `M` is linearly equivalent to `M`. -/
-def of_top (p : submodule R M) (h : p = ⊤) : p ≃ₗ[R] M :=
+def of_top (h : p = ⊤) : p ≃ₗ[R] M :=
 { inv_fun   := λ x, ⟨x, h.symm ▸ trivial⟩,
   left_inv  := λ ⟨x, h⟩, rfl,
   right_inv := λ x, rfl,
   .. p.subtype }
 
-@[simp] theorem of_top_apply (p : submodule R M) {h} (x : p) :
-  of_top p h x = x := rfl
+@[simp] theorem of_top_apply {h} (x : p) : of_top p h x = x := rfl
 
-@[simp] theorem of_top_symm_apply (p : submodule R M) {h} (x : M) :
+@[simp] theorem of_top_symm_apply {h} (x : M) :
   (of_top p h).symm x = ⟨x, h.symm ▸ trivial⟩ := rfl
 
-lemma eq_bot_of_equiv (p : submodule R M) (e : p ≃ₗ[R] (⊥ : submodule R M₂)) :
+lemma eq_bot_of_equiv [module R M₂] (e : p ≃ₗ[R] (⊥ : submodule R M₂)) :
   p = ⊥ :=
 begin
   refine bot_unique (submodule.le_def'.2 $ assume b hb, (submodule.mem_bot R).2 _),
@@ -1510,6 +1531,7 @@ begin
   rw [← e.coe_apply, submodule.eq_zero_of_bot_submodule ((e : p →ₗ[R] (⊥ : submodule R M₂)) ⟨b, hb⟩),
     ← e.symm.coe_apply, linear_map.map_zero] at this,
   exact congr_arg (coe : p → M) this.symm
+end
 end
 
 end ring

--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -565,7 +565,7 @@ variables (R : Type*) [comm_ring R] (S : Type*) [ring S] [algebra R S]
 (E : Type*) [add_comm_group E] [module S E] {F : Type*} [add_comm_group F] [module S F]
 
 /-- When `E` is a module over a ring `S`, and `S` is an algebra over `R`, then `E` inherits a
-module structure over `R`, called `module.restrict S R E`.
+module structure over `R`, called `module.restrict_scalars R S E`.
 Not registered as an instance as `S` can not be inferred. -/
 def module.restrict_scalars : module R E :=
 { smul      := λc x, (algebra_map R S c) • x,
@@ -576,9 +576,36 @@ def module.restrict_scalars : module R E :=
   add_smul  := by simp [add_smul],
   zero_smul := by simp [zero_smul] }
 
+/--
+The identity function, as an `R`-linear map from `S` to itself,
+with `module.restrict_scalars R S S` as the module structure in the source,
+and `algebra.to_module` as the module structure in the target.
+
+Unfortunately these structures are not generally definitionally equal,
+so we sometimes need to insert this map in order to typecheck.
+-/
+def algebra.restrict_scalars_iso :
+  @linear_map R S S _ _ _ (module.restrict_scalars R S S) (algebra.to_module) :=
+{ to_fun := λ s, s,
+  add := λ x y, rfl,
+  smul := λ c x, (algebra.smul_def' _ _).symm,  }
+
+@[simp]
+lemma algebra.restrict_scalars_iso_apply (s : S) : algebra.restrict_scalars_iso R S s = s := rfl
+
 variables {S E}
 
 local attribute [instance] module.restrict_scalars
+
+/--
+The `R`-submodule of the `R`-module given by restriction of scalars,
+corresponding to an `S`-submodule of the original `S`-module.
+-/
+def submodule.restrict_scalars (V : submodule S E) : submodule R E :=
+{ carrier := V.carrier,
+  zero := V.zero,
+  smul := λ c e h, V.smul _ h,
+  add := λ x y hx hy, V.add hx hy, }
 
 /-- The `R`-linear map induced by an `S`-linear map when `S` is an algebra over `R`. -/
 def linear_map.restrict_scalars (f : E →ₗ[S] F) : E →ₗ[R] F :=

--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -565,7 +565,7 @@ variables (R : Type*) [comm_ring R] (S : Type*) [ring S] [algebra R S]
 (E : Type*) [add_comm_group E] [module S E] {F : Type*} [add_comm_group F] [module S F]
 
 /-- When `E` is a module over a ring `S`, and `S` is an algebra over `R`, then `E` inherits a
-module structure over `R`, called `module.restrict_scalars R S E`.
+module structure over `R`, called `module.restrict S R E`.
 Not registered as an instance as `S` can not be inferred. -/
 def module.restrict_scalars : module R E :=
 { smul      := λc x, (algebra_map R S c) • x,
@@ -576,36 +576,9 @@ def module.restrict_scalars : module R E :=
   add_smul  := by simp [add_smul],
   zero_smul := by simp [zero_smul] }
 
-/--
-The identity function, as an `R`-linear map from `S` to itself,
-with `module.restrict_scalars R S S` as the module structure in the source,
-and `algebra.to_module` as the module structure in the target.
-
-Unfortunately these structures are not generally definitionally equal,
-so we sometimes need to insert this map in order to typecheck.
--/
-def algebra.restrict_scalars_iso :
-  @linear_map R S S _ _ _ (module.restrict_scalars R S S) (algebra.to_module) :=
-{ to_fun := λ s, s,
-  add := λ x y, rfl,
-  smul := λ c x, (algebra.smul_def' _ _).symm,  }
-
-@[simp]
-lemma algebra.restrict_scalars_iso_apply (s : S) : algebra.restrict_scalars_iso R S s = s := rfl
-
 variables {S E}
 
 local attribute [instance] module.restrict_scalars
-
-/--
-The `R`-submodule of the `R`-module given by restriction of scalars,
-corresponding to an `S`-submodule of the original `S`-module.
--/
-def submodule.restrict_scalars (V : submodule S E) : submodule R E :=
-{ carrier := V.carrier,
-  zero := V.zero,
-  smul := λ c e h, V.smul _ h,
-  add := λ x y hx hy, V.add hx hy, }
 
 /-- The `R`-linear map induced by an `S`-linear map when `S` is an algebra over `R`. -/
 def linear_map.restrict_scalars (f : E →ₗ[S] F) : E →ₗ[R] F :=


### PR DESCRIPTION
This doesn't change the explicit type signature of any functions, but makes some inferable typeclass arguments implicit.

Beyond the potential performance improvement, my motivation for doing this was that in `monoid_algebra` we currently have two possible `module k (monoid_algebra k G)` instances: one directly from `monoid_algebra.module`, and another one via `restrict_scalars`. These are equal, but not definitionally. In another experimental branch, I couldn't even express the isomorphism between these module structures, because type inference was filling in the `monoid_algebra.module` instance in composition of linear maps, and then failing because one of the linear maps was actually using the other module structure...

This change fixes this.
