### PR TITLE
[Merged by Bors] - chore(*): update to lean 3.16.3

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mathlib"
 version = "0.1"
-lean_version = "leanprover-community/lean:3.16.2"
+lean_version = "leanprover-community/lean:3.16.3"
 path = "src"
 
 [dependencies]

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -115,7 +115,7 @@ begin
           simpa using Z },
         { left,
           rw [this, add_comm, nat.add_one] at Z,
-          exact nat.succ_inj Z } },
+          exact nat.succ.inj Z } },
       have : is_closed (f.ker : set E),
       { cases this,
         { exact H₁ _ this },

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -970,7 +970,7 @@ calc ∑ m in filter (λ k, n ≤ k) (range j), (1 / m.fact : α)
   by simp [mul_inv', mul_sum.symm, sum_mul.symm, -nat.fact_succ, mul_comm, inv_pow']
 ... = (n.succ - n.succ * n.succ⁻¹ ^ (j - n)) / (n.fact * n) :
   have h₁ : (n.succ : α) ≠ 1, from @nat.cast_one α _ _ ▸ mt nat.cast_inj.1
-        (mt nat.succ_inj (nat.pos_iff_ne_zero.1 hn)),
+        (mt nat.succ.inj (nat.pos_iff_ne_zero.1 hn)),
   have h₂ : (n.succ : α) ≠ 0, from nat.cast_ne_zero.2 (nat.succ_ne_zero _),
   have h₃ : (n.fact * n : α) ≠ 0,
     from mul_ne_zero (nat.cast_ne_zero.2 (nat.pos_iff_ne_zero.1 (nat.fact_pos _)))

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -1233,7 +1233,7 @@ eq_of_veq $ by rw [map_val, attach_val]; exact attach_map_val _
 end map
 
 lemma range_add_one' (n : ℕ) :
-  range (n + 1) = insert 0 ((range n).map ⟨λi, i + 1, assume i j, nat.succ_inj⟩) :=
+  range (n + 1) = insert 0 ((range n).map ⟨λi, i + 1, assume i j, nat.succ.inj⟩) :=
 by ext (⟨⟩ | ⟨n⟩); simp [nat.succ_eq_add_one, nat.zero_lt_succ n]
 
 /-! ### image -/

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1011,4 +1011,4 @@ instance nat.infinite : infinite ℕ :=
 ⟨λ ⟨s, hs⟩, finset.not_mem_range_self $ s.subset_range_sup_succ (hs _)⟩
 
 instance int.infinite : infinite ℤ :=
-infinite.of_injective int.of_nat (λ _ _, int.of_nat_inj)
+infinite.of_injective int.of_nat (λ _ _, int.of_nat.inj)

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -148,7 +148,7 @@ begin
     { subst e, rw [add_comm _ i, add_assoc],
       exact nat.le_add_right i (b.succ + b).succ },
     { apply succ_le_succ,
-      rw [← succ_inj e, ← add_assoc, add_comm],
+      rw [← succ.inj e, ← add_assoc, add_comm],
       apply nat.le_add_right } },
   cases a; cases b with b b; simp [nat_abs, nat.succ_add];
   try {refl}; [skip, rw add_comm a b]; apply this

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -1108,7 +1108,7 @@ theorem nth_modify_nth (f : α → α) : ∀ n (l : list α) m,
 | 0     (a::l) (m+1) := by cases nth l m; refl
 | (n+1) (a::l) (m+1) := (nth_modify_nth n l m).trans $
   by cases nth l m with b; by_cases n = m;
-  simp only [h, if_pos, if_true, if_false, option.map_none, option.map_some, mt succ_inj,
+  simp only [h, if_pos, if_true, if_false, option.map_none, option.map_some, mt succ.inj,
     not_false_iff]
 
 theorem modify_nth_tail_length (f : list α → list α) (H : ∀ l, length (f l) = length l) :

--- a/src/data/list/zip.lean
+++ b/src/data/list/zip.lean
@@ -40,7 +40,7 @@ theorem zip_append : ∀ {l₁ l₂ r₁ r₂ : list α} (h : length l₁ = leng
    zip (l₁ ++ r₁) (l₂ ++ r₂) = zip l₁ l₂ ++ zip r₁ r₂
 | []      l₂      r₁ r₂ h := by simp only [eq_nil_of_length_eq_zero h.symm]; refl
 | l₁      []      r₁ r₂ h := by simp only [eq_nil_of_length_eq_zero h]; refl
-| (a::l₁) (b::l₂) r₁ r₂ h := by simp only [cons_append, zip_cons_cons, zip_append (succ_inj h)];
+| (a::l₁) (b::l₂) r₁ r₂ h := by simp only [cons_append, zip_cons_cons, zip_append (succ.inj h)];
     split; refl
 
 theorem zip_map (f : α → γ) (g : β → δ) : ∀ (l₁ : list α) (l₂ : list β),

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -50,7 +50,7 @@ attribute [simp] nat.sub_self
 @[simp] lemma succ_pos' {n : ℕ} : 0 < succ n := succ_pos n
 
 theorem succ_inj' {n m : ℕ} : succ n = succ m ↔ n = m :=
-⟨succ_inj, congr_arg _⟩
+⟨succ.inj, congr_arg _⟩
 
 theorem succ_le_succ_iff {m n : ℕ} : succ m ≤ succ n ↔ m ≤ n :=
 ⟨le_of_succ_le_succ, succ_le_succ⟩
@@ -1059,7 +1059,7 @@ begin
   cases b, {exact absurd rfl h},
   have : shiftl' tt m n + 1 = 1 := congr_arg (+1) s0,
   rw [shiftl'_tt_eq_mul_pow] at this,
-  have m0 := succ_inj (eq_one_of_dvd_one ⟨_, this.symm⟩),
+  have m0 := succ.inj (eq_one_of_dvd_one ⟨_, this.symm⟩),
   subst m0,
   simp at this,
   have : n = 0 := eq_zero_of_le_zero (le_of_not_gt $ λ hn,

--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -26,7 +26,7 @@ def succ_pnat (n : ℕ) : ℕ+ := ⟨succ n, succ_pos n⟩
 @[simp] theorem succ_pnat_coe (n : ℕ) : (succ_pnat n : ℕ) = succ n := rfl
 
 theorem succ_pnat_inj {n m : ℕ} : succ_pnat n = succ_pnat m → n = m :=
-λ h, by { let h' := congr_arg (coe : ℕ+ → ℕ) h, exact nat.succ_inj h' }
+λ h, by { let h' := congr_arg (coe : ℕ+ → ℕ) h, exact nat.succ.inj h' }
 
 /-- Convert a natural number to a pnat. `n+1` is mapped to itself,
   and `0` becomes `1`. -/

--- a/src/data/pnat/xgcd.lean
+++ b/src/data/pnat/xgcd.lean
@@ -83,7 +83,7 @@ begin
   split; intro h,
   { apply eq, dsimp [w, z, succ_pnat], rw [← h],
     repeat { rw [nat.succ_eq_add_one] }, ring },
-  { apply nat.succ_inj,
+  { apply nat.succ.inj,
     replace h := congr_arg (coe : ℕ+ → ℕ) h,
     rw [mul_coe, w, z] at h,
     repeat { rw [succ_pnat_coe, nat.succ_eq_add_one] at h },

--- a/src/tactic/alias.lean
+++ b/src/tactic/alias.lean
@@ -63,7 +63,7 @@ do updateex_env $ λ env,
   alias_attr.set al () tt,
   add_doc_string al doc
 
-meta def mk_iff_mp_app (iffmp : name) : expr → (nat → expr) → tactic expr
+meta def mk_iff_mp_app (iffmp : name) : expr → (ℕ → expr) → tactic expr
 | (expr.pi n bi e t) f := expr.lam n bi e <$> mk_iff_mp_app t (λ n, f (n+1) (expr.var n))
 | `(%%a ↔ %%b) f := pure $ @expr.const tt iffmp [] a b (f 0)
 | _ f := fail "Target theorem must have the form `Π x y z, a ↔ b`"

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -442,7 +442,7 @@ begin
   rw [tsum_add hf₁ hf₂, tsum_eq_single 0],
   { congr' 1,
     fapply tsum_eq_tsum_of_ne_zero_bij (λ n _, n + 1),
-    { intros _ _ _ _, exact nat.succ_inj },
+    { intros _ _ _ _, exact nat.succ.inj },
     { rintros (_ | n) h,
       { contradiction },
       { exact ⟨n, h, rfl⟩ } },

--- a/test/lint.lean
+++ b/test/lint.lean
@@ -95,7 +95,7 @@ def foo_has_mul {α} [has_mul α] : has_mul α := infer_instance
 local attribute [instance, priority 1] foo_has_mul
 run_cmd do
   d ← get_decl `has_mul,
-  some s ← fails_quickly 100 d,
+  some s ← fails_quickly 20 d,
   guard $ s = "type-class inference timed out"
 local attribute [instance, priority 10000] foo_has_mul
 run_cmd do


### PR DESCRIPTION
The changes to mathlib are from https://github.com/leanprover-community/lean/pull/321 which removed some redundant lemmas:
* `int.of_nat_inj` -> `int.of_nat.inj`
* `int.neg_succ_of_nat_inj` -> `int.neg_succ_of_nat.inj`
* `nat.succ_inj` -> `nat.succ.inj`

---
<!-- put comments you want to keep out of the PR commit here -->
