### PR TITLE
[Merged by Bors] - feat(algebra/lie_algebra): define simple Lie algebras and define classical Lie algebra, slₙ

### DIFF
--- a/src/algebra/classical_lie_algebras.lean
+++ b/src/algebra/classical_lie_algebras.lean
@@ -1,0 +1,71 @@
+import algebra.lie_algebra
+import linear_algebra.matrix
+
+universes u₁ u₂
+
+namespace lie_algebra
+
+namespace special_linear
+open_locale matrix
+
+variables (n : Type u₁) (R : Type u₂)
+variables [fintype n] [decidable_eq n] [nonzero_comm_ring R]
+
+local attribute [instance] matrix.lie_ring
+local attribute [instance] matrix.lie_algebra
+
+lemma matrix_trace_commutator_zero (X Y : matrix n n R) : matrix.trace n R R ⁅X, Y⁆ = 0 :=
+begin
+  change matrix.trace n R R (X ⬝ Y - Y ⬝ X) = 0,
+  simp only [matrix.trace_mul_comm, linear_map.map_sub, sub_self],
+end
+
+/-- The special linear Lie algebra: square matrices of trace zero. -/
+def sl : lie_subalgebra R (matrix n n R) :=
+{ lie_mem := λ X Y _ _, by
+  { suffices : matrix.trace n R R ⁅X, Y⁆ = 0,
+      by apply (list.mem_pure ((matrix.trace n R R) ⁅X,Y⁆) 0).2 this,
+    apply matrix_trace_commutator_zero, },
+  ..linear_map.ker (matrix.trace n R R) }
+
+lemma sl_bracket (A B : sl n R) : ⁅A, B⁆.val = A.val ⬝ B.val - B.val ⬝ A.val := rfl
+
+section elementary_basis
+
+variables {n} (i j : n)
+
+/-- It is useful to define these matrices, for various explicit calculations. For j ≠ i, they are
+part of a natural basis of sl n R. -/
+abbreviation E : matrix n n R := λ i' j', if i = i' ∧ j = j' then 1 else 0
+
+@[simp] lemma E_one : E R i j i j = 1 := if_pos (and.intro rfl rfl)
+
+@[simp] lemma E_diag_zero (h : j ≠ i) : matrix.diag n R R (E R i j) = 0 :=
+begin
+  ext k, rw matrix.diag_apply,
+  suffices : ¬(i = k ∧ j = k), by exact if_neg this,
+  rintros ⟨e₁, e₂⟩, apply h, subst e₁, exact e₂,
+end
+
+lemma E_trace_zero (h : j ≠ i) : matrix.trace n R R (E R i j) = 0 := by simp [h]
+
+/-- The E matrices as elements of sl n R. -/
+abbreviation E' (h : j ≠ i) : sl n R :=
+⟨E R i j, by { change E R i j ∈ linear_map.ker (matrix.trace n R R), simp [E_trace_zero R i j h], }⟩
+
+end elementary_basis
+
+lemma sl_non_abelian (h : 1 < fintype.card n) : ¬lie_algebra.is_abelian ↥(sl n R) :=
+begin
+  rcases fintype.exists_pair_of_one_lt_card h with ⟨i, j, hij⟩,
+  let A := E' R i j hij,
+  let B := E' R j i hij.symm,
+  intros c,
+  have c' : A.val ⬝ B.val = B.val ⬝ A.val := by { rw [←sub_eq_zero, ←sl_bracket, c.abelian], refl, },
+  have : 1 = 0 := by simpa [matrix.mul_val, hij] using (congr_fun (congr_fun c' i) i),
+  exact one_ne_zero this,
+end
+
+end special_linear
+
+end lie_algebra

--- a/src/algebra/classical_lie_algebras.lean
+++ b/src/algebra/classical_lie_algebras.lean
@@ -1,5 +1,26 @@
+/-
+Copyright (c) 2020 Oliver Nash. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Oliver Nash
+-/
 import algebra.lie_algebra
 import linear_algebra.matrix
+
+/-!
+# Classical Lie algebras
+
+This file is the place to find definitions and basic properties of the classical Lie algebras:
+  * Aₙ sl(n+1)
+  * Bₙ so(2n+1)
+  * Cₙ sp(2n)
+  * Dₙ so(2n)
+
+As of April 2020, the definition of Aₙ is in place while the others still need to be provided.
+
+## Tags
+
+classical lie algebra, special linear
+-/
 
 universes u₁ u₂
 

--- a/src/algebra/classical_lie_algebras.lean
+++ b/src/algebra/classical_lie_algebras.lean
@@ -33,7 +33,7 @@ variables [fintype n] [decidable_eq n] [nonzero_comm_ring R]
 local attribute [instance] matrix.lie_ring
 local attribute [instance] matrix.lie_algebra
 
-lemma matrix_trace_commutator_zero (X Y : matrix n n R) : matrix.trace n R R ⁅X, Y⁆ = 0 :=
+@[simp] lemma matrix_trace_commutator_zero (X Y : matrix n n R) : matrix.trace n R R ⁅X, Y⁆ = 0 :=
 begin
   change matrix.trace n R R (X ⬝ Y - Y ⬝ X) = 0,
   simp only [matrix.trace_mul_comm, linear_map.map_sub, sub_self],

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -168,15 +168,8 @@ lemma lie_ring.of_associative_ring_bracket (A : Type v) [ring A] (x y : A) :
 lemma commutative_ring_iff_abelian_lie_ring (A : Type v) [ring A] :
   is_commutative A ring.mul ↔ lie_algebra.is_abelian A :=
 begin
-  -- Proof is obviously ridiculous but we can come back to it.
-  have h₁ : is_commutative A ring.mul ↔ ∀ (a b : A), a * b = b * a := by {
-    split; intros h,
-    { exact h.comm, },
-    { exact ⟨h⟩, }, },
-  have h₂ : lie_algebra.is_abelian A ↔ ∀ (a b : A), ⁅a, b⁆ = 0 := by {
-    split; intros h,
-    { exact h.abelian, },
-    { exact ⟨h⟩, }, },
+  have h₁ : is_commutative A ring.mul ↔ ∀ (a b : A), a * b = b * a := ⟨λ h, h.1, λ h, ⟨h⟩⟩,
+  have h₂ : lie_algebra.is_abelian A ↔ ∀ (a b : A), ⁅a, b⁆ = 0 := ⟨λ h, h.1, λ h, ⟨h⟩⟩,
   simp only [h₁, h₂, lie_ring.of_associative_ring_bracket, sub_eq_zero],
 end
 

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -168,7 +168,7 @@ lemma lie_ring.of_associative_ring_bracket (A : Type v) [ring A] (x y : A) :
 lemma commutative_ring_iff_abelian_lie_ring (A : Type v) [ring A] :
   is_commutative A (*) ↔ lie_algebra.is_abelian A :=
 begin
-  have h₁ : is_commutative A ring.mul ↔ ∀ (a b : A), a * b = b * a := ⟨λ h, h.1, λ h, ⟨h⟩⟩,
+  have h₁ : is_commutative A (*) ↔ ∀ (a b : A), a * b = b * a := ⟨λ h, h.1, λ h, ⟨h⟩⟩,
   have h₂ : lie_algebra.is_abelian A ↔ ∀ (a b : A), ⁅a, b⁆ = 0 := ⟨λ h, h.1, λ h, ⟨h⟩⟩,
   simp only [h₁, h₂, lie_ring.of_associative_ring_bracket, sub_eq_zero],
 end

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -46,6 +46,12 @@ class has_bracket (L : Type v) := (bracket : L → L → L)
 
 notation `⁅`x`,` y`⁆` := has_bracket.bracket x y
 
+/-- An Abelian Lie algebra is one in which all brackets vanish. Arguably this class belongs in the
+`has_bracket` namespace but it seems much more user-friendly to compromise slightly and put it in
+the `lie_algebra` namespace. -/
+class lie_algebra.is_abelian (L : Type v) [has_bracket L] [has_zero L] : Prop :=
+(abelian : ∀ (x y : L), ⁅x, y⁆ = 0)
+
 namespace ring_commutator
 
 variables {A : Type v} [ring A]
@@ -153,6 +159,26 @@ def lie_ring.of_associative_ring (A : Type v) [ring A] : lie_ring A :=
   lie_add  := ring_commutator.add_right,
   lie_self := ring_commutator.alternate,
   jacobi   := ring_commutator.jacobi }
+
+local attribute [instance] lie_ring.of_associative_ring
+
+lemma lie_ring.of_associative_ring_bracket (A : Type v) [ring A] (x y : A) :
+  ⁅x, y⁆ = x*y - y*x := rfl
+
+lemma commutative_ring_iff_abelian_lie_ring (A : Type v) [ring A] :
+  is_commutative A ring.mul ↔ lie_algebra.is_abelian A :=
+begin
+  -- Proof is obviously ridiculous but we can come back to it.
+  have h₁ : is_commutative A ring.mul ↔ ∀ (a b : A), a * b = b * a := by {
+    split; intros h,
+    { exact h.comm, },
+    { exact ⟨h⟩, }, },
+  have h₂ : lie_algebra.is_abelian A ↔ ∀ (a b : A), ⁅a, b⁆ = 0 := by {
+    split; intros h,
+    { exact h.abelian, },
+    { exact ⟨h⟩, }, },
+  simp only [h₁, h₂, lie_ring.of_associative_ring_bracket, sub_eq_zero],
+end
 
 end lie_ring
 
@@ -365,18 +391,16 @@ instance : inhabited (lie_subalgebra R L) := ⟨0⟩
 instance lie_subalgebra_coe_submodule : has_coe (lie_subalgebra R L) (submodule R L) :=
 ⟨lie_subalgebra.to_submodule⟩
 
-/-- A Lie subalgebra forms a new Lie ring.
-This cannot be an instance, since being a Lie subalgebra is (currently) not a class. -/
-def lie_subalgebra_lie_ring (L' : lie_subalgebra R L) : lie_ring L' := {
+/-- A Lie subalgebra forms a new Lie ring. -/
+instance lie_subalgebra_lie_ring (L' : lie_subalgebra R L) : lie_ring L' := {
   bracket  := λ x y, ⟨⁅x.val, y.val⁆, L'.lie_mem x.property y.property⟩,
   lie_add  := by { intros, apply set_coe.ext, apply lie_add, },
   add_lie  := by { intros, apply set_coe.ext, apply add_lie, },
   lie_self := by { intros, apply set_coe.ext, apply lie_self, },
   jacobi   := by { intros, apply set_coe.ext, apply lie_ring.jacobi, } }
 
-/-- A Lie subalgebra forms a new Lie algebra.
-This cannot be an instance, since being a Lie subalgebra is (currently) not a class. -/
-def lie_subalgebra_lie_algebra (L' : lie_subalgebra R L) :
+/-- A Lie subalgebra forms a new Lie algebra. -/
+instance lie_subalgebra_lie_algebra (L' : lie_subalgebra R L) :
     @lie_algebra R L' _ (lie_subalgebra_lie_ring _ _ _) :=
 { lie_smul := by { intros, apply set_coe.ext, apply lie_smul } }
 
@@ -467,6 +491,15 @@ An ideal of a Lie algebra is a Lie subalgebra.
 def lie_ideal_subalgebra (I : lie_ideal R L) : lie_subalgebra R L := {
   lie_mem := by { intros x y hx hy, apply lie_mem_right, exact hy, },
   ..I.to_submodule, }
+
+/-- A Lie module is irreducible if its only non-trivial Lie submodule is itself. -/
+class lie_module.is_irreducible [lie_module R L M] : Prop :=
+(irreducible : ∀ (M' : lie_submodule R L M), (∃ (m : M'), m ≠ 0) → (∀ (m : M), m ∈ M'))
+
+/-- A Lie algebra is simple if it is irreducible as a Lie module over itself via the adjoint
+action, and it is non-Abelian. -/
+class lie_algebra.is_simple : Prop :=
+(simple : lie_module.is_irreducible R L L ∧ ¬lie_algebra.is_abelian L)
 
 end lie_module
 

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -166,7 +166,7 @@ lemma lie_ring.of_associative_ring_bracket (A : Type v) [ring A] (x y : A) :
   ⁅x, y⁆ = x*y - y*x := rfl
 
 lemma commutative_ring_iff_abelian_lie_ring (A : Type v) [ring A] :
-  is_commutative A ring.mul ↔ lie_algebra.is_abelian A :=
+  is_commutative A (*) ↔ lie_algebra.is_abelian A :=
 begin
   have h₁ : is_commutative A ring.mul ↔ ∀ (a b : A), a * b = b * a := ⟨λ h, h.1, λ h, ⟨h⟩⟩,
   have h₂ : lie_algebra.is_abelian A ↔ ∀ (a b : A), ⁅a, b⁆ = 0 := ⟨λ h, h.1, λ h, ⟨h⟩⟩,

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -423,6 +423,13 @@ let ⟨c, hc⟩ := classical.not_forall.1 hb in
 by haveI := classical.dec_eq α; exact
 if hba : b = a then ⟨c, by cc⟩ else ⟨b, hba⟩
 
+lemma fintype.exists_pair_of_one_lt_card [fintype α] (h : 1 < fintype.card α) :
+  ∃ (a b : α), b ≠ a :=
+begin
+  rcases fintype.card_pos_iff.1 (nat.lt_of_succ_lt h) with a,
+  exact ⟨a, fintype.exists_ne_of_one_lt_card h a⟩,
+end
+
 lemma fintype.injective_iff_surjective [fintype α] {f : α → α} : injective f ↔ surjective f :=
 by haveI := classical.prop_decidable; exact
 have ∀ {f : α → α}, injective f → surjective f,

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -197,6 +197,8 @@ def diag (n : Type u) (R : Type v) (M : Type w)
   add    := by { intros, ext, refl, },
   smul   := by { intros, ext, refl, } }
 
+@[simp] lemma diag_apply (A : matrix n n M) (i : n) : diag n R M A i = A i i := rfl
+
 @[simp] lemma diag_one [decidable_eq n] :
   diag n R R 1 = λ i, 1 := by { dunfold diag, ext, simp [one_val_eq] }
 
@@ -210,6 +212,8 @@ def trace (n : Type u) (R : Type v) (M : Type w)
   to_fun := finset.univ.sum ∘ (diag n R M),
   add    := by { intros, apply finset.sum_add_distrib, },
   smul   := by { intros, simp [finset.smul_sum], } }
+
+@[simp] lemma trace_diag (A : matrix n n M) : trace n R M A = finset.univ.sum (diag n R M A) := rfl
 
 @[simp] lemma trace_one [decidable_eq n] :
   trace n R R 1 = fintype.card n :=


### PR DESCRIPTION
The changes here introduce a few important properties of Lie algebras and also begin providing definitions of the classical Lie algebras. The key changes are the following definitions:
 * `lie_algebra.is_abelian`
 * `lie_module.is_irreducible`
 * `lie_algebra.is_simple`
 * `lie_algebra.special_linear.sl`

Some simple related proofs are also included such as:
 * `commutative_ring_iff_abelian_lie_ring`
 * `lie_algebra.special_linear.sl_non_abelian`

TO CONTRIBUTORS:

Please include a summary of the changes made in this PR above "TO CONTRIBUTORS:", as that text will become the commit message. You are also encouraged to append the following [co-authorship template](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) if you'd like to acknowledge suggestions / commits made by other users:

Co-authored-by: name <name@example.com>

Make sure you have:

  * [x] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [x] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [x] make sure definitions and lemmas are put in the right files
  * [x] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)

If you're confused by comments on your PR like `bors r+` or `bors d+`, please see our [notes on bors](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for information on our merging workflow.
