### PR TITLE
[Merged by Bors] - chore(measure/theory): remove useless module instances

### DIFF
--- a/src/measure_theory/ae_eq_fun.lean
+++ b/src/measure_theory/ae_eq_fun.lean
@@ -377,28 +377,6 @@ instance : mul_action 𝕜 (α →ₘ γ) := by apply_instance
 
 end semimodule
 
-section module
-
-variables {𝕜 : Type*} [ring 𝕜] [topological_space 𝕜]
-variables {γ : Type*} [topological_space γ] [second_countable_topology γ] [measurable_space γ]
-  [borel_space γ] [add_comm_group γ] [topological_add_group γ] [module 𝕜 γ]
-  [topological_semimodule 𝕜 γ]
-
-instance : module 𝕜 (α →ₘ γ) := { .. ae_eq_fun.semimodule }
-
-end module
-
-section vector_space
-
-variables {𝕜 : Type*} [field 𝕜] [topological_space 𝕜]
-variables {γ : Type*} [topological_space γ] [second_countable_topology γ] [measurable_space γ]
-  [borel_space γ] [add_comm_group γ] [topological_add_group γ] [vector_space 𝕜 γ]
-  [topological_semimodule 𝕜 γ]
-
-instance : vector_space 𝕜 (α →ₘ γ) := { .. ae_eq_fun.semimodule }
-
-end vector_space
-
 /- TODO : Prove that `L⁰` is a complete space if the codomain is complete. -/
 /- TODO : Multiplicative structure of `L⁰` if useful -/
 

--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -514,17 +514,7 @@ protected def semimodule : semimodule 𝕜 (α →₁ₛ β) :=
   add_smul  := λx y f, simple_func.eq (by { simp only [coe_smul], exact add_smul _ _ _ }),
   zero_smul := λf, simple_func.eq (by { simp only [coe_smul], exact zero_smul _ _ }) }
 
-/-- Not declared as an instance as `α →₁ₛ β` will only be useful in the construction of the bochner
-  integral. -/
-protected def module : module 𝕜 (α →₁ₛ β) :=
-{ .. simple_func.semimodule }
-
-/-- Not declared as an instance as `α →₁ₛ β` will only be useful in the construction of the bochner
-  integral. -/
-protected def vector_space : vector_space 𝕜 (α →₁ₛ β) :=
-{ .. simple_func.semimodule }
-
-local attribute [instance] simple_func.vector_space simple_func.normed_group
+local attribute [instance] simple_func.normed_group simple_func.semimodule
 
 /-- Not declared as an instance as `α →₁ₛ β` will only be useful in the construction of the bochner
   integral. -/

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -232,12 +232,6 @@ instance [semiring K] [add_comm_monoid β] [semimodule K β] : semimodule K (α 
   add_smul := λ r s f, ext (λa, add_smul _ _ _),
   zero_smul := λ f, ext (λa, zero_smul _ _) }
 
-instance [ring K] [add_comm_group β] [module K β] : module K (α →ₛ β) :=
-{ .. simple_func.semimodule }
-
-instance [field K] [add_comm_group β] [module K β] : vector_space K (α →ₛ β) :=
-{ .. simple_func.module }
-
 lemma smul_apply [has_scalar K β] (k : K) (f : α →ₛ β) (a : α) : (k • f) a = k • f a := rfl
 
 lemma smul_eq_map [has_scalar K β] (k : K) (f : α →ₛ β) : k • f = f.map (λb, k • b) := rfl

--- a/src/measure_theory/l1_space.lean
+++ b/src/measure_theory/l1_space.lean
@@ -553,10 +553,6 @@ instance : semimodule 𝕜 (α →₁ β) :=
   add_smul  := λx y f, l1.eq (by { simp only [coe_smul], exact add_smul _ _ _ }),
   zero_smul := λf, l1.eq (by { simp only [coe_smul], exact zero_smul _ _ }) }
 
-instance : module 𝕜 (α →₁ β) := { .. l1.semimodule }
-
-instance : vector_space 𝕜 (α →₁ β) := { .. l1.semimodule }
-
 instance : normed_space 𝕜 (α →₁ β) :=
 ⟨ begin
     rintros x ⟨f, hf⟩,

--- a/src/ring_theory/power_series.lean
+++ b/src/ring_theory/power_series.lean
@@ -382,13 +382,10 @@ instance : semimodule α (mv_power_series σ α) :=
 
 end semiring
 
-instance [ring α] : module α (mv_power_series σ α) :=
-{ ..mv_power_series.semimodule }
-
 instance [comm_ring α] : algebra α (mv_power_series σ α) :=
 { commutes' := λ _ _, mul_comm _ _,
   smul_def' := λ c p, rfl,
-  .. C σ α, .. mv_power_series.module }
+  .. C σ α, .. mv_power_series.semimodule }
 
 section map
 variables {β : Type*} {γ : Type*} [semiring α] [semiring β] [semiring γ]
@@ -769,7 +766,6 @@ instance [ring α]            : ring            (power_series α) := by delta po
 instance [comm_ring α]       : comm_ring       (power_series α) := by delta power_series; apply_instance
 instance [semiring α] [nonzero α] : nonzero (power_series α) := by delta power_series; apply_instance
 instance [semiring α]        : semimodule α    (power_series α) := by delta power_series; apply_instance
-instance [ring α]            : module α        (power_series α) := by delta power_series; apply_instance
 instance [comm_ring α]       : algebra α       (power_series α) := by delta power_series; apply_instance
 
 section add_monoid


### PR DESCRIPTION
Remove useless `module` and `vector_space` instances, as these words are now synonyms of `semimodule`.