### PR TITLE
[Merged by Bors] - fix(group_theory/submonoid): looping simp lemma

### DIFF
--- a/src/group_theory/submonoid.lean
+++ b/src/group_theory/submonoid.lean
@@ -453,15 +453,18 @@ namespace submonoid
 instance : has_coe (submonoid M) (set M) := ⟨submonoid.carrier⟩
 
 @[to_additive]
+instance : has_coe_to_sort (submonoid M) := ⟨Type*, λ S, S.carrier⟩
+
+@[to_additive]
 instance : has_mem M (submonoid M) := ⟨λ m S, m ∈ (S:set M)⟩
 
-@[simp, to_additive]
+@[simp, norm_cast, to_additive]
 lemma mem_coe {S : submonoid M} {m : M} : m ∈ (S : set M) ↔ m ∈ S := iff.rfl
 
-@[simp, norm_cast, to_additive, nolint simp_nf] -- `simp_nf: timeout`
+@[simp, norm_cast, to_additive]
 lemma coe_coe (s : submonoid M) : ↥(s : set M) = s := rfl
 
-attribute [norm_cast, nolint simp_nf] add_submonoid.coe_coe
+attribute [norm_cast] add_submonoid.mem_coe add_submonoid.coe_coe
 
 @[to_additive]
 instance is_submonoid (S : submonoid M) : is_submonoid (S : set M) := ⟨S.2, S.3⟩


### PR DESCRIPTION
Removes a `@[nolint simp_nf]`.  I have no idea why I didn't notice this earlier, but `coe_coe` loops due to `coe_sort_coe_base` since `submonoid` doesn't have it's own `has_coe_to_sort` instance.

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
