### PR TITLE
[Merged by Bors] - feat(algebra/lie_algebra): conjugation transformation for Lie algebras of skew-adjoint endomorphims, matrices

### DIFF
--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -444,7 +444,7 @@ instance lie_subalgebra_lie_algebra (L' : lie_subalgebra R L) :
 @[simp] lemma lie_subalgebra.mem_coe {L' : lie_subalgebra R L} {x : L} :
   x ∈ (L' : set L) ↔ x ∈ L' := iff.rfl
 
-@[simp, norm_cast] lemma lie_subalgebra_coe_bracket (L' : lie_subalgebra R L) (x y : L') :
+@[simp, norm_cast] lemma lie_subalgebra.coe_bracket (L' : lie_subalgebra R L) (x y : L') :
   (↑⁅x, y⁆ : L) = ⁅↑x, ↑y⁆ := rfl
 
 @[ext] lemma lie_subalgebra_ext (L₁' L₂' : lie_subalgebra R L) (h : (L₁' : set L) = L₂') :
@@ -801,11 +801,11 @@ noncomputable def matrix.lie_conj (P : matrix n n R) (h : is_unit P) :
 
 @[simp] lemma matrix.lie_conj_apply (P A : matrix n n R) (h : is_unit P) :
   P.lie_conj h A = P ⬝ A ⬝ P⁻¹ :=
-by simp [matrix.lie_conj, matrix.comp_to_matrix_mul, to_lin_to_matrix]
+by simp [linear_equiv.conj_apply, matrix.lie_conj, matrix.comp_to_matrix_mul, to_lin_to_matrix]
 
 @[simp] lemma matrix.lie_conj_symm_apply (P A : matrix n n R) (h : is_unit P) :
   (P.lie_conj h).symm A = P⁻¹ ⬝ A ⬝ P :=
-by simp [matrix.lie_conj, matrix.comp_to_matrix_mul, to_lin_to_matrix]
+by simp [linear_equiv.symm_conj_apply, matrix.lie_conj, matrix.comp_to_matrix_mul, to_lin_to_matrix]
 
 end matrices
 

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -257,9 +257,23 @@ variables {R : Type u} {L₁ : Type v} {L₂ : Type w} {L₃ : Type w₁}
 variables [comm_ring R] [lie_ring L₁] [lie_ring L₂] [lie_ring L₃]
 variables [lie_algebra R L₁] [lie_algebra R L₂] [lie_algebra R L₃]
 
+instance has_coe_to_lie_hom : has_coe (L₁ ≃ₗ⁅R⁆ L₂) (L₁ →ₗ⁅R⁆ L₂) := ⟨to_morphism⟩
+instance has_coe_to_linear_equiv : has_coe (L₁ ≃ₗ⁅R⁆ L₂) (L₁ ≃ₗ[R] L₂) := ⟨to_linear_equiv⟩
+
+/-- see Note [function coercion] -/
+instance : has_coe_to_fun (L₁ ≃ₗ⁅R⁆ L₂) := ⟨_, to_fun⟩
+
+@[simp, norm_cast] lemma coe_to_lie_equiv (e : L₁ ≃ₗ⁅R⁆ L₂) : ((e : L₁ →ₗ⁅R⁆ L₂) : L₁ → L₂) = e :=
+  rfl
+
+@[simp, norm_cast] lemma coe_to_linear_equiv (e : L₁ ≃ₗ⁅R⁆ L₂) : ((e : L₁ ≃ₗ[R] L₂) : L₁ → L₂) = e :=
+  rfl
+
 instance : has_one (L₁ ≃ₗ⁅R⁆ L₁) :=
 ⟨{ map_lie := λ x y, by { change ((1 : L₁→ₗ[R] L₁) ⁅x, y⁆) = ⁅(1 : L₁→ₗ[R] L₁) x, (1 : L₁→ₗ[R] L₁) y⁆, simp, },
   ..(1 : L₁ ≃ₗ[R] L₁)}⟩
+
+@[simp] lemma one_apply (x : L₁) : (1 : (L₁ ≃ₗ⁅R⁆ L₁)) x = x := rfl
 
 instance : inhabited (L₁ ≃ₗ⁅R⁆ L₁) := ⟨1⟩
 
@@ -267,17 +281,34 @@ instance : inhabited (L₁ ≃ₗ⁅R⁆ L₁) := ⟨1⟩
 @[refl]
 def refl : L₁ ≃ₗ⁅R⁆ L₁ := 1
 
+@[simp] lemma refl_apply (x : L₁) : (refl : L₁ ≃ₗ⁅R⁆ L₁) x = x := rfl
+
 /-- Lie algebra equivalences are symmetric. -/
 @[symm]
 def symm (e : L₁ ≃ₗ⁅R⁆ L₂) : L₂ ≃ₗ⁅R⁆ L₁ :=
 { ..morphism.inverse e.to_morphism e.inv_fun e.left_inv e.right_inv,
   ..e.to_linear_equiv.symm }
 
+@[simp] lemma symm_symm (e : L₁ ≃ₗ⁅R⁆ L₂) : e.symm.symm = e :=
+by { cases e, refl, }
+
+@[simp] lemma apply_symm_apply (e : L₁ ≃ₗ⁅R⁆ L₂) : ∀ x, e (e.symm x) = x :=
+  e.to_linear_equiv.apply_symm_apply
+
+@[simp] lemma symm_apply_apply (e : L₁ ≃ₗ⁅R⁆ L₂) : ∀ x, e.symm (e x) = x :=
+  e.to_linear_equiv.symm_apply_apply
+
 /-- Lie algebra equivalences are transitive. -/
 @[trans]
 def trans (e₁ : L₁ ≃ₗ⁅R⁆ L₂) (e₂ : L₂ ≃ₗ⁅R⁆ L₃) : L₁ ≃ₗ⁅R⁆ L₃ :=
 { ..morphism.comp e₂.to_morphism e₁.to_morphism,
   ..linear_equiv.trans e₁.to_linear_equiv e₂.to_linear_equiv }
+
+@[simp] lemma trans_apply (e₁ : L₁ ≃ₗ⁅R⁆ L₂) (e₂ : L₂ ≃ₗ⁅R⁆ L₃) (x : L₁) :
+  (e₁.trans e₂) x = e₂ (e₁ x) := rfl
+
+@[simp] lemma symm_trans_apply (e₁ : L₁ ≃ₗ⁅R⁆ L₂) (e₂ : L₂ ≃ₗ⁅R⁆ L₃) (x : L₃) :
+  (e₁.trans e₂).symm x = e₁.symm (e₂.symm x) := rfl
 
 end equiv
 
@@ -392,6 +423,7 @@ instance : has_zero (lie_subalgebra R L) :=
 
 instance : inhabited (lie_subalgebra R L) := ⟨0⟩
 instance : has_coe (lie_subalgebra R L) (set L) := ⟨lie_subalgebra.carrier⟩
+instance : has_mem L (lie_subalgebra R L) := ⟨λ x L', x ∈ (L' : set L)⟩
 
 instance lie_subalgebra_coe_submodule : has_coe (lie_subalgebra R L) (submodule R L) :=
 ⟨lie_subalgebra.to_submodule⟩
@@ -409,25 +441,18 @@ instance lie_subalgebra_lie_algebra (L' : lie_subalgebra R L) :
     @lie_algebra R L' _ (lie_subalgebra_lie_ring _ _ _) :=
 { lie_smul := by { intros, apply set_coe.ext, apply lie_smul } }
 
+@[simp] lemma lie_subalgebra.mem_coe {L' : lie_subalgebra R L} {x : L} :
+  x ∈ (L' : set L) ↔ x ∈ L' := iff.rfl
+
+@[simp, norm_cast] lemma lie_subalgebra_coe_bracket (L' : lie_subalgebra R L) (x y : L') :
+  (↑⁅x, y⁆ : L) = ⁅↑x, ↑y⁆ := rfl
+
+@[ext] lemma lie_subalgebra_ext (L₁' L₂' : lie_subalgebra R L) (h : (L₁' : set L) = L₂') :
+  L₁' = L₂' :=
+by { cases L₁', cases L₂', simp only [], exact h, }
+
 local attribute [instance] lie_ring.of_associative_ring
 local attribute [instance] lie_algebra.of_associative_algebra
-
-/-- The embedding of a Lie subalgebra into the ambient space as a Lie morphism. -/
-def lie_subalgebra.incl
-  {R : Type u} {L : Type v} [comm_ring R] [lie_ring L] [lie_algebra R L]
-  (L' : lie_subalgebra R L) : L' →ₗ⁅R⁆ L :=
-{ map_lie := λ x y, by { rw [linear_map.to_fun_eq_coe, submodule.subtype_apply], refl, },
-  ..L'.to_submodule.subtype }
-
-/-- The range of a morphism of Lie algebras is a Lie subalgebra. -/
-def lie_algebra.morphism.range {R : Type u} {L₁ : Type v} {L₂ : Type w}
-  [comm_ring R] [lie_ring L₁] [lie_ring L₂] [lie_algebra R L₁] [lie_algebra R L₂]
-  (f : L₁ →ₗ⁅R⁆ L₂) : lie_subalgebra R L₂ :=
-{ lie_mem := λ x y,
-    show x ∈ f.to_linear_map.range → y ∈ f.to_linear_map.range → ⁅x, y⁆ ∈ f.to_linear_map.range,
-    by { repeat { rw linear_map.mem_range }, rintros ⟨x', hx⟩ ⟨y', hy⟩, refine ⟨⁅x', y'⁆, _⟩,
-         rw [←hx, ←hy], change f ⁅x', y'⁆ = ⁅f x', f y'⁆, rw lie_algebra.map_lie, },
-  ..f.to_linear_map.range }
 
 /-- A subalgebra of an associative algebra is a Lie subalgebra of the associated Lie algebra. -/
 def lie_subalgebra_of_subalgebra (A : Type v) [ring A] [algebra R A]
@@ -440,7 +465,95 @@ def lie_subalgebra_of_subalgebra (A : Type v) [ring A] [algebra R A]
     exact submodule.sub_mem A'.to_submodule hxy hyx, },
   ..A'.to_submodule }
 
+variables {R L} {L₂ : Type w} [lie_ring L₂] [lie_algebra R L₂]
+
+/-- The embedding of a Lie subalgebra into the ambient space as a Lie morphism. -/
+def lie_subalgebra.incl (L' : lie_subalgebra R L) : L' →ₗ⁅R⁆ L :=
+{ map_lie := λ x y, by { rw [linear_map.to_fun_eq_coe, submodule.subtype_apply], refl, },
+  ..L'.to_submodule.subtype }
+
+/-- The range of a morphism of Lie algebras is a Lie subalgebra. -/
+def lie_algebra.morphism.range (f : L →ₗ⁅R⁆ L₂) : lie_subalgebra R L₂ :=
+{ lie_mem := λ x y,
+    show x ∈ f.to_linear_map.range → y ∈ f.to_linear_map.range → ⁅x, y⁆ ∈ f.to_linear_map.range,
+    by { repeat { rw linear_map.mem_range }, rintros ⟨x', hx⟩ ⟨y', hy⟩, refine ⟨⁅x', y'⁆, _⟩,
+         rw [←hx, ←hy], change f ⁅x', y'⁆ = ⁅f x', f y'⁆, rw lie_algebra.map_lie, },
+  ..f.to_linear_map.range }
+
+@[simp] lemma lie_algebra.morphism.range_bracket (f : L →ₗ⁅R⁆ L₂) (x y : f.range) :
+  (↑⁅x, y⁆ : L₂) = ⁅↑x, ↑y⁆ := rfl
+
+/-- The image of a Lie subalgebra under a Lie algebra morphism is a Lie subalgebra of the
+codomain. -/
+def lie_subalgebra.map (f : L →ₗ⁅R⁆ L₂) (L' : lie_subalgebra R L) : lie_subalgebra R L₂ :=
+{ lie_mem := λ x y hx hy, by {
+    erw submodule.mem_map at hx, rcases hx with ⟨x', hx', hx⟩, rw ←hx,
+    erw submodule.mem_map at hy, rcases hy with ⟨y', hy', hy⟩, rw ←hy,
+    erw submodule.mem_map,
+    exact ⟨⁅x', y'⁆, L'.lie_mem hx' hy', lie_algebra.map_lie f x' y'⟩, },
+..((L' : submodule R L).map (f : L →ₗ[R] L₂))}
+
+@[simp] lemma lie_subalgebra.mem_map_submodule (e : L ≃ₗ⁅R⁆ L₂) (L' : lie_subalgebra R L) (x : L₂) :
+  x ∈ L'.map (e : L →ₗ⁅R⁆ L₂) ↔ x ∈ (L' : submodule R L).map (e : L →ₗ[R] L₂) :=
+by refl
+
 end lie_subalgebra
+
+namespace lie_algebra
+
+variables {R : Type u} {L₁ : Type v} {L₂ : Type w}
+variables [comm_ring R] [lie_ring L₁] [lie_ring L₂] [lie_algebra R L₁] [lie_algebra R L₂]
+
+namespace equiv
+
+/-- An injective Lie algebra morphism is an equivalence onto its range. -/
+noncomputable def of_injective (f : L₁ →ₗ⁅R⁆ L₂) (h : function.injective f) :
+  L₁ ≃ₗ⁅R⁆ f.range :=
+have h' : (f : L₁ →ₗ[R] L₂).ker = ⊥ := linear_map.ker_eq_bot_of_injective h,
+{ map_lie := λ x y, by { apply set_coe.ext,
+    simp only [linear_equiv.of_injective_apply, lie_algebra.morphism.range_bracket],
+    apply f.map_lie, },
+..(linear_equiv.of_injective ↑f h')}
+
+@[simp] lemma of_injective_apply (f : L₁ →ₗ⁅R⁆ L₂) (h : function.injective f) (x : L₁) :
+  ↑(of_injective f h x) = f x := rfl
+
+variables (L₁' L₁'' : lie_subalgebra R L₁) (L₂' : lie_subalgebra R L₂)
+
+/-- Lie subalgebras that are equal as sets are equivalent as Lie algebras. -/
+def of_eq (h : (L₁' : set L₁) = L₁'') : L₁' ≃ₗ⁅R⁆ L₁'' :=
+{ map_lie := λ x y, by { apply set_coe.ext, simp, },
+  ..(linear_equiv.of_eq ↑L₁' ↑L₁'' (by {
+    ext x, change x ∈ (L₁' : set L₁) ↔ x ∈ (L₁'' : set L₁), rw h, } )) }
+
+@[simp] lemma of_eq_apply (L L' : lie_subalgebra R L₁) (h : (L : set L₁) = L') (x : L) :
+  (↑(of_eq L L' h x) : L₁) = x := rfl
+
+variables (e : L₁ ≃ₗ⁅R⁆ L₂)
+
+/-- An equivalence of Lie algebras restricts to an equivalence from any Lie subalgebra onto its
+image. -/
+def of_subalgebra : L₁'' ≃ₗ⁅R⁆ (L₁''.map e : lie_subalgebra R L₂) :=
+{ map_lie := λ x y, by { apply set_coe.ext, exact lie_algebra.map_lie (↑e : L₁ →ₗ⁅R⁆ L₂) ↑x ↑y, }
+  ..(linear_equiv.of_submodule (e : L₁ ≃ₗ[R] L₂) ↑L₁'') }
+
+@[simp] lemma of_subalgebra_apply (x : L₁'') : ↑(e.of_subalgebra _  x) = e x := rfl
+
+/-- An equivalence of Lie algebras restricts to an equivalence from any Lie subalgebra onto its
+image. -/
+def of_subalgebras (h : L₁'.map ↑e = L₂') : L₁' ≃ₗ⁅R⁆ L₂' :=
+{ map_lie := λ x y, by { apply set_coe.ext, exact lie_algebra.map_lie (↑e : L₁ →ₗ⁅R⁆ L₂) ↑x ↑y, },
+  ..(linear_equiv.of_submodules (e : L₁ ≃ₗ[R] L₂) ↑L₁' ↑L₂' (by { rw ←h, refl, })) }
+
+@[simp] lemma of_subalgebras_apply (h : L₁'.map ↑e = L₂') (x : L₁') :
+  ↑(e.of_subalgebras _ _ h x) = e x := rfl
+
+@[simp] lemma of_subalgebras_symm_apply (h : L₁'.map ↑e = L₂') (x : L₂') :
+  ↑((e.of_subalgebras _ _ h).symm x) = e.symm x := rfl
+
+end equiv
+
+end lie_algebra
 
 section lie_module
 
@@ -625,6 +738,24 @@ end quotient
 
 end lie_submodule
 
+namespace linear_equiv
+
+variables {R : Type u} {M₁ : Type v} {M₂ : Type w}
+variables [comm_ring R] [add_comm_group M₁] [module R M₁] [add_comm_group M₂] [module R M₂]
+variables (e : M₁ ≃ₗ[R] M₂)
+
+/-- A linear equivalence of two modules induces a Lie algebra equivalence of their endomorphisms. -/
+def lie_conj : module.End R M₁ ≃ₗ⁅R⁆ module.End R M₂ :=
+{ map_lie := λ f g, show e.conj ⁅f, g⁆ =  ⁅e.conj f, e.conj g⁆,
+             by simp only [lie_algebra.endo_algebra_bracket, e.conj_comp, linear_equiv.map_sub],
+  ..e.conj }
+
+@[simp] lemma lie_conj_apply (f : module.End R M₁) : e.lie_conj f = e.conj f := rfl
+
+@[simp] lemma lie_conj_symm : e.lie_conj.symm = e.symm.lie_conj := rfl
+
+end linear_equiv
+
 section matrices
 open_locale matrix
 
@@ -657,18 +788,34 @@ def lie_equiv_matrix' : module.End R (n → R) ≃ₗ⁅R⁆ matrix n n R :=
   end,
   ..linear_equiv_matrix' }
 
+@[simp] lemma lie_equiv_matrix'_apply (f : module.End R (n → R)) :
+  lie_equiv_matrix' f = f.to_matrix := rfl
+
+@[simp] lemma lie_equiv_matrix'_symm_apply (A : matrix n n R) :
+  (@lie_equiv_matrix' R _ n _ _).symm A = A.to_lin := rfl
+
+/-- An invertible matrix induces a Lie algebra equivalence from the space of matrices to itself. -/
+noncomputable def matrix.lie_conj (P : matrix n n R) (h : is_unit P) :
+  matrix n n R ≃ₗ⁅R⁆ matrix n n R :=
+((@lie_equiv_matrix' R _ n _ _).symm.trans (P.to_linear_equiv h).lie_conj).trans lie_equiv_matrix'
+
+@[simp] lemma matrix.lie_conj_apply (P A : matrix n n R) (h : is_unit P) :
+  P.lie_conj h A = P ⬝ A ⬝ P⁻¹ :=
+by simp [matrix.lie_conj, matrix.comp_to_matrix_mul, to_lin_to_matrix]
+
+@[simp] lemma matrix.lie_conj_symm_apply (P A : matrix n n R) (h : is_unit P) :
+  (P.lie_conj h).symm A = P⁻¹ ⬝ A ⬝ P :=
+by simp [matrix.lie_conj, matrix.comp_to_matrix_mul, to_lin_to_matrix]
+
 end matrices
 
-namespace bilin_form
-
-variables {R : Type u} [comm_ring R]
-
 section skew_adjoint_endomorphisms
+open bilin_form
 
-variables {M : Type v} [add_comm_group M] [module R M]
+variables {R : Type u} {M : Type v} [comm_ring R] [add_comm_group M] [module R M]
 variables (B : bilin_form R M)
 
-lemma is_skew_adjoint_bracket (f g : module.End R M)
+lemma bilin_form.is_skew_adjoint_bracket (f g : module.End R M)
   (hf : f ∈ B.skew_adjoint_submodule) (hg : g ∈ B.skew_adjoint_submodule) :
   ⁅f, g⁆ ∈ B.skew_adjoint_submodule :=
 begin
@@ -684,28 +831,76 @@ Lie subalgebra of the Lie algebra of endomorphisms. -/
 def skew_adjoint_lie_subalgebra : lie_subalgebra R (module.End R M) :=
 { lie_mem := B.is_skew_adjoint_bracket, ..B.skew_adjoint_submodule }
 
+variables {N : Type w} [add_comm_group N] [module R N] (e : N ≃ₗ[R] M)
+
+/-- An equivalence of modules with bilinear forms gives equivalence of Lie algebras of skew-adjoint
+endomorphisms. -/
+def skew_adjoint_lie_subalgebra_equiv :
+  skew_adjoint_lie_subalgebra (B.comp (↑e : N →ₗ[R] M) ↑e) ≃ₗ⁅R⁆ skew_adjoint_lie_subalgebra B :=
+begin
+  apply lie_algebra.equiv.of_subalgebras _ _ e.lie_conj,
+  ext f,
+  simp only [lie_subalgebra.mem_coe, submodule.mem_map_equiv, lie_subalgebra.mem_map_submodule,
+    coe_coe],
+  exact (bilin_form.is_pair_self_adjoint_equiv (-B) B e f).symm,
+end
+
+@[simp] lemma skew_adjoint_lie_subalgebra_equiv_apply
+  (f : skew_adjoint_lie_subalgebra (B.comp ↑e ↑e)) :
+  ↑(skew_adjoint_lie_subalgebra_equiv B e f) = e.lie_conj f :=
+by simp [skew_adjoint_lie_subalgebra_equiv]
+
+@[simp] lemma skew_adjoint_lie_subalgebra_equiv_symm_apply (f : skew_adjoint_lie_subalgebra B) :
+  ↑((skew_adjoint_lie_subalgebra_equiv B e).symm f) = e.symm.lie_conj f :=
+by simp [skew_adjoint_lie_subalgebra_equiv]
+
 end skew_adjoint_endomorphisms
 
 section skew_adjoint_matrices
+open_locale matrix
 
-variables {n : Type w} [fintype n] [decidable_eq n]
+variables {R : Type u} {n : Type w₁} [comm_ring R] [fintype n] [decidable_eq n]
 variables (J : matrix n n R)
 
 local attribute [instance] matrix.lie_ring
 local attribute [instance] matrix.lie_algebra
 
-/-- Given a square matrix `J` defining a bilinear form on the free module, there is a natural
-embedding from the corresponding Lie subalgebra of skew-adjoint endomorphisms into the Lie algebra
-of matrices. -/
-def skew_adjoint_matrices_lie_embedding :
-  J.to_bilin_form.skew_adjoint_lie_subalgebra →ₗ⁅R⁆ matrix n n R :=
-lie_algebra.morphism.comp (lie_algebra.equiv.to_morphism lie_equiv_matrix')
-  (skew_adjoint_lie_subalgebra J.to_bilin_form).incl
+lemma matrix.lie_transpose (A B : matrix n n R) : ⁅A, B⁆ᵀ = ⁅Bᵀ, Aᵀ⁆ :=
+show (A * B - B * A)ᵀ = (Bᵀ * Aᵀ - Aᵀ * Bᵀ), by simp
+
+lemma matrix.is_skew_adjoint_bracket (A B : matrix n n R)
+  (hA : A ∈ skew_adjoint_matrices_submodule J) (hB : B ∈ skew_adjoint_matrices_submodule J) :
+  ⁅A, B⁆ ∈ skew_adjoint_matrices_submodule J :=
+begin
+  simp only [mem_skew_adjoint_matrices_submodule] at *,
+  change ⁅A, B⁆ᵀ ⬝ J = J ⬝ -⁅A, B⁆, change Aᵀ ⬝ J = J ⬝ -A at hA, change Bᵀ ⬝ J = J ⬝ -B at hB,
+  simp only [←matrix.mul_eq_mul] at *,
+  rw [matrix.lie_transpose, lie_ring.of_associative_ring_bracket, lie_ring.of_associative_ring_bracket,
+    sub_mul, mul_assoc, mul_assoc, hA, hB, ←mul_assoc, ←mul_assoc, hA, hB],
+  noncomm_ring,
+end
 
 /-- The Lie subalgebra of skew-adjoint square matrices corresponding to a square matrix `J`. -/
 def skew_adjoint_matrices_lie_subalgebra : lie_subalgebra R (matrix n n R) :=
-(skew_adjoint_matrices_lie_embedding J).range
+{ lie_mem := J.is_skew_adjoint_bracket, ..(skew_adjoint_matrices_submodule J) }
+
+/-- An invertible matrix `P` gives a Lie algebra equivalence between those endomorphisms that are
+skew-adjoint with respect to a square matrix `J` and those with respect to `PᵀJP`. -/
+noncomputable def skew_adjoint_matrices_lie_subalgebra_equiv (P : matrix n n R) (h : is_unit P) :
+  skew_adjoint_matrices_lie_subalgebra J ≃ₗ⁅R⁆ skew_adjoint_matrices_lie_subalgebra (Pᵀ ⬝ J ⬝ P) :=
+lie_algebra.equiv.of_subalgebras _ _ (P.lie_conj h).symm
+begin
+  ext A,
+  suffices : P.lie_conj h A ∈ skew_adjoint_matrices_submodule J ↔
+    A ∈ skew_adjoint_matrices_submodule (Pᵀ ⬝ J ⬝ P),
+  { simp only [lie_subalgebra.mem_coe, submodule.mem_map_equiv, lie_subalgebra.mem_map_submodule,
+      coe_coe], exact this, },
+  simp [matrix.is_skew_adjoint, J.is_adjoint_pair_equiv _ _ P h],
+end
+
+lemma skew_adjoint_matrices_lie_subalgebra_equiv_apply
+  (P : matrix n n R) (h : is_unit P) (A : skew_adjoint_matrices_lie_subalgebra J) :
+  ↑(skew_adjoint_matrices_lie_subalgebra_equiv J P h A) = P⁻¹ ⬝ ↑A ⬝ P :=
+by simp [skew_adjoint_matrices_lie_subalgebra_equiv]
 
 end skew_adjoint_matrices
-
-end bilin_form

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -444,12 +444,18 @@ instance lie_subalgebra_lie_algebra (L' : lie_subalgebra R L) :
 @[simp] lemma lie_subalgebra.mem_coe {L' : lie_subalgebra R L} {x : L} :
   x ∈ (L' : set L) ↔ x ∈ L' := iff.rfl
 
+@[simp] lemma lie_subalgebra.mem_coe' {L' : lie_subalgebra R L} {x : L} :
+  x ∈ (L' : submodule R L) ↔ x ∈ L' := iff.rfl
+
 @[simp, norm_cast] lemma lie_subalgebra.coe_bracket (L' : lie_subalgebra R L) (x y : L') :
   (↑⁅x, y⁆ : L) = ⁅↑x, ↑y⁆ := rfl
 
-@[ext] lemma lie_subalgebra_ext (L₁' L₂' : lie_subalgebra R L) (h : (L₁' : set L) = L₂') :
+@[ext] lemma lie_subalgebra.ext (L₁' L₂' : lie_subalgebra R L) (h : ∀ x, x ∈ L₁' ↔ x ∈ L₂') :
   L₁' = L₂' :=
-by { cases L₁', cases L₂', simp only [], exact h, }
+by { cases L₁', cases L₂', simp only [], ext x, exact h x, }
+
+lemma lie_subalgebra.ext_iff (L₁' L₂' : lie_subalgebra R L) : L₁' = L₂' ↔ ∀ x, x ∈ L₁' ↔ x ∈ L₂' :=
+⟨λ h x, by rw h, lie_subalgebra.ext R L L₁' L₂'⟩
 
 local attribute [instance] lie_ring.of_associative_ring
 local attribute [instance] lie_algebra.of_associative_algebra

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -523,8 +523,8 @@ variables (L₁' L₁'' : lie_subalgebra R L₁) (L₂' : lie_subalgebra R L₂)
 /-- Lie subalgebras that are equal as sets are equivalent as Lie algebras. -/
 def of_eq (h : (L₁' : set L₁) = L₁'') : L₁' ≃ₗ⁅R⁆ L₁'' :=
 { map_lie := λ x y, by { apply set_coe.ext, simp, },
-  ..(linear_equiv.of_eq ↑L₁' ↑L₁'' (by {
-    ext x, change x ∈ (L₁' : set L₁) ↔ x ∈ (L₁'' : set L₁), rw h, } )) }
+  ..(linear_equiv.of_eq ↑L₁' ↑L₁''
+      (by {ext x, change x ∈ (L₁' : set L₁) ↔ x ∈ (L₁'' : set L₁), rw h, } )) }
 
 @[simp] lemma of_eq_apply (L L' : lie_subalgebra R L₁) (h : (L : set L₁) = L') (x : L) :
   (↑(of_eq L L' h x) : L₁) = x := rfl
@@ -859,7 +859,7 @@ end skew_adjoint_endomorphisms
 section skew_adjoint_matrices
 open_locale matrix
 
-variables {R : Type u} {n : Type w₁} [comm_ring R] [fintype n] [decidable_eq n]
+variables {R : Type u} {n : Type w} [comm_ring R] [fintype n] [decidable_eq n]
 variables (J : matrix n n R)
 
 local attribute [instance] matrix.lie_ring

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -488,6 +488,10 @@ end
   (M + N)ᵀ = Mᵀ + Nᵀ  :=
 by { ext i j, simp }
 
+@[simp] lemma transpose_sub [add_comm_group α] (M : matrix m n α) (N : matrix m n α) :
+  (M - N)ᵀ = Mᵀ - Nᵀ  :=
+by { ext i j, simp }
+
 @[simp] lemma transpose_mul [comm_ring α] (M : matrix m n α) (N : matrix n l α) :
   (M ⬝ N)ᵀ = Nᵀ ⬝ Mᵀ  :=
 begin

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1538,6 +1538,9 @@ structure linear_equiv (R : Type u) (M : Type v) (M₂ : Type w)
   extends M →ₗ[R] M₂, M ≃ M₂
 end
 
+attribute [nolint doc_blame] linear_equiv.to_linear_map
+attribute [nolint doc_blame] linear_equiv.to_equiv
+
 infix ` ≃ₗ ` := linear_equiv _
 notation M ` ≃ₗ[`:50 R `] ` M₂ := linear_equiv R M M₂
 
@@ -1654,12 +1657,10 @@ def of_submodule (p : submodule R M) : p ≃ₗ[R] ↥(p.map ↑e : submodule R 
   ..((e : M →ₗ[R] M₂).dom_restrict p).cod_restrict (p.map ↑e) (λ x, ⟨x, by simp⟩) }
 
 @[simp] lemma of_submodule_apply (p : submodule R M) (x : p) :
-  ↑(e.of_submodule p x) = e x :=
-rfl
+  ↑(e.of_submodule p x) = e x := rfl
 
 @[simp] lemma of_submodule_symm_apply (p : submodule R M) (x : (p.map ↑e : submodule R M₂)) :
-  ↑((e.of_submodule p).symm x) = e.symm x :=
-rfl
+  ↑((e.of_submodule p).symm x) = e.symm x := rfl
 
 end
 
@@ -1682,8 +1683,7 @@ lemma prod_symm : (e₁.prod e₂).symm = e₁.symm.prod e₂.symm := rfl
   e₁.prod e₂ p = (e₁ p.1, e₂ p.2) := rfl
 
 @[simp, norm_cast] lemma coe_prod :
-  (e₁.prod e₂ : (M × M₃) →ₗ[R] (M₂ × M₄)) = (e₁ : M →ₗ[R] M₂).prod_map (e₂ : M₃ →ₗ[R] M₄) :=
-rfl
+  (e₁.prod e₂ : (M × M₃) →ₗ[R] (M₂ × M₄)) = (e₁ : M →ₗ[R] M₂).prod_map (e₂ : M₃ →ₗ[R] M₄) := rfl
 
 end prod
 
@@ -1715,8 +1715,6 @@ variables (p q : submodule R M)
 def of_eq (h : p = q) : p ≃ₗ[R] q :=
 { map_smul' := λ _ _, rfl, map_add' := λ _ _, rfl, .. equiv.set.of_eq (congr_arg _ h) }
 
-@[simp] lemma of_eq_apply (h : p = q) (x : p) : (↑(of_eq p q h x) : M) = ↑x := rfl
-
 variables {p q}
 
 @[simp] lemma coe_of_eq_apply (h : p = q) (x : p) : (of_eq p q h x : M) = x := rfl
@@ -1729,12 +1727,10 @@ def of_submodules (p : submodule R M) (q : submodule R M₂) (h : p.map ↑e = q
 (e.of_submodule p).trans (linear_equiv.of_eq _ _ h)
 
 @[simp] lemma of_submodules_apply {p : submodule R M} {q : submodule R M₂}
-  (h : p.map ↑e = q) (x : p) : ↑(e.of_submodules p q h x) = e x :=
-rfl
+  (h : p.map ↑e = q) (x : p) : ↑(e.of_submodules p q h x) = e x := rfl
 
 @[simp] lemma of_submodules_symm_apply {p : submodule R M} {q : submodule R M₂}
-  (h : p.map ↑e = q) (x : q) : ↑((e.of_submodules p q h).symm x) = e.symm x :=
-rfl
+  (h : p.map ↑e = q) (x : q) : ↑((e.of_submodules p q h).symm x) = e.symm x := rfl
 
 variable (p)
 
@@ -1889,12 +1885,10 @@ themselves are linearly isomorphic. -/
 def conj (e : M ≃ₗ[R] M₂) : (module.End R M) ≃ₗ[R] (module.End R M₂) := arrow_congr e e
 
 @[simp] lemma conj_apply (e : M ≃ₗ[R] M₂) (f : module.End R M) :
-  e.conj f = ((↑e : M →ₗ[R] M₂).comp f).comp e.symm :=
-rfl
+  e.conj f = ((↑e : M →ₗ[R] M₂).comp f).comp e.symm := rfl
 
 @[simp] lemma symm_conj_apply (e : M ≃ₗ[R] M₂) (f : module.End R M₂) :
-  e.symm.conj f = ((↑e.symm : M₂ →ₗ[R] M).comp f).comp e :=
-rfl
+  e.symm.conj f = ((↑e.symm : M₂ →ₗ[R] M).comp f).comp e := rfl
 
 lemma conj_comp (e : M ≃ₗ[R] M₂) (f g : module.End R M) :
   e.conj (g.comp f) = (e.conj g).comp (e.conj f) :=

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1884,10 +1884,10 @@ def congr_right (f : M₂ ≃ₗ[R] M₃) : (M →ₗ[R] M₂) ≃ₗ (M →ₗ 
 themselves are linearly isomorphic. -/
 def conj (e : M ≃ₗ[R] M₂) : (module.End R M) ≃ₗ[R] (module.End R M₂) := arrow_congr e e
 
-@[simp] lemma conj_apply (e : M ≃ₗ[R] M₂) (f : module.End R M) :
+lemma conj_apply (e : M ≃ₗ[R] M₂) (f : module.End R M) :
   e.conj f = ((↑e : M →ₗ[R] M₂).comp f).comp e.symm := rfl
 
-@[simp] lemma symm_conj_apply (e : M ≃ₗ[R] M₂) (f : module.End R M₂) :
+lemma symm_conj_apply (e : M ≃ₗ[R] M₂) (f : module.End R M₂) :
   e.symm.conj f = ((↑e.symm : M₂ →ₗ[R] M).comp f).comp e := rfl
 
 lemma conj_comp (e : M ≃ₗ[R] M₂) (f g : module.End R M) :
@@ -1899,7 +1899,7 @@ lemma conj_trans (e₁ : M ≃ₗ[R] M₂) (e₂ : M₂ ≃ₗ[R] M₃) :
 by { ext f x, refl, }
 
 @[simp] lemma conj_id (e : M ≃ₗ[R] M₂) : e.conj linear_map.id = linear_map.id :=
-by { ext, simp, }
+by { ext, simp [conj_apply], }
 
 end comm_ring
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -108,6 +108,13 @@ linear_map.ext $ λ x, rfl
 theorem comp_assoc (g : M₂ →ₗ[R] M₃) (h : M₃ →ₗ[R] M₄) : (h.comp g).comp f = h.comp (g.comp f) :=
 rfl
 
+/-- The restriction of a linear map `f : M → M₂` to a submodule `p ⊆ M` gives a linear map
+`p → M₂`. -/
+def dom_restrict (f : M →ₗ[R] M₂) (p : submodule R M) : p →ₗ[R] M₂ := f.comp p.subtype
+
+@[simp] lemma dom_restrict_apply (f : M →ₗ[R] M₂) (p : submodule R M) (x : p) :
+  f.dom_restrict p x = f x := rfl
+
 /-- A linear map `f : M₂ → M` whose values lie in a submodule `p ⊆ M` can be restricted to a
 linear map M₂ → p. -/
 def cod_restrict (p : submodule R M) (f : M₂ →ₗ[R] M) (h : ∀c, f c ∈ p) : M₂ →ₗ[R] p :=
@@ -1636,6 +1643,24 @@ e.to_equiv.image_eq_preimage s
 lemma map_eq_comap {p : submodule R M} : (p.map e : submodule R M₂) = p.comap e.symm :=
 submodule.coe_injective $ by simp [e.image_eq_preimage]
 
+/-- A linear equivalence of two modules restricts to a linear equivalence from any submodule
+of the domain onto the image of the submodule. -/
+def of_submodule (p : submodule R M) : p ≃ₗ[R] ↥(p.map ↑e : submodule R M₂) :=
+{ inv_fun   := λ y, ⟨e.symm y, by {
+    rcases y with ⟨y', hy⟩, rw submodule.mem_map at hy, rcases hy with ⟨x, hx, hxy⟩, subst hxy,
+    simp only [symm_apply_apply, submodule.coe_mk, coe_coe, hx], }⟩,
+  left_inv  := λ x, by simp,
+  right_inv := λ y, by { apply set_coe.ext, simp, },
+  ..((e : M →ₗ[R] M₂).dom_restrict p).cod_restrict (p.map ↑e) (λ x, ⟨x, by simp⟩) }
+
+@[simp] lemma of_submodule_apply (p : submodule R M) (x : p) :
+  ↑(e.of_submodule p x) = e x :=
+rfl
+
+@[simp] lemma of_submodule_symm_apply (p : submodule R M) (x : (p.map ↑e : submodule R M₂)) :
+  ↑((e.of_submodule p).symm x) = e.symm x :=
+rfl
+
 end
 
 section prod
@@ -1690,11 +1715,26 @@ variables (p q : submodule R M)
 def of_eq (h : p = q) : p ≃ₗ[R] q :=
 { map_smul' := λ _ _, rfl, map_add' := λ _ _, rfl, .. equiv.set.of_eq (congr_arg _ h) }
 
+@[simp] lemma of_eq_apply (h : p = q) (x : p) : (↑(of_eq p q h x) : M) = ↑x := rfl
+
 variables {p q}
 
 @[simp] lemma coe_of_eq_apply (h : p = q) (x : p) : (of_eq p q h x : M) = x := rfl
 
 @[simp] lemma of_eq_symm (h : p = q) : (of_eq p q h).symm = of_eq q p h.symm := rfl
+
+/-- A linear equivalence which maps a submodule of one module onto another, restricts to a linear
+equivalence of the two submodules. -/
+def of_submodules (p : submodule R M) (q : submodule R M₂) (h : p.map ↑e = q) : p ≃ₗ[R] q :=
+(e.of_submodule p).trans (linear_equiv.of_eq _ _ h)
+
+@[simp] lemma of_submodules_apply {p : submodule R M} {q : submodule R M₂}
+  (h : p.map ↑e = q) (x : p) : ↑(e.of_submodules p q h x) = e x :=
+rfl
+
+@[simp] lemma of_submodules_symm_apply {p : submodule R M} {q : submodule R M₂}
+  (h : p.map ↑e = q) (x : q) : ↑((e.of_submodules p q h).symm x) = e.symm x :=
+rfl
 
 variable (p)
 
@@ -1782,6 +1822,9 @@ noncomputable def of_injective (h : f.ker = ⊥) : M ≃ₗ[R] f.range :=
 { .. (equiv.set.range f $ linear_map.ker_eq_bot.1 h).trans (equiv.set.of_eq f.range_coe.symm),
   .. f.cod_restrict f.range (λ x, f.mem_range_self x) }
 
+@[simp] theorem of_injective_apply {h : f.ker = ⊥} (x : M) :
+  ↑(of_injective f h x) = f x := rfl
+
 /-- A bijective linear map is a linear equivalence. Here, bijectivity is described by saying that
 the kernel of `f` is `{0}` and the range is the universal set. -/
 noncomputable def of_bijective (hf₁ : f.ker = ⊥) (hf₂ : f.range = ⊤) : M ≃ₗ[R] M₂ :=
@@ -1845,12 +1888,24 @@ def congr_right (f : M₂ ≃ₗ[R] M₃) : (M →ₗ[R] M₂) ≃ₗ (M →ₗ 
 themselves are linearly isomorphic. -/
 def conj (e : M ≃ₗ[R] M₂) : (module.End R M) ≃ₗ[R] (module.End R M₂) := arrow_congr e e
 
-@[simp] lemma conj_apply (e : M ≃ₗ[R] M₂) (f : module.End R M) (x : M₂) :
-  (e.conj f) x = e (f (e.symm x)) :=
+@[simp] lemma conj_apply (e : M ≃ₗ[R] M₂) (f : module.End R M) :
+  e.conj f = ((↑e : M →ₗ[R] M₂).comp f).comp e.symm :=
 rfl
 
+@[simp] lemma symm_conj_apply (e : M ≃ₗ[R] M₂) (f : module.End R M₂) :
+  e.symm.conj f = ((↑e.symm : M₂ →ₗ[R] M).comp f).comp e :=
+rfl
+
+lemma conj_comp (e : M ≃ₗ[R] M₂) (f g : module.End R M) :
+  e.conj (g.comp f) = (e.conj g).comp (e.conj f) :=
+arrow_congr_comp e e e f g
+
+lemma conj_trans (e₁ : M ≃ₗ[R] M₂) (e₂ : M₂ ≃ₗ[R] M₃) :
+  e₁.conj.trans e₂.conj = (e₁.trans e₂).conj :=
+by { ext f x, refl, }
+
 @[simp] lemma conj_id (e : M ≃ₗ[R] M₂) : e.conj linear_map.id = linear_map.id :=
-by { ext, rw [conj_apply, id_apply, id_apply, apply_symm_apply], }
+by { ext, simp, }
 
 end comm_ring
 
@@ -1937,6 +1992,13 @@ namespace submodule
 
 variables [comm_ring R] [add_comm_group M] [add_comm_group M₂] [module R M] [module R M₂]
 variables (p : submodule R M) (q : submodule R M₂)
+
+@[simp] lemma mem_map_equiv {e : M ≃ₗ[R] M₂} {x : M₂} : x ∈ p.map (e : M →ₗ[R] M₂) ↔ e.symm x ∈ p :=
+begin
+  rw submodule.mem_map, split,
+  { rintros ⟨y, hy, hx⟩, simp [←hx, hy], },
+  { intros hx, refine ⟨e.symm x, hx, by simp⟩, },
+end
 
 lemma comap_le_comap_smul (f : M →ₗ[R] M₂) (c : R) :
   comap f q ≤ comap (c • f) q :=

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -6,6 +6,7 @@ Author: Andreas Swerdlow
 
 import linear_algebra.matrix
 import linear_algebra.tensor_product
+import linear_algebra.nonsingular_inverse
 
 /-!
 # Bilinear form
@@ -210,6 +211,20 @@ B.comp linear_map.id f
 @[simp] lemma comp_right_apply (B : bilin_form R M) (f : M →ₗ[R] M) (v w) :
   B.comp_right f v w = B v (f w) := rfl
 
+lemma comp_injective (B₁ B₂ : bilin_form R N) (l r : M →ₗ[R] N)
+  (hₗ : function.surjective l) (hᵣ : function.surjective r) :
+  B₁.comp l r = B₂.comp l r ↔ B₁ = B₂ :=
+begin
+  split; intros h,
+  { -- B₁.comp l r = B₂.comp l r → B₁ = B₂
+    ext,
+    cases hₗ x with x' hx, subst hx,
+    cases hᵣ y with y' hy, subst hy,
+    rw [←comp_apply, ←comp_apply, h], },
+  { -- B₁ = B₂ → B₁.comp l r = B₂.comp l r
+    subst h, },
+end
+
 end comp
 
 section lin_mul_lin
@@ -381,6 +396,13 @@ def bilin_form_equiv_matrix : bilin_form R (n → R) ≃ₗ[R] matrix n n R :=
   right_inv := to_bilin_form_to_matrix,
   ..bilin_form.to_matrixₗ }
 
+lemma matrix.to_bilin_form_comp {n o : Type w} [fintype n] [fintype o]
+  (M : matrix n n R) (P Q : matrix n o R) :
+  M.to_bilin_form.comp P.to_lin Q.to_lin = (Pᵀ ⬝ M ⬝ Q).to_bilin_form :=
+by { classical, rw [←to_matrix_to_bilin_form (Pᵀ ⬝ M ⬝ Q).to_bilin_form,
+       ←to_matrix_to_bilin_form (M.to_bilin_form.comp P.to_lin Q.to_lin), bilin_form.to_matrix_comp,
+       to_bilin_form_to_matrix, to_bilin_form_to_matrix, to_lin_to_matrix, to_lin_to_matrix], }
+
 end matrix
 
 namespace refl_bilin_form
@@ -454,7 +476,7 @@ section linear_adjoints
 
 variables {R : Type u} [comm_ring R]
 variables {M : Type v} [add_comm_group M] [module R M]
-variables {M₂ : Type v} [add_comm_group M₂] [module R M₂]
+variables {M₂ : Type w} [add_comm_group M₂] [module R M₂]
 variables (B B' : bilin_form R M) (B₂ : bilin_form R M₂)
 variables (f f' : M →ₗ[R] M₂) (g g' : M₂ →ₗ[R] M)
 
@@ -518,6 +540,22 @@ def is_pair_self_adjoint_submodule : submodule R (module.End R M) :=
   add_mem'  := λ f g hf hg, hf.add hg,
   smul_mem' := λ c f h, h.smul c, }
 
+@[simp] lemma mem_is_pair_self_adjoint_submodule (f : module.End R M) :
+  f ∈ is_pair_self_adjoint_submodule B B' ↔ is_pair_self_adjoint B B' f :=
+by refl
+
+lemma is_pair_self_adjoint_equiv (e : M₂ ≃ₗ[R] M) (f : module.End R M) :
+  is_pair_self_adjoint B B' f ↔
+  is_pair_self_adjoint (B.comp ↑e ↑e) (B'.comp ↑e ↑e) (e.symm.conj f) :=
+begin
+  have hₗ : (B'.comp ↑e ↑e).comp_left (e.symm.conj f) = (B'.comp_left f).comp ↑e ↑e := by { ext, simp, },
+  have hᵣ : (B.comp ↑e ↑e).comp_right (e.symm.conj f) = (B.comp_right f).comp ↑e ↑e := by { ext, simp, },
+  have he : function.surjective (⇑(↑e : M₂ →ₗ[R] M) : M₂ → M) := e.surjective,
+  show bilin_form.is_adjoint_pair _ _ _ _  ↔ bilin_form.is_adjoint_pair _ _ _ _,
+  rw [is_adjoint_pair_iff_comp_left_eq_comp_right, is_adjoint_pair_iff_comp_left_eq_comp_right,
+      hᵣ, hₗ, comp_injective _ _ ↑e ↑e he he],
+end
+
 /-- An endomorphism of a module is self-adjoint with respect to a bilinear form if it serves as an
 adjoint for itself. -/
 def is_self_adjoint (f : module.End R M) := is_adjoint_pair B B f f
@@ -569,9 +607,9 @@ def matrix.is_self_adjoint := matrix.is_adjoint_pair J J A A
 `J`. -/
 def matrix.is_skew_adjoint := matrix.is_adjoint_pair J J A (-A)
 
-lemma matrix_is_adjoint_pair_bilin_form :
-  matrix.is_adjoint_pair J J₂ A B ↔
-  bilin_form.is_adjoint_pair J.to_bilin_form J₂.to_bilin_form A.to_lin B.to_lin :=
+@[simp] lemma matrix_is_adjoint_pair_bilin_form :
+  bilin_form.is_adjoint_pair J.to_bilin_form J₂.to_bilin_form A.to_lin B.to_lin ↔
+  matrix.is_adjoint_pair J J₂ A B:=
 begin
   classical,
   rw bilin_form.is_adjoint_pair_iff_comp_left_eq_comp_right,
@@ -582,37 +620,42 @@ begin
   refl,
 end
 
+lemma matrix.is_adjoint_pair_equiv [decidable_eq n] (P : matrix n n R) (h : is_unit P) :
+  (Pᵀ ⬝ J ⬝ P).is_adjoint_pair (Pᵀ ⬝ J ⬝ P) A B ↔ J.is_adjoint_pair J (P ⬝ A ⬝ P⁻¹) (P ⬝ B ⬝ P⁻¹) :=
+have h' : is_unit P.det := P.is_unit_iff_is_unit_det.mp h,
+begin
+  let u := P.nonsing_inv_unit h',
+  let v := Pᵀ.nonsing_inv_unit (P.is_unit_det_transpose h'),
+  let x := Aᵀ * Pᵀ * J,
+  let y := J * P * B,
+  suffices : x * ↑u = ↑v * y ↔ ↑v⁻¹ * x = y * ↑u⁻¹,
+  { dunfold matrix.is_adjoint_pair,
+    repeat { rw matrix.transpose_mul, },
+    simp only [←matrix.mul_eq_mul, ←mul_assoc, P.transpose_nonsing_inv h'],
+    conv_lhs { to_rhs, rw [mul_assoc, mul_assoc], congr, skip, rw ←mul_assoc, },
+    conv_rhs { rw [mul_assoc, mul_assoc], conv { to_lhs, congr, skip, rw ←mul_assoc }, },
+    exact this, },
+  rw units.eq_mul_inv_iff_mul_eq, conv_rhs { rw mul_assoc, }, rw v.inv_mul_eq_iff_eq_mul,
+end
+
 variables [decidable_eq n]
-
-/-- Given a pair of square matrices `J`, `J₂` defining bilinear forms on the free module, there
-is a natural embedding from the corresponding submodule of pair-self-adjoint endomorphisms into the
-module of matrices. -/
-def pair_self_adjoint_matrices_linear_embedding :
-  bilin_form.is_pair_self_adjoint_submodule J.to_bilin_form J₂.to_bilin_form →ₗ[R] matrix n n R :=
-linear_equiv_matrix'.to_linear_map.comp
-  (bilin_form.is_pair_self_adjoint_submodule J.to_bilin_form J₂.to_bilin_form).subtype
-
-lemma pair_self_adjoint_matrices_linear_embedding_apply
-  (f : bilin_form.is_pair_self_adjoint_submodule J.to_bilin_form J₂.to_bilin_form) :
-  (pair_self_adjoint_matrices_linear_embedding J J₂ : _ →ₗ _) f = (f : module.End R (n → R)).to_matrix := rfl
-
-lemma pair_self_adjoint_matrices_linear_embedding_injective :
-  function.injective (pair_self_adjoint_matrices_linear_embedding J J₂) :=
-λ f g h, by { apply set_coe.ext, exact linear_equiv_matrix'.injective h, }
 
 /-- The submodule of pair-self-adjoint matrices with respect to bilinear forms corresponding to
 given matrices `J`, `J₂`. -/
 def pair_self_adjoint_matrices_submodule : submodule R (matrix n n R) :=
-  (pair_self_adjoint_matrices_linear_embedding J J₂).range
+(bilin_form.is_pair_self_adjoint_submodule J.to_bilin_form J₂.to_bilin_form).map
+  (@linear_equiv_matrix' n n _ _ R _ _)
 
 @[simp] lemma mem_pair_self_adjoint_matrices_submodule :
   A ∈ (pair_self_adjoint_matrices_submodule J J₂) ↔ matrix.is_adjoint_pair J J₂ A A :=
 begin
-  change A ∈ (pair_self_adjoint_matrices_linear_embedding J J₂).range ↔ matrix.is_adjoint_pair J J₂ A A,
-  rw [matrix_is_adjoint_pair_bilin_form, linear_map.mem_range],
-  simp only [pair_self_adjoint_matrices_linear_embedding_apply], split,
-  { rintros ⟨⟨A', hA'⟩, h⟩, rw ←h, rw to_matrix_to_lin, exact hA', },
-  { intros h, exact ⟨⟨A.to_lin, h⟩, to_lin_to_matrix⟩, },
+  simp only [pair_self_adjoint_matrices_submodule,linear_equiv.coe_coe, linear_equiv_matrix'_apply,
+    submodule.mem_map, bilin_form.mem_is_pair_self_adjoint_submodule],
+  split,
+  { rintros ⟨f, hf, hA⟩, have hf' : f = A.to_lin := by rw [←hA, to_matrix_to_lin], rw hf' at hf,
+    rw ←matrix_is_adjoint_pair_bilin_form, exact hf, },
+  { intros h, refine ⟨A.to_lin, _, to_lin_to_matrix⟩,
+    exact (matrix_is_adjoint_pair_bilin_form _ _ _ _).mpr h, },
 end
 
 /-- The submodule of self-adjoint matrices with respect to the bilinear form corresponding to
@@ -620,9 +663,20 @@ the matrix `J`. -/
 def self_adjoint_matrices_submodule : submodule R (matrix n n R) :=
   pair_self_adjoint_matrices_submodule J J
 
+@[simp] lemma mem_self_adjoint_matrices_submodule :
+  A ∈ self_adjoint_matrices_submodule J ↔ J.is_self_adjoint A :=
+by { erw mem_pair_self_adjoint_matrices_submodule, refl, }
+
 /-- The submodule of skew-adjoint matrices with respect to the bilinear form corresponding to
 the matrix `J`. -/
 def skew_adjoint_matrices_submodule : submodule R (matrix n n R) :=
   pair_self_adjoint_matrices_submodule (-J) J
+
+@[simp] lemma mem_skew_adjoint_matrices_submodule :
+  A ∈ skew_adjoint_matrices_submodule J ↔ J.is_skew_adjoint A :=
+begin
+  erw mem_pair_self_adjoint_matrices_submodule,
+  simp [matrix.is_skew_adjoint, matrix.is_adjoint_pair],
+end
 
 end matrix_adjoints

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -548,8 +548,10 @@ lemma is_pair_self_adjoint_equiv (e : M₂ ≃ₗ[R] M) (f : module.End R M) :
   is_pair_self_adjoint B B' f ↔
   is_pair_self_adjoint (B.comp ↑e ↑e) (B'.comp ↑e ↑e) (e.symm.conj f) :=
 begin
-  have hₗ : (B'.comp ↑e ↑e).comp_left (e.symm.conj f) = (B'.comp_left f).comp ↑e ↑e := by { ext, simp, },
-  have hᵣ : (B.comp ↑e ↑e).comp_right (e.symm.conj f) = (B.comp_right f).comp ↑e ↑e := by { ext, simp, },
+  have hₗ : (B'.comp ↑e ↑e).comp_left (e.symm.conj f) = (B'.comp_left f).comp ↑e ↑e :=
+    by { ext, simp [linear_equiv.symm_conj_apply], },
+  have hᵣ : (B.comp ↑e ↑e).comp_right (e.symm.conj f) = (B.comp_right f).comp ↑e ↑e :=
+    by { ext, simp [linear_equiv.conj_apply], },
   have he : function.surjective (⇑(↑e : M₂ →ₗ[R] M) : M₂ → M) := e.surjective,
   show bilin_form.is_adjoint_pair _ _ _ _  ↔ bilin_form.is_adjoint_pair _ _ _ _,
   rw [is_adjoint_pair_iff_comp_left_eq_comp_right, is_adjoint_pair_iff_comp_left_eq_comp_right,

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Johannes Hölzl, Casper Putz
 -/
 import linear_algebra.finite_dimensional
+import linear_algebra.nonsingular_inverse
 
 /-!
 # Linear maps and matrices
@@ -303,14 +304,14 @@ end trace
 
 section ring
 
-variables {R : Type v} [comm_ring R]
+variables {R : Type v} [comm_ring R] [decidable_eq n]
 open linear_map matrix
 
-lemma proj_diagonal [decidable_eq m] (i : m) (w : m → R) :
+lemma proj_diagonal (i : n) (w : n → R) :
   (proj i).comp (to_lin (diagonal w)) = (w i) • proj i :=
 by ext j; simp [mul_vec_diagonal]
 
-lemma diagonal_comp_std_basis [decidable_eq n] (w : n → R) (i : n) :
+lemma diagonal_comp_std_basis (w : n → R) (i : n) :
   (diagonal w).to_lin.comp (std_basis R (λ_:n, R) i) = (w i) • std_basis R (λ_:n, R) i :=
 begin
   ext a j,
@@ -321,9 +322,29 @@ begin
   { rw [std_basis_ne R (λ_:n, R) _ _ (ne.symm h), _root_.mul_zero, _root_.mul_zero] }
 end
 
-lemma diagonal_to_lin [decidable_eq m] (w : m → R) :
+lemma diagonal_to_lin (w : n → R) :
   (diagonal w).to_lin = linear_map.pi (λi, w i • linear_map.proj i) :=
 by ext v j; simp [mul_vec_diagonal]
+
+/-- An invertible matrix yields a linear equivalence from the free module to itself. -/
+def to_linear_equiv (P : matrix n n R) (h : is_unit P) : (n → R) ≃ₗ[R] (n → R) :=
+have h' : is_unit P.det := P.is_unit_iff_is_unit_det.mp h,
+{ inv_fun   := P⁻¹.to_lin,
+  left_inv  := λ v, by { change (P⁻¹.to_lin.comp P.to_lin) v = v,
+                         rw [←matrix.mul_to_lin, P.nonsing_inv_mul h', matrix.to_lin_one,
+                             linear_map.id_apply], },
+  right_inv := λ v, by { change (P.to_lin.comp P⁻¹.to_lin) v = v,
+                         rw [←matrix.mul_to_lin, P.mul_nonsing_inv h', matrix.to_lin_one,
+                             linear_map.id_apply], },
+  ..P.to_lin }
+
+@[simp] lemma to_linear_equiv_apply (P : matrix n n R) (h : is_unit P) :
+  (↑(P.to_linear_equiv h) : module.End R (n → R)) = P.to_lin :=
+rfl
+
+@[simp] lemma to_linear_equiv_symm_apply (P : matrix n n R) (h : is_unit P) :
+  (↑(P.to_linear_equiv h).symm : module.End R (n → R)) = P⁻¹.to_lin :=
+rfl
 
 end ring
 

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -339,12 +339,10 @@ have h' : is_unit P.det := P.is_unit_iff_is_unit_det.mp h,
   ..P.to_lin }
 
 @[simp] lemma to_linear_equiv_apply (P : matrix n n R) (h : is_unit P) :
-  (↑(P.to_linear_equiv h) : module.End R (n → R)) = P.to_lin :=
-rfl
+  (↑(P.to_linear_equiv h) : module.End R (n → R)) = P.to_lin := rfl
 
 @[simp] lemma to_linear_equiv_symm_apply (P : matrix n n R) (h : is_unit P) :
-  (↑(P.to_linear_equiv h).symm : module.End R (n → R)) = P⁻¹.to_lin :=
-rfl
+  (↑(P.to_linear_equiv h).symm : module.End R (n → R)) = P⁻¹.to_lin := rfl
 
 end ring
 

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -330,12 +330,12 @@ by ext v j; simp [mul_vec_diagonal]
 def to_linear_equiv (P : matrix n n R) (h : is_unit P) : (n → R) ≃ₗ[R] (n → R) :=
 have h' : is_unit P.det := P.is_unit_iff_is_unit_det.mp h,
 { inv_fun   := P⁻¹.to_lin,
-  left_inv  := λ v, by { change (P⁻¹.to_lin.comp P.to_lin) v = v,
-                         rw [←matrix.mul_to_lin, P.nonsing_inv_mul h', matrix.to_lin_one,
-                             linear_map.id_apply], },
-  right_inv := λ v, by { change (P.to_lin.comp P⁻¹.to_lin) v = v,
-                         rw [←matrix.mul_to_lin, P.mul_nonsing_inv h', matrix.to_lin_one,
-                             linear_map.id_apply], },
+  left_inv  := λ v,
+  show (P⁻¹.to_lin.comp P.to_lin) v = v,
+  by rw [←matrix.mul_to_lin, P.nonsing_inv_mul h', matrix.to_lin_one, linear_map.id_apply], },
+  right_inv := λ v,
+  show (P.to_lin.comp P⁻¹.to_lin) v = v,
+  by rw [←matrix.mul_to_lin, P.mul_nonsing_inv h', matrix.to_lin_one, linear_map.id_apply], },
   ..P.to_lin }
 
 @[simp] lemma to_linear_equiv_apply (P : matrix n n R) (h : is_unit P) :

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -331,11 +331,11 @@ def to_linear_equiv (P : matrix n n R) (h : is_unit P) : (n → R) ≃ₗ[R] (n 
 have h' : is_unit P.det := P.is_unit_iff_is_unit_det.mp h,
 { inv_fun   := P⁻¹.to_lin,
   left_inv  := λ v,
-  show (P⁻¹.to_lin.comp P.to_lin) v = v,
-  by rw [←matrix.mul_to_lin, P.nonsing_inv_mul h', matrix.to_lin_one, linear_map.id_apply], },
+    show (P⁻¹.to_lin.comp P.to_lin) v = v,
+    by rw [←matrix.mul_to_lin, P.nonsing_inv_mul h', matrix.to_lin_one, linear_map.id_apply],
   right_inv := λ v,
-  show (P.to_lin.comp P⁻¹.to_lin) v = v,
-  by rw [←matrix.mul_to_lin, P.mul_nonsing_inv h', matrix.to_lin_one, linear_map.id_apply], },
+    show (P.to_lin.comp P⁻¹.to_lin) v = v,
+    by rw [←matrix.mul_to_lin, P.mul_nonsing_inv h', matrix.to_lin_one, linear_map.id_apply],
   ..P.to_lin }
 
 @[simp] lemma to_linear_equiv_apply (P : matrix n n R) (h : is_unit P) :

--- a/test/noncomm_ring.lean
+++ b/test/noncomm_ring.lean
@@ -44,3 +44,7 @@ example : a ⚬ b = b ⚬ a := by noncomm_ring
 example : a ⚬ (b + c) = a ⚬ b + a ⚬ c := by noncomm_ring
 example : (a + b) ⚬ c = a ⚬ c + b ⚬ c := by noncomm_ring
 example : (a ⚬ b) ⚬ (a ⚬ a) = a ⚬ (b ⚬ (a ⚬ a)) := by noncomm_ring
+
+example : ⁅a, b ⚬ c⁆ = ⁅a, b⁆ ⚬ c + b ⚬ ⁅a, c⁆ := by noncomm_ring
+example : ⁅a ⚬ b, c⁆ = a ⚬ ⁅b, c⁆ + ⁅a, c⁆ ⚬ b := by noncomm_ring
+example : (a ⚬ b) ⚬ c - a ⚬ (b ⚬ c) = -⁅⁅a, b⁆, c⁆ + ⁅a, ⁅b, c⁆⁆ := by noncomm_ring


### PR DESCRIPTION
The two main results are the lemmas:
 * skew_adjoint_lie_subalgebra_equiv
 * skew_adjoint_matrices_lie_subalgebra_equiv

The latter is expected to be useful when defining the classical Lie algebras
of type B and D.


---

