### PR TITLE
[Merged by Bors] - feat(analysis/special_functions/pow): `inv_rpow`, `div_rpow`

### DIFF
--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -235,6 +235,13 @@ lemma log_mul (hx : x ≠ 0) (hy : y ≠ 0) : log (x * y) = log x + log y :=
 exp_injective $
 by rw [exp_log_eq_abs (mul_ne_zero hx hy), exp_add, exp_log_eq_abs hx, exp_log_eq_abs hy, abs_mul]
 
+@[simp] lemma log_inv (x : ℝ) : log (x⁻¹) = -log x :=
+begin
+  by_cases hx : x = 0, { simp [hx] },
+  apply eq_neg_of_add_eq_zero,
+  rw [← log_mul (inv_ne_zero hx) hx, inv_mul_cancel hx, log_one]
+end
+
 lemma log_le_log (h : 0 < x) (h₁ : 0 < y) : real.log x ≤ real.log y ↔ x ≤ y :=
 ⟨λ h₂, by rwa [←real.exp_le_exp, real.exp_log h, real.exp_log h₁] at h₂, λ h₂,
 (real.exp_le_exp).1 $ by rwa [real.exp_log h₁, real.exp_log h]⟩

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -15,7 +15,7 @@ real numbers, or `x` is a nonnegative real and `y` is real, and prove their basi
 
 noncomputable theory
 
-open_locale classical real topological_space
+open_locale classical real topological_space nnreal
 
 namespace complex
 
@@ -76,8 +76,7 @@ by simpa using cpow_neg x 1
 | 0       := by simp
 | (n + 1) := if hx : x = 0 then by simp only [hx, pow_succ,
     complex.zero_cpow (nat.cast_ne_zero.2 (nat.succ_ne_zero _)), zero_mul]
-  else by simp [cpow_def, hx, mul_comm, mul_add, exp_add, pow_succ, (cpow_nat_cast n).symm,
-    exp_log hx]
+  else by simp [cpow_add, hx, pow_add, cpow_nat_cast n]
 
 @[simp] lemma cpow_int_cast (x : ℂ) : ∀ (n : ℤ), x ^ (n : ℂ) = x ^ n
 | (n : ℕ) := by simp; refl
@@ -295,7 +294,18 @@ begin
   { exact mul_nonneg h h₁},
 end
 
-lemma one_le_rpow {x z : ℝ} (h : 1 ≤ x) (h₁ : 0 ≤ z) : 1 ≤ x^z :=
+lemma inv_rpow (hx : 0 ≤ x) (y : ℝ) : (x⁻¹)^y = (x^y)⁻¹ :=
+begin
+  by_cases hy0 : y = 0, { simp [*] },
+  by_cases hx0 : x = 0, { simp [*] },
+  simp only [real.rpow_def_of_nonneg hx, real.rpow_def_of_nonneg (inv_nonneg.2 hx), if_false,
+    hx0, mt inv_eq_zero.1 hx0, log_inv, ← neg_mul_eq_neg_mul, exp_neg]
+end
+
+lemma div_rpow (hx : 0 ≤ x) (hy : 0 ≤ y) (z : ℝ) : (x / y) ^ z = x^z / y^z :=
+by simp only [div_eq_mul_inv, mul_rpow hx (inv_nonneg.2 hy), inv_rpow hy]
+
+lemma one_le_rpow (h : 1 ≤ x) (h₁ : 0 ≤ z) : 1 ≤ x^z :=
 begin
   rw real.rpow_def_of_nonneg, split_ifs with h₂ h₃,
   { refl},
@@ -716,95 +726,104 @@ end differentiability
 
 namespace nnreal
 
-/-- The nonnegative real power function `x^y`, defined for `x : nnreal` and `y : ℝ ` as the
+/-- The nonnegative real power function `x^y`, defined for `x : ℝ≥0` and `y : ℝ ` as the
 restriction of the real power function. For `x > 0`, it is equal to `exp (y log x)`. For `x = 0`,
 one sets `0 ^ 0 = 1` and `0 ^ y = 0` for `y ≠ 0`. -/
-noncomputable def rpow (x : nnreal) (y : ℝ) : nnreal :=
+noncomputable def rpow (x : ℝ≥0) (y : ℝ) : ℝ≥0 :=
 ⟨(x : ℝ) ^ y, real.rpow_nonneg_of_nonneg x.2 y⟩
 
-noncomputable instance : has_pow nnreal ℝ := ⟨rpow⟩
+noncomputable instance : has_pow ℝ≥0 ℝ := ⟨rpow⟩
 
-@[simp] lemma rpow_eq_pow (x : nnreal) (y : ℝ) : rpow x y = x ^ y := rfl
+@[simp] lemma rpow_eq_pow (x : ℝ≥0) (y : ℝ) : rpow x y = x ^ y := rfl
 
-@[simp, norm_cast] lemma coe_rpow (x : nnreal) (y : ℝ) : ((x ^ y : nnreal) : ℝ) = (x : ℝ) ^ y := rfl
+@[simp, norm_cast] lemma coe_rpow (x : ℝ≥0) (y : ℝ) : ((x ^ y : ℝ≥0) : ℝ) = (x : ℝ) ^ y := rfl
 
-@[simp] lemma rpow_zero (x : nnreal) : x ^ (0 : ℝ) = 1 :=
-by { rw ← nnreal.coe_eq, exact real.rpow_zero _ }
+@[simp] lemma rpow_zero (x : ℝ≥0) : x ^ (0 : ℝ) = 1 :=
+nnreal.eq $ real.rpow_zero _
 
-@[simp] lemma rpow_eq_zero_iff {x : nnreal} {y : ℝ} : x ^ y = 0 ↔ x = 0 ∧ y ≠ 0 :=
+@[simp] lemma rpow_eq_zero_iff {x : ℝ≥0} {y : ℝ} : x ^ y = 0 ↔ x = 0 ∧ y ≠ 0 :=
 begin
   rw [← nnreal.coe_eq, coe_rpow, ← nnreal.coe_eq_zero],
   exact real.rpow_eq_zero_iff_of_nonneg x.2
 end
 
-@[simp] lemma zero_rpow {x : ℝ} (h : x ≠ 0) : (0 : nnreal) ^ x = 0 :=
-by { rw ← nnreal.coe_eq, exact real.zero_rpow h }
+@[simp] lemma zero_rpow {x : ℝ} (h : x ≠ 0) : (0 : ℝ≥0) ^ x = 0 :=
+nnreal.eq $ real.zero_rpow h
 
-@[simp] lemma rpow_one (x : nnreal) : x ^ (1 : ℝ) = x :=
-by { rw ← nnreal.coe_eq, exact real.rpow_one _ }
+@[simp] lemma rpow_one (x : ℝ≥0) : x ^ (1 : ℝ) = x :=
+nnreal.eq $ real.rpow_one _
 
-@[simp] lemma one_rpow (x : ℝ) : (1 : nnreal) ^ x = 1 :=
-by { rw ← nnreal.coe_eq, exact real.one_rpow _ }
+@[simp] lemma one_rpow (x : ℝ) : (1 : ℝ≥0) ^ x = 1 :=
+nnreal.eq $ real.one_rpow _
 
-lemma rpow_add {x : nnreal} (hx : 0 < x) (y z : ℝ) : x ^ (y + z) = x ^ y * x ^ z :=
-by { rw ← nnreal.coe_eq, exact real.rpow_add hx _ _ }
+lemma rpow_add {x : ℝ≥0} (hx : 0 < x) (y z : ℝ) : x ^ (y + z) = x ^ y * x ^ z :=
+nnreal.eq $ real.rpow_add hx _ _
 
-lemma rpow_mul (x : nnreal) (y z : ℝ) : x ^ (y * z) = (x ^ y) ^ z :=
-by { rw ← nnreal.coe_eq, exact real.rpow_mul x.2 y z }
+lemma rpow_add' (x : ℝ≥0) {y z : ℝ} (h : y + z ≠ 0) : x ^ (y + z) = x ^ y * x ^ z :=
+nnreal.eq $ real.rpow_add' x.2 h
 
-lemma rpow_neg (x : nnreal) (y : ℝ) : x ^ -y = (x ^ y)⁻¹ :=
-by { rw ← nnreal.coe_eq, exact real.rpow_neg x.2 _ }
+lemma rpow_mul (x : ℝ≥0) (y z : ℝ) : x ^ (y * z) = (x ^ y) ^ z :=
+nnreal.eq $ real.rpow_mul x.2 y z
 
-@[simp] lemma rpow_nat_cast (x : nnreal) (n : ℕ) : x ^ (n : ℝ) = x ^ n :=
-by { rw [← nnreal.coe_eq, nnreal.coe_pow], exact real.rpow_nat_cast (x : ℝ) n }
+lemma rpow_neg (x : ℝ≥0) (y : ℝ) : x ^ -y = (x ^ y)⁻¹ :=
+nnreal.eq $ real.rpow_neg x.2 _
 
-lemma mul_rpow {x y : nnreal} {z : ℝ}  : (x*y)^z = x^z * y^z :=
-by { rw ← nnreal.coe_eq, exact real.mul_rpow x.2 y.2 }
+lemma inv_rpow (x : ℝ≥0) (y : ℝ) : (x⁻¹) ^ y = (x ^ y)⁻¹ :=
+nnreal.eq $ real.inv_rpow x.2 y
 
-lemma one_le_rpow {x : nnreal} {z : ℝ} (h : 1 ≤ x) (h₁ : 0 ≤ z) : 1 ≤ x^z :=
+lemma div_rpow (x y : ℝ≥0) (z : ℝ) : (x / y) ^ z = x ^ z / y ^ z :=
+nnreal.eq $ real.div_rpow x.2 y.2 z
+
+@[simp, norm_cast] lemma rpow_nat_cast (x : ℝ≥0) (n : ℕ) : x ^ (n : ℝ) = x ^ n :=
+nnreal.eq $ by simpa only [coe_rpow, coe_pow] using real.rpow_nat_cast x n
+
+lemma mul_rpow {x y : ℝ≥0} {z : ℝ}  : (x*y)^z = x^z * y^z :=
+nnreal.eq $ real.mul_rpow x.2 y.2
+
+lemma one_le_rpow {x : ℝ≥0} {z : ℝ} (h : 1 ≤ x) (h₁ : 0 ≤ z) : 1 ≤ x^z :=
 real.one_le_rpow h h₁
 
-lemma rpow_le_rpow {x y : nnreal} {z: ℝ} (h₁ : x ≤ y) (h₂ : 0 ≤ z) : x^z ≤ y^z :=
+lemma rpow_le_rpow {x y : ℝ≥0} {z: ℝ} (h₁ : x ≤ y) (h₂ : 0 ≤ z) : x^z ≤ y^z :=
 real.rpow_le_rpow x.2 h₁ h₂
 
-lemma rpow_lt_rpow {x y : nnreal} {z: ℝ} (h₁ : x < y) (h₂ : 0 < z) : x^z < y^z :=
+lemma rpow_lt_rpow {x y : ℝ≥0} {z: ℝ} (h₁ : x < y) (h₂ : 0 < z) : x^z < y^z :=
 real.rpow_lt_rpow x.2 h₁ h₂
 
-lemma rpow_lt_rpow_of_exponent_lt {x : nnreal} {y z : ℝ} (hx : 1 < x) (hyz : y < z) : x^y < x^z :=
+lemma rpow_lt_rpow_of_exponent_lt {x : ℝ≥0} {y z : ℝ} (hx : 1 < x) (hyz : y < z) : x^y < x^z :=
 real.rpow_lt_rpow_of_exponent_lt hx hyz
 
-lemma rpow_le_rpow_of_exponent_le {x : nnreal} {y z : ℝ} (hx : 1 ≤ x) (hyz : y ≤ z) : x^y ≤ x^z :=
+lemma rpow_le_rpow_of_exponent_le {x : ℝ≥0} {y z : ℝ} (hx : 1 ≤ x) (hyz : y ≤ z) : x^y ≤ x^z :=
 real.rpow_le_rpow_of_exponent_le hx hyz
 
-lemma rpow_lt_rpow_of_exponent_gt {x : nnreal} {y z : ℝ} (hx0 : 0 < x) (hx1 : x < 1) (hyz : z < y) :
+lemma rpow_lt_rpow_of_exponent_gt {x : ℝ≥0} {y z : ℝ} (hx0 : 0 < x) (hx1 : x < 1) (hyz : z < y) :
   x^y < x^z :=
 real.rpow_lt_rpow_of_exponent_gt hx0 hx1 hyz
 
-lemma rpow_le_rpow_of_exponent_ge {x : nnreal} {y z : ℝ} (hx0 : 0 < x) (hx1 : x ≤ 1) (hyz : z ≤ y) :
+lemma rpow_le_rpow_of_exponent_ge {x : ℝ≥0} {y z : ℝ} (hx0 : 0 < x) (hx1 : x ≤ 1) (hyz : z ≤ y) :
   x^y ≤ x^z :=
 real.rpow_le_rpow_of_exponent_ge hx0 hx1 hyz
 
-lemma rpow_le_one {x : nnreal} {z : ℝ} (hx2 : x ≤ 1) (hz : 0 ≤ z) : x^z ≤ 1 :=
+lemma rpow_le_one {x : ℝ≥0} {z : ℝ} (hx2 : x ≤ 1) (hz : 0 ≤ z) : x^z ≤ 1 :=
 real.rpow_le_one x.2 hx2 hz
 
-lemma one_lt_rpow {x : nnreal} {z : ℝ} (hx : 1 < x) (hz : 0 < z) : 1 < x^z :=
+lemma one_lt_rpow {x : ℝ≥0} {z : ℝ} (hx : 1 < x) (hz : 0 < z) : 1 < x^z :=
 real.one_lt_rpow hx hz
 
-lemma rpow_lt_one {x : nnreal} {z : ℝ} (hx : 0 < x) (hx1 : x < 1) (hz : 0 < z) : x^z < 1 :=
+lemma rpow_lt_one {x : ℝ≥0} {z : ℝ} (hx : 0 < x) (hx1 : x < 1) (hz : 0 < z) : x^z < 1 :=
 real.rpow_lt_one hx hx1 hz
 
-lemma pow_nat_rpow_nat_inv (x : nnreal) {n : ℕ} (hn : 0 < n) :
+lemma pow_nat_rpow_nat_inv (x : ℝ≥0) {n : ℕ} (hn : 0 < n) :
   (x ^ n) ^ (n⁻¹ : ℝ) = x :=
 by { rw [← nnreal.coe_eq, coe_rpow, nnreal.coe_pow], exact real.pow_nat_rpow_nat_inv x.2 hn }
 
-lemma rpow_nat_inv_pow_nat (x : nnreal) {n : ℕ} (hn : 0 < n) :
+lemma rpow_nat_inv_pow_nat (x : ℝ≥0) {n : ℕ} (hn : 0 < n) :
   (x ^ (n⁻¹ : ℝ)) ^ n = x :=
 by { rw [← nnreal.coe_eq, nnreal.coe_pow, coe_rpow], exact real.rpow_nat_inv_pow_nat x.2 hn }
 
-lemma continuous_at_rpow {x : nnreal} {y : ℝ} (h : x ≠ 0 ∨ 0 < y) :
-  continuous_at (λp:nnreal×ℝ, p.1^p.2) (x, y) :=
+lemma continuous_at_rpow {x : ℝ≥0} {y : ℝ} (h : x ≠ 0 ∨ 0 < y) :
+  continuous_at (λp:ℝ≥0×ℝ, p.1^p.2) (x, y) :=
 begin
-  have : (λp:nnreal×ℝ, p.1^p.2) = nnreal.of_real ∘ (λp:ℝ×ℝ, p.1^p.2) ∘ (λp:nnreal × ℝ, (p.1.1, p.2)),
+  have : (λp:ℝ≥0×ℝ, p.1^p.2) = nnreal.of_real ∘ (λp:ℝ×ℝ, p.1^p.2) ∘ (λp:ℝ≥0 × ℝ, (p.1.1, p.2)),
   { ext p,
     rw [← nnreal.coe_eq, coe_rpow, nnreal.coe_of_real _ (real.rpow_nonneg_of_nonneg p.1.2 _)],
     refl },
@@ -821,7 +840,7 @@ end nnreal
 
 open filter
 
-lemma filter.tendsto.nnrpow {α : Type*} {f : filter α} {u : α → nnreal} {v : α → ℝ} {x : nnreal} {y : ℝ}
+lemma filter.tendsto.nnrpow {α : Type*} {f : filter α} {u : α → ℝ≥0} {v : α → ℝ} {x : ℝ≥0} {y : ℝ}
   (hx : tendsto u f (𝓝 x)) (hy : tendsto v f (𝓝 y)) (h : x ≠ 0 ∨ 0 < y) :
   tendsto (λ a, (u a) ^ (v a)) f (𝓝 (x ^ y)) :=
 tendsto.comp (nnreal.continuous_at_rpow h) (tendsto.prod_mk_nhds hx hy)
@@ -833,7 +852,7 @@ namespace ennreal
 for `0` and `⊤` (i.e., `0 ^ x = 0` for `x > 0`, `1` for `x = 0` and `⊤` for `x < 0`, and
 `⊤ ^ x = 1 / 0 ^ x`). -/
 noncomputable def rpow : ennreal → ℝ → ennreal
-| (some x) y := if x = 0 ∧ y < 0 then ⊤ else (x ^ y : nnreal)
+| (some x) y := if x = 0 ∧ y < 0 then ⊤ else (x ^ y : ℝ≥0)
 | none     y := if 0 < y then ⊤ else if y = 0 then 1 else 0
 
 noncomputable instance : has_pow ennreal ℝ := ⟨rpow⟩
@@ -874,16 +893,16 @@ begin
   { simp [H, asymm H, ne_of_lt, zero_rpow_of_neg] }
 end
 
-@[norm_cast] lemma coe_rpow_of_ne_zero {x : nnreal} (h : x ≠ 0) (y : ℝ) :
-  (x : ennreal) ^ y = (x ^ y : nnreal) :=
+@[norm_cast] lemma coe_rpow_of_ne_zero {x : ℝ≥0} (h : x ≠ 0) (y : ℝ) :
+  (x : ennreal) ^ y = (x ^ y : ℝ≥0) :=
 begin
   rw [← ennreal.some_eq_coe],
   dsimp only [(^), rpow],
   simp [h]
 end
 
-@[norm_cast] lemma coe_rpow_of_nonneg (x : nnreal) {y : ℝ} (h : 0 ≤ y) :
-  (x : ennreal) ^ y = (x ^ y : nnreal) :=
+@[norm_cast] lemma coe_rpow_of_nonneg (x : ℝ≥0) {y : ℝ} (h : 0 ≤ y) :
+  (x : ennreal) ^ y = (x ^ y : ℝ≥0) :=
 begin
   by_cases hx : x = 0,
   { rcases le_iff_eq_or_lt.1 h with H|H,
@@ -966,7 +985,7 @@ begin
   { simp [coe_rpow_of_nonneg _ (nat.cast_nonneg n)] }
 end
 
-@[norm_cast] lemma coe_mul_rpow (x y : nnreal) (z : ℝ) :
+@[norm_cast] lemma coe_mul_rpow (x y : ℝ≥0) (z : ℝ) :
   ((x : ennreal) * y) ^ z = x^z * y^z :=
 begin
   rcases lt_trichotomy z 0 with H|H|H,
@@ -994,8 +1013,8 @@ end
 lemma mul_rpow_of_ne_top {x y : ennreal} (hx : x ≠ ⊤) (hy : y ≠ ⊤) (z : ℝ) :
   (x * y) ^ z = x^z * y^z :=
 begin
-  lift x to nnreal using hx,
-  lift y to nnreal using hy,
+  lift x to ℝ≥0 using hx,
+  lift y to ℝ≥0 using hy,
   exact coe_mul_rpow x y z
 end
 
@@ -1060,7 +1079,7 @@ end
 lemma rpow_lt_rpow_of_exponent_lt {x : ennreal} {y z : ℝ} (hx : 1 < x) (hx' : x ≠ ⊤) (hyz : y < z) :
   x^y < x^z :=
 begin
-  lift x to nnreal using hx',
+  lift x to ℝ≥0 using hx',
   rw [one_lt_coe_iff] at hx,
   simp [coe_rpow_of_ne_zero (ne_of_gt (lt_trans zero_lt_one hx)),
         nnreal.rpow_lt_rpow_of_exponent_lt hx hyz]
@@ -1081,7 +1100,7 @@ end
 lemma rpow_lt_rpow_of_exponent_gt {x : ennreal} {y z : ℝ} (hx0 : 0 < x) (hx1 : x < 1) (hyz : z < y) :
   x^y < x^z :=
 begin
-  lift x to nnreal using ne_of_lt (lt_of_lt_of_le hx1 le_top),
+  lift x to ℝ≥0 using ne_of_lt (lt_of_lt_of_le hx1 le_top),
   simp at hx0 hx1,
   simp [coe_rpow_of_ne_zero (ne_of_gt hx0), nnreal.rpow_lt_rpow_of_exponent_gt hx0 hx1 hyz]
 end
@@ -1089,7 +1108,7 @@ end
 lemma rpow_le_rpow_of_exponent_ge {x : ennreal} {y z : ℝ} (hx1 : x ≤ 1) (hyz : z ≤ y) :
   x^y ≤ x^z :=
 begin
-  lift x to nnreal using ne_of_lt (lt_of_le_of_lt hx1 coe_lt_top),
+  lift x to ℝ≥0 using ne_of_lt (lt_of_le_of_lt hx1 coe_lt_top),
   by_cases h : x = 0,
   { rcases lt_trichotomy y 0 with Hy|Hy|Hy;
     rcases lt_trichotomy z 0 with Hz|Hz|Hz;
@@ -1102,7 +1121,7 @@ end
 
 lemma rpow_le_one {x : ennreal} {z : ℝ} (hx2 : x ≤ 1) (hz : 0 ≤ z) : x^z ≤ 1 :=
 begin
-  lift x to nnreal using ne_of_lt (lt_of_le_of_lt hx2 coe_lt_top),
+  lift x to ℝ≥0 using ne_of_lt (lt_of_le_of_lt hx2 coe_lt_top),
   simp at hx2,
   simp [coe_rpow_of_nonneg _ hz, nnreal.rpow_le_one hx2 hz]
 end
@@ -1120,7 +1139,7 @@ lemma rpow_lt_one {x : ennreal} {z : ℝ} (hx1 : x < 1) (hz : 0 < z) : x^z < 1 :
 begin
   by_cases h : x = 0,
   { simp [h, zero_rpow_of_pos hz, ennreal.zero_lt_one] },
-  { lift x to nnreal using ne_of_lt (lt_of_lt_of_le hx1 le_top),
+  { lift x to ℝ≥0 using ne_of_lt (lt_of_lt_of_le hx1 le_top),
     simp at h hx1,
     have : 0 < x := bot_lt_iff_ne_bot.mpr h,
     simp [coe_rpow_of_nonneg _ (le_of_lt hz), nnreal.rpow_lt_one this hx1 hz] }


### PR DESCRIPTION
Also use notation `ℝ≥0` and use `nnreal.eq` instead of `rw ← nnreal.coe_eq`.

---
<!-- put comments you want to keep out of the PR commit here -->
