### PR TITLE
[Merged by Bors] - fix(category_theory/limits): make image.map_comp a simp lemma

### DIFF
--- a/src/category_theory/limits/shapes/images.lean
+++ b/src/category_theory/limits/shapes/images.lean
@@ -367,7 +367,7 @@ variables [has_image_map sq']
 def has_image_map_comp : has_image_map (sq ≫ sq') :=
 { map := image.map sq ≫ image.map sq' }
 
--- This cannot be a simp lemma, see https://github.com/leanprover-community/lean/issues/181.
+@[simp]
 lemma image.map_comp [has_image_map (sq ≫ sq')] :
   image.map (sq ≫ sq') = image.map sq ≫ image.map sq' :=
 show (has_image_map.map (sq ≫ sq')) = (has_image_map_comp sq sq').map, by congr
@@ -409,8 +409,7 @@ variables [has_images.{v} C] [has_image_maps.{v} C]
 @[simps]
 def im : arrow C ⥤ C :=
 { obj := λ f, image f.hom,
-  map := λ _ _ st, image.map st,
-  map_comp' := λ _ _ _ _ _, image.map_comp _ _ }
+  map := λ _ _ st, image.map st }
 
 end has_image_maps
 


### PR DESCRIPTION
This was not possible in Lean 3.8. Many thanks to @gebner for tracking down and fixing leanprover-community/lean#181 in Lean 3.9.

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
