### PR TITLE
[Merged by Bors] - feat(algebra): define `invertible` typeclass

### DIFF
--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -295,12 +295,21 @@ by rw [bit1, bit0_zero, zero_add]
 
 end add_monoid
 
+section monoid
+variables [monoid M]
+
+@[to_additive]
+lemma left_inv_eq_right_inv {a b c : M} (hba : b * a = 1) (hac : a * c = 1) : b = c :=
+by rw [←one_mul c, ←hba, mul_assoc, hac, mul_one b]
+
+end monoid
+
 section comm_monoid
 variables [comm_monoid M]
 
 @[to_additive] lemma inv_unique {x y z : M}
   (hy : x * y = 1) (hz : x * z = 1) : y = z :=
-by rw [←one_mul y, ←hz, mul_comm x, mul_assoc, hy, mul_one]
+left_inv_eq_right_inv (trans (mul_comm _ _) hy) hz
 
 end comm_monoid
 

--- a/src/algebra/invertible.lean
+++ b/src/algebra/invertible.lean
@@ -6,7 +6,8 @@ Author: Anne Baanen
 A typeclass for the two-sided multiplicative inverse.
 -/
 
-import tactic
+import algebra.char_zero
+import tactic.norm_cast
 
 /-!
 # Invertible elements
@@ -68,9 +69,6 @@ by simp [mul_assoc]
 @[simp]
 lemma mul_mul_inv_of_self_cancel [monoid α] (a b : α) [invertible b] : a * b * ⅟b = a :=
 by simp [mul_assoc]
-
-lemma left_inv_eq_right_inv [monoid α] {a b c : α} (hba : b * a = 1) (hac : a * c = 1) : b = c :=
-by rw [←one_mul c, ←hba, mul_assoc, hac, mul_one b]
 
 lemma inv_of_eq_right_inv [monoid α] {a b : α} [invertible a] (hac : a * b = 1) : ⅟a = b :=
 left_inv_eq_right_inv (inv_of_mul_self _) hac

--- a/src/algebra/invertible.lean
+++ b/src/algebra/invertible.lean
@@ -14,7 +14,7 @@ import tactic
 This file defines a typeclass `invertible a` for elements `a` with a
 multiplicative inverse.
 
-The intent of the typeclass is to provide a way to write e.g. `⅟ 2` in a ring
+The intent of the typeclass is to provide a way to write e.g. `⅟2` in a ring
 like `ℤ[1/2]` where some inverses exist but there is no general `⁻¹` operator;
 or to specify that a field has characteristic `≠ 2`.
 It is the `Type`-valued analogue to the `Prop`-valued `is_unit`.
@@ -25,14 +25,14 @@ To find instances, `invertible_of_nonzero` is a useful definition.
 
 ## Notation
 
- * `⅟ a` is `invertible.inv_of a`, the inverse of `a`
+ * `⅟a` is `invertible.inv_of a`, the inverse of `a`
 
 ## Implementation notes
 
 The `invertible` class lives in `Type`, not `Prop`, to make computation easier.
 If multiplication is associative, `invertible` is a subsingleton anyway.
 
-The `simp` normal form tries to normalize `⅟ a` to `a ⁻¹`. Otherwise, it pushes
+The `simp` normal form tries to normalize `⅟a` to `a ⁻¹`. Otherwise, it pushes
 `⅟` inside the expression as much as possible.
 
 ## Tags
@@ -53,19 +53,19 @@ class invertible [has_mul α] [has_one α] (a : α) : Type u :=
 notation `⅟`:1034 := invertible.inv_of
 
 @[simp]
-lemma inv_of_mul_self [has_mul α] [has_one α] (a : α) [invertible a] : ⅟ a * a = 1 :=
+lemma inv_of_mul_self [has_mul α] [has_one α] (a : α) [invertible a] : ⅟a * a = 1 :=
 invertible.inv_of_mul_self
 
 @[simp]
-lemma mul_inv_of_self [has_mul α] [has_one α] (a : α) [invertible a] : a * ⅟ a = 1 :=
+lemma mul_inv_of_self [has_mul α] [has_one α] (a : α) [invertible a] : a * ⅟a = 1 :=
 invertible.mul_inv_of_self
 
 @[simp]
-lemma mul_inv_of_mul_self_cancel [monoid α] (a b : α) [invertible b] : a * ⅟ b * b = a :=
+lemma mul_inv_of_mul_self_cancel [monoid α] (a b : α) [invertible b] : a * ⅟b * b = a :=
 by simp [mul_assoc]
 
 @[simp]
-lemma mul_mul_inv_of_self_cancel [monoid α] (a b : α) [invertible b] : a * b * ⅟ b = a :=
+lemma mul_mul_inv_of_self_cancel [monoid α] (a b : α) [invertible b] : a * b * ⅟b = a :=
 by simp [mul_assoc]
 
 lemma left_inv_eq_right_inv [monoid α] {a b c : α} (hba : b * a = 1) (hac : a * c = 1) : b = c :=
@@ -75,26 +75,26 @@ instance [monoid α] (a : α) : subsingleton (invertible a) :=
 ⟨ λ ⟨b, hba, hab⟩ ⟨c, hca, hac⟩, by { congr, exact left_inv_eq_right_inv hba hac } ⟩
 
 lemma is_unit_of_invertible [monoid α] (a : α) [invertible a] : is_unit a :=
-⟨⟨a, ⅟ a, mul_inv_of_self a, inv_of_mul_self a⟩, rfl⟩
+⟨⟨a, ⅟a, mul_inv_of_self a, inv_of_mul_self a⟩, rfl⟩
 
 @[priority(100)]
 instance invertible_of_group [group α] (a : α) : invertible a :=
 ⟨a⁻¹, inv_mul_self a, mul_inv_self a⟩
 
-@[simp] lemma inv_of_eq_group_inv [group α] (a : α) : ⅟ a = a⁻¹ :=
+@[simp] lemma inv_of_eq_group_inv [group α] (a : α) : ⅟a = a⁻¹ :=
 rfl
 
 instance invertible_one [monoid α] : invertible (1 : α) :=
 ⟨ 1, mul_one _, one_mul _ ⟩
 
-@[simp] lemma inv_of_one [monoid α] : ⅟ (1 : α) = 1 := rfl
+@[simp] lemma inv_of_one [monoid α] : ⅟(1 : α) = 1 := rfl
 
 instance invertible_neg [ring α] (a : α) [invertible a] : invertible (-a) :=
 ⟨ -⅟a, by simp, by simp ⟩
 
 @[simp] lemma inv_of_neg [ring α] (a : α) [invertible a] : ⅟(-a) = -⅟a := rfl
 
-instance invertible_inv_of [has_one α] [has_mul α] {a : α} [invertible a] : invertible (⅟ a) :=
+instance invertible_inv_of [has_one α] [has_mul α] {a : α} [invertible a] : invertible (⅟a) :=
 ⟨ a, mul_inv_of_self a, inv_of_mul_self a ⟩
 
 @[simp] lemma inv_of_inv_of [has_one α] [has_mul α] {a : α} [invertible a] : ⅟(⅟a) = a :=
@@ -111,14 +111,14 @@ section group_with_zero
 variable [group_with_zero α]
 
 lemma nonzero_of_invertible (a : α) [invertible a] : a ≠ 0 :=
-λ ha, zero_ne_one $ calc   0 = ⅟ a * a : by simp [ha]
+λ ha, zero_ne_one $ calc   0 = ⅟a * a : by simp [ha]
                          ... = 1 : inv_of_mul_self a
 
 /-- `a⁻¹` is an inverse of `a` if `a ≠ 0` -/
 def invertible_of_nonzero {a : α} (h : a ≠ 0) : invertible a :=
 ⟨ a⁻¹, inv_mul_cancel' _ h, mul_inv_cancel' _ h ⟩
 
-@[simp] lemma inv_of_eq_inv (a : α) [invertible a] : ⅟ a = a⁻¹ :=
+@[simp] lemma inv_of_eq_inv (a : α) [invertible a] : ⅟a = a⁻¹ :=
 left_inv_eq_right_inv (inv_of_mul_self a) (mul_inv_cancel' _ (nonzero_of_invertible a))
 
 @[simp] lemma inv_mul_cancel_of_invertible (a : α) [invertible a] : a⁻¹ * a = 1 :=
@@ -139,7 +139,7 @@ div_self' (nonzero_of_invertible a)
 instance invertible_div (a b : α) [invertible a] [invertible b] : invertible (a / b) :=
 ⟨ b / a, by simp [←mul_div_assoc''], by simp [←mul_div_assoc''] ⟩
 
-@[simp] lemma inv_of_div (a b : α) [invertible a] [invertible b] : ⅟ (a / b) = b / a :=
+@[simp] lemma inv_of_div (a b : α) [invertible a] [invertible b] : ⅟(a / b) = b / a :=
 rfl
 
 instance invertible_inv {a : α} [invertible a] : invertible (a⁻¹) :=

--- a/src/algebra/invertible.lean
+++ b/src/algebra/invertible.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2020 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Anne Baanen
+
+A typeclass for the two-sided multiplicative inverse.
+-/
+
+import tactic
+
+/-!
+# Invertible elements
+
+This file defines a typeclass `invertible a` for elements `a` with a
+multiplicative inverse.
+
+The intent of the typeclass is to provide a way to write e.g. `⅟ 2` in a ring
+like `ℤ[1/2]` where some inverses exist but there is no general `⁻¹` operator;
+or to specify that a field has characteristic `≠ 2`.
+It is the `Type`-valued analogue to the `Prop`-valued `is_unit`.
+
+This file also includes some instances of `invertible`, notably for all elements
+of a group and for some specific numbers if the characteristic is zero.
+To find instances, `invertible_of_nonzero` is a useful definition.
+
+## Notation
+
+ * `⅟ a` is `invertible.inv_of a`, the inverse of `a`
+
+## Implementation notes
+
+The `invertible` class lives in `Type`, not `Prop`, to make computation easier.
+If multiplication is associative, `invertible` is a subsingleton anyway.
+
+The `simp` normal form tries to normalize `⅟ a` to `a ⁻¹`. Otherwise, it pushes
+`⅟` inside the expression as much as possible.
+
+## Tags
+
+invertible, inverse element, inv_of, a half, one half, a third, one third, ½, ⅓
+
+-/
+
+universes u
+
+variables {α : Type u}
+
+/-- `invertible a` gives a two-sided multiplicative inverse of `a`. -/
+class invertible [has_mul α] [has_one α] (a : α) : Type u :=
+(inv_of : α) (inv_of_mul_self : inv_of * a = 1) (mul_inv_of_self : a * inv_of = 1)
+
+-- This notation has the same precedence as `has_inv.inv`.
+notation `⅟`:1034 := invertible.inv_of
+
+@[simp]
+lemma inv_of_mul_self [has_mul α] [has_one α] (a : α) [invertible a] : ⅟ a * a = 1 :=
+invertible.inv_of_mul_self
+
+@[simp]
+lemma mul_inv_of_self [has_mul α] [has_one α] (a : α) [invertible a] : a * ⅟ a = 1 :=
+invertible.mul_inv_of_self
+
+@[simp]
+lemma mul_inv_of_mul_self_cancel [monoid α] (a b : α) [invertible b] : a * ⅟ b * b = a :=
+by simp [mul_assoc]
+
+@[simp]
+lemma mul_mul_inv_of_self_cancel [monoid α] (a b : α) [invertible b] : a * b * ⅟ b = a :=
+by simp [mul_assoc]
+
+lemma left_inv_eq_right_inv [monoid α] {a b c : α} (hba : b * a = 1) (hac : a * c = 1) : b = c :=
+by rw [←one_mul c, ←hba, mul_assoc, hac, mul_one b]
+
+instance [monoid α] (a : α) : subsingleton (invertible a) :=
+⟨ λ ⟨b, hba, hab⟩ ⟨c, hca, hac⟩, by { congr, exact left_inv_eq_right_inv hba hac } ⟩
+
+lemma is_unit_of_invertible [monoid α] (a : α) [invertible a] : is_unit a :=
+⟨⟨a, ⅟ a, mul_inv_of_self a, inv_of_mul_self a⟩, rfl⟩
+
+@[priority(100)]
+instance invertible_of_group [group α] (a : α) : invertible a :=
+⟨a⁻¹, inv_mul_self a, mul_inv_self a⟩
+
+@[simp] lemma inv_of_eq_group_inv [group α] (a : α) : ⅟ a = a⁻¹ :=
+rfl
+
+instance invertible_one [monoid α] : invertible (1 : α) :=
+⟨ 1, mul_one _, one_mul _ ⟩
+
+@[simp] lemma inv_of_one [monoid α] : ⅟ (1 : α) = 1 := rfl
+
+instance invertible_neg [ring α] (a : α) [invertible a] : invertible (-a) :=
+⟨ -⅟a, by simp, by simp ⟩
+
+@[simp] lemma inv_of_neg [ring α] (a : α) [invertible a] : ⅟(-a) = -⅟a := rfl
+
+instance invertible_inv_of [has_one α] [has_mul α] {a : α} [invertible a] : invertible (⅟ a) :=
+⟨ a, mul_inv_of_self a, inv_of_mul_self a ⟩
+
+@[simp] lemma inv_of_inv_of [has_one α] [has_mul α] {a : α} [invertible a] : ⅟(⅟a) = a :=
+rfl
+
+instance invertible_mul [monoid α] (a b : α) [invertible a] [invertible b] : invertible (a * b) :=
+⟨ ⅟b * ⅟a, by simp [←mul_assoc], by simp [←mul_assoc] ⟩
+
+@[simp]
+lemma inv_of_mul [monoid α] (a b : α) [invertible a] [invertible b] : ⅟(a * b) = ⅟b * ⅟a := rfl
+
+section group_with_zero
+
+variable [group_with_zero α]
+
+lemma nonzero_of_invertible (a : α) [invertible a] : a ≠ 0 :=
+λ ha, zero_ne_one $ calc   0 = ⅟ a * a : by simp [ha]
+                         ... = 1 : inv_of_mul_self a
+
+/-- `a⁻¹` is an inverse of `a` if `a ≠ 0` -/
+def invertible_of_nonzero {a : α} (h : a ≠ 0) : invertible a :=
+⟨ a⁻¹, inv_mul_cancel' _ h, mul_inv_cancel' _ h ⟩
+
+@[simp] lemma inv_of_eq_inv (a : α) [invertible a] : ⅟ a = a⁻¹ :=
+left_inv_eq_right_inv (inv_of_mul_self a) (mul_inv_cancel' _ (nonzero_of_invertible a))
+
+@[simp] lemma inv_mul_cancel_of_invertible (a : α) [invertible a] : a⁻¹ * a = 1 :=
+inv_mul_cancel' _ (nonzero_of_invertible a)
+
+@[simp] lemma mul_inv_cancel_of_invertible (a : α) [invertible a] : a * a⁻¹ = 1 :=
+mul_inv_cancel' _ (nonzero_of_invertible a)
+
+@[simp] lemma div_mul_cancel_of_invertible (a b : α) [invertible b] : a / b * b = a :=
+div_mul_cancel' a (nonzero_of_invertible b)
+
+@[simp] lemma mul_div_cancel_of_invertible (a b : α) [invertible b] : a * b / b = a :=
+mul_div_cancel'' a (nonzero_of_invertible b)
+
+@[simp] lemma div_self_of_invertible (a : α) [invertible a] : a / a = 1 :=
+div_self' (nonzero_of_invertible a)
+
+instance invertible_div (a b : α) [invertible a] [invertible b] : invertible (a / b) :=
+⟨ b / a, by simp [←mul_div_assoc''], by simp [←mul_div_assoc''] ⟩
+
+@[simp] lemma inv_of_div (a b : α) [invertible a] [invertible b] : ⅟ (a / b) = b / a :=
+rfl
+
+instance invertible_inv {a : α} [invertible a] : invertible (a⁻¹) :=
+⟨ a, by simp, by simp ⟩
+
+end group_with_zero
+
+section division_ring
+
+variable [division_ring α]
+
+instance invertible_succ [char_zero α] (n : ℕ) : invertible (n.succ : α) :=
+invertible_of_nonzero (nat.cast_ne_zero.mpr (nat.succ_ne_zero _))
+
+/-!
+A few `invertible n` instances for small numerals `n`. Feel free to add your own
+number when you need its inverse.
+-/
+
+instance invertible_two [char_zero α] : invertible (2 : α) :=
+invertible_of_nonzero (by exact_mod_cast (dec_trivial : 2 ≠ 0))
+
+instance invertible_three [char_zero α] : invertible (3 : α) :=
+invertible_of_nonzero (by exact_mod_cast (dec_trivial : 3 ≠ 0))
+
+end division_ring

--- a/src/algebra/invertible.lean
+++ b/src/algebra/invertible.lean
@@ -19,9 +19,10 @@ like `ℤ[1/2]` where some inverses exist but there is no general `⁻¹` operat
 or to specify that a field has characteristic `≠ 2`.
 It is the `Type`-valued analogue to the `Prop`-valued `is_unit`.
 
-This file also includes some instances of `invertible`, notably for all elements
-of a group and for some specific numbers if the characteristic is zero.
-To find instances, `invertible_of_nonzero` is a useful definition.
+This file also includes some instances of `invertible` for specific numbers in
+characteristic zero. Some more cases are given as a `def`, to be included only
+when needed. To construct instances for concrete numbers,
+`invertible_of_nonzero` is a useful definition.
 
 ## Notation
 
@@ -71,40 +72,52 @@ by simp [mul_assoc]
 lemma left_inv_eq_right_inv [monoid α] {a b c : α} (hba : b * a = 1) (hac : a * c = 1) : b = c :=
 by rw [←one_mul c, ←hba, mul_assoc, hac, mul_one b]
 
+lemma inv_of_eq_right_inv [monoid α] {a b : α} [invertible a] (hac : a * b = 1) : ⅟a = b :=
+left_inv_eq_right_inv (inv_of_mul_self _) hac
+
 instance [monoid α] (a : α) : subsingleton (invertible a) :=
 ⟨ λ ⟨b, hba, hab⟩ ⟨c, hca, hac⟩, by { congr, exact left_inv_eq_right_inv hba hac } ⟩
 
 lemma is_unit_of_invertible [monoid α] (a : α) [invertible a] : is_unit a :=
 ⟨⟨a, ⅟a, mul_inv_of_self a, inv_of_mul_self a⟩, rfl⟩
 
-@[priority(100)]
-instance invertible_of_group [group α] (a : α) : invertible a :=
+/-- Each element of a group is invertible. -/
+def invertible_of_group [group α] (a : α) : invertible a :=
 ⟨a⁻¹, inv_mul_self a, mul_inv_self a⟩
 
-@[simp] lemma inv_of_eq_group_inv [group α] (a : α) : ⅟a = a⁻¹ :=
-rfl
+@[simp] lemma inv_of_eq_group_inv [group α] (a : α) [invertible a] : ⅟a = a⁻¹ :=
+inv_of_eq_right_inv (mul_inv_self a)
 
-instance invertible_one [monoid α] : invertible (1 : α) :=
+/-- `1` is the inverse of itself -/
+def invertible_one [monoid α] : invertible (1 : α) :=
 ⟨ 1, mul_one _, one_mul _ ⟩
 
-@[simp] lemma inv_of_one [monoid α] : ⅟(1 : α) = 1 := rfl
+@[simp] lemma inv_of_one [monoid α] [invertible (1 : α)] : ⅟(1 : α) = 1 :=
+inv_of_eq_right_inv (mul_one _)
 
-instance invertible_neg [ring α] (a : α) [invertible a] : invertible (-a) :=
+/-- `-⅟a` is the inverse of `-a` -/
+def invertible_neg [ring α] (a : α) [invertible a] : invertible (-a) :=
 ⟨ -⅟a, by simp, by simp ⟩
 
-@[simp] lemma inv_of_neg [ring α] (a : α) [invertible a] : ⅟(-a) = -⅟a := rfl
+@[simp] lemma inv_of_neg [ring α] (a : α) [invertible a] [invertible (-a)] : ⅟(-a) = -⅟a :=
+inv_of_eq_right_inv (by simp)
 
-instance invertible_inv_of [has_one α] [has_mul α] {a : α} [invertible a] : invertible (⅟a) :=
+/-- `a` is the inverse of `⅟a`. -/
+def invertible_inv_of [has_one α] [has_mul α] {a : α} [invertible a] : invertible (⅟a) :=
 ⟨ a, mul_inv_of_self a, inv_of_mul_self a ⟩
 
-@[simp] lemma inv_of_inv_of [has_one α] [has_mul α] {a : α} [invertible a] : ⅟(⅟a) = a :=
-rfl
+@[simp] lemma inv_of_inv_of [monoid α] {a : α} [invertible a] [invertible (⅟a)] :
+  ⅟(⅟a) = a :=
+inv_of_eq_right_inv (inv_of_mul_self _)
 
-instance invertible_mul [monoid α] (a b : α) [invertible a] [invertible b] : invertible (a * b) :=
+/-- `⅟b * ⅟a` is the inverse of `a * b` -/
+def invertible_mul [monoid α] (a b : α) [invertible a] [invertible b] : invertible (a * b) :=
 ⟨ ⅟b * ⅟a, by simp [←mul_assoc], by simp [←mul_assoc] ⟩
 
 @[simp]
-lemma inv_of_mul [monoid α] (a b : α) [invertible a] [invertible b] : ⅟(a * b) = ⅟b * ⅟a := rfl
+lemma inv_of_mul [monoid α] (a b : α) [invertible a] [invertible b] [invertible (a * b)] :
+  ⅟(a * b) = ⅟b * ⅟a :=
+inv_of_eq_right_inv (by simp [←mul_assoc])
 
 section group_with_zero
 
@@ -119,7 +132,7 @@ def invertible_of_nonzero {a : α} (h : a ≠ 0) : invertible a :=
 ⟨ a⁻¹, inv_mul_cancel' _ h, mul_inv_cancel' _ h ⟩
 
 @[simp] lemma inv_of_eq_inv (a : α) [invertible a] : ⅟a = a⁻¹ :=
-left_inv_eq_right_inv (inv_of_mul_self a) (mul_inv_cancel' _ (nonzero_of_invertible a))
+inv_of_eq_right_inv (mul_inv_cancel' _ (nonzero_of_invertible a))
 
 @[simp] lemma inv_mul_cancel_of_invertible (a : α) [invertible a] : a⁻¹ * a = 1 :=
 inv_mul_cancel' _ (nonzero_of_invertible a)
@@ -136,13 +149,16 @@ mul_div_cancel'' a (nonzero_of_invertible b)
 @[simp] lemma div_self_of_invertible (a : α) [invertible a] : a / a = 1 :=
 div_self' (nonzero_of_invertible a)
 
-instance invertible_div (a b : α) [invertible a] [invertible b] : invertible (a / b) :=
+/-- `b / a` is the inverse of `a / b` -/
+def invertible_div (a b : α) [invertible a] [invertible b] : invertible (a / b) :=
 ⟨ b / a, by simp [←mul_div_assoc''], by simp [←mul_div_assoc''] ⟩
 
-@[simp] lemma inv_of_div (a b : α) [invertible a] [invertible b] : ⅟(a / b) = b / a :=
-rfl
+@[simp] lemma inv_of_div (a b : α) [invertible a] [invertible b] [invertible (a / b)] :
+  ⅟(a / b) = b / a :=
+inv_of_eq_right_inv (by simp [←mul_div_assoc''])
 
-instance invertible_inv {a : α} [invertible a] : invertible (a⁻¹) :=
+/-- `a` is the inverse of `a⁻¹` -/
+def invertible_inv {a : α} [invertible a] : invertible (a⁻¹) :=
 ⟨ a, by simp, by simp ⟩
 
 end group_with_zero


### PR DESCRIPTION
In the discussion for #2480, we decided that the definitions would be cleaner if the elaborator could supply us with a suitable value of `1/2`. With these changes, we can now add an `[invertible 2]` argument to write `⅟ 2`.

Related to Zulip discussion: https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.232480.20bilinear.20forms

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.