### PR TITLE
[Merged by Bors] - chore(tactic/simp_result): forgot to import in tactic.basic

### DIFF
--- a/src/tactic/basic.lean
+++ b/src/tactic/basic.lean
@@ -25,6 +25,7 @@ import
   tactic.rewrite
   tactic.lint
   tactic.simp_rw
+  tactic.simp_result
   tactic.simpa
   tactic.simps
   tactic.split_ifs


### PR DESCRIPTION
When I write a new tactic, I tend not to import it into `tactic.basic` or `tactic.interactive` while testing it and PR'ing it, to save having to recompile the whole library every time I tweak the tactic.

But then, inevitably, I forget to add the import before the review process is finished.

This imports `simp_result`, from #2356, into `tactic.basic`.