### PR TITLE
[Merged by Bors] - fix(*): remove `@[nolint simp_nf]`

### DIFF
--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -264,7 +264,7 @@ def units_equiv_ne_zero : units K ≃ {a : K | a ≠ 0} :=
 
 variable {K}
 
-@[simp, nolint simp_nf] -- takes a crazy amount of time to simplify lhs
+@[simp]
 lemma coe_units_equiv_ne_zero (a : units K) :
   ((units_equiv_ne_zero K a) : K) = a := rfl
 

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -45,7 +45,7 @@ lemma le_coe_of_real (r : ℝ) : r ≤ nnreal.of_real r :=
 le_max_left r 0
 
 lemma coe_nonneg (r : nnreal) : (0 : ℝ) ≤ r := r.2
-@[norm_cast, simp, nolint simp_nf] -- takes a crazy amount of time simplify lhs
+@[norm_cast]
 theorem coe_mk (a : ℝ) (ha) : ((⟨a, ha⟩ : ℝ≥0) : ℝ) = a := rfl
 
 instance : has_zero ℝ≥0  := ⟨⟨0, le_refl 0⟩⟩

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -522,10 +522,8 @@ by refine
   simp only [has_inv.inv, inv_aux, quotient.lift_beta, dif_neg this],
   exact (quotient.sound $ r_of_eq $ by simp [mul_comm]) }
 
-@[simp, nolint simp_nf] -- takes a crazy amount of time simplify lhs
 lemma mk_eq_div {r s} : (mk r s : fraction_ring β) = (r / s : fraction_ring β) :=
-show _ = _ * dite (s.1 = 0) _ _, by rw [dif_neg (mem_non_zero_divisors_iff_ne_zero.mp s.2)];
-exact localization.mk_eq_mul_mk_one _ _
+by simp [div_eq_mul_inv]
 
 variables {β}
 

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -206,10 +206,10 @@ with_top (multiset { a : associates α // irreducible a })
 
 local attribute [instance] associated.setoid
 
-@[simp, nolint simp_nf] -- takes a crazy amount of time to simplify lhs
+@[norm_cast]
 theorem factor_set.coe_add {a b : multiset { a : associates α // irreducible a }} :
-  (↑a + ↑b : factor_set α) = ↑(a + b) :=
-with_top.coe_add
+  (↑(a + b) : factor_set α) = a + b :=
+by simp
 
 lemma factor_set.sup_add_inf_eq_add [decidable_eq (associates α)] :
   ∀(a b : factor_set α), a ⊔ b + a ⊓ b = a + b
@@ -237,7 +237,7 @@ rfl
 | a    none := show (a + ⊤).prod = a.prod * (⊤:factor_set α).prod, by simp
 | (some a) (some b) :=
   show (↑a + ↑b:factor_set α).prod = (↑a:factor_set α).prod * (↑b:factor_set α).prod,
-    by rw [factor_set.coe_add, prod_coe, prod_coe, prod_coe, multiset.map_add, multiset.prod_add]
+    by rw [← factor_set.coe_add, prod_coe, prod_coe, prod_coe, multiset.map_add, multiset.prod_add]
 
 theorem prod_mono : ∀{a b : factor_set α}, a ≤ b → a.prod ≤ b.prod
 | none b h := have b = ⊤, from top_unique h, by rw [this, prod_top]; exact le_refl _


### PR DESCRIPTION
This removes a couple more nolints:
 - `coe_units_equiv_ne_zero` doesn't cause any problems anymore
 - `coe_mk` is redundant
 - `mk_eq_div` was not in simp-normal form (previously the linter timed out instead of reporting it as an error)
 - `factor_set.coe_add` is redundant

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
