### PR TITLE
[Merged by Bors] - chore(data/list/*): various renamings to use dot notation

### DIFF
--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -756,7 +756,7 @@ def perms_of_finset (s : finset α) : finset (perm α) :=
 quotient.hrec_on s.1 (λ l hl, ⟨perms_of_list l, nodup_perms_of_list hl⟩)
   (λ a b hab, hfunext (congr_arg _ (quotient.sound hab))
     (λ ha hb _, heq_of_eq $ finset.ext.2 $
-      by simp [mem_perms_of_list_iff,mem_of_perm hab]))
+      by simp [mem_perms_of_list_iff, hab.mem_iff]))
   s.2
 
 lemma mem_perms_of_finset_iff : ∀ {s : finset α} {f : perm α},

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -642,7 +642,7 @@ theorem cons_sublist_cons_iff {l₁ l₂ : list α} {a : α} : a::l₁ <+ a::l�
 | []     := iff.rfl
 | (a::l) := cons_sublist_cons_iff.trans (append_sublist_append_left l)
 
-theorem append_sublist_append_of_sublist_right {l₁ l₂ : list α} (h : l₁ <+ l₂) (l) : l₁++l <+ l₂++l :=
+theorem sublist.append_right {l₁ l₂ : list α} (h : l₁ <+ l₂) (l) : l₁++l <+ l₂++l :=
 begin
   induction h with _ _ a _ ih _ _ a _ ih,
   { refl },
@@ -659,41 +659,40 @@ begin
     { exact (IH h).imp (cons_sublist_cons _) (mem_cons_of_mem _) } }
 end
 
-theorem reverse_sublist {l₁ l₂ : list α} (h : l₁ <+ l₂) : l₁.reverse <+ l₂.reverse :=
+theorem sublist.reverse {l₁ l₂ : list α} (h : l₁ <+ l₂) : l₁.reverse <+ l₂.reverse :=
 begin
   induction h with _ _ _ _ ih _ _ a _ ih, {refl},
   { rw reverse_cons, exact sublist_append_of_sublist_left ih },
-  { rw [reverse_cons, reverse_cons], exact append_sublist_append_of_sublist_right ih [a] }
+  { rw [reverse_cons, reverse_cons], exact ih.append_right [a] }
 end
 
 @[simp] theorem reverse_sublist_iff {l₁ l₂ : list α} : l₁.reverse <+ l₂.reverse ↔ l₁ <+ l₂ :=
-⟨λ h, by have := reverse_sublist h; simp only [reverse_reverse] at this; assumption, reverse_sublist⟩
+⟨λ h, l₁.reverse_reverse ▸ l₂.reverse_reverse ▸ h.reverse, sublist.reverse⟩
 
 @[simp] theorem append_sublist_append_right {l₁ l₂ : list α} (l) : l₁++l <+ l₂++l ↔ l₁ <+ l₂ :=
-⟨λ h, by have := reverse_sublist h; simp only [reverse_append, append_sublist_append_left, reverse_sublist_iff] at this; assumption,
- λ h, append_sublist_append_of_sublist_right h l⟩
+⟨λ h, by simpa only [reverse_append, append_sublist_append_left, reverse_sublist_iff] using h.reverse,
+ λ h, h.append_right l⟩
 
-theorem append_sublist_append {l₁ l₂ r₁ r₂ : list α}
+theorem sublist.append {l₁ l₂ r₁ r₂ : list α}
   (hl : l₁ <+ l₂) (hr : r₁ <+ r₂) : l₁ ++ r₁ <+ l₂ ++ r₂ :=
-(append_sublist_append_of_sublist_right hl _).trans
-  ((append_sublist_append_left _).2 hr)
+(hl.append_right _).trans ((append_sublist_append_left _).2 hr)
 
-theorem subset_of_sublist : Π {l₁ l₂ : list α}, l₁ <+ l₂ → l₁ ⊆ l₂
+theorem sublist.subset : Π {l₁ l₂ : list α}, l₁ <+ l₂ → l₁ ⊆ l₂
 | ._ ._ sublist.slnil             b h := h
-| ._ ._ (sublist.cons  l₁ l₂ a s) b h := mem_cons_of_mem _ (subset_of_sublist s h)
+| ._ ._ (sublist.cons  l₁ l₂ a s) b h := mem_cons_of_mem _ (sublist.subset s h)
 | ._ ._ (sublist.cons2 l₁ l₂ a s) b h :=
   match eq_or_mem_of_mem_cons h with
   | or.inl h := h ▸ mem_cons_self _ _
-  | or.inr h := mem_cons_of_mem _ (subset_of_sublist s h)
+  | or.inr h := mem_cons_of_mem _ (sublist.subset s h)
   end
 
 theorem singleton_sublist {a : α} {l} : [a] <+ l ↔ a ∈ l :=
-⟨λ h, subset_of_sublist h (mem_singleton_self _), λ h,
+⟨λ h, h.subset (mem_singleton_self _), λ h,
 let ⟨s, t, e⟩ := mem_split h in e.symm ▸
   (cons_sublist_cons _ (nil_sublist _)).trans (sublist_append_right _ _)⟩
 
 theorem eq_nil_of_sublist_nil {l : list α} (s : l <+ []) : l = [] :=
-eq_nil_of_subset_nil $ subset_of_sublist s
+eq_nil_of_subset_nil $ s.subset
 
 theorem repeat_sublist_repeat (a : α) {m n} : repeat a m <+ repeat a n ↔ m ≤ n :=
 ⟨λ h, by simpa only [length_repeat] using length_le_of_sublist h,
@@ -709,7 +708,7 @@ theorem eq_of_sublist_of_length_eq : ∀ {l₁ l₂ : list α}, l₁ <+ l₂ →
 theorem eq_of_sublist_of_length_le {l₁ l₂ : list α} (s : l₁ <+ l₂) (h : length l₂ ≤ length l₁) : l₁ = l₂ :=
 eq_of_sublist_of_length_eq s (le_antisymm (length_le_of_sublist s) h)
 
-theorem sublist_antisymm {l₁ l₂ : list α} (s₁ : l₁ <+ l₂) (s₂ : l₂ <+ l₁) : l₁ = l₂ :=
+theorem sublist.antisymm {l₁ l₂ : list α} (s₁ : l₁ <+ l₂) (s₂ : l₂ <+ l₁) : l₁ = l₂ :=
 eq_of_sublist_of_length_le s₁ (length_le_of_sublist s₂)
 
 instance decidable_sublist [decidable_eq α] : ∀ (l₁ l₂ : list α), decidable (l₁ <+ l₂)
@@ -2100,15 +2099,15 @@ theorem map_filter_map_of_inv (f : α → option β) (g : β → α)
   map g (filter_map f l) = l :=
 by simp only [map_filter_map, H, filter_map_some]
 
-theorem filter_map_sublist_filter_map (f : α → option β) {l₁ l₂ : list α}
+theorem sublist.filter_map (f : α → option β) {l₁ l₂ : list α}
   (s : l₁ <+ l₂) : filter_map f l₁ <+ filter_map f l₂ :=
 by induction s with l₁ l₂ a s IH l₁ l₂ a s IH;
    simp only [filter_map]; cases f a with b;
    simp only [filter_map, IH, sublist.cons, sublist.cons2]
 
-theorem map_sublist_map (f : α → β) {l₁ l₂ : list α}
+theorem sublist.map (f : α → β) {l₁ l₂ : list α}
   (s : l₁ <+ l₂) : map f l₁ <+ map f l₂ :=
-by rw ← filter_map_eq_map; exact filter_map_sublist_filter_map _ s
+filter_map_eq_map f ▸ s.filter_map _
 
 /- filter -/
 
@@ -2123,7 +2122,7 @@ lemma filter_congr {p q : α → Prop} [decidable_pred p] [decidable_pred q]
    simp only [filter_cons_of_neg _ pa, filter_cons_of_neg _ (mt h.1.2 pa), filter_congr h.2]]; split; refl
 
 @[simp] theorem filter_subset (l : list α) : filter p l ⊆ l :=
-subset_of_sublist $ filter_sublist l
+(filter_sublist l).subset
 
 theorem of_mem_filter {a : α} : ∀ {l}, a ∈ filter p l → p a
 | (b::l) ain :=
@@ -2163,7 +2162,7 @@ theorem filter_eq_nil {l} : filter p l = [] ↔ ∀ a ∈ l, ¬p a :=
 by simp only [eq_nil_iff_forall_not_mem, mem_filter, not_and]
 
 theorem filter_sublist_filter {l₁ l₂} (s : l₁ <+ l₂) : filter p l₁ <+ filter p l₂ :=
-by rw ← filter_map_eq_filter; exact filter_map_sublist_filter_map _ s
+filter_map_eq_filter p ▸ s.filter_map _
 
 theorem filter_of_map (f : β → α) (l) : filter p (map f l) = map f (filter (p ∘ f) l) :=
 by rw [← filter_map_eq_map, filter_filter_map, filter_map_filter]; refl
@@ -2180,14 +2179,18 @@ by convert filter_eq_self.2 (λ _ _, trivial)
 @[simp] lemma filter_false {h : decidable_pred (λ a : α, false)} (l : list α) : @filter α (λ _, false) h l = [] :=
 by convert filter_eq_nil.2 (λ _ _, id)
 
-@[simp] theorem span_eq_take_drop (p : α → Prop) [decidable_pred p] : ∀ (l : list α), span p l = (take_while p l, drop_while p l)
+@[simp] theorem span_eq_take_drop (p : α → Prop) [decidable_pred p] :
+  ∀ (l : list α), span p l = (take_while p l, drop_while p l)
 | []     := rfl
-| (a::l) := if pa : p a then by simp only [span, if_pos pa, span_eq_take_drop l, take_while, drop_while]
+| (a::l) :=
+    if pa : p a then by simp only [span, if_pos pa, span_eq_take_drop l, take_while, drop_while]
     else by simp only [span, take_while, drop_while, if_neg pa]
 
-@[simp] theorem take_while_append_drop (p : α → Prop) [decidable_pred p] : ∀ (l : list α), take_while p l ++ drop_while p l = l
+@[simp] theorem take_while_append_drop (p : α → Prop) [decidable_pred p] :
+  ∀ (l : list α), take_while p l ++ drop_while p l = l
 | []     := rfl
-| (a::l) := if pa : p a then by rw [take_while, drop_while, if_pos pa, if_pos pa, cons_append, take_while_append_drop l]
+| (a::l) := if pa : p a then by rw [take_while, drop_while, if_pos pa, if_pos pa, cons_append,
+      take_while_append_drop l]
     else by rw [take_while, drop_while, if_neg pa, if_neg pa, nil_append]
 
 @[simp] theorem countp_nil (p : α → Prop) [decidable_pred p] : countp p [] = 0 := rfl
@@ -2199,8 +2202,10 @@ if_pos pa
 if_neg pa
 
 theorem countp_eq_length_filter (l) : countp p l = length (filter p l) :=
-by induction l with x l ih; [refl, by_cases (p x)]; [simp only [filter_cons_of_pos _ h, countp, ih, if_pos h],
-  simp only [countp_cons_of_neg _ h, ih, filter_cons_of_neg _ h]]; refl
+by induction l with x l ih; [refl, by_cases (p x)];
+  [simp only [filter_cons_of_pos _ h, countp, ih, if_pos h],
+   simp only [countp_cons_of_neg _ h, ih, filter_cons_of_neg _ h]]; refl
+
 local attribute [simp] countp_eq_length_filter
 
 @[simp] theorem countp_append (l₁ l₂) : countp p (l₁ ++ l₂) = countp p l₁ + countp p l₂ :=
@@ -2691,9 +2696,8 @@ lemma sublists_len_sublist_sublists' {α : Type*} : ∀ n (l : list α),
 | (n+1) []     := nil_sublist _
 | (n+1) (a::l) := begin
   rw [sublists_len_succ_cons, sublists'_cons],
-  exact append_sublist_append
-    (sublists_len_sublist_sublists' _ _)
-    (map_sublist_map _ (sublists_len_sublist_sublists' _ _))
+  exact (sublists_len_sublist_sublists' _ _).append
+    ((sublists_len_sublist_sublists' _ _).map _)
 end
 
 lemma sublists_len_sublist_of_sublist
@@ -2705,7 +2709,7 @@ begin
     rw sublists_len_succ_cons,
     apply sublist_append_left },
   { simp [sublists_len_succ_cons],
-    exact append_sublist_append IH (map_sublist_map _ (IHn s)) }
+    exact IH.append ((IHn s).map _) }
 end
 
 lemma length_of_sublists_len {α : Type*} : ∀ {n} {l l' : list α},
@@ -2734,7 +2738,7 @@ end
 @[simp] lemma mem_sublists_len {α : Type*} {n} {l l' : list α} :
   l' ∈ sublists_len n l ↔ l' <+ l ∧ length l' = n :=
 ⟨λ h, ⟨mem_sublists'.1
-    (subset_of_sublist (sublists_len_sublist_sublists' _ _) h),
+    ((sublists_len_sublist_sublists' _ _).subset h),
   length_of_sublists_len h⟩,
 λ ⟨h₁, h₂⟩, h₂ ▸ mem_sublists_len_self h₁⟩
 
@@ -2862,9 +2866,9 @@ by rcases exists_or_eq_self_of_erasep p l with h | ⟨c, l₁, l₂, h₁, h₂,
    [rw h, {rw [h₄, h₃], simp}]
 
 theorem erasep_subset (l : list α) : l.erasep p ⊆ l :=
-subset_of_sublist (erasep_sublist l)
+(erasep_sublist l).subset
 
-theorem erasep_sublist_erasep {l₁ l₂ : list α} (s : l₁ <+ l₂) : l₁.erasep p <+ l₂.erasep p :=
+theorem sublist.erasep {l₁ l₂ : list α} (s : l₁ <+ l₂) : l₁.erasep p <+ l₂.erasep p :=
 begin
   induction s,
   case list.sublist.slnil { refl },
@@ -2943,10 +2947,10 @@ theorem erase_sublist (a : α) (l : list α) : l.erase a <+ l :=
 by rw erase_eq_erasep; apply erasep_sublist
 
 theorem erase_subset (a : α) (l : list α) : l.erase a ⊆ l :=
-subset_of_sublist (erase_sublist a l)
+(erase_sublist a l).subset
 
-theorem erase_sublist_erase (a : α) {l₁ l₂ : list α} (h : l₁ <+ l₂) : l₁.erase a <+ l₂.erase a :=
-by simp [erase_eq_erasep]; exact erasep_sublist_erasep h
+theorem sublist.erase (a : α) {l₁ l₂ : list α} (h : l₁ <+ l₂) : l₁.erase a <+ l₂.erase a :=
+by simp [erase_eq_erasep]; exact sublist.erasep h
 
 theorem mem_of_mem_erase {a b : α} {l : list α} : a ∈ l.erase b → a ∈ l :=
 @erase_subset _ _ _ _ _
@@ -3033,24 +3037,24 @@ theorem diff_sublist : ∀ l₁ l₂ : list α, l₁.diff l₂ <+ l₁
   ... <+ l₁ : list.erase_sublist _ _
 
 theorem diff_subset (l₁ l₂ : list α) : l₁.diff l₂ ⊆ l₁ :=
-subset_of_sublist $ diff_sublist _ _
+(diff_sublist _ _).subset
 
 theorem mem_diff_of_mem {a : α} : ∀ {l₁ l₂ : list α}, a ∈ l₁ → a ∉ l₂ → a ∈ l₁.diff l₂
 | l₁ []      h₁ h₂ := h₁
 | l₁ (b::l₂) h₁ h₂ := by rw diff_cons; exact
   mem_diff_of_mem ((mem_erase_of_ne (ne_of_not_mem_cons h₂)).2 h₁) (not_mem_of_not_mem_cons h₂)
 
-theorem diff_sublist_of_sublist : ∀ {l₁ l₂ l₃: list α}, l₁ <+ l₂ → l₁.diff l₃ <+ l₂.diff l₃
+theorem sublist.diff_right : ∀ {l₁ l₂ l₃: list α}, l₁ <+ l₂ → l₁.diff l₃ <+ l₂.diff l₃
 | l₁ l₂ [] h      := h
 | l₁ l₂ (a::l₃) h := by simp only
-  [diff_cons, diff_sublist_of_sublist (erase_sublist_erase _ h)]
+  [diff_cons, (h.erase _).diff_right]
 
 theorem erase_diff_erase_sublist_of_sublist {a : α} : ∀ {l₁ l₂ : list α},
   l₁ <+ l₂ → (l₂.erase a).diff (l₁.erase a) <+ l₂.diff l₁
 | []      l₂ h := erase_sublist _ _
 | (b::l₁) l₂ h := if heq : b = a then by simp only [heq, erase_cons_head, diff_cons]
                   else by simpa only [erase_cons_head, erase_cons_tail _ heq, diff_cons, erase_comm a b l₂]
-                  using erase_diff_erase_sublist_of_sublist (erase_sublist_erase b h)
+                  using erase_diff_erase_sublist_of_sublist (h.erase b)
 
 end diff
 

--- a/src/data/list/pairwise.lean
+++ b/src/data/list/pairwise.lean
@@ -80,7 +80,7 @@ theorem pairwise_of_sublist : Π {l₁ l₂ : list α}, l₁ <+ l₂ → pairwis
 | ._ ._ sublist.slnil h := h
 | ._ ._ (sublist.cons l₁ l₂ a s) (pairwise.cons i n) := pairwise_of_sublist s n
 | ._ ._ (sublist.cons2 l₁ l₂ a s) (pairwise.cons i n) :=
-  (pairwise_of_sublist s n).cons (ball.imp_left (subset_of_sublist s) i)
+  (pairwise_of_sublist s n).cons (ball.imp_left s.subset i)
 
 theorem forall_of_forall_of_pairwise (H : symmetric R)
   {l : list α} (H₁ : ∀ x ∈ l, R x x) (H₂ : pairwise R l) :
@@ -220,7 +220,7 @@ theorem pairwise_sublists' {R} : ∀ {l : list α}, pairwise R l →
     refine ⟨IH, IH.imp (λ l₁ l₂, lex.cons), _⟩,
     intros l₁ sl₁ x l₂ sl₂ e, subst e,
     cases l₁ with b l₁, {constructor},
-    exact lex.rel (H₁ _ $ subset_of_sublist sl₁ $ mem_cons_self _ _)
+    exact lex.rel (H₁ _ $ sl₁.subset $ mem_cons_self _ _)
   end
 
 theorem pairwise_sublists {R} {l : list α} (H : pairwise R l) :
@@ -264,7 +264,7 @@ theorem pw_filter_sublist : ∀ (l : list α), pw_filter R l <+ l
 end
 
 theorem pw_filter_subset (l : list α) : pw_filter R l ⊆ l :=
-subset_of_sublist (pw_filter_sublist _)
+(pw_filter_sublist _).subset
 
 theorem pairwise_pw_filter : ∀ (l : list α), pairwise R (pw_filter R l)
 | []     := pairwise.nil

--- a/src/data/list/perm.lean
+++ b/src/data/list/perm.lean
@@ -2,13 +2,15 @@
 Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
-
-List permutations.
 -/
 import data.list.bag_inter
 import data.list.erase_dup
 import data.list.zip
 import logic.relation
+
+/-!
+# List permutations
+-/
 
 namespace list
 universe variables uu vv
@@ -18,27 +20,30 @@ variables {α : Type uu} {β : Type vv}
   of each other. This is defined by induction using pairwise swaps. -/
 inductive perm : list α → list α → Prop
 | nil   : perm [] []
-| skip  : Π (x : α) {l₁ l₂ : list α}, perm l₁ l₂ → perm (x::l₁) (x::l₂)
+| cons  : Π (x : α) {l₁ l₂ : list α}, perm l₁ l₂ → perm (x::l₁) (x::l₂)
 | swap  : Π (x y : α) (l : list α), perm (y::x::l) (x::y::l)
 | trans : Π {l₁ l₂ l₃ : list α}, perm l₁ l₂ → perm l₂ l₃ → perm l₁ l₃
-open perm
+
+open perm (swap)
 
 infix ~ := perm
 
 @[refl] protected theorem perm.refl : ∀ (l : list α), l ~ l
 | []      := perm.nil
-| (x::xs) := skip x (perm.refl xs)
+| (x::xs) := (perm.refl xs).cons x
 
 @[symm] protected theorem perm.symm {l₁ l₂ : list α} (p : l₁ ~ l₂) : l₂ ~ l₁ :=
 perm.rec_on p
   perm.nil
-  (λ x l₁ l₂ p₁ r₁, skip x r₁)
+  (λ x l₁ l₂ p₁ r₁, r₁.cons x)
   (λ x y l, swap y x l)
-  (λ l₁ l₂ l₃ p₁ p₂ r₁ r₂, trans r₂ r₁)
+  (λ l₁ l₂ l₃ p₁ p₂ r₁ r₂, r₂.trans r₁)
+
+theorem perm_comm {l₁ l₂ : list α} : l₁ ~ l₂ ↔ l₂ ~ l₁ := ⟨perm.symm, perm.symm⟩
 
 theorem perm.swap'
   (x y : α) {l₁ l₂ : list α} (p : l₁ ~ l₂) : y::x::l₁ ~ x::y::l₂ :=
-trans (swap _ _ _) (skip _ $ skip _ p)
+(swap _ _ _).trans ((p.cons _).cons _)
 
 attribute [trans] perm.trans
 
@@ -48,7 +53,7 @@ mk_equivalence (@perm α) (@perm.refl α) (@perm.symm α) (@perm.trans α)
 instance is_setoid (α) : setoid (list α) :=
 setoid.mk (@perm α) (perm.eqv α)
 
-theorem perm_subset {l₁ l₂ : list α} (p : l₁ ~ l₂) : l₁ ⊆ l₂ :=
+theorem perm.subset {l₁ l₂ : list α} (p : l₁ ~ l₂) : l₁ ⊆ l₂ :=
 λ a, perm.rec_on p
   (λ h, h)
   (λ x l₁ l₂ p₁ r₁ i, or.elim i
@@ -61,80 +66,95 @@ theorem perm_subset {l₁ l₂ : list α} (p : l₁ ~ l₂) : l₁ ⊆ l₂ :=
       (λ al, or.inr (or.inr al))))
   (λ l₁ l₂ l₃ p₁ p₂ r₁ r₂ ainl₁, r₂ (r₁ ainl₁))
 
-theorem mem_of_perm {a : α} {l₁ l₂ : list α} (h : l₁ ~ l₂) : a ∈ l₁ ↔ a ∈ l₂ :=
-iff.intro (λ m, perm_subset h m) (λ m, perm_subset h.symm m)
+theorem perm.mem_iff {a : α} {l₁ l₂ : list α} (h : l₁ ~ l₂) : a ∈ l₁ ↔ a ∈ l₂ :=
+iff.intro (λ m, h.subset m) (λ m, h.symm.subset m)
 
-theorem perm_app_left {l₁ l₂ : list α} (t₁ : list α) (p : l₁ ~ l₂) : l₁++t₁ ~ l₂++t₁ :=
+theorem perm.append_right {l₁ l₂ : list α} (t₁ : list α) (p : l₁ ~ l₂) : l₁++t₁ ~ l₂++t₁ :=
 perm.rec_on p
   (perm.refl ([] ++ t₁))
-  (λ x l₁ l₂ p₁ r₁, skip x r₁)
+  (λ x l₁ l₂ p₁ r₁, r₁.cons x)
   (λ x y l, swap x y _)
-  (λ l₁ l₂ l₃ p₁ p₂ r₁ r₂, trans r₁ r₂)
+  (λ l₁ l₂ l₃ p₁ p₂ r₁ r₂, r₁.trans r₂)
 
-theorem perm_app_right {t₁ t₂ : list α} : ∀ (l : list α), t₁ ~ t₂ → l++t₁ ~ l++t₂
+theorem perm.append_left {t₁ t₂ : list α} : ∀ (l : list α), t₁ ~ t₂ → l++t₁ ~ l++t₂
 | []      p := p
-| (x::xs) p := skip x (perm_app_right xs p)
+| (x::xs) p := (perm.append_left xs p).cons x
 
-theorem perm_app {l₁ l₂ t₁ t₂ : list α} (p₁ : l₁ ~ l₂) (p₂ : t₁ ~ t₂) : l₁++t₁ ~ l₂++t₂ :=
-trans (perm_app_left t₁ p₁) (perm_app_right l₂ p₂)
+theorem perm.append {l₁ l₂ t₁ t₂ : list α} (p₁ : l₁ ~ l₂) (p₂ : t₁ ~ t₂) : l₁++t₁ ~ l₂++t₂ :=
+(p₁.append_right t₁).trans (p₂.append_left l₂)
 
-theorem perm_app_cons (a : α) {h₁ h₂ t₁ t₂ : list α}
+theorem perm.append_cons (a : α) {h₁ h₂ t₁ t₂ : list α}
   (p₁ : h₁ ~ h₂) (p₂ : t₁ ~ t₂) : h₁ ++ a::t₁ ~ h₂ ++ a::t₂ :=
-perm_app p₁ (skip a p₂)
+p₁.append (p₂.cons a)
 
 @[simp] theorem perm_middle {a : α} : ∀ {l₁ l₂ : list α}, l₁++a::l₂ ~ a::(l₁++l₂)
 | []      l₂ := perm.refl _
-| (b::l₁) l₂ := (skip b (@perm_middle l₁ l₂)).trans (swap a b _)
+| (b::l₁) l₂ := ((@perm_middle l₁ l₂).cons _).trans (swap a b _)
 
-@[simp] theorem perm_cons_app (a : α) (l : list α) : l ++ [a] ~ a::l :=
-by simpa using @perm_middle _ a l []
+@[simp] theorem perm_append_singleton (a : α) (l : list α) : l ++ [a] ~ a::l :=
+perm_middle.trans $ by rw [append_nil]
 
-@[simp] theorem perm_app_comm : ∀ {l₁ l₂ : list α}, (l₁++l₂) ~ (l₂++l₁)
+theorem perm_append_comm : ∀ {l₁ l₂ : list α}, (l₁++l₂) ~ (l₂++l₁)
 | []     l₂ := by simp
-| (a::t) l₂ := (skip a perm_app_comm).trans perm_middle.symm
+| (a::t) l₂ := (perm_append_comm.cons _).trans perm_middle.symm
 
 theorem concat_perm (l : list α) (a : α) : concat l a ~ a :: l :=
 by simp
 
-theorem perm_length {l₁ l₂ : list α} (p : l₁ ~ l₂) : length l₁ = length l₂ :=
+theorem perm.length_eq {l₁ l₂ : list α} (p : l₁ ~ l₂) : length l₁ = length l₂ :=
 perm.rec_on p
   rfl
   (λ x l₁ l₂ p r, by simp[r])
   (λ x y l, by simp)
   (λ l₁ l₂ l₃ p₁ p₂ r₁ r₂, eq.trans r₁ r₂)
 
-theorem eq_nil_of_perm_nil {l₁ : list α} (p : [] ~ l₁) : l₁ = [] :=
-eq_nil_of_length_eq_zero (perm_length p).symm
+theorem perm.eq_nil {l : list α} (p : l ~ []) : l = [] :=
+eq_nil_of_length_eq_zero p.length_eq
+
+theorem perm.nil_eq {l : list α} (p : [] ~ l) : [] = l :=
+p.symm.eq_nil.symm
 
 theorem perm_nil {l₁ : list α} : l₁ ~ [] ↔ l₁ = [] :=
-⟨λ p, eq_nil_of_perm_nil p.symm, λ e, e ▸ perm.refl _⟩
+⟨λ p, p.eq_nil, λ e, e ▸ perm.refl _⟩
 
 theorem not_perm_nil_cons (x : α) (l : list α) : ¬ [] ~ x::l
-| p := by injection eq_nil_of_perm_nil p
-
-theorem eq_singleton_of_perm {a b : α} (p : [a] ~ [b]) : a = b :=
-by simpa using perm_subset p (by simp)
-
-theorem eq_singleton_of_perm_inv {a : α} {l : list α} (p : [a] ~ l) : l = [a] :=
-match l, show 1 = _, from perm_length p, p with
-| [a'], rfl, p := by rw [eq_singleton_of_perm p]
-end
+| p := by injection p.symm.eq_nil
 
 @[simp] theorem reverse_perm : ∀ (l : list α), reverse l ~ l
 | []     := perm.nil
-| (a::l) := by rw reverse_cons; exact
-  (perm_cons_app _ _).trans (skip a $ reverse_perm l)
+| (a::l) := by { rw reverse_cons,
+  exact (perm_append_singleton _ _).trans ((reverse_perm l).cons a) }
 
-theorem perm_cons_app_cons {l l₁ l₂ : list α} (a : α) (p : l ~ l₁++l₂) : a::l ~ l₁++(a::l₂) :=
-trans (skip a p) perm_middle.symm
+theorem perm_cons_append_cons {l l₁ l₂ : list α} (a : α) (p : l ~ l₁++l₂) :
+  a::l ~ l₁++(a::l₂) :=
+(p.cons a).trans perm_middle.symm
 
-@[simp] theorem perm_repeat {a : α} {n : ℕ} {l : list α} : repeat a n ~ l ↔ repeat a n = l :=
-⟨λ p, (eq_repeat.2 $ by exact
-  ⟨by simpa using (perm_length p).symm,
-   λ b m, eq_of_mem_repeat $ perm_subset p.symm m⟩).symm,
+@[simp] theorem perm_repeat {a : α} {n : ℕ} {l : list α} : l ~ repeat a n ↔ l = repeat a n :=
+⟨λ p, (eq_repeat.2
+  ⟨p.length_eq.trans $ length_repeat _ _,
+   λ b m, eq_of_mem_repeat $ p.subset m⟩),
  λ h, h ▸ perm.refl _⟩
 
-theorem perm_erase [decidable_eq α] {a : α} {l : list α} (h : a ∈ l) : l ~ a :: l.erase a :=
+@[simp] theorem repeat_perm {a : α} {n : ℕ} {l : list α} : repeat a n ~ l ↔ repeat a n = l :=
+(perm_comm.trans perm_repeat).trans eq_comm
+
+@[simp] theorem perm_singleton {a : α} {l : list α} : l ~ [a] ↔ l = [a] :=
+@perm_repeat α a 1 l
+
+@[simp] theorem singleton_perm {a : α} {l : list α} : [a] ~ l ↔ [a] = l :=
+@repeat_perm α a 1 l
+
+theorem perm.eq_singleton {a : α} {l : list α} (p : l ~ [a]) : l = [a] :=
+perm_singleton.1 p
+
+theorem perm.singleton_eq {a : α} {l : list α} (p : [a] ~ l) : [a] = l :=
+p.symm.eq_singleton.symm
+
+theorem singleton_perm_singleton {a b : α} : [a] ~ [b] ↔ a = b :=
+by simp
+
+theorem perm_cons_erase [decidable_eq α] {a : α} {l : list α} (h : a ∈ l) :
+  l ~ a :: l.erase a :=
 let ⟨l₁, l₂, _, e₁, e₂⟩ := exists_erase_eq h in
 e₂.symm ▸ e₁.symm ▸ perm_middle
 
@@ -150,34 +170,34 @@ have P_refl : ∀ l, P l l, from
   list.rec_on l h₁ (λ x xs ih, h₂ x xs xs (perm.refl xs) ih),
 perm.rec_on p h₁ h₂ (λ x y l, h₃ x y l l (perm.refl l) (P_refl l)) h₄
 
-@[congr] theorem perm_filter_map (f : α → option β) {l₁ l₂ : list α} (p : l₁ ~ l₂) :
+@[congr] theorem perm.filter_map (f : α → option β) {l₁ l₂ : list α} (p : l₁ ~ l₂) :
   filter_map f l₁ ~ filter_map f l₂ :=
 begin
   induction p with x l₂ l₂' p IH  x y l₂  l₂ m₂ r₂ p₁ p₂ IH₁ IH₂,
   { simp },
-  { simp [filter_map], cases f x with a; simp [filter_map, IH, skip] },
-  { simp [filter_map], cases f x with a; cases f y with b; simp [filter_map, swap] },
+  { simp only [filter_map], cases f x with a; simp [filter_map, IH, perm.cons] },
+  { simp only [filter_map], cases f x with a; cases f y with b; simp [filter_map, swap] },
   { exact IH₁.trans IH₂ }
 end
 
-@[congr] theorem perm_map (f : α → β) {l₁ l₂ : list α} (p : l₁ ~ l₂) :
+@[congr] theorem perm.map (f : α → β) {l₁ l₂ : list α} (p : l₁ ~ l₂) :
   map f l₁ ~ map f l₂ :=
-by rw ← filter_map_eq_map; apply perm_filter_map _ p
+filter_map_eq_map f ▸ p.filter_map _
 
-theorem perm_pmap {p : α → Prop} (f : Π a, p a → β)
+theorem perm.pmap {p : α → Prop} (f : Π a, p a → β)
   {l₁ l₂ : list α} (p : l₁ ~ l₂) {H₁ H₂} : pmap f l₁ H₁ ~ pmap f l₂ H₂ :=
 begin
   induction p with x l₂ l₂' p IH  x y l₂  l₂ m₂ r₂ p₁ p₂ IH₁ IH₂,
   { simp },
-  { simp [IH, skip] },
+  { simp [IH, perm.cons] },
   { simp [swap] },
   { refine IH₁.trans IH₂,
-    exact λ a m, H₂ a (perm_subset p₂ m) }
+    exact λ a m, H₂ a (p₂.subset m) }
 end
 
-theorem perm_filter (p : α → Prop) [decidable_pred p]
+theorem perm.filter (p : α → Prop) [decidable_pred p]
   {l₁ l₂ : list α} (s : l₁ ~ l₂) : filter p l₁ ~ filter p l₂ :=
-by rw ← filter_map_eq_filter; apply perm_filter_map _ s
+by rw ← filter_map_eq_filter; apply s.filter_map _
 
 theorem exists_perm_sublist {l₁ l₂ l₂' : list α}
   (s : l₁ <+ l₂) (p : l₂ ~ l₂') : ∃ l₁' ~ l₁, l₁' <+ l₂' :=
@@ -186,7 +206,7 @@ begin
   { exact ⟨[], eq_nil_of_sublist_nil s ▸ perm.refl _, nil_sublist _⟩ },
   { cases s with _ _ _ s l₁ _ _ s,
     { exact let ⟨l₁', p', s'⟩ := IH s in ⟨l₁', p', s'.cons _ _ _⟩ },
-    { exact let ⟨l₁', p', s'⟩ := IH s in ⟨x::l₁', skip x p', s'.cons2 _ _ _⟩ } },
+    { exact let ⟨l₁', p', s'⟩ := IH s in ⟨x::l₁', p'.cons x, s'.cons2 _ _ _⟩ } },
   { cases s with _ _ _ s l₁ _ _ s; cases s with _ _ _ s l₁ _ _ s,
     { exact ⟨l₁, perm.refl _, (s.cons _ _ _).cons _ _ _⟩ },
     { exact ⟨x::l₁, perm.refl _, (s.cons _ _ _).cons2 _ _ _⟩ },
@@ -214,10 +234,10 @@ lemma perm_comp_forall₂ {l u v} (hlu : perm l u) (huv : forall₂ r u v) : (fo
 begin
   induction hlu generalizing v,
   case perm.nil { cases huv, exact ⟨[], forall₂.nil, perm.nil⟩ },
-  case perm.skip : a l u hlu ih {
+  case perm.cons : a l u hlu ih {
     cases huv with _ b _ v hab huv',
     rcases ih huv' with ⟨l₂, h₁₂, h₂₃⟩,
-    exact ⟨b::l₂, forall₂.cons hab h₁₂, perm.skip _ h₂₃⟩
+    exact ⟨b::l₂, forall₂.cons hab h₁₂, h₂₃.cons _⟩
   },
   case perm.swap : a₁ a₂ l₁ l₂ h₂₃ {
     cases h₂₃ with _ b₁ _ l₂ h₁ hr_₂₃,
@@ -281,61 +301,61 @@ theorem perm.subperm_right {l₁ l₂ l : list α} (p : l₁ ~ l₂) : l₁ <+~ 
 ⟨λ ⟨u, pu, su⟩, ⟨u, pu.trans p, su⟩,
  λ ⟨u, pu, su⟩, ⟨u, pu.trans p.symm, su⟩⟩
 
-theorem subperm_of_sublist {l₁ l₂ : list α} (s : l₁ <+ l₂) : l₁ <+~ l₂ :=
+theorem sublist.subperm {l₁ l₂ : list α} (s : l₁ <+ l₂) : l₁ <+~ l₂ :=
 ⟨l₁, perm.refl _, s⟩
 
-theorem subperm_of_perm {l₁ l₂ : list α} (p : l₁ ~ l₂) : l₁ <+~ l₂ :=
+theorem perm.subperm {l₁ l₂ : list α} (p : l₁ ~ l₂) : l₁ <+~ l₂ :=
 ⟨l₂, p.symm, sublist.refl _⟩
 
-theorem subperm.refl (l : list α) : l <+~ l := subperm_of_perm (perm.refl _)
+@[refl] theorem subperm.refl (l : list α) : l <+~ l := (perm.refl _).subperm
 
-theorem subperm.trans {l₁ l₂ l₃ : list α} : l₁ <+~ l₂ → l₂ <+~ l₃ → l₁ <+~ l₃
+@[trans] theorem subperm.trans {l₁ l₂ l₃ : list α} : l₁ <+~ l₂ → l₂ <+~ l₃ → l₁ <+~ l₃
 | s ⟨l₂', p₂, s₂⟩ :=
   let ⟨l₁', p₁, s₁⟩ := p₂.subperm_left.2 s in ⟨l₁', p₁, s₁.trans s₂⟩
 
-theorem length_le_of_subperm {l₁ l₂ : list α} : l₁ <+~ l₂ → length l₁ ≤ length l₂
-| ⟨l, p, s⟩ := perm_length p ▸ length_le_of_sublist s
+theorem subperm.length_le {l₁ l₂ : list α} : l₁ <+~ l₂ → length l₁ ≤ length l₂
+| ⟨l, p, s⟩ := p.length_eq ▸ length_le_of_sublist s
 
 theorem subperm.perm_of_length_le {l₁ l₂ : list α} : l₁ <+~ l₂ → length l₂ ≤ length l₁ → l₁ ~ l₂
 | ⟨l, p, s⟩ h :=
   suffices l = l₂, from this ▸ p.symm,
-  eq_of_sublist_of_length_le s $ perm_length p.symm ▸ h
+  eq_of_sublist_of_length_le s $ p.symm.length_eq ▸ h
 
 theorem subperm.antisymm {l₁ l₂ : list α} (h₁ : l₁ <+~ l₂) (h₂ : l₂ <+~ l₁) : l₁ ~ l₂ :=
-h₁.perm_of_length_le (length_le_of_subperm h₂)
+h₁.perm_of_length_le h₂.length_le
 
-theorem subset_of_subperm {l₁ l₂ : list α} : l₁ <+~ l₂ → l₁ ⊆ l₂
-| ⟨l, p, s⟩ := subset.trans (perm_subset p.symm) (subset_of_sublist s)
+theorem subperm.subset {l₁ l₂ : list α} : l₁ <+~ l₂ → l₁ ⊆ l₂
+| ⟨l, p, s⟩ := subset.trans p.symm.subset s.subset
 
 end subperm
 
-theorem exists_perm_append_of_sublist : ∀ {l₁ l₂ : list α}, l₁ <+ l₂ → ∃ l, l₂ ~ l₁ ++ l
+theorem sublist.exists_perm_append : ∀ {l₁ l₂ : list α}, l₁ <+ l₂ → ∃ l, l₂ ~ l₁ ++ l
 | ._ ._ sublist.slnil            := ⟨nil, perm.refl _⟩
 | ._ ._ (sublist.cons l₁ l₂ a s) :=
-  let ⟨l, p⟩ := exists_perm_append_of_sublist s in
-  ⟨a::l, (skip a p).trans perm_middle.symm⟩
+  let ⟨l, p⟩ := sublist.exists_perm_append s in
+  ⟨a::l, (p.cons a).trans perm_middle.symm⟩
 | ._ ._ (sublist.cons2 l₁ l₂ a s) :=
-  let ⟨l, p⟩ := exists_perm_append_of_sublist s in
-  ⟨l, skip a p⟩
+  let ⟨l, p⟩ := sublist.exists_perm_append s in
+  ⟨l, p.cons a⟩
 
-theorem perm_countp (p : α → Prop) [decidable_pred p]
+theorem perm.countp_eq (p : α → Prop) [decidable_pred p]
   {l₁ l₂ : list α} (s : l₁ ~ l₂) : countp p l₁ = countp p l₂ :=
 by rw [countp_eq_length_filter, countp_eq_length_filter];
-   exact perm_length (perm_filter _ s)
+   exact (s.filter _).length_eq
 
-theorem countp_le_of_subperm (p : α → Prop) [decidable_pred p]
+theorem subperm.countp_le (p : α → Prop) [decidable_pred p]
   {l₁ l₂ : list α} : l₁ <+~ l₂ → countp p l₁ ≤ countp p l₂
-| ⟨l, p', s⟩ := perm_countp p p' ▸ countp_le_of_sublist s
+| ⟨l, p', s⟩ := p'.countp_eq p ▸ countp_le_of_sublist s
 
-theorem perm_count [decidable_eq α] {l₁ l₂ : list α}
+theorem perm.count_eq [decidable_eq α] {l₁ l₂ : list α}
   (p : l₁ ~ l₂) (a) : count a l₁ = count a l₂ :=
-perm_countp _ p
+p.countp_eq _
 
-theorem count_le_of_subperm [decidable_eq α] {l₁ l₂ : list α}
+theorem subperm.count_le [decidable_eq α] {l₁ l₂ : list α}
   (s : l₁ <+~ l₂) (a) : count a l₁ ≤ count a l₂ :=
-countp_le_of_subperm _ s
+s.countp_le _
 
-theorem foldl_eq_of_perm {f : β → α → β} {l₁ l₂ : list α} (rcomm : right_commutative f) (p : l₁ ~ l₂) :
+theorem perm.foldl_eq {f : β → α → β} {l₁ l₂ : list α} (rcomm : right_commutative f) (p : l₁ ~ l₂) :
   ∀ b, foldl f b l₁ = foldl f b l₂ :=
 perm_induction_on p
   (λ b, rfl)
@@ -343,7 +363,7 @@ perm_induction_on p
   (λ x y t₁ t₂ p r b, by simp; rw rcomm; exact r (f (f b x) y))
   (λ t₁ t₂ t₃ p₁ p₂ r₁ r₂ b, eq.trans (r₁ b) (r₂ b))
 
-theorem foldr_eq_of_perm {f : α → β → β} {l₁ l₂ : list α} (lcomm : left_commutative f) (p : l₁ ~ l₂) :
+theorem perm.foldr_eq {f : α → β → β} {l₁ l₂ : list α} (lcomm : left_commutative f) (p : l₁ ~ l₂) :
   ∀ b, foldr f b l₁ = foldr f b l₂ :=
 perm_induction_on p
   (λ b, rfl)
@@ -351,7 +371,7 @@ perm_induction_on p
   (λ x y t₁ t₂ p r b, by simp; rw [lcomm, r b])
   (λ t₁ t₂ t₃ p₁ p₂ r₁ r₂ a, eq.trans (r₁ a) (r₂ a))
 
-lemma rec_heq_of_perm {β : list α → Sort*} {f : Πa l, β l → β (a::l)} {b : β []} {l l' : list α}
+lemma perm.rec_heq {β : list α → Sort*} {f : Πa l, β l → β (a::l)} {b : β []} {l l' : list α}
   (hl : perm l l')
   (f_congr : ∀{a l l' b b'}, perm l l' → b == b' → f a l b == f a l' b')
   (f_swap : ∀{a a' l b}, f a (a'::l) (f a' l b) == f a' (a::l) (f a l b)) :
@@ -359,7 +379,7 @@ lemma rec_heq_of_perm {β : list α → Sort*} {f : Πa l, β l → β (a::l)} {
 begin
   induction hl,
   case list.perm.nil { refl },
-  case list.perm.skip : a l l' h ih { exact f_congr h ih },
+  case list.perm.cons : a l l' h ih { exact f_congr h ih },
   case list.perm.swap : a a' l { exact f_swap },
   case list.perm.trans : l₁ l₂ l₃ h₁ h₂ ih₁ ih₂ { exact heq.trans ih₁ ih₂ }
 end
@@ -369,8 +389,8 @@ variables {op : α → α → α} [is_associative α op] [is_commutative α op]
 local notation a * b := op a b
 local notation l <*> a := foldl op a l
 
-lemma fold_op_eq_of_perm {l₁ l₂ : list α} {a : α} (h : l₁ ~ l₂) : l₁ <*> a = l₂ <*> a :=
-foldl_eq_of_perm (right_comm _ is_commutative.comm is_associative.assoc) h _
+lemma perm.fold_op_eq {l₁ l₂ : list α} {a : α} (h : l₁ ~ l₂) : l₁ <*> a = l₂ <*> a :=
+h.foldl_eq (right_comm _ is_commutative.comm is_associative.assoc) _
 end
 
 section comm_monoid
@@ -378,12 +398,12 @@ open list
 variable [comm_monoid α]
 
 @[to_additive]
-lemma prod_eq_of_perm {l₁ l₂ : list α} (h : perm l₁ l₂) : prod l₁ = prod l₂ :=
-by induction h; simp [*, mul_left_comm]
+lemma perm.prod_eq {l₁ l₂ : list α} (h : perm l₁ l₂) : prod l₁ = prod l₂ :=
+h.fold_op_eq
 
 @[to_additive]
 lemma prod_reverse (l : list α) : prod l.reverse = prod l :=
-prod_eq_of_perm $ reverse_perm l
+(reverse_perm l).prod_eq
 
 end comm_monoid
 
@@ -399,54 +419,53 @@ begin
     { substs t₁ t₂,     exact p },
     { substs z t₁ t₂,   exact p.trans perm_middle },
     { substs y t₁ t₂,   exact perm_middle.symm.trans p },
-    { substs z t₁ t₂,   exact skip y (IH rfl rfl) } },
+    { substs z t₁ t₂,   exact (IH rfl rfl).cons y } },
   { rcases l₁ with _|⟨y, _|⟨z, l₁⟩⟩; rcases l₂ with _|⟨u, _|⟨v, l₂⟩⟩;
       dsimp at e₁ e₂; injections; substs x y,
-    { substs r₁ r₂,     exact skip a p },
-    { substs r₁ r₂,     exact skip u p },
-    { substs r₁ v t₂,   exact skip u (p.trans perm_middle) },
-    { substs r₁ r₂,     exact skip y p },
-    { substs r₁ r₂ y u, exact skip a p },
-    { substs r₁ u v t₂, exact (skip y $ p.trans perm_middle).trans (swap _ _ _) },
-    { substs r₂ z t₁,   exact skip y (perm_middle.symm.trans p) },
-    { substs r₂ y z t₁, exact (swap _ _ _).trans (skip u $ perm_middle.symm.trans p) },
+    { substs r₁ r₂,     exact p.cons a },
+    { substs r₁ r₂,     exact p.cons u },
+    { substs r₁ v t₂,   exact (p.trans perm_middle).cons u },
+    { substs r₁ r₂,     exact p.cons y },
+    { substs r₁ r₂ y u, exact p.cons a },
+    { substs r₁ u v t₂, exact ((p.trans perm_middle).cons y).trans (swap _ _ _) },
+    { substs r₂ z t₁,   exact (perm_middle.symm.trans p).cons y },
+    { substs r₂ y z t₁, exact (swap _ _ _).trans ((perm_middle.symm.trans p).cons u) },
     { substs u v t₁ t₂, exact (IH rfl rfl).swap' _ _ } },
   { substs t₁ t₃,
-    have : a ∈ t₂ := perm_subset p₁ (by simp),
+    have : a ∈ t₂ := p₁.subset (by simp),
     rcases mem_split this with ⟨l₂, r₂, e₂⟩,
     subst t₂, exact (IH₁ rfl rfl).trans (IH₂ rfl rfl) }
 end
 
-theorem perm_cons_inv {a : α} {l₁ l₂ : list α} : a::l₁ ~ a::l₂ → l₁ ~ l₂ :=
+theorem perm.cons_inv {a : α} {l₁ l₂ : list α} : a::l₁ ~ a::l₂ → l₁ ~ l₂ :=
 @perm_inv_core _ _ [] [] _ _
 
-theorem perm_cons (a : α) {l₁ l₂ : list α} : a::l₁ ~ a::l₂ ↔ l₁ ~ l₂ :=
-⟨perm_cons_inv, skip a⟩
+@[simp] theorem perm_cons (a : α) {l₁ l₂ : list α} : a::l₁ ~ a::l₂ ↔ l₁ ~ l₂ :=
+⟨perm.cons_inv, perm.cons a⟩
 
-theorem perm_app_left_iff {l₁ l₂ : list α} : ∀ l, l++l₁ ~ l++l₂ ↔ l₁ ~ l₂
+theorem perm_append_left_iff {l₁ l₂ : list α} : ∀ l, l++l₁ ~ l++l₂ ↔ l₁ ~ l₂
 | []     := iff.rfl
-| (a::l) := (perm_cons a).trans (perm_app_left_iff l)
+| (a::l) := (perm_cons a).trans (perm_append_left_iff l)
 
-theorem perm_app_right_iff {l₁ l₂ : list α} (l) : l₁++l ~ l₂++l ↔ l₁ ~ l₂ :=
-⟨λ p, (perm_app_left_iff _).1 $ trans perm_app_comm $ trans p perm_app_comm,
- perm_app_left _⟩
+theorem perm_append_right_iff {l₁ l₂ : list α} (l) : l₁++l ~ l₂++l ↔ l₁ ~ l₂ :=
+⟨λ p, (perm_append_left_iff _).1 $ perm_append_comm.trans $ p.trans perm_append_comm,
+ perm.append_right _⟩
 
 theorem perm_option_to_list {o₁ o₂ : option α} : o₁.to_list ~ o₂.to_list ↔ o₁ = o₂ :=
 begin
   refine ⟨λ p, _, λ e, e ▸ perm.refl _⟩,
   cases o₁ with a; cases o₂ with b, {refl},
-  { cases (perm_length p) },
-  { cases (perm_length p) },
-  { exact option.mem_to_list.1 ((mem_of_perm p).2 $ by simp) }
+  { cases p.length_eq },
+  { cases p.length_eq },
+  { exact option.mem_to_list.1 (p.symm.subset $ by simp) }
 end
 
 theorem subperm_cons (a : α) {l₁ l₂ : list α} : a::l₁ <+~ a::l₂ ↔ l₁ <+~ l₂ :=
 ⟨λ ⟨l, p, s⟩, begin
   cases s with _ _ _ s' u _ _ s',
-  { exact (p.subperm_left.2 $ subperm_of_sublist $ sublist_cons _ _).trans
-     (subperm_of_sublist s') },
-  { exact ⟨u, perm_cons_inv p, s'⟩ }
-end, λ ⟨l, p, s⟩, ⟨a::l, skip a p, s.cons2 _ _ _⟩⟩
+  { exact (p.subperm_left.2 $ (sublist_cons _ _).subperm).trans s'.subperm },
+  { exact ⟨u, p.cons_inv, s'⟩ }
+end, λ ⟨l, p, s⟩, ⟨a::l, p.cons a, s.cons2 _ _ _⟩⟩
 
 theorem cons_subperm_of_mem {a : α} {l₁ l₂ : list α} (d₁ : nodup l₁) (h₁ : a ∉ l₁) (h₂ : a ∈ l₂)
  (s : l₁ <+~ l₂) : a :: l₁ <+~ l₂ :=
@@ -457,37 +476,37 @@ begin
   case list.sublist.cons : r₁ r₂ b s' ih {
     simp at h₂,
     cases h₂ with e m,
-    { subst b, exact ⟨a::r₁, skip a p, s'.cons2 _ _ _⟩ },
+    { subst b, exact ⟨a::r₁, p.cons a, s'.cons2 _ _ _⟩ },
     { rcases ih m d₁ h₁ p with ⟨t, p', s'⟩, exact ⟨t, p', s'.cons _ _ _⟩ } },
   case list.sublist.cons2 : r₁ r₂ b s' ih {
-    have bm : b ∈ l₁ := (perm_subset p $ mem_cons_self _ _),
+    have bm : b ∈ l₁ := (p.subset $ mem_cons_self _ _),
     have am : a ∈ r₂ := h₂.resolve_left (λ e, h₁ $ e.symm ▸ bm),
     rcases mem_split bm with ⟨t₁, t₂, rfl⟩,
     have st : t₁ ++ t₂ <+ t₁ ++ b :: t₂ := by simp,
     rcases ih am (nodup_of_sublist st d₁)
-      (mt (λ x, subset_of_sublist st x) h₁)
-      (perm_cons_inv $ p.trans perm_middle) with ⟨t, p', s'⟩,
-    exact ⟨b::t, (skip b p').trans $ (swap _ _ _).trans (skip a perm_middle.symm), s'.cons2 _ _ _⟩ }
+      (mt (λ x, st.subset x) h₁)
+      (perm.cons_inv $ p.trans perm_middle) with ⟨t, p', s'⟩,
+    exact ⟨b::t, (p'.cons b).trans $ (swap _ _ _).trans (perm_middle.symm.cons a), s'.cons2 _ _ _⟩ }
 end
 
-theorem subperm_app_left {l₁ l₂ : list α} : ∀ l, l++l₁ <+~ l++l₂ ↔ l₁ <+~ l₂
+theorem subperm_append_left {l₁ l₂ : list α} : ∀ l, l++l₁ <+~ l++l₂ ↔ l₁ <+~ l₂
 | []     := iff.rfl
-| (a::l) := (subperm_cons a).trans (subperm_app_left l)
+| (a::l) := (subperm_cons a).trans (subperm_append_left l)
 
-theorem subperm_app_right {l₁ l₂ : list α} (l) : l₁++l <+~ l₂++l ↔ l₁ <+~ l₂ :=
-(perm_app_comm.subperm_left.trans perm_app_comm.subperm_right).trans (subperm_app_left l)
+theorem subperm_append_right {l₁ l₂ : list α} (l) : l₁++l <+~ l₂++l ↔ l₁ <+~ l₂ :=
+(perm_append_comm.subperm_left.trans perm_append_comm.subperm_right).trans (subperm_append_left l)
 
 theorem subperm.exists_of_length_lt {l₁ l₂ : list α} :
   l₁ <+~ l₂ → length l₁ < length l₂ → ∃ a, a :: l₁ <+~ l₂
 | ⟨l, p, s⟩ h :=
   suffices length l < length l₂ → ∃ (a : α), a :: l <+~ l₂, from
-  (this $ perm_length p.symm ▸ h).imp (λ a, (skip a p).subperm_right.1),
+  (this $ p.symm.length_eq ▸ h).imp (λ a, (p.cons a).subperm_right.1),
   begin
     clear subperm.exists_of_length_lt p h l₁, rename l₂ u,
     induction s with l₁ l₂ a s IH _ _ b s IH; intro h,
     { cases h },
     { cases lt_or_eq_of_le (nat.le_of_lt_succ h : length l₁ ≤ length l₂) with h h,
-      { exact (IH h).imp (λ a s, s.trans (subperm_of_sublist $ sublist_cons _ _)) },
+      { exact (IH h).imp (λ a s, s.trans (sublist_cons _ _).subperm) },
       { exact ⟨a, eq_of_sublist_of_length_eq s h ▸ subperm.refl _⟩ } },
     { exact (IH $ nat.lt_of_succ_lt_succ h).imp
         (λ a s, (swap _ _ _).subperm_right.1 $ (subperm_cons _).2 s) }
@@ -503,128 +522,157 @@ begin
     exact cons_subperm_of_mem d h H₁ (IH H₂) }
 end
 
-theorem perm_ext {l₁ l₂ : list α} (d₁ : nodup l₁) (d₂ : nodup l₂) : l₁ ~ l₂ ↔ ∀a, a ∈ l₁ ↔ a ∈ l₂ :=
-⟨λ p a, mem_of_perm p, λ H, subperm.antisymm
+theorem perm_ext {l₁ l₂ : list α} (d₁ : nodup l₁) (d₂ : nodup l₂) :
+  l₁ ~ l₂ ↔ ∀a, a ∈ l₁ ↔ a ∈ l₂ :=
+⟨λ p a, p.mem_iff, λ H, subperm.antisymm
   (subperm_of_subset_nodup d₁ (λ a, (H a).1))
   (subperm_of_subset_nodup d₂ (λ a, (H a).2))⟩
 
-theorem perm_ext_sublist_nodup {l₁ l₂ l : list α} (d : nodup l)
+theorem nodup.sublist_ext {l₁ l₂ l : list α} (d : nodup l)
   (s₁ : l₁ <+ l) (s₂ : l₂ <+ l) : l₁ ~ l₂ ↔ l₁ = l₂ :=
 ⟨λ h, begin
   induction s₂ with l₂ l a s₂ IH l₂ l a s₂ IH generalizing l₁,
-  { exact eq_nil_of_perm_nil h.symm },
+  { exact h.eq_nil },
   { simp at d,
     cases s₁ with _ _ _ s₁ l₁ _ _ s₁,
     { exact IH d.2 s₁ h },
     { apply d.1.elim,
-      exact subset_of_subperm ⟨_, h.symm, s₂⟩ (mem_cons_self _ _) } },
+      exact subperm.subset ⟨_, h.symm, s₂⟩ (mem_cons_self _ _) } },
   { simp at d,
     cases s₁ with _ _ _ s₁ l₁ _ _ s₁,
     { apply d.1.elim,
-      exact subset_of_subperm ⟨_, h, s₁⟩ (mem_cons_self _ _) },
-    { rw IH d.2 s₁ (perm_cons_inv h) } }
+      exact subperm.subset ⟨_, h, s₁⟩ (mem_cons_self _ _) },
+    { rw IH d.2 s₁ h.cons_inv } }
 end, λ h, by rw h⟩
 
 section
 variable [decidable_eq α]
 
 -- attribute [congr]
-theorem erase_perm_erase (a : α) {l₁ l₂ : list α} (p : l₁ ~ l₂) :
+theorem perm.erase (a : α) {l₁ l₂ : list α} (p : l₁ ~ l₂) :
   l₁.erase a ~ l₂.erase a :=
 if h₁ : a ∈ l₁ then
-have h₂ : a ∈ l₂, from perm_subset p h₁,
-perm_cons_inv $ trans (perm_erase h₁).symm $ trans p (perm_erase h₂)
+have h₂ : a ∈ l₂, from p.subset h₁,
+perm.cons_inv $ (perm_cons_erase h₁).symm.trans $ p.trans (perm_cons_erase h₂)
 else
-have h₂ : a ∉ l₂, from mt (mem_of_perm p).2 h₁,
+have h₂ : a ∉ l₂, from mt p.mem_iff.2 h₁,
 by rw [erase_of_not_mem h₁, erase_of_not_mem h₂]; exact p
 
+theorem subperm_cons_erase (a : α) (l : list α) : l <+~ a :: l.erase a :=
+begin
+  by_cases h : a ∈ l,
+  { exact (perm_cons_erase h).subperm },
+  { rw [erase_of_not_mem h],
+    exact (sublist_cons _ _).subperm }
+end
+
 theorem erase_subperm (a : α) (l : list α) : l.erase a <+~ l :=
-⟨l.erase a, perm.refl _, erase_sublist _ _⟩
+(erase_sublist _ _).subperm
 
-theorem erase_subperm_erase {l₁ l₂ : list α} (a : α) (h : l₁ <+~ l₂) : l₁.erase a <+~ l₂.erase a :=
-let ⟨l, hp, hs⟩ := h in ⟨l.erase a, erase_perm_erase _ hp, erase_sublist_erase _ hs⟩
+theorem subperm.erase {l₁ l₂ : list α} (a : α) (h : l₁ <+~ l₂) : l₁.erase a <+~ l₂.erase a :=
+let ⟨l, hp, hs⟩ := h in ⟨l.erase a, hp.erase _, hs.erase _⟩
 
-theorem perm_diff_left {l₁ l₂ : list α} (t : list α) (h : l₁ ~ l₂) : l₁.diff t ~ l₂.diff t :=
-by induction t generalizing l₁ l₂ h; simp [*, erase_perm_erase]
+theorem perm.diff_right {l₁ l₂ : list α} (t : list α) (h : l₁ ~ l₂) : l₁.diff t ~ l₂.diff t :=
+by induction t generalizing l₁ l₂ h; simp [*, perm.erase]
 
-theorem perm_diff_right (l : list α) {t₁ t₂ : list α} (h : t₁ ~ t₂) : l.diff t₁ = l.diff t₂ :=
-by induction h generalizing l; simp [*, erase_perm_erase, erase_comm]
+theorem perm.diff_left (l : list α) {t₁ t₂ : list α} (h : t₁ ~ t₂) : l.diff t₁ = l.diff t₂ :=
+by induction h generalizing l; simp [*, perm.erase, erase_comm]
   <|> exact (ih_1 _).trans (ih_2 _)
+
+theorem perm.diff {l₁ l₂ t₁ t₂ : list α} (hl : l₁ ~ l₂) (ht : t₁ ~ t₂) :
+  l₁.diff t₁ ~ l₂.diff t₂ :=
+ht.diff_left l₂ ▸ hl.diff_right _
+
+theorem subperm.diff_right {l₁ l₂ : list α} (h : l₁ <+~ l₂) (t : list α) :
+  l₁.diff t <+~ l₂.diff t :=
+by induction t generalizing l₁ l₂ h; simp [*, subperm.erase]
+
+theorem erase_cons_subperm_cons_erase (a b : α) (l : list α) :
+  (a :: l).erase b <+~ a :: l.erase b :=
+begin
+  by_cases h : a = b,
+  { subst b,
+    rw [erase_cons_head],
+    apply subperm_cons_erase },
+  { rw [erase_cons_tail _ h] }
+end
 
 theorem subperm_cons_diff {a : α} : ∀ {l₁ l₂ : list α}, (a :: l₁).diff l₂ <+~ a :: l₁.diff l₂
 | l₁ []      := ⟨a::l₁, by simp⟩
 | l₁ (b::l₂) :=
 begin
-  repeat {rw diff_cons},
-  by_cases heq : a = b,
-  { by_cases b ∈ l₁,
-    { rw perm.subperm_right, apply subperm_cons_diff,
-      simp [perm_diff_left, heq, perm_erase h] },
-    { simp [subperm_of_sublist, sublist.cons, h, heq] } },
-  { simp [heq, subperm_cons_diff] }
+  simp only [diff_cons],
+  refine ((erase_cons_subperm_cons_erase a b l₁).diff_right l₂).trans _,
+  apply subperm_cons_diff
 end
 
 theorem subset_cons_diff {a : α} {l₁ l₂ : list α} : (a :: l₁).diff l₂ ⊆ a :: l₁.diff l₂ :=
-subset_of_subperm subperm_cons_diff
+subperm_cons_diff.subset
 
-theorem perm_bag_inter_left {l₁ l₂ : list α} (t : list α) (h : l₁ ~ l₂) : l₁.bag_inter t ~ l₂.bag_inter t :=
+theorem perm.bag_inter_right {l₁ l₂ : list α} (t : list α) (h : l₁ ~ l₂) :
+  l₁.bag_inter t ~ l₂.bag_inter t :=
 begin
   induction h with x _ _ _ _ x y _ _ _ _ _ _ ih_1 ih_2 generalizing t, {simp},
-  { by_cases x ∈ t; simp [*, skip] },
+  { by_cases x ∈ t; simp [*, perm.cons] },
   { by_cases x = y, {simp [h]},
     by_cases xt : x ∈ t; by_cases yt : y ∈ t,
     { simp [xt, yt, mem_erase_of_ne h, mem_erase_of_ne (ne.symm h), erase_comm, swap] },
-    { simp [xt, yt, mt mem_of_mem_erase, skip] },
-    { simp [xt, yt, mt mem_of_mem_erase, skip] },
+    { simp [xt, yt, mt mem_of_mem_erase, perm.cons] },
+    { simp [xt, yt, mt mem_of_mem_erase, perm.cons] },
     { simp [xt, yt] } },
   { exact (ih_1 _).trans (ih_2 _) }
 end
 
-theorem perm_bag_inter_right (l : list α) {t₁ t₂ : list α} (p : t₁ ~ t₂) : l.bag_inter t₁ = l.bag_inter t₂ :=
+theorem perm.bag_inter_left (l : list α) {t₁ t₂ : list α} (p : t₁ ~ t₂) :
+  l.bag_inter t₁ = l.bag_inter t₂ :=
 begin
   induction l with a l IH generalizing t₁ t₂ p, {simp},
   by_cases a ∈ t₁,
-  { simp [h, (mem_of_perm p).1 h, IH (erase_perm_erase _ p)] },
-  { simp [h, mt (mem_of_perm p).2 h, IH p] }
+  { simp [h, p.subset h, IH (p.erase _)] },
+  { simp [h, mt p.mem_iff.2 h, IH p] }
 end
 
+theorem perm.bag_inter {l₁ l₂ t₁ t₂ : list α} (hl : l₁ ~ l₂) (ht : t₁ ~ t₂) :
+  l₁.bag_inter t₁ ~ l₂.bag_inter t₂ :=
+ht.bag_inter_left l₂ ▸ hl.bag_inter_right _
+
 theorem cons_perm_iff_perm_erase {a : α} {l₁ l₂ : list α} : a::l₁ ~ l₂ ↔ a ∈ l₂ ∧ l₁ ~ l₂.erase a :=
-⟨λ h, have a ∈ l₂, from perm_subset h (mem_cons_self a l₁),
-      ⟨this, perm_cons_inv $ h.trans $ perm_erase this⟩,
- λ ⟨m, h⟩, trans (skip a h) (perm_erase m).symm⟩
+⟨λ h, have a ∈ l₂, from h.subset (mem_cons_self a l₁),
+      ⟨this, (h.trans $ perm_cons_erase this).cons_inv⟩,
+ λ ⟨m, h⟩, (h.cons a).trans (perm_cons_erase m).symm⟩
 
 theorem perm_iff_count {l₁ l₂ : list α} : l₁ ~ l₂ ↔ ∀ a, count a l₁ = count a l₂ :=
-⟨perm_count, λ H, begin
+⟨perm.count_eq, λ H, begin
   induction l₁ with a l₁ IH generalizing l₂,
   { cases l₂ with b l₂, {refl},
     specialize H b, simp at H, contradiction },
   { have : a ∈ l₂ := count_pos.1 (by rw ← H; simp; apply nat.succ_pos),
-    refine trans (skip a $ IH $ λ b, _) (perm_erase this).symm,
+    refine ((IH $ λ b, _).cons a).trans (perm_cons_erase this).symm,
     specialize H b,
-    rw perm_count (perm_erase this) at H,
+    rw (perm_cons_erase this).count_eq at H,
     by_cases b = a; simp [h] at H ⊢; assumption }
 end⟩
 
 instance decidable_perm : ∀ (l₁ l₂ : list α), decidable (l₁ ~ l₂)
 | []      []      := is_true $ perm.refl _
-| []      (b::l₂) := is_false $ λ h, by have := eq_nil_of_perm_nil h; contradiction
+| []      (b::l₂) := is_false $ λ h, by have := h.nil_eq; contradiction
 | (a::l₁) l₂      := by haveI := decidable_perm l₁ (l₂.erase a);
                         exact decidable_of_iff' _ cons_perm_iff_perm_erase
 
 -- @[congr]
-theorem perm_erase_dup_of_perm {l₁ l₂ : list α} (p : l₁ ~ l₂) :
+theorem perm.erase_dup {l₁ l₂ : list α} (p : l₁ ~ l₂) :
   erase_dup l₁ ~ erase_dup l₂ :=
 perm_iff_count.2 $ λ a,
 if h : a ∈ l₁
-then by simp [nodup_erase_dup, h, perm_subset p h]
-else by simp [h, mt (mem_of_perm p).2 h]
+then by simp [nodup_erase_dup, h, p.subset h]
+else by simp [h, mt p.mem_iff.2 h]
 
 -- attribute [congr]
-theorem perm_insert (a : α)
+theorem perm.insert (a : α)
   {l₁ l₂ : list α} (p : l₁ ~ l₂) : insert a l₁ ~ insert a l₂ :=
 if h : a ∈ l₁
-then by simpa [h, perm_subset p h] using p
-else by simpa [h, mt (mem_of_perm p).2 h] using skip a p
+then by simpa [h, p.subset h] using p
+else by simpa [h, mt p.mem_iff.2 h] using p.cons a
 
 theorem perm_insert_swap (x y : α) (l : list α) :
   insert x (insert y l) ~ insert y (insert x l) :=
@@ -636,85 +684,87 @@ begin
   constructor
 end
 
-theorem perm_union_left {l₁ l₂ : list α} (t₁ : list α) (h : l₁ ~ l₂) : l₁ ∪ t₁ ~ l₂ ∪ t₁ :=
+theorem perm.union_right {l₁ l₂ : list α} (t₁ : list α) (h : l₁ ~ l₂) : l₁ ∪ t₁ ~ l₂ ∪ t₁ :=
 begin
   induction h with a _ _ _ ih _ _ _ _ _ _ _ _ ih_1 ih_2; try {simp},
-  { exact perm_insert a ih },
+  { exact ih.insert a },
   { apply perm_insert_swap },
   { exact ih_1.trans ih_2 }
 end
 
-theorem perm_union_right (l : list α) {t₁ t₂ : list α} (h : t₁ ~ t₂) : l ∪ t₁ ~ l ∪ t₂ :=
-by induction l; simp [*, perm_insert]
+theorem perm.union_left (l : list α) {t₁ t₂ : list α} (h : t₁ ~ t₂) : l ∪ t₁ ~ l ∪ t₂ :=
+by induction l; simp [*, perm.insert]
 
 -- @[congr]
-theorem perm_union {l₁ l₂ t₁ t₂ : list α} (p₁ : l₁ ~ l₂) (p₂ : t₁ ~ t₂) : l₁ ∪ t₁ ~ l₂ ∪ t₂ :=
-trans (perm_union_left t₁ p₁) (perm_union_right l₂ p₂)
+theorem perm.union {l₁ l₂ t₁ t₂ : list α} (p₁ : l₁ ~ l₂) (p₂ : t₁ ~ t₂) : l₁ ∪ t₁ ~ l₂ ∪ t₂ :=
+(p₁.union_right t₁).trans (p₂.union_left l₂)
 
-theorem perm_inter_left {l₁ l₂ : list α} (t₁ : list α) : l₁ ~ l₂ → l₁ ∩ t₁ ~ l₂ ∩ t₁ :=
-perm_filter _
+theorem perm.inter_right {l₁ l₂ : list α} (t₁ : list α) : l₁ ~ l₂ → l₁ ∩ t₁ ~ l₂ ∩ t₁ :=
+perm.filter _
 
-theorem perm_inter_right (l : list α) {t₁ t₂ : list α} (p : t₁ ~ t₂) : l ∩ t₁ = l ∩ t₂ :=
-by dsimp [(∩), list.inter]; congr; funext a; rw [mem_of_perm p]
+theorem perm.inter_left (l : list α) {t₁ t₂ : list α} (p : t₁ ~ t₂) : l ∩ t₁ = l ∩ t₂ :=
+by { dsimp [(∩), list.inter], congr, funext a, rw [p.mem_iff] }
 
 -- @[congr]
-theorem perm_inter {l₁ l₂ t₁ t₂ : list α} (p₁ : l₁ ~ l₂) (p₂ : t₁ ~ t₂) : l₁ ∩ t₁ ~ l₂ ∩ t₂ :=
-perm_inter_right l₂ p₂ ▸ perm_inter_left t₁ p₁
+theorem perm.inter {l₁ l₂ t₁ t₂ : list α} (p₁ : l₁ ~ l₂) (p₂ : t₁ ~ t₂) : l₁ ∩ t₁ ~ l₂ ∩ t₂ :=
+p₂.inter_left l₂ ▸ p₁.inter_right t₁
 end
 
-theorem perm_pairwise {R : α → α → Prop} (S : symmetric R) :
+theorem perm.pairwise_iff {R : α → α → Prop} (S : symmetric R) :
   ∀ {l₁ l₂ : list α} (p : l₁ ~ l₂), pairwise R l₁ ↔ pairwise R l₂ :=
 suffices ∀ {l₁ l₂}, l₁ ~ l₂ → pairwise R l₁ → pairwise R l₂, from λ l₁ l₂ p, ⟨this p, this p.symm⟩,
 λ l₁ l₂ p d, begin
   induction d with a l₁ h d IH generalizing l₂,
-  { rw eq_nil_of_perm_nil p, constructor },
-  { have : a ∈ l₂ := perm_subset p (mem_cons_self _ _),
+  { rw ← p.nil_eq, constructor },
+  { have : a ∈ l₂ := p.subset (mem_cons_self _ _),
     rcases mem_split this with ⟨s₂, t₂, rfl⟩,
-    have p' := perm_cons_inv (p.trans perm_middle),
+    have p' := (p.trans perm_middle).cons_inv,
     refine (pairwise_middle S).2 (pairwise_cons.2 ⟨λ b m, _, IH _ p'⟩),
-    exact h _ (perm_subset p'.symm m) }
+    exact h _ (p'.symm.subset m) }
 end
 
-theorem perm_nodup {l₁ l₂ : list α} : l₁ ~ l₂ → (nodup l₁ ↔ nodup l₂) :=
-perm_pairwise $ @ne.symm α
+theorem perm.nodup_iff {l₁ l₂ : list α} : l₁ ~ l₂ → (nodup l₁ ↔ nodup l₂) :=
+perm.pairwise_iff $ @ne.symm α
 
-theorem perm_bind_left {l₁ l₂ : list α} (f : α → list β) (p : l₁ ~ l₂) :
+theorem perm.bind_right {l₁ l₂ : list α} (f : α → list β) (p : l₁ ~ l₂) :
   l₁.bind f ~ l₂.bind f :=
 begin
   induction p with a l₁ l₂ p IH a b l l₁ l₂ l₃ p₁ p₂ IH₁ IH₂, {simp},
-  { simp, exact perm_app_right _ IH },
-  { simp, rw [← append_assoc, ← append_assoc], exact perm_app_left _ perm_app_comm },
-  { exact trans IH₁ IH₂ }
+  { simp, exact IH.append_left _ },
+  { simp, rw [← append_assoc, ← append_assoc], exact perm_append_comm.append_right _ },
+  { exact IH₁.trans IH₂ }
 end
 
-theorem perm_bind_right (l : list α) {f g : α → list β} (h : ∀ a, f a ~ g a) :
+theorem perm.bind_left (l : list α) {f g : α → list β} (h : ∀ a, f a ~ g a) :
   l.bind f ~ l.bind g :=
-by induction l with a l IH; simp; exact perm_app (h a) IH
+by induction l with a l IH; simp; exact (h a).append IH
 
-theorem perm_product_left {l₁ l₂ : list α} (t₁ : list β) (p : l₁ ~ l₂) : product l₁ t₁ ~ product l₂ t₁ :=
-perm_bind_left _ p
+theorem perm.product_right {l₁ l₂ : list α} (t₁ : list β) (p : l₁ ~ l₂) :
+  product l₁ t₁ ~ product l₂ t₁ :=
+p.bind_right _
 
-theorem perm_product_right (l : list α) {t₁ t₂ : list β} (p : t₁ ~ t₂) : product l t₁ ~ product l t₂ :=
-perm_bind_right _ $ λ a, perm_map _ p
+theorem perm.product_left (l : list α) {t₁ t₂ : list β} (p : t₁ ~ t₂) :
+  product l t₁ ~ product l t₂ :=
+perm.bind_left _ $ λ a, p.map _
 
-@[congr] theorem perm_product {l₁ l₂ : list α} {t₁ t₂ : list β}
+@[congr] theorem perm.product {l₁ l₂ : list α} {t₁ t₂ : list β}
   (p₁ : l₁ ~ l₂) (p₂ : t₁ ~ t₂) : product l₁ t₁ ~ product l₂ t₂ :=
-trans (perm_product_left t₁ p₁) (perm_product_right l₂ p₂)
+(p₁.product_right t₁).trans (p₂.product_left l₂)
 
 theorem sublists_cons_perm_append (a : α) (l : list α) :
   sublists (a :: l) ~ sublists l ++ map (cons a) (sublists l) :=
 begin
-  simp [sublists, sublists_aux_cons_cons],
-  refine skip _ ((skip _ _).trans perm_middle.symm),
+  simp only [sublists, sublists_aux_cons_cons, cons_append, perm_cons],
+  refine (perm.cons _ _).trans perm_middle.symm,
   induction sublists_aux l cons with b l IH; simp,
-  exact skip b ((skip _ IH).trans perm_middle.symm)
+  exact (IH.cons _).trans perm_middle.symm
 end
 
 theorem sublists_perm_sublists' : ∀ l : list α, sublists l ~ sublists' l
 | []     := perm.refl _
 | (a::l) := let IH := sublists_perm_sublists' l in
   by rw sublists'_cons; exact
-  (sublists_cons_perm_append _ _).trans (perm_app IH (perm_map _ IH))
+  (sublists_cons_perm_append _ _).trans (IH.append (IH.map _))
 
 theorem revzip_sublists (l : list α) :
   ∀ l₁ l₂, (l₁, l₂) ∈ revzip l.sublists → l₁ ++ l₂ ~ l :=
@@ -728,11 +778,11 @@ begin
     simp only [prod.mk.inj_iff, mem_map, mem_append, prod.map_mk, prod.exists] at h,
     rcases h with ⟨l₁, l₂', h, rfl, rfl⟩ | ⟨l₁', l₂, h, rfl, rfl⟩,
     { rw ← append_assoc,
-      exact perm_app_left _ (IH _ _ h) },
+      exact (IH _ _ h).append_right _ },
     { rw append_assoc,
-      apply (perm_app_right _ perm_app_comm).trans,
+      apply (perm_append_comm.append_left _).trans,
       rw ← append_assoc,
-      exact perm_app_left _ (IH _ _ h) } }
+      exact (IH _ _ h).append_right _ } }
 end
 
 theorem revzip_sublists' (l : list α) :
@@ -744,8 +794,8 @@ begin
   { rw [sublists'_cons, reverse_append, zip_append, ← map_reverse,
         zip_map_right, zip_map_left] at h; [simp at h, simp],
     rcases h with ⟨l₁, l₂', h, rfl, rfl⟩ | ⟨l₁', l₂, h, rfl, rfl⟩,
-    { exact perm_middle.trans (skip _ (IH _ _ h)) },
-    { exact skip _ (IH _ _ h) } }
+    { exact perm_middle.trans ((IH _ _ h).cons _) },
+    { exact (IH _ _ h).cons _ } }
 end
 
 theorem perm_lookmap (f : α → option α) {l₁ l₂ : list α}
@@ -756,8 +806,8 @@ begin
   change pairwise F l₁ at H,
   induction p with a l₁ l₂ p IH a b l l₁ l₂ l₃ p₁ p₂ IH₁ IH₂, {simp},
   { cases h : f a,
-    { simp [h], exact (IH (pairwise_cons.1 H).2).skip _ },
-    { simp [lookmap_cons_some _ _ h], exact p.skip _ } },
+    { simp [h], exact IH (pairwise_cons.1 H).2 },
+    { simp [lookmap_cons_some _ _ h, p] } },
   { cases h₁ : f a with c; cases h₂ : f b with d,
     { simp [h₁, h₂], apply swap },
     { simp [h₁, lookmap_cons_some _ _ h₂], apply swap },
@@ -765,11 +815,11 @@ begin
     { simp [lookmap_cons_some _ _ h₁, lookmap_cons_some _ _ h₂],
       rcases (pairwise_cons.1 H).1 _ (or.inl rfl) _ h₂ _ h₁ with ⟨rfl, rfl⟩,
       refl } },
-  { refine (IH₁ H).trans (IH₂ ((perm_pairwise _ p₁).1 H)),
+  { refine (IH₁ H).trans (IH₂ ((p₁.pairwise_iff _).1 H)),
     exact λ a b h c h₁ d h₂, (h d h₂ c h₁).imp eq.symm eq.symm }
 end
 
-theorem perm_erasep (f : α → Prop) [decidable_pred f] {l₁ l₂ : list α}
+theorem perm.erasep (f : α → Prop) [decidable_pred f] {l₁ l₂ : list α}
   (H : pairwise (λ a b, f a → f b → false) l₁)
   (p : l₁ ~ l₂) : erasep f l₁ ~ erasep f l₂ :=
 begin
@@ -778,11 +828,11 @@ begin
   induction p with a l₁ l₂ p IH a b l l₁ l₂ l₃ p₁ p₂ IH₁ IH₂, {simp},
   { by_cases h : f a,
     { simp [h, p] },
-    { simp [h], exact (IH (pairwise_cons.1 H).2).skip _ } },
+    { simp [h], exact IH (pairwise_cons.1 H).2 } },
   { by_cases h₁ : f a; by_cases h₂ : f b; simp [h₁, h₂],
     { cases (pairwise_cons.1 H).1 _ (or.inl rfl) h₂ h₁ },
     { apply swap } },
-  { refine (IH₁ H).trans (IH₂ ((perm_pairwise _ p₁).1 H)),
+  { refine (IH₁ H).trans (IH₂ ((p₁.pairwise_iff _).1 H)),
     exact λ a b h h₁ h₂, h h₂ h₁ }
 end
 
@@ -883,7 +933,7 @@ begin
     { simp [permutations] at m,
       cases m with e m, {simp [e]},
       exact is.append_nil ▸ IH2 m },
-    exact (perm_app_left _ (perm_middle.trans (skip _ p))).trans (skip _ perm_app_comm) }
+    exact ((perm_middle.trans (p.cons _)).append_right _).trans (perm_append_comm.cons _) }
 end
 
 theorem perm_of_mem_permutations {l₁ l₂ : list α}
@@ -901,7 +951,7 @@ begin
   simp [-add_comm, nat.fact, nat.add_succ, mul_comm] at IH1,
   rw [permutations_aux_cons,
       length_foldr_permutations_aux2' _ _ _ _ _
-        (λ l m, perm_length (perm_of_mem_permutations m)),
+        (λ l m, (perm_of_mem_permutations m).length_eq),
       permutations, length, length, IH2,
       nat.succ_add, nat.fact_succ, mul_comm (nat.succ _), ← IH1,
       add_comm (_*_), add_assoc, nat.mul_succ, mul_comm]
@@ -923,9 +973,9 @@ begin
   rw [permutations_aux_cons, mem_foldr_permutations_aux2],
   rcases IH1 (p.trans perm_middle) with ⟨is', p', e⟩ | m,
   { clear p, subst e,
-    rcases mem_split (perm_subset p'.symm (mem_cons_self _ _)) with ⟨l₁, l₂, e⟩,
+    rcases mem_split (p'.symm.subset (mem_cons_self _ _)) with ⟨l₁, l₂, e⟩,
     subst is',
-    have p := perm_cons_inv (perm_middle.symm.trans p'),
+    have p := (perm_middle.symm.trans p').cons_inv,
     cases l₂ with a l₂',
     { exact or.inl ⟨l₁, by simpa using p⟩ },
     { exact or.inr (or.inr ⟨l₁, a::l₂',

--- a/src/data/list/range.lean
+++ b/src/data/list/range.lean
@@ -70,7 +70,7 @@ theorem range'_sublist_right {s m n : ℕ} : range' s m <+ range' s n ↔ m ≤ 
 theorem range'_subset_right {s m n : ℕ} : range' s m ⊆ range' s n ↔ m ≤ n :=
 ⟨λ h, le_of_not_lt $ λ hn, lt_irrefl (s+n) $
   (mem_range'.1 $ h $ mem_range'.2 ⟨le_add_right _ _, nat.add_lt_add_left hn s⟩).2,
- λ h, subset_of_sublist (range'_sublist_right.2 h)⟩
+ λ h, (range'_sublist_right.2 h).subset⟩
 
 theorem nth_range' : ∀ s {m n : ℕ}, m < n → nth (range' s n) m = some (s + m)
 | s 0     (n+1) _ := rfl

--- a/src/data/list/sigma.lean
+++ b/src/data/list/sigma.lean
@@ -51,6 +51,10 @@ l.keys.nodup
 theorem nodupkeys_iff_pairwise {l} : nodupkeys l ↔
   pairwise (λ s s' : sigma β, s.1 ≠ s'.1) l := pairwise_map _
 
+theorem nodupkeys.pairwise_ne {l} (h : nodupkeys l) :
+  pairwise (λ s s' : sigma β, s.1 ≠ s'.1) l :=
+nodupkeys_iff_pairwise.1 h
+
 @[simp] theorem nodupkeys_nil : @nodupkeys α β [] := pairwise.nil
 
 @[simp] theorem nodupkeys_cons {s : sigma β} {l : list (sigma β)} :
@@ -71,14 +75,15 @@ by cases nd.eq_of_fst_eq h h' rfl; refl
 
 theorem nodupkeys_singleton (s : sigma β) : nodupkeys [s] := nodup_singleton _
 
-theorem nodupkeys_of_sublist {l₁ l₂ : list (sigma β)} (h : l₁ <+ l₂) : nodupkeys l₂ → nodupkeys l₁ :=
-nodup_of_sublist (map_sublist_map _ h)
+theorem nodupkeys_of_sublist {l₁ l₂ : list (sigma β)} (h : l₁ <+ l₂) :
+  nodupkeys l₂ → nodupkeys l₁ :=
+nodup_of_sublist (h.map _)
 
 theorem nodup_of_nodupkeys {l : list (sigma β)} : nodupkeys l → nodup l :=
 nodup_of_nodup_map _
 
 theorem perm_nodupkeys {l₁ l₂ : list (sigma β)} (h : l₁ ~ l₂) : nodupkeys l₁ ↔ nodupkeys l₂ :=
-perm_nodup $ perm_map _ h
+(h.map _).nodup_iff
 
 theorem nodupkeys_join {L : list (list (sigma β))} :
   nodupkeys (join L) ↔ (∀ l ∈ L, nodupkeys l) ∧ pairwise disjoint (L.map keys) :=
@@ -120,7 +125,7 @@ begin
           simp [mem_erase_of_ne,*] } } },
     transitivity y :: x :: ys.erase x,
     { constructor },
-    { constructor, symmetry, apply perm_erase,
+    { constructor, symmetry, apply perm_cons_erase,
       specialize h x, simp [h'] at h, exact h } }
 end
 
@@ -191,7 +196,7 @@ theorem mem_lookup_iff {a : α} {b : β a} {l : list (sigma β)} (nd : l.nodupke
 
 theorem perm_lookup (a : α) {l₁ l₂ : list (sigma β)}
   (nd₁ : l₁.nodupkeys) (nd₂ : l₂.nodupkeys) (p : l₁ ~ l₂) : lookup a l₁ = lookup a l₂ :=
-by ext b; simp [mem_lookup_iff, nd₁, nd₂]; exact mem_of_perm p
+by ext b; simp [mem_lookup_iff, nd₁, nd₂]; exact p.mem_iff
 
 lemma lookup_ext {l₀ l₁ : list (sigma β)}
   (nd₀ : l₀.nodupkeys) (nd₁ : l₁.nodupkeys)
@@ -246,7 +251,7 @@ theorem lookup_all_sublist (a : α) :
 
 theorem lookup_all_length_le_one (a : α) {l : list (sigma β)} (h : l.nodupkeys) :
   length (lookup_all a l) ≤ 1 :=
-by have := nodup_of_sublist (map_sublist_map _ $ lookup_all_sublist a l) h;
+by have := nodup_of_sublist ((lookup_all_sublist a l).map _) h;
    rw map_map at this; rwa [← nodup_repeat, ← map_const _ a]
 
 theorem lookup_all_eq_lookup (a : α) {l : list (sigma β)} (h : l.nodupkeys) :
@@ -299,11 +304,11 @@ theorem kreplace_nodupkeys (a : α) (b : β a) {l : list (sigma β)} :
   (kreplace a b l).nodupkeys ↔ l.nodupkeys :=
 by simp [nodupkeys, keys_kreplace]
 
-theorem perm_kreplace {a : α} {b : β a} {l₁ l₂ : list (sigma β)}
+theorem perm.kreplace {a : α} {b : β a} {l₁ l₂ : list (sigma β)}
   (nd : l₁.nodupkeys) : l₁ ~ l₂ →
   kreplace a b l₁ ~ kreplace a b l₂ :=
 perm_lookmap _ $ begin
-  refine (nodupkeys_iff_pairwise.1 nd).imp _,
+  refine nd.pairwise_ne.imp _,
   intros x y h z h₁ w h₂,
   split_ifs at h₁ h₂; cases h₁; cases h₂,
   exact (h (h_2.symm.trans h_1)).elim
@@ -339,7 +344,7 @@ erasep_sublist _
 
 theorem kerase_keys_subset (a) (l : list (sigma β)) :
   (kerase a l).keys ⊆ l.keys :=
-subset_of_sublist (map_sublist_map _ (kerase_sublist a l))
+((kerase_sublist a l).map _).subset
 
 theorem mem_keys_of_mem_keys_kerase {a₁ a₂} {l : list (sigma β)} :
   a₁ ∈ (kerase a₂ l).keys → a₁ ∈ l.keys :=
@@ -380,7 +385,8 @@ iff.intro mem_keys_of_mem_keys_kerase $ λ p,
 theorem keys_kerase {a} {l : list (sigma β)} : (kerase a l).keys = l.keys.erase a :=
 by rw [keys, kerase, ←erasep_map sigma.fst l, erase_eq_erasep]
 
-theorem kerase_kerase {a a'} {l : list (sigma β)} : (kerase a' l).kerase a = (kerase a l).kerase a' :=
+theorem kerase_kerase {a a'} {l : list (sigma β)} :
+  (kerase a' l).kerase a = (kerase a l).kerase a' :=
 begin
   by_cases a = a',
   { subst a' },
@@ -395,9 +401,9 @@ end
 theorem kerase_nodupkeys (a : α) {l : list (sigma β)} : nodupkeys l → (kerase a l).nodupkeys :=
 nodupkeys_of_sublist $ kerase_sublist _ _
 
-theorem perm_kerase {a : α} {l₁ l₂ : list (sigma β)}
+theorem perm.kerase {a : α} {l₁ l₂ : list (sigma β)}
   (nd : l₁.nodupkeys) : l₁ ~ l₂ → kerase a l₁ ~ kerase a l₂ :=
-perm_erasep _ $ (nodupkeys_iff_pairwise.1 nd).imp $
+perm.erasep _ $ (nodupkeys_iff_pairwise.1 nd).imp $
 by rintro x y h rfl; exact h
 
 @[simp] theorem not_mem_keys_kerase (a) {l : list (sigma β)} (nd : l.nodupkeys) :
@@ -485,9 +491,9 @@ theorem kinsert_nodupkeys (a) (b : β a) {l : list (sigma β)} (nd : l.nodupkeys
   (kinsert a b l).nodupkeys :=
 nodupkeys_cons.mpr ⟨not_mem_keys_kerase a nd, kerase_nodupkeys a nd⟩
 
-theorem perm_kinsert {a} {b : β a} {l₁ l₂ : list (sigma β)} (nd₁ : l₁.nodupkeys)
+theorem perm.kinsert {a} {b : β a} {l₁ l₂ : list (sigma β)} (nd₁ : l₁.nodupkeys)
   (p : l₁ ~ l₂) : kinsert a b l₁ ~ kinsert a b l₂ :=
-perm.skip ⟨a, b⟩ $ perm_kerase nd₁ p
+(p.kerase nd₁).cons _
 
 theorem lookup_kinsert {a} {b : β a} (l : list (sigma β)) :
   lookup a (kinsert a b l) = some b :=
@@ -515,10 +521,12 @@ def kextract (a : α) : list (sigma β) → option (β a) × list (sigma β)
 
 /- erase_dupkeys -/
 
+/-- Remove entries with duplicate keys from `l : list (sigma β)`. -/
 def erase_dupkeys : list (sigma β) → list (sigma β) :=
-list.foldr (λ ⟨x,y⟩, kinsert x y) []
+list.foldr (λ x, kinsert x.1 x.2) []
 
-lemma erase_dupkeys_cons {x : α} {y : β x} (l : list (sigma β)) : erase_dupkeys (⟨x,y⟩ :: l) = kinsert x y (erase_dupkeys l) := rfl
+lemma erase_dupkeys_cons {x : sigma β} (l : list (sigma β)) :
+  erase_dupkeys (x :: l) = kinsert x.1 x.2 (erase_dupkeys l) := rfl
 
 lemma nodupkeys_erase_dupkeys (l : list (sigma β)) : nodupkeys (erase_dupkeys l) :=
 begin
@@ -584,29 +592,28 @@ begin
     simp [not_or_distrib, nd₁.1, nd₂, ih nd₁.2 (kerase_nodupkeys s.1 nd₂)] }
 end
 
-theorem perm_kunion_left {l₁ l₂ : list (sigma β)} (p : l₁ ~ l₂) (l) :
+theorem perm.kunion_right {l₁ l₂ : list (sigma β)} (p : l₁ ~ l₂) (l) :
   kunion l₁ l ~ kunion l₂ l :=
 begin
   induction p generalizing l,
   case list.perm.nil { refl },
-  case list.perm.skip : hd tl₁ tl₂ p ih {
-    simp [ih (kerase hd.1 l), perm.skip] },
+  case list.perm.cons : hd tl₁ tl₂ p ih {
+    simp [ih (kerase hd.1 l), perm.cons] },
   case list.perm.swap : s₁ s₂ l {
     simp [kerase_comm, perm.swap] },
   case list.perm.trans : l₁ l₂ l₃ p₁₂ p₂₃ ih₁₂ ih₂₃ {
     exact perm.trans (ih₁₂ l) (ih₂₃ l) }
 end
 
-theorem perm_kunion_right : ∀ l {l₁ l₂ : list (sigma β)},
+theorem perm.kunion_left : ∀ l {l₁ l₂ : list (sigma β)},
   l₁.nodupkeys → l₁ ~ l₂ → kunion l l₁ ~ kunion l l₂
 | []       _  _  _   p := p
 | (s :: l) l₁ l₂ nd₁ p :=
-  by simp [perm.skip s
-    (perm_kunion_right l (kerase_nodupkeys s.1 nd₁) (perm_kerase nd₁ p))]
+  by simp [((p.kerase nd₁).kunion_left l (kerase_nodupkeys s.1 nd₁)).cons s]
 
-theorem perm_kunion {l₁ l₂ l₃ l₄ : list (sigma β)} (nd₃ : l₃.nodupkeys)
+theorem perm.kunion {l₁ l₂ l₃ l₄ : list (sigma β)} (nd₃ : l₃.nodupkeys)
   (p₁₂ : l₁ ~ l₂) (p₃₄ : l₃ ~ l₄) : kunion l₁ l₃ ~ kunion l₂ l₄ :=
-perm.trans (perm_kunion_left p₁₂ l₃) (perm_kunion_right l₂ nd₃ p₃₄)
+(p₁₂.kunion_right l₃).trans (p₃₄.kunion_left l₂ nd₃)
 
 @[simp] theorem lookup_kunion_left {a} {l₁ l₂ : list (sigma β)} (h : a ∈ l₁.keys) :
   lookup a (kunion l₁ l₂) = lookup a l₁ :=

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -60,7 +60,7 @@ iff.trans coe_eq_coe perm_nil
   instance of `a`. -/
 def cons (a : α) (s : multiset α) : multiset α :=
 quot.lift_on s (λ l, (a :: l : multiset α))
-  (λ l₁ l₂ p, quot.sound ((perm_cons a).2 p))
+  (λ l₁ l₂ p, quot.sound (p.cons a))
 
 notation a :: b := cons a b
 
@@ -78,10 +78,10 @@ theorem singleton_coe (a : α) : (a::0 : multiset α) = ([a] : list α) := rfl
   a::s = b::s ↔ a = b :=
 ⟨quot.induction_on s $ λ l e,
   have [a] ++ l ~ [b] ++ l, from quotient.exact e,
-  eq_singleton_of_perm $ (perm_app_right_iff _).1 this, congr_arg _⟩
+  singleton_perm_singleton.1 $ (perm_append_right_iff _).1 this, congr_arg _⟩
 
 @[simp] theorem cons_inj_right (a : α) : ∀{s t : multiset α}, a::s = a::t ↔ s = t :=
-by rintros ⟨l₁⟩ ⟨l₂⟩; simp [perm_cons]
+by rintros ⟨l₁⟩ ⟨l₂⟩; simp
 
 @[recursor 5] protected theorem induction {p : multiset α → Prop}
   (h₁ : p 0) (h₂ : ∀ ⦃a : α⦄ {s : multiset α}, p s → p (a :: s)) : ∀s, p s :=
@@ -99,7 +99,7 @@ variables {C : multiset α → Sort*}
 
 /-- Dependent recursor on multisets.
 
-TODO: should be @[recursor 6], but then the definition of `multiset.pi` failes with a stack
+TODO: should be @[recursor 6], but then the definition of `multiset.pi` fails with a stack
 overflow in `whnf`.
 -/
 protected def rec
@@ -109,7 +109,7 @@ protected def rec
   (m : multiset α) : C m :=
 quotient.hrec_on m (@list.rec α (λl, C ⟦l⟧) C_0 (λa l b, C_cons a ⟦l⟧ b)) $
   assume l l' h,
-  list.rec_heq_of_perm h
+  h.rec_heq
     (assume a l l' b b' hl, have ⟦l⟧ = ⟦l'⟧, from quot.sound hl, by cc)
     (assume a a' l, C_cons_heq a a' ⟦l⟧)
 
@@ -137,7 +137,7 @@ section mem
 
 /-- `a ∈ s` means that `a` has nonzero multiplicity in `s`. -/
 def mem (a : α) (s : multiset α) : Prop :=
-quot.lift_on s (λ l, a ∈ l) (λ l₁ l₂ (e : l₁ ~ l₂), propext $ mem_of_perm e)
+quot.lift_on s (λ l, a ∈ l) (λ l₁ l₂ (e : l₁ ~ l₂), propext $ e.mem_iff)
 
 instance : has_mem α (multiset α) := ⟨mem⟩
 
@@ -254,7 +254,7 @@ instance : partial_order (multiset α) :=
   le_antisymm := by rintros ⟨l₁⟩ ⟨l₂⟩ h₁ h₂; exact quot.sound (subperm.antisymm h₁ h₂) }
 
 theorem subset_of_le {s t : multiset α} : s ≤ t → s ⊆ t :=
-quotient.induction_on₂ s t $ λ l₁ l₂, subset_of_subperm
+quotient.induction_on₂ s t $ λ l₁ l₂, subperm.subset
 
 theorem mem_of_le {s t : multiset α} {a : α} (h : s ≤ t) : a ∈ s → a ∈ t :=
 mem_of_subset (subset_of_le h)
@@ -268,7 +268,7 @@ quotient.induction_on₂ s t (λ l₁ l₂ ⟨l, p, s⟩,
   (show ⟦l⟧ = ⟦l₁⟧, from quot.sound p) ▸ H s) h
 
 theorem zero_le (s : multiset α) : 0 ≤ s :=
-quot.induction_on s $ λ l, subperm_of_sublist $ nil_sublist l
+quot.induction_on s $ λ l, (nil_sublist l).subperm
 
 theorem le_zero {s : multiset α} : s ≤ 0 ↔ s = 0 :=
 ⟨λ h, le_antisymm h (zero_le _), le_of_eq⟩
@@ -277,9 +277,8 @@ theorem lt_cons_self (s : multiset α) (a : α) : s < a :: s :=
 quot.induction_on s $ λ l,
 suffices l <+~ a :: l ∧ (¬l ~ a :: l),
   by simpa [lt_iff_le_and_ne],
-⟨subperm_of_sublist (sublist_cons _ _),
- λ p, ne_of_lt (lt_succ_self (length l)) (perm_length p)⟩
-
+⟨(sublist_cons _ _).subperm,
+ λ p, ne_of_lt (lt_succ_self (length l)) p.length_eq⟩
 
 theorem le_cons_self (s : multiset α) (a : α) : s ≤ a :: s :=
 le_of_lt $ lt_cons_self _ _
@@ -298,8 +297,8 @@ begin
   introv h, revert m, refine le_induction_on h _,
   introv s m₁ m₂,
   rcases mem_split m₂ with ⟨r₁, r₂, rfl⟩,
-  exact perm_middle.subperm_left.2 ((subperm_cons _).2 $ subperm_of_sublist $
-    (sublist_or_mem_of_sublist s).resolve_right m₁)
+  exact perm_middle.subperm_left.2 ((subperm_cons _).2 $
+    ((sublist_or_mem_of_sublist s).resolve_right m₁).subperm)
 end
 
 /- cardinality -/
@@ -307,7 +306,7 @@ end
 /-- The cardinality of a multiset is the sum of the multiplicities
   of all its elements, or simply the length of the underlying list. -/
 def card (s : multiset α) : ℕ :=
-quot.lift_on s length $ λ l₁ l₂, perm_length
+quot.lift_on s length $ λ l₁ l₂, perm.length_eq
 
 @[simp] theorem coe_card (l : list α) : card (l : multiset α) = length l := rfl
 
@@ -387,14 +386,14 @@ theorem card_eq_one {s : multiset α} : card s = 1 ↔ ∃ a, s = a::0 :=
   i.e. `count a (s + t) = count a s + count a t`. -/
 protected def add (s₁ s₂ : multiset α) : multiset α :=
 quotient.lift_on₂ s₁ s₂ (λ l₁ l₂, ((l₁ ++ l₂ : list α) : multiset α)) $
-  λ v₁ v₂ w₁ w₂ p₁ p₂, quot.sound $ perm_app p₁ p₂
+  λ v₁ v₂ w₁ w₂ p₁ p₂, quot.sound $ p₁.append p₂
 
 instance : has_add (multiset α) := ⟨multiset.add⟩
 
 @[simp] theorem coe_add (s t : list α) : (s + t : multiset α) = (s ++ t : list α) := rfl
 
 protected theorem add_comm (s t : multiset α) : s + t = t + s :=
-quotient.induction_on₂ s t $ λ l₁ l₂, quot.sound perm_app_comm
+quotient.induction_on₂ s t $ λ l₁ l₂, quot.sound perm_append_comm
 
 protected theorem zero_add (s : multiset α) : 0 + s = s :=
 quot.induction_on s $ λ l, rfl
@@ -402,7 +401,7 @@ quot.induction_on s $ λ l, rfl
 theorem singleton_add (a : α) (s : multiset α) : ↑[a] + s = a::s := rfl
 
 protected theorem add_le_add_left (s) {t u : multiset α} : s + t ≤ s + u ↔ t ≤ u :=
-quotient.induction_on₃ s t u $ λ l₁ l₂ l₃, subperm_app_left _
+quotient.induction_on₃ s t u $ λ l₁ l₂ l₃, subperm_append_left _
 
 protected theorem add_left_cancel (s) {t u : multiset α} (h : s + t = s + u) : t = u :=
 le_antisymm ((multiset.add_le_add_left _).1 (le_of_eq h))
@@ -447,7 +446,7 @@ quotient.induction_on₂ s t $ λ l₁ l₂, mem_append
 
 theorem le_iff_exists_add {s t : multiset α} : s ≤ t ↔ ∃ u, t = s + u :=
 ⟨λ h, le_induction_on h $ λ l₁ l₂ s,
-  let ⟨l, p⟩ := exists_perm_append_of_sublist s in ⟨l, quot.sound p⟩,
+  let ⟨l, p⟩ := s.exists_perm_append in ⟨l, quot.sound p⟩,
 λ⟨u, e⟩, e.symm ▸ le_add_right s u⟩
 
 instance : canonically_ordered_add_monoid (multiset α) :=
@@ -474,7 +473,7 @@ theorem eq_of_mem_repeat {a b : α} {n} : b ∈ repeat a n → b = a := eq_of_me
 
 theorem eq_repeat' {a : α} {s : multiset α} : s = repeat a s.card ↔ ∀ b ∈ s, b = a :=
 quot.induction_on s $ λ l, iff.trans ⟨λ h,
-  (perm_repeat.1 $ (quotient.exact h).symm).symm, congr_arg coe⟩ eq_repeat'
+  (perm_repeat.1 $ (quotient.exact h)), congr_arg coe⟩ eq_repeat'
 
 theorem eq_repeat_of_mem {a : α} {s : multiset α} : (∀ b ∈ s, b = a) → s = repeat a s.card :=
 eq_repeat'.2
@@ -486,7 +485,7 @@ theorem eq_repeat {a : α} {n} {s : multiset α} : s = repeat a n ↔ card s = n
 theorem repeat_subset_singleton : ∀ (a : α) n, repeat a n ⊆ a::0 := repeat_subset_singleton
 
 theorem repeat_le_coe {a : α} {n} {l : list α} : repeat a n ≤ l ↔ list.repeat a n <+ l :=
-⟨λ ⟨l', p, s⟩, (perm_repeat.1 p.symm).symm ▸ s, subperm_of_sublist⟩
+⟨λ ⟨l', p, s⟩, (perm_repeat.1 p) ▸ s, sublist.subperm⟩
 
 /- range -/
 
@@ -515,7 +514,7 @@ variables [decidable_eq α] {s t : multiset α} {a b : α}
   multiplicity of `a`. -/
 def erase (s : multiset α) (a : α) : multiset α :=
 quot.lift_on s (λ l, (l.erase a : multiset α))
-  (λ l₁ l₂ p, quot.sound (erase_perm_erase a p))
+  (λ l₁ l₂ p, quot.sound (p.erase a))
 
 @[simp] theorem coe_erase (l : list α) (a : α) :
   erase (l : multiset α) a = l.erase a := rfl
@@ -535,7 +534,7 @@ quot.induction_on s $ λ l h, congr_arg coe $ erase_of_not_mem h
 
 @[simp, priority 980]
 theorem cons_erase {s : multiset α} {a : α} : a ∈ s → a :: s.erase a = s :=
-quot.induction_on s $ λ l h, quot.sound (perm_erase h).symm
+quot.induction_on s $ λ l h, quot.sound (perm_cons_erase h).symm
 
 theorem le_cons_erase (s : multiset α) (a : α) : s ≤ a :: s.erase a :=
 if h : a ∈ s then le_of_eq (cons_erase h).symm
@@ -544,17 +543,20 @@ else by rw erase_of_not_mem h; apply le_cons_self
 theorem erase_add_left_pos {a : α} {s : multiset α} (t) : a ∈ s → (s + t).erase a = s.erase a + t :=
 quotient.induction_on₂ s t $ λ l₁ l₂ h, congr_arg coe $ erase_append_left l₂ h
 
-theorem erase_add_right_pos {a : α} (s) {t : multiset α} (h : a ∈ t) : (s + t).erase a = s + t.erase a :=
+theorem erase_add_right_pos {a : α} (s) {t : multiset α} (h : a ∈ t) :
+  (s + t).erase a = s + t.erase a :=
 by rw [add_comm, erase_add_left_pos s h, add_comm]
 
-theorem erase_add_right_neg {a : α} {s : multiset α} (t) : a ∉ s → (s + t).erase a = s + t.erase a :=
+theorem erase_add_right_neg {a : α} {s : multiset α} (t) :
+  a ∉ s → (s + t).erase a = s + t.erase a :=
 quotient.induction_on₂ s t $ λ l₁ l₂ h, congr_arg coe $ erase_append_right l₂ h
 
-theorem erase_add_left_neg {a : α} (s) {t : multiset α} (h : a ∉ t) : (s + t).erase a = s.erase a + t :=
+theorem erase_add_left_neg {a : α} (s) {t : multiset α} (h : a ∉ t) :
+  (s + t).erase a = s.erase a + t :=
 by rw [add_comm, erase_add_right_neg s h, add_comm]
 
 theorem erase_le (a : α) (s : multiset α) : s.erase a ≤ s :=
-quot.induction_on s $ λ l, subperm_of_sublist (erase_sublist a l)
+quot.induction_on s $ λ l, (erase_sublist a l).subperm
 
 @[simp] theorem erase_lt {a : α} {s : multiset α} : s.erase a < s ↔ a ∈ s :=
 ⟨λ h, not_imp_comm.1 erase_of_not_mem (ne_of_lt h),
@@ -573,7 +575,7 @@ theorem erase_comm (s : multiset α) (a b : α) : (s.erase a).erase b = (s.erase
 quot.induction_on s $ λ l, congr_arg coe $ l.erase_comm a b
 
 theorem erase_le_erase {s t : multiset α} (a : α) (h : s ≤ t) : s.erase a ≤ t.erase a :=
-le_induction_on h $ λ l₁ l₂ h, subperm_of_sublist (erase_sublist_erase _ h)
+le_induction_on h $ λ l₁ l₂ h, (h.erase _).subperm
 
 theorem erase_le_iff_le_cons {s t : multiset α} {a : α} : s.erase a ≤ t ↔ s ≤ a :: t :=
 ⟨λ h, le_trans (le_cons_erase _ _) (cons_le_cons _ h),
@@ -581,7 +583,8 @@ theorem erase_le_iff_le_cons {s t : multiset α} {a : α} : s.erase a ≤ t ↔ 
   then by rw ← cons_erase m at h; exact (cons_le_cons_iff _).1 h
   else le_trans (erase_le _ _) ((le_cons_of_not_mem m).1 h)⟩
 
-@[simp] theorem card_erase_of_mem {a : α} {s : multiset α} : a ∈ s → card (s.erase a) = pred (card s) :=
+@[simp] theorem card_erase_of_mem {a : α} {s : multiset α} :
+  a ∈ s → card (s.erase a) = pred (card s) :=
 quot.induction_on s $ λ l, length_erase_of_mem
 
 theorem card_erase_lt_of_mem {a : α} {s : multiset α} : a ∈ s → card (s.erase a) < card s :=
@@ -602,7 +605,7 @@ quot.sound $ reverse_perm _
   such that `f a = b`. -/
 def map (f : α → β) (s : multiset α) : multiset β :=
 quot.lift_on s (λ l : list α, (l.map f : multiset β))
-  (λ l₁ l₂ p, quot.sound (perm_map f p))
+  (λ l₁ l₂ p, quot.sound (p.map f))
 
 @[simp] theorem coe_map (f : α → β) (l : list α) : map f ↑l = l.map f := rfl
 
@@ -658,7 +661,7 @@ theorem eq_of_mem_map_const {b₁ b₂ : β} {l : list α} (h : b₁ ∈ map (fu
 eq_of_mem_repeat $ by rwa map_const at h
 
 @[simp] theorem map_le_map {f : α → β} {s t : multiset α} (h : s ≤ t) : map f s ≤ map f t :=
-le_induction_on h $ λ l₁ l₂ h, subperm_of_sublist $ map_sublist_map f h
+le_induction_on h $ λ l₁ l₂ h, (h.map f).subperm
 
 @[simp] theorem map_subset_map {f : α → β} {s t : multiset α} (H : s ⊆ t) : map f s ⊆ map f t :=
 λ b m, let ⟨a, h, e⟩ := mem_map.1 m in mem_map.2 ⟨a, H h, e⟩
@@ -670,7 +673,7 @@ le_induction_on h $ λ l₁ l₂ h, subperm_of_sublist $ map_sublist_map f h
   that is, `f (f b a₁) a₂ = f (f b a₂) a₁`. -/
 def foldl (f : β → α → β) (H : right_commutative f) (b : β) (s : multiset α) : β :=
 quot.lift_on s (λ l, foldl f b l)
-  (λ l₁ l₂ p, foldl_eq_of_perm H p b)
+  (λ l₁ l₂ p, p.foldl_eq H b)
 
 @[simp] theorem foldl_zero (f : β → α → β) (H b) : foldl f H b 0 = b := rfl
 
@@ -685,7 +688,7 @@ quotient.induction_on₂ s t $ λ l₁ l₂, foldl_append _ _ _ _
   that is, `f a₁ (f a₂ b) = f a₂ (f a₁ b)`. -/
 def foldr (f : α → β → β) (H : left_commutative f) (b : β) (s : multiset α) : β :=
 quot.lift_on s (λ l, foldr f b l)
-  (λ l₁ l₂ p, foldr_eq_of_perm H p b)
+  (λ l₁ l₂ p, p.foldr_eq H b)
 
 @[simp] theorem foldr_zero (f : α → β → β) (H b) : foldr f H b 0 = b := rfl
 
@@ -1001,11 +1004,11 @@ end
 def pmap {p : α → Prop} (f : Π a, p a → β) (s : multiset α) : (∀ a ∈ s, p a) → multiset β :=
 quot.rec_on s (λ l H, ↑(pmap f l H)) $ λ l₁ l₂ (pp : l₁ ~ l₂),
 funext $ λ (H₂ : ∀ a ∈ l₂, p a),
-have H₁ : ∀ a ∈ l₁, p a, from λ a h, H₂ a ((mem_of_perm pp).1 h),
+have H₁ : ∀ a ∈ l₁, p a, from λ a h, H₂ a (pp.subset h),
 have ∀ {s₂ e H}, @eq.rec (multiset α) l₁
   (λ s, (∀ a ∈ s, p a) → multiset β) (λ _, ↑(pmap f l₁ H₁))
   s₂ e H = ↑(pmap f l₁ H₁), by intros s₂ e _; subst e,
-this.trans $ quot.sound $ perm_pmap f pp
+this.trans $ quot.sound $ pp.pmap f
 
 @[simp] theorem coe_pmap {p : α → Prop} (f : Π a, p a → β)
   (l : list α) (H : ∀ a ∈ l, p a) : pmap f l H = l.pmap f H := rfl
@@ -1104,7 +1107,7 @@ variables [decidable_eq α] {s t u : multiset α} {a b : α}
   `count a (s - t) = count a s - count a t` for all `a`. -/
 protected def sub (s t : multiset α) : multiset α :=
 quotient.lift_on₂ s t (λ l₁ l₂, (l₁.diff l₂ : multiset α)) $ λ v₁ v₂ w₁ w₂ p₁ p₂,
-  quot.sound $ perm_diff_right w₁ p₂ ▸ perm_diff_left _ p₁
+  quot.sound $ p₁.diff p₂
 
 instance : has_sub (multiset α) := ⟨multiset.sub⟩
 
@@ -1212,7 +1215,7 @@ congr_arg coe (by rw [list.map_append f, list.map_diff finj])
   of the multiplicities in `s` and `t`. -/
 def inter (s t : multiset α) : multiset α :=
 quotient.lift_on₂ s t (λ l₁ l₂, (l₁.bag_inter l₂ : multiset α)) $ λ v₁ v₂ w₁ w₂ p₁ p₂,
-  quot.sound $ perm_bag_inter_right w₁ p₂ ▸ perm_bag_inter_left _ p₁
+  quot.sound $ p₁.bag_inter p₂
 
 instance : has_inter (multiset α) := ⟨inter⟩
 
@@ -1234,7 +1237,7 @@ congr_arg coe $ cons_bag_inter_of_neg _ h
 
 theorem inter_le_left (s t : multiset α) : s ∩ t ≤ s :=
 quotient.induction_on₂ s t $ λ l₁ l₂,
-subperm_of_sublist $ bag_inter_sublist_left _ _
+(bag_inter_sublist_left _ _).subperm
 
 theorem inter_le_right (s : multiset α) : ∀ t, s ∩ t ≤ t :=
 multiset.induction_on s (λ t, (zero_inter t).symm ▸ zero_le _) $
@@ -1352,7 +1355,7 @@ variables {p : α → Prop} [decidable_pred p]
   which satisfy `p`, and removes the rest. -/
 def filter (p : α → Prop) [h : decidable_pred p] (s : multiset α) : multiset α :=
 quot.lift_on s (λ l, (filter p l : multiset α))
-  (λ l₁ l₂ h, quot.sound $ perm_filter p h)
+  (λ l₁ l₂ h, quot.sound $ h.filter p)
 
 @[simp] theorem coe_filter (p : α → Prop) [h : decidable_pred p]
   (l : list α) : filter p (↑l) = l.filter p := rfl
@@ -1374,7 +1377,7 @@ quot.induction_on s $ λ l h, congr_arg coe $ filter_congr h
 quotient.induction_on₂ s t $ λ l₁ l₂, congr_arg coe $ filter_append _ _
 
 @[simp] theorem filter_le (s : multiset α) : filter p s ≤ s :=
-quot.induction_on s $ λ l, subperm_of_sublist $ filter_sublist _
+quot.induction_on s $ λ l, (filter_sublist _).subperm
 
 @[simp] theorem filter_subset (s : multiset α) : filter p s ⊆ s :=
 subset_of_le $ filter_le _
@@ -1402,7 +1405,7 @@ quot.induction_on s $ λ l, iff.trans ⟨λ h,
   congr_arg coe⟩ filter_eq_nil
 
 theorem filter_le_filter {s t} (h : s ≤ t) : filter p s ≤ filter p t :=
-le_induction_on h $ λ l₁ l₂ h, subperm_of_sublist $ filter_sublist_filter h
+le_induction_on h $ λ l₁ l₂ h, (filter_sublist_filter h).subperm
 
 theorem le_filter {s t} : s ≤ filter p t ↔ s ≤ t ∧ ∀ a ∈ s, p a :=
 ⟨λ h, ⟨le_trans h (filter_le _), λ a m, of_mem_filter (mem_of_le h m)⟩,
@@ -1459,9 +1462,10 @@ by rw [filter_add_filter, filter_eq_self.2, filter_eq_nil.2]; simp [decidable.em
   `a` is removed from the resulting multiset. -/
 def filter_map (f : α → option β) (s : multiset α) : multiset β :=
 quot.lift_on s (λ l, (filter_map f l : multiset β))
-  (λ l₁ l₂ h, quot.sound $perm_filter_map f h)
+  (λ l₁ l₂ h, quot.sound $ h.filter_map f)
 
-@[simp] theorem coe_filter_map (f : α → option β) (l : list α) : filter_map f l = l.filter_map f := rfl
+@[simp] theorem coe_filter_map (f : α → option β) (l : list α) :
+  filter_map f l = l.filter_map f := rfl
 
 @[simp] theorem filter_map_zero (f : α → option β) : filter_map f 0 = 0 := rfl
 
@@ -1517,8 +1521,7 @@ quot.induction_on s $ λ l, congr_arg coe $ map_filter_map_of_inv f g H l
 
 theorem filter_map_le_filter_map (f : α → option β) {s t : multiset α}
   (h : s ≤ t) : filter_map f s ≤ filter_map f t :=
-le_induction_on h $ λ l₁ l₂ h,
-subperm_of_sublist $ filter_map_sublist_filter_map _ h
+le_induction_on h $ λ l₁ l₂ h, (h.filter_map _).subperm
 
 /- powerset -/
 
@@ -1543,8 +1546,7 @@ def powerset_aux' (l : list α) : list (multiset α) := (sublists' l).map coe
 
 theorem powerset_aux_perm_powerset_aux' {l : list α} :
   powerset_aux l ~ powerset_aux' l :=
-by rw powerset_aux_eq_map_coe; exact
-perm_map _ (sublists_perm_sublists' _)
+by rw powerset_aux_eq_map_coe; exact (sublists_perm_sublists' _).map _
 
 @[simp] theorem powerset_aux'_nil : powerset_aux' (@nil α) = [0] := rfl
 
@@ -1556,11 +1558,11 @@ theorem powerset_aux'_perm {l₁ l₂ : list α} (p : l₁ ~ l₂) :
   powerset_aux' l₁ ~ powerset_aux' l₂ :=
 begin
   induction p with a l₁ l₂ p IH a b l l₁ l₂ l₃ p₁ p₂ IH₁ IH₂, {simp},
-  { simp, exact perm_app IH (perm_map _ IH) },
-  { simp, apply perm_app_right,
+  { simp, exact IH.append (IH.map _) },
+  { simp, apply perm.append_left,
     rw [← append_assoc, ← append_assoc,
         (by funext s; simp [cons_swap] : cons b ∘ cons a = cons a ∘ cons b)],
-    exact perm_app_left _ perm_app_comm },
+    exact perm_append_comm.append_right _ },
   { exact IH₁.trans IH₂ }
 end
 
@@ -1598,8 +1600,7 @@ quotient.induction_on s $ λ l, begin
   simp [powerset_coe],
   show l.map (coe ∘ list.ret) <+~ (sublists l).map coe,
   rw ← list.map_map,
-  exact subperm_of_sublist
-    (map_sublist_map _ (map_ret_sublist_sublists _))
+  exact ((map_ret_sublist_sublists _).map _).subperm
 end
 
 @[simp] theorem card_powerset (s : multiset α) :
@@ -1642,7 +1643,7 @@ begin
   haveI := classical.dec_eq α,
   rw [revzip_powerset_aux_lemma l revzip_powerset_aux,
       revzip_powerset_aux_lemma l revzip_powerset_aux'],
-  exact perm_map _ powerset_aux_perm_powerset_aux',
+  exact powerset_aux_perm_powerset_aux'.map _
 end
 
 theorem revzip_powerset_aux_perm {l₁ l₂ : list α} (p : l₁ ~ l₂) :
@@ -1650,7 +1651,7 @@ theorem revzip_powerset_aux_perm {l₁ l₂ : list α} (p : l₁ ~ l₂) :
 begin
   haveI := classical.dec_eq α,
   simp [λ l:list α, revzip_powerset_aux_lemma l revzip_powerset_aux, coe_eq_coe.2 p],
-  exact perm_map _ (powerset_aux_perm p)
+  exact (powerset_aux_perm p).map _
 end
 
 /-- The antidiagonal of a multiset `s` consists of all pairs `(t₁, t₂)`
@@ -1730,8 +1731,8 @@ by rw [powerset_len_aux, sublists_len_aux_eq, append_nil]
   s ∈ powerset_len_aux n l ↔ s ≤ ↑l ∧ card s = n :=
 quotient.induction_on s $
 by simp [powerset_len_aux_eq_map_coe, subperm]; exact
-  λ l₁, ⟨λ ⟨l₂, ⟨s, e⟩, p⟩, ⟨⟨_, p, s⟩, (perm_length p.symm).trans e⟩,
-    λ ⟨⟨l₂, p, s⟩, e⟩, ⟨_, ⟨s, (perm_length p).trans e⟩, p⟩⟩
+  λ l₁, ⟨λ ⟨l₂, ⟨s, e⟩, p⟩, ⟨⟨_, p, s⟩, p.symm.length_eq.trans e⟩,
+    λ ⟨⟨l₂, p, s⟩, e⟩, ⟨_, ⟨s, p.length_eq.trans e⟩, p⟩⟩
 
 @[simp] theorem powerset_len_aux_zero (l : list α) :
   powerset_len_aux 0 l = [0] :=
@@ -1750,13 +1751,13 @@ theorem powerset_len_aux_perm {n} {l₁ l₂ : list α} (p : l₁ ~ l₂) :
 begin
   induction n with n IHn generalizing l₁ l₂, {simp},
   induction p with a l₁ l₂ p IH a b l l₁ l₂ l₃ p₁ p₂ IH₁ IH₂, {refl},
-  { simp, exact perm_app IH (perm_map _ (IHn p)) },
-  { simp, apply perm_app_right,
+  { simp, exact IH.append ((IHn p).map _) },
+  { simp, apply perm.append_left,
     cases n, {simp, apply perm.swap},
     simp,
     rw [← append_assoc, ← append_assoc,
         (by funext s; simp [cons_swap] : cons b ∘ cons a = cons a ∘ cons b)],
-    exact perm_app_left _ perm_app_comm },
+    exact perm_append_comm.append_right _ },
   { exact IH₁.trans IH₂ }
 end
 
@@ -1795,19 +1796,19 @@ quotient.induction_on s $ by simp [powerset_len_coe]
 theorem powerset_len_le_powerset (n : ℕ) (s : multiset α) :
   powerset_len n s ≤ powerset s :=
 quotient.induction_on s $ λ l, by simp [powerset_len_coe]; exact
-  subperm_of_sublist (map_sublist_map _ (sublists_len_sublist_sublists' _ _))
+  ((sublists_len_sublist_sublists' _ _).map _).subperm
 
 theorem powerset_len_mono (n : ℕ) {s t : multiset α} (h : s ≤ t) :
   powerset_len n s ≤ powerset_len n t :=
 le_induction_on h $ λ l₁ l₂ h, by simp [powerset_len_coe]; exact
-  subperm_of_sublist (map_sublist_map _ (sublists_len_sublist_of_sublist _ h))
+  ((sublists_len_sublist_of_sublist _ h).map _).subperm
 
 /- countp -/
 
 /-- `countp p s` counts the number of elements of `s` (with multiplicity) that
   satisfy `p`. -/
 def countp (p : α → Prop) [decidable_pred p] (s : multiset α) : ℕ :=
-quot.lift_on s (countp p) (λ l₁ l₂, perm_countp p)
+quot.lift_on s (countp p) (λ l₁ l₂, perm.countp_eq p)
 
 @[simp] theorem coe_countp (l : list α) : countp p l = l.countp p := rfl
 
@@ -2229,7 +2230,7 @@ def pairwise (r : α → α → Prop) (m : multiset α) : Prop :=
 lemma pairwise_coe_iff_pairwise {r : α → α → Prop} (hr : symmetric r) {l : list α} :
   multiset.pairwise r l ↔ l.pairwise r :=
 iff.intro
-  (assume ⟨l', eq, h⟩, (list.perm_pairwise hr (quotient.exact eq)).2 h)
+  (assume ⟨l', eq, h⟩, ((quotient.exact eq).pairwise_iff hr).2 h)
   (assume h, ⟨l, rfl, h⟩)
 
 /- nodup -/
@@ -2237,7 +2238,7 @@ iff.intro
 /-- `nodup s` means that `s` has no duplicates, i.e. the multiplicity of
   any element is at most 1. -/
 def nodup (s : multiset α) : Prop :=
-quot.lift_on s nodup (λ s t p, propext $ perm_nodup p)
+quot.lift_on s nodup (λ s t p, propext p.nodup_iff)
 
 @[simp] theorem coe_nodup {l : list α} : @nodup α l ↔ l.nodup := iff.rfl
 
@@ -2361,7 +2362,7 @@ nodup_of_le $ inter_le_right _ _
   quotient.induction_on s $ λ l h,
   by simp; refine list.nodup_map_on _ (nodup_sublists'.2 h); exact
   λ x sx y sy e,
-    (perm_ext_sublist_nodup h (mem_sublists'.1 sx) (mem_sublists'.1 sy)).1
+    (h.sublist_ext (mem_sublists'.1 sx) (mem_sublists'.1 sy)).1
       (quotient.exact e)⟩
 
 theorem nodup_powerset_len {n : ℕ} {s : multiset α}
@@ -2418,7 +2419,7 @@ variable [decidable_eq α]
 /-- `erase_dup s` removes duplicates from `s`, yielding a `nodup` multiset. -/
 def erase_dup (s : multiset α) : multiset α :=
 quot.lift_on s (λ l, (l.erase_dup : multiset α))
-  (λ s t p, quot.sound (perm_erase_dup_of_perm p))
+  (λ s t p, quot.sound p.erase_dup)
 
 @[simp] theorem coe_erase_dup (l : list α) : @erase_dup α _ l = l.erase_dup := rfl
 
@@ -2436,7 +2437,7 @@ quot.induction_on s $ λ l m, @congr_arg _ _ _ _ coe $ erase_dup_cons_of_mem m
 quot.induction_on s $ λ l m, congr_arg coe $ erase_dup_cons_of_not_mem m
 
 theorem erase_dup_le (s : multiset α) : erase_dup s ≤ s :=
-quot.induction_on s $ λ l, subperm_of_sublist $ erase_dup_sublist _
+quot.induction_on s $ λ l, (erase_dup_sublist _).subperm
 
 theorem erase_dup_subset (s : multiset α) : erase_dup s ⊆ s :=
 subset_of_le $ erase_dup_le _
@@ -2481,7 +2482,7 @@ theorem erase_dup_map_erase_dup_eq [decidable_eq β] (f : α → β) (s : multis
   an insert operation on `finset`. -/
 def ndinsert (a : α) (s : multiset α) : multiset α :=
 quot.lift_on s (λ l, (l.insert a : multiset α))
-  (λ s t p, quot.sound (perm_insert a p))
+  (λ s t p, quot.sound (p.insert a))
 
 @[simp] theorem coe_ndinsert (a : α) (l : list α) : ndinsert a l = (insert a l : list α) := rfl
 
@@ -2499,7 +2500,7 @@ quot.induction_on s $ λ l h, congr_arg coe $ insert_of_not_mem h
 quot.induction_on s $ λ l, mem_insert_iff
 
 @[simp] theorem le_ndinsert_self (a : α) (s : multiset α) : s ≤ ndinsert a s :=
-quot.induction_on s $ λ l, subperm_of_sublist $ sublist_of_suffix $ suffix_insert _ _
+quot.induction_on s $ λ l, (sublist_of_suffix $ suffix_insert _ _).subperm
 
 @[simp] theorem mem_ndinsert_self (a : α) (s : multiset α) : a ∈ ndinsert a s :=
 mem_ndinsert.2 (or.inl rfl)
@@ -2566,14 +2567,15 @@ by rw [disjoint_comm, disjoint_ndinsert_left]; tauto
   on finset, but this is more efficient.) -/
 def ndunion (s t : multiset α) : multiset α :=
 quotient.lift_on₂ s t (λ l₁ l₂, (l₁.union l₂ : multiset α)) $ λ v₁ v₂ w₁ w₂ p₁ p₂,
-  quot.sound $ perm_union p₁ p₂
+  quot.sound $ p₁.union p₂
 
 @[simp] theorem coe_ndunion (l₁ l₂ : list α) : @ndunion α _ l₁ l₂ = (l₁ ∪ l₂ : list α) := rfl
 
 @[simp] theorem zero_ndunion (s : multiset α) : ndunion 0 s = s :=
 quot.induction_on s $ λ l, rfl
 
-@[simp] theorem cons_ndunion (s t : multiset α) (a : α) : ndunion (a :: s) t = ndinsert a (ndunion s t) :=
+@[simp] theorem cons_ndunion (s t : multiset α) (a : α) :
+  ndunion (a :: s) t = ndinsert a (ndunion s t) :=
 quotient.induction_on₂ s t $ λ l₁ l₂, rfl
 
 @[simp] theorem mem_ndunion {s t : multiset α} {a : α} : a ∈ ndunion s t ↔ a ∈ s ∨ a ∈ t :=
@@ -2581,13 +2583,14 @@ quotient.induction_on₂ s t $ λ l₁ l₂, list.mem_union
 
 theorem le_ndunion_right (s t : multiset α) : t ≤ ndunion s t :=
 quotient.induction_on₂ s t $ λ l₁ l₂,
-subperm_of_sublist $ sublist_of_suffix $ suffix_union_right _ _
+(sublist_of_suffix $ suffix_union_right _ _).subperm
 
 theorem ndunion_le_add (s t : multiset α) : ndunion s t ≤ s + t :=
-quotient.induction_on₂ s t $ λ l₁ l₂, subperm_of_sublist $ union_sublist_append _ _
+quotient.induction_on₂ s t $ λ l₁ l₂, (union_sublist_append _ _).subperm
 
 theorem ndunion_le {s t u : multiset α} : ndunion s t ≤ u ↔ s ⊆ u ∧ t ≤ u :=
-multiset.induction_on s (by simp) (by simp [ndinsert_le, and_comm, and.left_comm] {contextual := tt})
+multiset.induction_on s (by simp)
+  (by simp [ndinsert_le, and_comm, and.left_comm] {contextual := tt})
 
 theorem subset_ndunion_left (s t : multiset α) : s ⊆ ndunion s t :=
 λ a h, mem_ndunion.2 $ or.inl h
@@ -3028,7 +3031,7 @@ begin
   introv p, unfold function.comp,
   induction p,
   case perm.nil { refl },
-  case perm.skip {
+  case perm.cons {
     have : multiset.cons <$> f p_x <*> (coe <$> traverse f p_l₁) =
       multiset.cons <$> f p_x <*> (coe <$> traverse f p_l₂),
     { rw [p_ih] },
@@ -3230,7 +3233,7 @@ variable (α)
 def subsingleton_equiv [subsingleton α] : list α ≃ multiset α :=
 { to_fun := coe,
   inv_fun := quot.lift id $ λ (a b : list α) (h : a ~ b),
-    list.ext_le (perm_length h) $ λ n h₁ h₂, subsingleton.elim _ _,
+    list.ext_le h.length_eq $ λ n h₁ h₂, subsingleton.elim _ _,
   left_inv := λ l, rfl,
   right_inv := λ m, quot.induction_on m $ λ l, rfl }
 

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -439,11 +439,11 @@ lemma perm_of_prod_eq_prod : ∀ {l₁ l₂ : list ℕ}, prod l₁ = prod l₂ �
   have hl₂' : ∀ p ∈ (b :: l₂).erase a, prime p := λ p hp, hl₂ p (mem_of_mem_erase hp),
   have ha : a ∈ (b :: l₂) := mem_list_primes_of_dvd_prod (hl₁ a (mem_cons_self _ _)) hl₂
     (h ▸ by rw prod_cons; exact dvd_mul_right _ _),
-  have hb : b :: l₂ ~ a :: (b :: l₂).erase a := perm_erase ha,
+  have hb : b :: l₂ ~ a :: (b :: l₂).erase a := perm_cons_erase ha,
   have hl : prod l₁ = prod ((b :: l₂).erase a) :=
   (nat.mul_left_inj (prime.pos (hl₁ a (mem_cons_self _ _)))).1 $
-    by rwa [← prod_cons, ← prod_cons, ← prod_eq_of_perm hb],
-  perm.trans (perm.skip _ (perm_of_prod_eq_prod hl hl₁' hl₂')) hb.symm
+    by rwa [← prod_cons, ← prod_cons, ← hb.prod_eq],
+  perm.trans ((perm_of_prod_eq_prod hl hl₁' hl₂').cons _) hb.symm
 
 lemma factors_unique {n : ℕ} {l : list ℕ} (h₁ : prod l = n) (h₂ : ∀ p ∈ l, prime p) : l ~ factors n :=
 have hn : 0 < n := nat.pos_of_ne_zero $ λ h, begin

--- a/src/group_theory/perm/cycles.lean
+++ b/src/group_theory/perm/cycles.lean
@@ -130,7 +130,7 @@ else let ⟨m, hm₁, hm₂, hm₃⟩ := cycle_factors_aux l ((cycle_of f x)⁻�
           have hxy : same_cycle f x y := not_not.1 (mt cycle_of_apply_of_not_same_cycle hfy),
           have hgm : g :: m.erase g ~ m := list.cons_perm_iff_perm_erase.2 ⟨hg, list.perm.refl _⟩,
           have ∀ h ∈ m.erase g, disjoint g h,
-            from (list.pairwise_cons.1 ((list.perm_pairwise (λ a b (h : disjoint a b), h.symm) hgm).2 hm₃)).1,
+            from (list.pairwise_cons.1 ((hgm.pairwise_iff (λ a b (h : disjoint a b), h.symm)).2 hm₃)).1,
           classical.by_cases id $ λ hgy : g y ≠ y,
             (disjoint_prod_right _ this y).resolve_right $
             have hsc : same_cycle f⁻¹ x (f y), by rwa [same_cycle_inv, same_cycle_apply],

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -45,6 +45,8 @@ by conv {to_lhs, rw [← injective.eq_iff f.injective, apply_inv_self]}
 lemma inv_eq_iff_eq {f : perm α} {x y : α} : f⁻¹ x = y ↔ x = f y :=
 by rw [eq_comm, eq_inv_iff_eq, eq_comm]
 
+/-- Two permutations `f` and `g` are `disjoint` if their supports are disjoint, i.e.,
+every element is fixed either by `f`, or by `g`. -/
 def disjoint (f g : perm α) := ∀ x, f x = x ∨ g x = x
 
 @[symm] lemma disjoint.symm {f g : perm α} : disjoint f g → disjoint g f :=
@@ -84,14 +86,7 @@ end
 
 lemma disjoint_prod_perm {l₁ l₂ : list (perm α)} (hl : l₁.pairwise disjoint)
   (hp : l₁ ~ l₂) : l₁.prod = l₂.prod :=
-begin
-  induction hp,
-  { refl },
-  { rw [list.prod_cons, list.prod_cons, hp_ih (list.pairwise_cons.1 hl).2] },
-  { simp [list.prod_cons, disjoint_mul_comm, (mul_assoc _ _ _).symm, *,
-      list.pairwise_cons] at * },
-  { rw [hp_ih_a hl, hp_ih_a_1 ((list.perm_pairwise (λ x y (h : disjoint x y), disjoint.symm h) hp_a).1 hl)] }
-end
+hp.prod_eq' $ hl.imp $ λ f g, disjoint_mul_comm
 
 lemma of_subtype_subtype_perm {f : perm α} {p : α → Prop} [decidable_pred p] (h₁ : ∀ x, p x ↔ p (f x))
   (h₂ : ∀ x, f x ≠ x → p x) : of_subtype (subtype_perm f h₁) = f :=
@@ -429,7 +424,7 @@ def sign_aux3 [fintype α] (f : perm α) {s : multiset α} : (∀ x, x ∈ s) �
 quotient.hrec_on s (λ l h, sign_aux2 l f)
   (trunc.induction_on (equiv_fin α)
     (λ e l₁ l₂ h, function.hfunext
-      (show (∀ x, x ∈ l₁) = ∀ x, x ∈ l₂, by simp [list.mem_of_perm h])
+      (show (∀ x, x ∈ l₁) = ∀ x, x ∈ l₂, by simp only [h.mem_iff])
       (λ h₁ h₂ _, by rw [← sign_aux_eq_sign_aux2 _ _ e (λ _ _, h₁ _),
         ← sign_aux_eq_sign_aux2 _ _ e (λ _ _, h₂ _)])))
 


### PR DESCRIPTION
* use dot notation
* add a version of `list.perm.prod_eq` that only assumes that elements of the list pairwise commute instead of commutativity of the monoid.

## List of renamed symbols

### `data/list/basic`

* `append_sublist_append_of_sublist_right` : `sublist.append_right`;
* `reverse_sublist` : `sublist.reverse`;
* `append_sublist_append` : `sublist.append`;
* `subset_of_sublist`: `sublist.subset`;
* `sublist_antisymm` : `sublist.antisymm`;
* `filter_map_sublist_filter_map` : `sublist.filter_map`
* `map_sublist_map` : `sublist.map`
* `erasep_sublist_erasep`: `sublist.erasep`
* `erase_sublist_erase` : `sublist.erase`;
* `diff_sublist_of_sublist` : `sublist.diff_right`;

### `data/list/perm`

* `perm.skip` : `perm.cons`;
* `perm_comm` (new);
* `perm_subset` : `perm.subset`;
* `mem_of_perm` : `perm.mem_iff`;
* `perm_app_left` : `perm.append_right` (note `right` vs `left`)
* `perm_app_right` : `perm.append_left` (note `right` vs `left`)
* `perm_app` : `perm.append`;
* `perm_app_cons` : `perm.append_cons`;
* `perm_cons_app` : `perm_append_singleton`;
* `perm_app_comm` : `perm_append_comm`;
* `perm_length` : `perm.length_eq`;
* `eq_nil_of_perm_nil` : `perm.eq_nil` and `perm.nil_eq`
  with different choices of lhs/rhs;
* `eq_singleton_of_perm_inv` : `perm.eq_singleton` and `perm.singleton_eq`
  with different choices of lhs/rhs;
* `perm_singleton` and `singleton_perm`: `iff` versions
  of `perm.eq_singleton` and `perm.singleton_eq`;
* `eq_singleton_of_perm` : `singleton_perm_singleton`;
* `perm_cons_app_cons` : `perm_cons_append_cons`;
* `perm_repeat` : `repeat_perm`; new `perm_repeat` differs from it
  in the choice of lhs/rhs;
* `perm_erase` : `perm_cons_erase`;
* `perm_filter_map` : `perm.filter_map`;
* `perm_map` : `perm.map`;
* `perm_pmap` : `perm.pmap`;
* `perm_filter` : `perm.filter`;
* `subperm_of_sublist` : `sublist.subperm`;
* `subperm_of_perm` : `perm.subperm`;
* `subperm.refl` : now has `@[refl]` attribute;
* `subperm.trans` : now has `@[trans]` attribute;
* `length_le_of_subperm` : `subperm.length_le`;
* `subset_of_subperm` : `subperm.subset`;
* `exists_perm_append_of_sublist` : `sublist.exists_perm_append`;
* `perm_countp` : `perm.countp_eq`;
* `countp_le_of_subperm` : `subperm.countp_le`;
* `perm_count` : `perm.count_eq`;
* `count_le_of_subperm` : `subperm.count_le`;
* `foldl_eq_of_perm` : `perm.foldl_eq`, added a primed version
  with slightly weaker assumptions;
* `foldr_eq_of_perm` : `perm.foldr_eq`;
* `rec_heq_of_perm` : `perm.eec_heq`;
* `fold_op_eq_of_perm` : `perm.fold_op_eq`;
* `prod_eq_of_perm`: `perm.prod_eq` and `perm.prod_eq'`;
* `perm_cons_inv` : `perm.cons_inv`;
* `perm_cons` : now is a `@[simp]` lemma;
* `perm_app_right_iff` : `perm_append_right_iff`;
* `subperm_app_left` : `subperm_append_left`;
* `subperm_app_right` : `subperm_append_right`;
* `perm_ext_sublist_nodup` : `nodup.sublist_ext`;
* `erase_perm_erase` : `perm.erase`;
* `subperm_cons_erase` (new);
* `erase_subperm_erase` : `subperm.erase`;
* `perm_diff_left` : `perm.diff_right` (note `left` vs `right`);
* `perm_diff_right` : `perm.diff_left` (note `left` vs `right`);
* `perm.diff`, `subperm.diff_right`, `erase_cons_subperm_cons_erase` (new);
* `perm_bag_inter_left` : `perm.bag_inter_right` (note `left` vs `right`);
* `perm_bag_inter_right` : `perm.bag_inter_left` (note `left` vs `right`);
* `perm.bag_inter` (new);
* `perm_erase_dup_of_perm` : `perm.erase_dup`;
* `perm_union_left` : `perm.union_right` (note `left` vs `right`);
* `perm_union_right` : `perm.union_left` (note `left` vs `right`);
* `perm_union` : `perm.union`;
* `perm_inter_left` : `perm.inter_right` (note `left` vs `right`);
* `perm_inter_right` : `perm.inter_left` (note `left` vs `right`);
* `perm_inter` : `perm.inter`;
* `perm_nodup` : `perm.nodup_iff`;
* `perm_bind_left` : `perm.bind_right` (note `left` vs `right`);
* `perm_bind_right` : `perm.bind_left` (note `left` vs `right`);
* `perm_product_left` : `perm.product_right` (note `left` vs `right`);
* `perm_product_right` : `peerm.product_left` (note `left` vs `right`);
* `perm_product` : `perm.product`;
* `perm_erasep` : `perm.erasep`;

### `data/list/sigma`

* `nodupkeys.pairwise_ne` (new);
* `perm_kreplace` : `perm.kreplace`;
* `perm_kerase` : `perm.kerase`;
* `perm_kinsert` : `perm.kinsert`;
* `erase_dupkeys_cons` : now take `x : sigma β` instead
  of `{x : α}` and `{y : β x}`;
* `perm_kunion_left` : `perm.kunion_right` (note `left` vs `right`);
* `perm_kunion_right` : `perm.kunion_left` (note `left` vs `right`);
* `perm_kunion` : `perm.kunion`;
* 

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.