### PR TITLE
[Merged by Bors] - chore(meta/expr): add a docstring

### DIFF
--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -662,6 +662,8 @@ end expr
 namespace declaration
 open tactic
 
+/-- Sets the name of the given `decl : declaration` to `tgt`, and applies `f` to the names
+of all `expr.const`s which appear in the value or type of `decl`. -/
 protected meta def update_with_fun (f : name → name) (tgt : name) (decl : declaration) :
   declaration :=
 let decl := decl.update_name $ tgt in

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -662,8 +662,11 @@ end expr
 namespace declaration
 open tactic
 
-/-- Sets the name of the given `decl : declaration` to `tgt`, and applies `f` to the names
-of all `expr.const`s which appear in the value or type of `decl`. -/
+/-- 
+`declaration.update_with_fun f tgt decl` 
+sets the name of the given `decl : declaration` to `tgt`, and applies `f` to the names
+of all `expr.const`s which appear in the value or type of `decl`. 
+-/
 protected meta def update_with_fun (f : name → name) (tgt : name) (decl : declaration) :
   declaration :=
 let decl := decl.update_name $ tgt in


### PR DESCRIPTION
Add a docstring.


<br>
<br>
<br>

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
