### PR TITLE
[Merged by Bors] - feat(data/sym2) Defining the symmetric square (unordered pairs)

### DIFF
--- a/src/data/sym.lean
+++ b/src/data/sym.lean
@@ -55,7 +55,7 @@ def sym' (α : Type*) (n : ℕ) := quotient (vector.perm.is_setoid α n)
 /--
 Multisets of cardinality n are equivalent to length-n vectors up to permutations.
 -/
-def sym_equiv_sym' (α : Type*) (n : ℕ) : equiv (sym α n) (sym' α n) :=
+def sym_equiv_sym' (α : Type*) (n : ℕ) : sym α n ≃ sym' α n :=
 equiv.subtype_quotient_equiv_quotient_subtype _ _ (λ _, by refl) (λ _ _, by refl)
 
 section inhabited

--- a/src/data/sym.lean
+++ b/src/data/sym.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2020 Kyle Miller All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Kyle Miller.
+-/
+
+import data.multiset.basic
+import data.vector
+import data.quot
+import tactic
+
+/-!
+# Symmetric powers
+
+This file defines symmetric powers of a type.  The nth symmetric power
+consists of homogeneous n-tuples modulo permutations by the symmetric
+group.
+
+The special case of 2-tuples is called the symmetric square, which is
+addressed in more detail in `data.sym2`.
+
+TODO: This was created as supporting material for `data.sym2`; it
+needs a fleshed-out interface.
+
+## Tags
+
+symmetric powers
+
+-/
+
+/--
+The nth symmetric power is n-tuples up to permutation.  We define it
+as a subtype of `multiset` since these are well developed in the
+library.  We also give a definition `sym.sym'` in terms of vectors, and we
+show these are equivalent in `sym.sym_equiv_sym'`.
+-/
+def sym (α : Type*) (n : ℕ) := {s : multiset α // s.card = n}
+
+/--
+This is the `list.perm` setoid lifted to `vector`.
+-/
+def vector.perm.is_setoid (α : Type*) (n : ℕ) : setoid (vector α n) :=
+{ r := λ a b, list.perm a.1 b.1,
+  iseqv := by { rcases list.perm.eqv α with ⟨hr, hs, ht⟩, tidy, } }
+
+local attribute [instance] vector.perm.is_setoid
+
+namespace sym
+
+/--
+Another definition of the nth symmetric power, using vectors modulo permutations. (See `sym`.)
+-/
+def sym' (α : Type*) (n : ℕ) := quotient (vector.perm.is_setoid α n)
+
+/--
+Multisets of cardinality n are equivalent to length-n vectors up to permutations.
+-/
+def sym_equiv_sym' (α : Type*) (n : ℕ) : equiv (sym α n) (sym' α n) :=
+equiv.subtype_quotient_equiv_quotient_subtype _ _ (λ _, by refl) (λ _ _, by refl)
+
+section inhabited
+-- Instances to make the linter happy
+
+variables (α : Type*)
+
+instance inhabited_sym [inhabited α] (n : ℕ) : inhabited (sym α n) :=
+⟨⟨multiset.repeat (default α) n, multiset.card_repeat _ _⟩⟩
+
+instance inhabited_sym' [inhabited α] (n : ℕ) : inhabited (sym' α n) :=
+⟨quotient.mk' (vector.repeat (default α) n)⟩
+
+end inhabited
+
+end sym

--- a/src/data/sym2.lean
+++ b/src/data/sym2.lean
@@ -14,6 +14,13 @@ open function
 This file defines symmetric squares, which is `α × α` modulo swapping.
 This is also known as the type of unordered pairs.
 
+From the point of view that an unordered pair is equivalent to a
+multiset of cardinality two, we have `sym2.mem` (the `has_mem`
+instance), which is a `Prop`-valued membership test.  Given `a ∈ z`
+for `z : sym2 α`, it does not appear to be possible, in general, to
+*computably* give the other element in the pair.  For this,
+`sym2.vmem a z` is a `Type`-valued predicate that contains this other
+element.
 
 ## Notation
 
@@ -26,100 +33,85 @@ symmetric square, unordered pairs
 -/
 
 namespace sym2
-universe u
-variables {α : Type u}
+variables {α : Type*}
 
 /--
 This is the relation capturing the notion of pairs equivalent up to permutations.
 -/
-inductive rel (α : Type u) : (α × α) → (α × α) → Prop
+inductive rel (α : Type*) : (α × α) → (α × α) → Prop
 | refl (x y : α) : rel (x, y) (x, y)
 | swap (x y : α) : rel (x, y) (y, x)
 
 attribute [refl] rel.refl
 
 @[symm] lemma rel.symm {x y : α × α} : rel α x y → rel α y x :=
-by { tidy, cases a, exact a, apply rel.swap }
+by { intro a, cases a, exact a, apply rel.swap }
 
 @[trans] lemma rel.trans {x y z : α × α} : rel α x y → rel α y z → rel α x z :=
-by { tidy, cases_matching* rel _ _ _; apply rel.refl <|> apply rel.swap }
+by { intros a b, cases_matching* rel _ _ _; apply rel.refl <|> apply rel.swap }
 
-instance rel.setoid (α : Type u) : setoid (α × α) :=
-by { use rel α, tidy, apply rel.trans a a_1 }
+instance rel.setoid (α : Type*) : setoid (α × α) :=
+by { use rel α,
+     split, { intros x, cases x, refl },
+     split, { apply rel.symm },
+     { intros x y z a b, apply rel.trans a b } }
+
+end sym2
 
 /--
 This is the type for the symmetric square (i.e., the type of unordered pairs).
 -/
 @[reducible]
-def sym2 (α : Type u) [h : setoid (α × α)] := quotient h
+def sym2 (α : Type*) := quotient (sym2.rel.setoid α)
+
+namespace sym2
+universe u
+variables {α : Type u}
 
 lemma eq_swap {a b : α} : ⟦(a, b)⟧ = ⟦(b, a)⟧ :=
 by { rw quotient.eq, apply rel.swap }
 
-lemma other_unique (a b c : α) : ⟦(a, b)⟧ = ⟦(a, c)⟧ ↔ b = c :=
+lemma congr_right (a b c : α) : ⟦(a, b)⟧ = ⟦(a, c)⟧ ↔ b = c :=
 begin
   split,
   intro h, rw quotient.eq at h, cases h; refl,
   intro h, apply congr_arg _ h,
 end
 
-/--
-A type `α` is naturally included in the diagonal of `α × α`, this function gives the image
-of this diagonal in `sym2 α`.
--/
-def incl (x : α) : sym2 α := ⟦(x, x)⟧
 
 /--
-Checks whether a given element of `sym2 α` is in the image of `incl`.
+The functor `sym2` is functorial, and this function constructs the induced maps.
 -/
-def is_diag (z : sym2 α) : Prop :=
-quotient.rec_on z (λ y, y.1 = y.2) (by { tidy, cases p; refl, cases p; refl })
-
-def image_incl_is_diag (z : sym2 α) (h : is_diag z) : ∃ x, z = incl x :=
-by tidy
-
-lemma diag_to_eq (x y : α) (h : is_diag ⟦(x, y)⟧) : x = y :=
-by tidy
-
-/--
-The functor `sym2` is functorial, and this constructs induced maps.
--/
-def induce {α β : Type u} (f : α → β) : sym2 α → sym2 β :=
-λ z, quotient.rec_on z (λ x, ⟦(f x.1, f x.2)⟧)
-begin
-  intros, rw [eq_rec_constant, quotient.eq],
-  cases p, refl, apply rel.swap,
+def map {α β : Type*} (f : α → β) : sym2 α → sym2 β :=
+quotient.map (prod.map f f) begin
+  rintros ⟨a₁, a₂⟩ ⟨b₁, b₂⟩ h,
+  cases h,
+  apply rel.refl,
+  apply rel.swap,
 end
 
 @[simp]
-def induce.id : sym2.induce (@id α) = id :=
+lemma map_id : sym2.map (@id α) = id :=
 by tidy
 
-def induce.functorial {α β γ: Type u} {g : β → γ} {f : α → β} : sym2.induce (g ∘ f) = sym2.induce g ∘ sym2.induce f :=
+lemma map_comp {α β γ: Type*} {g : β → γ} {f : α → β} : sym2.map (g ∘ f) = sym2.map g ∘ sym2.map f :=
 by tidy
-
-instance is_diag.decidable_pred (α : Type u) [decidable_eq α] : decidable_pred (@is_diag α) :=
-begin
-  intro x,
-  induction x,
-  solve_by_elim,
-  cases x_p,
-  simp only [],
-  apply subsingleton.elim,
-end
 
 section membership
 
 /-! ### Declarations about membership -/
 
 /--
-This is a predicate that determines whether a given term is a member of a term of the symmetric square.
-From this point of view, the symmetric square is the subtype of cardinality-two multisets on `α`.
+This is a predicate that determines whether a given term is a member of a term of the
+symmetric square.  From this point of view, the symmetric square is the subtype of
+cardinality-two multisets on `α`.
 -/
 def mem (x : α) (z : sym2 α) : Prop :=
 ∃ (y : α), z = ⟦(x, y)⟧
 
-def mk_has_mem (x y : α) : mem x ⟦(x, y)⟧ :=
+instance : has_mem α (sym2 α) := ⟨mem⟩
+
+lemma mk_has_mem (x y : α) : x ∈ ⟦(x, y)⟧ :=
 ⟨y, rfl⟩
 
 /--
@@ -131,8 +123,11 @@ def vmem (x : α) (z : sym2 α) : Type u :=
 {y : α // z = ⟦(x, y)⟧}
 
 instance (x : α) (z : sym2 α) : subsingleton {y : α // z = ⟦(x, y)⟧} :=
-⟨by { rintros ⟨a, ha⟩ ⟨b, hb⟩, rw ha at hb, rw other_unique at hb, tidy, }⟩
+⟨by { rintros ⟨a, ha⟩ ⟨b, hb⟩, rw ha at hb, rw congr_right at hb, tidy, }⟩
 
+/--
+The `vmem` version of `mk_has_mem`.
+-/
 def mk_has_vmem (x y : α) : vmem x ⟦(x, y)⟧ :=
 ⟨y, rfl⟩
 
@@ -141,41 +136,78 @@ instance {a : α} {z : sym2 α} : has_lift (vmem a z) (mem a z) := ⟨λ h, ⟨h
 /--
 Given an element of a term of the symmetric square (using `vmem`), retrieve the other element.
 -/
-lemma other {a : α} {p : sym2 α} (h : vmem a p) : α := h.val
+def vmem.other {a : α} {p : sym2 α} (h : vmem a p) : α := h.val
 
 /--
 The defining property of the other element is that it can be used to
 reconstruct the term of the symmetric square.
 -/
-lemma other_spec (a : α) (z : sym2 α) (h : vmem a z) : z = ⟦(a, other h)⟧ :=
-by { dunfold other, tidy, }
+lemma vmem_other_spec {a : α} {z : sym2 α} (h : vmem a z) : z = ⟦(a, h.other)⟧ :=
+by { dunfold vmem.other, tidy, }
 
 /--
 This is the `mem`-based version of `other`.
 -/
-noncomputable
-lemma mem_other {a : α} {z : sym2 α} (h : mem a z) : α :=
+noncomputable def mem.other {a : α} {z : sym2 α} (h : a ∈ z) : α :=
 classical.some h
 
-lemma mem_other_spec (a : α) (z : sym2 α) (h : mem a z) : ⟦(a, mem_other h)⟧ = z :=
+lemma mem_other_spec {a : α} {z : sym2 α} (h : a ∈ z) :
+  ⟦(a, h.other)⟧ = z :=
 begin
-  dunfold mem_other,
+  dunfold mem.other,
   exact (classical.some_spec h).symm,
 end
 
-lemma other_is_mem_other {a : α} {z : sym2 α} (h : vmem a z) (h' : mem a z) :
-  other h = mem_other h' :=
-by rw [←other_unique a, ←other_spec a z, mem_other_spec]
+lemma other_is_mem_other {a : α} {z : sym2 α} (h : vmem a z) (h' : a ∈ z) :
+  h.other = mem.other h' :=
+by rw [←congr_right a, ←vmem_other_spec h, mem_other_spec]
 
-lemma eq {x y z w : α} (h : ⟦(x, y)⟧ = ⟦(z, w)⟧):
-  (x = z ∧ y = w) ∨ (x = w ∧ y = z) :=
-by { rw quotient.eq at h, cases h; tidy }
+lemma eq_pairs {x y z w : α} :
+  ⟦(x, y)⟧ = ⟦(z, w)⟧ ↔ (x = z ∧ y = w) ∨ (x = w ∧ y = z) :=
+by { split; intro h,
+     { rw quotient.eq at h, cases h; tidy, },
+     { cases h; rw [h.1, h.2], rw eq_swap, } }
 
-lemma is_one_of {a b c : α} (h : mem a ⟦(b, c)⟧) : a = b ∨ a = c :=
-by { cases h, have p := eq h_h, tidy }
+lemma mem_iff {a b c : α} : a ∈ ⟦(b, c)⟧ ↔ a = b ∨ a = c :=
+begin
+  split,
+  { intro h, cases h, rw eq_pairs at h_h, tidy },
+  { intro h, cases h, rw h, apply mk_has_mem,
+    rw h, rw eq_swap, apply mk_has_mem, }
+end
 
 end membership
 
+/--
+A type `α` is naturally included in the diagonal of `α × α`, this function gives the image
+of this diagonal in `sym2 α`.
+-/
+def diag (x : α) : sym2 α := ⟦(x, x)⟧
+
+/--
+A predicate for testing whether an element of `sym2 α` is on the diagonal.
+-/
+def is_diag (z : sym2 α) : Prop :=
+z ∈ set.range (@diag α)
+
+lemma is_diag_iff_proj_eq (z : α × α) : is_diag ⟦z⟧ ↔ z.1 = z.2 :=
+begin
+  cases z with a b,
+  split,
+  { intro h, cases h with x h, dsimp [diag] at h,
+    cases eq_pairs.mp h with h h; rw [←h.1, ←h.2], },
+  { intro h, dsimp at h, rw h, use b, simp [diag], },
+end
+
+instance is_diag.decidable_pred (α : Type u) [decidable_eq α] : decidable_pred (@is_diag α) :=
+begin
+  intro z,
+  induction z,
+  change decidable (is_diag ⟦z⟧),
+  rw is_diag_iff_proj_eq,
+  apply_instance,
+  apply subsingleton.elim,
+end
 
 section relations
 
@@ -183,17 +215,20 @@ section relations
 
 variables {r : α → α → Prop}
 
-def in_rel (sym : symmetric r) (z : sym2 α) : Prop :=
-quotient.rec_on z (λ z, r z.1 z.2) (begin
+/--
+Symmetric relations define a set on `sym2 α` by taking all those elements that are related.
+-/
+def from_rel (sym : symmetric r) : set (sym2 α) :=
+(λ z, quotient.rec_on z (λ z, r z.1 z.2) (begin
   intros z w p,
   cases p,
   simp,
   simp,
   split; apply sym,
-end)
+end))
 
 @[simp]
-lemma in_rel_prop {sym : symmetric r} {a b : α} : in_rel sym ⟦(a, b)⟧ ↔ r a b :=
+lemma from_rel_prop {sym : symmetric r} {a b : α} : ⟦(a, b)⟧ ∈ from_rel sym  ↔ r a b :=
 by tidy
 
 end relations

--- a/src/data/sym2.lean
+++ b/src/data/sym2.lean
@@ -273,7 +273,7 @@ section multiset_equiv
 In more generality, the nth symmetric power is n-tuples up to
 permutation.  We define it as a subtype of `multiset` since these are
 well developed in the library.  We also give a definition `sym'` in terms of
-vectors, and show these are equivalent in `sym2_equiv_sym'`.
+vectors, and we show these are equivalent in `sym_equiv_sym'`.
 -/
 def sym (α : Type*) (n : ℕ) := {s : multiset α // s.card = n}
 
@@ -368,8 +368,7 @@ instance inhabited_vmem [inhabited α] : inhabited (vmem (default α) (diag (def
 ⟨⟨default α, rfl⟩⟩
 
 instance inhabited_sym [inhabited α] (n : ℕ) : inhabited (sym α n) :=
-⟨⟨list.repeat (default α) n,
-  by { simp only [multiset.coe_card, list.length_repeat] }⟩⟩
+⟨⟨multiset.repeat (default α) n, multiset.card_repeat _ _⟩⟩
 
 instance inhabited_sym' [inhabited α] (n : ℕ) : inhabited (sym' α n) :=
 ⟨quotient.mk' (vector.repeat (default α) n)⟩

--- a/src/data/sym2.lean
+++ b/src/data/sym2.lean
@@ -22,6 +22,11 @@ for `z : sym2 α`, it does not appear to be possible, in general, to
 `sym2.vmem a z` is a `Type`-valued predicate that contains this other
 element.
 
+Recall that an undirected graph (allowing self loops, but no multiple
+edges) is equivalent to a symmetric relation on the vertex type `α`.
+Given a symmetric relation on `α`, the corresponding edge set is
+constructed by `sym2.from_rel`.
+
 ## Notation
 
 The symmetric square has a setoid instance, so `⟦(a, b)⟧` denotes a
@@ -216,7 +221,8 @@ section relations
 variables {r : α → α → Prop}
 
 /--
-Symmetric relations define a set on `sym2 α` by taking all those elements that are related.
+Symmetric relations define a set on `sym2 α` by taking all those pairs
+of elements that are related.
 -/
 def from_rel (sym : symmetric r) : set (sym2 α) :=
 (λ z, quotient.rec_on z (λ z, r z.1 z.2) (begin
@@ -228,8 +234,29 @@ def from_rel (sym : symmetric r) : set (sym2 α) :=
 end))
 
 @[simp]
-lemma from_rel_prop {sym : symmetric r} {a b : α} : ⟦(a, b)⟧ ∈ from_rel sym  ↔ r a b :=
+lemma from_rel_proj_prop {sym : symmetric r} {z : α × α} : ⟦z⟧ ∈ from_rel sym ↔ r z.1 z.2 :=
 by tidy
+
+@[simp]
+lemma from_rel_prop {sym : symmetric r} {a b : α} : ⟦(a, b)⟧ ∈ from_rel sym ↔ r a b :=
+by simp only [from_rel_proj_prop]
+
+@[simp]
+lemma from_rel_irreflexive {sym : symmetric r} : irreflexive r ↔ ∀{z}, z ∈ from_rel sym → ¬is_diag z :=
+begin
+  split,
+  { intros h z hr hd,
+    induction z,
+    change ⟦z⟧ ∈ _ at hr,
+    change is_diag ⟦z⟧ at hd,
+    rw is_diag_iff_proj_eq at hd,
+    rw [from_rel_proj_prop, hd] at hr,
+    exact h _ hr,
+    refl, },
+  { intros h x hr,
+    rw ← @from_rel_prop _ _ sym at hr,
+    exact h hr ⟨x, rfl⟩, }
+end
 
 end relations
 

--- a/src/data/sym2.lean
+++ b/src/data/sym2.lean
@@ -62,11 +62,15 @@ by { intro a, cases a, exact a, apply rel.swap }
 @[trans] lemma rel.trans {x y z : α × α} : rel α x y → rel α y z → rel α x z :=
 by { intros a b, cases_matching* rel _ _ _; apply rel.refl <|> apply rel.swap }
 
+lemma rel.is_equivalence : equivalence (rel α) :=
+begin
+  split, { intros x, cases x, refl },
+  split, { apply rel.symm },
+  { intros x y z a b, apply rel.trans a b },
+end
+
 instance rel.setoid (α : Type*) : setoid (α × α) :=
-by { use rel α,
-     split, { intros x, cases x, refl },
-     split, { apply rel.symm },
-     { intros x y z a b, apply rel.trans a b } }
+⟨rel α, rel.is_equivalence⟩
 
 end sym2
 
@@ -180,9 +184,11 @@ by rw [←congr_right a, ←vmem_other_spec h, mem_other_spec]
 
 lemma eq_iff {x y z w : α} :
   ⟦(x, y)⟧ = ⟦(z, w)⟧ ↔ (x = z ∧ y = w) ∨ (x = w ∧ y = z) :=
-by { split; intro h,
-     { rw quotient.eq at h, cases h; tidy, },
-     { cases h; rw [h.1, h.2], rw eq_swap, } }
+begin
+  split; intro h,
+  { rw quotient.eq at h, cases h; tidy, },
+  { cases h; rw [h.1, h.2], rw eq_swap, }
+end
 
 lemma mem_iff {a b c : α} : a ∈ ⟦(b, c)⟧ ↔ a = b ∨ a = c :=
 begin
@@ -236,13 +242,14 @@ Symmetric relations define a set on `sym2 α` by taking all those pairs
 of elements that are related.
 -/
 def from_rel (sym : symmetric r) : set (sym2 α) :=
-(λ z, quotient.rec_on z (λ z, r z.1 z.2) (begin
+λ z, quotient.rec_on z (λ z, r z.1 z.2)
+begin
   intros z w p,
   cases p,
   simp,
   simp,
   split; apply sym,
-end))
+end
 
 @[simp]
 lemma from_rel_proj_prop {sym : symmetric r} {z : α × α} : ⟦z⟧ ∈ from_rel sym ↔ r z.1 z.2 :=
@@ -327,8 +334,7 @@ def sym2_equiv_sym' {α : Type*} : equiv (sym2 α) (sym' α 2) :=
     cases x with x2 x, swap, simp at hx, exfalso, linarith [hx],
     refl,
     refl,
-  end
-}
+  end }
 
 /--
 The symmetric square is equivalent to the second symmetric power.

--- a/src/data/sym2.lean
+++ b/src/data/sym2.lean
@@ -359,4 +359,21 @@ equiv.trans sym2_equiv_sym' (sym_equiv_sym' α 2).symm
 
 end multiset_equiv
 
+
+section inhabited
+
+-- Instances to make the linter happy
+
+instance inhabited_vmem [inhabited α] : inhabited (vmem (default α) (diag (default α))) :=
+⟨⟨default α, rfl⟩⟩
+
+instance inhabited_sym [inhabited α] (n : ℕ) : inhabited (sym α n) :=
+⟨⟨list.repeat (default α) n,
+  by { simp only [multiset.coe_card, list.length_repeat] }⟩⟩
+
+instance inhabited_sym' [inhabited α] (n : ℕ) : inhabited (sym' α n) :=
+⟨quotient.mk' (vector.repeat (default α) n)⟩
+
+end inhabited
+
 end sym2

--- a/src/data/sym2.lean
+++ b/src/data/sym2.lean
@@ -139,6 +139,7 @@ This is a type-valued version of the membership predicate `mem` that contains th
 element `y` of `z` such that `z = ⟦(x, y)⟧`.  It is a subsingleton already,
 so there is no need to apply `trunc` to the type.
 -/
+@[nolint has_inhabited_instance]
 def vmem (x : α) (z : sym2 α) : Type u :=
 {y : α // z = ⟦(x, y)⟧}
 
@@ -351,14 +352,5 @@ def equiv_multiset (α : Type*) : sym2 α ≃ {s : multiset α // s.card = 2} :=
 equiv_sym α
 
 end sym_equiv
-
-section inhabited
-
--- Instances to make the linter happy
-
-instance inhabited_vmem [inhabited α] : inhabited (vmem (default α) (diag (default α))) :=
-⟨⟨default α, rfl⟩⟩
-
-end inhabited
 
 end sym2

--- a/src/data/sym2.lean
+++ b/src/data/sym2.lean
@@ -241,8 +241,8 @@ by tidy
 lemma from_rel_prop {sym : symmetric r} {a b : α} : ⟦(a, b)⟧ ∈ from_rel sym ↔ r a b :=
 by simp only [from_rel_proj_prop]
 
-@[simp]
-lemma from_rel_irreflexive {sym : symmetric r} : irreflexive r ↔ ∀{z}, z ∈ from_rel sym → ¬is_diag z :=
+lemma from_rel_irreflexive {sym : symmetric r} :
+  irreflexive r ↔ ∀ {z}, z ∈ from_rel sym → ¬is_diag z :=
 begin
   split,
   { intros h z hr hd,

--- a/src/data/sym2.lean
+++ b/src/data/sym2.lean
@@ -1,0 +1,201 @@
+/-
+Copyright (c) 2020 Kyle Miller All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Kyle Miller.
+-/
+
+import data.quot
+import tactic
+open function
+
+/-!
+# The symmetric square
+
+This file defines symmetric squares, which is `α × α` modulo swapping.
+This is also known as the type of unordered pairs.
+
+
+## Notation
+
+The symmetric square has a setoid instance, so `⟦(a, b)⟧` denotes a
+term of the symmetric square.
+
+## Tags
+
+symmetric square, unordered pairs
+-/
+
+namespace sym2
+universe u
+variables {α : Type u}
+
+/--
+This is the relation capturing the notion of pairs equivalent up to permutations.
+-/
+inductive rel (α : Type u) : (α × α) → (α × α) → Prop
+| refl (x y : α) : rel (x, y) (x, y)
+| swap (x y : α) : rel (x, y) (y, x)
+
+attribute [refl] rel.refl
+
+@[symm] lemma rel.symm {x y : α × α} : rel α x y → rel α y x :=
+by { tidy, cases a, exact a, apply rel.swap }
+
+@[trans] lemma rel.trans {x y z : α × α} : rel α x y → rel α y z → rel α x z :=
+by { tidy, cases_matching* rel _ _ _; apply rel.refl <|> apply rel.swap }
+
+instance rel.setoid (α : Type u) : setoid (α × α) :=
+by { use rel α, tidy, apply rel.trans a a_1 }
+
+/--
+This is the type for the symmetric square (i.e., the type of unordered pairs).
+-/
+@[reducible]
+def sym2 (α : Type u) [h : setoid (α × α)] := quotient h
+
+lemma eq_swap {a b : α} : ⟦(a, b)⟧ = ⟦(b, a)⟧ :=
+by { rw quotient.eq, apply rel.swap }
+
+lemma other_unique (a b c : α) : ⟦(a, b)⟧ = ⟦(a, c)⟧ ↔ b = c :=
+begin
+  split,
+  intro h, rw quotient.eq at h, cases h; refl,
+  intro h, apply congr_arg _ h,
+end
+
+/--
+A type `α` is naturally included in the diagonal of `α × α`, this function gives the image
+of this diagonal in `sym2 α`.
+-/
+def incl (x : α) : sym2 α := ⟦(x, x)⟧
+
+/--
+Checks whether a given element of `sym2 α` is in the image of `incl`.
+-/
+def is_diag (z : sym2 α) : Prop :=
+quotient.rec_on z (λ y, y.1 = y.2) (by { tidy, cases p; refl, cases p; refl })
+
+def image_incl_is_diag (z : sym2 α) (h : is_diag z) : ∃ x, z = incl x :=
+by tidy
+
+lemma diag_to_eq (x y : α) (h : is_diag ⟦(x, y)⟧) : x = y :=
+by tidy
+
+/--
+The functor `sym2` is functorial, and this constructs induced maps.
+-/
+def induce {α β : Type u} (f : α → β) : sym2 α → sym2 β :=
+λ z, quotient.rec_on z (λ x, ⟦(f x.1, f x.2)⟧)
+begin
+  intros, rw [eq_rec_constant, quotient.eq],
+  cases p, refl, apply rel.swap,
+end
+
+@[simp]
+def induce.id : sym2.induce (@id α) = id :=
+by tidy
+
+def induce.functorial {α β γ: Type u} {g : β → γ} {f : α → β} : sym2.induce (g ∘ f) = sym2.induce g ∘ sym2.induce f :=
+by tidy
+
+instance is_diag.decidable_pred (α : Type u) [decidable_eq α] : decidable_pred (@is_diag α) :=
+begin
+  intro x,
+  induction x,
+  solve_by_elim,
+  cases x_p,
+  simp only [],
+  apply subsingleton.elim,
+end
+
+section membership
+
+/-! ### Declarations about membership -/
+
+/--
+This is a predicate that determines whether a given term is a member of a term of the symmetric square.
+From this point of view, the symmetric square is the subtype of cardinality-two multisets on `α`.
+-/
+def mem (x : α) (z : sym2 α) : Prop :=
+∃ (y : α), z = ⟦(x, y)⟧
+
+def mk_has_mem (x y : α) : mem x ⟦(x, y)⟧ :=
+⟨y, rfl⟩
+
+/--
+This is a type-valued version of the membership predicate `mem` that contains the other
+element `y` of `z` such that `z = ⟦(x, y)⟧`.  It is a subsingleton already,
+so there is no need to apply `trunc` to the type.
+-/
+def vmem (x : α) (z : sym2 α) : Type u :=
+{y : α // z = ⟦(x, y)⟧}
+
+instance (x : α) (z : sym2 α) : subsingleton {y : α // z = ⟦(x, y)⟧} :=
+⟨by { rintros ⟨a, ha⟩ ⟨b, hb⟩, rw ha at hb, rw other_unique at hb, tidy, }⟩
+
+def mk_has_vmem (x y : α) : vmem x ⟦(x, y)⟧ :=
+⟨y, rfl⟩
+
+instance {a : α} {z : sym2 α} : has_lift (vmem a z) (mem a z) := ⟨λ h, ⟨h.val, h.property⟩⟩
+
+/--
+Given an element of a term of the symmetric square (using `vmem`), retrieve the other element.
+-/
+lemma other {a : α} {p : sym2 α} (h : vmem a p) : α := h.val
+
+/--
+The defining property of the other element is that it can be used to
+reconstruct the term of the symmetric square.
+-/
+lemma other_spec (a : α) (z : sym2 α) (h : vmem a z) : z = ⟦(a, other h)⟧ :=
+by { dunfold other, tidy, }
+
+/--
+This is the `mem`-based version of `other`.
+-/
+noncomputable
+lemma mem_other {a : α} {z : sym2 α} (h : mem a z) : α :=
+classical.some h
+
+lemma mem_other_spec (a : α) (z : sym2 α) (h : mem a z) : ⟦(a, mem_other h)⟧ = z :=
+begin
+  dunfold mem_other,
+  exact (classical.some_spec h).symm,
+end
+
+lemma other_is_mem_other {a : α} {z : sym2 α} (h : vmem a z) (h' : mem a z) :
+  other h = mem_other h' :=
+by rw [←other_unique a, ←other_spec a z, mem_other_spec]
+
+lemma eq {x y z w : α} (h : ⟦(x, y)⟧ = ⟦(z, w)⟧):
+  (x = z ∧ y = w) ∨ (x = w ∧ y = z) :=
+by { rw quotient.eq at h, cases h; tidy }
+
+lemma is_one_of {a b c : α} (h : mem a ⟦(b, c)⟧) : a = b ∨ a = c :=
+by { cases h, have p := eq h_h, tidy }
+
+end membership
+
+
+section relations
+
+/-! ### Declarations about symmetric relations -/
+
+variables {r : α → α → Prop}
+
+def in_rel (sym : symmetric r) (z : sym2 α) : Prop :=
+quotient.rec_on z (λ z, r z.1 z.2) (begin
+  intros z w p,
+  cases p,
+  simp,
+  simp,
+  split; apply sym,
+end)
+
+@[simp]
+lemma in_rel_prop {sym : symmetric r} {a b : α} : in_rel sym ⟦(a, b)⟧ ↔ r a b :=
+by tidy
+
+end relations
+
+end sym2


### PR DESCRIPTION
This adds a type for the symmetric square of a type, which is the quotient of the cartesian square by permutations.  These are also known as unordered pairs.

Additionally, this provides some definitions and lemmas for equalities, functoriality, membership, and a relationship between symmetric relations and terms of the symmetric square.

I preferred `sym2` over `unordered_pairs` out of a combination of familiarity and brevity, but I could go either way for naming.


---
<!-- put comments you want to keep out of the PR commit here -->
