### PR TITLE
[Merged by Bors] - feat(data/bool): add de Morgan's laws

### DIFF
--- a/src/data/bool.lean
+++ b/src/data/bool.lean
@@ -13,6 +13,9 @@ relation to decidable propositions.
 ## Notations
 
 This file introduces the notation `!b` for `bnot b`, the boolean "not".
+
+## Tags
+bool, boolean, De Morgan
 -/
 
 prefix `!`:90 := bnot

--- a/src/data/bool.lean
+++ b/src/data/bool.lean
@@ -137,6 +137,6 @@ lemma bxor_iff_ne : ∀ {x y : bool}, bxor x y = tt ↔ x ≠ y := dec_trivial
 
 @[simp] lemma bnot_band : ∀ (a b : bool), !(a && b) = !a || !b := dec_trivial
 @[simp] lemma bnot_bor : ∀ (a b : bool), !(a || b) = !a && !b := dec_trivial
-lemma bnot_inj : ∀ {a b : bool}, bnot a = bnot b → a = b := dec_trivial
+lemma bnot_inj : ∀ {a b : bool}, !a = !b → a = b := dec_trivial
 
 end bool

--- a/src/data/bool.lean
+++ b/src/data/bool.lean
@@ -135,8 +135,10 @@ theorem bxor_left_comm : ∀ a b c, bxor a (bxor b c) = bxor b (bxor a c) := dec
 
 lemma bxor_iff_ne : ∀ {x y : bool}, bxor x y = tt ↔ x ≠ y := dec_trivial
 
+/-! ### De Morgan's laws for booleans-/
 @[simp] lemma bnot_band : ∀ (a b : bool), !(a && b) = !a || !b := dec_trivial
 @[simp] lemma bnot_bor : ∀ (a b : bool), !(a || b) = !a && !b := dec_trivial
+
 lemma bnot_inj : ∀ {a b : bool}, bnot a = bnot b → a = b := dec_trivial
 
 end bool

--- a/src/data/bool.lean
+++ b/src/data/bool.lean
@@ -4,6 +4,17 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Leonardo de Moura, Jeremy Avigad
 -/
 
+/-!
+# booleans
+
+This file proves various trivial lemmas about booleans and their
+relation to decidable propositions.
+
+## Notations
+
+This file introduces the notation `!b` for `bnot b`, the boolean "not".
+-/
+
 prefix `!`:90 := bnot
 
 namespace bool
@@ -61,9 +72,11 @@ theorem exists_bool {p : bool → Prop} : (∃ b, p b) ↔ p ff ∨ p tt :=
 ⟨λ ⟨b, h⟩, by cases b; [exact or.inl h, exact or.inr h],
  λ h, by cases h; exact ⟨_, h⟩⟩
 
+/-- If `p b` is decidable for all `b : bool`, then `∀ b, p b` is decidable -/
 instance decidable_forall_bool {p : bool → Prop} [∀ b, decidable (p b)] : decidable (∀ b, p b) :=
 decidable_of_decidable_of_iff and.decidable forall_bool.symm
 
+/-- If `p b` is decidable for all `b : bool`, then `∃ b, p b` is decidable -/
 instance decidable_exists_bool {p : bool → Prop} [∀ b, decidable (p b)] : decidable (∃ b, p b) :=
 decidable_of_decidable_of_iff or.decidable exists_bool.symm
 

--- a/src/data/bool.lean
+++ b/src/data/bool.lean
@@ -122,4 +122,8 @@ theorem bxor_left_comm : ∀ a b c, bxor a (bxor b c) = bxor b (bxor a c) := dec
 
 lemma bxor_iff_ne : ∀ {x y : bool}, bxor x y = tt ↔ x ≠ y := dec_trivial
 
+@[simp] lemma bnot_band : ∀ (a b : bool), !(a && b) = !a || !b := dec_trivial
+@[simp] lemma bnot_bor : ∀ (a b : bool), !(a || b) = !a && !b := dec_trivial
+lemma bnot_inj : ∀ {a b : bool}, bnot a = bnot b → a = b := dec_trivial
+
 end bool


### PR DESCRIPTION
I will go away with my tail between my legs if someone can show me that our esteemed mathematics library already contains de Morgan's laws for booleans. I also added a docstring. I can't lint the file because it's so high up in the import heirarchy, but I also added a docstring for the two instances.

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
