### PR TITLE
[Merged by Bors] - feat(analysis/specific_limits): more geometric series

### DIFF
--- a/src/analysis/analytic/basic.lean
+++ b/src/analysis/analytic/basic.lean
@@ -429,7 +429,7 @@ lemma formal_multilinear_series.has_fpower_series_on_ball [complete_space F]
     obtain ⟨a, C, ha, hC⟩ : ∃ a C, a < 1 ∧ ∀ n, nnnorm (p n) * (nnnorm y)^n ≤ C * a^n :=
       p.geometric_bound_of_lt_radius hy,
     refine (summable_of_norm_bounded (λ n, (C : ℝ) * a ^ n)
-      ((summable_geometric a.2 ha).mul_left _) (λ n, _)).has_sum,
+      ((summable_geometric_of_lt_1 a.2 ha).mul_left _) (λ n, _)).has_sum,
     calc ∥(p n) (λ (i : fin n), y)∥
       ≤ ∥p n∥ * (finset.univ.prod (λ i : fin n, ∥y∥)) : continuous_multilinear_map.le_op_norm _ _
       ... = nnnorm (p n) * (nnnorm y)^n : by simp

--- a/src/analysis/normed_space/banach.lean
+++ b/src/analysis/normed_space/banach.lean
@@ -146,7 +146,7 @@ begin
          ... = (1 / 2) ^ n * (C * ∥y∥) : by ring },
   have sNu : summable (λn, ∥u n∥),
   { refine summable_of_nonneg_of_le (λn, norm_nonneg _) ule _,
-    exact summable.mul_right _ (summable_geometric (by norm_num) (by norm_num)) },
+    exact summable.mul_right _ (summable_geometric_of_lt_1 (by norm_num) (by norm_num)) },
   have su : summable u := summable_of_summable_norm sNu,
   let x := tsum u,
   have x_ineq : ∥x∥ ≤ (2 * C + 1) * ∥y∥ := calc

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -16,7 +16,7 @@ variables {α : Type*} {β : Type*} {γ : Type*} {ι : Type*}
 
 noncomputable theory
 open filter metric
-open_locale topological_space
+open_locale topological_space big_operators
 localized "notation f `→_{`:50 a `}`:0 b := filter.tendsto f (_root_.nhds a) (_root_.nhds b)" in filter
 
 /-- Auxiliary class, endowing a type `α` with a function `norm : α → ℝ`. This class is designed to
@@ -624,6 +624,10 @@ lemma filter.tendsto.div [normed_field α] {l : filter β} {f g : β → α} {x 
   tendsto (λa, f a / g a) l (𝓝 (x / y)) :=
 hf.mul (hg.inv' hy)
 
+lemma filter.tendsto.div_const [normed_field α] {l : filter β} {f : β → α} {x y : α}
+  (hf : tendsto f l (𝓝 x)) : tendsto (λa, f a / y) l (𝓝 (x / y)) :=
+by { simp only [div_eq_inv_mul], exact tendsto_const_nhds.mul hf }
+
 /-- Continuity at a point of the result of dividing two functions
 continuous at that point, where the denominator is nonzero. -/
 lemma continuous_at.div [topological_space α] [normed_field β] {f : α → β} {g : α → β} {x : α}
@@ -856,7 +860,7 @@ its sum is converging to a limit `a`, then this holds along all finsets, i.e., `
 with sum `a`. -/
 lemma has_sum_of_subseq_of_summable {f : ι → α} (hf : summable (λa, ∥f a∥))
   {s : β → finset ι} {p : filter β} (hp : p ≠ ⊥)
-  (hs : tendsto s p at_top) {a : α} (ha : tendsto (λ b, (s b).sum f) p (𝓝 a)) :
+  (hs : tendsto s p at_top) {a : α} (ha : tendsto (λ b, ∑ i in s b, f i) p (𝓝 a)) :
   has_sum f a :=
 tendsto_nhds_of_cauchy_seq_of_subseq (cauchy_seq_finset_of_summable_norm hf) hp hs ha
 
@@ -873,6 +877,11 @@ begin
   { rw tsum_eq_zero_of_not_summable h,
     simp [tsum_nonneg] }
 end
+
+lemma has_sum_iff_tendsto_nat_of_summable_norm {f : ℕ → α} {a : α} (hf : summable (λi, ∥f i∥)) :
+  has_sum f a ↔ tendsto (λn:ℕ, ∑ i in range n, f i) at_top (𝓝 a) :=
+⟨λ h, h.tendsto_sum_nat,
+λ h, has_sum_of_subseq_of_summable hf at_top_ne_bot tendsto_finset_range h⟩
 
 variable [complete_space α]
 

--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -126,6 +126,26 @@ lemma summable_of_absolute_convergence_real {f : ℕ → ℝ} :
     simpa only using hr
   end
 
+lemma tendsto_inverse_at_top_nhds_0_nat : tendsto (λ n : ℕ, (n : ℝ)⁻¹) at_top (𝓝 0) :=
+tendsto_inv_at_top_zero.comp (tendsto_coe_nat_real_at_top_iff.2 tendsto_id)
+
+lemma tendsto_const_div_at_top_nhds_0_nat (C : ℝ) : tendsto (λ n : ℕ, C / n) at_top (𝓝 0) :=
+by simpa only [mul_zero] using tendsto_const_nhds.mul tendsto_inverse_at_top_nhds_0_nat
+
+lemma nnreal.tendsto_inverse_at_top_nhds_0_nat : tendsto (λ n : ℕ, (n : nnreal)⁻¹) at_top (𝓝 0) :=
+by { rw ← nnreal.tendsto_coe, convert tendsto_inverse_at_top_nhds_0_nat, simp }
+
+lemma nnreal.tendsto_const_div_at_top_nhds_0_nat (C : nnreal) :
+  tendsto (λ n : ℕ, C / n) at_top (𝓝 0) :=
+by simpa using tendsto_const_nhds.mul nnreal.tendsto_inverse_at_top_nhds_0_nat
+
+lemma tendsto_one_div_add_at_top_nhds_0_nat :
+  tendsto (λ n : ℕ, 1 / ((n : ℝ) + 1)) at_top (𝓝 0) :=
+suffices tendsto (λ n : ℕ, 1 / (↑(n + 1) : ℝ)) at_top (𝓝 0), by simpa,
+(tendsto_add_at_top_iff_nat 1).2 (tendsto_const_div_at_top_nhds_0_nat 1)
+
+/-! ### Powers -/
+
 lemma tendsto_pow_at_top_at_top_of_gt_1 {r : ℝ} (h : 1 < r) :
   tendsto (λn:ℕ, r ^ n) at_top at_top :=
 (tendsto_at_top_at_top _).2 $ assume p,
@@ -165,14 +185,18 @@ begin
   apply nnreal.tendsto_pow_at_top_nhds_0_of_lt_1 hr
 end
 
-lemma tendsto_pow_at_top_nhds_0_of_lt_1_normed_field {K : Type*} [normed_field K] {ξ : K}
+lemma tendsto_pow_at_top_nhds_0_of_norm_lt_1 {K : Type*} [normed_field K] {ξ : K}
   (_ : ∥ξ∥ < 1) : tendsto (λ n : ℕ, ξ^n) at_top (𝓝 0) :=
 begin
-  rw[tendsto_iff_norm_tendsto_zero],
+  rw [tendsto_iff_norm_tendsto_zero],
   convert tendsto_pow_at_top_nhds_0_of_lt_1 (norm_nonneg ξ) ‹∥ξ∥ < 1›,
   ext n,
   simp
 end
+
+lemma tendsto_pow_at_top_nhds_0_of_abs_lt_1 {r : ℝ} (h : abs r < 1) :
+  tendsto (λn:ℕ, r^n) at_top (𝓝 0) :=
+tendsto_pow_at_top_nhds_0_of_norm_lt_1 h
 
 lemma tendsto_pow_at_top_at_top_of_gt_1_nat {k : ℕ} (h : 1 < k) :
   tendsto (λn:ℕ, k ^ n) at_top at_top :=
@@ -180,25 +204,11 @@ tendsto_coe_nat_real_at_top_iff.1 $
   have hr : 1 < (k : ℝ), by rw [← nat.cast_one, nat.cast_lt]; exact h,
   by simpa using tendsto_pow_at_top_at_top_of_gt_1 hr
 
-lemma tendsto_inverse_at_top_nhds_0_nat : tendsto (λ n : ℕ, (n : ℝ)⁻¹) at_top (𝓝 0) :=
-tendsto_inv_at_top_zero.comp (tendsto_coe_nat_real_at_top_iff.2 tendsto_id)
 
-lemma tendsto_const_div_at_top_nhds_0_nat (C : ℝ) : tendsto (λ n : ℕ, C / n) at_top (𝓝 0) :=
-by simpa only [mul_zero] using tendsto_const_nhds.mul tendsto_inverse_at_top_nhds_0_nat
+/-! ### Geometric series-/
+section geometric
 
-lemma nnreal.tendsto_inverse_at_top_nhds_0_nat : tendsto (λ n : ℕ, (n : nnreal)⁻¹) at_top (𝓝 0) :=
-by { rw ← nnreal.tendsto_coe, convert tendsto_inverse_at_top_nhds_0_nat, simp }
-
-lemma nnreal.tendsto_const_div_at_top_nhds_0_nat (C : nnreal) :
-  tendsto (λ n : ℕ, C / n) at_top (𝓝 0) :=
-by simpa using tendsto_const_nhds.mul nnreal.tendsto_inverse_at_top_nhds_0_nat
-
-lemma tendsto_one_div_add_at_top_nhds_0_nat :
-  tendsto (λ n : ℕ, 1 / ((n : ℝ) + 1)) at_top (𝓝 0) :=
-suffices tendsto (λ n : ℕ, 1 / (↑(n + 1) : ℝ)) at_top (𝓝 0), by simpa,
-(tendsto_add_at_top_iff_nat 1).2 (tendsto_const_div_at_top_nhds_0_nat 1)
-
-lemma has_sum_geometric {r : ℝ} (h₁ : 0 ≤ r) (h₂ : r < 1) :
+lemma has_sum_geometric_of_lt_1 {r : ℝ} (h₁ : 0 ≤ r) (h₂ : r < 1) :
   has_sum (λn:ℕ, r ^ n) (1 - r)⁻¹ :=
 have r ≠ 1, from ne_of_lt h₂,
 have r + -1 ≠ 0,
@@ -209,14 +219,14 @@ have (λ n, (∑ i in range n, r ^ i)) = (λ n, geom_series r n) := rfl,
 (has_sum_iff_tendsto_nat_of_nonneg (pow_nonneg h₁) _).mpr $
   by simp [neg_inv, geom_sum, div_eq_mul_inv, *] at *
 
-lemma summable_geometric {r : ℝ} (h₁ : 0 ≤ r) (h₂ : r < 1) : summable (λn:ℕ, r ^ n) :=
-⟨_, has_sum_geometric h₁ h₂⟩
+lemma summable_geometric_of_lt_1 {r : ℝ} (h₁ : 0 ≤ r) (h₂ : r < 1) : summable (λn:ℕ, r ^ n) :=
+⟨_, has_sum_geometric_of_lt_1 h₁ h₂⟩
 
-lemma tsum_geometric {r : ℝ} (h₁ : 0 ≤ r) (h₂ : r < 1) : (∑'n:ℕ, r ^ n) = (1 - r)⁻¹ :=
-tsum_eq_has_sum (has_sum_geometric h₁ h₂)
+lemma tsum_geometric_of_lt_1 {r : ℝ} (h₁ : 0 ≤ r) (h₂ : r < 1) : (∑'n:ℕ, r ^ n) = (1 - r)⁻¹ :=
+tsum_eq_has_sum (has_sum_geometric_of_lt_1 h₁ h₂)
 
 lemma has_sum_geometric_two : has_sum (λn:ℕ, ((1:ℝ)/2) ^ n) 2 :=
-by convert has_sum_geometric _ _; norm_num
+by convert has_sum_geometric_of_lt_1 _ _; norm_num
 
 lemma summable_geometric_two : summable (λn:ℕ, ((1:ℝ)/2) ^ n) :=
 ⟨_, has_sum_geometric_two⟩
@@ -226,7 +236,7 @@ tsum_eq_has_sum has_sum_geometric_two
 
 lemma has_sum_geometric_two' (a : ℝ) : has_sum (λn:ℕ, (a / 2) / 2 ^ n) a :=
 begin
-  convert has_sum.mul_left (a / 2) (has_sum_geometric
+  convert has_sum.mul_left (a / 2) (has_sum_geometric_of_lt_1
     (le_of_lt one_half_pos) one_half_lt_one),
   { funext n, simp, refl, },
   { norm_num }
@@ -244,7 +254,7 @@ begin
   apply nnreal.has_sum_coe.1,
   push_cast,
   rw [nnreal.coe_sub (le_of_lt hr)],
-  exact has_sum_geometric r.coe_nonneg hr
+  exact has_sum_geometric_of_lt_1 r.coe_nonneg hr
 end
 
 lemma nnreal.summable_geometric {r : nnreal} (hr : r < 1) : summable (λn:ℕ, r ^ n) :=
@@ -270,21 +280,44 @@ begin
     ... ≤ ∑ i in range n, r ^ i : sum_le_sum (λ k _, this k) }
 end
 
-/-- For any positive `ε`, define on an encodable type a positive sequence with sum less than `ε` -/
-def pos_sum_of_encodable {ε : ℝ} (hε : 0 < ε)
-  (ι) [encodable ι] : {ε' : ι → ℝ // (∀ i, 0 < ε' i) ∧ ∃ c, has_sum ε' c ∧ c ≤ ε} :=
+variables {K : Type*} [normed_field K] {ξ : K}
+
+lemma has_sum_geometric_of_norm_lt_1 (h : ∥ξ∥ < 1) : has_sum (λn:ℕ, ξ ^ n) (1 - ξ)⁻¹ :=
 begin
-  let f := λ n, (ε / 2) / 2 ^ n,
-  have hf : has_sum f ε := has_sum_geometric_two' _,
-  have f0 : ∀ n, 0 < f n := λ n, div_pos (half_pos hε) (pow_pos two_pos _),
-  refine ⟨f ∘ encodable.encode, λ i, f0 _, _⟩,
-  rcases hf.summable.summable_comp_of_injective (@encodable.encode_injective ι _)
-    with ⟨c, hg⟩,
-  refine ⟨c, hg, has_sum_le_inj _ (@encodable.encode_injective ι _) _ _ hg hf⟩,
-  { assume i _, exact le_of_lt (f0 _) },
-  { assume n, exact le_refl _ }
+  have xi_ne_one : ξ ≠ 1, by { contrapose! h, simp [h] },
+  have A : tendsto (λn, (ξ ^ n - 1) * (ξ - 1)⁻¹) at_top (𝓝 ((0 - 1) * (ξ - 1)⁻¹)),
+    from ((tendsto_pow_at_top_nhds_0_of_norm_lt_1 h).sub tendsto_const_nhds).mul tendsto_const_nhds,
+  have B : (λ n, (∑ i in range n, ξ ^ i)) = (λ n, geom_series ξ n) := rfl,
+  rw [has_sum_iff_tendsto_nat_of_summable_norm, B],
+  { simpa [geom_sum, xi_ne_one, neg_inv] using A },
+  { simp [normed_field.norm_pow, summable_geometric_of_lt_1 (norm_nonneg _) h] }
 end
 
+lemma summable_geometric_of_norm_lt_1 (h : ∥ξ∥ < 1) : summable (λn:ℕ, ξ ^ n) :=
+⟨_, has_sum_geometric_of_norm_lt_1 h⟩
+
+lemma tsum_geometric_of_norm_lt_1 (h : ∥ξ∥ < 1) : (∑'n:ℕ, ξ ^ n) = (1 - ξ)⁻¹ :=
+tsum_eq_has_sum (has_sum_geometric_of_norm_lt_1 h)
+
+lemma has_sum_geometric_of_abs_lt_1 {r : ℝ} (h : abs r < 1) : has_sum (λn:ℕ, r ^ n) (1 - r)⁻¹ :=
+has_sum_geometric_of_norm_lt_1 h
+
+lemma summable_geometric_of_abs_lt_1 {r : ℝ} (h : abs r < 1) : summable (λn:ℕ, r ^ n) :=
+summable_geometric_of_norm_lt_1 h
+
+lemma tsum_geometric_of_abs_lt_1 {r : ℝ} (h : abs r < 1) : (∑'n:ℕ, r ^ n) = (1 - r)⁻¹ :=
+tsum_geometric_of_norm_lt_1 h
+
+end geometric
+
+/-!
+### Sequences with geometrically decaying distance in metric spaces
+
+In this paragraph, we discuss sequences in metric spaces or emetric spaces for which the distance
+between two consecutive terms decays geometrically. We show that such sequences are Cauchy
+sequences, and bound their distances to the limit. We also discuss series with geometrically
+decaying terms.
+-/
 section edist_le_geometric
 
 variables [emetric_space α] (r C : ennreal) (hr : r < 1) (hC : C ≠ ⊤) {f : ℕ → α}
@@ -374,7 +407,7 @@ begin
   { have rnonneg: r ≥ 0, from nonneg_of_mul_nonneg_left
       (by simpa only [pow_one] using le_trans dist_nonneg (hu 1)) Cpos,
     refine has_sum.mul_left C _,
-    by simpa using has_sum_geometric rnonneg hr }
+    by simpa using has_sum_geometric_of_lt_1 rnonneg hr }
 end
 
 variables (r C)
@@ -464,6 +497,23 @@ begin
 end
 
 end summable_le_geometric
+
+/-! ### Positive sequences with small sums on encodable types -/
+
+/-- For any positive `ε`, define on an encodable type a positive sequence with sum less than `ε` -/
+def pos_sum_of_encodable {ε : ℝ} (hε : 0 < ε)
+  (ι) [encodable ι] : {ε' : ι → ℝ // (∀ i, 0 < ε' i) ∧ ∃ c, has_sum ε' c ∧ c ≤ ε} :=
+begin
+  let f := λ n, (ε / 2) / 2 ^ n,
+  have hf : has_sum f ε := has_sum_geometric_two' _,
+  have f0 : ∀ n, 0 < f n := λ n, div_pos (half_pos hε) (pow_pos two_pos _),
+  refine ⟨f ∘ encodable.encode, λ i, f0 _, _⟩,
+  rcases hf.summable.summable_comp_of_injective (@encodable.encode_injective ι _)
+    with ⟨c, hg⟩,
+  refine ⟨c, hg, has_sum_le_inj _ (@encodable.encode_injective ι _) _ _ hg hf⟩,
+  { assume i _, exact le_of_lt (f0 _) },
+  { assume n, exact le_refl _ }
+end
 
 namespace nnreal
 

--- a/src/data/real/cardinality.lean
+++ b/src/data/real/cardinality.lean
@@ -37,7 +37,7 @@ by { ext n, cases h : f (n + 1); simp [h, _root_.pow_succ] }
 lemma summable_cantor_function (f : ℕ → bool) (h1 : 0 ≤ c) (h2 : c < 1) :
   summable (cantor_function_aux c f) :=
 begin
-  apply (summable_geometric h1 h2).summable_of_eq_zero_or_self,
+  apply (summable_geometric_of_lt_1 h1 h2).summable_of_eq_zero_or_self,
   intro n, cases h : f n; simp [h]
 end
 
@@ -78,7 +78,7 @@ begin
       rwa sub_pos },
     convert this,
     { rw [cantor_function_succ _ (le_of_lt h1) h3, div_eq_mul_inv,
-          ←tsum_geometric (le_of_lt h1) h3],
+          ←tsum_geometric_of_lt_1 (le_of_lt h1) h3],
       apply zero_add },
     { apply tsum_eq_single 0, intros n hn, cases n, contradiction, refl, apply_instance }},
   rw [cantor_function_succ f (le_of_lt h1) h3, cantor_function_succ g (le_of_lt h1) h3],


### PR DESCRIPTION
Currently, the sum of a geometric series is only known for real numbers in `[0,1)`. We prove it for any element of a normed field with norm `< 1`, and specialize it to real numbers in `(-1, 1)`.

Some lemmas in `analysis/specific_limits` are also moved around (but their content is not changed) to get a better organization of this file.