### PR TITLE
[Merged by Bors] - feat(ring_theory): define subsemirings

### DIFF
--- a/src/algebra/group/prod.lean
+++ b/src/algebra/group/prod.lean
@@ -156,15 +156,15 @@ protected def prod (f : M →* N) (g : M →* P) : M →* N × P :=
 @[simp, to_additive prod_apply]
 lemma prod_apply (f : M →* N) (g : M →* P) (x) : f.prod g x = (f x, g x) := rfl
 
-@[to_additive fst_comp_prod]
+@[simp, to_additive fst_comp_prod]
 lemma fst_comp_prod (f : M →* N) (g : M →* P) : (fst N P).comp (f.prod g) = f :=
 ext $ λ x, rfl
 
-@[to_additive snd_comp_prod]
+@[simp, to_additive snd_comp_prod]
 lemma snd_comp_prod (f : M →* N) (g : M →* P) : (snd N P).comp (f.prod g) = g :=
 ext $ λ x, rfl
 
-@[to_additive prod_unique]
+@[simp, to_additive prod_unique]
 lemma prod_unique (f : M →* N × P) :
   ((fst N P).comp f).prod ((snd N P).comp f) = f :=
 ext $ λ x, by simp only [prod_apply, coe_fst, coe_snd, comp_apply, prod.mk.eta]
@@ -183,9 +183,8 @@ def prod_map : M × N →* M' × N' := (f.comp (fst M N)).prod (g.comp (snd M N)
 @[to_additive prod_map_def]
 lemma prod_map_def : prod_map f g = (f.comp (fst M N)).prod (g.comp (snd M N)) := rfl
 
--- TODO : use `rfl` once we redefine `prod.map` in stdlib
 @[simp, to_additive coe_prod_map]
-lemma coe_prod_map : ⇑(prod_map f g) = prod.map f g := funext $ λ ⟨x, y⟩, rfl
+lemma coe_prod_map : ⇑(prod_map f g) = prod.map f g := rfl
 
 @[to_additive prod_comp_prod_map]
 lemma prod_comp_prod_map (f : P →* M) (g : P →* N) (f' : M →* M') (g' : N →* N') :

--- a/src/algebra/pi_instances.lean
+++ b/src/algebra/pi_instances.lean
@@ -2,11 +2,14 @@
 Copyright (c) 2018 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot
-
-Pi instances for algebraic structures.
 -/
 import algebra.module
 import ring_theory.subring
+import ring_theory.prod
+
+/-!
+# Pi instances for algebraic structures
+-/
 
 namespace pi
 universes u v w
@@ -339,32 +342,15 @@ lemma snd_prod [comm_monoid α] [comm_monoid β] {t : finset γ} {f : γ → α 
   (t.prod f).2 = t.prod (λc, (f c).2) :=
 (monoid_hom.snd α β).map_prod f t
 
-instance [semiring α] [semiring β] : semiring (α × β) :=
-{ zero_mul := λ a, mk.inj_iff.mpr ⟨zero_mul _, zero_mul _⟩,
-  mul_zero := λ a, mk.inj_iff.mpr ⟨mul_zero _, mul_zero _⟩,
-  left_distrib := λ a b c, mk.inj_iff.mpr ⟨left_distrib _ _ _, left_distrib _ _ _⟩,
-  right_distrib := λ a b c, mk.inj_iff.mpr ⟨right_distrib _ _ _, right_distrib _ _ _⟩,
-  ..prod.add_comm_monoid, ..prod.monoid }
-
-instance [ring α] [ring β] : ring (α × β) :=
-{ ..prod.add_comm_group, ..prod.semiring }
-
-instance [comm_ring α] [comm_ring β] : comm_ring (α × β) :=
-{ ..prod.ring, ..prod.comm_monoid }
-
-instance [nonzero_comm_ring α] [comm_ring β] : nonzero_comm_ring (α × β) :=
-{ zero_ne_one := mt (congr_arg prod.fst) zero_ne_one,
-  ..prod.comm_ring }
-
 instance fst.is_semiring_hom [semiring α] [semiring β] : is_semiring_hom (prod.fst : α × β → α) :=
-by refine_struct {..}; simp
+(ring_hom.fst α β).is_semiring_hom
 instance snd.is_semiring_hom [semiring α] [semiring β] : is_semiring_hom (prod.snd : α × β → β) :=
-by refine_struct {..}; simp
+(ring_hom.snd α β).is_semiring_hom
 
 instance fst.is_ring_hom [ring α] [ring β] : is_ring_hom (prod.fst : α × β → α) :=
-by refine_struct {..}; simp
+(ring_hom.fst α β).is_ring_hom
 instance snd.is_ring_hom [ring α] [ring β] : is_ring_hom (prod.snd : α × β → β) :=
-by refine_struct {..}; simp
+(ring_hom.snd α β).is_ring_hom
 
 /-- Left injection function for the inner product
 From a vector space (and also group and module) perspective the product is the same as the sum of

--- a/src/group_theory/congruence.lean
+++ b/src/group_theory/congruence.lean
@@ -719,7 +719,7 @@ noncomputable def quotient_ker_equiv_range (f : M →* P) : (ker f).quotient ≃
 { map_mul' := monoid_hom.map_mul _,
   ..@equiv.of_bijective _ _
       ((@mul_equiv.to_monoid_hom (ker_lift f).mrange _ _ _
-        $ mul_equiv.submonoid_congr ker_lift_range_eq).comp (ker_lift f).range_restrict) $
+        $ mul_equiv.submonoid_congr ker_lift_range_eq).comp (ker_lift f).mrange_restrict) $
       (equiv.bijective _).comp
         ⟨λ x y h, injective_ker_lift f $ by rcases x; rcases y; injections,
          λ ⟨w, z, hzm, hz⟩, ⟨z, by rcases hz; rcases _x; refl⟩⟩ }

--- a/src/group_theory/monoid_localization.lean
+++ b/src/group_theory/monoid_localization.lean
@@ -218,15 +218,15 @@ by rw [mul_comm, sec_spec]
     `w : M, z : N` and `y ∈ S`, we have `w * (f y)⁻¹ = z ↔ w = f y * z`. -/
 @[to_additive "Given an add_monoid hom `f : M →+ N` and submonoid `S ⊆ M` such that `f(S) ⊆ add_units N`, for all `w : M, z : N` and `y ∈ S`, we have `w - f y = z ↔ w = f y + z`."]
 lemma mul_inv_left {f : M →* N} (h : ∀ y : S, is_unit (f y))
-  (y : S) (w z) : w * ↑(is_unit.lift_right (f.restrict S) h y)⁻¹ = z ↔ w = f y * z :=
+  (y : S) (w z) : w * ↑(is_unit.lift_right (f.mrestrict S) h y)⁻¹ = z ↔ w = f y * z :=
 by rw mul_comm; convert units.inv_mul_eq_iff_eq_mul _;
-  exact (is_unit.coe_lift_right (f.restrict S) h _).symm
+  exact (is_unit.coe_lift_right (f.mrestrict S) h _).symm
 
 /-- Given a monoid hom `f : M →* N` and submonoid `S ⊆ M` such that `f(S) ⊆ units N`, for all
     `w : M, z : N` and `y ∈ S`, we have `z = w * (f y)⁻¹ ↔ z * f y = w`. -/
 @[to_additive "Given an add_monoid hom `f : M →+ N` and submonoid `S ⊆ M` such that `f(S) ⊆ add_units N`, for all `w : M, z : N` and `y ∈ S`, we have `z = w - f y ↔ z + f y = w`."]
 lemma mul_inv_right {f : M →* N} (h : ∀ y : S, is_unit (f y))
-  (y : S) (w z) : z = w * ↑(is_unit.lift_right (f.restrict S) h y)⁻¹ ↔ z * f y = w :=
+  (y : S) (w z) : z = w * ↑(is_unit.lift_right (f.mrestrict S) h y)⁻¹ ↔ z * f y = w :=
 by rw [eq_comm, mul_inv_left h, mul_comm, eq_comm]
 
 /-- Given a monoid hom `f : M →* N` and submonoid `S ⊆ M` such that
@@ -234,8 +234,8 @@ by rw [eq_comm, mul_inv_left h, mul_comm, eq_comm]
     `f x₁ * (f y₁)⁻¹ = f x₂ * (f y₂)⁻¹ ↔ f (x₁ * y₂) = f (x₂ * y₁)`. -/
 @[simp, to_additive "Given an add_monoid hom `f : M →+ N` and submonoid `S ⊆ M` such that `f(S) ⊆ add_units N`, for all `x₁ x₂ : M` and `y₁, y₂ ∈ S`, we have `f x₁ - f y₁ = f x₂ - f y₂ ↔ f (x₁ + y₂) = f (x₂ + y₁)`."]
 lemma mul_inv {f : M →* N} (h : ∀ y : S, is_unit (f y)) {x₁ x₂} {y₁ y₂ : S} :
-  f x₁ * ↑(is_unit.lift_right (f.restrict S) h y₁)⁻¹ =
-    f x₂ * ↑(is_unit.lift_right (f.restrict S) h y₂)⁻¹ ↔ f (x₁ * y₂) = f (x₂ * y₁) :=
+  f x₁ * ↑(is_unit.lift_right (f.mrestrict S) h y₁)⁻¹ =
+    f x₂ * ↑(is_unit.lift_right (f.mrestrict S) h y₂)⁻¹ ↔ f (x₁ * y₂) = f (x₂ * y₁) :=
 by rw [mul_inv_right h, mul_assoc, mul_comm _ (f y₂), ←mul_assoc, mul_inv_left h, mul_comm x₂,
   f.map_mul, f.map_mul]
 
@@ -243,16 +243,16 @@ by rw [mul_inv_right h, mul_assoc, mul_comm _ (f y₂), ←mul_assoc, mul_inv_le
     `y, z ∈ S`, we have `(f y)⁻¹ = (f z)⁻¹ → f y = f z`. -/
 @[to_additive "Given an add_monoid hom `f : M →+ N` and submonoid `S ⊆ M` such that `f(S) ⊆ add_units N`, for all `y, z ∈ S`, we have `- (f y) = - (f z) → f y = f z`."]
 lemma inv_inj {f : M →* N} (hf : ∀ y : S, is_unit (f y)) {y z}
-  (h : (is_unit.lift_right (f.restrict S) hf y)⁻¹ = (is_unit.lift_right (f.restrict S) hf z)⁻¹) :
+  (h : (is_unit.lift_right (f.mrestrict S) hf y)⁻¹ = (is_unit.lift_right (f.mrestrict S) hf z)⁻¹) :
   f y = f z :=
 by rw [←mul_one (f y), eq_comm, ←mul_inv_left hf y (f z) 1, h];
-  convert units.inv_mul _; exact (is_unit.coe_lift_right (f.restrict S) hf _).symm
+  convert units.inv_mul _; exact (is_unit.coe_lift_right (f.mrestrict S) hf _).symm
 
 /-- Given a monoid hom `f : M →* N` and submonoid `S ⊆ M` such that `f(S) ⊆ units N`, for all
     `y ∈ S`, `(f y)⁻¹` is unique. -/
 @[to_additive "Given an add_monoid hom `f : M →+ N` and submonoid `S ⊆ M` such that `f(S) ⊆ add_units N`, for all `y ∈ S`, `- (f y)` is unique."]
 lemma inv_unique {f : M →* N} (h : ∀ y : S, is_unit (f y)) {y : S}
-  {z} (H : f y * z = 1) : ↑(is_unit.lift_right (f.restrict S) h y)⁻¹ = z :=
+  {z} (H : f y * z = 1) : ↑(is_unit.lift_right (f.mrestrict S) h y)⁻¹ = z :=
 by rw [←one_mul ↑(_)⁻¹, mul_inv_left, ←H]
 
 variables (f : localization_map S N)
@@ -274,7 +274,7 @@ f.map_right_cancel $ by rw [mul_comm _ x, mul_comm _ y, h]
     `f x * (f y)⁻¹`. -/
 @[to_additive "Given a localization map `f : M →+ N`, the surjection sending `(x, y) : M × S` to `f x - f y`."]
 noncomputable def mk' (f : localization_map S N) (x : M) (y : S) : N :=
-f.to_map x * ↑(is_unit.lift_right (f.to_map.restrict S) f.map_units y)⁻¹
+f.to_map x * ↑(is_unit.lift_right (f.to_map.mrestrict S) f.map_units y)⁻¹
 
 @[to_additive] lemma mk'_mul (x₁ x₂ : M) (y₁ y₂ : S) :
   f.mk' (x₁ * x₂) (y₁ * y₂) = f.mk' x₁ y₁ * f.mk' x₂ y₂ :=
@@ -378,9 +378,9 @@ by rw [mul_comm, mk'_mul_cancel_right]
 
 @[to_additive] lemma is_unit_comp (j : N →* P) (y : S) :
   is_unit (j.comp f.to_map y) :=
-⟨units.map j $ is_unit.lift_right (f.to_map.restrict S) f.map_units y,
+⟨units.map j $ is_unit.lift_right (f.to_map.mrestrict S) f.map_units y,
   show j _ = j _, from congr_arg j $
-    (is_unit.coe_lift_right (f.to_map.restrict S) f.map_units _)⟩
+    (is_unit.coe_lift_right (f.to_map.mrestrict S) f.map_units _)⟩
 
 variables {g : M →* P}
 
@@ -391,7 +391,7 @@ lemma eq_of_eq (hg : ∀ y : S, is_unit (g y)) {x y} (h : f.to_map x = f.to_map 
   g x = g y :=
 begin
   obtain ⟨c, hc⟩ := f.eq_iff_exists.1 h,
-  rw [←mul_one (g x), ←is_unit.mul_lift_right_inv (g.restrict S) hg c],
+  rw [←mul_one (g x), ←is_unit.mul_lift_right_inv (g.mrestrict S) hg c],
   show _ * (g c * _) = _,
   rw [←mul_assoc, ←g.map_mul, hc, mul_inv_left hg, g.map_mul, mul_comm],
 end
@@ -413,7 +413,7 @@ variables (hg : ∀ y : S, is_unit (g y))
     `z = f x * (f y)⁻¹`. -/
 @[to_additive "Given a localization map `f : M →+ N` for a submonoid `S ⊆ M` and a map of `add_comm_monoid`s `g : M →+ P` such that `g y` is invertible for all `y : S`, the homomorphism induced from `N` to `P` sending `z : N` to `g x - g y`, where `(x, y) : M × S` are such that `z = f x - f y`."]
 noncomputable def lift : N →* P :=
-{ to_fun := λ z, g (f.sec z).1 * ↑(is_unit.lift_right (g.restrict S) hg (f.sec z).2)⁻¹,
+{ to_fun := λ z, g (f.sec z).1 * ↑(is_unit.lift_right (g.mrestrict S) hg (f.sec z).2)⁻¹,
   map_one' := by rw [mul_inv_left, mul_one]; exact f.eq_of_eq hg
     (by rw [←sec_spec, one_mul]),
   map_mul' := λ x y,
@@ -431,7 +431,7 @@ variables {S g}
     `N` to `P` maps `f x * (f y)⁻¹` to `g x * (g y)⁻¹` for all `x : M, y ∈ S`. -/
 @[to_additive "Given a localization map `f : M →+ N` for a submonoid `S ⊆ M` and a map of `add_comm_monoid`s `g : M →+ P` such that `g y` is invertible for all `y : S`, the homomorphism induced from `N` to `P` maps `f x - f y` to `g x - g y` for all `x : M, y ∈ S`."]
 lemma lift_mk' (x y) :
-  f.lift hg (f.mk' x y) = g x * ↑(is_unit.lift_right (g.restrict S) hg y)⁻¹ :=
+  f.lift hg (f.mk' x y) = g x * ↑(is_unit.lift_right (g.mrestrict S) hg y)⁻¹ :=
 (mul_inv hg).2 $ f.eq_of_eq hg $ by
   rw [f.to_map.map_mul, f.to_map.map_mul, sec_spec', mul_assoc, f.mk'_spec, mul_comm]
 
@@ -545,7 +545,7 @@ begin
       obtain ⟨x, hx⟩ := f.surj z,
       use x,
       rw [←hz, f.eq_mk'_iff_mul_eq.2 hx, lift_mk', mul_assoc, mul_comm _ (g ↑x.2)],
-      erw [is_unit.mul_lift_right_inv (g.restrict S) hg, mul_one] },
+      erw [is_unit.mul_lift_right_inv (g.mrestrict S) hg, mul_one] },
   { intros H v,
     obtain ⟨x, hx⟩ := H v,
     use f.mk' x.1 x.2,

--- a/src/group_theory/submonoid.lean
+++ b/src/group_theory/submonoid.lean
@@ -761,7 +761,7 @@ lemma closure_Union {ι} (s : ι → set M) : closure (⋃ i, s i) = ⨆ i, clos
 @[to_additive]
 lemma mem_supr_of_directed {ι} [hι : nonempty ι] {S : ι → submonoid M} (hS : directed (≤) S)
   {x : M} :
-  x ∈ (supr S : submonoid M) ↔ ∃ i, x ∈ S i :=
+  x ∈ (⨆ i, S i) ↔ ∃ i, x ∈ S i :=
 begin
   refine ⟨_, λ ⟨i, hi⟩, (le_def.1 $ le_supr S i) hi⟩,
   suffices : x ∈ closure (⋃ i, (S i : set M)) → ∃ i, x ∈ S i,
@@ -774,6 +774,11 @@ begin
 end
 
 @[to_additive]
+lemma coe_supr_of_directed {ι} [nonempty ι] {S : ι → submonoid M} (hS : directed (≤) S) :
+  ((⨆ i, S i : submonoid M) : set M) = ⋃ i, ↑(S i) :=
+set.ext $ λ x, by simp [mem_supr_of_directed hS]
+
+@[to_additive]
 lemma mem_Sup_of_directed_on {S : set (submonoid M)} (Sne : S.nonempty)
   (hS : directed_on (≤) S) {x : M} :
   x ∈ Sup S ↔ ∃ s ∈ S, x ∈ s :=
@@ -782,6 +787,11 @@ begin
   rw [Sup_eq_supr, supr_subtype', mem_supr_of_directed, subtype.exists],
   exact (directed_on_iff_directed _).1 hS
 end
+
+@[to_additive]
+lemma coe_Sup_of_directed_on {S : set (submonoid M)} (Sne : S.nonempty) (hS : directed_on (≤) S) :
+  (↑(Sup S) : set M) = ⋃ s ∈ S, ↑s :=
+set.ext $ λ x, by simp [mem_Sup_of_directed_on Sne hS]
 
 variables {N : Type*} [monoid N] {P : Type*} [monoid P]
 
@@ -935,29 +945,26 @@ lemma map_mrange (g : N →* P) (f : M →* N) : f.mrange.map g = (g.comp f).mra
 
 /-- Restriction of a monoid hom to a submonoid of the domain. -/
 @[to_additive "Restriction of an add_monoid hom to an `add_submonoid` of the domain."]
-def restrict {N : Type*} [monoid N] (f : M →* N) (S : submonoid M) : S →* N := f.comp S.subtype
+def mrestrict {N : Type*} [monoid N] (f : M →* N) (S : submonoid M) : S →* N := f.comp S.subtype
 
-@[to_additive]
-lemma restrict_apply {N : Type*} [monoid N] (f : M →* N) (x : S) : f.restrict S x = f x := rfl
-
-@[simp, to_additive] lemma restrict_eq {N : Type} [monoid N] (f : M →* N) (x) :
-  f.restrict S x = f x := rfl
+@[simp, to_additive]
+lemma mrestrict_apply {N : Type*} [monoid N] (f : M →* N) (x : S) : f.mrestrict S x = f x := rfl
 
 /-- Restriction of a monoid hom to a submonoid of the codomain. -/
 @[to_additive "Restriction of an `add_monoid` hom to an `add_submonoid` of the codomain."]
-def cod_restrict (f : M →* N) (S : submonoid N) (h : ∀ x, f x ∈ S) : M →* S :=
+def cod_mrestrict (f : M →* N) (S : submonoid N) (h : ∀ x, f x ∈ S) : M →* S :=
 { to_fun := λ n, ⟨f n, h n⟩,
   map_one' := subtype.eq f.map_one,
   map_mul' := λ x y, subtype.eq (f.map_mul x y) }
 
 /-- Restriction of a monoid hom to its range iterpreted as a submonoid. -/
 @[to_additive "Restriction of an `add_monoid` hom to its range interpreted as a submonoid."]
-def range_restrict {N} [monoid N] (f : M →* N) : M →* f.mrange :=
-f.cod_restrict f.mrange $ λ x, ⟨x, submonoid.mem_top x, rfl⟩
+def mrange_restrict {N} [monoid N] (f : M →* N) : M →* f.mrange :=
+f.cod_mrestrict f.mrange $ λ x, ⟨x, submonoid.mem_top x, rfl⟩
 
 @[simp, to_additive]
-lemma coe_range_restrict {N} [monoid N] (f : M →* N) (x : M) :
-  (f.range_restrict x : N) = f x :=
+lemma coe_mrange_restrict {N} [monoid N] (f : M →* N) (x : M) :
+  (f.mrange_restrict x : N) = f x :=
 rfl
 
 @[to_additive]
@@ -995,7 +1002,7 @@ lemma eq_of_eq_on_mdense {s : set M} (hs : closure s = ⊤) {f g : M →* N} (h 
 eq_of_eq_on_mtop $ hs ▸ eq_on_mclosure h
 
 @[to_additive]
-lemma closure_preimage_le (f : M →* N) (s : set N) :
+lemma mclosure_preimage_le (f : M →* N) (s : set N) :
   closure (f ⁻¹' s) ≤ (closure s).comap f :=
 closure_le.2 $ λ x hx, mem_coe.2 $ mem_comap.2 $ subset_closure hx
 
@@ -1007,7 +1014,7 @@ lemma map_mclosure (f : M →* N) (s : set M) :
   (closure s).map f = closure (f '' s) :=
 le_antisymm
   (map_le_iff_le_comap.2 $ le_trans (closure_mono $ set.subset_preimage_image _ _)
-    (closure_preimage_le _ _))
+    (mclosure_preimage_le _ _))
   (closure_le.2 $ set.image_subset _ subset_closure)
 
 end monoid_hom
@@ -1029,12 +1036,12 @@ namespace submonoid
 
 variables {N : Type*} [monoid N]
 
-open monoid_hom lattice
+open monoid_hom
 
 /-- The monoid hom associated to an inclusion of submonoids. -/
 @[to_additive "The `add_monoid` hom associated to an inclusion of submonoids."]
 def inclusion {S T : submonoid M} (h : S ≤ T) : S →* T :=
-S.subtype.cod_restrict _ (λ x, h x.2)
+S.subtype.cod_mrestrict _ (λ x, h x.2)
 
 @[simp, to_additive]
 lemma range_subtype (s : submonoid M) : s.subtype.mrange = s :=

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -306,7 +306,7 @@ variables {g : R →+* P} (hg : ∀ y : M, is_unit (g y))
 `g : R →* P` such that `g y` is invertible for all `y : M`, the homomorphism induced from
 `S` to `P` maps `f x * (f y)⁻¹` to `g x * (g y)⁻¹` for all `x : R, y ∈ M`. -/
 lemma lift_mk' (x y) :
-  f.lift hg (f.mk' x y) = g x * ↑(is_unit.lift_right (g.to_monoid_hom.restrict M) hg y)⁻¹ :=
+  f.lift hg (f.mk' x y) = g x * ↑(is_unit.lift_right (g.to_monoid_hom.mrestrict M) hg y)⁻¹ :=
 f.to_localization_map.lift_mk' _ _ _
 
 lemma lift_mk'_spec (x v) (y : M) :

--- a/src/ring_theory/prod.lean
+++ b/src/ring_theory/prod.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2020 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Chris Hughes, Mario Carneiro, Yury Kudryashov
+-/
+import algebra.group.prod
+import algebra.ring
+
+/-!
+# Semiring, ring etc structures on `R × S`
+
+In this file we define two-binop (`semiring`, `ring` etc) structures on `R × S`. We also prove
+trivial `simp` lemmas, and define the following operations on `ring_hom`s:
+
+* `fst R S : R × S →+* R`, `snd R S : R × S →+* R`: projections `prod.fst` and `prod.snd`
+  as `ring_hom`s;
+* `f.prod g : `R →+* S × T`: sends `x` to `(f x, g x)`;
+* `f.prod_map g : `R × S → R' × S'`: `prod.map f g` as a `ring_hom`,
+  sends `(x, y)` to `(f x, g y)`.
+-/
+
+variables {R : Type*} {R' : Type*} {S : Type*} {S' : Type*} {T : Type*} {T' : Type*}
+
+namespace prod
+
+/-- Product of two semirings is a semiring. -/
+instance [semiring R] [semiring S] : semiring (R × S) :=
+{ zero_mul := λ a, mk.inj_iff.mpr ⟨zero_mul _, zero_mul _⟩,
+  mul_zero := λ a, mk.inj_iff.mpr ⟨mul_zero _, mul_zero _⟩,
+  left_distrib := λ a b c, mk.inj_iff.mpr ⟨left_distrib _ _ _, left_distrib _ _ _⟩,
+  right_distrib := λ a b c, mk.inj_iff.mpr ⟨right_distrib _ _ _, right_distrib _ _ _⟩,
+  .. prod.add_comm_monoid, .. prod.monoid }
+
+/-- Product of two commutative semirings is a commutative semiring. -/
+instance [comm_semiring R] [comm_semiring S] : comm_semiring (R × S) :=
+{ .. prod.semiring, .. prod.comm_monoid }
+
+/-- Product of two rings is a ring. -/
+instance [ring R] [ring S] : ring (R × S) :=
+{ .. prod.add_comm_group, .. prod.semiring }
+
+/-- Product of two commutative rings is a commutative ring. -/
+instance [comm_ring R] [comm_ring S] : comm_ring (R × S) :=
+{ .. prod.ring, .. prod.comm_monoid }
+
+/-- Product of two commutative rings is a nonzero commutative ring provided that the first
+ring is a nonzero ring. -/
+instance [nonzero_comm_ring R] [comm_ring S] : nonzero_comm_ring (R × S) :=
+{ zero_ne_one := mt (congr_arg prod.fst) zero_ne_one,
+  .. prod.comm_ring }
+
+end prod
+
+namespace ring_hom
+
+variables (R S) [semiring R] [semiring S]
+
+/-- Given semirings `R`, `S`, the natural projection homomorphism from `R × S` to `R`.-/
+def fst : R × S →+* R := { to_fun := prod.fst, .. monoid_hom.fst R S, .. add_monoid_hom.fst R S }
+
+/-- Given semirings `R`, `S`, the natural projection homomorphism from `R × S` to `S`.-/
+def snd : R × S →+* S := { to_fun := prod.snd, .. monoid_hom.snd R S, .. add_monoid_hom.snd R S }
+
+variables {R S}
+
+@[simp] lemma coe_fst : ⇑(fst R S) = prod.fst := rfl
+@[simp] lemma coe_snd : ⇑(snd R S) = prod.snd := rfl
+
+section prod
+
+variables [semiring T] (f : R →+* S) (g : R →+* T)
+
+/-- Combine two ring homomorphisms `f : R →+* S`, `g : R →+* T` into `f.prod g : R →+* S × T`
+given by `(f.prod g) x = (f x, g x)` -/
+protected def prod (f : R →+* S) (g : R →+* T) : R →+* S × T :=
+{ to_fun := λ x, (f x, g x),
+  .. monoid_hom.prod (f : R →* S) (g : R →* T), .. add_monoid_hom.prod (f : R →+ S) (g : R →+ T) }
+
+@[simp] lemma prod_apply (x) : f.prod g x = (f x, g x) := rfl
+
+@[simp] lemma fst_comp_prod : (fst S T).comp (f.prod g) = f :=
+ext $ λ x, rfl
+
+@[simp] lemma snd_comp_prod : (snd S T).comp (f.prod g) = g :=
+ext $ λ x, rfl
+
+lemma prod_unique (f : R →+* S × T) :
+  ((fst S T).comp f).prod ((snd S T).comp f) = f :=
+ext $ λ x, by simp only [prod_apply, coe_fst, coe_snd, comp_apply, prod.mk.eta]
+
+end prod
+
+section prod_map
+
+variables [semiring R'] [semiring S'] [semiring T] (f : R →+* R') (g : S →+* S')
+
+/-- `prod.map` as a `ring_hom`. -/
+def prod_map : R × S →* R' × S' := (f.comp (fst R S)).prod (g.comp (snd R S))
+
+lemma prod_map_def : prod_map f g = (f.comp (fst R S)).prod (g.comp (snd R S)) := rfl
+
+@[simp]
+lemma coe_prod_map : ⇑(prod_map f g) = prod.map f g := rfl
+
+lemma prod_comp_prod_map (f : T →* R) (g : T →* S) (f' : R →* R') (g' : S →* S') :
+  (f'.prod_map g').comp (f.prod g) = (f'.comp f).prod (g'.comp g) :=
+rfl
+
+end prod_map
+
+end ring_hom

--- a/src/ring_theory/subsemiring.lean
+++ b/src/ring_theory/subsemiring.lean
@@ -1,0 +1,561 @@
+/-
+Copyright (c) 2020 Yury Kudryashov All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov
+-/
+
+import ring_theory.prod
+import group_theory.submonoid
+import data.equiv.ring
+
+/-!
+# Bundled subsemirings
+
+We define bundled subsemirings and some standard constructions: `complete_lattice` structure,
+`subtype` and `inclusion` ring homomorphisms, subsemiring kernel and range of a `ring_hom` etc.
+-/
+
+universes u v w
+
+variables {R : Type u} {S : Type v} {T : Type w} [semiring R] [semiring S] [semiring T]
+
+set_option old_structure_cmd true
+
+/-- Subsemiring of a semiring `R` is a subset `s` that is both a multiplicative and an additive
+submonoid. -/
+structure subsemiring (R : Type u) [semiring R] extends submonoid R, add_submonoid R
+
+/-- Reinterpret a `subsemiring` as a `submonoid`. -/
+add_decl_doc subsemiring.to_submonoid
+
+/-- Reinterpret a `subsemiring` as an `add_submonoid`. -/
+add_decl_doc subsemiring.to_add_submonoid
+
+namespace subsemiring
+
+instance : has_coe (subsemiring R) (set R) := ⟨subsemiring.carrier⟩
+
+instance : has_coe_to_sort (subsemiring R) := ⟨Type*, λ S, S.carrier⟩
+
+instance : has_mem R (subsemiring R) := ⟨λ m S, m ∈ (S:set R)⟩
+
+/-- Construct a `subsemiring R` from a set `s`, a submonoid `sm`, and an additive
+submonoid `sa` such that `x ∈ s ↔ x ∈ sm ↔ x ∈ sa`. -/
+protected def mk' (s : set R) (sm : submonoid R) (hm : ↑sm = s)
+  (sa : add_submonoid R) (ha : ↑sa = s) :
+  subsemiring R :=
+{ carrier := s,
+  zero_mem' := ha ▸ sa.zero_mem,
+  one_mem' := hm ▸ sm.one_mem,
+  add_mem' := λ x y, by simpa only [← ha] using sa.add_mem,
+  mul_mem' := λ x y, by simpa only [← hm] using sm.mul_mem }
+
+@[simp] lemma coe_mk' {s : set R} {sm : submonoid R} (hm : ↑sm = s)
+  {sa : add_submonoid R} (ha : ↑sa = s) :
+  (subsemiring.mk' s sm hm sa ha : set R) = s := rfl
+
+@[simp] lemma mem_mk' {s : set R} {sm : submonoid R} (hm : ↑sm = s)
+  {sa : add_submonoid R} (ha : ↑sa = s) {x : R} :
+  x ∈ subsemiring.mk' s sm hm sa ha ↔ x ∈ s :=
+iff.rfl
+
+@[simp] lemma mk'_to_submonoid {s : set R} {sm : submonoid R} (hm : ↑sm = s)
+  {sa : add_submonoid R} (ha : ↑sa = s) :
+  (subsemiring.mk' s sm hm sa ha).to_submonoid = sm :=
+submonoid.ext' hm.symm
+
+@[simp] lemma mk'_to_add_submonoid {s : set R} {sm : submonoid R} (hm : ↑sm = s)
+  {sa : add_submonoid R} (ha : ↑sa  =s) :
+  (subsemiring.mk' s sm hm sa ha).to_add_submonoid = sa :=
+add_submonoid.ext' ha.symm
+
+end subsemiring
+
+protected lemma subsemiring.exists {s : subsemiring R} {p : s → Prop} :
+  (∃ x : s, p x) ↔ ∃ x ∈ s, p ⟨x, ‹x ∈ s›⟩ :=
+set_coe.exists
+
+protected lemma subsemiring.forall {s : subsemiring R} {p : s → Prop} :
+  (∀ x : s, p x) ↔ ∀ x ∈ s, p ⟨x, ‹x ∈ s›⟩ :=
+set_coe.forall
+
+namespace subsemiring
+
+variables (s : subsemiring R)
+
+/-- Two subsemirings are equal if the underlying subsets are equal. -/
+theorem ext' ⦃s t : subsemiring R⦄ (h : (s : set R) = t) : s = t :=
+by cases s; cases t; congr'
+
+/-- Two subsemirings are equal if and only if the underlying subsets are equal. -/
+protected theorem ext'_iff {s t : subsemiring R}  : s = t ↔ (s : set R) = t :=
+⟨λ h, h ▸ rfl, λ h, ext' h⟩
+
+/-- Two subsemirings are equal if they have the same elements. -/
+theorem ext {S T : subsemiring R} (h : ∀ x, x ∈ S ↔ x ∈ T) : S = T := ext' $ set.ext h
+
+/-- A subsemiring contains the semiring's 1. -/
+theorem one_mem : (1 : R) ∈ s := s.one_mem'
+
+/-- A subsemiring contains the semiring's 0. -/
+theorem zero_mem : (0 : R) ∈ s := s.zero_mem'
+
+/-- A subsemiring is closed under multiplication. -/
+theorem mul_mem : ∀ {x y : R}, x ∈ s → y ∈ s → x * y ∈ s := s.mul_mem'
+
+/-- A subsemiring is closed under addition. -/
+theorem add_mem : ∀ {x y : R}, x ∈ s → y ∈ s → x + y ∈ s := s.add_mem'
+
+/-- Product of a list of elements in a subsemiring is in the subsemiring. -/
+lemma list_prod_mem {l : list R} : (∀x ∈ l, x ∈ s) → l.prod ∈ s :=
+s.to_submonoid.list_prod_mem
+
+/-- Sum of a list of elements in an `add_subsemiring` is in the `add_subsemiring`. -/
+lemma list_sum_mem {l : list R} : (∀x ∈ l, x ∈ s) → l.sum ∈ s :=
+s.to_add_submonoid.list_sum_mem
+
+/-- Product of a multiset of elements in a subsemiring of a `comm_monoid` is in the subsemiring. -/
+lemma multiset_prod_mem {R} [comm_semiring R] (s : subsemiring R) (m : multiset R) :
+  (∀a ∈ m, a ∈ s) → m.prod ∈ s :=
+s.to_submonoid.multiset_prod_mem m
+
+/-- Sum of a multiset of elements in an `add_subsemiring` of an `add_comm_monoid` is
+in the `add_subsemiring`. -/
+lemma multiset_sum_mem {R} [semiring R] (s : subsemiring R) (m : multiset R) :
+  (∀a ∈ m, a ∈ s) → m.sum ∈ s :=
+s.to_add_submonoid.multiset_sum_mem m
+
+/-- Product of elements of a subsemiring of a `comm_monoid` indexed by a `finset` is in the
+    subsemiring. -/
+lemma prod_mem {R : Type*} [comm_semiring R] (s : subsemiring R)
+  {ι : Type*} {t : finset ι} {f : ι → R} (h : ∀c ∈ t, f c ∈ s) :
+  t.prod f ∈ s :=
+s.to_submonoid.prod_mem h
+
+/-- Sum of elements in an `add_subsemiring` of an `add_comm_monoid` indexed by a `finset`
+is in the `add_subsemiring`. -/
+lemma sum_mem {R : Type*} [semiring R] (s : subsemiring R)
+  {ι : Type*} {t : finset ι} {f : ι → R} (h : ∀c ∈ t, f c ∈ s) :
+  t.sum f ∈ s :=
+s.to_add_submonoid.sum_mem h
+
+lemma pow_mem {x : R} (hx : x ∈ s) (n : ℕ) : x^n ∈ s := s.to_submonoid.pow_mem hx n
+
+lemma smul_mem {x : R} (hx : x ∈ s) (n : ℕ) :
+  add_monoid.smul n x ∈ s := s.to_add_submonoid.smul_mem hx n
+
+lemma coe_nat_mem (n : ℕ) : (n : R) ∈ s :=
+by simp only [← add_monoid.smul_one, smul_mem, one_mem]
+
+/-- A subsemiring of a semiring inherits a semiring structure -/
+instance to_semiring : semiring s :=
+{ mul_zero := λ x, subtype.eq $ mul_zero x,
+  zero_mul := λ x, subtype.eq $ zero_mul x,
+  right_distrib := λ x y z, subtype.eq $ right_distrib x y z,
+  left_distrib := λ x y z, subtype.eq $ left_distrib x y z,
+  .. s.to_submonoid.to_monoid, .. s.to_add_submonoid.to_add_comm_monoid }
+
+@[simp, norm_cast] lemma coe_mul (x y : s) : (↑(x * y) : R) = ↑x * ↑y := rfl
+@[simp, norm_cast] lemma coe_one : ((1 : s) : R) = 1 := rfl
+
+/-- A subsemiring of a `comm_semiring` is a `comm_semiring`. -/
+instance to_comm_semiring {R} [comm_semiring R] (s : subsemiring R) : comm_semiring s :=
+{ mul_comm := λ _ _, subtype.eq $ mul_comm _ _, ..s.to_semiring}
+
+/-- The natural ring hom from a subsemiring of monoid `R` to `R`. -/
+def subtype : s →+* R :=
+{ to_fun := coe, .. s.to_submonoid.subtype, .. s.to_add_submonoid.subtype }
+
+@[simp] theorem coe_subtype : ⇑s.subtype = coe := rfl
+
+instance : partial_order (subsemiring R) :=
+{ le := λ s t, ∀ ⦃x⦄, x ∈ s → x ∈ t,
+  .. partial_order.lift (coe : subsemiring R → set R) ext' _ }
+
+lemma le_def {s t : subsemiring R} : s ≤ t ↔ ∀ ⦃x : R⦄, x ∈ s → x ∈ t := iff.rfl
+
+@[simp, norm_cast] lemma coe_subset_coe {s t : subsemiring R} : (s : set R) ⊆ t ↔ s ≤ t := iff.rfl
+
+@[simp, norm_cast] lemma coe_ssubset_coe {s t : subsemiring R} : (s : set R) ⊂ t ↔ s < t := iff.rfl
+
+@[simp, norm_cast]
+lemma mem_coe {S : subsemiring R} {m : R} : m ∈ (S : set R) ↔ m ∈ S := iff.rfl
+
+@[simp, norm_cast]
+lemma coe_coe (s : subsemiring R) : ↥(s : set R) = s := rfl
+
+@[simp] lemma mem_to_submonoid {s : subsemiring R} {x : R} : x ∈ s.to_submonoid ↔ x ∈ s := iff.rfl
+@[simp] lemma coe_to_submonoid (s : subsemiring R) : (s.to_submonoid : set R) = s := rfl
+@[simp] lemma mem_to_add_submonoid {s : subsemiring R} {x : R} :
+  x ∈ s.to_add_submonoid ↔ x ∈ s := iff.rfl
+@[simp] lemma coe_to_add_submonoid (s : subsemiring R) : (s.to_add_submonoid : set R) = s := rfl
+
+/-- The subsemiring `R` of the semiring `R`. -/
+instance : has_top (subsemiring R) :=
+⟨{ .. (⊤ : submonoid R), .. (⊤ : add_submonoid R) }⟩
+
+@[simp] lemma mem_top (x : R) : x ∈ (⊤ : subsemiring R) := set.mem_univ x
+
+@[simp] lemma coe_top : ((⊤ : subsemiring R) : set R) = set.univ := rfl
+
+/-- The preimage of a subsemiring along a ring homomorphism is a subsemiring. -/
+def comap (f : R →+* S) (s : subsemiring S) : subsemiring R :=
+{ carrier := f ⁻¹' s,
+  .. s.to_submonoid.comap (f : R →* S), .. s.to_add_submonoid.comap (f : R →+ S) }
+
+@[simp] lemma coe_comap (s : subsemiring S) (f : R →+* S) : (s.comap f : set R) = f ⁻¹' s := rfl
+
+@[simp]
+lemma mem_comap {s : subsemiring S} {f : R →+* S} {x : R} : x ∈ s.comap f ↔ f x ∈ s := iff.rfl
+
+lemma comap_comap (s : subsemiring T) (g : S →+* T) (f : R →+* S) :
+  (s.comap g).comap f = s.comap (g.comp f) :=
+rfl
+
+/-- The image of a subsemiring along a ring homomorphism is a subsemiring. -/
+def map (f : R →+* S) (s : subsemiring R) : subsemiring S :=
+{ carrier := f '' s,
+  .. s.to_submonoid.map (f : R →* S), .. s.to_add_submonoid.map (f : R →+ S) }
+
+@[simp] lemma coe_map (f : R →+* S) (s : subsemiring R) : (s.map f : set S) = f '' s := rfl
+
+@[simp] lemma mem_map {f : R →+* S} {s : subsemiring R} {y : S} :
+  y ∈ s.map f ↔ ∃ x ∈ s, f x = y :=
+set.mem_image_iff_bex
+
+lemma map_map (g : S →+* T) (f : R →+* S) : (s.map f).map g = s.map (g.comp f) :=
+ext' $ set.image_image _ _ _
+
+lemma map_le_iff_le_comap {f : R →+* S} {s : subsemiring R} {t : subsemiring S} :
+  s.map f ≤ t ↔ s ≤ t.comap f :=
+set.image_subset_iff
+
+lemma gc_map_comap (f : R →+* S) : galois_connection (map f) (comap f) :=
+λ S T, map_le_iff_le_comap
+
+end subsemiring
+
+namespace ring_hom
+
+variables (g : S →+* T) (f : R →+* S)
+
+/-- The range of a ring homomorphism is a subsemiring. -/
+def srange : subsemiring S := (⊤ : subsemiring R).map f
+
+@[simp] lemma coe_srange : (f.srange : set S) = set.range f := set.image_univ
+
+@[simp] lemma mem_srange {f : R →+* S} {y : S} : y ∈ f.srange ↔ ∃ x, f x = y :=
+by simp [srange]
+
+lemma map_srange : f.srange.map g = (g.comp f).srange :=
+(⊤ : subsemiring R).map_map g f
+
+end ring_hom
+
+namespace subsemiring
+
+instance : has_bot (subsemiring R) := ⟨(nat.cast_ring_hom R).srange⟩
+
+instance : inhabited (subsemiring R) := ⟨⊥⟩
+
+lemma coe_bot : ((⊥ : subsemiring R) : set R) = set.range (coe : ℕ → R) :=
+(nat.cast_ring_hom R).coe_srange
+
+lemma mem_bot {x : R} : x ∈ (⊥ : subsemiring R) ↔ ∃ n : ℕ, ↑n=x := ring_hom.mem_srange
+
+/-- The inf of two subsemirings is their intersection. -/
+instance : has_inf (subsemiring R) :=
+⟨λ s t,
+  { carrier := s ∩ t,
+    .. s.to_submonoid ⊓ t.to_submonoid,
+    .. s.to_add_submonoid ⊓ t.to_add_submonoid }⟩
+
+@[simp] lemma coe_inf (p p' : subsemiring R) : ((p ⊓ p' : subsemiring R) : set R) = p ∩ p' := rfl
+
+@[simp] lemma mem_inf {p p' : subsemiring R} {x : R} : x ∈ p ⊓ p' ↔ x ∈ p ∧ x ∈ p' := iff.rfl
+
+instance : has_Inf (subsemiring R) :=
+⟨λ s, subsemiring.mk' (⋂ t ∈ s, ↑t) (⨅ t ∈ s, subsemiring.to_submonoid t) (by simp)
+  (⨅ t ∈ s, subsemiring.to_add_submonoid t) (by simp)⟩
+
+@[simp, norm_cast] lemma coe_Inf (S : set (subsemiring R)) :
+  ((Inf S : subsemiring R) : set R) = ⋂ s ∈ S, ↑s := rfl
+
+lemma mem_Inf {S : set (subsemiring R)} {x : R} : x ∈ Inf S ↔ ∀ p ∈ S, x ∈ p := set.mem_bInter_iff
+
+@[simp] lemma Inf_to_submonoid (s : set (subsemiring R)) :
+  (Inf s).to_submonoid = ⨅ t ∈ s, subsemiring.to_submonoid t :=
+mk'_to_submonoid _ _
+
+@[simp] lemma Inf_to_add_submonoid (s : set (subsemiring R)) :
+  (Inf s).to_add_submonoid = ⨅ t ∈ s, subsemiring.to_add_submonoid t :=
+mk'_to_add_submonoid _ _
+
+/-- Subsemirings of a semiring form a complete lattice. -/
+instance : complete_lattice (subsemiring R) :=
+{ bot := (⊥),
+  bot_le := λ s x hx, let ⟨n, hn⟩ := mem_bot.1 hx in hn ▸ s.coe_nat_mem n,
+  top := (⊤),
+  le_top := λ s x hx, trivial,
+  inf := (⊓),
+  inf_le_left := λ s t x, and.left,
+  inf_le_right := λ s t x, and.right,
+  le_inf := λ s t₁ t₂ h₁ h₂ x hx, ⟨h₁ hx, h₂ hx⟩,
+  .. complete_lattice_of_Inf (subsemiring R)
+    (λ s, is_glb.of_image (λ s t, show (s : set R) ≤ t ↔ s ≤ t, from coe_subset_coe) is_glb_binfi)}
+
+/-- The `subsemiring` generated by a set. -/
+def closure (s : set R) : subsemiring R := Inf {S | s ⊆ S}
+
+lemma mem_closure {x : R} {s : set R} : x ∈ closure s ↔ ∀ S : subsemiring R, s ⊆ S → x ∈ S :=
+mem_Inf
+
+/-- The subsemiring generated by a set includes the set. -/
+@[simp] lemma subset_closure {s : set R} : s ⊆ closure s := λ x hx, mem_closure.2 $ λ S hS, hS hx
+
+/-- A subsemiring `S` includes `closure s` if and only if it includes `s`. -/
+@[simp]
+lemma closure_le {s : set R} {t : subsemiring R} : closure s ≤ t ↔ s ⊆ t :=
+⟨set.subset.trans subset_closure, λ h, Inf_le h⟩
+
+/-- Subsemiring closure of a set is monotone in its argument: if `s ⊆ t`,
+then `closure s ≤ closure t`. -/
+lemma closure_mono ⦃s t : set R⦄ (h : s ⊆ t) : closure s ≤ closure t :=
+closure_le.2 $ set.subset.trans h subset_closure
+
+lemma closure_eq_of_le {s : set R} {t : subsemiring R} (h₁ : s ⊆ t) (h₂ : t ≤ closure s) :
+  closure s = t :=
+le_antisymm (closure_le.2 h₁) h₂
+
+/-- An induction principle for closure membership. If `p` holds for `0`, `1`, and all elements
+of `s`, and is preserved under addition and multiplication, then `p` holds for all elements
+of the closure of `s`. -/
+@[elab_as_eliminator]
+lemma closure_induction {s : set R} {p : R → Prop} {x} (h : x ∈ closure s)
+  (Hs : ∀ x ∈ s, p x) (H0 : p 0) (H1 : p 1)
+  (Hadd : ∀ x y, p x → p y → p (x + y)) (Hmul : ∀ x y, p x → p y → p (x * y)) : p x :=
+(@closure_le _ _ _ ⟨p, H1, Hmul, H0, Hadd⟩).2 Hs h
+
+variable (R)
+
+/-- `closure` forms a Galois insertion with the coercion to set. -/
+protected def gi : galois_insertion (@closure R _) coe :=
+{ choice := λ s _, closure s,
+  gc := λ s t, closure_le,
+  le_l_u := λ s, subset_closure,
+  choice_eq := λ s h, rfl }
+
+variable {R}
+
+/-- Closure of a subsemiring `S` equals `S`. -/
+lemma closure_eq (s : subsemiring R) : closure (s : set R) = s := (subsemiring.gi R).l_u_eq s
+
+@[simp] lemma closure_empty : closure (∅ : set R) = ⊥ := (subsemiring.gi R).gc.l_bot
+
+@[simp] lemma closure_univ : closure (set.univ : set R) = ⊤ := @coe_top R _ ▸ closure_eq ⊤
+
+lemma closure_union (s t : set R) : closure (s ∪ t) = closure s ⊔ closure t :=
+(subsemiring.gi R).gc.l_sup
+
+lemma closure_Union {ι} (s : ι → set R) : closure (⋃ i, s i) = ⨆ i, closure (s i) :=
+(subsemiring.gi R).gc.l_supr
+
+lemma closure_sUnion (s : set (set R)) : closure (⋃₀ s) = ⨆ t ∈ s, closure t :=
+(subsemiring.gi R).gc.l_Sup
+
+lemma map_sup (s t : subsemiring R) (f : R →+* S) : (s ⊔ t).map f = s.map f ⊔ t.map f :=
+(gc_map_comap f).l_sup
+
+lemma map_supr {ι : Sort*} (f : R →+* S) (s : ι → subsemiring R) :
+  (supr s).map f = ⨆ i, (s i).map f :=
+(gc_map_comap f).l_supr
+
+lemma comap_inf (s t : subsemiring S) (f : R →+* S) : (s ⊓ t).comap f = s.comap f ⊓ t.comap f :=
+(gc_map_comap f).u_inf
+
+lemma comap_infi {ι : Sort*} (f : R →+* S) (s : ι → subsemiring S) :
+  (infi s).comap f = ⨅ i, (s i).comap f :=
+(gc_map_comap f).u_infi
+
+@[simp] lemma map_bot (f : R →+* S) : (⊥ : subsemiring R).map f = ⊥ :=
+(gc_map_comap f).l_bot
+
+@[simp] lemma comap_top (f : R →+* S) : (⊤ : subsemiring S).comap f = ⊤ :=
+(gc_map_comap f).u_top
+
+/-- Given `subsemiring`s `s`, `t` of semirings `R`, `S` respectively, `s.prod t` is `s × t`
+as a subsemiring of `R × S`. -/
+def prod (s : subsemiring R) (t : subsemiring S) : subsemiring (R × S) :=
+{ carrier := (s : set R).prod t,
+  .. s.to_submonoid.prod t.to_submonoid, .. s.to_add_submonoid.prod t.to_add_submonoid}
+
+@[norm_cast]
+lemma coe_prod (s : subsemiring R) (t : subsemiring S) :
+  (s.prod t : set (R × S)) = (s : set R).prod (t : set S) :=
+rfl
+
+lemma mem_prod {s : subsemiring R} {t : subsemiring S} {p : R × S} :
+  p ∈ s.prod t ↔ p.1 ∈ s ∧ p.2 ∈ t := iff.rfl
+
+@[mono] lemma prod_mono ⦃s₁ s₂ : subsemiring R⦄ (hs : s₁ ≤ s₂) ⦃t₁ t₂ : subsemiring S⦄
+  (ht : t₁ ≤ t₂) : s₁.prod t₁ ≤ s₂.prod t₂ :=
+set.prod_mono hs ht
+
+lemma prod_mono_right (s : subsemiring R) : monotone (λ t : subsemiring S, s.prod t) :=
+prod_mono (le_refl s)
+
+lemma prod_mono_left (t : subsemiring S) : monotone (λ s : subsemiring R, s.prod t) :=
+λ s₁ s₂ hs, prod_mono hs (le_refl t)
+
+lemma prod_top (s : subsemiring R) :
+  s.prod (⊤ : subsemiring S) = s.comap (ring_hom.fst R S) :=
+ext $ λ x, by simp [mem_prod, monoid_hom.coe_fst]
+
+lemma top_prod (s : subsemiring S) :
+  (⊤ : subsemiring R).prod s = s.comap (ring_hom.snd R S) :=
+ext $ λ x, by simp [mem_prod, monoid_hom.coe_snd]
+
+@[simp]
+lemma top_prod_top : (⊤ : subsemiring R).prod (⊤ : subsemiring S) = ⊤ :=
+(top_prod _).trans $ comap_top _
+
+/-- Product of subsemirings is isomorphic to their product as monoids. -/
+def prod_equiv (s : subsemiring R) (t : subsemiring S) : s.prod t ≃+* s × t :=
+{ map_mul' := λ x y, rfl, map_add' := λ x y, rfl, .. equiv.set.prod ↑s ↑t }
+
+lemma mem_supr_of_directed {ι} [hι : nonempty ι] {S : ι → subsemiring R} (hS : directed (≤) S)
+  {x : R} :
+  x ∈ (⨆ i, S i) ↔ ∃ i, x ∈ S i :=
+begin
+  refine ⟨_, λ ⟨i, hi⟩, (le_def.1 $ le_supr S i) hi⟩,
+  let U : subsemiring R := subsemiring.mk' (⋃ i, (S i : set R))
+    (⨆ i, (S i).to_submonoid) (submonoid.coe_supr_of_directed $ hS.mono_comp _ (λ _ _, id))
+    (⨆ i, (S i).to_add_submonoid) (add_submonoid.coe_supr_of_directed $ hS.mono_comp _ (λ _ _, id)),
+  suffices : (⨆ i, S i) ≤ U, by simpa using @this x,
+  exact supr_le (λ i x hx, set.mem_Union.2 ⟨i, hx⟩),
+end
+
+lemma coe_supr_of_directed {ι} [hι : nonempty ι] {S : ι → subsemiring R} (hS : directed (≤) S) :
+  ((⨆ i, S i : subsemiring R) : set R) = ⋃ i, ↑(S i) :=
+set.ext $ λ x, by simp [mem_supr_of_directed hS]
+
+lemma mem_Sup_of_directed_on {S : set (subsemiring R)} (Sne : S.nonempty)
+  (hS : directed_on (≤) S) {x : R} :
+  x ∈ Sup S ↔ ∃ s ∈ S, x ∈ s :=
+begin
+  haveI : nonempty S := Sne.to_subtype,
+  rw [Sup_eq_supr, supr_subtype', mem_supr_of_directed, subtype.exists],
+  exact (directed_on_iff_directed _).1 hS
+end
+
+lemma coe_Sup_of_directed_on {S : set (subsemiring R)} (Sne : S.nonempty) (hS : directed_on (≤) S) :
+  (↑(Sup S) : set R) = ⋃ s ∈ S, ↑s :=
+set.ext $ λ x, by simp [mem_Sup_of_directed_on Sne hS]
+
+end subsemiring
+
+namespace ring_hom
+
+variables [semiring T] {s : subsemiring R}
+
+open subsemiring
+
+/-- Restriction of a ring homomorphism to a subsemiring of the domain. -/
+def srestrict (f : R →+* S) (s : subsemiring R) : s →+* S := f.comp s.subtype
+
+@[simp] lemma srestrict_apply (f : R →+* S) (x : s) : f.srestrict s x = f x := rfl
+
+/-- Restriction of a ring homomorphism to a subsemiring of the codomain. -/
+def cod_srestrict (f : R →+* S) (s : subsemiring S) (h : ∀ x, f x ∈ s) : R →+* s :=
+{ to_fun := λ n, ⟨f n, h n⟩,
+  .. (f : R →* S).cod_mrestrict s.to_submonoid h,
+  .. (f : R →+ S).cod_mrestrict s.to_add_submonoid h }
+
+/-- Restriction of a ring homomorphism to its range iterpreted as a subsemiring. -/
+def srange_restrict (f : R →+* S) : R →+* f.srange :=
+f.cod_srestrict f.srange $ λ x, ⟨x, subsemiring.mem_top x, rfl⟩
+
+@[simp] lemma coe_srange_restrict (f : R →+* S) (x : R) :
+  (f.srange_restrict x : S) = f x :=
+rfl
+
+lemma srange_top_iff_surjective {f : R →+* S} :
+  f.srange = (⊤ : subsemiring S) ↔ function.surjective f :=
+subsemiring.ext'_iff.trans $ iff.trans (by rw [coe_srange, coe_top]) set.range_iff_surjective
+
+/-- The range of a surjective ring homomorphism is the whole of the codomain. -/
+lemma srange_top_of_surjective (f : R →+* S) (hf : function.surjective f) :
+  f.srange = (⊤ : subsemiring S) :=
+srange_top_iff_surjective.2 hf
+
+/-- The subsemiring of elements `x : R` such that `f x = g x` -/
+def eq_slocus (f g : R →+* S) : subsemiring R :=
+{ carrier := {x | f x = g x}, .. (f : R →* S).eq_mlocus g, .. (f : R →+ S).eq_mlocus g }
+
+/-- If two ring homomorphisms are equal on a set, then they are equal on its subsemiring closure. -/
+lemma eq_on_sclosure {f g : R →+* S} {s : set R} (h : set.eq_on f g s) :
+  set.eq_on f g (closure s) :=
+show closure s ≤ f.eq_slocus g, from closure_le.2 h
+
+lemma eq_of_eq_on_stop {f g : R →+* S} (h : set.eq_on f g (⊤ : subsemiring R)) :
+  f = g :=
+ext $ λ x, h trivial
+
+lemma eq_of_eq_on_sdense {s : set R} (hs : closure s = ⊤) {f g : R →+* S} (h : s.eq_on f g) :
+  f = g :=
+eq_of_eq_on_stop $ hs ▸ eq_on_sclosure h
+
+lemma sclosure_preimage_le (f : R →+* S) (s : set S) :
+  closure (f ⁻¹' s) ≤ (closure s).comap f :=
+closure_le.2 $ λ x hx, mem_coe.2 $ mem_comap.2 $ subset_closure hx
+
+/-- The image under a ring homomorphism of the subsemiring generated by a set equals
+the subsemiring generated by the image of the set. -/
+lemma map_sclosure (f : R →+* S) (s : set R) :
+  (closure s).map f = closure (f '' s) :=
+le_antisymm
+  (map_le_iff_le_comap.2 $ le_trans (closure_mono $ set.subset_preimage_image _ _)
+    (sclosure_preimage_le _ _))
+  (closure_le.2 $ set.image_subset _ subset_closure)
+
+end ring_hom
+
+namespace subsemiring
+
+open ring_hom
+
+/-- The ring homomorphism associated to an inclusion of subsemirings. -/
+def inclusion {S T : subsemiring R} (h : S ≤ T) : S →* T :=
+S.subtype.cod_srestrict _ (λ x, h x.2)
+
+@[simp] lemma srange_subtype (s : subsemiring R) : s.subtype.srange = s :=
+ext' $ (coe_srange _).trans $ set.range_coe_subtype s
+
+@[simp]
+lemma range_fst : (fst R S).srange = ⊤ :=
+(fst R S).srange_top_of_surjective $ prod.fst_surjective
+
+@[simp]
+lemma range_snd : (snd R S).srange = ⊤ :=
+(snd R S).srange_top_of_surjective $ prod.snd_surjective
+
+@[simp]
+lemma prod_bot_sup_bot_prod (s : subsemiring R) (t : subsemiring S) :
+  (s.prod ⊥) ⊔ (prod ⊥ t) = s.prod t :=
+le_antisymm (sup_le (prod_mono_right s bot_le) (prod_mono_left t bot_le)) $
+assume p hp, prod.fst_mul_snd p ▸ mul_mem _
+  ((le_sup_left : s.prod ⊥ ≤ s.prod ⊥ ⊔ prod ⊥ t) ⟨hp.1, mem_coe.2 $ one_mem ⊥⟩)
+  ((le_sup_right : prod ⊥ t ≤ s.prod ⊥ ⊔ prod ⊥ t) ⟨mem_coe.2 $ one_mem ⊥, hp.2⟩)
+
+end subsemiring
+
+namespace ring_equiv
+
+variables {s t : subsemiring R}
+
+/-- Makes the identity isomorphism from a proof two subsemirings of a multiplicative
+    monoid are equal. -/
+def subsemiring_congr (h : s = t) : s ≃+* t :=
+{ map_mul' :=  λ _ _, rfl, map_add' := λ _ _, rfl, ..equiv.set_congr $ subsemiring.ext'_iff.1 h }
+
+end ring_equiv


### PR DESCRIPTION
~~Depends on #2836,~~ needs a better module docstring.

Some lemmas are missing, most notably `(subsemiring.closure s : set R) = add_submonoid.closure (submonoid.closure s)`.