### PR TITLE
[Merged by Bors] - feat(linear_algebra/basic): curry is linear_equiv

### DIFF
--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1653,6 +1653,10 @@ protected def uncurry :
   smul := λ _ _, by { ext z, cases z, refl },
   .. equiv.arrow_arrow_equiv_prod_arrow _ _ _}
 
+@[simp] lemma coe_uncurry (x) : linear_equiv.uncurry R V V₂ x = uncurry x := rfl
+
+@[simp] lemma coe_curry_symm (x) : (linear_equiv.uncurry R V V₂).symm x = curry x := rfl
+
 end curry
 
 section

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1645,7 +1645,8 @@ section curry
 
 variables (V V₂ R)
 
-/-- Linear equivalence between an uncurried and curried function. -/
+/-- Linear equivalence between an uncurried and curried function.
+  Differs from `tensor_product.curry`. -/
 protected def curry :
   (V → V₂ → R) ≃ₗ[R] (V × V₂ → R) :=
 { add := λ _ _, by { ext z, cases z, refl },

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johannes Hölzl, Mario Carneiro, Kevin Buzzard, Yury Kudryashov
+Authors: Johannes Hölzl, Mario Carneiro, Kevin Buzzard, Yury Kudryashov, Yakov Pechersky
 -/
 import algebra.pi_instances
 import data.finsupp
@@ -1640,6 +1640,19 @@ lemma prod_symm : (e₁.prod e₂).symm = e₁.symm.prod e₂.symm := rfl
 rfl
 
 end prod
+
+section curry
+
+variables (V V₂ R)
+
+/-- Linear equivalence between an uncurried and curried function. -/
+protected def curry :
+  (V → V₂ → R) ≃ₗ[R] (V × V₂ → R) :=
+{ add := λ _ _, by ext z; cases z; refl,
+  smul := λ _ _, by ext z; cases z; refl,
+  .. equiv.arrow_arrow_equiv_prod_arrow _ _ _}
+
+end curry
 
 section
 variables {semimodule_M : semimodule R M} {semimodule_M₂ : semimodule R M₂}

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1645,9 +1645,9 @@ section curry
 
 variables (V V₂ R)
 
-/-- Linear equivalence between an uncurried and curried function.
+/-- Linear equivalence between a curried and uncurried function.
   Differs from `tensor_product.curry`. -/
-protected def curry :
+protected def uncurry :
   (V → V₂ → R) ≃ₗ[R] (V × V₂ → R) :=
 { add := λ _ _, by { ext z, cases z, refl },
   smul := λ _ _, by { ext z, cases z, refl },

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1653,9 +1653,9 @@ protected def uncurry :
   smul := λ _ _, by { ext z, cases z, refl },
   .. equiv.arrow_arrow_equiv_prod_arrow _ _ _}
 
-@[simp] lemma coe_uncurry (x) : linear_equiv.uncurry R V V₂ x = uncurry x := rfl
+@[simp] lemma coe_uncurry : ⇑(linear_equiv.uncurry R V V₂) = uncurry := rfl
 
-@[simp] lemma coe_curry_symm (x) : (linear_equiv.uncurry R V V₂).symm x = curry x := rfl
+@[simp] lemma coe_uncurry_symm : ⇑(linear_equiv.uncurry R V V₂).symm = curry := rfl
 
 end uncurry
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1641,7 +1641,7 @@ rfl
 
 end prod
 
-section curry
+section uncurry
 
 variables (V V₂ R)
 
@@ -1657,7 +1657,7 @@ protected def uncurry :
 
 @[simp] lemma coe_curry_symm (x) : (linear_equiv.uncurry R V V₂).symm x = curry x := rfl
 
-end curry
+end uncurry
 
 section
 variables {semimodule_M : semimodule R M} {semimodule_M₂ : semimodule R M₂}

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1648,8 +1648,8 @@ variables (V V₂ R)
 /-- Linear equivalence between an uncurried and curried function. -/
 protected def curry :
   (V → V₂ → R) ≃ₗ[R] (V × V₂ → R) :=
-{ add := λ _ _, by ext z; cases z; refl,
-  smul := λ _ _, by ext z; cases z; refl,
+{ add := λ _ _, by { ext z, cases z, refl },
+  smul := λ _ _, by { ext z, cases z, refl },
   .. equiv.arrow_arrow_equiv_prod_arrow _ _ _}
 
 end curry


### PR DESCRIPTION
Currying provides a linear_equiv. This can be used to show that
matrix lookup is a linear operation. This should allow to easily
provide a finite_dimensional instance for matrices.

---
<!-- put comments you want to keep out of the PR commit here -->
