### PR TITLE
[Merged by Bors] - feat(analysis/hofer): Hofer's lemma

### DIFF
--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -896,14 +896,6 @@ lemma sum_boole_mul [decidable_eq α] (s : finset α) (f : α → β) (a : α) :
   (∑ x in s, (ite (a = x) 1 0) * f x) = ite (a ∈ s) (f a) 0 :=
 by simp
 
-lemma sum_map_mul_right {b : β} {s : finset α} {f : α → β} :
-  ∑ a in s, f a * b = (∑ a in s, f a) * b :=
-multiset.sum_map_mul_right
-
-lemma sum_map_mul_left {b : β} {s : finset α} {f : α → β} :
-  ∑ a in s, b*f a = b * (∑ a in s, f a) :=
-multiset.sum_map_mul_left
-
 end semiring
 
 lemma sum_div [division_ring β] {s : finset α} {f : α → β} {b : β} :

--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -896,6 +896,14 @@ lemma sum_boole_mul [decidable_eq α] (s : finset α) (f : α → β) (a : α) :
   (∑ x in s, (ite (a = x) 1 0) * f x) = ite (a ∈ s) (f a) 0 :=
 by simp
 
+lemma sum_map_mul_right {b : β} {s : finset α} {f : α → β} :
+  ∑ a in s, f a * b = (∑ a in s, f a) * b :=
+multiset.sum_map_mul_right
+
+lemma sum_map_mul_left {b : β} {s : finset α} {f : α → β} :
+  ∑ a in s, b*f a = b * (∑ a in s, f a) :=
+multiset.sum_map_mul_left
+
 end semiring
 
 lemma sum_div [division_ring β] {s : finset α} {f : α → β} {b : β} :

--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -131,7 +131,7 @@ div_pos ha (pow_pos hb k)
 
 @[simp] lemma div_pow_le {a b : K} (ha : 0 < a) (hb : 1 ≤ b) (k : ℕ) : a/b^k ≤ a :=
 (div_le_iff $ pow_pos (lt_of_lt_of_le zero_lt_one hb) k).mpr
-(calc a = a *1 : by simp
+(calc a = a * 1 : (mul_one a).symm
    ...  ≤ a*b^k : (mul_le_mul_left ha).mpr $ one_le_pow_of_one_le hb _)
 
 lemma injective_fpow {x : K} (h₀ : 0 < x) (h₁ : x ≠ 1) :

--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -126,6 +126,14 @@ end
   x ^ m ≤ x ^ n ↔ m ≤ n :=
 (fpow_strict_mono hx).le_iff_le
 
+@[simp] lemma pos_div_pow_pos {a b : K} (ha : 0 < a) (hb : 0 < b) (k : ℕ) : 0 < a/b^k :=
+div_pos ha (pow_pos hb k)
+
+@[simp] lemma div_pow_le {a b : K} (ha : 0 < a) (hb : 1 ≤ b) (k : ℕ) : a/b^k ≤ a :=
+(div_le_iff $ pow_pos (lt_of_lt_of_le zero_lt_one hb) k).mpr
+(calc a = a *1 : by simp
+   ...  ≤ a*b^k : (mul_le_mul_left ha).mpr $ one_le_pow_of_one_le hb _)
+
 lemma injective_fpow {x : K} (h₀ : 0 < x) (h₁ : x ≠ 1) :
   function.injective ((^) x : ℤ → K) :=
 begin

--- a/src/analysis/hofer.lean
+++ b/src/analysis/hofer.lean
@@ -81,7 +81,7 @@ begin
       ... ≤ ∑ i in r, ε/2^i             : sum_le_sum (λ i i_in, (IH i $ nat.lt_succ_iff.mp $
                                                                   finset.mem_range.mp i_in).1)
       ... = ∑ i in r, (1/2)^i*ε         : by {congr, ext i, field_simp }
-      ... = (∑ i in r, (1/2)^i)*ε       : finset.sum_map_mul_right
+      ... = (∑ i in r, (1/2)^i)*ε       : finset.sum_mul.symm
       ... ≤ 2*ε                         : mul_le_mul_of_nonneg_right (sum_geometric_two_le _)
                                             (le_of_lt ε_pos), },
     have B : 2^(n+1) * ϕ x ≤ ϕ (u (n + 1)),

--- a/src/analysis/hofer.lean
+++ b/src/analysis/hofer.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2017 Patrick Massot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Patrick Massot
+-/
+
+import analysis.specific_limits
+
+/-!
+# Hofer's lemma
+
+This is an elementary lemma about complete metric space. It is motivated by
+application to the bubbling-off analysis for holomorphic curves in symplectic topology.
+We are *very* far away from having these applications, but the proof here is a nice
+example of a proof needing to construct a sequence by induction in the middle of the proof.
+
+## References:
+
+* H. Hofer and C. Viterbo, *The weinstein conjecture in the presence of holomorphic spheres*
+-/
+
+open_locale classical topological_space big_operators
+open filter finset
+
+local notation `d` := dist
+
+lemma hofer {X: Type*} [metric_space X] [complete_space X]
+  (x : X) (ε : ℝ) (ε_pos : 0 < ε)
+  {ϕ : X → ℝ} (cont : continuous ϕ) (nonneg : ∀ y, 0 ≤ ϕ y) :
+∃ (ε' > 0) (x' : X), ε' ≤ ε ∧
+                   d x' x ≤ 2*ε ∧
+                   ε * ϕ(x) ≤ ε' * ϕ x' ∧
+                   ∀ y, d x' y ≤ ε' → ϕ y ≤ 2*ϕ x' :=
+begin
+  by_contradiction H,
+  have reformulation : ∀ x' (k : ℕ), ε * ϕ x ≤ ε / 2 ^ k * ϕ x' ↔ 2^k * ϕ x ≤ ϕ x',
+  { intros x' k,
+    rw [div_mul_eq_mul_div, le_div_iff, mul_assoc, mul_le_mul_left ε_pos, mul_comm],
+    exact pow_pos (by norm_num) k, },
+  -- Now let's pull the existential quantifiers in front
+  replace H : ∀ k : ℕ, ∀ x', ∃ y,
+    d x' x ≤ 2 * ε ∧ 2^k * ϕ x ≤ ϕ x' → d x' y ≤ ε/2^k ∧ 2 * ϕ x' < ϕ y,
+  { intros k x',
+    by_cases h' : d x' x ≤ 2 * ε ∧ 2^k * ϕ x ≤ ϕ x',
+    { contrapose H,
+      rw not_not,
+      use ε/2^k,
+      suffices : ∃ x', d x' x ≤ 2 * ε ∧ ε * ϕ x ≤ ε / 2 ^ k * ϕ x' ∧
+                       ∀ (y : X), d x' y ≤ ε / 2 ^ k → ϕ y ≤ 2 * ϕ x',
+      by simpa [ε_pos, two_pos, one_le_two],
+      use x',
+      simpa [h'.left, reformulation,  h'.right, h'] using H },
+    { use x } },
+  clear reformulation,
+  choose F hF using H,  -- Use the axiom of choice
+  -- Now define u by induction starting at x, with u_{n+1} = F(n, u_n)
+  let u : ℕ → X := λ n, nat.rec_on n x F,
+  -- The properties of F translate to properties of u
+  have hu :
+    ∀ n,
+      d (u n) x ≤ 2 * ε ∧ 2^n * ϕ x ≤ ϕ (u n) →
+      d (u n) (u $ n + 1) ≤ ε / 2 ^ n ∧ 2 * ϕ (u n) < ϕ (u $ n + 1),
+  { intro n,
+    exact hF n (u n) },
+  clear hF,
+
+  -- Key properties of u, to be proven by induction
+  have key : ∀ n, d (u n) (u (n + 1)) ≤ ε / 2 ^ n ∧ 2 * ϕ (u n) < ϕ (u (n + 1)),
+  { intro n,
+    induction n using nat.case_strong_induction_on with n IH,
+    { specialize hu 0,
+      simp [show u 0 = x, from rfl, le_refl] at *,
+      exact hu (by linarith) },
+    have A : d (u (n+1)) x ≤ 2 * ε,
+    { rw [dist_comm],
+      let r := range (n+1), -- range (n+1) = {0, ..., n}
+      calc
+      d (u 0) (u (n + 1))
+          ≤ ∑ i in r, d (u i) (u $ i+1) : dist_le_range_sum_dist u (n + 1)
+      ... ≤ ∑ i in r, ε/2^i             : sum_le_sum (λ i i_in, (IH i $ nat.lt_succ_iff.mp $ finset.mem_range.mp i_in).1)
+      ... = ∑ i in r, (1/2)^i*ε         : by {congr, ext i, field_simp }
+      ... = (∑ i in r, (1/2)^i)*ε       : finset.sum_map_mul_right
+      ... ≤ 2*ε                         : mul_le_mul_of_nonneg_right (sum_geometric_two_le _) (le_of_lt ε_pos), },
+    have B : 2^(n+1) * ϕ x ≤ ϕ (u (n + 1)),
+    { apply le_of_lt,
+      exact geom_lt (by norm_num) (λ  m hm, (IH _ hm).2), },
+    exact hu (n+1) ⟨A, B⟩, },
+  cases forall_and_distrib.mp key with key₁ key₂,
+
+  -- Hence u is Cauchy
+  have cauchy_u : cauchy_seq u,
+  { apply cauchy_seq_of_le_geometric _ ε (by norm_num : 1/(2:ℝ) < 1),
+    intro n,
+    convert key₁ n,
+    simp },
+
+  -- So u converges to some y
+  obtain ⟨y, limy⟩ : ∃ y, tendsto u at_top (𝓝 y),
+    from complete_space.complete cauchy_u,
+
+  -- And ϕ ∘ u goes to +∞
+  have lim_top : tendsto (ϕ ∘ u) at_top at_top,
+  { let v := λ n, (ϕ ∘ u) (n+1),
+    suffices : tendsto v at_top at_top,
+      by rwa tendsto_add_at_top_iff_nat at this,
+    have hv₀ : 0 < v 0,
+    { have : 0 ≤ ϕ (u 0) := nonneg x,
+      calc 0 ≤ 2 * ϕ (u 0) : by linarith
+      ... < ϕ (u (0 + 1)) : key₂ 0 },
+    apply tendsto_at_top_of_geom_lt hv₀ (by norm_num : (1 : ℝ) < 2),
+    exact λ n, key₂ (n+1) },
+
+  -- But ϕ ∘ u also needs to go to ϕ(y)
+  have lim : tendsto (ϕ ∘ u) at_top (𝓝 (ϕ y)),
+    from tendsto.comp cont.continuous_at limy,
+
+  -- So we have our contradiction!
+  exact not_tendsto_at_top_of_tendsto_nhds at_top_ne_bot lim lim_top,
+end

--- a/src/analysis/hofer.lean
+++ b/src/analysis/hofer.lean
@@ -24,6 +24,7 @@ open filter finset
 
 local notation `d` := dist
 
+@[nolint ge_or_gt] -- see Note [nolint_ge]
 lemma hofer {X: Type*} [metric_space X] [complete_space X]
   (x : X) (ε : ℝ) (ε_pos : 0 < ε)
   {ϕ : X → ℝ} (cont : continuous ϕ) (nonneg : ∀ y, 0 ≤ ϕ y) :

--- a/src/analysis/hofer.lean
+++ b/src/analysis/hofer.lean
@@ -50,7 +50,7 @@ begin
                        ∀ (y : X), d x' y ≤ ε / 2 ^ k → ϕ y ≤ 2 * ϕ x',
       by simpa [ε_pos, two_pos, one_le_two],
       use x',
-      simpa [h'.left, reformulation,  h'.right, h'] using H },
+      simpa [h'.left, reformulation, h'.right, h'] using H },
     { use x } },
   clear reformulation,
   choose F hF using H,  -- Use the axiom of choice
@@ -80,15 +80,16 @@ begin
           ≤ ∑ i in r, d (u i) (u $ i+1) : dist_le_range_sum_dist u (n + 1)
       ... ≤ ∑ i in r, ε/2^i             : sum_le_sum (λ i i_in, (IH i $ nat.lt_succ_iff.mp $
                                                                   finset.mem_range.mp i_in).1)
-      ... = ∑ i in r, (1/2)^i*ε         : by {congr, ext i, field_simp }
+      ... = ∑ i in r, (1/2)^i*ε         : by { congr, ext i, field_simp }
       ... = (∑ i in r, (1/2)^i)*ε       : finset.sum_mul.symm
       ... ≤ 2*ε                         : mul_le_mul_of_nonneg_right (sum_geometric_two_le _)
                                             (le_of_lt ε_pos), },
     have B : 2^(n+1) * ϕ x ≤ ϕ (u (n + 1)),
     { apply le_of_lt,
-      exact geom_lt (by norm_num) (λ  m hm, (IH _ hm).2), },
+      exact geom_lt (by norm_num) (λ m hm, (IH _ hm).2), },
     exact hu (n+1) ⟨A, B⟩, },
   cases forall_and_distrib.mp key with key₁ key₂,
+  clear hu key,
 
   -- Hence u is Cauchy
   have cauchy_u : cauchy_seq u,

--- a/src/analysis/hofer.lean
+++ b/src/analysis/hofer.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2017 Patrick Massot. All rights reserved.
+Copyright (c) 2020 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot
 -/
@@ -9,14 +9,14 @@ import analysis.specific_limits
 /-!
 # Hofer's lemma
 
-This is an elementary lemma about complete metric space. It is motivated by
+This is an elementary lemma about complete metric spaces. It is motivated by an
 application to the bubbling-off analysis for holomorphic curves in symplectic topology.
 We are *very* far away from having these applications, but the proof here is a nice
 example of a proof needing to construct a sequence by induction in the middle of the proof.
 
 ## References:
 
-* H. Hofer and C. Viterbo, *The weinstein conjecture in the presence of holomorphic spheres*
+* H. Hofer and C. Viterbo, *The Weinstein conjecture in the presence of holomorphic spheres*
 -/
 
 open_locale classical topological_space big_operators
@@ -27,10 +27,10 @@ local notation `d` := dist
 lemma hofer {X: Type*} [metric_space X] [complete_space X]
   (x : X) (ε : ℝ) (ε_pos : 0 < ε)
   {ϕ : X → ℝ} (cont : continuous ϕ) (nonneg : ∀ y, 0 ≤ ϕ y) :
-∃ (ε' > 0) (x' : X), ε' ≤ ε ∧
-                   d x' x ≤ 2*ε ∧
-                   ε * ϕ(x) ≤ ε' * ϕ x' ∧
-                   ∀ y, d x' y ≤ ε' → ϕ y ≤ 2*ϕ x' :=
+  ∃ (ε' > 0) (x' : X), ε' ≤ ε ∧
+                       d x' x ≤ 2*ε ∧
+                       ε * ϕ(x) ≤ ε' * ϕ x' ∧
+                       ∀ y, d x' y ≤ ε' → ϕ y ≤ 2*ϕ x' :=
 begin
   by_contradiction H,
   have reformulation : ∀ x' (k : ℕ), ε * ϕ x ≤ ε / 2 ^ k * ϕ x' ↔ 2^k * ϕ x ≤ ϕ x',
@@ -77,10 +77,12 @@ begin
       calc
       d (u 0) (u (n + 1))
           ≤ ∑ i in r, d (u i) (u $ i+1) : dist_le_range_sum_dist u (n + 1)
-      ... ≤ ∑ i in r, ε/2^i             : sum_le_sum (λ i i_in, (IH i $ nat.lt_succ_iff.mp $ finset.mem_range.mp i_in).1)
+      ... ≤ ∑ i in r, ε/2^i             : sum_le_sum (λ i i_in, (IH i $ nat.lt_succ_iff.mp $
+                                                                  finset.mem_range.mp i_in).1)
       ... = ∑ i in r, (1/2)^i*ε         : by {congr, ext i, field_simp }
       ... = (∑ i in r, (1/2)^i)*ε       : finset.sum_map_mul_right
-      ... ≤ 2*ε                         : mul_le_mul_of_nonneg_right (sum_geometric_two_le _) (le_of_lt ε_pos), },
+      ... ≤ 2*ε                         : mul_le_mul_of_nonneg_right (sum_geometric_two_le _)
+                                            (le_of_lt ε_pos), },
     have B : 2^(n+1) * ϕ x ≤ ϕ (u (n + 1)),
     { apply le_of_lt,
       exact geom_lt (by norm_num) (λ  m hm, (IH _ hm).2), },

--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -185,7 +185,7 @@ by_cases
     tendsto.congr' (univ_mem_sets' $ by simp *) this)
 
 lemma geom_lt {u : ℕ → ℝ} {k : ℝ} (hk : 0 < k) {n : ℕ} (h : ∀ m ≤ n, k*u m < u (m + 1)) :
-k^(n + 1) *u 0 < u (n + 1) :=
+  k^(n + 1) *u 0 < u (n + 1) :=
 begin
  induction n with n ih,
  { simpa using h 0 (le_refl _) },

--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -200,7 +200,7 @@ begin
 end
 
 /-- If a sequence `v` of real numbers satisfies `k*v n < v (n+1)` with `1 < k`,
-then it goes to +∞ -/
+then it goes to +∞. -/
 lemma tendsto_at_top_of_geom_lt {v : ℕ → ℝ} {k : ℝ} (h₀ : 0 < v 0) (hk : 1 < k)
   (hu : ∀ n, k*v n < v (n+1)) : tendsto v at_top at_top :=
 begin

--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -277,7 +277,7 @@ lemma sum_geometric_two_le (n : ℕ) : ∑ (i : ℕ) in range n, (1 / (2 : ℝ))
 begin
   have : ∀ i, 0 ≤ (1 / (2 : ℝ)) ^ i,
   { intro i, apply pow_nonneg, norm_num },
-  convert sum_le_tsum (range $ n) (λ i _, this i) summable_geometric_two,
+  convert sum_le_tsum (range n) (λ i _, this i) summable_geometric_two,
   exact tsum_geometric_two.symm
 end
 

--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -8,6 +8,7 @@ A collection of specific limit computations.
 import analysis.normed_space.basic
 import algebra.geom_sum
 import topology.instances.ennreal
+import tactic.ring_exp
 
 noncomputable theory
 open_locale classical topological_space
@@ -183,6 +184,39 @@ by_cases
         (tendsto_pow_at_top_at_top_of_one_lt $ one_lt_inv (lt_of_le_of_ne h₁ this.symm) h₂),
     tendsto.congr' (univ_mem_sets' $ by simp *) this)
 
+lemma geom_lt {u : ℕ → ℝ} {k : ℝ} (hk : 0 < k) {n : ℕ} (h : ∀ m ≤ n, k*u m < u (m + 1)) :
+k^(n + 1) *u 0 < u (n + 1) :=
+begin
+ induction n with n ih,
+ { simpa using h 0 (le_refl _) },
+ have : (∀ (m : ℕ), m ≤ n → k * u m < u (m + 1)),
+   intros m hm, apply h, exact nat.le_succ_of_le hm,
+ specialize ih this,
+ change k ^ (n + 2) * u 0 < u (n + 2),
+ replace h : k * u (n + 1) < u (n + 2) := h (n+1) (le_refl _),
+ calc k ^ (n + 2) * u 0 = k*(k ^ (n + 1) * u 0) : by ring_exp
+  ... < k*(u (n + 1)) : mul_lt_mul_of_pos_left ih hk
+  ... < u (n + 2) : h,
+end
+
+/-- If a sequence `v` of real numbers satisfies `k*v n < v (n+1)` with `1 < k`,
+then it goes to +∞ -/
+lemma tendsto_at_top_of_geom_lt {v : ℕ → ℝ} {k : ℝ} (h₀ : 0 < v 0) (hk : 1 < k)
+  (hu : ∀ n, k*v n < v (n+1)) : tendsto v at_top at_top :=
+begin
+  apply tendsto_at_top_mono,
+  show ∀ n, k^n*v 0 ≤ v n,
+  { intro n,
+    induction n with n ih,
+    { simp },
+    calc
+    k ^ (n + 1) * v 0 = k*(k^n*v 0) : by ring_exp
+                  ... ≤ k*v n       : mul_le_mul_of_nonneg_left ih (by linarith)
+                  ... ≤ v (n + 1)   : le_of_lt (hu n) },
+  apply tendsto_at_top_mul_right h₀,
+  exact tendsto_pow_at_top_at_top_of_one_lt hk,
+end
+
 lemma nnreal.tendsto_pow_at_top_nhds_0_of_lt_1 {r : nnreal} (hr : r < 1) :
   tendsto (λ n:ℕ, r^n) at_top (𝓝 0) :=
 nnreal.tendsto_coe.1 $ by simp only [nnreal.coe_pow, nnreal.coe_zero,
@@ -238,6 +272,14 @@ lemma summable_geometric_two : summable (λn:ℕ, ((1:ℝ)/2) ^ n) :=
 
 lemma tsum_geometric_two : (∑'n:ℕ, ((1:ℝ)/2) ^ n) = 2 :=
 tsum_eq_has_sum has_sum_geometric_two
+
+lemma sum_geometric_two_le (n : ℕ) : ∑ (i : ℕ) in range n, (1 / (2 : ℝ)) ^ i ≤ 2 :=
+begin
+  have : ∀ i, 0 ≤ (1 / (2 : ℝ)) ^ i,
+  { intro i, apply pow_nonneg, norm_num },
+  convert sum_le_tsum (range $ n) (λ i _, this i) summable_geometric_two,
+  exact tsum_geometric_two.symm
+end
 
 lemma has_sum_geometric_two' (a : ℝ) : has_sum (λn:ℕ, (a / 2) / 2 ^ n) a :=
 begin

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -7,7 +7,7 @@ import order.zorn
 import order.copy
 import data.set.finite
 
-/-! 
+/-!
 # Theory of filters on sets
 
 ## Main definitions
@@ -485,6 +485,20 @@ begin
   { rintros S ⟨U, U_in, V, V_in, hUV⟩,
     cases h U_in V_in with a ha,
     use [a, hUV ha] }
+end
+
+lemma inf_eq_bot_iff {f g : filter α} :
+  f ⊓ g = ⊥ ↔ ∃ U V, (U ∈ f) ∧ (V ∈ g) ∧ U ∩ V = ∅ :=
+begin
+  rw ← not_iff_not,
+  simp only [not_exists],
+  convert inf_ne_bot_iff,
+  rw forall_congr,
+  intro U,
+  rw forall_congr,
+  intro V,
+  rw ← ne_empty_iff_nonempty,
+  tauto,
 end
 
 lemma eq_Inf_of_mem_sets_iff_exists_mem {S : set (filter α)} {l : filter α}
@@ -1938,6 +1952,15 @@ def at_bot [preorder α] : filter α := ⨅ a, principal {b | b ≤ a}
 
 lemma mem_at_top [preorder α] (a : α) : {b : α | a ≤ b} ∈ @at_top α _ :=
 mem_infi_sets a $ subset.refl _
+
+lemma Ioi_mem_at_top [preorder α] [no_top_order α] (x : α) : Ioi x ∈ (at_top : filter α) :=
+let ⟨z, hz⟩ := no_top x in mem_sets_of_superset (mem_at_top z) $ λ y h,  lt_of_lt_of_le hz h
+
+lemma mem_at_bot [preorder α] (a : α) : {b : α | b ≤ a} ∈ @at_bot α _ :=
+mem_infi_sets a $ subset.refl _
+
+lemma Iio_mem_at_bot [preorder α] [no_bot_order α] (x : α) : Iio x ∈ (at_bot : filter α) :=
+let ⟨z, hz⟩ := no_bot x in mem_sets_of_superset (mem_at_bot z) $ λ y h, lt_of_le_of_lt h hz
 
 @[simp] lemma at_top_ne_bot [nonempty α] [semilattice_sup α] : (at_top : filter α) ≠ ⊥ :=
 infi_ne_bot_of_directed (by apply_instance)

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -491,15 +491,12 @@ lemma inf_eq_bot_iff {f g : filter α} :
   f ⊓ g = ⊥ ↔ ∃ U V, (U ∈ f) ∧ (V ∈ g) ∧ U ∩ V = ∅ :=
 begin
   rw ← not_iff_not,
-  simp only [not_exists],
-  convert inf_ne_bot_iff,
-  rw forall_congr,
-  intro U,
-  rw forall_congr,
-  intro V,
-  rw ← ne_empty_iff_nonempty,
-  tauto,
+  simp only [not_exists, not_and, ← ne.def, inf_ne_bot_iff, ne_empty_iff_nonempty]
 end
+
+protected lemma disjoint_iff {f g : filter α} :
+  disjoint f g ↔ ∃ U V, (U ∈ f) ∧ (V ∈ g) ∧ U ∩ V = ∅ :=
+disjoint_iff.trans inf_eq_bot_iff
 
 lemma eq_Inf_of_mem_sets_iff_exists_mem {S : set (filter α)} {l : filter α}
   (h : ∀ {s}, s ∈ l ↔ ∃ f ∈ S, s ∈ f) : l = Inf S :=
@@ -1756,6 +1753,13 @@ tendsto_pure.2 rfl
 
 lemma tendsto_const_pure {a : filter α} {b : β} : tendsto (λx, b) a (pure b) :=
 tendsto_pure.2 $ univ_mem_sets' $ λ _, rfl
+
+/-- If two filters are disjoint, then a function cannot tend to both of them along a non-trivial
+filter. -/
+lemma tendsto.not_tendsto {f : α → β} {a : filter α} {b₁ b₂ : filter β} (hf : tendsto f a b₁)
+  (ha : a ≠ ⊥) (hb : disjoint b₁ b₂) :
+  ¬ tendsto f a b₂ :=
+λ hf', (tendsto_inf.2 ⟨hf, hf'⟩).ne_bot ha hb.eq_bot
 
 lemma tendsto_if {l₁ : filter α} {l₂ : filter β}
     {f g : α → β} {p : α → Prop} [decidable_pred p]

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -708,7 +708,7 @@ end
 
 lemma not_tendsto_nhds_of_tendsto_at_top [no_top_order α] [no_bot_order α]
   {F : filter β} (hF : F ≠ ⊥) {f : β → α} (hf : tendsto f F at_top) (x : α) :
-¬ tendsto f F (𝓝 x) :=
+  ¬ tendsto f F (𝓝 x) :=
 begin
   intros h,
   rw tendsto at *,
@@ -719,12 +719,12 @@ end
 
 lemma not_tendsto_at_top_of_tendsto_nhds  [no_top_order α] [no_bot_order α]
   {F : filter β} (hF : F ≠ ⊥) {f : β → α} {x : α} (hf : tendsto f F (𝓝 x)) :
-¬  tendsto f F at_top :=
+  ¬  tendsto f F at_top :=
 λ h', not_tendsto_nhds_of_tendsto_at_top hF h' x hf
 
 lemma not_tendsto_nhds_of_tendsto_at_bot [no_top_order α] [no_bot_order α]
   {F : filter β} (hF : F ≠ ⊥) {f : β → α} (hf : tendsto f F at_bot) (x : α) :
-¬ tendsto f F (𝓝 x) :=
+  ¬ tendsto f F (𝓝 x) :=
 begin
   intros h,
   rw tendsto at *,
@@ -735,7 +735,7 @@ end
 
 lemma not_tendsto_at_bot_of_tendsto_nhds  [no_top_order α] [no_bot_order α]
   {F : filter β} (hF : F ≠ ⊥) {f : β → α} {x : α} (hf : tendsto f F (𝓝 x)) :
-¬  tendsto f F at_bot :=
+  ¬  tendsto f F at_bot :=
 λ h', not_tendsto_nhds_of_tendsto_at_bot hF h' x hf
 
 /-!

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -710,7 +710,7 @@ lemma not_tendsto_nhds_of_tendsto_at_top [no_top_order α]
   ¬ tendsto f F (𝓝 x) :=
 hf.not_tendsto hF (disjoint_nhds_at_top x).symm
 
-lemma not_tendsto_at_top_of_tendsto_nhds [no_top_order α] [no_bot_order α]
+lemma not_tendsto_at_top_of_tendsto_nhds [no_top_order α]
   {F : filter β} (hF : F ≠ ⊥) {f : β → α} {x : α} (hf : tendsto f F (𝓝 x)) :
   ¬  tendsto f F at_top :=
 hf.not_tendsto hF (disjoint_nhds_at_top x)
@@ -720,7 +720,7 @@ lemma not_tendsto_nhds_of_tendsto_at_bot [no_bot_order α]
   ¬ tendsto f F (𝓝 x) :=
 hf.not_tendsto hF (disjoint_nhds_at_bot x).symm
 
-lemma not_tendsto_at_bot_of_tendsto_nhds [no_top_order α] [no_bot_order α]
+lemma not_tendsto_at_bot_of_tendsto_nhds [no_bot_order α]
   {F : filter β} (hF : F ≠ ⊥) {f : β → α} {x : α} (hf : tendsto f F (𝓝 x)) :
   ¬  tendsto f F at_bot :=
 hf.not_tendsto hF (disjoint_nhds_at_bot x)

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -710,7 +710,7 @@ lemma not_tendsto_nhds_of_tendsto_at_top [no_top_order α]
   ¬ tendsto f F (𝓝 x) :=
 hf.not_tendsto hF (disjoint_nhds_at_top x).symm
 
-lemma not_tendsto_at_top_of_tendsto_nhds  [no_top_order α] [no_bot_order α]
+lemma not_tendsto_at_top_of_tendsto_nhds [no_top_order α] [no_bot_order α]
   {F : filter β} (hF : F ≠ ⊥) {f : β → α} {x : α} (hf : tendsto f F (𝓝 x)) :
   ¬  tendsto f F at_top :=
 hf.not_tendsto hF (disjoint_nhds_at_top x)
@@ -720,7 +720,7 @@ lemma not_tendsto_nhds_of_tendsto_at_bot [no_bot_order α]
   ¬ tendsto f F (𝓝 x) :=
 hf.not_tendsto hF (disjoint_nhds_at_bot x).symm
 
-lemma not_tendsto_at_bot_of_tendsto_nhds  [no_top_order α] [no_bot_order α]
+lemma not_tendsto_at_bot_of_tendsto_nhds [no_top_order α] [no_bot_order α]
   {F : filter β} (hF : F ≠ ⊥) {f : β → α} {x : α} (hf : tendsto f F (𝓝 x)) :
   ¬  tendsto f F at_bot :=
 hf.not_tendsto hF (disjoint_nhds_at_bot x)

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -675,6 +675,69 @@ lemma mem_nhds_iff_exists_Ioo_subset [no_top_order α] [no_bot_order α] {a : α
   s ∈ 𝓝 a ↔ ∃l u, a ∈ Ioo l u ∧ Ioo l u ⊆ s :=
 let ⟨l', hl'⟩ := no_bot a in let ⟨u', hu'⟩ := no_top a in mem_nhds_iff_exists_Ioo_subset' hl' hu'
 
+lemma Ioo_mem_nhds {a b x : α} (ha : a < x) (hb : x < b) : Ioo a b ∈ 𝓝 x :=
+mem_nhds_sets is_open_Ioo ⟨ha, hb⟩
+
+lemma inf_nhds_at_top (x : α) [no_top_order α] [no_bot_order α] :
+  𝓝 x ⊓ at_top = ⊥ :=
+begin
+  rw inf_eq_bot_iff,
+  cases no_bot x with a ha,
+  cases no_top x with b hb,
+  cases no_top b with c hc,
+  use [Ioo a b, Ioi c, Ioo_mem_nhds ha hb, Ioi_mem_at_top c],
+  ext y,
+  suffices : a < y → y < b → y ≤ c, by simpa,
+  intros h h',
+  exact le_of_lt (lt_trans h' hc)
+end
+
+lemma inf_nhds_at_bot (x : α) [no_top_order α] [no_bot_order α] :
+  𝓝 x ⊓ at_bot = ⊥ :=
+begin
+  rw inf_eq_bot_iff,
+  cases no_bot x with b hb,
+  cases no_bot b with a' ha,
+  cases no_top x with c hc,
+  use [Ioo b c, Iio a', Ioo_mem_nhds hb hc, Iio_mem_at_bot a'],
+  ext y,
+  suffices : b < y → y < c → a' ≤ y, by simpa,
+  intros h h',
+  exact le_of_lt (lt_trans ha h)
+end
+
+lemma not_tendsto_nhds_of_tendsto_at_top [no_top_order α] [no_bot_order α]
+  {F : filter β} (hF : F ≠ ⊥) {f : β → α} (hf : tendsto f F at_top) (x : α) :
+¬ tendsto f F (𝓝 x) :=
+begin
+  intros h,
+  rw tendsto at *,
+  have : map f F ≤ 𝓝 x ⊓ at_top,
+    from le_inf h hf,
+  exact ne_bot_of_le_ne_bot (map_ne_bot hF) this (inf_nhds_at_top _),
+end
+
+lemma not_tendsto_at_top_of_tendsto_nhds  [no_top_order α] [no_bot_order α]
+  {F : filter β} (hF : F ≠ ⊥) {f : β → α} {x : α} (hf : tendsto f F (𝓝 x)) :
+¬  tendsto f F at_top :=
+λ h', not_tendsto_nhds_of_tendsto_at_top hF h' x hf
+
+lemma not_tendsto_nhds_of_tendsto_at_bot [no_top_order α] [no_bot_order α]
+  {F : filter β} (hF : F ≠ ⊥) {f : β → α} (hf : tendsto f F at_bot) (x : α) :
+¬ tendsto f F (𝓝 x) :=
+begin
+  intros h,
+  rw tendsto at *,
+  have : map f F ≤ 𝓝 x ⊓ at_bot,
+    from le_inf h hf,
+  exact ne_bot_of_le_ne_bot (map_ne_bot hF) this (inf_nhds_at_bot _),
+end
+
+lemma not_tendsto_at_bot_of_tendsto_nhds  [no_top_order α] [no_bot_order α]
+  {F : filter β} (hF : F ≠ ⊥) {f : β → α} {x : α} (hf : tendsto f F (𝓝 x)) :
+¬  tendsto f F at_bot :=
+λ h', not_tendsto_nhds_of_tendsto_at_bot hF h' x hf
+
 /-!
 ### Neighborhoods to the left and to the right
 

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -675,68 +675,55 @@ lemma mem_nhds_iff_exists_Ioo_subset [no_top_order α] [no_bot_order α] {a : α
   s ∈ 𝓝 a ↔ ∃l u, a ∈ Ioo l u ∧ Ioo l u ⊆ s :=
 let ⟨l', hl'⟩ := no_bot a in let ⟨u', hu'⟩ := no_top a in mem_nhds_iff_exists_Ioo_subset' hl' hu'
 
+lemma Iio_mem_nhds {a b : α} (h : a < b) : Iio b ∈ 𝓝 a :=
+mem_nhds_sets is_open_Iio h
+
+lemma Ioi_mem_nhds {a b : α} (h : a < b) : Ioi a ∈ 𝓝 b :=
+mem_nhds_sets is_open_Ioi h
+
 lemma Ioo_mem_nhds {a b x : α} (ha : a < x) (hb : x < b) : Ioo a b ∈ 𝓝 x :=
 mem_nhds_sets is_open_Ioo ⟨ha, hb⟩
 
-lemma inf_nhds_at_top (x : α) [no_top_order α] [no_bot_order α] :
+lemma disjoint_nhds_at_top [no_top_order α] (x : α) :
+  disjoint (𝓝 x) at_top :=
+begin
+  rw filter.disjoint_iff,
+  cases no_top x with a ha,
+  use [Iio a, Ici a, Iio_mem_nhds ha, mem_at_top a],
+  rw [inter_comm, Ici_inter_Iio, Ico_self]
+end
+
+@[simp] lemma inf_nhds_at_top [no_top_order α] (x : α) :
   𝓝 x ⊓ at_top = ⊥ :=
-begin
-  rw inf_eq_bot_iff,
-  cases no_bot x with a ha,
-  cases no_top x with b hb,
-  cases no_top b with c hc,
-  use [Ioo a b, Ioi c, Ioo_mem_nhds ha hb, Ioi_mem_at_top c],
-  ext y,
-  suffices : a < y → y < b → y ≤ c, by simpa,
-  intros h h',
-  exact le_of_lt (lt_trans h' hc)
-end
+disjoint_iff.1 (disjoint_nhds_at_top x)
 
-lemma inf_nhds_at_bot (x : α) [no_top_order α] [no_bot_order α] :
+lemma disjoint_nhds_at_bot [no_bot_order α] (x : α) :
+  disjoint (𝓝 x) at_bot :=
+@disjoint_nhds_at_top (order_dual α) _ _ _ _ x
+
+@[simp] lemma inf_nhds_at_bot [no_bot_order α] (x : α) :
   𝓝 x ⊓ at_bot = ⊥ :=
-begin
-  rw inf_eq_bot_iff,
-  cases no_bot x with b hb,
-  cases no_bot b with a' ha,
-  cases no_top x with c hc,
-  use [Ioo b c, Iio a', Ioo_mem_nhds hb hc, Iio_mem_at_bot a'],
-  ext y,
-  suffices : b < y → y < c → a' ≤ y, by simpa,
-  intros h h',
-  exact le_of_lt (lt_trans ha h)
-end
+@inf_nhds_at_top (order_dual α) _ _ _ _ x
 
-lemma not_tendsto_nhds_of_tendsto_at_top [no_top_order α] [no_bot_order α]
+lemma not_tendsto_nhds_of_tendsto_at_top [no_top_order α]
   {F : filter β} (hF : F ≠ ⊥) {f : β → α} (hf : tendsto f F at_top) (x : α) :
   ¬ tendsto f F (𝓝 x) :=
-begin
-  intros h,
-  rw tendsto at *,
-  have : map f F ≤ 𝓝 x ⊓ at_top,
-    from le_inf h hf,
-  exact ne_bot_of_le_ne_bot (map_ne_bot hF) this (inf_nhds_at_top _),
-end
+hf.not_tendsto hF (disjoint_nhds_at_top x).symm
 
 lemma not_tendsto_at_top_of_tendsto_nhds  [no_top_order α] [no_bot_order α]
   {F : filter β} (hF : F ≠ ⊥) {f : β → α} {x : α} (hf : tendsto f F (𝓝 x)) :
   ¬  tendsto f F at_top :=
-λ h', not_tendsto_nhds_of_tendsto_at_top hF h' x hf
+hf.not_tendsto hF (disjoint_nhds_at_top x)
 
-lemma not_tendsto_nhds_of_tendsto_at_bot [no_top_order α] [no_bot_order α]
+lemma not_tendsto_nhds_of_tendsto_at_bot [no_bot_order α]
   {F : filter β} (hF : F ≠ ⊥) {f : β → α} (hf : tendsto f F at_bot) (x : α) :
   ¬ tendsto f F (𝓝 x) :=
-begin
-  intros h,
-  rw tendsto at *,
-  have : map f F ≤ 𝓝 x ⊓ at_bot,
-    from le_inf h hf,
-  exact ne_bot_of_le_ne_bot (map_ne_bot hF) this (inf_nhds_at_bot _),
-end
+hf.not_tendsto hF (disjoint_nhds_at_bot x).symm
 
 lemma not_tendsto_at_bot_of_tendsto_nhds  [no_top_order α] [no_bot_order α]
   {F : filter β} (hF : F ≠ ⊥) {f : β → α} {x : α} (hf : tendsto f F (𝓝 x)) :
   ¬  tendsto f F at_bot :=
-λ h', not_tendsto_nhds_of_tendsto_at_bot hF h' x hf
+hf.not_tendsto hF (disjoint_nhds_at_bot x)
 
 /-!
 ### Neighborhoods to the left and to the right


### PR DESCRIPTION
Adds Hofer's lemma about complete metric spaces, with supporting material.

---
<!-- put comments you want to keep out of the PR commit here -->

The origin of this PR is that Hofer asked me to give a talk about formalized maths so I wanted to use his only elementary lemma during my demo. But I think the proof is a nice example to have in mathlib, and it also revealed crazy holes in mathlib like showing a sequence of real numbers cannot tend both to a finite and an infinite limit.

We still lack a large number of lemmas about the `at_bot` filter compared to `at_top` which is very well served because of its importance for sequences. Maybe someone should write a version of `to_additive` that would turn lemmas about `at_top` to lemmas about `at_bot`.