### PR TITLE
[Merged by Bors] - feat(category_theory): preadditive categories

### DIFF
--- a/src/algebra/category/Group/default.lean
+++ b/src/algebra/category/Group/default.lean
@@ -1,3 +1,4 @@
 import algebra.category.Group.limits
 import algebra.category.Group.colimits
+import algebra.category.Group.preadditive
 import algebra.category.Group.zero

--- a/src/algebra/category/Group/preadditive.lean
+++ b/src/algebra/category/Group/preadditive.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2020 Markus Himmel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus Himmel
+-/
+import algebra.category.Group.basic
+import category_theory.preadditive
+
+/-!
+# The category of additive commutative groups is preadditive.
+-/
+
+open category_theory
+
+universe u
+
+namespace AddCommGroup
+
+instance : preadditive.{u} AddCommGroup.{u} :=
+{ add_comp' := λ P Q R f f' g,
+    show (f + f') ≫ g = f ≫ g + f' ≫ g, by { ext, simp },
+  comp_add' := λ P Q R f g g',
+    show f ≫ (g + g') = f ≫ g + f ≫ g', by { ext, simp } }
+
+end AddCommGroup

--- a/src/algebra/category/Group/zero.lean
+++ b/src/algebra/category/Group/zero.lean
@@ -7,7 +7,10 @@ import algebra.category.Group.basic
 import category_theory.limits.shapes.zero
 
 /-!
-# The category of commutative additive groups has a zero object and zero morphism.
+# The category of commutative additive groups has a zero object.
+
+It also has zero morphisms. For definitional reasons, we infer this from preadditivity rather than
+from the existence of a zero object.
 -/
 
 open category_theory
@@ -16,9 +19,6 @@ open category_theory.limits
 universe u
 
 namespace AddCommGroup
-
-instance : has_zero_morphisms.{u} AddCommGroup.{u} :=
-{ has_zero := λ X Y, ⟨0⟩ }
 
 instance : has_zero_object.{u} AddCommGroup.{u} :=
 { zero := 0,

--- a/src/algebra/category/Module/basic.lean
+++ b/src/algebra/category/Module/basic.lean
@@ -6,6 +6,7 @@ Authors: Robert A. Spencer, Markus Himmel
 import algebra.category.Group.basic
 import category_theory.concrete_category
 import category_theory.limits.shapes.kernels
+import category_theory.preadditive
 import linear_algebra.basic
 
 open category_theory
@@ -121,15 +122,15 @@ def linear_equiv_iso_Group_iso {X Y : Type u} [add_comm_group X] [add_comm_group
 
 namespace Module
 
-section zero_morphisms
+section preadditive
 
-instance : has_zero_morphisms.{u} (Module R) :=
-{ has_zero := λ M N, ⟨0⟩,
-  comp_zero' := λ M N f Z, by ext; erw linear_map.zero_apply,
-  zero_comp' := λ M N Z f, by ext; erw [linear_map.comp_apply, linear_map.zero_apply,
-    linear_map.zero_apply, linear_map.map_zero] }
+instance : preadditive.{u} (Module.{u} R) :=
+{ add_comp' := λ P Q R f f' g,
+    show (f + f') ≫ g = f ≫ g + f' ≫ g, by { ext, simp },
+  comp_add' := λ P Q R f g g',
+    show f ≫ (g + g') = f ≫ g + f ≫ g', by { ext, simp } }
 
-end zero_morphisms
+end preadditive
 
 section kernel
 variables {R} {M N : Module R} (f : M ⟶ N)

--- a/src/category_theory/limits/shapes/equalizers.lean
+++ b/src/category_theory/limits/shapes/equalizers.lean
@@ -210,6 +210,12 @@ abbreviation fork.ι (t : fork f g) := t.π.app zero
     `t.ι.app zero : X ⟶ t.X` and `t.ι.app one : Y ⟶ t.X`. Of these, only the second one is
     interesting, and we give it the shorter name `cofork.π t`. -/
 abbreviation cofork.π (t : cofork f g) := t.ι.app one
+
+@[simp] lemma fork.ι_of_ι {P : C} (ι : P ⟶ X) (w : ι ≫ f = ι ≫ g) :
+  fork.ι (fork.of_ι ι w) = ι := rfl
+@[simp] lemma cofork.π_of_π {P : C} (π : Y ⟶ P) (w : f ≫ π = g ≫ π) :
+  cofork.π (cofork.of_π π w) = π := rfl
+
 lemma fork.condition (t : fork f g) : (fork.ι t) ≫ f = (fork.ι t) ≫ g :=
 begin
   erw [t.w left, ← t.w right], refl

--- a/src/category_theory/limits/shapes/kernels.lean
+++ b/src/category_theory/limits/shapes/kernels.lean
@@ -124,7 +124,7 @@ def kernel.zero_cone : cone (parallel_pair f 0) :=
 def kernel.is_limit_cone_zero_cone [mono f] : is_limit (kernel.zero_cone f) :=
 fork.is_limit.mk _ (λ s, 0)
   (λ s, by { erw has_zero_morphisms.zero_comp,
-    convert (@zero_of_comp_mono _ _ _ _ _ _ _ f _ _).symm,
+    convert (zero_of_comp_mono f _).symm,
     exact kernel_fork.condition _ })
   (λ _ _ _, has_zero_object.zero_of_to_zero _)
 

--- a/src/category_theory/limits/shapes/kernels.lean
+++ b/src/category_theory/limits/shapes/kernels.lean
@@ -221,7 +221,7 @@ def cokernel.zero_cocone : cocone (parallel_pair f 0) :=
 def cokernel.is_colimit_cocone_zero_cocone [epi f] : is_colimit (cokernel.zero_cocone f) :=
 cofork.is_colimit.mk _ (λ s, 0)
   (λ s, by { erw has_zero_morphisms.zero_comp,
-    convert (@zero_of_comp_epi _ _ _ _ _ _ f _ _ _).symm,
+    convert (zero_of_epi_comp f _).symm,
     exact cokernel_cofork.condition _ })
   (λ _ _ _, has_zero_object.zero_of_from_zero _)
 

--- a/src/category_theory/limits/shapes/zero.lean
+++ b/src/category_theory/limits/shapes/zero.lean
@@ -91,10 +91,10 @@ open has_zero_morphisms
 section
 variables {C} [has_zero_morphisms.{v} C]
 
-lemma zero_of_comp_mono {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} [mono g] (h : f ≫ g = 0) : f = 0 :=
+lemma zero_of_comp_mono {X Y Z : C} {f : X ⟶ Y} (g : Y ⟶ Z) [mono g] (h : f ≫ g = 0) : f = 0 :=
 by { rw [←zero_comp.{v} X g, cancel_mono] at h, exact h }
 
-lemma zero_of_comp_epi {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} [epi f] (h : f ≫ g = 0) : g = 0 :=
+lemma zero_of_epi_comp {X Y Z : C} (f : X ⟶ Y) {g : Y ⟶ Z} [epi f] (h : f ≫ g = 0) : g = 0 :=
 by { rw [←comp_zero.{v} f Z, cancel_epi] at h, exact h }
 
 end

--- a/src/category_theory/preadditive.lean
+++ b/src/category_theory/preadditive.lean
@@ -22,7 +22,7 @@ available, the contents of this file should become obsolete.
 * Definition of preadditive categories and basic properties
 * In a preadditive category, `f : Q ⟶ R` is mono if and only if `g ≫ f = 0 → g = 0` for all
   composable `g`.
-* A preadditive categories which has kernels has equalizers.
+* A preadditive category with kernels has equalizers.
 
 ## Implementation notes
 

--- a/src/category_theory/preadditive.lean
+++ b/src/category_theory/preadditive.lean
@@ -14,7 +14,7 @@ composition of morphisms is linear in both variables.
 
 This file contains a definition of preadditive category that directly encodes the definition given
 above. The definition could also be phrased as follows: A preadditive category is a category
-enriched over the category of Abelian groups. Once the general framework the state this in Lean is
+enriched over the category of Abelian groups. Once the general framework to state this in Lean is
 available, the contents of this file should become obsolete.
 
 ## Main results

--- a/src/category_theory/preadditive.lean
+++ b/src/category_theory/preadditive.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2020 Markus Himmel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus Himmel
+-/
+import algebra.group.hom
+import category_theory.limits.shapes.kernels
+
+/-!
+# Preadditive categories
+
+A preadditive category is a category in which `X ⟶ Y` is an abelian group in such a way that
+composition of morphisms is linear in both variables.
+
+This file contains a definition of preadditive category that directly encodes the definition given
+above. The definition could also be phrased as follows: A preadditive category is a category
+enriched over the category of Abelian groups. Once the general framework the state this in Lean is
+available, the contents of this file should become obsolete.
+
+## Main results
+
+* Definition of preadditive categories and basic properties
+* In a preadditive category, `f : Q ⟶ R` is mono if and only if `g ≫ f = 0 → g = 0` for all
+  composable `g`.
+* A preadditive categories which has kernels has equalizers.
+
+## Implementation notes
+
+The simp normal form for negation and composition is to push negations as far as possible to
+the outside. For example, `f ≫ (-g)` and `(-f) ≫ g` both become `-(f ≫ g)`, and `(-f) ≫ (-g)`
+is simplified to `f ≫ g`.
+
+## References
+
+* [F. Borceux, *Handbook of Categorical Algebra 2*][borceux-vol2]
+
+## Tags
+
+additive, preadditive, Hom group, Ab-category, Ab-enriched
+-/
+
+universes v u
+
+open category_theory.limits
+open add_monoid_hom
+
+namespace category_theory
+
+variables (C : Type u) [𝒞 : category.{v} C]
+include 𝒞
+
+/-- A category is called preadditive if `P ⟶ Q` is an abelian group such that composition is
+    linear in both variables. -/
+class preadditive :=
+(hom_group : Π P Q : C, add_comm_group (P ⟶ Q) . tactic.apply_instance)
+(add_comp' : ∀ (P Q R : C) (f f' : P ⟶ Q) (g : Q ⟶ R),
+  (f + f') ≫ g = f ≫ g + f' ≫ g . obviously)
+(comp_add' : ∀ (P Q R : C) (f : P ⟶ Q) (g g' : Q ⟶ R),
+  f ≫ (g + g') = f ≫ g + f ≫ g' . obviously)
+
+attribute [instance] preadditive.hom_group
+restate_axiom preadditive.add_comp'
+restate_axiom preadditive.comp_add'
+attribute [simp] preadditive.add_comp preadditive.comp_add
+
+end category_theory
+
+open category_theory
+
+namespace category_theory.preadditive
+
+section preadditive
+variables {C : Type u} [𝒞 : category.{v} C]
+include 𝒞
+variables [preadditive.{v} C]
+
+/-- Composition by a fixed left argument as a group homomorphism -/
+def left_comp {P Q : C} (R : C) (f : P ⟶ Q) : (Q ⟶ R) →+ (P ⟶ R) :=
+mk' (λ g, f ≫ g) $ λ g g', by simp
+
+/-- Composition by a fixed right argument as a group homomorphism -/
+def right_comp (P : C) {Q R : C} (g : Q ⟶ R) : (P ⟶ Q) →+ (P ⟶ R) :=
+mk' (λ f, f ≫ g) $ λ f f', by simp
+
+@[simp] lemma sub_comp {P Q R : C} (f f' : P ⟶ Q) (g : Q ⟶ R) :
+  (f - f') ≫ g = f ≫ g - f' ≫ g :=
+map_sub (right_comp P g) f f'
+
+@[simp] lemma comp_sub {P Q R : C} (f : P ⟶ Q) (g g' : Q ⟶ R) :
+  f ≫ (g - g') = f ≫ g - f ≫ g' :=
+map_sub (left_comp R f) g g'
+
+@[simp] lemma neg_comp {P Q R : C} (f : P ⟶ Q) (g : Q ⟶ R) : (-f) ≫ g = -(f ≫ g) :=
+map_neg (right_comp _ _) _
+
+@[simp] lemma comp_neg {P Q R : C} (f : P ⟶ Q) (g : Q ⟶ R) : f ≫ (-g) = -(f ≫ g) :=
+map_neg (left_comp _ _) _
+
+lemma neg_comp_neg {P Q R : C} (f : P ⟶ Q) (g : Q ⟶ R) : (-f) ≫ (-g) = f ≫ g :=
+by simp
+
+instance {P Q : C} {f : P ⟶ Q} [epi f] : epi (-f) :=
+⟨λ R g g', by { rw [neg_comp, neg_comp, ←comp_neg, ←comp_neg, cancel_epi], exact neg_inj }⟩
+
+instance {P Q : C} {f : P ⟶ Q} [mono f] : mono (-f) :=
+⟨λ R g g', by { rw [comp_neg, comp_neg, ←neg_comp, ←neg_comp, cancel_mono], exact neg_inj }⟩
+
+@[priority 100]
+instance preadditive_has_zero_morphisms : has_zero_morphisms.{v} C :=
+{ has_zero := infer_instance,
+  comp_zero' := λ P Q f R, map_zero $ left_comp R f,
+  zero_comp' := λ P Q R f, map_zero $ right_comp P f }
+
+lemma mono_of_cancel_zero {Q R : C} (f : Q ⟶ R) (h : ∀ {P : C} (g : P ⟶ Q), g ≫ f = 0 → g = 0) :
+  mono f :=
+⟨λ P g g' hg, sub_eq_zero.1 $ h _ $ (map_sub (right_comp P f) g g').trans $ sub_eq_zero.2 hg⟩
+
+lemma mono_iff_cancel_zero {Q R : C} (f : Q ⟶ R) :
+  mono f ↔ ∀ (P : C) (g : P ⟶ Q), g ≫ f = 0 → g = 0 :=
+⟨λ m P g, by exactI zero_of_comp_mono _, mono_of_cancel_zero f⟩
+
+lemma epi_of_cancel_zero {P Q : C} (f : P ⟶ Q) (h : ∀ {R : C} (g : Q ⟶ R), f ≫ g = 0 → g = 0) :
+  epi f :=
+⟨λ R g g' hg, sub_eq_zero.1 $ h _ $ (map_sub (left_comp R f) g g').trans $ sub_eq_zero.2 hg⟩
+
+lemma epi_iff_cancel_zero {P Q : C} (f : P ⟶ Q) :
+  epi f ↔ ∀ (R : C) (g : Q ⟶ R), f ≫ g = 0 → g = 0 :=
+⟨λ e R g, by exactI zero_of_epi_comp _, epi_of_cancel_zero f⟩
+
+end preadditive
+
+section equalizers
+variables {C : Type u} [𝒞 : category.{v} C] [preadditive.{v} C]
+include 𝒞
+
+section
+variables {X Y : C} (f : X ⟶ Y) (g : X ⟶ Y)
+
+/-- A kernel of `f - g` is an equalizer of `f` and `g`. -/
+def has_limit_parallel_pair [has_limit (parallel_pair (f - g) 0)] :
+  has_limit (parallel_pair f g) :=
+{ cone := fork.of_ι (kernel.ι (f - g)) (sub_eq_zero.1 $
+    by { rw ←comp_sub, exact kernel.condition _ }),
+  is_limit := fork.is_limit.mk _
+    (λ s, kernel.lift (f - g) (fork.ι s) $
+      by { rw comp_sub, apply sub_eq_zero.2, exact fork.condition _ })
+    (λ s, by simp)
+    (λ s m h, by { ext, simpa using h walking_parallel_pair.zero }) }
+
+end
+
+section
+
+/-- If a preadditive category has all kernels, then it also has all equalizers. -/
+def has_equalizers_of_has_kernels [has_kernels.{v} C] : has_equalizers.{v} C :=
+@has_equalizers_of_has_limit_parallel_pair _ _ (λ _ _ f g, has_limit_parallel_pair f g)
+
+end
+
+section
+variables {X Y : C} (f : X ⟶ Y) (g : X ⟶ Y)
+
+/-- A cokernel of `f - g` is a coequalizer of `f` and `g`. -/
+def has_colimit_parallel_pair [has_colimit (parallel_pair (f - g) 0)] :
+  has_colimit (parallel_pair f g) :=
+{ cocone := cofork.of_π (cokernel.π (f - g)) (sub_eq_zero.1 $
+    by { rw ←sub_comp, exact cokernel.condition _ }),
+  is_colimit := cofork.is_colimit.mk _
+    (λ s, cokernel.desc (f - g) (cofork.π s) $
+      by { rw sub_comp, apply sub_eq_zero.2, exact cofork.condition _ })
+    (λ s, by simp)
+    (λ s m h, by { ext, simpa using h walking_parallel_pair.one }) }
+
+end
+
+section
+
+/-- If a preadditive category has all cokernels, then it also has all coequalizers. -/
+def has_coequalizers_of_has_cokernels [has_cokernels.{v} C] : has_coequalizers.{v} C :=
+@has_coequalizers_of_has_colimit_parallel_pair _ _ (λ _ _ f g, has_colimit_parallel_pair f g)
+
+end
+
+end equalizers
+end category_theory.preadditive

--- a/src/category_theory/preadditive.lean
+++ b/src/category_theory/preadditive.lean
@@ -46,8 +46,7 @@ open add_monoid_hom
 
 namespace category_theory
 
-variables (C : Type u) [𝒞 : category.{v} C]
-include 𝒞
+variables (C : Type u) [category.{v} C]
 
 /-- A category is called preadditive if `P ⟶ Q` is an abelian group such that composition is
     linear in both variables. -/
@@ -70,9 +69,7 @@ open category_theory
 namespace category_theory.preadditive
 
 section preadditive
-variables {C : Type u} [𝒞 : category.{v} C]
-include 𝒞
-variables [preadditive.{v} C]
+variables {C : Type u} [category.{v} C] [preadditive.{v} C]
 
 /-- Composition by a fixed left argument as a group homomorphism -/
 def left_comp {P Q : C} (R : C) (f : P ⟶ Q) : (Q ⟶ R) →+ (P ⟶ R) :=
@@ -130,8 +127,7 @@ lemma epi_iff_cancel_zero {P Q : C} (f : P ⟶ Q) :
 end preadditive
 
 section equalizers
-variables {C : Type u} [𝒞 : category.{v} C] [preadditive.{v} C]
-include 𝒞
+variables {C : Type u} [category.{v} C] [preadditive.{v} C]
 
 section
 variables {X Y : C} (f : X ⟶ Y) (g : X ⟶ Y)


### PR DESCRIPTION
[As discussed](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Lean.20in.20the.20wild/near/197168926), here is the pedestrian definition of preadditive categories. Hopefully, it is not here to stay, but it will allow me to start PRing abelian categories.