### PR TITLE
[Merged by Bors] - fix(algebra/ordered*): add norm_cast attribute

### DIFF
--- a/src/algebra/group_power.lean
+++ b/src/algebra/group_power.lean
@@ -416,7 +416,7 @@ end comm_group
 
 @[simp] lemma with_bot.coe_nsmul [add_monoid A] (a : A) (n : ℕ) :
   ((nsmul n a : A) : with_bot A) = nsmul n a :=
-add_monoid_hom.map_nsmul ⟨_, with_bot.coe_zero, with_bot.coe_add⟩ a n
+add_monoid_hom.map_nsmul ⟨(coe : A → with_bot A), with_bot.coe_zero, with_bot.coe_add⟩ a n
 
 theorem nsmul_eq_mul' [semiring R] (a : R) (n : ℕ) : n •ℕ a = a * n :=
 by induction n with n ih; [rw [zero_nsmul, nat.cast_zero, mul_zero],

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -399,9 +399,9 @@ begin
     exact ⟨_, rfl, add_le_add_left' h⟩, }
 end
 
-@[simp, norm_cast] lemma coe_zero [add_monoid α] : ((0 : α) : with_bot α) = 0 := rfl
+@[norm_cast] lemma coe_zero [add_monoid α] : ((0 : α) : with_bot α) = 0 := rfl
 
-@[simp, norm_cast] lemma coe_eq_zero {α : Type*}
+@[norm_cast] lemma coe_eq_zero {α : Type*}
   [add_monoid α] {a : α} : (a : with_bot α) = 0 ↔ a = 0 :=
 by norm_cast
 

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -204,11 +204,11 @@ namespace units
 instance [monoid α] [preorder α] : preorder (units α) :=
 preorder.lift (coe : units α → α)
 
-@[simp, to_additive]
+@[simp, to_additive, norm_cast]
 theorem coe_le_coe [monoid α] [preorder α] {a b : units α} :
   (a : α) ≤ b ↔ a ≤ b := iff.rfl
 
-@[simp, to_additive]
+@[simp, to_additive, norm_cast]
 theorem coe_lt_coe [monoid α] [preorder α] {a b : units α} :
   (a : α) < b ↔ a < b := iff.rfl
 
@@ -224,12 +224,12 @@ linear_order.lift coe units.ext
 instance [monoid α] [decidable_linear_order α] : decidable_linear_order (units α) :=
 decidable_linear_order.lift coe units.ext
 
-@[simp, to_additive]
+@[simp, to_additive, norm_cast]
 theorem max_coe [monoid α] [decidable_linear_order α] {a b : units α} :
   (↑(max a b) : α) = max a b :=
 by by_cases a ≤ b; simp [max, h]
 
-@[simp, to_additive]
+@[simp, to_additive, norm_cast]
 theorem min_coe [monoid α] [decidable_linear_order α] {a b : units α} :
   (↑(min a b) : α) = min a b :=
 by by_cases a ≤ b; simp [min, h]
@@ -284,13 +284,17 @@ end
 
 end with_zero
 
+-- the norm_cast attribute was not available in order.bounded_lattice
+attribute [norm_cast] with_top.coe_eq_coe with_top.coe_le_coe with_top.coe_lt_coe
+  with_bot.coe_eq_coe with_bot.coe_le_coe with_bot.coe_lt_coe
+
 namespace with_top
 
 instance [add_semigroup α] : add_semigroup (with_top α) :=
 { add := λ o₁ o₂, o₁.bind (λ a, o₂.map (λ b, a + b)),
   ..@additive.add_semigroup _ $ @with_zero.semigroup (multiplicative α) _ }
 
-lemma coe_add [add_semigroup α] {a b : α} : ((a + b : α) : with_top α) = a + b := rfl
+@[norm_cast] lemma coe_add [add_semigroup α] {a b : α} : ((a + b : α) : with_top α) = a + b := rfl
 
 instance [add_comm_semigroup α] : add_comm_semigroup (with_top α) :=
 { ..@additive.add_comm_semigroup _ $
@@ -300,6 +304,13 @@ instance [add_monoid α] : add_monoid (with_top α) :=
 { zero := some 0,
   add := (+),
   ..@additive.add_monoid _ $ @with_zero.monoid (multiplicative α) _ }
+
+@[simp, norm_cast] lemma coe_zero {α : Type*}
+  [add_monoid α] : ((0 : α) : with_top α) = 0 := rfl
+
+@[simp, norm_cast] lemma coe_eq_zero {α : Type*}
+  [add_monoid α] {a : α} : (a : with_top α) = 0 ↔ a = 0 :=
+by norm_cast
 
 instance [add_comm_monoid α] : add_comm_monoid (with_top α) :=
 { zero := 0,
@@ -334,7 +345,7 @@ end
 @[simp] lemma zero_lt_top [ordered_add_comm_monoid α] : (0 : with_top α) < ⊤ :=
 coe_lt_top 0
 
-@[simp] lemma zero_lt_coe [ordered_add_comm_monoid α] (a : α) : (0 : with_top α) < a ↔ 0 < a :=
+@[simp, norm_cast] lemma zero_lt_coe [ordered_add_comm_monoid α] (a : α) : (0 : with_top α) < a ↔ 0 < a :=
 coe_lt_coe
 
 @[simp] lemma add_top [ordered_add_comm_monoid α] : ∀{a : with_top α}, a + ⊤ = ⊤
@@ -388,9 +399,13 @@ begin
     exact ⟨_, rfl, add_le_add_left' h⟩, }
 end
 
-@[simp] lemma coe_zero [add_monoid α] : ((0 : α) : with_bot α) = 0 := rfl
+@[simp, norm_cast] lemma coe_zero [add_monoid α] : ((0 : α) : with_bot α) = 0 := rfl
 
-@[simp] lemma coe_add [add_semigroup α] (a b : α) : ((a + b : α) : with_bot α) = a + b := rfl
+@[simp, norm_cast] lemma coe_eq_zero {α : Type*}
+  [add_monoid α] {a : α} : (a : with_bot α) = 0 ↔ a = 0 :=
+by norm_cast
+
+@[simp, norm_cast] lemma coe_add [add_semigroup α] (a b : α) : ((a + b : α) : with_bot α) = a + b := rfl
 
 @[simp] lemma bot_add [ordered_add_comm_monoid α] (a : with_bot α) : ⊥ + a = ⊥ := rfl
 
@@ -398,7 +413,7 @@ end
 
 instance has_one [has_one α] : has_one (with_bot α) := ⟨(1 : α)⟩
 
-@[simp] lemma coe_one [has_one α] : ((1 : α) : with_bot α) = 1 := rfl
+@[simp, norm_cast] lemma coe_one [has_one α] : ((1 : α) : with_bot α) = 1 := rfl
 
 end with_bot
 
@@ -478,7 +493,7 @@ instance with_top.canonically_ordered_add_monoid : canonically_ordered_add_monoi
     begin
       simp [canonically_ordered_add_monoid.le_iff_exists_add, -add_comm],
       split,
-      { rintro ⟨c, rfl⟩, refine ⟨c, _⟩, simp [with_top.coe_add] },
+      { rintro ⟨c, rfl⟩, refine ⟨c, _⟩, norm_cast },
       { exact assume h, match b, h with _, ⟨some c, rfl⟩ := ⟨_, rfl⟩ end }
     end
   | none, some b := show (⊤ : with_top α) ≤ b ↔ ∃c:with_top α, ↑b = ⊤ + c, by simp
@@ -812,9 +827,8 @@ lemma with_top.add_lt_add_iff_left :
     assume b c h,
     cases b; cases c;
       simp [with_top.none_eq_top, with_top.some_eq_coe, with_top.coe_lt_top, with_top.coe_lt_coe],
-    { rw [← with_top.coe_add], exact with_top.coe_lt_top _ },
-    { rw [← with_top.coe_add, ← with_top.coe_add, with_top.coe_lt_coe],
-      exact add_lt_add_iff_left _ }
+    { norm_cast, exact with_top.coe_lt_top _ },
+    { norm_cast, exact add_lt_add_iff_left _ }
   end
 
 lemma with_top.add_lt_add_iff_right

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -284,11 +284,6 @@ end
 
 end with_zero
 
--- The norm_cast attribute was not available in order.bounded_lattice
--- so I tag them here. TODO Can one change the import heirarchy to fix this?
-attribute [norm_cast] with_top.coe_eq_coe with_top.coe_le_coe with_top.coe_lt_coe
-  with_bot.coe_eq_coe with_bot.coe_le_coe with_bot.coe_lt_coe
-
 namespace with_top
 
 instance [has_zero α] : has_zero (with_top α) := ⟨(0 : α)⟩
@@ -296,8 +291,7 @@ instance [has_zero α] : has_zero (with_top α) := ⟨(0 : α)⟩
 @[simp, norm_cast] lemma coe_zero {α : Type*}
   [has_zero α] : ((0 : α) : with_top α) = 0 := rfl
 
--- not tagged with norm_cast because norm_cast can prove it
-@[simp] lemma coe_eq_zero {α : Type*}
+@[simp, norm_cast] lemma coe_eq_zero {α : Type*}
   [has_zero α] {a : α} : (a : with_top α) = 0 ↔ a = 0 :=
 by norm_cast
 
@@ -306,8 +300,7 @@ instance [has_one α] : has_one (with_top α) := ⟨(1 : α)⟩
 @[simp, norm_cast] lemma coe_one {α : Type*}
   [has_one α] : ((1 : α) : with_top α) = 1 := rfl
 
--- not tagged with norm_cast because norm_cast can prove it
-@[simp] lemma coe_eq_one {α : Type*}
+@[simp, norm_cast] lemma coe_eq_one {α : Type*}
   [has_one α] {a : α} : (a : with_top α) = 1 ↔ a = 1 :=
 by norm_cast
 

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -433,7 +433,7 @@ lemma coe_eq_zero {α : Type*}
 by norm_cast
 
 -- `by norm_cast` proves this lemma, so I did not tag it with `norm_cast`
-lemma coe_add [add_semigroup α] {a b : α} : ((a + b : α) : with_bot α) = a + b := by norm_cast
+lemma coe_add [add_semigroup α] (a b : α) : ((a + b : α) : with_bot α) = a + b := by norm_cast
 
 -- `by norm_cast` proves this lemma, so I did not tag it with `norm_cast`
 lemma coe_bit0 [add_semigroup α] {a : α} : ((bit0 a : α) : with_bot α) = bit0 a :=

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -284,17 +284,44 @@ end
 
 end with_zero
 
--- the norm_cast attribute was not available in order.bounded_lattice
+-- The norm_cast attribute was not available in order.bounded_lattice
+-- so I tag them here. TODO Can one change the import heirarchy to fix this?
 attribute [norm_cast] with_top.coe_eq_coe with_top.coe_le_coe with_top.coe_lt_coe
   with_bot.coe_eq_coe with_bot.coe_le_coe with_bot.coe_lt_coe
 
 namespace with_top
+
+instance [has_zero α] : has_zero (with_top α) := ⟨(0 : α)⟩
+
+@[simp, norm_cast] lemma coe_zero {α : Type*}
+  [has_zero α] : ((0 : α) : with_top α) = 0 := rfl
+
+-- not tagged with norm_cast because norm_cast can prove it
+@[simp] lemma coe_eq_zero {α : Type*}
+  [has_zero α] {a : α} : (a : with_top α) = 0 ↔ a = 0 :=
+by norm_cast
+
+instance [has_one α] : has_one (with_top α) := ⟨(1 : α)⟩
+
+@[simp, norm_cast] lemma coe_one {α : Type*}
+  [has_one α] : ((1 : α) : with_top α) = 1 := rfl
+
+-- not tagged with norm_cast because norm_cast can prove it
+@[simp] lemma coe_eq_one {α : Type*}
+  [has_one α] {a : α} : (a : with_top α) = 1 ↔ a = 1 :=
+by norm_cast
 
 instance [add_semigroup α] : add_semigroup (with_top α) :=
 { add := λ o₁ o₂, o₁.bind (λ a, o₂.map (λ b, a + b)),
   ..@additive.add_semigroup _ $ @with_zero.semigroup (multiplicative α) _ }
 
 @[norm_cast] lemma coe_add [add_semigroup α] {a b : α} : ((a + b : α) : with_top α) = a + b := rfl
+
+@[norm_cast] lemma coe_bit0 [add_semigroup α] {a : α} : ((bit0 a : α) : with_top α) = bit0 a :=
+by unfold bit0; norm_cast
+
+@[norm_cast] lemma coe_bit1 [add_semigroup α] [has_one α] {a : α} : ((bit1 a : α) : with_top α) = bit1 a :=
+by unfold bit1; norm_cast
 
 instance [add_comm_semigroup α] : add_comm_semigroup (with_top α) :=
 { ..@additive.add_comm_semigroup _ $
@@ -304,13 +331,6 @@ instance [add_monoid α] : add_monoid (with_top α) :=
 { zero := some 0,
   add := (+),
   ..@additive.add_monoid _ $ @with_zero.monoid (multiplicative α) _ }
-
-@[simp, norm_cast] lemma coe_zero {α : Type*}
-  [add_monoid α] : ((0 : α) : with_top α) = 0 := rfl
-
-@[simp, norm_cast] lemma coe_eq_zero {α : Type*}
-  [add_monoid α] {a : α} : (a : with_top α) = 0 ↔ a = 0 :=
-by norm_cast
 
 instance [add_comm_monoid α] : add_comm_monoid (with_top α) :=
 { zero := 0,
@@ -370,6 +390,8 @@ end with_top
 
 namespace with_bot
 
+instance [has_zero α] : has_zero (with_bot α) := with_top.has_zero
+instance [has_one α] : has_one (with_bot α) := with_top.has_one
 instance [add_semigroup α] : add_semigroup (with_bot α) := with_top.add_semigroup
 instance [add_comm_semigroup α] : add_comm_semigroup (with_bot α) := with_top.add_comm_semigroup
 instance [add_monoid α] : add_monoid (with_bot α) := with_top.add_monoid
@@ -399,21 +421,31 @@ begin
     exact ⟨_, rfl, add_le_add_left' h⟩, }
 end
 
-@[norm_cast] lemma coe_zero [add_monoid α] : ((0 : α) : with_bot α) = 0 := rfl
+-- `by norm_cast` proves this lemma, so I did not tag it with `norm_cast`
+lemma coe_zero [has_zero α] : ((0 : α) : with_bot α) = 0 := rfl
 
-@[norm_cast] lemma coe_eq_zero {α : Type*}
+-- `by norm_cast` proves this lemma, so I did not tag it with `norm_cast`
+lemma coe_one [has_one α] : ((1 : α) : with_bot α) = 1 := rfl
+
+-- `by norm_cast` proves this lemma, so I did not tag it with `norm_cast`
+lemma coe_eq_zero {α : Type*}
   [add_monoid α] {a : α} : (a : with_bot α) = 0 ↔ a = 0 :=
 by norm_cast
 
-@[simp, norm_cast] lemma coe_add [add_semigroup α] (a b : α) : ((a + b : α) : with_bot α) = a + b := rfl
+-- `by norm_cast` proves this lemma, so I did not tag it with `norm_cast`
+lemma coe_add [add_semigroup α] {a b : α} : ((a + b : α) : with_bot α) = a + b := by norm_cast
+
+-- `by norm_cast` proves this lemma, so I did not tag it with `norm_cast`
+lemma coe_bit0 [add_semigroup α] {a : α} : ((bit0 a : α) : with_bot α) = bit0 a :=
+by norm_cast
+
+-- `by norm_cast` proves this lemma, so I did not tag it with `norm_cast`
+lemma coe_bit1 [add_semigroup α] [has_one α] {a : α} : ((bit1 a : α) : with_bot α) = bit1 a :=
+by norm_cast
 
 @[simp] lemma bot_add [ordered_add_comm_monoid α] (a : with_bot α) : ⊥ + a = ⊥ := rfl
 
 @[simp] lemma add_bot [ordered_add_comm_monoid α] (a : with_bot α) : a + ⊥ = ⊥ := by cases a; refl
-
-instance has_one [has_one α] : has_one (with_bot α) := ⟨(1 : α)⟩
-
-@[simp, norm_cast] lemma coe_one [has_one α] : ((1 : α) : with_bot α) = 1 := rfl
 
 end with_bot
 

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -960,8 +960,6 @@ end canonically_ordered_semiring
 namespace with_top
 variables [canonically_ordered_comm_semiring α]
 
-instance : has_one (with_top α) := ⟨↑(1:α)⟩
-
 @[simp] theorem top_ne_zero : ⊤ ≠ (0 : with_top α) .
 @[simp] theorem zero_ne_top : (0 : with_top α) ≠ ⊤ .
 
@@ -1044,8 +1042,8 @@ begin
 end
 
 private lemma one_mul' : ∀a : with_top α, 1 * a = a
-| none     := show ((1:α) : with_top α) * ⊤ = ⊤, by simp [-with_bot.coe_one]
-| (some a) := show ((1:α) : with_top α) * a = a, by simp [coe_mul.symm, -with_bot.coe_one]
+| none     := show ((1:α) : with_top α) * ⊤ = ⊤, by simp [-with_top.coe_one]
+| (some a) := show ((1:α) : with_top α) * a = a, by simp [coe_mul.symm, -with_top.coe_one]
 
 instance : canonically_ordered_comm_semiring (with_top α) :=
 { one             := (1 : α),

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -965,15 +965,8 @@ instance : has_one (with_top α) := ⟨↑(1:α)⟩
 @[simp] theorem top_ne_zero : ⊤ ≠ (0 : with_top α) .
 @[simp] theorem zero_ne_top : (0 : with_top α) ≠ ⊤ .
 
-@[simp] theorem coe_eq_zero {a : α} : (a : with_top α) = 0 ↔ a = 0 :=
-iff.intro
-  (assume h, match a, h with _, rfl := rfl end)
-  (assume h, h.symm ▸ rfl)
-
 @[simp] theorem zero_eq_coe {a : α} : 0 = (a : with_top α) ↔ a = 0 :=
 by rw [eq_comm, coe_eq_zero]
-
-@[simp] theorem coe_zero : ↑(0 : α) = (0 : with_top α) := rfl
 
 variable [decidable_eq α]
 

--- a/src/order/bounded_lattice.lean
+++ b/src/order/bounded_lattice.lean
@@ -10,6 +10,7 @@ Includes the Prop and fun instances.
 import order.lattice
 import data.option.basic
 import tactic.pi_instances
+import tactic.norm_cast
 
 set_option old_structure_cmd true
 
@@ -355,6 +356,7 @@ instance : inhabited (with_bot α) := ⟨⊥⟩
 lemma none_eq_bot : (none : with_bot α) = (⊥ : with_bot α) := rfl
 lemma some_eq_coe (a : α) : (some a : with_bot α) = (↑a : with_bot α) := rfl
 
+@[norm_cast]
 theorem coe_eq_coe {a b : α} : (a : with_bot α) = b ↔ a = b :=
 by rw [← option.some.inj_eq a b]; refl
 
@@ -397,7 +399,7 @@ instance order_bot [partial_order α] : order_bot (with_bot α) :=
 { bot_le := λ a a' h, option.no_confusion h,
   ..with_bot.partial_order, ..with_bot.has_bot }
 
-@[simp] theorem coe_le_coe [partial_order α] {a b : α} :
+@[simp, norm_cast] theorem coe_le_coe [partial_order α] {a b : α} :
   (a : with_bot α) ≤ b ↔ a ≤ b :=
 ⟨λ h, by rcases h a rfl with ⟨_, ⟨⟩, h⟩; exact h,
  λ h a' e, option.some_inj.1 e ▸ ⟨b, rfl, h⟩⟩
@@ -409,6 +411,7 @@ theorem coe_le [partial_order α] {a b : α} :
   ∀ {o : option α}, b ∈ o → ((a : with_bot α) ≤ o ↔ a ≤ b)
 | _ rfl := coe_le_coe
 
+@[norm_cast]
 lemma coe_lt_coe [partial_order α] {a b : α} : (a : with_bot α) < b ↔ a < b := some_lt_some
 
 lemma le_coe_get_or_else [preorder α] : ∀ (a : with_bot α) (b : α), a ≤ a.get_or_else b
@@ -540,6 +543,7 @@ instance : inhabited (with_top α) := ⟨⊤⟩
 lemma none_eq_top : (none : with_top α) = (⊤ : with_top α) := rfl
 lemma some_eq_coe (a : α) : (some a : with_top α) = (↑a : with_top α) := rfl
 
+@[norm_cast]
 theorem coe_eq_coe {a b : α} : (a : with_top α) = b ↔ a = b :=
 by rw [← option.some.inj_eq a b]; refl
 
@@ -596,7 +600,7 @@ instance order_top [partial_order α] : order_top (with_top α) :=
 { le_top := λ a a' h, option.no_confusion h,
   ..with_top.partial_order, .. with_top.has_top }
 
-@[simp] theorem coe_le_coe [partial_order α] {a b : α} :
+@[simp, norm_cast] theorem coe_le_coe [partial_order α] {a b : α} :
   (a : with_top α) ≤ b ↔ a ≤ b :=
 ⟨λ h, by rcases h b rfl with ⟨_, ⟨⟩, h⟩; exact h,
  λ h a' e, option.some_inj.1 e ▸ ⟨a, rfl, h⟩⟩
@@ -618,6 +622,7 @@ theorem lt_iff_exists_coe [partial_order α] : ∀(a b : with_top α), a < b ↔
 | (some a) b := by simp [some_eq_coe, coe_eq_coe]
 | none     b := by simp [none_eq_top]
 
+@[norm_cast]
 lemma coe_lt_coe [partial_order α] {a b : α} : (a : with_top α) < b ↔ a < b := some_lt_some
 
 lemma coe_lt_top [partial_order α] (a : α) : (a : with_top α) < ⊤ :=
@@ -918,4 +923,3 @@ is_compl.of_eq bot_inf_eq sup_top_eq
 
 lemma is_compl_top_bot [bounded_lattice α] : is_compl (⊤ : α) ⊥ :=
 is_compl.of_eq inf_bot_eq top_sup_eq
-

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -206,7 +206,6 @@ with_top (multiset { a : associates α // irreducible a })
 
 local attribute [instance] associated.setoid
 
--- removing norm_cast attribute becasue proof is by norm_cast
 theorem factor_set.coe_add {a b : multiset { a : associates α // irreducible a }} :
   (↑(a + b) : factor_set α) = a + b :=
 by norm_cast

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -206,10 +206,10 @@ with_top (multiset { a : associates α // irreducible a })
 
 local attribute [instance] associated.setoid
 
-@[norm_cast]
+-- removing norm_cast attribute becasue proof is by norm_cast
 theorem factor_set.coe_add {a b : multiset { a : associates α // irreducible a }} :
   (↑(a + b) : factor_set α) = a + b :=
-by simp
+by norm_cast
 
 lemma factor_set.sup_add_inf_eq_add [decidable_eq (associates α)] :
   ∀(a b : factor_set α), a ⊔ b + a ⊓ b = a + b


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->
A few `with_top` and `with_bot` coercion lemmas didn't have the `norm_cast` attribute. I added them. 

Comments:

1) I went to the docs to read about which lemmas should be tagged, but the recent refactor which meant that everything should be tagged `norm_cast` also entailed a cleanup of the docs, so I was a bit in the dark as to exactly what I should be tagging. I went for an "if it moves, norm_cast it" approach on the basis that it would be easier for a reviewer to say "no, you don't tag that kind of lemma" than for a reviewer to say "you missed this one, 100 lines up". 

2) The `norm_cast` attribute was not available in `order.bounded_lattice` so I just add the attribute to the coe lemmas from that file in the ordered_group file, where the attribute was available. This can't be the right answer. But again I took the approach that it was better to do the wrong thing than just ignore the problem completely and then forget about it.

3) coe_zero and coe_eq_zero were only written for canonically ordered rings or something -- I've changed it so that they apply to additive monoids. Why can't they just apply to `with_zero`? Is there a problem with defining a zero on with_top X to be the zero of X, whenever X has a zero?
