### PR TITLE
[Merged by Bors] - feat(logic/basic): spaces with a zero or a one are nonempty

### DIFF
--- a/src/analysis/calculus/inverse.lean
+++ b/src/analysis/calculus/inverse.lean
@@ -174,9 +174,8 @@ Should not be used outside of this file, because it is superseded by `to_local_h
 
 This is a first step towards the inverse function. -/
 def to_local_equiv (hf : approximates_linear_on f (f' : E →L[𝕜] F) s c)
-  (hc : subsingleton E ∨ c < N⁻¹) :
-  local_equiv E F :=
-by haveI : nonempty E := ⟨0⟩; exact (hf.inj_on hc).to_local_equiv _ _
+  (hc : subsingleton E ∨ c < N⁻¹) : local_equiv E F :=
+(hf.inj_on hc).to_local_equiv _ _
 
 /-- The inverse function is continuous on `f '' s`. Use properties of `local_homeomorph` instead. -/
 lemma inverse_continuous_on (hf : approximates_linear_on f (f' : E →L[𝕜] F) s c)

--- a/src/analysis/normed_space/banach.lean
+++ b/src/analysis/normed_space/banach.lean
@@ -36,7 +36,6 @@ is within distance `∥y∥/2` of `y`, to apply an iterative process. -/
 lemma exists_approx_preimage_norm_le (surj : surjective f) :
   ∃C ≥ 0, ∀y, ∃x, dist (f x) y ≤ 1/2 * ∥y∥ ∧ ∥x∥ ≤ C * ∥y∥ :=
 begin
-  haveI : nonempty F := ⟨0⟩,
   have A : (⋃n:ℕ, closure (f '' (ball 0 n))) = univ,
   { refine subset.antisymm (subset_univ _) (λy hy, _),
     rcases surj y with ⟨x, hx⟩,

--- a/src/group_theory/bundled_subgroup.lean
+++ b/src/group_theory/bundled_subgroup.lean
@@ -467,7 +467,7 @@ end
 @[to_additive]
 lemma mem_Sup_of_directed_on {K : set (subgroup G)} (Kne : K.nonempty)
   (hK : directed_on (≤) K) {x : G} :
-  x ∈ Sup  K↔ ∃ s ∈ K, x ∈ s :=
+  x ∈ Sup K ↔ ∃ s ∈ K, x ∈ s :=
 begin
   haveI : nonempty K := Kne.to_subtype,
   rw [Sup_eq_supr, supr_subtype', mem_supr_of_directed, subtype.exists],

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -128,7 +128,6 @@ lemma one_mem_fixed_points_rotate (n : ℕ) [fact (0 < n)] :
   (⟨vector.repeat (1 : G) n, one_mem_vectors_prod_eq_one n⟩ : vectors_prod_eq_one G n) ∈
   fixed_points (multiplicative (zmod n)) (vectors_prod_eq_one G n) :=
 λ m, subtype.eq $ vector.eq _ _ $
-by haveI : nonempty G := ⟨1⟩; exact
 rotate_eq_self_iff_eq_repeat.2 ⟨(1 : G),
   show list.repeat (1 : G) n = list.repeat 1 (list.repeat (1 : G) n).length, by simp⟩ _
 
@@ -159,7 +158,6 @@ have hlt : 1 < card (fixed_points (multiplicative (zmod p)) (vectors_prod_eq_one
 let ⟨⟨⟨⟨x, hx₁⟩, hx₂⟩, hx₃⟩, hx₄⟩ := fintype.exists_ne_of_one_lt_card hlt
   ⟨_, one_mem_fixed_points_rotate p⟩ in
 have hx : x ≠ list.repeat (1 : G) p, from λ h, by simpa [h, vector.repeat] using hx₄,
-have nG : nonempty G, from ⟨1⟩,
 have ∃ a, x = list.repeat a x.length := by exactI rotate_eq_self_iff_eq_repeat.1 (λ n,
   have list.rotate x (n : zmod p).val = x :=
     subtype.mk.inj (subtype.mk.inj (hx₃ (n : zmod p))),

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -874,6 +874,9 @@ variables {α : Type u} {β : Type v} {γ : α → Type w}
 
 attribute [simp] nonempty_of_inhabited
 
+instance has_zero.to_nonempty [has_zero α] : nonempty α := ⟨0⟩
+instance has_one.to_nonempty [has_one α] : nonempty α := ⟨1⟩
+
 lemma exists_true_iff_nonempty {α : Sort*} : (∃a:α, true) ↔ nonempty α :=
 iff.intro (λ⟨a, _⟩, ⟨a⟩) (λ⟨a⟩, ⟨a, trivial⟩)
 

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -874,7 +874,9 @@ variables {α : Type u} {β : Type v} {γ : α → Type w}
 
 attribute [simp] nonempty_of_inhabited
 
+@[priority 20]
 instance has_zero.to_nonempty [has_zero α] : nonempty α := ⟨0⟩
+@[priority 20]
 instance has_one.to_nonempty [has_one α] : nonempty α := ⟨1⟩
 
 lemma exists_true_iff_nonempty {α : Sort*} : (∃a:α, true) ↔ nonempty α :=

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -875,9 +875,9 @@ variables {α : Type u} {β : Type v} {γ : α → Type w}
 attribute [simp] nonempty_of_inhabited
 
 @[priority 20]
-instance has_zero.to_nonempty [has_zero α] : nonempty α := ⟨0⟩
+instance has_zero.nonempty [has_zero α] : nonempty α := ⟨0⟩
 @[priority 20]
-instance has_one.to_nonempty [has_one α] : nonempty α := ⟨1⟩
+instance has_one.nonempty [has_one α] : nonempty α := ⟨1⟩
 
 lemma exists_true_iff_nonempty {α : Sort*} : (∃a:α, true) ↔ nonempty α :=
 iff.intro (λ⟨a, _⟩, ⟨a⟩) (λ⟨a⟩, ⟨a, trivial⟩)


### PR DESCRIPTION
Register instances that a space with a zero or a one is not empty, with low priority as we don't want to embark on a search for a zero or a one if this is not necessary.

Discussion on Zulip at https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/inhabited.20and.20nonempty.20instances/near/198030072