### PR TITLE
[Merged by Bors] - feat(category_theory/discrete): build equivalence from equiv

### DIFF
--- a/src/algebra/category/Group/biproducts.lean
+++ b/src/algebra/category/Group/biproducts.lean
@@ -62,7 +62,7 @@ def lift (s : cone F) :
 instance has_limit_discrete : has_limit F :=
 { cone :=
   { X := AddCommGroup.of (Π j, F.obj j),
-    π := nat_trans.of_homs (λ j, add_monoid_hom.apply (λ j, F.obj j) j), },
+    π := nat_trans.of_function (λ j, add_monoid_hom.apply (λ j, F.obj j) j), },
   is_limit :=
   { lift := lift F,
     fac' := λ s j, by { ext, dsimp, simp, },
@@ -105,7 +105,7 @@ variables [decidable_eq J]
 instance has_colimit_discrete : has_colimit F :=
 { cocone :=
   { X := AddCommGroup.of (Π j, F.obj j),
-    ι := nat_trans.of_homs (λ j, add_monoid_hom.single (λ j, F.obj j) j), },
+    ι := nat_trans.of_function (λ j, add_monoid_hom.single (λ j, F.obj j) j), },
   is_colimit :=
   { desc := desc F,
     fac' := λ s j,
@@ -143,8 +143,8 @@ variables [decidable_eq J] [fintype J]
 instance : has_bilimit F :=
 { bicone :=
   { X := AddCommGroup.of (Π j, F.obj j),
-    ι := nat_trans.of_homs (λ j, add_monoid_hom.single (λ j, F.obj j) j),
-    π := nat_trans.of_homs (λ j, add_monoid_hom.apply (λ j, F.obj j) j), },
+    ι := nat_trans.of_function (λ j, add_monoid_hom.single (λ j, F.obj j) j),
+    π := nat_trans.of_function (λ j, add_monoid_hom.apply (λ j, F.obj j) j), },
   is_limit := limit.is_limit F,
   is_colimit := colimit.is_colimit F, }.
 

--- a/src/algebra/category/Group/biproducts.lean
+++ b/src/algebra/category/Group/biproducts.lean
@@ -62,7 +62,7 @@ def lift (s : cone F) :
 instance has_limit_discrete : has_limit F :=
 { cone :=
   { X := AddCommGroup.of (Π j, F.obj j),
-    π := nat_trans.of_function (λ j, add_monoid_hom.apply (λ j, F.obj j) j), },
+    π := discrete.nat_trans (λ j, add_monoid_hom.apply (λ j, F.obj j) j), },
   is_limit :=
   { lift := lift F,
     fac' := λ s j, by { ext, dsimp, simp, },
@@ -105,7 +105,7 @@ variables [decidable_eq J]
 instance has_colimit_discrete : has_colimit F :=
 { cocone :=
   { X := AddCommGroup.of (Π j, F.obj j),
-    ι := nat_trans.of_function (λ j, add_monoid_hom.single (λ j, F.obj j) j), },
+    ι := discrete.nat_trans (λ j, add_monoid_hom.single (λ j, F.obj j) j), },
   is_colimit :=
   { desc := desc F,
     fac' := λ s j,
@@ -143,8 +143,8 @@ variables [decidable_eq J] [fintype J]
 instance : has_bilimit F :=
 { bicone :=
   { X := AddCommGroup.of (Π j, F.obj j),
-    ι := nat_trans.of_function (λ j, add_monoid_hom.single (λ j, F.obj j) j),
-    π := nat_trans.of_function (λ j, add_monoid_hom.apply (λ j, F.obj j) j), },
+    ι := discrete.nat_trans (λ j, add_monoid_hom.single (λ j, F.obj j) j),
+    π := discrete.nat_trans (λ j, add_monoid_hom.apply (λ j, F.obj j) j), },
   is_limit := limit.is_limit F,
   is_colimit := colimit.is_colimit F, }.
 

--- a/src/category_theory/discrete_category.lean
+++ b/src/category_theory/discrete_category.lean
@@ -5,7 +5,7 @@ Authors: Stephen Morgan, Scott Morrison, Floris van Doorn
 -/
 import data.ulift
 import data.fintype.basic
-import category_theory.opposites
+import category_theory.eq_to_hom
 
 namespace category_theory
 
@@ -43,7 +43,9 @@ def of_function {I : Type u₁} (F : I → C) : (discrete I) ⥤ C :=
 { obj := F,
   map := λ X Y f, begin cases f, cases f, cases f, exact 𝟙 (F X) end }
 
-@[simp] lemma of_function_obj  {I : Type u₁} (F : I → C) (i : I) : (of_function F).obj i = F i := rfl
+@[simp] lemma of_function_obj  {I : Type u₁} (F : I → C) (i : I) :
+  (of_function F).obj i = F i := rfl
+
 lemma of_function_map  {I : Type u₁} (F : I → C) {i : discrete I} (f : i ⟶ i) :
   (of_function F).map f = 𝟙 (F i) :=
 by { cases f, cases f, cases f, refl }
@@ -56,8 +58,9 @@ def of_homs {I : Type u₁} {F G : discrete I ⥤ C}
   (f : Π i : discrete I, F.obj i ⟶ G.obj i) : F ⟶ G :=
 { app := f }
 
-@[simp] lemma of_homs_app  {I : Type u₁} {F G : discrete I ⥤ C} (f : Π i : discrete I, F.obj i ⟶ G.obj i) (i) :
-  (of_homs f).app i = f i := rfl
+@[simp] lemma of_homs_app  {I : Type u₁} {F G : discrete I ⥤ C}
+  (f : Π i : discrete I, F.obj i ⟶ G.obj i) (i) : (of_homs f).app i = f i :=
+rfl
 
 def of_function {I : Type u₁} {F G : I → C} (f : Π i : I, F i ⟶ G i) :
   (functor.of_function F) ⟶ (functor.of_function G) :=
@@ -70,11 +73,23 @@ end nat_trans
 
 namespace nat_iso
 
-def of_isos {I : Type u₁} {F G : discrete I ⥤ C}
+def of_function {I : Type u₁} {F G : discrete I ⥤ C}
   (f : Π i : discrete I, F.obj i ≅ G.obj i) : F ≅ G :=
 of_components f (by tidy)
 
 end nat_iso
+
+
+namespace equivalence
+
+@[simps]
+def of_equiv {I J : Type u₁} (e : I ≃ J) : discrete I ≌ discrete J :=
+{ functor := functor.of_function (e : I → J),
+  inverse := functor.of_function (e.symm : J → I),
+  unit_iso := nat_iso.of_function (λ i, eq_to_iso (by simp)),
+  counit_iso := nat_iso.of_function (λ j, eq_to_iso (by simp)), }
+
+end equivalence
 
 namespace discrete
 variables {J : Type v₁}
@@ -87,7 +102,7 @@ open opposite
 protected def opposite (α : Type u₁) : (discrete α)ᵒᵖ ≌ discrete α :=
 let F : discrete α ⥤ (discrete α)ᵒᵖ := functor.of_function (λ x, op x) in
 begin
-  refine equivalence.mk (functor.left_op F) F _ (nat_iso.of_isos $ λ X, by simp [F]),
+  refine equivalence.mk (functor.left_op F) F _ (nat_iso.of_function $ λ X, by simp [F]),
   refine nat_iso.of_components (λ X, by simp [F]) _,
   tidy
 end

--- a/src/category_theory/discrete_category.lean
+++ b/src/category_theory/discrete_category.lean
@@ -37,73 +37,56 @@ by { apply ulift.fintype }
 
 @[simp] lemma id_def (X : discrete α) : ulift.up (plift.up (eq.refl X)) = 𝟙 X := rfl
 
-end discrete
-
 variables {C : Type u₂} [category.{v₂} C]
-
-namespace functor
 
 /--
 Any function `I → C` gives a functor `discrete I ⥤ C`.
 -/
-def of_function {I : Type u₁} (F : I → C) : discrete I ⥤ C :=
+def functor {I : Type u₁} (F : I → C) : discrete I ⥤ C :=
 { obj := F,
   map := λ X Y f, begin cases f, cases f, cases f, exact 𝟙 (F X) end }
 
-@[simp] lemma of_function_obj  {I : Type u₁} (F : I → C) (i : I) :
-  (of_function F).obj i = F i := rfl
+@[simp] lemma functor_obj  {I : Type u₁} (F : I → C) (i : I) :
+  (discrete.functor F).obj i = F i := rfl
 
-lemma of_function_map  {I : Type u₁} (F : I → C) {i : discrete I} (f : i ⟶ i) :
-  (of_function F).map f = 𝟙 (F i) :=
+lemma functor_map  {I : Type u₁} (F : I → C) {i : discrete I} (f : i ⟶ i) :
+  (discrete.functor F).map f = 𝟙 (F i) :=
 by { cases f, cases f, cases f, refl }
-
-end functor
-
-namespace nat_trans
 
 /--
 For functors out of a discrete category,
 a natural transformation is just a collection of maps,
 as the naturality squares are trivial.
 -/
-def of_function {I : Type u₁} {F G : discrete I ⥤ C}
+def nat_trans {I : Type u₁} {F G : discrete I ⥤ C}
   (f : Π i : discrete I, F.obj i ⟶ G.obj i) : F ⟶ G :=
 { app := f }
 
-@[simp] lemma of_function_app  {I : Type u₁} {F G : discrete I ⥤ C}
-  (f : Π i : discrete I, F.obj i ⟶ G.obj i) (i) : (of_function f).app i = f i :=
+@[simp] lemma nat_trans_app  {I : Type u₁} {F G : discrete I ⥤ C}
+  (f : Π i : discrete I, F.obj i ⟶ G.obj i) (i) : (discrete.nat_trans f).app i = f i :=
 rfl
-
-end nat_trans
-
-namespace nat_iso
 
 /--
 For functors out of a discrete category,
 a natural isomorphism is just a collection of isomorphisms,
 as the naturality squares are trivial.
 -/
-def of_function {I : Type u₁} {F G : discrete I ⥤ C}
+def nat_iso {I : Type u₁} {F G : discrete I ⥤ C}
   (f : Π i : discrete I, F.obj i ≅ G.obj i) : F ≅ G :=
-of_components f (by tidy)
-
-end nat_iso
-
-
-namespace equivalence
+nat_iso.of_components f (by tidy)
 
 /--
 We can promote a type-level `equiv` to
 an equivalence between the corresponding `discrete` categories.
 -/
 @[simps]
-def of_equiv {I J : Type u₁} (e : I ≃ J) : discrete I ≌ discrete J :=
-{ functor := functor.of_function (e : I → J),
-  inverse := functor.of_function (e.symm : J → I),
-  unit_iso := nat_iso.of_function (λ i, eq_to_iso (by simp)),
-  counit_iso := nat_iso.of_function (λ j, eq_to_iso (by simp)), }
+def equivalence {I J : Type u₁} (e : I ≃ J) : discrete I ≌ discrete J :=
+{ functor := discrete.functor (e : I → J),
+  inverse := discrete.functor (e.symm : J → I),
+  unit_iso := discrete.nat_iso (λ i, eq_to_iso (by simp)),
+  counit_iso := discrete.nat_iso (λ j, eq_to_iso (by simp)), }
 
-end equivalence
+end discrete
 
 namespace discrete
 variables {J : Type v₁}
@@ -112,12 +95,14 @@ open opposite
 
 /-- A discrete category is equivalent to its opposite category. -/
 protected def opposite (α : Type u₁) : (discrete α)ᵒᵖ ≌ discrete α :=
-let F : discrete α ⥤ (discrete α)ᵒᵖ := functor.of_function (λ x, op x) in
+let F : discrete α ⥤ (discrete α)ᵒᵖ := discrete.functor (λ x, op x) in
 begin
-  refine equivalence.mk (functor.left_op F) F _ (nat_iso.of_function $ λ X, by simp [F]),
+  refine equivalence.mk (functor.left_op F) F _ (discrete.nat_iso $ λ X, by simp [F]),
   refine nat_iso.of_components (λ X, by simp [F]) _,
   tidy
 end
+
+variables {C : Type u₂} [category.{v₂} C]
 
 @[simp] lemma functor_map_id
   (F : discrete J ⥤ C) {j : discrete J} (f : j ⟶ j) : F.map f = 𝟙 (F.obj j) :=

--- a/src/category_theory/discrete_category.lean
+++ b/src/category_theory/discrete_category.lean
@@ -11,6 +11,10 @@ namespace category_theory
 
 universes v₁ v₂ u₁ u₂ -- declare the `v`'s first; see `category_theory.category` for an explanation
 
+/--
+A type synonym for promoting any type to a category,
+with the only morphisms being equalities.
+-/
 def discrete (α : Type u₁) := α
 
 instance discrete_category (α : Type u₁) : small_category (discrete α) :=
@@ -39,7 +43,10 @@ variables {C : Type u₂} [category.{v₂} C]
 
 namespace functor
 
-def of_function {I : Type u₁} (F : I → C) : (discrete I) ⥤ C :=
+/--
+Any function `I → C` gives a functor `discrete I ⥤ C`.
+-/
+def of_function {I : Type u₁} (F : I → C) : discrete I ⥤ C :=
 { obj := F,
   map := λ X Y f, begin cases f, cases f, cases f, exact 𝟙 (F X) end }
 
@@ -54,25 +61,28 @@ end functor
 
 namespace nat_trans
 
-def of_homs {I : Type u₁} {F G : discrete I ⥤ C}
+/--
+For functors out of a discrete category,
+a natural transformation is just a collection of maps,
+as the naturality squares are trivial.
+-/
+def of_function {I : Type u₁} {F G : discrete I ⥤ C}
   (f : Π i : discrete I, F.obj i ⟶ G.obj i) : F ⟶ G :=
 { app := f }
 
-@[simp] lemma of_homs_app  {I : Type u₁} {F G : discrete I ⥤ C}
-  (f : Π i : discrete I, F.obj i ⟶ G.obj i) (i) : (of_homs f).app i = f i :=
+@[simp] lemma of_function_app  {I : Type u₁} {F G : discrete I ⥤ C}
+  (f : Π i : discrete I, F.obj i ⟶ G.obj i) (i) : (of_function f).app i = f i :=
 rfl
-
-def of_function {I : Type u₁} {F G : I → C} (f : Π i : I, F i ⟶ G i) :
-  (functor.of_function F) ⟶ (functor.of_function G) :=
-of_homs f
-
-@[simp] lemma of_function_app {I : Type u₁} {F G : I → C} (f : Π i : I, F i ⟶ G i) (i : I) :
-  (of_function f).app i = f i := rfl
 
 end nat_trans
 
 namespace nat_iso
 
+/--
+For functors out of a discrete category,
+a natural isomorphism is just a collection of isomorphisms,
+as the naturality squares are trivial.
+-/
 def of_function {I : Type u₁} {F G : discrete I ⥤ C}
   (f : Π i : discrete I, F.obj i ≅ G.obj i) : F ≅ G :=
 of_components f (by tidy)
@@ -82,6 +92,10 @@ end nat_iso
 
 namespace equivalence
 
+/--
+We can promote a type-level `equiv` to
+an equivalence between the corresponding `discrete` categories.
+-/
 @[simps]
 def of_equiv {I J : Type u₁} (e : I ≃ J) : discrete I ≌ discrete J :=
 { functor := functor.of_function (e : I → J),
@@ -94,11 +108,9 @@ end equivalence
 namespace discrete
 variables {J : Type v₁}
 
-def lift {α : Type u₁} {β : Type u₂} (f : α → β) : (discrete α) ⥤ (discrete β) :=
-functor.of_function f
-
 open opposite
 
+/-- A discrete category is equivalent to its opposite category. -/
 protected def opposite (α : Type u₁) : (discrete α)ᵒᵖ ≌ discrete α :=
 let F : discrete α ⥤ (discrete α)ᵒᵖ := functor.of_function (λ x, op x) in
 begin
@@ -106,7 +118,6 @@ begin
   refine nat_iso.of_components (λ X, by simp [F]) _,
   tidy
 end
-
 
 @[simp] lemma functor_map_id
   (F : discrete J ⥤ C) {j : discrete J} (f : j ⟶ j) : F.map f = 𝟙 (F.obj j) :=

--- a/src/category_theory/limits/shapes/binary_products.lean
+++ b/src/category_theory/limits/shapes/binary_products.lean
@@ -42,7 +42,7 @@ variables {C : Type u} [category.{v} C]
 
 /-- The diagram on the walking pair, sending the two points to `X` and `Y`. -/
 def pair (X Y : C) : discrete walking_pair ⥤ C :=
-functor.of_function (λ j, walking_pair.cases_on j X Y)
+discrete.functor (λ j, walking_pair.cases_on j X Y)
 
 @[simp] lemma pair_obj_left (X Y : C) : (pair X Y).obj left = X := rfl
 @[simp] lemma pair_obj_right (X Y : C) : (pair X Y).obj right = Y := rfl

--- a/src/category_theory/limits/shapes/biproducts.lean
+++ b/src/category_theory/limits/shapes/biproducts.lean
@@ -131,7 +131,7 @@ attribute [instance] has_finite_biproducts.has_bilimits_of_shape
 The isomorphism between the specified limit and the specified colimit for
 a functor with a bilimit.
 -/
-def biproduct_iso {J : Type v} (F : J → C) [has_bilimit (functor.of_function F)] :
+def biproduct_iso {J : Type v} (F : J → C) [has_bilimit (discrete.functor F)] :
   limits.pi_obj F ≅ limits.sigma_obj F :=
 eq_to_iso rfl
 
@@ -142,41 +142,41 @@ variables {J : Type v}
 variables {C : Type u} [category.{v} C]
 
 /-- `biproduct f` computes the biproduct of a family of elements `f`. (It is defined as an
-   abbreviation for `limit (functor.of_function f)`, so for most facts about `biproduct f`, you will
+   abbreviation for `limit (discrete.functor f)`, so for most facts about `biproduct f`, you will
    just use general facts about limits and colimits.) -/
-abbreviation biproduct (f : J → C) [has_bilimit (functor.of_function f)] :=
-limit (functor.of_function f)
+abbreviation biproduct (f : J → C) [has_bilimit (discrete.functor f)] :=
+limit (discrete.functor f)
 
 notation `⨁ ` f:20 := biproduct f
 
 /-- The projection onto a summand of a biproduct. -/
-abbreviation biproduct.π (f : J → C) [has_bilimit (functor.of_function f)] (b : J) : ⨁ f ⟶ f b :=
-limit.π (functor.of_function f) b
+abbreviation biproduct.π (f : J → C) [has_bilimit (discrete.functor f)] (b : J) : ⨁ f ⟶ f b :=
+limit.π (discrete.functor f) b
 /-- The inclusion into a summand of a biproduct. -/
-abbreviation biproduct.ι (f : J → C) [has_bilimit (functor.of_function f)] (b : J) : f b ⟶ ⨁ f :=
-colimit.ι (functor.of_function f) b
+abbreviation biproduct.ι (f : J → C) [has_bilimit (discrete.functor f)] (b : J) : f b ⟶ ⨁ f :=
+colimit.ι (discrete.functor f) b
 
 /-- Given a collection of maps into the summands, we obtain a map into the biproduct. -/
 abbreviation biproduct.lift
-  {f : J → C} [has_bilimit (functor.of_function f)] {P : C} (p : Π b, P ⟶ f b) : P ⟶ ⨁ f :=
+  {f : J → C} [has_bilimit (discrete.functor f)] {P : C} (p : Π b, P ⟶ f b) : P ⟶ ⨁ f :=
 limit.lift _ (fan.mk p)
 /-- Given a collection of maps out of the summands, we obtain a map out of the biproduct. -/
 abbreviation biproduct.desc
-  {f : J → C} [has_bilimit (functor.of_function f)] {P : C} (p : Π b, f b ⟶ P) : ⨁ f ⟶ P :=
+  {f : J → C} [has_bilimit (discrete.functor f)] {P : C} (p : Π b, f b ⟶ P) : ⨁ f ⟶ P :=
 colimit.desc _ (cofan.mk p)
 
 /-- Given a collection of maps between corresponding summands of a pair of biproducts
 indexed by the same type, we obtain a map betweeen the biproducts. -/
 abbreviation biproduct.map [fintype J] [decidable_eq J] {f g : J → C} [has_finite_biproducts.{v} C]
   (p : Π b, f b ⟶ g b) : ⨁ f ⟶ ⨁ g :=
-(@lim (discrete J) _ C _ _).map (nat_trans.of_function p)
+(@lim (discrete J) _ C _ _).map (discrete.nat_trans p)
 
-instance biproduct.ι_mono [decidable_eq J] (f : J → C) [has_bilimit (functor.of_function f)]
+instance biproduct.ι_mono [decidable_eq J] (f : J → C) [has_bilimit (discrete.functor f)]
   (b : J) : split_mono (biproduct.ι f b) :=
 { retraction := biproduct.desc $
     λ b', if h : b' = b then eq_to_hom (congr_arg f h) else biproduct.ι f b' ≫ biproduct.π f b }
 
-instance biproduct.π_epi [decidable_eq J] (f : J → C) [has_bilimit (functor.of_function f)]
+instance biproduct.π_epi [decidable_eq J] (f : J → C) [has_bilimit (discrete.functor f)]
   (b : J) : split_epi (biproduct.π f b) :=
 { section_ := biproduct.lift $
     λ b', if h : b = b' then eq_to_hom (congr_arg f h) else biproduct.ι f b ≫ biproduct.π f b' }

--- a/src/category_theory/limits/shapes/constructions/binary_products.lean
+++ b/src/category_theory/limits/shapes/constructions/binary_products.lean
@@ -28,7 +28,7 @@ def has_binary_products_of_terminal_and_pullbacks
     { cone :=
       { X := pullback (terminal.from (F.obj walking_pair.left))
                       (terminal.from (F.obj walking_pair.right)),
-        π := nat_trans.of_function (λ x, walking_pair.cases_on x pullback.fst pullback.snd)},
+        π := discrete.nat_trans (λ x, walking_pair.cases_on x pullback.fst pullback.snd)},
       is_limit :=
       { lift := λ c, pullback.lift ((c.π).app walking_pair.left)
                                    ((c.π).app walking_pair.right)

--- a/src/category_theory/limits/shapes/constructions/binary_products.lean
+++ b/src/category_theory/limits/shapes/constructions/binary_products.lean
@@ -28,7 +28,7 @@ def has_binary_products_of_terminal_and_pullbacks
     { cone :=
       { X := pullback (terminal.from (F.obj walking_pair.left))
                       (terminal.from (F.obj walking_pair.right)),
-        π := nat_trans.of_homs (λ x, walking_pair.cases_on x pullback.fst pullback.snd)},
+        π := nat_trans.of_function (λ x, walking_pair.cases_on x pullback.fst pullback.snd)},
       is_limit :=
       { lift := λ c, pullback.lift ((c.π).app walking_pair.left)
                                    ((c.π).app walking_pair.right)

--- a/src/category_theory/limits/shapes/constructions/limits_of_products_and_equalizers.lean
+++ b/src/category_theory/limits/shapes/constructions/limits_of_products_and_equalizers.lean
@@ -31,8 +31,8 @@ namespace has_limit_of_has_products_of_has_equalizers
 -- We assume here only that we have exactly the products we need, so that we can prove
 -- variations of the construction (all products gives all limits, finite products gives finite limits...)
 variables (F : J ⥤ C)
-          [H₁ : has_limit.{v} (functor.of_function F.obj)]
-          [H₂ : has_limit.{v} (functor.of_function (λ f : (Σ p : J × J, p.1 ⟶ p.2), F.obj f.1.2))]
+          [H₁ : has_limit.{v} (discrete.functor F.obj)]
+          [H₂ : has_limit.{v} (discrete.functor (λ f : (Σ p : J × J, p.1 ⟶ p.2), F.obj f.1.2))]
 include H₁ H₂
 
 /--

--- a/src/category_theory/limits/shapes/constructions/preserve_binary_products.lean
+++ b/src/category_theory/limits/shapes/constructions/preserve_binary_products.lean
@@ -27,7 +27,7 @@ variables [has_binary_products.{v} D] (F : C ⥤ D)
 @[simps]
 def alternative_cone (A B : C) : cone (pair A B ⋙ F) :=
 { X := F.obj A ⨯ F.obj B,
-  π := nat_trans.of_homs (λ j, walking_pair.cases_on j limits.prod.fst limits.prod.snd)}
+  π := nat_trans.of_function (λ j, walking_pair.cases_on j limits.prod.fst limits.prod.snd)}
 
 /-- (Implementation). Show that we have a limit for the shape `pair A B ⋙ F`. -/
 def alternative_cone_is_limit (A B : C) : is_limit (alternative_cone F A B) :=

--- a/src/category_theory/limits/shapes/constructions/preserve_binary_products.lean
+++ b/src/category_theory/limits/shapes/constructions/preserve_binary_products.lean
@@ -27,7 +27,7 @@ variables [has_binary_products.{v} D] (F : C ⥤ D)
 @[simps]
 def alternative_cone (A B : C) : cone (pair A B ⋙ F) :=
 { X := F.obj A ⨯ F.obj B,
-  π := nat_trans.of_function (λ j, walking_pair.cases_on j limits.prod.fst limits.prod.snd)}
+  π := discrete.nat_trans (λ j, walking_pair.cases_on j limits.prod.fst limits.prod.snd)}
 
 /-- (Implementation). Show that we have a limit for the shape `pair A B ⋙ F`. -/
 def alternative_cone_is_limit (A B : C) : is_limit (alternative_cone F A B) :=

--- a/src/category_theory/limits/shapes/products.lean
+++ b/src/category_theory/limits/shapes/products.lean
@@ -16,10 +16,10 @@ variables {β : Type v}
 variables {C : Type u} [category.{v} C]
 
 -- We don't need an analogue of `pair` (for binary products), `parallel_pair` (for equalizers),
--- or `(co)span`, since we already have `functor.of_function`.
+-- or `(co)span`, since we already have `discrete.functor`.
 
-abbreviation fan (f : β → C) := cone (functor.of_function f)
-abbreviation cofan (f : β → C) := cocone (functor.of_function f)
+abbreviation fan (f : β → C) := cone (discrete.functor f)
+abbreviation cofan (f : β → C) := cocone (discrete.functor f)
 
 def fan.mk {f : β → C} {P : C} (p : Π b, P ⟶ f b) : fan f :=
 { X := P,
@@ -33,33 +33,33 @@ def cofan.mk {f : β → C} {P : C} (p : Π b, f b ⟶ P) : cofan f :=
 @[simp] lemma cofan.mk_π_app {f : β → C} {P : C} (p : Π b, f b ⟶ P) (b : β) : (cofan.mk p).ι.app b = p b := rfl
 
 /-- `pi_obj f` computes the product of a family of elements `f`. (It is defined as an abbreviation
-   for `limit (functor.of_function f)`, so for most facts about `pi_obj f`, you will just use general facts
+   for `limit (discrete.functor f)`, so for most facts about `pi_obj f`, you will just use general facts
    about limits.) -/
-abbreviation pi_obj (f : β → C) [has_limit (functor.of_function f)] := limit (functor.of_function f)
+abbreviation pi_obj (f : β → C) [has_limit (discrete.functor f)] := limit (discrete.functor f)
 /-- `sigma_obj f` computes the coproduct of a family of elements `f`. (It is defined as an abbreviation
-   for `colimit (functor.of_function f)`, so for most facts about `sigma_obj f`, you will just use general facts
+   for `colimit (discrete.functor f)`, so for most facts about `sigma_obj f`, you will just use general facts
    about colimits.) -/
-abbreviation sigma_obj (f : β → C) [has_colimit (functor.of_function f)] := colimit (functor.of_function f)
+abbreviation sigma_obj (f : β → C) [has_colimit (discrete.functor f)] := colimit (discrete.functor f)
 
 notation `∏ ` f:20 := pi_obj f
 notation `∐ ` f:20 := sigma_obj f
 
-abbreviation pi.π (f : β → C) [has_limit (functor.of_function f)] (b : β) : ∏ f ⟶ f b :=
-limit.π (functor.of_function f) b
-abbreviation sigma.ι (f : β → C) [has_colimit (functor.of_function f)] (b : β) : f b ⟶ ∐ f :=
-colimit.ι (functor.of_function f) b
+abbreviation pi.π (f : β → C) [has_limit (discrete.functor f)] (b : β) : ∏ f ⟶ f b :=
+limit.π (discrete.functor f) b
+abbreviation sigma.ι (f : β → C) [has_colimit (discrete.functor f)] (b : β) : f b ⟶ ∐ f :=
+colimit.ι (discrete.functor f) b
 
-abbreviation pi.lift {f : β → C} [has_limit (functor.of_function f)] {P : C} (p : Π b, P ⟶ f b) : P ⟶ ∏ f :=
+abbreviation pi.lift {f : β → C} [has_limit (discrete.functor f)] {P : C} (p : Π b, P ⟶ f b) : P ⟶ ∏ f :=
 limit.lift _ (fan.mk p)
-abbreviation sigma.desc {f : β → C} [has_colimit (functor.of_function f)] {P : C} (p : Π b, f b ⟶ P) : ∐ f ⟶ P :=
+abbreviation sigma.desc {f : β → C} [has_colimit (discrete.functor f)] {P : C} (p : Π b, f b ⟶ P) : ∐ f ⟶ P :=
 colimit.desc _ (cofan.mk p)
 
 abbreviation pi.map {f g : β → C} [has_limits_of_shape.{v} (discrete β) C]
   (p : Π b, f b ⟶ g b) : ∏ f ⟶ ∏ g :=
-lim.map (nat_trans.of_function p)
+lim.map (discrete.nat_trans p)
 abbreviation sigma.map {f g : β → C} [has_colimits_of_shape.{v} (discrete β) C]
   (p : Π b, f b ⟶ g b) : ∐ f ⟶ ∐ g :=
-colim.map (nat_trans.of_function p)
+colim.map (discrete.nat_trans p)
 
 variables (C)
 

--- a/src/category_theory/limits/shapes/zero.lean
+++ b/src/category_theory/limits/shapes/zero.lean
@@ -206,14 +206,14 @@ end has_zero_object
 instance split_mono_sigma_ι
   {β : Type v} [decidable_eq β]
   [has_zero_morphisms.{v} C]
-  (f : β → C) [has_colimit (functor.of_function f)] (b : β) : split_mono (sigma.ι f b) :=
+  (f : β → C) [has_colimit (discrete.functor f)] (b : β) : split_mono (sigma.ι f b) :=
 { retraction := sigma.desc (λ b', if h : b' = b then eq_to_hom (congr_arg f h) else 0), }
 
 /-- In the presence of zero morphisms, projections into a product are (split) epimorphisms. -/
 instance split_epi_pi_π
   {β : Type v} [decidable_eq β]
   [has_zero_morphisms.{v} C]
-  (f : β → C) [has_limit (functor.of_function f)] (b : β) : split_epi (pi.π f b) :=
+  (f : β → C) [has_limit (discrete.functor f)] (b : β) : split_epi (pi.π f b) :=
 { section_ := pi.lift (λ b', if h : b = b' then eq_to_hom (congr_arg f h) else 0), }
 
 /-- In the presence of zero morphisms, coprojections into a coproduct are (split) monomorphisms. -/


### PR DESCRIPTION
* renames all the construction building functors/transformations out of discrete categories as `discrete.functor`, `discrete.nat_trans`, `discrete.nat_iso`, rather than names using `of_function`.
* adds `def discrete.equivalence {I J : Type u₁} (e : I ≃ J) : discrete I ≌ discrete J`,
* removes some redundant definitions
* breaks some long lines, 
* and adds doc-strings.

---
<!-- put comments you want to keep out of the PR commit here -->
