### PR TITLE
[Merged by Bors] - chore(logic/function): move to `logic/function/basic`

### DIFF
--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Simon Hudon, Mario Carneiro
 -/
 import algebra.group.to_additive
-import logic.function
+import logic.function.basic
 
 attribute [simp] sub_neg_eq_add
 

--- a/src/algebra/group/units.lean
+++ b/src/algebra/group/units.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Mario Carneiro, Johannes, Hölzl, Chris Hughes
 -/
-import logic.function
+import logic.function.basic
 import algebra.group.to_additive
 import tactic.norm_cast
 

--- a/src/category_theory/fully_faithful.lean
+++ b/src/category_theory/fully_faithful.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import logic.function
+import logic.function.basic
 import category_theory.natural_isomorphism
 
 universes v₁ v₂ v₃ u₁ u₂ u₃ -- declare the `v`'s first; see `category_theory.category` for an explanation

--- a/src/control/bifunctor.lean
+++ b/src/control/bifunctor.lean
@@ -5,7 +5,7 @@ Author: Simon Hudon
 
 Functors with two arguments
 -/
-import logic.function
+import logic.function.basic
 import tactic.basic
 
 universes u₀ u₁ u₂ v₀ v₁ v₂

--- a/src/data/set/function.lean
+++ b/src/data/set/function.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Jeremy Avigad, Andrew Zipperer, Haitao Zhang, Minchao Wu, Yury Kudryashov
 -/
 import data.set.basic
-import logic.function
+import logic.function.basic
 
 /-! # Functions over sets
 

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -281,7 +281,7 @@ section bicomp
 variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*} {ε : Type*}
 
 /-- Compose a binary function `f` with a pair of unary functions `g` and `h`.
-If both arguments of `f` have the same and `g = h`, then `bicompl f g g = f on g`. -/
+If both arguments of `f` have the same type and `g = h`, then `bicompl f g g = f on g`. -/
 def bicompl (f : γ → δ → ε) (g : α → γ) (h : β → δ) (a b) :=
 f (g a) (h b)
 

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -2,11 +2,13 @@
 Copyright (c) 2016 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
-
-Miscellaneous function constructions and lemmas.
 -/
 import logic.basic
 import data.option.defs
+
+/-!
+# Miscellaneous function constructions and lemmas
+-/
 
 universes u v w
 
@@ -57,11 +59,14 @@ instance decidable_eq_pfun (p : Prop) [decidable p] (α : p → Type*)
   [Π hp, decidable_eq (α hp)] : decidable_eq (Π hp, α hp)
 | f g := decidable_of_iff (∀ hp, f hp = g hp) funext_iff.symm
 
-theorem cantor_surjective {α} (f : α → α → Prop) : ¬ function.surjective f | h :=
+/-- Cantor's diagonal argument implies that there are no surjective functions from `α`
+to `set α`. -/
+theorem cantor_surjective {α} (f : α → set α) : ¬ function.surjective f | h :=
 let ⟨D, e⟩ := h (λ a, ¬ f a a) in
 (iff_not_self (f D D)).1 $ iff_of_eq (congr_fun e D)
 
-theorem cantor_injective {α : Type*} (f : (α → Prop) → α) :
+/-- Cantor's diagonal argument implies that there are no injective functions from `set α` to `α`. -/
+theorem cantor_injective {α : Type*} (f : (set α) → α) :
   ¬ function.injective f | i :=
 cantor_surjective (λ a b, ∀ U, a = f U → U b) $
 surjective_of_has_right_inverse ⟨f, λ U, funext $
@@ -124,7 +129,8 @@ variables {α : Type u} [n : nonempty α] {β : Sort v} {f : α → β} {s : set
 include n
 local attribute [instance, priority 10] classical.prop_decidable
 
-/-- Construct the inverse for a function `f` on domain `s`. -/
+/-- Construct the inverse for a function `f` on domain `s`. This function is a right inverse of `f`
+on `f '' s`. -/
 noncomputable def inv_fun_on (f : α → β) (s : set α) (b : β) : α :=
 if h : ∃a, a ∈ s ∧ f a = b then classical.some h else classical.choice n
 
@@ -274,9 +280,12 @@ by { funext, simp [curry, uncurry', prod.mk.eta] }
 section bicomp
 variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*} {ε : Type*}
 
+/-- Compose a binary function `f` with a pair of unary functions `g` and `h`.
+If both arguments of `f` have the same and `g = h`, then `bicompl f g g = f on g`. -/
 def bicompl (f : γ → δ → ε) (g : α → γ) (h : β → δ) (a b) :=
 f (g a) (h b)
 
+/-- Compose an unary function `f` with a binary function `g`. -/
 def bicompr (f : γ → δ) (g : α → β → γ) (a b) :=
 f (g a b)
 

--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -6,7 +6,7 @@ Authors: Johannes Hölzl
 Type class hierarchy for Boolean algebras.
 -/
 import order.bounded_lattice
-import logic.function
+import logic.function.basic
 set_option old_structure_cmd true
 
 universes u


### PR DESCRIPTION
Also add some docstrings.

I'm going to add more `logic.function.*` files with theorems that can't go to `basic` because of imports.