### PR TITLE
[Merged by Bors] - chore(topology/algebra/module): don't use unbundled homs for `algebra` instance

### DIFF
--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -62,6 +62,28 @@ namespace algebra
 
 variables {R : Type u} {S : Type v} {A : Type w}
 
+/-- Let `R` be a commutative semiring, let `A` be a semiring with a `semimodule R` structure.
+If `(r • 1) * x = x * (r • 1) = r • x` for all `r : R` and `x : A`, then `A` is an `algebra`
+over `R`. -/
+def of_semimodule' [comm_semiring R] [semiring A] [semimodule R A]
+  (h₁ : ∀ (r : R) (x : A), (r • 1) * x = r • x)
+  (h₂ : ∀ (r : R) (x : A), x * (r • 1) = r • x) : algebra R A :=
+{ to_fun := λ r, r • 1,
+  map_one' := one_smul _ _,
+  map_mul' := λ r₁ r₂, by rw [h₁, mul_smul],
+  map_zero' := zero_smul _ _,
+  map_add' := λ r₁ r₂, add_smul r₁ r₂ 1,
+  commutes' := λ r x, by simp only [h₁, h₂],
+  smul_def' := λ r x, by simp only [h₁] }
+
+/-- Let `R` be a commutative semiring, let `A` be a semiring with a `semimodule R` structure.
+If `(r • x) * y = x * (r • y) = r • (x * y)` for all `r : R` and `x y : A`, then `A`
+is an `algebra` over `R`. -/
+def of_semimodule [comm_semiring R] [semiring A] [semimodule R A]
+  (h₁ : ∀ (r : R) (x y : A), (r • x) * y = r • (x * y))
+  (h₂ : ∀ (r : R) (x y : A), x * (r • y) = r • (x * y)) : algebra R A :=
+of_semimodule' (λ r x, by rw [h₁, one_mul]) (λ r x, by rw [h₂, mul_one])
+
 section semiring
 
 variables [comm_semiring R] [comm_semiring S] [semiring A] [algebra R A]

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -316,6 +316,8 @@ rfl
 
 instance : has_mul (M →L[R] M) := ⟨comp⟩
 
+@[simp] lemma mul_apply (f g : M →L[R] M) (x : M) : (f * g) x = f (g x) := rfl
+
 instance [topological_add_group M] : ring (M →L[R] M) :=
 { mul := (*),
   one := 1,
@@ -516,16 +518,8 @@ instance : module R (M →L[R] M₂) :=
   add_smul  := λ _ _ _, ext $ λ _, add_smul _ _ _,
   smul_add  := λ _ _ _, ext $ λ _, smul_add _ _ _ }
 
-set_option class.instance_max_depth 55
-
-instance : is_ring_hom (λ c : R, c • (1 : M₂ →L[R] M₂)) :=
-{ map_one := one_smul _ _,
-  map_add := λ _ _, ext $ λ _, add_smul _ _ _,
-  map_mul := λ _ _, ext $ λ _, mul_smul _ _ _ }
-
 instance : algebra R (M₂ →L[R] M₂) :=
-(ring_hom.of $ λ c, c • (1 : M₂ →L[R] M₂)).to_algebra' $
-  λ _ _, ext $ λ _, (map_smul _ _ _).symm
+algebra.of_semimodule' (λ c f, ext $ λ x, rfl) (λ c f, ext $ λ x, f.map_smul c x)
 
 end comm_ring
 


### PR DESCRIPTION
Define special `algebra.of_semimodule` and `algebra.of_semimodule'`
constructors instead.

ref. #2534