### PR TITLE
[Merged by Bors] - fix(library_search): only unfold reducible definitions when matching

### DIFF
--- a/test/library_search/basic.lean
+++ b/test/library_search/basic.lean
@@ -114,7 +114,7 @@ example (a : ℕ) (h : P a) : a < 0 := by library_search -- says `exact lemma_wi
 example (a b : ℕ) (h1 : a < b) (h2 : P a) : false := by library_search
 -- says `exact lemma_with_false_in_head a b h1 h2`
 
-example (a b : ℕ) (h1 : a < b) : ¬ (P a) := by library_search
+example (a b : ℕ) (h1 : a < b) : ¬ (P a) := by library_search!
 -- says `exact lemma_with_false_in_head a b h1`
 
 end synonym
@@ -122,7 +122,7 @@ end synonym
 -- We even find `iff` results:
 
 example : ∀ P : Prop, ¬(P ↔ ¬P) :=
-by library_search -- says: `λ (a : Prop), (iff_not_self a).mp`
+by library_search! -- says: `λ (a : Prop), (iff_not_self a).mp`
 
 example {a b c : ℕ} (ha : a > 0) (w : b ∣ c) : a * b ∣ a * c :=
 by library_search -- exact mul_dvd_mul_left a w
@@ -152,7 +152,6 @@ attribute [ex] add_lt_add
 
 example {a b c d: nat} (h₁ : a < c) (h₂ : b < d) : max (c + d) (a + b) = (c + d) :=
 begin
-  suggest with ex,
   library_search with ex, -- Says: `exact max_eq_left_of_lt (add_lt_add h₁ h₂)`
 end
 
@@ -181,6 +180,6 @@ begin
   success_if_fail {
     library_search { apply := λ e, tactic.apply e { md := tactic.transparency.reducible } },
   },
-  library_search,
+  library_search!,
 end
 end test.library_search

--- a/test/library_search/ring_theory.lean
+++ b/test/library_search/ring_theory.lean
@@ -12,11 +12,8 @@ set_option trace.silence_library_search true
 example {α : Type} [euclidean_domain α] {S : ideal α} {x y : α} (hy : y ∈ S) : x % y ∈ S ↔ x ∈ S :=
 by library_search -- exact mod_mem_iff hy
 
--- The next test timeouts for an unknown reason, disabled.
--- See https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Tests.20fail
+variables {R : Type} [comm_ring R] [decidable_eq R]
+variables {I : ideal (polynomial R)}
 
--- variables {R : Type} [comm_ring R] [decidable_eq R]
--- variables {I : ideal (polynomial R)}
-
--- example {m n : ℕ} (H : m ≤ n) : I.leading_coeff_nth m ≤ I.leading_coeff_nth n :=
--- by library_search -- exact ideal.leading_coeff_nth_mono I H
+example {m n : ℕ} (H : m ≤ n) : I.leading_coeff_nth m ≤ I.leading_coeff_nth n :=
+by library_search -- exact ideal.leading_coeff_nth_mono I H


### PR DESCRIPTION
By default `library_search` only unfolds `reducible` definitions
when attempting to match lemmas against the goal.
Previously, it would unfold most definitions, sometimes giving surprising answers, or slow answers.
The old behaviour is still available via `library_search!`.

---
<!-- put comments you want to keep out of the PR commit here -->
