### PR TITLE
[Merged by Bors] - fix(tactic/interactive): make `inhabit` work on quantified goals

### DIFF
--- a/test/inhabit.lean
+++ b/test/inhabit.lean
@@ -1,0 +1,13 @@
+import tactic.interactive
+
+lemma a {α} [nonempty α] : ∃ a : α, a = a :=
+by inhabit α; use default _; refl
+
+noncomputable def b {α} [nonempty α] : α :=
+by inhabit α; apply default
+
+lemma c {α} [nonempty α] : ∀ n : ℕ, ∃ b : α, n = n :=
+by inhabit α; intro; use default _; refl
+
+noncomputable def d {α} [nonempty α] : ∀ n : ℕ, α :=
+by inhabit α; intro; apply default


### PR DESCRIPTION
This didn't work before because of the `∀` in the goal:
```lean
lemma c {α} [nonempty α] : ∀ n : ℕ, ∃ b : α, n = n :=
by inhabit α; intro; use default _; refl
```