### PR TITLE
[Merged by Bors] - feat(data/finset): add card_insert_of_mem

### DIFF
--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -1395,6 +1395,9 @@ by cases s; simp only [multiset.card_eq_one, finset.card, ← val_inj, singleton
 by simpa only [card_cons, card, insert_val] using
 congr_arg multiset.card (ndinsert_of_not_mem h)
 
+@[simp] theorem card_insert_of_mem [decidable_eq α] {a : α} {s : finset α}
+  (h : a ∈ s) : card (insert a s) = card s := by rw insert_eq_of_mem h
+
 theorem card_insert_le [decidable_eq α] (a : α) (s : finset α) : card (insert a s) ≤ card s + 1 :=
 by by_cases a ∈ s; [{rw [insert_eq_of_mem h], apply nat.le_add_right},
 rw [card_insert_of_not_mem h]]

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -1395,7 +1395,7 @@ by cases s; simp only [multiset.card_eq_one, finset.card, ← val_inj, singleton
 by simpa only [card_cons, card, insert_val] using
 congr_arg multiset.card (ndinsert_of_not_mem h)
 
-@[simp] theorem card_insert_of_mem [decidable_eq α] {a : α} {s : finset α}
+theorem card_insert_of_mem [decidable_eq α] {a : α} {s : finset α}
   (h : a ∈ s) : card (insert a s) = card s := by rw insert_eq_of_mem h
 
 theorem card_insert_le [decidable_eq α] (a : α) (s : finset α) : card (insert a s) ≤ card s + 1 :=


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->
A Zulip user was asking where this function was; they found card_insert_of_not_mem. Note that insert_eq_of_mem is strictly stronger (the cardinalities are equal because the finsets are equal). Is this worth putting in the library?
