### PR TITLE
[Merged by Bors] - chore(algebra/group_with_zero_power): review

### DIFF
--- a/src/algebra/commute.lean
+++ b/src/algebra/commute.lean
@@ -402,7 +402,7 @@ protected theorem mul_gpow {G : Type*} [group G] {a b : G} (hab : commute a b) :
   ∀ (n : ℤ), (a * b) ^ n = a ^ n * b ^ n
 | (n : ℕ) := hab.mul_pow n
 | -[1+n] :=
-    by { simp only [gpow_neg_succ, hab.mul_pow, mul_inv_rev],
+    by { simp only [gpow_neg_succ_of_nat, hab.mul_pow, mul_inv_rev],
          exact (hab.pow_pow n.succ n.succ).inv_inv.symm.eq }
 
 end commute

--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -133,7 +133,8 @@ begin
   rcases lt_trichotomy x 1 with H|rfl|H,
   { apply (fpow_strict_mono (one_lt_inv h₀ H)).injective,
     show x⁻¹ ^ m = x⁻¹ ^ n,
-    rw [← fpow_inv, ← fpow_mul, ← fpow_mul, mul_comm _ m, mul_comm _ n, fpow_mul, fpow_mul, h], },
+    rw [← fpow_neg_one, ← fpow_mul, ← fpow_mul, mul_comm _ m, mul_comm _ n, fpow_mul, fpow_mul,
+      h], },
   { contradiction },
   { exact (fpow_strict_mono H).injective h, },
 end

--- a/src/algebra/group_power.lean
+++ b/src/algebra/group_power.lean
@@ -236,8 +236,8 @@ infix ` •ℤ `:70 := gsmul
 theorem gpow_of_nat (a : G) (n : ℕ) : a ^ of_nat n = a ^ n := rfl
 theorem gsmul_of_nat (a : A) (n : ℕ) : of_nat n •ℤ a = n •ℕ a := rfl
 
-@[simp] theorem gpow_neg_succ (a : G) (n : ℕ) : a ^ -[1+n] = (a ^ n.succ)⁻¹ := rfl
-@[simp] theorem gsmul_neg_succ (a : A) (n : ℕ) : -[1+n] •ℤ a = - (n.succ •ℕ a) := rfl
+@[simp] theorem gpow_neg_succ_of_nat (a : G) (n : ℕ) : a ^ -[1+n] = (a ^ n.succ)⁻¹ := rfl
+@[simp] theorem gsmul_neg_succ_of_nat (a : A) (n : ℕ) : -[1+n] •ℤ a = - (n.succ •ℕ a) := rfl
 
 local attribute [ematch] le_of_lt
 open nat
@@ -340,6 +340,9 @@ by cases n; [exact f.map_pow _ _, exact (f.map_inv _).trans (congr_arg _ $ f.map
 
 theorem add_monoid_hom.map_gsmul (f : A →+ B) (a : A) (n : ℤ) : f (n •ℤ a) = n •ℤ f a :=
 f.to_multiplicative.map_gpow a n
+
+@[simp, norm_cast] lemma units.coe_gpow (u : units G) (n : ℤ) : ((u ^ n : units G) : G) = u ^ n :=
+(units.coe_hom G).map_gpow u n
 
 end group
 

--- a/src/algebra/group_with_zero_power.lean
+++ b/src/algebra/group_with_zero_power.lean
@@ -68,7 +68,7 @@ def fpow (a : G₀) : ℤ → G₀
 
 theorem fpow_of_nat (a : G₀) (n : ℕ) : a ^ of_nat n = a ^ n := rfl
 
-@[simp] theorem fpow_neg_succ (a : G₀) (n : ℕ) : a ^ -[1+n] = (a ^ n.succ)⁻¹ := rfl
+@[simp] theorem fpow_neg_succ_of_nat (a : G₀) (n : ℕ) : a ^ -[1+n] = (a ^ n.succ)⁻¹ := rfl
 
 local attribute [ematch] le_of_lt
 
@@ -95,34 +95,26 @@ theorem inv_fpow (a : G₀) : ∀n:ℤ, a⁻¹ ^ n = (a ^ n)⁻¹
 | (n : ℕ) := inv_pow' a n
 | -[1+ n] := congr_arg has_inv.inv $ inv_pow' a (n+1)
 
-private lemma fpow_add_aux (a : G₀) (h : a ≠ 0) (m n : nat) :
-  a ^ ((of_nat m) + -[1+n]) = a ^ of_nat m * a ^ -[1+n] :=
-or.elim (nat.lt_or_ge m (nat.succ n))
- (assume h1 : m < n.succ,
-  have h2 : m ≤ n, from nat.le_of_lt_succ h1,
-  suffices a ^ -[1+ n-m] = a ^ of_nat m * a ^ -[1+n],
-    by rwa [of_nat_add_neg_succ_of_nat_of_lt h1],
-  show (a ^ nat.succ (n - m))⁻¹ = a ^ of_nat m * a ^ -[1+n],
-  by rw [← nat.succ_sub h2, pow_sub' _ h (le_of_lt h1), mul_inv_rev', inv_inv']; refl)
- (assume : m ≥ n.succ,
-  suffices a ^ (of_nat (m - n.succ)) = (a ^ (of_nat m)) * (a ^ -[1+ n]),
-    by rw [of_nat_add_neg_succ_of_nat_of_ge]; assumption,
-  suffices a ^ (m - n.succ) = a ^ m * (a ^ n.succ)⁻¹, from this,
-  by rw pow_sub'; assumption)
+lemma fpow_add_one {a : G₀} (ha : a ≠ 0) : ∀ n : ℤ, a ^ (n + 1) = a ^ n * a
+| (of_nat n) := by simp [← int.coe_nat_succ, pow_succ']
+| -[1+0]     := by simp [int.neg_succ_of_nat_eq, ha]
+| -[1+(n+1)] := by rw [int.neg_succ_of_nat_eq, fpow_neg, neg_add, neg_add_cancel_right, fpow_neg,
+  ← int.coe_nat_succ, fpow_coe_nat, fpow_coe_nat, pow_succ _ (n + 1), mul_inv_rev', mul_assoc,
+  inv_mul_cancel' a ha, mul_one]
 
-theorem fpow_add {a : G₀} (h : a ≠ 0) : ∀ (i j : ℤ), a ^ (i + j) = a ^ i * a ^ j
-| (of_nat m) (of_nat n) := pow_add _ _ _
-| (of_nat m) -[1+n]     := fpow_add_aux _ h _ _
-| -[1+m]     (of_nat n) := by rw [add_comm, fpow_add_aux _ h,
-  fpow_neg_succ, fpow_of_nat, ← inv_pow', ← pow_inv_comm']
-| -[1+m]     -[1+n]     :=
-  suffices (a ^ (m + n.succ.succ))⁻¹ = (a ^ m.succ)⁻¹ * (a ^ n.succ)⁻¹, from this,
-  by rw [← nat.succ_add_eq_succ_add, add_comm, pow_add, mul_inv_rev']
+lemma fpow_sub_one {a : G₀} (ha : a ≠ 0) (n : ℤ) : a ^ (n - 1) = a ^ n * a⁻¹ :=
+calc a ^ (n - 1) = a ^ (n - 1) * a * a⁻¹ : by rw [mul_assoc, mul_inv_cancel' a ha, mul_one]
+             ... = a^n * a⁻¹             : by rw [← fpow_add_one ha, sub_add_cancel]
 
-theorem fpow_add_one (a : G₀) (h : a ≠ 0) (i : ℤ) : a ^ (i + 1) = a ^ i * a :=
-by rw [fpow_add h, fpow_one]
+lemma fpow_add {a : G₀} (ha : a ≠ 0) (m n : ℤ) : a ^ (m + n) = a ^ m * a ^ n :=
+begin
+  induction n using int.induction_on with n ihn n ihn,
+  case hz : { simp },
+  { simp only [← add_assoc, fpow_add_one ha, ihn, mul_assoc] },
+  { rw [fpow_sub_one ha, ← mul_assoc, ← ihn, ← fpow_sub_one ha, add_sub_assoc] }
+end
 
-theorem fpow_one_add (a : G₀) (h : a ≠ 0) (i : ℤ) : a ^ (1 + i) = a * a ^ i :=
+theorem fpow_one_add {a : G₀} (h : a ≠ 0) (i : ℤ) : a ^ (1 + i) = a * a ^ i :=
 by rw [fpow_add h, fpow_one]
 
 theorem fpow_mul_comm (a : G₀) (h : a ≠ 0) (i j : ℤ) : a ^ i * a ^ j = a ^ j * a ^ i :=
@@ -140,17 +132,10 @@ theorem fpow_mul (a : G₀) : ∀ m n : ℤ, a ^ (m * n) = (a ^ m) ^ n
 theorem fpow_mul' (a : G₀) (m n : ℤ) : a ^ (m * n) = (a ^ n) ^ m :=
 by rw [mul_comm, fpow_mul]
 
-@[simp] lemma unit_pow {a : G₀} (ha : a ≠ 0) :
-  ∀ n : ℕ, (((units.mk0 a ha) ^ n : units G₀) : G₀) = a ^ n
-| 0     := units.coe_one.symm
-| (k+1) := by { simp only [pow_succ, units.coe_mul, units.coe_mk0], rw unit_pow }
-
-lemma fpow_neg_succ_of_nat (a : G₀) (n : ℕ) : a ^ (-[1+ n]) = (a ^ (n + 1))⁻¹ := rfl
-
-@[simp] lemma unit_gpow {a : G₀} (h : a ≠ 0) :
-  ∀ (z : ℤ), (((units.mk0 a h) ^ z : units G₀) : G₀) = a ^ z
-| (of_nat k) := unit_pow _ _
-| -[1+k] := by rw [fpow_neg_succ_of_nat, gpow_neg_succ, units.inv_eq_inv, unit_pow]
+@[simp, norm_cast] lemma units.coe_gpow' (u : units G₀) :
+  ∀ (n : ℤ), ((u ^ n : units G₀) : G₀) = u ^ n
+| (n : ℕ) := u.coe_pow n
+| -[1+k] := by rw [gpow_neg_succ_of_nat, fpow_neg_succ_of_nat, units.inv_eq_inv, u.coe_pow]
 
 lemma fpow_ne_zero_of_ne_zero {a : G₀} (ha : a ≠ 0) : ∀ (z : ℤ), a ^ z ≠ 0
 | (of_nat n) := pow_ne_zero' _ ha

--- a/src/algebra/group_with_zero_power.lean
+++ b/src/algebra/group_with_zero_power.lean
@@ -140,9 +140,6 @@ theorem fpow_mul (a : G₀) : ∀ m n : ℤ, a ^ (m * n) = (a ^ m) ^ n
 theorem fpow_mul' (a : G₀) (m n : ℤ) : a ^ (m * n) = (a ^ n) ^ m :=
 by rw [mul_comm, fpow_mul]
 
-lemma fpow_inv (a : G₀) : a ^ (-1 : ℤ) = a⁻¹ :=
-show (a*1)⁻¹ = a⁻¹, by rw [mul_one]
-
 @[simp] lemma unit_pow {a : G₀} (ha : a ≠ 0) :
   ∀ n : ℕ, (((units.mk0 a ha) ^ n : units G₀) : G₀) = a ^ n
 | 0     := units.coe_one.symm

--- a/src/algebra/semiconj.lean
+++ b/src/algebra/semiconj.lean
@@ -109,7 +109,7 @@ units.ext h
 @[simp] lemma units_gpow_right {a : M} {x y : units M} (h : semiconj_by a x y) :
   ∀ m : ℤ, semiconj_by a (↑(x^m)) (↑(y^m))
 | (n : ℕ) := by simp only [gpow_coe_nat, units.coe_pow, h, pow_right]
-| -[1+n] := by simp only [gpow_neg_succ, units.coe_pow, units_inv_right, h, pow_right]
+| -[1+n] := by simp only [gpow_neg_succ_of_nat, units.coe_pow, units_inv_right, h, pow_right]
 
 /-- `a` semiconjugates `x` to `a * x * a⁻¹`. -/
 lemma units_conj_mk (a : units M) (x : M) : semiconj_by ↑a x (a * x * ↑a⁻¹) :=

--- a/src/group_theory/perm/cycles.lean
+++ b/src/group_theory/perm/cycles.lean
@@ -83,8 +83,8 @@ end
 @[simp] lemma cycle_of_gpow_apply_self [fintype α] (f : perm α) (x : α) :
   ∀ n : ℤ, (cycle_of f x ^ n) x = (f ^ n) x
 | (n : ℕ) := cycle_of_pow_apply_self f x n
-| -[1+ n] := by rw [gpow_neg_succ, ← inv_pow, cycle_of_inv,
-  gpow_neg_succ, ← inv_pow, cycle_of_pow_apply_self]
+| -[1+ n] := by rw [gpow_neg_succ_of_nat, ← inv_pow, cycle_of_inv,
+  gpow_neg_succ_of_nat, ← inv_pow, cycle_of_pow_apply_self]
 
 lemma cycle_of_apply_of_same_cycle [fintype α] {f : perm α} {x y : α} (h : same_cycle f x y) :
   cycle_of f x y = f y := dif_pos h

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -118,7 +118,7 @@ lemma pow_apply_eq_self_of_apply_eq_self {f : perm α} {x : α} (hfx : f x = x) 
 lemma gpow_apply_eq_self_of_apply_eq_self {f : perm α} {x : α} (hfx : f x = x) :
   ∀ n : ℤ, (f ^ n) x = x
 | (n : ℕ) := pow_apply_eq_self_of_apply_eq_self hfx n
-| -[1+ n] := by rw [gpow_neg_succ, inv_eq_iff_eq, pow_apply_eq_self_of_apply_eq_self hfx]
+| -[1+ n] := by rw [gpow_neg_succ_of_nat, inv_eq_iff_eq, pow_apply_eq_self_of_apply_eq_self hfx]
 
 lemma pow_apply_eq_of_apply_apply_eq_self {f : perm α} {x : α} (hffx : f (f x) = x) :
   ∀ n : ℕ, (f ^ n) x = x ∨ (f ^ n) x = f x
@@ -131,7 +131,7 @@ lemma gpow_apply_eq_of_apply_apply_eq_self {f : perm α} {x : α} (hffx : f (f x
   ∀ i : ℤ, (f ^ i) x = x ∨ (f ^ i) x = f x
 | (n : ℕ) := pow_apply_eq_of_apply_apply_eq_self hffx n
 | -[1+ n] :=
-  by rw [gpow_neg_succ, inv_eq_iff_eq, ← injective.eq_iff f.injective, ← mul_apply, ← pow_succ,
+  by rw [gpow_neg_succ_of_nat, inv_eq_iff_eq, ← injective.eq_iff f.injective, ← mul_apply, ← pow_succ,
     eq_comm, inv_eq_iff_eq, ← mul_apply, ← pow_succ', @eq_comm _ x, or.comm];
   exact pow_apply_eq_of_apply_apply_eq_self hffx _
 
@@ -631,7 +631,7 @@ lemma is_cycle_swap_mul_aux₂ : ∀ (n : ℤ) {b x : α} {f : perm α}
       simp [inv_eq_iff_eq, eq_inv_iff_eq] at *; cc,
   let ⟨i, hi⟩ := is_cycle_swap_mul_aux₁ n hb
     (show (f⁻¹ ^ n) (f⁻¹ x) = f⁻¹ b, by
-      rw [← gpow_coe_nat, ← h, ← mul_apply, ← mul_apply, ← mul_apply, gpow_neg_succ, ← inv_pow, pow_succ', mul_assoc,
+      rw [← gpow_coe_nat, ← h, ← mul_apply, ← mul_apply, ← mul_apply, gpow_neg_succ_of_nat, ← inv_pow, pow_succ', mul_assoc,
         mul_assoc, inv_mul_self, mul_one, gpow_coe_nat, ← pow_succ', ← pow_succ]) in
   have h : (swap x (f⁻¹ x) * f⁻¹) (f x) = f⁻¹ x, by rw [mul_apply, inv_apply_self, swap_apply_left],
   ⟨-i, by rw [← add_sub_cancel i 1, neg_sub, sub_eq_add_neg, gpow_add, gpow_one, gpow_neg, ← inv_gpow,


### PR DESCRIPTION
List of changes:
* Rename `gpow_neg_succ` to `gpow_neg_succ_of_nat` to match other names in `int` namespace.
* Add `units.coe_gpow`.
* Remove `fpow_neg_succ`, leave `fpow_neg_succ_of_nat`.
* Rewrite the proof of `fpow_add` in the same way I rewrote the proof of `gpow_add`.
* Make argument `a` implicit in some lemmas because they have an argument `ha : a ≠ 0`.
* Remove `fpow_inv`. This was a copy of `fpow_neg_one` with a misleading name.
* Remove `unit_pow` in favor of a more general `units.coe_pow`.
* Remove `unit_gpow`, add a more general `units.coe_gpow'` instead.

---
<!-- put comments you want to keep out of the PR commit here -->