### PR TITLE
[Merged by Bors] -  feat(data/set/intervals/image_preimage): new file

### DIFF
--- a/src/analysis/convex/basic.lean
+++ b/src/analysis/convex/basic.lean
@@ -3,7 +3,8 @@ Copyright (c) 2019 Alexander Bentkamp. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alexander Bentkamp, Yury Kudriashov
 -/
-import data.set.intervals
+import data.set.intervals.unordered_interval
+import data.set.intervals.image_preimage
 import data.complex.module
 import algebra.pointwise
 
@@ -91,7 +92,7 @@ lemma segment_eq_Icc {a b : ℝ} (h : a ≤ b) : [a, b] = Icc a b :=
 begin
   rw [segment_eq_image'],
   show (((+) a) ∘ (λ t, t * (b - a))) '' Icc 0 1 = Icc a b,
-  rw [image_comp, image_mul_right_Icc (@zero_le_one ℝ _) (sub_nonneg.2 h), image_add_left_Icc],
+  rw [image_comp, image_mul_right_Icc (@zero_le_one ℝ _) (sub_nonneg.2 h), image_const_add_Icc],
   simp
 end
 

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -23,8 +23,6 @@ This file contains these definitions, and basic facts on inclusion, intersection
 intervals (where the precise statements may depend on the properties of the order, in particular
 for some statements it should be `linear_order` or `densely_ordered`).
 
-This file also contains statements on lower and upper bounds of intervals.
-
 TODO: This is just the beginning; a lot of rules are missing
 -/
 
@@ -590,61 +588,6 @@ set.ext $ by simp [Ico, Iio, iff_def, lt_min_iff] {contextual:=tt}
 
 end decidable_linear_order
 
-section ordered_add_comm_group
-
-variables {α : Type u} [ordered_add_comm_group α]
-
-lemma image_add_left_Icc (a b c : α) : ((+) a) '' Icc b c = Icc (a + b) (a + c) :=
-begin
-  ext x,
-  split,
-  { rintros ⟨x, hx, rfl⟩,
-    exact ⟨add_le_add_left hx.1 a, add_le_add_left hx.2 a⟩},
-  { intro hx,
-    refine ⟨-a + x, _, add_neg_cancel_left _ _⟩,
-    exact ⟨le_neg_add_iff_add_le.2 hx.1, neg_add_le_iff_le_add.2 hx.2⟩ }
-end
-
-lemma image_add_right_Icc (a b c : α) : (λ x, x + c) '' Icc a b = Icc (a + c) (b + c) :=
-by convert image_add_left_Icc c a b using 1; simp only [add_comm _ c]
-
-lemma image_neg_Iio (r : α) : image (λz, -z) (Iio r) = Ioi (-r) :=
-begin
-  ext z,
-  apply iff.intro,
-  { intros hz,
-    apply exists.elim hz,
-    intros z' hz',
-    rw [←hz'.2],
-    simp only [mem_Ioi, neg_lt_neg_iff],
-    exact hz'.1 },
-  { intros hz,
-    simp only [mem_image, mem_Iio],
-    use -z,
-    simp [hz],
-    exact neg_lt.1 hz }
-end
-
-lemma image_neg_Iic (r : α)  : image (λz, -z) (Iic r) = Ici (-r) :=
-begin
-  apply set.ext,
-  intros z,
-  apply iff.intro,
-  { intros hz,
-    apply exists.elim hz,
-    intros z' hz',
-    rw [←hz'.2],
-    simp only [neg_le_neg_iff, mem_Ici],
-    exact hz'.1 },
-  { intros hz,
-    simp only [mem_image, mem_Iic],
-    use -z,
-    simp [hz],
-    exact neg_le.1 hz }
-end
-
-end ordered_add_comm_group
-
 section decidable_linear_ordered_add_comm_group
 
 variables {α : Type u} [decidable_linear_ordered_add_comm_group α]
@@ -659,41 +602,5 @@ begin
 end
 
 end decidable_linear_ordered_add_comm_group
-
-section linear_ordered_field
-
-variables {α : Type u} [linear_ordered_field α]
-
-lemma image_mul_right_Icc' (a b : α) {c : α} (h : 0 < c) :
-  (λ x, x * c) '' Icc a b = Icc (a * c) (b * c) :=
-begin
-  ext x,
-  split,
-  { rintros ⟨x, hx, rfl⟩,
-    exact ⟨mul_le_mul_of_nonneg_right hx.1 (le_of_lt h),
-      mul_le_mul_of_nonneg_right hx.2 (le_of_lt h)⟩ },
-  { intro hx,
-    refine ⟨x / c, _, div_mul_cancel x (ne_of_gt h)⟩,
-    exact ⟨le_div_of_mul_le h hx.1, div_le_of_le_mul h (mul_comm b c ▸ hx.2)⟩ }
-end
-
-lemma image_mul_right_Icc {a b c : α} (hab : a ≤ b) (hc : 0 ≤ c) :
-  (λ x, x * c) '' Icc a b = Icc (a * c) (b * c) :=
-begin
-  cases eq_or_lt_of_le hc,
-  { subst c,
-    simp [(nonempty_Icc.2 hab).image_const] },
-  exact image_mul_right_Icc' a b ‹0 < c›
-end
-
-lemma image_mul_left_Icc' {a : α} (h : 0 < a) (b c : α) :
-  ((*) a) '' Icc b c = Icc (a * b) (a * c) :=
-by { convert image_mul_right_Icc' b c h using 1; simp only [mul_comm _ a] }
-
-lemma image_mul_left_Icc {a b c : α} (ha : 0 ≤ a) (hbc : b ≤ c) :
-  ((*) a) '' Icc b c = Icc (a * b) (a * c) :=
-by { convert image_mul_right_Icc hbc ha using 1; simp only [mul_comm _ a] }
-
-end linear_ordered_field
 
 end set

--- a/src/data/set/intervals/image_preimage.lean
+++ b/src/data/set/intervals/image_preimage.lean
@@ -1,0 +1,326 @@
+/-
+Copyright (c) 2020 Yury G. Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury G. Kudryashov, Patrick Massot
+-/
+import data.set.intervals.basic
+import data.equiv.mul_add
+
+/-!
+# (Pre)images of intervals
+
+In this file we prove a bunch of trivial lemmas like “if we add `a` to all points of `[b, c]`,
+then we get `[a + b, a + c]`”. For the functions `x ↦ x ± a`, `x ↦ a ± x`, and `x ↦ -x` we prove
+lemmas about preimages and images of all intervals. We also prove a few lemmas about images under
+`x ↦ a * x` and `x ↦ x * a`.
+
+-/
+
+universe u
+
+namespace set
+section ordered_add_comm_group
+
+variables {G : Type u} [ordered_add_comm_group G] (a b c : G)
+
+/-!
+### Preimages under `x ↦ a + x`
+-/
+
+@[simp] lemma preimage_const_add_Ici : (λ x, a + x) ⁻¹' (Ici b) = Ici (b - a) :=
+ext $ λ x, sub_le_iff_le_add'.symm
+
+@[simp] lemma preimage_const_add_Ioi : (λ x, a + x) ⁻¹' (Ioi b) = Ioi (b - a) :=
+ext $ λ x, sub_lt_iff_lt_add'.symm
+
+@[simp] lemma preimage_const_add_Iic : (λ x, a + x) ⁻¹' (Iic b) = Iic (b - a) :=
+ext $ λ x, le_sub_iff_add_le'.symm
+
+@[simp] lemma preimage_const_add_Iio : (λ x, a + x) ⁻¹' (Iio b) = Iio (b - a) :=
+ext $ λ x, lt_sub_iff_add_lt'.symm
+
+@[simp] lemma preimage_const_add_Icc : (λ x, a + x) ⁻¹' (Icc b c) = Icc (b - a) (c - a) :=
+by simp [← Ici_inter_Iic]
+
+@[simp] lemma preimage_const_add_Ico : (λ x, a + x) ⁻¹' (Ico b c) = Ico (b - a) (c - a) :=
+by simp [← Ici_inter_Iio]
+
+@[simp] lemma preimage_const_add_Ioc : (λ x, a + x) ⁻¹' (Ioc b c) = Ioc (b - a) (c - a) :=
+by simp [← Ioi_inter_Iic]
+
+@[simp] lemma preimage_const_add_Ioo : (λ x, a + x) ⁻¹' (Ioo b c) = Ioo (b - a) (c - a) :=
+by simp [← Ioi_inter_Iio]
+
+/-!
+### Preimages under `x ↦ x + a`
+-/
+
+@[simp] lemma preimage_add_const_Ici : (λ x, x + a) ⁻¹' (Ici b) = Ici (b - a) :=
+ext $ λ x, sub_le_iff_le_add.symm
+
+@[simp] lemma preimage_add_const_Ioi : (λ x, x + a) ⁻¹' (Ioi b) = Ioi (b - a) :=
+ext $ λ x, sub_lt_iff_lt_add.symm
+
+@[simp] lemma preimage_add_const_Iic : (λ x, x + a) ⁻¹' (Iic b) = Iic (b - a) :=
+ext $ λ x, le_sub_iff_add_le.symm
+
+@[simp] lemma preimage_add_const_Iio : (λ x, x + a) ⁻¹' (Iio b) = Iio (b - a) :=
+ext $ λ x, lt_sub_iff_add_lt.symm
+
+@[simp] lemma preimage_add_const_Icc : (λ x, x + a) ⁻¹' (Icc b c) = Icc (b - a) (c - a) :=
+by simp [← Ici_inter_Iic]
+
+@[simp] lemma preimage_add_const_Ico : (λ x, x + a) ⁻¹' (Ico b c) = Ico (b - a) (c - a) :=
+by simp [← Ici_inter_Iio]
+
+@[simp] lemma preimage_add_const_Ioc : (λ x, x + a) ⁻¹' (Ioc b c) = Ioc (b - a) (c - a) :=
+by simp [← Ioi_inter_Iic]
+
+@[simp] lemma preimage_add_const_Ioo : (λ x, x + a) ⁻¹' (Ioo b c) = Ioo (b - a) (c - a) :=
+by simp [← Ioi_inter_Iio]
+
+/-!
+### Preimages under `x ↦ -x`
+-/
+
+@[simp] lemma preimage_neg_Ici : has_neg.neg ⁻¹' (Ici a) = Iic (-a) := ext $ λ x, le_neg
+@[simp] lemma preimage_neg_Iic : has_neg.neg ⁻¹' (Iic a) = Ici (-a) := ext $ λ x, neg_le
+@[simp] lemma preimage_neg_Ioi : has_neg.neg ⁻¹' (Ioi a) = Iio (-a) := ext $ λ x, lt_neg
+@[simp] lemma preimage_neg_Iio : has_neg.neg ⁻¹' (Iio a) = Ioi (-a) := ext $ λ x, neg_lt
+
+@[simp] lemma preimage_neg_Icc : has_neg.neg ⁻¹' (Icc a b) = Icc (-b) (-a) :=
+by simp [← Ici_inter_Iic, inter_comm]
+
+@[simp] lemma preimage_neg_Ico : has_neg.neg ⁻¹' (Ico a b) = Ioc (-b) (-a) :=
+by simp [← Ici_inter_Iio, ← Ioi_inter_Iic, inter_comm]
+
+@[simp] lemma preimage_neg_Ioc : has_neg.neg ⁻¹' (Ioc a b) = Ico (-b) (-a) :=
+by simp [← Ioi_inter_Iic, ← Ici_inter_Iio, inter_comm]
+
+@[simp] lemma preimage_neg_Ioo : has_neg.neg ⁻¹' (Ioo a b) = Ioo (-b) (-a) :=
+by simp [← Ioi_inter_Iio, inter_comm]
+
+/-!
+### Preimages under `x ↦ x - a`
+-/
+
+@[simp] lemma preimage_sub_const_Ici : (λ x, x - a) ⁻¹' (Ici b) = Ici (b + a) :=
+by simp [sub_eq_add_neg]
+
+@[simp] lemma preimage_sub_const_Ioi : (λ x, x - a) ⁻¹' (Ioi b) = Ioi (b + a) :=
+by simp [sub_eq_add_neg]
+
+@[simp] lemma preimage_sub_const_Iic : (λ x, x - a) ⁻¹' (Iic b) = Iic (b + a) :=
+by simp [sub_eq_add_neg]
+
+@[simp] lemma preimage_sub_const_Iio : (λ x, x - a) ⁻¹' (Iio b) = Iio (b + a) :=
+by simp [sub_eq_add_neg]
+
+@[simp] lemma preimage_sub_const_Icc : (λ x, x - a) ⁻¹' (Icc b c) = Icc (b + a) (c + a) :=
+by simp [sub_eq_add_neg]
+
+@[simp] lemma preimage_sub_const_Ico : (λ x, x - a) ⁻¹' (Ico b c) = Ico (b + a) (c + a) :=
+by simp [sub_eq_add_neg]
+
+@[simp] lemma preimage_sub_const_Ioc : (λ x, x - a) ⁻¹' (Ioc b c) = Ioc (b + a) (c + a) :=
+by simp [sub_eq_add_neg]
+
+@[simp] lemma preimage_sub_const_Ioo : (λ x, x - a) ⁻¹' (Ioo b c) = Ioo (b + a) (c + a) :=
+by simp [sub_eq_add_neg]
+
+/-!
+### Preimages under `x ↦ a - x`
+-/
+
+@[simp] lemma preimage_const_sub_Ici : (λ x, a - x) ⁻¹' (Ici b) = Iic (a - b) :=
+ext $ λ x, le_sub
+
+@[simp] lemma preimage_const_sub_Iic : (λ x, a - x) ⁻¹' (Iic b) = Ici (a - b) :=
+ext $ λ x, sub_le
+
+@[simp] lemma preimage_const_sub_Ioi : (λ x, a - x) ⁻¹' (Ioi b) = Iio (a - b) :=
+ext $ λ x, lt_sub
+
+@[simp] lemma preimage_const_sub_Iio : (λ x, a - x) ⁻¹' (Iio b) = Ioi (a - b) :=
+ext $ λ x, sub_lt
+
+@[simp] lemma preimage_const_sub_Icc : (λ x, a - x) ⁻¹' (Icc b c) = Icc (a - c) (a - b) :=
+by simp [← Ici_inter_Iic, inter_comm]
+
+@[simp] lemma preimage_const_sub_Ico : (λ x, a - x) ⁻¹' (Ico b c) = Ioc (a - c) (a - b) :=
+by simp [← Ioi_inter_Iic, ← Ici_inter_Iio, inter_comm]
+
+@[simp] lemma preimage_const_sub_Ioc : (λ x, a - x) ⁻¹' (Ioc b c) = Ico (a - c) (a - b) :=
+by simp [← Ioi_inter_Iic, ← Ici_inter_Iio, inter_comm]
+
+@[simp] lemma preimage_const_sub_Ioo : (λ x, a - x) ⁻¹' (Ioo b c) = Ioo (a - c) (a - b) :=
+by simp [← Ioi_inter_Iio, inter_comm]
+
+/-!
+### Images under `x ↦ a + x`
+-/
+
+@[simp] lemma image_const_add_Ici : (λ x, a + x) '' Ici b = Ici (a + b) :=
+((equiv.add_left a).image_eq_preimage _).trans $ by simp [add_comm]
+
+@[simp] lemma image_const_add_Iic : (λ x, a + x) '' Iic b = Iic (a + b) :=
+((equiv.add_left a).image_eq_preimage _).trans $ by simp [add_comm]
+
+@[simp] lemma image_const_add_Iio : (λ x, a + x) '' Iio b = Iio (a + b) :=
+((equiv.add_left a).image_eq_preimage _).trans $ by simp [add_comm]
+
+@[simp] lemma image_const_add_Ioi : (λ x, a + x) '' Ioi b = Ioi (a + b) :=
+((equiv.add_left a).image_eq_preimage _).trans $ by simp [add_comm]
+
+@[simp] lemma image_const_add_Icc : (λ x, a + x) '' Icc b c = Icc (a + b) (a + c) :=
+((equiv.add_left a).image_eq_preimage _).trans $ by simp [add_comm]
+
+@[simp] lemma image_const_add_Ico : (λ x, a + x) '' Ico b c = Ico (a + b) (a + c) :=
+((equiv.add_left a).image_eq_preimage _).trans $ by simp [add_comm]
+
+@[simp] lemma image_const_add_Ioc : (λ x, a + x) '' Ioc b c = Ioc (a + b) (a + c) :=
+((equiv.add_left a).image_eq_preimage _).trans $ by simp [add_comm]
+
+@[simp] lemma image_const_add_Ioo : (λ x, a + x) '' Ioo b c = Ioo (a + b) (a + c) :=
+((equiv.add_left a).image_eq_preimage _).trans $ by simp [add_comm]
+
+/-!
+### Images under `x ↦ x + a`
+-/
+
+@[simp] lemma image_add_const_Ici : (λ x, x + a) '' Ici b = Ici (a + b) := by simp [add_comm _ a]
+@[simp] lemma image_add_const_Iic : (λ x, x + a) '' Iic b = Iic (a + b) := by simp [add_comm _ a]
+@[simp] lemma image_add_const_Iio : (λ x, x + a) '' Iio b = Iio (a + b) := by simp [add_comm _ a]
+@[simp] lemma image_add_const_Ioi : (λ x, x + a) '' Ioi b = Ioi (a + b) := by simp [add_comm _ a]
+
+@[simp] lemma image_add_const_Icc : (λ x, x + a) '' Icc b c = Icc (a + b) (a + c) :=
+by simp [add_comm _ a]
+
+@[simp] lemma image_add_const_Ico : (λ x, x + a) '' Ico b c = Ico (a + b) (a + c) :=
+by simp [add_comm _ a]
+
+@[simp] lemma image_add_const_Ioc : (λ x, x + a) '' Ioc b c = Ioc (a + b) (a + c) :=
+by simp [add_comm _ a]
+
+@[simp] lemma image_add_const_Ioo : (λ x, x + a) '' Ioo b c = Ioo (a + b) (a + c) :=
+by simp [add_comm _ a]
+
+/-!
+### Images under `x ↦ -x`
+-/
+
+@[simp] lemma image_neg_Ici : has_neg.neg '' (Ici a) = Iic (-a) :=
+((equiv.neg G).image_eq_preimage _).trans $ preimage_neg_Ici _
+
+@[simp] lemma image_neg_Iic : has_neg.neg '' (Iic a) = Ici (-a) :=
+((equiv.neg G).image_eq_preimage _).trans $ preimage_neg_Iic _
+
+@[simp] lemma image_neg_Ioi : has_neg.neg '' (Ioi a) = Iio (-a) :=
+((equiv.neg G).image_eq_preimage _).trans $ preimage_neg_Ioi _
+
+@[simp] lemma image_neg_Iio : has_neg.neg '' (Iio a) = Ioi (-a) :=
+((equiv.neg G).image_eq_preimage _).trans $ preimage_neg_Iio _
+
+@[simp] lemma image_neg_Icc : has_neg.neg '' (Icc a b) = Icc (-b) (-a) :=
+((equiv.neg G).image_eq_preimage _).trans $ preimage_neg_Icc _ _
+
+@[simp] lemma image_neg_Ico : has_neg.neg '' (Ico a b) = Ioc (-b) (-a) :=
+((equiv.neg G).image_eq_preimage _).trans $ preimage_neg_Ico _ _
+
+@[simp] lemma image_neg_Ioc : has_neg.neg '' (Ioc a b) = Ico (-b) (-a) :=
+((equiv.neg G).image_eq_preimage _).trans $ preimage_neg_Ioc _ _
+
+@[simp] lemma image_neg_Ioo : has_neg.neg '' (Ioo a b) = Ioo (-b) (-a) :=
+((equiv.neg G).image_eq_preimage _).trans $ preimage_neg_Ioo _ _
+
+/-!
+### Images under `x ↦ a - x`
+-/
+
+@[simp] lemma image_const_sub_Ici : (λ x, a - x) '' Ici b = Iic (a - b) :=
+by simp [sub_eq_add_neg, image_comp (λ x, a + x) (λ x, -x)]
+
+@[simp] lemma image_const_sub_Iic : (λ x, a - x) '' Iic b = Ici (a - b) :=
+by simp [sub_eq_add_neg, image_comp (λ x, a + x) (λ x, -x)]
+
+@[simp] lemma image_const_sub_Ioi : (λ x, a - x) '' Ioi b = Iio (a - b) :=
+by simp [sub_eq_add_neg, image_comp (λ x, a + x) (λ x, -x)]
+
+@[simp] lemma image_const_sub_Iio : (λ x, a - x) '' Iio b = Ioi (a - b) :=
+by simp [sub_eq_add_neg, image_comp (λ x, a + x) (λ x, -x)]
+
+@[simp] lemma image_const_sub_Icc : (λ x, a - x) '' Icc b c = Icc (a - c) (a - b) :=
+by simp [sub_eq_add_neg, image_comp (λ x, a + x) (λ x, -x)]
+
+@[simp] lemma image_const_sub_Ico : (λ x, a - x) '' Ico b c = Ioc (a - c) (a - b) :=
+by simp [sub_eq_add_neg, image_comp (λ x, a + x) (λ x, -x)]
+
+@[simp] lemma image_const_sub_Ioc : (λ x, a - x) '' Ioc b c = Ico (a - c) (a - b) :=
+by simp [sub_eq_add_neg, image_comp (λ x, a + x) (λ x, -x)]
+
+@[simp] lemma image_const_sub_Ioo : (λ x, a - x) '' Ioo b c = Ioo (a - c) (a - b) :=
+by simp [sub_eq_add_neg, image_comp (λ x, a + x) (λ x, -x)]
+
+/-!
+### Images under `x ↦ x - a`
+-/
+
+@[simp] lemma image_sub_const_Ici : (λ x, x - a) '' Ici b = Ici (b - a) := by simp [sub_eq_neg_add]
+@[simp] lemma image_sub_const_Iic : (λ x, x - a) '' Iic b = Iic (b - a) := by simp [sub_eq_neg_add]
+@[simp] lemma image_sub_const_Ioi : (λ x, x - a) '' Ioi b = Ioi (b - a) := by simp [sub_eq_neg_add]
+@[simp] lemma image_sub_const_Iio : (λ x, x - a) '' Iio b = Iio (b - a) := by simp [sub_eq_neg_add]
+
+@[simp] lemma image_sub_const_Icc : (λ x, x - a) '' Icc b c = Icc (b - a) (c - a) :=
+by simp [sub_eq_neg_add]
+
+@[simp] lemma image_sub_const_Ico : (λ x, x - a) '' Ico b c = Ico (b - a) (c - a) :=
+by simp [sub_eq_neg_add]
+
+@[simp] lemma image_sub_const_Ioc : (λ x, x - a) '' Ioc b c = Ioc (b - a) (c - a) :=
+by simp [sub_eq_neg_add]
+
+@[simp] lemma image_sub_const_Ioo : (λ x, x - a) '' Ioo b c = Ioo (b - a) (c - a) :=
+by simp [sub_eq_neg_add]
+
+end ordered_add_comm_group
+
+/-!
+### Multiplication in a field
+-/
+
+section linear_ordered_field
+
+variables {k : Type u} [linear_ordered_field k]
+
+lemma image_mul_right_Icc' (a b : k) {c : k} (h : 0 < c) :
+  (λ x, x * c) '' Icc a b = Icc (a * c) (b * c) :=
+begin
+  ext x,
+  split,
+  { rintros ⟨x, hx, rfl⟩,
+    exact ⟨mul_le_mul_of_nonneg_right hx.1 (le_of_lt h),
+      mul_le_mul_of_nonneg_right hx.2 (le_of_lt h)⟩ },
+  { intro hx,
+    refine ⟨x / c, _, div_mul_cancel x (ne_of_gt h)⟩,
+    exact ⟨le_div_of_mul_le h hx.1, div_le_of_le_mul h (mul_comm b c ▸ hx.2)⟩ }
+end
+
+lemma image_mul_right_Icc {a b c : k} (hab : a ≤ b) (hc : 0 ≤ c) :
+  (λ x, x * c) '' Icc a b = Icc (a * c) (b * c) :=
+begin
+  cases eq_or_lt_of_le hc,
+  { subst c,
+    simp [(nonempty_Icc.2 hab).image_const] },
+  exact image_mul_right_Icc' a b ‹0 < c›
+end
+
+lemma image_mul_left_Icc' {a : k} (h : 0 < a) (b c : k) :
+  ((*) a) '' Icc b c = Icc (a * b) (a * c) :=
+by { convert image_mul_right_Icc' b c h using 1; simp only [mul_comm _ a] }
+
+lemma image_mul_left_Icc {a b c : k} (ha : 0 ≤ a) (hbc : b ≤ c) :
+  ((*) a) '' Icc b c = Icc (a * b) (a * c) :=
+by { convert image_mul_right_Icc hbc ha using 1; simp only [mul_comm _ a] }
+
+end linear_ordered_field
+end set


### PR DESCRIPTION
* Create a file for lemmas like
  `(λ x, x + a) '' Icc b c = Icc (b + a) (b + c)`.
* Prove lemmas about images and preimages of all intervals under
  `x ↦ x ± a`, `x ↦ a ± x`, and `x ↦ -x`.
* Move lemmas about multiplication from `basic`.
---
<!-- put comments you want to keep out of the PR commit here -->
