### PR TITLE
[Merged by Bors] - doc(tactic/explode): expand doc string

### DIFF
--- a/src/tactic/explode.lean
+++ b/src/tactic/explode.lean
@@ -167,10 +167,11 @@ proof displays like [this](http://us.metamath.org/mpeuni/ru.html). The headers o
 * Ref: The name of the theorem being applied. This is well-defined in Metamath, but in Lean there
   are some special steps that may have long names because the structure of proof terms doesn't
   exactly match this mold.
-  * If the theorem is `foo (x y : Z) : A x -> B y -> C x y` the Ref field will contain `foo`, `x`
-    and `y` will be suppressed (because term construction is not interesting), while the Hyp field
-    will reference steps proving `A x` and `B y`. This corresponds to a proof term like
-    `@foo x y pA pB` where `pA` and `pB` are subproofs.
+  * If the theorem is `foo (x y : Z) : A x -> B y -> C x y`:
+    * the Ref field will contain `foo`,
+    * `x` and `y` will be suppressed, because term construction is not interesting, and
+    * the Hyp field will reference steps proving `A x` and `B y`. This corresponds to a proof term
+      like `@foo x y pA pB` where `pA` and `pB` are subproofs.
   * If the head of the proof term is a local constant or lambda, then in this case the Ref will
     say `∀E` for forall-elimination. This happens when you have for example `h : A -> B` and
     `ha : A` and prove `b` by `h ha`; we reinterpret this as if it said `∀E h ha` where `∀E` is

--- a/src/tactic/explode.lean
+++ b/src/tactic/explode.lean
@@ -204,7 +204,4 @@ add_tactic_doc
   decl_names := [`tactic.explode_cmd],
   tags       := ["proof display"] }
 
--- #explode iff_true_intro
--- #explode nat.strong_rec_on
-
 end tactic


### PR DESCRIPTION
Explanation copied from @digama0's Zulip message [here](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/.23explode.20error/near/202396813). Also removed a redundant function and added some type ascriptions.

Co-authored-by: Mario Carneiro <di.gama@gmail.com>

---
<!-- put comments you want to keep out of the PR commit here -->
