### PR TITLE
[Merged by Bors] - refactor(ci): only update nolints once a day

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,28 +114,6 @@ jobs:
         run: |
           ./scripts/mk_all.sh
           lean --run scripts/lint_mathlib.lean
-          mv nolints.txt scripts/nolints.txt
-          ./scripts/rm_all.sh
-          git diff
-
-      - name: configure git setup
-        if: github.repository == 'leanprover-community/mathlib' && github.ref == 'refs/heads/master'
-        run: |
-          git remote add origin-bot "https://leanprover-community-bot:${{ secrets.DEPLOY_GITHUB_TOKEN }}@github.com/leanprover-community/mathlib.git"
-          git config user.email "leanprover.community@gmail.com"
-          git config user.name "leanprover-community-bot"
-
-          # By default, github actions overrides the credentials used to access any
-          # github url so that it uses the github-actions[bot] user.  We want to access
-          # github using a different username.
-          git config --unset http.https://github.com/.extraheader
-
-      - name: update nolints.txt
-        if: github.repository == 'leanprover-community/mathlib' && github.ref == 'refs/heads/master'
-        run: ./scripts/update_nolints.sh
-        env:
-          DEPLOY_GITHUB_TOKEN: ${{ secrets.DEPLOY_GITHUB_TOKEN }}
-          DEPLOY_GITHUB_USER: leanprover-community-bot
 
   tests:
     name: Run tests and docs

--- a/.github/workflows/update_nolints.yml
+++ b/.github/workflows/update_nolints.yml
@@ -1,0 +1,62 @@
+name: update nolints
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  build:
+    name: Build, lint and update nolints
+    if: github.repository == 'leanprover-community/mathlib'
+    runs-on: ubuntu-latest
+    env:
+      # number of commits to check for olean cache
+      GIT_HISTORY_DEPTH: 20
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: ${{ env.GIT_HISTORY_DEPTH }}
+
+      - name: install elan
+        run: |
+          set -o pipefail
+          curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh -s -- --default-toolchain none -y
+          ~/.elan/bin/lean --version
+          echo "::add-path::$HOME/.elan/bin"
+          echo "::set-env name=short_lean_version::$(~/.elan/bin/lean --run scripts/lean_version.lean)"
+
+      - name: install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: try to find olean cache
+        run: ./scripts/fetch_olean_cache.sh
+
+      - name: leanpkg build
+        id: build
+        run: leanpkg build -- -T100000 | python scripts/detect_errors.py
+
+      - name: lint
+        run: |
+          ./scripts/mk_all.sh
+          lean --run scripts/lint_mathlib.lean
+          mv nolints.txt scripts/nolints.txt
+          ./scripts/rm_all.sh
+          git diff
+
+      - name: configure git setup
+        run: |
+          git remote add origin-bot "https://leanprover-community-bot:${{ secrets.DEPLOY_GITHUB_TOKEN }}@github.com/leanprover-community/mathlib.git"
+          git config user.email "leanprover.community@gmail.com"
+          git config user.name "leanprover-community-bot"
+
+          # By default, github actions overrides the credentials used to access any
+          # github url so that it uses the github-actions[bot] user.  We want to access
+          # github using a different username.
+          git config --unset http.https://github.com/.extraheader
+
+      - name: update nolints.txt
+        run: ./scripts/update_nolints.sh
+        env:
+          DEPLOY_GITHUB_TOKEN: ${{ secrets.DEPLOY_GITHUB_TOKEN }}

--- a/scripts/update_nolints.sh
+++ b/scripts/update_nolints.sh
@@ -9,9 +9,9 @@ owner_name=leanprover-community
 git fetch $remote_name
 git rev-parse --verify --quiet refs/remotes/$remote_name/$branch_name && exit 0
 
-# Exit if there are no changes with respect to master
+# Exit if there are no changes relative to master
 git diff-index --quiet refs/remotes/$remote_name/master -- scripts/nolints.txt && exit 0
-# Exit if staging exists and there are no changes with respect to staging
+# Exit if staging exists and there are no changes relative to staging
 git rev-parse --verify --quiet refs/remotes/$remote_name/staging && git diff-index --quiet refs/remotes/$remote_name/staging -- scripts/nolints.txt && exit 0
 
 pr_title='chore(scripts): update nolints.txt'

--- a/scripts/update_nolints.sh
+++ b/scripts/update_nolints.sh
@@ -11,8 +11,6 @@ git rev-parse --verify --quiet refs/remotes/$remote_name/$branch_name && exit 0
 
 # Exit if there are no changes relative to master
 git diff-index --quiet refs/remotes/$remote_name/master -- scripts/nolints.txt && exit 0
-# Exit if staging exists and there are no changes relative to staging
-git rev-parse --verify --quiet refs/remotes/$remote_name/staging && git diff-index --quiet refs/remotes/$remote_name/staging -- scripts/nolints.txt && exit 0
 
 pr_title='chore(scripts): update nolints.txt'
 pr_body='I am happy to remove some nolints for you!'

--- a/scripts/update_nolints.sh
+++ b/scripts/update_nolints.sh
@@ -9,8 +9,10 @@ owner_name=leanprover-community
 git fetch $remote_name
 git rev-parse --verify --quiet refs/remotes/$remote_name/$branch_name && exit 0
 
-# Exit if there are no changes
+# Exit if there are no changes with respect to master
 git diff-index --quiet refs/remotes/$remote_name/master -- scripts/nolints.txt && exit 0
+# Exit if staging exists and there are no changes with respect to staging
+git rev-parse --verify --quiet refs/remotes/$remote_name/staging && git diff-index --quiet refs/remotes/$remote_name/staging -- scripts/nolints.txt && exit 0
 
 pr_title='chore(scripts): update nolints.txt'
 pr_body='I am happy to remove some nolints for you!'


### PR DESCRIPTION
This PR moves the update nolints step to a new GitHub actions workflow `update_nolints.yml` which runs once a day.

---
<!-- put comments you want to keep out of the PR commit here -->

The following info was the justification for an additional check against `staging` (now removed). 

Here are the most recent merged duplicate nolints PRs: #3034 #3035. 

[Here's](https://github.com/leanprover-community/mathlib/runs/763444613?check_suite_focus=true#step:7:220) the point in the logs, just before #3035 was created. The timestamp is "Thu, 11 Jun 2020 22:31:44 GMT".

Since #2906, a new nolints PR should be opened only if:

1. There is no `nolints` branch.
2. The generated `nolints.txt` differs from `master`. 

Indeed, it looks like bors deleted the `nolints` branch from #3034 about 14 seconds before (the timestamp reported in the HTML on that PR is "2020-06-11T22:31:30Z"). I can't seem to find a timestamp for when bors fast-forwarded `master` to `staging`, but I'm guessing it didn't happen until after #3035 was created. 

Checking against `staging` would have prevented this case, since bors should only delete the `nolints` branch well after it has landed in `staging`. I also put in a guard to check that `staging` exists, since we don't have any branch protection on it.