### PR TITLE
[Merged by Bors] - feat(mk_iff_of_inductive_prop): add, use, and document command

### DIFF
--- a/src/data/list/chain.lean
+++ b/src/data/list/chain.lean
@@ -16,7 +16,7 @@ namespace list
 
 /- chain relation (conjunction of R a b ∧ R b c ∧ R c d ...) -/
 
-run_cmd tactic.mk_iff_of_inductive_prop `list.chain `list.chain_iff
+mk_iff_of_inductive_prop list.chain list.chain_iff
 
 variable {R : α → α → Prop}
 

--- a/src/data/list/forall2.lean
+++ b/src/data/list/forall2.lean
@@ -19,7 +19,7 @@ namespace list
 variables {r : α → β → Prop} {p : γ → δ → Prop}
 open relator
 
-run_cmd tactic.mk_iff_of_inductive_prop `list.forall₂ `list.forall₂_iff
+mk_iff_of_inductive_prop list.forall₂ list.forall₂_iff
 
 @[simp] theorem forall₂_cons {R : α → β → Prop} {a b l₁ l₂} :
   forall₂ R (a::l₁) (b::l₂) ↔ R a b ∧ forall₂ R l₁ l₂ :=

--- a/src/data/list/pairwise.lean
+++ b/src/data/list/pairwise.lean
@@ -15,7 +15,7 @@ namespace list
 
 /- pairwise relation (generalized no duplicate) -/
 
-run_cmd tactic.mk_iff_of_inductive_prop `list.pairwise `list.pairwise_iff
+mk_iff_of_inductive_prop list.pairwise list.pairwise_iff
 
 variable {R : α → α → Prop}
 

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -1980,7 +1980,7 @@ inductive rel (r : α → β → Prop) : multiset α → multiset β → Prop
 | zero : rel 0 0
 | cons {a b as bs} : r a b → rel as bs → rel (a :: as) (b :: bs)
 
-run_cmd tactic.mk_iff_of_inductive_prop `multiset.rel `multiset.rel_iff
+mk_iff_of_inductive_prop multiset.rel multiset.rel_iff
 
 variables {δ : Type*} {r : α → β → Prop} {p : γ → δ → Prop}
 

--- a/src/field_theory/perfect_closure.lean
+++ b/src/field_theory/perfect_closure.lean
@@ -75,7 +75,8 @@ variables (α : Type u) [comm_ring α] (p : ℕ) [nat.prime p] [char_p α p]
 /-- `perfect_closure α p` is the quotient by this relation. -/
 inductive perfect_closure.r : (ℕ × α) → (ℕ × α) → Prop
 | intro : ∀ n x, perfect_closure.r (n, x) (n+1, frobenius α p x)
-run_cmd tactic.mk_iff_of_inductive_prop `perfect_closure.r `perfect_closure.r_iff
+
+mk_iff_of_inductive_prop perfect_closure.r perfect_closure.r_iff
 
 /-- The perfect closure is the smallest extension that makes frobenius surjective. -/
 def perfect_closure : Type u := quot (perfect_closure.r α p)

--- a/src/logic/relation.lean
+++ b/src/logic/relation.lean
@@ -65,21 +65,21 @@ inductive refl_trans_gen (r : α → α → Prop) (a : α) : α → Prop
 
 attribute [refl] refl_trans_gen.refl
 
-run_cmd tactic.mk_iff_of_inductive_prop `relation.refl_trans_gen `relation.refl_trans_gen.cases_tail_iff
+mk_iff_of_inductive_prop relation.refl_trans_gen relation.refl_trans_gen.cases_tail_iff
 
 /-- `refl_gen r`: reflexive closure of `r` -/
 inductive refl_gen (r : α → α → Prop) (a : α) : α → Prop
 | refl : refl_gen a
 | single {b} : r a b → refl_gen b
 
-run_cmd tactic.mk_iff_of_inductive_prop `relation.refl_gen `relation.refl_gen_iff
+mk_iff_of_inductive_prop relation.refl_gen relation.refl_gen_iff
 
 /-- `trans_gen r`: transitive closure of `r` -/
 inductive trans_gen (r : α → α → Prop) (a : α) : α → Prop
 | single {b} : r a b → trans_gen b
 | tail {b c} : trans_gen b → r b c → trans_gen c
 
-run_cmd tactic.mk_iff_of_inductive_prop `relation.trans_gen `relation.trans_gen_iff
+mk_iff_of_inductive_prop relation.trans_gen relation.trans_gen_iff
 
 attribute [refl] refl_gen.refl
 

--- a/src/tactic/mk_iff_of_inductive_prop.lean
+++ b/src/tactic/mk_iff_of_inductive_prop.lean
@@ -135,19 +135,20 @@ match s.length with
   done
 end
 
-/-- `mk_iff_of_inductive_prop i r` makes a iff rule for the inductively defined proposition `i`.
-  The new rule `r` has the shape `∀ps is, i as ↔ ⋁_j, ∃cs, is = cs`, where `ps` are the type
-  parameters, `is` are the indices, `j` ranges over all possible constructors, the `cs` are the
-  parameters for each constructors, the equalities `is = cs` are the instantiations for each
-  constructor for each of the indices to the inductive type `i`.
+/--
+`mk_iff_of_inductive_prop i r` makes a iff rule for the inductively defined proposition `i`.
+The new rule `r` has the shape `∀ps is, i as ↔ ⋁_j, ∃cs, is = cs`, where `ps` are the type
+parameters, `is` are the indices, `j` ranges over all possible constructors, the `cs` are the
+parameters for each constructors, the equalities `is = cs` are the instantiations for each
+constructor for each of the indices to the inductive type `i`.
 
-  In each case, we remove constructor parameters (i.e. `cs`) when the corresponding equality would
-  be just `c = i` for some index `i`.
+In each case, we remove constructor parameters (i.e. `cs`) when the corresponding equality would
+be just `c = i` for some index `i`.
 
-  For example: `mk_iff_of_inductive_prop` on `list.chain` produces:
+For example: `mk_iff_of_inductive_prop` on `list.chain` produces:
 
-    ∀{α : Type*} (R : α → α → Prop) (a : α) (l : list α),
-      chain R a l ↔ l = [] ∨ ∃{b : α} {l' : list α}, R a b ∧ chain R b l ∧ l = b :: l'
+  ∀{α : Type*} (R : α → α → Prop) (a : α) (l : list α),
+    chain R a l ↔ l = [] ∨ ∃{b : α} {l' : list α}, R a b ∧ chain R b l ∧ l = b :: l'
 
 -/
 meta def mk_iff_of_inductive_prop (i : name) (r : name) : tactic unit := do
@@ -176,3 +177,33 @@ meta def mk_iff_of_inductive_prop (i : name) (r : name) : tactic unit := do
   skip
 
 end tactic
+
+section
+setup_tactic_parser
+
+/--
+`mk_iff_of_inductive_prop i r` makes a iff rule for the inductively defined proposition `i`.
+The new rule `r` has the shape `∀ps is, i as ↔ ⋁_j, ∃cs, is = cs`, where `ps` are the type
+parameters, `is` are the indices, `j` ranges over all possible constructors, the `cs` are the
+parameters for each constructors, the equalities `is = cs` are the instantiations for each
+constructor for each of the indices to the inductive type `i`.
+
+In each case, we remove constructor parameters (i.e. `cs`) when the corresponding equality would
+be just `c = i` for some index `i`.
+
+For example: `mk_iff_of_inductive_prop` on `list.chain` produces:
+
+  ∀{α : Type*} (R : α → α → Prop) (a : α) (l : list α),
+    chain R a l ↔ l = [] ∨ ∃{b : α} {l' : list α}, R a b ∧ chain R b l ∧ l = b :: l'
+
+-/
+@[user_command] meta def mk_iff_of_inductive_prop_cmd (_ : parse (tk "mk_iff_of_inductive_prop")) :
+  parser unit :=
+do i ← ident, r ← ident, tactic.mk_iff_of_inductive_prop i r
+
+add_tactic_doc
+{ name        := "mk_iff_of_inductive_prop",
+  category    := doc_category.cmd,
+  decl_names  := [``mk_iff_of_inductive_prop_cmd],
+  tags        := ["logic", "environment"] }
+end

--- a/src/tactic/mk_iff_of_inductive_prop.lean
+++ b/src/tactic/mk_iff_of_inductive_prop.lean
@@ -136,7 +136,7 @@ match s.length with
 end
 
 /--
-`mk_iff_of_inductive_prop i r` makes a iff rule for the inductively defined proposition `i`.
+`mk_iff_of_inductive_prop i r` makes an iff rule for the inductively defined proposition `i`.
 The new rule `r` has the shape `∀ps is, i as ↔ ⋁_j, ∃cs, is = cs`, where `ps` are the type
 parameters, `is` are the indices, `j` ranges over all possible constructors, the `cs` are the
 parameters for each constructors, the equalities `is = cs` are the instantiations for each
@@ -182,7 +182,7 @@ section
 setup_tactic_parser
 
 /--
-`mk_iff_of_inductive_prop i r` makes a iff rule for the inductively defined proposition `i`.
+`mk_iff_of_inductive_prop i r` makes an iff rule for the inductively defined proposition `i`.
 The new rule `r` has the shape `∀ps is, i as ↔ ⋁_j, ∃cs, is = cs`, where `ps` are the type
 parameters, `is` are the indices, `j` ranges over all possible constructors, the `cs` are the
 parameters for each constructors, the equalities `is = cs` are the instantiations for each

--- a/src/tactic/mk_iff_of_inductive_prop.lean
+++ b/src/tactic/mk_iff_of_inductive_prop.lean
@@ -147,9 +147,10 @@ be just `c = i` for some index `i`.
 
 For example: `mk_iff_of_inductive_prop` on `list.chain` produces:
 
-  ∀{α : Type*} (R : α → α → Prop) (a : α) (l : list α),
-    chain R a l ↔ l = [] ∨ ∃{b : α} {l' : list α}, R a b ∧ chain R b l ∧ l = b :: l'
-
+```lean
+∀ {α : Type*} (R : α → α → Prop) (a : α) (l : list α),
+  chain R a l ↔ l = [] ∨ ∃{b : α} {l' : list α}, R a b ∧ chain R b l ∧ l = b :: l'
+```
 -/
 meta def mk_iff_of_inductive_prop (i : name) (r : name) : tactic unit := do
   e ← get_env,
@@ -193,9 +194,10 @@ be just `c = i` for some index `i`.
 
 For example: `mk_iff_of_inductive_prop` on `list.chain` produces:
 
-  ∀{α : Type*} (R : α → α → Prop) (a : α) (l : list α),
-    chain R a l ↔ l = [] ∨ ∃{b : α} {l' : list α}, R a b ∧ chain R b l ∧ l = b :: l'
-
+```lean
+∀ {α : Type*} (R : α → α → Prop) (a : α) (l : list α),
+  chain R a l ↔ l = [] ∨ ∃{b : α} {l' : list α}, R a b ∧ chain R b l ∧ l = b :: l'
+```
 -/
 @[user_command] meta def mk_iff_of_inductive_prop_cmd (_ : parse (tk "mk_iff_of_inductive_prop")) :
   parser unit :=

--- a/test/mk_iff_of_inductive.lean
+++ b/test/mk_iff_of_inductive.lean
@@ -2,27 +2,27 @@ import tactic.mk_iff_of_inductive_prop
 
 import data.list data.list.perm data.multiset
 
-run_cmd tactic.mk_iff_of_inductive_prop `list.chain `test.chain_iff
+mk_iff_of_inductive_prop list.chain test.chain_iff
 
-run_cmd tactic.mk_iff_of_inductive_prop `false    `test.false_iff
+mk_iff_of_inductive_prop false    test.false_iff
 
-run_cmd tactic.mk_iff_of_inductive_prop `true     `test.true_iff
+mk_iff_of_inductive_prop true     test.true_iff
 
-run_cmd tactic.mk_iff_of_inductive_prop `nonempty `test.non_empty_iff
+mk_iff_of_inductive_prop nonempty test.non_empty_iff
 
-run_cmd tactic.mk_iff_of_inductive_prop `and      `test.and_iff
+mk_iff_of_inductive_prop and      test.and_iff
 
-run_cmd tactic.mk_iff_of_inductive_prop `or       `test.or_iff
+mk_iff_of_inductive_prop or       test.or_iff
 
-run_cmd tactic.mk_iff_of_inductive_prop `eq       `test.eq_iff
+mk_iff_of_inductive_prop eq       test.eq_iff
 
-run_cmd tactic.mk_iff_of_inductive_prop `heq      `test.heq_iff
+mk_iff_of_inductive_prop heq      test.heq_iff
 
-run_cmd tactic.mk_iff_of_inductive_prop `list.perm  `test.perm_iff
+mk_iff_of_inductive_prop list.perm  test.perm_iff
 
-run_cmd tactic.mk_iff_of_inductive_prop `list.pairwise  `test.pairwise_iff
+mk_iff_of_inductive_prop list.pairwise  test.pairwise_iff
 
 inductive test.is_true (p : Prop) : Prop
 | triviality : p → test.is_true
 
-run_cmd tactic.mk_iff_of_inductive_prop `test.is_true `test.is_true_iff
+mk_iff_of_inductive_prop test.is_true test.is_true_iff


### PR DESCRIPTION
This existed as an (undocumented) tactic that was being called with `run_cmd`. It deserves to be a documented user command.

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
