### PR TITLE
[Merged by Bors] - refactor(analysis/calculus/*deriv): use eventually_eq in congruence statements

### DIFF
--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -231,7 +231,7 @@ definition with a limit. In this version we have to take the limit along the sub
 because for `y=x` the slope equals zero due to the convention `0⁻¹=0`. -/
 lemma has_deriv_at_filter_iff_tendsto_slope {x : 𝕜} {L : filter 𝕜} :
   has_deriv_at_filter f f' x L ↔
-    tendsto (λ y, (y - x)⁻¹ • (f y - f x)) (L ⊓ 𝓟 (-{x})) (𝓝 f') :=
+    tendsto (λ y, (y - x)⁻¹ • (f y - f x)) (L ⊓ 𝓟 {x}ᶜ) (𝓝 f') :=
 begin
   conv_lhs { simp only [has_deriv_at_filter_iff_tendsto, (normed_field.norm_inv _).symm,
     (norm_smul _ _).symm, tendsto_zero_iff_norm_tendsto_zero.symm] },
@@ -260,7 +260,7 @@ end
 
 lemma has_deriv_at_iff_tendsto_slope {x : 𝕜} :
   has_deriv_at f f' x ↔
-    tendsto (λ y, (y - x)⁻¹ • (f y - f x)) (nhds_within x (-{x})) (𝓝 f') :=
+    tendsto (λ y, (y - x)⁻¹ • (f y - f x)) (nhds_within x {x}ᶜ) (𝓝 f') :=
 has_deriv_at_filter_iff_tendsto_slope
 
 theorem has_deriv_at_iff_is_o_nhds_zero : has_deriv_at f f' x ↔

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -368,14 +368,14 @@ by { unfold deriv_within, rw fderiv_within_inter ht hs }
 section congr
 /-! ### Congruence properties of derivatives -/
 
-theorem filter.eventually_eq.has_deriv_at_filter_congr
+theorem filter.eventually_eq.has_deriv_at_filter_iff
   (h₀ : f₀ =ᶠ[L] f₁) (hx : f₀ x = f₁ x) (h₁ : f₀' = f₁') :
   has_deriv_at_filter f₀ f₀' x L ↔ has_deriv_at_filter f₁ f₁' x L :=
-h₀.has_fderiv_at_filter_congr hx (by simp [h₁])
+h₀.has_fderiv_at_filter_iff hx (by simp [h₁])
 
 lemma has_deriv_at_filter.congr_of_eventually_eq (h : has_deriv_at_filter f f' x L)
   (hL : f₁ =ᶠ[L] f) (hx : f₁ x = f x) : has_deriv_at_filter f₁ f' x L :=
-by rwa hL.has_deriv_at_filter_congr hx rfl
+by rwa hL.has_deriv_at_filter_iff hx rfl
 
 lemma has_deriv_within_at.congr_mono (h : has_deriv_within_at f f' s x) (ht : ∀x ∈ t, f₁ x = f x)
   (hx : f₁ x = f x) (h₁ : t ⊆ s) : has_deriv_within_at f₁ f' t x :=
@@ -393,18 +393,18 @@ lemma has_deriv_at.congr_of_eventually_eq (h : has_deriv_at f f' x)
   (h₁ : f₁ =ᶠ[𝓝 x] f) : has_deriv_at f₁ f' x :=
 has_deriv_at_filter.congr_of_eventually_eq h h₁ (mem_of_nhds h₁ : _)
 
-lemma filter.eventually_eq.deriv_within_congr (hs : unique_diff_within_at 𝕜 s x)
+lemma filter.eventually_eq.deriv_within_eq (hs : unique_diff_within_at 𝕜 s x)
   (hL : f₁ =ᶠ[nhds_within x s] f) (hx : f₁ x = f x) :
   deriv_within f₁ s x = deriv_within f s x :=
-by { unfold deriv_within, rw hL.fderiv_within_congr hs hx }
+by { unfold deriv_within, rw hL.fderiv_within_eq hs hx }
 
 lemma deriv_within_congr (hs : unique_diff_within_at 𝕜 s x)
   (hL : ∀y∈s, f₁ y = f y) (hx : f₁ x = f x) :
   deriv_within f₁ s x = deriv_within f s x :=
 by { unfold deriv_within, rw fderiv_within_congr hs hL hx }
 
-lemma filter.eventually_eq.deriv_congr (hL : f₁ =ᶠ[𝓝 x] f) : deriv f₁ x = deriv f x :=
-by { unfold deriv, rwa filter.eventually_eq.fderiv_congr }
+lemma filter.eventually_eq.deriv_eq (hL : f₁ =ᶠ[𝓝 x] f) : deriv f₁ x = deriv f x :=
+by { unfold deriv, rwa filter.eventually_eq.fderiv_eq }
 
 end congr
 
@@ -1633,7 +1633,7 @@ begin
       sub_zero, int.cast_one] },
   { rw [function.iterate_succ', finset.prod_range_succ, int.cast_mul, mul_assoc, mul_left_comm,
       int.coe_nat_succ, ← sub_sub, ← ((has_deriv_at_fpow _ hx).const_mul _).deriv],
-    exact filter.eventually_eq.deriv_congr (eventually.mono (mem_nhds_sets is_open_ne hx) @ihk) }
+    exact filter.eventually_eq.deriv_eq (eventually.mono (mem_nhds_sets is_open_ne hx) @ihk) }
 end
 
 end fpow

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -368,14 +368,14 @@ by { unfold deriv_within, rw fderiv_within_inter ht hs }
 section congr
 /-! ### Congruence properties of derivatives -/
 
-theorem has_deriv_at_filter_congr_of_eventually_eq
-  (hx : f₀ x = f₁ x) (h₀ : f₀ =ᶠ[L] f₁) (h₁ : f₀' = f₁') :
+theorem filter.eventually_eq.has_deriv_at_filter_congr
+  (h₀ : f₀ =ᶠ[L] f₁) (hx : f₀ x = f₁ x) (h₁ : f₀' = f₁') :
   has_deriv_at_filter f₀ f₀' x L ↔ has_deriv_at_filter f₁ f₁' x L :=
-has_fderiv_at_filter_congr_of_eventually_eq hx h₀ (by simp [h₁])
+h₀.has_fderiv_at_filter_congr hx (by simp [h₁])
 
 lemma has_deriv_at_filter.congr_of_eventually_eq (h : has_deriv_at_filter f f' x L)
   (hL : f₁ =ᶠ[L] f) (hx : f₁ x = f x) : has_deriv_at_filter f₁ f' x L :=
-by rwa has_deriv_at_filter_congr_of_eventually_eq hx hL rfl
+by rwa hL.has_deriv_at_filter_congr hx rfl
 
 lemma has_deriv_within_at.congr_mono (h : has_deriv_within_at f f' s x) (ht : ∀x ∈ t, f₁ x = f x)
   (hx : f₁ x = f x) (h₁ : t ⊆ s) : has_deriv_within_at f₁ f' t x :=
@@ -393,18 +393,18 @@ lemma has_deriv_at.congr_of_eventually_eq (h : has_deriv_at f f' x)
   (h₁ : f₁ =ᶠ[𝓝 x] f) : has_deriv_at f₁ f' x :=
 has_deriv_at_filter.congr_of_eventually_eq h h₁ (mem_of_nhds h₁ : _)
 
-lemma deriv_within_congr_of_eventually_eq (hs : unique_diff_within_at 𝕜 s x)
+lemma filter.eventually_eq.deriv_within_congr (hs : unique_diff_within_at 𝕜 s x)
   (hL : f₁ =ᶠ[nhds_within x s] f) (hx : f₁ x = f x) :
   deriv_within f₁ s x = deriv_within f s x :=
-by { unfold deriv_within, rw fderiv_within_congr_of_eventually_eq hs hL hx }
+by { unfold deriv_within, rw hL.fderiv_within_congr hs hx }
 
 lemma deriv_within_congr (hs : unique_diff_within_at 𝕜 s x)
   (hL : ∀y∈s, f₁ y = f y) (hx : f₁ x = f x) :
   deriv_within f₁ s x = deriv_within f s x :=
 by { unfold deriv_within, rw fderiv_within_congr hs hL hx }
 
-lemma deriv_congr_of_eventually_eq (hL : f₁ =ᶠ[𝓝 x] f) : deriv f₁ x = deriv f x :=
-by { unfold deriv, rwa fderiv_congr_of_eventually_eq }
+lemma filter.eventually_eq.deriv_congr (hL : f₁ =ᶠ[𝓝 x] f) : deriv f₁ x = deriv f x :=
+by { unfold deriv, rwa filter.eventually_eq.fderiv_congr }
 
 end congr
 
@@ -1633,7 +1633,7 @@ begin
       sub_zero, int.cast_one] },
   { rw [function.iterate_succ', finset.prod_range_succ, int.cast_mul, mul_assoc, mul_left_comm,
       int.coe_nat_succ, ← sub_sub, ← ((has_deriv_at_fpow _ hx).const_mul _).deriv],
-    exact deriv_congr_of_eventually_eq (eventually.mono (mem_nhds_sets is_open_ne hx) @ihk) }
+    exact filter.eventually_eq.deriv_congr (eventually.mono (mem_nhds_sets is_open_ne hx) @ihk) }
 end
 
 end fpow

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -231,7 +231,7 @@ definition with a limit. In this version we have to take the limit along the sub
 because for `y=x` the slope equals zero due to the convention `0⁻¹=0`. -/
 lemma has_deriv_at_filter_iff_tendsto_slope {x : 𝕜} {L : filter 𝕜} :
   has_deriv_at_filter f f' x L ↔
-    tendsto (λ y, (y - x)⁻¹ • (f y - f x)) (L ⊓ 𝓟 {x}ᶜ) (𝓝 f') :=
+    tendsto (λ y, (y - x)⁻¹ • (f y - f x)) (L ⊓ 𝓟 (-{x})) (𝓝 f') :=
 begin
   conv_lhs { simp only [has_deriv_at_filter_iff_tendsto, (normed_field.norm_inv _).symm,
     (norm_smul _ _).symm, tendsto_zero_iff_norm_tendsto_zero.symm] },
@@ -260,7 +260,7 @@ end
 
 lemma has_deriv_at_iff_tendsto_slope {x : 𝕜} :
   has_deriv_at f f' x ↔
-    tendsto (λ y, (y - x)⁻¹ • (f y - f x)) (nhds_within x {x}ᶜ) (𝓝 f') :=
+    tendsto (λ y, (y - x)⁻¹ • (f y - f x)) (nhds_within x (-{x})) (𝓝 f') :=
 has_deriv_at_filter_iff_tendsto_slope
 
 theorem has_deriv_at_iff_is_o_nhds_zero : has_deriv_at f f' x ↔
@@ -368,14 +368,14 @@ by { unfold deriv_within, rw fderiv_within_inter ht hs }
 section congr
 /-! ### Congruence properties of derivatives -/
 
-theorem has_deriv_at_filter_congr_of_mem_sets
-  (hx : f₀ x = f₁ x) (h₀ : ∀ᶠ x in L, f₀ x = f₁ x) (h₁ : f₀' = f₁') :
+theorem has_deriv_at_filter_congr_of_eventually_eq
+  (hx : f₀ x = f₁ x) (h₀ : f₀ =ᶠ[L] f₁) (h₁ : f₀' = f₁') :
   has_deriv_at_filter f₀ f₀' x L ↔ has_deriv_at_filter f₁ f₁' x L :=
-has_fderiv_at_filter_congr_of_mem_sets hx h₀ (by simp [h₁])
+has_fderiv_at_filter_congr_of_eventually_eq hx h₀ (by simp [h₁])
 
-lemma has_deriv_at_filter.congr_of_mem_sets (h : has_deriv_at_filter f f' x L)
-  (hL : ∀ᶠ x in L, f₁ x = f x) (hx : f₁ x = f x) : has_deriv_at_filter f₁ f' x L :=
-by rwa has_deriv_at_filter_congr_of_mem_sets hx hL rfl
+lemma has_deriv_at_filter.congr_of_eventually_eq (h : has_deriv_at_filter f f' x L)
+  (hL : f₁ =ᶠ[L] f) (hx : f₁ x = f x) : has_deriv_at_filter f₁ f' x L :=
+by rwa has_deriv_at_filter_congr_of_eventually_eq hx hL rfl
 
 lemma has_deriv_within_at.congr_mono (h : has_deriv_within_at f f' s x) (ht : ∀x ∈ t, f₁ x = f x)
   (hx : f₁ x = f x) (h₁ : t ⊆ s) : has_deriv_within_at f₁ f' t x :=
@@ -385,26 +385,26 @@ lemma has_deriv_within_at.congr (h : has_deriv_within_at f f' s x) (hs : ∀x �
   (hx : f₁ x = f x) : has_deriv_within_at f₁ f' s x :=
 h.congr_mono hs hx (subset.refl _)
 
-lemma has_deriv_within_at.congr_of_mem_nhds_within (h : has_deriv_within_at f f' s x)
-  (h₁ : ∀ᶠ y in nhds_within x s, f₁ y = f y) (hx : f₁ x = f x) : has_deriv_within_at f₁ f' s x :=
-has_deriv_at_filter.congr_of_mem_sets h h₁ hx
+lemma has_deriv_within_at.congr_of_eventually_eq (h : has_deriv_within_at f f' s x)
+  (h₁ : f₁ =ᶠ[nhds_within x s] f) (hx : f₁ x = f x) : has_deriv_within_at f₁ f' s x :=
+has_deriv_at_filter.congr_of_eventually_eq h h₁ hx
 
-lemma has_deriv_at.congr_of_mem_nhds (h : has_deriv_at f f' x)
-  (h₁ : ∀ᶠ y in 𝓝 x, f₁ y = f y) : has_deriv_at f₁ f' x :=
-has_deriv_at_filter.congr_of_mem_sets h h₁ (mem_of_nhds h₁ : _)
+lemma has_deriv_at.congr_of_eventually_eq (h : has_deriv_at f f' x)
+  (h₁ : f₁ =ᶠ[𝓝 x] f) : has_deriv_at f₁ f' x :=
+has_deriv_at_filter.congr_of_eventually_eq h h₁ (mem_of_nhds h₁ : _)
 
-lemma deriv_within_congr_of_mem_nhds_within (hs : unique_diff_within_at 𝕜 s x)
-  (hL : ∀ᶠ y in nhds_within x s, f₁ y = f y) (hx : f₁ x = f x) :
+lemma deriv_within_congr_of_eventually_eq (hs : unique_diff_within_at 𝕜 s x)
+  (hL : f₁ =ᶠ[nhds_within x s] f) (hx : f₁ x = f x) :
   deriv_within f₁ s x = deriv_within f s x :=
-by { unfold deriv_within, rw fderiv_within_congr_of_mem_nhds_within hs hL hx }
+by { unfold deriv_within, rw fderiv_within_congr_of_eventually_eq hs hL hx }
 
 lemma deriv_within_congr (hs : unique_diff_within_at 𝕜 s x)
   (hL : ∀y∈s, f₁ y = f y) (hx : f₁ x = f x) :
   deriv_within f₁ s x = deriv_within f s x :=
 by { unfold deriv_within, rw fderiv_within_congr hs hL hx }
 
-lemma deriv_congr_of_mem_nhds (hL : ∀ᶠ y in 𝓝 x, f₁ y = f y) : deriv f₁ x = deriv f x :=
-by { unfold deriv, rwa fderiv_congr_of_mem_nhds }
+lemma deriv_congr_of_eventually_eq (hL : f₁ =ᶠ[𝓝 x] f) : deriv f₁ x = deriv f x :=
+by { unfold deriv, rwa fderiv_congr_of_eventually_eq }
 
 end congr
 
@@ -1633,7 +1633,7 @@ begin
       sub_zero, int.cast_one] },
   { rw [function.iterate_succ', finset.prod_range_succ, int.cast_mul, mul_assoc, mul_left_comm,
       int.coe_nat_succ, ← sub_sub, ← ((has_deriv_at_fpow _ hx).const_mul _).deriv],
-    exact deriv_congr_of_mem_nhds (eventually.mono (mem_nhds_sets is_open_ne hx) @ihk) }
+    exact deriv_congr_of_eventually_eq (eventually.mono (mem_nhds_sets is_open_ne hx) @ihk) }
 end
 
 end fpow

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -260,7 +260,7 @@ begin
     have : closure (submodule.span 𝕜 (tangent_cone_at 𝕜 s x) : set E) ⊆ closure K :=
       closure_mono this,
     have : y ∈ closure K := this hy,
-    rwa closure_eq_of_is_closed (is_closed_eq f'.continuous f₁'.continuous) at this },
+    rwa (is_closed_eq f'.continuous f₁'.continuous).closure_eq at this },
   rw H.1 at C,
   ext y,
   exact C y (mem_univ _)

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -260,7 +260,7 @@ begin
     have : closure (submodule.span 𝕜 (tangent_cone_at 𝕜 s x) : set E) ⊆ closure K :=
       closure_mono this,
     have : y ∈ closure K := this hy,
-    rwa (is_closed_eq f'.continuous f₁'.continuous).closure_eq at this },
+    rwa closure_eq_of_is_closed (is_closed_eq f'.continuous f₁'.continuous) at this },
   rw H.1 at C,
   ext y,
   exact C y (mem_univ _)
@@ -585,8 +585,7 @@ end continuous
 section congr
 /-! ### congr properties of the derivative -/
 
-theorem has_strict_fderiv_at_congr_of_mem_sets (h : ∀ᶠ y in 𝓝 x, f₀ y = f₁ y)
-  (h' : ∀ y, f₀' y = f₁' y) :
+theorem has_strict_fderiv_at_congr_of_eventually_eq (h : f₀ =ᶠ[𝓝 x] f₁) (h' : ∀ y, f₀' y = f₁' y) :
   has_strict_fderiv_at f₀ f₀' x ↔ has_strict_fderiv_at f₁ f₁' x :=
 begin
   refine is_o_congr ((h.prod_mk_nhds h).mono _) (eventually_of_forall _ $ λ _, rfl),
@@ -594,34 +593,34 @@ begin
   simp only [*]
 end
 
-theorem has_strict_fderiv_at.congr_of_mem_sets (h : has_strict_fderiv_at f f' x)
-  (h₁ : ∀ᶠ y in 𝓝 x, f y = f₁ y) : has_strict_fderiv_at f₁ f' x :=
-(has_strict_fderiv_at_congr_of_mem_sets h₁ (λ _, rfl)).1 h
+theorem has_strict_fderiv_at.congr_of_eventually_eq (h : has_strict_fderiv_at f f' x)
+  (h₁ : f =ᶠ[𝓝 x] f₁) : has_strict_fderiv_at f₁ f' x :=
+(has_strict_fderiv_at_congr_of_eventually_eq h₁ (λ _, rfl)).1 h
 
-theorem has_fderiv_at_filter_congr_of_mem_sets
-  (hx : f₀ x = f₁ x) (h₀ : ∀ᶠ x in L, f₀ x = f₁ x) (h₁ : ∀ x, f₀' x = f₁' x) :
+theorem has_fderiv_at_filter_congr_of_eventually_eq
+  (hx : f₀ x = f₁ x) (h₀ : f₀ =ᶠ[L] f₁) (h₁ : ∀ x, f₀' x = f₁' x) :
   has_fderiv_at_filter f₀ f₀' x L ↔ has_fderiv_at_filter f₁ f₁' x L :=
 is_o_congr (h₀.mono $ λ y hy, by simp only [hy, h₁, hx]) (eventually_of_forall _ $ λ _, rfl)
 
-lemma has_fderiv_at_filter.congr_of_mem_sets (h : has_fderiv_at_filter f f' x L)
-  (hL : ∀ᶠ x in L, f₁ x = f x) (hx : f₁ x = f x) : has_fderiv_at_filter f₁ f' x L :=
-(has_fderiv_at_filter_congr_of_mem_sets hx hL $ λ _, rfl).2 h
+lemma has_fderiv_at_filter.congr_of_eventually_eq (h : has_fderiv_at_filter f f' x L)
+  (hL : f₁ =ᶠ[L] f) (hx : f₁ x = f x) : has_fderiv_at_filter f₁ f' x L :=
+(has_fderiv_at_filter_congr_of_eventually_eq hx hL $ λ _, rfl).2 h
 
 lemma has_fderiv_within_at.congr_mono (h : has_fderiv_within_at f f' s x) (ht : ∀x ∈ t, f₁ x = f x)
   (hx : f₁ x = f x) (h₁ : t ⊆ s) : has_fderiv_within_at f₁ f' t x :=
-has_fderiv_at_filter.congr_of_mem_sets (h.mono h₁) (filter.mem_inf_sets_of_right ht) hx
+has_fderiv_at_filter.congr_of_eventually_eq (h.mono h₁) (filter.mem_inf_sets_of_right ht) hx
 
 lemma has_fderiv_within_at.congr (h : has_fderiv_within_at f f' s x) (hs : ∀x ∈ s, f₁ x = f x)
   (hx : f₁ x = f x) : has_fderiv_within_at f₁ f' s x :=
 h.congr_mono hs hx (subset.refl _)
 
-lemma has_fderiv_within_at.congr_of_mem_nhds_within (h : has_fderiv_within_at f f' s x)
-  (h₁ : ∀ᶠ y in nhds_within x s, f₁ y = f y) (hx : f₁ x = f x) : has_fderiv_within_at f₁ f' s x :=
-has_fderiv_at_filter.congr_of_mem_sets h h₁ hx
+lemma has_fderiv_within_at.congr_of_eventually_eq (h : has_fderiv_within_at f f' s x)
+  (h₁ : f₁ =ᶠ[nhds_within x s] f) (hx : f₁ x = f x) : has_fderiv_within_at f₁ f' s x :=
+has_fderiv_at_filter.congr_of_eventually_eq h h₁ hx
 
-lemma has_fderiv_at.congr_of_mem_nhds (h : has_fderiv_at f f' x)
-  (h₁ : ∀ᶠ y in 𝓝 x, f₁ y = f y) : has_fderiv_at f₁ f' x :=
-has_fderiv_at_filter.congr_of_mem_sets h h₁ (mem_of_nhds h₁ : _)
+lemma has_fderiv_at.congr_of_eventually_eq (h : has_fderiv_at f f' x)
+  (h₁ : f₁ =ᶠ[𝓝 x] f) : has_fderiv_at f₁ f' x :=
+has_fderiv_at_filter.congr_of_eventually_eq h h₁ (mem_of_nhds h₁ : _)
 
 lemma differentiable_within_at.congr_mono (h : differentiable_within_at 𝕜 f s x)
   (ht : ∀x ∈ t, f₁ x = f x) (hx : f₁ x = f x) (h₁ : t ⊆ s) : differentiable_within_at 𝕜 f₁ t x :=
@@ -631,10 +630,10 @@ lemma differentiable_within_at.congr (h : differentiable_within_at 𝕜 f s x)
   (ht : ∀x ∈ s, f₁ x = f x) (hx : f₁ x = f x) : differentiable_within_at 𝕜 f₁ s x :=
 differentiable_within_at.congr_mono h ht hx (subset.refl _)
 
-lemma differentiable_within_at.congr_of_mem_nhds_within
-  (h : differentiable_within_at 𝕜 f s x) (h₁ : ∀ᶠ y in nhds_within x s, f₁ y = f y)
+lemma differentiable_within_at.congr_of_eventually_eq
+  (h : differentiable_within_at 𝕜 f s x) (h₁ : f₁ =ᶠ[nhds_within x s] f)
   (hx : f₁ x = f x) : differentiable_within_at 𝕜 f₁ s x :=
-(h.has_fderiv_within_at.congr_of_mem_nhds_within h₁ hx).differentiable_within_at
+(h.has_fderiv_within_at.congr_of_eventually_eq h₁ hx).differentiable_within_at
 
 lemma differentiable_on.congr_mono (h : differentiable_on 𝕜 f s) (h' : ∀x ∈ t, f₁ x = f x)
   (h₁ : t ⊆ s) : differentiable_on 𝕜 f₁ t :=
@@ -649,23 +648,24 @@ lemma differentiable_on_congr (h' : ∀x ∈ s, f₁ x = f x) :
 ⟨λ h, differentiable_on.congr h (λy hy, (h' y hy).symm),
 λ h, differentiable_on.congr h h'⟩
 
-lemma differentiable_at.congr_of_mem_nhds (h : differentiable_at 𝕜 f x)
-  (hL : ∀ᶠ y in 𝓝 x, f₁ y = f y) : differentiable_at 𝕜 f₁ x :=
-has_fderiv_at.differentiable_at (has_fderiv_at_filter.congr_of_mem_sets h.has_fderiv_at hL (mem_of_nhds hL : _))
+lemma differentiable_at.congr_of_eventually_eq (h : differentiable_at 𝕜 f x) (hL : f₁ =ᶠ[𝓝 x] f) :
+  differentiable_at 𝕜 f₁ x :=
+has_fderiv_at.differentiable_at
+  (has_fderiv_at_filter.congr_of_eventually_eq h.has_fderiv_at hL (mem_of_nhds hL : _))
 
 lemma differentiable_within_at.fderiv_within_congr_mono (h : differentiable_within_at 𝕜 f s x)
   (hs : ∀x ∈ t, f₁ x = f x) (hx : f₁ x = f x) (hxt : unique_diff_within_at 𝕜 t x) (h₁ : t ⊆ s) :
   fderiv_within 𝕜 f₁ t x = fderiv_within 𝕜 f s x :=
 (has_fderiv_within_at.congr_mono h.has_fderiv_within_at hs hx h₁).fderiv_within hxt
 
-lemma fderiv_within_congr_of_mem_nhds_within (hs : unique_diff_within_at 𝕜 s x)
-  (hL : ∀ᶠ y in nhds_within x s, f₁ y = f y) (hx : f₁ x = f x) :
+lemma fderiv_within_congr_of_eventually_eq (hs : unique_diff_within_at 𝕜 s x)
+  (hL : f₁ =ᶠ[nhds_within x s] f) (hx : f₁ x = f x) :
   fderiv_within 𝕜 f₁ s x = fderiv_within 𝕜 f s x :=
 if h : differentiable_within_at 𝕜 f s x
-then has_fderiv_within_at.fderiv_within (h.has_fderiv_within_at.congr_of_mem_sets hL hx) hs
+then has_fderiv_within_at.fderiv_within (h.has_fderiv_within_at.congr_of_eventually_eq hL hx) hs
 else
   have h' : ¬ differentiable_within_at 𝕜 f₁ s x,
-  from mt (λ h, h.congr_of_mem_nhds_within (hL.mono $ λ x, eq.symm) hx.symm) h,
+  from mt (λ h, h.congr_of_eventually_eq (hL.mono $ λ x, eq.symm) hx.symm) h,
   by rw [fderiv_within_zero_of_not_differentiable_within_at h,
     fderiv_within_zero_of_not_differentiable_within_at h']
 
@@ -673,18 +673,18 @@ lemma fderiv_within_congr (hs : unique_diff_within_at 𝕜 s x)
   (hL : ∀y∈s, f₁ y = f y) (hx : f₁ x = f x) :
   fderiv_within 𝕜 f₁ s x = fderiv_within 𝕜 f s x :=
 begin
-  apply fderiv_within_congr_of_mem_nhds_within hs _ hx,
+  apply fderiv_within_congr_of_eventually_eq hs _ hx,
   apply mem_sets_of_superset self_mem_nhds_within,
   exact hL
 end
 
-lemma fderiv_congr_of_mem_nhds (hL : ∀ᶠ y in 𝓝 x, f₁ y = f y) :
+lemma fderiv_congr_of_eventually_eq (hL : f₁ =ᶠ[𝓝 x] f) :
   fderiv 𝕜 f₁ x = fderiv 𝕜 f x :=
 begin
   have A : f₁ x = f x := (mem_of_nhds hL : _),
   rw [← fderiv_within_univ, ← fderiv_within_univ],
   rw ← nhds_within_univ at hL,
-  exact fderiv_within_congr_of_mem_nhds_within unique_diff_within_at_univ hL A
+  exact fderiv_within_congr_of_eventually_eq unique_diff_within_at_univ hL A
 end
 
 end congr
@@ -942,6 +942,11 @@ begin
   rcases hg with ⟨g', hg'⟩,
   exact ⟨continuous_linear_map.comp g' f', hg'.comp x hf' h⟩
 end
+
+lemma differentiable_within_at.comp' {g : F → G} {t : set F}
+  (hg : differentiable_within_at 𝕜 g t (f x)) (hf : differentiable_within_at 𝕜 f s x) :
+  differentiable_within_at 𝕜 (g ∘ f) (s ∩ f⁻¹' t) x :=
+hg.comp x (hf.mono (inter_subset_left _ _)) (inter_subset_right _ _)
 
 lemma differentiable_at.comp {g : F → G}
   (hg : differentiable_at 𝕜 g (f x)) (hf : differentiable_at 𝕜 f x) :

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -585,7 +585,8 @@ end continuous
 section congr
 /-! ### congr properties of the derivative -/
 
-theorem has_strict_fderiv_at_congr_of_eventually_eq (h : f₀ =ᶠ[𝓝 x] f₁) (h' : ∀ y, f₀' y = f₁' y) :
+theorem filter.eventually_eq.has_strict_fderiv_at_congr
+  (h : f₀ =ᶠ[𝓝 x] f₁) (h' : ∀ y, f₀' y = f₁' y) :
   has_strict_fderiv_at f₀ f₀' x ↔ has_strict_fderiv_at f₁ f₁' x :=
 begin
   refine is_o_congr ((h.prod_mk_nhds h).mono _) (eventually_of_forall _ $ λ _, rfl),
@@ -595,16 +596,16 @@ end
 
 theorem has_strict_fderiv_at.congr_of_eventually_eq (h : has_strict_fderiv_at f f' x)
   (h₁ : f =ᶠ[𝓝 x] f₁) : has_strict_fderiv_at f₁ f' x :=
-(has_strict_fderiv_at_congr_of_eventually_eq h₁ (λ _, rfl)).1 h
+(h₁.has_strict_fderiv_at_congr (λ _, rfl)).1 h
 
-theorem has_fderiv_at_filter_congr_of_eventually_eq
-  (hx : f₀ x = f₁ x) (h₀ : f₀ =ᶠ[L] f₁) (h₁ : ∀ x, f₀' x = f₁' x) :
+theorem filter.eventually_eq.has_fderiv_at_filter_congr
+  (h₀ : f₀ =ᶠ[L] f₁) (hx : f₀ x = f₁ x) (h₁ : ∀ x, f₀' x = f₁' x) :
   has_fderiv_at_filter f₀ f₀' x L ↔ has_fderiv_at_filter f₁ f₁' x L :=
 is_o_congr (h₀.mono $ λ y hy, by simp only [hy, h₁, hx]) (eventually_of_forall _ $ λ _, rfl)
 
 lemma has_fderiv_at_filter.congr_of_eventually_eq (h : has_fderiv_at_filter f f' x L)
   (hL : f₁ =ᶠ[L] f) (hx : f₁ x = f x) : has_fderiv_at_filter f₁ f' x L :=
-(has_fderiv_at_filter_congr_of_eventually_eq hx hL $ λ _, rfl).2 h
+(hL.has_fderiv_at_filter_congr hx $ λ _, rfl).2 h
 
 lemma has_fderiv_within_at.congr_mono (h : has_fderiv_within_at f f' s x) (ht : ∀x ∈ t, f₁ x = f x)
   (hx : f₁ x = f x) (h₁ : t ⊆ s) : has_fderiv_within_at f₁ f' t x :=
@@ -658,7 +659,7 @@ lemma differentiable_within_at.fderiv_within_congr_mono (h : differentiable_with
   fderiv_within 𝕜 f₁ t x = fderiv_within 𝕜 f s x :=
 (has_fderiv_within_at.congr_mono h.has_fderiv_within_at hs hx h₁).fderiv_within hxt
 
-lemma fderiv_within_congr_of_eventually_eq (hs : unique_diff_within_at 𝕜 s x)
+lemma filter.eventually_eq.fderiv_within_congr (hs : unique_diff_within_at 𝕜 s x)
   (hL : f₁ =ᶠ[nhds_within x s] f) (hx : f₁ x = f x) :
   fderiv_within 𝕜 f₁ s x = fderiv_within 𝕜 f s x :=
 if h : differentiable_within_at 𝕜 f s x
@@ -673,18 +674,18 @@ lemma fderiv_within_congr (hs : unique_diff_within_at 𝕜 s x)
   (hL : ∀y∈s, f₁ y = f y) (hx : f₁ x = f x) :
   fderiv_within 𝕜 f₁ s x = fderiv_within 𝕜 f s x :=
 begin
-  apply fderiv_within_congr_of_eventually_eq hs _ hx,
+  apply filter.eventually_eq.fderiv_within_congr hs _ hx,
   apply mem_sets_of_superset self_mem_nhds_within,
   exact hL
 end
 
-lemma fderiv_congr_of_eventually_eq (hL : f₁ =ᶠ[𝓝 x] f) :
+lemma filter.eventually_eq.fderiv_congr (hL : f₁ =ᶠ[𝓝 x] f) :
   fderiv 𝕜 f₁ x = fderiv 𝕜 f x :=
 begin
   have A : f₁ x = f x := (mem_of_nhds hL : _),
   rw [← fderiv_within_univ, ← fderiv_within_univ],
   rw ← nhds_within_univ at hL,
-  exact fderiv_within_congr_of_eventually_eq unique_diff_within_at_univ hL A
+  exact hL.fderiv_within_congr unique_diff_within_at_univ A
 end
 
 end congr

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -585,7 +585,7 @@ end continuous
 section congr
 /-! ### congr properties of the derivative -/
 
-theorem filter.eventually_eq.has_strict_fderiv_at_congr
+theorem filter.eventually_eq.has_strict_fderiv_at_iff
   (h : f₀ =ᶠ[𝓝 x] f₁) (h' : ∀ y, f₀' y = f₁' y) :
   has_strict_fderiv_at f₀ f₀' x ↔ has_strict_fderiv_at f₁ f₁' x :=
 begin
@@ -596,16 +596,16 @@ end
 
 theorem has_strict_fderiv_at.congr_of_eventually_eq (h : has_strict_fderiv_at f f' x)
   (h₁ : f =ᶠ[𝓝 x] f₁) : has_strict_fderiv_at f₁ f' x :=
-(h₁.has_strict_fderiv_at_congr (λ _, rfl)).1 h
+(h₁.has_strict_fderiv_at_iff (λ _, rfl)).1 h
 
-theorem filter.eventually_eq.has_fderiv_at_filter_congr
+theorem filter.eventually_eq.has_fderiv_at_filter_iff
   (h₀ : f₀ =ᶠ[L] f₁) (hx : f₀ x = f₁ x) (h₁ : ∀ x, f₀' x = f₁' x) :
   has_fderiv_at_filter f₀ f₀' x L ↔ has_fderiv_at_filter f₁ f₁' x L :=
 is_o_congr (h₀.mono $ λ y hy, by simp only [hy, h₁, hx]) (eventually_of_forall _ $ λ _, rfl)
 
 lemma has_fderiv_at_filter.congr_of_eventually_eq (h : has_fderiv_at_filter f f' x L)
   (hL : f₁ =ᶠ[L] f) (hx : f₁ x = f x) : has_fderiv_at_filter f₁ f' x L :=
-(hL.has_fderiv_at_filter_congr hx $ λ _, rfl).2 h
+(hL.has_fderiv_at_filter_iff hx $ λ _, rfl).2 h
 
 lemma has_fderiv_within_at.congr_mono (h : has_fderiv_within_at f f' s x) (ht : ∀x ∈ t, f₁ x = f x)
   (hx : f₁ x = f x) (h₁ : t ⊆ s) : has_fderiv_within_at f₁ f' t x :=
@@ -659,7 +659,7 @@ lemma differentiable_within_at.fderiv_within_congr_mono (h : differentiable_with
   fderiv_within 𝕜 f₁ t x = fderiv_within 𝕜 f s x :=
 (has_fderiv_within_at.congr_mono h.has_fderiv_within_at hs hx h₁).fderiv_within hxt
 
-lemma filter.eventually_eq.fderiv_within_congr (hs : unique_diff_within_at 𝕜 s x)
+lemma filter.eventually_eq.fderiv_within_eq (hs : unique_diff_within_at 𝕜 s x)
   (hL : f₁ =ᶠ[nhds_within x s] f) (hx : f₁ x = f x) :
   fderiv_within 𝕜 f₁ s x = fderiv_within 𝕜 f s x :=
 if h : differentiable_within_at 𝕜 f s x
@@ -674,18 +674,18 @@ lemma fderiv_within_congr (hs : unique_diff_within_at 𝕜 s x)
   (hL : ∀y∈s, f₁ y = f y) (hx : f₁ x = f x) :
   fderiv_within 𝕜 f₁ s x = fderiv_within 𝕜 f s x :=
 begin
-  apply filter.eventually_eq.fderiv_within_congr hs _ hx,
+  apply filter.eventually_eq.fderiv_within_eq hs _ hx,
   apply mem_sets_of_superset self_mem_nhds_within,
   exact hL
 end
 
-lemma filter.eventually_eq.fderiv_congr (hL : f₁ =ᶠ[𝓝 x] f) :
+lemma filter.eventually_eq.fderiv_eq (hL : f₁ =ᶠ[𝓝 x] f) :
   fderiv 𝕜 f₁ x = fderiv 𝕜 f x :=
 begin
   have A : f₁ x = f x := (mem_of_nhds hL : _),
   rw [← fderiv_within_univ, ← fderiv_within_univ],
   rw ← nhds_within_univ at hL,
-  exact hL.fderiv_within_congr unique_diff_within_at_univ A
+  exact hL.fderiv_within_eq unique_diff_within_at_univ A
 end
 
 end congr

--- a/src/analysis/calculus/inverse.lean
+++ b/src/analysis/calculus/inverse.lean
@@ -289,7 +289,7 @@ begin
     { exact lipschitz_with.of_dist_le_mul (λ x x', hf.inverse_approx_map_contracts_on
         y (hε x.mem) (hε x'.mem)) } },
   refine ⟨this.efixed_point' _ _ _ b (mem_closed_ball_self ε0) (edist_lt_top _ _), _, _⟩,
-  { exact is_complete_of_is_closed is_closed_ball },
+  { exact is_closed_ball.is_complete },
   { apply contracting_with.efixed_point_mem' },
   { exact (inverse_approx_map_fixed_iff y).1 (this.efixed_point_is_fixed_pt' _ _ _ _) }
 end

--- a/src/analysis/calculus/inverse.lean
+++ b/src/analysis/calculus/inverse.lean
@@ -289,7 +289,7 @@ begin
     { exact lipschitz_with.of_dist_le_mul (λ x x', hf.inverse_approx_map_contracts_on
         y (hε x.mem) (hε x'.mem)) } },
   refine ⟨this.efixed_point' _ _ _ b (mem_closed_ball_self ε0) (edist_lt_top _ _), _, _⟩,
-  { exact is_closed_ball.is_complete },
+  { exact is_complete_of_is_closed is_closed_ball },
   { apply contracting_with.efixed_point_mem' },
   { exact (inverse_approx_map_fixed_iff y).1 (this.efixed_point_is_fixed_pt' _ _ _ _) }
 end
@@ -461,7 +461,7 @@ see `of_local_left_inverse`.  -/
 theorem to_local_left_inverse (hf : has_strict_fderiv_at f (f' : E →L[𝕜] F) a) {g : F → E}
   (hg : ∀ᶠ x in 𝓝 a, g (f x) = x) :
   has_strict_fderiv_at g (f'.symm : F →L[𝕜] E) (f a) :=
-hf.to_local_inverse.congr_of_mem_sets $ (hf.local_inverse_unique hg).mono $ λ _, eq.symm
+hf.to_local_inverse.congr_of_eventually_eq $ (hf.local_inverse_unique hg).mono $ λ _, eq.symm
 
 end has_strict_fderiv_at
 

--- a/src/analysis/calculus/specific_functions.lean
+++ b/src/analysis/calculus/specific_functions.lean
@@ -69,7 +69,7 @@ is the `n+1`-th auxiliary function. -/
 lemma f_aux_deriv_pos (n : ℕ) (x : ℝ) (hx : 0 < x) :
   has_deriv_at (f_aux n) ((P_aux (n+1)).eval x * exp (-x⁻¹) / x^(2 * (n + 1))) x :=
 begin
-  apply (f_aux_deriv n x (ne_of_gt hx)).congr_of_mem_nhds,
+  apply (f_aux_deriv n x (ne_of_gt hx)).congr_of_eventually_eq,
   have : Ioi (0 : ℝ) ∈ 𝓝 x := lt_mem_nhds hx,
   filter_upwards [this],
   assume y hy,
@@ -133,7 +133,7 @@ begin
   rcases lt_trichotomy x 0 with hx|hx|hx,
   { have : f_aux (n+1) x = 0, by simp [f_aux, le_of_lt hx],
     rw this,
-    apply (has_deriv_at_const x (0 : ℝ)).congr_of_mem_nhds,
+    apply (has_deriv_at_const x (0 : ℝ)).congr_of_eventually_eq,
     have : Iio (0 : ℝ) ∈ 𝓝 x := gt_mem_nhds hx,
     filter_upwards [this],
     assume y hy,

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -501,7 +501,7 @@ begin
   { convert (has_deriv_at_exp _).comp x ((has_deriv_at_log (ne_of_gt h)).mul_const p) using 1,
     field_simp [rpow_def_of_pos h, mul_sub, exp_sub, exp_log h, ne_of_gt h],
     ring },
-  apply this.congr_of_mem_nhds,
+  apply this.congr_of_eventually_eq,
   have : set.Ioi (0 : ℝ) ∈ 𝓝 x := mem_nhds_sets is_open_Ioi h,
   exact filter.eventually_of_mem this (λ y hy, rpow_def_of_pos hy _)
 end
@@ -514,7 +514,7 @@ begin
       using 1,
     field_simp [rpow_def_of_neg h, mul_sub, exp_sub, sub_mul, cos_sub, exp_log_of_neg h, ne_of_lt h],
     ring },
-  apply this.congr_of_mem_nhds,
+  apply this.congr_of_eventually_eq,
   have : set.Iio (0 : ℝ) ∈ 𝓝 x := mem_nhds_sets is_open_Iio h,
   exact filter.eventually_of_mem this (λ y hy, rpow_def_of_neg hy _)
 end

--- a/src/geometry/manifold/basic_smooth_bundle.lean
+++ b/src/geometry/manifold/basic_smooth_bundle.lean
@@ -363,7 +363,7 @@ def tangent_bundle_core : basic_smooth_bundle_core I M E :=
       simp only [hz.2.symm, hz.1] with mfld_simps },
     have C : fderiv_within 𝕜 (I ∘ i.1 ∘ i.1.symm ∘ I.symm) (range I) (I x) =
              fderiv_within 𝕜 (id : E → E) (range I) (I x) :=
-      fderiv_within_congr_of_eventually_eq I.unique_diff_at_image B
+      filter.eventually_eq.fderiv_within_congr I.unique_diff_at_image B
       (by simp only [hx] with mfld_simps),
     rw fderiv_within_id I.unique_diff_at_image at C,
     rw C,

--- a/src/geometry/manifold/basic_smooth_bundle.lean
+++ b/src/geometry/manifold/basic_smooth_bundle.lean
@@ -363,7 +363,7 @@ def tangent_bundle_core : basic_smooth_bundle_core I M E :=
       simp only [hz.2.symm, hz.1] with mfld_simps },
     have C : fderiv_within 𝕜 (I ∘ i.1 ∘ i.1.symm ∘ I.symm) (range I) (I x) =
              fderiv_within 𝕜 (id : E → E) (range I) (I x) :=
-      fderiv_within_congr_of_mem_nhds_within I.unique_diff_at_image B
+      fderiv_within_congr_of_eventually_eq I.unique_diff_at_image B
       (by simp only [hx] with mfld_simps),
     rw fderiv_within_id I.unique_diff_at_image at C,
     rw C,

--- a/src/geometry/manifold/basic_smooth_bundle.lean
+++ b/src/geometry/manifold/basic_smooth_bundle.lean
@@ -363,7 +363,7 @@ def tangent_bundle_core : basic_smooth_bundle_core I M E :=
       simp only [hz.2.symm, hz.1] with mfld_simps },
     have C : fderiv_within 𝕜 (I ∘ i.1 ∘ i.1.symm ∘ I.symm) (range I) (I x) =
              fderiv_within 𝕜 (id : E → E) (range I) (I x) :=
-      filter.eventually_eq.fderiv_within_congr I.unique_diff_at_image B
+      filter.eventually_eq.fderiv_within_eq I.unique_diff_at_image B
       (by simp only [hx] with mfld_simps),
     rw fderiv_within_id I.unique_diff_at_image at C,
     rw C,

--- a/src/geometry/manifold/mfderiv.lean
+++ b/src/geometry/manifold/mfderiv.lean
@@ -590,49 +590,49 @@ omit Is I's
 
 /-! ### Congruence lemmas for derivatives on manifolds -/
 
-lemma has_mfderiv_within_at.congr_of_mem_nhds_within (h : has_mfderiv_within_at I I' f s x f')
-  (h₁ : ∀ᶠ y in nhds_within x s, f₁ y = f y) (hx : f₁ x = f x) : has_mfderiv_within_at I I' f₁ s x f' :=
+lemma has_mfderiv_within_at.congr_of_eventually_eq (h : has_mfderiv_within_at I I' f s x f')
+  (h₁ : f₁ =ᶠ[nhds_within x s] f) (hx : f₁ x = f x) : has_mfderiv_within_at I I' f₁ s x f' :=
 begin
-  refine ⟨continuous_within_at.congr_of_mem_nhds_within h.1 h₁ hx, _⟩,
-  apply has_fderiv_within_at.congr_of_mem_nhds_within h.2,
+  refine ⟨continuous_within_at.congr_of_eventually_eq h.1 h₁ hx, _⟩,
+  apply has_fderiv_within_at.congr_of_eventually_eq h.2,
   { have : (ext_chart_at I x).symm ⁻¹' {y | f₁ y = f y} ∈
       nhds_within ((ext_chart_at I x) x) ((ext_chart_at I x).symm ⁻¹' s ∩ range I) :=
       ext_chart_preimage_mem_nhds_within I x h₁,
     apply filter.mem_sets_of_superset this (λy, _),
-    simp only [hx] with mfld_simps {contextual := tt}},
+    simp only [hx] with mfld_simps {contextual := tt} },
   { simp only [hx] with mfld_simps },
 end
 
 lemma has_mfderiv_within_at.congr_mono (h : has_mfderiv_within_at I I' f s x f')
   (ht : ∀x ∈ t, f₁ x = f x) (hx : f₁ x = f x) (h₁ : t ⊆ s) :
   has_mfderiv_within_at I I' f₁ t x f' :=
-(h.mono h₁).congr_of_mem_nhds_within (filter.mem_inf_sets_of_right ht) hx
+(h.mono h₁).congr_of_eventually_eq (filter.mem_inf_sets_of_right ht) hx
 
-lemma has_mfderiv_at.congr_of_mem_nhds (h : has_mfderiv_at I I' f x f')
-  (h₁ : ∀ᶠ y in 𝓝 x, f₁ y = f y) : has_mfderiv_at I I' f₁ x f' :=
+lemma has_mfderiv_at.congr_of_eventually_eq (h : has_mfderiv_at I I' f x f')
+  (h₁ : f₁ =ᶠ[𝓝 x] f) : has_mfderiv_at I I' f₁ x f' :=
 begin
   rw ← has_mfderiv_within_at_univ at ⊢ h,
-  apply h.congr_of_mem_nhds_within _ (mem_of_nhds h₁ : _),
+  apply h.congr_of_eventually_eq _ (mem_of_nhds h₁ : _),
   rwa nhds_within_univ
 end
 
 include Is I's
 
-lemma mdifferentiable_within_at.congr_of_mem_nhds_within
-  (h : mdifferentiable_within_at I I' f s x) (h₁ : ∀ᶠ y in nhds_within x s, f₁ y = f y)
+lemma mdifferentiable_within_at.congr_of_eventually_eq
+  (h : mdifferentiable_within_at I I' f s x) (h₁ : f₁ =ᶠ[nhds_within x s] f)
   (hx : f₁ x = f x) : mdifferentiable_within_at I I' f₁ s x :=
-(h.has_mfderiv_within_at.congr_of_mem_nhds_within h₁ hx).mdifferentiable_within_at
+(h.has_mfderiv_within_at.congr_of_eventually_eq h₁ hx).mdifferentiable_within_at
 
 variables (I I')
-lemma mdifferentiable_within_at_congr_of_mem_nhds_within
-  (h₁ : ∀ᶠ y in nhds_within x s, f₁ y = f y) (hx : f₁ x = f x) :
+lemma mdifferentiable_within_at_congr_of_eventually_eq
+  (h₁ : f₁ =ᶠ[nhds_within x s] f) (hx : f₁ x = f x) :
   mdifferentiable_within_at I I' f s x ↔ mdifferentiable_within_at I I' f₁ s x :=
 begin
   split,
   { assume h,
-    apply h.congr_of_mem_nhds_within h₁ hx },
+    apply h.congr_of_eventually_eq h₁ hx },
   { assume h,
-    apply h.congr_of_mem_nhds_within _ hx.symm,
+    apply h.congr_of_eventually_eq _ hx.symm,
     apply h₁.mono,
     intro y,
     apply eq.symm }
@@ -651,33 +651,33 @@ lemma mdifferentiable_on.congr_mono (h : mdifferentiable_on I I' f s) (h' : ∀x
   (h₁ : t ⊆ s) : mdifferentiable_on I I' f₁ t :=
 λ x hx, (h x (h₁ hx)).congr_mono h' (h' x hx) h₁
 
-lemma mdifferentiable_at.congr_of_mem_nhds (h : mdifferentiable_at I I' f x)
-  (hL : ∀ᶠ y in 𝓝 x, f₁ y = f y) : mdifferentiable_at I I' f₁ x :=
-((h.has_mfderiv_at).congr_of_mem_nhds hL).mdifferentiable_at
+lemma mdifferentiable_at.congr_of_eventually_eq (h : mdifferentiable_at I I' f x)
+  (hL : f₁ =ᶠ[𝓝 x] f) : mdifferentiable_at I I' f₁ x :=
+((h.has_mfderiv_at).congr_of_eventually_eq hL).mdifferentiable_at
 
 lemma mdifferentiable_within_at.mfderiv_within_congr_mono (h : mdifferentiable_within_at I I' f s x)
   (hs : ∀x ∈ t, f₁ x = f x) (hx : f₁ x = f x) (hxt : unique_mdiff_within_at I t x) (h₁ : t ⊆ s) :
   mfderiv_within I I' f₁ t x = (mfderiv_within I I' f s x : _) :=
 (has_mfderiv_within_at.congr_mono h.has_mfderiv_within_at hs hx h₁).mfderiv_within hxt
 
-lemma mfderiv_within_congr_of_mem_nhds_within (hs : unique_mdiff_within_at I s x)
-  (hL : ∀ᶠ y in nhds_within x s, f₁ y = f y) (hx : f₁ x = f x) :
+lemma mfderiv_within_congr_of_eventually_eq (hs : unique_mdiff_within_at I s x)
+  (hL : f₁ =ᶠ[nhds_within x s] f) (hx : f₁ x = f x) :
   mfderiv_within I I' f₁ s x = (mfderiv_within I I' f s x : _) :=
 begin
   by_cases h : mdifferentiable_within_at I I' f s x,
-  { exact ((h.has_mfderiv_within_at).congr_of_mem_nhds_within hL hx).mfderiv_within hs },
+  { exact ((h.has_mfderiv_within_at).congr_of_eventually_eq hL hx).mfderiv_within hs },
   { unfold mfderiv_within,
     rw [dif_neg h, dif_neg],
-    rwa ← mdifferentiable_within_at_congr_of_mem_nhds_within I I' hL hx }
+    rwa ← mdifferentiable_within_at_congr_of_eventually_eq I I' hL hx }
 end
 
-lemma mfderiv_congr_of_mem_nhds (hL : ∀ᶠ y in 𝓝 x, f₁ y = f y) :
+lemma mfderiv_congr_of_eventually_eq (hL : f₁ =ᶠ[𝓝 x] f) :
   mfderiv I I' f₁ x = (mfderiv I I' f x : _) :=
 begin
   have A : f₁ x = f x := (mem_of_nhds hL : _),
   rw [← mfderiv_within_univ, ← mfderiv_within_univ],
   rw ← nhds_within_univ at hL,
-  exact mfderiv_within_congr_of_mem_nhds_within (unique_mdiff_within_at_univ I) hL A
+  exact mfderiv_within_congr_of_eventually_eq (unique_mdiff_within_at_univ I) hL A
 end
 
 /-! ### Composition lemmas -/
@@ -727,7 +727,7 @@ begin
     simp only with mfld_simps at hy,
     have : f (((chart_at H x).symm : H → M) (I.symm y)) ∈ u := hst hy.1.1,
     simp only [hy, this] with mfld_simps },
-  apply A.congr_of_mem_nhds_within (written_in_ext_chart_comp hf.1),
+  apply A.congr_of_eventually_eq (written_in_ext_chart_comp hf.1),
   simp only with mfld_simps
 end
 
@@ -839,7 +839,7 @@ begin
   { apply filter.mem_sets_of_superset (ext_chart_at_target_mem_nhds_within I x),
     assume y hy,
     simp only [-ext_chart_at, hy] with mfld_simps },
-  apply has_fderiv_within_at.congr_of_mem_nhds_within (has_fderiv_within_at_id _ _) this,
+  apply has_fderiv_within_at.congr_of_eventually_eq (has_fderiv_within_at_id _ _) this,
   simp only with mfld_simps
 end
 
@@ -964,9 +964,9 @@ begin
   have mem : I ((chart_at H x : M → H) x) ∈
     I.symm ⁻¹' ((chart_at H x).symm ≫ₕ e).source ∩ range I,
     by simp only [hx] with mfld_simps,
-  have : (chart_at H x).symm.trans e ∈ times_cont_diff_groupoid ⊤ I :=
+  have : (chart_at H x).symm.trans e ∈ times_cont_diff_groupoid ∞ I :=
     has_groupoid.compatible _ (chart_mem_atlas H x) h,
-  have A : times_cont_diff_on 𝕜 ⊤
+  have A : times_cont_diff_on 𝕜 ∞
     (I ∘ ((chart_at H x).symm.trans e) ∘ I.symm)
     (I.symm ⁻¹' ((chart_at H x).symm.trans e).source ∩ range I) :=
     this.1,
@@ -987,9 +987,9 @@ begin
   refine ⟨(e.continuous_on_symm x hx).continuous_at (mem_nhds_sets e.open_target hx), _⟩,
   have mem : I x ∈ I.symm ⁻¹' (e.symm ≫ₕ chart_at H (e.symm x)).source ∩ range (I),
     by simp only [hx] with mfld_simps,
-  have : e.symm.trans (chart_at H (e.symm x)) ∈ times_cont_diff_groupoid ⊤ I :=
+  have : e.symm.trans (chart_at H (e.symm x)) ∈ times_cont_diff_groupoid ∞ I :=
     has_groupoid.compatible _ h (chart_mem_atlas H _),
-  have A : times_cont_diff_on 𝕜 ⊤
+  have A : times_cont_diff_on 𝕜 ∞
     (I ∘ (e.symm.trans (chart_at H (e.symm x))) ∘ I.symm)
     (I.symm ⁻¹' (e.symm.trans (chart_at H (e.symm x))).source ∩ range I) :=
     this.1,
@@ -1166,7 +1166,7 @@ begin
   rw ← this,
   have : mfderiv I I (_root_.id : M → M) x = continuous_linear_map.id _ _ := mfderiv_id I,
   rw ← this,
-  apply mfderiv_congr_of_mem_nhds,
+  apply mfderiv_congr_of_eventually_eq,
   have : e.source ∈ 𝓝 x := mem_nhds_sets e.open_source hx,
   apply filter.mem_sets_of_superset this,
   assume p hp,

--- a/src/geometry/manifold/mfderiv.lean
+++ b/src/geometry/manifold/mfderiv.lean
@@ -624,7 +624,7 @@ lemma mdifferentiable_within_at.congr_of_eventually_eq
 (h.has_mfderiv_within_at.congr_of_eventually_eq h₁ hx).mdifferentiable_within_at
 
 variables (I I')
-lemma filter.eventually_eq.mdifferentiable_within_at_congr
+lemma filter.eventually_eq.mdifferentiable_within_at_iff
   (h₁ : f₁ =ᶠ[nhds_within x s] f) (hx : f₁ x = f x) :
   mdifferentiable_within_at I I' f s x ↔ mdifferentiable_within_at I I' f₁ s x :=
 begin
@@ -660,7 +660,7 @@ lemma mdifferentiable_within_at.mfderiv_within_congr_mono (h : mdifferentiable_w
   mfderiv_within I I' f₁ t x = (mfderiv_within I I' f s x : _) :=
 (has_mfderiv_within_at.congr_mono h.has_mfderiv_within_at hs hx h₁).mfderiv_within hxt
 
-lemma filter.eventually_eq.mfderiv_within_congr (hs : unique_mdiff_within_at I s x)
+lemma filter.eventually_eq.mfderiv_within_eq (hs : unique_mdiff_within_at I s x)
   (hL : f₁ =ᶠ[nhds_within x s] f) (hx : f₁ x = f x) :
   mfderiv_within I I' f₁ s x = (mfderiv_within I I' f s x : _) :=
 begin
@@ -668,16 +668,16 @@ begin
   { exact ((h.has_mfderiv_within_at).congr_of_eventually_eq hL hx).mfderiv_within hs },
   { unfold mfderiv_within,
     rw [dif_neg h, dif_neg],
-    rwa ← hL.mdifferentiable_within_at_congr I I' hx }
+    rwa ← hL.mdifferentiable_within_at_iff I I' hx }
 end
 
-lemma filter.eventually_eq.mfderiv_congr (hL : f₁ =ᶠ[𝓝 x] f) :
+lemma filter.eventually_eq.mfderiv_eq (hL : f₁ =ᶠ[𝓝 x] f) :
   mfderiv I I' f₁ x = (mfderiv I I' f x : _) :=
 begin
   have A : f₁ x = f x := (mem_of_nhds hL : _),
   rw [← mfderiv_within_univ, ← mfderiv_within_univ],
   rw ← nhds_within_univ at hL,
-  exact hL.mfderiv_within_congr (unique_mdiff_within_at_univ I) A
+  exact hL.mfderiv_within_eq (unique_mdiff_within_at_univ I) A
 end
 
 /-! ### Composition lemmas -/
@@ -1166,7 +1166,7 @@ begin
   rw ← this,
   have : mfderiv I I (_root_.id : M → M) x = continuous_linear_map.id _ _ := mfderiv_id I,
   rw ← this,
-  apply filter.eventually_eq.mfderiv_congr,
+  apply filter.eventually_eq.mfderiv_eq,
   have : e.source ∈ 𝓝 x := mem_nhds_sets e.open_source hx,
   apply filter.mem_sets_of_superset this,
   assume p hp,

--- a/src/geometry/manifold/mfderiv.lean
+++ b/src/geometry/manifold/mfderiv.lean
@@ -964,9 +964,9 @@ begin
   have mem : I ((chart_at H x : M → H) x) ∈
     I.symm ⁻¹' ((chart_at H x).symm ≫ₕ e).source ∩ range I,
     by simp only [hx] with mfld_simps,
-  have : (chart_at H x).symm.trans e ∈ times_cont_diff_groupoid ∞ I :=
+  have : (chart_at H x).symm.trans e ∈ times_cont_diff_groupoid ⊤ I :=
     has_groupoid.compatible _ (chart_mem_atlas H x) h,
-  have A : times_cont_diff_on 𝕜 ∞
+  have A : times_cont_diff_on 𝕜 ⊤
     (I ∘ ((chart_at H x).symm.trans e) ∘ I.symm)
     (I.symm ⁻¹' ((chart_at H x).symm.trans e).source ∩ range I) :=
     this.1,
@@ -987,9 +987,9 @@ begin
   refine ⟨(e.continuous_on_symm x hx).continuous_at (mem_nhds_sets e.open_target hx), _⟩,
   have mem : I x ∈ I.symm ⁻¹' (e.symm ≫ₕ chart_at H (e.symm x)).source ∩ range (I),
     by simp only [hx] with mfld_simps,
-  have : e.symm.trans (chart_at H (e.symm x)) ∈ times_cont_diff_groupoid ∞ I :=
+  have : e.symm.trans (chart_at H (e.symm x)) ∈ times_cont_diff_groupoid ⊤ I :=
     has_groupoid.compatible _ h (chart_mem_atlas H _),
-  have A : times_cont_diff_on 𝕜 ∞
+  have A : times_cont_diff_on 𝕜 ⊤
     (I ∘ (e.symm.trans (chart_at H (e.symm x))) ∘ I.symm)
     (I.symm ⁻¹' (e.symm.trans (chart_at H (e.symm x))).source ∩ range I) :=
     this.1,

--- a/src/geometry/manifold/mfderiv.lean
+++ b/src/geometry/manifold/mfderiv.lean
@@ -624,7 +624,7 @@ lemma mdifferentiable_within_at.congr_of_eventually_eq
 (h.has_mfderiv_within_at.congr_of_eventually_eq h₁ hx).mdifferentiable_within_at
 
 variables (I I')
-lemma mdifferentiable_within_at_congr_of_eventually_eq
+lemma filter.eventually_eq.mdifferentiable_within_at_congr
   (h₁ : f₁ =ᶠ[nhds_within x s] f) (hx : f₁ x = f x) :
   mdifferentiable_within_at I I' f s x ↔ mdifferentiable_within_at I I' f₁ s x :=
 begin
@@ -660,7 +660,7 @@ lemma mdifferentiable_within_at.mfderiv_within_congr_mono (h : mdifferentiable_w
   mfderiv_within I I' f₁ t x = (mfderiv_within I I' f s x : _) :=
 (has_mfderiv_within_at.congr_mono h.has_mfderiv_within_at hs hx h₁).mfderiv_within hxt
 
-lemma mfderiv_within_congr_of_eventually_eq (hs : unique_mdiff_within_at I s x)
+lemma filter.eventually_eq.mfderiv_within_congr (hs : unique_mdiff_within_at I s x)
   (hL : f₁ =ᶠ[nhds_within x s] f) (hx : f₁ x = f x) :
   mfderiv_within I I' f₁ s x = (mfderiv_within I I' f s x : _) :=
 begin
@@ -668,16 +668,16 @@ begin
   { exact ((h.has_mfderiv_within_at).congr_of_eventually_eq hL hx).mfderiv_within hs },
   { unfold mfderiv_within,
     rw [dif_neg h, dif_neg],
-    rwa ← mdifferentiable_within_at_congr_of_eventually_eq I I' hL hx }
+    rwa ← hL.mdifferentiable_within_at_congr I I' hx }
 end
 
-lemma mfderiv_congr_of_eventually_eq (hL : f₁ =ᶠ[𝓝 x] f) :
+lemma filter.eventually_eq.mfderiv_congr (hL : f₁ =ᶠ[𝓝 x] f) :
   mfderiv I I' f₁ x = (mfderiv I I' f x : _) :=
 begin
   have A : f₁ x = f x := (mem_of_nhds hL : _),
   rw [← mfderiv_within_univ, ← mfderiv_within_univ],
   rw ← nhds_within_univ at hL,
-  exact mfderiv_within_congr_of_eventually_eq (unique_mdiff_within_at_univ I) hL A
+  exact hL.mfderiv_within_congr (unique_mdiff_within_at_univ I) A
 end
 
 /-! ### Composition lemmas -/
@@ -1166,7 +1166,7 @@ begin
   rw ← this,
   have : mfderiv I I (_root_.id : M → M) x = continuous_linear_map.id _ _ := mfderiv_id I,
   rw ← this,
-  apply mfderiv_congr_of_eventually_eq,
+  apply filter.eventually_eq.mfderiv_congr,
   have : e.source ∈ 𝓝 x := mem_nhds_sets e.open_source hx,
   apply filter.mem_sets_of_superset this,
   assume p hp,

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -475,9 +475,9 @@ lemma forall_sets_nonempty_iff_ne_bot {f : filter α} :
   (∀ (s : set α), s ∈ f → s.nonempty) ↔ f ≠ ⊥ :=
 ⟨λ h hf, empty_not_nonempty (h ∅ $ hf.symm ▸ mem_bot_sets), nonempty_of_mem_sets⟩
 
-lemma mem_sets_of_eq_bot {f : filter α} {s : set α} (h : f ⊓ 𝓟 (-s) = ⊥) : s ∈ f :=
-have ∅ ∈ f ⊓ 𝓟 (- s), from h.symm ▸ mem_bot_sets,
-let ⟨s₁, hs₁, s₂, (hs₂ : -s ⊆ s₂), (hs : s₁ ∩ s₂ ⊆ ∅)⟩ := this in
+lemma mem_sets_of_eq_bot {f : filter α} {s : set α} (h : f ⊓ 𝓟 sᶜ = ⊥) : s ∈ f :=
+have ∅ ∈ f ⊓ 𝓟 sᶜ, from h.symm ▸ mem_bot_sets,
+let ⟨s₁, hs₁, s₂, (hs₂ : sᶜ ⊆ s₂), (hs : s₁ ∩ s₂ ⊆ ∅)⟩ := this in
 by filter_upwards [hs₁] assume a ha, classical.by_contradiction $ assume ha', hs ⟨ha, hs₂ ha'⟩
 
 lemma inf_ne_bot_iff {f g : filter α} :
@@ -735,11 +735,11 @@ empty_in_sets_eq_bot.symm.trans $ mem_principal_sets.trans subset_empty_iff
 lemma principal_ne_bot_iff {s : set α} : 𝓟 s ≠ ⊥ ↔ s.nonempty :=
 (not_congr principal_eq_bot_iff).trans ne_empty_iff_nonempty
 
-lemma is_compl_principal (s : set α) : is_compl (𝓟 s) (𝓟 (-s)) :=
+lemma is_compl_principal (s : set α) : is_compl (𝓟 s) (𝓟 sᶜ) :=
 ⟨by simp only [inf_principal, inter_compl_self, principal_empty, le_refl],
   by simp only [sup_principal, union_compl_self, principal_univ, le_refl]⟩
 
-lemma inf_principal_eq_bot {f : filter α} {s : set α} (hs : -s ∈ f) : f ⊓ 𝓟 s = ⊥ :=
+lemma inf_principal_eq_bot {f : filter α} {s : set α} (hs : sᶜ ∈ f) : f ⊓ 𝓟 s = ⊥ :=
 empty_in_sets_eq_bot.mp ⟨_, hs, s, mem_principal_self s, assume x ⟨h₁, h₂⟩, h₁ h₂⟩
 
 theorem mem_inf_principal (f : filter α) (s t : set α) :
@@ -747,17 +747,17 @@ theorem mem_inf_principal (f : filter α) (s t : set α) :
 begin
   simp only [← le_principal_iff, (is_compl_principal s).le_left_iff, disjoint, inf_assoc,
     inf_principal, imp_iff_not_or],
-  rw [← disjoint, ← (is_compl_principal (t ∩ -s)).le_right_iff, compl_inter, compl_compl],
+  rw [← disjoint, ← (is_compl_principal (t ∩ sᶜ)).le_right_iff, compl_inter, compl_compl],
   refl
 end
 
 lemma mem_iff_inf_principal_compl {f : filter α} {V : set α} :
-  V ∈ f ↔ f ⊓ 𝓟 (-V) = ⊥ :=
+  V ∈ f ↔ f ⊓ 𝓟 Vᶜ = ⊥ :=
 begin
   rw inf_eq_bot_iff,
   split,
   { intro h,
-    use [V, -V],
+    use [V, Vᶜ],
     simp [h, subset.refl] },
   { rintros ⟨U, W, U_in, W_in, UW⟩,
     rw [mem_principal_sets, compl_subset_comm] at W_in,
@@ -770,7 +770,7 @@ begin
 end
 
 lemma le_iff_forall_inf_principal_compl {f g : filter α} :
-  f ≤ g ↔ ∀ V ∈ g, f ⊓ 𝓟 (-V) = ⊥ :=
+  f ≤ g ↔ ∀ V ∈ g, f ⊓ 𝓟 Vᶜ = ⊥ :=
 begin
   change (∀ V ∈ g, V ∈ f) ↔ _,
   simp_rw [mem_iff_inf_principal_compl],

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -475,9 +475,9 @@ lemma forall_sets_nonempty_iff_ne_bot {f : filter α} :
   (∀ (s : set α), s ∈ f → s.nonempty) ↔ f ≠ ⊥ :=
 ⟨λ h hf, empty_not_nonempty (h ∅ $ hf.symm ▸ mem_bot_sets), nonempty_of_mem_sets⟩
 
-lemma mem_sets_of_eq_bot {f : filter α} {s : set α} (h : f ⊓ 𝓟 sᶜ = ⊥) : s ∈ f :=
-have ∅ ∈ f ⊓ 𝓟 sᶜ, from h.symm ▸ mem_bot_sets,
-let ⟨s₁, hs₁, s₂, (hs₂ : sᶜ ⊆ s₂), (hs : s₁ ∩ s₂ ⊆ ∅)⟩ := this in
+lemma mem_sets_of_eq_bot {f : filter α} {s : set α} (h : f ⊓ 𝓟 (-s) = ⊥) : s ∈ f :=
+have ∅ ∈ f ⊓ 𝓟 (- s), from h.symm ▸ mem_bot_sets,
+let ⟨s₁, hs₁, s₂, (hs₂ : -s ⊆ s₂), (hs : s₁ ∩ s₂ ⊆ ∅)⟩ := this in
 by filter_upwards [hs₁] assume a ha, classical.by_contradiction $ assume ha', hs ⟨ha, hs₂ ha'⟩
 
 lemma inf_ne_bot_iff {f g : filter α} :
@@ -735,11 +735,11 @@ empty_in_sets_eq_bot.symm.trans $ mem_principal_sets.trans subset_empty_iff
 lemma principal_ne_bot_iff {s : set α} : 𝓟 s ≠ ⊥ ↔ s.nonempty :=
 (not_congr principal_eq_bot_iff).trans ne_empty_iff_nonempty
 
-lemma is_compl_principal (s : set α) : is_compl (𝓟 s) (𝓟 sᶜ) :=
+lemma is_compl_principal (s : set α) : is_compl (𝓟 s) (𝓟 (-s)) :=
 ⟨by simp only [inf_principal, inter_compl_self, principal_empty, le_refl],
   by simp only [sup_principal, union_compl_self, principal_univ, le_refl]⟩
 
-lemma inf_principal_eq_bot {f : filter α} {s : set α} (hs : sᶜ ∈ f) : f ⊓ 𝓟 s = ⊥ :=
+lemma inf_principal_eq_bot {f : filter α} {s : set α} (hs : -s ∈ f) : f ⊓ 𝓟 s = ⊥ :=
 empty_in_sets_eq_bot.mp ⟨_, hs, s, mem_principal_self s, assume x ⟨h₁, h₂⟩, h₁ h₂⟩
 
 theorem mem_inf_principal (f : filter α) (s t : set α) :
@@ -747,17 +747,17 @@ theorem mem_inf_principal (f : filter α) (s t : set α) :
 begin
   simp only [← le_principal_iff, (is_compl_principal s).le_left_iff, disjoint, inf_assoc,
     inf_principal, imp_iff_not_or],
-  rw [← disjoint, ← (is_compl_principal (t ∩ sᶜ)).le_right_iff, compl_inter, compl_compl],
+  rw [← disjoint, ← (is_compl_principal (t ∩ -s)).le_right_iff, compl_inter, compl_compl],
   refl
 end
 
 lemma mem_iff_inf_principal_compl {f : filter α} {V : set α} :
-  V ∈ f ↔ f ⊓ 𝓟 Vᶜ = ⊥ :=
+  V ∈ f ↔ f ⊓ 𝓟 (-V) = ⊥ :=
 begin
   rw inf_eq_bot_iff,
   split,
   { intro h,
-    use [V, Vᶜ],
+    use [V, -V],
     simp [h, subset.refl] },
   { rintros ⟨U, W, U_in, W_in, UW⟩,
     rw [mem_principal_sets, compl_subset_comm] at W_in,
@@ -770,7 +770,7 @@ begin
 end
 
 lemma le_iff_forall_inf_principal_compl {f g : filter α} :
-  f ≤ g ↔ ∀ V ∈ g, f ⊓ 𝓟 Vᶜ = ⊥ :=
+  f ≤ g ↔ ∀ V ∈ g, f ⊓ 𝓟 (-V) = ⊥ :=
 begin
   change (∀ V ∈ g, V ∈ f) ↔ _,
   simp_rw [mem_iff_inf_principal_compl],
@@ -846,6 +846,14 @@ empty_in_sets_eq_bot
 @[simp] lemma eventually_const {f : filter α} (hf : f ≠ ⊥) {p : Prop} :
   (∀ᶠ x in f, p) ↔ p :=
 classical.by_cases (λ h : p, by simp [h]) (λ h, by simp [h, hf])
+
+lemma eventually.exists_mem {p : α → Prop} {f : filter α} (hp : ∀ᶠ x in f, p x) :
+  ∃ v ∈ f, ∀ y ∈ v, p y :=
+ ⟨{x | p x}, hp, λ y hy, hy⟩
+
+lemma eventually_iff_exists_mem {p : α → Prop} {f : filter α} :
+  (∀ᶠ x in f, p x) ↔ ∃ v ∈ f, ∀ y ∈ v, p y :=
+⟨λ hp, hp.exists_mem, λ ⟨v, vf, hv⟩, eventually_of_mem vf hv⟩
 
 lemma eventually.mp {p q : α → Prop} {f : filter α} (hp : ∀ᶠ x in f, p x)
   (hq : ∀ᶠ x in f, p x → q x) :
@@ -1076,6 +1084,18 @@ lemma eventually_eq.rw {l : filter α} {f g : α → β} (h : f =ᶠ[l] g) (p : 
   (hf : ∀ᶠ x in l, p x (f x)) :
   ∀ᶠ x in l, p x (g x) :=
 hf.congr $ h.mono $ λ x hx, hx ▸ iff.rfl
+
+lemma eventually_eq.exists_mem {l : filter α} {f g : α → β} (h : f =ᶠ[l] g) :
+  ∃ s ∈ l, ∀ x ∈ s, f x = g x :=
+filter.eventually.exists_mem h
+
+lemma eventually_eq_of_mem {l : filter α} {f g : α → β} {s : set α}
+  (hs : s ∈ l) (h : ∀ x ∈ s, f x = g x) : f =ᶠ[l] g :=
+eventually_of_mem hs h
+
+lemma eventually_eq_iff_exists_mem {l : filter α} {f g : α → β} :
+  (f =ᶠ[l] g) ↔ ∃ s ∈ l, ∀ x ∈ s, f x = g x :=
+eventually_iff_exists_mem
 
 @[refl] lemma eventually_eq.refl (l : filter α) (f : α → β) :
   f =ᶠ[l] f :=

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -182,7 +182,7 @@ mem_closure_iff_nhds_within_ne_bot.1 $ subset_closure hx
 
 lemma is_closed.mem_of_nhds_within_ne_bot {s : set α} (hs : is_closed s)
   {x : α} (hx : nhds_within x s ≠ ⊥) : x ∈ s :=
-by simpa only [closure_eq_of_is_closed hs] using mem_closure_iff_nhds_within_ne_bot.2 hx
+by simpa only [hs.closure_eq] using mem_closure_iff_nhds_within_ne_bot.2 hx
 
 /-
 nhds_within and subtypes

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -182,7 +182,7 @@ mem_closure_iff_nhds_within_ne_bot.1 $ subset_closure hx
 
 lemma is_closed.mem_of_nhds_within_ne_bot {s : set α} (hs : is_closed s)
   {x : α} (hx : nhds_within x s ≠ ⊥) : x ∈ s :=
-by simpa only [hs.closure_eq] using mem_closure_iff_nhds_within_ne_bot.2 hx
+by simpa only [closure_eq_of_is_closed hs] using mem_closure_iff_nhds_within_ne_bot.2 hx
 
 /-
 nhds_within and subtypes
@@ -420,6 +420,11 @@ begin
   exact tendsto.comp hg this
 end
 
+lemma continuous_within_at.comp' {g : β → γ} {f : α → β} {s : set α} {t : set β} {x : α}
+  (hg : continuous_within_at g t (f x)) (hf : continuous_within_at f s x) :
+  continuous_within_at (g ∘ f) (s ∩ f⁻¹' t) x :=
+hg.comp (hf.mono (inter_subset_left _ _)) (inter_subset_right _ _)
+
 lemma continuous_on.comp {g : β → γ} {f : α → β} {s : set α} {t : set β}
   (hg : continuous_on g t) (hf : continuous_on f s) (h : s ⊆ f ⁻¹' t) :
   continuous_on (g ∘ f) s :=
@@ -428,6 +433,11 @@ lemma continuous_on.comp {g : β → γ} {f : α → β} {s : set α} {t : set �
 lemma continuous_on.mono {f : α → β} {s t : set α} (hf : continuous_on f s) (h : t ⊆ s)  :
   continuous_on f t :=
 λx hx, tendsto_le_left (nhds_within_mono _ h) (hf x (h hx))
+
+lemma continuous_on.comp' {g : β → γ} {f : α → β} {s : set α} {t : set β}
+  (hg : continuous_on g t) (hf : continuous_on f s) :
+  continuous_on (g ∘ f) (s ∩ f⁻¹' t) :=
+hg.comp (hf.mono (inter_subset_left _ _)) (inter_subset_right _ _)
 
 lemma continuous.continuous_on {f : α → β} {s : set α} (h : continuous f) :
   continuous_on f s :=
@@ -464,7 +474,7 @@ begin
     ... ⊆ f ⁻¹' t : preimage_mono hu
 end
 
-lemma continuous_within_at.congr_of_mem_nhds_within {f f₁ : α → β} {s : set α} {x : α}
+lemma continuous_within_at.congr_of_eventually_eq {f f₁ : α → β} {s : set α} {x : α}
   (h : continuous_within_at f s x) (h₁ : f₁ =ᶠ[nhds_within x s] f) (hx : f₁ x = f x) :
   continuous_within_at f₁ s x :=
 by rwa [continuous_within_at, filter.tendsto, hx, filter.map_congr h₁]
@@ -472,7 +482,7 @@ by rwa [continuous_within_at, filter.tendsto, hx, filter.map_congr h₁]
 lemma continuous_within_at.congr {f f₁ : α → β} {s : set α} {x : α}
   (h : continuous_within_at f s x) (h₁ : ∀y∈s, f₁ y = f y) (hx : f₁ x = f x) :
   continuous_within_at f₁ s x :=
-h.congr_of_mem_nhds_within (mem_sets_of_superset self_mem_nhds_within h₁) hx
+h.congr_of_eventually_eq (mem_sets_of_superset self_mem_nhds_within h₁) hx
 
 lemma continuous_on_const {s : set α} {c : β} : continuous_on (λx, c) s :=
 continuous_const.continuous_on


### PR DESCRIPTION
Use `eventually_eq` instead of `mem_sets` for congruence lemmas in continuity and differentiability statements.
