### PR TITLE
[Merged by Bors] - chore(data/set/basic): simp attribute on mem_range_self

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1394,7 +1394,7 @@ def range (f : ι → α) : set α := {x | ∃y, f y = x}
 
 @[simp] theorem mem_range {x : α} : x ∈ range f ↔ ∃ y, f y = x := iff.rfl
 
-theorem mem_range_self (i : ι) : f i ∈ range f := ⟨i, rfl⟩
+@[simp] theorem mem_range_self (i : ι) : f i ∈ range f := ⟨i, rfl⟩
 
 theorem forall_range_iff {p : α → Prop} : (∀ a ∈ range f, p a) ↔ (∀ i, p (f i)) :=
 ⟨assume h i, h (f i) (mem_range_self _), assume h a ⟨i, (hi : f i = a)⟩, hi ▸ h i⟩


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->

I thought for a long time that `mem_range` would fire before this one, and make it unusable by simp, but it turns out it's not the case (contrary to other lemmas with the same flavor: in
```lean
@[simp] theorem mem_image (f : α → β) (s : set α) (y : β) :
  y ∈ f '' s ↔ ∃ x, x ∈ s ∧ f x = y := iff.rfl

theorem mem_image_of_mem (f : α → β) {x : α} {a : set α} (h : x ∈ a) : f x ∈ f '' a :=
⟨_, h, rfl⟩
```
one can not put a simp attribute on the second lemma. I am not sure I understand the difference between the two situations, by the way).