### PR TITLE
[Merged by Bors] - chore(*): update to lean 3.13.2

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mathlib"
 version = "0.1"
-lean_version = "leanprover-community/lean:3.13.1"
+lean_version = "leanprover-community/lean:3.13.2"
 path = "src"
 
 [dependencies]


### PR DESCRIPTION
This should fix the bug with the missing module doc strings in the documentation.