### PR TITLE
[Merged by Bors] - fix(*): put headings in multiline module docs on their own lines

### DIFF
--- a/archive/sensitivity.lean
+++ b/archive/sensitivity.lean
@@ -42,7 +42,8 @@ notation `√` := real.sqrt
 
 open function bool linear_map fintype finite_dimensional dual_pair
 
-/-! ### The hypercube
+/-!
+### The hypercube
 
 Notations:
 - `ℕ` denotes natural numbers (including zero).

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -784,7 +784,8 @@ lemma differentiable_on_const (c : F) : differentiable_on 𝕜 (λx, c) s :=
 end const
 
 section continuous_linear_map
-/-! ### Continuous linear maps
+/-!
+### Continuous linear maps
 
 There are currently two variants of these in mathlib, the bundled version
 (named `continuous_linear_map`, and denoted `E →L[𝕜] F`), and the unbundled version (with a
@@ -2370,11 +2371,13 @@ end
 end tangent_cone
 
 section restrict_scalars
-/-! ### Restricting from `ℂ` to `ℝ`, or generally from `𝕜'` to `𝕜`
+/-!
+### Restricting from `ℂ` to `ℝ`, or generally from `𝕜'` to `𝕜`
 
 If a function is differentiable over `ℂ`, then it is differentiable over `ℝ`. In this paragraph,
 we give variants of this statement, in the general situation where `ℂ` and `ℝ` are replaced
-respectively by `𝕜'` and `𝕜` where `𝕜'` is a normed algebra over `𝕜`. -/
+respectively by `𝕜'` and `𝕜` where `𝕜'` is a normed algebra over `𝕜`.
+-/
 
 variables (𝕜 : Type*) [nondiscrete_normed_field 𝕜]
 {𝕜' : Type*} [nondiscrete_normed_field 𝕜'] [normed_algebra 𝕜 𝕜']

--- a/src/analysis/calculus/local_extr.lean
+++ b/src/analysis/calculus/local_extr.lean
@@ -6,7 +6,8 @@ Authors: Yury Kudryashov
 import topology.local_extr
 import analysis.calculus.deriv
 
-/-! # Local extrema of smooth functions
+/-!
+# Local extrema of smooth functions
 
 ## Main definitions
 

--- a/src/category_theory/shift.lean
+++ b/src/category_theory/shift.lean
@@ -5,7 +5,8 @@ Authors: Scott Morrison
 -/
 import category_theory.limits.shapes.zero
 
-/-! #Shift
+/-!
+# Shift
 
 A `shift` on a category is nothing more than an automorphism of the category. An example to
 keep in mind might be the category of complexes ⋯ → C_{n-1} → C_n → C_{n+1} → ⋯ with the shift

--- a/src/computability/turing_machine.lean
+++ b/src/computability/turing_machine.lean
@@ -807,7 +807,8 @@ roption.ext $ λ b₂,
     rwa bb at h
   end⟩
 
-/-! ## The TM0 model
+/-!
+## The TM0 model
 
 A TM0 turing machine is essentially a Post-Turing machine, adapted for type theory.
 
@@ -977,7 +978,8 @@ end
 
 end TM0
 
-/-! ## The TM1 model
+/-!
+## The TM1 model
 
 The TM1 model is a simplification and extension of TM0 (Post-Turing model) in the direction of
 Wang B-machines. The machine's internal state is extended with a (finite) store `σ` of variables
@@ -1174,7 +1176,8 @@ end
 
 end TM1
 
-/-! ## TM1 emulator in TM0
+/-!
+## TM1 emulator in TM0
 
 To prove that TM1 computable functions are TM0 computable, we need to reduce each TM1 program to a
 TM0 program. So suppose a TM1 program is given. We take the following:
@@ -1316,7 +1319,8 @@ end⟩
 end
 end TM1to0
 
-/-! ## TM1(Γ) emulator in TM1(bool)
+/-!
+## TM1(Γ) emulator in TM1(bool)
 
 The most parsimonious Turing machine model that is still Turing complete is `TM0` with `Γ = bool`.
 Because our construction in the previous section reducing `TM1` to `TM0` doesn't change the
@@ -1666,7 +1670,8 @@ end
 
 end TM1to1
 
-/-! ## TM0 emulator in TM1
+/-!
+## TM0 emulator in TM1
 
 To establish that TM0 and TM1 are equivalent computational models, we must also have a TM0 emulator
 in TM1. The main complication here is that TM0 allows an action to depend on the value at the head
@@ -1740,7 +1745,8 @@ end
 
 end TM0to1
 
-/-! ## The TM2 model
+/-!
+## The TM2 model
 
 The TM2 model removes the tape entirely from the TM1 model, replacing it with an arbitrary (finite)
 collection of stacks, each with elements of different types (the alphabet of stack `k : K` is
@@ -1935,7 +1941,8 @@ end
 
 end TM2
 
-/-! ## TM2 emulator in TM1
+/-!
+## TM2 emulator in TM1
 
 To prove that TM2 computable functions are TM1 computable, we need to reduce each TM2 program to a
 TM1 program. So suppose a TM2 program is given. This program has to maintain a whole collection of

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -2,11 +2,11 @@
 Copyright (c) 2018 Ellen Arlt. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ellen Arlt, Blair Shi, Sean Leather, Mario Carneiro, Johan Commelin
-
-Matrices
 -/
 import algebra.pi_instances
-
+/-!
+# Matrices
+-/
 universes u v w
 
 open_locale big_operators
@@ -491,9 +491,10 @@ def sub_down_left {d u l r : nat} (A: matrix (fin (u + d)) (fin (l + r)) α) :
 sub_down (sub_left A)
 
 section row_col
-/-! ### `row_col` section
+/-!
+### `row_col` section
 
-  Simplification lemmas for `matrix.row` and `matrix.col`.
+Simplification lemmas for `matrix.row` and `matrix.col`.
 -/
 open_locale matrix
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -10,7 +10,6 @@ import logic.unique
 import data.prod
 
 /-!
-
 # Basic properties of sets
 
 Sets in Lean are homogeneous; all their elements have the same type. Sets whose elements
@@ -513,9 +512,11 @@ ext (assume x, or_and_distrib_left)
 theorem union_distrib_right (s t u : set α) : (s ∩ t) ∪ u = (s ∪ u) ∩ (t ∪ u) :=
 ext (assume x, and_or_distrib_right)
 
-/-! ### Lemmas about `insert`
+/-!
+### Lemmas about `insert`
 
-`insert α s` is the set `{α} ∪ s`. -/
+`insert α s` is the set `{α} ∪ s`.
+-/
 
 theorem insert_def (x : α) (s : set α) : insert x s = { y | y = x ∨ y ∈ s } := rfl
 

--- a/src/data/set/function.lean
+++ b/src/data/set/function.lean
@@ -6,7 +6,8 @@ Author: Jeremy Avigad, Andrew Zipperer, Haitao Zhang, Minchao Wu, Yury Kudryasho
 import data.set.basic
 import logic.function.basic
 
-/-! # Functions over sets
+/-!
+# Functions over sets
 
 ## Main definitions
 

--- a/src/data/set/intervals/disjoint.lean
+++ b/src/data/set/intervals/disjoint.lean
@@ -5,7 +5,8 @@ Authors: Floris van Doorn, Yury Kudryashov
 -/
 import data.set.lattice
 
-/-! # Extra lemmas about intervals
+/-!
+# Extra lemmas about intervals
 
 This file contains lemmas about intervals that cannot be included into `data.set.intervals.basic`
 because this would create an `import` cycle. Namely, lemmas in this file can use definitions

--- a/src/geometry/manifold/mfderiv.lean
+++ b/src/geometry/manifold/mfderiv.lean
@@ -1066,7 +1066,8 @@ end specific_functions
 
 section mfderiv_fderiv
 
-/-! ### Relations between vector space derivative and manifold derivative
+/-!
+### Relations between vector space derivative and manifold derivative
 
 The manifold derivative `mfderiv`, when considered on the model vector space with its trivial
 manifold structure, coincides with the usual Frechet derivative `fderiv`. In this section, we prove

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -150,9 +150,10 @@ calc det (c • A) = det (matrix.mul (diagonal (λ _, c)) A) : by rw [smul_eq_di
              ... = c ^ fintype.card n * det A             : by simp [card_univ]
 
 section det_zero
-/-! ### `det_zero` section
+/-!
+### `det_zero` section
 
-  Prove that a matrix with a repeated column has determinant equal to zero.
+Prove that a matrix with a repeated column has determinant equal to zero.
 -/
 
 lemma det_eq_zero_of_column_eq_zero {A : matrix n n R} (i : n) (h : ∀ j, A i j = 0) : det A = 0 :=

--- a/src/linear_algebra/nonsingular_inverse.lean
+++ b/src/linear_algebra/nonsingular_inverse.lean
@@ -1,9 +1,7 @@
 /-
-  Copyright (c) 2019 Tim Baanen. All rights reserved.
-  Released under Apache 2.0 license as described in the file LICENSE.
-  Author: Tim Baanen.
-
-  Inverses for nonsingular square matrices.
+Copyright (c) 2019 Tim Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Tim Baanen.
 -/
 import algebra.associated
 import linear_algebra.determinant
@@ -196,7 +194,8 @@ calc s.sum (λ x, cramer α A (λ j, f j x) i)
 end cramer
 
 section adjugate
-/-! ### `adjugate` section
+/-!
+### `adjugate` section
 
 Define the `adjugate` matrix and a few equations.
 These will hold for any matrix over a commutative ring,
@@ -348,7 +347,8 @@ end
 end adjugate
 
 section inv
-/-! ### `inv` section
+/-!
+### `inv` section
 
 Defines the matrix `nonsing_inv A` and proves it is the inverse matrix
 of a square matrix `A` as long as `det A` has a multiplicative inverse.

--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -2,8 +2,6 @@
 Copyright (c) 2020 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Anne Baanen
-
-Quadratic forms over modules.
 -/
 
 import algebra.invertible
@@ -158,7 +156,8 @@ end comp
 
 end quadratic_form
 
-/-! ### Associated bilinear forms
+/-!
+### Associated bilinear forms
 
 Over a commutative ring with an inverse of 2, the theory of quadratic forms is
 basically identical to that of symmetric bilinear forms. The map from quadratic
@@ -251,7 +250,8 @@ lemma smul_pos_def_of_nonzero {K : Type u} [linear_ordered_field K] [module K M]
 end pos_def
 end quadratic_form
 
-/-! ### Quadratic forms and matrices
+/-!
+### Quadratic forms and matrices
 
 Connect quadratic forms and matrices, in order to explicitly compute with them.
 The convention is twos out, so there might be a factor 2⁻¹ in the entries of the

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2018 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
-Adapted from the corresponding theory for complete lattices.
 -/
 import data.nat.enat
 
@@ -586,7 +585,8 @@ end order_dual
 
 section with_top_bot
 
-/-! ### Complete lattice structure on `with_top (with_bot α)`
+/-!
+### Complete lattice structure on `with_top (with_bot α)`
 
 If `α` is a `conditionally_complete_lattice`, then we show that `with_top α` and `with_bot α`
 also inherit the structure of conditionally complete lattices. Furthermore, we show

--- a/src/order/filter/bases.lean
+++ b/src/order/filter/bases.lean
@@ -6,7 +6,8 @@ Author: Yury Kudryashov, Johannes Hölzl, Mario Carneiro, Patrick Massot
 import order.filter.basic
 import data.set.countable
 
-/-! # Filter bases
+/-!
+# Filter bases
 
 A filter basis `B : filter_basis α` on a type `α` is a nonempty collection of sets of `α`
 such that the intersection of two elements of this collection contains some element of

--- a/src/order/filter/extr.lean
+++ b/src/order/filter/extr.lean
@@ -5,7 +5,8 @@ Authors: Yury Kudryashov
 -/
 import order.filter.basic
 
-/-! # Minimum and maximum w.r.t. a filter and on a aet
+/-!
+# Minimum and maximum w.r.t. a filter and on a aet
 
 ## Main Definitions
 

--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -2,8 +2,6 @@
 Copyright (c) 2020 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
-
-Fractional ideals of an integral domain.
 -/
 import ring_theory.localization
 
@@ -138,10 +136,11 @@ mem_one_iff.mpr ⟨x, rfl⟩
 
 section lattice
 
-/-! ### `lattice` section
+/-!
+### `lattice` section
 
-  Defines the order on fractional ideals as inclusion of their underlying sets,
-  and ports the lattice structure on submodules to fractional ideals.
+Defines the order on fractional ideals as inclusion of their underlying sets,
+and ports the lattice structure on submodules to fractional ideals.
 -/
 
 
@@ -311,7 +310,8 @@ end semiring
 
 section quotient
 
-/-! ### `quotient` section
+/-!
+### `quotient` section
 
 This section defines the ideal quotient of fractional ideals.
 

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -600,9 +600,10 @@ def le_order_embedding :
 end ideals
 
 section module
-/-! ### `module` section
+/-!
+### `module` section
 
-  Localizations form an algebra over `α` induced by the embedding `coe : α → localization α S`.
+Localizations form an algebra over `α` induced by the embedding `coe : α → localization α S`.
 -/
 
 

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -433,8 +433,11 @@ In contrast to `generalize` it already introduces the generalized variable. -/
 meta def generalize' (e : expr) (n : name) : tactic expr :=
 (generalize e n >> intro1) <|> note n none e
 
-/-! ### Various tactics related to local definitions (local constants of the form `x : α := t`)
-We call `t` the value of `x`. -/
+/-!
+### Various tactics related to local definitions (local constants of the form `x : α := t`)
+
+We call `t` the value of `x`.
+-/
 
 /-- `local_def_value e` returns the value of the expression `e`, assuming that `e` has been defined
   locally using a `let` expression. Otherwise it fails. -/

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -8,7 +8,8 @@ import order.liminf_limsup
 import data.set.intervals
 import topology.algebra.group
 
-/-! # Theory of topology on ordered spaces
+/-!
+# Theory of topology on ordered spaces
 
 ## Main definitions
 

--- a/src/topology/local_extr.lean
+++ b/src/topology/local_extr.lean
@@ -6,7 +6,8 @@ Authors: Yury Kudryashov
 import order.filter.extr
 import topology.continuous_on
 
-/-! # Local extrema of functions on topological spaces
+/-!
+# Local extrema of functions on topological spaces
 
 ## Main definitions
 

--- a/src/topology/metric_space/cau_seq_filter.lean
+++ b/src/topology/metric_space/cau_seq_filter.lean
@@ -5,7 +5,8 @@ Authors: Robert Y. Lewis, Sébastien Gouëzel
 -/
 import analysis.normed_space.basic
 
-/-! # Completeness in terms of `cauchy` filters vs `is_cau_seq` sequences
+/-!
+# Completeness in terms of `cauchy` filters vs `is_cau_seq` sequences
 
 In this file we apply `metric.complete_of_cauchy_seq_tendsto` to prove that a `normed_ring`
 is complete in terms of `cauchy` filter if and only if it is complete in terms

--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -2,13 +2,13 @@
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
-
-Theory of Cauchy filters in uniform spaces. Complete uniform spaces. Totally bounded subsets.
 -/
 import topology.uniform_space.basic
 import topology.bases
 import data.set.intervals
-
+/-!
+# Theory of Cauchy filters in uniform spaces. Complete uniform spaces. Totally bounded subsets.
+-/
 universes u v
 
 open filter topological_space set classical
@@ -399,12 +399,13 @@ lemma compact_of_totally_bounded_is_closed [complete_space α] {s : set α}
   (ht : totally_bounded s) (hc : is_closed s) : compact s :=
 (@compact_iff_totally_bounded_complete α _ s).2 ⟨ht, is_complete_of_is_closed hc⟩
 
-/-! ### Sequentially complete space
+/-!
+### Sequentially complete space
 
 In this section we prove that a uniform space is complete provided that it is sequentially complete
 (i.e., any Cauchy sequence converges) and its uniformity filter admits a countable generating set.
-In particular, this applies to (e)metric spaces, see the files `topology/metric_space/emetric_space` and
-`topology/metric_space/basic`.
+In particular, this applies to (e)metric spaces, see the files `topology/metric_space/emetric_space`
+and `topology/metric_space/basic`.
 
 More precisely, we assume that there is a sequence of entourages `U_n` such that any other
 entourage includes one of `U_n`. Then any Cauchy filter `f` generates a decreasing sequence of


### PR DESCRIPTION
found using regex: `/-! #([^-/])*$`.

These don't render correctly in the mathlib docs. Module doc strings that consist of a heading on its own line are OK so I haven't changed them.

I also moved some descriptive text from copyright headers to module docs, or removed such text if there was already a module doc string.