### PR TITLE
[Merged by Bors] - refactor(category_theory/abelian): use has_finite_products

### DIFF
--- a/src/category_theory/abelian/basic.lean
+++ b/src/category_theory/abelian/basic.lean
@@ -81,8 +81,8 @@ variables (C)
 section prio
 set_option default_priority 100
 
-/-- A (preadditive) category `C` is called abelian if it has a zero object, all binary products and
-    coproducts, all kernels and cokernels, and if every monomorphism is the kernel of some morphism
+/-- A (preadditive) category `C` is called abelian if it has all finite products,
+    all kernels and cokernels, and if every monomorphism is the kernel of some morphism
     and every epimorphism is the cokernel of some morphism. -/
 class abelian extends preadditive.{v} C :=
 [has_finite_products : has_finite_products.{v} C]
@@ -93,6 +93,12 @@ class abelian extends preadditive.{v} C :=
 
 attribute [instance] abelian.has_finite_products
 attribute [instance] abelian.has_kernels abelian.has_cokernels
+
+-- Verify that we can find the `has_zero_object C` instance:
+--   `has_finite_products C` gives `has_terminal C`,
+--   and as `preadditive C` gives `has_zero_morphisms C`, together we have `has_zero_object C`.
+example [abelian.{v} C] : has_zero_object.{v} C := by apply_instance
+
 end prio
 end category_theory
 

--- a/src/category_theory/abelian/basic.lean
+++ b/src/category_theory/abelian/basic.lean
@@ -85,15 +85,13 @@ set_option default_priority 100
     coproducts, all kernels and cokernels, and if every monomorphism is the kernel of some morphism
     and every epimorphism is the cokernel of some morphism. -/
 class abelian extends preadditive.{v} C :=
-[has_zero_object : has_zero_object.{v} C]
-[has_binary_products : has_binary_products.{v} C]
+[has_finite_products : has_finite_products.{v} C]
 [has_kernels : has_kernels.{v} C]
 [has_cokernels : has_cokernels.{v} C]
 (normal_mono : Π {X Y : C} (f : X ⟶ Y) [mono f], normal_mono.{v} f)
 (normal_epi : Π {X Y : C} (f : X ⟶ Y) [epi f], normal_epi.{v} f)
 
-attribute [instance] abelian.has_zero_object
-attribute [instance] abelian.has_binary_products
+attribute [instance] abelian.has_finite_products
 attribute [instance] abelian.has_kernels abelian.has_cokernels
 end prio
 end category_theory

--- a/src/category_theory/abelian/basic.lean
+++ b/src/category_theory/abelian/basic.lean
@@ -14,9 +14,10 @@ import category_theory.limits.shapes.images
 
 This file contains the definition and basic properties of abelian categories.
 
-There are many definitions of abelian category. Our definition is as follows: A category is called
-abelian if it is preadditive, has a zero object, binary products, kernels and cokernels, and if
-every monomorphism and epimorphism is normal.
+There are many definitions of abelian category. Our definition is as follows:
+A category is called abelian if it is preadditive,
+has a finite products, kernels and cokernels,
+and if every monomorphism and epimorphism is normal.
 
 It should be noted that if we also assume coproducts, then preadditivity is actually a consequence
 of the other properties. However, this fact is of little practical relevance (and, as of now, there
@@ -81,9 +82,15 @@ variables (C)
 section prio
 set_option default_priority 100
 
-/-- A (preadditive) category `C` is called abelian if it has all finite products,
-    all kernels and cokernels, and if every monomorphism is the kernel of some morphism
-    and every epimorphism is the cokernel of some morphism. -/
+/--
+A (preadditive) category `C` is called abelian if it has all finite products,
+all kernels and cokernels, and if every monomorphism is the kernel of some morphism
+and every epimorphism is the cokernel of some morphism.
+
+(This definition implies the existence of zero objects:
+finite products give a terminal object, and in a preadditive category
+any terminal object is a zero object.)
+-/
 class abelian extends preadditive.{v} C :=
 [has_finite_products : has_finite_products.{v} C]
 [has_kernels : has_kernels.{v} C]
@@ -93,11 +100,6 @@ class abelian extends preadditive.{v} C :=
 
 attribute [instance] abelian.has_finite_products
 attribute [instance] abelian.has_kernels abelian.has_cokernels
-
--- Verify that we can find the `has_zero_object C` instance:
---   `has_finite_products C` gives `has_terminal C`,
---   and as `preadditive C` gives `has_zero_morphisms C`, together we have `has_zero_object C`.
-example [abelian.{v} C] : has_zero_object.{v} C := by apply_instance
 
 end prio
 end category_theory

--- a/src/category_theory/limits/shapes/binary_products.lean
+++ b/src/category_theory/limits/shapes/binary_products.lean
@@ -340,10 +340,10 @@ class has_binary_coproducts :=
 
 attribute [instance] has_binary_products.has_limits_of_shape has_binary_coproducts.has_colimits_of_shape
 
-@[priority 100] -- see Note [lower instance priority]
+@[priority 200] -- see Note [lower instance priority]
 instance [has_finite_products.{v} C] : has_binary_products.{v} C :=
 { has_limits_of_shape := by apply_instance }
-@[priority 100] -- see Note [lower instance priority]
+@[priority 200] -- see Note [lower instance priority]
 instance [has_finite_coproducts.{v} C] : has_binary_coproducts.{v} C :=
 { has_colimits_of_shape := by apply_instance }
 

--- a/src/category_theory/limits/shapes/biproducts.lean
+++ b/src/category_theory/limits/shapes/biproducts.lean
@@ -37,6 +37,8 @@ biproduct, which is a preadditive version of binary biproducts. We show that a p
 biproduct is a binary biproduct and construct preadditive binary biproducts both from binary
 products and from binary coproducts.
 
+TODO: the preadditive version of finite biproducts
+
 ## Notation
 As `⊕` is already taken for the sum of types, we introduce the notation `X ⊞ Y` for
 a binary biproduct. We introduce `⨁ f` for the indexed biproduct.

--- a/src/category_theory/limits/shapes/biproducts.lean
+++ b/src/category_theory/limits/shapes/biproducts.lean
@@ -451,12 +451,16 @@ instance [has_preadditive_binary_biproducts.{v} C] : has_binary_biproducts.{v} C
 
 /-- If a preadditive category has all binary products, then it has all preadditive binary
     biproducts. -/
+-- This particularly dangerous as an instance,
+-- as we can deduce `has_binary_products` from `has_preadditive_binary_biproducts`.
 def has_preadditive_binary_biproducts_of_has_binary_products [has_binary_products.{v} C] :
   has_preadditive_binary_biproducts.{v} C :=
 ⟨λ X Y, has_preadditive_binary_biproduct.of_has_limit_pair X Y⟩
 
 /-- If a preadditive category has all binary coproducts, then it has all preadditive binary
     biproducts. -/
+-- This particularly dangerous as an instance,
+-- as we can deduce `has_binary_products` from `has_preadditive_binary_biproducts`.
 def has_preadditive_binary_biproducts_of_has_binary_coproducts [has_binary_coproducts.{v} C] :
   has_preadditive_binary_biproducts.{v} C :=
 ⟨λ X Y, has_preadditive_binary_biproduct.of_has_colimit_pair X Y⟩

--- a/src/category_theory/limits/shapes/zero.lean
+++ b/src/category_theory/limits/shapes/zero.lean
@@ -194,13 +194,39 @@ by ext
 end
 
 /-- A zero object is in particular initial. -/
-def has_initial_of_has_zero_object : has_initial.{v} C :=
+def has_initial [has_zero_object.{v} C] : has_initial.{v} C :=
 has_initial_of_unique 0
 /-- A zero object is in particular terminal. -/
-def has_terminal_of_has_zero_object : has_terminal.{v} C :=
+def has_terminal [has_zero_object.{v} C] : has_terminal.{v} C :=
 has_terminal_of_unique 0
 
 end has_zero_object
+
+/-- If there are zero morphisms, any initial object is a zero object. -/
+@[priority 50]
+instance has_zero_object_of_has_initial_object
+  [has_zero_morphisms.{v} C] [has_initial.{v} C] : has_zero_object.{v} C :=
+{ zero := ⊥_ C,
+  unique_to := λ X, ⟨⟨0⟩, by tidy⟩,
+  unique_from := λ X, ⟨⟨0⟩, λ f,
+  calc
+    f = f ≫ 𝟙 _ : (category.comp_id _).symm
+    ... = f ≫ 0 : by congr
+    ... = 0     : has_zero_morphisms.comp_zero _ _
+  ⟩ }
+
+/-- If there are zero morphisms, any terminal object is a zero object. -/
+@[priority 50]
+instance has_zero_object_of_has_terminal_object
+  [has_zero_morphisms.{v} C] [has_terminal.{v} C] : has_zero_object.{v} C :=
+{ zero := ⊤_ C,
+  unique_from := λ X, ⟨⟨0⟩, by tidy⟩,
+  unique_to := λ X, ⟨⟨0⟩, λ f,
+  calc
+    f = 𝟙 _ ≫ f : (category.id_comp _).symm
+    ... = 0 ≫ f : by congr
+    ... = 0     : has_zero_morphisms.zero_comp _ _
+  ⟩ }
 
 /-- In the presence of zero morphisms, coprojections into a coproduct are (split) monomorphisms. -/
 instance split_mono_sigma_ι

--- a/src/category_theory/limits/shapes/zero.lean
+++ b/src/category_theory/limits/shapes/zero.lean
@@ -194,10 +194,10 @@ by ext
 end
 
 /-- A zero object is in particular initial. -/
-def has_initial [has_zero_object.{v} C] : has_initial.{v} C :=
+def has_initial : has_initial.{v} C :=
 has_initial_of_unique 0
 /-- A zero object is in particular terminal. -/
-def has_terminal [has_zero_object.{v} C] : has_terminal.{v} C :=
+def has_terminal : has_terminal.{v} C :=
 has_terminal_of_unique 0
 
 end has_zero_object


### PR DESCRIPTION
This doesn't go nearly as far as I wanted.

Really I'd like to factor out `additive`, which is a `preadditive` category with all finite biproducts, and then layer `abelian` on top of that (with (co)kernels and every epi/mono normal).

I can't do that immediately, because:
1. we don't provide the instances from `has_finite_biproducts` to `has_finite_(co)products`
2. we don't define the preadditive version of finite biproducts (we only did the binary ones)
3. hence we don't show that in a preadditive category finite products give rise to finite biproducts

@TwoFX, @b-mehta, if either of you are interested in doing any of these, that would be great. I'll hopefully get to them eventually.