### PR TITLE
[Merged by Bors] - refactor(computability/reduce): define many-one degrees without parameter

### DIFF
--- a/src/computability/partrec.lean
+++ b/src/computability/partrec.lean
@@ -564,6 +564,17 @@ theorem option_map {f : α → option β} {g : α → β → σ}
   (hf : computable f) (hg : computable₂ g) : computable (λ a, (f a).map (g a)) :=
 option_bind hf (option_some.comp₂ hg)
 
+theorem option_get_or_else {f : α → option β} {g : α → β}
+  (hf : computable f) (hg : computable g) :
+  computable (λ a, (f a).get_or_else (g a)) :=
+(computable.option_cases hf hg (show computable₂ (λ a b, b), from computable.snd)).of_eq $
+λ a, by cases f a; refl
+
+theorem subtype_mk {f : α → β} {p : β → Prop} [decidable_pred p] {h : ∀ a, p (f a)}
+    (hp : primrec_pred p) (hf : computable f) :
+  @computable _ _ _ (primcodable.subtype hp) (λ a, (⟨f a, h a⟩ : subtype p)) :=
+nat.partrec.of_eq hf $ λ n, by cases decode α n; simp [subtype.encode_eq]
+
 theorem sum_cases
   {f : α → β ⊕ γ} {g : α → β → σ} {h : α → γ → σ}
   (hf : computable f) (hg : computable₂ g) (hh : computable₂ h) :

--- a/src/computability/reduce.lean
+++ b/src/computability/reduce.lean
@@ -50,10 +50,12 @@ theorem many_one_reducible.trans {α β γ} [primcodable α] [primcodable β] [p
 | ⟨f, c₁, h₁⟩ ⟨g, c₂, h₂⟩ := ⟨g ∘ f, c₂.comp c₁,
   λ a, ⟨λ h, by rwa [←h₂, ←h₁], λ h, by rwa [h₁, h₂]⟩⟩
 
-theorem reflexive_many_one_reducible {α} [primcodable α] : reflexive (@many_one_reducible α α _ _) :=
+theorem reflexive_many_one_reducible {α} [primcodable α] :
+  reflexive (@many_one_reducible α α _ _) :=
 many_one_reducible_refl
 
-theorem transitive_many_one_reducible {α} [primcodable α] : transitive (@many_one_reducible α α _ _) :=
+theorem transitive_many_one_reducible {α} [primcodable α] :
+  transitive (@many_one_reducible α α _ _) :=
 λ p q r, many_one_reducible.trans
 
 /--
@@ -82,17 +84,22 @@ theorem one_one_reducible.to_many_one {α β} [primcodable α] [primcodable β]
   {p : α → Prop} {q : β → Prop} : p ≤₁ q → p ≤₀ q
 | ⟨f, c, i, h⟩ := ⟨f, c, h⟩
 
-theorem one_one_reducible.of_equiv {α β} [primcodable α] [primcodable β] {e : α ≃ β} (q : β → Prop)
-  (h : computable e) : (q ∘ e) ≤₁ q := one_one_reducible.mk _ h e.injective
+theorem one_one_reducible.of_equiv {α β} [primcodable α] [primcodable β]
+    {e : α ≃ β} (q : β → Prop) (h : computable e) :
+  (q ∘ e) ≤₁ q :=
+one_one_reducible.mk _ h e.injective
 
-theorem one_one_reducible.of_equiv_symm {α β} [primcodable α] [primcodable β] {e : α ≃ β} (q : β → Prop)
-  (h : computable e.symm) : q ≤₁ (q ∘ e) :=
+theorem one_one_reducible.of_equiv_symm {α β} [primcodable α] [primcodable β]
+    {e : α ≃ β} (q : β → Prop) (h : computable e.symm) :
+  q ≤₁ (q ∘ e) :=
 by convert one_one_reducible.of_equiv _ h; funext; simp
 
-theorem reflexive_one_one_reducible {α} [primcodable α] : reflexive (@one_one_reducible α α _ _) :=
+theorem reflexive_one_one_reducible {α} [primcodable α] :
+  reflexive (@one_one_reducible α α _ _) :=
 one_one_reducible_refl
 
-theorem transitive_one_one_reducible {α} [primcodable α] : transitive (@one_one_reducible α α _ _) :=
+theorem transitive_one_one_reducible {α} [primcodable α] :
+  transitive (@one_one_reducible α α _ _) :=
 λ p q r, one_one_reducible.trans
 
 namespace computable_pred
@@ -139,7 +146,8 @@ theorem many_one_equiv.trans {α β γ} [primcodable α] [primcodable β] [primc
   many_one_equiv p q → many_one_equiv q r → many_one_equiv p r
 | ⟨pq, qp⟩ ⟨qr, rq⟩ := ⟨pq.trans qr, rq.trans qp⟩
 
-theorem equivalence_of_many_one_equiv {α} [primcodable α] : equivalence (@many_one_equiv α α _ _) :=
+theorem equivalence_of_many_one_equiv {α} [primcodable α] :
+  equivalence (@many_one_equiv α α _ _) :=
 ⟨many_one_equiv_refl, λ x y, many_one_equiv.symm, λ x y z, many_one_equiv.trans⟩
 
 @[refl]
@@ -164,7 +172,8 @@ theorem one_one_equiv.to_many_one {α β} [primcodable α] [primcodable β]
 | ⟨pq, qp⟩ := ⟨pq.to_many_one, qp.to_many_one⟩
 
 /-- a computable bijection -/
-def equiv.computable {α β} [primcodable α] [primcodable β] (e : α ≃ β) := computable e ∧ computable e.symm
+def equiv.computable {α β} [primcodable α] [primcodable β] (e : α ≃ β) :=
+computable e ∧ computable e.symm
 
 theorem equiv.computable.symm {α β} [primcodable α] [primcodable β] {e : α ≃ β} :
   e.computable → e.symm.computable := and.swap


### PR DESCRIPTION
The file `reduce.lean` defines many-one degrees for computable reductions.  At the moment every primcodable type `α` has a separate type of degrees `many_one_degree α`.  This is completely antithetical to the notion of degrees, which are introduced to classify problems up to many-one equivalence.

This PR defines a single `many_one_degree` type that lives in `Type 0`.  We use the `ulower` infrastructure from #2574 which shows that every type is computably equivalent to a subset of natural numbers.  The function `many_one_degree.of` which assigns to every set of a primcodable type a degree is still universe polymorphic.  In particular, we show that `of p = of q ↔ many_one_equiv p q`, etc. in maximal generality, where `p` and `q` are subsets of different types in different universes.

See previous discussion at #1203.