### PR TITLE
[Merged by Bors] - chore(algebra/big_operators): don't use omega

### DIFF
--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -6,7 +6,6 @@ Authors: Johannes Hölzl
 
 import data.finset
 import data.nat.enat
-import tactic.omega
 import tactic.abel
 
 /-!
@@ -674,9 +673,9 @@ lemma sum_range_sub_of_monotone {f : ℕ → ℕ} (h : monotone f) (n : ℕ) :
   ∑ i in range n, (f (i+1) - f i) = f n - f 0 :=
 begin
   refine sum_range_induction _ _ (nat.sub_self _) (λ n, _) _,
-  have : f n ≤ f (n+1) := h (nat.le_succ _),
-  have : f 0 ≤ f n := h (nat.zero_le _),
-  omega
+  have h₁ : f n ≤ f (n+1) := h (nat.le_succ _),
+  have h₂ : f 0 ≤ f n := h (nat.zero_le _),
+  rw [←nat.sub_add_comm h₂, nat.add_sub_cancel' h₁],
 end
 
 lemma prod_Ico_reflect (f : ℕ → β) (k : ℕ) {m n : ℕ} (h : m ≤ n + 1) :

--- a/src/data/nat/choose.lean
+++ b/src/data/nat/choose.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Bhavik Mehta, Patrick Stevens
 -/
 import tactic.linarith
+import tactic.omega
 import algebra.big_operators
 
 open nat

--- a/src/ring_theory/coprime.lean
+++ b/src/ring_theory/coprime.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Ken Lee, Chris Hughes
 -/
-
+import tactic.ring
 import algebra.big_operators
 import data.fintype.basic
 import data.int.gcd


### PR DESCRIPTION
Postpone importing `omega` a little bit longer.

---
<!-- put comments you want to keep out of the PR commit here -->
