### PR TITLE
feat(tactic/conv) add a tactic replacing natural numbers with their prime factorization

### DIFF
--- a/src/tactic/converter/to_factors.lean
+++ b/src/tactic/converter/to_factors.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2020 Alex J. Best. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Alex J. Best
+
+Factor naturals inside of a conv.
+-/
+import data.nat.prime
+import tactic.converter.interactive
+import tactic.norm_num
+
+namespace conv
+open tactic
+
+/-- `to_factors_aux` tactic factors a `nat` expression into prime factors,
+returning a proof that the original expession is product of these factors,
+expanded as a sequence of `mul`'s. The tactic does not provide proofs that
+the factors are indeed prime. -/
+meta def to_factors_aux : expr → tactic (expr × expr) :=
+λ e₁, do
+  α ← infer_type e₁,
+  c ← mk_instance_cache α,
+  match α with
+  | `(nat) := do
+
+    n₁ ← e₁.to_nat,
+    factors_expr ← mk_app ``nat.factors [e₁],
+    factors_list ← eval_expr (list ℕ) factors_expr,
+
+    factor_prod ← (mk_app ``list.prod [reflect factors_list]),
+    (mul_expr, p_mul) ← expr.simp factor_prod {} failed tt []
+      [simp_arg_type.expr (expr.const `list.prod_cons []),
+      simp_arg_type.expr (expr.const `list.prod_nil []),
+      simp_arg_type.expr (expr.const `nat.mul_one [])],
+    p ← to_expr ``(by norm_num : %%e₁ = %%mul_expr),
+    return (mul_expr, p)
+  | _ := failed
+  end
+
+/-- The `to_factors` tactic factors a `nat` into prime factors inside of a `conv` block.
+The number to be factored must be the current target. -/
+meta def to_factors : conv unit := conv.replace_lhs to_factors_aux
+
+end conv

--- a/test/conv/conv.lean
+++ b/test/conv/conv.lean
@@ -7,6 +7,7 @@ Tests for the `conv` tactic inside the inveractive `conv` monad
 -/
 
 import tactic.converter.interactive
+import tactic.converter.to_factors
 
 example (a b c d : ℕ) (h₁ : b = c) (h₂ : a + c = a + d) : a + b = a + d :=
 begin
@@ -45,4 +46,15 @@ begin
       rw h₁,
     },         -- returning to the left hand side
   },
+end
+
+example : ¬ nat.prime 11413 :=
+begin
+   conv
+   {
+     congr,
+     congr,
+     conv.to_factors,
+   },
+   exact nat.not_prime_mul (int.coe_nat_lt.mp trivial) (int.coe_nat_lt.mp trivial),
 end


### PR DESCRIPTION
A convenience tactic, to save some keystrokes here and there. The factorization is currently done via evaling `factors` in lean, so as I understand it this uses the vm and hence it is faster than a `rfl` but does not result in a proof (correct me if I've mixed things up here). It doesn't seem too slow for medium size numbers.

In the future it would be cool to call out to mpir/gmp/pari/Sage or some other software and construct a proof of the claimed factorization.

---

This was a nice exercise (for me) in tactic writing, but it seems somewhat useful to have in mathlib. 

It seems to work ok, but I would like some comments at this stage. (I'd especially appreciate it if someone told me this was already possible!).

One question I have for the community: would this be more useful if it provided proof of primality of all the multiplicands? Or a proof that `n = 2*5*11` or `factors n = [2,5,11]` instead. It seems to me it would be, but as I understand the way this all works, the tactic would have to construct proofs of primality after which could be quite slow?
