### PR TITLE
[Merged by Bors] - feat(algebra/continued_fractions): add computation definitions and basic translation lemmas

### DIFF
--- a/src/algebra/continued_fractions/computation/basic.lean
+++ b/src/algebra/continued_fractions/computation/basic.lean
@@ -29,10 +29,10 @@ For an example, refer to `int_fract_pair.stream`.
 ## Main definitions
 
 - `generalized_continued_fraction.int_fract_pair.stream`: computes the stream of integer and
-fractional parts of a given value as described in the summary.
+  fractional parts of a given value as described in the summary.
 - `generalized_continued_fraction.of`: computes the generalised continued fraction of a value `v`.
-In fact, it computes a regular continued fraction that terminates if and only if `v` is rational
-(those proofs will be added in a future commit).
+  In fact, it computes a regular continued fraction that terminates if and only if `v` is rational
+  (those proofs will be added in a future commit).
 
 ## Implementation Notes
 
@@ -72,7 +72,7 @@ We collect an integer part `b = ⌊v⌋` and fractional part `fr = v - ⌊v⌋` 
 -/
 structure int_fract_pair := (b : ℤ) (fr : K)
 
-/- Interlude: define some expected coercions and instances. -/
+/-! Interlude: define some expected coercions and instances. -/
 namespace int_fract_pair
 
 /-- Make an `int_fract_pair` printable. -/
@@ -102,7 +102,7 @@ end coe
 
 -- Note: this could be relaxed to something like `discrete_linear_ordered_division_ring` in the
 -- future.
-/-- Fix a discrete linear ordered field with `floor` function. -/
+/- Fix a discrete linear ordered field with `floor` function. -/
 variables [discrete_linear_ordered_field K] [floor_ring K]
 
 /-- Creates the integer and fractional part of a value `v`, i.e. `⟨⌊v⌋, v - ⌊v⌋⟩`. -/

--- a/src/algebra/continued_fractions/computation/basic.lean
+++ b/src/algebra/continued_fractions/computation/basic.lean
@@ -58,7 +58,7 @@ section coe
 /- Fix another type `β` and assume `K` can be converted to `β`. -/
 variables {β : Type*} [has_coe K β]
 
-/-- Coerce a pair by coercion the fractional component. -/
+/-- Coerce a pair by coercing the fractional component. -/
 instance has_coe_to_int_fract_pair : has_coe (int_fract_pair K) (int_fract_pair β) :=
 ⟨λ ⟨b, fr⟩, ⟨b, (fr : β)⟩⟩
 

--- a/src/algebra/continued_fractions/computation/basic.lean
+++ b/src/algebra/continued_fractions/computation/basic.lean
@@ -11,15 +11,45 @@ import algebra.archimedean
 
 ## Summary
 
-We formalise the standard computation of regular continued fractions for linear ordered floor
-fields. The algorithm is rather simple and connected to the Euclidean algorithm. It can be found,
-for example, on Wikipedia:
-https://en.wikipedia.org/wiki/Continued_fraction#Calculating_continued_fraction_representations.
+We formalise the standard computation of (regular) continued fractions for linear ordered floor
+fields. The algorithm is rather simple. Here is an outline of the procedure adapted from Wikipedia:
+
+Take a value `v`. We call `⌊v⌋` the *integer part* of `v` and `v − ⌊v⌋` the *fractional part* of `r`.
+A continued fraction representation of `v` can then be given by `[⌊v⌋; b₀, b₁, b₂,...]`,
+where `[b₀; b₁, b₂,...]` recursively is the continued fraction representation of `1 / (v − ⌊v⌋)`.
+This process stops when the fractional part hits 0.
+
+In other words: to calculate a continued fraction representation of a number `v`, write down the
+integer part (i.e. the floor) of `v`. Subtract this integer part from `v`. If the difference is 0,
+stop; otherwise find the reciprocal of the difference and repeat. The procedure will termiante if
+and only if `v` is rational.
+
+For an example, refer to `int_fract_pair.stream`.
 
 ## Main definitions
 
-- `generalized_continued_fraction.of`: computes the generalised continued fraction of a value.
-In fact, it computes a regular continued fraction (the proof will be added in a future commit).
+- `generalized_continued_fraction.int_fract_pair.stream`: computes the stream of integer and
+fractional parts of a given value as described in the summary.
+- `generalized_continued_fraction.of`: computes the generalised continued fraction of a value `v`.
+In fact, it computes a regular continued fraction that terminates if and only if `v` is rational
+(those proofs will be added in a future commit).
+
+## Implementation Notes
+
+There is an intermediate definition `generalized_continued_fraction.int_fract_pair.seq1` between
+`generalized_continued_fraction.int_fract_pair.stream` and `generalized_continued_fraction.of`
+to wire up things. User should not (need to) directly interact with it.
+
+The computation of the integer and fractional pairs of a value can elegantly be
+captured by a recursive computation of a stream of option pairs. This is done in
+`int_fract_pair.stream`. However, the type then does not guarantee the first pair to always be
+`some` value, as expected by a continued fraction.
+
+To separate concerns, we first compute a single head term that always exists in
+`generalized_continued_fraction.int_fract_pair.seq1` followed by the remaining stream of option
+pairs. This sequence with a head term (`seq1`) is then transformed to a generalized continued
+fraction in `generalized_continued_fraction.of` by extracting the wanted integer parts of the
+head term and the stream.
 
 ## References
 
@@ -72,49 +102,76 @@ end coe
 
 -- Note: this could be relaxed to something like `discrete_linear_ordered_division_ring` in the
 -- future.
-/-- Fix a linear ordered ring with `floor` function. -/
+/-- Fix a discrete linear ordered field with `floor` function. -/
 variables [discrete_linear_ordered_field K] [floor_ring K]
 
 /-- Creates the integer and fractional part of a value `v`, i.e. `⟨⌊v⌋, v - ⌊v⌋⟩`. -/
 protected def of (v : K) : int_fract_pair K := ⟨⌊v⌋, fract v⟩
 
-/-- Creates the stream of integer and fractional parts of a value `v`. -/
+/--
+Creates the stream of integer and fractional parts of a value `v` needed to obtain the continued
+fraction representation of `v` in `generalized_continued_fraction.of`. More precisely, given a value
+`v : K`, it recursively computes a stream of option `ℤ × K` pairs as follows:
+
+  `stream v 0 = some ⟨⌊v⌋, v - ⌊v⌋⟩`,
+  `stream v (n + 1) = some ⟨⌊frₙ⁻¹⌋, frₙ⁻¹ - ⌊frₙ⁻¹⌋⟩`, if `stream v n = some ⟨_, frₙ⟩` and `frₙ ≠ 0`.
+  `stream v (n + 1) = none`, otherwise.
+
+For example, let `(v : ℚ) := 3.4`. The process goes as follows:
+  `stream v 0 = some ⟨⌊v⌋, v - ⌊v⌋⟩ = some ⟨3, 0.4⟩`,
+  `stream v 1 = some ⟨⌊0.4⁻¹⌋, 0.4⁻¹ - ⌊0.4⁻¹⌋⟩ = some ⟨⌊2.5⌋, 2.5 - ⌊2.5⌋⟩ = some ⟨2, 0.5⟩`,
+  `stream v 2 = some ⟨⌊0.5⁻¹⌋, 0.5⁻¹ - ⌊0.5⁻¹⌋⟩ = some ⟨⌊2⌋, 2 - ⌊2⌋⟩ = some ⟨2, 0⟩`
+  `stream v n = none`, for `n ≥ 3`.
+-/
 protected def stream (v : K) : stream $ option (int_fract_pair K)
 | 0 := some (int_fract_pair.of v)
 | (n + 1) := do ap_n ← stream n,
   if ap_n.fr = 0 then none else int_fract_pair.of ap_n.fr⁻¹
 
 /--
-Shows that `stream` has the sequence property, that is once we return `none` at position `n`,
-we also return `none` at `n + 1`.
+Shows that `int_fract_pair.stream` has the sequence property, that is once we return `none` at
+position `n`, we also return `none` at `n + 1`.
 -/
 lemma stream_is_seq (v : K) : (int_fract_pair.stream v).is_seq :=
 by { assume _ hyp, simp [int_fract_pair.stream, hyp] }
 
-/-- Creates the sequence with head of `int_fract_pair`s. -/
+/--
+Uses `int_fract_pair.stream` to create a sequence with head (i.e. `seq1`) of integer and fractional
+parts of a value `v`. The first value of `int_fract_pair.stream` is never `none`, so we can safely
+extract it and put the tail of the stream in the sequence part.
+
+This is just an intermediate representation and users should not (need to) directly interact with it.
+The setup of rewriting/simplification lemmas that make the definitions easy to use is done in
+`algebra.continued_fractions.computation.translations`.
+-/
 protected def seq1 (v : K) : seq1 $ int_fract_pair K :=
-⟨
-  int_fract_pair.of v,--the head
-  seq.tail -- take the tail of `int_fract_pair.stream` since the first element is in the head
-  ⟨ -- create a sequence from `int_fract_pair.stream`
-    int_fract_pair.stream v, -- the underlying stream
-    @stream_is_seq _ _ _ v
-  ⟩
-⟩
+⟨ int_fract_pair.of v,--the head
+  seq.tail -- take the tail of `int_fract_pair.stream` since the first element is already in the head
+  -- create a sequence from `int_fract_pair.stream`
+  ⟨ int_fract_pair.stream v, -- the underlying stream
+    @stream_is_seq _ _ _ v ⟩ ⟩ -- the proof that the stream is a sequence
+
 end int_fract_pair
 
 variable {K}
 
 /--
-Returns the `generalized continued fraction` of a value. In fact, the returned gcf is also
-a regular continued fraction (the proof will be added in a future commit).
+Returns the `generalized_continued_fraction` of a value. In fact, the returned gcf is also
+a `continued_fraction` that terminates if and only if `v` is rational (those proofs will be
+added in a future commit).
+
+The continued fraction representation of `v` is given by `[⌊v⌋; b₀, b₁, b₂,...]`, where
+`[b₀; b₁, b₂,...]` recursively is the continued fraction representation of `1 / (v − ⌊v⌋)`. This
+process stops when the fractional part `v- ⌊v⌋` hits 0 at some step.
+
+The implementation uses `int_fract_pair.stream` to obtain the partial denominators of the continued
+fraction. Refer to said function for more details about the computation process.
 -/
 protected def of [discrete_linear_ordered_field K] [floor_ring K] (v : K) : gcf K :=
 let ⟨h, s⟩ := int_fract_pair.seq1 v in -- get the sequence of integer and fractional parts.
-⟨
-  h.b, -- the head is just the first integer part
-  s.map (λ p, ⟨1, p.b⟩) -- the sequence consists of the remaining integer parts as the partial
-                        -- denominators; all partial numerators are simply 1
-⟩
+⟨ h.b, -- the head is just the first integer part
+  s.map (λ p, ⟨1, p.b⟩) ⟩ -- the sequence consists of the remaining integer parts as the partial
+                          -- denominators; all partial numerators are simply 1
+
 
 end generalized_continued_fraction

--- a/src/algebra/continued_fractions/computation/basic.lean
+++ b/src/algebra/continued_fractions/computation/basic.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2020 Kevin Kappelmann. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Kappelmann
+-/
+import algebra.continued_fractions.basic
+import algebra.ordered_field
+import algebra.archimedean
+/-!
+# Computable Continued Fractions
+
+## Summary
+
+We formalise the standard computation of regular continued fractions for linear ordered floor
+fields. The algorithm is rather simple and connected to the Euclidean algorithm. It can be found,
+for example, on Wikipedia:
+https://en.wikipedia.org/wiki/Continued_fraction#Calculating_continued_fraction_representations.
+
+## Main definitions
+
+- `generalized_continued_fraction.of`: computes the generalised continued fraction of a value.
+In fact, it computes a regular continued fraction (the proof will be added in a future commit).
+
+## References
+
+- https://en.wikipedia.org/wiki/Continued_fraction
+
+## Tags
+
+numerics, number theory, approximations, fractions
+-/
+
+namespace generalized_continued_fraction
+open generalized_continued_fraction as gcf
+
+-- Fix a carrier `α`.
+variable (α : Type*)
+
+/--
+We collect an integer part `b = ⌊v⌋` and fractional part `fr = v - ⌊v⌋` of a value `v` in a pair
+`⟨b, fr⟩`.
+-/
+structure int_fract_pair := (b : ℤ) (fr : α)
+
+/- Interlude: define some expected coercions and instances. -/
+namespace int_fract_pair
+
+/-- Make an `int_fract_pair` printable. -/
+instance [has_repr α] : has_repr (int_fract_pair α) :=
+⟨λ p, "(b : " ++ (repr p.b) ++ ", fract : " ++ (repr p.fr) ++ ")"⟩
+
+instance inhabited [inhabited α] : inhabited (int_fract_pair α) := ⟨⟨0, (default _)⟩⟩
+
+variable {α}
+
+section coe
+/-! Interlude: define some expected coercions. -/
+/- Fix another type `β` and assume `α` can be converted to `β`. -/
+variables {β : Type*} [has_coe α β]
+
+/-- Coerce a pair by coercion the fractional component. -/
+instance has_coe_to_int_fract_pair : has_coe (int_fract_pair α) (int_fract_pair β) :=
+⟨λ ⟨b, fr⟩, ⟨b, (fr : β)⟩⟩
+
+
+@[simp, norm_cast]
+lemma coe_to_int_fract_pair {b : ℤ} {fr : α} :
+  (↑(int_fract_pair.mk b fr) : int_fract_pair β) = int_fract_pair.mk b (↑fr : β) :=
+rfl
+
+end coe
+
+-- Note: this could be relaxed to something like `discrete_linear_ordered_division_ring` in the
+-- future.
+/-- Fix a linear ordered ring with `floor` function. -/
+variables [discrete_linear_ordered_field α] [floor_ring α]
+
+/-- Creates the integer and fractional part of a value `v`, i.e. `⟨⌊v⌋, v - ⌊v⌋⟩`. -/
+protected def of (v : α) : int_fract_pair α := ⟨⌊v⌋, fract v⟩
+
+/-- Creates the stream of integer and fractional parts of a value `v`. -/
+protected def stream (v : α) : stream $ option (int_fract_pair α)
+| 0 := some (int_fract_pair.of v)
+| (n + 1) := do ap_n ← stream n,
+  if ap_n.fr = 0 then none else int_fract_pair.of ap_n.fr⁻¹
+
+/--
+Shows that `stream` has the sequence property, that is once we return `none` at position `n`,
+we also return `none` at `n + 1`.
+-/
+lemma stream_is_seq (v : α) : (int_fract_pair.stream v).is_seq :=
+by { assume _ hyp, simp [int_fract_pair.stream, hyp] }
+
+/-- Creates the sequence with head of `int_fract_pair`s. -/
+protected def seq1 (v : α) : seq1 $ int_fract_pair α :=
+⟨
+  int_fract_pair.of v,--the head
+  seq.tail -- take the tail of `int_fract_pair.stream` since the first element is in the head
+  ⟨ -- create a sequence from `int_fract_pair.stream`
+    int_fract_pair.stream v, -- the underlying stream
+    @stream_is_seq _ _ _ v
+  ⟩
+⟩
+end int_fract_pair
+
+variable {α}
+
+/--
+Returns the `generalized continued fraction` of a value. In fact, the returned gcf is also
+a regular continued fraction (the proof will be added in a future commit).
+-/
+protected def of [discrete_linear_ordered_field α] [floor_ring α] (v : α) : gcf α :=
+let ⟨h, s⟩ := int_fract_pair.seq1 v in -- get the sequence of integer and fractional parts.
+⟨
+  h.b, -- the head is just the first integer part
+  s.map (λ p, ⟨1, p.b⟩) -- the sequence consists of the remaining integer parts as the partial
+                        -- denominators; all partial numerators are simply 1
+⟩
+
+end generalized_continued_fraction

--- a/src/algebra/continued_fractions/computation/basic.lean
+++ b/src/algebra/continued_fractions/computation/basic.lean
@@ -21,7 +21,7 @@ This process stops when the fractional part hits 0.
 
 In other words: to calculate a continued fraction representation of a number `v`, write down the
 integer part (i.e. the floor) of `v`. Subtract this integer part from `v`. If the difference is 0,
-stop; otherwise find the reciprocal of the difference and repeat. The procedure will termiante if
+stop; otherwise find the reciprocal of the difference and repeat. The procedure will terminate if
 and only if `v` is rational.
 
 For an example, refer to `int_fract_pair.stream`.

--- a/src/algebra/continued_fractions/computation/basic.lean
+++ b/src/algebra/continued_fractions/computation/basic.lean
@@ -14,7 +14,7 @@ import algebra.archimedean
 We formalise the standard computation of (regular) continued fractions for linear ordered floor
 fields. The algorithm is rather simple. Here is an outline of the procedure adapted from Wikipedia:
 
-Take a value `v`. We call `⌊v⌋` the *integer part* of `v` and `v − ⌊v⌋` the *fractional part* of `r`.
+Take a value `v`. We call `⌊v⌋` the *integer part* of `v` and `v − ⌊v⌋` the *fractional part* of `v`.
 A continued fraction representation of `v` can then be given by `[⌊v⌋; b₀, b₁, b₂,...]`,
 where `[b₀; b₁, b₂,...]` recursively is the continued fraction representation of `1 / (v − ⌊v⌋)`.
 This process stops when the fractional part hits 0.

--- a/src/algebra/continued_fractions/computation/basic.lean
+++ b/src/algebra/continued_fractions/computation/basic.lean
@@ -33,38 +33,38 @@ numerics, number theory, approximations, fractions
 namespace generalized_continued_fraction
 open generalized_continued_fraction as gcf
 
--- Fix a carrier `α`.
-variable (α : Type*)
+-- Fix a carrier `K`.
+variable (K : Type*)
 
 /--
 We collect an integer part `b = ⌊v⌋` and fractional part `fr = v - ⌊v⌋` of a value `v` in a pair
 `⟨b, fr⟩`.
 -/
-structure int_fract_pair := (b : ℤ) (fr : α)
+structure int_fract_pair := (b : ℤ) (fr : K)
 
 /- Interlude: define some expected coercions and instances. -/
 namespace int_fract_pair
 
 /-- Make an `int_fract_pair` printable. -/
-instance [has_repr α] : has_repr (int_fract_pair α) :=
+instance [has_repr K] : has_repr (int_fract_pair K) :=
 ⟨λ p, "(b : " ++ (repr p.b) ++ ", fract : " ++ (repr p.fr) ++ ")"⟩
 
-instance inhabited [inhabited α] : inhabited (int_fract_pair α) := ⟨⟨0, (default _)⟩⟩
+instance inhabited [inhabited K] : inhabited (int_fract_pair K) := ⟨⟨0, (default _)⟩⟩
 
-variable {α}
+variable {K}
 
 section coe
 /-! Interlude: define some expected coercions. -/
-/- Fix another type `β` and assume `α` can be converted to `β`. -/
-variables {β : Type*} [has_coe α β]
+/- Fix another type `β` and assume `K` can be converted to `β`. -/
+variables {β : Type*} [has_coe K β]
 
 /-- Coerce a pair by coercion the fractional component. -/
-instance has_coe_to_int_fract_pair : has_coe (int_fract_pair α) (int_fract_pair β) :=
+instance has_coe_to_int_fract_pair : has_coe (int_fract_pair K) (int_fract_pair β) :=
 ⟨λ ⟨b, fr⟩, ⟨b, (fr : β)⟩⟩
 
 
 @[simp, norm_cast]
-lemma coe_to_int_fract_pair {b : ℤ} {fr : α} :
+lemma coe_to_int_fract_pair {b : ℤ} {fr : K} :
   (↑(int_fract_pair.mk b fr) : int_fract_pair β) = int_fract_pair.mk b (↑fr : β) :=
 rfl
 
@@ -73,13 +73,13 @@ end coe
 -- Note: this could be relaxed to something like `discrete_linear_ordered_division_ring` in the
 -- future.
 /-- Fix a linear ordered ring with `floor` function. -/
-variables [discrete_linear_ordered_field α] [floor_ring α]
+variables [discrete_linear_ordered_field K] [floor_ring K]
 
 /-- Creates the integer and fractional part of a value `v`, i.e. `⟨⌊v⌋, v - ⌊v⌋⟩`. -/
-protected def of (v : α) : int_fract_pair α := ⟨⌊v⌋, fract v⟩
+protected def of (v : K) : int_fract_pair K := ⟨⌊v⌋, fract v⟩
 
 /-- Creates the stream of integer and fractional parts of a value `v`. -/
-protected def stream (v : α) : stream $ option (int_fract_pair α)
+protected def stream (v : K) : stream $ option (int_fract_pair K)
 | 0 := some (int_fract_pair.of v)
 | (n + 1) := do ap_n ← stream n,
   if ap_n.fr = 0 then none else int_fract_pair.of ap_n.fr⁻¹
@@ -88,11 +88,11 @@ protected def stream (v : α) : stream $ option (int_fract_pair α)
 Shows that `stream` has the sequence property, that is once we return `none` at position `n`,
 we also return `none` at `n + 1`.
 -/
-lemma stream_is_seq (v : α) : (int_fract_pair.stream v).is_seq :=
+lemma stream_is_seq (v : K) : (int_fract_pair.stream v).is_seq :=
 by { assume _ hyp, simp [int_fract_pair.stream, hyp] }
 
 /-- Creates the sequence with head of `int_fract_pair`s. -/
-protected def seq1 (v : α) : seq1 $ int_fract_pair α :=
+protected def seq1 (v : K) : seq1 $ int_fract_pair K :=
 ⟨
   int_fract_pair.of v,--the head
   seq.tail -- take the tail of `int_fract_pair.stream` since the first element is in the head
@@ -103,13 +103,13 @@ protected def seq1 (v : α) : seq1 $ int_fract_pair α :=
 ⟩
 end int_fract_pair
 
-variable {α}
+variable {K}
 
 /--
 Returns the `generalized continued fraction` of a value. In fact, the returned gcf is also
 a regular continued fraction (the proof will be added in a future commit).
 -/
-protected def of [discrete_linear_ordered_field α] [floor_ring α] (v : α) : gcf α :=
+protected def of [discrete_linear_ordered_field K] [floor_ring K] (v : K) : gcf K :=
 let ⟨h, s⟩ := int_fract_pair.seq1 v in -- get the sequence of integer and fractional parts.
 ⟨
   h.b, -- the head is just the first integer part

--- a/src/algebra/continued_fractions/computation/default.lean
+++ b/src/algebra/continued_fractions/computation/default.lean
@@ -5,5 +5,5 @@ Authors: Kevin Kappelmann
 -/
 import algebra.continued_fractions.computation.basic
 /-!
-# Default Exports for The Computation of Continued Fractions
+# Default Exports for the Computation of Continued Fractions
 -/

--- a/src/algebra/continued_fractions/computation/default.lean
+++ b/src/algebra/continued_fractions/computation/default.lean
@@ -1,0 +1,9 @@
+/-
+Copyright (c) 2020 Kevin Kappelmann. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Kappelmann
+-/
+import algebra.continued_fractions.computation.basic
+/-!
+# Default Exports for The Computation of Continued Fractions
+-/

--- a/src/algebra/continued_fractions/computation/translations.lean
+++ b/src/algebra/continued_fractions/computation/translations.lean
@@ -18,7 +18,7 @@ namespace generalized_continued_fraction
 open generalized_continued_fraction as gcf
 
 /-- Fix a discrete linear order floor field and a value `v`. -/
-variables {α : Type*} [discrete_linear_ordered_field α] [floor_ring α] {v : α}
+variables {K : Type*} [discrete_linear_ordered_field K] [floor_ring K] {v : K}
 
 namespace int_fract_pair
 /-!
@@ -32,7 +32,7 @@ later on.
 
 variable {n : ℕ}
 
-lemma stream_eq_none_of_fr_eq_zero {ifp_n : int_fract_pair α}
+lemma stream_eq_none_of_fr_eq_zero {ifp_n : int_fract_pair K}
   (stream_nth_eq : int_fract_pair.stream v n = some ifp_n) (nth_fr_eq_zero : ifp_n.fr = 0) :
   int_fract_pair.stream v (n + 1) = none :=
 begin
@@ -52,9 +52,9 @@ begin
     finish [int_fract_pair.stream] }
 end
 
-lemma succ_nth_stream_eq_some_iff {ifp_succ_n : int_fract_pair α} :
+lemma succ_nth_stream_eq_some_iff {ifp_succ_n : int_fract_pair K} :
     int_fract_pair.stream v (n + 1) = some ifp_succ_n
-  ↔ ∃ (ifp_n : int_fract_pair α), int_fract_pair.stream v n = some ifp_n
+  ↔ ∃ (ifp_n : int_fract_pair K), int_fract_pair.stream v n = some ifp_n
       ∧ ifp_n.fr ≠ 0
       ∧ int_fract_pair.of ifp_n.fr⁻¹ = ifp_succ_n :=
 begin
@@ -80,10 +80,10 @@ begin
   { rintro ⟨⟨_⟩, ifp_n_props⟩, finish [int_fract_pair.stream, ifp_n_props] }
 end
 
-lemma obtain_succ_nth_stream_of_fr_zero {ifp_succ_n : int_fract_pair α}
+lemma obtain_succ_nth_stream_of_fr_zero {ifp_succ_n : int_fract_pair K}
   (stream_succ_nth_eq : int_fract_pair.stream v (n + 1) = some ifp_succ_n)
   (succ_nth_fr_eq_zero : ifp_succ_n.fr = 0) :
-  ∃ (ifp_n : int_fract_pair α), int_fract_pair.stream v n = some ifp_n ∧ ifp_n.fr⁻¹ = ⌊ifp_n.fr⁻¹⌋ :=
+  ∃ (ifp_n : int_fract_pair K), int_fract_pair.stream v n = some ifp_n ∧ ifp_n.fr⁻¹ = ⌊ifp_n.fr⁻¹⌋ :=
 begin
   -- get the witness from `succ_nth_stream_eq_some_iff` and prove that it has the additional
   -- properties
@@ -165,7 +165,7 @@ section values
 #### Translation of The Values of The Sequence
 -/
 
-lemma nth_of_eq_some_of_succ_nth_int_fract_pair_stream {ifp_succ_n : int_fract_pair α}
+lemma nth_of_eq_some_of_succ_nth_int_fract_pair_stream {ifp_succ_n : int_fract_pair K}
   (stream_succ_nth_eq : int_fract_pair.stream v (n + 1) = some ifp_succ_n) :
   (gcf.of v).s.nth n = some ⟨1, ifp_succ_n.b⟩ :=
 begin
@@ -174,12 +174,12 @@ begin
   simp [seq.nth, stream_succ_nth_eq]
 end
 
-lemma int_fract_pair.obtain_succ_nth_stream_of_gcf_of_nth_eq_some {gp_n : gcf.pair α}
+lemma int_fract_pair.obtain_succ_nth_stream_of_gcf_of_nth_eq_some {gp_n : gcf.pair K}
   (s_nth_eq : (gcf.of v).s.nth n = some gp_n) :
-  ∃ (ifp : int_fract_pair α), int_fract_pair.stream v (n + 1) = some ifp ∧ (ifp.b : α) = gp_n.b :=
+  ∃ (ifp : int_fract_pair K), int_fract_pair.stream v (n + 1) = some ifp ∧ (ifp.b : K) = gp_n.b :=
 begin
   obtain ⟨ifp, stream_succ_nth_eq, gp_n_eq⟩ :
-    ∃ ifp, int_fract_pair.stream v (n + 1) = some ifp ∧ gcf.pair.mk 1 (ifp.b : α) = gp_n, by
+    ∃ ifp, int_fract_pair.stream v (n + 1) = some ifp ∧ gcf.pair.mk 1 (ifp.b : K) = gp_n, by
     { unfold gcf.of int_fract_pair.seq1 at s_nth_eq,
       rwa [seq.map_tail, seq.nth_tail, seq.map_nth, option.map_eq_some'] at s_nth_eq },
   cases gp_n_eq,
@@ -188,7 +188,7 @@ begin
   exact ⟨stream_succ_nth_eq, ifp_b_eq_gp_n_b⟩
 end
 
-lemma nth_of_eq_some_of_nth_int_fract_pair_stream_fr_ne_zero {ifp_n : int_fract_pair α}
+lemma nth_of_eq_some_of_nth_int_fract_pair_stream_fr_ne_zero {ifp_n : int_fract_pair K}
   (stream_nth_eq : int_fract_pair.stream v n = some ifp_n) (nth_fr_ne_zero : ifp_n.fr ≠ 0) :
   (gcf.of v).s.nth n = some ⟨1, (int_fract_pair.of ifp_n.fr⁻¹).b⟩ :=
 have int_fract_pair.stream v (n + 1) = some (int_fract_pair.of ifp_n.fr⁻¹), by

--- a/src/algebra/continued_fractions/computation/translations.lean
+++ b/src/algebra/continued_fractions/computation/translations.lean
@@ -14,29 +14,30 @@ This is a collection of simple lemmas between the different structures used for 
 of continued fractions defined in `algebra.continued_fractions.computation.basic`. The file consists
 of three sections:
 1. Recurrences and inversion lemmas for `int_fract_pair.stream`: these lemmas give us inversion
-rules and recurrences for the computation of the stream of integer and fractional parts of a value.
+   rules and recurrences for the computation of the stream of integer and fractional parts of a value.
 2. Translation lemmas for the head term: these lemmas show us that the head term of the computed
-continued fraction of a value `v` is `⌊v⌋` and how this head term is moved along the structures used
-in the computation process.
+   continued fraction of a value `v` is `⌊v⌋` and how this head term is moved along the structures
+   used in the computation process.
 3. Translation lemmas for the sequence: these lemmas show how the sequences of the involved
-structures (`int_fract_pair.stream`, `int_fract_pair.seq1`, and `generalized_continued_fraction.of`)
-are connected, i.e. how the values are moved along the structures and the termination of one
-sequence implies the termination of another sequence.
+   structures (`int_fract_pair.stream`, `int_fract_pair.seq1`, and `generalized_continued_fraction.of`)
+   are connected, i.e. how the values are moved along the structures and the termination of one
+   sequence implies the termination of another sequence.
 
 ## Main Theorems
+
 - `succ_nth_stream_eq_some_iff` gives as a recurrence to compute the `n + 1`th value of the sequence
-of integer and fractional parts of a value in case of non-termination.
+  of integer and fractional parts of a value in case of non-termination.
 - `succ_nth_stream_eq_none_iff` gives as a recurrence to compute the `n + 1`th value of the sequence
-of integer and fractional parts of a value in case of termination.
+  of integer and fractional parts of a value in case of termination.
 - `nth_of_eq_some_of_succ_nth_int_fract_pair_stream` and
-`nth_of_eq_some_of_nth_int_fract_pair_stream_fr_ne_zero` show how the entries of the sequence
-of the computed continued fraction can be obtained from the stream of integer and fractional parts.
+  `nth_of_eq_some_of_nth_int_fract_pair_stream_fr_ne_zero` show how the entries of the sequence
+  of the computed continued fraction can be obtained from the stream of integer and fractional parts.
 -/
 
 namespace generalized_continued_fraction
 open generalized_continued_fraction as gcf
 
-/-- Fix a discrete linear ordered floor field and a value `v`. -/
+/- Fix a discrete linear ordered floor field and a value `v`. -/
 variables {K : Type*} [discrete_linear_ordered_field K] [floor_ring K] {v : K}
 
 namespace int_fract_pair
@@ -59,7 +60,7 @@ begin
 end
 
 /--
-Gives as a recurrence to compute the `n + 1`th value of the sequence of integer and fractional
+Gives a recurrence to compute the `n + 1`th value of the sequence of integer and fractional
 parts of a value in case of termination.
 -/
 lemma succ_nth_stream_eq_none_iff : int_fract_pair.stream v (n + 1) = none
@@ -74,7 +75,7 @@ begin
 end
 
 /--
-Gives as a recurrence to compute the `n + 1`th value of the sequence of integer and fractional
+Gives a recurrence to compute the `n + 1`th value of the sequence of integer and fractional
 parts of a value in case of non-termination.
 -/
 lemma succ_nth_stream_eq_some_iff {ifp_succ_n : int_fract_pair K} :
@@ -131,21 +132,21 @@ end int_fract_pair
 
 section head
 /-!
-### Translation of The Head Term
+### Translation of the Head Term
 
 Here we state some lemmas that show us that the head term of the computed continued fraction of a
 value `v` is `⌊v⌋` and how this head term is moved along the structures used in the computation
 process.
 -/
 
-/- The head term of the sequence with head of `v` is just the integer part of `v`. -/
+/-- The head term of the sequence with head of `v` is just the integer part of `v`. -/
 @[simp]
 lemma int_fract_pair.seq1_fst_eq_of : (int_fract_pair.seq1 v).fst = int_fract_pair.of v := rfl
 
 lemma of_h_eq_int_fract_pair_seq1_fst_b : (gcf.of v).h = (int_fract_pair.seq1 v).fst.b :=
 by { cases aux_seq_eq : (int_fract_pair.seq1 v), simp [gcf.of, aux_seq_eq] }
 
-/- The head term of the gcf of `v` is ⌊v⌋. -/
+/-- The head term of the gcf of `v` is `⌊v⌋`. -/
 @[simp]
 lemma of_h_eq_floor : (gcf.of v).h = ⌊v⌋ :=
 by simp [of_h_eq_int_fract_pair_seq1_fst_b, int_fract_pair.of]
@@ -169,9 +170,9 @@ lemma int_fract_pair.nth_seq1_eq_succ_nth_stream :
 
 section termination
 /-!
-#### Translation of The Termination of The Sequences
+#### Translation of the Termination of the Sequences
 
-Let's first show how he termination of one sequence implies the termination of another sequence.
+Let's first show how the termination of one sequence implies the termination of another sequence.
 -/
 
 lemma of_terminated_at_iff_int_fract_pair_seq1_terminated_at :
@@ -192,9 +193,9 @@ end termination
 
 section values
 /-!
-#### Translation of The Values of The Sequence
+#### Translation of the Values of the Sequence
 
-Now let's show how he values of the sequences correspond to one another.
+Now let's show how the values of the sequences correspond to one another.
 -/
 
 lemma int_fract_pair.obtain_succ_nth_stream_of_gcf_of_nth_eq_some {gp_n : gcf.pair K}

--- a/src/algebra/continued_fractions/computation/translations.lean
+++ b/src/algebra/continued_fractions/computation/translations.lean
@@ -155,11 +155,11 @@ end head
 
 section sequence
 /-!
-### Translation of The Sequences
+### Translation of the Sequences
 
 Here we state some lemmas that show how the sequences of the involved structures
 (`int_fract_pair.stream`, `int_fract_pair.seq1`, and `generalized_continued_fraction.of`) are
-connected, i.e. how the values are moved along the structures and the termination of one sequence
+connected, i.e. how the values are moved along the structures and how the termination of one sequence
 implies the termination of another sequence.
 -/
 

--- a/src/algebra/continued_fractions/computation/translations.lean
+++ b/src/algebra/continued_fractions/computation/translations.lean
@@ -10,8 +10,27 @@ import algebra.continued_fractions.translations
 
 ## Summary
 
-Some simple translation lemmas between the different structures used for the computations defined in
-`algebra.continued_fractions.computation.basic`.
+This is a collection of simple lemmas between the different structures used for the computation
+of continued fractions defined in `algebra.continued_fractions.computation.basic`. The file consists
+of three sections:
+1. Translation and inversion lemmas for `int_fract_pair.stream`: these lemmas give us inversion
+rules and recurrences for the computation of the stream of integer and fractional parts of a value.
+2. Translation lemmas for the head term: these lemmas show us that the head term of the computed
+continued fraction of a value `v` is `⌊v⌋` and how this head term is moved along the structures used
+in the computation process.
+3. Translation lemmas for the sequence: these lemmas show how the sequences of the involved
+structures (`int_fract_pair.stream`, `int_fract_pair.seq1`, and `generalized_continued_fraction.of`)
+are connected, i.e. how the values are moved along the structures and the termination of one
+sequence implies the termination of another sequence.
+
+## Main Theorems
+- `succ_nth_stream_eq_some_iff` gives as a recurrence to compute the `n + 1`th value of the sequence
+of integer and fractional parts of a value in case of non-termination.
+- `succ_nth_stream_eq_none_iff` gives as a recurrence to compute the `n + 1`th value of the sequence
+of integer and fractional parts of a value in case of termination.
+- `nth_of_eq_some_of_succ_nth_int_fract_pair_stream` and
+`nth_of_eq_some_of_nth_int_fract_pair_stream_fr_ne_zero` show how the entries of the sequence
+of the computed continued fraction can be obtained from the stream of integer and fractional parts.
 -/
 
 namespace generalized_continued_fraction
@@ -22,11 +41,10 @@ variables {K : Type*} [discrete_linear_ordered_field K] [floor_ring K] {v : K}
 
 namespace int_fract_pair
 /-!
-### Translation and Inversion Lemmas for `int_fract_pair.stream`
+### Recurrences and Inversion Lemmas for `int_fract_pair.stream`
 
-Here we state some technical lemmas that deal with the computation of the sequence of integer and
-fractional parts used to obtain a continued fraction. The lemmas themselves are not interesting and
-are just needed to prove properties about the sequence later on.
+Here we state some lemmas that give us inversion rules and recurrences for the computation of the
+stream of integer and fractional parts of a value.
 -/
 
 variable {n : ℕ}
@@ -40,6 +58,10 @@ begin
   simp [int_fract_pair.stream, stream_nth_eq, nth_fr_eq_zero]
 end
 
+/--
+Gives as a recurrence to compute the `n + 1`th value of the sequence of integer and fractional
+parts of a value in case of termination.
+-/
 lemma succ_nth_stream_eq_none_iff : int_fract_pair.stream v (n + 1) = none
   ↔ (int_fract_pair.stream v n = none ∨ ∃ ifp, int_fract_pair.stream v n = some ifp ∧ ifp.fr = 0) :=
 begin
@@ -51,6 +73,10 @@ begin
     finish [int_fract_pair.stream] }
 end
 
+/--
+Gives as a recurrence to compute the `n + 1`th value of the sequence of integer and fractional
+parts of a value in case of non-termination.
+-/
 lemma succ_nth_stream_eq_some_iff {ifp_succ_n : int_fract_pair K} :
     int_fract_pair.stream v (n + 1) = some ifp_succ_n
   ↔ ∃ (ifp_n : int_fract_pair K), int_fract_pair.stream v n = some ifp_n
@@ -107,8 +133,9 @@ section head
 /-!
 ### Translation of The Head Term
 
-Here we give some basic translations that between the various methods that return the head term of
-the continued fraction computed for a value.
+Here we state some lemmas that show us that the head term of the computed continued fraction of a
+value `v` is `⌊v⌋` and how this head term is moved along the structures used in the computation
+process.
 -/
 
 /- The head term of the sequence with head of `v` is just the integer part of `v`. -/
@@ -127,10 +154,12 @@ end head
 
 section sequence
 /-!
-### Translation of The Sequence
+### Translation of The Sequences
 
-Here we give some basic translations that between the various methods that return the sequence part
-of the continued fraction computed for a value.
+Here we state some lemmas that show how the sequences of the involved structures
+(`int_fract_pair.stream`, `int_fract_pair.seq1`, and `generalized_continued_fraction.of`) are
+connected, i.e. how the values are moved along the structures and the termination of one sequence
+implies the termination of another sequence.
 -/
 
 variable {n : ℕ}
@@ -140,7 +169,9 @@ lemma int_fract_pair.nth_seq1_eq_succ_nth_stream :
 
 section termination
 /-!
-#### Translation of The Termination of The Sequence
+#### Translation of The Termination of The Sequences
+
+Let's first show how he termination of one sequence implies the termination of another sequence.
 -/
 
 lemma of_terminated_at_iff_int_fract_pair_seq1_terminated_at :
@@ -162,16 +193,9 @@ end termination
 section values
 /-!
 #### Translation of The Values of The Sequence
--/
 
-lemma nth_of_eq_some_of_succ_nth_int_fract_pair_stream {ifp_succ_n : int_fract_pair K}
-  (stream_succ_nth_eq : int_fract_pair.stream v (n + 1) = some ifp_succ_n) :
-  (gcf.of v).s.nth n = some ⟨1, ifp_succ_n.b⟩ :=
-begin
-  unfold gcf.of int_fract_pair.seq1,
-  rw [seq.map_tail, seq.nth_tail, seq.map_nth],
-  simp [seq.nth, stream_succ_nth_eq]
-end
+Now let's show how he values of the sequences correspond to one another.
+-/
 
 lemma int_fract_pair.obtain_succ_nth_stream_of_gcf_of_nth_eq_some {gp_n : gcf.pair K}
   (s_nth_eq : (gcf.of v).s.nth n = some gp_n) :
@@ -187,6 +211,23 @@ begin
   exact ⟨stream_succ_nth_eq, ifp_b_eq_gp_n_b⟩
 end
 
+/--
+Shows how the entries of the sequence of the computed continued fraction can be obtained by the
+integer parts of the stream of integer and fractional parts.
+-/
+lemma nth_of_eq_some_of_succ_nth_int_fract_pair_stream {ifp_succ_n : int_fract_pair K}
+  (stream_succ_nth_eq : int_fract_pair.stream v (n + 1) = some ifp_succ_n) :
+  (gcf.of v).s.nth n = some ⟨1, ifp_succ_n.b⟩ :=
+begin
+  unfold gcf.of int_fract_pair.seq1,
+  rw [seq.map_tail, seq.nth_tail, seq.map_nth],
+  simp [seq.nth, stream_succ_nth_eq]
+end
+
+/--
+Shows how the entries of the sequence of the computed continued fraction can be obtained by the
+fractional parts of the stream of integer and fractional parts.
+-/
 lemma nth_of_eq_some_of_nth_int_fract_pair_stream_fr_ne_zero {ifp_n : int_fract_pair K}
   (stream_nth_eq : int_fract_pair.stream v n = some ifp_n) (nth_fr_ne_zero : ifp_n.fr ≠ 0) :
   (gcf.of v).s.nth n = some ⟨1, (int_fract_pair.of ifp_n.fr⁻¹).b⟩ :=

--- a/src/algebra/continued_fractions/computation/translations.lean
+++ b/src/algebra/continued_fractions/computation/translations.lean
@@ -13,7 +13,7 @@ import algebra.continued_fractions.translations
 This is a collection of simple lemmas between the different structures used for the computation
 of continued fractions defined in `algebra.continued_fractions.computation.basic`. The file consists
 of three sections:
-1. Translation and inversion lemmas for `int_fract_pair.stream`: these lemmas give us inversion
+1. Recurrences and inversion lemmas for `int_fract_pair.stream`: these lemmas give us inversion
 rules and recurrences for the computation of the stream of integer and fractional parts of a value.
 2. Translation lemmas for the head term: these lemmas show us that the head term of the computed
 continued fraction of a value `v` is `⌊v⌋` and how this head term is moved along the structures used

--- a/src/algebra/continued_fractions/computation/translations.lean
+++ b/src/algebra/continued_fractions/computation/translations.lean
@@ -25,9 +25,8 @@ namespace int_fract_pair
 ### Translation and Inversion Lemmas for `int_fract_pair.stream`
 
 Here we state some technical lemmas that deal with the computation of the sequence of integer and
-fractional parts used to obtain a continued fraction.
-The lemmas themselves are not interesting and are just needed to prove properties about the sequence
-later on.
+fractional parts used to obtain a continued fraction. The lemmas themselves are not interesting and
+are just needed to prove properties about the sequence later on.
 -/
 
 variable {n : ℕ}

--- a/src/algebra/continued_fractions/computation/translations.lean
+++ b/src/algebra/continued_fractions/computation/translations.lean
@@ -1,0 +1,200 @@
+/-
+Copyright (c) 2020 Kevin Kappelmann. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Kappelmann
+-/
+import algebra.continued_fractions.computation.basic
+import algebra.continued_fractions.translations
+/-!
+# Basic Translation Lemmas Between Structures Defined for Computing Continued Fractions
+
+## Summary
+
+Some simple translation lemmas between the different structures used for the computations defined in
+`algebra.continued_fractions.computation.basic`.
+-/
+
+namespace generalized_continued_fraction
+open generalized_continued_fraction as gcf
+
+/-- Fix a discrete linear order floor field and a value `v`. -/
+variables {α : Type*} [discrete_linear_ordered_field α] [floor_ring α] {v : α}
+
+namespace int_fract_pair
+/-!
+### Translation and Inversion Lemmas for `int_fract_pair.stream`
+
+Here we state some technical lemmas that deal with the computation of the sequence of integer and
+fractional parts used to obtain a continued fraction.
+The lemmas themselves are not interesting and are just needed to prove properties about the sequence
+later on.
+-/
+
+variable {n : ℕ}
+
+lemma stream_eq_none_of_fr_eq_zero {ifp_n : int_fract_pair α}
+  (stream_nth_eq : int_fract_pair.stream v n = some ifp_n) (nth_fr_eq_zero : ifp_n.fr = 0) :
+  int_fract_pair.stream v (n + 1) = none :=
+begin
+  cases ifp_n with _ fr,
+  change fr = 0 at nth_fr_eq_zero,
+  simp [int_fract_pair.stream, stream_nth_eq, nth_fr_eq_zero]
+end
+
+lemma succ_nth_stream_eq_none_iff : int_fract_pair.stream v (n + 1) = none
+  ↔ (int_fract_pair.stream v n = none ∨ ∃ ifp, int_fract_pair.stream v n = some ifp ∧ ifp.fr = 0) :=
+begin
+  cases stream_nth_eq : (int_fract_pair.stream v n) with ifp,
+  case option.none : { simp [stream_nth_eq, int_fract_pair.stream] },
+  case option.some :
+  { cases ifp with _ fr,
+    cases decidable.em (fr = 0);
+    finish [int_fract_pair.stream] }
+end
+
+lemma succ_nth_stream_eq_some_iff {ifp_succ_n : int_fract_pair α} :
+    int_fract_pair.stream v (n + 1) = some ifp_succ_n
+  ↔ ∃ (ifp_n : int_fract_pair α), int_fract_pair.stream v n = some ifp_n
+      ∧ ifp_n.fr ≠ 0
+      ∧ int_fract_pair.of ifp_n.fr⁻¹ = ifp_succ_n :=
+begin
+  split,
+  { assume stream_succ_nth_eq,
+    have : int_fract_pair.stream v (n + 1) ≠ none, by simp [stream_succ_nth_eq],
+    have : ¬int_fract_pair.stream v n = none
+           ∧ ¬(∃ ifp, int_fract_pair.stream v n = some ifp ∧ ifp.fr = 0), by
+    { have not_none_not_fract_zero, from (not_iff_not_of_iff succ_nth_stream_eq_none_iff).elim_left this,
+      exact (not_or_distrib.elim_left not_none_not_fract_zero) },
+    cases this with stream_nth_ne_none nth_fr_ne_zero,
+    replace nth_fr_ne_zero : ∀ ifp, int_fract_pair.stream v n = some ifp → ifp.fr ≠ 0, by
+      simpa using nth_fr_ne_zero,
+    obtain ⟨ifp_n, stream_nth_eq⟩ : ∃ ifp_n, int_fract_pair.stream v n = some ifp_n, from
+      with_one.ne_one_iff_exists.elim_left stream_nth_ne_none,
+    existsi ifp_n,
+    have ifp_n_fr_ne_zero : ifp_n.fr ≠ 0, from nth_fr_ne_zero ifp_n stream_nth_eq,
+    cases ifp_n with _ ifp_n_fr,
+    suffices : int_fract_pair.of ifp_n_fr⁻¹ = ifp_succ_n, by simpa [stream_nth_eq, ifp_n_fr_ne_zero],
+    simp only [int_fract_pair.stream, stream_nth_eq, ifp_n_fr_ne_zero, option.some_bind, if_false]
+      at stream_succ_nth_eq,
+    injection stream_succ_nth_eq },
+  { rintro ⟨⟨_⟩, ifp_n_props⟩, finish [int_fract_pair.stream, ifp_n_props] }
+end
+
+lemma obtain_succ_nth_stream_of_fr_zero {ifp_succ_n : int_fract_pair α}
+  (stream_succ_nth_eq : int_fract_pair.stream v (n + 1) = some ifp_succ_n)
+  (succ_nth_fr_eq_zero : ifp_succ_n.fr = 0) :
+  ∃ (ifp_n : int_fract_pair α), int_fract_pair.stream v n = some ifp_n ∧ ifp_n.fr⁻¹ = ⌊ifp_n.fr⁻¹⌋ :=
+begin
+  -- get the witness from `succ_nth_stream_eq_some_iff` and prove that it has the additional
+  -- properties
+  rcases (succ_nth_stream_eq_some_iff.elim_left stream_succ_nth_eq) with
+    ⟨ifp_n, stream_nth_eq, nth_fr_ne_zero, _⟩,
+  existsi ifp_n,
+  cases ifp_n with _ ifp_n_fr,
+  suffices : ifp_n_fr⁻¹ = ⌊ifp_n_fr⁻¹⌋, by simpa [stream_nth_eq],
+  have : int_fract_pair.of ifp_n_fr⁻¹ = ifp_succ_n, by finish,
+  cases ifp_succ_n with _ ifp_succ_n_fr,
+  change ifp_succ_n_fr = 0 at succ_nth_fr_eq_zero,
+  have : fract ifp_n_fr⁻¹ = ifp_succ_n_fr, by injection this,
+  have : fract ifp_n_fr⁻¹ = 0, by rwa [succ_nth_fr_eq_zero] at this,
+  calc
+    ifp_n_fr⁻¹ = fract ifp_n_fr⁻¹ + ⌊ifp_n_fr⁻¹⌋ : by rw (fract_add_floor ifp_n_fr⁻¹)
+           ... = ⌊ifp_n_fr⁻¹⌋                    : by simp [‹fract ifp_n_fr⁻¹ = 0›]
+end
+
+end int_fract_pair
+
+section head
+/-!
+### Translation of The Head Term
+
+Here we give some basic translations that between the various methods that return the head term of
+the continued fraction computed for a value.
+-/
+
+/- The head term of the sequence with head of `v` is just the integer part of `v`. -/
+@[simp]
+lemma int_fract_pair.seq1_fst_eq_of : (int_fract_pair.seq1 v).fst = int_fract_pair.of v := rfl
+
+lemma of_h_eq_int_fract_pair_seq1_fst_b : (gcf.of v).h = (int_fract_pair.seq1 v).fst.b :=
+by { cases aux_seq_eq : (int_fract_pair.seq1 v), simp [gcf.of, aux_seq_eq] }
+
+/- The head term of the gcf of `v` is ⌊v⌋. -/
+@[simp]
+lemma of_h_eq_floor : (gcf.of v).h = ⌊v⌋ :=
+by simp [of_h_eq_int_fract_pair_seq1_fst_b, int_fract_pair.of]
+
+end head
+
+section sequence
+/-!
+### Translation of The Sequence
+
+Here we give some basic translations that between the various methods that return the sequence part
+of the continued fraction computed for a value.
+-/
+
+variable {n : ℕ}
+
+lemma int_fract_pair.nth_seq1_eq_succ_nth_stream :
+  (int_fract_pair.seq1 v).snd.nth n = (int_fract_pair.stream v) (n + 1) := rfl
+
+section termination
+/-!
+#### Translation of The Termination of The Sequence
+-/
+
+lemma of_terminated_at_iff_int_fract_pair_seq1_terminated_at :
+  (gcf.of v).terminated_at n ↔ (int_fract_pair.seq1 v).snd.terminated_at n :=
+begin
+  rw [gcf.terminated_at_iff_s_none, gcf.of],
+  rcases (int_fract_pair.seq1 v) with ⟨head, ⟨st⟩⟩,
+  cases st_n_eq : st n;
+  simp [gcf.of, st_n_eq, seq.map, seq.nth, stream.map, seq.terminated_at, stream.nth]
+end
+
+lemma of_terminated_at_n_iff_succ_nth_int_fract_pair_stream_eq_none :
+  (gcf.of v).terminated_at n ↔ int_fract_pair.stream v (n + 1) = none :=
+by rw [of_terminated_at_iff_int_fract_pair_seq1_terminated_at, seq.terminated_at,
+  int_fract_pair.nth_seq1_eq_succ_nth_stream]
+
+end termination
+
+section values
+/-!
+#### Translation of The Values of The Sequence
+-/
+
+lemma nth_of_eq_some_of_succ_nth_int_fract_pair_stream {ifp_succ_n : int_fract_pair α}
+  (stream_succ_nth_eq : int_fract_pair.stream v (n + 1) = some ifp_succ_n) :
+  (gcf.of v).s.nth n = some ⟨1, ifp_succ_n.b⟩ :=
+begin
+  unfold gcf.of int_fract_pair.seq1,
+  rw [seq.map_tail, seq.nth_tail, seq.map_nth],
+  simp [seq.nth, stream_succ_nth_eq]
+end
+
+lemma int_fract_pair.obtain_succ_nth_stream_of_gcf_of_nth_eq_some {gp_n : gcf.pair α}
+  (s_nth_eq : (gcf.of v).s.nth n = some gp_n) :
+  ∃ (ifp : int_fract_pair α), int_fract_pair.stream v (n + 1) = some ifp ∧ (ifp.b : α) = gp_n.b :=
+begin
+  obtain ⟨ifp, stream_succ_nth_eq, gp_n_eq⟩ :
+    ∃ ifp, int_fract_pair.stream v (n + 1) = some ifp ∧ gcf.pair.mk 1 (ifp.b : α) = gp_n, by
+    { unfold gcf.of int_fract_pair.seq1 at s_nth_eq,
+      rwa [seq.map_tail, seq.nth_tail, seq.map_nth, option.map_eq_some'] at s_nth_eq },
+  cases gp_n_eq,
+  injection gp_n_eq with _ ifp_b_eq_gp_n_b,
+  existsi ifp,
+  exact ⟨stream_succ_nth_eq, ifp_b_eq_gp_n_b⟩
+end
+
+lemma nth_of_eq_some_of_nth_int_fract_pair_stream_fr_ne_zero {ifp_n : int_fract_pair α}
+  (stream_nth_eq : int_fract_pair.stream v n = some ifp_n) (nth_fr_ne_zero : ifp_n.fr ≠ 0) :
+  (gcf.of v).s.nth n = some ⟨1, (int_fract_pair.of ifp_n.fr⁻¹).b⟩ :=
+have int_fract_pair.stream v (n + 1) = some (int_fract_pair.of ifp_n.fr⁻¹), by
+  { cases ifp_n, simp [int_fract_pair.stream, stream_nth_eq, nth_fr_ne_zero], refl },
+nth_of_eq_some_of_succ_nth_int_fract_pair_stream this
+
+end values
+end sequence
+end generalized_continued_fraction

--- a/src/algebra/continued_fractions/computation/translations.lean
+++ b/src/algebra/continued_fractions/computation/translations.lean
@@ -17,7 +17,7 @@ Some simple translation lemmas between the different structures used for the com
 namespace generalized_continued_fraction
 open generalized_continued_fraction as gcf
 
-/-- Fix a discrete linear order floor field and a value `v`. -/
+/-- Fix a discrete linear ordered floor field and a value `v`. -/
 variables {K : Type*} [discrete_linear_ordered_field K] [floor_ring K] {v : K}
 
 namespace int_fract_pair

--- a/src/algebra/continued_fractions/default.lean
+++ b/src/algebra/continued_fractions/default.lean
@@ -6,6 +6,7 @@ Authors: Kevin Kappelmann
 import algebra.continued_fractions.continuants_recurrence
 import algebra.continued_fractions.terminated_stable
 import algebra.continued_fractions.convergents_equiv
+import algebra.continued_fractions.computation
 /-!
 # Default Exports for Continued Fractions
 -/


### PR DESCRIPTION
### What
- add definitions of the computation of a continued fraction for a given value (in a given floor field)
- add very basic, mostly technical lemmas to convert between the different structures used by the computation

### Why
- I want to be able to compute the continued fraction of a value. I next will add termination, approximation, and correctness lemmas for the definitions in this commit (I already have them lying around on my PC for ages :cold_sweat: )
- The technical lemmas are needed for the next bunch of commits.

### How
- Follow the straightforward approach as described, for example, on [Wikipedia](https://en.wikipedia.org/wiki/Continued_fraction#Calculating_continued_fraction_representations)