### PR TITLE
[Merged by Bors] - chore(*): add docs and nolints

### DIFF
--- a/src/algebra/archimedean.lean
+++ b/src/algebra/archimedean.lean
@@ -10,6 +10,8 @@ import data.rat
 
 variables {α : Type*}
 
+/-- An ordered additive commutative monoid is called `archimedean` if for any two elements `x`, `y`
+such that `0 < y` there exists a natural number `n` such that `x ≤ n •ℕ y`. -/
 class archimedean (α) [ordered_add_comm_monoid α] : Prop :=
 (arch : ∀ (x : α) {y}, 0 < y → ∃ n : ℕ, x ≤ n •ℕ y)
 
@@ -133,6 +135,8 @@ instance : archimedean ℤ :=
 by simpa only [nsmul_eq_mul, int.nat_cast_eq_coe_nat, zero_add, mul_one] using mul_le_mul_of_nonneg_left
     (int.add_one_le_iff.2 m0) (int.coe_zero_le n.to_nat)⟩⟩
 
+/-- A linear ordered archimedean ring is a floor ring. This is not an `instance` because in some
+cases we have a computable `floor` function. -/
 noncomputable def archimedean.floor_ring (α)
   [linear_ordered_ring α] [archimedean α] : floor_ring α :=
 { floor := λ x, classical.some (exists_floor x),

--- a/src/algebra/category/Group/basic.lean
+++ b/src/algebra/category/Group/basic.lean
@@ -29,13 +29,19 @@ open category_theory
 @[to_additive AddGroup]
 def Group : Type (u+1) := bundled group
 
+/-- The category of additive groups and group morphisms -/
+add_decl_doc AddGroup
+
 namespace Group
 
 @[to_additive]
 instance : bundled_hom.parent_projection group.to_monoid := ⟨⟩
 
-/-- Construct a bundled Group from the underlying type and typeclass. -/
+/-- Construct a bundled `Group` from the underlying type and typeclass. -/
 @[to_additive] def of (X : Type u) [group X] : Group := bundled.of X
+
+/-- Construct a bundled `AddGroup` from the underlying type and typeclass. -/
+add_decl_doc AddGroup.of
 
 local attribute [reducible] Group
 
@@ -76,10 +82,12 @@ instance has_forget_to_Mon : has_forget₂ Group Mon := bundled_hom.forget₂ _ 
 
 end Group
 
-
 /-- The category of commutative groups and group morphisms. -/
 @[to_additive AddCommGroup]
 def CommGroup : Type (u+1) := bundled comm_group
+
+/-- The category of additive commutative groups and group morphisms. -/
+add_decl_doc AddCommGroup
 
 /-- `Ab` is an abbreviation for `AddCommGroup`, for the sake of mathematicians' sanity. -/
 abbreviation Ab := AddCommGroup
@@ -148,9 +156,7 @@ namespace AddCommGroup
 -- TODO allow other universe levels
 -- this will require writing a `ulift_instances.lean` file
 def as_hom {G : AddCommGroup.{0}} (g : G) : (AddCommGroup.of ℤ) ⟶ G :=
-{ to_fun := λ i : ℤ, i • g,
-  map_zero' := rfl,
-  map_add' := λ a b, gpow_add g a b }
+gmultiples_hom G g
 
 @[simp]
 lemma as_hom_apply {G : AddCommGroup.{0}} (g : G) (i : ℤ) : (as_hom g) i = i • g := rfl
@@ -161,12 +167,7 @@ lemma as_hom_injective {G : AddCommGroup.{0}} : function.injective (@as_hom G) :
 @[ext]
 lemma int_hom_ext
   {G : AddCommGroup.{0}} (f g : (AddCommGroup.of ℤ) ⟶ G) (w : f (1 : ℤ) = g (1 : ℤ)) : f = g :=
-begin
-  ext,
-  change ℤ at x,
-  rw ←gsmul_int_one x,
-  rw [add_monoid_hom.map_gsmul, add_monoid_hom.map_gsmul, w],
-end
+add_monoid_hom.ext_int w
 
 -- TODO: this argument should be generalised to the situation where
 -- the forgetful functor is representable.
@@ -176,8 +177,7 @@ begin
   have t0 : as_hom g₁ ≫ f = as_hom g₂ ≫ f :=
   begin
     ext,
-    dsimp [as_hom],
-    simpa using h,
+    simpa [as_hom_apply] using h,
   end,
   have t1 : as_hom g₁ = as_hom g₂ := (cancel_mono _).1 t0,
   apply as_hom_injective t1,
@@ -188,21 +188,26 @@ end AddCommGroup
 variables {X Y : Type u}
 
 /-- Build an isomorphism in the category `Group` from a `mul_equiv` between `group`s. -/
-@[to_additive add_equiv.to_AddGroup_iso "Build an isomorphism in the category `AddGroup` from
-an `add_equiv` between `add_group`s."]
+@[to_additive add_equiv.to_AddGroup_iso]
 def mul_equiv.to_Group_iso [group X] [group Y] (e : X ≃* Y) : Group.of X ≅ Group.of Y :=
 { hom := e.to_monoid_hom,
   inv := e.symm.to_monoid_hom }
 
+/-- Build an isomorphism in the category `AddGroup` from an `add_equiv` between `add_group`s. -/
+add_decl_doc add_equiv.to_AddGroup_iso
+
 attribute [simps] mul_equiv.to_Group_iso add_equiv.to_AddGroup_iso
 
 /-- Build an isomorphism in the category `CommGroup` from a `mul_equiv` between `comm_group`s. -/
-@[to_additive add_equiv.to_AddCommGroup_iso "Build an isomorphism in the category `AddCommGroup`
-from a `add_equiv` between `add_comm_group`s."]
+@[to_additive add_equiv.to_AddCommGroup_iso]
 def mul_equiv.to_CommGroup_iso [comm_group X] [comm_group Y] (e : X ≃* Y) :
   CommGroup.of X ≅ CommGroup.of Y :=
 { hom := e.to_monoid_hom,
   inv := e.symm.to_monoid_hom }
+
+/-- Build an isomorphism in the category `AddCommGroup` from a `add_equiv` between
+`add_comm_group`s. -/
+add_decl_doc add_equiv.to_AddCommGroup_iso
 
 attribute [simps] mul_equiv.to_CommGroup_iso add_equiv.to_AddCommGroup_iso
 

--- a/src/algebra/category/Mon/basic.lean
+++ b/src/algebra/category/Mon/basic.lean
@@ -52,11 +52,17 @@ open category_theory
 @[to_additive AddMon]
 def Mon : Type (u+1) := bundled monoid
 
+/-- The category of additive monoids and monoid morphisms. -/
+add_decl_doc AddMon
+
 namespace Mon
 
-/-- Construct a bundled Mon from the underlying type and typeclass. -/
+/-- Construct a bundled `Mon` from the underlying type and typeclass. -/
 @[to_additive]
 def of (M : Type u) [monoid M] : Mon := bundled.of M
+
+/-- Construct a bundled Mon from the underlying type and typeclass. -/
+add_decl_doc AddMon.of
 
 @[to_additive]
 instance : inhabited Mon :=
@@ -88,14 +94,20 @@ end Mon
 @[to_additive AddCommMon]
 def CommMon : Type (u+1) := bundled comm_monoid
 
+/-- The category of additive commutative monoids and monoid morphisms. -/
+add_decl_doc AddCommMon
+
 namespace CommMon
 
 @[to_additive]
 instance : bundled_hom.parent_projection comm_monoid.to_monoid := ⟨⟩
 
-/-- Construct a bundled CommMon from the underlying type and typeclass. -/
+/-- Construct a bundled `CommMon` from the underlying type and typeclass. -/
 @[to_additive]
 def of (M : Type u) [comm_monoid M] : CommMon := bundled.of M
+
+/-- Construct a bundled `AddCommMon` from the underlying type and typeclass. -/
+add_decl_doc AddCommMon.of
 
 @[to_additive]
 instance : inhabited CommMon :=

--- a/src/algebra/field.lean
+++ b/src/algebra/field.lean
@@ -26,11 +26,8 @@ variables [division_ring α] {a b : α}
 instance division_ring.to_nonzero : nonzero α :=
 ⟨division_ring.zero_ne_one⟩
 
-protected definition algebra.div (a b : α) : α :=
-a * b⁻¹
-
 instance division_ring_has_div : has_div α :=
-⟨algebra.div⟩
+⟨λ a b, a * b⁻¹⟩
 
 lemma division_def (a b : α) : a / b = a * b⁻¹ :=
 rfl

--- a/src/algebra/group/conj.lean
+++ b/src/algebra/group/conj.lean
@@ -14,6 +14,7 @@ variables {α : Type u} {β : Type v}
 
 variables [group α] [group β]
 
+/-- We say that `a` is conjugate to `b` if for some `c` we have `c * a * c⁻¹ = b`. -/
 def is_conj (a b : α) := ∃ c : α, c * a * c⁻¹ = b
 
 @[refl] lemma is_conj_refl (a : α) : is_conj a a :=

--- a/src/algebra/group/defs.lean
+++ b/src/algebra/group/defs.lean
@@ -48,8 +48,10 @@ universe u
    to the additive one.
 -/
 
+/-- A semigroup is a type with an associative `(*)`. -/
 @[protect_proj, ancestor has_mul] class semigroup (G : Type u) extends has_mul G :=
 (mul_assoc : ∀ a b c : G, a * b * c = a * (b * c))
+/-- An additive semigroup is a type with an associative `(+)`. -/
 @[protect_proj, ancestor has_add] class add_semigroup (G : Type u) extends has_add G :=
 (add_assoc : ∀ a b c : G, a + b + c = a + (b + c))
 attribute [to_additive add_semigroup] semigroup
@@ -69,9 +71,12 @@ instance semigroup.to_is_associative : is_associative G (*) :=
 
 end semigroup
 
+/-- A commutative semigroup is a type with an associative commutative `(*)`. -/
 @[protect_proj, ancestor semigroup]
 class comm_semigroup (G : Type u) extends semigroup G :=
 (mul_comm : ∀ a b : G, a * b = b * a)
+
+/-- A commutative additive semigroup is a type with an associative commutative `(+)`. -/
 @[protect_proj, ancestor add_semigroup]
 class add_comm_semigroup (G : Type u) extends add_semigroup G :=
 (add_comm : ∀ a b : G, a + b = b + a)
@@ -91,9 +96,12 @@ instance comm_semigroup.to_is_commutative : is_commutative G (*) :=
 
 end comm_semigroup
 
+/-- A `left_cancel_semigroup` is a semigroup such that `a * b = a * c` implies `b = c`. -/
 @[protect_proj, ancestor semigroup]
 class left_cancel_semigroup (G : Type u) extends semigroup G :=
 (mul_left_cancel : ∀ a b c : G, a * b = a * c → b = c)
+/-- An `add_left_cancel_semigroup` is an additive semigroup such that
+`a + b = a + c` implies `b = c`. -/
 @[protect_proj, ancestor add_semigroup]
 class add_left_cancel_semigroup (G : Type u) extends add_semigroup G :=
 (add_left_cancel : ∀ a b c : G, a + b = a + c → b = c)
@@ -120,9 +128,13 @@ theorem mul_right_inj (a : G) {b c : G} : a * b = a * c ↔ b = c :=
 
 end left_cancel_semigroup
 
+/-- A `right_cancel_semigroup` is a semigroup such that `a * b = c * b` implies `a = c`. -/
 @[protect_proj, ancestor semigroup]
 class right_cancel_semigroup (G : Type u) extends semigroup G :=
 (mul_right_cancel : ∀ a b c : G, a * b = c * b → a = c)
+
+/-- An `add_right_cancel_semigroup` is an additive semigroup such that
+`a + b = c + b` implies `a = c`. -/
 @[protect_proj, ancestor add_semigroup]
 class add_right_cancel_semigroup (G : Type u) extends add_semigroup G :=
 (add_right_cancel : ∀ a b c : G, a + b = c + b → a = c)
@@ -149,9 +161,11 @@ theorem mul_left_inj (a : G) {b c : G} : b * a = c * a ↔ b = c :=
 
 end right_cancel_semigroup
 
+/-- A `monoid` is a `semigroup` with an element `1` such that `1 * a = a * 1 = a`. -/
 @[ancestor semigroup has_one]
 class monoid (M : Type u) extends semigroup M, has_one M :=
 (one_mul : ∀ a : M, 1 * a = a) (mul_one : ∀ a : M, a * 1 = a)
+/-- An `add_monoid` is an `add_semigroup` with an element `0` such that `0 + a = a + 0 = a`. -/
 @[ancestor add_semigroup has_zero]
 class add_monoid (M : Type u) extends add_semigroup M, has_zero M :=
 (zero_add : ∀ a : M, 0 + a = a) (add_zero : ∀ a : M, a + 0 = a)
@@ -184,8 +198,11 @@ by rw [←one_mul c, ←hba, mul_assoc, hac, mul_one b]
 
 end monoid
 
+/-- A commutative monoid is a monoid with commutative `(*)`. -/
 @[protect_proj, ancestor monoid comm_semigroup]
 class comm_monoid (M : Type u) extends monoid M, comm_semigroup M
+
+/-- An additive commutative monoid is an additive monoid with commutative `(+)`. -/
 @[protect_proj, ancestor add_monoid add_comm_semigroup]
 class add_comm_monoid (M : Type u) extends add_monoid M, add_comm_semigroup M
 attribute [to_additive add_comm_monoid] comm_monoid
@@ -198,9 +215,11 @@ class add_left_cancel_monoid (M : Type u) extends add_left_cancel_semigroup M, a
 -- TODO: I found 1 (one) lemma assuming `[add_left_cancel_monoid]`.
 -- Should we port more lemmas to this typeclass? Should we add a multiplicative version?
 
+/-- A `group` is a `monoid` with an operation `⁻¹` satisfying `a⁻¹ * a = 1`. -/
 @[protect_proj, ancestor monoid has_inv]
 class group (α : Type u) extends monoid α, has_inv α :=
 (mul_left_inv : ∀ a : α, a⁻¹ * a = 1)
+/-- An `add_group` is an `add_monoid` with an unary `-` satisfying `-a + a = 0`. -/
 @[protect_proj, ancestor add_monoid has_neg]
 class add_group (α : Type u) extends add_monoid α, has_neg α :=
 (add_left_neg : ∀ a : α, -a + a = 0)
@@ -268,8 +287,10 @@ instance add_group.to_add_left_cancel_monoid : add_left_cancel_monoid G :=
 
 end add_group
 
+/-- A commutative group is a group with commutative `(*)`. -/
 @[protect_proj, ancestor group comm_monoid]
 class comm_group (G : Type u) extends group G, comm_monoid G
+/-- An additive commutative group is an additive group with commutative `(+)`. -/
 @[protect_proj, ancestor add_group add_comm_monoid]
 class add_comm_group (G : Type u) extends add_group G, add_comm_monoid G
 attribute [to_additive add_comm_group] comm_group

--- a/src/algebra/group/defs.lean
+++ b/src/algebra/group/defs.lean
@@ -219,7 +219,7 @@ class add_left_cancel_monoid (M : Type u) extends add_left_cancel_semigroup M, a
 @[protect_proj, ancestor monoid has_inv]
 class group (α : Type u) extends monoid α, has_inv α :=
 (mul_left_inv : ∀ a : α, a⁻¹ * a = 1)
-/-- An `add_group` is an `add_monoid` with an unary `-` satisfying `-a + a = 0`. -/
+/-- An `add_group` is an `add_monoid` with a unary `-` satisfying `-a + a = 0`. -/
 @[protect_proj, ancestor add_monoid has_neg]
 class add_group (α : Type u) extends add_monoid α, has_neg α :=
 (add_left_neg : ∀ a : α, -a + a = 0)

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -96,13 +96,19 @@ attribute [ext] _root_.add_monoid_hom.ext
 lemma ext_iff {f g : M →* N} : f = g ↔ ∀ x, f x = g x :=
 ⟨λ h x, h ▸ rfl, λ h, ext h⟩
 
-/-- If f is a monoid homomorphism then f 1 = 1. -/
+/-- If `f` is a monoid homomorphism then `f 1 = 1`. -/
 @[simp, to_additive]
 lemma map_one (f : M →* N) : f 1 = 1 := f.map_one'
 
-/-- If f is a monoid homomorphism then f (a * b) = f a * f b. -/
+/-- If `f` is an additive monoid homomorphism then `f 0 = 0`. -/
+add_decl_doc add_monoid_hom.map_zero
+
+/-- If `f` is a monoid homomorphism then `f (a * b) = f a * f b`. -/
 @[simp, to_additive]
 lemma map_mul (f : M →* N) (a b : M) : f (a * b) = f a * f b := f.map_mul' a b
+
+/-- If `f` is an additive monoid homomorphism then `f (a + b) = f a + f b`. -/
+add_decl_doc add_monoid_hom.map_add
 
 @[to_additive]
 lemma map_mul_eq_one (f : M →* N) {a b : M} (h : a * b = 1) : f a * f b = 1 :=
@@ -134,17 +140,23 @@ def id (M : Type*) [monoid M] : M →* M :=
   map_one' := rfl,
   map_mul' := λ _ _, rfl }
 
+/-- The identity map from an additive monoid to itself. -/
+add_decl_doc add_monoid_hom.id
+
 @[simp, to_additive] lemma id_apply {M : Type*} [monoid M] (x : M) :
   id M x = x := rfl
 
 include mM mN mP
 
-/-- Composition of monoid morphisms is a monoid morphism. -/
+/-- Composition of monoid morphisms as a monoid morphism. -/
 @[to_additive]
 def comp (hnp : N →* P) (hmn : M →* N) : M →* P :=
 { to_fun := hnp ∘ hmn,
   map_one' := by simp,
   map_mul' := by simp }
+
+/-- Composition of additive monoid morphisms as an additive monoid morphism. -/
+add_decl_doc add_monoid_hom.comp
 
 @[simp, to_additive] lemma comp_apply (g : N →* P) (f : M →* N) (x : M) :
   g.comp f x = g (f x) := rfl
@@ -170,14 +182,12 @@ omit mP
 
 variables [mM] [mN]
 
+/-- `1` is the monoid homomorphism sending all elements to `1`. -/
 @[to_additive]
-protected def one : M →* N :=
-{ to_fun := λ _, 1,
-  map_one' := rfl,
-  map_mul' := λ _ _, (one_mul 1).symm }
+instance : has_one (M →* N) := ⟨⟨λ _, 1, rfl, λ _ _, (one_mul 1).symm⟩⟩
 
-@[to_additive]
-instance : has_one (M →* N) := ⟨monoid_hom.one⟩
+/-- `0` is the additive monoid homomorphism sending all elements to `0`. -/
+add_decl_doc add_monoid_hom.has_zero
 
 @[simp, to_additive] lemma one_apply (x : M) : (1 : M →* N) x = 1 := rfl
 
@@ -186,16 +196,19 @@ instance : inhabited (M →* N) := ⟨1⟩
 
 omit mM mN
 
-/-- The product of two monoid morphisms is a monoid morphism if the target is commutative. -/
+/-- Given two monoid morphisms `f`, `g` to a commutative monoid, `f * g` is the monoid morphism
+sending `x` to `f x * g x`. -/
 @[to_additive]
-protected def mul {M N} {mM : monoid M} [comm_monoid N] (f g : M →* N) : M →* N :=
-{ to_fun := λ m, f m * g m,
-  map_one' := show f 1 * g 1 = 1, by simp,
-  map_mul' := begin intros, show f (x * y) * g (x * y) = f x * g x * (f y * g y),
-    rw [f.map_mul, g.map_mul, ←mul_assoc, ←mul_assoc, mul_right_comm (f x)], end }
+instance {M N} {mM : monoid M} [comm_monoid N] : has_mul (M →* N) :=
+⟨λ f g,
+  { to_fun := λ m, f m * g m,
+    map_one' := show f 1 * g 1 = 1, by simp,
+    map_mul' := begin intros, show f (x * y) * g (x * y) = f x * g x * (f y * g y),
+      rw [f.map_mul, g.map_mul, ←mul_assoc, ←mul_assoc, mul_right_comm (f x)], end }⟩
 
-@[to_additive]
-instance {M N} {mM : monoid M} [comm_monoid N] : has_mul (M →* N) := ⟨monoid_hom.mul⟩
+/-- Given two additive monoid morphisms `f`, `g` to an additive commutative monoid, `f + g` is the
+additive monoid morphism sending `x` to `f x + g x`. -/
+add_decl_doc add_monoid_hom.has_add
 
 @[simp, to_additive] lemma mul_apply {M N} {mM : monoid M} {mN : comm_monoid N}
   (f g : M →* N) (x : M) :
@@ -259,31 +272,38 @@ def mk' (f : M → G) (map_mul : ∀ a b : M, f (a * b) = f a * f b) : M →* G 
   map_mul' := map_mul,
   map_one' := mul_self_iff_eq_one.1 $ by rw [←map_mul, mul_one] }
 
+/-- Makes an additive group homomomorphism from a proof that the map preserves multiplication. -/
+add_decl_doc add_monoid_hom.mk'
+
 @[simp, to_additive]
 lemma coe_mk' {f : M → G} (map_mul : ∀ a b : M, f (a * b) = f a * f b) :
   ⇑(mk' f map_mul) = f := rfl
 
 omit mM
 
-/-- The inverse of a monoid homomorphism is a monoid homomorphism if the target is
-    a commutative group.-/
+/-- If `f` is a monoid homomorphism to a commutative group, then `f⁻¹` is the homomorphism sending
+`x` to `(f x)⁻¹`. -/
 @[to_additive]
-protected def inv {M G} {mM : monoid M} [comm_group G] (f : M →* G) : M →* G :=
-mk' (λ g, (f g)⁻¹) $ λ a b, by rw [←mul_inv, f.map_mul]
+instance {M G} [monoid M] [comm_group G] : has_inv (M →* G) :=
+⟨λ f, mk' (λ g, (f g)⁻¹) $ λ a b, by rw [←mul_inv, f.map_mul]⟩
 
-@[to_additive]
-instance {M G} [monoid M] [comm_group G] : has_inv (M →* G) := ⟨monoid_hom.inv⟩
+/-- If `f` is an additive monoid homomorphism to an additive commutative group, then `-f` is the
+homomorphism sending `x` to `-(f x)`. -/
+add_decl_doc add_monoid_hom.has_neg
 
 @[simp, to_additive] lemma inv_apply {M G} {mM : monoid M} {gG : comm_group G}
   (f : M →* G) (x : M) :
   f⁻¹ x = (f x)⁻¹ := rfl
 
-/-- (M →* G) is a comm_group if G is a comm_group -/
+/-- If `G` is a commutative group, then `M →* G` a commutative group too. -/
 @[to_additive add_comm_group]
 instance {M G} [monoid M] [comm_group G] : comm_group (M →* G) :=
 { inv := has_inv.inv,
   mul_left_inv := by intros; ext; apply mul_left_inv,
   ..monoid_hom.comm_monoid }
+
+/-- If `G` is an additive commutative group, then `M →+ G` an additive commutative group too. -/
+add_decl_doc add_monoid_hom.add_comm_group
 
 end monoid_hom
 

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -202,6 +202,7 @@ protected theorem tendsto_nhds {f : filter α} {u : α → ennreal} {a : ennreal
   tendsto u f (𝓝 a) ↔ ∀ ε > 0, ∀ᶠ x in f, (u x) ∈ Icc (a - ε) (a + ε) :=
 by simp only [nhds_of_ne_top ha, tendsto_infi, tendsto_principal, mem_Icc]
 
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 protected lemma tendsto_at_top [nonempty β] [semilattice_sup β] {f : β → ennreal} {a : ennreal}
   (ha : a ≠ ⊤) : tendsto f at_top (𝓝 a) ↔ ∀ε>0, ∃N, ∀n≥N, (f n) ∈ Icc (a - ε) (a + ε) :=
 by simp only [ennreal.tendsto_nhds ha, mem_at_top_sets, mem_set_of_eq, filter.eventually]
@@ -626,7 +627,7 @@ lemma has_sum_iff_tendsto_nat_of_nonneg {f : ℕ → ℝ} (hf : ∀i, 0 ≤ f i)
   end⟩
 
 lemma infi_real_pos_eq_infi_nnreal_pos {α : Type*} [complete_lattice α] {f : ℝ → α} :
-  (⨅(n:ℝ) (h : n > 0), f n) = (⨅(n:nnreal) (h : n > 0), f n) :=
+  (⨅(n:ℝ) (h : 0 < n), f n) = (⨅(n:nnreal) (h : 0 < n), f n) :=
 le_antisymm
   (le_infi $ assume n, le_infi $ assume hn, infi_le_of_le n $ infi_le _ (nnreal.coe_pos.2 hn))
   (le_infi $ assume r, le_infi $ assume hr, infi_le_of_le ⟨r, le_of_lt hr⟩ $ infi_le _ hr)

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -864,6 +864,7 @@ metric.cauchy_seq_iff.2 $ λ ε ε0,
                     ... < ε : (hN _ (le_refl N))
 
 /-- A Cauchy sequence on the natural numbers is bounded. -/
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 theorem cauchy_seq_bdd {u : ℕ → α} (hu : cauchy_seq u) :
   ∃ R > 0, ∀ m n, dist (u m) (u n) < R :=
 begin
@@ -1077,6 +1078,7 @@ theorem mem_closure_iff {α : Type u} [metric_space α] {s : set α} {a : α} :
 (mem_closure_iff_nhds_basis nhds_basis_ball).trans $
   by simp only [mem_ball, dist_comm]
 
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 lemma mem_closure_range_iff {α : Type u} [metric_space α] {e : β → α} {a : α} :
   a ∈ closure (range e) ↔ ∀ε>0, ∃ k : β, dist a (e k) < ε :=
 by simp only [mem_closure_iff, exists_range_iff]
@@ -1086,6 +1088,7 @@ lemma mem_closure_range_iff_nat {α : Type u} [metric_space α] {e : β → α} 
 (mem_closure_iff_nhds_basis nhds_basis_ball_inv_nat_succ).trans $
   by simp only [mem_ball, dist_comm, exists_range_iff, forall_const]
 
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 theorem mem_of_closed' {α : Type u} [metric_space α] {s : set α} (hs : is_closed s)
   {a : α} : a ∈ s ↔ ∀ε>0, ∃b ∈ s, dist a b < ε :=
 by simpa only [closure_eq_of_is_closed hs] using @mem_closure_iff _ _ s a
@@ -1294,7 +1297,8 @@ namespace metric
 section second_countable
 open topological_space
 
-/-- A metric space is second countable if, for every ε > 0, there is a countable set which is ε-dense. -/
+/-- A metric space is second countable if, for every `ε > 0`, there is a countable set which is
+`ε`-dense. -/
 lemma second_countable_of_almost_dense_set
   (H : ∀ε > (0 : ℝ), ∃ s : set α, countable s ∧ (∀x, ∃y ∈ s, dist x y ≤ ε)) :
   second_countable_topology α :=
@@ -1317,8 +1321,9 @@ begin
   exact emetric.second_countable_of_separable α
 end
 
-/-- A metric space space is second countable if one can reconstruct up to any ε>0 any element of the
-space from countably many data. -/
+/-- A metric space space is second countable if one can reconstruct up to any `ε>0` any element of
+the space from countably many data. -/
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 lemma second_countable_of_countable_discretization {α : Type u} [metric_space α]
   (H : ∀ε > (0 : ℝ), ∃ (β : Type u) [encodable β] (F : α → β), ∀x y, F x = F y → dist x y ≤ ε) :
   second_countable_topology α :=
@@ -1339,6 +1344,7 @@ end
 end second_countable
 end metric
 
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 lemma lebesgue_number_lemma_of_metric
   {s : set α} {ι} {c : ι → set α} (hs : compact s)
   (hc₁ : ∀ i, is_open (c i)) (hc₂ : s ⊆ ⋃ i, c i) :
@@ -1348,6 +1354,7 @@ let ⟨n, en, hn⟩ := lebesgue_number_lemma hs hc₁ hc₂,
 ⟨δ, δ0, assume x hx, let ⟨i, hi⟩ := hn x hx in
  ⟨i, assume y hy, hi (hδ (mem_ball'.mp hy))⟩⟩
 
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 lemma lebesgue_number_lemma_of_metric_sUnion
   {s : set α} {c : set (set α)} (hs : compact s)
   (hc₁ : ∀ t ∈ c, is_open t) (hc₂ : s ⊆ ⋃₀ c) :


### PR DESCRIPTION
Other changes:

* Reuse `gmultiples_hom` for `AddCommGroup.as_hom`.
* Reuse `add_monoid_hom.ext_int` for `AddCommGroup.int_hom_ext`.
* Drop the following definitions, define an `instance` right away
  instead:
  - `algebra.div`;
  - `monoid_hom.one`, `add_monoid_hom.zero`;
  - `monoid_hom.mul`, `add_monoid_hom.add`;
  - `monoid_hom.inv`, `add_monoid_hom.neg`.

---
<!-- put comments you want to keep out of the PR commit here -->