### PR TITLE
[Merged by Bors] - feat(linear_algebra): quadratic forms

### DIFF
--- a/src/algebra/module.lean
+++ b/src/algebra/module.lean
@@ -239,6 +239,9 @@ variables {f g}
 @[ext] theorem ext (H : ∀ x, f x = g x) : f = g :=
 by cases f; cases g; congr'; exact funext H
 
+lemma coe_fn_congr : Π {x x' : M}, x = x' → f x = f x'
+| _ _ rfl := rfl
+
 theorem ext_iff : f = g ↔ ∀ x, f x = g x :=
 ⟨by { rintro rfl x, refl } , ext⟩
 

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -9,6 +9,7 @@ import algebra.pi_instances
 
 universes u v w
 
+@[nolint unused_arguments]
 def matrix (m n : Type u) [fintype m] [fintype n] (α : Type v) : Type (max u v) :=
 m → n → α
 
@@ -307,13 +308,13 @@ by { ext, rw [←diagonal_one, mul_vec_diagonal, one_mul] }
 @[simp] lemma vec_mul_one [decidable_eq m] (v : m → α) : vec_mul v 1 = v :=
 by { ext, rw [←diagonal_one, vec_mul_diagonal, mul_one] }
 
-@[simp] lemma mul_vec_zero [decidable_eq m] (A : matrix m n α) : mul_vec A 0 = 0 :=
+@[simp] lemma mul_vec_zero (A : matrix m n α) : mul_vec A 0 = 0 :=
 by { ext, simp [mul_vec] }
 
-@[simp] lemma vec_mul_zero [decidable_eq m] (A : matrix m n α) : vec_mul 0 A = 0 :=
+@[simp] lemma vec_mul_zero (A : matrix m n α) : vec_mul 0 A = 0 :=
 by { ext, simp [vec_mul] }
 
-@[simp] lemma vec_mul_vec_mul [decidable_eq n] (v : m → α) (M : matrix m n α) (N : matrix n o α) :
+@[simp] lemma vec_mul_vec_mul (v : m → α) (M : matrix m n α) (N : matrix n o α) :
   vec_mul (vec_mul v M) N = vec_mul v (M ⬝ N) :=
 begin
   ext,
@@ -321,7 +322,7 @@ begin
   apply finset.sum_comm
 end
 
-@[simp] lemma mul_vec_mul_vec [decidable_eq n] (v : o → α) (M : matrix m n α) (N : matrix n o α) :
+@[simp] lemma mul_vec_mul_vec (v : o → α) (M : matrix m n α) (N : matrix n o α) :
   mul_vec M (mul_vec N v) = mul_vec (M ⬝ N) v :=
 begin
   ext,

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -209,10 +209,10 @@ section ring
 variables [ring α]
 
 @[simp] theorem neg_mul (M : matrix m n α) (N : matrix n o α) :
-  (-M) ⬝ N = -(M ⬝ N) := by ext; simp [matrix.mul]
+  (-M) ⬝ N = -(M ⬝ N) := by ext; simp [matrix.mul_val]
 
 @[simp] theorem mul_neg (M : matrix m n α) (N : matrix n o α) :
-  M ⬝ (-N) = -(M ⬝ N) := by ext; simp [matrix.mul]
+  M ⬝ (-N) = -(M ⬝ N) := by ext; simp [matrix.mul_val]
 
 end ring
 
@@ -241,8 +241,7 @@ by { ext, simp [mul_comm] }
 @[simp] lemma mul_smul (M : matrix m n α) (a : α) (N : matrix n l α) : M ⬝ (a • N) = a • M ⬝ N :=
 begin
   ext i j,
-  unfold matrix.mul has_scalar.smul,
-  rw finset.mul_sum,
+  simp only [matrix.mul_val, has_scalar.smul, finset.mul_sum],
   congr,
   ext,
   ac_refl
@@ -251,8 +250,7 @@ end
 @[simp] lemma smul_mul (M : matrix m n α) (a : α) (N : matrix n l α) : (a • M) ⬝ N = a • M ⬝ N :=
 begin
   ext i j,
-  unfold matrix.mul has_scalar.smul,
-  rw finset.mul_sum,
+  simp only [matrix.mul_val, has_scalar.smul, finset.mul_sum],
   congr,
   ext,
   ac_refl
@@ -293,12 +291,47 @@ begin
   { rw [diagonal_val_eq] }
 end
 
+lemma vec_mul_diagonal [decidable_eq m] (v w : m → α) (x : m) :
+  vec_mul v (diagonal w) x = v x * w x :=
+begin
+  transitivity,
+  refine finset.sum_eq_single x _ _,
+  { assume b _ ne, simp [diagonal, if_neg ne] },
+  { simp },
+  { rw [diagonal_val_eq] }
+end
+
 @[simp] lemma mul_vec_one [decidable_eq m] (v : m → α) : mul_vec 1 v = v :=
 by { ext, rw [←diagonal_one, mul_vec_diagonal, one_mul] }
 
+@[simp] lemma vec_mul_one [decidable_eq m] (v : m → α) : vec_mul v 1 = v :=
+by { ext, rw [←diagonal_one, vec_mul_diagonal, mul_one] }
+
+@[simp] lemma mul_vec_zero [decidable_eq m] (A : matrix m n α) : mul_vec A 0 = 0 :=
+by { ext, simp [mul_vec] }
+
+@[simp] lemma vec_mul_zero [decidable_eq m] (A : matrix m n α) : vec_mul 0 A = 0 :=
+by { ext, simp [vec_mul] }
+
+@[simp] lemma vec_mul_vec_mul [decidable_eq n] (v : m → α) (M : matrix m n α) (N : matrix n o α) :
+  vec_mul (vec_mul v M) N = vec_mul v (M ⬝ N) :=
+begin
+  ext,
+  simp_rw [vec_mul, matrix.mul, finset.mul_sum, finset.sum_mul, mul_assoc],
+  apply finset.sum_comm
+end
+
+@[simp] lemma mul_vec_mul_vec [decidable_eq n] (v : o → α) (M : matrix m n α) (N : matrix n o α) :
+  mul_vec M (mul_vec N v) = mul_vec (M ⬝ N) v :=
+begin
+  ext,
+  simp_rw [mul_vec, matrix.mul, finset.sum_mul, finset.mul_sum, mul_assoc],
+  apply finset.sum_comm
+end
+
 lemma vec_mul_vec_eq (w : m → α) (v : n → α) :
   vec_mul_vec w v = (col w) ⬝ (row v) :=
-by simp [matrix.mul]; refl
+by { ext i j, simp, refl }
 
 end semiring
 
@@ -337,7 +370,7 @@ by { ext i j, simp }
   (M ⬝ N)ᵀ = Nᵀ ⬝ Mᵀ  :=
 begin
   ext i j,
-  unfold matrix.mul transpose,
+  simp only [matrix.mul_val, transpose],
   congr,
   ext,
   ac_refl
@@ -391,5 +424,36 @@ sub_up (sub_left A)
 def sub_down_left {d u l r : nat} (A: matrix (fin (u + d)) (fin (l + r)) α) :
   matrix (fin d) (fin (l)) α :=
 sub_down (sub_left A)
+
+section row_col
+/-! ### `row_col` section
+
+  Simplification lemmas for `matrix.row` and `matrix.col`.
+-/
+open_locale matrix
+
+@[simp] lemma col_add [semiring α] (v w : m → α) : col (v + w) = col v + col w := by { ext, refl }
+@[simp] lemma col_smul [semiring α] (x : α) (v : m → α) : col (x • v) = x • col v := by { ext, refl }
+@[simp] lemma row_add [semiring α] (v w : m → α) : row (v + w) = row v + row w := by { ext, refl }
+@[simp] lemma row_smul [semiring α] (x : α) (v : m → α) : row (x • v) = x • row v := by { ext, refl }
+
+@[simp] lemma col_val (v : m → α) (i j) : matrix.col v i j = v i := rfl
+@[simp] lemma row_val (v : m → α) (i j) : matrix.row v i j = v j := rfl
+
+@[simp]
+lemma transpose_col (v : m → α) : (matrix.col v).transpose = matrix.row v := by {ext, refl}
+@[simp]
+lemma transpose_row (v : m → α) : (matrix.row v).transpose = matrix.col v := by {ext, refl}
+
+lemma row_vec_mul [semiring α] (M : matrix m n α) (v : m → α) :
+  matrix.row (matrix.vec_mul v M) = matrix.row v ⬝ M := by {ext, refl}
+lemma col_vec_mul [semiring α] (M : matrix m n α) (v : m → α) :
+  matrix.col (matrix.vec_mul v M) = (matrix.row v ⬝ M)ᵀ := by {ext, refl}
+lemma col_mul_vec [semiring α] (M : matrix m n α) (v : n → α) :
+  matrix.col (matrix.mul_vec M v) = M ⬝ matrix.col v := by {ext, refl}
+lemma row_mul_vec [semiring α] (M : matrix m n α) (v : n → α) :
+  matrix.row (matrix.mul_vec M v) = (M ⬝ matrix.col v)ᵀ := by {ext, refl}
+
+end row_col
 
 end matrix

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -182,6 +182,10 @@ ext $ assume c, by rw [comp_apply, zero_apply, zero_apply, f.map_zero]
 @[simp] theorem zero_comp : (0 : M₂ →ₗ[R] M₃).comp f = 0 :=
 rfl
 
+@[norm_cast] lemma coe_fn_sum {ι : Type*} (t : finset ι) (f : ι → M →ₗ[R] M₂) :
+  ⇑(t.sum f) = t.sum (λ i, (f i : M → M₂)) :=
+add_monoid_hom.map_sum ⟨@to_fun R M M₂ _ _ _ _ _, rfl, λ x y, rfl⟩ _ _
+
 section
 variables (R M)
 include M

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -41,7 +41,7 @@ structure bilin_form (R : Type u) (M : Type v) [ring R] [add_comm_group M] [modu
 (bilin_add_right : ∀ (x y z : M), bilin x (y + z) = bilin x y + bilin x z)
 (bilin_smul_right : ∀ (a : R) (x y : M), bilin x (a • y) = a * (bilin x y))
 
-/-- A linear map with two arguments is a bilinear form. -/
+/-- A map with two arguments that is linear in both is a bilinear form -/
 def linear_map.to_bilin {R : Type u} {M : Type v} [comm_ring R] [add_comm_group M] [module R M]
   (f : M →ₗ[R] M →ₗ[R] R) : bilin_form R M :=
 { bilin := λ x y, f x y,

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -142,7 +142,7 @@ lemma smul_apply (a : R₂) (x y : M) : (a • F) x y = a • (F x y) := rfl
 def to_linear_map : M →ₗ[R₂] M →ₗ[R₂] R₂ :=
 linear_map.mk₂ R₂ F.1 (bilin_add_left F) (bilin_smul_left F) (bilin_add_right F) (bilin_smul_right F)
 
-/-- Bilinear forms are equivalent to linear maps with two arguments. -/
+/-- Bilinear forms are equivalent to maps with two arguments that is linear in both. -/
 def bilin_linear_map_equiv : (bilin_form R₂ M) ≃ₗ[R₂] (M →ₗ[R₂] M →ₗ[R₂] R₂) :=
 { to_fun := to_linear_map,
   add := λ B D, rfl,
@@ -191,13 +191,13 @@ B.comp linear_map.id f
 @[simp] lemma comp_right_comp_left (B : bilin_form R M) (l r : M →ₗ[R] M) :
   (B.comp_right r).comp_left l = B.comp l r := rfl
 
-@[simp] lemma coe_fn_comp (B : bilin_form R N) (l r : M →ₗ[R] N) (v w) :
+@[simp] lemma comp_apply (B : bilin_form R N) (l r : M →ₗ[R] N) (v w) :
   B.comp l r v w = B (l v) (r w) := rfl
 
-@[simp] lemma coe_fn_comp_left (B : bilin_form R M) (f : M →ₗ[R] M) (v w) :
+@[simp] lemma comp_left_apply (B : bilin_form R M) (f : M →ₗ[R] M) (v w) :
   B.comp_left f v w = B (f v) w := rfl
 
-@[simp] lemma coe_fn_comp_right (B : bilin_form R M) (f : M →ₗ[R] M) (v w) :
+@[simp] lemma comp_right_apply (B : bilin_form R M) (f : M →ₗ[R] M) (v w) :
   B.comp_right f v w = B v (f w) := rfl
 
 end comp
@@ -255,8 +255,7 @@ def matrix.to_bilin_formₗ : matrix n n R →ₗ[R] bilin_form R (n → R) :=
     bilin_add_left := λ x y z, by simp [matrix.add_mul],
     bilin_smul_left := λ a x y, by simp,
     bilin_add_right := λ x y z, by simp [matrix.mul_add],
-    bilin_smul_right := λ a x y, by simp,
-  },
+    bilin_smul_right := λ a x y, by simp },
   add := λ f g, by { ext, simp [add_apply, matrix.mul_add, matrix.add_mul] },
   smul := λ f g, by { ext, simp [smul_apply] } }
 
@@ -291,7 +290,7 @@ lemma bilin_form.to_matrix_comp (B : bilin_form R (n → R)) (l r : (o → R) �
   (B.comp l r).to_matrix = l.to_matrixᵀ ⬝ B.to_matrix ⬝ r.to_matrix :=
 begin
   ext i j,
-  simp only [to_matrix_apply, coe_fn_comp, mul_val, sum_mul],
+  simp only [to_matrix_apply, comp_apply, mul_val, sum_mul],
   have sum_smul_eq : Π (f : (o → R) →ₗ[R] (n → R)) (i : o),
     f (λ n, ite (n = i) 1 0) = univ.sum (λ k, f.to_matrix k i • λ n, ite (n = k) (1 : R) 0),
   { intros f i,
@@ -328,7 +327,7 @@ def bilin_form_equiv_matrix : bilin_form R (n → R) ≃ₗ[R] matrix n n R :=
   left_inv := λ B, show B.to_matrix.to_bilin_form = B,
   begin
     ext,
-    rw [matrix.to_bilin_form_apply, B.mul_to_matrix_mul, bilin_form.to_matrix_apply, coe_fn_comp],
+    rw [matrix.to_bilin_form_apply, B.mul_to_matrix_mul, bilin_form.to_matrix_apply, comp_apply],
     { apply coe_fn_congr; ext; simp [mul_vec] },
     apply_instance
   end,

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -3,6 +3,8 @@ Copyright (c) 2018 Andreas Swerdlow. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Andreas Swerdlow
 -/
+
+import linear_algebra.matrix
 import linear_algebra.tensor_product
 
 /-!
@@ -29,7 +31,7 @@ the notation B x y to refer to the function field, ie. B x y = B.bilin x y.
 Bilinear form,
 -/
 
-universes u v
+universes u v w
 
 /-- A bilinear form over a module  -/
 structure bilin_form (R : Type u) (M : Type v) [ring R] [add_comm_group M] [module R M] :=
@@ -39,8 +41,9 @@ structure bilin_form (R : Type u) (M : Type v) [ring R] [add_comm_group M] [modu
 (bilin_add_right : ∀ (x y z : M), bilin x (y + z) = bilin x y + bilin x z)
 (bilin_smul_right : ∀ (a : R) (x y : M), bilin x (a • y) = a * (bilin x y))
 
+/-- A linear map with two arguments is a bilinear form. -/
 def linear_map.to_bilin {R : Type u} {M : Type v} [comm_ring R] [add_comm_group M] [module R M]
-(f : M →ₗ[R] M →ₗ[R] R) : bilin_form R M :=
+  (f : M →ₗ[R] M →ₗ[R] R) : bilin_form R M :=
 { bilin := λ x y, f x y,
   bilin_add_left := λ x y z, (linear_map.map_add f x y).symm ▸ linear_map.add_apply (f x) (f y) z,
   bilin_smul_left := λ a x y, by {rw linear_map.map_smul, rw linear_map.smul_apply, rw smul_eq_mul},
@@ -53,6 +56,13 @@ variables {R : Type u} {M : Type v} [ring R] [add_comm_group M] [module R M] {B 
 
 instance : has_coe_to_fun (bilin_form R M) :=
 ⟨_, λ B, B.bilin⟩
+
+@[simp] lemma coe_fn_mk (f : M → M → R) (h₁ h₂ h₃ h₄) :
+  (bilin_form.mk f h₁ h₂ h₃ h₄ : M → M → R) = f :=
+rfl
+
+lemma coe_fn_congr : Π {x x' y y' : M}, x = x' → y = y' → B x y = B x' y'
+| _ _ _ _ rfl rfl := rfl
 
 lemma add_left (x y z : M) : B (x + y) z = B x z + B y z := bilin_add_left B x y z
 
@@ -105,6 +115,8 @@ instance : add_comm_group (bilin_form R M) :=
   add_left_neg := by {intros, ext, unfold coe_fn has_coe_to_fun.coe bilin, rw neg_add_self},
   add_comm := by {intros, ext, unfold coe_fn has_coe_to_fun.coe bilin, rw add_comm} }
 
+lemma add_apply (x y : M) : (B + D) x y = B x y + D x y := rfl
+
 instance : inhabited (bilin_form R M) := ⟨0⟩
 
 section
@@ -124,9 +136,13 @@ instance to_module : module R₂ (bilin_form R₂ M) :=
   zero_smul := λ B, by {ext, unfold coe_fn has_coe_to_fun.coe bilin, rw zero_mul},
   smul_zero := λ B, by {ext, unfold coe_fn has_coe_to_fun.coe bilin, rw mul_zero} }
 
+lemma smul_apply (a : R₂) (x y : M) : (a • F) x y = a • (F x y) := rfl
+
+/-- `B.to_linear_map` applies B on the left argument, then the right.  -/
 def to_linear_map : M →ₗ[R₂] M →ₗ[R₂] R₂ :=
 linear_map.mk₂ R₂ F.1 (bilin_add_left F) (bilin_smul_left F) (bilin_add_right F) (bilin_smul_right F)
 
+/-- Bilinear forms are equivalent to linear maps with two arguments. -/
 def bilin_linear_map_equiv : (bilin_form R₂ M) ≃ₗ[R₂] (M →ₗ[R₂] M →ₗ[R₂] R₂) :=
 { to_fun := to_linear_map,
   add := λ B D, rfl,
@@ -135,7 +151,56 @@ def bilin_linear_map_equiv : (bilin_form R₂ M) ≃ₗ[R₂] (M →ₗ[R₂] M 
   left_inv := λ B, by {ext, refl},
   right_inv := λ B, by {ext, refl} }
 
+@[norm_cast]
+lemma coe_fn_to_linear_map (x : M) : ⇑(F.to_linear_map x) = F x := rfl
+
+lemma map_sum_left {α} (B : bilin_form R₂ M) (t : finset α) (g : α → M) (w : M) :
+  B (t.sum g) w = t.sum (λ i, B (g i) w) :=
+show B.to_linear_map (t.sum g) w = t.sum (λ i, B (g i) w),
+by { rw [B.to_linear_map.map_sum, linear_map.coe_fn_sum, finset.sum_apply], norm_cast }
+
+lemma map_sum_right {α} (B : bilin_form R₂ M) (t : finset α) (g : α → M) (v : M) :
+  B v (t.sum g) = t.sum (λ i, B v (g i)) :=
+(B.to_linear_map v).map_sum
+
 end
+
+section comp
+
+variables {N : Type w} [add_comm_group N] [module R N]
+
+/-- Apply a linear map on the left and right argument of a bilinear form. -/
+def comp (B : bilin_form R N) (l r : M →ₗ[R] N) : bilin_form R M :=
+{ bilin := λ x y, B (l x) (r y),
+  bilin_add_left := λ x y z, by simp [add_left],
+  bilin_smul_left := λ x y z, by simp [smul_left],
+  bilin_add_right := λ x y z, by simp [add_right],
+  bilin_smul_right := λ x y z, by simp [smul_right] }
+
+/-- Apply a linear map to the left argument of a bilinear form. -/
+def comp_left (B : bilin_form R M) (f : M →ₗ[R] M) : bilin_form R M :=
+B.comp f linear_map.id
+
+/-- Apply a linear map to the right argument of a bilinear form. -/
+def comp_right (B : bilin_form R M) (f : M →ₗ[R] M) : bilin_form R M :=
+B.comp linear_map.id f
+
+@[simp] lemma comp_left_comp_right (B : bilin_form R M) (l r : M →ₗ[R] M) :
+  (B.comp_left l).comp_right r = B.comp l r := rfl
+
+@[simp] lemma comp_right_comp_left (B : bilin_form R M) (l r : M →ₗ[R] M) :
+  (B.comp_right r).comp_left l = B.comp l r := rfl
+
+@[simp] lemma coe_fn_comp (B : bilin_form R N) (l r : M →ₗ[R] N) (v w) :
+  B.comp l r v w = B (l v) (r w) := rfl
+
+@[simp] lemma coe_fn_comp_left (B : bilin_form R M) (f : M →ₗ[R] M) (v w) :
+  B.comp_left f v w = B (f v) w := rfl
+
+@[simp] lemma coe_fn_comp_right (B : bilin_form R M) (f : M →ₗ[R] M) (v w) :
+  B.comp_right f v w = B v (f w) := rfl
+
+end comp
 
 /-- The proposition that two elements of a bilinear form space are orthogonal -/
 def is_ortho (B : bilin_form R M) (x y : M) : Prop :=
@@ -175,6 +240,102 @@ end
 end
 
 end bilin_form
+
+section matrix
+variables {R : Type u} [comm_ring R]
+variables {n o : Type w} [fintype n] [fintype o]
+
+open bilin_form finset matrix
+open_locale matrix
+
+/-- The linear map from `matrix n n R` to bilinear forms on `n → R`. -/
+def matrix.to_bilin_formₗ : matrix n n R →ₗ[R] bilin_form R (n → R) :=
+{ to_fun := λ M,
+  { bilin := λ v w, (row v ⬝ M ⬝ col w) ⟨⟩ ⟨⟩,
+    bilin_add_left := λ x y z, by simp [matrix.add_mul],
+    bilin_smul_left := λ a x y, by simp,
+    bilin_add_right := λ x y z, by simp [matrix.mul_add],
+    bilin_smul_right := λ a x y, by simp,
+  },
+  add := λ f g, by { ext, simp [add_apply, matrix.mul_add, matrix.add_mul] },
+  smul := λ f g, by { ext, simp [smul_apply] } }
+
+/-- The map from `matrix n n R` to bilinear forms on `n → R`. -/
+def matrix.to_bilin_form : matrix n n R → bilin_form R (n → R) :=
+matrix.to_bilin_formₗ.to_fun
+
+lemma matrix.to_bilin_form_apply (M : matrix n n R) (v w : n → R) :
+(M.to_bilin_form : (n → R) → (n → R) → R) v w = (row v ⬝ M ⬝ col w) ⟨⟩ ⟨⟩ := rfl
+
+variables [decidable_eq n] [decidable_eq o]
+
+/-- The linear map from bilinear forms on `n → R` to `matrix n n R`. -/
+def bilin_form.to_matrixₗ : bilin_form R (n → R) →ₗ[R] matrix n n R :=
+{ to_fun := λ B i j, B (λ n, if n = i then 1 else 0) (λ n, if n = j then 1 else 0),
+  add := λ f g, rfl,
+  smul := λ f g, rfl }
+
+/-- The map from bilinear forms on `n → R` to `matrix n n R`. -/
+def bilin_form.to_matrix : bilin_form R (n → R) → matrix n n R :=
+bilin_form.to_matrixₗ.to_fun
+
+lemma bilin_form.to_matrix_apply (B : bilin_form R (n → R)) (i j : n) :
+  B.to_matrix i j = B (λ n, if n = i then 1 else 0) (λ n, if n = j then 1 else 0) := rfl
+
+lemma bilin_form.to_matrix_smul (B : bilin_form R (n → R)) (x : R) :
+  (x • B).to_matrix = x • B.to_matrix :=
+by { ext, refl }
+
+open bilin_form
+lemma bilin_form.to_matrix_comp (B : bilin_form R (n → R)) (l r : (o → R) →ₗ[R] (n → R)) :
+  (B.comp l r).to_matrix = l.to_matrixᵀ ⬝ B.to_matrix ⬝ r.to_matrix :=
+begin
+  ext i j,
+  simp only [to_matrix_apply, coe_fn_comp, mul_val, sum_mul],
+  have sum_smul_eq : Π (f : (o → R) →ₗ[R] (n → R)) (i : o),
+    f (λ n, ite (n = i) 1 0) = univ.sum (λ k, f.to_matrix k i • λ n, ite (n = k) (1 : R) 0),
+  { intros f i,
+    ext j,
+    change f (λ n, ite (n = i) 1 0) j = univ.sum (λ k n, f.to_matrix k i * ite (n = k) (1 : R) 0) j,
+    simp [linear_map.to_matrix, linear_map.to_matrixₗ, eq_comm] },
+  simp_rw [sum_smul_eq, map_sum_right, map_sum_left, smul_right, mul_comm, smul_left],
+  refl
+end
+
+lemma bilin_form.to_matrix_comp_left (B : bilin_form R (n → R)) (f : (n → R) →ₗ[R] (n → R)) :
+  (B.comp_left f).to_matrix = f.to_matrixᵀ ⬝ B.to_matrix :=
+by simp [comp_left, bilin_form.to_matrix_comp]
+
+lemma bilin_form.to_matrix_comp_right (B : bilin_form R (n → R)) (f : (n → R) →ₗ[R] (n → R)) :
+  (B.comp_right f).to_matrix = B.to_matrix ⬝ f.to_matrix :=
+by simp [comp_right, bilin_form.to_matrix_comp]
+
+lemma bilin_form.mul_to_matrix_mul (B : bilin_form R (n → R)) (M : matrix o n R) (N : matrix n o R) :
+  M ⬝ B.to_matrix ⬝ N = (B.comp (Mᵀ.to_lin) (N.to_lin)).to_matrix :=
+by { ext, simp [B.to_matrix_comp (Mᵀ.to_lin) (N.to_lin), to_lin_to_matrix] }
+
+lemma bilin_form.mul_to_matrix (B : bilin_form R (n → R)) (M : matrix n n R) :
+  M ⬝ B.to_matrix = (B.comp_left (Mᵀ.to_lin)).to_matrix :=
+by { ext, simp [B.to_matrix_comp_left (Mᵀ.to_lin), to_lin_to_matrix] }
+
+lemma bilin_form.to_matrix_mul (B : bilin_form R (n → R)) (M : matrix n n R) :
+  B.to_matrix ⬝ M = (B.comp_right (M.to_lin)).to_matrix :=
+by { ext, simp [B.to_matrix_comp_right (M.to_lin), to_lin_to_matrix] }
+
+/-- Bilinear forms are linearly equivalent to matrices. -/
+def bilin_form_equiv_matrix : bilin_form R (n → R) ≃ₗ[R] matrix n n R :=
+{ inv_fun := matrix.to_bilin_form,
+  left_inv := λ B, show B.to_matrix.to_bilin_form = B,
+  begin
+    ext,
+    rw [matrix.to_bilin_form_apply, B.mul_to_matrix_mul, bilin_form.to_matrix_apply, coe_fn_comp],
+    { apply coe_fn_congr; ext; simp [mul_vec] },
+    apply_instance
+  end,
+  right_inv := λ M, by { ext, simp [bilin_form.to_matrixₗ, matrix.to_bilin_form_apply, mul_val] },
+  ..bilin_form.to_matrixₗ }
+
+end matrix
 
 namespace refl_bilin_form
 

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -87,13 +87,7 @@ instance to_lin.is_add_monoid_hom :
 
 lemma mul_to_lin (M : matrix m n R) (N : matrix n l R) :
   (M.mul N).to_lin = M.to_lin.comp N.to_lin :=
-begin
-  ext v x,
-  simp [to_lin_apply, mul_vec, matrix.mul_val, finset.sum_mul, finset.mul_sum],
-  rw [finset.sum_comm],
-  congr, funext x, congr, funext y,
-  rw [mul_assoc]
-end
+by { ext, simp [to_lin_apply, mul_vec, matrix.mul_val, finset.sum_mul, finset.mul_sum] }
 
 @[simp] lemma to_lin_one [decidable_eq n] : (1 : matrix n n R).to_lin = linear_map.id :=
 by { ext, simp }

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -89,7 +89,7 @@ lemma mul_to_lin (M : matrix m n R) (N : matrix n l R) :
   (M.mul N).to_lin = M.to_lin.comp N.to_lin :=
 begin
   ext v x,
-  simp [to_lin_apply, mul_vec, matrix.mul, finset.sum_mul, finset.mul_sum],
+  simp [to_lin_apply, mul_vec, matrix.mul_val, finset.sum_mul, finset.mul_sum],
   rw [finset.sum_comm],
   congr, funext x, congr, funext y,
   rw [mul_assoc]
@@ -114,6 +114,10 @@ end
 
 /-- The map from linear maps (n → R) →ₗ[R] (m → R) to matrix m n R. -/
 def to_matrix [decidable_eq n] : ((n → R) →ₗ[R] (m → R)) → matrix m n R := to_matrixₗ.to_fun
+
+@[simp] lemma to_matrix_id [decidable_eq n] :
+  (@linear_map.id _ (n → R) _ _ _).to_matrix = 1 :=
+by { ext, simp [to_matrix, to_matrixₗ, matrix.one_val, eq_comm] }
 
 end linear_map
 

--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -1,0 +1,290 @@
+/-
+Copyright (c) 2020 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Anne Baanen
+
+Quadratic forms over modules.
+-/
+
+import linear_algebra.bilinear_form
+import linear_algebra.determinant
+import linear_algebra.special_linear_group
+
+/-!
+# Quadratic forms
+
+This file defines quadratic forms over a `R`-module `M`.
+A quadratic form is a map `Q : M → R` such that
+  (`map_smul`) `Q (a • x) = a * a * Q x`
+  (`polar_...`) The map `polar Q := λ x y, Q (x + y) - Q x - Q y` is bilinear.
+They come with a scalar multiplication, `(a • Q) x = Q (a • x) = a * a * Q x`,
+and composition with linear maps `f`, `Q.comp f x = Q (f x)`.
+
+## Main definitions
+
+ * `quadratic_form.associated`: associated bilinear form
+ * `quadratic_form.pos_def`: positive definite quadratic forms
+ * `quadratic_form.discr`: discriminant of a quadratic form
+
+## Main statements
+
+ * `quadratic_form.associated_left_inverse`,
+ * `quadratic_form.associated_right_inverse`: in a commutative ring where 2 has
+  an inverse, there is a correspondence between quadratic forms and symmetric
+  bilinear forms
+
+## References
+
+ * https://en.wikipedia.org/wiki/Quadratic_form
+ * https://en.wikipedia.org/wiki/Discriminant#Quadratic_forms
+
+## Tags
+
+quadratic form, homogeneous polynomial, quadratic polynomial
+-/
+
+universes u v w
+variables {R : Type u} {M : Type v} [add_comm_group M] [ring R]
+variables {R₁ : Type u} [comm_ring R₁] [module R₁ M]
+
+/-- Up to a factor 2, `Q.polar` is the associated bilinear form for a quadratic form `Q`. -/
+def quadratic_form.polar (f : M → R) (x y : M) :=
+f (x + y) - f x - f y
+
+variables [module R M]
+
+open quadratic_form
+/-- A quadratic form over a module. -/
+structure quadratic_form (R : Type u) (M : Type v) [ring R] [add_comm_group M] [module R M] :=
+(map : M → R)
+(map_smul : ∀ (a : R) (x : M), map (a • x) = a * a * map x)
+(polar_add_left : ∀ (x x' y : M), polar map (x + x') y = polar map x y + polar map x' y)
+(polar_smul_left : ∀ (a : R) (x y : M), polar map (a • x) y = a • polar map x y)
+(polar_add_right : ∀ (x y y' : M), polar map x (y + y') = polar map x y + polar map x y')
+(polar_smul_right : ∀ (a : R) (x y : M), polar map x (a • y) = a • polar map x y)
+
+namespace quadratic_form
+
+variables {Q : quadratic_form R M}
+
+instance : has_coe_to_fun (quadratic_form R M) :=
+⟨_, λ B, B.map⟩
+
+/-- The `simp` normal form for a quadratic form is `coe_fn`, not `map`. -/
+@[simp] lemma map_eq_apply : Q.map = ⇑ Q := rfl
+
+lemma apply_smul (a : R) (x : M) : Q (a • x) = a * a * Q x := Q.map_smul a x
+
+lemma apply_add_self (x : M) : Q (x + x) = 4 * Q x :=
+by { rw [←one_smul R x, ←add_smul, apply_smul], norm_num }
+
+lemma apply_zero : Q 0 = 0 :=
+by rw [←@zero_smul R _ _ _ _ (0 : M), apply_smul, zero_mul, zero_mul]
+
+lemma apply_neg (x : M) : Q (-x) = Q x :=
+by rw [←@neg_one_smul R _ _ _ _ x, apply_smul, neg_one_mul, neg_neg, one_mul]
+
+lemma apply_sub (x y : M) : Q (x - y) = Q (y - x) :=
+by rw [←neg_sub, apply_neg]
+
+variable {Q' : quadratic_form R M}
+@[ext] lemma ext (H : ∀ (x : M), Q x = Q' x) : Q = Q' :=
+by { cases Q, cases Q', congr, funext, apply H }
+
+instance : has_zero (quadratic_form R M) :=
+⟨ { map := λ x, 0,
+    map_smul := λ a x, by simp,
+    polar_add_left := λ x x' y, by simp [polar],
+    polar_smul_left := λ a x y, by simp [polar],
+    polar_add_right := λ x y y', by simp [polar],
+    polar_smul_right := λ a x y, by simp [polar] } ⟩
+
+instance : inhabited (quadratic_form R M) := ⟨0⟩
+
+instance : has_scalar R₁ (quadratic_form R₁ M) :=
+⟨ λ a Q,
+  { map := λ x, Q (a • x),
+    map_smul := λ b x, by rw [smul_comm, apply_smul],
+    polar_add_left := λ x x' y,
+      by convert Q.polar_add_left (a • x) (a • x') (a • y) using 1; simp [polar, smul_add],
+    polar_smul_left := λ b x y,
+      by convert Q.polar_smul_left b (a • x) (a • y) using 1; simp [polar, smul_add, smul_comm],
+    polar_add_right := λ x y y',
+      by convert Q.polar_add_right (a • x) (a • y) (a • y') using 1; simp [polar, smul_add],
+    polar_smul_right := λ b x y,
+      by convert Q.polar_smul_right b (a • x) (a • y) using 1; simp [polar, smul_add, smul_comm] } ⟩
+
+@[simp] lemma smul_apply (a : R₁) (Q : quadratic_form R₁ M) (x : M) : (a • Q) x = Q (a • x) := rfl
+
+instance : mul_action R₁ (quadratic_form R₁ M) :=
+{ mul_smul := λ a b Q, ext (λ x, by simp [mul_smul, smul_comm]),
+  one_smul := λ Q, ext (λ x, by simp),
+  ..quadratic_form.has_scalar }
+
+section comp
+
+variables {N : Type v} [add_comm_group N] [module R N]
+
+/-- Compose the quadratic form with a linear function. -/
+def comp (Q : quadratic_form R N) (f : M →ₗ[R] N) :
+  quadratic_form R M :=
+{ map := λ x, Q (f x),
+  map_smul := λ a x, by simp [apply_smul],
+  polar_add_left := λ x x' y,
+    by convert Q.polar_add_left (f x) (f x') (f y) using 1; simp [polar],
+  polar_smul_left := λ a x y,
+    by convert Q.polar_smul_left a (f x) (f y) using 1; simp [polar],
+  polar_add_right := λ x y y',
+    by convert Q.polar_add_right (f x) (f y) (f y') using 1; simp [polar],
+  polar_smul_right := λ a x y,
+    by convert Q.polar_smul_right a (f x) (f y) using 1; simp [polar] }
+
+@[simp] lemma comp_apply (Q : quadratic_form R N) (f : M →ₗ[R] N) (x : M) :
+  (Q.comp f) x = Q (f x) := rfl
+
+end comp
+
+end quadratic_form
+
+/-! ### Associated bilinear forms
+
+Over a commutative ring where 2⁻¹ exists, the theory of quadratic forms is
+basically identical to that of symmetric bilinear forms. The map from quadratic
+forms to bilinear forms giving this identification is called the `associated`
+quadratic form.
+-/
+
+variables {B : bilin_form R M}
+
+namespace bilin_form
+open quadratic_form
+
+lemma polar_to_quadratic_form (x y : M) : polar (λ x, B x x) x y = B x y + B y x :=
+by simp [polar, add_left, add_right, sub_eq_add_neg _ (B y y), add_comm (B y x) _]
+
+/-- A bilinear form gives a quadratic form by applying the argument twice. -/
+def to_quadratic_form (B : bilin_form R M) : quadratic_form R M :=
+⟨ λ x, B x x,
+  λ a x, by simp [smul_left, smul_right, mul_assoc],
+  λ x x' y, by simp [polar_to_quadratic_form, add_left, add_right, add_left_comm],
+  λ a x y, by simp [polar_to_quadratic_form, smul_left, smul_right, mul_add],
+  λ x y y', by simp [polar_to_quadratic_form, add_left, add_right, add_left_comm],
+  λ a x y, by simp [polar_to_quadratic_form, smul_left, smul_right, mul_add] ⟩
+
+@[simp] lemma to_quadratic_form_apply (B : bilin_form R M) :
+(B.to_quadratic_form : M → R) = λ x, B x x :=
+rfl
+
+end bilin_form
+
+namespace quadratic_form
+open bilin_form sym_bilin_form
+
+section associated
+variables [has_inv R₁] {B₁ : bilin_form R₁ M}
+/-- `Q.associated` is the symmetric bilinear form associated to a quadratic form `Q`. -/
+def associated (Q : quadratic_form R₁ M) : bilin_form R₁ M :=
+{ bilin := λ x y, 2⁻¹ * polar Q x y,
+  bilin_add_left := λ x y z, by { erw [← mul_add, Q.polar_add_left], refl },
+  bilin_smul_left := λ x y z, by { erw [← mul_left_comm, Q.polar_smul_left], refl },
+  bilin_add_right := λ x y z, by { erw [← mul_add, Q.polar_add_right], refl },
+  bilin_smul_right := λ x y z, by { erw [← mul_left_comm, Q.polar_smul_right], refl } }
+
+@[simp] lemma associated_apply (Q : quadratic_form R₁ M) (x y : M) :
+  Q.associated x y = 2⁻¹ * (Q (x + y) - Q x - Q y) := rfl
+
+lemma ssociated_is_sym (Q : quadratic_form R₁ M) : is_sym Q.associated :=
+λ x y, by simp [add_comm, add_left_comm, sub_eq_add_neg]
+
+@[simp] lemma associated_smul (a : R₁) (Q : quadratic_form R₁ M) :
+  (a • Q).associated = (a * a) • Q.associated :=
+by { ext, simp [bilin_form.smul_apply, apply_smul, mul_sub, mul_left_comm] }
+
+@[simp] lemma associated_comp {N : Type v} [add_comm_group N] [module R₁ N]
+  (Q : quadratic_form R₁ N) (f : M →ₗ[R₁] N) : associated (Q.comp f) = Q.associated.comp f f :=
+by { ext, simp }
+
+lemma associated_to_quadratic_form (B : bilin_form R₁ M) (x y : M) :
+  associated (B.to_quadratic_form) x y = 2⁻¹ * (B x y + B y x) :=
+by simp [associated_apply, ←polar_to_quadratic_form, polar]
+
+lemma associated_left_inverse (h : is_sym B₁) (two_inv : (2⁻¹ : R₁) * 2 = 1) :
+  associated B₁.to_quadratic_form = B₁ :=
+bilin_form.ext $ λ x y,
+by rw [associated_to_quadratic_form, sym h x y, ←two_mul, ←mul_assoc, two_inv, one_mul]
+
+lemma associated_right_inverse (Q : quadratic_form R₁ M) (two_inv : (2⁻¹ : R₁) * 2 = 1) :
+  (associated Q).to_quadratic_form = Q :=
+quadratic_form.ext $ λ x,
+  calc  (associated Q).to_quadratic_form x
+      = 2⁻¹ * (Q x + Q x) : by simp [apply_add_self, bit0, add_mul]
+  ... = Q x : by rw [← two_mul (Q x), ←mul_assoc, two_inv, one_mul]
+end associated
+
+section pos_def
+
+variables {R₂ : Type u} [ordered_ring R₂] [module R₂ M] {Q₂ : quadratic_form R₂ M}
+
+/-- A positive definite quadratic form is positive on nonzero vectors. -/
+def pos_def (Q₂ : quadratic_form R₂ M) : Prop := ∀ x ≠ 0, 0 < Q₂ x
+
+lemma smul_pos_def_of_smul_nonzero {R} [linear_ordered_comm_ring R] [module R M]
+  {Q : quadratic_form R M} (h : pos_def Q) {a : R} : (∀ x ≠ (0 : M), a • x ≠ 0) → pos_def (a • Q) :=
+λ ha x hx, h (a • x) (ha x hx)
+
+lemma smul_pos_def_of_nonzero {K : Type u} [linear_ordered_field K] [module K M]
+  {Q : quadratic_form K M} (h : pos_def Q) {a : K} : a ≠ 0 → pos_def (a • Q) :=
+λ ha x hx, h (a • x) (λ hax, (smul_eq_zero.mp hax).elim ha hx)
+
+end pos_def
+end quadratic_form
+
+/-! ### Quadratic forms and matrices
+
+Connect quadratic forms and matrices, in order to explicitly compute with them.
+The convention is twos out, so there might be a factor 2⁻¹ in the entries of the
+matrix.
+The determinant of the matrix is the discriminant of the quadratic form.
+-/
+
+variables {n : Type w} [fintype n] [decidable_eq n]
+
+/-- A matrix representation of the quadratic form. -/
+def quadratic_form.to_matrix [has_inv R₁] (Q : quadratic_form R₁ (n → R₁)) : matrix n n R₁ :=
+Q.associated.to_matrix
+
+open quadratic_form
+lemma quadratic_form.to_matrix_smul [has_inv R₁] (a : R₁) (Q : quadratic_form R₁ (n → R₁)) :
+  (a • Q).to_matrix = (a * a) • Q.to_matrix :=
+by simp_rw [to_matrix, associated_smul, mul_smul, bilin_form.to_matrix_smul]
+
+/-- `M.to_quadratic_form` is the map `λ x, col x ⬝ M ⬝ row x` as a quadratic form. -/
+def matrix.to_quadratic_form (M : matrix n n R₁) : quadratic_form R₁ (n → R₁) :=
+M.to_bilin_form.to_quadratic_form
+
+namespace quadratic_form
+
+variables {m : Type w} [fintype m] [decidable_eq m]
+open_locale matrix
+
+@[simp]
+lemma to_matrix_comp [has_inv R₁] (Q : quadratic_form R₁ (m → R₁)) (f : (n → R₁) →ₗ[R₁] (m → R₁)) :
+  (Q.comp f).to_matrix = f.to_matrixᵀ ⬝ Q.to_matrix ⬝ f.to_matrix :=
+by { ext, simp [to_matrix, bilin_form.to_matrix_comp] }
+
+section discriminant
+variables [has_inv R₁] {Q : quadratic_form R₁ (n → R₁)}
+
+/-- The discriminant of a quadratic form generalizes the discriminant of a quadratic polynomial. -/
+def discr (Q : quadratic_form R₁ (n → R₁)) : R₁ := Q.to_matrix.det
+
+lemma discr_smul (a : R₁) : discr (a • Q) = (a * a) ^ fintype.card n * discr Q :=
+by simp [discr, to_matrix_smul]
+
+lemma discr_comp (f : (n → R₁) →ₗ[R₁] (n → R₁)) :
+  discr (Q.comp f) = f.to_matrix.det * f.to_matrix.det * discr Q :=
+by simp [discr, mul_left_comm, mul_comm]
+
+end discriminant
+
+end quadratic_form

--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -6,6 +6,7 @@ Author: Anne Baanen
 Quadratic forms over modules.
 -/
 
+import algebra.invertible
 import linear_algebra.bilinear_form
 import linear_algebra.determinant
 import linear_algebra.special_linear_group
@@ -159,10 +160,10 @@ end quadratic_form
 
 /-! ### Associated bilinear forms
 
-Over a commutative ring with an inverse of 2 (`two_inv`), the theory of
-quadratic forms is basically identical to that of symmetric bilinear forms. The
-map from quadratic forms to bilinear forms giving this identification is called
-the `associated` quadratic form.
+Over a commutative ring with an inverse of 2, the theory of quadratic forms is
+basically identical to that of symmetric bilinear forms. The map from quadratic
+forms to bilinear forms giving this identification is called the `associated`
+quadratic form.
 -/
 
 variables {B : bilin_form R M}
@@ -192,51 +193,44 @@ namespace quadratic_form
 open bilin_form sym_bilin_form
 
 section associated
-variables {B₁ : bilin_form R₁ M} (Q : quadratic_form R₁ M) (two_inv : {half : R₁ // half * 2 = 1})
-
-@[simp] lemma two_inv_mul_two : (two_inv : R₁) * 2 = 1 := two_inv.2
-
-/-- `2⁻¹` is an inverse of `2` in a field with characteristic 0 -/
-def two_inv_of_char_zero_field {K : Type u} [field K] [char_zero K] :
-  {half : K // half * 2 = 1} :=
-⟨2⁻¹, inv_mul_cancel two_ne_zero'⟩
+variables [invertible (2 : R₁)] {B₁ : bilin_form R₁ M} (Q : quadratic_form R₁ M)
 
 /-- `Q.associated` is the symmetric bilinear form associated to a quadratic form `Q`. -/
 def associated : bilin_form R₁ M :=
-{ bilin := λ x y, two_inv * polar Q x y,
+{ bilin := λ x y, ⅟2 * polar Q x y,
   bilin_add_left := λ x y z, by { erw [← mul_add, Q.polar_add_left], refl },
   bilin_smul_left := λ x y z, by { erw [← mul_left_comm, Q.polar_smul_left], refl },
   bilin_add_right := λ x y z, by { erw [← mul_add, Q.polar_add_right], refl },
   bilin_smul_right := λ x y z, by { erw [← mul_left_comm, Q.polar_smul_right], refl } }
 
 @[simp] lemma associated_apply (x y : M) :
-  Q.associated two_inv x y = two_inv * (Q (x + y) - Q x - Q y) := rfl
+  Q.associated x y = ⅟2 * (Q (x + y) - Q x - Q y) := rfl
 
-lemma associated_is_sym : is_sym (Q.associated two_inv) :=
+lemma associated_is_sym : is_sym Q.associated :=
 λ x y, by simp [add_comm, add_left_comm, sub_eq_add_neg]
 
 @[simp] lemma associated_smul (a : R₁) :
-  (a • Q).associated two_inv = (a * a) • Q.associated two_inv :=
+  (a • Q).associated = (a * a) • Q.associated :=
 by { ext, simp [bilin_form.smul_apply, map_smul, mul_sub, mul_left_comm] }
 
 @[simp] lemma associated_comp {N : Type v} [add_comm_group N] [module R₁ N] (f : N →ₗ[R₁] M) :
-  (Q.comp f).associated two_inv = (Q.associated two_inv).comp f f :=
+  (Q.comp f).associated = Q.associated.comp f f :=
 by { ext, simp }
 
 lemma associated_to_quadratic_form (B : bilin_form R₁ M) (x y : M) :
-  B.to_quadratic_form.associated two_inv x y = two_inv * (B x y + B y x) :=
+  B.to_quadratic_form.associated x y = ⅟2 * (B x y + B y x) :=
 by simp [associated_apply, ←polar_to_quadratic_form, polar]
 
-lemma associated_left_inverse_of_two_inv (h : is_sym B₁) :
-  B₁.to_quadratic_form.associated two_inv = B₁ :=
+lemma associated_left_inverse (h : is_sym B₁) :
+  B₁.to_quadratic_form.associated = B₁ :=
 bilin_form.ext $ λ x y,
-by rw [associated_to_quadratic_form, sym h x y, ←two_mul, ←mul_assoc, two_inv_mul_two, one_mul]
+by rw [associated_to_quadratic_form, sym h x y, ←two_mul, ←mul_assoc, inv_of_mul_self, one_mul]
 
-lemma associated_right_inverse_of_two_inv : (Q.associated two_inv).to_quadratic_form = Q :=
+lemma associated_right_inverse : Q.associated.to_quadratic_form = Q :=
 quadratic_form.ext $ λ x,
-  calc  (Q.associated two_inv).to_quadratic_form x
-      = two_inv * (Q x + Q x) : by simp [map_add_self, bit0, add_mul]
-  ... = Q x : by rw [← two_mul (Q x), ←mul_assoc, two_inv_mul_two, one_mul]
+  calc  Q.associated.to_quadratic_form x
+      = ⅟2 * (Q x + Q x) : by simp [map_add_self, bit0, add_mul]
+  ... = Q x : by rw [← two_mul (Q x), ←mul_assoc, inv_of_mul_self, one_mul]
 end associated
 
 section pos_def
@@ -271,16 +265,16 @@ variables {n : Type w} [fintype n]
 def matrix.to_quadratic_form (M : matrix n n R₁) : quadratic_form R₁ (n → R₁) :=
 M.to_bilin_form.to_quadratic_form
 
-variables [decidable_eq n] (two_inv : {half : R₁ // half * 2 = 1})
+variables [decidable_eq n] [invertible (2 : R₁)]
 
 /-- A matrix representation of the quadratic form. -/
 def quadratic_form.to_matrix (Q : quadratic_form R₁ (n → R₁)) :
   matrix n n R₁ :=
-(Q.associated two_inv).to_matrix
+Q.associated.to_matrix
 
 open quadratic_form
 lemma quadratic_form.to_matrix_smul (a : R₁) (Q : quadratic_form R₁ (n → R₁)) :
-  (a • Q).to_matrix two_inv = (a * a) • Q.to_matrix two_inv :=
+  (a • Q).to_matrix = (a * a) • Q.to_matrix :=
 by simp_rw [to_matrix, associated_smul, mul_smul, bilin_form.to_matrix_smul]
 
 namespace quadratic_form
@@ -290,20 +284,20 @@ open_locale matrix
 
 @[simp]
 lemma to_matrix_comp (Q : quadratic_form R₁ (m → R₁)) (f : (n → R₁) →ₗ[R₁] (m → R₁)) :
-  (Q.comp f).to_matrix two_inv = f.to_matrixᵀ ⬝ Q.to_matrix two_inv ⬝ f.to_matrix :=
+  (Q.comp f).to_matrix = f.to_matrixᵀ ⬝ Q.to_matrix ⬝ f.to_matrix :=
 by { ext, simp [to_matrix, bilin_form.to_matrix_comp] }
 
 section discriminant
 variables {Q : quadratic_form R₁ (n → R₁)}
 
 /-- The discriminant of a quadratic form generalizes the discriminant of a quadratic polynomial. -/
-def discr (Q : quadratic_form R₁ (n → R₁)) : R₁ := (Q.to_matrix two_inv).det
+def discr (Q : quadratic_form R₁ (n → R₁)) : R₁ := Q.to_matrix.det
 
-lemma discr_smul (a : R₁) : (a • Q).discr two_inv = (a * a) ^ fintype.card n * Q.discr two_inv :=
+lemma discr_smul (a : R₁) : (a • Q).discr = (a * a) ^ fintype.card n * Q.discr :=
 by simp [discr, to_matrix_smul]
 
 lemma discr_comp (f : (n → R₁) →ₗ[R₁] (n → R₁)) :
-  (Q.comp f).discr two_inv = f.to_matrix.det * f.to_matrix.det * Q.discr two_inv :=
+  (Q.comp f).discr = f.to_matrix.det * f.to_matrix.det * Q.discr :=
 by simp [discr, mul_left_comm, mul_comm]
 
 end discriminant

--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -55,7 +55,10 @@ universes u v w
 variables {R : Type u} {M : Type v} [add_comm_group M] [ring R]
 variables {R₁ : Type u} [comm_ring R₁] [module R₁ M]
 
-/-- Up to a factor 2, `Q.polar` is the associated bilinear form for a quadratic form `Q`. -/
+/-- Up to a factor 2, `Q.polar` is the associated bilinear form for a quadratic form `Q`.d
+
+Source of this name: https://en.wikipedia.org/wiki/Quadratic_form#Generalization
+-/
 def quadratic_form.polar (f : M → R) (x y : M) :=
 f (x + y) - f x - f y
 

--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -196,6 +196,7 @@ variables {B₁ : bilin_form R₁ M} (Q : quadratic_form R₁ M) (two_inv : {hal
 
 @[simp] lemma two_inv_mul_two : (two_inv : R₁) * 2 = 1 := two_inv.2
 
+/-- `2⁻¹` is an inverse of `2` in a field with characteristic 0 -/
 def two_inv_of_char_zero_field {K : Type u} [field K] [char_zero K] :
   {half : K // half * 2 = 1} :=
 ⟨2⁻¹, inv_mul_cancel two_ne_zero'⟩

--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -247,20 +247,22 @@ matrix.
 The determinant of the matrix is the discriminant of the quadratic form.
 -/
 
-variables {n : Type w} [fintype n] [decidable_eq n]
-
-/-- A matrix representation of the quadratic form. -/
-def quadratic_form.to_matrix [has_inv R₁] (Q : quadratic_form R₁ (n → R₁)) : matrix n n R₁ :=
-Q.associated.to_matrix
-
-open quadratic_form
-lemma quadratic_form.to_matrix_smul [has_inv R₁] (a : R₁) (Q : quadratic_form R₁ (n → R₁)) :
-  (a • Q).to_matrix = (a * a) • Q.to_matrix :=
-by simp_rw [to_matrix, associated_smul, mul_smul, bilin_form.to_matrix_smul]
+variables {n : Type w} [fintype n]
 
 /-- `M.to_quadratic_form` is the map `λ x, col x ⬝ M ⬝ row x` as a quadratic form. -/
 def matrix.to_quadratic_form (M : matrix n n R₁) : quadratic_form R₁ (n → R₁) :=
 M.to_bilin_form.to_quadratic_form
+
+variables [decidable_eq n] [has_inv R₁]
+/-- A matrix representation of the quadratic form. -/
+def quadratic_form.to_matrix (Q : quadratic_form R₁ (n → R₁)) :
+  matrix n n R₁ :=
+Q.associated.to_matrix
+
+open quadratic_form
+lemma quadratic_form.to_matrix_smul (a : R₁) (Q : quadratic_form R₁ (n → R₁)) :
+  (a • Q).to_matrix = (a * a) • Q.to_matrix :=
+by simp_rw [to_matrix, associated_smul, mul_smul, bilin_form.to_matrix_smul]
 
 namespace quadratic_form
 
@@ -268,12 +270,12 @@ variables {m : Type w} [fintype m] [decidable_eq m]
 open_locale matrix
 
 @[simp]
-lemma to_matrix_comp [has_inv R₁] (Q : quadratic_form R₁ (m → R₁)) (f : (n → R₁) →ₗ[R₁] (m → R₁)) :
+lemma to_matrix_comp (Q : quadratic_form R₁ (m → R₁)) (f : (n → R₁) →ₗ[R₁] (m → R₁)) :
   (Q.comp f).to_matrix = f.to_matrixᵀ ⬝ Q.to_matrix ⬝ f.to_matrix :=
 by { ext, simp [to_matrix, bilin_form.to_matrix_comp] }
 
 section discriminant
-variables [has_inv R₁] {Q : quadratic_form R₁ (n → R₁)}
+variables {Q : quadratic_form R₁ (n → R₁)}
 
 /-- The discriminant of a quadratic form generalizes the discriminant of a quadratic polynomial. -/
 def discr (Q : quadratic_form R₁ (n → R₁)) : R₁ := Q.to_matrix.det

--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -196,7 +196,7 @@ variables {B₁ : bilin_form R₁ M} (Q : quadratic_form R₁ M) (two_inv : {hal
 
 @[simp] lemma two_inv_mul_two : (two_inv : R₁) * 2 = 1 := two_inv.2
 
-lemma two_inv_of_char_zero_field {K : Type u} [field K] [char_zero K] :
+def two_inv_of_char_zero_field {K : Type u} [field K] [char_zero K] :
   {half : K // half * 2 = 1} :=
 ⟨2⁻¹, inv_mul_cancel two_ne_zero'⟩
 

--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -193,7 +193,7 @@ def associated (Q : quadratic_form R₁ M) : bilin_form R₁ M :=
 @[simp] lemma associated_apply (Q : quadratic_form R₁ M) (x y : M) :
   Q.associated x y = 2⁻¹ * (Q (x + y) - Q x - Q y) := rfl
 
-lemma ssociated_is_sym (Q : quadratic_form R₁ M) : is_sym Q.associated :=
+lemma associated_is_sym (Q : quadratic_form R₁ M) : is_sym Q.associated :=
 λ x y, by simp [add_comm, add_left_comm, sub_eq_add_neg]
 
 @[simp] lemma associated_smul (a : R₁) (Q : quadratic_form R₁ M) :

--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -15,7 +15,7 @@ import linear_algebra.special_linear_group
 
 This file defines quadratic forms over a `R`-module `M`.
 A quadratic form is a map `Q : M → R` such that
-  (`map_smul`) `Q (a • x) = a * a * Q x`
+  (`to_fun_smul`) `Q (a • x) = a * a * Q x`
   (`polar_...`) The map `polar Q := λ x y, Q (x + y) - Q x - Q y` is bilinear.
 They come with a scalar multiplication, `(a • Q) x = Q (a • x) = a * a * Q x`,
 and composition with linear maps `f`, `Q.comp f x = Q (f x)`.
@@ -32,6 +32,14 @@ and composition with linear maps `f`, `Q.comp f x = Q (f x)`.
  * `quadratic_form.associated_right_inverse`: in a commutative ring where 2 has
   an inverse, there is a correspondence between quadratic forms and symmetric
   bilinear forms
+
+## Notation
+
+In this file, the variable `R` is used when a `ring` structure is sufficient and
+`R₁` is used when specifically a `comm_ring` is required. This allows us to keep
+`[module R M]` and `[module R₁ M]` assumptions in the variables without
+confusion between `*` from `ring` and `*` from `comm_ring`.
+
 
 ## References
 
@@ -56,44 +64,44 @@ variables [module R M]
 open quadratic_form
 /-- A quadratic form over a module. -/
 structure quadratic_form (R : Type u) (M : Type v) [ring R] [add_comm_group M] [module R M] :=
-(map : M → R)
-(map_smul : ∀ (a : R) (x : M), map (a • x) = a * a * map x)
-(polar_add_left : ∀ (x x' y : M), polar map (x + x') y = polar map x y + polar map x' y)
-(polar_smul_left : ∀ (a : R) (x y : M), polar map (a • x) y = a • polar map x y)
-(polar_add_right : ∀ (x y y' : M), polar map x (y + y') = polar map x y + polar map x y')
-(polar_smul_right : ∀ (a : R) (x y : M), polar map x (a • y) = a • polar map x y)
+(to_fun : M → R)
+(to_fun_smul : ∀ (a : R) (x : M), to_fun (a • x) = a * a * to_fun x)
+(polar_add_left : ∀ (x x' y : M), polar to_fun (x + x') y = polar to_fun x y + polar to_fun x' y)
+(polar_smul_left : ∀ (a : R) (x y : M), polar to_fun (a • x) y = a • polar to_fun x y)
+(polar_add_right : ∀ (x y y' : M), polar to_fun x (y + y') = polar to_fun x y + polar to_fun x y')
+(polar_smul_right : ∀ (a : R) (x y : M), polar to_fun x (a • y) = a • polar to_fun x y)
 
 namespace quadratic_form
 
 variables {Q : quadratic_form R M}
 
 instance : has_coe_to_fun (quadratic_form R M) :=
-⟨_, λ B, B.map⟩
+⟨_, λ B, B.to_fun⟩
 
-/-- The `simp` normal form for a quadratic form is `coe_fn`, not `map`. -/
-@[simp] lemma map_eq_apply : Q.map = ⇑ Q := rfl
+/-- The `simp` normal form for a quadratic form is `coe_fn`, not `to_fun`. -/
+@[simp] lemma to_fun_eq_apply : Q.to_fun = ⇑ Q := rfl
 
-lemma apply_smul (a : R) (x : M) : Q (a • x) = a * a * Q x := Q.map_smul a x
+lemma map_smul (a : R) (x : M) : Q (a • x) = a * a * Q x := Q.to_fun_smul a x
 
-lemma apply_add_self (x : M) : Q (x + x) = 4 * Q x :=
-by { rw [←one_smul R x, ←add_smul, apply_smul], norm_num }
+lemma map_add_self (x : M) : Q (x + x) = 4 * Q x :=
+by { rw [←one_smul R x, ←add_smul, map_smul], norm_num }
 
-lemma apply_zero : Q 0 = 0 :=
-by rw [←@zero_smul R _ _ _ _ (0 : M), apply_smul, zero_mul, zero_mul]
+lemma map_zero : Q 0 = 0 :=
+by rw [←@zero_smul R _ _ _ _ (0 : M), map_smul, zero_mul, zero_mul]
 
-lemma apply_neg (x : M) : Q (-x) = Q x :=
-by rw [←@neg_one_smul R _ _ _ _ x, apply_smul, neg_one_mul, neg_neg, one_mul]
+lemma map_neg (x : M) : Q (-x) = Q x :=
+by rw [←@neg_one_smul R _ _ _ _ x, map_smul, neg_one_mul, neg_neg, one_mul]
 
-lemma apply_sub (x y : M) : Q (x - y) = Q (y - x) :=
-by rw [←neg_sub, apply_neg]
+lemma map_sub (x y : M) : Q (x - y) = Q (y - x) :=
+by rw [←neg_sub, map_neg]
 
 variable {Q' : quadratic_form R M}
 @[ext] lemma ext (H : ∀ (x : M), Q x = Q' x) : Q = Q' :=
 by { cases Q, cases Q', congr, funext, apply H }
 
 instance : has_zero (quadratic_form R M) :=
-⟨ { map := λ x, 0,
-    map_smul := λ a x, by simp,
+⟨ { to_fun := λ x, 0,
+    to_fun_smul := λ a x, by simp,
     polar_add_left := λ x x' y, by simp [polar],
     polar_smul_left := λ a x y, by simp [polar],
     polar_add_right := λ x y y', by simp [polar],
@@ -103,8 +111,8 @@ instance : inhabited (quadratic_form R M) := ⟨0⟩
 
 instance : has_scalar R₁ (quadratic_form R₁ M) :=
 ⟨ λ a Q,
-  { map := λ x, Q (a • x),
-    map_smul := λ b x, by rw [smul_comm, apply_smul],
+  { to_fun := λ x, Q (a • x),
+    to_fun_smul := λ b x, by rw [smul_comm, map_smul],
     polar_add_left := λ x x' y,
       by convert Q.polar_add_left (a • x) (a • x') (a • y) using 1; simp [polar, smul_add],
     polar_smul_left := λ b x y,
@@ -128,8 +136,8 @@ variables {N : Type v} [add_comm_group N] [module R N]
 /-- Compose the quadratic form with a linear function. -/
 def comp (Q : quadratic_form R N) (f : M →ₗ[R] N) :
   quadratic_form R M :=
-{ map := λ x, Q (f x),
-  map_smul := λ a x, by simp [apply_smul],
+{ to_fun := λ x, Q (f x),
+  to_fun_smul := λ a x, by simp [map_smul],
   polar_add_left := λ x x' y,
     by convert Q.polar_add_left (f x) (f x') (f y) using 1; simp [polar],
   polar_smul_left := λ a x y,
@@ -171,8 +179,8 @@ def to_quadratic_form (B : bilin_form R M) : quadratic_form R M :=
   λ x y y', by simp [polar_to_quadratic_form, add_left, add_right, add_left_comm],
   λ a x y, by simp [polar_to_quadratic_form, smul_left, smul_right, mul_add] ⟩
 
-@[simp] lemma to_quadratic_form_apply (B : bilin_form R M) :
-(B.to_quadratic_form : M → R) = λ x, B x x :=
+@[simp] lemma to_quadratic_form_apply (B : bilin_form R M) (x : M) :
+B.to_quadratic_form x = B x x :=
 rfl
 
 end bilin_form
@@ -198,7 +206,7 @@ lemma associated_is_sym (Q : quadratic_form R₁ M) : is_sym Q.associated :=
 
 @[simp] lemma associated_smul (a : R₁) (Q : quadratic_form R₁ M) :
   (a • Q).associated = (a * a) • Q.associated :=
-by { ext, simp [bilin_form.smul_apply, apply_smul, mul_sub, mul_left_comm] }
+by { ext, simp [bilin_form.smul_apply, map_smul, mul_sub, mul_left_comm] }
 
 @[simp] lemma associated_comp {N : Type v} [add_comm_group N] [module R₁ N]
   (Q : quadratic_form R₁ N) (f : M →ₗ[R₁] N) : associated (Q.comp f) = Q.associated.comp f f :=
@@ -217,7 +225,7 @@ lemma associated_right_inverse (Q : quadratic_form R₁ M) (two_inv : (2⁻¹ : 
   (associated Q).to_quadratic_form = Q :=
 quadratic_form.ext $ λ x,
   calc  (associated Q).to_quadratic_form x
-      = 2⁻¹ * (Q x + Q x) : by simp [apply_add_self, bit0, add_mul]
+      = 2⁻¹ * (Q x + Q x) : by simp [map_add_self, bit0, add_mul]
   ... = Q x : by rw [← two_mul (Q x), ←mul_assoc, two_inv, one_mul]
 end associated
 


### PR DESCRIPTION
Define quadratic forms over a module, maps from quadratic forms to bilinear forms and matrices, positive definite quadratic forms and the discriminant of quadratic forms.

Along the way, I added some definitions to `data/matrix/basic.lean` and `linear_algebra/bilinear_form.lean` and did some cleaning up.

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
