### PR TITLE
[Merged by Bors] - chore(linear_algebra/nonsingular_inverse): `matrix.nonsing_inv` no longer requires base ring to carry `has_inv` instance

### DIFF
--- a/src/algebra/group/units.lean
+++ b/src/algebra/group/units.lean
@@ -277,6 +277,7 @@ by cases ha with a ha; rw [←ha, units.mul_right_inj]
   b * a = c * a ↔ b = c :=
 by cases ha with a ha; rw [←ha, units.mul_left_inj]
 
+/-- The element of the group of units, corresponding to an element of a monoid which is a unit. -/
 noncomputable def is_unit.unit [monoid M] {a : M} (h : is_unit a) : units M :=
 classical.some h
 

--- a/src/algebra/group/units.lean
+++ b/src/algebra/group/units.lean
@@ -82,6 +82,14 @@ attribute [norm_cast] add_units.coe_neg
 @[simp, to_additive] lemma inv_mul : (↑a⁻¹ * a : α) = 1 := inv_val _
 @[simp, to_additive] lemma mul_inv : (a * ↑a⁻¹ : α) = 1 := val_inv _
 
+@[to_additive] lemma inv_mul' {α : Type*} [monoid α] {a : α} {u : units α} (h : ↑u = a) :
+  ↑u⁻¹ * a = 1 :=
+by { rw [←h, u.inv_mul], }
+
+@[to_additive] lemma mul_inv' {α : Type*} [monoid α] {a : α} {u : units α} (h : ↑u = a) :
+  a * ↑u⁻¹ = 1 :=
+by { rw [←h, u.mul_inv], }
+
 @[simp, to_additive] lemma mul_inv_cancel_left (a : units α) (b : α) : (a:α) * (↑a⁻¹ * b) = b :=
 by rw [← mul_assoc, mul_inv, one_mul]
 
@@ -118,6 +126,19 @@ by rw [mul_assoc, inv_mul, mul_one]
 
 @[to_additive] theorem mul_inv_eq_iff_eq_mul {a c : α} : a * ↑b⁻¹ = c ↔ a = c * b :=
 ⟨λ h, by rw [← h, inv_mul_cancel_right], λ h, by rw [h, mul_inv_cancel_right]⟩
+
+lemma inv_eq_of_mul_eq_one (u : units α) (a : α) (h : ↑u * a = 1) :
+  ↑u⁻¹ = a :=
+calc ↑u⁻¹ = ↑u⁻¹ * 1 : by rw mul_one
+      ... = ↑u⁻¹ * ↑u * a : by rw [←h, ←mul_assoc]
+      ... = a : by rw [u.inv_mul, one_mul]
+
+lemma inv_unique {u₁ u₂ : units α} (h : (↑u₁ : α) = ↑u₂) :
+  (↑u₁⁻¹ : α) = ↑u₂⁻¹ :=
+begin
+  suffices : ↑u₁ * (↑u₂⁻¹ : α) = 1, by exact u₁.inv_eq_of_mul_eq_one _ this,
+  rw [h, u₂.mul_inv],
+end
 
 end units
 
@@ -255,5 +276,11 @@ by cases ha with a ha; rw [←ha, units.mul_right_inj]
 @[to_additive] theorem is_unit.mul_left_inj [monoid M] {a b c : M} (ha : is_unit a) :
   b * a = c * a ↔ b = c :=
 by cases ha with a ha; rw [←ha, units.mul_left_inj]
+
+noncomputable def is_unit.unit [monoid M] {a : M} (h : is_unit a) : units M :=
+classical.some h
+
+lemma is_unit.unit_spec [monoid M] {a : M} (h : is_unit a) : ↑h.unit = a :=
+classical.some_spec h
 
 end is_unit

--- a/src/algebra/group/units.lean
+++ b/src/algebra/group/units.lean
@@ -125,18 +125,13 @@ by rw [mul_assoc, inv_mul, mul_one]
 @[to_additive] theorem mul_inv_eq_iff_eq_mul {a c : α} : a * ↑b⁻¹ = c ↔ a = c * b :=
 ⟨λ h, by rw [← h, inv_mul_cancel_right], λ h, by rw [h, mul_inv_cancel_right]⟩
 
-lemma inv_eq_of_mul_eq_one {u : units α} {a : α} (h : ↑u * a = 1) :
-  ↑u⁻¹ = a :=
+lemma inv_eq_of_mul_eq_one {u : units α} {a : α} (h : ↑u * a = 1) : ↑u⁻¹ = a :=
 calc ↑u⁻¹ = ↑u⁻¹ * 1 : by rw mul_one
       ... = ↑u⁻¹ * ↑u * a : by rw [←h, ←mul_assoc]
       ... = a : by rw [u.inv_mul, one_mul]
 
-lemma inv_unique {u₁ u₂ : units α} (h : (↑u₁ : α) = ↑u₂) :
-  (↑u₁⁻¹ : α) = ↑u₂⁻¹ :=
-begin
-  suffices : ↑u₁ * (↑u₂⁻¹ : α) = 1, by exact inv_eq_of_mul_eq_one this,
-  rw [h, u₂.mul_inv],
-end
+lemma inv_unique {u₁ u₂ : units α} (h : (↑u₁ : α) = ↑u₂) : (↑u₁⁻¹ : α) = ↑u₂⁻¹ :=
+suffices ↑u₁ * (↑u₂⁻¹ : α) = 1, by exact inv_eq_of_mul_eq_one this, by rw [h, u₂.mul_inv]
 
 end units
 

--- a/src/algebra/group/units.lean
+++ b/src/algebra/group/units.lean
@@ -82,12 +82,10 @@ attribute [norm_cast] add_units.coe_neg
 @[simp, to_additive] lemma inv_mul : (↑a⁻¹ * a : α) = 1 := inv_val _
 @[simp, to_additive] lemma mul_inv : (a * ↑a⁻¹ : α) = 1 := val_inv _
 
-@[to_additive] lemma inv_mul' {α : Type*} [monoid α] {a : α} {u : units α} (h : ↑u = a) :
-  ↑u⁻¹ * a = 1 :=
+@[to_additive] lemma inv_mul' {u : units α} {a : α} (h : ↑u = a) : ↑u⁻¹ * a = 1 :=
 by { rw [←h, u.inv_mul], }
 
-@[to_additive] lemma mul_inv' {α : Type*} [monoid α] {a : α} {u : units α} (h : ↑u = a) :
-  a * ↑u⁻¹ = 1 :=
+@[to_additive] lemma mul_inv' {u : units α} {a : α} (h : ↑u = a) : a * ↑u⁻¹ = 1 :=
 by { rw [←h, u.mul_inv], }
 
 @[simp, to_additive] lemma mul_inv_cancel_left (a : units α) (b : α) : (a:α) * (↑a⁻¹ * b) = b :=
@@ -127,7 +125,7 @@ by rw [mul_assoc, inv_mul, mul_one]
 @[to_additive] theorem mul_inv_eq_iff_eq_mul {a c : α} : a * ↑b⁻¹ = c ↔ a = c * b :=
 ⟨λ h, by rw [← h, inv_mul_cancel_right], λ h, by rw [h, mul_inv_cancel_right]⟩
 
-lemma inv_eq_of_mul_eq_one (u : units α) (a : α) (h : ↑u * a = 1) :
+lemma inv_eq_of_mul_eq_one {u : units α} {a : α} (h : ↑u * a = 1) :
   ↑u⁻¹ = a :=
 calc ↑u⁻¹ = ↑u⁻¹ * 1 : by rw mul_one
       ... = ↑u⁻¹ * ↑u * a : by rw [←h, ←mul_assoc]
@@ -136,7 +134,7 @@ calc ↑u⁻¹ = ↑u⁻¹ * 1 : by rw mul_one
 lemma inv_unique {u₁ u₂ : units α} (h : (↑u₁ : α) = ↑u₂) :
   (↑u₁⁻¹ : α) = ↑u₂⁻¹ :=
 begin
-  suffices : ↑u₁ * (↑u₂⁻¹ : α) = 1, by exact u₁.inv_eq_of_mul_eq_one _ this,
+  suffices : ↑u₁ * (↑u₂⁻¹ : α) = 1, by exact inv_eq_of_mul_eq_one this,
   rw [h, u₂.mul_inv],
 end
 

--- a/src/algebra/invertible.lean
+++ b/src/algebra/invertible.lean
@@ -73,6 +73,10 @@ by simp [mul_assoc]
 lemma inv_of_eq_right_inv [monoid α] {a b : α} [invertible a] (hac : a * b = 1) : ⅟a = b :=
 left_inv_eq_right_inv (inv_of_mul_self _) hac
 
+lemma invertible_unique {α : Type u} [monoid α] (a b : α) (h : a = b) [invertible a] [invertible b] :
+  ⅟a = ⅟b :=
+by { apply inv_of_eq_right_inv, rw [h, mul_inv_of_self], }
+
 instance [monoid α] (a : α) : subsingleton (invertible a) :=
 ⟨ λ ⟨b, hba, hab⟩ ⟨c, hca, hac⟩, by { congr, exact left_inv_eq_right_inv hba hac } ⟩
 

--- a/src/linear_algebra/nonsingular_inverse.lean
+++ b/src/linear_algebra/nonsingular_inverse.lean
@@ -366,12 +366,14 @@ by { rw det_transpose, exact h, }
 noncomputable def nonsing_inv : matrix n n α :=
 if h : is_unit A.det then (↑h.unit⁻¹ : α) • A.adjugate else 0
 
+noncomputable instance : has_inv (matrix n n α) := ⟨matrix.nonsing_inv⟩
+
 lemma nonsing_inv_apply (h : is_unit A.det) :
-  A.nonsing_inv = (↑h.unit⁻¹ : α) • A.adjugate :=
-by { dunfold nonsing_inv, simp only [dif_pos, h], }
+  A⁻¹ = (↑h.unit⁻¹ : α) • A.adjugate :=
+by { change A.nonsing_inv = _, dunfold nonsing_inv, simp only [dif_pos, h], }
 
 lemma transpose_nonsing_inv (h : is_unit A.det) :
-  (A.nonsing_inv)ᵀ = Aᵀ.nonsing_inv :=
+  (A⁻¹)ᵀ = (Aᵀ)⁻¹ :=
 begin
   have h' := A.is_unit_det_transpose h,
   have dets_eq : (↑h.unit : α) = ↑h'.unit := by rw [h.unit_spec, h'.unit_spec, det_transpose],
@@ -381,36 +383,35 @@ begin
 end
 
 /-- The `nonsing_inv` of `A` is a right inverse. -/
-@[simp] lemma mul_nonsing_inv (h : is_unit A.det) : A ⬝ A.nonsing_inv = 1 :=
+@[simp] lemma mul_nonsing_inv (h : is_unit A.det) : A ⬝ A⁻¹ = 1 :=
 by rw [A.nonsing_inv_apply h, mul_smul, mul_adjugate, smul_smul, units.inv_mul' h.unit_spec,
        one_smul]
 
 /-- The `nonsing_inv` of `A` is a left inverse. -/
-@[simp] lemma nonsing_inv_mul (h : is_unit A.det) : A.nonsing_inv ⬝ A = 1 :=
-calc A.nonsing_inv ⬝ A
-    = (Aᵀ ⬝ Aᵀ.nonsing_inv)ᵀ : by { rw [transpose_mul,
-                                       Aᵀ.transpose_nonsing_inv (A.is_unit_det_transpose h),
-                                       transpose_transpose], }
-... = 1ᵀ                     : by { rw Aᵀ.mul_nonsing_inv, exact A.is_unit_det_transpose h, }
-... = 1                      : transpose_one
+@[simp] lemma nonsing_inv_mul (h : is_unit A.det) : A⁻¹ ⬝ A = 1 :=
+calc A⁻¹ ⬝ A = (Aᵀ ⬝ (Aᵀ)⁻¹)ᵀ : by { rw [transpose_mul,
+                                    Aᵀ.transpose_nonsing_inv (A.is_unit_det_transpose h),
+                                    transpose_transpose], }
+         ... = 1ᵀ             : by { rw Aᵀ.mul_nonsing_inv, exact A.is_unit_det_transpose h, }
+         ... = 1              : transpose_one
 
-@[simp] lemma nonsing_inv_det (h : is_unit A.det) : A.nonsing_inv.det * A.det = 1 :=
+@[simp] lemma nonsing_inv_det (h : is_unit A.det) : A⁻¹.det * A.det = 1 :=
 by rw [←det_mul, A.nonsing_inv_mul h, det_one]
 
-lemma is_unit_nonsing_inv_det (h : is_unit A.det) : is_unit A.nonsing_inv.det :=
+lemma is_unit_nonsing_inv_det (h : is_unit A.det) : is_unit A⁻¹.det :=
 is_unit_of_mul_eq_one _ _ (A.nonsing_inv_det h)
 
-@[simp] lemma nonsing_inv_nonsing_inv (h : is_unit A.det) : A.nonsing_inv.nonsing_inv = A :=
-calc A.nonsing_inv.nonsing_inv
-    = 1 ⬝ A.nonsing_inv.nonsing_inv : by rw matrix.one_mul
-... = A ⬝ A.nonsing_inv ⬝ A.nonsing_inv.nonsing_inv : by rw A.mul_nonsing_inv h
-... = A : by { rw [matrix.mul_assoc, A.nonsing_inv.mul_nonsing_inv (A.is_unit_nonsing_inv_det h),
-                   matrix.mul_one], }
+@[simp] lemma nonsing_inv_nonsing_inv (h : is_unit A.det) : (A⁻¹)⁻¹ = A :=
+calc (A⁻¹)⁻¹ = 1 ⬝ (A⁻¹)⁻¹        : by rw matrix.one_mul
+         ... = A ⬝ A⁻¹ ⬝ (A⁻¹)⁻¹  : by rw A.mul_nonsing_inv h
+         ... = A                  : by { rw [matrix.mul_assoc,
+                                         (A⁻¹).mul_nonsing_inv (A.is_unit_nonsing_inv_det h),
+                                         matrix.mul_one], }
 
 /-- A matrix whose determinant is a unit is itself a unit. -/
 noncomputable def nonsing_inv_unit (h : is_unit A.det) : units (matrix n n α) :=
 { val     := A,
-  inv     := A.nonsing_inv,
+  inv     := A⁻¹,
   val_inv := by { rw matrix.mul_eq_mul, apply A.mul_nonsing_inv h, },
   inv_val := by { rw matrix.mul_eq_mul, apply A.nonsing_inv_mul h, } }
 


### PR DESCRIPTION
---

There are several other ways one could set this up including:

1. Requiring the user to supply an argument of type `is_unit A.det` to `matrix.nonsing_inv`, thus avoiding the need to define a result on non-invertible matrices.
1. Requiring the user to supply an actual unit that inverts `A.det` to `matrix.nonsing_inv`, thus rendering the function computable.
1. Using the `invertible` class to pull the required inverse for `A.det` from a typeclass instance.

Obviously I prefer the approach proposed but I am interested in dissenting opinions!

https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Concerns.20about.20.60invertible.60.20class
