### PR TITLE
[Merged by Bors] - chore(*): unify use of left and right for injectivity lemmas

### DIFF
--- a/docs/contribute/naming.md
+++ b/docs/contribute/naming.md
@@ -45,6 +45,10 @@ of a theorem.
 - `le_of_mul_le_mul_left`
 - `le_of_mul_le_mul_right`
 
+An injectivity lemma that uses "left" or "right" should refer to the
+argument that "changes". For example, a lemma with the statement
+`a - b = a - c ↔ b = c` could be called `sub_right_inj`.
+
 We can also use the word "self" to indicate a repeated argument:
 
 - `mul_inv_self`

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -61,7 +61,7 @@ lemma dvd_and_not_dvd_iff [integral_domain α] {x y : α} :
 ⟨λ ⟨⟨d, hd⟩, hyx⟩, ⟨λ hx0, by simpa [hx0] using hyx, ⟨d,
     mt is_unit_iff_dvd_one.1 (λ ⟨e, he⟩, hyx ⟨e, by rw [hd, mul_assoc, ← he, mul_one]⟩), hd⟩⟩,
   λ ⟨hx0, d, hdu, hdx⟩, ⟨⟨d, hdx⟩, λ ⟨e, he⟩, hdu (is_unit_of_dvd_one _
-    ⟨e, (domain.mul_left_inj hx0).1 $ by conv {to_lhs, rw [he, hdx]};simp [mul_assoc]⟩)⟩⟩
+    ⟨e, (domain.mul_right_inj hx0).1 $ by conv {to_lhs, rw [he, hdx]};simp [mul_assoc]⟩)⟩⟩
 
 lemma pow_dvd_pow_iff [integral_domain α] {x : α} {n m : ℕ} (h0 : x ≠ 0) (h1 : ¬ is_unit x) :
   x ^ n ∣ x ^ m ↔ n ≤ m :=
@@ -169,7 +169,7 @@ lemma succ_dvd_or_succ_dvd_of_succ_sum_dvd_mul [integral_domain α] {p : α} (hp
 have h : p ^ (k + l) * (x * y) = p ^ (k + l) * (p * z),
   by simpa [mul_comm, _root_.pow_add, hx, hy, mul_assoc, mul_left_comm] using hz,
 have hp0: p ^ (k + l) ≠ 0, from pow_ne_zero _ hp.ne_zero,
-have hpd : p ∣ x * y, from ⟨z, by rwa [domain.mul_left_inj hp0] at h⟩,
+have hpd : p ∣ x * y, from ⟨z, by rwa [domain.mul_right_inj hp0] at h⟩,
 (hp.div_or_div hpd).elim
   (λ ⟨d, hd⟩, or.inl ⟨d, by simp [*, _root_.pow_succ, mul_comm, mul_left_comm, mul_assoc]⟩)
   (λ ⟨d, hd⟩, or.inr ⟨d, by simp [*, _root_.pow_succ, mul_comm, mul_left_comm, mul_assoc]⟩)
@@ -294,7 +294,7 @@ lemma irreducible_iff_of_associated [comm_semiring α] {p q : α} (h : p ~ᵤ q)
 lemma associated_mul_left_cancel [integral_domain α] {a b c d : α}
 (h : a * b ~ᵤ c * d) (h₁ : a ~ᵤ c) (ha : a ≠ 0) : b ~ᵤ d :=
 let ⟨u, hu⟩ := h in let ⟨v, hv⟩ := associated.symm h₁ in
-⟨u * (v : units α), (domain.mul_left_inj ha).1
+⟨u * (v : units α), (domain.mul_right_inj ha).1
   begin
     rw [← hv, mul_assoc c (v : α) d, mul_left_comm c, ← hu],
     simp [hv.symm, mul_assoc, mul_comm, mul_left_comm]

--- a/src/algebra/char_p.lean
+++ b/src/algebra/char_p.lean
@@ -73,7 +73,7 @@ theorem add_pow_char (α : Type u) [comm_ring α] {p : ℕ} (hp : nat.prime p)
   [char_p α p] (x y : α) : (x + y)^p = x^p + y^p :=
 begin
   rw [add_pow, finset.sum_range_succ, nat.sub_self, pow_zero, nat.choose_self],
-  rw [nat.cast_one, mul_one, mul_one, add_left_inj],
+  rw [nat.cast_one, mul_one, mul_one, add_right_inj],
   transitivity,
   { refine finset.sum_eq_single 0 _ _,
     { intros b h1 h2,

--- a/src/algebra/euclidean_domain.lean
+++ b/src/algebra/euclidean_domain.lean
@@ -281,7 +281,7 @@ begin
   suffices : x * y ∣ z * gcd x y,
   { cases this with p hp, use p,
     generalize_hyp : gcd x y = g at hxy hs hp ⊢, subst hs,
-    rw [mul_left_comm, mul_div_cancel_left _ hxy, ← domain.mul_right_inj hxy, hp],
+    rw [mul_left_comm, mul_div_cancel_left _ hxy, ← domain.mul_left_inj hxy, hp],
     rw [← mul_assoc], simp only [mul_right_comm] },
   rw [gcd_eq_gcd_ab, mul_add], apply dvd_add,
   { rw mul_left_comm, exact mul_dvd_mul_left _ (dvd_mul_of_dvd_left hyz _) },

--- a/src/algebra/field.lean
+++ b/src/algebra/field.lean
@@ -111,7 +111,7 @@ by haveI := classical.dec; exact not_iff_not.1 f.map_ne_zero
 lemma map_inv : f x⁻¹ = (f x)⁻¹ :=
 begin
   classical, by_cases h : x = 0, by simp [h],
-  apply (domain.mul_left_inj (f.map_ne_zero.2 h)).1,
+  apply (domain.mul_right_inj (f.map_ne_zero.2 h)).1,
   rw [mul_inv_cancel (f.map_ne_zero.2 h), ← f.map_mul, mul_inv_cancel h, f.map_one]
 end
 

--- a/src/algebra/gcd_domain.lean
+++ b/src/algebra/gcd_domain.lean
@@ -291,7 +291,7 @@ classical.by_cases (assume : lcm a b = 0, by rw [this, normalize_zero]) $
     rintros ⟨rfl, rfl⟩; left; refl) h_lcm,
   have h2 : normalize (gcd a b * lcm a b) = gcd a b * lcm a b,
     by rw [gcd_mul_lcm, normalize_idem],
-  by simpa only [normalize_mul, normalize_gcd, one_mul, domain.mul_left_inj h1] using h2
+  by simpa only [normalize_mul, normalize_gcd, one_mul, domain.mul_right_inj h1] using h2
 
 theorem lcm_comm (a b : α) : lcm a b = lcm b a :=
 dvd_antisymm_of_normalize_eq (normalize_lcm _ _) (normalize_lcm _ _)
@@ -573,7 +573,7 @@ lemma nat.prime_iff_prime {p : ℕ} : p.prime ↔ _root_.prime (p : ℕ) :=
         (λ ha, or.inr (nat.dvd_antisymm h ha))
         (λ hb, or.inl (have hpb : p = b, from nat.dvd_antisymm hb
             (hab.symm ▸ dvd_mul_left _ _),
-          (nat.mul_left_inj (show 0 < p, from
+          (nat.mul_right_inj (show 0 < p, from
               nat.pos_of_ne_zero hp.1)).1 $
             by rw [hpb, mul_comm, ← hab, hpb, mul_one]))⟩⟩
 

--- a/src/algebra/geom_sum.lean
+++ b/src/algebra/geom_sum.lean
@@ -148,7 +148,7 @@ have h₄ : x * (x ^ n)⁻¹ = (x ^ n)⁻¹ * x :=
   nat.rec_on n (by simp)
   (λ n h, by rw [pow_succ, mul_inv', ←mul_assoc, h, mul_assoc, mul_inv_cancel hx0, mul_assoc, inv_mul_cancel hx0]),
 begin
-  rw [geom_sum h₁, div_eq_iff_mul_eq h₂, ← domain.mul_left_inj h₃,
+  rw [geom_sum h₁, div_eq_iff_mul_eq h₂, ← domain.mul_right_inj h₃,
     ← mul_assoc, ← mul_assoc, mul_inv_cancel h₃],
   simp [mul_add, add_mul, mul_inv_cancel hx0, mul_assoc, h₄, sub_eq_add_neg, add_comm, add_left_comm],
 end

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -44,19 +44,19 @@ instance monoid_to_is_right_id [monoid M] : is_right_id M (*) 1 :=
 ⟨ monoid.mul_one ⟩
 
 @[to_additive]
-theorem mul_left_injective [left_cancel_semigroup M] (a : M) : function.injective ((*) a) :=
+theorem mul_right_injective [left_cancel_semigroup M] (a : M) : function.injective ((*) a) :=
 λ b c, mul_left_cancel
 
 @[to_additive]
-theorem mul_right_injective [right_cancel_semigroup M] (a : M) : function.injective (λ x, x * a) :=
+theorem mul_left_injective [right_cancel_semigroup M] (a : M) : function.injective (λ x, x * a) :=
 λ b c, mul_right_cancel
 
 @[simp, to_additive]
-theorem mul_left_inj [left_cancel_semigroup M] (a : M) {b c : M} : a * b = a * c ↔ b = c :=
+theorem mul_right_inj [left_cancel_semigroup M] (a : M) {b c : M} : a * b = a * c ↔ b = c :=
 ⟨mul_left_cancel, congr_arg _⟩
 
 @[simp, to_additive]
-theorem mul_right_inj [right_cancel_semigroup M] (a : M) {b c : M} : b * a = c * a ↔ b = c :=
+theorem mul_left_inj [right_cancel_semigroup M] (a : M) {b c : M} : b * a = c * a ↔ b = c :=
 ⟨mul_right_cancel, congr_arg _⟩
 
 @[to_additive]
@@ -85,7 +85,7 @@ inv_inj'.1
 
 @[to_additive]
 theorem mul_self_iff_eq_one : a * a = a ↔ a = 1 :=
-by have := @mul_left_inj _ _ a a 1; rwa mul_one at this
+by have := @mul_right_inj _ _ a a 1; rwa mul_one at this
 
 @[simp, to_additive]
 theorem inv_eq_one : a⁻¹ = 1 ↔ a = 1 :=
@@ -112,7 +112,7 @@ eq_comm.trans $ eq_inv_iff_eq_inv.trans eq_comm
 
 @[to_additive]
 theorem mul_eq_one_iff_eq_inv : a * b = 1 ↔ a = b⁻¹ :=
-by simpa [mul_left_inv, -mul_right_inj] using @mul_right_inj _ _ b a (b⁻¹)
+by simpa [mul_left_inv, -mul_left_inj] using @mul_left_inj _ _ b a (b⁻¹)
 
 @[to_additive]
 theorem mul_eq_one_iff_inv_eq : a * b = 1 ↔ a⁻¹ = b :=
@@ -173,11 +173,11 @@ variables [add_group A] {a b c d : A}
 
 local attribute [simp] sub_eq_add_neg
 
-@[simp] lemma sub_left_inj : a - b = a - c ↔ b = c :=
-(add_left_inj _).trans neg_inj'
+@[simp] lemma sub_right_inj : a - b = a - c ↔ b = c :=
+(add_right_inj _).trans neg_inj'
 
-@[simp] lemma sub_right_inj : b - a = c - a ↔ b = c :=
-add_right_inj _
+@[simp] lemma sub_left_inj : b - a = c - a ↔ b = c :=
+add_left_inj _
 
 lemma sub_add_sub_cancel (a b c : A) : (a - b) + (b - c) = a - c :=
 by rw [← add_sub_assoc, sub_add_cancel]

--- a/src/algebra/group/units.lean
+++ b/src/algebra/group/units.lean
@@ -100,10 +100,10 @@ by rw [mul_assoc, inv_mul, mul_one]
 
 @[to_additive] instance [has_repr α] : has_repr (units α) := ⟨repr ∘ val⟩
 
-@[simp, to_additive] theorem mul_left_inj (a : units α) {b c : α} : (a:α) * b = a * c ↔ b = c :=
+@[simp, to_additive] theorem mul_right_inj (a : units α) {b c : α} : (a:α) * b = a * c ↔ b = c :=
 ⟨λ h, by simpa only [inv_mul_cancel_left] using congr_arg ((*) ↑(a⁻¹ : units α)) h, congr_arg _⟩
 
-@[simp, to_additive] theorem mul_right_inj (a : units α) {b c : α} : b * a = c * a ↔ b = c :=
+@[simp, to_additive] theorem mul_left_inj (a : units α) {b c : α} : b * a = c * a ↔ b = c :=
 ⟨λ h, by simpa only [mul_inv_cancel_right] using congr_arg (* ↑(a⁻¹ : units α)) h, congr_arg _⟩
 
 @[to_additive] theorem eq_mul_inv_iff_mul_eq {a b : α} : a = b * ↑c⁻¹ ↔ a * c = b :=
@@ -160,17 +160,17 @@ section monoid
   @[simp] theorem mul_divp_cancel (a : α) (u : units α) : (a * u) /ₚ u = a :=
   (mul_assoc _ _ _).trans $ by rw [units.mul_inv, mul_one]
 
-  @[simp] theorem divp_right_inj (u : units α) {a b : α} : a /ₚ u = b /ₚ u ↔ a = b :=
-  units.mul_right_inj _
+  @[simp] theorem divp_left_inj (u : units α) {a b : α} : a /ₚ u = b /ₚ u ↔ a = b :=
+  units.mul_left_inj _
 
   theorem divp_divp_eq_divp_mul (x : α) (u₁ u₂ : units α) : (x /ₚ u₁) /ₚ u₂ = x /ₚ (u₂ * u₁) :=
   by simp only [divp, mul_inv_rev, units.coe_mul, mul_assoc]
 
   theorem divp_eq_iff_mul_eq {x : α} {u : units α} {y : α} : x /ₚ u = y ↔ y * u = x :=
-  u.mul_right_inj.symm.trans $ by rw [divp_mul_cancel]; exact ⟨eq.symm, eq.symm⟩
+  u.mul_left_inj.symm.trans $ by rw [divp_mul_cancel]; exact ⟨eq.symm, eq.symm⟩
 
   theorem divp_eq_one_iff_eq {a : α} {u : units α} : a /ₚ u = 1 ↔ a = u :=
-  (units.mul_right_inj u).symm.trans $ by rw [divp_mul_cancel, one_mul]
+  (units.mul_left_inj u).symm.trans $ by rw [divp_mul_cancel, one_mul]
 
   @[simp] theorem one_divp (u : units α) : 1 /ₚ u = ↑u⁻¹ :=
   one_mul _

--- a/src/algebra/group_power.lean
+++ b/src/algebra/group_power.lean
@@ -543,7 +543,7 @@ begin
   { rw [←h, zero_pow Hnpos], apply pow_pos (by rwa ←h at Hxy : 0 < y),}
 end
 
-theorem pow_right_inj {x y : R} {n : ℕ} (Hxpos : 0 ≤ x) (Hypos : 0 ≤ y) (Hnpos : 0 < n)
+theorem pow_left_inj {x y : R} {n : ℕ} (Hxpos : 0 ≤ x) (Hypos : 0 ≤ y) (Hnpos : 0 < n)
   (Hxyn : x ^ n = y ^ n) : x = y :=
 begin
   rcases lt_trichotomy x y with hxy | rfl | hyx,

--- a/src/algebra/group_with_zero.lean
+++ b/src/algebra/group_with_zero.lean
@@ -173,7 +173,7 @@ def mk0 (a : G₀) (ha : a ≠ 0) : units G₀ :=
 @[simp] lemma coe_mk0 {a : G₀} (h : a ≠ 0) : (mk0 a h : G₀) = a := rfl
 
 @[simp] theorem inv_eq_inv (u : units G₀) : (↑u⁻¹ : G₀) = u⁻¹ :=
-(mul_left_inj u).1 $ by { rw [units.mul_inv, mul_inv_cancel'], apply unit_ne_zero }
+(mul_right_inj u).1 $ by { rw [units.mul_inv, mul_inv_cancel'], apply unit_ne_zero }
 
 @[simp] lemma mk0_coe (u : units G₀) (h : (u : G₀) ≠ 0) : mk0 (u : G₀) h = u :=
 units.ext rfl
@@ -362,11 +362,11 @@ lemma div_eq_zero_iff (hb : b ≠ 0) : a / b = 0 ↔ a = 0 :=
 by haveI := classical.prop_decidable; exact
 not_iff_not.1 (div_ne_zero_iff hb)
 
-lemma div_right_inj' (hc : c ≠ 0) : a / c = b / c ↔ a = b :=
-by rw [← divp_mk0 _ hc, ← divp_mk0 _ hc, divp_right_inj]
+lemma div_left_inj' (hc : c ≠ 0) : a / c = b / c ↔ a = b :=
+by rw [← divp_mk0 _ hc, ← divp_mk0 _ hc, divp_left_inj]
 
-lemma mul_right_inj' (hc : c ≠ 0) : a * c = b * c ↔ a = b :=
-by rw [← inv_inv'' c, ← div_eq_mul_inv, ← div_eq_mul_inv, div_right_inj' (inv_ne_zero' hc)]
+lemma mul_left_inj' (hc : c ≠ 0) : a * c = b * c ↔ a = b :=
+by rw [← inv_inv'' c, ← div_eq_mul_inv, ← div_eq_mul_inv, div_left_inj' (inv_ne_zero' hc)]
 
 lemma div_eq_iff_mul_eq (hb : b ≠ 0) : a / b = c ↔ c * b = a :=
 ⟨λ h, by rw [← h, div_mul_cancel' _ hb],
@@ -488,7 +488,7 @@ by rw [← mul_div_assoc'', div_mul_cancel' _ hc]
 
 lemma div_eq_div_iff (hb : b ≠ 0) (hd : d ≠ 0) : a / b = c / d ↔ a * d = c * b :=
 calc a / b = c / d ↔ a / b * (b * d) = c / d * (b * d) :
-by rw [mul_right_inj' (mul_ne_zero'' hb hd)]
+by rw [mul_left_inj' (mul_ne_zero'' hb hd)]
                ... ↔ a * d = c * b :
 by rw [← mul_assoc, div_mul_cancel' _ hb,
       ← mul_assoc, mul_right_comm, div_mul_cancel' _ hd]

--- a/src/algebra/ring.lean
+++ b/src/algebra/ring.lean
@@ -498,11 +498,11 @@ end prio
 -- This could be generalized, for example if we added `nonzero_ring` into the hierarchy,
 -- but it doesn't seem worth doing just for these lemmas.
 lemma succ_ne_self [nonzero_comm_ring α] (a : α) : a + 1 ≠ a :=
-λ h, one_ne_zero ((add_left_inj a).mp (by simp [h]))
+λ h, one_ne_zero ((add_right_inj a).mp (by simp [h]))
 
 -- As with succ_ne_self.
 lemma pred_ne_self [nonzero_comm_ring α] (a : α) : a - 1 ≠ a :=
-λ h, one_ne_zero (neg_inj ((add_left_inj a).mp (by { convert h, simp })))
+λ h, one_ne_zero (neg_inj ((add_right_inj a).mp (by { convert h, simp })))
 
 /-- A nonzero commutative semiring is a nonzero semiring. -/
 @[priority 100] -- see Note [lower instance priority]
@@ -574,12 +574,12 @@ section domain
   λ h, or.elim (eq_zero_or_eq_zero_of_mul_eq_zero h) h₁ h₂
 
 /-- Right multiplication by a nonzero element in a domain is injective. -/
-  theorem domain.mul_right_inj {a b c : α} (ha : a ≠ 0) : b * a = c * a ↔ b = c :=
+  theorem domain.mul_left_inj {a b c : α} (ha : a ≠ 0) : b * a = c * a ↔ b = c :=
   by rw [← sub_eq_zero, ← mul_sub_right_distrib, mul_eq_zero];
      simp [ha]; exact sub_eq_zero
 
 /-- Left multiplication by a nonzero element in a domain is injective. -/
-  theorem domain.mul_left_inj {a b c : α} (ha : a ≠ 0) : a * b = a * c ↔ b = c :=
+  theorem domain.mul_right_inj {a b c : α} (ha : a ≠ 0) : a * b = a * c ↔ b = c :=
   by rw [← sub_eq_zero, ← mul_sub_left_distrib, mul_eq_zero];
      simp [ha]; exact sub_eq_zero
 
@@ -628,12 +628,12 @@ section
 /-- Given two elements b, c of an integral domain and a nonzero element a, a*b divides a*c iff
     b divides c. -/
   theorem mul_dvd_mul_iff_left {a b c : α} (ha : a ≠ 0) : a * b ∣ a * c ↔ b ∣ c :=
-  exists_congr $ λ d, by rw [mul_assoc, domain.mul_left_inj ha]
+  exists_congr $ λ d, by rw [mul_assoc, domain.mul_right_inj ha]
 
 /-- Given two elements a, b of an integral domain and a nonzero element c, a*c divides b*c iff
     a divides b. -/
   theorem mul_dvd_mul_iff_right {a b c : α} (hc : c ≠ 0) : a * c ∣ b * c ↔ a ∣ b :=
-  exists_congr $ λ d, by rw [mul_right_comm, domain.mul_right_inj hc]
+  exists_congr $ λ d, by rw [mul_right_comm, domain.mul_left_inj hc]
 
 /-- In the unit group of an integral domain, a unit is its own inverse iff the unit is one or
     one's additive inverse. -/

--- a/src/analysis/convex/basic.lean
+++ b/src/analysis/convex/basic.lean
@@ -105,7 +105,7 @@ lemma mem_segment_translate (a : E) {x b c} : a + x ∈ [a + b, a + c] ↔ x ∈
 begin
   rw [segment_eq_image', segment_eq_image'],
   refine exists_congr (λ θ, and_congr iff.rfl _),
-  simp only [add_sub_add_left_eq_sub, add_assoc, add_left_inj]
+  simp only [add_sub_add_left_eq_sub, add_assoc, add_right_inj]
 end
 
 lemma segment_translate_preimage (a b c : E) : (λ x, a + x) ⁻¹' [a + b, a + c] = [b, c] :=

--- a/src/analysis/special_functions/trigonometric.lean
+++ b/src/analysis/special_functions/trigonometric.lean
@@ -789,7 +789,7 @@ lemma cos_inj_of_nonneg_of_le_pi {x y : ℝ} (hx₁ : 0 ≤ x) (hx₂ : x ≤ π
   (hxy : cos x = cos y) : x = y :=
 begin
   rw [← sin_pi_div_two_sub, ← sin_pi_div_two_sub] at hxy,
-  refine (sub_left_inj).1 (sin_inj_of_le_of_le_pi_div_two _ _ _ _ hxy);
+  refine (sub_right_inj).1 (sin_inj_of_le_of_le_pi_div_two _ _ _ _ hxy);
   linarith
 end
 
@@ -893,7 +893,7 @@ begin
   split,
   { intro Hsin, rw [← cos_pi_div_two_sub, ← cos_pi_div_two_sub] at Hsin,
     cases cos_eq_iff_eq_or_eq_neg.mp Hsin with h h,
-    { left, rw coe_sub at h, exact sub_left_inj.1 h },
+    { left, rw coe_sub at h, exact sub_right_inj.1 h },
       right, rw [coe_sub, coe_sub, eq_neg_iff_add_eq_zero, add_sub,
       sub_add_eq_add_sub, ← coe_add, add_halves, sub_sub, sub_eq_zero] at h,
     exact h.symm },
@@ -1137,7 +1137,7 @@ have h₂ : (x / sqrt (1 + x ^ 2)) ^ 2 < 1,
 by rw [arctan, cos_arcsin (le_of_lt (neg_one_lt_div_sqrt_one_add _)) (le_of_lt (div_sqrt_one_add_lt_one _)),
     one_div_eq_inv, ← sqrt_inv, sqrt_inj (sub_nonneg.2 (le_of_lt h₂)) (inv_nonneg.2 (le_of_lt h₁)),
     div_pow, pow_two (sqrt _), mul_self_sqrt (le_of_lt h₁),
-    ← domain.mul_left_inj (ne.symm (ne_of_lt h₁)), mul_sub,
+    ← domain.mul_right_inj (ne.symm (ne_of_lt h₁)), mul_sub,
     mul_div_cancel' _ (ne.symm (ne_of_lt h₁)), mul_inv_cancel (ne.symm (ne_of_lt h₁))];
   simp
 

--- a/src/combinatorics/composition.lean
+++ b/src/combinatorics/composition.lean
@@ -662,7 +662,7 @@ def composition_as_set_equiv (n : ℕ) : composition_as_set n ≃ finset (fin (n
     ext i,
     have : 1 + i.val ≠ n,
       by { apply ne_of_lt, have := i.2, omega },
-    simp only [fin.ext_iff, this, exists_prop, fin.val_zero, false_or, add_left_inj, add_comm,
+    simp only [fin.ext_iff, this, exists_prop, fin.val_zero, false_or, add_right_inj, add_comm,
       set.mem_to_finset, true_or, add_eq_zero_iff, or_true, one_ne_zero, set.mem_set_of_eq,
       fin.last_val, false_and],
     split,

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -417,7 +417,7 @@ lemma exp_ne_zero : exp x ≠ 0 :=
   by rw [← exp_zero, ← add_neg_self x, exp_add, h]; simp
 
 lemma exp_neg : exp (-x) = (exp x)⁻¹ :=
-by rw [← domain.mul_left_inj (exp_ne_zero x), ← exp_add];
+by rw [← domain.mul_right_inj (exp_ne_zero x), ← exp_add];
   simp [mul_inv_cancel (exp_ne_zero x)]
 
 lemma exp_sub : exp (x - y) = exp x / exp y :=
@@ -461,10 +461,10 @@ private lemma sinh_add_aux {a b c d : ℂ} :
 
 lemma sinh_add : sinh (x + y) = sinh x * cosh y + cosh x * sinh y :=
 begin
-  rw [← domain.mul_left_inj (@two_ne_zero' ℂ _ _ _), two_sinh,
+  rw [← domain.mul_right_inj (@two_ne_zero' ℂ _ _ _), two_sinh,
       exp_add, neg_add, exp_add, eq_comm,
       mul_add, ← mul_assoc, two_sinh, mul_left_comm, two_sinh,
-      ← domain.mul_left_inj (@two_ne_zero' ℂ _ _ _), mul_add,
+      ← domain.mul_right_inj (@two_ne_zero' ℂ _ _ _), mul_add,
       mul_left_comm, two_cosh, ← mul_assoc, two_cosh],
   exact sinh_add_aux
 end
@@ -479,10 +479,10 @@ private lemma cosh_add_aux {a b c d : ℂ} :
 
 lemma cosh_add : cosh (x + y) = cosh x * cosh y + sinh x * sinh y :=
 begin
-  rw [← domain.mul_left_inj (@two_ne_zero' ℂ _ _ _), two_cosh,
+  rw [← domain.mul_right_inj (@two_ne_zero' ℂ _ _ _), two_cosh,
       exp_add, neg_add, exp_add, eq_comm,
       mul_add, ← mul_assoc, two_cosh, ← mul_assoc, two_sinh,
-      ← domain.mul_left_inj (@two_ne_zero' ℂ _ _ _), mul_add,
+      ← domain.mul_right_inj (@two_ne_zero' ℂ _ _ _), mul_add,
       mul_left_comm, two_cosh, mul_left_comm, two_sinh],
   exact cosh_add_aux
 end
@@ -542,14 +542,14 @@ by rw [← of_real_tanh_of_real_re, of_real_im]
 lemma tanh_of_real_re (x : ℝ) : (tanh x).re = real.tanh x := rfl
 
 lemma cosh_add_sinh : cosh x + sinh x = exp x :=
-by rw [← domain.mul_left_inj (@two_ne_zero' ℂ _ _ _), mul_add,
+by rw [← domain.mul_right_inj (@two_ne_zero' ℂ _ _ _), mul_add,
        two_cosh, two_sinh, add_add_sub_cancel, two_mul]
 
 lemma sinh_add_cosh : sinh x + cosh x = exp x :=
 by rw [add_comm, cosh_add_sinh]
 
 lemma cosh_sub_sinh : cosh x - sinh x = exp (-x) :=
-by rw [← domain.mul_left_inj (@two_ne_zero' ℂ _ _ _), mul_sub,
+by rw [← domain.mul_right_inj (@two_ne_zero' ℂ _ _ _), mul_sub,
        two_cosh, two_sinh, add_sub_sub_cancel, two_mul]
 
 lemma cosh_sq_sub_sinh_sq : cosh x ^ 2 - sinh x ^ 2 = 1 :=
@@ -567,16 +567,16 @@ lemma two_cos : 2 * cos x = exp (x * I) + exp (-x * I) :=
 mul_div_cancel' _ two_ne_zero'
 
 lemma sinh_mul_I : sinh (x * I) = sin x * I :=
-by rw [← domain.mul_left_inj (@two_ne_zero' ℂ _ _ _), two_sinh,
+by rw [← domain.mul_right_inj (@two_ne_zero' ℂ _ _ _), two_sinh,
        ← mul_assoc, two_sin, mul_assoc, I_mul_I, mul_neg_one,
        neg_sub, neg_mul_eq_neg_mul]
 
 lemma cosh_mul_I : cosh (x * I) = cos x :=
-by rw [← domain.mul_left_inj (@two_ne_zero' ℂ _ _ _), two_cosh,
+by rw [← domain.mul_right_inj (@two_ne_zero' ℂ _ _ _), two_cosh,
        two_cos, neg_mul_eq_neg_mul]
 
 lemma sin_add : sin (x + y) = sin x * cos y + cos x * sin y :=
-by rw [← domain.mul_right_inj I_ne_zero, ← sinh_mul_I,
+by rw [← domain.mul_left_inj I_ne_zero, ← sinh_mul_I,
        add_mul, add_mul, mul_right_comm, ← sinh_mul_I,
        mul_assoc, ← sinh_mul_I, ← cosh_mul_I, ← cosh_mul_I, sinh_add]
 
@@ -601,7 +601,7 @@ lemma cos_sub : cos (x - y) = cos x * cos y + sin x * sin y :=
 by simp [sub_eq_add_neg, cos_add, sin_neg, cos_neg]
 
 lemma sin_conj : sin (conj x) = conj (sin x) :=
-by rw [← domain.mul_right_inj I_ne_zero, ← sinh_mul_I,
+by rw [← domain.mul_left_inj I_ne_zero, ← sinh_mul_I,
        ← conj_neg_I, ← conj_mul, ← conj_mul, sinh_conj,
        mul_neg_eq_neg_mul_symm, sinh_neg, sinh_mul_I, mul_neg_eq_neg_mul_symm]
 
@@ -900,7 +900,7 @@ calc (filter (λ k, n ≤ k) (range j)).sum (λ m : ℕ, (1 / m.fact : α))
       (by simp at hm; tauto))
     (λ m hm, by rw nat.sub_add_cancel; simp at *; tauto)
     (λ a₁ a₂ ha₁ ha₂ h,
-      by rwa [nat.sub_eq_iff_eq_add, ← nat.sub_add_comm, eq_comm, nat.sub_eq_iff_eq_add, add_right_inj, eq_comm] at h;
+      by rwa [nat.sub_eq_iff_eq_add, ← nat.sub_add_comm, eq_comm, nat.sub_eq_iff_eq_add, add_left_inj, eq_comm] at h;
         simp at *; tauto)
     (λ b hb, ⟨b + n, mem_filter.2 ⟨mem_range.2 $ nat.add_lt_of_lt_sub_right (mem_range.1 hb), nat.le_add_left _ _⟩,
       by rw nat.add_sub_cancel⟩)

--- a/src/data/finsupp.lean
+++ b/src/data/finsupp.lean
@@ -187,7 +187,7 @@ begin
     { rw [single_zero, single_zero] } }
 end
 
-lemma single_right_inj (h : b ≠ 0) :
+lemma single_left_inj (h : b ≠ 0) :
   single a b = single a' b ↔ a = a' :=
 ⟨λ H, by simpa only [h, single_eq_single_iff,
   and_false, or_false, eq_self_iff_true, and_true] using H,

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -759,7 +759,7 @@ have hln' : (perms_of_list l).nodup, from nodup_perms_of_list hl',
 have hmeml : ∀ {f : perm α}, f ∈ perms_of_list l → f a = a,
   from λ f hf, not_not.1 (mt (mem_of_mem_perms_of_list hf) (nodup_cons.1 hl).1),
 by rw [perms_of_list, list.nodup_append, list.nodup_bind, pairwise_iff_nth_le]; exact
-⟨hln', ⟨λ _ _, nodup_map (λ _ _, (mul_left_inj _).1) hln',
+⟨hln', ⟨λ _ _, nodup_map (λ _ _, (mul_right_inj _).1) hln',
   λ i j hj hij x hx₁ hx₂,
     let ⟨f, hf⟩ := list.mem_map.1 hx₁ in
     let ⟨g, hg⟩ := list.mem_map.1 hx₂ in

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -366,32 +366,32 @@ theorem append_inj : ∀ {s₁ s₂ t₁ t₂ : list α}, s₁ ++ t₁ = s₂ ++
   let ⟨e1, e2⟩ := @append_inj s₁ s₂ t₁ t₂ hap (succ.inj hl) in
   by rw [ab, e1, e2]; exact ⟨rfl, rfl⟩
 
-theorem append_inj_left {s₁ s₂ t₁ t₂ : list α} (h : s₁ ++ t₁ = s₂ ++ t₂) (hl : length s₁ = length s₂) : t₁ = t₂ :=
+theorem append_inj_right {s₁ s₂ t₁ t₂ : list α} (h : s₁ ++ t₁ = s₂ ++ t₂) (hl : length s₁ = length s₂) : t₁ = t₂ :=
 (append_inj h hl).right
 
-theorem append_inj_right {s₁ s₂ t₁ t₂ : list α} (h : s₁ ++ t₁ = s₂ ++ t₂) (hl : length s₁ = length s₂) : s₁ = s₂ :=
+theorem append_inj_left {s₁ s₂ t₁ t₂ : list α} (h : s₁ ++ t₁ = s₂ ++ t₂) (hl : length s₁ = length s₂) : s₁ = s₂ :=
 (append_inj h hl).left
 
 theorem append_inj' {s₁ s₂ t₁ t₂ : list α} (h : s₁ ++ t₁ = s₂ ++ t₂) (hl : length t₁ = length t₂) : s₁ = s₂ ∧ t₁ = t₂ :=
 append_inj h $ @nat.add_right_cancel _ (length t₁) _ $
 let hap := congr_arg length h in by simp only [length_append] at hap; rwa [← hl] at hap
 
-theorem append_inj_left' {s₁ s₂ t₁ t₂ : list α} (h : s₁ ++ t₁ = s₂ ++ t₂) (hl : length t₁ = length t₂) : t₁ = t₂ :=
+theorem append_inj_right' {s₁ s₂ t₁ t₂ : list α} (h : s₁ ++ t₁ = s₂ ++ t₂) (hl : length t₁ = length t₂) : t₁ = t₂ :=
 (append_inj' h hl).right
 
-theorem append_inj_right' {s₁ s₂ t₁ t₂ : list α} (h : s₁ ++ t₁ = s₂ ++ t₂) (hl : length t₁ = length t₂) : s₁ = s₂ :=
+theorem append_inj_left' {s₁ s₂ t₁ t₂ : list α} (h : s₁ ++ t₁ = s₂ ++ t₂) (hl : length t₁ = length t₂) : s₁ = s₂ :=
 (append_inj' h hl).left
 
 theorem append_left_cancel {s t₁ t₂ : list α} (h : s ++ t₁ = s ++ t₂) : t₁ = t₂ :=
-append_inj_left h rfl
+append_inj_right h rfl
 
 theorem append_right_cancel {s₁ s₂ t : list α} (h : s₁ ++ t = s₂ ++ t) : s₁ = s₂ :=
-append_inj_right' h rfl
+append_inj_left' h rfl
 
-theorem append_left_inj {t₁ t₂ : list α} (s) : s ++ t₁ = s ++ t₂ ↔ t₁ = t₂ :=
+theorem append_right_inj {t₁ t₂ : list α} (s) : s ++ t₁ = s ++ t₂ ↔ t₁ = t₂ :=
 ⟨append_left_cancel, congr_arg _⟩
 
-theorem append_right_inj {s₁ s₂ : list α} (t) : s₁ ++ t = s₂ ++ t ↔ s₁ = s₂ :=
+theorem append_left_inj {s₁ s₂ : list α} (t) : s₁ ++ t = s₂ ++ t ↔ s₁ = s₂ :=
 ⟨append_right_cancel, congr_arg _⟩
 
 theorem map_eq_append_split {f : α → β} {l : list α} {s₁ s₂ : list β}
@@ -2586,11 +2586,11 @@ theorem infix_of_mem_join : ∀ {L : list (list α)} {l}, l ∈ L → l <:+: joi
 | (l' :: L) l (or.inr h)   :=
   is_infix.trans (infix_of_mem_join h) $ infix_of_suffix $ suffix_append _ _
 
-theorem prefix_append_left_inj {l₁ l₂ : list α} (l) : l ++ l₁ <+: l ++ l₂ ↔ l₁ <+: l₂ :=
-exists_congr $ λ r, by rw [append_assoc, append_left_inj]
+theorem prefix_append_right_inj {l₁ l₂ : list α} (l) : l ++ l₁ <+: l ++ l₂ ↔ l₁ <+: l₂ :=
+exists_congr $ λ r, by rw [append_assoc, append_right_inj]
 
 theorem prefix_cons_inj {l₁ l₂ : list α} (a) : a :: l₁ <+: a :: l₂ ↔ l₁ <+: l₂ :=
-prefix_append_left_inj [a]
+prefix_append_right_inj [a]
 
 theorem take_prefix (n) (l : list α) : take n l <+: l := ⟨_, take_append_drop _ _⟩
 

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -461,17 +461,17 @@ nat.pos_of_ne_zero (λ h, lt_irrefl a
       ... < b : nat.mod_lt a hb
       ... ≤ a : hba))
 
-protected theorem mul_right_inj {a b c : ℕ} (ha : 0 < a) : b * a = c * a ↔ b = c :=
+protected theorem mul_left_inj {a b c : ℕ} (ha : 0 < a) : b * a = c * a ↔ b = c :=
 ⟨nat.eq_of_mul_eq_mul_right ha, λ e, e ▸ rfl⟩
 
-protected theorem mul_left_inj {a b c : ℕ} (ha : 0 < a) : a * b = a * c ↔ b = c :=
+protected theorem mul_right_inj {a b c : ℕ} (ha : 0 < a) : a * b = a * c ↔ b = c :=
 ⟨nat.eq_of_mul_eq_mul_left ha, λ e, e ▸ rfl⟩
 
 protected lemma div_div_self : ∀ {a b : ℕ}, b ∣ a → 0 < a → a / (a / b) = b
 | a     0     h₁ h₂ := by rw eq_zero_of_zero_dvd h₁; refl
 | 0     b     h₁ h₂ := absurd h₂ dec_trivial
 | (a+1) (b+1) h₁ h₂ :=
-(nat.mul_right_inj (nat.div_pos (le_of_dvd (succ_pos a) h₁) (succ_pos b))).1 $
+(nat.mul_left_inj (nat.div_pos (le_of_dvd (succ_pos a) h₁) (succ_pos b))).1 $
   by rw [nat.div_mul_cancel (div_dvd_of_dvd h₁), nat.mul_div_cancel' h₁]
 
 protected lemma div_lt_of_lt_mul {m n k : ℕ} (h : m < n * k) : m / n < k :=
@@ -486,7 +486,7 @@ lt_of_not_ge $ not_le_of_gt h ∘ (nat.le_div_iff_mul_le _ _ w).2
 
 protected lemma div_eq_zero_iff {a b : ℕ} (hb : 0 < b) : a / b = 0 ↔ a < b :=
 ⟨λ h, by rw [← mod_add_div a b, h, mul_zero, add_zero]; exact mod_lt _ hb,
-  λ h, by rw [← nat.mul_left_inj hb, ← @add_left_cancel_iff _ _ (a % b), mod_add_div,
+  λ h, by rw [← nat.mul_right_inj hb, ← @add_left_cancel_iff _ _ (a % b), mod_add_div,
     mod_eq_of_lt h, mul_zero, add_zero]⟩
 
 lemma eq_zero_of_le_div {a b : ℕ} (hb : 2 ≤ b) (h : a ≤ a / b) : a = 0 :=
@@ -545,10 +545,10 @@ nat.dvd_add_right (dvd_refl m)
 nat.dvd_add_left (dvd_refl m)
 
 protected theorem mul_dvd_mul_iff_left {a b c : ℕ} (ha : 0 < a) : a * b ∣ a * c ↔ b ∣ c :=
-exists_congr $ λ d, by rw [mul_assoc, nat.mul_left_inj ha]
+exists_congr $ λ d, by rw [mul_assoc, nat.mul_right_inj ha]
 
 protected theorem mul_dvd_mul_iff_right {a b c : ℕ} (hc : 0 < c) : a * c ∣ b * c ↔ a ∣ b :=
-exists_congr $ λ d, by rw [mul_right_comm, nat.mul_right_inj hc]
+exists_congr $ λ d, by rw [mul_right_comm, nat.mul_left_inj hc]
 
 lemma succ_div : ∀ (a b : ℕ), (a + 1) / b =
   a / b + if b ∣ a + 1 then 1 else 0
@@ -678,7 +678,7 @@ lemma mul_eq_one_iff : ∀ {a b : ℕ}, a * b = 1 ↔ a = 1 ∧ b = 1
 
 lemma mul_right_eq_self_iff {a b : ℕ} (ha : 0 < a) : a * b = a ↔ b = 1 :=
 suffices a * b = a * 1 ↔ b = 1, by rwa mul_one at this,
-nat.mul_left_inj ha
+nat.mul_right_inj ha
 
 lemma mul_left_eq_self_iff {a b : ℕ} (hb : 0 < b) : a * b = b ↔ a = 1 :=
 by rw [mul_comm, nat.mul_right_eq_self_iff hb]

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -150,7 +150,7 @@ modeq.modeq_of_modeq_mul_left _ (modeq.mod_modeq _ _)
 lemma div_mod_eq_mod_mul_div (a b c : ℕ) : a / b % c = a % (b * c) / b :=
 if hb0 : b = 0 then by simp [hb0]
 else by rw [← @add_right_cancel_iff _ _ (c * (a / b / c)), mod_add_div, nat.div_div_eq_div_mul,
-  ← nat.mul_left_inj (nat.pos_of_ne_zero hb0),← @add_left_cancel_iff _ _ (a % b), mod_add_div,
+  ← nat.mul_right_inj (nat.pos_of_ne_zero hb0),← @add_left_cancel_iff _ _ (a % b), mod_add_div,
   mul_add, ← @add_left_cancel_iff _ _ (a % (b * c) % b), add_left_comm,
   ← add_assoc (a % (b * c) % b), mod_add_div, ← mul_assoc, mod_add_div, mod_mul_right_mod]
 
@@ -184,7 +184,7 @@ by rw [← add_mod_add_ite, if_pos hc]
 lemma add_div {a b c : ℕ} (hc0 : 0 < c) : (a + b) / c = a / c + b / c +
   if c ≤ a % c + b % c then 1 else 0 :=
 begin
-  rw [← nat.mul_left_inj hc0, ← @add_left_cancel_iff _ _ ((a + b) % c + a % c + b % c)],
+  rw [← nat.mul_right_inj hc0, ← @add_left_cancel_iff _ _ ((a + b) % c + a % c + b % c)],
   suffices : (a + b) % c + c * ((a + b) / c) + a % c + b % c =
     a % c + c * (a / c) + (b % c + c * (b / c)) + c * (if c ≤ a % c + b % c then 1 else 0) + (a + b) % c,
   { simpa only [mul_add, add_comm, add_left_comm, add_assoc] },
@@ -219,7 +219,7 @@ lemma odd_mul_odd_div_two {m n : ℕ} (hm1 : m % 2 = 1) (hn1 : n % 2 = 1) :
   (m * n) / 2 = m * (n / 2) + m / 2 :=
 have hm0 : 0 < m := nat.pos_of_ne_zero (λ h, by simp * at *),
 have hn0 : 0 < n := nat.pos_of_ne_zero (λ h, by simp * at *),
-(nat.mul_left_inj (show 0 < 2, from dec_trivial)).1 $
+(nat.mul_right_inj (show 0 < 2, from dec_trivial)).1 $
 by rw [mul_add, two_mul_odd_div_two hm1, mul_left_comm, two_mul_odd_div_two hn1,
   two_mul_odd_div_two (nat.odd_mul_odd hm1 hn1), nat.mul_sub_left_distrib, mul_one,
   ← nat.add_sub_assoc hm0, nat.sub_add_cancel (le_mul_of_one_le_right' (nat.zero_le _) hn0)]

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -356,12 +356,12 @@ begin
   wlog := hp.dvd_mul.1 pdvdxy using x y,
   cases case with a ha,
   have hap : a ∣ p, from ⟨y, by rwa [ha, nat.pow_two,
-        mul_assoc, nat.mul_left_inj hp.pos, eq_comm] at h⟩,
+        mul_assoc, nat.mul_right_inj hp.pos, eq_comm] at h⟩,
   exact ((nat.dvd_prime hp).1 hap).elim
-    (λ _, by clear_aux_decl; simp [*, nat.pow_two, nat.mul_left_inj hp.pos] at *
+    (λ _, by clear_aux_decl; simp [*, nat.pow_two, nat.mul_right_inj hp.pos] at *
       {contextual := tt})
     (λ _, by clear_aux_decl; simp [*, nat.pow_two, mul_comm, mul_assoc,
-      nat.mul_left_inj hp.pos, nat.mul_right_eq_self_iff hp.pos] at *
+      nat.mul_right_inj hp.pos, nat.mul_right_eq_self_iff hp.pos] at *
       {contextual := tt})
 end,
 λ ⟨h₁, h₂⟩, h₁.symm ▸ h₂.symm ▸ (nat.pow_two _).symm⟩
@@ -400,7 +400,7 @@ begin
     { apply pp.not_dvd_one.elim,
       simp at e, rw ← e, apply dvd_mul_right },
     { refine ⟨k, le_of_succ_le_succ h, _⟩,
-      rwa [mul_comm, pow_succ, nat.mul_right_inj pp.pos] at e } },
+      rwa [mul_comm, pow_succ, nat.mul_left_inj pp.pos] at e } },
   { split; intro d,
     { rw (pp.coprime_pow_of_not_dvd h).eq_one_of_dvd d,
       exact ⟨0, zero_le _, rfl⟩ },
@@ -443,7 +443,7 @@ lemma perm_of_prod_eq_prod : ∀ {l₁ l₂ : list ℕ}, prod l₁ = prod l₂ �
     (h ▸ by rw prod_cons; exact dvd_mul_right _ _),
   have hb : b :: l₂ ~ a :: (b :: l₂).erase a := perm_cons_erase ha,
   have hl : prod l₁ = prod ((b :: l₂).erase a) :=
-  (nat.mul_left_inj (prime.pos (hl₁ a (mem_cons_self _ _)))).1 $
+  (nat.mul_right_inj (prime.pos (hl₁ a (mem_cons_self _ _)))).1 $
     by rwa [← prod_cons, ← prod_cons, ← hb.prod_eq],
   perm.trans ((perm_of_prod_eq_prod hl hl₁' hl₂').cons _) hb.symm
 

--- a/src/data/nat/totient.lean
+++ b/src/data/nat/totient.lean
@@ -37,13 +37,13 @@ calc ((range n.succ).filter (∣ n)).sum φ
     (λ a b ha hb h,
       have ha : a * (n / a) = n, from nat.mul_div_cancel' (mem_filter.1 ha).2,
       have 0 < (n / a), from nat.pos_of_ne_zero (λ h, by simp [*, lt_irrefl] at *),
-      by rw [← nat.mul_right_inj this, ha, h, nat.mul_div_cancel' (mem_filter.1 hb).2])
+      by rw [← nat.mul_left_inj this, ha, h, nat.mul_div_cancel' (mem_filter.1 hb).2])
     (λ b hb,
       have hb : b < n.succ ∧ b ∣ n, by simpa [-range_succ] using hb,
       have hbn : (n / b) ∣ n, from ⟨b, by rw nat.div_mul_cancel hb.2⟩,
       have hnb0 : (n / b) ≠ 0, from λ h, by simpa [h, ne.symm hn0] using nat.div_mul_cancel hbn,
       ⟨n / b, mem_filter.2 ⟨mem_range.2 $ lt_succ_of_le $ nat.div_le_self _ _, hbn⟩,
-        by rw [← nat.mul_right_inj (nat.pos_of_ne_zero hnb0),
+        by rw [← nat.mul_left_inj (nat.pos_of_ne_zero hnb0),
           nat.mul_div_cancel' hb.2, nat.div_mul_cancel hbn]⟩)
 ... = ((range n.succ).filter (∣ n)).sum (λ d, ((range n).filter (λ m, gcd n m = d)).card) :
   sum_congr rfl (λ d hd,
@@ -54,7 +54,7 @@ calc ((range n.succ).filter (∣ n)).sum φ
         mem_filter.2 ⟨mem_range.2 $ nat.mul_div_cancel' hd ▸
           (mul_lt_mul_left hd0).2 hm.1,
           by rw [← nat.mul_div_cancel' hd, gcd_mul_left, hm.2, mul_one]⟩)
-      (λ a b ha hb h, (nat.mul_left_inj hd0).1 h)
+      (λ a b ha hb h, (nat.mul_right_inj hd0).1 h)
       (λ b hb, have hb : b < n ∧ gcd n b = d, by simpa using hb,
         ⟨b / d, mem_filter.2 ⟨mem_range.2 ((mul_lt_mul_left (show 0 < d, from hb.2 ▸ hb.2.symm ▸ hd0)).1
             (by rw [← hb.2, nat.mul_div_cancel' (gcd_dvd_left _ _),
@@ -71,4 +71,3 @@ calc ((range n.succ).filter (∣ n)).sum φ
 ... = n : card_range _
 
 end nat
-

--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -94,14 +94,14 @@ instance : add_left_cancel_semigroup ℕ+ :=
 { add_left_cancel := λ a b c h, by {
     replace h := congr_arg (coe : ℕ+ → ℕ) h,
     rw [add_coe, add_coe] at h,
-    exact eq ((add_left_inj (a : ℕ)).mp h)},
+    exact eq ((add_right_inj (a : ℕ)).mp h)},
   .. (pnat.add_comm_semigroup) }
 
 instance : add_right_cancel_semigroup ℕ+ :=
 { add_right_cancel := λ a b c h, by {
     replace h := congr_arg (coe : ℕ+ → ℕ) h,
     rw [add_coe, add_coe] at h,
-    exact eq ((add_right_inj (b : ℕ)).mp h)},
+    exact eq ((add_left_inj (b : ℕ)).mp h)},
   .. (pnat.add_comm_semigroup) }
 
 @[simp] theorem ne_zero (n : ℕ+) : (n : ℕ) ≠ 0 := ne_of_gt n.2
@@ -167,13 +167,13 @@ by induction n with n ih;
 instance : left_cancel_semigroup ℕ+ :=
 { mul_left_cancel := λ a b c h, by {
    replace h := congr_arg (coe : ℕ+ → ℕ) h,
-   exact eq ((nat.mul_left_inj a.pos).mp h)},
+   exact eq ((nat.mul_right_inj a.pos).mp h)},
   .. (pnat.comm_monoid) }
 
 instance : right_cancel_semigroup ℕ+ :=
 { mul_right_cancel := λ a b c h, by {
    replace h := congr_arg (coe : ℕ+ → ℕ) h,
-   exact eq ((nat.mul_right_inj b.pos).mp h)},
+   exact eq ((nat.mul_left_inj b.pos).mp h)},
   .. (pnat.comm_monoid) }
 
 instance : distrib ℕ+ :=

--- a/src/data/real/cau_seq.lean
+++ b/src/data/real/cau_seq.lean
@@ -40,7 +40,7 @@ variables {α : Type*} [discrete_linear_ordered_field α]
 theorem abv_zero : abv 0 = 0 := (abv_eq_zero abv).2 rfl
 
 theorem abv_one' (h : (1:β) ≠ 0) : abv 1 = 1 :=
-(domain.mul_left_inj $ mt (abv_eq_zero abv).1 h).1 $
+(domain.mul_right_inj $ mt (abv_eq_zero abv).1 h).1 $
 by rw [← abv_mul abv, mul_one, mul_one]
 
 theorem abv_one

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -469,11 +469,11 @@ Inf_le_Inf $ assume e (h : b ≤ e + d),
 @[simp] lemma add_sub_self' (h : a < ∞) : (a + b) - a = b :=
 by rw [add_comm, add_sub_self h]
 
-lemma add_left_inj (h : a < ∞) : a + b = a + c ↔ b = c :=
+lemma add_right_inj (h : a < ∞) : a + b = a + c ↔ b = c :=
 ⟨λ e, by simpa [h] using congr_arg (λ x, x - a) e, congr_arg _⟩
 
-lemma add_right_inj (h : a < ∞) : b + a = c + a ↔ b = c :=
-by rw [add_comm, add_comm c, add_left_inj h]
+lemma add_left_inj (h : a < ∞) : b + a = c + a ↔ b = c :=
+by rw [add_comm, add_comm c, add_right_inj h]
 
 @[simp] lemma sub_add_cancel_of_le : ∀{a b : ennreal}, b ≤ a → (a - b) + b = a :=
 begin
@@ -552,10 +552,10 @@ calc a ≤ a - b + b : le_sub_add_self
 ... = a - b + (b - c) + c : (add_assoc _ _ _).symm
 
 lemma sub_sub_cancel (h : a < ∞) (h2 : b ≤ a) : a - (a - b) = b :=
-by rw [← add_right_inj (lt_of_le_of_lt (sub_le_self _ _) h),
+by rw [← add_left_inj (lt_of_le_of_lt (sub_le_self _ _) h),
   sub_add_cancel_of_le (sub_le_self _ _), add_sub_cancel_of_le h2]
 
-lemma sub_left_inj {a b c : ennreal} (ha : a < ⊤) (hb : b ≤ a) (hc : c ≤ a) :
+lemma sub_right_inj {a b c : ennreal} (ha : a < ⊤) (hb : b ≤ a) (hc : c ≤ a) :
   a - b = a - c ↔ b = c :=
 iff.intro
   begin
@@ -667,7 +667,7 @@ by rw [bit0, add_eq_top, or_self]
 @[simp] lemma bit1_inj : bit1 a = bit1 b ↔ a = b :=
 ⟨λh, begin
   unfold bit1 at h,
-  rwa [add_right_inj, bit0_inj] at h,
+  rwa [add_left_inj, bit0_inj] at h,
   simp [lt_top_iff_ne_top]
 end,
 λh, congr_arg _ h⟩

--- a/src/field_theory/finite.lean
+++ b/src/field_theory/finite.lean
@@ -38,7 +38,7 @@ def field_of_integral_domain [fintype R] [decidable_eq R] [integral_domain R] :
   field R :=
 { inv := λ a, if h : a = 0 then 0
     else fintype.bij_inv (show function.bijective (* a),
-      from fintype.injective_iff_bijective.1 $ λ _ _, (domain.mul_right_inj h).1) 1,
+      from fintype.injective_iff_bijective.1 $ λ _ _, (domain.mul_left_inj h).1) 1,
   mul_inv_cancel := λ a ha, show a * dite _ _ _ = _, by rw [dif_neg ha, mul_comm];
     exact fintype.right_inverse_bij_inv (show function.bijective (* a), from _) 1,
   inv_zero := dif_pos rfl,

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -104,7 +104,7 @@ is_noetherian_ring.irreducible_induction_on (f.map i)
       have hp1 : degree p = 1, from hfs.resolve_left hpf0 hp (by simp),
       begin
         rw [multiset.map_cons, multiset.prod_cons, leading_coeff_mul, C_mul, mul_assoc,
-          mul_left_comm (C f.leading_coeff), ← hs, ← mul_assoc, domain.mul_right_inj hf0],
+          mul_left_comm (C f.leading_coeff), ← hs, ← mul_assoc, domain.mul_left_inj hf0],
         conv_lhs {rw eq_X_add_C_of_degree_eq_one hp1},
         simp only [mul_add, coe_norm_unit hp.ne_zero, mul_comm p, coeff_neg,
           C_neg, sub_eq_add_neg, neg_neg, coeff_C_mul, (mul_assoc _ _ _).symm, C_mul.symm,

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -438,7 +438,7 @@ have hinsert : insert d.succ ((range d.succ).filter (∣ d.succ))
     (by clear _let_match; simp [range_succ]; tauto), by clear _let_match; simp [range_succ] {contextual := tt}; tauto⟩),
 have hinsert₁ : d.succ ∉ (range d.succ).filter (∣ d.succ),
   by simp [mem_range, zero_le_one, le_succ],
-(add_right_inj (((range d.succ).filter (∣ d.succ)).sum
+(add_left_inj (((range d.succ).filter (∣ d.succ)).sum
   (λ m, (univ.filter (λ a : α, order_of a = m)).card))).1
   (calc _ = (insert d.succ (filter (∣ d.succ) (range d.succ))).sum
         (λ m, (univ.filter (λ a : α, order_of a = m)).card) :

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -96,7 +96,7 @@ lemma mem_vectors_prod_eq_one_iff {n : ℕ} (v : vector G (n + 1)) :
     conv {to_rhs, rw ← vector.cons_head_tail v},
     suffices : (v.tail.to_list.prod)⁻¹ = v.head,
     { rw this },
-    rw [← mul_right_inj v.tail.to_list.prod, inv_mul_self, ← list.prod_cons,
+    rw [← mul_left_inj v.tail.to_list.prod, inv_mul_self, ← list.prod_cons,
       ← vector.to_list_cons, vector.cons_head_tail, h]
   end⟩,
   λ ⟨w, hw⟩, by rw [mem_vectors_prod_eq_one, ← hw, mk_vector_prod_eq_one,
@@ -204,7 +204,7 @@ let ⟨H, ⟨hH1, hH2⟩⟩ := @exists_subgroup_card_pow_prime _ hp
 let ⟨s, hs⟩ := exists_eq_mul_left_of_dvd hdvd in
 by exactI
 have hcard : card (quotient H) = s * p :=
-  (nat.mul_right_inj (show card H > 0, from fintype.card_pos_iff.2
+  (nat.mul_left_inj (show card H > 0, from fintype.card_pos_iff.2
       ⟨⟨1, is_submonoid.one_mem⟩⟩)).1
     (by rwa [← card_eq_card_quotient_mul_card_subgroup, hH2, hs,
       nat.pow_succ, mul_assoc, mul_comm p]),

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -98,7 +98,7 @@ calc det (M ⬝ N) = univ.sum (λ p : n → n, univ.sum
           by rw [mul_comm, sign_mul (τ * σ⁻¹)]; simp [sign_mul]
         ... = ε τ : by simp,
       by rw h; simp [this, mul_comm, mul_assoc, mul_left_comm])
-    (λ _ _ _ _, (mul_right_inj _).1) (λ τ _, ⟨τ * σ, by simp⟩))
+    (λ _ _ _ _, (mul_left_inj _).1) (λ τ _, ⟨τ * σ, by simp⟩))
 ... = det M * det N : by simp [det, mul_assoc, mul_sum, mul_comm, mul_left_comm]
 
 instance : is_monoid_hom (det : matrix n n R → R) :=
@@ -136,7 +136,7 @@ end
     congr,
     { simp [pow_two] },
     { ext i, apply pequiv.equiv_to_pequiv_to_matrix } },
-  { intros τ τ' _ _, exact (mul_left_inj σ).mp },
+  { intros τ τ' _ _, exact (mul_right_inj σ).mp },
   { intros τ _, use σ⁻¹ * τ, use (mem_univ _), exact (mul_inv_cancel_left _ _).symm }
 end
 

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -1048,7 +1048,7 @@ lemma lintegral_sub {f g : α → ennreal} (hf : measurable f) (hg : measurable 
   (hg_fin : lintegral g < ⊤) (h_le : ∀ₘ a, g a ≤ f a) :
   (∫⁻ a, f a - g a) = (∫⁻ a, f a) - (∫⁻ a, g a) :=
 begin
-  rw [← ennreal.add_right_inj hg_fin,
+  rw [← ennreal.add_left_inj hg_fin,
         ennreal.sub_add_cancel_of_le (lintegral_le_lintegral_ae h_le),
       ← lintegral_add (hf.ennreal_sub hg) hg],
   show  (∫⁻ (a : α), f a - g a + g a) = ∫⁻ (a : α), f a,
@@ -1064,7 +1064,7 @@ lemma lintegral_infi_ae
 have fn_le_f0 : (∫⁻ a, ⨅n, f n a) ≤ lintegral (f 0), from
   lintegral_mono (assume a, infi_le_of_le 0 (le_refl _)),
 have fn_le_f0' : (⨅n, ∫⁻ a, f n a) ≤ lintegral (f 0), from infi_le_of_le 0 (le_refl _),
-(ennreal.sub_left_inj h_fin fn_le_f0 fn_le_f0').1 $
+(ennreal.sub_right_inj h_fin fn_le_f0 fn_le_f0').1 $
 show lintegral (f 0) - (∫⁻ a, ⨅n, f n a) = lintegral (f 0) - (⨅n, ∫⁻ a, f n a), from
 calc
   lintegral (f 0) - (∫⁻ a, ⨅n, f n a) = ∫⁻ a, f 0 a - ⨅n, f n a :

--- a/src/number_theory/quadratic_reciprocity.lean
+++ b/src/number_theory/quadratic_reciprocity.lean
@@ -229,7 +229,7 @@ private lemma gauss_lemma_aux₂ (p : ℕ) [hp : fact p.prime] [hp2 : fact (p % 
   {a : ℕ} (hap : (a : zmod p) ≠ 0) :
   (a^(p / 2) : zmod p) = (-1)^((Ico 1 (p / 2).succ).filter
     (λ x : ℕ, p / 2 < (a * x : zmod p).val)).card :=
-(domain.mul_right_inj
+(domain.mul_left_inj
     (show ((p / 2).fact : zmod p) ≠ 0,
       by rw [ne.def, char_p.cast_eq_zero_iff (zmod p) p, hp.dvd_fact, not_le];
           exact nat.div_lt_self hp.pos dec_trivial)).1 $

--- a/src/number_theory/sum_four_squares.lean
+++ b/src/number_theory/sum_four_squares.lean
@@ -27,7 +27,7 @@ have (x^2 + y^2).even, by simp [h.symm, even_mul],
 have hxaddy : (x + y).even, by simpa [pow_two] with parity_simps,
 have hxsuby : (x - y).even, by simpa [pow_two] with parity_simps,
 have (x^2 + y^2) % 2 = 0, by simp [h.symm],
-(domain.mul_left_inj (show (2*2 : ℤ) ≠ 0, from dec_trivial)).1 $
+(domain.mul_right_inj (show (2*2 : ℤ) ≠ 0, from dec_trivial)).1 $
 calc 2 * 2 * m = (x - y)^2 + (x + y)^2 : by rw [mul_assoc, h]; ring
 ... = (2 * ((x - y) / 2))^2 + (2 * ((x + y) / 2))^2 :
   by rw [int.mul_div_cancel' hxsuby, int.mul_div_cancel' hxaddy]
@@ -91,7 +91,7 @@ let ⟨x, hx⟩ := h01 in let ⟨y, hy⟩ := h23 in
   begin
     rw [← int.sum_two_squares_of_two_mul_sum_two_squares hx.symm, add_assoc,
       ← int.sum_two_squares_of_two_mul_sum_two_squares hy.symm,
-      ← domain.mul_left_inj (show (2 : ℤ) ≠ 0, from dec_trivial), ← h, mul_add, ← hx, ← hy],
+      ← domain.mul_right_inj (show (2 : ℤ) ≠ 0, from dec_trivial), ← h, mul_add, ← hx, ← hy],
     have : univ.sum (λ x, f (σ x)^2) = univ.sum (λ x, f x^2),
     { conv_rhs { rw ← finset.sum_equiv σ } },
     have fin4univ : (univ : finset (fin 4)).1 = 0::1::2::3::0, from dec_trivial,
@@ -160,7 +160,7 @@ m.mod_two_eq_zero_or_one.elim
             ⟨mc, hmc⟩ := habcd0.2.2.1, ⟨md, hmd⟩ := habcd0.2.2.2 in
         have hmdvdp : m ∣ p,
           from int.coe_nat_dvd.1 ⟨ma^2 + mb^2 + mc^2 + md^2,
-            (domain.mul_left_inj (show (m : ℤ) ≠ 0, from int.coe_nat_ne_zero_iff_pos.2 hm0)).1 $
+            (domain.mul_right_inj (show (m : ℤ) ≠ 0, from int.coe_nat_ne_zero_iff_pos.2 hm0)).1 $
               by rw [← habcd, hma, hmb, hmc, hmd]; ring⟩,
         (hp.2 _ hmdvdp).elim hm1 (λ hmeqp, by simpa [lt_irrefl, hmeqp] using hmp)),
       have hawbxcydz : ((m : ℕ) : ℤ) ∣ a * w + b * x + c * y + d * z,
@@ -181,7 +181,7 @@ m.mod_two_eq_zero_or_one.elim
           (by rw [int.nat_abs_of_nonneg hn_nonneg, ← hn, ← _root_.pow_two]; exact hwxyzlt)
           (int.coe_nat_nonneg m)),
       have hstuv : s^2 + t^2 + u^2 + v^2 = n.nat_abs * p,
-        from (domain.mul_left_inj (show (m^2 : ℤ) ≠ 0, from pow_ne_zero 2
+        from (domain.mul_right_inj (show (m^2 : ℤ) ≠ 0, from pow_ne_zero 2
             (int.coe_nat_ne_zero_iff_pos.2 hm0))).1 $
           calc (m : ℤ)^2 * (s^2 + t^2 + u^2 + v^2) = ((m : ℕ) * s)^2 + ((m : ℕ) * t)^2 +
               ((m : ℕ) * u)^2 + ((m : ℕ) * v)^2 :

--- a/src/ring_theory/integral_domain.lean
+++ b/src/ring_theory/integral_domain.lean
@@ -49,7 +49,7 @@ begin
   refine card_congr (λ g _, g * x⁻¹ * y) _ _ (λ g hg, ⟨g * y⁻¹ * x, _⟩),
   { simp only [mem_filter, one_mul, monoid_hom.map_mul, mem_univ, mul_right_inv,
       eq_self_iff_true, monoid_hom.map_mul_inv, and_self, forall_true_iff] {contextual := tt} },
-  { simp only [mul_right_inj, imp_self, forall_2_true_iff], },
+  { simp only [mul_left_inj, imp_self, forall_2_true_iff], },
   { simp only [true_and, mem_filter, mem_univ] at hg,
     simp only [hg, mem_filter, one_mul, monoid_hom.map_mul, mem_univ, mul_right_inv,
       eq_self_iff_true, exists_prop_of_true, monoid_hom.map_mul_inv, and_self,
@@ -105,7 +105,7 @@ begin
       (λ b hb, let ⟨n, hn⟩ := hx b in ⟨n % order_of x, mem_range.2 (nat.mod_lt _ (order_of_pos _)),
         by rw [← pow_eq_mod_order_of, hn]⟩)
   ... = 0 : _,
-  rw [← domain.mul_right_inj hx1, zero_mul, ← geom_series, geom_sum_mul, coe_coe],
+  rw [← domain.mul_left_inj hx1, zero_mul, ← geom_series, geom_sum_mul, coe_coe],
   norm_cast,
   rw [pow_order_of_eq_one, is_submonoid.coe_one, units.coe_one, sub_self],
 end

--- a/src/ring_theory/multiplicity.lean
+++ b/src/ring_theory/multiplicity.lean
@@ -290,7 +290,7 @@ variable [decidable_rel ((∣) : α → α → Prop)]
 @[simp] lemma multiplicity_self {a : α} (ha : ¬is_unit a) (ha0 : a ≠ 0) :
   multiplicity a a = 1 :=
 eq_some_iff.2 ⟨by simp, λ ⟨b, hb⟩, ha (is_unit_iff_dvd_one.2
-  ⟨b, (domain.mul_left_inj ha0).1 $ by clear _fun_match;
+  ⟨b, (domain.mul_right_inj ha0).1 $ by clear _fun_match;
     simpa [_root_.pow_succ, mul_assoc] using hb⟩)⟩
 
 @[simp] lemma get_multiplicity_self {a : α} (ha : finite a a) :
@@ -298,7 +298,7 @@ eq_some_iff.2 ⟨by simp, λ ⟨b, hb⟩, ha (is_unit_iff_dvd_one.2
 roption.get_eq_iff_eq_some.2 (eq_some_iff.2
   ⟨by simp, λ ⟨b, hb⟩,
     by rw [← mul_one a, _root_.pow_add, _root_.pow_one, mul_assoc, mul_assoc,
-        domain.mul_left_inj (ne_zero_of_finite ha)] at hb;
+        domain.mul_right_inj (ne_zero_of_finite ha)] at hb;
       exact mt is_unit_iff_dvd_one.2 (not_unit_of_finite ha)
         ⟨b, by clear _fun_match; simp * at *⟩⟩)
 

--- a/src/ring_theory/power_series.lean
+++ b/src/ring_theory/power_series.lean
@@ -292,7 +292,7 @@ lemma coeff_X (n : σ →₀ ℕ) (s : σ) :
 
 lemma coeff_index_single_X (s t : σ) :
   coeff α (single t 1) (X s : mv_power_series σ α) = if t = s then 1 else 0 :=
-by { simp only [coeff_X, single_right_inj one_ne_zero], split_ifs; refl }
+by { simp only [coeff_X, single_left_inj one_ne_zero], split_ifs; refl }
 
 @[simp] lemma coeff_index_single_self_X (s : σ) :
   coeff α (single s 1) (X s : mv_power_series σ α) = 1 :=
@@ -1134,7 +1134,7 @@ begin
       { have : m + n < i + j := add_lt_add_of_lt_of_le this hj,
         exfalso, exact ne_of_lt this hij.symm },
       contrapose! hne, have : i = m := le_antisymm hne hi, subst i, clear hi hne,
-      simpa [ne.def, prod.mk.inj_iff] using (add_left_inj m).mp hij },
+      simpa [ne.def, prod.mk.inj_iff] using (add_right_inj m).mp hij },
     { contrapose!, intro h, rw finset.nat.mem_antidiagonal }
 end
 

--- a/src/ring_theory/principal_ideal_domain.lean
+++ b/src/ring_theory/principal_ideal_domain.lean
@@ -58,7 +58,7 @@ is_maximal_iff.2 ⟨(ne_top_iff_one S).1 hpi.1, begin
     exact (hxS $ hTS hxT).elim },
   cases (mem_iff_generator_dvd _).1 h with y hy,
   have : generator S ≠ 0 := mt (eq_bot_iff_generator_eq_zero _).2 hS,
-  rw [← mul_one (generator S), hy, mul_left_comm, domain.mul_left_inj this] at hz,
+  rw [← mul_one (generator S), hy, mul_left_comm, domain.mul_right_inj this] at hz,
   exact hz.symm ▸ ideal.mul_mem_right _ (generator_mem T)
 end⟩
 

--- a/src/set_theory/game/domineering.lean
+++ b/src/set_theory/game/domineering.lean
@@ -28,12 +28,12 @@ open function
 /-- The embedding `(x, y) ↦ (x, y+1)`. -/
 def shift_up : ℤ × ℤ ↪ ℤ × ℤ :=
 ⟨λ p : ℤ × ℤ, (p.1, p.2 + 1),
- have injective (λ (n : ℤ), n + 1) := λ _ _, (add_right_inj 1).mp,
+ have injective (λ (n : ℤ), n + 1) := λ _ _, (add_left_inj 1).mp,
  injective_id.prod this⟩
 /-- The embedding `(x, y) ↦ (x+1, y)`. -/
 def shift_right : ℤ × ℤ ↪ ℤ × ℤ :=
 ⟨λ p : ℤ × ℤ, (p.1 + 1, p.2),
- have injective (λ (n : ℤ), n + 1) := λ _ _, (add_right_inj 1).mp,
+ have injective (λ (n : ℤ), n + 1) := λ _ _, (add_left_inj 1).mp,
  this.prod injective_id⟩
 
 /-- A Domineering board is an arbitrary finite subset of `ℤ × ℤ`. -/

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -1543,7 +1543,7 @@ theorem le_of_mul_le_mul_left {a b c : ordinal}
   (h : c * a ≤ c * b) (h0 : 0 < c) : a ≤ b :=
 le_imp_le_of_lt_imp_lt (λ h', mul_lt_mul_of_pos_left h' h0) h
 
-theorem mul_left_inj {a b c : ordinal} (a0 : 0 < a) : a * b = a * c ↔ b = c :=
+theorem mul_right_inj {a b c : ordinal} (a0 : 0 < a) : a * b = a * c ↔ b = c :=
 (mul_is_normal a0).inj
 
 theorem mul_is_limit {a b : ordinal}
@@ -3038,7 +3038,7 @@ begin
       exact lt_of_lt_of_le hb (le_add_left b a) },
     right, rw [← h, add_lt_omega_iff, lt_omega, lt_omega] at ha,
     rcases ha with ⟨⟨n, rfl⟩, ⟨m, rfl⟩⟩, norm_cast at h ⊢,
-    rw [← add_left_inj, h, add_zero] },
+    rw [← add_right_inj, h, add_zero] },
   { rintro (⟨h1, h2⟩|h3), rw [add_eq_max h1, max_eq_left h2], rw [h3, add_zero] }
 end
 

--- a/src/tactic/omega/eq_elim.lean
+++ b/src/tactic/omega/eq_elim.lean
@@ -185,7 +185,7 @@ begin
         a_n * coeffs.val_except n v (as.map (λ x, symmod x m))) :
           begin
             simp only [term.val, rhs, mul_add, m, a_n,
-              add_assoc, add_left_inj, add_comm, add_left_comm],
+              add_assoc, add_right_inj, add_comm, add_left_comm],
             rw [← coeffs.val_except_add_eq n,
               get_set, update_eq, mul_add],
             apply fun_mono_2,

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -693,7 +693,7 @@ begin
   refine le_trans (dist_le_Ico_sum_of_dist_le hnm (λ k _ _, hf k)) _,
   rw [sum_Ico_eq_sum_range],
   refine sum_le_tsum (range _) (λ _ _, le_trans dist_nonneg (hf _)) _,
-  exact hd.summable_comp_of_injective (add_left_injective n)
+  exact hd.summable_comp_of_injective (add_right_injective n)
 end
 
 lemma dist_le_tsum_of_dist_le_of_tendsto₀ [metric_space α] {f : ℕ → α} (d : ℕ → ℝ)


### PR DESCRIPTION
This is the evil twin of #2652 using the opposite convention: the name of a lemma stating that a function in two arguments is injective in one of the arguments refers to the argument that changes. Example:
```lean
lemma sub_right_inj : a - b = a - c ↔ b = c
```
See also the [Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/pow_(left.7Cright)_inj(ective)).

This PR renames lemmas following the other convention. The following lemmas were renamed:

`algebra/group/basic.lean`:
* `mul_left_injective` ↔ `mul_right_injective`
* `mul_left_inj` ↔ `mul_right_inj`
* `sub_left_inj` ↔ `sub_right_inj`

`algebra/goup/units.lean`:
* `mul_left_inj` ↔ `mul_right_inj`
* `divp_right_inj` → `divp_left_inj`

`algebra/group_power.lean`:
* `pow_right_inj` → `pow_left_inj`

`algebra/group_with_zero.lean`:
* `div_right_inj'` → ` div_left_inj'`
* `mul_right_inj'` → `mul_left_inj'`

`algebra/ring.lean`:
* `domain.mul_right_inj` ↔ `domain.mul_left_inj`

`data/finsupp.lean`:
* `single_right_inj` → `single_left_inj`

`data/list/basic.lean`:
* `append_inj_left` ↔ `append_inj_right`
* `append_inj_left'` ↔ `append_inj_right'`
* `append_left_inj` ↔ `append_right_inj`
* `prefix_append_left_inj` → `prefix_append_right_inj`

`data/nat/basic.lean`:
* `mul_left_inj` ↔ `mul_right_inj`

`data/real/ennreal.lean`:
* `add_left_inj` ↔ `add_right_inj`
* `sub_left_inj` → `sub_right_inj`

`set_theory/ordinal.lean`:
* `mul_left_inj` → `mul_right_inj`