### PR TITLE
[Merged by Bors] - feat(data/finset): remove uses of choice for infima

### DIFF
--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -2163,7 +2163,7 @@ fold_insert_idem
 @[simp] theorem min_singleton {a : α} : finset.min {a} = some a :=
 by { rw ← insert_emptyc_eq, exact min_insert }
 
-theorem min_of_mem [decidable_eq α] {s : finset α} {a : α} (h : a ∈ s) : ∃ b, b ∈ s.min :=
+theorem min_of_mem {s : finset α} {a : α} (h : a ∈ s) : ∃ b, b ∈ s.min :=
 (@inf_le (with_top α) _ _ _ _ _ h _ rfl).imp $ λ b, Exists.fst
 
 theorem min_of_nonempty {s : finset α} (h : s.nonempty) : ∃ a, a ∈ s.min :=


### PR DESCRIPTION
This PR removes the dependence of many lemmas about inf of finset sets on the axiom of choice. The motivation for this is to make `category_theory.limits.has_finite_limits_of_semilattice_inf_top` not depend on choice, which I would like so that I can prove independence results about topos models of set theory from the axiom of choice.

This does make the decidable_classical linter fail.