### PR TITLE
[Merged by Bors] - chore(data/equiv/basic): simplify some defs, add `coe` lemmas

### DIFF
--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -96,15 +96,23 @@ protected def cast {α β : Sort*} (h : α = β) : α ≃ β :=
 @[simp] theorem coe_fn_symm_mk (f : α → β) (g l r) : ((equiv.mk f g l r).symm : β → α) = g :=
 rfl
 
-@[simp] theorem refl_apply (x : α) : equiv.refl α x = x := rfl
+@[simp] theorem coe_refl : ⇑(equiv.refl α) = id := rfl
 
-@[simp] theorem trans_apply (f : α ≃ β) (g : β ≃ γ) (a : α) : (f.trans g) a = g (f a) := rfl
+theorem refl_apply (x : α) : equiv.refl α x = x := rfl
 
-@[simp] theorem apply_symm_apply : ∀ (e : α ≃ β) (x : β), e (e.symm x) = x
-| ⟨f₁, g₁, l₁, r₁⟩ x := by { simp [equiv.symm], rw r₁ }
+@[simp] theorem coe_trans (f : α ≃ β) (g : β ≃ γ) : ⇑(f.trans g) = g ∘ f := rfl
 
-@[simp] theorem symm_apply_apply : ∀ (e : α ≃ β) (x : α), e.symm (e x) = x
-| ⟨f₁, g₁, l₁, r₁⟩ x := by { simp [equiv.symm], rw l₁ }
+theorem trans_apply (f : α ≃ β) (g : β ≃ γ) (a : α) : (f.trans g) a = g (f a) := rfl
+
+@[simp] theorem apply_symm_apply  (e : α ≃ β) (x : β) : e (e.symm x) = x :=
+e.right_inv x
+
+@[simp] theorem symm_apply_apply (e : α ≃ β) (x : α) : e.symm (e x) = x :=
+e.left_inv x
+
+@[simp] theorem symm_comp_self (e : α ≃ β) : e.symm ∘ e = id := funext e.symm_apply_apply
+
+@[simp] theorem self_comp_symm (e : α ≃ β) : e ∘ e.symm = id := funext e.apply_symm_apply
 
 @[simp] lemma symm_trans_apply (f : α ≃ β) (g : β ≃ γ) (a : γ) :
   (f.trans g).symm a = f.symm (g.symm a) := rfl
@@ -295,6 +303,7 @@ rfl
   (arrow_congr' e₁ e₂).symm = arrow_congr' e₁.symm e₂.symm :=
 rfl
 
+/-- Conjugate a map `f : α → α` by an equivalence `α ≃ β`. -/
 def conj (e : α ≃ β) : (α → α) ≃ (β → β) := arrow_congr e e
 
 @[simp] lemma conj_apply (e : α ≃ β) (f : α → α) (x : β) :
@@ -339,77 +348,87 @@ calc (false → α) ≃ (empty → α) : arrow_congr false_equiv_empty (equiv.re
 
 end
 
-@[congr] def prod_congr {α₁ β₁ α₂ β₂ : Sort*} (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) : α₁ × β₁ ≃ α₂ × β₂ :=
-⟨λp, (e₁ p.1, e₂ p.2), λp, (e₁.symm p.1, e₂.symm p.2),
-   λ ⟨a, b⟩, show (e₁.symm (e₁ a), e₂.symm (e₂ b)) = (a, b), by rw [symm_apply_apply, symm_apply_apply],
-   λ ⟨a, b⟩, show (e₁ (e₁.symm a), e₂ (e₂.symm b)) = (a, b), by rw [apply_symm_apply, apply_symm_apply]⟩
+/-- Product of two equivalences. If `α₁ ≃ α₂` and `β₁ ≃ β₂`, then `α₁ × β₁ ≃ α₂ × β₂`. -/
+@[congr] def prod_congr {α₁ β₁ α₂ β₂ : Type*} (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) : α₁ × β₁ ≃ α₂ × β₂ :=
+⟨prod.map e₁ e₂, prod.map e₁.symm e₂.symm, λ ⟨a, b⟩, by simp, λ ⟨a, b⟩, by simp⟩
 
-@[simp] theorem prod_congr_apply {α₁ β₁ α₂ β₂ : Sort*} (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) (a : α₁) (b : β₁) :
-  prod_congr e₁ e₂ (a, b) = (e₁ a, e₂ b) :=
+@[simp] theorem coe_prod_congr {α₁ β₁ α₂ β₂ : Type*} (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) :
+  ⇑(prod_congr e₁ e₂) = prod.map e₁ e₂ :=
 rfl
 
-def prod_comm (α β : Sort*) : α × β ≃ β × α :=
-⟨λ p, (p.2, p.1), λ p, (p.2, p.1), λ⟨a, b⟩, rfl, λ⟨a, b⟩, rfl⟩
+@[simp] theorem prod_congr_symm {α₁ β₁ α₂ β₂ : Type*} (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) :
+  (prod_congr e₁ e₂).symm = prod_congr e₁.symm e₂.symm :=
+rfl
 
-@[simp] lemma prod_comm_apply {α β} (a b) : prod_comm α β ⟨a, b⟩ = ⟨b, a⟩ := rfl
+/-- Type product is commutative up to an equivalence: `α × β ≃ β × α`. -/
+def prod_comm (α β : Type*) : α × β ≃ β × α :=
+⟨prod.swap, prod.swap, λ⟨a, b⟩, rfl, λ⟨a, b⟩, rfl⟩
 
+@[simp] lemma coe_prod_comm (α β) : ⇑(prod_comm α β)= prod.swap := rfl
+
+@[simp] lemma prod_comm_symm (α β) : (prod_comm α β).symm = prod_comm β α := rfl
+
+/-- Type product is associative up to an equivalence. -/
 def prod_assoc (α β γ : Sort*) : (α × β) × γ ≃ α × (β × γ) :=
 ⟨λ p, ⟨p.1.1, ⟨p.1.2, p.2⟩⟩, λp, ⟨⟨p.1, p.2.1⟩, p.2.2⟩, λ ⟨⟨a, b⟩, c⟩, rfl, λ ⟨a, ⟨b, c⟩⟩, rfl⟩
 
 @[simp] theorem prod_assoc_apply {α β γ : Sort*} (p : (α × β) × γ) :
   prod_assoc α β γ p = ⟨p.1.1, ⟨p.1.2, p.2⟩⟩ := rfl
 
+@[simp] theorem prod_assoc_sym_apply {α β γ : Sort*} (p : α × (β × γ)) :
+  (prod_assoc α β γ).symm p = ⟨⟨p.1, p.2.1⟩, p.2.2⟩ := rfl
+
 section
-def prod_punit (α : Sort*) : α × punit.{u+1} ≃ α :=
+/-- `punit` is a right identity for type product up to an equivalence. -/
+def prod_punit (α : Type*) : α × punit.{u+1} ≃ α :=
 ⟨λ p, p.1, λ a, (a, punit.star), λ ⟨_, punit.star⟩, rfl, λ a, rfl⟩
 
 @[simp] theorem prod_punit_apply {α : Sort*} (a : α × punit.{u+1}) : prod_punit α a = a.1 := rfl
 
-def punit_prod (α : Sort*) : punit.{u+1} × α ≃ α :=
+/-- `punit` is a left identity for type product up to an equivalence. -/
+def punit_prod (α : Type*) : punit.{u+1} × α ≃ α :=
 calc punit × α ≃ α × punit : prod_comm _ _
            ... ≃ α         : prod_punit _
 
-@[simp] theorem punit_prod_apply {α : Sort*} (a : punit.{u+1} × α) : punit_prod α a = a.2 := rfl
+@[simp] theorem punit_prod_apply {α : Type*} (a : punit.{u+1} × α) : punit_prod α a = a.2 := rfl
 
-def prod_empty (α : Sort*) : α × empty ≃ empty :=
+/-- `empty` type is a right absorbing element for type product up to an equivalence. -/
+def prod_empty (α : Type*) : α × empty ≃ empty :=
 equiv_empty (λ ⟨_, e⟩, e.rec _)
 
-def empty_prod (α : Sort*) : empty × α ≃ empty :=
+/-- `empty` type is a left absorbing element for type product up to an equivalence. -/
+def empty_prod (α : Type*) : empty × α ≃ empty :=
 equiv_empty (λ ⟨e, _⟩, e.rec _)
 
-def prod_pempty (α : Sort*) : α × pempty ≃ pempty :=
+/-- `pempty` type is a right absorbing element for type product up to an equivalence. -/
+def prod_pempty (α : Type*) : α × pempty ≃ pempty :=
 equiv_pempty (λ ⟨_, e⟩, e.rec _)
 
-def pempty_prod (α : Sort*) : pempty × α ≃ pempty :=
+/-- `pempty` type is a left absorbing element for type product up to an equivalence. -/
+def pempty_prod (α : Type*) : pempty × α ≃ pempty :=
 equiv_pempty (λ ⟨e, _⟩, e.rec _)
 end
 
 section
 open sum
-def psum_equiv_sum (α β : Sort*) : psum α β ≃ α ⊕ β :=
+/-- `psum` is equivalent to `sum`. -/
+def psum_equiv_sum (α β : Type*) : psum α β ≃ α ⊕ β :=
 ⟨λ s, psum.cases_on s inl inr,
  λ s, sum.cases_on s psum.inl psum.inr,
  λ s, by cases s; refl,
  λ s, by cases s; refl⟩
 
-def sum_congr {α₁ β₁ α₂ β₂ : Sort*} : α₁ ≃ α₂ → β₁ ≃ β₂ → α₁ ⊕ β₁ ≃ α₂ ⊕ β₂
-| ⟨f₁, g₁, l₁, r₁⟩ ⟨f₂, g₂, l₂, r₂⟩ :=
-  ⟨λ s, match s with inl a₁ := inl (f₁ a₁) | inr b₁ := inr (f₂ b₁) end,
-   λ s, match s with inl a₂ := inl (g₁ a₂) | inr b₂ := inr (g₂ b₂) end,
-   λ s, match s with inl a := congr_arg inl (l₁ a) | inr a := congr_arg inr (l₂ a) end,
-   λ s, match s with inl a := congr_arg inl (r₁ a) | inr a := congr_arg inr (r₂ a) end⟩
+/-- If `α ≃ α'` and `β ≃ β'`, then `α ⊕ β ≃ α' ⊕ β'`. -/
+def sum_congr {α₁ β₁ α₂ β₂ : Type*} (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) : α₁ ⊕ β₁ ≃ α₂ ⊕ β₂ :=
+⟨sum.map ea eb, sum.map ea.symm eb.symm, λ x, by simp, λ x, by simp⟩
 
-@[simp] theorem sum_congr_apply_inl {α₁ β₁ α₂ β₂ : Sort*} (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) (a : α₁) :
-  sum_congr e₁ e₂ (inl a) = inl (e₁ a) :=
-by { cases e₁, cases e₂, refl }
+@[simp] theorem sum_congr_apply {α₁ β₁ α₂ β₂ : Type*} (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) (a : α₁ ⊕ β₁) :
+  sum_congr e₁ e₂ a = a.map e₁ e₂ :=
+rfl
 
-@[simp] theorem sum_congr_apply_inr {α₁ β₁ α₂ β₂ : Sort*} (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) (b : β₁) :
-  sum_congr e₁ e₂ (inr b) = inr (e₂ b) :=
-by { cases e₁, cases e₂, refl }
-
-@[simp] lemma sum_congr_symm {α β γ δ : Type u} (e : α ≃ β) (f : γ ≃ δ) (x) :
-  (equiv.sum_congr e f).symm x = (equiv.sum_congr (e.symm) (f.symm)) x :=
-by { cases e, cases f, cases x; refl }
+@[simp] lemma sum_congr_symm {α β γ δ : Type u} (e : α ≃ β) (f : γ ≃ δ) :
+  (equiv.sum_congr e f).symm = (equiv.sum_congr (e.symm) (f.symm)) :=
+rfl
 
 def bool_equiv_punit_sum_punit : bool ≃ punit.{u+1} ⊕ punit.{v+1} :=
 ⟨λ b, cond b (inr punit.star) (inl punit.star),
@@ -421,28 +440,27 @@ noncomputable def Prop_equiv_bool : Prop ≃ bool :=
 ⟨λ p, @to_bool p (classical.prop_decidable _),
  λ b, b, λ p, by simp, λ b, by simp⟩
 
+/-- Sum of types is commutative up to an equivalence. -/
 def sum_comm (α β : Sort*) : α ⊕ β ≃ β ⊕ α :=
-⟨λ s, match s with inl a := inr a | inr b := inl b end,
- λ s, match s with inl b := inr b | inr a := inl a end,
- λ s, by cases s; refl,
- λ s, by cases s; refl⟩
+⟨sum.swap, sum.swap, sum.swap_swap, sum.swap_swap⟩
 
-@[simp] lemma sum_comm_apply_inl (α β) (a) : sum_comm α β (sum.inl a) = sum.inr a := rfl
-@[simp] lemma sum_comm_apply_inr (α β) (b) : sum_comm α β (sum.inr b) = sum.inl b := rfl
-@[simp] lemma sum_comm_symm (α β) : (sum_comm α β).symm = sum_comm β α := by ext x; cases x; refl
+@[simp] lemma sum_comm_apply (α β) (a) : sum_comm α β a = a.swap := rfl
+@[simp] lemma sum_comm_symm (α β) : (sum_comm α β).symm = sum_comm β α := rfl
 
+/-- Sum of types is associative up to an equivalence. -/
 def sum_assoc (α β γ : Sort*) : (α ⊕ β) ⊕ γ ≃ α ⊕ (β ⊕ γ) :=
-⟨λ s, match s with inl (inl a) := inl a | inl (inr b) := inr (inl b) | inr c := inr (inr c) end,
- λ s, match s with inl a := inl (inl a) | inr (inl b) := inl (inr b) | inr (inr c) := inr c end,
- λ s, by rcases s with ⟨_ | _⟩ | _; refl,
- λ s, by rcases s with _ | _ | _; refl⟩
+⟨sum.elim (sum.elim sum.inl (sum.inr ∘ sum.inl)) (sum.inr ∘ sum.inr),
+  sum.elim (sum.inl ∘ sum.inl) $ sum.elim (sum.inl ∘ sum.inr) sum.inr,
+  by rintros (⟨_ | _⟩ | _); refl,
+  by rintros (_ | ⟨_ | _⟩); refl⟩
 
 @[simp] theorem sum_assoc_apply_in1 {α β γ} (a) : sum_assoc α β γ (inl (inl a)) = inl a := rfl
 @[simp] theorem sum_assoc_apply_in2 {α β γ} (b) : sum_assoc α β γ (inl (inr b)) = inr (inl b) := rfl
 @[simp] theorem sum_assoc_apply_in3 {α β γ} (c) : sum_assoc α β γ (inr c) = inr (inr c) := rfl
 
-def sum_empty (α : Sort*) : α ⊕ empty ≃ α :=
-⟨λ s, match s with inl a := a | inr e := empty.rec _ e end,
+/-- Sum with `empty` is equivalent to the original type. -/
+def sum_empty (α : Type*) : α ⊕ empty ≃ α :=
+⟨sum.elim id (empty.rec _),
  inl,
  λ s, by { rcases s with _ | ⟨⟨⟩⟩, refl },
  λ a, rfl⟩
@@ -454,8 +472,9 @@ def empty_sum (α : Sort*) : empty ⊕ α ≃ α :=
 
 @[simp] lemma empty_sum_apply_inr {α} (a) : empty_sum α (sum.inr a) = a := rfl
 
-def sum_pempty (α : Sort*) : α ⊕ pempty ≃ α :=
-⟨λ s, match s with inl a := a | inr e := pempty.rec _ e end,
+/-- Sum with `pempty` is equivalent to the original type. -/
+def sum_pempty (α : Type*) : α ⊕ pempty ≃ α :=
+⟨sum.elim id (pempty.rec _),
  inl,
  λ s, by { rcases s with _ | ⟨⟨⟩⟩, refl },
  λ a, rfl⟩
@@ -625,18 +644,24 @@ def sigma_congr_left {α₁ α₂} {β : α₂ → Sort*} : ∀ f : α₁ ≃ α
    λ ⟨a, b⟩, match f (g a), _ : ∀ a' (h : a' = a), sigma.mk a' (@@eq.rec β b h.symm) = ⟨a, b⟩ with
      | _, rfl := rfl end⟩
 
-/-- transporting a sigma type through an equivalence of the base -/
-def sigma_congr_left' {α₁ α₂} {β : α₁ → Sort*} : ∀ f : α₁ ≃ α₂, (Σ a:α₁, β a) ≃ (Σ a:α₂, β (f.symm a)) :=
-λ f, (sigma_congr_left f.symm).symm
+/-- Transporting a sigma type through an equivalence of the base -/
+def sigma_congr_left' {α₁ α₂} {β : α₁ → Sort*} (f : α₁ ≃ α₂) :
+  (Σ a:α₁, β a) ≃ (Σ a:α₂, β (f.symm a)) :=
+(sigma_congr_left f.symm).symm
 
-/-- transporting a sigma type through an equivalence of the base and a family of equivalences of matching fibres -/
-def sigma_congr {α₁ α₂} {β₁ : α₁ → Sort*} {β₂ : α₂ → Sort*} (f : α₁ ≃ α₂) (F : ∀ a, β₁ a ≃ β₂ (f a)) :
+/-- Transporting a sigma type through an equivalence of the base and a family of equivalences
+of matching fibres -/
+def sigma_congr {α₁ α₂} {β₁ : α₁ → Sort*} {β₂ : α₂ → Sort*} (f : α₁ ≃ α₂)
+  (F : ∀ a, β₁ a ≃ β₂ (f a)) :
   sigma β₁ ≃ sigma β₂ :=
 (sigma_congr_right F).trans (sigma_congr_left f)
 
+/-- `sigma` type with a constant fiber is equivalent to the product. -/
 def sigma_equiv_prod (α β : Sort*) : (Σ_:α, β) ≃ α × β :=
 ⟨λ ⟨a, b⟩, ⟨a, b⟩, λ ⟨a, b⟩, ⟨a, b⟩, λ ⟨a, b⟩, rfl, λ ⟨a, b⟩, rfl⟩
 
+/-- If each fiber of a `sigma` type is equivalent to a fixed type, then the sigma type
+is equivalent to the product. -/
 def sigma_equiv_prod_of_equiv {α β} {β₁ : α → Sort*} (F : ∀ a, β₁ a ≃ β) : sigma β₁ ≃ α × β :=
 (sigma_congr_right F).trans (sigma_equiv_prod α β)
 
@@ -649,16 +674,14 @@ def arrow_prod_equiv_prod_arrow (α β γ : Type*) : (γ → α × β) ≃ (γ �
  λ f, funext $ λ c, prod.mk.eta,
  λ p, by { cases p, refl }⟩
 
+/-- Functions `α → β → γ` are equivalent to functions on `α × β`. -/
 def arrow_arrow_equiv_prod_arrow (α β γ : Sort*) : (α → β → γ) ≃ (α × β → γ) :=
-⟨λ f, λ p, f p.1 p.2,
- λ f, λ a b, f (a, b),
- λ f, rfl,
- λ f, by { funext p, cases p, refl }⟩
+⟨uncurry, curry, curry_uncurry, uncurry_curry⟩
 
 open sum
 def sum_arrow_equiv_prod_arrow (α β γ : Type*) : ((α ⊕ β) → γ) ≃ (α → γ) × (β → γ) :=
 ⟨λ f, (f ∘ inl, f ∘ inr),
- λ p s, sum.rec_on s p.1 p.2,
+ λ p, sum.elim p.1 p.2,
  λ f, by { funext s, cases s; refl },
  λ p, by { cases p, refl }⟩
 
@@ -989,7 +1012,8 @@ noncomputable def of_bijective {α β} {f : α → β} (hf : bijective f) : α �
 ⟨f, λ x, classical.some (hf.2 x), λ x, hf.1 (classical.some_spec (hf.2 (f x))),
   λ x, classical.some_spec (hf.2 x)⟩
 
-@[simp] theorem of_bijective_to_fun {α β} {f : α → β} (hf : bijective f) : (of_bijective hf : α → β) = f := rfl
+@[simp] theorem of_bijective_to_fun {α β} {f : α → β} (hf : bijective f) :
+  (of_bijective hf : α → β) = f := rfl
 
 def subtype_quotient_equiv_quotient_subtype (p₁ : α → Prop) [s₁ : setoid α]
   [s₂ : setoid (subtype p₁)] (p₂ : quotient s₁ → Prop) (hp₂ :  ∀ a, p₁ a ↔ p₂ ⟦a⟧)

--- a/src/data/equiv/functor.lean
+++ b/src/data/equiv/functor.lean
@@ -34,10 +34,8 @@ variables (f : Type u → Type v) [functor f] [is_lawful_functor f]
 def map_equiv (h : α ≃ β) : f α ≃ f β :=
 { to_fun    := map h,
   inv_fun   := map h.symm,
-  left_inv  := λ x,
-    by { rw map_map, convert is_lawful_functor.id_map x, ext a, apply symm_apply_apply },
-  right_inv := λ x,
-    by { rw map_map, convert is_lawful_functor.id_map x, ext a, apply apply_symm_apply } }
+  left_inv  := λ x, by simp [map_map],
+  right_inv := λ x, by simp [map_map] }
 
 @[simp]
 lemma map_equiv_apply (h : α ≃ β) (x : f α) :
@@ -65,10 +63,8 @@ variables {α' β' : Type v} (F : Type u → Type v → Type w) [bifunctor F] [i
 def map_equiv (h : α ≃ β) (h' : α' ≃ β') : F α α' ≃ F β β' :=
 { to_fun    := bimap h h',
   inv_fun   := bimap h.symm h'.symm,
-  left_inv  := λ x,
-    by { rw bimap_bimap, convert is_lawful_bifunctor.id_bimap x; { ext a, apply symm_apply_apply } },
-  right_inv := λ x,
-    by { rw bimap_bimap, convert is_lawful_bifunctor.id_bimap x; { ext a, apply apply_symm_apply } } }
+  left_inv  := λ x, by simp [bimap_bimap, id_bimap],
+  right_inv := λ x, by simp [bimap_bimap, id_bimap] }
 
 @[simp]
 lemma map_equiv_apply (h : α ≃ β) (h' : α' ≃ β') (x : F α α') :
@@ -82,8 +78,7 @@ lemma map_equiv_symm_apply (h : α ≃ β) (h' : α' ≃ β') (y : F β β') :
 lemma map_equiv_refl_refl : map_equiv F (equiv.refl α) (equiv.refl α') = equiv.refl (F α α') :=
 begin
   ext x,
-  simp only [map_equiv_apply, refl_apply],
-  exact is_lawful_bifunctor.id_bimap x,
+  simp [id_bimap]
 end
 
 end bifunctor

--- a/src/data/polynomial.lean
+++ b/src/data/polynomial.lean
@@ -2,8 +2,6 @@
 Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Scott Morrison, Jens Wagemaker
-
-Theory of univariate polynomials, represented as `add_monoid_algebra R ℕ`, where `R` is a commutative semiring.
 -/
 import data.monoid_algebra
 import algebra.gcd_domain
@@ -11,6 +9,12 @@ import ring_theory.euclidean_domain
 import ring_theory.multiplicity
 import tactic.ring_exp
 import deprecated.field
+
+/-!
+# Theory of univariate polynomials
+
+Polynomials are represented as `add_monoid_algebra R ℕ`, where `R` is a commutative semiring.
+-/
 
 noncomputable theory
 local attribute [instance, priority 100] classical.prop_decidable

--- a/src/data/sum.lean
+++ b/src/data/sum.lean
@@ -49,10 +49,10 @@ funext $ map_map f' g' f g
 @[simp] lemma map_id_id (α β) : sum.map (@id α) (@id β) = id :=
 funext $ λ x, sum.rec_on x (λ _, rfl) (λ _, rfl)
 
-@[simp] theorem inl.inj_iff {a b} : (inl a : α ⊕ β) = inl b ↔ a = b :=
+theorem inl.inj_iff {a b} : (inl a : α ⊕ β) = inl b ↔ a = b :=
 ⟨inl.inj, congr_arg _⟩
 
-@[simp] theorem inr.inj_iff {a b} : (inr a : α ⊕ β) = inr b ↔ a = b :=
+theorem inr.inj_iff {a b} : (inr a : α ⊕ β) = inr b ↔ a = b :=
 ⟨inr.inj, congr_arg _⟩
 
 theorem inl_ne_inr {a : α} {b : β} : inl a ≠ inr b.

--- a/src/data/sum.lean
+++ b/src/data/sum.lean
@@ -1,14 +1,16 @@
 /-
 Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Mario Carneiro
-
-More theorems about the sum type.
+Authors: Mario Carneiro, Yury G. Kudryashov
 -/
 import tactic.lint
 
-universes u v
-variables {α : Type u} {β : Type v}
+/-!
+# More theorems about the sum type
+-/
+
+universes u v w x
+variables {α : Type u} {α' : Type w} {β : Type v} {β' : Type x}
 open sum
 
 attribute [derive decidable_eq] sum
@@ -27,20 +29,37 @@ end⟩
 
 namespace sum
 
-protected def map {α α' β β'} (f : α → α') (g : β → β')  : α ⊕ β → α' ⊕ β'
+/-- Map `α ⊕ β` to `α' ⊕ β'` sending `α` to `α'` and `β` to `β'`. -/
+protected def map (f : α → α') (g : β → β')  : α ⊕ β → α' ⊕ β'
 | (sum.inl x) := sum.inl (f x)
 | (sum.inr x) := sum.inr (g x)
 
-theorem inl.inj_iff {a b} : (inl a : α ⊕ β) = inl b ↔ a = b :=
+@[simp] lemma map_inl (f : α → α') (g : β → β') (x : α) : (inl x).map f g = inl (f x) := rfl
+@[simp] lemma map_inr (f : α → α') (g : β → β') (x : β) : (inr x).map f g = inr (g x) := rfl
+
+@[simp] lemma map_map {α'' β''} (f' : α' → α'') (g' : β' → β'') (f : α → α') (g : β → β') :
+  ∀ x : α ⊕ β, (x.map f g).map f' g' = x.map (f' ∘ f) (g' ∘ g)
+| (inl a) := rfl
+| (inr b) := rfl
+
+@[simp] lemma map_comp_map {α'' β''} (f' : α' → α'') (g' : β' → β'') (f : α → α') (g : β → β') :
+  (sum.map f' g') ∘ (sum.map f g) = sum.map (f' ∘ f) (g' ∘ g) :=
+funext $ map_map f' g' f g
+
+@[simp] lemma map_id_id (α β) : sum.map (@id α) (@id β) = id :=
+funext $ λ x, sum.rec_on x (λ _, rfl) (λ _, rfl)
+
+@[simp] theorem inl.inj_iff {a b} : (inl a : α ⊕ β) = inl b ↔ a = b :=
 ⟨inl.inj, congr_arg _⟩
 
-theorem inr.inj_iff {a b} : (inr a : α ⊕ β) = inr b ↔ a = b :=
+@[simp] theorem inr.inj_iff {a b} : (inr a : α ⊕ β) = inr b ↔ a = b :=
 ⟨inr.inj, congr_arg _⟩
 
 theorem inl_ne_inr {a : α} {b : β} : inl a ≠ inr b.
 
 theorem inr_ne_inl {a : α} {b : β} : inr b ≠ inl a.
 
+/-- Define a function on `α ⊕ β` by giving separate definitions on `α` and `β`. -/
 protected def elim {α β γ : Sort*} (f : α → γ) (g : β → γ) : α ⊕ β → γ := λ x, sum.rec_on x f g
 
 @[simp] lemma elim_inl {α β γ : Sort*} (f : α → γ) (g : β → γ) (x : α) :


### PR DESCRIPTION
Use functions like `prod.map`, `curry`, `uncurry`, `sum.elim`, `sum.map` to define equivalences.