### PR TITLE
[Merged by Bors] - chore(algebra/ordered_group): merge `add_le_add'` with `add_le_add`

### DIFF
--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -1116,7 +1116,7 @@ begin
   exact (λ _, le_refl _),
   assume a s ha ih h,
   have : f a + (∑ x in s, f x) ≤ g a + (∑ x in s, g x),
-    from add_le_add' (h _ (mem_insert_self _ _)) (ih $ assume x hx, h _ $ mem_insert_of_mem hx),
+    from add_le_add (h _ (mem_insert_self _ _)) (ih $ assume x hx, h _ $ mem_insert_of_mem hx),
   by simpa only [sum_insert ha]
 end
 

--- a/src/algebra/group_power.lean
+++ b/src/algebra/group_power.lean
@@ -542,7 +542,7 @@ calc n •ℕ a = n •ℕ a + 0 : (add_zero _).symm
 
 lemma nsmul_le_nsmul_of_le_right {a b : A} (hab : a ≤ b) : ∀ i : ℕ, i •ℕ a ≤ i •ℕ b
 | 0 := by simp
-| (k+1) := add_le_add' hab (nsmul_le_nsmul_of_le_right _)
+| (k+1) := add_le_add hab (nsmul_le_nsmul_of_le_right _)
 
 end add_monoid
 

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -64,7 +64,7 @@ mul_comm c a ▸ mul_comm c b ▸ mul_le_mul_left' h
 lemma lt_of_mul_lt_mul_left' : a * b < a * c → b < c :=
 ordered_comm_monoid.lt_of_mul_lt_mul_left a b c
 
-@[to_additive]
+@[to_additive add_le_add]
 lemma mul_le_mul' (h₁ : a ≤ b) (h₂ : c ≤ d) : a * c ≤ b * d :=
 le_trans (mul_le_mul_right' h₁) (mul_le_mul_left' h₂)
 
@@ -484,11 +484,11 @@ end
 
 lemma le_add_left (h : a ≤ c) : a ≤ b + c :=
 calc a = 0 + a : by simp
-  ... ≤ b + c : add_le_add' (zero_le _) h
+  ... ≤ b + c : add_le_add (zero_le _) h
 
 lemma le_add_right (h : a ≤ b) : a ≤ b + c :=
 calc a = a + 0 : by simp
-  ... ≤ b + c : add_le_add' h (zero_le _)
+  ... ≤ b + c : add_le_add h (zero_le _)
 
 instance with_zero.canonically_ordered_add_monoid :
   canonically_ordered_add_monoid (with_zero α) :=
@@ -590,10 +590,6 @@ begin
  exact (mul_lt_mul_left' h c)
 end
 
-@[to_additive add_le_add]
-lemma mul_le_mul'' {a b c d : α} (h₁ : a ≤ b) (h₂ : c ≤ d) : a * c ≤ b * d :=
-le_trans (mul_le_mul_right' h₁) (mul_le_mul_left' h₂)
-
 @[to_additive]
 lemma le_mul_of_one_le_right (h : 1 ≤ b) : a ≤ a * b :=
 have a * 1 ≤ a * b, from mul_le_mul_left' h,
@@ -639,7 +635,7 @@ lt_of_mul_lt_mul_left''
 -- here we start using properties of one.
 @[to_additive add_nonneg]
 lemma one_le_mul (ha : 1 ≤ a) (hb : 1 ≤ b) : 1 ≤ a * b :=
-one_mul (1:α) ▸ (mul_le_mul'' ha hb)
+one_mul (1:α) ▸ (mul_le_mul' ha hb)
 
 @[to_additive]
 lemma mul_one_lt (ha : 1 < a) (hb : 1 < b) : 1 < a * b :=
@@ -655,7 +651,7 @@ one_mul (1:α) ▸ (mul_lt_mul_of_le_of_lt ha hb)
 
 @[to_additive add_nonpos]
 lemma mul_le_one'' (ha : a ≤ 1) (hb : b ≤ 1) : a * b ≤ 1 :=
-one_mul (1:α) ▸ (mul_le_mul'' ha hb)
+one_mul (1:α) ▸ (mul_le_mul' ha hb)
 
 @[to_additive]
 lemma mul_lt_one (ha : a < 1) (hb : b < 1) : a * b < 1 :=
@@ -692,11 +688,11 @@ iff.intro
 
 @[to_additive]
 lemma le_mul_of_one_le_of_le (ha : 1 ≤ a) (hbc : b ≤ c) : b ≤ a * c :=
-one_mul b ▸ mul_le_mul'' ha hbc
+one_mul b ▸ mul_le_mul' ha hbc
 
 @[to_additive]
 lemma le_mul_of_le_of_one_le (hbc : b ≤ c) (ha : 1 ≤ a) : b ≤ c * a :=
-mul_one b ▸ mul_le_mul'' hbc ha
+mul_one b ▸ mul_le_mul' hbc ha
 
 @[to_additive]
 lemma lt_mul_of_one_lt_of_le (ha : 1 < a) (hbc : b ≤ c) : b < a * c :=
@@ -708,11 +704,11 @@ mul_one b ▸ mul_lt_mul_of_le_of_lt hbc ha
 
 @[to_additive]
 lemma mul_le_of_le_one_of_le (ha : a ≤ 1) (hbc : b ≤ c) : a * b ≤ c :=
-one_mul c ▸ mul_le_mul'' ha hbc
+one_mul c ▸ mul_le_mul' ha hbc
 
 @[to_additive]
 lemma mul_le_of_le_of_le_one (hbc : b ≤ c) (ha : a ≤ 1) : b * a ≤ c :=
-mul_one c ▸ mul_le_mul'' hbc ha
+mul_one c ▸ mul_le_mul' hbc ha
 
 @[to_additive]
 lemma mul_lt_of_lt_one_of_le (ha : a < 1) (hbc : b ≤ c) : a * b < c :=
@@ -1099,8 +1095,8 @@ lemma mul_le_mul_three {a b c d e f : α} (h₁ : a ≤ d) (h₂ : b ≤ e) (h�
       a * b * c ≤ d * e * f :=
 begin
   apply le_trans,
-  apply mul_le_mul'',
-  apply mul_le_mul'',
+  apply mul_le_mul',
+  apply mul_le_mul',
   assumption',
   apply le_refl
 end

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -257,7 +257,7 @@ lemma lipschitz_with.add {α : Type*} [emetric_space α] {Kf : nnreal} {f : α �
 calc edist (f x + g x) (f y + g y) ≤ edist (f x) (f y) + edist (g x) (g y) :
   edist_add_add_le _ _ _ _
 ... ≤ Kf * edist x y + Kg * edist x y :
-  add_le_add' (hf x y) (hg x y)
+  add_le_add (hf x y) (hg x y)
 ... = (Kf + Kg) * edist x y :
   (add_mul _ _ _).symm
 

--- a/src/analysis/normed_space/enorm.lean
+++ b/src/analysis/normed_space/enorm.lean
@@ -125,8 +125,8 @@ noncomputable instance : semilattice_sup_top (enorm 𝕜 V) :=
   { to_fun := λ x, max (e₁ x) (e₂ x),
     eq_zero' := λ x h, e₁.eq_zero_iff.1 (ennreal.max_eq_zero_iff.1 h).1,
     map_add_le' := λ x y, max_le
-      (le_trans (e₁.map_add_le _ _) $ add_le_add' (le_max_left _ _) (le_max_left _ _))
-      (le_trans (e₂.map_add_le _ _) $ add_le_add' (le_max_right _ _) (le_max_right _ _)),
+      (le_trans (e₁.map_add_le _ _) $ add_le_add (le_max_left _ _) (le_max_left _ _))
+      (le_trans (e₂.map_add_le _ _) $ add_le_add (le_max_right _ _) (le_max_right _ _)),
     map_smul_le' := λ c x, le_of_eq $ by simp only [map_smul, ennreal.mul_max] },
   le_sup_left := λ e₁ e₂ x, le_max_left _ _,
   le_sup_right := λ e₁ e₂ x, le_max_right _ _,

--- a/src/data/polynomial.lean
+++ b/src/data/polynomial.lean
@@ -816,14 +816,14 @@ calc degree (p * q) ≤ (p.support).sup (λi, degree (sum q (λj a, C (coeff p i
       refine finset.sup_le (λ a ha, finset.sup_le (λ b hb, le_trans (degree_monomial_le _ _) _)),
       rw [with_bot.coe_add],
       rw mem_support_iff at ha hb,
-      exact add_le_add' (le_degree_of_ne_zero ha) (le_degree_of_ne_zero hb)
+      exact add_le_add (le_degree_of_ne_zero ha) (le_degree_of_ne_zero hb)
     end
 
 lemma degree_pow_le (p : polynomial R) : ∀ n, degree (p ^ n) ≤ n •ℕ (degree p)
 | 0     := by rw [pow_zero, zero_nsmul]; exact degree_one_le
 | (n+1) := calc degree (p ^ (n + 1)) ≤ degree p + degree (p ^ n) :
     by rw pow_succ; exact degree_mul_le _ _
-  ... ≤ _ : by rw succ_nsmul; exact add_le_add' (le_refl _) (degree_pow_le _)
+  ... ≤ _ : by rw succ_nsmul; exact add_le_add (le_refl _) (degree_pow_le _)
 
 @[simp] lemma leading_coeff_monomial (a : R) (n : ℕ) : leading_coeff (C a * X ^ n) = a :=
 begin
@@ -977,7 +977,7 @@ else with_bot.coe_le_coe.1 $
     calc degree (C (coeff p n) * q ^ n)
         ≤ degree (C (coeff p n)) + degree (q ^ n) : degree_mul_le _ _
     ... ≤ nat_degree (C (coeff p n)) + n •ℕ (degree q) :
-      add_le_add' degree_le_nat_degree (degree_pow_le _ _)
+      add_le_add degree_le_nat_degree (degree_pow_le _ _)
     ... ≤ nat_degree (C (coeff p n)) + n •ℕ (nat_degree q) :
       add_le_add_left' (nsmul_le_nsmul_of_le_right (@degree_le_nat_degree _ _ q) n)
     ... = (n * nat_degree q : ℕ) :
@@ -1342,7 +1342,7 @@ calc (div_X p).degree < (div_X p * X + C (p.coeff 0)).degree :
          ... = degree (X : polynomial R) : degree_X.symm
          ... ≤ degree (div_X p * X) :
           by rw [← zero_add (degree X), degree_mul_eq' this];
-            exact add_le_add'
+            exact add_le_add
               (by rw [zero_le_degree_iff, ne.def, div_X_eq_zero_iff];
                 exact λ h0, h (h0.symm ▸ degree_C_le))
               (le_refl _),
@@ -2077,7 +2077,7 @@ then
     ... ≤ degree p :
       by rw [← degree_add_div_by_monic (monic_X_sub_C x) hdeg,
           degree_X_sub_C, add_comm];
-        exact add_le_add' (le_refl (1 : with_bot ℕ)) htd,
+        exact add_le_add (le_refl (1 : with_bot ℕ)) htd,
   begin
     assume y,
     rw [mem_insert, htr, eq_comm, ← root_X_sub_C],

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -354,7 +354,7 @@ begin
     rw [← coe_add, ← coe_add, coe_lt_coe],
     apply add_lt_add (coe_lt_coe.1 aa') (coe_lt_coe.1 bb')
   end,
-  have J : ↑a'R + ↑b'R ≤ c + d := add_le_add' (le_of_lt a'c) (le_of_lt b'd),
+  have J : ↑a'R + ↑b'R ≤ c + d := add_le_add (le_of_lt a'c) (le_of_lt b'd),
   apply lt_of_lt_of_le I J
 end
 
@@ -460,7 +460,7 @@ lemma sub_le_sub (h₁ : a ≤ b) (h₂ : d ≤ c) : a - c ≤ b - d :=
 Inf_le_Inf $ assume e (h : b ≤ e + d),
   calc a ≤ b : h₁
     ... ≤ e + d : h
-    ... ≤ e + c : add_le_add' (le_refl _) h₂
+    ... ≤ e + c : add_le_add (le_refl _) h₂
 
 @[simp] lemma add_sub_self : ∀{a b : ennreal}, b < ∞ → (a + b) - b = a
 | a        none     := by simp [none_eq_top]
@@ -1125,7 +1125,7 @@ variables {ι : Sort*} {f g : ι → ennreal}
 
 lemma infi_add : infi f + a = ⨅i, f i + a :=
 le_antisymm
-  (le_infi $ assume i, add_le_add' (infi_le _ _) $ le_refl _)
+  (le_infi $ assume i, add_le_add (infi_le _ _) $ le_refl _)
   (ennreal.sub_le_iff_le_add.1 $ le_infi $ assume i, ennreal.sub_le_iff_le_add.2 $ infi_le _ _)
 
 lemma supr_sub : (⨆i, f i) - a = (⨆i, f i - a) :=
@@ -1148,7 +1148,7 @@ by rw [add_comm, infi_add]; simp [add_comm]
 
 lemma infi_add_infi (h : ∀i j, ∃k, f k + g k ≤ f i + g j) : infi f + infi g = (⨅a, f a + g a) :=
 suffices (⨅a, f a + g a) ≤ infi f + infi g,
-  from le_antisymm (le_infi $ assume a, add_le_add' (infi_le _ _) (infi_le _ _)) this,
+  from le_antisymm (le_infi $ assume a, add_le_add (infi_le _ _) (infi_le _ _)) this,
 calc (⨅a, f a + g a) ≤ (⨅ a a', f a + g a') :
     le_infi $ assume a, le_infi $ assume a',
       let ⟨k, h⟩ := h a a' in infi_le_of_le k h
@@ -1162,7 +1162,7 @@ finset.induction_on s (by simp) $ assume a s ha ih,
   have ∀ (i j : ι), ∃ (k : ι), f k a + ∑ b in s, f k b ≤ f i a + ∑ b in s, f j b,
     from assume i j,
     let ⟨k, hk⟩ := h (insert a s) i j in
-    ⟨k, add_le_add' (hk a (finset.mem_insert_self _ _)).left $ finset.sum_le_sum $
+    ⟨k, add_le_add (hk a (finset.mem_insert_self _ _)).left $ finset.sum_le_sum $
       assume a ha, (hk _ $ finset.mem_insert_of_mem ha).right⟩,
   by simp [ha, ih.symm, infi_add_infi this]
 

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -851,7 +851,7 @@ calc (∫⁻ a, f a + g a) =
     rw [lintegral_supr],
     { congr, funext n, rw [← simple_func.add_integral, ← simple_func.lintegral_eq_integral], refl },
     { assume n, exact measurable.add (eapprox f n).measurable (eapprox g n).measurable },
-    { assume i j h a, exact add_le_add' (monotone_eapprox _ h _) (monotone_eapprox _ h _) }
+    { assume i j h a, exact add_le_add (monotone_eapprox _ h _) (monotone_eapprox _ h _) }
   end
   ... = (⨆n, (eapprox f n).integral) + (⨆n, (eapprox g n).integral) :
   by refine (ennreal.supr_add_supr_of_monotone _ _).symm;

--- a/src/measure_theory/l1_space.lean
+++ b/src/measure_theory/l1_space.lean
@@ -300,7 +300,7 @@ begin
     apply of_real_le_of_real,
     { apply norm_sub_le }, { exact norm_nonneg _ }, { exact norm_nonneg _ }
   end
-    ... ≤ (ennreal.of_real (bound a)) + (ennreal.of_real (bound a)) : add_le_add' h₁ h₂
+    ... ≤ (ennreal.of_real (bound a)) + (ennreal.of_real (bound a)) : add_le_add h₁ h₂
     ... = b a : by rw ← two_mul
 end,
 /- On the other hand, `F n a --> f a` implies that `∥F n a - f a∥ --> 0`  -/

--- a/src/measure_theory/lebesgue_measure.lean
+++ b/src/measure_theory/lebesgue_measure.lean
@@ -178,7 +178,7 @@ lemma is_lebesgue_measurable_Iio {c : ℝ} :
   lebesgue_outer.caratheodory.is_measurable (Iio c) :=
 outer_measure.caratheodory_is_measurable $ λ t,
 le_infi $ λ a, le_infi $ λ b, le_infi $ λ h, begin
-  refine le_trans (add_le_add'
+  refine le_trans (add_le_add
     (lebesgue_length_mono $ inter_subset_inter_left _ h)
     (lebesgue_length_mono $ diff_subset_diff_left h)) _,
   cases le_total a c with hac hca; cases le_total b c with hbc hcb;

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -241,7 +241,7 @@ ext $ λ s, begin
   rw ennreal.infi_add_infi,
   rintro ⟨t₁, st₁, ht₁⟩ ⟨t₂, st₂, ht₂⟩,
   exact ⟨⟨_, subset_inter_iff.2 ⟨st₁, st₂⟩, ht₁.inter ht₂⟩,
-    add_le_add'
+    add_le_add
       (m₁.mono' (inter_subset_left _ _))
       (m₂.mono' (inter_subset_right _ _))⟩,
 end
@@ -627,7 +627,7 @@ begin
     rw [to_outer_measure_apply],
     refine measure_mono hst },
   rw [measure_eq_inter_diff hu hs],
-  refine add_le_add' (hm $ inter_subset_inter_left _ htu) (hm $ diff_subset_diff_left htu)
+  refine add_le_add (hm $ inter_subset_inter_left _ htu) (hm $ diff_subset_diff_left htu)
 end
 
 instance : has_Inf (measure α) :=

--- a/src/measure_theory/outer_measure.lean
+++ b/src/measure_theory/outer_measure.lean
@@ -133,11 +133,11 @@ instance : has_add (outer_measure α) :=
 ⟨λm₁ m₂,
   { measure_of := λs, m₁ s + m₂ s,
     empty      := show m₁ ∅ + m₂ ∅ = 0, by simp [outer_measure.empty],
-    mono       := assume s₁ s₂ h, add_le_add' (m₁.mono h) (m₂.mono h),
+    mono       := assume s₁ s₂ h, add_le_add (m₁.mono h) (m₂.mono h),
     Union_nat  := assume s,
       calc m₁ (⋃i, s i) + m₂ (⋃i, s i) ≤
           (∑'i, m₁ (s i)) + (∑'i, m₂ (s i)) :
-          add_le_add' (m₁.Union_nat s) (m₂.Union_nat s)
+          add_le_add (m₁.Union_nat s) (m₂.Union_nat s)
         ... = _ : ennreal.tsum_add.symm}⟩
 
 @[simp] theorem add_apply (m₁ m₂ : outer_measure α) (s : set α) :
@@ -470,7 +470,7 @@ lemma caratheodory_is_measurable {m : set α → ennreal} {s : set α}
 let o := (outer_measure.of_function m h₀) in
 (is_caratheodory_le o).2 $ λ t,
 le_infi $ λ f, le_infi $ λ hf, begin
-  refine le_trans (add_le_add'
+  refine le_trans (add_le_add
     (infi_le_of_le (λi, f i ∩ s) $ infi_le _ _)
     (infi_le_of_le (λi, f i \ s) $ infi_le _ _)) _,
   { rw ← Union_inter,

--- a/src/order/filter/extr.lean
+++ b/src/order/filter/extr.lean
@@ -324,12 +324,12 @@ variables [ordered_add_comm_monoid β] {f g : α → β} {a : α} {s : set α} {
 lemma is_min_filter.add (hf : is_min_filter f l a) (hg : is_min_filter g l a) :
   is_min_filter (λ x, f x + g x) l a :=
 show is_min_filter (λ x, f x + g x) l a,
-from hf.bicomp_mono (λ x x' hx y y' hy, add_le_add' hx hy) hg
+from hf.bicomp_mono (λ x x' hx y y' hy, add_le_add hx hy) hg
 
 lemma is_max_filter.add (hf : is_max_filter f l a) (hg : is_max_filter g l a) :
   is_max_filter (λ x, f x + g x) l a :=
 show is_max_filter (λ x, f x + g x) l a,
-from hf.bicomp_mono (λ x x' hx y y' hy, add_le_add' hx hy) hg
+from hf.bicomp_mono (λ x x' hx y y' hy, add_le_add hx hy) hg
 
 lemma is_min_on.add (hf : is_min_on f s a) (hg : is_min_on g s a) :
   is_min_on (λ x, f x + g x) s a :=

--- a/src/ring_theory/polynomial.lean
+++ b/src/ring_theory/polynomial.lean
@@ -205,7 +205,7 @@ begin
     { exact nat.add_sub_cancel' (nat_degree_le_of_degree_le hpdeg) },
     refine ⟨p * X ^ (n - nat_degree p), ⟨_, I.mul_mem_right hpI⟩, _⟩,
     { apply le_trans (degree_mul_le _ _) _,
-      apply le_trans (add_le_add' (degree_le_nat_degree) (degree_X_pow_le _)) _,
+      apply le_trans (add_le_add (degree_le_nat_degree) (degree_X_pow_le _)) _,
       rw [← with_bot.coe_add, this],
       exact le_refl _ },
     { rw [leading_coeff, ← coeff_mul_X_pow p (n - nat_degree p), this] } }
@@ -227,7 +227,7 @@ begin
   rcases hr with ⟨p, hpI, hpdeg, rfl⟩,
   refine ⟨p * X ^ (n - m), I.mul_mem_right hpI, _, leading_coeff_mul_X_pow⟩,
   refine le_trans (degree_mul_le _ _) _,
-  refine le_trans (add_le_add' hpdeg (degree_X_pow_le _)) _,
+  refine le_trans (add_le_add hpdeg (degree_X_pow_le _)) _,
   rw [← with_bot.coe_add, nat.add_sub_cancel' H],
   exact le_refl _
 end

--- a/src/ring_theory/power_series.lean
+++ b/src/ring_theory/power_series.lean
@@ -1392,7 +1392,7 @@ begin
   { rw [coeff_of_lt_order ψ j hj, mul_zero] },
   rw not_lt at hi hj, rw finset.nat.mem_antidiagonal at hij,
   exfalso,
-  apply ne_of_lt (lt_of_lt_of_le hn $ add_le_add' hi hj),
+  apply ne_of_lt (lt_of_lt_of_le hn $ add_le_add hi hj),
   rw [← enat.coe_add, hij]
 end
 

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -327,7 +327,7 @@ ennreal.inv_top ▸ ennreal.tendsto_inv_iff.2 tendsto_nat_nhds_top
 lemma Sup_add {s : set ennreal} (hs : s.nonempty) : Sup s + a = ⨆b∈s, b + a :=
 have Sup ((λb, b + a) '' s) = Sup s + a,
   from is_lub.Sup_eq (is_lub_of_is_lub_of_tendsto
-    (assume x _ y _ h, add_le_add' h (le_refl _))
+    (assume x _ y _ h, add_le_add h (le_refl _))
     (is_lub_Sup s)
     hs
     (tendsto.add (tendsto_id' inf_le_left) tendsto_const_nhds)),
@@ -347,7 +347,7 @@ lemma supr_add_supr {ι : Sort*} {f g : ι → ennreal} (h : ∀i j, ∃k, f i +
 begin
   by_cases hι : nonempty ι,
   { letI := hι,
-    refine le_antisymm _ (supr_le $ λ a, add_le_add' (le_supr _ _) (le_supr _ _)),
+    refine le_antisymm _ (supr_le $ λ a, add_le_add (le_supr _ _) (le_supr _ _)),
     simpa [add_supr, supr_add] using
       λ i j:ι, show f i + g j ≤ ⨆ a, f a + g a, from
       let ⟨k, hk⟩ := h i j in le_supr_of_le k hk },
@@ -358,7 +358,7 @@ end
 lemma supr_add_supr_of_monotone {ι : Sort*} [semilattice_sup ι]
   {f g : ι → ennreal} (hf : monotone f) (hg : monotone g) :
   supr f + supr g = (⨆ a, f a + g a) :=
-supr_add_supr $ assume i j, ⟨i ⊔ j, add_le_add' (hf $ le_sup_left) (hg $ le_sup_right)⟩
+supr_add_supr $ assume i j, ⟨i ⊔ j, add_le_add (hf $ le_sup_left) (hg $ le_sup_right)⟩
 
 lemma finset_sum_supr_nat {α} {ι} [semilattice_sup ι] {s : finset α} {f : α → ι → ennreal}
   (hf : ∀a, monotone (f a)) :
@@ -773,7 +773,7 @@ begin
   calc edist x y ≤ edist x x' + edist x' y' + edist y' y : edist_triangle4 _ _ _ _
     ... = edist x' y' + (edist x x' + edist y y') : by simp [edist_comm]; cc
     ... ≤ edist x' y' + (edist (x, y) (x', y') + edist (x, y) (x', y')) :
-      add_le_add_left' (add_le_add' (by simp [edist, le_refl]) (by simp [edist, le_refl]))
+      add_le_add_left' (add_le_add (by simp [edist, le_refl]) (by simp [edist, le_refl]))
     ... = edist x' y' + 2 * edist (x, y) (x', y') : by rw [← mul_two, mul_comm]
 end
 

--- a/src/topology/metric_space/baire.lean
+++ b/src/topology/metric_space/baire.lean
@@ -132,8 +132,8 @@ begin
       show min (min (δ / 2) r) (B (n+1)) ≤ B (n+1), from min_le_right _ _,
       show z ∈ closed_ball x δ, from calc
         edist z x ≤ edist z y + edist y x : edist_triangle _ _ _
-        ... ≤ (min (min (δ / 2) r) (B (n+1))) + (δ/2) : add_le_add' hz (le_of_lt xy)
-        ... ≤ δ/2 + δ/2 : add_le_add' (le_trans (min_le_left _ _) (min_le_left _ _)) (le_refl _)
+        ... ≤ (min (min (δ / 2) r) (B (n+1))) + (δ/2) : add_le_add hz (le_of_lt xy)
+        ... ≤ δ/2 + δ/2 : add_le_add (le_trans (min_le_left _ _) (min_le_left _ _)) (le_refl _)
         ... = δ : ennreal.add_halves δ,
       show z ∈ f n, from hr (calc
         edist z y ≤ min (min (δ / 2) r) (B (n+1)) : hz

--- a/src/topology/metric_space/closeds.lean
+++ b/src/topology/metric_space/closeds.lean
@@ -55,7 +55,7 @@ begin
   ... = inf_edist y (t.val) + (edist x y + Hausdorff_edist (s.val) (t.val)) :
     by simp [add_comm, add_left_comm, Hausdorff_edist_comm]
   ... ≤ inf_edist y (t.val) + (edist (x, s) (y, t) + edist (x, s) (y, t)) :
-    add_le_add_left' (add_le_add' (by simp [edist, le_refl]) (by simp [edist, le_refl]))
+    add_le_add_left' (add_le_add (by simp [edist, le_refl]) (by simp [edist, le_refl]))
   ... = inf_edist y (t.val) + 2 * edist (x, s) (y, t) :
     by rw [← mul_two, mul_comm]
 end
@@ -162,7 +162,7 @@ begin
     -- y : α,  hy : y ∈ (s n).val,  Dzy : edist z y < B n
     exact ⟨y, hy, calc
       edist x y ≤ edist x z + edist z y : edist_triangle _ _ _
-            ... ≤ B n + B n : add_le_add' (le_of_lt Dxz) (le_of_lt Dzy)
+            ... ≤ B n + B n : add_le_add (le_of_lt Dxz) (le_of_lt Dzy)
             ... = 2 * B n : (two_mul _).symm ⟩ },
   -- Deduce from the above inequalities that the distance between `s n` and `t0` is at most `2 B n`.
   have main : ∀n:ℕ, edist (s n) t ≤ 2 * B n := λn, Hausdorff_edist_le_of_mem_edist (I1 n) (I2 n),

--- a/src/topology/metric_space/contracting.lean
+++ b/src/topology/metric_space/contracting.lean
@@ -59,7 +59,7 @@ suffices edist x y ≤ edist x (f x) + edist y (f y) + K * edist x y,
     mul_comm, ennreal.sub_mul (λ _ _, ne_of_lt h), one_mul, ennreal.sub_le_iff_le_add],
 calc edist x y ≤ edist x (f x) + edist (f x) (f y) + edist (f y) y : edist_triangle4 _ _ _ _
   ... = edist x (f x) + edist y (f y) + edist (f x) (f y) : by rw [edist_comm y, add_right_comm]
-  ... ≤ edist x (f x) + edist y (f y) + K * edist x y : add_le_add' (le_refl _) (hf.2 _ _)
+  ... ≤ edist x (f x) + edist y (f y) + K * edist x y : add_le_add (le_refl _) (hf.2 _ _)
 
 lemma edist_le_of_fixed_point (hf : contracting_with K f) {x y}
   (h : edist x y < ⊤) (hy : is_fixed_pt f y) :

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -145,7 +145,7 @@ begin
     exact le_refl (0:ennreal) },
   { assume n hn hrec,
     calc edist (f m) (f (n+1)) ≤ edist (f m) (f n) + edist (f n) (f (n+1)) : edist_triangle _ _ _
-      ... ≤ ∑ i in finset.Ico m n, _ + _ : add_le_add' hrec (le_refl _)
+      ... ≤ ∑ i in finset.Ico m n, _ + _ : add_le_add hrec (le_refl _)
       ... = ∑ i in finset.Ico m (n+1), _ :
         by rw [finset.Ico.succ_top hn, finset.sum_insert, add_comm]; simp }
 end
@@ -438,8 +438,8 @@ instance prod.emetric_space_max [emetric_space β] : emetric_space (α × β) :=
   end,
   edist_comm := λ x y, by simp [edist_comm],
   edist_triangle := λ x y z, max_le
-    (le_trans (edist_triangle _ _ _) (add_le_add' (le_max_left _ _) (le_max_left _ _)))
-    (le_trans (edist_triangle _ _ _) (add_le_add' (le_max_right _ _) (le_max_right _ _))),
+    (le_trans (edist_triangle _ _ _) (add_le_add (le_max_left _ _) (le_max_left _ _)))
+    (le_trans (edist_triangle _ _ _) (add_le_add (le_max_right _ _) (le_max_right _ _))),
   uniformity_edist := begin
     refine uniformity_prod.trans _,
     simp [emetric_space.uniformity_edist, comap_infi],
@@ -470,7 +470,7 @@ instance emetric_space_pi [∀b, emetric_space (π b)] : emetric_space (Πb, π 
     begin
       simp only [finset.sup_le_iff],
       assume b hb,
-      exact le_trans (edist_triangle _ (g b) _) (add_le_add' (le_sup hb) (le_sup hb))
+      exact le_trans (edist_triangle _ (g b) _) (add_le_add (le_sup hb) (le_sup hb))
     end,
   eq_of_edist_eq_zero := assume f g eq0,
     begin
@@ -806,7 +806,7 @@ begin
   have A : ∀a ∈ s, ∀b ∈ t, edist a b ≤ diam s + edist x y + diam t := λa ha b hb, calc
     edist a b ≤ edist a x + edist x y + edist y b : edist_triangle4 _ _ _ _
     ... ≤ diam s + edist x y + diam t :
-      add_le_add' (add_le_add' (edist_le_diam_of_mem ha xs) (le_refl _)) (edist_le_diam_of_mem yt hb),
+      add_le_add (add_le_add (edist_le_diam_of_mem ha xs) (le_refl _)) (edist_le_diam_of_mem yt hb),
   refine diam_le_of_forall_edist_le (λa ha b hb, _),
   cases (mem_union _ _ _).1 ha with h'a h'a; cases (mem_union _ _ _).1 hb with h'b h'b,
   { calc edist a b ≤ diam s : edist_le_diam_of_mem h'a h'b
@@ -824,7 +824,7 @@ let ⟨x, ⟨xs, xt⟩⟩ := h in by simpa using diam_union xs xt
 lemma diam_closed_ball {r : ennreal} : diam (closed_ball x r) ≤ 2 * r :=
 diam_le_of_forall_edist_le $ λa ha b hb, calc
   edist a b ≤ edist a x + edist b x : edist_triangle_right _ _ _
-  ... ≤ r + r : add_le_add' ha hb
+  ... ≤ r + r : add_le_add ha hb
   ... = 2 * r : by simp [mul_two, mul_comm]
 
 lemma diam_ball {r : ennreal} : diam (ball x r) ≤ 2 * r :=

--- a/src/topology/metric_space/hausdorff_distance.lean
+++ b/src/topology/metric_space/hausdorff_distance.lean
@@ -106,7 +106,7 @@ begin
   -- z : α,  zs : z ∈ s,  dyz : edist y z < ↑ε / 2
   calc inf_edist x s ≤ edist x z : inf_edist_le_edist_of_mem zs
         ... ≤ edist x y + edist y z : edist_triangle _ _ _
-        ... ≤ (inf_edist x (closure s) + ε / 2) + (ε/2) : add_le_add' (le_of_lt hy) (le_of_lt dyz)
+        ... ≤ (inf_edist x (closure s) + ε / 2) + (ε/2) : add_le_add (le_of_lt hy) (le_of_lt dyz)
         ... = inf_edist x (closure s) + ↑ε : by rw [add_assoc, ennreal.add_halves]
 end
 
@@ -227,7 +227,7 @@ ennreal.le_of_forall_epsilon_le $ λε εpos h, begin
   -- z : α,  zt : z ∈ t,  dyz : edist y z < Hausdorff_edist s t + ↑ε / 2
   calc inf_edist x t ≤ edist x z : inf_edist_le_edist_of_mem zt
     ... ≤ edist x y + edist y z : edist_triangle _ _ _
-    ... ≤ (inf_edist x s + ε/2) + (Hausdorff_edist s t + ε/2) : add_le_add' (le_of_lt dxy) (le_of_lt dyz)
+    ... ≤ (inf_edist x s + ε/2) + (Hausdorff_edist s t + ε/2) : add_le_add (le_of_lt dxy) (le_of_lt dyz)
     ... = inf_edist x s + Hausdorff_edist s t + ε : by simp [ennreal.add_halves, add_comm, add_left_comm]
 end
 

--- a/src/topology/metric_space/lipschitz.lean
+++ b/src/topology/metric_space/lipschitz.lean
@@ -144,7 +144,7 @@ begin
   rintros ⟨a₁, b₁⟩ ⟨a₂, b₂⟩,
   simp only [function.uncurry, ennreal.coe_add, add_mul],
   apply le_trans (edist_triangle _ (f a₂ b₁) _),
-  exact add_le_add' (le_trans (hα _ _ _) $ ennreal.mul_left_mono $ le_max_left _ _)
+  exact add_le_add (le_trans (hα _ _ _) $ ennreal.mul_left_mono $ le_max_left _ _)
     (le_trans (hβ _ _ _) $ ennreal.mul_left_mono $ le_max_right _ _)
 end
 


### PR DESCRIPTION
Also drop `mul_le_mul''` (was a weaker version of `mul_le_mul'`).

---
<!-- put comments you want to keep out of the PR commit here -->
I used `sed` to replace `add_le_add'` with `add_le_add`. Waiting for CI.