### PR TITLE
[Merged by Bors] - feat(algebra/continued_fractions): add correctness of terminating computations

### DIFF
--- a/src/algebra/continued_fractions/basic.lean
+++ b/src/algebra/continued_fractions/basic.lean
@@ -266,21 +266,21 @@ variables {K : Type*} [division_ring K]
 
 /-
 We start with the definition of the recurrence relation. Given a gcf `g`, for all `n ≥ 1`, we define
-- `A₋₁ = 1,  A₀ = h,  Aₙ = bₙ-₁ * Aₙ₋₁ + aₙ-₁ * Aₙ₋₂`, and
-- `B₋₁ = 0,  B₀ = 1,  Bₙ = bₙ-₁ * Bₙ₋₁ + aₙ-₁ * Bₙ₋₂`.
+- `A₋₁ = 1,  A₀ = h,  Aₙ = bₙ₋₁ * Aₙ₋₁ + aₙ₋₁ * Aₙ₋₂`, and
+- `B₋₁ = 0,  B₀ = 1,  Bₙ = bₙ₋₁ * Bₙ₋₁ + aₙ₋₁ * Bₙ₋₂`.
 
 `Aₙ, `Bₙ` are called the *nth continuants*, Aₙ the *nth numerator*, and `Bₙ` the
 *nth denominator* of `g`. The *nth convergent* of `g` is given by `Aₙ / Bₙ`.
 -/
 
 /--
-Returns the next numerator `Aₙ = bₙ-₁ * Aₙ₋₁ + aₙ-₁ * Aₙ₋₂`, where `predA` is `Aₙ₋₁`,
+Returns the next numerator `Aₙ = bₙ₋₁ * Aₙ₋₁ + aₙ₋₁ * Aₙ₋₂`, where `predA` is `Aₙ₋₁`,
 `ppredA` is `Aₙ₋₂`, `a` is `aₙ₋₁`, and `b` is `bₙ₋₁`.
 -/
 def next_numerator (a b ppredA predA : K) : K := b * predA + a * ppredA
 
 /--
-Returns the next denominator `Bₙ = bₙ-₁ * Bₙ₋₁ + aₙ-₁ * Bₙ₋₂``, where `predB` is `Bₙ₋₁` and
+Returns the next denominator `Bₙ = bₙ₋₁ * Bₙ₋₁ + aₙ₋₁ * Bₙ₋₂``, where `predB` is `Bₙ₋₁` and
 `ppredB` is `Bₙ₋₂`, `a` is `aₙ₋₁`, and `b` is `bₙ₋₁`.
 -/
 def next_denominator (aₙ bₙ ppredB predB : K) : K := bₙ * predB + aₙ * ppredB

--- a/src/algebra/continued_fractions/basic.lean
+++ b/src/algebra/continued_fractions/basic.lean
@@ -266,9 +266,8 @@ variables {K : Type*} [division_ring K]
 
 /-
 We start with the definition of the recurrence relation. Given a gcf `g`, for all `n ≥ 1`, we define
-
-  `A₋₁ = 1,  A₀ = h,  Aₙ = bₙ-₁ * Aₙ₋₁ + aₙ-₁ * Aₙ₋₂`, and
-  `B₋₁ = 0,  B₀ = 1,  Bₙ = bₙ-₁ * Bₙ₋₁ + aₙ-₁ * Bₙ₋₂`.
+- `A₋₁ = 1,  A₀ = h,  Aₙ = bₙ-₁ * Aₙ₋₁ + aₙ-₁ * Aₙ₋₂`, and
+- `B₋₁ = 0,  B₀ = 1,  Bₙ = bₙ-₁ * Bₙ₋₁ + aₙ-₁ * Bₙ₋₂`.
 
 `Aₙ, `Bₙ` are called the *nth continuants*, Aₙ the *nth numerator*, and `Bₙ` the
 *nth denominator* of `g`. The *nth convergent* of `g` is given by `Aₙ / Bₙ`.

--- a/src/algebra/continued_fractions/computation/basic.lean
+++ b/src/algebra/continued_fractions/computation/basic.lean
@@ -112,16 +112,15 @@ protected def of (v : K) : int_fract_pair K := ⟨⌊v⌋, fract v⟩
 Creates the stream of integer and fractional parts of a value `v` needed to obtain the continued
 fraction representation of `v` in `generalized_continued_fraction.of`. More precisely, given a value
 `v : K`, it recursively computes a stream of option `ℤ × K` pairs as follows:
-
-  `stream v 0 = some ⟨⌊v⌋, v - ⌊v⌋⟩`,
-  `stream v (n + 1) = some ⟨⌊frₙ⁻¹⌋, frₙ⁻¹ - ⌊frₙ⁻¹⌋⟩`, if `stream v n = some ⟨_, frₙ⟩` and `frₙ ≠ 0`.
-  `stream v (n + 1) = none`, otherwise.
+- `stream v 0 = some ⟨⌊v⌋, v - ⌊v⌋⟩`
+- `stream v (n + 1) = some ⟨⌊frₙ⁻¹⌋, frₙ⁻¹ - ⌊frₙ⁻¹⌋⟩`, if `stream v n = some ⟨_, frₙ⟩` and `frₙ ≠ 0`
+- `stream v (n + 1) = none`, otherwise
 
 For example, let `(v : ℚ) := 3.4`. The process goes as follows:
-  `stream v 0 = some ⟨⌊v⌋, v - ⌊v⌋⟩ = some ⟨3, 0.4⟩`,
-  `stream v 1 = some ⟨⌊0.4⁻¹⌋, 0.4⁻¹ - ⌊0.4⁻¹⌋⟩ = some ⟨⌊2.5⌋, 2.5 - ⌊2.5⌋⟩ = some ⟨2, 0.5⟩`,
-  `stream v 2 = some ⟨⌊0.5⁻¹⌋, 0.5⁻¹ - ⌊0.5⁻¹⌋⟩ = some ⟨⌊2⌋, 2 - ⌊2⌋⟩ = some ⟨2, 0⟩`
-  `stream v n = none`, for `n ≥ 3`.
+- `stream v 0 = some ⟨⌊v⌋, v - ⌊v⌋⟩ = some ⟨3, 0.4⟩`
+- `stream v 1 = some ⟨⌊0.4⁻¹⌋, 0.4⁻¹ - ⌊0.4⁻¹⌋⟩ = some ⟨⌊2.5⌋, 2.5 - ⌊2.5⌋⟩ = some ⟨2, 0.5⟩`
+- `stream v 2 = some ⟨⌊0.5⁻¹⌋, 0.5⁻¹ - ⌊0.5⁻¹⌋⟩ = some ⟨⌊2⌋, 2 - ⌊2⌋⟩ = some ⟨2, 0⟩`
+- `stream v n = none`, for `n ≥ 3`
 -/
 protected def stream (v : K) : stream $ option (int_fract_pair K)
 | 0 := some (int_fract_pair.of v)

--- a/src/algebra/continued_fractions/computation/correctness_terminating.lean
+++ b/src/algebra/continued_fractions/computation/correctness_terminating.lean
@@ -1,0 +1,215 @@
+/-
+Copyright (c) 2020 Kevin Kappelmann. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Kappelmann
+-/
+import algebra.continued_fractions.computation.translations
+import algebra.continued_fractions.terminated_stable
+import algebra.continued_fractions.continuants_recurrence
+/-!
+# Correctness of Terminating Continued Fraction Computations (`gcf.of`)
+
+## Summary
+
+Let us write `gcf` for `generalized_continued_fraction`. We show the correctness of the
+algorithm computing continued fractions (`gcf.of`) in case of termination in the following sense:
+
+At every step `n : ℕ`, we can obtain the value `v` by adding a specific residual term to the
+convergent `(gcf.of v).convergents n`. The residual term will be zero exactly when the continued
+fraction terminated; otherwise, the residual term will be given by the fractional part stored in
+`gcf.int_fract_pair.stream v n`.
+
+For an example, refer to `gcf.comp_exact_value` and for more information
+about the computation process, refer to `algebra.continued_fraction.computation.basic`.
+
+## Main definitions
+
+- `gcf.comp_exact_value` returns the exact value approximated by the continued fraction `gcf.of v`
+  by adding a residual term as described in the summary.
+
+## Main Theorems
+
+- `gcf.comp_exact_value_correctness_of_stream_eq_some` shows that `gcf.comp_exact_value` indeed
+  returns the value `v` when given the convergent and fractional part as described in the summary.
+- `gcf.of_correctness_of_terminated_at` shows the equality `v = (gcf.of v).convergents n`
+  if `gcf.of v` terminated at position `n`.
+-/
+
+namespace generalized_continued_fraction
+open generalized_continued_fraction as gcf
+
+variables {K : Type*} [discrete_linear_ordered_field K] [floor_ring K] {v : K} {n : ℕ}
+
+/--
+Given two successive continuants (at positions `n + 1` and `n`) of a continued fraction
+`generalized_continued_fraction.of v` and the fractional part at `int_fract_pair.stream n`,
+this function returns the exact value approximated by the continued fraction, that is `v`.
+
+For example, let `(v : ℚ) := 3.4`. We have:
+  `gcf.int_fract_pair.stream v 0 = some ⟨3, 0.4⟩`, and
+  `gcf.int_fract_pair.stream v 1 = some ⟨2, 0.5⟩`,
+
+Now `(gcf.of v).convergents 1 = 3 + 1/2`, and our fractional term (the residual) at position `2` is
+`0.5`. We hence have `v = 3 + 1/(2 + 0.5) = 3 + 1/2.5 = 3.4`.
+-/
+protected def comp_exact_value (predConts conts : gcf.pair K) (fr : K) : K :=
+-- if the fractional part is zero, we exactly approximated the value by the last continuants
+if fr = 0 then conts.a / conts.b
+-- otherwise, we have to include the fractional part in a final continuants step.
+else let exactConts := next_continuants 1 fr⁻¹ predConts conts in
+  exactConts.a / exactConts.b
+
+/-- Just a computational lemmas we need for the next main proof -/
+protected lemma comp_exact_value_correctness_of_stream_eq_some_aux_comp {a : K} (b c : K)
+  (fract_a_ne_zero : fract a ≠ 0) :
+  ((⌊a⌋ : K) * b + c) / (fract a) + b = (b * a + c) / fract a :=
+begin
+  have : ((⌊a⌋ : K) * b + c) / (fract a) + b = ((b * (fract a) + b * ⌊a⌋ + c) / fract a), by
+  { field_simp [fract_a_ne_zero], ac_refl },
+  simpa [←left_distrib] using this
+end
+
+open generalized_continued_fraction as gcf
+
+/--
+Shows the correctness of `comp_exact_value` in case the continued fraction did not terminate.
+That is, at every step of the computation of a continued fraction `gcf.of v`, we obtain the value
+`v` if we compute the continuant at position `n` and add the residual term given by the fractional
+part stored in `int_fract_pair.stream v n`.
+-/
+lemma comp_exact_value_correctness_of_stream_eq_some :
+  ∀ {ifp_n : int_fract_pair K}, int_fract_pair.stream v n = some ifp_n →
+    v = gcf.comp_exact_value
+          ((gcf.of v).continuants_aux  n)
+          ((gcf.of v).continuants_aux $ n + 1)
+          ifp_n.fr :=
+begin
+  let g := gcf.of v,
+  induction n with n IH,
+  { assume ifp_zero stream_zero_eq, -- nat.zero
+    have : int_fract_pair.of v = ifp_zero, by
+    { have : int_fract_pair.stream v 0 = some (int_fract_pair.of v), from rfl,
+      simpa only [this] using stream_zero_eq },
+    cases this with refl,
+    cases decidable.em (fract v = 0) with fract_eq_zero fract_ne_zero,
+    -- fract v = 0; we must then have `v = ⌊v⌋`
+    { suffices : v = ⌊v⌋, by simpa [continuants_aux, fract_eq_zero, gcf.comp_exact_value],
+      calc
+          v = fract v + ⌊v⌋ : by rw fract_add_floor
+        ... = ⌊v⌋           : by simp [fract_eq_zero] },
+    -- fract v ≠ 0; the claim then easily follows by unfolding a single computation step
+    { field_simp [continuants_aux, next_continuants, next_numerator, next_denominator,
+        gcf.of_h_eq_floor, gcf.comp_exact_value, fract_ne_zero] } },
+  { assume ifp_succ_n succ_nth_stream_eq,  -- nat.succ
+    obtain ⟨ifp_n, nth_stream_eq, nth_fract_ne_zero, _⟩ :
+      ∃ ifp_n, int_fract_pair.stream v n = some ifp_n ∧ ifp_n.fr ≠ 0
+      ∧ int_fract_pair.of ifp_n.fr⁻¹ = ifp_succ_n, from
+        int_fract_pair.succ_nth_stream_eq_some_iff.elim_left succ_nth_stream_eq,
+    -- introduce some notation
+    let conts := g.continuants_aux (n + 2),
+    set predConts := g.continuants_aux (n + 1) with predConts_eq,
+    set ppredConts := g.continuants_aux n with ppredConts_eq,
+    cases decidable.em (ifp_succ_n.fr = 0) with ifp_succ_n_fr_eq_zero ifp_succ_n_fr_ne_zero,
+    -- ifp_succ_n.fr = 0
+    { suffices : v = conts.a / conts.b, by
+        simpa [gcf.comp_exact_value, ifp_succ_n_fr_eq_zero],
+      -- use the IH and the fact that ifp_n.fr⁻¹ = ⌊ifp_n.fr⁻¹⌋ to prove this case
+      obtain ⟨ifp_n', nth_stream_eq', ifp_n_fract_inv_eq_floor⟩ :
+        ∃ ifp_n, int_fract_pair.stream v n = some ifp_n ∧ ifp_n.fr⁻¹ = ⌊ifp_n.fr⁻¹⌋, from
+          int_fract_pair.obtain_succ_nth_stream_of_fr_zero succ_nth_stream_eq ifp_succ_n_fr_eq_zero,
+      have : ifp_n' = ifp_n, by injection (eq.trans (nth_stream_eq').symm nth_stream_eq),
+      cases this with refl,
+      have s_nth_eq : g.s.nth n = some ⟨1, ⌊ifp_n.fr⁻¹⌋⟩, from
+        gcf.nth_of_eq_some_of_nth_int_fract_pair_stream_fr_ne_zero nth_stream_eq nth_fract_ne_zero,
+      rw [←ifp_n_fract_inv_eq_floor] at s_nth_eq,
+      suffices : v = gcf.comp_exact_value ppredConts predConts ifp_n.fr, by
+        simpa [conts, continuants_aux, s_nth_eq,gcf.comp_exact_value, nth_fract_ne_zero] using this,
+      exact (IH nth_stream_eq) },
+    -- ifp_succ_n.fr ≠ 0
+    { -- use the IH to show that the following equality suffices
+      suffices : gcf.comp_exact_value ppredConts predConts ifp_n.fr
+               = gcf.comp_exact_value predConts conts ifp_succ_n.fr, by
+      { have : v = gcf.comp_exact_value ppredConts predConts ifp_n.fr, from IH nth_stream_eq,
+        conv_lhs { rw this }, assumption },
+      -- get the correspondence between ifp_n and ifp_succ_n
+      obtain ⟨ifp_n', nth_stream_eq', ifp_n_fract_ne_zero, ⟨refl⟩⟩ :
+        ∃ ifp_n, int_fract_pair.stream v n = some ifp_n ∧ ifp_n.fr ≠ 0
+        ∧ int_fract_pair.of ifp_n.fr⁻¹ = ifp_succ_n, from
+          int_fract_pair.succ_nth_stream_eq_some_iff.elim_left succ_nth_stream_eq,
+      have : ifp_n' = ifp_n, by injection (eq.trans (nth_stream_eq').symm nth_stream_eq),
+      cases this with refl,
+      -- get the correspondence between ifp_n and g.s.nth n
+      have s_nth_eq : g.s.nth n = some ⟨1, (⌊ifp_n.fr⁻¹⌋ : K)⟩, from
+        gcf.nth_of_eq_some_of_nth_int_fract_pair_stream_fr_ne_zero nth_stream_eq ifp_n_fract_ne_zero,
+      -- the claim now follows by unfolding the definitions and tedious calculations
+      -- some shorthand notation
+      let ppA := ppredConts.a, let ppB := ppredConts.b,
+      let pA := predConts.a, let pB := predConts.b,
+      have : gcf.comp_exact_value ppredConts predConts ifp_n.fr
+          = (ppA + ifp_n.fr⁻¹ * pA) / (ppB + ifp_n.fr⁻¹ * pB), by
+        -- unfold comp_exact_value and the convergent computation once
+        { field_simp [ifp_n_fract_ne_zero, gcf.comp_exact_value, next_continuants, next_numerator,
+          next_denominator], ac_refl },
+      rw this,
+      -- two calculations needed to show the claim
+      have tmpCalc := gcf.comp_exact_value_correctness_of_stream_eq_some_aux_comp
+        pA ppA ifp_succ_n_fr_ne_zero,
+      have tmpCalc' := gcf.comp_exact_value_correctness_of_stream_eq_some_aux_comp
+        pB ppB ifp_succ_n_fr_ne_zero,
+      rw inv_eq_one_div at tmpCalc tmpCalc',
+      have : fract (1 / ifp_n.fr) ≠ 0, by simpa using ifp_succ_n_fr_ne_zero,
+      -- now unfold the recurrence one step and simplify both sides to arrive at the conclusion
+      field_simp [conts, gcf.comp_exact_value,
+        (gcf.continuants_aux_recurrence s_nth_eq ppredConts_eq predConts_eq), next_continuants,
+        next_numerator, next_denominator, this, tmpCalc, tmpCalc'],
+      ac_refl } }
+end
+
+/--
+Shows the correctness of `comp_exact_value` in case the `int_fract_pair.stream` of the corresponding
+to the continued fraction terminated.
+-/
+lemma comp_exact_value_correctness_of_stream_eq_none
+  (nth_stream_eq_none : int_fract_pair.stream v n = none) :
+  v = (gcf.of v).convergents (n - 1) :=
+begin
+  induction n with n IH,
+  case nat.zero { contradiction }, -- int_fract_pair.stream v 0 ≠ none
+  case nat.succ
+  { rename nth_stream_eq_none succ_nth_stream_eq_none,
+    let g := gcf.of v,
+    change v = g.convergents n,
+    have : int_fract_pair.stream v n = none
+      ∨ ∃ ifp, int_fract_pair.stream v n = some ifp ∧ ifp.fr = 0, from
+      int_fract_pair.succ_nth_stream_eq_none_iff.elim_left succ_nth_stream_eq_none,
+    rcases this with ⟨nth_stream_eq_none⟩ | ⟨ifp_n, nth_stream_eq, nth_stream_fr_eq_zero⟩,
+    { cases n with n',
+      { contradiction }, -- int_fract_pair.stream v 0 ≠ none
+      { have : g.terminated_at n', from
+          gcf.of_terminated_at_n_iff_succ_nth_int_fract_pair_stream_eq_none.elim_right
+          nth_stream_eq_none,
+        have : g.convergents (n' + 1) = g.convergents n', from
+          gcf.convergents_stable_of_terminated n'.le_succ this,
+        rw this,
+        exact (IH nth_stream_eq_none) } },
+    { simpa [nth_stream_fr_eq_zero, gcf.comp_exact_value] using
+      (comp_exact_value_correctness_of_stream_eq_some nth_stream_eq) } }
+end
+
+/-- If `generalized_continued_fraction.of v` terminated at step `n`, then the `n`th convergent is
+exactly `v`. -/
+lemma of_correctness_of_terminated_at (terminated_at_n : (gcf.of v).terminated_at n) :
+  v = (gcf.of v).convergents n :=
+have int_fract_pair.stream v (n + 1) = none, from
+  gcf.of_terminated_at_n_iff_succ_nth_int_fract_pair_stream_eq_none.elim_left terminated_at_n,
+comp_exact_value_correctness_of_stream_eq_none this
+
+/-- If `generalized_continued_fraction.of v` terminates, then its convergent will eventually be
+exactly `v`. -/
+theorem of_correctness_of_terminates (terminates : (gcf.of v).terminates) :
+  ∃ (n : ℕ), v = (gcf.of v).convergents n :=
+exists.elim terminates
+( assume n terminated_at_n,
+  exists.intro n (of_correctness_of_terminated_at terminated_at_n) )
+
+end generalized_continued_fraction

--- a/src/algebra/continued_fractions/computation/correctness_terminating.lean
+++ b/src/algebra/continued_fractions/computation/correctness_terminating.lean
@@ -6,6 +6,7 @@ Authors: Kevin Kappelmann
 import algebra.continued_fractions.computation.translations
 import algebra.continued_fractions.terminated_stable
 import algebra.continued_fractions.continuants_recurrence
+import tactic.lint
 /-!
 # Correctness of Terminating Continued Fraction Computations (`gcf.of`)
 
@@ -38,7 +39,7 @@ about the computation process, refer to `algebra.continued_fraction.computation.
 namespace generalized_continued_fraction
 open generalized_continued_fraction as gcf
 
-variables {K : Type*} [discrete_linear_ordered_field K] [floor_ring K] {v : K} {n : ℕ}
+variables {K : Type*} [discrete_linear_ordered_field K] {v : K} {n : ℕ}
 
 /--
 Given two successive continuants (at positions `n + 1` and `n`) of a continued fraction
@@ -58,6 +59,8 @@ if fr = 0 then conts.a / conts.b
 -- otherwise, we have to include the fractional part in a final continuants step.
 else let exactConts := next_continuants 1 fr⁻¹ predConts conts in
   exactConts.a / exactConts.b
+
+variable [floor_ring K]
 
 /-- Just a computational lemmas we need for the next main proof -/
 protected lemma comp_exact_value_correctness_of_stream_eq_some_aux_comp {a : K} (b c : K)

--- a/src/algebra/continued_fractions/computation/correctness_terminating.lean
+++ b/src/algebra/continued_fractions/computation/correctness_terminating.lean
@@ -6,7 +6,6 @@ Authors: Kevin Kappelmann
 import algebra.continued_fractions.computation.translations
 import algebra.continued_fractions.terminated_stable
 import algebra.continued_fractions.continuants_recurrence
-import tactic.lint
 /-!
 # Correctness of Terminating Continued Fraction Computations (`gcf.of`)
 

--- a/src/algebra/continued_fractions/computation/correctness_terminating.lean
+++ b/src/algebra/continued_fractions/computation/correctness_terminating.lean
@@ -45,9 +45,9 @@ Given two successive continuants (at positions `n + 1` and `n`) of a continued f
 `generalized_continued_fraction.of v` and the fractional part at `int_fract_pair.stream n`,
 this function returns the exact value approximated by the continued fraction, that is `v`.
 
-For example, let `(v : ℚ) := 3.4`. We have:
-  `gcf.int_fract_pair.stream v 0 = some ⟨3, 0.4⟩`, and
-  `gcf.int_fract_pair.stream v 1 = some ⟨2, 0.5⟩`,
+For example, let `(v : ℚ) := 3.4`. We have
+- `gcf.int_fract_pair.stream v 0 = some ⟨3, 0.4⟩`, and
+- `gcf.int_fract_pair.stream v 1 = some ⟨2, 0.5⟩`.
 
 Now `(gcf.of v).convergents 1 = 3 + 1/2`, and our fractional term (the residual) at position `2` is
 `0.5`. We hence have `v = 3 + 1/(2 + 0.5) = 3 + 1/2.5 = 3.4`.

--- a/src/algebra/continued_fractions/computation/correctness_terminating.lean
+++ b/src/algebra/continued_fractions/computation/correctness_terminating.lean
@@ -92,7 +92,7 @@ begin
     have : int_fract_pair.of v = ifp_zero, by
     { have : int_fract_pair.stream v 0 = some (int_fract_pair.of v), from rfl,
       simpa only [this] using stream_zero_eq },
-    cases this with refl,
+    cases this,
     cases decidable.em (fract v = 0) with fract_eq_zero fract_ne_zero,
     -- fract v = 0; we must then have `v = ⌊v⌋`
     { suffices : v = ⌊v⌋, by simpa [continuants_aux, fract_eq_zero, gcf.comp_exact_value],
@@ -120,7 +120,7 @@ begin
         ∃ ifp_n, int_fract_pair.stream v n = some ifp_n ∧ ifp_n.fr⁻¹ = ⌊ifp_n.fr⁻¹⌋, from
           int_fract_pair.obtain_succ_nth_stream_of_fr_zero succ_nth_stream_eq ifp_succ_n_fr_eq_zero,
       have : ifp_n' = ifp_n, by injection (eq.trans (nth_stream_eq').symm nth_stream_eq),
-      cases this with refl,
+      cases this,
       have s_nth_eq : g.s.nth n = some ⟨1, ⌊ifp_n.fr⁻¹⌋⟩, from
         gcf.nth_of_eq_some_of_nth_int_fract_pair_stream_fr_ne_zero nth_stream_eq nth_fract_ne_zero,
       rw [←ifp_n_fract_inv_eq_floor] at s_nth_eq,
@@ -139,7 +139,7 @@ begin
         ∧ int_fract_pair.of ifp_n.fr⁻¹ = ifp_succ_n, from
           int_fract_pair.succ_nth_stream_eq_some_iff.elim_left succ_nth_stream_eq,
       have : ifp_n' = ifp_n, by injection (eq.trans (nth_stream_eq').symm nth_stream_eq),
-      cases this with refl,
+      cases this,
       -- get the correspondence between ifp_n and g.s.nth n
       have s_nth_eq : g.s.nth n = some ⟨1, (⌊ifp_n.fr⁻¹⌋ : K)⟩, from
         gcf.nth_of_eq_some_of_nth_int_fract_pair_stream_fr_ne_zero nth_stream_eq ifp_n_fract_ne_zero,

--- a/src/algebra/continued_fractions/computation/correctness_terminating.lean
+++ b/src/algebra/continued_fractions/computation/correctness_terminating.lean
@@ -52,12 +52,12 @@ For example, let `(v : ℚ) := 3.4`. We have:
 Now `(gcf.of v).convergents 1 = 3 + 1/2`, and our fractional term (the residual) at position `2` is
 `0.5`. We hence have `v = 3 + 1/(2 + 0.5) = 3 + 1/2.5 = 3.4`.
 -/
-protected def comp_exact_value (predConts conts : gcf.pair K) (fr : K) : K :=
+protected def comp_exact_value (pred_conts conts : gcf.pair K) (fr : K) : K :=
 -- if the fractional part is zero, we exactly approximated the value by the last continuants
 if fr = 0 then conts.a / conts.b
 -- otherwise, we have to include the fractional part in a final continuants step.
-else let exactConts := next_continuants 1 fr⁻¹ predConts conts in
-  exactConts.a / exactConts.b
+else let exact_conts := next_continuants 1 fr⁻¹ pred_conts conts in
+  exact_conts.a / exact_conts.b
 
 variable [floor_ring K]
 
@@ -109,8 +109,8 @@ begin
         int_fract_pair.succ_nth_stream_eq_some_iff.elim_left succ_nth_stream_eq,
     -- introduce some notation
     let conts := g.continuants_aux (n + 2),
-    set predConts := g.continuants_aux (n + 1) with predConts_eq,
-    set ppredConts := g.continuants_aux n with ppredConts_eq,
+    set pred_conts := g.continuants_aux (n + 1) with pred_conts_eq,
+    set ppred_conts := g.continuants_aux n with ppred_conts_eq,
     cases decidable.em (ifp_succ_n.fr = 0) with ifp_succ_n_fr_eq_zero ifp_succ_n_fr_ne_zero,
     -- ifp_succ_n.fr = 0
     { suffices : v = conts.a / conts.b, by
@@ -124,14 +124,14 @@ begin
       have s_nth_eq : g.s.nth n = some ⟨1, ⌊ifp_n.fr⁻¹⌋⟩, from
         gcf.nth_of_eq_some_of_nth_int_fract_pair_stream_fr_ne_zero nth_stream_eq nth_fract_ne_zero,
       rw [←ifp_n_fract_inv_eq_floor] at s_nth_eq,
-      suffices : v = gcf.comp_exact_value ppredConts predConts ifp_n.fr, by
+      suffices : v = gcf.comp_exact_value ppred_conts pred_conts ifp_n.fr, by
         simpa [conts, continuants_aux, s_nth_eq,gcf.comp_exact_value, nth_fract_ne_zero] using this,
       exact (IH nth_stream_eq) },
     -- ifp_succ_n.fr ≠ 0
     { -- use the IH to show that the following equality suffices
-      suffices : gcf.comp_exact_value ppredConts predConts ifp_n.fr
-               = gcf.comp_exact_value predConts conts ifp_succ_n.fr, by
-      { have : v = gcf.comp_exact_value ppredConts predConts ifp_n.fr, from IH nth_stream_eq,
+      suffices : gcf.comp_exact_value ppred_conts pred_conts ifp_n.fr
+               = gcf.comp_exact_value pred_conts conts ifp_succ_n.fr, by
+      { have : v = gcf.comp_exact_value ppred_conts pred_conts ifp_n.fr, from IH nth_stream_eq,
         conv_lhs { rw this }, assumption },
       -- get the correspondence between ifp_n and ifp_succ_n
       obtain ⟨ifp_n', nth_stream_eq', ifp_n_fract_ne_zero, ⟨refl⟩⟩ :
@@ -145,25 +145,25 @@ begin
         gcf.nth_of_eq_some_of_nth_int_fract_pair_stream_fr_ne_zero nth_stream_eq ifp_n_fract_ne_zero,
       -- the claim now follows by unfolding the definitions and tedious calculations
       -- some shorthand notation
-      let ppA := ppredConts.a, let ppB := ppredConts.b,
-      let pA := predConts.a, let pB := predConts.b,
-      have : gcf.comp_exact_value ppredConts predConts ifp_n.fr
+      let ppA := ppred_conts.a, let ppB := ppred_conts.b,
+      let pA := pred_conts.a, let pB := pred_conts.b,
+      have : gcf.comp_exact_value ppred_conts pred_conts ifp_n.fr
           = (ppA + ifp_n.fr⁻¹ * pA) / (ppB + ifp_n.fr⁻¹ * pB), by
         -- unfold comp_exact_value and the convergent computation once
         { field_simp [ifp_n_fract_ne_zero, gcf.comp_exact_value, next_continuants, next_numerator,
           next_denominator], ac_refl },
       rw this,
       -- two calculations needed to show the claim
-      have tmpCalc := gcf.comp_exact_value_correctness_of_stream_eq_some_aux_comp
+      have tmp_calc := gcf.comp_exact_value_correctness_of_stream_eq_some_aux_comp
         pA ppA ifp_succ_n_fr_ne_zero,
-      have tmpCalc' := gcf.comp_exact_value_correctness_of_stream_eq_some_aux_comp
+      have tmp_calc' := gcf.comp_exact_value_correctness_of_stream_eq_some_aux_comp
         pB ppB ifp_succ_n_fr_ne_zero,
-      rw inv_eq_one_div at tmpCalc tmpCalc',
+      rw inv_eq_one_div at tmp_calc tmp_calc',
       have : fract (1 / ifp_n.fr) ≠ 0, by simpa using ifp_succ_n_fr_ne_zero,
       -- now unfold the recurrence one step and simplify both sides to arrive at the conclusion
       field_simp [conts, gcf.comp_exact_value,
-        (gcf.continuants_aux_recurrence s_nth_eq ppredConts_eq predConts_eq), next_continuants,
-        next_numerator, next_denominator, this, tmpCalc, tmpCalc'],
+        (gcf.continuants_aux_recurrence s_nth_eq ppred_conts_eq pred_conts_eq), next_continuants,
+        next_numerator, next_denominator, this, tmp_calc, tmp_calc'],
       ac_refl } }
 end
 

--- a/src/algebra/continued_fractions/computation/correctness_terminating.lean
+++ b/src/algebra/continued_fractions/computation/correctness_terminating.lean
@@ -61,7 +61,7 @@ else let exact_conts := next_continuants 1 fr⁻¹ pred_conts conts in
 
 variable [floor_ring K]
 
-/-- Just a computational lemmas we need for the next main proof -/
+/-- Just a computational lemma we need for the next main proof. -/
 protected lemma comp_exact_value_correctness_of_stream_eq_some_aux_comp {a : K} (b c : K)
   (fract_a_ne_zero : fract a ≠ 0) :
   ((⌊a⌋ : K) * b + c) / (fract a) + b = (b * a + c) / fract a :=

--- a/src/algebra/continued_fractions/computation/correctness_terminating.lean
+++ b/src/algebra/continued_fractions/computation/correctness_terminating.lean
@@ -198,7 +198,7 @@ end
 
 /-- If `generalized_continued_fraction.of v` terminated at step `n`, then the `n`th convergent is
 exactly `v`. -/
-lemma of_correctness_of_terminated_at (terminated_at_n : (gcf.of v).terminated_at n) :
+theorem of_correctness_of_terminated_at (terminated_at_n : (gcf.of v).terminated_at n) :
   v = (gcf.of v).convergents n :=
 have int_fract_pair.stream v (n + 1) = none, from
   gcf.of_terminated_at_n_iff_succ_nth_int_fract_pair_stream_eq_none.elim_left terminated_at_n,
@@ -206,7 +206,7 @@ comp_exact_value_correctness_of_stream_eq_none this
 
 /-- If `generalized_continued_fraction.of v` terminates, then its convergent will eventually be
 exactly `v`. -/
-theorem of_correctness_of_terminates (terminates : (gcf.of v).terminates) :
+lemma of_correctness_of_terminates (terminates : (gcf.of v).terminates) :
   ∃ (n : ℕ), v = (gcf.of v).convergents n :=
 exists.elim terminates
 ( assume n terminated_at_n,

--- a/src/algebra/continued_fractions/computation/correctness_terminating.lean
+++ b/src/algebra/continued_fractions/computation/correctness_terminating.lean
@@ -16,7 +16,7 @@ Let us write `gcf` for `generalized_continued_fraction`. We show the correctness
 algorithm computing continued fractions (`gcf.of`) in case of termination in the following sense:
 
 At every step `n : ℕ`, we can obtain the value `v` by adding a specific residual term to the last
-denimonator of the fraction described by `(gcf.of v).convergents' n`. The residual term will be zero
+denominator of the fraction described by `(gcf.of v).convergents' n`. The residual term will be zero
 exactly when the continued fraction terminated; otherwise, the residual term will be given by the
 fractional part stored in `gcf.int_fract_pair.stream v n`.
 
@@ -42,7 +42,7 @@ open generalized_continued_fraction as gcf
 variables {K : Type*} [discrete_linear_ordered_field K] {v : K} {n : ℕ}
 
 /--
-Given two continants `pconts` and `conts` and a value `fr`, this function returns
+Given two continuants `pconts` and `conts` and a value `fr`, this function returns
 - `conts.a / conts.b` if `fr = 0`
 - `exact_conts.a / exact_conts.b` where `exact_conts = next_continuants 1 fr⁻¹ pconts conts` otherwise.
 

--- a/src/algebra/continued_fractions/computation/default.lean
+++ b/src/algebra/continued_fractions/computation/default.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Kappelmann
 -/
 import algebra.continued_fractions.computation.basic
+import algebra.continued_fractions.computation.translations
 /-!
 # Default Exports for the Computation of Continued Fractions
 -/

--- a/src/algebra/continued_fractions/continuants_recurrence.lean
+++ b/src/algebra/continued_fractions/continuants_recurrence.lean
@@ -32,6 +32,7 @@ lemma continuants_recurrence_aux {gp ppred pred : gcf.pair K} (nth_s_eq : g.s.nt
 by simp [nth_cont_eq_succ_nth_cont_aux,
   (continuants_aux_recurrence nth_s_eq nth_conts_aux_eq succ_nth_conts_aux_eq)]
 
+/-- Shows that `Aₙ = bₙ * Aₙ₋₁ + aₙ * Aₙ₋₂` and `Bₙ = bₙ * Bₙ₋₁ + aₙ * Bₙ₋₂`. -/
 theorem continuants_recurrence {gp ppred pred : gcf.pair K}
   (succ_nth_s_eq : g.s.nth (n + 1) = some gp)
   (nth_conts_eq : g.continuants n = ppred)
@@ -42,6 +43,7 @@ begin
   exact (continuants_recurrence_aux succ_nth_s_eq nth_conts_eq succ_nth_conts_eq)
 end
 
+/-- Shows that `Aₙ = bₙ * Aₙ₋₁ + aₙ * Aₙ₋₂`. -/
 lemma numerators_recurrence {gp : gcf.pair K} {ppredA predA : K}
   (succ_nth_s_eq : g.s.nth (n + 1) = some gp)
   (nth_num_eq : g.numerators n = ppredA)
@@ -56,6 +58,7 @@ begin
   rw [num_eq_conts_a, (continuants_recurrence succ_nth_s_eq nth_conts_eq succ_nth_conts_eq)]
 end
 
+/-- Shows that `Bₙ = bₙ * Bₙ₋₁ + aₙ * Bₙ₋₂`. -/
 lemma denominators_recurrence {gp : gcf.pair K} {ppredB predB : K}
   (succ_nth_s_eq : g.s.nth (n + 1) = some gp)
   (nth_denom_eq : g.denominators n = ppredB)

--- a/src/algebra/continued_fractions/continuants_recurrence.lean
+++ b/src/algebra/continued_fractions/continuants_recurrence.lean
@@ -11,8 +11,8 @@ import algebra.continued_fractions.translations
 
 Given a generalized continued fraction `g`, for all `n ≥ 1`, we prove that the `continuants`
 function indeed satisfies the following recurrences:
-
-  `Aₙ = bₙ * Aₙ₋₁ + aₙ * Aₙ₋₂`, and `Bₙ = bₙ * Bₙ₋₁ + aₙ * Bₙ₋₂`.
+- `Aₙ = bₙ * Aₙ₋₁ + aₙ * Aₙ₋₂`, and
+- `Bₙ = bₙ * Bₙ₋₁ + aₙ * Bₙ₋₂`.
 -/
 
 namespace generalized_continued_fraction

--- a/src/algebra/continued_fractions/convergents_equiv.lean
+++ b/src/algebra/continued_fractions/convergents_equiv.lean
@@ -285,13 +285,14 @@ begin
         g.s.ge_stable n'.le_succ s_nth_eq,
       -- Notations
       let g' := squash_gcf g (n' + 1),
-      set predConts := g.continuants_aux (n' + 1) with succ_n'th_conts_aux_eq,
-      set ppredConts := g.continuants_aux n' with n'th_conts_aux_eq,
-      let pA := predConts.a, let pB := predConts.b, let ppA := ppredConts.a, let ppB := ppredConts.b,
-      set predConts' := g'.continuants_aux (n' + 1) with succ_n'th_conts_aux_eq',
-      set ppredConts' := g'.continuants_aux n' with n'th_conts_aux_eq',
-      let pA' := predConts'.a, let pB' := predConts'.b, let ppA' := ppredConts'.a,
-      let ppB' := ppredConts'.b,
+      set pred_conts := g.continuants_aux (n' + 1) with succ_n'th_conts_aux_eq,
+      set ppred_conts := g.continuants_aux n' with n'th_conts_aux_eq,
+      let pA := pred_conts.a, let pB := pred_conts.b,
+      let ppA := ppred_conts.a, let ppB := ppred_conts.b,
+      set pred_conts' := g'.continuants_aux (n' + 1) with succ_n'th_conts_aux_eq',
+      set ppred_conts' := g'.continuants_aux n' with n'th_conts_aux_eq',
+      let pA' := pred_conts'.a, let pB' := pred_conts'.b, let ppA' := ppred_conts'.a,
+      let ppB' := ppred_conts'.b,
       -- first compute the convergent of the squashed gcf
       have : g'.convergents (n' + 1)
            = ((pb + a / b) * pA' + pa * ppA') / ((pb + a / b) * pB' + pa * ppB'),

--- a/src/algebra/continued_fractions/convergents_equiv.lean
+++ b/src/algebra/continued_fractions/convergents_equiv.lean
@@ -28,9 +28,9 @@ Let `c` be a continued fraction `[h; (a₀, b₀), (a₁, b₁), (a₂, b₂),..
 
 One can compute the convergents of `c` in two ways:
 1. Directly evaluating the fraction described by `c` up to a given `n` (`convergents'`)
-2. Using the recurrence (`convergents`)
-  `A₋₁ = 1,  A₀ = h,  Aₙ = bₙ-₁ * Aₙ₋₁ + aₙ-₁ * Aₙ₋₂`, and
-  `B₋₁ = 0,  B₀ = 1,  Bₙ = bₙ-₁ * Bₙ₋₁ + aₙ-₁ * Bₙ₋₂`.
+2. Using the recurrence (`convergents`):
+  - `A₋₁ = 1,  A₀ = h,  Aₙ = bₙ-₁ * Aₙ₋₁ + aₙ-₁ * Aₙ₋₂`, and
+  - `B₋₁ = 0,  B₀ = 1,  Bₙ = bₙ-₁ * Bₙ₋₁ + aₙ-₁ * Bₙ₋₂`.
 
 To show the equivalence of the computations in the main theorem of this file
 `convergents_eq_convergents'`, we proceed by induction. The case `n = 0` is trivial.

--- a/src/algebra/continued_fractions/convergents_equiv.lean
+++ b/src/algebra/continued_fractions/convergents_equiv.lean
@@ -177,7 +177,7 @@ begin
       suffices : gp_head.a / (gp_head.b + convergents'_aux s.tail (m + 2))
                = convergents'_aux (squash_seq s (m + 1)) (m + 2), by
         simpa only [convergents'_aux, s_head_eq],
-      have : convergents'_aux s.tail (m + 2) = convergents'_aux (squash_seq s.tail m) (m + 1),by
+      have : convergents'_aux s.tail (m + 2) = convergents'_aux (squash_seq s.tail m) (m + 1), by
       { have : s.tail.nth (m + 1) = some gp_succ_n, by simpa [seq.nth_tail] using s_succ_nth_eq,
         exact (IH _ this) },
       have : (squash_seq s (m + 1)).head = some gp_head, from

--- a/src/algebra/continued_fractions/convergents_equiv.lean
+++ b/src/algebra/continued_fractions/convergents_equiv.lean
@@ -29,8 +29,8 @@ Let `c` be a continued fraction `[h; (a₀, b₀), (a₁, b₁), (a₂, b₂),..
 One can compute the convergents of `c` in two ways:
 1. Directly evaluating the fraction described by `c` up to a given `n` (`convergents'`)
 2. Using the recurrence (`convergents`):
-  - `A₋₁ = 1,  A₀ = h,  Aₙ = bₙ-₁ * Aₙ₋₁ + aₙ-₁ * Aₙ₋₂`, and
-  - `B₋₁ = 0,  B₀ = 1,  Bₙ = bₙ-₁ * Bₙ₋₁ + aₙ-₁ * Bₙ₋₂`.
+  - `A₋₁ = 1,  A₀ = h,  Aₙ = bₙ₋₁ * Aₙ₋₁ + aₙ₋₁ * Aₙ₋₂`, and
+  - `B₋₁ = 0,  B₀ = 1,  Bₙ = bₙ₋₁ * Bₙ₋₁ + aₙ₋₁ * Bₙ₋₂`.
 
 To show the equivalence of the computations in the main theorem of this file
 `convergents_eq_convergents'`, we proceed by induction. The case `n = 0` is trivial.


### PR DESCRIPTION
### What
Add correctness lemmas for terminating computations of continued fractions

### Why
To show that the continued fractions algorithm is computing the right thing in case of termination. For non-terminating sequences, lemmas about the limit will be added in a later PR.

### How
1. Show that the value to be approximated can always be obtained by adding the corresponding, remaining fractional part stored in `int_fract_pair.stream`.
2. Use this to derive that once the fractional part becomes 0 (and hence the continued fraction terminates), we have exactly computed the value.