### PR TITLE
[Merged by Bors] - chore(topology/*): use dot syntax for some lemmas

### DIFF
--- a/src/algebraic_geometry/prime_spectrum.lean
+++ b/src/algebraic_geometry/prime_spectrum.lean
@@ -354,7 +354,7 @@ begin
     rw [subset_zero_locus_iff_subset_vanishing_ideal] at ht,
     calc fs ⊆ vanishing_ideal t : ht
         ... ⊆ x.as_ideal        : hx },
-  { rw closure_subset_iff_subset_of_is_closed (is_closed_zero_locus _),
+  { rw (is_closed_zero_locus _).closure_subset_iff,
     exact subset_zero_locus_vanishing_ideal t }
 end
 
@@ -366,7 +366,7 @@ begin
   let I : ι → ideal R := λ i, vanishing_ideal (Z i),
   have hI : ∀ i, Z i = zero_locus (I i),
   { intro i,
-    rw [zero_locus_vanishing_ideal_eq_closure, closure_eq_of_is_closed],
+    rw [zero_locus_vanishing_ideal_eq_closure, is_closed.closure_eq],
     exact hZc i },
   have one_mem : (1:R) ∈ ⨆ (i : ι), I i,
   { rw [← ideal.eq_top_iff_one, ← zero_locus_empty_iff_eq_top, zero_locus_supr],

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -260,7 +260,7 @@ begin
     have : closure (submodule.span 𝕜 (tangent_cone_at 𝕜 s x) : set E) ⊆ closure K :=
       closure_mono this,
     have : y ∈ closure K := this hy,
-    rwa closure_eq_of_is_closed (is_closed_eq f'.continuous f₁'.continuous) at this },
+    rwa (is_closed_eq f'.continuous f₁'.continuous).closure_eq at this },
   rw H.1 at C,
   ext y,
   exact C y (mem_univ _)

--- a/src/analysis/calculus/inverse.lean
+++ b/src/analysis/calculus/inverse.lean
@@ -289,7 +289,7 @@ begin
     { exact lipschitz_with.of_dist_le_mul (λ x x', hf.inverse_approx_map_contracts_on
         y (hε x.mem) (hε x'.mem)) } },
   refine ⟨this.efixed_point' _ _ _ b (mem_closed_ball_self ε0) (edist_lt_top _ _), _, _⟩,
-  { exact is_complete_of_is_closed is_closed_ball },
+  { exact is_closed_ball.is_complete },
   { apply contracting_with.efixed_point_mem' },
   { exact (inverse_approx_map_fixed_iff y).1 (this.efixed_point_is_fixed_pt' _ _ _ _) }
 end

--- a/src/analysis/convex/topology.lean
+++ b/src/analysis/convex/topology.lean
@@ -116,7 +116,7 @@ end
 /-- Convex hull of a finite set is closed. -/
 lemma set.finite.is_closed_convex_hull [t2_space E] {s : set E} (hs : finite s) :
   is_closed (convex_hull s) :=
-closed_of_compact _ hs.compact_convex_hull
+hs.compact_convex_hull.is_closed
 
 end topological_vector_space
 

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -825,12 +825,12 @@ end
 
 theorem frontier_closed_ball [normed_space ℝ E] (x : E) {r : ℝ} (hr : 0 < r) :
   frontier (closed_ball x r) = sphere x r :=
-by rw [frontier, closure_eq_of_is_closed is_closed_ball, interior_closed_ball x hr,
+by rw [frontier, closure_closed_ball, interior_closed_ball x hr,
   closed_ball_diff_ball]
 
 theorem frontier_closed_ball' [normed_space ℝ E] (x : E) (r : ℝ) (hE : ∃ z : E, z ≠ 0) :
   frontier (closed_ball x r) = sphere x r :=
-by rw [frontier, closure_eq_of_is_closed is_closed_ball, interior_closed_ball' x r hE,
+by rw [frontier, closure_closed_ball, interior_closed_ball' x r hE,
   closed_ball_diff_ball]
 
 open normed_field

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -97,7 +97,7 @@ begin
         exact (equiv_fun_basis b_basis).symm.uniform_embedding (linear_map.continuous_on_pi _) this },
       have : is_complete (s : set E),
         from complete_space_coe_iff_is_complete.1 ((complete_space_congr U).1 (by apply_instance)),
-      exact is_closed_of_is_complete this },
+      exact this.is_closed },
     -- second step: any linear form is continuous, as its kernel is closed by the first step
     have H₂ : ∀f : E →ₗ[𝕜] 𝕜, continuous f,
     { assume f,
@@ -199,7 +199,7 @@ complete_space_coe_iff_is_complete.1 (finite_dimensional.complete 𝕜 s)
 /-- A finite-dimensional subspace is closed. -/
 lemma submodule.closed_of_finite_dimensional (s : submodule 𝕜 E) [finite_dimensional 𝕜 s] :
   is_closed (s : set E) :=
-is_closed_of_is_complete s.complete_of_finite_dimensional
+s.complete_of_finite_dimensional.is_closed
 
 lemma continuous_linear_map.exists_right_inverse_of_surjective [finite_dimensional 𝕜 F]
   (f : E →L[𝕜] F) (hf : f.range = ⊤) :

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -344,7 +344,7 @@ continuous_iff_is_closed.1 f.cont _ is_closed_singleton
 lemma is_complete_ker {M' : Type*} [uniform_space M'] [complete_space M'] [add_comm_monoid M']
   [semimodule R M'] [t1_space M₂] (f : M' →L[R] M₂) :
   is_complete (f.ker : set M') :=
-is_complete_of_is_closed f.is_closed_ker
+f.is_closed_ker.is_complete
 
 instance complete_space_ker {M' : Type*} [uniform_space M'] [complete_space M'] [add_comm_monoid M']
   [semimodule R M'] [t1_space M₂] (f : M' →L[R] M₂) :

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -281,13 +281,13 @@ subset_sInter $ assume t ⟨h₁, h₂⟩, h₂
 lemma closure_minimal {s t : set α} (h₁ : s ⊆ t) (h₂ : is_closed t) : closure s ⊆ t :=
 sInter_subset_of_mem ⟨h₂, h₁⟩
 
-lemma closure_eq_of_is_closed {s : set α} (h : is_closed s) : closure s = s :=
+lemma is_closed.closure_eq {s : set α} (h : is_closed s) : closure s = s :=
 subset.antisymm (closure_minimal (subset.refl s) h) subset_closure
 
-lemma closure_eq_iff_is_closed {s : set α} : closure s = s ↔ is_closed s :=
-⟨assume h, h ▸ is_closed_closure, closure_eq_of_is_closed⟩
+lemma is_closed.closure_subset {s : set α} (hs : is_closed s) : closure s ⊆ s :=
+closure_minimal (subset.refl _) hs
 
-lemma closure_subset_iff_subset_of_is_closed {s t : set α} (h₁ : is_closed t) :
+lemma is_closed.closure_subset_iff {s t : set α} (h₁ : is_closed t) :
   closure s ⊆ t ↔ s ⊆ t :=
 ⟨subset.trans subset_closure, assume h, closure_minimal h h₁⟩
 
@@ -304,10 +304,16 @@ lemma closure_inter_subset_inter_closure (s t : set α) :
 lemma is_closed_of_closure_subset {s : set α} (h : closure s ⊆ s) : is_closed s :=
 by rw subset.antisymm subset_closure h; exact is_closed_closure
 
-@[simp] lemma closure_empty : closure (∅ : set α) = ∅ :=
-closure_eq_of_is_closed is_closed_empty
+lemma closure_eq_iff_is_closed {s : set α} : closure s = s ↔ is_closed s :=
+⟨assume h, h ▸ is_closed_closure, is_closed.closure_eq⟩
 
-lemma closure_empty_iff (s : set α) : closure s = ∅ ↔ s = ∅ :=
+lemma closure_subset_iff_is_closed {s : set α} : closure s ⊆ s ↔ is_closed s :=
+⟨is_closed_of_closure_subset, is_closed.closure_subset⟩
+
+@[simp] lemma closure_empty : closure (∅ : set α) = ∅ :=
+is_closed_empty.closure_eq
+
+@[simp] lemma closure_empty_iff (s : set α) : closure s = ∅ ↔ s = ∅ :=
 ⟨subset_eq_empty subset_closure, λ h, h.symm ▸ closure_empty⟩
 
 lemma set.nonempty.closure {s : set α} (h : s.nonempty) :
@@ -315,10 +321,10 @@ lemma set.nonempty.closure {s : set α} (h : s.nonempty) :
 let ⟨x, hx⟩ := h in ⟨x, subset_closure hx⟩
 
 @[simp] lemma closure_univ : closure (univ : set α) = univ :=
-closure_eq_of_is_closed is_closed_univ
+is_closed_univ.closure_eq
 
 @[simp] lemma closure_closure {s : set α} : closure (closure s) = closure s :=
-closure_eq_of_is_closed is_closed_closure
+is_closed_closure.closure_eq
 
 @[simp] lemma closure_union {s t : set α} : closure (s ∪ t) = closure s ∪ closure t :=
 subset.antisymm
@@ -396,7 +402,7 @@ by simpa only [frontier_compl, ← compl_union]
   using frontier_inter_subset sᶜ tᶜ
 
 lemma is_closed.frontier_eq {s : set α} (hs : is_closed s) : frontier s = s \ interior s :=
-by rw [frontier, closure_eq_of_is_closed hs]
+by rw [frontier, hs.closure_eq]
 
 lemma is_open.frontier_eq {s : set α} (hs : is_open s) : frontier s = closure s \ s :=
 by rw [frontier, interior_eq_of_open hs]
@@ -625,10 +631,9 @@ begin
   rw [←le_principal_iff, inf_comm, le_inf_iff]
 end
 
-lemma is_closed_iff_nhds {s : set α} : is_closed s ↔ ∀a, cluster_pt a (𝓟 s) → a ∈ s :=
-calc is_closed s ↔ closure s = s : by rw [closure_eq_iff_is_closed]
-  ... ↔ closure s ⊆ s : ⟨assume h, by rw h, assume h, subset.antisymm h subset_closure⟩
-  ... ↔ (∀a, cluster_pt a (𝓟 s) → a ∈ s) : by rw [closure_eq_cluster_pts]; refl
+lemma is_closed_iff_cluster_pt {s : set α} : is_closed s ↔ ∀a, cluster_pt a (𝓟 s) → a ∈ s :=
+calc is_closed s ↔ closure s ⊆ s : closure_subset_iff_is_closed.symm
+  ... ↔ (∀a, cluster_pt a (𝓟 s) → a ∈ s) : by simp only [subset_def, mem_closure_iff_cluster_pt]
 
 lemma closure_inter_open {s t : set α} (h : is_open s) : s ∩ closure t ⊆ closure (s ∩ t) :=
 assume a ⟨hs, ht⟩,
@@ -661,11 +666,11 @@ lemma mem_of_closed_of_tendsto {f : β → α} {b : filter β} {a : α} {s : set
   (hb : b ≠ ⊥) (hf : tendsto f b (𝓝 a)) (hs : is_closed s) (h : f ⁻¹' s ∈ b) : a ∈ s :=
 have b.map f ≤ 𝓝 a ⊓ 𝓟 s,
   from le_trans (le_inf (le_refl _) (le_principal_iff.mpr h)) (inf_le_inf_right _ hf),
-is_closed_iff_nhds.mp hs a $ ne_bot_of_le_ne_bot (map_ne_bot hb) this
+is_closed_iff_cluster_pt.mp hs a $ ne_bot_of_le_ne_bot (map_ne_bot hb) this
 
 lemma mem_of_closed_of_tendsto' {f : β → α} {x : filter β} {a : α} {s : set α}
   (hf : tendsto f x (𝓝 a)) (hs : is_closed s) (h : x ⊓ 𝓟 (f ⁻¹' s) ≠ ⊥) : a ∈ s :=
-is_closed_iff_nhds.mp hs _ $ ne_bot_of_le_ne_bot (@map_ne_bot _ _ _ f h) $
+is_closed_iff_cluster_pt.mp hs _ $ ne_bot_of_le_ne_bot (@map_ne_bot _ _ _ f h) $
   le_inf (le_trans (map_mono $ inf_le_left) hf) $
     le_trans (map_mono $ inf_le_right_of_le $
       by simp only [comap_principal, le_principal_iff]; exact subset.refl _) (@map_comap_le _ _ _ f)

--- a/src/topology/bounded_continuous_function.lean
+++ b/src/topology/bounded_continuous_function.lean
@@ -313,7 +313,7 @@ theorem arzela_ascoli
 /- This version is deduced from the previous one by checking that the closure of A, in
 addition to being closed, still satisfies the properties of compact range and equicontinuity -/
 arzela_ascoli₂ s hs (closure A) is_closed_closure
-  (λ f x hf, (mem_of_closed' (closed_of_compact _ hs)).2 $ λ ε ε0,
+  (λ f x hf, (mem_of_closed' hs.is_closed).2 $ λ ε ε0,
     let ⟨g, gA, dist_fg⟩ := metric.mem_closure_iff.1 hf ε ε0 in
     ⟨g x, in_s g x gA, lt_of_le_of_lt (dist_coe_le_dist _) dist_fg⟩)
   (λ x ε ε0, show ∃ U ∈ 𝓝 x,

--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -319,7 +319,7 @@ show (λp:α×β, f p.1 p.2) (a, b) ∈ closure u, from
 
 lemma is_closed_prod {s₁ : set α} {s₂ : set β} (h₁ : is_closed s₁) (h₂ : is_closed s₂) :
   is_closed (set.prod s₁ s₂) :=
-closure_eq_iff_is_closed.mp $ by simp [h₁, h₂, closure_prod_eq, closure_eq_of_is_closed]
+closure_eq_iff_is_closed.mp $ by simp only [h₁.closure_eq, h₂.closure_eq, closure_prod_eq]
 
 lemma inducing.prod_mk {f : α → β} {g : γ → δ} (hf : inducing f) (hg : inducing g) :
   inducing (λx:α×γ, (f x.1, g x.2)) :=
@@ -778,12 +778,11 @@ end ulift
 
 lemma mem_closure_of_continuous [topological_space α] [topological_space β]
   {f : α → β} {a : α} {s : set α} {t : set β}
-  (hf : continuous f) (ha : a ∈ closure s) (h : ∀a∈s, f a ∈ closure t) :
+  (hf : continuous f) (ha : a ∈ closure s) (h : maps_to f s (closure t)) :
   f a ∈ closure t :=
 calc f a ∈ f '' closure s : mem_image_of_mem _ ha
   ... ⊆ closure (f '' s) : image_closure_subset_closure_image hf
-  ... ⊆ closure (closure t) : closure_mono $ image_subset_iff.mpr $ h
-  ... ⊆ closure t : begin rw [closure_eq_of_is_closed], exact subset.refl _, exact is_closed_closure end
+  ... ⊆ closure t : closure_minimal h.image_subset is_closed_closure
 
 lemma mem_closure_of_continuous2 [topological_space α] [topological_space β] [topological_space γ]
   {f : α → β → γ} {a : α} {b : β} {s : set α} {t : set β} {u : set γ}

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -182,7 +182,7 @@ mem_closure_iff_nhds_within_ne_bot.1 $ subset_closure hx
 
 lemma is_closed.mem_of_nhds_within_ne_bot {s : set α} (hs : is_closed s)
   {x : α} (hx : nhds_within x s ≠ ⊥) : x ∈ s :=
-by simpa only [closure_eq_of_is_closed hs] using mem_closure_iff_nhds_within_ne_bot.2 hx
+by simpa only [hs.closure_eq] using mem_closure_iff_nhds_within_ne_bot.2 hx
 
 /-
 nhds_within and subtypes

--- a/src/topology/dense_embedding.lean
+++ b/src/topology/dense_embedding.lean
@@ -185,7 +185,7 @@ let ⟨s'', hs''₁, hs''₂, hs''₃⟩ := nhds_is_closed hs in
 let ⟨s', hs'₁, (hs'₂ : i ⁻¹' s' ⊆ f ⁻¹' s'')⟩ := mem_of_nhds hφ hs''₁ in
 let ⟨t, (ht₁ : t ⊆ φ ∩ s'), ht₂, ht₃⟩ := mem_nhds_sets_iff.mp $ inter_mem_sets hφ hs'₁ in
 have h₁ : closure (f '' (i ⁻¹' s')) ⊆ s'',
-  by rw [closure_subset_iff_subset_of_is_closed hs''₃, image_subset_iff]; exact hs'₂,
+  by rw [hs''₃.closure_subset_iff, image_subset_iff]; exact hs'₂,
 have h₂ : t ⊆ di.extend f ⁻¹' closure (f '' (i ⁻¹' t)), from
   assume b' hb',
   have 𝓝 b' ≤ 𝓟 t, by simp; exact mem_nhds_sets ht₂ hb',
@@ -287,7 +287,7 @@ lemma is_closed_property [topological_space β] {e : α → β} {p : β → Prop
 have univ ⊆ {b | p b},
   from calc univ = closure (range e) : he.closure_range.symm
     ... ⊆ closure {b | p b} : closure_mono $ range_subset_iff.mpr h
-    ... = _ : closure_eq_of_is_closed hp,
+    ... = _ : hp.closure_eq,
 assume b, this trivial
 
 lemma is_closed_property2 [topological_space β] {e : α → β} {p : β → β → Prop}

--- a/src/topology/instances/real.lean
+++ b/src/topology/instances/real.lean
@@ -284,7 +284,7 @@ section
 
 lemma closure_of_rat_image_lt {q : ℚ} : closure ((coe:ℚ → ℝ) '' {x | q < x}) = {r | ↑q ≤ r} :=
 subset.antisymm
-  ((closure_subset_iff_subset_of_is_closed (is_closed_ge' _)).2
+  ((is_closed_ge' _).closure_subset_iff.2
     (image_subset_iff.2 $ λ p h, le_of_lt $ (@rat.cast_lt ℝ _ _ _).2 h)) $
 λ x hx, mem_closure_iff_nhds.2 $ λ t ht,
 let ⟨ε, ε0, hε⟩ := metric.mem_nhds_iff.1 ht in

--- a/src/topology/metric_space/baire.lean
+++ b/src/topology/metric_space/baire.lean
@@ -330,7 +330,7 @@ begin
     have : x ∈ g s := mem_bInter_iff.1 hx s hs,
     have : x ∈ interior (f s),
     { have : x ∈ f s \ (frontier (f s)) := mem_inter xs this,
-      simpa [frontier, xs, closure_eq_of_is_closed (hc s hs)] using this },
+      simpa [frontier, xs, (hc s hs).closure_eq] using this },
     exact mem_bUnion_iff.2 ⟨s, ⟨hs, this⟩⟩ },
   have := closure_mono this,
   rw clos_g at this,

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -1101,6 +1101,9 @@ variables {x y z : α} {ε ε₁ ε₂ : ℝ} {s : set α}
 theorem is_closed_ball : is_closed (closed_ball x ε) :=
 is_closed_le (continuous_id.dist continuous_const) continuous_const
 
+@[simp] theorem closure_closed_ball : closure (closed_ball x ε) = closed_ball x ε :=
+is_closed_ball.closure_eq
+
 theorem closure_ball_subset_closed_ball : closure (ball x ε) ⊆ closed_ball x ε :=
 closure_minimal ball_subset_closed_ball is_closed_ball
 
@@ -1133,7 +1136,7 @@ lemma mem_closure_range_iff_nat {α : Type u} [metric_space α] {e : β → α} 
 @[nolint ge_or_gt] -- see Note [nolint_ge]
 theorem mem_of_closed' {α : Type u} [metric_space α] {s : set α} (hs : is_closed s)
   {a : α} : a ∈ s ↔ ∀ε>0, ∃b ∈ s, dist a b < ε :=
-by simpa only [closure_eq_of_is_closed hs] using @mem_closure_iff _ _ s a
+by simpa only [hs.closure_eq] using @mem_closure_iff _ _ s a
 
 end metric
 
@@ -1466,7 +1469,7 @@ begin
     exact this (x, y) (mk_mem_prod x_in y_in) },
   intros p p_in,
   have := mem_closure continuous_dist p_in h,
-  rwa closure_eq_of_is_closed (is_closed_le' C) at this
+  rwa (is_closed_le' C).closure_eq at this
 end
 
 alias bounded_closure_of_bounded ← bounded.closure
@@ -1522,7 +1525,7 @@ compact_univ.bounded.subset (subset_univ _)
 In a proper space, a set is compact if and only if it is closed and bounded -/
 lemma compact_iff_closed_bounded [proper_space α] :
   compact s ↔ is_closed s ∧ bounded s :=
-⟨λ h, ⟨closed_of_compact _ h, h.bounded⟩, begin
+⟨λ h, ⟨h.is_closed, h.bounded⟩, begin
   rintro ⟨hc, hb⟩,
   cases s.eq_empty_or_nonempty with h h, {simp [h, compact_empty]},
   rcases h with ⟨x, hx⟩,
@@ -1538,7 +1541,7 @@ begin
   apply proper_space_of_compact_closed_ball_of_le 0 (λx₀ r hr, _),
   let K := f ⁻¹' (closed_ball x₀ r),
   have A : is_closed K :=
-    continuous_iff_is_closed.1 f_cont (closed_ball x₀ r) (is_closed_ball),
+    continuous_iff_is_closed.1 f_cont (closed_ball x₀ r) is_closed_ball,
   have B : bounded K := ⟨max C 0 * (r + r), λx y hx hy, calc
     dist x y ≤ C * dist (f x) (f y) : hC x y
     ... ≤ max C 0 * dist (f x) (f y) : mul_le_mul_of_nonneg_right (le_max_left _ _) (dist_nonneg)

--- a/src/topology/metric_space/closeds.lean
+++ b/src/topology/metric_space/closeds.lean
@@ -75,7 +75,7 @@ begin
     rcases exists_edist_lt_of_Hausdorff_edist_lt hx Dtu with ⟨y, hy, Dxy⟩,
     -- y : α,  hy : y ∈ u.val, Dxy : edist x y < ε
     exact ⟨y, hu hy, Dxy⟩ },
-  rwa closure_eq_of_is_closed hs at this,
+  rwa hs.closure_eq at this,
 end
 
 /-- By definition, the edistance on `closeds α` is given by the Hausdorff edistance -/
@@ -217,7 +217,7 @@ instance closeds.compact_space [compact_space α] : compact_space (closeds α) :
   -- `F` is ε-dense
   { assume u _,
     rcases main u.val with ⟨t0, t0s, Dut0⟩,
-    have : is_closed t0 := closed_of_compact _ (fs.subset t0s).compact,
+    have : is_closed t0 := (fs.subset t0s).compact.is_closed,
     let t : closeds α := ⟨t0, this⟩,
     have : t ∈ F := t0s,
     have : edist u t < ε := lt_of_le_of_lt Dut0 δlt,
@@ -234,8 +234,8 @@ instance nonempty_compacts.emetric_space : emetric_space (nonempty_compacts α) 
   edist_triangle      := λs t u, Hausdorff_edist_triangle,
   eq_of_edist_eq_zero := λs t h, subtype.eq $ begin
     have : closure (s.val) = closure (t.val) := Hausdorff_edist_zero_iff_closure_eq_closure.1 h,
-    rwa [closure_eq_iff_is_closed.2 (closed_of_compact _ s.property.2),
-              closure_eq_iff_is_closed.2 (closed_of_compact _ t.property.2)] at this,
+    rwa [s.property.2.is_closed.closure_eq,
+              t.property.2.is_closed.closure_eq] at this,
   end }
 
 /-- `nonempty_compacts.to_closeds` is a uniform embedding (as it is an isometry) -/
@@ -256,7 +256,7 @@ begin
     rw edist_comm at Dst,
     -- since `t` is nonempty, so is `s`
     exact nonempty_of_Hausdorff_edist_ne_top ht.1 (ne_of_lt Dst) },
-  { refine compact_iff_totally_bounded_complete.2 ⟨_, is_complete_of_is_closed s.property⟩,
+  { refine compact_iff_totally_bounded_complete.2 ⟨_, s.property.is_complete⟩,
     refine totally_bounded_iff.2 (λε εpos, _),
     -- we have to show that s is covered by finitely many eballs of radius ε
     -- pick a nonempty compact set t at distance at most ε/2 of s
@@ -281,7 +281,7 @@ from the same statement for closed subsets -/
 instance nonempty_compacts.complete_space [complete_space α] :
   complete_space (nonempty_compacts α) :=
 (complete_space_iff_is_complete_range nonempty_compacts.to_closeds.uniform_embedding).2 $
-  is_complete_of_is_closed nonempty_compacts.is_closed_in_closeds
+  nonempty_compacts.is_closed_in_closeds.is_complete
 
 /-- In a compact space, the type of nonempty compact subsets is compact. This follows from
 the same statement for closed subsets -/

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -678,7 +678,7 @@ begin
     exact ⟨y, ‹y ∈ t›, ‹edist x y < ε›⟩ },
   have T₄ : closure t ⊆ s := calc
     closure t ⊆ closure s : closure_mono T₁
-    ... = s : closure_eq_of_is_closed (closed_of_compact _ hs),
+    ... = s : hs.is_closed.closure_eq,
   exact ⟨t, ⟨T₁, T₂, subset.antisymm T₃ T₄⟩⟩
 end
 

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -362,7 +362,7 @@ begin
     exact (Hausdorff_dist_image (Kuratowski_embedding.isometry _)).symm },
 end
 
--- without the next two lines, `{ exact closed_of_compact (range Φ) hΦ }` in the next
+-- without the next two lines, `{ exact hΦ.is_closed }` in the next
 -- proof is very slow, as the `t2_space` instance is very hard to find
 local attribute [instance, priority 10] order_topology.t2_space
 local attribute [instance, priority 10] order_closed_topology.to_t2_space
@@ -397,8 +397,8 @@ instance GH_space_metric_space : metric_space GH_space :=
     { have hΦ : compact (range Φ) := compact_range Φisom.continuous,
       have hΨ : compact (range Ψ) := compact_range Ψisom.continuous,
       apply (Hausdorff_dist_zero_iff_eq_of_closed _ _ _).1 (DΦΨ.symm),
-      { exact closed_of_compact (range Φ) hΦ },
-      { exact closed_of_compact (range Ψ) hΨ },
+      { exact hΦ.is_closed },
+      { exact hΨ.is_closed },
       { exact Hausdorff_edist_ne_top_of_nonempty_of_bounded (range_nonempty _)
           (range_nonempty _) hΦ.bounded hΨ.bounded } },
     have T : ((range Ψ) ≃ᵢ y.rep) = ((range Φ) ≃ᵢ y.rep), by rw this,

--- a/src/topology/metric_space/hausdorff_distance.lean
+++ b/src/topology/metric_space/hausdorff_distance.lean
@@ -119,7 +119,7 @@ lemma mem_closure_iff_inf_edist_zero : x ∈ closure s ↔ inf_edist x s = 0 :=
 lemma mem_iff_ind_edist_zero_of_closed (h : is_closed s) : x ∈ s ↔ inf_edist x s = 0 :=
 begin
   convert ← mem_closure_iff_inf_edist_zero,
-  exact closure_eq_iff_is_closed.2 h
+  exact h.closure_eq
 end
 
 /-- The infimum edistance is invariant under isometries -/
@@ -343,8 +343,8 @@ end,
 /-- Two closed sets are at zero Hausdorff edistance if and only if they coincide -/
 lemma Hausdorff_edist_zero_iff_eq_of_closed (hs : is_closed s) (ht : is_closed t) :
   Hausdorff_edist s t = 0 ↔ s = t :=
-by rw [Hausdorff_edist_zero_iff_closure_eq_closure, closure_eq_iff_is_closed.2 hs,
-       closure_eq_iff_is_closed.2 ht]
+by rw [Hausdorff_edist_zero_iff_closure_eq_closure, hs.closure_eq,
+       ht.closure_eq]
 
 /-- The Haudorff edistance to the empty set is infinite -/
 lemma Hausdorff_edist_empty (ne : s.nonempty) : Hausdorff_edist s ∅ = ∞ :=
@@ -484,7 +484,7 @@ lemma mem_iff_inf_dist_zero_of_closed (h : is_closed s) (hs : s.nonempty) :
   x ∈ s ↔ inf_dist x s = 0 :=
 begin
   have := @mem_closure_iff_inf_dist_zero _ _ s x hs,
-  rwa closure_eq_iff_is_closed.2 h at this
+  rwa h.closure_eq at this
 end
 
 /-- The infimum distance is invariant under isometries -/

--- a/src/topology/opens.lean
+++ b/src/topology/opens.lean
@@ -36,7 +36,7 @@ p.property.1.to_subtype
 
 /-- Associate to a nonempty compact subset the corresponding closed subset -/
 def nonempty_compacts.to_closeds [t2_space α] : nonempty_compacts α → closeds α :=
-set.inclusion $ λ s hs, closed_of_compact _ hs.2
+set.inclusion $ λ s hs, hs.2.is_closed
 
 end nonempty_compacts
 

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -82,7 +82,7 @@ mem_nhds_sets is_closed_singleton $ by rwa [mem_compl_eq, mem_singleton_iff]
 
 @[simp] lemma closure_singleton [t1_space α] {a : α} :
   closure ({a} : set α) = {a} :=
-closure_eq_of_is_closed is_closed_singleton
+is_closed_singleton.closure_eq
 
 /-- A T₂ space, also known as a Hausdorff space, is one in which for every
   `x ≠ y` there exists disjoint open sets around `x` and `y`. This is
@@ -123,7 +123,7 @@ t2_iff_nhds.trans
      h f uf (le_trans hf inf_le_left) (le_trans hf inf_le_right)⟩
 
 lemma is_closed_diagonal [t2_space α] : is_closed (diagonal α) :=
-is_closed_iff_nhds.mpr $ assume ⟨a₁, a₂⟩ h, eq_of_nhds_ne_bot $ assume : 𝓝 a₁ ⊓ 𝓝 a₂ = ⊥, h $
+is_closed_iff_cluster_pt.mpr $ assume ⟨a₁, a₂⟩ h, eq_of_nhds_ne_bot $ assume : 𝓝 a₁ ⊓ 𝓝 a₂ = ⊥, h $
   let ⟨t₁, ht₁, t₂, ht₂, (h' : t₁ ∩ t₂ ⊆ ∅)⟩ :=
     by rw [←empty_in_sets_eq_bot, mem_inf_sets] at this; exact this in
   begin
@@ -258,7 +258,7 @@ lemma compact_compact_separated [t2_space α] {s t : set α}
 by simp only [prod_subset_compl_diagonal_iff_disjoint.symm] at ⊢ hst;
    exact generalized_tube_lemma hs ht is_closed_diagonal hst
 
-lemma closed_of_compact [t2_space α] (s : set α) (hs : compact s) : is_closed s :=
+lemma compact.is_closed [t2_space α] {s : set α} (hs : compact s) : is_closed s :=
 is_open_compl_iff.mpr $ is_open_iff_forall_mem_open.mpr $ assume x hx,
   let ⟨u, v, uo, vo, su, xv, uv⟩ :=
     compact_compact_separated hs (compact_singleton : compact {x})

--- a/src/topology/sequences.lean
+++ b/src/topology/sequences.lean
@@ -74,7 +74,7 @@ lemma is_seq_closed_of_is_closed (M : set α) (_ : is_closed M) : is_seq_closed 
 suffices sequential_closure M ⊆ M, from
   set.eq_of_subset_of_subset (subset_sequential_closure M) this,
 calc sequential_closure M ⊆ closure M : sequential_closure_subset_closure M
-  ... = M : closure_eq_of_is_closed ‹is_closed M›
+  ... = M : is_closed.closure_eq ‹is_closed M›
 
 /-- The limit of a convergent sequence in a sequentially closed set is in that set.-/
 lemma mem_of_is_seq_closed {A : set α} (_ : is_seq_closed A) {x : ℕ → α}

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -117,7 +117,7 @@ classical.by_contradiction $ assume h,
   have f ≤ 𝓟 (U i)ᶜ,
     from infi_le_of_le {i} $ principal_mono.mpr $ show s \ _ ⊆ (U i)ᶜ, by simp [diff_subset_iff],
   have is_closed (U i)ᶜ, from is_open_compl_iff.mp $ by rw compl_compl; exact hUo i,
-  have a ∈ (U i)ᶜ, from is_closed_iff_nhds.mp this _ (h.mono ‹f ≤ 𝓟 (U i)ᶜ›),
+  have a ∈ (U i)ᶜ, from is_closed_iff_cluster_pt.mp this _ (h.mono ‹f ≤ 𝓟 (U i)ᶜ›),
   this ‹a ∈ U i›
 
 /-- For every family of closed sets whose intersection avoids a compact set,
@@ -419,7 +419,7 @@ begin
   set πX := (prod.fst : X × Y → X),
   set πY := (prod.snd : X × Y → Y),
   assume C (hC : is_closed C),
-  rw is_closed_iff_nhds at hC ⊢,
+  rw is_closed_iff_cluster_pt at hC ⊢,
   assume y (y_closure : cluster_pt y $ 𝓟 (πY '' C)),
   have : map πX (comap πY (𝓝 y) ⊓ 𝓟 C) ≠ ⊥,
   { suffices : map πY (comap πY (𝓝 y) ⊓ 𝓟 C) ≠ ⊥,

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -759,7 +759,7 @@ lemma uniformity_has_basis_closure : has_basis (𝓤 α) (λ V : set (α × α),
   { rintros ⟨r, ⟨r_in, r_closed⟩, r_sub⟩,
     use [r, r_in],
     convert r_sub,
-    rw closure_eq_of_is_closed r_closed,
+    rw r_closed.closure_eq,
     refl },
   { rintros ⟨r, r_in, r_sub⟩,
     exact ⟨closure r, ⟨mem_sets_of_superset r_in subset_closure, is_closed_closure⟩, r_sub⟩ }

--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -259,10 +259,10 @@ theorem cauchy_seq.tendsto_lim [semilattice_sup β] [complete_space α] [nonempt
   tendsto u at_top (𝓝 $ lim at_top u) :=
 h.le_nhds_Lim
 
-lemma is_complete_of_is_closed [complete_space α] {s : set α}
+lemma is_closed.is_complete [complete_space α] {s : set α}
   (h : is_closed s) : is_complete s :=
 λ f cf fs, let ⟨x, hx⟩ := complete_space.complete cf in
-⟨x, is_closed_iff_nhds.mp h x (ne_bot_of_le_ne_bot cf.left (le_inf hx fs)), hx⟩
+⟨x, is_closed_iff_cluster_pt.mp h x (ne_bot_of_le_ne_bot cf.left (le_inf hx fs)), hx⟩
 
 /-- A set `s` is totally bounded if for every entourage `d` there is a finite
   set of points `t` such that every element of `s` is `d`-near to some element of `t`. -/
@@ -314,7 +314,7 @@ assume t ht,
 let ⟨t', ht', hct', htt'⟩ := mem_uniformity_is_closed ht, ⟨c, hcf, hc⟩ := h t' ht' in
 ⟨c, hcf,
   calc closure s ⊆ closure (⋃ (y : α) (H : y ∈ c), {x : α | (x, y) ∈ t'}) : closure_mono hc
-    ... = _ : closure_eq_of_is_closed $ is_closed_bUnion hcf $ assume i hi,
+    ... = _ : is_closed.closure_eq $ is_closed_bUnion hcf $ assume i hi,
       continuous_iff_is_closed.mp (continuous_id.prod_mk continuous_const) _ hct'
     ... ⊆ _ : bUnion_subset $ assume i hi, subset.trans (assume x, @htt' (x, i))
       (subset_bUnion_of_mem hi)⟩
@@ -418,7 +418,7 @@ instance complete_of_compact {α : Type u} [uniform_space α] [compact_space α]
 
 lemma compact_of_totally_bounded_is_closed [complete_space α] {s : set α}
   (ht : totally_bounded s) (hc : is_closed s) : compact s :=
-(@compact_iff_totally_bounded_complete α _ s).2 ⟨ht, is_complete_of_is_closed hc⟩
+(@compact_iff_totally_bounded_complete α _ s).2 ⟨ht, hc.is_complete⟩
 
 /-!
 ### Sequentially complete space

--- a/src/topology/uniform_space/complete_separated.lean
+++ b/src/topology/uniform_space/complete_separated.lean
@@ -17,9 +17,9 @@ open_locale topological_space filter
 variables {α : Type*}
 
 /-In a separated space, a complete set is closed -/
-lemma is_closed_of_is_complete  [uniform_space α] [separated_space α] {s : set α} (h : is_complete s) :
+lemma is_complete.is_closed  [uniform_space α] [separated_space α] {s : set α} (h : is_complete s) :
   is_closed s :=
-is_closed_iff_nhds.2 $ λ a ha, begin
+is_closed_iff_cluster_pt.2 $ λ a ha, begin
   let f := 𝓝 a ⊓ 𝓟 s,
   have : cauchy f := cauchy_downwards (cauchy_nhds) ha (inf_le_left),
   rcases h f this (inf_le_right) with ⟨y, ys, fy⟩,

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -275,7 +275,7 @@ begin
       rw closure_eq_cluster_pts,
       exact ne_bot_of_le_ne_bot f.2.1
         (le_inf f.2.le_nhds_Lim (le_principal_iff.2 xf)) },
-    have := (closure_subset_iff_subset_of_is_closed dc).2 h,
+    have := dc.closure_subset_iff.2 h,
     rw closure_prod_eq at this,
     refine dt (this ⟨_, _⟩); dsimp; apply limc; assumption }
 end

--- a/src/topology/uniform_space/uniform_embedding.lean
+++ b/src/topology/uniform_space/uniform_embedding.lean
@@ -218,7 +218,7 @@ complete_space_coe_iff_is_complete.2 hs
 
 lemma is_closed.complete_space_coe [complete_space α] {s : set α} (hs : is_closed s) :
   complete_space s :=
-(is_complete_of_is_closed hs).complete_space_coe
+hs.is_complete.complete_space_coe
 
 lemma complete_space_extension {m : β → α} (hm : uniform_inducing m) (dense : dense_range m)
   (h : ∀f:filter β, cauchy f → ∃x:α, map m f ≤ 𝓝 x) : complete_space α :=
@@ -356,7 +356,7 @@ begin
       rw [←closure_induced, closure_eq_cluster_pts, mem_set_of_eq, cluster_pt,
           (≠), nhds_induced, ← de.to_dense_inducing.nhds_eq_comap],
       change x ∈ {y | cluster_pt y (𝓟 s)} → x ∈ range subtype.val,
-      rw [←closure_eq_cluster_pts, closure_eq_of_is_closed hs],
+      rw [←closure_eq_cluster_pts, hs.closure_eq],
       exact assume hxs, ⟨⟨x, hp x hxs⟩, rfl⟩,
       exact de.inj
     end⟩


### PR DESCRIPTION
Rename:

* `closure_eq_of_is_closed` to `is_closed.closure_eq`;
* `closed_of_compact` to `compact.is_closed`;
* `bdd_above_of_compact` to `compact.bdd_above`;
* `bdd_below_of_compact` to `compact.bdd_below`.
* `is_complete_of_is_closed` to `is_closed.is_complete`
* `is_closed_of_is_complete` to `is_complete.is_closed`
* `is_closed_iff_nhds` to `is_closed_iff_cluster_pt`
* `closure_subset_iff_subset_of_is_closed` to `is_closed.closure_subset_iff`

Add:

* `closure_closed_ball` (`@[simp]` lemma)
* `is_closed.closure_subset : is_closed s → closure s ⊆ s`

---
<!-- put comments you want to keep out of the PR commit here -->