### PR TITLE
[Merged by Bors] - fix(tactic/doc_commands): clean up copy_doc_string command

### DIFF
--- a/src/tactic/doc_commands.lean
+++ b/src/tactic/doc_commands.lean
@@ -309,7 +309,7 @@ add_tactic_doc
 add_tactic_doc
 { name := "copy_doc_string",
   category := doc_category.cmd,
-  decl_names := [`copy_doc_string_cmd, `copy_doc_string],
+  decl_names := [`copy_doc_string_cmd, `tactic.copy_doc_string],
   tags := ["documentation"],
   inherit_description_from := `copy_doc_string_cmd }
 

--- a/src/tactic/doc_commands.lean
+++ b/src/tactic/doc_commands.lean
@@ -40,20 +40,25 @@ nspace <.> ("_" ++ to_string id.hash)
 
 open tactic
 
-/-- Copy the docstring from the name `fr` to the name `to`. -/
-meta def copy_doc_string (fr to : name) : tactic unit :=
-doc_string fr >>= add_doc_string to
+/-- Copy the docstring from the name `fr` to the names in `to`. -/
+meta def tactic.copy_doc_string (fr : name) (to : list name) : tactic unit :=
+do fr_ds ← doc_string fr,
+   to.mmap' $ λ tgt, add_doc_string tgt fr_ds
 
 open lean lean.parser interactive
 
-/-- Copy the docstring from the name `fr` to the name `to`. -/
+/--
+`copy_doc_string source → target_1 target_2 ... target_n` copies the doc string of the
+declaration named `source` to each of `target_1`, `target_2`, ..., `target_n`.
+ -/
 @[user_command] meta def copy_doc_string_cmd
   (_ : parse (tk "copy_doc_string")) : parser unit :=
 do fr ← parser.ident,
-   to ← parser.ident,
+   tk "->",
+   to ← parser.many parser.ident,
    expr.const fr _  ← resolve_name fr,
-   expr.const to _  ← resolve_name to,
-   copy_doc_string fr to
+   to ← parser.of_tactic (to.mmap $ λ n, expr.const_name <$> resolve_name n),
+   tactic.copy_doc_string fr to
 
 /-! ### The `library_note` command -/
 
@@ -300,6 +305,13 @@ add_tactic_doc
   decl_names               := [`add_tactic_doc_command, `tactic.add_tactic_doc],
   tags                     := ["documentation"],
   inherit_description_from := `add_tactic_doc_command }
+
+add_tactic_doc
+{ name := "copy_doc_string",
+  category := doc_category.cmd,
+  decl_names := [`copy_doc_string_cmd, `copy_doc_string],
+  tags := ["documentation"],
+  inherit_description_from := `copy_doc_string_cmd }
 
 -- add docs to core tactics
 

--- a/src/tactic/doc_commands.lean
+++ b/src/tactic/doc_commands.lean
@@ -40,7 +40,9 @@ nspace <.> ("_" ++ to_string id.hash)
 
 open tactic
 
-/-- Copy the docstring from the name `fr` to the names in `to`. -/
+/-- 
+`copy_doc_string fr to` copies the docstring from the declaration named `fr` 
+to each declaration named in the list `to`. -/
 meta def tactic.copy_doc_string (fr : name) (to : list name) : tactic unit :=
 do fr_ds ← doc_string fr,
    to.mmap' $ λ tgt, add_doc_string tgt fr_ds

--- a/src/tactic/nth_rewrite/default.lean
+++ b/src/tactic/nth_rewrite/default.lean
@@ -110,12 +110,10 @@ nth_rewrite_core [] n q l
 meta def nth_rewrite_lhs (n : parse small_nat) (q : parse rw_rules) (l : parse location) : tactic unit :=
 nth_rewrite_core [dir.F, dir.A] n q l
 
-copy_doc_string nth_rewrite nth_rewrite_lhs
-
 meta def nth_rewrite_rhs (n : parse small_nat) (q : parse rw_rules) (l : parse location) : tactic unit :=
 nth_rewrite_core [dir.A] n q l
 
-copy_doc_string nth_rewrite nth_rewrite_rhs
+copy_doc_string nth_rewrite → nth_rewrite_lhs nth_rewrite_rhs
 
 add_tactic_doc
 { name       := "nth_rewrite / nth_rewrite_lhs / nth_rewrite_rhs",


### PR DESCRIPTION
#2471 added a command for copying a doc string from one decl to another. This PR:
* documents this command
* extends it to copy to a list of decls
* moves `add_doc_string` from root to the `tactic` namespace

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
