### PR TITLE
[Merged by Bors] - fix(*): do not nolint simp_nf

### DIFF
--- a/src/algebra/field.lean
+++ b/src/algebra/field.lean
@@ -31,15 +31,6 @@ instance division_ring_has_div : has_div α :=
 lemma division_def (a b : α) : a / b = a * b⁻¹ :=
 rfl
 
-@[simp] lemma inv_zero : 0⁻¹ = (0:α) :=
-division_ring.inv_zero
-
-@[simp] lemma div_zero (a : α) : a / 0 = (0:α) :=
-calc
-  a / 0 = (a:α) * 0⁻¹ : by rw division_def
-    ... = a * 0       : by rw inv_zero
-    ... = (0:α)       : by rw mul_zero
-
 @[simp] lemma mul_inv_cancel (h : a ≠ 0) : a * a⁻¹ = 1 :=
 division_ring.mul_inv_cancel h
 

--- a/src/algebra/group_with_zero.lean
+++ b/src/algebra/group_with_zero.lean
@@ -73,7 +73,7 @@ lemma div_eq_mul_inv {G₀ : Type*} [group_with_zero G₀] {a b : G₀} :
 section group_with_zero
 variables {G₀ : Type*} [group_with_zero G₀]
 
-@[simp] lemma inv_zero' : (0 : G₀)⁻¹ = 0 :=
+@[simp] lemma inv_zero : (0 : G₀)⁻¹ = 0 :=
 group_with_zero.inv_zero
 
 @[simp] lemma mul_inv_cancel' (a : G₀) (h : a ≠ 0) : a * a⁻¹ = 1 :=
@@ -255,7 +255,7 @@ begin
   have : a⁻¹ * (b * a) * a⁻¹ = a⁻¹ * (a * b) * a⁻¹ :=
     congr_arg (λ x:G₀, a⁻¹ * x * a⁻¹) H.symm,
   classical,
-  by_cases h : a = 0, { rw [h, inv_zero', zero_mul, mul_zero] },
+  by_cases h : a = 0, { rw [h, inv_zero, zero_mul, mul_zero] },
   rwa [inv_mul_cancel_assoc_right _ _ h, mul_assoc, mul_inv_cancel_assoc_left _ _ h] at this,
 end
 
@@ -268,8 +268,8 @@ lemma one_div (a : G₀) : 1 / a = a⁻¹ := one_mul _
 
 @[simp] lemma zero_div' (a : G₀) : 0 / a = 0 := zero_mul _
 
-@[simp] lemma div_zero' (a : G₀) : a / 0 = 0 :=
-show a * 0⁻¹ = 0, by rw [inv_zero', mul_zero]
+@[simp] lemma div_zero (a : G₀) : a / 0 = 0 :=
+show a * 0⁻¹ = 0, by rw [inv_zero, mul_zero]
 
 @[simp] lemma div_mul_cancel' (a : G₀) {b : G₀} (h : b ≠ 0) : a / b * b = a :=
 inv_mul_cancel_assoc_left a b h
@@ -334,7 +334,7 @@ variables {G₀ : Type*} [group_with_zero G₀]
 variables {a b c : G₀}
 
 @[simp] lemma inv_eq_zero {a : G₀} : a⁻¹ = 0 ↔ a = 0 :=
-by rw [inv_eq_iff, inv_zero', eq_comm]
+by rw [inv_eq_iff, inv_zero, eq_comm]
 
 lemma one_div_mul_one_div_rev (a b : G₀) : (1 / a) * (1 / b) =  1 / (b * a) :=
 by simp only [div_eq_mul_inv, one_mul, mul_inv_rev']
@@ -448,7 +448,7 @@ lemma eq_of_mul_eq_mul_of_nonzero_right' {a b c : G₀} (h : c ≠ 0) (h2 : a * 
 by rw [← mul_one a, ← div_self' h, ← mul_div_assoc'', h2, mul_div_cancel'' _ h]
 
 lemma ne_zero_of_one_div_ne_zero' {a : G₀} (h : 1 / a ≠ 0) : a ≠ 0 :=
-assume ha : a = 0, begin rw [ha, div_zero'] at h, contradiction end
+assume ha : a = 0, begin rw [ha, div_zero] at h, contradiction end
 
 lemma eq_zero_of_one_div_eq_zero' {a : G₀} (h : 1 / a = 0) : a = 0 :=
 classical.by_cases

--- a/src/group_theory/bundled_subgroup.lean
+++ b/src/group_theory/bundled_subgroup.lean
@@ -150,14 +150,17 @@ lemma coe_to_submonoid (K : subgroup G) : (K.to_submonoid : set G) = K := rfl
 @[to_additive]
 instance : has_mem G (subgroup G) := ⟨λ m K, m ∈ (K : set G)⟩
 
+@[to_additive]
+instance : has_coe_to_sort (subgroup G) := ⟨_, λ G, (G : Type*)⟩
+
 @[simp, norm_cast, to_additive]
 lemma mem_coe {K : subgroup G} [g : G] : g ∈ (K : set G) ↔ g ∈ K := iff.rfl
 
-@[simp, norm_cast, to_additive, nolint simp_nf]
+@[simp, norm_cast, to_additive]
 lemma coe_coe (K : subgroup G) : ↥(K : set G) = K := rfl
 
 attribute [norm_cast] add_subgroup.mem_coe
-attribute [norm_cast, nolint simp_nf] add_subgroup.coe_coe
+attribute [norm_cast] add_subgroup.coe_coe
 
 @[to_additive]
 instance is_subgroup (K : subgroup G) : is_subgroup (K : set G) :=


### PR DESCRIPTION
The `nolint simp_nf` for `subgroup.coe_coe` was hiding an actual nontermination issue.  Please just ping me if you're unsure about the `simp_nf` linter.