### PR TITLE
[Merged by Bors] - refactor(*): remove instance max depth

### DIFF
--- a/src/algebra/direct_limit.lean
+++ b/src/algebra/direct_limit.lean
@@ -200,7 +200,6 @@ local attribute [instance] directed_system
 instance : add_comm_group (direct_limit G f) :=
 module.direct_limit.add_comm_group G (λ i j hij, (add_monoid_hom.of $f i j hij).to_int_linear_map)
 
-set_option class.instance_max_depth 50
 
 /-- The canonical map from a component to the direct limit. -/
 def of (i) : G i → direct_limit G f :=

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -85,7 +85,6 @@ open_locale classical topological_space
 open filter asymptotics set
 open continuous_linear_map (smul_right smul_right_one_eq_iff)
 
-set_option class.instance_max_depth 100
 
 variables {𝕜 : Type u} [nondiscrete_normed_field 𝕜]
 

--- a/src/analysis/calculus/extend_deriv.lean
+++ b/src/analysis/calculus/extend_deriv.lean
@@ -20,7 +20,6 @@ the right endpoint of an interval, are given in
 of the one-dimensional derivative `deriv ℝ f`.
 -/
 
-set_option class.instance_max_depth 40
 
 variables {E : Type*} [normed_group E] [normed_space ℝ E]
           {F : Type*} [normed_group F] [normed_space ℝ F]

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -114,7 +114,6 @@ open_locale topological_space classical
 
 noncomputable theory
 
-set_option class.instance_max_depth 90
 
 section
 
@@ -1821,7 +1820,6 @@ end smul
 section mul
 /-! ### Derivative of the product of two scalar-valued functions -/
 
-set_option class.instance_max_depth 120
 variables {c d : E → 𝕜} {c' d' : E →L[𝕜] 𝕜}
 
 theorem has_strict_fderiv_at.mul

--- a/src/analysis/calculus/iterated_deriv.lean
+++ b/src/analysis/calculus/iterated_deriv.lean
@@ -44,7 +44,6 @@ noncomputable theory
 open_locale classical topological_space
 open filter asymptotics set
 
-set_option class.instance_max_depth 110
 
 variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 variables {F : Type*} [normed_group F] [normed_space 𝕜 F]

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -54,7 +54,6 @@ In this file we prove the following facts:
   is increasing or its second derivative is nonnegative, then the original function is convex.
 -/
 
-set_option class.instance_max_depth 120
 
 variables {E : Type*} [normed_group E] [normed_space ℝ E]
           {F : Type*} [normed_group F] [normed_space ℝ F]

--- a/src/analysis/calculus/tangent_cone.lean
+++ b/src/analysis/calculus/tangent_cone.lean
@@ -35,7 +35,6 @@ variables {E : Type*} [normed_group E] [normed_space 𝕜 E]
 variables {F : Type*} [normed_group F] [normed_space 𝕜 F]
 variables {G : Type*} [normed_group G] [normed_space ℝ G]
 
-set_option class.instance_max_depth 50
 open filter set
 open_locale topological_space
 

--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -148,7 +148,6 @@ variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 {s s₁ t u : set E} {f f₁ : E → F} {g : F → G} {x : E} {c : F}
 {b : E × F → G}
 
-set_option class.instance_max_depth 370
 
 /-- A formal multilinear series over a field `𝕜`, from `E` to `F`, is given by a family of
 multilinear maps from `E^n` to `F` for all `n`. -/

--- a/src/analysis/complex/basic.lean
+++ b/src/analysis/complex/basic.lean
@@ -33,7 +33,6 @@ complex derivative.
 -/
 noncomputable theory
 
-set_option class.instance_max_depth 40
 
 namespace complex
 

--- a/src/analysis/normed_space/banach.lean
+++ b/src/analysis/normed_space/banach.lean
@@ -20,7 +20,6 @@ variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 (f : E →L[𝕜] F)
 include 𝕜
 
-set_option class.instance_max_depth 70
 
 variable [complete_space F]
 

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -676,7 +676,6 @@ variables [normed_field α] [normed_group β]
 instance normed_field.to_normed_space : normed_space α α :=
 { norm_smul := normed_field.norm_mul }
 
-set_option class.instance_max_depth 43
 
 lemma norm_smul [normed_space α β] (s : α) (x : β) : ∥s • x∥ = ∥s∥ * ∥x∥ :=
 normed_space.norm_smul s x
@@ -797,7 +796,6 @@ normed_algebra.norm_algebra_map_eq _
 end normed_algebra
 
 section restrict_scalars
-set_option class.instance_max_depth 40
 
 variables (𝕜 : Type*) (𝕜' : Type*) [normed_field 𝕜] [normed_field 𝕜'] [normed_algebra 𝕜 𝕜']
 {E : Type*} [normed_group E] [normed_space 𝕜' E]

--- a/src/analysis/normed_space/bounded_linear_maps.lean
+++ b/src/analysis/normed_space/bounded_linear_maps.lean
@@ -18,7 +18,6 @@ variables {E : Type*} [normed_group E] [normed_space 𝕜 E]
 variables {F : Type*} [normed_group F] [normed_space 𝕜 F]
 variables {G : Type*} [normed_group G] [normed_space 𝕜 G]
 
-set_option class.instance_max_depth 70
 
 /-- A function `f` satisfies `is_bounded_linear_map 𝕜 f` if it is linear and satisfies the
 inequality `∥ f x ∥ ≤ M * ∥ x ∥` for some positive constant `M`. -/
@@ -142,7 +141,6 @@ end
 end is_bounded_linear_map
 
 section
-set_option class.instance_max_depth 240
 variables {ι : Type*} [decidable_eq ι] [fintype ι]
 
 /-- Taking the cartesian product of two continuous linear maps is a bounded linear operation. -/
@@ -389,7 +387,6 @@ end
 @[simp] lemma is_bounded_bilinear_map_deriv_coe (h : is_bounded_bilinear_map 𝕜 f) (p q : E × F) :
   h.deriv p q = f (p.1, q.2) + f (q.1, p.2) := rfl
 
-set_option class.instance_max_depth 100
 
 /-- Given a bounded bilinear map `f`, the map associating to a point `p` the derivative of `f` at
 `p` is itself a bounded linear map. -/

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -48,7 +48,6 @@ local attribute [instance, priority 10000] pi.module normed_space.to_module
   submodule.add_comm_group submodule.module
   linear_map.finite_dimensional_range Pi.complete nondiscrete_normed_field.to_normed_field
 
-set_option class.instance_max_depth 100
 
 /-- A linear map on `ι → 𝕜` (where `ι` is a fintype) is continuous -/
 lemma linear_map.continuous_on_pi {ι : Type w} [fintype ι] {𝕜 : Type u} [normed_field 𝕜]
@@ -74,7 +73,6 @@ variables {𝕜 : Type u} [nondiscrete_normed_field 𝕜]
 [topological_add_group F'] [topological_vector_space 𝕜 F']
 [complete_space 𝕜]
 
-set_option class.instance_max_depth 150
 
 /-- In finite dimension over a complete field, the canonical identification (in terms of a basis)
 with `𝕜^n` together with its sup norm is continuous. This is the nontrivial part in the fact that

--- a/src/analysis/normed_space/multilinear.lean
+++ b/src/analysis/normed_space/multilinear.lean
@@ -57,7 +57,6 @@ noncomputable theory
 open_locale classical
 open finset
 
-set_option class.instance_max_depth 45
 
 universes u v w w₁ w₂ wG
 variables {𝕜 : Type u} {ι : Type v} {n : ℕ}
@@ -657,7 +656,6 @@ The inverse operations are called `uncurry_left` and `uncurry_right`.
 We also register continuous linear equiv versions of these correspondences, in
 `continuous_multilinear_curry_left_equiv` and `continuous_multilinear_curry_right_equiv`.
 -/
-set_option class.instance_max_depth 360
 open fin function
 
 lemma continuous_linear_map.norm_map_tail_le
@@ -978,6 +976,8 @@ def continuous_multilinear_map.curry0 (x : E₂) :
 variable {G}
 @[simp] lemma continuous_multilinear_map.curry0_apply (x : E₂) (m : (fin 0) → G) :
   (continuous_multilinear_map.curry0 𝕜 G x : ((fin 0) → G) → E₂) m = x := rfl
+
+
 
 variable {𝕜}
 @[simp] lemma continuous_multilinear_map.uncurry0_apply

--- a/src/analysis/normed_space/multilinear.lean
+++ b/src/analysis/normed_space/multilinear.lean
@@ -977,8 +977,6 @@ variable {G}
 @[simp] lemma continuous_multilinear_map.curry0_apply (x : E₂) (m : (fin 0) → G) :
   (continuous_multilinear_map.curry0 𝕜 G x : ((fin 0) → G) → E₂) m = x := rfl
 
-
-
 variable {𝕜}
 @[simp] lemma continuous_multilinear_map.uncurry0_apply
   (f : continuous_multilinear_map 𝕜 (λ (i : fin 0), G) E₂) :

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -13,7 +13,6 @@ import analysis.asymptotics
 noncomputable theory
 open_locale classical
 
-set_option class.instance_max_depth 70
 
 variables {𝕜 : Type*} {E : Type*} {F : Type*} {G : Type*}
 [normed_group E] [normed_group F] [normed_group G]
@@ -206,7 +205,6 @@ end
 section op_norm
 open set real
 
-set_option class.instance_max_depth 100
 
 /-- The operator norm of a continuous linear map is the inf of all its bounds. -/
 def op_norm := Inf { c | c ≥ 0 ∧ ∀ x, ∥f x∥ ≤ c * ∥x∥ }

--- a/src/analysis/normed_space/real_inner_product.lean
+++ b/src/analysis/normed_space/real_inner_product.lean
@@ -49,7 +49,6 @@ universes u v w
 
 variables {α : Type u} {F : Type v} {G : Type w}
 
-set_option class.instance_max_depth 40
 
 class has_inner (α : Type*) := (inner : α → α → ℝ)
 

--- a/src/data/padics/padic_numbers.lean
+++ b/src/data/padics/padic_numbers.lean
@@ -456,7 +456,6 @@ begin
   { simpa using ih }
 end
 
--- without short circuits, this needs an increase of class.instance_max_depth
 @[simp] lemma cast_eq_of_rat_of_int (n : ℤ) : ↑n = of_rat p n :=
 by induction n; simp
 

--- a/src/field_theory/mv_polynomial.lean
+++ b/src/field_theory/mv_polynomial.lean
@@ -148,7 +148,6 @@ begin
   exact degrees_X _
 end
 
-set_option class.instance_max_depth 50
 lemma indicator_mem_restrict_degree (c : σ → α) :
   indicator c ∈ restrict_degree σ α (fintype.card α - 1) :=
 begin
@@ -208,7 +207,6 @@ noncomputable instance decidable_restrict_degree (m : ℕ) :
   decidable_pred (λn, n ∈ {n : σ →₀ ℕ | ∀i, n i ≤ m }) :=
 by simp only [set.mem_set_of_eq]; apply_instance
 
-set_option class.instance_max_depth 60
 lemma dim_R : vector_space.dim α (R σ α) = fintype.card (σ → α) :=
 calc vector_space.dim α (R σ α) =
   vector_space.dim α (↥{s : σ →₀ ℕ | ∀ (n : σ), s n ≤ fintype.card α - 1} →₀ α) :

--- a/src/geometry/manifold/basic_smooth_bundle.lean
+++ b/src/geometry/manifold/basic_smooth_bundle.lean
@@ -287,7 +287,6 @@ variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
 (M : Type*) [topological_space M] [manifold H M] [smooth_manifold_with_corners I M]
 
-set_option class.instance_max_depth 50
 
 /-- Basic smooth bundle core version of the tangent bundle of a smooth manifold `M` modelled over a
 model with corners `I` on `(E, H)`. The fibers are equal to `E`, and the coordinate change in the

--- a/src/geometry/manifold/mfderiv.lean
+++ b/src/geometry/manifold/mfderiv.lean
@@ -232,7 +232,6 @@ if h : mdifferentiable_at I I' f x then
   ((ext_chart_at I x).to_fun x) : _)
 else 0
 
-set_option class.instance_max_depth 60
 
 /-- The derivative within a set, as a map between the tangent bundles -/
 def bundle_mfderiv_within (f : M → M') (s : set M) : tangent_bundle I M → tangent_bundle I' M' :=
@@ -346,7 +345,6 @@ begin
 end
 
 include Is I's
-set_option class.instance_max_depth 60
 
 lemma mfderiv_within_zero_of_not_mdifferentiable_within_at
   (h : ¬ mdifferentiable_within_at I I' f s x) : mfderiv_within I I' f s x = 0 :=
@@ -1201,7 +1199,6 @@ lemma to_fun_inv_fun_deriv {x : M'} (hx : x ∈ e.target) :
     continuous_linear_map.id 𝕜 (tangent_space I' x) :=
 he.symm.inv_fun_to_fun_deriv hx
 
-set_option class.instance_max_depth 60
 
 /-- The derivative of a differentiable local homeomorphism, as a continuous linear equivalence
 between the tangent spaces at `x` and `e.to_fun x`. -/
@@ -1224,7 +1221,6 @@ protected def mfderiv {x : M} (hx : x ∈ e.source) :
   end,
   .. mfderiv I I' e.to_fun x }
 
-set_option class.instance_max_depth 100
 
 lemma range_mfderiv_eq_univ {x : M} (hx : x ∈ e.source) :
   range (mfderiv I I' e.to_fun x) = univ :=

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -903,7 +903,6 @@ le_antisymm
   begin rw [map_le_iff_le_comap, comap_smul f _ a h, ← map_le_iff_le_comap], exact le_refl _ end
   begin rw [map_le_iff_le_comap, ← comap_smul f _ a h, ← map_le_iff_le_comap], exact le_refl _ end
 
-set_option class.instance_max_depth 40
 
 lemma comap_smul' (f : V →ₗ[K] V₂) (p : submodule K V₂) (a : K) :
   p.comap (a • f) = (⨅ h : a ≠ 0, p.comap f) :=
@@ -1543,7 +1542,6 @@ variables [module R M] [module R M₂] [module R M₃]
 include R
 open linear_map
 
-set_option class.instance_max_depth 39
 
 /-- Multiplying by a unit `a` of the ring `R` is a linear equivalence. -/
 def smul_of_unit (a : units R) : M ≃ₗ[R] M :=
@@ -1679,7 +1677,6 @@ def sup_quotient_to_quotient_inf (p p' : submodule R M) :
 rw [ker_comp, of_le, comap_cod_restrict, ker_mkq, map_comap_subtype],
 exact comap_mono (inf_le_inf le_sup_left (le_refl _)) end
 
-set_option class.instance_max_depth 41
 
 /--
 Second Isomorphism Law : the canonical map from p/(p ∩ p') to (p+p')/p' as a linear isomorphism.

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -962,7 +962,6 @@ open submodule
    (instead of a data containing type class) -/
 
 section
-set_option class.instance_max_depth 36
 
 lemma mem_span_insert_exchange : x ∈ span K (insert y s) → x ∉ span K s → y ∈ span K (insert x s) :=
 begin
@@ -1160,7 +1159,6 @@ begin
   exact right_inverse_inv_fun (linear_map.range_eq_top.1 hf_surj) _
 end
 
-set_option class.instance_max_depth 49
 open submodule linear_map
 theorem quotient_prod_linear_equiv (p : submodule K V) :
   nonempty ((p.quotient × p) ≃ₗ[K] V) :=

--- a/src/linear_algebra/contraction.lean
+++ b/src/linear_algebra/contraction.lean
@@ -19,7 +19,6 @@ contraction, dual module, tensor product
 
 universes u v
 
-set_option class.instance_max_depth 50
 
 section contraction
 open tensor_product

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -48,7 +48,6 @@ variables {K V}
 open vector_space
 
 section
-set_option class.instance_max_depth 50
 theorem is_basis.le_span (zero_ne_one : (0 : K) ≠ 1) {v : ι → V} {J : set V} (hv : is_basis K v)
    (hJ : span K J = ⊤) : cardinal.mk (range v) ≤ cardinal.mk J :=
 begin
@@ -239,7 +238,6 @@ dim_le_injective (of_le h) $ assume ⟨x, hx⟩ ⟨y, hy⟩ eq,
 section
 variables [add_comm_group V₃] [vector_space K V₃]
 variables [add_comm_group V₄] [vector_space K V₄]
-set_option class.instance_max_depth 70
 open linear_map
 
 /-- This is mostly an auxiliary lemma for `dim_sup_add_dim_inf_eq`. -/

--- a/src/linear_algebra/dual.lean
+++ b/src/linear_algebra/dual.lean
@@ -97,7 +97,6 @@ def eval_finsupp_at (i : ι) : (ι →₀ K) →ₗ[K] K :=
   smul := by intros; rw finsupp.smul_apply }
 include h
 
-set_option class.instance_max_depth 50
 
 def coord_fun (i : ι) : (V →ₗ[K] K) := (eval_finsupp_at i).comp h.repr
 
@@ -232,7 +231,6 @@ begin
   exact hb.dual_dim_eq
 end
 
-set_option class.instance_max_depth 70
 
 lemma eval_range (h : dim K V < omega) : (eval K V).range = ⊤ :=
 begin

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -139,7 +139,6 @@ linear_map.cod_restrict _
 variables {M R}
 
 section
-set_option class.instance_max_depth 50
 @[simp] theorem restrict_dom_apply (s : set α) (l : α →₀ M) :
   ((restrict_dom M R s : (α →₀ M) →ₗ supported M R s) l : α →₀ M) = finsupp.filter (∈ s) l := rfl
 end
@@ -209,7 +208,6 @@ begin
 end
 
 section
-set_option class.instance_max_depth 37
 def supported_equiv_finsupp (s : set α) :
   (supported M R s) ≃ₗ[R] (s →₀ M) :=
 (restrict_support_equiv s).to_linear_equiv

--- a/src/linear_algebra/finsupp_vector_space.lean
+++ b/src/linear_algebra/finsupp_vector_space.lean
@@ -96,7 +96,6 @@ variables [add_comm_group V'] [vector_space K V']
 
 open vector_space
 
-set_option class.instance_max_depth 70
 
 lemma equiv_of_dim_eq_lift_dim
   (h : cardinal.lift.{v w} (dim K V) = cardinal.lift.{w v} (dim K V')) :
@@ -158,7 +157,6 @@ section vector_space
 universes u
 
 open vector_space
-set_option class.instance_max_depth 50
 local attribute [instance] submodule.module
 
 variables {K V : Type u} [field K] [add_comm_group V] [vector_space K V]

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -269,7 +269,6 @@ begin
   exact le_refl _
 end
 
-set_option class.instance_max_depth 100
 
 lemma diagonal_to_lin [decidable_eq m] (w : m → K) :
   (diagonal w).to_lin = linear_map.pi (λi, w i • linear_map.proj i) :=

--- a/src/linear_algebra/nonsingular_inverse.lean
+++ b/src/linear_algebra/nonsingular_inverse.lean
@@ -52,7 +52,6 @@ open_locale matrix
 open equiv equiv.perm finset
 
 -- Increase max depth to allow inference of `mul_action α (matrix n n α)`.
-set_option class.instance_max_depth 60
 
 section update
 

--- a/src/linear_algebra/nonsingular_inverse.lean
+++ b/src/linear_algebra/nonsingular_inverse.lean
@@ -51,7 +51,6 @@ variables {n : Type u} [fintype n] [decidable_eq n] {α : Type v}
 open_locale matrix
 open equiv equiv.perm finset
 
--- Increase max depth to allow inference of `mul_action α (matrix n n α)`.
 
 section update
 

--- a/src/linear_algebra/special_linear_group.lean
+++ b/src/linear_algebra/special_linear_group.lean
@@ -45,7 +45,6 @@ universes u v
 open_locale matrix
 open linear_map
 
-set_option class.instance_max_depth 60
 
 section
 

--- a/src/linear_algebra/tensor_product.lean
+++ b/src/linear_algebra/tensor_product.lean
@@ -16,7 +16,6 @@ variables [module R M] [module R N] [module R P] [module R Q] [module R S]
 include R
 
 
-set_option class.instance_max_depth 100
 
 namespace linear_map
 

--- a/src/measure_theory/ae_eq_fun.lean
+++ b/src/measure_theory/ae_eq_fun.lean
@@ -518,7 +518,6 @@ end normed_group
 
 section normed_space
 
-set_option class.instance_max_depth 100
 
 variables {𝕜 : Type*} [normed_field 𝕜]
 variables {γ : Type*} [normed_group γ] [second_countable_topology γ] [normed_space 𝕜 γ]

--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -116,7 +116,6 @@ Bochner integral, simple function, function space, Lebesgue dominated convergenc
 noncomputable theory
 open_locale classical topological_space
 
-set_option class.instance_max_depth 100
 
 -- Typeclass inference has difficulty finding `has_scalar ℝ β` where `β` is a `normed_space` on `ℝ`
 local attribute [instance, priority 10000]

--- a/src/measure_theory/l1_space.lean
+++ b/src/measure_theory/l1_space.lean
@@ -52,7 +52,6 @@ integrable, function space, l1
 noncomputable theory
 open_locale classical topological_space
 
-set_option class.instance_max_depth 100
 
 namespace measure_theory
 open set filter topological_space ennreal emetric

--- a/src/ring_theory/algebra_operations.lean
+++ b/src/ring_theory/algebra_operations.lean
@@ -43,10 +43,8 @@ end
 theorem one_le : (1 : submodule R A) ≤ P ↔ (1 : A) ∈ P :=
 by simpa only [one_eq_span, span_le, set.singleton_subset_iff]
 
-set_option class.instance_max_depth 50
 instance : has_mul (submodule R A) :=
 ⟨λ M N, ⨆ s : M, N.map $ algebra.lmul R A s.1⟩
-set_option class.instance_max_depth 32
 
 theorem mul_mem_mul (hm : m ∈ M) (hn : n ∈ N) : m * n ∈ M * N :=
 (le_supr _ ⟨m, hm⟩ : _ ≤ M * N) ⟨n, hn, rfl⟩
@@ -79,7 +77,6 @@ end
 variables {R}
 
 variables (M N P Q)
-set_option class.instance_max_depth 50
 protected theorem mul_assoc : (M * N) * P = M * (N * P) :=
 le_antisymm (mul_le.2 $ λ mn hmn p hp, suffices M * N ≤ (M * (N * P)).comap ((algebra.lmul R A).flip p), from this hmn,
   mul_le.2 $ λ m hm n hn, show m * n * p ∈ M * (N * P), from
@@ -87,7 +84,6 @@ le_antisymm (mul_le.2 $ λ mn hmn p hp, suffices M * N ≤ (M * (N * P)).comap (
 (mul_le.2 $ λ m hm np hnp, suffices N * P ≤ (M * N * P).comap (algebra.lmul R A m), from this hnp,
   mul_le.2 $ λ n hn p hp, show m * (n * p) ∈ M * N * P, from
   mul_assoc m n p ▸ mul_mem_mul (mul_mem_mul hm hn) hp)
-set_option class.instance_max_depth 32
 
 @[simp] theorem mul_bot : M * ⊥ = ⊥ :=
 eq_bot_iff.2 $ mul_le.2 $ λ m hm n hn, by rw [submodule.mem_bot] at hn ⊢; rw [hn, mul_zero]
@@ -195,7 +191,6 @@ instance semimodule_set : semimodule (set A) (submodule R A) :=
   zero_smul := λ P, show span R ∅ * P = ⊥, by erw [span_empty, bot_mul],
   smul_zero := λ _, mul_bot _ }
 
-set_option class.instance_max_depth 45
 
 variables {R A}
 

--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -56,7 +56,6 @@ fractional ideal, fractional ideals, invertible ideal
 
 open localization
 
-set_option class.instance_max_depth 75
 
 universes u v w
 

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -132,7 +132,6 @@ begin
   refine is_integral_of_noetherian' H ⟨x, hx⟩
 end
 
-set_option class.instance_max_depth 100
 theorem is_integral_of_mem_of_fg (S : subalgebra R A)
   (HS : (S : submodule R A).fg) (x : A) (hx : x ∈ S) : is_integral R x :=
 begin
@@ -299,7 +298,6 @@ variables {R : Type*} {A : Type*} {B : Type*}
 variables [comm_ring R] [comm_ring A] [comm_ring B]
 variables [algebra R A] [algebra A B]
 
-set_option class.instance_max_depth 50
 
 lemma is_integral_trans_aux (x : B) {p : polynomial A} (pmonic : monic p) (hp : aeval A B x p = 0)
   (S : set (comap R A B))

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -605,7 +605,6 @@ section module
   Localizations form an algebra over `α` induced by the embedding `coe : α → localization α S`.
 -/
 
-set_option class.instance_max_depth 50
 
 variables (α S)
 
@@ -663,7 +662,6 @@ begin
   rw [coe_mul, ha, hb]
 end
 
-set_option class.instance_max_depth 50
 lemma is_integer_smul {a : α} {b} (hb : is_integer α S b) :
   is_integer α S (a • b) :=
 begin

--- a/src/tactic/ring.lean
+++ b/src/tactic/ring.lean
@@ -135,8 +135,6 @@ theorem horner_add_horner_gt {α} [comm_semiring α] (a₁ x n₁ b₁ a₂ n₂
   @horner α _ a₁ x n₁ b₁ + horner a₂ x n₂ b₂ = horner a' x n₂ b' :=
 by simp [h₂.symm, h₃.symm, h₁.symm, horner, pow_add, mul_add, mul_comm, mul_left_comm]; cc
 
--- set_option trace.class_instances true
--- set_option class.instance_max_depth 128
 theorem horner_add_horner_eq {α} [comm_semiring α] (a₁ x n b₁ a₂ b₂ a' b' t)
   (h₁ : a₁ + a₂ = a') (h₂ : b₁ + b₂ = b') (h₃ : horner a' x n b' = t) :
   @horner α _ a₁ x n b₁ + horner a₂ x n b₂ = t :=

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -141,7 +141,6 @@ variables {R : Type*} {M : Type*} {a : R}
 [topological_space M] [add_comm_group M]
 [vector_space R M] [topological_vector_space R M]
 
-set_option class.instance_max_depth 36
 
 /-- Scalar multiplication by a non-zero field element is a
 homeomorphism from a topological vector space onto itself. -/

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -45,7 +45,6 @@ universes u v w
 open classical set function topological_space filter metric quotient
 open bounded_continuous_function nat Kuratowski_embedding
 open sum (inl inr)
-set_option class.instance_max_depth 50
 
 local attribute [instance] metric_space_sum
 

--- a/src/topology/metric_space/gromov_hausdorff_realized.lean
+++ b/src/topology/metric_space/gromov_hausdorff_realized.lean
@@ -17,7 +17,6 @@ universes u v w
 open classical set function topological_space filter metric quotient
 open bounded_continuous_function
 open sum (inl inr)
-set_option class.instance_max_depth 50
 
 local attribute [instance] metric_space_sum
 


### PR DESCRIPTION
With current Lean, all the manual increases of the maximum instance depth have become unnecessary. This PR removes them all.