### PR TITLE
[Merged by Bors] - feat(*): define `equiv.reflection` and `isometry.reflection`

### DIFF
--- a/src/algebra/group_power.lean
+++ b/src/algebra/group_power.lean
@@ -83,7 +83,7 @@ by rw [succ_smul, smul_add_comm']
 
 theorem pow_two (a : M) : a^2 = a * a :=
 show a*(a*1)=a*a, by rw mul_one
-theorem two_smul (a : A) : 2•a = a + a :=
+theorem two_smul' (a : A) : 2•a = a + a :=
 show a+(a+0)=a+a, by rw add_zero
 
 theorem pow_add (a : M) (m n : ℕ) : a^(m + n) = a^m * a^n :=

--- a/src/algebra/midpoint.lean
+++ b/src/algebra/midpoint.lean
@@ -9,19 +9,26 @@ import algebra.invertible
 /-!
 # Midpoint of a segment
 
-Given two points `x` and `y` in a vector space over a ring `R` with invertible `2`,
-we define `midpoint R x y` to be `(⅟2:R) • (x + y)`, where `(⅟2:R)` is the inverse of `(2:R)`
-provided by `[invertible (2:R)]`.
+## Main definitions
 
-We prove that `z` is the midpoint of `[x, y]` if and only if `x + y = z + z`, hence `midpoint R x y`
-does not depend on `R`. We also prove that `midpoint x y` is linear both in `x` and `y`.
+* `midpoint R x y`: midpoint of the segment `[x, y]`. We define it for `x` and `y`
+  in a module over a ring `R` with invertible `2`.
+* `add_monoid_hom.of_map_midpoint`: construct an `add_monoid_hom` given a map `f` such that
+  `f` sends zero to zero and midpoints to midpoints.
 
-We do not mark lemmas other than `midpoint_self` as `@[simp]` because it is hard to tell which side
-is simpler.
+## Main theorems
+
+* `midpoint_eq_iff`: `z` is the midpoint of `[x, y]` if and only if `x + y = z + z`,
+* `midpoint_unique`: `midpoint R x y` does not depend on `R`;
+* `midpoint x y` is linear both in `x` and `y`;
+* `reflection_midpoint_left`, `reflection_midpoint_right`: `equiv.reflection (midpoint R x y)`
+  swaps `x` and `y`.
+
+We do not mark most lemmas as `@[simp]` because it is hard to tell which side is simpler.
 
 ## Tags
 
-midpoint
+midpoint, add_monoid_hom
 -/
 
 variables (R : Type*) {E : Type*}
@@ -36,11 +43,10 @@ def midpoint (x y : E) : E := (⅟2:R) • (x + y)
 lemma midpoint_eq_iff {x y z : E} : midpoint R x y = z ↔ x + y = z + z :=
 ⟨λ h, h ▸ calc x + y = (2 * ⅟2:R) • (x + y) : by rw [mul_inv_of_self, one_smul]
  ... = midpoint R x y + midpoint R x y : by rw [two_mul, add_smul, midpoint],
- λ h, by rw [midpoint, h, ← one_smul R z, ← add_smul, smul_smul, ← bit0, inv_of_mul_self]⟩
+ λ h, by rw [midpoint, h, ← two_smul R z, smul_smul, inv_of_mul_self, one_smul]⟩
 
-variable {R}
-
-lemma midpoint_def (x y : E) : midpoint R x y = (⅟2:R) • (x + y) := rfl
+@[simp] lemma midpoint_add_self (x y : E) : midpoint R x y + midpoint R x y = x + y :=
+((midpoint_eq_iff R).1 rfl).symm
 
 /-- `midpoint` does not depend on the ring `R`. -/
 lemma midpoint_unique (R' : Type*) [semiring R'] [invertible (2:R')] [semimodule R' E] (x y : E) :
@@ -48,10 +54,17 @@ lemma midpoint_unique (R' : Type*) [semiring R'] [invertible (2:R')] [semimodule
 (midpoint_eq_iff R).2 $ (midpoint_eq_iff R').1 rfl
 
 @[simp] lemma midpoint_self (x : E) : midpoint R x x = x :=
-by rw [midpoint_def, smul_add, ← add_smul, ← mul_two, inv_of_mul_self, one_smul]
+by rw [midpoint, smul_add, ← two_smul R, smul_smul, mul_inv_of_self, one_smul]
+
+variable {R}
+
+lemma midpoint_def (x y : E) : midpoint R x y = (⅟2:R) • (x + y) := rfl
 
 lemma midpoint_comm (x y : E) : midpoint R x y = midpoint R y x :=
 by simp only [midpoint_def, add_comm]
+
+lemma midpoint_zero_add (x y : E) : midpoint R 0 (x + y) = midpoint R x y :=
+(midpoint_eq_iff R).2 $ (zero_add (x + y)).symm ▸ (midpoint_eq_iff R).1 rfl
 
 lemma midpoint_add_add (x y x' y' : E) :
   midpoint R (x + x') (y + y') = midpoint R x y + midpoint R x' y' :=
@@ -68,6 +81,8 @@ lemma midpoint_smul_smul (c : R) (x y : E) : midpoint R (c • x) (c • y) = c 
 
 end monoid
 
+section group
+
 variables [ring R] [invertible (2:R)] [add_comm_group E] [module R E]
 
 lemma midpoint_neg_neg (x y : E) : midpoint R (-x) (-y) = -midpoint R x y :=
@@ -82,3 +97,42 @@ by rw [midpoint_sub_sub, midpoint_self]
 
 lemma midpoint_sub_left (x y z : E) : midpoint R (x - y) (x - z) = x - midpoint R y z :=
 by rw [midpoint_sub_sub, midpoint_self]
+
+end group
+
+namespace add_monoid_hom
+
+variables (R) (R' : Type*) {F : Type*}
+  [semiring R] [invertible (2:R)] [add_comm_monoid E] [semimodule R E]
+  [semiring R'] [invertible (2:R')] [add_comm_monoid F] [semimodule R' F]
+
+/-- A map `f : E → F` sending zero to zero and midpoints to midpoints is an `add_monoid_hom`. -/
+def of_map_midpoint (f : E → F) (h0 : f 0 = 0)
+  (hm : ∀ x y, f (midpoint R x y) = midpoint R' (f x) (f y)) :
+  E →+ F :=
+{ to_fun := f,
+  map_zero' := h0,
+  map_add' := λ x y, -- by rw [← midpoint_self R (x + y), ← midpoint_zero_add, hm, h0]
+    calc f (x + y) = f 0 + f (x + y) : by rw [h0, zero_add]
+    ... = midpoint R' (f 0) (f (x + y)) + midpoint R' (f 0) (f (x + y)) :
+      (midpoint_add_self _ _ _).symm
+    ... = f (midpoint R x y) + f (midpoint R x y) : by rw [← hm, midpoint_zero_add]
+    ... = f x + f y : by rw [hm, midpoint_add_self] }
+
+@[simp] lemma coe_of_map_midpoint (f : E → F) (h0 : f 0 = 0)
+  (hm : ∀ x y, f (midpoint R x y) = midpoint R' (f x) (f y)) :
+  ⇑(of_map_midpoint R R' f h0 hm) = f := rfl
+
+end add_monoid_hom
+
+namespace equiv
+
+variables [ring R] [invertible (2:R)] [add_comm_group E] [module R E]
+
+@[simp] lemma reflection_midpoint_left (x y : E) : (reflection (midpoint R x y) : E → E) x = y :=
+by rw [reflection_apply, midpoint_add_self, add_sub_cancel']
+
+@[simp] lemma reflection_midpoint_right (x y : E) : (reflection (midpoint R x y) : E → E) y = x :=
+by rw [reflection_apply, midpoint_add_self, add_sub_cancel]
+
+end equiv

--- a/src/algebra/module.lean
+++ b/src/algebra/module.lean
@@ -71,6 +71,8 @@ theorem add_smul : (r + s) • x = r • x + s • x := semimodule.add_smul r s 
 variables (R)
 @[simp] theorem zero_smul : (0 : R) • x = 0 := semimodule.zero_smul x
 
+theorem two_smul : (2 : R) • x = x + x := by rw [bit0, add_smul, one_smul]
+
 variable (M)
 
 /-- `(•)` as an `add_monoid_hom`. -/

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -633,6 +633,8 @@ hf.div hg hnz
 
 lemma real.norm_eq_abs (r : ℝ) : norm r = abs r := rfl
 
+@[simp] lemma real.norm_two : ∥(2:ℝ)∥ = 2 := abs_of_pos (@two_pos ℝ _)
+
 @[simp] lemma norm_norm [normed_group α] (x : α) : ∥∥x∥∥ = ∥x∥ :=
 by rw [real.norm_eq_abs, abs_of_nonneg (norm_nonneg _)]
 

--- a/src/analysis/normed_space/reflection.lean
+++ b/src/analysis/normed_space/reflection.lean
@@ -21,7 +21,14 @@ add a few results about `dist`.
 reflection, isometric
 -/
 
-variables {R : Type*} {E : Type*}
+variables (R : Type*) {E : Type*}
+
+lemma equiv.reflection_fixed_iff_of_module [ring R] [invertible (2:R)]
+  [add_comm_group E] [module R E] {x y : E} :
+  (equiv.reflection x : E → E) y = y ↔ y = x :=
+equiv.reflection_fixed_iff_of_bit0_inj $ λ x y h,
+by rw [← one_smul R x, ← one_smul R y, ← inv_of_mul_self (2:R), mul_smul, mul_smul, two_smul,
+  two_smul, ← bit0, ← bit0, h]
 
 namespace isometric
 
@@ -70,9 +77,7 @@ variable (R)
 include R
 
 lemma reflection_fixed_iff {x y : E} : (reflection x : E → E) y = y ↔ y = x :=
-equiv.reflection_fixed_iff $ λ x y h,
-by rw [← one_smul R x, ← one_smul R y, ← inv_of_mul_self (2:R), mul_smul, mul_smul, two_smul,
-  two_smul, ← bit0, ← bit0, h]
+equiv.reflection_fixed_iff_of_module R
 
 end module
 
@@ -85,5 +90,9 @@ lemma reflection_dist_self (x y : E) :
 by simp only [reflection_dist_self', ← two_smul R x, ← two_smul R y, dist_smul]
 
 end normed_space
+
+lemma reflection_dist_self_real [normed_group E] [normed_space ℝ E] (x y : E) :
+  dist ((reflection x : E → E) y) y = 2 * dist x y :=
+by simp [reflection_dist_self ℝ x y, real.norm_two]
 
 end isometric

--- a/src/analysis/normed_space/reflection.lean
+++ b/src/analysis/normed_space/reflection.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2020 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Yury Kudryashov
+-/
+import algebra.midpoint
+import topology.metric_space.isometry
+
+/-!
+# Reflection in a point as an `isometric` homeomorphism
+
+Given a `normed_group E` and `x : E`, we define `isometric.reflection x` to be
+the reflection in `x` interpreted as an `isometric` homeomorphism.
+
+Reflection is defined as an `equiv.perm` in `data.equiv.mul_add`. In this file
+we restate results about `equiv.reflection` for an `isometric.reflection`, and
+add a few results about `dist`.
+
+## Tags
+
+reflection, isometric
+-/
+
+variables {R : Type*} {E : Type*}
+
+namespace isometric
+
+section normed_group
+
+variables [normed_group E]
+
+/-- Reflection in `x` as an `isometric` homeomorphism. -/
+def reflection (x : E) : E ≃ᵢ E :=
+(isometric.neg E).trans (isometric.add_left (x + x))
+
+lemma reflection_apply (x y : E) : (reflection x : E → E) y = x + x - y := rfl
+
+@[simp] lemma reflection_to_equiv (x : E) : (reflection x).to_equiv = equiv.reflection x := rfl
+
+@[simp] lemma reflection_self (x : E) : (reflection x : E → E) x = x := add_sub_cancel _ _
+
+lemma reflection_involutive (x : E) : function.involutive (reflection x : E → E) :=
+equiv.reflection_involutive x
+
+@[simp] lemma reflection_symm (x : E) : (reflection x).symm = reflection x :=
+to_equiv_inj $ equiv.reflection_symm x
+
+@[simp] lemma reflection_dist_fixed (x y : E) :
+  dist ((reflection x : E → E) y) x = dist y x :=
+by rw [← (reflection x).dist_eq y x, reflection_self]
+
+lemma reflection_dist_self' (x y : E) :
+  dist ((reflection x : E → E) y) y = dist (x + x) (y + y) :=
+by { simp only [reflection_apply, dist_eq_norm], congr' 1, abel }
+
+end normed_group
+
+section module
+
+variables [ring R] [invertible (2:R)] [normed_group E] [module R E]
+
+@[simp] lemma reflection_midpoint_left (x y : E) : (reflection (midpoint R x y) : E → E) x = y :=
+equiv.reflection_midpoint_left R x y
+
+@[simp] lemma reflection_midpoint_right (x y : E) : (reflection (midpoint R x y) : E → E) y = x :=
+equiv.reflection_midpoint_right R x y
+
+end module
+
+section normed_space
+
+variables [normed_group E] [normed_space ℝ E]
+
+lemma reflection_dist_self (x y : E) :
+  dist ((reflection x : E → E) y) y = 2 * dist x y :=
+by simp only [reflection_dist_self', ← two_smul ℝ x, ← two_smul ℝ y, dist_smul, real.norm_eq_abs,
+  abs_of_pos (@two_pos ℝ _)]
+
+lemma reflection_fixed_iff {x y : E} : (reflection x : E → E) y = y ↔ y = x :=
+by { rw [← dist_eq_zero, reflection_dist_self, mul_eq_zero, dist_eq_zero],
+  simp only [two_ne_zero, false_or], exact eq_comm }
+
+end normed_space
+
+end isometric

--- a/src/analysis/normed_space/reflection.lean
+++ b/src/analysis/normed_space/reflection.lean
@@ -65,20 +65,24 @@ equiv.reflection_midpoint_left R x y
 @[simp] lemma reflection_midpoint_right (x y : E) : (reflection (midpoint R x y) : E → E) y = x :=
 equiv.reflection_midpoint_right R x y
 
+variable (R)
+
+include R
+
+lemma reflection_fixed_iff {x y : E} : (reflection x : E → E) y = y ↔ y = x :=
+equiv.reflection_fixed_iff $ λ x y h,
+by rw [← one_smul R x, ← one_smul R y, ← inv_of_mul_self (2:R), mul_smul, mul_smul, two_smul,
+  two_smul, ← bit0, ← bit0, h]
+
 end module
 
 section normed_space
 
-variables [normed_group E] [normed_space ℝ E]
+variables (R) [normed_field R] [normed_group E] [normed_space R E]
 
 lemma reflection_dist_self (x y : E) :
-  dist ((reflection x : E → E) y) y = 2 * dist x y :=
-by simp only [reflection_dist_self', ← two_smul ℝ x, ← two_smul ℝ y, dist_smul, real.norm_eq_abs,
-  abs_of_pos (@two_pos ℝ _)]
-
-lemma reflection_fixed_iff {x y : E} : (reflection x : E → E) y = y ↔ y = x :=
-by { rw [← dist_eq_zero, reflection_dist_self, mul_eq_zero, dist_eq_zero],
-  simp only [two_ne_zero, false_or], exact eq_comm }
+  dist ((reflection x : E → E) y) y = ∥(2:R)∥ * dist x y :=
+by simp only [reflection_dist_self', ← two_smul R x, ← two_smul R y, dist_smul]
 
 end normed_space
 

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -297,7 +297,7 @@ by { ext y, rw [symm_apply_eq, reflection_involutive x y] }
 
 /-- `x` is the only fixed point of `reflection x`. This lemma requires `x + x = y + y ↔ x = y`.
 There is no typeclass to use here, so we add it as an explicit argument. -/
-lemma reflection_fixed_iff {x y : A} (h: function.injective (bit0 : A → A)) :
+lemma reflection_fixed_iff {x y : A} (h : function.injective (bit0 : A → A)) :
   reflection x y = y ↔ y = x :=
 sub_eq_iff_eq_add.trans $ h.eq_iff.trans eq_comm
 

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -277,4 +277,30 @@ protected def inv : perm G :=
 
 end group
 
+section reflection
+
+variables [add_comm_group A] (x y : A)
+
+/-- Reflection in `x` as a permutation. -/
+def reflection (x : A) : perm A :=
+(equiv.neg A).trans (equiv.add_left (x + x))
+
+lemma reflection_apply : reflection x y = x + x - y := rfl
+
+@[simp] lemma reflection_self : reflection x x = x := add_sub_cancel _ _
+
+lemma reflection_involutive : function.involutive (reflection x : A → A) :=
+λ y, by simp only [reflection_apply, sub_sub_cancel]
+
+@[simp] lemma reflection_symm : (reflection x).symm = reflection x :=
+by { ext y, rw [symm_apply_eq, reflection_involutive x y] }
+
+/-- `x` is the only fixed point of `reflection x`. This lemma requires `x + x = y + y ↔ x = y`.
+There is no typeclass to use here, so we add it as an explicit argument. -/
+lemma reflection_fixed_iff {x y : A} (h: function.injective (bit0 : A → A)) :
+  reflection x y = y ↔ y = x :=
+sub_eq_iff_eq_add.trans $ h.eq_iff.trans eq_comm
+
+end reflection
+
 end equiv

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -297,7 +297,7 @@ by { ext y, rw [symm_apply_eq, reflection_involutive x y] }
 
 /-- `x` is the only fixed point of `reflection x`. This lemma requires `x + x = y + y ↔ x = y`.
 There is no typeclass to use here, so we add it as an explicit argument. -/
-lemma reflection_fixed_iff {x y : A} (h : function.injective (bit0 : A → A)) :
+lemma reflection_fixed_iff_of_bit0_inj {x y : A} (h : function.injective (bit0 : A → A)) :
   reflection x y = y ↔ y = x :=
 sub_eq_iff_eq_add.trans $ h.eq_iff.trans eq_comm
 

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -276,10 +276,10 @@ begin
       repeat {split},
       { exact λx y, calc
         F (inl x, inl y) = dist (Φ x) (Φ y) : rfl
-        ... = dist x y : Φisom.dist_eq },
+        ... = dist x y : Φisom.dist_eq x y },
       { exact λx y, calc
         F (inr x, inr y) = dist (Ψ x) (Ψ y) : rfl
-        ... = dist x y : Ψisom.dist_eq },
+        ... = dist x y : Ψisom.dist_eq x y },
       { exact λx y, dist_comm _ _ },
       { exact λx y z, dist_triangle _ _ _ },
       { exact λx y, calc

--- a/src/topology/metric_space/isometry.lean
+++ b/src/topology/metric_space/isometry.lean
@@ -34,12 +34,13 @@ lemma isometry_emetric_iff_metric [metric_space α] [metric_space β] {f : α �
 assume H x y, by simp [edist_dist, H x y]⟩
 
 /-- An isometry preserves edistances. -/
-theorem isometry.edist_eq [emetric_space α] [emetric_space β] {f : α → β} {x y : α} (hf : isometry f) :
+theorem isometry.edist_eq [emetric_space α] [emetric_space β] {f : α → β} (hf : isometry f)
+  (x y : α) :
   edist (f x) (f y) = edist x y :=
 hf x y
 
 /-- An isometry preserves distances. -/
-theorem isometry.dist_eq [metric_space α] [metric_space β] {f : α → β} {x y : α} (hf : isometry f) :
+theorem isometry.dist_eq [metric_space α] [metric_space β] {f : α → β} (hf : isometry f) (x y : α) :
   dist (f x) (f y) = dist x y :=
 by rw [dist_edist, dist_edist, hf]
 
@@ -79,9 +80,10 @@ hf.antilipschitz.uniform_embedding hf.lipschitz.uniform_continuous
 lemma isometry.continuous (hf : isometry f) : continuous f :=
 hf.lipschitz.continuous
 
-/-- The inverse of an isometry is an isometry. -/
-lemma isometry.inv (e : α ≃ β) (h : isometry e.to_fun) : isometry e.inv_fun :=
-λx y, by rw [← h, e.right_inv _, e.right_inv _]
+/-- The right inverse of an isometry is an isometry. -/
+lemma isometry.right_inv {f : α → β} {g : β → α} (h : isometry f) (hg : right_inverse g f) :
+  isometry g :=
+λ x y, by rw [← h, hg _, hg _]
 
 /-- Isometries preserve the diameter in emetric spaces. -/
 lemma isometry.ediam_image (hf : isometry f) (s : set α) :
@@ -122,11 +124,22 @@ instance : has_coe_to_fun (α ≃ᵢ β) := ⟨λ_, α → β, λe, e.to_equiv�
 
 lemma coe_eq_to_equiv (h : α ≃ᵢ β) (a : α) : h a = h.to_equiv a := rfl
 
-lemma isometry_inv_fun (h : α ≃ᵢ β) : isometry h.to_equiv.symm :=
-h.isometry_to_fun.inv h.to_equiv
+protected lemma isometry (h : α ≃ᵢ β) : isometry h := h.isometry_to_fun
 
-@[ext] lemma ext : ∀ ⦃h₁ h₂ : α ≃ᵢ β⦄, (∀ x, h₁ x = h₂ x) → h₁ = h₂
-| ⟨e₁, h₁⟩ ⟨e₂, h₂⟩ H := have e₁ = e₂ := equiv.ext _ _ H, by subst e₁
+protected lemma edist_eq (h : α ≃ᵢ β) (x y : α) : edist (h x) (h y) = edist x y :=
+h.isometry.edist_eq x y
+
+protected lemma dist_eq {α β : Type*} [metric_space α] [metric_space β] (h : α ≃ᵢ β) (x y : α) :
+  dist (h x) (h y) = dist x y :=
+h.isometry.dist_eq x y
+
+protected lemma continuous (h : α ≃ᵢ β) : continuous h := h.isometry.continuous
+
+lemma to_equiv_inj : ∀ ⦃h₁ h₂ : α ≃ᵢ β⦄, (h₁.to_equiv = h₂.to_equiv) → h₁ = h₂
+| ⟨e₁, h₁⟩ ⟨e₂, h₂⟩ H := by { dsimp at H, subst e₁ }
+
+@[ext] lemma ext ⦃h₁ h₂ : α ≃ᵢ β⦄ (H : ∀ x, h₁ x = h₂ x) : h₁ = h₂ :=
+to_equiv_inj $ equiv.ext _ _ H
 
 /-- Alternative constructor for isometric bijections,
 taking as input an isometry, and a right inverse. -/
@@ -160,19 +173,6 @@ protected def neg : G ≃ᵢ G :=
 
 end normed_group
 
-/-- The (bundled) homeomorphism associated to an isometric isomorphism. -/
-protected def to_homeomorph (h : α ≃ᵢ β) : α ≃ₜ β :=
-{ continuous_to_fun  := (isometry_to_fun h).continuous,
-  continuous_inv_fun := (isometry_inv_fun h).continuous,
-  .. h.to_equiv }
-
-lemma coe_eq_to_homeomorph (h : α ≃ᵢ β) (a : α) :
-  h a = h.to_homeomorph a := rfl
-
-lemma to_homeomorph_to_equiv (h : α ≃ᵢ β) :
-  h.to_homeomorph.to_equiv = h.to_equiv :=
-by ext; refl
-
 /-- The identity isometry of a space. -/
 protected def refl (α : Type*) [emetric_space α] : α ≃ᵢ α :=
 { isometry_to_fun := isometry_id, .. equiv.refl α }
@@ -186,12 +186,8 @@ protected def trans (h₁ : α ≃ᵢ β) (h₂ : β ≃ᵢ γ) : α ≃ᵢ γ :
 
 /-- The inverse of an isometric isomorphism, as an isometric isomorphism. -/
 protected def symm (h : α ≃ᵢ β) : β ≃ᵢ α :=
-{ isometry_to_fun  := h.isometry_inv_fun,
+{ isometry_to_fun  := h.isometry.right_inv h.right_inv,
   .. h.to_equiv.symm }
-
-protected lemma isometry (h : α ≃ᵢ β) : isometry h := h.isometry_to_fun
-
-protected lemma continuous (h : α ≃ᵢ β) : continuous h := h.isometry.continuous
 
 @[simp] lemma apply_symm_apply (h : α ≃ᵢ β) (y : β) : h (h.symm y) = y :=
 h.to_equiv.apply_symm_apply y
@@ -222,27 +218,30 @@ image_eq_preimage_of_inverse h.symm.to_equiv.left_inv h.symm.to_equiv.right_inv
 lemma preimage_symm (h : α ≃ᵢ β) : preimage h.symm = image h :=
 (image_eq_preimage_of_inverse h.to_equiv.left_inv h.to_equiv.right_inv).symm
 
+/-- The (bundled) homeomorphism associated to an isometric isomorphism. -/
+protected def to_homeomorph (h : α ≃ᵢ β) : α ≃ₜ β :=
+{ continuous_to_fun  := h.continuous,
+  continuous_inv_fun := h.symm.continuous,
+  .. h }
+
+@[simp] lemma coe_to_homeomorph (h : α ≃ᵢ β) : ⇑(h.to_homeomorph) = h := rfl
+
+@[simp] lemma to_homeomorph_to_equiv (h : α ≃ᵢ β) :
+  h.to_homeomorph.to_equiv = h.to_equiv :=
+rfl
+
 end isometric
 
 /-- An isometry induces an isometric isomorphism between the source space and the
 range of the isometry. -/
 def isometry.isometric_on_range [emetric_space α] [emetric_space β] {f : α → β} (h : isometry f) :
   α ≃ᵢ range f :=
-{ isometry_to_fun := λx y,
-  begin
-    change edist ((equiv.set.range f _) x) ((equiv.set.range f _) y) = edist x y,
-    rw [equiv.set.range_apply f h.injective, equiv.set.range_apply f h.injective],
-    exact h x y
-  end,
+{ isometry_to_fun := λx y, by simpa [subtype.edist_eq] using h x y,
   .. equiv.set.range f h.injective }
 
-lemma isometry.isometric_on_range_apply [emetric_space α] [emetric_space β]
+@[simp] lemma isometry.isometric_on_range_apply [emetric_space α] [emetric_space β]
   {f : α → β} (h : isometry f) (x : α) : h.isometric_on_range x = ⟨f x, mem_range_self _⟩ :=
-begin
-  dunfold isometry.isometric_on_range,
-  rw ← equiv.set.range_apply f h.injective x,
-  refl
-end
+rfl
 
 /-- In a normed algebra, the inclusion of the base field in the extended field is an isometry. -/
 lemma algebra_map_isometry (𝕜 : Type*) (𝕜' : Type*) [normed_field 𝕜] [normed_ring 𝕜']


### PR DESCRIPTION
Define reflection in a point and prove basic properties.
It is defined both as an `equiv.perm` of an `add_comm_group` and
as an `isometric` of a `normed_group`.

Other changes:

* rename `two_smul` to `two_smul'`, add `two_smul` using `semimodule`
  instead of `add_monoid.smul`;
* minor review of `algebra.midpoint`;
* arguments of `isometry.dist_eq` and `isometry.edist_eq` are now explicit;
* rename `isometry.inv` to `isometry.right_inv`; now it takes `right_inverse`
  instead of `equiv`;
* drop `isometry_inv_fun`: use `h.symm.isometry` instead;
* pull a few more lemmas about `equiv` and `isometry` to the `isometric` namespace.