### PR TITLE
[Merged by Bors] - fix(tactic/squeeze_simp): make `squeeze_simp [←...]` work

### DIFF
--- a/src/tactic/squeeze.lean
+++ b/src/tactic/squeeze.lean
@@ -25,18 +25,6 @@ meta def pos.move_left (p : pos) (n : ℕ) : pos :=
 
 namespace tactic
 
-/--
-  `erase_simp_args hs s` removes from `s` each name `n` such that `const n` is an element of `hs`
--/
-meta def erase_simp_args (hs : list simp_arg_type) (s : name_set) : tactic name_set :=
-do
-  (hs, _, _) ← decode_simp_arg_list_with_symm hs,
-  pure $ hs.foldr (λ (h : pexpr × bool) (s : name_set),
-    match h.1.get_app_fn h.1 with
-    | (expr.const n _) := s.erase n
-    | _ := s
-    end) s
-
 open list
 
 /-- parse structure instance of the shape `{ field1 := value1, .. , field2 := value2 }` -/
@@ -166,7 +154,6 @@ do v ← target >>= mk_meta_var,
    let vs := g.list_constant,
    vs ← vs.mfilter is_simp_lemma,
    vs ← vs.mmap strip_prefix,
-   vs ← erase_simp_args args vs,
    vs ← vs.to_list.mmap name.to_simp_args,
    with_local_goals' [v] (filter_simp_set tac args vs)
      >>= mk_suggestion,

--- a/src/tactic/squeeze.lean
+++ b/src/tactic/squeeze.lean
@@ -30,10 +30,9 @@ namespace tactic
 -/
 meta def erase_simp_args (hs : list simp_arg_type) (s : name_set) : tactic name_set :=
 do
-  -- TODO: when Lean 3.4 support is dropped, use `decode_simp_arg_list_with_symm` on the next line:
-  (hs, _, _) ← decode_simp_arg_list hs,
-  pure $ hs.foldr (λ (h : pexpr) (s : name_set),
-    match h.get_app_fn h with
+  (hs, _, _) ← decode_simp_arg_list_with_symm hs,
+  pure $ hs.foldr (λ (h : pexpr × bool) (s : name_set),
+    match h.1.get_app_fn h.1 with
     | (expr.const n _) := s.erase n
     | _ := s
     end) s

--- a/test/examples.lean
+++ b/test/examples.lean
@@ -93,7 +93,3 @@ example (n m k : ℕ) : {x ∈ finset.range n | x < m ∨ x < k } =
 by simp [finset.filter_or]
 
 end
-
--- Test that squeeze_simp succeeds when it closes the goal.
-example : 1 = 1 :=
-by { squeeze_simp }

--- a/test/squeeze.lean
+++ b/test/squeeze.lean
@@ -1,0 +1,10 @@
+import data.nat.basic
+import tactic.squeeze
+
+-- Test that squeeze_simp succeeds when it closes the goal.
+example : 1 = 1 :=
+by { squeeze_simp }
+
+-- Test that `squeeze_simp` succeeds when given arguments.
+example {a b : ℕ} (h : a + a = b) : b + 0 = 2 * a :=
+by { squeeze_simp [←h, two_mul] }


### PR DESCRIPTION
`squeeze_simp` parses the argument list using a function in core Lean, and when support for backwards arguments was added to `simp`, it used a new function to parse the additional structure. This PR fixes the TODO left in the code to switch `squeeze_simp` to the new function by deleting the code that needed it - it wasn't used anyway!

To add a test for the fix, I moved the single existing `squeeze_simp` test from the deprecated file `examples.lean` to a new file.
