### PR TITLE
[Merged by Bors] - feat(linear_algebra/finsupp_vector_space): is_basis.tensor_product

### DIFF
--- a/src/data/finsupp.lean
+++ b/src/data/finsupp.lean
@@ -1490,6 +1490,11 @@ lemma sum_smul_index [ring β] [add_comm_monoid γ] {g : α →₀ β} {b : β} 
   (h0 : ∀i, h i 0 = 0) : (b • g).sum h = g.sum (λi a, h i (b * a)) :=
 finsupp.sum_map_range_index h0
 
+lemma sum_smul_index' [semiring β] [add_comm_monoid γ] [semimodule β γ] [add_comm_monoid δ]
+  {g : α →₀ γ} {b : β} {h : α → γ → δ} (h0 : ∀i, h i 0 = 0) :
+  (b • g).sum h = g.sum (λi c, h i (b • c)) :=
+finsupp.sum_map_range_index h0
+
 section
 variables [semiring β] [semiring γ]
 

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -823,6 +823,10 @@ by rw [is_basis.constr, linear_map.range_comp, linear_map.range_comp, is_basis.r
 def module_equiv_finsupp (hv : is_basis R v) : M ≃ₗ[R] ι →₀ R :=
 (hv.1.total_equiv.trans (linear_equiv.of_top _ hv.2)).symm
 
+@[simp] theorem module_equiv_finsupp_apply (hv : is_basis R v) (i : ι) :
+  module_equiv_finsupp hv (v i) = finsupp.single i 1 :=
+(linear_equiv.symm_apply_eq _).2 $ by simp [linear_independent.total_equiv]
+
 /-- Isomorphism between the two modules, given two modules `M` and `M'` with respective bases
 `v` and `v'` and a bijection between the indexing sets of the two bases. -/
 def equiv_of_is_basis {v : ι → M} {v' : ι' → M'} (hv : is_basis R v) (hv' : is_basis R v')

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -823,7 +823,7 @@ by rw [is_basis.constr, linear_map.range_comp, linear_map.range_comp, is_basis.r
 def module_equiv_finsupp (hv : is_basis R v) : M ≃ₗ[R] ι →₀ R :=
 (hv.1.total_equiv.trans (linear_equiv.of_top _ hv.2)).symm
 
-@[simp] theorem module_equiv_finsupp_apply (hv : is_basis R v) (i : ι) :
+@[simp] theorem module_equiv_finsupp_apply_basis (hv : is_basis R v) (i : ι) :
   module_equiv_finsupp hv (v i) = finsupp.single i 1 :=
 (linear_equiv.symm_apply_eq _).2 $ by simp [linear_independent.total_equiv]
 

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -403,6 +403,7 @@ by rw finsupp.total_apply; refl
 
 end total
 
+/-- An equivalence of domains induces a linear equivalence of finitely supported functions. -/
 protected def dom_lcongr
   {α₁ : Type*} {α₂ : Type*} (e : α₁ ≃ α₂) :
   (α₁ →₀ M) ≃ₗ[R] (α₂ →₀ M) :=
@@ -411,6 +412,10 @@ begin
   change is_linear_map R (lmap_domain M R e : (α₁ →₀ M) →ₗ[R] (α₂ →₀ M)),
   exact linear_map.is_linear _
 end
+
+@[simp] theorem dom_lcongr_single {α₁ : Type*} {α₂ : Type*} (e : α₁ ≃ α₂) (i : α₁) (m : M) :
+  (finsupp.dom_lcongr e : _ ≃ₗ[R] _) (finsupp.single i m) = finsupp.single (e i) m :=
+by simp [finsupp.dom_lcongr, equiv.to_linear_equiv, finsupp.dom_congr, map_domain_single]
 
 noncomputable def congr {α' : Type*} (s : set α) (t : set α') (e : s ≃ t) :
   supported M R s ≃ₗ[R] supported M R t :=
@@ -421,6 +426,28 @@ begin
       (linear_equiv.trans _ (finsupp.supported_equiv_finsupp t).symm),
   exact finsupp.dom_lcongr e
 end
+
+/-- An equivalence of domain and a linear equivalence of codomain induce a linear equivalence of the
+corresponding finitely supported functions. -/
+def lcongr {ι κ : Sort*} (e₁ : ι ≃ κ) (e₂ : M ≃ₗ[R] N) : (ι →₀ M) ≃ₗ[R] (κ →₀ N) :=
+(finsupp.dom_lcongr e₁).trans
+{ to_fun := map_range e₂ e₂.map_zero,
+  inv_fun := map_range e₂.symm e₂.symm.map_zero,
+  left_inv := λ f, finsupp.induction f (by simp_rw map_range_zero) $ λ a b f ha hb ih,
+    by rw [map_range_add e₂.map_add, map_range_add e₂.symm.map_add,
+      map_range_single, map_range_single, e₂.symm_apply_apply, ih],
+  right_inv := λ f, finsupp.induction f (by simp_rw map_range_zero) $ λ a b f ha hb ih,
+    by rw [map_range_add e₂.symm.map_add, map_range_add e₂.map_add,
+      map_range_single, map_range_single, e₂.apply_symm_apply, ih],
+  map_add' := map_range_add e₂.map_add,
+  map_smul' := λ c f, finsupp.induction f
+    (by rw [smul_zero, map_range_zero, smul_zero]) $ λ a b f ha hb ih,
+    by rw [smul_add, smul_single, map_range_add e₂.map_add, map_range_single, e₂.map_smul, ih,
+      map_range_add e₂.map_add, smul_add, map_range_single, smul_single] }
+
+@[simp] theorem lcongr_single {ι κ : Sort*} (e₁ : ι ≃ κ) (e₂ : M ≃ₗ[R] N)
+  (i : ι) (m : M) : lcongr e₁ e₂ (finsupp.single i m) = finsupp.single (e₁ i) (e₂ m) :=
+by simp [lcongr]
 
 end finsupp
 

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -223,6 +223,8 @@ def lsum (f : α → M →ₗ[R] N) : (α →₀ M) →ₗ[R] N :=
   assume d₁ d₂, by simp [sum_add_index],
   assume a d, by simp [sum_smul_index', smul_sum]⟩
 
+@[simp] lemma coe_lsum (f : α → M →ₗ[R] N) : (lsum f : (α →₀ M) → N) = λ d, d.sum (λ i, f i) := rfl
+
 theorem lsum_apply (f : α → M →ₗ[R] N) (l : α →₀ M) :
   finsupp.lsum f l = l.sum (λ b, f b) := rfl
 
@@ -497,7 +499,7 @@ linear_equiv.of_linear
   (finsupp.lsum $ direct_sum.lof R ι (λ _, M))
   (direct_sum.to_module _ _ _ finsupp.lsingle)
   (linear_map.ext $ direct_sum.to_module.ext _ $ λ i,
-    linear_map.ext $ λ x, by simp [finsupp.lsum_single])
+    linear_map.ext $ λ x, by simp [finsupp.sum_single_index])
   (linear_map.ext $ λ f, finsupp.ext $ λ i, by simp [finsupp.lsum_apply])
 
 @[simp] theorem finsupp_lequiv_direct_sum_single (i : ι) (m : M) :

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -459,10 +459,57 @@ begin
   exact hN i hi (hg _),
 end
 
-noncomputable def finsupp_lequiv_direct_sum {ι : Sort*} : (ι →₀ M) ≃ₗ[R] direct_sum ι (λ i, M) :=
+section finsupp_lequiv_direct_sum
+
+variables (R M) (ι : Type*) [decidable_eq ι]
+
+/-- The finitely supported functions ι →₀ M are in linear equivalence with the direct sum of
+copies of M indexed by ι. -/
+def finsupp_lequiv_direct_sum : (ι →₀ M) ≃ₗ[R] direct_sum ι (λ i, M) :=
 linear_equiv.of_linear
   (finsupp.lsum $ direct_sum.lof R ι (λ _, M))
   (direct_sum.to_module _ _ _ finsupp.lsingle)
   (linear_map.ext $ direct_sum.to_module.ext _ $ λ i,
     linear_map.ext $ λ x, by simp [finsupp.lsum_single])
   (linear_map.ext $ λ f, finsupp.ext $ λ i, by simp [finsupp.lsum_apply])
+
+@[simp] theorem finsupp_lequiv_direct_sum_single (i : ι) (m : M) :
+  finsupp_lequiv_direct_sum R M ι (finsupp.single i m) = direct_sum.lof R ι _ i m :=
+finsupp.sum_single_index $ direct_sum.of_zero i
+
+@[simp] theorem finsupp_lequiv_direct_sum_symm_lof (i : ι) (m : M) :
+  (finsupp_lequiv_direct_sum R M ι).symm (direct_sum.lof R ι _ i m) = finsupp.single i m :=
+direct_sum.to_module_lof _ _ _
+
+end finsupp_lequiv_direct_sum
+
+section tensor_product
+
+open_locale tensor_product
+
+/-- The tensor product of ι →₀ M and κ →₀ N is linearly equivalent to (ι × κ) →₀ (M ⊗ N). -/
+def finsupp_tensor_finsupp (R M N ι κ : Sort*) [comm_ring R]
+  [add_comm_group M] [module R M] [add_comm_group N] [module R N] :
+  (ι →₀ M) ⊗[R] (κ →₀ N) ≃ₗ[R] (ι × κ) →₀ (M ⊗[R] N) :=
+linear_equiv.trans
+  (tensor_product.congr (finsupp_lequiv_direct_sum R M ι) (finsupp_lequiv_direct_sum R N κ)) $
+linear_equiv.trans
+  (tensor_product.direct_sum R ι κ (λ _, M) (λ _, N))
+  (finsupp_lequiv_direct_sum R (M ⊗[R] N) (ι × κ)).symm
+
+@[simp] theorem finsupp_tensor_finsupp_single (R M N ι κ : Sort*) [comm_ring R]
+  [add_comm_group M] [module R M] [add_comm_group N] [module R N]
+  (i : ι) (m : M) (k : κ) (n : N) :
+  finsupp_tensor_finsupp R M N ι κ (finsupp.single i m ⊗ₜ finsupp.single k n) =
+  finsupp.single (i, k) (m ⊗ₜ n) :=
+by simp [finsupp_tensor_finsupp]
+
+@[simp] theorem finsupp_tensor_finsupp_symm_single (R M N ι κ : Sort*) [comm_ring R]
+  [add_comm_group M] [module R M] [add_comm_group N] [module R N]
+  (i : ι × κ) (m : M) (n : N) :
+  (finsupp_tensor_finsupp R M N ι κ).symm (finsupp.single i (m ⊗ₜ n)) =
+  (finsupp.single i.1 m ⊗ₜ finsupp.single i.2 n) :=
+prod.cases_on i $ λ i k, (linear_equiv.symm_apply_eq _).2
+  (finsupp_tensor_finsupp_single _ _ _ _ _ _ _ _ _).symm
+
+end tensor_product

--- a/src/linear_algebra/finsupp_vector_space.lean
+++ b/src/linear_algebra/finsupp_vector_space.lean
@@ -14,7 +14,7 @@ open set linear_map submodule
 
 namespace finsupp
 
-section module
+section ring
 variables {R : Type*} {M : Type*} {ι : Type*}
 variables [ring R] [add_comm_group M] [module R M]
 
@@ -41,17 +41,11 @@ begin
       apply range_comp_subset_range } }
 end
 
-end module
-
-section vector_space
-variables {K : Type*} {V : Type*} {ι : Type*}
-variables [field K] [add_comm_group V] [vector_space K V]
-
 open linear_map submodule
 
-lemma is_basis_single {φ : ι → Type*} (f : Π ι, φ ι → V)
-  (hf : ∀i, is_basis K (f i)) :
-  is_basis K (λ ix : Σ i, φ i, single ix.1 (f ix.1 ix.2)) :=
+lemma is_basis_single {φ : ι → Type*} (f : Π ι, φ ι → M)
+  (hf : ∀i, is_basis R (f i)) :
+  is_basis R (λ ix : Σ i, φ i, single ix.1 (f ix.1 ix.2)) :=
 begin
   split,
   { apply linear_independent_single,
@@ -61,7 +55,28 @@ begin
     simp only [image_univ, (hf _).2, map_top, supr_lsingle_range] }
 end
 
-end vector_space
+lemma is_basis_single_one : is_basis R (λ i : ι, single i (1 : R)) :=
+by convert (is_basis_single (λ (i : ι) (x : unit), (1 : R)) (λ i, is_basis_singleton_one R)).comp
+  (λ i : ι, ⟨i, ()⟩) ⟨λ _ _, and.left ∘ sigma.mk.inj, λ ⟨i, ⟨⟩⟩, ⟨i, rfl⟩⟩
+
+end ring
+
+section comm_ring
+variables {R : Type*} {M : Type*} {N : Type*} {ι : Type*} {κ : Type*}
+variables [comm_ring R] [add_comm_group M] [module R M] [add_comm_group N] [module R N]
+
+lemma is_basis.tensor_product {b : ι → M} (hb : is_basis R b) {c : κ → N} (hc : is_basis R c) :
+  is_basis R (λ i : ι × κ, b i.1 ⊗ₜ[R] c i.2) :=
+let e := (tensor_product.congr (module_equiv_finsupp hb) (module_equiv_finsupp hc)).trans
+  (finsupp_tensor_finsupp _ _ _ _ _) in
+_
+
+#check finsupp.dom_lcongr
+
+#check linear_equiv.is_basis
+#check tensor_product.lid
+
+end comm_ring
 
 section dim
 universes u v

--- a/src/linear_algebra/finsupp_vector_space.lean
+++ b/src/linear_algebra/finsupp_vector_space.lean
@@ -65,16 +65,14 @@ section comm_ring
 variables {R : Type*} {M : Type*} {N : Type*} {ι : Type*} {κ : Type*}
 variables [comm_ring R] [add_comm_group M] [module R M] [add_comm_group N] [module R N]
 
+/-- If b : ι → M and c : κ → N are bases then so is λ i, b i.1 ⊗ₜ c i.2 : ι × κ → M ⊗ N. -/
 lemma is_basis.tensor_product {b : ι → M} (hb : is_basis R b) {c : κ → N} (hc : is_basis R c) :
   is_basis R (λ i : ι × κ, b i.1 ⊗ₜ[R] c i.2) :=
-let e := (tensor_product.congr (module_equiv_finsupp hb) (module_equiv_finsupp hc)).trans
-  (finsupp_tensor_finsupp _ _ _ _ _) in
-_
-
-#check finsupp.dom_lcongr
-
-#check linear_equiv.is_basis
-#check tensor_product.lid
+by { convert linear_equiv.is_basis is_basis_single_one
+  ((tensor_product.congr (module_equiv_finsupp hb) (module_equiv_finsupp hc)).trans $
+    (finsupp_tensor_finsupp _ _ _ _ _).trans $
+    lcongr (equiv.refl _) (tensor_product.lid R R)).symm,
+  ext ⟨i, k⟩, rw [function.comp_apply, linear_equiv.eq_symm_apply], simp }
 
 end comm_ring
 

--- a/src/linear_algebra/tensor_product.lean
+++ b/src/linear_algebra/tensor_product.lean
@@ -477,12 +477,18 @@ lift $ comp (compl₂ (mk _ _ _) g) f
   map f g (m ⊗ₜ n) = f m ⊗ₜ g n :=
 rfl
 
+/-- If M and P are linearly equivalent and N and Q are linearly equivalent
+then M ⊗ N and P ⊗ Q are linearly equivalent. -/
 def congr (f : M ≃ₗ[R] P) (g : N ≃ₗ[R] Q) : M ⊗ N ≃ₗ[R] P ⊗ Q :=
 linear_equiv.of_linear (map f g) (map f.symm g.symm)
   (ext $ λ m n, by simp; simp only [linear_equiv.apply_symm_apply])
   (ext $ λ m n, by simp; simp only [linear_equiv.symm_apply_apply])
 
-variables (ι₁ : Type*) (ι₂ : Type*)
+@[simp] theorem congr_tmul (f : M ≃ₗ[R] P) (g : N ≃ₗ[R] Q) (m : M) (n : N) :
+  congr f g (m ⊗ₜ n) = f m ⊗ₜ g n :=
+rfl
+
+variables (R) (ι₁ : Type*) (ι₂ : Type*)
 variables [decidable_eq ι₁] [decidable_eq ι₂]
 variables (M₁ : ι₁ → Type*) (M₂ : ι₂ → Type*)
 variables [Π i₁, add_comm_group (M₁ i₁)] [Π i₂, add_comm_group (M₂ i₂)]
@@ -504,5 +510,10 @@ begin
     rw curry_apply },
   cases i; refl
 end
+
+@[simp] theorem direct_sum_lof_tmul_lof (i₁ : ι₁) (m₁ : M₁ i₁) (i₂ : ι₂) (m₂ : M₂ i₂) :
+  direct_sum R ι₁ ι₂ M₁ M₂ (direct_sum.lof R ι₁ M₁ i₁ m₁ ⊗ₜ direct_sum.lof R ι₂ M₂ i₂ m₂) =
+  direct_sum.lof R (ι₁ × ι₂) (λ i, M₁ i.1 ⊗[R] M₂ i.2) (i₁, i₂) (m₁ ⊗ₜ m₂) :=
+by simp [direct_sum]
 
 end tensor_product


### PR DESCRIPTION
If `b : ι → M` and `c : κ → N` are bases then so is `λ i, b i.1 ⊗ₜ c i.2 : ι × κ → M ⊗ N`.

---
<!-- put comments you want to keep out of the PR commit here -->
