### PR TITLE
[Merged by Bors] - fix(tactic/apply_fun): beta reduction was too aggressive

### DIFF
--- a/src/tactic/apply_fun.lean
+++ b/src/tactic/apply_fun.lean
@@ -34,7 +34,6 @@ do {
   | _ := fail ("failed to apply " ++ to_string e ++ " at " ++ to_string hyp.local_pp_name)
   end,
   clear hyp,
-  -- Let's try to force β-reduction at `h`.
   hyp ← note hyp.local_pp_name none prf,
   -- let's try to force β-reduction at `h`
   try $ tactic.dsimp_hyp hyp simp_lemmas.mk [] { eta := false, beta := true }

--- a/src/tactic/apply_fun.lean
+++ b/src/tactic/apply_fun.lean
@@ -33,24 +33,11 @@ do {
        to_expr ``(%%Hmono %%hyp)
   | _ := fail ("failed to apply " ++ to_string e ++ " at " ++ to_string hyp.local_pp_name)
   end,
-  -- Let's try to force β-reduction at `h`.
-  -- (Unfortunately `tactic.dsimp_hyp hyp none [] { eta := false, beta := true }`
-  -- is slightly too aggressive; see the tests.)
-  t ← infer_type prf,
-  t ← match t with
-  | `(%%l = %%r) := do
-      l ← head_beta l,
-      r ← head_beta r,
-      to_expr ``(%%l = %%r)
-  | `(%%l ≤ %%r) := do
-      l ← head_beta l,
-      r ← head_beta r,
-      to_expr ``(%%l ≤ %%r)
-  | t := pure t
-  end,
   clear hyp,
-  note hyp.local_pp_name (some t) prf,
-  skip
+  -- Let's try to force β-reduction at `h`.
+  hyp ← note hyp.local_pp_name none prf,
+  -- let's try to force β-reduction at `h`
+  try $ tactic.dsimp_hyp hyp simp_lemmas.mk [] { eta := false, beta := true }
 }
 
 namespace interactive

--- a/src/tactic/apply_fun.lean
+++ b/src/tactic/apply_fun.lean
@@ -33,11 +33,24 @@ do {
        to_expr ``(%%Hmono %%hyp)
   | _ := fail ("failed to apply " ++ to_string e ++ " at " ++ to_string hyp.local_pp_name)
   end,
+  -- Let's try to force β-reduction at `h`.
+  -- (Unfortunately `tactic.dsimp_hyp hyp none [] { eta := false, beta := true }`
+  -- is slightly too aggressive; see the tests.)
+  t ← infer_type prf,
+  t ← match t with
+  | `(%%l = %%r) := do
+      l ← head_beta l,
+      r ← head_beta r,
+      to_expr ``(%%l = %%r)
+  | `(%%l ≤ %%r) := do
+      l ← head_beta l,
+      r ← head_beta r,
+      to_expr ``(%%l ≤ %%r)
+  | t := pure t
+  end,
   clear hyp,
-  hyp ← note hyp.local_pp_name none prf,
-
-  -- let's try to force β-reduction at `h`
-  try $ tactic.dsimp_hyp hyp none [] { eta := false, beta := true }
+  note hyp.local_pp_name (some t) prf,
+  skip
 }
 
 namespace interactive

--- a/test/apply_fun.lean
+++ b/test/apply_fun.lean
@@ -1,4 +1,5 @@
 import tactic.apply_fun
+import data.matrix.basic
 open function
 
 example (X Y Z : Type) (f : X → Y) (g : Y → Z) (H : injective $ g ∘ f) :
@@ -35,4 +36,14 @@ example (a b : ℕ) (h : a ≤ b) : a + 1 ≤ b + 1 :=
 begin
   apply_fun (λ n, n+1) at h,
   exact h
+end
+
+example {n : Type} [fintype n] {X : Type} [semiring X]
+  (f : matrix n n X → matrix n n X) (A B : matrix n n X) (h : A * B = 0) : f (A * B) = f 0 :=
+begin
+  apply_fun f at h,
+  -- check that our β-reduction didn't mess things up:
+  -- (previously `apply_fun` was producing `f (A.mul B) = f 0`)
+  guard_hyp' h := f (A * B) = f 0,
+  exact h,
 end

--- a/test/apply_fun.lean
+++ b/test/apply_fun.lean
@@ -10,7 +10,7 @@ begin
   exact H h
 end
 
-example (f : ℕ → ℕ) (a b : ℕ) (monof : monotone f)  (h : a ≤ b) : f a ≤ f b :=
+example (f : ℕ → ℕ) (a b : ℕ) (monof : monotone f) (h : a ≤ b) : f a ≤ f b :=
 begin
   apply_fun f at h,
   assumption,
@@ -25,7 +25,7 @@ begin
   exact h
 end
 
-example (f : ℕ → ℕ) (a b : ℕ) (monof : monotone f)  (h : a ≤ b) : f a ≤ f b :=
+example (f : ℕ → ℕ) (a b : ℕ) (monof : monotone f) (h : a ≤ b) : f a ≤ f b :=
 begin
   apply_fun f at h using monof,
   assumption


### PR DESCRIPTION
The beta reduction performed by `apply_fun` was previously too aggressive -- in particular it was unfolding `A * B` to `A.mul B` when `A` and `B` are matrices. 

This fix avoids using `dsimp`, and instead calls `head_beta` separately on the left and right sides of the new hypothesis. 

---
<!-- put comments you want to keep out of the PR commit here -->

This is cumbersome, so if anyone has a better fix that would be great.