### PR TITLE
[Merged by Bors] - feat(algebra/big_operators): prod_dite_eq

### DIFF
--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -700,6 +700,30 @@ lemma prod_eq_one {f : α → β} {s : finset α} (h : ∀x∈s, f x = 1) : (∏
 calc (∏ x in s, f x) = ∏ x in s, 1 : finset.prod_congr rfl h
   ... = 1 : finset.prod_const_one
 
+@[simp, to_additive]
+lemma prod_dite_eq [decidable_eq α] (s : finset α) (a : α) (b : Π x : α, a = x → β) :
+  (∏ x in s, (if h : a = x then b x h else 1)) = ite (a ∈ s) (b a rfl) 1 :=
+begin
+  split_ifs with h,
+  { rw [finset.prod_eq_single a, dif_pos rfl],
+    { intros, rw dif_neg, cc },
+    { cc } },
+  { rw finset.prod_eq_one,
+    intros, rw dif_neg, intro, cc }
+end
+
+@[simp, to_additive]
+lemma prod_dite_eq' [decidable_eq α] (s : finset α) (a : α) (b : Π x : α, x = a → β) :
+  (∏ x in s, (if h : x = a then b x h else 1)) = ite (a ∈ s) (b a rfl) 1 :=
+begin
+  split_ifs with h,
+  { rw [finset.prod_eq_single a, dif_pos rfl],
+    { intros, rw dif_neg, cc },
+    { cc } },
+  { rw finset.prod_eq_one,
+    intros, rw dif_neg, intro, cc }
+end
+
 /-- A product over all subsets of `s ∪ {x}` is obtained by multiplying the product over all subsets
 of `s`, and over all subsets of `s` to which one adds `x`. -/
 @[to_additive]

--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -338,6 +338,11 @@ by haveI := classical.dec_eq α; exact
     by rw [prod_image]; exact assume x _ y _, subtype.eq
   ... = _ : by rw [attach_image_val]
 
+@[to_additive]
+lemma prod_eq_one {f : α → β} {s : finset α} (h : ∀x∈s, f x = 1) : (∏ x in s, f x) = 1 :=
+calc (∏ x in s, f x) = ∏ x in s, 1 : finset.prod_congr rfl h
+  ... = 1 : finset.prod_const_one
+
 @[to_additive] lemma prod_apply_dite {s : finset α} {p : α → Prop} {hp : decidable_pred p}
   (f : Π (x : α), p x → γ) (g : Π (x : α), ¬p x → γ) (h : γ → β) :
   (∏ x in s, h (if hx : p x then f x hx else g x hx)) =
@@ -378,13 +383,33 @@ by simp [prod_apply_dite _ _ (λ x, x)]
   (∏ x in s.filter p, f x) * (∏ x in s.filter (λ x, ¬ p x), g x) :=
 by simp [prod_apply_ite _ _ (λ x, x)]
 
+@[simp, to_additive]
+lemma prod_dite_eq [decidable_eq α] (s : finset α) (a : α) (b : Π x : α, a = x → β) :
+  (∏ x in s, (if h : a = x then b x h else 1)) = ite (a ∈ s) (b a rfl) 1 :=
+begin
+  split_ifs with h,
+  { rw [finset.prod_eq_single a, dif_pos rfl],
+    { intros, rw dif_neg, cc },
+    { cc } },
+  { rw finset.prod_eq_one,
+    intros, rw dif_neg, intro, cc }
+end
+
+@[simp, to_additive]
+lemma prod_dite_eq' [decidable_eq α] (s : finset α) (a : α) (b : Π x : α, x = a → β) :
+  (∏ x in s, (if h : x = a then b x h else 1)) = ite (a ∈ s) (b a rfl) 1 :=
+begin
+  split_ifs with h,
+  { rw [finset.prod_eq_single a, dif_pos rfl],
+    { intros, rw dif_neg, cc },
+    { cc } },
+  { rw finset.prod_eq_one,
+    intros, rw dif_neg, intro, cc }
+end
+
 @[simp, to_additive] lemma prod_ite_eq [decidable_eq α] (s : finset α) (a : α) (b : α → β) :
   (∏ x in s, (ite (a = x) (b x) 1)) = ite (a ∈ s) (b a) 1 :=
-begin
-  rw ←finset.prod_filter,
-  split_ifs;
-  simp only [filter_eq, if_true, if_false, h, prod_empty, prod_singleton],
-end
+prod_dite_eq s a (λ x _, b x)
 
 /--
   When a product is taken over a conditional whose condition is an equality test on the index
@@ -394,11 +419,7 @@ end
 -/
 @[simp, to_additive] lemma prod_ite_eq' [decidable_eq α] (s : finset α) (a : α) (b : α → β) :
   (∏ x in s, (ite (x = a) (b x) 1)) = ite (a ∈ s) (b a) 1 :=
-begin
-  rw ←prod_ite_eq,
-  congr, ext x,
-  by_cases x = a; finish
-end
+prod_dite_eq' s a (λ x _, b x)
 
 /--
   Reorder a product.
@@ -694,35 +715,6 @@ calc ∏ a in s, f (g a)
   prod_congr rfl (λ b hb, prod_congr rfl (by simp {contextual := tt}))
 ... = ∏ b in s.image g, f b ^ (s.filter (λ a, g a = b)).card :
   prod_congr rfl (λ _ _, prod_const _)
-
-@[to_additive]
-lemma prod_eq_one {f : α → β} {s : finset α} (h : ∀x∈s, f x = 1) : (∏ x in s, f x) = 1 :=
-calc (∏ x in s, f x) = ∏ x in s, 1 : finset.prod_congr rfl h
-  ... = 1 : finset.prod_const_one
-
-@[simp, to_additive]
-lemma prod_dite_eq [decidable_eq α] (s : finset α) (a : α) (b : Π x : α, a = x → β) :
-  (∏ x in s, (if h : a = x then b x h else 1)) = ite (a ∈ s) (b a rfl) 1 :=
-begin
-  split_ifs with h,
-  { rw [finset.prod_eq_single a, dif_pos rfl],
-    { intros, rw dif_neg, cc },
-    { cc } },
-  { rw finset.prod_eq_one,
-    intros, rw dif_neg, intro, cc }
-end
-
-@[simp, to_additive]
-lemma prod_dite_eq' [decidable_eq α] (s : finset α) (a : α) (b : Π x : α, x = a → β) :
-  (∏ x in s, (if h : x = a then b x h else 1)) = ite (a ∈ s) (b a rfl) 1 :=
-begin
-  split_ifs with h,
-  { rw [finset.prod_eq_single a, dif_pos rfl],
-    { intros, rw dif_neg, cc },
-    { cc } },
-  { rw finset.prod_eq_one,
-    intros, rw dif_neg, intro, cc }
-end
 
 /-- A product over all subsets of `s ∪ {x}` is obtained by multiplying the product over all subsets
 of `s`, and over all subsets of `s` to which one adds `x`. -/


### PR DESCRIPTION
Add `finset.prod_dite_eq`, the dependent analogue of `finset.prod_ite_eq`, and its primed version for the flipped equality.

---
<!-- put comments you want to keep out of the PR commit here -->
