### PR TITLE
[Merged by Bors] - refactor(order/basic): make `*order.lift` use `[]` argument

### DIFF
--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -201,8 +201,8 @@ add_pos' h h
 namespace units
 
 @[to_additive]
-instance [monoid α] [i : preorder α] : preorder (units α) :=
-preorder.lift (coe : units α → α) i
+instance [monoid α] [preorder α] : preorder (units α) :=
+preorder.lift (coe : units α → α)
 
 @[simp, to_additive]
 theorem coe_le_coe [monoid α] [preorder α] {a b : units α} :
@@ -213,16 +213,16 @@ theorem coe_lt_coe [monoid α] [preorder α] {a b : units α} :
   (a : α) < b ↔ a < b := iff.rfl
 
 @[to_additive]
-instance [monoid α] [i : partial_order α] : partial_order (units α) :=
-partial_order.lift (coe : units α → α) (by ext) i
+instance [monoid α] [partial_order α] : partial_order (units α) :=
+partial_order.lift coe units.ext
 
 @[to_additive]
-instance [monoid α] [i : linear_order α] : linear_order (units α) :=
-linear_order.lift (coe : units α → α) (by ext) i
+instance [monoid α] [linear_order α] : linear_order (units α) :=
+linear_order.lift coe units.ext
 
 @[to_additive]
-instance [monoid α] [i : decidable_linear_order α] : decidable_linear_order (units α) :=
-decidable_linear_order.lift (coe : units α → α) (by ext) i
+instance [monoid α] [decidable_linear_order α] : decidable_linear_order (units α) :=
+decidable_linear_order.lift coe units.ext
 
 @[simp, to_additive]
 theorem max_coe [monoid α] [decidable_linear_order α] {a b : units α} :

--- a/src/analysis/convex/cone.lean
+++ b/src/analysis/convex/cone.lean
@@ -153,7 +153,7 @@ instance : complete_lattice (convex_cone E) :=
   Sup_le       := λ s p hs x hx, mem_Inf.1 hx p hs,
   le_Inf       := λ s a ha x hx, mem_Inf.2 $ λ t ht, ha t ht hx,
   Inf_le       := λ s a ha x hx, mem_Inf.1 hx _ ha,
-  .. partial_order.lift (coe : convex_cone E → set E) (λ a b, ext') (by apply_instance) }
+  .. partial_order.lift (coe : convex_cone E → set E) (λ a b, ext') }
 
 instance : inhabited (convex_cone E) := ⟨⊥⟩
 

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -164,7 +164,7 @@ protected lemma heq_ext_iff {k l : ℕ} (h : k = l) {i : fin k} {j : fin l} :
 by { induction h, simp [fin.ext_iff] }
 
 instance {n : ℕ} : decidable_linear_order (fin n) :=
-decidable_linear_order.lift fin.val (@fin.eq_of_veq _) (by apply_instance)
+decidable_linear_order.lift fin.val (@fin.eq_of_veq _)
 
 lemma exists_iff {p : fin n → Prop} : (∃ i, p i) ↔ ∃ i h, p ⟨i, h⟩ :=
 ⟨λ h, exists.elim h (λ ⟨i, hi⟩ hpi, ⟨i, hi, hpi⟩),

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -133,7 +133,7 @@ to_real_hom.to_add_monoid_hom.map_nsmul _ _
 to_real_hom.map_nat_cast n
 
 instance : decidable_linear_order ℝ≥0 :=
-decidable_linear_order.lift (coe : ℝ≥0 → ℝ) subtype.val_injective (by apply_instance)
+decidable_linear_order.lift (coe : ℝ≥0 → ℝ) subtype.val_injective
 
 @[norm_cast] protected lemma coe_le_coe {r₁ r₂ : ℝ≥0} : (r₁ : ℝ) ≤ r₂ ↔ r₁ ≤ r₂ := iff.rfl
 @[norm_cast] protected lemma coe_lt_coe {r₁ r₂ : ℝ≥0} : (r₁ : ℝ) < r₂ ↔ r₁ < r₂ := iff.rfl

--- a/src/geometry/manifold/manifold.lean
+++ b/src/geometry/manifold/manifold.lean
@@ -133,7 +133,7 @@ variable [topological_space H]
 /-- Partial order on the set of groupoids, given by inclusion of the members of the groupoid -/
 instance structure_groupoid.partial_order : partial_order (structure_groupoid H) :=
 partial_order.lift structure_groupoid.members
-(λa b h, by { cases a, cases b, dsimp at h, induction h, refl }) (by apply_instance)
+(λa b h, by { cases a, cases b, dsimp at h, induction h, refl })
 
 /-- The trivial groupoid, containing only the identity (and maps with empty source, as this is
 necessary from the definition) -/

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -312,7 +312,7 @@ lemma coe_subset_coe {H K : subgroup G} : (H : set G) ⊆ K ↔ H ≤ K := iff.r
 @[to_additive]
 instance : partial_order (subgroup G) :=
 { le := (≤),
-  .. partial_order.lift (coe : subgroup G → set G) (λ a b, ext') infer_instance }
+  .. partial_order.lift (coe : subgroup G → set G) (λ a b, ext') }
 
 /-- The subgroup `G` of the group `G`. -/
 @[to_additive "The `add_subgroup G` of the `add_group G`."]

--- a/src/group_theory/submonoid.lean
+++ b/src/group_theory/submonoid.lean
@@ -237,7 +237,7 @@ lemma coe_subset_coe {S T : submonoid M} : (S : set M) ⊆ T ↔ S ≤ T := iff.
 @[to_additive]
 instance : partial_order (submonoid M) :=
 { le := λ S T, ∀ ⦃x⦄, x ∈ S → x ∈ T,
-  .. partial_order.lift (coe : submonoid M → set M) ext' infer_instance }
+  .. partial_order.lift (coe : submonoid M → set M) ext' }
 
 @[simp, norm_cast, to_additive]
 lemma coe_ssubset_coe {S T : submonoid M} : (S : set M) ⊂ T ↔ S < T := iff.rfl

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -380,7 +380,7 @@ open set
 
 instance : partial_order (submodule R M) :=
 { le := λ p p', ∀ ⦃x⦄, x ∈ p → x ∈ p',
-  ..partial_order.lift (coe : submodule R M → set M) ext' (by apply_instance) }
+  ..partial_order.lift (coe : submodule R M → set M) ext' }
 
 variables {p p'}
 

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -337,8 +337,7 @@ theorem strict_mono.order_dual [has_lt α] [has_lt β] {f : α → β} (hf : str
 λ x y hxy, hf hxy
 
 /-- Transfer a `preorder` on `β` to a `preorder` on `α` using a function `f : α → β`. -/
-def preorder.lift {α β} (f : α → β) (i : preorder β) : preorder α :=
-by exactI
+def preorder.lift {α β} [preorder β] (f : α → β) : preorder α :=
 { le := λx y, f x ≤ f y,
   le_refl := λ a, le_refl _,
   le_trans := λ a b c, le_trans,
@@ -347,41 +346,38 @@ by exactI
 
 /-- Transfer a `partial_order` on `β` to a `partial_order` on `α` using an injective
 function `f : α → β`. -/
-def partial_order.lift {α β} (f : α → β) (inj : injective f) (i : partial_order β) :
+def partial_order.lift {α β} [partial_order β] (f : α → β) (inj : injective f) :
   partial_order α :=
-by exactI
-{ le_antisymm := λ a b h₁ h₂, inj (le_antisymm h₁ h₂), .. preorder.lift f (by apply_instance) }
+{ le_antisymm := λ a b h₁ h₂, inj (le_antisymm h₁ h₂), .. preorder.lift f }
 
 /-- Transfer a `linear_order` on `β` to a `linear_order` on `α` using an injective
 function `f : α → β`. -/
-def linear_order.lift {α β} (f : α → β) (inj : injective f) (i : linear_order β) :
+def linear_order.lift {α β} [linear_order β] (f : α → β) (inj : injective f) :
   linear_order α :=
-by exactI
-{ le_total := λx y, le_total (f x) (f y), .. partial_order.lift f inj (by apply_instance) }
+{ le_total := λx y, le_total (f x) (f y), .. partial_order.lift f inj }
 
 /-- Transfer a `decidable_linear_order` on `β` to a `decidable_linear_order` on `α` using
 an injective function `f : α → β`. -/
-def decidable_linear_order.lift {α β} (f : α → β) (inj : injective f)
-  (i : decidable_linear_order β) : decidable_linear_order α :=
-by exactI
+def decidable_linear_order.lift {α β} [decidable_linear_order β] (f : α → β) (inj : injective f) :
+  decidable_linear_order α :=
 { decidable_le := λ x y, show decidable (f x ≤ f y), by apply_instance,
   decidable_lt := λ x y, show decidable (f x < f y), by apply_instance,
   decidable_eq := λ x y, decidable_of_iff _ ⟨@inj x y, congr_arg f⟩,
-  .. linear_order.lift f inj (by apply_instance) }
+  .. linear_order.lift f inj }
 
-instance subtype.preorder {α} [i : preorder α] (p : α → Prop) : preorder (subtype p) :=
-preorder.lift subtype.val i
+instance subtype.preorder {α} [preorder α] (p : α → Prop) : preorder (subtype p) :=
+preorder.lift subtype.val
 
-instance subtype.partial_order {α} [i : partial_order α] (p : α → Prop) :
+instance subtype.partial_order {α} [partial_order α] (p : α → Prop) :
   partial_order (subtype p) :=
-partial_order.lift subtype.val subtype.val_injective i
+partial_order.lift subtype.val subtype.val_injective
 
-instance subtype.linear_order {α} [i : linear_order α] (p : α → Prop) : linear_order (subtype p) :=
-linear_order.lift subtype.val subtype.val_injective i
+instance subtype.linear_order {α} [linear_order α] (p : α → Prop) : linear_order (subtype p) :=
+linear_order.lift subtype.val subtype.val_injective
 
-instance subtype.decidable_linear_order {α} [i : decidable_linear_order α] (p : α → Prop) :
+instance subtype.decidable_linear_order {α} [decidable_linear_order α] (p : α → Prop) :
   decidable_linear_order (subtype p) :=
-decidable_linear_order.lift subtype.val subtype.val_injective i
+decidable_linear_order.lift subtype.val subtype.val_injective
 
 instance prod.has_le (α : Type u) (β : Type v) [has_le α] [has_le β] : has_le (α × β) :=
 ⟨λp q, p.1 ≤ q.1 ∧ p.2 ≤ q.2⟩

--- a/src/order/zorn.lean
+++ b/src/order/zorn.lean
@@ -245,7 +245,7 @@ theorem zorn_subset {α : Type u} (S : set (set α))
   (h : ∀c ⊆ S, chain (⊆) c → ∃ub ∈ S, ∀ s ∈ c, s ⊆ ub) :
   ∃ m ∈ S, ∀a ∈ S, m ⊆ a → a = m :=
 begin
-  letI : partial_order S := partial_order.lift subtype.val (λ _ _, subtype.eq') (by apply_instance),
+  letI : partial_order S := partial_order.lift subtype.val (λ _ _, subtype.eq'),
   have : ∀c:set S, @chain S (≤) c → ∃ub, ∀a∈c, a ≤ ub,
   { intros c hc,
     rcases h (subtype.val '' c) (image_subset_iff.2 _) _ with ⟨s, sS, hs⟩,

--- a/src/ring_theory/subsemiring.lean
+++ b/src/ring_theory/subsemiring.lean
@@ -172,7 +172,7 @@ def subtype : s →+* R :=
 
 instance : partial_order (subsemiring R) :=
 { le := λ s t, ∀ ⦃x⦄, x ∈ s → x ∈ t,
-  .. partial_order.lift (coe : subsemiring R → set R) ext' _ }
+  .. partial_order.lift (coe : subsemiring R → set R) ext' }
 
 lemma le_def {s t : subsemiring R} : s ≤ t ↔ ∀ ⦃x : R⦄, x ∈ s → x ∈ t := iff.rfl
 

--- a/src/topology/algebra/open_subgroup.lean
+++ b/src/topology/algebra/open_subgroup.lean
@@ -118,7 +118,7 @@ end
 @[to_additive]
 instance : partial_order (open_subgroup G) :=
 { le := λ U V, ∀ ⦃x⦄, x ∈ U → x ∈ V,
-  .. partial_order.lift (coe : open_subgroup G → set G) ext' infer_instance }
+  .. partial_order.lift (coe : open_subgroup G → set G) ext' }
 
 @[to_additive]
 instance : semilattice_inf_top (open_subgroup G) :=


### PR DESCRIPTION
Take an order on the codomain as a `[*order β]` argument.

---
<!-- put comments you want to keep out of the PR commit here -->