### PR TITLE
[Merged by Bors] - feat(control/equiv_functor/instances): allow equiv_rw on finset

### DIFF
--- a/src/control/equiv_functor/instances.lean
+++ b/src/control/equiv_functor/instances.lean
@@ -3,7 +3,8 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Scott Morrison
 -/
-import tactic.equiv_rw
+import data.finset
+import control.equiv_functor
 
 /-!
 # `equiv_functor` instances
@@ -18,3 +19,9 @@ instance equiv_functor_unique : equiv_functor unique :=
 
 instance equiv_functor_perm : equiv_functor perm :=
 { map := λ α β e p, (e.symm.trans p).trans e }
+
+instance equiv_functor_multiset : equiv_functor multiset :=
+{ map := λ α β e s, s.map e, }
+
+instance equiv_functor_finset : equiv_functor finset :=
+{ map := λ α β e s, s.map e.to_embedding, }

--- a/src/control/equiv_functor/instances.lean
+++ b/src/control/equiv_functor/instances.lean
@@ -20,8 +20,7 @@ instance equiv_functor_unique : equiv_functor unique :=
 instance equiv_functor_perm : equiv_functor perm :=
 { map := λ α β e p, (e.symm.trans p).trans e }
 
-instance equiv_functor_multiset : equiv_functor multiset :=
-{ map := λ α β e s, s.map e, }
-
+-- There is a classical instance of `is_lawful_functor finset` available,
+-- but we provide this computable alternative separately.
 instance equiv_functor_finset : equiv_functor finset :=
 { map := λ α β e s, s.map e.to_embedding, }

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -1311,6 +1311,18 @@ lemma image_const {s : finset α} (h : s.nonempty) (b : β) : s.image (λa, b) =
 ext.2 $ assume b', by simp only [mem_image, exists_prop, exists_and_distrib_right,
   h.bex, true_and, mem_singleton, eq_comm]
 
+/--
+Because `finset.image` requires a `decidable_eq` instances for the target type,
+we can only construct a `functor finset` when working classically.
+-/
+instance [Π P, decidable P] : functor finset :=
+{ map := λ α β f s, s.image f, }
+
+instance [Π P, decidable P] : is_lawful_functor finset :=
+{ id_map := λ α x, image_id,
+  comp_map := λ α β γ f g s, image_image.symm, }
+
+
 /-- Given a finset `s` and a predicate `p`, `s.subtype p` is the finset of `subtype p` whose
 elements belong to `s`.  -/
 protected def subtype {α} (p : α → Prop) [decidable_pred p] (s : finset α) : finset (subtype p) :=

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -1161,7 +1161,7 @@ theorem map_to_finset [decidable_eq α] [decidable_eq β] {s : multiset α} :
   s.to_finset.map f = (s.map f).to_finset :=
 ext.2 $ λ _, by simp only [mem_map, multiset.mem_map, exists_prop, multiset.mem_to_finset]
 
-theorem map_refl : s.map (embedding.refl _) = s :=
+@[simp] theorem map_refl : s.map (embedding.refl _) = s :=
 ext.2 $ λ _, by simpa only [mem_map, exists_prop] using exists_eq_right
 
 theorem map_map {g : β ↪ γ} : (s.map f).map g = s.map (f.trans g) :=

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -672,13 +672,6 @@ le_induction_on h $ λ l₁ l₂ h, (h.map f).subperm
 @[simp] theorem map_subset_map {f : α → β} {s t : multiset α} (H : s ⊆ t) : map f s ⊆ map f t :=
 λ b m, let ⟨a, h, e⟩ := mem_map.1 m in mem_map.2 ⟨a, H h, e⟩
 
-instance : functor multiset :=
-{ map := λ α β f s, s.map f, }
-
-instance : is_lawful_functor multiset :=
-{ id_map := λ α x, map_id x,
-  comp_map := λ α β γ f g s, (map_map g f s).symm, }
-
 /- fold -/
 
 /-- `foldl f H b s` is the lift of the list operation `foldl f b l`,

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -672,6 +672,13 @@ le_induction_on h $ λ l₁ l₂ h, (h.map f).subperm
 @[simp] theorem map_subset_map {f : α → β} {s t : multiset α} (H : s ⊆ t) : map f s ⊆ map f t :=
 λ b m, let ⟨a, h, e⟩ := mem_map.1 m in mem_map.2 ⟨a, H h, e⟩
 
+instance : functor multiset :=
+{ map := λ α β f s, s.map f, }
+
+instance : is_lawful_functor multiset :=
+{ id_map := λ α x, map_id x,
+  comp_map := λ α β γ f g s, (map_map g f s).symm, }
+
 /- fold -/
 
 /-- `foldl f H b s` is the lift of the list operation `foldl f b l`,

--- a/src/logic/embedding.lean
+++ b/src/logic/embedding.lean
@@ -196,6 +196,18 @@ protected def image {α β} (f : α ↪ β) : set α ↪ set β :=
 end embedding
 end function
 
+namespace equiv
+
+@[simp]
+lemma refl_to_embedding {α : Type*} :
+  (equiv.refl α).to_embedding = function.embedding.refl α := rfl
+
+@[simp]
+lemma trans_to_embedding {α β γ : Type*} (e : α ≃ β) (f : β ≃ γ) :
+  (e.trans f).to_embedding = e.to_embedding.trans f.to_embedding := rfl
+
+end equiv
+
 namespace set
 
 /-- The injection map is an embedding between subsets. -/

--- a/src/tactic/equiv_rw.lean
+++ b/src/tactic/equiv_rw.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import control.equiv_functor
+import control.equiv_functor.instances
 
 /-!
 # The `equiv_rw` tactic transports goals or hypotheses along equivalences.


### PR DESCRIPTION
Allows moving `finset` over an `equiv` using `equiv_rw`, as requested by @jcommelin.

e.g.
```
import data.finset
import tactic.equiv_rw

example (σ τ : Type) (e : σ ≃ τ) : finset σ ≃ finset τ :=
by { equiv_rw e, refl, }
```


---
<!-- put comments you want to keep out of the PR commit here -->
