### PR TITLE
[Merged by Bors] - feat(geometry/manifold/smooth_manifold_with_corners): product of smooth manifolds with corners

### DIFF
--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -1590,14 +1590,14 @@ times_cont_diff_on_univ.1 $ times_cont_diff_on.comp (times_cont_diff_on_univ.2 h
 
 /-- The product map of two `C^n` functions is `C^n`. -/
 lemma times_cont_diff_on.map_prod {E' : Type*} [normed_group E'] [normed_space 𝕜 E']
-{F' : Type*} [normed_group F'] [normed_space 𝕜 F']
-{s : set E} {t : set E'} {n : with_top ℕ} {f : E → F} {g : E' → F'}
+  {F' : Type*} [normed_group F'] [normed_space 𝕜 F']
+  {s : set E} {t : set E'} {n : with_top ℕ} {f : E → F} {g : E' → F'}
   (hf : times_cont_diff_on 𝕜 n f s) (hg : times_cont_diff_on 𝕜 n g t) :
   times_cont_diff_on 𝕜 n (prod.map f g) (set.prod s t) :=
 begin
-    have hs : s.prod t ⊆ (prod.fst) ⁻¹' s := by { rintros x ⟨h_x_1, h_x_2⟩, exact h_x_1, },
-    have ht : s.prod t ⊆ (prod.snd) ⁻¹' t := by { rintros x ⟨h_x_1, h_x_2⟩, exact h_x_2, },
-    exact (hf.comp (times_cont_diff_on_fst) hs).prod (hg.comp (times_cont_diff_on_snd) ht),
+  have hs : s.prod t ⊆ (prod.fst) ⁻¹' s := by { rintros x ⟨h_x_1, h_x_2⟩, exact h_x_1, },
+  have ht : s.prod t ⊆ (prod.snd) ⁻¹' t := by { rintros x ⟨h_x_1, h_x_2⟩, exact h_x_2, },
+  exact (hf.comp (times_cont_diff_on_fst) hs).prod (hg.comp (times_cont_diff_on_snd) ht),
 end
 
 /-- The bundled derivative of a `C^{n+1}` function is `C^n`. -/

--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -1262,7 +1262,7 @@ lemma times_cont_diff_snd {n : with_top ℕ} : times_cont_diff 𝕜 n (prod.snd 
 is_bounded_linear_map.times_cont_diff is_bounded_linear_map.snd
 
 /--
-The first projection on a domain in a product is `C^∞`.
+The second projection on a domain in a product is `C^∞`.
 -/
 lemma times_cont_diff_on_snd {s : set (E×F)} {n : with_top ℕ} :
   times_cont_diff_on 𝕜 n (prod.snd : E × F → F) s :=
@@ -1589,8 +1589,9 @@ times_cont_diff_on_univ.1 $ times_cont_diff_on.comp (times_cont_diff_on_univ.2 h
   (times_cont_diff_on_univ.2 hf) (subset_univ _)
 
 /-- The product map of two `C^n` functions is `C^n`. -/
-lemma times_cont_diff_on.map_prod {T : Type*} [normed_group T] [normed_space 𝕜 T]
-{s : set E} {t : set T} {n : with_top ℕ} {f : E → F} {g : T → G}
+lemma times_cont_diff_on.map_prod {E' : Type*} [normed_group E'] [normed_space 𝕜 E']
+{F' : Type*} [normed_group F'] [normed_space 𝕜 F']
+{s : set E} {t : set E'} {n : with_top ℕ} {f : E → F} {g : E' → F'}
   (hf : times_cont_diff_on 𝕜 n f s) (hg : times_cont_diff_on 𝕜 n g t) :
   times_cont_diff_on 𝕜 n (prod.map f g) (set.prod s t) :=
 begin

--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -1249,10 +1249,24 @@ lemma times_cont_diff_fst {n : with_top ℕ} : times_cont_diff 𝕜 n (prod.fst 
 is_bounded_linear_map.times_cont_diff is_bounded_linear_map.fst
 
 /--
+The first projection on a domain in a product is `C^∞`.
+-/
+lemma times_cont_diff_on_fst {s : set (E×F)} {n : with_top ℕ} :
+  times_cont_diff_on 𝕜 n (prod.fst : E × F → E) s :=
+times_cont_diff.times_cont_diff_on times_cont_diff_fst
+
+/--
 The second projection in a product is `C^∞`.
 -/
 lemma times_cont_diff_snd {n : with_top ℕ} : times_cont_diff 𝕜 n (prod.snd : E × F → F) :=
 is_bounded_linear_map.times_cont_diff is_bounded_linear_map.snd
+
+/--
+The first projection on a domain in a product is `C^∞`.
+-/
+lemma times_cont_diff_on_snd {s : set (E×F)} {n : with_top ℕ} :
+  times_cont_diff_on 𝕜 n (prod.snd : E × F → F) s :=
+times_cont_diff.times_cont_diff_on times_cont_diff_snd
 
 /--
 The identity is `C^∞`.
@@ -1573,6 +1587,17 @@ lemma times_cont_diff.comp {n : with_top ℕ} {g : F → G} {f : E → F}
   times_cont_diff 𝕜 n (g ∘ f) :=
 times_cont_diff_on_univ.1 $ times_cont_diff_on.comp (times_cont_diff_on_univ.2 hg)
   (times_cont_diff_on_univ.2 hf) (subset_univ _)
+
+/-- The product map of two `C^n` functions is `C^n`. -/
+lemma times_cont_diff_on.map_prod {T : Type*} [normed_group T] [normed_space 𝕜 T]
+{s : set E} {t : set T} {n : with_top ℕ} {f : E → F} {g : T → G}
+  (hf : times_cont_diff_on 𝕜 n f s) (hg : times_cont_diff_on 𝕜 n g t) :
+  times_cont_diff_on 𝕜 n (prod.map f g) (set.prod s t) :=
+begin
+    have hs : s.prod t ⊆ (prod.fst) ⁻¹' s := by { rintros x ⟨h_x_1, h_x_2⟩, exact h_x_1, },
+    have ht : s.prod t ⊆ (prod.snd) ⁻¹' t := by { rintros x ⟨h_x_1, h_x_2⟩, exact h_x_2, },
+    exact (hf.comp (times_cont_diff_on_fst) hs).prod (hg.comp (times_cont_diff_on_snd) ht),
+end
 
 /-- The bundled derivative of a `C^{n+1}` function is `C^n`. -/
 lemma times_cont_diff_on_fderiv_within_apply {m n : with_top  ℕ} {s : set E}

--- a/src/data/prod.lean
+++ b/src/data/prod.lean
@@ -19,7 +19,7 @@ variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*}
 @[simp] theorem prod.exists {p : α × β → Prop} : (∃ x, p x) ↔ (∃ a b, p (a, b)) :=
 ⟨assume ⟨⟨a, b⟩, h⟩, ⟨a, b, h⟩, assume ⟨a, b, h⟩, ⟨⟨a, b⟩, h⟩⟩
 
-@[simp] lemma prod_map (f : α → γ) (g : β → δ) : prod.map f g = λ p, (f p.1, g p.2) := rfl
+@[simp] lemma prod_map (f : α → γ) (g : β → δ) (p : α × β) : prod.map f g p = (f p.1, g p.2) := rfl
 
 namespace prod
 

--- a/src/data/prod.lean
+++ b/src/data/prod.lean
@@ -21,16 +21,18 @@ variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*}
 
 namespace prod
 
+@[simp] lemma map_def {f : α → γ} {g : β → δ} : prod.map f g = λ (p : α × β), (f p.1, g p.2) := rfl
+
 @[simp] lemma map_mk (f : α → γ) (g : β → δ) (a : α) (b : β) : map f g (a, b) = (f a, g b) := rfl
 
-@[simp] lemma map_fst (f : α → γ) (g : β → δ) (p : α × β) : (map f g p).1 = f (p.1) := rfl
+lemma map_fst (f : α → γ) (g : β → δ) (p : α × β) : (map f g p).1 = f (p.1) := rfl
 
-@[simp] lemma map_snd (f : α → γ) (g : β → δ) (p : α × β) : (map f g p).2 = g (p.2) := rfl
+lemma map_snd (f : α → γ) (g : β → δ) (p : α × β) : (map f g p).2 = g (p.2) := rfl
 
-@[simp] lemma map_fst' (f : α → γ) (g : β → δ) : (prod.fst ∘ map f g) = f ∘ prod.fst :=
+lemma map_fst' (f : α → γ) (g : β → δ) : (prod.fst ∘ map f g) = f ∘ prod.fst :=
 funext $ map_fst f g
 
-@[simp] lemma map_snd' (f : α → γ) (g : β → δ) : (prod.snd ∘ map f g) = g ∘ prod.snd :=
+lemma map_snd' (f : α → γ) (g : β → δ) : (prod.snd ∘ map f g) = g ∘ prod.snd :=
 funext $ map_snd f g
 
 @[simp] theorem mk.inj_iff {a₁ a₂ : α} {b₁ b₂ : β} : (a₁, b₁) = (a₂, b₂) ↔ (a₁ = a₂ ∧ b₁ = b₂) :=
@@ -42,9 +44,6 @@ by rw [← @mk.eta _ _ p, ← @mk.eta _ _ q, mk.inj_iff]
 @[ext]
 lemma ext {α β} {p q : α × β} (h₁ : p.1 = q.1) (h₂ : p.2 = q.2) : p = q :=
 ext_iff.2 ⟨h₁, h₂⟩
-
-lemma map_def {f : α → γ} {g : β → δ} : prod.map f g = λ (p : α × β), (f p.1, g p.2) :=
-funext (λ p, ext (map_fst f g p) (map_snd f g p))
 
 lemma id_prod : (λ (p : α × α), (p.1, p.2)) = id :=
 funext $ λ ⟨a, b⟩, rfl

--- a/src/data/prod.lean
+++ b/src/data/prod.lean
@@ -19,9 +19,9 @@ variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*}
 @[simp] theorem prod.exists {p : α × β → Prop} : (∃ x, p x) ↔ (∃ a b, p (a, b)) :=
 ⟨assume ⟨⟨a, b⟩, h⟩, ⟨a, b, h⟩, assume ⟨a, b, h⟩, ⟨⟨a, b⟩, h⟩⟩
 
-namespace prod
+@[simp] lemma prod_map (f : α → γ) (g : β → δ) : prod.map f g = λ p, (f p.1, g p.2) := rfl
 
-@[simp] lemma map_def {f : α → γ} {g : β → δ} : prod.map f g = λ (p : α × β), (f p.1, g p.2) := rfl
+namespace prod
 
 @[simp] lemma map_mk (f : α → γ) (g : β → δ) (a : α) (b : β) : map f g (a, b) = (f a, g b) := rfl
 
@@ -44,6 +44,9 @@ by rw [← @mk.eta _ _ p, ← @mk.eta _ _ q, mk.inj_iff]
 @[ext]
 lemma ext {α β} {p q : α × β} (h₁ : p.1 = q.1) (h₂ : p.2 = q.2) : p = q :=
 ext_iff.2 ⟨h₁, h₂⟩
+
+lemma map_def {f : α → γ} {g : β → δ} : prod.map f g = λ (p : α × β), (f p.1, g p.2) :=
+funext (λ p, ext (map_fst f g p) (map_snd f g p))
 
 lemma id_prod : (λ (p : α × α), (p.1, p.2)) = id :=
 funext $ λ ⟨a, b⟩, rfl

--- a/src/geometry/manifold/basic_smooth_bundle.lean
+++ b/src/geometry/manifold/basic_smooth_bundle.lean
@@ -213,10 +213,10 @@ by simp only [chart_at] with mfld_simps
 by simp only [chart_at] with mfld_simps
 
 @[simp, mfld_simps] lemma coe_chart_at_fst (p q : Z.to_topological_fiber_bundle_core.total_space) :
-  (((chart_at (model_prod H F) q) : _ → H × F) p).1 = (chart_at H q.1 : _ → H) p.1 := rfl
+  (((chart_at (model_prod H F) q) : _ → model_prod H F) p).1 = (chart_at H q.1 : _ → H) p.1 := rfl
 
 @[simp, mfld_simps] lemma coe_chart_at_symm_fst (p : H × F) (q : Z.to_topological_fiber_bundle_core.total_space) :
-  (((chart_at (model_prod H F) q).symm : H × F → Z.to_topological_fiber_bundle_core.total_space) p).1
+  (((chart_at (model_prod H F) q).symm : model_prod H F → Z.to_topological_fiber_bundle_core.total_space) p).1
   = ((chart_at H q.1).symm : H → M) p.1 := rfl
 
 /-- Smooth manifold structure on the total space of a basic smooth bundle -/

--- a/src/geometry/manifold/basic_smooth_bundle.lean
+++ b/src/geometry/manifold/basic_smooth_bundle.lean
@@ -171,7 +171,7 @@ def to_topological_fiber_bundle_core : topological_fiber_bundle_core (atlas H M)
 
 /-- Local chart for the total space of a basic smooth bundle -/
 def chart {e : local_homeomorph M H} (he : e ∈ atlas H M) :
-  local_homeomorph (Z.to_topological_fiber_bundle_core.total_space) (H × F) :=
+  local_homeomorph (Z.to_topological_fiber_bundle_core.total_space) (model_prod H F) :=
 (Z.to_topological_fiber_bundle_core.local_triv ⟨e, he⟩).trans
   (local_homeomorph.prod e (local_homeomorph.refl F))
 
@@ -190,7 +190,7 @@ end
 
 /-- The total space of a basic smooth bundle is endowed with a charted space structure, where the
 charts are in bijection with the charts of the basis. -/
-instance to_charted_space : charted_space (H × F) Z.to_topological_fiber_bundle_core.total_space :=
+instance to_charted_space : charted_space (model_prod H F) Z.to_topological_fiber_bundle_core.total_space :=
 { atlas := ⋃(e : local_homeomorph M H) (he : e ∈ atlas H M), {Z.chart he},
   chart_at := λp, Z.chart (chart_mem_atlas H p.1),
   mem_chart_source := λp, by simp [mem_chart_source],
@@ -199,24 +199,24 @@ instance to_charted_space : charted_space (H × F) Z.to_topological_fiber_bundle
     exact ⟨chart_at H p.1, chart_mem_atlas H p.1, rfl⟩
   end }
 
-lemma mem_atlas_iff (f : local_homeomorph Z.to_topological_fiber_bundle_core.total_space (H × F)) :
-  f ∈ atlas (H × F) Z.to_topological_fiber_bundle_core.total_space ↔
+lemma mem_atlas_iff (f : local_homeomorph Z.to_topological_fiber_bundle_core.total_space (model_prod H F)) :
+  f ∈ atlas (model_prod H F) Z.to_topological_fiber_bundle_core.total_space ↔
   ∃(e : local_homeomorph M H) (he : e ∈ atlas H M), f = Z.chart he :=
 by simp only [atlas, mem_Union, mem_singleton_iff]
 
 @[simp, mfld_simps] lemma mem_chart_source_iff (p q : Z.to_topological_fiber_bundle_core.total_space) :
-  p ∈ (chart_at (H × F) q).source ↔ p.1 ∈ (chart_at H q.1).source :=
+  p ∈ (chart_at (model_prod H F) q).source ↔ p.1 ∈ (chart_at H q.1).source :=
 by simp only [chart_at] with mfld_simps
 
 @[simp, mfld_simps] lemma mem_chart_target_iff (p : H × F) (q : Z.to_topological_fiber_bundle_core.total_space) :
-  p ∈ (chart_at (H × F) q).target ↔ p.1 ∈ (chart_at H q.1).target :=
+  p ∈ (chart_at (model_prod H F) q).target ↔ p.1 ∈ (chart_at H q.1).target :=
 by simp only [chart_at] with mfld_simps
 
 @[simp, mfld_simps] lemma coe_chart_at_fst (p q : Z.to_topological_fiber_bundle_core.total_space) :
-  (((chart_at (H × F) q) : _ → H × F) p).1 = (chart_at H q.1 : _ → H) p.1 := rfl
+  (((chart_at (model_prod H F) q) : _ → H × F) p).1 = (chart_at H q.1 : _ → H) p.1 := rfl
 
 @[simp, mfld_simps] lemma coe_chart_at_symm_fst (p : H × F) (q : Z.to_topological_fiber_bundle_core.total_space) :
-  (((chart_at (H × F) q).symm : H × F → Z.to_topological_fiber_bundle_core.total_space) p).1
+  (((chart_at (model_prod H F) q).symm : H × F → Z.to_topological_fiber_bundle_core.total_space) p).1
   = ((chart_at H q.1).symm : H → M) p.1 := rfl
 
 /-- Smooth manifold structure on the total space of a basic smooth bundle -/
@@ -235,11 +235,8 @@ begin
   { assume e e' he he',
     have : J.symm ⁻¹' ((chart Z he).symm.trans (chart Z he')).source ∩ range J =
       (I.symm ⁻¹' (e.symm.trans e').source ∩ range I).prod univ,
-    { have : range (λ (p : H × F), (I (p.fst), id p.snd)) =
-             (range I).prod (range (id : F → F)) := prod_range_range_eq.symm,
-      simp only [id.def, range_id] with mfld_simps at this,
-      ext p,
-      simp only [J, chart, model_with_corners.prod, this] with mfld_simps,
+    { ext p,
+      simp only [J, chart, model_with_corners.prod] with mfld_simps,
       split,
       { tauto },
       { exact λ⟨⟨hx1, hx2⟩, hx3⟩, ⟨⟨⟨hx1, e.map_target hx1⟩, hx2⟩, hx3⟩ } },
@@ -497,7 +494,7 @@ variable (M)
 local attribute [reducible] tangent_bundle
 
 instance : topological_space (tangent_bundle I M) := by apply_instance
-instance : charted_space (H × E) (tangent_bundle I M) := by apply_instance
+instance : charted_space (model_prod H E) (tangent_bundle I M) := by apply_instance
 instance : smooth_manifold_with_corners I.tangent (tangent_bundle I M) := by apply_instance
 
 local attribute [reducible] tangent_space topological_fiber_bundle_core.fiber
@@ -529,7 +526,7 @@ topological_fiber_bundle_core.is_open_map_proj _
 
 /-- In the tangent bundle to the model space, the charts are just the identity-/
 @[simp, mfld_simps] lemma tangent_bundle_model_space_chart_at (p : tangent_bundle I H) :
-  (chart_at (H × E) p).to_local_equiv = local_equiv.refl (H × E) :=
+  (chart_at (model_prod H E) p).to_local_equiv = local_equiv.refl (model_prod H E) :=
 begin
   have A : ∀ x_fst, fderiv_within 𝕜 (I ∘ I.symm) (range I) (I x_fst)
            = continuous_linear_map.id 𝕜 E,
@@ -540,26 +537,26 @@ begin
       exact model_with_corners.right_inv _ hy },
     rwa fderiv_within_id I.unique_diff_at_image at this },
   ext x : 1,
-  show (chart_at (H × E) p : tangent_bundle I H → H × E) x = (local_equiv.refl (H × E)) x,
+  show (chart_at (model_prod H E) p : tangent_bundle I H → model_prod H E) x = (local_equiv.refl (model_prod H E)) x,
   { cases x,
     simp only [chart_at, basic_smooth_bundle_core.chart, topological_fiber_bundle_core.local_triv,
       topological_fiber_bundle_core.local_triv', tangent_bundle_core, A, continuous_linear_map.coe_id',
       basic_smooth_bundle_core.to_topological_fiber_bundle_core] with mfld_simps },
-  show ∀ x, ((chart_at (H × E) p).to_local_equiv).symm x = (local_equiv.refl (H × E)).symm x,
+  show ∀ x, ((chart_at (model_prod H E) p).to_local_equiv).symm x = (local_equiv.refl (model_prod H E)).symm x,
   { rintros ⟨x_fst, x_snd⟩,
     simp only [chart_at, basic_smooth_bundle_core.chart, topological_fiber_bundle_core.local_triv,
       topological_fiber_bundle_core.local_triv', tangent_bundle_core, A, continuous_linear_map.coe_id',
       basic_smooth_bundle_core.to_topological_fiber_bundle_core] with mfld_simps},
-  show ((chart_at (H × E) p).to_local_equiv).source = (local_equiv.refl (H × E)).source,
+  show ((chart_at (model_prod H E) p).to_local_equiv).source = (local_equiv.refl (model_prod H E)).source,
     by simp only [chart_at] with mfld_simps,
 end
 
 @[simp, mfld_simps] lemma tangent_bundle_model_space_coe_chart_at (p : tangent_bundle I H) :
-  (chart_at (H × E) p : tangent_bundle I H → H × E) = id :=
+  (chart_at (model_prod H E) p : tangent_bundle I H → model_prod H E) = id :=
 by { unfold_coes, simp only with mfld_simps }
 
 @[simp, mfld_simps] lemma tangent_bundle_model_space_coe_chart_at_symm (p : tangent_bundle I H) :
-  ((chart_at (H × E) p).symm : H × E → tangent_bundle I H) = id :=
+  ((chart_at (model_prod H E) p).symm : model_prod H E → tangent_bundle I H) = id :=
 by { unfold_coes, simp only with mfld_simps, refl }
 
 variable (H)
@@ -570,7 +567,7 @@ lemma tangent_bundle_model_space_topology_eq_prod :
 begin
   ext o,
   let x : tangent_bundle I H := (I.symm (0 : E), (0 : E)),
-  let e := chart_at (H × E) x,
+  let e := chart_at (model_prod H E) x,
   have e_source : e.source = univ, by { simp only with mfld_simps, refl },
   have e_target : e.target = univ, by { simp only with mfld_simps, refl },
   let e' := e.to_homeomorph_of_source_eq_univ_target_eq_univ e_source e_target,

--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -407,14 +407,14 @@ by simp [atlas, charted_space.atlas]
   chart_at H x = local_homeomorph.refl H :=
 by simpa using chart_mem_atlas H x
 
-/-- Same thing as `H × H'`. We introduce it for tecnical reasons: a charted space `M` with model `H`
+/-- Same thing as `H × H'`. We introduce it for technical reasons: a charted space `M` with model `H`
 is a set of local charts from `M` to `H` covering the space. Every space is registered as a charted
-space over itself, using the only chart `id`, in `charted_space_self`. You can also define a product
+space over itself, using the only chart `id`, in `manifold_model_space`. You can also define a product
 of charted space `M` and `M'` (with model space `H × H'`) by taking the products of the charts. Now,
 on `H × H'`, there are two charted space structures with model space `H × H'` itself, the one coming
-from `charted_space_self`, and the one coming from the product of the two `charted_space_self` on
+from `manifold_model_space`, and the one coming from the product of the two `manifold_model_space` on
 each component. They are equal, but not defeq (because the product of `id` and `id` is not defeq to
-`id`), which is bad as we know. This expedient of renaiming `H × H'` solves this problem. -/
+`id`), which is bad as we know. This expedient of renaming `H × H'` solves this problem. -/
 def model_prod (H : Type*) (H' : Type*) := H × H'
 
 section
@@ -447,11 +447,13 @@ instance prod_charted_space (H : Type*) [topological_space H]
     {f : (local_homeomorph (M×M') (model_prod H H')) |
       ∃ g ∈ charted_space.atlas H M, ∃ h ∈ (charted_space.atlas H' M'),
         f = local_homeomorph.prod g h},
-  chart_at         := (λ x: (M × M'), (charted_space.chart_at H x.1).prod (charted_space.chart_at H' x.2)),
+  chart_at         := λ x: (M × M'),
+    (charted_space.chart_at H x.1).prod (charted_space.chart_at H' x.2),
   mem_chart_source :=
   begin
     intro x,
-    simp only [local_homeomorph.prod_to_local_equiv, set.mem_prod, mem_chart_source, and_self, local_equiv.prod_source],
+    simp only [local_homeomorph.prod_to_local_equiv, set.mem_prod, mem_chart_source, and_self,
+      local_equiv.prod_source],
   end,
   chart_mem_atlas  :=
   begin
@@ -460,59 +462,15 @@ instance prod_charted_space (H : Type*) [topological_space H]
     split,
     { apply chart_mem_atlas _, },
     { use (charted_space.chart_at H' x.2), simp only [chart_mem_atlas, eq_self_iff_true, and_self], }
-  end
-}
+  end }
 
 section prod_charted_space
 
 variables [topological_space H] [topological_space M] [charted_space H M]
 [topological_space H'] [topological_space M'] [charted_space H' M'] {x : M×M'}
 
-@[simp] lemma chart_of_prod_eq_prod_of_charts_coe :
-  (chart_at (model_prod H H') x : M × M' → model_prod H H')
-  = (prod.map (chart_at H x.fst) (chart_at H' x.snd)) := rfl
-
-@[simp] lemma chart_of_prod_eq_prod_of_charts_coe_symm :
-  ((chart_at (model_prod H H') x).symm : model_prod H H' → M × M') =
-  (prod.map (chart_at H x.fst).symm (chart_at H' x.snd).symm) := rfl
-
-@[simp] lemma chart_of_prod_eq_prod_of_charts_coe_to_local_equiv_trans {α : Type*} {β : Type*}
-  {e : local_equiv H α} {e' : local_equiv H' β} :
-  (chart_at (model_prod H H') x).to_local_equiv.trans (e.prod e') =
-  (((chart_at H x.fst).to_local_equiv.trans e).prod ((chart_at H' x.snd).to_local_equiv.trans e'))
-  :=
-begin
-  cases x,
-  ext1,
-  {refl,},
-  { intro y, refl, },
-  { ext1 z,
-    cases z,
-    simp only [local_homeomorph.prod_to_local_equiv, local_homeomorph.trans_to_local_equiv,
-    set.prod_mk_mem_set_prod_eq, local_equiv.prod_source],
-    fsplit,
-    { rintro ⟨⟨h1, h2⟩, h3, h4⟩, exact ⟨⟨h1, h3⟩, ⟨h2, h4⟩⟩, },
-    { rintro ⟨⟨h1, h2⟩, h3, h4⟩, exact ⟨⟨h1, h3⟩, ⟨h2, h4⟩⟩, } }
-end
-
-@[simp] lemma chart_of_prod_eq_prod_of_charts_coe_trans {α : Type*} {β : Type*}
-[topological_space α] [topological_space β]
-{e : local_homeomorph H α} {e' : local_homeomorph H' β} :
-(chart_at (model_prod H H') x).trans (e.prod e') =
-((chart_at H x.fst).trans e).prod ((chart_at H' x.snd).trans e') :=
-begin
-  cases x,
-  ext1,
-  {refl,},
-  { intro y, refl, },
-  { ext1 z,
-    cases z,
-    simp only [local_homeomorph.prod_to_local_equiv, local_homeomorph.trans_to_local_equiv,
-    set.prod_mk_mem_set_prod_eq, local_equiv.prod_source],
-    fsplit,
-    { rintro ⟨⟨h1, h2⟩, h3, h4⟩, exact ⟨⟨h1, h3⟩, ⟨h2, h4⟩⟩, },
-    { rintro ⟨⟨h1, h2⟩, h3, h4⟩, exact ⟨⟨h1, h3⟩, ⟨h2, h4⟩⟩, } }
-end
+@[simp, mfld_simps] lemma prod_charted_space_chart_at :
+  (chart_at (model_prod H H') x) = (chart_at H x.fst).prod (chart_at H' x.snd) := rfl
 
 end prod_charted_space
 

--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -407,10 +407,22 @@ by simp [atlas, charted_space.atlas]
   chart_at H x = local_homeomorph.refl H :=
 by simpa using chart_mem_atlas H x
 
+/-- Same thing as `H × H'`. We introduce it for tecnical reasons: a charted space `M` with model `H`
+is a set of local charts from `M` to `H` covering the space. Every space is registered as a charted
+space over itself, using the only chart `id`, in `charted_space_self`. You can also define a product
+of charted space `M` and `M'` (with model space `H × H'`) by taking the products of the charts. Now,
+on `H × H'`, there are two charted space structures with model space `H × H'` itself, the one coming
+from `charted_space_self`, and the one coming from the product of the two `charted_space_self` on
+each component. They are equal, but not defeq (because the product of `id` and `id` is not defeq to
+`id`), which is bad as we know. This expedient of renaiming `H × H'` solves this problem. -/
 def model_prod (H : Type*) (H' : Type*) := H × H'
 
 section
 local attribute [reducible] model_prod
+
+instance model_prod_inhabited {α β : Type*} [inhabited α] [inhabited β] :
+  inhabited (model_prod α β) :=
+⟨(default α, default β)⟩
 
 instance (H : Type*) [topological_space H] (H' : Type*) [topological_space H'] :
   topological_space (model_prod H H') :=

--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -452,7 +452,7 @@ instance prod_charted_space (H : Type*) [topological_space H]
   mem_chart_source :=
   begin
     intro x,
-    simp only [] with mfld_simps,
+    simp only with mfld_simps,
   end,
   chart_mem_atlas  :=
   begin

--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -452,8 +452,7 @@ instance prod_charted_space (H : Type*) [topological_space H]
   mem_chart_source :=
   begin
     intro x,
-    simp only [local_homeomorph.prod_to_local_equiv, set.mem_prod, mem_chart_source, and_self,
-      local_equiv.prod_source],
+    simp only [] with mfld_simps,
   end,
   chart_mem_atlas  :=
   begin

--- a/src/geometry/manifold/mfderiv.lean
+++ b/src/geometry/manifold/mfderiv.lean
@@ -1012,7 +1012,7 @@ mdifferentiable_of_mem_atlas _ (chart_mem_atlas _ _)
 
 /-- The derivative of the chart at a base point is the chart of the tangent bundle. -/
 lemma tangent_map_chart {p q : tangent_bundle I M} (h : q.1 ∈ (chart_at H p.1).source) :
-  tangent_map I I (chart_at H p.1) q = (chart_at (H × E) p : tangent_bundle I M → H × E) q :=
+  tangent_map I I (chart_at H p.1) q = (chart_at (model_prod H E) p : tangent_bundle I M → model_prod H E) q :=
 begin
   dsimp [tangent_map],
   rw mdifferentiable_at.mfderiv,
@@ -1022,10 +1022,10 @@ end
 
 /-- The derivative of the inverse of the chart at a base point is the inverse of the chart of the
 tangent bundle. -/
-lemma tangent_map_chart_symm {p : tangent_bundle I M} {q : H × E}
+lemma tangent_map_chart_symm {p : tangent_bundle I M} {q : model_prod H E}
   (h : q.1 ∈ (chart_at H p.1).target) :
   tangent_map I I (chart_at H p.1).symm q =
-  ((chart_at (H × E) p).symm : H × E → tangent_bundle I M) q :=
+  ((chart_at (model_prod H E) p).symm : model_prod H E → tangent_bundle I M) q :=
 begin
   dsimp only [tangent_map],
   rw mdifferentiable_at.mfderiv (mdifferentiable_at_atlas_symm _ (chart_mem_atlas _ _) h),
@@ -1358,7 +1358,7 @@ begin
   assume p hp,
   replace hp : p.fst ∈ s, by simpa only [] with mfld_simps using hp,
   let e₀ := chart_at H p.1,
-  let e := chart_at (H × F) p,
+  let e := chart_at (model_prod H F) p,
   -- It suffices to prove unique differentiability in a chart
   suffices h : unique_mdiff_on (I.prod (model_with_corners_self 𝕜 F))
     (e.target ∩ e.symm⁻¹' (Z.to_topological_fiber_bundle_core.proj ⁻¹' s)),
@@ -1377,13 +1377,13 @@ begin
   -- rewrite the relevant set in the chart as a direct product
   have : (λ (p : E × F), (I.symm p.1, p.snd)) ⁻¹' e.target ∩
          (λ (p : E × F), (I.symm p.1, p.snd)) ⁻¹' (e.symm ⁻¹' (prod.fst ⁻¹' s)) ∩
-         range (λ (p : H × F), (I p.1, p.snd))
+         ((range I).prod univ)
     = set.prod (I.symm ⁻¹' (e₀.target ∩ e₀.symm⁻¹' s) ∩ range I) univ,
   { ext q,
     split;
     { assume hq,
-      simp only [prod_range_univ_eq.symm] with mfld_simps at hq,
-      simp only [hq, prod_range_univ_eq.symm] with mfld_simps } },
+      simp only with mfld_simps at hq,
+      simp only [hq] with mfld_simps } },
   assume q hq,
   replace hq : q.1 ∈ (chart_at H p.1).target ∧ ((chart_at H p.1).symm : H → M) q.1 ∈ s,
     by simpa only [] with mfld_simps using hq,

--- a/src/geometry/manifold/smooth_manifold_with_corners.lean
+++ b/src/geometry/manifold/smooth_manifold_with_corners.lean
@@ -246,8 +246,8 @@ def model_with_corners.prod
   (I : model_with_corners 𝕜 E H)
   {E' : Type v'} [normed_group E'] [normed_space 𝕜 E'] {H' : Type w'} [topological_space H']
   (I' : model_with_corners 𝕜 E' H') : model_with_corners 𝕜 (E × E') (model_prod H H') :=
-{ to_fun       := λp, (I p.1, I' p.2),
-  inv_fun      := λp, (I.symm p.1, I'.symm p.2),
+{ to_fun       := λ p, (I p.1, I' p.2),
+  inv_fun      := λ p, (I.symm p.1, I'.symm p.2),
   source       := (univ : set (H × H')),
   target       := set.prod (range I) (range I'),
   map_source'  := λ ⟨x, x'⟩ _, by simp [-mem_range, mem_range_self],
@@ -281,7 +281,7 @@ variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 {G : Type*} [topological_space G] {G' : Type*} [topological_space G']
 {I : model_with_corners 𝕜 E H} {J : model_with_corners 𝕜 F G}
 
-@[simp] lemma model_with_corners_prod_to_local_equiv :
+@[simp, mfld_simps] lemma model_with_corners_prod_to_local_equiv :
   (I.prod J).to_local_equiv = (I.to_local_equiv).prod (J.to_local_equiv) :=
 begin
   ext1 x,
@@ -289,6 +289,14 @@ begin
   { intro x, refl, },
   { simp only [set.univ_prod_univ, model_with_corners.source_eq, local_equiv.prod_source], }
 end
+
+@[simp, mfld_simps] lemma model_with_corners_prod_coe
+  (I : model_with_corners 𝕜 E H) (I' : model_with_corners 𝕜 E' H') :
+  (I.prod I' : _ × _ → _ × _) = (prod.map I I') := rfl
+
+@[simp, mfld_simps] lemma model_with_corners_prod_coe_symm
+  (I : model_with_corners 𝕜 E H) (I' : model_with_corners 𝕜 E' H') :
+  ((I.prod I').symm : _ × _ → _ × _) = (prod.map I.symm (I').symm) := rfl
 
 end model_with_corners_prod
 
@@ -440,20 +448,12 @@ end
 
 variables {E' : Type*} [normed_group E'] [normed_space 𝕜 E'] {H' : Type*} [topological_space H']
 
-@[simp] lemma model_with_corners_prod_coe
-  (I : model_with_corners 𝕜 E H) (I' : model_with_corners 𝕜 E' H') :
-  (I.prod I' : _ × _ → _ × _) = (prod.map I I') := rfl
-
-@[simp] lemma model_with_corners_prod_coe_symm
-  (I : model_with_corners 𝕜 E H) (I' : model_with_corners 𝕜 E' H') :
-  ((I.prod I').symm : _ × _ → _ × _) = (prod.map I.symm (I').symm) := rfl
-
 /-- The product of two smooth local homeomorphisms is smooth. -/
 lemma times_cont_diff_groupoid_prod
   {I : model_with_corners 𝕜 E H} {I' : model_with_corners 𝕜 E' H'}
   {e : local_homeomorph H H} {e' : local_homeomorph H' H'}
-  (he : (e ∈ (times_cont_diff_groupoid ⊤ I))) (he' : (e' ∈ (times_cont_diff_groupoid ⊤ I'))) :
-  (e.prod e') ∈ (times_cont_diff_groupoid ⊤ (I.prod I')) :=
+  (he : e ∈ times_cont_diff_groupoid ⊤ I) (he' : e' ∈ times_cont_diff_groupoid ⊤ I') :
+  e.prod e' ∈ times_cont_diff_groupoid ⊤ (I.prod I') :=
 begin
   cases he with he he_symm,
   cases he' with he' he'_symm,
@@ -537,16 +537,14 @@ instance prod_smooth_manifold_with_corners {𝕜 : Type*} [nondiscrete_normed_fi
   (M : Type*) [topological_space M] [charted_space H M] [smooth_manifold_with_corners I M]
   (M' : Type*) [topological_space M'] [charted_space H' M'] [smooth_manifold_with_corners I' M'] :
   smooth_manifold_with_corners (I.prod I') (M×M') :=
-{
-  compatible :=
+{ compatible :=
   begin
     rintros f g ⟨f1, hf1, f2, hf2, hf⟩ ⟨g1, hg1, g2, hg2, hg⟩,
     rw [hf, hg, local_homeomorph.prod_symm, local_homeomorph.prod_trans],
     have h1 := has_groupoid.compatible (times_cont_diff_groupoid ⊤ I) hf1 hg1,
     have h2 := has_groupoid.compatible (times_cont_diff_groupoid ⊤ I') hf2 hg2,
     exact times_cont_diff_groupoid_prod h1 h2,
-  end,
-}
+  end,}
 
 end smooth_manifold_with_corners
 

--- a/src/geometry/manifold/smooth_manifold_with_corners.lean
+++ b/src/geometry/manifold/smooth_manifold_with_corners.lean
@@ -292,11 +292,11 @@ end
 
 @[simp, mfld_simps] lemma model_with_corners_prod_coe
   (I : model_with_corners 𝕜 E H) (I' : model_with_corners 𝕜 E' H') :
-  (I.prod I' : _ × _ → _ × _) = (prod.map I I') := rfl
+  (I.prod I' : _ × _ → _ × _) = prod.map I I' := rfl
 
 @[simp, mfld_simps] lemma model_with_corners_prod_coe_symm
   (I : model_with_corners 𝕜 E H) (I' : model_with_corners 𝕜 E' H') :
-  ((I.prod I').symm : _ × _ → _ × _) = (prod.map I.symm (I').symm) := rfl
+  ((I.prod I').symm : _ × _ → _ × _) = prod.map I.symm I'.symm := rfl
 
 end model_with_corners_prod
 
@@ -457,7 +457,7 @@ lemma times_cont_diff_groupoid_prod
 begin
   cases he with he he_symm,
   cases he' with he' he'_symm,
-  simp only [] at he he_symm he' he'_symm,
+  simp only at he he_symm he' he'_symm,
   split;
   simp only [local_equiv.prod_source, local_homeomorph.prod_to_local_equiv],
   { have h3 := times_cont_diff_on.map_prod he he',

--- a/src/geometry/manifold/smooth_manifold_with_corners.lean
+++ b/src/geometry/manifold/smooth_manifold_with_corners.lean
@@ -235,6 +235,8 @@ I.unique_diff _ (mem_range_self _)
 
 end
 
+section model_with_corners_prod
+
 /-- Given two model_with_corners `I` on `(E, H)` and `I'` on `(E', H')`, we define the model with
 corners `I.prod I'` on `(E × E', H × H')`. This appears in particular for the manifold structure on
 the tangent bundle to a manifold modelled on `(E, H)`: it will be modelled on `(E × E, H × E)`. -/
@@ -272,17 +274,14 @@ as the model to tangent bundles. -/
   (I : model_with_corners 𝕜 E H) : model_with_corners 𝕜 (E × E) (model_prod H E) :=
  I.prod (model_with_corners_self 𝕜 E)
 
-lemma model_with_corners_prod_to_local_equiv {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
-{E : Type*} [normed_group E] [normed_space 𝕜 E]
-{E' : Type*} [normed_group E'] [normed_space 𝕜 E']
-{F : Type*} [normed_group F] [normed_space 𝕜 F]
-{F' : Type*} [normed_group F'] [normed_space 𝕜 F']
-{H : Type*} [topological_space H]
-{H' : Type*} [topological_space H']
-{G : Type*} [topological_space G]
-{G' : Type*} [topological_space G']
-{I : model_with_corners 𝕜 E H} {I' : model_with_corners 𝕜 E' H'}
-{J : model_with_corners 𝕜 F G} {J' : model_with_corners 𝕜 F' G'} :
+variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
+{E : Type*} [normed_group E] [normed_space 𝕜 E] {E' : Type*} [normed_group E'] [normed_space 𝕜 E']
+{F : Type*} [normed_group F] [normed_space 𝕜 F] {F' : Type*} [normed_group F'] [normed_space 𝕜 F']
+{H : Type*} [topological_space H] {H' : Type*} [topological_space H']
+{G : Type*} [topological_space G] {G' : Type*} [topological_space G']
+{I : model_with_corners 𝕜 E H} {J : model_with_corners 𝕜 F G}
+
+@[simp] lemma model_with_corners_prod_to_local_equiv :
   (I.prod J).to_local_equiv = (I.to_local_equiv).prod (J.to_local_equiv) :=
 begin
   ext1 x,
@@ -290,6 +289,8 @@ begin
   { intro x, refl, },
   { simp only [set.univ_prod_univ, model_with_corners.source_eq, local_equiv.prod_source], }
 end
+
+end model_with_corners_prod
 
 section boundaryless
 
@@ -531,8 +532,8 @@ structure_groupoid.compatible_of_mem_maximal_atlas he he'
 instance prod_smooth_manifold_with_corners {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
   {E : Type*} [normed_group E] [normed_space 𝕜 E]
   {E' : Type*} [normed_group E'] [normed_space 𝕜 E']
-  {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
-  {H' : Type*} [topological_space H'] (I' : model_with_corners 𝕜 E' H')
+  {H : Type*} [topological_space H] {I : model_with_corners 𝕜 E H}
+  {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
   (M : Type*) [topological_space M] [charted_space H M] [smooth_manifold_with_corners I M]
   (M' : Type*) [topological_space M'] [charted_space H' M'] [smooth_manifold_with_corners I' M'] :
   smooth_manifold_with_corners (I.prod I') (M×M') :=

--- a/src/geometry/manifold/smooth_manifold_with_corners.lean
+++ b/src/geometry/manifold/smooth_manifold_with_corners.lean
@@ -272,6 +272,25 @@ as the model to tangent bundles. -/
   (I : model_with_corners 𝕜 E H) : model_with_corners 𝕜 (E × E) (model_prod H E) :=
  I.prod (model_with_corners_self 𝕜 E)
 
+lemma model_with_corners_prod_to_local_equiv {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
+{E : Type*} [normed_group E] [normed_space 𝕜 E]
+{E' : Type*} [normed_group E'] [normed_space 𝕜 E']
+{F : Type*} [normed_group F] [normed_space 𝕜 F]
+{F' : Type*} [normed_group F'] [normed_space 𝕜 F']
+{H : Type*} [topological_space H]
+{H' : Type*} [topological_space H']
+{G : Type*} [topological_space G]
+{G' : Type*} [topological_space G']
+{I : model_with_corners 𝕜 E H} {I' : model_with_corners 𝕜 E' H'}
+{J : model_with_corners 𝕜 F G} {J' : model_with_corners 𝕜 F' G'} :
+  (I.prod J).to_local_equiv = (I.to_local_equiv).prod (J.to_local_equiv) :=
+begin
+  ext1 x,
+  { refl, },
+  { intro x, refl, },
+  { simp only [set.univ_prod_univ, model_with_corners.source_eq, local_equiv.prod_source], }
+end
+
 section boundaryless
 
 /-- Property ensuring that the model with corners `I` defines manifolds without boundary. -/
@@ -520,8 +539,7 @@ instance prod_smooth_manifold_with_corners {𝕜 : Type*} [nondiscrete_normed_fi
 {
   compatible :=
   begin
-    intros f g,
-    rintros ⟨f1, hf1, f2, hf2, hf⟩ ⟨g1, hg1, g2, hg2, hg⟩,
+    rintros f g ⟨f1, hf1, f2, hf2, hf⟩ ⟨g1, hg1, g2, hg2, hg⟩,
     rw [hf, hg, local_homeomorph.prod_symm, local_homeomorph.prod_trans],
     have h1 := has_groupoid.compatible (times_cont_diff_groupoid ⊤ I) hf1 hg1,
     have h2 := has_groupoid.compatible (times_cont_diff_groupoid ⊤ I') hf2 hg2,

--- a/src/geometry/manifold/smooth_manifold_with_corners.lean
+++ b/src/geometry/manifold/smooth_manifold_with_corners.lean
@@ -544,7 +544,7 @@ instance prod_smooth_manifold_with_corners {𝕜 : Type*} [nondiscrete_normed_fi
     have h1 := has_groupoid.compatible (times_cont_diff_groupoid ⊤ I) hf1 hg1,
     have h2 := has_groupoid.compatible (times_cont_diff_groupoid ⊤ I') hf2 hg2,
     exact times_cont_diff_groupoid_prod h1 h2,
-  end,}
+  end }
 
 end smooth_manifold_with_corners
 

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -349,3 +349,6 @@ end function
 def set.piecewise {α : Type u} {β : α → Sort v} (s : set α) (f g : Πi, β i) [∀j, decidable (j ∈ s)] :
   Πi, β i :=
 λi, if i ∈ s then f i else g i
+
+@[simp] lemma prod_map {α₁ α₂ β₁ β₂ : Type*}
+  (f : α₁ → α₂) (g : β₁ → β₂) : prod.map f g = λ x, (f x.1, g x.2) := rfl

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -349,6 +349,3 @@ end function
 def set.piecewise {α : Type u} {β : α → Sort v} (s : set α) (f g : Πi, β i) [∀j, decidable (j ∈ s)] :
   Πi, β i :=
 λi, if i ∈ s then f i else g i
-
-@[simp] lemma prod_map {α₁ α₂ β₁ β₂ : Type*}
-  (f : α₁ → α₂) (g : β₁ → β₂) : prod.map f g = λ x, (f x.1, g x.2) := rfl


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->
We define the natural instance of the product of charted space and of the product of smooth manifolds with corners. To this goal, we also prove that the product map of two smooth maps (times_cont_diff \top) is smooth and we prove some technical lemmas necessary to do simplifications.