### PR TITLE
[Merged by Bors] - fix(algebra/category/*/colimits): cleaning up

### DIFF
--- a/src/algebra/category/CommRing/colimits.lean
+++ b/src/algebra/category/CommRing/colimits.lean
@@ -350,17 +350,17 @@ begin
     -- trans
     { exact eq.trans r_ih_h r_ih_k },
     -- map
-    { rw cocone.naturality_concrete, },
+    { simp, },
     -- zero
-    { erw ring_hom.map_zero ((s.ι).app r) },
+    { simp, },
     -- one
-    { erw ring_hom.map_one ((s.ι).app r) },
+    { simp, },
     -- neg
-    { rw ring_hom.map_neg ((s.ι).app r_j) },
+    { simp, },
     -- add
-    { rw ring_hom.map_add ((s.ι).app r_j) },
+    { simp, },
     -- mul
-    { rw ring_hom.map_mul ((s.ι).app r_j) },
+    { simp, },
     -- neg_1
     { rw r_ih, },
     -- add_1
@@ -416,24 +416,11 @@ def colimit_is_colimit : is_colimit (colimit_cocone F) :=
     { have w' := congr_fun (congr_arg (λ f : F.obj x_j ⟶ s.X, (f : F.obj x_j → s.X)) (w x_j)) x_x,
       erw w',
       refl, },
-    { simp only [desc_morphism, quot_zero],
-      erw ring_hom.map_zero m,
-      refl, },
-    { simp only [desc_morphism, quot_one],
-      erw ring_hom.map_one m,
-      refl, },
-    { simp only [desc_morphism, quot_neg],
-      erw ring_hom.map_neg m,
-      rw [x_ih],
-      refl, },
-    { simp only [desc_morphism, quot_add],
-      erw ring_hom.map_add m,
-      rw [x_ih_a, x_ih_a_1],
-      refl, },
-    { simp only [desc_morphism, quot_mul],
-      erw ring_hom.map_mul m,
-      rw [x_ih_a, x_ih_a_1],
-      refl, },
+    { simp, },
+    { simp, },
+    { simp *, },
+    { simp *, },
+    { simp *, },
     refl
   end }.
 

--- a/src/algebra/category/Group/colimits.lean
+++ b/src/algebra/category/Group/colimits.lean
@@ -229,13 +229,13 @@ begin
     -- trans
     { exact eq.trans r_ih_h r_ih_k },
     -- map
-    { rw cocone.naturality_concrete, },
+    { simp, },
     -- zero
-    { erw ((s.ι).app r).map_zero },
+    { simp, },
     -- neg
-    { rw ((s.ι).app r_j).map_neg },
+    { simp, },
     -- add
-    { rw ((s.ι).app r_j).map_add },
+    { simp, },
     -- neg_1
     { rw r_ih, },
     -- add_1
@@ -273,17 +273,9 @@ def colimit_is_colimit : is_colimit (colimit_cocone F) :=
     { have w' := congr_fun (congr_arg (λ f : F.obj x_j ⟶ s.X, (f : F.obj x_j → s.X)) (w x_j)) x_x,
       erw w',
       refl, },
-    { simp only [desc_morphism, quot_zero],
-      erw m.map_zero,
-      refl, },
-    { simp only [desc_morphism, quot_neg],
-      erw m.map_neg,
-      rw [x_ih],
-      refl, },
-    { simp only [desc_morphism, quot_add],
-      erw m.map_add,
-      rw [x_ih_a, x_ih_a_1],
-      refl, },
+    { simp *, },
+    { simp *, },
+    { simp *, },
     refl
   end }.
 

--- a/src/algebra/category/Mon/colimits.lean
+++ b/src/algebra/category/Mon/colimits.lean
@@ -200,11 +200,11 @@ begin
     -- trans
     { exact eq.trans r_ih_h r_ih_k },
     -- map
-    { rw cocone.naturality_concrete, },
+    { simp, },
     -- mul
-    { rw monoid_hom.map_mul ((s.ι).app r_j) },
+    { simp, },
     -- one
-    { erw monoid_hom.map_one ((s.ι).app r) },
+    { simp, },
     -- mul_1
     { rw r_ih, },
     -- mul_2
@@ -235,13 +235,8 @@ def colimit_is_colimit : is_colimit (colimit_cocone F) :=
     { have w' := congr_fun (congr_arg (λ f : F.obj x_j ⟶ s.X, (f : F.obj x_j → s.X)) (w x_j)) x_x,
       erw w',
       refl, },
-    { simp only [desc_morphism, quot_one],
-      erw monoid_hom.map_one m,
-      refl, },
-    { simp only [desc_morphism, quot_mul],
-      erw monoid_hom.map_mul m,
-      rw [x_ih_a, x_ih_a_1],
-      refl, },
+    { simp *, },
+    { simp *, },
     refl
   end }.
 


### PR DESCRIPTION
With the passage of time, it seems some difficulties have dissolved away, and steps in the semi-automated construction of colimits in algebraic categories which previously required `rw` or even `erw`, can now be handled by `simp`. Yay!