### PR TITLE
[Merged by Bors] - feat(linear_algebra/bilinear_form): introduce adjoints of linear maps

### DIFF
--- a/src/algebra/classical_lie_algebras.lean
+++ b/src/algebra/classical_lie_algebras.lean
@@ -44,7 +44,7 @@ namespace special_linear
 /-- The special linear Lie algebra: square matrices of trace zero. -/
 def sl : lie_subalgebra R (matrix n n R) :=
 { lie_mem := λ X Y _ _, linear_map.mem_ker.2 $ matrix_trace_commutator_zero _ _ _ _,
-  to_submodule := linear_map.ker (matrix.trace n R R) }
+  ..linear_map.ker (matrix.trace n R R) }
 
 lemma sl_bracket (A B : sl n R) : ⁅A, B⁆.val = A.val ⬝ B.val - B.val ⬝ A.val := rfl
 

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -682,12 +682,10 @@ lemma is_skew_adjoint_bracket (f g : module.End R M)
   ⁅f, g⁆ ∈ B.skew_adjoint_submodule :=
 begin
   rw mem_skew_adjoint_submodule at *,
-  have hfg : is_adjoint_pair B B (f * g) (g * f),
-  { rw ←neg_mul_neg g f, exact is_adjoint_pair.mul hf hg, },
-  have hgf : is_adjoint_pair B B (g * f) (f * g),
-  { rw ←neg_mul_neg f g, exact is_adjoint_pair.mul hg hf, },
+  have hfg : is_adjoint_pair B B (f * g) (g * f), { rw ←neg_mul_neg g f, exact hf.mul hg, },
+  have hgf : is_adjoint_pair B B (g * f) (f * g), { rw ←neg_mul_neg f g, exact hg.mul hf, },
   change bilin_form.is_adjoint_pair B B (f * g - g * f) (-(f * g - g * f)), rw neg_sub,
-  exact bilin_form.is_adjoint_pair.sub hfg hgf,
+  exact hfg.sub hgf,
 end
 
 /-- Given an `R`-module `M`, equipped with a bilinear form, the skew-adjoint endomorphisms form a

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -711,7 +711,7 @@ lie_equiv_matrix'.to_morphism.comp (skew_adjoint_lie_subalgebra J.to_bilin_form)
 
 /-- The Lie subalgebra of skew-adjoint square matrices corresponding to a square matrix `J` -/
 def skew_adjoint_matrices_lie_subalgebra (J : matrix n n R) : lie_subalgebra R (matrix n n R) :=
-  (skew_adjoint_matrices_lie_embedding J).range
+(skew_adjoint_matrices_lie_embedding J).range
 
 end skew_adjoint_matrices
 

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -683,9 +683,9 @@ lemma is_skew_adjoint_bracket (f g : module.End R M)
 begin
   rw mem_skew_adjoint_submodule at *,
   have hfg : is_adjoint_pair B B (f * g) (g * f),
-  { rw ←neg_mul_neg g f, exact B.is_adjoint_pair_mul _ _ _ _ hf hg, },
+  { rw ←neg_mul_neg g f, exact is_adjoint_pair.mul B hf hg, },
   have hgf : is_adjoint_pair B B (g * f) (f * g),
-  { rw ←neg_mul_neg f g, exact B.is_adjoint_pair_mul _ _ _ _ hg hf, },
+  { rw ←neg_mul_neg f g, exact is_adjoint_pair.mul B hg hf, },
   change bilin_form.is_adjoint_pair B B (f * g - g * f) (-(f * g - g * f)), rw neg_sub,
   exact bilin_form.is_adjoint_pair.sub _ _ _ _ _ _ hfg hgf,
 end

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -422,7 +422,7 @@ local attribute [instance] lie_ring.of_associative_ring
 local attribute [instance] lie_algebra.of_associative_algebra
 
 /-- The embedding of a Lie subalgebra into the ambient space as a Lie morphism. -/
-def lie_subalgebra.subtype
+def lie_subalgebra.incl
   {R : Type u} {L : Type v} [comm_ring R] [lie_ring L] [lie_algebra R L]
   (L' : lie_subalgebra R L) : L' →ₗ⁅R⁆ L :=
 { map_lie := λ x y, by { rw [linear_map.to_fun_eq_coe, submodule.subtype_apply], refl, },
@@ -707,7 +707,7 @@ embedding from the corresponding Lie subalgebra of skew-adjoint endomorphisms in
 of matrices. -/
 def skew_adjoint_matrices_lie_embedding (J : matrix n n R) :
   J.to_bilin_form.skew_adjoint_lie_subalgebra →ₗ⁅R⁆ matrix n n R :=
-lie_equiv_matrix'.to_morphism.comp (skew_adjoint_lie_subalgebra J.to_bilin_form).subtype
+lie_equiv_matrix'.to_morphism.comp (skew_adjoint_lie_subalgebra J.to_bilin_form).incl
 
 /-- The Lie subalgebra of skew-adjoint square matrices corresponding to a square matrix `J` -/
 def skew_adjoint_matrices_lie_subalgebra (J : matrix n n R) : lie_subalgebra R (matrix n n R) :=

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -680,10 +680,10 @@ variables (B : bilin_form R M)
 lemma is_skew_adjoint_bracket (T S : module.End R M)
   (hT : B.is_skew_adjoint T) (hS : B.is_skew_adjoint S) : B.is_skew_adjoint ⁅T, S⁆ :=
 begin
-  have hST : B.is_adjoint_pair (S * T) (T * S) := by {
-    rw ←neg_mul_neg T S, exact B.is_adjoint_pair_mul _ _ _ _ hS hT, },
-  have hTS : B.is_adjoint_pair (T * S) (S * T) := by {
-    rw ←neg_mul_neg S T, exact B.is_adjoint_pair_mul _ _ _ _ hT hS, },
+  have hST : B.is_adjoint_pair (S * T) (T * S),
+  { rw ←neg_mul_neg T S, exact B.is_adjoint_pair_mul _ _ _ _ hS hT, },
+  have hTS : B.is_adjoint_pair (T * S) (S * T),
+  { rw ←neg_mul_neg S T, exact B.is_adjoint_pair_mul _ _ _ _ hT hS, },
   change B.is_adjoint_pair (T * S - S * T) (-(T * S - S * T)), rw neg_sub,
   exact B.is_adjoint_pair_sub _ _ _ _ hTS hST,
 end

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -707,7 +707,7 @@ embedding from the corresponding Lie subalgebra of skew-adjoint endomorphisms in
 of matrices. -/
 def skew_adjoint_matrices_lie_embedding (J : matrix n n R) :
   J.to_bilin_form.skew_adjoint_lie_subalgebra →ₗ⁅R⁆ matrix n n R :=
-  lie_equiv_matrix'.to_morphism.comp (skew_adjoint_lie_subalgebra J.to_bilin_form).subtype
+lie_equiv_matrix'.to_morphism.comp (skew_adjoint_lie_subalgebra J.to_bilin_form).subtype
 
 /-- The Lie subalgebra of skew-adjoint square matrices corresponding to a square matrix `J` -/
 def skew_adjoint_matrices_lie_subalgebra (J : matrix n n R) : lie_subalgebra R (matrix n n R) :=

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -683,11 +683,11 @@ lemma is_skew_adjoint_bracket (f g : module.End R M)
 begin
   rw mem_skew_adjoint_submodule at *,
   have hfg : is_adjoint_pair B B (f * g) (g * f),
-  { rw ←neg_mul_neg g f, exact is_adjoint_pair.mul B hf hg, },
+  { rw ←neg_mul_neg g f, exact is_adjoint_pair.mul hf hg, },
   have hgf : is_adjoint_pair B B (g * f) (f * g),
-  { rw ←neg_mul_neg f g, exact is_adjoint_pair.mul B hg hf, },
+  { rw ←neg_mul_neg f g, exact is_adjoint_pair.mul hg hf, },
   change bilin_form.is_adjoint_pair B B (f * g - g * f) (-(f * g - g * f)), rw neg_sub,
-  exact bilin_form.is_adjoint_pair.sub _ _ _ _ _ _ hfg hgf,
+  exact bilin_form.is_adjoint_pair.sub hfg hgf,
 end
 
 /-- Given an `R`-module `M`, equipped with a bilinear form, the skew-adjoint endomorphisms form a

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -676,13 +676,13 @@ variables {M : Type v} [add_comm_group M] [module R M]
 variables (B : bilin_form R M)
 
 lemma is_skew_adjoint_bracket (T S : module.End R M)
-  (hT : is_skew_adjoint B T) (hS : is_skew_adjoint B S) : is_skew_adjoint B ⁅T, S⁆ :=
+  (hT : B.is_skew_adjoint T) (hS : B.is_skew_adjoint S) : B.is_skew_adjoint ⁅T, S⁆ :=
 begin
-  have hST : is_adjoint_pair B (S * T) (T * S) := by {
+  have hST : B.is_adjoint_pair (S * T) (T * S) := by {
     rw ←neg_mul_neg T S, exact B.is_adjoint_pair_mul _ _ _ _ hS hT, },
-  have hTS : is_adjoint_pair B (T * S) (S * T) := by {
+  have hTS : B.is_adjoint_pair (T * S) (S * T) := by {
     rw ←neg_mul_neg S T, exact B.is_adjoint_pair_mul _ _ _ _ hT hS, },
-  change is_adjoint_pair B (T * S - S * T) (-(T * S - S * T)), rw neg_sub,
+  change B.is_adjoint_pair (T * S - S * T) (-(T * S - S * T)), rw neg_sub,
   exact B.is_adjoint_pair_sub _ _ _ _ hTS hST,
 end
 

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -687,7 +687,7 @@ begin
   have hgf : is_adjoint_pair B B (g * f) (f * g),
   { rw ←neg_mul_neg f g, exact B.is_adjoint_pair_mul _ _ _ _ hg hf, },
   change bilin_form.is_adjoint_pair B B (f * g - g * f) (-(f * g - g * f)), rw neg_sub,
-  exact bilin_form.is_adjoint_pair_sub _ _ _ _ _ _ hfg hgf,
+  exact bilin_form.is_adjoint_pair.sub _ _ _ _ _ _ hfg hgf,
 end
 
 /-- Given an `R`-module `M`, equipped with a bilinear form, the skew-adjoint endomorphisms form a
@@ -700,6 +700,7 @@ end skew_adjoint_endomorphisms
 section skew_adjoint_matrices
 
 variables {n : Type w} [fintype n] [decidable_eq n]
+variables (J : matrix n n R)
 
 local attribute [instance] matrix.lie_ring
 local attribute [instance] matrix.lie_algebra
@@ -707,12 +708,12 @@ local attribute [instance] matrix.lie_algebra
 /-- Given a square matrix `J` defining a bilinear form on the free module, there is a natural
 embedding from the corresponding Lie subalgebra of skew-adjoint endomorphisms into the Lie algebra
 of matrices. -/
-def skew_adjoint_matrices_lie_embedding (J : matrix n n R) :
+def skew_adjoint_matrices_lie_embedding :
   J.to_bilin_form.skew_adjoint_lie_subalgebra →ₗ⁅R⁆ matrix n n R :=
 lie_equiv_matrix'.to_morphism.comp (skew_adjoint_lie_subalgebra J.to_bilin_form).incl
 
 /-- The Lie subalgebra of skew-adjoint square matrices corresponding to a square matrix `J`. -/
-def skew_adjoint_matrices_lie_subalgebra (J : matrix n n R) : lie_subalgebra R (matrix n n R) :=
+def skew_adjoint_matrices_lie_subalgebra : lie_subalgebra R (matrix n n R) :=
 (skew_adjoint_matrices_lie_embedding J).range
 
 end skew_adjoint_matrices

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -677,15 +677,17 @@ section skew_adjoint_endomorphisms
 variables {M : Type v} [add_comm_group M] [module R M]
 variables (B : bilin_form R M)
 
-lemma is_skew_adjoint_bracket (T S : module.End R M)
-  (hT : B.is_skew_adjoint T) (hS : B.is_skew_adjoint S) : B.is_skew_adjoint ⁅T, S⁆ :=
+lemma is_skew_adjoint_bracket (f g : module.End R M)
+  (hf : f ∈ B.skew_adjoint_submodule) (hg : g ∈ B.skew_adjoint_submodule) :
+  ⁅f, g⁆ ∈ B.skew_adjoint_submodule :=
 begin
-  have hST : B.is_adjoint_pair (S * T) (T * S),
-  { rw ←neg_mul_neg T S, exact B.is_adjoint_pair_mul _ _ _ _ hS hT, },
-  have hTS : B.is_adjoint_pair (T * S) (S * T),
-  { rw ←neg_mul_neg S T, exact B.is_adjoint_pair_mul _ _ _ _ hT hS, },
-  change B.is_adjoint_pair (T * S - S * T) (-(T * S - S * T)), rw neg_sub,
-  exact B.is_adjoint_pair_sub _ _ _ _ hTS hST,
+  rw mem_skew_adjoint_submodule at *,
+  have hfg : is_adjoint_pair B B (f * g) (g * f),
+  { rw ←neg_mul_neg g f, exact B.is_adjoint_pair_mul _ _ _ _ hf hg, },
+  have hgf : is_adjoint_pair B B (g * f) (f * g),
+  { rw ←neg_mul_neg f g, exact B.is_adjoint_pair_mul _ _ _ _ hg hf, },
+  change bilin_form.is_adjoint_pair B B (f * g - g * f) (-(f * g - g * f)), rw neg_sub,
+  exact bilin_form.is_adjoint_pair_sub _ _ _ _ _ _ hfg hgf,
 end
 
 /-- Given an `R`-module `M`, equipped with a bilinear form, the skew-adjoint endomorphisms form a
@@ -709,7 +711,7 @@ def skew_adjoint_matrices_lie_embedding (J : matrix n n R) :
   J.to_bilin_form.skew_adjoint_lie_subalgebra →ₗ⁅R⁆ matrix n n R :=
 lie_equiv_matrix'.to_morphism.comp (skew_adjoint_lie_subalgebra J.to_bilin_form).incl
 
-/-- The Lie subalgebra of skew-adjoint square matrices corresponding to a square matrix `J` -/
+/-- The Lie subalgebra of skew-adjoint square matrices corresponding to a square matrix `J`. -/
 def skew_adjoint_matrices_lie_subalgebra (J : matrix n n R) : lie_subalgebra R (matrix n n R) :=
 (skew_adjoint_matrices_lie_embedding J).range
 

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -657,11 +657,13 @@ local attribute [instance] matrix.lie_algebra
 /-- The natural equivalence between linear endomorphisms of finite free modules and square matrices
 is compatible with the Lie algebra structures. -/
 def lie_equiv_matrix' : module.End R (n → R) ≃ₗ⁅R⁆ matrix n n R :=
-{ map_lie := λ T S, by {
+{ map_lie := λ T S,
+  begin
     let f := @linear_map.to_matrixₗ n n _ _ R _ _,
     change f (T.comp S - S.comp T) = (f T) * (f S) - (f S) * (f T),
     have h : ∀ (T S : module.End R _), f (T.comp S) = (f T) ⬝ (f S) := matrix.comp_to_matrix_mul,
-    rw [linear_map.map_sub, h, h, matrix.mul_eq_mul, matrix.mul_eq_mul], },
+    rw [linear_map.map_sub, h, h, matrix.mul_eq_mul, matrix.mul_eq_mul],
+  end,
   ..linear_equiv_matrix' }
 
 end matrices

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -564,7 +564,7 @@ given matrices `J`, `J₂`. -/
 def pair_self_adjoint_matrices_submodule : submodule R (matrix n n R) :=
   (pair_self_adjoint_matrices_linear_embedding J J₂).range
 
-lemma mem_pair_self_adjoint_matrices_submodule :
+@[simp] lemma mem_pair_self_adjoint_matrices_submodule :
   A ∈ (pair_self_adjoint_matrices_submodule J J₂) ↔ matrix.is_adjoint_pair J J₂ A A :=
 begin
   change A ∈ (pair_self_adjoint_matrices_linear_embedding J J₂).range ↔ matrix.is_adjoint_pair J J₂ A A,

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -478,7 +478,7 @@ def is_pair_self_adjoint (f : module.End R M) := is_adjoint_pair B B' f f
 def is_pair_self_adjoint_submodule : submodule R (module.End R M) :=
 { carrier := { f | is_pair_self_adjoint B B' f },
   zero    := is_adjoint_pair_zero,
-  add     := λ f g hf hg, is_adjoint_pair.add hf hg,
+  add     := λ f g hf hg, hf.add hg,
   smul    := λ c f h, is_adjoint_pair.smul c h, }
 
 /-- An endomorphism of a module is self-adjoint with respect to a bilinear form if it serves as an

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -459,7 +459,7 @@ lemma is_adjoint_pair.comp {M₃ : Type v} [add_comm_group M₃] [module R M₃]
   is_adjoint_pair B B₃ (f'.comp f) (g.comp g') :=
 λ x y, by rw [linear_map.comp_apply, linear_map.comp_apply, h', h]
 
-lemma is_adjoint_pair_mul
+lemma is_adjoint_pair.mul
   (f g f' g' : module.End R M) (h : is_adjoint_pair B B f g) (h' : is_adjoint_pair B B f' g') :
   is_adjoint_pair B B (f * f') (g' * g) :=
 λ x y, by rw [linear_map.mul_app, linear_map.mul_app, h, h']

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -425,14 +425,14 @@ variables (f f' : M →ₗ[R] M₂) (g g' : M₂ →ₗ[R] M)
 maps between them to be mutually adjoint. -/
 def is_adjoint_pair := ∀ {{x y}}, B₂ (f x) y = B x (g y)
 
-lemma is_adjoint_pair.eq (h : is_adjoint_pair B B2 f g) :
+lemma is_adjoint_pair.eq (h : is_adjoint_pair B B₂ f g) :
   ∀ {x y}, B₂ (f x) y = B x (g y) := h
 
 lemma is_adjoint_pair_iff_comp_left_eq_comp_right (f g : module.End R M) :
   is_adjoint_pair B B' f g ↔ B'.comp_left f = B.comp_right g :=
 begin
   split; intros h,
-  { ext x y, rw [comp_left_apply, comp_right_apply], exact h x y, },
+  { ext x y, rw [comp_left_apply, comp_right_apply], apply h, },
   { intros x y, rw [←comp_left_apply, ←comp_right_apply], rw h, },
 end
 
@@ -457,7 +457,7 @@ lemma is_adjoint_pair.comp {M₃ : Type v} [add_comm_group M₃] [module R M₃]
   {f' : M₂ →ₗ[R] M₃} {g' : M₃ →ₗ[R] M₂}
   (h : is_adjoint_pair B B₂ f g) (h' : is_adjoint_pair B₂ B₃ f' g') :
   is_adjoint_pair B B₃ (f'.comp f) (g.comp g') :=
-λ x y, by rw [linear_map.comp_apply, linear_map.comp_apply, h' (f x) y, h x (g' y)]
+λ x y, by rw [linear_map.comp_apply, linear_map.comp_apply, h', h]
 
 lemma is_adjoint_pair_mul
   (f g f' g' : module.End R M) (h : is_adjoint_pair B B f g) (h' : is_adjoint_pair B B f' g') :
@@ -474,8 +474,8 @@ def is_pair_self_adjoint (f : module.End R M) := is_adjoint_pair B B' f f
 def is_pair_self_adjoint_submodule : submodule R (module.End R M) :=
 { carrier := { f | is_pair_self_adjoint B B' f },
   zero    := is_adjoint_pair_zero B B',
-  add     := λ f g hf hg, is_adjoint_pair_add B B' _ _ _ _ hf hg,
-  smul    := λ c f h, is_adjoint_pair_smul B B' _ _ c h, }
+  add     := λ f g hf hg, is_adjoint_pair.add B B' _ _ _ _ hf hg,
+  smul    := λ c f h, is_adjoint_pair.smul B B' _ _ c h, }
 
 /-- An endomorphism of a module is self-adjoint with respect to a bilinear form if it serves as an
 adjoint for itself. -/

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -423,7 +423,7 @@ variables (f f' : M →ₗ[R] M₂) (g g' : M₂ →ₗ[R] M)
 
 /-- Given a pair of modules equipped with bilinear forms, this is the condition for a pair of
 maps between them to be mutually adjoint. -/
-def is_adjoint_pair := ∀ {{x y}}, B₂ (f x) y = B x (g y)
+def is_adjoint_pair := ∀ ⦃x y⦄, B₂ (f x) y = B x (g y)
 
 lemma is_adjoint_pair.eq (h : is_adjoint_pair B B₂ f g) :
   ∀ {x y}, B₂ (f x) y = B x (g y) := h

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -445,7 +445,7 @@ lemma is_adjoint_pair.add (h : is_adjoint_pair B B₂ f g) (h' : is_adjoint_pair
   is_adjoint_pair B B₂ (f + f') (g + g') :=
 λ x y, by rw [linear_map.add_apply, linear_map.add_apply, add_left, add_right, h, h']
 
-lemma is_adjoint_pair_sub (h : is_adjoint_pair B B₂ f g) (h' : is_adjoint_pair B B₂ f' g') :
+lemma is_adjoint_pair.sub (h : is_adjoint_pair B B₂ f g) (h' : is_adjoint_pair B B₂ f' g') :
   is_adjoint_pair B B₂ (f - f') (g - g') :=
 λ x y, by rw [linear_map.sub_apply, linear_map.sub_apply, sub_left, sub_right, h, h']
 

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -425,6 +425,9 @@ variables (f f' : M →ₗ[R] M₂) (g g' : M₂ →ₗ[R] M)
 maps between them to be mutually adjoint. -/
 def is_adjoint_pair := ∀ {{x y}}, B₂ (f x) y = B x (g y)
 
+lemma is_adjoint_pair.eq (h : is_adjoint_pair B B2 f g) :
+  ∀ {x y}, B₂ (f x) y = B x (g y) := h
+
 lemma is_adjoint_pair_iff_comp_left_eq_comp_right (f g : module.End R M) :
   is_adjoint_pair B B' f g ↔ B'.comp_left f = B.comp_right g :=
 begin

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -543,7 +543,7 @@ end
 
 variables [decidable_eq n]
 
-/-- Given a pair of square matrices `J`, `J₂` defining a bilinear forms on the free module, there
+/-- Given a pair of square matrices `J`, `J₂` defining bilinear forms on the free module, there
 is a natural embedding from the corresponding submodule of pair-skew-adjoint endomorphisms into the
 module of matrices. -/
 def pair_self_adjoint_matrices_linear_embedding :

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -494,7 +494,7 @@ by simp only [linear_map.neg_apply, bilin_form.neg_apply, bilin_form.neg_right]
 it is a Jordan subalgebra.) -/
 def self_adjoint_submodule := is_pair_self_adjoint_submodule B B
 
-lemma mem_self_adjoint_submodule (f : module.End R M) :
+@[simp] lemma mem_self_adjoint_submodule (f : module.End R M) :
   f ∈ B.self_adjoint_submodule ↔ B.is_self_adjoint f := iff.rfl
 
 /-- The set of skew-adjoint endomorphisms of a module with bilinear form is a submodule. (In fact

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -423,7 +423,7 @@ variables (f f' : M →ₗ[R] M₂) (g g' : M₂ →ₗ[R] M)
 
 /-- Given a pair of modules equipped with bilinear forms, this is the condition for a pair of
 maps between them to be mutually adjoint. -/
-def is_adjoint_pair := ∀ x y, B₂ (f x) y = B x (g y)
+def is_adjoint_pair := ∀ {{x y}}, B₂ (f x) y = B x (g y)
 
 lemma is_adjoint_pair_iff_comp_left_eq_comp_right (f g : module.End R M) :
   is_adjoint_pair B B' f g ↔ B'.comp_left f = B.comp_right g :=

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -449,8 +449,8 @@ lemma is_adjoint_pair_smul (c : R) (T T' : module.End R M) (hT : B.is_adjoint_pa
 λ x y, by rw [linear_map.smul_apply, linear_map.smul_apply, smul_left, smul_right, hT]
 
 lemma is_adjoint_pair_mul
-  (T S T' S' : module.End R M) (hT : is_adjoint_pair B T T') (hS : is_adjoint_pair B S S') :
-  is_adjoint_pair B (T * S) (S' * T') :=
+  (T S T' S' : module.End R M) (hT : B.is_adjoint_pair T T') (hS : B.is_adjoint_pair S S') :
+  B.is_adjoint_pair (T * S) (S' * T') :=
 λ x y, by rw [linear_map.mul_app, linear_map.mul_app, hT, hS]
 
 /-- An endomorphism of a module is self-adjoint with respect to a bilinear form, if it serves as an
@@ -491,7 +491,7 @@ lemma is_skew_adjoint_smul (c : R) (T : module.End R M)
 /-- Given an `R`-module `M`, equipped with a bilinear form, the set of self-adjoint endomorphisms
 form a submodule of End R M. (In fact they form a Jordan subalgebra.) -/
 def self_adjoint_submodule : submodule R (module.End R M) :=
-{ carrier := { T | is_self_adjoint B T },
+{ carrier := { T | B.is_self_adjoint T },
   zero    := B.is_self_adjoint_zero,
   add     := B.is_self_adjoint_add,
   smul    := B.is_self_adjoint_smul, }
@@ -499,7 +499,7 @@ def self_adjoint_submodule : submodule R (module.End R M) :=
 /-- Given an `R`-module `M`, equipped with a bilinear form, the set of skew-adjoint endomorphisms
 form a submodule of End R M. (In fact they form a Lie subalgebra.) -/
 def skew_adjoint_submodule : submodule R (module.End R M) :=
-{ carrier := { T | is_skew_adjoint B T },
+{ carrier := { T | B.is_skew_adjoint T },
   zero    := B.is_skew_adjoint_zero,
   add     := B.is_skew_adjoint_add,
   smul    := B.is_skew_adjoint_smul, }
@@ -581,9 +581,8 @@ def skew_adjoint_matrices_submodule (J : matrix n n R) : submodule R (matrix n n
 lemma self_adjoint_matrices_submodule_spec (J A : matrix n n R) :
   A ∈ self_adjoint_matrices_submodule J ↔ J.is_self_adjoint A :=
 begin
-  suffices : A ∈ self_adjoint_matrices_submodule J ↔ J.to_bilin_form.is_adjoint_pair _ _, by
-    { change _ ↔ J.is_adjoint_pair A A, rw [this, matrix_is_adjoint_pair_bilin_form], },
-  change A ∈ (self_adjoint_matrices_linear_embedding J).range ↔ _, rw linear_map.mem_range,
+  change A ∈ (self_adjoint_matrices_linear_embedding J).range ↔ J.is_adjoint_pair A A,
+  rw [matrix_is_adjoint_pair_bilin_form, linear_map.mem_range],
   simp only [self_adjoint_matrices_linear_embedding_apply], split,
   { rintros ⟨⟨A', hA'⟩, h⟩, rw ←h, rw to_matrix_to_lin, exact hA', },
   { intros h, exact ⟨⟨A.to_lin, h⟩, to_lin_to_matrix⟩, },
@@ -592,9 +591,8 @@ end
 lemma skew_adjoint_matrices_submodule_spec (J A : matrix n n R) :
   A ∈ skew_adjoint_matrices_submodule J ↔ J.is_skew_adjoint A :=
 begin
-  suffices : A ∈ skew_adjoint_matrices_submodule J ↔ J.to_bilin_form.is_adjoint_pair _ _, by
-    { change _ ↔ J.is_adjoint_pair A (-A), rw [this, matrix_is_adjoint_pair_bilin_form, A.to_lin_neg], },
-  change A ∈ (skew_adjoint_matrices_linear_embedding J).range ↔ _, rw linear_map.mem_range,
+  change A ∈ (skew_adjoint_matrices_linear_embedding J).range ↔ J.is_adjoint_pair A (-A),
+  rw [matrix_is_adjoint_pair_bilin_form, matrix.to_lin_neg, linear_map.mem_range],
   simp only [skew_adjoint_matrices_linear_embedding_apply], split,
   { rintros ⟨⟨A', hA'⟩, h⟩, rw ←h, rw to_matrix_to_lin, exact hA', },
   { intros h, exact ⟨⟨A.to_lin, h⟩, to_lin_to_matrix⟩, },

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -453,8 +453,8 @@ lemma is_adjoint_pair.smul (c : R) (h : is_adjoint_pair B B₂ f g) :
   is_adjoint_pair B B₂ (c • f) (c • g) :=
 λ x y, by rw [linear_map.smul_apply, linear_map.smul_apply, smul_left, smul_right, h]
 
-lemma is_adjoint_pair_comp {M₃ : Type v} [add_comm_group M₃] [module R M₃] (B₃ : bilin_form R M₃)
-  (f' : M₂ →ₗ[R] M₃) (g' : M₃ →ₗ[R] M₂)
+lemma is_adjoint_pair.comp {M₃ : Type v} [add_comm_group M₃] [module R M₃] {B₃ : bilin_form R M₃}
+  {f' : M₂ →ₗ[R] M₃} {g' : M₃ →ₗ[R] M₂}
   (h : is_adjoint_pair B B₂ f g) (h' : is_adjoint_pair B₂ B₃ f' g') :
   is_adjoint_pair B B₃ (f'.comp f) (g.comp g') :=
 λ x y, by rw [linear_map.comp_apply, linear_map.comp_apply, h' (f x) y, h x (g' y)]

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -441,7 +441,7 @@ lemma is_adjoint_pair_zero : is_adjoint_pair B B₂ 0 0 :=
 
 lemma is_adjoint_pair_id : is_adjoint_pair B B 1 1 := λ x y, rfl
 
-lemma is_adjoint_pair_add (h : is_adjoint_pair B B₂ f g) (h' : is_adjoint_pair B B₂ f' g') :
+lemma is_adjoint_pair.add (h : is_adjoint_pair B B₂ f g) (h' : is_adjoint_pair B B₂ f' g') :
   is_adjoint_pair B B₂ (f + f') (g + g') :=
 λ x y, by rw [linear_map.add_apply, linear_map.add_apply, add_left, add_right, h, h']
 

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -449,7 +449,7 @@ lemma is_adjoint_pair.sub (h : is_adjoint_pair B B₂ f g) (h' : is_adjoint_pair
   is_adjoint_pair B B₂ (f - f') (g - g') :=
 λ x y, by rw [linear_map.sub_apply, linear_map.sub_apply, sub_left, sub_right, h, h']
 
-lemma is_adjoint_pair_smul (c : R) (h : is_adjoint_pair B B₂ f g) :
+lemma is_adjoint_pair.smul (c : R) (h : is_adjoint_pair B B₂ f g) :
   is_adjoint_pair B B₂ (c • f) (c • g) :=
 λ x y, by rw [linear_map.smul_apply, linear_map.smul_apply, smul_left, smul_right, h]
 

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -501,7 +501,7 @@ def self_adjoint_submodule := is_pair_self_adjoint_submodule B B
 it is a Lie subalgebra.) -/
 def skew_adjoint_submodule := is_pair_self_adjoint_submodule (-B) B
 
-lemma mem_skew_adjoint_submodule (f : module.End R M) :
+@[simp] lemma mem_skew_adjoint_submodule (f : module.End R M) :
   f ∈ B.skew_adjoint_submodule ↔ B.is_skew_adjoint f :=
 by { rw is_skew_adjoint_iff_neg_self_adjoint, exact iff.rfl, }
 

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -460,7 +460,7 @@ lemma is_adjoint_pair.comp {M₃ : Type v} [add_comm_group M₃] [module R M₃]
 λ x y, by rw [linear_map.comp_apply, linear_map.comp_apply, h', h]
 
 lemma is_adjoint_pair.mul
-  (f g f' g' : module.End R M) (h : is_adjoint_pair B B f g) (h' : is_adjoint_pair B B f' g') :
+  {f g f' g' : module.End R M} (h : is_adjoint_pair B B f g) (h' : is_adjoint_pair B B f' g') :
   is_adjoint_pair B B (f * f') (g' * g) :=
 λ x y, by rw [linear_map.mul_app, linear_map.mul_app, h, h']
 

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -425,6 +425,8 @@ variables (f f' : M →ₗ[R] M₂) (g g' : M₂ →ₗ[R] M)
 maps between them to be mutually adjoint. -/
 def is_adjoint_pair := ∀ ⦃x y⦄, B₂ (f x) y = B x (g y)
 
+variables {B B' B₂ f f' g g'}
+
 lemma is_adjoint_pair.eq (h : is_adjoint_pair B B₂ f g) :
   ∀ {x y}, B₂ (f x) y = B x (g y) := h
 
@@ -464,6 +466,8 @@ lemma is_adjoint_pair.mul
   is_adjoint_pair B B (f * f') (g' * g) :=
 λ x y, by rw [linear_map.mul_app, linear_map.mul_app, h, h']
 
+variables (B B' B₂)
+
 /-- The condition for an endomorphism to be "self-adjoint" with respect to a pair of bilinear forms
 on the underlying module. In the case that these two forms are identical, this is the usual concept
 of self adjointness. In the case that one of the forms is the negation of the other, this is the
@@ -473,9 +477,9 @@ def is_pair_self_adjoint (f : module.End R M) := is_adjoint_pair B B' f f
 /-- The set of pair-self-adjoint endomorphisms are a submodule of the type of all endomorphisms. -/
 def is_pair_self_adjoint_submodule : submodule R (module.End R M) :=
 { carrier := { f | is_pair_self_adjoint B B' f },
-  zero    := is_adjoint_pair_zero B B',
-  add     := λ f g hf hg, is_adjoint_pair.add B B' _ _ _ _ hf hg,
-  smul    := λ c f h, is_adjoint_pair.smul B B' _ _ c h, }
+  zero    := is_adjoint_pair_zero,
+  add     := λ f g hf hg, is_adjoint_pair.add hf hg,
+  smul    := λ c f h, is_adjoint_pair.smul c h, }
 
 /-- An endomorphism of a module is self-adjoint with respect to a bilinear form if it serves as an
 adjoint for itself. -/

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -479,7 +479,7 @@ def is_pair_self_adjoint_submodule : submodule R (module.End R M) :=
 { carrier := { f | is_pair_self_adjoint B B' f },
   zero    := is_adjoint_pair_zero,
   add     := λ f g hf hg, hf.add hg,
-  smul    := λ c f h, is_adjoint_pair.smul c h, }
+  smul    := λ c f h, h.smul c, }
 
 /-- An endomorphism of a module is self-adjoint with respect to a bilinear form if it serves as an
 adjoint for itself. -/

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -118,6 +118,8 @@ instance : add_comm_group (bilin_form R M) :=
 
 lemma add_apply (x y : M) : (B + D) x y = B x y + D x y := rfl
 
+lemma neg_apply (x y : M) : (-B) x y = -(B x y) := rfl
+
 instance : inhabited (bilin_form R M) := ⟨0⟩
 
 section
@@ -417,9 +419,14 @@ variables {R : Type u} [comm_ring R]
 variables {M : Type v} [add_comm_group M] [module R M]
 variables (B : bilin_form R M)
 
+/-- Given a pair of modules equipped with bilinear forms, this is the condition for a pair of
+maps between them to be mutually adjoint. -/
+def is_adjoint_maps {M' : Type v} [add_comm_group M'] [module R M'] (B' : bilin_form R M')
+  (T : M →ₗ[R] M') (T' : M' →ₗ[R] M) := ∀ x y, B' (T x) y = B x (T' y)
+
 /-- Given a module equipped with a bilinear form, this is the condition for a pair of endomorphims
 to be mutually adjoint. -/
-def is_adjoint_pair (T S : module.End R M) := ∀ x y, B (T x) y = B x (S y)
+def is_adjoint_pair (T S : module.End R M) := is_adjoint_maps B B T S
 
 lemma is_adjoint_pair_iff_comp_left_eq_comp_right (T S : module.End R M) :
   B.is_adjoint_pair T S ↔ B.comp_left T = B.comp_right S :=
@@ -460,6 +467,13 @@ def is_self_adjoint (T : module.End R M) := B.is_adjoint_pair T T
 /-- An endomorphism of a module is skew-adjoint with respect to a bilinear form, if its negation
 serves as an adjoint. -/
 def is_skew_adjoint (T : module.End R M) := B.is_adjoint_pair T (-T)
+
+lemma is_skew_adjoint_iff_neg_self_adjoint (T : module.End R M) :
+  B.is_skew_adjoint T ↔ is_adjoint_maps (-B) B T T :=
+begin
+  change (∀ x y, B (T x) y = B x ((-T) y)) ↔ ∀ x y, B (T x) y = (-B) x (T y),
+  simp only [linear_map.neg_apply, bilin_form.neg_right, bilin_form.neg_apply, neg_eq_iff_neg_eq],
+end
 
 lemma is_self_adjoint_zero : B.is_self_adjoint 0 := B.is_adjoint_pair_zero
 

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -12,9 +12,10 @@ import linear_algebra.tensor_product
 
 This file defines a bilinear form over a module. Basic ideas
 such as orthogonality are also introduced, as well as reflexivive,
-symmetric and alternating bilinear forms.
+symmetric and alternating bilinear forms. Adjoints of linear maps
+with respect to a bilinear form are also introduced.
 
-A bilinear form on an R-module V, is a function from V x V to R,
+A bilinear form on an R-module M, is a function from M x M to R,
 that is linear in both arguments
 
 ## Notations
@@ -321,17 +322,24 @@ lemma bilin_form.to_matrix_mul (B : bilin_form R (n → R)) (M : matrix n n R) :
   B.to_matrix ⬝ M = (B.comp_right (M.to_lin)).to_matrix :=
 by { ext, simp [B.to_matrix_comp_right (M.to_lin), to_lin_to_matrix] }
 
+@[simp] lemma to_matrix_to_bilin_form (B : bilin_form R (n → R)) :
+  B.to_matrix.to_bilin_form = B :=
+begin
+  ext,
+  rw [matrix.to_bilin_form_apply, B.mul_to_matrix_mul, bilin_form.to_matrix_apply, comp_apply],
+  { apply coe_fn_congr; ext; simp [mul_vec], },
+  { apply_instance, },
+end
+
+@[simp] lemma to_bilin_form_to_matrix (M : matrix n n R) :
+  M.to_bilin_form.to_matrix = M :=
+by { ext, simp [bilin_form.to_matrix_apply, matrix.to_bilin_form_apply, mul_val], }
+
 /-- Bilinear forms are linearly equivalent to matrices. -/
 def bilin_form_equiv_matrix : bilin_form R (n → R) ≃ₗ[R] matrix n n R :=
-{ inv_fun := matrix.to_bilin_form,
-  left_inv := λ B, show B.to_matrix.to_bilin_form = B,
-  begin
-    ext,
-    rw [matrix.to_bilin_form_apply, B.mul_to_matrix_mul, bilin_form.to_matrix_apply, comp_apply],
-    { apply coe_fn_congr; ext; simp [mul_vec] },
-    apply_instance
-  end,
-  right_inv := λ M, by { ext, simp [bilin_form.to_matrixₗ, matrix.to_bilin_form_apply, mul_val] },
+{ inv_fun   := matrix.to_bilin_form,
+  left_inv  := to_matrix_to_bilin_form,
+  right_inv := to_bilin_form_to_matrix,
   ..bilin_form.to_matrixₗ }
 
 end matrix
@@ -400,3 +408,196 @@ begin
 end
 
 end alt_bilin_form
+
+namespace bilin_form
+
+section endomorphism_adjoints
+
+variables {R : Type u} [comm_ring R]
+variables {M : Type v} [add_comm_group M] [module R M]
+variables (B : bilin_form R M)
+
+/-- Given a module equipped with a bilinear form, this is the condition for a pair of endomorphims
+to be mutually adjoint. -/
+def is_adjoint_pair (T S : module.End R M) := ∀ x y, B (T x) y = B x (S y)
+
+lemma is_adjoint_pair_iff_comp_left_eq_comp_right (T S : module.End R M) :
+  B.is_adjoint_pair T S ↔ B.comp_left T = B.comp_right S :=
+begin
+  split; intros h,
+  { ext x y, rw [comp_left_apply, comp_right_apply], exact h x y, },
+  { intros x y, rw [←comp_left_apply, ←comp_right_apply], rw h, },
+end
+
+lemma is_adjoint_pair_zero : B.is_adjoint_pair 0 0 :=
+λ x y, by simp only [bilin_form.zero_left, bilin_form.zero_right, linear_map.zero_apply]
+
+lemma is_adjoint_pair_id : B.is_adjoint_pair 1 1 := λ x y, rfl
+
+lemma is_adjoint_pair_add
+  (T S T' S' : module.End R M) (hT : B.is_adjoint_pair T T') (hS : B.is_adjoint_pair S S') :
+  B.is_adjoint_pair (T + S) (T' + S') :=
+λ x y, by rw [linear_map.add_apply, linear_map.add_apply, add_left, add_right, hT, hS]
+
+lemma is_adjoint_pair_sub
+  (T S T' S' : module.End R M) (hT : B.is_adjoint_pair T T') (hS : B.is_adjoint_pair S S') :
+  B.is_adjoint_pair (T - S) (T' - S') :=
+λ x y, by rw [linear_map.sub_apply, linear_map.sub_apply, sub_left, sub_right, hT, hS]
+
+lemma is_adjoint_pair_smul (c : R) (T T' : module.End R M) (hT : B.is_adjoint_pair T T') :
+  B.is_adjoint_pair (c • T) (c • T') :=
+λ x y, by rw [linear_map.smul_apply, linear_map.smul_apply, smul_left, smul_right, hT]
+
+lemma is_adjoint_pair_mul
+  (T S T' S' : module.End R M) (hT : is_adjoint_pair B T T') (hS : is_adjoint_pair B S S') :
+  is_adjoint_pair B (T * S) (S' * T') :=
+λ x y, by rw [linear_map.mul_app, linear_map.mul_app, hT, hS]
+
+/-- An endomorphism of a module is self-adjoint with respect to a bilinear form, if it serves as an
+adjoint for itself. -/
+def is_self_adjoint (T : module.End R M) := B.is_adjoint_pair T T
+
+/-- An endomorphism of a module is skew-adjoint with respect to a bilinear form, if its negation
+serves as an adjoint. -/
+def is_skew_adjoint (T : module.End R M) := B.is_adjoint_pair T (-T)
+
+lemma is_self_adjoint_zero : B.is_self_adjoint 0 := B.is_adjoint_pair_zero
+
+lemma is_skew_adjoint_zero : B.is_skew_adjoint 0 :=
+  λ x y, by simp only [bilin_form.zero_left, bilin_form.zero_right, linear_map.zero_apply, neg_zero]
+
+lemma is_self_adjoint_add (T S : module.End R M)
+  (hT : B.is_self_adjoint T) (hS : B.is_self_adjoint S) : B.is_self_adjoint (T + S) :=
+λ x y, by rw [linear_map.add_apply, linear_map.add_apply,
+              bilin_form.add_left, bilin_form.add_right, hT, hS]
+
+lemma is_skew_adjoint_add (T S : module.End R M)
+  (hT : B.is_skew_adjoint T) (hS : B.is_skew_adjoint S) : B.is_skew_adjoint (T + S) :=
+λ x y, by rw [linear_map.neg_apply, linear_map.add_apply, linear_map.add_apply, neg_right,
+              bilin_form.add_left, bilin_form.add_right, hT, hS, neg_add_rev, add_comm,
+              linear_map.neg_apply, linear_map.neg_apply, bilin_form.neg_right, bilin_form.neg_right]
+
+lemma is_self_adjoint_smul (c : R) (T : module.End R M)
+  (hT : B.is_self_adjoint T) : B.is_self_adjoint (c • T) :=
+λ x y, by rw [linear_map.smul_apply, linear_map.smul_apply,
+              bilin_form.smul_left, bilin_form.smul_right, hT]
+
+lemma is_skew_adjoint_smul (c : R) (T : module.End R M)
+  (hT : B.is_skew_adjoint T) : B.is_skew_adjoint (c • T) :=
+λ x y, by rw [linear_map.smul_apply, linear_map.neg_apply, linear_map.smul_apply,
+              bilin_form.neg_right, bilin_form.smul_left, bilin_form.smul_right, hT,
+              linear_map.neg_apply, bilin_form.neg_right, mul_neg_eq_neg_mul_symm]
+
+/-- Given an `R`-module `M`, equipped with a bilinear form, the set of self-adjoint endomorphisms
+form a submodule of End R M. (In fact they form a Jordan subalgebra.) -/
+def self_adjoint_submodule : submodule R (module.End R M) :=
+{ carrier := { T | is_self_adjoint B T },
+  zero    := B.is_self_adjoint_zero,
+  add     := B.is_self_adjoint_add,
+  smul    := B.is_self_adjoint_smul, }
+
+/-- Given an `R`-module `M`, equipped with a bilinear form, the set of skew-adjoint endomorphisms
+form a submodule of End R M. (In fact they form a Lie subalgebra.) -/
+def skew_adjoint_submodule : submodule R (module.End R M) :=
+{ carrier := { T | is_skew_adjoint B T },
+  zero    := B.is_skew_adjoint_zero,
+  add     := B.is_skew_adjoint_add,
+  smul    := B.is_skew_adjoint_smul, }
+
+end endomorphism_adjoints
+
+end bilin_form
+
+section matrix_adjoints
+open_locale matrix
+
+variables {R : Type u} [comm_ring R]
+variables {n : Type w} [fintype n]
+
+/-- The condition for the square matrices `A`, `B` to be an adjoint pair with respect to the square
+matrix `J`. -/
+def matrix.is_adjoint_pair (J A B : matrix n n R) := Aᵀ ⬝ J = J ⬝ B
+
+/-- The condition for a square matrix `A` to be self-adjoint with respect to the square matrix
+`J`. -/
+def matrix.is_self_adjoint (J A : matrix n n R) := J.is_adjoint_pair A A
+
+/-- The condition for a square matrix `A` to be skew-adjoint with respect to the square matrix
+`J`. -/
+def matrix.is_skew_adjoint (J A : matrix n n R) := J.is_adjoint_pair A (-A)
+
+lemma matrix_is_adjoint_pair_bilin_form (J A B : matrix n n R) :
+  J.is_adjoint_pair A B ↔ J.to_bilin_form.is_adjoint_pair A.to_lin B.to_lin :=
+begin
+  classical,
+  rw bilin_form.is_adjoint_pair_iff_comp_left_eq_comp_right,
+  have h : ∀ (B B' : bilin_form R (n → R)), B = B' ↔ B.to_matrix = B'.to_matrix := λ B B', by {
+    split; intros h, { rw h, }, { rw [←to_matrix_to_bilin_form B, h, to_matrix_to_bilin_form B'], }, },
+  rw [h, J.to_bilin_form.to_matrix_comp_left A.to_lin, J.to_bilin_form.to_matrix_comp_right B.to_lin,
+      to_lin_to_matrix, to_lin_to_matrix, to_bilin_form_to_matrix],
+  refl,
+end
+
+variables [decidable_eq n]
+
+/-- Given a square matrix `J` defining a bilinear form on the free module, there is a natural
+embedding from the corresponding submodule of self-adjoint endomorphisms into the module of
+matrices. -/
+def self_adjoint_matrices_linear_embedding (J : matrix n n R) :
+  J.to_bilin_form.self_adjoint_submodule →ₗ[R] matrix n n R :=
+linear_equiv_matrix'.to_linear_map.comp J.to_bilin_form.self_adjoint_submodule.subtype
+
+/-- Given a square matrix `J` defining a bilinear form on the free module, there is a natural
+embedding from the corresponding submodule of skew-adjoint endomorphisms into the module of
+matrices. -/
+def skew_adjoint_matrices_linear_embedding (J : matrix n n R) :
+  J.to_bilin_form.skew_adjoint_submodule →ₗ[R] matrix n n R :=
+linear_equiv_matrix'.to_linear_map.comp J.to_bilin_form.skew_adjoint_submodule.subtype
+
+lemma self_adjoint_matrices_linear_embedding_apply
+  (J : matrix n n R) (T : J.to_bilin_form.self_adjoint_submodule) :
+  (self_adjoint_matrices_linear_embedding J : _ →ₗ _) T = (T : module.End R (n → R)).to_matrix := rfl
+
+lemma skew_adjoint_matrices_linear_embedding_apply
+  (J : matrix n n R) (T : J.to_bilin_form.skew_adjoint_submodule) :
+  (skew_adjoint_matrices_linear_embedding J : _ →ₗ _) T = (T : module.End R (n → R)).to_matrix := rfl
+
+lemma self_adjoint_matrices_linear_embedding_injective (J : matrix n n R) :
+  function.injective (self_adjoint_matrices_linear_embedding J) :=
+λ T S h, by { apply set_coe.ext, exact linear_equiv_matrix'.injective h, }
+
+lemma skew_adjoint_matrices_linear_embedding_injective (J : matrix n n R) :
+  function.injective (skew_adjoint_matrices_linear_embedding J) :=
+λ T S h, by { apply set_coe.ext, exact linear_equiv_matrix'.injective h, }
+
+/-- The submodule of self-adjoint square matrices corresponding to a square matrix `J` -/
+def self_adjoint_matrices_submodule (J : matrix n n R) : submodule R (matrix n n R) :=
+  (self_adjoint_matrices_linear_embedding J).range
+
+/-- The submodule of skew-adjoint square matrices corresponding to a square matrix `J` -/
+def skew_adjoint_matrices_submodule (J : matrix n n R) : submodule R (matrix n n R) :=
+  (skew_adjoint_matrices_linear_embedding J).range
+
+lemma self_adjoint_matrices_submodule_spec (J A : matrix n n R) :
+  A ∈ self_adjoint_matrices_submodule J ↔ J.is_self_adjoint A :=
+begin
+  suffices : A ∈ self_adjoint_matrices_submodule J ↔ J.to_bilin_form.is_adjoint_pair _ _, by
+    { change _ ↔ J.is_adjoint_pair A A, rw [this, matrix_is_adjoint_pair_bilin_form], },
+  change A ∈ (self_adjoint_matrices_linear_embedding J).range ↔ _, rw linear_map.mem_range,
+  simp only [self_adjoint_matrices_linear_embedding_apply], split,
+  { rintros ⟨⟨A', hA'⟩, h⟩, rw ←h, rw to_matrix_to_lin, exact hA', },
+  { intros h, exact ⟨⟨A.to_lin, h⟩, to_lin_to_matrix⟩, },
+end
+
+lemma skew_adjoint_matrices_submodule_spec (J A : matrix n n R) :
+  A ∈ skew_adjoint_matrices_submodule J ↔ J.is_skew_adjoint A :=
+begin
+  suffices : A ∈ skew_adjoint_matrices_submodule J ↔ J.to_bilin_form.is_adjoint_pair _ _, by
+    { change _ ↔ J.is_adjoint_pair A (-A), rw [this, matrix_is_adjoint_pair_bilin_form, A.to_lin_neg], },
+  change A ∈ (skew_adjoint_matrices_linear_embedding J).range ↔ _, rw linear_map.mem_range,
+  simp only [skew_adjoint_matrices_linear_embedding_apply], split,
+  { rintros ⟨⟨A', hA'⟩, h⟩, rw ←h, rw to_matrix_to_lin, exact hA', },
+  { intros h, exact ⟨⟨A.to_lin, h⟩, to_lin_to_matrix⟩, },
+end
+
+end matrix_adjoints

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -74,6 +74,8 @@ matrix.eval.map_add M N
 @[simp] lemma to_lin_zero : (0 : matrix m n R).to_lin = 0 :=
 matrix.eval.map_zero
 
+@[simp] lemma to_lin_neg (M : matrix m n R) : (-M).to_lin = -M.to_lin := matrix.eval.map_neg M
+
 instance to_lin.is_linear_map :
   @is_linear_map R (matrix m n R) ((n → R) →ₗ[R] (m → R)) _ _ _ _ _ to_lin :=
 matrix.eval.is_linear
@@ -183,6 +185,12 @@ end linear_equiv_matrix
 
 namespace matrix
 open_locale matrix
+
+lemma comp_to_matrix_mul {R : Type v} [comm_ring R] [decidable_eq l] [decidable_eq m]
+  (f : (m → R) →ₗ[R] (n → R)) (g : (l → R) →ₗ[R] (m → R)) :
+  (f.comp g).to_matrix = f.to_matrix ⬝ g.to_matrix :=
+suffices (f.comp g) = (f.to_matrix ⬝ g.to_matrix).to_lin, by rw [this, to_lin_to_matrix],
+by rw [mul_to_lin, to_matrix_to_lin, to_matrix_to_lin]
 
 section trace
 


### PR DESCRIPTION
We also use this to define the Lie algebra structure on skew-adjoint
endomorphisms / matrices. The motivation is to enable us to define the
classical Lie algebras.