### PR TITLE
refactor(data/finset): use `lattice` operations

### DIFF
--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -78,57 +78,32 @@ set.ext_iff.trans ext_iff.symm
 lemma coe_injective {α} : function.injective (coe : finset α → set α) :=
 λ s t, coe_inj.1
 
-/-! ### subset -/
+/-!
+### Partial order with bottom element structure
+-/
 
-instance : has_subset (finset α) := ⟨λ s₁ s₂, ∀ ⦃a⦄, a ∈ s₁ → a ∈ s₂⟩
+instance : order_bot (finset α) :=
+{ le := λ s t, ∀ ⦃a⦄, a ∈ s → a ∈ t,
+  bot := ⟨0, nodup_zero⟩,
+  bot_le := λ _, zero_subset _,
+  .. partial_order.lift (coe : finset α → set α) coe_injective }
 
-theorem subset_def {s₁ s₂ : finset α} : s₁ ⊆ s₂ ↔ s₁.1 ⊆ s₂.1 := iff.rfl
+@[simp, norm_cast] lemma coe_subset {s t : finset α} : (↑s : set α) ⊆ ↑t ↔ s ≤ t := iff.rfl
 
-@[simp] theorem subset.refl (s : finset α) : s ⊆ s := subset.refl _
+@[simp, norm_cast] lemma coe_ssubset {s t : finset α} : (↑s : set α) ⊂ ↑t ↔ s < t := iff.rfl
 
-theorem subset.trans {s₁ s₂ s₃ : finset α} : s₁ ⊆ s₂ → s₂ ⊆ s₃ → s₁ ⊆ s₃ := subset.trans
+@[simp] lemma val_subset_iff {s t : finset α} : s.1 ⊆ t.1 ↔ s ≤ t := iff.rfl
 
-theorem superset.trans {s₁ s₂ s₃ : finset α} : s₁ ⊇ s₂ → s₂ ⊇ s₃ → s₁ ⊇ s₃ :=
-λ h' h, subset.trans h h'
+@[simp] lemma val_le_iff {s t : finset α} : s.1 ≤ t.1 ↔ s ≤ t := le_iff_subset s.2
 
--- TODO: these should be global attributes, but this will require fixing other files
-local attribute [trans] subset.trans superset.trans
+@[simp] lemma val_lt_iff {s t : finset α} : s.1 < t.1 ↔ s < t :=
+lt_iff_lt_of_le_iff_le' val_le_iff val_le_iff
 
-theorem mem_of_subset {s₁ s₂ : finset α} {a : α} : s₁ ⊆ s₂ → a ∈ s₁ → a ∈ s₂ := mem_of_subset
+theorem mem_of_le {s t : finset α} {a : α} : s ≤ t → a ∈ s → a ∈ t := mem_of_subset
 
-theorem subset.antisymm {s₁ s₂ : finset α} (H₁ : s₁ ⊆ s₂) (H₂ : s₂ ⊆ s₁) : s₁ = s₂ :=
-ext $ λ a, ⟨@H₁ a, @H₂ a⟩
+theorem le_def {s t : finset α} : s ≤ t ↔ ∀ ⦃x⦄, x ∈ s → x ∈ t := iff.rfl
 
-theorem subset_iff {s₁ s₂ : finset α} : s₁ ⊆ s₂ ↔ ∀ ⦃x⦄, x ∈ s₁ → x ∈ s₂ := iff.rfl
-
-@[simp] theorem coe_subset {s₁ s₂ : finset α} :
-  (↑s₁ : set α) ⊆ ↑s₂ ↔ s₁ ⊆ s₂ := iff.rfl
-
-@[simp] theorem val_le_iff {s₁ s₂ : finset α} : s₁.1 ≤ s₂.1 ↔ s₁ ⊆ s₂ := le_iff_subset s₁.2
-
-instance : has_ssubset (finset α) := ⟨λa b, a ⊆ b ∧ ¬ b ⊆ a⟩
-
-instance : partial_order (finset α) :=
-{ le := (⊆),
-  lt := (⊂),
-  le_refl := subset.refl,
-  le_trans := @subset.trans _,
-  le_antisymm := @subset.antisymm _ }
-
-theorem subset.antisymm_iff {s₁ s₂ : finset α} : s₁ = s₂ ↔ s₁ ⊆ s₂ ∧ s₂ ⊆ s₁ :=
-le_antisymm_iff
-
-@[simp] theorem le_iff_subset {s₁ s₂ : finset α} : s₁ ≤ s₂ ↔ s₁ ⊆ s₂ := iff.rfl
-@[simp] theorem lt_iff_ssubset {s₁ s₂ : finset α} : s₁ < s₂ ↔ s₁ ⊂ s₂ := iff.rfl
-
-@[simp] lemma coe_ssubset {s₁ s₂ : finset α} : (↑s₁ : set α) ⊂ ↑s₂ ↔ s₁ ⊂ s₂ :=
-show (↑s₁ : set α) ⊂ ↑s₂ ↔ s₁ ⊆ s₂ ∧ ¬s₂ ⊆ s₁,
-  by simp only [set.ssubset_def, finset.coe_subset]
-
-@[simp] theorem val_lt_iff {s₁ s₂ : finset α} : s₁.1 < s₂.1 ↔ s₁ ⊂ s₂ :=
-and_congr val_le_iff $ not_congr val_le_iff
-
-theorem ssubset_iff_of_subset {s₁ s₂ : finset α} (h : s₁ ⊆ s₂) : s₁ ⊂ s₂ ↔ ∃ x ∈ s₂, x ∉ s₁ :=
+theorem lt_iff_of_le {s t : finset α} (h : s ≤ t) : s < t ↔ ∃ x ∈ t, x ∉ s :=
 set.ssubset_iff_of_subset h
 
 /-! ### Nonempty -/
@@ -140,52 +115,47 @@ protected def nonempty (s : finset α) : Prop := ∃ x:α, x ∈ s
 
 @[norm_cast] lemma coe_nonempty {s : finset α} : (↑s:set α).nonempty ↔ s.nonempty := iff.rfl
 
+lemma nonempty.coe {s : finset α} (h : s.nonempty) : (↑s:set α).nonempty := h
+
 lemma nonempty.bex {s : finset α} (h : s.nonempty) : ∃ x:α, x ∈ s := h
 
-lemma nonempty.mono {s t : finset α} (hst : s ⊆ t) (hs : s.nonempty) : t.nonempty :=
+lemma nonempty.mono {s t : finset α} (hst : s ≤ t) (hs : s.nonempty) : t.nonempty :=
 set.nonempty.mono hst hs
 
-/-! ### empty -/
+/-!
+### empty set, denoted by `⊥`
+-/
 
-/-- The empty finset -/
-protected def empty : finset α := ⟨0, nodup_zero⟩
+instance : inhabited (finset α) := ⟨⊥⟩
 
-instance : has_emptyc (finset α) := ⟨finset.empty⟩
+@[simp, norm_cast] lemma coe_bot : (↑(⊥ : finset α) : set α)  = ∅ := rfl
 
-instance : inhabited (finset α) := ⟨∅⟩
+@[simp] lemma bot_val : (⊥ : finset α).1 = 0 := rfl
 
-@[simp] theorem empty_val : (∅ : finset α).1 = 0 := rfl
+@[simp] theorem not_mem_bot (a : α) : a ∉ (⊥ : finset α) := id
 
-@[simp] theorem not_mem_empty (a : α) : a ∉ (∅ : finset α) := id
+@[simp] theorem ne_bot_of_mem {a : α} {s : finset α} (h : a ∈ s) : s ≠ ⊥ :=
+λ e, not_mem_bot a $ e ▸ h
 
-@[simp] theorem ne_empty_of_mem {a : α} {s : finset α} (h : a ∈ s) : s ≠ ∅ :=
-λ e, not_mem_empty a $ e ▸ h
+theorem nonempty.ne_bot {s : finset α} (h : s.nonempty) : s ≠ ⊥ :=
+exists.elim h $ λ a, ne_bot_of_mem
 
-theorem nonempty.ne_empty {s : finset α} (h : s.nonempty) : s ≠ ∅ :=
-exists.elim h $ λ a, ne_empty_of_mem
-
-@[simp] theorem empty_subset (s : finset α) : ∅ ⊆ s := zero_subset _
-
-theorem eq_empty_of_forall_not_mem {s : finset α} (H : ∀x, x ∉ s) : s = ∅ :=
+theorem eq_bot_of_forall_not_mem {s : finset α} (H : ∀x, x ∉ s) : s = ⊥ :=
 eq_of_veq (eq_zero_of_forall_not_mem H)
 
-lemma eq_empty_iff_forall_not_mem {s : finset α} : s = ∅ ↔ ∀ x, x ∉ s :=
-⟨by rintro rfl x; exact id, λ h, eq_empty_of_forall_not_mem h⟩
+lemma eq_bot_iff_forall_not_mem {s : finset α} : s = ⊥ ↔ ∀ x, x ∉ s :=
+⟨by rintro rfl x; exact id, λ h, eq_bot_of_forall_not_mem h⟩
 
-@[simp] theorem val_eq_zero {s : finset α} : s.1 = 0 ↔ s = ∅ := @val_inj _ s ∅
+@[simp] theorem val_eq_zero {s : finset α} : s.1 = 0 ↔ s = ⊥ := @val_inj _ s ⊥
 
-theorem subset_empty {s : finset α} : s ⊆ ∅ ↔ s = ∅ := subset_zero.trans val_eq_zero
-
-theorem nonempty_of_ne_empty {s : finset α} (h : s ≠ ∅) : s.nonempty :=
+theorem nonempty_of_ne_bot {s : finset α} (h : s ≠ ⊥) : s.nonempty :=
 exists_mem_of_ne_zero (mt val_eq_zero.1 h)
 
-theorem nonempty_iff_ne_empty {s : finset α} : s.nonempty ↔ s ≠ ∅ :=
-⟨nonempty.ne_empty, nonempty_of_ne_empty⟩
+theorem nonempty_iff_ne_bot {s : finset α} : s.nonempty ↔ s ≠ ⊥ :=
+⟨nonempty.ne_bot, nonempty_of_ne_bot⟩
 
-theorem eq_empty_or_nonempty (s : finset α) : s = ∅ ∨ s.nonempty :=
-classical.by_cases or.inl (λ h, or.inr (nonempty_of_ne_empty h))
-
-@[simp] lemma coe_empty : ↑(∅ : finset α) = (∅ : set α) := rfl
+theorem eq_bot_or_nonempty (s : finset α) : s = ⊥ ∨ s.nonempty :=
+classical.by_cases or.inl (λ h, or.inr (nonempty_of_ne_bot h))
 
 /-! ### singleton -/
 /--
@@ -208,7 +178,7 @@ theorem singleton_inj {a b : α} : ({a} : finset α) = {b} ↔ a = b :=
 
 theorem singleton_nonempty (a : α) : ({a} : finset α).nonempty := ⟨a, mem_singleton_self a⟩
 
-@[simp] theorem singleton_ne_empty (a : α) : ({a} : finset α) ≠ ∅ := (singleton_nonempty a).ne_empty
+@[simp] theorem singleton_ne_bot (a : α) : ({a} : finset α) ≠ ⊥ := (singleton_nonempty a).ne_bot
 
 @[simp] lemma coe_singleton (a : α) : ↑({a} : finset α) = ({a} : set α) := by { ext, simp }
 
@@ -229,9 +199,98 @@ lemma singleton_subset_set_iff {s : set α} {a : α} :
   ↑({a} : finset α) ⊆ s ↔ a ∈ s :=
 by rw [coe_singleton, set.singleton_subset_iff]
 
-@[simp] lemma singleton_subset_iff {s : finset α} {a : α} :
-  {a} ⊆ s ↔ a ∈ s :=
+@[simp] lemma singleton_le_iff {s : finset α} {a : α} :
+  {a} ≤ s ↔ a ∈ s :=
 singleton_subset_set_iff
+
+/-!
+### Lattice structure
+
+In this section we define the following structures on `finset α` assuming `[decidable_eq α]`:
+
+* `distrib_lattice`;
+* `semilattice_sup_bot`;
+* `semilattice_inf_bot`.
+
+-/
+
+section lattice
+
+variable [decidable_eq α]
+
+instance : lattice (finset α) :=
+{ sup := λ s t, ⟨s.1.ndunion t.1, s.1.nodup_ndunion t.2⟩,
+  sup_le := λ s₁ s₂ t h₁ h₂, val_le_iff.1 $ ndunion_le.2 $ ⟨h₁, val_le_iff.2 h₂⟩,
+  le_sup_left := λ s t, subset_ndunion_left s.1 t.1,
+  le_sup_right := λ s t, subset_ndunion_right s.1 t.1,
+  inf := λ s t, ⟨_, t.1.nodup_ndinter s.2⟩,
+  le_inf := λ s t₁ t₂ h₁ h₂, subset_of_le $ le_ndinter.2 ⟨val_le_iff.2 h₁, h₂⟩,
+  inf_le_left := λ s t, ndinter_subset_left s.1 t.1,
+  inf_le_right := λ s t, ndinter_subset_right _ _,
+ .. finset.order_bot }
+
+instance : semilattice_sup_bot (finset α) :=
+{ .. finset.lattice, .. finset.order_bot }
+
+instance : semilattice_inf_bot (finset α) :=
+{ .. finset.lattice, .. finset.order_bot }
+
+@[simp, norm_cast] lemma coe_sup {s t : finset α} : ↑(s ⊔ t : finset α) = (↑s ∪ ↑t : set α) :=
+set.ext $ λ x, mem_ndunion
+
+@[simp] lemma mem_sup {s t : finset α} {a : α} : a ∈ (s ⊔ t) ↔ a ∈ s ∨ a ∈ t := mem_ndunion
+
+theorem mem_sup_left {a : α} {s : finset α} (h : a ∈ s) (t : finset α) : a ∈ s ⊔ t :=
+mem_of_le le_sup_left h
+
+theorem mem_sup_right {a : α} (s : finset α) {t : finset α} (h : a ∈ t) : a ∈ s ⊔ t :=
+mem_of_le le_sup_right h
+
+theorem not_mem_sup {a : α} {s t : finset α} : a ∉ s ⊔ t ↔ a ∉ s ∧ a ∉ t :=
+by rw [mem_sup, not_or_distrib]
+
+lemma sup_val_nd {s t : finset α} : (s ⊔ t).1 = s.1.ndunion t.1 := rfl
+
+@[simp] lemma sup_val {s t : finset α} : (s ⊔ t).1 = s.1 ∪ t.1 := ndunion_eq_union s.2
+
+@[simp, norm_cast] lemma coe_inf {s t : finset α} : ↑(s ⊓ t : finset α) = (↑s ∩ ↑t : set α) :=
+set.ext $ λ x, mem_ndinter
+
+@[simp] theorem sup_singleton_of_mem {a : α} {s : finset α} (h : a ∈ s) : s ⊔ {a} = s :=
+sup_eq_left.2 $ singleton_le_iff.2 h
+
+@[simp] theorem singleton_sup_of_mem {a : α} {s : finset α} (h : a ∈ s) : {a} ⊔ s = s :=
+sup_eq_right.2 $ singleton_le_iff.2 h
+
+@[simp] lemma mem_inf {s t : finset α} {a : α} : a ∈ s ⊓ t ↔ a ∈ s ∧ a ∈ t := mem_ndinter
+
+lemma inf_val_nd {s t : finset α} : (s ⊓ t).1 = s.1.ndinter t.1 := rfl
+
+@[simp] lemma inf_val {s t : finset α} : (s ⊓ t).1 = s.1 ∩ t.1 := ndinter_eq_inter s.2
+
+theorem mem_of_mem_inf_left {a : α} {s t : finset α} (h : a ∈ s ⊓ t) : a ∈ s := (mem_inf.1 h).1
+
+theorem mem_of_mem_inf_right {a : α} {s t : finset α} (h : a ∈ s ⊓ t) : a ∈ t := (mem_inf.1 h).2
+
+theorem mem_inf_of_mem {a : α} {s t : finset α} : a ∈ s → a ∈ t → a ∈ s ⊓ t := and_imp.1 mem_inf.2
+
+instance : distrib_lattice (finset α) :=
+{ le_sup_inf := λ s t₁ t₂, coe_subset.1 $ by simp only [coe_sup, coe_inf, set.union_distrib_left],
+  .. finset.lattice }
+
+@[simp] theorem singleton_inf_of_mem {a : α} {s : finset α} (H : a ∈ s) : {a} ⊓ s = {a} :=
+inf_eq_left.2 $ singleton_le_iff.2 H
+
+@[simp] theorem singleton_inf_of_not_mem {a : α} {s : finset α} (H : a ∉ s) : {a} ⊓ s = ⊥ :=
+eq_bot_of_forall_not_mem $ by simp only [mem_inf, mem_singleton]; rintro x ⟨rfl, h⟩; exact H h
+
+@[simp] theorem inf_singleton_of_mem {a : α} {s : finset α} (h : a ∈ s) : s ⊓ {a} = {a} :=
+by rw [inf_comm, singleton_inf_of_mem h]
+
+@[simp] theorem inf_singleton_of_not_mem {a : α} {s : finset α} (h : a ∉ s) : s ⊓ {a} = ⊥ :=
+by rw [inf_comm, singleton_inf_of_not_mem h]
+
+end lattice
 
 /-! ### insert -/
 section decidable_eq
@@ -244,24 +303,27 @@ theorem insert_def (a : α) (s : finset α) : insert a s = ⟨_, nodup_ndinsert 
 
 @[simp] theorem insert_val (a : α) (s : finset α) : (insert a s).1 = ndinsert a s.1 := rfl
 
+@[simp] theorem mem_insert {a b : α} {s : finset α} : a ∈ insert b s ↔ a = b ∨ a ∈ s := mem_ndinsert
+
+theorem insert_eq (a : α) (s : finset α) : insert a s = {a} ⊔ s := rfl
+
+@[simp, norm_cast] lemma coe_insert (a : α) (s : finset α) :
+  ↑(insert a s) = (insert a ↑s : set α) :=
+by simp [insert_eq]
+
+@[simp] lemma insert_bot (a : α) : insert a (⊥ : finset α) = {a} := by simp [insert_eq]
+
 theorem insert_val' (a : α) (s : finset α) : (insert a s).1 = erase_dup (a :: s.1) :=
 by rw [erase_dup_cons, erase_dup_eq_self]; refl
 
 theorem insert_val_of_not_mem {a : α} {s : finset α} (h : a ∉ s) : (insert a s).1 = a :: s.1 :=
 by rw [insert_val, ndinsert_of_not_mem h]
 
-@[simp] theorem mem_insert {a b : α} {s : finset α} : a ∈ insert b s ↔ a = b ∨ a ∈ s := mem_ndinsert
-
 theorem mem_insert_self (a : α) (s : finset α) : a ∈ insert a s := mem_ndinsert_self a s.1
 theorem mem_insert_of_mem {a b : α} {s : finset α} (h : a ∈ s) : a ∈ insert b s :=
 mem_ndinsert_of_mem h
 theorem mem_of_mem_insert_of_ne {a b : α} {s : finset α} (h : b ∈ insert a s) : b ≠ a → b ∈ s :=
 (mem_insert.1 h).resolve_left
-
-@[simp] lemma coe_insert (a : α) (s : finset α) : ↑(insert a s) = (insert a ↑s : set α) :=
-set.ext $ λ x, by simp only [mem_coe, mem_insert, set.mem_insert_iff]
-
-instance : is_lawful_singleton α (finset α) := ⟨λ a, by { ext, simp }⟩
 
 @[simp] theorem insert_eq_of_mem {a : α} {s : finset α} (h : a ∈ s) : insert a s = s :=
 eq_of_veq $ ndinsert_of_mem h
@@ -270,41 +332,70 @@ eq_of_veq $ ndinsert_of_mem h
 insert_eq_of_mem $ mem_singleton_self _
 
 theorem insert.comm (a b : α) (s : finset α) : insert a (insert b s) = insert b (insert a s) :=
-ext $ λ x, by simp only [finset.mem_insert, or.left_comm]
+by simp only [insert_eq, sup_left_comm]
 
 @[simp] theorem insert_idem (a : α) (s : finset α) : insert a (insert a s) = insert a s :=
-ext $ λ x, by simp only [finset.mem_insert, or.assoc.symm, or_self]
+by simp only [insert_eq, sup_left_idem]
 
-@[simp] theorem insert_ne_empty (a : α) (s : finset α) : insert a s ≠ ∅ :=
-ne_empty_of_mem (mem_insert_self a s)
+theorem insert_nonempty (a : α) (s : finset α) : (insert a s).nonempty := ⟨a, mem_insert_self a s⟩
+
+@[simp] theorem insert_ne_bot (a : α) (s : finset α) : insert a s ≠ ⊥ :=
+(insert_nonempty a s).ne_bot
 
 lemma ne_insert_of_not_mem (s t : finset α) {a : α} (h : a ∉ s) :
   s ≠ insert a t :=
-by { contrapose! h, simp [h] }
+flip mt h $ λ h, h.symm ▸ mem_insert_self a t
 
-theorem insert_subset {a : α} {s t : finset α} : insert a s ⊆ t ↔ a ∈ t ∧ s ⊆ t :=
-by simp only [subset_iff, mem_insert, forall_eq, or_imp_distrib, forall_and_distrib]
+theorem insert_le {a : α} {s t : finset α} : insert a s ≤ t ↔ a ∈ t ∧ s ≤ t :=
+by simp only [insert_eq, sup_le_iff, singleton_le_iff]
 
-theorem subset_insert (a : α) (s : finset α) : s ⊆ insert a s :=
-λ b, mem_insert_of_mem
+theorem le_insert (a : α) (s : finset α) : s ≤ insert a s := λ b, mem_insert_of_mem
 
-theorem insert_subset_insert (a : α) {s t : finset α} (h : s ⊆ t) : insert a s ⊆ insert a t :=
-insert_subset.2 ⟨mem_insert_self _ _, subset.trans h (subset_insert _ _)⟩
+@[mono] theorem insert_mono (a : α) {s t : finset α} (h : s ≤ t) : insert a s ≤ insert a t :=
+by simp only [insert_eq, sup_le_sup, h]
 
-lemma ssubset_iff {s t : finset α} : s ⊂ t ↔ (∃a, a ∉ s ∧ insert a s ⊆ t) :=
-iff.intro
-  (assume H,
-    have ∃a ∈ t, a ∉ s := set.exists_of_ssubset H,
-    let ⟨a, hat, has⟩ := this in ⟨a, has, insert_subset.mpr ⟨hat, H.1⟩⟩)
-  (assume ⟨a, hat, has⟩,
-    let ⟨h₁, h₂⟩ := insert_subset.mp has in
-    ⟨h₂, assume h, hat $ h h₁⟩)
+lemma lt_iff {s t : finset α} : s < t ↔ (∃a ∉ s, insert a s ≤ t) :=
+by simpa only [← coe_insert] using (@set.ssubset_iff_insert α ↑s ↑t)
 
-lemma ssubset_insert {s : finset α} {a : α} (h : a ∉ s) : s ⊂ insert a s :=
-ssubset_iff.mpr ⟨a, h, subset.refl _⟩
+lemma lt_insert {s : finset α} {a : α} (h : a ∉ s) : s < insert a s :=
+lt_iff.mpr ⟨a, h, subset.refl _⟩
 
-@[recursor 6] protected theorem induction {α : Type*} {p : finset α → Prop} [decidable_eq α]
-  (h₁ : p ∅) (h₂ : ∀ ⦃a : α⦄ {s : finset α}, a ∉ s → p s → p (insert a s)) : ∀ s, p s
+@[simp] theorem insert_sup (a : α) (s t : finset α) : insert a s ⊔ t = insert a (s ⊔ t) :=
+by simp only [insert_eq, sup_assoc]
+
+@[simp] theorem sup_insert (a : α) (s t : finset α) : s ⊔ insert a t = insert a (s ⊔ t) :=
+by simp only [insert_eq, sup_left_comm]
+
+theorem insert_sup_distrib (a : α) (s t : finset α) :
+  insert a (s ⊔ t) = insert a s ⊔ insert a t :=
+by simp only [insert_sup, sup_insert, insert_idem]
+
+theorem insert_inf_insert (a : α) (s t : finset α) :
+  insert a s ⊓ insert a t = insert a (s ⊓ t) :=
+by simp only [insert_eq, sup_inf_left]
+
+@[simp] theorem insert_inf_of_mem (s : finset α) {t : finset α} {a : α} (h : a ∈ t) :
+  insert a s ⊓ t = insert a (s ⊓ t) :=
+by simp only [← insert_inf_insert, insert_eq_of_mem h]
+
+@[simp] theorem inf_insert_of_mem {s : finset α} {a : α} (h : a ∈ s) (t : finset α) :
+  s ⊓ insert a t = insert a (s ⊓ t) :=
+by rw [inf_comm, insert_inf_of_mem t h, inf_comm]
+
+@[simp] theorem insert_inf_of_not_mem (s : finset α) {t : finset α} {a : α} (h : a ∉ t) :
+  insert a s ⊓ t = s ⊓ t :=
+by simp [insert_eq, inf_sup_right, h]
+
+@[simp] theorem inf_insert_of_not_mem {s : finset α} {a : α} (h : a ∉ s) (t : finset α) :
+  s ⊓ insert a t = s ⊓ t :=
+by rw [inf_comm, insert_inf_of_not_mem t h, inf_comm]
+
+/-!
+### Induction principle
+-/
+
+protected theorem induction {α : Type*} {p : finset α → Prop} [decidable_eq α]
+  (h₁ : p ⊥) (h₂ : ∀ ⦃a : α⦄ {s : finset α}, a ∉ s → p s → p (insert a s)) : ∀ s, p s
 | ⟨s, nd⟩ := multiset.induction_on s (λ _, h₁) (λ a s IH nd, begin
     cases nodup_cons.1 nd with m nd',
     rw [← (eq_of_veq _ : insert a (finset.mk s _) = ⟨a::s, nd⟩)],
@@ -320,246 +411,8 @@ then it holds for the `finset` obtained by inserting a new element.
 -/
 @[elab_as_eliminator]
 protected theorem induction_on {α : Type*} {p : finset α → Prop} [decidable_eq α]
-  (s : finset α) (h₁ : p ∅) (h₂ : ∀ ⦃a : α⦄ {s : finset α}, a ∉ s → p s → p (insert a s)) : p s :=
+  (s : finset α) (h₁ : p ⊥) (h₂ : ∀ ⦃a : α⦄ {s : finset α}, a ∉ s → p s → p (insert a s)) : p s :=
 finset.induction h₁ h₂ s
-
-/-! ### union -/
-
-/-- `s ∪ t` is the set such that `a ∈ s ∪ t` iff `a ∈ s` or `a ∈ t`. -/
-instance : has_union (finset α) := ⟨λ s₁ s₂, ⟨_, nodup_ndunion s₁.1 s₂.2⟩⟩
-
-theorem union_val_nd (s₁ s₂ : finset α) : (s₁ ∪ s₂).1 = ndunion s₁.1 s₂.1 := rfl
-
-@[simp] theorem union_val (s₁ s₂ : finset α) : (s₁ ∪ s₂).1 = s₁.1 ∪ s₂.1 :=
-ndunion_eq_union s₁.2
-
-@[simp] theorem mem_union {a : α} {s₁ s₂ : finset α} : a ∈ s₁ ∪ s₂ ↔ a ∈ s₁ ∨ a ∈ s₂ := mem_ndunion
-
-theorem mem_union_left {a : α} {s₁ : finset α} (s₂ : finset α) (h : a ∈ s₁) : a ∈ s₁ ∪ s₂ :=
-mem_union.2 $ or.inl h
-
-theorem mem_union_right {a : α} {s₂ : finset α} (s₁ : finset α) (h : a ∈ s₂) : a ∈ s₁ ∪ s₂ :=
-mem_union.2 $ or.inr h
-
-theorem not_mem_union {a : α} {s₁ s₂ : finset α} : a ∉ s₁ ∪ s₂ ↔ a ∉ s₁ ∧ a ∉ s₂ :=
-by rw [mem_union, not_or_distrib]
-
-@[simp]
-lemma coe_union (s₁ s₂ : finset α) : ↑(s₁ ∪ s₂) = (↑s₁ ∪ ↑s₂ : set α) := set.ext $ λ x, mem_union
-
-theorem union_subset {s₁ s₂ s₃ : finset α} (h₁ : s₁ ⊆ s₃) (h₂ : s₂ ⊆ s₃) : s₁ ∪ s₂ ⊆ s₃ :=
-val_le_iff.1 (ndunion_le.2 ⟨h₁, val_le_iff.2 h₂⟩)
-
-theorem subset_union_left (s₁ s₂ : finset α) : s₁ ⊆ s₁ ∪ s₂ := λ x, mem_union_left _
-
-theorem subset_union_right (s₁ s₂ : finset α) : s₂ ⊆ s₁ ∪ s₂ := λ x, mem_union_right _
-
-theorem union_comm (s₁ s₂ : finset α) : s₁ ∪ s₂ = s₂ ∪ s₁ :=
-ext $ λ x, by simp only [mem_union, or_comm]
-
-instance : is_commutative (finset α) (∪) := ⟨union_comm⟩
-
-@[simp] theorem union_assoc (s₁ s₂ s₃ : finset α) : (s₁ ∪ s₂) ∪ s₃ = s₁ ∪ (s₂ ∪ s₃) :=
-ext $ λ x, by simp only [mem_union, or_assoc]
-
-instance : is_associative (finset α) (∪) := ⟨union_assoc⟩
-
-@[simp] theorem union_idempotent (s : finset α) : s ∪ s = s :=
-ext $ λ _, mem_union.trans $ or_self _
-
-instance : is_idempotent (finset α) (∪) := ⟨union_idempotent⟩
-
-theorem union_left_comm (s₁ s₂ s₃ : finset α) : s₁ ∪ (s₂ ∪ s₃) = s₂ ∪ (s₁ ∪ s₃) :=
-ext $ λ _, by simp only [mem_union, or.left_comm]
-
-theorem union_right_comm (s₁ s₂ s₃ : finset α) : (s₁ ∪ s₂) ∪ s₃ = (s₁ ∪ s₃) ∪ s₂ :=
-ext $ λ x, by simp only [mem_union, or_assoc, or_comm (x ∈ s₂)]
-
-theorem union_self (s : finset α) : s ∪ s = s := union_idempotent s
-
-@[simp] theorem union_empty (s : finset α) : s ∪ ∅ = s :=
-ext $ λ x, mem_union.trans $ or_false _
-
-@[simp] theorem empty_union (s : finset α) : ∅ ∪ s = s :=
-ext $ λ x, mem_union.trans $ false_or _
-
-theorem insert_eq (a : α) (s : finset α) : insert a s = {a} ∪ s := rfl
-
-@[simp] theorem insert_union (a : α) (s t : finset α) : insert a s ∪ t = insert a (s ∪ t) :=
-by simp only [insert_eq, union_assoc]
-
-@[simp] theorem union_insert (a : α) (s t : finset α) : s ∪ insert a t = insert a (s ∪ t) :=
-by simp only [insert_eq, union_left_comm]
-
-theorem insert_union_distrib (a : α) (s t : finset α) :
-  insert a (s ∪ t) = insert a s ∪ insert a t :=
-by simp only [insert_union, union_insert, insert_idem]
-
-@[simp] lemma union_eq_left_iff_subset {s t : finset α} :
-  s ∪ t = s ↔ t ⊆ s :=
-begin
-  split,
-  { assume h,
-    have : t ⊆ s ∪ t := subset_union_right _ _,
-    rwa h at this },
-  { assume h,
-    exact subset.antisymm (union_subset (subset.refl _) h) (subset_union_left _ _) }
-end
-
-@[simp] lemma left_eq_union_iff_subset {s t : finset α} :
-  s = s ∪ t ↔ t ⊆ s :=
-by rw [← union_eq_left_iff_subset, eq_comm]
-
-@[simp] lemma union_eq_right_iff_subset {s t : finset α} :
-  t ∪ s = s ↔ t ⊆ s :=
-by rw [union_comm, union_eq_left_iff_subset]
-
-@[simp] lemma right_eq_union_iff_subset {s t : finset α} :
-  s = t ∪ s ↔ t ⊆ s :=
-by rw [← union_eq_right_iff_subset, eq_comm]
-
-/-! ### inter -/
-
-/-- `s ∩ t` is the set such that `a ∈ s ∩ t` iff `a ∈ s` and `a ∈ t`. -/
-instance : has_inter (finset α) := ⟨λ s₁ s₂, ⟨_, nodup_ndinter s₂.1 s₁.2⟩⟩
-
-theorem inter_val_nd (s₁ s₂ : finset α) : (s₁ ∩ s₂).1 = ndinter s₁.1 s₂.1 := rfl
-
-@[simp] theorem inter_val (s₁ s₂ : finset α) : (s₁ ∩ s₂).1 = s₁.1 ∩ s₂.1 :=
-ndinter_eq_inter s₁.2
-
-@[simp] theorem mem_inter {a : α} {s₁ s₂ : finset α} : a ∈ s₁ ∩ s₂ ↔ a ∈ s₁ ∧ a ∈ s₂ := mem_ndinter
-
-theorem mem_of_mem_inter_left {a : α} {s₁ s₂ : finset α} (h : a ∈ s₁ ∩ s₂) :
-  a ∈ s₁ := (mem_inter.1 h).1
-
-theorem mem_of_mem_inter_right {a : α} {s₁ s₂ : finset α} (h : a ∈ s₁ ∩ s₂) :
-  a ∈ s₂ := (mem_inter.1 h).2
-
-theorem mem_inter_of_mem {a : α} {s₁ s₂ : finset α} : a ∈ s₁ → a ∈ s₂ → a ∈ s₁ ∩ s₂ :=
-and_imp.1 mem_inter.2
-
-theorem inter_subset_left (s₁ s₂ : finset α) : s₁ ∩ s₂ ⊆ s₁ := λ a, mem_of_mem_inter_left
-
-theorem inter_subset_right (s₁ s₂ : finset α) : s₁ ∩ s₂ ⊆ s₂ := λ a, mem_of_mem_inter_right
-
-theorem subset_inter {s₁ s₂ s₃ : finset α} : s₁ ⊆ s₂ → s₁ ⊆ s₃ → s₁ ⊆ s₂ ∩ s₃ :=
-by simp only [subset_iff, mem_inter] {contextual:=tt}; intros; split; trivial
-
-@[simp]
-lemma coe_inter (s₁ s₂ : finset α) : ↑(s₁ ∩ s₂) = (↑s₁ ∩ ↑s₂ : set α) := set.ext $ λ _, mem_inter
-
-@[simp] theorem union_inter_cancel_left {s t : finset α} : (s ∪ t) ∩ s = s :=
-by rw [← coe_inj, coe_inter, coe_union, set.union_inter_cancel_left]
-
-@[simp] theorem union_inter_cancel_right {s t : finset α} : (s ∪ t) ∩ t = t :=
-by rw [← coe_inj, coe_inter, coe_union, set.union_inter_cancel_right]
-
-theorem inter_comm (s₁ s₂ : finset α) : s₁ ∩ s₂ = s₂ ∩ s₁ :=
-ext $ λ _, by simp only [mem_inter, and_comm]
-
-@[simp] theorem inter_assoc (s₁ s₂ s₃ : finset α) : (s₁ ∩ s₂) ∩ s₃ = s₁ ∩ (s₂ ∩ s₃) :=
-ext $ λ _, by simp only [mem_inter, and_assoc]
-
-theorem inter_left_comm (s₁ s₂ s₃ : finset α) : s₁ ∩ (s₂ ∩ s₃) = s₂ ∩ (s₁ ∩ s₃) :=
-ext $ λ _, by simp only [mem_inter, and.left_comm]
-
-theorem inter_right_comm (s₁ s₂ s₃ : finset α) : (s₁ ∩ s₂) ∩ s₃ = (s₁ ∩ s₃) ∩ s₂ :=
-ext $ λ _, by simp only [mem_inter, and.right_comm]
-
-@[simp] theorem inter_self (s : finset α) : s ∩ s = s :=
-ext $ λ _, mem_inter.trans $ and_self _
-
-@[simp] theorem inter_empty (s : finset α) : s ∩ ∅ = ∅ :=
-ext $ λ _, mem_inter.trans $ and_false _
-
-@[simp] theorem empty_inter (s : finset α) : ∅ ∩ s = ∅ :=
-ext $ λ _, mem_inter.trans $ false_and _
-
-@[simp] lemma inter_union_self (s t : finset α) : s ∩ (t ∪ s) = s :=
-by rw [inter_comm, union_inter_cancel_right]
-
-@[simp] theorem insert_inter_of_mem {s₁ s₂ : finset α} {a : α} (h : a ∈ s₂) :
-  insert a s₁ ∩ s₂ = insert a (s₁ ∩ s₂) :=
-ext $ λ x, have x = a ∨ x ∈ s₂ ↔ x ∈ s₂, from or_iff_right_of_imp $ by rintro rfl; exact h,
-by simp only [mem_inter, mem_insert, or_and_distrib_left, this]
-
-@[simp] theorem inter_insert_of_mem {s₁ s₂ : finset α} {a : α} (h : a ∈ s₁) :
-  s₁ ∩ insert a s₂ = insert a (s₁ ∩ s₂) :=
-by rw [inter_comm, insert_inter_of_mem h, inter_comm]
-
-@[simp] theorem insert_inter_of_not_mem {s₁ s₂ : finset α} {a : α} (h : a ∉ s₂) :
-  insert a s₁ ∩ s₂ = s₁ ∩ s₂ :=
-ext $ λ x, have ¬ (x = a ∧ x ∈ s₂), by rintro ⟨rfl, H⟩; exact h H,
-by simp only [mem_inter, mem_insert, or_and_distrib_right, this, false_or]
-
-@[simp] theorem inter_insert_of_not_mem {s₁ s₂ : finset α} {a : α} (h : a ∉ s₁) :
-  s₁ ∩ insert a s₂ = s₁ ∩ s₂ :=
-by rw [inter_comm, insert_inter_of_not_mem h, inter_comm]
-
-@[simp] theorem singleton_inter_of_mem {a : α} {s : finset α} (H : a ∈ s) : {a} ∩ s = {a} :=
-show insert a ∅ ∩ s = insert a ∅, by rw [insert_inter_of_mem H, empty_inter]
-
-@[simp] theorem singleton_inter_of_not_mem {a : α} {s : finset α} (H : a ∉ s) : {a} ∩ s = ∅ :=
-eq_empty_of_forall_not_mem $ by simp only [mem_inter, mem_singleton]; rintro x ⟨rfl, h⟩; exact H h
-
-@[simp] theorem inter_singleton_of_mem {a : α} {s : finset α} (h : a ∈ s) : s ∩ {a} = {a} :=
-by rw [inter_comm, singleton_inter_of_mem h]
-
-@[simp] theorem inter_singleton_of_not_mem {a : α} {s : finset α} (h : a ∉ s) : s ∩ {a} = ∅ :=
-by rw [inter_comm, singleton_inter_of_not_mem h]
-
-@[mono]
-lemma inter_subset_inter {x y s t : finset α} (h : x ⊆ y) (h' : s ⊆ t) : x ∩ s ⊆ y ∩ t :=
-begin
-  intros a a_in,
-  rw finset.mem_inter at a_in ⊢,
-  exact ⟨h a_in.1, h' a_in.2⟩
-end
-
-lemma inter_subset_inter_right {x y s : finset α} (h : x ⊆ y) : x ∩ s ⊆ y ∩ s :=
-finset.inter_subset_inter h (finset.subset.refl _)
-
-lemma inter_subset_inter_left {x y s : finset α} (h : x ⊆ y) : s ∩ x ⊆ s ∩ y :=
-finset.inter_subset_inter (finset.subset.refl _) h
-
-/-! ### lattice laws -/
-
-instance : lattice (finset α) :=
-{ sup          := (∪),
-  sup_le       := assume a b c, union_subset,
-  le_sup_left  := subset_union_left,
-  le_sup_right := subset_union_right,
-  inf          := (∩),
-  le_inf       := assume a b c, subset_inter,
-  inf_le_left  := inter_subset_left,
-  inf_le_right := inter_subset_right,
-  ..finset.partial_order }
-
-@[simp] theorem sup_eq_union (s t : finset α) : s ⊔ t = s ∪ t := rfl
-@[simp] theorem inf_eq_inter (s t : finset α) : s ⊓ t = s ∩ t := rfl
-
-instance : semilattice_inf_bot (finset α) :=
-{ bot := ∅, bot_le := empty_subset, ..finset.lattice }
-
-instance {α : Type*} [decidable_eq α] : semilattice_sup_bot (finset α) :=
-{ ..finset.semilattice_inf_bot, ..finset.lattice }
-
-instance : distrib_lattice (finset α) :=
-{ le_sup_inf := assume a b c, show (a ∪ b) ∩ (a ∪ c) ⊆ a ∪ b ∩ c,
-    by simp only [subset_iff, mem_inter, mem_union, and_imp, or_imp_distrib] {contextual:=tt};
-    simp only [true_or, imp_true_iff, true_and, or_true],
-  ..finset.lattice }
-
-theorem inter_distrib_left (s t u : finset α) : s ∩ (t ∪ u) = (s ∩ t) ∪ (s ∩ u) := inf_sup_left
-
-theorem inter_distrib_right (s t u : finset α) : (s ∪ t) ∩ u = (s ∩ u) ∪ (t ∩ u) := inf_sup_right
-
-theorem union_distrib_left (s t u : finset α) : s ∪ (t ∩ u) = (s ∪ t) ∩ (s ∪ u) := sup_inf_left
-
-theorem union_distrib_right (s t u : finset α) : (s ∩ t) ∪ u = (s ∪ u) ∩ (t ∪ u) := sup_inf_right
-
-lemma union_eq_empty_iff (A B : finset α) : A ∪ B = ∅ ↔ A = ∅ ∧ B = ∅ := sup_eq_bot_iff
 
 /-! ### erase -/
 
@@ -574,7 +427,7 @@ mem_erase_iff_of_nodup s.2
 
 theorem not_mem_erase (a : α) (s : finset α) : a ∉ erase s a := mem_erase_of_nodup s.2
 
-@[simp] theorem erase_empty (a : α) : erase ∅ a = ∅ := rfl
+@[simp] theorem erase_bot (a : α) : erase ⊥ a = ⊥ := rfl
 
 theorem ne_of_mem_erase {a b : α} {s : finset α} : b ∈ erase s a → b ≠ a :=
 by simp only [mem_erase]; exact and.left
@@ -592,30 +445,30 @@ theorem insert_erase {a : α} {s : finset α} (h : a ∈ s) : insert a (erase s 
 ext $ assume x, by simp only [mem_insert, mem_erase, or_and_distrib_left, dec_em, true_and];
 apply or_iff_right_of_imp; rintro rfl; exact h
 
-theorem erase_subset_erase (a : α) {s t : finset α} (h : s ⊆ t) : erase s a ⊆ erase t a :=
+@[mono] theorem erase_mono (a : α) {s t : finset α} (h : s ≤ t) : erase s a ≤ erase t a :=
 val_le_iff.1 $ erase_le_erase _ $ val_le_iff.2 h
 
-theorem erase_subset (a : α) (s : finset α) : erase s a ⊆ s := erase_subset _ _
+theorem erase_le (a : α) (s : finset α) : erase s a ≤ s := erase_subset _ _
 
-@[simp] lemma coe_erase (a : α) (s : finset α) : ↑(erase s a) = (↑s \ {a} : set α) :=
-set.ext $ λ _, mem_erase.trans $ by rw [and_comm, set.mem_diff, set.mem_singleton_iff]; refl
+@[simp, norm_cast] lemma coe_erase (a : α) (s : finset α) : ↑(erase s a) = (↑s \ {a} : set α) :=
+set.ext $ λ _, mem_erase.trans $ by rw [and_comm, set.mem_diff, set.mem_singleton_iff, mem_coe]
 
-lemma erase_ssubset {a : α} {s : finset α} (h : a ∈ s) : s.erase a ⊂ s :=
-calc s.erase a ⊂ insert a (s.erase a) : ssubset_insert $ not_mem_erase _ _
-  ... = _ : insert_erase h
+lemma erase_lt {a : α} {s : finset α} (h : a ∈ s) : s.erase a < s :=
+calc s.erase a < insert a (s.erase a) : lt_insert $ not_mem_erase _ _
+           ... = s                    : insert_erase h
 
 theorem erase_eq_of_not_mem {a : α} {s : finset α} (h : a ∉ s) : erase s a = s :=
 eq_of_veq $ erase_of_not_mem h
 
-theorem subset_insert_iff {a : α} {s t : finset α} : s ⊆ insert a t ↔ erase s a ⊆ t :=
-by simp only [subset_iff, or_iff_not_imp_left, mem_erase, mem_insert, and_imp];
+theorem le_insert_iff {a : α} {s t : finset α} : s ≤ insert a t ↔ erase s a ≤ t :=
+by simp only [le_def, or_iff_not_imp_left, mem_erase, mem_insert, and_imp];
 exact forall_congr (λ x, forall_swap)
 
-theorem erase_insert_subset (a : α) (s : finset α) : erase (insert a s) a ⊆ s :=
-subset_insert_iff.1 $ subset.refl _
+theorem erase_insert_le (a : α) (s : finset α) : erase (insert a s) a ≤ s :=
+le_insert_iff.1 $ subset.refl _
 
-theorem insert_erase_subset (a : α) (s : finset α) : s ⊆ insert a (erase s a) :=
-subset_insert_iff.2 $ subset.refl _
+theorem insert_erase_le (a : α) (s : finset α) : s ≤ insert a (erase s a) :=
+le_insert_iff.2 $ subset.refl _
 
 /-! ### sdiff -/
 
@@ -625,74 +478,76 @@ instance : has_sdiff (finset α) := ⟨λs₁ s₂, ⟨s₁.1 - s₂.1, nodup_of
 @[simp] theorem mem_sdiff {a : α} {s₁ s₂ : finset α} :
   a ∈ s₁ \ s₂ ↔ a ∈ s₁ ∧ a ∉ s₂ := mem_sub_of_nodup s₁.2
 
+@[simp, norm_cast] lemma coe_sdiff (s₁ s₂ : finset α) : ↑(s₁ \ s₂) = (↑s₁ \ ↑s₂ : set α) :=
+set.ext $ λ _, mem_sdiff
+
 lemma not_mem_sdiff_of_mem_right {a : α} {s t : finset α} (h : a ∈ t) : a ∉ s \ t :=
 by simp only [mem_sdiff, h, not_true, not_false_iff, and_false]
 
-theorem sdiff_union_of_subset {s₁ s₂ : finset α} (h : s₁ ⊆ s₂) : (s₂ \ s₁) ∪ s₁ = s₂ :=
-ext $ λ a, by simpa only [mem_sdiff, mem_union, or_comm,
+theorem sdiff_sup_of_le {s₁ s₂ : finset α} (h : s₁ ≤ s₂) : (s₂ \ s₁) ⊔ s₁ = s₂ :=
+ext $ λ a, by simpa only [mem_sdiff, mem_sup, or_comm,
   or_and_distrib_left, dec_em, and_true] using or_iff_right_of_imp (@h a)
 
-theorem union_sdiff_of_subset {s₁ s₂ : finset α} (h : s₁ ⊆ s₂) : s₁ ∪ (s₂ \ s₁) = s₂ :=
-(union_comm _ _).trans (sdiff_union_of_subset h)
+theorem sup_sdiff_of_le {s₁ s₂ : finset α} (h : s₁ ≤ s₂) : s₁ ⊔ (s₂ \ s₁) = s₂ :=
+sup_comm.trans (sdiff_sup_of_le h)
 
-theorem inter_sdiff (s t u : finset α) : s ∩ (t \ u) = s ∩ t \ u :=
+theorem inf_sdiff (s t u : finset α) : s ⊓ (t \ u) = s ⊓ t \ u :=
 by { ext x, simp [and_assoc] }
 
-@[simp] theorem inter_sdiff_self (s₁ s₂ : finset α) : s₁ ∩ (s₂ \ s₁) = ∅ :=
-eq_empty_of_forall_not_mem $
-by simp only [mem_inter, mem_sdiff]; rintro x ⟨h, _, hn⟩; exact hn h
+theorem sdiff_disjoint (s t : finset α) : disjoint (s \ t) t :=
+λ x, by simp [mem_inf, mem_sdiff]
 
-@[simp] theorem sdiff_inter_self (s₁ s₂ : finset α) : (s₂ \ s₁) ∩ s₁ = ∅ :=
-(inter_comm _ _).trans (inter_sdiff_self _ _)
+theorem disjoint_sdiff (s t : finset α) : disjoint t (s \ t) :=
+(sdiff_disjoint s t).symm
 
-@[simp] theorem sdiff_self (s₁ : finset α) : s₁ \ s₁ = ∅ :=
+@[simp] theorem inf_sdiff_self (s₁ s₂ : finset α) : s₁ ⊓ (s₂ \ s₁) = ⊥ :=
+(disjoint_sdiff s₂ s₁).eq_bot
+
+@[simp] theorem sdiff_inf_self (s₁ s₂ : finset α) : (s₂ \ s₁) ⊓ s₁ = ⊥ :=
+(sdiff_disjoint s₂ s₁).eq_bot
+
+@[simp] theorem sdiff_self (s₁ : finset α) : s₁ \ s₁ = ⊥ :=
 by ext; simp
 
-theorem sdiff_inter_distrib_right (s₁ s₂ s₃ : finset α) : s₁ \ (s₂ ∩ s₃) = (s₁ \ s₂) ∪ (s₁ \ s₃) :=
-by ext; simp only [and_or_distrib_left, mem_union, classical.not_and_distrib, mem_sdiff, mem_inter]
+theorem sdiff_inf_distrib_right (s₁ s₂ s₃ : finset α) : s₁ \ (s₂ ⊓ s₃) = (s₁ \ s₂) ⊔ (s₁ \ s₃) :=
+by ext; simp only [and_or_distrib_left, mem_sup, classical.not_and_distrib, mem_sdiff, mem_inf]
 
-@[simp] theorem sdiff_inter_self_left (s₁ s₂ : finset α) : s₁ \ (s₁ ∩ s₂) = s₁ \ s₂ :=
-by simp only [sdiff_inter_distrib_right, sdiff_self, empty_union]
+@[simp] theorem sdiff_inf_self_left (s₁ s₂ : finset α) : s₁ \ (s₁ ⊓ s₂) = s₁ \ s₂ :=
+by simp only [sdiff_inf_distrib_right, sdiff_self, bot_sup_eq]
 
-@[simp] theorem sdiff_inter_self_right (s₁ s₂ : finset α) : s₁ \ (s₂ ∩ s₁) = s₁ \ s₂ :=
-by simp only [sdiff_inter_distrib_right, sdiff_self, union_empty]
+@[simp] theorem sdiff_inf_self_right (s₁ s₂ : finset α) : s₁ \ (s₂ ⊓ s₁) = s₁ \ s₂ :=
+by simp only [sdiff_inf_distrib_right, sdiff_self, sup_bot_eq]
 
-@[simp] theorem sdiff_empty {s₁ : finset α} : s₁ \ ∅ = s₁ :=
+@[simp] theorem sdiff_bot {s₁ : finset α} : s₁ \ ⊥ = s₁ :=
 ext (by simp)
 
-@[mono]
-theorem sdiff_subset_sdiff {s₁ s₂ t₁ t₂ : finset α} (h₁ : t₁ ⊆ t₂) (h₂ : s₂ ⊆ s₁) :
-  t₁ \ s₁ ⊆ t₂ \ s₂ :=
-by simpa only [subset_iff, mem_sdiff, and_imp] using λ a m₁ m₂, and.intro (h₁ m₁) (mt (@h₂ _) m₂)
+@[mono] theorem sdiff_mono {s₁ s₂ t₁ t₂ : finset α} (h₁ : t₁ ≤ t₂) (h₂ : s₂ ≤ s₁) :
+  t₁ \ s₁ ≤ t₂ \ s₂ :=
+by simpa only [le_def, mem_sdiff, and_imp] using λ a m₁ m₂, and.intro (h₁ m₁) (mt (@h₂ _) m₂)
 
-theorem sdiff_subset_self {s₁ s₂ : finset α} : s₁ \ s₂ ⊆ s₁ :=
-suffices s₁ \ s₂ ⊆ s₁ \ ∅, by simpa [sdiff_empty] using this,
-sdiff_subset_sdiff (subset.refl _) (empty_subset _)
+@[simp] theorem sdiff_le_self (s t : finset α) : s \ t ≤ s :=
+by exact_mod_cast set.diff_subset (↑s : set α) ↑t
 
-@[simp] lemma coe_sdiff (s₁ s₂ : finset α) : ↑(s₁ \ s₂) = (↑s₁ \ ↑s₂ : set α) :=
-set.ext $ λ _, mem_sdiff
+@[simp] theorem sup_sdiff_self (s t : finset α) : s ⊔ (t \ s) = s ⊔ t :=
+by exact_mod_cast @set.union_diff_self α ↑s ↑t
 
-@[simp] theorem union_sdiff_self_eq_union {s t : finset α} : s ∪ (t \ s) = s ∪ t :=
-ext $ λ a, by simp only [mem_union, mem_sdiff, or_iff_not_imp_left,
-  imp_and_distrib, and_iff_left id]
+@[simp] theorem sdiff_sup_self (s t : finset α) : (s \ t) ⊔ t = s ⊔ t :=
+by exact_mod_cast @set.diff_union_self α ↑s ↑t
 
-@[simp] theorem sdiff_union_self_eq_union {s t : finset α} : (s \ t) ∪ t = s ∪ t :=
-by rw [union_comm, union_sdiff_self_eq_union, union_comm]
+lemma sup_sdiff_symm (s t : finset α) : s ⊔ (t \ s) = t ⊔ (s \ t) :=
+by rw [sup_sdiff_self, sup_sdiff_self, sup_comm]
 
-lemma union_sdiff_symm {s t : finset α} : s ∪ (t \ s) = t ∪ (s \ t) :=
-by rw [union_sdiff_self_eq_union, union_sdiff_self_eq_union, union_comm]
-
-lemma sdiff_union_inter (s t : finset α) : (s \ t) ∪ (s ∩ t) = s :=
-by { simp only [ext_iff, mem_union, mem_sdiff, mem_inter], tauto }
+lemma sdiff_sup_inf (s t : finset α) : (s \ t) ⊔ (s ⊓ t) = s :=
+by { simp only [ext_iff, mem_sup, mem_sdiff, mem_inf], tauto }
 
 @[simp] lemma sdiff_idem (s t : finset α) : s \ t \ t = s \ t :=
 by { simp only [ext_iff, mem_sdiff], tauto }
 
-lemma sdiff_eq_empty_iff_subset {s t : finset α} : s \ t = ∅ ↔ s ⊆ t :=
-by { rw [subset_iff, ext_iff], simp }
+lemma sdiff_eq_bot_iff_le {s t : finset α} : s \ t = ⊥ ↔ s ≤ t :=
+by { rw [le_def, ext_iff], simp }
 
-@[simp] lemma empty_sdiff (s : finset α) : ∅ \ s = ∅ :=
-by { rw sdiff_eq_empty_iff_subset, exact empty_subset _ }
+@[simp] lemma bot_sdiff (s : finset α) : ⊥ \ s = ⊥ :=
+bot_unique $ sdiff_le_self _ _
 
 lemma insert_sdiff_of_not_mem (s : finset α) {t : finset α} {x : α} (h : x ∉ t) :
   (insert x s) \ t = insert x (s \ t) :=
@@ -708,26 +563,20 @@ begin
   exact set.insert_diff_of_mem ↑s h
 end
 
-@[simp] lemma sdiff_subset (s t : finset α) : s \ t ⊆ s :=
-by simp [subset_iff, mem_sdiff] {contextual := tt}
+lemma sup_sdiff_distrib (s₁ s₂ t : finset α) : (s₁ ⊔ s₂) \ t = s₁ \ t ⊔ s₂ \ t :=
+by { simp only [ext_iff, mem_sdiff, mem_sup], tauto }
 
-lemma union_sdiff_distrib (s₁ s₂ t : finset α) : (s₁ ∪ s₂) \ t = s₁ \ t ∪ s₂ \ t :=
-by { simp only [ext_iff, mem_sdiff, mem_union], tauto }
+lemma sdiff_sup_distrib (s t₁ t₂ : finset α) : s \ (t₁ ⊔ t₂) = (s \ t₁) ⊓ (s \ t₂) :=
+by { simp only [ext_iff, mem_sup, mem_sdiff, mem_inf], tauto }
 
-lemma sdiff_union_distrib (s t₁ t₂ : finset α) : s \ (t₁ ∪ t₂) = (s \ t₁) ∩ (s \ t₂) :=
-by { simp only [ext_iff, mem_union, mem_sdiff, mem_inter], tauto }
-
-lemma union_sdiff_self (s t : finset α) : (s ∪ t) \ t = s \ t :=
-by rw [union_sdiff_distrib, sdiff_self, union_empty]
-
-lemma sdiff_singleton_eq_erase (a : α) (s : finset α) : s \ singleton a = erase s a :=
+lemma sdiff_singleton_eq_erase (a : α) (s : finset α) : s \ {a} = erase s a :=
 by { ext, rw [mem_erase, mem_sdiff, mem_singleton], tauto }
 
-lemma sdiff_sdiff_self_left (s t : finset α) : s \ (s \ t) = s ∩ t :=
-by { simp only [ext_iff, mem_sdiff, mem_inter], tauto }
+lemma sdiff_sdiff_self_left (s t : finset α) : s \ (s \ t) = s ⊓ t :=
+by { simp only [ext_iff, mem_sdiff, mem_inf], tauto }
 
-lemma inter_eq_inter_of_sdiff_eq_sdiff {s t₁ t₂ : finset α} : s \ t₁ = s \ t₂ → s ∩ t₁ = s ∩ t₂ :=
-by { simp only [ext_iff, mem_sdiff, mem_inter], intros b c, replace b := b c, split; tauto }
+lemma inter_eq_inter_of_sdiff_eq_sdiff {s t₁ t₂ : finset α} : s \ t₁ = s \ t₂ → s ⊓ t₁ = s ⊓ t₂ :=
+by { simp only [ext_iff, mem_sdiff, mem_inf], intros b c, replace b := b c, split; tauto }
 
 end decidable_eq
 
@@ -741,7 +590,7 @@ def attach (s : finset α) : finset {x // x ∈ s} := ⟨attach s.1, nodup_attac
 
 @[simp] theorem mem_attach (s : finset α) : ∀ x, x ∈ s.attach := mem_attach _
 
-@[simp] theorem attach_empty : attach (∅ : finset α) = ∅ := rfl
+@[simp] theorem attach_bot : attach (⊥ : finset α) = ⊥ := rfl
 
 /-! ### piecewise -/
 section piecewise
@@ -758,7 +607,7 @@ variables {δ : α → Sort*} (s : finset α) (f g : Πi, δ i)
   (insert j s).piecewise f g j = f j :=
 by simp [piecewise]
 
-@[simp] lemma piecewise_empty [∀i : α, decidable (i ∈ (∅ : finset α))] : piecewise ∅ f g = g :=
+@[simp] lemma piecewise_bot [∀i : α, decidable (i ∈ (⊥ : finset α))] : piecewise ⊥ f g = g :=
 by { ext i, simp [piecewise] }
 
 variable [∀j, decidable (j ∈ s)]
@@ -829,11 +678,11 @@ def filter (p : α → Prop) [decidable_pred p] (s : finset α) : finset α :=
 
 @[simp] theorem mem_filter {s : finset α} {a : α} : a ∈ s.filter p ↔ a ∈ s ∧ p a := mem_filter
 
-@[simp] theorem filter_subset (s : finset α) : s.filter p ⊆ s := filter_subset _
+@[simp] theorem filter_le (s : finset α) : s.filter p ≤ s := filter_subset _
 
-theorem filter_ssubset {s : finset α} : s.filter p ⊂ s ↔ ∃ x ∈ s, ¬ p x :=
+theorem filter_lt {s : finset α} : s.filter p < s ↔ ∃ x ∈ s, ¬ p x :=
 ⟨λ h, let ⟨x, hs, hp⟩ := set.exists_of_ssubset h in ⟨x, hs, mt (λ hp, mem_filter.2 ⟨hs, hp⟩) hp⟩,
-  λ ⟨x, hs, hp⟩, ⟨s.filter_subset, λ h, hp (mem_filter.1 (h hs)).2⟩⟩
+  λ ⟨x, hs, hp⟩, ⟨s.filter_le, λ h, hp (mem_filter.1 (h hs)).2⟩⟩
 
 theorem filter_filter (s : finset α) :
   (s.filter p).filter q = s.filter (λa, p a ∧ q a) :=
@@ -843,54 +692,54 @@ ext $ assume a, by simp only [mem_filter, and_comm, and.left_comm]
   @finset.filter α (λ _, true) h s = s :=
 by ext; simp
 
-@[simp] theorem filter_false {h} (s : finset α) : @filter α (λa, false) h s = ∅ :=
+@[simp] theorem filter_false {h} (s : finset α) : @filter α (λa, false) h s = ⊥ :=
 ext $ assume a, by simp only [mem_filter, and_false]; refl
 
 lemma filter_congr {s : finset α} (H : ∀ x ∈ s, p x ↔ q x) : filter p s = filter q s :=
 eq_of_veq $ filter_congr H
 
-lemma filter_empty : filter p ∅ = ∅ :=
-subset_empty.1 $ filter_subset _
+lemma filter_bot : filter p ⊥ = ⊥ := bot_unique $ filter_le _
 
-lemma filter_subset_filter {s t : finset α} (h : s ⊆ t) : s.filter p ⊆ t.filter p :=
+@[mono] lemma filter_mono {s t : finset α} (h : s ≤ t) : s.filter p ≤ t.filter p :=
 assume a ha, mem_filter.2 ⟨h (mem_filter.1 ha).1, (mem_filter.1 ha).2⟩
 
 @[simp] lemma coe_filter (s : finset α) : ↑(s.filter p) = ({x ∈ ↑s | p x} : set α) :=
 set.ext $ λ _, mem_filter
 
-theorem filter_singleton (a : α) : filter p (singleton a) = if p a then singleton a else ∅ :=
+theorem filter_singleton (a : α) : filter p {a} = if p a then {a} else ⊥ :=
 by { classical, ext x, simp, split_ifs with h; by_cases h' : x = a; simp [h, h'] }
 
 variable [decidable_eq α]
 
-theorem filter_union (s₁ s₂ : finset α) :
-  (s₁ ∪ s₂).filter p = s₁.filter p ∪ s₂.filter p :=
-ext $ λ _, by simp only [mem_filter, mem_union, or_and_distrib_right]
+theorem filter_sup (s₁ s₂ : finset α) :
+  (s₁ ⊔ s₂).filter p = s₁.filter p ⊔ s₂.filter p :=
+ext $ λ _, by simp only [mem_filter, mem_sup, or_and_distrib_right]
 
-theorem filter_union_right (p q : α → Prop) [decidable_pred p] [decidable_pred q] (s : finset α) :
-  s.filter p ∪ s.filter q = s.filter (λx, p x ∨ q x) :=
-ext $ λ x, by simp only [mem_filter, mem_union, and_or_distrib_left.symm]
+theorem filter_sup_right (p q : α → Prop) [decidable_pred p] [decidable_pred q]
+  [decidable_pred (λ a, p a ∨ q a)](s : finset α) :
+  s.filter p ⊔ s.filter q = s.filter (λx, p x ∨ q x) :=
+ext $ λ x, by simp only [mem_filter, mem_sup, and_or_distrib_left.symm]
 
-lemma filter_mem_eq_inter {s t : finset α} : s.filter (λ i, i ∈ t) = s ∩ t :=
-ext $ λ i, by rw [mem_filter, mem_inter]
+lemma filter_mem_eq_inf {s t : finset α} : s.filter (λ i, i ∈ t) = s ⊓ t :=
+ext $ λ i, by rw [mem_filter, mem_inf]
 
-theorem filter_inter {s t : finset α} : filter p s ∩ t = filter p (s ∩ t) :=
-by { ext, simp only [mem_inter, mem_filter, and.right_comm] }
+theorem filter_inf {s t : finset α} : filter p s ⊓ t = filter p (s ⊓ t) :=
+by { ext, simp only [mem_inf, mem_filter, and.right_comm] }
 
-theorem inter_filter {s t : finset α} : s ∩ filter p t = filter p (s ∩ t) :=
-by rw [inter_comm, filter_inter, inter_comm]
+theorem inf_filter {s t : finset α} : s ⊓ filter p t = filter p (s ⊓ t) :=
+by rw [inf_comm, filter_inf, inf_comm]
 
 theorem filter_insert (a : α) (s : finset α) :
   filter p (insert a s) = if p a then insert a (filter p s) else (filter p s) :=
 by { ext x, simp, split_ifs with h; by_cases h' : x = a; simp [h, h'] }
 
 theorem filter_or [decidable_pred (λ a, p a ∨ q a)] (s : finset α) :
-  s.filter (λ a, p a ∨ q a) = s.filter p ∪ s.filter q :=
-ext $ λ _, by simp only [mem_filter, mem_union, and_or_distrib_left]
+  s.filter (λ a, p a ∨ q a) = s.filter p ⊔ s.filter q :=
+(filter_sup_right _ _ _).symm
 
 theorem filter_and [decidable_pred (λ a, p a ∧ q a)] (s : finset α) :
-  s.filter (λ a, p a ∧ q a) = s.filter p ∩ s.filter q :=
-ext $ λ _, by simp only [mem_filter, mem_inter, and_comm, and.left_comm, and_self]
+  s.filter (λ a, p a ∧ q a) = s.filter p ⊓ s.filter q :=
+ext $ λ _, by simp only [mem_filter, mem_inf, and_comm, and.left_comm, and_self]
 
 theorem filter_not [decidable_pred (λ a, ¬ p a)] (s : finset α) :
   s.filter (λ a, ¬ p a) = s \ s.filter p :=
@@ -900,29 +749,27 @@ ext $ by simpa only [mem_filter, mem_sdiff, and_comm, not_and] using λ a, and_c
 theorem sdiff_eq_filter (s₁ s₂ : finset α) :
   s₁ \ s₂ = filter (∉ s₂) s₁ := ext $ λ _, by simp only [mem_sdiff, mem_filter]
 
-theorem sdiff_eq_self (s₁ s₂ : finset α) :
-  s₁ \ s₂ = s₁ ↔ s₁ ∩ s₂ ⊆ ∅ :=
-by { simp [subset.antisymm_iff,sdiff_subset_self],
-     split; intro h,
-     { transitivity' ((s₁ \ s₂) ∩ s₂), mono, simp },
-     { calc  s₁ \ s₂
-           ⊇ s₁ \ (s₁ ∩ s₂) : by simp [(⊇)]
-       ... ⊇ s₁ \ ∅         : by mono using [(⊇)]
-       ... ⊇ s₁             : by simp [(⊇)] } }
+theorem sdiff_eq_self {s₁ s₂ : finset α} :
+  s₁ \ s₂ = s₁ ↔ disjoint s₁ s₂ :=
+begin
+  simp only [_root_.disjoint, ext_iff, mem_sdiff, le_def, mem_inf, not_mem_bot],
+  refine forall_congr (λ a, _),
+  tauto
+end
 
-theorem filter_union_filter_neg_eq [decidable_pred (λ a, ¬ p a)]
-  (s : finset α) : s.filter p ∪ s.filter (λa, ¬ p a) = s :=
-by simp only [filter_not, union_sdiff_of_subset (filter_subset s)]
+theorem filter_sup_filter_neg_eq [decidable_pred (λ a, ¬ p a)]
+  (s : finset α) : s.filter p ⊔ s.filter (λa, ¬ p a) = s :=
+by simp only [filter_not, sup_sdiff_of_le (filter_le s)]
 
-theorem filter_inter_filter_neg_eq (s : finset α) : s.filter p ∩ s.filter (λa, ¬ p a) = ∅ :=
-by simp only [filter_not, inter_sdiff_self]
+theorem filter_inf_filter_neg_eq (s : finset α) : s.filter p ⊓ s.filter (λa, ¬ p a) = ⊥ :=
+by simp only [filter_not, inf_sdiff_self]
 
-lemma subset_union_elim {s : finset α} {t₁ t₂ : set α} (h : ↑s ⊆ t₁ ∪ t₂) :
-  ∃s₁ s₂ : finset α, s₁ ∪ s₂ = s ∧ ↑s₁ ⊆ t₁ ∧ ↑s₂ ⊆ t₂ \ t₁ :=
+lemma le_sup_elim {s : finset α} {t₁ t₂ : set α} (h : ↑s ⊆ t₁ ∪ t₂) :
+  ∃s₁ s₂ : finset α, s₁ ⊔ s₂ = s ∧ ↑s₁ ⊆ t₁ ∧ ↑s₂ ⊆ t₂ \ t₁ :=
 begin
   classical,
   refine ⟨s.filter (∈ t₁), s.filter (∉ t₁), _, _ , _⟩,
-  { simp [filter_union_right, classical.or_not] },
+  { simp [filter_sup_right, classical.or_not] },
   { intro x, simp },
   { intro x, simp, intros hx hx₂, refine ⟨or.resolve_left (h hx) hx₂, hx₂⟩ }
 end
@@ -957,14 +804,14 @@ end classical
 -- This is not a good simp lemma, as it would prevent `finset.mem_filter` from firing
 -- on, e.g. `x ∈ s.filter(eq b)`.
 lemma filter_eq [decidable_eq β] (s : finset β) (b : β) :
-  s.filter(eq b) = ite (b ∈ s) {b} ∅ :=
+  s.filter(eq b) = ite (b ∈ s) {b} ⊥ :=
 begin
   split_ifs,
   { ext,
     simp only [mem_filter, mem_singleton],
     exact ⟨λ h, h.2.symm, by { rintro ⟨h⟩, exact ⟨h, rfl⟩, }⟩ },
   { ext,
-    simp only [mem_filter, not_and, iff_false, not_mem_empty],
+    simp only [mem_filter, not_and, iff_false, not_mem_bot],
     rintros m ⟨e⟩, exact h m, }
 end
 
@@ -974,7 +821,7 @@ end
   This is equivalent to `filter_eq` with the equality the other way.
 -/
 lemma filter_eq' [decidable_eq β] (s : finset β) (b : β) :
-  s.filter (λ a, a = b) = ite (b ∈ s) {b} ∅ :=
+  s.filter (λ a, a = b) = ite (b ∈ s) {b} ⊥ :=
 trans (filter_congr (λ _ _, ⟨eq.symm, eq.symm⟩)) (filter_eq s b)
 
 lemma filter_ne [decidable_eq β] (s : finset β) (b : β) :
@@ -998,7 +845,7 @@ def range (n : ℕ) : finset ℕ := ⟨_, nodup_range n⟩
 
 @[simp] theorem mem_range : m ∈ range n ↔ m < n := mem_range
 
-@[simp] theorem range_zero : range 0 = ∅ := rfl
+@[simp] theorem range_zero : range 0 = ⊥ := rfl
 
 @[simp] theorem range_one : range 1 = {0} := rfl
 
@@ -1012,22 +859,22 @@ range_succ
 
 @[simp] theorem self_mem_range_succ (n : ℕ) : n ∈ range (n + 1) := multiset.self_mem_range_succ n
 
-@[simp] theorem range_subset {n m} : range n ⊆ range m ↔ n ≤ m := range_subset
+@[simp] theorem range_le {n m} : range n ≤ range m ↔ n ≤ m := range_subset
 
 theorem range_mono : monotone range := λ _ _, range_subset.2
 
 end range
 
 /- useful rules for calculations with quantifiers -/
-theorem exists_mem_empty_iff (p : α → Prop) : (∃ x, x ∈ (∅ : finset α) ∧ p x) ↔ false :=
-by simp only [not_mem_empty, false_and, exists_false]
+theorem exists_mem_bot_iff (p : α → Prop) : (∃ x, x ∈ (⊥ : finset α) ∧ p x) ↔ false :=
+by simp only [not_mem_bot, false_and, exists_false]
 
 theorem exists_mem_insert [d : decidable_eq α]
     (a : α) (s : finset α) (p : α → Prop) :
   (∃ x, x ∈ insert a s ∧ p x) ↔ p a ∨ (∃ x, x ∈ s ∧ p x) :=
 by simp only [mem_insert, or_and_distrib_right, exists_or_distrib, exists_eq_left]
 
-theorem forall_mem_empty_iff (p : α → Prop) : (∀ x, x ∈ (∅ : finset α) → p x) ↔ true :=
+theorem forall_mem_bot_iff (p : α → Prop) : (∀ x, x ∈ (⊥ : finset α) → p x) ↔ true :=
 iff_true_intro $ λ _, false.elim
 
 theorem forall_mem_insert [d : decidable_eq α]
@@ -1061,11 +908,11 @@ namespace option
 /-- Construct an empty or singleton finset from an `option` -/
 def to_finset (o : option α) : finset α :=
 match o with
-| none   := ∅
+| none   := ⊥
 | some a := {a}
 end
 
-@[simp] theorem to_finset_none : none.to_finset = (∅ : finset α) := rfl
+@[simp] theorem to_finset_none : none.to_finset = (⊥ : finset α) := rfl
 
 @[simp] theorem to_finset_some {a : α} : (some a).to_finset = {a} := rfl
 
@@ -1090,16 +937,14 @@ finset.val_inj.1 (erase_dup_eq_self.2 n).symm
 @[simp] theorem mem_to_finset {a : α} {s : multiset α} : a ∈ s.to_finset ↔ a ∈ s :=
 mem_erase_dup
 
-@[simp] lemma to_finset_zero :
-  to_finset (0 : multiset α) = ∅ :=
-rfl
+@[simp] lemma to_finset_zero : to_finset (0 : multiset α) = ⊥ := rfl
 
 @[simp] lemma to_finset_cons (a : α) (s : multiset α) :
   to_finset (a :: s) = insert a (to_finset s) :=
 finset.eq_of_veq erase_dup_cons
 
 @[simp] lemma to_finset_add (s t : multiset α) :
-  to_finset (s + t) = to_finset s ∪ to_finset t :=
+  to_finset (s + t) = to_finset s ⊔ to_finset t :=
 finset.ext $ by simp
 
 @[simp] lemma to_finset_nsmul (s : multiset α) :
@@ -1109,14 +954,14 @@ finset.ext $ by simp
   begin
     by_cases n = 0,
     { rw [h, zero_add, one_nsmul] },
-    { rw [add_nsmul, to_finset_add, one_nsmul, to_finset_nsmul n h, finset.union_idempotent] }
+    { rw [add_nsmul, to_finset_add, one_nsmul, to_finset_nsmul n h, sup_idem] }
   end
 
 @[simp] lemma to_finset_inter (s t : multiset α) :
-  to_finset (s ∩ t) = to_finset s ∩ to_finset t :=
+  to_finset (s ∩ t) = to_finset s ⊓ to_finset t :=
 finset.ext $ by simp
 
-theorem to_finset_eq_empty {m : multiset α} : m.to_finset = ∅ ↔ m = 0 :=
+theorem to_finset_eq_bot {m : multiset α} : m.to_finset = ⊥ ↔ m = 0 :=
 finset.val_inj.symm.trans multiset.erase_dup_eq_zero
 
 end multiset
@@ -1135,8 +980,7 @@ multiset.to_finset_eq n
 @[simp] theorem mem_to_finset {a : α} {l : list α} : a ∈ l.to_finset ↔ a ∈ l :=
 mem_erase_dup
 
-@[simp] theorem to_finset_nil : to_finset (@nil α) = ∅ :=
-rfl
+@[simp] theorem to_finset_nil : to_finset (@nil α) = ⊥ := rfl
 
 @[simp] theorem to_finset_cons {a : α} {l : list α} : to_finset (a :: l) = insert a (to_finset l) :=
 finset.eq_of_veq $ by by_cases h : a ∈ l; simp [finset.insert_val', multiset.erase_dup_cons, h]
@@ -1156,7 +1000,7 @@ def map (f : α ↪ β) (s : finset α) : finset β :=
 
 @[simp] theorem map_val (f : α ↪ β) (s : finset α) : (map f s).1 = s.1.map f := rfl
 
-@[simp] theorem map_empty (f : α ↪ β) : (∅ : finset α).map f = ∅ := rfl
+@[simp] theorem map_bot (f : α ↪ β) : (⊥ : finset α).map f = ⊥ := rfl
 
 variables {f : α ↪ β} {s : finset α}
 
@@ -1186,12 +1030,12 @@ ext $ λ _, by simpa only [mem_map, exists_prop] using exists_eq_right
 theorem map_map {g : β ↪ γ} : (s.map f).map g = s.map (f.trans g) :=
 eq_of_veq $ by simp only [map_val, multiset.map_map]; refl
 
-theorem map_subset_map {s₁ s₂ : finset α} : s₁.map f ⊆ s₂.map f ↔ s₁ ⊆ s₂ :=
+theorem map_subset_map {s₁ s₂ : finset α} : s₁.map f ≤ s₂.map f ↔ s₁ ≤ s₂ :=
 ⟨λ h x xs, (mem_map' _).1 $ h $ (mem_map' f).2 xs,
- λ h, by simp [subset_def, map_subset_map h]⟩
+ λ h, by simp [← val_subset_iff, map_subset_map h]⟩
 
 theorem map_inj {s₁ s₂ : finset α} : s₁.map f = s₂.map f ↔ s₁ = s₂ :=
-by simp only [subset.antisymm_iff, map_subset_map]
+by simp only [le_antisymm_iff, map_subset_map]
 
 /-- Associate to an embedding `f` from `α` to `β` the embedding that maps a finset to its image
 under `f`. -/
@@ -1205,13 +1049,13 @@ ext $ λ b, by simp only [mem_filter, mem_map, exists_prop, and_assoc]; exact
 ⟨by rintro ⟨⟨x, h1, rfl⟩, h2⟩; exact ⟨x, h1, h2, rfl⟩,
 by rintro ⟨x, h1, h2, rfl⟩; exact ⟨⟨x, h1, rfl⟩, h2⟩⟩
 
-theorem map_union [decidable_eq α] [decidable_eq β]
-  {f : α ↪ β} (s₁ s₂ : finset α) : (s₁ ∪ s₂).map f = s₁.map f ∪ s₂.map f :=
-ext $ λ _, by simp only [mem_map, mem_union, exists_prop, or_and_distrib_right, exists_or_distrib]
+theorem map_sup [decidable_eq α] [decidable_eq β]
+  {f : α ↪ β} (s₁ s₂ : finset α) : (s₁ ⊔ s₂).map f = s₁.map f ⊔ s₂.map f :=
+ext $ λ _, by simp only [mem_map, mem_sup, exists_prop, or_and_distrib_right, exists_or_distrib]
 
 theorem map_inter [decidable_eq α] [decidable_eq β]
-  {f : α ↪ β} (s₁ s₂ : finset α) : (s₁ ∩ s₂).map f = s₁.map f ∩ s₂.map f :=
-ext $ λ b, by simp only [mem_map, mem_inter, exists_prop]; exact
+  {f : α ↪ β} (s₁ s₂ : finset α) : (s₁ ⊓ s₂).map f = s₁.map f ⊓ s₂.map f :=
+ext $ λ b, by simp only [mem_map, mem_inf, exists_prop]; exact
 ⟨by rintro ⟨a, ⟨m₁, m₂⟩, rfl⟩; exact ⟨⟨a, m₁, rfl⟩, ⟨a, m₂, rfl⟩⟩,
 by rintro ⟨⟨a, m₁, e⟩, ⟨a', m₂, rfl⟩⟩; cases f.2 e; exact ⟨_, ⟨m₁, m₂⟩, rfl⟩⟩
 
@@ -1221,11 +1065,11 @@ ext $ λ _, by simp only [mem_map, mem_singleton, exists_prop, exists_eq_left]; 
 @[simp] theorem map_insert [decidable_eq α] [decidable_eq β]
   (f : α ↪ β) (a : α) (s : finset α) :
   (insert a s).map f = insert (f a) (s.map f) :=
-by simp only [insert_eq, map_union, map_singleton]
+by simp only [insert_eq, map_sup, map_singleton]
 
-@[simp] theorem map_eq_empty : s.map f = ∅ ↔ s = ∅ :=
-⟨λ h, eq_empty_of_forall_not_mem $
- λ a m, ne_empty_of_mem (mem_map_of_mem _ m) h, λ e, e.symm ▸ rfl⟩
+@[simp] theorem map_eq_bot : s.map f = ⊥ ↔ s = ⊥ :=
+⟨λ h, eq_bot_of_forall_not_mem $
+ λ a m, ne_bot_of_mem (mem_map_of_mem _ m) h, λ e, e.symm ▸ rfl⟩
 
 lemma attach_map_val {s : finset α} : s.attach.map (embedding.subtype _) = s :=
 eq_of_veq $ by rw [map_val, attach_val]; exact attach_map_val _
@@ -1245,7 +1089,7 @@ def image (f : α → β) (s : finset α) : finset β := (s.1.map f).to_finset
 
 @[simp] theorem image_val (f : α → β) (s : finset α) : (image f s).1 = (s.1.map f).erase_dup := rfl
 
-@[simp] theorem image_empty (f : α → β) : (∅ : finset α).image f = ∅ := rfl
+@[simp] theorem image_bot (f : α → β) : (⊥ : finset α).image f = ⊥ := rfl
 
 variables {f : α → β} {s : finset α}
 
@@ -1274,11 +1118,11 @@ ext $ λ _, by simp only [mem_image, exists_prop, id, exists_eq_right]
 theorem image_image [decidable_eq γ] {g : β → γ} : (s.image f).image g = s.image (g ∘ f) :=
 eq_of_veq $ by simp only [image_val, erase_dup_map_erase_dup_eq, multiset.map_map]
 
-theorem image_subset_image {s₁ s₂ : finset α} (h : s₁ ⊆ s₂) : s₁.image f ⊆ s₂.image f :=
-by simp only [subset_def, image_val, subset_erase_dup', erase_dup_subset',
+@[mono] theorem image_le_image {s₁ s₂ : finset α} (h : s₁ ≤ s₂) : s₁.image f ≤ s₂.image f :=
+by simp only [← val_subset_iff, image_val, subset_erase_dup', erase_dup_subset',
   multiset.map_subset_map h]
 
-theorem image_mono (f : α → β) : monotone (finset.image f) := λ _ _, image_subset_image
+theorem image_mono (f : α → β) : monotone (finset.image f) := λ _ _, image_le_image
 
 theorem coe_image_subset_range : ↑(s.image f) ⊆ set.range f :=
 calc ↑(s.image f) = f '' ↑s     : coe_image
@@ -1290,27 +1134,21 @@ ext $ λ b, by simp only [mem_filter, mem_image, exists_prop]; exact
 ⟨by rintro ⟨⟨x, h1, rfl⟩, h2⟩; exact ⟨x, ⟨h1, h2⟩, rfl⟩,
  by rintro ⟨x, ⟨h1, h2⟩, rfl⟩; exact ⟨⟨x, h1, rfl⟩, h2⟩⟩
 
-theorem image_union [decidable_eq α] {f : α → β} (s₁ s₂ : finset α) :
-  (s₁ ∪ s₂).image f = s₁.image f ∪ s₂.image f :=
-ext $ λ _, by simp only [mem_image, mem_union, exists_prop, or_and_distrib_right,
-  exists_or_distrib]
+theorem image_sup [decidable_eq α] {f : α → β} (s₁ s₂ : finset α) :
+  (s₁ ⊔ s₂).image f = s₁.image f ⊔ s₂.image f :=
+ext $ λ _, by simp only [mem_image, mem_sup, exists_prop, or_and_distrib_right, exists_or_distrib]
 
-theorem image_inter [decidable_eq α] (s₁ s₂ : finset α) (hf : ∀x y, f x = f y → x = y) :
-  (s₁ ∩ s₂).image f = s₁.image f ∩ s₂.image f :=
-ext $ by simp only [mem_image, exists_prop, mem_inter]; exact λ b,
-⟨λ ⟨a, ⟨m₁, m₂⟩, e⟩, ⟨⟨a, m₁, e⟩, ⟨a, m₂, e⟩⟩,
- λ ⟨⟨a, m₁, e₁⟩, ⟨a', m₂, e₂⟩⟩, ⟨a, ⟨m₁, hf _ _ (e₂.trans e₁.symm) ▸ m₂⟩, e₁⟩⟩.
+theorem image_inf [decidable_eq α] (s₁ s₂ : finset α) (hf : function.injective f) :
+  (s₁ ⊓ s₂).image f = s₁.image f ⊓ s₂.image f :=
+coe_inj.1 $ by simp [set.image_inter hf]
 
-@[simp] theorem image_singleton (f : α → β) (a : α) : image f {a} = {f a} :=
-ext $ λ x, by simpa only [mem_image, exists_prop, mem_singleton, exists_eq_left] using eq_comm
+@[simp] theorem image_singleton (f : α → β) (a : α) : image f {a} = {f a} := by simp [← coe_inj]
 
 @[simp] theorem image_insert [decidable_eq α] (f : α → β) (a : α) (s : finset α) :
   (insert a s).image f = insert (f a) (s.image f) :=
-by simp only [insert_eq, image_singleton, image_union]
+by simp only [insert_eq, image_singleton, image_sup]
 
-@[simp] theorem image_eq_empty : s.image f = ∅ ↔ s = ∅ :=
-⟨λ h, eq_empty_of_forall_not_mem $
- λ a m, ne_empty_of_mem (mem_image_of_mem _ m) h, λ e, e.symm ▸ rfl⟩
+@[simp] theorem image_eq_bot : s.image f = ⊥ ↔ s = ⊥ := by simp [← coe_inj]
 
 lemma attach_image_val [decidable_eq α] {s : finset α} : s.attach.image subtype.val = s :=
 eq_of_veq $ by rw [image_val, attach_val, multiset.attach_map_val, erase_dup_eq_self]
@@ -1326,9 +1164,8 @@ ext $ λ ⟨x, hx⟩, ⟨or.cases_on (mem_insert.1 hx)
 theorem map_eq_image (f : α ↪ β) (s : finset α) : s.map f = s.image f :=
 eq_of_veq $ (multiset.erase_dup_eq_self.2 (s.map f).2).symm
 
-lemma image_const {s : finset α} (h : s.nonempty) (b : β) : s.image (λa, b) = singleton b :=
-ext $ assume b', by simp only [mem_image, exists_prop, exists_and_distrib_right,
-  h.bex, true_and, mem_singleton, eq_comm]
+lemma image_const {s : finset α} (h : s.nonempty) (b : β) : s.image (λa, b) = {b} :=
+by simp [← coe_inj, h.coe.image_const]
 
 /--
 Because `finset.image` requires a `decidable_eq` instances for the target type,
@@ -1359,8 +1196,8 @@ begin
   split, swap,
   { rintro ⟨s, hs, rfl⟩, rw [coe_image], exact set.image_subset f hs },
   intro h, induction s using finset.induction with a s has ih h,
-  { refine ⟨∅, set.empty_subset _, _⟩,
-    convert finset.image_empty _ },
+  { refine ⟨⊥, set.empty_subset _, _⟩,
+    convert finset.image_bot _ },
   rw [finset.coe_insert, set.insert_subset] at h,
   rcases ih h.2 with ⟨s', hst, hsi⟩,
   rcases h.1 with ⟨x, hxt, rfl⟩,
@@ -1380,16 +1217,16 @@ def card (s : finset α) : nat := s.1.card
 
 theorem card_def (s : finset α) : s.card = s.1.card := rfl
 
-@[simp] theorem card_empty : card (∅ : finset α) = 0 := rfl
+@[simp] theorem card_bot : card (⊥ : finset α) = 0 := rfl
 
-@[simp] theorem card_eq_zero {s : finset α} : card s = 0 ↔ s = ∅ :=
+@[simp] theorem card_eq_zero {s : finset α} : card s = 0 ↔ s = ⊥ :=
 card_eq_zero.trans val_eq_zero
 
 theorem card_pos {s : finset α} : 0 < card s ↔ s.nonempty :=
-pos_iff_ne_zero.trans $ (not_congr card_eq_zero).trans nonempty_iff_ne_empty.symm
+pos_iff_ne_zero.trans $ (not_congr card_eq_zero).trans nonempty_iff_ne_bot.symm
 
 theorem card_ne_zero_of_mem {s : finset α} {a : α} (h : a ∈ s) : card s ≠ 0 :=
-(not_congr card_eq_zero).2 (ne_empty_of_mem h)
+(not_congr card_eq_zero).2 (ne_bot_of_mem h)
 
 theorem card_eq_one {s : finset α} : s.card = 1 ↔ ∃ a, s = {a} :=
 by cases s; simp only [multiset.card_eq_one, finset.card, ← val_inj, singleton_val]
@@ -1475,13 +1312,13 @@ iff.intro
       by simp only [eq, card_erase_of_mem has, pred_succ]⟩)
   (assume ⟨a, t, hat, s_eq, n_eq⟩, s_eq ▸ n_eq ▸ card_insert_of_not_mem hat)
 
-theorem card_le_of_subset {s t : finset α} : s ⊆ t → card s ≤ card t :=
+@[mono] theorem card_mono {s t : finset α} : s ≤ t → card s ≤ card t :=
 multiset.card_le_of_le ∘ val_le_iff.mpr
 
-theorem eq_of_subset_of_card_le {s t : finset α} (h : s ⊆ t) (h₂ : card t ≤ card s) : s = t :=
+theorem eq_of_le_of_card_le {s t : finset α} (h : s ≤ t) (h₂ : card t ≤ card s) : s = t :=
 eq_of_veq $ multiset.eq_of_le_of_card_le (val_le_iff.mpr h) h₂
 
-lemma card_lt_card {s t : finset α} (h : s ⊂ t) : s.card < t.card :=
+lemma card_lt_card {s t : finset α} (h : s < t) : s.card < t.card :=
 card_lt_of_lt (val_lt_iff.2 h)
 
 lemma card_le_card_of_inj_on {s : finset α} {t : finset β}
@@ -1490,7 +1327,7 @@ lemma card_le_card_of_inj_on {s : finset α} {t : finset β}
 begin
   classical,
   calc card s = card (s.image f) : by rw [card_image_of_inj_on f_inj]
-    ... ≤ card t : card_le_of_subset $
+    ... ≤ card t : card_mono $
       assume x hx, match x, finset.mem_image.1 hx with _, ⟨a, ha, rfl⟩ := hf a ha end
 end
 
@@ -1505,15 +1342,15 @@ calc n = card (range n) : (card_range n).symm
 define an object on `s`. Then one can inductively define an object on all finsets, starting from
 the empty set and iterating. This can be used either to define data, or to prove properties. -/
 @[elab_as_eliminator] def strong_induction_on {p : finset α → Sort*} :
-  ∀ (s : finset α), (∀s, (∀t ⊂ s, p t) → p s) → p s
+  ∀ (s : finset α), (∀s, (∀t < s, p t) → p s) → p s
 | ⟨s, nd⟩ ih := multiset.strong_induction_on s
   (λ s IH nd, ih ⟨s, nd⟩ (λ ⟨t, nd'⟩ ss, IH t (val_lt_iff.2 ss) nd')) nd
 
 @[elab_as_eliminator] lemma case_strong_induction_on [decidable_eq α] {p : finset α → Prop}
-  (s : finset α) (h₀ : p ∅) (h₁ : ∀ a s, a ∉ s → (∀t ⊆ s, p t) → p (insert a s)) : p s :=
+  (s : finset α) (h₀ : p ⊥) (h₁ : ∀ a s, a ∉ s → (∀t ≤ s, p t) → p (insert a s)) : p s :=
 finset.strong_induction_on s $ λ s,
 finset.induction_on s (λ _, h₀) $ λ a s n _ ih, h₁ a s n $
-λ t ss, ih _ (lt_of_le_of_lt ss (ssubset_insert n) : t < _)
+λ t ss, ih _ (lt_of_le_of_lt ss (lt_insert n) : t < _)
 
 lemma card_congr {s : finset α} {t : finset β} (f : Π a ∈ s, β)
   (h₁ : ∀ a ha, f a ha ∈ t) (h₂ : ∀ a b ha hb, f a ha = f b hb → a = b)
@@ -1526,13 +1363,13 @@ calc s.card = s.attach.card : card_attach.symm
     ⟨λ h, let ⟨a, ha₁, ha₂⟩ := mem_image.1 h in ha₂ ▸ h₁ _ _,
       λ h, let ⟨a, ha₁, ha₂⟩ := h₃ b h in mem_image.2 ⟨⟨a, ha₁⟩, by simp [ha₂]⟩⟩)
 
-lemma card_union_add_card_inter [decidable_eq α] (s t : finset α) :
-  (s ∪ t).card + (s ∩ t).card = s.card + t.card :=
+lemma card_sup_add_card_inf [decidable_eq α] (s t : finset α) :
+  (s ⊔ t).card + (s ⊓ t).card = s.card + t.card :=
 finset.induction_on t (by simp) $ λ a r har, by by_cases a ∈ s; simp *; cc
 
-lemma card_union_le [decidable_eq α] (s t : finset α) :
-  (s ∪ t).card ≤ s.card + t.card :=
-card_union_add_card_inter s t ▸ le_add_right _ _
+lemma card_sup_le [decidable_eq α] (s t : finset α) :
+  (s ⊔ t).card ≤ s.card + t.card :=
+card_sup_add_card_inf s t ▸ le_add_right _ _
 
 lemma surj_on_of_inj_on_of_card_le {s : finset α} {t : finset β}
   (f : Π a ∈ s, β) (hf : ∀ a ha, f a ha ∈ t)
@@ -1545,7 +1382,7 @@ by haveI := classical.dec_eq β; exact
     from @card_attach _ s ▸ card_image_of_injective _
       (λ ⟨a₁, ha₁⟩ ⟨a₂, ha₂⟩ h, subtype.eq $ hinj _ _ _ _ h),
   have h₁ : image (λ a : {a // a ∈ s}, f a.1 a.2) s.attach = t :=
-  eq_of_subset_of_card_le (λ b h, let ⟨a, ha₁, ha₂⟩ := mem_image.1 h in
+  eq_of_le_of_card_le (λ b h, let ⟨a, ha₁, ha₂⟩ := mem_image.1 h in
     ha₂ ▸ hf _ _) (by simp [hst, h]),
 begin
   rw ← h₁ at hb,
@@ -1590,33 +1427,29 @@ protected def bind (s : finset α) (t : α → finset β) : finset β :=
 @[simp] theorem bind_val (s : finset α) (t : α → finset β) :
   (s.bind t).1 = (s.1.bind (λ a, (t a).1)).erase_dup := rfl
 
-@[simp] theorem bind_empty : finset.bind ∅ t = ∅ := rfl
+@[simp] theorem bind_bot : finset.bind ⊥ t = ⊥ := rfl
 
 @[simp] theorem mem_bind {b : β} : b ∈ s.bind t ↔ ∃a∈s, b ∈ t a :=
 by simp only [mem_def, bind_val, mem_erase_dup, mem_bind, exists_prop]
 
-@[simp] theorem bind_insert [decidable_eq α] {a : α} : (insert a s).bind t = t a ∪ s.bind t :=
-ext $ λ x, by simp only [mem_bind, exists_prop, mem_union, mem_insert,
+@[simp, norm_cast] theorem coe_bind : ↑(s.bind t) = ⋃ i ∈ s, (↑(t i) : set β) :=
+set.ext $ by simp
+
+@[simp] theorem bind_insert [decidable_eq α] {a : α} : (insert a s).bind t = t a ⊔ s.bind t :=
+ext $ λ x, by simp only [mem_bind, exists_prop, mem_sup, mem_insert,
   or_and_distrib_right, exists_or_distrib, exists_eq_left]
 -- ext $ λ x, by simp [or_and_distrib_right, exists_or_distrib]
 
 @[simp] lemma singleton_bind {a : α} : finset.bind {a} t = t a :=
-begin
-  classical,
-  rw [← insert_emptyc_eq, bind_insert, bind_empty, union_empty]
-end
+ext $ by simp
 
-theorem bind_inter (s : finset α) (f : α → finset β) (t : finset β) :
-  s.bind f ∩ t = s.bind (λ x, f x ∩ t) :=
-begin
-  ext x,
-  simp only [mem_bind, mem_inter],
-  tauto
-end
+theorem bind_inf (s : finset α) (f : α → finset β) (t : finset β) :
+  s.bind f ⊓ t = s.bind (λ x, f x ⊓ t) :=
+ext $ λ x, by simp only [mem_bind, mem_inf, exists_and_distrib_right]
 
-theorem inter_bind (t : finset β) (s : finset α) (f : α → finset β) :
-  t ∩ s.bind f = s.bind (λ x, t ∩ f x) :=
-by rw [inter_comm, bind_inter]; simp [inter_comm]
+theorem inf_bind (t : finset β) (s : finset α) (f : α → finset β) :
+  t ⊓ s.bind f = s.bind (λ x, t ⊓ f x) :=
+by rw [inf_comm, bind_inf]; simp [inf_comm]
 
 theorem image_bind [decidable_eq γ] {f : α → β} {s : finset α} {t : β → finset γ} :
   (s.image f).bind t = s.bind (λa, t (f a)) :=
@@ -1628,26 +1461,24 @@ theorem bind_image [decidable_eq γ] {s : finset α} {t : α → finset β} {f :
   (s.bind t).image f = s.bind (λa, (t a).image f) :=
 by haveI := classical.dec_eq α; exact
 finset.induction_on s rfl (λ a s has ih,
-  by simp only [bind_insert, image_union, ih])
+  by simp only [bind_insert, image_sup, ih])
 
 theorem bind_to_finset [decidable_eq α] (s : multiset α) (t : α → multiset β) :
   (s.bind t).to_finset = s.to_finset.bind (λa, (t a).to_finset) :=
 ext $ λ x, by simp only [multiset.mem_to_finset, mem_bind, multiset.mem_bind, exists_prop]
 
-lemma bind_mono {t₁ t₂ : α → finset β} (h : ∀a∈s, t₁ a ⊆ t₂ a) : s.bind t₁ ⊆ s.bind t₂ :=
-have ∀b a, a ∈ s → b ∈ t₁ a → (∃ (a : α), a ∈ s ∧ b ∈ t₂ a),
-  from assume b a ha hb, ⟨a, ha, finset.mem_of_subset (h a ha) hb⟩,
-by simpa only [subset_iff, mem_bind, exists_imp_distrib, and_imp, exists_prop]
+@[mono] lemma bind_mono {s₁ s₂ : finset α} {t₁ t₂ : α → finset β} (hs : s₁ ≤ s₂)
+  (ht : ∀ a ∈ s₁, t₁ a ≤ t₂ a) :
+  s₁.bind t₁ ≤ s₂.bind t₂ :=
+λ x hx, let ⟨i, hi, hx⟩ := mem_bind.1 hx in mem_bind.2 ⟨i, hs hi, ht i hi hx⟩
 
-lemma bind_subset_bind_of_subset_left {α : Type*} {s₁ s₂ : finset α}
-  (t : α → finset β) (h : s₁ ⊆ s₂) : s₁.bind t ⊆ s₂.bind t :=
-begin
-  intro x,
-  simp only [and_imp, mem_bind, exists_prop],
-  exact Exists.imp (λ a ha, ⟨h ha.1, ha.2⟩)
-end
+lemma bind_mono_right {t₁ t₂ : α → finset β} (h : ∀a∈s, t₁ a ≤ t₂ a) : s.bind t₁ ≤ s.bind t₂ :=
+bind_mono (le_refl _) h
 
-lemma bind_singleton {f : α → β} : s.bind (λa, {f a}) = s.image f :=
+lemma bind_mono_left {s₁ s₂ : finset α} (t : α → finset β) (h : s₁ ≤ s₂) : s₁.bind t ≤ s₂.bind t :=
+bind_mono h (λ _ _, le_refl _)
+
+@[simp] lemma bind_singleton {f : α → β} : s.bind (λa, {f a}) = s.image f :=
 ext $ λ x, by simp only [mem_bind, mem_image, mem_singleton, eq_comm]
 
 lemma image_bind_filter_eq [decidable_eq α] (s : finset β) (g : β → α) :
@@ -1691,8 +1522,8 @@ protected def sigma (s : finset α) (t : Πa, finset (σ a)) : finset (Σa, σ a
 
 @[simp] theorem mem_sigma {p : sigma σ} : p ∈ s.sigma t ↔ p.1 ∈ s ∧ p.2 ∈ t (p.1) := mem_sigma
 
-theorem sigma_mono {s₁ s₂ : finset α} {t₁ t₂ : Πa, finset (σ a)}
-  (H1 : s₁ ⊆ s₂) (H2 : ∀a, t₁ a ⊆ t₂ a) : s₁.sigma t₁ ⊆ s₂.sigma t₂ :=
+@[mono] theorem sigma_mono {s₁ s₂ : finset α} {t₁ t₂ : Πa, finset (σ a)}
+  (H1 : s₁ ≤ s₂) (H2 : ∀a, t₁ a ≤ t₂ a) : s₁.sigma t₁ ≤ s₂.sigma t₂ :=
 λ ⟨x, sx⟩ H, let ⟨H3, H4⟩ := mem_sigma.1 H in mem_sigma.2 ⟨H1 H3, H2 x H4⟩
 
 theorem sigma_eq_bind [decidable_eq α] [∀a, decidable_eq (σ a)] (s : finset α)
@@ -1720,9 +1551,9 @@ def pi (s : finset α) (t : Πa, finset (δ a)) : finset (Πa∈s, δ a) :=
   f ∈ s.pi t ↔ (∀a (h : a ∈ s), f a h ∈ t a) :=
 mem_pi _ _ _
 
-/-- The empty dependent product function, defined on the emptyset. The assumption `a ∈ ∅` is never
+/-- The empty dependent product function, defined on the emptyset. The assumption `a ∈ ⊥` is never
 satisfied. -/
-def pi.empty (β : α → Sort*) (a : α) (h : a ∈ (∅ : finset α)) : β a :=
+def pi.empty (β : α → Sort*) (a : α) (h : a ∈ (⊥ : finset α)) : β a :=
 multiset.pi.empty β a h
 
 /-- Given a function `f` defined on a finset `s`, define a new function on the finset `s ∪ {a}`,
@@ -1753,8 +1584,8 @@ assume e₁ e₂ eq,
   { rw [eq] },
   this
 
-@[simp] lemma pi_empty {t : Πa:α, finset (δ a)} :
-  pi (∅ : finset α) t = singleton (pi.empty δ) := rfl
+@[simp] lemma pi_bot {t : Πa:α, finset (δ a)} :
+  pi (⊥ : finset α) t = singleton (pi.empty δ) := rfl
 
 @[simp] lemma pi_insert [∀a, decidable_eq (δ a)]
   {s : finset α} {t : Πa:α, finset (δ a)} {a : α} (ha : a ∉ s) :
@@ -1772,8 +1603,8 @@ begin
   exact multiset.nodup_map (multiset.injective_pi_cons ha) (pi s t).2,
 end
 
-lemma pi_subset {s : finset α} (t₁ t₂ : Πa, finset (δ a)) (h : ∀ a ∈ s, t₁ a ⊆ t₂ a) :
-  s.pi t₁ ⊆ s.pi t₂ :=
+@[mono] lemma pi_mono {s : finset α} (t₁ t₂ : Πa, finset (δ a)) (h : ∀ a ∈ s, t₁ a ≤ t₂ a) :
+  s.pi t₁ ≤ s.pi t₂ :=
 λ g hg, mem_pi.2 $ λ a ha, h a ha (mem_pi.mp hg a ha)
 
 end pi
@@ -1788,21 +1619,24 @@ def powerset (s : finset α) : finset (finset α) :=
  nodup_pmap (λ a ha b hb, congr_arg finset.val)
    (nodup_powerset.2 s.2)⟩
 
-@[simp] theorem mem_powerset {s t : finset α} : s ∈ powerset t ↔ s ⊆ t :=
+@[simp] theorem mem_powerset {s t : finset α} : s ∈ powerset t ↔ s ≤ t :=
 by cases s; simp only [powerset, mem_mk, mem_pmap, mem_powerset, exists_prop, exists_eq_right];
   rw ← val_le_iff
 
-@[simp] theorem empty_mem_powerset (s : finset α) : ∅ ∈ powerset s :=
-mem_powerset.2 (empty_subset _)
+@[simp] theorem bot_mem_powerset (s : finset α) : ⊥ ∈ powerset s :=
+mem_powerset.2 bot_le
 
 @[simp] theorem mem_powerset_self (s : finset α) : s ∈ powerset s :=
-mem_powerset.2 (subset.refl _)
+mem_powerset.2 (le_refl _)
 
-@[simp] lemma powerset_empty : finset.powerset (∅ : finset α) = {∅} := rfl
+@[simp] lemma powerset_bot : finset.powerset (⊥ : finset α) = {⊥} := rfl
 
-@[simp] theorem powerset_mono {s t : finset α} : powerset s ⊆ powerset t ↔ s ⊆ t :=
+@[simp] theorem powerset_le_iff {s t : finset α} : powerset s ≤ powerset t ↔ s ≤ t :=
 ⟨λ h, (mem_powerset.1 $ h $ mem_powerset_self _),
  λ st u h, mem_powerset.2 $ subset.trans (mem_powerset.1 h) st⟩
+
+@[mono] theorem powerset_mono {s t : finset α} (h : s ≤ t) : powerset s ≤ powerset t :=
+powerset_le_iff.2 h
 
 @[simp] theorem card_powerset (s : finset α) :
   card (powerset s) = 2 ^ card s :=
@@ -1813,20 +1647,20 @@ lemma not_mem_of_mem_powerset_of_not_mem {s t : finset α} {a : α}
 by { apply mt _ h, apply mem_powerset.1 ht }
 
 lemma powerset_insert [decidable_eq α] (s : finset α) (a : α) :
-  powerset (insert a s) = s.powerset ∪ s.powerset.image (insert a) :=
+  powerset (insert a s) = s.powerset ⊔ s.powerset.image (insert a) :=
 begin
   ext t,
-  simp only [exists_prop, mem_powerset, mem_image, mem_union, subset_insert_iff],
+  simp only [exists_prop, mem_powerset, mem_image, mem_sup, le_insert_iff],
   by_cases h : a ∈ t,
   { split,
     { exact λH, or.inr ⟨_, H, insert_erase h⟩ },
     { intros H,
       cases H,
-      { exact subset.trans (erase_subset a t) H },
+      { exact subset.trans (erase_le a t) H },
       { rcases H with ⟨u, hu⟩,
         rw ← hu.2,
-        exact subset.trans (erase_insert_subset a u) hu.1 } } },
-  { have : ¬ ∃ (u : finset α), u ⊆ s ∧ insert a u = t,
+        exact subset.trans (erase_insert_le a u) hu.1 } } },
+  { have : ¬ ∃ (u : finset α), u ≤ s ∧ insert a u = t,
       by simp [ne.symm (ne_insert_of_not_mem _ _ h)],
     simp [finset.erase_eq_of_not_mem h, this] }
 end
@@ -1844,11 +1678,11 @@ def powerset_len (n : ℕ) (s : finset α) : finset (finset α) :=
    (nodup_powerset_len s.2)⟩
 
 theorem mem_powerset_len {n} {s t : finset α} :
-  s ∈ powerset_len n t ↔ s ⊆ t ∧ card s = n :=
+  s ∈ powerset_len n t ↔ s ≤ t ∧ card s = n :=
 by cases s; simp [powerset_len, val_le_iff.symm]; refl
 
-@[simp] theorem powerset_len_mono {n} {s t : finset α} (h : s ⊆ t) :
-  powerset_len n s ⊆ powerset_len n t :=
+@[simp, mono] theorem powerset_len_mono {n} {s t : finset α} (h : s ≤ t) :
+  powerset_len n s ≤ powerset_len n t :=
 λ u h', mem_powerset_len.2 $
   and.imp (λ h₂, subset.trans h₂ h) id (mem_powerset_len.1 h')
 
@@ -1870,7 +1704,7 @@ def fold (b : β) (f : α → β) (s : finset α) : β := (s.1.map f).fold op b
 
 variables {op} {f : α → β} {b : β} {s : finset α} {a : α}
 
-@[simp] theorem fold_empty : (∅ : finset α).fold op b f = b := rfl
+@[simp] theorem fold_bot : (⊥ : finset α).fold op b f = b := rfl
 
 @[simp] theorem fold_insert [decidable_eq α] (h : a ∉ s) :
   (insert a s).fold op b f = f a * s.fold op b f :=
@@ -1899,9 +1733,9 @@ theorem fold_hom {op' : γ → γ → γ} [is_commutative γ op'] [is_associativ
 by rw [fold, fold, ← fold_hom op hm, multiset.map_map]
 
 theorem fold_union_inter [decidable_eq α] {s₁ s₂ : finset α} {b₁ b₂ : β} :
-  (s₁ ∪ s₂).fold op b₁ f * (s₁ ∩ s₂).fold op b₂ f = s₁.fold op b₂ f * s₂.fold op b₁ f :=
-by unfold fold; rw [← fold_add op, ← map_add, union_val,
-     inter_val, union_add_inter, map_add, hc.comm, fold_add]
+  (s₁ ⊔ s₂).fold op b₁ f * (s₁ ⊓ s₂).fold op b₂ f = s₁.fold op b₂ f * s₂.fold op b₁ f :=
+by unfold fold; rw [← fold_add op, ← map_add, sup_val,
+     inf_val, union_add_inter, map_add, hc.comm, fold_add]
 
 @[simp] theorem fold_insert_idem [decidable_eq α] [hi : is_idempotent β op] :
   (insert a s).fold op b f = f a * s.fold op b f :=
@@ -2004,153 +1838,145 @@ end order
 
 end fold
 
-/-! ### sup -/
-section sup
+/-! ### supr -/
+section supr
 variables [semilattice_sup_bot α]
 
 /-- Supremum of a finite set: `sup {a, b, c} f = f a ⊔ f b ⊔ f c` -/
-def sup (s : finset β) (f : β → α) : α := s.fold (⊔) ⊥ f
+def supr (s : finset β) (f : β → α) : α := s.fold (⊔) ⊥ f
 
 variables {s s₁ s₂ : finset β} {f : β → α}
 
-lemma sup_val : s.sup f = (s.1.map f).sup := rfl
+lemma supr_val : s.supr f = (s.1.map f).sup := rfl
 
-@[simp] lemma sup_empty : (∅ : finset β).sup f = ⊥ :=
-fold_empty
+@[simp] lemma supr_bot : (⊥ : finset β).supr f = ⊥ :=
+fold_bot
 
-@[simp] lemma sup_insert [decidable_eq β] {b : β} : (insert b s : finset β).sup f = f b ⊔ s.sup f :=
+@[simp] lemma supr_insert [decidable_eq β] {b : β} :
+  (insert b s : finset β).supr f = f b ⊔ s.supr f :=
 fold_insert_idem
 
-@[simp] lemma sup_singleton {b : β} : ({b} : finset β).sup f = f b :=
+@[simp] lemma supr_singleton {b : β} : ({b} : finset β).supr f = f b :=
 sup_singleton
 
-lemma sup_union [decidable_eq β] : (s₁ ∪ s₂).sup f = s₁.sup f ⊔ s₂.sup f :=
-finset.induction_on s₁ (by rw [empty_union, sup_empty, bot_sup_eq]) $ λ a s has ih,
-by rw [insert_union, sup_insert, sup_insert, ih, sup_assoc]
+lemma supr_sup [decidable_eq β] : (s₁ ⊔ s₂).supr f = s₁.supr f ⊔ s₂.supr f :=
+finset.induction_on s₁ (by rw [bot_sup_eq, supr_bot, bot_sup_eq]) $ λ a s has ih,
+by rw [insert_sup, supr_insert, supr_insert, ih, sup_assoc]
 
-theorem sup_congr {f g : β → α} (hs : s₁ = s₂) (hfg : ∀a∈s₂, f a = g a) : s₁.sup f = s₂.sup g :=
+@[congr] theorem supr_congr {f g : β → α} (hs : s₁ = s₂) (hfg : ∀a∈s₂, f a = g a) :
+  s₁.supr f = s₂.supr g :=
 by subst hs; exact finset.fold_congr hfg
 
-@[simp] lemma sup_le_iff {a : α} : s.sup f ≤ a ↔ (∀b ∈ s, f b ≤ a) :=
+@[simp] lemma supr_le_iff {a : α} : s.supr f ≤ a ↔ (∀b ∈ s, f b ≤ a) :=
 begin
   apply iff.trans multiset.sup_le,
   simp only [multiset.mem_map, and_imp, exists_imp_distrib],
   exact ⟨λ k b hb, k _ _ hb rfl, λ k a' b hb h, h ▸ k _ hb⟩,
 end
 
-lemma sup_le {a : α} : (∀b ∈ s, f b ≤ a) → s.sup f ≤ a :=
-sup_le_iff.2
+lemma supr_le {a : α} : (∀b ∈ s, f b ≤ a) → s.supr f ≤ a :=
+supr_le_iff.2
 
-lemma le_sup {b : β} (hb : b ∈ s) : f b ≤ s.sup f :=
-sup_le_iff.1 (le_refl _) _ hb
+lemma le_supr {b : β} (hb : b ∈ s) : f b ≤ s.supr f :=
+supr_le_iff.1 (le_refl _) _ hb
 
-lemma sup_mono_fun {g : β → α} (h : ∀b∈s, f b ≤ g b) : s.sup f ≤ s.sup g :=
-sup_le (λ b hb, le_trans (h b hb) (le_sup hb))
+lemma is_lub_supr (s : finset β) (f : β → α) : is_lub (f '' ↑s) (s.supr f) :=
+⟨λ x hx, let ⟨a, ha, hx⟩ := hx in hx ▸ le_supr ha,
+  λ b hb, supr_le $ λ x hx, hb ⟨x, hx, rfl⟩⟩
 
-lemma sup_mono (h : s₁ ⊆ s₂) : s₁.sup f ≤ s₂.sup f :=
-sup_le $ assume b hb, le_sup (h hb)
+@[mono] lemma supr_mono {g : β → α} (hs : s₁ ≤ s₂) (hf : ∀ b ∈ s₁, f b ≤ g b) :
+  s₁.supr f ≤ s₂.supr g :=
+supr_le $ λ b hb, le_trans (hf b hb) (le_supr $ hs hb)
 
-@[simp] lemma sup_lt_iff [is_total α (≤)] {a : α} (ha : ⊥ < a) :
-  s.sup f < a ↔ (∀b ∈ s, f b < a) :=
+lemma supr_mono_fun {g : β → α} (h : ∀b∈s, f b ≤ g b) : s.supr f ≤ s.supr g :=
+supr_mono (le_refl s) h
+
+lemma supr_mono_set (h : s₁ ≤ s₂) : s₁.supr f ≤ s₂.supr f :=
+supr_mono h (λ _ _, le_refl _)
+
+@[simp] lemma supr_lt_iff [is_total α (≤)] {a : α} (ha : ⊥ < a) :
+  s.supr f < a ↔ (∀b ∈ s, f b < a) :=
 by letI := classical.dec_eq β; from
-⟨ λh b hb, lt_of_le_of_lt (le_sup hb) h,
+⟨ λh b hb, lt_of_le_of_lt (le_supr hb) h,
   finset.induction_on s (by simp [ha]) (by simp {contextual := tt}) ⟩
 
-lemma comp_sup_eq_sup_comp [is_total α (≤)] {γ : Type} [semilattice_sup_bot γ]
-  (g : α → γ) (mono_g : monotone g) (bot : g ⊥ = ⊥) : g (s.sup f) = s.sup (g ∘ f) :=
-have A : ∀x y, g (x ⊔ y) = g x ⊔ g y :=
-begin
-  assume x y,
-  cases (@is_total.total _ (≤) _ x y) with h,
-  { simp [sup_of_le_right h, sup_of_le_right (mono_g h)] },
-  { simp [sup_of_le_left h, sup_of_le_left (mono_g h)] }
-end,
+lemma comp_supr_eq_supr_comp [is_total α (≤)] {γ : Type} [semilattice_sup_bot γ]
+  (g : α → γ) (mono_g : monotone g) (bot : g ⊥ = ⊥) :
+  g (s.supr f) = s.supr (g ∘ f) :=
 by letI := classical.dec_eq β; from
-finset.induction_on s (by simp [bot]) (by simp [A] {contextual := tt})
+finset.induction_on s (by simp [bot]) (by simp [mono_g.map_sup] {contextual := tt})
 
-theorem subset_range_sup_succ (s : finset ℕ) : s ⊆ range (s.sup id).succ :=
-λ n hn, mem_range.2 $ nat.lt_succ_of_le $ le_sup hn
+theorem le_range_supr_succ (s : finset ℕ) : s ≤ range (s.supr id).succ :=
+λ n hn, mem_range.2 $ nat.lt_succ_of_le $ le_supr hn
 
-theorem exists_nat_subset_range (s : finset ℕ) : ∃n : ℕ, s ⊆ range n :=
-⟨_, s.subset_range_sup_succ⟩
+theorem exists_nat_le_range (s : finset ℕ) : ∃n : ℕ, s ≤ range n :=
+⟨_, s.le_range_supr_succ⟩
 
-end sup
+end supr
 
-lemma sup_eq_supr [complete_lattice β] (s : finset α) (f : α → β) : s.sup f = (⨆a∈s, f a) :=
-le_antisymm
-  (finset.sup_le $ assume a ha, le_supr_of_le a $ le_supr _ ha)
-  (supr_le $ assume a, supr_le $ assume ha, le_sup ha)
+lemma supr_eq_bsupr [complete_lattice β] (s : finset α) (f : α → β) : s.supr f = (⨆a∈s, f a) :=
+(is_lub_supr s f).unique is_lub_bsupr
 
-/-! ### inf -/
-section inf
+/-! ### infi -/
+section infi
 variables [semilattice_inf_top α]
 
 /-- Infimum of a finite set: `inf {a, b, c} f = f a ⊓ f b ⊓ f c` -/
-def inf (s : finset β) (f : β → α) : α := s.fold (⊓) ⊤ f
+def infi (s : finset β) (f : β → α) : α := s.fold (⊓) ⊤ f
 
 variables {s s₁ s₂ : finset β} {f : β → α}
 
-lemma inf_val : s.inf f = (s.1.map f).inf := rfl
+lemma infi_val : s.infi f = (s.1.map f).inf := rfl
 
-@[simp] lemma inf_empty : (∅ : finset β).inf f = ⊤ :=
-fold_empty
+@[simp] lemma infi_bot : (⊥ : finset β).infi f = ⊤ := fold_bot
 
-lemma le_inf_iff {a : α} : a ≤ s.inf f ↔ ∀b ∈ s, a ≤ f b :=
-begin
-  apply iff.trans multiset.le_inf,
-  refine ⟨λ k b hb, k (f b) (multiset.mem_map_of_mem _ hb), λ k b hb, _⟩,
-  rw multiset.mem_map at hb,
-  rcases hb with ⟨a', ha', rfl⟩,
-  apply k a' ha'
-end
+lemma le_infi_iff {a : α} : a ≤ s.infi f ↔ ∀b ∈ s, a ≤ f b :=
+@supr_le_iff (order_dual α) β _ _ _ _
 
-@[simp] lemma inf_insert [decidable_eq β] {b : β} : (insert b s : finset β).inf f = f b ⊓ s.inf f :=
+@[simp] lemma infi_insert [decidable_eq β] {b : β} :
+  (insert b s : finset β).infi f = f b ⊓ s.infi f :=
 fold_insert_idem
 
-@[simp] lemma inf_singleton {b : β} : ({b} : finset β).inf f = f b :=
+@[simp] lemma infi_singleton {b : β} : ({b} : finset β).infi f = f b :=
 inf_singleton
 
-lemma inf_union [decidable_eq β] : (s₁ ∪ s₂).inf f = s₁.inf f ⊓ s₂.inf f :=
-finset.induction_on s₁ (by rw [empty_union, inf_empty, top_inf_eq]) $ λ a s has ih,
-by rw [insert_union, inf_insert, inf_insert, ih, inf_assoc]
+lemma infi_sup [decidable_eq β] : (s₁ ⊔ s₂).infi f = s₁.infi f ⊓ s₂.infi f :=
+@supr_sup (order_dual α) _ _ _ _ _ _
 
-theorem inf_congr {f g : β → α} (hs : s₁ = s₂) (hfg : ∀a∈s₂, f a = g a) : s₁.inf f = s₂.inf g :=
-by subst hs; exact finset.fold_congr hfg
+theorem infi_congr {f g : β → α} (hs : s₁ = s₂) (hfg : ∀a∈s₂, f a = g a) : s₁.infi f = s₂.infi g :=
+@supr_congr (order_dual α) _ _ _ _ _ _ hs hfg
 
-lemma inf_le {b : β} (hb : b ∈ s) : s.inf f ≤ f b :=
-le_inf_iff.1 (le_refl _) _ hb
+lemma infi_le {b : β} (hb : b ∈ s) : s.infi f ≤ f b :=
+le_infi_iff.1 (le_refl _) _ hb
 
-lemma le_inf {a : α} : (∀b ∈ s, a ≤ f b) → a ≤ s.inf f :=
-le_inf_iff.2
+lemma le_infi {a : α} : (∀b ∈ s, a ≤ f b) → a ≤ s.infi f :=
+le_infi_iff.2
 
-lemma inf_mono_fun {g : β → α} (h : ∀b∈s, f b ≤ g b) : s.inf f ≤ s.inf g :=
-le_inf (λ b hb, le_trans (inf_le hb) (h b hb))
+lemma is_glb_infi (s : finset β) (f : β → α) : is_glb (f '' ↑s) (s.infi f) :=
+@is_lub_supr (order_dual α) _ _ s f
 
-lemma inf_mono (h : s₁ ⊆ s₂) : s₂.inf f ≤ s₁.inf f :=
-le_inf $ assume b hb, inf_le (h hb)
+@[mono] lemma infi_mono {g : β → α} (hs : s₁ ≤ s₂) (hf : ∀ b ∈ s₁, f b ≤ g b) :
+  s₂.infi f ≤ s₁.infi g :=
+@supr_mono (order_dual α) β _ _ _ _ _ hs hf
 
-lemma lt_inf [is_total α (≤)] {a : α} : (a < ⊤) → (∀b ∈ s, a < f b) → a < s.inf f :=
-by letI := classical.dec_eq β; from
-finset.induction_on s (by simp) (by simp {contextual := tt})
+lemma infi_mono_fun {g : β → α} (h : ∀b∈s, f b ≤ g b) : s.infi f ≤ s.infi g :=
+infi_mono (le_refl s) h
 
-lemma comp_inf_eq_inf_comp [is_total α (≤)] {γ : Type} [semilattice_inf_top γ]
-  (g : α → γ) (mono_g : monotone g) (top : g ⊤ = ⊤) : g (s.inf f) = s.inf (g ∘ f) :=
-have A : ∀x y, g (x ⊓ y) = g x ⊓ g y :=
-begin
-  assume x y,
-  cases (@is_total.total _ (≤) _ x y) with h,
-  { simp [inf_of_le_left h, inf_of_le_left (mono_g h)] },
-  { simp [inf_of_le_right h, inf_of_le_right (mono_g h)] }
-end,
-by letI := classical.dec_eq β; from
-finset.induction_on s (by simp [top]) (by simp [A] {contextual := tt})
+lemma infi_mono_set (h : s₁ ≤ s₂) : s₂.infi f ≤ s₁.infi f := infi_mono h (λ _ _, le_refl _)
 
-end inf
+lemma lt_infi_iff [h : is_total α (≤)] {a : α} (ha : a < ⊤) : a < s.infi f ↔ (∀b ∈ s, a < f b) :=
+@supr_lt_iff (order_dual α) β _ _ _ (@is_total.swap _ _ h) _ ha
 
-lemma inf_eq_infi [complete_lattice β] (s : finset α) (f : α → β) : s.inf f = (⨅a∈s, f a) :=
-le_antisymm
-  (le_infi $ assume a, le_infi $ assume ha, inf_le ha)
-  (finset.le_inf $ assume a ha, infi_le_of_le a $ infi_le _ ha)
+lemma comp_infi_eq_infi_comp [h : is_total α (≤)] {γ : Type} [semilattice_inf_top γ]
+  (g : α → γ) (mono_g : monotone g) (top : g ⊤ = ⊤) :
+  g (s.infi f) = s.infi (g ∘ f) :=
+@comp_supr_eq_supr_comp (order_dual α) _ _ _ _ (@is_total.swap _ _ h)
+  (order_dual γ) _ g mono_g.order_dual top
+
+end infi
+
+lemma infi_eq_binfi [complete_lattice β] (s : finset α) (f : α → β) : s.infi f = (⨅a∈s, f a) :=
+@supr_eq_bsupr α (order_dual β) _ s f
 
 /-! ### max and min of finite sets -/
 section max_min
@@ -2162,27 +1988,27 @@ and `none` otherwise. It belongs to `option α`. If you want to get an element o
 protected def max : finset α → option α :=
 fold (option.lift_or_get max) none some
 
-theorem max_eq_sup_with_bot (s : finset α) :
-  s.max = @sup (with_bot α) α _ s some := rfl
+theorem max_eq_supr_with_bot (s : finset α) :
+  s.max = @supr (with_bot α) α _ s some := rfl
 
-@[simp] theorem max_empty : (∅ : finset α).max = none := rfl
+@[simp] theorem max_bot : (⊥ : finset α).max = none := rfl
 
 @[simp] theorem max_insert {a : α} {s : finset α} :
   (insert a s).max = option.lift_or_get max (some a) s.max := fold_insert_idem
 
 @[simp] theorem max_singleton {a : α} : finset.max {a} = some a :=
-by { rw [← insert_emptyc_eq], exact max_insert }
+by { rw [← insert_bot], exact max_insert }
 
 theorem max_of_mem {s : finset α} {a : α} (h : a ∈ s) : ∃ b, b ∈ s.max :=
-(@le_sup (with_bot α) _ _ _ _ _ h _ rfl).imp $ λ b, Exists.fst
+(@le_supr (with_bot α) _ _ _ _ _ h _ rfl).imp $ λ b, Exists.fst
 
 theorem max_of_nonempty {s : finset α} (h : s.nonempty) : ∃ a, a ∈ s.max :=
 let ⟨a, ha⟩ := h in max_of_mem ha
 
-theorem max_eq_none {s : finset α} : s.max = none ↔ s = ∅ :=
-⟨λ h, s.eq_empty_or_nonempty.elim id
+theorem max_eq_none {s : finset α} : s.max = none ↔ s = ⊥ :=
+⟨λ h, s.eq_bot_or_nonempty.elim id
   (λ H, let ⟨a, ha⟩ := max_of_nonempty H in by rw h at ha; cases ha),
-  λ h, h.symm ▸ max_empty⟩
+  λ h, h.symm ▸ max_bot⟩
 
 theorem mem_of_max {s : finset α} : ∀ {a : α}, a ∈ s.max → a ∈ s :=
 finset.induction_on s (λ _ H, by cases H)
@@ -2197,7 +2023,7 @@ finset.induction_on s (λ _ H, by cases H)
   end)
 
 theorem le_max_of_mem {s : finset α} {a b : α} (h₁ : a ∈ s) (h₂ : b ∈ s.max) : a ≤ b :=
-by rcases @le_sup (with_bot α) _ _ _ _ _ h₁ _ rfl with ⟨b', hb, ab⟩;
+by rcases @le_supr (with_bot α) _ _ _ _ _ h₁ _ rfl with ⟨b', hb, ab⟩;
    cases h₂.symm.trans hb; assumption
 
 /-- Let `s` be a finset in a linear order. Then `s.min` is the minimum of `s` if `s` is not empty,
@@ -2206,28 +2032,28 @@ and `none` otherwise. It belongs to `option α`. If you want to get an element o
 protected def min : finset α → option α :=
 fold (option.lift_or_get min) none some
 
-theorem min_eq_inf_with_top (s : finset α) :
-  s.min = @inf (with_top α) α _ s some := rfl
+theorem min_eq_infi_with_top (s : finset α) :
+  s.min = @infi (with_top α) α _ s some := rfl
 
-@[simp] theorem min_empty : (∅ : finset α).min = none := rfl
+@[simp] theorem min_bot : (⊥ : finset α).min = none := rfl
 
 @[simp] theorem min_insert {a : α} {s : finset α} :
   (insert a s).min = option.lift_or_get min (some a) s.min :=
 fold_insert_idem
 
 @[simp] theorem min_singleton {a : α} : finset.min {a} = some a :=
-by { rw ← insert_emptyc_eq, exact min_insert }
+by { rw ← insert_bot, exact min_insert }
 
 theorem min_of_mem {s : finset α} {a : α} (h : a ∈ s) : ∃ b, b ∈ s.min :=
-(@inf_le (with_top α) _ _ _ _ _ h _ rfl).imp $ λ b, Exists.fst
+(@infi_le (with_top α) _ _ _ _ _ h _ rfl).imp $ λ b, Exists.fst
 
 theorem min_of_nonempty {s : finset α} (h : s.nonempty) : ∃ a, a ∈ s.min :=
 let ⟨a, ha⟩ := h in min_of_mem ha
 
-theorem min_eq_none {s : finset α} : s.min = none ↔ s = ∅ :=
-⟨λ h, s.eq_empty_or_nonempty.elim id
+theorem min_eq_none {s : finset α} : s.min = none ↔ s = ⊥ :=
+⟨λ h, s.eq_bot_or_nonempty.elim id
   (λ H, let ⟨a, ha⟩ := min_of_nonempty H in by rw h at ha; cases ha),
-  λ h, h.symm ▸ min_empty⟩
+  λ h, h.symm ▸ min_bot⟩
 
 theorem mem_of_min {s : finset α} : ∀ {a : α}, a ∈ s.min → a ∈ s :=
 finset.induction_on s (λ _ H, by cases H) $
@@ -2242,7 +2068,7 @@ finset.induction_on s (λ _ H, by cases H) $
   end
 
 theorem min_le_of_mem {s : finset α} {a b : α} (h₁ : b ∈ s) (h₂ : a ∈ s.min) : a ≤ b :=
-by rcases @inf_le (with_top α) _ _ _ _ _ h₁ _ rfl with ⟨b', hb, ab⟩;
+by rcases @infi_le (with_top α) _ _ _ _ _ h₁ _ rfl with ⟨b', hb, ab⟩;
    cases h₂.symm.trans hb; assumption
 
 /-- Given a nonempty finset `s` in a linear order `α `, then `s.min' h` is its minimum, as an
@@ -2515,15 +2341,15 @@ end sort_linear_order
 section disjoint
 variable [decidable_eq α]
 
+@[simp, norm_cast] lemma disjoint_coe {s t : finset α} :
+  disjoint (↑s : set α) ↑t ↔ disjoint s t :=
+by { simp only [disjoint_iff, set.bot_eq_empty, set.inf_eq_inter, ← coe_bot, ← coe_inf, coe_inj] }
+
 theorem disjoint_left {s t : finset α} : disjoint s t ↔ ∀ {a}, a ∈ s → a ∉ t :=
-by simp only [_root_.disjoint, inf_eq_inter, le_iff_subset, subset_iff, mem_inter, not_and,
-  and_imp]; refl
+by exact_mod_cast @set.disjoint_left α ↑s ↑t
 
 theorem disjoint_val {s t : finset α} : disjoint s t ↔ s.1.disjoint t.1 :=
 disjoint_left
-
-theorem disjoint_iff_inter_eq_empty {s t : finset α} : disjoint s t ↔ s ∩ t = ∅ :=
-disjoint_iff
 
 instance decidable_disjoint (U V : finset α) : decidable (disjoint U V) :=
 decidable_of_decidable_of_iff (by apply_instance) eq_bot_iff
@@ -2533,16 +2359,6 @@ by rw [disjoint.comm, disjoint_left]
 
 theorem disjoint_iff_ne {s t : finset α} : disjoint s t ↔ ∀ a ∈ s, ∀ b ∈ t, a ≠ b :=
 by simp only [disjoint_left, imp_not_comm, forall_eq']
-
-theorem disjoint_of_subset_left {s t u : finset α} (h : s ⊆ u) (d : disjoint u t) : disjoint s t :=
-disjoint_left.2 (λ x m₁, (disjoint_left.1 d) (h m₁))
-
-theorem disjoint_of_subset_right {s t u : finset α} (h : t ⊆ u) (d : disjoint s u) : disjoint s t :=
-disjoint_right.2 (λ x m₁, (disjoint_right.1 d) (h m₁))
-
-@[simp] theorem disjoint_empty_left (s : finset α) : disjoint ∅ s := disjoint_bot_left
-
-@[simp] theorem disjoint_empty_right (s : finset α) : disjoint s ∅ := disjoint_bot_right
 
 @[simp] theorem singleton_disjoint {s : finset α} {a : α} : disjoint (singleton a) s ↔ a ∉ s :=
 by simp only [disjoint_left, mem_singleton, forall_eq]
@@ -2558,30 +2374,21 @@ by simp only [disjoint_left, mem_insert, or_imp_distrib, forall_and_distrib, for
   disjoint s (insert a t) ↔ a ∉ s ∧ disjoint s t :=
 disjoint.comm.trans $ by rw [disjoint_insert_left, disjoint.comm]
 
-@[simp] theorem disjoint_union_left {s t u : finset α} :
-  disjoint (s ∪ t) u ↔ disjoint s u ∧ disjoint t u :=
-by simp only [disjoint_left, mem_union, or_imp_distrib, forall_and_distrib]
+@[simp] theorem disjoint_sup_left {s t u : finset α} :
+  disjoint (s ⊔ t) u ↔ disjoint s u ∧ disjoint t u :=
+by simp only [disjoint_left, mem_sup, or_imp_distrib, forall_and_distrib]
 
-@[simp] theorem disjoint_union_right {s t u : finset α} :
-  disjoint s (t ∪ u) ↔ disjoint s t ∧ disjoint s u :=
-by simp only [disjoint_right, mem_union, or_imp_distrib, forall_and_distrib]
+@[simp] theorem disjoint_sup_right {s t u : finset α} :
+  disjoint s (t ⊔ u) ↔ disjoint s t ∧ disjoint s u :=
+by simp only [disjoint_right, mem_sup, or_imp_distrib, forall_and_distrib]
 
-lemma sdiff_disjoint {s t : finset α} : disjoint (t \ s) s :=
-disjoint_left.2 $ assume a ha, (mem_sdiff.1 ha).2
-
-lemma disjoint_sdiff {s t : finset α} : disjoint s (t \ s) :=
-sdiff_disjoint.symm
-
-lemma disjoint_sdiff_inter (s t : finset α) : disjoint (s \ t) (s ∩ t) :=
-disjoint_of_subset_right (inter_subset_right _ _) sdiff_disjoint
-
-lemma sdiff_eq_self_iff_disjoint {s t : finset α} : s \ t = s ↔ disjoint s t :=
-by rw [sdiff_eq_self, subset_empty, disjoint_iff_inter_eq_empty]
+lemma disjoint_sdiff_inf (s t : finset α) : disjoint (s \ t) (s ⊓ t) :=
+(sdiff_disjoint s t).mono_right inf_le_right
 
 lemma sdiff_eq_self_of_disjoint {s t : finset α} (h : disjoint s t) : s \ t = s :=
-sdiff_eq_self_iff_disjoint.2 h
+sdiff_eq_self.2 h
 
-lemma disjoint_self_iff_empty (s : finset α) : disjoint s s ↔ s = ∅ :=
+lemma disjoint_self_iff_bot (s : finset α) : disjoint s s ↔ s = ⊥ :=
 disjoint_self
 
 lemma disjoint_bind_left {ι : Type*}
@@ -2590,9 +2397,9 @@ lemma disjoint_bind_left {ι : Type*}
 begin
   classical,
   refine s.induction _ _,
-  { simp only [forall_mem_empty_iff, bind_empty, disjoint_empty_left] },
+  { simp only [forall_mem_bot_iff, bind_bot, disjoint_bot_left] },
   { assume i s his ih,
-    simp only [disjoint_union_left, bind_insert, his, forall_mem_insert, ih] }
+    simp only [disjoint_sup_left, bind_insert, his, forall_mem_insert, ih] }
 end
 
 lemma disjoint_bind_right {ι : Type*}
@@ -2600,13 +2407,13 @@ lemma disjoint_bind_right {ι : Type*}
   disjoint s (t.bind f) ↔ (∀i∈t, disjoint s (f i)) :=
 by simpa only [disjoint.comm] using disjoint_bind_left t f s
 
-@[simp] theorem card_disjoint_union {s t : finset α} (h : disjoint s t) :
-  card (s ∪ t) = card s + card t :=
-by rw [← card_union_add_card_inter, disjoint_iff_inter_eq_empty.1 h, card_empty, add_zero]
+@[simp] theorem card_disjoint_sup {s t : finset α} (h : disjoint s t) :
+  card (s ⊔ t) = card s + card t :=
+by rw [← card_sup_add_card_inf, h.eq_bot, card_bot, add_zero]
 
-theorem card_sdiff {s t : finset α} (h : s ⊆ t) : card (t \ s) = card t - card s :=
-suffices card (t \ s) = card ((t \ s) ∪ s) - card s, by rwa sdiff_union_of_subset h at this,
-by rw [card_disjoint_union sdiff_disjoint, nat.add_sub_cancel]
+theorem card_sdiff {s t : finset α} (h : s ≤ t) : card (t \ s) = card t - card s :=
+suffices card (t \ s) = card ((t \ s) ⊔ s) - card s, by rwa sdiff_sup_of_le h at this,
+by rw [card_disjoint_sup (sdiff_disjoint _ _), nat.add_sub_cancel]
 
 lemma disjoint_filter {s : finset α} {p q : α → Prop} [decidable_pred p] [decidable_pred q] :
     disjoint (s.filter p) (s.filter q) ↔ (∀ x ∈ s, p x → ¬ q x) :=
@@ -2636,8 +2443,8 @@ Given a set A and a set B inside it, we can shrink A to any appropriate size, an
 inside it.
 -/
 lemma exists_intermediate_set {A B : finset α} (i : ℕ)
-  (h₁ : i + card B ≤ card A) (h₂ : B ⊆ A) :
-  ∃ (C : finset α), B ⊆ C ∧ C ⊆ A ∧ card C = i + card B :=
+  (h₁ : i + card B ≤ card A) (h₂ : B ≤ A) :
+  ∃ (C : finset α), B ≤ C ∧ C ≤ A ∧ card C = i + card B :=
 begin
   classical,
   rcases nat.le.dest h₁ with ⟨k, _⟩,
@@ -2663,8 +2470,8 @@ end
 
 /-- We can shrink A to any smaller size. -/
 lemma exists_smaller_set (A : finset α) (i : ℕ) (h₁ : i ≤ card A) :
-  ∃ (B : finset α), B ⊆ A ∧ card B = i :=
-let ⟨B, _, x₁, x₂⟩ := exists_intermediate_set i (by simpa) (empty_subset A) in ⟨B, x₁, x₂⟩
+  ∃ (B : finset α), B ≤ A ∧ card B = i :=
+let ⟨B, _, x₁, x₂⟩ := exists_intermediate_set i (by simpa) bot_le in ⟨B, x₁, x₂⟩
 
 instance [has_repr α] : has_repr (finset α) := ⟨λ s, repr s.1⟩
 
@@ -2742,19 +2549,19 @@ multiset.Ico.card _ _
 @[simp] theorem mem {n m l : ℕ} : l ∈ Ico n m ↔ n ≤ l ∧ l < m :=
 multiset.Ico.mem
 
-theorem eq_empty_of_le {n m : ℕ} (h : m ≤ n) : Ico n m = ∅ :=
+theorem eq_bot_of_le {n m : ℕ} (h : m ≤ n) : Ico n m = ⊥ :=
 eq_of_veq $ multiset.Ico.eq_zero_of_le h
 
-@[simp] theorem self_eq_empty (n : ℕ) : Ico n n = ∅ :=
-eq_empty_of_le $ le_refl n
+@[simp] theorem self_eq_bot (n : ℕ) : Ico n n = ⊥ :=
+eq_bot_of_le $ le_refl n
 
-@[simp] theorem eq_empty_iff {n m : ℕ} : Ico n m = ∅ ↔ m ≤ n :=
+@[simp] theorem eq_bot_iff {n m : ℕ} : Ico n m = ⊥ ↔ m ≤ n :=
 iff.trans val_eq_zero.symm multiset.Ico.eq_zero_iff
 
-theorem subset_iff {m₁ n₁ m₂ n₂ : ℕ} (hmn : m₁ < n₁) :
-  Ico m₁ n₁ ⊆ Ico m₂ n₂ ↔ (m₂ ≤ m₁ ∧ n₁ ≤ n₂) :=
+theorem le_iff {m₁ n₁ m₂ n₂ : ℕ} (hmn : m₁ < n₁) :
+  Ico m₁ n₁ ≤ Ico m₂ n₂ ↔ (m₂ ≤ m₁ ∧ n₁ ≤ n₂) :=
 begin
-  simp only [subset_iff, mem],
+  simp only [le_def, mem],
   refine ⟨λ h, ⟨_, _⟩, _⟩,
   { exact (h ⟨le_refl _, hmn⟩).1 },
   { refine le_of_pred_lt (@h (pred n₁) ⟨le_pred_of_lt hmn, pred_lt _⟩).2,
@@ -2763,20 +2570,20 @@ begin
     exact ⟨le_trans hm hmk, lt_of_lt_of_le hkn hn⟩ }
 end
 
-protected theorem subset {m₁ n₁ m₂ n₂ : ℕ} (hmm : m₂ ≤ m₁) (hnn : n₁ ≤ n₂) :
-  Ico m₁ n₁ ⊆ Ico m₂ n₂ :=
+protected theorem le {m₁ n₁ m₂ n₂ : ℕ} (hmm : m₂ ≤ m₁) (hnn : n₁ ≤ n₂) :
+  Ico m₁ n₁ ≤ Ico m₂ n₂ :=
 begin
-  simp only [finset.subset_iff, Ico.mem],
+  simp only [le_def, Ico.mem],
   assume x hx,
   exact ⟨le_trans hmm hx.1, lt_of_lt_of_le hx.2 hnn⟩
 end
 
-lemma union_consecutive {n m l : ℕ} (hnm : n ≤ m) (hml : m ≤ l) :
-  Ico n m ∪ Ico m l = Ico n l :=
+lemma sup_consecutive {n m l : ℕ} (hnm : n ≤ m) (hml : m ≤ l) :
+  Ico n m ⊔ Ico m l = Ico n l :=
 by rw [← to_finset, ← to_finset, ← multiset.to_finset_add,
   multiset.Ico.add_consecutive hnm hml, to_finset]
 
-@[simp] lemma inter_consecutive (n m l : ℕ) : Ico n m ∩ Ico m l = ∅ :=
+@[simp] lemma inter_consecutive (n m l : ℕ) : Ico n m ⊓ Ico m l = ⊥ :=
 begin
   rw [← to_finset, ← to_finset, ← multiset.to_finset_inter, multiset.Ico.inter_consecutive],
   simp,
@@ -2811,7 +2618,7 @@ multiset.Ico.not_mem_top
 lemma filter_lt_of_top_le {n m l : ℕ} (hml : m ≤ l) : (Ico n m).filter (λ x, x < l) = Ico n m :=
 eq_of_veq $ multiset.Ico.filter_lt_of_top_le hml
 
-lemma filter_lt_of_le_bot {n m l : ℕ} (hln : l ≤ n) : (Ico n m).filter (λ x, x < l) = ∅ :=
+lemma filter_lt_of_le_bot {n m l : ℕ} (hln : l ≤ n) : (Ico n m).filter (λ x, x < l) = ⊥ :=
 eq_of_veq $ multiset.Ico.filter_lt_of_le_bot hln
 
 lemma filter_lt_of_ge {n m l : ℕ} (hlm : l ≤ m) : (Ico n m).filter (λ x, x < l) = Ico n l :=
@@ -2823,7 +2630,7 @@ eq_of_veq $ multiset.Ico.filter_lt n m l
 lemma filter_le_of_le_bot {n m l : ℕ} (hln : l ≤ n) : (Ico n m).filter (λ x, l ≤ x) = Ico n m :=
 eq_of_veq $ multiset.Ico.filter_le_of_le_bot hln
 
-lemma filter_le_of_top_le {n m l : ℕ} (hml : m ≤ l) : (Ico n m).filter (λ x, l ≤ x) = ∅ :=
+lemma filter_le_of_top_le {n m l : ℕ} (hml : m ≤ l) : (Ico n m).filter (λ x, l ≤ x) = ⊥ :=
 eq_of_veq $ multiset.Ico.filter_le_of_top_le hml
 
 lemma filter_le_of_le {n m l : ℕ} (hnl : n ≤ l) : (Ico n m).filter (λ x, l ≤ x) = Ico l m :=
@@ -2909,13 +2716,13 @@ end finset
 namespace multiset
 
 lemma count_sup [decidable_eq β] (s : finset α) (f : α → multiset β) (b : β) :
-  count b (s.sup f) = s.sup (λa, count b (f a)) :=
+  count b (s.supr f) = s.supr (λa, count b (f a)) :=
 begin
   letI := classical.dec_eq α,
   refine s.induction _ _,
   { exact count_zero _ },
   { assume i s his ih,
-    rw [finset.sup_insert, sup_eq_union, count_union, finset.sup_insert, ih],
+    rw [finset.supr_insert, sup_eq_union, count_union, finset.supr_insert, ih],
     refl }
 end
 
@@ -2998,23 +2805,23 @@ namespace finset
 /-! ### bUnion -/
 
 @[simp] theorem bUnion_singleton (a : α) (s : α → set β) : (⋃ x ∈ ({a} : finset α), s x) = s a :=
-by { simp only [set.Union, ← supr_coe], rw coe_singleton, exact supr_singleton }
+by { simp only [set.Union, ← supr_coe], rw coe_singleton, exact _root_.supr_singleton }
 
 variables [decidable_eq α]
 
-theorem supr_union {α} [complete_lattice α] {β} [decidable_eq β] {f : β → α} {s t : finset β} :
-  (⨆ x ∈ s ∪ t, f x) = (⨆x∈s, f x) ⊔ (⨆x∈t, f x) :=
-calc (⨆ x ∈ s ∪ t, f x) = (⨆ x, (⨆h : x∈s, f x) ⊔ (⨆h : x∈t, f x)) :
-  congr_arg _ $ funext $ λ x, by { convert supr_or, rw finset.mem_union, rw finset.mem_union, refl,
+theorem bsupr_sup {α} [complete_lattice α] {β} [decidable_eq β] {f : β → α} {s t : finset β} :
+  (⨆ x ∈ s ⊔ t, f x) = (⨆x∈s, f x) ⊔ (⨆x∈t, f x) :=
+calc (⨆ x ∈ s ⊔ t, f x) = (⨆ x, (⨆h : x∈s, f x) ⊔ (⨆h : x∈t, f x)) :
+  congr_arg _ $ funext $ λ x, by { convert supr_or, rw finset.mem_sup, rw finset.mem_sup, refl,
     refl }
                     ... = (⨆x∈s, f x) ⊔ (⨆x∈t, f x) : supr_sup_eq
 
-lemma bUnion_union (s t : finset α) (u : α → set β) :
-  (⋃ x ∈ s ∪ t, u x) = (⋃ x ∈ s, u x) ∪ (⋃ x ∈ t, u x) :=
-supr_union
+lemma bUnion_sup (s t : finset α) (u : α → set β) :
+  (⋃ x ∈ s ⊔ t, u x) = (⋃ x ∈ s, u x) ∪ (⋃ x ∈ t, u x) :=
+bsupr_sup
 
 @[simp] lemma bUnion_insert (a : α) (s : finset α) (t : α → set β) :
   (⋃ x ∈ insert a s, t x) = t a ∪ (⋃ x ∈ s, t x) :=
-begin rw insert_eq, simp only [bUnion_union, finset.bUnion_singleton] end
+begin rw insert_eq, simp only [bUnion_sup, finset.bUnion_singleton] end
 
 end finset

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -2592,6 +2592,9 @@ theorem le_ndunion_right (s t : multiset α) : t ≤ ndunion s t :=
 quotient.induction_on₂ s t $ λ l₁ l₂,
 (sublist_of_suffix $ suffix_union_right _ _).subperm
 
+theorem subset_ndunion_right (s t : multiset α) : t ⊆ ndunion s t :=
+subset_of_le (le_ndunion_right s t)
+
 theorem ndunion_le_add (s t : multiset α) : ndunion s t ≤ s + t :=
 quotient.induction_on₂ s t $ λ l₁ l₂, (union_sublist_append _ _).subperm
 
@@ -2650,6 +2653,9 @@ by simp [ndinter, le_filter, subset_iff]
 
 theorem ndinter_le_left (s t : multiset α) : ndinter s t ≤ s :=
 (le_ndinter.1 (le_refl _)).1
+
+theorem ndinter_subset_left (s t : multiset α) : ndinter s t ⊆ s :=
+subset_of_le (ndinter_le_left s t)
 
 theorem ndinter_subset_right (s t : multiset α) : ndinter s t ⊆ t :=
 (le_ndinter.1 (le_refl _)).2

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -551,8 +551,14 @@ by simp [subset_def, or_imp_distrib, forall_and_distrib]
 theorem insert_subset_insert (h : s ⊆ t) : insert a s ⊆ insert a t :=
 assume a', or.imp_right (@h a')
 
+theorem ssubset_iff_insert {s t : set α} : s ⊂ t ↔ ∃ a ∉ s, insert a s ⊆ t :=
+begin
+  simp only [insert_subset, exists_and_distrib_right, ssubset_def, not_subset],
+  simp only [exists_prop, and_comm]
+end
+
 theorem ssubset_insert {s : set α} {a : α} (h : a ∉ s) : s ⊂ insert a s :=
-by finish [ssubset_iff_subset_ne, ext_iff]
+ssubset_iff_insert.2 ⟨a, h, subset.refl _⟩
 
 theorem insert_comm (a b : α) (s : set α) : insert a (insert b s) = insert b (insert a s) :=
 ext $ by simp [or.left_comm]

--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -36,6 +36,12 @@ instance lattice_set : complete_lattice (set α) :=
 instance : distrib_lattice (set α) :=
 { le_sup_inf := λ s t u x, or_and_distrib_left.2, ..set.lattice_set }
 
+@[simp] lemma bot_eq_empty : (⊥ : set α) = ∅ := rfl
+@[simp] lemma sup_eq_union (s t : set α) : s ⊔ t = s ∪ t := rfl
+@[simp] lemma inf_eq_inter (s t : set α) : s ⊓ t = s ∩ t := rfl
+@[simp] lemma le_eq_subset (s t : set α) : s ≤ t = (s ⊆ t) := rfl
+@[simp] lemma lt_eq_ssubset (s t : set α) : s < t = (s ⊂ t) := rfl
+
 /-- Image is monotone. See `set.image_image` for the statement in terms of `⊆`. -/
 lemma monotone_image {f : α → β} : monotone (image f) :=
 assume s t, assume h : s ⊆ t, image_subset _ h

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -248,7 +248,7 @@ assume x, m_f (le_gh x)
 section monotone
 variables [preorder α] [preorder γ]
 
-theorem monotone.order_dual {f : α → γ} (hf : monotone f) :
+protected theorem monotone.order_dual {f : α → γ} (hf : monotone f) :
   @monotone (order_dual α) (order_dual γ) _ _ f :=
 λ x y hxy, hf hxy
 

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -429,10 +429,24 @@ lemma le_map_sup [semilattice_sup α] [semilattice_sup β]
   f x ⊔ f y ≤ f (x ⊔ y) :=
 sup_le (h le_sup_left) (h le_sup_right)
 
+lemma map_sup [semilattice_sup α] [is_total α (≤)] [semilattice_sup β] {f : α → β}
+  (hf : monotone f) (x y : α) :
+  f (x ⊔ y) = f x ⊔ f y :=
+(is_total.total x y).elim
+  (λ h : x ≤ y, by simp only [h, hf h, sup_of_le_right])
+  (λ h, by simp only [h, hf h, sup_of_le_left])
+
 lemma map_inf_le [semilattice_inf α] [semilattice_inf β]
   {f : α → β} (h : monotone f) (x y : α) :
   f (x ⊓ y) ≤ f x ⊓ f y :=
 le_inf (h inf_le_left) (h inf_le_right)
+
+lemma map_inf [semilattice_inf α] [is_total α (≤)] [semilattice_inf β] {f : α → β}
+  (hf : monotone f) (x y : α) :
+  f (x ⊓ y) = f x ⊓ f y :=
+(is_total.total x y).elim
+  (λ h : x ≤ y, by simp only [h, hf h, inf_of_le_left])
+  (λ h, by simp only [h, hf h, inf_of_le_right])
 
 end monotone
 


### PR DESCRIPTION
Use `⊔`, `⊓`, `⊥` instead of `∪`, `∩`, `∅`. Rename `sup`/`inf` to `supr`/`infi` to avoid
name conflicts.

---
<!-- put comments you want to keep out of the PR commit here -->

I made `data.finset` compile. I'd like to know if there are any objections before porting
the rest of `mathlib`.

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/3083.20finset.20lattice)