### PR TITLE
[Merged by Bors] - feat(tactic/abel) teach abel to gsmul_zero

### DIFF
--- a/src/tactic/abel.lean
+++ b/src/tactic/abel.lean
@@ -272,7 +272,7 @@ meta def normalize (mode := normalize_mode.term) (e : expr) : tactic (expr × ex
 pow_lemma ← simp_lemmas.mk.add_simp ``pow_one,
 let lemmas := match mode with
 | normalize_mode.term :=
-  [``term.equations._eqn_1, ``termg.equations._eqn_1, ``add_zero, ``one_nsmul, ``one_gsmul]
+  [``term.equations._eqn_1, ``termg.equations._eqn_1, ``add_zero, ``one_nsmul, ``one_gsmul, ``gsmul_zero]
 | _ := []
 end,
 lemmas ← lemmas.mfoldl simp_lemmas.add_simp simp_lemmas.mk,

--- a/test/abel.lean
+++ b/test/abel.lean
@@ -3,3 +3,4 @@ variables {α : Type*} {a b : α}
 
 example [add_comm_monoid α] : a + (b + a) = a + a + b := by abel
 example [add_comm_group α] : (a + b) - ((b + a) + a) = -a := by abel
+example [add_comm_group α] (x : α) : x - 0 = x := by abel


### PR DESCRIPTION
As reported by Heather Macbeth in:
https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/limitations.20of.20.60abel.60

`abel` was not negating zero to zero.

---
<!-- put comments you want to keep out of the PR commit here -->
