### PR TITLE
[Merged by Bors] - doc(data/nat/modeq): add module docstring and lemma

### DIFF
--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -9,7 +9,7 @@ import data.list.rotate
 /-
 # nat.modeq -- congruences modulo a natural on ℕ.
 
-This file defines the equivalence relation a ≡ b [MOD n] on the natural numbers,
+This file defines the equivalence relation `a ≡ b [MOD n]` on the natural numbers,
 and proves basic properties about it such as the Chinese Remainder Theorem
 `modeq_and_modeq_iff_modeq_mul`.
 

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -37,6 +37,10 @@ by rw [modeq, eq_comm, ← int.coe_nat_inj', int.coe_nat_mod, int.coe_nat_mod,
 theorem modeq_of_dvd : (n:ℤ) ∣ b - a → a ≡ b [MOD n] := modeq_iff_dvd.2
 theorem dvd_of_modeq : a ≡ b [MOD n] → (n:ℤ) ∣ b - a := modeq_iff_dvd.1
 
+/-- A variant of modeq_iff_dvd with nat divisibility -/
+theorem modeq_iff_dvd' {n : ℕ} {a b : ℕ} (h : a ≤ b) : a ≡ b [MOD n] ↔ n ∣ b - a :=
+by rw [modeq_iff_dvd, ←int.coe_nat_dvd, int.coe_nat_sub h]
+
 theorem mod_modeq (a n) : a % n ≡ a [MOD n] := nat.mod_mod _ _
 
 theorem modeq_of_dvd_of_modeq (d : m ∣ n) (h : a ≡ b [MOD n]) : a ≡ b [MOD m] :=

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -49,7 +49,7 @@ by rw [modeq, eq_comm, ← int.coe_nat_inj', int.coe_nat_mod, int.coe_nat_mod,
 theorem modeq_of_dvd : (n:ℤ) ∣ b - a → a ≡ b [MOD n] := modeq_iff_dvd.2
 theorem dvd_of_modeq : a ≡ b [MOD n] → (n:ℤ) ∣ b - a := modeq_iff_dvd.1
 
-/-- A variant of modeq_iff_dvd with nat divisibility -/
+/-- A variant of `modeq_iff_dvd` with `nat` divisibility -/
 theorem modeq_iff_dvd' {n : ℕ} {a b : ℕ} (h : a ≤ b) : a ≡ b [MOD n] ↔ n ∣ b - a :=
 by rw [modeq_iff_dvd, ←int.coe_nat_dvd, int.coe_nat_sub h]
 

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -7,7 +7,7 @@ import data.int.gcd
 import tactic.abel
 import data.list.rotate
 /-
-# nat.modeq -- congruences modulo a natural on ℕ.
+# Congruences modulo a natural number
 
 This file defines the equivalence relation `a ≡ b [MOD n]` on the natural numbers,
 and proves basic properties about it such as the Chinese Remainder Theorem

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -2,13 +2,25 @@
 Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
-
-Modular equality relation.
 -/
 import data.int.gcd
 import tactic.abel
 import data.list.rotate
+/-
+# nat.modeq -- congruences modulo a natural on ℕ.
 
+This file defines the equivalence relation a ≡ b [MOD n] on the natural numbers,
+and proves basic properties about it such as the Chinese Remainder Theorem
+`modeq_and_modeq_iff_modeq_mul`.
+
+## Notations
+
+`a ≡ b [MOD n]` is notation for `modeq n a b`, which is defined to mean `a % n = b % n`.
+
+## Tags
+
+modeq, congruence, mod, MOD, modulo
+-/
 namespace nat
 
 /-- Modular equality. `modeq n a b`, or `a ≡ b [MOD n]`, means
@@ -84,6 +96,7 @@ by rw [modeq_iff_dvd] at *; exact dvd.trans (dvd_mul_left (n : ℤ) (m : ℤ)) h
 theorem modeq_of_modeq_mul_right (m : ℕ) : a ≡ b [MOD n * m] → a ≡ b [MOD n] :=
 mul_comm m n ▸ modeq_of_modeq_mul_left _
 
+/-- The natural number less than `n*m` congruent to `a` mod `n` and `b` mod `m` -/
 def chinese_remainder (co : coprime n m) (a b : ℕ) : {k // k ≡ a [MOD n] ∧ k ≡ b [MOD m]} :=
 ⟨let (c, d) := xgcd n m in int.to_nat ((b * c * n + a * d * m) % (n * m)), begin
   rw xgcd_val, dsimp [chinese_remainder._match_1],

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -50,7 +50,7 @@ theorem modeq_of_dvd : (n:ℤ) ∣ b - a → a ≡ b [MOD n] := modeq_iff_dvd.2
 theorem dvd_of_modeq : a ≡ b [MOD n] → (n:ℤ) ∣ b - a := modeq_iff_dvd.1
 
 /-- A variant of `modeq_iff_dvd` with `nat` divisibility -/
-theorem modeq_iff_dvd' {n : ℕ} {a b : ℕ} (h : a ≤ b) : a ≡ b [MOD n] ↔ n ∣ b - a :=
+theorem modeq_iff_dvd' (h : a ≤ b) : a ≡ b [MOD n] ↔ n ∣ b - a :=
 by rw [modeq_iff_dvd, ←int.coe_nat_dvd, int.coe_nat_sub h]
 
 theorem mod_modeq (a n) : a % n ≡ a [MOD n] := nat.mod_mod _ _


### PR DESCRIPTION
I add a simple docstrong and also a lemma which I found useful for a codewars kata.

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
