### PR TITLE
[Merged by Bors] - docs(linear_algebra/sesquilinear_form): correct module docs

### DIFF
--- a/src/linear_algebra/sesquilinear_form.lean
+++ b/src/linear_algebra/sesquilinear_form.lean
@@ -9,7 +9,7 @@ import ring_theory.maps
 /-!
 # Sesquilinear form
 
-This file defines a bilinear form over a module. The definition requires a ring antiautomorphism
+This file defines a sesquilinear form over a module. The definition requires a ring antiautomorphism
 on the scalar ring, which comes from the file ring_theory.involution. Basic ideas such as
 orthogonality are also introduced.
 
@@ -19,7 +19,7 @@ and antilinear in the second, with respect to an antiautomorphism on R (an antii
 ## Notations
 
 Given any term S of type sesq_form, due to a coercion, can use the notation S x y to
-refer to the function field, ie. S x y = S.bilin x y.
+refer to the function field, ie. `S x y = S.sesq x y`.
 
 ## References
 


### PR DESCRIPTION
@PatrickMassot mentioned that the docs for `sesquilinear_form` mention bilinear forms instead in a few places. This PR corrects them to use "sesquilinear form" everywhere.