### PR TITLE
[Merged by Bors] - docs(*): merge rewrite tactic tag into rewriting

### DIFF
--- a/src/tactic/converter/apply_congr.lean
+++ b/src/tactic/converter/apply_congr.lean
@@ -94,7 +94,7 @@ add_tactic_doc {
   name := "apply_congr",
   category := doc_category.tactic,
   decl_names := [`conv.interactive.apply_congr],
-  tags := ["conv", "congruence", "rewrite"]
+  tags := ["conv", "congruence", "rewriting"]
 }
 
 end conv.interactive

--- a/src/tactic/elide.lean
+++ b/src/tactic/elide.lean
@@ -82,7 +82,7 @@ add_tactic_doc
 { name        := "elide / unelide",
   category    := doc_category.tactic,
   decl_names  := [`tactic.interactive.elide, `tactic.interactive.unelide],
-  tags        := ["goal management", "context management", "rewrite"] }
+  tags        := ["goal management", "context management", "rewriting"] }
 
 end interactive
 

--- a/src/tactic/ext.lean
+++ b/src/tactic/ext.lean
@@ -396,6 +396,6 @@ add_tactic_doc
 { name        := "ext1 / ext",
   category    := doc_category.tactic,
   decl_names  := [`tactic.interactive.ext1, `tactic.interactive.ext],
-  tags        := ["rewrite", "logic"] }
+  tags        := ["rewriting", "logic"] }
 
 end tactic

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -42,7 +42,7 @@ add_tactic_doc
 { name       := "substs",
   category   := doc_category.tactic,
   decl_names := [`tactic.interactive.substs],
-  tags       := ["rewrite"] }
+  tags       := ["rewriting"] }
 
 /-- Unfold coercion-related definitions -/
 meta def unfold_coes (loc : parse location) : tactic unit :=

--- a/src/tactic/lean_core_docs.lean
+++ b/src/tactic/lean_core_docs.lean
@@ -576,13 +576,13 @@ add_tactic_doc
 { name       := "subst",
   category   := doc_category.tactic,
   decl_names := [`tactic.interactive.subst],
-  tags       := ["core", "rewrite"] }
+  tags       := ["core", "rewriting"] }
 
 add_tactic_doc
 { name       := "subst_vars",
   category   := doc_category.tactic,
   decl_names := [`tactic.interactive.subst_vars],
-  tags       := ["core", "rewrite"] }
+  tags       := ["core", "rewriting"] }
 
 add_tactic_doc
 { name       := "success_if_fail",

--- a/src/tactic/rewrite.lean
+++ b/src/tactic/rewrite.lean
@@ -207,7 +207,7 @@ add_tactic_doc
 { name                     := "assoc_rewrite",
   category                 := doc_category.tactic,
   decl_names               := [`tactic.interactive.assoc_rewrite, `tactic.interactive.assoc_rw],
-  tags                     := ["rewrite"],
+  tags                     := ["rewriting"],
   inherit_description_from := `tactic.interactive.assoc_rewrite }
 
 end interactive


### PR DESCRIPTION
We had two overlapping tags in the docs.

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
