### PR TITLE
[Merged by Bors] - feat(uniform_space/separation): add separated_set

### DIFF
--- a/src/topology/algebra/group_completion.lean
+++ b/src/topology/algebra/group_completion.lean
@@ -65,7 +65,7 @@ instance is_add_group_hom_coe : is_add_group_hom (coe : α → completion α) :=
 
 variables {β : Type v} [uniform_space β] [add_group β] [uniform_add_group β]
 
-lemma is_add_group_hom_extension  [complete_space β] [separated β]
+lemma is_add_group_hom_extension  [complete_space β] [separated_space β]
   {f : α → β} [is_add_group_hom f] (hf : continuous f) : is_add_group_hom (completion.extension f) :=
 have hf : uniform_continuous f, from uniform_continuous_of_continuous hf,
 { map_add := assume a b, completion.induction_on₂ a b

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -339,7 +339,7 @@ variables [topological_space α] [add_comm_group α] [topological_add_group α]
 variables [topological_space β] [add_comm_group β] [topological_add_group β]
 variables [topological_space γ] [add_comm_group γ] [topological_add_group γ]
 variables [topological_space δ] [add_comm_group δ] [topological_add_group δ]
-variables [uniform_space G] [add_comm_group G] [uniform_add_group G] [separated G] [complete_space G]
+variables [uniform_space G] [add_comm_group G] [uniform_add_group G] [separated_space G] [complete_space G]
 variables {e : β → α} [is_add_group_hom e] (de : dense_inducing e)
 variables {f : δ → γ} [is_add_group_hom f] (df : dense_inducing f)
 variables {φ : β × δ → G} (hφ : continuous φ) [bilin : is_Z_bilin φ]

--- a/src/topology/algebra/uniform_ring.lean
+++ b/src/topology/algebra/uniform_ring.lean
@@ -97,7 +97,7 @@ variables {β : Type u} [uniform_space β] [ring β] [uniform_add_group β] [top
           (f : α →+* β) (hf : continuous f)
 
 /-- The completion extension as a ring morphism. -/
-def extension_hom [complete_space β] [separated β] :
+def extension_hom [complete_space β] [separated_space β] :
   completion α →+* β :=
 have hf : uniform_continuous f, from uniform_continuous_of_continuous hf,
 { to_fun := completion.extension f,

--- a/src/topology/category/UniformSpace.lean
+++ b/src/topology/category/UniformSpace.lean
@@ -58,7 +58,7 @@ structure CpltSepUniformSpace :=
 (α : Type u)
 [is_uniform_space : uniform_space α]
 [is_complete_space : complete_space α]
-[is_separated : separated α]
+[is_separated : separated_space α]
 
 namespace CpltSepUniformSpace
 
@@ -71,10 +71,10 @@ def to_UniformSpace (X : CpltSepUniformSpace) : UniformSpace :=
 UniformSpace.of X
 
 instance (X : CpltSepUniformSpace) : complete_space ((to_UniformSpace X).α) := CpltSepUniformSpace.is_complete_space X
-instance (X : CpltSepUniformSpace) : separated ((to_UniformSpace X).α) := CpltSepUniformSpace.is_separated X
+instance (X : CpltSepUniformSpace) : separated_space ((to_UniformSpace X).α) := CpltSepUniformSpace.is_separated X
 
 /-- Construct a bundled `UniformSpace` from the underlying type and the appropriate typeclasses. -/
-def of (X : Type u) [uniform_space X] [complete_space X] [separated X] : CpltSepUniformSpace := ⟨X⟩
+def of (X : Type u) [uniform_space X] [complete_space X] [separated_space X] : CpltSepUniformSpace := ⟨X⟩
 
 /-- The category instance on `CpltSepUniformSpace`. -/
 instance category : category CpltSepUniformSpace :=
@@ -136,7 +136,7 @@ adjunction.mk_of_hom_equiv
     right_inv := λ f,
     begin
       apply subtype.eq, funext x, cases f,
-      exact @completion.extension_coe _ _ _ _ _ (CpltSepUniformSpace.separated _) f_property _
+      exact @completion.extension_coe _ _ _ _ _ (CpltSepUniformSpace.separated_space _) f_property _
     end },
   hom_equiv_naturality_left_symm' := λ X X' Y f g,
   begin

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -650,7 +650,7 @@ end metric
 open metric
 
 @[priority 100] -- see Note [lower instance priority]
-instance metric_space.to_separated : separated α :=
+instance metric_space.to_separated : separated_space α :=
 separated_def.2 $ λ x y h, eq_of_forall_dist_le $
   λ ε ε0, le_of_lt (h _ (dist_mem_uniformity ε0))
 

--- a/src/topology/metric_space/completion.lean
+++ b/src/topology/metric_space/completion.lean
@@ -142,7 +142,7 @@ protected lemma completion.eq_of_dist_eq_zero (x y : completion α) (h : dist x 
 begin
   /- This follows from the separation of `completion α` and from the description of
   entourages in terms of the distance. -/
-  have : separated (completion α) := by apply_instance,
+  have : separated_space (completion α) := by apply_instance,
   refine separated_def.1 this x y (λs hs, _),
   rcases (completion.mem_uniformity_dist s).1 hs with ⟨ε, εpos, hε⟩,
   rw ← h at εpos,

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -375,7 +375,7 @@ open emetric
 
 /-- An emetric space is separated -/
 @[priority 100] -- see Note [lower instance priority]
-instance to_separated : separated α :=
+instance to_separated : separated_space α :=
 separated_def.2 $ λ x y h, eq_of_forall_edist_le $
 λ ε ε0, le_of_lt (h _ (edist_mem_uniformity ε0))
 

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -122,6 +122,40 @@ t2_iff_nhds.trans
      let ⟨f, hf, uf⟩ := exists_ultrafilter xy in
      h f uf (le_trans hf inf_le_left) (le_trans hf inf_le_right)⟩
 
+lemma is_closed_diagonal [t2_space α] : is_closed (diagonal α) :=
+is_closed_iff_nhds.mpr $ assume ⟨a₁, a₂⟩ h, eq_of_nhds_ne_bot $ assume : 𝓝 a₁ ⊓ 𝓝 a₂ = ⊥, h $
+  let ⟨t₁, ht₁, t₂, ht₂, (h' : t₁ ∩ t₂ ⊆ ∅)⟩ :=
+    by rw [←empty_in_sets_eq_bot, mem_inf_sets] at this; exact this in
+  begin
+    change t₁ ∈ 𝓝 a₁ at ht₁,
+    change t₂ ∈ 𝓝 a₂ at ht₂,
+    rw [nhds_prod_eq, ←empty_in_sets_eq_bot],
+    apply filter.sets_of_superset,
+    apply inter_mem_inf_sets (prod_mem_prod ht₁ ht₂) (mem_principal_sets.mpr (subset.refl _)),
+    exact assume ⟨x₁, x₂⟩ ⟨⟨hx₁, hx₂⟩, (heq : x₁ = x₂)⟩,
+      show false, from @h' x₁ ⟨hx₁, heq.symm ▸ hx₂⟩
+  end
+
+lemma t2_iff_is_closed_diagonal : t2_space α ↔ is_closed (diagonal α) :=
+begin
+  split,
+  { introI h,
+    exact is_closed_diagonal },
+  { intro h,
+    constructor,
+    intros x y hxy,
+    have : (x, y) ∈ -diagonal α, by rwa [mem_compl_iff],
+    obtain ⟨t, t_sub, t_op, xyt⟩ : ∃ t ⊆ -diagonal α, is_open t ∧ (x, y) ∈ t :=
+      is_open_iff_forall_mem_open.mp h _ this,
+    rcases is_open_prod_iff.mp t_op x y xyt with ⟨U, V, U_op, V_op, xU, yV, H⟩,
+    use [U, V, U_op, V_op, xU, yV],
+    have := subset.trans H t_sub,
+    rw eq_empty_iff_forall_not_mem,
+    rintros z ⟨zU, zV⟩,
+    have : ¬ (z, z) ∈ diagonal α := this (mk_mem_prod zU zV),
+    exact this rfl },
+end
+
 @[simp] lemma nhds_eq_nhds_iff {a b : α} [t2_space α] : 𝓝 a = 𝓝 b ↔ a = b :=
 ⟨assume h, eq_of_nhds_ne_bot $ by rw [h, inf_idem]; exact nhds_ne_bot, assume h, h ▸ rfl⟩
 
@@ -201,20 +235,6 @@ instance Pi.t2_space {α : Type*} {β : α → Type v} [t₂ : Πa, topological_
 ⟨assume x y h,
   let ⟨i, hi⟩ := not_forall.mp (mt funext h) in
   separated_by_f (λz, z i) (infi_le _ i) hi⟩
-
-lemma is_closed_diagonal [t2_space α] : is_closed {p:α×α | p.1 = p.2} :=
-is_closed_iff_nhds.mpr $ assume ⟨a₁, a₂⟩ h, eq_of_nhds_ne_bot $ assume : 𝓝 a₁ ⊓ 𝓝 a₂ = ⊥, h $
-  let ⟨t₁, ht₁, t₂, ht₂, (h' : t₁ ∩ t₂ ⊆ ∅)⟩ :=
-    by rw [←empty_in_sets_eq_bot, mem_inf_sets] at this; exact this in
-  begin
-    change t₁ ∈ 𝓝 a₁ at ht₁,
-    change t₂ ∈ 𝓝 a₂ at ht₂,
-    rw [nhds_prod_eq, ←empty_in_sets_eq_bot],
-    apply filter.sets_of_superset,
-    apply inter_mem_inf_sets (prod_mem_prod ht₁ ht₂) (mem_principal_sets.mpr (subset.refl _)),
-    exact assume ⟨x₁, x₂⟩ ⟨⟨hx₁, hx₂⟩, (heq : x₁ = x₂)⟩,
-      show false, from @h' x₁ ⟨hx₁, heq.symm ▸ hx₂⟩
-  end
 
 variables [topological_space β]
 

--- a/src/topology/uniform_space/abstract_completion.lean
+++ b/src/topology/uniform_space/abstract_completion.lean
@@ -55,7 +55,7 @@ structure abstract_completion (α : Type u) [uniform_space α] :=
 (coe : α → space)
 (uniform_struct : uniform_space space)
 (complete : complete_space space)
-(separation : separated space)
+(separation : separated_space space)
 (uniform_inducing : uniform_inducing coe)
 (dense : dense_range coe)
 
@@ -110,7 +110,7 @@ begin
   exact pkg.dense_inducing.extend_eq_of_cont hf.continuous a
 end
 
-variables [complete_space β] [separated β]
+variables [complete_space β] [separated_space β]
 
 lemma uniform_continuous_extend : uniform_continuous (pkg.extend f) :=
 begin
@@ -178,7 +178,7 @@ pkg.map_unique pkg uniform_continuous_id (assume a, rfl)
 
 variables {γ : Type*} [uniform_space γ]
 
-lemma extend_map [complete_space γ] [separated γ] {f : β → γ} {g : α → β}
+lemma extend_map [complete_space γ] [separated_space γ] {f : β → γ} {g : α → β}
   (hf : uniform_continuous f) (hg : uniform_continuous g) :
   pkg'.extend f ∘ map g = pkg.extend (f ∘ g) :=
 pkg.funext (pkg'.continuous_extend.comp (pkg.continuous_map pkg' _)) pkg.continuous_extend $ λ a,
@@ -263,7 +263,7 @@ open function
 protected def extend₂ (f : α → β → γ) : hatα → hatβ → γ :=
 curry $ (pkg.prod pkg').extend (uncurry f)
 
-variables [separated γ] {f : α → β → γ}
+variables [separated_space γ] {f : α → β → γ}
 
 lemma extension₂_coe_coe (hf : uniform_continuous $ uncurry f) (a : α) (b : β) :
   pkg.extend₂ pkg' f (ι a) (ι' b) = f a b :=

--- a/src/topology/uniform_space/complete_separated.lean
+++ b/src/topology/uniform_space/complete_separated.lean
@@ -17,7 +17,7 @@ open_locale topological_space
 variables {α : Type*}
 
 /-In a separated space, a complete set is closed -/
-lemma is_closed_of_is_complete  [uniform_space α] [separated α] {s : set α} (h : is_complete s) :
+lemma is_closed_of_is_complete  [uniform_space α] [separated_space α] {s : set α} (h : is_complete s) :
   is_closed s :=
 is_closed_iff_nhds.2 $ λ a ha, begin
   let f := 𝓝 a ⊓ principal s,
@@ -29,7 +29,7 @@ end
 namespace dense_inducing
 open filter
 variables [topological_space α] {β : Type*} [topological_space β]
-variables {γ : Type*} [uniform_space γ] [complete_space γ] [separated γ]
+variables {γ : Type*} [uniform_space γ] [complete_space γ] [separated_space γ]
 
 lemma continuous_extend_of_cauchy {e : α → β} {f : α → γ}
   (de : dense_inducing e) (h : ∀ b : β, cauchy (map f (comap e $ 𝓝 b))) :

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -225,7 +225,7 @@ if uniform_continuous f then
 else
   λ x, f (classical.inhabited_of_nonempty $ nonempty_Cauchy_iff.1 ⟨x⟩).default
 
-variables [separated β]
+variables [separated_space β]
 
 lemma extend_pure_cauchy {f : α → β} (hf : uniform_continuous f) (a : α) :
   extend f (pure_cauchy a) = f a :=
@@ -250,7 +250,7 @@ end extend
 end
 
 theorem Cauchy_eq
-  {α : Type*} [inhabited α] [uniform_space α] [complete_space α] [separated α] {f g : Cauchy α} :
+  {α : Type*} [inhabited α] [uniform_space α] [complete_space α] [separated_space α] {f g : Cauchy α} :
   Lim f.1 = Lim g.1 ↔ (f, g) ∈ separation_rel (Cauchy α) :=
 begin
   split,
@@ -283,7 +283,7 @@ end
 section
 local attribute [instance] uniform_space.separation_setoid
 
-lemma separated_pure_cauchy_injective {α : Type*} [uniform_space α] [s : separated α] :
+lemma separated_pure_cauchy_injective {α : Type*} [uniform_space α] [s : separated_space α] :
   function.injective (λa:α, ⟦pure_cauchy a⟧) | a b h :=
 separated_def.1 s _ _ $ assume s hs,
 let ⟨t, ht, hts⟩ :=
@@ -330,7 +330,7 @@ instance : uniform_space (completion α) := by dunfold completion ; apply_instan
 
 instance : complete_space (completion α) := by dunfold completion ; apply_instance
 
-instance : separated (completion α) := by dunfold completion ; apply_instance
+instance : separated_space (completion α) := by dunfold completion ; apply_instance
 
 instance : t2_space (completion α) := separated_t2
 
@@ -389,7 +389,7 @@ cpkg.uniform_continuous_coe
 lemma continuous_coe : continuous (coe : α → completion α) :=
 cpkg.continuous_coe
 
-lemma uniform_embedding_coe [separated α] : uniform_embedding  (coe : α → completion α) :=
+lemma uniform_embedding_coe [separated_space α] : uniform_embedding  (coe : α → completion α) :=
 { comap_uniformity := comap_coe_eq_uniformity α,
   inj := separated_pure_cauchy_injective }
 
@@ -399,7 +399,7 @@ lemma dense_inducing_coe : dense_inducing (coe : α → completion α) :=
 { dense := dense,
   ..(uniform_inducing_coe α).inducing }
 
-lemma dense_embedding_coe [separated α]: dense_embedding (coe : α → completion α) :=
+lemma dense_embedding_coe [separated_space α]: dense_embedding (coe : α → completion α) :=
 { inj := separated_pure_cauchy_injective,
   ..dense_inducing_coe }
 
@@ -445,7 +445,7 @@ returns an arbitrary constant value if `f` is not uniformly continuous -/
 protected def extension (f : α → β) : completion α → β :=
 cpkg.extend f
 
-variables [separated β]
+variables [separated_space β]
 
 @[simp] lemma extension_coe (hf : uniform_continuous f) (a : α) : (completion.extension f) a = f a :=
 cpkg.extend_coe hf a
@@ -490,7 +490,7 @@ cpkg.map_unique cpkg hg h
 @[simp] lemma map_id : completion.map (@id α) = id :=
 cpkg.map_id
 
-lemma extension_map [complete_space γ] [separated γ] {f : β → γ} {g : α → β}
+lemma extension_map [complete_space γ] [separated_space γ] {f : β → γ} {g : α → β}
   (hf : uniform_continuous f) (hg : uniform_continuous g) :
   completion.extension f ∘ completion.map g = completion.extension (f ∘ g) :=
 completion.ext (continuous_extension.comp continuous_map) continuous_extension $
@@ -543,7 +543,7 @@ open function
 protected def extension₂ (f : α → β → γ) : completion α → completion β → γ :=
 cpkg.extend₂ cpkg f
 
-variables [separated γ] {f}
+variables [separated_space γ] {f}
 
 @[simp] lemma extension₂_coe_coe (hf : uniform_continuous₂ f) (a : α) (b : β) :
   completion.extension₂ f a b = f a b :=

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -332,8 +332,6 @@ instance : complete_space (completion α) := by dunfold completion ; apply_insta
 
 instance : separated_space (completion α) := by dunfold completion ; apply_instance
 
-instance : t2_space (completion α) := separated_t2
-
 instance : regular_space (completion α) := separated_regular
 
 /-- Automatic coercion from `α` to its completion. Not always injective. -/

--- a/src/topology/uniform_space/pi.lean
+++ b/src/topology/uniform_space/pi.lean
@@ -46,7 +46,7 @@ instance Pi.complete [∀ i, complete_space (α i)] : complete_space (Π i, α i
   exact λ i, map_le_iff_le_comap.mp (hx i),
 end⟩
 
-instance Pi.separated [∀ i, separated (α i)] : separated (Π i, α i) :=
+instance Pi.separated [∀ i, separated_space (α i)] : separated_space (Π i, α i) :=
 separated_def.2 $ assume x y H,
 begin
   ext i,

--- a/src/topology/uniform_space/separation.lean
+++ b/src/topology/uniform_space/separation.lean
@@ -56,7 +56,7 @@ on a uniform space `X`,
 
 ## Implementation notes
 
-The separatoin setoid `separation_setoid` is not declared as a global instance.
+The separation setoid `separation_setoid` is not declared as a global instance.
 It is made a local instance while building the theory of `separation_quotient`.
 The factored map `separation_quotient.lift f` is defined without imposing any condition on
 `f`, but returns junk if `f` is not uniformly continuous (constant junk hence it is always

--- a/src/topology/uniform_space/separation.lean
+++ b/src/topology/uniform_space/separation.lean
@@ -13,7 +13,7 @@ import tactic.apply_fun
 This file studies uniform spaces whose underlying topological spaces are separated
 (also known as Hausdorff or T₂).
 This turns out to be equivalent to asking that the intersection of all entourages
-is the diagonal only. This conditions actually implies the stronger separation property
+is the diagonal only. This condition actually implies the stronger separation property
 that the space is regular (T₃), hence those conditions are equivalent for topologies coming from
 a uniform structure.
 
@@ -23,7 +23,7 @@ undistinguishable from the point of view of the uniform structure. For instance 
 continuous function will send equivalent points to the same value.
 
 The quotient `separation_quotient X` of `X` by `𝓢 X` has a natural uniform structure which is
-separated space, and satisfies a universal property: every uniformly continuous function
+separated, and satisfies a universal property: every uniformly continuous function
 from `X` to a separated uniform space uniquely factors through `separation_quotient X`.
 As usual, this allows to turn `separation_quotient` into a functor (but we don't use the
 category theory library in this file).
@@ -113,7 +113,7 @@ theorem separated_def' {α : Type u} [uniform_space α] :
 separated_def.trans $ forall_congr $ λ x, forall_congr $ λ y,
 by rw ← not_imp_not; simp [classical.not_forall]
 
-lemma id_rel_sub_separation_relation (α : Type*) [uniform_space α]: id_rel ⊆ 𝓢 α :=
+lemma id_rel_sub_separation_relation (α : Type*) [uniform_space α] : id_rel ⊆ 𝓢 α :=
 begin
   unfold separation_rel,
   rw id_rel_subset,
@@ -123,7 +123,7 @@ begin
 end
 
 lemma separation_rel_comap  {f : α → β} (h : ‹uniform_space α› = uniform_space.comap f ‹uniform_space β›) :
-𝓢 α = (prod.map f f) ⁻¹' 𝓢 β :=
+  𝓢 α = (prod.map f f) ⁻¹' 𝓢 β :=
 begin
   dsimp [separation_rel],
   rw [uniformity_comap h, (filter.comap_has_basis (prod.map f f) (𝓤 β)).sInter_sets,
@@ -133,7 +133,7 @@ end
 
 protected lemma filter.has_basis.separation_rel {ι : Type*} {p : ι → Prop} {s : ι → set (α × α)}
   (h : has_basis (𝓤 α) p s) :
-𝓢 α = ⋂ i ∈ set_of p, s i :=
+  𝓢 α = ⋂ i ∈ set_of p, s i :=
 by { unfold separation_rel, rw h.sInter_sets }
 
 lemma separation_rel_eq_inter_closure : 𝓢 α = ⋂₀ (closure '' (𝓤 α).sets) :=
@@ -245,7 +245,7 @@ lemma separated_set_iff_induced {s : set α} : separated_set s ↔ separated s :
 begin
   change _ ↔ 𝓢 ({x // x ∈ s}) = _,
   rw [separation_rel_comap rfl, separated_set_def'],
-  split ; intro h,
+  split; intro h,
   { ext ⟨⟨x, x_in⟩, ⟨y, y_in⟩⟩,
     suffices : (x, y) ∈ 𝓢 α ↔ x = y, by simpa only [mem_id_rel],
     refine ⟨λ H, h ⟨mk_mem_prod x_in y_in, H⟩, _⟩,

--- a/src/topology/uniform_space/separation.lean
+++ b/src/topology/uniform_space/separation.lean
@@ -34,8 +34,8 @@ is equivalent to asking that the uniform structure induced on `s` is separated.
 ## Main definitions
 
 * `separation_relation X : set (X × X)`: the separation relation
-* `separated X`: a predicate class asserting that `X` is separated
-* `separated_set s`: a predicate asserting that `s : set X` is separated
+* `separated_space X`: a predicate class asserting that `X` is separated
+* `is_separated s`: a predicate asserting that `s : set X` is separated
 * `separation_quotient X`: the maximal separated quotient of `X`.
 * `separation_quotient.lift f`: factors a map `f : X → Y` through the separation quotient of `X`.
 * `separation_quotient.map f`: turns a map `f : X → Y` into a map between the separation quotients
@@ -100,16 +100,16 @@ lemma separated_equiv : equivalence (λx y, (x, y) ∈ 𝓢 α) :=
 
 /-- A uniform space is separated if its separation relation is trivial (each point
 is related only to itself). -/
-@[class] def separated (α : Type u) [uniform_space α] :=
+@[class] def separated_space (α : Type u) [uniform_space α] :=
 𝓢 α = id_rel
 
 theorem separated_def {α : Type u} [uniform_space α] :
-  separated α ↔ ∀ x y, (∀ r ∈ 𝓤 α, (x, y) ∈ r) → x = y :=
-by simp [separated, id_rel_subset.2 separated_equiv.1, subset.antisymm_iff];
+  separated_space α ↔ ∀ x y, (∀ r ∈ 𝓤 α, (x, y) ∈ r) → x = y :=
+by simp [separated_space, id_rel_subset.2 separated_equiv.1, subset.antisymm_iff];
    simp [subset_def, separation_rel]
 
 theorem separated_def' {α : Type u} [uniform_space α] :
-  separated α ↔ ∀ x y, x ≠ y → ∃ r ∈ 𝓤 α, (x, y) ∉ r :=
+  separated_space α ↔ ∀ x y, x ≠ y → ∃ r ∈ 𝓤 α, (x, y) ∉ r :=
 separated_def.trans $ forall_congr $ λ x, forall_congr $ λ y,
 by rw ← not_imp_not; simp [classical.not_forall]
 
@@ -147,34 +147,29 @@ begin
   exact is_closed_closure,
 end
 
-@[priority 100] -- see Note [lower instance priority]
-instance separated_t2 [s : separated α] : t2_space α :=
-begin
-  rw [t2_iff_is_closed_diagonal, ← show 𝓢 α = diagonal α, from s],
-  exact is_closed_separation_rel
-end
-
-lemma separated_iff_t2 : separated α ↔ t2_space α :=
+lemma separated_iff_t2 : separated_space α ↔ t2_space α :=
 begin
   classical,
-  refine ⟨by { introI, apply_instance },  λ h, _⟩,
-  rw separated_def',
-  intros x y hxy,
-  have : 𝓝 x ⊓ 𝓝 y = ⊥,
-  { rw t2_iff_nhds at h,
-    by_contra H,
-    exact hxy (h H) },
-  rcases inf_eq_bot_iff.mp this with ⟨U, V, U_in, V_in, H⟩,
-  rcases mem_nhds_iff_symm.mp U_in with ⟨S, S_in, S_symm, S_sub⟩,
-  use [S, S_in],
-  change y ∉ ball x S,
-  intro y_in,
-  have : y ∈ U ∩ V := ⟨S_sub y_in, mem_of_nhds V_in⟩,
-  rwa H at this,
+  split ; intro h,
+  { rw [t2_iff_is_closed_diagonal, ← show 𝓢 α = diagonal α, from h],
+    exact is_closed_separation_rel },
+  { rw separated_def',
+    intros x y hxy,
+    have : 𝓝 x ⊓ 𝓝 y = ⊥,
+    { rw t2_iff_nhds at h,
+      by_contra H,
+      exact hxy (h H) },
+    rcases inf_eq_bot_iff.mp this with ⟨U, V, U_in, V_in, H⟩,
+    rcases mem_nhds_iff_symm.mp U_in with ⟨S, S_in, S_symm, S_sub⟩,
+    use [S, S_in],
+    change y ∉ ball x S,
+    intro y_in,
+    have : y ∈ U ∩ V := ⟨S_sub y_in, mem_of_nhds V_in⟩,
+    rwa H at this },
 end
 
 @[priority 100] -- see Note [lower instance priority]
-instance separated_regular [separated α] : regular_space α :=
+instance separated_regular [separated_space α] : regular_space α :=
 { regular := λs a hs ha,
     have -s ∈ 𝓝 a,
       from mem_nhds_sets hs ha,
@@ -199,7 +194,7 @@ instance separated_regular [separated α] : regular_space α :=
       from (@inf_eq_bot_iff_le_compl _ _ _ (principal (- closure e)) (principal (closure e))
         (by simp [principal_univ, union_comm]) (by simp)).mpr (by simp [this]),
     ⟨- closure e, is_closed_closure, assume x h₁ h₂, @e_subset x h₂ h₁, this⟩,
-  ..separated_t2 }
+    ..@t2_space.t1_space _ _ (separated_iff_t2.mp ‹_›) }
 
 /-!
 ### Separated sets
@@ -207,14 +202,14 @@ instance separated_regular [separated α] : regular_space α :=
 
 /-- A set `s` in a uniform space `α` is separated if the separation relation `𝓢 α`
 induces the trivial relation on `s`. -/
-def separated_set (s : set α) : Prop := ∀ x y ∈ s, (x, y) ∈ 𝓢 α → x = y
+def is_separated (s : set α) : Prop := ∀ x y ∈ s, (x, y) ∈ 𝓢 α → x = y
 
-lemma separated_set_def (s : set α) : separated_set s ↔ ∀ x y ∈ s, (x, y) ∈ 𝓢 α → x = y :=
+lemma is_separated_def (s : set α) : is_separated s ↔ ∀ x y ∈ s, (x, y) ∈ 𝓢 α → x = y :=
 iff.rfl
 
-lemma separated_set_def' (s : set α) : separated_set s ↔ (s.prod s) ∩ 𝓢 α ⊆ id_rel :=
+lemma is_separated_def' (s : set α) : is_separated s ↔ (s.prod s) ∩ 𝓢 α ⊆ id_rel :=
 begin
-  rw separated_set_def,
+  rw is_separated_def,
   split,
   { rintros h ⟨x, y⟩ ⟨⟨x_in, y_in⟩, H⟩,
     simp [h x y x_in y_in H] },
@@ -224,9 +219,9 @@ begin
 end
 
 
-lemma univ_separated_iff : separated_set (univ : set α) ↔ separated α :=
+lemma univ_separated_iff : is_separated (univ : set α) ↔ separated_space α :=
 begin
-  simp only [separated_set, mem_univ, true_implies_iff, separated],
+  simp only [is_separated, mem_univ, true_implies_iff, separated_space],
   split,
   { intro h,
     exact subset.antisymm (λ ⟨x, y⟩ xy_in, h x y xy_in) (id_rel_sub_separation_relation α), },
@@ -235,16 +230,16 @@ begin
 end
 
 
-lemma separated_set_of_separated [separated α] (s : set α) : separated_set s :=
+lemma is_separated_of_separated_space [separated_space α] (s : set α) : is_separated s :=
 begin
-  rw [separated_set, show 𝓢 α = diagonal α, from  ‹separated α›],
+  rw [is_separated, show 𝓢 α = diagonal α, from  ‹separated_space α›],
   tauto,
 end
 
-lemma separated_set_iff_induced {s : set α} : separated_set s ↔ separated s :=
+lemma is_separated_iff_induced {s : set α} : is_separated s ↔ separated_space s :=
 begin
   change _ ↔ 𝓢 ({x // x ∈ s}) = _,
-  rw [separation_rel_comap rfl, separated_set_def'],
+  rw [separation_rel_comap rfl, is_separated_def'],
   split; intro h,
   { ext ⟨⟨x, x_in⟩, ⟨y, y_in⟩⟩,
     suffices : (x, y) ∈ 𝓢 α ↔ x = y, by simpa only [mem_id_rel],
@@ -273,7 +268,7 @@ begin
     rw h },
 end
 
-lemma eq_of_uniformity_inf_nhds_of_separated_set {s : set α} (hs : separated_set s) :
+lemma eq_of_uniformity_inf_nhds_of_is_separated {s : set α} (hs : is_separated s) :
   ∀ x y ∈ s, 𝓤 α ⊓ 𝓝 (x, y) ≠ ⊥ → x = y :=
 begin
   intros x y x_in y_in H,
@@ -286,12 +281,12 @@ begin
   simpa [separation_rel_eq_inter_closure],
 end
 
-lemma eq_of_uniformity_inf_nhds [separated α] : ∀ {x y}, 𝓤 α ⊓ 𝓝 (x, y) ≠ ⊥ → x = y :=
+lemma eq_of_uniformity_inf_nhds [separated_space α] : ∀ {x y}, 𝓤 α ⊓ 𝓝 (x, y) ≠ ⊥ → x = y :=
 begin
-  have : separated_set (univ : set α),
+  have : is_separated (univ : set α),
   { rw univ_separated_iff,
     assumption },
-  simpa using eq_of_uniformity_inf_nhds_of_separated_set this,
+  simpa using eq_of_uniformity_inf_nhds_of_is_separated this,
 end
 
 /-!
@@ -395,7 +390,7 @@ lemma comap_quotient_eq_uniformity :
 le_antisymm comap_quotient_le_uniformity le_comap_map
 
 
-instance separated_separation : separated (quotient (separation_setoid α)) :=
+instance separated_separation : separated_space (quotient (separation_setoid α)) :=
 set.ext $ assume ⟨a, b⟩, quotient.induction_on₂ a b $ assume a b,
   ⟨assume h,
     have a ≈ b, from assume s hs,
@@ -412,7 +407,7 @@ lemma separated_of_uniform_continuous {f : α → β} {x y : α}
   (H : uniform_continuous f) (h : x ≈ y) : f x ≈ f y :=
 assume _ h', h _ (H h')
 
-lemma eq_of_separated_of_uniform_continuous [separated β] {f : α → β} {x y : α}
+lemma eq_of_separated_of_uniform_continuous [separated_space β] {f : α → β} {x y : α}
   (H : uniform_continuous f) (h : x ≈ y) : f x = f y :=
 separated_def.1 (by apply_instance) _ _ $ separated_of_uniform_continuous H h
 
@@ -421,21 +416,21 @@ def separation_quotient (α : Type*) [uniform_space α] := quotient (separation_
 
 namespace separation_quotient
 instance : uniform_space (separation_quotient α) := by dunfold separation_quotient ; apply_instance
-instance : separated (separation_quotient α) := by dunfold separation_quotient ; apply_instance
+instance : separated_space (separation_quotient α) := by dunfold separation_quotient ; apply_instance
 instance [inhabited α] : inhabited (separation_quotient α) :=
 by unfold separation_quotient; apply_instance
 
 /-- Factoring functions to a separated space through the separation quotient. -/
-def lift [separated β] (f : α → β) : (separation_quotient α → β) :=
+def lift [separated_space β] (f : α → β) : (separation_quotient α → β) :=
 if h : uniform_continuous f then
   quotient.lift f (λ x y, eq_of_separated_of_uniform_continuous h)
 else
   λ x, f (classical.inhabited_of_nonempty $ (nonempty_quotient_iff $ separation_setoid α).1 ⟨x⟩).default
 
-lemma lift_mk [separated β] {f : α → β} (h : uniform_continuous f) (a : α) : lift f ⟦a⟧ = f a :=
+lemma lift_mk [separated_space β] {f : α → β} (h : uniform_continuous f) (a : α) : lift f ⟦a⟧ = f a :=
 by rw [lift, dif_pos h]; refl
 
-lemma uniform_continuous_lift [separated β] (f : α → β) : uniform_continuous (lift f) :=
+lemma uniform_continuous_lift [separated_space β] (f : α → β) : uniform_continuous (lift f) :=
 begin
   by_cases hf : uniform_continuous f,
   { rw [lift, dif_pos hf], exact uniform_continuous_quotient_lift hf },
@@ -485,7 +480,7 @@ begin
     exact H ⟨h_α key_α, h_β key_β⟩ },
 end
 
-instance separated.prod [separated α] [separated β] : separated (α × β) :=
+instance separated.prod [separated_space α] [separated_space β] : separated_space (α × β) :=
 separated_def.2 $ assume x y H, prod.ext
   (eq_of_separated_of_uniform_continuous uniform_continuous_fst H)
   (eq_of_separated_of_uniform_continuous uniform_continuous_snd H)

--- a/src/topology/uniform_space/uniform_embedding.lean
+++ b/src/topology/uniform_space/uniform_embedding.lean
@@ -362,7 +362,7 @@ begin
     end⟩
 end
 
-variables [separated γ]
+variables [separated_space γ]
 
 lemma uniformly_extend_of_ind (b : β) : ψ (e b) = f b :=
 dense_inducing.extend_e_eq _ b (continuous_iff_continuous_at.1 h_f.continuous b)


### PR DESCRIPTION
Also add documentation and simplify the proof of separated => t2 and add the converse. 

---
<!-- put comments you want to keep out of the PR commit here -->

This is the third PR towards Heine (only two more to go). The main point is to introduce `separated_set`. Mathematically this is simply asking that the uniform structure induced on a subset is separated, but expressed without subtypes. I do prove the equivalence with the natural definition, after a lot of coercion pain because, given `s : set X`, the subtype associated to `s.prod s` is not the product of the subtype associated to `s` with itself.