### PR TITLE
[Merged by Bors] - feat(analysis/calculus/deriv): define `has_strict_deriv_at`

### DIFF
--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -27,6 +27,10 @@ of the corresponding predicates for Fréchet derivatives:
  - `has_deriv_at f f' x` states that the function `f` has the derivative `f'`
     at the point `x`.
 
+ - `has_strict_deriv_at f f' x` states that the function `f` has the derivative `f'`
+    at the point `x` in the sense of strict differentiability, i.e.,
+   `f y - f z = (y - z) • f' + o (y - z)` as `y, z → x`.
+
 For the last two notions we also define a functional version:
 
   - `deriv_within f s x` is a derivative of `f` at `x` within `s`. If the
@@ -112,6 +116,12 @@ That is, `f x' = f x + (x' - x) • f' + o(x' - x)` where `x'` converges to `x`.
 def has_deriv_at (f : 𝕜 → F) (f' : F) (x : 𝕜) :=
 has_deriv_at_filter f f' x (𝓝 x)
 
+/-- `f` has the derivative `f'` at the point `x` in the sense of strict differentiability.
+
+That is, `f y - f z = (y - z) • f' + o(y - z)` as `y, z → x`. -/
+def has_strict_deriv_at (f : 𝕜 → F) (f' : F) (x : 𝕜) :=
+has_strict_fderiv_at f (smul_right 1 f' : 𝕜 →L[𝕜] F) x
+
 /--
 Derivative of `f` at the point `x` within the set `s`, if it exists.  Zero otherwise.
 
@@ -141,10 +151,14 @@ lemma has_fderiv_at_filter_iff_has_deriv_at_filter {f' : 𝕜 →L[𝕜] F} :
   has_fderiv_at_filter f f' x L ↔ has_deriv_at_filter f (f' 1) x L :=
 by simp [has_deriv_at_filter]
 
+lemma has_fderiv_at_filter.has_deriv_at_filter {f' : 𝕜 →L[𝕜] F} :
+  has_fderiv_at_filter f f' x L → has_deriv_at_filter f (f' 1) x L :=
+has_fderiv_at_filter_iff_has_deriv_at_filter.mp
+
 /-- Expressing `has_fderiv_within_at f f' s x` in terms of `has_deriv_within_at` -/
 lemma has_fderiv_within_at_iff_has_deriv_within_at {f' : 𝕜 →L[𝕜] F} :
   has_fderiv_within_at f f' s x ↔ has_deriv_within_at f (f' 1) s x :=
-by simp [has_deriv_within_at, has_deriv_at_filter, has_fderiv_within_at]
+has_fderiv_at_filter_iff_has_deriv_at_filter
 
 /-- Expressing `has_deriv_within_at f f' s x` in terms of `has_fderiv_within_at` -/
 lemma has_deriv_within_at_iff_has_fderiv_within_at {f' : F} :
@@ -152,10 +166,26 @@ lemma has_deriv_within_at_iff_has_fderiv_within_at {f' : F} :
   has_fderiv_within_at f (smul_right 1 f' : 𝕜 →L[𝕜] F) s x :=
 iff.rfl
 
+lemma has_fderiv_within_at.has_deriv_within_at {f' : 𝕜 →L[𝕜] F} :
+  has_fderiv_within_at f f' s x → has_deriv_within_at f (f' 1) s x :=
+has_fderiv_within_at_iff_has_deriv_within_at.mp
+
 /-- Expressing `has_fderiv_at f f' x` in terms of `has_deriv_at` -/
 lemma has_fderiv_at_iff_has_deriv_at {f' : 𝕜 →L[𝕜] F} :
   has_fderiv_at f f' x ↔ has_deriv_at f (f' 1) x :=
-by simp [has_deriv_at, has_deriv_at_filter, has_fderiv_at]
+has_fderiv_at_filter_iff_has_deriv_at_filter
+
+lemma has_fderiv_at.has_deriv_at {f' : 𝕜 →L[𝕜] F} :
+  has_fderiv_at f f' x → has_deriv_at f (f' 1) x :=
+has_fderiv_at_iff_has_deriv_at.mp
+
+lemma has_strict_fderiv_at_iff_has_strict_deriv_at {f' : 𝕜 →L[𝕜] F} :
+  has_strict_fderiv_at f f' x ↔ has_strict_deriv_at f (f' 1) x :=
+by simp [has_strict_deriv_at, has_strict_fderiv_at]
+
+lemma has_strict_fderiv_at.has_strict_deriv_at {f' : 𝕜 →L[𝕜] F} :
+  has_strict_fderiv_at f f' x → has_strict_deriv_at f (f' 1) x :=
+has_strict_fderiv_at_iff_has_strict_deriv_at.mp
 
 /-- Expressing `has_deriv_at f f' x` in terms of `has_fderiv_at` -/
 lemma has_deriv_at_iff_has_fderiv_at {f' : F} :
@@ -186,6 +216,10 @@ has_fderiv_at_filter_iff_tendsto
 theorem has_deriv_at_iff_tendsto : has_deriv_at f f' x ↔
   tendsto (λ x', ∥x' - x∥⁻¹ * ∥f x' - f x - (x' - x) • f'∥) (𝓝 x) (𝓝 0) :=
 has_fderiv_at_filter_iff_tendsto
+
+theorem has_strict_deriv_at.has_deriv_at (h : has_strict_deriv_at f f' x) :
+  has_deriv_at f f' x :=
+h.has_fderiv_at
 
 /-- If the domain has dimension one, then Fréchet derivative is equivalent to the classical
 definition with a limit. In this version we have to take the limit along the subset `-{x}`,
@@ -376,7 +410,7 @@ section id
 variables (s x L)
 
 theorem has_deriv_at_filter_id : has_deriv_at_filter id 1 x L :=
-(is_o_zero _ _).congr_left $ by simp
+(has_fderiv_at_filter_id x L).has_deriv_at_filter
 
 theorem has_deriv_within_at_id : has_deriv_within_at id 1 s x :=
 has_deriv_at_filter_id _ _
@@ -386,6 +420,9 @@ has_deriv_at_filter_id _ _
 
 theorem has_deriv_at_id' : has_deriv_at (λ (x : 𝕜), x) 1 x :=
 has_deriv_at_filter_id _ _
+
+theorem has_strict_deriv_at_id : has_strict_deriv_at id 1 x :=
+(has_strict_fderiv_at_id x).has_strict_deriv_at
 
 lemma deriv_id : deriv id x = 1 :=
 has_deriv_at.deriv (has_deriv_at_id x)
@@ -397,7 +434,7 @@ funext deriv_id
 deriv_id x
 
 lemma deriv_within_id (hxs : unique_diff_within_at 𝕜 s x) : deriv_within id s x = 1 :=
-by { unfold deriv_within, rw fderiv_within_id, simp, assumption }
+(has_deriv_within_at_id x s).deriv_within hxs
 
 end id
 
@@ -406,7 +443,10 @@ section const
 variables (c : F) (s x L)
 
 theorem has_deriv_at_filter_const : has_deriv_at_filter (λ x, c) 0 x L :=
-(is_o_zero _ _).congr_left $ λ _, by simp [continuous_linear_map.zero_apply, sub_self]
+(has_fderiv_at_filter_const c x L).has_deriv_at_filter
+
+theorem has_strict_deriv_at_const : has_strict_deriv_at (λ x, c) 0 x :=
+(has_strict_fderiv_at_const c x).has_strict_deriv_at
 
 theorem has_deriv_within_at_const : has_deriv_within_at (λ x, c) 0 s x :=
 has_deriv_at_filter_const _ _ _
@@ -421,53 +461,59 @@ has_deriv_at.deriv (has_deriv_at_const x c)
 funext (λ x, deriv_const x c)
 
 lemma deriv_within_const (hxs : unique_diff_within_at 𝕜 s x) : deriv_within (λ x, c) s x = 0 :=
-by { rw (differentiable_at_const _).deriv_within hxs, apply deriv_const }
+(has_deriv_within_at_const _ _ _).deriv_within hxs
 
 end const
 
-section is_linear_map
-/-! ### Derivative of linear maps -/
-variables (s x L) [is_linear_map 𝕜 f]
+section continuous_linear_map
+/-! ### Derivative of continuous linear maps -/
+variables (e : 𝕜 →L[𝕜] F)
 
-lemma is_linear_map.has_deriv_at_filter : has_deriv_at_filter f (f 1) x L :=
-(is_o_zero _ _).congr_left begin
-  intro y,
-  simp only [sub_smul, continuous_linear_map.one_apply, continuous_linear_map.smul_right_apply],
-  rw ← is_linear_map.smul f x,
-  rw ← is_linear_map.smul f y,
-  simp
-end
+lemma continuous_linear_map.has_deriv_at_filter : has_deriv_at_filter e (e 1) x L :=
+e.has_fderiv_at_filter.has_deriv_at_filter
 
-lemma is_linear_map.has_deriv_within_at : has_deriv_within_at f (f 1) s x :=
-is_linear_map.has_deriv_at_filter _ _
+lemma continuous_linear_map.has_strict_deriv_at : has_strict_deriv_at e (e 1) x :=
+e.has_strict_fderiv_at.has_strict_deriv_at
 
-lemma is_linear_map.has_deriv_at : has_deriv_at f (f 1) x  :=
-is_linear_map.has_deriv_at_filter _ _
+lemma continuous_linear_map.has_deriv_at : has_deriv_at e (e 1) x :=
+e.has_deriv_at_filter
 
-lemma is_linear_map.differentiable_at : differentiable_at 𝕜 f x :=
-(is_linear_map.has_deriv_at _).differentiable_at
+lemma continuous_linear_map.has_deriv_within_at : has_deriv_within_at e (e 1) s x :=
+e.has_deriv_at_filter
 
-lemma is_linear_map.differentiable_within_at : differentiable_within_at 𝕜 f s x :=
-(is_linear_map.differentiable_at _).differentiable_within_at
+@[simp] lemma continuous_linear_map.deriv : deriv e x = e 1 :=
+e.has_deriv_at.deriv
 
-@[simp] lemma is_linear_map.deriv : deriv f x = f 1 :=
-has_deriv_at.deriv (is_linear_map.has_deriv_at _)
+lemma continuous_linear_map.deriv_within (hxs : unique_diff_within_at 𝕜 s x) :
+  deriv_within e s x = e 1 :=
+e.has_deriv_within_at.deriv_within hxs
 
-lemma is_linear_map.deriv_within (hxs : unique_diff_within_at 𝕜 s x) :
-  deriv_within f s x = f 1 :=
-begin
-  rw differentiable_at.deriv_within (is_linear_map.differentiable_at _) hxs,
-  apply is_linear_map.deriv,
-  assumption
-end
+end continuous_linear_map
 
-lemma is_linear_map.differentiable : differentiable 𝕜 f :=
-λ x, is_linear_map.differentiable_at _
+section linear_map
+/-! ### Derivative of bundled linear maps -/
+variables (e : 𝕜 →ₗ[𝕜] F)
 
-lemma is_linear_map.differentiable_on : differentiable_on 𝕜 f s :=
-is_linear_map.differentiable.differentiable_on
+lemma linear_map.has_deriv_at_filter : has_deriv_at_filter e (e 1) x L :=
+e.to_continuous_linear_map₁.has_deriv_at_filter
 
-end is_linear_map
+lemma linear_map.has_strict_deriv_at : has_strict_deriv_at e (e 1) x :=
+e.to_continuous_linear_map₁.has_strict_deriv_at
+
+lemma linear_map.has_deriv_at : has_deriv_at e (e 1) x :=
+e.has_deriv_at_filter
+
+lemma linear_map.has_deriv_within_at : has_deriv_within_at e (e 1) s x :=
+e.has_deriv_at_filter
+
+@[simp] lemma linear_map.deriv : deriv e x = e 1 :=
+e.has_deriv_at.deriv
+
+lemma linear_map.deriv_within (hxs : unique_diff_within_at 𝕜 s x) :
+  deriv_within e s x = e 1 :=
+e.has_deriv_within_at.deriv_within hxs
+
+end linear_map
 
 section add
 /-! ### Derivative of the sum of two functions -/
@@ -475,7 +521,12 @@ section add
 theorem has_deriv_at_filter.add
   (hf : has_deriv_at_filter f f' x L) (hg : has_deriv_at_filter g g' x L) :
   has_deriv_at_filter (λ y, f y + g y) (f' + g') x L :=
-(hf.add hg).congr_left $ by simp [add_smul, smul_add]
+by simpa using (hf.add hg).has_deriv_at_filter
+
+theorem has_strict_deriv_at.add
+  (hf : has_strict_deriv_at f f' x) (hg : has_strict_deriv_at g g' x) :
+  has_strict_deriv_at (λ y, f y + g y) (f' + g') x :=
+by simpa using (hf.add hg).has_strict_deriv_at
 
 theorem has_deriv_within_at.add
   (hf : has_deriv_within_at f f' s x) (hg : has_deriv_within_at g g' s x) :
@@ -551,12 +602,7 @@ variables {c : 𝕜 → 𝕜} {c' : 𝕜}
 theorem has_deriv_within_at.smul
   (hc : has_deriv_within_at c c' s x) (hf : has_deriv_within_at f f' s x) :
   has_deriv_within_at (λ y, c y • f y) (c x • f' + c' • f x) s x :=
-begin
-  show has_fderiv_within_at _ _ _ _,
-  convert has_fderiv_within_at.smul hc hf,
-  ext,
-  simp [smul_add, (mul_smul _ _ _).symm, mul_comm]
-end
+by simpa using (has_fderiv_within_at.smul hc hf).has_deriv_within_at
 
 theorem has_deriv_at.smul
   (hc : has_deriv_at c c' x) (hf : has_deriv_at f f' x) :
@@ -565,6 +611,11 @@ begin
   rw [← has_deriv_within_at_univ] at *,
   exact hc.smul hf
 end
+
+theorem has_strict_deriv_at.smul
+  (hc : has_strict_deriv_at c c' x) (hf : has_strict_deriv_at f f' x) :
+  has_strict_deriv_at (λ y, c y • f y) (c x • f' + c' • f x) x :=
+by simpa using (hc.smul hf).has_strict_deriv_at
 
 lemma deriv_within_smul (hxs : unique_diff_within_at 𝕜 s x)
   (hc : differentiable_within_at 𝕜 c s x) (hf : differentiable_within_at 𝕜 f s x) :
@@ -631,7 +682,7 @@ section neg
 
 theorem has_deriv_at_filter.neg (h : has_deriv_at_filter f f' x L) :
   has_deriv_at_filter (λ x, -f x) (-f') x L :=
-h.neg.congr (by simp) (by simp)
+by simpa using h.neg.has_deriv_at_filter
 
 theorem has_deriv_within_at.neg (h : has_deriv_within_at f f' s x) :
   has_deriv_within_at (λ x, -f x) (-f') s x :=
@@ -639,6 +690,10 @@ h.neg
 
 theorem has_deriv_at.neg (h : has_deriv_at f f' x) : has_deriv_at (λ x, -f x) (-f') x :=
 h.neg
+
+theorem has_strict_deriv_at.neg (h : has_strict_deriv_at f f' x) :
+  has_strict_deriv_at (λ x, -f x) (-f') x :=
+by simpa using h.neg.has_strict_deriv_at
 
 lemma deriv_within_neg (hxs : unique_diff_within_at 𝕜 s x)
   (h : differentiable_within_at 𝕜 f s x) :
@@ -673,6 +728,11 @@ theorem has_deriv_at.sub
   (hf : has_deriv_at f f' x) (hg : has_deriv_at g g' x) :
   has_deriv_at (λ x, f x - g x) (f' - g') x :=
 hf.sub hg
+
+theorem has_strict_deriv_at.sub
+  (hf : has_strict_deriv_at f f' x) (hg : has_strict_deriv_at g g' x) :
+  has_strict_deriv_at (λ x, f x - g x) (f' - g') x :=
+hf.add hg.neg
 
 lemma deriv_within_sub (hxs : unique_diff_within_at 𝕜 s x)
   (hf : differentiable_within_at 𝕜 f s x) (hg : differentiable_within_at 𝕜 g s x) :
@@ -741,7 +801,7 @@ section continuous
 theorem has_deriv_at_filter.tendsto_nhds
   (hL : L ≤ 𝓝 x) (h : has_deriv_at_filter f f' x L) :
   tendsto f L (𝓝 (f x)) :=
-has_fderiv_at_filter.tendsto_nhds hL h
+h.tendsto_nhds hL
 
 theorem has_deriv_within_at.continuous_within_at
   (h : has_deriv_within_at f f' s x) : continuous_within_at f s x :=
@@ -795,14 +855,7 @@ theorem has_deriv_at_filter.scomp
   (hg : has_deriv_at_filter g g' (h x) (L.map h))
   (hh : has_deriv_at_filter h h' x L) :
   has_deriv_at_filter (g ∘ h) (h' • g') x L :=
-have (smul_right 1 g' : 𝕜 →L[𝕜] _).comp
-      (smul_right 1 h' : 𝕜 →L[𝕜] _) =
-    smul_right 1 (h' • g'), by { ext, simp [mul_smul] },
-begin
-  unfold has_deriv_at_filter,
-  rw ← this,
-  exact has_fderiv_at_filter.comp x hg hh,
-end
+by simpa using (hg.comp x hh).has_deriv_at_filter
 
 theorem has_deriv_within_at.scomp {t : set 𝕜}
   (hg : has_deriv_within_at g g' t (h x))
@@ -820,6 +873,11 @@ theorem has_deriv_at.scomp
   (hg : has_deriv_at g g' (h x)) (hh : has_deriv_at h h' x) :
   has_deriv_at (g ∘ h) (h' • g') x :=
 (hg.mono hh.continuous_at).scomp x hh
+
+theorem has_strict_deriv_at.scomp
+  (hg : has_strict_deriv_at g g' (h x)) (hh : has_strict_deriv_at h h' x) :
+  has_strict_deriv_at (g ∘ h) (h' • g') x :=
+by simpa using (hg.comp x hh).has_strict_deriv_at
 
 theorem has_deriv_at.scomp_has_deriv_within_at
   (hg : has_deriv_at g g' (h x)) (hh : has_deriv_within_at h h' s x) :
@@ -865,6 +923,11 @@ theorem has_deriv_at.comp
   (hh₁ : has_deriv_at h₁ h₁' (h₂ x)) (hh₂ : has_deriv_at h₂ h₂' x) :
   has_deriv_at (h₁ ∘ h₂) (h₁' * h₂') x :=
 (hh₁.mono hh₂.continuous_at).comp x hh₂
+
+theorem has_strict_deriv_at.comp
+  (hh₁ : has_strict_deriv_at h₁ h₁' (h₂ x)) (hh₂ : has_strict_deriv_at h₂ h₂' x) :
+  has_strict_deriv_at (h₁ ∘ h₂) (h₁' * h₂') x :=
+by { rw mul_comm, exact hh₁.scomp x hh₂ }
 
 theorem has_deriv_at.comp_has_deriv_within_at
   (hh₁ : has_deriv_at h₁ h₁' (h₂ x)) (hh₂ : has_deriv_within_at h₂ h₂' s x) :
@@ -969,6 +1032,14 @@ begin
   exact hc.mul hd
 end
 
+theorem has_strict_deriv_at.mul
+  (hc : has_strict_deriv_at c c' x) (hd : has_strict_deriv_at d d' x) :
+  has_strict_deriv_at (λ y, c y * d y) (c' * d x + c x * d') x :=
+begin
+  convert hc.smul hd using 1,
+  rw [smul_eq_mul, smul_eq_mul, add_comm]
+end
+
 lemma deriv_within_mul (hxs : unique_diff_within_at 𝕜 s x)
   (hc : differentiable_within_at 𝕜 c s x) (hd : differentiable_within_at 𝕜 d s x) :
   deriv_within (λ y, c y * d y) s x = deriv_within c s x * d x + c x * deriv_within d s x :=
@@ -1029,46 +1100,23 @@ end mul
 section inverse
 /-! ### Derivative of `x ↦ x⁻¹` -/
 
-lemma has_deriv_at_inv_one :
-  has_deriv_at (λx, x⁻¹) (-1) (1 : 𝕜) :=
+theorem has_strict_deriv_at_inv (hx : x ≠ 0) : has_strict_deriv_at has_inv.inv (-(x^2)⁻¹) x :=
 begin
-  rw has_deriv_at_iff_is_o_nhds_zero,
-  have : is_o (λ (h : 𝕜), h^2 * (1 + h)⁻¹) (λ (h : 𝕜), h * 1) (𝓝 0),
-  { have : tendsto (λ (h : 𝕜), (1 + h)⁻¹) (𝓝 0) (𝓝 (1 + 0)⁻¹) :=
-      ((tendsto_const_nhds).add tendsto_id).inv' (by norm_num),
-    exact is_o.mul_is_O (is_o_pow_id one_lt_two) (is_O_one_of_tendsto _ this) },
-  apply this.congr' _ _,
-  { have : metric.ball (0 : 𝕜) 1 ∈ 𝓝 (0 : 𝕜),
-      from metric.ball_mem_nhds 0 zero_lt_one,
-    filter_upwards [this],
-    assume h hx,
-    have : 0 < ∥1 + h∥ := calc
-      0 < ∥(1:𝕜)∥ - ∥-h∥ : by rwa [norm_neg, sub_pos, ← dist_zero_right h, normed_field.norm_one]
-      ... ≤ ∥1 - -h∥ : norm_sub_norm_le _ _
-      ... = ∥1 + h∥ : by simp,
-    have : 1 + h ≠ 0 := norm_pos_iff.mp this,
-    simp,
-    rw ← eq_div_iff_mul_eq _ _ (inv_ne_zero this),
-    field_simp,
-    simp [right_distrib, sub_mul,
-      (show (1 + h)⁻¹ * (1 + h) = 1, by rw mul_comm; exact field.mul_inv_cancel this)],
-    ring },
-  { exact univ_mem_sets' mul_one }
+  suffices : is_o (λ p : 𝕜 × 𝕜, (p.1 - p.2) * ((x * x)⁻¹ - (p.1 * p.2)⁻¹))
+    (λ (p : 𝕜 × 𝕜), (p.1 - p.2) * 1) (𝓝 (x, x)),
+  { refine this.congr' _ (eventually_of_forall _ $ λ _, mul_one _),
+    refine eventually.mono (mem_nhds_sets (is_open_prod is_open_ne is_open_ne) ⟨hx, hx⟩) _,
+    rintro ⟨y, z⟩ ⟨hy, hz⟩,
+    simp only [mem_set_of_eq] at hy hz, -- hy : y ≠ 0, hz : z ≠ 0
+    field_simp [hx, hy, hz], ring, },
+  refine (is_O_refl (λ p : 𝕜 × 𝕜, p.1 - p.2) _).mul_is_o ((is_o_one_iff _).2 _),
+  rw [← sub_self (x * x)⁻¹],
+  exact tendsto_const_nhds.sub ((continuous_mul.tendsto (x, x)).inv' $ mul_ne_zero hx hx)
 end
 
 theorem has_deriv_at_inv (x_ne_zero : x ≠ 0) :
   has_deriv_at (λy, y⁻¹) (-(x^2)⁻¹) x :=
-begin
-  have A : has_deriv_at (λy, y⁻¹) (-1) (x⁻¹ * x : 𝕜),
-    by { simp only [inv_mul_cancel x_ne_zero, has_deriv_at_inv_one] },
-  have B : has_deriv_at (λy, x⁻¹ * y) (x⁻¹) x,
-    by simpa only [mul_one] using (has_deriv_at_id x).const_mul x⁻¹,
-  convert (A.comp x B : _).const_mul x⁻¹,
-  { ext y,
-    rw [function.comp_apply, mul_inv', inv_inv', mul_comm, mul_assoc, mul_inv_cancel x_ne_zero,
-      mul_one] },
-  { field_simp [pow_two] }
-end
+(has_strict_deriv_at_inv x_ne_zero).has_deriv_at
 
 theorem has_deriv_within_at_inv (x_ne_zero : x ≠ 0) (s : set 𝕜) :
   has_deriv_within_at (λx, x⁻¹) (-(x^2)⁻¹) s x :=
@@ -1224,18 +1272,23 @@ variables {x : 𝕜} {s : set 𝕜}
 variable (p : polynomial 𝕜)
 
 /-- The derivative (in the analysis sense) of a polynomial `p` is given by `p.derivative`. -/
-protected lemma has_deriv_at (x : 𝕜) : has_deriv_at (λx, p.eval x) (p.derivative.eval x) x :=
+protected lemma has_strict_deriv_at (x : 𝕜) :
+  has_strict_deriv_at (λx, p.eval x) (p.derivative.eval x) x :=
 begin
   apply p.induction_on,
-  { simp [has_deriv_at_const] },
+  { simp [has_strict_deriv_at_const] },
   { assume p q hp hq,
     convert hp.add hq;
     simp },
   { assume n a h,
-    convert h.mul (has_deriv_at_id x),
+    convert h.mul (has_strict_deriv_at_id x),
     { ext y, simp [pow_add, mul_assoc] },
     { simp [pow_add], ring } }
 end
+
+/-- The derivative (in the analysis sense) of a polynomial `p` is given by `p.derivative`. -/
+protected lemma has_deriv_at (x : 𝕜) : has_deriv_at (λx, p.eval x) (p.derivative.eval x) x :=
+(p.has_strict_deriv_at x).has_deriv_at
 
 protected theorem has_deriv_within_at (x : 𝕜) (s : set 𝕜) :
   has_deriv_within_at (λx, p.eval x) (p.derivative.eval x) s x :=
@@ -1300,12 +1353,16 @@ section pow
 variables {x : 𝕜} {s : set 𝕜} {c : 𝕜 → 𝕜} {c' : 𝕜}
 variable {n : ℕ }
 
-lemma has_deriv_at_pow (n : ℕ) (x : 𝕜) : has_deriv_at (λx, x^n) ((n : 𝕜) * x^(n-1)) x :=
+lemma has_strict_deriv_at_pow (n : ℕ) (x : 𝕜) :
+  has_strict_deriv_at (λx, x^n) ((n : 𝕜) * x^(n-1)) x :=
 begin
-  convert (polynomial.C 1 * (polynomial.X)^n).has_deriv_at x,
+  convert (polynomial.C 1 * (polynomial.X)^n).has_strict_deriv_at x,
   { simp },
   { rw [polynomial.derivative_monomial], simp }
 end
+
+lemma has_deriv_at_pow (n : ℕ) (x : 𝕜) : has_deriv_at (λx, x^n) ((n : 𝕜) * x^(n-1)) x :=
+(has_strict_deriv_at_pow n x).has_deriv_at
 
 theorem has_deriv_within_at_pow (n : ℕ) (x : 𝕜) (s : set 𝕜) :
   has_deriv_within_at (λx, x^n) ((n : 𝕜) * x^(n-1)) s x :=
@@ -1388,27 +1445,31 @@ section fpow
 variables {x : 𝕜} {s : set 𝕜}
 variable {m : ℤ}
 
-lemma has_deriv_at_fpow (m : ℤ) (hx : x ≠ 0) :
-  has_deriv_at (λx, x^m) ((m : 𝕜) * x^(m-1)) x :=
+lemma has_strict_deriv_at_fpow (m : ℤ) (hx : x ≠ 0) :
+  has_strict_deriv_at (λx, x^m) ((m : 𝕜) * x^(m-1)) x :=
 begin
-  have : ∀ m : ℤ, 0 < m → has_deriv_at (λx, x^m) ((m:𝕜) * x^(m-1)) x,
+  have : ∀ m : ℤ, 0 < m → has_strict_deriv_at (λx, x^m) ((m:𝕜) * x^(m-1)) x,
   { assume m hm,
     lift m to ℕ using (le_of_lt hm),
     simp only [fpow_of_nat, int.cast_coe_nat],
-    convert has_deriv_at_pow _ _ using 2,
+    convert has_strict_deriv_at_pow _ _ using 2,
     rw [← int.coe_nat_one, ← int.coe_nat_sub, fpow_coe_nat],
     norm_cast at hm,
     exact nat.succ_le_of_lt hm },
   rcases lt_trichotomy m 0 with hm|hm|hm,
-  { have := (has_deriv_at_inv _).scomp _ (this (-m) (neg_pos.2 hm));
+  { have := (has_strict_deriv_at_inv _).scomp _ (this (-m) (neg_pos.2 hm));
       [skip, exact fpow_ne_zero_of_ne_zero hx _],
     simp only [(∘), fpow_neg, one_div_eq_inv, inv_inv', smul_eq_mul] at this,
     convert this using 1,
     rw [pow_two, mul_inv', inv_inv', int.cast_neg, ← neg_mul_eq_neg_mul, neg_mul_neg,
       ← fpow_add hx, mul_assoc, ← fpow_add hx], congr, abel },
-  { simp only [hm, fpow_zero, int.cast_zero, zero_mul, has_deriv_at_const] },
+  { simp only [hm, fpow_zero, int.cast_zero, zero_mul, has_strict_deriv_at_const] },
   { exact this m hm }
 end
+
+lemma has_deriv_at_fpow (m : ℤ) (hx : x ≠ 0) :
+  has_deriv_at (λx, x^m) ((m : 𝕜) * x^(m-1)) x :=
+(has_strict_deriv_at_fpow m hx).has_deriv_at
 
 theorem has_deriv_within_at_fpow (m : ℤ) (hx : x ≠ 0) (s : set 𝕜) :
   has_deriv_within_at (λx, x^m) ((m : 𝕜) * x^(m-1)) s x :=

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -581,6 +581,10 @@ begin
   simp only [*]
 end
 
+theorem has_strict_fderiv_at.congr_of_mem_sets (h : has_strict_fderiv_at f f' x)
+  (h₁ : ∀ᶠ y in 𝓝 x, f y = f₁ y) : has_strict_fderiv_at f₁ f' x :=
+(has_strict_fderiv_at_congr_of_mem_sets h₁ (λ _, rfl)).1 h
+
 theorem has_fderiv_at_filter_congr_of_mem_sets
   (hx : f₀ x = f₁ x) (h₀ : ∀ᶠ x in L, f₀ x = f₁ x) (h₁ : ∀ x, f₀' x = f₁' x) :
   has_fderiv_at_filter f₀ f₀' x L ↔ has_fderiv_at_filter f₁ f₁' x L :=
@@ -1053,7 +1057,7 @@ variables {f₂ : E → F × G} {f₂' : E →L[𝕜] F × G} {p : E × F}
 lemma has_strict_fderiv_at_fst : has_strict_fderiv_at prod.fst (fst 𝕜 E F) p :=
 (fst 𝕜 E F).has_strict_fderiv_at
 
-lemma has_strict_fderiv_at.fst (h : has_strict_fderiv_at f₂ f₂' x) :
+protected lemma has_strict_fderiv_at.fst (h : has_strict_fderiv_at f₂ f₂' x) :
   has_strict_fderiv_at (λ x, (f₂ x).1) ((fst 𝕜 F G).comp f₂') x :=
 has_strict_fderiv_at_fst.comp x h
 
@@ -1061,14 +1065,14 @@ lemma has_fderiv_at_filter_fst {L : filter (E × F)} :
   has_fderiv_at_filter prod.fst (fst 𝕜 E F) p L :=
 (fst 𝕜 E F).has_fderiv_at_filter
 
-lemma has_fderiv_at_filter.fst (h : has_fderiv_at_filter f₂ f₂' x L) :
+protected lemma has_fderiv_at_filter.fst (h : has_fderiv_at_filter f₂ f₂' x L) :
   has_fderiv_at_filter (λ x, (f₂ x).1) ((fst 𝕜 F G).comp f₂') x L :=
 has_fderiv_at_filter_fst.comp x h
 
 lemma has_fderiv_at_fst : has_fderiv_at prod.fst (fst 𝕜 E F) p :=
 has_fderiv_at_filter_fst
 
-lemma has_fderiv_at.fst (h : has_fderiv_at f₂ f₂' x) :
+protected lemma has_fderiv_at.fst (h : has_fderiv_at f₂ f₂' x) :
   has_fderiv_at (λ x, (f₂ x).1) ((fst 𝕜 F G).comp f₂') x :=
 h.fst
 
@@ -1076,34 +1080,35 @@ lemma has_fderiv_within_at_fst {s : set (E × F)} :
   has_fderiv_within_at prod.fst (fst 𝕜 E F) s p :=
 has_fderiv_at_filter_fst
 
-lemma has_fderiv_within_at.fst (h : has_fderiv_within_at f₂ f₂' s x) :
+protected lemma has_fderiv_within_at.fst (h : has_fderiv_within_at f₂ f₂' s x) :
   has_fderiv_within_at (λ x, (f₂ x).1) ((fst 𝕜 F G).comp f₂') s x :=
 h.fst
 
 lemma differentiable_at_fst : differentiable_at 𝕜 prod.fst p :=
 has_fderiv_at_fst.differentiable_at
 
-@[simp] lemma differentiable_at.fst (h : differentiable_at 𝕜 f₂ x) :
+@[simp] protected lemma differentiable_at.fst (h : differentiable_at 𝕜 f₂ x) :
   differentiable_at 𝕜 (λ x, (f₂ x).1) x :=
 differentiable_at_fst.comp x h
 
 lemma differentiable_fst : differentiable 𝕜 (prod.fst : E × F → E) :=
 λ x, differentiable_at_fst
 
-@[simp] lemma differentiable.fst (h : differentiable 𝕜 f₂) : differentiable 𝕜 (λ x, (f₂ x).1) :=
+@[simp] protected lemma differentiable.fst (h : differentiable 𝕜 f₂) :
+  differentiable 𝕜 (λ x, (f₂ x).1) :=
 differentiable_fst.comp h
 
 lemma differentiable_within_at_fst {s : set (E × F)} : differentiable_within_at 𝕜 prod.fst s p :=
 differentiable_at_fst.differentiable_within_at
 
-lemma differentiable_within_at.fst (h : differentiable_within_at 𝕜 f₂ s x) :
+protected lemma differentiable_within_at.fst (h : differentiable_within_at 𝕜 f₂ s x) :
   differentiable_within_at 𝕜 (λ x, (f₂ x).1) s x :=
 differentiable_at_fst.comp_differentiable_within_at x h
 
 lemma differentiable_on_fst {s : set (E × F)} : differentiable_on 𝕜 prod.fst s :=
 differentiable_fst.differentiable_on
 
-lemma differentiable_on.fst (h : differentiable_on 𝕜 f₂ s) :
+protected lemma differentiable_on.fst (h : differentiable_on 𝕜 f₂ s) :
   differentiable_on 𝕜 (λ x, (f₂ x).1) s :=
 differentiable_fst.comp_differentiable_on h
 
@@ -1138,14 +1143,14 @@ lemma has_fderiv_at_filter_snd {L : filter (E × F)} :
   has_fderiv_at_filter prod.snd (snd 𝕜 E F) p L :=
 (snd 𝕜 E F).has_fderiv_at_filter
 
-lemma has_fderiv_at_filter.snd (h : has_fderiv_at_filter f₂ f₂' x L) :
+protected lemma has_fderiv_at_filter.snd (h : has_fderiv_at_filter f₂ f₂' x L) :
   has_fderiv_at_filter (λ x, (f₂ x).2) ((snd 𝕜 F G).comp f₂') x L :=
 has_fderiv_at_filter_snd.comp x h
 
 lemma has_fderiv_at_snd : has_fderiv_at prod.snd (snd 𝕜 E F) p :=
 has_fderiv_at_filter_snd
 
-lemma has_fderiv_at.snd (h : has_fderiv_at f₂ f₂' x) :
+protected lemma has_fderiv_at.snd (h : has_fderiv_at f₂ f₂' x) :
   has_fderiv_at (λ x, (f₂ x).2) ((snd 𝕜 F G).comp f₂') x :=
 h.snd
 
@@ -1153,34 +1158,35 @@ lemma has_fderiv_within_at_snd {s : set (E × F)} :
   has_fderiv_within_at prod.snd (snd 𝕜 E F) s p :=
 has_fderiv_at_filter_snd
 
-lemma has_fderiv_within_at.snd (h : has_fderiv_within_at f₂ f₂' s x) :
+protected lemma has_fderiv_within_at.snd (h : has_fderiv_within_at f₂ f₂' s x) :
   has_fderiv_within_at (λ x, (f₂ x).2) ((snd 𝕜 F G).comp f₂') s x :=
 h.snd
 
 lemma differentiable_at_snd : differentiable_at 𝕜 prod.snd p :=
 has_fderiv_at_snd.differentiable_at
 
-@[simp] lemma differentiable_at.snd (h : differentiable_at 𝕜 f₂ x) :
+@[simp] protected lemma differentiable_at.snd (h : differentiable_at 𝕜 f₂ x) :
   differentiable_at 𝕜 (λ x, (f₂ x).2) x :=
 differentiable_at_snd.comp x h
 
 lemma differentiable_snd : differentiable 𝕜 (prod.snd : E × F → F) :=
 λ x, differentiable_at_snd
 
-@[simp] lemma differentiable.snd (h : differentiable 𝕜 f₂) : differentiable 𝕜 (λ x, (f₂ x).2) :=
+@[simp] protected lemma differentiable.snd (h : differentiable 𝕜 f₂) :
+  differentiable 𝕜 (λ x, (f₂ x).2) :=
 differentiable_snd.comp h
 
 lemma differentiable_within_at_snd {s : set (E × F)} : differentiable_within_at 𝕜 prod.snd s p :=
 differentiable_at_snd.differentiable_within_at
 
-lemma differentiable_within_at.snd (h : differentiable_within_at 𝕜 f₂ s x) :
+protected lemma differentiable_within_at.snd (h : differentiable_within_at 𝕜 f₂ s x) :
   differentiable_within_at 𝕜 (λ x, (f₂ x).2) s x :=
 differentiable_at_snd.comp_differentiable_within_at x h
 
 lemma differentiable_on_snd {s : set (E × F)} : differentiable_on 𝕜 prod.snd s :=
 differentiable_snd.differentiable_on
 
-lemma differentiable_on.snd (h : differentiable_on 𝕜 f₂ s) :
+protected lemma differentiable_on.snd (h : differentiable_on 𝕜 f₂ s) :
   differentiable_on 𝕜 (λ x, (f₂ x).2) s :=
 differentiable_snd.comp_differentiable_on h
 
@@ -1206,17 +1212,17 @@ variables {f₂ : G → G'} {f₂' : G →L[𝕜] G'} {y : G} (p : E × G)
 
 -- TODO (Lean 3.8): use `prod.map f f₂``
 
-theorem has_strict_fderiv_at.prod_map (hf : has_strict_fderiv_at f f' p.1)
+protected theorem has_strict_fderiv_at.prod_map (hf : has_strict_fderiv_at f f' p.1)
   (hf₂ : has_strict_fderiv_at f₂ f₂' p.2) :
   has_strict_fderiv_at (λ p : E × G, (f p.1, f₂ p.2)) (f'.prod_map f₂') p :=
 (hf.comp p has_strict_fderiv_at_fst).prod (hf₂.comp p has_strict_fderiv_at_snd)
 
-theorem has_fderiv_at.prod_map (hf : has_fderiv_at f f' p.1)
+protected theorem has_fderiv_at.prod_map (hf : has_fderiv_at f f' p.1)
   (hf₂ : has_fderiv_at f₂ f₂' p.2) :
   has_fderiv_at (λ p : E × G, (f p.1, f₂ p.2)) (f'.prod_map f₂') p :=
 (hf.comp p has_fderiv_at_fst).prod (hf₂.comp p has_fderiv_at_snd)
 
-@[simp] theorem differentiable_at.prod_map (hf : differentiable_at 𝕜 f p.1)
+@[simp] protected theorem differentiable_at.prod_map (hf : differentiable_at 𝕜 f p.1)
   (hf₂ : differentiable_at 𝕜 f₂ p.2) :
   differentiable_at 𝕜 (λ p : E × G, (f p.1, f₂ p.2)) p :=
 (hf.comp p differentiable_at_fst).prod (hf₂.comp p differentiable_at_snd)
@@ -2148,7 +2154,7 @@ lemma has_fderiv_within_at.unique_diff_within_at_of_continuous_linear_equiv
   unique_diff_within_at 𝕜 (f '' s) (f x) :=
 begin
   apply h.unique_diff_within_at hs,
-  have : range (e' : E →L[𝕜] F) = univ := e'.to_linear_equiv.to_equiv.range_eq_univ,
+  have : set.range (e' : E →L[𝕜] F) = univ := e'.to_linear_equiv.to_equiv.range_eq_univ,
   rw [this, closure_univ]
 end
 

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -57,6 +57,13 @@ The fact that the norm of the continuous linear map is then controlled is given 
 def linear_map.mk_continuous (C : ℝ) (h : ∀x, ∥f x∥ ≤ C * ∥x∥) : E →L[𝕜] F :=
 ⟨f, linear_map.continuous_of_bound f C h⟩
 
+/-- Reinterpret a linear map `𝕜 →ₗ[𝕜] E` as a continuous linear map. This construction
+is generalized to the case of any finite dimensional domain
+in `linear_map.to_continuous_linear_map`. -/
+def linear_map.to_continuous_linear_map₁ (f : 𝕜 →ₗ[𝕜] E) : 𝕜 →L[𝕜] E :=
+f.mk_continuous (∥f 1∥) $ λ x, le_of_eq $
+by { conv_lhs { rw ← mul_one x }, rw [← smul_eq_mul, f.map_smul, norm_smul, mul_comm] }
+
 /-- Construct a continuous linear map from a linear map and the existence of a bound on this linear
 map. If you have an explicit bound, use `linear_map.mk_continuous` instead, as a norm estimate will
 follow automatically in `linear_map.mk_continuous_norm_le`. -/
@@ -74,6 +81,14 @@ def linear_map.mk_continuous_of_exists_bound (h : ∃C, ∀x, ∥f x∥ ≤ C * 
 
 @[simp] lemma linear_map.mk_continuous_of_exists_bound_apply (h : ∃C, ∀x, ∥f x∥ ≤ C * ∥x∥) (x : E) :
   f.mk_continuous_of_exists_bound h x = f x := rfl
+
+@[simp] lemma linear_map.to_continuous_linear_map₁_coe (f : 𝕜 →ₗ[𝕜] E) :
+  (f.to_continuous_linear_map₁ : 𝕜 →ₗ[𝕜] E) = f :=
+rfl
+
+@[simp] lemma linear_map.to_continuous_linear_map₁_apply (f : 𝕜 →ₗ[𝕜] E) (x) :
+  f.to_continuous_linear_map₁ x = f x :=
+rfl
 
 lemma linear_map.continuous_iff_is_closed_ker {f : E →ₗ[𝕜] 𝕜} :
   continuous f ↔ is_closed (f.ker : set E) :=

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1346,7 +1346,7 @@ section
 set_option old_structure_cmd true
 
 /-- A linear equivalence is an invertible linear map. -/
-@[nolint doc_blame has_inhabited_instance]
+@[nolint has_inhabited_instance]
 structure linear_equiv (R : Type u) (M : Type v) (M₂ : Type w)
   [ring R] [add_comm_group M] [add_comm_group M₂] [module R M] [module R M₂]
   extends M →ₗ[R] M₂, M ≃ M₂


### PR DESCRIPTION
Also make more proofs explicitly use their `has_fderiv*` counterparts
and mark some lemmas in `fderiv` as `protected`.