### PR TITLE
[Merged by Bors] - chore(category_theory/pempty): use discrete pempty instead of a special pempty category

### DIFF
--- a/src/category_theory/limits/shapes/terminal.lean
+++ b/src/category_theory/limits/shapes/terminal.lean
@@ -18,26 +18,28 @@ namespace category_theory.limits
 
 variables (C : Type u) [category.{v} C]
 
-/-- A category has a terminal object if it has a limit over the empty diagram. -/
--- Use `has_terminal_of_unique` to construct instances.
+/--
+A category has a terminal object if it has a limit over the empty diagram.
+Use `has_terminal_of_unique` to construct instances.
+-/
 class has_terminal :=
-(has_limits_of_shape : has_limits_of_shape.{v} pempty C)
-/-- A category has an initial object if it has a colimit over the empty diagram. -/
--- Use `has_initial_of_unique` to construct instances.
+(has_limits_of_shape : has_limits_of_shape.{v} (discrete pempty) C)
+/--
+A category has an initial object if it has a colimit over the empty diagram.
+Use `has_initial_of_unique` to construct instances.
+-/
 class has_initial :=
-(has_colimits_of_shape : has_colimits_of_shape.{v} pempty C)
+(has_colimits_of_shape : has_colimits_of_shape.{v} (discrete pempty) C)
 
 attribute [instance] has_terminal.has_limits_of_shape has_initial.has_colimits_of_shape
 
 @[priority 100] -- see Note [lower instance priority]
 instance [has_finite_products.{v} C] : has_terminal.{v} C :=
-{ has_limits_of_shape :=
-  { has_limit := λ F,
-      has_limit_of_equivalence_comp ((functor.empty.{v} (discrete pempty.{v+1})).as_equivalence.symm) } }
+{ has_limits_of_shape := by apply_instance }
+
 @[priority 100] -- see Note [lower instance priority]
 instance [has_finite_coproducts.{v} C] : has_initial.{v} C :=
-{ has_colimits_of_shape :=
-  { has_colimit := λ F, has_colimit_of_equivalence_comp ((functor.empty (discrete pempty)).as_equivalence.symm) } }
+{ has_colimits_of_shape := by apply_instance }
 
 abbreviation terminal [has_terminal.{v} C] : C := limit (functor.empty C)
 abbreviation initial [has_initial.{v} C] : C := colimit (functor.empty C)

--- a/src/category_theory/limits/shapes/zero.lean
+++ b/src/category_theory/limits/shapes/zero.lean
@@ -7,6 +7,7 @@ import category_theory.limits.shapes.binary_products
 import category_theory.limits.shapes.images
 import category_theory.epi_mono
 import category_theory.punit
+import category_theory.discrete_category
 
 /-!
 # Zero morphisms and zero objects
@@ -45,7 +46,7 @@ attribute [simp] has_zero_morphisms.comp_zero
 restate_axiom has_zero_morphisms.zero_comp'
 attribute [simp, reassoc] has_zero_morphisms.zero_comp
 
-instance has_zero_morphisms_pempty : has_zero_morphisms.{v} pempty.{v+1} :=
+instance has_zero_morphisms_pempty : has_zero_morphisms.{v} (discrete pempty.{v+1}) :=
 { has_zero := by tidy }
 
 instance has_zero_morphisms_punit : has_zero_morphisms.{v} punit.{v+1} :=

--- a/src/category_theory/pempty.lean
+++ b/src/category_theory/pempty.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2018 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Scott Morrison
+Authors: Scott Morrison, Bhavik Mehta.
 -/
 import category_theory.discrete_category
 
@@ -14,29 +14,32 @@ Defines a category structure on `pempty`, and the unique functor `pempty ⥤ C` 
 universes v u w -- declare the `v`'s first; see `category_theory.category` for an explanation
 
 namespace category_theory
-
-/-- The empty category -/
-instance pempty_category : small_category.{w} pempty.{w+1} :=
-{ hom  := λ X Y, pempty,
-  id   := by obviously,
-  comp := by obviously }
-
 namespace functor
+
 variables (C : Type u) [category.{v} C]
 
-/-- The unique functor from the empty category to any target category. -/
-def empty : pempty.{v+1} ⥤ C := by tidy
+/-- The canonical functor out of the empty category. -/
+def empty : discrete pempty.{v+1} ⥤ C := discrete.functor pempty.elim
 
-/-- The natural isomorphism between any two functors out of the empty category. -/
-@[simps]
-def empty_ext (F G : pempty.{v+1} ⥤ C) : F ≅ G :=
-{ hom := { app := λ j, by cases j },
-  inv := { app := λ j, by cases j } }
+variable {C}
+/-- Any two functors out of the empty category are isomorphic. -/
+def empty_ext (F G : discrete pempty.{v+1} ⥤ C) : F ≅ G :=
+discrete.nat_iso (λ x, pempty.elim x)
+
+/--
+Any functor out of the empty category is isomorphic to the canonical functor from the empty
+category.
+-/
+def unique_from_empty (F : discrete pempty.{v+1} ⥤ C) : F ≅ empty C :=
+empty_ext _ _
+
+/--
+Any two functors out of the empty category are *equal*. You probably want to use
+`empty_ext` instead of this.
+-/
+lemma empty_ext' (F G : discrete pempty.{v+1} ⥤ C) : F = G :=
+functor.ext (λ x, x.elim) (λ x _ _, x.elim)
 
 end functor
-
-/-- The category `pempty` is equivalent to the category `discrete pempty`. -/
-instance pempty_equiv_discrete_pempty : is_equivalence (functor.empty.{v} (discrete pempty.{v+1})) :=
-by obviously
 
 end category_theory


### PR DESCRIPTION
Use `discrete pempty` instead of a specialised `pempty` category.

Motivation: Since we have a good API for `discrete` categories, there doesn't seem to be much point in defining a specialised `pempty` category with an equivalence, instead we might as well just use `discrete pempty`. 