### PR TITLE
[Merged by Bors] - refactor(order/*): make `data.set.basic` import `order.bounded_lattice`

### DIFF
--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -388,13 +388,7 @@ lemma add_eq_top [ordered_add_comm_monoid α] (a b : with_top α) : a + b = ⊤ 
 by cases a; cases b; simp [none_eq_top, some_eq_coe, coe_add.symm]
 
 lemma add_lt_top [ordered_add_comm_monoid α] (a b : with_top α) : a + b < ⊤ ↔ a < ⊤ ∧ b < ⊤ :=
-begin
-  apply not_iff_not.1,
-  simp [lt_top_iff_ne_top, add_eq_top],
-  finish,
-  apply classical.dec _,
-  apply classical.dec _,
-end
+by simp [lt_top_iff_ne_top, add_eq_top, not_or_distrib]
 
 end with_top
 

--- a/src/data/equiv/encodable.lean
+++ b/src/data/equiv/encodable.lean
@@ -8,6 +8,8 @@ Note that every encodable Type is countable.
 -/
 import data.equiv.nat
 import order.order_iso
+import order.directed
+
 open option list nat function
 
 /-- An encodable type is a "constructively countable" type. This is where

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -3,8 +3,10 @@ Copyright (c) 2014 Floris van Doorn (c) 2016 Microsoft Corporation. All rights r
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
+import tactic.finish
 import algebra.ordered_ring
 import algebra.order_functions
+import data.set.basic
 
 /-!
 # Basic operations on the natural numbers
@@ -83,6 +85,13 @@ instance : canonically_ordered_comm_semiring ℕ :=
   .. (infer_instance : ordered_add_comm_monoid ℕ),
   .. (infer_instance : linear_ordered_semiring ℕ),
   .. (infer_instance : comm_semiring ℕ) }
+
+instance nat.subtype.semilattice_sup_bot (s : set ℕ) [decidable_pred s] [h : nonempty s] :
+  semilattice_sup_bot s :=
+{ bot := ⟨nat.find (nonempty_subtype.1 h), nat.find_spec (nonempty_subtype.1 h)⟩,
+  bot_le := λ x, nat.find_min' _ x.2,
+  ..subtype.linear_order s,
+  ..lattice_of_decidable_linear_order }
 
 namespace nat
 variables {m n k : ℕ}

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -7,10 +7,8 @@ import tactic.push_neg
 import tactic.split_ifs
 import tactic.simpa
 import tactic.finish
-import data.subtype
 import logic.unique
-import data.prod
-import logic.function.basic
+import order.boolean_algebra
 
 /-!
 # Basic properties of sets
@@ -84,19 +82,31 @@ open function
 
 universe variables u v w x
 
-/-- Set / lattice complement -/
-class has_compl (α : Type*) := (compl : α → α)
-
-export has_compl (compl)
-
-postfix `ᶜ`:(max+1) := compl
-
 run_cmd do e ← tactic.get_env,
   tactic.set_env $ e.mk_protected `set.compl
 
-instance {α : Type*} : has_compl (set α) := ⟨set.compl⟩
-
 namespace set
+
+variable {α : Type*}
+
+instance : has_le (set α) := ⟨(⊆)⟩
+instance : has_lt (set α) := ⟨λ s t, s ≤ t ∧ ¬t ≤ s⟩
+
+instance {α : Type*} : boolean_algebra (set α) :=
+{ sup := (∪),
+  le  := (≤),
+  lt  := (<),
+  inf := (∩),
+  bot := ∅,
+  compl := set.compl,
+  top := univ,
+  sdiff := (\),
+  .. (infer_instance : boolean_algebra (α → Prop)) }
+
+@[simp] lemma bot_eq_empty : (⊥ : set α) = ∅ := rfl
+@[simp] lemma sup_eq_union (s t : set α) : s ⊔ t = s ∪ t := rfl
+@[simp] lemma inf_eq_inter (s t : set α) : s ⊓ t = s ∩ t := rfl
+@[simp] lemma le_eq_subset (s t : set α) : s ≤ t = (s ⊆ t) := rfl
 
 /-- Coercion from a set to the corresponding subtype. -/
 instance {α : Type*} : has_coe_to_sort (set α) := ⟨_, λ s, {x // x ∈ s}⟩
@@ -208,10 +218,9 @@ by simp [subset_def, classical.not_forall]
 
 /-! ### Definition of strict subsets `s ⊂ t` and basic properties. -/
 
-/-- `s ⊂ t` means that `s` is a strict subset of `t`, that is, `s ⊆ t` but `s ≠ t`. -/
-def strict_subset (s t : set α) := s ⊆ t ∧ ¬ (t ⊆ s)
+instance : has_ssubset (set α) := ⟨(<)⟩
 
-instance : has_ssubset (set α) := ⟨strict_subset⟩
+@[simp] lemma lt_eq_ssubset (s t : set α) : s < t = (s ⊂ t) := rfl
 
 theorem ssubset_def : (s ⊂ t) = (s ⊆ t ∧ ¬ (t ⊆ s)) := rfl
 
@@ -1514,7 +1523,7 @@ funext $ λ i, rfl
 lemma surjective_onto_range : surjective (range_factorization f) :=
 λ ⟨_, ⟨i, rfl⟩⟩, ⟨i, rfl⟩
 
-lemma image_eq_range (f : α → β) (s : set α) : f '' s = range (λ(x : s), f x.1) :=
+lemma image_eq_range (f : α → β) (s : set α) : f '' s = range (λ(x : s), f x) :=
 by { ext, split, rintro ⟨x, h1, h2⟩, exact ⟨⟨x, h1⟩, h2⟩, rintro ⟨⟨x, h1⟩, h2⟩, exact ⟨x, h1, h2⟩ }
 
 @[simp] lemma sum.elim_range {α β γ : Type*} (f : α → γ) (g : β → γ) :

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -7,6 +7,7 @@ import tactic.tauto
 import tactic.localized
 import algebra.order_functions
 import algebra.ordered_field
+import data.set.basic
 
 /-!
 # Intervals

--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -8,6 +8,7 @@ Authors: Jeremy Avigad, Leonardo de Moura, Johannes Hölzl, Mario Carneiro
 import order.complete_boolean_algebra
 import data.sigma.basic
 import order.galois_connection
+import order.directed
 
 open function tactic set auto
 
@@ -17,13 +18,7 @@ variables {α : Type u} {β : Type v} {γ : Type w} {ι : Sort x} {ι' : Sort y}
 namespace set
 
 instance lattice_set : complete_lattice (set α) :=
-{ le     := (⊆),
-  lt     := (⊂),
-  sup    := (∪),
-  inf    := (∩),
-  top    := univ,
-  bot    := ∅,
-  Sup    := λs, {a | ∃ t ∈ s, a ∈ t },
+{ Sup    := λs, {a | ∃ t ∈ s, a ∈ t },
   Inf    := λs, {a | ∀ t ∈ s, a ∈ t },
 
   le_Sup := assume s t t_in a a_in, ⟨t, ⟨t_in, a_in⟩⟩,
@@ -31,16 +26,9 @@ instance lattice_set : complete_lattice (set α) :=
 
   le_Inf := assume s t h a a_in t' t'_in, h t' t'_in a_in,
   Inf_le := assume s t t_in a h, h _ t_in,
+
+  .. set.boolean_algebra,
   .. (infer_instance : complete_lattice (α → Prop)) }
-
-instance : distrib_lattice (set α) :=
-{ le_sup_inf := λ s t u x, or_and_distrib_left.2, ..set.lattice_set }
-
-@[simp] lemma bot_eq_empty : (⊥ : set α) = ∅ := rfl
-@[simp] lemma sup_eq_union (s t : set α) : s ⊔ t = s ∪ t := rfl
-@[simp] lemma inf_eq_inter (s t : set α) : s ⊓ t = s ∩ t := rfl
-@[simp] lemma le_eq_subset (s t : set α) : s ≤ t = (s ⊆ t) := rfl
-@[simp] lemma lt_eq_ssubset (s t : set α) : s < t = (s ⊂ t) := rfl
 
 /-- Image is monotone. See `set.image_image` for the statement in terms of `⊆`. -/
 lemma monotone_image {f : α → β} : monotone (image f) :=
@@ -541,10 +529,6 @@ set.ext $ λ x, by simp [bool.forall_bool, and_comm]
 instance : complete_boolean_algebra (set α) :=
 { compl               := compl,
   sdiff               := (\),
-  le_sup_inf          := distrib_lattice.le_sup_inf,
-  inf_compl_eq_bot    := assume s, ext $ assume x, ⟨assume ⟨h, nh⟩, nh h, false.elim⟩,
-  sup_compl_eq_top    := assume s, ext $ assume x, ⟨assume h, trivial, assume _, classical.em $ x ∈ s⟩,
-  sdiff_eq            := assume x y, rfl,
   infi_sup_le_sup_Inf := assume s t x, show x ∈ (⋂ b ∈ t, s ∪ b) → x ∈ s ∪ (⋂₀ t),
     by simp; exact assume h,
       or.imp_right
@@ -552,7 +536,7 @@ instance : complete_boolean_algebra (set α) :=
         (classical.em $ x ∈ s),
   inf_Sup_le_supr_inf := assume s t x, show x ∈ s ∩ (⋃₀ t) → x ∈ (⋃ b ∈ t, s ∩ b),
     by simp [-and_imp, and.left_comm],
-  ..set.lattice_set }
+  .. set.boolean_algebra, .. set.lattice_set }
 
 lemma sInter_union_sInter {S T : set (set α)} :
   (⋂₀S) ∪ (⋂₀T) = (⋂p ∈ set.prod S T, (p : (set α) × (set α)).1 ∪ p.2) :=

--- a/src/data/setoid/basic.lean
+++ b/src/data/setoid/basic.lean
@@ -165,11 +165,10 @@ end
     supremum of the set's image under the map to the underlying binary operation. -/
 lemma Sup_def {s : set (setoid α)} : Sup s = eqv_gen.setoid (Sup (rel '' s)) :=
 begin
-  rw Sup_eq_eqv_gen,
+  rw [Sup_eq_eqv_gen, Sup_image],
   congr,
   ext x y,
-  erw [Sup_image, supr_apply, supr_apply, supr_Prop_eq],
-  simp only [Sup_image, supr_Prop_eq, supr_apply, supr_Prop_eq, exists_prop]
+  simp only [supr_apply, supr_Prop_eq, exists_prop]
 end
 
 /-- The equivalence closure of an equivalence relation r is r. -/

--- a/src/group_theory/congruence.lean
+++ b/src/group_theory/congruence.lean
@@ -103,6 +103,8 @@ instance : inhabited (con M) :=
 @[to_additive "A coercion from an additive congruence relation to its underlying binary relation."]
 instance : has_coe_to_fun (con M) := ⟨_, λ c, λ x y, c.r x y⟩
 
+@[simp, to_additive] lemma rel_eq_coe (c : con M) : c.r = c := rfl
+
 /-- Congruence relations are reflexive. -/
 @[to_additive "Additive congruence relations are reflexive."]
 protected lemma refl (x) : c x x := c.2.1 x
@@ -441,12 +443,10 @@ additive congruence relation containing the supremum of the set's image under th
 underlying binary relation."]
 lemma Sup_def {S : set (con M)} : Sup S = con_gen (Sup (r '' S)) :=
 begin
-  rw Sup_eq_con_gen,
+  rw [Sup_eq_con_gen, Sup_image],
   congr,
   ext x y,
-  erw [Sup_image, supr_apply, supr_apply, supr_Prop_eq],
-  simp only [Sup_image, supr_Prop_eq, supr_apply, supr_Prop_eq, exists_prop],
-  refl,
+  simp only [Sup_image, supr_apply, supr_Prop_eq, exists_prop, rel_eq_coe]
 end
 
 variables (M)

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -3,7 +3,11 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Mario Carneiro
 -/
-import data.set.basic
+import tactic.interactive
+import tactic.push_neg
+import data.subtype
+import data.prod
+
 open function
 
 /-!
@@ -421,48 +425,3 @@ variables {s : β → β → Prop} {t : γ → γ → Prop}
 as an instance to avoid a loop. -/
 noncomputable def classical.DLO (α) [LO : linear_order α] : decidable_linear_order α :=
 { decidable_le := classical.dec_rel _, ..LO }
-
-variable (r)
-local infix ` ≼ ` : 50 := r
-
-/-- A family of elements of α is directed (with respect to a relation `≼` on α)
-  if there is a member of the family `≼`-above any pair in the family.  -/
-def directed {ι : Sort v} (f : ι → α) := ∀x y, ∃z, f x ≼ f z ∧ f y ≼ f z
-
-/-- A subset of α is directed if there is an element of the set `≼`-above any
-  pair of elements in the set. -/
-def directed_on (s : set α) := ∀ (x ∈ s) (y ∈ s), ∃z ∈ s, x ≼ z ∧ y ≼ z
-
-theorem directed_on_iff_directed {s} : @directed_on α r s ↔ directed r (coe : s → α) :=
-by simp [directed, directed_on]; refine ball_congr (λ x hx, by simp; refl)
-
-theorem directed_on_image {s} {f : β → α} :
-  directed_on r (f '' s) ↔ directed_on (f ⁻¹'o r) s :=
-by simp only [directed_on, set.ball_image_iff, set.bex_image_iff, order.preimage]
-
-theorem directed_on.mono {s : set α} (h : directed_on r s)
-  {r' : α → α → Prop} (H : ∀ {a b}, r a b → r' a b) :
-  directed_on r' s :=
-λ x hx y hy, let ⟨z, zs, xz, yz⟩ := h x hx y hy in ⟨z, zs, H xz, H yz⟩
-
-theorem directed_comp {ι} (f : ι → β) (g : β → α) :
-  directed r (g ∘ f) ↔ directed (g ⁻¹'o r) f := iff.rfl
-
-variable {r}
-
-theorem directed.mono {s : α → α → Prop} {ι} {f : ι → α}
-  (H : ∀ a b, r a b → s a b) (h : directed r f) : directed s f :=
-λ a b, let ⟨c, h₁, h₂⟩ := h a b in ⟨c, H _ _ h₁, H _ _ h₂⟩
-
-theorem directed.mono_comp {ι} {rb : β → β → Prop} {g : α → β} {f : ι → α}
-  (hg : ∀ ⦃x y⦄, x ≼ y → rb (g x) (g y)) (hf : directed r f) :
-  directed rb (g ∘ f) :=
-(directed_comp rb f g).2 $ hf.mono hg
-
-section prio
-set_option default_priority 100 -- see Note [default priority]
-/-- A `preorder` is a `directed_order` if for any two elements `i`, `j`
-there is an element `k` such that `i ≤ k` and `j ≤ k`. -/
-class directed_order (α : Type u) extends preorder α :=
-(directed : ∀ i j : α, ∃ k, i ≤ k ∧ j ≤ k)
-end prio

--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -9,8 +9,15 @@ import order.bounded_lattice
 import logic.function.basic
 set_option old_structure_cmd true
 
-universes u
+universes u v
 variables {α : Type u} {w x y z : α}
+
+/-- Set / lattice complement -/
+class has_compl (α : Type*) := (compl : α → α)
+
+export has_compl (compl)
+
+postfix `ᶜ`:(max+1) := compl
 
 section prio
 set_option default_priority 100 -- see Note [default priority]
@@ -19,8 +26,8 @@ set_option default_priority 100 -- see Note [default priority]
   This is a generalization of (classical) logic of propositions, or
   the powerset lattice. -/
 class boolean_algebra α extends bounded_distrib_lattice α, has_compl α, has_sdiff α :=
-(inf_compl_eq_bot : ∀x:α, x ⊓ xᶜ = ⊥)
-(sup_compl_eq_top : ∀x:α, x ⊔ xᶜ = ⊤)
+(inf_compl_le_bot : ∀x:α, x ⊓ xᶜ ≤ ⊥)
+(top_le_sup_compl : ∀x:α, ⊤ ≤ x ⊔ xᶜ)
 (sdiff_eq : ∀x y:α, x \ y = x ⊓ yᶜ)
 end prio
 
@@ -28,13 +35,13 @@ section boolean_algebra
 variables [boolean_algebra α]
 
 @[simp] theorem inf_compl_eq_bot : x ⊓ xᶜ = ⊥ :=
-boolean_algebra.inf_compl_eq_bot x
+bot_unique $ boolean_algebra.inf_compl_le_bot x
 
 @[simp] theorem compl_inf_eq_bot : xᶜ ⊓ x = ⊥ :=
 eq.trans inf_comm inf_compl_eq_bot
 
 @[simp] theorem sup_compl_eq_top : x ⊔ xᶜ = ⊤ :=
-boolean_algebra.sup_compl_eq_top x
+top_unique $ boolean_algebra.top_le_sup_compl x
 
 @[simp] theorem compl_sup_eq_top : xᶜ ⊔ x = ⊤ :=
 eq.trans sup_comm sup_compl_eq_top
@@ -98,3 +105,15 @@ theorem sdiff_le_sdiff (h₁ : w ≤ y) (h₂ : z ≤ x) : w \ x ≤ y \ z :=
 by rw [sdiff_eq, sdiff_eq]; from inf_le_inf h₁ (compl_le_compl h₂)
 
 end boolean_algebra
+
+instance boolean_algebra_Prop : boolean_algebra Prop :=
+{ compl := not,
+  sdiff := λ p q, p ∧ ¬ q,
+  sdiff_eq := λ _ _, rfl,
+  inf_compl_le_bot := λ p ⟨Hp, Hpc⟩, Hpc Hp,
+  top_le_sup_compl := λ p H, classical.em p,
+  .. bounded_distrib_lattice_Prop }
+
+instance pi.boolean_algebra {α : Type u} {β : Type v} [boolean_algebra β] :
+  boolean_algebra (α → β) :=
+by pi_instance

--- a/src/order/bounded_lattice.lean
+++ b/src/order/bounded_lattice.lean
@@ -187,17 +187,6 @@ end semilattice_sup_bot
 instance nat.semilattice_sup_bot : semilattice_sup_bot ℕ :=
 { bot := 0, bot_le := nat.zero_le, .. nat.distrib_lattice }
 
-private def bot_aux (s : set ℕ) [decidable_pred s] [h : nonempty s] : s :=
-have ∃ x, x ∈ s, from nonempty.elim h (λ x, ⟨x.1, x.2⟩),
-⟨nat.find this, nat.find_spec this⟩
-
-instance nat.subtype.semilattice_sup_bot (s : set ℕ) [decidable_pred s] [h : nonempty s] :
-  semilattice_sup_bot s :=
-{ bot := bot_aux s,
-  bot_le := λ x, nat.find_min' _ x.2,
-  ..subtype.linear_order s,
-  ..lattice_of_decidable_linear_order }
-
 section prio
 set_option default_priority 100 -- see Note [default priority]
 /-- A `semilattice_inf_top` is a semilattice with top and meet. -/
@@ -292,9 +281,8 @@ lemma inf_eq_bot_iff_le_compl {α : Type u} [bounded_distrib_lattice α] {a b c 
       ... = ⊥ : h₂⟩
 
 /- Prop instance -/
-instance bounded_lattice_Prop : bounded_lattice Prop :=
-{ bounded_lattice .
-  le           := λa b, a → b,
+instance bounded_distrib_lattice_Prop : bounded_distrib_lattice Prop :=
+{ le           := λa b, a → b,
   le_refl      := assume _, id,
   le_trans     := assume a b c f g, g ∘ f,
   le_antisymm  := assume a b Hab Hba, propext ⟨Hab, Hba⟩,
@@ -308,6 +296,8 @@ instance bounded_lattice_Prop : bounded_lattice Prop :=
   inf_le_left  := @and.left,
   inf_le_right := @and.right,
   le_inf       := assume a b c Hab Hac Ha, and.intro (Hab Ha) (Hac Ha),
+  le_sup_inf   := assume a b c H, classical.or_iff_not_imp_left.2 $
+    λ Ha, ⟨H.1.resolve_left Ha, H.2.resolve_left Ha⟩,
 
   top          := true,
   le_top       := assume a Ha, true.intro,
@@ -330,14 +320,64 @@ end logic
 
 /- Function lattices -/
 
-/- TODO:
- * build up the lattice hierarchy for `fun`-functor piecewise. semilattic_*, bounded_lattice,
-   lattice ...
- * can this be generalized to the dependent function space?
--/
-instance pi.bounded_lattice {α : Type u} {β : Type v} [bounded_lattice β] :
-  bounded_lattice (α → β) :=
-by pi_instance
+instance pi.has_sup {ι : Type*} {α : ι → Type*} [Π i, has_sup (α i)] : has_sup (Π i, α i) :=
+⟨λ f g i, f i ⊔ g i⟩
+
+@[simp] lemma sup_apply {ι : Type*} {α : ι → Type*} [Π i, has_sup (α i)] (f g : Π i, α i) (i : ι) :
+  (f ⊔ g) i = f i ⊔ g i :=
+rfl
+
+instance pi.has_inf {ι : Type*} {α : ι → Type*} [Π i, has_inf (α i)] : has_inf (Π i, α i) :=
+⟨λ f g i, f i ⊓ g i⟩
+
+@[simp] lemma inf_apply {ι : Type*} {α : ι → Type*} [Π i, has_inf (α i)] (f g : Π i, α i) (i : ι) :
+  (f ⊓ g) i = f i ⊓ g i :=
+rfl
+
+instance pi.has_bot {ι : Type*} {α : ι → Type*} [Π i, has_bot (α i)] : has_bot (Π i, α i) :=
+⟨λ i, ⊥⟩
+
+@[simp] lemma bot_apply {ι : Type*} {α : ι → Type*} [Π i, has_bot (α i)] (i : ι) :
+  (⊥ : Π i, α i) i = ⊥ :=
+rfl
+
+instance pi.has_top {ι : Type*} {α : ι → Type*} [Π i, has_top (α i)] : has_top (Π i, α i) :=
+⟨λ i, ⊤⟩
+
+@[simp] lemma top_apply {ι : Type*} {α : ι → Type*} [Π i, has_top (α i)] (i : ι) :
+  (⊤ : Π i, α i) i = ⊤ :=
+rfl
+
+instance pi.semilattice_sup {ι : Type*} {α : ι → Type*} [Π i, semilattice_sup (α i)] :
+  semilattice_sup (Π i, α i) :=
+by refine_struct { sup := (⊔), .. pi.partial_order }; tactic.pi_instance_derive_field
+
+instance pi.semilattice_inf {ι : Type*} {α : ι → Type*} [Π i, semilattice_inf (α i)] :
+  semilattice_inf (Π i, α i) :=
+by refine_struct { inf := (⊓), .. pi.partial_order }; tactic.pi_instance_derive_field
+
+instance pi.semilattice_inf_bot {ι : Type*} {α : ι → Type*} [Π i, semilattice_inf_bot (α i)] :
+  semilattice_inf_bot (Π i, α i) :=
+by refine_struct { inf := (⊓), bot := ⊥, .. pi.partial_order }; tactic.pi_instance_derive_field
+
+instance pi.semilattice_inf_top {ι : Type*} {α : ι → Type*} [Π i, semilattice_inf_top (α i)] :
+  semilattice_inf_top (Π i, α i) :=
+by refine_struct { inf := (⊓), top := ⊤, .. pi.partial_order }; tactic.pi_instance_derive_field
+
+instance pi.semilattice_sup_bot {ι : Type*} {α : ι → Type*} [Π i, semilattice_sup_bot (α i)] :
+  semilattice_sup_bot (Π i, α i) :=
+by refine_struct { sup := (⊔), bot := ⊥, .. pi.partial_order }; tactic.pi_instance_derive_field
+
+instance pi.semilattice_sup_top {ι : Type*} {α : ι → Type*} [Π i, semilattice_sup_top (α i)] :
+  semilattice_sup_top (Π i, α i) :=
+by refine_struct { sup := (⊔), top := ⊤, .. pi.partial_order }; tactic.pi_instance_derive_field
+
+instance pi.lattice {ι : Type*} {α : ι → Type*} [Π i, lattice (α i)] : lattice (Π i, α i) :=
+{ .. pi.semilattice_sup, .. pi.semilattice_inf }
+
+instance pi.bounded_lattice {ι : Type*} {α : ι → Type*} [Π i, bounded_lattice (α i)] :
+  bounded_lattice (Π i, α i) :=
+{ .. pi.semilattice_sup_top, .. pi.semilattice_inf_bot }
 
 /-- Attach `⊥` to a type. -/
 def with_bot (α : Type*) := option α

--- a/src/order/directed.lean
+++ b/src/order/directed.lean
@@ -1,0 +1,59 @@
+import order.lattice
+import data.set.basic
+
+universes u v w
+
+variables {α : Type u} {β : Type v} {ι : Sort w} (r : α → α → Prop)
+local infix ` ≼ ` : 50 := r
+
+/-- A family of elements of α is directed (with respect to a relation `≼` on α)
+  if there is a member of the family `≼`-above any pair in the family.  -/
+def directed (f : ι → α) := ∀x y, ∃z, f x ≼ f z ∧ f y ≼ f z
+
+/-- A subset of α is directed if there is an element of the set `≼`-above any
+  pair of elements in the set. -/
+def directed_on (s : set α) := ∀ (x ∈ s) (y ∈ s), ∃z ∈ s, x ≼ z ∧ y ≼ z
+
+theorem directed_on_iff_directed {s} : @directed_on α r s ↔ directed r (coe : s → α) :=
+by simp [directed, directed_on]; refine ball_congr (λ x hx, by simp; refl)
+
+theorem directed_on_image {s} {f : β → α} :
+  directed_on r (f '' s) ↔ directed_on (f ⁻¹'o r) s :=
+by simp only [directed_on, set.ball_image_iff, set.bex_image_iff, order.preimage]
+
+theorem directed_on.mono {s : set α} (h : directed_on r s)
+  {r' : α → α → Prop} (H : ∀ {a b}, r a b → r' a b) :
+  directed_on r' s :=
+λ x hx y hy, let ⟨z, zs, xz, yz⟩ := h x hx y hy in ⟨z, zs, H xz, H yz⟩
+
+theorem directed_comp {ι} (f : ι → β) (g : β → α) :
+  directed r (g ∘ f) ↔ directed (g ⁻¹'o r) f := iff.rfl
+
+variable {r}
+
+theorem directed.mono {s : α → α → Prop} {ι} {f : ι → α}
+  (H : ∀ a b, r a b → s a b) (h : directed r f) : directed s f :=
+λ a b, let ⟨c, h₁, h₂⟩ := h a b in ⟨c, H _ _ h₁, H _ _ h₂⟩
+
+theorem directed.mono_comp {ι} {rb : β → β → Prop} {g : α → β} {f : ι → α}
+  (hg : ∀ ⦃x y⦄, x ≼ y → rb (g x) (g y)) (hf : directed r f) :
+  directed rb (g ∘ f) :=
+(directed_comp rb f g).2 $ hf.mono hg
+
+/-- A monotone function on a sup-semilattice is directed. -/
+lemma directed_of_sup [semilattice_sup α] {f : α → β} {r : β → β → Prop}
+  (H : ∀ ⦃i j⦄, i ≤ j → r (f i) (f j)) : directed r f :=
+λ a b, ⟨a ⊔ b, H le_sup_left, H le_sup_right⟩
+
+/-- An antimonotone function on an inf-semilattice is directed. -/
+lemma directed_of_inf [semilattice_inf α] {r : β → β → Prop} {f : α → β}
+  (hf : ∀a₁ a₂, a₁ ≤ a₂ → r (f a₂) (f a₁)) : directed r f :=
+assume x y, ⟨x ⊓ y, hf _ _ inf_le_left, hf _ _ inf_le_right⟩
+
+section prio
+set_option default_priority 100 -- see Note [default priority]
+/-- A `preorder` is a `directed_order` if for any two elements `i`, `j`
+there is an element `k` such that `i ≤ k` and `j ≤ k`. -/
+class directed_order (α : Type u) extends preorder α :=
+(directed : ∀ i j : α, ∃ k, i ≤ k ∧ j ≤ k)
+end prio

--- a/src/order/directed.lean
+++ b/src/order/directed.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Johannes Hölzl
+-/
 import order.lattice
 import data.set.basic
 

--- a/src/order/filter/bases.lean
+++ b/src/order/filter/bases.lean
@@ -605,13 +605,8 @@ lemma has_antimono_basis {f : filter α} (h : f.is_countably_generated) :
  ∃ x : ℕ → set α, f.has_antimono_basis (λ _, true) x :=
 begin
   rcases h.exists_antimono_seq with ⟨x, x_dec, rfl⟩,
-  use x,
-  constructor,
-  apply has_basis_infi_principal,
-  apply directed_of_mono, apply x_dec,
-  use 0,
-  simpa using x_dec,
-  exact monotone_const
+  refine ⟨x, has_basis_infi_principal _ ⟨0⟩, _, monotone_const⟩,
+  exacts [directed_of_sup x_dec, λ i j _ _, x_dec i j]
 end
 
 end is_countably_generated
@@ -623,7 +618,7 @@ begin
   use [range y, countable_range _],
   rw (has_basis_infi_principal _ _).eq_generate,
   { simp [range] },
-  { apply directed_of_mono, apply am },
+  { exact directed_of_sup am },
   { use 0 },
 end
 
@@ -680,7 +675,7 @@ begin
     subst gbasis,
     rw mem_infi,
     { simp only [set.mem_Union, iff_self, filter.mem_principal_sets] },
-    { exact directed_of_mono _ (λ i j h, principal_mono.mpr $ gmon _ _ h) },
+    { exact directed_of_sup (λ i j h, principal_mono.mpr $ gmon _ _ h) },
     { apply_instance } },
   classical, contrapose,
   simp only [not_forall, not_imp, not_exists, subset_def, @tendsto_def _ _ f, gbasis],

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -103,11 +103,6 @@ sup_le_sup h₁ (le_refl _)
 theorem le_of_sup_eq (h : a ⊔ b = b) : a ≤ b :=
 by { rw ← h, simp }
 
-/-- A monotone function on a sup-semilattice is directed. -/
-lemma directed_of_mono (f : α → β) {r : β → β → Prop}
-  (H : ∀ ⦃i j⦄, i ≤ j → r (f i) (f j)) : directed r f :=
-λ a b, ⟨a ⊔ b, H le_sup_left, H le_sup_right⟩
-
 lemma sup_ind [is_total α (≤)] (a b : α) {p : α → Prop} (ha : p a) (hb : p b) : p (a ⊔ b) :=
 (is_total.total a b).elim (λ h : a ≤ b, by rwa sup_eq_right.2 h) (λ h, by rwa sup_eq_left.2 h)
 
@@ -165,10 +160,6 @@ begin
   casesI A, casesI B,
   injection this; congr'
 end
-
-lemma directed_of_sup {β : Type*} {r : β → β → Prop} {f : α → β}
-  (hf : ∀a₁ a₂, a₁ ≤ a₂ → r (f a₁) (f a₂)) : directed r f :=
-assume x y, ⟨x ⊔ y, hf _ _ le_sup_left, hf _ _ le_sup_right⟩
 
 end semilattice_sup
 
@@ -299,11 +290,6 @@ begin
   casesI A, casesI B,
   injection this; congr'
 end
-
-/-- An antimonotone function on an inf-semilattice is directed. -/
-lemma directed_of_inf {r : β → β → Prop} {f : α → β}
-  (hf : ∀a₁ a₂, a₁ ≤ a₂ → r (f a₂) (f a₁)) : directed r f :=
-assume x y, ⟨x ⊓ y, hf _ _ inf_le_left, hf _ _ inf_le_right⟩
 
 end semilattice_inf
 

--- a/src/order/order_iso.lean
+++ b/src/order/order_iso.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import logic.embedding
-import data.nat.basic
 import logic.function.iterate
 import order.rel_classes
 
@@ -153,35 +152,6 @@ def lt_embedding_of_le_embedding [preorder α] [preorder β]
   (f : (has_le.le : α → α → Prop) ≼o (has_le.le : β → β → Prop)) :
 (has_lt.lt : α → α → Prop) ≼o (has_lt.lt : β → β → Prop) :=
 { ord' := by intros; simp [lt_iff_le_not_le,f.ord], .. f }
-
-def nat_lt [is_strict_order α r] (f : ℕ → α) (H : ∀ n:ℕ, r (f n) (f (n+1))) :
-  ((<) : ℕ → ℕ → Prop) ≼o r :=
-of_monotone f $ λ a b h, begin
-  induction b with b IH, {exact (nat.not_lt_zero _ h).elim},
-  cases nat.lt_succ_iff_lt_or_eq.1 h with h e,
-  { exact trans (IH h) (H _) },
-  { subst b, apply H }
-end
-
-def nat_gt [is_strict_order α r] (f : ℕ → α) (H : ∀ n:ℕ, r (f (n+1)) (f n)) :
-  ((>) : ℕ → ℕ → Prop) ≼o r :=
-by haveI := is_strict_order.swap r; exact rsymm (nat_lt f H)
-
-theorem well_founded_iff_no_descending_seq [is_strict_order α r] :
-  well_founded r ↔ ¬ nonempty (((>) : ℕ → ℕ → Prop) ≼o r) :=
-⟨λ ⟨h⟩ ⟨⟨f, o⟩⟩,
-  suffices ∀ a, acc r a → ∀ n, a ≠ f n, from this (f 0) (h _) 0 rfl,
-  λ a ac, begin
-    induction ac with a _ IH, intros n h, subst a,
-    exact IH (f (n+1)) (o.1 (nat.lt_succ_self _)) _ rfl
-  end,
-λ N, ⟨λ a, classical.by_contradiction $ λ na,
-  let ⟨f, h⟩ := classical.axiom_of_choice $
-    show ∀ x : {a // ¬ acc r a}, ∃ y : {a // ¬ acc r a}, r y.1 x.1,
-    from λ ⟨x, h⟩, classical.by_contradiction $ λ hn, h $
-      ⟨_, λ y h, classical.by_contradiction $ λ na, hn ⟨⟨y, na⟩, h⟩⟩ in
-  N ⟨nat_gt (λ n, (f^[n] ⟨a, na⟩).1) $ λ n,
-    by { rw [function.iterate_succ'], apply h }⟩⟩⟩
 
 end order_embedding
 

--- a/src/order/order_iso_nat.lean
+++ b/src/order/order_iso_nat.lean
@@ -1,0 +1,37 @@
+import data.nat.basic
+import order.order_iso
+
+namespace order_embedding
+
+variables {α : Type*} {r : α → α → Prop}
+
+def nat_lt [is_strict_order α r] (f : ℕ → α) (H : ∀ n:ℕ, r (f n) (f (n+1))) :
+  ((<) : ℕ → ℕ → Prop) ≼o r :=
+of_monotone f $ λ a b h, begin
+  induction b with b IH, {exact (nat.not_lt_zero _ h).elim},
+  cases nat.lt_succ_iff_lt_or_eq.1 h with h e,
+  { exact trans (IH h) (H _) },
+  { subst b, apply H }
+end
+
+def nat_gt [is_strict_order α r] (f : ℕ → α) (H : ∀ n:ℕ, r (f (n+1)) (f n)) :
+  ((>) : ℕ → ℕ → Prop) ≼o r :=
+by haveI := is_strict_order.swap r; exact rsymm (nat_lt f H)
+
+theorem well_founded_iff_no_descending_seq [is_strict_order α r] :
+  well_founded r ↔ ¬ nonempty (((>) : ℕ → ℕ → Prop) ≼o r) :=
+⟨λ ⟨h⟩ ⟨⟨f, o⟩⟩,
+  suffices ∀ a, acc r a → ∀ n, a ≠ f n, from this (f 0) (h _) 0 rfl,
+  λ a ac, begin
+    induction ac with a _ IH, intros n h, subst a,
+    exact IH (f (n+1)) (o.1 (nat.lt_succ_self _)) _ rfl
+  end,
+λ N, ⟨λ a, classical.by_contradiction $ λ na,
+  let ⟨f, h⟩ := classical.axiom_of_choice $
+    show ∀ x : {a // ¬ acc r a}, ∃ y : {a // ¬ acc r a}, r y.1 x.1,
+    from λ ⟨x, h⟩, classical.by_contradiction $ λ hn, h $
+      ⟨_, λ y h, classical.by_contradiction $ λ na, hn ⟨⟨y, na⟩, h⟩⟩ in
+  N ⟨nat_gt (λ n, (f^[n] ⟨a, na⟩).1) $ λ n,
+    by { rw [function.iterate_succ'], apply h }⟩⟩⟩
+
+end order_embedding

--- a/src/order/order_iso_nat.lean
+++ b/src/order/order_iso_nat.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2017 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Mario Carneiro
+-/
 import data.nat.basic
 import order.order_iso
 

--- a/src/order/rel_classes.lean
+++ b/src/order/rel_classes.lean
@@ -9,6 +9,7 @@ import tactic.lint.misc
 import tactic.localized
 import algebra.order
 import order.basic
+import data.set.basic
 
 /-!
 # Unbundled relation classes

--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -627,9 +627,9 @@ instance coe_to_submodule : has_coe (subalgebra R A) (submodule R A) :=
 instance to_submodule.is_subring : is_subring ((S : submodule R A) : set A) := S.2
 
 instance : partial_order (subalgebra R A) :=
-{ le := λ S T, (S : set A) ≤ (T : set A),
-  le_refl := λ _, le_refl _,
-  le_trans := λ _ _ _, le_trans,
+{ le := λ S T, (S : set A) ⊆ (T : set A),
+  le_refl := λ S, set.subset.refl S,
+  le_trans := λ _ _ _, set.subset.trans,
   le_antisymm := λ S T hst hts, ext $ λ x, ⟨@hst x, @hts x⟩ }
 
 /-- Reinterpret an `S`-subalgebra as an `R`-subalgebra in `comap R S A`. -/

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro, Kevin Buzzard
 -/
 import ring_theory.ideal_operations
 import linear_algebra.basis
+import order.order_iso_nat
 
 /-!
 # Noetherian rings and modules

--- a/src/tactic/pi_instances.lean
+++ b/src/tactic/pi_instances.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Simon Hudon All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Simon Hudon
 -/
+import tactic.solve_by_elim
 import order.basic
 
 /-!

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -168,7 +168,7 @@ lemma compact.nonempty_Inter_of_sequence_nonempty_compact_closed
   (hZn : ∀ i, (Z i).nonempty) (hZ0 : compact (Z 0)) (hZcl : ∀ i, is_closed (Z i)) :
   (⋂ i, Z i).nonempty :=
 have Zmono : _, from @monotone_of_monotone_nat (order_dual _) _ Z hZd,
-have hZd : directed (⊇) Z, from directed_of_mono Z Zmono,
+have hZd : directed (⊇) Z, from directed_of_sup Zmono,
 have ∀ i, Z i ⊆ Z 0, from assume i, Zmono $ zero_le i,
 have hZc : ∀ i, compact (Z i), from assume i, compact_of_is_closed_subset hZ0 (hZcl i) (this i),
 compact.nonempty_Inter_of_directed_nonempty_compact_closed Z hZd hZn hZc hZcl


### PR DESCRIPTION
I have two goals:

* make it possible to refactor `set` to use `lattice` operations;
* make `submonoid.basic` independent of `data.nat.basic`.

---
<!-- put comments you want to keep out of the PR commit here -->
