### PR TITLE
[Merged by Bors] - feat(data/complex/basic): inv_I and div_I

### DIFF
--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -287,7 +287,7 @@ by rw [division_def, conj_mul, conj_inv]; refl
 (div_eq_iff_mul_eq I_ne_zero).2 $ by simp [mul_assoc]
 
 @[simp] lemma inv_I : I⁻¹ = -I :=
-by simp [inv_eq_one_div, div_I]
+by simp [inv_eq_one_div]
 
 @[simp] lemma norm_sq_inv (z : ℂ) : norm_sq z⁻¹ = (norm_sq z)⁻¹ :=
 by classical; exact

--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -283,6 +283,12 @@ by ext; simp [neg_div]
 @[simp] lemma conj_div (z w : ℂ) : conj (z / w) = conj z / conj w :=
 by rw [division_def, conj_mul, conj_inv]; refl
 
+@[simp] lemma div_I (z : ℂ) : z / I = -(z * I) :=
+(div_eq_iff_mul_eq I_ne_zero).2 $ by simp [mul_assoc]
+
+@[simp] lemma inv_I : I⁻¹ = -I :=
+by simp [inv_eq_one_div, div_I]
+
 @[simp] lemma norm_sq_inv (z : ℂ) : norm_sq z⁻¹ = (norm_sq z)⁻¹ :=
 by classical; exact
 if h : z = 0 then by simp [h] else


### PR DESCRIPTION

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
