### PR TITLE
[Merged by Bors] - feat(category_theory): wide pullbacks and limits in the over category

### DIFF
--- a/src/category_theory/adjunction/basic.lean
+++ b/src/category_theory/adjunction/basic.lean
@@ -100,11 +100,11 @@ adj.counit.naturality f
   (adj.unit).app X ≫ G.map (F.map f) = f ≫ (adj.unit).app Y :=
 (adj.unit.naturality f).symm
 
-lemma transpose_equality {A : C} {B : D} (f : F.obj A ⟶ B) (g : A ⟶ G.obj B) :
+lemma hom_equiv_apply_eq {A : C} {B : D} (f : F.obj A ⟶ B) (g : A ⟶ G.obj B) :
   adj.hom_equiv A B f = g ↔ f = (adj.hom_equiv A B).symm g :=
 ⟨λ h, by {cases h, simp}, λ h, by {cases h, simp}⟩
 
-lemma transpose_equality' {A : C} {B : D} (f : F.obj A ⟶ B) (g : A ⟶ G.obj B) :
+lemma eq_hom_equiv_apply {A : C} {B : D} (f : F.obj A ⟶ B) (g : A ⟶ G.obj B) :
   g = adj.hom_equiv A B f ↔ (adj.hom_equiv A B).symm g = f :=
 ⟨λ h, by {cases h, simp}, λ h, by {cases h, simp}⟩
 

--- a/src/category_theory/adjunction/basic.lean
+++ b/src/category_theory/adjunction/basic.lean
@@ -100,6 +100,14 @@ adj.counit.naturality f
   (adj.unit).app X ≫ G.map (F.map f) = f ≫ (adj.unit).app Y :=
 (adj.unit.naturality f).symm
 
+lemma transpose_equality {A : C} {B : D} (f : F.obj A ⟶ B) (g : A ⟶ G.obj B) :
+  adj.hom_equiv A B f = g ↔ f = (adj.hom_equiv A B).symm g :=
+⟨λ h, by {cases h, simp}, λ h, by {cases h, simp}⟩
+
+lemma transpose_equality' {A : C} {B : D} (f : F.obj A ⟶ B) (g : A ⟶ G.obj B) :
+  g = adj.hom_equiv A B f ↔ (adj.hom_equiv A B).symm g = f :=
+⟨λ h, by {cases h, simp}, λ h, by {cases h, simp}⟩
+
 end
 
 end adjunction

--- a/src/category_theory/limits/connected.lean
+++ b/src/category_theory/limits/connected.lean
@@ -5,6 +5,7 @@ Authors: Bhavik Mehta
 -/
 
 import category_theory.limits.shapes.pullbacks
+import category_theory.limits.shapes.wide_pullbacks
 import category_theory.limits.shapes.binary_products
 import category_theory.limits.shapes.equalizers
 import category_theory.limits.preserves
@@ -26,16 +27,14 @@ open category_theory category_theory.category category_theory.limits
 namespace category_theory
 
 section examples
-instance cospan_inhabited : inhabited walking_cospan := ⟨walking_cospan.one⟩
 
-instance cospan_connected : connected (walking_cospan) :=
+instance wide_pullback_shape_connected (J : Type v₁) : connected (wide_pullback_shape J) :=
 begin
   apply connected.of_induct,
   introv _ t,
   cases j,
-  { rwa t walking_cospan.hom.inl },
-  { rwa t walking_cospan.hom.inr },
-  { assumption }
+  { exact a },
+  { rwa t (wide_pullback_shape.hom.term j) }
 end
 
 instance span_inhabited : inhabited walking_span := ⟨walking_span.zero⟩

--- a/src/category_theory/limits/connected.lean
+++ b/src/category_theory/limits/connected.lean
@@ -37,16 +37,13 @@ begin
   { rwa t (wide_pullback_shape.hom.term j) }
 end
 
-instance span_inhabited : inhabited walking_span := ⟨walking_span.zero⟩
-
-instance span_connected : connected (walking_span) :=
+instance wide_pushout_shape_connected (J : Type v₁) : connected (wide_pushout_shape J) :=
 begin
   apply connected.of_induct,
   introv _ t,
   cases j,
-  { assumption },
-  { rwa ← t walking_span.hom.fst },
-  { rwa ← t walking_span.hom.snd },
+  { exact a },
+  { rwa ← t (wide_pushout_shape.hom.init j) }
 end
 
 instance parallel_pair_inhabited : inhabited walking_parallel_pair := ⟨walking_parallel_pair.one⟩

--- a/src/category_theory/limits/limits.lean
+++ b/src/category_theory/limits/limits.lean
@@ -178,14 +178,17 @@ def iso_unique_cone_morphism {t : cone F} :
   { lift := λ s, (h s).default.hom,
     uniq' := λ s f w, congr_arg cone_morphism.hom ((h s).uniq ⟨f, w⟩) } }
 
+-- TODO: this should actually hold for an adjunction between cone F and cone G, not just for
+-- equivalences
 /--
-TODO: write me
+Given two functors which have equivalent categories of cones, we can transport a limiting cone across
+the equivalence.
 -/
-def of_cone_equiv {D : Type u'} [category.{v} D] {F : J ⥤ C} {G : K ⥤ D} (h : cone F ≌ cone G) {c : cone G} (t : is_limit c) :
+def of_cone_equiv {D : Type u'} [category.{v} D] {G : K ⥤ D} (h : cone F ≌ cone G) {c : cone G} (t : is_limit c) :
   is_limit (h.inverse.obj c) :=
 mk_cone_morphism
-  (λ s, (h.to_adjunction.hom_equiv s c) (t.lift_cone_morphism _))
-  (λ s m, by { rw adjunction.eq_hom_equiv_apply, apply t.uniq_cone_morphism} )
+  (λ s, h.to_adjunction.hom_equiv s c (t.lift_cone_morphism _))
+  (λ s m, (adjunction.eq_hom_equiv_apply _ _ _).2 t.uniq_cone_morphism )
 
 namespace of_nat_iso
 variables {X : C} (h : yoneda.obj X ≅ F.cones)

--- a/src/category_theory/limits/limits.lean
+++ b/src/category_theory/limits/limits.lean
@@ -185,7 +185,7 @@ def of_cone_equiv {D : Type u'} [category.{v} D] {F : J ⥤ C} {G : K ⥤ D} (h 
   is_limit (h.inverse.obj c) :=
 mk_cone_morphism
   (λ s, (h.to_adjunction.hom_equiv s c) (t.lift_cone_morphism _))
-  (λ s m, by { rw adjunction.transpose_equality', apply t.uniq_cone_morphism} )
+  (λ s m, by { rw adjunction.eq_hom_equiv_apply, apply t.uniq_cone_morphism} )
 
 namespace of_nat_iso
 variables {X : C} (h : yoneda.obj X ≅ F.cones)

--- a/src/category_theory/limits/limits.lean
+++ b/src/category_theory/limits/limits.lean
@@ -7,6 +7,7 @@ import category_theory.whiskering
 import category_theory.yoneda
 import category_theory.limits.cones
 import category_theory.eq_to_hom
+import category_theory.adjunction.basic
 
 open category_theory category_theory.category category_theory.functor opposite
 
@@ -176,6 +177,15 @@ def iso_unique_cone_morphism {t : cone F} :
   inv := λ h,
   { lift := λ s, (h s).default.hom,
     uniq' := λ s f w, congr_arg cone_morphism.hom ((h s).uniq ⟨f, w⟩) } }
+
+/--
+TODO: write me
+-/
+def of_cone_equiv {D : Type u'} [category.{v} D] {F : J ⥤ C} {G : K ⥤ D} (h : cone F ≌ cone G) {c : cone G} (t : is_limit c) :
+  is_limit (h.inverse.obj c) :=
+mk_cone_morphism
+  (λ s, (h.to_adjunction.hom_equiv s c) (t.lift_cone_morphism _))
+  (λ s m, by { rw adjunction.transpose_equality', apply t.uniq_cone_morphism} )
 
 namespace of_nat_iso
 variables {X : C} (h : yoneda.obj X ≅ F.cones)

--- a/src/category_theory/limits/over.lean
+++ b/src/category_theory/limits/over.lean
@@ -14,7 +14,7 @@ import category_theory.limits.shapes.binary_products
 import category_theory.limits.shapes.constructions.limits_of_products_and_equalizers
 import category_theory.limits.shapes.constructions.equalizers
 
-universes v u u' -- declare the `v`'s first; see `category_theory.category` for an explanation
+universes v u -- declare the `v`'s first; see `category_theory.category` for an explanation
 
 open category_theory category_theory.limits
 

--- a/src/category_theory/limits/over.lean
+++ b/src/category_theory/limits/over.lean
@@ -4,12 +4,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Reid Barton, Bhavik Mehta
 -/
 import category_theory.comma
+import category_theory.pempty
 import category_theory.limits.connected
 import category_theory.limits.creates
 import category_theory.limits.limits
 import category_theory.limits.preserves
 import category_theory.limits.shapes.pullbacks
 import category_theory.limits.shapes.binary_products
+import category_theory.limits.shapes.constructions.limits_of_products_and_equalizers
+import category_theory.limits.shapes.constructions.equalizers
 
 universes v u -- declare the `v`'s first; see `category_theory.category` for an explanation
 
@@ -89,40 +92,83 @@ instance forget_preserves_colimits [has_colimits.{v} C] {X : C} :
   { preserves_colimit := λ F, by exactI
     preserves_colimit_of_preserves_colimit_cocone (colimit.is_colimit F) (forget_colimit_is_colimit F) } }
 
-/-- Given the appropriate pullback in C, construct a product in the over category -/
-def over_product_of_pullbacks (B : C) (F : discrete walking_pair ⥤ over B)
-  [q : has_limit (cospan (F.obj walking_pair.left).hom (F.obj walking_pair.right).hom)] :
-has_limit F :=
-{ cone :=
-  begin
-    refine ⟨_, _⟩,
-    exact @over.mk _ _ B (pullback (F.obj walking_pair.left).hom (F.obj walking_pair.right).hom) (pullback.fst ≫ (F.obj walking_pair.left).hom),
-    apply nat_trans.of_homs, intro i, cases i,
-    apply over.hom_mk _ _, apply pullback.fst, dsimp, refl,
-    apply over.hom_mk _ _, apply pullback.snd, exact pullback.condition.symm
-  end,
-  is_limit :=
-  { lift := λ s,
-      begin
-        apply over.hom_mk _ _,
-          apply pullback.lift _ _ _,
-              exact (s.π.app walking_pair.left).left,
-            exact (s.π.app walking_pair.right).left,
-          erw over.w (s.π.app walking_pair.left),
-          erw over.w (s.π.app walking_pair.right),
-          refl,
-        dsimp, erw ← category.assoc, simp,
-      end,
-    fac' := λ s j,
-      begin
-        ext, cases j; simp [nat_trans.of_homs]
-      end,
-    uniq' := λ s m j,
-      begin
-        ext,
-        { erw ← j walking_pair.left, simp },
-        { erw ← j walking_pair.right, simp }
-      end } }
+namespace construct_products
+
+/-- (Impl) Given a product shape in `C/B`, construct the corresponding wide pullback shape in `C`. -/
+@[reducible]
+def grow_diagram (B : C) {J : Type v} (F : discrete J ⥤ over B) : wide_pullback_shape J ⥤ C :=
+wide_pullback_shape.wide_cospan B (λ j, (F.obj j).left) (λ j, (F.obj j).hom)
+
+local attribute [tidy] tactic.case_bash
+
+/-- (Impl) Pull these out to avoid timeouts. -/
+@[simps]
+def cones_equiv_inverse (B : C) {J : Type v} (F : discrete J ⥤ over B) : cone F ⥤ cone (grow_diagram B F) :=
+{ obj := λ c,
+  { X := c.X.left,
+    π := { app := λ X, option.cases_on X c.X.hom (λ (j : J), (c.π.app j).left) } },
+  map := λ c₁ c₂ f,
+  { hom := f.hom.left,
+    w' := λ j,
+    begin
+      cases j,
+      { simp },
+      { dsimp,
+        rw ← f.w j,
+        refl }
+    end } }
+
+/-- (Impl) Pull these out to avoid timeouts. -/
+@[simps]
+def cones_equiv_functor (B : C) {J : Type v} (F : discrete J ⥤ over B) : cone (grow_diagram B F) ⥤ cone F :=
+{ obj := λ c,
+  { X := over.mk (c.π.app none),
+    π := { app := λ j, over.hom_mk (c.π.app (some j)) (by apply c.w (wide_pullback_shape.hom.term j)) } },
+  map := λ c₁ c₂ f,
+  { hom := over.hom_mk f.hom } }
+
+/-- (Impl) Establish an equivalence between the category of cones for `F` and for the "grown" `F`. -/
+@[simps]
+def cones_equiv (B : C) {J : Type v} (F : discrete J ⥤ over B) : cone (grow_diagram B F) ≌ cone F :=
+{ functor := cones_equiv_functor B F,
+  inverse := cones_equiv_inverse B F,
+  unit_iso := nat_iso.of_components (λ _, cones.ext {hom := 𝟙 _, inv := 𝟙 _} (by tidy)) (by tidy),
+  counit_iso := nat_iso.of_components (λ _, cones.ext {hom := over.hom_mk (𝟙 _), inv := over.hom_mk (𝟙 _)} (by tidy)) (by tidy) }
+
+/-- Use the above equivalence to prove we have a limit. -/
+def has_over_limit_discrete_of_grown {B : C} {J : Type v} (F : discrete J ⥤ over B) [has_limit (grow_diagram B F)] :
+  has_limit F :=
+{ cone := (cones_equiv B F).functor.obj (limit.cone (grow_diagram B F)),
+  is_limit := is_limit.mk_cone_morphism
+  (λ s, (cones_equiv B F).counit_iso.inv.app s ≫ (cones_equiv B F).functor.map (limit.cone_morphism ((cones_equiv B F).inverse.obj s)))
+  (λ s m,
+    begin
+      apply (cones_equiv B F).inverse.injectivity,
+      rw ← cancel_mono ((cones_equiv B F).unit_iso.app (limit.cone _)).inv,
+      apply is_limit.uniq_cone_morphism (limit.is_limit _),
+    end) }
+
+/-- Given a wide pullback in `C`, construct a product in `C/B`. -/
+def over_product_of_wide_pullback {J : Type v} [has_limits_of_shape.{v} (wide_pullback_shape J) C] {B : C} :
+  has_limits_of_shape.{v} (discrete J) (over B) :=
+{ has_limit := λ F, has_over_limit_discrete_of_grown F }
+
+/-- Given a pullback in `C`, construct a binary product in `C/B`. -/
+def over_binary_product_of_pullback [has_pullbacks.{v} C] {B : C} :
+  has_binary_products.{v} (over B) :=
+{ has_limits_of_shape := over_product_of_wide_pullback }
+
+/-- Given all wide pullbacks in `C`, construct products in `C/B`. -/
+def over_products_of_wide_pullbacks [has_wide_pullbacks.{v} C] {B : C} :
+  has_products.{v} (over B) :=
+{ has_limits_of_shape := λ J, over_product_of_wide_pullback }
+
+/-- Given all finite wide pullbacks in `C`, construct finite products in `C/B`. -/
+def over_finite_products_of_finite_wide_pullbacks [has_finite_wide_pullbacks.{v} C] {B : C} :
+  has_finite_products.{v} (over B) :=
+{ has_limits_of_shape := λ J 𝒥₁ 𝒥₂, by exactI over_product_of_wide_pullback }
+
+end construct_products
 
 /-- Construct terminal object in the over category. -/
 instance (B : C) : has_terminal.{v} (over B) :=
@@ -200,27 +246,27 @@ example {B : C} [has_pullbacks.{v} C] : has_pullbacks.{v} (over B) :=
 example {B : C} [has_equalizers.{v} C] : has_equalizers.{v} (over B) :=
 { has_limits_of_shape := infer_instance }
 
-/-- Given pullbacks in C, we have binary products in any over category -/
-instance over_has_prods_of_pullback [has_pullbacks.{v} C] (B : C) :
-  has_binary_products.{v} (over B) :=
-{has_limits_of_shape := {has_limit := λ F, over_product_of_pullbacks B F}}
+instance has_finite_limits {B : C} [has_finite_wide_pullbacks.{v} C] : has_finite_limits.{v} (over B) :=
+begin
+  apply @finite_limits_from_equalizers_and_finite_products _ _ _ _,
+  { exact construct_products.over_finite_products_of_finite_wide_pullbacks },
+  { apply @has_equalizers_of_pullbacks_and_binary_products _ _ _ _,
+    { haveI: has_pullbacks.{v} C := ⟨infer_instance⟩,
+      exact construct_products.over_binary_product_of_pullback },
+    { split,
+      apply_instance} }
+end
 
-/-! A collection of lemmas to decompose products in the over category -/
-@[simp] lemma over_prod_pair_left [has_pullbacks.{v} C] {B : C} (f g : over B) :
-  (f ⨯ g).left = pullback f.hom g.hom := rfl
-
-@[simp] lemma over_prod_pair_hom [has_pullbacks.{v} C] {B : C} (f g : over B) :
-  (f ⨯ g).hom = pullback.fst ≫ f.hom := rfl
-
-@[simp] lemma over_prod_fst_left [has_pullbacks.{v} C] {B : C} (f g : over B) :
-  (limits.prod.fst : f ⨯ g ⟶ f).left = pullback.fst := rfl
-
-@[simp] lemma over_prod_snd_left [has_pullbacks.{v} C] {B : C} (f g : over B) :
-  (limits.prod.snd : f ⨯ g ⟶ g).left = pullback.snd := rfl
-
-lemma over_prod_map_left [has_pullbacks.{v} C] {B : C} (f g h k : over B) (α : f ⟶ g) (β : h ⟶ k) :
-  (limits.prod.map α β).left = pullback.lift (pullback.fst ≫ α.left) (pullback.snd ≫ β.left) (by { simp only [category.assoc], convert pullback.condition; apply over.w }) :=
-rfl
+instance has_limits {B : C} [has_wide_pullbacks.{v} C] : has_limits.{v} (over B) :=
+begin
+  apply @limits_from_equalizers_and_products _ _ _ _,
+  { exact construct_products.over_products_of_wide_pullbacks },
+  { apply @has_equalizers_of_pullbacks_and_binary_products _ _ _ _,
+    { haveI: has_pullbacks.{v} C := ⟨infer_instance⟩,
+      exact construct_products.over_binary_product_of_pullback },
+    { split,
+      apply_instance } }
+end
 
 end category_theory.over
 

--- a/src/category_theory/limits/over.lean
+++ b/src/category_theory/limits/over.lean
@@ -14,7 +14,7 @@ import category_theory.limits.shapes.binary_products
 import category_theory.limits.shapes.constructions.limits_of_products_and_equalizers
 import category_theory.limits.shapes.constructions.equalizers
 
-universes v u -- declare the `v`'s first; see `category_theory.category` for an explanation
+universes v u u' -- declare the `v`'s first; see `category_theory.category` for an explanation
 
 open category_theory category_theory.limits
 
@@ -129,6 +129,7 @@ def cones_equiv_functor (B : C) {J : Type v} (F : discrete J ⥤ over B) :
   map := λ c₁ c₂ f,
   { hom := over.hom_mk f.hom } }
 
+-- TODO: Can we add `. obviously` to the second arguments of `nat_iso.of_components` and `cones.ext`?
 /-- (Impl) Establish an equivalence between the category of cones for `F` and for the "grown" `F`. -/
 @[simps]
 def cones_equiv (B : C) {J : Type v} (F : discrete J ⥤ over B) :

--- a/src/category_theory/limits/over.lean
+++ b/src/category_theory/limits/over.lean
@@ -94,16 +94,17 @@ instance forget_preserves_colimits [has_colimits.{v} C] {X : C} :
 
 namespace construct_products
 
-/-- (Impl) Given a product shape in `C/B`, construct the corresponding wide pullback shape in `C`. -/
+/-- (Impl) Given a product shape in `C/B`, construct the corresponding wide pullback diagram in `C`. -/
 @[reducible]
-def grow_diagram (B : C) {J : Type v} (F : discrete J ⥤ over B) : wide_pullback_shape J ⥤ C :=
+def wide_pullback_diagram_of_diagram_over (B : C) {J : Type v} (F : discrete J ⥤ over B) : wide_pullback_shape J ⥤ C :=
 wide_pullback_shape.wide_cospan B (λ j, (F.obj j).left) (λ j, (F.obj j).hom)
 
 local attribute [tidy] tactic.case_bash
 
 /-- (Impl) Pull these out to avoid timeouts. -/
 @[simps]
-def cones_equiv_inverse (B : C) {J : Type v} (F : discrete J ⥤ over B) : cone F ⥤ cone (grow_diagram B F) :=
+def cones_equiv_inverse (B : C) {J : Type v} (F : discrete J ⥤ over B) :
+  cone F ⥤ cone (wide_pullback_diagram_of_diagram_over B F) :=
 { obj := λ c,
   { X := c.X.left,
     π := { app := λ X, option.cases_on X c.X.hom (λ (j : J), (c.π.app j).left) } },
@@ -120,7 +121,8 @@ def cones_equiv_inverse (B : C) {J : Type v} (F : discrete J ⥤ over B) : cone 
 
 /-- (Impl) Pull these out to avoid timeouts. -/
 @[simps]
-def cones_equiv_functor (B : C) {J : Type v} (F : discrete J ⥤ over B) : cone (grow_diagram B F) ⥤ cone F :=
+def cones_equiv_functor (B : C) {J : Type v} (F : discrete J ⥤ over B) :
+  cone (wide_pullback_diagram_of_diagram_over B F) ⥤ cone F :=
 { obj := λ c,
   { X := over.mk (c.π.app none),
     π := { app := λ j, over.hom_mk (c.π.app (some j)) (by apply c.w (wide_pullback_shape.hom.term j)) } },
@@ -129,21 +131,24 @@ def cones_equiv_functor (B : C) {J : Type v} (F : discrete J ⥤ over B) : cone 
 
 /-- (Impl) Establish an equivalence between the category of cones for `F` and for the "grown" `F`. -/
 @[simps]
-def cones_equiv (B : C) {J : Type v} (F : discrete J ⥤ over B) : cone (grow_diagram B F) ≌ cone F :=
+def cones_equiv (B : C) {J : Type v} (F : discrete J ⥤ over B) :
+  cone (wide_pullback_diagram_of_diagram_over B F) ≌ cone F :=
 { functor := cones_equiv_functor B F,
   inverse := cones_equiv_inverse B F,
   unit_iso := nat_iso.of_components (λ _, cones.ext {hom := 𝟙 _, inv := 𝟙 _} (by tidy)) (by tidy),
   counit_iso := nat_iso.of_components (λ _, cones.ext {hom := over.hom_mk (𝟙 _), inv := over.hom_mk (𝟙 _)} (by tidy)) (by tidy) }
 
 /-- Use the above equivalence to prove we have a limit. -/
-def has_over_limit_discrete_of_grown {B : C} {J : Type v} (F : discrete J ⥤ over B) [has_limit (grow_diagram B F)] :
+def has_over_limit_discrete_of_wide_pullback_limit {B : C} {J : Type v} (F : discrete J ⥤ over B)
+  [has_limit (wide_pullback_diagram_of_diagram_over B F)] :
   has_limit F :=
-{ cone := _, is_limit := is_limit.of_cone_equiv (cones_equiv B F).symm (limit.is_limit (grow_diagram B F)) }
+{ cone := _,
+  is_limit := is_limit.of_cone_equiv (cones_equiv B F).symm (limit.is_limit (wide_pullback_diagram_of_diagram_over B F)) }
 
 /-- Given a wide pullback in `C`, construct a product in `C/B`. -/
 def over_product_of_wide_pullback {J : Type v} [has_limits_of_shape.{v} (wide_pullback_shape J) C] {B : C} :
   has_limits_of_shape.{v} (discrete J) (over B) :=
-{ has_limit := λ F, has_over_limit_discrete_of_grown F }
+{ has_limit := λ F, has_over_limit_discrete_of_wide_pullback_limit F }
 
 /-- Given a pullback in `C`, construct a binary product in `C/B`. -/
 def over_binary_product_of_pullback [has_pullbacks.{v} C] {B : C} :

--- a/src/category_theory/limits/over.lean
+++ b/src/category_theory/limits/over.lean
@@ -138,15 +138,7 @@ def cones_equiv (B : C) {J : Type v} (F : discrete J ⥤ over B) : cone (grow_di
 /-- Use the above equivalence to prove we have a limit. -/
 def has_over_limit_discrete_of_grown {B : C} {J : Type v} (F : discrete J ⥤ over B) [has_limit (grow_diagram B F)] :
   has_limit F :=
-{ cone := (cones_equiv B F).functor.obj (limit.cone (grow_diagram B F)),
-  is_limit := is_limit.mk_cone_morphism
-  (λ s, (cones_equiv B F).counit_iso.inv.app s ≫ (cones_equiv B F).functor.map (limit.cone_morphism ((cones_equiv B F).inverse.obj s)))
-  (λ s m,
-    begin
-      apply (cones_equiv B F).inverse.injectivity,
-      rw ← cancel_mono ((cones_equiv B F).unit_iso.app (limit.cone _)).inv,
-      apply is_limit.uniq_cone_morphism (limit.is_limit _),
-    end) }
+{ cone := _, is_limit := is_limit.of_cone_equiv (cones_equiv B F).symm (limit.is_limit (grow_diagram B F)) }
 
 /-- Given a wide pullback in `C`, construct a product in `C/B`. -/
 def over_product_of_wide_pullback {J : Type v} [has_limits_of_shape.{v} (wide_pullback_shape J) C] {B : C} :

--- a/src/category_theory/limits/shapes/pullbacks.lean
+++ b/src/category_theory/limits/shapes/pullbacks.lean
@@ -31,7 +31,10 @@ universes v u
 
 local attribute [tidy] tactic.case_bash
 
-/-- The type of objects for the diagram indexing a pullback. -/
+/--
+The type of objects for the diagram indexing a pullback, defined as a special case of
+`wide_pullback_shape`.
+-/
 abbreviation walking_cospan : Type v := wide_pullback_shape walking_pair
 
 /-- The left point of the walking cospan. -/

--- a/src/category_theory/limits/shapes/pullbacks.lean
+++ b/src/category_theory/limits/shapes/pullbacks.lean
@@ -34,8 +34,11 @@ local attribute [tidy] tactic.case_bash
 /-- The type of objects for the diagram indexing a pullback. -/
 abbreviation walking_cospan : Type v := wide_pullback_shape walking_pair
 
+/-- The left point of the walking cospan. -/
 abbreviation walking_cospan.left : walking_cospan := some walking_pair.left
+/-- The right point of the walking cospan. -/
 abbreviation walking_cospan.right : walking_cospan := some walking_pair.right
+/-- The central point of the walking cospan. -/
 abbreviation walking_cospan.one : walking_cospan := none
 
 /-- The type of objects for the diagram indexing a pushout. -/
@@ -51,8 +54,11 @@ namespace walking_cospan
 /-- The type of arrows for the diagram indexing a pullback. -/
 abbreviation hom : walking_cospan → walking_cospan → Type v := wide_pullback_shape.hom
 
+/-- The left arrow of the walking cospan. -/
 abbreviation hom.inl : left ⟶ one := wide_pullback_shape.hom.term _
+/-- The right arrow of the walking cospan. -/
 abbreviation hom.inr : right ⟶ one := wide_pullback_shape.hom.term _
+/-- The identity arrows of the walking cospan. -/
 abbreviation hom.id (X : walking_cospan) : X ⟶ X := wide_pullback_shape.hom.id X
 
 instance (X Y : walking_cospan) : subsingleton (X ⟶ Y) := by tidy
@@ -320,10 +326,6 @@ def cone.of_pullback_cone
 { X := t.X,
   π := t.π ≫ (diagram_iso_cospan F).inv }
 
-@[simp] lemma cone.of_pullback_cone_π_app
-  {F : walking_cospan.{v} ⥤ C} (t : pullback_cone (F.map inl) (F.map inr)) (j) :
-(cone.of_pullback_cone t).π.app j = t.π.app j ≫ eq_to_hom (by tidy) := rfl
-
 /-- This is a helper construction that can be useful when verifying that a category has all
     pushout. Given `F : walking_span ⥤ C`, which is really the same as
     `span (F.map fst) (F.mal snd)`, and a pushout cocone on `F.map fst` and `F.map snd`,
@@ -354,9 +356,6 @@ def pullback_cone.of_cone
   {F : walking_cospan.{v} ⥤ C} (t : cone F) : pullback_cone (F.map inl) (F.map inr) :=
 { X := t.X,
   π := t.π ≫ (diagram_iso_cospan F).hom }
-
-@[simp] lemma pullback_cone.of_cone_π_app {F : walking_cospan.{v} ⥤ C} (t : cone F) (j) :
-  (pullback_cone.of_cone t).π.app j = t.π.app j ≫ eq_to_hom (by tidy) := rfl
 
 /-- Given `F : walking_span ⥤ C`, which is really the same as `span (F.map fst) (F.map snd)`,
     and a cocone on `F`, we get a pushout cocone on `F.map fst` and `F.map snd`. -/

--- a/src/category_theory/limits/shapes/pullbacks.lean
+++ b/src/category_theory/limits/shapes/pullbacks.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2018 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Scott Morrison
+Authors: Scott Morrison, Markus Himmel, Bhavik Mehta
 -/
 import data.fintype.basic
 import category_theory.limits.limits
@@ -44,13 +44,18 @@ abbreviation walking_cospan.right : walking_cospan := some walking_pair.right
 /-- The central point of the walking cospan. -/
 abbreviation walking_cospan.one : walking_cospan := none
 
-/-- The type of objects for the diagram indexing a pushout. -/
-@[derive decidable_eq, derive inhabited] inductive walking_span : Type v
-| zero | left | right
+/--
+The type of objects for the diagram indexing a pushout, defined as a special case of
+`wide_pushout_shape`.
+-/
+abbreviation walking_span : Type v := wide_pushout_shape walking_pair
 
-instance fintype_walking_span : fintype walking_span :=
-{ elems := [walking_span.zero, walking_span.left, walking_span.right].to_finset,
-  complete := λ x, by { cases x; simp } }
+/-- The left point of the walking span. -/
+abbreviation walking_span.left : walking_span := some walking_pair.left
+/-- The right point of the walking span. -/
+abbreviation walking_span.right : walking_span := some walking_pair.right
+/-- The central point of the walking span. -/
+abbreviation walking_span.zero : walking_span := none
 
 namespace walking_cospan
 
@@ -70,51 +75,21 @@ end walking_cospan
 
 namespace walking_span
 
-/-- The arrows in a pushout diagram. -/
-@[derive decidable_eq] inductive hom : walking_span → walking_span → Type v
-| fst : hom zero left
-| snd : hom zero right
-| id : Π X : walking_span.{v}, hom X X
+/-- The type of arrows for the diagram indexing a pushout. -/
+abbreviation hom : walking_span → walking_span → Type v := wide_pushout_shape.hom
 
-instance hom.inhabited : inhabited (hom zero left) :=
-{ default := hom.fst }
-
-open hom
-
-instance fintype_walking_span_hom (j j' : walking_span) : fintype (hom j j') :=
-{ elems := walking_span.rec_on j
-    (walking_span.rec_on j' [hom.id zero].to_finset [fst].to_finset [snd].to_finset)
-    (walking_span.rec_on j' ∅ [hom.id left].to_finset ∅)
-    (walking_span.rec_on j' ∅ ∅ [hom.id right].to_finset),
-  complete := by tidy }
-
-/-- Composition of morphisms in the category indexing a pushout. -/
-def hom.comp : Π (X Y Z : walking_span) (f : hom X Y) (g : hom Y Z), hom X Z
-  | _ _ _ (id _) h := h
-  | _ _ _ fst    (id left) := fst
-  | _ _ _ snd    (id right) := snd
-.
-
-instance category_struct : category_struct walking_span :=
-{ hom  := hom,
-  id   := hom.id,
-  comp := hom.comp }
+/-- The left arrow of the walking span. -/
+abbreviation hom.fst : zero ⟶ left := wide_pushout_shape.hom.init _
+/-- The right arrow of the walking span. -/
+abbreviation hom.snd : zero ⟶ right := wide_pushout_shape.hom.init _
+/-- The identity arrows of the walking span. -/
+abbreviation hom.id (X : walking_span) : X ⟶ X := wide_pushout_shape.hom.id X
 
 instance (X Y : walking_span) : subsingleton (X ⟶ Y) := by tidy
 
--- We make this a @[simp] lemma later; if we do it now there's a mysterious
--- failure in `span`, below.
-lemma hom_id (X : walking_span.{v}) : hom.id X = 𝟙 X := rfl
-
-/-- The walking_span is the index diagram for a pushout. -/
-instance : small_category.{v} walking_span.{v} := sparse_category
-
-instance : fin_category.{v} walking_span.{v} :=
-{ fintype_hom := walking_span.fintype_walking_span_hom }
-
 end walking_span
 
-open walking_span walking_cospan walking_span.hom wide_pullback_shape.hom walking_cospan.hom
+open walking_span.hom walking_cospan.hom wide_pullback_shape.hom wide_pushout_shape.hom
 
 variables {C : Type u} [𝒞 : category.{v} C]
 include 𝒞
@@ -125,16 +100,7 @@ wide_pullback_shape.wide_cospan Z (λ j, walking_pair.cases_on j X Y) (λ j, wal
 
 /-- `span f g` is the functor from the walking span hitting `f` and `g`. -/
 def span {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) : walking_span.{v} ⥤ C :=
-{ obj := λ x, match x with
-  | zero := X
-  | left := Y
-  | right := Z
-  end,
-  map := λ x y h, match x, y, h with
-  | _, _, (id _) := 𝟙 _
-  | _, _, fst := f
-  | _, _, snd := g
-  end }
+wide_pushout_shape.wide_span X (λ j, walking_pair.cases_on j Y Z) (λ j, walking_pair.cases_on j f g)
 
 @[simp] lemma cospan_left {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) :
   (cospan f g).obj walking_cospan.left = X := rfl
@@ -178,8 +144,6 @@ nat_iso.of_components (λ j, eq_to_iso (by tidy)) (by tidy)
 
 variables {X Y Z : C}
 
-attribute [simp] walking_span.hom_id
-
 /-- A pullback cone is just a cone on the cospan formed by two morphisms `f : X ⟶ Z` and
     `g : Y ⟶ Z`.-/
 abbreviation pullback_cone (f : X ⟶ Z) (g : Y ⟶ Z) := cone (cospan f g)
@@ -188,23 +152,24 @@ namespace pullback_cone
 variables {f : X ⟶ Z} {g : Y ⟶ Z}
 
 /-- The first projection of a pullback cone. -/
-abbreviation fst (t : pullback_cone f g) : t.X ⟶ X := t.π.app left
+abbreviation fst (t : pullback_cone f g) : t.X ⟶ X := t.π.app walking_cospan.left
 
 /-- The second projection of a pullback cone. -/
-abbreviation snd (t : pullback_cone f g) : t.X ⟶ Y := t.π.app right
+abbreviation snd (t : pullback_cone f g) : t.X ⟶ Y := t.π.app walking_cospan.right
 
 /-- A pullback cone on `f` and `g` is determined by morphisms `fst : W ⟶ X` and `snd : W ⟶ Y`
     such that `fst ≫ f = snd ≫ g`. -/
+@[simps]
 def mk {W : C} (fst : W ⟶ X) (snd : W ⟶ Y) (eq : fst ≫ f = snd ≫ g) : pullback_cone f g :=
 { X := W,
   π := { app := λ j, option.cases_on j (fst ≫ f) (λ j', walking_pair.cases_on j' fst snd) } }
 
 @[simp] lemma mk_π_app_left {W : C} (fst : W ⟶ X) (snd : W ⟶ Y) (eq : fst ≫ f = snd ≫ g) :
-  (mk fst snd eq).π.app left = fst := rfl
+  (mk fst snd eq).π.app walking_cospan.left = fst := rfl
 @[simp] lemma mk_π_app_right {W : C} (fst : W ⟶ X) (snd : W ⟶ Y) (eq : fst ≫ f = snd ≫ g) :
-  (mk fst snd eq).π.app right = snd := rfl
+  (mk fst snd eq).π.app walking_cospan.right = snd := rfl
 @[simp] lemma mk_π_app_one {W : C} (fst : W ⟶ X) (snd : W ⟶ Y) (eq : fst ≫ f = snd ≫ g) :
-  (mk fst snd eq).π.app one = fst ≫ f := rfl
+  (mk fst snd eq).π.app walking_cospan.one = fst ≫ f := rfl
 
 @[reassoc] lemma condition (t : pullback_cone f g) : fst t ≫ f = snd t ≫ g :=
 (t.w inl).trans (t.w inr).symm
@@ -232,14 +197,14 @@ def is_limit.lift' {t : pullback_cone f g} (ht : is_limit t) {W : C} (h : W ⟶ 
 /-- This is a slightly more convenient method to verify that a pullback cone is a limit cone. It
     only asks for a proof of facts that carry any mathematical content -/
 def is_limit.mk (t : pullback_cone f g) (lift : Π (s : cone (cospan f g)), s.X ⟶ t.X)
-  (fac_left : ∀ (s : cone (cospan f g)), lift s ≫ t.π.app left = s.π.app left)
-  (fac_right : ∀ (s : cone (cospan f g)), lift s ≫ t.π.app right = s.π.app right)
+  (fac_left : ∀ (s : cone (cospan f g)), lift s ≫ t.π.app walking_cospan.left = s.π.app walking_cospan.left)
+  (fac_right : ∀ (s : cone (cospan f g)), lift s ≫ t.π.app walking_cospan.right = s.π.app walking_cospan.right)
   (uniq : ∀ (s : cone (cospan f g)) (m : s.X ⟶ t.X)
     (w : ∀ j : walking_cospan, m ≫ t.π.app j = s.π.app j), m = lift s) :
   is_limit t :=
 { lift := lift,
   fac' := λ s j, option.cases_on j
-    (by rw [←t.w inl, ←s.w inl, ←fac_left s, category.assoc])
+    (by { simp [← s.w inl, ← t.w inl, ← fac_left s] } )
     (λ j', walking_pair.cases_on j' (fac_left s) (fac_right s)),
   uniq' := uniq }
 
@@ -254,41 +219,36 @@ namespace pushout_cocone
 variables {f : X ⟶ Y} {g : X ⟶ Z}
 
 /-- The first inclusion of a pushout cocone. -/
-abbreviation inl (t : pushout_cocone f g) : Y ⟶ t.X := t.ι.app left
+abbreviation inl (t : pushout_cocone f g) : Y ⟶ t.X := t.ι.app walking_span.left
 
 /-- The second inclusion of a pushout cocone. -/
-abbreviation inr (t : pushout_cocone f g) : Z ⟶ t.X := t.ι.app right
+abbreviation inr (t : pushout_cocone f g) : Z ⟶ t.X := t.ι.app walking_span.right
 
 /-- A pushout cocone on `f` and `g` is determined by morphisms `inl : Y ⟶ W` and `inr : Z ⟶ W` such
     that `f ≫ inl = g ↠ inr`. -/
+@[simps]
 def mk {W : C} (inl : Y ⟶ W) (inr : Z ⟶ W) (eq : f ≫ inl = g ≫ inr) : pushout_cocone f g :=
 { X := W,
-  ι :=
-  { app := λ j, walking_span.cases_on j (f ≫ inl) inl inr,
-    naturality' := λ j j' f, by { cases f; obviously } } }
+  ι := { app := λ j, option.cases_on j (f ≫ inl) (λ j', walking_pair.cases_on j' inl inr) } }
 
 @[simp] lemma mk_ι_app_left {W : C} (inl : Y ⟶ W) (inr : Z ⟶ W) (eq : f ≫ inl = g ≫ inr) :
-  (mk inl inr eq).ι.app left = inl := rfl
+  (mk inl inr eq).ι.app walking_span.left = inl := rfl
 @[simp] lemma mk_ι_app_right {W : C} (inl : Y ⟶ W) (inr : Z ⟶ W) (eq : f ≫ inl = g ≫ inr) :
-  (mk inl inr eq).ι.app right = inr := rfl
+  (mk inl inr eq).ι.app walking_span.right = inr := rfl
 @[simp] lemma mk_ι_app_zero {W : C} (inl : Y ⟶ W) (inr : Z ⟶ W) (eq : f ≫ inl = g ≫ inr) :
-  (mk inl inr eq).ι.app zero = f ≫ inl := rfl
+  (mk inl inr eq).ι.app walking_span.zero = f ≫ inl := rfl
 
 @[reassoc] lemma condition (t : pushout_cocone f g) : f ≫ (inl t) = g ≫ (inr t) :=
-begin
-  erw [t.w fst, ← t.w snd], refl
-end
+(t.w fst).trans (t.w snd).symm
 
 /-- To check whether a morphism is coequalized by the maps of a pushout cocone, it suffices to check
   it for `inl t` and `inr t` -/
 lemma coequalizer_ext (t : pushout_cocone f g) {W : C} {k l : t.X ⟶ W}
   (h₀ : inl t ≫ k = inl t ≫ l) (h₁ : inr t ≫ k = inr t ≫ l) :
   ∀ (j : walking_span), t.ι.app j ≫ k = t.ι.app j ≫ l
-| left := h₀
-| right := h₁
-| zero := calc t.ι.app zero ≫ k = ((span f g).map fst ≫ t.ι.app left) ≫ k : by rw ←t.w
-    ... = ((span f g).map fst ≫ t.ι.app left) ≫ l : by rw [category.assoc, h₀, ←category.assoc]
-    ... = t.ι.app zero ≫ l : by rw t.w
+| (some walking_pair.left) := h₀
+| (some walking_pair.right) := h₁
+| none := by rw [← t.w fst, category.assoc, category.assoc, h₀]
 
 lemma is_colimit.hom_ext {t : pushout_cocone f g} (ht : is_colimit t) {W : C} {k l : t.X ⟶ W}
   (h₀ : inl t ≫ k = inl t ≫ l) (h₁ : inr t ≫ k = inr t ≫ l) : k = l :=
@@ -304,14 +264,14 @@ def is_colimit.desc' {t : pushout_cocone f g} (ht : is_colimit t) {W : C} (h : Y
 /-- This is a slightly more convenient method to verify that a pushout cocone is a colimit cocone.
     It only asks for a proof of facts that carry any mathematical content -/
 def is_colimit.mk (t : pushout_cocone f g) (desc : Π (s : cocone (span f g)), t.X ⟶ s.X)
-  (fac_left : ∀ (s : cocone (span f g)), t.ι.app left ≫ desc s = s.ι.app left)
-  (fac_right : ∀ (s : cocone (span f g)), t.ι.app right ≫ desc s = s.ι.app right)
+  (fac_left : ∀ (s : cocone (span f g)), t.ι.app walking_span.left ≫ desc s = s.ι.app walking_span.left)
+  (fac_right : ∀ (s : cocone (span f g)), t.ι.app walking_span.right ≫ desc s = s.ι.app walking_span.right)
   (uniq : ∀ (s : cocone (span f g)) (m : t.X ⟶ s.X)
     (w : ∀ j : walking_span, t.ι.app j ≫ m = s.ι.app j), m = desc s) :
   is_colimit t :=
 { desc := desc,
-  fac' := λ s j, walking_span.cases_on j (by rw [←s.w fst, ←t.w fst, category.assoc, fac_left s])
-    (fac_left s) (fac_right s),
+  fac' := λ s j, option.cases_on j (by { simp [← s.w fst, ← t.w fst, fac_left s] } )
+                    (λ j', walking_pair.cases_on j' (fac_left s) (fac_right s)),
   uniq' := uniq }
 
 end pushout_cocone
@@ -336,21 +296,11 @@ def cone.of_pullback_cone
 
     If you're thinking about using this, have a look at `has_pushouts_of_has_colimit_span`, which
     you may find to be an easiery way of achieving your goal.  -/
+@[simps]
 def cocone.of_pushout_cocone
   {F : walking_span.{v} ⥤ C} (t : pushout_cocone (F.map fst) (F.map snd)) : cocone F :=
 { X := t.X,
-  ι :=
-  { app := λ X, eq_to_hom (by tidy) ≫ t.ι.app X,
-    naturality' := λ j j' g,
-    begin
-      cases j; cases j'; cases g; dsimp; simp,
-      exact t.w fst,
-      exact t.w snd
-    end } }.
-
-@[simp] lemma cocone.of_pushout_cocone_ι
-  {F : walking_span.{v} ⥤ C} (t : pushout_cocone (F.map fst) (F.map snd)) (j) :
-  (cocone.of_pushout_cocone t).ι.app j = eq_to_hom (by tidy) ≫ t.ι.app j := rfl
+  ι := (diagram_iso_span F).hom ≫ t.ι }
 
 /-- Given `F : walking_cospan ⥤ C`, which is really the same as `cospan (F.map inl) (F.map inr)`,
     and a cone on `F`, we get a pullback cone on `F.map inl` and `F.map inr`. -/
@@ -362,13 +312,11 @@ def pullback_cone.of_cone
 
 /-- Given `F : walking_span ⥤ C`, which is really the same as `span (F.map fst) (F.map snd)`,
     and a cocone on `F`, we get a pushout cocone on `F.map fst` and `F.map snd`. -/
+@[simps]
 def pushout_cocone.of_cocone
   {F : walking_span.{v} ⥤ C} (t : cocone F) : pushout_cocone (F.map fst) (F.map snd) :=
 { X := t.X,
-  ι := { app := λ j, eq_to_hom (by tidy) ≫ t.ι.app j } }
-
-@[simp] lemma pushout_cocone.of_cocone_ι {F : walking_span.{v} ⥤ C} (t : cocone F) (j) :
-  (pushout_cocone.of_cocone t).ι.app j = eq_to_hom (by tidy) ≫ t.ι.app j := rfl
+  ι := (diagram_iso_span F).inv ≫ t.ι }
 
 /-- `pullback f g` computes the pullback of a pair of morphisms with the same target. -/
 abbreviation pullback {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) [has_limit (cospan f g)] :=
@@ -443,10 +391,12 @@ def pullback.desc' {W X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} [has_colimit (span 
   {l : pushout f g ⟶ W // pushout.inl ≫ l = h ∧ pushout.inr ≫ l = k} :=
 ⟨pushout.desc h k w, pushout.inl_desc _ _ _, pushout.inr_desc _ _ _⟩
 
+@[reassoc]
 lemma pullback.condition {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} [has_limit (cospan f g)] :
   (pullback.fst : pullback f g ⟶ X) ≫ f = pullback.snd ≫ g :=
 pullback_cone.condition _
 
+@[reassoc]
 lemma pushout.condition {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} [has_colimit (span f g)] :
   f ≫ (pushout.inl : Y ⟶ pushout f g) = g ≫ pushout.inr :=
 pushout_cocone.condition _
@@ -478,18 +428,12 @@ colimit.hom_ext $ pushout_cocone.coequalizer_ext _ h₀ h₁
 /-- The pushout of an epimorphism is an epimorphism -/
 instance pushout.inl_of_epi {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} [has_colimit (span f g)] [epi g] :
   epi (pushout.inl : Y ⟶ pushout f g) :=
-⟨λ W u v h, pushout.hom_ext h $ (cancel_epi g).1 $
-  calc g ≫ pushout.inr ≫ u = (f ≫ pushout.inl) ≫ u : by rw [←category.assoc, ←pushout.condition]
-    ... = f ≫ pushout.inl ≫ v : by rw [category.assoc, h]
-    ... = g ≫ pushout.inr ≫ v : by rw [←category.assoc, pushout.condition, category.assoc]⟩
+⟨λ W u v h, pushout.hom_ext h $ (cancel_epi g).1 $ by simp [← pushout.condition_assoc, h] ⟩
 
 /-- The pushout of an epimorphism is an epimorphism -/
 instance pushout.inr_of_epi {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} [has_colimit (span f g)] [epi f] :
   epi (pushout.inr : Z ⟶ pushout f g) :=
-⟨λ W u v h, pushout.hom_ext ((cancel_epi f).1 $
-  calc f ≫ pushout.inl ≫ u = (g ≫ pushout.inr) ≫ u : by rw [←category.assoc, pushout.condition]
-    ... = g ≫ pushout.inr ≫ v : by rw [category.assoc, h]
-    ... = f ≫ pushout.inl ≫ v : by rw [←category.assoc, ←pushout.condition, category.assoc]) h⟩
+⟨λ W u v h, pushout.hom_ext ((cancel_epi f).1 $ by simp [pushout.condition_assoc, h]) h⟩
 
 variables (C)
 

--- a/src/category_theory/limits/shapes/wide_pullbacks.lean
+++ b/src/category_theory/limits/shapes/wide_pullbacks.lean
@@ -7,8 +7,6 @@ import data.fintype.basic
 import category_theory.limits.limits
 import category_theory.limits.shapes.finite_limits
 import category_theory.sparse
-import category_theory.punit
--- import category_theory.connected
 
 universes v u
 

--- a/src/category_theory/limits/shapes/wide_pullbacks.lean
+++ b/src/category_theory/limits/shapes/wide_pullbacks.lean
@@ -11,13 +11,14 @@ import category_theory.sparse
 /-!
 # Wide pullbacks
 
-We define the category `wide_pullback_shape`, which is the category obtained from a discrete
-category of type `J` by adjoining a terminal element. Limits of this shape are wide pullbacks.
-The convenience method `wide_cospan` constructs a functor from this category, hitting the given
-morphisms.
+We define the category `wide_pullback_shape`, (resp. `wide_pushout_shape`) which is the category
+obtained from a discrete category of type `J` by adjoining a terminal (resp. initial) element.
+Limits of this shape are wide pullbacks (pushouts).
+The convenience method `wide_cospan` (`wide_span`) constructs a functor from this category, hitting
+the given morphisms.
 
-We use `wide_pullback_shape` to define ordinary (binary) pullbacks by using `J := walking_pair`,
-which allows easy proofs of some pullback lemmas.
+We use `wide_pullback_shape` to define ordinary pullbacks (pushouts) by using `J := walking_pair`,
+which allows easy proofs of some related lemmas.
 Furthermore, wide pullbacks are used to show the existence of limits in the slice category.
 Namely, if `C` has wide pullbacks then `C/B` has limits for any object `B` in `C`.
 
@@ -35,9 +36,11 @@ variable (J : Type v)
 @[derive inhabited]
 def wide_pullback_shape := option J
 
-namespace wide_pullback_shape
+/-- A wide pushout shape for any type `J` can be written simply as `option J`. -/
+@[derive inhabited]
+def wide_pushout_shape := option J
 
-local attribute [tidy] tactic.case_bash
+namespace wide_pullback_shape
 
 instance fintype_obj [fintype J] : fintype (wide_pullback_shape J) :=
 by { rw wide_pullback_shape, apply_instance }
@@ -62,6 +65,8 @@ instance struct : category_struct (wide_pullback_shape J) :=
   end }
 
 instance : inhabited (hom none none) := ⟨hom.id (none : wide_pullback_shape J)⟩
+
+local attribute [tidy] tactic.case_bash
 
 instance fintype_hom [decidable_eq J] (j j' : wide_pullback_shape J) :
   fintype (j ⟶ j') :=
@@ -91,8 +96,6 @@ instance fin_category [fintype J] [decidable_eq J] : fin_category (wide_pullback
 variables {C : Type u} [𝒞 : category.{v} C]
 include 𝒞
 
-local attribute [tidy] tactic.case_bash
-
 /--
 Construct a functor out of the wide pullback shape given a J-indexed collection of arrows to a
 fixed object.
@@ -114,6 +117,83 @@ nat_iso.of_components (λ j, eq_to_iso $ by tidy) $ by tidy
 
 end wide_pullback_shape
 
+namespace wide_pushout_shape
+
+instance fintype_obj [fintype J] : fintype (wide_pushout_shape J) :=
+by { rw wide_pushout_shape, apply_instance }
+
+variable {J}
+
+/-- The type of arrows for the shape indexing a wide psuhout. -/
+@[derive decidable_eq]
+inductive hom : wide_pushout_shape J → wide_pushout_shape J → Type v
+| id : Π X, hom X X
+| init : Π (j : J), hom none (some j)
+
+instance struct : category_struct (wide_pushout_shape J) :=
+{ hom := hom,
+  id := λ j, hom.id j,
+  comp := λ j₁ j₂ j₃ f g,
+  begin
+    cases f,
+      exact g,
+    cases g,
+    apply hom.init _
+  end }
+
+instance : inhabited (hom none none) := ⟨hom.id (none : wide_pushout_shape J)⟩
+
+local attribute [tidy] tactic.case_bash
+
+instance fintype_hom [decidable_eq J] (j j' : wide_pushout_shape J) :
+  fintype (j ⟶ j') :=
+{ elems :=
+  begin
+    cases j,
+    { cases j',
+      { exact {hom.id none} },
+      { exact {hom.init j'} } },
+    { by_cases some j = j',
+      { rw h,
+        exact {hom.id j'} },
+      { exact ∅ } }
+  end,
+  complete := by tidy }
+
+instance subsingleton_hom (j j' : wide_pushout_shape J) : subsingleton (j ⟶ j') :=
+⟨by tidy⟩
+
+instance category : small_category (wide_pushout_shape J) := sparse_category
+
+instance fin_category [fintype J] [decidable_eq J] : fin_category (wide_pushout_shape J) :=
+{ fintype_hom := wide_pushout_shape.fintype_hom }
+
+@[simp] lemma hom_id (X : wide_pushout_shape J) : hom.id X = 𝟙 X := rfl
+
+variables {C : Type u} [𝒞 : category.{v} C]
+include 𝒞
+
+/--
+Construct a functor out of the wide pushout shape given a J-indexed collection of arrows from a
+fixed object.
+-/
+@[simps]
+def wide_span (B : C) (objs : J → C) (arrows : Π (j : J), B ⟶ objs j) : wide_pushout_shape J ⥤ C :=
+{ obj := λ j, option.cases_on j B objs,
+  map := λ X Y f,
+  begin
+    cases f with _ j,
+    { apply (𝟙 _) },
+    { exact arrows j }
+  end }
+
+/-- Every diagram is naturally isomorphic (actually, equal) to a `wide_span` -/
+def diagram_iso_wide_span (F : wide_pushout_shape J ⥤ C) :
+  F ≅ wide_span (F.obj none) (λ j, F.obj (some j)) (λ j, F.map (hom.init j)) :=
+nat_iso.of_components (λ j, eq_to_iso $ by tidy) $ by tidy
+
+end wide_pushout_shape
+
 variables (C : Type u) [𝒞 : category.{v} C]
 include 𝒞
 
@@ -131,3 +211,18 @@ def has_finite_wide_pullbacks_of_has_finite_limits [has_finite_limits.{v} C] : h
 
 attribute [instance] has_wide_pullbacks.has_limits_of_shape
 attribute [instance] has_finite_wide_pullbacks.has_limits_of_shape
+
+/-- `has_wide_pushouts` represents a choice of wide pushout for every collection of morphisms -/
+class has_wide_pushouts :=
+(has_limits_of_shape : Π (J : Type v), has_limits_of_shape.{v} (wide_pushout_shape J) C)
+
+/-- `has_wide_pushouts` represents a choice of wide pushout for every finite collection of morphisms -/
+class has_finite_wide_pushouts :=
+(has_limits_of_shape : Π (J : Type v) [decidable_eq J] [fintype J], has_limits_of_shape.{v} (wide_pushout_shape J) C)
+
+/-- Finite wide pushouts are finite limits, so if `C` has all finite limits, it also has finite wide pushouts -/
+def has_finite_wide_pushouts_of_has_finite_limits [has_finite_limits.{v} C] : has_finite_wide_pushouts.{v} C :=
+{ has_limits_of_shape := λ J _ _, by exactI (has_finite_limits.has_limits_of_shape _) }
+
+attribute [instance] has_wide_pushouts.has_limits_of_shape
+attribute [instance] has_finite_wide_pushouts.has_limits_of_shape

--- a/src/category_theory/limits/shapes/wide_pullbacks.lean
+++ b/src/category_theory/limits/shapes/wide_pullbacks.lean
@@ -8,6 +8,23 @@ import category_theory.limits.limits
 import category_theory.limits.shapes.finite_limits
 import category_theory.sparse
 
+/-!
+# Wide pullbacks
+
+We define the category `wide_pullback_shape`, which is the category obtained from a discrete
+category of type `J` by adjoining a terminal element. Limits of this shape are wide pullbacks.
+The convenience method `wide_cospan` constructs a functor from this category, hitting the given
+morphisms.
+
+We use `wide_pullback_shape` to define ordinary (binary) pullbacks by using `J := walking_pair`,
+which allows easy proofs of some pullback lemmas.
+Furthermore, wide pullbacks are used to show the existence of limits in the slice category.
+Namely, if `C` has wide pullbacks then `C/B` has limits for any object `B` in `C`.
+
+Typeclasses `has_wide_pullbacks` and `has_finite_wide_pullbacks` assert the existence of wide
+pullbacks and finite wide pullbacks.
+-/
+
 universes v u
 
 open category_theory category_theory.limits
@@ -93,7 +110,7 @@ def wide_cospan (B : C) (objs : J → C) (arrows : Π (j : J), objs j ⟶ B) : w
 /-- Every diagram is naturally isomorphic (actually, equal) to a `wide_cospan` -/
 def diagram_iso_wide_cospan (F : wide_pullback_shape J ⥤ C) :
   F ≅ wide_cospan (F.obj none) (λ j, F.obj (some j)) (λ j, F.map (hom.term j)) :=
-nat_iso.of_components (λ j, eq_to_iso $ by cases j; tidy) $ by tidy
+nat_iso.of_components (λ j, eq_to_iso $ by tidy) $ by tidy
 
 end wide_pullback_shape
 

--- a/src/category_theory/limits/shapes/wide_pullbacks.lean
+++ b/src/category_theory/limits/shapes/wide_pullbacks.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2020 Bhavik Mehta. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Bhavik Mehta
+-/
+import data.fintype.basic
+import category_theory.limits.limits
+import category_theory.limits.shapes.finite_limits
+import category_theory.sparse
+import category_theory.punit
+-- import category_theory.connected
+
+universes v u
+
+open category_theory category_theory.limits
+
+variable (J : Type v)
+
+/-- A wide pullback shape for any type `J` can be written simply as `option J`. -/
+@[derive inhabited]
+def wide_pullback_shape := option J
+
+namespace wide_pullback_shape
+
+local attribute [tidy] tactic.case_bash
+
+instance fintype_obj [fintype J] : fintype (wide_pullback_shape J) :=
+by { rw wide_pullback_shape, apply_instance }
+
+variable {J}
+
+/-- The type of arrows for the shape indexing a wide pullback. -/
+@[derive decidable_eq]
+inductive hom : wide_pullback_shape J → wide_pullback_shape J → Type v
+| id : Π X, hom X X
+| term : Π (j : J), hom (some j) none
+
+instance struct : category_struct (wide_pullback_shape J) :=
+{ hom := hom,
+  id := λ j, hom.id j,
+  comp := λ j₁ j₂ j₃ f g,
+  begin
+    cases f,
+      exact g,
+    cases g,
+    apply hom.term _
+  end }
+
+instance : inhabited (hom none none) := ⟨hom.id (none : wide_pullback_shape J)⟩
+
+instance fintype_hom [decidable_eq J] (j j' : wide_pullback_shape J) :
+  fintype (j ⟶ j') :=
+{ elems :=
+  begin
+    cases j',
+    { cases j,
+      { exact {hom.id none} },
+      { exact {hom.term j} } },
+    { by_cases some j' = j,
+      { rw h,
+        exact {hom.id j} },
+      { exact ∅ } }
+  end,
+  complete := by tidy }
+
+instance subsingleton_hom (j j' : wide_pullback_shape J) : subsingleton (j ⟶ j') :=
+⟨by tidy⟩
+
+instance category : small_category (wide_pullback_shape J) := sparse_category
+
+instance fin_category [fintype J] [decidable_eq J] : fin_category (wide_pullback_shape J) :=
+{ fintype_hom := wide_pullback_shape.fintype_hom }
+
+@[simp] lemma hom_id (X : wide_pullback_shape J) : hom.id X = 𝟙 X := rfl
+
+variables {C : Type u} [𝒞 : category.{v} C]
+include 𝒞
+
+local attribute [tidy] tactic.case_bash
+
+/--
+Construct a functor out of the wide pullback shape given a J-indexed collection of arrows to a
+fixed object.
+-/
+@[simps]
+def wide_cospan (B : C) (objs : J → C) (arrows : Π (j : J), objs j ⟶ B) : wide_pullback_shape J ⥤ C :=
+{ obj := λ j, option.cases_on j B objs,
+  map := λ X Y f,
+  begin
+    cases f with _ j,
+    { apply (𝟙 _) },
+    { exact arrows j }
+  end }
+
+/-- Every diagram is naturally isomorphic (actually, equal) to a `wide_cospan` -/
+def diagram_iso_wide_cospan (F : wide_pullback_shape J ⥤ C) :
+  F ≅ wide_cospan (F.obj none) (λ j, F.obj (some j)) (λ j, F.map (hom.term j)) :=
+nat_iso.of_components (λ j, eq_to_iso $ by cases j; tidy) $ by tidy
+
+end wide_pullback_shape
+
+variables (C : Type u) [𝒞 : category.{v} C]
+include 𝒞
+
+/-- `has_wide_pullbacks` represents a choice of wide pullback for every collection of morphisms -/
+class has_wide_pullbacks :=
+(has_limits_of_shape : Π (J : Type v), has_limits_of_shape.{v} (wide_pullback_shape J) C)
+
+/-- `has_wide_pullbacks` represents a choice of wide pullback for every finite collection of morphisms -/
+class has_finite_wide_pullbacks :=
+(has_limits_of_shape : Π (J : Type v) [decidable_eq J] [fintype J], has_limits_of_shape.{v} (wide_pullback_shape J) C)
+
+/-- Finite wide pullbacks are finite limits, so if `C` has all finite limits, it also has finite wide pullbacks -/
+def has_finite_wide_pullbacks_of_has_finite_limits [has_finite_limits.{v} C] : has_finite_wide_pullbacks.{v} C :=
+{ has_limits_of_shape := λ J _ _, by exactI (has_finite_limits.has_limits_of_shape _) }
+
+attribute [instance] has_wide_pullbacks.has_limits_of_shape
+attribute [instance] has_finite_wide_pullbacks.has_limits_of_shape

--- a/src/category_theory/limits/shapes/wide_pullbacks.lean
+++ b/src/category_theory/limits/shapes/wide_pullbacks.lean
@@ -53,6 +53,8 @@ inductive hom : wide_pullback_shape J → wide_pullback_shape J → Type v
 | id : Π X, hom X X
 | term : Π (j : J), hom (some j) none
 
+attribute [nolint unused_arguments] hom.decidable_eq
+
 instance struct : category_struct (wide_pullback_shape J) :=
 { hom := hom,
   id := λ j, hom.id j,
@@ -129,6 +131,8 @@ variable {J}
 inductive hom : wide_pushout_shape J → wide_pushout_shape J → Type v
 | id : Π X, hom X X
 | init : Π (j : J), hom none (some j)
+
+attribute [nolint unused_arguments] hom.decidable_eq
 
 instance struct : category_struct (wide_pushout_shape J) :=
 { hom := hom,


### PR DESCRIPTION
This PR introduces [wide pullbacks](https://ncatlab.org/nlab/show/wide+pullback). 
Ordinary pullbacks are then defined as a special case of wide pullbacks, which simplifies some of the definitions and proofs there. 
Finally we show that the existence of wide pullbacks in `C` gives products in the slice `C/B`, and in fact gives all limits.

TO CONTRIBUTORS:

This PR may break some downstream code using pullbacks, but only slightly (as can be seen in pullbacks.lean). In particular, the only thing that used to work that doesn't any more would be applying cases to a `walking_cospan` - but thanks to the super helpful `pullback_cone.is_limit.mk` and `pullback_cone.equalizer_ext`, one shouldn't need to take cases on a `walking_cospan` anyway.

I haven't done the dual construction - of course before this PR is merged it should probably be included.

The new proof would of course follow by not changing the definition of pullback the same and showing an equivalence of categories between `wide_pullback_shape walking_pair` and `walking_cospan`, but since the change does simplify some proofs I've kept it for now.

The docs linter complains about
```
abbreviation walking_cospan.left : walking_cospan := some walking_pair.left
abbreviation walking_cospan.right : walking_cospan := some walking_pair.right
abbreviation walking_cospan.one : walking_cospan := none
```
and I'd appreciate suggestions of what sort of docs would be helpful here.

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.