### PR TITLE
[Merged by Bors] - fix(tactic/group): bugfix for inverse of 1

### DIFF
--- a/src/tactic/group.lean
+++ b/src/tactic/group.lean
@@ -43,6 +43,8 @@ meta def aux_group₁ (locat : loc) : tactic unit :=
   simp_core {} skip tt [
   expr ``(mul_one),
   expr ``(one_mul),
+  expr ``(one_pow),
+  expr ``(one_gpow),
   expr ``(sub_self),
   expr ``(add_neg_self),
   expr ``(neg_add_self),

--- a/test/group.lean
+++ b/test/group.lean
@@ -65,9 +65,12 @@ end
 example (n m : ℤ) (a b : G) : a^n*b^n*a^n*a^n*a^-n*a^-n*b^-n*a^-n = 1 :=
 by group
 
--- Test that group does not make simple equalities harder
+-- Test that group deals with `1⁻¹` properly
 
-example {G : Type*} [group G] (x : G) (h : x = 1) : x = 1 :=
+example (x y : G) : (x⁻¹ * (x * y) * y⁻¹)⁻¹ = 1 :=
+by group
+
+example (x : G) (h : x = 1) : x = 1 :=
 begin
   group,
   exact h,

--- a/test/group.lean
+++ b/test/group.lean
@@ -64,3 +64,11 @@ end
 
 example (n m : ℤ) (a b : G) : a^n*b^n*a^n*a^n*a^-n*a^-n*b^-n*a^-n = 1 :=
 by group
+
+-- Test that group does not make simple equalities harder
+
+example {G : Type*} [group G] (x : G) (h : x = 1) : x = 1 :=
+begin
+  group,
+  exact h,
+end


### PR DESCRIPTION
The new group tactic made goals like

```lean
example {G : Type*} [group G] (x : G) (h : x = 1) : x = 1 :=
begin
  group, -- x * 1 ^(-1) = 1
  exact h,
end
```

worse, presumably from trying to move the rhs to the lhs we end up with `x * 1^(-1) = 1`, we add a couple more lemmas to try to fix this.

---
<!-- put comments you want to keep out of the PR commit here -->
