### PR TITLE
[Merged by Bors] - refactor(computability/turing_machine): add list_blank

### DIFF
--- a/src/computability/turing_machine.lean
+++ b/src/computability/turing_machine.lean
@@ -7,103 +7,544 @@ Define a sequence of simple machine languages, starting with Turing
 machines and working up to more complex lanaguages based on
 Wang B-machines.
 -/
+import algebra.order
 import data.fintype.basic
 import data.pfun
+import tactic.apply_fun
 
 open relation
+open function (update)
 
 namespace turing
+
+/-- The `blank_extends` partial order holds of `l₁` and `l₂` if `l₂` is obtained by adding
+blanks (`default Γ`) to the end of `l₁`. -/
+def blank_extends {Γ} [inhabited Γ] (l₁ l₂ : list Γ) : Prop :=
+∃ n, l₂ = l₁ ++ list.repeat (default Γ) n
+
+@[refl] theorem blank_extends.refl {Γ} [inhabited Γ] (l : list Γ) : blank_extends l l := ⟨0, by simp⟩
+
+@[trans] theorem blank_extends.trans {Γ} [inhabited Γ] {l₁ l₂ l₃ : list Γ} :
+  blank_extends l₁ l₂ → blank_extends l₂ l₃ → blank_extends l₁ l₃ :=
+by rintro ⟨i, rfl⟩ ⟨j, rfl⟩; exact ⟨i+j, by simp [list.repeat_add]⟩
+
+theorem blank_extends.below_of_le {Γ} [inhabited Γ] {l l₁ l₂ : list Γ} :
+  blank_extends l l₁ → blank_extends l l₂ →
+  l₁.length ≤ l₂.length → blank_extends l₁ l₂ :=
+begin
+  rintro ⟨i, rfl⟩ ⟨j, rfl⟩ h, use j - i,
+  simp only [list.length_append, add_le_add_iff_left, list.length_repeat] at h,
+  simp only [← list.repeat_add, nat.add_sub_cancel' h, list.append_assoc],
+end
+
+/-- Any two extensions by blank `l₁,l₂` of `l` have a common join (which can be taken to be the
+longer of `l₁` and `l₂`). -/
+def blank_extends.above {Γ} [inhabited Γ] {l l₁ l₂ : list Γ}
+  (h₁ : blank_extends l l₁) (h₂ : blank_extends l l₂) :
+  {l' // blank_extends l₁ l' ∧ blank_extends l₂ l'} :=
+if h : l₁.length ≤ l₂.length then
+  ⟨l₂, h₁.below_of_le h₂ h, blank_extends.refl _⟩
+else
+  ⟨l₁, blank_extends.refl _, h₂.below_of_le h₁ (le_of_not_ge h)⟩
+
+theorem blank_extends.above_of_le {Γ} [inhabited Γ] {l l₁ l₂ : list Γ} :
+  blank_extends l₁ l → blank_extends l₂ l →
+  l₁.length ≤ l₂.length → blank_extends l₁ l₂ :=
+begin
+  rintro ⟨i, rfl⟩ ⟨j, e⟩ h, use i - j,
+  refine list.append_right_cancel (e.symm.trans _),
+  rw [list.append_assoc, ← list.repeat_add, nat.sub_add_cancel],
+  apply_fun list.length at e,
+  simp only [list.length_append, list.length_repeat] at e,
+  rwa [ge, ← add_le_add_iff_left, e, add_le_add_iff_right]
+end
+
+/-- `blank_rel` is the symmetric closure of `blank_extends`, turning it into an equivalence
+relation. Two lists are related by `blank_rel` if one extends the other by blanks. -/
+def blank_rel {Γ} [inhabited Γ] (l₁ l₂ : list Γ) : Prop :=
+blank_extends l₁ l₂ ∨ blank_extends l₂ l₁
+
+@[refl] theorem blank_rel.refl {Γ} [inhabited Γ] (l : list Γ) : blank_rel l l :=
+or.inl (blank_extends.refl _)
+
+@[symm] theorem blank_rel.symm {Γ} [inhabited Γ] {l₁ l₂ : list Γ} :
+  blank_rel l₁ l₂ → blank_rel l₂ l₁ := or.symm
+
+@[trans] theorem blank_rel.trans {Γ} [inhabited Γ] {l₁ l₂ l₃ : list Γ} :
+  blank_rel l₁ l₂ → blank_rel l₂ l₃ → blank_rel l₁ l₃ :=
+begin
+  rintro (h₁|h₁) (h₂|h₂),
+  { exact or.inl (h₁.trans h₂) },
+  { cases le_total l₁.length l₃.length with h h,
+    { exact or.inl (h₁.above_of_le h₂ h) },
+    { exact or.inr (h₂.above_of_le h₁ h) } },
+  { cases le_total l₁.length l₃.length with h h,
+    { exact or.inl (h₁.below_of_le h₂ h) },
+    { exact or.inr (h₂.below_of_le h₁ h) } },
+  { exact or.inr (h₂.trans h₁) },
+end
+
+/-- Given two `blank_rel` lists, there exists (constructively) a common join. -/
+def blank_rel.above {Γ} [inhabited Γ] {l₁ l₂ : list Γ} (h : blank_rel l₁ l₂) :
+  {l // blank_extends l₁ l ∧ blank_extends l₂ l} :=
+begin
+  refine if hl : l₁.length ≤ l₂.length
+    then ⟨l₂, or.elim h id (λ h', _), blank_extends.refl _⟩
+    else ⟨l₁, blank_extends.refl _, or.elim h (λ h', _) id⟩,
+  exact (blank_extends.refl _).above_of_le h' hl,
+  exact (blank_extends.refl _).above_of_le h' (le_of_not_ge hl)
+end
+
+/-- Given two `blank_rel` lists, there exists (constructively) a common meet. -/
+def blank_rel.below {Γ} [inhabited Γ] {l₁ l₂ : list Γ} (h : blank_rel l₁ l₂) :
+  {l // blank_extends l l₁ ∧ blank_extends l l₂} :=
+begin
+  refine if hl : l₁.length ≤ l₂.length
+    then ⟨l₁, blank_extends.refl _, or.elim h id (λ h', _)⟩
+    else ⟨l₂, or.elim h (λ h', _) id, blank_extends.refl _⟩,
+  exact (blank_extends.refl _).above_of_le h' hl,
+  exact (blank_extends.refl _).above_of_le h' (le_of_not_ge hl)
+end
+
+theorem blank_rel.equivalence (Γ) [inhabited Γ] : equivalence (@blank_rel Γ _) :=
+⟨blank_rel.refl, @blank_rel.symm _ _, @blank_rel.trans _ _⟩
+
+/-- Construct a setoid instance for `blank_rel`. -/
+def blank_rel.setoid (Γ) [inhabited Γ] : setoid (list Γ) := ⟨_, blank_rel.equivalence _⟩
+
+/-- A `list_blank Γ` is a quotient of `list Γ` by extension by blanks at the end. This is used to
+represent half-tapes of a Turing machine, so that we can pretend that the list continues
+infinitely with blanks. -/
+def list_blank (Γ) [inhabited Γ] := quotient (blank_rel.setoid Γ)
+
+instance list_blank.inhabited {Γ} [inhabited Γ] : inhabited (list_blank Γ) := ⟨quotient.mk' []⟩
+instance list_blank.has_emptyc {Γ} [inhabited Γ] : has_emptyc (list_blank Γ) := ⟨quotient.mk' []⟩
+
+/-- A modified version of `quotient.lift_on'` specialized for `list_blank`, with the stronger
+precondition `blank_extends` instead of `blank_rel`. -/
+@[elab_as_eliminator, reducible]
+protected def list_blank.lift_on {Γ} [inhabited Γ] {α} (l : list_blank Γ) (f : list Γ → α)
+  (H : ∀ a b, blank_extends a b → f a = f b) : α :=
+l.lift_on' f $ by rintro a b (h|h); [exact H _ _ h, exact (H _ _ h).symm]
+
+/-- The quotient map turning a `list` into a `list_blank`. -/
+def list_blank.mk {Γ} [inhabited Γ] : list Γ → list_blank Γ := quotient.mk'
+
+@[elab_as_eliminator]
+protected lemma list_blank.induction_on {Γ} [inhabited Γ]
+  {p : list_blank Γ → Prop} (q : list_blank Γ)
+  (h : ∀ a, p (list_blank.mk a)) : p q := quotient.induction_on' q h
+
+/-- The head of a `list_blank` is well defined. -/
+def list_blank.head {Γ} [inhabited Γ] (l : list_blank Γ) : Γ :=
+l.lift_on list.head begin
+  rintro _ _ ⟨i, rfl⟩,
+  cases a, {cases i; refl}, refl
+end
+
+@[simp] theorem list_blank.head_mk {Γ} [inhabited Γ] (l : list Γ) :
+  list_blank.head (list_blank.mk l) = l.head := rfl
+
+/-- The tail of a `list_blank` is well defined (up to the tail of blanks). -/
+def list_blank.tail {Γ} [inhabited Γ] (l : list_blank Γ) : list_blank Γ :=
+l.lift_on (λ l, list_blank.mk l.tail) begin
+  rintro _ _ ⟨i, rfl⟩,
+  refine quotient.sound' (or.inl _),
+  cases a; [{cases i; [exact ⟨0, rfl⟩, exact ⟨i, rfl⟩]}, exact ⟨i, rfl⟩]
+end
+
+@[simp] theorem list_blank.tail_mk {Γ} [inhabited Γ] (l : list Γ) :
+  list_blank.tail (list_blank.mk l) = list_blank.mk l.tail := rfl
+
+/-- We can cons an element onto a `list_blank`. -/
+def list_blank.cons {Γ} [inhabited Γ] (a : Γ) (l : list_blank Γ) : list_blank Γ :=
+l.lift_on (λ l, list_blank.mk (list.cons a l)) begin
+  rintro _ _ ⟨i, rfl⟩,
+  exact quotient.sound' (or.inl ⟨i, rfl⟩),
+end
+
+@[simp] theorem list_blank.cons_mk {Γ} [inhabited Γ] (a : Γ) (l : list Γ) :
+  list_blank.cons a (list_blank.mk l) = list_blank.mk (a :: l) := rfl
+
+@[simp] theorem list_blank.head_cons {Γ} [inhabited Γ] (a : Γ) :
+  ∀ (l : list_blank Γ), (l.cons a).head = a :=
+quotient.ind' $ by exact λ l, rfl
+
+@[simp] theorem list_blank.tail_cons {Γ} [inhabited Γ] (a : Γ) :
+  ∀ (l : list_blank Γ), (l.cons a).tail = l :=
+quotient.ind' $ by exact λ l, rfl
+
+/-- The `cons` and `head`/`tail` functions are mutually inverse, unlike in the case of `list` where
+this only holds for nonempty lists. -/
+@[simp] theorem list_blank.cons_head_tail {Γ} [inhabited Γ] :
+  ∀ (l : list_blank Γ), l.tail.cons l.head = l :=
+quotient.ind' begin
+  refine (λ l, quotient.sound' (or.inr _)),
+  cases l, {exact ⟨1, rfl⟩}, {refl},
+end
+
+/-- The `cons` and `head`/`tail` functions are mutually inverse, unlike in the case of `list` where
+this only holds for nonempty lists. -/
+theorem list_blank.exists_cons {Γ} [inhabited Γ] (l : list_blank Γ) :
+  ∃ a l', l = list_blank.cons a l' :=
+⟨_, _, (list_blank.cons_head_tail _).symm⟩
+
+/-- The n-th element of a `list_blank` is well defined for all `n : ℕ`, unlike in a `list`. -/
+def list_blank.nth {Γ} [inhabited Γ] (l : list_blank Γ) (n : ℕ) : Γ :=
+l.lift_on (λ l, list.inth l n) begin
+  rintro l _ ⟨i, rfl⟩,
+  simp only [list.inth],
+  cases lt_or_le _ _ with h h, {rw list.nth_append h},
+  rw list.nth_len_le h,
+  cases le_or_lt _ _ with h₂ h₂, {rw list.nth_len_le h₂},
+  rw [list.nth_le_nth h₂, list.nth_le_append_right h, list.nth_le_repeat]
+end
+
+@[simp] theorem list_blank.nth_mk {Γ} [inhabited Γ] (l : list Γ) (n : ℕ) :
+  (list_blank.mk l).nth n = l.inth n := rfl
+
+@[simp] theorem list_blank.nth_zero {Γ} [inhabited Γ] (l : list_blank Γ) : l.nth 0 = l.head :=
+begin
+  conv {to_lhs, rw [← list_blank.cons_head_tail l]},
+  exact quotient.induction_on' l.tail (λ l, rfl)
+end
+
+@[simp] theorem list_blank.nth_succ {Γ} [inhabited Γ] (l : list_blank Γ) (n : ℕ) :
+  l.nth (n + 1) = l.tail.nth n :=
+begin
+  conv {to_lhs, rw [← list_blank.cons_head_tail l]},
+  exact quotient.induction_on' l.tail (λ l, rfl)
+end
+
+@[ext] theorem list_blank.ext {Γ} [inhabited Γ] {L₁ L₂ : list_blank Γ} :
+  (∀ i, L₁.nth i = L₂.nth i) → L₁ = L₂ :=
+list_blank.induction_on L₁ $ λ l₁, list_blank.induction_on L₂ $ λ l₂ H,
+begin
+  wlog h : l₁.length ≤ l₂.length using l₁ l₂,
+  swap, { exact (this $ λ i, (H i).symm).symm },
+  refine quotient.sound' (or.inl ⟨l₂.length - l₁.length, _⟩),
+  refine list.ext_le _ (λ i h h₂, eq.symm _),
+  { simp only [nat.add_sub_of_le h, list.length_append, list.length_repeat] },
+  simp at H,
+  cases lt_or_le i l₁.length with h' h',
+  { simpa only [list.nth_le_append _ h',
+      list.nth_le_nth h, list.nth_le_nth h', option.iget] using H i },
+  { simpa only [list.nth_le_append_right h', list.nth_le_repeat,
+      list.nth_le_nth h, list.nth_len_le h', option.iget] using H i },
+end
+
+/-- Apply a function to a value stored at the nth position of the list. -/
+@[simp] def list_blank.modify_nth {Γ} [inhabited Γ] (f : Γ → Γ) : ℕ → list_blank Γ → list_blank Γ
+| 0     L := L.tail.cons (f L.head)
+| (n+1) L := (L.tail.modify_nth n).cons L.head
+
+theorem list_blank.nth_modify_nth {Γ} [inhabited Γ] (f : Γ → Γ) (n i) (L : list_blank Γ) :
+  (L.modify_nth f n).nth i = if i = n then f (L.nth i) else L.nth i :=
+begin
+  induction n with n IH generalizing i L,
+  { cases i; simp only [list_blank.nth_zero, if_true,
+      list_blank.head_cons, list_blank.modify_nth, eq_self_iff_true,
+      list_blank.nth_succ, if_false, list_blank.tail_cons] },
+  { cases i,
+    { rw if_neg (nat.succ_ne_zero _).symm,
+      simp only [list_blank.nth_zero, list_blank.head_cons, list_blank.modify_nth] },
+    { simp only [IH, list_blank.modify_nth, list_blank.nth_succ, list_blank.tail_cons],
+      congr } }
+end
+
+/-- A pointed map of `inhabited` types is a map that sends one default value to the other. -/
+structure {u v} pointed_map (Γ : Type u) (Γ' : Type v)
+  [inhabited Γ] [inhabited Γ'] : Type (max u v) :=
+(f : Γ → Γ') (map_pt' : f (default _) = default _)
+
+instance {Γ Γ'} [inhabited Γ] [inhabited Γ'] : inhabited (pointed_map Γ Γ') :=
+⟨⟨λ _, default _, rfl⟩⟩
+
+instance {Γ Γ'} [inhabited Γ] [inhabited Γ'] : has_coe_to_fun (pointed_map Γ Γ') :=
+⟨_, pointed_map.f⟩
+
+@[simp] theorem pointed_map.mk_val {Γ Γ'} [inhabited Γ] [inhabited Γ']
+  (f : Γ → Γ') (pt) : (pointed_map.mk f pt : Γ → Γ') = f := rfl
+
+@[simp] theorem pointed_map.map_pt {Γ Γ'} [inhabited Γ] [inhabited Γ']
+  (f : pointed_map Γ Γ') : f (default _) = default _ := pointed_map.map_pt' _
+
+@[simp] theorem pointed_map.head_map {Γ Γ'} [inhabited Γ] [inhabited Γ']
+  (f : pointed_map Γ Γ') (l : list Γ) : (l.map f).head = f l.head :=
+by cases l; [exact (pointed_map.map_pt f).symm, refl]
+
+/-- The `map` function on lists is well defined on `list_blank`s provided that the map is
+pointed. -/
+def list_blank.map {Γ Γ'} [inhabited Γ] [inhabited Γ']
+  (f : pointed_map Γ Γ') (l : list_blank Γ) : list_blank Γ' :=
+l.lift_on (λ l, list_blank.mk (list.map f l)) begin
+  rintro l _ ⟨i, rfl⟩, refine quotient.sound' (or.inl ⟨i, _⟩),
+  simp only [pointed_map.map_pt, list.map_append, list.map_repeat],
+end
+
+@[simp] theorem list_blank.map_mk {Γ Γ'} [inhabited Γ] [inhabited Γ']
+  (f : pointed_map Γ Γ') (l : list Γ) : (list_blank.mk l).map f = list_blank.mk (l.map f) := rfl
+
+@[simp] theorem list_blank.head_map {Γ Γ'} [inhabited Γ] [inhabited Γ']
+  (f : pointed_map Γ Γ') (l : list_blank Γ) : (l.map f).head = f l.head :=
+begin
+  conv {to_lhs, rw [← list_blank.cons_head_tail l]},
+  exact quotient.induction_on' l (λ a, rfl)
+end
+
+@[simp] theorem list_blank.tail_map {Γ Γ'} [inhabited Γ] [inhabited Γ']
+  (f : pointed_map Γ Γ') (l : list_blank Γ) : (l.map f).tail = l.tail.map f :=
+begin
+  conv {to_lhs, rw [← list_blank.cons_head_tail l]},
+  exact quotient.induction_on' l (λ a, rfl)
+end
+
+@[simp] theorem list_blank.map_cons {Γ Γ'} [inhabited Γ] [inhabited Γ']
+  (f : pointed_map Γ Γ') (l : list_blank Γ) (a : Γ) : (l.cons a).map f = (l.map f).cons (f a) :=
+begin
+  refine (list_blank.cons_head_tail _).symm.trans _,
+  simp only [list_blank.head_map, list_blank.head_cons, list_blank.tail_map, list_blank.tail_cons]
+end
+
+@[simp] theorem list_blank.nth_map {Γ Γ'} [inhabited Γ] [inhabited Γ']
+  (f : pointed_map Γ Γ') (l : list_blank Γ) (n : ℕ) : (l.map f).nth n = f (l.nth n) :=
+l.induction_on begin
+  intro l, simp only [list.nth_map, list_blank.map_mk, list_blank.nth_mk, list.inth],
+  cases l.nth n, {exact f.2.symm}, {refl}
+end
+
+theorem list_blank.map_modify_nth {Γ Γ'} [inhabited Γ] [inhabited Γ']
+  (F : pointed_map Γ Γ') (f : Γ → Γ) (f' : Γ' → Γ')
+  (H : ∀ x, F (f x) = f' (F x)) (n) (L : list_blank Γ) :
+  (L.modify_nth f n).map F = (L.map F).modify_nth f' n :=
+by induction n with n IH generalizing L; simp only [*,
+  list_blank.head_map, list_blank.modify_nth, list_blank.map_cons, list_blank.tail_map]
+
+/-- Append a list on the left side of a list_blank. -/
+@[simp] def list_blank.append {Γ} [inhabited Γ] : list Γ → list_blank Γ → list_blank Γ
+| [] L := L
+| (a :: l) L := list_blank.cons a (list_blank.append l L)
+
+@[simp] theorem list_blank.append_mk {Γ} [inhabited Γ] (l₁ l₂ : list Γ) :
+  list_blank.append l₁ (list_blank.mk l₂) = list_blank.mk (l₁ ++ l₂) :=
+by induction l₁; simp only [*,
+     list_blank.append, list.nil_append, list.cons_append, list_blank.cons_mk]
+
+theorem list_blank.append_assoc {Γ} [inhabited Γ] (l₁ l₂ : list Γ) (l₃ : list_blank Γ) :
+  list_blank.append (l₁ ++ l₂) l₃ = list_blank.append l₁ (list_blank.append l₂ l₃) :=
+l₃.induction_on $ by intro; simp only [list_blank.append_mk, list.append_assoc]
+
+/-- The `bind` function on lists is well defined on `list_blank`s provided that the default element
+is sent to a sequence of default elements. -/
+def list_blank.bind {Γ Γ'} [inhabited Γ] [inhabited Γ']
+  (l : list_blank Γ) (f : Γ → list Γ')
+  (hf : ∃ n, f (default _) = list.repeat (default _) n) : list_blank Γ' :=
+l.lift_on (λ l, list_blank.mk (list.bind l f)) begin
+  rintro l _ ⟨i, rfl⟩, cases hf with n e, refine quotient.sound' (or.inl ⟨i * n, _⟩),
+  rw [list.bind_append, mul_comm], congr,
+  induction i with i IH, refl,
+  simp only [IH, e, list.repeat_add, nat.mul_succ, add_comm, list.repeat_succ, list.cons_bind],
+end
+
+@[simp] lemma list_blank.bind_mk {Γ Γ'} [inhabited Γ] [inhabited Γ']
+  (l : list Γ) (f : Γ → list Γ') (hf) :
+  (list_blank.mk l).bind f hf = list_blank.mk (l.bind f) := rfl
+
+@[simp] lemma list_blank.cons_bind {Γ Γ'} [inhabited Γ] [inhabited Γ']
+  (a : Γ) (l : list_blank Γ) (f : Γ → list Γ') (hf) :
+  (l.cons a).bind f hf = (l.bind f hf).append (f a) :=
+l.induction_on $ by intro; simp only [list_blank.append_mk,
+  list_blank.bind_mk, list_blank.cons_mk, list.cons_bind]
+
+/-- The tape of a Turing machine is composed of a head element (which we imagine to be the
+current position of the head), together with two `list_blank`s denoting the portions of the tape
+going off to the left and right. When the Turing machine moves right, an element is pulled from the
+right side and becomes the new head, while the head element is consed onto the left side. -/
+structure tape (Γ : Type*) [inhabited Γ] :=
+(head : Γ)
+(left : list_blank Γ)
+(right : list_blank Γ)
+
+instance tape.inhabited {Γ} [inhabited Γ] : inhabited (tape Γ) :=
+⟨by constructor; apply default⟩
 
 /-- A direction for the turing machine `move` command, either
   left or right. -/
 @[derive decidable_eq, derive inhabited]
 inductive dir | left | right
 
-def tape (Γ) := Γ × list Γ × list Γ
+/-- The "inclusive" left side of the tape, including both `left` and `head`. -/
+def tape.left₀ {Γ} [inhabited Γ] (T : tape Γ) : list_blank Γ := T.left.cons T.head
 
-instance {Γ} [inhabited Γ] : inhabited (tape Γ) :=
-⟨by constructor; apply default⟩
+/-- The "inclusive" right side of the tape, including both `right` and `head`. -/
+def tape.right₀ {Γ} [inhabited Γ] (T : tape Γ) : list_blank Γ := T.right.cons T.head
 
-def tape.mk {Γ} [inhabited Γ] (l : list Γ) : tape Γ :=
-(l.head, [], l.tail)
-
-def tape.mk' {Γ} [inhabited Γ] (L R : list Γ) : tape Γ :=
-(R.head, L, R.tail)
-
+/-- Move the tape in response to a motion of the Turing machine. Note that `T.move dir.left` makes
+`T.left` smaller; the Turing machine is moving left and the tape is moving right. -/
 def tape.move {Γ} [inhabited Γ] : dir → tape Γ → tape Γ
-| dir.left (a, L, R) := (L.head, L.tail, a :: R)
-| dir.right (a, L, R) := (R.head, a :: L, R.tail)
+| dir.left ⟨a, L, R⟩ := ⟨L.head, L.tail, R.cons a⟩
+| dir.right ⟨a, L, R⟩ := ⟨R.head, L.cons a, R.tail⟩
 
-def tape.nth {Γ} [inhabited Γ] : tape Γ → ℤ → Γ
-| (a, L, R) 0 := a
-| (a, L, R) (n+1:ℕ) := R.inth n
-| (a, L, R) -[1+ n] := L.inth n
+@[simp] theorem tape.move_left_right {Γ} [inhabited Γ] (T : tape Γ) :
+  (T.move dir.left).move dir.right = T :=
+by cases T; simp [tape.move]
 
-@[simp] theorem tape.nth_zero {Γ} [inhabited Γ] :
-  ∀ (T : tape Γ), T.nth 0 = T.1
-| (a, L, R) := rfl
+@[simp] theorem tape.move_right_left {Γ} [inhabited Γ] (T : tape Γ) :
+  (T.move dir.right).move dir.left = T :=
+by cases T; simp [tape.move]
+
+/-- Construct a tape from a left side and an inclusive right side. -/
+def tape.mk' {Γ} [inhabited Γ] (L R : list_blank Γ) : tape Γ := ⟨R.head, L, R.tail⟩
+
+@[simp] theorem tape.mk'_left {Γ} [inhabited Γ] (L R : list_blank Γ) :
+  (tape.mk' L R).left = L := rfl
+
+@[simp] theorem tape.mk'_head {Γ} [inhabited Γ] (L R : list_blank Γ) :
+  (tape.mk' L R).head = R.head := rfl
+
+@[simp] theorem tape.mk'_right {Γ} [inhabited Γ] (L R : list_blank Γ) :
+  (tape.mk' L R).right = R.tail := rfl
+
+@[simp] theorem tape.mk'_right₀ {Γ} [inhabited Γ] (L R : list_blank Γ) :
+  (tape.mk' L R).right₀ = R := list_blank.cons_head_tail _
+
+@[simp] theorem tape.mk'_left_right₀ {Γ} [inhabited Γ] (T : tape Γ) :
+  tape.mk' T.left T.right₀ = T :=
+by cases T; simp only [tape.right₀, tape.mk',
+     list_blank.head_cons, list_blank.tail_cons, eq_self_iff_true, and_self]
+
+theorem tape.exists_mk' {Γ} [inhabited Γ] (T : tape Γ) :
+  ∃ L R, T = tape.mk' L R := ⟨_, _, (tape.mk'_left_right₀ _).symm⟩
+
+@[simp] theorem tape.move_left_mk' {Γ} [inhabited Γ] (L R : list_blank Γ) :
+  (tape.mk' L R).move dir.left = tape.mk' L.tail (R.cons L.head) :=
+by simp only [tape.move, tape.mk', list_blank.head_cons, eq_self_iff_true,
+  list_blank.cons_head_tail, and_self, list_blank.tail_cons]
+
+@[simp] theorem tape.move_right_mk' {Γ} [inhabited Γ] (L R : list_blank Γ) :
+  (tape.mk' L R).move dir.right = tape.mk' (L.cons R.head) R.tail :=
+by simp only [tape.move, tape.mk', list_blank.head_cons, eq_self_iff_true,
+  list_blank.cons_head_tail, and_self, list_blank.tail_cons]
+
+/-- Construct a tape from a left side and an inclusive right side. -/
+def tape.mk₂ {Γ} [inhabited Γ] (L R : list Γ) : tape Γ :=
+tape.mk' (list_blank.mk L) (list_blank.mk R)
+
+/-- Construct a tape from a list, with the head of the list at the TM head and the rest going
+to the right. -/
+def tape.mk₁ {Γ} [inhabited Γ] (l : list Γ) : tape Γ :=
+tape.mk₂ [] l
+
+/-- The `nth` function of a tape is integer-valued, with index `0` being the head, negative indexes
+on the left and positive indexes on the right. (Picture a number line.) -/
+def tape.nth {Γ} [inhabited Γ] (T : tape Γ) : ℤ → Γ
+| 0 := T.head
+| (n+1:ℕ) := T.right.nth n
+| -[1+ n] := T.left.nth n
+
+@[simp] theorem tape.nth_zero {Γ} [inhabited Γ] (T : tape Γ) : T.nth 0 = T.1 := rfl
+
+theorem tape.right₀_nth {Γ} [inhabited Γ] (T : tape Γ) (n : ℕ) : T.right₀.nth n = T.nth n :=
+by cases n; simp only [tape.nth, tape.right₀, int.coe_nat_zero,
+  list_blank.nth_zero, list_blank.nth_succ, list_blank.head_cons, list_blank.tail_cons]
+
+@[simp] theorem tape.mk'_nth_nat {Γ} [inhabited Γ] (L R : list_blank Γ) (n : ℕ) :
+  (tape.mk' L R).nth n = R.nth n :=
+by rw [← tape.right₀_nth, tape.mk'_right₀]
 
 @[simp] theorem tape.move_left_nth {Γ} [inhabited Γ] :
   ∀ (T : tape Γ) (i : ℤ), (T.move dir.left).nth i = T.nth (i-1)
-| (a, L, R) -[1+ n]      := by cases L; refl
-| (a, L, R) 0           := by cases L; refl
-| (a, L, R) 1           := rfl
-| (a, L, R) ((n+1:ℕ)+1) := by rw add_sub_cancel; refl
+| ⟨a, L, R⟩ -[1+ n]     := (list_blank.nth_succ _ _).symm
+| ⟨a, L, R⟩ 0           := (list_blank.nth_zero _).symm
+| ⟨a, L, R⟩ 1           := (list_blank.nth_zero _).trans (list_blank.head_cons _ _)
+| ⟨a, L, R⟩ ((n+1:ℕ)+1) := begin
+    rw add_sub_cancel,
+    change (R.cons a).nth (n+1) = R.nth n,
+    rw [list_blank.nth_succ, list_blank.tail_cons]
+  end
 
-@[simp] theorem tape.move_right_nth {Γ} [inhabited Γ] :
-  ∀ (T : tape Γ) (i : ℤ), (T.move dir.right).nth i = T.nth (i+1)
-| (a, L, R) (n+1:ℕ)    := by cases R; refl
-| (a, L, R) 0         := by cases R; refl
-| (a, L, R) -1        := rfl
-| (a, L, R) -[1+ n+1] := show _ = tape.nth _ (-[1+ n] - 1 + 1),
-  by rw sub_add_cancel; refl
+@[simp] theorem tape.move_right_nth {Γ} [inhabited Γ] (T : tape Γ) (i : ℤ) :
+  (T.move dir.right).nth i = T.nth (i+1) :=
+by conv {to_rhs, rw ← T.move_right_left}; rw [tape.move_left_nth, add_sub_cancel]
 
-def tape.write {Γ} (b : Γ) : tape Γ → tape Γ
-| (a, LR) := (b, LR)
+@[simp] theorem tape.move_right_n_head {Γ} [inhabited Γ] (T : tape Γ) (i : ℕ) :
+  ((tape.move dir.right)^[i] T).head = T.nth i :=
+by induction i generalizing T; [refl, simp only [*,
+  tape.move_right_nth, int.coe_nat_succ, nat.iterate_succ]]
 
-@[simp] theorem tape.write_self {Γ} : ∀ (T : tape Γ), T.write T.1 = T
-| (a, LR) := rfl
+/-- Replace the current value of the head on the tape. -/
+def tape.write {Γ} [inhabited Γ] (b : Γ) (T : tape Γ) : tape Γ := {head := b, ..T}
+
+@[simp] theorem tape.write_self {Γ} [inhabited Γ] : ∀ (T : tape Γ), T.write T.1 = T :=
+by rintro ⟨⟩; refl
 
 @[simp] theorem tape.write_nth {Γ} [inhabited Γ] (b : Γ) :
   ∀ (T : tape Γ) {i : ℤ}, (T.write b).nth i = if i = 0 then b else T.nth i
-| (a, L, R) 0       := rfl
-| (a, L, R) (n+1:ℕ) := rfl
-| (a, L, R) -[1+ n] := rfl
+| ⟨a, L, R⟩ 0       := rfl
+| ⟨a, L, R⟩ (n+1:ℕ) := rfl
+| ⟨a, L, R⟩ -[1+ n] := rfl
 
-def tape.map {Γ Γ'} (f : Γ → Γ') : tape Γ → tape Γ'
-| (a, L, R) := (f a, L.map f, R.map f)
+@[simp] theorem tape.write_mk' {Γ} [inhabited Γ] (a b : Γ) (L R : list_blank Γ) :
+  (tape.mk' L (R.cons a)).write b = tape.mk' L (R.cons b) :=
+by simp only [tape.write, tape.mk', list_blank.head_cons, list_blank.tail_cons,
+  eq_self_iff_true, and_self]
 
-@[simp] theorem tape.map_fst {Γ Γ'} (f : Γ → Γ') : ∀ (T : tape Γ), (T.map f).1 = f T.1
-| (a, L, R) := rfl
+/-- Apply a pointed map to a tape to change the alphabet. -/
+def tape.map {Γ Γ'} [inhabited Γ] [inhabited Γ'] (f : pointed_map Γ Γ') (T : tape Γ) : tape Γ' :=
+⟨f T.1, T.2.map f, T.3.map f⟩
 
-@[simp] theorem tape.map_write {Γ Γ'} (f : Γ → Γ') (b : Γ) :
-  ∀ (T : tape Γ), (T.write b).map f = (T.map f).write (f b)
-| (a, L, R) := rfl
+@[simp] theorem tape.map_fst {Γ Γ'} [inhabited Γ] [inhabited Γ']
+  (f : pointed_map Γ Γ') : ∀ (T : tape Γ), (T.map f).1 = f T.1 :=
+by rintro ⟨⟩; refl
 
-@[class] def pointed_map {Γ Γ'} [inhabited Γ] [inhabited Γ'] (f : Γ → Γ') :=
-f (default _) = default _
+@[simp] theorem tape.map_write {Γ Γ'} [inhabited Γ] [inhabited Γ'] (f : pointed_map Γ Γ') (b : Γ) :
+  ∀ (T : tape Γ), (T.write b).map f = (T.map f).write (f b) :=
+by rintro ⟨⟩; refl
+
+@[simp] theorem tape.write_move_right_n {Γ} [inhabited Γ] (f : Γ → Γ) (L R : list_blank Γ) (n : ℕ) :
+  ((tape.move dir.right)^[n] (tape.mk' L R)).write (f (R.nth n)) =
+  ((tape.move dir.right)^[n] (tape.mk' L (R.modify_nth f n))) :=
+begin
+  induction n with n IH generalizing L R,
+  { simp only [list_blank.nth_zero, list_blank.modify_nth, nat.iterate_zero],
+    rw [← tape.write_mk', list_blank.cons_head_tail] },
+  simp only [list_blank.head_cons, list_blank.nth_succ, list_blank.modify_nth,
+    tape.move_right_mk', list_blank.tail_cons, nat.iterate_succ, IH]
+end
 
 theorem tape.map_move {Γ Γ'} [inhabited Γ] [inhabited Γ']
-  (f : Γ → Γ') [pointed_map f] :
-  ∀ (T : tape Γ) d, (T.move d).map f = (T.map f).move d
-| (a, [],   R) dir.left  := prod.ext ‹pointed_map f› rfl
-| (a, b::L, R) dir.left  := rfl
-| (a, L, [])   dir.right := prod.ext ‹pointed_map f› rfl
-| (a, L, b::R) dir.right := rfl
+  (f : pointed_map Γ Γ') (T : tape Γ) (d) : (T.move d).map f = (T.map f).move d :=
+by cases T; cases d; simp only [tape.move, tape.map,
+  list_blank.head_map, eq_self_iff_true, list_blank.map_cons, and_self, list_blank.tail_map]
 
-theorem tape.map_mk {Γ Γ'} [inhabited Γ] [inhabited Γ']
-  (f : Γ → Γ') [f0 : pointed_map f] :
-  ∀ (l : list Γ), (tape.mk l).map f = tape.mk (l.map f)
-| []     := prod.ext ‹pointed_map f› rfl
-| (a::l) := rfl
+theorem tape.map_mk' {Γ Γ'} [inhabited Γ] [inhabited Γ'] (f : pointed_map Γ Γ')
+  (L R : list_blank Γ) : (tape.mk' L R).map f = tape.mk' (L.map f) (R.map f) :=
+by simp only [tape.mk', tape.map, list_blank.head_map,
+  eq_self_iff_true, and_self, list_blank.tail_map]
 
+theorem tape.map_mk₂ {Γ Γ'} [inhabited Γ] [inhabited Γ'] (f : pointed_map Γ Γ')
+  (L R : list Γ) : (tape.mk₂ L R).map f = tape.mk₂ (L.map f) (R.map f) :=
+by simp only [tape.mk₂, tape.map_mk', list_blank.map_mk]
+
+theorem tape.map_mk₁ {Γ Γ'} [inhabited Γ] [inhabited Γ'] (f : pointed_map Γ Γ')
+  (l : list Γ) : (tape.mk₁ l).map f = tape.mk₁ (l.map f) := tape.map_mk₂ _ _ _
+
+/-- Run a state transition function `σ → option σ` "to completion". The return value is the last
+state returned before a `none` result. If the state transition function always returns `some`,
+then the computation diverges, returning `roption.none`. -/
 def eval {σ} (f : σ → option σ) : σ → roption σ :=
 pfun.fix (λ s, roption.some $
   match f s with none := sum.inl s | some s' := sum.inr s' end)
 
+/-- The reflexive transitive closure of a state transition function. `reaches f a b` means
+there is a finite sequence of steps `f a = some a₁`, `f a₁ = some a₂`, ... such that `aₙ = b`.
+This relation permits zero steps of the state transition function. -/
 def reaches {σ} (f : σ → option σ) : σ → σ → Prop :=
 refl_trans_gen (λ a b, b ∈ f a)
 
+/-- The transitive closure of a state transition function. `reaches₁ f a b` means there is a
+nonempty finite sequence of steps `f a = some a₁`, `f a₁ = some a₂`, ... such that `aₙ = b`.
+This relation does not permit zero steps of the state transition function. -/
 def reaches₁ {σ} (f : σ → option σ) : σ → σ → Prop :=
 trans_gen (λ a b, b ∈ f a)
 
@@ -123,6 +564,9 @@ begin
   cases option.mem_unique hab h₂, exact hbc
 end
 
+/-- A variation on `reaches`. `reaches₀ f a b` holds if whenever `reaches₁ f b c` then
+`reaches₁ f a c`. This is a weaker property than `reaches` and is useful for replacing states with
+equivalent states without taking a step. -/
 def reaches₀ {σ} (f : σ → option σ) (a b : σ) : Prop :=
 ∀ c, reaches₁ f b c → reaches₁ f a c
 
@@ -201,6 +645,11 @@ roption.ext $ λ c,
       (reaches_total ab ac), c0⟩,
   λ h, let ⟨bc, c0⟩ := mem_eval.1 h in mem_eval.2 ⟨ab.trans bc, c0⟩,⟩
 
+/-- Given a relation `tr : σ₁ → σ₂ → Prop` between state spaces, and state transition functions
+`f₁ : σ₁ → option σ₁` and `f₂ : σ₂ → option σ₂`, `respects f₁ f₂ tr` means that if `tr a₁ a₂` holds
+initially and `f₁` takes a step to `a₂` then `f₂` will take one or more steps before reaching a
+state `b₂` satisfying `tr a₂ b₂`, and if `f₁ a₁` terminates then `f₂ a₂` also terminates.
+Such a relation `tr` is also known as a refinement. -/
 def respects {σ₁ σ₂}
   (f₁ : σ₁ → option σ₁) (f₂ : σ₂ → option σ₂) (tr : σ₁ → σ₂ → Prop) :=
 ∀ ⦃a₁ a₂⦄, tr a₁ a₂ → (match f₁ a₁ with
@@ -241,7 +690,7 @@ begin
   { rcases IH with ⟨e₁, e₂, ce, ee, ae⟩,
     rcases refl_trans_gen.cases_head ce with rfl | ⟨d', cd', de⟩,
     { have := H ee, revert this,
-      cases eg : f₁ e₁ with g₁; simp [respects],
+      cases eg : f₁ e₁ with g₁; simp only [respects, and_imp, exists_imp_distrib],
       { intro c0, cases cd.symm.trans c0 },
       { intros g₂ gg cg,
         rcases trans_gen.head'_iff.1 cg with ⟨d', cd', dg⟩,
@@ -282,6 +731,7 @@ theorem tr_eval_dom {σ₁ σ₂ f₁ f₂} {tr : σ₁ → σ₂ → Prop}
 ⟨λ h, let ⟨b₂, tr, h, _⟩ := tr_eval_rev H aa ⟨h, rfl⟩ in h,
  λ h, let ⟨b₂, tr, h, _⟩ := tr_eval H aa ⟨h, rfl⟩ in h⟩
 
+/-- A simpler version of `respects` when the state transition relation `tr` is a function. -/
 def frespects {σ₁ σ₂} (f₂ : σ₂ → option σ₂) (tr : σ₁ → σ₂) (a₂ : σ₂) : option σ₁ → Prop
 | (some b₁) := reaches₁ f₂ a₂ (tr b₁)
 | none := f₂ a₂ = none
@@ -308,23 +758,6 @@ roption.ext $ λ b₂,
     rwa bb at h
   end⟩
 
-def dwrite {K} [decidable_eq K] {C : K → Type*}
-  (S : ∀ k, C k) (k') (l : C k') (k) : C k :=
-if h : k = k' then eq.rec_on h.symm l else S k
-
-@[simp] theorem dwrite_eq {K} [decidable_eq K] {C : K → Type*}
-  (S : ∀ k, C k) (k) (l : C k) : dwrite S k l k = l :=
-dif_pos rfl
-
-@[simp] theorem dwrite_ne {K} [decidable_eq K] {C : K → Type*}
-  (S : ∀ k, C k) (k') (l : C k') (k) (h : ¬ k = k') : dwrite S k' l k = S k :=
-dif_neg h
-
-@[simp] theorem dwrite_self
-  {K} [decidable_eq K] {C : K → Type*}
-  (S : ∀ k, C k) (k) : dwrite S k (S k) = S :=
-funext $ λ k', by unfold dwrite; split_ifs; [subst h, refl]
-
 namespace TM0
 
 section
@@ -333,10 +766,11 @@ parameters (Λ : Type*) [inhabited Λ] -- type of "labels" or TM states
 
 /-- A Turing machine "statement" is just a command to either move
   left or right, or write a symbol on the tape. -/
-@[derive inhabited]
 inductive stmt
 | move : dir → stmt
 | write : Γ → stmt
+
+instance stmt.inhabited : inhabited stmt := ⟨stmt.write (default _)⟩
 
 /-- A Post-Turing machine with symbol type `Γ` and label type `Λ`
   is a function which, given the current state `q : Λ` and
@@ -347,6 +781,7 @@ inductive stmt
   Both `Λ` and `Γ` are required to be inhabited; the default value
   for `Γ` is the "blank" tape value, and the default value of `Λ` is
   the initial state. -/
+@[nolint unused_arguments]
 def machine := Λ → Γ → option (Λ × stmt)
 
 instance machine.inhabited : inhabited machine := by unfold machine; apply_instance
@@ -356,10 +791,11 @@ instance machine.inhabited : inhabited machine := by unfold machine; apply_insta
   the form `(a, L, R)` meaning the tape looks like `L.rev ++ [a] ++ R`
   with the machine currently reading the `a`. The lists are
   automatically extended with blanks as the machine moves around. -/
-@[derive inhabited]
 structure cfg :=
 (q : Λ)
 (tape : tape Γ)
+
+instance cfg.inhabited : inhabited cfg := ⟨⟨default _, default _⟩⟩
 
 parameters {Γ Λ}
 /-- Execution semantics of the Turing machine. -/
@@ -377,12 +813,12 @@ refl_trans_gen (λ a b, b ∈ step M a)
 
 /-- The initial configuration. -/
 def init (l : list Γ) : cfg :=
-⟨default Λ, tape.mk l⟩
+⟨default Λ, tape.mk₁ l⟩
 
 /-- Evaluate a Turing machine on initial input to a final state,
   if it terminates. -/
-def eval (M : machine) (l : list Γ) : roption (list Γ) :=
-(eval (step M) (init l)).map (λ c, c.tape.2.2)
+def eval (M : machine) (l : list Γ) : roption (list_blank Γ) :=
+(eval (step M) (init l)).map (λ c, c.tape.right₀)
 
 /-- The raw definition of a Turing machine does not require that
   `Γ` and `Λ` are finite, and in practice we will be interested
@@ -413,21 +849,28 @@ variables {Γ' : Type*} [inhabited Γ']
 variables {Λ : Type*} [inhabited Λ]
 variables {Λ' : Type*} [inhabited Λ']
 
-def stmt.map (f : Γ → Γ') : stmt Γ → stmt Γ'
+/-- Map a TM statement across a function. This does nothing to move statements and maps the write
+values. -/
+def stmt.map (f : pointed_map Γ Γ') : stmt Γ → stmt Γ'
 | (stmt.move d)  := stmt.move d
 | (stmt.write a) := stmt.write (f a)
 
-def cfg.map (f : Γ → Γ') (g : Λ → Λ') : cfg Γ Λ → cfg Γ' Λ'
+/-- Map a configuration across a function, given `f : Γ → Γ'` a map of the alphabets and
+`g : Λ → Λ'` a map of the machine states. -/
+def cfg.map (f : pointed_map Γ Γ') (g : Λ → Λ') : cfg Γ Λ → cfg Γ' Λ'
 | ⟨q, T⟩ := ⟨g q, T.map f⟩
 
 variables (M : machine Γ Λ)
-  (f₁ : Γ → Γ') (f₂ : Γ' → Γ) (g₁ : Λ → Λ') (g₂ : Λ' → Λ)
+  (f₁ : pointed_map Γ Γ') (f₂ : pointed_map Γ' Γ) (g₁ : Λ → Λ') (g₂ : Λ' → Λ)
 
+/-- Because the state transition function uses the alphabet and machine states in both the input
+and output, to map a machine from one alphabet and machine state space to another we need functions
+in both directions, essentially an `equiv` without the laws. -/
 def machine.map : machine Γ' Λ'
 | q l := (M (g₂ q) (f₂ l)).map (prod.map g₁ (stmt.map f₁))
 
-theorem machine.map_step {S} (ss : supports M S)
-  [pointed_map f₁] (f₂₁ : function.right_inverse f₁ f₂)
+theorem machine.map_step {S : set Λ}
+  (f₂₁ : function.right_inverse f₁ f₂)
   (g₂₁ : ∀ q ∈ S, g₂ (g₁ q) = q) :
   ∀ c : cfg Γ Λ, c.q ∈ S →
     (step M c).map (cfg.map f₁ g₁) =
@@ -440,21 +883,22 @@ theorem machine.map_step {S} (ss : supports M S)
   { simp only [step, cfg.map, option.map_some', tape.map_write], refl }
 end
 
-theorem map_init [pointed_map f₁] [g0 : pointed_map g₁] (l : list Γ) :
+theorem map_init (g₁ : pointed_map Λ Λ') (l : list Γ) :
   (init l).map f₁ g₁ = init (l.map f₁) :=
-congr (congr_arg cfg.mk g0) (tape.map_mk _ _)
+congr (congr_arg cfg.mk g₁.map_pt) (tape.map_mk₁ _ _)
 
-theorem machine.map_respects {S} (ss : supports M S)
-  [pointed_map f₁] [pointed_map g₁]
+theorem machine.map_respects
+  (g₁ : pointed_map Λ Λ') (g₂ : Λ' → Λ)
+  {S} (ss : supports M S)
   (f₂₁ : function.right_inverse f₁ f₂)
   (g₂₁ : ∀ q ∈ S, g₂ (g₁ q) = q) :
   respects (step M) (step (M.map f₁ f₂ g₁ g₂))
     (λ a b, a.q ∈ S ∧ cfg.map f₁ g₁ a = b)
 | c _ ⟨cs, rfl⟩ := begin
   cases e : step M c with c'; unfold respects,
-  { rw [← M.map_step f₁ f₂ g₁ g₂ ss f₂₁ g₂₁ _ cs, e], refl },
+  { rw [← M.map_step f₁ f₂ g₁ g₂ f₂₁ g₂₁ _ cs, e], refl },
   { refine ⟨_, ⟨step_supports M ss e cs, rfl⟩, trans_gen.single _⟩,
-    rw [← M.map_step f₁ f₂ g₁ g₂ ss f₂₁ g₂₁ _ cs, e], exact rfl }
+    rw [← M.map_step f₁ f₂ g₁ g₂ f₂₁ g₂₁ _ cs, e], exact rfl }
 end
 
 end
@@ -493,11 +937,12 @@ instance stmt.inhabited : inhabited stmt := ⟨halt⟩
 
 /-- The configuration of a TM1 machine is given by the currently
   evaluating statement, the variable store value, and the tape. -/
-@[derive inhabited]
 structure cfg :=
 (l : option Λ)
 (var : σ)
 (tape : tape Γ)
+
+instance cfg.inhabited [inhabited σ] : inhabited cfg := ⟨⟨default _, default _, default _⟩⟩
 
 parameters {Γ Λ σ}
 /-- The semantics of TM1 evaluation. -/
@@ -510,18 +955,13 @@ def step_aux : stmt → σ → tape Γ → cfg
 | (goto l)         v T := ⟨some (l T.1 v), v, T⟩
 | halt             v T := ⟨none, v, T⟩
 
+/-- The state transition function. -/
 def step (M : Λ → stmt) : cfg → option cfg
 | ⟨none,   v, T⟩ := none
 | ⟨some l, v, T⟩ := some (step_aux (M l) v T)
 
-variables [inhabited Λ] [inhabited σ]
-def init (l : list Γ) : cfg :=
-⟨some (default _), default _, tape.mk l⟩
-
-def eval (M : Λ → stmt) (l : list Γ) : roption (list Γ) :=
-(eval (step M) (init l)).map (λ c, c.tape.2.2)
-
-variables [fintype Γ]
+/-- A set `S` of labels supports the statement `q` if all the `goto`
+  statements in `q` refer only to other functions in `S`. -/
 def supports_stmt (S : finset Λ) : stmt → Prop
 | (move d q)       := supports_stmt q
 | (write a q)      := supports_stmt q
@@ -530,13 +970,8 @@ def supports_stmt (S : finset Λ) : stmt → Prop
 | (goto l)         := ∀ a v, l a v ∈ S
 | halt             := true
 
-/-- A set `S` of labels supports machine `M` if all the `goto`
-  statements in the functions in `S` refer only to other functions
-  in `S`. -/
-def supports (M : Λ → stmt) (S : finset Λ) :=
-default Λ ∈ S ∧ ∀ q ∈ S, supports_stmt S (M q)
-
 open_locale classical
+/-- The subterm closure of a statement. -/
 noncomputable def stmts₁ : stmt → finset stmt
 | Q@(move d q)       := insert Q (stmts₁ q)
 | Q@(write a q)      := insert Q (stmts₁ q)
@@ -583,8 +1018,9 @@ begin
   case TM1.stmt.halt { subst h, trivial }
 end
 
-noncomputable def stmts
-  (M : Λ → stmt) (S : finset Λ) : finset (option stmt) :=
+/-- The set of all statements in a turing machine, plus one extra value `none` representing the
+halt state. This is used in the TM1 to TM0 reduction. -/
+noncomputable def stmts (M : Λ → stmt) (S : finset Λ) : finset (option stmt) :=
 (S.bind (λ q, stmts₁ (M q))).insert_none
 
 theorem stmts_trans {M : Λ → stmt} {S q₁ q₂}
@@ -592,6 +1028,14 @@ theorem stmts_trans {M : Λ → stmt} {S q₁ q₂}
 by simp only [stmts, finset.mem_insert_none, finset.mem_bind,
   option.mem_def, forall_eq', exists_imp_distrib];
 exact λ l ls h₂, ⟨_, ls, stmts₁_trans h₂ h₁⟩
+
+variable [inhabited Λ]
+
+/-- A set `S` of labels supports machine `M` if all the `goto`
+  statements in the functions in `S` refer only to other functions
+  in `S`. -/
+def supports (M : Λ → stmt) (S : finset Λ) :=
+default Λ ∈ S ∧ ∀ q ∈ S, supports_stmt S (M q)
 
 theorem stmts_supports_stmt {M : Λ → stmt} {S q}
   (ss : supports M S) : some q ∈ stmts M S → supports_stmt S q :=
@@ -616,6 +1060,18 @@ theorem step_supports (M : Λ → stmt) {S}
   case TM1.stmt.halt { apply multiset.mem_cons_self }
 end
 
+variable [inhabited σ]
+
+/-- The initial state, given a finite input that is placed on the tape starting at the TM head and
+going to the right. -/
+def init (l : list Γ) : cfg :=
+⟨some (default _), default _, tape.mk₁ l⟩
+
+/-- Evaluate a TM to completion, resulting in an output list on the tape (with an indeterminate
+number of blanks on the end). -/
+def eval (M : Λ → stmt) (l : list Γ) : roption (list_blank Γ) :=
+(eval (step M) (init l)).map (λ c, c.tape.right₀)
+
 end
 
 end TM1
@@ -634,11 +1090,21 @@ local notation `stmt₀` := TM0.stmt Γ
 parameters (M : Λ → stmt₁)
 include M
 
+/-- The base machine state space is a pair of an `option stmt₁` representing the current program
+to be executed, or `none` for the halt state, and a `σ` which is the local state (stored in the TM,
+not the tape). Because there are an infinite number of programs, this state space is infinite, but
+for a finitely supported TM1 machine and a finite type `σ`, only finitely many of these states are
+reachable. -/
+@[nolint unused_arguments]
 def Λ' := option stmt₁ × σ
 instance : inhabited Λ' := ⟨(some (M (default _)), default _)⟩
 
 open TM0.stmt
 
+/-- The core TM1 → TM0 translation function. Here `s` is the current value on the tape, and the
+`stmt₁` is the TM1 statement to translate, with local state `v : σ`. We evaluate all regular
+instructions recursively until we reach either a `move` or `write` command, or a `goto`; in the
+latter case we emit a dummy `write s` step and transition to the new target location. -/
 def tr_aux (s : Γ) : stmt₁ → σ → Λ' × stmt₀
 | (TM1.stmt.move d q)       v := ((some q, v), move d)
 | (TM1.stmt.write a q)      v := ((some q, v), write (a s v))
@@ -649,10 +1115,12 @@ def tr_aux (s : Γ) : stmt₁ → σ → Λ' × stmt₀
 
 local notation `cfg₀` := TM0.cfg Γ Λ'
 
+/-- The translated TM0 machine (given the TM1 machine input). -/
 def tr : TM0.machine Γ Λ'
 | (none,   v) s := none
 | (some q, v) s := some (tr_aux s q v)
 
+/-- Translate configurations from TM1 to TM0. -/
 def tr_cfg : cfg₁ → cfg₀
 | ⟨l, v, T⟩ := ⟨(l.map M, v), T⟩
 
@@ -674,7 +1142,15 @@ fun_respects.2 $ λ ⟨l₁, v, T⟩, begin
       (congr (congr_arg TM0.cfg.mk rfl) (tape.write_self T))) }
 end
 
-variables [fintype Γ] [fintype σ]
+theorem tr_eval (l : list Γ) : TM0.eval tr l = TM1.eval M l :=
+(congr_arg _ (tr_eval' _ _ _ tr_respects ⟨some _, _, _⟩)).trans begin
+  rw [roption.map_eq_map, roption.map_map, TM1.eval],
+  congr', ext ⟨⟩, refl
+end
+
+variables [fintype σ]
+/-- Given a finite set of accessible `Λ` machine states, there is a finite set of accessible
+machine states in the target (even though the type `Λ'` is infinite). -/
 noncomputable def tr_stmts (S : finset Λ) : finset Λ' :=
 (TM1.stmts M S).product finset.univ
 
@@ -720,12 +1196,6 @@ theorem tr_supports {S : finset Λ} (ss : TM1.supports M S) :
   case TM1.stmt.halt { cases h₁ }
 end⟩
 
-theorem tr_eval (l : list Γ) : TM0.eval tr l = TM1.eval M l :=
-(congr_arg _ (tr_eval' _ _ _ tr_respects ⟨some _, _, _⟩)).trans begin
-  rw [roption.map_eq_map, roption.map_map, TM1.eval],
-  congr', exact funext (λ ⟨_, _, _⟩, rfl)
-end
-
 end
 end TM1to0
 
@@ -756,6 +1226,7 @@ parameters {σ : Type*} [inhabited σ]
 local notation `stmt₁` := stmt Γ Λ σ
 local notation `cfg₁` := cfg Γ Λ σ
 
+/-- The configuration state of the TM. -/
 inductive Λ' : Type (max u_1 u_2 u_3)
 | normal : Λ → Λ'
 | write : Γ → stmt₁ → Λ'
@@ -764,6 +1235,7 @@ instance : inhabited Λ' := ⟨Λ'.normal (default _)⟩
 local notation `stmt'` := stmt bool Λ' σ
 local notation `cfg'` := cfg bool Λ' σ
 
+/-- Read a vector of length `n` from the tape. -/
 def read_aux : ∀ n, (vector bool n → stmt') → stmt'
 | 0     f := f vector.nil
 | (i+1) f := stmt.branch (λ a s, a)
@@ -772,15 +1244,21 @@ def read_aux : ∀ n, (vector bool n → stmt') → stmt'
 
 parameters {n : ℕ} (enc : Γ → vector bool n) (dec : vector bool n → Γ)
 
+/-- A move left or right corresponds to `n` moves across the super-cell. -/
 def move (d : dir) (q : stmt') : stmt' := (stmt.move d)^[n] q
 
+/-- To read a symbol from the tape, we use `read_aux` to traverse the symbol,
+then return to the original position with `n` moves to the left. -/
 def read (f : Γ → stmt') : stmt' :=
 read_aux n (λ v, move dir.left $ f (dec v))
 
+/-- Write a list of bools on the tape. -/
 def write : list bool → stmt' → stmt'
 | []       q := q
 | (a :: l) q := stmt.write (λ _ _, a) $ stmt.move dir.right $ write l q
 
+/-- Translate a normal instruction. For the `write` command, we use a `goto` indirection so that
+we can access the current value of the tape. -/
 def tr_normal : stmt₁ → stmt'
 | (stmt.move dir.left q)  := move dir.right $ (move dir.left)^[2] $ tr_normal q
 | (stmt.move dir.right q) := move dir.right $ tr_normal q
@@ -790,100 +1268,7 @@ def tr_normal : stmt₁ → stmt'
   stmt.branch (λ _ s, p a s) (tr_normal q₁) (tr_normal q₂)
 | (stmt.goto l)           := read $ λ a,
   stmt.goto (λ _ s, Λ'.normal (l a s))
-| stmt.halt               := move dir.right $ move dir.left $ stmt.halt
-
-def tr_tape' (L R : list Γ) : tape bool :=
-tape.mk'
-  (L.bind (λ x, (enc x).to_list.reverse))
-  (R.bind (λ x, (enc x).to_list) ++ [default _])
-
-def tr_tape : tape Γ → tape bool
-| (a, L, R) := tr_tape' L (a :: R)
-
-theorem tr_tape_drop_right : ∀ R : list Γ,
-  list.drop n (R.bind (λ x, (enc x).to_list)) =
-  R.tail.bind (λ x, (enc x).to_list)
-| []     := list.drop_nil _
-| (a::R) := list.drop_left' (enc a).2
-
-parameters (enc0 : enc (default _) = vector.repeat ff n)
-
-section
-include enc0
-theorem tr_tape_take_right : ∀ R : list Γ,
-  list.take' n (R.bind (λ x, (enc x).to_list)) =
-  (enc R.head).to_list
-| []     := show list.take' n list.nil = _,
-    by rw [list.take'_nil]; exact (congr_arg vector.to_list enc0).symm
-| (a::R) := list.take'_left' (enc a).2
-end
-
-parameters (M : Λ → stmt₁)
-
-def tr : Λ' → stmt'
-| (Λ'.normal l)  := tr_normal (M l)
-| (Λ'.write a q) := write (enc a).to_list $ move dir.left $ tr_normal q
-
-def tr_cfg : cfg₁ → cfg'
-| ⟨l, v, T⟩ := ⟨l.map Λ'.normal, v, tr_tape T⟩
-
-include enc0
-
-theorem tr_tape'_move_left (L R) :
-  (tape.move dir.left)^[n] (tr_tape' L R) =
-  (tr_tape' L.tail (L.head :: R)) :=
-begin
-  cases L with a L,
-  { simp only [enc0, vector.repeat, tr_tape',
-      list.cons_bind, list.head, list.append_assoc],
-    suffices : ∀ i R', default _ ∈ R' →
-      (tape.move dir.left^[i]) (tape.mk' [] R') =
-      tape.mk' [] (list.repeat ff i ++ R'),
-    from this n _ (list.mem_append_right _
-      (list.mem_singleton_self _)),
-    intros i R' hR, induction i with i IH, {refl},
-    rw [nat.iterate_succ', IH],
-    refine prod.ext rfl (prod.ext rfl (list.cons_head_tail
-      (list.ne_nil_of_mem $ list.mem_append_right _ hR))) },
-  { simp only [tr_tape', list.cons_bind, list.append_assoc],
-    suffices : ∀ L' R' l₁ l₂
-      (hR : default _ ∈ R')
-      (e : vector.to_list (enc a) = list.reverse_core l₁ l₂),
-      (tape.move dir.left^[l₁.length]) (tape.mk' (l₁ ++ L') (l₂ ++ R')) =
-      tape.mk' L' (vector.to_list (enc a) ++ R'),
-    { simpa only [list.length_reverse, vector.to_list_length]
-        using this _ _ _ _ _ (list.reverse_reverse _).symm,
-      exact list.mem_append_right _ (list.mem_singleton_self _) },
-    intros, induction l₁ with b l₁ IH generalizing l₂,
-    { cases e, refl },
-    simp only [list.length, list.cons_append, nat.iterate_succ],
-    convert IH _ e,
-    exact prod.ext rfl (prod.ext rfl (list.cons_head_tail
-      (list.ne_nil_of_mem $ list.mem_append_right _ hR))) }
-end
-
-theorem tr_tape'_move_right (L R) :
-  (tape.move dir.right)^[n] (tr_tape' L R) =
-  (tr_tape' (R.head :: L) R.tail) :=
-begin
-  cases R with a R,
-  { simp only [enc0, vector.repeat, tr_tape', list.head,
-      list.cons_bind, vector.to_list_mk, list.reverse_repeat],
-    suffices : ∀ i L',
-      (tape.move dir.right^[i]) (ff, L', []) =
-      (ff, list.repeat ff i ++ L', []),
-    from this n _,
-    intros, induction i with i IH, {refl},
-    rw [nat.iterate_succ', IH],
-    refine prod.ext rfl (prod.ext rfl rfl) },
-  { simp only [tr_tape', list.cons_bind, list.append_assoc],
-    suffices : ∀ L' R' l₁ l₂ : list bool,
-      (tape.move dir.right^[l₂.length]) (tape.mk' (l₁ ++ L') (l₂ ++ R')) =
-      tape.mk' (list.reverse_core l₂ l₁ ++ L') R',
-    { simpa only [vector.to_list_length] using this _ _ [] (enc a).to_list },
-    intros, induction l₂ with b l₂ IH generalizing l₁, {refl},
-    exact IH (b::l₁) }
-end
+| stmt.halt               := stmt.halt
 
 theorem step_aux_move (d q v T) :
   step_aux (move d q) v T =
@@ -896,118 +1281,6 @@ begin
   rw [nat.iterate_succ', step_aux, IH, ← nat.iterate_succ]
 end
 
-parameters (encdec : ∀ a, dec (enc a) = a)
-include encdec
-
-theorem step_aux_read (f v L R) :
-  step_aux (read f) v (tr_tape' L R) =
-  step_aux (f R.head) v (tr_tape' L (R.head :: R.tail)) :=
-begin
-  suffices : ∀ f,
-    step_aux (read_aux n f) v (tr_tape' enc L R) =
-    step_aux (f (enc R.head)) v
-      (tr_tape' enc (R.head :: L) R.tail),
-  { rw [read, this, step_aux_move enc enc0, encdec,
-      tr_tape'_move_left enc enc0], refl },
-  cases R with a R,
-  { suffices : ∀ i f L',
-      step_aux (read_aux i f) v (ff, L', []) =
-      step_aux (f (vector.repeat ff i)) v
-        (ff, list.repeat ff i ++ L', []),
-    { intro f, convert this n f _,
-      refine prod.ext rfl (prod.ext ((list.cons_bind _ _ _).trans _) rfl),
-      simp only [list.head, enc0, vector.repeat, vector.to_list, list.reverse_repeat] },
-    clear f L, intros, induction i with i IH generalizing L', {refl},
-    change step_aux (read_aux i (λ v, f (ff :: v))) v (ff, ff :: L', [])
-      = step_aux (f (vector.repeat ff (nat.succ i))) v (ff, ff :: (list.repeat ff i ++ L'), []),
-    rw [IH], congr',
-    simpa only [list.append_assoc] using congr_arg (++ L') (list.repeat_add ff i 1).symm },
-  { simp only [tr_tape', list.cons_bind, list.append_assoc],
-    suffices : ∀ i f L' R' l₁ l₂ h,
-      step_aux (read_aux i f) v
-        (tape.mk' (l₁ ++ L') (l₂ ++ R')) =
-      step_aux (f ⟨l₂, h⟩) v
-        (tape.mk' (l₂.reverse_core l₁ ++ L') R'),
-    { intro f, convert this n f _ _ _ _ (enc a).2; simp },
-    clear f L a R, intros, subst i,
-    induction l₂ with a l₂ IH generalizing l₁, {refl},
-    change (tape.mk' (l₁ ++ L') (a :: (l₂ ++ R'))).1 with a,
-    transitivity step_aux
-      (read_aux l₂.length (λ v, f (a :: v))) v
-      (tape.mk' (a :: l₁ ++ L') (l₂ ++ R')),
-    { cases a; refl },
-    rw IH, refl }
-end
-
-theorem step_aux_write (q v a b L R) :
-  step_aux (write (enc a).to_list q) v (tr_tape' L (b :: R)) =
-  step_aux q v (tr_tape' (a :: L) R) :=
-begin
-  simp only [tr_tape', list.cons_bind, list.append_assoc],
-  suffices : ∀ {L' R'} (l₁ l₂ l₂' : list bool)
-    (e : l₂'.length = l₂.length),
-    step_aux (write l₂ q) v (tape.mk' (l₁ ++ L') (l₂' ++ R')) =
-    step_aux q v (tape.mk' (list.reverse_core l₂ l₁ ++ L') R'),
-  from this [] _ _ ((enc b).2.trans (enc a).2.symm),
-  clear a b L R, intros,
-  induction l₂ with a l₂ IH generalizing l₁ l₂',
-  { cases list.length_eq_zero.1 e, refl },
-  cases l₂' with b l₂'; injection e with e,
-  unfold write step_aux,
-  convert IH _ _ e, refl
-end
-
-theorem tr_respects : respects (step M) (step tr)
-  (λ c₁ c₂, tr_cfg c₁ = c₂) :=
-fun_respects.2 $ λ ⟨l₁, v, (a, L, R)⟩, begin
-  cases l₁ with l₁, {exact rfl},
-  suffices : ∀ q R, reaches (step (tr enc dec M))
-    (step_aux (tr_normal dec q) v (tr_tape' enc L R))
-    (tr_cfg enc (step_aux q v (tape.mk' L R))),
-  { refine trans_gen.head' rfl (this _ (a::R)) },
-  clear R l₁, intros,
-  induction q with _ q IH _ q IH _ q IH generalizing v L R,
-  case TM1.stmt.move : d q IH {
-    cases d; simp only [tr_normal, nat.iterate, step_aux_move enc enc0, step_aux,
-      tr_tape'_move_left enc enc0, tr_tape'_move_right enc enc0];
-      apply IH },
-  case TM1.stmt.write : a q IH {
-    simp only [tr_normal, step_aux_read enc dec enc0 encdec, step_aux],
-    refine refl_trans_gen.head rfl _,
-    simp only [tr, tr_normal, step_aux,
-      step_aux_write enc dec enc0 encdec,
-      step_aux_move enc enc0, tr_tape'_move_left enc enc0],
-    apply IH },
-  case TM1.stmt.load : a q IH {
-    simp only [tr_normal, step_aux_read enc dec enc0 encdec],
-    apply IH },
-  case TM1.stmt.branch : p q₁ q₂ IH₁ IH₂ {
-    simp only [tr_normal, step_aux_read enc dec enc0 encdec, step_aux],
-    change (tape.mk' L R).1 with R.head,
-    cases p R.head v; [apply IH₂, apply IH₁] },
-  case TM1.stmt.goto : l {
-    simp only [tr_normal, step_aux_read enc dec enc0 encdec, step_aux],
-    apply refl_trans_gen.refl },
-  case TM1.stmt.halt {
-    simp only [tr_normal, step_aux, tr_cfg, step_aux_move enc enc0,
-      tr_tape'_move_left enc enc0, tr_tape'_move_right enc enc0],
-    apply refl_trans_gen.refl }
-end
-
-omit enc0 encdec
-open_locale classical
-parameters [fintype Γ]
-noncomputable def writes : stmt₁ → finset Λ'
-| (stmt.move d q)       := writes q
-| (stmt.write f q)      := finset.univ.image (λ a, Λ'.write a q) ∪ writes q
-| (stmt.load f q)       := writes q
-| (stmt.branch p q₁ q₂) := writes q₁ ∪ writes q₂
-| (stmt.goto l)         := ∅
-| stmt.halt             := ∅
-
-noncomputable def tr_supp (S : finset Λ) : finset Λ' :=
-S.bind (λ l, insert (Λ'.normal l) (writes (M l)))
-
 theorem supports_stmt_move {S d q} :
   supports_stmt S (move d q) = supports_stmt S q :=
 suffices ∀ {i}, supports_stmt S (stmt.move d^[i] q) = _, from this,
@@ -1016,8 +1289,6 @@ by intro; induction i generalizing q; simp only [*, nat.iterate]; refl
 theorem supports_stmt_write {S l q} :
   supports_stmt S (write l q) = supports_stmt S q :=
 by induction l with a l IH; simp only [write, supports_stmt, *]
-
-local attribute [simp] supports_stmt_move supports_stmt_write
 
 theorem supports_stmt_read {S} : ∀ {f : Γ → stmt'},
   (∀ a, supports_stmt S (f a)) → supports_stmt S (read f) :=
@@ -1028,6 +1299,184 @@ from λ f hf, this n _ (by intro; simp only [supports_stmt_move, hf]),
   induction i with i IH, {exact hf _},
   split; apply IH; intro; apply hf,
 end
+
+parameter (enc0 : enc (default _) = vector.repeat ff n)
+
+section
+parameter {enc}
+include enc0
+
+/-- The low level tape corresponding to the given tape over alphabet `Γ`. -/
+def tr_tape' (L R : list_blank Γ) : tape bool :=
+begin
+  refine tape.mk'
+    (L.bind (λ x, (enc x).to_list.reverse) ⟨n, _⟩)
+    (R.bind (λ x, (enc x).to_list) ⟨n, _⟩);
+  simp only [enc0, vector.repeat,
+    list.reverse_repeat, bool.default_bool, vector.to_list_mk]
+end
+
+/-- The low level tape corresponding to the given tape over alphabet `Γ`. -/
+def tr_tape (T : tape Γ) : tape bool := tr_tape' T.left T.right₀
+
+theorem tr_tape_mk' (L R : list_blank Γ) : tr_tape (tape.mk' L R) = tr_tape' L R :=
+by simp only [tr_tape, tape.mk'_left, tape.mk'_right₀]
+
+end
+
+parameters (M : Λ → stmt₁)
+
+/-- The top level program. -/
+def tr : Λ' → stmt'
+| (Λ'.normal l)  := tr_normal (M l)
+| (Λ'.write a q) := write (enc a).to_list $ move dir.left $ tr_normal q
+
+/-- The machine configuration translation. -/
+def tr_cfg : cfg₁ → cfg'
+| ⟨l, v, T⟩ := ⟨l.map Λ'.normal, v, tr_tape T⟩
+
+parameter {enc}
+include enc0
+
+theorem tr_tape'_move_left (L R) :
+  (tape.move dir.left)^[n] (tr_tape' L R) =
+  (tr_tape' L.tail (R.cons L.head)) :=
+begin
+  obtain ⟨a, L, rfl⟩ := L.exists_cons,
+  simp only [tr_tape', list_blank.cons_bind, list_blank.head_cons, list_blank.tail_cons],
+  suffices : ∀ {L' R' l₁ l₂}
+    (e : vector.to_list (enc a) = list.reverse_core l₁ l₂),
+    tape.move dir.left^[l₁.length]
+      (tape.mk' (list_blank.append l₁ L') (list_blank.append l₂ R')) =
+    tape.mk' L' (list_blank.append (vector.to_list (enc a)) R'),
+  { simpa only [list.length_reverse, vector.to_list_length]
+      using this (list.reverse_reverse _).symm },
+  intros, induction l₁ with b l₁ IH generalizing l₂,
+  { cases e, refl },
+  simp only [list.length, list.cons_append, nat.iterate_succ],
+  convert IH e,
+  simp only [list_blank.tail_cons, list_blank.append, tape.move_left_mk', list_blank.head_cons]
+end
+
+theorem tr_tape'_move_right (L R) :
+  (tape.move dir.right)^[n] (tr_tape' L R) =
+  (tr_tape' (L.cons R.head) R.tail) :=
+begin
+  suffices : ∀ i L, (tape.move dir.right)^[i] ((tape.move dir.left)^[i] L) = L,
+  { refine (eq.symm _).trans (this n _),
+    simp only [tr_tape'_move_left, list_blank.cons_head_tail,
+      list_blank.head_cons, list_blank.tail_cons] },
+  intros, induction i with i IH, {refl},
+  rw [nat.iterate_succ, nat.iterate_succ', tape.move_left_right, IH]
+end
+
+theorem step_aux_write (q v a b L R) :
+  step_aux (write (enc a).to_list q) v (tr_tape' L (list_blank.cons b R)) =
+  step_aux q v (tr_tape' (list_blank.cons a L) R) :=
+begin
+  simp only [tr_tape', list.cons_bind, list.append_assoc],
+  suffices : ∀ {L' R'} (l₁ l₂ l₂' : list bool)
+    (e : l₂'.length = l₂.length),
+    step_aux (write l₂ q) v (tape.mk' (list_blank.append l₁ L') (list_blank.append l₂' R')) =
+    step_aux q v (tape.mk' (L'.append (list.reverse_core l₂ l₁)) R'),
+  { convert this [] _ _ ((enc b).2.trans (enc a).2.symm);
+    rw list_blank.cons_bind; refl },
+  clear a b L R, intros,
+  induction l₂ with a l₂ IH generalizing l₁ l₂',
+  { cases list.length_eq_zero.1 e, refl },
+  cases l₂' with b l₂'; injection e with e,
+  dunfold write step_aux,
+  convert IH _ _ e, simp only [list_blank.head_cons, list_blank.tail_cons,
+    list_blank.append, tape.move_right_mk', tape.write_mk']
+end
+
+parameters (encdec : ∀ a, dec (enc a) = a)
+include encdec
+
+theorem step_aux_read (f v L R) :
+  step_aux (read f) v (tr_tape' L R) =
+  step_aux (f R.head) v (tr_tape' L R) :=
+begin
+  suffices : ∀ f,
+    step_aux (read_aux n f) v (tr_tape' enc0 L R) =
+    step_aux (f (enc R.head)) v
+      (tr_tape' enc0 (L.cons R.head) R.tail),
+  { rw [read, this, step_aux_move, encdec, tr_tape'_move_left enc0],
+    simp only [list_blank.head_cons, list_blank.cons_head_tail, list_blank.tail_cons] },
+  obtain ⟨a, R, rfl⟩ := R.exists_cons,
+  simp only [list_blank.head_cons, list_blank.tail_cons,
+    tr_tape', list_blank.cons_bind, list_blank.append_assoc],
+  suffices : ∀ i f L' R' l₁ l₂ h,
+    step_aux (read_aux i f) v
+      (tape.mk' (list_blank.append l₁ L') (list_blank.append l₂ R')) =
+    step_aux (f ⟨l₂, h⟩) v
+      (tape.mk' (list_blank.append (l₂.reverse_core l₁) L') R'),
+  { intro f, convert this n f _ _ _ _ (enc a).2; simp },
+  clear f L a R, intros, subst i,
+  induction l₂ with a l₂ IH generalizing l₁, {refl},
+  transitivity step_aux
+    (read_aux l₂.length (λ v, f (a :: v))) v
+    (tape.mk' ((L'.append l₁).cons a) (R'.append l₂)),
+  { dsimp [read_aux, step_aux], simp, cases a; refl },
+  rw [← list_blank.append, IH], refl
+end
+
+theorem tr_respects : respects (step M) (step tr)
+  (λ c₁ c₂, tr_cfg c₁ = c₂) :=
+fun_respects.2 $ λ ⟨l₁, v, T⟩, begin
+  obtain ⟨L, R, rfl⟩ := T.exists_mk',
+  cases l₁ with l₁, {exact rfl},
+  suffices : ∀ q R, reaches (step (tr enc dec M))
+    (step_aux (tr_normal dec q) v (tr_tape' enc0 L R))
+    (tr_cfg enc0 (step_aux q v (tape.mk' L R))),
+  { refine trans_gen.head' rfl _, rw tr_tape_mk', exact this _ R },
+  clear R l₁, intros,
+  induction q with _ q IH _ q IH _ q IH generalizing v L R,
+  case TM1.stmt.move : d q IH {
+    cases d; simp only [tr_normal, nat.iterate, step_aux_move, step_aux,
+      list_blank.head_cons, tape.move_left_mk',
+      list_blank.cons_head_tail, list_blank.tail_cons,
+      tr_tape'_move_left enc0, tr_tape'_move_right enc0];
+      apply IH },
+  case TM1.stmt.write : f q IH {
+    simp only [tr_normal, step_aux_read dec enc0 encdec, step_aux],
+    refine refl_trans_gen.head rfl _,
+    obtain ⟨a, R, rfl⟩ := R.exists_cons,
+    rw [tr, tape.mk'_head, step_aux_write, list_blank.head_cons,
+      step_aux_move, tr_tape'_move_left enc0, list_blank.head_cons,
+      list_blank.tail_cons, tape.write_mk'],
+    apply IH },
+  case TM1.stmt.load : a q IH {
+    simp only [tr_normal, step_aux_read dec enc0 encdec],
+    apply IH },
+  case TM1.stmt.branch : p q₁ q₂ IH₁ IH₂ {
+    simp only [tr_normal, step_aux_read dec enc0 encdec, step_aux],
+    cases p R.head v; [apply IH₂, apply IH₁] },
+  case TM1.stmt.goto : l {
+    simp only [tr_normal, step_aux_read dec enc0 encdec, step_aux, tr_cfg, tr_tape_mk'],
+    apply refl_trans_gen.refl },
+  case TM1.stmt.halt {
+    simp only [tr_normal, step_aux, tr_cfg, step_aux_move,
+      tr_tape'_move_left enc0, tr_tape'_move_right enc0, tr_tape_mk'],
+    apply refl_trans_gen.refl }
+end
+
+omit enc0 encdec
+open_locale classical
+parameters [fintype Γ]
+/-- The set of accessible `Λ'.write` machine states. -/
+noncomputable def writes : stmt₁ → finset Λ'
+| (stmt.move d q)       := writes q
+| (stmt.write f q)      := finset.univ.image (λ a, Λ'.write a q) ∪ writes q
+| (stmt.load f q)       := writes q
+| (stmt.branch p q₁ q₂) := writes q₁ ∪ writes q₂
+| (stmt.goto l)         := ∅
+| stmt.halt             := ∅
+
+/-- The set of accessible machine states, assuming that the input machine is supported on `S`,
+are the normal states embedded from `S`, plus all write states accessible from these states. -/
+noncomputable def tr_supp (S : finset Λ) : finset Λ' :=
+S.bind (λ l, insert (Λ'.normal l) (writes (M l)))
 
 theorem tr_supports {S} (ss : supports M S) :
   supports tr (tr_supp S) :=
@@ -1087,6 +1536,9 @@ section
 parameters {Γ : Type*} [inhabited Γ]
 parameters {Λ : Type*} [inhabited Λ]
 
+/-- The machine states for a TM1 emulating a TM0 machine. States of the TM0 machine are embedded
+as `normal q` states, but the actual operation is split into two parts, a jump to `act s q`
+followed by the action and a jump to the next `normal` state.  -/
 inductive Λ'
 | normal : Λ → Λ'
 | act : TM0.stmt Γ → Λ → Λ'
@@ -1100,6 +1552,7 @@ parameters (M : TM0.machine Γ Λ)
 
 open TM1.stmt
 
+/-- The program.  -/
 def tr : Λ' → stmt₁
 | (Λ'.normal q) :=
   branch (λ a _, (M q a).is_none) halt $
@@ -1112,9 +1565,9 @@ def tr : Λ' → stmt₁
 | (Λ'.act (TM0.stmt.write a) q) :=
   write (λ _ _, a) $ goto (λ _ _, Λ'.normal q)
 
+/-- The configuration translation. -/
 def tr_cfg : cfg₀ → cfg₁
-| ⟨q, T⟩ := ⟨cond (M q T.1).is_some
-  (some (Λ'.normal q)) none, (), T⟩
+| ⟨q, T⟩ := ⟨cond (M q T.1).is_some (some (Λ'.normal q)) none, (), T⟩
 
 theorem tr_respects : respects (TM0.step M) (TM1.step tr)
   (λ a b, tr_cfg a = b) :=
@@ -1166,40 +1619,38 @@ open stmt
 
 instance stmt.inhabited : inhabited stmt := ⟨halt⟩
 
+/-- A configuration in the TM2 model is a label (or `none` for the halt state), the state of
+local variables, and the stacks. (Note that the stacks are not `list_blank`s, they have a definite
+size.) -/
 structure cfg :=
 (l : option Λ)
 (var : σ)
 (stk : ∀ k, list (Γ k))
 
-instance cfg.inhabited [inhabited σ] [∀ k, inhabited (Γ k)] : inhabited cfg :=
-⟨by constructor; intros; apply default⟩
+instance cfg.inhabited [inhabited σ] : inhabited cfg := ⟨⟨default _, default _, default _⟩⟩
 
 parameters {Γ Λ σ K}
+/-- The step function for the TM2 model. -/
 def step_aux : stmt → σ → (∀ k, list (Γ k)) → cfg
-| (push k f q)     v S := step_aux q v (dwrite S k (f v :: S k))
+| (push k f q)     v S := step_aux q v (update S k (f v :: S k))
 | (peek k f q)     v S := step_aux q (f v (S k).head') S
-| (pop k f q)      v S := step_aux q (f v (S k).head') (dwrite S k (S k).tail)
+| (pop k f q)      v S := step_aux q (f v (S k).head') (update S k (S k).tail)
 | (load a q)       v S := step_aux q (a v) S
 | (branch f q₁ q₂) v S :=
   cond (f v) (step_aux q₁ v S) (step_aux q₂ v S)
 | (goto f)         v S := ⟨some (f v), v, S⟩
 | halt             v S := ⟨none, v, S⟩
 
+/-- The step function for the TM2 model. -/
 def step (M : Λ → stmt) : cfg → option cfg
 | ⟨none,   v, S⟩ := none
 | ⟨some l, v, S⟩ := some (step_aux (M l) v S)
 
+/-- The (reflexive) reachability relation for the TM2 model. -/
 def reaches (M : Λ → stmt) : cfg → cfg → Prop :=
 refl_trans_gen (λ a b, b ∈ step M a)
 
-variables [inhabited Λ] [inhabited σ]
-def init (k) (L : list (Γ k)) : cfg :=
-⟨some (default _), default _, dwrite (λ _, []) k L⟩
-
-def eval (M : Λ → stmt) (k) (L : list (Γ k)) : roption (list (Γ k)) :=
-(eval (step M) (init k L)).map $ λ c, c.stk k
-
-variables [fintype K] [∀ k, fintype (Γ k)] [fintype σ]
+/-- Given a set `S` of states, `support_stmt S q` means that `q` only jumps to states in `S`. -/
 def supports_stmt (S : finset Λ) : stmt → Prop
 | (push k f q)     := supports_stmt q
 | (peek k f q)     := supports_stmt q
@@ -1209,10 +1660,8 @@ def supports_stmt (S : finset Λ) : stmt → Prop
 | (goto l)         := ∀ v, l v ∈ S
 | halt             := true
 
-def supports (M : Λ → stmt) (S : finset Λ) :=
-default Λ ∈ S ∧ ∀ q ∈ S, supports_stmt S (M q)
-
 open_locale classical
+/-- The set of subtree statements in a statement. -/
 noncomputable def stmts₁ : stmt → finset stmt
 | Q@(push k f q)     := insert Q (stmts₁ q)
 | Q@(peek k f q)     := insert Q (stmts₁ q)
@@ -1261,8 +1710,8 @@ begin
   case TM2.stmt.halt { subst h, trivial }
 end
 
-noncomputable def stmts
-  (M : Λ → stmt) (S : finset Λ) : finset (option stmt) :=
+/-- The set of statements accessible from initial set `S` of labels. -/
+noncomputable def stmts (M : Λ → stmt) (S : finset Λ) : finset (option stmt) :=
 (S.bind (λ q, stmts₁ (M q))).insert_none
 
 theorem stmts_trans {M : Λ → stmt} {S q₁ q₂}
@@ -1270,6 +1719,13 @@ theorem stmts_trans {M : Λ → stmt} {S q₁ q₂}
 by simp only [stmts, finset.mem_insert_none, finset.mem_bind,
   option.mem_def, forall_eq', exists_imp_distrib];
 exact λ l ls h₂, ⟨_, ls, stmts₁_trans h₂ h₁⟩
+
+variable [inhabited Λ]
+
+/-- Given a TM2 machine `M` and a set `S` of states, `supports M S` means that all states in
+`S` jump only to other states in `S`. -/
+def supports (M : Λ → stmt) (S : finset Λ) :=
+default Λ ∈ S ∧ ∀ q ∈ S, supports_stmt S (M q)
 
 theorem stmts_supports_stmt {M : Λ → stmt} {S q}
   (ss : supports M S) : some q ∈ stmts M S → supports_stmt S q :=
@@ -1294,6 +1750,15 @@ theorem step_supports (M : Λ → stmt) {S}
   case TM2.stmt.halt { apply multiset.mem_cons_self }
 end
 
+variable [inhabited σ]
+/-- The initial state of the TM2 model. The input is provided on a designated stack. -/
+def init (k) (L : list (Γ k)) : cfg :=
+⟨some (default _), default _, update (λ _, []) k L⟩
+
+/-- Evaluates a TM2 program to completion, with the output on the same stack as the input. -/
+def eval (M : Λ → stmt) (k) (L : list (Γ k)) : roption (list (Γ k)) :=
+(eval (step M) (init k L)).map $ λ c, c.stk k
+
 end
 
 end TM2
@@ -1309,74 +1774,49 @@ parameters {σ : Type*} [inhabited σ]
 local notation `stmt₂` := TM2.stmt Γ Λ σ
 local notation `cfg₂` := TM2.cfg Γ Λ σ
 
-inductive stackel (k : K)
-| val : Γ k → stackel
-| bottom [] : stackel
-| top [] : stackel
+/-- The alphabet of the TM2 simulator on TM1 is a marker for the stack bottom,
+plus a vector of stack elements for each stack, or none if the stack does not extend this far. -/
+@[nolint unused_arguments]
+def Γ' := bool × ∀ k, option (Γ k)
 
-instance stackel.inhabited (k) : inhabited (stackel k) :=
-⟨stackel.top _⟩
-
-def stackel.is_bottom {k} : stackel k → bool
-| (stackel.bottom _) := tt
-| _ := ff
-
-def stackel.is_top {k} : stackel k → bool
-| (stackel.top _) := tt
-| _ := ff
-
-def stackel.get {k} : stackel k → option (Γ k)
-| (stackel.val a) := some a
-| _ := none
-
-section
-open stackel
-
-def stackel_equiv {k} : stackel k ≃ option (option (Γ k)) :=
-begin
-  refine ⟨λ s, _, λ s, _, _, _⟩,
-  { cases s, exacts [some (some s), none, some none] },
-  { rcases s with _|_|s, exacts [bottom _, top _, val s] },
-  { intro s, cases s; refl },
-  { intro s, rcases s with _|_|s; refl },
-end
-
-end
-
-def Γ' := ∀ k, stackel k
-
-instance Γ'.inhabited : inhabited Γ' := ⟨λ _, default _⟩
-
-instance stackel.fintype {k} [fintype (Γ k)] : fintype (stackel k) :=
-fintype.of_equiv _ stackel_equiv.symm
+instance Γ'.inhabited : inhabited Γ' := ⟨⟨ff, λ _, none⟩⟩
 
 instance Γ'.fintype [fintype K] [∀ k, fintype (Γ k)] : fintype Γ' :=
-pi.fintype
+prod.fintype _ _
 
+/-- A stack action is a command that interacts with the top of a stack. Our default position
+is at the bottom of all the stacks, so we have to hold on to this action while going to the end
+to modify the stack. -/
 inductive st_act (k : K)
 | push : (σ → Γ k) → st_act
-| pop : bool → (σ → option (Γ k) → σ) → st_act
+| peek : (σ → option (Γ k) → σ) → st_act
+| pop : (σ → option (Γ k) → σ) → st_act
 
 section
 open st_act
 
-instance st_act.inhabited {k} : inhabited (st_act k) :=
-⟨pop (default _) (λ s _, s)⟩
-
+/-- The TM2 statement corresponding to a stack action. -/
+@[nolint unused_arguments]
 def st_run {k : K} : st_act k → stmt₂ → stmt₂
-| (push f)   := TM2.stmt.push k f
-| (pop ff f) := TM2.stmt.peek k f
-| (pop tt f) := TM2.stmt.pop k f
+| (push f) := TM2.stmt.push k f
+| (peek f) := TM2.stmt.peek k f
+| (pop f) := TM2.stmt.pop k f
 
+/-- The effect of a stack action on the local variables, given the value of the stack. -/
 def st_var {k : K} (v : σ) (l : list (Γ k)) : st_act k → σ
 | (push f)  := v
-| (pop b f) := f v l.head'
+| (peek f) := f v l.head'
+| (pop f) := f v l.head'
 
+/-- The effect of a stack action on the stack. -/
 def st_write {k : K} (v : σ) (l : list (Γ k)) : st_act k → list (Γ k)
 | (push f) := f v :: l
-| (pop ff f) := l
-| (pop tt f) := l.tail
+| (peek f) := l
+| (pop f) := l.tail
 
+/-- We have partitioned the TM2 statements into "stack actions", which require going to the end
+of the stack, and all other actions, which do not. This is a modified recursor which lumps the
+stack actions into one. -/
 @[elab_as_eliminator] def {l} stmt_st_rec
   {C : stmt₂ → Sort l}
   (H₁ : Π k (s : st_act k) q (IH : C q), C (st_run s q))
@@ -1385,24 +1825,26 @@ def st_write {k : K} (v : σ) (l : list (Γ k)) : st_act k → list (Γ k)
   (H₄ : Π l, C (TM2.stmt.goto l))
   (H₅ : C TM2.stmt.halt) : ∀ n, C n
 | (TM2.stmt.push k f q)     := H₁ _ (push f) _ (stmt_st_rec q)
-| (TM2.stmt.peek k f q)     := H₁ _ (pop ff f) _ (stmt_st_rec q)
-| (TM2.stmt.pop k f q)      := H₁ _ (pop tt f) _ (stmt_st_rec q)
+| (TM2.stmt.peek k f q)     := H₁ _ (peek f) _ (stmt_st_rec q)
+| (TM2.stmt.pop k f q)      := H₁ _ (pop f) _ (stmt_st_rec q)
 | (TM2.stmt.load a q)       := H₂ _ _ (stmt_st_rec q)
 | (TM2.stmt.branch a q₁ q₂) := H₃ _ _ _ (stmt_st_rec q₁) (stmt_st_rec q₂)
 | (TM2.stmt.goto l)         := H₄ _
 | TM2.stmt.halt             := H₅
 
-theorem supports_run [fintype K] [∀ k, fintype (Γ k)] [fintype σ]
-  (S : finset Λ) {k} (s : st_act k) (q) :
+theorem supports_run (S : finset Λ) {k} (s : st_act k) (q) :
   TM2.supports_stmt S (st_run s q) ↔ TM2.supports_stmt S q :=
 by rcases s with _|_|_; refl
 
 end
 
+/-- The machine states of the TM2 emulator. We can either be in a normal state when waiting for the
+next TM2 action, or we can be in the "go" and "return" states to go to the top of the stack and
+return to the bottom, respectively. -/
 inductive Λ' : Type (max u_1 u_2 u_3 u_4)
 | normal : Λ → Λ'
 | go (k) : st_act k → stmt₂ → Λ'
-| ret : K → stmt₂ → Λ'
+| ret : stmt₂ → Λ'
 open Λ'
 instance : inhabited Λ' := ⟨normal (default _)⟩
 
@@ -1411,204 +1853,237 @@ local notation `cfg₁` := TM1.cfg Γ' Λ' σ
 
 open TM1.stmt
 
+/-- The program corresponding to state transitions at the end of a stack. Here we start out just
+after the top of the stack, and should end just after the new top of the stack. -/
 def tr_st_act {k} (q : stmt₁) : st_act k → stmt₁
-| (st_act.push f) :=
-  write (λ a s, dwrite a k $ stackel.val $ f s) $
-  move dir.right $
-  write (λ a s, dwrite a k $ stackel.top k) q
-| (st_act.pop b f) :=
-  move dir.left $
-  load (λ a s, f s (a k).get) $
-  cond b
-  ( branch (λ a s, (a k).is_bottom)
-    ( move dir.right q )
-    ( move dir.right $
-      write (λ a s, dwrite a k $ default _) $
-      move dir.left $
-      write (λ a s, dwrite a k $ stackel.top k) q ) )
-  ( move dir.right q )
+| (st_act.push f) := write (λ a s, (a.1, update a.2 k $ some $ f s)) $ move dir.right q
+| (st_act.peek f) := move dir.left $ load (λ a s, f s (a.2 k)) $ move dir.right q
+| (st_act.pop f) :=
+  branch (λ a _, a.1)
+  ( load (λ a s, f s none) q )
+  ( move dir.left $
+    load (λ a s, f s (a.2 k)) $
+    write (λ a s, (a.1, update a.2 k none)) q )
 
+/-- The initial state for the TM2 emulator, given an initial TM2 state. All stacks start out empty
+except for the input stack, and the stack bottom mark is set at the head. -/
 def tr_init (k) (L : list (Γ k)) : list Γ' :=
-stackel.bottom :: match L.reverse with
-| [] := [stackel.top]
-| (a::L') := dwrite stackel.top k (stackel.val a) ::
-  (L'.map stackel.val ++ [stackel.top k]).map (dwrite (default _) k)
-end
+let L' : list Γ' := L.reverse.map (λ a, (ff, update (λ _, none) k a)) in
+(tt, L'.head.2) :: L'.tail
 
 theorem step_run {k : K} (q v S) : ∀ s : st_act k,
   TM2.step_aux (st_run s q) v S =
-  TM2.step_aux q (st_var v (S k) s) (dwrite S k (st_write v (S k) s))
+  TM2.step_aux q (st_var v (S k) s) (update S k (st_write v (S k) s))
 | (st_act.push f) := rfl
-| (st_act.pop ff f) := by unfold st_write; rw dwrite_self; refl
-| (st_act.pop tt f) := rfl
+| (st_act.peek f) := by unfold st_write; rw function.update_eq_self; refl
+| (st_act.pop f) := rfl
 
+/-- The translation of TM2 statements to TM1 statements. regular actions have direct equivalents,
+but stack actions are deferred by going to the corresponding `go` state, so that we can find the
+appropriate stack top. -/
 def tr_normal : stmt₂ → stmt₁
 | (TM2.stmt.push k f q)     := goto (λ _ _, go k (st_act.push f) q)
-| (TM2.stmt.peek k f q)     := goto (λ _ _, go k (st_act.pop ff f) q)
-| (TM2.stmt.pop k f q)      := goto (λ _ _, go k (st_act.pop tt f) q)
+| (TM2.stmt.peek k f q)     := goto (λ _ _, go k (st_act.peek f) q)
+| (TM2.stmt.pop k f q)      := goto (λ _ _, go k (st_act.pop f) q)
 | (TM2.stmt.load a q)       := load (λ _, a) (tr_normal q)
 | (TM2.stmt.branch f q₁ q₂) := branch (λ a, f) (tr_normal q₁) (tr_normal q₂)
 | (TM2.stmt.goto l)         := goto (λ a s, normal (l s))
 | TM2.stmt.halt             := halt
 
-theorem tr_normal_run {k} (s q) :
-  tr_normal (st_run s q) = goto (λ _ _, go k s q) :=
+theorem tr_normal_run {k} (s q) : tr_normal (st_run s q) = goto (λ _ _, go k s q) :=
 by rcases s with _|_|_; refl
 
 parameters (M : Λ → stmt₂)
 include M
 
+/-- The TM2 emulator machine states written as a TM1 program.
+This handles the `go` and `ret` states, which shuttle to and from a stack top. -/
 def tr : Λ' → stmt₁
 | (normal q) := tr_normal (M q)
 | (go k s q) :=
-  branch (λ a s, (a k).is_top) (tr_st_act (goto (λ _ _, ret k q)) s)
+  branch (λ a s, (a.2 k).is_none) (tr_st_act (goto (λ _ _, ret q)) s)
     (move dir.right $ goto (λ _ _, go k s q))
-| (ret k q) :=
-  branch (λ a s, (a k).is_bottom) (tr_normal q)
-    (move dir.left $ goto (λ _ _, ret k q))
+| (ret q) :=
+  branch (λ a s, a.1) (tr_normal q)
+    (move dir.left $ goto (λ _ _, ret q))
 
-def tr_stk {k} (S : list (Γ k)) (L : list (stackel k)) : Prop :=
-∃ n, L = (S.map stackel.val).reverse_core (stackel.top k :: list.repeat (default _) n)
+/-- The `k`-th projection as a pointed map. -/
+@[nolint unused_arguments]
+def proj (k) : pointed_map (∀ k, option (Γ k)) (option (Γ k)) := ⟨λ a, a k, rfl⟩
 
-local attribute [pp_using_anonymous_constructor] turing.TM1.cfg
-inductive tr_cfg : cfg₂ → cfg₁ → Prop
-| mk {q v} {S : ∀ k, list (Γ k)} {L : list Γ'} :
-  (∀ k, tr_stk (S k) (L.map (λ a, a k))) →
-  tr_cfg ⟨q, v, S⟩ ⟨q.map normal, v, (stackel.bottom, [], L)⟩
+theorem proj_map_nth (k L n) : (list_blank.map (proj k) L).nth n = L.nth n k :=
+by rw list_blank.nth_map; refl
 
-theorem tr_respects_aux₁ {k} (o q v) : ∀ S₁ {s S₂} {T : list Γ'},
-  T.map (λ (a : Γ'), a k) = (list.map stackel.val S₁).reverse_core (s :: S₂) →
-  ∃ a T₁ T₂,
-    T = list.reverse_core T₁ (a :: T₂) ∧
-    a k = s ∧
-    T₁.map (λ (a : Γ'), a k) = S₁.map stackel.val ∧
-    T₂.map (λ (a : Γ'), a k) = S₂ ∧
-    reaches₀ (TM1.step tr)
-      ⟨some (go k o q), v, (stackel.bottom, [], T)⟩
-      ⟨some (go k o q), v, (a, T₁ ++ [stackel.bottom], T₂)⟩
-| [] s S₂ (a :: T) hT := by injection hT with es e₂; exact
-  ⟨a, [], _, rfl, es, rfl, e₂, reaches₀.single rfl⟩
-| (s' :: S₁) s S₂ T hT :=
-  let ⟨a, T₁, b'::T₂, e, es', e₁, e₂, H⟩ := tr_respects_aux₁ S₁ hT in
-  by injection e₂ with es e₂; exact
-  ⟨b', a::T₁, T₂, e, es, congr (congr_arg list.cons es') e₁,
-    e₂, H.tail (by unfold TM1.step;
-      change some (cond (TM2to1.stackel.is_top (a k)) _ _) = _;
-      rw es'; refl)⟩
-
-local attribute [simp] TM1.step TM1.step_aux tr tr_st_act st_var st_write
-  tape.move tape.write list.reverse_core stackel.get stackel.is_bottom
-
-theorem tr_respects_aux₂
-  {k q v} {S : Π k, list (Γ k)} {T₁ T₂ : list Γ'} {a : Γ'}
-  (hT : ∀ k, tr_stk (S k) ((T₁.reverse_core (a :: T₂)).map (λ (a : Γ'), a k)))
-  (e₁ : T₁.map (λ (a : Γ'), a k) = list.map stackel.val (S k))
-  (ea : a k = stackel.top k) (o) :
-  let v' := st_var v (S k) o,
-      Sk' := st_write v (S k) o,
-      S' : ∀ k, list (Γ k) := dwrite S k Sk' in
-  ∃ b (T₁' T₂' : list Γ'),
-    (∀ (k' : K), tr_stk (S' k') ((T₁'.reverse_core (b :: T₂')).map (λ (a : Γ'), a k'))) ∧
-    T₁'.map (λ a, a k) = Sk'.map stackel.val ∧
-    b k = stackel.top k ∧
-    TM1.step_aux (tr_st_act q o) v (a, T₁ ++ [stackel.bottom], T₂) =
-    TM1.step_aux q v' (b, T₁' ++ [stackel.bottom], T₂') :=
+theorem stk_nth_val {k L S} (n)
+  (hL : list_blank.map (proj k) L = list_blank.mk (list.map some S).reverse) :
+  L.nth n k = S.reverse.nth n :=
 begin
-  dsimp only,
-  cases o with f b f,
-  case TM2to1.st_act.push : {
-    refine ⟨_, dwrite a k (stackel.val (f v)) :: T₁,
-      _, _, by simp only [list.map, dwrite_eq, e₁]; refl,
-      by simp only [tape.write, tape.move, dwrite_eq], rfl⟩,
-    intro k', cases hT k' with n e,
-    by_cases h : k' = k,
-    { subst k', existsi n.pred,
-      simp only [list.reverse_core_eq, list.map_append, list.map_reverse, e₁,
-        list.map_cons, list.append_left_inj] at e,
-      simp only [list.reverse_core_eq, e.1, e.2, list.map_append, prod.fst,
-        list.map_reverse, list.reverse_cons, list.map, dwrite_eq, e₁, list.map_tail,
-        list.tail_repeat, TM2to1.st_write] },
-    { cases T₂ with t T₂,
-      { existsi n+1,
-        simpa only [dwrite_ne _ _ _ _ h, list.reverse_core_eq, e₁, list.repeat_add,
-          tape.write, tape.move, list.reverse_cons, list.map_reverse, list.map_append,
-          list.map, list.head, list.tail, list.append_assoc] using
-          congr_arg (++ [default Γ' k']) e },
-      { existsi n,
-        simpa only [dwrite_ne _ _ _ _ h, list.reverse_core_eq, e₁, list.repeat_add,
-          tape.write, tape.move, list.reverse_cons, list.map_reverse, list.map_append,
-          list.map, list.head, list.tail, list.append_assoc] using e } } },
-  have dw := dwrite_self S k,
-  cases T₁ with t T₁; cases eS : S k with s Sk;
-    rw eS at e₁ dw; injection e₁ with tk e₁'; cases b,
-  { -- peek nil
-    simp only [dw, st_write],
-    exact ⟨_, [], _, hT, rfl, ea, rfl⟩ },
-  { -- pop nil
-    simp only [dw, st_write, list.tail],
-    exact ⟨_, [], _, hT, rfl, ea, rfl⟩ },
-  { -- peek cons
-    change t k = stackel.val s at tk,
-    simp only [eS, tk, dw, st_write, TM1.step_aux, tr_st_act, cond, tape.move,
-      list.head, list.tail, list.cons_append],
-    exact ⟨_, t::T₁, _, hT, e₁, ea, rfl⟩ },
-  { -- pop cons
-    change t k = stackel.val s at tk,
-    simp only [tk, st_write, list.tail, TM1.step_aux, tr_st_act, cond,
-      tape.move, list.cons_append, list.head],
-    refine ⟨_, _, _, _, e₁', dwrite_eq _ _ _, rfl⟩,
-    intro k', cases hT k' with n e,
-    by_cases h : k' = k,
-    { subst k', existsi n+1,
-      simp only [list.reverse_core_eq, eS, e₁', list.append_left_inj,
-        list.map_append, list.map_reverse, list.map, list.reverse_cons,
-        list.append_assoc, list.cons_append] at e ⊢,
-      simp only [tape.move, tape.write, list.head, list.tail, dwrite_eq],
-      rw [e.2.2]; refl },
-    { existsi n, simpa only [dwrite_ne _ _ _ _ h, list.map, list.head, list.tail,
-        list.reverse_core, list.map_reverse_core, tape.move, tape.write] using e } },
+  rw [← proj_map_nth M, hL, ← list.map_reverse, list_blank.nth_mk, list.inth, list.nth_map],
+  cases S.reverse.nth n; refl
 end
 
-theorem tr_respects_aux₃ {k q v}
-  {S : Π k, list (Γ k)} {T : list Γ'}
-  (hT : ∀ k, tr_stk (S k) (T.map (λ (a : Γ'), a k))) :
-  ∀ (T₁ : list Γ') {T₂ : list Γ'} {a : Γ'} {S₁}
-    (e : T = T₁.reverse_core (a :: T₂))
-    (ha : (a k).is_bottom = ff)
-    (e₁ : T₁.map (λ (a : Γ'), a k) = list.map stackel.val S₁),
-    reaches₀ (TM1.step tr)
-      ⟨some (ret k q), v, (a, T₁ ++ [stackel.bottom], T₂)⟩
-      ⟨some (ret k q), v, (stackel.bottom, [], T)⟩
-| [] T₂ a S₁ e ha e₁ := reaches₀.single (by simp only [ha, e, TM1.step,
-    option.mem_def, tr, TM1.step_aux] {constructor_eq:=ff}; refl)
-| (b :: T₁) T₂ a (s :: S₁) e ha e₁ := begin
-    unfold list.map at e₁, injection e₁ with es e₁,
-    refine reaches₀.head _ (tr_respects_aux₃ T₁ e (by rw es; refl) e₁),
-    simp only [ha, option.mem_def, TM1.step, tr, TM1.step_aux], refl
-  end
+/-- The bottom marker is fixed throughout the calculation, so we use the `add_bottom` function
+to express the program state in terms of a tape with only the stacks themselves. -/
+@[nolint unused_arguments]
+def add_bottom (L : list_blank (∀ k, option (Γ k))) : list_blank Γ' :=
+list_blank.cons (tt, L.head) (L.tail.map ⟨prod.mk ff, rfl⟩)
+
+theorem add_bottom_map (L) : (add_bottom L).map ⟨prod.snd, rfl⟩ = L :=
+begin
+  simp only [add_bottom, list_blank.map_cons]; convert list_blank.cons_head_tail _,
+  generalize : list_blank.tail L = L',
+  refine L'.induction_on _, intro l, simp,
+  rw (_ : _ ∘ _ = id), {simp},
+  funext a, refl
+end
+
+theorem add_bottom_modify_nth (f : (∀ k, option (Γ k)) → (∀ k, option (Γ k))) (L n) :
+  (add_bottom L).modify_nth (λ a, (a.1, f a.2)) n = add_bottom (L.modify_nth f n) :=
+begin
+  cases n; simp only [add_bottom,
+    list_blank.head_cons, list_blank.modify_nth, list_blank.tail_cons],
+  congr, symmetry, apply list_blank.map_modify_nth, intro, refl
+end
+
+theorem add_bottom_nth_snd (L n) : ((add_bottom L).nth n).2 = L.nth n :=
+by conv {to_rhs, rw [← add_bottom_map M L, list_blank.nth_map]}; refl
+
+theorem add_bottom_nth_succ_fst (L n) : ((add_bottom L).nth (n+1)).1 = ff :=
+by rw [list_blank.nth_succ, add_bottom, list_blank.tail_cons, list_blank.nth_map]; refl
+
+theorem add_bottom_head_fst (L) : (add_bottom L).head.1 = tt :=
+by rw [add_bottom, list_blank.head_cons]; refl
+
+local attribute [pp_using_anonymous_constructor] turing.TM1.cfg
+/-- The relation between TM2 configurations and TM1 configurations of the TM2 emulator. -/
+inductive tr_cfg : cfg₂ → cfg₁ → Prop
+| mk {q v} {S : ∀ k, list (Γ k)} (L : list_blank (∀ k, option (Γ k))) :
+  (∀ k, L.map (proj k) = list_blank.mk ((S k).map some).reverse) →
+  tr_cfg ⟨q, v, S⟩ ⟨q.map normal, v, tape.mk' ∅ (add_bottom L)⟩
+
+theorem tr_respects_aux₁ {k} (o q v) {S : list (Γ k)} {L : list_blank (∀ k, option (Γ k))}
+  (hL : L.map (proj k) = list_blank.mk (S.map some).reverse) (n ≤ S.length) :
+  reaches₀ (TM1.step tr)
+    ⟨some (go k o q), v, (tape.mk' ∅ (add_bottom L))⟩
+    ⟨some (go k o q), v, (tape.move dir.right)^[n] (tape.mk' ∅ (add_bottom L))⟩ :=
+begin
+  induction n with n IH, {refl},
+  apply (IH (le_of_lt H)).tail,
+  rw nat.iterate_succ', simp only [TM1.step, TM1.step_aux, tr,
+    tape.mk'_nth_nat, tape.move_right_n_head, add_bottom_nth_snd,
+    option.mem_def],
+  rw [stk_nth_val M _ hL, list.nth_le_nth], refl, rwa list.length_reverse
+end
+
+theorem tr_respects_aux₂
+  {k q v} {S : Π k, list (Γ k)} {L : list_blank (∀ k, option (Γ k))}
+  (hL : ∀ k, L.map (proj k) = list_blank.mk ((S k).map some).reverse) (o) :
+  let v' := st_var v (S k) o,
+      Sk' := st_write v (S k) o,
+      S' := update S k Sk' in
+  ∃ (L' : list_blank (∀ k, option (Γ k))),
+    (∀ k, L'.map (proj k) = list_blank.mk ((S' k).map some).reverse) ∧
+    TM1.step_aux (tr_st_act q o) v
+      ((tape.move dir.right)^[(S k).length] (tape.mk' ∅ (add_bottom L))) =
+    TM1.step_aux q v'
+      ((tape.move dir.right)^[(S' k).length] (tape.mk' ∅ (add_bottom L'))) :=
+begin
+  dsimp only, simp, cases o;
+  simp only [st_write, st_var, tr_st_act, TM1.step_aux],
+  case TM2to1.st_act.push : f {
+    have := tape.write_move_right_n (λ a : Γ', (a.1, update a.2 k (some (f v)))),
+    dsimp only at this,
+    refine ⟨_, λ k', _, by rw [
+      tape.move_right_n_head, list.length, tape.mk'_nth_nat, this,
+      add_bottom_modify_nth M (λ a, update a k (some (f v))),
+      nat.add_one, nat.iterate_succ']⟩,
+    refine list_blank.ext (λ i, _),
+    rw [list_blank.nth_map, list_blank.nth_modify_nth, proj, pointed_map.mk_val],
+    by_cases h' : k' = k,
+    { subst k', split_ifs; simp only [list.reverse_cons,
+        function.update_same, list_blank.nth_mk, list.inth, list.map],
+      { rw [list.nth_le_nth, list.nth_le_append_right];
+        simp only [h, list.nth_le_singleton, list.length_map, list.length_reverse, nat.succ_pos',
+          list.length_append, lt_add_iff_pos_right, list.length] },
+      rw [← proj_map_nth M, hL, list_blank.nth_mk, list.inth],
+      cases decidable.lt_or_gt_of_ne h with h h,
+      { rw list.nth_append, simpa only [list.length_map, list.length_reverse] using h },
+      { rw [list.nth_len_le, list.nth_len_le];
+        simp only [nat.add_one_le_iff, h, list.length, le_of_lt,
+          list.length_reverse, list.length_append, list.length_map] } },
+    { split_ifs; rw [function.update_noteq h', ← proj_map_nth M, hL],
+      rw function.update_noteq h' } },
+  case TM2to1.st_act.peek : b f {
+    rw function.update_eq_self,
+    use [L, hL], rw [tape.move_left_right], congr,
+    cases e : S k, {refl},
+    rw [list.length_cons, nat.iterate_succ', tape.move_right_left, tape.move_right_n_head,
+      tape.mk'_nth_nat, add_bottom_nth_snd, stk_nth_val M _ (hL k), e,
+      list.reverse_cons, ← list.length_reverse, list.nth_concat_length], refl },
+  case TM2to1.st_act.pop : b f {
+    cases e : S k,
+    { simp only [tape.mk'_head, list_blank.head_cons, tape.move_left_mk',
+        list.length, tape.write_mk', list.head', nat.iterate_zero, list.tail_nil],
+      rw [← e, function.update_eq_self], exact ⟨L, hL, by rw [add_bottom_head_fst, cond]⟩ },
+    { refine ⟨_, λ k', _, by rw [
+        list.length_cons, tape.move_right_n_head, tape.mk'_nth_nat, add_bottom_nth_succ_fst,
+        cond, nat.iterate_succ', tape.move_right_left, tape.move_right_n_head, tape.mk'_nth_nat,
+        tape.write_move_right_n (λ a:Γ', (a.1, update a.2 k none)),
+        add_bottom_modify_nth M (λ a, update a k none),
+        add_bottom_nth_snd, stk_nth_val M _ (hL k), e,
+        show (list.cons hd tl).reverse.nth tl.length = some hd,
+        by rw [list.reverse_cons, ← list.length_reverse, list.nth_concat_length]; refl,
+        list.head', list.tail]⟩,
+    refine list_blank.ext (λ i, _),
+    rw [list_blank.nth_map, list_blank.nth_modify_nth, proj, pointed_map.mk_val],
+    by_cases h' : k' = k,
+    { subst k', split_ifs; simp only [
+        function.update_same, list_blank.nth_mk, list.tail, list.inth],
+      { rw [list.nth_len_le], {refl}, rw [h, list.length_reverse, list.length_map] },
+      rw [← proj_map_nth M, hL, list_blank.nth_mk, list.inth, e, list.map, list.reverse_cons],
+      cases decidable.lt_or_gt_of_ne h with h h,
+      { rw list.nth_append, simpa only [list.length_map, list.length_reverse] using h },
+      { rw [list.nth_len_le, list.nth_len_le];
+        simp only [nat.add_one_le_iff, h, list.length, le_of_lt,
+          list.length_reverse, list.length_append, list.length_map] } },
+    { split_ifs; rw [function.update_noteq h', ← proj_map_nth M, hL],
+      rw function.update_noteq h' } } },
+end
+
+theorem tr_respects_aux₃ {q v} {L : list_blank (∀ k, option (Γ k))} (n) :
+  reaches₀ (TM1.step tr)
+    ⟨some (ret q), v, (tape.move dir.right)^[n] (tape.mk' ∅ (add_bottom L))⟩
+    ⟨some (ret q), v, (tape.mk' ∅ (add_bottom L))⟩ :=
+begin
+  induction n with n IH, {refl},
+  refine reaches₀.head _ IH,
+  rw [option.mem_def, TM1.step, tr, TM1.step_aux, tape.move_right_n_head, tape.mk'_nth_nat,
+    add_bottom_nth_succ_fst, TM1.step_aux, nat.iterate_succ', tape.move_right_left], refl,
+end
 
 theorem tr_respects_aux {q v T k} {S : Π k, list (Γ k)}
-  (hT : ∀ (k : K), tr_stk (S k) (list.map (λ (a : Γ'), a k) T))
+  (hT : ∀ k, list_blank.map (proj k) T = list_blank.mk ((S k).map some).reverse)
   (o : st_act k)
-  (IH : ∀ {v : σ} {S : Π (k : K), list (Γ k)} {T : list Γ'},
-    (∀ (k : K), tr_stk (S k) (list.map (λ (a : Γ'), a k) T)) →
+  (IH : ∀ {v : σ} {S : Π (k : K), list (Γ k)} {T : list_blank (∀ k, option (Γ k))},
+    (∀ k, list_blank.map (proj k) T = list_blank.mk ((S k).map some).reverse) →
     (∃ b, tr_cfg (TM2.step_aux q v S) b ∧
-      reaches (TM1.step tr) (TM1.step_aux (tr_normal q) v (stackel.bottom, [], T)) b)) :
+      reaches (TM1.step tr) (TM1.step_aux (tr_normal q) v (tape.mk' ∅ (add_bottom T))) b)) :
   ∃ b, tr_cfg (TM2.step_aux (st_run o q) v S) b ∧
     reaches (TM1.step tr) (TM1.step_aux (tr_normal (st_run o q))
-      v (stackel.bottom, [], T)) b :=
+      v (tape.mk' ∅ (add_bottom T))) b :=
 begin
-  rcases hT k with ⟨n, hTk⟩,
-  simp only [tr_normal_run],
-  rcases tr_respects_aux₁ M o q v _ hTk with ⟨a, T₁, T₂, rfl, ea, e₁, e₂, hgo⟩,
-  rcases tr_respects_aux₂ M hT e₁ ea _ with ⟨b, T₁', T₂', hT', e₁', eb, hrun⟩,
-  have hret := tr_respects_aux₃ M hT' _ rfl (by rw eb; refl) e₁',
+  simp only [tr_normal_run, step_run],
+  have hgo := tr_respects_aux₁ M o q v (hT k) _ (le_refl _),
+  obtain ⟨T', hT', hrun⟩ := tr_respects_aux₂ M hT o,
+  have hret := tr_respects_aux₃ M _,
   have := hgo.tail' rfl,
-  simp only [ea, tr, TM1.step_aux] at this,
-  rw [hrun, TM1.step_aux] at this,
-  rcases IH hT' with ⟨c, gc, rc⟩,
-  simp only [step_run],
-  refine ⟨c, gc, (this.to₀.trans hret _ (trans_gen.head' rfl rc)).to_refl⟩
+  rw [tr, TM1.step_aux, tape.move_right_n_head, tape.mk'_nth_nat, add_bottom_nth_snd,
+    stk_nth_val M _ (hT k), list.nth_len_le (le_of_eq (list.length_reverse _)),
+    option.is_none, cond, hrun, TM1.step_aux] at this,
+  obtain ⟨c, gc, rc⟩ := IH hT',
+  refine ⟨c, gc, (this.to₀.trans hret c (trans_gen.head' rfl _)).to_refl⟩,
+  rw [tr, TM1.step_aux, tape.mk'_head, add_bottom_head_fst],
+  exact rc,
 end
 
 local attribute [simp] respects TM2.step TM2.step_aux tr_normal
@@ -1623,30 +2098,30 @@ theorem tr_respects : respects (TM2.step M) (TM1.step tr) tr_cfg :=
   rw [tr],
   revert v S L hT, refine stmt_st_rec _ _ _ _ _ (M l); intros,
   { exact tr_respects_aux M hT s @IH },
-  { exact IH hT },
+  { exact IH _ hT },
   { unfold TM2.step_aux tr_normal TM1.step_aux,
-    cases p v; [exact IH₂ hT, exact IH₁ hT] },
-  { exact ⟨_, ⟨hT⟩, refl_trans_gen.refl⟩ },
-  { exact ⟨_, ⟨hT⟩, refl_trans_gen.refl⟩ }
+    cases p v; [exact IH₂ _ hT, exact IH₁ _ hT] },
+  { exact ⟨_, ⟨_, hT⟩, refl_trans_gen.refl⟩ },
+  { exact ⟨_, ⟨_, hT⟩, refl_trans_gen.refl⟩ }
 end
 
 theorem tr_cfg_init (k) (L : list (Γ k)) :
   tr_cfg (TM2.init k L) (TM1.init (tr_init k L)) :=
-⟨λ k', begin
-  unfold tr_init,
-  cases e : L.reverse with a L',
-  { cases list.reverse_eq_nil.1 e, rw dwrite_self, exact ⟨0, rfl⟩ },
-  by_cases k' = k,
-  { subst k', existsi 0,
-    simp only [list.tail, dwrite_eq, list.reverse_core_eq,
-      list.repeat, tr_init, list.map, list.map_map, (∘), list.map_id' (λ _, rfl)],
-    rw [← list.map_reverse, e], refl },
-  { existsi L'.length + 1,
-    simp only [dwrite_ne _ _ _ _ h, list.tail, tr_init, list.map_map,
-      list.map, list.map_append, list.repeat_add, (∘),
-      list.map_const] {constructor_eq:=ff},
-    refl }
-end⟩
+begin
+  rw (_ : TM1.init _ = _),
+  { refine ⟨list_blank.mk (L.reverse.map $ λ a, update (default _) k (some a)), λ k', _⟩,
+    refine list_blank.ext (λ i, _),
+    rw [list_blank.map_mk, list_blank.nth_mk, list.inth, list.map_map, (∘),
+       list.nth_map, proj, pointed_map.mk_val],
+    by_cases k' = k,
+    { subst k', simp only [function.update_same],
+      rw [list_blank.nth_mk, list.inth, ← list.map_reverse, list.nth_map] },
+    { simp only [function.update_noteq h],
+      rw [list_blank.nth_mk, list.inth, list.map, list.reverse_nil, list.nth],
+      cases L.reverse.nth i; refl } },
+  { rw [tr_init, TM1.init], dsimp only, congr; cases L.reverse; try {refl},
+    simp only [list.map_map, list.tail_cons, list.map], refl }
+end
 
 theorem tr_eval_dom (k) (L : list (Γ k)) :
   (TM1.eval tr (tr_init k L)).dom ↔ (TM2.eval M k L).dom :=
@@ -1655,37 +2130,38 @@ tr_eval_dom tr_respects (tr_cfg_init _ _)
 theorem tr_eval (k) (L : list (Γ k)) {L₁ L₂}
   (H₁ : L₁ ∈ TM1.eval tr (tr_init k L))
   (H₂ : L₂ ∈ TM2.eval M k L) :
-  ∃ S : ∀ k, list (Γ k),
-    (∀ k', tr_stk (S k') (L₁.map (λ a, a k'))) ∧ S k = L₂ :=
+  ∃ (S : ∀ k, list (Γ k)) (L' : list_blank (∀ k, option (Γ k))),
+    add_bottom L' = L₁ ∧
+    (∀ k, L'.map (proj k) = list_blank.mk ((S k).map some).reverse) ∧
+    S k = L₂ :=
 begin
-  rcases (roption.mem_map_iff _).1 H₁ with ⟨c₁, h₁, rfl⟩,
-  rcases (roption.mem_map_iff _).1 H₂ with ⟨c₂, h₂, rfl⟩,
-  rcases tr_eval (tr_respects M) (tr_cfg_init M k L) h₂
-    with ⟨_, ⟨q, v, S, L₁', hT⟩, h₃⟩,
+  obtain ⟨c₁, h₁, rfl⟩ := (roption.mem_map_iff _).1 H₁,
+  obtain ⟨c₂, h₂, rfl⟩ := (roption.mem_map_iff _).1 H₂,
+  obtain ⟨_, ⟨q, v, S, L', hT⟩, h₃⟩ := tr_eval (tr_respects M) (tr_cfg_init M k L) h₂,
   cases roption.mem_unique h₁ h₃,
-  exact ⟨S, hT, rfl⟩
+  exact ⟨S, L', by simp only [tape.mk'_right₀], hT, rfl⟩
 end
 
 variables [fintype K] [∀ k, fintype (Γ k)] [fintype σ]
 open_locale classical
 local attribute [simp] TM2.stmts₁_self
 
+/-- The set of machine states accessible from an initial TM2 statement. -/
+@[nolint unused_arguments]
 noncomputable def tr_stmts₁ : stmt₂ → finset Λ'
-| Q@(TM2.stmt.push k f q)     := {go k (st_act.push f) q, ret k q} ∪ tr_stmts₁ q
-| Q@(TM2.stmt.peek k f q)     := {go k (st_act.pop ff f) q, ret k q} ∪ tr_stmts₁ q
-| Q@(TM2.stmt.pop k f q)      := {go k (st_act.pop tt f) q, ret k q} ∪ tr_stmts₁ q
+| Q@(TM2.stmt.push k f q)     := {go k (st_act.push f) q, ret q} ∪ tr_stmts₁ q
+| Q@(TM2.stmt.peek k f q)     := {go k (st_act.peek f) q, ret q} ∪ tr_stmts₁ q
+| Q@(TM2.stmt.pop k f q)      := {go k (st_act.pop f) q, ret q} ∪ tr_stmts₁ q
 | Q@(TM2.stmt.load a q)       := tr_stmts₁ q
 | Q@(TM2.stmt.branch f q₁ q₂) := tr_stmts₁ q₁ ∪ tr_stmts₁ q₂
 | _                           := ∅
 
-theorem tr_stmts₁_run {k s q} : tr_stmts₁ (st_run s q) = {go k s q, ret k q} ∪ tr_stmts₁ q :=
+theorem tr_stmts₁_run {k s q} : tr_stmts₁ (st_run s q) = {go k s q, ret q} ∪ tr_stmts₁ q :=
 by rcases s with _|_|_; unfold tr_stmts₁ st_run
 
+/-- The support of a set of TM2 states in the TM2 emulator. -/
 noncomputable def tr_supp (S : finset Λ) : finset Λ' :=
 S.bind (λ l, insert (normal l) (tr_stmts₁ (M l)))
-
-local attribute [simp] tr_stmts₁ tr_stmts₁_run supports_run
-  tr_normal_run TM1.supports_stmt TM2.supports_stmt
 
 theorem tr_supports {S} (ss : TM2.supports M S) :
   TM1.supports tr (tr_supp S) :=

--- a/src/computability/turing_machine.lean
+++ b/src/computability/turing_machine.lean
@@ -1792,6 +1792,8 @@ inductive st_act (k : K)
 | peek : (σ → option (Γ k) → σ) → st_act
 | pop : (σ → option (Γ k) → σ) → st_act
 
+instance st_act.inhabited {k} : inhabited (st_act k) := ⟨st_act.peek (λ s _, s)⟩
+
 section
 open st_act
 
@@ -1846,7 +1848,7 @@ inductive Λ' : Type (max u_1 u_2 u_3 u_4)
 | go (k) : st_act k → stmt₂ → Λ'
 | ret : stmt₂ → Λ'
 open Λ'
-instance : inhabited Λ' := ⟨normal (default _)⟩
+instance Λ'.inhabited : inhabited Λ' := ⟨normal (default _)⟩
 
 local notation `stmt₁` := TM1.stmt Γ' Λ' σ
 local notation `cfg₁` := TM1.cfg Γ' Λ' σ
@@ -2142,7 +2144,6 @@ begin
   exact ⟨S, L', by simp only [tape.mk'_right₀], hT, rfl⟩
 end
 
-variables [fintype K] [∀ k, fintype (Γ k)] [fintype σ]
 open_locale classical
 local attribute [simp] TM2.stmts₁_self
 

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -884,7 +884,7 @@ lemma last_eq_nth_le : ∀ (l : list α) (h : l ≠ []),
 | (a :: b :: l) h := by { rw [last_cons, last_eq_nth_le (b :: l)],
                           refl, exact cons_ne_nil b l }
 
-@[simp] lemma nth_concat_length: ∀ (l : list α) (a : α), (l ++ [a]).nth l.length = a
+@[simp] lemma nth_concat_length : ∀ (l : list α) (a : α), (l ++ [a]).nth l.length = some a
 | []     a := rfl
 | (b::l) a := by rw [cons_append, length_cons, nth, nth_concat_length]
 

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -584,6 +584,8 @@ by {induction s, contradiction, refl}
 theorem cons_head_tail [inhabited α] {l : list α} (h : l ≠ []) : (head l)::(tail l) = l :=
 by {induction l, contradiction, refl}
 
+@[simp] theorem head'_map (f : α → β) (l) : head' (map f l) = (head' l).map f := by cases l; refl
+
 /-! ### sublists -/
 
 @[simp] theorem nil_sublist : Π (l : list α), [] <+ l

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -187,6 +187,9 @@ eq_max (nat.le_sub_add _ _) (le_add_left _ _) $ λ k h₁ h₂,
 by rw ← nat.sub_add_cancel h₂; exact
 add_le_add_right (nat.sub_le_sub_right h₁ _) _
 
+theorem add_sub_eq_max (n m : ℕ) : n + (m - n) = max n m :=
+by rw [add_comm, max_comm, sub_add_eq_max]
+
 theorem sub_add_min (n m : ℕ) : n - m + min n m = n :=
 (le_total n m).elim
   (λ h, by rw [min_eq_left h, sub_eq_zero_of_le h, zero_add])


### PR DESCRIPTION
This ended up being a major refactor of `computability.turing_machine`. It started as a change of the definition of turing machine so that the tape is a quotient of lists up to the relation "ends with blanks", but the file is quite old and I updated it to pass the linter as well. I'm not up to speed on the new documentation requirements, but now is a good time to request them for this file. This doesn't add many new theorems, it's mostly just fixes to make it compile again after the change. (Some of the turing machine constructions are also simplified.)