### PR TITLE
[Merged by Bors] - perf(*): avoid `user_attribute.get_param`

### DIFF
--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -148,8 +148,7 @@ meta def proceed_fields (env : environment) (src tgt : name) (prio : ℕ) : comm
 let aux := proceed_fields_aux src tgt prio in
 do
 aux (λ n, pure $ list.map name.to_string $ (env.structure_fields n).get_or_else []) >>
-aux (λ n, (list.map (λ (x : name), "to_" ++ x.to_string) <$>
-                            (ancestor_attr.get_param n <|> pure []))) >>
+aux (λ n, (list.map (λ (x : name), "to_" ++ x.to_string) <$> get_tagged_ancestors n)) >>
 aux (λ n, (env.constructors_of n).mmap $
           λ cs, match cs with
                 | (name.mk_string s pre) :=

--- a/src/tactic/algebra.lean
+++ b/src/tactic/algebra.lean
@@ -9,16 +9,48 @@ open lean.parser
 
 namespace tactic
 
+section performance -- see Note [user attribute parameters]
+
+local attribute [semireducible] reflected
+
+local attribute [instance, priority 9000]
+private meta def reflect_name_list : has_reflect (list name) | ns :=
+`(id %%(expr.mk_app `(Prop) $ ns.map (flip expr.const [])) : list name)
+
+private meta def parse_name_list (e : expr) : list name :=
+e.app_arg.get_app_args.map expr.const_name
+
 @[user_attribute]
-meta def ancestor_attr : user_attribute unit (list name) :=
+private meta def ancestor_attr : user_attribute unit (list name) :=
 { name := `ancestor,
   descr := "ancestor of old structures",
   parser := many ident }
 
+end performance
+
+/--
+Returns the parents of a structure added via the `ancestor` attribute.
+
+On failure, the empty list is returned.
+-/
+meta def get_tagged_ancestors (cl : name) : tactic (list name) :=
+parse_name_list <$> ancestor_attr.get_param_untyped cl <|> pure []
+
+/--
+Returns the parents of a structure added via the `ancestor` attribute, as well as subobjects.
+
+On failure, the empty list is returned.
+-/
 meta def get_ancestors (cl : name) : tactic (list name) :=
 (++) <$> (prod.fst <$> subobject_names cl <|> pure [])
-     <*> (user_attribute.get_param ancestor_attr cl <|> pure [])
+     <*> get_tagged_ancestors cl
 
+/--
+Returns the (transitive) ancestors of a structure added via the `ancestor`
+attribute (or reachable via subobjects).
+
+On failure, the empty list is returned.
+-/
 meta def find_ancestors : name → expr → tactic (list expr) | cl arg :=
 do cs ← get_ancestors cl,
    r ← cs.mmap $ λ c, list.ret <$> (mk_app c [arg] >>= mk_instance) <|> find_ancestors c arg,


### PR DESCRIPTION
Recent studies have shown that `monoid_localization.lean` is the slowest file in mathlib.  One hundred and three seconds (93%) of its class-leading runtime are spent in constructing the attribute cache for `_to_additive`.  This is due to the use of the `user_attribute.get_param` function inside `get_cache`.  See the [library note on user attribute parameters](https://leanprover-community.github.io/mathlib_docs/notes.html#user%20attribute%20parameters) for more information on this anti-pattern.

This PR removes two uses of `user_attribute.get_param`, one in `to_additive` and the other in `ancestor`.

---
<!-- put comments you want to keep out of the PR commit here -->

Not sure if this breaks anything.