### PR TITLE
[Merged by Bors] - chore(tactic/auto_cases): add docstring and remove duplication

### DIFF
--- a/src/tactic/auto_cases.lean
+++ b/src/tactic/auto_cases.lean
@@ -1,53 +1,74 @@
 /-
 Copyright (c) 2017 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Scott Morrison
+Authors: Keeley Hoek, Scott Morrison
 -/
 import logic.basic
 import tactic.core
 import data.option.defs
 import tactic.hint
 
-open tactic
+namespace tactic
 
-meta def auto_cases_at (h : expr) : tactic string :=
-do t' ← infer_type h,
-  t' ← whnf t',
-  let use_cases := match t' with
-  | `(empty)     := tt
-  | `(pempty)    := tt
-  | `(false)     := tt
-  | `(unit)      := tt
-  | `(punit)     := tt
-  | `(ulift _)   := tt
-  | `(plift _)   := tt
-  | `(prod _ _)  := tt
-  | `(and _ _)   := tt
-  | `(sigma _)   := tt
-  | `(psigma _)  := tt
-  | `(subtype _) := tt
-  | `(Exists _)  := tt
-  | `(fin 0)     := tt
-  | `(sum _ _)   := tt -- This is perhaps dangerous!
-  | `(or _ _)    := tt -- This is perhaps dangerous!
-  | `(iff _ _)   := tt -- This is perhaps dangerous!
-  | _            := ff
-  end,
-  if use_cases then
-    do cases h, pp ← pp h, return ("cases " ++ pp.to_string)
-  else
-    match t' with
-    -- `cases` can be dangerous on `eq` and `quot`, producing mysterious errors during type checking.
-    -- instead we attempt `induction`
-    | `(eq _ _)        := do induction h, pp ← pp h, return ("induction " ++ pp.to_string)
-    | `(quot _)        := do induction h, pp ← pp h, return ("induction " ++ pp.to_string)
-    | _                := failed
-    end
+namespace auto_cases
+
+/-- Structure representing a tactic which can be used by `tactic.auto_cases`. -/
+meta structure auto_cases_tac :=
+(name : string)
+{α : Type}
+(tac : expr → tactic α)
+
+/-- The `auto_cases_tac` for `tactic.cases`. -/
+meta def tac_cases : auto_cases_tac := ⟨"cases", cases⟩
+
+/-- The `auto_cases_tac` for `tactic.induction⟩`. -/
+meta def tac_induction : auto_cases_tac := ⟨"induction", induction⟩
+
+/-- Find an `auto_cases_tac` which matches the given `type : expr`. -/
+meta def find_tac : expr → option auto_cases_tac
+| `(empty)     := tac_cases
+| `(pempty)    := tac_cases
+| `(false)     := tac_cases
+| `(unit)      := tac_cases
+| `(punit)     := tac_cases
+| `(ulift _)   := tac_cases
+| `(plift _)   := tac_cases
+| `(prod _ _)  := tac_cases
+| `(and _ _)   := tac_cases
+| `(sigma _)   := tac_cases
+| `(psigma _)  := tac_cases
+| `(subtype _) := tac_cases
+| `(Exists _)  := tac_cases
+| `(fin 0)     := tac_cases
+| `(sum _ _)   := tac_cases -- This is perhaps dangerous!
+| `(or _ _)    := tac_cases -- This is perhaps dangerous!
+| `(iff _ _)   := tac_cases -- This is perhaps dangerous!
+/- `cases` can be dangerous on `eq` and `quot`, producing mysterious errors during type checking.
+   instead we attempt `induction`. -/
+| `(eq _ _)    := tac_induction
+| `(quot _)    := tac_induction
+| _            := none
+
+end auto_cases
+
+/-- Applies `cases` or `induction` on the local_hypothesis `hyp : expr`. -/
+meta def auto_cases_at (hyp : expr) : tactic string :=
+do t ← infer_type hyp >>= whnf,
+   match auto_cases.find_tac t with
+   | some atac := do
+     atac.tac hyp,
+     pp ← pp hyp,
+     return sformat!"{atac.name} {pp}"
+   | none := fail "hypothesis type unsupported"
+   end
 
 /-- Applies `cases` or `induction` on certain hypotheses. -/
 @[hint_tactic]
 meta def auto_cases : tactic string :=
 do l ← local_context,
-   results ← successes (l.reverse.map(λ h, auto_cases_at h)),
-   when (results.empty) (fail "`auto_cases` did not find any hypotheses to apply `cases` or `induction` to"),
+   results ← successes $ l.reverse.map auto_cases_at,
+   when (results.empty) $
+     fail "`auto_cases` did not find any hypotheses to apply `cases` or `induction` to",
    return (string.intercalate ", " results)
+
+end tactic


### PR DESCRIPTION
I was just adding a docstring, and I saw some duplication so I removed it too.


<br>
<br>
<br>

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
