### PR TITLE
[Merged by Bors] - feat(data/padics/padic_norm): New padic_val_nat convenience functions

### DIFF
--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -119,13 +119,13 @@ section padic_val_nat
 /--
 A convenience function for the case of `padic_val_rat` when both inputs are natural numbers.
 -/
-def padic_val_nat (p : nat) (n : nat) : ℕ :=
+def padic_val_nat (p : ℕ) (n : ℕ) : ℕ :=
 int.to_nat (padic_val_rat p n)
 
 /--
 `padic_val_nat` is defined as an `int.to_nat` cast; this lemma ensures that the cast is well-behaved.
 -/
-lemma zero_le_padic_val_rat_of_nat (p n : nat) : 0 ≤ padic_val_rat p n :=
+lemma zero_le_padic_val_rat_of_nat (p n : ℕ) : 0 ≤ padic_val_rat p n :=
 begin
   unfold padic_val_rat,
   split_ifs,
@@ -136,7 +136,7 @@ end
 /--
 `padic_val_rat` coincides with `padic_val_nat`.
 -/
-@[simp, norm_cast] lemma padic_val_rat_of_nat (p n : nat) : ↑(padic_val_nat p n) = padic_val_rat p n :=
+@[simp, norm_cast] lemma padic_val_rat_of_nat (p n : ℕ) : ↑(padic_val_nat p n) = padic_val_rat p n :=
 begin
   unfold padic_val_nat,
   rw int.to_nat_of_nonneg (zero_le_padic_val_rat_of_nat p n),

--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -112,14 +112,18 @@ lemma padic_val_rat_of_int (z : ℤ) (hp : p ≠ 1) (hz : z ≠ 0) :
     (finite_int_iff.2 ⟨hp, hz⟩) :=
 by rw [padic_val_rat, dif_pos]; simp *; refl
 
+end padic_val_rat
+
+section padic_val_nat
+
 /--
 A convenience function for the case of `padic_val_rat` when both inputs are natural numbers.
 -/
 def padic_val_nat (p : nat) (n : nat) : ℕ :=
-  int.to_nat (padic_val_rat p n)
+int.to_nat (padic_val_rat p n)
 
 /--
-`padic_val_rat` is defined as an `int.to_nat` cast; this lemma ensures that the cast is well-behaved.
+`padic_val_nat` is defined as an `int.to_nat` cast; this lemma ensures that the cast is well-behaved.
 -/
 lemma zero_le_padic_val_rat_of_nat (p n : nat) : 0 ≤ padic_val_rat p n :=
 begin
@@ -132,7 +136,7 @@ end
 /--
 `padic_val_rat` coincides with `padic_val_nat`.
 -/
-lemma padic_val_rat_of_nat (p n : nat) : padic_val_rat p n = ↑(padic_val_nat p n) :=
+@[simp, norm_cast] lemma padic_val_rat_of_nat (p n : nat) : ↑(padic_val_nat p n) = padic_val_rat p n :=
 begin
   unfold padic_val_nat,
   rw int.to_nat_of_nonneg (zero_le_padic_val_rat_of_nat p n),
@@ -146,11 +150,11 @@ lemma padic_val_nat_def {p : ℕ} [hp : fact p.prime] {n : ℕ} (hn : n ≠ 0) :
   (multiplicity p n).get (multiplicity.finite_nat_iff.2 ⟨nat.prime.ne_one hp, bot_lt_iff_ne_bot.mpr hn⟩) :=
 begin
   have n_nonzero : (n : ℚ) ≠ 0, by simpa only [cast_eq_zero, ne.def],
-  simpa [int.coe_nat_multiplicity p n, rat.coe_nat_denom n, padic_val_rat_of_nat p n]
+  simpa [int.coe_nat_multiplicity p n, rat.coe_nat_denom n, eq.symm (padic_val_rat_of_nat p n)]
     using padic_val_rat_def p n_nonzero,
 end
 
-end padic_val_rat
+end padic_val_nat
 
 section padic_val_rat
 open multiplicity

--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -121,7 +121,7 @@ def padic_val_nat (p : nat) (n : nat) : ℕ :=
 /--
 `padic_val_rat` is defined as an `int.to_nat` cast; this lemma ensures that the cast is well-behaved.
 -/
-lemma zero_le_padic_val_rat (p n : nat) : 0 ≤ padic_val_rat p n :=
+lemma zero_le_padic_val_rat_of_nat (p n : nat) : 0 ≤ padic_val_rat p n :=
 begin
   unfold padic_val_rat,
   split_ifs,
@@ -135,7 +135,7 @@ end
 lemma padic_val_rat_of_nat (p n : nat) : padic_val_rat p n = ↑(padic_val_nat p n) :=
 begin
   unfold padic_val_nat,
-  rw int.to_nat_of_nonneg (zero_le_padic_val_rat p n),
+  rw int.to_nat_of_nonneg (zero_le_padic_val_rat_of_nat p n),
 end
 
 /--

--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -112,7 +112,47 @@ lemma padic_val_rat_of_int (z : ℤ) (hp : p ≠ 1) (hz : z ≠ 0) :
     (finite_int_iff.2 ⟨hp, hz⟩) :=
 by rw [padic_val_rat, dif_pos]; simp *; refl
 
+/--
+A convenience function for the case of `padic_val_rat` when both inputs are natural numbers.
+-/
+def padic_val_nat (p : nat) (n : nat) : ℕ :=
+  int.to_nat (padic_val_rat p n)
+
+/--
+`padic_val_rat` is defined as an `int.to_nat` cast; this lemma ensures that the cast is well-behaved.
+-/
+lemma zero_le_padic_val_rat (p n : nat) : 0 ≤ padic_val_rat p n :=
+begin
+  unfold padic_val_rat,
+  split_ifs,
+  { simp, },
+  { trivial, },
+end
+
+/--
+`padic_val_rat` coincides with `padic_val_nat`.
+-/
+lemma padic_val_rat_of_nat (p n : nat) : padic_val_rat p n = ↑(padic_val_nat p n) :=
+begin
+  unfold padic_val_nat,
+  rw int.to_nat_of_nonneg (zero_le_padic_val_rat p n),
+end
+
+/--
+A simplification of `padic_val_nat` when one input is prime, by analogy with `padic_val_rat_def`.
+-/
+def padic_val_nat_def {p : ℕ} [hp : fact p.prime] {n : ℕ} (hn : n ≠ 0) :
+  padic_val_nat p n =
+  (multiplicity p n).get (multiplicity.finite_nat_iff.2 ⟨nat.prime.ne_one hp, bot_lt_iff_ne_bot.mpr hn⟩) :=
+begin
+  have n_nonzero : (n : ℚ) ≠ 0, by simpa only [cast_eq_zero, ne.def],
+  simpa [int.coe_nat_multiplicity p n, rat.coe_nat_denom n, padic_val_rat_of_nat p n]
+    using padic_val_rat_def p n_nonzero,
+end
+
 end padic_val_rat
+
+/-
 
 section padic_val_rat
 open multiplicity
@@ -483,3 +523,5 @@ end
 
 end padic_norm
 end padic_norm
+
+-/

--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -152,8 +152,6 @@ end
 
 end padic_val_rat
 
-/-
-
 section padic_val_rat
 open multiplicity
 variables (p : ℕ) [p_prime : fact p.prime]
@@ -523,5 +521,3 @@ end
 
 end padic_norm
 end padic_norm
-
--/

--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -150,7 +150,12 @@ lemma padic_val_nat_def {p : ℕ} [hp : fact p.prime] {n : ℕ} (hn : n ≠ 0) :
   (multiplicity p n).get (multiplicity.finite_nat_iff.2 ⟨nat.prime.ne_one hp, bot_lt_iff_ne_bot.mpr hn⟩) :=
 begin
   have n_nonzero : (n : ℚ) ≠ 0, by simpa only [cast_eq_zero, ne.def],
-  simpa [int.coe_nat_multiplicity p n, rat.coe_nat_denom n, eq.symm (padic_val_rat_of_nat p n)]
+  -- Infinite loop with @simp padic_val_rat_of_nat unless we restrict the available lemmas here,
+  -- hence the very long list
+  simpa only
+    [ int.coe_nat_multiplicity p n, rat.coe_nat_denom n, (padic_val_rat_of_nat p n).symm,
+      int.coe_nat_zero, int.coe_nat_inj', sub_zero, get_one_right, int.coe_nat_succ, zero_add,
+      rat.coe_nat_num ]
     using padic_val_rat_def p n_nonzero,
 end
 

--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -141,7 +141,7 @@ end
 /--
 A simplification of `padic_val_nat` when one input is prime, by analogy with `padic_val_rat_def`.
 -/
-def padic_val_nat_def {p : ℕ} [hp : fact p.prime] {n : ℕ} (hn : n ≠ 0) :
+lemma padic_val_nat_def {p : ℕ} [hp : fact p.prime] {n : ℕ} (hn : n ≠ 0) :
   padic_val_nat p n =
   (multiplicity p n).get (multiplicity.finite_nat_iff.2 ⟨nat.prime.ne_one hp, bot_lt_iff_ne_bot.mpr hn⟩) :=
 begin


### PR DESCRIPTION
Convenience functions to allow us to deal either with the p-adic valuation or with multiplicity in the naturals, depending on what is locally convenient.

---

Discussed in https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Transforming.20the.20type.20of.20a.20function/near/199250256