### PR TITLE
[Merged by Bors] - feat(ring_theory/localization): integral closure in field extension

### DIFF
--- a/src/data/polynomial.lean
+++ b/src/data/polynomial.lean
@@ -291,6 +291,9 @@ open is_semiring_hom
 def eval₂ (p : polynomial R) : S :=
 p.sum (λ e a, f a * x ^ e)
 
+@[simp] lemma eval₂_zero : (0 : polynomial R).eval₂ f x = 0 :=
+finsupp.sum_zero_index
+
 variables [is_semiring_hom f]
 
 @[simp] lemma eval₂_C : (C a).eval₂ f x = f a :=
@@ -298,9 +301,6 @@ variables [is_semiring_hom f]
 
 @[simp] lemma eval₂_X : X.eval₂ f x = x :=
 (sum_single_index $ by rw [map_zero f, zero_mul]).trans $ by rw [map_one f, one_mul, pow_one]
-
-@[simp] lemma eval₂_zero : (0 : polynomial R).eval₂ f x = 0 :=
-finsupp.sum_zero_index
 
 @[simp] lemma eval₂_add : (p + q).eval₂ f x = p.eval₂ f x + q.eval₂ f x :=
 finsupp.sum_add_index
@@ -542,7 +542,7 @@ begin
   exact le_refl _
 end
 
-lemma nat_degree_eq_of_degree_eq [comm_semiring S] {q : polynomial S}
+lemma nat_degree_eq_of_degree_eq {q : polynomial S}
   (h : degree p = degree q) : nat_degree p = nat_degree q :=
 by unfold nat_degree; rw h
 

--- a/src/data/polynomial.lean
+++ b/src/data/polynomial.lean
@@ -313,6 +313,22 @@ by rw [← C_1, eval₂_C, map_one f]
 instance eval₂.is_add_monoid_hom : is_add_monoid_hom (eval₂ f x) :=
 { map_zero := eval₂_zero _ _, map_add := λ _ _, eval₂_add _ _ }
 
+lemma eval₂_smul (g : R →+* S) (p : polynomial R) (x : S) {s : R} :
+  eval₂ g x (s • p) = g s * eval₂ g x p :=
+begin
+  simp_rw [eval₂, finsupp.sum, finset.mul_sum],
+  refine trans (finset.sum_subset _ _) (finset.sum_congr rfl _),
+  { intros x hx,
+    rw mem_support_iff at ⊢ hx,
+    intro h,
+    rw [smul_apply, smul_eq_mul, h, mul_zero] at hx,
+    contradiction },
+  { intros i _ hi,
+    rw [not_mem_support_iff.mp hi, g.map_zero, zero_mul] },
+  intros i hi,
+  simp [mul_assoc]
+end
+
 end eval₂
 
 section eval₂

--- a/src/data/polynomial.lean
+++ b/src/data/polynomial.lean
@@ -337,11 +337,7 @@ end
 
 lemma eval₂_smul (g : R →+* S) (p : polynomial R) (x : S) {s : R} :
   eval₂ g x (s • p) = g s * eval₂ g x p :=
-begin
-  convert (show eval₂ g x (C s * p) = g s * eval₂ g x p, by rw [eval₂_mul, eval₂_C]),
-  ext,
-  rw [coeff_smul, coeff_C_mul]
-end
+by rw [← C_mul', eval₂_mul, eval₂_C]
 
 instance eval₂.is_semiring_hom : is_semiring_hom (eval₂ f x) :=
 ⟨eval₂_zero _ _, eval₂_one _ _, λ _ _, eval₂_add _ _, λ _ _, eval₂_mul _ _⟩

--- a/src/data/polynomial.lean
+++ b/src/data/polynomial.lean
@@ -640,7 +640,7 @@ begin
   exact congr_arg C hp
 end
 
-lemma coeff_nonzero_of_eq_degree {p : polynomial R} {n : ℕ} (hn : degree p = n) :
+lemma coeff_ne_zero_of_eq_degree {p : polynomial R} {n : ℕ} (hn : degree p = n) :
   coeff p n ≠ 0 :=
 λ h, mem_support_iff.mp (mem_of_max hn) h
 
@@ -2745,7 +2745,7 @@ on_finset f.support
     intros i h,
     apply mem_support_iff.mpr,
     split_ifs at h with hi,
-    { exact coeff_nonzero_of_eq_degree hi },
+    { exact coeff_ne_zero_of_eq_degree hi },
     { exact ne_zero_of_mul_ne_zero_right h },
   end
 
@@ -2789,7 +2789,7 @@ begin
   simp only [to_monic, on_finset_apply, mem_support_iff],
   split_ifs with hi,
   { simp only [ne.def, not_false_iff, true_iff, one_ne_zero, hi],
-    exact coeff_nonzero_of_eq_degree hi },
+    exact coeff_ne_zero_of_eq_degree hi },
   split,
   { intro h,
     exact ne_zero_of_mul_ne_zero_right h },

--- a/src/data/polynomial.lean
+++ b/src/data/polynomial.lean
@@ -313,22 +313,6 @@ by rw [← C_1, eval₂_C, map_one f]
 instance eval₂.is_add_monoid_hom : is_add_monoid_hom (eval₂ f x) :=
 { map_zero := eval₂_zero _ _, map_add := λ _ _, eval₂_add _ _ }
 
-lemma eval₂_smul (g : R →+* S) (p : polynomial R) (x : S) {s : R} :
-  eval₂ g x (s • p) = g s * eval₂ g x p :=
-begin
-  simp_rw [eval₂, finsupp.sum, finset.mul_sum],
-  refine trans (finset.sum_subset _ _) (finset.sum_congr rfl _),
-  { intros x hx,
-    rw mem_support_iff at ⊢ hx,
-    intro h,
-    rw [smul_apply, smul_eq_mul, h, mul_zero] at hx,
-    contradiction },
-  { intros i _ hi,
-    rw [not_mem_support_iff.mp hi, g.map_zero, zero_mul] },
-  intros i hi,
-  simp [mul_assoc]
-end
-
 end eval₂
 
 section eval₂
@@ -349,6 +333,14 @@ begin
     { intros, rw [map_add f, add_mul] } },
   { intro, rw [map_zero f, zero_mul] },
   { intros, rw [map_add f, add_mul] }
+end
+
+lemma eval₂_smul (g : R →+* S) (p : polynomial R) (x : S) {s : R} :
+  eval₂ g x (s • p) = g s * eval₂ g x p :=
+begin
+  convert (show eval₂ g x (C s * p) = g s * eval₂ g x p, by rw [eval₂_mul, eval₂_C]),
+  ext,
+  rw [coeff_smul, coeff_C_mul]
 end
 
 instance eval₂.is_semiring_hom : is_semiring_hom (eval₂ f x) :=

--- a/src/data/polynomial.lean
+++ b/src/data/polynomial.lean
@@ -2791,7 +2791,7 @@ begin
   { intro h,
     exact ne_zero_of_mul_ne_zero_right h },
   { intro h,
-    refine mul_ne_zero' h (pow_ne_zero _ _),
+    refine mul_ne_zero h (pow_ne_zero _ _),
     exact λ h, hf (leading_coeff_eq_zero.mp h) }
 end
 

--- a/src/data/polynomial.lean
+++ b/src/data/polynomial.lean
@@ -2724,17 +2724,17 @@ end
 
 end identities
 
-section to_monic
+section integral_normalization
 
 section comm_semiring
 variables [comm_semiring R]
 
-/-- If `f : polynomial R` is a nonzero polynomial with root `z`, `to_monic f` is
+/-- If `f : polynomial R` is a nonzero polynomial with root `z`, `integral_normalization f` is
 a monic polynomial with root `leading_coeff f * z`.
 
-Moreover, `to_monic 0 = 0`.
+Moreover, `integral_normalization 0 = 0`.
 -/
-noncomputable def to_monic (f : polynomial R) : polynomial R :=
+noncomputable def integral_normalization (f : polynomial R) : polynomial R :=
 on_finset f.support
   (λ i, if f.degree = i then 1 else coeff f i * f.leading_coeff ^ (f.nat_degree - 1 - i))
   begin
@@ -2745,44 +2745,45 @@ on_finset f.support
     { exact ne_zero_of_mul_ne_zero_right h },
   end
 
-lemma to_monic_coeff_degree {f : polynomial R} {i : ℕ} (hi : f.degree = i) :
-  (to_monic f).coeff i = 1 :=
+lemma integral_normalization_coeff_degree {f : polynomial R} {i : ℕ} (hi : f.degree = i) :
+  (integral_normalization f).coeff i = 1 :=
 if_pos hi
 
-lemma to_monic_coeff_nat_degree {f : polynomial R} (hf : f ≠ 0) :
-  (to_monic f).coeff (nat_degree f) = 1 :=
-to_monic_coeff_degree (degree_eq_nat_degree hf)
+lemma integral_normalization_coeff_nat_degree {f : polynomial R} (hf : f ≠ 0) :
+  (integral_normalization f).coeff (nat_degree f) = 1 :=
+integral_normalization_coeff_degree (degree_eq_nat_degree hf)
 
-lemma to_monic_coeff_ne_degree {f : polynomial R} {i : ℕ} (hi : f.degree ≠ i) :
-  coeff (to_monic f) i = coeff f i * f.leading_coeff ^ (f.nat_degree - 1 - i) :=
+lemma integral_normalization_coeff_ne_degree {f : polynomial R} {i : ℕ} (hi : f.degree ≠ i) :
+  coeff (integral_normalization f) i = coeff f i * f.leading_coeff ^ (f.nat_degree - 1 - i) :=
 if_neg hi
 
-lemma to_monic_coeff_ne_nat_degree {f : polynomial R} {i : ℕ} (hi : i ≠ nat_degree f) :
-  coeff (to_monic f) i = coeff f i * f.leading_coeff ^ (f.nat_degree - 1 - i) :=
-to_monic_coeff_ne_degree (degree_ne_of_nat_degree_ne hi.symm)
+lemma integral_normalization_coeff_ne_nat_degree {f : polynomial R} {i : ℕ} (hi : i ≠ nat_degree f) :
+  coeff (integral_normalization f) i = coeff f i * f.leading_coeff ^ (f.nat_degree - 1 - i) :=
+integral_normalization_coeff_ne_degree (degree_ne_of_nat_degree_ne hi.symm)
 
-lemma monic_to_monic {f : polynomial R} (hf : f ≠ 0) : monic (to_monic f) :=
+lemma monic_integral_normalization {f : polynomial R} (hf : f ≠ 0) :
+  monic (integral_normalization f) :=
 begin
   apply monic_of_degree_le f.nat_degree,
   { refine finset.sup_le (λ i h, _),
-    rw [to_monic, mem_support_iff, on_finset_apply] at h,
+    rw [integral_normalization, mem_support_iff, on_finset_apply] at h,
     split_ifs at h with hi,
     { exact le_trans (le_of_eq hi.symm) degree_le_nat_degree },
     { erw [with_bot.some_le_some],
       apply le_nat_degree_of_ne_zero,
       exact ne_zero_of_mul_ne_zero_right h } },
-  { exact to_monic_coeff_nat_degree hf }
+  { exact integral_normalization_coeff_nat_degree hf }
 end
 
 end comm_semiring
 
 variables [integral_domain R]
 
-@[simp] lemma support_to_monic {f : polynomial R} (hf : f ≠ 0) :
-  (to_monic f).support = f.support :=
+@[simp] lemma support_integral_normalization {f : polynomial R} (hf : f ≠ 0) :
+  (integral_normalization f).support = f.support :=
 begin
   ext i,
-  simp only [to_monic, on_finset_apply, mem_support_iff],
+  simp only [integral_normalization, on_finset_apply, mem_support_iff],
   split_ifs with hi,
   { simp only [ne.def, not_false_iff, true_iff, one_ne_zero, hi],
     exact coeff_ne_zero_of_eq_degree hi },
@@ -2796,13 +2797,13 @@ end
 
 variables [comm_ring S]
 
-lemma to_monic_eval₂_eq_zero {p : polynomial R} (hp : p ≠ 0) (f : R →+* S)
+lemma integral_normalization_eval₂_eq_zero {p : polynomial R} (hp : p ≠ 0) (f : R →+* S)
   {z : S} (hz : eval₂ f z p = 0) (inj : ∀ (x : R), f x = 0 → x = 0) :
-  eval₂ f (z * f p.leading_coeff) (to_monic p) = 0 :=
-calc eval₂ f (z * f p.leading_coeff) (to_monic p)
+  eval₂ f (z * f p.leading_coeff) (integral_normalization p) = 0 :=
+calc eval₂ f (z * f p.leading_coeff) (integral_normalization p)
     = p.support.attach.sum
-        (λ i, f (coeff (to_monic p) i.1 * p.leading_coeff ^ i.1) * z ^ i.1) :
-      by { rw [eval₂, finsupp.sum, support_to_monic hp],
+        (λ i, f (coeff (integral_normalization p) i.1 * p.leading_coeff ^ i.1) * z ^ i.1) :
+      by { rw [eval₂, finsupp.sum, support_integral_normalization hp],
            simp only [mul_comm z, mul_pow, mul_assoc, ring_hom.map_pow, ring_hom.map_mul],
            exact finset.sum_attach.symm }
 ... = p.support.attach.sum
@@ -2814,12 +2815,13 @@ calc eval₂ f (z * f p.leading_coeff) (to_monic p)
         ext i,
         congr' 2,
         by_cases hi : i.1 = nat_degree p,
-        { rw [hi, to_monic_coeff_degree, one_mul, leading_coeff, ←pow_succ,
+        { rw [hi, integral_normalization_coeff_degree, one_mul, leading_coeff, ←pow_succ,
               nat.sub_add_cancel one_le_deg],
           exact degree_eq_nat_degree hp },
         { have : i.1 ≤ p.nat_degree - 1 := nat.le_pred_of_lt (lt_of_le_of_ne
             (le_nat_degree_of_ne_zero (finsupp.mem_support_iff.mp i.2)) hi),
-          rw [to_monic_coeff_ne_nat_degree hi, mul_assoc, ←pow_add, nat.sub_add_cancel this] }
+          rw [integral_normalization_coeff_ne_nat_degree hi, mul_assoc, ←pow_add,
+              nat.sub_add_cancel this] }
       end
 ... = f p.leading_coeff ^ (nat_degree p - 1) * eval₂ f z p :
       by { simp_rw [eval₂, finsupp.sum, λ i, mul_comm (coeff p i), ring_hom.map_mul,
@@ -2828,12 +2830,12 @@ calc eval₂ f (z * f p.leading_coeff) (to_monic p)
            exact @finset.sum_attach _ _ p.support _ (λ i, f (p.coeff i) * z ^ i) }
 ... = 0 : by rw [hz, _root_.mul_zero]
 
-lemma to_monic_aeval_eq_zero [algebra R S] {f : polynomial R} (hf : f ≠ 0)
+lemma integral_normalization_aeval_eq_zero [algebra R S] {f : polynomial R} (hf : f ≠ 0)
   {z : S} (hz : aeval R S z f = 0) (inj : ∀ (x : R), algebra_map R S x = 0 → x = 0) :
-  aeval R S (z * algebra_map R S f.leading_coeff) (to_monic f) = 0 :=
-to_monic_eval₂_eq_zero hf (algebra_map R S) hz inj
+  aeval R S (z * algebra_map R S f.leading_coeff) (integral_normalization f) = 0 :=
+integral_normalization_eval₂_eq_zero hf (algebra_map R S) hz inj
 
-end to_monic
+end integral_normalization
 
 end polynomial
 

--- a/src/ring_theory/algebraic.lean
+++ b/src/ring_theory/algebraic.lean
@@ -3,6 +3,8 @@ Copyright (c) 2019 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
+
+import linear_algebra.finite_dimensional
 import ring_theory.integral_closure
 
 /-!
@@ -104,6 +106,11 @@ begin
   exact is_integral_trans L_alg A_alg,
 end
 
+/-- A field extension is algebraic if it is finite. -/
+lemma is_algebraic_of_finite (finite : finite_dimensional K L) : is_algebraic K L :=
+λ x, (is_algebraic_iff_is_integral _).mpr (is_integral_of_noetherian ⊤
+  (is_noetherian_of_submodule_of_noetherian _ _ _ finite) x algebra.mem_top)
+
 end algebra
 
 variables {R S : Type*} [integral_domain R] [comm_ring S]
@@ -123,4 +130,3 @@ begin
   refine ⟨⟨_, x_integral⟩, ⟨_, y_integral⟩, _, rfl⟩,
   exact λ h, a_nonzero (inj _ (subtype.ext.mp h))
 end
-

--- a/src/ring_theory/algebraic.lean
+++ b/src/ring_theory/algebraic.lean
@@ -120,13 +120,13 @@ lemma exists_integral_multiple [algebra R S] {z : S} (hz : is_algebraic R z)
   ∃ (x : integral_closure R S) (y ≠ (0 : integral_closure R S)),
     z * y = x :=
 begin
-  rcases hz with ⟨p, p_nonzero, px⟩,
+  rcases hz with ⟨p, p_ne_zero, px⟩,
   set n := p.nat_degree with n_def,
   set a := p.leading_coeff with a_def,
-  have a_nonzero : a ≠ 0 := mt polynomial.leading_coeff_eq_zero.mp p_nonzero,
+  have a_ne_zero : a ≠ 0 := mt polynomial.leading_coeff_eq_zero.mp p_ne_zero,
   have y_integral : is_integral R (algebra_map R S a) := is_integral_algebra_map,
   have x_integral : is_integral R (z * algebra_map R S a) :=
-    ⟨ p.to_monic, monic_to_monic p_nonzero, to_monic_aeval_eq_zero p_nonzero px inj ⟩,
+    ⟨ p.to_monic, monic_to_monic p_ne_zero, to_monic_aeval_eq_zero p_ne_zero px inj ⟩,
   refine ⟨⟨_, x_integral⟩, ⟨_, y_integral⟩, _, rfl⟩,
-  exact λ h, a_nonzero (inj _ (subtype.ext.mp h))
+  exact λ h, a_ne_zero (inj _ (subtype.ext.mp h))
 end

--- a/src/ring_theory/algebraic.lean
+++ b/src/ring_theory/algebraic.lean
@@ -126,7 +126,9 @@ begin
   have a_ne_zero : a ≠ 0 := mt polynomial.leading_coeff_eq_zero.mp p_ne_zero,
   have y_integral : is_integral R (algebra_map R S a) := is_integral_algebra_map,
   have x_integral : is_integral R (z * algebra_map R S a) :=
-    ⟨ p.to_monic, monic_to_monic p_ne_zero, to_monic_aeval_eq_zero p_ne_zero px inj ⟩,
+    ⟨ p.integral_normalization,
+      monic_integral_normalization p_ne_zero,
+      integral_normalization_aeval_eq_zero p_ne_zero px inj ⟩,
   refine ⟨⟨_, x_integral⟩, ⟨_, y_integral⟩, _, rfl⟩,
   exact λ h, a_ne_zero (inj _ (subtype.ext.mp h))
 end

--- a/src/ring_theory/algebraic.lean
+++ b/src/ring_theory/algebraic.lean
@@ -107,7 +107,7 @@ begin
 end
 
 /-- A field extension is algebraic if it is finite. -/
-lemma is_algebraic_of_finite (finite : finite_dimensional K L) : is_algebraic K L :=
+lemma is_algebraic_of_finite [finite : finite_dimensional K L] : is_algebraic K L :=
 λ x, (is_algebraic_iff_is_integral _).mpr (is_integral_of_noetherian ⊤
   (is_noetherian_of_submodule_of_noetherian _ _ _ finite) x algebra.mem_top)
 

--- a/src/ring_theory/algebraic.lean
+++ b/src/ring_theory/algebraic.lean
@@ -105,3 +105,22 @@ begin
 end
 
 end algebra
+
+variables {R S : Type*} [integral_domain R] [comm_ring S]
+
+lemma exists_integral_multiple [algebra R S] {z : S} (hz : is_algebraic R z)
+  (inj : ∀ x, algebra_map R S x = 0 → x = 0) :
+  ∃ (x : integral_closure R S) (y ≠ (0 : integral_closure R S)),
+    z * y = x :=
+begin
+  rcases hz with ⟨p, p_nonzero, px⟩,
+  set n := p.nat_degree with n_def,
+  set a := p.leading_coeff with a_def,
+  have a_nonzero : a ≠ 0 := mt polynomial.leading_coeff_eq_zero.mp p_nonzero,
+  have y_integral : is_integral R (algebra_map R S a) := is_integral_algebra_map,
+  have x_integral : is_integral R (z * algebra_map R S a) :=
+    ⟨ p.to_monic, monic_to_monic p_nonzero, to_monic_aeval_eq_zero p_nonzero px inj ⟩,
+  refine ⟨⟨_, x_integral⟩, ⟨_, y_integral⟩, _, rfl⟩,
+  exact λ h, a_nonzero (inj _ (subtype.ext.mp h))
+end
+

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -363,3 +363,14 @@ lemma algebra.is_integral_trans (A_int : ∀ x : A, is_integral R x)(B_int : ∀
 λ x, is_integral_trans A_int x (B_int x)
 
 end algebra
+
+section integral_domain
+variables {R S : Type*} [comm_ring R] [integral_domain S] [algebra R S]
+
+instance : integral_domain (integral_closure R S) :=
+{ zero_ne_one := mt subtype.ext.mp zero_ne_one,
+  eq_zero_or_eq_zero_of_mul_eq_zero := λ ⟨a, ha⟩ ⟨b, hb⟩ h,
+    or.imp subtype.ext.mpr subtype.ext.mpr (eq_zero_or_eq_zero_of_mul_eq_zero (subtype.ext.mp h)),
+  ..(integral_closure R S).comm_ring R S }
+
+end integral_domain

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -651,13 +651,14 @@ lemma map_smul (x : f.codomain) (z : R) :
 show f.map hy k (f.to_map z * x) = k.to_map (g z) * f.map hy k x,
 by rw [ring_hom.map_mul, map_eq]
 
-section to_base_ring
+section integer_normalization
 
 open finsupp polynomial
 open_locale classical
 
-/-- `coeff_to_base_ring p` gives the coefficients of the polynomial `to_base_ring p` -/
-noncomputable def coeff_to_base_ring (p : polynomial f.codomain) (i : ℕ) : R :=
+/-- `coeff_integer_normalization p` gives the coefficients of the polynomial
+`integer_normalization p` -/
+noncomputable def coeff_integer_normalization (p : polynomial f.codomain) (i : ℕ) : R :=
 if hi : i ∈ p.support
 then classical.some (classical.some_spec
       (f.exist_integer_multiples_of_finset (p.support.image p.coeff))
@@ -665,27 +666,28 @@ then classical.some (classical.some_spec
       (finset.mem_image.mpr ⟨i, hi, rfl⟩))
 else 0
 
-lemma coeff_to_base_ring_mem_support (p : polynomial f.codomain) (i : ℕ)
-  (h : coeff_to_base_ring p i ≠ 0) : i ∈ p.support :=
+lemma coeff_integer_normalization_mem_support (p : polynomial f.codomain) (i : ℕ)
+  (h : coeff_integer_normalization p i ≠ 0) : i ∈ p.support :=
 begin
   contrapose h,
-  rw [ne.def, not_not, coeff_to_base_ring, dif_neg h]
+  rw [ne.def, not_not, coeff_integer_normalization, dif_neg h]
 end
 
-/-- `to_base_ring g` clears the denominators of the given polynomial -/
-noncomputable def to_base_ring : polynomial f.codomain → polynomial R :=
-λ p, on_finset p.support (coeff_to_base_ring p) (coeff_to_base_ring_mem_support p)
+/-- `integer_normalization g` normalizes `g` to have integer coefficients
+by clearing the denominators -/
+noncomputable def integer_normalization : polynomial f.codomain → polynomial R :=
+λ p, on_finset p.support (coeff_integer_normalization p) (coeff_integer_normalization_mem_support p)
 
 @[simp]
-lemma to_base_ring_coeff (p : polynomial f.codomain) (i : ℕ) :
-  (to_base_ring p).coeff i = coeff_to_base_ring p i := rfl
+lemma integer_normalization_coeff (p : polynomial f.codomain) (i : ℕ) :
+  (integer_normalization p).coeff i = coeff_integer_normalization p i := rfl
 
-lemma to_base_ring_spec (p : polynomial f.codomain) :
-  ∃ (b : M), ∀ i, f.to_map ((to_base_ring p).coeff i) = f.to_map b * p.coeff i :=
+lemma integer_normalization_spec (p : polynomial f.codomain) :
+  ∃ (b : M), ∀ i, f.to_map ((integer_normalization p).coeff i) = f.to_map b * p.coeff i :=
 begin
   use classical.some (f.exist_integer_multiples_of_finset (p.support.image p.coeff)),
   intro i,
-  rw [to_base_ring_coeff, coeff_to_base_ring],
+  rw [integer_normalization_coeff, coeff_integer_normalization],
   split_ifs with hi,
   { exact classical.some_spec (classical.some_spec
       (f.exist_integer_multiples_of_finset (p.support.image p.coeff))
@@ -696,22 +698,24 @@ begin
     { exact finsupp.not_mem_support_iff.mp hi } }
 end
 
-lemma to_base_ring_map_to_map (p : polynomial f.codomain) :
-  ∃ (b : M), (to_base_ring p).map f.to_map = f.to_map b • p :=
-let ⟨b, hb⟩ := to_base_ring_spec p in ⟨b, polynomial.ext (λ i, by { rw coeff_map, exact hb i })⟩
+lemma integer_normalization_map_to_map (p : polynomial f.codomain) :
+  ∃ (b : M), (integer_normalization p).map f.to_map = f.to_map b • p :=
+let ⟨b, hb⟩ := integer_normalization_spec p in
+⟨b, polynomial.ext (λ i, by { rw coeff_map, exact hb i })⟩
 
 variables {R' : Type*} [comm_ring R']
 
-lemma to_base_ring_eval₂_eq_zero (g : f.codomain →+* R') (p : polynomial f.codomain) {x : R'}
-  (hx : eval₂ g x p = 0) : eval₂ (g ∘ f.to_map) x (to_base_ring p) = 0 :=
-let ⟨b, hb⟩ := to_base_ring_map_to_map p in
+lemma integer_normalization_eval₂_eq_zero (g : f.codomain →+* R') (p : polynomial f.codomain)
+  {x : R'} (hx : eval₂ g x p = 0) : eval₂ (g ∘ f.to_map) x (integer_normalization p) = 0 :=
+let ⟨b, hb⟩ := integer_normalization_map_to_map p in
 trans (eval₂_map f.to_map g x).symm (by rw [hb, eval₂_smul, hx, _root_.mul_zero])
 
-lemma to_base_ring_aeval_eq_zero [algebra f.codomain R'] (p : polynomial f.codomain) {x : R'}
-  (hx : aeval _ _ x p = 0) : aeval _ (algebra.comap R f.codomain R') x (to_base_ring p) = 0 :=
-to_base_ring_eval₂_eq_zero (algebra_map f.codomain R') p hx
+lemma integer_normalization_aeval_eq_zero [algebra f.codomain R'] (p : polynomial f.codomain)
+  {x : R'} (hx : aeval _ _ x p = 0) :
+  aeval _ (algebra.comap R f.codomain R') x (integer_normalization p) = 0 :=
+integer_normalization_eval₂_eq_zero (algebra_map f.codomain R') p hx
 
-end to_base_ring
+end integer_normalization
 
 end localization_map
 variables (R)
@@ -890,10 +894,11 @@ def int.fraction_map : fraction_map ℤ ℚ :=
   end,
   ..int.cast_ring_hom ℚ }
 
-lemma to_base_ring_eq_zero_iff {p : polynomial f.codomain} : to_base_ring p = 0 ↔ p = 0 :=
+lemma integer_normalization_eq_zero_iff {p : polynomial f.codomain} :
+  integer_normalization p = 0 ↔ p = 0 :=
 begin
   refine (polynomial.ext_iff.trans (polynomial.ext_iff.trans _).symm),
-  obtain ⟨⟨b, nonzero⟩, hb⟩ := to_base_ring_spec p,
+  obtain ⟨⟨b, nonzero⟩, hb⟩ := integer_normalization_spec p,
   split; intros h i,
   { apply f.to_map_eq_zero_iff.mpr,
     rw [hb i, h i],
@@ -915,7 +920,9 @@ begin
   { have : f.to_map (p.coeff i) = 0 := trans (polynomial.coeff_map _ _).symm (by simp [h]),
     exact f.to_map_eq_zero_iff.mpr this },
   { exact trans (polynomial.eval₂_map _ _ _) px } },
-  { exact ⟨to_base_ring p, mt f.to_base_ring_eq_zero_iff.mp hp, to_base_ring_aeval_eq_zero p px⟩ },
+  { exact ⟨integer_normalization p,
+           mt f.integer_normalization_eq_zero_iff.mp hp,
+           integer_normalization_aeval_eq_zero p px⟩ },
 end
 
 end fraction_map

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -906,11 +906,23 @@ begin
     exact f.to_map_eq_zero_iff.mpr h }
 end
 
+/-- A field is algebraic over the ring `A` iff it is algebraic over the field of fractions of `A`. -/
+lemma comap_is_algebraic_iff [algebra f.codomain L] :
+  algebra.is_algebraic A (algebra.comap A f.codomain L) ↔ algebra.is_algebraic f.codomain L :=
+begin
+  split; intros h x; obtain ⟨p, hp, px⟩ := h x,
+  { refine ⟨p.map f.to_map, λ h, hp (polynomial.ext (λ i, _)), _⟩,
+  { have : f.to_map (p.coeff i) = 0 := trans (polynomial.coeff_map _ _).symm (by simp [h]),
+    exact f.to_map_eq_zero_iff.mpr this },
+  { exact trans (polynomial.eval₂_map _ _ _) px } },
+  { exact ⟨to_base_ring p, mt f.to_base_ring_eq_zero_iff.mp hp, to_base_ring_aeval_eq_zero p px⟩ },
+end
+
 end fraction_map
 
 namespace integral_closure
 
-variables {L : Type*} [field L]
+variables {L : Type*} [field K] [field L] {f : fraction_map A K}
 
 open algebra
 
@@ -928,6 +940,15 @@ def fraction_map_of_algebraic [algebra A L] (alg : is_algebraic A L)
   (λ x y, ⟨ λ (h : x.1 = y.1), ⟨1, by simpa using subtype.ext.mpr h⟩,
             λ ⟨c, hc⟩, congr_arg (algebra_map _ L)
               (eq_of_mul_eq_mul_right_of_ne_zero (mem_non_zero_divisors_iff_ne_zero.mp c.2) hc) ⟩)
+
+/-- If the field `L` is a finite extension of the fraction field of the integral domain `A`,
+the integral closure of `A` in `L` has fraction field `L`. -/
+def fraction_map_of_finite_extension [algebra f.codomain L]
+  (finite : finite_dimensional f.codomain L) :
+  fraction_map (integral_closure A (algebra.comap A f.codomain L)) (algebra.comap A f.codomain L) :=
+fraction_map_of_algebraic
+  (f.comap_is_algebraic_iff.mpr (is_algebraic_of_finite finite))
+  (λ x hx, f.to_map_eq_zero_iff.mpr ((algebra_map f.codomain L).map_eq_zero.mp hx))
 
 end integral_closure
 

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -943,11 +943,10 @@ def fraction_map_of_algebraic [algebra A L] (alg : is_algebraic A L)
 
 /-- If the field `L` is a finite extension of the fraction field of the integral domain `A`,
 the integral closure of `A` in `L` has fraction field `L`. -/
-def fraction_map_of_finite_extension [algebra f.codomain L]
-  (finite : finite_dimensional f.codomain L) :
+def fraction_map_of_finite_extension [algebra f.codomain L] [finite_dimensional f.codomain L] :
   fraction_map (integral_closure A (algebra.comap A f.codomain L)) (algebra.comap A f.codomain L) :=
 fraction_map_of_algebraic
-  (f.comap_is_algebraic_iff.mpr (is_algebraic_of_finite finite))
+  (f.comap_is_algebraic_iff.mpr is_algebraic_of_finite)
   (λ x hx, f.to_map_eq_zero_iff.mpr ((algebra_map f.codomain L).map_eq_zero.mp hx))
 
 end integral_closure


### PR DESCRIPTION
Let `A` be an integral domain with field of fractions `K` and `L` a finite extension of `K`. This PR shows the integral closure of `A` in `L` has fraction field `L`. If those definitions existed, the corollary is that the ring of integers of a number field is a number ring.

For this, we need two constructions on polynomials:
 * If `p` is a nonzero polynomial, `integral_normalization p` is a monic polynomial with roots `z * a` for `z` a root of `p` and `a` the leading coefficient of `p`
 * If `f` is the localization map from `A` to `K` and `p` has coefficients in `K`, then `f.integer_normalization p` is a polynomial with coefficients in `A` (think: `∀ i, is_integer (f.integer_normalization p).coeff i`) with the same roots as `p`.