### PR TITLE
refactor(algebra/group/basic): minimal axioms for group and comm_monoid

### DIFF
--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -349,8 +349,6 @@ rfl
 instance : comm_monoid (associates α) :=
 { one       := 1,
   mul       := (*),
-  mul_one   := assume a', quotient.induction_on a' $
-    assume a, show ⟦a * 1⟧ = ⟦ a ⟧, by simp,
   one_mul   := assume a', quotient.induction_on a' $
     assume a, show ⟦1 * a⟧ = ⟦ a ⟧, by simp,
   mul_assoc := assume a' b' c', quotient.induction_on₃ a' b' c' $

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -208,7 +208,6 @@ instance {M N} [monoid M] [comm_monoid N] : comm_monoid (M →* N) :=
   mul_assoc := by intros; ext; apply mul_assoc,
   one := 1,
   one_mul := by intros; ext; apply one_mul,
-  mul_one := by intros; ext; apply mul_one,
   mul_comm := by intros; ext; apply mul_comm }
 
 /-- `flip` arguments of `f : M →* N →* P` -/

--- a/src/algebra/group/units.lean
+++ b/src/algebra/group/units.lean
@@ -61,7 +61,6 @@ ext.eq_iff.symm
     by rw [mul_assoc, ← mul_assoc u₂.val, val_inv, one_mul, val_inv],
     by rw [mul_assoc, ← mul_assoc u₁.inv, inv_val, one_mul, inv_val]⟩,
   one := ⟨1, 1, one_mul 1, one_mul 1⟩,
-  mul_one := λ u, ext $ mul_one u,
   one_mul := λ u, ext $ one_mul u,
   mul_assoc := λ u₁ u₂ u₃, ext $ mul_assoc u₁ u₂ u₃,
   inv := λ u, ⟨u.2, u.1, u.4, u.3⟩,

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -580,7 +580,9 @@ instance ordered_cancel_add_comm_monoid.to_ordered_add_comm_monoid : ordered_add
 { lt_of_add_lt_add_left := @lt_of_add_lt_add_left _ _, ..‹ordered_cancel_add_comm_monoid α› }
 
 instance ordered_cancel_add_comm_monoid.to_add_left_cancel_monoid :
-  add_left_cancel_monoid α := { ..‹ordered_cancel_add_comm_monoid α› }
+  add_left_cancel_monoid α := {
+  ..show add_monoid α, by apply_instance,
+  ..‹ordered_cancel_add_comm_monoid α› }
 
 @[simp] lemma add_le_add_iff_left (a : α) {b c : α} : a + b ≤ a + c ↔ b ≤ c :=
 ⟨le_of_add_le_add_left, λ h, add_le_add_left h _⟩

--- a/src/data/equiv/transfer_instance.lean
+++ b/src/data/equiv/transfer_instance.lean
@@ -80,7 +80,7 @@ protected def comm_monoid [comm_monoid β] : comm_monoid α :=
 
 /-- Transfer `group` across an `equiv` -/
 protected def group [group β] : group α :=
-{ mul_left_inv := by simp [mul_def, inv_def, one_def],
+{ mul_left_inv := λ _, by simp [mul_def, one_def, inv_def]; refl,
   ..equiv.monoid e,
   ..equiv.has_inv e }
 

--- a/src/data/fintype/card.lean
+++ b/src/data/fintype/card.lean
@@ -76,7 +76,7 @@ end
 
 theorem fin.sum_univ_succ [add_comm_monoid β] {n:ℕ} (f : fin n.succ → β) :
   univ.sum f = f 0 + univ.sum (λ i:fin n, f i.succ) :=
-by apply @fin.prod_univ_succ (multiplicative β)
+@fin.prod_univ_succ (multiplicative β) _ _ f
 
 attribute [to_additive] fin.prod_univ_succ
 
@@ -90,7 +90,7 @@ end
 
 theorem fin.sum_univ_cast_succ [add_comm_monoid β] {n:ℕ} (f : fin n.succ → β) :
   univ.sum f = univ.sum (λ i:fin n, f i.cast_succ) + f (fin.last n) :=
-by apply @fin.prod_univ_cast_succ (multiplicative β)
+@fin.prod_univ_cast_succ (multiplicative β) _ _ f
 attribute [to_additive] fin.prod_univ_cast_succ
 
 @[simp] theorem fintype.card_sigma {α : Type*} (β : α → Type*)

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -1721,8 +1721,8 @@ begin
   refine s.induction_on _ _,
   { simp },
   { assume a s ih,
-    simp [ih, add_mul, mul_comm, mul_left_comm, mul_assoc, sum_map_mul_left.symm],
-    cc },
+    simp [ih, add_mul, mul_comm, mul_left_comm, mul_assoc, sum_map_mul_left.symm,
+      add_assoc, add_left_comm, add_comm] },
 end
 
 /- powerset_len -/

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -420,7 +420,6 @@ instance : ordered_cancel_add_comm_monoid (multiset α) :=
   add_assoc             := λ s₁ s₂ s₃, quotient.induction_on₃ s₁ s₂ s₃ $ λ l₁ l₂ l₃,
     congr_arg coe $ append_assoc l₁ l₂ l₃,
   zero_add              := multiset.zero_add,
-  add_zero              := λ s, by rw [multiset.add_comm, multiset.zero_add],
   add_left_cancel       := multiset.add_left_cancel,
   add_right_cancel      := λ s₁ s₂ s₃ h, multiset.add_left_cancel s₂ $
     by simpa [multiset.add_comm] using h,

--- a/src/data/nat/enat.lean
+++ b/src/data/nat/enat.lean
@@ -28,7 +28,6 @@ instance : add_comm_monoid enat :=
   zero      := (0),
   add_comm  := λ x y, roption.ext' and.comm (λ _ _, add_comm _ _),
   zero_add  := λ x, roption.ext' (true_and _) (λ _ _, zero_add _),
-  add_zero  := λ x, roption.ext' (and_true _) (λ _ _, add_zero _),
   add_assoc := λ x y z, roption.ext' and.assoc (λ _ _, add_assoc _ _ _) }
 
 instance : has_le enat := ⟨λ x y, ∃ h : y.dom → x.dom, ∀ hy : y.dom, x.get (h hy) ≤ y.get hy⟩

--- a/src/data/num/lemmas.lean
+++ b/src/data/num/lemmas.lean
@@ -283,7 +283,6 @@ by refine {
   add      := (+),
   zero     := 0,
   zero_add := zero_add,
-  add_zero := add_zero,
   mul      := (*),
   one      := 1, .. }; try {transfer}; simp [mul_add, mul_left_comm, mul_comm, add_comm]
 
@@ -1013,7 +1012,6 @@ instance : add_comm_group znum :=
   add_assoc        := by transfer,
   zero             := 0,
   zero_add         := zero_add,
-  add_zero         := add_zero,
   add_comm         := by transfer,
   neg              := has_neg.neg,
   add_left_neg     := by transfer }

--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -115,7 +115,6 @@ instance : comm_monoid ℕ+ :=
   mul_assoc := λ a b c, subtype.eq (mul_assoc _ _ _),
   one       := succ_pnat 0,
   one_mul   := λ a, subtype.eq (one_mul _),
-  mul_one   := λ a, subtype.eq (mul_one _),
   mul_comm  := λ a b, subtype.eq (mul_comm _ _) }
 
 theorem lt_add_one_iff : ∀ {a b : ℕ+}, a < b + 1 ↔ a ≤ b :=

--- a/src/data/rat/basic.lean
+++ b/src/data/rat/basic.lean
@@ -144,7 +144,8 @@ begin
     constructor; intro h; apply neg_inj; simpa [left_distrib, neg_add_eq_iff_eq_add,
       eq_neg_iff_add_eq_zero, neg_eq_iff_add_eq_zero] using h },
   { change -a * ↑d = c * b.succ ↔ a * d = c * -b.succ,
-    constructor; intro h; apply neg_inj; simpa [left_distrib, eq_comm] using h },
+    constructor; intro h; apply neg_inj;
+    simp [left_distrib, *] at * },
   { change -a * d.succ = -c * b.succ ↔ a * -d.succ = c * -b.succ,
     simp [left_distrib, sub_eq_add_neg], cc }
 end,
@@ -417,7 +418,6 @@ instance : field ℚ :=
   mul              := rat.mul,
   inv              := rat.inv,
   zero_add         := rat.zero_add,
-  add_zero         := rat.add_zero,
   add_comm         := rat.add_comm,
   add_assoc        := rat.add_assoc,
   add_left_neg     := rat.add_left_neg,

--- a/src/group_theory/eckmann_hilton.lean
+++ b/src/group_theory/eckmann_hilton.lean
@@ -17,7 +17,7 @@ class is_unital (m : X → X → X) (e : X) : Prop :=
 (one_mul : ∀ x : X, (e <m> x) = x)
 (mul_one : ∀ x : X, (x <m> e) = x)
 
-lemma group.is_unital [G : group X] : is_unital (*) (1 : X) := { ..G }
+lemma monoid.is_unital [G : monoid X] : is_unital (*) (1 : X) := { ..G }
 
 variables {m₁ m₂ : X → X → X} {e₁ e₂ : X}
 variables (h₁ : is_unital m₁ e₁) (h₂ : is_unital m₂ e₂)
@@ -50,7 +50,7 @@ def comm_monoid : comm_monoid X :=
   ..h₂ }
 
 def comm_group [G : group X] (distrib : ∀ a b c d, ((a * b) <m₁> (c * d)) = ((a <m₁> c) * (b <m₁> d))) : comm_group X :=
-{ mul_comm := (eckmann_hilton.comm_monoid h₁ group.is_unital distrib).mul_comm,
+{ mul_comm := (eckmann_hilton.comm_monoid h₁ monoid.is_unital distrib).mul_comm,
   ..G }
 
 end eckmann_hilton

--- a/src/group_theory/free_group.lean
+++ b/src/group_theory/free_group.lean
@@ -346,7 +346,6 @@ instance : group (free_group α) :=
   inv := has_inv.inv,
   mul_assoc := by rintros ⟨L₁⟩ ⟨L₂⟩ ⟨L₃⟩; simp,
   one_mul := by rintros ⟨L⟩; refl,
-  mul_one := by rintros ⟨L⟩; simp [one_eq_mk],
   mul_left_inv := by rintros ⟨L⟩; exact (list.rec_on L rfl $
     λ ⟨x, b⟩ tl ih, eq.trans (quot.sound $ by simp [one_eq_mk]) ih) }
 

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -467,7 +467,7 @@ is_mul_hom.map_mul sign _ _
 is_group_hom.map_one sign
 
 @[simp] lemma sign_refl : sign (equiv.refl α) = 1 :=
-is_group_hom.map_one sign
+show sign 1 = 1, by exact is_group_hom.map_one sign
 
 @[simp] lemma sign_inv (f : perm α) : sign f⁻¹ = sign f :=
 by rw [is_group_hom.map_inv sign, int.units_inv_eq_self]; apply_instance

--- a/src/group_theory/quotient_group.lean
+++ b/src/group_theory/quotient_group.lean
@@ -26,8 +26,6 @@ instance : group (quotient N) :=
     (λ a b c, congr_arg mk (mul_assoc a b c)),
   one_mul := λ a, quotient.induction_on' a
     (λ a, congr_arg mk (one_mul a)),
-  mul_one := λ a, quotient.induction_on' a
-    (λ a, congr_arg mk (mul_one a)),
   inv := λ a, quotient.lift_on' a (λ a, ((a⁻¹ : G) : quotient N))
     (λ a b hab, quotient.sound' begin
       show a⁻¹⁻¹ * b⁻¹ ∈ N,

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -496,7 +496,7 @@ set.subset.antisymm (closure_subset $ set.subset.refl s) subset_closure
 theorem exists_list_of_mem_closure {s : set G} {a : G} (h : a ∈ closure s) :
   (∃l:list G, (∀x∈l, x ∈ s ∨ x⁻¹ ∈ s) ∧ l.prod = a) :=
 in_closure.rec_on h
-  (λ x hxs, ⟨[x], list.forall_mem_singleton.2 $ or.inl hxs, one_mul _⟩)
+  (λ x hxs, ⟨[x], list.forall_mem_singleton.2 $ or.inl hxs, by exact _root_.one_mul x⟩)
   ⟨[], list.forall_mem_nil _, rfl⟩
   (λ x _ ⟨L, HL1, HL2⟩, ⟨L.reverse.map has_inv.inv,
     λ x hx, let ⟨y, hy1, hy2⟩ := list.exists_of_mem_map hx in
@@ -548,10 +548,10 @@ begin
   simp only [closure_eq_mclosure, monoid.mem_closure_union_iff, exists_prop, preimage_union], split,
   { rintro ⟨_, ⟨ys, hys, yt, hyt, rfl⟩, _, ⟨zs, hzs, zt, hzt, rfl⟩, rfl⟩,
     refine ⟨_, ⟨_, hys, _, hzs, rfl⟩, _, ⟨_, hyt, _, hzt, rfl⟩, _⟩,
-    rw [mul_assoc, mul_assoc, mul_left_comm zs], refl },
+    rw [_root_.mul_assoc, _root_.mul_assoc, mul_left_comm zs], },
   { rintro ⟨_, ⟨ys, hys, zs, hzs, rfl⟩, _, ⟨yt, hyt, zt, hzt, rfl⟩, rfl⟩,
     refine ⟨_, ⟨ys, hys, yt, hyt, rfl⟩, _, ⟨zs, hzs, zt, hzt, rfl⟩, _⟩,
-    rw [mul_assoc, mul_assoc, mul_left_comm yt], refl }
+    rw [_root_.mul_assoc, _root_.mul_assoc, mul_left_comm yt] }
 end
 
 @[to_additive gmultiples_eq_closure]

--- a/src/init_/data/int/basic.lean
+++ b/src/init_/data/int/basic.lean
@@ -13,7 +13,6 @@ instance : comm_ring int :=
   add_assoc      := int.add_assoc,
   zero           := int.zero,
   zero_add       := int.zero_add,
-  add_zero       := int.add_zero,
   neg            := int.neg,
   add_left_neg   := int.add_left_neg,
   add_comm       := int.add_comm,

--- a/src/init_/data/nat/lemmas.lean
+++ b/src/init_/data/nat/lemmas.lean
@@ -20,7 +20,6 @@ instance : comm_semiring nat :=
   add_assoc      := nat.add_assoc,
   zero           := nat.zero,
   zero_add       := nat.zero_add,
-  add_zero       := nat.add_zero,
   add_comm       := nat.add_comm,
   mul            := nat.mul,
   mul_assoc      := nat.mul_assoc,

--- a/src/number_theory/dioph.lean
+++ b/src/number_theory/dioph.lean
@@ -678,7 +678,7 @@ dioph_fn_comp d [f, g] (by exact ⟨df, dg⟩)
 theorem eq_dioph : dioph (λv, f v = g v) :=
 dioph_comp2 df dg $ of_no_dummies _ (poly.proj &0 - poly.proj &1)
   (λv, (int.coe_nat_eq_coe_nat_iff _ _).symm.trans
-  ⟨@sub_eq_zero_of_eq ℤ _ (v &0) (v &1), eq_of_sub_eq_zero⟩)
+  ⟨@sub_eq_zero_of_eq ℤ _ (v &0) (v &1), λ h, eq_of_sub_eq_zero h⟩)
 localized "infix ` D= `:50 := dioph.eq_dioph" in dioph
 
 theorem add_dioph : dioph_fn (λv, f v + g v) :=


### PR DESCRIPTION
Minimising the axioms for `group` and `comm_monoid`.

`group` and `comm_monoid` are both defined to be structures at first, so the same instances can be maintained as were there before to avoid performance issues caused by superfluous instances.

This does cause some funny breakages in mathlib. 
- `cc` failed in `multiset.lean`.
- `simp [eq_comm]` failed to put the same equality in the goal and the hypothesis the same way around. 
- A `monoid.one` appeared in a goal in `data/equiv/transfer_instance`, and a similar issue in `pi_instances`
- Unification failure in `group_theory.sign`, it could not unify `1` and `equiv.refl`
- Unification failure in `number_theory.dioph` solved with an eta expansion
- some places used `group.mul_assoc` instead of `mul_assoc`, which now has the `group` argument in explicit brackets

Mainly because of the unification problems, I'm not sure it's best to merge this, and a change to core which would give nice notation to a custom constructor would be a better idea.