### PR TITLE
[Merged by Bors] - feat(tactic/zify): move nat propositions to int

### DIFF
--- a/src/tactic/default.lean
+++ b/src/tactic/default.lean
@@ -29,3 +29,4 @@ import tactic.reassoc_axiom -- most likely useful only for category_theory
 import tactic.slice
 import tactic.subtype_instance
 import tactic.group
+import tactic.zify

--- a/src/tactic/lift.lean
+++ b/src/tactic/lift.lean
@@ -163,6 +163,11 @@ Lift an expression to another type.
 * Given an instance `can_lift β γ`, it can also lift `α → β` to `α → γ`; more generally, given
   `β : Π a : α, Type*`, `γ : Π a : α, Type*`, and `[Π a : α, can_lift (β a) (γ a)]`, it automatically
   generates an instance `can_lift (Π a, β a) (Π a, γ a)`.
+
+`lift` is in some sense dual to the `zify` tactic. `lift (z : ℤ) to ℕ` will change the type of an
+integer `z` (in the supertype) to `ℕ` (the subtype), given a proof that `z ≥ 0`;
+propositions concerning `z` will still be over `ℤ`. `zify` changes propositions about `ℕ` (the
+subtype) to propositions about `ℤ` (the supertype), without changing the type of any variable.
 -/
 meta def lift (p : parse texpr) (t : parse to_texpr) (h : parse using_texpr)
   (n : parse with_ident_list) : tactic unit :=

--- a/src/tactic/norm_cast.lean
+++ b/src/tactic/norm_cast.lean
@@ -325,6 +325,7 @@ end
 meta def push_cast (hs : parse tactic.simp_arg_list) (l : parse location) : tactic unit :=
 tactic.interactive.simp none tt hs [`push_cast] l
 
+
 end tactic.interactive
 
 namespace norm_cast
@@ -526,6 +527,15 @@ do
   pr ← mk_eq_trans pr pr3,
   pr ← mk_eq_trans pr pr4,
   return (new_e, pr)
+
+/--
+A small variant of `push_cast` suited for non-interactive use.
+
+`derive_push_cast extra_lems e` returns an expression `e'` and a proof that `e = e'`.
+-/
+meta def derive_push_cast (extra_lems : list simp_arg_type) (e : expr) : tactic (expr × expr) :=
+do (s, _) ← mk_simp_set tt [`push_cast] extra_lems,
+   simplify (s.erase [`int.coe_nat_succ]) [] e {fail_if_unchanged := ff}
 
 end norm_cast
 

--- a/src/tactic/zify.lean
+++ b/src/tactic/zify.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2020 Robert Y. Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Y. Lewis
+-/
+
+import tactic.norm_cast
+import data.int.basic
+
+/-!
+# A tactic to shift `ℕ` goals to `ℤ`
+
+It is often easier to work in `ℤ`, where subtraction is well behaved, than in `ℕ` where it isn't.
+`zify` is a tactic that casts goals and hypotheses about natural numbers to ones about integers.
+It makes use of `push_cast`, part of the `norm_cast` family, to simplify these goals.
+
+## Implementation notes
+
+`zify` is extensible.
+TODO
+-/
+
+open tactic
+
+namespace zify
+
+@[user_attribute]
+meta def zify_attr : user_attribute unit unit :=
+{ name := `zify,
+  descr := "",
+  after_set := some $ λ n _ _, do
+    d ← get_decl n,
+    guard (d.type = `(expr → tactic  (expr × expr)))
+      <|> fail "zify patterns must have type `expr → tactic (expr × expr)`" }
+
+/-- Returns a list of all `zify` patterns in the context. -/
+meta def get_patterns : tactic (list (expr → tactic  (expr × expr))) :=
+attribute.get_instances `zify >>= mmap (λ t, mk_const t >>= eval_expr (expr → tactic (expr × expr)))
+
+private meta def mk_app_tuple (lem : name) (lhs rhs : expr) (pe : pexpr) : tactic (expr × expr) :=
+do type ← to_expr pe,
+   eq_pf ← mk_app lem [lhs, rhs],
+   return (type, eq_pf)
+
+/-- A `zify` pattern for equalities and inequalities. -/
+@[zify]
+meta def comparison : expr → tactic (expr × expr)
+| `(@has_le.le ℕ %%_ %%lhs %%rhs) := mk_app_tuple ``int.coe_nat_le_coe_nat_iff lhs rhs ``((%%lhs : ℤ) ≤ %%rhs)
+| `(@has_lt.lt ℕ %%_ %%lhs %%rhs) := mk_app_tuple ``int.coe_nat_lt_coe_nat_iff lhs rhs ``((%%lhs : ℤ) < %%rhs)
+| `(@ge ℕ %%_ %%lhs %%rhs) := mk_app_tuple ``int.coe_nat_le_coe_nat_iff rhs lhs ``((%%lhs : ℤ) ≥ %%rhs)
+| `(@gt ℕ %%_ %%lhs %%rhs) := mk_app_tuple ``int.coe_nat_lt_coe_nat_iff rhs lhs ``((%%lhs : ℤ) > %%rhs)
+| `(@eq ℕ %%lhs %%rhs) := mk_app_tuple ``int.coe_nat_eq_coe_nat_iff lhs rhs ``((%%lhs : ℤ) = %%rhs)
+| _ := failed
+
+
+end zify
+
+/--
+Given `e` a proposition about natural numbers,
+`zify e` tries to translate it to a proposition `e'` about integers.
+Returns `e'` and a proof that `e = e'`. -/
+meta def tactic.zify1 (e : expr) : tactic (expr × expr) :=
+do zify_patterns ← zify.get_patterns,
+   (zv, iff_pf) ← zify_patterns.mfirst (λ f, f e),
+   (s, _) ← mk_simp_set tt [`push_cast] [],
+   (newe, cast_eq) ← simplify (s.erase [`int.coe_nat_succ]) [] zv {fail_if_unchanged := ff},
+   pex_pf ← mk_app `propext [iff_pf] >>= mk_eq_symm,
+   prod.mk newe <$> mk_eq_trans pex_pf cast_eq
+
+meta def tactic.zify : expr → tactic (expr × expr) := λ z,
+prod.snd <$> simplify_bottom_up () (λ _ e, prod.mk () <$> tactic.zify1 e) z
+
+/--
+Given `h` a proof of a proposition about natural numbers,
+`zify_proof h` tries to translate it to a proof of a proposition about integers.
+-/
+meta def tactic.zify_proof (h : expr) : tactic expr :=
+do (_, pf) ← infer_type h >>= tactic.zify,
+   mk_eq_mp pf h
+
+section
+
+setup_tactic_parser
+
+meta def tactic.interactive.zify (l : parse location) : tactic unit :=
+do locs ← l.get_locals,
+replace_at tactic.zify locs l.include_goal >>= guardb
+
+end
+
+example (a b c x y z : ℕ) (h : ¬ x*y*z < 0) : a + 3*b > c :=
+begin
+  zify at h ⊢,
+  guard_hyp h := ¬↑x * ↑y * ↑z < (0 : ℤ),
+  guard_target ↑a + 3 * ↑b > (↑c : ℤ),
+  admit
+end
+
+
+example (a b : ℕ) : a ≤ b :=
+begin
+  zify,
+  guard_target (a : ℤ) ≤ b,
+  admit
+end

--- a/src/tactic/zify.lean
+++ b/src/tactic/zify.lean
@@ -62,15 +62,6 @@ do sl ← zify_attr.get_cache,
    sl ← sl.add_simp `ge_iff_le, sl ← sl.add_simp `gt_iff_lt,
    simplify sl [] e
 
-/--
-A small variant of `push_cast` suited for non-interactive use.
-
-`push_casts extra_lems e` returns an expression `e'` and a proof that `e = e'`.
--/
-meta def push_casts (extra_lems : list simp_arg_type) (e : expr) : tactic (expr × expr) :=
-do (s, _) ← mk_simp_set tt [`push_cast] extra_lems,
-   simplify (s.erase [`int.coe_nat_succ]) [] e {fail_if_unchanged := ff}
-
 attribute [zify] int.coe_nat_le_coe_nat_iff int.coe_nat_lt_coe_nat_iff int.coe_nat_eq_coe_nat_iff
 
 end zify
@@ -130,6 +121,11 @@ end
 
 `zify` makes use of the `@[zify]` attribute to move propositions,
 and the `push_cast` tactic to simplify the `ℤ`-valued expressions.
+
+`zify` is in some sense dual to the `lift` tactic. `lift (z : ℤ) to ℕ` will change the type of an
+integer `z` (in the supertype) to `ℕ` (the subtype), given a proof that `z ≥ 0`;
+propositions concerning `z` will still be over `ℤ`. `zify` changes propositions about `ℕ` (the
+subtype) to propositions about `ℤ` (the supertype), without changing the type of any variable.
 -/
 meta def tactic.interactive.zify (sl : parse simp_arg_list) (l : parse location) : tactic unit :=
 do locs ← l.get_locals,

--- a/src/tactic/zify.lean
+++ b/src/tactic/zify.lean
@@ -75,6 +75,9 @@ attribute [zify] int.coe_nat_le_coe_nat_iff int.coe_nat_lt_coe_nat_iff int.coe_n
 
 end zify
 
+@[zify] lemma int.coe_nat_ne_coe_nat_iff (a b : ℕ) : (a : ℤ) ≠ b ↔ a ≠ b :=
+by simp
+
 /--
 `zify extra_lems e` is used to shift propositions in `e` from `ℕ` to `ℤ`.
 This is often useful since `ℤ` has well-behaved subtraction.

--- a/src/tactic/zify.lean
+++ b/src/tactic/zify.lean
@@ -16,63 +16,78 @@ It makes use of `push_cast`, part of the `norm_cast` family, to simplify these g
 
 ## Implementation notes
 
-`zify` is extensible.
-TODO
+`zify` is extensible, using the attribute `@[zify]` to label lemmas used for moving propositions
+from `ℕ` to `ℤ`.
+`zify` lemmas should have the form `∀ a₁ ... aₙ : ℕ, Pz (a₁ : ℤ) ... (aₙ : ℤ) ↔ Pn a₁ ... aₙ`.
+For example, `int.coe_nat_le_coe_nat_iff : ∀ (m n : ℕ), ↑m ≤ ↑n ↔ m ≤ n` is a `zify` lemma.
+
+`zify` is very nearly just `simp only with zify push_cast`. There are a few minor differences:
+* `zify` lemmas are used in the opposite order of the standard simp form.
+  E.g. we will rewrite with `int.coe_nat_le_coe_nat_iff` from right to left.
+* `zify` should fail if no `zify` lemma applies (i.e. it was unable to shift any proposition to ℤ).
+  However, once this succeeds, it does not necessarily need to rewrite with any `push_cast` rules.
 -/
 
 open tactic
 
 namespace zify
 
+/--
+The `zify` attribute is used by the `zify` tactic. It applies to lemmas that shift propositions
+between `nat` and `int`.
+
+`zify` lemmas should have the form `∀ a₁ ... aₙ : ℕ, Pz (a₁ : ℤ) ... (aₙ : ℤ) ↔ Pn a₁ ... aₙ`.
+For example, `int.coe_nat_le_coe_nat_iff : ∀ (m n : ℕ), ↑m ≤ ↑n ↔ m ≤ n` is a `zify` lemma.
+-/
 @[user_attribute]
-meta def zify_attr : user_attribute unit unit :=
+meta def zify_attr : user_attribute simp_lemmas unit :=
 { name := `zify,
-  descr := "",
-  after_set := some $ λ n _ _, do
-    d ← get_decl n,
-    guard (d.type = `(expr → tactic  (expr × expr)))
-      <|> fail "zify patterns must have type `expr → tactic (expr × expr)`" }
+  descr := "Used to tag lemmas for use in the `zify` tactic",
+  cache_cfg :=
+    { mk_cache :=
+        λ ns, mmap (λ n, do c ← mk_const n, return (c, tt)) ns >>= simp_lemmas.mk.append_with_symm,
+      dependencies := [] } }
 
-/-- Returns a list of all `zify` patterns in the context. -/
-meta def get_patterns : tactic (list (expr → tactic  (expr × expr))) :=
-attribute.get_instances `zify >>= mmap (λ t, mk_const t >>= eval_expr (expr → tactic (expr × expr)))
+/--
+Given an expression `e`, `lift_to_z e` looks for subterms of `e` that are propositions "about"
+natural numbers and change them to propositions about integers.
 
-private meta def mk_app_tuple (lem : name) (lhs rhs : expr) (pe : pexpr) : tactic (expr × expr) :=
-do type ← to_expr pe,
-   eq_pf ← mk_app lem [lhs, rhs],
-   return (type, eq_pf)
+Returns an expression `e'` and a proof that `e = e'`.
 
-/-- A `zify` pattern for equalities and inequalities. -/
-@[zify]
-meta def comparison : expr → tactic (expr × expr)
-| `(@has_le.le ℕ %%_ %%lhs %%rhs) := mk_app_tuple ``int.coe_nat_le_coe_nat_iff lhs rhs ``((%%lhs : ℤ) ≤ %%rhs)
-| `(@has_lt.lt ℕ %%_ %%lhs %%rhs) := mk_app_tuple ``int.coe_nat_lt_coe_nat_iff lhs rhs ``((%%lhs : ℤ) < %%rhs)
-| `(@ge ℕ %%_ %%lhs %%rhs) := mk_app_tuple ``int.coe_nat_le_coe_nat_iff rhs lhs ``((%%lhs : ℤ) ≥ %%rhs)
-| `(@gt ℕ %%_ %%lhs %%rhs) := mk_app_tuple ``int.coe_nat_lt_coe_nat_iff rhs lhs ``((%%lhs : ℤ) > %%rhs)
-| `(@eq ℕ %%lhs %%rhs) := mk_app_tuple ``int.coe_nat_eq_coe_nat_iff lhs rhs ``((%%lhs : ℤ) = %%rhs)
-| _ := failed
+Includes `ge_iff_le` and `gt_iff_lt` in the simp set. These can't be tagged with `zify` as we
+want to use them in the "forward", not "backward", direction.
+-/
+meta def lift_to_z (e : expr) : tactic (expr × expr) :=
+do sl ← zify_attr.get_cache,
+   sl ← sl.add_simp `ge_iff_le, sl ← sl.add_simp `gt_iff_lt,
+   simplify sl [] e
 
+/--
+A small variant of `push_cast` suited for non-interactive use.
+
+`push_casts e` returns an expression `e'` and a proof that `e = e'`.
+-/
+meta def push_casts (e : expr) : tactic (expr × expr) :=
+do (s, _) ← mk_simp_set tt [`push_cast] [],
+   simplify (s.erase [`int.coe_nat_succ]) [] e {fail_if_unchanged := ff}
+
+attribute [zify] int.coe_nat_le_coe_nat_iff int.coe_nat_lt_coe_nat_iff int.coe_nat_eq_coe_nat_iff
 
 end zify
 
 /--
-Given `e` a proposition about natural numbers,
-`zify e` tries to translate it to a proposition `e'` about integers.
-Returns `e'` and a proof that `e = e'`. -/
-meta def tactic.zify1 (e : expr) : tactic (expr × expr) :=
-do zify_patterns ← zify.get_patterns,
-   (zv, iff_pf) ← zify_patterns.mfirst (λ f, f e),
-   (s, _) ← mk_simp_set tt [`push_cast] [],
-   (newe, cast_eq) ← simplify (s.erase [`int.coe_nat_succ]) [] zv {fail_if_unchanged := ff},
-   pex_pf ← mk_app `propext [iff_pf] >>= mk_eq_symm,
-   prod.mk newe <$> mk_eq_trans pex_pf cast_eq
+`zify e` is used to shift propositions in `e` from `ℕ` to `ℤ`.
+This is often useful since `ℤ` has well-behaved subtraction.
 
+Returns an expression `e'` and a proof that `e = e'`.-/
 meta def tactic.zify : expr → tactic (expr × expr) := λ z,
-prod.snd <$> simplify_bottom_up () (λ _ e, prod.mk () <$> tactic.zify1 e) z
+do (z1, p1) ← zify.lift_to_z z <|> fail "failed to find an applicable zify lemma",
+   (z2, p2) ← zify.push_casts z1,
+   prod.mk z2 <$> mk_eq_trans p1 p2
 
 /--
-Given `h` a proof of a proposition about natural numbers,
-`zify_proof h` tries to translate it to a proof of a proposition about integers.
+A variant of `tactic.zify` that takes `h`, a proof of a proposition about natural numbers,
+and returns a proof of the zified version of that propositon.
 -/
 meta def tactic.zify_proof (h : expr) : tactic expr :=
 do (_, pf) ← infer_type h >>= tactic.zify,
@@ -82,24 +97,37 @@ section
 
 setup_tactic_parser
 
+/--
+The `zify` tactic is used to shift propositions from `ℕ` to `ℤ`.
+This is often useful since `ℤ` has well-behaved subtraction.
+
+```lean
+example (a b c x y z : ℕ) (h : ¬ x*y*z < 0) : c < a + 3*b :=
+begin
+  zify,
+  zify at h,
+  /-
+  h : ¬↑x * ↑y * ↑z < 0
+  ⊢ ↑c < ↑a + 3 * ↑b
+  -/
+
+`zify` makes use of the `@[zify]` attribute to move propositions,
+and the `push_cast` tactic to simplify the `ℤ`-valued expressions.
+end
+```
+-/
 meta def tactic.interactive.zify (l : parse location) : tactic unit :=
 do locs ← l.get_locals,
 replace_at tactic.zify locs l.include_goal >>= guardb
 
 end
 
-example (a b c x y z : ℕ) (h : ¬ x*y*z < 0) : a + 3*b > c :=
-begin
-  zify at h ⊢,
-  guard_hyp h := ¬↑x * ↑y * ↑z < (0 : ℤ),
-  guard_target ↑a + 3 * ↑b > (↑c : ℤ),
-  admit
-end
+add_tactic_doc
+{ name := "zify",
+  category := doc_category.attr,
+  decl_names := [`zify.zify_attr] }
 
-
-example (a b : ℕ) : a ≤ b :=
-begin
-  zify,
-  guard_target (a : ℤ) ≤ b,
-  admit
-end
+add_tactic_doc
+{ name := "zify",
+  category := doc_category.tactic,
+  decl_names := [`tactic.interactive.zify] }

--- a/src/tactic/zify.lean
+++ b/src/tactic/zify.lean
@@ -78,7 +78,7 @@ The list of extra lemmas is used in the `push_cast` step.
 Returns an expression `e'` and a proof that `e = e'`.-/
 meta def tactic.zify (extra_lems : list simp_arg_type) : expr → tactic (expr × expr) := λ z,
 do (z1, p1) ← zify.lift_to_z z <|> fail "failed to find an applicable zify lemma",
-   (z2, p2) ← zify.push_casts extra_lems z1,
+   (z2, p2) ← norm_cast.derive_push_cast extra_lems z1,
    prod.mk z2 <$> mk_eq_trans p1 p2
 
 /--

--- a/src/tactic/zify.lean
+++ b/src/tactic/zify.lean
@@ -140,9 +140,11 @@ end
 add_tactic_doc
 { name := "zify",
   category := doc_category.attr,
-  decl_names := [`zify.zify_attr] }
+  decl_names := [`zify.zify_attr],
+  tags := ["coercions", "transport"] }
 
 add_tactic_doc
 { name := "zify",
   category := doc_category.tactic,
-  decl_names := [`tactic.interactive.zify] }
+  decl_names := [`tactic.interactive.zify],
+  tags := ["coercions", "transport"] }

--- a/test/zify.lean
+++ b/test/zify.lean
@@ -1,0 +1,24 @@
+import tactic.zify
+
+example (a b c x y z : ℕ) (h : ¬ x*y*z < 0) : a + 3*b > c :=
+begin
+  zify at h ⊢,
+  guard_hyp h := ¬↑x * ↑y * ↑z < (0 : ℤ),
+  guard_target ↑c < (↑a : ℤ) + 3 * ↑b,
+  admit
+end
+
+example (a b : ℕ) : a ≤ b :=
+begin
+  zify,
+  guard_target (a : ℤ) ≤ b,
+  admit
+end
+
+example (a b : ℕ) (h : a = b ∧ b < a) : false :=
+begin
+  zify at h,
+  cases h with ha hb,
+  apply ne_of_lt hb,
+  rw ha
+end

--- a/test/zify.lean
+++ b/test/zify.lean
@@ -22,3 +22,10 @@ begin
   apply ne_of_lt hb,
   rw ha
 end
+
+example (a b c : ℕ) (h : a - b < c) (hab : b ≤ a) : false :=
+begin
+  zify [hab] at h,
+  guard_hyp h := (a : ℤ) - b < c,
+  admit
+end

--- a/test/zify.lean
+++ b/test/zify.lean
@@ -29,3 +29,10 @@ begin
   guard_hyp h := (a : ℤ) - b < c,
   admit
 end
+
+example (a b c : ℕ) (h : a + b ≠ c) : false :=
+begin
+  zify at h,
+  guard_hyp h := (a : ℤ) + b ≠ c,
+  admit
+end


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->
I've broken a chunk of the `linarith` preprocessing into a standalone tactic. IIRC @kbuzzard has talked about doing this by hand before. 

Sometimes you're trying to prove a proposition about nats but it would be more convenient to treat them as ints so you can subtract them. `zify` will insert some casts and try to simplify things for you. It uses a new attribute `@[zify]` to insert the casts, and `push_cast` to do the simplification. It's extensible: throw `@[zify]` on a lemma of the right shape and it will take care of those propositions for you too.

```lean
example (a b c x y z : ℕ) (h : ¬ x*y*z < 0) : a + 3*b > c :=
begin
  zify at h ⊢,
  guard_hyp h := ¬↑x * ↑y * ↑z < (0 : ℤ),
  guard_target ↑c < (↑a : ℤ) + 3 * ↑b,
  admit
end

example (a b c : ℕ) (h : a - b < c) (hab : b ≤ a) : false :=
begin
  zify [hab] at h,
  guard_hyp h := (a : ℤ) - b < c,
  admit
end
```