### PR TITLE
[Merged by Bors] - fix(ci): check nolints.txt against master

### DIFF
--- a/scripts/update_nolints.sh
+++ b/scripts/update_nolints.sh
@@ -10,7 +10,7 @@ git fetch $remote_name
 git rev-parse --verify --quiet refs/remotes/$remote_name/$branch_name && exit 0
 
 # Exit if there are no changes
-git diff-index --quiet HEAD -- scripts/nolints.txt && exit 0
+git diff-index --quiet refs/remotes/$remote_name/master -- scripts/nolints.txt && exit 0
 
 pr_title='chore(scripts): update nolints.txt'
 pr_body='I am happy to remove some nolints for you!'


### PR DESCRIPTION
Currently, leanprover-community-bot makes an "update nolints" PR if both of the following hold:
- the `nolints` branch doesn't exist, meaning there isn't already an open nolints PR
- `nolints.txt` has been modified compared to HEAD.

This can lead to a duplicate nolints PR (see e.g. #2899 and #2901), since a nolints PR might have been merged after this build on `master` started, but before this step runs.

This PR changes the second check so that it instead compares `nolints.txt` against the most recent `master` commit, which should fix this.