### PR TITLE
[Merged by Bors] - feat(algebra/pointwise): make instances global

### DIFF
--- a/src/algebra/pointwise.lean
+++ b/src/algebra/pointwise.lean
@@ -185,7 +185,7 @@ hs.image2 _ ht
 @[to_additive "addition preserves finiteness"]
 def fintype_mul [has_mul α] [decidable_eq α] (s t : set α) [hs : fintype s] [ht : fintype t] :
   fintype (s * t : set α) :=
-fintype_image2 _ s t
+set.fintype_image2 _ s t
 
 /-! Properties about inversion -/
 @[to_additive set.has_neg'] -- todo: remove prime once name becomes available

--- a/src/algebra/pointwise.lean
+++ b/src/algebra/pointwise.lean
@@ -1,274 +1,304 @@
 /-
 Copyright (c) 2019 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johan Commelin
+Authors: Johan Commelin, Floris van Doorn
 -/
 import algebra.module
 
 /-!
-
 # Pointwise addition, multiplication, and scalar multiplication of sets.
 
-This file defines `pointwise_mul`: for a type `α` with multiplication,
-multiplication is defined on `set α` by taking `s * t` to be the set
-of all `x * y` where `x ∈ s` and `y ∈ t`.
+This file defines pointwise algebraic operations on sets.
+* For a type `α` with multiplication, multiplication is defined on `set α` by taking
+  `s * t` to be the set of all `x * y` where `x ∈ s` and `y ∈ t`. Similarly for addition.
+* For `α` a semigroup, `set α` is a semigroup.
+* If `α` is a (commutative) monoid, we define an alias `set_semiring α` for `set α`, which then
+  becomes a (commutative) semiring with union as addition and pointwise multiplication as
+  multiplication.
+* For a type `β` with scalar multiplication by another type `α`, this
+  file defines a scalar multiplication of `set β` by `set α` and a separate scalar
+  multiplication of `set β` by `α`.
 
-Pointwise multiplication on `set α` where `α` is a semigroup makes
-`set α` into a semigroup. If `α` is additionally a (commutative)
-monoid, `set α` becomes a (commutative) semiring with union as
-addition. These are given by `pointwise_mul_semigroup` and
-`pointwise_mul_semiring`.
-
-Definitions and results are also transported to the additive theory
-via `to_additive`.
-
-For a type `β` with scalar multiplication by another type `α`, this
-file defines `pointwise_smul`. Separately it defines `smul_set`, for
-scalar multiplication of `set β` by a single term of type `α`.
+Appropriate definitions and results are also transported to the additive theory via `to_additive`.
 
 ## Implementation notes
+* The following expressions are considered in simp-normal form in a group:
+  `(λ h, h * g) ⁻¹' s`, `(λ h, g * h) ⁻¹' s`, `(λ h, h * g⁻¹) ⁻¹' s`, `(λ h, g⁻¹ * h) ⁻¹' s`,
+  `s * t`, `s⁻¹`, `(1 : set _)` (and similarly for additive variants).
+  Expressions equal to one of these will be simplified.
 
-Elsewhere, one should register local instances to use the definitions
-in this file.
+## Tags
+
+set multiplication, set addition, pointwise addition, pointwise multiplication
 
 -/
 
 namespace set
 open function
 
-variables {α : Type*} {β : Type*} (f : α → β)
+variables {α : Type*} {β : Type*} {s s₁ s₂ t t₁ t₂ u : set α} {a b : α} {x y : β}
 
+/-! Properties about 1 -/
 @[to_additive]
-def pointwise_one [has_one α] : has_one (set α) := ⟨{1}⟩
-
-local attribute [instance] pointwise_one
+instance [has_one α] : has_one (set α) := ⟨{1}⟩
 
 @[simp, to_additive]
-lemma mem_pointwise_one [has_one α] (a : α) :
-  a ∈ (1 : set α) ↔ a = 1 :=
-mem_singleton_iff
+lemma singleton_one [has_one α] : ({1} : set α) = 1 := rfl
+
+@[simp, to_additive]
+lemma mem_one [has_one α] : a ∈ (1 : set α) ↔ a = 1 := iff.rfl
 
 @[to_additive]
-def pointwise_mul [has_mul α] : has_mul (set α) :=
-  ⟨λ s t, {a | ∃ x ∈ s, ∃ y ∈ t, a = x * y}⟩
+lemma one_mem_one [has_one α] : (1 : α) ∈ (1 : set α) := eq.refl _
 
-local attribute [instance] pointwise_one pointwise_mul pointwise_add
-
-@[to_additive]
-lemma mem_pointwise_mul [has_mul α] {s t : set α} {a : α} :
-  a ∈ s * t ↔ ∃ x ∈ s, ∃ y ∈ t, a = x * y := iff.rfl
+@[simp, to_additive]
+theorem one_subset [has_one α] : 1 ⊆ s ↔ (1 : α) ∈ s := singleton_subset_iff
 
 @[to_additive]
-lemma mul_mem_pointwise_mul [has_mul α] {s t : set α} {a b : α} (ha : a ∈ s) (hb : b ∈ t) :
-  a * b ∈ s * t := ⟨_, ha, _, hb, rfl⟩
+theorem one_nonempty [has_one α] : (1 : set α).nonempty := ⟨1, rfl⟩
+
+@[simp, to_additive]
+theorem image_one [has_one α] {f : α → β} : f '' 1 = {f 1} := image_singleton
+
+/-! Properties about multiplication -/
+@[to_additive]
+instance [has_mul α] : has_mul (set α) := ⟨image2 has_mul.mul⟩
+
+@[simp, to_additive]
+lemma image2_mul [has_mul α] : image2 has_mul.mul s t = s * t := rfl
 
 @[to_additive]
-lemma pointwise_mul_eq_image [has_mul α] {s t : set α} :
-  s * t = (λ x : α × α, x.fst * x.snd) '' s.prod t :=
-set.ext $ λ a,
-⟨ by { rintros ⟨_, _, _, _, rfl⟩, exact ⟨(_, _), mem_prod.mpr ⟨‹_›, ‹_›⟩, rfl⟩ },
-  by { rintros ⟨_, _, rfl⟩, exact ⟨_, (mem_prod.mp ‹_›).1, _, (mem_prod.mp ‹_›).2, rfl⟩ }⟩
+lemma mem_mul [has_mul α] : a ∈ s * t ↔ ∃ x y, x ∈ s ∧ y ∈ t ∧ x * y = a := iff.rfl
 
 @[to_additive]
-lemma pointwise_mul_finite [has_mul α] {s t : set α} (hs : finite s) (ht : finite t) :
-  finite (s * t) :=
-by { rw pointwise_mul_eq_image, exact (hs.prod ht).image _ }
+lemma mul_mem_mul [has_mul α] (ha : a ∈ s) (hb : b ∈ t) : a * b ∈ s * t := mem_image2_of_mem ha hb
 
-@[to_additive pointwise_add_add_semigroup]
-def pointwise_mul_semigroup [semigroup α] : semigroup (set α) :=
-{ mul_assoc := λ _ _ _, set.ext $ λ _,
-  begin
-    split,
-    { rintros ⟨_, ⟨_, _, _, _, rfl⟩, _, _, rfl⟩,
-      exact ⟨_, ‹_›, _, ⟨_, ‹_›, _, ‹_›, rfl⟩, mul_assoc _ _ _⟩ },
-    { rintros ⟨_, _, _, ⟨_, _, _, _, rfl⟩, rfl⟩,
-      exact ⟨_, ⟨_, ‹_›, _, ‹_›, rfl⟩, _, ‹_›, (mul_assoc _ _ _).symm⟩ }
-  end,
-  ..pointwise_mul }
+@[to_additive add_image_prod]
+lemma image_mul_prod [has_mul α] : (λ x : α × α, x.fst * x.snd) '' s.prod t = s * t := image_prod _
 
-@[to_additive pointwise_add_add_monoid]
-def pointwise_mul_monoid [monoid α] : monoid (set α) :=
-{ one_mul := λ s, set.ext $ λ a,
-    ⟨by {rintros ⟨_, _, _, _, rfl⟩, simp * at *},
-     λ h, ⟨1, mem_singleton 1, a, h, (one_mul a).symm⟩⟩,
-  mul_one := λ s, set.ext $ λ a,
-    ⟨by {rintros ⟨_, _, _, _, rfl⟩, simp * at *},
-     λ h, ⟨a, h, 1, mem_singleton 1, (mul_one a).symm⟩⟩,
-  ..pointwise_mul_semigroup,
-  ..pointwise_one }
+@[simp, to_additive]
+lemma image_mul_left [group α] : (λ b, a * b) '' t = (λ b, a⁻¹ * b) ⁻¹' t :=
+by { rw image_eq_preimage_of_inverse; intro c; simp }
 
-local attribute [instance] pointwise_mul_monoid
+@[simp, to_additive]
+lemma image_mul_right [group α] : (λ a, a * b) '' t = (λ a, a * b⁻¹) ⁻¹' t :=
+by { rw image_eq_preimage_of_inverse; intro c; simp }
+
+@[to_additive]
+lemma image_mul_left' [group α] : (λ b, a⁻¹ * b) '' t = (λ b, a * b) ⁻¹' t := by simp
+
+@[to_additive]
+lemma image_mul_right' [group α] : (λ a, a * b⁻¹) '' t = (λ a, a * b) ⁻¹' t := by simp
+
+@[simp, to_additive]
+lemma preimage_mul_left_one [group α] : (λ b, a * b) ⁻¹' 1 = {a⁻¹} :=
+by rw [← image_mul_left', image_one, mul_one]
+
+@[simp, to_additive]
+lemma preimage_mul_right_one [group α] : (λ a, a * b) ⁻¹' 1 = {b⁻¹} :=
+by rw [← image_mul_right', image_one, one_mul]
+
+@[to_additive]
+lemma preimage_mul_left_one' [group α] : (λ b, a⁻¹ * b) ⁻¹' 1 = {a} := by simp
+
+@[to_additive]
+lemma preimage_mul_right_one' [group α] : (λ a, a * b) ⁻¹' 1 = {b⁻¹} := by simp
+
+@[simp, to_additive]
+lemma mul_singleton [has_mul α] : s * {b} = (λ a, a * b) '' s := image2_singleton_right
+
+@[simp, to_additive]
+lemma singleton_mul [has_mul α] : {a} * t = (λ b, a * b) '' t := image2_singleton_left
+
+@[simp, to_additive]
+lemma singleton_mul_singleton [has_mul α] : ({a} : set α) * {b} = {a * b} := image2_singleton
+
+@[to_additive set.add_semigroup]
+instance [semigroup α] : semigroup (set α) :=
+{ mul_assoc :=
+    by { intros, simp only [← image2_mul, image2_image2_left, image2_image2_right, mul_assoc] },
+  ..set.has_mul }
+
+@[to_additive set.add_monoid]
+instance [monoid α] : monoid (set α) :=
+{ mul_one := λ s, by { simp only [← singleton_one, mul_singleton, mul_one, image_id'] },
+  one_mul := λ s, by { simp only [← singleton_one, singleton_mul, one_mul, image_id'] },
+  ..set.semigroup,
+  ..set.has_one }
+
+@[to_additive]
+protected lemma mul_comm [comm_semigroup α] : s * t = t * s :=
+by simp only [← image2_mul, image2_swap _ s, mul_comm]
+
+@[to_additive set.add_comm_monoid]
+instance [comm_monoid α] : comm_monoid (set α) :=
+{ mul_comm := λ _ _, set.mul_comm, ..set.monoid }
 
 @[to_additive]
 lemma singleton.is_mul_hom [has_mul α] : is_mul_hom (singleton : α → set α) :=
-{ map_mul := λ x y, set.ext $ λ a, by simp [mem_singleton_iff, mem_pointwise_mul] }
-
-@[to_additive is_add_monoid_hom]
-lemma singleton.is_monoid_hom [monoid α] : is_monoid_hom (singleton : α → set α) :=
-{ map_one := rfl, ..singleton.is_mul_hom }
-
-@[to_additive]
-def pointwise_inv [has_inv α] : has_inv (set α) :=
-⟨λ s, {a | a⁻¹ ∈ s}⟩
+{ map_mul := λ a b, singleton_mul_singleton.symm }
 
 @[simp, to_additive]
-lemma pointwise_mul_empty [has_mul α] (s : set α) :
-  s * ∅ = ∅ :=
-set.ext $ λ a, ⟨by {rintros ⟨_, _, _, _, rfl⟩, tauto}, false.elim⟩
+lemma empty_mul [has_mul α] : ∅ * s = ∅ := image2_empty_left
 
 @[simp, to_additive]
-lemma empty_pointwise_mul [has_mul α] (s : set α) :
-  ∅ * s = ∅ :=
-set.ext $ λ a, ⟨by {rintros ⟨_, _, _, _, rfl⟩, tauto}, false.elim⟩
+lemma mul_empty [has_mul α] : s * ∅ = ∅ := image2_empty_right
 
 @[to_additive]
-lemma pointwise_mul_subset_mul [has_mul α] {s₁ s₂ t₁ t₂ : set α} (h₁ : s₁ ⊆ t₁) (h₂ : s₂ ⊆ t₂) :
-  s₁ * s₂ ⊆ t₁ * t₂ :=
-by {rintros _ ⟨_, _, _, _, rfl⟩, exact ⟨_, h₁ ‹_›, _, h₂ ‹_›, rfl⟩ }
+lemma mul_subset_mul [has_mul α] (h₁ : s₁ ⊆ t₁) (h₂ : s₂ ⊆ t₂) : s₁ * s₂ ⊆ t₁ * t₂ :=
+image2_subset h₁ h₂
 
 @[to_additive]
-lemma pointwise_mul_union [has_mul α] (s t u : set α) :
-  s * (t ∪ u) = (s * t) ∪ (s * u) :=
-begin
-  ext a, split,
-  { rintros ⟨_, _, _, H, rfl⟩,
-    cases H; [left, right]; exact ⟨_, ‹_›, _, ‹_›, rfl⟩ },
-  { intro H,
-    cases H with H H;
-    { rcases H with ⟨_, _, _, _, rfl⟩,
-      refine ⟨_, ‹_›, _, _, rfl⟩,
-      erw mem_union,
-      simp * } }
-end
+lemma union_mul [has_mul α] : (s ∪ t) * u = (s * u) ∪ (t * u) := image2_union_left
 
 @[to_additive]
-lemma union_pointwise_mul [has_mul α] (s t u : set α) :
-  (s ∪ t) * u = (s * u) ∪ (t * u) :=
-begin
-  ext a, split,
-  { rintros ⟨_, H, _, _, rfl⟩,
-    cases H; [left, right]; exact ⟨_, ‹_›, _, ‹_›, rfl⟩ },
-  { intro H,
-    cases H with H H;
-    { rcases H with ⟨_, _, _, _, rfl⟩;
-      refine ⟨_, _, _, ‹_›, rfl⟩;
-      erw mem_union;
-      simp * } }
-end
+lemma mul_union [has_mul α] : s * (t ∪ u) = (s * t) ∪ (s * u) := image2_union_right
 
 @[to_additive]
-lemma pointwise_mul_eq_Union_mul_left [has_mul α] {s t : set α} : s * t = ⋃a∈s, (λx, a * x) '' t :=
-by { ext y; split; simp only [mem_Union]; rintros ⟨a, ha, x, hx, ax⟩; exact ⟨a, ha, x, hx, ax.symm⟩ }
+lemma Union_mul_left_image [has_mul α] : (⋃ a ∈ s, (λ x, a * x) '' t) = s * t :=
+Union_image_left _
 
 @[to_additive]
-lemma pointwise_mul_eq_Union_mul_right [has_mul α] {s t : set α} : s * t = ⋃a∈t, (λx, x * a) '' s :=
-by { ext y; split; simp only [mem_Union]; rintros ⟨a, ha, x, hx, ax⟩; exact ⟨x, hx, a, ha, ax.symm⟩ }
-
-@[to_additive]
-lemma nonempty.pointwise_mul [has_mul α] {s t : set α} : s.nonempty → t.nonempty → (s * t).nonempty
-| ⟨x, hx⟩ ⟨y, hy⟩ := ⟨x * y, ⟨x, hx, y, hy, rfl⟩⟩
+lemma Union_mul_right_image [has_mul α] : (⋃ a ∈ t, (λ x, x * a) '' s) = s * t :=
+Union_image_right _
 
 @[simp, to_additive]
-lemma univ_pointwise_mul_univ [monoid α] : (univ : set α) * univ = univ :=
+lemma univ_mul_univ [monoid α] : (univ : set α) * univ = univ :=
 begin
-  have : ∀x, ∃a b : α, x = a * b := λx, ⟨x, ⟨1, (mul_one x).symm⟩⟩,
-  show {a | ∃ x ∈ univ, ∃ y ∈ univ, a = x * y} = univ,
-  simpa [eq_univ_iff_forall]
+  have : ∀x, ∃a b : α, a * b = x := λx, ⟨x, ⟨1, mul_one x⟩⟩,
+  simpa only [mem_mul, eq_univ_iff_forall, mem_univ, true_and]
 end
 
-def pointwise_mul_fintype [has_mul α] [decidable_eq α] (s t : set α) [hs : fintype s] [ht : fintype t] :
-  fintype (s * t : set α) := by { rw pointwise_mul_eq_image, apply set.fintype_image }
+/-- `singleton` is a monoid hom. -/
+@[to_additive singleton_add_hom "singleton is an add monoid hom"]
+def singleton_hom [monoid α] : α →* set α :=
+{ to_fun := singleton, map_one' := rfl, map_mul' := λ a b, singleton_mul_singleton.symm }
 
-def pointwise_add_fintype [has_add α] [decidable_eq α] (s t : set α) [hs : fintype s] [ht : fintype t] :
-  fintype (s + t : set α) := by { rw pointwise_add_eq_image, apply set.fintype_image }
+@[to_additive]
+lemma nonempty.mul [has_mul α] : s.nonempty → t.nonempty → (s * t).nonempty := nonempty.image2
 
-attribute [to_additive] set.pointwise_mul_fintype
+@[to_additive]
+lemma finite.mul [has_mul α] (hs : finite s) (ht : finite t) : finite (s * t) :=
+hs.image2 _ ht
 
-/-- Pointwise scalar multiplication by a set of scalars. -/
-def pointwise_smul [has_scalar α β] : has_scalar (set α) (set β) :=
-  ⟨λ s t, { x | ∃ a ∈ s, ∃ y ∈ t, x  = a • y }⟩
+/-- multiplication preserves finiteness -/
+@[to_additive "addition preserves finiteness"]
+def fintype_mul [has_mul α] [decidable_eq α] (s t : set α) [hs : fintype s] [ht : fintype t] :
+  fintype (s * t : set α) :=
+fintype_image2 _ s t
+
+/-! Properties about inversion -/
+@[to_additive set.has_neg'] -- todo: remove prime once name becomes available
+instance [has_inv α] : has_inv (set α) :=
+⟨preimage has_inv.inv⟩
+
+@[simp, to_additive]
+lemma mem_inv [has_inv α] : a ∈ s⁻¹ ↔ a⁻¹ ∈ s := iff.rfl
+
+@[to_additive]
+lemma inv_mem_inv [group α] : a⁻¹ ∈ s⁻¹ ↔ a ∈ s :=
+by simp only [mem_inv, inv_inv]
+
+@[simp, to_additive]
+lemma inv_preimage [has_inv α] : has_inv.inv ⁻¹' s = s⁻¹ := rfl
+
+@[simp, to_additive]
+lemma image_inv [group α] : has_inv.inv '' s = s⁻¹ :=
+by { simp only [← inv_preimage], rw [image_eq_preimage_of_inverse]; intro; simp only [inv_inv] }
+
+@[simp, to_additive]
+lemma inter_inv [has_inv α] : (s ∩ t)⁻¹ = s⁻¹ ∩ t⁻¹ := preimage_inter
+
+@[simp, to_additive]
+lemma union_inv [has_inv α] : (s ∪ t)⁻¹ = s⁻¹ ∪ t⁻¹ := preimage_union
+
+@[simp, to_additive]
+lemma compl_inv [has_inv α] : (sᶜ)⁻¹ = (s⁻¹)ᶜ := preimage_compl
+
+@[simp, to_additive]
+protected lemma inv_inv [group α] : s⁻¹⁻¹ = s :=
+by { simp only [← inv_preimage, preimage_preimage, inv_inv, preimage_id'] }
+
+@[simp, to_additive]
+protected lemma univ_inv [group α] : (univ : set α)⁻¹ = univ := preimage_univ
+
+/-! Properties about scalar multiplication -/
 
 /-- Scaling a set: multiplying every element by a scalar. -/
-def smul_set [has_scalar α β] : has_scalar α (set β) :=
-  ⟨λ a s, { x | ∃ y ∈ s, x = a • y }⟩
+instance has_scalar_set [has_scalar α β] : has_scalar α (set β) :=
+⟨λ a, image (has_scalar.smul a)⟩
 
-local attribute [instance] pointwise_smul smul_set
+@[simp]
+lemma image_smul [has_scalar α β] {t : set β} : (λ x, a • x) '' t = a • t := rfl
 
-lemma mem_smul_set [has_scalar α β] (a : α) (s : set β) (x : β) :
-  x ∈ a • s ↔ ∃ y ∈ s, x = a • y := iff.rfl
+lemma mem_smul_set [has_scalar α β] {t : set β} : x ∈ a • t ↔ ∃ y, y ∈ t ∧ a • y = x := iff.rfl
 
-lemma smul_set_eq_image [has_scalar α β] (a : α) (s : set β) :
-  a • s = (λ x, a • x) '' s :=
-set.ext $ λ x, iff.intro
-  (λ ⟨_, hy₁, hy₂⟩, ⟨_, hy₁, hy₂.symm⟩)
-  (λ ⟨_, hy₁, hy₂⟩, ⟨_, hy₁, hy₂.symm⟩)
+lemma smul_mem_smul_set [has_scalar α β] {t : set β} (hy : y ∈ t) : a • y ∈ a • t :=
+⟨y, hy, rfl⟩
 
-lemma smul_set_eq_pointwise_smul_singleton [has_scalar α β]
-  (a : α) (s : set β) : a • s = ({a} : set α) • s :=
-set.ext $ λ x, iff.intro
-  (λ ⟨_, h⟩, ⟨a, mem_singleton _, _, h⟩)
-  (λ ⟨_, h, y, hy, hx⟩, ⟨_, hy, by {
-    rw mem_singleton_iff at h; rwa h at hx }⟩)
+lemma smul_set_union [has_scalar α β] {s t : set β} : a • (s ∪ t) = a • s ∪ a • t :=
+by simp only [← image_smul, image_union]
 
-lemma smul_mem_smul_set [has_scalar α β]
-  (a : α) {s : set β} {y : β} (hy : y ∈ s) : a • y ∈ a • s :=
-by rw mem_smul_set; use [y, hy]
+@[simp]
+lemma smul_set_empty [has_scalar α β] (a : α) : a • (∅ : set β) = ∅ :=
+by rw [← image_smul, image_empty]
 
-lemma smul_set_union [has_scalar α β] (a : α) (s t : set β) :
-  a • (s ∪ t) = a • s ∪ a • t :=
-by simp only [smul_set_eq_image, image_union]
+lemma smul_set_mono [has_scalar α β] {s t : set β} (h : s ⊆ t) : a • s ⊆ a • t :=
+by { simp only [← image_smul, image_subset, h] }
 
-@[simp] lemma smul_set_empty [has_scalar α β] (a : α) :
-  a • (∅ : set β) = ∅ :=
-by rw [smul_set_eq_image, image_empty]
+/-- Pointwise scalar multiplication by a set of scalars. -/
+instance [has_scalar α β] : has_scalar (set α) (set β) := ⟨image2 has_scalar.smul⟩
 
-lemma smul_set_mono [has_scalar α β]
-  (a : α) {s t : set β} (h : s ⊆ t) : a • s ⊆ a • t :=
-by { rw [smul_set_eq_image, smul_set_eq_image], exact image_subset _ h }
+@[simp]
+lemma image2_smul [has_scalar α β] {t : set β} : image2 has_scalar.smul s t = s • t := rfl
+
+lemma mem_smul [has_scalar α β] {t : set β} : x ∈ s • t ↔ ∃ a y, a ∈ s ∧ y ∈ t ∧ a • y = x :=
+iff.rfl
+
+lemma image_smul_prod [has_scalar α β] {t : set β} :
+  (λ x : α × β, x.fst • x.snd) '' s.prod t = s • t :=
+image_prod _
+
+lemma singleton_smul [has_scalar α β] {t : set β} : ({a} : set α) • t = a • t :=
+image2_singleton_left
 
 section monoid
 
-def pointwise_mul_semiring [monoid α] : semiring (set α) :=
-{ add := (⊔),
-  zero := ∅,
-  add_assoc := set.union_assoc,
-  zero_add := set.empty_union,
-  add_zero := set.union_empty,
-  add_comm := set.union_comm,
-  zero_mul := empty_pointwise_mul,
-  mul_zero := pointwise_mul_empty,
-  left_distrib := pointwise_mul_union,
-  right_distrib := union_pointwise_mul,
-  ..pointwise_mul_monoid }
+/-! `set α` as a `(∪,*)`-semiring -/
 
-def pointwise_mul_comm_semiring [comm_monoid α] : comm_semiring (set α) :=
-{ mul_comm := λ s t, set.ext $ λ a,
-  by split; { rintros ⟨_, _, _, _, rfl⟩, exact ⟨_, ‹_›, _, ‹_›, mul_comm _ _⟩ },
-  ..pointwise_mul_semiring }
+/-- An alias for `set α`, which has a semiring structure given by `∪` as "addition" and pointwise
+  multiplication `*` as "multiplication". -/
+@[derive inhabited] def set_semiring (α : Type*) : Type* := set α
 
-local attribute [instance] pointwise_mul_semiring
+/-- The identitiy function `set α → set_semiring α`. -/
+protected def up (s : set α) : set_semiring α := s
+/-- The identitiy function `set_semiring α → set α`. -/
+protected def set_semiring.down (s : set_semiring α) : set α := s
+@[simp] protected lemma down_up {s : set α} : s.up.down = s := rfl
+@[simp] protected lemma up_down {s : set_semiring α} : s.down.up = s := rfl
 
-def comm_monoid [comm_monoid α] : comm_monoid (set α) :=
-@comm_semiring.to_comm_monoid (set α) pointwise_mul_comm_semiring
+instance set_semiring.semiring [monoid α] : semiring (set_semiring α) :=
+{ add := λ s t, (s ∪ t : set α),
+  zero := (∅ : set α),
+  add_assoc := union_assoc,
+  zero_add := empty_union,
+  add_zero := union_empty,
+  add_comm := union_comm,
+  zero_mul := λ s, empty_mul,
+  mul_zero := λ s, mul_empty,
+  left_distrib := λ _ _ _, mul_union,
+  right_distrib := λ _ _ _, union_mul,
+  ..set.monoid }
 
-def add_comm_monoid [add_comm_monoid α] : add_comm_monoid (set α) :=
-show @add_comm_monoid (additive (set (multiplicative α))),
-from @additive.add_comm_monoid _ set.comm_monoid
-
-attribute [to_additive set.add_comm_monoid] set.comm_monoid
+instance set_semiring.comm_semiring [comm_monoid α] : comm_semiring (set_semiring α) :=
+{ ..set.comm_monoid, ..set_semiring.semiring }
 
 /-- A multiplicative action of a monoid on a type β gives also a
  multiplicative action on the subsets of β. -/
-def smul_set_action [monoid α] [mul_action α β] :
-  mul_action α (set β) :=
-{ smul     := λ a s, a • s,
-  mul_smul := λ a b s, set.ext $ λ x, iff.intro
-    (λ ⟨_, hy, _⟩, ⟨b • _, smul_mem_smul_set _ hy, by rwa ←mul_smul⟩)
-    (λ ⟨_, hy, _⟩, let ⟨_, hz, h⟩ := (mem_smul_set _ _ _).2 hy in
-      ⟨_, hz, by rwa [mul_smul, ←h]⟩),
-  one_smul := λ b, set.ext $ λ x, iff.intro
-    (λ ⟨_, _, h⟩, by { rw [one_smul] at h; rwa h })
-    (λ h, ⟨_, h, by rw one_smul⟩) }
+instance mul_action_set [monoid α] [mul_action α β] : mul_action α (set β) :=
+{ mul_smul := by { intros, simp only [← image_smul, image_image, ← mul_smul] },
+  one_smul := by { intros, simp only [← image_smul, image_eta, one_smul, image_id'] },
+  ..set.has_scalar_set }
 
 section is_mul_hom
 open is_mul_hom
@@ -276,37 +306,23 @@ open is_mul_hom
 variables [has_mul α] [has_mul β] (m : α → β) [is_mul_hom m]
 
 @[to_additive]
-lemma image_pointwise_mul (s t : set α) : m '' (s * t) = m '' s * m '' t :=
-set.ext $ assume y,
-begin
-  split,
-  { rintros ⟨_, ⟨_, _, _, _, rfl⟩, rfl⟩,
-    refine ⟨_, mem_image_of_mem _ ‹_›, _, mem_image_of_mem _ ‹_›, map_mul _ _ _⟩ },
-  { rintros ⟨_, ⟨_, _, rfl⟩, _, ⟨_, _, rfl⟩, rfl⟩,
-    refine ⟨_, ⟨_, ‹_›, _, ‹_›, rfl⟩, map_mul _ _ _⟩ }
-end
+lemma image_mul : m '' (s * t) = m '' s * m '' t :=
+by { simp only [← image2_mul, image_image2, image2_image_left, image2_image_right, map_mul m] }
 
 @[to_additive]
-lemma preimage_pointwise_mul_preimage_subset (s t : set β) : m ⁻¹' s * m ⁻¹' t ⊆ m ⁻¹' (s * t) :=
-begin
-  rintros _ ⟨_, _, _, _, rfl⟩,
-  exact ⟨_, ‹_›, _, ‹_›, map_mul _ _ _⟩,
-end
+lemma preimage_mul_preimage_subset {s t : set β} : m ⁻¹' s * m ⁻¹' t ⊆ m ⁻¹' (s * t) :=
+by { rintros _ ⟨_, _, _, _, rfl⟩, exact ⟨_, _, ‹_›, ‹_›, (map_mul _ _ _).symm ⟩ }
 
 end is_mul_hom
 
-variables [monoid α] [monoid β] [is_monoid_hom f]
-
-/--
-The image of a set under function is a ring homomorphism
-with respect to the pointwise operations on sets.
--/
-def pointwise_mul_image_ring_hom : set α →+* set β :=
+/-- The image of a set under function is a ring homomorphism
+with respect to the pointwise operations on sets. -/
+def image_hom [monoid α] [monoid β] (f : α →* β) : set_semiring α →+* set_semiring β :=
 { to_fun := image f,
   map_zero' := image_empty _,
-  map_one' := by erw [image_singleton, is_monoid_hom.map_one f]; refl,
+  map_one' := by simp only [← singleton_one, image_singleton, is_monoid_hom.map_one f],
   map_add' := image_union _,
-  map_mul' := image_pointwise_mul _ }
+  map_mul' := λ _ _, image_mul _ }
 
 end monoid
 
@@ -318,26 +334,18 @@ open set
 
 variables {α : Type*} {β : Type*}
 
-local attribute [instance] set.smul_set
-
 /-- A nonempty set in a semimodule is scaled by zero to the singleton
 containing 0 in the semimodule. -/
-lemma zero_smul_set [semiring α] [add_comm_monoid β] [semimodule α β]
-  {s : set β} (h : s.nonempty) : (0 : α) • s = {(0 : β)} :=
-set.ext $ λ x, iff.intro
-(λ ⟨_, _, hx⟩, mem_singleton_iff.mpr (by { rwa [hx, zero_smul] }))
-(λ hx, let ⟨_, hs⟩ := h in
-  ⟨_, hs, by { rw mem_singleton_iff at hx; rw [hx, zero_smul] }⟩)
+lemma zero_smul_set [semiring α] [add_comm_monoid β] [semimodule α β] {s : set β} (h : s.nonempty) :
+  (0 : α) • s = (0 : set β) :=
+by simp only [← image_smul, image_eta, zero_smul, h.image_const, singleton_zero]
 
-lemma mem_inv_smul_set_iff [field α] [mul_action α β]
-  {a : α} (ha : a ≠ 0) (A : set β) (x : β) : x ∈ a⁻¹ • A ↔ a • x ∈ A :=
-iff.intro
-  (λ ⟨y, hy, h⟩, by rwa [h, ←mul_smul, mul_inv_cancel ha, one_smul])
-  (λ h, ⟨_, h, by rw [←mul_smul, inv_mul_cancel ha, one_smul]⟩)
+lemma mem_inv_smul_set_iff [field α] [mul_action α β] {a : α} (ha : a ≠ 0) (A : set β) (x : β) :
+  x ∈ a⁻¹ • A ↔ a • x ∈ A :=
+by simp only [← image_smul, mem_image, inv_smul_eq_iff ha, exists_eq_right]
 
-lemma mem_smul_set_iff_inv_smul_mem [field α] [mul_action α β]
-  {a : α} (ha : a ≠ 0) (A : set β) (x : β) : x ∈ a • A ↔ a⁻¹ • x ∈ A :=
-by conv_lhs { rw ← inv_inv' a };
-   exact (mem_inv_smul_set_iff (inv_ne_zero ha) _ _)
+lemma mem_smul_set_iff_inv_smul_mem [field α] [mul_action α β] {a : α} (ha : a ≠ 0) (A : set β)
+  (x : β) : x ∈ a • A ↔ a⁻¹ • x ∈ A :=
+by rw [← mem_inv_smul_set_iff $ inv_ne_zero ha, inv_inv']
 
 end

--- a/src/algebraic_geometry/prime_spectrum.lean
+++ b/src/algebraic_geometry/prime_spectrum.lean
@@ -176,7 +176,7 @@ lemma zero_locus_bot :
 (gc R).l_bot
 
 @[simp] lemma zero_locus_singleton_zero :
-  zero_locus ({0} : set R) = set.univ :=
+  zero_locus (0 : set R) = set.univ :=
 zero_locus_bot
 
 @[simp] lemma zero_locus_empty :

--- a/src/analysis/convex/basic.lean
+++ b/src/analysis/convex/basic.lean
@@ -48,8 +48,6 @@ open_locale classical big_operators
 
 local notation `I` := (Icc 0 1 : set ℝ)
 
-local attribute [instance] set.pointwise_add set.smul_set
-
 section sets
 
 /-! ### Segment -/
@@ -145,11 +143,11 @@ lemma convex_iff_pointwise_add_subset:
   convex s ↔ ∀ ⦃a b : ℝ⦄, 0 ≤ a → 0 ≤ b → a + b = 1 → a • s + b • s ⊆ s :=
 iff.intro
   begin
-    rintros hA a b ha hb hab w ⟨au, ⟨u, hu, rfl⟩, bv, ⟨v, hv, rfl⟩, rfl⟩,
+    rintros hA a b ha hb hab w ⟨au, bv, ⟨u, hu, rfl⟩, ⟨v, hv, rfl⟩, rfl⟩,
     exact hA hu hv ha hb hab
   end
   (λ h x y hx hy a b ha hb hab,
-    (h ha hb hab) (set.add_mem_pointwise_add ⟨_, hx, rfl⟩ ⟨_, hy, rfl⟩))
+    (h ha hb hab) (set.add_mem_add ⟨_, hx, rfl⟩ ⟨_, hy, rfl⟩))
 
 /-- Alternative definition of set convexity, using division -/
 lemma convex_iff_div:
@@ -235,7 +233,7 @@ hs.is_linear_preimage is_linear_map.is_linear_map_neg
 
 lemma convex.smul (c : ℝ) (hs : convex s) : convex (c • s) :=
 begin
-  rw smul_set_eq_image,
+  rw ← image_smul,
   exact hs.is_linear_image (is_linear_map.is_linear_map_smul c)
 end
 
@@ -243,7 +241,7 @@ lemma convex.smul_preimage (c : ℝ) (hs : convex s) : convex ((λ z, c • z) �
 hs.is_linear_preimage (is_linear_map.is_linear_map_smul c)
 
 lemma convex.add {t : set E}  (hs : convex s) (ht : convex t) : convex (s + t) :=
-by { rw pointwise_add_eq_image, exact (hs.prod ht).is_linear_image is_linear_map.is_linear_map_add }
+by { rw ← add_image_prod, exact (hs.prod ht).is_linear_image is_linear_map.is_linear_map_add }
 
 lemma convex.sub {t : set E}  (hs : convex s) (ht : convex t) :
   convex ((λx : E × E, x.1 - x.2) '' (s.prod t)) :=
@@ -253,13 +251,13 @@ lemma convex.translate (hs : convex s) (z : E) : convex ((λx, z + x) '' s) :=
 begin
   convert (convex_singleton z).add hs,
   ext x,
-  simp [set.mem_image, mem_pointwise_add, eq_comm]
+  simp [set.mem_image, mem_add, eq_comm]
 end
 
 lemma convex.affinity (hs : convex s) (z : E) (c : ℝ) : convex ((λx, z + c • x) '' s) :=
 begin
   convert (hs.smul c).translate z using 1,
-  erw [smul_set_eq_image, ←image_comp]
+  erw [← image_smul, ←image_comp]
 end
 
 lemma convex_real_iff {s : set ℝ} :

--- a/src/analysis/convex/cone.lean
+++ b/src/analysis/convex/cone.lean
@@ -193,15 +193,13 @@ end convex_cone
 
 namespace convex
 
-local attribute [instance] smul_set
-
 /-- The set of vectors proportional to those in a convex set forms a convex cone. -/
 def to_cone (s : set E) (hs : convex s) : convex_cone E :=
 begin
   apply convex_cone.mk (⋃ c > 0, (c : ℝ) • s);
     simp only [mem_Union, mem_smul_set],
   { rintros c c_pos _ ⟨c', c'_pos, x, hx, rfl⟩,
-    exact ⟨c * c', mul_pos c_pos c'_pos, x, hx, smul_smul _ _ _⟩ },
+    exact ⟨c * c', mul_pos c_pos c'_pos, x, hx, (smul_smul _ _ _).symm⟩ },
   { rintros _ ⟨cx, cx_pos, x, hx, rfl⟩ _ ⟨cy, cy_pos, y, hy, rfl⟩,
     have : 0 < cx + cy, from add_pos cx_pos cy_pos,
     refine ⟨_, this, _, convex_iff_div.1 hs hx hy (le_of_lt cx_pos) (le_of_lt cy_pos) this, _⟩,
@@ -212,7 +210,7 @@ variables {s : set E} (hs : convex s) {x : E}
 
 @[nolint ge_or_gt]
 lemma mem_to_cone : x ∈ hs.to_cone s ↔ ∃ (c > 0) (y ∈ s), (c : ℝ) • y = x :=
-by simp only [to_cone, convex_cone.mem_mk, mem_Union, mem_smul_set, eq_comm]
+by simp only [to_cone, convex_cone.mem_mk, mem_Union, mem_smul_set, eq_comm, exists_prop]
 
 @[nolint ge_or_gt]
 lemma mem_to_cone' : x ∈ hs.to_cone s ↔ ∃ c > 0, (c : ℝ) • x ∈ s :=

--- a/src/analysis/convex/topology.lean
+++ b/src/analysis/convex/topology.lean
@@ -71,8 +71,6 @@ section topological_vector_space
 variables [add_comm_group E] [vector_space ℝ E] [topological_space E]
   [topological_add_group E] [topological_vector_space ℝ E]
 
-local attribute [instance] set.pointwise_add set.smul_set
-
 /-- In a topological vector space, the interior of a convex set is convex. -/
 lemma convex.interior {s : set E} (hs : convex s) : convex (interior s) :=
 convex_iff_pointwise_add_subset.mpr $ λ a b ha hb hab,
@@ -80,17 +78,13 @@ convex_iff_pointwise_add_subset.mpr $ λ a b ha hb hab,
   or.elim (classical.em (a = 0))
   (λ heq,
     have hne : b ≠ 0, by { rw [heq, zero_add] at hab, rw hab, exact one_ne_zero },
-    (smul_set_eq_image b (interior s)).symm ▸
-    (is_open_pointwise_add_left ((is_open_map_smul_of_ne_zero hne _) is_open_interior)))
+    by { rw ← image_smul, apply is_open_add_left,
+         exact is_open_map_smul_of_ne_zero hne _ is_open_interior } )
   (λ hne,
-    (smul_set_eq_image a (interior s)).symm ▸
-    (is_open_pointwise_add_right ((is_open_map_smul_of_ne_zero hne _) is_open_interior))),
+    by { rw ← image_smul, apply is_open_add_right,
+         exact is_open_map_smul_of_ne_zero hne _ is_open_interior }),
   (subset_interior_iff_subset_of_open h).mpr $ subset.trans
-    begin
-      apply pointwise_add_subset_add;
-      rw [smul_set_eq_image, smul_set_eq_image];
-      exact image_subset _ interior_subset
-    end
+    (by { simp only [← image_smul], apply add_subset_add; exact image_subset _ interior_subset })
     (convex_iff_pointwise_add_subset.mp hs ha hb hab)
 
 /-- In a topological vector space, the closure of a convex set is convex. -/

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -301,6 +301,15 @@ fintype.of_finset (s.to_finset.product t.to_finset) $ by simp
 lemma finite.prod {s : set α} {t : set β} : finite s → finite t → finite (set.prod s t)
 | ⟨hs⟩ ⟨ht⟩ := by exactI ⟨set.fintype_prod s t⟩
 
+/-- `image2 f s t` is finitype if `s` and `t` are. -/
+instance fintype_image2 [decidable_eq γ] (f : α → β → γ) (s : set α) (t : set β)
+  [hs : fintype s] [ht : fintype t] : fintype (image2 f s t : set γ) :=
+by { rw ← image_prod, apply set.fintype_image }
+
+lemma finite.image2 (f : α → β → γ) {s : set α} {t : set β} (hs : finite s) (ht : finite t) :
+  finite (image2 f s t) :=
+by { rw ← image_prod, exact (hs.prod ht).image _ }
+
 /-- If `s : set α` is a set with `fintype` instance and `f : α → set β` is a function such that
 each `f a`, `a ∈ s`, has a `fintype` structure, then `s >>= f` has a `fintype` structure. -/
 def fintype_bind {α β} [decidable_eq β] (s : set α) [fintype s]

--- a/src/data/set/intervals/image_preimage.lean
+++ b/src/data/set/intervals/image_preimage.lean
@@ -5,6 +5,7 @@ Authors: Yury G. Kudryashov, Patrick Massot
 -/
 import data.set.intervals.basic
 import data.equiv.mul_add
+import algebra.pointwise
 
 /-!
 # (Pre)images of intervals
@@ -83,21 +84,21 @@ by simp [← Ioi_inter_Iio]
 ### Preimages under `x ↦ -x`
 -/
 
-@[simp] lemma preimage_neg_Ici : has_neg.neg ⁻¹' (Ici a) = Iic (-a) := ext $ λ x, le_neg
-@[simp] lemma preimage_neg_Iic : has_neg.neg ⁻¹' (Iic a) = Ici (-a) := ext $ λ x, neg_le
-@[simp] lemma preimage_neg_Ioi : has_neg.neg ⁻¹' (Ioi a) = Iio (-a) := ext $ λ x, lt_neg
-@[simp] lemma preimage_neg_Iio : has_neg.neg ⁻¹' (Iio a) = Ioi (-a) := ext $ λ x, neg_lt
+@[simp] lemma preimage_neg_Ici : - Ici a = Iic (-a) := ext $ λ x, le_neg
+@[simp] lemma preimage_neg_Iic : - Iic a = Ici (-a) := ext $ λ x, neg_le
+@[simp] lemma preimage_neg_Ioi : - Ioi a = Iio (-a) := ext $ λ x, lt_neg
+@[simp] lemma preimage_neg_Iio : - Iio a = Ioi (-a) := ext $ λ x, neg_lt
 
-@[simp] lemma preimage_neg_Icc : has_neg.neg ⁻¹' (Icc a b) = Icc (-b) (-a) :=
+@[simp] lemma preimage_neg_Icc : - Icc a b = Icc (-b) (-a) :=
 by simp [← Ici_inter_Iic, inter_comm]
 
-@[simp] lemma preimage_neg_Ico : has_neg.neg ⁻¹' (Ico a b) = Ioc (-b) (-a) :=
+@[simp] lemma preimage_neg_Ico : - Ico a b = Ioc (-b) (-a) :=
 by simp [← Ici_inter_Iio, ← Ioi_inter_Iic, inter_comm]
 
-@[simp] lemma preimage_neg_Ioc : has_neg.neg ⁻¹' (Ioc a b) = Ico (-b) (-a) :=
+@[simp] lemma preimage_neg_Ioc : - Ioc a b = Ico (-b) (-a) :=
 by simp [← Ioi_inter_Iic, ← Ici_inter_Iio, inter_comm]
 
-@[simp] lemma preimage_neg_Ioo : has_neg.neg ⁻¹' (Ioo a b) = Ioo (-b) (-a) :=
+@[simp] lemma preimage_neg_Ioo : - Ioo a b = Ioo (-b) (-a) :=
 by simp [← Ioi_inter_Iio, inter_comm]
 
 /-!
@@ -161,77 +162,62 @@ by simp [← Ioi_inter_Iio, inter_comm]
 -/
 
 @[simp] lemma image_const_add_Ici : (λ x, a + x) '' Ici b = Ici (a + b) :=
-((equiv.add_left a).image_eq_preimage _).trans $ by simp [add_comm]
+by simp [add_comm]
 
 @[simp] lemma image_const_add_Iic : (λ x, a + x) '' Iic b = Iic (a + b) :=
-((equiv.add_left a).image_eq_preimage _).trans $ by simp [add_comm]
+by simp [add_comm]
 
 @[simp] lemma image_const_add_Iio : (λ x, a + x) '' Iio b = Iio (a + b) :=
-((equiv.add_left a).image_eq_preimage _).trans $ by simp [add_comm]
+by simp [add_comm]
 
 @[simp] lemma image_const_add_Ioi : (λ x, a + x) '' Ioi b = Ioi (a + b) :=
-((equiv.add_left a).image_eq_preimage _).trans $ by simp [add_comm]
+by simp [add_comm]
 
 @[simp] lemma image_const_add_Icc : (λ x, a + x) '' Icc b c = Icc (a + b) (a + c) :=
-((equiv.add_left a).image_eq_preimage _).trans $ by simp [add_comm]
+by simp [add_comm]
 
 @[simp] lemma image_const_add_Ico : (λ x, a + x) '' Ico b c = Ico (a + b) (a + c) :=
-((equiv.add_left a).image_eq_preimage _).trans $ by simp [add_comm]
+by simp [add_comm]
 
 @[simp] lemma image_const_add_Ioc : (λ x, a + x) '' Ioc b c = Ioc (a + b) (a + c) :=
-((equiv.add_left a).image_eq_preimage _).trans $ by simp [add_comm]
+by simp [add_comm]
 
 @[simp] lemma image_const_add_Ioo : (λ x, a + x) '' Ioo b c = Ioo (a + b) (a + c) :=
-((equiv.add_left a).image_eq_preimage _).trans $ by simp [add_comm]
+by simp [add_comm]
 
 /-!
 ### Images under `x ↦ x + a`
 -/
 
-@[simp] lemma image_add_const_Ici : (λ x, x + a) '' Ici b = Ici (a + b) := by simp [add_comm _ a]
-@[simp] lemma image_add_const_Iic : (λ x, x + a) '' Iic b = Iic (a + b) := by simp [add_comm _ a]
-@[simp] lemma image_add_const_Iio : (λ x, x + a) '' Iio b = Iio (a + b) := by simp [add_comm _ a]
-@[simp] lemma image_add_const_Ioi : (λ x, x + a) '' Ioi b = Ioi (a + b) := by simp [add_comm _ a]
+@[simp] lemma image_add_const_Ici : (λ x, x + a) '' Ici b = Ici (a + b) := by simp [add_comm]
+@[simp] lemma image_add_const_Iic : (λ x, x + a) '' Iic b = Iic (a + b) := by simp [add_comm]
+@[simp] lemma image_add_const_Iio : (λ x, x + a) '' Iio b = Iio (a + b) := by simp [add_comm]
+@[simp] lemma image_add_const_Ioi : (λ x, x + a) '' Ioi b = Ioi (a + b) := by simp [add_comm]
 
 @[simp] lemma image_add_const_Icc : (λ x, x + a) '' Icc b c = Icc (a + b) (a + c) :=
-by simp [add_comm _ a]
+by simp [add_comm]
 
 @[simp] lemma image_add_const_Ico : (λ x, x + a) '' Ico b c = Ico (a + b) (a + c) :=
-by simp [add_comm _ a]
+by simp [add_comm]
 
 @[simp] lemma image_add_const_Ioc : (λ x, x + a) '' Ioc b c = Ioc (a + b) (a + c) :=
-by simp [add_comm _ a]
+by simp [add_comm]
 
 @[simp] lemma image_add_const_Ioo : (λ x, x + a) '' Ioo b c = Ioo (a + b) (a + c) :=
-by simp [add_comm _ a]
+by simp [add_comm]
 
 /-!
 ### Images under `x ↦ -x`
 -/
 
-@[simp] lemma image_neg_Ici : has_neg.neg '' (Ici a) = Iic (-a) :=
-((equiv.neg G).image_eq_preimage _).trans $ preimage_neg_Ici _
-
-@[simp] lemma image_neg_Iic : has_neg.neg '' (Iic a) = Ici (-a) :=
-((equiv.neg G).image_eq_preimage _).trans $ preimage_neg_Iic _
-
-@[simp] lemma image_neg_Ioi : has_neg.neg '' (Ioi a) = Iio (-a) :=
-((equiv.neg G).image_eq_preimage _).trans $ preimage_neg_Ioi _
-
-@[simp] lemma image_neg_Iio : has_neg.neg '' (Iio a) = Ioi (-a) :=
-((equiv.neg G).image_eq_preimage _).trans $ preimage_neg_Iio _
-
-@[simp] lemma image_neg_Icc : has_neg.neg '' (Icc a b) = Icc (-b) (-a) :=
-((equiv.neg G).image_eq_preimage _).trans $ preimage_neg_Icc _ _
-
-@[simp] lemma image_neg_Ico : has_neg.neg '' (Ico a b) = Ioc (-b) (-a) :=
-((equiv.neg G).image_eq_preimage _).trans $ preimage_neg_Ico _ _
-
-@[simp] lemma image_neg_Ioc : has_neg.neg '' (Ioc a b) = Ico (-b) (-a) :=
-((equiv.neg G).image_eq_preimage _).trans $ preimage_neg_Ioc _ _
-
-@[simp] lemma image_neg_Ioo : has_neg.neg '' (Ioo a b) = Ioo (-b) (-a) :=
-((equiv.neg G).image_eq_preimage _).trans $ preimage_neg_Ioo _ _
+lemma image_neg_Ici : has_neg.neg '' (Ici a) = Iic (-a) := by simp
+lemma image_neg_Iic : has_neg.neg '' (Iic a) = Ici (-a) := by simp
+lemma image_neg_Ioi : has_neg.neg '' (Ioi a) = Iio (-a) := by simp
+lemma image_neg_Iio : has_neg.neg '' (Iio a) = Ioi (-a) := by simp
+lemma image_neg_Icc : has_neg.neg '' (Icc a b) = Icc (-b) (-a) := by simp
+lemma image_neg_Ico : has_neg.neg '' (Ico a b) = Ioc (-b) (-a) := by simp
+lemma image_neg_Ioc : has_neg.neg '' (Ioc a b) = Ico (-b) (-a) := by simp
+lemma image_neg_Ioo : has_neg.neg '' (Ioo a b) = Ioo (-b) (-a) := by simp
 
 /-!
 ### Images under `x ↦ a - x`

--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -669,6 +669,19 @@ infi_image
 
 end image
 
+section image2
+
+variables (f : α → β → γ) {s : set α} {t : set β}
+
+lemma Union_image_left : (⋃ a ∈ s, f a '' t) = image2 f s t :=
+by { ext y, split; simp only [mem_Union]; rintros ⟨a, ha, x, hx, ax⟩; exact ⟨a, x, ha, hx, ax⟩ }
+
+lemma Union_image_right : (⋃ b ∈ t, (λ a, f a b) '' s) = image2 f s t :=
+by { ext y, split; simp only [mem_Union]; rintros ⟨a, b, c, d, e⟩, exact ⟨c, a, d, b, e⟩,
+     exact ⟨b, d, a, c, e⟩ }
+
+end image2
+
 section preimage
 
 theorem monotone_preimage {f : α → β} : monotone (preimage f) := assume a b h, preimage_mono h

--- a/src/group_theory/group_action.lean
+++ b/src/group_theory/group_action.lean
@@ -57,6 +57,12 @@ lemma inv_smul_smul' {c : G} (hc : c ≠ 0) (x : β) : c⁻¹ • c • x = x :=
 lemma smul_inv_smul' {c : G} (hc : c ≠ 0) (x : β) : c • c⁻¹ • x = x :=
 (units.mk0 c hc).smul_inv_smul x
 
+lemma inv_smul_eq_iff {a : G} (ha : a ≠ 0) {x y : β} : a⁻¹ • x = y ↔ x = a • y :=
+by { split; intro h, rw [← h, smul_inv_smul' ha], rw [h, inv_smul_smul' ha] }
+
+lemma eq_inv_smul_iff {a : G} (ha : a ≠ 0) {x y : β} : x = a⁻¹ • y ↔ a • x = y :=
+by { split; intro h, rw [h, smul_inv_smul' ha], rw [← h, inv_smul_smul' ha] }
+
 end gwz
 
 variables (p : Prop) [decidable p]

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -343,6 +343,26 @@ protected lemma bijective : bijective f := ⟨h.injective, h.surjective⟩
 
 end involutive
 
+/-- The property of a binary function `f : α → β → γ` being injective.
+  Mathematically this should be thought of as the corresponding function `α × β → γ` being injective.
+-/
+@[reducible] def injective2 {α β γ} (f : α → β → γ) : Prop :=
+∀ ⦃a₁ a₂ b₁ b₂⦄, f a₁ b₁ = f a₂ b₂ → a₁ = a₂ ∧ b₁ = b₂
+
+namespace injective2
+variables {α β γ : Type*} (f : α → β → γ)
+
+protected lemma left (hf : injective2 f) ⦃a₁ a₂ b₁ b₂⦄ (h : f a₁ b₁ = f a₂ b₂) : a₁ = a₂ :=
+(hf h).1
+
+protected lemma right (hf : injective2 f) ⦃a₁ a₂ b₁ b₂⦄ (h : f a₁ b₁ = f a₂ b₂) : b₁ = b₂ :=
+(hf h).2
+
+lemma eq_iff (hf : injective2 f) ⦃a₁ a₂ b₁ b₂⦄ : f a₁ b₁ = f a₂ b₂ ↔ a₁ = a₂ ∧ b₁ = b₂ :=
+⟨λ h, hf h, λ⟨h1, h2⟩, congr_arg2 f h1 h2⟩
+
+end injective2
+
 end function
 
 /-- `s.piecewise f g` is the function equal to `f` on the set `s`, and to `g` on its complement. -/

--- a/src/order/filter/pointwise.lean
+++ b/src/order/filter/pointwise.lean
@@ -2,14 +2,17 @@
 Copyright (c) 2019 Zhouhang Zhou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhouhang Zhou
-
-The pointwise operations on filters have nice properties, such as
-  • map m (f₁ * f₂) = map m f₁ * map m f₂
-  • 𝓝 x * 𝓝 y = 𝓝 (x * y)
-
 -/
 import algebra.pointwise
 import order.filter.basic
+/-!
+# Pointwise operations on filters.
+
+The pointwise operations on filters have nice properties, such as
+  • `map m (f₁ * f₂) = map m f₁ * map m f₂`
+  • `𝓝 x * 𝓝 y = 𝓝 (x * y)`
+
+-/
 
 open classical set
 
@@ -17,26 +20,22 @@ universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
 
 open_locale classical
-local attribute [instance] pointwise_one pointwise_mul pointwise_add
 
 namespace filter
 open set
 
 @[to_additive]
-def pointwise_one [has_one α] : has_one (filter α) := ⟨principal {1}⟩
-
-local attribute [instance] pointwise_one
+instance [has_one α] : has_one (filter α) := ⟨principal 1⟩
 
 @[simp, to_additive]
-lemma mem_pointwise_one [has_one α] (s : set α) :
-  s ∈ (1 : filter α) ↔ (1:α) ∈ s :=
+lemma mem_one [has_one α] (s : set α) : s ∈ (1 : filter α) ↔ (1:α) ∈ s :=
 calc
-  s ∈ (1:filter α) ↔ {(1:α)} ⊆ s : iff.rfl
-  ... ↔ (1:α) ∈ s : by simp
+  s ∈ (1:filter α) ↔ 1 ⊆ s : iff.rfl
+  ... ↔ (1 : α) ∈ s : by simp
 
 @[to_additive]
-def pointwise_mul [monoid α] : has_mul (filter α) := ⟨λf g,
-{ sets             := { s | ∃t₁∈f, ∃t₂∈g, t₁ * t₂  ⊆ s },
+instance [monoid α] : has_mul (filter α) := ⟨λf g,
+{ sets             := { s | ∃t₁ t₂, t₁ ∈ f ∧ t₂ ∈ g ∧ t₁ * t₂ ⊆ s },
   univ_sets        :=
   begin
     have h₁ : (∃x, x ∈ f) := ⟨univ, univ_sets f⟩,
@@ -51,87 +50,78 @@ def pointwise_mul [monoid α] : has_mul (filter α) := ⟨λf g,
   inter_sets       := λx y,
   begin
     simp only [exists_prop, mem_set_of_eq, subset_inter_iff],
-    rintros ⟨s₁, hs₁, s₂, hs₂, s₁s₂⟩ ⟨t₁, ht₁, t₂, ht₂, t₁t₂⟩,
-    exact ⟨s₁ ∩ t₁, inter_sets f hs₁ ht₁, s₂ ∩ t₂, inter_sets g hs₂ ht₂,
-    subset.trans (pointwise_mul_subset_mul (inter_subset_left _ _) (inter_subset_left _ _)) s₁s₂,
-    subset.trans (pointwise_mul_subset_mul (inter_subset_right _ _) (inter_subset_right _ _)) t₁t₂⟩,
+    rintros ⟨s₁, s₂, hs₁, hs₂, s₁s₂⟩ ⟨t₁, t₂, ht₁, ht₂, t₁t₂⟩,
+    exact ⟨s₁ ∩ t₁, s₂ ∩ t₂, inter_sets f hs₁ ht₁, inter_sets g hs₂ ht₂,
+    subset.trans (mul_subset_mul (inter_subset_left _ _) (inter_subset_left _ _)) s₁s₂,
+    subset.trans (mul_subset_mul (inter_subset_right _ _) (inter_subset_right _ _)) t₁t₂⟩,
   end }⟩
 
-local attribute [instance] pointwise_mul pointwise_add
+@[to_additive]
+lemma mem_mul [monoid α] {f g : filter α} {s : set α} :
+  s ∈ f * g ↔ ∃t₁ t₂, t₁ ∈ f ∧ t₂ ∈ g ∧ t₁ * t₂  ⊆ s := iff.rfl
 
 @[to_additive]
-lemma mem_pointwise_mul [monoid α] {f g : filter α} {s : set α} :
-  s ∈ f * g ↔ ∃ t₁ ∈ f, ∃ t₂ ∈ g, t₁ * t₂ ⊆ s := iff.rfl
+lemma mul_mem_mul [monoid α] {f g : filter α} {s t : set α} (hs : s ∈ f) (ht : t ∈ g) :
+  s * t ∈ f * g := ⟨_, _, hs, ht, subset.refl _⟩
 
 @[to_additive]
-lemma mul_mem_pointwise_mul [monoid α] {f g : filter α} {s t : set α} (hs : s ∈ f) (ht : t ∈ g) :
-  s * t ∈ f * g := ⟨_, hs, _, ht, subset.refl _⟩
+protected lemma mul_le_mul [monoid α] {f₁ f₂ g₁ g₂ : filter α} (hf : f₁ ≤ f₂) (hg : g₁ ≤ g₂) :
+  f₁ * g₁ ≤ f₂ * g₂ := assume _ ⟨s, t, hs, ht, hst⟩, ⟨s, t, hf hs, hg ht, hst⟩
 
 @[to_additive]
-lemma pointwise_mul_le_mul [monoid α] {f₁ f₂ g₁ g₂ : filter α} (hf : f₁ ≤ f₂) (hg : g₁ ≤ g₂) :
-  f₁ * g₁ ≤ f₂ * g₂ := assume _ ⟨s, hs, t, ht, hst⟩, ⟨s, hf hs, t, hg ht, hst⟩
-
-@[to_additive]
-lemma pointwise_mul_ne_bot [monoid α] {f g : filter α} : f ≠ ⊥ → g ≠ ⊥ → f * g ≠ ⊥ :=
+lemma mul_ne_bot [monoid α] {f g : filter α} : f ≠ ⊥ → g ≠ ⊥ → f * g ≠ ⊥ :=
 begin
   simp only [forall_sets_nonempty_iff_ne_bot.symm],
-  rintros hf hg s ⟨a, ha, b, hb, ab⟩,
-  exact ((hf a ha).pointwise_mul (hg b hb)).mono ab
+  rintros hf hg s ⟨a, b, ha, hb, ab⟩,
+  exact ((hf a ha).mul (hg b hb)).mono ab
 end
 
 @[to_additive]
-lemma pointwise_mul_assoc [monoid α] (f g h : filter α) : f * g * h = f * (g * h) :=
+protected lemma mul_assoc [monoid α] (f g h : filter α) : f * g * h = f * (g * h) :=
 begin
   ext s, split,
-  { rintros ⟨a, ⟨a₁, ha₁, a₂, ha₂, a₁a₂⟩, b, hb, ab⟩,
-    refine ⟨a₁, ha₁, a₂ * b, mul_mem_pointwise_mul ha₂ hb, _⟩,
-    rw [← pointwise_mul_semigroup.mul_assoc],
+  { rintros ⟨a, b, ⟨a₁, a₂, ha₁, ha₂, a₁a₂⟩, hb, ab⟩,
+    refine ⟨a₁, a₂ * b, ha₁, mul_mem_mul ha₂ hb, _⟩, rw [← mul_assoc],
     exact calc
-      a₁ * a₂ * b ⊆ a * b : pointwise_mul_subset_mul a₁a₂ (subset.refl _)
+      a₁ * a₂ * b ⊆ a * b : mul_subset_mul a₁a₂ (subset.refl _)
       ...         ⊆ s     : ab },
-  { rintros ⟨a, ha, b, ⟨b₁, hb₁, b₂, hb₂, b₁b₂⟩, ab⟩,
-    refine ⟨a * b₁, mul_mem_pointwise_mul ha hb₁, b₂, hb₂, _⟩,
-    rw [pointwise_mul_semigroup.mul_assoc],
+  { rintros ⟨a, b, ha, ⟨b₁, b₂, hb₁, hb₂, b₁b₂⟩, ab⟩,
+    refine ⟨a * b₁, b₂, mul_mem_mul ha hb₁, hb₂, _⟩, rw [mul_assoc],
     exact calc
-      a * (b₁ * b₂) ⊆ a * b : pointwise_mul_subset_mul (subset.refl _) b₁b₂
+      a * (b₁ * b₂) ⊆ a * b : mul_subset_mul (subset.refl _) b₁b₂
       ...           ⊆ s     : ab }
 end
 
-local attribute [instance] pointwise_mul_monoid
-
 @[to_additive]
-lemma pointwise_one_mul [monoid α] (f : filter α) : 1 * f = f :=
+protected lemma one_mul [monoid α] (f : filter α) : 1 * f = f :=
 begin
   ext s, split,
-  { rintros ⟨t₁, ht₁, t₂, ht₂, t₁t₂⟩,
+  { rintros ⟨t₁, t₂, ht₁, ht₂, t₁t₂⟩,
     refine mem_sets_of_superset (mem_sets_of_superset ht₂ _) t₁t₂,
     assume x hx,
-    exact ⟨1, by rwa [← mem_pointwise_one], x, hx, (one_mul _).symm⟩ },
-  { assume hs,
-    refine ⟨(1:set α), mem_principal_self _, s, hs, by simp only [one_mul]⟩ }
+    exact ⟨1, x, by rwa [← mem_one], hx, one_mul _⟩ },
+  { assume hs, refine ⟨(1:set α), s, mem_principal_self _, hs, by simp only [one_mul]⟩ }
 end
 
 @[to_additive]
-lemma pointwise_mul_one [monoid α] (f : filter α) : f * 1 = f :=
+protected lemma mul_one [monoid α] (f : filter α) : f * 1 = f :=
 begin
   ext s, split,
-  { rintros ⟨t₁, ht₁, t₂, ht₂, t₁t₂⟩,
+  { rintros ⟨t₁, t₂, ht₁, ht₂, t₁t₂⟩,
     refine mem_sets_of_superset (mem_sets_of_superset ht₁ _) t₁t₂,
     assume x hx,
-    exact ⟨x, hx, 1, by rwa [← mem_pointwise_one], (mul_one _).symm⟩ },
+    exact ⟨x, 1, hx, by rwa [← mem_one], mul_one _⟩ },
   { assume hs,
-    refine ⟨s, hs, (1:set α), mem_principal_self _, by simp only [mul_one]⟩ }
+    refine ⟨s, (1:set α), hs, mem_principal_self _, by simp only [mul_one]⟩ }
 end
 
-@[to_additive pointwise_add_add_monoid]
-def pointwise_mul_monoid [monoid α] : monoid (filter α) :=
-{ mul_assoc := pointwise_mul_assoc,
-  one_mul := pointwise_one_mul,
-  mul_one := pointwise_mul_one,
-  .. pointwise_mul,
-  .. pointwise_one }
-
-local attribute [instance] filter.pointwise_mul_monoid filter.pointwise_add_add_monoid
+@[to_additive filter.add_monoid]
+instance [monoid α] : monoid (filter α) :=
+{ mul_assoc := filter.mul_assoc,
+  one_mul := filter.one_mul,
+  mul_one := filter.mul_one,
+  .. filter.has_mul,
+  .. filter.has_one }
 
 section map
 open is_mul_hom
@@ -139,53 +129,47 @@ open is_mul_hom
 variables [monoid α] [monoid β] {f : filter α} (m : α → β)
 
 @[to_additive]
-lemma map_pointwise_mul [is_mul_hom m] {f₁ f₂ : filter α} : map m (f₁ * f₂) = map m f₁ * map m f₂ :=
+protected lemma map_mul [is_mul_hom m] {f₁ f₂ : filter α} : map m (f₁ * f₂) = map m f₁ * map m f₂ :=
 filter_eq $ set.ext $ assume s,
 begin
-  simp only [mem_pointwise_mul], split,
-  { rintro ⟨t₁, ht₁, t₂, ht₂, t₁t₂⟩,
+  simp only [mem_mul], split,
+  { rintro ⟨t₁, t₂, ht₁, ht₂, t₁t₂⟩,
     have : m '' (t₁ * t₂) ⊆ s := subset.trans (image_subset m t₁t₂) (image_preimage_subset _ _),
-    refine ⟨m '' t₁, image_mem_map ht₁, m '' t₂, image_mem_map ht₂, _⟩,
-    rwa ← image_pointwise_mul m t₁ t₂ },
-  { rintro ⟨t₁, ht₁, t₂, ht₂, t₁t₂⟩,
-    refine ⟨m ⁻¹' t₁, ht₁, m ⁻¹' t₂, ht₂, image_subset_iff.1 _⟩,
-    rw image_pointwise_mul m,
+    refine ⟨m '' t₁, m '' t₂, image_mem_map ht₁, image_mem_map ht₂, _⟩,
+    rwa ← image_mul m },
+  { rintro ⟨t₁, t₂, ht₁, ht₂, t₁t₂⟩,
+    refine ⟨m ⁻¹' t₁, m ⁻¹' t₂, ht₁, ht₂, image_subset_iff.1 _⟩,
+    rw image_mul m,
     exact subset.trans
-      (pointwise_mul_subset_mul (image_preimage_subset _ _) (image_preimage_subset _ _)) t₁t₂ },
+      (mul_subset_mul (image_preimage_subset _ _) (image_preimage_subset _ _)) t₁t₂ },
 end
 
 @[to_additive]
-lemma map_pointwise_one [is_monoid_hom m] : map m (1:filter α) = 1 :=
+protected lemma map_one [is_monoid_hom m] : map m (1:filter α) = 1 :=
 le_antisymm
   (le_principal_iff.2 $ mem_map_sets_iff.2 ⟨(1:set α), by simp,
-    by { assume x, simp [is_monoid_hom.map_one m], rintros rfl, refl  }⟩)
+    by { assume x, simp [is_monoid_hom.map_one m] }⟩)
   (le_map $ assume s hs,
    begin
-     simp only [mem_pointwise_one],
-     exact ⟨(1:α), (mem_pointwise_one s).1 hs, is_monoid_hom.map_one _⟩
+     simp only [mem_one],
+     exact ⟨(1:α), (mem_one s).1 hs, is_monoid_hom.map_one _⟩
    end)
 
 -- TODO: prove similar statements when `m` is group homomorphism etc.
-lemma pointwise_mul_map_is_monoid_hom [is_monoid_hom m] : is_monoid_hom (map m) :=
-{ map_one := map_pointwise_one m,
-  map_mul := λ _ _, map_pointwise_mul m }
-
-lemma pointwise_add_map_is_add_monoid_hom {α : Type*} {β : Type*} [add_monoid α] [add_monoid β]
-  (m : α → β) [is_add_monoid_hom m] : is_add_monoid_hom (map m) :=
-{ map_zero := map_pointwise_zero m,
-  map_add := λ _ _, map_pointwise_add m }
-
-attribute [to_additive pointwise_add_map_is_add_monoid_hom] pointwise_mul_map_is_monoid_hom
+@[to_additive map.is_add_monoid_hom]
+lemma map.is_monoid_hom [is_monoid_hom m] : is_monoid_hom (map m) :=
+{ map_one := filter.map_one m,
+  map_mul := λ _ _, filter.map_mul m }
 
 -- The other direction does not hold in general.
 @[to_additive]
 lemma comap_mul_comap_le [is_mul_hom m] {f₁ f₂ : filter β} :
   comap m f₁ * comap m f₂ ≤ comap m (f₁ * f₂) :=
 begin
-  rintros s ⟨t, ⟨t₁, ht₁, t₂, ht₂, t₁t₂⟩, mt⟩,
-  refine ⟨m ⁻¹' t₁, ⟨t₁, ht₁, subset.refl _⟩, m ⁻¹' t₂, ⟨t₂, ht₂, subset.refl _⟩, _⟩,
+  rintros s ⟨t, ⟨t₁, t₂, ht₁, ht₂, t₁t₂⟩, mt⟩,
+  refine ⟨m ⁻¹' t₁, m ⁻¹' t₂, ⟨t₁, ht₁, subset.refl _⟩, ⟨t₂, ht₂, subset.refl _⟩, _⟩,
   have := subset.trans (preimage_mono t₁t₂) mt,
-  exact subset.trans (preimage_pointwise_mul_preimage_subset m _ _) this
+  exact subset.trans (preimage_mul_preimage_subset m) this
 end
 
 variables {m}
@@ -193,7 +177,7 @@ variables {m}
 @[to_additive]
 lemma tendsto.mul_mul [is_mul_hom m] {f₁ g₁ : filter α} {f₂ g₂ : filter β} :
   tendsto m f₁ f₂ → tendsto m g₁ g₂ → tendsto m (f₁ * g₁) (f₂ * g₂) :=
-assume hf hg, by { rw [tendsto, map_pointwise_mul m], exact pointwise_mul_le_mul hf hg }
+assume hf hg, by { rw [tendsto, filter.map_mul m], exact filter.mul_le_mul hf hg }
 
 end map
 

--- a/src/ring_theory/adjoin.lean
+++ b/src/ring_theory/adjoin.lean
@@ -94,18 +94,13 @@ theorem adjoin_union_coe_submodule : (adjoin R (s ∪ t) : submodule R A) =
   (adjoin R s) * (adjoin R t) :=
 begin
   rw [adjoin_eq_span, adjoin_eq_span, adjoin_eq_span, span_mul_span],
-  congr' 1,
-  ext z,
-  rw monoid.mem_closure_union_iff,
-  split;
-  { rintro ⟨y, hys, z, hzt, rfl⟩, exact ⟨_, hys, _, hzt, rfl⟩ }
+  congr' 1, ext z, simp [monoid.mem_closure_union_iff, set.mem_mul],
 end
+
 variables {R s t}
 
 theorem adjoin_int (s : set R) : adjoin ℤ s = subalgebra_of_subring (ring.closure s) :=
 le_antisymm (adjoin_le subset_closure) (closure_subset subset_adjoin)
-
-local attribute [instance] set.pointwise_mul_semiring
 
 theorem fg_trans (h1 : (adjoin R s : submodule R A).fg)
   (h2 : (adjoin (adjoin R s) t : submodule (adjoin R s) A).fg) :
@@ -113,9 +108,9 @@ theorem fg_trans (h1 : (adjoin R s : submodule R A).fg)
 begin
   rcases fg_def.1 h1 with ⟨p, hp, hp'⟩,
   rcases fg_def.1 h2 with ⟨q, hq, hq'⟩,
-  refine fg_def.2 ⟨p * q, set.pointwise_mul_finite hp hq, le_antisymm _ _⟩,
+  refine fg_def.2 ⟨p * q, hp.mul hq, le_antisymm _ _⟩,
   { rw [span_le],
-    rintros _ ⟨x, hx, y, hy, rfl⟩,
+    rintros _ ⟨x, y, hx, hy, rfl⟩,
     change x * y ∈ _,
     refine is_submonoid.mul_mem _ _,
     { have : x ∈ (adjoin R s : submodule R A),
@@ -144,7 +139,7 @@ begin
     rw [←hl, finsupp.sum_mul],
     refine sum_mem _ _,
     intros t ht, change _ * _ ∈ _, rw smul_mul_assoc, refine smul_mem _ _ _,
-    exact subset_span ⟨t, hlp ht, z, hlq hz, rfl⟩ }
+    exact subset_span ⟨t, z, hlp ht, hlq hz, rfl⟩ }
 end
 
 end algebra

--- a/src/ring_theory/algebra_operations.lean
+++ b/src/ring_theory/algebra_operations.lean
@@ -11,9 +11,7 @@ import algebra.pointwise
 
 universes u v
 
-open algebra
-
-local attribute [instance] set.pointwise_mul_semiring
+open algebra set
 
 namespace submodule
 
@@ -67,11 +65,11 @@ begin
   { rw mul_le, intros a ha b hb,
     apply span_induction ha,
     work_on_goal 0 { intros, apply span_induction hb,
-      work_on_goal 0 { intros, exact subset_span ⟨_, ‹_›, _, ‹_›, rfl⟩ } },
+      work_on_goal 0 { intros, exact subset_span ⟨_, _, ‹_›, ‹_›, rfl⟩ } },
     all_goals { intros, simp only [mul_zero, zero_mul, zero_mem,
         left_distrib, right_distrib, mul_smul_comm, smul_mul_assoc],
       try {apply add_mem _ _ _}, try {apply smul_mem _ _ _} }, assumption' },
-  { rw span_le, rintros _ ⟨a, ha, b, hb, rfl⟩,
+  { rw span_le, rintros _ ⟨a, b, ha, hb, rfl⟩,
     exact mul_mem_mul (subset_span ha) (subset_span hb) }
 end
 variables {R}
@@ -119,12 +117,8 @@ le_antisymm (mul_le.2 $ λ mn hmn p hp, let ⟨m, hm, n, hn, hmn⟩ := mem_sup.1
   mem_sup.2 ⟨_, mul_mem_mul hm hp, _, mul_mem_mul hn hp, hmn ▸ (add_mul m n p).symm⟩)
 (sup_le (mul_le_mul_left le_sup_left) (mul_le_mul_left le_sup_right))
 
-lemma mul_subset_mul :
-  (↑M : set A) * (↑N : set A) ⊆ (↑(M * N) : set A) :=
-begin
-  rintros _ ⟨i, hi, j, hj, rfl⟩,
-  exact mul_mem_mul hi hj
-end
+lemma mul_subset_mul : (↑M : set A) * (↑N : set A) ⊆ (↑(M * N) : set A) :=
+by { rintros _ ⟨i, j, hi, hj, rfl⟩, exact mul_mem_mul hi hj }
 
 lemma map_mul {A'} [ring A'] [algebra R A'] (f : A →ₐ[R] A') :
   map f.to_linear_map (M * N) = map f.to_linear_map M * map f.to_linear_map N :=
@@ -163,24 +157,23 @@ instance : semiring (submodule R A) :=
 
 variables (M)
 
-lemma pow_subset_pow {n : ℕ} :
-  (↑M : set A)^n ⊆ ↑(M^n : submodule R A) :=
+lemma pow_subset_pow {n : ℕ} : (↑M : set A)^n ⊆ ↑(M^n : submodule R A) :=
 begin
   induction n with n ih,
   { erw [pow_zero, pow_zero, set.singleton_subset_iff], rw [mem_coe, ← one_le], exact le_refl _ },
   { rw [pow_succ, pow_succ],
-    refine set.subset.trans (set.pointwise_mul_subset_mul (set.subset.refl _) ih) _,
+    refine set.subset.trans (set.mul_subset_mul (subset.refl _) ih) _,
     apply mul_subset_mul }
 end
 
 /-- `span` is a semiring homomorphism (recall multiplication is pointwise multiplication of subsets on either side). -/
-def span.ring_hom : set A →+* submodule R A :=
+def span.ring_hom : set_semiring A →+* submodule R A :=
 { to_fun := submodule.span R,
   map_zero' := span_empty,
-  map_one' := show _ = map _ ⊤,
-    by erw [← ideal.span_singleton_one, ← span_image, set.image_singleton, alg_hom.map_one]; refl,
+  map_one' := show _ = map _ ⊤, by { erw [← ideal.span_singleton_one, ← span_image,
+      set.image_singleton, alg_hom.map_one], refl },
   map_add' := span_union,
-  map_mul' := λ s t, by erw [span_mul_span, set.pointwise_mul_eq_image] }
+  map_mul' := λ s t, by erw [span_mul_span, ← image_mul_prod] }
 
 end ring
 
@@ -203,12 +196,12 @@ instance : comm_semiring (submodule R A) :=
 
 variables (R A)
 
-instance semimodule_set : semimodule (set A) (submodule R A) :=
+instance semimodule_set : semimodule (set_semiring A) (submodule R A) :=
 { smul := λ s P, span R s * P,
   smul_add := λ _ _ _, mul_add _ _ _,
   add_smul := λ s t P, show span R (s ⊔ t) * P = _, by { erw [span_union, right_distrib] },
   mul_smul := λ s t P, show _ = _ * (_ * _),
-    by { rw [← mul_assoc, span_mul_span, set.pointwise_mul_eq_image] },
+    by { rw [← mul_assoc, span_mul_span, ← image_mul_prod] },
   one_smul := λ P, show span R {(1 : A)} * P = _,
     by { conv_lhs {erw ← span_eq P}, erw [span_mul_span, one_mul, span_eq] },
   zero_smul := λ P, show span R ∅ * P = ⊥, by erw [span_empty, bot_mul],
@@ -217,31 +210,27 @@ instance semimodule_set : semimodule (set A) (submodule R A) :=
 
 variables {R A}
 
-lemma smul_def {s : set A} {P : submodule R A} :
-  s • P = span R s * P := rfl
+lemma smul_def {s : set_semiring A} {P : submodule R A} : s • P = span R s * P := rfl
 
-lemma smul_le_smul {s t : set A} {M N : submodule R A} (h₁ : s ≤ t) (h₂ : M ≤ N) :
-  s • M ≤ t • N :=
+lemma smul_le_smul {s t : set_semiring A} {M N : submodule R A} (h₁ : s.down ≤ t.down)
+  (h₂ : M ≤ N) : s • M ≤ t • N :=
 mul_le_mul (span_mono h₁) h₂
 
 lemma smul_singleton (a : A) (M : submodule R A) :
-  ({a} : set A) • M = M.map (lmul_left _ _ a) :=
+  ({a} : set A).up • M = M.map (lmul_left _ _ a) :=
 begin
   conv_lhs {rw ← span_eq M},
   change span _ _ * span _ _ = _,
   rw [span_mul_span],
   apply le_antisymm,
   { rw span_le,
-    rintros _ ⟨b, hb, m, hm, rfl⟩,
-    erw [mem_map, set.mem_singleton_iff.mp hb],
+    rintros _ ⟨b, m, hb, hm, rfl⟩,
+    rw [mem_coe, mem_map, set.mem_singleton_iff.mp hb],
     exact ⟨m, hm, rfl⟩ },
-  { rintros _ ⟨m, hm, rfl⟩,
-    exact subset_span ⟨a, set.mem_singleton a, m, hm, rfl⟩ }
+  { rintros _ ⟨m, hm, rfl⟩, exact subset_span ⟨a, m, set.mem_singleton a, hm, rfl⟩ }
 end
 
 section quotient
-
-local attribute [instance] set.smul_set_action
 
 /-- The elements of `I / J` are the `x` such that `x • J ⊆ I`.
 
@@ -263,8 +252,8 @@ lemma mem_div_iff_forall_mul_mem {x : A} {I J : submodule R A} :
 iff.refl _
 
 lemma mem_div_iff_smul_subset {x : A} {I J : submodule R A} : x ∈ I / J ↔ x • (J : set A) ⊆ I :=
-⟨ λ h y ⟨y', hy', y_eq_xy'⟩, by { rw y_eq_xy', apply h, assumption },
-  λ h y hy, h (set.smul_mem_smul_set _ hy)⟩
+⟨ λ h y ⟨y', hy', xy'_eq_y⟩, by { rw ← xy'_eq_y, apply h, assumption },
+  λ h y hy, h (set.smul_mem_smul_set hy) ⟩
 
 lemma le_div_iff {I J K : submodule R A} : I ≤ J / K ↔ ∀ (x ∈ I) (z ∈ K), x * z ∈ J := iff.refl _
 end quotient

--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -559,7 +559,7 @@ lemma is_principal_iff (I : fractional_ideal f) :
   λ ⟨x, hx⟩, { principal := ⟨x, trans (congr_arg _ hx) (coe_span_singleton x)⟩ } ⟩
 
 @[simp] lemma span_singleton_zero : span_singleton (0 : f.codomain) = 0 :=
-by { ext, simp [submodule.mem_span_singleton, eq_comm] }
+by { ext, simp [submodule.mem_span_singleton, eq_comm, -singleton_zero] }
 
 lemma span_singleton_eq_zero_iff {y : f.codomain} : span_singleton y = 0 ↔ y = 0 :=
 ⟨ λ h, span_eq_bot.mp (by simpa using congr_arg subtype.val h) y (mem_singleton y),

--- a/src/ring_theory/ideals.lean
+++ b/src/ring_theory/ideals.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Chris Hughes, Mario Carneiro
 -/
 import algebra.associated
+import algebra.pointwise
 import linear_algebra.basic
 import order.zorn
 
@@ -47,7 +48,7 @@ lemma span_mono {s t : set α} : s ⊆ t → span s ≤ span t := submodule.span
 
 @[simp] lemma span_eq : span (I : set α) = I := submodule.span_eq _
 
-@[simp] lemma span_singleton_one : span ({1} : set α) = ⊤ :=
+@[simp] lemma span_singleton_one : span (1 : set α) = ⊤ :=
 (eq_top_iff_one _).2 $ subset_span $ mem_singleton _
 
 lemma mem_span_insert {s : set α} {x y} :
@@ -72,7 +73,8 @@ lemma span_eq_bot {s : set α} : span s = ⊥ ↔ ∀ x ∈ s, (x:α) = 0 := sub
 lemma span_singleton_eq_bot {x} : span ({x} : set α) = ⊥ ↔ x = 0 := submodule.span_singleton_eq_bot
 
 lemma span_singleton_eq_top {x} : span ({x} : set α) = ⊤ ↔ is_unit x :=
-by rw [is_unit_iff_dvd_one, ← span_singleton_le_span_singleton, span_singleton_one, eq_top_iff]
+by rw [is_unit_iff_dvd_one, ← span_singleton_le_span_singleton, singleton_one, span_singleton_one,
+  eq_top_iff]
 
 /-- An ideal `P` of a ring `R` is prime if `P ≠ R` and `xy ∈ P → x ∈ P ∨ y ∈ P` -/
 @[class] def is_prime (I : ideal α) : Prop :=

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -505,11 +505,9 @@ namespace submodule
 variables {R : Type*} {A : Type*} [comm_ring R] [ring A] [algebra R A]
 variables (M N : submodule R A)
 
-local attribute [instance] set.pointwise_mul_semiring
-
 theorem fg_mul (hm : M.fg) (hn : N.fg) : (M * N).fg :=
 let ⟨m, hfm, hm⟩ := fg_def.1 hm, ⟨n, hfn, hn⟩ := fg_def.1 hn in
-fg_def.2 ⟨m * n, set.pointwise_mul_finite hfm hfn, span_mul_span R m n ▸ hm ▸ hn ▸ rfl⟩
+fg_def.2 ⟨m * n, hfm.mul hfn, span_mul_span R m n ▸ hm ▸ hn ▸ rfl⟩
 
 lemma fg_pow (h : M.fg) (n : ℕ) : (M ^ n).fg :=
 nat.rec_on n

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -347,28 +347,25 @@ instance : topological_add_group α :=
 end add_group_with_zero_nhd
 
 section filter_mul
-local attribute [instance]
-  set.pointwise_one set.pointwise_mul set.pointwise_add filter.pointwise_mul filter.pointwise_add
-  filter.pointwise_one
 
 section
 variables [topological_space α] [group α] [topological_group α]
 
 @[to_additive]
-lemma is_open_pointwise_mul_left {s t : set α} : is_open t → is_open (s * t) := λ ht,
+lemma is_open_mul_left {s t : set α} : is_open t → is_open (s * t) := λ ht,
 begin
   have : ∀a, is_open ((λ (x : α), a * x) '' t),
     assume a, apply is_open_map_mul_left, exact ht,
-  rw pointwise_mul_eq_Union_mul_left,
+  rw ← Union_mul_left_image,
   exact is_open_Union (λa, is_open_Union $ λha, this _),
 end
 
 @[to_additive]
-lemma is_open_pointwise_mul_right {s t : set α} : is_open s → is_open (s * t) := λ hs,
+lemma is_open_mul_right {s t : set α} : is_open s → is_open (s * t) := λ hs,
 begin
   have : ∀a, is_open ((λ (x : α), x * a) '' s),
     assume a, apply is_open_map_mul_right, exact hs,
-  rw pointwise_mul_eq_Union_mul_right,
+  rw ← Union_mul_right_image,
   exact is_open_Union (λa, is_open_Union $ λha, this _),
 end
 
@@ -388,14 +385,14 @@ lemma topological_group.regular_space [t1_space α] : regular_space α :=
    is_open_prod_iff.1 (hf _ (is_open_compl_iff.2 hs)) a (1:α) (by simpa [f]) in
  begin
    use s * t₂,
-   use is_open_pointwise_mul_left ht₂,
-   use λ x hx, ⟨x, hx, 1, one_mem_t₂, (mul_one _).symm⟩,
+   use is_open_mul_left ht₂,
+   use λ x hx, ⟨x, 1, hx, one_mem_t₂, mul_one _⟩,
    apply inf_principal_eq_bot,
    rw mem_nhds_sets_iff,
    refine ⟨t₁, _, ht₁, a_mem_t₁⟩,
-   rintros x hx ⟨y, hy, z, hz, yz⟩,
+   rintros x hx ⟨y, z, hy, hz, yz⟩,
    have : x * z⁻¹ ∈ sᶜ := (prod_subset_iff.1 t_subset) x hx z hz,
-   have : x * z⁻¹ ∈ s, rw yz, simpa,
+   have : x * z⁻¹ ∈ s, rw ← yz, simpa,
    contradiction
  end⟩
 
@@ -409,30 +406,30 @@ section
 variables [topological_space α] [comm_group α] [topological_group α]
 
 @[to_additive]
-lemma nhds_pointwise_mul (x y : α) : 𝓝 (x * y) = 𝓝 x * 𝓝 y :=
+lemma nhds_mul (x y : α) : 𝓝 (x * y) = 𝓝 x * 𝓝 y :=
 filter_eq $ set.ext $ assume s,
 begin
   rw [← nhds_translation_mul_inv x, ← nhds_translation_mul_inv y, ← nhds_translation_mul_inv (x*y)],
   split,
   { rintros ⟨t, ht, ts⟩,
     rcases exists_nhds_split ht with ⟨V, V_mem, h⟩,
-    refine ⟨(λa, a * x⁻¹) ⁻¹' V, ⟨V, V_mem, subset.refl _⟩,
-            (λa, a * y⁻¹) ⁻¹' V, ⟨V, V_mem, subset.refl _⟩, _⟩,
-    rintros a ⟨v, v_mem, w, w_mem, rfl⟩,
+    refine ⟨(λa, a * x⁻¹) ⁻¹' V, (λa, a * y⁻¹) ⁻¹' V,
+            ⟨V, V_mem, subset.refl _⟩, ⟨V, V_mem, subset.refl _⟩, _⟩,
+    rintros a ⟨v, w, v_mem, w_mem, rfl⟩,
     apply ts,
     simpa [mul_comm, mul_assoc, mul_left_comm] using h (v * x⁻¹) (w * y⁻¹) v_mem w_mem },
-  { rintros ⟨a, ⟨b, hb, ba⟩, c, ⟨d, hd, dc⟩, ac⟩,
+  { rintros ⟨a, c, ⟨b, hb, ba⟩, ⟨d, hd, dc⟩, ac⟩,
     refine ⟨b ∩ d, inter_mem_sets hb hd, assume v, _⟩,
     simp only [preimage_subset_iff, mul_inv_rev, mem_preimage] at *,
     rintros ⟨vb, vd⟩,
-    refine ac ⟨v * y⁻¹, _, y, _, _⟩,
+    refine ac ⟨v * y⁻¹, y, _, _, _⟩,
     { rw ← mul_assoc _ _ _ at vb, exact ba _ vb },
     { apply dc y, rw mul_right_inv, exact mem_of_nhds hd },
     { simp only [inv_mul_cancel_right] } }
 end
 
 @[to_additive]
-lemma nhds_is_mul_hom : is_mul_hom (λx:α, 𝓝 x) := ⟨λ_ _, nhds_pointwise_mul _ _⟩
+lemma nhds_is_mul_hom : is_mul_hom (λx:α, 𝓝 x) := ⟨λ_ _, nhds_mul _ _⟩
 
 end
 

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -76,7 +76,7 @@ definition GH_space : Type := quotient (isometry_rel.setoid)
 definition to_GH_space (α : Type u) [metric_space α] [compact_space α] [nonempty α] : GH_space :=
   ⟦nonempty_compacts.Kuratowski_embedding α⟧
 
-instance : inhabited GH_space := ⟨quot.mk _ ⟨{0}, by simp⟩⟩
+instance : inhabited GH_space := ⟨quot.mk _ ⟨{0}, by simp [-singleton_zero]⟩⟩
 
 /-- A metric space representative of any abstract point in `GH_space` -/
 definition GH_space.rep (p : GH_space) : Type := (quot.out p).val


### PR DESCRIPTION
add image2 and image3, the images of binary and ternary functions
cleanup in algebra/pointwise
make many variables implicit
make many names shorter
add some lemmas
add more simp lemmas
add type set_semiring as alias for set, with semiring instance using union as "addition"

---
<!-- put comments you want to keep out of the PR commit here -->
