### PR TITLE
[Merged by Bors] - feat(topology/bounded_continuous_function): the normed space C^0

### DIFF
--- a/src/topology/bounded_continuous_function.lean
+++ b/src/topology/bounded_continuous_function.lean
@@ -19,7 +19,7 @@ open_locale topological_space classical
 open set filter metric
 
 universes u v w
-variables {α : Type u} {β : Type v} {γ : Type w}
+variables {α : Type u} {β : Type v} {γ : Type w} {𝕜 : Type*}
 
 /-- The type of bounded continuous functions from a topological space to a metric space -/
 def bounded_continuous_function (α : Type u) (β : Type v) [topological_space α] [metric_space β] :
@@ -429,5 +429,115 @@ def of_normed_group_discrete {α : Type u} {β : Type v}
   (f : α  → β) (C : ℝ) (H : ∀x, norm (f x) ≤ C) : α →ᵇ β :=
 of_normed_group f C H continuous_of_discrete_topology
 
+/- Formula for norm. -/
+lemma norm_eq ( f : α →ᵇ β) :
+  ∥ f ∥  = Inf {C : ℝ | C ≥ 0 ∧ ∀ (x : α), ∥ f x ∥ ≤ C} :=
+begin
+  rw ← sub_zero f,
+  rw ← dist_eq_norm,
+  rw bounded_continuous_function.dist_eq,
+  simp,
+end
+
+
 end normed_group
+
+
+section normed_space
+/- In this section, if β is a normed space, then we show that the space of bounded
+continuous functions from α to β inherits a normed space structure, by using
+pointwise operations and checking that they are compatible with the uniform distance. -/
+
+variables [nondiscrete_normed_field 𝕜]
+variables [topological_space α] [normed_group β] [normed_space 𝕜 β]
+variables {f g : α →ᵇ β} {x : α} {C : ℝ}
+
+
+instance : has_scalar 𝕜 (α →ᵇ β) :=
+  ⟨λc, λf, ⟨ λx, c • f.1 x,
+    begin
+      have h : continuous (λ x : α, c),
+        exact continuous_const,
+      exact continuous.smul h f.2.left,
+    end,
+    begin
+      cases f.2.right with C hbound,
+      use ∥ c ∥ * C,
+      intros,
+      have hnneg : ∥ c ∥ ≥ 0,
+      { exact norm_nonneg c },
+      specialize hbound x y,
+      rw dist_eq_norm at hbound,
+      rw dist_eq_norm,
+      calc ∥c • f x - c • f y∥ = ∥ c • (f x - f y) ∥ : by rw smul_sub c (f x) (f y)
+      ... = ∥ c ∥ * ∥ f x - f y ∥ : norm_smul c (f x - f y)
+      ... ≤ ∥ c ∥ * C : mul_le_mul_of_nonneg_left hbound hnneg,
+    end⟩⟩
+
+
+instance : module 𝕜 (α →ᵇ β) :=
+  module.of_core $ begin
+    refine { smul := (•), ..},
+    intros c f g, ext,
+    exact smul_add c (f x) (g x),
+    intros c₁ c₂ f, ext,
+    exact add_smul c₁ c₂ (f x),
+    intros c₁ c₂ f,
+    ext, exact mul_smul c₁ c₂ (f x),
+    intros f,
+    ext, exact one_smul 𝕜 (f x),
+  end
+
+
+instance : vector_space 𝕜 (α →ᵇ β) :=
+  { .. bounded_continuous_function.module }
+
+
+lemma bounded_continuous_sub_smul (c : 𝕜) (f : α →ᵇ β) :  ∥c • f∥ ≤ ∥c∥ * ∥f∥ :=
+begin
+  have hnneg : ∥ c ∥ ≥ 0,
+    exact norm_nonneg c,
+  rw norm_eq (c • f),
+  apply real.Inf_le,
+  { use 0, intros y hy,
+    rw set.mem_set_of_eq at hy,
+    exact hy.left,},
+  { rw set.mem_set_of_eq,
+    split,
+    exact mul_nonneg' hnneg (norm_nonneg f),
+    intros,
+    calc ∥ (c • f) x ∥ = ∥ c ∥ * ∥ f x ∥ : norm_smul c (f x)
+    ... ≤ ∥ c ∥ * ∥ f ∥ : mul_le_mul_of_nonneg_left (norm_coe_le_norm x) hnneg,}
+end
+
+
+lemma bounded_continuous_smul (c : 𝕜) (f : α →ᵇ β) :  ∥c • f∥ = ∥c∥ * ∥f∥ :=
+begin
+  by_cases ( c = 0),
+  rw h, simp,
+  have hnneg : ∥ c ∥ ≥ 0,
+    exact norm_nonneg c,
+  apply le_antisymm,
+  exact bounded_continuous_sub_smul c f,
+  have hinv : ∥ f ∥ ≤ ∥ 1 / c ∥ * ∥ c • f ∥,
+    calc ∥ f ∥ = ∥ (1 : 𝕜) • f ∥ : by simp
+    ... = ∥ (1 / c * c ) • f ∥ : by rw (div_mul_cancel 1 h)
+    ... = ∥ (1 / c) • ( c • f) ∥ : by rw (mul_smul _ _ _).symm
+    ... ≤ ∥ 1 / c ∥ * ∥ c • f ∥ : bounded_continuous_sub_smul (1 / c) (c • f),
+  calc ∥ c ∥ * ∥ f ∥  ≤ ∥ c ∥ * (∥ 1 / c ∥ * ∥ c • f ∥) : mul_le_mul_of_nonneg_left hinv hnneg
+  ... = (∥ c ∥ * ∥ 1 / c ∥) * ∥ c • f ∥ : by ring
+  ... = ∥ c * (1 / c) ∥ * ∥ c • f ∥ : by rw (normed_field.norm_mul c (1/c))
+  ... = ∥ (1 : 𝕜) ∥ * ∥ c • f ∥ : by rw (mul_div_cancel' 1 h)
+  ... = 1 * ∥ c • f ∥ : by rw normed_field.norm_one
+  ... = ∥ c • f ∥ : by ring,
+end
+
+
+instance : normed_space 𝕜 (α →ᵇ β) :=
+⟨ begin
+    exact bounded_continuous_smul,
+  end ⟩
+
+end normed_space
+
 end bounded_continuous_function

--- a/src/topology/bounded_continuous_function.lean
+++ b/src/topology/bounded_continuous_function.lean
@@ -464,12 +464,12 @@ instance : has_scalar 𝕜 (α →ᵇ β) :=
   end⟩⟩
 
 instance : module 𝕜 (α →ᵇ β) :=
-  module.of_core $
-  { smul     := (•),
-    smul_add := λ c f g, ext $ λ x, smul_add c (f x) (g x),
-    add_smul := λ c₁ c₂ f, ext $ λ x, add_smul c₁ c₂ (f x),
-    mul_smul := λ c₁ c₂ f, ext $ λ x, mul_smul c₁ c₂ (f x),
-    one_smul := λ f, ext $ λ x, one_smul 𝕜 (f x) }
+module.of_core $
+{ smul     := (•),
+  smul_add := λ c f g, ext $ λ x, smul_add c (f x) (g x),
+  add_smul := λ c₁ c₂ f, ext $ λ x, add_smul c₁ c₂ (f x),
+  mul_smul := λ c₁ c₂ f, ext $ λ x, mul_smul c₁ c₂ (f x),
+  one_smul := λ f, ext $ λ x, one_smul 𝕜 (f x) }
 
 instance : vector_space 𝕜 (α →ᵇ β) :=
 { .. bounded_continuous_function.module }

--- a/src/topology/bounded_continuous_function.lean
+++ b/src/topology/bounded_continuous_function.lean
@@ -490,7 +490,7 @@ begin
       ... ≤ ∥c∥ * ∥f∥ : mul_le_mul_of_nonneg_left (norm_coe_le_norm x) hnneg } }
 end
 
-lemma bounded_continuous_smul (c : 𝕜) (f : α →ᵇ β) : ∥c • f∥ = ∥c∥ * ∥f∥ :=
+lemma norm_smul (c : 𝕜) (f : α →ᵇ β) : ∥c • f∥ = ∥c∥ * ∥f∥ :=
 begin
   by_cases h : c = 0,
   { rw [h, zero_smul, norm_zero, norm_zero, zero_mul] },
@@ -502,16 +502,15 @@ begin
         ... = ∥(1 / c * c ) • f∥ : by rw (div_mul_cancel 1 h)
         ... = ∥(1 / c) • ( c • f)∥ : by rw ← (mul_smul _ _ _)
         ... ≤ ∥1 / c∥ * ∥c • f∥ : (c • f).norm_smul_le (1 / c) },
-    calc ∥c∥ * ∥f∥  ≤ ∥c∥ * (∥1 / c∥ * ∥c • f∥) : mul_le_mul_of_nonneg_left hinv hnneg
-    ... = (∥c ∥ * ∥1 / c∥) * ∥c • f∥ : (mul_assoc _ _ _).symm
-    ... = ∥c * (1 / c)∥ * ∥c • f∥ : by rw (normed_field.norm_mul c (1/c))
-    ... = ∥(1 : 𝕜)∥ * ∥c • f∥ : by rw (mul_div_cancel' 1 h)
-    ... = 1 * ∥c • f∥ : by rw normed_field.norm_one
-    ... = ∥c • f∥ : one_mul _ } }
+      calc ∥c∥ * ∥f∥  ≤ ∥c∥ * (∥1 / c∥ * ∥c • f∥) : mul_le_mul_of_nonneg_left hinv hnneg
+      ... = (∥c ∥ * ∥1 / c∥) * ∥c • f∥ : (mul_assoc _ _ _).symm
+      ... = ∥c * (1 / c)∥ * ∥c • f∥ : by rw (normed_field.norm_mul c (1/c))
+      ... = ∥(1 : 𝕜)∥ * ∥c • f∥ : by rw (mul_div_cancel' 1 h)
+      ... = 1 * ∥c • f∥ : by rw normed_field.norm_one
+      ... = ∥c • f∥ : one_mul _ } }
 end
 
-instance : normed_space 𝕜 (α →ᵇ β) :=
-⟨bounded_continuous_smul⟩
+instance : normed_space 𝕜 (α →ᵇ β) := ⟨norm_smul⟩
 
 end normed_space
 

--- a/src/topology/bounded_continuous_function.lean
+++ b/src/topology/bounded_continuous_function.lean
@@ -460,8 +460,7 @@ instance : has_scalar 𝕜 (α →ᵇ β) :=
     have hnneg : 0 ≤ ∥c∥,
     { exact norm_nonneg c },
     specialize hbound x y,
-    rw dist_eq_norm at hbound,
-    rw dist_eq_norm,
+    rw dist_eq_norm at hbound ⊢,
       calc ∥c • f x - c • f y∥ = ∥c • (f x - f y)∥ : by rw smul_sub c (f x) (f y)
     ... = ∥c∥ * ∥f x - f y∥ : norm_smul c (f x - f y)
     ... ≤ ∥c∥ * C : mul_le_mul_of_nonneg_left hbound hnneg,
@@ -469,17 +468,25 @@ instance : has_scalar 𝕜 (α →ᵇ β) :=
 
 
 instance : module 𝕜 (α →ᵇ β) :=
-  module.of_core $ begin
-    refine { smul := (•), ..},
+  module.of_core $
+  { smul := (•),
+    smul_add := begin
     intros c f g, ext,
-    exact smul_add c (f x) (g x),
+    exact smul_add c (f x) (g x)
+    end,
+    add_smul := begin
     intros c₁ c₂ f, ext,
     exact add_smul c₁ c₂ (f x),
+    end,
+    mul_smul := begin
     intros c₁ c₂ f,
     ext, exact mul_smul c₁ c₂ (f x),
+    end,
+    one_smul := begin
     intros f,
     ext, exact one_smul 𝕜 (f x),
-  end
+    end }
+
 
 
 instance : vector_space 𝕜 (α →ᵇ β) :=
@@ -505,7 +512,7 @@ end
 
 lemma bounded_continuous_smul (c : 𝕜) (f : α →ᵇ β) : ∥c • f∥ = ∥c∥ * ∥f∥ :=
 begin
-  by_cases (c = 0),
+  by_cases h : c = 0,
   rw h, simp,
   have hnneg : 0 ≤ ∥c∥,
     exact norm_nonneg c,

--- a/src/topology/bounded_continuous_function.lean
+++ b/src/topology/bounded_continuous_function.lean
@@ -498,16 +498,16 @@ begin
     apply le_antisymm,
     { exact bounded_continuous_sub_smul c f, },
     { have hinv : ∥f∥ ≤ ∥1 / c∥ * ∥c • f∥,
-      { calc ∥f ∥= ∥(1 : 𝕜) • f∥ : by rw one_smul
+      { calc ∥f∥ = ∥(1 : 𝕜) • f∥ : by rw one_smul
         ... = ∥(1 / c * c ) • f∥ : by rw (div_mul_cancel 1 h)
         ... = ∥(1 / c) • ( c • f)∥ : by rw (mul_smul _ _ _).symm
         ... ≤ ∥1 / c∥ * ∥c • f∥ : bounded_continuous_sub_smul (1 / c) (c • f) },
       calc ∥c∥ * ∥f∥  ≤ ∥c∥ * (∥1 / c∥ * ∥c • f∥) : mul_le_mul_of_nonneg_left hinv hnneg
-      ... = (∥c ∥ * ∥1 / c∥) * ∥c • f∥ : by rw mul_assoc
+      ... = (∥c ∥ * ∥1 / c∥) * ∥c • f∥ : (mul_assoc _ _ _).symm
       ... = ∥c * (1 / c)∥ * ∥c • f∥ : by rw (normed_field.norm_mul c (1/c))
       ... = ∥(1 : 𝕜)∥ * ∥c • f∥ : by rw (mul_div_cancel' 1 h)
       ... = 1 * ∥c • f∥ : by rw normed_field.norm_one
-      ... = ∥c • f∥ : by rw one_mul, } }
+      ... = ∥c • f∥ : one_mul _, } }
 end
 
 instance : normed_space 𝕜 (α →ᵇ β) :=

--- a/src/topology/bounded_continuous_function.lean
+++ b/src/topology/bounded_continuous_function.lean
@@ -460,12 +460,12 @@ instance : has_scalar 𝕜 (α →ᵇ β) :=
     rw dist_eq_norm at hbound ⊢,
     calc ∥c • f x - c • f y∥ = ∥c • (f x - f y)∥ : by rw smul_sub c (f x) (f y)
     ... = ∥c∥ * ∥f x - f y∥ : norm_smul c (f x - f y)
-    ... ≤ ∥c∥ * C : mul_le_mul_of_nonneg_left hbound hnneg,
+    ... ≤ ∥c∥ * C : mul_le_mul_of_nonneg_left hbound hnneg
   end⟩⟩
 
 instance : module 𝕜 (α →ᵇ β) :=
   module.of_core $
-  { smul := (•),
+  { smul     := (•),
     smul_add := λ c f g, ext $ λ x, smul_add c (f x) (g x),
     add_smul := λ c₁ c₂ f, ext $ λ x, add_smul c₁ c₂ (f x),
     mul_smul := λ c₁ c₂ f, ext $ λ x, mul_smul c₁ c₂ (f x),
@@ -493,21 +493,21 @@ end
 lemma bounded_continuous_smul (c : 𝕜) (f : α →ᵇ β) : ∥c • f∥ = ∥c∥ * ∥f∥ :=
 begin
   by_cases h : c = 0,
-  { rw [h, zero_smul, norm_zero, norm_zero, zero_mul], },
+  { rw [h, zero_smul, norm_zero, norm_zero, zero_mul] },
   { have hnneg : 0 ≤ ∥c∥ := norm_nonneg c,
     apply le_antisymm,
-    { exact bounded_continuous_sub_smul c f, },
+    { exact bounded_continuous_sub_smul c f },
     { have hinv : ∥f∥ ≤ ∥1 / c∥ * ∥c • f∥,
       { calc ∥f∥ = ∥(1 : 𝕜) • f∥ : by rw one_smul
         ... = ∥(1 / c * c ) • f∥ : by rw (div_mul_cancel 1 h)
-        ... = ∥(1 / c) • ( c • f)∥ : by rw (mul_smul _ _ _).symm
+        ... = ∥(1 / c) • ( c • f)∥ : by rw ← (mul_smul _ _ _)
         ... ≤ ∥1 / c∥ * ∥c • f∥ : bounded_continuous_sub_smul (1 / c) (c • f) },
-      calc ∥c∥ * ∥f∥  ≤ ∥c∥ * (∥1 / c∥ * ∥c • f∥) : mul_le_mul_of_nonneg_left hinv hnneg
-      ... = (∥c ∥ * ∥1 / c∥) * ∥c • f∥ : (mul_assoc _ _ _).symm
-      ... = ∥c * (1 / c)∥ * ∥c • f∥ : by rw (normed_field.norm_mul c (1/c))
-      ... = ∥(1 : 𝕜)∥ * ∥c • f∥ : by rw (mul_div_cancel' 1 h)
-      ... = 1 * ∥c • f∥ : by rw normed_field.norm_one
-      ... = ∥c • f∥ : one_mul _, } }
+    calc ∥c∥ * ∥f∥  ≤ ∥c∥ * (∥1 / c∥ * ∥c • f∥) : mul_le_mul_of_nonneg_left hinv hnneg
+    ... = (∥c ∥ * ∥1 / c∥) * ∥c • f∥ : (mul_assoc _ _ _).symm
+    ... = ∥c * (1 / c)∥ * ∥c • f∥ : by rw (normed_field.norm_mul c (1/c))
+    ... = ∥(1 : 𝕜)∥ * ∥c • f∥ : by rw (mul_div_cancel' 1 h)
+    ... = 1 * ∥c • f∥ : by rw normed_field.norm_one
+    ... = ∥c • f∥ : one_mul _ } }
 end
 
 instance : normed_space 𝕜 (α →ᵇ β) :=

--- a/src/topology/bounded_continuous_function.lean
+++ b/src/topology/bounded_continuous_function.lean
@@ -51,11 +51,11 @@ def mk_of_discrete [discrete_topology α] (f : α → β) (hf : ∃C, ∀x y, di
 
 /-- The uniform distance between two bounded continuous functions -/
 instance : has_dist (α →ᵇ β) :=
-⟨λf g, Inf {C | C ≥ 0 ∧ ∀ x : α, dist (f x) (g x) ≤ C}⟩
+⟨λf g, Inf {C | 0 ≤ C ∧ ∀ x : α, dist (f x) (g x) ≤ C}⟩
 
-lemma dist_eq : dist f g = Inf {C | C ≥ 0 ∧ ∀ x : α, dist (f x) (g x) ≤ C} := rfl
+lemma dist_eq : dist f g = Inf {C | 0 ≤ C ∧ ∀ x : α, dist (f x) (g x) ≤ C} := rfl
 
-lemma dist_set_exists : ∃ C, C ≥ 0 ∧ ∀ x : α, dist (f x) (g x) ≤ C :=
+lemma dist_set_exists : ∃ C, 0 ≤ C ∧ ∀ x : α, dist (f x) (g x) ≤ C :=
 begin
   refine if h : nonempty α then _ else ⟨0, le_refl _, λ x, h.elim ⟨x⟩⟩,
   cases h with x,
@@ -431,7 +431,7 @@ of_normed_group f C H continuous_of_discrete_topology
 
 /- Formula for norm. -/
 lemma norm_eq ( f : α →ᵇ β) :
-  ∥ f ∥  = Inf {C : ℝ | C ≥ 0 ∧ ∀ (x : α), ∥ f x ∥ ≤ C} :=
+  ∥f∥ = Inf {C : ℝ | 0 ≤ C ∧ ∀ (x : α), ∥f x∥ ≤ C} :=
 begin
   rw ← sub_zero f,
   rw ← dist_eq_norm,
@@ -454,24 +454,20 @@ variables {f g : α →ᵇ β} {x : α} {C : ℝ}
 
 
 instance : has_scalar 𝕜 (α →ᵇ β) :=
-  ⟨λc, λf, ⟨ λx, c • f.1 x,
-    begin
-      have h : continuous (λ x : α, c),
-        exact continuous_const,
-      exact continuous.smul h f.2.left,
-    end,
+  ⟨λc, λf, ⟨λx, c • f.1 x,
+    continuous.smul continuous_const f.2.left,
     begin
       cases f.2.right with C hbound,
-      use ∥ c ∥ * C,
+      use ∥c∥ * C,
       intros,
-      have hnneg : ∥ c ∥ ≥ 0,
+      have hnneg : 0 ≤ ∥c∥,
       { exact norm_nonneg c },
       specialize hbound x y,
       rw dist_eq_norm at hbound,
       rw dist_eq_norm,
-      calc ∥c • f x - c • f y∥ = ∥ c • (f x - f y) ∥ : by rw smul_sub c (f x) (f y)
-      ... = ∥ c ∥ * ∥ f x - f y ∥ : norm_smul c (f x - f y)
-      ... ≤ ∥ c ∥ * C : mul_le_mul_of_nonneg_left hbound hnneg,
+      calc ∥c • f x - c • f y∥ = ∥c • (f x - f y)∥ : by rw smul_sub c (f x) (f y)
+      ... = ∥c∥ * ∥f x - f y∥ : norm_smul c (f x - f y)
+      ... ≤ ∥c∥ * C : mul_le_mul_of_nonneg_left hbound hnneg,
     end⟩⟩
 
 
@@ -495,7 +491,7 @@ instance : vector_space 𝕜 (α →ᵇ β) :=
 
 lemma bounded_continuous_sub_smul (c : 𝕜) (f : α →ᵇ β) :  ∥c • f∥ ≤ ∥c∥ * ∥f∥ :=
 begin
-  have hnneg : ∥ c ∥ ≥ 0,
+  have hnneg : 0 ≤ ∥ c ∥,
     exact norm_nonneg c,
   rw norm_eq (c • f),
   apply real.Inf_le,
@@ -506,8 +502,8 @@ begin
     split,
     exact mul_nonneg' hnneg (norm_nonneg f),
     intros,
-    calc ∥ (c • f) x ∥ = ∥ c ∥ * ∥ f x ∥ : norm_smul c (f x)
-    ... ≤ ∥ c ∥ * ∥ f ∥ : mul_le_mul_of_nonneg_left (norm_coe_le_norm x) hnneg,}
+    calc ∥(c • f) x∥ = ∥c∥ * ∥f x∥ : norm_smul c (f x)
+    ... ≤ ∥c∥ * ∥f∥ : mul_le_mul_of_nonneg_left (norm_coe_le_norm x) hnneg,}
 end
 
 
@@ -515,28 +511,26 @@ lemma bounded_continuous_smul (c : 𝕜) (f : α →ᵇ β) :  ∥c • f∥ = �
 begin
   by_cases ( c = 0),
   rw h, simp,
-  have hnneg : ∥ c ∥ ≥ 0,
+  have hnneg : 0 ≤ ∥c∥,
     exact norm_nonneg c,
   apply le_antisymm,
   exact bounded_continuous_sub_smul c f,
-  have hinv : ∥ f ∥ ≤ ∥ 1 / c ∥ * ∥ c • f ∥,
-    calc ∥ f ∥ = ∥ (1 : 𝕜) • f ∥ : by simp
-    ... = ∥ (1 / c * c ) • f ∥ : by rw (div_mul_cancel 1 h)
-    ... = ∥ (1 / c) • ( c • f) ∥ : by rw (mul_smul _ _ _).symm
-    ... ≤ ∥ 1 / c ∥ * ∥ c • f ∥ : bounded_continuous_sub_smul (1 / c) (c • f),
-  calc ∥ c ∥ * ∥ f ∥  ≤ ∥ c ∥ * (∥ 1 / c ∥ * ∥ c • f ∥) : mul_le_mul_of_nonneg_left hinv hnneg
-  ... = (∥ c ∥ * ∥ 1 / c ∥) * ∥ c • f ∥ : by ring
-  ... = ∥ c * (1 / c) ∥ * ∥ c • f ∥ : by rw (normed_field.norm_mul c (1/c))
-  ... = ∥ (1 : 𝕜) ∥ * ∥ c • f ∥ : by rw (mul_div_cancel' 1 h)
-  ... = 1 * ∥ c • f ∥ : by rw normed_field.norm_one
-  ... = ∥ c • f ∥ : by ring,
+  have hinv : ∥f∥ ≤ ∥1 / c∥ * ∥c • f∥,
+    calc ∥f ∥= ∥(1 : 𝕜) • f∥ : by simp
+    ... = ∥(1 / c * c ) • f∥ : by rw (div_mul_cancel 1 h)
+    ... = ∥(1 / c) • ( c • f)∥ : by rw (mul_smul _ _ _).symm
+    ... ≤ ∥1 / c∥ * ∥c • f∥ : bounded_continuous_sub_smul (1 / c) (c • f),
+  calc ∥c∥ * ∥f∥  ≤ ∥c∥ * (∥1 / c∥ * ∥c • f∥) : mul_le_mul_of_nonneg_left hinv hnneg
+  ... = (∥c ∥ * ∥1 / c∥) * ∥c • f∥ : by ring
+  ... = ∥c * (1 / c)∥ * ∥c • f∥ : by rw (normed_field.norm_mul c (1/c))
+  ... = ∥(1 : 𝕜)∥ * ∥c • f∥ : by rw (mul_div_cancel' 1 h)
+  ... = 1 * ∥c • f∥ : by rw normed_field.norm_one
+  ... = ∥c • f∥ : by ring,
 end
 
 
 instance : normed_space 𝕜 (α →ᵇ β) :=
-⟨ begin
-    exact bounded_continuous_smul,
-  end ⟩
+  ⟨bounded_continuous_smul⟩
 
 end normed_space
 

--- a/src/topology/bounded_continuous_function.lean
+++ b/src/topology/bounded_continuous_function.lean
@@ -19,7 +19,7 @@ open_locale topological_space classical
 open set filter metric
 
 universes u v w
-variables {α : Type u} {β : Type v} {γ : Type w} {𝕜 : Type*}
+variables {α : Type u} {β : Type v} {γ : Type w}
 
 /-- The type of bounded continuous functions from a topological space to a metric space -/
 def bounded_continuous_function (α : Type u) (β : Type v) [topological_space α] [metric_space β] :
@@ -437,16 +437,14 @@ begin
   simp,
 end
 
-
 end normed_group
-
 
 section normed_space
 /-! In this section, if `β` is a normed space, then we show that the space of bounded
 continuous functions from `α` to `β` inherits a normed space structure, by using
 pointwise operations and checking that they are compatible with the uniform distance. -/
 
-variables [nondiscrete_normed_field 𝕜]
+variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 variables [topological_space α] [normed_group β] [normed_space 𝕜 β]
 variables {f g : α →ᵇ β} {x : α} {C : ℝ}
 
@@ -457,46 +455,28 @@ instance : has_scalar 𝕜 (α →ᵇ β) :=
     cases f.2.right with C hbound,
     use ∥c∥ * C,
     intros,
-    have hnneg : 0 ≤ ∥c∥,
-    { exact norm_nonneg c },
+    have hnneg : 0 ≤ ∥c∥ := norm_nonneg c,
     specialize hbound x y,
     rw dist_eq_norm at hbound ⊢,
-      calc ∥c • f x - c • f y∥ = ∥c • (f x - f y)∥ : by rw smul_sub c (f x) (f y)
+    calc ∥c • f x - c • f y∥ = ∥c • (f x - f y)∥ : by rw smul_sub c (f x) (f y)
     ... = ∥c∥ * ∥f x - f y∥ : norm_smul c (f x - f y)
     ... ≤ ∥c∥ * C : mul_le_mul_of_nonneg_left hbound hnneg,
   end⟩⟩
 
-
 instance : module 𝕜 (α →ᵇ β) :=
   module.of_core $
   { smul := (•),
-    smul_add := begin
-    intros c f g, ext,
-    exact smul_add c (f x) (g x)
-    end,
-    add_smul := begin
-    intros c₁ c₂ f, ext,
-    exact add_smul c₁ c₂ (f x),
-    end,
-    mul_smul := begin
-    intros c₁ c₂ f,
-    ext, exact mul_smul c₁ c₂ (f x),
-    end,
-    one_smul := begin
-    intros f,
-    ext, exact one_smul 𝕜 (f x),
-    end }
-
-
+    smul_add := λ c f g, ext $ λ x, smul_add c (f x) (g x),
+    add_smul := λ c₁ c₂ f, ext $ λ x, add_smul c₁ c₂ (f x),
+    mul_smul := λ c₁ c₂ f, ext $ λ x, mul_smul c₁ c₂ (f x),
+    one_smul := λ f, ext $ λ x, one_smul 𝕜 (f x) }
 
 instance : vector_space 𝕜 (α →ᵇ β) :=
 { .. bounded_continuous_function.module }
 
-
-lemma bounded_continuous_sub_smul (c : 𝕜) (f : α →ᵇ β) :  ∥c • f∥ ≤ ∥c∥ * ∥f∥ :=
+lemma bounded_continuous_sub_smul (c : 𝕜) (f : α →ᵇ β) : ∥c • f∥ ≤ ∥c∥ * ∥f∥ :=
 begin
-  have hnneg : 0 ≤ ∥ c ∥,
-    exact norm_nonneg c,
+  have hnneg : 0 ≤ ∥ c ∥ := norm_nonneg c,
   rw norm_eq (c • f),
   apply real.Inf_le,
   { use 0, intros y hy,
@@ -513,24 +493,22 @@ end
 lemma bounded_continuous_smul (c : 𝕜) (f : α →ᵇ β) : ∥c • f∥ = ∥c∥ * ∥f∥ :=
 begin
   by_cases h : c = 0,
-  rw h, simp,
-  have hnneg : 0 ≤ ∥c∥,
-    exact norm_nonneg c,
-  apply le_antisymm,
-  exact bounded_continuous_sub_smul c f,
-  have hinv : ∥f∥ ≤ ∥1 / c∥ * ∥c • f∥,
-  { calc ∥f ∥= ∥(1 : 𝕜) • f∥ : by simp
-    ... = ∥(1 / c * c ) • f∥ : by rw (div_mul_cancel 1 h)
-    ... = ∥(1 / c) • ( c • f)∥ : by rw (mul_smul _ _ _).symm
-    ... ≤ ∥1 / c∥ * ∥c • f∥ : bounded_continuous_sub_smul (1 / c) (c • f) },
-  calc ∥c∥ * ∥f∥  ≤ ∥c∥ * (∥1 / c∥ * ∥c • f∥) : mul_le_mul_of_nonneg_left hinv hnneg
-  ... = (∥c ∥ * ∥1 / c∥) * ∥c • f∥ : by ring
-  ... = ∥c * (1 / c)∥ * ∥c • f∥ : by rw (normed_field.norm_mul c (1/c))
-  ... = ∥(1 : 𝕜)∥ * ∥c • f∥ : by rw (mul_div_cancel' 1 h)
-  ... = 1 * ∥c • f∥ : by rw normed_field.norm_one
-  ... = ∥c • f∥ : by ring,
+  { rw [h, zero_smul, norm_zero, norm_zero, zero_mul], },
+  { have hnneg : 0 ≤ ∥c∥ := norm_nonneg c,
+    apply le_antisymm,
+    { exact bounded_continuous_sub_smul c f, },
+    { have hinv : ∥f∥ ≤ ∥1 / c∥ * ∥c • f∥,
+      { calc ∥f ∥= ∥(1 : 𝕜) • f∥ : by rw one_smul
+        ... = ∥(1 / c * c ) • f∥ : by rw (div_mul_cancel 1 h)
+        ... = ∥(1 / c) • ( c • f)∥ : by rw (mul_smul _ _ _).symm
+        ... ≤ ∥1 / c∥ * ∥c • f∥ : bounded_continuous_sub_smul (1 / c) (c • f) },
+      calc ∥c∥ * ∥f∥  ≤ ∥c∥ * (∥1 / c∥ * ∥c • f∥) : mul_le_mul_of_nonneg_left hinv hnneg
+      ... = (∥c ∥ * ∥1 / c∥) * ∥c • f∥ : by rw mul_assoc
+      ... = ∥c * (1 / c)∥ * ∥c • f∥ : by rw (normed_field.norm_mul c (1/c))
+      ... = ∥(1 : 𝕜)∥ * ∥c • f∥ : by rw (mul_div_cancel' 1 h)
+      ... = 1 * ∥c • f∥ : by rw normed_field.norm_one
+      ... = ∥c • f∥ : by rw one_mul, } }
 end
-
 
 instance : normed_space 𝕜 (α →ᵇ β) :=
 ⟨bounded_continuous_smul⟩

--- a/src/topology/bounded_continuous_function.lean
+++ b/src/topology/bounded_continuous_function.lean
@@ -474,7 +474,7 @@ instance : module 𝕜 (α →ᵇ β) :=
 instance : vector_space 𝕜 (α →ᵇ β) :=
 { .. bounded_continuous_function.module }
 
-lemma bounded_continuous_sub_smul (c : 𝕜) (f : α →ᵇ β) : ∥c • f∥ ≤ ∥c∥ * ∥f∥ :=
+lemma norm_smul_le (c : 𝕜) (f : α →ᵇ β) : ∥c • f∥ ≤ ∥c∥ * ∥f∥ :=
 begin
   have hnneg : 0 ≤ ∥ c ∥ := norm_nonneg c,
   rw norm_eq (c • f),
@@ -496,12 +496,12 @@ begin
   { rw [h, zero_smul, norm_zero, norm_zero, zero_mul] },
   { have hnneg : 0 ≤ ∥c∥ := norm_nonneg c,
     apply le_antisymm,
-    { exact bounded_continuous_sub_smul c f },
+    { exact f.norm_smul_le c },
     { have hinv : ∥f∥ ≤ ∥1 / c∥ * ∥c • f∥,
       { calc ∥f∥ = ∥(1 : 𝕜) • f∥ : by rw one_smul
         ... = ∥(1 / c * c ) • f∥ : by rw (div_mul_cancel 1 h)
         ... = ∥(1 / c) • ( c • f)∥ : by rw ← (mul_smul _ _ _)
-        ... ≤ ∥1 / c∥ * ∥c • f∥ : bounded_continuous_sub_smul (1 / c) (c • f) },
+        ... ≤ ∥1 / c∥ * ∥c • f∥ : (c • f).norm_smul_le (1 / c) },
     calc ∥c∥ * ∥f∥  ≤ ∥c∥ * (∥1 / c∥ * ∥c • f∥) : mul_le_mul_of_nonneg_left hinv hnneg
     ... = (∥c ∥ * ∥1 / c∥) * ∥c • f∥ : (mul_assoc _ _ _).symm
     ... = ∥c * (1 / c)∥ * ∥c • f∥ : by rw (normed_field.norm_mul c (1/c))

--- a/src/topology/bounded_continuous_function.lean
+++ b/src/topology/bounded_continuous_function.lean
@@ -430,12 +430,10 @@ def of_normed_group_discrete {α : Type u} {β : Type v}
 of_normed_group f C H continuous_of_discrete_topology
 
 /- Formula for norm. -/
-lemma norm_eq ( f : α →ᵇ β) :
+lemma norm_eq (f : α →ᵇ β) :
   ∥f∥ = Inf {C : ℝ | 0 ≤ C ∧ ∀ (x : α), ∥f x∥ ≤ C} :=
 begin
-  rw ← sub_zero f,
-  rw ← dist_eq_norm,
-  rw bounded_continuous_function.dist_eq,
+  rw [← sub_zero f, ← dist_eq_norm, bounded_continuous_function.dist_eq],
   simp,
 end
 
@@ -444,31 +442,30 @@ end normed_group
 
 
 section normed_space
-/- In this section, if β is a normed space, then we show that the space of bounded
-continuous functions from α to β inherits a normed space structure, by using
+/-! In this section, if `β` is a normed space, then we show that the space of bounded
+continuous functions from `α` to `β` inherits a normed space structure, by using
 pointwise operations and checking that they are compatible with the uniform distance. -/
 
 variables [nondiscrete_normed_field 𝕜]
 variables [topological_space α] [normed_group β] [normed_space 𝕜 β]
 variables {f g : α →ᵇ β} {x : α} {C : ℝ}
 
-
 instance : has_scalar 𝕜 (α →ᵇ β) :=
-  ⟨λc, λf, ⟨λx, c • f.1 x,
-    continuous.smul continuous_const f.2.left,
-    begin
-      cases f.2.right with C hbound,
-      use ∥c∥ * C,
-      intros,
-      have hnneg : 0 ≤ ∥c∥,
-      { exact norm_nonneg c },
-      specialize hbound x y,
-      rw dist_eq_norm at hbound,
-      rw dist_eq_norm,
+⟨λc, λf, ⟨λx, c • f.1 x,
+  continuous.smul continuous_const f.2.left,
+  begin
+    cases f.2.right with C hbound,
+    use ∥c∥ * C,
+    intros,
+    have hnneg : 0 ≤ ∥c∥,
+    { exact norm_nonneg c },
+    specialize hbound x y,
+    rw dist_eq_norm at hbound,
+    rw dist_eq_norm,
       calc ∥c • f x - c • f y∥ = ∥c • (f x - f y)∥ : by rw smul_sub c (f x) (f y)
-      ... = ∥c∥ * ∥f x - f y∥ : norm_smul c (f x - f y)
-      ... ≤ ∥c∥ * C : mul_le_mul_of_nonneg_left hbound hnneg,
-    end⟩⟩
+    ... = ∥c∥ * ∥f x - f y∥ : norm_smul c (f x - f y)
+    ... ≤ ∥c∥ * C : mul_le_mul_of_nonneg_left hbound hnneg,
+  end⟩⟩
 
 
 instance : module 𝕜 (α →ᵇ β) :=
@@ -486,7 +483,7 @@ instance : module 𝕜 (α →ᵇ β) :=
 
 
 instance : vector_space 𝕜 (α →ᵇ β) :=
-  { .. bounded_continuous_function.module }
+{ .. bounded_continuous_function.module }
 
 
 lemma bounded_continuous_sub_smul (c : 𝕜) (f : α →ᵇ β) :  ∥c • f∥ ≤ ∥c∥ * ∥f∥ :=
@@ -497,29 +494,28 @@ begin
   apply real.Inf_le,
   { use 0, intros y hy,
     rw set.mem_set_of_eq at hy,
-    exact hy.left,},
+    exact hy.left },
   { rw set.mem_set_of_eq,
     split,
-    exact mul_nonneg' hnneg (norm_nonneg f),
-    intros,
-    calc ∥(c • f) x∥ = ∥c∥ * ∥f x∥ : norm_smul c (f x)
-    ... ≤ ∥c∥ * ∥f∥ : mul_le_mul_of_nonneg_left (norm_coe_le_norm x) hnneg,}
+    { exact mul_nonneg' hnneg (norm_nonneg f) },
+    { intros,
+      calc ∥(c • f) x∥ = ∥c∥ * ∥f x∥ : norm_smul c (f x)
+      ... ≤ ∥c∥ * ∥f∥ : mul_le_mul_of_nonneg_left (norm_coe_le_norm x) hnneg } }
 end
 
-
-lemma bounded_continuous_smul (c : 𝕜) (f : α →ᵇ β) :  ∥c • f∥ = ∥c∥ * ∥f∥ :=
+lemma bounded_continuous_smul (c : 𝕜) (f : α →ᵇ β) : ∥c • f∥ = ∥c∥ * ∥f∥ :=
 begin
-  by_cases ( c = 0),
+  by_cases (c = 0),
   rw h, simp,
   have hnneg : 0 ≤ ∥c∥,
     exact norm_nonneg c,
   apply le_antisymm,
   exact bounded_continuous_sub_smul c f,
   have hinv : ∥f∥ ≤ ∥1 / c∥ * ∥c • f∥,
-    calc ∥f ∥= ∥(1 : 𝕜) • f∥ : by simp
+  { calc ∥f ∥= ∥(1 : 𝕜) • f∥ : by simp
     ... = ∥(1 / c * c ) • f∥ : by rw (div_mul_cancel 1 h)
     ... = ∥(1 / c) • ( c • f)∥ : by rw (mul_smul _ _ _).symm
-    ... ≤ ∥1 / c∥ * ∥c • f∥ : bounded_continuous_sub_smul (1 / c) (c • f),
+    ... ≤ ∥1 / c∥ * ∥c • f∥ : bounded_continuous_sub_smul (1 / c) (c • f) },
   calc ∥c∥ * ∥f∥  ≤ ∥c∥ * (∥1 / c∥ * ∥c • f∥) : mul_le_mul_of_nonneg_left hinv hnneg
   ... = (∥c ∥ * ∥1 / c∥) * ∥c • f∥ : by ring
   ... = ∥c * (1 / c)∥ * ∥c • f∥ : by rw (normed_field.norm_mul c (1/c))
@@ -530,7 +526,7 @@ end
 
 
 instance : normed_space 𝕜 (α →ᵇ β) :=
-  ⟨bounded_continuous_smul⟩
+⟨bounded_continuous_smul⟩
 
 end normed_space
 


### PR DESCRIPTION
For β a normed (vector) space over a nondiscrete normed field 𝕜, we construct the normed 𝕜-space structure on the set of bounded continuous functions from a topological space into β.