### PR TITLE
[Merged by Bors] - chore(algebra/ordered_field): move inv_neg to field and prove for division ring

### DIFF
--- a/src/algebra/field.lean
+++ b/src/algebra/field.lean
@@ -59,6 +59,9 @@ inv_eq_iff
 lemma div_neg (a : α) : a / -b = -(a / b) :=
 by rw [← div_neg_eq_neg_div]
 
+lemma inv_neg : (-a)⁻¹ = -(a⁻¹) :=
+by rw neg_inv
+
 end division_ring
 
 @[priority 100] -- see Note [lower instance priority]

--- a/src/algebra/ordered_field.lean
+++ b/src/algebra/ordered_field.lean
@@ -185,9 +185,6 @@ by haveI := classical.dec_eq α; exact
 if ha0 : a = 0 then by simp [ha0]
 else (div_le_div_left (lt_of_le_of_ne ha (ne.symm ha0)) (lt_of_lt_of_le hc h) hc).2 h
 
-lemma inv_neg : (-a)⁻¹ = -(a⁻¹) :=
-by rwa [inv_eq_one_div, inv_eq_one_div, div_neg_eq_neg_div]
-
 lemma inv_le_inv_of_le {a b : α} (hb : 0 < b) (h : b ≤ a) : a⁻¹ ≤ b⁻¹ :=
 begin
   rw [inv_eq_one_div, inv_eq_one_div],


### PR DESCRIPTION
`neg_inv` this lemma with the equality swapped was already in the library, so maybe we should just get rid of this or `neg_inv`

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/inv_neg/near/196042954)