### PR TITLE
[Merged by Bors] - feat(data/equiv): add add_equiv.to_multiplicative

### DIFF
--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -310,3 +310,16 @@ sub_eq_iff_eq_add.trans $ h.eq_iff.trans eq_comm
 end point_reflection
 
 end equiv
+
+section type_tags
+
+/-- Reinterpret `f : G ≃+ H` as `multiplicative G ≃* multiplicative H`. -/
+def add_equiv.to_multiplicative [add_monoid G] [add_monoid H] (f : G ≃+ H) :
+  multiplicative G ≃* multiplicative H :=
+⟨f.to_add_monoid_hom.to_multiplicative, f.symm.to_add_monoid_hom.to_multiplicative, f.3, f.4, f.5⟩
+
+/-- Reinterpret `f : G ≃* H` as `additive G ≃+ additive H`. -/
+def mul_equiv.to_additive [monoid G] [monoid H] (f : G ≃* H) : additive G ≃+ additive H :=
+⟨f.to_monoid_hom.to_additive, f.symm.to_monoid_hom.to_additive, f.3, f.4, f.5⟩
+
+end type_tags


### PR DESCRIPTION
We already have `add_monoid_hom.to_multiplicative`. This adds `add_equiv.to_multiplicative`.

It is placed in `data/equiv/mul_add.lean` because `data/equiv/mul_add.lean` already imports `algebra/group/type_tags.lean`.