### PR TITLE
[Merged by Bors] - chore(*): add missing copyright headers

### DIFF
--- a/src/data/string/defs.lean
+++ b/src/data/string/defs.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2019 Simon Hudon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Simon Hudon, Keeley Hoek, Floris van Doorn
+-/
 import data.list.defs
 
 namespace string

--- a/src/deprecated/group.lean
+++ b/src/deprecated/group.lean
@@ -2,8 +2,6 @@
 Copyright (c) 2019 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Yury Kudryashov
-
-Supplementary theorems about the `string` type.
 -/
 import algebra.group.type_tags
 import algebra.group.is_unit

--- a/src/deprecated/group.lean
+++ b/src/deprecated/group.lean
@@ -1,3 +1,10 @@
+/-
+Copyright (c) 2019 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Yury Kudryashov
+
+Supplementary theorems about the `string` type.
+-/
 import algebra.group.type_tags
 import algebra.group.is_unit
 

--- a/src/tactic/transform_decl.lean
+++ b/src/tactic/transform_decl.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2017 Mario Carneiro All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
 import meta.expr
 import meta.rb_map
 

--- a/src/topology/algebra/open_subgroup.lean
+++ b/src/topology/algebra/open_subgroup.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2019 Johan Commelin All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johan Commelin
+-/
 import order.filter.lift
 import linear_algebra.basic
 import topology.opens


### PR DESCRIPTION
I think these are close to the last remaining files without copyright headers.

(We decided at some point to allow that `import`-only files don't need one.)
