### PR TITLE
[Merged by Bors] - fix(tactic/suggest): normalize synonyms uniformly in goal and lemma

### DIFF
--- a/test/library_search/basic.lean
+++ b/test/library_search/basic.lean
@@ -70,9 +70,50 @@ by library_search -- says: `exact add_pos ha hb`
 example (a b : ℕ) : 0 < a → 0 < b → 0 < a + b :=
 by library_search -- says: `exact add_pos`
 
+section synonym
+
+-- Synonym `>` for `<` in the goal
+example (a b : ℕ) : 0 < a → 0 < b → a + b > 0 :=
+by library_search -- says: `exact add_pos`
+
+-- Synonym `>` for `<` in another part of the goal
+example (a b : ℕ) : a > 0 → 0 < b → 0 < a + b :=
+by library_search -- says: `exact add_pos`
+
+-- Synonym `>` for `<` in another part of the goal
+example (a b : ℕ) (ha : a > 0) (hb : 0 < b) : 0 < a + b :=
+by library_search -- says: `exact add_pos ha hb`
+
 example (a b : ℕ) (h : a ∣ b) (w : b > 0) : a ≤ b :=
 by library_search -- says: `exact nat.le_of_dvd w h`
 
+example (a b : ℕ) (h : a ∣ b) (w : b > 0) : b ≥ a :=
+by library_search -- says: `exact nat.le_of_dvd w h`
+
+-- A lemma with head symbol `¬` can be used to prove `¬ p` or `⊥`
+example (a : ℕ) : ¬ (a < 0) := by library_search -- says `exact not_lt_bot`
+
+example (a : ℕ) (h : a < 0) : false := by library_search -- says `exact not_lt_bot h`
+
+def P : ℕ → Prop := λ _, sorry
+
+-- This lemma with `>` as its head symbol should also be found for goals with head symbol `<`.
+lemma lemma_with_gt_in_head (a : ℕ) : P a → 0 > a := sorry
+
+example (a : ℕ) (h : P a) : 0 > a := by library_search -- says `exact lemma_with_gt_in_head a h`
+
+example (a : ℕ) (h : P a) : a < 0 := by library_search -- says `exact lemma_with_gt_in_head a h`
+
+lemma lemma_with_false_in_head (a b : ℕ) (h1 : a < b) (h2 : P a) : false := sorry
+
+set_option trace.silence_library_search false
+example (a b : ℕ) (h1 : a < b) (h2 : P a) : false := by library_search
+-- says `exact lemma_with_false_in_head a b h1 h2`
+
+example (a b : ℕ) (h1 : a < b) : ¬ (P a) := by library_search
+-- says `exact lemma_with_false_in_head a b h1`
+
+end synonym
 
 -- We even find `iff` results:
 

--- a/test/library_search/basic.lean
+++ b/test/library_search/basic.lean
@@ -95,18 +95,22 @@ example (a : ℕ) : ¬ (a < 0) := by library_search -- says `exact not_lt_bot`
 
 example (a : ℕ) (h : a < 0) : false := by library_search -- says `exact not_lt_bot h`
 
-def P : ℕ → Prop := λ _, sorry
+-- An inductive type hides the constructor's arguments enough
+-- so that `library_search` doesn't accidentally close the goal.
+inductive P : ℕ → Prop
+| gt_in_head {n : ℕ} : n < 0 → P n
 
 -- This lemma with `>` as its head symbol should also be found for goals with head symbol `<`.
-lemma lemma_with_gt_in_head (a : ℕ) : P a → 0 > a := sorry
+lemma lemma_with_gt_in_head (a : ℕ) (h : P a) : 0 > a := by { cases h, assumption }
+
+-- This lemma with `false` as its head symbols should also be found for goals with head symbol `¬`.
+lemma lemma_with_false_in_head (a b : ℕ) (h1 : a < b) (h2 : P a) : false :=
+by { apply nat.not_lt_zero, cases h2, assumption }
 
 example (a : ℕ) (h : P a) : 0 > a := by library_search -- says `exact lemma_with_gt_in_head a h`
 
 example (a : ℕ) (h : P a) : a < 0 := by library_search -- says `exact lemma_with_gt_in_head a h`
 
-lemma lemma_with_false_in_head (a b : ℕ) (h1 : a < b) (h2 : P a) : false := sorry
-
-set_option trace.silence_library_search false
 example (a b : ℕ) (h1 : a < b) (h2 : P a) : false := by library_search
 -- says `exact lemma_with_false_in_head a b h1 h2`
 


### PR DESCRIPTION
This change is intended to make `library_search` and `suggest` a bit more robust in unfolding the types of the goal and lemma in order to determine which lemmas it will try to apply.

Before, there were two ad-hoc systems to map a head symbol to the name(s) that it should match, now there is only one ad-hoc function that does so.  As a consequence, `library_search` should be able to use a lemma with return type `a > b` to close the goal `b < a`, and use `lemma foo : p → false` to close the goal `¬ p`.
(The `>` normalization shouldn't "really" be needed if we all strictly followed the `gt_or_ge` linter but we don't and the failure has already caused confusion.)

[Discussion on Zulip starts here](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/How.20to.20get.20familiar.20enough.20with.20Mathlib.20to.20use.20it/near/198746479)