### PR TITLE
chore(*): unify use of left and right for injecitivity lemmas

### DIFF
--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -75,13 +75,13 @@ instance : has_insert α (multiset α) := ⟨cons⟩
 
 theorem singleton_coe (a : α) : (a::0 : multiset α) = ([a] : list α) := rfl
 
-@[simp] theorem cons_inj_left {a b : α} (s : multiset α) :
+@[simp] theorem cons_inj_right {a b : α} (s : multiset α) :
   a::s = b::s ↔ a = b :=
 ⟨quot.induction_on s $ λ l e,
   have [a] ++ l ~ [b] ++ l, from quotient.exact e,
   singleton_perm_singleton.1 $ (perm_append_right_iff _).1 this, congr_arg _⟩
 
-@[simp] theorem cons_inj_right (a : α) : ∀{s t : multiset α}, a::s = a::t ↔ s = t :=
+@[simp] theorem cons_inj_left (a : α) : ∀{s t : multiset α}, a::s = a::t ↔ s = t :=
 by rintros ⟨l₁⟩ ⟨l₂⟩; simp
 
 @[recursor 5] protected theorem induction {p : multiset α → Prop}
@@ -366,7 +366,7 @@ multiset.induction_on s (λ _, h₀) $ λ a s _ ih, h₁ _ _ $
 
 theorem mem_singleton_self (a : α) : a ∈ (a::0 : multiset α) := mem_cons_self _ _
 
-theorem singleton_inj {a b : α} : a::0 = b::0 ↔ a = b := cons_inj_left _
+theorem singleton_inj {a b : α} : a::0 = b::0 ↔ a = b := cons_inj_right _
 
 @[simp] theorem singleton_ne_zero (a : α) : a::0 ≠ 0 :=
 ne_of_gt (lt_cons_self _ _)
@@ -1420,7 +1420,7 @@ begin
   by_cases p a,
   { rw [filter_cons_of_pos _ h, sub_cons], congr,
     by_cases m : a ∈ s,
-    { rw [← cons_inj_right a, ← filter_cons_of_pos _ h,
+    { rw [← cons_inj_left a, ← filter_cons_of_pos _ h,
           cons_erase (mem_filter_of_mem m h), cons_erase m] },
     { rw [erase_of_not_mem m, erase_of_not_mem (mt mem_of_mem_filter m)] } },
   { rw [filter_cons_of_neg _ h],

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -914,29 +914,29 @@ lemma lt_pow_self {p : ℕ} (h : 1 < p) : ∀ n : ℕ, n < p ^ n
   n + 1 < p^n + 1 : nat.add_lt_add_right (lt_pow_self _) _
     ... ≤ p ^ (n+1) : pow_lt_pow_succ h _
 
-lemma pow_right_strict_mono {x : ℕ} (k : 2 ≤ x) : strict_mono (nat.pow x) :=
+lemma pow_left_strict_mono {x : ℕ} (k : 2 ≤ x) : strict_mono (nat.pow x) :=
 λ _ _, pow_lt_pow_of_lt_right k
 
 lemma pow_le_iff_le_right {x m n : ℕ} (k : 2 ≤ x) : x^m ≤ x^n ↔ m ≤ n :=
-strict_mono.le_iff_le (pow_right_strict_mono k)
+strict_mono.le_iff_le (pow_left_strict_mono k)
 
 lemma pow_lt_iff_lt_right {x m n : ℕ} (k : 2 ≤ x) : x^m < x^n ↔ m < n :=
-strict_mono.lt_iff_lt (pow_right_strict_mono k)
+strict_mono.lt_iff_lt (pow_left_strict_mono k)
 
-lemma pow_right_injective {x : ℕ} (k : 2 ≤ x) : function.injective (nat.pow x) :=
-strict_mono.injective (pow_right_strict_mono k)
+lemma pow_left_injective {x : ℕ} (k : 2 ≤ x) : function.injective (nat.pow x) :=
+strict_mono.injective (pow_left_strict_mono k)
 
-lemma pow_left_strict_mono {m : ℕ} (k : 1 ≤ m) : strict_mono (λ (x : ℕ), x^m) :=
+lemma pow_right_strict_mono {m : ℕ} (k : 1 ≤ m) : strict_mono (λ (x : ℕ), x^m) :=
 λ _ _ h, pow_lt_pow_of_lt_left h k
 
 lemma pow_le_iff_le_left {m x y : ℕ} (k : 1 ≤ m) : x^m ≤ y^m ↔ x ≤ y :=
-strict_mono.le_iff_le (pow_left_strict_mono k)
+strict_mono.le_iff_le (pow_right_strict_mono k)
 
 lemma pow_lt_iff_lt_left {m x y : ℕ} (k : 1 ≤ m) : x^m < y^m ↔ x < y :=
-strict_mono.lt_iff_lt (pow_left_strict_mono k)
+strict_mono.lt_iff_lt (pow_right_strict_mono k)
 
-lemma pow_left_injective {m : ℕ} (k : 1 ≤ m) : function.injective (λ (x : ℕ), x^m) :=
-strict_mono.injective (pow_left_strict_mono k)
+lemma pow_right_injective {m : ℕ} (k : 1 ≤ m) : function.injective (λ (x : ℕ), x^m) :=
+strict_mono.injective (pow_right_strict_mono k)
 
 lemma not_pos_pow_dvd : ∀ {p k : ℕ} (hp : 1 < p) (hk : 1 < k), ¬ p^k ∣ p
 | (succ p) (succ k) hp hk h :=

--- a/src/data/nat/multiplicity.lean
+++ b/src/data/nat/multiplicity.lean
@@ -171,12 +171,12 @@ le_antisymm
       assume i h1i hip h,
       refine lt_succ_of_le (le_of_not_gt (λ hin, _)),
       have hpik : ¬ p ^ i ∣ k, from mt (le_of_dvd hk0)
-        (not_le_of_gt (lt_of_le_of_lt hkn (pow_right_strict_mono hp.two_le hin))),
+        (not_le_of_gt (lt_of_le_of_lt hkn (pow_left_strict_mono hp.two_le hin))),
       have hpn : k % p ^ i + (p ^ n - k) % p ^ i < p ^ i,
         from calc k % p ^ i + (p ^ n - k) % p ^ i
               ≤ k + (p ^ n - k) : add_le_add (mod_le _ _) (mod_le _ _)
           ... = p ^ n : nat.add_sub_cancel' hkn
-          ... < p ^ i : pow_right_strict_mono hp.two_le hin,
+          ... < p ^ i : pow_left_strict_mono hp.two_le hin,
       simpa [hpik, not_le_of_gt hpn] using h
     end,
   begin

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -2048,7 +2048,7 @@ theorem power_le_power_iff_right {a b c : ordinal}
   (a1 : 1 < a) : a ^ b ≤ a ^ c ↔ b ≤ c :=
 (power_is_normal a1).le_iff
 
-theorem power_right_inj {a b c : ordinal}
+theorem power_left_inj {a b c : ordinal}
   (a1 : 1 < a) : a ^ b = a ^ c ↔ b = c :=
 (power_is_normal a1).inj
 


### PR DESCRIPTION
The convention used by the majority of lemmas stating that a function in two arguments is injective in one of the arguments is that the name of the lemma refers to the argument that stays fixed. Example:
```lean
lemma sub_left_inj : a - b = a - c ↔ b = c
```
This PR renames lemmas following the opposite convention.

See also the [Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/pow_(left.7Cright)_inj(ective)).