### PR TITLE
[Merged by Bors] - feat(category_theory/concrete): make constructing morphisms easier

### DIFF
--- a/src/algebra/category/CommRing/basic.lean
+++ b/src/algebra/category/CommRing/basic.lean
@@ -63,9 +63,11 @@ instance has_forget_to_AddCommMon : has_forget₂ SemiRing AddCommMon :=
 end SemiRing
 
 /-- The category of rings. -/
-def Ring : Type (u+1) := induced_category SemiRing (bundled.map @ring.to_semiring)
+def Ring : Type (u+1) := bundled ring
 
 namespace Ring
+
+instance : bundled_hom.parent_projection @ring.to_semiring := ⟨⟩
 
 /-- Construct a bundled Ring from the underlying type and typeclass. -/
 def of (R : Type u) [ring R] : Ring := bundled.of R
@@ -81,7 +83,7 @@ instance (R : Ring) : ring R := R.str
 instance : category Ring := infer_instance -- short-circuit type class inference
 instance : concrete_category Ring := infer_instance -- short-circuit type class inference
 
-instance has_forget_to_SemiRing : has_forget₂ Ring SemiRing := infer_instance  -- short-circuit type class inference
+instance has_forget_to_SemiRing : has_forget₂ Ring SemiRing := bundled_hom.forget₂ _ _
 instance has_forget_to_AddCommGroup : has_forget₂ Ring AddCommGroup :=
 -- can't use bundled_hom.mk_has_forget₂, since AddCommGroup is an induced category
 { forget₂ :=
@@ -91,9 +93,11 @@ instance has_forget_to_AddCommGroup : has_forget₂ Ring AddCommGroup :=
 end Ring
 
 /-- The category of commutative semirings. -/
-def CommSemiRing : Type (u+1) := induced_category SemiRing (bundled.map comm_semiring.to_semiring)
+def CommSemiRing : Type (u+1) := bundled comm_semiring
 
 namespace CommSemiRing
+
+instance : bundled_hom.parent_projection @comm_semiring.to_semiring := ⟨⟩
 
 /-- Construct a bundled CommSemiRing from the underlying type and typeclass. -/
 def of (R : Type u) [comm_semiring R] : CommSemiRing := bundled.of R
@@ -109,7 +113,7 @@ instance (R : CommSemiRing) : comm_semiring R := R.str
 instance : category CommSemiRing := infer_instance -- short-circuit type class inference
 instance : concrete_category CommSemiRing := infer_instance -- short-circuit type class inference
 
-instance has_forget_to_SemiRing : has_forget₂ CommSemiRing SemiRing := infer_instance -- short-circuit type class inference
+instance has_forget_to_SemiRing : has_forget₂ CommSemiRing SemiRing := bundled_hom.forget₂ _ _
 
 /-- The forgetful functor from commutative rings to (multiplicative) commutative monoids. -/
 instance has_forget_to_CommMon : has_forget₂ CommSemiRing CommMon :=
@@ -120,9 +124,11 @@ has_forget₂.mk'
 end CommSemiRing
 
 /-- The category of commutative rings. -/
-def CommRing : Type (u+1) := induced_category Ring (bundled.map comm_ring.to_ring)
+def CommRing : Type (u+1) := bundled comm_ring
 
 namespace CommRing
+
+instance : bundled_hom.parent_projection @comm_ring.to_ring := ⟨⟩
 
 /-- Construct a bundled CommRing from the underlying type and typeclass. -/
 def of (R : Type u) [comm_ring R] : CommRing := bundled.of R
@@ -138,7 +144,7 @@ instance (R : CommRing) : comm_ring R := R.str
 instance : category CommRing := infer_instance -- short-circuit type class inference
 instance : concrete_category CommRing := infer_instance -- short-circuit type class inference
 
-instance has_forget_to_Ring : has_forget₂ CommRing Ring := infer_instance -- short-circuit type class inference
+instance has_forget_to_Ring : has_forget₂ CommRing Ring := bundled_hom.forget₂ _ _
 
 /-- The forgetful functor from commutative rings to (multiplicative) commutative monoids. -/
 instance has_forget_to_CommSemiRing : has_forget₂ CommRing CommSemiRing :=

--- a/src/algebra/category/Group/Z_Module_equivalence.lean
+++ b/src/algebra/category/Group/Z_Module_equivalence.lean
@@ -31,7 +31,7 @@ instance : full (forget₂ (Module ℤ) AddCommGroup) :=
 /-- The forgetful functor from `ℤ` modules to `AddCommGroup` is essentially surjective. -/
 instance : ess_surj (forget₂ (Module ℤ) AddCommGroup) :=
 { obj_preimage := λ A, Module.of ℤ A,
-  iso' := λ A, { hom := 𝟙 _, inv := 𝟙 _, } }
+  iso' := λ A, { hom := 𝟙 A, inv := 𝟙 A, } }
 
 instance : is_equivalence (forget₂ (Module ℤ) AddCommGroup) :=
 equivalence_of_fully_faithfully_ess_surj (forget₂ (Module ℤ) AddCommGroup)

--- a/src/algebra/category/Group/basic.lean
+++ b/src/algebra/category/Group/basic.lean
@@ -30,9 +30,12 @@ open category_theory
 
 /-- The category of groups and group morphisms. -/
 @[to_additive AddGroup]
-def Group : Type (u+1) := induced_category Mon (bundled.map group.to_monoid)
+def Group : Type (u+1) := bundled group
 
 namespace Group
+
+@[to_additive]
+instance : bundled_hom.parent_projection group.to_monoid := ⟨⟩
 
 /-- Construct a bundled Group from the underlying type and typeclass. -/
 @[to_additive] def of (X : Type u) [group X] : Group := bundled.of X
@@ -72,19 +75,22 @@ by { ext1, apply w }
 attribute [ext] AddGroup.ext
 
 @[to_additive has_forget_to_AddMon]
-instance has_forget_to_Mon : has_forget₂ Group Mon := infer_instance -- short-circuit type class inference
+instance has_forget_to_Mon : has_forget₂ Group Mon := bundled_hom.forget₂ _ _
 
 end Group
 
 
 /-- The category of commutative groups and group morphisms. -/
 @[to_additive AddCommGroup]
-def CommGroup : Type (u+1) := induced_category Group (bundled.map comm_group.to_group)
+def CommGroup : Type (u+1) := bundled comm_group
 
 /-- `Ab` is an abbreviation for `AddCommGroup`, for the sake of mathematicians' sanity. -/
 abbreviation Ab := AddCommGroup
 
 namespace CommGroup
+
+@[to_additive]
+instance : bundled_hom.parent_projection comm_group.to_group := ⟨⟩
 
 /-- Construct a bundled CommGroup from the underlying type and typeclass. -/
 @[to_additive] def of (G : Type u) [comm_group G] : CommGroup := bundled.of G
@@ -120,7 +126,7 @@ by { ext1, apply w }
 attribute [ext] AddCommGroup.ext
 
 @[to_additive has_forget_to_AddGroup]
-instance has_forget_to_Group : has_forget₂ CommGroup Group := infer_instance -- short-circuit type class inference
+instance has_forget_to_Group : has_forget₂ CommGroup Group := bundled_hom.forget₂ _ _
 
 @[to_additive has_forget_to_AddCommMon]
 instance has_forget_to_CommMon : has_forget₂ CommGroup CommMon :=

--- a/src/algebra/category/Mon/basic.lean
+++ b/src/algebra/category/Mon/basic.lean
@@ -9,22 +9,6 @@ import algebra.group.hom
 import data.equiv.mul_add
 import algebra.punit_instances
 
-
-namespace tactic.interactive
-setup_tactic_parser
-open tactic
-
-/--
-`match_hyp h := t` fails if the hypothesis `h` does not match the type `t` (which may be a pattern).
-We use this tactic for writing tests.
--/
-meta def match_hyp (n : parse ident) (p : parse $ tk ":=" *> texpr) (m := reducible) : tactic (list expr) :=
-do
-  h ← get_local n >>= infer_type >>= instantiate_mvars,
-  match_expr p h m
-
-end tactic.interactive
-
 /-!
 # Category instances for monoid, add_monoid, comm_monoid, and add_comm_monoid.
 

--- a/src/algebra/category/Mon/basic.lean
+++ b/src/algebra/category/Mon/basic.lean
@@ -9,6 +9,22 @@ import algebra.group.hom
 import data.equiv.mul_add
 import algebra.punit_instances
 
+
+namespace tactic.interactive
+setup_tactic_parser
+open tactic
+
+/--
+`match_hyp h := t` fails if the hypothesis `h` does not match the type `t` (which may be a pattern).
+We use this tactic for writing tests.
+-/
+meta def match_hyp (n : parse ident) (p : parse $ tk ":=" *> texpr) (m := reducible) : tactic (list expr) :=
+do
+  h ← get_local n >>= infer_type >>= instantiate_mvars,
+  match_expr p h m
+
+end tactic.interactive
+
 /-!
 # Category instances for monoid, add_monoid, comm_monoid, and add_comm_monoid.
 
@@ -89,9 +105,12 @@ end Mon
 
 /-- The category of commutative monoids and monoid morphisms. -/
 @[to_additive AddCommMon]
-def CommMon : Type (u+1) := induced_category Mon (bundled.map @comm_monoid.to_monoid)
+def CommMon : Type (u+1) := bundled comm_monoid
 
 namespace CommMon
+
+@[to_additive]
+instance : bundled_hom.parent_projection comm_monoid.to_monoid := ⟨⟩
 
 /-- Construct a bundled CommMon from the underlying type and typeclass. -/
 @[to_additive]
@@ -118,7 +137,7 @@ instance : category CommMon := infer_instance -- short-circuit type class infere
 instance : concrete_category CommMon := infer_instance -- short-circuit type class inference
 
 @[to_additive has_forget_to_AddMon]
-instance has_forget_to_Mon : has_forget₂ CommMon Mon := infer_instance -- short-circuit type class inference
+instance has_forget_to_Mon : has_forget₂ CommMon Mon := bundled_hom.forget₂ _ _
 
 end CommMon
 
@@ -126,6 +145,19 @@ end CommMon
 example {R S : Mon}     (f : R ⟶ S) : (R : Type) → (S : Type) := f
 example {R S : CommMon} (f : R ⟶ S) : (R : Type) → (S : Type) := f
 
+-- We verify that when constructing a morphism in `CommMon`,
+-- when we construct the `to_fun` field, the types are presented as `↥R`,
+-- rather than `R.α` or (as we used to have) `↥(bundled.map comm_monoid.to_monoid R)`.
+example (R : CommMon.{u}) : R ⟶ R :=
+{ to_fun := λ x,
+  begin
+    match_target (R : Type u),
+    match_hyp x := (R : Type u),
+    exact x * x
+  end ,
+  map_one' := by simp,
+  map_mul' := λ x y,
+  begin rw [mul_assoc x y (x * y), ←mul_assoc y x y, mul_comm y x, mul_assoc, mul_assoc], end, }
 
 variables {X Y : Type u}
 

--- a/src/category_theory/concrete_category/bundled_hom.lean
+++ b/src/category_theory/concrete_category/bundled_hom.lean
@@ -88,6 +88,8 @@ has_forget₂.mk'
 variables {d : Type u → Type u}
 variables (hom)
 
+section
+omit 𝒞
 /--
 The `hom` corresponding to first forgetting along `F`, then taking the `hom` associated to `c`.
 
@@ -95,6 +97,7 @@ For typical usage, see the construction of `CommMon` from `Mon`.
 -/
 @[reducible] def map_hom (F : Π {α}, d α → c α) : Π ⦃α β : Type u⦄ (Iα : d α) (Iβ : d β), Type u :=
 λ α β iα iβ, hom (F iα) (F iβ)
+end
 
 /--
 Construct the `bundled_hom` induced by a map between type classes.
@@ -109,16 +112,20 @@ def map (F : Π {α}, d α → c α) : bundled_hom (map_hom hom @F) :=
 section
 omit 𝒞
 /--
-We used the empty `parent_projection` class to label functions like `comm_monoid.to_monoid`,
+We use the empty `parent_projection` class to label functions like `comm_monoid.to_monoid`,
 which we would like to use to automatically construct `bundled_hom` instances from.
 
 Once we've set up `Mon` as the category of bundled monoids,
-this allows us to set up `CommMon` by defining an instance `parent_project (comm_monoid.to_monoid)`.
+this allows us to set up `CommMon` by defining an instance
+```instance : parent_projection (comm_monoid.to_monoid) := ⟨⟩```
 -/
 class parent_projection (F : Π {α}, d α → c α)
 end
 
-instance (F : Π {α}, d α → c α) [parent_projection @F] : bundled_hom (map_hom hom @F) := map hom @F
+@[nolint unused_arguments] -- The `parent_projection` typeclass is just a marker, so won't be used.
+instance bundled_hom_of_parent_projection (F : Π {α}, d α → c α) [parent_projection @F] :
+  bundled_hom (map_hom hom @F) :=
+map hom @F
 
 instance forget₂ (F : Π {α}, d α → c α) [parent_projection @F] : has_forget₂ (bundled d) (bundled c) :=
 { forget₂ :=

--- a/src/category_theory/concrete_category/bundled_hom.lean
+++ b/src/category_theory/concrete_category/bundled_hom.lean
@@ -50,7 +50,7 @@ This instance generates the type-class problem `bundled_hom ?m` (which is why th
 `[nolint]`). Currently that is not a problem, as there are almost no instances of `bundled_hom`. -/
 @[nolint dangerous_instance] instance category : category (bundled c) :=
 by refine
-{ hom := λ X Y, @hom X.1 Y.1 X.str Y.str,
+{ hom := λ X Y, @hom X Y X.str Y.str,
   id := λ X, @bundled_hom.id c hom 𝒞 X X.str,
   comp := λ X Y Z f g, @bundled_hom.comp c hom 𝒞 X Y Z X.str Y.str Z.str g f,
   comp_id' := _,
@@ -84,6 +84,44 @@ has_forget₂.mk'
   (λ _, rfl)
   @map
   (by intros; apply heq_of_eq; apply h_map)
+
+variables {d : Type u → Type u}
+variables (hom)
+
+/--
+The `hom` corresponding to first forgetting along `F`, then taking the `hom` associated to `c`.
+-/
+@[reducible] def map_hom (F : Π {α}, d α → c α) : Π ⦃α β : Type u⦄ (Iα : d α) (Iβ : d β), Type u :=
+λ α β iα iβ, hom (F iα) (F iβ)
+
+/--
+Construct the `bundled_hom` induced by a map between type classes.
+This is useful for building categories such as `CommMon` from `Mon`.
+-/
+def map (F : Π {α}, d α → c α) : bundled_hom (map_hom hom @F) :=
+{ to_fun := λ α β iα iβ f, 𝒞.to_fun (F iα) (F iβ) f,
+  id := λ α iα, 𝒞.id (F iα),
+  comp := λ α β γ iα iβ iγ f g, 𝒞.comp (F iα) (F iβ) (F iγ) f g,
+  hom_ext := λ α β iα iβ f g h, 𝒞.hom_ext (F iα) (F iβ) h }
+
+section
+omit 𝒞
+/--
+We used the empty `parent_projection` class to label functions like `comm_monoid.to_monoid`,
+which we would like to use to automatically construct `bundled_hom` instances from.
+
+Once we've set up `Mon` as the category of bundled monoids,
+this allows us to set up `CommMon` by defining an instance `parent_project (comm_monoid.to_monoid)`.
+-/
+class parent_projection (F : Π {α}, d α → c α)
+end
+
+instance (F : Π {α}, d α → c α) [parent_projection @F] : bundled_hom (map_hom hom @F) := map hom @F
+
+instance forget₂ (F : Π {α}, d α → c α) [parent_projection @F] : has_forget₂ (bundled d) (bundled c) :=
+{ forget₂ :=
+  { obj := λ X, ⟨X, F X.2⟩,
+    map := λ X Y f, f } }
 
 end bundled_hom
 

--- a/src/category_theory/concrete_category/bundled_hom.lean
+++ b/src/category_theory/concrete_category/bundled_hom.lean
@@ -90,6 +90,8 @@ variables (hom)
 
 /--
 The `hom` corresponding to first forgetting along `F`, then taking the `hom` associated to `c`.
+
+For typical usage, see the construction of `CommMon` from `Mon`.
 -/
 @[reducible] def map_hom (F : Π {α}, d α → c α) : Π ⦃α β : Type u⦄ (Iα : d α) (Iβ : d β), Type u :=
 λ α β iα iβ, hom (F iα) (F iβ)

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -420,6 +420,15 @@ meta def guard_hyp' (n : parse ident) (p : parse $ tk ":=" *> texpr) : tactic un
 do h ← get_local n >>= infer_type >>= instantiate_mvars, guard_expr_eq h p
 
 /--
+`match_hyp h := t` fails if the hypothesis `h` does not match the type `t` (which may be a pattern).
+We use this tactic for writing tests.
+-/
+meta def match_hyp (n : parse ident) (p : parse $ tk ":=" *> texpr) (m := reducible) : tactic (list expr) :=
+do
+  h ← get_local n >>= infer_type >>= instantiate_mvars,
+  match_expr p h m
+
+/--
 `guard_expr_strict t := e` fails if the expr `t` is not equal to `e`. By contrast
 to `guard_expr`, this tests strict (syntactic) equality.
 We use this tactic for writing tests.


### PR DESCRIPTION
Previously, if you wrote:
```lean
example (R : CommMon.{u}) : R ⟶ R :=
{ to_fun := λ x, _,
  map_one' := sorry,
  map_mul' := sorry, }
```
you were told the expected type was `↥(bundled.map comm_monoid.to_monoid R)`, which is not particularly reassuring unless you understand the details of how we've set up concrete categories.

If you called `dsimp`, this got better, just giving `R.α`. This still isn't ideal, as we prefer to talk about the underlying type of a bundled object via the coercion, not the structure projection.

After this PR, which provides a slightly different mechanism for constructing "induced" categories from bundled categories, the expected type is exactly what you might have hoped for: `↥R`.

There seems to be one place where we used to get away with writing `𝟙 _` and now have to write `𝟙 A`, but otherwise there appear to be no ill-effects of this change.

(For follow-up, I think I can entirely get rid of our `local attribute [reducible]` work-arounds when setting up concrete categories, and in fact construct most of the instances in `@[derive]` handlers, but these will be separate PRs.)