### PR TITLE
[Merged by Bors] - chore(*): remove non-canonical `option.decidable_eq_none` instance

### DIFF
--- a/src/computability/primrec.lean
+++ b/src/computability/primrec.lean
@@ -1045,14 +1045,13 @@ local attribute [instance, priority 100]
   encodable.decidable_range_encode encodable.decidable_eq_of_encodable
 
 instance ulower : primcodable (ulower α) :=
-have primrec_pred (λ n, none ≠ encodable.decode2 α n),
-from primrec.not (primrec.eq.comp (primrec.const _) (primrec.option_bind primrec.decode
+have primrec_pred (λ n, encodable.decode2 α n ≠ none),
+from primrec.not (primrec.eq.comp (primrec.option_bind primrec.decode
   (primrec.ite (primrec.eq.comp (primrec.encode.comp primrec.snd) primrec.fst)
-    (primrec.option_some.comp primrec.snd) (primrec.const _)))),
-(primcodable.subtype $
+    (primrec.option_some.comp primrec.snd) (primrec.const _))) (primrec.const _)),
+primcodable.subtype $
   primrec_pred.of_eq this $
-  by simp [set.range, option.eq_none_iff_forall_not_mem, encodable.mem_decode2,
-    show ∀ α (a : option α), none = a ↔ a = none, by intros; cc])
+  by simp [set.range, option.eq_none_iff_forall_not_mem, encodable.mem_decode2]
 
 end ulower
 

--- a/src/data/list/sigma.lean
+++ b/src/data/list/sigma.lean
@@ -161,11 +161,7 @@ end
 
 theorem lookup_eq_none {a : α} {l : list (sigma β)} :
   lookup a l = none ↔ a ∉ l.keys :=
-begin
-  have := not_congr (@lookup_is_some _ _ _ a l),
-  simp at this, refine iff.trans _ this,
-  cases lookup a l; exact dec_trivial
-end
+by simp [← lookup_is_some, option.is_none_iff_eq_none]
 
 theorem of_mem_lookup
   {a : α} {b : β a} : ∀ {l : list (sigma β)}, b ∈ lookup a l → sigma.mk a b ∈ l

--- a/src/data/option/defs.lean
+++ b/src/data/option/defs.lean
@@ -26,7 +26,14 @@ theorem is_none_iff_eq_none {o : option α} : o.is_none = tt ↔ o = none :=
 
 theorem some_inj {a b : α} : some a = some b ↔ a = b := by simp
 
-instance decidable_eq_none {o : option α} : decidable (o = none) :=
+/--
+`o = none` is decidable even if the wrapped type does not have decidable equality.
+
+This is not an instance because it is not definitionally equal to `option.decidable_eq`.
+Try to use `o.is_none` or `o.is_some` instead.
+-/
+@[inline]
+def decidable_eq_none {o : option α} : decidable (o = none) :=
 decidable_of_decidable_of_iff (bool.decidable_eq _ _) is_none_iff_eq_none
 
 instance decidable_forall_mem {p : α → Prop} [decidable_pred p] :

--- a/src/data/seq/seq.lean
+++ b/src/data/seq/seq.lean
@@ -48,10 +48,15 @@ def nth : seq α → ℕ → option α := subtype.val
 /-- A sequence has terminated at position `n` if the value at position `n` equals `none`. -/
 def terminated_at (s : seq α) (n : ℕ) : Prop := s.nth n = none
 
+section
+local attribute [instance] option.decidable_eq_none
+
 /-- It is decidable whether a sequence terminates at a given position. -/
 instance terminated_at_decidable (s : seq α) (n : ℕ) : decidable (s.terminated_at n) :=
 if p : s.nth n = none then is_true p
 else is_false (assume h, by contradiction)
+
+end
 
 /-- A sequence terminates if there is some position `n` at which it has terminated. -/
 def terminates (s : seq α) : Prop := ∃ (n : ℕ), s.terminated_at n

--- a/src/data/seq/seq.lean
+++ b/src/data/seq/seq.lean
@@ -48,15 +48,9 @@ def nth : seq α → ℕ → option α := subtype.val
 /-- A sequence has terminated at position `n` if the value at position `n` equals `none`. -/
 def terminated_at (s : seq α) (n : ℕ) : Prop := s.nth n = none
 
-section
-local attribute [instance] option.decidable_eq_none
-
 /-- It is decidable whether a sequence terminates at a given position. -/
 instance terminated_at_decidable (s : seq α) (n : ℕ) : decidable (s.terminated_at n) :=
-if p : s.nth n = none then is_true p
-else is_false (assume h, by contradiction)
-
-end
+decidable_of_iff' (s.nth n).is_none $ by unfold terminated_at; cases s.nth n; simp
 
 /-- A sequence terminates if there is some position `n` at which it has terminated. -/
 def terminates (s : seq α) : Prop := ∃ (n : ℕ), s.terminated_at n


### PR DESCRIPTION
I also removed the hack in `ulower.primcodable` where I had to use `none = o` instead of `o = none`.