### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/add_torsor): normed_add_torsor

### DIFF
--- a/src/algebra/add_torsor.lean
+++ b/src/algebra/add_torsor.lean
@@ -74,6 +74,16 @@ instance add_group_is_add_torsor (G : Type*) [add_group G] :
   vsub_vadd' := sub_add_cancel,
   vadd_vsub' := add_sub_cancel }
 
+/-- Simplify addition for a torsor for an `add_group G` over
+itself. -/
+@[simp] lemma vadd_eq_add (G : Type*) [add_group G] (g1 g2 : G) : g1 +ᵥ g2 = g1 + g2 :=
+rfl
+
+/-- Simplify subtraction for a torsor for an `add_group G` over
+itself. -/
+@[simp] lemma vsub_eq_sub (G : Type*) [add_group G] (g1 g2 : G) : g1 -ᵥ g2 = g1 - g2 :=
+rfl
+
 namespace add_action
 
 section general

--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -11,54 +11,28 @@ noncomputable theory
 /-!
 # Torsors of additive normed group actions.
 
-This file defines torsors of additive normed group actions and the
-metric space structure on them.  The motivating case is Euclidean
-affine spaces.
+This file defines torsors of additive normed group actions, with a
+metric space structure.  The motivating case is Euclidean affine
+spaces.
 
 -/
 
 section prio
 set_option default_priority 100 -- see Note [default priority]
 /-- A `normed_add_torsor V P` is a torsor of an additive normed group
-action by a `normed_group V` on points `P`. We bundle the distance and
-require it to be the same as results from the norm. -/
-class normed_add_torsor (V : Type*) (P : Type*) [normed_group V] [has_dist P]
+action by a `normed_group V` on points `P`. We bundle the metric space
+structure and require the distance to be the same as results from the
+norm (which in fact implies the distance yields a metric space, but
+bundling just the distance and using an instance for the metric space
+results in type class problems). -/
+class normed_add_torsor (V : Type*) (P : Type*) [normed_group V] [metric_space P]
   extends add_torsor V P :=
 (norm_dist' : ∀ (x y : P), dist x y = ∥(x -ᵥ y : V)∥)
 end prio
 
 /-- The distance equals the norm of subtracting two points. This lemma
 is needed to make V an explicit rather than implicit argument. -/
-lemma norm_dist (V : Type*) {P : Type*} [normed_group V] [has_dist P] [normed_add_torsor V P]
+lemma norm_dist (V : Type*) {P : Type*} [normed_group V] [metric_space P] [normed_add_torsor V P]
     (x y : P) :
   dist x y = ∥(x -ᵥ y : V)∥ :=
 normed_add_torsor.norm_dist' x y
-
-variables (V : Type*) {P : Type*} [normed_group V] [has_dist P] [normed_add_torsor V P]
-include V
-
-open add_torsor
-
-/-- The distance defines a metric space structure on the torsor. -/
-@[priority 100] -- see Note [lower instance priority]
-instance normed_add_torsor_is_metric_space : metric_space P :=
-{ dist_self := begin
-    intro p,
-    rw [norm_dist V p p, vsub_self, norm_zero]
-  end,
-  eq_of_dist_eq_zero := begin
-    intros p1 p2 h,
-    rw [norm_dist V p1 p2, norm_eq_zero] at h,
-    exact eq_of_vsub_eq_zero V h
-  end,
-  dist_comm := begin
-    intros x y,
-    rw [norm_dist V x y, norm_dist V y x],
-    convert norm_neg (y -ᵥ x),
-    exact (neg_vsub_eq_vsub_rev V y x).symm
-  end,
-  dist_triangle := begin
-    intros x y z,
-    rw [norm_dist V x y, norm_dist V y z, norm_dist V x z, ←vsub_add_vsub_cancel],
-    apply norm_add_le
-  end }

--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -40,7 +40,7 @@ lemma dist_eq_norm (V : Type u) {P : Type v} [normed_group V] [metric_space P]
 normed_add_torsor.torsor_dist_eq_norm' x y
 
 /-- A `normed_group` is a `normed_add_torsor` over itself. -/
-instance normed_group_is_normed_add_torsor (V : Type u) [normed_group V] :
+instance normed_group.normed_add_torsor (V : Type u) [normed_group V] :
   normed_add_torsor V V :=
 { torsor_dist_eq_norm' := dist_eq_norm }
 

--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -17,6 +17,8 @@ spaces.
 
 -/
 
+universes u v
+
 section prio
 set_option default_priority 100 -- see Note [default priority]
 /-- A `normed_add_torsor V P` is a torsor of an additive normed group
@@ -25,42 +27,34 @@ structure and require the distance to be the same as results from the
 norm (which in fact implies the distance yields a metric space, but
 bundling just the distance and using an instance for the metric space
 results in type class problems). -/
-class normed_add_torsor (V : Type*) (P : Type*) [normed_group V] [metric_space P]
+class normed_add_torsor (V : Type u) (P : Type v) [normed_group V] [metric_space P]
   extends add_torsor V P :=
 (torsor_dist_eq_norm' : ∀ (x y : P), dist x y = ∥(x -ᵥ y : V)∥)
 end prio
 
 /-- The distance equals the norm of subtracting two points. This lemma
 is needed to make V an explicit rather than implicit argument. -/
-lemma torsor_dist_eq_norm (V : Type*) {P : Type*} [normed_group V] [metric_space P]
+lemma torsor_dist_eq_norm (V : Type u) {P : Type v} [normed_group V] [metric_space P]
     [normed_add_torsor V P] (x y : P) :
   dist x y = ∥(x -ᵥ y : V)∥ :=
 normed_add_torsor.torsor_dist_eq_norm' x y
+
+/-- A `normed_group` is a `normed_add_torsor` over itself. -/
+instance normed_group_is_normed_add_torsor (V : Type u) [normed_group V] :
+  normed_add_torsor V V :=
+{ torsor_dist_eq_norm' := dist_eq_norm }
 
 open add_torsor
 
 /-- The distance defines a metric space structure on the torsor. This
 is not an instance because it depends on `V` to define a `metric_space
 P`. -/
-def metric_space_of_normed_group_of_add_torsor (V : Type*) (P : Type*) [normed_group V]
+def metric_space_of_normed_group_of_add_torsor (V : Type u) (P : Type v) [normed_group V]
     [add_torsor V P] : metric_space P :=
 { dist := λ x y, ∥(x -ᵥ y : V)∥,
-  dist_self := begin
-    intro p,
-    change ∥p -ᵥ p∥ = 0,
-    rw [vsub_self, norm_zero]
-  end,
-  eq_of_dist_eq_zero := begin
-    intros p1 p2 h,
-    rw norm_eq_zero at h,
-    exact eq_of_vsub_eq_zero V h
-  end,
-  dist_comm := begin
-    intros x y,
-    change ∥x -ᵥ y∥ = ∥y -ᵥ x∥,
-    convert norm_neg (y -ᵥ x),
-    exact (neg_vsub_eq_vsub_rev V y x).symm
-  end,
+  dist_self := λ x, by simp,
+  eq_of_dist_eq_zero := λ x y h, by simpa using h,
+  dist_comm := λ x y, by simp only [←neg_vsub_eq_vsub_rev V y x, norm_neg],
   dist_triangle := begin
     intros x y z,
     change ∥x -ᵥ z∥ ≤ ∥x -ᵥ y∥ + ∥y -ᵥ z∥,

--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -36,3 +36,34 @@ lemma norm_dist (V : Type*) {P : Type*} [normed_group V] [metric_space P] [norme
     (x y : P) :
   dist x y = ∥(x -ᵥ y : V)∥ :=
 normed_add_torsor.norm_dist' x y
+
+open add_torsor
+
+/-- The distance defines a metric space structure on the torsor. This
+is not an instance because it depends on `V` to define a `metric_space
+P`. -/
+def metric_space_of_normed_group_of_add_torsor (V : Type*) (P : Type*) [normed_group V]
+    [add_torsor V P] : metric_space P :=
+{ dist := λ x y, ∥(x -ᵥ y : V)∥,
+  dist_self := begin
+    intro p,
+    change ∥p -ᵥ p∥ = 0,
+    rw [vsub_self, norm_zero]
+  end,
+  eq_of_dist_eq_zero := begin
+    intros p1 p2 h,
+    rw norm_eq_zero at h,
+    exact eq_of_vsub_eq_zero V h
+  end,
+  dist_comm := begin
+    intros x y,
+    change ∥x -ᵥ y∥ = ∥y -ᵥ x∥,
+    convert norm_neg (y -ᵥ x),
+    exact (neg_vsub_eq_vsub_rev V y x).symm
+  end,
+  dist_triangle := begin
+    intros x y z,
+    change ∥x -ᵥ z∥ ≤ ∥x -ᵥ y∥ + ∥y -ᵥ z∥,
+    rw ←vsub_add_vsub_cancel,
+    apply norm_add_le
+  end }

--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -34,7 +34,7 @@ end prio
 
 /-- The distance equals the norm of subtracting two points. This lemma
 is needed to make V an explicit rather than implicit argument. -/
-lemma torsor_dist_eq_norm (V : Type u) {P : Type v} [normed_group V] [metric_space P]
+lemma dist_eq_norm (V : Type u) {P : Type v} [normed_group V] [metric_space P]
     [normed_add_torsor V P] (x y : P) :
   dist x y = ∥(x -ᵥ y : V)∥ :=
 normed_add_torsor.torsor_dist_eq_norm' x y

--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -27,15 +27,15 @@ bundling just the distance and using an instance for the metric space
 results in type class problems). -/
 class normed_add_torsor (V : Type*) (P : Type*) [normed_group V] [metric_space P]
   extends add_torsor V P :=
-(norm_dist' : ∀ (x y : P), dist x y = ∥(x -ᵥ y : V)∥)
+(torsor_dist_eq_norm' : ∀ (x y : P), dist x y = ∥(x -ᵥ y : V)∥)
 end prio
 
 /-- The distance equals the norm of subtracting two points. This lemma
 is needed to make V an explicit rather than implicit argument. -/
-lemma norm_dist (V : Type*) {P : Type*} [normed_group V] [metric_space P] [normed_add_torsor V P]
-    (x y : P) :
+lemma torsor_dist_eq_norm (V : Type*) {P : Type*} [normed_group V] [metric_space P]
+    [normed_add_torsor V P] (x y : P) :
   dist x y = ∥(x -ᵥ y : V)∥ :=
-normed_add_torsor.norm_dist' x y
+normed_add_torsor.torsor_dist_eq_norm' x y
 
 open add_torsor
 

--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -34,15 +34,15 @@ end prio
 
 /-- The distance equals the norm of subtracting two points. This lemma
 is needed to make V an explicit rather than implicit argument. -/
-lemma dist_eq_norm (V : Type u) {P : Type v} [normed_group V] [metric_space P]
+lemma add_torsor.dist_eq_norm (V : Type u) {P : Type v} [normed_group V] [metric_space P]
     [normed_add_torsor V P] (x y : P) :
   dist x y = ∥(x -ᵥ y : V)∥ :=
-normed_add_torsor.torsor_dist_eq_norm' x y
+normed_add_torsor.dist_eq_norm' x y
 
 /-- A `normed_group` is a `normed_add_torsor` over itself. -/
 instance normed_group.normed_add_torsor (V : Type u) [normed_group V] :
   normed_add_torsor V V :=
-{ torsor_dist_eq_norm' := dist_eq_norm }
+{ dist_eq_norm' := dist_eq_norm }
 
 open add_torsor
 

--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -39,8 +39,7 @@ include V
 
 open add_torsor
 
-/-- The distance defines a metric space structure on the affine
-space. -/
+/-- The distance defines a metric space structure on the torsor. -/
 @[priority 100] -- see Note [lower instance priority]
 instance normed_add_torsor_is_metric_space : metric_space P :=
 { dist_self := begin

--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2020 Joseph Myers. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Joseph Myers.
+-/
+import algebra.add_torsor
+import analysis.normed_space.basic
+
+noncomputable theory
+
+/-!
+# Torsors of additive normed group actions.
+
+This file defines torsors of additive normed group actions and the
+metric space structure on them.  The motivating case is Euclidean
+affine spaces.
+
+-/
+
+section prio
+set_option default_priority 100 -- see Note [default priority]
+/-- A `normed_add_torsor V P` is a torsor of an additive normed group
+action by a `normed_group V` on points `P`. We bundle the distance and
+require it to be the same as results from the norm. -/
+class normed_add_torsor (V : Type*) (P : Type*) [normed_group V] [has_dist P]
+  extends add_torsor V P :=
+(norm_dist' : ∀ (x y : P), dist x y = ∥(x -ᵥ y : V)∥)
+end prio
+
+/-- The distance equals the norm of subtracting two points. This lemma
+is needed to make V an explicit rather than implicit argument. -/
+lemma norm_dist (V : Type*) {P : Type*} [normed_group V] [has_dist P] [normed_add_torsor V P]
+    (x y : P) :
+  dist x y = ∥(x -ᵥ y : V)∥ :=
+normed_add_torsor.norm_dist' x y
+
+variables (V : Type*) {P : Type*} [normed_group V] [has_dist P] [normed_add_torsor V P]
+include V
+
+open add_torsor
+
+/-- The distance defines a metric space structure on the affine
+space. -/
+@[priority 100] -- see Note [lower instance priority]
+instance normed_add_torsor_is_metric_space : metric_space P :=
+{ dist_self := begin
+    intro p,
+    rw [norm_dist V p p, vsub_self, norm_zero]
+  end,
+  eq_of_dist_eq_zero := begin
+    intros p1 p2 h,
+    rw [norm_dist V p1 p2, norm_eq_zero] at h,
+    exact eq_of_vsub_eq_zero V h
+  end,
+  dist_comm := begin
+    intros x y,
+    rw [norm_dist V x y, norm_dist V y x],
+    convert norm_neg (y -ᵥ x),
+    exact (neg_vsub_eq_vsub_rev V y x).symm
+  end,
+  dist_triangle := begin
+    intros x y z,
+    rw [norm_dist V x y, norm_dist V y z, norm_dist V x z, ←vsub_add_vsub_cancel],
+    apply norm_add_le
+  end }

--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -29,7 +29,7 @@ bundling just the distance and using an instance for the metric space
 results in type class problems). -/
 class normed_add_torsor (V : Type u) (P : Type v) [normed_group V] [metric_space P]
   extends add_torsor V P :=
-(torsor_dist_eq_norm' : ∀ (x y : P), dist x y = ∥(x -ᵥ y : V)∥)
+(dist_eq_norm' : ∀ (x y : P), dist x y = ∥(x -ᵥ y : V)∥)
 end prio
 
 /-- The distance equals the norm of subtracting two points. This lemma

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -141,7 +141,7 @@ by simpa only [dist_add_left, dist_add_right, dist_comm h₂]
 @[simp] lemma norm_nonneg (g : α) : 0 ≤ ∥g∥ :=
 by { rw[←dist_zero_right], exact dist_nonneg }
 
-lemma norm_eq_zero {g : α} : ∥g∥ = 0 ↔ g = 0 :=
+@[simp] lemma norm_eq_zero {g : α} : ∥g∥ = 0 ↔ g = 0 :=
 dist_zero_right g ▸ dist_eq_zero
 
 @[simp] lemma norm_zero : ∥(0:α)∥ = 0 := norm_eq_zero.2 rfl


### PR DESCRIPTION
Define the metric space structure on torsors of additive normed group
actions.  The motivating case is Euclidean affine spaces.

See
https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Some.20olympiad.20formalisations
for the discussion leading to this particular handling of the
distance.

Note: I'm not sure what the right way is to address the
dangerous_instance linter error "The following arguments become
metavariables. argument 1: (V : Type u_1)".