### PR TITLE
[Merged by Bors] - refactor(scripts/mk_all): generate a single deterministic all.lean file

### DIFF
--- a/scripts/mk_all.sh
+++ b/scripts/mk_all.sh
@@ -1,15 +1,7 @@
 #!/usr/bin/env bash
-# Makes a file all.lean in all subfolders of src/ importing all files in that folder,
-# including subfolders.
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-# Set DIR to the (absolute) directory of this script
-for d in $(find $DIR/../src/ -type d)
-# For every subfolder of src/ (including src/ itself)
-do
-  cd "$d" # cd to that directory
-  echo "/- automatically generated file importing all files in this directory and subdirectories. -/" > all.lean
-  find . -maxdepth 1 -mindepth 1 -name 'all.lean' -prune -o -name 'lint_mathlib.lean' -prune -o -name '.*' -prune -o -name '*.lean' -print -o -type d -print |
-  # find all non-hidden files with the .lean extension (except all.lean) and all subdirectories
-  sed 's/$/\.all/; s/\.lean\.all//; s/^\.\//       \./; 1s/^      /import/' >> all.lean
-  # Now modify this output so that Lean can parse it. Changes `./foo.lean` to `.foo` and `foodir` to `.foodir.all`. Also adds indentation, a comment and `import`. Write this to `all.lean`
-done
+# Makes a file src/all.lean importing all files.
+cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../src
+
+find -name \*.lean -not -name all.lean \
+  | sed 's,^\./,,;s,\.lean$,,;s,/,.,g;s,^,import ,' \
+  | sort >all.lean

--- a/scripts/mk_all.sh
+++ b/scripts/mk_all.sh
@@ -1,7 +1,20 @@
 #!/usr/bin/env bash
-# Makes a file src/all.lean importing all files.
-cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../src
+# Usage: mk_all.sh [subdirectory]
+#
+# Examples:
+#   ./scripts/mk_all.sh
+#   ./scripts/mk_all.sh data/real
+#
+# Makes a mathlib/src/$directory/all.lean importing all files inside $directory.
+# If $directory is omitted, creates `mathlib/src/all.lean`.
 
-find -name \*.lean -not -name all.lean \
+cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../src
+if [[ $# = 1 ]]; then
+  dir="$1"
+else
+  dir="."
+fi
+
+find $dir -name \*.lean -not -name all.lean \
   | sed 's,^\./,,;s,\.lean$,,;s,/,.,g;s,^,import ,' \
-  | sort >all.lean
+  | sort >$dir/all.lean

--- a/scripts/mk_all.sh
+++ b/scripts/mk_all.sh
@@ -15,6 +15,6 @@ else
   dir="."
 fi
 
-find $dir -name \*.lean -not -name all.lean \
+find "$dir" -name \*.lean -not -name all.lean \
   | sed 's,^\./,,;s,\.lean$,,;s,/,.,g;s,^,import ,' \
-  | sort >$dir/all.lean
+  | sort >"$dir"/all.lean


### PR DESCRIPTION
The current `mk_all.sh` script is non-deterministic, and creates invalid Lean code for the `data.matrix.notation` import.  The generated `all.lean` files are also slow: they take two minutes to compile on my machine.

The new script fixes all of that.  The single generated `all.lean` file takes only 27 seconds to compile now.