### PR TITLE
[Merged by Bors] - fix(tactic/norm_num): workaround int.sub unfolding bug

### DIFF
--- a/src/tactic/norm_num.lean
+++ b/src/tactic/norm_num.lean
@@ -537,6 +537,15 @@ do na ← a.to_nat, nb ← b.to_nat,
     (ic, p) ← prove_add_nat ic a c b,
     return (`(0 : ℕ), `(sub_nat_neg).mk_app [a, b, c, p])
 
+/-- This is needed because when `a` and `b` are numerals lean is more likely to unfold them
+than unfold the instances in order to prove that `add_group_has_sub = int.has_add`. -/
+theorem int_sub_hack (a b c : ℤ) (h : @has_sub.sub ℤ add_group_has_sub a b = c) : a - b = c := h
+
+/-- Given `a : int`,`b : int` integral numerals, returns `(c, ⊢ a - b = c)`. -/
+meta def prove_sub_int (ic : instance_cache) (a b : expr) : tactic (expr × expr) :=
+do (_, c, p) ← prove_sub ic a b,
+  return (c, `(int_sub_hack).mk_app [a, b, c, p])
+
 /-- Evaluates the basic field operations `+`,`neg`,`-`,`*`,`inv`,`/` on numerals.
 Also handles nat subtraction. Does not do recursive simplification; that is,
 `1 + 1 + 1` will not simplify but `2 + 1` will. This is handled by the top level
@@ -556,10 +565,10 @@ meta def eval_field : expr → tactic (expr × expr)
 | `(- %%e) := do
   c ← infer_type e >>= mk_instance_cache,
   prod.snd <$> prove_neg c e
-| `(%%a - %%b) := do
-  α ← infer_type a,
+| `(@has_sub.sub %%α %%inst %%a %%b) := do
   c ← mk_instance_cache α,
   if α = `(nat) then prove_sub_nat c a b
+  else if inst = `(int.has_sub) then prove_sub_int c a b
   else prod.snd <$> prove_sub c a b
 | `(has_inv.inv %%e) := do
   n ← e.to_rat,

--- a/src/tactic/norm_num.lean
+++ b/src/tactic/norm_num.lean
@@ -538,7 +538,7 @@ do na ← a.to_nat, nb ← b.to_nat,
     return (`(0 : ℕ), `(sub_nat_neg).mk_app [a, b, c, p])
 
 /-- This is needed because when `a` and `b` are numerals lean is more likely to unfold them
-than unfold the instances in order to prove that `add_group_has_sub = int.has_add`. -/
+than unfold the instances in order to prove that `add_group_has_sub = int.has_sub`. -/
 theorem int_sub_hack (a b c : ℤ) (h : @has_sub.sub ℤ add_group_has_sub a b = c) : a - b = c := h
 
 /-- Given `a : int`,`b : int` integral numerals, returns `(c, ⊢ a - b = c)`. -/

--- a/src/tactic/norm_num.lean
+++ b/src/tactic/norm_num.lean
@@ -541,7 +541,7 @@ do na ← a.to_nat, nb ← b.to_nat,
 than unfold the instances in order to prove that `add_group_has_sub = int.has_sub`. -/
 theorem int_sub_hack (a b c : ℤ) (h : @has_sub.sub ℤ add_group_has_sub a b = c) : a - b = c := h
 
-/-- Given `a : int`,`b : int` integral numerals, returns `(c, ⊢ a - b = c)`. -/
+/-- Given `a : ℤ`, `b : ℤ` integral numerals, returns `(c, ⊢ a - b = c)`. -/
 meta def prove_sub_int (ic : instance_cache) (a b : expr) : tactic (expr × expr) :=
 do (_, c, p) ← prove_sub ic a b,
   return (c, `(int_sub_hack).mk_app [a, b, c, p])

--- a/test/norm_num.lean
+++ b/test/norm_num.lean
@@ -48,6 +48,7 @@ example : (5 / -2:ℤ) < -1 := by norm_num
 example : (0 + 1) / 2 < 0 + 1 := by norm_num
 example : nat.succ (nat.succ (2 ^ 3)) = 10 := by norm_num
 example : 10 = (-1 : ℤ) % 11 := by norm_num
+example : (12321 - 2 : ℤ) = 12319 := by norm_num
 
 example (x : ℤ) (h : 1000 + 2000 < x) : 100 * 30 < x :=
 by norm_num at *; try_for 100 {exact h}


### PR DESCRIPTION
Fixes https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/certificates.20for.20calculations/near/198631936 . Or rather, it works around an issue in how the kernel unfolds applications. The real fix is probably to adjust the definitional height or other heuristics around `add_group_has_sub` and `int.sub` so that tries to prove that they are defeq that way rather than unfolding `bit0` and `bit1`. Here is a MWE for the issue:

```lean
example : int.has_sub = add_group_has_sub := rfl

example :
  (@has_sub.sub ℤ int.has_sub 5000 2 : ℤ) =
  (@has_sub.sub ℤ add_group_has_sub 5000 2) := rfl -- deep recursion
```