### PR TITLE
[Merged by Bors] - perf(tactic/ring): use new norm_num, avoid mk_app

### DIFF
--- a/src/tactic/norm_num.lean
+++ b/src/tactic/norm_num.lean
@@ -254,6 +254,12 @@ meta def match_neg : expr → option expr
 | `(- %%e) := some e
 | _ := none
 
+/-- `match_sign (- e) = inl e`, `match_sign 0 = inr ff`, otherwise `inr tt` -/
+meta def match_sign : expr → expr ⊕ bool
+| `(- %%e) := sum.inl e
+| `(has_zero.zero) := sum.inr ff
+| _ := sum.inr tt
+
 theorem ne_zero_of_pos {α} [ordered_add_comm_group α] (a : α) : 0 < a → a ≠ 0 := ne_of_gt
 theorem ne_zero_neg {α} [add_group α] (a : α) : a ≠ 0 → -a ≠ 0 := mt neg_eq_zero.1
 
@@ -388,22 +394,30 @@ theorem mul_neg_neg {α} [ring α] (a b c : α) (h : a * b = c) : -a * -b = c :=
 
 /-- Given `a`,`b` rational numerals, returns `(c, ⊢ a * b = c)`. -/
 meta def prove_mul_rat (ic : instance_cache) (a b : expr) (na nb : ℚ) : tactic (instance_cache × expr × expr) :=
-match match_neg a, match_neg b with
-| some a, some b := do
+match match_sign a, match_sign b with
+| sum.inl a, sum.inl b := do
   (ic, c, p) ← prove_mul_nonneg_rat ic a b (-na) (-nb),
   (ic, p) ← ic.mk_app ``mul_neg_neg [a, b, c, p],
   return (ic, c, p)
-| some a, none := do
+| sum.inr ff, _ := do
+  (ic, z) ← ic.mk_app ``has_zero.zero [],
+  (ic, p) ← ic.mk_app ``zero_mul [b],
+  return (ic, z, p)
+| _, sum.inr ff := do
+  (ic, z) ← ic.mk_app ``has_zero.zero [],
+  (ic, p) ← ic.mk_app ``mul_zero [a],
+  return (ic, z, p)
+| sum.inl a, sum.inr tt := do
   (ic, c, p) ← prove_mul_nonneg_rat ic a b (-na) nb,
   (ic, p) ← ic.mk_app ``mul_neg_pos [a, b, c, p],
   (ic, c') ← ic.mk_app ``has_neg.neg [c],
   return (ic, c', p)
-| none, some b := do
+| sum.inr tt, sum.inl b := do
   (ic, c, p) ← prove_mul_nonneg_rat ic a b na (-nb),
   (ic, p) ← ic.mk_app ``mul_pos_neg [a, b, c, p],
   (ic, c') ← ic.mk_app ``has_neg.neg [c],
   return (ic, c', p)
-| none, none := prove_mul_nonneg_rat ic a b na nb
+| sum.inr tt, sum.inr tt := prove_mul_nonneg_rat ic a b na nb
 end
 
 theorem inv_neg {α} [division_ring α] (a b : α) (h : a⁻¹ = b) : (-a)⁻¹ = -b :=
@@ -420,16 +434,16 @@ by simp only [inv_eq_one_div, one_div_div]
 /-- Given `a` a rational numeral, returns `(b, ⊢ a⁻¹ = b)`. -/
 meta def prove_inv : instance_cache → expr → ℚ → tactic (instance_cache × expr × expr)
 | ic e n :=
-  if n = 0 then do
-    (ic, p) ← ic.mk_app ``inv_zero [],
-    return (ic, e, p)
-  else match match_neg e with
-  | some e := do
+  match match_sign e with
+  | sum.inl e := do
     (ic, e', p) ← prove_inv ic e (-n),
     (ic, r) ← ic.mk_app ``has_neg.neg [e'],
     (ic, p) ← ic.mk_app ``inv_neg [e, e', p],
     return (ic, r, p)
-  | none :=
+  | sum.inr ff := do
+    (ic, p) ← ic.mk_app ``inv_zero [],
+    return (ic, e, p)
+  | sum.inr tt :=
     if n.num = 1 then
       if n.denom = 1 then do
         (ic, p) ← ic.mk_app ``one_inv_eq [],
@@ -461,20 +475,17 @@ do (ic, b', pb) ← prove_inv ic b nb,
 
 /-- Given `a` a rational numeral, returns `(b, ⊢ -a = b)`. -/
 meta def prove_neg (ic : instance_cache) (a : expr) : tactic (instance_cache × expr × expr) :=
-match match_neg a with
-| some a := do
+match match_sign a with
+| sum.inl a := do
   (ic, p) ← ic.mk_app ``neg_neg [a],
   return (ic, a, p)
-| none :=
-  match a with
-  | `(has_zero.zero) := do
-    (ic, p) ← ic.mk_app ``neg_zero [],
-    return (ic, a, p)
-  | _ := do
-    (ic, a') ← ic.mk_app ``has_neg.neg [a],
-    p ← mk_eq_refl a',
-    return (ic, a', p)
-  end
+| sum.inr ff := do
+  (ic, p) ← ic.mk_app ``neg_zero [],
+  return (ic, a, p)
+| sum.inr tt := do
+  (ic, a') ← ic.mk_app ``has_neg.neg [a],
+  p ← mk_eq_refl a',
+  return (ic, a', p)
 end
 
 theorem sub_pos {α} [add_group α] (a b b' c : α) (hb : -b = b') (h : a + b' = c) : a - b = c :=
@@ -484,12 +495,15 @@ by rwa sub_neg_eq_add
 
 /-- Given `a`,`b` rational numerals, returns `(c, ⊢ a - b = c)`. -/
 meta def prove_sub (ic : instance_cache) (a b : expr) : tactic (instance_cache × expr × expr) :=
-match match_neg b with
-| some b := do
+match match_sign b with
+| sum.inl b := do
   (ic, c, p) ← prove_add_rat' ic a b,
   (ic, p) ← ic.mk_app ``sub_neg [a, b, c, p],
   return (ic, c, p)
-| none := do
+| sum.inr ff := do
+  (ic, p) ← ic.mk_app ``sub_zero [a],
+  return (ic, a, p)
+| sum.inr tt := do
   (ic, b', pb) ← prove_neg ic b,
   (ic, c, p) ← prove_add_rat' ic a b',
   (ic, p) ← ic.mk_app ``sub_pos [a, b, b', c, pb, p],
@@ -740,21 +754,19 @@ lt_trans (neg_neg_of_pos ha) hb
 
 /-- Given `a`,`b` rational numerals, proves `⊢ a < b`. -/
 meta def prove_lt_rat (ic : instance_cache) (a b : expr) (na nb : ℚ) : tactic (instance_cache × expr) :=
-match match_neg a, match_neg b with
-| some a, some b := do
+match match_sign a, match_sign b with
+| sum.inl a, sum.inl b := do
   (ic, p) ← prove_lt_nonneg_rat ic a b (-na) (-nb),
   ic.mk_app ``neg_lt_neg [a, b, p]
-| some a, none :=
-  if nb.num = 0 then do
-    (ic, p) ← prove_pos ic a,
-    ic.mk_app ``neg_neg_of_pos [a, p]
-  else do
-    (ic, pa) ← prove_pos ic a,
-    (ic, pb) ← prove_pos ic b,
-    ic.mk_app ``lt_neg_pos [a, b, pa, pb]
-| none, _ :=
-  if na.num = 0 then prove_pos ic b
-  else prove_lt_nonneg_rat ic a b na nb
+| sum.inl a, sum.inr ff := do
+  (ic, p) ← prove_pos ic a,
+  ic.mk_app ``neg_neg_of_pos [a, p]
+| sum.inl a, sum.inr tt := do
+  (ic, pa) ← prove_pos ic a,
+  (ic, pb) ← prove_pos ic b,
+  ic.mk_app ``lt_neg_pos [a, b, pa, pb]
+| sum.inr ff, _ := prove_pos ic b
+| sum.inr tt, _ := prove_lt_nonneg_rat ic a b na nb
 end
 
 theorem clear_denom_le {α} [linear_ordered_semiring α] (a a' b b' d : α)
@@ -779,21 +791,19 @@ le_trans (neg_nonpos_of_nonneg ha) hb
 
 /-- Given `a`,`b` rational numerals, proves `⊢ a ≤ b`. -/
 meta def prove_le_rat (ic : instance_cache) (a b : expr) (na nb : ℚ) : tactic (instance_cache × expr) :=
-match match_neg a, match_neg b with
-| some a, some b := do
+match match_sign a, match_sign b with
+| sum.inl a, sum.inl b := do
   (ic, p) ← prove_le_nonneg_rat ic a b (-na) (-nb),
   ic.mk_app ``neg_le_neg [a, b, p]
-| some a, none :=
-  if nb.num = 0 then do
-    (ic, p) ← prove_nonneg ic a,
-    ic.mk_app ``neg_nonpos_of_nonneg [a, p]
-  else do
-    (ic, pa) ← prove_nonneg ic a,
-    (ic, pb) ← prove_nonneg ic b,
-    ic.mk_app ``le_neg_pos [a, b, pa, pb]
-| none, _ :=
-  if na.num = 0 then prove_nonneg ic b
-  else prove_le_nonneg_rat ic a b na nb
+| sum.inl a, sum.inr ff := do
+  (ic, p) ← prove_nonneg ic a,
+  ic.mk_app ``neg_nonpos_of_nonneg [a, p]
+| sum.inl a, sum.inr tt := do
+  (ic, pa) ← prove_nonneg ic a,
+  (ic, pb) ← prove_nonneg ic b,
+  ic.mk_app ``le_neg_pos [a, b, pa, pb]
+| sum.inr ff, _ := prove_nonneg ic b
+| sum.inr tt, _ := prove_le_nonneg_rat ic a b na nb
 end
 
 /-- Given `a`,`b` rational numerals, proves `⊢ a ≠ b`. This version

--- a/src/tactic/ring.lean
+++ b/src/tactic/ring.lean
@@ -114,7 +114,10 @@ These constraints ensure that there is a unique normal form for each ring expres
 algorithm is simply to calculate the normal form of each side and compare for equality.
 
 To allow us to efficiently pattern match on normal forms, we maintain this inductive type that
-holds a normalized expression together with its structure. We also -/
+holds a normalized expression together with its structure. All the `expr`s in this type could be
+removed without loss of information, and conversely the `horner_expr` structure and the `ℕ` and
+`ℚ` values can be recovered from the top level `expr`, but we keep both in order to keep proof
+ producing normalization functions efficient. -/
 meta inductive horner_expr : Type
 | const (e : expr × ℚ) : horner_expr
 | xadd (e : expr) (a : horner_expr) (x : expr × ℕ) (n : expr × ℕ) (b : horner_expr) : horner_expr

--- a/test/ring.lean
+++ b/test/ring.lean
@@ -17,11 +17,13 @@ example (x : ℚ) : x ^ (2 + 2) = x^4 := by ring
 example {α} [comm_ring α] (x : α) : x ^ 2 = x * x := by ring
 example {α} [linear_ordered_field α] (a b c : α) :
   b ^ 2 - 4 * c * a = -(4 * c * a) + b ^ 2 := by ring
-example {α} [linear_ordered_field α] (a b c: α) :
+example {α} [linear_ordered_field α] (a b c : α) :
   b ^ 2 - 4 * a * c = 4 * a * 0 + b * b - 4 * a * c := by ring
 example {α} [comm_semiring α] (x y z : α) (n : ℕ) :
   (x + y) * (z * (y * y) + (x * x ^ n + (1 + ↑n) * x ^ n * y)) =
     x * (x * x ^ n) + ((2 + ↑n) * (x * x ^ n) * y + (x * z + (z * y + (1 + ↑n) * x ^ n)) * (y * y)) := by ring
+example {α} [comm_ring α] (a b c d e : α) :
+  (-(a * b) + c + d) * e = (c + (d + -a * b)) * e := by ring
 example (a n s: ℕ) : a * (n - s) = (n - s) * a := by ring
 
 example (x y z : ℚ) (hx : x ≠ 0) (hy : y ≠ 0) (hz : z ≠ 0) :


### PR DESCRIPTION
Remove `tactic.norm_num` from `ring`, and do some performance upgrades borrowed from the `norm_num` overhaul while I'm at it.