### PR TITLE
[Merged by Bors] - chore(algebra/field): deduplicate with group_with_zero

### DIFF
--- a/src/algebra/continued_fractions/convergents_equiv.lean
+++ b/src/algebra/continued_fractions/convergents_equiv.lean
@@ -318,7 +318,7 @@ begin
         { simp [*, (continuants_aux_eq_continuants_aux_squash_gcf_of_le $ le_refl $ n' + 1).symm,
             (continuants_aux_eq_continuants_aux_squash_gcf_of_le n'.le_succ).symm] },
         symmetry,
-        simpa only [eq1, eq2, eq3, eq4, mul_div_cancel'' _  b_ne_zero] },
+        simpa only [eq1, eq2, eq3, eq4, mul_div_cancel _  b_ne_zero] },
       field_simp [b_ne_zero],
       congr' 1; ring } }
 end

--- a/src/algebra/field.lean
+++ b/src/algebra/field.lean
@@ -50,8 +50,6 @@ lemma mul_one_div_cancel (h : a ≠ 0) : a * (1 / a) = 1 := by simp [h]
 
 lemma one_div_mul_cancel (h : a ≠ 0) : (1 / a) * a = 1 := by simp [h]
 
-@[simp] lemma div_self (h : a ≠ 0) : a / a = 1 := by simp [h]
-
 lemma one_div_one : 1 / 1 = (1:α) :=
 div_self (ne.symm zero_ne_one)
 
@@ -83,10 +81,6 @@ calc 1⁻¹ = 1 * 1⁻¹ : by rw [one_mul]
      ... = (1:α)   : by simp
 
 local attribute [simp] one_inv_eq
-
-lemma div_one (a : α) : a / 1 = a := by simp
-
-lemma zero_div (a : α) : 0 / a = 0 := by simp
 
 -- note: integral domain has a "mul_ne_zero". a commutative division ring is an integral
 -- domain, but let's not define that class for now.
@@ -176,9 +170,6 @@ lemma div_helper (b : α) (h : a ≠ 0) : (1 / (a * b)) * a = 1 / b :=
 by simp only [division_def, mul_inv', one_mul, mul_assoc, inv_mul_cancel h, mul_one]
 
 lemma mul_div_cancel (a : α) {b : α} (hb : b ≠ 0) : a * b / b = a :=
-by simp [hb]
-
-lemma div_mul_cancel (a : α) {b : α} (hb : b ≠ 0) : a / b * b = a :=
 by simp [hb]
 
 @[field_simps] lemma div_div_eq_mul_div (a b c : α) : a / (b / c) = (a * c) / b :=

--- a/src/algebra/field.lean
+++ b/src/algebra/field.lean
@@ -29,26 +29,16 @@ instance division_ring.to_nonzero : nonzero α :=
 instance division_ring_has_div : has_div α :=
 ⟨λ a b, a * b⁻¹⟩
 
-lemma division_def (a b : α) : a / b = a * b⁻¹ :=
-rfl
-
-@[simp] lemma mul_inv_cancel (h : a ≠ 0) : a * a⁻¹ = 1 :=
-division_ring.mul_inv_cancel h
-
-@[simp] lemma inv_mul_cancel (h : a ≠ 0) : a⁻¹ * a = 1 :=
-division_ring.inv_mul_cancel h
+/-- Every division ring is a `group_with_zero`. -/
+@[priority 100] -- see Note [lower instance priority]
+instance division_ring.to_group_with_zero :
+  group_with_zero α :=
+{ .. ‹division_ring α›,
+  .. (infer_instance : semiring α) }
 
 @[simp] lemma one_div_eq_inv (a : α) : 1 / a = a⁻¹ := one_mul a⁻¹
 
 @[field_simps] lemma inv_eq_one_div (a : α) : a⁻¹ = 1 / a := by simp
-
-/-- Every division ring is a `group_with_zero`. -/
-@[priority 10] -- see Note [lower instance priority]
-instance division_ring.to_group_with_zero :
-  group_with_zero α :=
-{ mul_inv_cancel := λ _, mul_inv_cancel,
-  .. ‹division_ring α›,
-  .. (by apply_instance : semiring α) }
 
 local attribute [simp]
   division_def mul_comm mul_assoc

--- a/src/algebra/field.lean
+++ b/src/algebra/field.lean
@@ -44,41 +44,8 @@ local attribute [simp]
   division_def mul_comm mul_assoc
   mul_left_comm mul_inv_cancel inv_mul_cancel
 
-lemma div_eq_mul_one_div (a b : α) : a / b = a * (1 / b) := by simp
-
-lemma mul_one_div_cancel (h : a ≠ 0) : a * (1 / a) = 1 := by simp [h]
-
-lemma one_div_mul_cancel (h : a ≠ 0) : (1 / a) * a = 1 := by simp [h]
-
-lemma one_div_one : 1 / 1 = (1:α) :=
-div_self (ne.symm zero_ne_one)
-
-theorem inv_one : (1⁻¹ : α) = 1 := by rw [inv_eq_one_div, one_div_one]
-
-lemma mul_div_assoc (a b c : α) : (a * b) / c = a * (b / c) := by simp
-
 @[field_simps] lemma mul_div_assoc' (a b c : α) : a * (b / c) = (a * b) / c :=
 by simp [mul_div_assoc]
-
-lemma one_div_ne_zero (h : a ≠ 0) : 1 / a ≠ 0 :=
-assume : 1 / a = 0,
-have 0 = (1:α), from eq.symm (by rw [← mul_one_div_cancel h, this, mul_zero]),
-absurd this zero_ne_one
-
-lemma ne_zero_of_one_div_ne_zero (h : 1 / a ≠ 0) : a ≠ 0 :=
-assume ha : a = 0, begin rw [ha, div_zero] at h, contradiction end
-
-lemma inv_ne_zero (h : a ≠ 0) : a⁻¹ ≠ 0 :=
-by rw inv_eq_one_div; exact one_div_ne_zero h
-
-lemma eq_zero_of_one_div_eq_zero (h : 1 / a = 0) : a = 0 :=
-classical.by_cases
-  (assume ha, ha)
-  (assume ha, false.elim ((one_div_ne_zero ha) h))
-
-lemma one_inv_eq : 1⁻¹ = (1:α) :=
-calc 1⁻¹ = 1 * 1⁻¹ : by rw [one_mul]
-     ... = (1:α)   : by simp
 
 local attribute [simp] one_inv_eq
 
@@ -166,22 +133,6 @@ lemma one_div_div (a b : α) : 1 / (a / b) = b / a :=
 by rw [one_div_eq_inv, division_def, mul_inv',
        inv_inv', division_def]
 
-lemma div_helper (b : α) (h : a ≠ 0) : (1 / (a * b)) * a = 1 / b :=
-by simp only [division_def, mul_inv', one_mul, mul_assoc, inv_mul_cancel h, mul_one]
-
-lemma mul_div_cancel (a : α) {b : α} (hb : b ≠ 0) : a * b / b = a :=
-by simp [hb]
-
-@[field_simps] lemma div_div_eq_mul_div (a b c : α) : a / (b / c) = (a * c) / b :=
-by rw [div_eq_mul_one_div, one_div_div, ← mul_div_assoc]
-
-lemma div_mul_left (hb : b ≠ 0) : b / (a * b) = 1 / a :=
-by simp only [division_def, mul_inv', ← mul_assoc, mul_inv_cancel hb]
-
-lemma mul_div_mul_right (a : α) (b : α) {c : α} (hc : c ≠ 0) :
-      (a * c) / (b * c) = a / b :=
-by rw [mul_div_assoc, div_mul_left hc, ← mul_div_assoc, mul_one]
-
 @[field_simps] lemma div_add_div_same (a b c : α) : a / c + b / c = (a + b) / c :=
 eq.symm $ right_distrib a b (c⁻¹)
 
@@ -248,12 +199,6 @@ have (a + b / c) * c = a * c + b, by rw [right_distrib, (div_mul_cancel _ hc)],
 lemma mul_mul_div (a : α) {c : α} (hc : c ≠ 0) : a = a * c * (1 / c) :=
 by simp [hc]
 
-lemma eq_of_mul_eq_mul_of_nonzero_left {a b c : α} (h : a ≠ 0) (h₂ : a * b = a * c) : b = c :=
-by rw [← one_mul b, ← inv_mul_cancel h, mul_assoc, h₂, ← mul_assoc, inv_mul_cancel h, one_mul]
-
-lemma eq_of_mul_eq_mul_of_nonzero_right {a b c : α} (h : c ≠ 0) (h2 : a * c = b * c) : a = b :=
-by rw [← mul_one a, ← mul_inv_cancel h, ← mul_assoc, h2, mul_assoc, mul_inv_cancel h, mul_one]
-
 instance division_ring.to_domain : domain α :=
 { eq_zero_or_eq_zero_of_mul_eq_zero := λ a b h,
     classical.by_contradiction $ λ hn,
@@ -276,17 +221,10 @@ instance field.to_division_ring : division_ring α :=
 { inv_mul_cancel := λ _ h, by rw [mul_comm, field.mul_inv_cancel h]
   ..show field α, by apply_instance }
 
-lemma one_div_mul_one_div (a b : α) : (1 / a) * (1 / b) =  1 / (a * b) :=
-by rw [division_ring.one_div_mul_one_div, mul_comm b]
-
-lemma div_mul_right {a : α} (b : α) (ha : a ≠ 0) : a / (a * b) = 1 / b :=
-by rw [mul_comm, div_mul_left ha]
-
-lemma mul_div_cancel_left {a : α} (b : α) (ha : a ≠ 0) : a * b / a = b :=
-by rw [mul_comm a, (mul_div_cancel _ ha)]
-
-lemma mul_div_cancel' (a : α) {b : α} (hb : b ≠ 0) : b * (a / b) = a :=
-by rw [mul_comm, (div_mul_cancel _ hb)]
+/-- Every field is a `comm_group_with_zero`. -/
+instance field.to_comm_group_with_zero :
+  comm_group_with_zero α :=
+{ .. (_ : group_with_zero α), .. ‹field α› }
 
 lemma one_div_add_one_div {a b : α} (ha : a ≠ 0) (hb : b ≠ 0) : 1 / a + 1 / b = (a + b) / (a * b) :=
 by rw [add_comm, ← div_mul_left ha, ← div_mul_right _ hb,
@@ -294,26 +232,9 @@ by rw [add_comm, ← div_mul_left ha, ← div_mul_right _ hb,
 
 local attribute [simp] mul_assoc mul_comm mul_left_comm
 
-lemma div_mul_div (a b c d : α) :
-      (a / b) * (c / d) = (a * c) / (b * d) :=
-begin simp [division_def], rw [mul_inv', mul_comm d⁻¹] end
-
-lemma mul_div_mul_left (a b : α) {c : α} (hc : c ≠ 0) :
-      (c * a) / (c * b) = a / b :=
-by rw [← div_mul_div, div_self hc, one_mul]
-
-@[field_simps] lemma div_mul_eq_mul_div (a b c : α) : (b / c) * a = (b * a) / c :=
-by simp [division_def]
-
-lemma div_mul_eq_mul_div_comm (a b c : α) :
-      (b / c) * a = b * (a / c) :=
-by rw [div_mul_eq_mul_div, ← one_mul c, ← div_mul_div,
-       div_one, one_mul]
-
 lemma div_add_div (a : α) {b : α} (c : α) {d : α} (hb : b ≠ 0) (hd : d ≠ 0) :
       (a / b) + (c / d) = ((a * d) + (b * c)) / (b * d) :=
 by rw [← mul_div_mul_right _ b hd, ← mul_div_mul_left c d hb, div_add_div_same]
-
 
 @[field_simps] lemma div_sub_div (a : α) {b : α} (c : α) {d : α} (hb : b ≠ 0) (hd : d ≠ 0) :
   (a / b) - (c / d) = ((a * d) - (b * c)) / (b * d) :=
@@ -322,23 +243,6 @@ begin
   rw [neg_eq_neg_one_mul, ← mul_div_assoc, div_add_div _ _ hb hd,
       ← mul_assoc, mul_comm b, mul_assoc, ← neg_eq_neg_one_mul]
 end
-
-lemma mul_eq_mul_of_div_eq_div (a : α) {b : α} (c : α) {d : α} (hb : b ≠ 0)
-  (hd : d ≠ 0) (h : a / b = c / d) : a * d = c * b :=
-by rw [← mul_one (a*d), mul_assoc, mul_comm d, ← mul_assoc, ← div_self hb,
-       ← div_mul_eq_mul_div_comm, h, div_mul_eq_mul_div, div_mul_cancel _ hd]
-
-@[field_simps] lemma div_div_eq_div_mul (a b c : α) : (a / b) / c = a / (b * c) :=
-by rw [div_eq_mul_one_div, div_mul_div, mul_one]
-
-lemma div_div_div_div_eq (a : α) {b c d : α} :
-      (a / b) / (c / d) = (a * d) / (b * c) :=
-by rw [div_div_eq_mul_div, div_mul_eq_mul_div,
-       div_div_eq_div_mul]
-
-lemma div_mul_eq_div_mul_one_div (a b c : α) :
-      a / (b * c) = (a / b) * (1 / c) :=
-by rw [← div_div_eq_div_mul, ← div_eq_mul_one_div]
 
 lemma inv_add_inv {a b : α} (ha : a ≠ 0) (hb : b ≠ 0) : a⁻¹ + b⁻¹ = (a + b) / (a * b) :=
 by rw [inv_eq_one_div, inv_eq_one_div, one_div_add_one_div ha hb]
@@ -357,11 +261,6 @@ by rwa [add_comm, add_div', add_comm]
 
 @[field_simps] lemma div_sub' (a b c : α) (hc : c ≠ 0) : a / c - b = (a - c * b) / c :=
 by simpa using div_sub_div a b hc one_ne_zero
-
-/-- Every field is a `comm_group_with_zero`. -/
-instance field.to_comm_group_with_zero :
-  comm_group_with_zero α :=
-{ .. (_ : group_with_zero α), .. ‹field α› }
 
 @[priority 100] -- see Note [lower instance priority]
 instance field.to_integral_domain : integral_domain α :=

--- a/src/algebra/group_with_zero.lean
+++ b/src/algebra/group_with_zero.lean
@@ -73,13 +73,15 @@ end prio
 lemma div_eq_mul_inv {G₀ : Type*} [group_with_zero G₀] {a b : G₀} :
   a / b = a * b⁻¹ := rfl
 
+alias div_eq_mul_inv ← division_def
+
 section group_with_zero
 variables {G₀ : Type*} [group_with_zero G₀]
 
 @[simp] lemma inv_zero : (0 : G₀)⁻¹ = 0 :=
 group_with_zero.inv_zero
 
-@[simp] lemma mul_inv_cancel' (a : G₀) (h : a ≠ 0) : a * a⁻¹ = 1 :=
+@[simp] lemma mul_inv_cancel {a : G₀} (h : a ≠ 0) : a * a⁻¹ = 1 :=
 group_with_zero.mul_inv_cancel a h
 
 @[simp] lemma mul_inv_cancel_assoc_left (a b : G₀) (h : b ≠ 0) :
@@ -93,9 +95,9 @@ calc a * (a⁻¹ * b) = (a * a⁻¹) * b : (mul_assoc _ _ _).symm
                ... = b             : by simp [h]
 
 lemma inv_ne_zero' {a : G₀} (h : a ≠ 0) : a⁻¹ ≠ 0 :=
-assume a_eq_0, by simpa [a_eq_0] using mul_inv_cancel' a h
+assume a_eq_0, by simpa [a_eq_0] using mul_inv_cancel h
 
-@[simp] lemma inv_mul_cancel' (a : G₀) (h : a ≠ 0) : a⁻¹ * a = 1 :=
+@[simp] lemma inv_mul_cancel {a : G₀} (h : a ≠ 0) : a⁻¹ * a = 1 :=
 calc a⁻¹ * a = (a⁻¹ * a) * a⁻¹ * a⁻¹⁻¹ : by simp [inv_ne_zero' h]
          ... = a⁻¹ * a⁻¹⁻¹             : by simp [h]
          ... = 1                       : by simp [inv_ne_zero' h]
@@ -125,7 +127,7 @@ begin
   classical,
   by_cases h : a = 0,
   { rw [h, inv_zero, mul_zero] },
-  { rw [mul_assoc, mul_inv_cancel' a h, mul_one] }
+  { rw [mul_assoc, mul_inv_cancel h, mul_one] }
 end
 
 /-- Multiplying `a` by its inverse and then by itself results in `a`
@@ -135,7 +137,7 @@ begin
   classical,
   by_cases h : a = 0,
   { rw [h, inv_zero, mul_zero] },
-  { rw [mul_inv_cancel' a h, one_mul] }
+  { rw [mul_inv_cancel h, one_mul] }
 end
 
 /-- Multiplying `a⁻¹` by `a` twice results in `a` (whether or not `a`
@@ -145,7 +147,7 @@ begin
   classical,
   by_cases h : a = 0,
   { rw [h, inv_zero, mul_zero] },
-  { rw [inv_mul_cancel' a h, one_mul] }
+  { rw [inv_mul_cancel h, one_mul] }
 end
 
 /-- Multiplying `a` by itself and then dividing by itself results in
@@ -192,10 +194,10 @@ lemma inv_eq_iff {g h : G₀} : g⁻¹ = h ↔ h⁻¹ = g :=
 by rw [← inv_inj'', eq_comm, inv_inv']
 
 @[simp] lemma coe_unit_mul_inv' (a : units G₀) : (a : G₀) * a⁻¹ = 1 :=
-mul_inv_cancel' _ $ ne_zero_of_mul_right_eq_one' _ (a⁻¹ : units G₀) $ by simp
+mul_inv_cancel $ ne_zero_of_mul_right_eq_one' _ (a⁻¹ : units G₀) $ by simp
 
 @[simp] lemma coe_unit_inv_mul' (a : units G₀) : (a⁻¹ : G₀) * a = 1 :=
-inv_mul_cancel' _ $ ne_zero_of_mul_right_eq_one' _ (a⁻¹ : units G₀) $ by simp
+inv_mul_cancel $ ne_zero_of_mul_right_eq_one' _ (a⁻¹ : units G₀) $ by simp
 
 @[simp] lemma unit_ne_zero (a : units G₀) : (a : G₀) ≠ 0 :=
 assume a_eq_0, zero_ne_one $
@@ -213,12 +215,12 @@ variables {a b : G₀}
   or the `/ₚ` operation, it is possible to write a division
   as a partial function with three arguments. -/
 def mk0 (a : G₀) (ha : a ≠ 0) : units G₀ :=
-⟨a, a⁻¹, mul_inv_cancel' _ ha, inv_mul_cancel' _ ha⟩
+⟨a, a⁻¹, mul_inv_cancel ha, inv_mul_cancel ha⟩
 
 @[simp] lemma coe_mk0 {a : G₀} (h : a ≠ 0) : (mk0 a h : G₀) = a := rfl
 
 @[simp] theorem inv_eq_inv (u : units G₀) : (↑u⁻¹ : G₀) = u⁻¹ :=
-(mul_right_inj u).1 $ by { rw [units.mul_inv, mul_inv_cancel'], apply unit_ne_zero }
+(mul_right_inj u).1 $ by { rw [units.mul_inv, mul_inv_cancel], apply unit_ne_zero }
 
 @[simp] lemma mk0_coe (u : units G₀) (h : (u : G₀) ≠ 0) : mk0 (u : G₀) h = u :=
 units.ext rfl
@@ -293,7 +295,7 @@ begin
   simp [mul_assoc, hx, hy]
 end
 
-@[simp] lemma div_self' {a : G₀} (h : a ≠ 0) : a / a = 1 := mul_inv_cancel' _ h
+@[simp] lemma div_self' {a : G₀} (h : a ≠ 0) : a / a = 1 := mul_inv_cancel h
 
 @[simp] lemma div_one' (a : G₀) : a / 1 = a :=
 show a * 1⁻¹ = a, by rw [inv_one', mul_one]
@@ -419,7 +421,7 @@ by rw [one_div_mul_one_div_rev, mul_comm b]
 
 lemma div_mul_right' {a : G₀} (b : G₀) (ha : a ≠ 0) : a / (a * b) = 1 / b :=
 eq.symm (calc
-    1 / b = a * ((1 / a) * (1 / b)) : by rw [← mul_assoc, one_div a, mul_inv_cancel' a ha, one_mul]
+    1 / b = a * ((1 / a) * (1 / b)) : by rw [← mul_assoc, one_div a, mul_inv_cancel ha, one_mul]
       ... = a * (1 / (b * a))       : by rw one_div_mul_one_div_rev
       ... = a * (a * b)⁻¹           : by rw [← one_div, mul_comm a b])
 

--- a/src/algebra/group_with_zero.lean
+++ b/src/algebra/group_with_zero.lean
@@ -295,19 +295,18 @@ begin
   simp [mul_assoc, hx, hy]
 end
 
-@[simp] lemma div_self' {a : G₀} (h : a ≠ 0) : a / a = 1 := mul_inv_cancel h
+@[simp] lemma div_self {a : G₀} (h : a ≠ 0) : a / a = 1 := mul_inv_cancel h
 
-@[simp] lemma div_one' (a : G₀) : a / 1 = a :=
-show a * 1⁻¹ = a, by rw [inv_one', mul_one]
+@[simp] lemma div_one (a : G₀) : a / 1 = a := by simp [div_eq_mul_inv]
 
 lemma one_div (a : G₀) : 1 / a = a⁻¹ := one_mul _
 
-@[simp] lemma zero_div' (a : G₀) : 0 / a = 0 := zero_mul _
+@[simp] lemma zero_div (a : G₀) : 0 / a = 0 := zero_mul _
 
 @[simp] lemma div_zero (a : G₀) : a / 0 = 0 :=
 show a * 0⁻¹ = 0, by rw [inv_zero, mul_zero]
 
-@[simp] lemma div_mul_cancel' (a : G₀) {b : G₀} (h : b ≠ 0) : a / b * b = a :=
+@[simp] lemma div_mul_cancel (a : G₀) {b : G₀} (h : b ≠ 0) : a / b * b = a :=
 inv_mul_cancel_assoc_left a b h
 
 @[simp] lemma mul_div_cancel'' (a : G₀) {b : G₀} (h : b ≠ 0) : a * b / b = a :=
@@ -328,7 +327,7 @@ lemma one_div_mul_cancel' {a : G₀} (h : a ≠ 0) : (1 / a) * a = 1 :=
 by simp [h]
 
 lemma one_div_one' : 1 / 1 = (1:G₀) :=
-div_self' (ne.symm zero_ne_one)
+div_self (ne.symm zero_ne_one)
 
 lemma one_div_ne_zero' {a : G₀} (h : a ≠ 0) : 1 / a ≠ 0 :=
 assume : 1 / a = 0,
@@ -351,7 +350,7 @@ have a ≠ 0, from
   assume : a = 0,
   have 0 = (1:G₀), by rwa [this, mul_zero] at h,
     absurd this zero_ne_one,
-by rw [← h, mul_div_assoc'', div_self' this, mul_one]
+by rw [← h, mul_div_assoc'', div_self this, mul_one]
 
 @[simp] lemma one_div_div' (a b : G₀) : 1 / (a / b) = b / a :=
 by rw [one_div, div_eq_mul_inv, mul_inv_rev', inv_inv', div_eq_mul_inv]
@@ -392,7 +391,7 @@ lemma div_ne_zero (ha : a ≠ 0) (hb : b ≠ 0) : a / b ≠ 0 :=
 mul_ne_zero'' ha (inv_ne_zero' hb)
 
 lemma div_ne_zero_iff (hb : b ≠ 0) : a / b ≠ 0 ↔ a ≠ 0 :=
-⟨mt (λ h, by rw [h, zero_div']), λ ha, div_ne_zero ha hb⟩
+⟨mt (λ h, by rw [h, zero_div]), λ ha, div_ne_zero ha hb⟩
 
 lemma div_eq_zero_iff (hb : b ≠ 0) : a / b = 0 ↔ a = 0 :=
 by haveI := classical.prop_decidable; exact
@@ -405,7 +404,7 @@ lemma mul_left_inj' (hc : c ≠ 0) : a * c = b * c ↔ a = b :=
 by rw [← inv_inv' c, ← div_eq_mul_inv, ← div_eq_mul_inv, div_left_inj' (inv_ne_zero' hc)]
 
 lemma div_eq_iff_mul_eq (hb : b ≠ 0) : a / b = c ↔ c * b = a :=
-⟨λ h, by rw [← h, div_mul_cancel' _ hb],
+⟨λ h, by rw [← h, div_mul_cancel _ hb],
  λ h, by rw [← h, mul_div_cancel'' _ hb]⟩
 
 end group_with_zero
@@ -432,7 +431,7 @@ lemma mul_div_cancel_left' {a : G₀} (b : G₀) (ha : a ≠ 0) : a * b / a = b 
 by rw [mul_comm a, (mul_div_cancel'' _ ha)]
 
 lemma mul_div_cancel''' (a : G₀) {b : G₀} (hb : b ≠ 0) : b * (a / b) = a :=
-by rw [mul_comm, (div_mul_cancel' _ hb)]
+by rw [mul_comm, (div_mul_cancel _ hb)]
 
 local attribute [simp] mul_assoc mul_comm mul_left_comm
 
@@ -442,7 +441,7 @@ by { simp [div_eq_mul_inv], rw [mul_inv_rev', mul_comm d⁻¹] }
 
 lemma mul_div_mul_left' (a b : G₀) {c : G₀} (hc : c ≠ 0) :
       (c * a) / (c * b) = a / b :=
-by rw [← div_mul_div', div_self' hc, one_mul]
+by rw [← div_mul_div', div_self hc, one_mul]
 
 lemma mul_div_mul_right' (a b : G₀) {c : G₀} (hc : c ≠ 0) :
       (a * c) / (b * c) = a / b :=
@@ -454,12 +453,12 @@ by simp [div_eq_mul_inv]
 lemma div_mul_eq_mul_div_comm' (a b c : G₀) :
       (b / c) * a = b * (a / c) :=
 by rw [div_mul_eq_mul_div', ← one_mul c, ← div_mul_div',
-       div_one', one_mul]
+       div_one, one_mul]
 
 lemma mul_eq_mul_of_div_eq_div' (a : G₀) {b : G₀} (c : G₀) {d : G₀} (hb : b ≠ 0)
       (hd : d ≠ 0) (h : a / b = c / d) : a * d = c * b :=
-by rw [← mul_one (a*d), mul_assoc, mul_comm d, ← mul_assoc, ← div_self' hb,
-       ← div_mul_eq_mul_div_comm', h, div_mul_eq_mul_div', div_mul_cancel' _ hd]
+by rw [← mul_one (a*d), mul_assoc, mul_comm d, ← mul_assoc, ← div_self hb,
+       ← div_mul_eq_mul_div_comm', h, div_mul_eq_mul_div', div_mul_cancel _ hd]
 
 lemma div_div_eq_mul_div' (a b c : G₀) :
       a / (b / c) = (a * c) / b :=
@@ -486,10 +485,10 @@ begin
 end
 
 lemma eq_of_mul_eq_mul_of_nonzero_left' {a b c : G₀} (h : a ≠ 0) (h₂ : a * b = a * c) : b = c :=
-by rw [← one_mul b, ← div_self' h, div_mul_eq_mul_div', h₂, mul_div_cancel_left' _ h]
+by rw [← one_mul b, ← div_self h, div_mul_eq_mul_div', h₂, mul_div_cancel_left' _ h]
 
 lemma eq_of_mul_eq_mul_of_nonzero_right' {a b c : G₀} (h : c ≠ 0) (h2 : a * c = b * c) : a = b :=
-by rw [← mul_one a, ← div_self' h, ← mul_div_assoc'', h2, mul_div_cancel'' _ h]
+by rw [← mul_one a, ← div_self h, ← mul_div_assoc'', h2, mul_div_cancel'' _ h]
 
 lemma ne_zero_of_one_div_ne_zero' {a : G₀} (h : 1 / a ≠ 0) : a ≠ 0 :=
 assume ha : a = 0, begin rw [ha, div_zero] at h, contradiction end
@@ -525,17 +524,17 @@ lemma div_right_comm' (a : G₀) : (a / b) / c = (a / c) / b :=
 by rw [div_div_eq_div_mul', div_div_eq_div_mul', mul_comm]
 
 lemma div_div_div_cancel_right' (a : G₀) (hc : c ≠ 0) : (a / c) / (b / c) = a / b :=
-by rw [div_div_eq_mul_div', div_mul_cancel' _ hc]
+by rw [div_div_eq_mul_div', div_mul_cancel _ hc]
 
 lemma div_mul_div_cancel' (a : G₀) (hc : c ≠ 0) : (a / c) * (c / b) = a / b :=
-by rw [← mul_div_assoc'', div_mul_cancel' _ hc]
+by rw [← mul_div_assoc'', div_mul_cancel _ hc]
 
 @[field_simps] lemma div_eq_div_iff (hb : b ≠ 0) (hd : d ≠ 0) : a / b = c / d ↔ a * d = c * b :=
 calc a / b = c / d ↔ a / b * (b * d) = c / d * (b * d) :
 by rw [mul_left_inj' (mul_ne_zero'' hb hd)]
                ... ↔ a * d = c * b :
-by rw [← mul_assoc, div_mul_cancel' _ hb,
-      ← mul_assoc, mul_right_comm, div_mul_cancel' _ hd]
+by rw [← mul_assoc, div_mul_cancel _ hb,
+      ← mul_assoc, mul_right_comm, div_mul_cancel _ hd]
 
 @[field_simps] lemma div_eq_iff (hb : b ≠ 0) : a / b = c ↔ a = c * b :=
 by simpa using @div_eq_div_iff _ _ a b c 1 hb one_ne_zero

--- a/src/algebra/group_with_zero.lean
+++ b/src/algebra/group_with_zero.lean
@@ -122,7 +122,7 @@ begin
   classical,
   by_cases h : a = 0, { simp [h] },
   calc a⁻¹⁻¹ = a * (a⁻¹ * a⁻¹⁻¹) : by simp [h]
-        ... = a                 : by simp [inv_ne_zero h]
+         ... = a                 : by simp [inv_ne_zero h]
 end
 
 /-- Multiplying `a` by itself and then by its inverse results in `a`
@@ -427,7 +427,7 @@ variables {G₀ : Type*} [comm_group_with_zero G₀] {a b c : G₀}
 lemma mul_inv'' : (a * b)⁻¹ = a⁻¹ * b⁻¹ :=
 by rw [mul_inv_rev', mul_comm]
 
-lemma one_div_mul_one_div (a b : G₀) : (1 / a) * (1 / b) =  1 / (a * b) :=
+lemma one_div_mul_one_div (a b : G₀) : (1 / a) * (1 / b) = 1 / (a * b) :=
 by rw [one_div_mul_one_div_rev, mul_comm b]
 
 lemma div_mul_right {a : G₀} (b : G₀) (ha : a ≠ 0) : a / (a * b) = 1 / b :=
@@ -497,7 +497,7 @@ assume ha : a = 0, begin rw [ha, div_zero] at h, contradiction end
 lemma eq_zero_of_one_div_eq_zero {a : G₀} (h : 1 / a = 0) : a = 0 :=
 classical.by_cases
   (assume ha, ha)
-  (assume ha, false.elim ((one_div_ne_zero ha) h))
+  (assume ha, ((one_div_ne_zero ha) h).elim)
 
 lemma div_helper {a : G₀} (b : G₀) (h : a ≠ 0) : (1 / (a * b)) * a = 1 / b :=
 by rw [div_mul_eq_mul_div, one_mul, div_mul_right _ h]

--- a/src/algebra/group_with_zero.lean
+++ b/src/algebra/group_with_zero.lean
@@ -42,7 +42,8 @@ set_option default_priority 10 -- see Note [default priority]
 
 /-- A type `M` is a commutative “monoid with zero”
 if it is a commutative monoid with zero element. -/
-@[protect_proj] class comm_monoid_with_zero (G₀ : Type*) extends comm_monoid G₀, monoid_with_zero G₀.
+@[protect_proj]
+class comm_monoid_with_zero (G₀ : Type*) extends comm_monoid G₀, monoid_with_zero G₀.
 
 /-- A type `G₀` is a “group with zero” if it is a monoid with zero element (distinct from `1`)
 such that every nonzero element is invertible.
@@ -94,13 +95,13 @@ calc (a * b) * b⁻¹ = a * (b * b⁻¹) : mul_assoc _ _ _
 calc a * (a⁻¹ * b) = (a * a⁻¹) * b : (mul_assoc _ _ _).symm
                ... = b             : by simp [h]
 
-lemma inv_ne_zero' {a : G₀} (h : a ≠ 0) : a⁻¹ ≠ 0 :=
+lemma inv_ne_zero {a : G₀} (h : a ≠ 0) : a⁻¹ ≠ 0 :=
 assume a_eq_0, by simpa [a_eq_0] using mul_inv_cancel h
 
 @[simp] lemma inv_mul_cancel {a : G₀} (h : a ≠ 0) : a⁻¹ * a = 1 :=
-calc a⁻¹ * a = (a⁻¹ * a) * a⁻¹ * a⁻¹⁻¹ : by simp [inv_ne_zero' h]
+calc a⁻¹ * a = (a⁻¹ * a) * a⁻¹ * a⁻¹⁻¹ : by simp [inv_ne_zero h]
          ... = a⁻¹ * a⁻¹⁻¹             : by simp [h]
-         ... = 1                       : by simp [inv_ne_zero' h]
+         ... = 1                       : by simp [inv_ne_zero h]
 
 @[simp] lemma inv_mul_cancel_assoc_left (a b : G₀) (h : b ≠ 0) :
   (a * b⁻¹) * b = a :=
@@ -112,12 +113,16 @@ calc (a * b⁻¹) * b = a * (b⁻¹ * b) : mul_assoc _ _ _
 calc a⁻¹ * (a * b) = (a⁻¹ * a) * b : (mul_assoc _ _ _).symm
                ... = b             : by simp [h]
 
+lemma one_inv_eq : 1⁻¹ = (1:G₀) :=
+calc 1⁻¹ = 1 * 1⁻¹ : by rw [one_mul]
+     ... = (1:G₀)  : by simp
+
 @[simp] lemma inv_inv' (a : G₀) : a⁻¹⁻¹ = a :=
 begin
   classical,
   by_cases h : a = 0, { simp [h] },
   calc a⁻¹⁻¹ = a * (a⁻¹ * a⁻¹⁻¹) : by simp [h]
-        ... = a                 : by simp [inv_ne_zero' h]
+        ... = a                 : by simp [inv_ne_zero h]
 end
 
 /-- Multiplying `a` by itself and then by its inverse results in `a`
@@ -180,7 +185,7 @@ lemma eq_inv_of_mul_left_eq_one' (a b : G₀) (h : a * b = 1) :
 calc a = (a * b) * b⁻¹ : (mul_inv_cancel_assoc_left _ _ (ne_zero_of_mul_left_eq_one' a b h)).symm
    ... = b⁻¹ : by simp [h]
 
-@[simp] lemma inv_one' : (1 : G₀)⁻¹ = 1 :=
+@[simp] lemma inv_one : (1 : G₀)⁻¹ = 1 :=
 eq.symm $ eq_inv_of_mul_right_eq_one' _ _ (mul_one 1)
 
 lemma inv_injective' : function.injective (@has_inv.inv G₀ _) :=
@@ -309,29 +314,29 @@ show a * 0⁻¹ = 0, by rw [inv_zero, mul_zero]
 @[simp] lemma div_mul_cancel (a : G₀) {b : G₀} (h : b ≠ 0) : a / b * b = a :=
 inv_mul_cancel_assoc_left a b h
 
-@[simp] lemma mul_div_cancel'' (a : G₀) {b : G₀} (h : b ≠ 0) : a * b / b = a :=
+@[simp] lemma mul_div_cancel (a : G₀) {b : G₀} (h : b ≠ 0) : a * b / b = a :=
 mul_inv_cancel_assoc_left a b h
 
-lemma mul_div_assoc'' {a b c : G₀} : a * b / c = a * (b / c) :=
+lemma mul_div_assoc {a b c : G₀} : a * b / c = a * (b / c) :=
 mul_assoc _ _ _
 
 local attribute [simp] div_eq_mul_inv mul_comm mul_assoc mul_left_comm
 
-lemma div_eq_mul_one_div' (a b : G₀) : a / b = a * (1 / b) :=
+lemma div_eq_mul_one_div (a b : G₀) : a / b = a * (1 / b) :=
 by simp
 
-lemma mul_one_div_cancel' {a : G₀} (h : a ≠ 0) : a * (1 / a) = 1 :=
+lemma mul_one_div_cancel {a : G₀} (h : a ≠ 0) : a * (1 / a) = 1 :=
 by simp [h]
 
-lemma one_div_mul_cancel' {a : G₀} (h : a ≠ 0) : (1 / a) * a = 1 :=
+lemma one_div_mul_cancel {a : G₀} (h : a ≠ 0) : (1 / a) * a = 1 :=
 by simp [h]
 
-lemma one_div_one' : 1 / 1 = (1:G₀) :=
+lemma one_div_one : 1 / 1 = (1:G₀) :=
 div_self (ne.symm zero_ne_one)
 
-lemma one_div_ne_zero' {a : G₀} (h : a ≠ 0) : 1 / a ≠ 0 :=
+lemma one_div_ne_zero {a : G₀} (h : a ≠ 0) : 1 / a ≠ 0 :=
 assume : 1 / a = 0,
-have 0 = (1:G₀), from eq.symm (by rw [← mul_one_div_cancel' h, this, mul_zero]),
+have 0 = (1:G₀), from eq.symm (by rw [← mul_one_div_cancel h, this, mul_zero]),
 absurd this zero_ne_one
 
 lemma mul_ne_zero_comm'' {a b : G₀} (h : a * b ≠ 0) : b * a ≠ 0 :=
@@ -342,7 +347,7 @@ have a ≠ 0, from
    assume : a = 0,
    have 0 = (1:G₀), by rwa [this, zero_mul] at h,
       absurd this zero_ne_one,
-have b = (1 / a) * a * b, by rw [one_div_mul_cancel' this, one_mul],
+have b = (1 / a) * a * b, by rw [one_div_mul_cancel this, one_mul],
 show b = 1 / a, by rwa [mul_assoc, h, mul_one] at this
 
 lemma eq_one_div_of_mul_eq_one_left' {a b : G₀} (h : b * a = 1) : b = 1 / a :=
@@ -350,7 +355,7 @@ have a ≠ 0, from
   assume : a = 0,
   have 0 = (1:G₀), by rwa [this, mul_zero] at h,
     absurd this zero_ne_one,
-by rw [← h, mul_div_assoc'', div_self this, mul_one]
+by rw [← h, mul_div_assoc, div_self this, mul_one]
 
 @[simp] lemma one_div_div' (a b : G₀) : 1 / (a / b) = b / a :=
 by rw [one_div, div_eq_mul_inv, mul_inv_rev', inv_inv', div_eq_mul_inv]
@@ -388,7 +393,7 @@ lemma inv_div_left : a⁻¹ / b = (b * a)⁻¹ :=
 (mul_inv_rev' _ _).symm
 
 lemma div_ne_zero (ha : a ≠ 0) (hb : b ≠ 0) : a / b ≠ 0 :=
-mul_ne_zero'' ha (inv_ne_zero' hb)
+mul_ne_zero'' ha (inv_ne_zero hb)
 
 lemma div_ne_zero_iff (hb : b ≠ 0) : a / b ≠ 0 ↔ a ≠ 0 :=
 ⟨mt (λ h, by rw [h, zero_div]), λ ha, div_ne_zero ha hb⟩
@@ -401,11 +406,18 @@ lemma div_left_inj' (hc : c ≠ 0) : a / c = b / c ↔ a = b :=
 by rw [← divp_mk0 _ hc, ← divp_mk0 _ hc, divp_left_inj]
 
 lemma mul_left_inj' (hc : c ≠ 0) : a * c = b * c ↔ a = b :=
-by rw [← inv_inv' c, ← div_eq_mul_inv, ← div_eq_mul_inv, div_left_inj' (inv_ne_zero' hc)]
+by rw [← inv_inv' c, ← div_eq_mul_inv, ← div_eq_mul_inv, div_left_inj' (inv_ne_zero hc)]
 
 lemma div_eq_iff_mul_eq (hb : b ≠ 0) : a / b = c ↔ c * b = a :=
 ⟨λ h, by rw [← h, div_mul_cancel _ hb],
- λ h, by rw [← h, mul_div_cancel'' _ hb]⟩
+ λ h, by rw [← h, mul_div_cancel _ hb]⟩
+
+lemma div_mul_left {a b : G₀} (hb : b ≠ 0) : b / (a * b) = 1 / a :=
+by simp only [div_eq_mul_inv, mul_inv_rev', mul_inv_cancel_assoc_right _ _ hb, one_mul]
+
+lemma mul_div_mul_right (a b : G₀) {c : G₀} (hc : c ≠ 0) :
+      (a * c) / (b * c) = a / b :=
+by simp only [div_eq_mul_inv, mul_inv_rev', mul_assoc, mul_inv_cancel_assoc_right _ _ hc]
 
 end group_with_zero
 
@@ -415,91 +427,80 @@ variables {G₀ : Type*} [comm_group_with_zero G₀] {a b c : G₀}
 lemma mul_inv'' : (a * b)⁻¹ = a⁻¹ * b⁻¹ :=
 by rw [mul_inv_rev', mul_comm]
 
-lemma one_div_mul_one_div' (a b : G₀) : (1 / a) * (1 / b) =  1 / (a * b) :=
+lemma one_div_mul_one_div (a b : G₀) : (1 / a) * (1 / b) =  1 / (a * b) :=
 by rw [one_div_mul_one_div_rev, mul_comm b]
 
-lemma div_mul_right' {a : G₀} (b : G₀) (ha : a ≠ 0) : a / (a * b) = 1 / b :=
-eq.symm (calc
-    1 / b = a * ((1 / a) * (1 / b)) : by rw [← mul_assoc, one_div a, mul_inv_cancel ha, one_mul]
-      ... = a * (1 / (b * a))       : by rw one_div_mul_one_div_rev
-      ... = a * (a * b)⁻¹           : by rw [← one_div, mul_comm a b])
+lemma div_mul_right {a : G₀} (b : G₀) (ha : a ≠ 0) : a / (a * b) = 1 / b :=
+by rw [mul_comm, div_mul_left ha]
 
-lemma div_mul_left' {a b : G₀} (hb : b ≠ 0) : b / (a * b) = 1 / a :=
-by rw [mul_comm a, div_mul_right' _ hb]
+lemma mul_div_cancel_left {a : G₀} (b : G₀) (ha : a ≠ 0) : a * b / a = b :=
+by rw [mul_comm a, (mul_div_cancel _ ha)]
 
-lemma mul_div_cancel_left' {a : G₀} (b : G₀) (ha : a ≠ 0) : a * b / a = b :=
-by rw [mul_comm a, (mul_div_cancel'' _ ha)]
-
-lemma mul_div_cancel''' (a : G₀) {b : G₀} (hb : b ≠ 0) : b * (a / b) = a :=
+lemma mul_div_cancel' (a : G₀) {b : G₀} (hb : b ≠ 0) : b * (a / b) = a :=
 by rw [mul_comm, (div_mul_cancel _ hb)]
 
 local attribute [simp] mul_assoc mul_comm mul_left_comm
 
-lemma div_mul_div' (a b c d : G₀) :
+lemma div_mul_div (a b c d : G₀) :
       (a / b) * (c / d) = (a * c) / (b * d) :=
 by { simp [div_eq_mul_inv], rw [mul_inv_rev', mul_comm d⁻¹] }
 
-lemma mul_div_mul_left' (a b : G₀) {c : G₀} (hc : c ≠ 0) :
+lemma mul_div_mul_left (a b : G₀) {c : G₀} (hc : c ≠ 0) :
       (c * a) / (c * b) = a / b :=
-by rw [← div_mul_div', div_self hc, one_mul]
+by rw [mul_comm c, mul_comm c, mul_div_mul_right _ _ hc]
 
-lemma mul_div_mul_right' (a b : G₀) {c : G₀} (hc : c ≠ 0) :
-      (a * c) / (b * c) = a / b :=
-by rw [mul_comm a, mul_comm b, mul_div_mul_left' _ _ hc]
-
-lemma div_mul_eq_mul_div' (a b c : G₀) : (b / c) * a = (b * a) / c :=
+@[field_simps] lemma div_mul_eq_mul_div (a b c : G₀) : (b / c) * a = (b * a) / c :=
 by simp [div_eq_mul_inv]
 
-lemma div_mul_eq_mul_div_comm' (a b c : G₀) :
+lemma div_mul_eq_mul_div_comm (a b c : G₀) :
       (b / c) * a = b * (a / c) :=
-by rw [div_mul_eq_mul_div', ← one_mul c, ← div_mul_div',
-       div_one, one_mul]
+by rw [div_mul_eq_mul_div, ← one_mul c, ← div_mul_div, div_one, one_mul]
 
-lemma mul_eq_mul_of_div_eq_div' (a : G₀) {b : G₀} (c : G₀) {d : G₀} (hb : b ≠ 0)
+lemma mul_eq_mul_of_div_eq_div (a : G₀) {b : G₀} (c : G₀) {d : G₀} (hb : b ≠ 0)
       (hd : d ≠ 0) (h : a / b = c / d) : a * d = c * b :=
 by rw [← mul_one (a*d), mul_assoc, mul_comm d, ← mul_assoc, ← div_self hb,
-       ← div_mul_eq_mul_div_comm', h, div_mul_eq_mul_div', div_mul_cancel _ hd]
+       ← div_mul_eq_mul_div_comm, h, div_mul_eq_mul_div, div_mul_cancel _ hd]
 
-lemma div_div_eq_mul_div' (a b c : G₀) :
+@[field_simps] lemma div_div_eq_mul_div (a b c : G₀) :
       a / (b / c) = (a * c) / b :=
-by rw [div_eq_mul_one_div', one_div_div', ← mul_div_assoc'']
+by rw [div_eq_mul_one_div, one_div_div', ← mul_div_assoc]
 
-lemma div_div_eq_div_mul' (a b c : G₀) :
+@[field_simps] lemma div_div_eq_div_mul (a b c : G₀) :
       (a / b) / c = a / (b * c) :=
-by rw [div_eq_mul_one_div', div_mul_div', mul_one]
+by rw [div_eq_mul_one_div, div_mul_div, mul_one]
 
-lemma div_div_div_div_eq' (a : G₀) {b c d : G₀} :
+lemma div_div_div_div_eq (a : G₀) {b c d : G₀} :
       (a / b) / (c / d) = (a * d) / (b * c) :=
-by rw [div_div_eq_mul_div', div_mul_eq_mul_div', div_div_eq_div_mul']
+by rw [div_div_eq_mul_div, div_mul_eq_mul_div, div_div_eq_div_mul]
 
-lemma div_mul_eq_div_mul_one_div' (a b c : G₀) :
+lemma div_mul_eq_div_mul_one_div (a b c : G₀) :
       a / (b * c) = (a / b) * (1 / c) :=
-by rw [← div_div_eq_div_mul', ← div_eq_mul_one_div']
+by rw [← div_div_eq_div_mul, ← div_eq_mul_one_div]
 
 /-- Dividing `a` by the result of dividing `a` by itself results in
 `a` (whether or not `a` is zero). -/
 @[simp] lemma div_div_self (a : G₀) : a / (a / a) = a :=
 begin
-  rw div_div_eq_mul_div',
+  rw div_div_eq_mul_div,
   exact mul_self_div_self a
 end
 
-lemma eq_of_mul_eq_mul_of_nonzero_left' {a b c : G₀} (h : a ≠ 0) (h₂ : a * b = a * c) : b = c :=
-by rw [← one_mul b, ← div_self h, div_mul_eq_mul_div', h₂, mul_div_cancel_left' _ h]
+lemma eq_of_mul_eq_mul_of_nonzero_left {a b c : G₀} (h : a ≠ 0) (h₂ : a * b = a * c) : b = c :=
+by rw [← one_mul b, ← div_self h, div_mul_eq_mul_div, h₂, mul_div_cancel_left _ h]
 
-lemma eq_of_mul_eq_mul_of_nonzero_right' {a b c : G₀} (h : c ≠ 0) (h2 : a * c = b * c) : a = b :=
-by rw [← mul_one a, ← div_self h, ← mul_div_assoc'', h2, mul_div_cancel'' _ h]
+lemma eq_of_mul_eq_mul_of_nonzero_right {a b c : G₀} (h : c ≠ 0) (h2 : a * c = b * c) : a = b :=
+by rw [← mul_one a, ← div_self h, ← mul_div_assoc, h2, mul_div_cancel _ h]
 
-lemma ne_zero_of_one_div_ne_zero' {a : G₀} (h : 1 / a ≠ 0) : a ≠ 0 :=
+lemma ne_zero_of_one_div_ne_zero {a : G₀} (h : 1 / a ≠ 0) : a ≠ 0 :=
 assume ha : a = 0, begin rw [ha, div_zero] at h, contradiction end
 
-lemma eq_zero_of_one_div_eq_zero' {a : G₀} (h : 1 / a = 0) : a = 0 :=
+lemma eq_zero_of_one_div_eq_zero {a : G₀} (h : 1 / a = 0) : a = 0 :=
 classical.by_cases
   (assume ha, ha)
-  (assume ha, false.elim ((one_div_ne_zero' ha) h))
+  (assume ha, false.elim ((one_div_ne_zero ha) h))
 
-lemma div_helper' {a : G₀} (b : G₀) (h : a ≠ 0) : (1 / (a * b)) * a = 1 / b :=
-by rw [div_mul_eq_mul_div', one_mul, div_mul_right' _ h]
+lemma div_helper {a : G₀} (b : G₀) (h : a ≠ 0) : (1 / (a * b)) * a = 1 / b :=
+by rw [div_mul_eq_mul_div, one_mul, div_mul_right _ h]
 
 end comm_group_with_zero
 
@@ -512,22 +513,22 @@ lemma mul_div_right_comm (a b c : G₀) : (a * b) / c = (a / c) * b :=
 by rw [div_eq_mul_inv, mul_assoc, mul_comm b, ← mul_assoc]; refl
 
 lemma mul_comm_div' (a b c : G₀) : (a / b) * c = a * (c / b) :=
-by rw [← mul_div_assoc'', mul_div_right_comm]
+by rw [← mul_div_assoc, mul_div_right_comm]
 
 lemma div_mul_comm' (a b c : G₀) : (a / b) * c = (c / b) * a :=
-by rw [div_mul_eq_mul_div', mul_comm, mul_div_right_comm]
+by rw [div_mul_eq_mul_div, mul_comm, mul_div_right_comm]
 
 lemma mul_div_comm (a b c : G₀) : a * (b / c) = b * (a / c) :=
-by rw [← mul_div_assoc'', mul_comm, mul_div_assoc'']
+by rw [← mul_div_assoc, mul_comm, mul_div_assoc]
 
 lemma div_right_comm' (a : G₀) : (a / b) / c = (a / c) / b :=
-by rw [div_div_eq_div_mul', div_div_eq_div_mul', mul_comm]
+by rw [div_div_eq_div_mul, div_div_eq_div_mul, mul_comm]
 
 lemma div_div_div_cancel_right' (a : G₀) (hc : c ≠ 0) : (a / c) / (b / c) = a / b :=
-by rw [div_div_eq_mul_div', div_mul_cancel _ hc]
+by rw [div_div_eq_mul_div, div_mul_cancel _ hc]
 
 lemma div_mul_div_cancel' (a : G₀) (hc : c ≠ 0) : (a / c) * (c / b) = a / b :=
-by rw [← mul_div_assoc'', div_mul_cancel _ hc]
+by rw [← mul_div_assoc, div_mul_cancel _ hc]
 
 @[field_simps] lemma div_eq_div_iff (hb : b ≠ 0) (hd : d ≠ 0) : a / b = c / d ↔ a * d = c * b :=
 calc a / b = c / d ↔ a / b * (b * d) = c / d * (b * d) :
@@ -543,7 +544,7 @@ by simpa using @div_eq_div_iff _ _ a b c 1 hb one_ne_zero
 by simpa using @div_eq_div_iff _ _ c 1 a b one_ne_zero hb
 
 lemma div_div_cancel' (ha : a ≠ 0) : a / (a / b) = b :=
-by rw [div_eq_mul_inv, inv_div, mul_div_cancel''' _ ha]
+by rw [div_eq_mul_inv, inv_div, mul_div_cancel' _ ha]
 
 end comm_group_with_zero
 

--- a/src/algebra/group_with_zero_power.lean
+++ b/src/algebra/group_with_zero_power.lean
@@ -100,10 +100,10 @@ lemma fpow_add_one {a : G₀} (ha : a ≠ 0) : ∀ n : ℤ, a ^ (n + 1) = a ^ n 
 | -[1+0]     := by simp [int.neg_succ_of_nat_eq, ha]
 | -[1+(n+1)] := by rw [int.neg_succ_of_nat_eq, fpow_neg, neg_add, neg_add_cancel_right, fpow_neg,
   ← int.coe_nat_succ, fpow_coe_nat, fpow_coe_nat, pow_succ _ (n + 1), mul_inv_rev', mul_assoc,
-  inv_mul_cancel' a ha, mul_one]
+  inv_mul_cancel ha, mul_one]
 
 lemma fpow_sub_one {a : G₀} (ha : a ≠ 0) (n : ℤ) : a ^ (n - 1) = a ^ n * a⁻¹ :=
-calc a ^ (n - 1) = a ^ (n - 1) * a * a⁻¹ : by rw [mul_assoc, mul_inv_cancel' a ha, mul_one]
+calc a ^ (n - 1) = a ^ (n - 1) * a * a⁻¹ : by rw [mul_assoc, mul_inv_cancel ha, mul_one]
              ... = a^n * a⁻¹             : by rw [← fpow_add_one ha, sub_add_cancel]
 
 lemma fpow_add {a : G₀} (ha : a ≠ 0) (m n : ℤ) : a ^ (m + n) = a ^ m * a ^ n :=
@@ -180,7 +180,7 @@ theorem fpow_neg_mul_fpow_self (n : ℤ) {x : G₀} (h : x ≠ 0) :
   x ^ (-n) * x ^ n = 1 :=
 begin
   rw [fpow_neg],
-  exact inv_mul_cancel' _ (fpow_ne_zero n h)
+  exact inv_mul_cancel (fpow_ne_zero n h)
 end
 
 theorem one_div_pow {a : G₀} (n : ℕ) :

--- a/src/algebra/group_with_zero_power.lean
+++ b/src/algebra/group_with_zero_power.lean
@@ -23,7 +23,7 @@ variables {G₀ : Type*} [group_with_zero G₀]
 section nat_pow
 
 @[simp, field_simps] theorem inv_pow' (a : G₀) (n : ℕ) : (a⁻¹) ^ n = (a ^ n)⁻¹ :=
-by induction n with n ih; [exact inv_one'.symm,
+by induction n with n ih; [exact inv_one.symm,
   rw [pow_succ', pow_succ, ih, mul_inv_rev']]
 
 theorem pow_eq_zero' {g : G₀} {n : ℕ} (H : g ^ n = 0) : g = 0 :=
@@ -78,7 +78,7 @@ local attribute [ematch] le_of_lt
 
 @[simp] theorem one_fpow : ∀ (n : ℤ), (1 : G₀) ^ n = 1
 | (n : ℕ) := one_pow _
-| -[1+ n] := show _⁻¹=(1:G₀), by rw [one_pow, inv_one']
+| -[1+ n] := show _⁻¹=(1:G₀), by rw [one_pow, inv_one]
 
 lemma zero_fpow : ∀ z : ℤ, z ≠ 0 → (0 : G₀) ^ z = 0
 | (of_nat n) h := zero_pow' _ $ by rintro rfl; exact h rfl
@@ -86,7 +86,7 @@ lemma zero_fpow : ∀ z : ℤ, z ≠ 0 → (0 : G₀) ^ z = 0
 
 @[simp] theorem fpow_neg (a : G₀) : ∀ (n : ℤ), a ^ -n = (a ^ n)⁻¹
 | (n+1:ℕ) := rfl
-| 0       := inv_one'.symm
+| 0       := inv_one.symm
 | -[1+ n] := (inv_inv' _).symm
 
 theorem fpow_neg_one (x : G₀) : x ^ (-1:ℤ) = x⁻¹ := congr_arg has_inv.inv $ pow_one x
@@ -156,7 +156,7 @@ by rw [mul_comm, fpow_mul]
 
 lemma fpow_ne_zero_of_ne_zero {a : G₀} (ha : a ≠ 0) : ∀ (z : ℤ), a ^ z ≠ 0
 | (of_nat n) := pow_ne_zero' _ ha
-| -[1+n]     := inv_ne_zero' $ pow_ne_zero' _ ha
+| -[1+n]     := inv_ne_zero $ pow_ne_zero' _ ha
 
 lemma fpow_sub {a : G₀} (ha : a ≠ 0) (z1 z2 : ℤ) : a ^ (z1 - z2) = a ^ z1 / a ^ z2 :=
 by rw [sub_eq_add_neg, fpow_add ha, fpow_neg]; refl

--- a/src/algebra/group_with_zero_power.lean
+++ b/src/algebra/group_with_zero_power.lean
@@ -205,6 +205,6 @@ by simp only [div_eq_mul_inv, mul_pow, inv_pow']
 by simp only [div_eq_mul_inv, mul_fpow, inv_fpow]
 
 lemma div_sq_cancel {a : G₀} (ha : a ≠ 0) (b : G₀) : a ^ 2 * b / a = a * b :=
-by rw [pow_two, mul_assoc, mul_div_cancel_left' _ ha]
+by rw [pow_two, mul_assoc, mul_div_cancel_left _ ha]
 
 end

--- a/src/algebra/invertible.lean
+++ b/src/algebra/invertible.lean
@@ -146,7 +146,7 @@ div_mul_cancel' a (nonzero_of_invertible b)
 mul_div_cancel'' a (nonzero_of_invertible b)
 
 @[simp] lemma div_self_of_invertible (a : α) [invertible a] : a / a = 1 :=
-div_self' (nonzero_of_invertible a)
+div_self (nonzero_of_invertible a)
 
 /-- `b / a` is the inverse of `a / b` -/
 def invertible_div (a b : α) [invertible a] [invertible b] : invertible (a / b) :=

--- a/src/algebra/invertible.lean
+++ b/src/algebra/invertible.lean
@@ -128,16 +128,16 @@ lemma nonzero_of_invertible (a : α) [invertible a] : a ≠ 0 :=
 
 /-- `a⁻¹` is an inverse of `a` if `a ≠ 0` -/
 def invertible_of_nonzero {a : α} (h : a ≠ 0) : invertible a :=
-⟨ a⁻¹, inv_mul_cancel' _ h, mul_inv_cancel' _ h ⟩
+⟨ a⁻¹, inv_mul_cancel h, mul_inv_cancel h ⟩
 
 @[simp] lemma inv_of_eq_inv (a : α) [invertible a] : ⅟a = a⁻¹ :=
-inv_of_eq_right_inv (mul_inv_cancel' _ (nonzero_of_invertible a))
+inv_of_eq_right_inv (mul_inv_cancel (nonzero_of_invertible a))
 
 @[simp] lemma inv_mul_cancel_of_invertible (a : α) [invertible a] : a⁻¹ * a = 1 :=
-inv_mul_cancel' _ (nonzero_of_invertible a)
+inv_mul_cancel (nonzero_of_invertible a)
 
 @[simp] lemma mul_inv_cancel_of_invertible (a : α) [invertible a] : a * a⁻¹ = 1 :=
-mul_inv_cancel' _ (nonzero_of_invertible a)
+mul_inv_cancel (nonzero_of_invertible a)
 
 @[simp] lemma div_mul_cancel_of_invertible (a b : α) [invertible b] : a / b * b = a :=
 div_mul_cancel' a (nonzero_of_invertible b)

--- a/src/algebra/invertible.lean
+++ b/src/algebra/invertible.lean
@@ -149,7 +149,7 @@ div_self (nonzero_of_invertible a)
 
 /-- `b / a` is the inverse of `a / b` -/
 def invertible_div (a b : α) [invertible a] [invertible b] : invertible (a / b) :=
-⟨ b / a, by simp [←mul_div_assoc], by simp [←mul_div_assoc] ⟩
+⟨b / a, by simp [←mul_div_assoc], by simp [←mul_div_assoc]⟩
 
 @[simp] lemma inv_of_div (a b : α) [invertible a] [invertible b] [invertible (a / b)] :
   ⅟(a / b) = b / a :=

--- a/src/algebra/invertible.lean
+++ b/src/algebra/invertible.lean
@@ -8,7 +8,6 @@ A typeclass for the two-sided multiplicative inverse.
 
 import algebra.char_zero
 import algebra.char_p
-import tactic.norm_cast
 
 /-!
 # Invertible elements
@@ -140,21 +139,21 @@ inv_mul_cancel (nonzero_of_invertible a)
 mul_inv_cancel (nonzero_of_invertible a)
 
 @[simp] lemma div_mul_cancel_of_invertible (a b : α) [invertible b] : a / b * b = a :=
-div_mul_cancel' a (nonzero_of_invertible b)
+div_mul_cancel a (nonzero_of_invertible b)
 
 @[simp] lemma mul_div_cancel_of_invertible (a b : α) [invertible b] : a * b / b = a :=
-mul_div_cancel'' a (nonzero_of_invertible b)
+mul_div_cancel a (nonzero_of_invertible b)
 
 @[simp] lemma div_self_of_invertible (a : α) [invertible a] : a / a = 1 :=
 div_self (nonzero_of_invertible a)
 
 /-- `b / a` is the inverse of `a / b` -/
 def invertible_div (a b : α) [invertible a] [invertible b] : invertible (a / b) :=
-⟨ b / a, by simp [←mul_div_assoc''], by simp [←mul_div_assoc''] ⟩
+⟨ b / a, by simp [←mul_div_assoc], by simp [←mul_div_assoc] ⟩
 
 @[simp] lemma inv_of_div (a b : α) [invertible a] [invertible b] [invertible (a / b)] :
   ⅟(a / b) = b / a :=
-inv_of_eq_right_inv (by simp [←mul_div_assoc''])
+inv_of_eq_right_inv (by simp [←mul_div_assoc])
 
 /-- `a` is the inverse of `a⁻¹` -/
 def invertible_inv {a : α} [invertible a] : invertible (a⁻¹) :=

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -53,7 +53,6 @@ instance : has_add ℝ≥0   := ⟨λa b, ⟨a + b, add_nonneg a.2 b.2⟩⟩
 instance : has_sub ℝ≥0   := ⟨λa b, nnreal.of_real (a - b)⟩
 instance : has_mul ℝ≥0   := ⟨λa b, ⟨a * b, mul_nonneg a.2 b.2⟩⟩
 instance : has_inv ℝ≥0   := ⟨λa, ⟨(a.1)⁻¹, inv_nonneg.2 a.2⟩⟩
-instance : has_div ℝ≥0   := ⟨λa b, ⟨a.1 / b.1, div_nonneg' a.2 b.2⟩⟩
 instance : has_le ℝ≥0    := ⟨λ r s, (r:ℝ) ≤ s⟩
 instance : has_bot ℝ≥0   := ⟨0⟩
 instance : inhabited ℝ≥0 := ⟨0⟩
@@ -64,7 +63,6 @@ subtype.ext.symm
 @[simp, norm_cast] protected lemma coe_one  : ((1 : ℝ≥0) : ℝ) = 1 := rfl
 @[simp, norm_cast] protected lemma coe_add (r₁ r₂ : ℝ≥0) : ((r₁ + r₂ : ℝ≥0) : ℝ) = r₁ + r₂ := rfl
 @[simp, norm_cast] protected lemma coe_mul (r₁ r₂ : ℝ≥0) : ((r₁ * r₂ : ℝ≥0) : ℝ) = r₁ * r₂ := rfl
-@[simp, norm_cast] protected lemma coe_div (r₁ r₂ : ℝ≥0) : ((r₁ / r₂ : ℝ≥0) : ℝ) = r₁ / r₂ := rfl
 @[simp, norm_cast] protected lemma coe_inv (r : ℝ≥0) : ((r⁻¹ : ℝ≥0) : ℝ) = r⁻¹ := rfl
 @[simp, norm_cast] protected lemma coe_bit0 (r : ℝ≥0) : ((bit0 r : ℝ≥0) : ℝ) = bit0 r := rfl
 @[simp, norm_cast] protected lemma coe_bit1 (r : ℝ≥0) : ((bit1 r : ℝ≥0) : ℝ) = bit1 r := rfl
@@ -74,7 +72,6 @@ subtype.ext.symm
 max_eq_left $ le_sub.2 $ by simp [show (r₂ : ℝ) ≤ r₁, from h]
 
 -- TODO: setup semifield!
-@[simp] protected lemma zero_div (r : ℝ≥0) : 0 / r = 0 := nnreal.eq (zero_div _)
 @[simp] protected lemma coe_eq_zero (r : ℝ≥0) : ↑r = (0 : ℝ) ↔ r = 0 := by norm_cast
 lemma coe_ne_zero {r : ℝ≥0} : (r : ℝ) ≠ 0 ↔ r ≠ 0 := by norm_cast
 
@@ -101,6 +98,7 @@ instance : comm_group_with_zero ℝ≥0 :=
   .. (_ : comm_semiring ℝ≥0),
   .. (_ : semiring ℝ≥0) }
 
+@[simp, norm_cast] protected lemma coe_div (r₁ r₂ : ℝ≥0) : ((r₁ / r₂ : ℝ≥0) : ℝ) = r₁ / r₂ := rfl
 @[norm_cast] lemma coe_pow (r : ℝ≥0) (n : ℕ) : ((r^n : ℝ≥0) : ℝ) = r^n :=
 to_real_hom.map_pow r n
 

--- a/src/geometry/euclidean.lean
+++ b/src/geometry/euclidean.lean
@@ -127,7 +127,7 @@ by rw [angle_comm, angle_self_neg_of_nonzero hx]
 begin
   unfold angle,
   rw [inner_smul_right, norm_smul, real.norm_eq_abs, abs_of_nonneg (le_of_lt hr), ←mul_assoc,
-      mul_comm _ r, mul_assoc, mul_div_mul_left' _ _ (ne_of_gt hr)]
+      mul_comm _ r, mul_assoc, mul_div_mul_left _ _ (ne_of_gt hr)]
 end
 
 /-- The angle between a positive multiple of a vector and a vector. -/


### PR DESCRIPTION
For historical reasons there are lots of lemmas we prove for `group_with_zero`, then again for a `division_ring`. Merge some of them.

---
<!-- put comments you want to keep out of the PR commit here -->

Waiting for CI.