### PR TITLE
[Merged by Bors] - fix(tactic/equiv_rw): use kdepends_on rather than occurs

### DIFF
--- a/src/tactic/equiv_rw.lean
+++ b/src/tactic/equiv_rw.lean
@@ -172,7 +172,8 @@ do
   -- Check that we actually used the equivalence `eq`
   -- (`equiv_rw_type_core` will always find `equiv.refl`, but hopefully only after all other possibilities)
   new_eqv ← instantiate_mvars new_eqv,
-  guard (eqv.occurs new_eqv) <|> (do
+  -- We previously had `guard (eqv.occurs new_eqv)` here, but `kdepends_on` is more reliable.
+  kdepends_on new_eqv eqv >>= guardb <|> (do
     eqv_pp ← pp eqv,
     ty_pp ← pp ty,
     fail format!"Could not construct an equivalence from {eqv_pp} of the form: {ty_pp} ≃ _"),

--- a/test/equiv_rw.lean
+++ b/test/equiv_rw.lean
@@ -9,6 +9,12 @@ import control.equiv_functor.instances -- these make equiv_rw more powerful!
 -- Uncomment this line to observe the steps of constructing appropriate equivalences.
 -- set_option trace.equiv_rw_type true
 
+import tactic.equiv_rw
+
+-- This fails if we use `occurs` rather than `kdepends_on` in `equiv_rw_type`.
+instance : equiv_functor set :=
+{ map := λ α β e s, by { equiv_rw e.symm, assumption, } }
+
 -- Rewriting a hypothesis along an equivalence.
 example {α β : Type} (e : α ≃ β)
   (f : α → ℕ) (h : ∀ b : β, f (e.symm b) = 0) (i : α) : f i = 0 :=


### PR DESCRIPTION
`kdepends_on t e` and `e.occurs t` sometimes give different answers, and it seems `equiv_rw` wants the behaviour that `kdepends_on` provides.

There is a new test which failed with `occurs`, and succeeds using `kdepends_on`. No other changes.