### PR TITLE
[Merged by Bors] - fix(tactic/default): import tactic.basic

### DIFF
--- a/src/tactic/default.lean
+++ b/src/tactic/default.lean
@@ -17,6 +17,7 @@ As (non-exhaustive) examples, these includes things like:
 * data.equiv.encodable
 * order.complete_lattice
 -/
+import tactic.basic -- ensure basic tactics are available
 import tactic.abel
 import tactic.ring_exp
 import tactic.noncomm_ring


### PR DESCRIPTION
Some basic tactics and commands (e.g. `#explode`) were not available even if `import tactic` was used. I added `import tactic.basic` to `tactic/default.lean` to remedy this.

---
<!-- put comments you want to keep out of the PR commit here -->

Reported by @stanescuUW [on Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/library_search.20in.203.2E16.2E5/near/202850388).