### PR TITLE
[Merged by Bors] - chore(algebra/group_with_zero): rename div_eq_inv_mul' to div_eq_inv_mul

### DIFF
--- a/src/algebra/group_with_zero.lean
+++ b/src/algebra/group_with_zero.lean
@@ -455,7 +455,7 @@ end comm_group_with_zero
 section comm_group_with_zero
 variables {G₀ : Type*} [comm_group_with_zero G₀] {a b c d : G₀}
 
-lemma div_eq_inv_mul' : a / b = b⁻¹ * a := mul_comm _ _
+lemma div_eq_inv_mul : a / b = b⁻¹ * a := mul_comm _ _
 
 lemma mul_div_right_comm (a b c : G₀) : (a * b) / c = (a / c) * b :=
 by rw [div_eq_mul_inv, mul_assoc, mul_comm b, ← mul_assoc]; refl

--- a/src/algebra/ordered_field.lean
+++ b/src/algebra/ordered_field.lean
@@ -75,7 +75,7 @@ lemma div_lt_iff_of_neg (hc : c < 0) : b / c < a ↔ a * c < b :=
 
 lemma inv_le_inv (ha : 0 < a) (hb : 0 < b) : a⁻¹ ≤ b⁻¹ ↔ b ≤ a :=
 by rw [inv_eq_one_div, div_le_iff ha,
-       ← div_eq_inv_mul', one_le_div_iff_le hb]
+       ← div_eq_inv_mul, one_le_div_iff_le hb]
 
 lemma inv_le (ha : 0 < a) (hb : 0 < b) : a⁻¹ ≤ b ↔ b⁻¹ ≤ a :=
 by rw [← inv_le_inv hb (inv_pos.2 ha), inv_inv']

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -1220,7 +1220,7 @@ begin
   have A : (d x)⁻¹ * (d x)⁻¹ * (c' * d x) = (d x)⁻¹ * c',
     by rw [← mul_assoc, mul_comm, ← mul_assoc, ← mul_assoc, mul_inv_cancel hx, one_mul],
   convert hc.mul ((has_deriv_at_inv hx).comp_has_deriv_within_at x hd),
-  simp [div_eq_inv_mul', pow_two, mul_inv', mul_add, A, sub_eq_add_neg],
+  simp [div_eq_inv_mul, pow_two, mul_inv', mul_add, A, sub_eq_add_neg],
   ring
 end
 

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -283,7 +283,7 @@ have h : ∀ x', ∥x' - x∥ = 0 → ∥f x' - f x - f' (x' - x)∥ = 0, from �
 begin
   unfold has_fderiv_at_filter,
   rw [←is_o_norm_left, ←is_o_norm_right, is_o_iff_tendsto h],
-  exact tendsto_congr (λ _, div_eq_inv_mul'),
+  exact tendsto_congr (λ _, div_eq_inv_mul),
 end
 
 theorem has_fderiv_within_at_iff_tendsto : has_fderiv_within_at f f' s x ↔

--- a/src/analysis/convex/basic.lean
+++ b/src/analysis/convex/basic.lean
@@ -158,9 +158,9 @@ lemma convex_iff_div:
   assume h x y hx hy a b ha hb hab,
   apply h hx hy,
   have ha', from mul_le_mul_of_nonneg_left ha (le_of_lt (inv_pos.2 hab)),
-  rwa [mul_zero, ←div_eq_inv_mul'] at ha',
+  rwa [mul_zero, ←div_eq_inv_mul] at ha',
   have hb', from mul_le_mul_of_nonneg_left hb (le_of_lt (inv_pos.2 hab)),
-  rwa [mul_zero, ←div_eq_inv_mul'] at hb',
+  rwa [mul_zero, ←div_eq_inv_mul] at hb',
   rw [←add_div],
   exact div_self (ne_of_lt hab).symm
 end,
@@ -534,7 +534,7 @@ by simp only [center_mass, sum_empty, smul_zero]
 
 lemma finset.center_mass_pair (hne : i ≠ j) :
   ({i, j} : finset ι).center_mass w z = (w i / (w i + w j)) • z i + (w j / (w i + w j)) • z j :=
-by simp only [center_mass, sum_pair hne, smul_add, (mul_smul _ _ _).symm, div_eq_inv_mul']
+by simp only [center_mass, sum_pair hne, smul_add, (mul_smul _ _ _).symm, div_eq_inv_mul]
 
 variable {w}
 
@@ -689,7 +689,7 @@ begin
   have : f y ≤ t.center_mass w (f ∘ z) := h.map_center_mass_le hw₀ hws hz,
   rw ← sum_filter_ne_zero at hws,
   rw [← finset.center_mass_filter_ne_zero (f ∘ z), center_mass, smul_eq_mul,
-    ← div_eq_inv_mul', le_div_iff hws, mul_sum] at this,
+    ← div_eq_inv_mul, le_div_iff hws, mul_sum] at this,
   replace : ∃ i ∈ t.filter (λ i, w i ≠ 0), f y * w i ≤ w i • (f ∘ z) i :=
     exists_le_of_sum_le (nonempty_of_sum_ne_zero (ne_of_gt hws)) this,
   rcases this with ⟨i, hi, H⟩,

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -271,7 +271,7 @@ lemma antilipschitz_with.add_lipschitz_with {α : Type*} [metric_space α] {Kf :
   antilipschitz_with (Kf⁻¹ - Kg)⁻¹ (λ x, f x + g x) :=
 begin
   refine antilipschitz_with.of_le_mul_dist (λ x y, _),
-  rw [nnreal.coe_inv, ← div_eq_inv_mul'],
+  rw [nnreal.coe_inv, ← div_eq_inv_mul],
   apply le_div_of_mul_le (nnreal.coe_pos.2 $ nnreal.sub_pos.2 hK),
   rw [mul_comm, nnreal.coe_sub (le_of_lt hK), sub_mul],
   calc ↑Kf⁻¹ * dist x y - Kg * dist x y ≤ dist (f x) (f y) - dist (g x) (g y) :
@@ -588,7 +588,7 @@ begin
       by { rw [← dist_eq_norm, dist_comm], exact le_trans hx (min_le_left _ _) },
     show ∥x∥⁻¹ ≤ 2 * ∥r∥⁻¹,
     { convert (inv_le_inv norm_x_pos (half_pos norm_r_pos)).2 rx,
-      rw [inv_div, div_eq_inv_mul', mul_comm] },
+      rw [inv_div, div_eq_inv_mul, mul_comm] },
     show (0 : ℝ) ≤ 2, by norm_num
   end
   ... = ε * (∥r∥ * ∥r∥⁻¹)^2 : by { generalize : ∥r∥⁻¹ = u, ring }
@@ -736,16 +736,16 @@ begin
   show (c ^ (n + 1))⁻¹  ≠ 0,
     by rwa [ne.def, inv_eq_zero, ← ne.def, ← norm_pos_iff],
   show ∥(c ^ (n + 1))⁻¹ • x∥ ≤ ε,
-  { rw [norm_smul, norm_inv, ← div_eq_inv_mul', div_le_iff cnpos, mul_comm, norm_fpow],
+  { rw [norm_smul, norm_inv, ← div_eq_inv_mul, div_le_iff cnpos, mul_comm, norm_fpow],
     exact (div_le_iff εpos).1 (le_of_lt (hn.2)) },
   show ε / ∥c∥ ≤ ∥(c ^ (n + 1))⁻¹ • x∥,
   { rw [div_le_iff cpos, norm_smul, norm_inv, norm_fpow, fpow_add (ne_of_gt cpos),
         fpow_one, mul_inv', mul_comm, ← mul_assoc, ← mul_assoc, mul_inv_cancel (ne_of_gt cpos),
-        one_mul, ← div_eq_inv_mul', le_div_iff (fpow_pos_of_pos cpos _), mul_comm],
+        one_mul, ← div_eq_inv_mul, le_div_iff (fpow_pos_of_pos cpos _), mul_comm],
     exact (le_div_iff εpos).1 hn.1 },
   show ∥(c ^ (n + 1))⁻¹∥⁻¹ ≤ ε⁻¹ * ∥c∥ * ∥x∥,
   { have : ε⁻¹ * ∥c∥ * ∥x∥ = ε⁻¹ * ∥x∥ * ∥c∥, by ring,
-    rw [norm_inv, inv_inv', norm_fpow, fpow_add (ne_of_gt cpos), fpow_one, this, ← div_eq_inv_mul'],
+    rw [norm_inv, inv_inv', norm_fpow, fpow_add (ne_of_gt cpos), fpow_one, this, ← div_eq_inv_mul],
     exact mul_le_mul_of_nonneg_right hn.1 (norm_nonneg _) }
 end
 

--- a/src/data/real/cau_seq_completion.lean
+++ b/src/data/real/cau_seq_completion.lean
@@ -138,7 +138,7 @@ theorem of_rat_inv (x : β) : of_rat (x⁻¹) = ((of_rat x)⁻¹ : Cauchy) :=
 congr_arg mk $ by split_ifs with h; try {simp [const_lim_zero.1 h]}; refl
 
 theorem of_rat_div (x y : β) : of_rat (x / y) = (of_rat x / of_rat y : Cauchy) :=
-by simp only [div_eq_inv_mul', of_rat_inv, of_rat_mul]
+by simp only [div_eq_inv_mul, of_rat_inv, of_rat_mul]
 
 end
 end cau_seq.completion

--- a/src/measure_theory/probability_mass_function.lean
+++ b/src/measure_theory/probability_mass_function.lean
@@ -107,7 +107,7 @@ def seq (f : pmf (α → β)) (p : pmf α) : pmf β := f.bind (λm, p.bind $ λa
 def of_multiset (s : multiset α) (hs : s ≠ 0) : pmf α :=
 ⟨λa, s.count a / s.card,
   have s.to_finset.sum (λa, (s.count a : ℝ) / s.card) = 1,
-    by simp [div_eq_inv_mul', finset.mul_sum.symm, (finset.sum_nat_cast _ _).symm, hs],
+    by simp [div_eq_inv_mul, finset.mul_sum.symm, (finset.sum_nat_cast _ _).symm, hs],
   have s.to_finset.sum (λa, (s.count a : nnreal) / s.card) = 1,
     by rw [← nnreal.eq_iff, nnreal.coe_one, ← this, nnreal.coe_sum]; simp,
   begin

--- a/src/topology/metric_space/antilipschitz.lean
+++ b/src/topology/metric_space/antilipschitz.lean
@@ -41,7 +41,7 @@ lemma antilipschitz_with.mul_le_dist [metric_space α] [metric_space β] {K : �
   ↑K⁻¹ * dist x y ≤ dist (f x) (f y) :=
 begin
   by_cases hK : K = 0, by simp [hK, dist_nonneg],
-  rw [nnreal.coe_inv, ← div_eq_inv_mul'],
+  rw [nnreal.coe_inv, ← div_eq_inv_mul],
   apply div_le_of_le_mul (nnreal.coe_pos.2 $ zero_lt_iff_ne_zero.2 hK),
   exact hf.le_mul_dist x y
 end


### PR DESCRIPTION
There are no occurrences of the name without ' in either core or mathlib
so this change in name (from #2242) seems to have been unnecessary.