### PR TITLE
[Merged by Bors] - chore(logic/embedding,order/order_iso): review

### DIFF
--- a/src/computability/turing_machine.lean
+++ b/src/computability/turing_machine.lean
@@ -745,6 +745,7 @@ begin
     λ a b h, of_to_bool_true $ (congr_fun h b).trans $ to_bool_tt rfl⟩,
   let H := (F.to_embedding.trans G).trans
     (equiv.vector_equiv_fin _ _).symm.to_embedding,
+  classical,
   let enc := H.set_value (default _) (vector.repeat ff n),
   exact ⟨_, enc, function.inv_fun enc,
     H.set_value_eq _ _, function.left_inverse_inv_fun enc.2⟩

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -2781,7 +2781,7 @@ by { ext i, simp }
 def Ico_ℤ (l u : ℤ) : finset ℤ :=
 (finset.range (u - l).to_nat).map
   { to_fun := λ n, n + l,
-    inj := λ n m h, by simpa using h }
+    inj' := λ n m h, by simpa using h }
 
 @[simp] lemma Ico_ℤ.mem {n m l : ℤ} : l ∈ Ico_ℤ n m ↔ n ≤ l ∧ l < m :=
 begin

--- a/src/data/finsupp.lean
+++ b/src/data/finsupp.lean
@@ -893,7 +893,7 @@ begin
   ext a,
   by_cases a ∈ set.range f,
   { rcases h with ⟨a, rfl⟩,
-    rw [map_domain_apply (function.embedding.inj' _), emb_domain_apply] },
+    rw [map_domain_apply f.inj, emb_domain_apply] },
   { rw [map_domain_notin_range, emb_domain_notin_range]; assumption }
 end
 

--- a/src/data/pnat/intervals.lean
+++ b/src/data/pnat/intervals.lean
@@ -12,7 +12,8 @@ namespace pnat
 def Ico (l u : ℕ+) : finset ℕ+ :=
 (finset.Ico l u).attach.map
   { to_fun := λ n, ⟨(n : ℕ), lt_of_lt_of_le l.2 (finset.Ico.mem.1 n.2).1⟩,
-    inj := λ n m h, subtype.ext.2 (by { replace h := congr_arg subtype.val h, exact h }) } -- why can't we do this directly?
+    -- why can't we do this directly?
+    inj' := λ n m h, subtype.eq (by { replace h := congr_arg subtype.val h, exact h }) }
 
 @[simp] lemma Ico.mem {n m l : ℕ+} : l ∈ Ico n m ↔ n ≤ l ∧ l < m :=
 begin

--- a/src/data/set/countable.lean
+++ b/src/data/set/countable.lean
@@ -96,7 +96,7 @@ end
 ⟨of_equiv _ (equiv.set.singleton a)⟩
 
 lemma countable_subset {s₁ s₂ : set α} (h : s₁ ⊆ s₂) : countable s₂ → countable s₁
-| ⟨H⟩ := ⟨@of_inj _ _ H _ (embedding_of_subset h).2⟩
+| ⟨H⟩ := ⟨@of_inj _ _ H _ (embedding_of_subset _ _ h).2⟩
 
 lemma countable_image {s : set α} (f : α → β) (hs : countable s) : countable (f '' s) :=
 let f' : s → f '' s := λ⟨a, ha⟩, ⟨f a, mem_image_of_mem f ha⟩ in
@@ -149,12 +149,10 @@ begin
   refine countable_subset _ (countable_range
     (λ t : finset s, {a | ∃ h:a ∈ s, subtype.mk a h ∈ t})),
   rintro t ⟨⟨ht⟩, ts⟩,
-  refine ⟨finset.univ.map (embedding_of_subset ts),
+  refine ⟨finset.univ.map (embedding_of_subset _ _ ts),
     set.ext $ λ a, _⟩,
-  simp, split,
-  { rintro ⟨as, b, bt, e⟩,
-    cases congr_arg subtype.val e, exact bt },
-  { exact λ h, ⟨ts h, _, h, rfl⟩ }
+  suffices : a ∈ s ∧ a ∈ t ↔ a ∈ t, by simpa,
+  exact ⟨and.right, λ h, ⟨ts h, h⟩⟩
 end
 
 lemma countable_pi {π : α → Type*} [fintype α] {s : Πa, set (π a)} (hs : ∀a, countable (s a)) :

--- a/src/data/setoid.lean
+++ b/src/data/setoid.lean
@@ -329,7 +329,7 @@ open quotient
         λ x y h, show s.rel ⟦x⟧ ⟦y⟧, by rw (@eq_rel _ r x y).2 ((ker_mk_eq r) ▸ h) in
       ext' $ λ x y, ⟨λ h, let ⟨a, b, hx, hy, H⟩ := h in hx ▸ hy ▸ H,
         quotient.induction_on₂ x y $ λ w z h, ⟨w, z, rfl, rfl, h⟩⟩,
-    ord := λ s t, ⟨λ h x y hs, let ⟨a, b, hx, hy, Hs⟩ := hs in ⟨a, b, hx, hy, h Hs⟩,
+    ord' := λ s t, ⟨λ h x y hs, let ⟨a, b, hx, hy, Hs⟩ := hs in ⟨a, b, hx, hy, h Hs⟩,
       λ h x y hs, let ⟨a, b, hx, hy, ht⟩ := h ⟨x, y, rfl, rfl, hs⟩ in
         t.1.trans' (t.1.symm' $ t.2 $ eq_rel.1 hx) $ t.1.trans' ht $ t.2 $ eq_rel.1 hy⟩ }
 end
@@ -489,7 +489,7 @@ def partition.order_iso :
   inv_fun := λ x, mk_classes x.1 x.2.2,
   left_inv := mk_classes_classes,
   right_inv := λ x, by rw [subtype.ext, ←classes_mk_classes x.1 x.2],
-  ord := λ x y, by conv {to_lhs, rw [←mk_classes_classes x, ←mk_classes_classes y]}; refl }
+  ord' := λ x y, by conv {to_lhs, rw [←mk_classes_classes x, ←mk_classes_classes y]}; refl }
 
 variables {α}
 

--- a/src/group_theory/congruence.lean
+++ b/src/group_theory/congruence.lean
@@ -472,7 +472,7 @@ open quotient
         λ x y h, show d _ _, by rw mul_ker_mk_eq at h; exact c.eq.2 h ▸ d.refl _ in
       ext $ λ x y, ⟨λ h, let ⟨a, b, hx, hy, H⟩ := h in hx ▸ hy ▸ H,
         con.induction_on₂ x y $ λ w z h, ⟨w, z, rfl, rfl, h⟩⟩,
-    ord := λ s t, ⟨λ h _ _ hs, let ⟨a, b, hx, hy, Hs⟩ := hs in ⟨a, b, hx, hy, h Hs⟩,
+    ord' := λ s t, ⟨λ h _ _ hs, let ⟨a, b, hx, hy, Hs⟩ := hs in ⟨a, b, hx, hy, h Hs⟩,
       λ h _ _ hs, let ⟨a, b, hx, hy, ht⟩ := h ⟨_, _, rfl, rfl, hs⟩ in
         t.1.trans (t.1.symm $ t.2 $ eq_rel.1 hx) $ t.1.trans ht $ t.2 $ eq_rel.1 hy⟩ }
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1195,7 +1195,7 @@ def map_subtype.order_iso :
   inv_fun   := λ q, comap p.subtype q,
   left_inv  := λ p', comap_map_eq_self $ by simp,
   right_inv := λ ⟨q, hq⟩, subtype.eq' $ by simp [map_comap_subtype p, inf_of_le_right hq],
-  ord       := λ p₁ p₂, (map_le_map_iff $ ker_subtype _).symm }
+  ord'      := λ p₁ p₂, (map_le_map_iff $ ker_subtype _).symm }
 
 /-- If `p ⊆ M` is a submodule, the ordering of submodules of `p` is embedded in the ordering of
 submodules of M. -/
@@ -1322,7 +1322,7 @@ def comap_mkq.order_iso :
   inv_fun   := λ q, map p.mkq q,
   left_inv  := λ p', map_comap_eq_self $ by simp,
   right_inv := λ ⟨q, hq⟩, subtype.eq' $ by simp [comap_map_mkq p, sup_of_le_right hq],
-  ord       := λ p₁ p₂, (comap_le_comap_iff $ range_mkq _).symm }
+  ord'      := λ p₁ p₂, (comap_le_comap_iff $ range_mkq _).symm }
 
 /-- The ordering on submodules of the quotient of `M` by `p` embeds into the ordering on submodules
 of `M`. -/

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -72,7 +72,7 @@ begin
       exact ⟨hj, rfl⟩ },
     refine le_of_not_lt (λ IJ, _),
     suffices : cardinal.mk (⋃ j, S' j) < cardinal.mk (range v),
-    { exact not_le_of_lt this ⟨set.embedding_of_subset hs⟩ },
+    { exact not_le_of_lt this ⟨set.embedding_of_subset _ _ hs⟩ },
     refine lt_of_le_of_lt (le_trans cardinal.mk_Union_le_sum_mk
       (cardinal.sum_le_sum _ (λ _, cardinal.omega) _)) _,
     { exact λ j, le_of_lt (cardinal.lt_omega_iff_finite.2 $ finite_image _ (finset.finite_to_set _)) },

--- a/src/logic/embedding.lean
+++ b/src/logic/embedding.lean
@@ -24,7 +24,7 @@ instance {α : Sort u} {β : Sort v} : has_coe_to_fun (α ↪ β) := ⟨_, embed
 
 end function
 
-/-- Convert an `α ≃β` to `α ↪ β`. -/
+/-- Convert an `α ≃ β` to `α ↪ β`. -/
 protected def equiv.to_embedding {α : Sort u} {β : Sort v} (f : α ≃ β) : α ↪ β :=
 ⟨f, f.injective⟩
 
@@ -85,7 +85,7 @@ equiv.of_bijective ⟨f.inj, hf⟩
 protected def of_not_nonempty {α β} (hα : ¬ nonempty α) : α ↪ β :=
 ⟨λa, (hα ⟨a⟩).elim, assume a, (hα ⟨a⟩).elim⟩
 
-/-- Change value of an embedding `f` at one point. If the prescribed image
+/-- Change the value of an embedding `f` at one point. If the prescribed image
 is already occupied by some `f a'`, then swap the values at these two points. -/
 def set_value {α β} (f : α ↪ β) (a : α) (b : β) [∀ a', decidable (a' = a)]
   [∀ a', decidable (f a' = b)] : α ↪ β :=

--- a/src/logic/embedding.lean
+++ b/src/logic/embedding.lean
@@ -2,18 +2,21 @@
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
-
-Injective functions.
 -/
 import data.equiv.basic
+
+/-!
+# Injective functions
+-/
 
 universes u v w x
 
 namespace function
 
+/-- `α ↪ β` is a bundled injective function. -/
 structure embedding (α : Sort*) (β : Sort*) :=
 (to_fun : α → β)
-(inj    : injective to_fun)
+(inj'   : injective to_fun)
 
 infixr ` ↪ `:25 := embedding
 
@@ -21,6 +24,7 @@ instance {α : Sort u} {β : Sort v} : has_coe_to_fun (α ↪ β) := ⟨_, embed
 
 end function
 
+/-- Convert an `α ≃β` to `α ↪ β`. -/
 protected def equiv.to_embedding {α : Sort u} {β : Sort v} (f : α ≃ β) : α ↪ β :=
 ⟨f, f.injective⟩
 
@@ -41,8 +45,7 @@ lemma ext_iff {α β} {f g : embedding α β} : (∀ x, f x = g x) ↔ f = g :=
 @[simp] theorem coe_fn_mk {α β} (f : α → β) (i) :
   (@mk _ _ f i : α → β) = f := rfl
 
-theorem inj' {α β} : ∀ (f : α ↪ β), injective f
-| ⟨f, hf⟩ := hf
+theorem inj {α β} (f : α ↪ β) : injective f := f.inj'
 
 @[refl] protected def refl (α : Sort*) : α ↪ α :=
 ⟨id, injective_id⟩
@@ -69,10 +72,12 @@ protected def congr {α : Sort u} {β : Sort v} {γ : Sort w} {δ : Sort x}
   (e₁ : α ≃ β) (e₂ : γ ≃ δ) (f : α ↪ γ) : (β ↪ δ) :=
 (equiv.to_embedding e₁.symm).trans (f.trans e₂.to_embedding)
 
-protected noncomputable def of_surjective {α β} {f : β → α} (hf : surjective f) :
+/-- A right inverse `surj_inv` of a surjective function as an `embedding`. -/
+protected noncomputable def of_surjective {α β} (f : β → α) (hf : surjective f) :
   α ↪ β :=
 ⟨surj_inv hf, injective_surj_inv _⟩
 
+/-- Convert a surjective `embedding` to an `equiv` -/
 protected noncomputable def equiv_of_surjective {α β} (f : α ↪ β) (hf : surjective f) :
   α ≃ β :=
 equiv.of_bijective ⟨f.inj, hf⟩
@@ -80,33 +85,27 @@ equiv.of_bijective ⟨f.inj, hf⟩
 protected def of_not_nonempty {α β} (hα : ¬ nonempty α) : α ↪ β :=
 ⟨λa, (hα ⟨a⟩).elim, assume a, (hα ⟨a⟩).elim⟩
 
-noncomputable def set_value {α β} (f : α ↪ β) (a : α) (b : β) : α ↪ β :=
-by haveI := classical.dec; exact
-if h : ∃ a', f a' = b then
-  (equiv.swap a (classical.some h)).to_embedding.trans f
-else
-  ⟨λ a', if a' = a then b else f a',
-   λ a₁ a₂ e, begin
-    simp at e, split_ifs at e with h₁ h₂,
-    { cc },
-    { cases h ⟨_, e.symm⟩ },
-    { cases h ⟨_, e⟩ },
-    { exact f.2 e }
-   end⟩
+/-- Change value of an embedding `f` at one point. If the prescribed image
+is already occupied by some `f a'`, then swap the values at these two points. -/
+def set_value {α β} (f : α ↪ β) (a : α) (b : β) [∀ a', decidable (a' = a)]
+  [∀ a', decidable (f a' = b)] : α ↪ β :=
+⟨λ a', if a' = a then b else if f a' = b then f a else f a',
+  begin
+    intros x y h,
+    dsimp at h,
+    unfreezeI,
+    split_ifs at h; try { subst b }; try { simp only [f.inj.eq_iff] at * }; cc
+  end⟩
 
-theorem set_value_eq {α β} (f : α ↪ β) (a : α) (b : β) : set_value f a b a = b :=
-begin
-  rw [set_value],
-  cases classical.dec (∃ a', f a' = b);
-    dsimp [dite], {simp},
-  simp [equiv.swap_apply_left],
-  apply classical.some_spec h
-end
+theorem set_value_eq {α β} (f : α ↪ β) (a : α) (b : β) [∀ a', decidable (a' = a)]
+  [∀ a', decidable (f a' = b)] : set_value f a b a = b :=
+by simp [set_value]
 
 /-- Embedding into `option` -/
 protected def some {α} : α ↪ option α :=
 ⟨some, option.injective_some α⟩
 
+/-- Embedding of a `subtype`. -/
 def subtype {α} (p : α → Prop) : subtype p ↪ α :=
 ⟨subtype.val, λ _ _, subtype.eq'⟩
 
@@ -187,8 +186,12 @@ protected def subtype_map {α β} {p : α → Prop} {q : β → Prop} (f : α �
 ⟨subtype.map f h, subtype.map_injective h f.2⟩
 
 open set
+
+/-- `set.image` as an embedding `set α ↪ set β`. -/
 protected def image {α β} (f : α ↪ β) : set α ↪ set β :=
 ⟨image f, injective_image f.2⟩
+
+@[simp] lemma coe_image {α β} (f : α ↪ β) : ⇑f.image = image f := rfl
 
 end embedding
 end function
@@ -196,8 +199,13 @@ end function
 namespace set
 
 /-- The injection map is an embedding between subsets. -/
-def embedding_of_subset {α} {s t : set α} (h : s ⊆ t) : s ↪ t :=
+def embedding_of_subset {α} (s t : set α) (h : s ⊆ t) : s ↪ t :=
 ⟨λ x, ⟨x.1, h x.2⟩, λ ⟨x, hx⟩ ⟨y, hy⟩ h, by congr; injection h⟩
 
+@[simp] lemma embedding_of_subset_apply_mk {α} {s t : set α} (h : s ⊆ t) (x : α) (hx : x ∈ s) :
+  embedding_of_subset s t h ⟨x, hx⟩ = ⟨x, h hx⟩ := rfl
+
+@[simp] lemma coe_embedding_of_subset_apply {α} {s t : set α} (h : s ⊆ t) (x : s) :
+  (embedding_of_subset s t h x : α) = x := rfl
 
 end set

--- a/src/order/galois_connection.lean
+++ b/src/order/galois_connection.lean
@@ -20,7 +20,7 @@ def galois_connection [preorder α] [preorder β] (l : α → β) (u : β → α
 /-- Makes a Galois connection from an order-preserving bijection. -/
 theorem order_iso.to_galois_connection [preorder α] [preorder β] (oi : @order_iso α β (≤) (≤)) :
   galois_connection oi oi.symm :=
-λ b g, by rw [order_iso.ord' oi, order_iso.apply_symm_apply]
+λ b g, by rw [oi.ord, order_iso.apply_symm_apply]
 
 namespace galois_connection
 

--- a/src/order/order_iso.lean
+++ b/src/order/order_iso.lean
@@ -202,9 +202,17 @@ infix ` ≃o `:25 := order_iso
 
 namespace order_iso
 
-instance : has_coe (r ≃o s) (r ≼o s) := ⟨λ f, ⟨f.to_equiv.to_embedding, f.ord'⟩⟩
+/-- Convert an `order_iso` to an `order_embedding`. This function is also available as a coercion
+but often it is easier to write `f.to_order_embedding` than to write explicitly `r` and `s`
+in the target type. -/
+def to_order_embedding (f : r ≃o s) : r ≼o s :=
+⟨f.to_equiv.to_embedding, f.ord'⟩
+
+instance : has_coe (r ≃o s) (r ≼o s) := ⟨to_order_embedding⟩
 -- see Note [function coercion]
 instance : has_coe_to_fun (r ≃o s) := ⟨λ _, α → β, λ f, f⟩
+
+@[simp] lemma to_order_embedding_eq_coe (f : r ≃o s) : f.to_order_embedding = f := rfl
 
 @[simp] lemma coe_coe_fn (f : r ≃o s) : ((f : r ≼o s) : α → β) = f := rfl
 @[simp] lemma to_equiv_to_fun (f : r ≃o s) (x : α) : f.to_equiv.to_fun x = f x := rfl

--- a/src/order/order_iso.lean
+++ b/src/order/order_iso.lean
@@ -26,7 +26,7 @@ end
 /-- An order embedding with respect to a given pair of orders `r` and `s`
 is an embedding `f : α ↪ β` such that `r a b ↔ s (f a) (f b)`. -/
 structure order_embedding {α β : Type*} (r : α → α → Prop) (s : β → β → Prop) extends α ↪ β :=
-(ord : ∀ {a b}, r a b ↔ s (to_embedding a) (to_embedding b))
+(ord' : ∀ {a b}, r a b ↔ s (to_embedding a) (to_embedding b))
 
 infix ` ≼o `:25 := order_embedding
 
@@ -43,8 +43,9 @@ namespace order_embedding
 
 instance : has_coe_to_fun (r ≼o s) := ⟨λ _, α → β, λ o, o.to_embedding⟩
 
-theorem ord' : ∀ (f : r ≼o s) {a b}, r a b ↔ s (f a) (f b)
-| ⟨f, o⟩ := @o
+theorem inj (f : r ≼o s) : injective f := f.inj'
+
+theorem ord (f : r ≼o s) : ∀ {a b}, r a b ↔ s (f a) (f b) := f.ord'
 
 @[simp] theorem coe_fn_mk (f : α ↪ β) (o) :
   (@order_embedding.mk _ _ r s f o : α → β) = f := rfl
@@ -66,14 +67,14 @@ theorem eq_of_to_fun_eq : ∀ {e₁ e₂ : r ≼o s}, (e₁ : α → β) = e₂ 
 
 /-- An order embedding is also an order embedding between dual orders. -/
 def rsymm (f : r ≼o s) : swap r ≼o swap s :=
-⟨f.to_embedding, λ a b, f.ord'⟩
+⟨f.to_embedding, λ a b, f.ord⟩
 
 /-- If `f` is injective, then it is an order embedding from the
   preimage order of `s` to `s`. -/
 def preimage (f : α ↪ β) (s : β → β → Prop) : f ⁻¹'o s ≼o s := ⟨f, λ a b, iff.rfl⟩
 
 theorem eq_preimage (f : r ≼o s) : r = f ⁻¹'o s :=
-by funext a b; exact propext f.ord'
+by { ext a b, exact f.ord }
 
 protected theorem is_irrefl : ∀ (f : r ≼o s) [is_irrefl β s], is_irrefl α r
 | ⟨f, o⟩ ⟨H⟩ := ⟨λ a h, H _ (o.1 h)⟩
@@ -118,7 +119,7 @@ protected theorem acc (f : r ≼o s) (a : α) : acc s (f a) → acc r a :=
 begin
   generalize h : f a = b, intro ac,
   induction ac with _ H IH generalizing a, subst h,
-  exact ⟨_, λ a' h, IH (f a') (f.ord'.1 h) _ rfl⟩
+  exact ⟨_, λ a' h, IH (f a') (f.ord.1 h) _ rfl⟩
 end
 
 protected theorem well_founded : ∀ (f : r ≼o s) (h : well_founded s), well_founded r
@@ -147,9 +148,7 @@ end
 def lt_embedding_of_le_embedding [preorder α] [preorder β]
   (f : (has_le.le : α → α → Prop) ≼o (has_le.le : β → β → Prop)) :
 (has_lt.lt : α → α → Prop) ≼o (has_lt.lt : β → β → Prop) :=
-{ to_fun := f,
-  inj := f.inj,
-  ord := by intros; simp [lt_iff_le_not_le,f.ord] }
+{ ord' := by intros; simp [lt_iff_le_not_le,f.ord], .. f }
 
 def nat_lt [is_strict_order α r] (f : ℕ → α) (H : ∀ n:ℕ, r (f n) (f (n+1))) :
   ((<) : ℕ → ℕ → Prop) ≼o r :=
@@ -197,27 +196,23 @@ instance fin.lt.is_well_order (n) : is_well_order (fin n) (<) :=
 
 /-- An order isomorphism is an equivalence that is also an order embedding. -/
 structure order_iso {α β : Type*} (r : α → α → Prop) (s : β → β → Prop) extends α ≃ β :=
-(ord : ∀ {a b}, r a b ↔ s (to_equiv a) (to_equiv b))
+(ord' : ∀ {a b}, r a b ↔ s (to_equiv a) (to_equiv b))
 
 infix ` ≃o `:25 := order_iso
 
 namespace order_iso
 
-def to_order_embedding (f : r ≃o s) : r ≼o s :=
-⟨f.to_equiv.to_embedding, f.ord⟩
-
-instance : has_coe (r ≃o s) (r ≼o s) := ⟨to_order_embedding⟩
+instance : has_coe (r ≃o s) (r ≼o s) := ⟨λ f, ⟨f.to_equiv.to_embedding, f.ord'⟩⟩
 -- see Note [function coercion]
 instance : has_coe_to_fun (r ≃o s) := ⟨λ _, α → β, λ f, f⟩
 
 @[simp] lemma coe_coe_fn (f : r ≃o s) : ((f : r ≼o s) : α → β) = f := rfl
 @[simp] lemma to_equiv_to_fun (f : r ≃o s) (x : α) : f.to_equiv.to_fun x = f x := rfl
 
-theorem ord' : ∀ (f : r ≃o s) {a b}, r a b ↔ s (f a) (f b)
-| ⟨f, o⟩ := @o
+theorem ord (f : r ≃o s) : ∀ {a b}, r a b ↔ s (f a) (f b) := f.ord'
 
 lemma ord'' {r : α → α → Prop} {s : β → β → Prop} (f : r ≃o s) {x y : α} :
-    r x y ↔ s ((↑f : r ≼o s) x) ((↑f : r ≼o s) y) := f.ord'
+    r x y ↔ s ((↑f : r ≼o s) x) ((↑f : r ≼o s) y) := f.ord
 
 @[simp] theorem coe_fn_mk (f : α ≃ β) (o) :
   (@order_iso.mk _ _ r s f o : α → β) = f := rfl
@@ -314,7 +309,7 @@ end subrel
 
 /-- Restrict the codomain of an order embedding -/
 def order_embedding.cod_restrict (p : set β) (f : r ≼o s) (H : ∀ a, f a ∈ p) : r ≼o subrel s p :=
-⟨f.to_embedding.cod_restrict p H, f.ord⟩
+⟨f.to_embedding.cod_restrict p H, f.ord'⟩
 
 @[simp] theorem order_embedding.cod_restrict_apply (p) (f : r ≼o s) (H a) :
   order_embedding.cod_restrict p f H a = ⟨f a, H a⟩ := rfl

--- a/src/ring_theory/ideal_operations.lean
+++ b/src/ring_theory/ideal_operations.lean
@@ -536,7 +536,7 @@ def order_iso_of_surjective :
   right_inv := λ I, subtype.eq $ show comap f (map f I.1) = I.1,
     from (comap_map_of_surjective f hf I).symm ▸ le_antisymm
       (sup_le (le_refl _) I.2) le_sup_left,
-  ord := λ I1 I2, ⟨comap_mono, λ H, map_comap_of_surjective f hf I1 ▸
+  ord' := λ I1 I2, ⟨comap_mono, λ H, map_comap_of_surjective f hf I1 ▸
     map_comap_of_surjective f hf I2 ▸ map_mono H⟩ }
 
 def le_order_embedding_of_surjective :

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -593,8 +593,8 @@ def le_order_embedding :
   ((≤) : ideal (localization α S) → ideal (localization α S) → Prop) ≼o
   ((≤) : ideal α → ideal α → Prop) :=
 { to_fun := λ J, ideal.comap (ring_hom.of coe) J,
-  inj := function.injective_of_left_inverse (map_comap α),
-  ord := λ J₁ J₂, ⟨ideal.comap_mono, λ hJ,
+  inj'   := function.injective_of_left_inverse (map_comap α),
+  ord'   := λ J₁ J₂, ⟨ideal.comap_mono, λ hJ,
     map_comap α J₁ ▸ map_comap α J₂ ▸ ideal.map_mono hJ⟩ }
 
 end ideals

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -348,7 +348,7 @@ begin
     span R ((subtype.val ∘ f) '' {m | m ≤ a}) ≤ span R ((subtype.val ∘ f) '' {m | m ≤ b}),
   { assume a b,
     rw [span_le_span_iff (@zero_ne_one R _) hs (this a) (this b),
-      set.image_subset_image_iff (injective_comp subtype.val_injective f.inj'),
+      set.image_subset_image_iff (injective_comp subtype.val_injective f.inj),
       set.subset_def],
     exact ⟨λ hab x (hxa : x ≤ a), le_trans hxa hab, λ hx, hx a (le_refl a)⟩ },
   exact ⟨⟨λ n, span R ((subtype.val ∘ f) '' {m | m ≤ n}),

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -77,7 +77,7 @@ theorem mk_le_of_injective {α β : Type u} {f : α → β} (hf : injective f) :
 ⟨⟨f, hf⟩⟩
 
 theorem mk_le_of_surjective {α β : Type u} {f : α → β} (hf : surjective f) : mk β ≤ mk α :=
-⟨embedding.of_surjective hf⟩
+⟨embedding.of_surjective f hf⟩
 
 theorem le_mk_iff_exists_set {c : cardinal} {α : Type u} :
   c ≤ mk α ↔ ∃ p : set α, mk p = c :=
@@ -795,7 +795,7 @@ lt_of_not_ge $ λ ⟨F⟩, begin
     simp only [- not_exists, not_exists.symm, classical.not_forall.symm],
     refine λ h, not_le_of_lt (H i) _,
     rw [← mk_out (f i), ← mk_out (g i)],
-    exact ⟨embedding.of_surjective h⟩ },
+    exact ⟨embedding.of_surjective _ h⟩ },
   exact (let ⟨⟨i, a⟩, h⟩ := sG C in hc i a (congr_fun h _))
 end
 
@@ -862,7 +862,7 @@ mk_le_of_surjective surjective_onto_image
 
 theorem mk_image_le_lift {α : Type u} {β : Type v} {f : α → β} {s : set α} :
   lift.{v u} (mk (f '' s)) ≤ lift.{u v} (mk s) :=
-lift_mk_le.{v u 0}.mpr ⟨embedding.of_surjective surjective_onto_image⟩
+lift_mk_le.{v u 0}.mpr ⟨embedding.of_surjective _ surjective_onto_image⟩
 
 theorem mk_range_le {α β : Type u} {f : α → β} : mk (range f) ≤ mk α :=
 mk_le_of_surjective surjective_onto_range
@@ -923,10 +923,10 @@ lemma mk_sum_compl {α} (s : set α) : #s + #(-s : set α) = #α :=
 quotient.sound ⟨equiv.set.sum_compl s⟩
 
 lemma mk_le_mk_of_subset {α} {s t : set α} (h : s ⊆ t) : mk s ≤ mk t :=
-⟨ set.embedding_of_subset h ⟩
+⟨set.embedding_of_subset s t h⟩
 
 lemma mk_subtype_mono {p q : α → Prop} (h : ∀x, p x → q x) : mk {x // p x} ≤ mk {x // q x} :=
-⟨embedding_of_subset h⟩
+⟨embedding_of_subset _ _ h⟩
 
 lemma mk_set_le (s : set α) : mk s ≤ mk α :=
 mk_subtype_le s

--- a/src/set_theory/cofinality.lean
+++ b/src/set_theory/cofinality.lean
@@ -2,10 +2,11 @@
 Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Mario Carneiro
-
-Cofinality on ordinals, regular cardinals.
 -/
 import set_theory.ordinal
+/-!
+# Cofinality on ordinals, regular cardinals
+-/
 noncomputable theory
 
 open function cardinal set
@@ -280,7 +281,7 @@ begin
   refine ordinal.induction_on o _ e, introsI α r _ e',
   rw e' at H,
   refine le_trans (cof_type_le (set.range (λ i, enum r _ (H i))) _)
-    ⟨embedding.of_surjective _⟩,
+    ⟨embedding.of_surjective _ _⟩,
   { intro a, by_contra h,
     apply not_le_of_lt (typein_lt_type r a),
     rw [← e', sup_le],
@@ -447,7 +448,7 @@ theorem succ_is_regular {c : cardinal.{u}} (h : omega ≤ c) : is_regular (succ 
   rw [mul_eq_self h, ← succ_le, ← αe, ← sum_const],
   refine le_trans _ (sum_le_sum (λ x:S, card (typein r x)) _ _),
   { simp [typein, sum_mk (λ x:S, {a//r a x})],
-    refine ⟨embedding.of_surjective _⟩,
+    refine ⟨embedding.of_surjective _ _⟩,
     { exact λ x, x.2.1 },
     { exact λ a, let ⟨b, h, ab⟩ := H a in ⟨⟨⟨_, h⟩, _, ab⟩, rfl⟩ } },
   { intro i,
@@ -503,7 +504,7 @@ quotient.induction_on c $ λ α h, begin
   have := sum_lt_prod (λ a:S, mk {x // r x a}) (λ _, mk α) (λ i, _),
   { simp [Se.symm] at this ⊢,
     refine lt_of_le_of_lt _ this,
-    refine ⟨embedding.of_surjective _⟩,
+    refine ⟨embedding.of_surjective _ _⟩,
     { exact λ x, x.2.1 },
     { exact λ a, let ⟨b, h, ab⟩ := H a in ⟨⟨⟨_, h⟩, _, ab⟩, rfl⟩ } },
   { have := typein_lt_type r i,

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -39,8 +39,8 @@ theorem init' (f : r ≼i s) {a : α} {b : β} : s b (f a) → ∃ a', f a' = b 
 f.init _ _
 
 theorem init_iff (f : r ≼i s) {a : α} {b : β} : s b (f a) ↔ ∃ a', f a' = b ∧ r a' a :=
-⟨λ h, let ⟨a', e⟩ := f.init' h in ⟨a', e, (f : r ≼o s).ord'.2 (e.symm ▸ h)⟩,
- λ ⟨a', e, h⟩, e ▸ (f : r ≼o s).ord'.1 h⟩
+⟨λ h, let ⟨a', e⟩ := f.init' h in ⟨a', e, (f : r ≼o s).ord.2 (e.symm ▸ h)⟩,
+ λ ⟨a', e, h⟩, e ▸ (f : r ≼o s).ord.1 h⟩
 
 /-- An order isomorphism is an initial segment -/
 def of_iso (f : r ≃o s) : r ≼i s :=
@@ -54,7 +54,7 @@ def of_iso (f : r ≃o s) : r ≼i s :=
 @[trans] protected def trans (f : r ≼i s) (g : s ≼i t) : r ≼i t :=
 ⟨f.1.trans g.1, λ a c h, begin
   simp at h ⊢,
-  rcases g.2 _ _ h with ⟨b, rfl⟩, have h := g.1.ord'.2 h,
+  rcases g.2 _ _ h with ⟨b, rfl⟩, have h := g.1.ord.2 h,
   rcases f.2 _ _ h with ⟨a', rfl⟩, exact ⟨a', rfl⟩
 end⟩
 
@@ -70,9 +70,9 @@ theorem unique_of_extensional [is_extensional β s] :
   funext a, have := h a, induction this with a H IH,
   refine @is_extensional.ext _ s _ _ _ (λ x, ⟨λ h, _, λ h, _⟩),
   { rcases f.init_iff.1 h with ⟨y, rfl, h'⟩,
-    rw IH _ h', exact (g : r ≼o s).ord'.1 h' },
+    rw IH _ h', exact (g : r ≼o s).ord.1 h' },
   { rcases g.init_iff.1 h with ⟨y, rfl, h'⟩,
-    rw ← IH _ h', exact (f : r ≼o s).ord'.1 h' }
+    rw ← IH _ h', exact (f : r ≼o s).ord.1 h' }
 end⟩
 
 instance [is_well_order β s] : subsingleton (r ≼i s) :=
@@ -88,7 +88,7 @@ initial_seg.eq (f.trans g) (initial_seg.refl _)
 /-- If we have order embeddings between `α` and `β` whose images are initial segments, and β is a well-order then `α` and `β` are order-isomorphic. -/
 def antisymm [is_well_order β s] (f : r ≼i s) (g : s ≼i r) : r ≃o s :=
 by haveI := f.to_order_embedding.is_well_order; exact
-⟨⟨f, g, antisymm.aux f g, antisymm.aux g f⟩, f.ord⟩
+⟨⟨f, g, antisymm.aux f g, antisymm.aux g f⟩, f.ord'⟩
 
 @[simp] theorem antisymm_to_fun [is_well_order β s]
   (f : r ≼i s) (g : s ≼i r) : (antisymm f g : α → β) = f := rfl
@@ -193,7 +193,7 @@ def lt_equiv {r : α → α → Prop} {s : β → β → Prop} {t : γ → γ �
 ⟨@order_embedding.trans _ _ _ r s t f g, g f.top,
   begin
     intro x,
-    rw [← g.right_inv x, order_iso.to_equiv_to_fun, ← order_iso.ord' g, f.down', exists_congr],
+    rw [← g.right_inv x, order_iso.to_equiv_to_fun, ← g.ord, f.down', exists_congr],
     intro y, exact ⟨congr_arg g, λ h, g.to_equiv.bijective.1 h⟩
   end⟩
 
@@ -281,8 +281,8 @@ def collapse_F [is_well_order β s] (f : r ≼o s) : Π a, {b // ¬ s (f a) b} :
 (order_embedding.well_founded f $ is_well_order.wf).fix $ λ a IH, begin
   let S := {b | ∀ a h, s (IH a h).1 b},
   have : f a ∈ S, from λ a' h, ((trichotomous _ _)
-    .resolve_left $ λ h', (IH a' h).2 $ trans (f.ord'.1 h) h')
-    .resolve_left $ λ h', (IH a' h).2 $ h' ▸ f.ord'.1 h,
+    .resolve_left $ λ h', (IH a' h).2 $ trans (f.ord.1 h) h')
+    .resolve_left $ λ h', (IH a' h).2 $ h' ▸ f.ord.1 h,
   exact ⟨is_well_order.wf.min S ⟨_, this⟩,
    is_well_order.wf.not_lt_min _ _ this⟩
 end
@@ -485,9 +485,9 @@ eq.symm $ quot.sound ⟨order_iso.of_surjective
 eq.symm $ quotient.sound ⟨order_iso.of_surjective
   (order_embedding.cod_restrict _
     ((subrel.order_embedding _ _).trans f)
-    (λ ⟨x, h⟩, by rw [order_embedding.trans_apply]; exact f.to_order_embedding.ord'.1 h))
+    (λ ⟨x, h⟩, by rw [order_embedding.trans_apply]; exact f.to_order_embedding.ord.1 h))
   (λ ⟨y, h⟩, by rcases f.init' h with ⟨a, rfl⟩;
-    exact ⟨⟨a, f.to_order_embedding.ord'.2 h⟩, subtype.eq $ order_embedding.trans_apply _ _ _⟩)⟩
+    exact ⟨⟨a, f.to_order_embedding.ord.2 h⟩, subtype.eq $ order_embedding.trans_apply _ _ _⟩)⟩
 
 @[simp] theorem typein_lt_typein (r : α → α → Prop) [is_well_order α r]
   {a b : α} : typein r a < typein r b ↔ r a b :=
@@ -662,7 +662,7 @@ induction_on a $ λ α r hr, induction_on b $ λ β s hs ⟨⟨f, t, hf⟩⟩, b
     (sum.rec _ _) (λ a b, _), λ a b, _⟩⟩,
   { exact f }, { exact λ _, t },
   { rcases a with a|_; rcases b with b|_,
-    { simpa only [sum.lex_inl_inl] using f.ord'.1 },
+    { simpa only [sum.lex_inl_inl] using f.ord.1 },
     { intro _, rw hf, exact ⟨_, rfl⟩ },
     { exact false.elim ∘ sum.lex_inr_inl },
     { exact false.elim ∘ sum.lex_inr_inr.1 } },
@@ -736,12 +736,12 @@ theorem add_le_add_iff_left (a) {b c : ordinal} : a + b ≤ a + c ↔ b ≤ c :=
         ((initial_seg.le_add r s₁).trans f) (initial_seg.le_add r s₂) a,
   have ∀ b, {b' // f (sum.inr b) = sum.inr b'}, begin
     intro b, cases e : f (sum.inr b),
-    { rw ← fl at e, have := f.inj e, contradiction },
+    { rw ← fl at e, have := f.inj' e, contradiction },
     { exact ⟨_, rfl⟩ }
   end,
   let g (b) := (this b).1 in
   have fr : ∀ b, f (sum.inr b) = sum.inr (g b), from λ b, (this b).2,
-  ⟨⟨⟨g, λ x y h, by injection f.inj
+  ⟨⟨⟨g, λ x y h, by injection f.inj'
     (by rw [fr, fr, h] : f (sum.inr x) = f (sum.inr y))⟩,
     λ a b, by simpa only [sum.lex_inr_inr, fr, order_embedding.coe_fn_to_embedding,
         initial_seg.coe_fn_to_order_embedding, function.embedding.coe_fn_mk]
@@ -856,7 +856,7 @@ quotient.induction_on c (λ α, induction_on b $ λ β s _ e', begin
       ← cardinal.lift_umax.{u v}, lift_mk_eq.{u (max u v) (max u v)}] at e',
   cases e' with f,
   have g := order_iso.preimage f s,
-  haveI := g.to_order_embedding.is_well_order,
+  haveI := (g : ⇑f ⁻¹'o s ≼o s).is_well_order,
   have := lift_type_eq.{u (max u v) (max u v)}.2 ⟨g⟩,
   rw [lift_id, lift_umax.{u v}] at this,
   exact ⟨_, this⟩
@@ -1302,7 +1302,7 @@ def lift.principal_seg : @principal_seg ordinal.{u} ordinal.{max (u+1) v} (<) (<
     { exact λ b, enum r (f b) ((hf _).2 ⟨_, rfl⟩) },
     { refine λ a b h, (typein_lt_typein r).1 _,
       rw [typein_enum, typein_enum],
-      exact f.ord'.1 h },
+      exact f.ord.1 h },
     { intro a', cases (hf _).1 (typein_lt_type _ a') with b e,
       existsi b, simp, simp [e] } },
   { cases h with a e, rw [← e],
@@ -1456,7 +1456,7 @@ quotient.induction_on₃ a b c $ λ ⟨α, r, _⟩ ⟨β, s, _⟩ ⟨γ, t, _⟩
     (λ a, (f a.1, a.2))
     (λ a b h, _)⟩, clear_,
   cases h with a₁ b₁ a₂ b₂ h' a b₁ b₂ h',
-  { exact prod.lex.left _ _ (f.to_order_embedding.ord'.1 h') },
+  { exact prod.lex.left _ _ (f.to_order_embedding.ord.1 h') },
   { exact prod.lex.right _ h' }
 end
 
@@ -1468,7 +1468,7 @@ quotient.induction_on₃ a b c $ λ ⟨α, r, _⟩ ⟨β, s, _⟩ ⟨γ, t, _⟩
     (λ a b h, _)⟩,
   cases h with a₁ b₁ a₂ b₂ h' a b₁ b₂ h',
   { exact prod.lex.left _ _ h' },
-  { exact prod.lex.right _ (f.to_order_embedding.ord'.1 h') }
+  { exact prod.lex.right _ (f.to_order_embedding.ord.1 h') }
 end
 
 theorem mul_le_mul {a b c d : ordinal} (h₁ : a ≤ c) (h₂ : b ≤ d) : a * b ≤ c * d :=
@@ -2762,7 +2762,7 @@ def aleph_idx : cardinal → ordinal := aleph_idx.initial_seg
   (aleph_idx.initial_seg : cardinal → ordinal) = aleph_idx := rfl
 
 @[simp] theorem aleph_idx_lt {a b} : aleph_idx a < aleph_idx b ↔ a < b :=
-aleph_idx.initial_seg.to_order_embedding.ord'.symm
+aleph_idx.initial_seg.to_order_embedding.ord.symm
 
 @[simp] theorem aleph_idx_le {a b} : aleph_idx a ≤ aleph_idx b ↔ a ≤ b :=
 by rw [← not_lt, ← not_lt, aleph_idx_lt]
@@ -2804,7 +2804,7 @@ def aleph' : ordinal → cardinal := aleph'.order_iso
   (aleph'.order_iso : ordinal → cardinal) = aleph' := rfl
 
 @[simp] theorem aleph'_lt {o₁ o₂ : ordinal.{u}} : aleph' o₁ < aleph' o₂ ↔ o₁ < o₂ :=
-aleph'.order_iso.ord'.symm
+aleph'.order_iso.ord.symm
 
 @[simp] theorem aleph'_le {o₁ o₂ : ordinal.{u}} : aleph' o₁ ≤ aleph' o₂ ↔ o₁ ≤ o₂ :=
 le_iff_le_iff_lt_iff_lt.2 aleph'_lt
@@ -2916,7 +2916,7 @@ begin
       simp only [s, embedding.coe_fn_mk, order.preimage, typein_lt_typein, prod.lex_def, typein_inj] at h,
       exact max_le_iff.1 (le_iff_lt_or_eq.2 $ h.imp_right and.left) },
     suffices H : (insert (g p) {x | r x (g p)} : set α) ≃ ({x | r x (g p)} ⊕ punit),
-    { exact ⟨(set.embedding_of_subset this).trans
+    { exact ⟨(set.embedding_of_subset _ _ this).trans
         ((equiv.set.prod _ _).trans (H.prod_congr H)).to_embedding⟩ },
     refine (equiv.set.insert _).trans
       ((equiv.refl _).sum_congr punit_equiv_punit),


### PR DESCRIPTION
* swap `inj` with `inj'` to match other bundled homomorphisms;
* make some arguments explicit to avoid `embedding.of_surjective _`
  in the pretty printer output;
* make `set_value` computable.