### PR TITLE
[Merged by Bors] - chore(*): switch to lean 3.9.0

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mathlib"
 version = "0.1"
-lean_version = "leanprover-community/lean:3.8.0"
+lean_version = "leanprover-community/lean:3.9.0"
 path = "src"
 
 [dependencies]

--- a/src/data/array/lemmas.lean
+++ b/src/data/array/lemmas.lean
@@ -5,7 +5,7 @@ Authors: Leonardo de Moura, Mario Carneiro
 -/
 import category.traversable.equiv data.vector2
 
-universes u w
+universes u v w
 
 namespace d_array
 variables {n : ℕ} {α : fin n → Type u}
@@ -227,31 +227,19 @@ end push_back
 /- foreach -/
 
 section foreach
-variables {n : ℕ} {α : Type u} {i : fin n} {f : fin n → α → α} {a : array n α}
-
-theorem read_foreach_aux : ∀ i h (b : array n α) (j : fin n), j.1 < i →
-  (d_array.iterate_aux a (λ i v a', write a' i (f i v)) i h b).read j = f j (a.read j)
-| 0     hi a ⟨j, hj⟩ ji := absurd ji (nat.not_lt_zero _)
-| (i+1) hi a ⟨j, hj⟩ ji := begin
-  dsimp [d_array.iterate_aux], dsimp at ji,
-  by_cases e : (⟨i, hi⟩ : fin _) = ⟨j, hj⟩,
-  { rw [e], simp, refl },
-  { rw [read_write_of_ne _ _ e, read_foreach_aux _ _ _ ⟨j, hj⟩],
-    exact (lt_or_eq_of_le (nat.le_of_lt_succ ji)).resolve_right
-      (ne.symm $ mt (@fin.eq_of_veq _ ⟨i, hi⟩ ⟨j, hj⟩) e) }
-end
+variables {n : ℕ} {α : Type u} {β : Type v} {i : fin n} {f : fin n → α → β} {a : array n α}
 
 @[simp] theorem read_foreach : (foreach a f).read i = f i (a.read i) :=
-read_foreach_aux _ _ _ _ i.2
+rfl
 
 end foreach
 
 /- map -/
 
 section map
-variables {n : ℕ} {α : Type u} {i : fin n} {f : α → α} {a : array n α}
+variables {n : ℕ} {α : Type u} {β : Type v} {i : fin n} {f : α → β} {a : array n α}
 
-theorem read_map : (map f a).read i = f (a.read i) :=
+theorem read_map : (a.map f).read i = f (a.read i) :=
 read_foreach
 
 end map

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -332,7 +332,9 @@ meta def contains_constant (e : expr) (p : name → Prop) [decidable_pred p] : b
 e.fold ff (λ e' _ b, if p (e'.const_name) then tt else b)
 
 /-- `get_simp_args e` returns the arguments of `e` that simp can reach via congruence lemmas. -/
-meta def get_simp_args (e : expr) : tactic (list expr) := do
+meta def get_simp_args (e : expr) : tactic (list expr) :=
+-- `mk_specialized_congr_lemma_simp` throws an assertion violation if its argument is not an app
+if ¬ e.is_app then pure [] else do
 cgr ← mk_specialized_congr_lemma_simp e,
 pure $ do
   (arg_kind, arg) ← cgr.arg_kinds.zip e.get_app_args,


### PR DESCRIPTION
It's been too long since the last Lean release.

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
