### PR TITLE
[Merged by Bors] - feat(data/fin): add some lemmas about coercions

### DIFF
--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -106,36 +106,45 @@ iff.rfl
 @[norm_cast, simp] lemma coe_fin_le {n : ℕ} {a b : fin n} : (a : ℕ) ≤ (b : ℕ) ↔ a ≤ b :=
 iff.rfl
 
-/-- Converting an in-range number to `fin (n + 1)` with `of_nat`
-produces a result whose value is the original number.  -/
-lemma of_nat_val_of_lt {n : ℕ} {a : ℕ} (h : a < n + 1) :
-  ((of_nat a) : fin (n + 1)).val = a :=
-nat.mod_eq_of_lt h
+lemma val_add {n : ℕ} : ∀ a b : fin n, (a + b).val = (a.val + b.val) % n
+| ⟨_, _⟩ ⟨_, _⟩ := rfl
 
-/-- Converting the value of a `fin (n + 1)` to `fin (n + 1)` with `of_nat`
-results in the same value.  -/
-@[simp] lemma of_nat_val_eq_self {n : ℕ} (a : fin (n + 1)) : of_nat a.val = a :=
+@[simp]
+lemma of_nat_eq_coe (n : ℕ) (a : ℕ) : (of_nat a : fin (n+1)) = a :=
 begin
-  rw eq_iff_veq,
-  exact of_nat_val_of_lt a.is_lt
+  induction a with a ih, { refl },
+  ext, show (a+1) % (n+1) = fin.val (a+1 : fin (n+1)),
+  { rw [val_add, ← ih, of_nat],
+    exact add_mod _ _ _ }
 end
 
-/-- `of_nat` of an in-range number, converted back to `ℕ`, is that
-number. -/
-lemma of_nat_coe_of_lt {n : ℕ} {a : ℕ} (h : a < n + 1) :
-  (((of_nat a) : fin (n + 1)) : ℕ) = a :=
-nat.mod_eq_of_lt h
+/-- Converting an in-range number to `fin (n + 1)` produces a result
+whose value is the original number.  -/
+lemma coe_val_of_lt {n : ℕ} {a : ℕ} (h : a < n + 1) :
+  (a : fin (n + 1)).val = a :=
+begin
+  rw ←of_nat_eq_coe,
+  exact nat.mod_eq_of_lt h
+end
 
-/-- Converting a `fin (n + 1)` to `ℕ` and back with `of_nat` results in
-the same value. -/
-@[simp] lemma of_nat_coe_eq_self {n : ℕ} (a : fin (n + 1)) : of_nat (a : ℕ) = a :=
-of_nat_val_eq_self a
+/-- Converting the value of a `fin (n + 1)` to `fin (n + 1)` results
+in the same value.  -/
+@[simp] lemma coe_val_eq_self {n : ℕ} (a : fin (n + 1)) : (a.val : fin (n + 1)) = a :=
+begin
+  rw fin.eq_iff_veq,
+  exact coe_val_of_lt a.is_lt
+end
 
-attribute [simp] of_nat_zero
+/-- Coercing an in-range number to `fin (n + 1)`, and converting back
+to `ℕ`, results in that number. -/
+lemma coe_coe_of_lt {n : ℕ} {a : ℕ} (h : a < n + 1) :
+  ((a : fin (n + 1)) : ℕ) = a :=
+coe_val_of_lt h
 
-/-- `of_nat 1` is `1 : fin (n + 1)`. -/
-@[simp] lemma of_nat_one {n : ℕ} : (of_nat 1 : fin (n + 1)) = 1 :=
-rfl
+/-- Converting a `fin (n + 1)` to `ℕ` and back results in the same
+value. -/
+@[simp] lemma coe_coe_eq_self {n : ℕ} (a : fin (n + 1)) : ((a : ℕ) : fin (n + 1)) = a :=
+coe_val_eq_self a
 
 /-- Assume `k = l`. If two functions defined on `fin k` and `fin l` are equal on each element,
 then they coincide (in the heq sense). -/

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -99,7 +99,7 @@ attribute [simp] val_zero
 @[simp] lemma coe_two  {n : ℕ} : ((2 : fin (n+3)) : ℕ) = 2 := rfl
 
 /-- `a < b` as natural numbers if and only if `a < b` in `fin n`. -/
-@[norm_cast] lemma coe_fin_lt {n : ℕ} {a b : fin n} : (a : ℕ) < (b : ℕ) ↔ a < b :=
+@[norm_cast, simp] lemma coe_fin_lt {n : ℕ} {a b : fin n} : (a : ℕ) < (b : ℕ) ↔ a < b :=
 iff.rfl
 
 /-- `a ≤ b` as natural numbers if and only if `a ≤ b` in `fin n`. -/

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -132,7 +132,7 @@ the same value. -/
 of_nat_val_eq_self a
 
 /-- `of_nat 0`, converted to `ℕ`, is 0. -/
-lemma of_nat_coe_zero {n : ℕ} : (((of_nat 0) : fin (n + 1)) : ℕ) = 0 :=
+@[simp] lemma of_nat_coe_zero {n : ℕ} : (((of_nat 0) : fin (n + 1)) : ℕ) = 0 :=
 rfl
 
 /-- Assume `k = l`. If two functions defined on `fin k` and `fin l` are equal on each element,

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -109,6 +109,13 @@ iff.rfl
 lemma val_add {n : ℕ} : ∀ a b : fin n, (a + b).val = (a.val + b.val) % n
 | ⟨_, _⟩ ⟨_, _⟩ := rfl
 
+lemma val_mul {n : ℕ} :  ∀ a b : fin n, (a * b).val = (a.val * b.val) % n
+| ⟨_, _⟩ ⟨_, _⟩ := rfl
+
+lemma one_val {n : ℕ} : (1 : fin (n+1)).val = 1 % (n+1) := rfl
+
+@[simp] lemma zero_val (n : ℕ) : (0 : fin (n+1)).val = 0 := rfl
+
 @[simp]
 lemma of_nat_eq_coe (n : ℕ) (a : ℕ) : (of_nat a : fin (n+1)) = a :=
 begin

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -131,8 +131,10 @@ the same value. -/
 @[simp] lemma of_nat_coe_eq_self {n : ℕ} (a : fin (n + 1)) : of_nat (a : ℕ) = a :=
 of_nat_val_eq_self a
 
-/-- `of_nat 0`, converted to `ℕ`, is 0. -/
-@[simp] lemma of_nat_coe_zero {n : ℕ} : (((of_nat 0) : fin (n + 1)) : ℕ) = 0 :=
+attribute [simp] of_nat_zero
+
+/-- `of_nat 1` is `1 : fin (n + 1)`. -/
+@[simp] lemma of_nat_one {n : ℕ} : (of_nat 1 : fin (n + 1)) = 1 :=
 rfl
 
 /-- Assume `k = l`. If two functions defined on `fin k` and `fin l` are equal on each element,

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -114,7 +114,7 @@ nat.mod_eq_of_lt h
 
 /-- Converting the value of a `fin (n + 1)` to `fin (n + 1)` with `of_nat`
 results in the same value.  -/
-lemma of_nat_val_eq_self {n : ℕ} (a : fin (n + 1)) : of_nat a.val = a :=
+@[simp] lemma of_nat_val_eq_self {n : ℕ} (a : fin (n + 1)) : of_nat a.val = a :=
 begin
   rw eq_iff_veq,
   exact of_nat_val_of_lt a.is_lt

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -103,7 +103,7 @@ attribute [simp] val_zero
 iff.rfl
 
 /-- `a ≤ b` as natural numbers if and only if `a ≤ b` in `fin n`. -/
-@[norm_cast] lemma coe_fin_le {n : ℕ} {a b : fin n} : (a : ℕ) ≤ (b : ℕ) ↔ a ≤ b :=
+@[norm_cast, simp] lemma coe_fin_le {n : ℕ} {a b : fin n} : (a : ℕ) ≤ (b : ℕ) ↔ a ≤ b :=
 iff.rfl
 
 /-- Converting an in-range number to `fin (n + 1)` with `of_nat`

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -128,7 +128,7 @@ nat.mod_eq_of_lt h
 
 /-- Converting a `fin (n + 1)` to `ℕ` and back with `of_nat` results in
 the same value. -/
-lemma of_nat_coe_eq_self {n : ℕ} (a : fin (n + 1)) : of_nat (a : ℕ) = a :=
+@[simp] lemma of_nat_coe_eq_self {n : ℕ} (a : fin (n + 1)) : of_nat (a : ℕ) = a :=
 of_nat_val_eq_self a
 
 /-- `of_nat 0`, converted to `ℕ`, is 0. -/

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -106,15 +106,15 @@ iff.rfl
 @[norm_cast] lemma coe_fin_le {n : ℕ} {a b : fin n} : (a : ℕ) ≤ (b : ℕ) ↔ a ≤ b :=
 iff.rfl
 
-/-- Converting an in-range number to `fin (succ n)` with `of_nat`
+/-- Converting an in-range number to `fin (n + 1)` with `of_nat`
 produces a result whose value is the original number.  -/
-lemma of_nat_val_of_lt {n : ℕ} {a : ℕ} (h : a < nat.succ n) :
-  ((of_nat a) : fin (nat.succ n)).val = a :=
+lemma of_nat_val_of_lt {n : ℕ} {a : ℕ} (h : a < n + 1) :
+  ((of_nat a) : fin (n + 1)).val = a :=
 nat.mod_eq_of_lt h
 
-/-- Converting the value of a `fin (succ n)` to `fin (succ n)` with `of_nat`
+/-- Converting the value of a `fin (n + 1)` to `fin (n + 1)` with `of_nat`
 results in the same value.  -/
-lemma of_nat_val_eq_self {n : ℕ} (a : fin (nat.succ n)) : of_nat a.val = a :=
+lemma of_nat_val_eq_self {n : ℕ} (a : fin (n + 1)) : of_nat a.val = a :=
 begin
   rw eq_iff_veq,
   exact of_nat_val_of_lt a.is_lt
@@ -122,17 +122,17 @@ end
 
 /-- `of_nat` of an in-range number, converted back to `ℕ`, is that
 number. -/
-lemma of_nat_coe_of_lt {n : ℕ} {a : ℕ} (h : a < nat.succ n) :
-  (((of_nat a) : fin (nat.succ n)) : ℕ) = a :=
+lemma of_nat_coe_of_lt {n : ℕ} {a : ℕ} (h : a < n + 1) :
+  (((of_nat a) : fin (n + 1)) : ℕ) = a :=
 nat.mod_eq_of_lt h
 
-/-- Converting a `fin (succ n)` to `ℕ` and back with `of_nat` results in
+/-- Converting a `fin (n + 1)` to `ℕ` and back with `of_nat` results in
 the same value. -/
-lemma of_nat_coe_eq_self {n : ℕ} (a : fin (nat.succ n)) : of_nat (a : ℕ) = a :=
+lemma of_nat_coe_eq_self {n : ℕ} (a : fin (n + 1)) : of_nat (a : ℕ) = a :=
 of_nat_val_eq_self a
 
 /-- `of_nat 0`, converted to `ℕ`, is 0. -/
-lemma of_nat_coe_zero {n : ℕ} : (((of_nat 0) : fin (nat.succ n)) : ℕ) = 0 :=
+lemma of_nat_coe_zero {n : ℕ} : (((of_nat 0) : fin (n + 1)) : ℕ) = 0 :=
 rfl
 
 /-- Assume `k = l`. If two functions defined on `fin k` and `fin l` are equal on each element,

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -98,6 +98,43 @@ attribute [simp] val_zero
 @[simp] lemma coe_one  {n : ℕ} : ((1 : fin (n+2)) : ℕ) = 1 := rfl
 @[simp] lemma coe_two  {n : ℕ} : ((2 : fin (n+3)) : ℕ) = 2 := rfl
 
+/-- `a < b` as natural numbers if and only if `a < b` in `fin n`. -/
+@[norm_cast] lemma coe_fin_lt {n : ℕ} {a b : fin n} : (a : ℕ) < (b : ℕ) ↔ a < b :=
+iff.rfl
+
+/-- `a ≤ b` as natural numbers if and only if `a ≤ b` in `fin n`. -/
+@[norm_cast] lemma coe_fin_le {n : ℕ} {a b : fin n} : (a : ℕ) ≤ (b : ℕ) ↔ a ≤ b :=
+iff.rfl
+
+/-- Converting an in-range number to `fin (succ n)` with `of_nat`
+produces a result whose value is the original number.  -/
+lemma of_nat_val_of_lt {n : ℕ} {a : ℕ} (h : a < nat.succ n) :
+  ((of_nat a) : fin (nat.succ n)).val = a :=
+nat.mod_eq_of_lt h
+
+/-- Converting the value of a `fin (succ n)` to `fin (succ n)` with `of_nat`
+results in the same value.  -/
+lemma of_nat_val_eq_self {n : ℕ} (a : fin (nat.succ n)) : of_nat a.val = a :=
+begin
+  rw eq_iff_veq,
+  exact of_nat_val_of_lt a.is_lt
+end
+
+/-- `of_nat` of an in-range number, converted back to `ℕ`, is that
+number. -/
+lemma of_nat_coe_of_lt {n : ℕ} {a : ℕ} (h : a < nat.succ n) :
+  (((of_nat a) : fin (nat.succ n)) : ℕ) = a :=
+nat.mod_eq_of_lt h
+
+/-- Converting a `fin (succ n)` to `ℕ` and back with `of_nat` results in
+the same value. -/
+lemma of_nat_coe_eq_self {n : ℕ} (a : fin (nat.succ n)) : of_nat (a : ℕ) = a :=
+of_nat_val_eq_self a
+
+/-- `of_nat 0`, converted to `ℕ`, is 0. -/
+lemma of_nat_coe_zero {n : ℕ} : (((of_nat 0) : fin (nat.succ n)) : ℕ) = 0 :=
+rfl
+
 /-- Assume `k = l`. If two functions defined on `fin k` and `fin l` are equal on each element,
 then they coincide (in the heq sense). -/
 protected lemma heq_fun_iff {α : Type*} {k l : ℕ} (h : k = l) {f : fin k → α} {g : fin l → α} :

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -606,6 +606,16 @@ by rw [←nat.mod_add_div a c, ←nat.mod_add_div b c, ←h, ←nat.sub_sub, nat
 lemma dvd_sub_mod (k : ℕ) : n ∣ (k - (k % n)) :=
 ⟨k / n, nat.sub_eq_of_eq_add (nat.mod_add_div k n).symm⟩
 
+lemma add_mod (a b n : ℕ) : (a + b) % n = ((a % n) + (b % n)) % n :=
+begin
+  conv
+  begin
+    to_lhs,
+    rw [←mod_add_div a n, ←mod_add_div b n, ←add_assoc, add_mul_mod_self_left,
+        add_assoc, add_comm _ (b % n), ←add_assoc, add_mul_mod_self_left]
+  end
+end
+
 theorem add_pos_left {m : ℕ} (h : 0 < m) (n : ℕ) : 0 < m + n :=
 calc
   m + n > 0 + n : nat.add_lt_add_right h n

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -613,6 +613,14 @@ begin
         add_assoc, add_comm _ (b % n), ←add_assoc, add_mul_mod_self_left] }
 end
 
+lemma mul_mod (a b n : ℕ) : (a * b) % n = ((a % n) * (b % n)) % n :=
+begin
+  conv_lhs {
+    rw [←mod_add_div a n, ←mod_add_div b n, right_distrib, left_distrib, left_distrib,
+        mul_assoc, mul_assoc, ←left_distrib n _ _, add_mul_mod_self_left,
+        mul_comm _ (n * (b / n)), mul_assoc, add_mul_mod_self_left] }
+end
+
 theorem add_pos_left {m : ℕ} (h : 0 < m) (n : ℕ) : 0 < m + n :=
 calc
   m + n > 0 + n : nat.add_lt_add_right h n

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -608,12 +608,9 @@ lemma dvd_sub_mod (k : ℕ) : n ∣ (k - (k % n)) :=
 
 lemma add_mod (a b n : ℕ) : (a + b) % n = ((a % n) + (b % n)) % n :=
 begin
-  conv
-  begin
-    to_lhs,
+  conv_lhs {
     rw [←mod_add_div a n, ←mod_add_div b n, ←add_assoc, add_mul_mod_self_left,
-        add_assoc, add_comm _ (b % n), ←add_assoc, add_mul_mod_self_left]
-  end
+        add_assoc, add_comm _ (b % n), ←add_assoc, add_mul_mod_self_left] }
 end
 
 theorem add_pos_left {m : ℕ} (h : 0 < m) (n : ℕ) : 0 < m + n :=

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -124,9 +124,6 @@ end)
 
 end modeq
 
-lemma mul_mod (a b n : ℕ) : (a * b) % n = ((a % n) * (b % n)) % n :=
-(nat.modeq.modeq_mul (nat.modeq.mod_modeq a n) (nat.modeq.mod_modeq b n)).symm
-
 @[simp] lemma mod_mul_right_mod (a b c : ℕ) : a % (b * c) % b = a % b :=
 modeq.modeq_of_modeq_mul_right _ (modeq.mod_modeq _ _)
 

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -124,9 +124,6 @@ end)
 
 end modeq
 
-lemma add_mod (a b n : ℕ) : (a + b) % n = ((a % n) + (b % n)) % n :=
-(nat.modeq.modeq_add (nat.modeq.mod_modeq a n) (nat.modeq.mod_modeq b n)).symm
-
 lemma mul_mod (a b n : ℕ) : (a * b) % n = ((a % n) * (b % n)) % n :=
 (nat.modeq.modeq_mul (nat.modeq.mod_modeq a n) (nat.modeq.mod_modeq b n)).symm
 

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -73,9 +73,6 @@ def comm_semigroup (n : ℕ) : comm_semigroup (fin (n+1)) :=
 
 local attribute [instance] fin.add_comm_semigroup fin.comm_semigroup
 
-lemma val_add {n : ℕ} : ∀ a b : fin n, (a + b).val = (a.val + b.val) % n
-| ⟨_, _⟩ ⟨_, _⟩ := rfl
-
 lemma val_mul {n : ℕ} :  ∀ a b : fin n, (a * b).val = (a.val * b.val) % n
 | ⟨_, _⟩ ⟨_, _⟩ := rfl
 
@@ -125,15 +122,6 @@ def comm_ring (n : ℕ) : comm_ring (fin (n+1)) :=
   ..fin.comm_semigroup n }
 
 local attribute [instance] fin.add_comm_semigroup
-
-@[simp]
-lemma of_nat_eq_coe (n : ℕ) (a : ℕ) : (of_nat a : fin (n+1)) = a :=
-begin
-  induction a with a ih, { refl },
-  ext, show (a+1) % (n+1) = fin.val (a+1 : fin (n+1)),
-  { rw [fin.val_add, ← ih, of_nat],
-    exact nat.add_mod _ _ _ }
-end
 
 end fin
 

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -73,13 +73,6 @@ def comm_semigroup (n : ℕ) : comm_semigroup (fin (n+1)) :=
 
 local attribute [instance] fin.add_comm_semigroup fin.comm_semigroup
 
-lemma val_mul {n : ℕ} :  ∀ a b : fin n, (a * b).val = (a.val * b.val) % n
-| ⟨_, _⟩ ⟨_, _⟩ := rfl
-
-lemma one_val {n : ℕ} : (1 : fin (n+1)).val = 1 % (n+1) := rfl
-
-@[simp] lemma zero_val (n : ℕ) : (0 : fin (n+1)).val = 0 := rfl
-
 private lemma one_mul_aux (n : ℕ) (a : fin (n+1)) : (1 : fin (n+1)) * a = a :=
 begin
   cases n with n,
@@ -120,8 +113,6 @@ def comm_ring (n : ℕ) : comm_ring (fin (n+1)) :=
   ..fin.has_neg (n+1),
   ..fin.add_comm_semigroup n,
   ..fin.comm_semigroup n }
-
-local attribute [instance] fin.add_comm_semigroup
 
 end fin
 


### PR DESCRIPTION
Two of these lemmas allow norm_cast to work with inequalities
involving fin values converted to ℕ.  The rest are for simplifying
expressions where coercions are used to convert from ℕ to fin, in
cases where an inequality means those coercions do not in fact change
the value.

There are very few lemmas relating to coercions from ℕ to fin in
mathlib at present; the lemma of_nat_eq_coe (and val_add on which it
depends, and a few similarly trivial lemmas alongside val_add) is
moved from data.zmod.basic to fin.basic for use in proving the other
lemmas, while the nat lemma add_mod is moved to data.nat.basic for use
in the proof of of_nat_eq_coe, and mul_mod is moved alongside it as
suggested in review.  These lemmas were found useful in formalising
solutions to an olympiad problem, see
<https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Some.20olympiad.20formalisations>,
and seem more generally relevant than to just that particular problem.


TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
