### PR TITLE
[Merged by Bors] - feat(scripts/deploy_docs): force push generated docs

### DIFF
--- a/scripts/deploy_docs.sh
+++ b/scripts/deploy_docs.sh
@@ -37,8 +37,9 @@ if [ "$github_repo" = "leanprover-community/mathlib" -a "$github_event" = "push"
   git config user.email "leanprover.community@gmail.com"
   git config user.name "leanprover-community-bot"
   git add -A .
+  git reset --soft HEAD~1
   git commit -m "automatic update to $git_hash"
-  git push
+  git push -f
 else
   bash ../scripts/mk_all.sh
   lean src/export_json.lean

--- a/scripts/deploy_docs.sh
+++ b/scripts/deploy_docs.sh
@@ -39,6 +39,4 @@ if [ "$github_repo" = "leanprover-community/mathlib" -a "$github_event" = "push"
   git checkout --orphan master2
   git commit -m "automatic update to $git_hash"
   git push -f HEAD:master
-  git commit -m "automatic update to $git_hash"
-  git push -f
 fi

--- a/scripts/deploy_docs.sh
+++ b/scripts/deploy_docs.sh
@@ -36,7 +36,9 @@ if [ "$github_repo" = "leanprover-community/mathlib" -a "$github_event" = "push"
   git config user.email "leanprover.community@gmail.com"
   git config user.name "leanprover-community-bot"
   git add -A .
-  git reset --soft HEAD~1
+  git checkout --orphan master2
+  git commit -m "automatic update to $git_hash"
+  git push -f HEAD:master
   git commit -m "automatic update to $git_hash"
   git push -f
 fi

--- a/scripts/deploy_docs.sh
+++ b/scripts/deploy_docs.sh
@@ -27,15 +27,20 @@ rm -rf mathlib_docs/docs/
 # but this is better than trying to recompile all of mathlib.
 elan override set "$lean_version"
 
-python3 -m pip install --upgrade pip
-pip3 install markdown2 toml
-./gen_docs -w -r "../" -t "mathlib_docs/docs/"
+
 
 if [ "$github_repo" = "leanprover-community/mathlib" -a "$github_event" = "push" -a "$github_ref" = "refs/heads/master" ]; then
+  python3 -m pip install --upgrade pip
+  pip3 install markdown2 toml
+  ./gen_docs -w -r "../" -t "mathlib_docs/docs/"
   cd mathlib_docs/docs
   git config user.email "leanprover.community@gmail.com"
   git config user.name "leanprover-community-bot"
   git add -A .
   git commit -m "automatic update to $git_hash"
   git push
+else
+  bash ../scripts/mk_all.sh
+  lean src/export_json.lean
+  lean src/lean_commit.lean
 fi

--- a/scripts/deploy_docs.sh
+++ b/scripts/deploy_docs.sh
@@ -27,12 +27,11 @@ rm -rf mathlib_docs/docs/
 # but this is better than trying to recompile all of mathlib.
 elan override set "$lean_version"
 
-
+python3 -m pip install --upgrade pip
+pip3 install markdown2 toml
+./gen_docs -w -r "../" -t "mathlib_docs/docs/"
 
 if [ "$github_repo" = "leanprover-community/mathlib" -a "$github_event" = "push" -a "$github_ref" = "refs/heads/master" ]; then
-  python3 -m pip install --upgrade pip
-  pip3 install markdown2 toml
-  ./gen_docs -w -r "../" -t "mathlib_docs/docs/"
   cd mathlib_docs/docs
   git config user.email "leanprover.community@gmail.com"
   git config user.name "leanprover-community-bot"
@@ -40,8 +39,4 @@ if [ "$github_repo" = "leanprover-community/mathlib" -a "$github_event" = "push"
   git reset --soft HEAD~1
   git commit -m "automatic update to $git_hash"
   git push -f
-else
-  bash ../scripts/mk_all.sh
-  lean src/export_json.lean
-  lean src/lean_commit.lean
 fi


### PR DESCRIPTION
(1) We build the full html docs in every CI run, even though they only get saved on master builds. Just compiling the .lean files used in doc generation should be enough to catch 95% of breaks. I think the bit of extra risk is worth speeding up the CI runs, especially since linting is now as fast as tests + docs. 

(2) The repo hosting the html pages was 1.3gb because we kept every revision. Half of the time spent on doc builds was just checking out the repo. I've deleted the history. This PR changes the build script to overwrite the previous version. 