### PR TITLE
[Merged by Bors] - feat(data/padics/padic_norm) Fix namespacing of padic_val_nat

### DIFF
--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -113,7 +113,9 @@ lemma padic_val_rat_of_int (z : ℤ) (hp : p ≠ 1) (hz : z ≠ 0) :
 by rw [padic_val_rat, dif_pos]; simp *; refl
 
 end padic_val_rat
+end padic_val_rat
 
+namespace padic_val_nat
 section padic_val_nat
 
 /--
@@ -160,7 +162,9 @@ begin
 end
 
 end padic_val_nat
+end padic_val_nat
 
+namespace padic_val_rat
 section padic_val_rat
 open multiplicity
 variables (p : ℕ) [p_prime : fact p.prime]

--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -76,7 +76,6 @@ dif_pos ⟨hq, hp.ne_one⟩
 
 namespace padic_val_rat
 open multiplicity
-section padic_val_rat
 variables {p : ℕ}
 
 /--
@@ -113,16 +112,14 @@ lemma padic_val_rat_of_int (z : ℤ) (hp : p ≠ 1) (hz : z ≠ 0) :
 by rw [padic_val_rat, dif_pos]; simp *; refl
 
 end padic_val_rat
-end padic_val_rat
-
-namespace padic_val_nat
-section padic_val_nat
 
 /--
 A convenience function for the case of `padic_val_rat` when both inputs are natural numbers.
 -/
 def padic_val_nat (p : ℕ) (n : ℕ) : ℕ :=
 int.to_nat (padic_val_rat p n)
+
+section padic_val_nat
 
 /--
 `padic_val_nat` is defined as an `int.to_nat` cast; this lemma ensures that the cast is well-behaved.
@@ -162,10 +159,8 @@ begin
 end
 
 end padic_val_nat
-end padic_val_nat
 
 namespace padic_val_rat
-section padic_val_rat
 open multiplicity
 variables (p : ℕ) [p_prime : fact p.prime]
 include p_prime
@@ -301,7 +296,6 @@ theorem min_le_padic_val_rat_add {q r : ℚ}
   (λ h, by rw [min_eq_right h, add_comm]; exact le_padic_val_rat_add_of_le _ hr hq
     (by rwa add_comm) h)
 
-end padic_val_rat
 end padic_val_rat
 
 /--


### PR DESCRIPTION
No longer need we `padic_val_rat.padic_val_nat`.

---
<!-- put comments you want to keep out of the PR commit here -->

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.233207.20padic_val_nat.20namespacing).