### PR TITLE
[Merged by Bors] - feat(tactic/linarith): improve parsing expressions into linear form

### DIFF
--- a/src/tactic/linarith.lean
+++ b/src/tactic/linarith.lean
@@ -131,7 +131,7 @@ Index 0 is reserved for constants, i.e. `coeffs.find 0` is the coefficient of 1.
 The represented term is `coeffs.keys.sum (λ i, coeffs.find i * Var[i])`.
 str determines the direction of the comparison -- is it < 0, ≤ 0, or = 0?
 -/
-@[derive _root_.inhabited]
+@[derive inhabited]
 meta structure comp :=
 (str : ineq)
 (coeffs : rb_map ℕ int)
@@ -420,11 +420,8 @@ meta def mk_linarith_structure (red : transparency) (l : list expr) :
   tactic (linarith_structure × rb_map ℕ (expr × expr)) :=
 do pftps ← l.mmap infer_type,
   (l', _, map) ← to_comp_fold red mk_rb_map pftps mk_rb_map,
-  -- trace "map:", trace map,
-  -- trace "l':", trace l',
   let lz := list.enum $ ((l.zip pftps).zip l').filter_map (λ ⟨a, b⟩, prod.mk a <$> b),
   let prmap := rb_map.of_list $ lz.map (λ ⟨n, x⟩, (n, x.1)),
-  --trace "prmap:", trace prmap,
   let vars : rb_set ℕ := rb_map.set_of_list $ list.range map.size.succ,
   let pc : rb_set pcomp := rb_map.set_of_list $
     lz.map (λ ⟨n, x⟩, ⟨x.2, comp_source.assump n⟩),

--- a/src/tactic/linarith.lean
+++ b/src/tactic/linarith.lean
@@ -289,7 +289,7 @@ The resulting `rb_map ℕ ℤ` represents the ring-normalized linear form of the
 -/
 
 /-- Variables (represented by natural numbers) map to their power. -/
-@[reducible] meta def monom := rb_map ℕ ℕ
+@[reducible] meta def monom : Type := rb_map ℕ ℕ
 
 /-- Compare monomials by first comparing their keys and then their powers. -/
 @[reducible] meta def monom.lt : monom → monom → Prop :=
@@ -300,7 +300,7 @@ local attribute [instance]
 meta def monom_has_lt : has_lt monom := ⟨monom.lt⟩
 
 /-- Linear combinations of monomials are represented by mapping monomials to coefficients. -/
-@[reducible] meta def sum := rb_map monom ℤ
+@[reducible] meta def sum : Type := rb_map monom ℤ
 
 /-- `sum.scale_by_monom s m` multiplies every monomial in `s` by `m`. -/
 meta def sum.scale_by_monom (s : sum) (m : monom) : sum :=

--- a/src/tactic/linarith.lean
+++ b/src/tactic/linarith.lean
@@ -628,12 +628,8 @@ meta def find_cancel_factor : expr → ℕ × tree ℕ
   let (v1, t1) := find_cancel_factor e1, (v2, t2) := find_cancel_factor e2, lcm := v1.lcm v2 in
   (lcm, tree.node lcm t1 t2)
 | `(%%e1 * %%e2) :=
-  match is_numeric e1, is_numeric e2 with
-  | none, none := (1, tree.node 1 tree.nil tree.nil)
-  | _, _ :=
-    let (v1, t1) := find_cancel_factor e1, (v2, t2) := find_cancel_factor e2, pd := v1*v2 in
-    (pd, tree.node pd t1 t2)
-  end
+  let (v1, t1) := find_cancel_factor e1, (v2, t2) := find_cancel_factor e2, pd := v1*v2 in
+  (pd, tree.node pd t1 t2)
 | `(%%e1 / %%e2) :=
   match is_numeric e2 with
   | some q := let (v1, t1) := find_cancel_factor e1, n := v1.lcm q.num.nat_abs in

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -27,8 +27,6 @@ begin
   linarith
 end
 
-#exit
-
 example (ε : ℚ) (h1 : ε > 0) : ε / 2 + ε / 3 + ε / 7 < ε :=
  by linarith
 

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -4,6 +4,11 @@ example (e b c a v0 v1 : ℚ) (h1 : v0 = 5*a) (h2 : v1 = 3*b) (h3 : v0 + v1 + c 
   v0 + 5 + (v1 - 3) + (c - 2) = 10 :=
 by linarith
 
+
+-- example (u v r s t : ℚ) (h : 0 < u*(t*v + t*r + s)) : 0 < (t*(r + v) + s)*3*u :=
+-- by linarith
+
+
 example (ε : ℚ) (h1 : ε > 0) : ε / 2 + ε / 3 + ε / 7 < ε :=
  by linarith
 

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -4,10 +4,23 @@ example (e b c a v0 v1 : ℚ) (h1 : v0 = 5*a) (h2 : v1 = 3*b) (h3 : v0 + v1 + c 
   v0 + 5 + (v1 - 3) + (c - 2) = 10 :=
 by linarith
 
+example (u v r s t : ℚ) (h : 0 < u*(t*v + t*r + s)) : 0 < (t*(r + v) + s)*3*u :=
+by linarith
 
--- example (u v r s t : ℚ) (h : 0 < u*(t*v + t*r + s)) : 0 < (t*(r + v) + s)*3*u :=
--- by linarith
+example (A B : ℚ) (h : 0 < A * B) : 0 < 8*A*B :=
+begin
+  linarith
+end
 
+example (A B : ℚ) (h : 0 < A * B) : 0 < A*8*B :=
+begin
+  linarith
+end
+
+example (A B : ℚ) (h : 0 < A * B) : 0 < A*B/8 :=
+begin
+  linarith
+end
 
 example (ε : ℚ) (h1 : ε > 0) : ε / 2 + ε / 3 + ε / 7 < ε :=
  by linarith

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -22,6 +22,13 @@ begin
   linarith
 end
 
+example (A B : ℚ) (h : 0 < A * B) : 0 < A/8*B :=
+begin
+  linarith
+end
+
+#exit
+
 example (ε : ℚ) (h1 : ε > 0) : ε / 2 + ε / 3 + ε / 7 < ε :=
  by linarith
 


### PR DESCRIPTION
This PR generalizes the parsing stage of `linarith`. It will try harder to recognize expressions as linear combinations of monomials, and will match monomials up to commutativity. 
```lean
example (u v r s t : ℚ) (h : 0 < u*(t*v + t*r + s)) : 0 < (t*(r + v) + s)*3*u :=
by linarith
```

This is helpful for #2637 .

---
<!-- put comments you want to keep out of the PR commit here -->

I'm planning a refactor/documentation push for `linarith` but wanted to PR this first, since I don't know how long that will take me and this is useful.