### PR TITLE
[Merged by Bors] - chore(data/set/countable): use dot syntax here and there

### DIFF
--- a/src/data/set/countable.lean
+++ b/src/data/set/countable.lean
@@ -99,7 +99,7 @@ end
 ⟨of_equiv _ (equiv.set.singleton a)⟩
 
 lemma countable.mono {s₁ s₂ : set α} (h : s₁ ⊆ s₂) : countable s₂ → countable s₁
-| ⟨H⟩ := ⟨@of_inj _ _ H _ (embedding_of_subset _ _ h).2⟩
+| ⟨H⟩ := ⟨@of_inj _ _ H _ (embedding_of_subset h).2⟩
 
 lemma countable.image {s : set α} (hs : countable s) (f : α → β) : countable (f '' s) :=
 let f' : s → f '' s := λ⟨a, ha⟩, ⟨f a, mem_image_of_mem f ha⟩ in

--- a/src/data/set/countable.lean
+++ b/src/data/set/countable.lean
@@ -210,5 +210,5 @@ end enumerate
 
 end set
 
-lemma finset.countable_to_set (s : finset α) : set.countable s.to_set :=
+lemma finset.countable_to_set (s : finset α) : set.countable (↑s : set α) :=
 s.finite_to_set.countable

--- a/src/data/set/countable.lean
+++ b/src/data/set/countable.lean
@@ -153,10 +153,12 @@ begin
   refine countable.mono _ (countable_range
     (λ t : finset s, {a | ∃ h:a ∈ s, subtype.mk a h ∈ t})),
   rintro t ⟨⟨ht⟩, ts⟩,
-  refine ⟨finset.univ.map (embedding_of_subset _ _ ts),
+  refine ⟨finset.univ.map (embedding_of_subset ts),
     set.ext $ λ a, _⟩,
-  suffices : a ∈ s ∧ a ∈ t ↔ a ∈ t, by simpa,
-  exact ⟨and.right, λ h, ⟨ts h, h⟩⟩
+  simp, split,
+  { rintro ⟨as, b, bt, e⟩,
+    cases congr_arg subtype.val e, exact bt },
+  { exact λ h, ⟨ts h, _, h, rfl⟩ }
 end
 
 lemma countable_pi {π : α → Type*} [fintype α] {s : Πa, set (π a)} (hs : ∀a, countable (s a)) :

--- a/src/data/set/countable.lean
+++ b/src/data/set/countable.lean
@@ -2,11 +2,13 @@
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Johannes Hölzl
-
-Countable sets.
 -/
 import data.equiv.list
 import data.set.finite
+
+/-!
+# Countable sets
+-/
 noncomputable theory
 
 open function set encodable
@@ -18,9 +20,7 @@ variables {α : Type u} {β : Type v} {γ : Type w}
 
 namespace set
 
-/-- Countable sets
-
-A set is countable if there exists an encoding of the set into the natural numbers.
+/-- A set is countable if there exists an encoding of the set into the natural numbers.
 An encoding is an injection with a partial inverse, which can be viewed as a
 constructive analogue of countability. (For the most part, theorems about
 `countable` will be classical and `encodable` will be constructive.)
@@ -66,6 +66,7 @@ have (∃ f : ℕ → s, surjective f) → countable s, from assume ⟨f, fsurj�
     by intro h; simp [(inv_fun_eq (fsurj h) : f (inv_fun f h) = h)]⟩⟩,
 by split; assumption
 
+/-- Convert `countable s` to `encodable s` (noncomputable). -/
 def countable.to_encodable {s : set α} : countable s → encodable s :=
 classical.choice
 
@@ -75,7 +76,9 @@ lemma countable_encodable' (s : set α) [H : encodable s] : countable s :=
 lemma countable_encodable [encodable α] (s : set α) : countable s :=
 ⟨by apply_instance⟩
 
-lemma exists_surjective_of_countable {s : set α} (hs : s.nonempty) (hc : countable s) :
+/-- If `s : set α` is a nonempty countable set, then there exists a map
+`f : ℕ → α` such that `s = range f`. -/
+lemma countable.exists_surjective {s : set α} (hc : countable s) (hs : s.nonempty) :
   ∃f:ℕ → α, s = range f :=
 begin
   rcases hs with ⟨x, hx⟩,
@@ -95,16 +98,16 @@ end
 @[simp] lemma countable_singleton (a : α) : countable ({a} : set α) :=
 ⟨of_equiv _ (equiv.set.singleton a)⟩
 
-lemma countable_subset {s₁ s₂ : set α} (h : s₁ ⊆ s₂) : countable s₂ → countable s₁
-| ⟨H⟩ := ⟨@of_inj _ _ H _ (embedding_of_subset h).2⟩
+lemma countable.mono {s₁ s₂ : set α} (h : s₁ ⊆ s₂) : countable s₂ → countable s₁
+| ⟨H⟩ := ⟨@of_inj _ _ H _ (embedding_of_subset _ _ h).2⟩
 
-lemma countable_image {s : set α} (f : α → β) (hs : countable s) : countable (f '' s) :=
+lemma countable.image {s : set α} (hs : countable s) (f : α → β) : countable (f '' s) :=
 let f' : s → f '' s := λ⟨a, ha⟩, ⟨f a, mem_image_of_mem f ha⟩ in
 have hf' : surjective f', from assume ⟨b, a, ha, hab⟩, ⟨⟨a, ha⟩, subtype.eq hab⟩,
 ⟨@encodable.of_inj _ _ hs.to_encodable (surj_inv hf') (injective_surj_inv hf')⟩
 
 lemma countable_range [encodable α] (f : α → β) : countable (range f) :=
-by rw ← image_univ; exact countable_image _ (countable_encodable _)
+by rw ← image_univ; exact (countable_encodable _).image _
 
 lemma countable_of_injective_of_countable_image {s : set α} {f : α → β}
   (hf : inj_on f s) (hs : countable (f '' s)) : countable s :=
@@ -116,7 +119,7 @@ lemma countable_Union {t : α → set β} [encodable α] (ht : ∀a, countable (
 by haveI := (λ a, (ht a).to_encodable);
    rw Union_eq_range_sigma; apply countable_range
 
-lemma countable_bUnion {s : set α} {t : α → set β} (hs : countable s) (ht : ∀a∈s, countable (t a)) :
+lemma countable.bUnion {s : set α} {t : α → set β} (hs : countable s) (ht : ∀a∈s, countable (t a)) :
   countable (⋃a∈s, t a) :=
 begin
   rw bUnion_eq_Union,
@@ -124,42 +127,41 @@ begin
   exact countable_Union (by simpa using ht)
 end
 
-lemma countable_sUnion {s : set (set α)} (hs : countable s) (h : ∀a∈s, countable a) :
+lemma countable.sUnion {s : set (set α)} (hs : countable s) (h : ∀a∈s, countable a) :
   countable (⋃₀ s) :=
-by rw sUnion_eq_bUnion; exact countable_bUnion hs h
+by rw sUnion_eq_bUnion; exact hs.bUnion h
 
 lemma countable_Union_Prop {p : Prop} {t : p → set β} (ht : ∀h:p, countable (t h)) :
   countable (⋃h:p, t h) :=
 by by_cases p; simp [h, ht]
 
-lemma countable_union {s₁ s₂ : set α} (h₁ : countable s₁) (h₂ : countable s₂) : countable (s₁ ∪ s₂) :=
+lemma countable.union {s₁ s₂ : set α} (h₁ : countable s₁) (h₂ : countable s₂) : countable (s₁ ∪ s₂) :=
 by rw union_eq_Union; exact
 countable_Union (bool.forall_bool.2 ⟨h₂, h₁⟩)
 
-lemma countable_insert {s : set α} {a : α} (h : countable s) : countable (insert a s) :=
-by rw [set.insert_eq]; from countable_union (countable_singleton _) h
+lemma countable.insert {s : set α} (a : α) (h : countable s) : countable (insert a s) :=
+by { rw [set.insert_eq], exact (countable_singleton _).union h }
 
-lemma countable_finite {s : set α} : finite s → countable s
+lemma finite.countable {s : set α} : finite s → countable s
 | ⟨h⟩ := nonempty_of_trunc (by exactI trunc_encodable_of_fintype s)
 
+/-- The set of finite subsets of a countable set is countable. -/
 lemma countable_set_of_finite_subset {s : set α} : countable s →
   countable {t | finite t ∧ t ⊆ s} | ⟨h⟩ :=
 begin
   resetI,
-  refine countable_subset _ (countable_range
+  refine countable.mono _ (countable_range
     (λ t : finset s, {a | ∃ h:a ∈ s, subtype.mk a h ∈ t})),
   rintro t ⟨⟨ht⟩, ts⟩,
-  refine ⟨finset.univ.map (embedding_of_subset ts),
+  refine ⟨finset.univ.map (embedding_of_subset _ _ ts),
     set.ext $ λ a, _⟩,
-  simp, split,
-  { rintro ⟨as, b, bt, e⟩,
-    cases congr_arg subtype.val e, exact bt },
-  { exact λ h, ⟨ts h, _, h, rfl⟩ }
+  suffices : a ∈ s ∧ a ∈ t ↔ a ∈ t, by simpa,
+  exact ⟨and.right, λ h, ⟨ts h, h⟩⟩
 end
 
 lemma countable_pi {π : α → Type*} [fintype α] {s : Πa, set (π a)} (hs : ∀a, countable (s a)) :
   countable {f : Πa, π a | ∀a, f a ∈ s a} :=
-countable_subset
+countable.mono
   (show {f : Πa, π a | ∀a, f a ∈ s a} ⊆ range (λf : Πa, s a, λa, (f a).1), from
     assume f hf, ⟨λa, ⟨f a, hf a⟩, funext $ assume a, rfl⟩) $
 have trunc (encodable (Π (a : α), s a)), from
@@ -205,3 +207,6 @@ by simp [enumerate_countable, encodable.encodek]⟩
 end enumerate
 
 end set
+
+lemma finset.countable_to_set (s : finset α) : set.countable s.to_set :=
+s.finite_to_set.countable

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -58,7 +58,7 @@ instance [inhabited β] : inhabited (α →ₛ β) := ⟨const _ (default _)⟩
 
 @[simp] theorem const_apply (a : α) (b : β) : (const α b) a = b := rfl
 
-lemma range_const (α) [measurable_space α] [ne : nonempty α] (b : β) :
+lemma range_const (α) [measurable_space α] [nonempty α] (b : β) :
   (const α b).range = {b} :=
 begin
   ext b',
@@ -70,7 +70,7 @@ lemma is_measurable_cut (p : α → β → Prop) (f : α →ₛ β)
   (h : ∀b, is_measurable {a | p a b}) : is_measurable {a | p a (f a)} :=
 begin
   rw (_ : {a | p a (f a)} = ⋃ b ∈ set.range f, {a | p a b} ∩ f ⁻¹' {b}),
-  { exact is_measurable.bUnion (countable_finite f.finite)
+  { exact is_measurable.bUnion f.finite.countable
       (λ b _, is_measurable.inter (h b) (f.measurable_sn _)) },
   ext a, simp,
   exact ⟨λ h, ⟨a, ⟨h, rfl⟩⟩, λ ⟨a', ⟨h', e⟩⟩, e.symm ▸ h'⟩

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -852,7 +852,7 @@ lemma volume_bUnion_finset {β} {s : finset β} {f : β → set α}
   volume (⋃b∈s, f b) = s.sum (λp, volume (f p)) :=
 show volume (⋃b∈(↑s : set β), f b) = s.sum (λp, volume (f p)),
 begin
-  rw [volume_bUnion (countable_finite (finset.finite_to_set s)) hd hm, tsum_eq_sum],
+  rw [volume_bUnion s.countable_to_set hd hm, tsum_eq_sum],
   { show s.attach.sum (λb:(↑s : set β), volume (f b)) = s.sum (λb, volume (f b)),
     exact @finset.sum_attach _ _ s _ (λb, volume (f b)) },
   simp

--- a/src/order/filter/bases.lean
+++ b/src/order/filter/bases.lean
@@ -496,8 +496,9 @@ lemma eq_generate {f : filter α} (h : is_countably_generated f) :
 (classical.some_spec h).2
 
 /-- A countable filter basis for a countably generated filter. -/
-def countable_filter_basis {l : filter α} (h : is_countably_generated l) : countable_filter_basis α :=
-{ countable := countable_image _ (countable_set_of_finite_subset h.countable_generating_set),
+def countable_filter_basis {l : filter α} (h : is_countably_generated l) :
+  countable_filter_basis α :=
+{ countable := (countable_set_of_finite_subset h.countable_generating_set).image _,
   ..filter_basis.of_sets (h.generating_set) }
 
 lemma filter_basis_filter {l : filter α} (h : is_countably_generated l) :

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -127,7 +127,7 @@ let ⟨b, hb, eq⟩ := second_countable_topology.is_open_generated_countable α 
 ⟨begin
    intros,
    rw [eq, nhds_generate_from],
-   exact is_countably_generated_binfi_principal (countable_subset (assume x ⟨_, hx⟩, hx) hb),
+   exact is_countably_generated_binfi_principal (hb.mono (assume x, and.right)),
  end⟩
 
 lemma second_countable_topology_induced (β)
@@ -135,7 +135,7 @@ lemma second_countable_topology_induced (β)
   @second_countable_topology α (t.induced f) :=
 begin
   rcases second_countable_topology.is_open_generated_countable β with ⟨b, hb, eq⟩,
-  refine { is_open_generated_countable := ⟨preimage f '' b, countable_image _ hb, _⟩ },
+  refine { is_open_generated_countable := ⟨preimage f '' b, hb.image _, _⟩ },
   rw [eq, induced_generate_from_eq]
 end
 
@@ -148,9 +148,8 @@ lemma is_open_generated_countable_inter [second_countable_topology α] :
 let ⟨b, hb₁, hb₂⟩ := second_countable_topology.is_open_generated_countable α in
 let b' := (λs, ⋂₀ s) '' {s:set (set α) | finite s ∧ s ⊆ b ∧ (⋂₀ s).nonempty} in
 ⟨b',
-  countable_image _ $ countable_subset
-    (by simp only [(and_assoc _ _).symm]; exact inter_subset_left _ _)
-    (countable_set_of_finite_subset hb₁),
+  ((countable_set_of_finite_subset hb₁).mono
+    (by { simp only [← and_assoc], apply inter_subset_left })).image _,
   assume ⟨s, ⟨_, _, hn⟩, hp⟩, absurd hn (not_nonempty_iff_eq_empty.2 hp),
   is_topological_basis_of_subbasis hb₂⟩
 
@@ -162,7 +161,7 @@ instance {β : Type*} [topological_space β]
   ⟨{g | ∃u∈a, ∃v∈b, g = set.prod u v},
     have {g | ∃u∈a, ∃v∈b, g = set.prod u v} = (⋃u∈a, ⋃v∈b, {set.prod u v}),
       by apply set.ext; simp,
-    by rw [this]; exact (countable_bUnion ha₁ $ assume u hu, countable_bUnion hb₁ $ by simp),
+    by rw [this]; exact (ha₁.bUnion $ assume u hu, hb₁.bUnion $ by simp),
     by rw [ha₅, hb₅, prod_generate_from_generate_from_eq ha₄ hb₄]⟩⟩
 
 instance second_countable_topology_fintype {ι : Type*} {π : ι → Type*}
@@ -174,7 +173,7 @@ let ⟨g, hg⟩ := classical.axiom_of_choice this in
 have t = (λa, generate_from (g a)), from funext $ assume a, (hg a).2.2.2.2,
 begin
   constructor,
-  refine ⟨pi univ '' pi univ g, countable_image _ _, _⟩,
+  refine ⟨pi univ '' pi univ g, countable.image _ _, _⟩,
   { suffices : countable {f : Πa, set (π a) | ∀a, f a ∈ g a}, { simpa [pi] },
     exact countable_pi (assume i, (hg i).1), },
   rw [this, pi_generate_from_eq_fintype],
@@ -193,7 +192,7 @@ have ∀s∈b, set.nonempty s,
 have ∃f:∀s∈b, α, ∀s h, f s h ∈ s, by simpa only [skolem, set.nonempty] using this,
 let ⟨f, hf⟩ := this in
 ⟨⟨(⋃s∈b, ⋃h:s∈b, {f s h}),
-  countable_bUnion hb₁ (λ _ _, countable_Union_Prop $ λ _, countable_singleton _),
+  hb₁.bUnion (λ _ _, countable_Union_Prop $ λ _, countable_singleton _),
   set.ext $ assume a,
   have a ∈ (⋃₀ b), by rw [hb₄]; exact trivial,
   let ⟨t, ht₁, ht₂⟩ := this in
@@ -223,7 +222,7 @@ let ⟨B, cB, _, bB⟩ := is_open_generated_countable_inter α in
 begin
   let B' := {b ∈ B | ∃ i, b ⊆ s i},
   choose f hf using λ b:B', b.2.2,
-  haveI : encodable B' := (countable_subset (sep_subset _ _) cB).to_encodable,
+  haveI : encodable B' := (cB.mono (sep_subset _ _)).to_encodable,
   refine ⟨_, countable_range f,
     subset.antisymm (bUnion_subset_Union _ _) (sUnion_subset _)⟩,
   rintro _ ⟨i, rfl⟩ x xs,
@@ -235,7 +234,7 @@ lemma is_open_sUnion_countable [second_countable_topology α]
   (S : set (set α)) (H : ∀ s ∈ S, _root_.is_open s) :
   ∃ T : set (set α), countable T ∧ T ⊆ S ∧ ⋃₀ T = ⋃₀ S :=
 let ⟨T, cT, hT⟩ := is_open_Union_countable (λ s:S, s.1) (λ s, H s.1 s.2) in
-⟨subtype.val '' T, countable_image _ cT,
+⟨subtype.val '' T, cT.image _,
   image_subset_iff.2 $ λ ⟨x, xs⟩ xt, xs,
   by rwa [sUnion_image, sUnion_eq_Union]⟩
 

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -35,7 +35,7 @@ instance : t2_space ennreal := by apply_instance -- short-circuit type class inf
 
 instance : second_countable_topology ennreal :=
 ⟨⟨⋃q ≥ (0:ℚ), {{a : ennreal | a < nnreal.of_real q}, {a : ennreal | ↑(nnreal.of_real q) < a}},
-  countable_bUnion (countable_encodable _) $ assume a ha, countable_insert (countable_singleton _),
+  (countable_encodable _).bUnion $ assume a ha, (countable_singleton _).insert _,
   le_antisymm
     (le_generate_from $ by simp [or_imp_distrib, is_open_lt', is_open_gt'] {contextual := tt})
     (le_generate_from $ λ s h, begin

--- a/src/topology/metric_space/baire.lean
+++ b/src/topology/metric_space/baire.lean
@@ -40,7 +40,7 @@ lemma is_open.is_Gδ {s : set α} (h : is_open s) : is_Gδ s :=
 
 lemma is_Gδ_bInter_of_open {ι : Type*} {I : set ι} (hI : countable I) {f : ι → set α}
   (hf : ∀i ∈ I, is_open (f i)) : is_Gδ (⋂i∈I, f i) :=
-⟨f '' I, by rwa ball_image_iff, countable_image _ hI, by rw sInter_image⟩
+⟨f '' I, by rwa ball_image_iff, hI.image _, by rw sInter_image⟩
 
 lemma is_Gδ_Inter_of_open {ι : Type*} [encodable ι] {f : ι → set α}
   (hf : ∀i, is_open (f i)) : is_Gδ (⋂i, f i) :=
@@ -59,7 +59,7 @@ begin
   { simp only [exists_prop, set.mem_Union] at ht,
     rcases ht with ⟨s, hs, tTs⟩,
     exact (hT s hs).1 t tTs },
-  { exact countable_bUnion hS (λs hs, (hT s hs).2.1) },
+  { exact hS.bUnion (λs hs, (hT s hs).2.1) },
   { exact (sInter_bUnion (λs hs, (hT s hs).2.2)).symm }
 end
 
@@ -188,7 +188,7 @@ theorem dense_sInter_of_open {S : set (set α)} (ho : ∀s∈S, is_open s) (hS :
 begin
   cases S.eq_empty_or_nonempty with h h,
   { simp [h] },
-  { rcases exists_surjective_of_countable h hS with ⟨f, hf⟩,
+  { rcases hS.exists_surjective h with ⟨f, hf⟩,
     have F : ∀n, f n ∈ S := λn, by rw hf; exact mem_range_self _,
     rw [hf, sInter_range],
     exact dense_Inter_of_open_nat (λn, ho _ (F n)) (λn, hd _ (F n)) }
@@ -202,7 +202,7 @@ begin
   rw ← sInter_image,
   apply dense_sInter_of_open,
   { rwa ball_image_iff },
-  { exact countable_image _ hS },
+  { exact hS.image _ },
   { rwa ball_image_iff }
 end
 
@@ -232,7 +232,7 @@ begin
   choose T hT using this,
   have : ⋂₀ S = ⋂₀ (⋃s∈S, T s) := (sInter_bUnion (λs hs, (hT s hs).2.2)).symm,
   rw this,
-  refine dense_sInter_of_open (λt ht, _) (countable_bUnion hS (λs hs, (hT s hs).2.1)) (λt ht, _),
+  refine dense_sInter_of_open (λt ht, _) (hS.bUnion (λs hs, (hT s hs).2.1)) (λt ht, _),
   show is_open t,
   { simp only [exists_prop, set.mem_Union] at ht,
     rcases ht with ⟨s, hs, tTs⟩,
@@ -255,7 +255,7 @@ begin
   rw ← sInter_image,
   apply dense_sInter_of_Gδ,
   { rwa ball_image_iff },
-  { exact countable_image _ hS },
+  { exact hS.image _ },
   { rwa ball_image_iff }
 end
 

--- a/src/topology/metric_space/closeds.lean
+++ b/src/topology/metric_space/closeds.lean
@@ -310,7 +310,7 @@ begin
     let v : set (nonempty_compacts α) := {t : nonempty_compacts α | t.val ∈ v0},
     refine  ⟨⟨v, ⟨_, _⟩⟩⟩,
     { have : countable (subtype.val '' v),
-      { refine countable_subset (λx hx, _) (countable_set_of_finite_subset cs),
+      { refine (countable_set_of_finite_subset cs).mono (λx hx, _),
         rcases (mem_image _ _ _).1 hx with ⟨y, ⟨hy, yx⟩⟩,
         rw ← yx,
         exact hy },

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -655,7 +655,7 @@ begin
   choose T T_in_s finite_T using B,
   let t := ⋃n:ℕ, T n⁻¹,
   have T₁ : t ⊆ s := begin apply Union_subset, assume n, apply T_in_s end,
-  have T₂ : countable t := by finish [countable_Union, countable_finite],
+  have T₂ : countable t := by finish [countable_Union, finite.countable],
   have T₃ : s ⊆ closure t,
   { intros x x_in_s,
     apply mem_closure_iff.2,
@@ -698,7 +698,7 @@ lemma second_countable_of_separable (α : Type u) [emetric_space α] [separable_
 let ⟨S, ⟨S_countable, S_dense⟩⟩ := separable_space.exists_countable_closure_eq_univ in
 ⟨⟨⋃x ∈ S, ⋃ (n : nat), {ball x (n⁻¹)},
 ⟨show countable ⋃x ∈ S, ⋃ (n : nat), {ball x (n⁻¹)},
-{ apply countable_bUnion S_countable,
+{ apply S_countable.bUnion,
   intros a aS,
   apply countable_Union,
   simp },


### PR DESCRIPTION
Renamed:

* `exists_surjective_of_countable` -> `countable.exists_surjective`;
* `countable_subset` -> `countable.mono`;
* `countable_image` -> `countable.image`;
* `countable_bUnion` -> `countable.bUnion`;
* `countable_sUnion` -> `countable.sUnion`;
* `countable_union` -> `countable.union`;
* `countable_insert` -> `countable.insert`;
* `countable_finite` -> `finite.countable`;

Add:

* `finset.countable_to_set`