### PR TITLE
[Merged by Bors] - feat(data/list/defs): list.singleton_append and list.bind_singleton

### DIFF
--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -321,6 +321,8 @@ end
 
 lemma append_eq_has_append {L₁ L₂ : list α} : list.append L₁ L₂ = L₁ ++ L₂ := rfl
 
+@[simp] lemma singleton_append {x : α} {l : list α} : [x] ++ l = x :: l := rfl
+
 theorem append_ne_nil_of_ne_nil_left (s t : list α) : s ≠ [] → s ++ t ≠ [] :=
 by induction s; intros; contradiction
 
@@ -475,6 +477,9 @@ by induction n; [refl, simp only [*, repeat, join, append_nil]]
 @[simp] theorem bind_append (f : α → list β) (l₁ l₂ : list α) :
   (l₁ ++ l₂).bind f = l₁.bind f ++ l₂.bind f :=
 append_bind _ _ _
+
+@[simp] theorem bind_singleton (f : α → list β) (x : α) : [x].bind f = f x :=
+append_nil (f x)
 
 /-! ### concat -/
 


### PR DESCRIPTION
I found these useful when working with palindromes and Fibonacci words respectively.

While `bind_singleton` is available as a monad law, I find the specialized version more convenient.


---
<!-- put comments you want to keep out of the PR commit here -->

Should they be marked as `@[simp]` lemmas? They can be implemented with `simp` themselves, so they're technically redundant.