### PR TITLE
[Merged by Bors] - fix(finset/lattice): undo removal of bUnion_preimage_singleton

### DIFF
--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -433,6 +433,10 @@ supr_singleton a s
 @[simp] theorem bInter_singleton (a : α) (s : α → set β) : (⋂ x ∈ ({a} : finset α), s x) = s a :=
 infi_singleton a s
 
+@[simp] lemma bUnion_preimage_singleton (f : α → β) (s : finset β) :
+  (⋃ y ∈ s, f ⁻¹' {y}) = f ⁻¹' ↑s :=
+set.bUnion_preimage_singleton f ↑s
+
 variables [decidable_eq α]
 
 lemma bUnion_union (s t : finset α) (u : α → set β) :


### PR DESCRIPTION
In #3189 I removed it, which was a mistake.


---
<!-- put comments you want to keep out of the PR commit here -->

@urkud 