### PR TITLE
[Merged by Bors] - feat(category_theory/opposites): some opposite category properties

### DIFF
--- a/src/category_theory/opposites.lean
+++ b/src/category_theory/opposites.lean
@@ -5,6 +5,7 @@ Authors: Stephen Morgan, Scott Morrison
 -/
 import category_theory.types
 import category_theory.natural_isomorphism
+import category_theory.equivalence
 import data.opposite
 
 universes v₁ v₂ u₁ u₂ -- declare the `v`'s first; see `category_theory.category` for an explanation
@@ -64,11 +65,22 @@ instance category.opposite : category.{v₁} Cᵒᵖ :=
 @[simp] lemma unop_id_op {X : C} : (𝟙 (op X)).unop = 𝟙 X := rfl
 @[simp] lemma op_id_unop {X : Cᵒᵖ} : (𝟙 (unop X)).op = 𝟙 X := rfl
 
+@[simps]
 def op_op : (Cᵒᵖ)ᵒᵖ ⥤ C :=
 { obj := λ X, unop (unop X),
   map := λ X Y f, f.unop.unop }
 
--- TODO this is an equivalence
+@[simps]
+def unop_unop : C ⥤ Cᵒᵖᵒᵖ :=
+{ obj := λ X, op (op X),
+  map := λ X Y f, f.op.op }
+
+@[simps]
+def op_op_equivalence : Cᵒᵖᵒᵖ ≌ C :=
+{ functor := op_op,
+  inverse := unop_unop,
+  unit_iso := iso.refl (𝟭 Cᵒᵖᵒᵖ),
+  counit_iso := iso.refl (unop_unop ⋙ op_op) }
 
 def is_iso_of_op {X Y : C} (f : X ⟶ Y) [is_iso f.op] : is_iso f :=
 { inv := (inv (f.op)).unop,
@@ -150,6 +162,12 @@ instance {F : C ⥤ D} [full F] : full F.op :=
 instance {F : C ⥤ D} [faithful F] : faithful F.op :=
 { injectivity' := λ X Y f g h,
     has_hom.hom.unop_inj $ by simpa using injectivity F (has_hom.hom.op_inj h) }
+
+instance right_op_faithful {F : Cᵒᵖ ⥤ D} [faithful F] : faithful F.right_op :=
+{ injectivity' := λ X Y f g h, has_hom.hom.op_inj (injectivity F (has_hom.hom.op_inj h)) }
+
+instance left_op_faithful {F : C ⥤ Dᵒᵖ} [faithful F] : faithful F.left_op :=
+{ injectivity' := λ X Y f g h, has_hom.hom.unop_inj (injectivity F (has_hom.hom.unop_inj h)) }
 
 end
 

--- a/src/category_theory/opposites.lean
+++ b/src/category_theory/opposites.lean
@@ -65,16 +65,19 @@ instance category.opposite : category.{v₁} Cᵒᵖ :=
 @[simp] lemma unop_id_op {X : C} : (𝟙 (op X)).unop = 𝟙 X := rfl
 @[simp] lemma op_id_unop {X : Cᵒᵖ} : (𝟙 (unop X)).op = 𝟙 X := rfl
 
+/-- The functor from the double-opposite of a category to the underlying category. -/
 @[simps]
 def op_op : (Cᵒᵖ)ᵒᵖ ⥤ C :=
 { obj := λ X, unop (unop X),
   map := λ X Y f, f.unop.unop }
 
+/-- The functor from a category to its double-opposite.  -/
 @[simps]
 def unop_unop : C ⥤ Cᵒᵖᵒᵖ :=
 { obj := λ X, op (op X),
   map := λ X Y f, f.op.op }
 
+/-- The double opposite category is equivalent to the original. -/
 @[simps]
 def op_op_equivalence : Cᵒᵖᵒᵖ ≌ C :=
 { functor := op_op,
@@ -163,9 +166,11 @@ instance {F : C ⥤ D} [faithful F] : faithful F.op :=
 { injectivity' := λ X Y f g h,
     has_hom.hom.unop_inj $ by simpa using injectivity F (has_hom.hom.op_inj h) }
 
+/-- If F is faithful then the right_op of F is also faithful. -/
 instance right_op_faithful {F : Cᵒᵖ ⥤ D} [faithful F] : faithful F.right_op :=
 { injectivity' := λ X Y f g h, has_hom.hom.op_inj (injectivity F (has_hom.hom.op_inj h)) }
 
+/-- If F is faithful then the right_op of F is also faithful. -/
 instance left_op_faithful {F : C ⥤ Dᵒᵖ} [faithful F] : faithful F.left_op :=
 { injectivity' := λ X Y f g h, has_hom.hom.unop_inj (injectivity F (has_hom.hom.unop_inj h)) }
 


### PR DESCRIPTION
Add some more basic properties relating to the opposite category.

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
