### PR TITLE
[Merged by Bors] - feat(data/matrix): matrix and vector notation

### DIFF
--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -77,7 +77,7 @@ by simp [diagonal]; refl
   (diagonal v)ᵀ = diagonal v :=
 begin
   ext i j,
-  by_cases i = j,
+  by_cases h : i = j,
   { simp [h, transpose] },
   { simp [h, transpose, diagonal_val_ne' h] }
 end

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -9,6 +9,8 @@ import algebra.pi_instances
 
 universes u v w
 
+open_locale big_operators
+
 @[nolint unused_arguments]
 def matrix (m n : Type u) [fintype m] [fintype n] (α : Type v) : Type (max u v) :=
 m → n → α
@@ -71,6 +73,15 @@ theorem diagonal_val_ne' [has_zero α] {d : n → α} {i j : n} (h : j ≠ i) :
 @[simp] theorem diagonal_zero [has_zero α] : (diagonal (λ _, 0) : matrix n n α) = 0 :=
 by simp [diagonal]; refl
 
+@[simp] lemma diagonal_transpose [has_zero α] (v : n → α) :
+  (diagonal v)ᵀ = diagonal v :=
+begin
+  ext i j,
+  by_cases i = j,
+  { simp [h, transpose] },
+  { simp [h, transpose, diagonal_val_ne' h] }
+end
+
 section one
 variables [has_zero α] [has_one α]
 
@@ -95,16 +106,83 @@ end diagonal
   diagonal d₁ + diagonal d₂ = diagonal (λ i, d₁ i + d₂ i) :=
 by ext i j; by_cases i = j; simp [h]
 
+section dot_product
+
+/-- `dot_product v w` is the sum of the entrywise products `v i * w i` -/
+def dot_product [has_mul α] [add_comm_monoid α] (v w : m → α) : α :=
+∑ i, v i * w i
+
+lemma dot_product_assoc [semiring α] (u : m → α) (v : m → n → α) (w : n → α) :
+  dot_product (λ j, dot_product u (λ i, v i j)) w = dot_product u (λ i, dot_product (v i) w) :=
+by simpa [dot_product, finset.mul_sum, finset.sum_mul, mul_assoc] using finset.sum_comm
+
+lemma dot_product_comm [comm_semiring α] (v w : m → α) :
+  dot_product v w = dot_product w v :=
+by simp_rw [dot_product, mul_comm]
+
+@[simp] lemma dot_product_punit [add_comm_monoid α] [has_mul α] (v w : punit → α) :
+  dot_product v w = v ⟨⟩ * w ⟨⟩ :=
+by simp [dot_product]
+
+@[simp] lemma dot_product_zero [semiring α] (v : m → α) : dot_product v 0 = 0 :=
+by simp [dot_product]
+
+@[simp] lemma dot_product_zero' [semiring α] (v : m → α) : dot_product v (λ _, 0) = 0 :=
+dot_product_zero v
+
+@[simp] lemma zero_dot_product [semiring α] (v : m → α) : dot_product 0 v = 0 :=
+by simp [dot_product]
+
+@[simp] lemma zero_dot_product' [semiring α] (v : m → α) : dot_product (λ _, (0 : α)) v = 0 :=
+zero_dot_product v
+
+@[simp] lemma add_dot_product [semiring α] (u v w : m → α) :
+  dot_product (u + v) w = dot_product u w + dot_product v w :=
+by simp [dot_product, add_mul, finset.sum_add_distrib]
+
+@[simp] lemma dot_product_add [semiring α] (u v w : m → α) :
+  dot_product u (v + w) = dot_product u v + dot_product u w :=
+by simp [dot_product, mul_add, finset.sum_add_distrib]
+
+@[simp] lemma diagonal_dot_product [decidable_eq m] [semiring α] (v w : m → α) (i : m) :
+  dot_product (diagonal v i) w = v i * w i :=
+have ∀ j ≠ i, diagonal v i j * w j = 0 := λ j hij, by simp [diagonal_val_ne' hij],
+by convert finset.sum_eq_single i (λ j _, this j) _; simp
+
+@[simp] lemma dot_product_diagonal [decidable_eq m] [semiring α] (v w : m → α) (i : m) :
+  dot_product v (diagonal w i) = v i * w i :=
+have ∀ j ≠ i, v j * diagonal w i j = 0 := λ j hij, by simp [diagonal_val_ne' hij],
+by convert finset.sum_eq_single i (λ j _, this j) _; simp
+
+@[simp] lemma dot_product_diagonal' [decidable_eq m] [semiring α] (v w : m → α) (i : m) :
+  dot_product v (λ j, diagonal w j i) = v i * w i :=
+have ∀ j ≠ i, v j * diagonal w j i = 0 := λ j hij, by simp [diagonal_val_ne hij],
+by convert finset.sum_eq_single i (λ j _, this j) _; simp
+
+@[simp] lemma neg_dot_product [ring α] (v w : m → α) : dot_product (-v) w = - dot_product v w :=
+by simp [dot_product]
+
+@[simp] lemma dot_product_neg [ring α] (v w : m → α) : dot_product v (-w) = - dot_product v w :=
+by simp [dot_product]
+
+@[simp] lemma smul_dot_product [semiring α] (x : α) (v w : m → α) :
+  dot_product (x • v) w = x * dot_product v w :=
+by simp [dot_product, finset.mul_sum, mul_assoc]
+
+@[simp] lemma dot_product_smul [comm_semiring α] (x : α) (v w : m → α) :
+  dot_product v (x • w) = x * dot_product v w :=
+by simp [dot_product, finset.mul_sum, mul_assoc, mul_comm, mul_left_comm]
+
+end dot_product
+
 protected def mul [has_mul α] [add_comm_monoid α] (M : matrix l m α) (N : matrix m n α) :
   matrix l n α :=
-λ i k, finset.univ.sum (λ j, M i j * N j k)
+λ i k, dot_product (λ j, M i j) (λ j, N j k)
 
 localized "infixl ` ⬝ `:75 := matrix.mul" in matrix
 
 theorem mul_val [has_mul α] [add_comm_monoid α] {M : matrix l m α} {N : matrix m n α} {i k} :
-  (M ⬝ N) i k = finset.univ.sum (λ j, M i j * N j k) := rfl
-
-local attribute [simp] mul_val
+  (M ⬝ N) i k = ∑ j, M i j * N j k := rfl
 
 instance [has_mul α] [add_comm_monoid α] : has_mul (matrix n n α) := ⟨matrix.mul⟩
 
@@ -112,16 +190,14 @@ instance [has_mul α] [add_comm_monoid α] : has_mul (matrix n n α) := ⟨matri
   M * N = M ⬝ N := rfl
 
 theorem mul_val' [has_mul α] [add_comm_monoid α] {M N : matrix n n α} {i k} :
-  (M * N) i k = finset.univ.sum (λ j, M i j * N j k) := rfl
+  (M * N) i k = dot_product (λ j, M i j) (λ j, N j k) := rfl
 
 section semigroup
 variables [semiring α]
 
 protected theorem mul_assoc (L : matrix l m α) (M : matrix m n α) (N : matrix n o α) :
   (L ⬝ M) ⬝ N = L ⬝ (M ⬝ N) :=
-by classical; funext i k;
-   simp [finset.mul_sum, finset.sum_mul, mul_assoc];
-   rw finset.sum_comm
+by { ext, apply dot_product_assoc }
 
 instance : semigroup (matrix n n α) :=
 { mul_assoc := matrix.mul_assoc, ..matrix.has_mul }
@@ -136,24 +212,24 @@ section semiring
 variables [semiring α]
 
 @[simp] protected theorem mul_zero (M : matrix m n α) : M ⬝ (0 : matrix n o α) = 0 :=
-by ext i j; simp
+by { ext i j, apply dot_product_zero }
 
 @[simp] protected theorem zero_mul (M : matrix m n α) : (0 : matrix l m α) ⬝ M = 0 :=
-by ext i j; simp
+by { ext i j, apply zero_dot_product }
 
 protected theorem mul_add (L : matrix m n α) (M N : matrix n o α) : L ⬝ (M + N) = L ⬝ M + L ⬝ N :=
-by ext i j; simp [finset.sum_add_distrib, mul_add]
+by { ext i j, apply dot_product_add }
 
 protected theorem add_mul (L M : matrix l m α) (N : matrix m n α) : (L + M) ⬝ N = L ⬝ N + M ⬝ N :=
-by ext i j; simp [finset.sum_add_distrib, add_mul]
+by { ext i j, apply add_dot_product }
 
 @[simp] theorem diagonal_mul [decidable_eq m]
   (d : m → α) (M : matrix m n α) (i j) : (diagonal d).mul M i j = d i * M i j :=
-by simp; rw finset.sum_eq_single i; simp [diagonal_val_ne'] {contextual := tt}
+diagonal_dot_product _ _ _
 
 @[simp] theorem mul_diagonal [decidable_eq n]
   (d : n → α) (M : matrix m n α) (i j) : (M ⬝ diagonal d) i j = M i j * d j :=
-by simp; rw finset.sum_eq_single j; simp {contextual := tt}
+by { rw ← diagonal_transpose, apply dot_product_diagonal }
 
 @[simp] protected theorem one_mul [decidable_eq m] (M : matrix m n α) : (1 : matrix m m α) ⬝ M = M :=
 by ext i j; rw [← diagonal_one, diagonal_mul, one_mul]
@@ -210,10 +286,12 @@ section ring
 variables [ring α]
 
 @[simp] theorem neg_mul (M : matrix m n α) (N : matrix n o α) :
-  (-M) ⬝ N = -(M ⬝ N) := by ext; simp [matrix.mul_val]
+  (-M) ⬝ N = -(M ⬝ N) :=
+by { ext, apply neg_dot_product }
 
 @[simp] theorem mul_neg (M : matrix m n α) (N : matrix n o α) :
-  M ⬝ (-N) = -(M ⬝ N) := by ext; simp [matrix.mul_val]
+  M ⬝ (-N) = -(M ⬝ N) :=
+by { ext, apply dot_product_neg }
 
 end ring
 
@@ -240,22 +318,10 @@ lemma smul_eq_mul_diagonal [decidable_eq n] (M : matrix m n α) (a : α) :
 by { ext, simp [mul_comm] }
 
 @[simp] lemma mul_smul (M : matrix m n α) (a : α) (N : matrix n l α) : M ⬝ (a • N) = a • M ⬝ N :=
-begin
-  ext i j,
-  simp only [matrix.mul_val, has_scalar.smul, finset.mul_sum],
-  congr,
-  ext,
-  ac_refl
-end
+by { ext, apply dot_product_smul }
 
 @[simp] lemma smul_mul (M : matrix m n α) (a : α) (N : matrix n l α) : (a • M) ⬝ N = a • M ⬝ N :=
-begin
-  ext i j,
-  simp only [matrix.mul_val, has_scalar.smul, finset.mul_sum],
-  congr,
-  ext,
-  ac_refl
-end
+by { ext, apply smul_dot_product }
 
 end comm_semiring
 
@@ -266,10 +332,10 @@ def vec_mul_vec (w : m → α) (v : n → α) : matrix m n α
 | x y := w x * v y
 
 def mul_vec (M : matrix m n α) (v : n → α) : m → α
-| x := finset.univ.sum (λy:n, M x y * v y)
+| i := dot_product (λ j, M i j) v
 
 def vec_mul (v : m → α) (M : matrix m n α) : n → α
-| y := finset.univ.sum (λx:m, v x * M x y)
+| j := dot_product v (λ i, M i j)
 
 instance mul_vec.is_add_monoid_hom_left (v : n → α) :
   is_add_monoid_hom (λM:matrix m n α, mul_vec M v) :=
@@ -278,29 +344,16 @@ instance mul_vec.is_add_monoid_hom_left (v : n → α) :
   begin
     intros x y,
     ext m,
-    rw pi.add_apply (mul_vec x v) (mul_vec y v) m,
-    simp [mul_vec, finset.sum_add_distrib, right_distrib]
+    apply add_dot_product
   end }
 
 lemma mul_vec_diagonal [decidable_eq m] (v w : m → α) (x : m) :
   mul_vec (diagonal v) w x = v x * w x :=
-begin
-  transitivity,
-  refine finset.sum_eq_single x _ _,
-  { assume b _ ne, simp [diagonal, ne.symm] },
-  { simp },
-  { rw [diagonal_val_eq] }
-end
+diagonal_dot_product v w x
 
 lemma vec_mul_diagonal [decidable_eq m] (v w : m → α) (x : m) :
   vec_mul v (diagonal w) x = v x * w x :=
-begin
-  transitivity,
-  refine finset.sum_eq_single x _ _,
-  { assume b _ ne, simp [diagonal, if_neg ne] },
-  { simp },
-  { rw [diagonal_val_eq] }
-end
+dot_product_diagonal' v w x
 
 @[simp] lemma mul_vec_one [decidable_eq m] (v : m → α) : mul_vec 1 v = v :=
 by { ext, rw [←diagonal_one, mul_vec_diagonal, one_mul] }
@@ -316,25 +369,35 @@ by { ext, simp [vec_mul] }
 
 @[simp] lemma vec_mul_vec_mul (v : m → α) (M : matrix m n α) (N : matrix n o α) :
   vec_mul (vec_mul v M) N = vec_mul v (M ⬝ N) :=
-begin
-  ext,
-  simp_rw [vec_mul, matrix.mul, finset.mul_sum, finset.sum_mul, mul_assoc],
-  apply finset.sum_comm
-end
+by { ext, apply dot_product_assoc }
 
 @[simp] lemma mul_vec_mul_vec (v : o → α) (M : matrix m n α) (N : matrix n o α) :
   mul_vec M (mul_vec N v) = mul_vec (M ⬝ N) v :=
-begin
-  ext,
-  simp_rw [mul_vec, matrix.mul, finset.sum_mul, finset.mul_sum, mul_assoc],
-  apply finset.sum_comm
-end
+by { ext, symmetry, apply dot_product_assoc }
 
 lemma vec_mul_vec_eq (w : m → α) (v : n → α) :
   vec_mul_vec w v = (col w) ⬝ (row v) :=
-by { ext i j, simp, refl }
+by { ext i j, simp [vec_mul_vec, mul_val], refl }
 
 end semiring
+
+section ring
+
+variables [ring α]
+
+lemma neg_vec_mul (v : m → α) (A : matrix m n α) : vec_mul (-v) A = - vec_mul v A :=
+by { ext, apply neg_dot_product }
+
+lemma vec_mul_neg (v : m → α) (A : matrix m n α) : vec_mul v (-A) = - vec_mul v A :=
+by { ext, apply dot_product_neg }
+
+lemma neg_mul_vec (v : n → α) (A : matrix m n α) : mul_vec (-A) v = - mul_vec A v :=
+by { ext, apply neg_dot_product }
+
+lemma mul_vec_neg (v : n → α) (A : matrix m n α) : mul_vec A (-v) = - mul_vec A v :=
+by { ext, apply dot_product_neg }
+
+end ring
 
 section transpose
 
@@ -371,10 +434,7 @@ by { ext i j, simp }
   (M ⬝ N)ᵀ = Nᵀ ⬝ Mᵀ  :=
 begin
   ext i j,
-  simp only [matrix.mul_val, transpose],
-  congr,
-  ext,
-  ac_refl
+  apply dot_product_comm
 end
 
 @[simp] lemma transpose_smul [comm_ring α] (c : α)(M : matrix m n α) :

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -190,7 +190,7 @@ instance [has_mul α] [add_comm_monoid α] : has_mul (matrix n n α) := ⟨matri
   M * N = M ⬝ N := rfl
 
 theorem mul_val' [has_mul α] [add_comm_monoid α] {M N : matrix n n α} {i k} :
-  (M * N) i k = dot_product (λ j, M i j) (λ j, N j k) := rfl
+  (M ⬝ N) i k = dot_product (λ j, M i j) (λ j, N j k) := rfl
 
 section semigroup
 variables [semiring α]

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -280,6 +280,10 @@ protected lemma mul_sum {β : Type*} (s : finset β) (f : β → matrix m n α)
   `add_monoid` instances were def-eq -/
   (id (@is_add_monoid_hom_mul_left _ _ n _ _ _ _ _ M) : _)).symm
 
+@[simp]
+lemma row_mul_col_val (v w : m → α) (i j) : (row v ⬝ col w) i j = dot_product v w :=
+rfl
+
 end semiring
 
 section ring

--- a/src/data/matrix/notation.lean
+++ b/src/data/matrix/notation.lean
@@ -11,29 +11,29 @@ import data.matrix.basic
 import tactic.fin_cases
 
 /-!
-  # Matrix and vector notation
+# Matrix and vector notation
 
-  This file defines notation for vectors and matrices. Given `a b c d : α`,
-  the notation allows us to write `![a, b, c, d] : fin 4 → α`.
-  Nesting vectors gives a matrix, so `![![a, b], ![c, d]] : matrix (fin 2) (fin 2) α`.
-  This file includes `simp` lemmas for applying operations in
-  `data.matrix.basic` to values built out of this notation.
+This file defines notation for vectors and matrices. Given `a b c d : α`,
+the notation allows us to write `![a, b, c, d] : fin 4 → α`.
+Nesting vectors gives a matrix, so `![![a, b], ![c, d]] : matrix (fin 2) (fin 2) α`.
+This file includes `simp` lemmas for applying operations in
+`data.matrix.basic` to values built out of this notation.
 
-  ## Main definitions
+## Main definitions
 
-   * `vec_empty` is the empty vector (or `0` by `n` matrix) `![]`
-   * `vec_cons` prepends an entry to a vector, so `![a, b]` is `vec_cons a (vec_cons b vec_empty)`
+* `vec_empty` is the empty vector (or `0` by `n` matrix) `![]`
+* `vec_cons` prepends an entry to a vector, so `![a, b]` is `vec_cons a (vec_cons b vec_empty)`
 
-  ## Implementation notes
+## Implementation notes
 
-  The `simp` lemmas require that one of the arguments is of the form `vec_cons _ _`.
-  This ensures `simp` works with entries only when (some) entries are already given.
-  In other words, this notation will only appear in the output of `simp` if it
-  already appears in the input.
+The `simp` lemmas require that one of the arguments is of the form `vec_cons _ _`.
+This ensures `simp` works with entries only when (some) entries are already given.
+In other words, this notation will only appear in the output of `simp` if it
+already appears in the input.
 
-  ## Notations
+## Notations
 
-  The main new notation is `![a, b]`, which gets expanded to `vec_cons a (vec_cons b vec_empty)`.
+The main new notation is `![a, b]`, which gets expanded to `vec_cons a (vec_cons b vec_empty)`.
 -/
 
 namespace matrix

--- a/src/data/matrix/notation.lean
+++ b/src/data/matrix/notation.lean
@@ -1,0 +1,360 @@
+/-
+Copyright (c) 2020 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen
+
+Notation for vectors and matrices
+-/
+
+import data.fintype.card
+import data.matrix.basic
+import tactic.fin_cases
+
+/-!
+  # Matrix and vector notation
+
+  This file defines notation for vectors and matrices. Given `a b c d : α`,
+  the notation allows us to write `![a, b, c, d] : fin 4 → α`.
+  Nesting vectors gives a matrix, so `![![a, b], ![c, d]] : matrix (fin 2) (fin 2) α`.
+  This file includes `simp` lemmas for applying operations in
+  `data.matrix.basic` to values built out of this notation.
+
+  ## Main definitions
+
+   * `vec_empty` is the empty vector (or `0` by `n` matrix) `![]`
+   * `vec_cons` prepends an entry to a vector, so `![a, b]` is `vec_cons a (vec_cons b vec_empty)`
+
+  ## Implementation notes
+
+  The `simp` lemmas require that one of the arguments is of the form `vec_cons _ _`.
+  This ensures `simp` works with entries only when (some) entries are already given.
+  In other words, this notation will only appear in the output of `simp` if it
+  already appears in the input.
+
+  ## Notations
+
+  The main new notation is `![a, b]`, which gets expanded to `vec_cons a (vec_cons b vec_empty)`.
+-/
+
+namespace matrix
+
+universe u
+variables {α : Type u}
+
+open_locale matrix
+
+section matrix_notation
+
+/-- `![]` is the vector with no entries. -/
+def vec_empty : fin 0 → α :=
+fin_zero_elim
+
+/-- `vec_cons h t` prepends an entry `h` to a vector `t`.
+
+The inverse functions are `vec_head` and `vec_tail`.
+The notation `![a, b, ...]` expands to `vec_cons a (vec_cons b ...)`.
+-/
+def vec_cons {n : ℕ} (h : α) (t : fin n → α) : fin n.succ → α :=
+fin.cons h t
+
+notation `![` l:(foldr `, ` (h t, vec_cons h t) vec_empty `]`) := l
+
+/-- `vec_head v` gives the first entry of the vector `v` -/
+def vec_head {n : ℕ} (v : fin n.succ → α) : α :=
+v 0
+
+/-- `vec_tail v` gives a vector consisting of all entries of `v` except the first -/
+def vec_tail {n : ℕ} (v : fin n.succ → α) : fin n → α :=
+v ∘ fin.succ
+
+end matrix_notation
+
+variables {m n o : ℕ} {m' n' o' : Type} [fintype m'] [fintype n'] [fintype o']
+
+lemma empty_eq (v : fin 0 → α) : v = ![] :=
+by { ext i, fin_cases i }
+
+section val
+
+@[simp] lemma cons_val_zero (x : α) (u : fin m → α) : vec_cons x u 0 = x := rfl
+
+@[simp] lemma cons_val_zero' (h : 0 < m.succ) (x : α) (u : fin m → α) :
+  vec_cons x u ⟨0, h⟩ = x :=
+rfl
+
+@[simp] lemma cons_val_succ (x : α) (u : fin m → α) (i : fin m) :
+  vec_cons x u i.succ = u i :=
+by simp [vec_cons]
+
+@[simp] lemma cons_val_succ' {i : ℕ} (h : i.succ < m.succ) (x : α) (u : fin m → α) :
+  vec_cons x u ⟨i.succ, h⟩ = u ⟨i, nat.lt_of_succ_lt_succ h⟩ :=
+by simp [vec_cons, fin.cons, fin.cases]
+
+@[simp] lemma head_cons (x : α) (u : fin m → α) :
+  vec_head (vec_cons x u) = x :=
+rfl
+
+@[simp] lemma tail_cons (x : α) (u : fin m → α) :
+  vec_tail (vec_cons x u) = u :=
+by { ext, simp [vec_tail] }
+
+@[simp] lemma empty_val' {n' : Type} (j : n') :
+  (λ i, (![] : fin 0 → n' → α) i j) = ![] :=
+empty_eq _
+
+@[simp] lemma cons_val' (v : n' → α) (B : matrix (fin m) n' α) (i j) :
+  vec_cons v B i j = vec_cons (v j) (λ i, B i j) i :=
+by { refine fin.cases _ _ i; simp }
+
+@[simp] lemma head_val' (B : matrix (fin m.succ) n' α) (j : n') :
+  vec_head (λ i, B i j) = vec_head B j := rfl
+
+@[simp] lemma tail_val' (B : matrix (fin m.succ) n' α) (j : n') :
+  vec_tail (λ i, B i j) = λ i, vec_tail B i j :=
+by { ext, simp [vec_tail] }
+
+@[simp] lemma cons_head_tail (u : fin m.succ → α) :
+ vec_cons (vec_head u) (vec_tail u) = u :=
+by { ext i, refine fin.cases _ _ i; simp [vec_head, vec_tail] }
+
+/-- `![a, b, ...] 1` is equal to `b`.
+
+  The simplifier needs a special lemma for length `≥ 2`, in addition to
+  `cons_val_succ`, because `1 : fin 1 = 0 : fin 1`.
+-/
+@[simp] lemma cons_val_one (x : α) (u : fin m.succ → α) :
+  vec_cons x u 1 = vec_head u :=
+cons_val_succ x u 0
+
+@[simp] lemma cons_val_fin_one (x : α) (u : fin 0 → α) (i : fin 1) :
+  vec_cons x u i = x :=
+by { fin_cases i, refl }
+
+end val
+
+section dot_product
+
+variables [add_comm_monoid α] [has_mul α]
+
+@[simp] lemma dot_product_empty (v w : fin 0 → α) :
+  dot_product v w = 0 := finset.sum_empty
+
+@[simp] lemma cons_dot_product (x : α) (v : fin n → α) (w : fin n.succ → α) :
+  dot_product (vec_cons x v) w = x * vec_head w + dot_product v (vec_tail w) :=
+by simp [dot_product, fin.sum_univ_succ, vec_head, vec_tail]
+
+@[simp] lemma dot_product_cons (v : fin n.succ → α) (x : α) (w : fin n → α) :
+  dot_product v (vec_cons x w) = vec_head v * x + dot_product (vec_tail v) w :=
+by simp [dot_product, fin.sum_univ_succ, vec_head, vec_tail]
+
+end dot_product
+
+section col_row
+
+@[simp] lemma col_empty (v : fin 0 → α) : col v = vec_empty :=
+empty_eq _
+
+@[simp] lemma col_cons (x : α) (u : fin m → α) :
+  col (vec_cons x u) = vec_cons (λ _, x) (col u) :=
+by { ext i j, refine fin.cases _ _ i; simp [vec_head, vec_tail] }
+
+@[simp] lemma row_empty : row (vec_empty : fin 0 → α) = λ _, vec_empty :=
+by { ext, refl }
+
+@[simp] lemma row_cons (x : α) (u : fin m → α) :
+  row (vec_cons x u) = λ _, vec_cons x u :=
+by { ext, refl }
+
+end col_row
+
+section transpose
+
+@[simp] lemma transpose_empty_rows (A : matrix m' (fin 0) α) : Aᵀ = ![] := empty_eq _
+
+@[simp] lemma transpose_empty_cols : (![] : matrix (fin 0) m' α)ᵀ = λ i, ![] :=
+funext (λ i, empty_eq _)
+
+@[simp] lemma cons_transpose (v : n' → α) (A : matrix (fin m) n' α) :
+  (vec_cons v A)ᵀ = λ i, vec_cons (v i) (Aᵀ i) :=
+by { ext i j, refine fin.cases _ _ j; simp }
+
+@[simp] lemma head_transpose (A : matrix m' (fin n.succ) α) : vec_head (Aᵀ) = vec_head ∘ A :=
+rfl
+
+@[simp] lemma tail_transpose (A : matrix m' (fin n.succ) α) : vec_tail (Aᵀ) = (vec_tail ∘ A)ᵀ :=
+by { ext i j, refl }
+
+end transpose
+
+section mul
+
+variables [semiring α]
+
+@[simp] lemma empty_mul (A : matrix (fin 0) n' α) (B : matrix n' o' α) :
+  A ⬝ B = ![] :=
+empty_eq _
+
+@[simp] lemma empty_mul_empty (A : matrix m' (fin 0) α) (B : matrix (fin 0) o' α) :
+  A ⬝ B = 0 :=
+rfl
+
+@[simp] lemma mul_empty (A : matrix m' n' α) (B : matrix n' (fin 0) α) :
+  A ⬝ B = λ _, ![] :=
+funext (λ _, empty_eq _)
+
+lemma mul_val_succ (A : matrix (fin m.succ) n' α) (B : matrix n' o' α) (i : fin m) (j : o') :
+  (A ⬝ B) i.succ j = (vec_tail A ⬝ B) i j := rfl
+
+@[simp] lemma cons_mul (v : n' → α) (A : matrix (fin m) n' α) (B : matrix n' o' α) :
+  vec_cons v A ⬝ B = vec_cons (vec_mul v B) (A  ⬝ B) :=
+by { ext i j, refine fin.cases _ _ i, { refl }, simp [mul_val_succ] }
+
+end mul
+
+section vec_mul
+
+variables [semiring α]
+
+@[simp] lemma empty_vec_mul (v : fin 0 → α) (B : matrix (fin 0) o' α) :
+  vec_mul v B = 0 :=
+rfl
+
+@[simp] lemma vec_mul_empty (v : n' → α) (B : matrix n' (fin 0) α) :
+  vec_mul v B = ![] :=
+empty_eq _
+
+@[simp] lemma cons_vec_mul (x : α) (v : fin n → α) (B : matrix (fin n.succ) o' α) :
+  vec_mul (vec_cons x v) B = x • (vec_head B) + vec_mul v (vec_tail B) :=
+by { ext i, simp [vec_mul] }
+
+@[simp] lemma vec_mul_cons (v : fin n.succ → α) (w : o' → α) (B : matrix (fin n) o' α) :
+  vec_mul v (vec_cons w B) = vec_head v • w + vec_mul (vec_tail v) B :=
+by { ext i, simp [vec_mul] }
+
+end vec_mul
+
+section mul_vec
+
+variables [semiring α]
+
+@[simp] lemma empty_mul_vec (A : matrix (fin 0) n' α) (v : n' → α) :
+  mul_vec A v = ![] :=
+empty_eq _
+
+@[simp] lemma mul_vec_empty (A : matrix m' (fin 0) α) (v : fin 0 → α) :
+  mul_vec A v = 0 :=
+rfl
+
+@[simp] lemma cons_mul_vec (v : n' → α) (A : fin m → n' → α) (w : n' → α) :
+  mul_vec (vec_cons v A) w = vec_cons (dot_product v w) (mul_vec A w) :=
+by { ext i, refine fin.cases _ _ i; simp [mul_vec] }
+
+@[simp] lemma mul_vec_cons {α} [comm_semiring α] (A : m' → (fin n.succ) → α) (x : α) (v : fin n → α) :
+  mul_vec A (vec_cons x v) = (x • vec_head ∘ A) + mul_vec (vec_tail ∘ A) v :=
+by { ext i, simp [mul_vec, mul_comm] }
+
+end mul_vec
+
+section vec_mul_vec
+
+variables [semiring α]
+
+@[simp] lemma empty_vec_mul_vec (v : fin 0 → α) (w : n' → α) :
+  vec_mul_vec v w = ![] :=
+empty_eq _
+
+@[simp] lemma vec_mul_vec_empty (v : m' → α) (w : fin 0 → α) :
+  vec_mul_vec v w = λ _, ![] :=
+funext (λ i, empty_eq _)
+
+@[simp] lemma cons_vec_mul_vec (x : α) (v : fin m → α) (w : n' → α) :
+  vec_mul_vec (vec_cons x v) w = vec_cons (x • w) (vec_mul_vec v w) :=
+by { ext i, refine fin.cases _ _ i; simp [vec_mul_vec] }
+
+@[simp] lemma vec_mul_vec_cons (v : m' → α) (x : α) (w : fin n → α) :
+  vec_mul_vec v (vec_cons x w) = λ i, v i • vec_cons x w :=
+by { ext i j, simp [vec_mul_vec]}
+
+end vec_mul_vec
+
+section smul
+
+variables [semiring α]
+
+@[simp] lemma smul_empty (x : α) (v : fin 0 → α) : x • v = ![] := empty_eq _
+
+@[simp] lemma smul_cons (x y : α) (v : fin n → α) :
+  x • vec_cons y v = vec_cons (x * y) (x • v) :=
+by { ext i, refine fin.cases _ _ i; simp }
+
+end smul
+
+section add
+
+variables [has_add α]
+
+@[simp] lemma empty_add_empty (v w : fin 0 → α) : v + w = ![] := empty_eq _
+
+@[simp] lemma cons_add (x : α) (v : fin n → α) (w : fin n.succ → α) :
+  vec_cons x v + w = vec_cons (x + vec_head w) (v + vec_tail w) :=
+by { ext i, refine fin.cases _ _ i; simp [vec_head, vec_tail] }
+
+@[simp] lemma add_cons (v : fin n.succ → α) (y : α) (w : fin n → α) :
+  v + vec_cons y w = vec_cons (vec_head v + y) (vec_tail v + w) :=
+by { ext i, refine fin.cases _ _ i; simp [vec_head, vec_tail] }
+
+end add
+
+section zero
+
+variables [has_zero α]
+
+@[simp] lemma zero_empty : (0 : fin 0 → α) = ![] :=
+empty_eq _
+
+@[simp] lemma cons_zero_zero : vec_cons (0 : α) (0 : fin n → α) = 0 :=
+by { ext i j, refine fin.cases _ _ i, { refl }, simp }
+
+@[simp] lemma head_zero : vec_head (0 : fin n.succ → α) = 0 := rfl
+
+@[simp] lemma tail_zero : vec_tail (0 : fin n.succ → α) = 0 := rfl
+
+@[simp] lemma cons_eq_zero_iff {v : fin n → α} {x : α} :
+  vec_cons x v = 0 ↔ x = 0 ∧ v = 0 :=
+⟨ λ h, ⟨ congr_fun h 0, by { convert congr_arg vec_tail h, simp } ⟩,
+  λ ⟨hx, hv⟩, by simp [hx, hv] ⟩
+
+open_locale classical
+
+lemma cons_nonzero_iff {v : fin n → α} {x : α} :
+  vec_cons x v ≠ 0 ↔ (x ≠ 0 ∨ v ≠ 0) :=
+⟨ λ h, not_and_distrib.mp (h ∘ cons_eq_zero_iff.mpr),
+  λ h, mt cons_eq_zero_iff.mp (not_and_distrib.mpr h) ⟩
+
+end zero
+
+section neg
+
+variables [has_neg α]
+
+@[simp] lemma neg_empty (v : fin 0 → α) : -v = ![] := empty_eq _
+
+@[simp] lemma neg_cons (x : α) (v : fin n → α) :
+  -(vec_cons x v) = vec_cons (-x) (-v) :=
+by { ext i, refine fin.cases _ _ i; simp }
+
+end neg
+
+section minor
+
+@[simp] lemma minor_empty (A : matrix m' n' α) (row : fin 0 → m') (col : o' → n') :
+  minor A row col = ![] :=
+empty_eq _
+
+@[simp] lemma minor_cons_row (A : matrix m' n' α) (i : m') (row : fin m → m') (col : o' → n') :
+  minor A (vec_cons i row) col = vec_cons (λ j, A i (col j)) (minor A row col) :=
+by { ext i j, refine fin.cases _ _ i; simp [minor] }
+
+end minor
+
+end matrix

--- a/src/data/matrix/pequiv.lean
+++ b/src/data/matrix/pequiv.lean
@@ -50,7 +50,7 @@ def to_matrix [decidable_eq n] [has_zero α] [has_one α] (f : m ≃. n) : matri
 lemma mul_matrix_apply [decidable_eq m] [semiring α] (f : l ≃. m) (M : matrix m n α) (i j) :
   (f.to_matrix ⬝ M) i j = option.cases_on (f i) 0 (λ fi, M fi j) :=
 begin
-  dsimp [to_matrix, matrix.mul],
+  dsimp [to_matrix, matrix.mul_val],
   cases h : f i with fi,
   { simp [h] },
   { rw finset.sum_eq_single fi;
@@ -68,7 +68,7 @@ by ext; simp [to_matrix, one_val]; congr
 lemma matrix_mul_apply [semiring α] [decidable_eq n] (M : matrix l m α) (f : m ≃. n) (i j) :
   (M ⬝ f.to_matrix) i j = option.cases_on (f.symm j) 0 (λ fj, M i fj) :=
 begin
-  dsimp [to_matrix, matrix.mul],
+  dsimp [to_matrix, matrix.mul_val],
   cases h : f.symm j with fj,
   { simp [h, f.eq_some_iff.symm] },
   { conv in (_ ∈ _) { rw ← f.mem_iff_mem },

--- a/test/matrix.lean
+++ b/test/matrix.lean
@@ -1,0 +1,25 @@
+import data.matrix.notation
+
+variables {α : Type} [semiring α]
+
+namespace matrix
+
+open_locale matrix
+
+example {a a' b b' c c' d d' : α} :
+  ![![a, b], ![c, d]] + ![![a', b'], ![c', d']] = ![![a + a', b + b'], ![c + c', d + d']] :=
+by simp
+
+example {a a' b b' c c' d d' : α} :
+  ![![a, b], ![c, d]] ⬝ ![![a', b'], ![c', d']] =
+    ![![a * a' + b * c', a * b' + b * d'], ![c * a' + d * c', c * b' + d * d']] :=
+by simp
+
+example {a b c d x y : α} :
+  mul_vec ![![a, b], ![c, d]] ![x, y] = ![a * x + b * y, c * x + d * y] :=
+by simp
+
+example {a b c d : α} : minor ![![a, b], ![c, d]] ![1, 0] ![0] = ![![c], ![a]] :=
+by { ext, simp }
+
+end matrix


### PR DESCRIPTION
This PR adds notation for matrices and vectors [as discussed on Zulip a couple of months ago](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Notation.20for.20matrices.20and.20vectors), so that `![![a, b], ![c, d]]` constructs a 2x2 matrix with rows `![a, b] : fin 2 -> α` and `![c, d]`. It also adds corresponding `simp` lemmas for all matrix operations defined in `data.matrix.basic`. These lemmas should apply only when the input already contains `![...]`.

To express the `simp` lemmas nicely, I defined a function `dot_product : (v w : n -> α) -> α` which returns the sum of the entrywise product of two vectors. IMO, this makes the definitions of `matrix.mul`, `matrix.mul_vec` and `matrix.vec_mul` clearer, and it allows us to share some proofs. I could also inline `dot_product` (restoring the old situation) if the reviewers prefer.