### PR TITLE
[Merged by Bors] - feat(set): preliminaries for Haar measure

### DIFF
--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -2153,9 +2153,14 @@ le_inf $ assume b hb, inf_le (h hb)
 lemma lt_inf_iff [h : is_total α (≤)] {a : α} (ha : a < ⊤) : a < s.inf f ↔ (∀b ∈ s, a < f b) :=
 @sup_lt_iff (order_dual α) _ _ _ _ (@is_total.swap α _ h) _ ha
 
-lemma comp_inf_eq_inf_comp [h : is_total α (≤)] {γ : Type} [semilattice_inf_top γ]
+lemma comp_inf_eq_inf_comp [semilattice_inf_top γ] {s : finset β}
+  {f : β → α} (g : α → γ) (g_inf : ∀ x y, g (x ⊓ y) = g x ⊓ g y) (top : g ⊤ = ⊤) :
+  g (s.inf f) = s.inf (g ∘ f) :=
+@comp_sup_eq_sup_comp (order_dual α) _ (order_dual γ) _ _ _ _ _ g_inf top
+
+lemma comp_inf_eq_inf_comp_linear [h : is_total α (≤)] {γ : Type} [semilattice_inf_top γ]
   (g : α → γ) (mono_g : monotone g) (top : g ⊤ = ⊤) : g (s.inf f) = s.inf (g ∘ f) :=
-@comp_sup_eq_sup_comp_linear (order_dual α) _ _ _ _ (@is_total.swap α _ h) _ _ _ mono_g.order_dual top
+comp_inf_eq_inf_comp g mono_g.map_inf top
 
 end inf
 

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -2092,7 +2092,7 @@ lemma comp_sup_eq_sup_comp [semilattice_sup_bot γ] {s : finset β}
 by letI := classical.dec_eq β; from
 finset.induction_on s (by simp [bot]) (by simp [g_sup] {contextual := tt})
 
-lemma comp_sup_eq_sup_comp_linear [is_total α (≤)] {γ : Type} [semilattice_sup_bot γ]
+lemma comp_sup_eq_sup_comp_of_is_total [is_total α (≤)] {γ : Type} [semilattice_sup_bot γ]
   (g : α → γ) (mono_g : monotone g) (bot : g ⊥ = ⊥) : g (s.sup f) = s.sup (g ∘ f) :=
 comp_sup_eq_sup_comp g mono_g.map_sup bot
 
@@ -2158,7 +2158,7 @@ lemma comp_inf_eq_inf_comp [semilattice_inf_top γ] {s : finset β}
   g (s.inf f) = s.inf (g ∘ f) :=
 @comp_sup_eq_sup_comp (order_dual α) _ (order_dual γ) _ _ _ _ _ g_inf top
 
-lemma comp_inf_eq_inf_comp_linear [h : is_total α (≤)] {γ : Type} [semilattice_inf_top γ]
+lemma comp_inf_eq_inf_comp_of_is_total [h : is_total α (≤)] {γ : Type} [semilattice_inf_top γ]
   (g : α → γ) (mono_g : monotone g) (top : g ⊤ = ⊤) : g (s.inf f) = s.inf (g ∘ f) :=
 comp_inf_eq_inf_comp g mono_g.map_inf top
 

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -6,7 +6,6 @@ Authors: Leonardo de Moura, Jeremy Avigad, Minchao Wu, Mario Carneiro
 import data.multiset
 import tactic.monotonicity
 import tactic.apply
-import data.equiv.encodable
 
 /-!
 # Finite sets
@@ -1056,13 +1055,6 @@ theorem forall_mem_insert [d : decidable_eq α]
   (∀ x, x ∈ insert a s → p x) ↔ p a ∧ (∀ x, x ∈ s → p x) :=
 by simp only [mem_insert, or_imp_distrib, forall_and_distrib, forall_eq]
 
-lemma nonempty_encodable {α} (t : finset α) : nonempty $ encodable {i // i ∈ t} :=
-begin
-  classical, induction t using finset.induction with x t hx ih,
-  { refine ⟨⟨λ _, 0, λ _, none, λ ⟨x,y⟩, y.rec _⟩⟩ },
-  { cases ih with ih, exactI ⟨encodable.of_equiv _ (subtype_insert_equiv_option hx)⟩ }
-end
-
 end finset
 
 /-- Equivalence between the set of natural numbers which are `≥ k` and `ℕ`, given by `n → n - k`. -/
@@ -2109,13 +2101,6 @@ theorem subset_range_sup_succ (s : finset ℕ) : s ⊆ range (s.sup id).succ :=
 
 theorem exists_nat_subset_range (s : finset ℕ) : ∃n : ℕ, s ⊆ range n :=
 ⟨_, s.subset_range_sup_succ⟩
-
-/-- The first component of a sup in a subtype is the sup if first components. -/
-lemma sup_val {P : α → Prop}
-  {Pbot : P ⊥} {Psup : ∀{{x y}}, P x → P y → P (x ⊔ y)}
-  (t : finset β) (f : β → {x : α // P x}) :
-  (@finset.sup _ _ (subtype.semilattice_sup_bot Pbot Psup) t f).1 = t.sup (λ x, (f x).1) :=
-by { classical, rw [finset.comp_sup_eq_sup_comp' subtype.val]; intros; refl }
 
 end sup
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -75,6 +75,8 @@ singleton, complement, powerset
 
 open function
 
+universe variables u v w x
+
 namespace set
 
 /-- Coercion from a set to the corresponding subtype. -/
@@ -83,8 +85,6 @@ instance {α : Type*} : has_coe_to_sort (set α) := ⟨_, λ s, {x // x ∈ s}�
 end set
 
 section set_coe
-
-universe u
 
 variables {α : Type u}
 
@@ -118,8 +118,6 @@ end set_coe
 lemma subtype.mem {α : Type*} {s : set α} (p : s) : (p : α) ∈ s := p.property
 
 namespace set
-
-universes u v w x
 
 variables {α : Type u} {β : Type v} {γ : Type w} {ι : Sort x} {a : α} {s t : set α}
 
@@ -847,10 +845,6 @@ by finish [ext_iff, iff_def]
 theorem diff_subset (s t : set α) : s \ t ⊆ s :=
 by finish [subset_def]
 
-lemma subset_diff {s t u : set α} : s ⊆ t \ u ↔ s ⊆ t ∧ disjoint s u :=
-⟨λ h, ⟨λ x hxs, (h hxs).1, λ x ⟨hxs, hxu⟩, (h hxs).2 hxu⟩,
-λ ⟨h1, h2⟩ x hxs, ⟨h1 hxs, λ hxu, h2 ⟨hxs, hxu⟩⟩⟩
-
 theorem diff_subset_diff {s₁ s₂ t₁ t₂ : set α} : s₁ ⊆ s₂ → t₂ ⊆ t₁ → s₁ \ t₁ ⊆ s₂ \ t₂ :=
 by finish [subset_def]
 
@@ -899,7 +893,8 @@ lemma diff_inter {s t u : set α} : s \ (t ∩ u) = (s \ t) ∪ (s \ u) :=
 ext $ λ x, by simp [classical.not_and_distrib, and_or_distrib_left]
 
 lemma diff_inter_diff {s t u : set α} : s \ t ∩ (s \ u) = s \ (t ∪ u) :=
-by { ext x, simp only [mem_inter_eq, mem_union_eq, mem_diff], tauto }
+by { ext x, simp only [mem_inter_eq, mem_union_eq, mem_diff, not_or_distrib],
+     exact ⟨λ ⟨⟨h1, h2⟩, _, h3⟩, ⟨h1, h2, h3⟩, λ ⟨h1, h2, h3⟩, ⟨⟨h1, h2⟩, h1, h3⟩⟩ }
 
 lemma diff_compl : s \ -t = s ∩ t := by rw [diff_eq, compl_compl]
 
@@ -1296,9 +1291,6 @@ begin
   exact preimage_mono h
 end
 
-lemma image_injective {f : α → β} (hf : injective f) : injective (('') f) :=
-assume s t, (image_eq_image hf).1
-
 lemma prod_quotient_preimage_eq_image [s : setoid α] (g : quotient s → β) {h : α → β}
   (Hh : h = g ∘ quotient.mk) (r : set (β × β)) :
   {x : quotient s × quotient s | (g x.1, g x.2) ∈ r} =
@@ -1523,6 +1515,36 @@ theorem pairwise_on.mono' {s : set α} {r r' : α → α → Prop}
 end set
 open set
 
+namespace function
+
+variables {ι : Sort*} {α : Type*} {β : Type*} {f : α → β}
+
+lemma surjective.preimage_injective (hf : surjective f) : injective (preimage f) :=
+assume s t, (preimage_eq_preimage hf).1
+
+lemma injective.preimage_surjective (hf : injective f) : surjective (preimage f) :=
+by { intro s, use f '' s, rw preimage_image_eq _ hf }
+
+lemma surjective.image_surjective (hf : surjective f) : surjective (image f) :=
+by { intro s, use f ⁻¹' s, rw image_preimage_eq hf }
+
+lemma injective.image_injective (hf : injective f) : injective (image f) :=
+by { intros s t h, rw [←preimage_image_eq s hf, ←preimage_image_eq t hf, h] }
+
+lemma surjective.range_eq {f : ι → α} (hf : surjective f) : range f = univ :=
+range_iff_surjective.2 hf
+
+lemma surjective.range_comp (g : α → β) {f : ι → α} (hf : surjective f) :
+  range (g ∘ f) = range g :=
+by rw [range_comp, hf.range_eq, image_univ]
+
+lemma injective.nonempty {f : set α → set β} (hf : injective f)
+  (h2 : f ∅ = ∅) {s : set α} : (f s).nonempty ↔ s.nonempty :=
+by rw [← ne_empty_iff_nonempty, ← h2, ← ne_empty_iff_nonempty, hf.ne_iff]
+
+end function
+open function
+
 /-! ### Image and preimage on subtypes -/
 
 namespace subtype
@@ -1556,14 +1578,6 @@ begin
   rintros ⟨xt, xs⟩, exact ⟨x, xs, xt, rfl⟩
 end
 
-theorem preimage_val_eq_preimage_val_iff (s t u : set α) :
-  ((@subtype.val _ s) ⁻¹' t = (@subtype.val _ s) ⁻¹' u) ↔ (t ∩ s = u ∩ s) :=
-begin
-  rw [←image_preimage_val, ←image_preimage_val],
-  split, { intro h, rw h },
-  intro h, exact set.image_injective (val_injective) h
-end
-
 lemma exists_set_subtype {t : set α} (p : set α → Prop) :
 (∃(s : set t), p (subtype.val '' s)) ↔ ∃(s : set α), s ⊆ t ∧ p s :=
 begin
@@ -1573,6 +1587,18 @@ begin
   rintro ⟨s, hs₁, hs₂⟩, refine ⟨subtype.val ⁻¹' s, _⟩,
   rw [image_preimage_eq_of_subset], exact hs₂, rw [range_val], exact hs₁
 end
+
+theorem preimage_val_eq_preimage_val_iff (s t u : set α) :
+  ((@subtype.val _ s) ⁻¹' t = (@subtype.val _ s) ⁻¹' u) ↔ (t ∩ s = u ∩ s) :=
+begin
+  rw [←image_preimage_val, ←image_preimage_val],
+  split, { intro h, rw h },
+  intro h, exact val_injective.image_injective h
+end
+
+theorem preimage_coe_eq_preimage_coe_iff {s t u : set α} :
+  ((coe : s → α) ⁻¹' t = coe ⁻¹' u) ↔ t ∩ s = u ∩ s :=
+subtype.preimage_val_eq_preimage_val_iff _ _ _
 
 end subtype
 
@@ -1584,10 +1610,6 @@ variable {α : Type*}
 
 @[simp] lemma range_coe_subtype (s : set α) : range (coe : s → α) = s :=
 subtype.val_range
-
-theorem preimage_coe_eq_preimage_coe_iff {s t u : set α} :
-  ((coe : s → α) ⁻¹' t = coe ⁻¹' u) ↔ t ∩ s = u ∩ s :=
-subtype.preimage_val_eq_preimage_val_iff _ _ _
 
 end range
 
@@ -1812,76 +1834,6 @@ ext $ λ ⟨x, hx⟩ , by simp [inclusion]
 
 end inclusion
 
-/-! ### Group operations on sets
-
-The product/sum of two sets and the inverse/negation of sets.
--/
-
-section group
-
-variables {α : Type*}
-
-/-- The pointwise product of two sets `s` and `t`:
-  `st = s ⬝ t = s * t = { x * y | x ∈ s, y ∈ t }. -/
-@[to_additive "The pointwise sum of two sets `s` and `t`: `s + t = { x + y | x ∈ s, y ∈ t }."]
-protected def mul [has_mul α] (s t : set α) : set α :=
-(λ p : α × α, p.1 * p.2) '' s.prod t
-
-@[simp, to_additive] lemma mem_mul [has_mul α] {s t : set α} {x : α} :
-  x ∈ s.mul t ↔ ∃ y z, y ∈ s ∧ z ∈ t ∧ y * z = x :=
-by { simp only [set.mul, and.assoc, mem_image, mem_prod, prod.exists] }
-
-@[to_additive] lemma mul_mem_mul [has_mul α] {s t : set α} {x y : α} (hx : x ∈ s) (hy : y ∈ t) :
-  x * y ∈ s.mul t :=
-by { simp only [mem_mul], exact ⟨x, y, hx, hy, rfl⟩ }
-
-@[simp, to_additive add_image_prod]
-lemma mul_image_prod [has_mul α] (s t : set α) : (λ p : α × α, p.1 * p.2) '' s.prod t = s.mul t :=
-rfl
-
-@[to_additive]
-lemma mul_subset_mul [has_mul α] {s t u v : set α} (h1 : u ⊆ s) (h2 : v ⊆ t) :
-  u.mul v ⊆ s.mul t :=
-by { apply image_subset, simp only [prod_subset_prod_iff, h1, h2, true_or, and_self], }
-
-/-- The pointwise inverse of a set `s`: `s⁻¹ = { x⁻¹ | x ∈ s }.
-  We define this as the preimage of `inv` instead of the image, because the preimage is usually
-  better behaved. Use `inv_image` to rewrite it to an image. -/
-@[to_additive "The pointwise additive inverse of a set `s`: `s⁻¹ = { x⁻¹ | x ∈ s }"]
-protected def inv [has_inv α] (s : set α) : set α :=
-has_inv.inv ⁻¹' s
-
-@[to_additive, simp] lemma mem_inv [has_inv α] {s : set α} {x : α} :
-  x ∈ s.inv ↔ x⁻¹ ∈ s :=
-by { simp only [set.inv, mem_preimage] }
-
-@[to_additive] lemma inv_mem_inv [group α] {s : set α} {x : α} : x⁻¹ ∈ s.inv ↔ x ∈ s :=
-by simp only [mem_inv, inv_inv]
-
-@[simp, to_additive]
-lemma inv_preimage [has_inv α] (s : set α) : has_inv.inv ⁻¹' s = s.inv :=
-rfl
-
-@[simp, to_additive]
-lemma inv_image [group α] (s : set α) : has_inv.inv '' s = s.inv :=
-by refine congr_fun (image_eq_preimage_of_inverse _ _) s; intro; simp only [inv_inv]
-
-@[to_additive, simp] protected lemma inv_inv [group α] {s : set α} : s.inv.inv = s :=
-by { simp only [set.inv, ← preimage_comp], convert preimage_id, ext x, apply inv_inv }
-
-@[to_additive, simp] protected lemma univ_inv [group α] : (univ : set α).inv = univ :=
-preimage_univ
-
-@[simp, to_additive]
-lemma inv_subset_inv [group α] {s t : set α} : s.inv ⊆ t.inv ↔ s ⊆ t :=
-by { apply preimage_subset_preimage_iff, rw surjective.range_eq, apply subset_univ,
-     exact (equiv.inv α).surjective }
-
-@[to_additive] lemma inv_subset [group α] {s t : set α} : s.inv ⊆ t ↔ s ⊆ t.inv :=
-by { rw [← inv_subset_inv, set.inv_inv] }
-
-end group
-
 end set
 
 namespace subsingleton
@@ -1897,43 +1849,12 @@ s.eq_empty_or_nonempty.elim (λ h, h.symm ▸ h0) $ λ h, (eq_univ_of_nonempty h
 
 end subsingleton
 
-namespace function
-
-variables {ι : Sort*} {α : Type*} {β : Type*}
-
-lemma surjective.preimage_injective {f : β → α} (hf : surjective f) : injective (preimage f) :=
-assume s t, (preimage_eq_preimage hf).1
-
-lemma injective.preimage_surjective {α β : Type*} {f : α → β} (hf : injective f) :
-  surjective (preimage f) :=
-by { intro s, use f '' s, rw preimage_image_eq _ hf }
-
-lemma surjective.image_surjective {α β : Type*} {f : α → β} (hf : surjective f) :
-  surjective (image f) :=
-by { intro s, use f ⁻¹' s, rw image_preimage_eq hf }
-
-lemma injective.image_injective {α β : Type*} {f : α → β} (hf : injective f) :
-  injective (image f) :=
-by { intros s t h, rw [←preimage_image_eq s hf, ←preimage_image_eq t hf, h] }
-
-lemma surjective.range_eq {f : ι → α} (hf : surjective f) : range f = univ :=
-range_iff_surjective.2 hf
-
-lemma surjective.range_comp (g : α → β) {f : ι → α} (hf : surjective f) :
-  range (g ∘ f) = range g :=
-by rw [range_comp, hf.range_eq, image_univ]
-
-lemma injective.nonempty {α β : Type*} {f : set α → set β} (hf : injective f)
-  (h2 : f ∅ = ∅) {s : set α} : (f s).nonempty ↔ s.nonempty :=
-by rw [← ne_empty_iff_nonempty, ← h2, ← ne_empty_iff_nonempty, hf.ne_iff]
-
-end function
-open function
-
 namespace set
 
+variables {α : Type u} {β : Type v} {f : α → β}
+
 @[simp]
-lemma preimage_injective {α β : Type*} {f : α → β} : injective (preimage f) ↔ surjective f :=
+lemma preimage_injective : injective (preimage f) ↔ surjective f :=
 begin
   refine ⟨λ h y, _, surjective.preimage_injective⟩,
   obtain ⟨x, hx⟩ : (f ⁻¹' {y}).nonempty,
@@ -1942,14 +1863,14 @@ begin
 end
 
 @[simp]
-lemma preimage_surjective {α β : Type*} {f : α → β} : surjective (preimage f) ↔ injective f :=
+lemma preimage_surjective : surjective (preimage f) ↔ injective f :=
 begin
   refine ⟨λ h x x' hx, _, injective.preimage_surjective⟩,
   cases h {x} with s hs, have := mem_singleton x,
   rwa [← hs, mem_preimage, hx, ← mem_preimage, hs, mem_singleton_iff, eq_comm] at this
 end
 
-@[simp] lemma image_surjective {α β : Type*} {f : α → β} : surjective (image f) ↔ surjective f :=
+@[simp] lemma image_surjective : surjective (image f) ↔ surjective f :=
 begin
   refine ⟨λ h y, _, surjective.image_surjective⟩,
   cases h {y} with s hs,
@@ -1957,7 +1878,7 @@ begin
   exact ⟨x, h2x⟩
 end
 
-@[simp] lemma image_injective {α β : Type*} {f : α → β} : injective (image f) ↔ injective f :=
+@[simp] lemma image_injective : injective (image f) ↔ injective f :=
 begin
   refine ⟨λ h x x' hx, _, injective.image_injective⟩,
   rw [← singleton_eq_singleton_iff], apply h,

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1579,6 +1579,14 @@ begin
   rintros ⟨xt, xs⟩, exact ⟨x, xs, xt, rfl⟩
 end
 
+theorem preimage_val_eq_preimage_val_iff (s t u : set α) :
+  ((@subtype.val _ s) ⁻¹' t = (@subtype.val _ s) ⁻¹' u) ↔ (t ∩ s = u ∩ s) :=
+begin
+  rw [←image_preimage_val, ←image_preimage_val],
+  split, { intro h, rw h },
+  intro h, exact val_injective.image_injective h
+end
+
 lemma exists_set_subtype {t : set α} (p : set α → Prop) :
 (∃(s : set t), p (subtype.val '' s)) ↔ ∃(s : set α), s ⊆ t ∧ p s :=
 begin
@@ -1588,18 +1596,6 @@ begin
   rintro ⟨s, hs₁, hs₂⟩, refine ⟨subtype.val ⁻¹' s, _⟩,
   rw [image_preimage_eq_of_subset], exact hs₂, rw [range_val], exact hs₁
 end
-
-theorem preimage_val_eq_preimage_val_iff (s t u : set α) :
-  ((@subtype.val _ s) ⁻¹' t = (@subtype.val _ s) ⁻¹' u) ↔ (t ∩ s = u ∩ s) :=
-begin
-  rw [←image_preimage_val, ←image_preimage_val],
-  split, { intro h, rw h },
-  intro h, exact val_injective.image_injective h
-end
-
-theorem preimage_coe_eq_preimage_coe_iff {s t u : set α} :
-  ((coe : s → α) ⁻¹' t = coe ⁻¹' u) ↔ t ∩ s = u ∩ s :=
-subtype.preimage_val_eq_preimage_val_iff _ _ _
 
 end subtype
 
@@ -1611,6 +1607,10 @@ variable {α : Type*}
 
 @[simp] lemma range_coe_subtype (s : set α) : range (coe : s → α) = s :=
 subtype.val_range
+
+theorem preimage_coe_eq_preimage_coe_iff {s t u : set α} :
+  ((coe : s → α) ⁻¹' t = coe ⁻¹' u) ↔ t ∩ s = u ∩ s :=
+subtype.preimage_val_eq_preimage_val_iff _ _ _
 
 end range
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -8,6 +8,7 @@ import tactic.finish
 import data.subtype
 import logic.unique
 import data.prod
+import logic.function.basic
 
 /-!
 # Basic properties of sets

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1820,6 +1820,18 @@ variables {ι : Sort*} {α : Type*} {β : Type*}
 lemma surjective.preimage_injective {f : β → α} (hf : surjective f) : injective (preimage f) :=
 assume s t, (preimage_eq_preimage hf).1
 
+lemma injective.preimage_surjective {α β : Type*} {f : α → β} (hf : injective f) :
+  surjective (preimage f) :=
+by { intro s, use f '' s, rw preimage_image_eq _ hf }
+
+lemma surjective.image_surjective {α β : Type*} {f : α → β} (hf : surjective f) :
+  surjective (image f) :=
+by { intro s, use f ⁻¹' s, rw image_preimage_eq hf }
+
+lemma injective.image_injective {α β : Type*} {f : α → β} (hf : injective f) :
+  injective (image f) :=
+by { intros s t h, rw [←preimage_image_eq s hf, ←preimage_image_eq t hf, h] }
+
 lemma surjective.range_eq {f : ι → α} (hf : surjective f) : range f = univ :=
 range_iff_surjective.2 hf
 
@@ -1827,4 +1839,45 @@ lemma surjective.range_comp (g : α → β) {f : ι → α} (hf : surjective f) 
   range (g ∘ f) = range g :=
 by rw [range_comp, hf.range_eq, image_univ]
 
+lemma injective.nonempty {α β : Type*} {f : set α → set β} (hf : injective f)
+  (h2 : f ∅ = ∅) {s : set α} : (f s).nonempty ↔ s.nonempty :=
+by rw [← ne_empty_iff_nonempty, ← h2, ← ne_empty_iff_nonempty, hf.ne_iff]
+
 end function
+open function
+
+namespace set
+
+@[simp]
+lemma preimage_injective {α β : Type*} {f : α → β} : injective (preimage f) ↔ surjective f :=
+begin
+  refine ⟨λ h y, _, surjective.preimage_injective⟩,
+  obtain ⟨x, hx⟩ : (f ⁻¹' {y}).nonempty,
+  { rw [h.nonempty preimage_empty], apply singleton_nonempty },
+  exact ⟨x, hx⟩
+end
+
+@[simp]
+lemma preimage_surjective {α β : Type*} {f : α → β} : surjective (preimage f) ↔ injective f :=
+begin
+  refine ⟨λ h x x' hx, _, injective.preimage_surjective⟩,
+  cases h {x} with s hs, have := mem_singleton x,
+  rwa [← hs, mem_preimage, hx, ← mem_preimage, hs, mem_singleton_iff, eq_comm] at this
+end
+
+@[simp] lemma image_surjective {α β : Type*} {f : α → β} : surjective (image f) ↔ surjective f :=
+begin
+  refine ⟨λ h y, _, surjective.image_surjective⟩,
+  cases h {y} with s hs,
+  have := mem_singleton y, rw [← hs] at this, rcases this with ⟨x, h1x, h2x⟩,
+  exact ⟨x, h2x⟩
+end
+
+@[simp] lemma image_injective {α β : Type*} {f : α → β} : injective (image f) ↔ injective f :=
+begin
+  refine ⟨λ h x x' hx, _, injective.image_injective⟩,
+  rw [← singleton_eq_singleton_iff], apply h,
+  rw [image_singleton, image_singleton, hx]
+end
+
+end set

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1539,7 +1539,7 @@ lemma surjective.range_comp (g : α → β) {f : ι → α} (hf : surjective f) 
   range (g ∘ f) = range g :=
 by rw [range_comp, hf.range_eq, image_univ]
 
-lemma injective.nonempty {f : set α → set β} (hf : injective f)
+lemma injective.nonempty_apply_iff {f : set α → set β} (hf : injective f)
   (h2 : f ∅ = ∅) {s : set α} : (f s).nonempty ↔ s.nonempty :=
 by rw [← ne_empty_iff_nonempty, ← h2, ← ne_empty_iff_nonempty, hf.ne_iff]
 
@@ -1859,7 +1859,7 @@ lemma preimage_injective : injective (preimage f) ↔ surjective f :=
 begin
   refine ⟨λ h y, _, surjective.preimage_injective⟩,
   obtain ⟨x, hx⟩ : (f ⁻¹' {y}).nonempty,
-  { rw [h.nonempty preimage_empty], apply singleton_nonempty },
+  { rw [h.nonempty_apply_iff preimage_empty], apply singleton_nonempty },
   exact ⟨x, hx⟩
 end
 

--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -837,6 +837,10 @@ theorem disjoint_image_image {f : β → α} {g : γ → α} {s : set β} {t : s
   (h : ∀b∈s, ∀c∈t, f b ≠ g c) : disjoint (f '' s) (g '' t) :=
 by rintros a ⟨⟨b, hb, eq⟩, ⟨c, hc, rfl⟩⟩; exact h b hb c hc eq
 
+lemma disjoint.preimage {α β} (f : α → β) {s t : set β} (h : disjoint s t) :
+  disjoint (f ⁻¹' s) (f ⁻¹' t) :=
+λ x hx, h hx
+
 theorem pairwise_on_disjoint_fiber (f : α → β) (s : set β) :
   pairwise_on s (disjoint on (λ y, f ⁻¹' {y})) :=
 λ y₁ _ y₂ _ hy x ⟨hx₁, hx₂⟩, hy (eq.trans (eq.symm hx₁) hx₂)

--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -813,6 +813,9 @@ namespace set
 
 protected theorem disjoint_iff {s t : set α} : disjoint s t ↔ s ∩ t ⊆ ∅ := iff.rfl
 
+theorem disjoint_iff_inter_eq_empty {s t : set α} : disjoint s t ↔ s ∩ t = ∅ :=
+disjoint_iff
+
 lemma not_disjoint_iff {s t : set α} : ¬disjoint s t ↔ ∃x, x ∈ s ∧ x ∈ t :=
 (not_congr (set.disjoint_iff.trans subset_empty_iff)).trans ne_empty_iff_nonempty
 
@@ -821,6 +824,16 @@ show (∀ x, ¬(x ∈ s ∩ t)) ↔ _, from ⟨λ h a, not_and.1 $ h a, λ h a, 
 
 theorem disjoint_right {s t : set α} : disjoint s t ↔ ∀ {a}, a ∈ t → a ∉ s :=
 by rw [disjoint.comm, disjoint_left]
+
+theorem disjoint_of_subset_left {s t u : set α} (h : s ⊆ u) (d : disjoint u t) : disjoint s t :=
+disjoint_left.2 (λ x m₁, (disjoint_left.1 d) (h m₁))
+
+theorem disjoint_of_subset_right {s t u : set α} (h : t ⊆ u) (d : disjoint s u) : disjoint s t :=
+disjoint_right.2 (λ x m₁, (disjoint_right.1 d) (h m₁))
+
+theorem disjoint_of_subset {s t u v : set α} (h1 : s ⊆ u) (h2 : t ⊆ v) (d : disjoint u v) :
+  disjoint s t :=
+disjoint_of_subset_left h1 $ disjoint_of_subset_right h2 d
 
 theorem disjoint_diff {a b : set α} : disjoint a (b \ a) :=
 disjoint_iff.2 (inter_diff_self _ _)

--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -884,6 +884,10 @@ end set
 namespace set
 variables (t : α → set β)
 
+lemma subset_diff {s t u : set α} : s ⊆ t \ u ↔ s ⊆ t ∧ disjoint s u :=
+⟨λ h, ⟨λ x hxs, (h hxs).1, λ x ⟨hxs, hxu⟩, (h hxs).2 hxu⟩,
+λ ⟨h1, h2⟩ x hxs, ⟨h1 hxs, λ hxu, h2 ⟨hxs, hxu⟩⟩⟩
+
 /-- If `t` is an indexed family of sets, then there is a natural map from `Σ i, t i` to `⋃ i, t i`
 sending `⟨i, x⟩` to `x`. -/
 def sigma_to_Union (x : Σi, t i) : (⋃i, t i) := ⟨x.2, mem_Union.2 ⟨x.1, x.2.2⟩⟩

--- a/src/logic/embedding.lean
+++ b/src/logic/embedding.lean
@@ -197,7 +197,7 @@ open set
 
 /-- `set.image` as an embedding `set α ↪ set β`. -/
 protected def image {α β} (f : α ↪ β) : set α ↪ set β :=
-⟨image f, image_injective f.2⟩
+⟨image f, f.2.image_injective⟩
 
 @[simp] lemma coe_image {α β} (f : α ↪ β) : ⇑f.image = image f := rfl
 

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -41,8 +41,11 @@ lemma comp_apply {α : Sort u} {β : Sort v} {φ : Sort w} (f : β → φ) (g : 
   f a = f b ↔ a = b :=
 ⟨@I _ _, congr_arg f⟩
 
-lemma injective.ne (hf : function.injective f) {a₁ a₂ : α} : a₁ ≠ a₂ → f a₁ ≠ f a₂ :=
+lemma injective.ne (hf : injective f) {a₁ a₂ : α} : a₁ ≠ a₂ → f a₁ ≠ f a₂ :=
 mt (assume h, hf h)
+
+lemma injective.ne_iff (hf : injective f) {x y : α} : f x ≠ f y ↔ x ≠ y :=
+⟨mt $ congr_arg f, hf.ne⟩
 
 /-- If the co-domain `β` of an injective function `f : α → β` has decidable equality, then
 the domain `α` also has decidable equality. -/

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -1142,7 +1142,7 @@ begin
   { assume x y,
     have : sup univ (λ (b : β), edist (x b) (y b)) = ↑(sup univ (λ (b : β), nndist (x b) (y b))),
     { simp [edist_nndist],
-      refine eq.symm (comp_sup_eq_sup_comp_linear _ _ _),
+      refine eq.symm (comp_sup_eq_sup_comp_of_is_total _ _ _),
       exact (assume x y h, ennreal.coe_le_coe.2 h), refl },
     rw this,
     refl }

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -1142,7 +1142,7 @@ begin
   { assume x y,
     have : sup univ (λ (b : β), edist (x b) (y b)) = ↑(sup univ (λ (b : β), nndist (x b) (y b))),
     { simp [edist_nndist],
-      refine eq.symm (comp_sup_eq_sup_comp _ _ _),
+      refine eq.symm (comp_sup_eq_sup_comp_linear _ _ _),
       exact (assume x y h, ennreal.coe_le_coe.2 h), refl },
     rw this,
     refl }


### PR DESCRIPTION
`comp_sup_eq_sup_comp` is renamed `comp_sup_eq_sup_comp_of_is_total` and there is a new version that doesn't assume that the order is linear.
`set.image_injective` is renamed `function.injective.image_injective` (in the same way as the existing `function.surjective.preimage_injective`). `set.image_injective` is now an `iff`.

---
<!-- put comments you want to keep out of the PR commit here -->
PR 1/5(?) to put the Haar measure in mathlib. This PR: results about (fin)sets