### PR TITLE
feat(data/fintype): sigma_quotient_fin_card

### DIFF
--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -426,13 +426,6 @@ lemma fintype.card_eq_zero_iff [fintype α] : fintype.card α = 0 ↔ (α → fa
   λ h, have e : α ≃ empty := ⟨λ a, (h a).elim, λ a, a.elim, λ a, (h a).elim, λ a, a.elim⟩,
     by simp [fintype.card_congr e]⟩
 
-/-- A `fintype` with cardinality zero is equivalent to `pempty`. -/
-def fintype.equiv_pempty {α : Type v} [fintype α] (h : fintype.card α = 0) : α ≃ pempty.{v} :=
-{ to_fun := λ a, false.elim (fintype.card_eq_zero_iff.1 h a),
-  inv_fun := λ a, pempty.elim a,
-  left_inv := λ a, false.elim (fintype.card_eq_zero_iff.1 h a),
-  right_inv := λ a, pempty.elim a, }
-
 lemma fintype.card_pos_iff [fintype α] : 0 < fintype.card α ↔ nonempty α :=
 ⟨λ h, classical.by_contradiction (λ h₁,
   have fintype.card α = 0 := fintype.card_eq_zero_iff.2 (λ a, h₁ ⟨a⟩),

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -426,6 +426,13 @@ lemma fintype.card_eq_zero_iff [fintype α] : fintype.card α = 0 ↔ (α → fa
   λ h, have e : α ≃ empty := ⟨λ a, (h a).elim, λ a, a.elim, λ a, (h a).elim, λ a, a.elim⟩,
     by simp [fintype.card_congr e]⟩
 
+/-- A `fintype` with cardinality zero is equivalent to `pempty`. -/
+def fintype.equiv_pempty {α : Type v} [fintype α] (h : fintype.card α = 0) : α ≃ pempty.{v} :=
+{ to_fun := λ a, false.elim (fintype.card_eq_zero_iff.1 h a),
+  inv_fun := λ a, pempty.elim a,
+  left_inv := λ a, false.elim (fintype.card_eq_zero_iff.1 h a),
+  right_inv := λ a, pempty.elim a, }
+
 lemma fintype.card_pos_iff [fintype α] : 0 < fintype.card α ↔ nonempty α :=
 ⟨λ h, classical.by_contradiction (λ h₁,
   have fintype.card α = 0 := fintype.card_eq_zero_iff.2 (λ a, h₁ ⟨a⟩),
@@ -1016,6 +1023,52 @@ instance nat.infinite : infinite ℕ :=
 
 instance int.infinite : infinite ℤ :=
 infinite.of_injective int.of_nat (λ _ _, int.of_nat.inj)
+
+namespace equiv
+
+/--
+Given any `s : setoid α` on a `fintype α`,
+there is an `equiv` between `α` and the sigma type with base `quotient s`,
+and fiber over `q` given by `fin (fintype.card {x // ⟦x⟧ = q})`.
+
+Moreover, this equivalence takes each term `x : α`
+to a point in the fiber over its equivalence class.
+
+See also `equiv.sigma_quotient_fin_card` for the nonconstructive version.
+-/
+def sigma_quotient_fin_card_trunc
+  {α : Type*} [fa : fintype α] [decidable_eq α] (s : setoid α) [decidable_rel s.r] :
+  trunc { e : α ≃ Σ (q : quotient s), fin (fintype.card {x // ⟦x⟧ = q}) // ∀ x, (e x).1 = ⟦x⟧ } :=
+begin
+  unfreezingI { rcases fa with ⟨⟨S, hS₁⟩, hS₂⟩, },
+  refine quotient.rec_on_subsingleton S (λ l h₁ h₂, trunc.mk _) hS₁ hS₂, clear hS₂ hS₁ S,
+  fsplit,
+  { exact (equiv.sigma_preimage_equiv quotient.mk).symm.trans (equiv.sigma_congr_right (λ q,
+    fintype.equiv_fin_of_forall_mem_list
+      (λ ⟨x, px⟩, list.mem_pmap.2 ⟨x, list.mem_filter.2 ⟨h₂ _, px⟩, rfl⟩)
+      (list.nodup_pmap (λ a _ b _, congr_arg subtype.val) (list.nodup_filter _ h₁)))), },
+  { intro x, refl, }
+end
+
+open_locale classical
+
+/--
+Given any `s : setoid α` on a `fintype α`,
+there is an `equiv` between `α` and the sigma type with base `quotient s`,
+and fiber over `q` given by `fin (fintype.card {x // ⟦x⟧ = q})`.
+
+See also `equiv.sigma_quotient_fin_card_trunc` for the constructive version (wrapped in `trunc`).
+-/
+noncomputable def sigma_quotient_fin_card {α : Type*} [fintype α] (s : setoid α) :
+   α ≃ Σ (q : quotient s), fin (fintype.card {x // ⟦x⟧ = q}) :=
+(trunc.out (equiv.sigma_quotient_fin_card_trunc s)).1
+
+@[simp]
+lemma sigma_quot_fin_card_apply_fst {α : Type*} [fintype α] (s : setoid α) (x : α) :
+  ((equiv.sigma_quotient_fin_card s) x).1 = ⟦x⟧ :=
+(trunc.out (equiv.sigma_quotient_fin_card_trunc s)).2 x
+
+end equiv
 
 section trunc
 


### PR DESCRIPTION
Given any `s : setoid α` on a `fintype α`,
there is an `equiv` between `α` and the sigma type with base `quotient s`,
and fiber over `q` given by `fin (fintype.card {x // ⟦x⟧ = q})`.

See also `equiv.sigma_quotient_fin_card_trunc` for the constructive version (wrapped in `trunc`).

---
<!-- put comments you want to keep out of the PR commit here -->
