### PR TITLE
[Merged by Bors] - fix(tactic/where): remove hackery from `#where`, using Lean 3c APIs

### DIFF
--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -491,6 +491,12 @@ meta def to_binder : expr → binder
 | (local_const _ nm bi t) := ⟨nm, bi, t⟩
 | _                       := default binder
 
+/-- Strip-away the context-dependent unique id for the given local const and return: its friendly
+`name`, its `binder_info`, and its `type : expr`.-/
+meta def get_local_const_kind : expr → name × binder_info × expr
+| (expr.local_const _ n bi e) := (n, bi, e)
+| _ := (name.anonymous, binder_info.default, expr.const name.anonymous [])
+
 end expr
 
 /-! ### Declarations about `environment` -/

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -63,12 +63,6 @@ meta def mfoldl {α : Type} {m} [monad m] (f : α → expr → m α) : α → ex
 | x e := prod.snd <$> (state_t.run (e.traverse $ λ e',
     (get >>= monad_lift ∘ flip f e' >>= put) $> e') x : m _)
 
-/-- Strip-away the context-dependent unique id for the given local const and return: its friendly
-`name`, its `binder_info`, and its `type : expr`.-/
-meta def local_const_get_kind : expr → name × binder_info × expr
-| (expr.local_const _ n bi e) := (n, bi, e)
-| _ := (name.anonymous, binder_info.default, expr.const name.anonymous [])
-
 end expr
 
 namespace interaction_monad
@@ -1052,7 +1046,7 @@ do n ← tactic.mk_user_fresh_name,
 /-- `get_variables` returns a list of existing variable names, along with their types and binder
 info. -/
 meta def get_variables : lean.parser (list (name × binder_info × expr)) :=
-list.map expr.local_const_get_kind <$> list_available_include_vars
+list.map expr.get_local_const_kind <$> list_available_include_vars
 
 /-- `get_included_variables` returns those variables `v` returned by `get_variables` which have been
 "included" by an `include v` statement and are not (yet) `omit`ed. -/

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -63,6 +63,8 @@ meta def mfoldl {α : Type} {m} [monad m] (f : α → expr → m α) : α → ex
 | x e := prod.snd <$> (state_t.run (e.traverse $ λ e',
     (get >>= monad_lift ∘ flip f e' >>= put) $> e') x : m _)
 
+/-- Strip-away the context-dependent unique id for the given local const and return: its friendly
+`name`, its `binder_info`, and its `type : expr`.-/
 meta def local_const_get_kind : expr → name × binder_info × expr
 | (expr.local_const _ n bi e) := (n, bi, e)
 | _ := (name.anonymous, binder_info.default, expr.const name.anonymous [])

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -63,6 +63,10 @@ meta def mfoldl {α : Type} {m} [monad m] (f : α → expr → m α) : α → ex
 | x e := prod.snd <$> (state_t.run (e.traverse $ λ e',
     (get >>= monad_lift ∘ flip f e' >>= put) $> e') x : m _)
 
+meta def local_const_get_kind : expr → name × binder_info × expr
+| (expr.local_const _ n bi e) := (n, bi, e)
+| _ := (name.anonymous, binder_info.default, expr.const name.anonymous [])
+
 end expr
 
 namespace interaction_monad
@@ -92,24 +96,6 @@ meta def run_with_state (state : σ) (tac : interaction_monad σ α) : interacti
      end
 
 end interaction_monad
-
-namespace lean.parser
-open lean interaction_monad.result
-
-/-- `emit_command_here str` behaves as if the string `str` were placed as a user command at the
-current line. -/
-meta def emit_command_here (str : string) : lean.parser string :=
-do (_, left) ← with_input command_like str,
-   return left
-
-/-- `emit_code_here str` behaves as if the string `str` were placed at the current location in
-source code. -/
-meta def emit_code_here : string → lean.parser unit
-| str := do left ← emit_command_here str,
-            if left.length = 0 then return ()
-            else emit_code_here left
-
-end lean.parser
 
 namespace format
 
@@ -1032,6 +1018,51 @@ meta def mk_meta_pis : expr → tactic (list expr × expr)
   (ps, r) ← mk_meta_pis (expr.instantiate_var b p),
   return ((p :: ps), r)
 | e := return ([], e)
+
+end tactic
+
+namespace lean.parser
+open lean interaction_monad.result
+
+/-- `emit_command_here str` behaves as if the string `str` were placed as a user command at the
+current line. -/
+meta def emit_command_here (str : string) : lean.parser string :=
+do (_, left) ← with_input command_like str,
+   return left
+
+/-- `emit_code_here str` behaves as if the string `str` were placed at the current location in
+source code. -/
+meta def emit_code_here : string → lean.parser unit
+| str := do left ← emit_command_here str,
+            if left.length = 0 then return ()
+            else emit_code_here left
+
+/-- `get_current_namespace` returns the current namespace (it could be `name.anonymous`).
+
+This function deserves a C++ implementation in core lean, and will fail if it is not called from
+the body of a command (i.e. anywhere else that the `lean.parser` monad can be invoked). -/
+meta def get_current_namespace : lean.parser name :=
+do n ← tactic.mk_user_fresh_name,
+   emit_code_here $ sformat!"def {n} := ()",
+   nfull ← tactic.resolve_constant n,
+   return $ nfull.get_nth_prefix n.components.length
+
+/-- `get_variables` returns a list of existing variable names, along with their types and binder
+info. -/
+meta def get_variables : lean.parser (list (name × binder_info × expr)) :=
+list.map expr.local_const_get_kind <$> list_available_include_vars
+
+/-- `get_included_variables` returns those variables `v` returned by `get_variables` which have been
+"included" by an `include v` statement and are not (yet) `omit`ed. -/
+meta def get_included_variables : lean.parser (list (name × binder_info × expr)) :=
+do ns ← list_include_var_names,
+   list.filter (λ v, v.1 ∈ ns) <$> get_variables
+
+end lean.parser
+
+namespace tactic
+
+variables {α : Type}
 
 /--
 Hole command used to fill in a structure's field when specifying an instance.

--- a/src/tactic/where.lean
+++ b/src/tactic/where.lean
@@ -58,7 +58,7 @@ collect_by_aux p (l.map $ prod.fst ∘ p).erase_dup l
 def inflate {α β : Type} : α → list β → list (α × β)
 | a l := l.map $ prod.mk a
 
-/-- Sort the variables by their priority as defined above. -/
+/-- Sort the variables by their priority as defined by `where.binder_priority`. -/
 meta def sort_variable_list (l : list (name × binder_info × expr)) : list (expr × binder_info × list name) :=
 let l := collect_by l $ λ v, (v.2.2, (v.1, v.2.1)) in
 let l := l.map $ λ el, (el.1, collect_by el.2 $ λ v, (v.2, v.1)) in
@@ -71,7 +71,7 @@ meta def collect_implicit_names : list name → list string × list string
 let n := to_string n, (ns, ins) := collect_implicit_names ns in
 if n.front = '_' then (ns, n :: ins) else (n :: ns, ins)
 
-/-- Format an individual variable definitionfor printing. -/
+/-- Format an individual variable definition for printing. -/
 meta def format_variable : expr × binder_info × list name → tactic string
 | (e, bi, ns) := do let (l, r) := bi.brackets,
                     e ← pp e,

--- a/src/tactic/where.lean
+++ b/src/tactic/where.lean
@@ -9,20 +9,20 @@ import data.list.defs tactic.core
 /-!
 # The `where` command
 
-When working in a Lean file with namespaces, parameters, and variables,
-it can be confusing to identify what the current "parser context" is.
-The command `#where` tries to identify and print information about the current location,
-including the active namespace, open namespaces, and declared variables.
+When working in a Lean file with namespaces, parameters, and variables, it can be confusing to
+identify what the current "parser context" is. The command `#where` identifies and prints
+information about the current location, including the active namespace, open namespaces, and
+declared variables.
 
-This information is not "officially" accessible in the metaprogramming environment;
-`#where` retrieves it via a number of hacks that are not always reliable.
-While it is very useful as a quick reference, users should not assume its output is correct.
+It is a bug for `#where` to incorrectly report this information (this was not formerly the case);
+please file an issue on GitHub if you observe a failure.
 -/
 
 open lean.parser tactic
 
 namespace where
 
+/-- Assigns a priority to each binder for determining the order in which variables are traced. -/
 meta def binder_priority : binder_info → ℕ
 | binder_info.implicit := 1
 | binder_info.strict_implicit := 2
@@ -30,38 +30,48 @@ meta def binder_priority : binder_info → ℕ
 | binder_info.inst_implicit := 4
 | binder_info.aux_decl := 5
 
+/-- The relation on binder priorities. -/
 meta def binder_less_important (u v : binder_info) : bool :=
 (binder_priority u) < (binder_priority v)
 
+/-- Selects the elements of the given `list α` which under the image of `p : α → β × γ` have `β`
+component equal to `b'`. Returns the `γ` components of the selected elements under the image of `p`,
+and the elements of the original `list α` which were not selected. -/
 def select_for_which {α β γ : Type} (p : α → β × γ) [decidable_eq β] (b' : β) : list α → list γ × list α
 | [] := ([], [])
 | (a :: rest) :=
   let (cs, others) := select_for_which rest, (b, c) := p a in
   if b = b' then (c :: cs, others) else (cs, a :: others)
 
-meta def collect_by_aux {α β γ : Type} (p : α → β × γ) [decidable_eq β] : list β → list α → list (β × list γ)
+/-- Helper function for `collect_by`. -/
+private meta def collect_by_aux {α β γ : Type} (p : α → β × γ) [decidable_eq β] : list β → list α → list (β × list γ)
 | [] [] := []
 | [] _ := undefined_core "didn't find every key entry!"
 | (b :: rest) as := let (cs, as) := select_for_which p b as in (b, cs) :: collect_by_aux rest as
 
+/-- Returns the elements of `l` under the image of `p`, collecting together elements with the same
+`β` component, deleting duplicates. -/
 meta def collect_by {α β γ : Type} (l : list α) (p : α → β × γ) [decidable_eq β] : list (β × list γ) :=
 collect_by_aux p (l.map $ prod.fst ∘ p).erase_dup l
 
-def inflate {α β γ : Type} : list (α × list (β × γ)) → list (α × β × γ)
-| [] := []
-| ((a, l) :: rest) := (l.map $ λ e, (a, e.1, e.2)) ++ inflate rest
+/-- Given `a : α` and `l : list β` form a new list by mapping `prod.mk a` over `l`. -/
+def inflate {α β : Type} : α → list β → list (α × β)
+| a l := l.map $ prod.mk a
 
+/-- Sort the variables by their priority as defined above. -/
 meta def sort_variable_list (l : list (name × binder_info × expr)) : list (expr × binder_info × list name) :=
 let l := collect_by l $ λ v, (v.2.2, (v.1, v.2.1)) in
 let l := l.map $ λ el, (el.1, collect_by el.2 $ λ v, (v.2, v.1)) in
-(inflate l).qsort (λ v u, binder_less_important v.2.1 u.2.1)
+(list.join $ l.map $ λ e, let (a,b) := e in inflate a b).qsort (λ v u, binder_less_important v.2.1 u.2.1)
 
+/-- Separate out the names of implicit variables (commonly instances with no name). -/
 meta def collect_implicit_names : list name → list string × list string
 | [] := ([], [])
 | (n :: ns) :=
 let n := to_string n, (ns, ins) := collect_implicit_names ns in
 if n.front = '_' then (ns, n :: ins) else (n :: ns, ins)
 
+/-- Format an individual variable definitionfor printing. -/
 meta def format_variable : expr × binder_info × list name → tactic string
 | (e, bi, ns) := do let (l, r) := bi.brackets,
                     e ← pp e,
@@ -71,9 +81,21 @@ meta def format_variable : expr × binder_info × list name → tactic string
                     let ins := ins.map $ λ _, sformat!"{l}{e}{r}",
                     return $ " ".intercalate $ ns ++ ins
 
+/-- Turn a list of triples of variable names, binder info, and types, into a pretty list. -/
 meta def compile_variable_list (l : list (name × binder_info × expr)) : tactic string :=
 " ".intercalate <$> (sort_variable_list l).mmap format_variable
 
+/-- Strips the namespace prefix `ns` from `n`. -/
+private meta def strip_namespace (ns n : name) : name :=
+n.replace_prefix ns name.anonymous
+
+/-- `get_open_namespaces ns` returns a list of the open namespaces, given that we are currently in
+the namespace `ns` (which we do not include). -/
+meta def get_open_namespaces (ns : name) : tactic (list name) :=
+do opens ← list.erase_dup <$> tactic.open_namespaces,
+   return $ (opens.erase ns).map $ strip_namespace ns
+
+/-- `#where` output helper which traces the current namespace. -/
 meta def trace_namespace (ns : name) : lean.parser unit :=
 do let str := match ns with
    | name.anonymous := "[root namespace]"
@@ -81,43 +103,41 @@ do let str := match ns with
    end,
    trace format!"namespace {str}"
 
-private meta def strip_namespace (ns n : name) : name :=
-n.replace_prefix ns name.anonymous
-
-meta def get_open_namespaces (ns : name) : tactic (list name) :=
-do opens ← list.erase_dup <$> tactic.open_namespaces,
-   return $ (opens.erase ns).map $ strip_namespace ns
-
-meta def trace_opens (ns : name) : tactic unit :=
+/-- `#where` output helper which traces the open namespaces. -/
+meta def trace_open_namespaces (ns : name) : tactic unit :=
 do l ← get_open_namespaces ns,
    let str := " ".intercalate $ l.map to_string,
    if l.empty then skip
    else trace format!"open {str}"
 
+/-- `#where` output helper which traces the variables. -/
 meta def trace_variables : lean.parser unit :=
 do l ← get_variables,
    str ← compile_variable_list l,
    if l.empty then skip
    else trace format!"variables {str}"
 
+/-- `#where` output helper which traces the includes. -/
 meta def trace_includes : lean.parser unit :=
 do l ← get_included_variables,
    let str := " ".intercalate $ l.map $ λ n, to_string n.1,
    if l.empty then skip
    else trace format!"include {str}"
 
-meta def trace_nl : ℕ → tactic unit
-| 0 := skip
-| (n + 1) := trace "" >> trace_nl n
+/-- `#where` output helper which traces newlines. -/
+meta def trace_nl (n : ℕ) : tactic unit :=
+(list.range n).mmap' $ λ _, trace ""
 
+/-- `#where` output helper which traces the namespace end. -/
 meta def trace_end (ns : name) : tactic unit :=
 trace format!"end {ns}"
 
+/-- `#where` output main function. -/
 meta def trace_where : lean.parser unit :=
 do ns ← get_current_namespace,
    trace_namespace ns,
    trace_nl 1,
-   trace_opens ns,
+   trace_open_namespaces ns,
    trace_variables,
    trace_includes,
    trace_nl 3,

--- a/src/tactic/where.lean
+++ b/src/tactic/where.lean
@@ -55,7 +55,7 @@ meta def collect_by {α β γ : Type} (l : list α) (p : α → β × γ) [decid
 collect_by_aux p (l.map $ prod.fst ∘ p).erase_dup l
 
 /-- Given `a : α` and `l : list β` form a new list by mapping `prod.mk a` over `l`. -/
-def inflate {α β : Type} : α → list β → list (α × β)
+private def inflate {α β : Type} : α → list β → list (α × β)
 | a l := l.map $ prod.mk a
 
 /-- Sort the variables by their priority as defined by `where.binder_priority`. -/

--- a/src/tactic/where.lean
+++ b/src/tactic/where.lean
@@ -133,7 +133,7 @@ identify what the current "parser context" is. The command `#where` identifies a
 information about the current location, including the active namespace, open namespaces, and
 declared variables.
 
-It is a bug for `#where` to incorrectly report this information (this was not formerly the case);'
+It is a bug for `#where` to incorrectly report this information (this was not formerly the case);
 please file an issue on GitHub if you observe a failure.
 -/
 @[user_command]

--- a/src/tactic/where.lean
+++ b/src/tactic/where.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Keeley Hoek
 -/
 
-import data.list.defs tactic.core
+import data.list.defs
+import tactic.core
 
 /-!
 # The `where` command

--- a/test/where.lean
+++ b/test/where.lean
@@ -1,0 +1,279 @@
+import data.multiset
+import tactic.where
+
+-- First set up the testing framework...
+
+section framework
+
+-- Note that we cannot have any explicit `open`s, we are currently working around this bug:
+-- https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/What's.20the.20deal.20with.20.60open.60
+
+@[user_command]
+meta def run_parser_from_command_cmd
+  (_ : interactive.parse $ lean.parser.tk "run_parser_from_command")
+  : lean.parser unit :=
+do ns ← lean.parser.ident,
+   let ns := if ns = `NONE then name.anonymous else ns,
+   n ← lean.parser.ident,
+   prog ← lean.parser.of_tactic $ tactic.mk_const (ns ++ n) >>= tactic.eval_expr (lean.parser unit),
+   if ns = name.anonymous then tactic.skip else lean.parser.emit_code_here $
+     "namespace " ++ ns.to_string,
+   prog,
+   if ns = name.anonymous then tactic.skip else lean.parser.emit_code_here $
+     "end " ++ ns.to_string
+
+meta def remove_dot_aux : list char → list char
+| [] := []
+| (c :: rest) := (if c = '.' then '_' else c) :: remove_dot_aux rest
+
+meta def remove_dot (s : string) : string :=
+(remove_dot_aux s.data).as_string
+
+-- NOTE We must emit fully qualified names below in order to not influence the real tests!
+@[user_command]
+meta def run_parser_from_tactic_cmd
+  (_ : interactive.parse $ lean.parser.tk "run_parser_from_tactic")
+  : lean.parser unit :=
+do ns ← lean.parser.ident,
+   let ns := if ns = `NONE then name.anonymous else ns,
+   n ← lean.parser.ident,
+   let tac_name := "try_test_" ++ (remove_dot (ns ++ n).to_string),
+   lean.parser.emit_code_here $
+     "meta def tactic.interactive." ++ tac_name ++ " (_ : interactive.parse " ++ (ns ++ n).to_string ++ ")"
+       ++ ": tactic unit := tactic.triv",
+   if ns = name.anonymous then tactic.skip else lean.parser.emit_code_here $
+     "namespace " ++ ns.to_string,
+   lean.parser.emit_code_here $
+      "example : true := by " ++ (name.mk_string tac_name name.anonymous).to_string,
+   if ns = name.anonymous then tactic.skip else lean.parser.emit_code_here $
+     "end " ++ ns.to_string
+
+meta def assert_name_eq (n₁ n₂ : name) : lean.parser unit :=
+if n₁ = n₂ then return () else tactic.fail sformat!"violation: '{n₁}' ≠ '{n₂}'!"
+
+meta def assert_list_noorder_eq {α : Type} [decidable_eq α] [has_to_string α]
+  (l₁ l₂ : list α) : lean.parser unit :=
+if (l₁ : multiset α) = (l₂ : multiset α) then return () else tactic.fail sformat!"violation: '{l₁}' ≠ '{l₂}'!"
+
+meta def assert_where_msg_eq (s : string) : lean.parser unit :=
+do tw ← where.build_msg,
+   if s = tw then return () else tactic.fail sformat!"violation:\n'\n{tw}\n'\n\n          ≠\n\n'\n{s}\n'!"
+
+-- Test the test framework...
+
+meta def dummy : lean.parser unit := return ()
+
+run_parser_from_command NONE dummy
+run_parser_from_tactic  NONE dummy
+
+end framework
+
+-- TESTS START
+
+
+
+-- TEST: `#where` output
+-- NOTE: This section must come first because of the `open_namespaces` bug referenced above.
+-- NOTE: All other sections have correct answers, but the order of variables (say) may be safely
+--       reordered here: changes to `#where` which break this set of tests are possible, without an
+--       error.
+
+meta def test_output_1 : lean.parser unit := assert_where_msg_eq "namespace [root namespace]\n\n\n\n\nend [root namespace]\n"
+meta def test_output_2 : lean.parser unit := assert_where_msg_eq "namespace [root namespace]\n\nopen list nat\n\n\n\nend [root namespace]\n"
+meta def test_output_3 : lean.parser unit := assert_where_msg_eq "namespace [root namespace]\n\nopen list nat\nvariables {c : ℕ → list ℕ} (b a : ℕ) [decidable_eq : ℕ]\n\n\n\nend [root namespace]\n"
+meta def test_output_4 : lean.parser unit := assert_where_msg_eq "namespace [root namespace]\n\nopen list nat\nvariables {c : ℕ → list ℕ} (b a : ℕ) [decidable_eq : ℕ]\ninclude c a\n\n\n\nend [root namespace]\n"
+meta def test_output_5 : lean.parser unit := assert_where_msg_eq "namespace a\n\nopen list nat\nvariables {c : ℕ → list ℕ} (b a : ℕ) [decidable_eq : ℕ]\ninclude c a\n\n\n\nend a\n"
+meta def test_output_6 : lean.parser unit := assert_where_msg_eq "namespace a.b\n\nopen a list nat\nvariables {c : ℕ → list ℕ} (b a : ℕ) [decidable_eq : ℕ]\ninclude c a\n\n\n\nend a.b\n"
+
+section b1
+
+-- #where
+run_parser_from_command NONE test_output_1
+
+open nat list
+
+-- #where
+run_parser_from_command NONE test_output_2
+
+variables (a b : ℕ) [decidable_eq : ℕ] {c : ℕ → list ℕ}
+
+-- #where
+run_parser_from_command NONE test_output_3
+
+include a c
+
+-- #where
+run_parser_from_command NONE test_output_4
+
+end b1
+
+namespace a
+
+variables (a b : ℕ) [decidable_eq : ℕ] {c : ℕ → list ℕ}
+include a c
+open nat list
+
+-- #where
+run_parser_from_command NONE test_output_5
+
+namespace b
+
+-- #where
+run_parser_from_command NONE test_output_6
+
+end b
+
+end a
+
+
+
+
+
+-- TEST: `lean.parser.get_current_namespace`
+
+-- Check no namespace
+meta def test_no_namespace : lean.parser unit :=
+do ns ← lean.parser.get_current_namespace,
+   assert_name_eq ns name.anonymous,
+   return ()
+
+run_parser_from_command NONE test_no_namespace
+run_parser_from_tactic  NONE test_no_namespace
+
+section a1
+
+open nat list
+
+-- Check no namespace with opens
+meta def test_no_namespace_w_opens : lean.parser unit :=
+do ns ← lean.parser.get_current_namespace,
+   assert_name_eq ns name.anonymous,
+   return ()
+
+run_parser_from_command NONE test_no_namespace_w_opens
+run_parser_from_tactic  NONE test_no_namespace_w_opens
+
+end a1
+
+namespace test1
+
+-- Check a namespace
+meta def test_1 : lean.parser unit :=
+do ns ← lean.parser.get_current_namespace,
+   assert_name_eq ns `test1,
+   return ()
+
+open nat list
+
+-- Check a 2 namespaces with opens
+meta def test_2 : lean.parser unit :=
+do ns ← lean.parser.get_current_namespace,
+   assert_name_eq ns `test1,
+   return ()
+
+end test1
+
+run_parser_from_command test1 test_1
+run_parser_from_command test1 test_2
+run_parser_from_tactic  test1 test_1
+run_parser_from_tactic  test1 test_2
+
+namespace test1.test2
+
+-- Check a 2 namespaces
+meta def test_1 : lean.parser unit :=
+do ns ← lean.parser.get_current_namespace,
+   assert_name_eq ns `test1.test2,
+   return ()
+
+open nat list
+
+-- Check a 2 namespaces with opens
+meta def test_2 : lean.parser unit :=
+do ns ← lean.parser.get_current_namespace,
+   assert_name_eq ns `test1.test2,
+   return ()
+
+end test1.test2
+
+run_parser_from_command test1.test2 test_1
+run_parser_from_command test1.test2 test_2
+run_parser_from_tactic  test1.test2 test_1
+run_parser_from_tactic  test1.test2 test_2
+
+
+
+
+
+
+-- TEST: `lean.parser.get_variables` and `lean.parser.get_included_variables`
+
+-- Check no variables
+meta def test_no_variables : lean.parser unit :=
+do ns ← lean.parser.get_variables,
+   assert_list_noorder_eq (ns.map prod.fst) [],
+   return ()
+
+run_parser_from_command NONE test_no_variables
+run_parser_from_tactic  NONE test_no_variables
+
+section a1
+
+variables (a : ℕ)
+
+-- Check 1 variable from command
+meta def test_1_variable_from_command : lean.parser unit :=
+do ns ← lean.parser.get_variables,
+   assert_list_noorder_eq (ns.map prod.fst) [`a],
+   return ()
+
+run_parser_from_command NONE test_1_variable_from_command
+
+-- Check 1 variable from tactic
+meta def test_1_variable_from_tactic : lean.parser unit :=
+do ns ← lean.parser.get_variables,
+   assert_list_noorder_eq (ns.map prod.fst) [],
+   return ()
+
+run_parser_from_tactic  NONE test_1_variable_from_tactic
+
+end a1
+
+namespace a2
+
+variables (a : ℕ)
+
+-- Check 1 variable from command inside namespace
+meta def test_1_variable_from_command : lean.parser unit :=
+do ns ← lean.parser.get_variables,
+   assert_list_noorder_eq (ns.map prod.fst) [`a],
+   return ()
+
+run_parser_from_command NONE test_1_variable_from_command
+
+-- Check 1 variable from tactic inside namespace
+meta def test_1_variable_from_tactic : lean.parser unit :=
+do ns ← lean.parser.get_variables,
+   assert_list_noorder_eq (ns.map prod.fst) [],
+   return ()
+
+run_parser_from_tactic NONE test_1_variable_from_tactic
+
+end a2
+
+section a3
+
+-- Check 3 variables with 1 include
+meta def test_2_variable_from_command : lean.parser unit :=
+do ns ← lean.parser.get_variables,
+   assert_list_noorder_eq (ns.map prod.fst) [`a, `b, `c],
+   ns ← lean.parser.get_included_variables,
+   assert_list_noorder_eq (ns.map prod.fst) [`b],
+   return ()
+
+variables (a b c : ℕ)
+include b
+
+run_parser_from_command NONE test_2_variable_from_command
+
+end a3


### PR DESCRIPTION
We remove almost all of the hackery from `#where`, using the Lean 3c APIs exposed by @cipher1024. In doing so we add pair of library functions which make this a tad more convenient.

The last "hack" which remains is by far the most mild; we expose `lean.parser.get_current_namespace`, which creates a dummy definition in the environment in order to obtain the current namespace. Of course this should be replaced with an exposed C++ function when the time comes (crossref with the leanprover-community/lean issue here: https://github.com/leanprover-community/lean/issues/196).



TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
