### PR TITLE
[Merged by Bors] - refactor(data/polynomial): redefine `C` as an `alg_hom`

### DIFF
--- a/src/analysis/calculus/specific_functions.lean
+++ b/src/analysis/calculus/specific_functions.lean
@@ -34,7 +34,7 @@ derivatives for `x > 0`. The `n`-th derivative is of the form `P_aux n (x) exp(-
 where `P_aux n` is computed inductively. -/
 noncomputable def P_aux : ℕ → polynomial ℝ
 | 0 := 1
-| (n+1) := X^2 * (P_aux n).derivative  + (1 - C (2 * n) * X) * (P_aux n)
+| (n+1) := X^2 * (P_aux n).derivative  + (1 - C ↑(2 * n) * X) * (P_aux n)
 
 /-- Formula for the `n`-th derivative of `exp_neg_inv_glue`, as an auxiliary function `f_aux`. -/
 def f_aux (n : ℕ) (x : ℝ) : ℝ :=

--- a/src/field_theory/minimal_polynomial.lean
+++ b/src/field_theory/minimal_polynomial.lean
@@ -110,7 +110,7 @@ begin
   have ndeg_eq_zero : nat_degree (minimal_polynomial hx) = 0,
   { simpa using congr_arg nat_degree (eq_C_of_degree_eq_zero deg_eq_zero) },
   have eq_one : minimal_polynomial hx = 1,
-  { rw eq_C_of_degree_eq_zero deg_eq_zero, congr,
+  { rw eq_C_of_degree_eq_zero deg_eq_zero, convert C_1,
     simpa [ndeg_eq_zero.symm] using (monic hx).leading_coeff },
   simpa [eq_one, aeval_def] using aeval hx
 end


### PR DESCRIPTION
As a side effect Lean parses `C 1` as `polynomial nat`. If you need `polynomial R`, then use `C (1:R)`.

---
<!-- put comments you want to keep out of the PR commit here -->
Surprisingly, `polynomial.lean` required very few modifications. Waiting for CI to build the rest of `mathlib`.