### PR TITLE
[Merged by Bors] - refactor(zmod): merge `zmodp` into `zmod`, use `[fact p.prime]` for tc search

### DIFF
--- a/src/algebra/char_p.lean
+++ b/src/algebra/char_p.lean
@@ -209,7 +209,7 @@ end
 lemma char_is_prime_of_pos (p : ℕ) [h : fact (0 < p)] [char_p α p] : fact p.prime :=
 (char_p.char_is_prime_or_zero α _).resolve_right (nat.pos_iff_ne_zero.1 h)
 
-theorem char_is_prime [fintype α] (p : ℕ) [char_p α p] : fact p.prime :=
+theorem char_is_prime [fintype α] (p : ℕ) [char_p α p] : p.prime :=
 or.resolve_right (char_is_prime_or_zero α p) (char_ne_zero_of_fintype α p)
 
 end integral_domain

--- a/src/algebra/char_p.lean
+++ b/src/algebra/char_p.lean
@@ -218,6 +218,9 @@ section char_one
 
 variables {R : Type*}
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
+
 instance [semiring R] [char_p R 1] : subsingleton R :=
 subsingleton.intro $
 suffices ∀ (r : R), r = 0,
@@ -227,6 +230,8 @@ calc r = 1 * r       : by rw one_mul
    ... = (1 : ℕ) * r : by rw nat.cast_one
    ... = 0 * r       : by rw char_p.cast_eq_zero
    ... = 0           : by rw zero_mul
+
+end prio
 
 lemma false_of_nonzero_of_char_one [nonzero_comm_ring R] [char_p R 1] : false :=
 zero_ne_one $ show (0:R) = 1, from subsingleton.elim 0 1

--- a/src/algebra/char_p.lean
+++ b/src/algebra/char_p.lean
@@ -206,7 +206,10 @@ match p, hc with
 | (m+2), hc := or.inl (@char_is_prime_of_ge_two α _ (m+2) hc (nat.le_add_left 2 m))
 end
 
-theorem char_is_prime [fintype α] (p : ℕ) [char_p α p] : nat.prime p :=
+lemma char_is_prime_of_pos (p : ℕ) [h : fact (0 < p)] [char_p α p] : fact p.prime :=
+(char_p.char_is_prime_or_zero α _).resolve_right (nat.pos_iff_ne_zero.1 h)
+
+theorem char_is_prime [fintype α] (p : ℕ) [char_p α p] : fact p.prime :=
 or.resolve_right (char_is_prime_or_zero α p) (char_ne_zero_of_fintype α p)
 
 end integral_domain

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -603,6 +603,9 @@ lemma sub_mod_eq_zero_of_mod_eq {a b c : ℕ} (h : a % c = b % c) : (a - b) % c 
 by rw [←nat.mod_add_div a c, ←nat.mod_add_div b c, ←h, ←nat.sub_sub, nat.add_sub_cancel_left,
        ←nat.mul_sub_left_distrib, nat.mul_mod_right]
 
+lemma dvd_sub_mod (k : ℕ) : n ∣ (k - (k % n)) :=
+⟨k / n, nat.sub_eq_of_eq_add (nat.mod_add_div k n).symm⟩
+
 theorem add_pos_left {m : ℕ} (h : 0 < m) (n : ℕ) : 0 < m + n :=
 calc
   m + n > 0 + n : nat.add_lt_add_right h n
@@ -668,6 +671,17 @@ theorem le_add_one_iff {i j : ℕ} : i ≤ j + 1 ↔ (i ≤ j ∨ i = j + 1) :=
 theorem mul_self_inj {n m : ℕ} : n * n = m * m ↔ n = m :=
 le_antisymm_iff.trans (le_antisymm_iff.trans
   (and_congr mul_self_le_mul_self_iff mul_self_le_mul_self_iff)).symm
+
+section facts
+-- Inject some simple facts into the typeclass system.
+-- This `fact` should not be confused with the factorial function `nat.fact`!
+
+instance succ_pos' (n : ℕ) : _root_.fact (0 < n.succ) := n.succ_pos
+
+instance pos_of_one_lt (n : ℕ) [h : fact (1 < n)] : fact (0 < n) :=
+lt_trans zero_lt_one h
+
+end facts
 
 instance decidable_ball_lt (n : nat) (P : Π k < n, Prop) :
   ∀ [H : ∀ n h, decidable (P n h)], decidable (∀ n h, P n h) :=

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -676,7 +676,7 @@ section facts
 -- Inject some simple facts into the typeclass system.
 -- This `fact` should not be confused with the factorial function `nat.fact`!
 
-instance succ_pos' (n : ℕ) : _root_.fact (0 < n.succ) := n.succ_pos
+instance succ_pos'' (n : ℕ) : _root_.fact (0 < n.succ) := n.succ_pos
 
 instance pos_of_one_lt (n : ℕ) [h : fact (1 < n)] : fact (0 < n) :=
 lt_trans zero_lt_one h

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -124,6 +124,12 @@ end)
 
 end modeq
 
+lemma add_mod (a b n : ℕ) : (a + b) % n = ((a % n) + (b % n)) % n :=
+(modeq_add (mod_modeq a n) (mod_modeq b n)).symm
+
+lemma mul_mod (a b n : ℕ) : (a * b) % n = ((a % n) * (b % n)) % n :=
+(modeq_mul (mod_modeq a n) (mod_modeq b n)).symm
+
 @[simp] lemma mod_mul_right_mod (a b c : ℕ) : a % (b * c) % b = a % b :=
 modeq.modeq_of_modeq_mul_right _ (modeq.mod_modeq _ _)
 

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -125,10 +125,10 @@ end)
 end modeq
 
 lemma add_mod (a b n : ℕ) : (a + b) % n = ((a % n) + (b % n)) % n :=
-(modeq_add (mod_modeq a n) (mod_modeq b n)).symm
+(nat.modeq.modeq_add (nat.modeq.mod_modeq a n) (nat.modeq.mod_modeq b n)).symm
 
 lemma mul_mod (a b n : ℕ) : (a * b) % n = ((a % n) * (b % n)) % n :=
-(modeq_mul (mod_modeq a n) (mod_modeq b n)).symm
+(nat.modeq.modeq_mul (nat.modeq.mod_modeq a n) (nat.modeq.mod_modeq b n)).symm
 
 @[simp] lemma mod_mul_right_mod (a b c : ℕ) : a % (b * c) % b = a % b :=
 modeq.modeq_of_modeq_mul_right _ (modeq.mod_modeq _ _)

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -39,7 +39,7 @@ theorem prime.two_le {p : ℕ} : prime p → 2 ≤ p := and.left
 
 theorem prime.one_lt {p : ℕ} : prime p → 1 < p := prime.two_le
 
-instance prime.fact_one_lt (p : ℕ) [hp : fact p.prime] : fact (1 < p) := hp.one_lt
+instance prime.one_lt' (p : ℕ) [hp : _root_.fact p.prime] : _root_.fact (1 < p) := hp.one_lt
 
 lemma prime.ne_one {p : ℕ} (hp : p.prime) : p ≠ 1 :=
 ne.symm $ (ne_of_lt hp.one_lt)

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -39,6 +39,8 @@ theorem prime.two_le {p : ℕ} : prime p → 2 ≤ p := and.left
 
 theorem prime.one_lt {p : ℕ} : prime p → 1 < p := prime.two_le
 
+instance prime.fact_one_lt (p : ℕ) [hp : fact p.prime] : fact (1 < p) := hp.one_lt
+
 lemma prime.ne_one {p : ℕ} (hp : p.prime) : p ≠ 1 :=
 ne.symm $ (ne_of_lt hp.one_lt)
 

--- a/src/data/nat/totient.lean
+++ b/src/data/nat/totient.lean
@@ -3,7 +3,8 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
-import data.zmod.basic
+
+import algebra.big_operators
 
 open finset
 
@@ -71,19 +72,3 @@ calc ((range n.succ).filter (∣ n)).sum φ
 
 end nat
 
-namespace zmod
-
-open fintype
-open_locale nat
-
-@[simp] lemma card_units_eq_totient (n : ℕ+) :
-  card (units (zmod n)) = φ n :=
-calc card (units (zmod n)) = card {x : zmod n // x.1.coprime n} :
-  fintype.card_congr zmod.units_equiv_coprime
-... = φ n : finset.card_congr
-  (λ a _, a.1.1)
-  (λ a, by simp [a.1.2, a.2.symm] {contextual := tt})
-  (λ _ _ h, by simp [subtype.val_injective.eq_iff, (fin.eq_iff_veq _ _).symm])
-  (λ b hb, ⟨⟨⟨b, by finish⟩, nat.coprime.symm (by simp at hb; tauto)⟩, mem_univ _, rfl⟩)
-
-end zmod

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -13,23 +13,20 @@ import data.nat.totient
 
 Definition of the integers mod n, and the field structure on the integers mod p.
 
-There are two types defined, `zmod n`, which is for integers modulo a positive nat `n : ℕ+`.
-`zmodp` is the type of integers modulo a prime number, for which a field structure is defined.
 
 ## Definitions
 
-* `val` is inherited from `fin` and returns the least natural number in the equivalence class
+* `zmod n`, which is for integers modulo a nat `n : ℕ`
+
+* `val a` is defined as a natural number:
+  - for `a : zmod 0` it is the absolute value of `a`
+  - for `a : zmod n` with `0 < n` it is the least natural number in the equivalence class
 
 * `val_min_abs` returns the integer closest to zero in the equivalence class.
 
-* A coercion `cast` is defined from `zmod n` into any semiring. This is a semiring hom if the ring has
-characteristic dividing `n`
+* A coercion `cast` is defined from `zmod n` into any ring.
+This is a ring hom if the ring has characteristic dividing `n`
 
-## Implementation notes
-
-`zmod` and `zmodp` are implemented as different types so that the field instance for `zmodp` can be
-synthesized. This leads to a lot of code duplication and most of the functions and theorems for
-`zmod` are restated for `zmodp`
 -/
 
 namespace fin
@@ -128,7 +125,8 @@ end
 
 end fin
 
-def zmod : ℕ →  Type
+/-- The integers modulo `n : ℕ`. -/
+def zmod : ℕ → Type
 | 0     := ℤ
 | (n+1) := fin (n+1)
 
@@ -256,7 +254,7 @@ begin
   rcases nat_cast_surjective a with ⟨k, rfl⟩,
   symmetry,
   rw [val_cast_nat, ← sub_eq_zero, ← nat.cast_sub, char_p.cast_eq_zero_iff (zmod n) n],
-  { apply dvd_sub_mod },
+  { apply nat.dvd_sub_mod },
   { apply nat.mod_le }
 end
 
@@ -296,7 +294,7 @@ begin
   symmetry, resetI,
   rw [fin.val_add, ← nat.cast_add, ← sub_eq_zero, ← nat.cast_sub,
     @char_p.cast_eq_zero_iff R _ n.succ],
-  { apply dvd_sub_mod },
+  { apply nat.dvd_sub_mod },
   { apply nat.mod_le }
 end
 
@@ -308,7 +306,7 @@ begin
   symmetry, resetI,
   rw [fin.val_mul, ← nat.cast_mul, ← sub_eq_zero, ← nat.cast_sub,
     @char_p.cast_eq_zero_iff R _ n.succ],
-  { apply dvd_sub_mod },
+  { apply nat.dvd_sub_mod },
   { apply nat.mod_le }
 end
 

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -117,10 +117,7 @@ def comm_ring (n : ℕ) : comm_ring (fin (n+1)) :=
 
 local attribute [instance] fin.add_comm_semigroup
 
--- move this
-lemma nat.add_mod (x y n : ℕ) : (x + y) % n = ((x % n) + (y % n)) % n :=
-(modeq_add (mod_modeq x n) (mod_modeq y n)).symm
-
+@[simp]
 lemma of_nat_eq_coe (n : ℕ) (a : ℕ) : (of_nat a : fin (n+1)) = a :=
 begin
   induction a with a ih, { refl },
@@ -221,13 +218,6 @@ instance (n : ℕ) : has_coe (zmod n) R := ⟨cast⟩
 by { cases n; refl }
 
 end
-
--- move this
-lemma dvd_sub_mod (k : ℕ) : n ∣ (k - (k % n)) :=
-⟨k / n, nat.sub_eq_of_eq_add (nat.mod_add_div k n).symm⟩
-
--- move this
-instance nat.fact_succ_pos {n : ℕ} : fact (0 < n.succ) := n.succ_pos
 
 lemma nat_cast_surjective [fact (0 < n)] :
   function.surjective (coe : ℕ → zmod n) :=
@@ -351,10 +341,6 @@ begin
   ext,
   exact h
 end
-
--- move this
-instance pos_of_one_lt (n : ℕ) [fact (1 < n)] : fact (0 < n) :=
-lt_trans zero_lt_one ‹1 < n›
 
 lemma val_one_eq_one_mod (n : ℕ) : (1 : zmod n).val = 1 % n :=
 by rw [← nat.cast_one, val_cast_nat]
@@ -676,9 +662,6 @@ end zmod
 namespace zmod
 
 variables (p : ℕ) [fact p.prime]
-
--- move this
-instance prime.fact_one_lt : fact (1 < p) := nat.prime.one_lt ‹p.prime›
 
 private lemma mul_inv_cancel_aux (a : zmod p) (h : a ≠ 0) : a * a⁻¹ = 1 :=
 begin

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -31,6 +31,14 @@ This is a ring hom if the ring has characteristic dividing `n`
 
 namespace fin
 
+/-!
+## Ring structure on `fin n`
+
+We define a commutative ring structure on `fin n`, but we do not register it as instance.
+Afterwords, when we define `zmod n` in terms of `fin n`, we use these definitions
+to register the ring structure on `zmod n` as type class instance.
+-/
+
 open nat nat.modeq int
 
 /-- Negation on `fin n` -/

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -3,7 +3,10 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Chris Hughes
 -/
+
 import data.int.modeq
+import algebra.char_p
+import data.nat.totient
 
 /-!
 # Integers mod `n`
@@ -29,83 +32,76 @@ synthesized. This leads to a lot of code duplication and most of the functions a
 `zmod` are restated for `zmodp`
 -/
 
+namespace fin
+
 open nat nat.modeq int
 
-def zmod (n : ℕ+) := fin n
-
-namespace zmod
-
-instance (n : ℕ+) : has_neg (zmod n) :=
+def has_neg (n : ℕ) : has_neg (fin n) :=
 ⟨λ a, ⟨nat_mod (-(a.1 : ℤ)) n,
-  have h : (n : ℤ) ≠ 0 := int.coe_nat_ne_zero_iff_pos.2 n.pos,
-  have h₁ : ((n : ℕ) : ℤ) = abs n := (abs_of_nonneg (int.coe_nat_nonneg n)).symm,
-  by rw [← int.coe_nat_lt, nat_mod, to_nat_of_nonneg (int.mod_nonneg _ h), h₁];
-    exact int.mod_lt _ h⟩⟩
+begin
+  have npos : 0 < n := lt_of_le_of_lt (nat.zero_le _) a.2,
+  have h : (n : ℤ) ≠ 0 := int.coe_nat_ne_zero_iff_pos.2 npos,
+  have := int.mod_lt (-(a.1 : ℤ)) h,
+  rw [(abs_of_nonneg (int.coe_nat_nonneg n))] at this,
+  rwa [← int.coe_nat_lt, nat_mod, to_nat_of_nonneg (int.mod_nonneg _ h)]
+end⟩⟩
 
-instance (n : ℕ+) : add_comm_semigroup (zmod n) :=
+def add_comm_semigroup (n : ℕ) : add_comm_semigroup (fin (n+1)) :=
 { add_assoc := λ ⟨a, ha⟩ ⟨b, hb⟩ ⟨c, hc⟩, fin.eq_of_veq
-    (show ((a + b) % n + c) ≡ (a + (b + c) % n) [MOD n],
-    from calc ((a + b) % n + c) ≡ a + b + c [MOD n] : modeq_add (nat.mod_mod _ _) rfl
-      ... ≡ a + (b + c) [MOD n] : by rw add_assoc
-      ... ≡ (a + (b + c) % n) [MOD n] : modeq_add rfl (nat.mod_mod _ _).symm),
-  add_comm := λ ⟨a, _⟩ ⟨b, _⟩, fin.eq_of_veq (show (a + b) % n = (b + a) % n, by rw add_comm),
+    (show ((a + b) % (n+1) + c) ≡ (a + (b + c) % (n+1)) [MOD (n+1)],
+    from calc ((a + b) % (n+1) + c) ≡ a + b + c [MOD (n+1)] : modeq_add (nat.mod_mod _ _) rfl
+      ... ≡ a + (b + c) [MOD (n+1)] : by rw add_assoc
+      ... ≡ (a + (b + c) % (n+1)) [MOD (n+1)] : modeq_add rfl (nat.mod_mod _ _).symm),
+  add_comm := λ ⟨a, _⟩ ⟨b, _⟩, fin.eq_of_veq (show (a + b) % (n+1) = (b + a) % (n+1), by rw add_comm),
   ..fin.has_add }
 
-instance (n : ℕ+) : comm_semigroup (zmod n) :=
+def comm_semigroup (n : ℕ) : comm_semigroup (fin (n+1)) :=
 { mul_assoc := λ ⟨a, ha⟩ ⟨b, hb⟩ ⟨c, hc⟩, fin.eq_of_veq
-    (calc ((a * b) % n * c) ≡ a * b * c [MOD n] : modeq_mul (nat.mod_mod _ _) rfl
-      ... ≡ a * (b * c) [MOD n] : by rw mul_assoc
-      ... ≡ a * (b * c % n) [MOD n] : modeq_mul rfl (nat.mod_mod _ _).symm),
-  mul_comm := λ ⟨a, _⟩ ⟨b, _⟩, fin.eq_of_veq (show (a * b) % n = (b * a) % n, by rw mul_comm),
+    (calc ((a * b) % (n+1) * c) ≡ a * b * c [MOD (n+1)] : modeq_mul (nat.mod_mod _ _) rfl
+      ... ≡ a * (b * c) [MOD (n+1)] : by rw mul_assoc
+      ... ≡ a * (b * c % (n+1)) [MOD (n+1)] : modeq_mul rfl (nat.mod_mod _ _).symm),
+  mul_comm := λ ⟨a, _⟩ ⟨b, _⟩, fin.eq_of_veq (show (a * b) % (n+1) = (b * a) % (n+1), by rw mul_comm),
   ..fin.has_mul }
 
-instance (n : ℕ+) : has_one (zmod n) := ⟨⟨(1 % n), nat.mod_lt _ n.pos⟩⟩
+local attribute [instance] fin.add_comm_semigroup fin.comm_semigroup
 
-instance (n : ℕ+) : has_zero (zmod n) := ⟨⟨0, n.pos⟩⟩
-
-instance (n : ℕ+) : inhabited (zmod n) := ⟨0⟩
-
-instance zmod_one.subsingleton : subsingleton (zmod 1) :=
-⟨λ a b, fin.eq_of_veq (by rw [eq_zero_of_le_zero (le_of_lt_succ a.2),
-  eq_zero_of_le_zero (le_of_lt_succ b.2)])⟩
-
-lemma add_val {n : ℕ+} : ∀ a b : zmod n, (a + b).val = (a.val + b.val) % n
+lemma val_add {n : ℕ} : ∀ a b : fin n, (a + b).val = (a.val + b.val) % n
 | ⟨_, _⟩ ⟨_, _⟩ := rfl
 
-lemma mul_val {n : ℕ+} :  ∀ a b : zmod n, (a * b).val = (a.val * b.val) % n
+lemma val_mul {n : ℕ} :  ∀ a b : fin n, (a * b).val = (a.val * b.val) % n
 | ⟨_, _⟩ ⟨_, _⟩ := rfl
 
-lemma one_val {n : ℕ+} : (1 : zmod n).val = 1 % n := rfl
+lemma one_val {n : ℕ} : (1 : fin (n+1)).val = 1 % (n+1) := rfl
 
-@[simp] lemma zero_val (n : ℕ+) : (0 : zmod n).val = 0 := rfl
+@[simp] lemma zero_val (n : ℕ) : (0 : fin (n+1)).val = 0 := rfl
 
-private lemma one_mul_aux (n : ℕ+) (a : zmod n) : (1 : zmod n) * a = a :=
+private lemma one_mul_aux (n : ℕ) (a : fin (n+1)) : (1 : fin (n+1)) * a = a :=
 begin
-  cases n with n hn,
   cases n with n,
-  { exact (lt_irrefl _ hn).elim },
-  { cases n with n,
-    { exact @subsingleton.elim (zmod 1) _ _ _ },
-    { have h₁ : a.1 % n.succ.succ = a.1 := nat.mod_eq_of_lt a.2,
-      have h₂ : 1 % n.succ.succ = 1 := nat.mod_eq_of_lt dec_trivial,
-      refine fin.eq_of_veq _,
-      simp [mul_val, one_val, h₁, h₂] } }
+  { exact subsingleton.elim _ _ },
+  { have h₁ : a.1 % n.succ.succ = a.1 := nat.mod_eq_of_lt a.2,
+    have h₂ : 1 % n.succ.succ = 1 := nat.mod_eq_of_lt dec_trivial,
+    refine fin.eq_of_veq _,
+    simp [val_mul, one_val, h₁, h₂] }
 end
 
-private lemma left_distrib_aux (n : ℕ+) : ∀ a b c : zmod n, a * (b + c) = a * b + a * c :=
+private lemma left_distrib_aux (n : ℕ) : ∀ a b c : fin (n+1), a * (b + c) = a * b + a * c :=
 λ ⟨a, ha⟩ ⟨b, hb⟩ ⟨c, hc⟩, fin.eq_of_veq
-(calc a * ((b + c) % n) ≡ a * (b + c) [MOD n] : modeq_mul rfl (nat.mod_mod _ _)
-  ... ≡ a * b + a * c [MOD n] : by rw mul_add
-  ... ≡ (a * b) % n + (a * c) % n [MOD n] : modeq_add (nat.mod_mod _ _).symm (nat.mod_mod _ _).symm)
+(calc a * ((b + c) % (n+1)) ≡ a * (b + c) [MOD (n+1)] : modeq_mul rfl (nat.mod_mod _ _)
+  ... ≡ a * b + a * c [MOD (n+1)] : by rw mul_add
+  ... ≡ (a * b) % (n+1) + (a * c) % (n+1) [MOD (n+1)] :
+        modeq_add (nat.mod_mod _ _).symm (nat.mod_mod _ _).symm)
 
-instance (n : ℕ+) : comm_ring (zmod n) :=
-{ zero_add := λ ⟨a, ha⟩, fin.eq_of_veq (show (0 + a) % n = a, by rw zero_add; exact nat.mod_eq_of_lt ha),
+def comm_ring (n : ℕ) : comm_ring (fin (n+1)) :=
+{ zero_add := λ ⟨a, ha⟩, fin.eq_of_veq (show (0 + a) % (n+1) = a,
+    by rw zero_add; exact nat.mod_eq_of_lt ha),
   add_zero := λ ⟨a, ha⟩, fin.eq_of_veq (nat.mod_eq_of_lt ha),
   add_left_neg :=
-    λ ⟨a, ha⟩, fin.eq_of_veq (show (((-a : ℤ) % n).to_nat + a) % n = 0,
+    λ ⟨a, ha⟩, fin.eq_of_veq (show (((-a : ℤ) % (n+1)).to_nat + a) % (n+1) = 0,
       from int.coe_nat_inj
       begin
-        have hn : (n : ℤ) ≠ 0 := (ne_of_lt (int.coe_nat_lt.2 n.pos)).symm,
+        have npos : 0 < n+1 := lt_of_le_of_lt (nat.zero_le _) ha,
+        have hn : ((n+1) : ℤ) ≠ 0 := (ne_of_lt (int.coe_nat_lt.2 npos)).symm,
         rw [int.coe_nat_mod, int.coe_nat_add, to_nat_of_nonneg (int.mod_nonneg _ hn), add_comm],
         simp,
       end),
@@ -113,110 +109,385 @@ instance (n : ℕ+) : comm_ring (zmod n) :=
   mul_one := λ a, by rw mul_comm; exact one_mul_aux n a,
   left_distrib := left_distrib_aux n,
   right_distrib := λ a b c, by rw [mul_comm, left_distrib_aux, mul_comm _ b, mul_comm]; refl,
-  ..zmod.has_zero n,
-  ..zmod.has_one n,
-  ..zmod.has_neg n,
-  ..zmod.add_comm_semigroup n,
-  ..zmod.comm_semigroup n }
+  ..fin.has_zero,
+  ..fin.has_one,
+  ..fin.has_neg (n+1),
+  ..fin.add_comm_semigroup n,
+  ..fin.comm_semigroup n }
 
-lemma val_cast_nat {n : ℕ+} (a : ℕ) : (a : zmod n).val = a % n :=
+local attribute [instance] fin.add_comm_semigroup
+
+-- move this
+lemma nat.add_mod (x y n : ℕ) : (x + y) % n = ((x % n) + (y % n)) % n :=
+(modeq_add (mod_modeq x n) (mod_modeq y n)).symm
+
+lemma of_nat_eq_coe (n : ℕ) (a : ℕ) : (of_nat a : fin (n+1)) = a :=
 begin
-  induction a with a ih,
-  { rw [nat.zero_mod]; refl },
-  { rw [succ_eq_add_one, nat.cast_add, add_val, ih],
-    show (a % n + ((0 + (1 % n)) % n)) % n = (a + 1) % n,
-    rw [zero_add, nat.mod_mod],
-    exact nat.modeq.modeq_add (nat.mod_mod a n) (nat.mod_mod 1 n) }
+  induction a with a ih, { refl },
+  ext, show (a+1) % (n+1) = fin.val (a+1 : fin (n+1)),
+  { rw [fin.val_add, ← ih, of_nat],
+    exact nat.add_mod _ _ _ }
 end
 
-lemma neg_val' {m : pnat} (n : zmod m) : (-n).val = (m - n.val) % m :=
-have ((-n).val + n.val) % m = (m - n.val + n.val) % m,
-  by { rw [←add_val, add_left_neg, nat.sub_add_cancel (le_of_lt n.is_lt), nat.mod_self], refl },
-(nat.mod_eq_of_lt (fin.is_lt _)).symm.trans (nat.modeq.modeq_add_cancel_right rfl this)
+end fin
 
-lemma neg_val {m : pnat} (n : zmod m) : (-n).val = if n = 0 then 0 else m - n.val :=
+def zmod : ℕ →  Type
+| 0     := ℤ
+| (n+1) := fin (n+1)
+
+namespace zmod
+
+instance fintype : Π (n : ℕ) [fact (0 < n)], fintype (zmod n)
+| 0     _ := false.elim $ nat.not_lt_zero 0 ‹0 < 0›
+| (n+1) _ := fin.fintype (n+1)
+
+lemma card (n : ℕ) [fact (0 < n)] : fintype.card (zmod n) = n :=
 begin
-  rw neg_val',
-  by_cases h : n = 0; simp [h],
-  cases n with n nlt; cases n; dsimp, { contradiction },
+  unfreezeI, cases n,
+  { exfalso, exact nat.not_lt_zero 0 ‹0 < 0› },
+  { exact fintype.card_fin (n+1) }
+end
+
+instance decidable_eq : Π (n : ℕ), decidable_eq (zmod n)
+| 0     := int.decidable_eq
+| (n+1) := fin.decidable_eq _
+
+instance has_repr : Π (n : ℕ), has_repr (zmod n)
+| 0     := int.has_repr
+| (n+1) := fin.has_repr _
+
+instance comm_ring : Π (n : ℕ), comm_ring (zmod n)
+| 0     := int.comm_ring
+| (n+1) := fin.comm_ring n
+
+instance inhabited (n : ℕ) : inhabited (zmod n) := ⟨0⟩
+
+def val : Π {n : ℕ}, zmod n → ℕ
+| 0     := int.nat_abs
+| (n+1) := fin.val
+
+lemma val_lt {n : ℕ} [fact (0 < n)] (a : zmod n) : a.val < n :=
+begin
+  unfreezeI, cases n,
+  { exfalso, exact nat.not_lt_zero 0 ‹0 < 0› },
+  exact fin.is_lt a
+end
+
+@[simp] lemma val_zero : ∀ {n}, (0 : zmod n).val = 0
+| 0     := rfl
+| (n+1) := rfl
+
+lemma val_cast_nat {n : ℕ} (a : ℕ) : (a : zmod n).val = a % n :=
+begin
+  unfreezeI,
+  cases n,
+  { rw [nat.mod_zero, int.nat_cast_eq_coe_nat],
+    exact int.nat_abs_of_nat a, },
+  rw ← fin.of_nat_eq_coe,
+  refl
+end
+
+instance (n : ℕ) : char_p (zmod n) n :=
+{ cast_eq_zero_iff :=
+  begin
+    intro k,
+    cases n,
+    { simp only [int.nat_cast_eq_coe_nat, zero_dvd_iff, int.coe_nat_eq_zero], },
+    rw [fin.eq_iff_veq],
+    show (k : zmod (n+1)).val = (0 : zmod (n+1)).val ↔ _,
+    rw [val_cast_nat, val_zero, nat.dvd_iff_mod_eq_zero],
+  end }
+
+@[simp] lemma cast_self (n : ℕ) : (n : zmod n) = 0 :=
+char_p.cast_eq_zero (zmod n) n
+
+@[simp] lemma cast_self' (n : ℕ) : (n + 1 : zmod (n + 1)) = 0 :=
+by rw [← nat.cast_add_one, cast_self (n + 1)]
+
+section universal_property
+
+variables {n : ℕ} {R : Type*}
+
+section
+variables [has_zero R] [has_one R] [has_add R] [has_neg R]
+
+def cast : Π {n : ℕ}, zmod n → R
+| 0     := int.cast
+| (n+1) := λ i, i.val
+
+instance (n : ℕ) : has_coe (zmod n) R := ⟨cast⟩
+
+@[simp] lemma cast_zero : ((0 : zmod n) : R) = 0 :=
+by { cases n; refl }
+
+end
+
+-- move this
+lemma dvd_sub_mod (k : ℕ) : n ∣ (k - (k % n)) :=
+⟨k / n, nat.sub_eq_of_eq_add (nat.mod_add_div k n).symm⟩
+
+-- move this
+instance nat.fact_succ_pos {n : ℕ} : fact (0 < n.succ) := n.succ_pos
+
+lemma nat_cast_surjective [fact (0 < n)] :
+  function.surjective (coe : ℕ → zmod n) :=
+begin
+  assume i,
+  unfreezeI,
+  cases n,
+  { exfalso, exact nat.not_lt_zero 0 ‹0 < 0› },
+  { refine ⟨i.val, _⟩,
+    cases i with i hi,
+    induction i with i IH, { ext, refl },
+    show (i+1 : zmod (n+1)) = _,
+    specialize IH (lt_of_le_of_lt i.le_succ hi),
+    ext, erw [fin.val_add, IH],
+    suffices : fin.val (1 : zmod (n+1)) = 1,
+    { rw this, apply nat.mod_eq_of_lt hi },
+    show 1 % (n+1) = 1,
+    apply nat.mod_eq_of_lt,
+    apply lt_of_le_of_lt _ hi,
+    exact le_of_inf_eq rfl }
+end
+
+lemma int_cast_surjective :
+  function.surjective (coe : ℤ → zmod n) :=
+begin
+  assume i,
+  cases n,
+  { exact ⟨i, int.cast_id i⟩ },
+  { rcases nat_cast_surjective i with ⟨k, rfl⟩,
+    refine ⟨k, _⟩, norm_cast }
+end
+
+@[simp] lemma cast_val {n : ℕ} [fact (0 < n)] (a : zmod n) :
+  (a.val : zmod n) = a :=
+begin
+  rcases nat_cast_surjective a with ⟨k, rfl⟩,
+  symmetry,
+  rw [val_cast_nat, ← sub_eq_zero, ← nat.cast_sub, char_p.cast_eq_zero_iff (zmod n) n],
+  { apply dvd_sub_mod },
+  { apply nat.mod_le }
+end
+
+@[simp, norm_cast]
+lemma cast_id : ∀ n (i : zmod n), ↑i = i
+| 0     i := int.cast_id i
+| (n+1) i := cast_val i
+
+variables [ring R]
+
+@[simp] lemma nat_cast_val [fact (0 < n)] (i : zmod n) :
+  (i.val : R) = i :=
+begin
+  unfreezeI, cases n,
+  { exfalso, exact nat.not_lt_zero 0 ‹0 < 0› },
+  refl
+end
+
+variable [char_p R n]
+
+@[simp] lemma cast_one : ((1 : zmod n) : R) = 1 :=
+begin
+  unfreezeI,
+  cases n, { exact int.cast_one },
+  show ((1 % (n+1) : ℕ) : R) = 1,
+  cases n, { apply subsingleton.elim },
   rw nat.mod_eq_of_lt,
-  apply nat.sub_lt m.2 (nat.succ_pos _),
+  { exact nat.cast_one },
+  exact nat.lt_of_sub_eq_succ rfl
 end
 
-lemma mk_eq_cast {n : ℕ+} {a : ℕ} (h : a < n) : (⟨a, h⟩ : zmod n) = (a : zmod n) :=
-fin.eq_of_veq (by rw [val_cast_nat, nat.mod_eq_of_lt h])
+@[simp] lemma cast_add (a b : zmod n) : ((a + b : zmod n) : R) = a + b :=
+begin
+  unfreezeI,
+  cases n, { apply int.cast_add },
+  show ((fin.val (a + b) : ℕ) : R) = fin.val a + fin.val b,
+  symmetry, resetI,
+  rw [fin.val_add, ← nat.cast_add, ← sub_eq_zero, ← nat.cast_sub,
+    @char_p.cast_eq_zero_iff R _ n.succ],
+  { apply dvd_sub_mod },
+  { apply nat.mod_le }
+end
 
-@[simp] lemma cast_self_eq_zero {n : ℕ+} : ((n : ℕ) : zmod n) = 0 :=
-fin.eq_of_veq (show (n : zmod n).val = 0, by simp [val_cast_nat])
+@[simp] lemma cast_mul (a b : zmod n) : ((a * b : zmod n) : R) = a * b :=
+begin
+  unfreezeI,
+  cases n, { apply int.cast_mul },
+  show ((fin.val (a * b) : ℕ) : R) = fin.val a * fin.val b,
+  symmetry, resetI,
+  rw [fin.val_mul, ← nat.cast_mul, ← sub_eq_zero, ← nat.cast_sub,
+    @char_p.cast_eq_zero_iff R _ n.succ],
+  { apply dvd_sub_mod },
+  { apply nat.mod_le }
+end
 
-lemma val_cast_of_lt {n : ℕ+} {a : ℕ} (h : a < n) : (a : zmod n).val = a :=
-by rw [val_cast_nat, nat.mod_eq_of_lt h]
+def cast_hom (n : ℕ) (R : Type*) [ring R] [char_p R n] : zmod n →+* R :=
+{ to_fun := coe,
+  map_zero' := cast_zero,
+  map_one' := cast_one,
+  map_add' := cast_add,
+  map_mul' := cast_mul }
 
-@[simp] lemma cast_mod_nat (n : ℕ+) (a : ℕ) : ((a % n : ℕ) : zmod n) = a :=
+@[simp] lemma cast_hom_apply (i : zmod n) : cast_hom n R i = i := rfl
+
+@[simp, norm_cast]
+lemma cast_nat_cast (k : ℕ) : ((k : zmod n) : R) = k :=
+(cast_hom n R).map_nat_cast k
+
+@[simp, norm_cast]
+lemma cast_int_cast (k : ℤ) : ((k : zmod n) : R) = k :=
+(cast_hom n R).map_int_cast k
+
+end universal_property
+
+lemma val_injective (n : ℕ) [fact (0 < n)] :
+  function.injective (zmod.val : zmod n → ℕ) :=
+begin
+  unfreezeI,
+  cases n,
+  { exfalso, exact nat.not_lt_zero 0 ‹_› },
+  assume a b h,
+  ext,
+  exact h
+end
+
+-- move this
+instance pos_of_one_lt (n : ℕ) [fact (1 < n)] : fact (0 < n) :=
+lt_trans zero_lt_one ‹1 < n›
+
+lemma val_one_eq_one_mod (n : ℕ) : (1 : zmod n).val = 1 % n :=
+by rw [← nat.cast_one, val_cast_nat]
+
+lemma val_one (n : ℕ) [fact (1 < n)] : (1 : zmod n).val = 1 :=
+by { rw val_one_eq_one_mod, exact nat.mod_eq_of_lt ‹1 < n› }
+
+lemma val_add {n : ℕ} [fact (0 < n)] (a b : zmod n) : (a + b).val = (a.val + b.val) % n :=
+begin
+  unfreezeI, cases n,
+  { exfalso, exact nat.not_lt_zero 0 ‹0 < 0› },
+  { apply fin.val_add }
+end
+
+lemma val_mul {n : ℕ} (a b : zmod n) : (a * b).val = (a.val * b.val) % n :=
+begin
+  cases n,
+  { rw nat.mod_zero, apply int.nat_abs_mul },
+  { apply fin.val_mul }
+end
+
+instance nonzero_comm_ring (n : ℕ) [fact (1 < n)] : nonzero_comm_ring (zmod n) :=
+{ zero_ne_one := assume h, zero_ne_one $
+   calc 0 = (0 : zmod n).val : by rw val_zero
+      ... = (1 : zmod n).val : congr_arg zmod.val h
+      ... = 1                : val_one n,
+  .. zmod.comm_ring n }
+
+def inv : Π (n : ℕ), zmod n → zmod n
+| 0     i := int.sign i
+| (n+1) i := nat.gcd_a i.val (n+1)
+
+instance (n : ℕ) : has_inv (zmod n) :=
+⟨inv n⟩
+
+lemma inv_zero : ∀ (n : ℕ), (0 : zmod n)⁻¹ = 0
+| 0     := int.sign_zero
+| (n+1) := show (nat.gcd_a _ (n+1) : zmod (n+1)) = 0,
+             by { rw val_zero, unfold nat.gcd_a nat.xgcd nat.xgcd_aux, refl }
+
+lemma mul_inv_eq_gcd {n : ℕ} (a : zmod n) :
+  a * a⁻¹ = nat.gcd a.val n :=
+begin
+  cases n,
+  { calc a * a⁻¹ = a * int.sign a  : rfl
+             ... = a.nat_abs   : by rw [int.mul_sign, int.nat_cast_eq_coe_nat]
+             ... = a.val.gcd 0 : by rw nat.gcd_zero_right; refl },
+  { set k := n.succ,
+    calc a * a⁻¹ = a * a⁻¹ + k * nat.gcd_b (val a) k : by rw [cast_self, zero_mul, add_zero]
+             ... = ↑(↑a.val * nat.gcd_a (val a) k + k * nat.gcd_b (val a) k) : by { push_cast, rw cast_val, refl }
+             ... = nat.gcd a.val k : (congr_arg coe (nat.gcd_eq_gcd_ab a.val k)).symm, }
+end
+
+@[simp] lemma cast_mod_nat (n : ℕ) (a : ℕ) : ((a % n : ℕ) : zmod n) = a :=
 by conv {to_rhs, rw ← nat.mod_add_div a n}; simp
 
-@[simp, priority 980]
-lemma cast_mod_nat' {n : ℕ} (hn : 0 < n) (a : ℕ) : ((a % n : ℕ) : zmod ⟨n, hn⟩) = a :=
-cast_mod_nat ⟨n, hn⟩ a
+lemma eq_iff_modeq_nat (n : ℕ) {a b : ℕ} : (a : zmod n) = b ↔ a ≡ b [MOD n] :=
+begin
+  cases n,
+  { simp only [nat.modeq, int.coe_nat_inj', nat.mod_zero, int.nat_cast_eq_coe_nat], },
+  { rw [fin.ext_iff, nat.modeq, ← val_cast_nat, ← val_cast_nat], exact iff.rfl, }
+end
 
-@[simp] lemma cast_val {n : ℕ+} (a : zmod n) : (a.val : zmod n) = a :=
-by cases a; simp [mk_eq_cast]
+section totient
+open_locale nat
 
-@[simp] lemma cast_mod_int (n : ℕ+) (a : ℤ) : ((a % (n : ℕ) : ℤ) : zmod n) = a :=
-by conv {to_rhs, rw ← int.mod_add_div a n}; simp
+lemma coe_mul_inv_eq_one {n : ℕ} [fact (0 < n)] (x : ℕ) (h : nat.coprime x n) :
+  (x * x⁻¹ : zmod n) = 1 :=
+begin
+  rw [nat.coprime, nat.gcd_comm, nat.gcd_rec] at h,
+  rw [mul_inv_eq_gcd, val_cast_nat, h, nat.cast_one],
+end
 
-@[simp, priority 980]
-lemma cast_mod_int' {n : ℕ} (hn : 0 < n) (a : ℤ) :
-  ((a % (n : ℕ) : ℤ) : zmod ⟨n, hn⟩) = a := cast_mod_int ⟨n, hn⟩ a
+/-- `unit_of_coprime` makes an element of `units (zmod n)` given
+  a natural number `x` and a proof that `x` is coprime to `n`  -/
+def unit_of_coprime {n : ℕ} [fact (0 < n)] (x : ℕ) (h : nat.coprime x n) : units (zmod n) :=
+⟨x, x⁻¹, coe_mul_inv_eq_one x h, by rw [mul_comm, coe_mul_inv_eq_one x h]⟩
 
-lemma val_cast_int {n : ℕ+} (a : ℤ) : (a : zmod n).val = (a % (n : ℕ)).nat_abs :=
-have h : nat_abs (a % (n : ℕ)) < n := int.coe_nat_lt.1 begin
-  rw [nat_abs_of_nonneg (mod_nonneg _ (int.coe_nat_ne_zero_iff_pos.2 n.pos))],
-  conv {to_rhs, rw ← abs_of_nonneg (int.coe_nat_nonneg n)},
-  exact int.mod_lt _ (int.coe_nat_ne_zero_iff_pos.2 n.pos)
-end,
-int.coe_nat_inj $
-  by conv {to_lhs, rw [← cast_mod_int n a,
-    ← nat_abs_of_nonneg (mod_nonneg _ (int.coe_nat_ne_zero_iff_pos.2 n.pos)),
-    int.cast_coe_nat, val_cast_of_lt h] }
+@[simp] lemma cast_unit_of_coprime {n : ℕ} [fact (0 < n)] (x : ℕ) (h : nat.coprime x n) :
+  (unit_of_coprime x h : zmod n) = x := rfl
 
-lemma coe_val_cast_int {n : ℕ+} (a : ℤ) : ((a : zmod n).val : ℤ) = a % (n : ℕ) :=
-by rw [val_cast_int, int.nat_abs_of_nonneg (mod_nonneg _ (int.coe_nat_ne_zero_iff_pos.2 n.pos))]
+lemma val_coe_unit_coprime {n : ℕ} (u : units (zmod n)) :
+  nat.coprime (u : zmod n).val n :=
+begin
+  cases n,
+  { rcases int.units_eq_one_or u with rfl|rfl; exact dec_trivial },
+  apply nat.modeq.coprime_of_mul_modeq_one ((u⁻¹ : units (zmod (n+1))) : zmod (n+1)).val,
+  have := units.ext_iff.1 (mul_right_inv u),
+  rw [units.coe_one] at this,
+  rw [← eq_iff_modeq_nat, nat.cast_one, ← this], clear this,
+  rw [← cast_val ((u * u⁻¹ : units (zmod (n+1))) : zmod (n+1))],
+  rw [units.coe_mul, val_mul, cast_mod_nat],
+end
 
-lemma eq_iff_modeq_nat {n : ℕ+} {a b : ℕ} : (a : zmod n) = b ↔ a ≡ b [MOD n] :=
-⟨λ h, by have := fin.veq_of_eq h;
-  rwa [val_cast_nat, val_cast_nat] at this,
-λ h, fin.eq_of_veq $ by rwa [val_cast_nat, val_cast_nat]⟩
+@[simp] lemma inv_coe_unit {n : ℕ} (u : units (zmod n)) :
+  (u : zmod n)⁻¹ = (u⁻¹ : units (zmod n)) :=
+begin
+  have := congr_arg (coe : ℕ → zmod n) (val_coe_unit_coprime u),
+  rw [← mul_inv_eq_gcd, nat.cast_one] at this,
+  let u' : units (zmod n) := ⟨u, (u : zmod n)⁻¹, this, by rwa mul_comm⟩,
+  have h : u = u', { apply units.ext, refl },
+  rw h,
+  refl
+end
 
-lemma eq_iff_modeq_nat' {n : ℕ} (hn : 0 < n) {a b : ℕ} : (a : zmod ⟨n, hn⟩) = b ↔ a ≡ b [MOD n] :=
-eq_iff_modeq_nat
+def units_equiv_coprime {n : ℕ} [fact (0 < n)] :
+  units (zmod n) ≃ {x : zmod n // nat.coprime x.val n} :=
+{ to_fun := λ x, ⟨x, val_coe_unit_coprime x⟩,
+  inv_fun := λ x, unit_of_coprime x.1.val x.2,
+  left_inv := λ ⟨_, _, _, _⟩, units.ext (cast_val _),
+  right_inv := λ ⟨_, _⟩, by simp }
 
-lemma eq_iff_modeq_int {n : ℕ+} {a b : ℤ} : (a : zmod n) = b ↔ a ≡ b [ZMOD (n : ℕ)] :=
-⟨λ h, by have := fin.veq_of_eq h;
-  rwa [val_cast_int, val_cast_int, ← int.coe_nat_eq_coe_nat_iff,
-    nat_abs_of_nonneg (int.mod_nonneg _ (int.coe_nat_ne_zero_iff_pos.2 n.pos)),
-    nat_abs_of_nonneg (int.mod_nonneg _ (int.coe_nat_ne_zero_iff_pos.2 n.pos))] at this,
-λ h : a % (n : ℕ) = b % (n : ℕ),
-  by rw [← cast_mod_int n a, ← cast_mod_int n b, h]⟩
+@[simp] lemma card_units_eq_totient (n : ℕ) [fact (0 < n)] :
+  fintype.card (units (zmod n)) = φ n :=
+calc fintype.card (units (zmod n)) = fintype.card {x : zmod n // x.val.coprime n} :
+  fintype.card_congr zmod.units_equiv_coprime
+... = φ n :
+begin
+  apply finset.card_congr (λ (a : {x : zmod n // x.val.coprime n}) _, a.1.val),
+  { intro a, simp [a.1.val_lt, a.2.symm] {contextual := tt}, },
+  { intros _ _ _ _ h, rw subtype.ext, apply val_injective, exact h, },
+  { intros b hb,
+    rw [finset.mem_filter, finset.mem_range] at hb,
+    refine ⟨⟨b, _⟩, finset.mem_univ _, _⟩,
+    { let u := unit_of_coprime b hb.2.symm,
+      exact val_coe_unit_coprime u },
+    { show zmod.val (b : zmod n) = b,
+      rw [val_cast_nat, nat.mod_eq_of_lt hb.1], } }
+end
 
-lemma eq_iff_modeq_int' {n : ℕ} (hn : 0 < n) {a b : ℤ} :
-  (a : zmod ⟨n, hn⟩) = b ↔ a ≡ b [ZMOD (n : ℕ)] := eq_iff_modeq_int
+end totient
 
-lemma eq_zero_iff_dvd_nat {n : ℕ+} {a : ℕ} : (a : zmod n) = 0 ↔ (n : ℕ) ∣ a :=
-by rw [← @nat.cast_zero (zmod n), eq_iff_modeq_nat, nat.modeq.modeq_zero_iff]
-
-lemma eq_zero_iff_dvd_int {n : ℕ+} {a : ℤ} : (a : zmod n) = 0 ↔ ((n : ℕ) : ℤ) ∣ a :=
-by rw [← @int.cast_zero (zmod n), eq_iff_modeq_int, int.modeq.modeq_zero_iff]
-
-instance (n : ℕ+) : fintype (zmod n) := fin.fintype _
-
-instance decidable_eq (n : ℕ+) : decidable_eq (zmod n) := fin.decidable_eq _
-
-instance (n : ℕ+) : has_repr (zmod n) := fin.has_repr _
-
-lemma card_zmod (n : ℕ+) : fintype.card (zmod n) = n := fintype.card_fin n
-
-instance : subsingleton (units (zmod 2)) :=
+instance subsingleton_units : subsingleton (units (zmod 2)) :=
 ⟨λ x y, begin
   cases x with x xi,
   cases y with y yi,
@@ -224,305 +495,203 @@ instance : subsingleton (units (zmod 2)) :=
   exact dec_trivial
 end⟩
 
-lemma le_div_two_iff_lt_neg {n : ℕ+} (hn : (n : ℕ) % 2 = 1)
-  {x : zmod n} (hx0 : x ≠ 0) : x.1 ≤ (n / 2 : ℕ) ↔ (n / 2 : ℕ) < (-x).1 :=
-have hn2 : (n : ℕ) / 2 < n := nat.div_lt_of_lt_mul ((lt_mul_iff_one_lt_left n.pos).2 dec_trivial),
-have hn2' : (n : ℕ) - n / 2 = n / 2 + 1,
-  by conv {to_lhs, congr, rw [← succ_sub_one n, succ_sub n.pos]};
-  rw [← two_mul_odd_div_two hn, two_mul, ← succ_add, nat.add_sub_cancel],
-have hxn : (n : ℕ) - x.val < n,
-  begin
-    rw [nat.sub_lt_iff (le_of_lt x.2) (le_refl _), nat.sub_self],
+lemma le_div_two_iff_lt_neg (n : ℕ) [hn : fact ((n : ℕ) % 2 = 1)]
+  {x : zmod n} (hx0 : x ≠ 0) : x.val ≤ (n / 2 : ℕ) ↔ (n / 2 : ℕ) < (-x).val :=
+begin
+  haveI npos : fact (0 < n) :=
+  by { apply (nat.eq_zero_or_pos n).resolve_left, resetI, rintro rfl, simpa [fact] using hn, },
+  have hn2 : (n : ℕ) / 2 < n := nat.div_lt_of_lt_mul ((lt_mul_iff_one_lt_left npos).2 dec_trivial),
+  have hn2' : (n : ℕ) - n / 2 = n / 2 + 1,
+  { conv {to_lhs, congr, rw [← nat.succ_sub_one n, nat.succ_sub npos]},
+    rw [← nat.two_mul_odd_div_two hn, two_mul, ← nat.succ_add, nat.add_sub_cancel], },
+  have hxn : (n : ℕ) - x.val < n,
+  { rw [nat.sub_lt_iff (le_of_lt x.val_lt) (le_refl _), nat.sub_self],
     rw ← zmod.cast_val x at hx0,
-    exact nat.pos_of_ne_zero (λ h, by simpa [h] using hx0)
-  end,
-by conv {to_rhs, rw [← nat.succ_le_iff, succ_eq_add_one, ← hn2', ← zero_add (- x), ← zmod.cast_self_eq_zero,
-  ← sub_eq_add_neg, ← zmod.cast_val x, ← nat.cast_sub (le_of_lt x.2),
-  zmod.val_cast_nat, mod_eq_of_lt hxn, nat.sub_le_sub_left_iff (le_of_lt x.2)] }
+    exact nat.pos_of_ne_zero (λ h, by simpa [h] using hx0) },
+  by conv {to_rhs, rw [← nat.succ_le_iff, nat.succ_eq_add_one, ← hn2', ← zero_add (- x),
+    ← zmod.cast_self, ← sub_eq_add_neg, ← zmod.cast_val x, ← nat.cast_sub (le_of_lt x.val_lt),
+    zmod.val_cast_nat, nat.mod_eq_of_lt hxn, nat.sub_le_sub_left_iff (le_of_lt x.val_lt)] }
+end
 
-lemma ne_neg_self {n : ℕ+} (hn1 : (n : ℕ) % 2 = 1) {a : zmod n} (ha : a ≠ 0) : a ≠ -a :=
-λ h, have a.val ≤ n / 2 ↔ (n : ℕ) / 2 < (-a).val := le_div_two_iff_lt_neg hn1 ha,
+lemma ne_neg_self (n : ℕ) [hn : fact ((n : ℕ) % 2 = 1)] {a : zmod n} (ha : a ≠ 0) : a ≠ -a :=
+λ h, have a.val ≤ n / 2 ↔ (n : ℕ) / 2 < (-a).val := le_div_two_iff_lt_neg n ha,
 by rwa [← h, ← not_lt, not_iff_self] at this
 
-@[simp] lemma cast_mul_right_val_cast {n m : ℕ+} (a : ℕ) :
-  ((a : zmod (m * n)).val : zmod m) = (a : zmod m) :=
-zmod.eq_iff_modeq_nat.2 (by rw zmod.val_cast_nat;
-  exact nat.modeq.modeq_of_modeq_mul_right _ (nat.mod_mod _ _))
-
-@[simp] lemma cast_mul_left_val_cast {n m : ℕ+} (a : ℕ) :
-  ((a : zmod (n * m)).val : zmod m) = (a : zmod m) :=
-zmod.eq_iff_modeq_nat.2 (by rw zmod.val_cast_nat;
-  exact nat.modeq.modeq_of_modeq_mul_left _ (nat.mod_mod _ _))
-
-lemma cast_val_cast_of_dvd {n m : ℕ+} (h : (m : ℕ) ∣ n) (a : ℕ) :
-  ((a : zmod n).val : zmod m) = (a : zmod m) :=
-let ⟨k , hk⟩ := h in
-zmod.eq_iff_modeq_nat.2 (nat.modeq.modeq_of_modeq_mul_right k
-    (by rw [← hk, zmod.val_cast_nat]; exact nat.mod_mod _ _))
-
-/-- `unit_of_coprime` makes an element of `units (zmod n)` given
-  a natural number `x` and a proof that `x` is coprime to `n`  -/
-def unit_of_coprime {n : ℕ+} (x : ℕ) (h : nat.coprime x n) : units (zmod n) :=
-have (x * gcd_a x ↑n : zmod n) = 1,
-  by rw [← int.cast_coe_nat, ← int.cast_one, ← int.cast_mul,
-      zmod.eq_iff_modeq_int, ← int.coe_nat_one, ← (show nat.gcd _ _ = _, from h)];
-    simpa using int.modeq.gcd_a_modeq x n,
-⟨x, gcd_a x n, this, by simpa [mul_comm] using this⟩
-
-@[simp] lemma cast_unit_of_coprime {n : ℕ+} (x : ℕ) (h : nat.coprime x n) :
-  (unit_of_coprime x h : zmod n) = x := rfl
-
-def units_equiv_coprime {n : ℕ+} : units (zmod n) ≃ {x : zmod n // nat.coprime x.1 n} :=
-{ to_fun := λ x, ⟨x, nat.modeq.coprime_of_mul_modeq_one (x⁻¹).1.1 begin
-    have := units.ext_iff.1 (mul_right_inv x),
-    rwa [← zmod.cast_val ((1 : units (zmod n)) : zmod n), units.coe_one, zmod.one_val,
-      ← zmod.cast_val ((x * x⁻¹ : units (zmod n)) : zmod n),
-      units.coe_mul, zmod.mul_val, zmod.cast_mod_nat, zmod.cast_mod_nat,
-      zmod.eq_iff_modeq_nat] at this
-    end⟩,
-  inv_fun := λ x, unit_of_coprime x.1.1 x.2,
-  left_inv := λ ⟨_, _, _, _⟩, units.ext (by simp),
-  right_inv := λ ⟨_, _⟩, by simp }
-
-/-- `val_min_abs x` returns the integer in the same equivalence class as `x` that is closest to `0`,
-  The result will be in the interval `(-n/2, n/2]` -/
-def val_min_abs {n : ℕ+} (x : zmod n) : ℤ :=
-if x.val ≤ n / 2 then x.val else x.val - n
-
-@[simp] lemma coe_val_min_abs {n : ℕ+} (x : zmod n) :
-  (x.val_min_abs : zmod n) = x :=
-by simp [zmod.val_min_abs]; split_ifs; simp [sub_eq_add_neg]
-
-lemma nat_abs_val_min_abs_le {n : ℕ+} (x : zmod n) : x.val_min_abs.nat_abs ≤ n / 2 :=
-have (x.val - n : ℤ) ≤ 0, from sub_nonpos.2 $ int.coe_nat_le.2 $ le_of_lt x.2,
+lemma neg_one_ne_one {n : ℕ} [fact (2 < n)] :
+  (-1 : zmod n) ≠ 1 :=
 begin
-  rw zmod.val_min_abs,
-  split_ifs with h,
-  { exact h },
-  { rw [← int.coe_nat_le, int.of_nat_nat_abs_of_nonpos this, neg_sub],
-    conv_lhs { congr, rw [coe_coe, ← nat.mod_add_div n 2, int.coe_nat_add, int.coe_nat_mul,
-      int.coe_nat_bit0, int.coe_nat_one] },
-    rw ← sub_nonneg,
-    suffices : (0 : ℤ) ≤ x.val - ((n % 2 : ℕ) + (n / 2 : ℕ)),
-    { exact le_trans this (le_of_eq $ by ring) },
-    exact sub_nonneg.2 (by rw [← int.coe_nat_add, int.coe_nat_le];
-      exact calc (n : ℕ) % 2 + n / 2 ≤ 1 + n / 2 :
-        add_le_add (nat.le_of_lt_succ (nat.mod_lt _ dec_trivial)) (le_refl _)
-        ... ≤ x.val : by rw add_comm; exact nat.succ_le_of_lt (lt_of_not_ge h)) }
+  suffices : (2 : zmod n) ≠ 0,
+  { symmetry, rw [ne.def, ← sub_eq_zero, sub_neg_eq_add], exact this },
+  assume h,
+  rw [show (2 : zmod n) = (2 : ℕ), by norm_cast] at h,
+  have := (char_p.cast_eq_zero_iff (zmod n) n 2).mp h,
+  have := nat.le_of_dvd dec_trivial this,
+  rw fact at *, linarith,
 end
 
-@[simp] lemma val_min_abs_zero {n : ℕ+} : (0 : zmod n).val_min_abs = 0 :=
-by simp [zmod.val_min_abs]
-
-@[simp] lemma val_min_abs_eq_zero {n : ℕ+} (x : zmod n) :
-  x.val_min_abs = 0 ↔ x = 0 :=
-⟨λ h, begin
-  dsimp [zmod.val_min_abs] at h,
-  split_ifs at h,
-  { exact fin.eq_of_veq (by simp * at *) },
-  { exact absurd h (mt sub_eq_zero.1 (ne_of_lt $ int.coe_nat_lt.2 x.2)) }
-end, λ hx0, hx0.symm ▸ zmod.val_min_abs_zero⟩
-
-lemma cast_nat_abs_val_min_abs {n : ℕ+} (a : zmod n) :
-  (a.val_min_abs.nat_abs : zmod n) = if a.val ≤ (n : ℕ) / 2 then a else -a :=
-have (a.val : ℤ) + -n ≤ 0, by erw [sub_nonpos, int.coe_nat_le]; exact le_of_lt a.2,
-begin
-  dsimp [zmod.val_min_abs],
-  split_ifs,
-  { simp },
-  { erw [← int.cast_coe_nat, int.of_nat_nat_abs_of_nonpos this],
-    simp }
-end
-
-@[simp] lemma nat_abs_val_min_abs_neg {n : ℕ+} (a : zmod n) :
-  (-a).val_min_abs.nat_abs = a.val_min_abs.nat_abs :=
-if haa : -a = a then by rw [haa]
-else
-have hpa : (n : ℕ) - a.val ≤ n / 2 ↔ (n : ℕ) / 2 < a.val,
-  from suffices (((n : ℕ) % 2) + 2 * (n / 2)) - a.val ≤ (n : ℕ) / 2 ↔ (n : ℕ) / 2 < a.val,
-    by rwa [nat.mod_add_div] at this,
-  begin
-    rw [nat.sub_le_iff, two_mul, ← add_assoc, nat.add_sub_cancel],
-    cases (n : ℕ).mod_two_eq_zero_or_one with hn0 hn1,
-    { split,
-      { exact λ h, lt_of_le_of_ne (le_trans (nat.le_add_left _ _) h)
-          begin
-            assume hna,
-            rw [← zmod.cast_val a, ← hna, neg_eq_iff_add_eq_zero, ← nat.cast_add,
-              zmod.eq_zero_iff_dvd_nat, ← two_mul, ← zero_add (2 * _), ← hn0,
-              nat.mod_add_div] at haa,
-            exact haa (dvd_refl _)
-          end },
-      { rw [hn0, zero_add], exact le_of_lt } },
-    { rw [hn1, add_comm, nat.succ_le_iff] }
-  end,
-have ha0 : ¬ a = 0, from λ ha0, by simp * at *,
-begin
-  dsimp [zmod.val_min_abs],
-  rw [← not_le] at hpa,
-  simp only [if_neg ha0, zmod.neg_val, hpa, int.coe_nat_sub (le_of_lt a.2)],
-  split_ifs,
-  { simp [sub_eq_add_neg] },
-  { rw [← int.nat_abs_neg], simp }
-end
-
-lemma val_eq_ite_val_min_abs {n : ℕ+} (a : zmod n) :
-  (a.val : ℤ) = a.val_min_abs + if a.val ≤ n / 2 then 0 else n :=
-by simp [zmod.val_min_abs]; split_ifs; simp
-
-lemma neg_eq_self_mod_two : ∀ (a : zmod 2), -a = a := dec_trivial
+@[simp] lemma neg_eq_self_mod_two : ∀ (a : zmod 2), -a = a := dec_trivial
 
 @[simp] lemma nat_abs_mod_two (a : ℤ) : (a.nat_abs : zmod 2) = a :=
-by cases a; simp [zmod.neg_eq_self_mod_two]
-
-section
-variables {α : Type*} [has_zero α] [has_one α] [has_add α] {n : ℕ+}
-
-def cast : zmod n → α := nat.cast ∘ fin.val
-
+begin
+  cases a,
+  { simp only [int.nat_abs_of_nat, int.cast_coe_nat, int.of_nat_eq_coe] },
+  { simp only [neg_eq_self_mod_two, nat.cast_succ, int.nat_abs, int.cast_neg_succ_of_nat] }
 end
+
+@[simp] lemma val_eq_zero : ∀ {n : ℕ} (a : zmod n), a.val = 0 ↔ a = 0
+| 0     a := int.nat_abs_eq_zero
+| (n+1) a := by { rw fin.ext_iff, exact iff.rfl }
+
+lemma val_cast_of_lt {n : ℕ} {a : ℕ} (h : a < n) : (a : zmod n).val = a :=
+by rw [val_cast_nat, nat.mod_eq_of_lt h]
+
+lemma neg_val' {n : ℕ} [fact (0 < n)] (a : zmod n) : (-a).val = (n - a.val) % n :=
+begin
+  have : ((-a).val + a.val) % n = (n - a.val + a.val) % n,
+  { rw [←val_add, add_left_neg, nat.sub_add_cancel (le_of_lt a.val_lt), nat.mod_self, val_zero], },
+  calc (-a).val = val (-a)    % n : by rw nat.mod_eq_of_lt ((-a).val_lt)
+            ... = (n - val a) % n : nat.modeq.modeq_add_cancel_right rfl this
+end
+
+lemma neg_val {n : ℕ} [fact (0 < n)] (a : zmod n) : (-a).val = if a = 0 then 0 else n - a.val :=
+begin
+  rw neg_val',
+  by_cases h : a = 0, { rw [if_pos h, h, val_zero, nat.sub_zero, nat.mod_self] },
+  rw if_neg h,
+  apply nat.mod_eq_of_lt,
+  apply nat.sub_lt ‹0 < n›,
+  contrapose! h,
+  rwa [nat.le_zero_iff, val_eq_zero] at h,
+end
+
+/-- `val_min_abs x` returns the integer in the same equivalence class as `x` that is closest to `0`,
+  The result will be in the interval `(-n/2, n/2]`. -/
+def val_min_abs : Π {n : ℕ}, zmod n → ℤ
+| 0       x := x
+| n@(_+1) x := if x.val ≤ n / 2 then x.val else (x.val : ℤ) - n
+
+@[simp] lemma val_min_abs_def_zero (x : zmod 0) : val_min_abs x = x := rfl
+
+lemma val_min_abs_def_pos {n : ℕ} [fact (0 < n)] (x : zmod n) :
+  val_min_abs x = if x.val ≤ n / 2 then x.val else x.val - n :=
+begin
+  unfreezeI, cases n,
+  { exfalso, exact nat.not_lt_zero 0 ‹0 < 0› },
+  { refl }
+end
+
+@[simp] lemma coe_val_min_abs : ∀ {n : ℕ} (x : zmod n), (x.val_min_abs : zmod n) = x
+| 0       x := int.cast_id x
+| k@(n+1) x :=
+begin
+  rw val_min_abs_def_pos,
+  split_ifs,
+  { rw [int.cast_coe_nat, cast_val] },
+  { rw [int.cast_sub, int.cast_coe_nat, cast_val, int.cast_coe_nat, cast_self, sub_zero], }
+end
+
+lemma nat_abs_val_min_abs_le {n : ℕ} [fact (0 < n)] (x : zmod n) : x.val_min_abs.nat_abs ≤ n / 2 :=
+begin
+  rw zmod.val_min_abs_def_pos,
+  split_ifs with h, { exact h },
+  have : (x.val - n : ℤ) ≤ 0,
+  { rw [sub_nonpos, int.coe_nat_le], exact le_of_lt x.val_lt, },
+  rw [← int.coe_nat_le, int.of_nat_nat_abs_of_nonpos this, neg_sub],
+  conv_lhs { congr, rw [← nat.mod_add_div n 2, int.coe_nat_add, int.coe_nat_mul,
+    int.coe_nat_bit0, int.coe_nat_one] },
+  suffices : ((n % 2 : ℕ) + (n / 2) : ℤ) ≤ (val x),
+  { rw ← sub_nonneg at this ⊢, apply le_trans this (le_of_eq _), ring },
+  norm_cast,
+  calc (n : ℕ) % 2 + n / 2 ≤ 1 + n / 2 : nat.add_le_add_right (nat.le_of_lt_succ (nat.mod_lt _ dec_trivial)) _
+                       ... ≤ x.val     : by { rw add_comm, exact nat.succ_le_of_lt (lt_of_not_ge h) }
+end
+
+@[simp] lemma val_min_abs_zero : ∀ n, (0 : zmod n).val_min_abs = 0
+| 0     := by simp only [val_min_abs_def_zero]
+| (n+1) := by simp only [val_min_abs_def_pos, if_true, int.coe_nat_zero, zero_le, val_zero]
+
+@[simp] lemma val_min_abs_eq_zero {n : ℕ} (x : zmod n) :
+  x.val_min_abs = 0 ↔ x = 0 :=
+begin
+  cases n, { simp },
+  split,
+  { simp only [val_min_abs_def_pos, int.coe_nat_succ],
+    split_ifs with h h; assume h0,
+    { apply val_injective, rwa [int.coe_nat_eq_zero] at h0, },
+    { apply absurd h0, rw sub_eq_zero, apply ne_of_lt, exact_mod_cast x.val_lt } },
+  { rintro rfl, rw val_min_abs_zero }
+end
+
+lemma cast_nat_abs_val_min_abs {n : ℕ} [fact (0 < n)] (a : zmod n) :
+  (a.val_min_abs.nat_abs : zmod n) = if a.val ≤ (n : ℕ) / 2 then a else -a :=
+begin
+  have : (a.val : ℤ) - n ≤ 0,
+    by { erw [sub_nonpos, int.coe_nat_le], exact le_of_lt a.val_lt, },
+  rw [zmod.val_min_abs_def_pos],
+  split_ifs,
+  { rw [int.nat_abs_of_nat, cast_val] },
+  { rw [← int.cast_coe_nat, int.of_nat_nat_abs_of_nonpos this, int.cast_neg, int.cast_sub],
+    rw [int.cast_coe_nat, int.cast_coe_nat, cast_self, sub_zero, cast_val], }
+end
+
+@[simp] lemma nat_abs_val_min_abs_neg {n : ℕ} (a : zmod n) :
+  (-a).val_min_abs.nat_abs = a.val_min_abs.nat_abs :=
+begin
+  cases n, { simp only [int.nat_abs_neg, val_min_abs_def_zero], },
+  by_cases ha0 : a = 0, { rw [ha0, neg_zero] },
+  by_cases haa : -a = a, { rw [haa] },
+  suffices hpa : (n+1 : ℕ) - a.val ≤ (n+1) / 2 ↔ (n+1 : ℕ) / 2 < a.val,
+  { rw [val_min_abs_def_pos, val_min_abs_def_pos],
+    rw ← not_le at hpa,
+    simp only [if_neg ha0, neg_val, hpa, int.coe_nat_sub (le_of_lt a.val_lt)],
+    split_ifs,
+    all_goals { rw [← int.nat_abs_neg], congr' 1, ring } },
+  suffices : (((n+1 : ℕ) % 2) + 2 * ((n + 1) / 2)) - a.val ≤ (n+1) / 2 ↔ (n+1 : ℕ) / 2 < a.val,
+  by rwa [nat.mod_add_div] at this,
+  suffices : (n + 1) % 2 + (n + 1) / 2 ≤ val a ↔ (n + 1) / 2 < val a,
+  by rw [nat.sub_le_iff, two_mul, ← add_assoc, nat.add_sub_cancel, this],
+  cases (n + 1 : ℕ).mod_two_eq_zero_or_one with hn0 hn1,
+  { split,
+    { assume h,
+      apply lt_of_le_of_ne (le_trans (nat.le_add_left _ _) h),
+      contrapose! haa,
+      rw [← zmod.cast_val a, ← haa, neg_eq_iff_add_eq_zero, ← nat.cast_add],
+      rw [char_p.cast_eq_zero_iff (zmod (n+1)) (n+1)],
+      rw [← two_mul, ← zero_add (2 * _), ← hn0, nat.mod_add_div] },
+    { rw [hn0, zero_add], exact le_of_lt } },
+  { rw [hn1, add_comm, nat.succ_le_iff] }
+end
+
+lemma val_eq_ite_val_min_abs {n : ℕ} [fact (0 < n)] (a : zmod n) :
+  (a.val : ℤ) = a.val_min_abs + if a.val ≤ n / 2 then 0 else n :=
+by { rw [zmod.val_min_abs_def_pos], split_ifs; simp only [add_zero, sub_add_cancel] }
+
+lemma prime_ne_zero (p q : ℕ) [hp : fact p.prime] [hq : fact q.prime] (hpq : p ≠ q) :
+  (q : zmod p) ≠ 0 :=
+by rwa [← nat.cast_zero, ne.def, eq_iff_modeq_nat, nat.modeq.modeq_zero_iff,
+  ← hp.coprime_iff_not_dvd, nat.coprime_primes hp hq]
 
 end zmod
 
-def zmodp (p : ℕ) (hp : prime p) : Type := zmod ⟨p, hp.pos⟩
+namespace zmod
 
-namespace zmodp
+variables (p : ℕ) [fact p.prime]
 
-variables {p : ℕ} (hp : prime p)
+-- move this
+instance prime.fact_one_lt : fact (1 < p) := nat.prime.one_lt ‹p.prime›
 
-instance : comm_ring (zmodp p hp) := zmod.comm_ring ⟨p, hp.pos⟩
-
-instance : inhabited (zmodp p hp) := ⟨0⟩
-
-instance {p : ℕ} (hp : prime p) : has_inv (zmodp p hp) :=
-⟨λ a, gcd_a a.1 p⟩
-
-lemma add_val : ∀ a b : zmodp p hp, (a + b).val = (a.val + b.val) % p
-| ⟨_, _⟩ ⟨_, _⟩ := rfl
-
-lemma mul_val : ∀ a b : zmodp p hp, (a * b).val = (a.val * b.val) % p
-| ⟨_, _⟩ ⟨_, _⟩ := rfl
-
-@[simp] lemma one_val : (1 : zmodp p hp).val = 1 :=
-nat.mod_eq_of_lt hp.one_lt
-
-@[simp] lemma zero_val : (0 : zmodp p hp).val = 0 := rfl
-
-lemma val_cast_nat (a : ℕ) : (a : zmodp p hp).val = a % p :=
-@zmod.val_cast_nat ⟨p, hp.pos⟩ _
-
-lemma mk_eq_cast {a : ℕ} (h : a < p) : (⟨a, h⟩ : zmodp p hp) = (a : zmodp p hp) :=
-@zmod.mk_eq_cast ⟨p, hp.pos⟩ _ _
-
-@[simp] lemma cast_self_eq_zero: (p : zmodp p hp) = 0 :=
-fin.eq_of_veq $ by simp [val_cast_nat]
-
-lemma val_cast_of_lt {a : ℕ} (h : a < p) : (a : zmodp p hp).val = a :=
-@zmod.val_cast_of_lt ⟨p, hp.pos⟩ _ h
-
-@[simp] lemma cast_mod_nat (a : ℕ) : ((a % p : ℕ) : zmodp p hp) = a :=
-@zmod.cast_mod_nat ⟨p, hp.pos⟩ _
-
-@[simp] lemma cast_val (a : zmodp p hp) : (a.val : zmodp p hp) = a :=
-@zmod.cast_val ⟨p, hp.pos⟩ _
-
-@[simp] lemma cast_mod_int (a : ℤ) : ((a % p : ℤ) : zmodp p hp) = a :=
-@zmod.cast_mod_int ⟨p, hp.pos⟩ _
-
-lemma val_cast_int (a : ℤ) : (a : zmodp p hp).val = (a % p).nat_abs :=
-@zmod.val_cast_int ⟨p, hp.pos⟩ _
-
-lemma coe_val_cast_int  (a : ℤ) : ((a : zmodp p hp).val : ℤ) = a % (p : ℕ) :=
-@zmod.coe_val_cast_int ⟨p, hp.pos⟩ _
-
-lemma eq_iff_modeq_nat {a b : ℕ} : (a : zmodp p hp) = b ↔ a ≡ b [MOD p] :=
-@zmod.eq_iff_modeq_nat ⟨p, hp.pos⟩ _ _
-
-lemma eq_iff_modeq_int {a b : ℤ} : (a : zmodp p hp) = b ↔ a ≡ b [ZMOD p] :=
-@zmod.eq_iff_modeq_int ⟨p, hp.pos⟩ _ _
-
-lemma eq_zero_iff_dvd_nat (a : ℕ) : (a : zmodp p hp) = 0 ↔ p ∣ a :=
-@zmod.eq_zero_iff_dvd_nat ⟨p, hp.pos⟩ _
-
-lemma eq_zero_iff_dvd_int (a : ℤ) : (a : zmodp p hp) = 0 ↔ (p : ℤ) ∣ a :=
-@zmod.eq_zero_iff_dvd_int ⟨p, hp.pos⟩ _
-
-instance : fintype (zmodp p hp) := @zmod.fintype ⟨p, hp.pos⟩
-
-instance decidable_eq : decidable_eq (zmodp p hp) := fin.decidable_eq _
-
-instance X (h : prime 2) : subsingleton (units (zmodp 2 h)) :=
-zmod.subsingleton
-
-instance : has_repr (zmodp p hp) := fin.has_repr _
-
-@[simp] lemma card_zmodp : fintype.card (zmodp p hp) = p :=
-@zmod.card_zmod ⟨p, hp.pos⟩
-
-lemma le_div_two_iff_lt_neg {p : ℕ} (hp : prime p) (hp1 : p % 2 = 1)
-  {x : zmodp p hp} (hx0 : x ≠ 0) : x.1 ≤ (p / 2 : ℕ) ↔ (p / 2 : ℕ) < (-x).1 :=
-@zmod.le_div_two_iff_lt_neg ⟨p, hp.pos⟩ hp1 _ hx0
-
-lemma ne_neg_self (hp1 : p % 2 = 1) {a : zmodp p hp} (ha : a ≠ 0) : a ≠ -a :=
-@zmod.ne_neg_self ⟨p, hp.pos⟩ hp1 _ ha
-
-variable {hp}
-
-/-- `val_min_abs x` returns the integer in the same equivalence class as `x` that is closest to `0`,
-  The result will be in the interval `(-n/2, n/2]` -/
-def val_min_abs (x : zmodp p hp) : ℤ := zmod.val_min_abs x
-
-@[simp] lemma coe_val_min_abs (x : zmodp p hp) :
-  (x.val_min_abs : zmodp p hp) = x :=
-zmod.coe_val_min_abs x
-
-lemma nat_abs_val_min_abs_le (x : zmodp p hp) : x.val_min_abs.nat_abs ≤ p / 2 :=
-zmod.nat_abs_val_min_abs_le x
-
-@[simp] lemma val_min_abs_zero : (0 : zmodp p hp).val_min_abs = 0 :=
-zmod.val_min_abs_zero
-
-@[simp] lemma val_min_abs_eq_zero (x : zmodp p hp) : x.val_min_abs = 0 ↔ x = 0 :=
-zmod.val_min_abs_eq_zero x
-
-lemma cast_nat_abs_val_min_abs (a : zmodp p hp) :
-  (a.val_min_abs.nat_abs : zmodp p hp) = if a.val ≤ p / 2 then a else -a :=
-zmod.cast_nat_abs_val_min_abs a
-
-@[simp] lemma nat_abs_val_min_abs_neg (a : zmodp p hp) :
-  (-a).val_min_abs.nat_abs = a.val_min_abs.nat_abs :=
-zmod.nat_abs_val_min_abs_neg _
-
-lemma val_eq_ite_val_min_abs (a : zmodp p hp) :
-  (a.val : ℤ) = a.val_min_abs + if a.val ≤ p / 2 then 0 else p :=
-zmod.val_eq_ite_val_min_abs _
-
-variable (hp)
-
-lemma prime_ne_zero {q : ℕ} (hq : prime q) (hpq : p ≠ q) : (q : zmodp p hp) ≠ 0 :=
-by rwa [← nat.cast_zero, ne.def, zmodp.eq_iff_modeq_nat, nat.modeq.modeq_zero_iff,
-  ← hp.coprime_iff_not_dvd, coprime_primes hp hq]
-
-lemma mul_inv_eq_gcd (a : ℕ) : (a : zmodp p hp) * a⁻¹ = nat.gcd a p :=
-by rw [← int.cast_coe_nat (nat.gcd _ _), nat.gcd_comm, nat.gcd_rec, ← (eq_iff_modeq_int _).2 (int.modeq.gcd_a_modeq _ _)];
-  simp [has_inv.inv, val_cast_nat]
-
-private lemma mul_inv_cancel_aux : ∀ a : zmodp p hp, a ≠ 0 → a * a⁻¹ = 1 :=
-λ ⟨a, hap⟩ ha0, begin
-  rw [mk_eq_cast, ne.def, ← @nat.cast_zero (zmodp p hp), eq_iff_modeq_nat, modeq_zero_iff] at ha0,
-  have : nat.gcd p a = 1 := (prime.coprime_iff_not_dvd hp).2 ha0,
-  rw [mk_eq_cast _ hap, mul_inv_eq_gcd, nat.gcd_comm],
-  simp [nat.gcd_comm, this]
+private lemma mul_inv_cancel_aux (a : zmod p) (h : a ≠ 0) : a * a⁻¹ = 1 :=
+begin
+  obtain ⟨k, rfl⟩ := nat_cast_surjective a,
+  apply coe_mul_inv_eq_one,
+  apply nat.coprime.symm,
+  rwa [nat.prime.coprime_iff_not_dvd ‹p.prime›, ← char_p.cast_eq_zero_iff (zmod p)]
 end
 
-instance : field (zmodp p hp) :=
-{ zero_ne_one := fin.ne_of_vne $ show 0 ≠ 1 % p,
-    by rw nat.mod_eq_of_lt hp.one_lt;
-      exact zero_ne_one,
-  mul_inv_cancel := mul_inv_cancel_aux hp,
-  inv_zero := show (gcd_a 0 p : zmodp p hp) = 0,
-    by unfold gcd_a xgcd xgcd_aux; refl,
-  ..zmodp.comm_ring hp,
-  ..zmodp.has_inv hp }
+instance : field (zmod p) :=
+{ mul_inv_cancel := mul_inv_cancel_aux p,
+  inv_zero := inv_zero p,
+  .. zmod.nonzero_comm_ring p,
+  .. zmod.has_inv p }
 
-end zmodp
+end zmod

--- a/src/data/zmod/quadratic_reciprocity.lean
+++ b/src/data/zmod/quadratic_reciprocity.lean
@@ -3,7 +3,9 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
+
 import field_theory.finite
+import data.zmod.basic
 import data.nat.parity
 
 /-!
@@ -25,163 +27,192 @@ Also proven are conditions for `-1` and `2` to be a square modulo a prime,
 The proof of quadratic reciprocity implemented uses Gauss' lemma and Eisenstein's lemma
 -/
 
+open function finset nat finite_field zmod
 
-open function finset nat finite_field zmodp
+namespace zmod
 
-namespace zmodp
+variables (p q : ℕ) [fact p.prime] [fact q.prime]
 
-variables {p q : ℕ} (hp : nat.prime p) (hq : nat.prime q)
+@[simp] lemma card_units : fintype.card (units (zmod p)) = p - 1 :=
+by rw [card_units, card]
 
-@[simp] lemma card_units_zmodp : fintype.card (units (zmodp p hp)) = p - 1 :=
-by rw [card_units, card_zmodp]
+/-- Fermat's Little Theorem: for every unit `a` of `zmod p`, we have `a ^ (p - 1) = 1`. -/
+theorem fermat_little_units {p : ℕ} [fact p.prime] (a : units (zmod p)) :
+  a ^ (p - 1) = 1 :=
+by rw [← card_units p, pow_card_eq_one]
 
-theorem fermat_little {p : ℕ} (hp : nat.prime p) {a : zmodp p hp} (ha : a ≠ 0) : a ^ (p - 1) = 1 :=
-by rw [← units.coe_mk0 ha, ← @units.coe_one (zmodp p hp), ← units.coe_pow, ← units.ext_iff,
-    ← card_units_zmodp hp, pow_card_eq_one]
-
-lemma euler_criterion_units {x : units (zmodp p hp)} :
-  (∃ y : units (zmodp p hp), y ^ 2 = x) ↔ x ^ (p / 2) = 1 :=
-hp.eq_two_or_odd.elim
-  (λ h, by resetI; subst h; exact iff_of_true ⟨1, subsingleton.elim _ _⟩ (subsingleton.elim _ _))
-  (λ hp1, let ⟨g, hg⟩ := is_cyclic.exists_generator (units (zmodp p hp)) in
-    let ⟨n, hn⟩ := show x ∈ powers g, from (powers_eq_gpowers g).symm ▸ hg x in
-    ⟨λ ⟨y, hy⟩, by rw [← hy, ← pow_mul, two_mul_odd_div_two hp1,
-        ← card_units_zmodp hp, pow_card_eq_one],
-    λ hx, have 2 * (p / 2) ∣ n * (p / 2),
-        by rw [two_mul_odd_div_two hp1, ← card_units_zmodp hp, ← order_of_eq_card_of_forall_mem_gpowers hg];
-        exact order_of_dvd_of_pow_eq_one (by rwa [pow_mul, hn]),
-      let ⟨m, hm⟩ := dvd_of_mul_dvd_mul_right (nat.div_pos hp.two_le dec_trivial) this in
-      ⟨g ^ m, by rwa [← pow_mul, mul_comm, ← hm]⟩⟩)
-
-lemma euler_criterion {a : zmodp p hp} (ha : a ≠ 0) :
-  (∃ y : zmodp p hp, y ^ 2 = a) ↔ a ^ (p / 2) = 1 :=
-⟨λ ⟨y, hy⟩,
-  have hy0 : y ≠ 0, from λ h, by simp [h, _root_.zero_pow (succ_pos 1)] at hy; cc,
-  by simpa using (units.ext_iff.1 $ (euler_criterion_units hp).1 ⟨units.mk0 _ hy0, show _ = units.mk0 _ ha,
-    by rw [units.ext_iff]; simpa⟩),
-λ h, let ⟨y, hy⟩ := (euler_criterion_units hp).2 (show units.mk0 _ ha ^ (p / 2) = 1, by simpa [units.ext_iff]) in
-  ⟨y, by simpa [units.ext_iff] using hy⟩⟩
-
-lemma exists_pow_two_eq_neg_one_iff_mod_four_ne_three :
-  (∃ y : zmodp p hp, y ^ 2 = -1) ↔ p % 4 ≠ 3 :=
-have (-1 : zmodp p hp) ≠ 0, from mt neg_eq_zero.1 one_ne_zero,
-hp.eq_two_or_odd.elim (λ hp, by resetI; subst hp; exact dec_trivial)
-  (λ hp1, (mod_two_eq_zero_or_one (p / 2)).elim
-    (λ hp2, begin
-      rw [euler_criterion hp this, neg_one_pow_eq_pow_mod_two, hp2, _root_.pow_zero,
-        eq_self_iff_true, true_iff],
-      assume h,
-      rw [← nat.mod_mul_right_div_self, show 2 * 2 = 4, from rfl, h] at hp2,
-      exact absurd hp2 dec_trivial,
-    end)
-    (λ hp2, begin
-      rw [euler_criterion hp this, neg_one_pow_eq_pow_mod_two, hp2, _root_.pow_one,
-        iff_false_intro (zmodp.ne_neg_self hp hp1 one_ne_zero).symm, false_iff,
-        not_not],
-      rw [← nat.mod_mul_right_div_self, show 2 * 2 = 4, from rfl] at hp2,
-      rw [← nat.mod_mul_left_mod _ 2, show 2 * 2 = 4, from rfl] at hp1,
-      have hp4 : p % 4 < 4, from nat.mod_lt _ dec_trivial,
-      revert hp1 hp2, revert hp4,
-      generalize : p % 4 = k,
-      revert k, exact dec_trivial
-    end))
-
-lemma pow_div_two_eq_neg_one_or_one {a : zmodp p hp} (ha : a ≠ 0) : a ^ (p / 2) = 1 ∨ a ^ (p / 2) = -1 :=
-hp.eq_two_or_odd.elim
-  (λ h, by revert a ha; resetI; subst h; exact dec_trivial)
-  (λ hp1, by rw [← mul_self_eq_one_iff, ← _root_.pow_add, ← two_mul, two_mul_odd_div_two hp1];
-    exact fermat_little hp ha)
-
-@[simp] lemma wilsons_lemma {p : ℕ} (hp : nat.prime p) : (fact (p - 1) : zmodp p hp) = -1 :=
+/-- Fermat's Little Theorem: for all nonzero `a : zmod p`, we have `a ^ (p - 1) = 1`. -/
+theorem fermat_little {a : zmod p} (ha : a ≠ 0) : a ^ (p - 1) = 1 :=
 begin
-  rw [← finset.prod_Ico_id_eq_fact, ← @units.coe_one (zmodp p hp), ← units.coe_neg,
-    ← @prod_univ_units_id_eq_neg_one (zmodp p hp),
-    ← prod_hom _ (coe : units (zmodp p hp) → zmodp p hp),
-    prod_nat_cast],
-  exact eq.symm (prod_bij
-    (λ a _, (a : zmodp p hp).1)
-    (λ a ha, Ico.mem.2 ⟨nat.pos_of_ne_zero
-        (λ h, units.coe_ne_zero a (fin.eq_of_veq h)),
-      by rw [← succ_sub hp.pos, succ_sub_one]; exact (a : zmodp p hp).2⟩)
-    (λ a _, by simp) (λ _ _ _ _, units.ext_iff.2 ∘ fin.eq_of_veq)
-    (λ b hb,
-      have b ≠ 0 ∧ b < p, by rwa [Ico.mem, nat.succ_le_iff, ← succ_sub hp.pos,
-        succ_sub_one, nat.pos_iff_ne_zero] at hb,
-      ⟨units.mk0 _ (show (b : zmodp p hp) ≠ 0, from fin.ne_of_vne $
-        by rw [zmod.val_cast_nat, ← @nat.cast_zero (zmodp p hp), zmod.val_cast_nat];
-        simp [mod_eq_of_lt this.2, this.1]), mem_univ _,
-      by simp [val_cast_of_lt hp this.2]⟩))
+  have := fermat_little_units (units.mk0 a ha),
+  apply_fun (coe : units (zmod p) → zmod p) at this,
+  simpa,
 end
 
-@[simp] lemma prod_Ico_one_prime {p : ℕ} (hp : nat.prime p) :
-  (Ico 1 p).prod (λ x, (x : zmodp p hp)) = -1 :=
-by conv in (Ico 1 p) { rw [← succ_sub_one p, succ_sub hp.pos] };
-  rw [← prod_nat_cast, finset.prod_Ico_id_eq_fact, wilsons_lemma]
+/-- Euler's Criterion: A unit `x` of `zmod p` is a square if and only if `x ^ (p / 2) = 1`. -/
+lemma euler_criterion_units (x : units (zmod p)) :
+  (∃ y : units (zmod p), y ^ 2 = x) ↔ x ^ (p / 2) = 1 :=
+begin
+  cases nat.prime.eq_two_or_odd ‹p.prime› with hp2 hp_odd,
+  { resetI, subst p, refine iff_of_true ⟨1, _⟩ _; apply subsingleton.elim  },
+  obtain ⟨g, hg⟩ := is_cyclic.exists_generator (units (zmod p)),
+  obtain ⟨n, hn⟩ : x ∈ powers g, { rw powers_eq_gpowers, apply hg },
+  split,
+  { rintro ⟨y, rfl⟩, rw [← pow_mul, two_mul_odd_div_two hp_odd, fermat_little_units], },
+  { subst x, assume h,
+    have key : 2 * (p / 2) ∣ n * (p / 2),
+    { rw [← pow_mul] at h,
+      rw [two_mul_odd_div_two hp_odd, ← card_units, ← order_of_eq_card_of_forall_mem_gpowers hg],
+      apply order_of_dvd_of_pow_eq_one h },
+    have : 0 < p / 2 := nat.div_pos (show fact (1 < p), by apply_instance) dec_trivial,
+    obtain ⟨m, rfl⟩ := dvd_of_mul_dvd_mul_right this key,
+    refine ⟨g ^ m, _⟩,
+    rw [mul_comm, pow_mul], },
+end
 
-end zmodp
+/-- Euler's Criterion: a nonzero `a : zmod p` is a square if and only if `x ^ (p / 2) = 1`. -/
+lemma euler_criterion {a : zmod p} (ha : a ≠ 0) :
+  (∃ y : zmod p, y ^ 2 = a) ↔ a ^ (p / 2) = 1 :=
+begin
+  apply (iff_congr _ (by simp [units.ext_iff])).mp (euler_criterion_units p (units.mk0 a ha)),
+  simp only [units.ext_iff, _root_.pow_two, units.coe_mk0, units.coe_mul],
+  split, { rintro ⟨y, hy⟩, exact ⟨y, hy⟩ },
+  { rintro ⟨y, rfl⟩,
+    have hy : y ≠ 0, { rintro rfl, simpa [_root_.zero_pow] using ha, },
+    refine ⟨units.mk0 y hy, _⟩, simp, }
+end
+
+lemma exists_pow_two_eq_neg_one_iff_mod_four_ne_three :
+  (∃ y : zmod p, y ^ 2 = -1) ↔ p % 4 ≠ 3 :=
+begin
+  cases nat.prime.eq_two_or_odd ‹p.prime› with hp2 hp_odd,
+  { resetI, subst p, exact dec_trivial },
+  change fact (p % 2 = 1) at hp_odd, resetI,
+  have neg_one_ne_zero : (-1 : zmod p) ≠ 0, from mt neg_eq_zero.1 one_ne_zero,
+  rw [euler_criterion p neg_one_ne_zero, neg_one_pow_eq_pow_mod_two],
+  cases mod_two_eq_zero_or_one (p / 2) with p_half_even p_half_odd,
+  { rw [p_half_even, _root_.pow_zero, eq_self_iff_true, true_iff],
+    contrapose! p_half_even with hp,
+    rw [← nat.mod_mul_right_div_self, show 2 * 2 = 4, from rfl, hp],
+    exact dec_trivial },
+  { rw [p_half_odd, _root_.pow_one,
+        iff_false_intro (ne_neg_self p one_ne_zero).symm, false_iff, not_not],
+    rw [← nat.mod_mul_right_div_self, show 2 * 2 = 4, from rfl] at p_half_odd,
+    rw [_root_.fact, ← nat.mod_mul_left_mod _ 2, show 2 * 2 = 4, from rfl] at hp_odd,
+    have hp : p % 4 < 4, from nat.mod_lt _ dec_trivial,
+    revert hp hp_odd p_half_odd,
+    generalize : p % 4 = k, revert k, exact dec_trivial }
+end
+
+lemma pow_div_two_eq_neg_one_or_one {a : zmod p} (ha : a ≠ 0) :
+  a ^ (p / 2) = 1 ∨ a ^ (p / 2) = -1 :=
+begin
+  cases nat.prime.eq_two_or_odd ‹p.prime› with hp2 hp_odd,
+  { resetI, subst p, revert a ha, exact dec_trivial },
+  rw [← mul_self_eq_one_iff, ← _root_.pow_add, ← two_mul, two_mul_odd_div_two hp_odd],
+  exact fermat_little p ha
+end
+
+/-- Wilson's Lemma: the product of `1`, ..., `p-1` is `-1` modulo `p`. -/
+@[simp] lemma wilsons_lemma : (nat.fact (p - 1) : zmod p) = -1 :=
+begin
+  refine
+  calc (nat.fact (p - 1) : zmod p) = (Ico 1 (succ (p - 1))).prod (λ (x : ℕ), x) :
+    by rw [← finset.prod_Ico_id_eq_fact, prod_nat_cast]
+                               ... = finset.univ.prod (λ x : units (zmod p), x) : _
+                               ... = -1 :
+    by rw [prod_hom _ (coe : units (zmod p) → zmod p),
+           prod_univ_units_id_eq_neg_one, units.coe_neg, units.coe_one],
+  have hp : 0 < p := nat.prime.pos ‹p.prime›,
+  symmetry,
+  refine prod_bij (λ a _, (a : zmod p).val) _ _ _ _,
+  { intros a ha,
+    rw [Ico.mem, ← nat.succ_sub hp, nat.succ_sub_one],
+    split,
+    { apply nat.pos_of_ne_zero, rw ← @val_zero p,
+      assume h, apply units.coe_ne_zero a (val_injective p h) },
+    { exact val_lt _ } },
+  { intros a ha, simp only [cast_id, nat_cast_val], },
+  { intros _ _ _ _ h, rw units.ext_iff, exact val_injective p h },
+  { intros b hb,
+    rw [Ico.mem, nat.succ_le_iff, ← succ_sub hp, succ_sub_one, nat.pos_iff_ne_zero] at hb,
+    refine ⟨units.mk0 b _, finset.mem_univ _, _⟩,
+    { assume h, apply hb.1, apply_fun val at h,
+      simpa only [val_cast_of_lt hb.right, val_zero] using h },
+    { simp only [val_cast_of_lt hb.right, units.coe_mk0], } }
+end
+
+@[simp] lemma prod_Ico_one_prime : (Ico 1 p).prod (λ x, (x : zmod p)) = -1 :=
+begin
+  conv in (Ico 1 p) { rw [← succ_sub_one p, succ_sub (nat.prime.pos ‹p.prime›)] },
+  rw [← prod_nat_cast, finset.prod_Ico_id_eq_fact, wilsons_lemma]
+end
+
+end zmod
 
 /-- The image of the map sending a non zero natural number `x ≤ p / 2` to the absolute value
   of the element of interger in the interval `(-p/2, p/2]` congruent to `a * x` mod p is the set
   of non zero natural numbers `x` such that `x ≤ p / 2` -/
 lemma Ico_map_val_min_abs_nat_abs_eq_Ico_map_id
-  {p : ℕ} (hp : p.prime) (a : zmodp p hp) (hpa : a ≠ 0) :
+  (p : ℕ) [hp : fact p.prime] (a : zmod p) (hap : a ≠ 0) :
   (Ico 1 (p / 2).succ).1.map (λ x, (a * x).val_min_abs.nat_abs) =
   (Ico 1 (p / 2).succ).1.map (λ a, a) :=
-have he : ∀ {x}, x ∈ Ico 1 (p / 2).succ → x ≠ 0 ∧ x ≤ p / 2,
-  by simp [nat.lt_succ_iff, nat.succ_le_iff, nat.pos_iff_ne_zero] {contextual := tt},
-have hep : ∀ {x}, x ∈ Ico 1 (p / 2).succ → x < p,
-  from λ x hx, lt_of_le_of_lt (he hx).2 (nat.div_lt_self hp.pos dec_trivial),
-have hpe : ∀ {x}, x ∈ Ico 1 (p / 2).succ → ¬ p ∣ x,
-  from λ x hx hpx, not_lt_of_ge (le_of_dvd (nat.pos_of_ne_zero (he hx).1) hpx) (hep hx),
-have hsurj : ∀ b : ℕ , b ∈ Ico 1 (p / 2).succ →
-    ∃ x ∈ Ico 1 (p / 2).succ,
-      b = (a * x : zmodp p hp).val_min_abs.nat_abs,
-  from λ b hb, ⟨(b / a : zmodp p hp).val_min_abs.nat_abs,
-    Ico.mem.2 ⟨nat.pos_of_ne_zero $
-        by simp [div_eq_mul_inv, hpa, zmodp.eq_zero_iff_dvd_nat hp b, hpe hb],
-      nat.lt_succ_of_le $ zmodp.nat_abs_val_min_abs_le _⟩,
-    begin
-      rw [zmodp.cast_nat_abs_val_min_abs],
-      split_ifs,
-      { erw [mul_div_cancel' _ hpa, zmodp.val_min_abs, zmod.val_min_abs,
-          zmodp.val_cast_of_lt hp (hep hb), if_pos (le_of_lt_succ (Ico.mem.1 hb).2),
-          int.nat_abs_of_nat], },
-      { erw [mul_neg_eq_neg_mul_symm, mul_div_cancel' _ hpa, zmod.nat_abs_val_min_abs_neg,
-          zmod.val_min_abs, zmodp.val_cast_of_lt hp (hep hb),
-          if_pos (le_of_lt_succ (Ico.mem.1 hb).2), int.nat_abs_of_nat] },
-    end⟩,
-  have hmem : ∀ x : ℕ, x ∈ Ico 1 (p / 2).succ →
-    (a * x : zmodp p hp).val_min_abs.nat_abs ∈ Ico 1 (p / 2).succ,
-  from λ x hx, by simp [hpa, zmodp.eq_zero_iff_dvd_nat hp x, hpe hx, lt_succ_iff, succ_le_iff,
-        nat.pos_iff_ne_zero, zmodp.nat_abs_val_min_abs_le _],
-multiset.map_eq_map_of_bij_of_nodup _ _ (finset.nodup _) (finset.nodup _)
-  (λ x _, (a * x : zmodp p hp).val_min_abs.nat_abs) hmem (λ _ _, rfl)
-  (inj_on_of_surj_on_of_card_le _ hmem hsurj (le_refl _)) hsurj
+begin
+  have he : ∀ {x}, x ∈ Ico 1 (p / 2).succ → x ≠ 0 ∧ x ≤ p / 2,
+    by simp [nat.lt_succ_iff, nat.succ_le_iff, nat.pos_iff_ne_zero] {contextual := tt},
+  have hep : ∀ {x}, x ∈ Ico 1 (p / 2).succ → x < p,
+    from λ x hx, lt_of_le_of_lt (he hx).2 (nat.div_lt_self hp.pos dec_trivial),
+  have hpe : ∀ {x}, x ∈ Ico 1 (p / 2).succ → ¬ p ∣ x,
+    from λ x hx hpx, not_lt_of_ge (le_of_dvd (nat.pos_of_ne_zero (he hx).1) hpx) (hep hx),
+  have hmem : ∀ (x : ℕ) (hx : x ∈ Ico 1 (p / 2).succ),
+    (a * x : zmod p).val_min_abs.nat_abs ∈ Ico 1 (p / 2).succ,
+  { assume x hx,
+    simp [hap, char_p.cast_eq_zero_iff (zmod p) p, hpe hx, lt_succ_iff, succ_le_iff,
+        nat.pos_iff_ne_zero, nat_abs_val_min_abs_le _], },
+  have hsurj : ∀ (b : ℕ) (hb : b ∈ Ico 1 (p / 2).succ),
+    ∃ x ∈ Ico 1 (p / 2).succ, b = (a * x : zmod p).val_min_abs.nat_abs,
+  { assume b hb,
+    refine ⟨(b / a : zmod p).val_min_abs.nat_abs, Ico.mem.mpr ⟨_, _⟩, _⟩,
+    { apply nat.pos_of_ne_zero,
+      simp only [div_eq_mul_inv, hap, char_p.cast_eq_zero_iff (zmod p) p, hpe hb, not_false_iff,
+        val_min_abs_eq_zero, inv_eq_zero, int.nat_abs_eq_zero, ne.def, mul_eq_zero_iff', or_self] },
+      { apply lt_succ_of_le, apply nat_abs_val_min_abs_le },
+      { rw cast_nat_abs_val_min_abs,
+        split_ifs,
+        { erw [mul_div_cancel' _ hap, val_min_abs_def_pos, val_cast_of_lt (hep hb),
+            if_pos (le_of_lt_succ (Ico.mem.1 hb).2), int.nat_abs_of_nat], },
+        { erw [mul_neg_eq_neg_mul_symm, mul_div_cancel' _ hap, nat_abs_val_min_abs_neg,
+            val_min_abs_def_pos, val_cast_of_lt (hep hb), if_pos (le_of_lt_succ (Ico.mem.1 hb).2),
+            int.nat_abs_of_nat] } } },
+  exact multiset.map_eq_map_of_bij_of_nodup _ _ (finset.nodup _) (finset.nodup _)
+    (λ x _, (a * x : zmod p).val_min_abs.nat_abs) hmem (λ _ _, rfl)
+    (inj_on_of_surj_on_of_card_le _ hmem hsurj (le_refl _)) hsurj
+end
 
-private lemma gauss_lemma_aux₁ {p : ℕ} (hp : p.prime) (hp2 : p % 2 = 1) {a : ℕ}
-  (hpa : (a : zmodp p hp) ≠ 0) :
-  (a^(p / 2) * (p / 2).fact : zmodp p hp) =
+private lemma gauss_lemma_aux₁ (p : ℕ) [hp : fact p.prime] [hp2 : fact (p % 2 = 1)]
+  {a : ℕ} (hap : (a : zmod p) ≠ 0) :
+  (a^(p / 2) * (p / 2).fact : zmod p) =
   (-1)^((Ico 1 (p / 2).succ).filter
-    (λ x : ℕ, ¬(a * x : zmodp p hp).val ≤ p / 2)).card * (p / 2).fact :=
-calc (a ^ (p / 2) * (p / 2).fact : zmodp p hp) =
+    (λ x : ℕ, ¬(a * x : zmod p).val ≤ p / 2)).card * (p / 2).fact :=
+calc (a ^ (p / 2) * (p / 2).fact : zmod p) =
     (Ico 1 (p / 2).succ).prod (λ x, a * x) :
   by rw [prod_mul_distrib, ← prod_nat_cast, ← prod_nat_cast, prod_Ico_id_eq_fact,
       prod_const, Ico.card, succ_sub_one]; simp
-... = (Ico 1 (p / 2).succ).prod (λ x, (a * x : zmodp p hp).val) : by simp
+... = (Ico 1 (p / 2).succ).prod (λ x, (a * x : zmod p).val) : by simp
 ... = (Ico 1 (p / 2).succ).prod
-    (λ x, (if (a * x : zmodp p hp).val ≤ p / 2 then 1 else -1) *
-      (a * x : zmodp p hp).val_min_abs.nat_abs) :
+    (λ x, (if (a * x : zmod p).val ≤ p / 2 then 1 else -1) *
+      (a * x : zmod p).val_min_abs.nat_abs) :
   prod_congr rfl $ λ _ _, begin
-    simp only [zmodp.cast_nat_abs_val_min_abs],
+    simp only [cast_nat_abs_val_min_abs],
     split_ifs; simp
   end
 ... = (-1)^((Ico 1 (p / 2).succ).filter
-      (λ x : ℕ, ¬(a * x : zmodp p hp).val ≤ p / 2)).card *
-    (Ico 1 (p / 2).succ).prod (λ x, (a * x : zmodp p hp).val_min_abs.nat_abs) :
+      (λ x : ℕ, ¬(a * x : zmod p).val ≤ p / 2)).card *
+    (Ico 1 (p / 2).succ).prod (λ x, (a * x : zmod p).val_min_abs.nat_abs) :
   have (Ico 1 (p / 2).succ).prod
-        (λ x, if (a * x : zmodp p hp).val ≤ p / 2 then (1 : zmodp p hp) else -1) =
+        (λ x, if (a * x : zmod p).val ≤ p / 2 then (1 : zmod p) else -1) =
       ((Ico 1 (p / 2).succ).filter
-        (λ x : ℕ, ¬(a * x : zmodp p hp).val ≤ p / 2)).prod (λ _, -1),
+        (λ x : ℕ, ¬(a * x : zmod p).val ≤ p / 2)).prod (λ _, -1),
     from prod_bij_ne_one (λ x _ _, x)
       (λ x, by split_ifs; simp * at * {contextual := tt})
       (λ _ _ _ _ _ _, id)
@@ -189,61 +220,61 @@ calc (a ^ (p / 2) * (p / 2).fact : zmodp p hp) =
       (by intros; split_ifs at *; simp * at *),
   by rw [prod_mul_distrib, this]; simp
 ... = (-1)^((Ico 1 (p / 2).succ).filter
-      (λ x : ℕ, ¬(a * x : zmodp p hp).val ≤ p / 2)).card * (p / 2).fact :
+      (λ x : ℕ, ¬(a * x : zmod p).val ≤ p / 2)).card * (p / 2).fact :
   by rw [← prod_nat_cast, finset.prod_eq_multiset_prod,
-      Ico_map_val_min_abs_nat_abs_eq_Ico_map_id hp a hpa,
+      Ico_map_val_min_abs_nat_abs_eq_Ico_map_id p a hap,
       ← finset.prod_eq_multiset_prod, prod_Ico_id_eq_fact]
 
-private lemma gauss_lemma_aux₂ {p : ℕ} (hp : p.prime) (hp2 : p % 2 = 1) {a : ℕ}
-  (hpa : (a : zmodp p hp) ≠ 0) :
-  (a^(p / 2) : zmodp p hp) = (-1)^((Ico 1 (p / 2).succ).filter
-    (λ x : ℕ, p / 2 < (a * x : zmodp p hp).val)).card :=
+private lemma gauss_lemma_aux₂ (p : ℕ) [hp : fact p.prime] [hp2 : fact (p % 2 = 1)]
+  {a : ℕ} (hap : (a : zmod p) ≠ 0) :
+  (a^(p / 2) : zmod p) = (-1)^((Ico 1 (p / 2).succ).filter
+    (λ x : ℕ, p / 2 < (a * x : zmod p).val)).card :=
 (domain.mul_right_inj
-    (show ((p / 2).fact : zmodp p hp) ≠ 0,
-      by rw [ne.def, zmodp.eq_zero_iff_dvd_nat, hp.dvd_fact, not_le];
+    (show ((p / 2).fact : zmod p) ≠ 0,
+      by rw [ne.def, char_p.cast_eq_zero_iff (zmod p) p, hp.dvd_fact, not_le];
           exact nat.div_lt_self hp.pos dec_trivial)).1 $
-  by simpa using gauss_lemma_aux₁ _ hp2 hpa
+  by simpa using gauss_lemma_aux₁ p hap
 
-private lemma eisenstein_lemma_aux₁ {p : ℕ} (hp : p.prime) (hp2 : p % 2 = 1) {a : ℕ}
-  (hap : (a : zmodp p hp) ≠ 0) :
+private lemma eisenstein_lemma_aux₁ (p : ℕ) [hp : fact p.prime] [hp2 : fact (p % 2 = 1)]
+  {a : ℕ} (hap : (a : zmod p) ≠ 0) :
   (((Ico 1 (p / 2).succ).sum (λ x, a * x) : ℕ) : zmod 2) =
     ((Ico 1 (p / 2).succ).filter
-      ((λ x : ℕ, p / 2 < (a * x : zmodp p hp).val))).card +
+      ((λ x : ℕ, p / 2 < (a * x : zmod p).val))).card +
       (Ico 1 (p / 2).succ).sum (λ x, x)
     + ((Ico 1 (p / 2).succ).sum (λ x, (a * x) / p) : ℕ) :=
-have hp2 : (p : zmod 2) = (1 : ℕ), from zmod.eq_iff_modeq_nat.2 hp2,
+have hp2 : (p : zmod 2) = (1 : ℕ), from (eq_iff_modeq_nat _).2 hp2,
 calc (((Ico 1 (p / 2).succ).sum (λ x, a * x) : ℕ) : zmod 2)
     = (((Ico 1 (p / 2).succ).sum (λ x, (a * x) % p + p * ((a * x) / p)) : ℕ) : zmod 2) :
   by simp only [mod_add_div]
-... = ((Ico 1 (p / 2).succ).sum (λ x, ((a * x : ℕ) : zmodp p hp).val) : ℕ) +
+... = ((Ico 1 (p / 2).succ).sum (λ x, ((a * x : ℕ) : zmod p).val) : ℕ) +
     ((Ico 1 (p / 2).succ).sum (λ x, (a * x) / p) : ℕ) :
-  by simp only [zmodp.val_cast_nat];
+  by simp only [val_cast_nat];
     simp [sum_add_distrib, mul_sum.symm, nat.cast_add, nat.cast_mul, sum_nat_cast, hp2]
 ... = _ : congr_arg2 (+)
-  (calc (((Ico 1 (p / 2).succ).sum (λ x, ((a * x : ℕ) : zmodp p hp).val) : ℕ) : zmod 2)
+  (calc (((Ico 1 (p / 2).succ).sum (λ x, ((a * x : ℕ) : zmod p).val) : ℕ) : zmod 2)
       = (Ico 1 (p / 2).succ).sum
-          (λ x, ((((a * x : zmodp p hp).val_min_abs +
-            (if (a * x : zmodp p hp).val ≤ p / 2 then 0 else p)) : ℤ) : zmod 2)) :
-        by simp only [(zmodp.val_eq_ite_val_min_abs _).symm]; simp [sum_nat_cast]
+          (λ x, ((((a * x : zmod p).val_min_abs +
+            (if (a * x : zmod p).val ≤ p / 2 then 0 else p)) : ℤ) : zmod 2)) :
+        by simp only [(val_eq_ite_val_min_abs _).symm]; simp [sum_nat_cast]
   ... = ((Ico 1 (p / 2).succ).filter
-        (λ x : ℕ, p / 2 < (a * x : zmodp p hp).val)).card +
-      (((Ico 1 (p / 2).succ).sum (λ x, (a * x : zmodp p hp).val_min_abs.nat_abs)) : ℕ) :
-    by simp [ite_cast, add_comm, sum_add_distrib, finset.sum_ite, hp2, sum_nat_cast]
+        (λ x : ℕ, p / 2 < (a * x : zmod p).val)).card +
+      (((Ico 1 (p / 2).succ).sum (λ x, (a * x : zmod p).val_min_abs.nat_abs)) : ℕ) :
+    by { simp [ite_cast, add_comm, sum_add_distrib, finset.sum_ite, hp2, sum_nat_cast], }
   ... = _ : by rw [finset.sum_eq_multiset_sum,
-      Ico_map_val_min_abs_nat_abs_eq_Ico_map_id hp _ hap,
+      Ico_map_val_min_abs_nat_abs_eq_Ico_map_id p a hap,
       ← finset.sum_eq_multiset_sum];
     simp [sum_nat_cast]) rfl
 
-private lemma eisenstein_lemma_aux₂ {p : ℕ} (hp : p.prime) (hp2 : p % 2 = 1) {a : ℕ} (ha2 : a % 2 = 1)
-  (hap : (a : zmodp p hp) ≠ 0) :
+private lemma eisenstein_lemma_aux₂ (p : ℕ) [hp : fact p.prime] [hp2 : fact (p % 2 = 1)]
+  {a : ℕ} (ha2 : a % 2 = 1) (hap : (a : zmod p) ≠ 0) :
   ((Ico 1 (p / 2).succ).filter
-    ((λ x : ℕ, p / 2 < (a * x : zmodp p hp).val))).card
+    ((λ x : ℕ, p / 2 < (a * x : zmod p).val))).card
   ≡ (Ico 1 (p / 2).succ).sum (λ x, (x * a) / p) [MOD 2] :=
-have ha2 : (a : zmod 2) = (1 : ℕ), from zmod.eq_iff_modeq_nat.2 ha2,
-(@zmod.eq_iff_modeq_nat 2 _ _).1 $ sub_eq_zero.1 $
+have ha2 : (a : zmod 2) = (1 : ℕ), from (eq_iff_modeq_nat _).2 ha2,
+(eq_iff_modeq_nat 2).1 $ sub_eq_zero.1 $
   by simpa [add_left_comm, sub_eq_add_neg, finset.mul_sum.symm, mul_comm, ha2, sum_nat_cast,
-            add_neg_eq_iff_eq_add.symm, zmod.neg_eq_self_mod_two]
-    using eq.symm (eisenstein_lemma_aux₁ hp hp2 hap)
+            add_neg_eq_iff_eq_add.symm, neg_eq_self_mod_two]
+    using eq.symm (eisenstein_lemma_aux₁ p hap)
 
 lemma div_eq_filter_card {a b c : ℕ} (hb0 : 0 < b) (hc : a / b ≤ c) : a / b =
   ((Ico 1 c.succ).filter (λ x, x * b ≤ a)).card :=
@@ -254,7 +285,7 @@ calc a / b = (Ico 1 (a / b).succ).card : by simp
       from λ h, le_trans (by rwa [le_div_iff_mul_le _ _ hb0]) hc,
     by simp [lt_succ_iff, le_div_iff_mul_le _ _ hb0]; tauto
 
-/-- The given sum is the number of integers point in the triangle formed by the diagonal of the
+/-- The given sum is the number of integer points in the triangle formed by the diagonal of the
   rectangle `(0, p/2) × (0, q/2)`  -/
 private lemma sum_Ico_eq_card_lt {p q : ℕ} :
   (Ico 1 (p / 2).succ).sum (λ a, (a * q) / p) =
@@ -282,8 +313,8 @@ else
 /-- Each of the sums in this lemma is the cardinality of the set integer points in each of the
   two triangles formed by the diagonal of the rectangle `(0, p/2) × (0, q/2)`. Adding them
   gives the number of points in the rectangle. -/
-private lemma sum_mul_div_add_sum_mul_div_eq_mul {p q : ℕ} (hp : p.prime)
-  (hq0 : (q : zmodp p hp) ≠ 0) :
+private lemma sum_mul_div_add_sum_mul_div_eq_mul (p q : ℕ) [hp : fact p.prime]
+  (hq0 : (q : zmod p) ≠ 0) :
   (Ico 1 (p / 2).succ).sum (λ a, (a * q) / p) +
   (Ico 1 (q / 2).succ).sum (λ a, (a * p) / q) =
   (p / 2) * (q / 2) :=
@@ -305,9 +336,10 @@ have hdisj : disjoint
     (show x.1 ≤ p / 2, by simp [*, nat.lt_succ_iff] at *; tauto)
     (nat.div_lt_self hp.pos dec_trivial),
   begin
-    have : (x.1 : zmodp p hp) = 0,
-    { simpa [hq0] using congr_arg (coe : ℕ → zmodp p hp) (le_antisymm hpq hqp) },
-    rw [fin.eq_iff_veq, zmodp.val_cast_of_lt hp hxp, zmodp.zero_val] at this,
+    have : (x.1 : zmod p) = 0,
+    { simpa [hq0] using congr_arg (coe : ℕ → zmod p) (le_antisymm hpq hqp) },
+    apply_fun zmod.val at this,
+    rw [val_cast_of_lt hxp, val_zero] at this,
     simp * at *
   end,
 have hunion : ((Ico 1 (p / 2).succ).product (Ico 1 (q / 2).succ)).filter
@@ -320,81 +352,113 @@ by rw [sum_Ico_eq_card_lt, sum_Ico_eq_card_lt, hswap, ← card_disjoint_union hd
     card_product];
   simp
 
-variables {p q : ℕ} (hp : nat.prime p) (hq : nat.prime q)
+variables (p q : ℕ) [fact p.prime] [fact q.prime]
 
-namespace zmodp
+namespace zmod
 
-def legendre_sym (a p : ℕ) (hp : nat.prime p) : ℤ :=
-if (a : zmodp p hp) = 0 then 0 else if ∃ b : zmodp p hp, b ^ 2 = a then 1 else -1
+/-- The Legendre symbol of `a` and `p` is an integer defined as
 
-lemma legendre_sym_eq_pow (a p : ℕ) (hp : nat.prime p) :
-  (legendre_sym a p hp : zmodp p hp) = (a ^ (p / 2)) :=
-if ha : (a : zmodp p hp) = 0 then by simp [*, legendre_sym, _root_.zero_pow (nat.div_pos hp.two_le (succ_pos 1))]
-else
-(nat.prime.eq_two_or_odd hp).elim
-  (λ hp2, begin resetI; subst hp2,
-    suffices : ∀ a : zmodp 2 nat.prime_two,
-      (((ite (a = 0) 0 (ite (∃ (b : zmodp 2 hp), b ^ 2 = a) 1 (-1))) : ℤ) : zmodp 2 nat.prime_two) = a ^ (2 / 2),
-    { exact this a },
-    exact dec_trivial,
-   end)
-  (λ hp1, have _ := euler_criterion hp ha,
-    have (-1 : zmodp p hp) ≠ 1, from (ne_neg_self hp hp1 zero_ne_one.symm).symm,
-    by cases zmodp.pow_div_two_eq_neg_one_or_one hp ha; simp [legendre_sym, *] at *)
+* `0` if `a` is `0` modulo `p`;
+* `1` if `a ^ (p / 2)` is `1` modulo `p`
+   (by `euler_criterion` this is equivalent to “`a` is a square modulo `p`”);
+* `-1` otherwise.
 
-lemma legendre_sym_eq_one_or_neg_one (a : ℕ) (hp : nat.prime p) (ha : (a : zmodp p hp) ≠ 0) :
-  legendre_sym a p hp = -1 ∨ legendre_sym a p hp = 1 :=
-by unfold legendre_sym; split_ifs; simp * at *
+-/
+def legendre_sym (a p : ℕ) : ℤ :=
+if      (a : zmod p) = 0           then  0
+else if (a : zmod p) ^ (p / 2) = 1 then  1
+                                   else -1
+
+lemma legendre_sym_eq_pow (a p : ℕ) [hp : fact p.prime] :
+  (legendre_sym a p : zmod p) = (a ^ (p / 2)) :=
+begin
+  rw legendre_sym,
+  by_cases ha : (a : zmod p) = 0,
+  { simp only [if_pos, ha, _root_.zero_pow (nat.div_pos (hp.two_le) (succ_pos 1)), int.cast_zero] },
+  cases hp.eq_two_or_odd with hp2 hp_odd,
+  { resetI, subst p,
+    have : ∀ (a : zmod 2),
+      ((if a = 0 then 0 else if a ^ (2 / 2) = 1 then 1 else -1 : ℤ) : zmod 2) = a ^ (2 / 2),
+    by exact dec_trivial,
+    exact this a },
+  { change fact (p % 2 = 1) at hp_odd, resetI,
+    rw if_neg ha,
+    have : (-1 : zmod p) ≠ 1, from (ne_neg_self p one_ne_zero).symm,
+    cases pow_div_two_eq_neg_one_or_one p ha with h h,
+    { rw [if_pos h, h, int.cast_one], },
+    { rw [h, if_neg this, int.cast_neg, int.cast_one], } }
+end
+
+lemma legendre_sym_eq_one_or_neg_one (a p : ℕ) (ha : (a : zmod p) ≠ 0) :
+  legendre_sym a p = -1 ∨ legendre_sym a p = 1 :=
+by unfold legendre_sym; split_ifs; simp only [*, eq_self_iff_true, or_true, true_or] at *
+
+lemma legendre_sym_eq_zero_iff (a p : ℕ) :
+  legendre_sym a p = 0 ↔ (a : zmod p) = 0 :=
+begin
+  split,
+  { classical, contrapose,
+    assume ha, cases legendre_sym_eq_one_or_neg_one a p ha with h h,
+    all_goals { rw h, norm_num } },
+  { assume ha, rw [legendre_sym, if_pos ha] }
+end
 
 /-- Gauss' lemma. The legendre symbol can be computed by considering the number of naturals less
   than `p/2` such that `(a * x) % p > p / 2` -/
-lemma gauss_lemma {a : ℕ} (hp1 : p % 2 = 1) (ha0 : (a : zmodp p hp) ≠ 0) :
-  legendre_sym a p hp = (-1) ^ ((Ico 1 (p / 2).succ).filter
-    (λ x : ℕ, p / 2 < (a * x : zmodp p hp).val)).card :=
-have (legendre_sym a p hp : zmodp p hp) = (((-1)^((Ico 1 (p / 2).succ).filter
-    (λ x : ℕ, p / 2 < (a * x : zmodp p hp).val)).card : ℤ) : zmodp p hp),
-  by rw [legendre_sym_eq_pow, gauss_lemma_aux₂ hp hp1 ha0]; simp,
+lemma gauss_lemma {a : ℕ} [hp1 : fact (p % 2 = 1)] (ha0 : (a : zmod p) ≠ 0) :
+  legendre_sym a p = (-1) ^ ((Ico 1 (p / 2).succ).filter
+    (λ x : ℕ, p / 2 < (a * x : zmod p).val)).card :=
+have (legendre_sym a p : zmod p) = (((-1)^((Ico 1 (p / 2).succ).filter
+    (λ x : ℕ, p / 2 < (a * x : zmod p).val)).card : ℤ) : zmod p),
+  by rw [legendre_sym_eq_pow, gauss_lemma_aux₂ p ha0]; simp,
 begin
-  cases legendre_sym_eq_one_or_neg_one a hp ha0;
+  cases legendre_sym_eq_one_or_neg_one a p ha0;
   cases @neg_one_pow_eq_or ℤ _  ((Ico 1 (p / 2).succ).filter
-    (λ x : ℕ, p / 2 < (a * x : zmodp p hp).val)).card;
-  simp [*, zmodp.ne_neg_self hp hp1 one_ne_zero,
-    (zmodp.ne_neg_self hp hp1 one_ne_zero).symm] at *
+    (λ x : ℕ, p / 2 < (a * x : zmod p).val)).card;
+  simp [*, ne_neg_self p one_ne_zero, (ne_neg_self p one_ne_zero).symm] at *
 end
 
-lemma legendre_sym_eq_one_iff {a : ℕ} (ha0 : (a : zmodp p hp) ≠ 0) :
-  legendre_sym a p hp = 1 ↔ (∃ b : zmodp p hp, b ^ 2 = a) :=
-by rw [legendre_sym]; split_ifs; finish
+lemma legendre_sym_eq_one_iff {a : ℕ} (ha0 : (a : zmod p) ≠ 0) :
+  legendre_sym a p = 1 ↔ (∃ b : zmod p, b ^ 2 = a) :=
+begin
+  rw [euler_criterion p ha0, legendre_sym, if_neg ha0],
+  split_ifs,
+  { simp only [h, eq_self_iff_true] },
+  finish -- this is quite slow. I'm actually surprised that it can close the goal at all!
+end
 
-lemma eisenstein_lemma (hp1 : p % 2 = 1) {a : ℕ} (ha1 : a % 2 = 1) (ha0 : (a : zmodp p hp) ≠ 0) :
-  legendre_sym a p hp = (-1)^(Ico 1 (p / 2).succ).sum (λ x, (x * a) / p) :=
-by rw [neg_one_pow_eq_pow_mod_two, gauss_lemma hp hp1 ha0, neg_one_pow_eq_pow_mod_two,
-    show _ = _, from eisenstein_lemma_aux₂ hp hp1 ha1 ha0]
+lemma eisenstein_lemma [hp1 : fact (p % 2 = 1)] {a : ℕ} (ha1 : a % 2 = 1) (ha0 : (a : zmod p) ≠ 0) :
+  legendre_sym a p = (-1)^(Ico 1 (p / 2).succ).sum (λ x, (x * a) / p) :=
+by rw [neg_one_pow_eq_pow_mod_two, gauss_lemma p ha0, neg_one_pow_eq_pow_mod_two,
+    show _ = _, from eisenstein_lemma_aux₂ p ha1 ha0]
 
-theorem quadratic_reciprocity (hp1 : p % 2 = 1) (hq1 : q % 2 = 1) (hpq : p ≠ q) :
-  legendre_sym p q hq * legendre_sym q p hp = (-1) ^ ((p / 2) * (q / 2)) :=
-have hpq0 : (p : zmodp q hq) ≠ 0, from zmodp.prime_ne_zero _ hp hpq.symm,
-have hqp0 : (q : zmodp p hp) ≠ 0, from zmodp.prime_ne_zero _ hq hpq,
-by rw [eisenstein_lemma _ hq1 hp1 hpq0, eisenstein_lemma _ hp1 hq1 hqp0,
-  ← _root_.pow_add, sum_mul_div_add_sum_mul_div_eq_mul _ hpq0, mul_comm]
+theorem quadratic_reciprocity [hp1 : fact (p % 2 = 1)] [hq1 : fact (q % 2 = 1)] (hpq : p ≠ q) :
+  legendre_sym p q * legendre_sym q p = (-1) ^ ((p / 2) * (q / 2)) :=
+have hpq0 : (p : zmod q) ≠ 0, from prime_ne_zero q p hpq.symm,
+have hqp0 : (q : zmod p) ≠ 0, from prime_ne_zero p q hpq,
+by rw [eisenstein_lemma q hp1 hpq0, eisenstein_lemma p hq1 hqp0,
+  ← _root_.pow_add, sum_mul_div_add_sum_mul_div_eq_mul q p hpq0, mul_comm]
 
-lemma legendre_sym_two (hp1 : p % 2 = 1) : legendre_sym 2 p hp = (-1) ^ (p / 4 + p / 2) :=
-have hp2 : p ≠ 2, from mt (congr_arg (% 2)) (by simp [hp1]),
+-- move this
+instance fact_prime_two : fact (nat.prime 2) := nat.prime_two
+
+lemma legendre_sym_two [hp1 : fact (p % 2 = 1)] : legendre_sym 2 p = (-1) ^ (p / 4 + p / 2) :=
+have hp2 : p ≠ 2, from mt (congr_arg (% 2)) (by simpa using hp1),
 have hp22 : p / 2 / 2 = _ := div_eq_filter_card (show 0 < 2, from dec_trivial)
   (nat.div_le_self (p / 2) 2),
 have hcard : (Ico 1 (p / 2).succ).card = p / 2, by simp,
-have hx2 : ∀ x ∈ Ico 1 (p / 2).succ, (2 * x : zmodp p hp).val = 2 * x,
+have hx2 : ∀ x ∈ Ico 1 (p / 2).succ, (2 * x : zmod p).val = 2 * x,
   from λ x hx, have h2xp : 2 * x < p,
       from calc 2 * x ≤ 2 * (p / 2) : mul_le_mul_of_nonneg_left
         (le_of_lt_succ $ by finish) dec_trivial
-      ... < _ : by conv_rhs {rw [← mod_add_div p 2, add_comm, hp1]}; exact lt_succ_self _,
-    by rw [← nat.cast_two, ← nat.cast_mul, zmodp.val_cast_of_lt _ h2xp],
+      ... < _ : by conv_rhs {rw [← mod_add_div p 2, add_comm, show p % 2 = 1, from hp1]}; exact lt_succ_self _,
+    by rw [← nat.cast_two, ← nat.cast_mul, val_cast_of_lt h2xp],
 have hdisj : disjoint
-    ((Ico 1 (p / 2).succ).filter (λ x, p / 2 < ((2 : ℕ) * x : zmodp p hp).val))
+    ((Ico 1 (p / 2).succ).filter (λ x, p / 2 < ((2 : ℕ) * x : zmod p).val))
     ((Ico 1 (p / 2).succ).filter (λ x, x * 2 ≤ p / 2)),
   from disjoint_filter.2 (λ x hx, by simp [hx2 _ hx, mul_comm]),
 have hunion :
-    ((Ico 1 (p / 2).succ).filter (λ x, p / 2 < ((2 : ℕ) * x : zmodp p hp).val)) ∪
+    ((Ico 1 (p / 2).succ).filter (λ x, p / 2 < ((2 : ℕ) * x : zmod p).val)) ∪
     ((Ico 1 (p / 2).succ).filter (λ x, x * 2 ≤ p / 2)) =
     Ico 1 (p / 2).succ,
   begin
@@ -403,25 +467,26 @@ have hunion :
     exact filter_congr (λ x hx, by simp [hx2 _ hx, lt_or_le, mul_comm])
   end,
 begin
-  rw [gauss_lemma _ hp1 (prime_ne_zero hp prime_two hp2),
+  rw [gauss_lemma p (prime_ne_zero p 2 hp2),
     neg_one_pow_eq_pow_mod_two, @neg_one_pow_eq_pow_mod_two _ _ (p / 4 + p / 2)],
-  refine congr_arg2 _ rfl ((@zmod.eq_iff_modeq_nat 2 _ _).1 _),
+  refine congr_arg2 _ rfl ((eq_iff_modeq_nat 2).1 _),
   rw [show 4 = 2 * 2, from rfl, ← nat.div_div_eq_div_mul, hp22, nat.cast_add,
-    ← sub_eq_iff_eq_add', sub_eq_add_neg, zmod.neg_eq_self_mod_two,
+    ← sub_eq_iff_eq_add', sub_eq_add_neg, neg_eq_self_mod_two,
     ← nat.cast_add, ← card_disjoint_union hdisj, hunion, hcard]
 end
 
-lemma exists_pow_two_eq_two_iff (hp1 : p % 2 = 1) :
-  (∃ a : zmodp p hp, a ^ 2 = 2) ↔ p % 8 = 1 ∨ p % 8 = 7 :=
-have hp2 : ((2 : ℕ) : zmodp p hp) ≠ 0,
-  from zmodp.prime_ne_zero hp prime_two (λ h, by simp * at *),
+lemma exists_pow_two_eq_two_iff [hp1 : fact (p % 2 = 1)] :
+  (∃ a : zmod p, a ^ 2 = 2) ↔ p % 8 = 1 ∨ p % 8 = 7 :=
+have hp2 : ((2 : ℕ) : zmod p) ≠ 0,
+  from prime_ne_zero p 2 (λ h, by simpa [h] using hp1),
 have hpm4 : p % 4 = p % 8 % 4, from (nat.mod_mul_left_mod p 2 4).symm,
 have hpm2 : p % 2 = p % 8 % 2, from (nat.mod_mul_left_mod p 4 2).symm,
 begin
-  rw [show (2 : zmodp p hp) = (2 : ℕ), by simp, ← legendre_sym_eq_one_iff hp hp2,
-    legendre_sym_two hp hp1, neg_one_pow_eq_one_iff_even (show (-1 : ℤ) ≠ 1, from dec_trivial),
+  rw [show (2 : zmod p) = (2 : ℕ), by simp, ← legendre_sym_eq_one_iff p hp2,
+    legendre_sym_two p, neg_one_pow_eq_one_iff_even (show (-1 : ℤ) ≠ 1, from dec_trivial),
     even_add, even_div, even_div],
   have := nat.mod_lt p (show 0 < 8, from dec_trivial),
+  resetI, rw _root_.fact at hp1,
   revert this hp1,
   erw [hpm4, hpm2],
   generalize hm : p % 8 = m,
@@ -430,34 +495,40 @@ begin
   exact dec_trivial
 end
 
-lemma exists_pow_two_eq_prime_iff_of_mod_four_eq_one (hp1 : p % 4 = 1) (hq1 : q % 2 = 1) :
-  (∃ a : zmodp p hp, a ^ 2 = q) ↔ ∃ b : zmodp q hq, b ^ 2 = p :=
+lemma exists_pow_two_eq_prime_iff_of_mod_four_eq_one (hp1 : p % 4 = 1) [hq1 : fact (q % 2 = 1)] :
+  (∃ a : zmod p, a ^ 2 = q) ↔ ∃ b : zmod q, b ^ 2 = p :=
 if hpq : p = q then by resetI; subst hpq else
 have h1 : ((p / 2) * (q / 2)) % 2 = 0,
   from (dvd_iff_mod_eq_zero _ _).1
     (dvd_mul_of_dvd_left ((dvd_iff_mod_eq_zero _ _).2 $
     by rw [← mod_mul_right_div_self, show 2 * 2 = 4, from rfl, hp1]; refl) _),
 begin
-  have := quadratic_reciprocity hp hq (odd_of_mod_four_eq_one hp1) hq1 hpq,
+  haveI hp_odd : fact (p % 2 = 1) := odd_of_mod_four_eq_one hp1,
+  have hpq0 : (p : zmod q) ≠ 0 := prime_ne_zero q p (ne.symm hpq),
+  have hqp0 : (q : zmod p) ≠ 0 := prime_ne_zero p q hpq,
+  have := quadratic_reciprocity p q hpq,
   rw [neg_one_pow_eq_pow_mod_two, h1, legendre_sym, legendre_sym,
-    if_neg (zmodp.prime_ne_zero hp hq hpq),
-    if_neg (zmodp.prime_ne_zero hq hp (ne.symm hpq))] at this,
-  split_ifs at this; simp *; contradiction
+    if_neg hqp0, if_neg hpq0] at this,
+  rw [euler_criterion q hpq0, euler_criterion p hqp0],
+  split_ifs at this; simp *; contradiction,
 end
 
 lemma exists_pow_two_eq_prime_iff_of_mod_four_eq_three (hp3 : p % 4 = 3)
-  (hq3 : q % 4 = 3) (hpq : p ≠ q) : (∃ a : zmodp p hp, a ^ 2 = q) ↔ ¬∃ b : zmodp q hq, b ^ 2 = p :=
+  (hq3 : q % 4 = 3) (hpq : p ≠ q) : (∃ a : zmod p, a ^ 2 = q) ↔ ¬∃ b : zmod q, b ^ 2 = p :=
 have h1 : ((p / 2) * (q / 2)) % 2 = 1,
   from nat.odd_mul_odd
     (by rw [← mod_mul_right_div_self, show 2 * 2 = 4, from rfl, hp3]; refl)
     (by rw [← mod_mul_right_div_self, show 2 * 2 = 4, from rfl, hq3]; refl),
 begin
-  have := quadratic_reciprocity hp hq (odd_of_mod_four_eq_three hp3)
-    (odd_of_mod_four_eq_three hq3) hpq,
+  haveI hp_odd : fact (p % 2 = 1) := odd_of_mod_four_eq_three hp3,
+  haveI hq_odd : fact (q % 2 = 1) := odd_of_mod_four_eq_three hq3,
+  have hpq0 : (p : zmod q) ≠ 0 := prime_ne_zero q p (ne.symm hpq),
+  have hqp0 : (q : zmod p) ≠ 0 := prime_ne_zero p q hpq,
+  have := quadratic_reciprocity p q hpq,
   rw [neg_one_pow_eq_pow_mod_two, h1, legendre_sym, legendre_sym,
-    if_neg (zmodp.prime_ne_zero hp hq hpq),
-    if_neg (zmodp.prime_ne_zero hq hp hpq.symm)] at this,
+    if_neg hpq0, if_neg hqp0] at this,
+  rw [euler_criterion q hpq0, euler_criterion p hqp0],
   split_ifs at this; simp *; contradiction
 end
 
-end zmodp
+end zmod

--- a/src/data/zsqrtd/gaussian_int.lean
+++ b/src/data/zsqrtd/gaussian_int.lean
@@ -214,37 +214,37 @@ hp.eq_two_or_odd.elim
     begin
       obtain ⟨k, k_lt_p, rfl⟩ : ∃ (k' : ℕ) (h : k' < p), (k' : zmod p) = k,
       { refine ⟨k.val, k.val_lt, zmod.cast_val k⟩ },
-    have hpk : p ∣ k ^ 2 + 1,
-      by rw [← char_p.cast_eq_zero_iff (zmod p) p]; simp *,
-    have hkmul : (k ^ 2 + 1 : ℤ[i]) = ⟨k, 1⟩ * ⟨k, -1⟩ :=
-      by simp [_root_.pow_two, zsqrtd.ext],
-    have hpne1 : p ≠ 1, from (ne_of_lt (hp.one_lt)).symm,
-    have hkltp : 1 + k * k < p * p,
-      from calc 1 + k * k ≤ k + k * k :
-        add_le_add_right (nat.pos_of_ne_zero
-          (λ hk0, by clear_aux_decl; simp [*, nat.pow_succ] at *)) _
-      ... = k * (k + 1) : by simp [add_comm, mul_add]
-      ... < p * p : mul_lt_mul k_lt_p k_lt_p (nat.succ_pos _) (nat.zero_le _),
-    have hpk₁ : ¬ (p : ℤ[i]) ∣ ⟨k, -1⟩ :=
-      λ ⟨x, hx⟩, lt_irrefl (p * x : ℤ[i]).norm.nat_abs $
-        calc (norm (p * x : ℤ[i])).nat_abs = (norm ⟨k, -1⟩).nat_abs : by rw hx
-        ... < (norm (p : ℤ[i])).nat_abs : by simpa [add_comm, norm] using hkltp
-        ... ≤ (norm (p * x : ℤ[i])).nat_abs : norm_le_norm_mul_left _
-          (λ hx0, (show (-1 : ℤ) ≠ 0, from dec_trivial) $
-            by simpa [hx0] using congr_arg zsqrtd.im hx),
-    have hpk₂ : ¬ (p : ℤ[i]) ∣ ⟨k, 1⟩ :=
-      λ ⟨x, hx⟩, lt_irrefl (p * x : ℤ[i]).norm.nat_abs $
-        calc (norm (p * x : ℤ[i])).nat_abs = (norm ⟨k, 1⟩).nat_abs : by rw hx
-        ... < (norm (p : ℤ[i])).nat_abs : by simpa [add_comm, norm] using hkltp
-        ... ≤ (norm (p * x : ℤ[i])).nat_abs : norm_le_norm_mul_left _
-          (λ hx0, (show (1 : ℤ) ≠ 0, from dec_trivial) $
+      have hpk : p ∣ k ^ 2 + 1,
+        by rw [← char_p.cast_eq_zero_iff (zmod p) p]; simp *,
+      have hkmul : (k ^ 2 + 1 : ℤ[i]) = ⟨k, 1⟩ * ⟨k, -1⟩ :=
+        by simp [_root_.pow_two, zsqrtd.ext],
+      have hpne1 : p ≠ 1, from (ne_of_lt (hp.one_lt)).symm,
+      have hkltp : 1 + k * k < p * p,
+        from calc 1 + k * k ≤ k + k * k :
+          add_le_add_right (nat.pos_of_ne_zero
+            (λ hk0, by clear_aux_decl; simp [*, nat.pow_succ] at *)) _
+        ... = k * (k + 1) : by simp [add_comm, mul_add]
+        ... < p * p : mul_lt_mul k_lt_p k_lt_p (nat.succ_pos _) (nat.zero_le _),
+      have hpk₁ : ¬ (p : ℤ[i]) ∣ ⟨k, -1⟩ :=
+        λ ⟨x, hx⟩, lt_irrefl (p * x : ℤ[i]).norm.nat_abs $
+          calc (norm (p * x : ℤ[i])).nat_abs = (norm ⟨k, -1⟩).nat_abs : by rw hx
+          ... < (norm (p : ℤ[i])).nat_abs : by simpa [add_comm, norm] using hkltp
+          ... ≤ (norm (p * x : ℤ[i])).nat_abs : norm_le_norm_mul_left _
+            (λ hx0, (show (-1 : ℤ) ≠ 0, from dec_trivial) $
               by simpa [hx0] using congr_arg zsqrtd.im hx),
-    have hpu : ¬ is_unit (p : ℤ[i]), from mt norm_eq_one_iff.2
-      (by rw [norm_nat_cast, int.nat_abs_mul, nat.mul_eq_one_iff];
-      exact λ h, (ne_of_lt hp.one_lt).symm h.1),
-    obtain ⟨y, hy⟩ := hpk,
-    have := hpi.2.2 ⟨k, 1⟩ ⟨k, -1⟩ ⟨y, by rw [← hkmul, ← nat.cast_mul p, ← hy]; simp⟩,
-    clear_aux_decl, tauto
+      have hpk₂ : ¬ (p : ℤ[i]) ∣ ⟨k, 1⟩ :=
+        λ ⟨x, hx⟩, lt_irrefl (p * x : ℤ[i]).norm.nat_abs $
+          calc (norm (p * x : ℤ[i])).nat_abs = (norm ⟨k, 1⟩).nat_abs : by rw hx
+          ... < (norm (p : ℤ[i])).nat_abs : by simpa [add_comm, norm] using hkltp
+          ... ≤ (norm (p * x : ℤ[i])).nat_abs : norm_le_norm_mul_left _
+            (λ hx0, (show (1 : ℤ) ≠ 0, from dec_trivial) $
+                by simpa [hx0] using congr_arg zsqrtd.im hx),
+      have hpu : ¬ is_unit (p : ℤ[i]), from mt norm_eq_one_iff.2
+        (by rw [norm_nat_cast, int.nat_abs_mul, nat.mul_eq_one_iff];
+        exact λ h, (ne_of_lt hp.one_lt).symm h.1),
+      obtain ⟨y, hy⟩ := hpk,
+      have := hpi.2.2 ⟨k, 1⟩ ⟨k, -1⟩ ⟨y, by rw [← hkmul, ← nat.cast_mul p, ← hy]; simp⟩,
+      clear_aux_decl, tauto
     end)
 
 lemma sum_two_squares_of_nat_prime_of_not_irreducible (p : ℕ) [hp : fact p.prime]

--- a/src/data/zsqrtd/gaussian_int.lean
+++ b/src/data/zsqrtd/gaussian_int.lean
@@ -6,7 +6,7 @@ Author: Chris Hughes
 import data.zsqrtd.basic
 import data.complex.basic
 import ring_theory.principal_ideal_domain
-import number_theory.quadratic_reciprocity
+import data.zmod.quadratic_reciprocity
 /-!
 # Gaussian integers
 

--- a/src/data/zsqrtd/gaussian_int.lean
+++ b/src/data/zsqrtd/gaussian_int.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Chris Hughes
 -/
 import data.zsqrtd.basic
+import data.complex.basic
 import ring_theory.principal_ideal_domain
-import data.zmod.quadratic_reciprocity
+import number_theory.quadratic_reciprocity
 /-!
 # Gaussian integers
 
@@ -190,7 +191,7 @@ instance : euclidean_domain ℤ[i] :=
 
 open principal_ideal_domain
 
-lemma mod_four_eq_three_of_nat_prime_of_prime {p : ℕ} (hp : p.prime) (hpi : prime (p : ℤ[i])) :
+lemma mod_four_eq_three_of_nat_prime_of_prime (p : ℕ) [hp : fact p.prime] (hpi : prime (p : ℤ[i])) :
   p % 4 = 3 :=
 hp.eq_two_or_odd.elim
   (λ hp2, absurd hpi (mt irreducible_iff_prime.2 $
@@ -208,42 +209,45 @@ hp.eq_two_or_odd.elim
         generalize hm : p % 4 = m, clear hm, revert m,
         exact dec_trivial,
       end,
-    let ⟨k, hk⟩ := (zmodp.exists_pow_two_eq_neg_one_iff_mod_four_ne_three hp).2 $
+    let ⟨k, hk⟩ := (zmod.exists_pow_two_eq_neg_one_iff_mod_four_ne_three p).2 $
       by rw hp41; exact dec_trivial in
-    have hpk : p ∣ k.val ^ 2 + 1,
-      by rw [← zmodp.eq_zero_iff_dvd_nat hp]; simp *,
-    have hkmul : (k.val ^ 2 + 1 : ℤ[i]) = ⟨k.val, 1⟩ * ⟨k.val, -1⟩ :=
+    begin
+      obtain ⟨k, k_lt_p, rfl⟩ : ∃ (k' : ℕ) (h : k' < p), (k' : zmod p) = k,
+      { refine ⟨k.val, k.val_lt, zmod.cast_val k⟩ },
+    have hpk : p ∣ k ^ 2 + 1,
+      by rw [← char_p.cast_eq_zero_iff (zmod p) p]; simp *,
+    have hkmul : (k ^ 2 + 1 : ℤ[i]) = ⟨k, 1⟩ * ⟨k, -1⟩ :=
       by simp [_root_.pow_two, zsqrtd.ext],
     have hpne1 : p ≠ 1, from (ne_of_lt (hp.one_lt)).symm,
-    have hkltp : 1 + k.val * k.val < p * p,
-      from calc 1 + k.val * k.val ≤ k.val + k.val * k.val :
+    have hkltp : 1 + k * k < p * p,
+      from calc 1 + k * k ≤ k + k * k :
         add_le_add_right (nat.pos_of_ne_zero
           (λ hk0, by clear_aux_decl; simp [*, nat.pow_succ] at *)) _
-      ... = k.val * (k.val + 1) : by simp [add_comm, mul_add]
-      ... < p * p : mul_lt_mul k.2 k.2 (nat.succ_pos _) (nat.zero_le _),
-    have hpk₁ : ¬ (p : ℤ[i]) ∣ ⟨k.val, -1⟩ :=
+      ... = k * (k + 1) : by simp [add_comm, mul_add]
+      ... < p * p : mul_lt_mul k_lt_p k_lt_p (nat.succ_pos _) (nat.zero_le _),
+    have hpk₁ : ¬ (p : ℤ[i]) ∣ ⟨k, -1⟩ :=
       λ ⟨x, hx⟩, lt_irrefl (p * x : ℤ[i]).norm.nat_abs $
-        calc (norm (p * x : ℤ[i])).nat_abs = (norm ⟨k.val, -1⟩).nat_abs : by rw hx
+        calc (norm (p * x : ℤ[i])).nat_abs = (norm ⟨k, -1⟩).nat_abs : by rw hx
         ... < (norm (p : ℤ[i])).nat_abs : by simpa [add_comm, norm] using hkltp
         ... ≤ (norm (p * x : ℤ[i])).nat_abs : norm_le_norm_mul_left _
           (λ hx0, (show (-1 : ℤ) ≠ 0, from dec_trivial) $
             by simpa [hx0] using congr_arg zsqrtd.im hx),
-    have hpk₂ : ¬ (p : ℤ[i]) ∣ ⟨k.val, 1⟩ :=
+    have hpk₂ : ¬ (p : ℤ[i]) ∣ ⟨k, 1⟩ :=
       λ ⟨x, hx⟩, lt_irrefl (p * x : ℤ[i]).norm.nat_abs $
-        calc (norm (p * x : ℤ[i])).nat_abs = (norm ⟨k.val, 1⟩).nat_abs : by rw hx
+        calc (norm (p * x : ℤ[i])).nat_abs = (norm ⟨k, 1⟩).nat_abs : by rw hx
         ... < (norm (p : ℤ[i])).nat_abs : by simpa [add_comm, norm] using hkltp
         ... ≤ (norm (p * x : ℤ[i])).nat_abs : norm_le_norm_mul_left _
           (λ hx0, (show (1 : ℤ) ≠ 0, from dec_trivial) $
               by simpa [hx0] using congr_arg zsqrtd.im hx),
-    have hpu : ¬ is_unit (p : ℤ[i]), from mt norm_eq_one_iff.2 $
-      by rw [norm_nat_cast, int.nat_abs_mul, nat.mul_eq_one_iff];
-      exact λ h, (ne_of_lt hp.one_lt).symm h.1,
-    let ⟨y, hy⟩ := hpk in
-    by have := hpi.2.2 ⟨k.val, 1⟩ ⟨k.val, -1⟩
-      ⟨y, by rw [← hkmul, ← nat.cast_mul p, ← hy]; simp⟩;
-        clear_aux_decl; tauto)
+    have hpu : ¬ is_unit (p : ℤ[i]), from mt norm_eq_one_iff.2
+      (by rw [norm_nat_cast, int.nat_abs_mul, nat.mul_eq_one_iff];
+      exact λ h, (ne_of_lt hp.one_lt).symm h.1),
+    obtain ⟨y, hy⟩ := hpk,
+    have := hpi.2.2 ⟨k, 1⟩ ⟨k, -1⟩ ⟨y, by rw [← hkmul, ← nat.cast_mul p, ← hy]; simp⟩,
+    clear_aux_decl, tauto
+    end)
 
-lemma sum_two_squares_of_nat_prime_of_not_irreducible {p : ℕ} (hp : p.prime)
+lemma sum_two_squares_of_nat_prime_of_not_irreducible (p : ℕ) [hp : fact p.prime]
   (hpi : ¬irreducible (p : ℤ[i])) : ∃ a b, a^2 + b^2 = p :=
 have hpu : ¬ is_unit (p : ℤ[i]), from mt norm_eq_one_iff.2 $
   by rw [norm_nat_cast, int.nat_abs_mul, nat.mul_eq_one_iff];
@@ -258,16 +262,16 @@ have hnap : (norm a).nat_abs = p, from ((hp.mul_eq_prime_pow_two_iff
     simp).1,
 ⟨a.re.nat_abs, a.im.nat_abs, by simpa [nat_abs_norm_eq, nat.pow_two] using hnap⟩
 
-lemma prime_of_nat_prime_of_mod_four_eq_three {p : ℕ} (hp : p.prime) (hp3 : p % 4 = 3) :
+lemma prime_of_nat_prime_of_mod_four_eq_three (p : ℕ) [hp : fact p.prime] (hp3 : p % 4 = 3) :
   prime (p : ℤ[i]) :=
 irreducible_iff_prime.1 $ classical.by_contradiction $ λ hpi,
-  let ⟨a, b, hab⟩ := sum_two_squares_of_nat_prime_of_not_irreducible hp hpi in
+  let ⟨a, b, hab⟩ := sum_two_squares_of_nat_prime_of_not_irreducible p hpi in
 have ∀ a b : zmod 4, a^2 + b^2 ≠ p, by erw [← zmod.cast_mod_nat 4 p, hp3]; exact dec_trivial,
 this a b (hab ▸ by simp)
 
 /-- A prime natural number is prime in `ℤ[i]` if and only if it is `3` mod `4` -/
-lemma prime_iff_mod_four_eq_three_of_nat_prime {p : ℕ} (hp : p.prime) :
+lemma prime_iff_mod_four_eq_three_of_nat_prime (p : ℕ) [hp : fact p.prime] :
   prime (p : ℤ[i]) ↔ p % 4 = 3 :=
-⟨mod_four_eq_three_of_nat_prime_of_prime hp, prime_of_nat_prime_of_mod_four_eq_three hp⟩
+⟨mod_four_eq_three_of_nat_prime_of_prime p, prime_of_nat_prime_of_mod_four_eq_three p⟩
 
 end gaussian_int

--- a/src/field_theory/finite.lean
+++ b/src/field_theory/finite.lean
@@ -6,7 +6,7 @@ Authors: Chris Hughes
 import group_theory.order_of_element
 import data.polynomial
 import data.equiv.ring
-import algebra.char_p
+import data.zmod.basic
 
 universes u v
 variables {α : Type u} {β : Type v}
@@ -130,32 +130,45 @@ calc a ^ (fintype.card α - 1) = (units.mk0 a ha ^ (fintype.card α - 1) : units
 
 end finite_field
 
-namespace zmodp
+namespace zmod
 
 open finite_field
 
-lemma sum_two_squares {p : ℕ} (hp : p.prime) (x : zmodp p hp) :
-  ∃ a b : zmodp p hp, a^2 + b^2 = x :=
-hp.eq_two_or_odd.elim (λ hp2, by resetI; subst hp2; revert x; exact dec_trivial) $ λ hp2,
-let ⟨a, b, hab⟩ := @exists_root_sum_quadratic _ _ _
-  (X^2 : polynomial (zmodp p hp)) (X^2 - C x) (by simp)
-  (degree_X_pow_sub_C dec_trivial _) (by simp *) in
-⟨a, b, by simpa only [eval_add, eval_pow, eval_neg, eval_X, eval_sub, eval_C,
-    (add_sub_assoc _ _ _).symm, sub_eq_zero] using hab⟩
+lemma sum_two_squares (p : ℕ) [hp : fact p.prime] (x : zmod p) :
+  ∃ a b : zmod p, a^2 + b^2 = x :=
+begin
+  cases hp.eq_two_or_odd with hp2 hp_odd,
+  { unfreezeI, subst p, revert x, exact dec_trivial },
+  let f : polynomial (zmod p) := X^2,
+  let g : polynomial (zmod p) := X^2 - C x,
+  obtain ⟨a, b, hab⟩ : ∃ a b, f.eval a + g.eval b = 0 :=
+    @exists_root_sum_quadratic _ _ _ f g
+      (degree_X_pow 2) (degree_X_pow_sub_C dec_trivial _) (by rw [zmod.card, hp_odd]),
+  refine ⟨a, b, _⟩,
+  rw ← sub_eq_zero,
+  simpa only [eval_C, eval_X, eval_pow, eval_sub, ← add_sub_assoc] using hab,
+end
 
-end zmodp
+end zmod
 
 namespace char_p
 
-lemma sum_two_squares {α : Type*} [integral_domain α] {n : ℕ+} [char_p α n] (x : ℤ) :
-  ∃ a b : ℕ, (a^2 + b^2 : α) = x :=
-let ⟨a, b, hab⟩ := zmodp.sum_two_squares (show nat.prime n,
-  from (char_p.char_is_prime_or_zero α _).resolve_right (nat.pos_iff_ne_zero.1 n.2)) x in
-⟨a.val, b.val, begin
-  have := congr_arg ⇑(zmod.cast_hom α : zmod n →+* α) hab,
-  rw [← zmod.cast_val a, ← zmod.cast_val b] at this,
-  simpa using this
-end⟩
+-- move this
+lemma prime_of_pos_char_p_integral_domain (R : Type*) [integral_domain R]
+  (n : ℕ) [fact (0 < n)] [char_p R n] :
+  fact n.prime :=
+(char_p.char_is_prime_or_zero R _).resolve_right (nat.pos_iff_ne_zero.1 ‹0 < n›)
+
+lemma sum_two_squares (R : Type*) [integral_domain R] (p : ℕ) [fact (0 < p)] [char_p R p] (x : ℤ) :
+  ∃ a b : ℕ, (a^2 + b^2 : R) = x :=
+begin
+  haveI := prime_of_pos_char_p_integral_domain R p,
+  obtain ⟨a, b, hab⟩ := zmod.sum_two_squares p x,
+  refine ⟨a.val, b.val, _⟩,
+  have := congr_arg (zmod.cast_hom p R) hab,
+  simpa only [zmod.cast_int_cast, zmod.cast_hom_apply, zmod.cast_add,
+    zmod.nat_cast_val, _root_.pow_two, zmod.cast_mul]
+end
 
 end char_p
 
@@ -164,18 +177,18 @@ open zmod
 
 /-- The Fermat-Euler totient theorem. `nat.modeq.pow_totient` is an alternative statement
   of the same theorem. -/
-@[simp] lemma zmod.pow_totient {n : ℕ+} (x : units (zmod n)) : x ^ φ n = 1 :=
+@[simp] lemma zmod.pow_totient {n : ℕ} [fact (0 < n)] (x : units (zmod n)) : x ^ φ n = 1 :=
 by rw [← card_units_eq_totient, pow_card_eq_one]
 
 /-- The Fermat-Euler totient theorem. `zmod.pow_totient` is an alternative statement
   of the same theorem. -/
 lemma nat.modeq.pow_totient {x n : ℕ} (h : nat.coprime x n) : x ^ φ n ≡ 1 [MOD n] :=
 begin
-  rcases nat.eq_zero_or_pos n with rfl | h₁, {simp},
-  let n' : ℕ+ := ⟨n, h₁⟩,
-  let x' : units (zmod n') := zmod.unit_of_coprime _ h,
+  cases n, {simp},
+  rw ← zmod.eq_iff_modeq_nat,
+  let x' : units (zmod (n+1)) := zmod.unit_of_coprime _ h,
   have := zmod.pow_totient x',
-  apply (zmod.eq_iff_modeq_nat' h₁).1,
-  apply_fun (coe:units (zmod n') → zmod n') at this,
-  simpa [show (x':zmod n') = x, from rfl],
+  apply_fun (coe : units (zmod (n+1)) → zmod (n+1)) at this,
+  simpa only [-zmod.pow_totient, succ_eq_add_one, cast_pow, units.coe_one,
+    nat.cast_one, cast_unit_of_coprime, units.coe_pow],
 end

--- a/src/field_theory/finite.lean
+++ b/src/field_theory/finite.lean
@@ -156,7 +156,7 @@ namespace char_p
 lemma sum_two_squares (R : Type*) [integral_domain R] (p : ℕ) [fact (0 < p)] [char_p R p] (x : ℤ) :
   ∃ a b : ℕ, (a^2 + b^2 : R) = x :=
 begin
-  haveI := prime_of_pos_char_p_integral_domain R p,
+  haveI := char_is_prime_of_pos R p,
   obtain ⟨a, b, hab⟩ := zmod.sum_two_squares p x,
   refine ⟨a.val, b.val, _⟩,
   have := congr_arg (zmod.cast_hom p R) hab,

--- a/src/field_theory/finite.lean
+++ b/src/field_theory/finite.lean
@@ -153,12 +153,6 @@ end zmod
 
 namespace char_p
 
--- move this
-lemma prime_of_pos_char_p_integral_domain (R : Type*) [integral_domain R]
-  (n : ℕ) [fact (0 < n)] [char_p R n] :
-  fact n.prime :=
-(char_p.char_is_prime_or_zero R _).resolve_right (nat.pos_iff_ne_zero.1 ‹0 < n›)
-
 lemma sum_two_squares (R : Type*) [integral_domain R] (p : ℕ) [fact (0 < p)] [char_p R p] (x : ℤ) :
   ∃ a b : ℕ, (a^2 + b^2 : R) = x :=
 begin

--- a/src/field_theory/finite_card.lean
+++ b/src/field_theory/finite_card.lean
@@ -3,26 +3,30 @@ Copyright (c) 2019 Casper Putz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joey van Langen, Casper Putz
 -/
-import algebra.char_p
+
+import data.zmod.basic
 import linear_algebra.basis
 
 universes u
-variables (α : Type u) [field α] [fintype α]
+variables (K : Type u) [field K] [fintype K]
 
 namespace finite_field
 
-theorem card (p : ℕ) [char_p α p] : ∃ (n : ℕ+), nat.prime p ∧ fintype.card α = p^(n : ℕ) :=
-have hp : nat.prime p, from char_p.char_is_prime α p,
-have V : vector_space (zmodp p hp) α, from {..zmod.to_module' α},
-let ⟨n, h⟩ := @vector_space.card_fintype _ _ _ _ V _ _ in
-have hn : n > 0, from or.resolve_left (nat.eq_zero_or_pos n)
-  (assume h0 : n = 0,
-  have fintype.card α = 1, by rw[←nat.pow_zero (fintype.card _), ←h0]; exact h,
-  have (1 : α) = 0, from (fintype.card_le_one_iff.mp (le_of_eq this)) 1 0,
-  absurd this one_ne_zero),
-⟨⟨n, hn⟩, hp, fintype.card_fin p ▸ h⟩
+theorem card (p : ℕ) [char_p K p] : ∃ (n : ℕ+), nat.prime p ∧ fintype.card K = p^(n : ℕ) :=
+begin
+  haveI hp : fact p.prime := char_p.char_is_prime K p,
+  have V : vector_space (zmod p) K, from { .. (zmod.cast_hom p K).to_module },
+  obtain ⟨n, h⟩ := @vector_space.card_fintype _ _ _ _ V _ _,
+  rw zmod.card at h,
+  refine ⟨⟨n, _⟩, hp, h⟩,
+  apply or.resolve_left (nat.eq_zero_or_pos n),
+  rintro rfl,
+  rw nat.pow_zero at h,
+  have : (0 : K) = 1, { apply fintype.card_le_one_iff.mp (le_of_eq h) },
+  exact absurd this zero_ne_one,
+end
 
-theorem card' : ∃ (p : ℕ) (n : ℕ+), nat.prime p ∧ fintype.card α = p^(n : ℕ) :=
-let ⟨p, hc⟩ := char_p.exists α in ⟨p, @finite_field.card α _ _ p hc⟩
+theorem card' : ∃ (p : ℕ) (n : ℕ+), nat.prime p ∧ fintype.card K = p^(n : ℕ) :=
+let ⟨p, hc⟩ := char_p.exists K in ⟨p, @finite_field.card K _ _ p hc⟩
 
 end finite_field

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl
 -/
 import group_theory.coset
 import data.nat.totient
+import data.set.finite
 open function
 
 variables {α : Type*} {s : set α} {a a₁ a₂ b c: α}

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -6,7 +6,9 @@ Authors: Chris Hughes
 import group_theory.group_action
 import group_theory.quotient_group
 import group_theory.order_of_element
+import data.zmod.basic
 import data.fintype.card
+import data.list.rotate
 
 open equiv fintype finset mul_action function
 open equiv.perm is_subgroup list quotient_group
@@ -31,13 +33,13 @@ begin
 end
 
 lemma card_modeq_card_fixed_points [fintype α] [fintype G] [fintype (fixed_points G α)]
-  {p n : ℕ} (hp : nat.prime p) (h : card G = p ^ n) : card α ≡ card (fixed_points G α) [MOD p] :=
+  (p : ℕ) {n : ℕ} [hp : fact p.prime] (h : card G = p ^ n) : card α ≡ card (fixed_points G α) [MOD p] :=
 calc card α = card (Σ y : quotient (orbit_rel G α), {x // quotient.mk' x = y}) :
   card_congr (sigma_preimage_equiv (@quotient.mk' _ (orbit_rel G α))).symm
 ... = univ.sum (λ a : quotient (orbit_rel G α), card {x // quotient.mk' x = a}) : card_sigma _
 ... ≡ (@univ (fixed_points G α) _).sum (λ _, 1) [MOD p] :
 begin
-  rw [← zmodp.eq_iff_modeq_nat hp, sum_nat_cast, sum_nat_cast],
+  rw [← zmod.eq_iff_modeq_nat p, sum_nat_cast, sum_nat_cast],
   refine eq.symm (sum_bij_ne_zero (λ a _ _, quotient.mk' a.1)
     (λ _ _ _, mem_univ _)
     (λ a₁ a₂ _ _ _ _ h,
@@ -51,12 +53,13 @@ begin
       exact card_quotient_dvd_card _ },
     rcases (nat.dvd_prime_pow hp).1 this with ⟨k, _, hk⟩,
     have hb' :¬ p ^ 1 ∣ p ^ k,
-    { rw [nat.pow_one, ← hk, ← nat.modeq.modeq_zero_iff, ← zmodp.eq_iff_modeq_nat hp,
+    { rw [nat.pow_one, ← hk, ← nat.modeq.modeq_zero_iff, ← zmod.eq_iff_modeq_nat,
         nat.cast_zero, ← ne.def],
       exact eq.mpr (by simp only [quotient.eq']; congr) hb },
     have : k = 0 := nat.le_zero_iff.1 (nat.le_of_lt_succ (lt_of_not_ge (mt (nat.pow_dvd_pow p) hb'))),
-    refine ⟨⟨b, mem_fixed_points_iff_card_orbit_eq_one.2 $ by rw [hk, this, nat.pow_zero]⟩, mem_univ _,
-      by simp [zero_ne_one], rfl⟩ }
+    refine ⟨⟨b, mem_fixed_points_iff_card_orbit_eq_one.2 $ by rw [hk, this, nat.pow_zero]⟩,
+      mem_univ _, _, rfl⟩,
+    rw [nat.cast_one], exact one_ne_zero }
 end
 ... = _ : by simp; refl
 
@@ -96,22 +99,27 @@ lemma mem_vectors_prod_eq_one_iff {n : ℕ} (v : vector G (n + 1)) :
   λ ⟨w, hw⟩, by rw [mem_vectors_prod_eq_one, ← hw, mk_vector_prod_eq_one,
     vector.to_list_cons, list.prod_cons, inv_mul_self]⟩
 
-def rotate_vectors_prod_eq_one (G : Type*) [group G] (n : ℕ+) (m : multiplicative (zmod n))
-  (v : vectors_prod_eq_one G n) : vectors_prod_eq_one G n :=
-⟨⟨v.1.to_list.rotate m.1, by simp⟩, prod_rotate_eq_one_of_prod_eq_one v.2 _⟩
+def rotate_vectors_prod_eq_one (G : Type*) [group G] (n : ℕ) [fact (0 < n)]
+  (m : multiplicative (zmod n)) (v : vectors_prod_eq_one G n) : vectors_prod_eq_one G n :=
+⟨⟨v.1.to_list.rotate m.val, by simp⟩, prod_rotate_eq_one_of_prod_eq_one v.2 _⟩
 
-instance rotate_vectors_prod_eq_one.mul_action (n : ℕ+) :
+instance rotate_vectors_prod_eq_one.mul_action (n : ℕ) [fact (0 < n)] :
   mul_action (multiplicative (zmod n)) (vectors_prod_eq_one G n) :=
 { smul := (rotate_vectors_prod_eq_one G n),
-  one_smul := λ v, subtype.eq $ vector.eq _ _ $ rotate_zero v.1.to_list,
+  one_smul :=
+  begin
+    intro v, apply subtype.eq, apply vector.eq _ _,
+    show rotate _ (0 : zmod n).val = _, rw zmod.val_zero,
+    exact rotate_zero v.1.to_list
+  end,
   mul_smul := λ a b ⟨⟨v, hv₁⟩, hv₂⟩, subtype.eq $ vector.eq _ _ $
     show v.rotate ((a + b : zmod n).val) = list.rotate (list.rotate v (b.val)) (a.val),
-    by rw [zmod.add_val, rotate_rotate, ← rotate_mod _ (b.1 + a.1), add_comm, hv₁] }
+    by rw [zmod.val_add, rotate_rotate, ← rotate_mod _ (b.val + a.val), add_comm, hv₁] }
 
 lemma one_mem_vectors_prod_eq_one (n : ℕ) : vector.repeat (1 : G) n ∈ vectors_prod_eq_one G n :=
 by simp [vector.repeat, vectors_prod_eq_one]
 
-lemma one_mem_fixed_points_rotate (n : ℕ+) :
+lemma one_mem_fixed_points_rotate (n : ℕ) [fact (0 < n)] :
   (⟨vector.repeat (1 : G) n, one_mem_vectors_prod_eq_one n⟩ : vectors_prod_eq_one G n) ∈
   fixed_points (multiplicative (zmod n)) (vectors_prod_eq_one G n) :=
 λ m, subtype.eq $ vector.eq _ _ $
@@ -120,37 +128,36 @@ rotate_eq_self_iff_eq_repeat.2 ⟨(1 : G),
   show list.repeat (1 : G) n = list.repeat 1 (list.repeat (1 : G) n).length, by simp⟩ _
 
 /-- Cauchy's theorem -/
-lemma exists_prime_order_of_dvd_card [fintype G] {p : ℕ} (hp : nat.prime p)
+lemma exists_prime_order_of_dvd_card [fintype G] (p : ℕ) [hp : fact p.prime]
   (hdvd : p ∣ card G) : ∃ x : G, order_of x = p :=
 let n : ℕ+ := ⟨p - 1, nat.sub_pos_of_lt hp.one_lt⟩ in
-let p' : ℕ+ := ⟨p, hp.pos⟩ in
-have hn : p' = n + 1 := subtype.eq (nat.succ_sub hp.pos),
+have hn : p = n + 1 := nat.succ_sub hp.pos,
 have hcard : card (vectors_prod_eq_one G (n + 1)) = card G ^ (n : ℕ),
   by rw [set.ext mem_vectors_prod_eq_one_iff,
     set.card_range_of_injective (mk_vector_prod_eq_one_inj _), card_vector],
-have hzmod : fintype.card (multiplicative (zmod p')) =
-  (p' : ℕ) ^ 1 := (nat.pow_one p').symm ▸ fintype.card_fin _,
+have hzmod : fintype.card (multiplicative (zmod p)) = p ^ 1,
+  by { rw nat.pow_one p, exact zmod.card p },
 have hmodeq : _ = _ := @mul_action.card_modeq_card_fixed_points
-  (multiplicative (zmod p')) (vectors_prod_eq_one G p') _ _ _ _ _ _ 1 hp hzmod,
+  (multiplicative (zmod p)) (vectors_prod_eq_one G p) _ _ _ _ _ _ 1 hp hzmod,
 have hdvdcard : p ∣ fintype.card (vectors_prod_eq_one G (n + 1)) :=
   calc p ∣ card G ^ 1 : by rwa nat.pow_one
   ... ∣ card G ^ (n : ℕ) : nat.pow_dvd_pow _ n.2
   ... = card (vectors_prod_eq_one G (n + 1)) : hcard.symm,
-have hdvdcard₂ : p ∣ card (fixed_points (multiplicative (zmod p')) (vectors_prod_eq_one G p')) :=
-  nat.dvd_of_mod_eq_zero (hmodeq ▸ hn.symm ▸ nat.mod_eq_zero_of_dvd hdvdcard),
-have hcard_pos : 0 < card (fixed_points (multiplicative (zmod p')) (vectors_prod_eq_one G p')) :=
-  fintype.card_pos_iff.2 ⟨⟨⟨vector.repeat 1 p', one_mem_vectors_prod_eq_one _⟩,
+have hdvdcard₂ : p ∣ card (fixed_points (multiplicative (zmod p)) (vectors_prod_eq_one G p)),
+  by { rw nat.dvd_iff_mod_eq_zero at hdvdcard ⊢, rwa [← hn, hmodeq] at hdvdcard },
+have hcard_pos : 0 < card (fixed_points (multiplicative (zmod p)) (vectors_prod_eq_one G p)) :=
+  fintype.card_pos_iff.2 ⟨⟨⟨vector.repeat 1 p, one_mem_vectors_prod_eq_one _⟩,
     one_mem_fixed_points_rotate _⟩⟩,
-have hlt : 1 < card (fixed_points (multiplicative (zmod p')) (vectors_prod_eq_one G p')) :=
-  calc (1 : ℕ) < p' : hp.one_lt
+have hlt : 1 < card (fixed_points (multiplicative (zmod p)) (vectors_prod_eq_one G p)) :=
+  calc (1 : ℕ) < p : hp.one_lt
   ... ≤ _ : nat.le_of_dvd hcard_pos hdvdcard₂,
 let ⟨⟨⟨⟨x, hx₁⟩, hx₂⟩, hx₃⟩, hx₄⟩ := fintype.exists_ne_of_one_lt_card hlt
-  ⟨_, one_mem_fixed_points_rotate p'⟩ in
-have hx : x ≠ list.repeat (1 : G) p', from λ h, by simpa [h, vector.repeat] using hx₄,
+  ⟨_, one_mem_fixed_points_rotate p⟩ in
+have hx : x ≠ list.repeat (1 : G) p, from λ h, by simpa [h, vector.repeat] using hx₄,
 have nG : nonempty G, from ⟨1⟩,
 have ∃ a, x = list.repeat a x.length := by exactI rotate_eq_self_iff_eq_repeat.1 (λ n,
-  have list.rotate x (n : zmod p').val = x :=
-    subtype.mk.inj (subtype.mk.inj (hx₃ (n : zmod p'))),
+  have list.rotate x (n : zmod p).val = x :=
+    subtype.mk.inj (subtype.mk.inj (hx₃ (n : zmod p))),
   by rwa [zmod.val_cast_nat, ← hx₁, rotate_mod] at this),
 let ⟨a, ha⟩ := this in
 ⟨a, have hx1 : x.prod = 1 := hx₂,
@@ -183,7 +190,7 @@ def fixed_points_mul_left_cosets_equiv_quotient (H : set G) [is_subgroup H] [fin
 
 local attribute [instance] set_fintype
 
-lemma exists_subgroup_card_pow_prime [fintype G] {p : ℕ} : ∀ {n : ℕ} (hp : nat.prime p)
+lemma exists_subgroup_card_pow_prime [fintype G] (p : ℕ) : ∀ {n : ℕ} (hp : fact p.prime)
   (hdvd : p ^ n ∣ card G), ∃ H : set G, is_subgroup H ∧ fintype.card H = p ^ n
 | 0 := λ _ _, ⟨trivial G, by apply_instance, by simp⟩
 | (n+1) := λ hp hdvd,
@@ -198,7 +205,7 @@ have hcard : card (quotient H) = s * p :=
       nat.pow_succ, mul_assoc, mul_comm p]),
 have hm : s * p % p = card (quotient (subtype.val ⁻¹' H : set (normalizer H))) % p :=
   card_congr (fixed_points_mul_left_cosets_equiv_quotient H) ▸ hcard ▸
-    card_modeq_card_fixed_points hp hH2,
+    card_modeq_card_fixed_points p hH2,
 have hm' : p ∣ card (quotient (subtype.val ⁻¹' H : set (normalizer H))) :=
   nat.dvd_of_mod_eq_zero
     (by rwa [nat.mod_eq_zero_of_dvd (dvd_mul_left _ _), eq_comm] at hm),

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -195,11 +195,11 @@ def fixed_points_mul_left_cosets_equiv_quotient (H : set G) [is_subgroup H] [fin
 
 local attribute [instance] set_fintype
 
-lemma exists_subgroup_card_pow_prime [fintype G] (p : ℕ) : ∀ {n : ℕ} (hp : fact p.prime)
+lemma exists_subgroup_card_pow_prime [fintype G] (p : ℕ) : ∀ {n : ℕ} [hp : fact p.prime]
   (hdvd : p ^ n ∣ card G), ∃ H : set G, is_subgroup H ∧ fintype.card H = p ^ n
 | 0 := λ _ _, ⟨trivial G, by apply_instance, by simp⟩
 | (n+1) := λ hp hdvd,
-let ⟨H, ⟨hH1, hH2⟩⟩ := exists_subgroup_card_pow_prime hp
+let ⟨H, ⟨hH1, hH2⟩⟩ := @exists_subgroup_card_pow_prime _ hp
   (dvd.trans (nat.pow_dvd_pow _ (nat.le_succ _)) hdvd) in
 let ⟨s, hs⟩ := exists_eq_mul_left_of_dvd hdvd in
 by exactI

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -73,12 +73,15 @@ by rw [← fintype.card_prod, fintype.card_congr
 
 namespace sylow
 
+/-- Given a vector `v` of length `n`, make a vector of length `n+1` whose product is `1`,
+by consing the the inverse of the product of `v`. -/
 def mk_vector_prod_eq_one (n : ℕ) (v : vector G n) : vector G (n+1) :=
 v.to_list.prod⁻¹ :: v
 
 lemma mk_vector_prod_eq_one_inj (n : ℕ) : injective (@mk_vector_prod_eq_one G _ n) :=
 λ ⟨v, _⟩ ⟨w, _⟩ h, subtype.eq (show v = w, by injection h with h; injection h)
 
+/-- The type of vectors with terms from `G`, length `n`, and product equal to `1:G`. -/
 def vectors_prod_eq_one (G : Type*) [group G] (n : ℕ) : set (vector G n) :=
 {v | v.to_list.prod = 1}
 
@@ -99,7 +102,9 @@ lemma mem_vectors_prod_eq_one_iff {n : ℕ} (v : vector G (n + 1)) :
   λ ⟨w, hw⟩, by rw [mem_vectors_prod_eq_one, ← hw, mk_vector_prod_eq_one,
     vector.to_list_cons, list.prod_cons, inv_mul_self]⟩
 
-def rotate_vectors_prod_eq_one (G : Type*) [group G] (n : ℕ) [fact (0 < n)]
+/-- The rotation action of `zmod n` (viewed as multiplicative group) on
+`vectors_prod_eq_one G n`, where `G` is a multiplicative group. -/
+def rotate_vectors_prod_eq_one (G : Type*) [group G] (n : ℕ)
   (m : multiplicative (zmod n)) (v : vectors_prod_eq_one G n) : vectors_prod_eq_one G n :=
 ⟨⟨v.1.to_list.rotate m.val, by simp⟩, prod_rotate_eq_one_of_prod_eq_one v.2 _⟩
 

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -132,6 +132,12 @@ lemma ne_comm {α} {a b : α} : a ≠ b ↔ b ≠ a := ⟨ne.symm, ne.symm⟩
   (∀ {c}, a = c ↔ b = c) ↔ (a = b) :=
 ⟨λ h, by rw h, λ h a, by rw h⟩
 
+/-- Wrapper for adding elementary propositions to the type class systems.
+
+Examples: `fact (prime p)`, `fact (0 < n)`. -/
+@[class]
+def fact (p : Prop) := p
+
 end miscellany
 
 /-!

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -133,8 +133,22 @@ lemma ne_comm {α} {a b : α} : a ≠ b ↔ b ≠ a := ⟨ne.symm, ne.symm⟩
 ⟨λ h, by rw h, λ h a, by rw h⟩
 
 /-- Wrapper for adding elementary propositions to the type class systems.
+Warning: this can easily be abused. See the rest of this docstring for details.
 
-Examples: `fact (prime p)`, `fact (0 < n)`. -/
+Certain propositions should not be treated as a class globally,
+but sometimes it is very convenient to be able to use the type class system
+in specific circumstances.
+
+For example, `zmod p` is a field if and only if `p` is a prime number.
+In order to be able to find this field instance automatically by type class search,
+we have to turn `p.prime` into an instance implicit assumption.
+
+On the other hand, making `nat.prime` a class would require a major refactoring of the library,
+and it is questionable whether making `nat.prime` a class is desirable at all.
+The compromise is to add the assumption `[fact p.prime]` to `zmod.field`.
+
+In particular, this class is not intended for turning the type class system
+into an automated theorem prover for first order logic. -/
 @[class]
 def fact (p : Prop) := p
 

--- a/src/number_theory/sum_four_squares.lean
+++ b/src/number_theory/sum_four_squares.lean
@@ -12,6 +12,7 @@ a proof that every natural number is the sum of four square numbers.
 
 The proof used is close to Lagrange's original proof.
 -/
+import data.zmod.basic
 import field_theory.finite
 import group_theory.perm.sign
 import data.int.parity
@@ -33,12 +34,12 @@ calc 2 * 2 * m = (x - y)^2 + (x + y)^2 : by rw [mul_assoc, h]; ring
 ... = 2 * 2 * (((x - y) / 2) ^ 2 + ((x + y) / 2) ^ 2) :
   by simp [mul_add, _root_.pow_succ, mul_comm, mul_assoc, mul_left_comm]
 
-lemma exists_sum_two_squares_add_one_eq_k {p : ℕ} (hp : p.prime) :
+lemma exists_sum_two_squares_add_one_eq_k (p : ℕ) [hp : fact p.prime] :
   ∃ (a b : ℤ) (k : ℕ), a^2 + b^2 + 1 = k * p ∧ k < p :=
 hp.eq_two_or_odd.elim (λ hp2, hp2.symm ▸ ⟨1, 0, 1, rfl, dec_trivial⟩) $ λ hp1,
-let ⟨a, b, hab⟩ := zmodp.sum_two_squares hp (-1) in
+let ⟨a, b, hab⟩ := zmod.sum_two_squares p (-1) in
 have hab' : (p : ℤ) ∣ a.val_min_abs ^ 2 + b.val_min_abs ^ 2 + 1,
-  from (zmodp.eq_zero_iff_dvd_int hp _).1 $ by simpa [eq_neg_iff_add_eq_zero] using hab,
+  from (char_p.int_cast_eq_zero_iff (zmod p) p _).1 $ by simpa [eq_neg_iff_add_eq_zero] using hab,
 let ⟨k, hk⟩ := hab' in
 have hk0 : 0 ≤ k, from nonneg_of_mul_nonneg_left
   (by rw ← hk; exact (add_nonneg (add_nonneg (pow_two_nonneg _) (pow_two_nonneg _)) zero_le_one))
@@ -53,8 +54,8 @@ have hk0 : 0 ≤ k, from nonneg_of_mul_nonneg_left
       ... ≤ (p / 2) ^ 2 + (p / 2)^2 + 1 :
         add_le_add
           (add_le_add
-            (nat.pow_le_pow_of_le_left (zmodp.nat_abs_val_min_abs_le _) _)
-            (nat.pow_le_pow_of_le_left (zmodp.nat_abs_val_min_abs_le _) _))
+            (nat.pow_le_pow_of_le_left (zmod.nat_abs_val_min_abs_le _) _)
+            (nat.pow_le_pow_of_le_left (zmod.nat_abs_val_min_abs_le _) _))
           (le_refl _)
       ... < (p / 2) ^ 2 + (p / 2)^ 2 + (p % 2)^2 + ((2 * (p / 2)^2 + (4 * (p / 2) * (p % 2)))) :
         by rw [hp1, nat.one_pow, mul_one];
@@ -82,9 +83,9 @@ let ⟨i, hσ⟩ := this (coe ∘ f) (by rw [← @zero_mul (zmod 2) _ m, ← sho
   ← int.cast_mul, ← h]; simp only [int.cast_add, int.cast_pow]; refl) in
 let σ := swap i 0 in
 have h01 : 2 ∣ f (σ 0) ^ 2 + f (σ 1) ^ 2,
-  from (@zmod.eq_zero_iff_dvd_int 2 _).1 $ by simpa [σ] using hσ.1,
+  from (char_p.int_cast_eq_zero_iff (zmod 2) 2 _).1 $ by simpa [σ] using hσ.1,
 have h23 : 2 ∣ f (σ 2) ^ 2 + f (σ 3) ^ 2,
-  from (@zmod.eq_zero_iff_dvd_int 2 _).1 $ by simpa using hσ.2,
+  from (char_p.int_cast_eq_zero_iff (zmod 2) 2 _).1 $ by simpa using hσ.2,
 let ⟨x, hx⟩ := h01 in let ⟨y, hy⟩ := h23 in
 ⟨(f (σ 0) - f (σ 1)) / 2, (f (σ 0) + f (σ 1)) / 2, (f (σ 2) - f (σ 3)) / 2, (f (σ 2) + f (σ 3)) / 2,
   begin
@@ -97,10 +98,10 @@ let ⟨x, hx⟩ := h01 in let ⟨y, hy⟩ := h23 in
     simpa [finset.sum_eq_multiset_sum, fin4univ, multiset.sum_cons, f]
   end⟩
 
-private lemma prime_sum_four_squares {p : ℕ} (hp : p.prime) :
+private lemma prime_sum_four_squares (p : ℕ) [hp : _root_.fact p.prime] :
   ∃ a b c d : ℤ, a^2 + b^2 + c^2 + d^2 = p :=
 have hm : ∃ m < p, 0 < m ∧ ∃ a b c d : ℤ, a^2 + b^2 + c^2 + d^2 = m * p,
-  from let ⟨a, b, k, hk⟩ := exists_sum_two_squares_add_one_eq_k hp in
+  from let ⟨a, b, k, hk⟩ := exists_sum_two_squares_add_one_eq_k p in
   ⟨k, hk.2, nat.pos_of_ne_zero $
     (λ hk0, by rw [hk0, int.coe_nat_zero, zero_mul] at hk;
       exact ne_of_gt (show a^2 + b^2 + 1 > 0, from add_pos_of_nonneg_of_pos
@@ -108,12 +109,12 @@ have hm : ∃ m < p, 0 < m ∧ ∃ a b c d : ℤ, a^2 + b^2 + c^2 + d^2 = m * p,
     a, b, 1, 0, by simpa [_root_.pow_two] using hk.1⟩,
 let m := nat.find hm in
 let ⟨a, b, c, d, (habcd : a^2 + b^2 + c^2 + d^2 = m * p)⟩ := (nat.find_spec hm).snd.2 in
-have hm0 : 0 < m, from (nat.find_spec hm).snd.1,
+by haveI hm0 : _root_.fact (0 < m) := (nat.find_spec hm).snd.1; exact
 have hmp : m < p, from (nat.find_spec hm).fst,
 m.mod_two_eq_zero_or_one.elim
   (λ hm2 : m % 2 = 0,
     let ⟨k, hk⟩ := (nat.dvd_iff_mod_eq_zero _ _).2 hm2 in
-    have hk0 : 0 < k, from nat.pos_of_ne_zero $ λ _, by simp [*, lt_irrefl] at *,
+    have hk0 : 0 < k, from nat.pos_of_ne_zero $ λ _, by { simp [*, lt_irrefl] at *, exact hm0 },
     have hkm : k < m, by rw [hk, two_mul]; exact (lt_add_iff_pos_left _).2 hk0,
     false.elim $ nat.find_min hm hkm ⟨lt_trans hkm hmp, hk0,
       sum_four_squares_of_two_mul_sum_four_squares
@@ -122,9 +123,8 @@ m.mod_two_eq_zero_or_one.elim
   (λ hm2 : m % 2 = 1,
     if hm1 : m = 1 then ⟨a, b, c, d, by simp only [hm1, habcd, int.coe_nat_one, one_mul]⟩
     else --have hm1 : 1 < m, from lt_of_le_of_ne hm0 (ne.symm hm1),
-      let mp : ℕ+ := ⟨m, hm0⟩ in
-      let w := (a : zmod mp).val_min_abs, x := (b : zmod mp).val_min_abs,
-          y := (c : zmod mp).val_min_abs, z := (d : zmod mp).val_min_abs in
+      let w := (a : zmod m).val_min_abs, x := (b : zmod m).val_min_abs,
+          y := (c : zmod m).val_min_abs, z := (d : zmod m).val_min_abs in
       have hnat_abs : w^2 + x^2 + y^2 + z^2 =
           (w.nat_abs^2 + x.nat_abs^2 + y.nat_abs ^2 + z.nat_abs ^ 2 : ℕ),
         by simp [_root_.pow_two],
@@ -144,19 +144,18 @@ m.mod_two_eq_zero_or_one.elim
         ... = m ^ 2 : by conv_rhs {rw [← nat.mod_add_div m 2]};
           simp [-nat.mod_add_div, mul_add, add_mul, bit0, bit1, mul_comm, mul_assoc, mul_left_comm,
             _root_.pow_add, add_comm, add_left_comm],
-      have hwxyzabcd : ((w^2 + x^2 + y^2 + z^2 : ℤ) : zmod mp) =
-          ((a^2 + b^2 + c^2 + d^2 : ℤ) : zmod mp),
+      have hwxyzabcd : ((w^2 + x^2 + y^2 + z^2 : ℤ) : zmod m) =
+          ((a^2 + b^2 + c^2 + d^2 : ℤ) : zmod m),
         by simp [w, x, y, z, pow_two],
-      have hwxyz0 : ((w^2 + x^2 + y^2 + z^2 : ℤ) : zmod mp) = 0,
-        by rw [hwxyzabcd, habcd, int.cast_mul, show ((m : ℤ) : zmod mp) = (mp : zmod mp), from rfl,
-          int.cast_coe_nat, coe_coe, zmod.cast_self_eq_zero]; simp,
-      let ⟨n, hn⟩ := (zmod.eq_zero_iff_dvd_int.1 hwxyz0) in
+      have hwxyz0 : ((w^2 + x^2 + y^2 + z^2 : ℤ) : zmod m) = 0,
+        by rw [hwxyzabcd, habcd, int.cast_mul, cast_coe_nat, zmod.cast_self, zero_mul],
+      let ⟨n, hn⟩ := ((char_p.int_cast_eq_zero_iff _ m _).1 hwxyz0) in
       have hn0 : 0 < n.nat_abs, from int.nat_abs_pos_of_ne_zero (λ hn0,
         have hwxyz0 : (w.nat_abs^2 + x.nat_abs^2 + y.nat_abs^2 + z.nat_abs^2 : ℕ) = 0,
-          by rw [← int.coe_nat_eq_zero, ← hnat_abs]; rwa [hn0, mul_zero] at hn,
+          by { rw [← int.coe_nat_eq_zero, ← hnat_abs], rwa [hn0, mul_zero] at hn },
         have habcd0 : (m : ℤ) ∣ a ∧ (m : ℤ) ∣ b ∧ (m : ℤ) ∣ c ∧ (m : ℤ) ∣ d,
           by simpa [add_eq_zero_iff_eq_zero_of_nonneg (pow_two_nonneg _) (pow_two_nonneg _),
-            nat.pow_two, w, x, y, z, zmod.eq_zero_iff_dvd_int] using hwxyz0,
+            nat.pow_two, w, x, y, z, (char_p.int_cast_eq_zero_iff _ m _)] using hwxyz0,
         let ⟨ma, hma⟩ := habcd0.1,     ⟨mb, hmb⟩ := habcd0.2.1,
             ⟨mc, hmc⟩ := habcd0.2.2.1, ⟨md, hmd⟩ := habcd0.2.2.2 in
         have hmdvdp : m ∣ p,
@@ -164,42 +163,42 @@ m.mod_two_eq_zero_or_one.elim
             (domain.mul_left_inj (show (m : ℤ) ≠ 0, from int.coe_nat_ne_zero_iff_pos.2 hm0)).1 $
               by rw [← habcd, hma, hmb, hmc, hmd]; ring⟩,
         (hp.2 _ hmdvdp).elim hm1 (λ hmeqp, by simpa [lt_irrefl, hmeqp] using hmp)),
-      have hawbxcydz : ((mp : ℕ) : ℤ) ∣ a * w + b * x + c * y + d * z,
-        from zmod.eq_zero_iff_dvd_int.1 $ by rw [← hwxyz0]; simp; ring,
-      have haxbwczdy : ((mp : ℕ) : ℤ) ∣ a * x - b * w - c * z + d * y,
-        from zmod.eq_zero_iff_dvd_int.1 $ by simp [sub_eq_add_neg]; ring,
-      have haybzcwdx : ((mp : ℕ) : ℤ) ∣ a * y + b * z - c * w - d * x,
-        from zmod.eq_zero_iff_dvd_int.1 $ by simp [sub_eq_add_neg]; ring,
-      have hazbycxdw : ((mp : ℕ) : ℤ) ∣ a * z - b * y + c * x - d * w,
-        from zmod.eq_zero_iff_dvd_int.1 $ by simp [sub_eq_add_neg]; ring,
+      have hawbxcydz : ((m : ℕ) : ℤ) ∣ a * w + b * x + c * y + d * z,
+        from (char_p.int_cast_eq_zero_iff (zmod m) m _).1 $ by rw [← hwxyz0]; simp; ring,
+      have haxbwczdy : ((m : ℕ) : ℤ) ∣ a * x - b * w - c * z + d * y,
+        from (char_p.int_cast_eq_zero_iff (zmod m) m _).1 $ by simp [sub_eq_add_neg]; ring,
+      have haybzcwdx : ((m : ℕ) : ℤ) ∣ a * y + b * z - c * w - d * x,
+        from (char_p.int_cast_eq_zero_iff (zmod m) m _).1 $ by simp [sub_eq_add_neg]; ring,
+      have hazbycxdw : ((m : ℕ) : ℤ) ∣ a * z - b * y + c * x - d * w,
+        from (char_p.int_cast_eq_zero_iff (zmod m) m _).1 $ by simp [sub_eq_add_neg]; ring,
       let ⟨s, hs⟩ := hawbxcydz, ⟨t, ht⟩ := haxbwczdy, ⟨u, hu⟩ := haybzcwdx, ⟨v, hv⟩ := hazbycxdw in
       have hn_nonneg : 0 ≤ n,
         from nonneg_of_mul_nonneg_left
           (by erw [← hn]; repeat {try {refine add_nonneg _ _}, try {exact pow_two_nonneg _}})
           (int.coe_nat_pos.2 hm0),
-      have hnm : n.nat_abs < mp,
+      have hnm : n.nat_abs < m,
         from int.coe_nat_lt.1 (lt_of_mul_lt_mul_left
           (by rw [int.nat_abs_of_nonneg hn_nonneg, ← hn, ← _root_.pow_two]; exact hwxyzlt)
-          (int.coe_nat_nonneg mp)),
+          (int.coe_nat_nonneg m)),
       have hstuv : s^2 + t^2 + u^2 + v^2 = n.nat_abs * p,
         from (domain.mul_left_inj (show (m^2 : ℤ) ≠ 0, from pow_ne_zero 2
             (int.coe_nat_ne_zero_iff_pos.2 hm0))).1 $
-          calc (m : ℤ)^2 * (s^2 + t^2 + u^2 + v^2) = ((mp : ℕ) * s)^2 + ((mp : ℕ) * t)^2 +
-              ((mp : ℕ) * u)^2 + ((mp : ℕ) * v)^2 :
-            by simp [mp]; ring
+          calc (m : ℤ)^2 * (s^2 + t^2 + u^2 + v^2) = ((m : ℕ) * s)^2 + ((m : ℕ) * t)^2 +
+              ((m : ℕ) * u)^2 + ((m : ℕ) * v)^2 :
+            by simp; ring
           ... = (w^2 + x^2 + y^2 + z^2) * (a^2 + b^2 + c^2 + d^2) :
             by simp only [hs.symm, ht.symm, hu.symm, hv.symm]; ring
-          ... = _ : by rw [hn, habcd, int.nat_abs_of_nonneg hn_nonneg]; dsimp [mp]; ring,
+          ... = _ : by rw [hn, habcd, int.nat_abs_of_nonneg hn_nonneg]; dsimp [m]; ring,
       false.elim $ nat.find_min hm hnm ⟨lt_trans hnm hmp, hn0, s, t, u, v, hstuv⟩)
 
 lemma sum_four_squares : ∀ n : ℕ, ∃ a b c d : ℕ, a^2 + b^2 + c^2 + d^2 = n
 | 0 := ⟨0, 0, 0, 0, rfl⟩
 | 1 := ⟨1, 0, 0, 0, rfl⟩
 | n@(k+2) :=
-have hm : (min_fac n).prime := min_fac_prime dec_trivial,
+have hm : _root_.fact (min_fac (k+2)).prime := min_fac_prime dec_trivial,
 have n / min_fac n < n := factors_lemma,
 let ⟨a, b, c, d, h₁⟩ := show ∃ a b c d : ℤ, a^2 + b^2 + c^2 + d^2 = min_fac n,
-  from prime_sum_four_squares hm in
+  by exactI prime_sum_four_squares (min_fac (k+2)) in
 let ⟨w, x, y, z, h₂⟩ := sum_four_squares (n / min_fac n) in
 ⟨(a * x - b * w - c * z + d * y).nat_abs,
  (a * y + b * z - c * w - d * x).nat_abs,

--- a/src/number_theory/sum_two_squares.lean
+++ b/src/number_theory/sum_two_squares.lean
@@ -18,10 +18,10 @@ namespace prime
 
 /-- Fermat's theorem on the sum of two squares. Every prime congruent to 1 mod 4 is the sum
 of two squares -/
-lemma sum_two_squares {p : ℕ} (hp : p.prime) (hp1 : p % 4 = 1) :
+lemma sum_two_squares (p : ℕ) [hp : _root_.fact p.prime] (hp1 : p % 4 = 1) :
   ∃ a b : ℕ, a ^ 2 + b ^ 2 = p :=
-sum_two_squares_of_nat_prime_of_not_irreducible hp
-  (by rw [irreducible_iff_prime, prime_iff_mod_four_eq_three_of_nat_prime hp, hp1]; norm_num)
+sum_two_squares_of_nat_prime_of_not_irreducible p
+  (by rw [irreducible_iff_prime, prime_iff_mod_four_eq_three_of_nat_prime p, hp1]; norm_num)
 
 end prime
 end nat


### PR DESCRIPTION
This PR introduces the class `fact P := P` for `P : Prop`, which is a way to inject elementary propositions into the type class system. This desing is inspired by @cipher1024 's https://gist.github.com/cipher1024/9bd785a75384a4870b331714ec86ad6f#file-zmod_redesign-lean.

We use this to endow `zmod p` with a `field` instance under the assumption `[fact p.prime]`.
As a consequence, the type `zmodp` is no longer needed, which removes a lot of duplicate code.
Besides that, we redefine `zmod n`, so that `n` is a natural number instead of a *positive* natural number, and `zmod 0` is now definitionally the integers.
To preserve computational properties, `zmod n` is not defined as quotient type, but rather as `int` and `fin n`, depending on whether `n` is `0` or `(k+1)`.

The rest of this PR is adapting the library to the new definitions (most notably quadratic reciprocity and Lagrange's four squares theorem).

Future work: Refactor the padics to use `[fact p.prime]` instead of making `nat.prime` a class in those files. This will address #1601 and #1648. Once that is done, we can clean up the mess in `char_p` (where the imports are really tangled) and finally get some movement in #1564.

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
