### PR TITLE
[Merged by Bors] - chore(data/list/alist): nolint

### DIFF
--- a/src/data/list/alist.lean
+++ b/src/data/list/alist.lean
@@ -296,7 +296,7 @@ end
 /-! ### disjoint -/
 
 /-- Two associative lists are disjoint if they have no common keys. -/
-def disjoint (s₁ s₂ : alist β) :=
+def disjoint (s₁ s₂ : alist β) : Prop :=
 ∀ k ∈ s₁.keys, ¬ k ∈ s₂.keys
 
 variables [decidable_eq α]


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->

The weird sectioning is because `alist.foldl` and `alist.disjoint` don't use the `decidable_eq` instance.