### PR TITLE
[Merged by Bors] - refactor(ring_theory/*): make PID class a predicate

### DIFF
--- a/src/data/zsqrtd/gaussian_int.lean
+++ b/src/data/zsqrtd/gaussian_int.lean
@@ -191,7 +191,7 @@ instance : euclidean_domain ℤ[i] :=
   .. gaussian_int.comm_ring,
   .. gaussian_int.nonzero }
 
-open principal_ideal_domain
+open principal_ideal_ring
 
 lemma mod_four_eq_three_of_nat_prime_of_prime (p : ℕ) [hp : fact p.prime] (hpi : prime (p : ℤ[i])) :
   p % 4 = 3 :=

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -61,7 +61,7 @@ end
 
 lemma splits_mul {f g : polynomial α} (hf : splits i f) (hg : splits i g) : splits i (f * g) :=
 if h : f * g = 0 then by simp [h]
-else or.inr $ λ p hp hpf, ((principal_ideal_domain.irreducible_iff_prime.1 hp).2.2 _ _
+else or.inr $ λ p hp hpf, ((principal_ideal_ring.irreducible_iff_prime.1 hp).2.2 _ _
     (show p ∣ map i f * map i g, by convert hpf; rw polynomial.map_mul)).elim
   (hf.resolve_left (λ hf, by simpa [hf] using h) hp)
   (hg.resolve_left (λ hg, by simpa [hg] using h) hp)
@@ -144,7 +144,7 @@ is_noetherian_ring.irreducible_induction_on (f.map i)
 
 section UFD
 
-local attribute [instance, priority 10] principal_ideal_domain.to_unique_factorization_domain
+local attribute [instance, priority 10] principal_ideal_ring.to_unique_factorization_domain
 local infix ` ~ᵤ ` : 50 := associated
 
 open unique_factorization_domain associates

--- a/src/number_theory/sum_two_squares.lean
+++ b/src/number_theory/sum_two_squares.lean
@@ -11,7 +11,7 @@ Proof of Fermat's theorem on the sum of two squares. Every prime congruent to 1 
 of two squares
 -/
 
-open gaussian_int principal_ideal_domain
+open gaussian_int principal_ideal_ring
 
 namespace nat
 namespace prime

--- a/src/ring_theory/adjoin_root.lean
+++ b/src/ring_theory/adjoin_root.lean
@@ -110,7 +110,7 @@ end comm_ring
 variables [field K] {f : polynomial K} [irreducible f]
 
 instance is_maximal_span : is_maximal (span {f} : ideal (polynomial K)) :=
-principal_ideal_domain.is_maximal_of_irreducible ‹irreducible f›
+principal_ideal_ring.is_maximal_of_irreducible ‹irreducible f›
 
 noncomputable instance field : field (adjoin_root f) :=
 ideal.quotient.field (span {f} : ideal (polynomial K))

--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -521,7 +521,7 @@ theorem mul_inv_cancel_iff {I : fractional_ideal g} :
 
 end quotient
 
-section principal_ideal_domain
+section principal_ideal_ring
 
 variables {K : Type*} [field K] {g : fraction_map R K}
 
@@ -655,7 +655,6 @@ instance is_principal {R} [integral_domain R] [is_principal_ideal_ring R] {f : f
   (I : fractional_ideal f) : (I : submodule R f.codomain).is_principal :=
 ⟨ begin
   obtain ⟨a, aI, ha⟩ := exists_eq_span_singleton_mul I,
-  haveI : is_principal aI := is_principal_ideal_ring.principal aI,
   have := a * f.to_map (generator aI),
   use a * f.to_map (generator aI),
   suffices : I = span_singleton (a * f.to_map (generator aI)),
@@ -664,7 +663,7 @@ instance is_principal {R} [integral_domain R] [is_principal_ideal_ring R] {f : f
   rw [coe_ideal_span_singleton (generator aI), span_singleton_mul_span_singleton]
 end ⟩
 
-end principal_ideal_domain
+end principal_ideal_ring
 
 end fractional_ideal
 

--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -651,10 +651,11 @@ begin
     exact hy' }
 end
 
-instance is_principal {R} [principal_ideal_domain R] {f : fraction_map R K}
+instance is_principal {R} [integral_domain R] [is_principal_ideal_ring R] {f : fraction_map R K}
   (I : fractional_ideal f) : (I : submodule R f.codomain).is_principal :=
 ⟨ begin
   obtain ⟨a, aI, ha⟩ := exists_eq_span_singleton_mul I,
+  haveI : is_principal aI := is_principal_ideal_ring.principal aI,
   have := a * f.to_map (generator aI),
   use a * f.to_map (generator aI),
   suffices : I = span_singleton (a * f.to_map (generator aI)),

--- a/src/ring_theory/ideals.lean
+++ b/src/ring_theory/ideals.lean
@@ -158,6 +158,13 @@ lemma span_singleton_lt_span_singleton [integral_domain β] {x y : β} :
 by rw [lt_iff_le_not_le, span_singleton_le_span_singleton, span_singleton_le_span_singleton,
   dvd_and_not_dvd_iff]
 
+lemma factors_decreasing [integral_domain β] (b₁ b₂ : β) (h₁ : b₁ ≠ 0) (h₂ : ¬ is_unit b₂) :
+  span ({b₁ * b₂} : set β) < span {b₁} :=
+lt_of_le_not_le (ideal.span_le.2 $ singleton_subset_iff.2 $
+  ideal.mem_span_singleton.2 ⟨b₂, rfl⟩) $ λ h,
+h₂ $ is_unit_of_dvd_one _ $ (mul_dvd_mul_iff_left h₁).1 $
+by rwa [mul_one, ← ideal.span_singleton_le_span_singleton]
+
 def quotient (I : ideal α) := I.quotient
 
 namespace quotient

--- a/src/ring_theory/principal_ideal_domain.lean
+++ b/src/ring_theory/principal_ideal_domain.lean
@@ -5,7 +5,31 @@ Author: Chris Hughes, Morenikeji Neri
 -/
 import ring_theory.noetherian
 import ring_theory.unique_factorization_domain
+/-!
+# Principal ideal rings and principal ideal domains
 
+A principal ideal ring (PIR) is a commutative ring in which all ideals are principal. A
+principal ideal domain (PID) is an integral domain which is a principal ideal ring.
+
+# Main definitions
+
+Note that for principal ideal domains, one should use
+`[integral domain R] [is_principal_ideal_ring R]`. There is no explicit definition of a PID.
+Theorems about PID's are in the `principal_ideal_ring` namespace.
+
+- `is_principal_ideal_ring`: a predicate on commutative rings, saying that every
+  ideal is principal.
+- `generator`: a generator of a principal ideal (or more generally submodule)
+- `to_unique_factorization_domain`: a noncomputable definition, putting a UFD structure on a PID.
+  Note that the definition of a UFD is currently not a predicate, as it contains data
+  of factorizations of non-zero elements.
+
+# Main results
+
+- `to_maximal_ideal`: a non-zero prime ideal in a PID is maximal.
+- `euclidean_domain.to_principal_ideal_domain` : a Euclidean domain is a PID.
+
+-/
 universes u v
 variables {R : Type u} {M : Type v}
 
@@ -20,6 +44,8 @@ class submodule.is_principal [ring R] [add_comm_group M] [module R M] (S : submo
 /-- A commutative ring is a principal ideal ring if all ideals are principal. -/
 class is_principal_ideal_ring (R : Type u) [comm_ring R] : Prop :=
 (principal : ∀ (S : ideal R), S.is_principal)
+
+attribute [instance] is_principal_ideal_ring.principal
 
 namespace submodule.is_principal
 
@@ -56,8 +82,6 @@ lemma to_maximal_ideal [integral_domain R] [is_principal_ideal_ring R] {S : idea
   [hpi : is_prime S] (hS : S ≠ ⊥) : is_maximal S :=
 is_maximal_iff.2 ⟨(ne_top_iff_one S).1 hpi.1, begin
   assume T x hST hxS hxT,
-  haveI := is_principal_ideal_ring.principal S,
-  haveI := is_principal_ideal_ring.principal T,
   cases (mem_iff_generator_dvd _).1 (hST $ generator_mem S) with z hz,
   cases hpi.2 (show generator T * z ∈ S, from hz ▸ generator_mem S),
   { have hTS : T ≤ S, rwa [← span_singleton_generator T, submodule.span_le, singleton_subset_iff],

--- a/src/ring_theory/principal_ideal_domain.lean
+++ b/src/ring_theory/principal_ideal_domain.lean
@@ -17,6 +17,7 @@ open_locale classical
 class submodule.is_principal [ring R] [add_comm_group M] [module R M] (S : submodule R M) : Prop :=
 (principal [] : ∃ a, S = span R {a})
 
+/-- A commutative ring is a principal ideal ring if all ideals are principal. -/
 class is_principal_ideal_ring (R : Type u) [comm_ring R] : Prop :=
 (principal : ∀ (S : ideal R), S.is_principal)
 
@@ -77,6 +78,7 @@ lemma mod_mem_iff {S : ideal R} {x y : R} (hy : y ∈ S) : x % y ∈ S ↔ x ∈
 ⟨λ hxy, div_add_mod x y ▸ ideal.add_mem S (ideal.mul_mem_right S hy) hxy,
   λ hx, (mod_eq_sub_mul_div x y).symm ▸ ideal.sub_mem S hx (ideal.mul_mem_right S hy)⟩
 
+@[priority 100] -- see Note [lower instance priority]
 instance euclidean_domain.to_principal_ideal_domain : is_principal_ideal_ring R :=
 { principal := λ S, by exactI
     ⟨if h : {x : R | x ∈ S ∧ x ≠ 0}.nonempty
@@ -100,7 +102,6 @@ instance euclidean_domain.to_principal_ideal_domain : is_principal_ideal_ring R 
 
 end
 
-
 namespace principal_ideal_ring
 open is_principal_ideal_ring
 
@@ -114,18 +115,6 @@ begin
   rw [← finset.coe_singleton],
   exact ⟨{a}, submodule.ext' rfl⟩
 end⟩
-
-section
-open_locale classical
-
-lemma factors_decreasing (b₁ b₂ : R) (h₁ : b₁ ≠ 0) (h₂ : ¬ is_unit b₂) :
-  submodule.span R ({b₁ * b₂} : set R) < submodule.span R {b₁} :=
-lt_of_le_not_le (ideal.span_le.2 $ singleton_subset_iff.2 $
-  ideal.mem_span_singleton.2 ⟨b₂, rfl⟩) $ λ h,
-h₂ $ is_unit_of_dvd_one _ $ (mul_dvd_mul_iff_left h₁).1 $
-by rwa [mul_one, ← ideal.span_singleton_le_span_singleton]
-
-end
 
 lemma is_maximal_of_irreducible {p : R} (hp : irreducible p) :
   ideal.is_maximal (span R ({p} : set R)) :=
@@ -150,6 +139,7 @@ by rw [associates.irreducible_mk_iff, associates.prime_mk, irreducible_iff_prime
 section
 open_locale classical
 
+/-- `factors a` is a multiset of irreducible elements whose product is `a`, up to units -/
 noncomputable def factors (a : R) : multiset R :=
 if h : a = 0 then ∅ else classical.some
   (is_noetherian_ring.exists_factors a h)

--- a/src/ring_theory/principal_ideal_domain.lean
+++ b/src/ring_theory/principal_ideal_domain.lean
@@ -17,14 +17,9 @@ open_locale classical
 class submodule.is_principal [ring R] [add_comm_group M] [module R M] (S : submodule R M) : Prop :=
 (principal [] : ∃ a, S = span R {a})
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
-class principal_ideal_domain (R : Type u) extends integral_domain R :=
+class is_principal_ideal_ring (R : Type u) [comm_ring R] : Prop :=
 (principal : ∀ (S : ideal R), S.is_principal)
-end prio
 
--- see Note [lower instance priority]
-attribute [instance, priority 500] principal_ideal_domain.principal
 namespace submodule.is_principal
 
 variables [comm_ring R] [add_comm_group M] [module R M]
@@ -55,12 +50,13 @@ end submodule.is_principal
 namespace is_prime
 open submodule.is_principal ideal
 
-lemma to_maximal_ideal [principal_ideal_domain R] {S : ideal R}
+-- TODO -- for a non-ID should prove that if p < q then q maximal; 0 isn't prime in a non-ID
+lemma to_maximal_ideal [integral_domain R] [is_principal_ideal_ring R] {S : ideal R}
   [hpi : is_prime S] (hS : S ≠ ⊥) : is_maximal S :=
 is_maximal_iff.2 ⟨(ne_top_iff_one S).1 hpi.1, begin
   assume T x hST hxS hxT,
-  haveI := principal_ideal_domain.principal S,
-  haveI := principal_ideal_domain.principal T,
+  haveI := is_principal_ideal_ring.principal S,
+  haveI := is_principal_ideal_ring.principal T,
   cases (mem_iff_generator_dvd _).1 (hST $ generator_mem S) with z hz,
   cases hpi.2 (show generator T * z ∈ S, from hz ▸ generator_mem S),
   { have hTS : T ≤ S, rwa [← span_singleton_generator T, submodule.span_le, singleton_subset_iff],
@@ -81,8 +77,7 @@ lemma mod_mem_iff {S : ideal R} {x y : R} (hy : y ∈ S) : x % y ∈ S ↔ x ∈
 ⟨λ hxy, div_add_mod x y ▸ ideal.add_mem S (ideal.mul_mem_right S hy) hxy,
   λ hx, (mod_eq_sub_mul_div x y).symm ▸ ideal.sub_mem S hx (ideal.mul_mem_right S hy)⟩
 
-@[priority 100] -- see Note [lower instance priority]
-instance euclidean_domain.to_principal_ideal_domain : principal_ideal_domain R :=
+instance euclidean_domain.to_principal_ideal_domain : is_principal_ideal_ring R :=
 { principal := λ S, by exactI
     ⟨if h : {x : R | x ∈ S ∧ x ≠ 0}.nonempty
     then
@@ -106,14 +101,16 @@ instance euclidean_domain.to_principal_ideal_domain : principal_ideal_domain R :
 end
 
 
-namespace principal_ideal_domain
-variables [principal_ideal_domain R]
+namespace principal_ideal_ring
+open is_principal_ideal_ring
+
+variables [integral_domain R] [is_principal_ideal_ring R]
 
 @[priority 100] -- see Note [lower instance priority]
 instance is_noetherian_ring : is_noetherian_ring R :=
 ⟨assume s : ideal R,
 begin
-  rcases (principal s).principal with ⟨a, rfl⟩,
+  rcases (is_principal_ideal_ring.principal s).principal with ⟨a, rfl⟩,
   rw [← finset.coe_singleton],
   exact ⟨{a}, submodule.ext' rfl⟩
 end⟩
@@ -177,4 +174,4 @@ noncomputable def to_unique_factorization_domain : unique_factorization_domain R
 
 end
 
-end principal_ideal_domain
+end principal_ideal_ring


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->
tl;dr: I remove the `principal_ideal_domain` class and replace it with the `is_principal_ideal_ring` predicate, which requires an instance of [comm_ring]. To get principal ideal domains back, use [integral_domain] and `is_principal_ideal_ring`. 

## Rethinking the algebra heirarchy

There are literally 30+ predicates that one can put on a commutative ring in graduate level algebra (I went through a textbook and counted). Note that currently classes like `principal_ideal_domain` are not implemented as predicates -- they extend rings and contain data.

A very important predicate (a current target for me, and something which we need for the theory of local fields (the correct generalisation of of the p-adic numbers)) is that of a discrete valuation ring (DVR). Johan initially suggested that it should extend `principal_ideal_domain` and `local_ring` (https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/DVRs/near/188143031), but these classes have overlapping instances, and neither class was made with the old_structure_cmd; old structures struggle to extend new structures (https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/DVRs/near/200764626). Furthermore, trying to get local_ring to be an old structure is not as easy as one would expect (https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/DVRs/near/200765476). 

Both Scott and Johan suggested (in the DVR thread above) that perhaps we should move to predicates. We already have an `is_local_ring` predicate (although it's not a class); this PR creates an `is_principal_ideal_ring` predicate. My understanding of Johan's thoughts is that setting things up with predicates will remove a lot of potential diamond headaches. Note that the topology hierarchy (stuff like `t2_space`) all uses predicates.

One thing that could be done is to make a predicate `is_integral_domain`, built on top of `comm_ring`. One could even have `is_comm_ring` built on top of `ring`. Indeed, one could even have `is_comm_group` built on top of `group`. It seems to me that one has to decide what the "basic objects" are. A computer scientist might argue that one should take the minimal structure with data and then predicatise on top of this, but for me the theory of commutative rings is completely different to the theory of non-commutative rings; they are both big areas, and they study different kinds of question. The question of whether `is_integral_domain` would be better than `integral_domain` is less clear to me: I am not sure that `integral_domain` is causing any problems for us right now so I am minded to leave it for now.

If this PR gets accepted in some form then I'll go on to do DVR's.

## Comments about this PR

Making `is_PIR` a predicate enabled the linter to spot that the lemma `factors_decreasing` does not use the fact that R is a PID! I moved it out of the file and into somewhere more appropriate.

## Questions I was not sure about:

1) if we call the predicate `is_principal_ideal_ring` then we get `is_principal_ideal_ring.principal` (the field for the structure). But do we want the namespace to be called `principal_ideal_ring`?

2) Do we want `is_principal_ideal_domain`? Computer scientists might just say "it's just [integral_domain R] [is_principal_ideal_ring R]". Someone like Patrick might then counter that our system looks stupid to a mathematician because PIDs are much more common objects than PIRs so why are we focussing on PIRs and not even mentioning PIDs? Should we not even have a `principal_ideal_domain` namespace?

3) Thinking further ahead, if these ideas are deemed worth a try: `is_local_ring` is a Prop, but it's not a class (it's just
```
def is_local_ring (α : Type u) [comm_ring α] : Prop :=
((0:α) ≠ 1) ∧ ∀ (a : α), (is_unit a) ∨ (is_unit (1 - a))
```
Should it be made into a class, so we can write

```
class is_discrete_valuation_ring (R : Type u) [integral_domain R] [is_principal_ideal_ring R] [is_local_ring R] : Prop :=
(non_field : local_ring.maximal_ideal R ≠ ⊥ )
```
?