### PR TITLE
[Merged by Bors] - feat(data/nat,data/int): add some modular arithmetic lemmas

### DIFF
--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -753,7 +753,7 @@ begin
 end
 
 /-- If two integers are congruent to a sufficiently large modulus,
-    they are equal. -/
+they are equal. -/
 lemma eq_of_mod_eq_of_nat_abs_gt_nat_abs_sub {a b c : ℤ} (h1 : a % b = c)
     (h2 : nat_abs (a - c) < nat_abs b) :
   a = c :=

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -527,6 +527,14 @@ theorem mod_eq_zero_of_dvd : ∀ {a b : ℤ}, a ∣ b → b % a = 0
 theorem dvd_iff_mod_eq_zero (a b : ℤ) : a ∣ b ↔ b % a = 0 :=
 ⟨mod_eq_zero_of_dvd, dvd_of_mod_eq_zero⟩
 
+/-- If `a % b = c` then `b` divides `a - c`. -/
+lemma dvd_sub_of_mod_eq {a b c : ℤ} (h : a % b = c) : b ∣ a - c :=
+begin
+  have hx : a % b % b = c % b, {rw h},
+  rw [mod_mod, ←mod_sub_cancel_right c, sub_self, zero_mod] at hx,
+  exact dvd_of_mod_eq_zero hx
+end
+
 theorem nat_abs_dvd {a b : ℤ} : (a.nat_abs : ℤ) ∣ b ↔ a ∣ b :=
 (nat_abs_eq a).elim (λ e, by rw ← e) (λ e, by rw [← neg_dvd_iff_dvd, ← e])
 
@@ -733,6 +741,23 @@ begin
   apply _root_.eq_of_mul_eq_mul_left _ h,
   repeat {assumption}
 end
+
+/-- If an integer with larger absolute value divides an integer, it is
+    zero. -/
+lemma eq_zero_of_dvd_of_nat_abs_gt_nat_abs {a b : ℤ} (w : a ∣ b) (h : nat_abs b < nat_abs a) :
+  b = 0 :=
+begin
+  rw [←nat_abs_dvd, ←dvd_nat_abs, coe_nat_dvd] at w,
+  rw ←nat_abs_eq_zero,
+  exact eq_zero_of_dvd_of_gt w h
+end
+
+/-- If two integers are congruent to a sufficiently large modulus,
+    they are equal. -/
+lemma eq_of_mod_eq_of_nat_abs_gt_nat_abs_sub {a b c : ℤ} (h1 : a % b = c)
+    (h2 : nat_abs (a - c) < nat_abs b) :
+  a = c :=
+eq_of_sub_eq_zero (eq_zero_of_dvd_of_nat_abs_gt_nat_abs (dvd_sub_of_mod_eq h1) h2)
 
 theorem of_nat_add_neg_succ_of_nat_of_lt {m n : ℕ}
   (h : m < n.succ) : of_nat m + -[1+n] = -[1+ n - m] :=

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -743,7 +743,7 @@ begin
 end
 
 /-- If an integer with larger absolute value divides an integer, it is
-    zero. -/
+zero. -/
 lemma eq_zero_of_dvd_of_nat_abs_gt_nat_abs {a b : ℤ} (w : a ∣ b) (h : nat_abs b < nat_abs a) :
   b = 0 :=
 begin

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -749,7 +749,7 @@ lemma eq_zero_of_dvd_of_nat_abs_lt_nat_abs {a b : ℤ} (w : a ∣ b) (h : nat_ab
 begin
   rw [←nat_abs_dvd, ←dvd_nat_abs, coe_nat_dvd] at w,
   rw ←nat_abs_eq_zero,
-  exact eq_zero_of_dvd_of_gt w h
+  exact eq_zero_of_dvd_of_lt w h
 end
 
 /-- If two integers are congruent to a sufficiently large modulus,

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -530,7 +530,7 @@ theorem dvd_iff_mod_eq_zero (a b : ℤ) : a ∣ b ↔ b % a = 0 :=
 /-- If `a % b = c` then `b` divides `a - c`. -/
 lemma dvd_sub_of_mod_eq {a b c : ℤ} (h : a % b = c) : b ∣ a - c :=
 begin
-  have hx : a % b % b = c % b, {rw h},
+  have hx : a % b % b = c % b, { rw h },
   rw [mod_mod, ←mod_sub_cancel_right c, sub_self, zero_mod] at hx,
   exact dvd_of_mod_eq_zero hx
 end

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -754,7 +754,7 @@ end
 
 /-- If two integers are congruent to a sufficiently large modulus,
 they are equal. -/
-lemma eq_of_mod_eq_of_nat_abs_gt_nat_abs_sub {a b c : ℤ} (h1 : a % b = c)
+lemma eq_of_mod_eq_of_nat_abs_sub_lt_nat_abs {a b c : ℤ} (h1 : a % b = c)
     (h2 : nat_abs (a - c) < nat_abs b) :
   a = c :=
 eq_of_sub_eq_zero (eq_zero_of_dvd_of_nat_abs_gt_nat_abs (dvd_sub_of_mod_eq h1) h2)

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -744,7 +744,7 @@ end
 
 /-- If an integer with larger absolute value divides an integer, it is
 zero. -/
-lemma eq_zero_of_dvd_of_nat_abs_gt_nat_abs {a b : ℤ} (w : a ∣ b) (h : nat_abs b < nat_abs a) :
+lemma eq_zero_of_dvd_of_nat_abs_lt_nat_abs {a b : ℤ} (w : a ∣ b) (h : nat_abs b < nat_abs a) :
   b = 0 :=
 begin
   rw [←nat_abs_dvd, ←dvd_nat_abs, coe_nat_dvd] at w,

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -757,7 +757,7 @@ they are equal. -/
 lemma eq_of_mod_eq_of_nat_abs_sub_lt_nat_abs {a b c : ℤ} (h1 : a % b = c)
     (h2 : nat_abs (a - c) < nat_abs b) :
   a = c :=
-eq_of_sub_eq_zero (eq_zero_of_dvd_of_nat_abs_gt_nat_abs (dvd_sub_of_mod_eq h1) h2)
+eq_of_sub_eq_zero (eq_zero_of_dvd_of_nat_abs_lt_nat_abs (dvd_sub_of_mod_eq h1) h2)
 
 theorem of_nat_add_neg_succ_of_nat_of_lt {m n : ℕ}
   (h : m < n.succ) : of_nat m + -[1+n] = -[1+ n - m] :=

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -1367,7 +1367,7 @@ lemma eq_zero_of_dvd_of_div_eq_zero {a b : ℕ} (w : a ∣ b)  (h : b / a = 0) :
 by rw [←nat.div_mul_cancel w, h, zero_mul]
 
 /-- If a larger natural number divides a natural number, it is
-    zero. -/
+zero. -/
 lemma eq_zero_of_dvd_of_gt {a b : ℕ} (w : a ∣ b) (h : b < a) : b = 0 :=
 nat.eq_zero_of_dvd_of_div_eq_zero w
   ((nat.div_eq_zero_iff (lt_of_le_of_lt (zero_le b) h)).elim_right h)

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -597,6 +597,11 @@ end
   (λ n0, by simp [n0])
   (λ npos, mod_eq_of_lt (mod_lt _ npos))
 
+/--  If `a` and `b` are equal mod `c`, `a - b` is zero mod `c`. -/
+lemma sub_mod_eq_zero_of_mod_eq {a b c : ℕ} (h : a % c = b % c) : (a - b) % c = 0 :=
+by rw [←nat.mod_add_div a c, ←nat.mod_add_div b c, ←h, ←nat.sub_sub, nat.add_sub_cancel_left,
+       ←nat.mul_sub_left_distrib, nat.mul_mod_right]
+
 theorem add_pos_left {m : ℕ} (h : 0 < m) (n : ℕ) : 0 < m + n :=
 calc
   m + n > 0 + n : nat.add_lt_add_right h n
@@ -1360,6 +1365,12 @@ by rw [←nat.div_mul_cancel w, h, one_mul]
 
 lemma eq_zero_of_dvd_of_div_eq_zero {a b : ℕ} (w : a ∣ b)  (h : b / a = 0) : b = 0 :=
 by rw [←nat.div_mul_cancel w, h, zero_mul]
+
+/-- If a larger natural number divides a natural number, it is
+    zero. -/
+lemma eq_zero_of_dvd_of_gt {a b : ℕ} (w : a ∣ b) (h : b < a) : b = 0 :=
+nat.eq_zero_of_dvd_of_div_eq_zero w
+  ((nat.div_eq_zero_iff (lt_of_le_of_lt (zero_le b) h)).elim_right h)
 
 lemma div_le_div_left {a b c : ℕ} (h₁ : c ≤ b) (h₂ : 0 < c) : a / b ≤ a / c :=
 (nat.le_div_iff_mul_le _ _ h₂).2 $

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -1366,9 +1366,9 @@ by rw [←nat.div_mul_cancel w, h, one_mul]
 lemma eq_zero_of_dvd_of_div_eq_zero {a b : ℕ} (w : a ∣ b)  (h : b / a = 0) : b = 0 :=
 by rw [←nat.div_mul_cancel w, h, zero_mul]
 
-/-- If a larger natural number divides a natural number, it is
-zero. -/
-lemma eq_zero_of_dvd_of_gt {a b : ℕ} (w : a ∣ b) (h : b < a) : b = 0 :=
+/-- If a small natural number is divisible by a larger natural number,
+the small number is zero. -/
+lemma eq_zero_of_dvd_of_lt {a b : ℕ} (w : a ∣ b) (h : b < a) : b = 0 :=
 nat.eq_zero_of_dvd_of_div_eq_zero w
   ((nat.div_eq_zero_iff (lt_of_le_of_lt (zero_le b) h)).elim_right h)
 


### PR DESCRIPTION
These lemmas (a) were found useful in formalising solutions to some
olympiad problems, see
<https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Some.20olympiad.20formalisations>;
(b) seem more generally relevant than to just those particular
problems; (c) do not show up through library_search as being already
present.



TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
