### PR TITLE
[Merged by Bors] - feat(analysis/calculus): C^1 implies strictly differentiable

### DIFF
--- a/src/analysis/calculus/extend_deriv.lean
+++ b/src/analysis/calculus/extend_deriv.lean
@@ -29,66 +29,6 @@ open_locale topological_space
 local attribute [mono] prod_mono
 
 /-- If a function `f` is differentiable in a convex open set and continuous on its closure, and its
-derivative converges to `0` at a point on the boundary, then `f` is differentiable there with
-derivative `0`. This is an auxiliary statement to prove the same result for any value of the
-derivative, in `has_fderiv_at_boundary_of_tendsto_fderiv`. -/
-theorem has_fderiv_at_boundary_of_tendsto_fderiv_aux {f : E → F} {s : set E} {x : E}
-  (f_diff : differentiable_on ℝ f s) (s_conv : convex s) (s_open : is_open s)
-  (f_cont : ∀y ∈ closure s, continuous_within_at f s y)
-  (h : tendsto (λy, fderiv ℝ f y) (nhds_within x s) (𝓝 0)) :
-  has_fderiv_within_at f (0 : E →L[ℝ] F) (closure s) x :=
-begin
-  classical,
-  -- one can assume without loss of generality that `x` belongs to the closure of `s`, as the
-  -- statement is empty otherwise
-  by_cases hx : x ∉ closure s,
-  { rw ← closure_closure at hx, exact has_fderiv_within_at_of_not_mem_closure hx },
-  push_neg at hx,
-  rw [has_fderiv_within_at, has_fderiv_at_filter, asymptotics.is_o_iff],
-  /- One needs to show that `∥f y - f x∥ ≤ ε ∥y - x∥` for `y` close to `x` in `closure s`, where
-  `ε` is an arbitrary positive constant. By continuity of the functions, it suffices to prove this
-  for nearby points inside `s`. In a neighborhood of `x`, the derivative of `f` is arbitrarily small
-  by assumption. The mean value inequality ensures that `f` is `ε`-Lipschitz there, concluding the
-  proof. -/
-  assume ε ε_pos,
-  obtain ⟨δ, δ_pos, hδ⟩ : ∃ δ > 0, ∀ y ∈ s, dist y x < δ → ∥fderiv ℝ f y∥ < ε,
-    by simpa [dist_zero_right] using tendsto_nhds_within_nhds.1 h ε ε_pos,
-  set B := ball x δ,
-  suffices : ∀ y ∈ B ∩ (closure s), ∥f y - f x∥ ≤ ε * ∥y - x∥,
-    from mem_nhds_within_iff.2 ⟨δ, δ_pos, λy hy, by simpa using this y hy⟩,
-  suffices : ∀ p : E × E, p ∈ closure ((B ∩ s).prod (B ∩ s)) → ∥f p.2 - f p.1∥ ≤ ε * ∥p.2 - p.1∥,
-  { rw closure_prod_eq at this,
-    intros y y_in,
-    apply this ⟨x, y⟩,
-    have : B ∩ closure s ⊆ closure (B ∩ s), from closure_inter_open is_open_ball,
-    exact ⟨this ⟨mem_ball_self δ_pos, hx⟩, this y_in⟩ },
-  have key : ∀ p : E × E, p ∈ (B ∩ s).prod (B ∩ s) → ∥f p.2 - f p.1∥ ≤ ε * ∥p.2 - p.1∥,
-  { rintros ⟨u, v⟩ ⟨u_in, v_in⟩,
-    have conv : convex (B ∩ s) := (convex_ball _ _).inter s_conv,
-    have diff : differentiable_on ℝ f (B ∩ s) := f_diff.mono (inter_subset_right _ _),
-    refine conv.norm_image_sub_le_of_norm_fderiv_within_le diff (λz z_in, _) u_in v_in,
-    convert le_of_lt (hδ _ z_in.2 z_in.1),
-    have op : is_open (B ∩ s) := is_open_inter is_open_ball s_open,
-    rw differentiable_at.fderiv_within _ (op.unique_diff_on z z_in),
-    exact (diff z z_in).differentiable_at (mem_nhds_sets op z_in) },
-  rintros ⟨u, v⟩ uv_in,
-  refine continuous_within_at.closure_le uv_in _ _ key,
-  all_goals { -- common start for both continuity proofs
-    have : (B ∩ s).prod (B ∩ s) ⊆ s.prod s, by mono ; exact inter_subset_right _ _,
-    obtain ⟨u_in, v_in⟩ : u ∈ closure s ∧ v ∈ closure s,
-      by simpa [closure_prod_eq] using closure_mono this uv_in,
-    apply continuous_within_at.mono _ this,
-    simp only [continuous_within_at, nhds_prod_eq] },
-  { rw nhds_within_prod_eq,
-    exact tendsto.comp continuous_norm.continuous_at
-      ((tendsto.comp (f_cont v v_in) tendsto_snd).sub $ tendsto.comp (f_cont u u_in) tendsto_fst) },
-  { apply tendsto_nhds_within_of_tendsto_nhds,
-    rw nhds_prod_eq,
-    exact tendsto_const_nhds.mul
-      (tendsto.comp continuous_norm.continuous_at $ tendsto_snd.sub tendsto_fst) },
-end
-
-/-- If a function `f` is differentiable in a convex open set and continuous on its closure, and its
 derivative converges to a limit `f'` at a point on the boundary, then `f` is differentiable there
 with derivative `f'`. -/
 theorem has_fderiv_at_boundary_of_tendsto_fderiv {f : E → F} {s : set E} {x : E} {f' : E →L[ℝ] F}
@@ -97,33 +37,63 @@ theorem has_fderiv_at_boundary_of_tendsto_fderiv {f : E → F} {s : set E} {x : 
   (h : tendsto (λy, fderiv ℝ f y) (nhds_within x s) (𝓝 f')) :
   has_fderiv_within_at f f' (closure s) x :=
 begin
-  /- We subtract `f'` to define a new function `g` for which `g' = 0`, for which differentiability
-  is proved `has_fderiv_at_boundary_of_differentiable_aux`. Then, we just need to glue together the
-  pieces, expressing back `f` in terms of `g`. -/
-  let g := λy, f y - f' y,
-  have diff_g : differentiable_on ℝ g s :=
-    f_diff.sub (f'.differentiable.comp differentiable_id).differentiable_on,
-  have cont_g : ∀y ∈ closure s, continuous_within_at g s y :=
-    λy hy, tendsto.sub (f_cont y hy) (f'.continuous.comp continuous_id).continuous_within_at,
-  have A : ∀y ∈ s, fderiv ℝ f y - f' = fderiv ℝ g y,
-  { assume y hy,
-    have : has_fderiv_at f (fderiv ℝ f y) y :=
-      (differentiable_within_at.differentiable_at (f_diff y hy) (mem_nhds_sets s_open hy)).has_fderiv_at,
-    have : has_fderiv_at g (fderiv ℝ f y - f') y :=
-      this.sub (f'.has_fderiv_at.comp y (has_fderiv_at_id y)),
-    exact this.fderiv.symm },
-  have B : tendsto (λy, fderiv ℝ f y - f') (nhds_within x s) (𝓝 (f' - f')) :=
-    h.sub tendsto_const_nhds,
-  have : tendsto (λy, fderiv ℝ g y) (nhds_within x s) (𝓝 0),
-  { have : f' - f' = 0, by simp,
-    rw this at B,
-    apply tendsto.congr' _ B,
-    filter_upwards [self_mem_nhds_within] A },
-  have : has_fderiv_within_at g (0 : E →L[ℝ] F) (closure s) x :=
-    has_fderiv_at_boundary_of_tendsto_fderiv_aux diff_g s_conv s_open cont_g this,
-  convert this.add f'.has_fderiv_within_at,
-  { ext y, simp [g] },
-  { simp }
+  classical,
+  -- one can assume without loss of generality that `x` belongs to the closure of `s`, as the
+  -- statement is empty otherwise
+  by_cases hx : x ∉ closure s,
+  { rw ← closure_closure at hx, exact has_fderiv_within_at_of_not_mem_closure hx },
+  push_neg at hx,
+  rw [has_fderiv_within_at, has_fderiv_at_filter, asymptotics.is_o_iff],
+  /- One needs to show that `∥f y - f x - f' (y - x)∥ ≤ ε ∥y - x∥` for `y` close to `x` in `closure
+  s`, where `ε` is an arbitrary positive constant. By continuity of the functions, it suffices to
+  prove this for nearby points inside `s`. In a neighborhood of `x`, the derivative of `f` is
+  arbitrarily close to f' by assumption. The mean value inequality completes the proof. -/
+  assume ε ε_pos,
+  obtain ⟨δ, δ_pos, hδ⟩ : ∃ δ > 0, ∀ y ∈ s, dist y x < δ → ∥fderiv ℝ f y - f'∥ < ε,
+    by simpa [dist_zero_right] using tendsto_nhds_within_nhds.1 h ε ε_pos,
+  set B := ball x δ,
+  suffices : ∀ y ∈ B ∩ (closure s), ∥f y - f x - (f' y - f' x)∥ ≤ ε * ∥y - x∥,
+    from mem_nhds_within_iff.2 ⟨δ, δ_pos, λy hy, by simpa using this y hy⟩,
+  suffices : ∀ p : E × E, p ∈ closure ((B ∩ s).prod (B ∩ s)) → ∥f p.2 - f p.1 - (f' p.2 - f' p.1)∥
+    ≤ ε * ∥p.2 - p.1∥,
+  { rw closure_prod_eq at this,
+    intros y y_in,
+    apply this ⟨x, y⟩,
+    have : B ∩ closure s ⊆ closure (B ∩ s), from closure_inter_open is_open_ball,
+    exact ⟨this ⟨mem_ball_self δ_pos, hx⟩, this y_in⟩ },
+  have key : ∀ p : E × E, p ∈ (B ∩ s).prod (B ∩ s) → ∥f p.2 - f p.1 - (f' p.2 - f' p.1)∥
+    ≤ ε * ∥p.2 - p.1∥,
+  { rintros ⟨u, v⟩ ⟨u_in, v_in⟩,
+    have conv : convex (B ∩ s) := (convex_ball _ _).inter s_conv,
+    have diff : differentiable_on ℝ f (B ∩ s) := f_diff.mono (inter_subset_right _ _),
+    have bound : ∀ z ∈ (B ∩ s), ∥fderiv_within ℝ f (B ∩ s) z - f'∥ ≤ ε,
+    { intros z z_in,
+      convert le_of_lt (hδ _ z_in.2 z_in.1),
+      have op : is_open (B ∩ s) := is_open_inter is_open_ball s_open,
+      rw differentiable_at.fderiv_within _ (op.unique_diff_on z z_in),
+      exact (diff z z_in).differentiable_at (mem_nhds_sets op z_in) },
+    simpa using conv.norm_image_sub_le_of_norm_fderiv_within_le' diff bound u_in v_in },
+  rintros ⟨u, v⟩ uv_in,
+  refine continuous_within_at.closure_le uv_in _ _ key,
+  have f_cont' : ∀y ∈ closure s, continuous_within_at (f - f') s y,
+  { intros y y_in,
+    exact tendsto.sub (f_cont y y_in) (f'.cont.continuous_within_at) },
+  all_goals { -- common start for both continuity proofs
+    have : (B ∩ s).prod (B ∩ s) ⊆ s.prod s, by mono ; exact inter_subset_right _ _,
+    obtain ⟨u_in, v_in⟩ : u ∈ closure s ∧ v ∈ closure s,
+      by simpa [closure_prod_eq] using closure_mono this uv_in,
+    apply continuous_within_at.mono _ this,
+    simp only [continuous_within_at, nhds_prod_eq] },
+  rw nhds_within_prod_eq,
+  { have : f v - f u - (f' v - f' u) = f v - f' v - (f u - f' u) := by abel,
+    rw this,
+    convert tendsto.comp continuous_norm.continuous_at
+      ((tendsto.comp (f_cont' v v_in) tendsto_snd).sub $ tendsto.comp (f_cont' u u_in) tendsto_fst),
+    intros, simp, abel },
+  { apply tendsto_nhds_within_of_tendsto_nhds,
+    rw nhds_prod_eq,
+    exact tendsto_const_nhds.mul
+      (tendsto.comp continuous_norm.continuous_at $ tendsto_snd.sub tendsto_fst) },
 end
 
 /-- If a function is differentiable on the right of a point `a : ℝ`, continuous at `a`, and

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -5,7 +5,6 @@ Authors: Sébastien Gouëzel, Yury Kudryashov
 -/
 import analysis.calculus.local_extr
 import analysis.convex.topology
-import analysis.normed_space.dual
 
 /-!
 # The mean value inequality and equalities

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -13,7 +13,8 @@ In this file we prove the following facts:
 
 * `convex.norm_image_sub_le_of_norm_deriv_le` : if `f` is differentiable on a convex set `s`
   and the norm of its derivative is bounded by `C`, then `f` is Lipschitz continuous on `s` with
-  constant `C`.
+  constant `C`; also a variant in which what is bounded by `C` is the norm of the difference of the
+  derivative from a fixed linear map.
 
 * `image_le_of*`, `image_norm_le_of_*` : several similar lemmas deducing `f x ≤ B x` or
   `∥f x∥ ≤ B x` from upper estimates on `f'` or `∥f'∥`, respectively. These lemmas differ by
@@ -40,6 +41,8 @@ In this file we prove the following facts:
 
 * `exists_has_deriv_at_eq_slope` and `exists_deriv_eq_slope` : Lagrange's Mean Value Theorem.
 
+* `domain_mvt` : Lagrange's Mean Value Theorem, applied to a segment in a convex domain.
+
 * `convex.image_sub_lt_mul_sub_of_deriv_lt`, `convex.mul_sub_lt_image_sub_of_lt_deriv`,
   `convex.image_sub_le_mul_sub_of_deriv_le`, `convex.mul_sub_le_image_sub_of_le_deriv`,
   if `∀ x, C (</≤/>/≥) (f' x)`, then `C * (y - x) (</≤/>/≥) (f y - f x)` whenever `x < y`.
@@ -52,6 +55,9 @@ In this file we prove the following facts:
 
 * `convex_on_of_deriv_mono`, `convex_on_of_deriv2_nonneg` : if the derivative of a function
   is increasing or its second derivative is nonnegative, then the original function is convex.
+
+* `strict_fderiv_of_cont_diff` : a C^1 function over the reals is strictly differentiable.  (This
+  is a corollary of the mean value inequality.)
 -/
 
 
@@ -827,8 +833,7 @@ convex_on_of_deriv2_nonneg convex_univ hf'.continuous.continuous_on hf'.differen
 /-- Lagrange's Mean Value Theorem, applied to convex domains. -/
 theorem domain_mvt
   {f : E → ℝ} {s : set E} {x y : E} {f' : E → (E →L[ℝ] ℝ)}
-  (hf : ∀ x ∈ s, has_fderiv_within_at f (f' x) s x)
-  (hs : convex s) (xs : x ∈ s) (ys : y ∈ s) :
+  (hf : ∀ x ∈ s, has_fderiv_within_at f (f' x) s x) (hs : convex s) (xs : x ∈ s) (ys : y ∈ s) :
   ∃ z ∈ segment x y, f y - f x = f' z (y - x) :=
 begin
   have hIccIoo := @Ioo_subset_Icc_self ℝ _ 0 1,
@@ -871,8 +876,7 @@ end
 /-- Over the reals, a continuously differentiable function is strictly differentiable. -/
 lemma strict_fderiv_of_cont_diff
   {f : E → F} {s : set E}  {x : E} {f' : E → (E →L[ℝ] F)}
-  (hf : ∀ x ∈ s, has_fderiv_within_at f (f' x) s x)
-  (hcont : continuous_on f' s) (hs : is_open s) (xs : x ∈ s) :
+  (hf : ∀ x ∈ s, has_fderiv_within_at f (f' x) s x) (hcont : continuous_on f' s) (hs : s ∈ 𝓝 x) :
   has_strict_fderiv_at f (f' x) x :=
 begin
 -- turn little-o definition of strict_fderiv into an epsilon-delta statement
@@ -881,8 +885,8 @@ begin
   intros c hc,
   refine is_O_with.of_bound (eventually_iff.mpr (mem_nhds_iff.mpr _)),
 -- the correct ε is the modulus of continuity of f', shrunk to be inside s
-  rcases (metric.continuous_on_iff.mp hcont x xs c hc) with ⟨ε₁, H₁, hcont'⟩,
-  rcases (metric.is_open_iff.mp hs x xs) with ⟨ε₂, H₂, hε₂⟩,
+  rcases (metric.continuous_on_iff.mp hcont x (mem_of_nhds hs) c hc) with ⟨ε₁, H₁, hcont'⟩,
+  rcases (mem_nhds_iff.mp hs) with ⟨ε₂, H₂, hε₂⟩,
   use min ε₁ ε₂, refine ⟨lt_min H₁ H₂, _⟩,
 -- mess with ε construction
   set t := ball x (min ε₁ ε₂),

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -469,7 +469,7 @@ hs.norm_image_sub_le_of_norm_has_fderiv_within_le
 (λ x hx, (hf x hx).has_fderiv_at.has_fderiv_within_at) bound xs ys
 
 /-- Variant of the mean value inequality on a convex set, using a bound on the difference between
-the derivative and a fixed linear map, rather than a bound on the deriviative itself. Version with
+the derivative and a fixed linear map, rather than a bound on the derivative itself. Version with
 `has_fderiv_within`. -/
 theorem convex.norm_image_sub_le_of_norm_has_fderiv_within_le'
   {f : E → F} {C : ℝ} {s : set E} {x y : E} {f' : E → (E →L[ℝ] F)} {φ : E →L[ℝ] F}
@@ -880,14 +880,13 @@ lemma strict_fderiv_of_cont_diff
   has_strict_fderiv_at f (f' x) x :=
 begin
 -- turn little-o definition of strict_fderiv into an epsilon-delta statement
-  change is_o _ _ _,
   apply is_o_iff_forall_is_O_with.mpr,
   intros c hc,
   refine is_O_with.of_bound (eventually_iff.mpr (mem_nhds_iff.mpr _)),
 -- the correct ε is the modulus of continuity of f', shrunk to be inside s
   rcases (metric.continuous_on_iff.mp hcont x (mem_of_nhds hs) c hc) with ⟨ε₁, H₁, hcont'⟩,
   rcases (mem_nhds_iff.mp hs) with ⟨ε₂, H₂, hε₂⟩,
-  use min ε₁ ε₂, refine ⟨lt_min H₁ H₂, _⟩,
+  refine ⟨min ε₁ ε₂, lt_min H₁ H₂, _⟩,
 -- mess with ε construction
   set t := ball x (min ε₁ ε₂),
   have hts : t ⊆ s := λ _ hy, hε₂ (ball_subset_ball (min_le_right ε₁ ε₂) hy),
@@ -895,16 +894,14 @@ begin
     λ y yt, has_fderiv_within_at.mono (hf y (hts yt)) hts,
   have hconv := convex_ball x (min ε₁ ε₂),
 -- simplify formulas involving the product E × E
-  change _ → _, rintros ⟨a, b⟩ h,
+  rintros ⟨a, b⟩ h,
   simp only [mem_set_of_eq, map_sub],
   have hab : a ∈ t ∧ b ∈ t := by rwa [mem_ball, prod.dist_eq, max_lt_iff] at h,
 -- exploit the choice of ε as the modulus of continuity of f'
   have hf' : ∀ x' ∈ t, ∥f' x' - f' x∥ ≤ c,
   { intros x' H',
-    change dist (f' x') (f' x) ≤ c,
     refine le_of_lt (hcont' x' (hts H') _),
     exact ball_subset_ball (min_le_left ε₁ ε₂) H' },
 -- apply mean value theorem
-  have := convex.norm_image_sub_le_of_norm_has_fderiv_within_le' Hf hf' hconv hab.2 hab.1,
-  simpa,
+  simpa using convex.norm_image_sub_le_of_norm_has_fderiv_within_le' Hf hf' hconv hab.2 hab.1,
 end

--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
-import analysis.calculus.fderiv
+import analysis.calculus.mean_value
 
 /-!
 # Higher differentiability
@@ -1659,3 +1659,44 @@ lemma times_cont_diff.sub {n : with_top ℕ} {f g : E → F}
   (hf : times_cont_diff 𝕜 n f) (hg : times_cont_diff 𝕜 n g) :
   times_cont_diff 𝕜 n (λx, f x - g x) :=
 hf.add hg.neg
+
+section reals
+/-- ### Results over ℝ
+  The results in this section rely on the Mean Value Theorem, and therefore hold only over ℝ (and
+  its extension fields such as ℂ). -/
+
+variables
+{E' : Type*} [normed_group E'] [normed_space ℝ E']
+{F' : Type*} [normed_group F'] [normed_space ℝ F']
+
+/-- If a function has a Taylor series at order at least 1, then at points in the interior of the
+    domain of definition, the term of order 1 of this series is a strict derivative of f. -/
+lemma has_ftaylor_series_up_to_on.has_strict_fderiv_at
+  {s : set E'} {f : E' → F'} {x : E'} {p : E' → formal_multilinear_series ℝ E' F'} {n : with_top ℕ}
+  (hf : has_ftaylor_series_up_to_on n f p s) (hn : 1 ≤ n) (hs : s ∈ nhds x) :
+  has_strict_fderiv_at f ((continuous_multilinear_curry_fin1 ℝ E' F') (p x 1)) x :=
+begin
+  let f' := λ x, (continuous_multilinear_curry_fin1 ℝ E' F') (p x 1),
+  have hf' : ∀ x, x ∈ s → has_fderiv_within_at f (f' x) s x :=
+    λ x, has_ftaylor_series_up_to_on.has_fderiv_within_at hf hn,
+  have hcont : continuous_on f' s :=
+    (continuous_multilinear_curry_fin1 ℝ E' F').continuous.comp_continuous_on (hf.cont 1 hn),
+  exact strict_fderiv_of_cont_diff hf' hcont hs,
+end
+
+lemma times_cont_diff_on.has_strict_fderiv_at
+  {s : set E'} {f : E' → F'} {x : E'} {n : with_top ℕ} (hf : times_cont_diff_on ℝ n f s) (hn : 1 ≤ n)
+  (hs : s ∈ nhds x) : ∃ (f' : E' →L[ℝ] F'), has_strict_fderiv_at f f' x :=
+begin
+  rcases (hf 1 hn x (mem_of_nhds hs)) with ⟨u, H, p, hp⟩,
+  use (continuous_multilinear_curry_fin1 ℝ E' F') (p x 1),
+  refine hp.has_strict_fderiv_at (by norm_num) _,
+  exact continuous_on.nhds_of_nhds_within_of_nhds hs H,
+end
+
+lemma times_cont_diff.has_strict_fderiv_at
+  {f : E' → F'} {x : E'} {n : with_top ℕ} (hf : times_cont_diff ℝ n f) (hn : 1 ≤ n) :
+  ∃ (f' : E' →L[ℝ] F'), has_strict_fderiv_at f f' x :=
+times_cont_diff_on.has_strict_fderiv_at (times_cont_diff_on_univ.mpr hf) hn (nhds x).univ_sets
+
+end reals

--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -1661,19 +1661,21 @@ lemma times_cont_diff.sub {n : with_top ℕ} {f g : E → F}
 hf.add hg.neg
 
 section reals
-/-- ### Results over ℝ
-  The results in this section rely on the Mean Value Theorem, and therefore hold only over ℝ (and
-  its extension fields such as ℂ). -/
+/-!
+### Results over `ℝ`
+  The results in this section rely on the Mean Value Theorem, and therefore hold only over `ℝ` (and
+  its extension fields such as `ℂ`).
+-/
 
 variables
 {E' : Type*} [normed_group E'] [normed_space ℝ E']
 {F' : Type*} [normed_group F'] [normed_space ℝ F']
 
 /-- If a function has a Taylor series at order at least 1, then at points in the interior of the
-    domain of definition, the term of order 1 of this series is a strict derivative of f. -/
+    domain of definition, the term of order 1 of this series is a strict derivative of `f`. -/
 lemma has_ftaylor_series_up_to_on.has_strict_fderiv_at
   {s : set E'} {f : E' → F'} {x : E'} {p : E' → formal_multilinear_series ℝ E' F'} {n : with_top ℕ}
-  (hf : has_ftaylor_series_up_to_on n f p s) (hn : 1 ≤ n) (hs : s ∈ nhds x) :
+  (hf : has_ftaylor_series_up_to_on n f p s) (hn : 1 ≤ n) (hs : s ∈ 𝓝 x) :
   has_strict_fderiv_at f ((continuous_multilinear_curry_fin1 ℝ E' F') (p x 1)) x :=
 begin
   let f' := λ x, (continuous_multilinear_curry_fin1 ℝ E' F') (p x 1),
@@ -1684,19 +1686,22 @@ begin
   exact strict_fderiv_of_cont_diff hf' hcont hs,
 end
 
-lemma times_cont_diff_on.has_strict_fderiv_at
-  {s : set E'} {f : E' → F'} {x : E'} {n : with_top ℕ} (hf : times_cont_diff_on ℝ n f s) (hn : 1 ≤ n)
-  (hs : s ∈ nhds x) : ∃ (f' : E' →L[ℝ] F'), has_strict_fderiv_at f f' x :=
+/-- If a function is `C^n` with `1 ≤ n` on a domain, then at points in the interior of the
+    domain of definition, the derivative of `f` is also a strict derivative. -/
+lemma times_cont_diff_on.has_strict_fderiv_at  {s : set E'} {f : E' → F'} {x : E'} {n : with_top ℕ}
+  (hf : times_cont_diff_on ℝ n f s) (hn : 1 ≤ n) (hs : s ∈ 𝓝 x) :
+  has_strict_fderiv_at f (fderiv ℝ f x) x :=
 begin
   rcases (hf 1 hn x (mem_of_nhds hs)) with ⟨u, H, p, hp⟩,
-  use (continuous_multilinear_curry_fin1 ℝ E' F') (p x 1),
-  refine hp.has_strict_fderiv_at (by norm_num) _,
-  exact nhds_of_nhds_within_of_nhds hs H,
+  have := hp.has_strict_fderiv_at (by norm_num) (nhds_of_nhds_within_of_nhds hs H),
+  convert this,
+  exact this.has_fderiv_at.fderiv
 end
 
+/-- If a function is `C^n` with `1 ≤ n`, then the derivative of `f` is also a strict derivative. -/
 lemma times_cont_diff.has_strict_fderiv_at
   {f : E' → F'} {x : E'} {n : with_top ℕ} (hf : times_cont_diff ℝ n f) (hn : 1 ≤ n) :
-  ∃ (f' : E' →L[ℝ] F'), has_strict_fderiv_at f f' x :=
-times_cont_diff_on.has_strict_fderiv_at (times_cont_diff_on_univ.mpr hf) hn (nhds x).univ_sets
+  has_strict_fderiv_at f (fderiv ℝ f x) x :=
+times_cont_diff_on.has_strict_fderiv_at (times_cont_diff_on_univ.mpr hf) hn (𝓝 x).univ_sets
 
 end reals

--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -1691,7 +1691,7 @@ begin
   rcases (hf 1 hn x (mem_of_nhds hs)) with ⟨u, H, p, hp⟩,
   use (continuous_multilinear_curry_fin1 ℝ E' F') (p x 1),
   refine hp.has_strict_fderiv_at (by norm_num) _,
-  exact continuous_on.nhds_of_nhds_within_of_nhds hs H,
+  exact nhds_of_nhds_within_of_nhds hs H,
 end
 
 lemma times_cont_diff.has_strict_fderiv_at

--- a/src/analysis/normed_space/dual.lean
+++ b/src/analysis/normed_space/dual.lean
@@ -62,13 +62,12 @@ end general
 section real
 variables (E : Type*) [normed_group E] [normed_space ℝ E]
 
-open_locale classical
-
 /-- If one controls the norm of every `f x`, then one controls the norm of `x`.
     Compare `continuous_linear_map.op_norm_le_bound`. -/
 lemma norm_le_dual_bound (x : E) {M : ℝ} (hMp: 0 ≤ M) (hM : ∀ (f: dual ℝ E), ∥f x∥ ≤ M * ∥f∥) :
   ∥x∥ ≤ M :=
 begin
+  classical,
   by_cases h : x = 0,
   { simp only [h, hMp, norm_zero] },
   { cases exists_dual_vector x h with f hf,

--- a/src/analysis/normed_space/dual.lean
+++ b/src/analysis/normed_space/dual.lean
@@ -83,9 +83,8 @@ begin
   refine le_antisymm_iff.mpr ⟨double_dual_bound ℝ E x, _⟩,
   rw continuous_linear_map.norm_def,
   apply real.lb_le_Inf _ continuous_linear_map.bounds_nonempty,
-  intros c, 
-  simp only [and_imp, set.mem_set_of_eq],
-  exact norm_le_dual_bound E x,
+  intros c,
+  simpa using norm_le_dual_bound E x,
 end
 
 -- TODO: This is also true over ℂ.

--- a/src/analysis/normed_space/dual.lean
+++ b/src/analysis/normed_space/dual.lean
@@ -83,7 +83,8 @@ begin
   refine le_antisymm_iff.mpr ⟨double_dual_bound ℝ E x, _⟩,
   rw continuous_linear_map.norm_def,
   apply real.lb_le_Inf _ continuous_linear_map.bounds_nonempty,
-  intros c, simp only [and_imp, set.mem_set_of_eq],
+  intros c, 
+  simp only [and_imp, set.mem_set_of_eq],
   exact norm_le_dual_bound E x,
 end
 

--- a/src/analysis/normed_space/dual.lean
+++ b/src/analysis/normed_space/dual.lean
@@ -62,21 +62,30 @@ end general
 section real
 variables (E : Type*) [normed_group E] [normed_space ℝ E]
 
+open_locale classical
+
+/-- If one controls the norm of every `f x`, then one controls the norm of `x`.
+    Compare `continuous_linear_map.op_norm_le_bound`. -/
+lemma norm_le_dual_bound (x : E) {M : ℝ} (hMp: 0 ≤ M) (hM : ∀ (f: dual ℝ E), ∥f x∥ ≤ M * ∥f∥) :
+  ∥x∥ ≤ M :=
+begin
+  by_cases h : x = 0,
+  { simp only [h, hMp, norm_zero] },
+  { cases exists_dual_vector x h with f hf,
+    calc ∥x∥ = f x : hf.2.symm
+    ... ≤ ∥f x∥ : le_max_left (f x) (-f x)
+    ... ≤ M * ∥f∥ : hM f
+    ... = M : by rw [ hf.1, mul_one ] }
+end
+
 /-- The inclusion of a real normed space in its double dual is an isometry onto its image.-/
 lemma inclusion_in_double_dual_isometry (x : E) : ∥inclusion_in_double_dual ℝ E x∥ = ∥x∥ :=
 begin
-  by_cases h : vector_space.dim ℝ E = 0,
-  { rw dim_zero_iff_forall_zero.mp h x, simp },
-  { have h' : 0 < vector_space.dim ℝ E := zero_lt_iff_ne_zero.mpr h,
-    refine le_antisymm_iff.mpr ⟨double_dual_bound ℝ E x, _⟩,
-    rw continuous_linear_map.norm_def,
-    apply real.lb_le_Inf _ continuous_linear_map.bounds_nonempty,
-    intros c, simp only [and_imp, set.mem_set_of_eq], intros h₁ h₂,
-    cases exists_dual_vector' h' x with f hf,
-    calc ∥x∥ = f x : hf.2.symm
-    ... ≤ ∥f x∥ : le_max_left (f x) (-f x)
-    ... ≤ c * ∥f∥ : h₂ f
-    ... = c : by rw [ hf.1, mul_one ] }
+  refine le_antisymm_iff.mpr ⟨double_dual_bound ℝ E x, _⟩,
+  rw continuous_linear_map.norm_def,
+  apply real.lb_le_Inf _ continuous_linear_map.bounds_nonempty,
+  intros c, simp only [and_imp, set.mem_set_of_eq],
+  exact norm_le_dual_bound E x,
 end
 
 -- TODO: This is also true over ℂ.

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -58,6 +58,13 @@ lemma mem_nhds_within_iff_exists_mem_nhds_inter {t : set α} {a : α} {s : set �
   t ∈ nhds_within a s ↔ ∃ u ∈ 𝓝 a, u ∩ s ⊆ t :=
 (nhds_within_has_basis (𝓝 a).basis_sets s).mem_iff
 
+lemma nhds_of_nhds_within_of_nhds
+  {s t : set α} {a : α} (h1 : s ∈ 𝓝 a) (h2 : t ∈ nhds_within a s) : (t ∈ 𝓝 a) :=
+begin
+  rcases mem_nhds_within_iff_exists_mem_nhds_inter.mp h2 with ⟨_, Hw, hw⟩,
+  exact (nhds a).sets_of_superset ((nhds a).inter_sets Hw h1) hw,
+end
+
 lemma mem_nhds_within_of_mem_nhds {s t : set α} {a : α} (h : s ∈ 𝓝 a) :
   s ∈ nhds_within a t :=
 mem_inf_sets_of_left h


### PR DESCRIPTION
Over the reals, a continuously differentiable function is strictly differentiable.

Supporting material:  Add a standard mean-value-theorem-related trick as its own lemma, and refactor another proof (in `calculus/extend_deriv`) to use that lemma.

Other material:  an _equality_ (rather than _inequality_) version of the mean value theorem for domains; slight refactor of `normed_space/dual`.

---
<!-- put comments you want to keep out of the PR commit here -->

The "other material" was written to support a different proof of the main theorem; it seems worth keeping even though it is not used for the new proof method.

Closes #2547