### PR TITLE
[Merged by Bors] - feat(tactic/group): group normalization tactic

### DIFF
--- a/src/algebra/group_power.lean
+++ b/src/algebra/group_power.lean
@@ -295,6 +295,9 @@ open nat
 | 0       := one_inv.symm
 | -[1+ n] := (inv_inv _).symm
 
+lemma mul_gpow_neg_one (a b : G) : (a*b)^(-(1:ℤ)) = b^(-(1:ℤ))*a^(-(1:ℤ)) :=
+by simp only [mul_inv_rev, gpow_one, gpow_neg]
+
 @[simp] theorem neg_gsmul : ∀ (a : A) (n : ℤ), -n •ℤ a = -(n •ℤ a) :=
 @gpow_neg (multiplicative A) _
 
@@ -331,6 +334,12 @@ begin
   { simp only [← add_assoc, gpow_add_one, ihn, mul_assoc] },
   { rw [gpow_sub_one, ← mul_assoc, ← ihn, ← gpow_sub_one, add_sub_assoc] }
 end
+
+lemma mul_self_gpow (b : G) (m : ℤ) : b*b^m = b^(m+1) :=
+by { conv_lhs {congr, rw ← gpow_one b }, rw [← gpow_add, add_comm] }
+
+lemma mul_gpow_self (b : G) (m : ℤ) : b^m*b = b^(m+1) :=
+by { conv_lhs {congr, skip, rw ← gpow_one b }, rw [← gpow_add, add_comm] }
 
 theorem add_gsmul : ∀ (a : A) (i j : ℤ), (i + j) •ℤ a = i •ℤ a + j •ℤ a :=
 @gpow_add (multiplicative A) _

--- a/src/tactic/default.lean
+++ b/src/tactic/default.lean
@@ -28,3 +28,4 @@ import tactic.interval_cases
 import tactic.reassoc_axiom -- most likely useful only for category_theory
 import tactic.slice
 import tactic.subtype_instance
+import tactic.group

--- a/src/tactic/group.lean
+++ b/src/tactic/group.lean
@@ -33,7 +33,7 @@ by rw [mul_assoc, ← gpow_add] ; refl
 
 namespace tactic
 open tactic.simp_arg_type tactic.interactive interactive
-
+/-- Auxilliary tactic for the `group` tactic. Calls the simplifier only. -/
 meta def aux_group₁ (locat : loc) : tactic unit :=
   simp_core {} skip tt [
   expr ``(mul_one),
@@ -57,7 +57,7 @@ meta def aux_group₁ (locat : loc) : tactic unit :=
   symm_expr ``(gpow_add_one),
   symm_expr ``(gpow_one_add),
   symm_expr ``(gpow_add),
-  expr ``(mul_gpow_neg_one ),
+  expr ``(mul_gpow_neg_one),
   expr ``(gpow_zero),
   expr ``(mul_gpow),
   symm_expr ``(mul_assoc),
@@ -67,6 +67,7 @@ meta def aux_group₁ (locat : loc) : tactic unit :=
   expr ``(gpow_trick_sub)]
   [] locat
 
+/-- Auxilliary tactic for the `group` tactic. Calls `ring` to normalize exponents. -/
 meta def aux_group₂ (locat : loc) : tactic unit :=
 ring none tactic.ring.normalize_mode.raw locat
 end tactic
@@ -74,13 +75,6 @@ end tactic
 namespace tactic.interactive
 setup_tactic_parser
 open tactic
-
-meta def group (locat : parse location) : tactic unit :=
-do when locat.include_goal `[rw ← mul_inv_eq_one],
-   repeat (aux_group₁ locat ; aux_group₂ locat),
-   try (aux_group₁ locat),
-   repeat (aux_group₂ locat ; aux_group₁ locat)
-end tactic.interactive
 
 /--
 Tactic for normalizing expressions in multiplicative groups, without assuming
@@ -97,9 +91,15 @@ begin
 end
 ```
 -/
+meta def group (locat : parse location) : tactic unit :=
+do when locat.include_goal `[rw ← mul_inv_eq_one],
+   repeat (aux_group₁ locat ; aux_group₂ locat),
+   try (aux_group₁ locat),
+   repeat (aux_group₂ locat ; aux_group₁ locat)
+end tactic.interactive
+
 add_tactic_doc
 { name := "group",
   category := doc_category.tactic,
   decl_names := [`tactic.interactive.group],
-  tags := ["decision procedure", "simplification"]
-}
+  tags := ["decision procedure", "simplification"] }

--- a/src/tactic/group.lean
+++ b/src/tactic/group.lean
@@ -3,13 +3,18 @@ Copyright (c) 2020. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Patrick Massot
 -/
-import tactic
+import tactic.ring
 import tactic.doc_commands
 
 /-!
 # `group`
 
-Normalizes expressions in the language of groups.
+Normalizes expressions in the language of groups. The basic idea is to use the simplifier
+to put everything into a product of group powers (`gpow` which takes a group element and an
+integer), then simplify the exponents using the `ring` tactic. The process needs to be repeated
+since `ring` can normalize an exponent to zero, leading to a factor that can be removed
+before collecting exponents again. The simplifier step also uses some extra lemmas to avoid
+some `ring` invocations.
 
 ## Tags
 
@@ -19,20 +24,20 @@ group_theory
 -- The next four lemmas are not general purpose lemmas, they are intended for use only by
 -- the `group` tactic.
 
-lemma gpow_trick {G : Type*} [group G] (a b : G) (n m : ℤ) : a*b^n*b^m = a*b^(n+m) :=
+lemma tactic.group.gpow_trick {G : Type*} [group G] (a b : G) (n m : ℤ) : a*b^n*b^m = a*b^(n+m) :=
 by rw [mul_assoc, ← gpow_add]
 
-lemma gpow_trick_one {G : Type*} [group G] (a b : G) (m : ℤ) : a*b*b^m = a*b^(m+1) :=
+lemma tactic.group.gpow_trick_one {G : Type*} [group G] (a b : G) (m : ℤ) : a*b*b^m = a*b^(m+1) :=
 by rw [mul_assoc, mul_self_gpow]
 
-lemma gpow_trick_one' {G : Type*} [group G] (a b : G) (n : ℤ) : a*b^n*b = a*b^(n+1) :=
+lemma tactic.group.gpow_trick_one' {G : Type*} [group G] (a b : G) (n : ℤ) : a*b^n*b = a*b^(n+1) :=
 by rw [mul_assoc, mul_gpow_self]
 
-lemma gpow_trick_sub {G : Type*} [group G] (a b : G) (n m : ℤ) : a*b^n*b^(-m) = a*b^(n-m) :=
+lemma tactic.group.gpow_trick_sub {G : Type*} [group G] (a b : G) (n m : ℤ) : a*b^n*b^(-m) = a*b^(n-m) :=
 by rw [mul_assoc, ← gpow_add] ; refl
 
 namespace tactic
-open tactic.simp_arg_type tactic.interactive interactive
+open tactic.simp_arg_type tactic.interactive interactive tactic.group.
 /-- Auxilliary tactic for the `group` tactic. Calls the simplifier only. -/
 meta def aux_group₁ (locat : loc) : tactic unit :=
   simp_core {} skip tt [
@@ -64,7 +69,8 @@ meta def aux_group₁ (locat : loc) : tactic unit :=
   expr ``(gpow_trick),
   expr ``(gpow_trick_one),
   expr ``(gpow_trick_one'),
-  expr ``(gpow_trick_sub)]
+  expr ``(gpow_trick_sub),
+  expr ``(tactic.ring.horner)]
   [] locat
 
 /-- Auxilliary tactic for the `group` tactic. Calls `ring` to normalize exponents. -/
@@ -95,9 +101,9 @@ end
 -/
 meta def group (locat : parse location) : tactic unit :=
 do when locat.include_goal `[rw ← mul_inv_eq_one],
-   repeat (aux_group₁ locat ; aux_group₂ locat),
    try (aux_group₁ locat),
    repeat (aux_group₂ locat ; aux_group₁ locat)
+
 end tactic.interactive
 
 add_tactic_doc

--- a/src/tactic/group.lean
+++ b/src/tactic/group.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2020. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Patrick Massot
+-/
+import tactic
+import tactic.doc_commands
+
+/-!
+# `group`
+
+Normalizes expressions in the language of groups.
+
+## Tags
+
+group_theory
+-/
+
+-- The next four lemmas are not general purpose lemmas, they are intended for use only by
+-- the `group` tactic.
+
+lemma gpow_trick {G : Type*} [group G] (a b : G) (n m : ℤ) : a*b^n*b^m = a*b^(n+m) :=
+by rw [mul_assoc, ← gpow_add]
+
+lemma gpow_trick_one {G : Type*} [group G] (a b : G) (m : ℤ) : a*b*b^m = a*b^(m+1) :=
+by rw [mul_assoc, mul_self_gpow]
+
+lemma gpow_trick_one' {G : Type*} [group G] (a b : G) (n : ℤ) : a*b^n*b = a*b^(n+1) :=
+by rw [mul_assoc, mul_gpow_self]
+
+lemma gpow_trick_sub {G : Type*} [group G] (a b : G) (n m : ℤ) : a*b^n*b^(-m) = a*b^(n-m) :=
+by rw [mul_assoc, ← gpow_add] ; refl
+
+namespace tactic
+open tactic.simp_arg_type tactic.interactive interactive
+
+meta def aux_group₁ (locat : loc) : tactic unit :=
+  simp_core {} skip tt [
+  expr ``(mul_one),
+  expr ``(one_mul),
+  expr ``(sub_self),
+  expr ``(add_neg_self),
+  expr ``(neg_add_self),
+  expr ``(neg_neg),
+  expr ``(nat.sub_self),
+  expr ``(int.coe_nat_add),
+  expr ``(int.coe_nat_mul),
+  expr ``(int.coe_nat_zero),
+  expr ``(int.coe_nat_one),
+  expr ``(int.coe_nat_bit0),
+  expr ``(int.coe_nat_bit1),
+  expr ``(int.mul_neg_eq_neg_mul_symm),
+  expr ``(int.neg_mul_eq_neg_mul_symm),
+  symm_expr ``(gpow_coe_nat),
+  symm_expr ``(gpow_neg_one),
+  symm_expr ``(gpow_mul),
+  symm_expr ``(gpow_add_one),
+  symm_expr ``(gpow_one_add),
+  symm_expr ``(gpow_add),
+  expr ``(mul_gpow_neg_one ),
+  expr ``(gpow_zero),
+  expr ``(mul_gpow),
+  symm_expr ``(mul_assoc),
+  expr ``(gpow_trick),
+  expr ``(gpow_trick_one),
+  expr ``(gpow_trick_one'),
+  expr ``(gpow_trick_sub)]
+  [] locat
+
+meta def aux_group₂ (locat : loc) : tactic unit :=
+ring none tactic.ring.normalize_mode.raw locat
+end tactic
+
+namespace tactic.interactive
+setup_tactic_parser
+open tactic
+
+meta def group (locat : parse location) : tactic unit :=
+do when locat.include_goal `[rw ← mul_inv_eq_one],
+   repeat (aux_group₁ locat ; aux_group₂ locat),
+   try (aux_group₁ locat),
+   repeat (aux_group₂ locat ; aux_group₁ locat)
+end tactic.interactive
+
+/--
+Tactic for normalizing expressions in multiplicative groups, without assuming
+commutatitvity, using only the group axioms without any information about which group
+is manipulated.
+
+Example:
+```lean
+example {G : Type} [group G] (a b c d : G) (h : c = (a*b^2)*((b*b)⁻¹*a⁻¹)*d) : a*c*d⁻¹ = a :=
+begin
+  group at h, -- normalizes `h` which becomes `h : c = d`
+  rw h,       -- the goal is now `a*d*d⁻¹ = a`
+  group,      -- which then normalized and closed
+end
+```
+-/
+add_tactic_doc
+{ name := "group",
+  category := doc_category.tactic,
+  decl_names := [`tactic.interactive.group],
+  tags := ["decision procedure", "simplification"]
+}

--- a/src/tactic/group.lean
+++ b/src/tactic/group.lean
@@ -78,8 +78,10 @@ open tactic
 
 /--
 Tactic for normalizing expressions in multiplicative groups, without assuming
-commutatitvity, using only the group axioms without any information about which group
+commutativity, using only the group axioms without any information about which group
 is manipulated.
+
+(For additive commutative groups, use the `abel` tactic instead.)
 
 Example:
 ```lean

--- a/test/group.lean
+++ b/test/group.lean
@@ -1,0 +1,59 @@
+import tactic.group
+
+variables {G : Type} [group G]
+
+example (a b c d : G) : c *(a*b)*(b⁻¹*a⁻¹)*c = c*c :=
+by group
+
+example (a b c d : G) : (b*c⁻¹)*c *(a*b)*(b⁻¹*a⁻¹)*c = b*c :=
+by group
+
+example (a b c d : G) : c⁻¹*(b*c⁻¹)*c *(a*b)*(b⁻¹*a⁻¹*b⁻¹)*c = 1 :=
+by group
+
+
+def commutator {G} [group G] : G → G → G := λ g h, g * h * g⁻¹ * h⁻¹
+
+def commutator3 {G} [group G] : G → G → G → G := λ g h k, commutator (commutator g h) k
+
+-- The following is known as the Hall-Witt identity, see e.g. https://en.wikipedia.org/wiki/Three_subgroups_lemma#Proof_and_the_Hall%E2%80%93Witt_identity
+example (g h k : G) :
+  g * (commutator3 g⁻¹ h k) * g⁻¹ * k * (commutator3 k⁻¹ g h) * k⁻¹ * h * (commutator3 h⁻¹ k g) * h⁻¹ = 1 :=
+by { dsimp [commutator3, commutator], group }
+
+example (a : G) : a^2*a = a^3 :=
+by group
+
+example (n m : ℕ) (a : G) : a^n*a^m = a^(n+m) :=
+by group
+
+example (a b c d : G) : c *(a*b^2)*((b*b)⁻¹*a⁻¹)*c = c*c :=
+by group
+
+example (n m : ℕ) (a : G) : a^n*(a⁻¹)^n = 1 :=
+by group
+
+example (n m : ℕ) (a : G) : a^2*a⁻¹*a⁻¹ = 1 :=
+by group
+
+example (n m : ℕ) (a : G) : a^n*a^m = a^(m+n) :=
+by group
+
+example (n : ℕ) (a : G) : a^(n-n) = 1 :=
+by group
+
+example (n : ℤ) (a : G) : a^(n-n) = 1 :=
+by group
+
+example (n : ℤ) (a : G) (h : a^(n*(n+1)-n -n^2) = a) : a = 1 :=
+begin
+ group at h,
+ exact h.symm,
+ end
+
+example (a b c d : G) (h : c = (a*b^2)*((b*b)⁻¹*a⁻¹)*d) : a*c*d⁻¹ = a :=
+begin
+  group at h,
+  rw h,
+  group,
+end

--- a/test/group.lean
+++ b/test/group.lean
@@ -16,7 +16,8 @@ def commutator {G} [group G] : G → G → G := λ g h, g * h * g⁻¹ * h⁻¹
 
 def commutator3 {G} [group G] : G → G → G → G := λ g h k, commutator (commutator g h) k
 
--- The following is known as the Hall-Witt identity, see e.g. https://en.wikipedia.org/wiki/Three_subgroups_lemma#Proof_and_the_Hall%E2%80%93Witt_identity
+-- The following is known as the Hall-Witt identity,
+-- see e.g. https://en.wikipedia.org/wiki/Three_subgroups_lemma#Proof_and_the_Hall%E2%80%93Witt_identity
 example (g h k : G) :
   g * (commutator3 g⁻¹ h k) * g⁻¹ * k * (commutator3 k⁻¹ g h) * k⁻¹ * h * (commutator3 h⁻¹ k g) * h⁻¹ = 1 :=
 by { dsimp [commutator3, commutator], group }
@@ -57,3 +58,9 @@ begin
   rw h,
   group,
 end
+
+-- The next example can be expand to require an arbitrarily high number of alternation
+-- between simp and ring
+
+example (n m : ℤ) (a b : G) : a^n*b^n*a^n*a^n*a^-n*a^-n*b^-n*a^-n = 1 :=
+by group


### PR DESCRIPTION
A tactic to normalize expressions in multiplicative groups.

---
<!-- put comments you want to keep out of the PR commit here -->

I'm still cleaning up my PR backlog before diving into the sphere eversion project Lean code. This time it's the group tactic, discussed at length in https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60group.60.20tactic and then
https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Group.20Theory.20Tactic

This still a pretty naive version, but it seems that real tactic writers are not interested enough in this question, so this should be better than nothing.