### PR TITLE
[Merged by Bors] - feat(geometry/euclidean): Euclidean space

### DIFF
--- a/src/analysis/normed_space/real_inner_product.lean
+++ b/src/analysis/normed_space/real_inner_product.lean
@@ -264,7 +264,7 @@ def real.inner_product_space : inner_product_space ℝ :=
 section instances
 /-- The standard Euclidean space, functions on a finite type. For an `n`-dimensional space
 use `euclidean_space (fin n)`.  -/
-@[derive add_comm_group]
+@[derive add_comm_group, nolint unused_arguments]
 def euclidean_space (n : Type*) [fintype n] : Type* := n → ℝ
 
 variables {n : Type*} [fintype n]

--- a/src/analysis/normed_space/real_inner_product.lean
+++ b/src/analysis/normed_space/real_inner_product.lean
@@ -223,21 +223,18 @@ instance inner_product_space_is_normed_space : normed_space ℝ α :=
 end norm
 
 section instances
-/-- The standard Euclidean space, fin n → ℝ. -/
-def euclidean_space (n : ℕ) : Type := (fin n → ℝ)
+/-- The standard Euclidean space, `fin n → ℝ`. -/
+def euclidean_space (n : ℕ) : Type := fin n → ℝ
+
 local attribute [reducible] euclidean_space
+
 variable {n : ℕ}
- -- Short-circuit type class inference.
-instance : vector_space ℝ (euclidean_space n) := by apply_instance
+
 instance : inner_product_space (euclidean_space n) :=
 { inner := λ a b, ∑ i, a i * b i,
   comm := λ x y, begin
     unfold inner,
-    conv_lhs {
-      apply_congr,
-      skip,
-      rw mul_comm
-    }
+    simp [mul_comm],
   end,
   nonneg := λ x, begin
     unfold inner,
@@ -248,36 +245,21 @@ instance : inner_product_space (euclidean_space n) :=
     intro h,
     rw finset.sum_eq_zero_iff_of_nonneg at h,
     { ext i,
-      replace h := h i (finset.mem_univ _),
-      change x i = 0,
-      rwa [mul_eq_zero_iff', or_self] at h },
+      simpa [mul_eq_zero_iff', or_self] using h i (finset.mem_univ _) },
     { exact λ i hi, mul_self_nonneg _ }
   end,
   add_left := λ x y z, begin
     unfold inner,
     convert finset.sum_add_distrib,
-    conv_lhs {
-      funext,
-      rw [pi.add_apply x y i, right_distrib]
-    }
+    ext i,
+    rw [pi.add_apply x y i, right_distrib]
   end,
   smul_left := λ x y r, begin
     unfold inner,
     rw finset.mul_sum,
-    conv_lhs {
-      funext,
-      congr,
-      skip,
-      funext,
-      rw [pi.smul_apply, smul_eq_mul, mul_assoc]
-    }
+    simp [pi.smul_apply, smul_eq_mul, mul_assoc]
   end }
--- Ensure the norm and distance derived from the inner product are
--- used.
-instance : normed_group (euclidean_space n) := inner_product_space_is_normed_group
-instance : normed_space ℝ (euclidean_space n) := inner_product_space_is_normed_space
-instance : metric_space (euclidean_space n) := normed_group.to_metric_space
- -- Short-circuit type class inference.
+
 instance : finite_dimensional ℝ (euclidean_space n) := by apply_instance
 instance : inhabited (euclidean_space n) := ⟨0⟩
 end instances

--- a/src/analysis/normed_space/real_inner_product.lean
+++ b/src/analysis/normed_space/real_inner_product.lean
@@ -198,7 +198,7 @@ by { simp only [(inner_self_eq_norm_square _).symm], exact parallelogram_law }
 instance inner_product_space_is_normed_group : normed_group α :=
 normed_group.of_core α
 { norm_eq_zero_iff := assume x, iff.intro
-    (λ h : sqrt (inner x x) = 0, (inner_self_eq_zero x).1 $ (sqrt_eq_zero inner_self_nonneg).1 h )
+    (λ h : sqrt (inner x x) = 0, inner_self_eq_zero.1 $ (sqrt_eq_zero inner_self_nonneg).1 h )
     (by {rintro rfl, show sqrt (inner (0:α) 0) = 0, simp }),
   triangle := assume x y,
   begin

--- a/src/analysis/normed_space/real_inner_product.lean
+++ b/src/analysis/normed_space/real_inner_product.lean
@@ -43,6 +43,7 @@ The Coq code is available at the following address: <http://www.lri.fr/~sboldo/e
 noncomputable theory
 
 open real set
+open_locale big_operators
 open_locale topological_space
 
 universes u v w
@@ -220,6 +221,66 @@ instance inner_product_space_is_normed_space : normed_space ℝ α :=
   end }
 
 end norm
+
+section instances
+/-- The standard Euclidean space, fin n → ℝ. -/
+def euclidean_space (n : ℕ) : Type := (fin n → ℝ)
+local attribute [reducible] euclidean_space
+variable {n : ℕ}
+ -- Short-circuit type class inference.
+instance : vector_space ℝ (euclidean_space n) := by apply_instance
+instance : inner_product_space (euclidean_space n) :=
+{ inner := λ a b, ∑ i, a i * b i,
+  comm := λ x y, begin
+    unfold inner,
+    conv_lhs {
+      apply_congr,
+      skip,
+      rw mul_comm
+    }
+  end,
+  nonneg := λ x, begin
+    unfold inner,
+    exact finset.sum_nonneg (λ i hi, mul_self_nonneg _)
+  end,
+  definite := λ x, begin
+    unfold inner,
+    intro h,
+    rw finset.sum_eq_zero_iff_of_nonneg at h,
+    { ext i,
+      replace h := h i (finset.mem_univ _),
+      change x i = 0,
+      rwa [mul_eq_zero_iff', or_self] at h },
+    { exact λ i hi, mul_self_nonneg _ }
+  end,
+  add_left := λ x y z, begin
+    unfold inner,
+    convert finset.sum_add_distrib,
+    conv_lhs {
+      funext,
+      rw [pi.add_apply x y i, right_distrib]
+    }
+  end,
+  smul_left := λ x y r, begin
+    unfold inner,
+    rw finset.mul_sum,
+    conv_lhs {
+      funext,
+      congr,
+      skip,
+      funext,
+      rw [pi.smul_apply, smul_eq_mul, mul_assoc]
+    }
+  end }
+-- Ensure the norm and distance derived from the inner product are
+-- used.
+instance : normed_group (euclidean_space n) := inner_product_space_is_normed_group
+instance : normed_space ℝ (euclidean_space n) := inner_product_space_is_normed_space
+instance : metric_space (euclidean_space n) := normed_group.to_metric_space
+ -- Short-circuit type class inference.
+instance : finite_dimensional ℝ (euclidean_space n) := by apply_instance
+instance : inhabited (euclidean_space n) := ⟨0⟩
+end instances
 
 section orthogonal
 

--- a/src/geometry/euclidean.lean
+++ b/src/geometry/euclidean.lean
@@ -34,5 +34,5 @@ abbreviation euclidean_affine_space (V : Type*) (P : Type*) [inner_product_space
 normed_add_torsor V P
 end prio
 
-example (n : ℕ) : euclidean_affine_space (euclidean_space n) (euclidean_space n) :=
+example (n : Type*) [fintype n] : euclidean_affine_space (euclidean_space n) (euclidean_space n) :=
 by apply_instance

--- a/src/geometry/euclidean.lean
+++ b/src/geometry/euclidean.lean
@@ -25,14 +25,11 @@ theorems that need it.
 
 -/
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /-- A `euclidean_affine_space V P` is an affine space with points `P`
 over an `inner_product_space V`. -/
 abbreviation euclidean_affine_space (V : Type*) (P : Type*) [inner_product_space V]
     [metric_space P] :=
 normed_add_torsor V P
-end prio
 
 example (n : Type*) [fintype n] : euclidean_affine_space (euclidean_space n) (euclidean_space n) :=
 by apply_instance

--- a/src/geometry/euclidean.lean
+++ b/src/geometry/euclidean.lean
@@ -74,7 +74,7 @@ instance standard_euclidean_space_is_inner_product_space (n : ℕ) :
     convert finset.sum_add_distrib,
     conv_lhs {
       funext,
-      rw [(show (x + y) i = x i + y i, by refl), right_distrib]
+      rw [pi.add_apply x y i, right_distrib]
     }
   end,
   smul_left := begin

--- a/src/geometry/euclidean.lean
+++ b/src/geometry/euclidean.lean
@@ -31,8 +31,9 @@ section prio
 set_option default_priority 100 -- see Note [default priority]
 /-- A `euclidean_affine_space V P` is an affine space with points `P`
 over an `inner_product_space V`. -/
-class euclidean_affine_space (V : Type*) (P : Type*) [inner_product_space V] [metric_space P]
-  extends normed_add_torsor V P
+abbreviation euclidean_affine_space (V : Type*) (P : Type*) [inner_product_space V]
+    [metric_space P] :=
+normed_add_torsor V P
 end prio
 
 /-- The standard Euclidean space, fin n → ℝ. -/

--- a/src/geometry/euclidean.lean
+++ b/src/geometry/euclidean.lean
@@ -36,14 +36,16 @@ abbreviation euclidean_affine_space (V : Type*) (P : Type*) [inner_product_space
 normed_add_torsor V P
 end prio
 
+section instances
 /-- The standard Euclidean space, fin n → ℝ. -/
-instance standard_euclidean_space_is_vector_space (n : ℕ) : vector_space ℝ (fin n → ℝ) :=
-by apply_instance
-instance standard_euclidean_space_has_inner (n : ℕ) : has_inner (fin n → ℝ) :=
-{ inner := λ a b, ∑ i, a i * b i }
-instance standard_euclidean_space_is_inner_product_space (n : ℕ) :
-  inner_product_space (fin n → ℝ) :=
-{ comm := λ x y, begin
+def euclidean_space (n : ℕ) : Type := (fin n → ℝ)
+local attribute [reducible] euclidean_space
+variable {n : ℕ}
+ -- Short-circuit type class inference.
+instance : vector_space ℝ (euclidean_space n) := by apply_instance
+instance : inner_product_space (euclidean_space n) :=
+{ inner := λ a b, ∑ i, a i * b i,
+  comm := λ x y, begin
     unfold inner,
     conv_lhs {
       apply_congr,
@@ -84,10 +86,14 @@ instance standard_euclidean_space_is_inner_product_space (n : ℕ) :
       rw [pi.smul_apply, smul_eq_mul, mul_assoc]
     }
   end }
-instance standard_euclidean_affine_space_normed_group (n : ℕ) : normed_group (fin n → ℝ) :=
-inner_product_space_is_normed_group
-instance standard_euclidean_affine_space_metric_space (n : ℕ) : metric_space (fin n → ℝ) :=
-normed_group.to_metric_space
-instance standard_euclidean_affine_space (n : ℕ) :
-  euclidean_affine_space (fin n → ℝ) (fin n → ℝ) :=
+-- Ensure the norm and distance derived from the inner product are
+-- used.
+instance : normed_group (euclidean_space n) := inner_product_space_is_normed_group
+instance : normed_space ℝ (euclidean_space n) := inner_product_space_is_normed_space
+instance : metric_space (euclidean_space n) := normed_group.to_metric_space
+ -- Short-circuit type class inference.
+instance : finite_dimensional ℝ (euclidean_space n) := by apply_instance
+instance : inhabited (euclidean_space n) := ⟨0⟩
+instance : euclidean_affine_space (euclidean_space n) (euclidean_space n) :=
 { dist_eq_norm' := normed_group.dist_eq }
+end instances

--- a/src/geometry/euclidean.lean
+++ b/src/geometry/euclidean.lean
@@ -34,5 +34,5 @@ abbreviation euclidean_affine_space (V : Type*) (P : Type*) [inner_product_space
 normed_add_torsor V P
 end prio
 
-instance (n : ℕ) : euclidean_affine_space (euclidean_space n) (euclidean_space n) :=
-{ dist_eq_norm' := normed_group.dist_eq }
+example (n : ℕ) : euclidean_affine_space (euclidean_space n) (euclidean_space n) :=
+by apply_instance

--- a/src/geometry/euclidean.lean
+++ b/src/geometry/euclidean.lean
@@ -42,23 +42,19 @@ instance standard_euclidean_space_has_inner (n : ℕ) : has_inner (fin n → ℝ
 { inner := λ a b, ∑ i, a i * b i }
 instance standard_euclidean_space_is_inner_product_space (n : ℕ) :
   inner_product_space (fin n → ℝ) :=
-{ comm := begin
-    intros x y,
+{ comm := λ x y, begin
     unfold inner,
     conv_lhs {
-      congr,
+      apply_congr,
       skip,
-      funext,
       rw mul_comm
     }
   end,
-  nonneg := begin
-    intro x,
+  nonneg := λ x, begin
     unfold inner,
     exact finset.sum_nonneg (λ i hi, mul_self_nonneg _)
   end,
-  definite := begin
-    intro x,
+  definite := λ x, begin
     unfold inner,
     intro h,
     rw finset.sum_eq_zero_iff_of_nonneg at h,
@@ -68,8 +64,7 @@ instance standard_euclidean_space_is_inner_product_space (n : ℕ) :
       rwa [mul_eq_zero_iff', or_self] at h },
     { exact λ i hi, mul_self_nonneg _ }
   end,
-  add_left := begin
-    intros x y z,
+  add_left := λ x y z, begin
     unfold inner,
     convert finset.sum_add_distrib,
     conv_lhs {
@@ -77,8 +72,7 @@ instance standard_euclidean_space_is_inner_product_space (n : ℕ) :
       rw [pi.add_apply x y i, right_distrib]
     }
   end,
-  smul_left := begin
-    intros x y r,
+  smul_left := λ x y r, begin
     unfold inner,
     rw finset.mul_sum,
     conv_lhs {
@@ -86,7 +80,7 @@ instance standard_euclidean_space_is_inner_product_space (n : ℕ) :
       congr,
       skip,
       funext,
-      rw [(show (r • x) i = r * x i, by refl), mul_assoc]
+      rw [pi.smul_apply, smul_eq_mul, mul_assoc]
     }
   end }
 instance standard_euclidean_affine_space_normed_group (n : ℕ) : normed_group (fin n → ℝ) :=

--- a/src/geometry/euclidean.lean
+++ b/src/geometry/euclidean.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2020 Joseph Myers. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Joseph Myers.
+-/
+import algebra.big_operators
+import analysis.normed_space.real_inner_product
+import analysis.normed_space.add_torsor
+
+noncomputable theory
+open_locale big_operators
+
+/-!
+# Euclidean spaces
+
+This file defines Euclidean affine spaces.
+
+## Implementation notes
+
+Rather than requiring Euclidean affine spaces to be finite-dimensional
+(as in the definition on Wikipedia), this is specified only for those
+theorems that need it.
+
+## References
+
+* https://en.wikipedia.org/wiki/Euclidean_space
+
+-/
+
+section prio
+set_option default_priority 100 -- see Note [default priority]
+/-- A `euclidean_affine_space V P` is an affine space with points `P`
+over an `inner_product_space V`. -/
+class euclidean_affine_space (V : Type*) (P : Type*) [inner_product_space V] [metric_space P]
+  extends normed_add_torsor V P
+end prio
+
+/-- The standard Euclidean space, fin n → ℝ. -/
+instance standard_euclidean_space_is_vector_space (n : ℕ) : vector_space ℝ (fin n → ℝ) :=
+by apply_instance
+instance standard_euclidean_space_has_inner (n : ℕ) : has_inner (fin n → ℝ) :=
+{ inner := λ a b, ∑ i, a i * b i }
+instance standard_euclidean_space_is_inner_product_space (n : ℕ) :
+  inner_product_space (fin n → ℝ) :=
+{ comm := begin
+    intros x y,
+    unfold inner,
+    conv_lhs {
+      congr,
+      skip,
+      funext,
+      rw mul_comm
+    }
+  end,
+  nonneg := begin
+    intro x,
+    unfold inner,
+    exact finset.sum_nonneg (λ i hi, mul_self_nonneg _)
+  end,
+  definite := begin
+    intro x,
+    unfold inner,
+    intro h,
+    rw finset.sum_eq_zero_iff_of_nonneg at h,
+    { ext i,
+      replace h := h i (finset.mem_univ _),
+      change x i = 0,
+      rwa [mul_eq_zero_iff', or_self] at h },
+    { exact λ i hi, mul_self_nonneg _ }
+  end,
+  add_left := begin
+    intros x y z,
+    unfold inner,
+    convert finset.sum_add_distrib,
+    conv_lhs {
+      funext,
+      rw [(show (x + y) i = x i + y i, by refl), right_distrib]
+    }
+  end,
+  smul_left := begin
+    intros x y r,
+    unfold inner,
+    rw finset.mul_sum,
+    conv_lhs {
+      funext,
+      congr,
+      skip,
+      funext,
+      rw [(show (r • x) i = r * x i, by refl), mul_assoc]
+    }
+  end }
+instance standard_euclidean_affine_space_normed_group (n : ℕ) : normed_group (fin n → ℝ) :=
+inner_product_space_is_normed_group
+instance standard_euclidean_affine_space_metric_space (n : ℕ) : metric_space (fin n → ℝ) :=
+normed_group.to_metric_space
+instance standard_euclidean_affine_space (n : ℕ) :
+  euclidean_affine_space (fin n → ℝ) (fin n → ℝ) :=
+{ dist_eq_norm' := normed_group.dist_eq }

--- a/src/geometry/euclidean.lean
+++ b/src/geometry/euclidean.lean
@@ -3,12 +3,10 @@ Copyright (c) 2020 Joseph Myers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Joseph Myers.
 -/
-import algebra.big_operators
 import analysis.normed_space.real_inner_product
 import analysis.normed_space.add_torsor
 
 noncomputable theory
-open_locale big_operators
 
 /-!
 # Euclidean spaces
@@ -36,64 +34,5 @@ abbreviation euclidean_affine_space (V : Type*) (P : Type*) [inner_product_space
 normed_add_torsor V P
 end prio
 
-section instances
-/-- The standard Euclidean space, fin n → ℝ. -/
-def euclidean_space (n : ℕ) : Type := (fin n → ℝ)
-local attribute [reducible] euclidean_space
-variable {n : ℕ}
- -- Short-circuit type class inference.
-instance : vector_space ℝ (euclidean_space n) := by apply_instance
-instance : inner_product_space (euclidean_space n) :=
-{ inner := λ a b, ∑ i, a i * b i,
-  comm := λ x y, begin
-    unfold inner,
-    conv_lhs {
-      apply_congr,
-      skip,
-      rw mul_comm
-    }
-  end,
-  nonneg := λ x, begin
-    unfold inner,
-    exact finset.sum_nonneg (λ i hi, mul_self_nonneg _)
-  end,
-  definite := λ x, begin
-    unfold inner,
-    intro h,
-    rw finset.sum_eq_zero_iff_of_nonneg at h,
-    { ext i,
-      replace h := h i (finset.mem_univ _),
-      change x i = 0,
-      rwa [mul_eq_zero_iff', or_self] at h },
-    { exact λ i hi, mul_self_nonneg _ }
-  end,
-  add_left := λ x y z, begin
-    unfold inner,
-    convert finset.sum_add_distrib,
-    conv_lhs {
-      funext,
-      rw [pi.add_apply x y i, right_distrib]
-    }
-  end,
-  smul_left := λ x y r, begin
-    unfold inner,
-    rw finset.mul_sum,
-    conv_lhs {
-      funext,
-      congr,
-      skip,
-      funext,
-      rw [pi.smul_apply, smul_eq_mul, mul_assoc]
-    }
-  end }
--- Ensure the norm and distance derived from the inner product are
--- used.
-instance : normed_group (euclidean_space n) := inner_product_space_is_normed_group
-instance : normed_space ℝ (euclidean_space n) := inner_product_space_is_normed_space
-instance : metric_space (euclidean_space n) := normed_group.to_metric_space
- -- Short-circuit type class inference.
-instance : finite_dimensional ℝ (euclidean_space n) := by apply_instance
-instance : inhabited (euclidean_space n) := ⟨0⟩
-instance : euclidean_affine_space (euclidean_space n) (euclidean_space n) :=
+instance (n : ℕ) : euclidean_affine_space (euclidean_space n) (euclidean_space n) :=
 { dist_eq_norm' := normed_group.dist_eq }
-end instances

--- a/src/geometry/manifold/real_instances.lean
+++ b/src/geometry/manifold/real_instances.lean
@@ -14,10 +14,10 @@ or with boundary or with corners. As a concrete example, we construct explicitly
 boundary structure on the real interval `[x, y]`.
 
 More specifically, we introduce
-* `euclidean_space n` for a model vector space of dimension `n`.
-* `model_with_corners ℝ (euclidean_space n) (euclidean_half_space n)` for the model space used
+* `euclidean_space2 n` for a model vector space of dimension `n`.
+* `model_with_corners ℝ (euclidean_space2 n) (euclidean_half_space n)` for the model space used
 to define `n`-dimensional real manifolds with boundary
-* `model_with_corners ℝ (euclidean_space n) (euclidean_quadrant n)` for the model space used
+* `model_with_corners ℝ (euclidean_space2 n) (euclidean_quadrant n)` for the model space used
 to define `n`-dimensional real manifolds with corners
 
 ## Implementation notes
@@ -34,38 +34,38 @@ The space `ℝ^n`. Note that the name is slightly misleading, as we only need a 
 structure on `ℝ^n`, but the one we use here is the sup norm and not the euclidean one -- this is not
 a problem for the manifold applications, but should probably be refactored at some point.
 -/
-def euclidean_space (n : ℕ) : Type := (fin n → ℝ)
+def euclidean_space2 (n : ℕ) : Type := (fin n → ℝ)
 
 /--
 The half-space in `ℝ^n`, used to model manifolds with boundary. We only define it when
 `1 ≤ n`, as the definition only makes sense in this case.
 -/
 def euclidean_half_space (n : ℕ) [has_zero (fin n)] : Type :=
-{x : euclidean_space n // 0 ≤ x 0}
+{x : euclidean_space2 n // 0 ≤ x 0}
 
 /--
 The quadrant in `ℝ^n`, used to model manifolds with corners, made of all vectors with nonnegative
 coordinates.
 -/
-def euclidean_quadrant (n : ℕ) : Type := {x : euclidean_space n // ∀i:fin n, 0 ≤ x i}
+def euclidean_quadrant (n : ℕ) : Type := {x : euclidean_space2 n // ∀i:fin n, 0 ≤ x i}
 
 section
 /- Register class instances for euclidean space and half-space and quadrant -/
-local attribute [reducible] euclidean_space euclidean_half_space euclidean_quadrant
+local attribute [reducible] euclidean_space2 euclidean_half_space euclidean_quadrant
 variable {n : ℕ}
 
  -- short-circuit type class inference
-instance : vector_space ℝ (euclidean_space n) := by apply_instance
-instance : normed_group (euclidean_space n) := by apply_instance
-instance : normed_space ℝ (euclidean_space n) := by apply_instance
+instance : vector_space ℝ (euclidean_space2 n) := by apply_instance
+instance : normed_group (euclidean_space2 n) := by apply_instance
+instance : normed_space ℝ (euclidean_space2 n) := by apply_instance
 instance [has_zero (fin n)] : topological_space (euclidean_half_space n) := by apply_instance
 instance : topological_space (euclidean_quadrant n) := by apply_instance
-instance : finite_dimensional ℝ (euclidean_space n) := by apply_instance
-instance : inhabited (euclidean_space n) := ⟨0⟩
+instance : finite_dimensional ℝ (euclidean_space2 n) := by apply_instance
+instance : inhabited (euclidean_space2 n) := ⟨0⟩
 instance [has_zero (fin n)] : inhabited (euclidean_half_space n) := ⟨⟨0, by simp⟩⟩
 instance : inhabited (euclidean_quadrant n) := ⟨⟨0, λ i, by simp⟩⟩
 
-@[simp] lemma findim_euclidean_space : finite_dimensional.findim ℝ (euclidean_space n) = n :=
+@[simp] lemma findim_euclidean_space : finite_dimensional.findim ℝ (euclidean_space2 n) = n :=
 by simp
 
 lemma range_half_space (n : ℕ) [has_zero (fin n)] :
@@ -79,11 +79,11 @@ by simp
 end
 
 /--
-Definition of the model with corners `(euclidean_space n, euclidean_half_space n)`, used as a
+Definition of the model with corners `(euclidean_space2 n, euclidean_half_space n)`, used as a
 model for manifolds with boundary.
 -/
 def model_with_corners_euclidean_half_space (n : ℕ) [has_zero (fin n)] :
-  model_with_corners ℝ (euclidean_space n) (euclidean_half_space n) :=
+  model_with_corners ℝ (euclidean_space2 n) (euclidean_half_space n) :=
 { to_fun      := λx, x.val,
   inv_fun     := λx, ⟨λi, if h : i = 0 then max (x i) 0 else x i, by simp [le_refl]⟩,
   source      := univ,
@@ -108,10 +108,10 @@ def model_with_corners_euclidean_half_space (n : ℕ) [has_zero (fin n)] :
     `unique_diff_on_convex`: it suffices to check that it is convex and with nonempty interior. -/
     rw range_half_space,
     apply unique_diff_on_convex,
-    show convex {y : euclidean_space n | 0 ≤ y 0},
+    show convex {y : euclidean_space2 n | 0 ≤ y 0},
     { assume x y hx hy a b ha hb hab,
       simpa using add_le_add (mul_nonneg ha hx) (mul_nonneg hb hy) },
-    show (interior {y : euclidean_space n | 0 ≤ y 0}).nonempty,
+    show (interior {y : euclidean_space2 n | 0 ≤ y 0}).nonempty,
     { use (λi, 1),
       rw mem_interior,
       refine ⟨(pi (univ : set (fin n)) (λi, (Ioi 0 : set ℝ))), _,
@@ -137,10 +137,10 @@ def model_with_corners_euclidean_half_space (n : ℕ) [has_zero (fin n)] :
   end }
 
 /--
-Definition of the model with corners `(euclidean_space n, euclidean_quadrant n)`, used as a
+Definition of the model with corners `(euclidean_space2 n, euclidean_quadrant n)`, used as a
 model for manifolds with corners -/
 def model_with_corners_euclidean_quadrant (n : ℕ) :
-  model_with_corners ℝ (euclidean_space n) (euclidean_quadrant n) :=
+  model_with_corners ℝ (euclidean_space2 n) (euclidean_quadrant n) :=
 { to_fun      := λx, x.val,
   inv_fun     := λx, ⟨λi, max (x i) 0, λi, by simp [le_refl]⟩,
   source      := univ,
@@ -163,10 +163,10 @@ def model_with_corners_euclidean_quadrant (n : ℕ) :
     `unique_diff_on_convex`: it suffices to check that it is convex and with nonempty interior. -/
     rw range_quadrant,
     apply unique_diff_on_convex,
-    show convex {y : euclidean_space n | ∀ (i : fin n), 0 ≤ y i},
+    show convex {y : euclidean_space2 n | ∀ (i : fin n), 0 ≤ y i},
     { assume x y hx hy a b ha hb hab i,
       simpa using add_le_add (mul_nonneg ha (hx i)) (mul_nonneg hb (hy i)) },
-    show (interior {y : euclidean_space n | ∀ (i : fin n), 0 ≤ y i}).nonempty,
+    show (interior {y : euclidean_space2 n | ∀ (i : fin n), 0 ≤ y i}).nonempty,
     { use (λi, 1),
       rw mem_interior,
       refine ⟨(pi (univ : set (fin n)) (λi, (Ioi 0 : set ℝ))), _,


### PR DESCRIPTION
Define Euclidean affine spaces (not necessarily finite-dimensional),
and a corresponding instance for the standard Euclidean space `fin n → ℝ`.

This just defines the type class and the instance, with some other
basic geometric definitions and results to be added separately once
this is in.

I haven't attempted to do anything about the `euclidean_space`
definition in geometry/manifold/real_instances.lean that comes with a
comment that it uses the wrong norm.  That might better be refactored
by someone familiar with the manifold code.

By defining Euclidean spaces such that they are defined to be metric
spaces, and providing an instance, this probably implicitly gives item
91 "The Triangle Inequality" from the 100-theorems list, if that's
taken to have a geometric interpretation as in the Coq version, but
it's not very clear how something implicit like that from various
different pieces of the library, and where the item on the list could
be interpreted in several different ways anyway, should be entered in
100.yaml.

Co-authored-by: Yury G. Kudryashov <urkud@urkud.name>
Co-authored-by: sgouezel <sebastien.gouezel@univ-rennes1.fr>