### PR TITLE
[Merged by Bors] - feat(category_theory/eq_to_hom): functor extensionality using heq

### DIFF
--- a/src/category_theory/eq_to_hom.lean
+++ b/src/category_theory/eq_to_hom.lean
@@ -56,6 +56,18 @@ begin
   simpa using h_map X Y f
 end
 
+/-- Proving equality between functors using heterogeneous equality. -/
+lemma hext {F G : C ⥤ D} (h_obj : ∀ X, F.obj X = G.obj X)
+  (h_map : ∀ X Y (f : X ⟶ Y), F.map f == G.map f) : F = G :=
+begin
+  cases F with F_obj _ _ _, cases G with G_obj _ _ _,
+  have : F_obj = G_obj, by ext X; apply h_obj,
+  subst this,
+  congr,
+  funext X Y f,
+  exact eq_of_heq (h_map X Y f)
+end
+
 -- Using equalities between functors.
 
 lemma congr_obj {F G : C ⥤ D} (h : F = G) (X) : F.obj X = G.obj X :=

--- a/src/category_theory/fully_faithful.lean
+++ b/src/category_theory/fully_faithful.lean
@@ -146,6 +146,10 @@ protected def faithful.div (F : C ⥤ E) (G : D ⥤ E) [faithful G]
       exact h_map.symm
   end }
 
+-- This follows immediately from `functor.hext` (`functor.hext h_obj @h_map`),
+-- but importing `category_theory.eq_to_hom` causes an import loop:
+-- category_theory.eq_to_hom → category_theory.opposites →
+-- category_theory.equivalence → category_theory.fully_faithful
 lemma faithful.div_comp (F : C ⥤ E) [faithful F] (G : D ⥤ E) [faithful G]
   (obj : C → D) (h_obj : ∀ X, G.obj (obj X) = F.obj X)
   (map : Π {X Y}, (X ⟶ Y) → (obj X ⟶ obj Y))


### PR DESCRIPTION
Used in https://github.com/rwbarton/lean-homotopy-theory.
Also proves `faithful.div_comp`, but using it would create an import loop
so for now I just leave a comment.