### PR TITLE
[Merged by Bors] - feat(data/nat/choose): Sum a row of Pascal's triangle

### DIFF
--- a/src/data/nat/choose.lean
+++ b/src/data/nat/choose.lean
@@ -99,8 +99,9 @@ theorem add_pow [comm_semiring α] (x y : α) (n : ℕ) :
   (x + y) ^ n = ∑ m in range (n + 1), x ^ m * y ^ (n - m) * choose n m :=
 (commute.all x y).add_pow n
 
-theorem sum_pascal_row (n : ℕ) :
-  finset.sum (finset.range n.succ) (choose n) = 2 ^ n :=
+/-- The sum of entries in a row of Pascal's triangle -/
+theorem sum_range_choose (n : ℕ) : 
+  ∑ m in range (n + 1), choose n m = 2 ^ n :=
 by simpa using (add_pow 1 1 n).symm
 
 end binomial

--- a/src/data/nat/choose.lean
+++ b/src/data/nat/choose.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Chris Hughes, Bhavik Mehta
+Authors: Chris Hughes, Bhavik Mehta, Patrick Stevens
 -/
 import algebra.commute
 
@@ -99,7 +99,7 @@ theorem add_pow [comm_semiring α] (x y : α) (n : ℕ) :
   (x + y) ^ n = ∑ m in range (n + 1), x ^ m * y ^ (n - m) * choose n m :=
 (commute.all x y).add_pow n
 
-theorem pascal_row_sum (n : ℕ) :
+theorem sum_pascal_row (n : ℕ) :
   finset.sum (finset.range n.succ) (choose n) = 2 ^ n :=
 by simpa using (add_pow 1 1 n).symm
 

--- a/src/data/nat/choose.lean
+++ b/src/data/nat/choose.lean
@@ -99,4 +99,8 @@ theorem add_pow [comm_semiring α] (x y : α) (n : ℕ) :
   (x + y) ^ n = ∑ m in range (n + 1), x ^ m * y ^ (n - m) * choose n m :=
 (commute.all x y).add_pow n
 
+theorem pascal_row_sum (n : ℕ) :
+  finset.sum (finset.range n.succ) (choose n) = 2 ^ n :=
+by simpa using (add_pow 1 1 n).symm
+
 end binomial


### PR DESCRIPTION
Add the "sum of the nth row of Pascal's triangle" theorem.

Naming is hard, of course, and this is my first PR to mathlib, so naming suggestions are welcome.

Briefly discussed at https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Candidate.20for.20inclusion.20in.20mathlib/near/197619403 .