### PR TITLE
[Merged by Bors] - feat(linear_algebra/matrix): matrix has finite dim 

### DIFF
--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1653,6 +1653,10 @@ protected def uncurry :
   smul := λ _ _, by { ext z, cases z, refl },
   .. equiv.arrow_arrow_equiv_prod_arrow _ _ _}
 
+@[simp] lemma coe_uncurry (x) : linear_equiv.uncurry R V V₂ x = uncurry x := rfl
+
+@[simp] lemma coe_curry_symm (x) : (linear_equiv.uncurry R V V₂).symm x = curry x := rfl
+
 end curry
 
 section

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1649,8 +1649,8 @@ variables (V V₂ R)
   Differs from `tensor_product.curry`. -/
 protected def uncurry :
   (V → V₂ → R) ≃ₗ[R] (V × V₂ → R) :=
-{ add := λ _ _, by { ext z, cases z, refl },
-  smul := λ _ _, by { ext z, cases z, refl },
+{ add := λ _ _, by { ext ⟨⟩, refl },
+  smul := λ _ _, by { ext ⟨⟩, refl },
   .. equiv.arrow_arrow_equiv_prod_arrow _ _ _}
 
 @[simp] lemma coe_uncurry : ⇑(linear_equiv.uncurry R V V₂) = uncurry := rfl

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1645,7 +1645,8 @@ section curry
 
 variables (V V₂ R)
 
-/-- Linear equivalence between an uncurried and curried function. -/
+/-- Linear equivalence between an uncurried and curried function.
+  Differs from `tensor_product.curry`. -/
 protected def curry :
   (V → V₂ → R) ≃ₗ[R] (V × V₂ → R) :=
 { add := λ _ _, by { ext z, cases z, refl },

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johannes Hölzl, Mario Carneiro, Kevin Buzzard, Yury Kudryashov
+Authors: Johannes Hölzl, Mario Carneiro, Kevin Buzzard, Yury Kudryashov, Yakov Pechersky
 -/
 import algebra.pi_instances
 import data.finsupp
@@ -1640,6 +1640,19 @@ lemma prod_symm : (e₁.prod e₂).symm = e₁.symm.prod e₂.symm := rfl
 rfl
 
 end prod
+
+section curry
+
+variables (V V₂ R)
+
+/-- Linear equivalence between an uncurried and curried function. -/
+protected def curry :
+  (V → V₂ → R) ≃ₗ[R] (V × V₂ → R) :=
+{ add := λ _ _, by ext z; cases z; refl,
+  smul := λ _ _, by ext z; cases z; refl,
+  .. equiv.arrow_arrow_equiv_prod_arrow _ _ _}
+
+end curry
 
 section
 variables {semimodule_M : semimodule R M} {semimodule_M₂ : semimodule R M₂}

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1645,9 +1645,9 @@ section curry
 
 variables (V V₂ R)
 
-/-- Linear equivalence between an uncurried and curried function.
+/-- Linear equivalence between a curried and uncurried function.
   Differs from `tensor_product.curry`. -/
-protected def curry :
+protected def uncurry :
   (V → V₂ → R) ≃ₗ[R] (V × V₂ → R) :=
 { add := λ _ _, by { ext z, cases z, refl },
   smul := λ _ _, by { ext z, cases z, refl },

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1653,9 +1653,9 @@ protected def uncurry :
   smul := λ _ _, by { ext z, cases z, refl },
   .. equiv.arrow_arrow_equiv_prod_arrow _ _ _}
 
-@[simp] lemma coe_uncurry (x) : linear_equiv.uncurry R V V₂ x = uncurry x := rfl
+@[simp] lemma coe_uncurry : ⇑(linear_equiv.uncurry R V V₂) = uncurry := rfl
 
-@[simp] lemma coe_curry_symm (x) : (linear_equiv.uncurry R V V₂).symm x = curry x := rfl
+@[simp] lemma coe_uncurry_symm : ⇑(linear_equiv.uncurry R V V₂).symm = curry := rfl
 
 end uncurry
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1641,7 +1641,7 @@ rfl
 
 end prod
 
-section curry
+section uncurry
 
 variables (V V₂ R)
 
@@ -1657,7 +1657,7 @@ protected def uncurry :
 
 @[simp] lemma coe_curry_symm (x) : (linear_equiv.uncurry R V V₂).symm x = curry x := rfl
 
-end curry
+end uncurry
 
 section
 variables {semimodule_M : semimodule R M} {semimodule_M₂ : semimodule R M₂}

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1648,8 +1648,8 @@ variables (V V₂ R)
 /-- Linear equivalence between an uncurried and curried function. -/
 protected def curry :
   (V → V₂ → R) ≃ₗ[R] (V × V₂ → R) :=
-{ add := λ _ _, by ext z; cases z; refl,
-  smul := λ _ _, by ext z; cases z; refl,
+{ add := λ _ _, by { ext z, cases z, refl },
+  smul := λ _ _, by { ext z, cases z, refl },
   .. equiv.arrow_arrow_equiv_prod_arrow _ _ _}
 
 end curry

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -1,9 +1,9 @@
 /-
 Copyright (c) 2019 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Johannes Hölzl, Casper Putz
+Author: Johannes Hölzl, Casper Putz, Yakov Pechersky
 -/
-import linear_algebra.dimension
+import linear_algebra.finite_dimensional
 
 /-!
 # Linear maps and matrices
@@ -314,6 +314,21 @@ begin
 end
 
 end vector_space
+
+section finite_dimensional
+
+variables {R : Type v} [field R]
+
+instance finite_dimensional_matrix : finite_dimensional R (matrix m n R) :=
+linear_equiv.finite_dimensional (linear_equiv.curry R m n).symm
+
+/-- The dimmension of a finite dimensional matrix is the product of the number or rows and columns-/
+@[simp] lemma matrix_dim_fin :
+  finite_dimensional.findim R (matrix m n R) = fintype.card m * fintype.card n :=
+by rw [@linear_equiv.findim_eq R (matrix m n R) _ _ _ _ _ _ (linear_equiv.curry R m n),
+       finite_dimensional.findim_fintype_fun_eq_card, fintype.card_prod]
+
+end finite_dimensional
 
 end matrix
 

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -322,7 +322,10 @@ variables {R : Type v} [field R]
 instance : finite_dimensional R (matrix m n R) :=
 linear_equiv.finite_dimensional (linear_equiv.uncurry R m n).symm
 
-/-- The dimension of a finite dimensional matrix is the product of the number of rows and columns-/
+/-- 
+The dimension of the space of finite dimensional matrices 
+is the product of the number of rows and columns.
+-/
 @[simp] lemma findim_matrix :
   finite_dimensional.findim R (matrix m n R) = fintype.card m * fintype.card n :=
 by rw [@linear_equiv.findim_eq R (matrix m n R) _ _ _ _ _ _ (linear_equiv.uncurry R m n),

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -323,7 +323,7 @@ instance : finite_dimensional R (matrix m n R) :=
 linear_equiv.finite_dimensional (linear_equiv.uncurry R m n).symm
 
 /-- The dimension of a finite dimensional matrix is the product of the number of rows and columns-/
-@[simp] lemma matrix_dim_fin :
+@[simp] lemma findim_matrix :
   finite_dimensional.findim R (matrix m n R) = fintype.card m * fintype.card n :=
 by rw [@linear_equiv.findim_eq R (matrix m n R) _ _ _ _ _ _ (linear_equiv.uncurry R m n),
        finite_dimensional.findim_fintype_fun_eq_card, fintype.card_prod]

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -320,12 +320,12 @@ section finite_dimensional
 variables {R : Type v} [field R]
 
 instance finite_dimensional_matrix : finite_dimensional R (matrix m n R) :=
-linear_equiv.finite_dimensional (linear_equiv.curry R m n).symm
+linear_equiv.finite_dimensional (linear_equiv.uncurry R m n).symm
 
-/-- The dimmension of a finite dimensional matrix is the product of the number or rows and columns-/
+/-- The dimension of a finite dimensional matrix is the product of the number of rows and columns-/
 @[simp] lemma matrix_dim_fin :
   finite_dimensional.findim R (matrix m n R) = fintype.card m * fintype.card n :=
-by rw [@linear_equiv.findim_eq R (matrix m n R) _ _ _ _ _ _ (linear_equiv.curry R m n),
+by rw [@linear_equiv.findim_eq R (matrix m n R) _ _ _ _ _ _ (linear_equiv.uncurry R m n),
        finite_dimensional.findim_fintype_fun_eq_card, fintype.card_prod]
 
 end finite_dimensional

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -319,7 +319,7 @@ section finite_dimensional
 
 variables {R : Type v} [field R]
 
-instance finite_dimensional_matrix : finite_dimensional R (matrix m n R) :=
+instance : finite_dimensional R (matrix m n R) :=
 linear_equiv.finite_dimensional (linear_equiv.uncurry R m n).symm
 
 /-- The dimension of a finite dimensional matrix is the product of the number of rows and columns-/


### PR DESCRIPTION
Using the fact that currying is a linear operation, we give matrix
a finite dimensional instance. This allows one to invoke `findim`
on matrices, giving the expected dimensions for a finite-dim matrix.

The import is changed to linear_algebra.finite_dimension,
which brings in the previous linear_algebra.dimension import.

---
<!-- put comments you want to keep out of the PR commit here -->
Relies on #3012
