### PR TITLE
[Merged by Bors] - feat(category/limits/shapes): fix biproducts

### DIFF
--- a/src/algebra/category/Group/biproducts.lean
+++ b/src/algebra/category/Group/biproducts.lean
@@ -33,8 +33,8 @@ instance has_limit_pair (G H : AddCommGroup.{u}) : has_limit.{u} (pair G H) :=
       ext; [rw ← w walking_pair.left, rw ← w walking_pair.right]; refl,
     end, } }
 
-instance (G H : AddCommGroup.{u}) : has_preadditive_binary_biproduct.{u} G H :=
-has_preadditive_binary_biproduct.of_has_limit_pair _ _
+instance (G H : AddCommGroup.{u}) : has_binary_biproduct.{u} G H :=
+has_binary_biproduct.of_has_binary_product _ _
 
 -- We verify that the underlying type of the biproduct we've just defined is definitionally
 -- the cartesian product of the underlying types:
@@ -140,13 +140,19 @@ open has_limit has_colimit
 
 variables [decidable_eq J] [fintype J]
 
-instance : has_bilimit F :=
+instance (f : J → AddCommGroup.{u}) : has_biproduct f :=
 { bicone :=
-  { X := AddCommGroup.of (Π j, F.obj j),
-    ι := discrete.nat_trans (λ j, add_monoid_hom.single (λ j, F.obj j) j),
-    π := discrete.nat_trans (λ j, add_monoid_hom.apply (λ j, F.obj j) j), },
-  is_limit := limit.is_limit F,
-  is_colimit := colimit.is_colimit F, }.
+  { X := AddCommGroup.of (Π j, f j),
+    ι := λ j, add_monoid_hom.single (λ j, f j) j,
+    π := λ j, add_monoid_hom.apply (λ j, f j) j,
+    ι_π := λ j j',
+    begin
+      ext, split_ifs,
+      { subst h, simp, },
+      { rw [eq_comm] at h, simp [h], },
+    end, },
+  is_limit := limit.is_limit (discrete.functor f),
+  is_colimit := colimit.is_colimit (discrete.functor f), }.
 
 -- We verify that the underlying type of the biproduct we've just defined is definitionally
 -- the dependent function type:

--- a/src/category_theory/abelian/basic.lean
+++ b/src/category_theory/abelian/basic.lean
@@ -326,7 +326,7 @@ end
 
 section
 local attribute [instance] preadditive.has_coequalizers_of_has_cokernels
-local attribute [instance] has_preadditive_binary_biproducts_of_has_binary_products
+local attribute [instance] has_binary_biproducts.of_has_binary_products
 
 /-- Any abelian category has pushouts -/
 def has_pushouts : has_pushouts.{v} C :=
@@ -337,7 +337,7 @@ end
 namespace pullback_to_biproduct_is_kernel
 variables [limits.has_pullbacks.{v} C] {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z)
 
-local attribute [instance] has_preadditive_binary_biproducts_of_has_binary_products
+local attribute [instance] has_binary_biproducts.of_has_binary_products
 
 /-! This section contains a slightly technical result about pullbacks and biproducts.
     We will need it in the proof that the pullback of an epimorphism is an epimorpism. -/
@@ -362,7 +362,7 @@ def is_limit_pullback_to_biproduct : is_limit (pullback_to_biproduct_fork f g) :
 fork.is_limit.mk _
   (λ s, pullback.lift (fork.ι s ≫ biprod.fst) (fork.ι s ≫ biprod.snd) $
     sub_eq_zero.1 $ by rw [category.assoc, category.assoc, ←comp_sub, sub_eq_add_neg, ←comp_neg,
-      biprod.fst_add_snd, kernel_fork.condition s])
+      ←biprod.desc_eq, kernel_fork.condition s])
   (λ s,
   begin
     ext; rw [fork.ι_of_ι, category.assoc],
@@ -376,7 +376,7 @@ end pullback_to_biproduct_is_kernel
 namespace biproduct_to_pushout_is_cokernel
 variables [limits.has_pushouts.{v} C] {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z)
 
-local attribute [instance] has_preadditive_binary_biproducts_of_has_binary_products
+local attribute [instance] has_binary_biproducts.of_has_binary_products
 
 /-- The canonical map `Y ⊞ Z ⟶ pushout f g` -/
 abbreviation biproduct_to_pushout : Y ⊞ Z ⟶ pushout f g :=
@@ -394,7 +394,7 @@ def is_colimit_biproduct_to_pushout : is_colimit (biproduct_to_pushout_cofork f 
 cofork.is_colimit.mk _
   (λ s, pushout.desc (biprod.inl ≫ cofork.π s) (biprod.inr ≫ cofork.π s) $
     sub_eq_zero.1 $ by rw [←category.assoc, ←category.assoc, ←sub_comp, sub_eq_add_neg, ←neg_comp,
-      biprod.inl_add_inr, cofork.condition s, has_zero_morphisms.zero_comp])
+      ←biprod.lift_eq, cofork.condition s, has_zero_morphisms.zero_comp])
   (λ s, by ext; simp)
   (λ s m h, by ext; simp [cofork.π_eq_app_one, ←h walking_parallel_pair.one] )
 
@@ -403,7 +403,7 @@ end biproduct_to_pushout_is_cokernel
 section epi_pullback
 variables [limits.has_pullbacks.{v} C] {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z)
 
-local attribute [instance] has_preadditive_binary_biproducts_of_has_binary_products
+local attribute [instance] has_binary_biproducts.of_has_binary_products
 
 /-- In an abelian category, the pullback of an epimorphism is an epimorphism.
     Proof from [aluffi2016, IX.2.3], cf. [borceux-vol2, 1.7.6] -/
@@ -479,7 +479,7 @@ end epi_pullback
 section mono_pushout
 variables [limits.has_pushouts.{v} C] {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z)
 
-local attribute [instance] has_preadditive_binary_biproducts_of_has_binary_products
+local attribute [instance] has_binary_biproducts.of_has_binary_products
 
 instance mono_pushout_of_mono_f [mono f] : mono (pushout.inr : Z ⟶ pushout f g) :=
 mono_of_cancel_zero _ $ λ R e h,

--- a/src/category_theory/limits/shapes/binary_products.lean
+++ b/src/category_theory/limits/shapes/binary_products.lean
@@ -294,6 +294,16 @@ abbreviation prod.map_iso {W X Y Z : C} [has_limits_of_shape.{v} (discrete walki
   (f : W ≅ Y) (g : X ≅ Z) : W ⨯ X ≅ Y ⨯ Z :=
 lim.map_iso (map_pair_iso f g)
 
+-- Note that the next two `simp` lemmas are proved by `simp`,
+-- but nevertheless are useful,
+-- because they state the right hand side in terms of `prod.map`
+-- rather than `lim.map`.
+@[simp] lemma prod.map_iso_hom {W X Y Z : C} [has_limits_of_shape.{v} (discrete walking_pair) C]
+  (f : W ≅ Y) (g : X ≅ Z) : (prod.map_iso f g).hom = prod.map f.hom g.hom := by simp
+
+@[simp] lemma prod.map_iso_inv {W X Y Z : C} [has_limits_of_shape.{v} (discrete walking_pair) C]
+  (f : W ≅ Y) (g : X ≅ Z) : (prod.map_iso f g).inv = prod.map f.inv g.inv := by simp
+
 /-- If the coproducts `W ⨿ X` and `Y ⨿ Z` exist, then every pair of morphisms `f : W ⟶ Y` and
     `g : W ⟶ Z` induces a morphism `coprod.map f g : W ⨿ X ⟶ Y ⨿ Z`. -/
 abbreviation coprod.map {W X Y Z : C} [has_colimits_of_shape.{v} (discrete walking_pair) C]
@@ -305,6 +315,13 @@ colim.map (map_pair f g)
 abbreviation coprod.map_iso {W X Y Z : C} [has_colimits_of_shape.{v} (discrete walking_pair) C]
   (f : W ≅ Y) (g : X ≅ Z) : W ⨿ X ≅ Y ⨿ Z :=
 colim.map_iso (map_pair_iso f g)
+
+@[simp] lemma coprod.map_iso_hom {W X Y Z : C} [has_colimits_of_shape.{v} (discrete walking_pair) C]
+  (f : W ≅ Y) (g : X ≅ Z) : (coprod.map_iso f g).hom = coprod.map f.hom g.hom := by simp
+
+@[simp] lemma coprod.map_iso_inv {W X Y Z : C} [has_colimits_of_shape.{v} (discrete walking_pair) C]
+  (f : W ≅ Y) (g : X ≅ Z) : (coprod.map_iso f g).inv = coprod.map f.inv g.inv := by simp
+
 
 section prod_lemmas
 variable [has_limits_of_shape.{v} (discrete walking_pair) C]

--- a/src/category_theory/limits/shapes/binary_products.lean
+++ b/src/category_theory/limits/shapes/binary_products.lean
@@ -38,6 +38,34 @@ instance fintype_walking_pair : fintype walking_pair :=
 { elems := {left, right},
   complete := λ x, by { cases x; simp } }
 
+/--
+The equivalence swapping left and right.
+-/
+def walking_pair.swap : walking_pair ≃ walking_pair :=
+{ to_fun := λ j, walking_pair.rec_on j right left,
+  inv_fun := λ j, walking_pair.rec_on j right left,
+  left_inv := λ j, by { cases j; refl, },
+  right_inv := λ j, by { cases j; refl, }, }
+
+@[simp] lemma walking_pair.swap_apply_left : walking_pair.swap left = right := rfl
+@[simp] lemma walking_pair.swap_apply_right : walking_pair.swap right = left := rfl
+@[simp] lemma walking_pair.swap_symm_apply_tt : walking_pair.swap.symm left = right := rfl
+@[simp] lemma walking_pair.swap_symm_apply_ff : walking_pair.swap.symm right = left := rfl
+
+/--
+An equivalence from `walking_pair` to `bool`, sometimes useful when reindexing limits.
+-/
+def walking_pair.equiv_bool : walking_pair ≃ bool :=
+{ to_fun := λ j, walking_pair.rec_on j tt ff, -- to match equiv.sum_equiv_sigma_bool
+  inv_fun := λ b, bool.rec_on b right left,
+  left_inv := λ j, by { cases j; refl, },
+  right_inv := λ b, by { cases b; refl, }, }
+
+@[simp] lemma walking_pair.equiv_bool_apply_left : walking_pair.equiv_bool left = tt := rfl
+@[simp] lemma walking_pair.equiv_bool_apply_right : walking_pair.equiv_bool right = ff := rfl
+@[simp] lemma walking_pair.equiv_bool_symm_apply_tt : walking_pair.equiv_bool.symm tt = left := rfl
+@[simp] lemma walking_pair.equiv_bool_symm_apply_ff : walking_pair.equiv_bool.symm ff = right := rfl
+
 variables {C : Type u} [category.{v} C]
 
 /-- The diagram on the walking pair, sending the two points to `X` and `Y`. -/
@@ -143,109 +171,114 @@ def binary_cofan.is_colimit.desc' {W X Y : C} {s : binary_cofan X Y} (h : is_col
   (g : Y ⟶ W) : {l : s.X ⟶ W // s.inl ≫ l = f ∧ s.inr ≫ l = g} :=
 ⟨h.desc $ binary_cofan.mk f g, h.fac _ _, h.fac _ _⟩
 
+/-- An abbreviation for `has_limit (pair X Y)`. -/
+abbreviation has_binary_product (X Y : C) := has_limit (pair X Y)
+/-- An abbreviation for `has_colimit (pair X Y)`. -/
+abbreviation has_binary_coproduct (X Y : C) := has_colimit (pair X Y)
+
 /-- If we have chosen a product of `X` and `Y`, we can access it using `prod X Y` or
     `X ⨯ Y`. -/
-abbreviation prod (X Y : C) [has_limit (pair X Y)] := limit (pair X Y)
+abbreviation prod (X Y : C) [has_binary_product X Y] := limit (pair X Y)
 
 /-- If we have chosen a coproduct of `X` and `Y`, we can access it using `coprod X Y ` or
     `X ⨿ Y`. -/
-abbreviation coprod (X Y : C) [has_colimit (pair X Y)] := colimit (pair X Y)
+abbreviation coprod (X Y : C) [has_binary_coproduct X Y] := colimit (pair X Y)
 
 notation X ` ⨯ `:20 Y:20 := prod X Y
 notation X ` ⨿ `:20 Y:20 := coprod X Y
 
 /-- The projection map to the first component of the product. -/
-abbreviation prod.fst {X Y : C} [has_limit (pair X Y)] : X ⨯ Y ⟶ X :=
+abbreviation prod.fst {X Y : C} [has_binary_product X Y] : X ⨯ Y ⟶ X :=
 limit.π (pair X Y) walking_pair.left
 
 /-- The projecton map to the second component of the product. -/
-abbreviation prod.snd {X Y : C} [has_limit (pair X Y)] : X ⨯ Y ⟶ Y :=
+abbreviation prod.snd {X Y : C} [has_binary_product X Y] : X ⨯ Y ⟶ Y :=
 limit.π (pair X Y) walking_pair.right
 
 /-- The inclusion map from the first component of the coproduct. -/
-abbreviation coprod.inl {X Y : C} [has_colimit (pair X Y)] : X ⟶ X ⨿ Y :=
+abbreviation coprod.inl {X Y : C} [has_binary_coproduct X Y] : X ⟶ X ⨿ Y :=
 colimit.ι (pair X Y) walking_pair.left
 
 /-- The inclusion map from the second component of the coproduct. -/
-abbreviation coprod.inr {X Y : C} [has_colimit (pair X Y)] : Y ⟶ X ⨿ Y :=
+abbreviation coprod.inr {X Y : C} [has_binary_coproduct X Y] : Y ⟶ X ⨿ Y :=
 colimit.ι (pair X Y) walking_pair.right
 
-@[ext] lemma prod.hom_ext {W X Y : C} [has_limit (pair X Y)] {f g : W ⟶ X ⨯ Y}
+@[ext] lemma prod.hom_ext {W X Y : C} [has_binary_product X Y] {f g : W ⟶ X ⨯ Y}
   (h₁ : f ≫ prod.fst = g ≫ prod.fst) (h₂ : f ≫ prod.snd = g ≫ prod.snd) : f = g :=
 binary_fan.is_limit.hom_ext (limit.is_limit _) h₁ h₂
 
-@[ext] lemma coprod.hom_ext {W X Y : C} [has_colimit (pair X Y)] {f g : X ⨿ Y ⟶ W}
+@[ext] lemma coprod.hom_ext {W X Y : C} [has_binary_coproduct X Y] {f g : X ⨿ Y ⟶ W}
   (h₁ : coprod.inl ≫ f = coprod.inl ≫ g) (h₂ : coprod.inr ≫ f = coprod.inr ≫ g) : f = g :=
 binary_cofan.is_colimit.hom_ext (colimit.is_colimit _) h₁ h₂
 
 /-- If the product of `X` and `Y` exists, then every pair of morphisms `f : W ⟶ X` and `g : W ⟶ Y`
     induces a morphism `prod.lift f g : W ⟶ X ⨯ Y`. -/
-abbreviation prod.lift {W X Y : C} [has_limit (pair X Y)] (f : W ⟶ X) (g : W ⟶ Y) : W ⟶ X ⨯ Y :=
+abbreviation prod.lift {W X Y : C} [has_binary_product X Y] (f : W ⟶ X) (g : W ⟶ Y) : W ⟶ X ⨯ Y :=
 limit.lift _ (binary_fan.mk f g)
 
 /-- If the coproduct of `X` and `Y` exists, then every pair of morphisms `f : X ⟶ W` and
     `g : Y ⟶ W` induces a morphism `coprod.desc f g : X ⨿ Y ⟶ W`. -/
-abbreviation coprod.desc {W X Y : C} [has_colimit (pair X Y)] (f : X ⟶ W) (g : Y ⟶ W) : X ⨿ Y ⟶ W :=
+abbreviation coprod.desc {W X Y : C} [has_binary_coproduct X Y] (f : X ⟶ W) (g : Y ⟶ W) : X ⨿ Y ⟶ W :=
 colimit.desc _ (binary_cofan.mk f g)
 
 @[simp, reassoc]
-lemma prod.lift_fst {W X Y : C} [has_limit (pair X Y)] (f : W ⟶ X) (g : W ⟶ Y) :
+lemma prod.lift_fst {W X Y : C} [has_binary_product X Y] (f : W ⟶ X) (g : W ⟶ Y) :
   prod.lift f g ≫ prod.fst = f :=
 limit.lift_π _ _
 
 @[simp, reassoc]
-lemma prod.lift_snd {W X Y : C} [has_limit (pair X Y)] (f : W ⟶ X) (g : W ⟶ Y) :
+lemma prod.lift_snd {W X Y : C} [has_binary_product X Y] (f : W ⟶ X) (g : W ⟶ Y) :
   prod.lift f g ≫ prod.snd = g :=
 limit.lift_π _ _
 
 /- The redundant simp lemma linter says that simp can prove the reassoc version of this lemma. -/
 @[reassoc, simp]
-lemma prod.lift_comp_comp {V W X Y : C} [has_limit (pair X Y)] (f : V ⟶ W) (g : W ⟶ X) (h : W ⟶ Y) :
+lemma prod.lift_comp_comp {V W X Y : C} [has_binary_product X Y] (f : V ⟶ W) (g : W ⟶ X) (h : W ⟶ Y) :
   prod.lift (f ≫ g) (f ≫ h) = f ≫ prod.lift g h :=
 by tidy
 
 @[simp, reassoc]
-lemma coprod.inl_desc {W X Y : C} [has_colimit (pair X Y)] (f : X ⟶ W) (g : Y ⟶ W) :
+lemma coprod.inl_desc {W X Y : C} [has_binary_coproduct X Y] (f : X ⟶ W) (g : Y ⟶ W) :
   coprod.inl ≫ coprod.desc f g = f :=
 colimit.ι_desc _ _
 
 @[simp, reassoc]
-lemma coprod.inr_desc {W X Y : C} [has_colimit (pair X Y)] (f : X ⟶ W) (g : Y ⟶ W) :
+lemma coprod.inr_desc {W X Y : C} [has_binary_coproduct X Y] (f : X ⟶ W) (g : Y ⟶ W) :
   coprod.inr ≫ coprod.desc f g = g :=
 colimit.ι_desc _ _
 
 /- The redundant simp lemma linter says that simp can prove the reassoc version of this lemma. -/
 @[reassoc, simp]
-lemma coprod.desc_comp_comp {V W X Y : C} [has_colimit (pair X Y)] (f : V ⟶ W) (g : X ⟶ V)
+lemma coprod.desc_comp_comp {V W X Y : C} [has_binary_coproduct X Y] (f : V ⟶ W) (g : X ⟶ V)
   (h : Y ⟶ V) : coprod.desc (g ≫ f) (h ≫ f) = coprod.desc g h ≫ f :=
 by tidy
 
-instance prod.mono_lift_of_mono_left {W X Y : C} [has_limit (pair X Y)] (f : W ⟶ X) (g : W ⟶ Y)
+instance prod.mono_lift_of_mono_left {W X Y : C} [has_binary_product X Y] (f : W ⟶ X) (g : W ⟶ Y)
   [mono f] : mono (prod.lift f g) :=
 mono_of_mono_fac $ prod.lift_fst _ _
 
-instance prod.mono_lift_of_mono_right {W X Y : C} [has_limit (pair X Y)] (f : W ⟶ X) (g : W ⟶ Y)
+instance prod.mono_lift_of_mono_right {W X Y : C} [has_binary_product X Y] (f : W ⟶ X) (g : W ⟶ Y)
   [mono g] : mono (prod.lift f g) :=
 mono_of_mono_fac $ prod.lift_snd _ _
 
-instance coprod.epi_desc_of_epi_left {W X Y : C} [has_colimit (pair X Y)] (f : X ⟶ W) (g : Y ⟶ W)
+instance coprod.epi_desc_of_epi_left {W X Y : C} [has_binary_coproduct X Y] (f : X ⟶ W) (g : Y ⟶ W)
   [epi f] : epi (coprod.desc f g) :=
 epi_of_epi_fac $ coprod.inl_desc _ _
 
-instance coprod.epi_desc_of_epi_right {W X Y : C} [has_colimit (pair X Y)] (f : X ⟶ W) (g : Y ⟶ W)
+instance coprod.epi_desc_of_epi_right {W X Y : C} [has_binary_coproduct X Y] (f : X ⟶ W) (g : Y ⟶ W)
   [epi g] : epi (coprod.desc f g) :=
 epi_of_epi_fac $ coprod.inr_desc _ _
 
 /-- If the product of `X` and `Y` exists, then every pair of morphisms `f : W ⟶ X` and `g : W ⟶ Y`
     induces a morphism `l : W ⟶ X ⨯ Y` satisfying `l ≫ prod.fst = f` and `l ≫ prod.snd = g`. -/
-def prod.lift' {W X Y : C} [has_limit (pair X Y)] (f : W ⟶ X) (g : W ⟶ Y) :
+def prod.lift' {W X Y : C} [has_binary_product X Y] (f : W ⟶ X) (g : W ⟶ Y) :
   {l : W ⟶ X ⨯ Y // l ≫ prod.fst = f ∧ l ≫ prod.snd = g} :=
 ⟨prod.lift f g, prod.lift_fst _ _, prod.lift_snd _ _⟩
 
 /-- If the coproduct of `X` and `Y` exists, then every pair of morphisms `f : X ⟶ W` and
     `g : Y ⟶ W` induces a morphism `l : X ⨿ Y ⟶ W` satisfying `coprod.inl ≫ l = f` and
     `coprod.inr ≫ l = g`. -/
-def coprod.desc' {W X Y : C} [has_colimit (pair X Y)] (f : X ⟶ W) (g : Y ⟶ W) :
+def coprod.desc' {W X Y : C} [has_binary_coproduct X Y] (f : X ⟶ W) (g : Y ⟶ W) :
   {l : X ⨿ Y ⟶ W // coprod.inl ≫ l = f ∧ coprod.inr ≫ l = g} :=
 ⟨coprod.desc f g, coprod.inl_desc _ _, coprod.inr_desc _ _⟩
 
@@ -255,11 +288,23 @@ abbreviation prod.map {W X Y Z : C} [has_limits_of_shape.{v} (discrete walking_p
   (f : W ⟶ Y) (g : X ⟶ Z) : W ⨯ X ⟶ Y ⨯ Z :=
 lim.map (map_pair f g)
 
+/-- If the products `W ⨯ X` and `Y ⨯ Z` exist, then every pair of isomorphisms `f : W ≅ Y` and
+    `g : X ≅ Z` induces a isomorphism `prod.map_iso f g : W ⨯ X ≅ Y ⨯ Z`. -/
+abbreviation prod.map_iso {W X Y Z : C} [has_limits_of_shape.{v} (discrete walking_pair) C]
+  (f : W ≅ Y) (g : X ≅ Z) : W ⨯ X ≅ Y ⨯ Z :=
+lim.map_iso (map_pair_iso f g)
+
 /-- If the coproducts `W ⨿ X` and `Y ⨿ Z` exist, then every pair of morphisms `f : W ⟶ Y` and
     `g : W ⟶ Z` induces a morphism `coprod.map f g : W ⨿ X ⟶ Y ⨿ Z`. -/
 abbreviation coprod.map {W X Y Z : C} [has_colimits_of_shape.{v} (discrete walking_pair) C]
   (f : W ⟶ Y) (g : X ⟶ Z) : W ⨿ X ⟶ Y ⨿ Z :=
 colim.map (map_pair f g)
+
+/-- If the coproducts `W ⨿ X` and `Y ⨿ Z` exist, then every pair of isomorphisms `f : W ≅ Y` and
+    `g : W ≅ Z` induces a isomorphism `coprod.map_iso f g : W ⨿ X ≅ Y ⨿ Z`. -/
+abbreviation coprod.map_iso {W X Y Z : C} [has_colimits_of_shape.{v} (discrete walking_pair) C]
+  (f : W ≅ Y) (g : X ≅ Z) : W ⨿ X ≅ Y ⨿ Z :=
+colim.map_iso (map_pair_iso f g)
 
 section prod_lemmas
 variable [has_limits_of_shape.{v} (discrete walking_pair) C]

--- a/src/category_theory/limits/shapes/biproducts.lean
+++ b/src/category_theory/limits/shapes/biproducts.lean
@@ -153,13 +153,16 @@ limit (discrete.functor f)
 
 notation `⨁ ` f:20 := biproduct f
 
+/-- The chosen bicone over a family of elements. -/
 abbreviation biproduct.bicone (f : J → C) [has_biproduct f] : bicone f :=
 has_biproduct.bicone
 
+/-- The cone coming from the chosen bicone is a limit cone. -/
 abbreviation biproduct.is_limit (f : J → C) [has_biproduct f] :
   is_limit (biproduct.bicone f).to_cone :=
 has_biproduct.is_limit
 
+/-- The cocone coming from the chosen bicone is a colimit cocone. -/
 abbreviation biproduct.is_colimit (f : J → C) [has_biproduct f] :
   is_colimit (biproduct.bicone f).to_cocone :=
 has_biproduct.is_colimit
@@ -586,11 +589,12 @@ variables [has_binary_biproducts.{v} C]
 An alternative formula for the braiding isomorphism which swaps a binary biproduct,
 using the fact that the biproduct is a coproduct.
 -/
-@[simps] def biprod.braiding' (P Q : C) : P ⊞ Q ≅ Q ⊞ P :=
+@[simps]
+def biprod.braiding' (P Q : C) : P ⊞ Q ≅ Q ⊞ P :=
 { hom := biprod.desc biprod.inr biprod.inl,
   inv := biprod.desc biprod.inr biprod.inl }
 
-@[simp] lemma biprod.braiding'_eq_braiding {P Q : C} :
+lemma biprod.braiding'_eq_braiding {P Q : C} :
   biprod.braiding' P Q = biprod.braiding P Q :=
 by tidy
 
@@ -599,7 +603,7 @@ by tidy
   biprod.map f g ≫ (biprod.braiding _ _).hom = (biprod.braiding _ _).hom ≫ biprod.map g f :=
 by tidy
 
-@[simp, reassoc] lemma biprod.braiding_map_braiding {W X Y Z : C} (f : W ⟶ Y) (g : X ⟶ Z) :
+@[reassoc] lemma biprod.braiding_map_braiding {W X Y Z : C} (f : W ⟶ Y) (g : X ⟶ Z) :
   (biprod.braiding X W).hom ≫ biprod.map f g ≫ (biprod.braiding Y Z).hom = biprod.map g f :=
 by tidy
 

--- a/src/category_theory/limits/shapes/biproducts.lean
+++ b/src/category_theory/limits/shapes/biproducts.lean
@@ -6,6 +6,7 @@ Authors: Scott Morrison
 import category_theory.epi_mono
 import category_theory.limits.shapes.binary_products
 import category_theory.preadditive
+import algebra.big_operators
 
 /-!
 # Biproducts and binary biproducts
@@ -16,28 +17,28 @@ These are slightly unusual relative to the other shapes in the library,
 as they are simultaneously limits and colimits.
 (Zero objects are similar; they are "biterminal".)
 
-We model these here using a `bicone`, with a cone point `X`,
-and natural transformations `π` from the constant functor with value `X` to `F`
-and `ι` in the other direction.
+We treat first the case of a general category with zero morphisms,
+and subsequently the case of a preadditive category.
 
-We implement `has_bilimit` as a `bicone`, equipped with the evidence
-`is_limit bicone.to_cone` and `is_colimit bicone.to_cocone`.
+In a category with zero morphisms, we model the (binary) biproduct of `P Q : C`
+using a `binary_bicone`, which has a cone point `X`,
+and morphisms `fst : X ⟶ P`, `snd : X ⟶ Q`, `inl : P ⟶ X` and `inr : X ⟶ Q`,
+such that `inl ≫ fst = 𝟙 P`, `inl ≫ snd = 0`, `inr ≫ fst = 0`, and `inr ≫ snd = 𝟙 Q`.
+Such a `binary_bicone` is a biproduct if the cone is a limit cone, and the cocone is a colimit cocone.
 
-In practice, of course, we are only interested in the special case of bilimits
-over `discrete J` for `[fintype J] [decidable_eq J]`,
-which corresponds to finite biproducts.
+In a preadditive category,
+* any `binary_biproduct` satisfies `total : fst ≫ inl + snd ≫ inr = 𝟙 X`
+* any `binary_product` is a `binary_biproduct`
+* any `binary_coproduct` is a `binary_biproduct`
 
-TODO: We should provide a constructor that takes `has_limit F`, `has_colimit F`, and
-and iso `limit F ≅ colimit F`, and produces `has_bilimit F`.
+For biproducts indexed by a `fintype J`, a `bicone` again consists of a cone point `X`
+and morphisms `π j : X ⟶ F j` and `ι j : F j ⟶ X` for each `j`,
+such that `ι j ≫ π j'` is the identity when `j = j'` and zero otherwise.
 
-TODO: perhaps it makes sense to unify the treatment of zero objects with this a bit.
-
-In addition to biproducts and binary biproducts, we define the notion of preadditive binary
-biproduct, which is a preadditive version of binary biproducts. We show that a preadditive binary
-biproduct is a binary biproduct and construct preadditive binary biproducts both from binary
-products and from binary coproducts.
-
-TODO: the preadditive version of finite biproducts
+In a preadditive category,
+* any `biproduct` satisfies `total : ∑ j : J, biproduct.π f j ≫ biproduct.ι f j = 𝟙 (⨁ f)`
+* any `product` is a `biproduct`
+* any `coproduct` is a `biproduct`
 
 ## Notation
 As `⊕` is already taken for the sum of types, we introduce the notation `X ⊞ Y` for
@@ -51,165 +52,314 @@ open category_theory.functor
 
 namespace category_theory.limits
 
-variables {J : Type v} [small_category J]
-variables {C : Type u} [category.{v} C]
+variables {J : Type v} [decidable_eq J]
+variables {C : Type u} [category.{v} C] [has_zero_morphisms.{v} C]
 
 /--
 A `c : bicone F` is:
 * an object `c.X` and
-* a natural transformation `c.π : c.X ⟶ F` from the constant `c.X` functor to `F`.
-* a natural transformation `c.ι : F ⟶ c.X` from `F` to the constant `c.X` functor.
+* morphisms `π j : X ⟶ F j` and `ι j : F j ⟶ X` for each `j`,
+* such that `ι j ≫ π j'` is the identity when `j = j'` and zero otherwise.
 -/
 @[nolint has_inhabited_instance]
-structure bicone {J : Type v} [small_category J] (F : J ⥤ C) :=
+structure bicone (F : J → C) :=
 (X : C)
-(π : (const J).obj X ⟶ F)
-(ι : F ⟶ (const J).obj X)
+(π : Π j, X ⟶ F j)
+(ι : Π j, F j ⟶ X)
+(ι_π : ∀ j j', ι j ≫ π j' = if h : j = j' then eq_to_hom (congr_arg F h) else 0)
 
-variables {F : J ⥤ C}
+@[simp] lemma bicone_ι_π_self {F : J → C} (B : bicone F) (j : J) : B.ι j ≫ B.π j = 𝟙 (F j) :=
+by simpa using B.ι_π j j
+
+@[simp] lemma bicone_ι_π_ne {F : J → C} (B : bicone F) {j j' : J} (h : j ≠ j') :
+  B.ι j ≫ B.π j' = 0 :=
+by simpa [h] using B.ι_π j j'
+
+variables {F : J → C}
 
 namespace bicone
 /-- Extract the cone from a bicone. -/
 @[simps]
-def to_cone (B : bicone F) : cone F :=
-{ .. B }
+def to_cone (B : bicone F) : cone (discrete.functor F) :=
+{ X := B.X,
+  π := { app := λ j, B.π j }, }
 /-- Extract the cocone from a bicone. -/
 @[simps]
-def to_cocone (B : bicone F) : cocone F :=
-{ .. B }
+def to_cocone (B : bicone F) : cocone (discrete.functor F) :=
+{ X := B.X,
+  ι := { app := λ j, B.ι j }, }
 end bicone
 
 /--
-`has_bilimit F` represents a particular chosen bicone which is
+`has_biproduct F` represents a particular chosen bicone which is
 simultaneously a limit and a colimit of the diagram `F`.
-
-(This is only interesting when the source category is discrete.)
 -/
-class has_bilimit (F : J ⥤ C) :=
+class has_biproduct (F : J → C) :=
 (bicone : bicone F)
 (is_limit : is_limit bicone.to_cone)
 (is_colimit : is_colimit bicone.to_cocone)
 
 @[priority 100]
-instance has_limit_of_has_bilimit [has_bilimit F] : has_limit F :=
-{ cone := has_bilimit.bicone.to_cone,
-  is_limit := has_bilimit.is_limit, }
+instance has_product_of_has_biproduct [has_biproduct F] : has_limit (discrete.functor F) :=
+{ cone := has_biproduct.bicone.to_cone,
+  is_limit := has_biproduct.is_limit, }
 
 @[priority 100]
-instance has_colimit_of_has_bilimit [has_bilimit F] : has_colimit F :=
-{ cocone := has_bilimit.bicone.to_cocone,
-  is_colimit := has_bilimit.is_colimit, }
+instance has_coproduct_of_has_biproduct [has_biproduct F] : has_colimit (discrete.functor F) :=
+{ cocone := has_biproduct.bicone.to_cocone,
+  is_colimit := has_biproduct.is_colimit, }
 
 variables (J C)
 
 /--
-`C` has bilimits of shape `J` if we have chosen
+`C` has biproducts of shape `J` if we have chosen
 a particular limit and a particular colimit, with the same cone points,
-of every functor `F : J ⥤ C`.
-
-(This is only interesting if `J` is discrete.)
+of every function `F : J → C`.
 -/
-class has_bilimits_of_shape :=
-(has_bilimit : Π F : J ⥤ C, has_bilimit F)
+class has_biproducts_of_shape :=
+(has_biproduct : Π F : J → C, has_biproduct F)
 
-attribute [instance, priority 100] has_bilimits_of_shape.has_bilimit
-
-@[priority 100]
-instance [has_bilimits_of_shape J C] : has_limits_of_shape J C :=
-{ has_limit := λ F, by apply_instance }
-@[priority 100]
-instance [has_bilimits_of_shape J C] : has_colimits_of_shape J C :=
-{ has_colimit := λ F, by apply_instance }
+attribute [instance, priority 100] has_biproducts_of_shape.has_biproduct
 
 /-- `has_finite_biproducts C` represents a choice of biproduct for every family of objects in `C`
 indexed by a finite type with decidable equality. -/
 class has_finite_biproducts :=
-(has_bilimits_of_shape : Π (J : Type v) [fintype J] [decidable_eq J],
-  has_bilimits_of_shape.{v} (discrete J) C)
+(has_biproducts_of_shape : Π (J : Type v) [fintype J] [decidable_eq J],
+  has_biproducts_of_shape.{v} J C)
 
-attribute [instance] has_finite_biproducts.has_bilimits_of_shape
+attribute [instance, priority 100] has_finite_biproducts.has_biproducts_of_shape
+
+variables {J C}
 
 /--
 The isomorphism between the specified limit and the specified colimit for
 a functor with a bilimit.
 -/
-def biproduct_iso {J : Type v} (F : J → C) [has_bilimit (discrete.functor F)] :
+def biproduct_iso (F : J → C) [has_biproduct F] :
   limits.pi_obj F ≅ limits.sigma_obj F :=
 eq_to_iso rfl
 
 end category_theory.limits
 
 namespace category_theory.limits
-variables {J : Type v}
-variables {C : Type u} [category.{v} C]
+variables {J : Type v} [decidable_eq J]
+variables {C : Type u} [category.{v} C] [has_zero_morphisms.{v} C]
 
 /-- `biproduct f` computes the biproduct of a family of elements `f`. (It is defined as an
    abbreviation for `limit (discrete.functor f)`, so for most facts about `biproduct f`, you will
    just use general facts about limits and colimits.) -/
-abbreviation biproduct (f : J → C) [has_bilimit (discrete.functor f)] :=
+abbreviation biproduct (f : J → C) [has_biproduct f] : C :=
 limit (discrete.functor f)
 
 notation `⨁ ` f:20 := biproduct f
 
+abbreviation biproduct.bicone (f : J → C) [has_biproduct f] : bicone f :=
+has_biproduct.bicone
+
+abbreviation biproduct.is_limit (f : J → C) [has_biproduct f] :
+  is_limit (biproduct.bicone f).to_cone :=
+has_biproduct.is_limit
+
+abbreviation biproduct.is_colimit (f : J → C) [has_biproduct f] :
+  is_colimit (biproduct.bicone f).to_cocone :=
+has_biproduct.is_colimit
+
 /-- The projection onto a summand of a biproduct. -/
-abbreviation biproduct.π (f : J → C) [has_bilimit (discrete.functor f)] (b : J) : ⨁ f ⟶ f b :=
+abbreviation biproduct.π (f : J → C) [has_biproduct f] (b : J) : ⨁ f ⟶ f b :=
 limit.π (discrete.functor f) b
 /-- The inclusion into a summand of a biproduct. -/
-abbreviation biproduct.ι (f : J → C) [has_bilimit (discrete.functor f)] (b : J) : f b ⟶ ⨁ f :=
+abbreviation biproduct.ι (f : J → C) [has_biproduct f] (b : J) : f b ⟶ ⨁ f :=
 colimit.ι (discrete.functor f) b
+
+@[reassoc]
+lemma biproduct.ι_π (f : J → C) [has_biproduct f] (j j' : J) :
+  biproduct.ι f j ≫ biproduct.π f j' = if h : j = j' then eq_to_hom (congr_arg f h) else 0 :=
+has_biproduct.bicone.ι_π j j'
+
+@[simp,reassoc]
+lemma biproduct.ι_π_self (f : J → C) [has_biproduct f] (j : J) :
+  biproduct.ι f j ≫ biproduct.π f j = 𝟙 _ :=
+by simp [biproduct.ι_π]
+
+@[simp,reassoc]
+lemma biproduct.ι_π_ne (f : J → C) [has_biproduct f] {j j' : J} (h : j ≠ j') :
+  biproduct.ι f j ≫ biproduct.π f j' = 0 :=
+by simp [biproduct.ι_π, h]
 
 /-- Given a collection of maps into the summands, we obtain a map into the biproduct. -/
 abbreviation biproduct.lift
-  {f : J → C} [has_bilimit (discrete.functor f)] {P : C} (p : Π b, P ⟶ f b) : P ⟶ ⨁ f :=
+  {f : J → C} [has_biproduct f] {P : C} (p : Π b, P ⟶ f b) : P ⟶ ⨁ f :=
 limit.lift _ (fan.mk p)
 /-- Given a collection of maps out of the summands, we obtain a map out of the biproduct. -/
 abbreviation biproduct.desc
-  {f : J → C} [has_bilimit (discrete.functor f)] {P : C} (p : Π b, f b ⟶ P) : ⨁ f ⟶ P :=
+  {f : J → C} [has_biproduct f] {P : C} (p : Π b, f b ⟶ P) : ⨁ f ⟶ P :=
 colimit.desc _ (cofan.mk p)
 
 /-- Given a collection of maps between corresponding summands of a pair of biproducts
-indexed by the same type, we obtain a map betweeen the biproducts. -/
-abbreviation biproduct.map [fintype J] [decidable_eq J] {f g : J → C} [has_finite_biproducts.{v} C]
+indexed by the same type, we obtain a map between the biproducts. -/
+abbreviation biproduct.map [fintype J] {f g : J → C} [has_finite_biproducts.{v} C]
   (p : Π b, f b ⟶ g b) : ⨁ f ⟶ ⨁ g :=
-(@lim (discrete J) _ C _ _).map (discrete.nat_trans p)
+lim_map (discrete.nat_trans p)
 
-instance biproduct.ι_mono [decidable_eq J] (f : J → C) [has_bilimit (discrete.functor f)]
+/-- An alternative to `biproduct.map` constructed via colimits.
+This construction only exists in order to show it is equal to `biproduct.map`. -/
+abbreviation biproduct.map' [fintype J] {f g : J → C} [has_finite_biproducts.{v} C]
+  (p : Π b, f b ⟶ g b) : ⨁ f ⟶ ⨁ g :=
+@colim_map _ _ _ _ (discrete.functor f) (discrete.functor g) _ _ (discrete.nat_trans p)
+
+@[ext] lemma biproduct.hom_ext {f : J → C} [has_biproduct.{v} f]
+  {Z : C} (g h : Z ⟶ ⨁ f)
+  (w : ∀ j, g ≫ biproduct.π f j = h ≫ biproduct.π f j) : g = h :=
+limit.hom_ext w
+
+@[ext] lemma biproduct.hom_ext' {f : J → C} [has_biproduct.{v} f]
+  {Z : C} (g h : ⨁ f ⟶ Z)
+  (w : ∀ j, biproduct.ι f j ≫ g =  biproduct.ι f j ≫ h) : g = h :=
+colimit.hom_ext w
+
+lemma biproduct.map_eq_map' [fintype J] {f g : J → C} [has_finite_biproducts.{v} C]
+  (p : Π b, f b ⟶ g b) : biproduct.map p = biproduct.map' p :=
+begin
+  ext j j',
+  simp only [discrete.nat_trans_app, limits.ι_colim_map, limits.lim_map_π, category.assoc],
+  rw [biproduct.ι_π_assoc, biproduct.ι_π],
+  split_ifs,
+  { subst h, rw [eq_to_hom_refl, category.id_comp], erw category.comp_id, },
+  { simp, },
+end
+
+instance biproduct.ι_mono (f : J → C) [has_biproduct f]
   (b : J) : split_mono (biproduct.ι f b) :=
 { retraction := biproduct.desc $
     λ b', if h : b' = b then eq_to_hom (congr_arg f h) else biproduct.ι f b' ≫ biproduct.π f b }
 
-instance biproduct.π_epi [decidable_eq J] (f : J → C) [has_bilimit (discrete.functor f)]
+instance biproduct.π_epi (f : J → C) [has_biproduct f]
   (b : J) : split_epi (biproduct.π f b) :=
 { section_ := biproduct.lift $
     λ b', if h : b = b' then eq_to_hom (congr_arg f h) else biproduct.ι f b ≫ biproduct.π f b' }
+
+-- Because `biproduct.map` is defined in terms of `lim` rather than `colim`,
+-- we need to provide additional `simp` lemmas.
+@[simp]
+lemma biproduct.inl_map [fintype J] {f g : J → C} [has_finite_biproducts.{v} C]
+  (p : Π j, f j ⟶ g j) (j : J) :
+  biproduct.ι f j ≫ biproduct.map p = p j ≫ biproduct.ι g j :=
+begin
+  rw biproduct.map_eq_map',
+  simp,
+end
 
 variables {C}
 
 /--
 A binary bicone for a pair of objects `P Q : C` consists of the cone point `X`,
-maps from `X` to both `P` and `Q`, and maps from both `P` and `Q` to `X`.
+maps from `X` to both `P` and `Q`, and maps from both `P` and `Q` to `X`,
+so that `inl ≫ fst = 𝟙 P`, `inl ≫ snd = 0`, `inr ≫ fst = 0`, and `inr ≫ snd = 𝟙 Q`
 -/
 @[nolint has_inhabited_instance]
 structure binary_bicone (P Q : C) :=
 (X : C)
-(π₁ : X ⟶ P)
-(π₂ : X ⟶ Q)
-(ι₁ : P ⟶ X)
-(ι₂ : Q ⟶ X)
+(fst : X ⟶ P)
+(snd : X ⟶ Q)
+(inl : P ⟶ X)
+(inr : Q ⟶ X)
+(inl_fst' : inl ≫ fst = 𝟙 P . obviously)
+(inl_snd' : inl ≫ snd = 0 . obviously)
+(inr_fst' : inr ≫ fst = 0 . obviously)
+(inr_snd' : inr ≫ snd = 𝟙 Q . obviously)
+
+restate_axiom binary_bicone.inl_fst'
+restate_axiom binary_bicone.inl_snd'
+restate_axiom binary_bicone.inr_fst'
+restate_axiom binary_bicone.inr_snd'
+attribute [simp, reassoc] binary_bicone.inl_fst binary_bicone.inl_snd
+  binary_bicone.inr_fst binary_bicone.inr_snd
 
 namespace binary_bicone
 variables {P Q : C}
 
 /-- Extract the cone from a binary bicone. -/
-@[simp]
 def to_cone (c : binary_bicone.{v} P Q) : cone (pair P Q) :=
-binary_fan.mk c.π₁ c.π₂
-/-- Extract the cocone from a binary bicone. -/
+binary_fan.mk c.fst c.snd
+
 @[simp]
+lemma to_cone_X (c : binary_bicone.{v} P Q) :
+  c.to_cone.X = c.X := rfl
+
+@[simp]
+lemma to_cone_π_app_left (c : binary_bicone.{v} P Q) :
+  c.to_cone.π.app (walking_pair.left) = c.fst := rfl
+@[simp]
+lemma to_cone_π_app_right (c : binary_bicone.{v} P Q) :
+  c.to_cone.π.app (walking_pair.right) = c.snd := rfl
+
+/-- Extract the cocone from a binary bicone. -/
 def to_cocone (c : binary_bicone.{v} P Q) : cocone (pair P Q) :=
-binary_cofan.mk c.ι₁ c.ι₂
+binary_cofan.mk c.inl c.inr
+
+@[simp]
+lemma to_cocone_X (c : binary_bicone.{v} P Q) :
+  c.to_cocone.X = c.X := rfl
+
+@[simp]
+lemma to_cocone_ι_app_left (c : binary_bicone.{v} P Q) :
+  c.to_cocone.ι.app (walking_pair.left) = c.inl := rfl
+@[simp]
+lemma to_cocone_ι_app_right (c : binary_bicone.{v} P Q) :
+  c.to_cocone.ι.app (walking_pair.right) = c.inr := rfl
 
 end binary_bicone
+
+namespace bicone
+
+/-- Convert a `bicone` over a function on `walking_pair` to a binary_bicone. -/
+@[simps]
+def to_binary_bicone {X Y : C} (b : bicone (pair X Y).obj) : binary_bicone X Y :=
+{ X := b.X,
+  fst := b.π walking_pair.left,
+  snd := b.π walking_pair.right,
+  inl := b.ι walking_pair.left,
+  inr := b.ι walking_pair.right,
+  inl_fst' := by { simp [bicone.ι_π], refl, },
+  inr_fst' := by simp [bicone.ι_π],
+  inl_snd' := by simp [bicone.ι_π],
+  inr_snd' := by { simp [bicone.ι_π], refl, }, }
+
+/--
+If the cone obtained from a bicone over `pair X Y` is a limit cone,
+so is the cone obtained by converting that bicone to a binary_bicone, then to a cone.
+-/
+def to_binary_bicone_is_limit {X Y : C} {b : bicone (pair X Y).obj}
+  (c : is_limit (b.to_cone)) :
+  is_limit (b.to_binary_bicone.to_cone) :=
+{ lift := λ s, c.lift s,
+   fac' := λ s j, by { cases j; erw c.fac, },
+   uniq' := λ s m w,
+   begin
+     apply c.uniq s,
+     rintro (⟨⟩|⟨⟩),
+     exact w walking_pair.left,
+     exact w walking_pair.right,
+   end, }
+
+/--
+If the cocone obtained from a bicone over `pair X Y` is a colimit cocone,
+so is the cocone obtained by converting that bicone to a binary_bicone, then to a cocone.
+-/
+def to_binary_bicone_is_colimit {X Y : C} {b : bicone (pair X Y).obj}
+  (c : is_colimit (b.to_cocone)) :
+  is_colimit (b.to_binary_bicone.to_cocone) :=
+{ desc := λ s, c.desc s,
+   fac' := λ s j, by { cases j; erw c.fac, },
+   uniq' := λ s m w,
+   begin
+     apply c.uniq s,
+     rintro (⟨⟩|⟨⟩),
+     exact w walking_pair.left,
+     exact w walking_pair.right,
+   end, }
+
+end bicone
 
 /--
 `has_binary_biproduct P Q` represents a particular chosen bicone which is
@@ -231,6 +381,19 @@ class has_binary_biproducts :=
 (has_binary_biproduct : Π (P Q : C), has_binary_biproduct.{v} P Q)
 
 attribute [instance, priority 100] has_binary_biproducts.has_binary_biproduct
+
+/--
+A category with finite biproducts has binary biproducts.
+
+This is not an instance as typically in concrete categories there will be
+an alternative construction with nicer definitional properties.
+-/
+def has_binary_biproducts_of_finite_biproducts [has_finite_biproducts.{v} C] :
+  has_binary_biproducts.{v} C :=
+{ has_binary_biproduct := λ P Q,
+  { bicone := (biproduct.bicone (pair P Q).obj).to_binary_bicone,
+    is_limit := bicone.to_binary_bicone_is_limit (biproduct.is_limit _),
+    is_colimit := bicone.to_binary_bicone_is_colimit (biproduct.is_colimit _) } }
 
 end
 
@@ -291,6 +454,23 @@ colimit.ι (pair X Y) walking_pair.left
 abbreviation biprod.inr {X Y : C} [has_binary_biproduct.{v} X Y] : Y ⟶ X ⊞ Y :=
 colimit.ι (pair X Y) walking_pair.right
 
+@[simp,reassoc]
+lemma biprod.inl_fst {X Y : C} [has_binary_biproduct.{v} X Y] :
+  (biprod.inl : X ⟶ X ⊞ Y) ≫ (biprod.fst : X ⊞ Y ⟶ X) = 𝟙 X :=
+has_binary_biproduct.bicone.inl_fst
+@[simp,reassoc]
+lemma biprod.inl_snd {X Y : C} [has_binary_biproduct.{v} X Y] :
+  (biprod.inl : X ⟶ X ⊞ Y) ≫ (biprod.snd : X ⊞ Y ⟶ Y) = 0 :=
+has_binary_biproduct.bicone.inl_snd
+@[simp,reassoc]
+lemma biprod.inr_fst {X Y : C} [has_binary_biproduct.{v} X Y] :
+  (biprod.inr : Y ⟶ X ⊞ Y) ≫ (biprod.fst : X ⊞ Y ⟶ X) = 0 :=
+has_binary_biproduct.bicone.inr_fst
+@[simp,reassoc]
+lemma biprod.inr_snd {X Y : C} [has_binary_biproduct.{v} X Y] :
+  (biprod.inr : Y ⟶ X ⊞ Y) ≫ (biprod.snd : X ⊞ Y ⟶ Y) = 𝟙 Y :=
+has_binary_biproduct.bicone.inr_snd
+
 /-- Given a pair of maps into the summands of a binary biproduct,
 we obtain a map into the binary biproduct. -/
 abbreviation biprod.lift {W X Y : C} [has_binary_biproduct.{v} X Y] (f : W ⟶ X) (g : W ⟶ Y) :
@@ -304,9 +484,47 @@ colimit.desc _ (binary_cofan.mk f g)
 
 /-- Given a pair of maps between the summands of a pair of binary biproducts,
 we obtain a map between the binary biproducts. -/
-abbreviation biprod.map {W X Y Z : C} [has_binary_biproducts.{v} C]
+abbreviation biprod.map {W X Y Z : C} [has_binary_biproduct.{v} W X] [has_binary_biproduct.{v} Y Z]
   (f : W ⟶ Y) (g : X ⟶ Z) : W ⊞ X ⟶ Y ⊞ Z :=
-(@lim (discrete walking_pair) _ C _ _).map (@map_pair _ _ (pair W X) (pair Y Z) f g)
+lim_map (@map_pair _ _ (pair W X) (pair Y Z) f g)
+
+/-- Given a pair of isomorphisms between the summands of a pair of binary biproducts,
+we obtain an isomorphism between the binary biproducts. -/
+@[simps]
+def biprod.map_iso {W X Y Z : C} [has_binary_biproduct.{v} W X] [has_binary_biproduct.{v} Y Z]
+  (f : W ≅ Y) (g : X ≅ Z) : W ⊞ X ≅ Y ⊞ Z :=
+{ hom := biprod.map f.hom g.hom,
+  inv := biprod.map f.inv g.inv, }
+
+/-- An alternative to `biprod.map` constructed via colimits.
+This construction only exists in order to show it is equal to `biprod.map`. -/
+abbreviation biprod.map' {W X Y Z : C} [has_binary_biproduct.{v} W X] [has_binary_biproduct.{v} Y Z]
+  (f : W ⟶ Y) (g : X ⟶ Z) : W ⊞ X ⟶ Y ⊞ Z :=
+colim_map (@map_pair _ _ (pair W X) (pair Y Z) f g)
+
+@[ext] lemma biprod.hom_ext {X Y Z : C} [has_binary_biproduct.{v} X Y] (f g : Z ⟶ X ⊞ Y)
+  (h₀ : f ≫ biprod.fst = g ≫ biprod.fst) (h₁ : f ≫ biprod.snd = g ≫ biprod.snd) : f = g :=
+binary_fan.is_limit.hom_ext has_binary_biproduct.is_limit h₀ h₁
+
+@[ext] lemma biprod.hom_ext' {X Y Z : C} [has_binary_biproduct.{v} X Y] (f g : X ⊞ Y ⟶ Z)
+  (h₀ : biprod.inl ≫ f = biprod.inl ≫ g) (h₁ : biprod.inr ≫ f = biprod.inr ≫ g) : f = g :=
+binary_cofan.is_colimit.hom_ext has_binary_biproduct.is_colimit h₀ h₁
+
+lemma biprod.map_eq_map' {W X Y Z : C} [has_binary_biproduct.{v} W X] [has_binary_biproduct.{v} Y Z]
+  (f : W ⟶ Y) (g : X ⟶ Z) : biprod.map f g = biprod.map' f g :=
+begin
+  ext,
+  { simp only [map_pair_left, ι_colim_map, lim_map_π, biprod.inl_fst_assoc, category.assoc],
+    erw [biprod.inl_fst, category.comp_id], },
+  { simp only [map_pair_left, ι_colim_map, lim_map_π, has_zero_morphisms.zero_comp,
+      biprod.inl_snd_assoc, category.assoc],
+    erw [biprod.inl_snd], simp, },
+  { simp only [map_pair_right, biprod.inr_fst_assoc, ι_colim_map, lim_map_π,
+      has_zero_morphisms.zero_comp, category.assoc],
+    erw [biprod.inr_fst], simp, },
+  { simp only [map_pair_right, ι_colim_map, lim_map_π, biprod.inr_snd_assoc, category.assoc],
+    erw [biprod.inr_snd, category.comp_id], },
+end
 
 instance biprod.inl_mono {X Y : C} [has_binary_biproduct.{v} X Y] :
   split_mono (biprod.inl : X ⟶ X ⊞ Y) :=
@@ -324,148 +542,296 @@ instance biprod.snd_epi {X Y : C} [has_binary_biproduct.{v} X Y] :
   split_epi (biprod.snd : X ⊞ Y ⟶ Y) :=
 { section_ := biprod.lift (biprod.inr ≫ biprod.fst) (𝟙 Y) }
 
-@[ext] lemma biprod.hom_ext {X Y Z : C} [has_binary_biproduct.{v} X Y] (f g : Z ⟶ X ⊞ Y)
-  (h₀ : f ≫ biprod.fst = g ≫ biprod.fst) (h₁ : f ≫ biprod.snd = g ≫ biprod.snd) : f = g :=
-binary_fan.is_limit.hom_ext has_binary_biproduct.is_limit h₀ h₁
+@[simp,reassoc]
+lemma biprod.map_fst {W X Y Z : C} [has_binary_biproduct.{v} W X] [has_binary_biproduct.{v} Y Z]
+  (f : W ⟶ Y) (g : X ⟶ Z) :
+  biprod.map f g ≫ biprod.fst = biprod.fst ≫ f :=
+by simp
 
-@[ext] lemma biprod.hom_ext' {X Y Z : C} [has_binary_biproduct.{v} X Y] (f g : X ⊞ Y ⟶ Z)
-  (h₀ : biprod.inl ≫ f = biprod.inl ≫ g) (h₁ : biprod.inr ≫ f = biprod.inr ≫ g) : f = g :=
-binary_cofan.is_colimit.hom_ext has_binary_biproduct.is_colimit h₀ h₁
+@[simp,reassoc]
+lemma biprod.map_snd {W X Y Z : C} [has_binary_biproduct.{v} W X] [has_binary_biproduct.{v} Y Z]
+  (f : W ⟶ Y) (g : X ⟶ Z) :
+  biprod.map f g ≫ biprod.snd = biprod.snd ≫ g :=
+by simp
+
+-- Because `biprod.map` is defined in terms of `lim` rather than `colim`,
+-- we need to provide additional `simp` lemmas.
+@[simp,reassoc]
+lemma biprod.inl_map {W X Y Z : C} [has_binary_biproduct.{v} W X] [has_binary_biproduct.{v} Y Z]
+  (f : W ⟶ Y) (g : X ⟶ Z) :
+  biprod.inl ≫ biprod.map f g = f ≫ biprod.inl :=
+begin
+  rw biprod.map_eq_map',
+  simp,
+end
+
+@[simp,reassoc]
+lemma biprod.inr_map {W X Y Z : C} [has_binary_biproduct.{v} W X] [has_binary_biproduct.{v} Y Z]
+  (f : W ⟶ Y) (g : X ⟶ Z) :
+  biprod.inr ≫ biprod.map f g = g ≫ biprod.inr :=
+begin
+  rw biprod.map_eq_map',
+  simp,
+end
+
+section
+variables [has_binary_biproducts.{v} C]
+
+/-- The braiding isomorphism which swaps a binary biproduct. -/
+@[simps] def biprod.braiding (P Q : C) : P ⊞ Q ≅ Q ⊞ P :=
+{ hom := biprod.lift biprod.snd biprod.fst,
+  inv := biprod.lift biprod.snd biprod.fst }
+
+/--
+An alternative formula for the braiding isomorphism which swaps a binary biproduct,
+using the fact that the biproduct is a coproduct.
+-/
+@[simps] def biprod.braiding' (P Q : C) : P ⊞ Q ≅ Q ⊞ P :=
+{ hom := biprod.desc biprod.inr biprod.inl,
+  inv := biprod.desc biprod.inr biprod.inl }
+
+@[simp] lemma biprod.braiding'_eq_braiding {P Q : C} :
+  biprod.braiding' P Q = biprod.braiding P Q :=
+by tidy
+
+/-- The braiding isomorphism can be passed through a map by swapping the order. -/
+@[reassoc] lemma biprod.braid_natural {W X Y Z : C} (f : X ⟶ Y) (g : Z ⟶ W) :
+  biprod.map f g ≫ (biprod.braiding _ _).hom = (biprod.braiding _ _).hom ≫ biprod.map g f :=
+by tidy
+
+@[simp, reassoc] lemma biprod.braiding_map_braiding {W X Y Z : C} (f : W ⟶ Y) (g : X ⟶ Z) :
+  (biprod.braiding X W).hom ≫ biprod.map f g ≫ (biprod.braiding Y Z).hom = biprod.map g f :=
+by tidy
+
+@[simp, reassoc] lemma biprod.symmetry' (P Q : C) :
+  biprod.lift biprod.snd biprod.fst ≫ biprod.lift biprod.snd biprod.fst = 𝟙 (P ⊞ Q) :=
+by tidy
+
+/-- The braiding isomorphism is symmetric. -/
+@[reassoc] lemma biprod.symmetry (P Q : C) :
+  (biprod.braiding P Q).hom ≫ (biprod.braiding Q P).hom = 𝟙 _ :=
+by simp
+
+end
 
 -- TODO:
 -- If someone is interested, they could provide the constructions:
 --   has_binary_biproducts ↔ has_finite_biproducts
 
+end category_theory.limits
+
+namespace category_theory.limits
+
 section preadditive
-variables [preadditive.{v} C]
+variables {C : Type u} [category.{v} C] [preadditive.{v} C]
+variables {J : Type v} [fintype J] [decidable_eq J]
 
 open category_theory.preadditive
+open_locale big_operators
 
-/-- A preadditive binary biproduct is a bicone on two objects `X` and `Y` satisfying a set of five
-    axioms expressing the properties of a biproduct in additive terms. The notion of preadditive
-    binary biproduct is strictly stronger than the notion of binary biproduct (but it in any
-    preadditive category, the existence of a binary biproduct implies the existence of a
-    preadditive binary biproduct: a biproduct is, in particular, a product, and every product gives
-    rise to a preadditive binary biproduct, see `has_preadditive_binary_biproduct.of_has_limit_pair`). -/
-class has_preadditive_binary_biproduct (X Y : C) :=
-(bicone : binary_bicone.{v} X Y)
-(ι₁_π₁' : bicone.ι₁ ≫ bicone.π₁ = 𝟙 X . obviously)
-(ι₂_π₂' : bicone.ι₂ ≫ bicone.π₂ = 𝟙 Y . obviously)
-(ι₂_π₁' : bicone.ι₂ ≫ bicone.π₁ = 0 . obviously)
-(ι₁_π₂' : bicone.ι₁ ≫ bicone.π₂ = 0 . obviously)
-(total' : bicone.π₁ ≫ bicone.ι₁ + bicone.π₂ ≫ bicone.ι₂ = 𝟙 bicone.X . obviously)
+/--
+In a preadditive category, we can construct a biproduct for `f : J → C` from
+any bicone `b` for `f` satisfying `total : ∑ j : J, b.π j ≫ b.ι j = 𝟙 b.X`.
 
-restate_axiom has_preadditive_binary_biproduct.ι₁_π₁'
-restate_axiom has_preadditive_binary_biproduct.ι₂_π₂'
-restate_axiom has_preadditive_binary_biproduct.ι₂_π₁'
-restate_axiom has_preadditive_binary_biproduct.ι₁_π₂'
-restate_axiom has_preadditive_binary_biproduct.total'
-attribute [simp, reassoc] has_preadditive_binary_biproduct.ι₁_π₁
-  has_preadditive_binary_biproduct.ι₂_π₂ has_preadditive_binary_biproduct.ι₂_π₁
-  has_preadditive_binary_biproduct.ι₁_π₂
-attribute [simp] has_preadditive_binary_biproduct.total
-
-section
-local attribute [tidy] tactic.case_bash
-
-/-- A preadditive binary biproduct is a binary biproduct. -/
-@[priority 100]
-instance (X Y : C) [has_preadditive_binary_biproduct.{v} X Y] : has_binary_biproduct.{v} X Y :=
-{ bicone := has_preadditive_binary_biproduct.bicone,
+(That is, such a bicone is a limit cone and a colimit cocone.)
+-/
+def has_biproduct_of_total {f : J → C} (b : bicone f) (total : ∑ j : J, b.π j ≫ b.ι j = 𝟙 b.X) :
+  has_biproduct.{v} f :=
+{ bicone := b,
   is_limit :=
-  { lift := λ s, binary_fan.fst s ≫ has_preadditive_binary_biproduct.bicone.ι₁ +
-      binary_fan.snd s ≫ has_preadditive_binary_biproduct.bicone.ι₂,
-    uniq' := λ s m h, by erw [←category.comp_id m, ←has_preadditive_binary_biproduct.total,
-      comp_add, reassoc_of (h walking_pair.left), reassoc_of (h walking_pair.right)] },
+  { lift := λ s, ∑ j, s.π.app j ≫ b.ι j,
+    uniq' := λ s m h,
+    begin
+      erw [←category.comp_id m, ←total, comp_sum],
+      apply finset.sum_congr rfl,
+      intros j m,
+      erw [reassoc_of (h j)],
+    end,
+    fac' := λ s j,
+    begin
+      simp only [sum_comp, category.assoc, bicone.to_cone_π_app, b.ι_π, comp_dite],
+      dsimp, simp,
+    end },
   is_colimit :=
-  { desc := λ s, has_preadditive_binary_biproduct.bicone.π₁ ≫ binary_cofan.inl s +
-      has_preadditive_binary_biproduct.bicone.π₂ ≫ binary_cofan.inr s,
-    uniq' := λ s m h, by erw [←category.id_comp m, ←has_preadditive_binary_biproduct.total,
-      add_comp, category.assoc, category.assoc, h walking_pair.left, h walking_pair.right] } }
+  { desc := λ s, ∑ j, b.π j ≫ s.ι.app j,
+    uniq' := λ s m h,
+    begin
+      erw [←category.id_comp m, ←total, sum_comp],
+            apply finset.sum_congr rfl,
+      intros j m,
+      erw [category.assoc, h],
+    end,
+    fac' := λ s j,
+    begin
+      simp only [comp_sum, ←category.assoc, bicone.to_cocone_ι_app, b.ι_π, dite_comp],
+      dsimp, simp,
+    end } }
 
+/-- In a preadditive category, if the product over `f : J → C` exists,
+    then the biproduct over `f` exists. -/
+def has_biproduct.of_has_product (f : J → C) [has_product.{v} f] :
+  has_biproduct.{v} f :=
+has_biproduct_of_total
+{ X := pi_obj f,
+  π := limits.pi.π f,
+  ι := λ j, pi.lift (λ j', if h : j = j' then eq_to_hom (congr_arg f h) else 0),
+  ι_π := λ j j', by simp, }
+(by { ext, simp [sum_comp, comp_dite] })
+
+/-- In a preadditive category, if the coproduct over `f : J → C` exists,
+    then the biproduct over `f` exists. -/
+def has_biproduct.of_has_coproduct (f : J → C) [has_coproduct.{v} f] :
+  has_biproduct.{v} f :=
+has_biproduct_of_total
+{ X := sigma_obj f,
+  π := λ j, sigma.desc (λ j', if h : j' = j then eq_to_hom (congr_arg f h) else 0),
+  ι := limits.sigma.ι f,
+  ι_π := λ j j', by simp, }
+begin
+  ext,
+  simp only [comp_sum, limits.cofan.mk_π_app, limits.colimit.ι_desc_assoc, eq_self_iff_true,
+    limits.colimit.ι_desc, category.comp_id],
+  dsimp,
+  simp only [dite_comp, finset.sum_dite_eq, finset.mem_univ, if_true, category.id_comp,
+    eq_to_hom_refl, limits.has_zero_morphisms.zero_comp],
 end
 
 section
-variables (X Y : C) [has_preadditive_binary_biproduct.{v} X Y]
+variables {f : J → C} [has_biproduct.{v} f]
 
-@[simp, reassoc] lemma biprod.inl_fst : (biprod.inl : X ⟶ X ⊞ Y) ≫ biprod.fst = 𝟙 X :=
-has_preadditive_binary_biproduct.ι₁_π₁
-@[simp, reassoc] lemma biprod.inr_snd : (biprod.inr : Y ⟶ X ⊞ Y) ≫ biprod.snd = 𝟙 Y :=
-has_preadditive_binary_biproduct.ι₂_π₂
-@[simp, reassoc] lemma biprod.inr_fst : (biprod.inr : Y ⟶ X ⊞ Y) ≫ biprod.fst = 0 :=
-has_preadditive_binary_biproduct.ι₂_π₁
-@[simp, reassoc] lemma biprod.inl_snd : (biprod.inl : X ⟶ X ⊞ Y) ≫ biprod.snd = 0 :=
-has_preadditive_binary_biproduct.ι₁_π₂
+/--
+In any preadditive category, any biproduct satsifies
+`∑ j : J, biproduct.π f j ≫ biproduct.ι f j = 𝟙 (⨁ f)`
+-/
+@[simp] lemma biproduct.total : ∑ j : J, biproduct.π f j ≫ biproduct.ι f j = 𝟙 (⨁ f) :=
+begin
+  ext j j',
+  simp [comp_sum, sum_comp, biproduct.ι_π, comp_dite, dite_comp],
+end
+
+lemma biproduct.lift_eq {T : C} {g : Π j, T ⟶ f j} :
+  biproduct.lift g = ∑ j, g j ≫ biproduct.ι f j :=
+begin
+  ext j,
+  simp [sum_comp, biproduct.ι_π, comp_dite],
+end
+
+lemma biproduct.desc_eq {T : C} {g : Π j, f j ⟶ T} :
+  biproduct.desc g = ∑ j, biproduct.π f j ≫ g j :=
+begin
+  ext j,
+  simp [comp_sum, biproduct.ι_π_assoc, dite_comp],
+end
+
+@[simp, reassoc] lemma biproduct.lift_desc {T U : C} {g : Π j, T ⟶ f j} {h : Π j, f j ⟶ U} :
+  biproduct.lift g ≫ biproduct.desc h = ∑ j : J, g j ≫ h j :=
+by simp [biproduct.lift_eq, biproduct.desc_eq, comp_sum, sum_comp, biproduct.ι_π_assoc,
+  comp_dite, dite_comp]
+
+lemma biproduct.map_eq [has_finite_biproducts.{v} C] {f g : J → C} {h : Π j, f j ⟶ g j} :
+  biproduct.map h = ∑ j : J, biproduct.π f j ≫ h j ≫ biproduct.ι g j :=
+begin
+  ext,
+  simp [biproduct.ι_π, biproduct.ι_π_assoc, comp_sum, sum_comp, comp_dite, dite_comp],
+end
+
+end
+
+/--
+In a preadditive category, we can construct a binary biproduct for `X Y : C` from
+any binary bicone `b` satisfying `total : b.fst ≫ b.inl + b.snd ≫ b.inr = 𝟙 b.X`.
+
+(That is, such a bicone is a limit cone and a colimit cocone.)
+-/
+def has_binary_biproduct_of_total {X Y : C} (b : binary_bicone X Y)
+  (total : b.fst ≫ b.inl + b.snd ≫ b.inr = 𝟙 b.X) :
+  has_binary_biproduct.{v} X Y :=
+{ bicone := b,
+  is_limit :=
+  { lift := λ s, binary_fan.fst s ≫ b.inl +
+      binary_fan.snd s ≫ b.inr,
+    uniq' := λ s m h, by erw [←category.comp_id m, ←total,
+      comp_add, reassoc_of (h walking_pair.left), reassoc_of (h walking_pair.right)],
+    fac' := λ s j, by cases j; simp, },
+  is_colimit :=
+  { desc := λ s, b.fst ≫ binary_cofan.inl s +
+      b.snd ≫ binary_cofan.inr s,
+    uniq' := λ s m h, by erw [←category.id_comp m, ←total,
+      add_comp, category.assoc, category.assoc, h walking_pair.left, h walking_pair.right],
+    fac' := λ s j, by cases j; simp, } }
+
+/-- In a preadditive category, if the product of `X` and `Y` exists, then the
+    binary biproduct of `X` and `Y` exists. -/
+def has_binary_biproduct.of_has_binary_product (X Y : C) [has_binary_product.{v} X Y] :
+  has_binary_biproduct.{v} X Y :=
+has_binary_biproduct_of_total
+{ X := X ⨯ Y,
+  fst := category_theory.limits.prod.fst,
+  snd := category_theory.limits.prod.snd,
+  inl := prod.lift (𝟙 X) 0,
+  inr := prod.lift 0 (𝟙 Y) }
+begin
+  ext; simp [add_comp],
+end
+
+/-- In a preadditive category, if all binary products exist,
+    then the all binary biproducts exist. -/
+def has_binary_biproducts.of_has_binary_products [has_binary_products.{v} C] :
+  has_binary_biproducts.{v} C :=
+{ has_binary_biproduct := λ X Y, has_binary_biproduct.of_has_binary_product X Y, }
+
+/-- In a preadditive category, if the product of `X` and `Y` exists, then the
+    binary biproduct of `X` and `Y` exists. -/
+def has_binary_biproduct.of_has_binary_coproduct (X Y : C) [has_binary_coproduct.{v} X Y] :
+  has_binary_biproduct.{v} X Y :=
+has_binary_biproduct_of_total
+{ X := X ⨿ Y,
+  fst := coprod.desc (𝟙 X) 0,
+  snd := coprod.desc 0 (𝟙 Y),
+  inl := category_theory.limits.coprod.inl,
+  inr := category_theory.limits.coprod.inr }
+begin
+  ext; simp [add_comp],
+end
+
+/-- In a preadditive category, if all binary coproducts exist,
+    then the all binary biproducts exist. -/
+def has_binary_biproducts.of_has_binary_coproducts [has_binary_coproducts.{v} C] :
+  has_binary_biproducts.{v} C :=
+{ has_binary_biproduct := λ X Y, has_binary_biproduct.of_has_binary_coproduct X Y, }
+
+section
+variables {X Y : C} [has_binary_biproduct.{v} X Y]
+
+/--
+In any preadditive category, any binary biproduct satsifies
+`biprod.fst ≫ biprod.inl + biprod.snd ≫ biprod.inr = 𝟙 (X ⊞ Y)`.
+-/
 @[simp] lemma biprod.total : biprod.fst ≫ biprod.inl + biprod.snd ≫ biprod.inr = 𝟙 (X ⊞ Y) :=
-has_preadditive_binary_biproduct.total
+begin
+  ext; simp [add_comp],
+end
 
-lemma biprod.inl_add_inr {T : C} {f : T ⟶ X} {g : T ⟶ Y} :
-  f ≫ biprod.inl + g ≫ biprod.inr = biprod.lift f g := rfl
+lemma biprod.lift_eq {T : C} {f : T ⟶ X} {g : T ⟶ Y} :
+  biprod.lift f g = f ≫ biprod.inl + g ≫ biprod.inr :=
+begin
+  ext; simp [add_comp],
+end
 
-lemma biprod.fst_add_snd {T : C} {f : X ⟶ T} {g : Y ⟶ T} :
-  biprod.fst ≫ f + biprod.snd ≫ g = biprod.desc f g := rfl
+lemma biprod.desc_eq {T : C} {f : X ⟶ T} {g : Y ⟶ T} :
+  biprod.desc f g = biprod.fst ≫ f + biprod.snd ≫ g :=
+begin
+  ext; simp [add_comp],
+end
 
 @[simp, reassoc] lemma biprod.lift_desc {T U : C} {f : T ⟶ X} {g : T ⟶ Y} {h : X ⟶ U} {i : Y ⟶ U} :
   biprod.lift f g ≫ biprod.desc h i = f ≫ h + g ≫ i :=
-by simp [←biprod.inl_add_inr, ←biprod.fst_add_snd]
+by simp [biprod.lift_eq, biprod.desc_eq]
 
-end
 
-section has_limit_pair
-
-/-- In a preadditive category, if the product of `X` and `Y` exists, then the preadditive binary
-    biproduct of `X` and `Y` exists. -/
-def has_preadditive_binary_biproduct.of_has_limit_pair (X Y : C) [has_limit.{v} (pair X Y)] :
-  has_preadditive_binary_biproduct.{v} X Y :=
-{ bicone :=
-  { X := X ⨯ Y,
-    π₁ := category_theory.limits.prod.fst,
-    π₂ := category_theory.limits.prod.snd,
-    ι₁ := prod.lift (𝟙 X) 0,
-    ι₂ := prod.lift 0 (𝟙 Y) } }
-
-/-- In a preadditive category, if the coproduct of `X` and `Y` exists, then the preadditive binary
-    biproduct of `X` and `Y` exists. -/
-def has_preadditive_binary_biproduct.of_has_colimit_pair (X Y : C) [has_colimit.{v} (pair X Y)] :
-  has_preadditive_binary_biproduct.{v} X Y :=
-{ bicone :=
-  { X := X ⨿ Y,
-    π₁ := coprod.desc (𝟙 X) 0,
-    π₂ := coprod.desc 0 (𝟙 Y),
-    ι₁ := category_theory.limits.coprod.inl,
-    ι₂ := category_theory.limits.coprod.inr } }
-
-end has_limit_pair
-
-section
-variable (C)
-
-/-- A preadditive category `has_preadditive_binary_biproducts` if the preadditive binary biproduct
-    exists for every pair of objects. -/
-class has_preadditive_binary_biproducts :=
-(has_preadditive_binary_biproduct : Π (X Y : C), has_preadditive_binary_biproduct.{v} X Y)
-
-attribute [instance, priority 100] has_preadditive_binary_biproducts.has_preadditive_binary_biproduct
-
-@[priority 100]
-instance [has_preadditive_binary_biproducts.{v} C] : has_binary_biproducts.{v} C :=
-⟨λ X Y, by apply_instance⟩
-
-/-- If a preadditive category has all binary products, then it has all preadditive binary
-    biproducts. -/
--- This particularly dangerous as an instance,
--- as we can deduce `has_binary_products` from `has_preadditive_binary_biproducts`.
-def has_preadditive_binary_biproducts_of_has_binary_products [has_binary_products.{v} C] :
-  has_preadditive_binary_biproducts.{v} C :=
-⟨λ X Y, has_preadditive_binary_biproduct.of_has_limit_pair X Y⟩
-
-/-- If a preadditive category has all binary coproducts, then it has all preadditive binary
-    biproducts. -/
--- This particularly dangerous as an instance,
--- as we can deduce `has_binary_products` from `has_preadditive_binary_biproducts`.
-def has_preadditive_binary_biproducts_of_has_binary_coproducts [has_binary_coproducts.{v} C] :
-  has_preadditive_binary_biproducts.{v} C :=
-⟨λ X Y, has_preadditive_binary_biproduct.of_has_colimit_pair X Y⟩
+lemma biprod.map_eq [has_binary_biproducts.{v} C] {W X Y Z : C} {f : W ⟶ Y} {g : X ⟶ Z} :
+  biprod.map f g = biprod.fst ≫ f ≫ biprod.inl + biprod.snd ≫ g ≫ biprod.inr :=
+by apply biprod.hom_ext; apply biprod.hom_ext'; simp
 
 end
 

--- a/src/category_theory/limits/shapes/products.lean
+++ b/src/category_theory/limits/shapes/products.lean
@@ -32,32 +32,47 @@ def cofan.mk {f : β → C} {P : C} (p : Π b, f b ⟶ P) : cofan f :=
 @[simp] lemma fan.mk_π_app {f : β → C} {P : C} (p : Π b, P ⟶ f b) (b : β) : (fan.mk p).π.app b = p b := rfl
 @[simp] lemma cofan.mk_π_app {f : β → C} {P : C} (p : Π b, f b ⟶ P) (b : β) : (cofan.mk p).ι.app b = p b := rfl
 
+/-- An abbreviation for `has_limit (discrete.functor f)`. -/
+abbreviation has_product (f : β → C) := has_limit (discrete.functor f)
+
+/-- An abbreviation for `has_colimit (discrete.functor f)`. -/
+abbreviation has_coproduct (f : β → C) := has_colimit (discrete.functor f)
+
+section
+variables (C)
+
+/-- An abbreviation for `has_limits_of_shape (discrete f)`. -/
+abbreviation has_products_of_shape (β : Type v) := has_limits_of_shape.{v} (discrete β)
+/-- An abbreviation for `has_colimits_of_shape (discrete f)`. -/
+abbreviation has_coproducts_of_shape (β : Type v) := has_colimits_of_shape.{v} (discrete β)
+end
+
 /-- `pi_obj f` computes the product of a family of elements `f`. (It is defined as an abbreviation
    for `limit (discrete.functor f)`, so for most facts about `pi_obj f`, you will just use general facts
    about limits.) -/
-abbreviation pi_obj (f : β → C) [has_limit (discrete.functor f)] := limit (discrete.functor f)
+abbreviation pi_obj (f : β → C) [has_product f] := limit (discrete.functor f)
 /-- `sigma_obj f` computes the coproduct of a family of elements `f`. (It is defined as an abbreviation
    for `colimit (discrete.functor f)`, so for most facts about `sigma_obj f`, you will just use general facts
    about colimits.) -/
-abbreviation sigma_obj (f : β → C) [has_colimit (discrete.functor f)] := colimit (discrete.functor f)
+abbreviation sigma_obj (f : β → C) [has_coproduct f] := colimit (discrete.functor f)
 
 notation `∏ ` f:20 := pi_obj f
 notation `∐ ` f:20 := sigma_obj f
 
-abbreviation pi.π (f : β → C) [has_limit (discrete.functor f)] (b : β) : ∏ f ⟶ f b :=
+abbreviation pi.π (f : β → C) [has_product f] (b : β) : ∏ f ⟶ f b :=
 limit.π (discrete.functor f) b
-abbreviation sigma.ι (f : β → C) [has_colimit (discrete.functor f)] (b : β) : f b ⟶ ∐ f :=
+abbreviation sigma.ι (f : β → C) [has_coproduct f] (b : β) : f b ⟶ ∐ f :=
 colimit.ι (discrete.functor f) b
 
-abbreviation pi.lift {f : β → C} [has_limit (discrete.functor f)] {P : C} (p : Π b, P ⟶ f b) : P ⟶ ∏ f :=
+abbreviation pi.lift {f : β → C} [has_product f] {P : C} (p : Π b, P ⟶ f b) : P ⟶ ∏ f :=
 limit.lift _ (fan.mk p)
-abbreviation sigma.desc {f : β → C} [has_colimit (discrete.functor f)] {P : C} (p : Π b, f b ⟶ P) : ∐ f ⟶ P :=
+abbreviation sigma.desc {f : β → C} [has_coproduct f] {P : C} (p : Π b, f b ⟶ P) : ∐ f ⟶ P :=
 colimit.desc _ (cofan.mk p)
 
-abbreviation pi.map {f g : β → C} [has_limits_of_shape.{v} (discrete β) C]
+abbreviation pi.map {f g : β → C} [has_products_of_shape β C]
   (p : Π b, f b ⟶ g b) : ∏ f ⟶ ∏ g :=
 lim.map (discrete.nat_trans p)
-abbreviation sigma.map {f g : β → C} [has_colimits_of_shape.{v} (discrete β) C]
+abbreviation sigma.map {f g : β → C} [has_coproducts_of_shape β C]
   (p : Π b, f b ⟶ g b) : ∐ f ⟶ ∐ g :=
 colim.map (discrete.nat_trans p)
 


### PR DESCRIPTION
This is a second attempt at #3102.

Previously the definition of a (binary) biproduct in a category with zero morphisms (but not necessarily) preadditive was just wrong.

The definition for a "bicone" was just something that was simultaneously a cone and a cocone, with the same cone points. It was a "biproduct bicone" if the cone was a limit cone and the cocone was a colimit cocone. However, this definition was not particularly useful. In particular, there was no way to prove that the two different `map` constructions providing a morphism `W ⊞ X ⟶ Y ⊞ Z` (i.e. by treating the biproducts either as cones, or as cocones) were actually equal. Blech.

So, I've added the axioms `inl ≫ fst = 𝟙 P`, `inl ≫ snd = 0`, `inr ≫ fst = 0`, and `inr ≫ snd = 𝟙 Q` to `bicone P Q`. (Note these only require the exist of zero morphisms, not preadditivity.)

Now the two map constructions are equal.

I've then entirely removed the `has_preadditive_biproduct` typeclass. Instead we have
1. additional theorems providing `total`, when `preadditive C` is available
2. alternative constructors for `has_biproduct` that use `total` rather than `is_limit` and `is_colimit`.

This PR also introduces some abbreviations along the lines of `abbreviation has_binary_product (X Y : C) := has_limit (pair X Y)`, just to improve readability.

---
<!-- put comments you want to keep out of the PR commit here -->
