### PR TITLE
[Merged by Bors] -  feat(topology): preliminaries for Haar measure

### DIFF
--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -77,6 +77,13 @@ lemma comp_sup_eq_sup_comp_of_is_total [is_total α (≤)] {γ : Type} [semilatt
   (g : α → γ) (mono_g : monotone g) (bot : g ⊥ = ⊥) : g (s.sup f) = s.sup (g ∘ f) :=
 comp_sup_eq_sup_comp g mono_g.map_sup bot
 
+/-- The first component of a sup in a subtype is the sup if first components. -/
+lemma sup_coe {P : α → Prop}
+  {Pbot : P ⊥} {Psup : ∀{{x y}}, P x → P y → P (x ⊔ y)}
+  (t : finset β) (f : β → {x : α // P x}) :
+  (@sup _ _ (subtype.semilattice_sup_bot Pbot Psup) t f : α) = t.sup (λ x, f x) :=
+by { classical, rw [comp_sup_eq_sup_comp coe]; intros; refl }
+
 theorem subset_range_sup_succ (s : finset ℕ) : s ⊆ range (s.sup id).succ :=
 λ n hn, mem_range.2 $ nat.lt_succ_of_le $ le_sup hn
 
@@ -99,7 +106,7 @@ def inf (s : finset β) (f : β → α) : α := s.fold (⊓) ⊤ f
 
 variables {s s₁ s₂ : finset β} {f : β → α}
 
-lemma inf_val : s.inf f = (s.1.map f).inf := rfl
+lemma inf_def : s.inf f = (s.1.map f).inf := rfl
 
 @[simp] lemma inf_empty : (∅ : finset β).inf f = ⊤ :=
 fold_empty
@@ -142,6 +149,13 @@ lemma comp_inf_eq_inf_comp [semilattice_inf_top γ] {s : finset β}
 lemma comp_inf_eq_inf_comp_of_is_total [h : is_total α (≤)] {γ : Type} [semilattice_inf_top γ]
   (g : α → γ) (mono_g : monotone g) (top : g ⊤ = ⊤) : g (s.inf f) = s.inf (g ∘ f) :=
 comp_inf_eq_inf_comp g mono_g.map_inf top
+
+/-- The first component of a sup in a subtype is the sup if first components. -/
+lemma inf_coe {P : α → Prop}
+  {Ptop : P ⊤} {Pinf : ∀{{x y}}, P x → P y → P (x ⊓ y)}
+  (t : finset β) (f : β → {x : α // P x}) :
+  (@inf _ _ (subtype.semilattice_inf_top Ptop Pinf) t f : α) = t.inf (λ x, f x) :=
+by { classical, rw [comp_inf_eq_inf_comp coe]; intros; refl }
 
 end inf
 

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -150,7 +150,7 @@ lemma comp_inf_eq_inf_comp_of_is_total [h : is_total α (≤)] {γ : Type} [semi
   (g : α → γ) (mono_g : monotone g) (top : g ⊤ = ⊤) : g (s.inf f) = s.inf (g ∘ f) :=
 comp_inf_eq_inf_comp g mono_g.map_inf top
 
-/-- The first component of a sup in a subtype is the sup if first components. -/
+/-- Computating `inf` in a subtype (closed under `inf`) is the same as computing it in `α`. -/
 lemma inf_coe {P : α → Prop}
   {Ptop : P ⊤} {Pinf : ∀{{x y}}, P x → P y → P (x ⊓ y)}
   (t : finset β) (f : β → {x : α // P x}) :

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -77,7 +77,7 @@ lemma comp_sup_eq_sup_comp_of_is_total [is_total α (≤)] {γ : Type} [semilatt
   (g : α → γ) (mono_g : monotone g) (bot : g ⊥ = ⊥) : g (s.sup f) = s.sup (g ∘ f) :=
 comp_sup_eq_sup_comp g mono_g.map_sup bot
 
-/-- The first component of a sup in a subtype is the sup if first components. -/
+/-- Computating `sup` in a subtype (closed under `sup`) is the same as computing it in `α`. -/
 lemma sup_coe {P : α → Prop}
   {Pbot : P ⊥} {Psup : ∀{{x y}}, P x → P y → P (x ⊔ y)}
   (t : finset β) (f : β → {x : α // P x}) :

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -197,6 +197,9 @@ by simp [(≠), mul_eq_top] {contextual := tt}
 lemma mul_lt_top {a b : ennreal}  : a < ⊤ → b < ⊤ → a * b < ⊤ :=
 by simpa only [ennreal.lt_top_iff_ne_top] using mul_ne_top
 
+@[simp] lemma mul_pos {a b : ennreal} : 0 < a * b ↔ 0 < a ∧ 0 < b :=
+by simp only [zero_lt_iff_ne_zero, ne.def, mul_eq_zero, not_or_distrib]
+
 lemma pow_eq_top : ∀ n:ℕ, a^n=∞ → a=∞
 | 0 := by simp
 | (n+1) := λ o, (mul_eq_top.1 o).elim (λ h, pow_eq_top n h.2) and.left
@@ -753,6 +756,12 @@ inv_zero ▸ inv_eq_inv
 
 lemma inv_ne_top : a⁻¹ ≠ ∞ ↔ a ≠ 0 := by simp
 
+lemma inv_lt_top {x : ennreal} : x⁻¹ < ⊤ ↔ 0 < x :=
+by { simp only [lt_top_iff_ne_top, inv_ne_top, zero_lt_iff_ne_zero] }
+
+lemma div_lt_top {x y : ennreal} (h1 : x < ⊤) (h2 : 0 < y) : x / y < ⊤ :=
+mul_lt_top h1 (inv_lt_top.mpr h2)
+
 @[simp] lemma inv_eq_zero : a⁻¹ = 0 ↔ a = ∞ :=
 inv_top ▸ inv_eq_inv
 
@@ -1162,6 +1171,23 @@ finset.induction_on s (by simp) $ assume a s ha ih,
     ⟨k, add_le_add (hk a (finset.mem_insert_self _ _)).left $ finset.sum_le_sum $
       assume a ha, (hk _ $ finset.mem_insert_of_mem ha).right⟩,
   by simp [ha, ih.symm, infi_add_infi this]
+
+
+lemma infi_mul {ι} [nonempty ι] {f : ι → ennreal} {x : ennreal} (h : x ≠ ⊤) :
+  infi f * x = ⨅i, f i * x :=
+begin
+  by_cases h2 : x = 0, simp only [h2, mul_zero, infi_const],
+  refine le_antisymm
+    (le_infi $ λ i, mul_right_mono $ infi_le _ _)
+    ((div_le_iff_le_mul (or.inl h2) $ or.inl h).mp $ le_infi $
+      λ i, (div_le_iff_le_mul (or.inl h2) $ or.inl h).mpr $ infi_le _ _)
+end
+
+lemma mul_infi {ι} [nonempty ι] {f : ι → ennreal} {x : ennreal} (h : x ≠ ⊤) :
+  x * infi f = ⨅i, x * f i :=
+by { rw [mul_comm, infi_mul h], simp only [mul_comm], assumption }
+
+/-! `supr_mul`, `mul_supr` and variants are in `topology.instances.ennreal`. -/
 
 end infi
 

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -756,7 +756,7 @@ inv_zero ▸ inv_eq_inv
 
 lemma inv_ne_top : a⁻¹ ≠ ∞ ↔ a ≠ 0 := by simp
 
-lemma inv_lt_top {x : ennreal} : x⁻¹ < ⊤ ↔ 0 < x :=
+@[simp] lemma inv_lt_top {x : ennreal} : x⁻¹ < ⊤ ↔ 0 < x :=
 by { simp only [lt_top_iff_ne_top, inv_ne_top, zero_lt_iff_ne_zero] }
 
 lemma div_lt_top {x y : ennreal} (h1 : x < ⊤) (h2 : 0 < y) : x / y < ⊤ :=

--- a/src/order/bounded_lattice.lean
+++ b/src/order/bounded_lattice.lean
@@ -774,6 +774,13 @@ protected def semilattice_inf_bot [semilattice_inf_bot α] {P : α → Prop}
   bot_le := λ x, @bot_le α _ x,
   ..subtype.semilattice_inf Pinf }
 
+/-- A subtype forms a `⊓`-`⊤`-semilattice if `⊤` and `⊓` preserve the property. -/
+protected def semilattice_inf_top [semilattice_inf_top α] {P : α → Prop}
+  (Ptop : P ⊤) (Pinf : ∀{{x y}}, P x → P y → P (x ⊓ y)) : semilattice_inf_top {x : α // P x} :=
+{ top := ⟨⊤, Ptop⟩,
+  le_top := λ x, @le_top α _ x,
+  ..subtype.semilattice_inf Pinf }
+
 /-- A subtype forms a lattice if `⊔` and `⊓` preserve the property. -/
 protected def lattice [lattice α] {P : α → Prop}
   (Psup : ∀⦃x y⦄, P x → P y → P (x ⊔ y)) (Pinf : ∀⦃x y⦄, P x → P y → P (x ⊓ y)) :

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -403,6 +403,59 @@ lemma topological_group.t2_space [t1_space α] : t2_space α := regular_space.t2
 end
 
 section
+
+/-! Some results about an open set containing the product of two sets in a topological group. -/
+
+variables [topological_space α] [group α] [topological_group α]
+/-- Given a open neighborhood `U` of `1` there is a open neighborhood `V` of `1`
+  such that `VV ⊆ U`. -/
+lemma one_open_separated_mul {U : set α} (h1U : is_open U) (h2U : (1 : α) ∈ U) :
+  ∃ V : set α, is_open V ∧ (1 : α) ∈ V ∧ V * V ⊆ U :=
+begin
+  rcases exists_nhds_square (continuous_mul U h1U) (by simp only [mem_preimage, one_mul, h2U] :
+    ((1 : α), (1 : α)) ∈ (λ p : α × α, p.1 * p.2) ⁻¹' U) with ⟨V, h1V, h2V, h3V⟩,
+  refine ⟨V, h1V, h2V, _⟩,
+  rwa [← image_subset_iff, image_mul_prod] at h3V
+end
+
+/-- Given a compact set `K` inside an open set `U`, there is a open neighborhood `V` of `1`
+  such that `KV ⊆ U`. -/
+lemma compact_open_separated_mul {K U : set α} (hK : compact K) (hU : is_open U) (hKU : K ⊆ U) :
+  ∃ V : set α, is_open V ∧ (1 : α) ∈ V ∧ K * V ⊆ U :=
+begin
+  let W : α → set α := λ x, (λ y, x * y) ⁻¹' U,
+  have h1W : ∀ x, is_open (W x) := λ x, continuous_mul_left x U hU,
+  have h2W : ∀ x ∈ K, (1 : α) ∈ W x := λ x hx, by simp only [mem_preimage, mul_one, hKU hx],
+  choose V hV using λ x : K, one_open_separated_mul (h1W x) (h2W x.1 x.2),
+  let X : K → set α := λ x, (λ y, (x : α)⁻¹ * y) ⁻¹' (V x),
+  cases hK.elim_finite_subcover X (λ x, continuous_mul_left x⁻¹ (V x) (hV x).1) _ with t ht, swap,
+  { intros x hx, rw [mem_Union], use ⟨x, hx⟩, rw [mem_preimage], convert (hV _).2.1,
+    simp only [mul_left_inv, subtype.coe_mk] },
+  refine ⟨⋂ x ∈ t, V x, is_open_bInter (finite_mem_finset _) (λ x hx, (hV x).1), _, _⟩,
+  { simp only [mem_Inter], intros x hx, exact (hV x).2.1 },
+  rintro _ ⟨x, y, hx, hy, rfl⟩, simp only [mem_Inter] at hy,
+  have := ht hx, simp only [mem_Union, mem_preimage] at this, rcases this with ⟨z, h1z, h2z⟩,
+  have : (z : α)⁻¹ * x * y ∈ W z := (hV z).2.2 (mul_mem_mul h2z (hy z h1z)),
+  rw [mem_preimage] at this, convert this using 1, simp only [mul_assoc, mul_inv_cancel_left]
+end
+
+/-- A compact set is covered by finitely many left translates of a set with non-empty interior. -/
+lemma compact_covered_by_left_translates {K V : set α} (hK : compact K)
+  (hV : (interior V).nonempty) : ∃ t : finset α, K ⊆ ⋃ g ∈ t, (λ h, g * h) ⁻¹' V :=
+begin
+  cases hV with g₀ hg₀,
+  rcases compact.elim_finite_subcover hK (λ x : α, interior $ (λ h, x * h) ⁻¹' V) _ _ with ⟨t, ht⟩,
+  { refine ⟨t, subset.trans ht _⟩,
+    apply Union_subset_Union, intro g, apply Union_subset_Union, intro hg, apply interior_subset },
+  { intro g, apply is_open_interior },
+  { intros g hg, rw [mem_Union], use g₀ * g⁻¹,
+    apply preimage_interior_subset_interior_preimage, exact continuous_const.mul continuous_id,
+    rwa [mem_preimage, inv_mul_cancel_right] }
+end
+
+end
+
+section
 variables [topological_space α] [comm_group α] [topological_group α]
 
 @[to_additive]

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -409,6 +409,8 @@ section
 variables [topological_space α] [group α] [topological_group α]
 /-- Given a open neighborhood `U` of `1` there is a open neighborhood `V` of `1`
   such that `VV ⊆ U`. -/
+@[to_additive "Given a open neighborhood `U` of `0` there is a open neighborhood `V` of `0`
+  such that `V + V ⊆ U`."]
 lemma one_open_separated_mul {U : set α} (h1U : is_open U) (h2U : (1 : α) ∈ U) :
   ∃ V : set α, is_open V ∧ (1 : α) ∈ V ∧ V * V ⊆ U :=
 begin
@@ -420,6 +422,8 @@ end
 
 /-- Given a compact set `K` inside an open set `U`, there is a open neighborhood `V` of `1`
   such that `KV ⊆ U`. -/
+@[to_additive "Given a compact set `K` inside an open set `U`, there is a open neighborhood `V` of `0`
+  such that `K + V ⊆ U`."]
 lemma compact_open_separated_mul {K U : set α} (hK : compact K) (hU : is_open U) (hKU : K ⊆ U) :
   ∃ V : set α, is_open V ∧ (1 : α) ∈ V ∧ K * V ⊆ U :=
 begin
@@ -439,8 +443,11 @@ begin
   rw [mem_preimage] at this, convert this using 1, simp only [mul_assoc, mul_inv_cancel_left]
 end
 
-/-- A compact set is covered by finitely many left translates of a set with non-empty interior. -/
-lemma compact_covered_by_left_translates {K V : set α} (hK : compact K)
+/-- A compact set is covered by finitely many left multiplicative translates of a set
+  with non-empty interior. -/
+@[to_additive "A compact set is covered by finitely many left additive translates of a set
+  with non-empty interior."]
+lemma compact_covered_by_mul_left_translates {K V : set α} (hK : compact K)
   (hV : (interior V).nonempty) : ∃ t : finset α, K ⊆ ⋃ g ∈ t, (λ h, g * h) ⁻¹' V :=
 begin
   cases hV with g₀ hg₀,

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -339,6 +339,10 @@ tsum_eq_has_sum $ has_sum_sum_of_ne_finset_zero hf
 lemma tsum_fintype [fintype β] (f : β → α) : (∑'b, f b) = ∑ b, f b :=
 tsum_eq_has_sum $ has_sum_fintype f
 
+lemma sum_eq_tsum_subtype {f : β → α} {s : finset β} :
+  s.sum f = (∑'x : {x // x ∈ s}, f x.1) :=
+by { rw [tsum_fintype, ← finset.sum_attach], refl }
+
 lemma tsum_eq_single {f : β → α} (b : β) (hf : ∀b' ≠ b, f b' = 0)  :
   (∑'b, f b) = f b :=
 tsum_eq_has_sum $ has_sum_single b hf

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -339,9 +339,9 @@ tsum_eq_has_sum $ has_sum_sum_of_ne_finset_zero hf
 lemma tsum_fintype [fintype β] (f : β → α) : (∑'b, f b) = ∑ b, f b :=
 tsum_eq_has_sum $ has_sum_fintype f
 
-lemma sum_eq_tsum_subtype {f : β → α} {s : finset β} :
-  s.sum f = (∑'x : {x // x ∈ s}, f x.1) :=
-by { rw [tsum_fintype, ← finset.sum_attach], refl }
+@[simp] lemma tsum_subtype_eq_sum {f : β → α} {s : finset β} :
+  (∑'x : {x // x ∈ s}, f x.1) = ∑ x in s, f x :=
+by { rw [tsum_fintype], conv_rhs { rw ← finset.sum_attach }, refl }
 
 lemma tsum_eq_single {f : β → α} (b : β) (hf : ∀b' ≠ b, f b' = 0)  :
   (∑'b, f b) = f b :=

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -340,7 +340,7 @@ lemma tsum_fintype [fintype β] (f : β → α) : (∑'b, f b) = ∑ b, f b :=
 tsum_eq_has_sum $ has_sum_fintype f
 
 @[simp] lemma tsum_subtype_eq_sum {f : β → α} {s : finset β} :
-  (∑'x : {x // x ∈ s}, f x.1) = ∑ x in s, f x :=
+  (∑'x : {x // x ∈ s}, f x) = ∑ x in s, f x :=
 by { rw [tsum_fintype], conv_rhs { rw ← finset.sum_attach }, refl }
 
 lemma tsum_eq_single {f : β → α} (b : β) (hf : ∀b' ≠ b, f b' = 0)  :

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -822,6 +822,10 @@ open_locale topological_space
   of every open set is open. -/
 def continuous (f : α → β) := ∀s, is_open s → is_open (f ⁻¹' s)
 
+lemma is_open.preimage {f : α → β} (hf : continuous f) {s : set β} (h : is_open s) :
+  is_open (f ⁻¹' s) :=
+hf s h
+
 /-- A function between topological spaces is continuous at a point `x₀`
 if `f x` tends to `f x₀` when `x` tends to `x₀`. -/
 def continuous_at (f : α → β) (x : α) := tendsto f (𝓝 x) (𝓝 (f x))
@@ -890,6 +894,10 @@ lemma continuous_iff_is_closed {f : α → β} :
   continuous f ↔ (∀s, is_closed s → is_closed (f ⁻¹' s)) :=
 ⟨assume hf s hs, hf sᶜ hs,
   assume hf s, by rw [←is_closed_compl_iff, ←is_closed_compl_iff]; exact hf _⟩
+
+lemma is_closed.preimage {f : α → β} (hf : continuous f) {s : set β} (h : is_closed s) :
+  is_closed (f ⁻¹' s) :=
+continuous_iff_is_closed.mp hf s h
 
 lemma continuous_at_iff_ultrafilter {f : α → β} (x) : continuous_at f x ↔
   ∀ g, is_ultrafilter g → g ≤ 𝓝 x → g.map f ≤ 𝓝 (f x) :=

--- a/src/topology/compacts.lean
+++ b/src/topology/compacts.lean
@@ -104,6 +104,4 @@ set.inclusion $ λ s hs, hs.2.is_closed
 
 end nonempty_compacts
 
-
-
 end topological_space

--- a/src/topology/compacts.lean
+++ b/src/topology/compacts.lean
@@ -1,0 +1,109 @@
+/-
+Copyright (c) 2020 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Floris van Doorn
+-/
+import topology.homeomorph
+/-!
+# Compact sets
+
+## Summary
+
+We define the subtype of compact sets in a topological space.
+
+## Main Definitions
+
+- `closeds α` is the type of closed subsets of a topological space `α`.
+- `compacts α` is the type of compact subsets of a topological space `α`.
+- `nonempty_compacts α` is the type of non-empty compact subsets.
+- `positive_compacts α` is the type of compact subsets with non-empty interior.
+-/
+open set
+
+
+variables (α : Type*) {β : Type*} [topological_space α] [topological_space β]
+namespace topological_space
+
+/-- The type of closed subsets of a topological space. -/
+def closeds := {s : set α // is_closed s}
+
+/-- The compact sets of a topological space. See also `nonempty_compacts`. -/
+def compacts : Type* := { s : set α // compact s }
+
+/-- The type of non-empty compact subsets of a topological space. The
+non-emptiness will be useful in metric spaces, as we will be able to put
+a distance (and not merely an edistance) on this space. -/
+def nonempty_compacts := {s : set α // s.nonempty ∧ compact s}
+
+/-- The compact sets with nonempty interior of a topological space. See also `compacts` and
+  `nonempty_compacts`. -/
+@[nolint has_inhabited_instance]
+def positive_compacts: Type* := { s : set α // compact s ∧ (interior s).nonempty  }
+
+variables {α}
+
+namespace compacts
+
+instance : semilattice_sup_bot (compacts α) :=
+subtype.semilattice_sup_bot compact_empty (λ K₁ K₂, compact.union)
+
+instance [t2_space α]: semilattice_inf_bot (compacts α) :=
+subtype.semilattice_inf_bot compact_empty (λ K₁ K₂, compact.inter)
+
+instance [t2_space α] : lattice (compacts α) :=
+subtype.lattice (λ K₁ K₂, compact.union) (λ K₁ K₂, compact.inter)
+
+@[simp] lemma bot_val : (⊥ : compacts α).1 = ∅ := rfl
+
+@[simp] lemma sup_val {K₁ K₂ : compacts α} : (K₁ ⊔ K₂).1 = K₁.1 ∪ K₂.1 := rfl
+
+@[ext] protected lemma ext {K₁ K₂ : compacts α} (h : K₁.1 = K₂.1) : K₁ = K₂ :=
+subtype.eq h
+
+@[simp] lemma finset_sup_val {β} {K : β → compacts α} {s : finset β} :
+  (s.sup K).1 = s.sup (λ x, (K x).1) :=
+finset.sup_coe _ _
+
+instance : inhabited (compacts α) := ⟨⊥⟩
+
+/-- The image of a compact set under a continuous function. -/
+protected def map (f : α → β) (hf : continuous f) (K : compacts α) : compacts β :=
+⟨f '' K.1, K.2.image hf⟩
+
+@[simp] lemma map_val {f : α → β} (hf : continuous f) (K : compacts α) :
+  (K.map f hf).1 = f '' K.1 := rfl
+
+/-- A homeomorphism induces an equivalence on compact sets, by taking the image. -/
+@[simp] protected def equiv (f : α ≃ₜ β) : compacts α ≃ compacts β :=
+{ to_fun := compacts.map f f.continuous,
+  inv_fun := compacts.map _ f.symm.continuous,
+  left_inv := by { intro K, ext1, simp only [map_val, ← image_comp, f.symm_comp_self, image_id] },
+  right_inv := by { intro K, ext1,
+    simp only [map_val, ← image_comp, f.self_comp_symm, image_id] } }
+
+/-- The image of a compact set under a homeomorphism can also be expressed as a preimage. -/
+lemma equiv_to_fun_val (f : α ≃ₜ β) (K : compacts α) :
+  (compacts.equiv f K).1 = f.symm ⁻¹' K.1 :=
+congr_fun (image_eq_preimage_of_inverse f.left_inv f.right_inv) K.1
+
+end compacts
+
+section nonempty_compacts
+open topological_space set
+variable {α}
+
+instance nonempty_compacts.to_compact_space {p : nonempty_compacts α} : compact_space p.val :=
+⟨compact_iff_compact_univ.1 p.property.2⟩
+
+instance nonempty_compacts.to_nonempty {p : nonempty_compacts α} : nonempty p.val :=
+p.property.1.to_subtype
+
+/-- Associate to a nonempty compact subset the corresponding closed subset -/
+def nonempty_compacts.to_closeds [t2_space α] : nonempty_compacts α → closeds α :=
+set.inclusion $ λ s hs, hs.2.is_closed
+
+end nonempty_compacts
+
+
+
+end topological_space

--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -242,6 +242,16 @@ begin
       ⟨u, ⟨u, subset.refl u, uo, au⟩, v, ⟨v, subset.refl v, vo, bv⟩, h⟩⟩)
 end
 
+/-- Given an open neighborhood `s` of `(x, x)`, then `(x, x)` has a square open neighborhood
+  that is a subset of `s`. -/
+lemma exists_nhds_square {s : set (α × α)} (hs : is_open s) {x : α} (hx : (x, x) ∈ s) :
+  ∃U, is_open U ∧ x ∈ U ∧ set.prod U U ⊆ s :=
+begin
+  rcases is_open_prod_iff.mp hs x x hx with ⟨u, v, hu, hv, h1x, h2x, h2s⟩,
+  refine ⟨u ∩ v, is_open_inter hu hv, ⟨h1x, h2x⟩, subset.trans _ h2s⟩,
+  simp only [prod_subset_prod_iff, inter_subset_left, true_or, inter_subset_right, and_self],
+end
+
 /-- The first projection in a product of topological spaces sends open sets to open sets. -/
 lemma is_open_map_fst : is_open_map (@prod.fst α β) :=
 begin

--- a/src/topology/homeomorph.lean
+++ b/src/topology/homeomorph.lean
@@ -103,6 +103,12 @@ begin
   exact continuous_iff_is_closed.1 (h.symm.continuous) _
 end
 
+@[simp] lemma is_open_preimage (h : α ≃ₜ β) {s : set β} : is_open (h ⁻¹' s) ↔ is_open s :=
+begin
+  refine ⟨λ hs, _, h.continuous_to_fun s⟩,
+  rw [← (image_preimage_eq h.to_equiv.surjective : _ = s)], exact h.is_open_map _ hs
+end
+
 /-- If an bijective map `e : α ≃ β` is continuous and open, then it is a homeomorphism. -/
 def homeomorph_of_continuous_open (e : α ≃ β) (h₁ : continuous e) (h₂ : is_open_map e) :
   α ≃ₜ β :=

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -534,6 +534,9 @@ tsum_add ennreal.summable ennreal.summable
 protected lemma tsum_le_tsum (h : ∀a, f a ≤ g a) : (∑'a, f a) ≤ (∑'a, g a) :=
 tsum_le_tsum h ennreal.summable ennreal.summable
 
+protected lemma sum_le_tsum {f : α → ennreal} (s : finset α) : s.sum f ≤ tsum f :=
+sum_le_tsum s (λ x hx, zero_le _) ennreal.summable
+
 protected lemma tsum_eq_supr_nat {f : ℕ → ennreal} :
   (∑'i:ℕ, f i) = (⨆i:ℕ, ∑ a in finset.range i, f a) :=
 ennreal.tsum_eq_supr_sum' _ finset.exists_nat_subset_range

--- a/src/topology/metric_space/isometry.lean
+++ b/src/topology/metric_space/isometry.lean
@@ -5,7 +5,7 @@ Isometries of emetric and metric spaces
 Authors: Sébastien Gouëzel
 -/
 import topology.bounded_continuous_function
-import topology.opens
+import topology.compacts
 
 /-!
 # Isometries

--- a/src/topology/opens.lean
+++ b/src/topology/opens.lean
@@ -35,19 +35,22 @@ instance : has_coe (opens α) (set α) := { coe := subtype.val }
 lemma val_eq_coe (U : opens α) : U.1 = ↑U := rfl
 
 instance : has_subset (opens α) :=
-{ subset := λ U V, U.val ⊆ V.val }
+{ subset := λ U V, (U : set α) ⊆ V }
 
 instance : has_mem α (opens α) :=
-{ mem := λ a U, a ∈ U.val }
+{ mem := λ a U, a ∈ (U : set α) }
 
-@[ext] lemma ext {U V : opens α} (h : (U : set α) = V) : U = V := subtype.ext_iff_val.mpr h
+@[ext] lemma ext {U V : opens α} (h : (U : set α) = V) : U = V := subtype.ext_iff.mpr h
+
+@[ext] lemma ext_iff {U V : opens α} : (U : set α) = V ↔ U = V :=
+⟨opens.ext, congr_arg coe⟩
 
 instance : partial_order (opens α) := subtype.partial_order _
 
 /-- The interior of a set, as an element of `opens`. -/
 def interior (s : set α) : opens α := ⟨interior s, is_open_interior⟩
 
-lemma gc : galois_connection (subtype.val : opens α → set α) interior :=
+lemma gc : galois_connection (coe : opens α → set α) interior :=
 λ U s, ⟨λ h, interior_maximal h U.property, λ h, le_trans h interior_subset⟩
 
 /-- The galois insertion between sets and opens, but ordered by reverse inclusion. -/
@@ -61,14 +64,12 @@ def gi : @galois_insertion (order_dual (set α)) (order_dual (opens α)) _ _ int
 
 instance : complete_lattice (opens α) :=
 complete_lattice.copy
-(@order_dual.complete_lattice _
-  (@galois_insertion.lift_complete_lattice
-    (order_dual (set α)) (order_dual (opens α)) interior (subtype.val : opens α → set α) _ _ gi))
-/- le  -/ (λ U V, U.1 ⊆ V.1) rfl
+  (@order_dual.complete_lattice _ (galois_insertion.lift_complete_lattice (@gi α _)))
+/- le  -/ (λ U V, U ⊆ V) rfl
 /- top -/ ⟨set.univ, is_open_univ⟩ (subtype.ext_iff_val.mpr interior_univ.symm)
 /- bot -/ ⟨∅, is_open_empty⟩ rfl
-/- sup -/ (λ U V, ⟨U.1 ∪ V.1, is_open_union U.2 V.2⟩) rfl
-/- inf -/ (λ U V, ⟨U.1 ∩ V.1, is_open_inter U.2 V.2⟩)
+/- sup -/ (λ U V, ⟨↑U ∪ ↑V, is_open_union U.2 V.2⟩) rfl
+/- inf -/ (λ U V, ⟨↑U ∩ ↑V, is_open_inter U.2 V.2⟩)
 begin
   funext,
   apply subtype.ext_iff_val.mpr,
@@ -76,7 +77,7 @@ begin
   apply interior_eq_of_open,
   exact (is_open_inter U.2 V.2),
 end
-/- Sup -/ (λ Us, ⟨⋃₀ (subtype.val '' Us), is_open_sUnion $ λ U hU,
+/- Sup -/ (λ Us, ⟨⋃₀ (coe '' Us), is_open_sUnion $ λ U hU,
 by { rcases hU with ⟨⟨V, hV⟩, h, h'⟩, dsimp at h', subst h', exact hV}⟩)
 begin
   funext,
@@ -104,7 +105,7 @@ end
 lemma supr_def {ι} (s : ι → opens α) : (⨆ i, s i) = ⟨⋃ i, s i, is_open_Union $ λ i, (s i).2⟩ :=
 by { ext, simp only [supr, opens.Sup_s, sUnion_image, bUnion_range], refl }
 
-def is_basis (B : set (opens α)) : Prop := is_topological_basis (subtype.val '' B)
+def is_basis (B : set (opens α)) : Prop := is_topological_basis ((coe : _ → set α) '' B)
 
 lemma is_basis_iff_nbhd {B : set (opens α)} :
   is_basis B ↔ ∀ {U : opens α} {x}, x ∈ U → ∃ U' ∈ B, x ∈ U' ∧ U' ⊆ U :=
@@ -170,9 +171,9 @@ lemma comap_mono {f : α → β} (hf : continuous f) {V W : opens β} (hVW : V �
   ↑(U.comap hf) = f ⁻¹' U := rfl
 
 @[simp] lemma comap_val {f : α → β} (hf : continuous f) (U : opens β) :
-  (U.comap hf).1 = f ⁻¹' U.1 := rfl
+  (U.comap hf).1 = f ⁻¹' U := rfl
 
-protected lemma comap_compose {g : β → γ} {f : α → β} (hg : continuous g) (hf : continuous f)
+protected lemma comap_comp {g : β → γ} {f : α → β} (hg : continuous g) (hf : continuous f)
   (U : opens γ) : U.comap (hg.comp hf) = (U.comap hg).comap hf :=
 by { ext1, simp only [coe_comap, preimage_preimage] }
 

--- a/src/topology/opens.lean
+++ b/src/topology/opens.lean
@@ -1,48 +1,38 @@
 /-
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johannes Hölzl, Mario Carneiro
-
-Subtype of open subsets in a topological space.
+Authors: Johannes Hölzl, Mario Carneiro, Floris van Doorn
 -/
 import topology.bases
-import topology.separation
+import topology.homeomorph
+/-!
+# Open sets
 
-open filter
-variables {α : Type*} {β : Type*} [topological_space α] [topological_space β]
+## Summary
+
+We define the subtype of open sets in a topological space.
+
+## Main Definitions
+
+- `opens α` is the type of open subsets of a topological space `α`.
+- `open_nhds_of x` is the type of open subsets of a topological space `α` containing `x : α`.
+-
+-/
+
+open filter set
+variables {α : Type*} {β : Type*} {γ : Type*}
+  [topological_space α] [topological_space β] [topological_space γ]
 
 namespace topological_space
 variable (α)
 /-- The type of open subsets of a topological space. -/
 def opens := {s : set α // is_open s}
 
-/-- The type of closed subsets of a topological space. -/
-def closeds := {s : set α // is_closed s}
-
-/-- The type of non-empty compact subsets of a topological space. The
-non-emptiness will be useful in metric spaces, as we will be able to put
-a distance (and not merely an edistance) on this space. -/
-def nonempty_compacts := {s : set α // s.nonempty ∧ compact s}
-
-section nonempty_compacts
-open topological_space set
-variable {α}
-
-instance nonempty_compacts.to_compact_space {p : nonempty_compacts α} : compact_space p.val :=
-⟨compact_iff_compact_univ.1 p.property.2⟩
-
-instance nonempty_compacts.to_nonempty {p : nonempty_compacts α} : nonempty p.val :=
-p.property.1.to_subtype
-
-/-- Associate to a nonempty compact subset the corresponding closed subset -/
-def nonempty_compacts.to_closeds [t2_space α] : nonempty_compacts α → closeds α :=
-set.inclusion $ λ s hs, hs.2.is_closed
-
-end nonempty_compacts
-
 variable {α}
 namespace opens
 instance : has_coe (opens α) (set α) := { coe := subtype.val }
+
+lemma val_eq_coe (U : opens α) : U.1 = ↑U := rfl
 
 instance : has_subset (opens α) :=
 { subset := λ U V, U.val ⊆ V.val }
@@ -50,16 +40,18 @@ instance : has_subset (opens α) :=
 instance : has_mem α (opens α) :=
 { mem := λ a U, a ∈ U.val }
 
-@[ext] lemma ext {U V : opens α} (h : U.val = V.val) : U = V := subtype.ext_iff_val.mpr h
+@[ext] lemma ext {U V : opens α} (h : (U : set α) = V) : U = V := subtype.ext_iff_val.mpr h
 
 instance : partial_order (opens α) := subtype.partial_order _
 
+/-- The interior of a set, as an element of `opens`. -/
 def interior (s : set α) : opens α := ⟨interior s, is_open_interior⟩
 
 lemma gc : galois_connection (subtype.val : opens α → set α) interior :=
 λ U s, ⟨λ h, interior_maximal h U.property, λ h, le_trans h interior_subset⟩
 
-def gi : @galois_insertion (order_dual (set α)) (order_dual (opens α)) _ _ interior (subtype.val) :=
+/-- The galois insertion between sets and opens, but ordered by reverse inclusion. -/
+def gi : @galois_insertion (order_dual (set α)) (order_dual (opens α)) _ _ interior subtype.val :=
 { choice := λ s hs, ⟨s, interior_eq_iff_open.mp $ le_antisymm interior_subset hs⟩,
   gc := gc.dual,
   le_l_u := λ _, interior_subset,
@@ -103,11 +95,14 @@ instance : inhabited (opens α) := ⟨∅⟩
 @[simp] lemma union_eq (U V : opens α) : U ∪ V = U ⊔ V := rfl
 @[simp] lemma empty_eq : (∅ : opens α) = ⊥ := rfl
 
-@[simp] lemma Sup_s {Us : set (opens α)} : (Sup Us).val = ⋃₀ (subtype.val '' Us) :=
+@[simp] lemma Sup_s {Us : set (opens α)} : ↑(Sup Us) = ⋃₀ ((coe : _ → set α) '' Us) :=
 begin
-  rw [@galois_connection.l_Sup (opens α) (set α) _ _ (subtype.val : opens α → set α) interior gc Us, set.sUnion_image],
-  congr
+  rw [@galois_connection.l_Sup (opens α) (set α) _ _ (coe : opens α → set α) interior gc Us],
+  rw [set.sUnion_image]
 end
+
+lemma supr_def {ι} (s : ι → opens α) : (⨆ i, s i) = ⟨⋃ i, s i, is_open_Union $ λ i, (s i).2⟩ :=
+by { ext, simp only [supr, opens.Sup_s, sUnion_image, bUnion_range], refl }
 
 def is_basis (B : set (opens α)) : Prop := is_topological_basis (subtype.val '' B)
 
@@ -131,8 +126,8 @@ lemma is_basis_iff_cover {B : set (opens α)} :
 begin
   split,
   { intros hB U,
-    rcases sUnion_basis_of_is_open hB U.property with ⟨sUs, H, hU⟩,
-    existsi {U : opens α | U ∈ B ∧ U.val ∈ sUs},
+    rcases sUnion_basis_of_is_open hB U.prop with ⟨sUs, H, hU⟩,
+    existsi {U : opens α | U ∈ B ∧ ↑U ∈ sUs},
     split,
     { intros U hU, exact hU.left },
     { apply ext,
@@ -148,33 +143,60 @@ begin
     rw is_basis_iff_nbhd,
     intros U x hx,
     rcases h U with ⟨Us, hUs, H⟩,
-    replace H := congr_arg subtype.val H,
+    replace H := congr_arg (coe : _ → set α) H,
     rw Sup_s at H,
-    change x ∈ U.val at hx,
+    change x ∈ ↑U at hx,
     rw H at hx,
     rcases set.mem_sUnion.mp hx with ⟨sV, ⟨⟨V, H₁, H₂⟩, hsV⟩⟩,
     refine ⟨V,hUs H₁,_⟩,
     cases V with V hV,
     dsimp at H₂, subst H₂,
     refine ⟨hsV,_⟩,
-    change V ⊆ U.val, rw H,
+    change V ⊆ U, rw H,
     exact set.subset_sUnion_of_mem ⟨⟨V, _⟩, ⟨H₁, rfl⟩⟩ }
 end
 
+/-- The preimage of an open set, as an open set. -/
+def comap {f : α → β} (hf : continuous f) (V : opens β) : opens α :=
+⟨f ⁻¹' V.1, hf V.1 V.2⟩
+
+@[simp] lemma comap_id (U : opens α) : U.comap continuous_id = U := by { ext, refl }
+
+lemma comap_mono {f : α → β} (hf : continuous f) {V W : opens β} (hVW : V ⊆ W) :
+  V.comap hf ⊆ W.comap hf :=
+λ _ h, hVW h
+
+@[simp] lemma coe_comap {f : α → β} (hf : continuous f) (U : opens β) :
+  ↑(U.comap hf) = f ⁻¹' U := rfl
+
+@[simp] lemma comap_val {f : α → β} (hf : continuous f) (U : opens β) :
+  (U.comap hf).1 = f ⁻¹' U.1 := rfl
+
+protected lemma comap_compose {g : β → γ} {f : α → β} (hg : continuous g) (hf : continuous f)
+  (U : opens γ) : U.comap (hg.comp hf) = (U.comap hg).comap hf :=
+by { ext1, simp only [coe_comap, preimage_preimage] }
+
+/-- A homeomorphism induces an equivalence on open sets, by taking comaps. -/
+@[simp] protected def equiv (f : α ≃ₜ β) : opens α ≃ opens β :=
+{ to_fun := opens.comap f.symm.continuous,
+  inv_fun := opens.comap f.continuous,
+  left_inv := by { intro U, ext1,
+    simp only [coe_comap, ← preimage_comp, f.symm_comp_self, preimage_id] },
+  right_inv := by { intro U, ext1,
+    simp only [coe_comap, ← preimage_comp, f.self_comp_symm, preimage_id] } }
+
 end opens
+
+/-- The open neighborhoods of a point. See also `opens` or `nhds`. -/
+def open_nhds_of (x : α) : Type* := { s : set α // is_open s ∧ x ∈ s }
+
+instance open_nhds_of.inhabited {α : Type*} [topological_space α] (x : α) :
+  inhabited (open_nhds_of x) := ⟨⟨set.univ, is_open_univ, set.mem_univ _⟩⟩
 
 end topological_space
 
 namespace continuous
 open topological_space
 
-def comap {f : α → β} (hf : continuous f) (V : opens β) : opens α :=
-⟨f ⁻¹' V.1, hf V.1 V.2⟩
-
-@[simp] lemma comap_id (U : opens α) : (continuous_id).comap U = U := by { ext, refl }
-
-lemma comap_mono {f : α → β} (hf : continuous f) {V W : opens β} (hVW : V ⊆ W) :
-  hf.comap V ⊆ hf.comap W :=
-λ _ h, hVW h
 
 end continuous

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -267,6 +267,53 @@ is_open_compl_iff.mpr $ is_open_iff_forall_mem_open.mpr $ assume x hx,
     subset_compl_comm.mp (subset.trans su (subset_compl_iff_disjoint.mpr uv)),
 ⟨v, this, vo, by simpa using xv⟩
 
+lemma compact.inter [t2_space α] {s t : set α} (hs : compact s) (ht : compact t) :
+  compact (s ∩ t) :=
+hs.inter_right $ ht.is_closed
+
+/-- If a compact set is covered by two open sets, then we can cover it by two compact subsets. -/
+lemma compact.binary_compact_cover [t2_space α] {K U V : set α} (hK : compact K)
+  (hU : is_open U) (hV : is_open V) (h2K : K ⊆ U ∪ V) :
+  ∃ K₁ K₂ : set α, compact K₁ ∧ compact K₂ ∧ K₁ ⊆ U ∧ K₂ ⊆ V ∧ K = K₁ ∪ K₂ :=
+begin
+  rcases compact_compact_separated (compact_diff hK hU) (compact_diff hK hV)
+    (by rwa [diff_inter_diff, diff_eq_empty]) with ⟨O₁, O₂, h1O₁, h1O₂, h2O₁, h2O₂, hO⟩,
+  refine ⟨_, _, compact_diff hK h1O₁, compact_diff hK h1O₂,
+    by rwa [diff_subset_comm], by rwa [diff_subset_comm], by rw [← diff_inter, hO, diff_empty]⟩
+end
+
+section
+open finset function
+/-- For every finite open cover `Uᵢ` of a compact set, there exists a compact cover `Kᵢ ⊆ Uᵢ`. -/
+lemma compact.finite_compact_cover [t2_space α] {s : set α} (hs : compact s) {ι} (t : finset ι)
+  (U : ι → set α) (hU : ∀ i ∈ t, is_open (U i)) (hsC : s ⊆ ⋃ i ∈ t, U i) :
+  ∃ K : ι → set α, (∀ i ∈ t, compact (K i) ∧ K i ⊆ U i) ∧ s = ⋃ i ∈ t, K i :=
+begin
+  classical,
+  induction t using finset.induction with x t hx ih generalizing U hU s hs hsC,
+  { refine ⟨λ _, ∅, λ i _, ⟨compact_empty, empty_subset _⟩, _⟩, simpa only [subset_empty_iff,
+      finset.not_mem_empty, Union_neg, Union_empty, not_false_iff] using hsC },
+  simp only [finset.bUnion_insert] at hsC,
+  simp only [finset.mem_insert] at hU,
+  have hU' : ∀ i ∈ t, is_open (U i) := λ i hi, hU i (or.inr hi),
+  rcases hs.binary_compact_cover (hU x (or.inl rfl)) (is_open_bUnion hU') hsC
+    with ⟨K₁, K₂, h1K₁, h1K₂, h2K₁, h2K₂, hK⟩,
+  rcases ih U hU' h1K₂ h2K₂ with ⟨K, h1K, h2K⟩,
+  refine ⟨update K x K₁, _, _⟩,
+  { intros i hi, simp only [finset.mem_insert] at hi, rcases hi with rfl|hi,
+    simpa only [update_same, h1K₁, true_and] using h2K₁,
+    rw [update_noteq], exact h1K i hi, rintro rfl, exact hx hi },
+  { ext y, simp only [exists_prop, mem_Union, mem_union_eq, finset.bUnion_insert, update_same, hK],
+    split,
+    { rintro (hy|hy), exact or.inl hy,
+      simp only [h2K, mem_Union, subtype.exists] at hy, rcases hy with ⟨i, h1i, h2i⟩,
+      refine or.inr ⟨i, h1i, _⟩, rw [update_noteq], exact h2i, rintro rfl, exact hx h1i },
+    { rintro (hy|⟨i, h1i, h2i⟩), exact or.inl hy,
+      rw [h2K], simp only [exists_prop, mem_Union], rw [update_noteq] at h2i,
+      exact or.inr ⟨i, h1i, h2i⟩, rintro rfl, exact hx h1i }}
+end
+end
+
 lemma locally_compact_of_compact_nhds [t2_space α] (h : ∀ x : α, ∃ s, s ∈ 𝓝 x ∧ compact s) :
   locally_compact_space α :=
 ⟨assume x n hn,
@@ -290,6 +337,32 @@ lemma locally_compact_of_compact_nhds [t2_space α] (h : ∀ x : α, ∃ s, s �
 @[priority 100] -- see Note [lower instance priority]
 instance locally_compact_of_compact [t2_space α] [compact_space α] : locally_compact_space α :=
 locally_compact_of_compact_nhds (assume x, ⟨univ, mem_nhds_sets is_open_univ trivial, compact_univ⟩)
+
+/-- In a locally compact T₂ space, every point has an open neighborhood with compact closure -/
+lemma exists_open_with_compact_closure [locally_compact_space α] [t2_space α] (x : α) :
+  ∃ (U : set α), is_open U ∧ x ∈ U ∧ compact (closure U) :=
+begin
+  rcases locally_compact_space.local_compact_nhds x set.univ filter.univ_mem_sets with
+    ⟨K, h1K, _, h2K⟩,
+  rw [mem_nhds_sets_iff] at h1K, rcases h1K with ⟨t, h1t, h2t, h3t⟩,
+  exact ⟨t, h2t, h3t, compact_of_is_closed_subset h2K is_closed_closure $
+    closure_minimal h1t $ h2K.is_closed⟩
+end
+
+/-- In a locally compact T₂ space, every compact set is contained in the interior of a compact
+  set. -/
+lemma exists_compact_superset [locally_compact_space α] [t2_space α] {K : set α}
+  (hK : compact K) : ∃ (K' : set α), compact K' ∧ K ⊆ interior K' :=
+begin
+  choose U hU using λ x : K, exists_open_with_compact_closure (x : α),
+  rcases hK.elim_finite_subcover U (λ x, (hU x).1) (λ x hx, ⟨_, ⟨⟨x, hx⟩, rfl⟩, (hU ⟨x, hx⟩).2.1⟩) with
+    ⟨s, hs⟩,
+  refine ⟨⋃ (i : K) (H : i ∈ s), closure (U i), _, _⟩,
+  exact (finite_mem_finset s).compact_bUnion (λ x hx, (hU x).2.2),
+  refine subset.trans hs _, rw subset_interior_iff_subset_of_open,
+  exact bUnion_subset_bUnion_right (λ x hx, subset_closure),
+  exact is_open_bUnion (λ x hx, (hU x).1)
+end
 
 end separation
 

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -515,6 +515,11 @@ begin
     ⟨a, assume i, (ha i).left, assume i, map_le_iff_le_comap.mp $ (ha i).right⟩
 end
 
+/-- A version of Tychonoff's theorem that uses `set.pi`. -/
+lemma compact_univ_pi {s : Πi:ι, set (π i)} (h : ∀i, compact (s i)) : compact (set.pi set.univ s) :=
+by { convert compact_pi_infinite h, simp only [pi, forall_prop_of_true, mem_univ] }
+
+
 instance pi.compact [∀i:ι, compact_space (π i)] : compact_space (Πi, π i) :=
 ⟨begin
   have A : compact {x : Πi:ι, π i | ∀i, x i ∈ (univ : set (π i))} :=
@@ -539,6 +544,16 @@ evaluation `map C(X, Y) × X → Y` to be continuous for all `Y` when `C(X, Y)` 
 compact-open topology. -/
 class locally_compact_space (α : Type*) [topological_space α] : Prop :=
 (local_compact_nhds : ∀ (x : α) (n ∈ 𝓝 x), ∃ s ∈ 𝓝 x, s ⊆ n ∧ compact s)
+
+/-- A reformulation of the definition of locally compact space: In a locally compact space,
+  every open set containing `x` has a compact subset containing `x` in its interior. -/
+lemma exists_compact_subset [locally_compact_space α] {x : α} {U : set α}
+  (hU : is_open U) (hx : x ∈ U) : ∃ (K : set α), compact K ∧ x ∈ interior K ∧ K ⊆ U :=
+begin
+  rcases locally_compact_space.local_compact_nhds x U _ with ⟨K, h1K, h2K, h3K⟩,
+  { refine ⟨K, h3K, _, h2K⟩, rwa [ mem_interior_iff_mem_nhds] },
+  rwa [← mem_interior_iff_mem_nhds, interior_eq_of_open hU]
+end
 
 end compact
 


### PR DESCRIPTION
Define group operations on sets
Define compacts, in a similar way to opens
Prove some "separation" properties for topological groups
Rename `continuous.comap` to `opens.comap` (so that we can have comaps for other kinds of sets in topological spaces)
Rename `inf_val` to `inf_def` (unused)
Move some definitions from `topology.opens` to `topology.compacts`

---
<!-- put comments you want to keep out of the PR commit here -->

~~Depends on #3189 and #3190~~