### PR TITLE
[Merged by Bors] - chore(cmd/where): remove unused argument

### DIFF
--- a/src/tactic/where.lean
+++ b/src/tactic/where.lean
@@ -164,7 +164,7 @@ It is a bug for `#where` to incorrectly report this information (this was not fo
 please file an issue on GitHub if you observe a failure.
 -/
 @[user_command]
-meta def where_cmd (_ : decl_meta_info) (_ : parse $ tk "#where") : lean.parser unit :=
+meta def where_cmd (_ : parse $ tk "#where") : lean.parser unit :=
 do msg ← build_msg,
    trace msg
 


### PR DESCRIPTION
Just remove an unused argument from the `#where` declaration, satisfying the linter.

<br>
<br>
<br>

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
