### PR TITLE
[Merged by Bors] - feat(data/option): add `option.mmap` and `option.maybe`

### DIFF
--- a/src/data/option/defs.lean
+++ b/src/data/option/defs.lean
@@ -105,7 +105,7 @@ protected def {u v} traverse {F : Type u → Type v} [applicative F] {α β : Ty
 /- By analogy with `monad.sequence` in `init/category/combinators.lean`. -/
 
 /-- If you maybe have a monadic computation in a `[monad m]` which produces a term of type `α`, then
-there is a naturally associated way to always perform a computation in `m` which maybe products a
+there is a naturally associated way to always perform a computation in `m` which maybe produces a
 result. -/
 def {u v} maybe {m : Type u → Type v} [monad m] {α : Type u} : option (m α) → m (option α)
 | none := return none

--- a/src/data/option/defs.lean
+++ b/src/data/option/defs.lean
@@ -102,4 +102,17 @@ protected def {u v} traverse {F : Type u → Type v} [applicative F] {α β : Ty
 | none := pure none
 | (some x) := some <$> f x
 
+/- By analogy with `monad.sequence` in `init/category/combinators.lean`. -/
+
+/-- If you maybe have a monadic computation in a `[monad m]` which produces a term of type `α`, then
+there is a naturally associated way to always perform a computation in `m` which maybe products a
+result. -/
+def {u v} maybe {m : Type u → Type v} [monad m] {α : Type u} : option (m α) → m (option α)
+| none := return none
+| (some fn) := some <$> fn
+
+/-- Map a monadic function `f : α → m β` over an `o : option α`, maybe producing a result. -/
+def {u v w} mmap {m : Type u → Type v} [monad m] {α : Type w} {β : Type u} (f : α → m β)
+  (o : option α) : m (option β) := (o.map f).maybe
+
 end option


### PR DESCRIPTION
Please let me know if something like this exists already! Over the last few days I've wanted it multiple times, and it is used in #2485.


<br>
<br>
<br>

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
