### PR TITLE
fix(lint): disable incorrect type class linter on auto decls

### DIFF
--- a/src/tactic/lint/type_classes.lean
+++ b/src/tactic/lint/type_classes.lean
@@ -164,7 +164,7 @@ private meta def incorrect_type_class_argument (d : declaration) : tactic (optio
 /-- A linter object for `incorrect_type_class_argument`. -/
 @[linter] meta def linter.incorrect_type_class_argument : linter :=
 { test := incorrect_type_class_argument,
-  auto_decls := tt,
+  auto_decls := ff,
   no_errors_found := "All declarations have correct type-class arguments",
   errors_found := "INCORRECT TYPE-CLASS ARGUMENTS.
 Some declarations have non-classes between [square brackets]" }


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->
https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/incorrect_type_class_argument.20linter

I don't think there's a reason to run this linter on generated stuff, is there?
cc @gebner @fpvandoorn 