### PR TITLE
[Merged by Bors] - feat(nat, lattice): preliminaries for Haar measure

### DIFF
--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -2021,7 +2021,7 @@ def sup (s : finset β) (f : β → α) : α := s.fold (⊔) ⊥ f
 
 variables {s s₁ s₂ : finset β} {f : β → α}
 
-lemma sup_val : s.sup f = (s.1.map f).sup := rfl
+lemma sup_def : s.sup f = (s.1.map f).sup := rfl
 
 @[simp] lemma sup_empty : (∅ : finset β).sup f = ⊥ :=
 fold_empty
@@ -2074,13 +2074,6 @@ theorem subset_range_sup_succ (s : finset ℕ) : s ⊆ range (s.sup id).succ :=
 
 theorem exists_nat_subset_range (s : finset ℕ) : ∃n : ℕ, s ⊆ range n :=
 ⟨_, s.subset_range_sup_succ⟩
-
-/-- The first component of a sup in a subtype is the sup if first components. -/
-lemma sup_val {P : α → Prop}
-  {Pbot : P ⊥} {Psup : ∀{{x y}}, P x → P y → P (x ⊔ y)}
-  (t : finset β) (f : β → {x : α // P x}) :
-  (@finset.sup _ _ (_root_.subtype.semilattice_sup_bot Pbot Psup) t f).1 = t.sup (λ x, (f x).1) :=
-by { classical, rw [finset.comp_sup_eq_sup_comp' subtype.val]; intros; refl }
 
 end sup
 

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -521,7 +521,7 @@ finset.inter_subset_inter (finset.subset.refl _) h
 
 /-! ### lattice laws -/
 
-instance finset.lattice : lattice (finset α) :=
+instance : lattice (finset α) :=
 { sup          := (∪),
   sup_le       := assume a b c, union_subset,
   le_sup_left  := subset_union_left,
@@ -535,13 +535,13 @@ instance finset.lattice : lattice (finset α) :=
 @[simp] theorem sup_eq_union (s t : finset α) : s ⊔ t = s ∪ t := rfl
 @[simp] theorem inf_eq_inter (s t : finset α) : s ⊓ t = s ∩ t := rfl
 
-instance finset.semilattice_inf_bot : semilattice_inf_bot (finset α) :=
+instance : semilattice_inf_bot (finset α) :=
 { bot := ∅, bot_le := empty_subset, ..finset.lattice }
 
-instance finset.semilattice_sup_bot {α : Type*} [decidable_eq α] : semilattice_sup_bot (finset α) :=
+instance {α : Type*} [decidable_eq α] : semilattice_sup_bot (finset α) :=
 { ..finset.semilattice_inf_bot, ..finset.lattice }
 
-instance finset.distrib_lattice : distrib_lattice (finset α) :=
+instance : distrib_lattice (finset α) :=
 { le_sup_inf := assume a b c, show (a ∪ b) ∩ (a ∪ c) ⊆ a ∪ b ∩ c,
     by simp only [subset_iff, mem_inter, mem_union, and_imp, or_imp_distrib] {contextual:=tt};
     simp only [true_or, imp_true_iff, true_and, or_true],
@@ -2074,6 +2074,13 @@ theorem subset_range_sup_succ (s : finset ℕ) : s ⊆ range (s.sup id).succ :=
 
 theorem exists_nat_subset_range (s : finset ℕ) : ∃n : ℕ, s ⊆ range n :=
 ⟨_, s.subset_range_sup_succ⟩
+
+/-- The first component of a sup in a subtype is the sup if first components. -/
+lemma sup_val {P : α → Prop}
+  {Pbot : P ⊥} {Psup : ∀{{x y}}, P x → P y → P (x ⊔ y)}
+  (t : finset β) (f : β → {x : α // P x}) :
+  (@finset.sup _ _ (_root_.subtype.semilattice_sup_bot Pbot Psup) t f).1 = t.sup (λ x, (f x).1) :=
+by { classical, rw [finset.comp_sup_eq_sup_comp' subtype.val]; intros; refl }
 
 end sup
 

--- a/src/data/finset.lean
+++ b/src/data/finset.lean
@@ -521,7 +521,7 @@ finset.inter_subset_inter (finset.subset.refl _) h
 
 /-! ### lattice laws -/
 
-instance : lattice (finset α) :=
+instance finset.lattice : lattice (finset α) :=
 { sup          := (∪),
   sup_le       := assume a b c, union_subset,
   le_sup_left  := subset_union_left,
@@ -535,13 +535,13 @@ instance : lattice (finset α) :=
 @[simp] theorem sup_eq_union (s t : finset α) : s ⊔ t = s ∪ t := rfl
 @[simp] theorem inf_eq_inter (s t : finset α) : s ⊓ t = s ∩ t := rfl
 
-instance : semilattice_inf_bot (finset α) :=
+instance finset.semilattice_inf_bot : semilattice_inf_bot (finset α) :=
 { bot := ∅, bot_le := empty_subset, ..finset.lattice }
 
-instance {α : Type*} [decidable_eq α] : semilattice_sup_bot (finset α) :=
+instance finset.semilattice_sup_bot {α : Type*} [decidable_eq α] : semilattice_sup_bot (finset α) :=
 { ..finset.semilattice_inf_bot, ..finset.lattice }
 
-instance : distrib_lattice (finset α) :=
+instance finset.distrib_lattice : distrib_lattice (finset α) :=
 { le_sup_inf := assume a b c, show (a ∪ b) ∩ (a ∪ c) ⊆ a ∪ b ∩ c,
     by simp only [subset_iff, mem_inter, mem_union, and_imp, or_imp_distrib] {contextual:=tt};
     simp only [true_or, imp_true_iff, true_and, or_true],

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -1267,7 +1267,7 @@ end
 ⟨λ h, ⟨mem_of_le (inter_le_left _ _) h, mem_of_le (inter_le_right _ _) h⟩,
  λ ⟨h₁, h₂⟩, by rw [← cons_erase h₁, cons_inter_of_pos _ h₂]; apply mem_cons_self⟩
 
-instance multiset.lattice : lattice (multiset α) :=
+instance : lattice (multiset α) :=
 { sup          := (∪),
   sup_le       := @union_le _ _,
   le_sup_left  := le_union_left,
@@ -1284,7 +1284,7 @@ instance multiset.lattice : lattice (multiset α) :=
 @[simp] theorem le_inter_iff : s ≤ t ∩ u ↔ s ≤ t ∧ s ≤ u := le_inf_iff
 @[simp] theorem union_le_iff : s ∪ t ≤ u ↔ s ≤ u ∧ t ≤ u := sup_le_iff
 
-instance multiset.semilattice_inf_bot : semilattice_inf_bot (multiset α) :=
+instance : semilattice_inf_bot (multiset α) :=
 { bot := 0, bot_le := zero_le, ..multiset.lattice }
 
 theorem union_comm (s t : multiset α) : s ∪ t = t ∪ s := sup_comm
@@ -1971,7 +1971,7 @@ instance : distrib_lattice (multiset α) :=
       multiset.count_inter, multiset.sup_eq_union, multiset.count_union, multiset.inf_eq_inter],
   ..multiset.lattice }
 
-instance multiset.semilattice_sup_bot : semilattice_sup_bot (multiset α) :=
+instance : semilattice_sup_bot (multiset α) :=
 { bot := 0,
   bot_le := zero_le,
   ..multiset.lattice }

--- a/src/data/multiset.lean
+++ b/src/data/multiset.lean
@@ -1267,7 +1267,7 @@ end
 ⟨λ h, ⟨mem_of_le (inter_le_left _ _) h, mem_of_le (inter_le_right _ _) h⟩,
  λ ⟨h₁, h₂⟩, by rw [← cons_erase h₁, cons_inter_of_pos _ h₂]; apply mem_cons_self⟩
 
-instance : lattice (multiset α) :=
+instance multiset.lattice : lattice (multiset α) :=
 { sup          := (∪),
   sup_le       := @union_le _ _,
   le_sup_left  := le_union_left,
@@ -1284,7 +1284,7 @@ instance : lattice (multiset α) :=
 @[simp] theorem le_inter_iff : s ≤ t ∩ u ↔ s ≤ t ∧ s ≤ u := le_inf_iff
 @[simp] theorem union_le_iff : s ∪ t ≤ u ↔ s ≤ u ∧ t ≤ u := sup_le_iff
 
-instance : semilattice_inf_bot (multiset α) :=
+instance multiset.semilattice_inf_bot : semilattice_inf_bot (multiset α) :=
 { bot := 0, bot_le := zero_le, ..multiset.lattice }
 
 theorem union_comm (s t : multiset α) : s ∪ t = t ∪ s := sup_comm
@@ -1971,7 +1971,7 @@ instance : distrib_lattice (multiset α) :=
       multiset.count_inter, multiset.sup_eq_union, multiset.count_union, multiset.inf_eq_inter],
   ..multiset.lattice }
 
-instance : semilattice_sup_bot (multiset α) :=
+instance multiset.semilattice_sup_bot : semilattice_sup_bot (multiset α) :=
 { bot := 0,
   bot_le := zero_le,
   ..multiset.lattice }

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -1329,6 +1329,22 @@ iff.intro
   (assume ⟨u, hu⟩, match n, u, hu, nat.units_eq_one u with _, _, rfl, rfl := rfl end)
   (assume h, h.symm ▸ ⟨1, rfl⟩)
 
+section find
+
+@[simp] lemma find_eq_zero {p : ℕ → Prop} [decidable_pred p] (h : ∃ (n : ℕ), p n) :
+  nat.find h = 0 ↔ p 0 :=
+begin
+  split,
+  { intro h0, rw [← h0], apply nat.find_spec },
+  { intro hp, apply nat.eq_zero_of_le_zero, exact nat.find_min' _ hp }
+end
+
+@[simp] lemma find_pos {p : ℕ → Prop} [decidable_pred p] (h : ∃ (n : ℕ), p n) :
+  0 < nat.find h ↔ ¬ p 0 :=
+by rw [nat.pos_iff_ne_zero, not_iff_not, nat.find_eq_zero]
+
+end find
+
 section find_greatest
 
 /-- `find_greatest P b` is the largest `i ≤ bound` such that `P i` holds, or `0` if no such `i`

--- a/src/order/bounded_lattice.lean
+++ b/src/order/bounded_lattice.lean
@@ -740,10 +740,10 @@ lemma lt_iff_exists_coe_btwn [partial_order α] [densely_ordered α] [no_top_ord
 
 end with_top
 
-section subtype
+namespace subtype
 
 /-- A subtype forms a `⊔`-semilattice if `⊔` preserves the property. -/
-def subtype.semilattice_sup [semilattice_sup α] {P : α → Prop}
+protected def semilattice_sup [semilattice_sup α] {P : α → Prop}
   (Psup : ∀{{x y}}, P x → P y → P (x ⊔ y)) : semilattice_sup {x : α // P x} :=
 { sup := λ x y, ⟨x.1 ⊔ y.1, Psup x.2 y.2⟩,
   le_sup_left := λ x y, @le_sup_left _ _ (x : α) y,
@@ -752,7 +752,7 @@ def subtype.semilattice_sup [semilattice_sup α] {P : α → Prop}
   ..subtype.partial_order P }
 
 /-- A subtype forms a `⊓`-semilattice if `⊓` preserves the property. -/
-def subtype.semilattice_inf [semilattice_inf α] {P : α → Prop}
+protected def semilattice_inf [semilattice_inf α] {P : α → Prop}
   (Pinf : ∀{{x y}}, P x → P y → P (x ⊓ y)) : semilattice_inf {x : α // P x} :=
 { inf := λ x y, ⟨x.1 ⊓ y.1, Pinf x.2 y.2⟩,
   inf_le_left := λ x y, @inf_le_left _ _ (x : α) y,
@@ -761,21 +761,21 @@ def subtype.semilattice_inf [semilattice_inf α] {P : α → Prop}
   ..subtype.partial_order P }
 
 /-- A subtype forms a `⊔`-`⊥`-semilattice if `⊥` and `⊔` preserve the property. -/
-def subtype.semilattice_sup_bot [semilattice_sup_bot α] {P : α → Prop}
+protected def semilattice_sup_bot [semilattice_sup_bot α] {P : α → Prop}
   (Pbot : P ⊥) (Psup : ∀{{x y}}, P x → P y → P (x ⊔ y)) : semilattice_sup_bot {x : α // P x} :=
 { bot := ⟨⊥, Pbot⟩,
   bot_le := λ x, @bot_le α _ x,
   ..subtype.semilattice_sup Psup }
 
 /-- A subtype forms a `⊓`-`⊥`-semilattice if `⊥` and `⊓` preserve the property. -/
-def subtype.semilattice_inf_bot [semilattice_inf_bot α] {P : α → Prop}
+protected def semilattice_inf_bot [semilattice_inf_bot α] {P : α → Prop}
   (Pbot : P ⊥) (Pinf : ∀{{x y}}, P x → P y → P (x ⊓ y)) : semilattice_inf_bot {x : α // P x} :=
 { bot := ⟨⊥, Pbot⟩,
   bot_le := λ x, @bot_le α _ x,
   ..subtype.semilattice_inf Pinf }
 
 /-- A subtype forms a lattice if `⊔` and `⊓` preserve the property. -/
-def subtype.lattice [lattice α] {P : α → Prop}
+protected def lattice [lattice α] {P : α → Prop}
   (Psup : ∀{{x y}}, P x → P y → P (x ⊔ y)) (Pinf : ∀{{x y}}, P x → P y → P (x ⊓ y)) :
   lattice {x : α // P x} :=
 { ..subtype.semilattice_inf Pinf, ..subtype.semilattice_sup Psup }

--- a/src/order/bounded_lattice.lean
+++ b/src/order/bounded_lattice.lean
@@ -740,6 +740,48 @@ lemma lt_iff_exists_coe_btwn [partial_order α] [densely_ordered α] [no_top_ord
 
 end with_top
 
+section subtype
+
+/-- A subtype forms a `⊔`-semilattice if `⊔` preserves the property. -/
+def subtype.semilattice_sup [semilattice_sup α] {P : α → Prop}
+  (Psup : ∀{{x y}}, P x → P y → P (x ⊔ y)) : semilattice_sup {x : α // P x} :=
+{ sup := λ x y, ⟨x.1 ⊔ y.1, Psup x.2 y.2⟩,
+  le_sup_left := λ x y, @le_sup_left _ _ (x : α) y,
+  le_sup_right := λ x y, @le_sup_right _ _ (x : α) y,
+  sup_le := λ x y z h1 h2, @sup_le α _ _ _ _ h1 h2,
+  ..subtype.partial_order P }
+
+/-- A subtype forms a `⊓`-semilattice if `⊓` preserves the property. -/
+def subtype.semilattice_inf [semilattice_inf α] {P : α → Prop}
+  (Pinf : ∀{{x y}}, P x → P y → P (x ⊓ y)) : semilattice_inf {x : α // P x} :=
+{ inf := λ x y, ⟨x.1 ⊓ y.1, Pinf x.2 y.2⟩,
+  inf_le_left := λ x y, @inf_le_left _ _ (x : α) y,
+  inf_le_right := λ x y, @inf_le_right _ _ (x : α) y,
+  le_inf := λ x y z h1 h2, @le_inf α _ _ _ _ h1 h2,
+  ..subtype.partial_order P }
+
+/-- A subtype forms a `⊔`-`⊥`-semilattice if `⊥` and `⊔` preserve the property. -/
+def subtype.semilattice_sup_bot [semilattice_sup_bot α] {P : α → Prop}
+  (Pbot : P ⊥) (Psup : ∀{{x y}}, P x → P y → P (x ⊔ y)) : semilattice_sup_bot {x : α // P x} :=
+{ bot := ⟨⊥, Pbot⟩,
+  bot_le := λ x, @bot_le α _ x,
+  ..subtype.semilattice_sup Psup }
+
+/-- A subtype forms a `⊓`-`⊥`-semilattice if `⊥` and `⊓` preserve the property. -/
+def subtype.semilattice_inf_bot [semilattice_inf_bot α] {P : α → Prop}
+  (Pbot : P ⊥) (Pinf : ∀{{x y}}, P x → P y → P (x ⊓ y)) : semilattice_inf_bot {x : α // P x} :=
+{ bot := ⟨⊥, Pbot⟩,
+  bot_le := λ x, @bot_le α _ x,
+  ..subtype.semilattice_inf Pinf }
+
+/-- A subtype forms a lattice if `⊔` and `⊓` preserve the property. -/
+def subtype.lattice [lattice α] {P : α → Prop}
+  (Psup : ∀{{x y}}, P x → P y → P (x ⊔ y)) (Pinf : ∀{{x y}}, P x → P y → P (x ⊓ y)) :
+  lattice {x : α // P x} :=
+{ ..subtype.semilattice_inf Pinf, ..subtype.semilattice_sup Psup }
+
+end subtype
+
 namespace order_dual
 variable (α)
 

--- a/src/order/bounded_lattice.lean
+++ b/src/order/bounded_lattice.lean
@@ -744,7 +744,7 @@ namespace subtype
 
 /-- A subtype forms a `⊔`-semilattice if `⊔` preserves the property. -/
 protected def semilattice_sup [semilattice_sup α] {P : α → Prop}
-  (Psup : ∀{{x y}}, P x → P y → P (x ⊔ y)) : semilattice_sup {x : α // P x} :=
+  (Psup : ∀⦃x y⦄, P x → P y → P (x ⊔ y)) : semilattice_sup {x : α // P x} :=
 { sup := λ x y, ⟨x.1 ⊔ y.1, Psup x.2 y.2⟩,
   le_sup_left := λ x y, @le_sup_left _ _ (x : α) y,
   le_sup_right := λ x y, @le_sup_right _ _ (x : α) y,
@@ -753,7 +753,7 @@ protected def semilattice_sup [semilattice_sup α] {P : α → Prop}
 
 /-- A subtype forms a `⊓`-semilattice if `⊓` preserves the property. -/
 protected def semilattice_inf [semilattice_inf α] {P : α → Prop}
-  (Pinf : ∀{{x y}}, P x → P y → P (x ⊓ y)) : semilattice_inf {x : α // P x} :=
+  (Pinf : ∀⦃x y⦄, P x → P y → P (x ⊓ y)) : semilattice_inf {x : α // P x} :=
 { inf := λ x y, ⟨x.1 ⊓ y.1, Pinf x.2 y.2⟩,
   inf_le_left := λ x y, @inf_le_left _ _ (x : α) y,
   inf_le_right := λ x y, @inf_le_right _ _ (x : α) y,
@@ -762,21 +762,21 @@ protected def semilattice_inf [semilattice_inf α] {P : α → Prop}
 
 /-- A subtype forms a `⊔`-`⊥`-semilattice if `⊥` and `⊔` preserve the property. -/
 protected def semilattice_sup_bot [semilattice_sup_bot α] {P : α → Prop}
-  (Pbot : P ⊥) (Psup : ∀{{x y}}, P x → P y → P (x ⊔ y)) : semilattice_sup_bot {x : α // P x} :=
+  (Pbot : P ⊥) (Psup : ∀⦃x y⦄, P x → P y → P (x ⊔ y)) : semilattice_sup_bot {x : α // P x} :=
 { bot := ⟨⊥, Pbot⟩,
   bot_le := λ x, @bot_le α _ x,
   ..subtype.semilattice_sup Psup }
 
 /-- A subtype forms a `⊓`-`⊥`-semilattice if `⊥` and `⊓` preserve the property. -/
 protected def semilattice_inf_bot [semilattice_inf_bot α] {P : α → Prop}
-  (Pbot : P ⊥) (Pinf : ∀{{x y}}, P x → P y → P (x ⊓ y)) : semilattice_inf_bot {x : α // P x} :=
+  (Pbot : P ⊥) (Pinf : ∀⦃x y⦄, P x → P y → P (x ⊓ y)) : semilattice_inf_bot {x : α // P x} :=
 { bot := ⟨⊥, Pbot⟩,
   bot_le := λ x, @bot_le α _ x,
   ..subtype.semilattice_inf Pinf }
 
 /-- A subtype forms a lattice if `⊔` and `⊓` preserve the property. -/
 protected def lattice [lattice α] {P : α → Prop}
-  (Psup : ∀{{x y}}, P x → P y → P (x ⊔ y)) (Pinf : ∀{{x y}}, P x → P y → P (x ⊓ y)) :
+  (Psup : ∀⦃x y⦄, P x → P y → P (x ⊔ y)) (Pinf : ∀⦃x y⦄, P x → P y → P (x ⊓ y)) :
   lattice {x : α // P x} :=
 { ..subtype.semilattice_inf Pinf, ..subtype.semilattice_sup Psup }
 

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -6,7 +6,6 @@ Authors: Johannes Hölzl
 Theory of complete lattices.
 -/
 import order.bounds
-import data.equiv.encodable
 
 set_option old_structure_cmd true
 open set
@@ -862,11 +861,6 @@ by rw [← Sup_image]; refl
 lemma supr_apply {α : Type u} {β : α → Type v} {ι : Sort*} [∀ i, complete_lattice (β i)]
   {f : ι → Πa, β a} {a : α} : (⨆i, f i) a = (⨆i, f i a) :=
 by erw [← Sup_range, Sup_apply, supr_range]
-
-open encodable
-lemma supr_decode2 {α β} [complete_lattice α] [encodable β] (f : β → α) :
-  (⨆ b, f b) = ⨆ (i : ℕ) (b ∈ decode2 β i), f b :=
-by { rw [supr_comm], simp [mem_decode2] }
 
 section complete_lattice
 variables [preorder α] [complete_lattice β]

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -10,13 +10,12 @@ import order.bounds
 set_option old_structure_cmd true
 open set
 
-universes u v v₂ w w₂
-variables {α : Type u} {β : Type v} {β₂ : Type v} {ι : Sort w} {ι₂ : Sort w₂}
+variables {α β β₂ : Type*} {ι ι₂ : Sort*}
 
 /-- class for the `Sup` operator -/
-class has_Sup (α : Type u) := (Sup : set α → α)
+class has_Sup (α : Type*) := (Sup : set α → α)
 /-- class for the `Inf` operator -/
-class has_Inf (α : Type u) := (Inf : set α → α)
+class has_Inf (α : Type*) := (Inf : set α → α)
 /-- Supremum of a set -/
 def Sup [has_Sup α] : set α → α := has_Sup.Sup
 /-- Infimum of a set -/
@@ -36,7 +35,7 @@ section prio
 set_option default_priority 100 -- see Note [default priority]
 /-- A complete lattice is a bounded lattice which
   has suprema and infima for every subset. -/
-class complete_lattice (α : Type u) extends bounded_lattice α, has_Sup α, has_Inf α :=
+class complete_lattice (α : Type*) extends bounded_lattice α, has_Sup α, has_Inf α :=
 (le_Sup : ∀s, ∀a∈s, a ≤ Sup s)
 (Sup_le : ∀s a, (∀b∈s, b ≤ a) → Sup s ≤ a)
 (Inf_le : ∀s, ∀a∈s, Inf s ≤ a)
@@ -46,7 +45,7 @@ class complete_lattice (α : Type u) extends bounded_lattice α, has_Sup α, has
 that returns the greatest lower bound of a set. Usually this constructor provides
 poor definitional equalities, so it should be used with
 `.. complete_lattice_of_Inf α _`. -/
-def complete_lattice_of_Inf (α : Type u) [H1 : partial_order α]
+def complete_lattice_of_Inf (α : Type*) [H1 : partial_order α]
   [H2 : has_Inf α] (is_glb_Inf : ∀ s : set α, is_glb s (Inf s)) :
   complete_lattice α :=
 { bot := Inf univ,
@@ -95,7 +94,7 @@ def complete_lattice_of_Sup (α : Type*) [H1 : partial_order α]
   .. H1, .. H2 }
 
 /-- A complete linear order is a linear order whose lattice structure is complete. -/
-class complete_linear_order (α : Type u) extends complete_lattice α, decidable_linear_order α
+class complete_linear_order (α : Type*) extends complete_lattice α, decidable_linear_order α
 end prio
 
 section
@@ -312,11 +311,11 @@ lemma monotone.supr_comp_eq [preorder β] {f : β → α} (hf : monotone f)
 le_antisymm (supr_comp_le _ _) (supr_le_supr2 $ λ x, (hs x).imp $ λ i hi, hf hi)
 
 lemma supr_congr {f : β → α} {g : β₂ → α} (h : β → β₂)
-  (h1 : function.surjective h) (h2 : ∀ x, g (h x) = f x) : (⨆ x, f x) = ⨆ y, g y  :=
+  (h1 : function.surjective h) (h2 : ∀ x, g (h x) = f x) : (⨆ x, f x) = ⨆ y, g y :=
 by { unfold supr, congr' 1, convert h1.range_comp g, ext, rw ←h2 }
 
 -- TODO: finish doesn't do well here.
-@[congr] theorem supr_congr_Prop {α : Type u} [has_Sup α] {p q : Prop} {f₁ : p → α} {f₂ : q → α}
+@[congr] theorem supr_congr_Prop {α : Type*} [has_Sup α] {p q : Prop} {f₁ : p → α} {f₂ : q → α}
   (pq : p ↔ q) (f : ∀x, f₁ (pq.mpr x) = f₂ x) : supr f₁ = supr f₂ :=
 begin
   unfold supr,
@@ -390,10 +389,10 @@ lemma monotone.infi_comp_eq [preorder β] {f : β → α} (hf : monotone f)
 le_antisymm (infi_le_infi2 $ λ x, (hs x).imp $ λ i hi, hf hi) (le_infi_comp _ _)
 
 lemma infi_congr {f : β → α} {g : β₂ → α} (h : β → β₂)
-  (h1 : function.surjective h) (h2 : ∀ x, g (h x) = f x) : (⨅ x, f x) = ⨅ y, g y  :=
+  (h1 : function.surjective h) (h2 : ∀ x, g (h x) = f x) : (⨅ x, f x) = ⨅ y, g y :=
 by { unfold infi, congr' 1, convert h1.range_comp g, ext, rw ←h2 }
 
-@[congr] theorem infi_congr_Prop {α : Type u} [has_Inf α] {p q : Prop} {f₁ : p → α} {f₂ : q → α}
+@[congr] theorem infi_congr_Prop {α : Type*} [has_Inf α] {p q : Prop} {f₁ : p → α} {f₂ : q → α}
   (pq : p ↔ q) (f : ∀x, f₁ (pq.mpr x) = f₂ x) : infi f₁ = infi f₂ :=
 begin
   unfold infi,
@@ -613,9 +612,9 @@ le_antisymm
     (supr_le_supr2 $ assume i, ⟨or.inl i, le_refl _⟩)
     (supr_le_supr2 $ assume j, ⟨or.inr j, le_refl _⟩))
 
-lemma Sup_range {α : Type u} [has_Sup α] {f : ι → α} : Sup (range f) = supr f := rfl
+lemma Sup_range {α : Type*} [has_Sup α] {f : ι → α} : Sup (range f) = supr f := rfl
 
-lemma Inf_range {α : Type u} [has_Inf α] {f : ι → α} : Inf (range f) = infi f := rfl
+lemma Inf_range {α : Type*} [has_Inf α] {f : ι → α} : Inf (range f) = infi f := rfl
 
 lemma supr_range {g : β → α} {f : ι → β} : (⨆b∈range f, g b) = (⨆i, g (f i)) :=
 le_antisymm
@@ -757,27 +756,27 @@ lemma supr_subtype' {p : ι → Prop} {f : ∀ i, p i → α} :
 lemma is_lub_bsupr {s : set β} {f : β → α} : is_lub (f '' s) (⨆ x ∈ s, f x) :=
 by simpa only [range_comp, subtype.range_val, supr_subtype'] using @is_lub_supr α s _ (f ∘ subtype.val)
 
-theorem infi_sigma {p : β → Type w} {f : sigma p → α} : (⨅ x, f x) = (⨅ i (h:p i), f ⟨i, h⟩) :=
+theorem infi_sigma {p : β → Type*} {f : sigma p → α} : (⨅ x, f x) = (⨅ i (h:p i), f ⟨i, h⟩) :=
 le_antisymm
   (le_infi $ assume i, le_infi $ assume : p i, infi_le _ _)
   (le_infi $ assume ⟨i, h⟩, infi_le_of_le i $ infi_le _ _)
 
-theorem supr_sigma {p : β → Type w} {f : sigma p → α} : (⨆ x, f x) = (⨆ i (h:p i), f ⟨i, h⟩) :=
+theorem supr_sigma {p : β → Type*} {f : sigma p → α} : (⨆ x, f x) = (⨆ i (h:p i), f ⟨i, h⟩) :=
 le_antisymm
   (supr_le $ assume ⟨i, h⟩, le_supr_of_le i $ le_supr (λh:p i, f ⟨i, h⟩) _)
   (supr_le $ assume i, supr_le $ assume : p i, le_supr _ _)
 
-theorem infi_prod {γ : Type w} {f : β × γ → α} : (⨅ x, f x) = (⨅ i j, f (i, j)) :=
+theorem infi_prod {γ : Type*} {f : β × γ → α} : (⨅ x, f x) = (⨅ i j, f (i, j)) :=
 le_antisymm
   (le_infi $ assume i, le_infi $ assume j, infi_le _ _)
   (le_infi $ assume ⟨i, h⟩, infi_le_of_le i $ infi_le _ _)
 
-theorem supr_prod {γ : Type w} {f : β × γ → α} : (⨆ x, f x) = (⨆ i j, f (i, j)) :=
+theorem supr_prod {γ : Type*} {f : β × γ → α} : (⨆ x, f x) = (⨆ i j, f (i, j)) :=
 le_antisymm
   (supr_le $ assume ⟨i, h⟩, le_supr_of_le i $ le_supr (λj, f ⟨i, j⟩) _)
   (supr_le $ assume i, supr_le $ assume j, le_supr _ _)
 
-theorem infi_sum {γ : Type w} {f : β ⊕ γ → α} :
+theorem infi_sum {γ : Type*} {f : β ⊕ γ → α} :
   (⨅ x, f x) = (⨅ i, f (sum.inl i)) ⊓ (⨅ j, f (sum.inr j)) :=
 le_antisymm
   (le_inf
@@ -788,7 +787,7 @@ le_antisymm
   | sum.inr j := inf_le_right_of_le $ infi_le _ _
   end)
 
-theorem supr_sum {γ : Type w} {f : β ⊕ γ → α} :
+theorem supr_sum {γ : Type*} {f : β ⊕ γ → α} :
   (⨆ x, f x) = (⨆ i, f (sum.inl i)) ⊔ (⨆ j, f (sum.inr j)) :=
 le_antisymm
   (supr_le $ assume s, match s with
@@ -836,7 +835,7 @@ le_antisymm (assume h i, h _ ⟨i, rfl⟩ ) (assume h p ⟨i, eq⟩, eq ▸ h i)
 lemma supr_Prop_eq {ι : Sort*} {p : ι → Prop} : (⨆i, p i) = (∃i, p i) :=
 le_antisymm (assume ⟨q, ⟨i, (eq : p i = q)⟩, hq⟩, ⟨i, eq.symm ▸ hq⟩) (assume ⟨i, hi⟩, ⟨p i, ⟨i, rfl⟩, hi⟩)
 
-instance pi.complete_lattice {α : Type u} {β : α → Type v} [∀ i, complete_lattice (β i)] :
+instance pi.complete_lattice {α : Type*} {β : α → Type*} [∀ i, complete_lattice (β i)] :
   complete_lattice (Π i, β i) :=
 by { pi_instance;
      { intros, intro,
@@ -845,20 +844,20 @@ by { pi_instance;
        subst b, apply a_1 _ H₀ i, } }
 
 lemma Inf_apply
-  {α : Type u} {β : α → Type v} [∀ i, complete_lattice (β i)] {s : set (Πa, β a)} {a : α} :
+  {α : Type*} {β : α → Type*} [∀ i, complete_lattice (β i)] {s : set (Πa, β a)} {a : α} :
   (Inf s) a = (⨅f∈s, (f : Πa, β a) a) :=
 by rw [← Inf_image]; refl
 
-lemma infi_apply {α : Type u} {β : α → Type v} {ι : Sort*} [∀ i, complete_lattice (β i)]
+lemma infi_apply {α : Type*} {β : α → Type*} {ι : Sort*} [∀ i, complete_lattice (β i)]
   {f : ι → Πa, β a} {a : α} : (⨅i, f i) a = (⨅i, f i a) :=
 by erw [← Inf_range, Inf_apply, infi_range]
 
 lemma Sup_apply
-  {α : Type u} {β : α → Type v} [∀ i, complete_lattice (β i)] {s : set (Πa, β a)} {a : α} :
+  {α : Type*} {β : α → Type*} [∀ i, complete_lattice (β i)] {s : set (Πa, β a)} {a : α} :
   (Sup s) a = (⨆f∈s, (f : Πa, β a) a) :=
 by rw [← Sup_image]; refl
 
-lemma supr_apply {α : Type u} {β : α → Type v} {ι : Sort*} [∀ i, complete_lattice (β i)]
+lemma supr_apply {α : Type*} {β : α → Type*} {ι : Sort*} [∀ i, complete_lattice (β i)]
   {f : ι → Πa, β a} {a : α} : (⨆i, f i) a = (⨆i, f i a) :=
 by erw [← Sup_range, Sup_apply, supr_range]
 

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -29,9 +29,7 @@ set_option old_structure_cmd true
 
 open set
 
-universes u v w
-variables {α : Type u} {β : Type v} {ι : Sort w}
-
+variables {α β ι : Type*}
 
 section
 
@@ -67,16 +65,16 @@ To differentiate the statements from the corresponding statements in (unconditio
 complete lattices, we prefix Inf and Sup by a c everywhere. The same statements should
 hold in both worlds, sometimes with additional assumptions of nonemptiness or
 boundedness.-/
-class conditionally_complete_lattice (α : Type u) extends lattice α, has_Sup α, has_Inf α :=
+class conditionally_complete_lattice (α : Type*) extends lattice α, has_Sup α, has_Inf α :=
 (le_cSup : ∀s a, bdd_above s → a ∈ s → a ≤ Sup s)
 (cSup_le : ∀ s a, set.nonempty s → a ∈ upper_bounds s → Sup s ≤ a)
 (cInf_le : ∀s a, bdd_below s → a ∈ s → Inf s ≤ a)
 (le_cInf : ∀s a, set.nonempty s → a ∈ lower_bounds s → a ≤ Inf s)
 
-class conditionally_complete_linear_order (α : Type u)
+class conditionally_complete_linear_order (α : Type*)
   extends conditionally_complete_lattice α, decidable_linear_order α
 
-class conditionally_complete_linear_order_bot (α : Type u)
+class conditionally_complete_linear_order_bot (α : Type*)
   extends conditionally_complete_lattice α, decidable_linear_order α, order_bot α :=
 (cSup_empty : Sup ∅ = ⊥)
 end prio
@@ -414,7 +412,7 @@ by { rw [nat.Inf_def ⟨m, hm⟩], exact nat.find_min' ⟨m, hm⟩ hm }
 
 /-- This instance is necessary, otherwise the lattice operations would be derived via
 conditionally_complete_linear_order_bot and marked as noncomputable. -/
-instance : lattice ℕ := infer_instance
+instance : lattice ℕ := lattice_of_decidable_linear_order
 
 noncomputable instance : conditionally_complete_linear_order_bot ℕ :=
 { Sup := Sup, Inf := Inf,
@@ -429,7 +427,7 @@ noncomputable instance : conditionally_complete_linear_order_bot ℕ :=
     apply bot_unique (nat.find_min' _ _),
     trivial
   end,
-  .. (infer_instance : order_bot ℕ), .. (infer_instance : lattice ℕ),
+  .. (infer_instance : order_bot ℕ), .. (lattice_of_decidable_linear_order : lattice ℕ),
   .. (infer_instance : decidable_linear_order ℕ) }
 
 end nat

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -373,7 +373,7 @@ conditionally_complete_linear_order_bot.cSup_empty
 
 end conditionally_complete_linear_order_bot
 
-section
+namespace nat
 
 open_locale classical
 
@@ -383,12 +383,34 @@ noncomputable instance : has_Inf ℕ :=
 noncomputable instance : has_Sup ℕ :=
 ⟨λs, if h : ∃n, ∀a∈s, a ≤ n then @nat.find (λn, ∀a∈s, a ≤ n) _ h else 0⟩
 
-lemma Inf_nat_def {s : set ℕ} (h : ∃n, n ∈ s) : Inf s = @nat.find (λn, n ∈ s) _ h :=
+lemma Inf_def {s : set ℕ} (h : s.nonempty) : Inf s = @nat.find (λn, n ∈ s) _ h :=
 dif_pos _
 
-lemma Sup_nat_def {s : set ℕ} (h : ∃n, ∀a∈s, a ≤ n) :
+lemma Sup_def {s : set ℕ} (h : ∃n, ∀a∈s, a ≤ n) :
   Sup s = @nat.find (λn, ∀a∈s, a ≤ n) _ h :=
 dif_pos _
+
+@[simp] lemma Inf_eq_zero {s : set ℕ} : Inf s = 0 ↔ 0 ∈ s ∨ s = ∅ :=
+begin
+  cases eq_empty_or_nonempty s,
+  { subst h, simp only [or_true, eq_self_iff_true, iff_true, Inf, has_Inf.Inf,
+      mem_empty_eq, exists_false, dif_neg, not_false_iff] },
+  { have := ne_empty_iff_nonempty.mpr h,
+    simp only [this, or_false, nat.Inf_def, h, nat.find_eq_zero] }
+end
+
+lemma Inf_mem {s : set ℕ} (h : s.nonempty) : Inf s ∈ s :=
+by { rw [nat.Inf_def h], exact nat.find_spec h }
+
+lemma not_mem_of_lt_Inf {s : set ℕ} {m : ℕ} (hm : m < Inf s) : m ∉ s :=
+begin
+  cases eq_empty_or_nonempty s,
+  { subst h, apply not_mem_empty },
+  { rw [nat.Inf_def h] at hm, exact nat.find_min h hm }
+end
+
+protected lemma Inf_le {s : set ℕ} {m : ℕ} (hm : m ∈ s) : Inf s ≤ m :=
+by { rw [nat.Inf_def ⟨m, hm⟩], exact nat.find_min' ⟨m, hm⟩ hm }
 
 /-- This instance is necessary, otherwise the lattice operations would be derived via
 conditionally_complete_linear_order_bot and marked as noncomputable. -/
@@ -396,21 +418,21 @@ instance : lattice ℕ := infer_instance
 
 noncomputable instance : conditionally_complete_linear_order_bot ℕ :=
 { Sup := Sup, Inf := Inf,
-  le_cSup    := assume s a hb ha, by rw [Sup_nat_def hb]; revert a ha; exact @nat.find_spec _ _ hb,
-  cSup_le    := assume s a hs ha, by rw [Sup_nat_def ⟨a, ha⟩]; exact nat.find_min' _ ha,
+  le_cSup    := assume s a hb ha, by rw [Sup_def hb]; revert a ha; exact @nat.find_spec _ _ hb,
+  cSup_le    := assume s a hs ha, by rw [Sup_def ⟨a, ha⟩]; exact nat.find_min' _ ha,
   le_cInf    := assume s a hs hb,
-    by rw [Inf_nat_def hs]; exact hb (@nat.find_spec (λn, n ∈ s) _ _),
-  cInf_le    := assume s a hb ha, by rw [Inf_nat_def ⟨a, ha⟩]; exact nat.find_min' _ ha,
+    by rw [Inf_def hs]; exact hb (@nat.find_spec (λn, n ∈ s) _ _),
+  cInf_le    := assume s a hb ha, by rw [Inf_def ⟨a, ha⟩]; exact nat.find_min' _ ha,
   cSup_empty :=
   begin
-    simp only [Sup_nat_def, set.mem_empty_eq, forall_const, forall_prop_of_false, not_false_iff, exists_const],
+    simp only [Sup_def, set.mem_empty_eq, forall_const, forall_prop_of_false, not_false_iff, exists_const],
     apply bot_unique (nat.find_min' _ _),
     trivial
   end,
   .. (infer_instance : order_bot ℕ), .. (infer_instance : lattice ℕ),
   .. (infer_instance : decidable_linear_order ℕ) }
 
-end
+end nat
 
 namespace with_top
 open_locale classical

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -29,7 +29,7 @@ set_option old_structure_cmd true
 
 open set
 
-variables {α β ι : Type*}
+variables {α β : Type*} {ι : Sort*}
 
 section
 


### PR DESCRIPTION
PR 2/5 to put the Haar measure in mathlib. This PR: results about lattices and lattice operations on `nat`.
add some simp lemmas for `nat.find` (simplifying a proof in `sum_four_squares`)
rename `finset.sup_val` to `finset.sup_def` (it was unused). In PR 3 I will add a new declaration `finset.sup_val`
`Inf_nat_def` and `Sup_nat_def` renamed to `nat.Inf_def` and `nat.Sup_def`, and use `set.nonempty` in statement (they were unused outside that file)

---
<!-- put comments you want to keep out of the PR commit here -->
