### PR TITLE
[Merged by Bors] - chore(group_theory/perm): delete duplicate lemmas

### DIFF
--- a/src/data/fintype/card.lean
+++ b/src/data/fintype/card.lean
@@ -174,7 +174,7 @@ begin
 end
 
 @[to_additive]
-lemma prod_equiv [fintype α] [fintype β] [comm_monoid γ] (e : α ≃ β) (f : β → γ) :
+lemma finset.prod_equiv [fintype α] [fintype β] [comm_monoid γ] (e : α ≃ β) (f : β → γ) :
   finset.univ.prod (f ∘ e) = finset.univ.prod f :=
 begin
   apply prod_bij (λ i hi, e i) (λ i hi, mem_univ _) _ (λ a b _ _ h, e.injective h),

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -700,14 +700,3 @@ using_well_founded {rel_tac := λ _ _, `[exact ⟨_, measure_wf (λ f, f.support
 end sign
 
 end equiv.perm
-
-lemma finset.prod_univ_perm [fintype α] [comm_monoid β] {f : α → β} (σ : perm α) :
-  (univ : finset α).prod f = univ.prod (λ z, f (σ z)) :=
-eq.symm $ prod_bij (λ z _, σ z) (λ _ _, mem_univ _) (λ _ _, rfl)
-  (λ _ _ _ _ H, σ.injective H) (λ b _, ⟨σ⁻¹ b, mem_univ _, by simp⟩)
-
-lemma finset.sum_univ_perm [fintype α] [add_comm_monoid β] {f : α → β} (σ : perm α) :
-  (univ : finset α).sum f = univ.sum (λ z, f (σ z)) :=
-@finset.prod_univ_perm _ (multiplicative β) _ _ f σ
-
-attribute [to_additive] finset.prod_univ_perm

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -92,7 +92,7 @@ calc det (M ⬝ N) = univ.sum (λ p : n → n, univ.sum
   sum_congr rfl (λ σ _, sum_bij (λ τ _, τ * σ⁻¹) (λ _ _, mem_univ _)
     (λ τ _,
       have univ.prod (λ j, M (τ j) (σ j)) = univ.prod (λ j, M ((τ * σ⁻¹) j) j),
-        by rw prod_univ_perm σ⁻¹; simp [mul_apply],
+        by rw ← finset.prod_equiv σ⁻¹; simp [mul_apply],
       have h : ε σ * ε (τ * σ⁻¹) = ε τ :=
         calc ε σ * ε (τ * σ⁻¹) = ε ((τ * σ⁻¹) * σ) :
           by rw [mul_comm, sign_mul (τ * σ⁻¹)]; simp [sign_mul]

--- a/src/number_theory/sum_four_squares.lean
+++ b/src/number_theory/sum_four_squares.lean
@@ -14,8 +14,8 @@ The proof used is close to Lagrange's original proof.
 -/
 import data.zmod.basic
 import field_theory.finite
-import group_theory.perm.sign
 import data.int.parity
+import data.fintype.card
 
 open finset polynomial finite_field equiv
 
@@ -93,7 +93,7 @@ let ⟨x, hx⟩ := h01 in let ⟨y, hy⟩ := h23 in
       ← int.sum_two_squares_of_two_mul_sum_two_squares hy.symm,
       ← domain.mul_left_inj (show (2 : ℤ) ≠ 0, from dec_trivial), ← h, mul_add, ← hx, ← hy],
     have : univ.sum (λ x, f (σ x)^2) = univ.sum (λ x, f x^2),
-    { conv_rhs { rw finset.sum_univ_perm σ } },
+    { conv_rhs { rw ← finset.sum_equiv σ } },
     have fin4univ : (univ : finset (fin 4)).1 = 0::1::2::3::0, from dec_trivial,
     simpa [finset.sum_eq_multiset_sum, fin4univ, multiset.sum_cons, f]
   end⟩


### PR DESCRIPTION
`sum_univ_perm` is a special case of `sum_equiv`, so it's not necessary. 

I also moved `sum_equiv` into the `finset` namespace.