### PR TITLE
[Merged by Bors] - refactor(order/filter/basic): define `filter.eventually_eq`

### DIFF
--- a/src/analysis/asymptotics.lean
+++ b/src/analysis/asymptotics.lean
@@ -150,7 +150,7 @@ let ⟨c, hc⟩ := h in hc.exists_nonneg
 /-! ### Congruence -/
 
 theorem is_O_with_congr {c₁ c₂} {f₁ f₂ : α → E} {g₁ g₂ : α → F} {l : filter α}
-  (hc : c₁ = c₂) (hf : ∀ᶠ x in l, f₁ x = f₂ x) (hg : ∀ᶠ x in l, g₁ x = g₂ x) :
+  (hc : c₁ = c₂) (hf : f₁ =ᶠ[l] f₂) (hg : g₁ =ᶠ[l] g₂) :
   is_O_with c₁ f₁ g₁ l ↔ is_O_with c₂ f₂ g₂ l :=
 begin
   subst c₂,
@@ -162,7 +162,7 @@ begin
 end
 
 theorem is_O_with.congr' {c₁ c₂} {f₁ f₂ : α → E} {g₁ g₂ : α → F} {l : filter α}
-  (hc : c₁ = c₂) (hf : ∀ᶠ x in l, f₁ x = f₂ x) (hg : ∀ᶠ x in l, g₁ x = g₂ x) :
+  (hc : c₁ = c₂) (hf : f₁ =ᶠ[l] f₂) (hg : g₁ =ᶠ[l] g₂) :
   is_O_with c₁ f₁ g₁ l → is_O_with c₂ f₂ g₂ l :=
 (is_O_with_congr hc hf hg).mp
 
@@ -184,12 +184,12 @@ theorem is_O_with.congr_const {c₁ c₂} {l : filter α} (hc : c₁ = c₂) :
 is_O_with.congr hc (λ _, rfl) (λ _, rfl)
 
 theorem is_O_congr {f₁ f₂ : α → E} {g₁ g₂ : α → F} {l : filter α}
-    (hf : ∀ᶠ x in l, f₁ x = f₂ x) (hg : ∀ᶠ x in l, g₁ x = g₂ x) :
+    (hf : f₁ =ᶠ[l] f₂) (hg : g₁ =ᶠ[l] g₂) :
   is_O f₁ g₁ l ↔ is_O f₂ g₂ l :=
 exists_congr $ λ c, is_O_with_congr rfl hf hg
 
 theorem is_O.congr' {f₁ f₂ : α → E} {g₁ g₂ : α → F} {l : filter α}
-  (hf : ∀ᶠ x in l, f₁ x = f₂ x) (hg : ∀ᶠ x in l, g₁ x = g₂ x) :
+    (hf : f₁ =ᶠ[l] f₂) (hg : g₁ =ᶠ[l] g₂) :
   is_O f₁ g₁ l → is_O f₂ g₂ l :=
 (is_O_congr hf hg).mp
 
@@ -207,12 +207,12 @@ theorem is_O.congr_right {g₁ g₂ : α → E} {l : filter α} (hg : ∀ x, g�
 is_O.congr (λ _, rfl) hg
 
 theorem is_o_congr {f₁ f₂ : α → E} {g₁ g₂ : α → F} {l : filter α}
-    (hf : ∀ᶠ x in l, f₁ x = f₂ x) (hg : ∀ᶠ x in l, g₁ x = g₂ x) :
+    (hf : f₁ =ᶠ[l] f₂) (hg : g₁ =ᶠ[l] g₂) :
   is_o f₁ g₁ l ↔ is_o f₂ g₂ l :=
 ball_congr (λ c hc, is_O_with_congr (eq.refl c) hf hg)
 
 theorem is_o.congr' {f₁ f₂ : α → E} {g₁ g₂ : α → F} {l : filter α}
-  (hf : ∀ᶠ x in l, f₁ x = f₂ x) (hg : ∀ᶠ x in l, g₁ x = g₂ x) :
+    (hf : f₁ =ᶠ[l] f₂) (hg : g₁ =ᶠ[l] g₂) :
   is_o f₁ g₁ l → is_o f₂ g₂ l :=
 (is_o_congr hf hg).mp
 

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -237,11 +237,9 @@ begin
     (norm_smul _ _).symm, tendsto_zero_iff_norm_tendsto_zero.symm] },
   conv_rhs { rw [← nhds_translation f', tendsto_comap_iff] },
   refine (tendsto_inf_principal_nhds_iff_of_forall_eq $ by simp).symm.trans (tendsto_congr' _),
-  rw mem_inf_principal,
-  refine univ_mem_sets' (λ z hz, _),
-  have : z ≠ x, by simpa [function.comp] using hz,
-  simp only [mem_set_of_eq],
-  rw [smul_sub, ← mul_smul, inv_mul_cancel (sub_ne_zero.2 this), one_smul]
+  refine (eventually_principal.2 $ λ z hz, _).filter_mono inf_le_right,
+  simp only [(∘)],
+  rw [smul_sub, ← mul_smul, inv_mul_cancel (sub_ne_zero.2 hz), one_smul]
 end
 
 lemma has_deriv_within_at_iff_tendsto_slope {x : 𝕜} {s : set 𝕜} :

--- a/src/data/padics/hensel.lean
+++ b/src/data/padics/hensel.lean
@@ -355,10 +355,7 @@ squeeze_zero (λ _, norm_nonneg _) newton_seq_norm_le bound'_sq
 
 private lemma newton_seq_dist_tendsto :
   tendsto (λ n, ∥newton_cau_seq n - a∥) at_top (𝓝 (∥F.eval a∥ / ∥F.derivative.eval a∥)) :=
-tendsto.congr'
-  (suffices ∃ k, ∀ n ≥ k,  ∥F.eval a∥ / ∥F.derivative.eval a∥ = ∥newton_cau_seq n - a∥, by simpa,
-    ⟨1, λ _ hx, (newton_seq_dist_to_a _ hx).symm⟩)
-  (tendsto_const_nhds)
+tendsto_const_nhds.congr' $ eventually_at_top.2 ⟨1, λ _ hx, (newton_seq_dist_to_a _ hx).symm⟩
 
 private lemma newton_seq_dist_tendsto' :
   tendsto (λ n, ∥newton_cau_seq n - a∥) at_top (𝓝 ∥soln - a∥) :=

--- a/src/measure_theory/indicator_function.lean
+++ b/src/measure_theory/indicator_function.lean
@@ -114,7 +114,7 @@ begin
   by_cases h : ∃i, a ∈ s i,
   { rcases h with ⟨i, hi⟩,
     haveI : inhabited ι := ⟨i⟩,
-    simp only [tendsto_pure, mem_at_top_sets, mem_set_of_eq],
+    simp only [tendsto_pure, eventually_at_top],
     use i, assume n hn,
     rw [indicator_of_mem (hs hn hi) _, indicator_of_mem ((subset_Union _ _) hi) _] },
   { rw [not_exists] at h,
@@ -133,7 +133,7 @@ begin
   by_cases h : ∃i, a ∉ s i,
   { rcases h with ⟨i, hi⟩,
     haveI : inhabited ι := ⟨i⟩,
-    simp only [tendsto_pure, mem_at_top_sets, mem_set_of_eq],
+    simp only [tendsto_pure, eventually_at_top],
     use i, assume n hn,
     rw [indicator_of_not_mem _ _, indicator_of_not_mem _ _],
     { simp only [mem_Inter, not_forall], exact ⟨i, hi⟩ },
@@ -151,7 +151,7 @@ lemma tendsto_indicator_bUnion_finset {ι} [has_zero β] (s : ι → set α) (f 
   tendsto (λ (n : finset ι), indicator (⋃i∈n, s i) f a) at_top (pure $ indicator (Union s) f a) :=
 begin
   by_cases h : ∃i, a ∈ s i,
-  { simp only [mem_at_top_sets, tendsto_pure, mem_set_of_eq, ge_iff_le, finset.le_iff_subset],
+  { simp only [tendsto_pure, eventually_at_top, ge_iff_le, finset.le_iff_subset],
     rcases h with ⟨i, hi⟩,
     use {i}, assume n hn,
     replace hn : i ∈ n := hn (finset.mem_singleton_self _),

--- a/src/order/filter/at_top_bot.lean
+++ b/src/order/filter/at_top_bot.lean
@@ -63,7 +63,7 @@ iff.intro
     (assume s₁ s₂ h ⟨a, ha⟩, ⟨a, assume b hb, h $ ha _ hb⟩))
   (assume ⟨a, h⟩, mem_infi_sets a $ assume x, h x)
 
-@[nolint ge_or_gt]
+@[simp, nolint ge_or_gt]
 lemma eventually_at_top {α} [semilattice_sup α] [nonempty α] {p : α → Prop} :
   (∀ᶠ x in at_top, p x) ↔ (∃ a, ∀ b ≥ a, p b) :=
 by simp only [filter.eventually, filter.mem_at_top_sets, mem_set_of_eq]

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -1053,7 +1053,7 @@ H.mono $ λ _, eq.symm
   f =ᶠ[l] h :=
 H₂.rw (λ x y, f x = y) H₁
 
-lemma eventually_eq.func_comp {f g : α → β} {l : filter α} (H : f =ᶠ[l] g) (h : β → γ) :
+lemma eventually_eq.fun_comp {f g : α → β} {l : filter α} (H : f =ᶠ[l] g) (h : β → γ) :
   (h ∘ f) =ᶠ[l] (h ∘ g) :=
 H.mono $ λ x hx, congr_arg h hx
 
@@ -1071,7 +1071,7 @@ h.comp₂ (*) h'
 @[to_additive]
 lemma eventually_eq.inv [has_inv β] {f g : α → β} {l : filter α} (h : f =ᶠ[l] g) :
   ((λ x, (f x)⁻¹) =ᶠ[l] (λ x, (g x)⁻¹)) :=
-h.func_comp has_inv.inv
+h.fun_comp has_inv.inv
 
 lemma eventually_eq.div [group_with_zero β] {f f' g g' : α → β} {l : filter α} (h : f =ᶠ[l] g)
   (h' : f' =ᶠ[l] g') :
@@ -1130,6 +1130,8 @@ funext $ assume _, filter_eq $ rfl
 @[simp] lemma map_map : filter.map m' (filter.map m f) = filter.map (m' ∘ m) f :=
 congr_fun (@@filter.map_compose m m') f
 
+/-- If functions `m₁` and `m₂` are eventually equal at a filter `f`, then
+they map this filter to the same filter. -/
 lemma map_congr {m₁ m₂ : α → β} {f : filter α} (h : m₁ =ᶠ[f] m₂) :
   map m₁ f = map m₂ f :=
 filter.ext' $ λ p,

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -373,27 +373,24 @@ begin
 end
 
 lemma continuous_on.congr_mono {f g : α → β} {s s₁ : set α} (h : continuous_on f s)
-  (h' : ∀x ∈ s₁, g x = f x) (h₁ : s₁ ⊆ s) : continuous_on g s₁ :=
+  (h' : eq_on g f s₁) (h₁ : s₁ ⊆ s) : continuous_on g s₁ :=
 begin
   assume x hx,
   unfold continuous_within_at,
   have A := (h x (h₁ hx)).mono h₁,
   unfold continuous_within_at at A,
-  rw ← h' x hx at A,
-  have : {x : α | g x = f x} ∈ nhds_within x s₁ := mem_inf_sets_of_right h',
-  apply tendsto.congr' _ A,
-  convert this,
-  ext,
-  finish
+  rw ← h' hx at A,
+  have : (g =ᶠ[nhds_within x s₁] f) := mem_inf_sets_of_right h',
+  exact A.congr' this.symm
 end
 
-lemma continuous_on.congr {f g : α → β} {s : set α} (h : continuous_on f s)
-  (h' : ∀x ∈ s, g x = f x) : continuous_on g s :=
+lemma continuous_on.congr {f g : α → β} {s : set α} (h : continuous_on f s) (h' : eq_on g f s) :
+  continuous_on g s :=
 h.congr_mono h' (subset.refl _)
 
-lemma continuous_on_congr {f g : α → β} {s : set α} (h' : ∀x ∈ s, g x = f x) :
+lemma continuous_on_congr {f g : α → β} {s : set α} (h' : eq_on g f s) :
   continuous_on g s ↔ continuous_on f s :=
-⟨λ h, continuous_on.congr h (λx hx, (h' x hx).symm), λ h, continuous_on.congr h h'⟩
+⟨λ h, continuous_on.congr h h'.symm, λ h, h.congr h'⟩
 
 lemma continuous_at.continuous_within_at {f : α → β} {s : set α} {x : α} (h : continuous_at f x) :
   continuous_within_at f s x :=
@@ -468,9 +465,9 @@ begin
 end
 
 lemma continuous_within_at.congr_of_mem_nhds_within {f f₁ : α → β} {s : set α} {x : α}
-  (h : continuous_within_at f s x) (h₁ : {y | f₁ y = f y} ∈ nhds_within x s) (hx : f₁ x = f x) :
+  (h : continuous_within_at f s x) (h₁ : f₁ =ᶠ[nhds_within x s] f) (hx : f₁ x = f x) :
   continuous_within_at f₁ s x :=
-by rwa [continuous_within_at, filter.tendsto, hx, filter.map_cong h₁]
+by rwa [continuous_within_at, filter.tendsto, hx, filter.map_congr h₁]
 
 lemma continuous_within_at.congr {f f₁ : α → β} {s : set α} {x : α}
   (h : continuous_within_at f s x) (h₁ : ∀y∈s, f₁ y = f y) (hx : f₁ x = f x) :


### PR DESCRIPTION
* Define `eventually_eq` (`f =^f[l] g`) and `eventually_le` (`f ≤^f[l] g`).
* Use new notation and definitions in some files.

---
<!-- put comments you want to keep out of the PR commit here -->