### PR TITLE
[Merged by Bors] - chore(*): use is_algebra_tower instead of algebra.comap and generalize some constructions to semirings

### DIFF
--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -466,8 +466,8 @@ def lie_subalgebra_of_subalgebra (A : Type v) [ring A] [algebra R A]
 { lie_mem := λ x y hx hy, by {
     change ⁅x, y⁆ ∈ A', change x ∈ A' at hx, change y ∈ A' at hy,
     rw lie_ring.of_associative_ring_bracket,
-    have hxy := subalgebra.mul_mem A' x y hx hy,
-    have hyx := subalgebra.mul_mem A' y x hy hx,
+    have hxy := A'.mul_mem hx hy,
+    have hyx := A'.mul_mem hy hx,
     exact submodule.sub_mem A'.to_submodule hxy hyx, },
   ..A'.to_submodule }
 

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -927,6 +927,39 @@ end
 
 end total_degree
 
+section aeval
+
+/-- The algebra of multivariate polynomials. -/
+
+variables (R : Type u) (A : Type v) (f : σ → A)
+variables [comm_semiring R] [comm_semiring A] [algebra R A]
+
+/-- A map `σ → A` where `A` is an algebra over `R` generates an `R`-algebra homomorphism
+from multivariate polynomials over `σ` to `A`. -/
+def aeval : mv_polynomial σ R →ₐ[R] A :=
+{ commutes' := λ r, eval₂_C _ _ _
+  .. eval₂_hom (algebra_map R A) f }
+
+theorem aeval_def (p : mv_polynomial σ R) : aeval R A f p = eval₂ (algebra_map R A) f p := rfl
+
+@[simp] lemma aeval_X (s : σ) : aeval R A f (X s) = f s := eval₂_X _ _ _
+
+@[simp] lemma aeval_C (r : R) : aeval R A f (C r) = algebra_map R A r := eval₂_C _ _ _
+
+theorem eval_unique (φ : mv_polynomial σ R →ₐ[R] A) :
+  φ = aeval R A (φ ∘ X) :=
+begin
+  ext p,
+  apply mv_polynomial.induction_on p,
+  { intro r, rw aeval_C, exact φ.commutes r },
+  { intros f g ih1 ih2,
+    rw [φ.map_add, ih1, ih2, alg_hom.map_add] },
+  { intros p j ih,
+    rw [φ.map_mul, alg_hom.map_mul, aeval_X, ih] }
+end
+
+end aeval
+
 end comm_semiring
 
 section comm_ring
@@ -1068,39 +1101,6 @@ calc (a - b).total_degree = (a + -b).total_degree                : by rw sub_eq_
                       ... = max a.total_degree b.total_degree    : by rw total_degree_neg
 
 end total_degree
-
-section aeval
-
-/-- The algebra of multivariate polynomials. -/
-
-variables (R : Type u) (A : Type v) (f : σ → A)
-variables [comm_ring R] [comm_ring A] [algebra R A]
-
-/-- A map `σ → A` where `A` is an algebra over `R` generates an `R`-algebra homomorphism
-from multivariate polynomials over `σ` to `A`. -/
-def aeval : mv_polynomial σ R →ₐ[R] A :=
-{ commutes' := λ r, eval₂_C _ _ _
-  .. eval₂_hom (algebra_map R A) f }
-
-theorem aeval_def (p : mv_polynomial σ R) : aeval R A f p = eval₂ (algebra_map R A) f p := rfl
-
-@[simp] lemma aeval_X (s : σ) : aeval R A f (X s) = f s := eval₂_X _ _ _
-
-@[simp] lemma aeval_C (r : R) : aeval R A f (C r) = algebra_map R A r := eval₂_C _ _ _
-
-theorem eval_unique (φ : mv_polynomial σ R →ₐ[R] A) :
-  φ = aeval R A (φ ∘ X) :=
-begin
-  ext p,
-  apply mv_polynomial.induction_on p,
-  { intro r, rw aeval_C, exact φ.commutes r },
-  { intros f g ih1 ih2,
-    rw [φ.map_add, ih1, ih2, alg_hom.map_add] },
-  { intros p j ih,
-    rw [φ.map_mul, alg_hom.map_mul, aeval_X, ih] }
-end
-
-end aeval
 
 end comm_ring
 

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -929,7 +929,7 @@ end total_degree
 
 section aeval
 
-/-- The algebra of multivariate polynomials. -/
+/-! ### The algebra of multivariate polynomials -/
 
 variables (R : Type u) (A : Type v) (f : σ → A)
 variables [comm_semiring R] [comm_semiring A] [algebra R A]

--- a/src/data/polynomial.lean
+++ b/src/data/polynomial.lean
@@ -1810,11 +1810,13 @@ section comm_semiring
 variables [comm_semiring R] {p q : polynomial R}
 
 section aeval
-instance algebra' (R : Type u) [comm_semiring R] (A : Type v) [comm_semiring A] [algebra R A] :
+instance algebra' (R : Type u) [comm_semiring R] (A : Type v) [semiring A] [algebra R A] :
   algebra R (polynomial A) :=
 { smul := λ r p, algebra_map R A r • p,
-  commutes' := λ _ _, mul_comm _ _,
-  smul_def' := λ c p, algebra.smul_def _ _,
+  commutes' := λ c p, ext $ λ n,
+    show (C (algebra_map R A c) * p).coeff n = (p * C (algebra_map R A c)).coeff n,
+    by rw [coeff_C_mul, coeff_mul_C, algebra.commutes],
+  smul_def' := λ c p, (C_mul' _ _).symm,
   .. C.comp (algebra_map R A) }
 
 variables (R) (A)

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -271,7 +271,7 @@ instance inhabited {n : ℕ} {f : polynomial α} (hfn : f.nat_degree = n) :
 
 instance algebra (n : ℕ) : Π {α : Type u} [field α], by exactI
   Π {f : polynomial α} (hfn : f.nat_degree = n), algebra α (splitting_field_aux n f hfn) :=
-nat.rec_on n (λ α _ _ _, by exactI algebra.id α) $ λ n ih α _ f hfn,
+nat.rec_on n (λ α _ _ _, by exactI algebra.id) $ λ n ih α _ f hfn,
 by exactI @@algebra.comap.algebra _ _ _ _ _ _ _ (ih _)
 
 instance algebra' {n : ℕ} {f : polynomial α} (hfn : f.nat_degree = n + 1) :
@@ -289,12 +289,12 @@ splitting_field_aux.algebra n _
 
 instance algebra_tower {n : ℕ} {f : polynomial α} (hfn : f.nat_degree = n + 1) :
   is_algebra_tower α (adjoin_root f.factor) (splitting_field_aux _ _ hfn) :=
-is_algebra_tower.of_algebra_map_eq _ _ _ $ λ x, rfl
+is_algebra_tower.of_algebra_map_eq $ λ x, rfl
 
 instance algebra_tower' {n : ℕ} {f : polynomial α} (hfn : f.nat_degree = n + 1) :
   is_algebra_tower α (adjoin_root f.factor)
     (splitting_field_aux n f.remove_factor (nat_degree_remove_factor' hfn)) :=
-is_algebra_tower.of_algebra_map_eq _ _ _ $ λ x, rfl
+is_algebra_tower.of_algebra_map_eq $ λ x, rfl
 
 theorem algebra_map_succ (n : ℕ) (f : polynomial α) (hfn : f.nat_degree = n + 1) :
   by exact algebra_map α (splitting_field_aux _ _ hfn) =

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -271,7 +271,7 @@ instance inhabited {n : ℕ} {f : polynomial α} (hfn : f.nat_degree = n) :
 
 instance algebra (n : ℕ) : Π {α : Type u} [field α], by exactI
   Π {f : polynomial α} (hfn : f.nat_degree = n), algebra α (splitting_field_aux n f hfn) :=
-nat.rec_on n (λ α _ _ _, by exactI algebra.id) $ λ n ih α _ f hfn,
+nat.rec_on n (λ α _ _ _, by exactI algebra.id α) $ λ n ih α _ f hfn,
 by exactI @@algebra.comap.algebra _ _ _ _ _ _ _ (ih _)
 
 instance algebra' {n : ℕ} {f : polynomial α} (hfn : f.nat_degree = n + 1) :

--- a/src/linear_algebra/tensor_product.lean
+++ b/src/linear_algebra/tensor_product.lean
@@ -246,8 +246,8 @@ instance : semimodule R (M ⊗ N) := semimodule.of_core
 (smul_tmul _ _ _).symm
 
 variables (R M N)
-def mk : M →ₗ N →ₗ M ⊗ N :=
-linear_map.mk₂ R (⊗ₜ) (@add_tmul R _ _ _ _ _ _ _) (λ c m n, by rw [smul_tmul, tmul_smul]) tmul_add tmul_smul
+def mk : M →ₗ N →ₗ M ⊗[R] N :=
+linear_map.mk₂ R (⊗ₜ) add_tmul (λ c m n, by rw [smul_tmul, tmul_smul]) tmul_add tmul_smul
 variables {R M N}
 
 @[simp] lemma mk_apply (m : M) (n : N) : mk R M N m n = m ⊗ₜ n := rfl

--- a/src/linear_algebra/tensor_product.lean
+++ b/src/linear_algebra/tensor_product.lean
@@ -9,15 +9,14 @@ Tensor product of modules over commutative rings.
 import group_theory.free_abelian_group
 import linear_algebra.direct_sum_module
 
-variables {R : Type*} [comm_ring R]
-variables {M : Type*} {N : Type*} {P : Type*} {Q : Type*} {S : Type*}
-variables [add_comm_group M] [add_comm_group N] [add_comm_group P] [add_comm_group Q] [add_comm_group S]
-variables [module R M] [module R N] [module R P] [module R Q] [module R S]
-include R
-
-
-
 namespace linear_map
+
+variables {R : Type*} [comm_semiring R]
+variables {M : Type*} {N : Type*} {P : Type*} {Q : Type*} {S : Type*}
+
+variables [add_comm_monoid M] [add_comm_monoid N] [add_comm_monoid P] [add_comm_monoid Q] [add_comm_monoid S]
+variables [semimodule R M] [semimodule R N] [semimodule R P] [semimodule R Q] [semimodule R S]
+include R
 
 variables (R)
 def mk₂ (f : M → N → P)
@@ -64,7 +63,11 @@ variables {R M N P}
 
 theorem map_zero₂ (y) : f 0 y = 0 := (flip f y).map_zero
 
-theorem map_neg₂ (x y) : f (-x) y = -f x y := (flip f y).map_neg _
+theorem map_neg₂ {R : Type*} [comm_ring R] {M N P : Type*}
+  [add_comm_group M] [add_comm_group N] [add_comm_group P]
+  [module R M] [module R N] [module R P] (f : M →ₗ[R] N →ₗ[R] P) (x y) :
+  f (-x) y = -f x y :=
+(flip f y).map_neg _
 
 theorem map_add₂ (x₁ x₂ y) : f (x₁ + x₂) y = f x₁ y + f x₂ y := (flip f y).map_add _ _
 
@@ -111,6 +114,13 @@ variables {R M}
 @[simp] theorem lsmul_apply (r : R) (m : M) : lsmul R M r m = r • m := rfl
 
 end linear_map
+
+variables {R : Type*} [comm_ring R]
+variables {M : Type*} {N : Type*} {P : Type*} {Q : Type*} {S : Type*}
+
+variables [add_comm_group M] [add_comm_group N] [add_comm_group P] [add_comm_group Q] [add_comm_group S]
+variables [module R M] [module R N] [module R P] [module R Q] [module R S]
+include R
 
 variables (M N)
 
@@ -237,7 +247,7 @@ instance : semimodule R (M ⊗ N) := semimodule.of_core
 
 variables (R M N)
 def mk : M →ₗ N →ₗ M ⊗ N :=
-linear_map.mk₂ R (⊗ₜ) add_tmul (λ c m n, by rw [smul_tmul, tmul_smul]) tmul_add tmul_smul
+linear_map.mk₂ R (⊗ₜ) (@add_tmul R _ _ _ _ _ _ _) (λ c m n, by rw [smul_tmul, tmul_smul]) tmul_add tmul_smul
 variables {R M N}
 
 @[simp] lemma mk_apply (m : M) (n : N) : mk R M N m n = m ⊗ₜ n := rfl
@@ -354,7 +364,7 @@ theorem lift_compr₂ (g : P →ₗ Q) : lift (f.compr₂ g) = g.comp (lift f) :
 eq.symm $ lift.unique $ λ x y, by simp
 
 theorem lift_mk_compr₂ (f : M ⊗ N →ₗ P) : lift ((mk R M N).compr₂ f) = f :=
-by rw [lift_compr₂, lift_mk, linear_map.comp_id]
+by rw [lift_compr₂ f, lift_mk, linear_map.comp_id]
 
 @[ext]
 theorem ext {g h : (M ⊗[R] N) →ₗ[R] P}
@@ -500,7 +510,7 @@ end
 rfl
 
 /-- The tensor product of a pair of linear maps between modules. -/
-def map (f : M →ₗ[R] P) (g : N →ₗ Q) : M ⊗ N →ₗ P ⊗ Q :=
+def map (f : M →ₗ[R] P) (g : N →ₗ Q) : M ⊗ N →ₗ[R] P ⊗ Q :=
 lift $ comp (compl₂ (mk _ _ _) g) f
 
 @[simp] theorem map_tmul (f : M →ₗ[R] P) (g : N →ₗ[R] Q) (m : M) (n : N) :

--- a/src/ring_theory/adjoin.lean
+++ b/src/ring_theory/adjoin.lean
@@ -10,45 +10,38 @@ import ring_theory.principal_ideal_domain
 
 universes u v w
 
-open submodule ring
+open submodule
 
 namespace algebra
 
 variables {R : Type u} {A : Type v}
-variables [comm_ring R] [comm_ring A]
+
+section semiring
+variables [comm_semiring R] [semiring A]
 variables [algebra R A] {s t : set A}
+open subsemiring
 
 theorem subset_adjoin : s ⊆ adjoin R s :=
 set.subset.trans (set.subset_union_right _ _) subset_closure
 
 theorem adjoin_le {S : subalgebra R A} (H : s ⊆ S) : adjoin R s ≤ S :=
-closure_subset $ set.union_subset S.3 H
+closure_le.2 $ set.union_subset S.range_le H
 
 theorem adjoin_le_iff {S : subalgebra R A} : adjoin R s ≤ S ↔ s ⊆ S:=
 ⟨set.subset.trans subset_adjoin, adjoin_le⟩
 
 theorem adjoin_mono (H : s ⊆ t) : adjoin R s ≤ adjoin R t :=
-closure_subset (set.subset.trans (set.union_subset_union_right _ H) subset_closure)
+closure_le.2 (set.subset.trans (set.union_subset_union_right _ H) subset_closure)
 
 variables (R A)
 @[simp] theorem adjoin_empty : adjoin R (∅ : set A) = ⊥ :=
 eq_bot_iff.2 $ adjoin_le $ set.empty_subset _
-variables {A}
 
-variables (s t)
-theorem adjoin_union : adjoin R (s ∪ t) = (adjoin R s).under (adjoin (adjoin R s) t) :=
-le_antisymm
-  (closure_mono $ set.union_subset
-    (set.range_subset_iff.2 $ λ r, or.inl ⟨algebra_map R (adjoin R s) r, rfl⟩)
-    (set.union_subset_union_left _ $ λ x hxs, ⟨⟨_, subset_adjoin hxs⟩, rfl⟩))
-  (closure_subset $ set.union_subset
-    (set.range_subset_iff.2 $ λ x, adjoin_mono (set.subset_union_left _ _) x.2)
-    (set.subset.trans (set.subset_union_right _ _) subset_adjoin))
-
+variables (R) {A} (s)
 theorem adjoin_eq_span : (adjoin R s : submodule R A) = span R (monoid.closure s) :=
 begin
   apply le_antisymm,
-  { intros r hr, rcases ring.exists_list_of_mem_closure hr with ⟨L, HL, rfl⟩, clear hr,
+  { intros r hr, rcases mem_closure_iff_exists_list.1 hr with ⟨L, HL, rfl⟩, clear hr,
     induction L with hd tl ih, { exact zero_mem _ },
     rw list.forall_mem_cons at HL,
     rw [list.map_cons, list.sum_cons],
@@ -60,33 +53,48 @@ begin
     induction hd with hd tl ih, { exact ⟨1, 1, is_submonoid.one_mem, one_smul _ _⟩ },
     rw list.forall_mem_cons at HL,
     rcases (ih HL.2) with ⟨z, r, hr, hzr⟩, rw [list.prod_cons, ← hzr],
-    rcases HL.1 with ⟨⟨hd, rfl⟩ | hs⟩ | rfl,
+    rcases HL.1 with ⟨hd, rfl⟩ | hs,
     { refine ⟨hd * z, r, hr, _⟩,
       rw [smul_def, smul_def, (algebra_map _ _).map_mul, _root_.mul_assoc] },
-    { refine ⟨z, hd * r, is_submonoid.mul_mem (monoid.subset_closure hs) hr, _⟩,
-      rw [smul_def, smul_def, mul_left_comm] },
-    { refine ⟨-z, r, hr, _⟩, rw [neg_smul, neg_one_mul] } },
+    { exact ⟨z, hd * r, is_submonoid.mul_mem (monoid.subset_closure hs) hr,
+        (mul_smul_comm _ _ _).symm⟩ } },
   exact span_le.2 (show monoid.closure s ⊆ adjoin R s, from monoid.closure_subset subset_adjoin)
 end
+
+end semiring
+
+section comm_semiring
+variables [comm_semiring R] [comm_semiring A]
+variables [algebra R A] {s t : set A}
+open subsemiring
+
+variables (R s t)
+theorem adjoin_union : adjoin R (s ∪ t) = (adjoin R s).under (adjoin (adjoin R s) t) :=
+le_antisymm
+  (closure_mono $ set.union_subset
+    (set.range_subset_iff.2 $ λ r, or.inl ⟨algebra_map R (adjoin R s) r, rfl⟩)
+    (set.union_subset_union_left _ $ λ x hxs, ⟨⟨_, subset_adjoin hxs⟩, rfl⟩))
+  (closure_le.2 $ set.union_subset
+    (set.range_subset_iff.2 $ λ x, adjoin_mono (set.subset_union_left _ _) x.2)
+    (set.subset.trans (set.subset_union_right _ _) subset_adjoin))
 
 theorem adjoin_eq_range :
   adjoin R s = (mv_polynomial.aeval R A (coe : s → A)).range :=
 le_antisymm
   (adjoin_le $ λ x hx, ⟨mv_polynomial.X ⟨x, hx⟩, mv_polynomial.eval₂_X _ _ _⟩)
   (λ x ⟨p, hp⟩, hp ▸ mv_polynomial.induction_on p
-    (λ r, by rw [mv_polynomial.aeval_def, mv_polynomial.eval₂_C]; exact (adjoin R s).3 ⟨r, rfl⟩)
+    (λ r, by rw [mv_polynomial.aeval_def, mv_polynomial.eval₂_C]; exact (adjoin R s).2 r)
     (λ p q hp hq, by rw alg_hom.map_add; exact is_add_submonoid.add_mem hp hq)
     (λ p ⟨n, hn⟩ hp, by rw [alg_hom.map_mul, mv_polynomial.aeval_def _ _ _ (mv_polynomial.X _),
       mv_polynomial.eval₂_X]; exact is_submonoid.mul_mem hp (subset_adjoin hn)))
 
-theorem adjoin_singleton_eq_range (x : A) :
-  adjoin R {x} = (polynomial.aeval R A x).range :=
+theorem adjoin_singleton_eq_range (x : A) : adjoin R {x} = (polynomial.aeval R A x).range :=
 le_antisymm
   (adjoin_le $ set.singleton_subset_iff.2 ⟨polynomial.X, polynomial.eval₂_X _ _⟩)
   (λ y ⟨p, hp⟩, hp ▸ polynomial.induction_on p
-    (λ r, by rw [polynomial.aeval_def, polynomial.eval₂_C]; exact (adjoin R _).3 ⟨r, rfl⟩)
+    (λ r, by rw [polynomial.aeval_def, polynomial.eval₂_C]; exact (adjoin R _).2 r)
     (λ p q hp hq, by rw alg_hom.map_add; exact is_add_submonoid.add_mem hp hq)
-    (λ n r ih, by { rw [pow_succ', ← ring.mul_assoc, alg_hom.map_mul,
+    (λ n r ih, by { rw [pow_succ', ← mul_assoc, alg_hom.map_mul,
       polynomial.aeval_def _ polynomial.X, polynomial.eval₂_X],
       exact is_submonoid.mul_mem ih (subset_adjoin rfl) }))
 
@@ -97,10 +105,36 @@ begin
   congr' 1, ext z, simp [monoid.mem_closure_union_iff, set.mem_mul],
 end
 
-variables {R s t}
+end comm_semiring
 
-theorem adjoin_int (s : set R) : adjoin ℤ s = subalgebra_of_subring (ring.closure s) :=
+section ring
+variables [comm_ring R] [ring A]
+variables [algebra R A] {s t : set A}
+variables {R s t}
+open ring
+
+theorem adjoin_int (s : set R) : adjoin ℤ s = subalgebra_of_subring (closure s) :=
 le_antisymm (adjoin_le subset_closure) (closure_subset subset_adjoin)
+
+theorem mem_adjoin_iff {s : set A} {x : A} :
+  x ∈ adjoin R s ↔ x ∈ closure (set.range (algebra_map R A) ∪ s) :=
+⟨λ hx, subsemiring.closure_induction hx subset_closure is_add_submonoid.zero_mem
+  is_submonoid.one_mem (λ _ _, is_add_submonoid.add_mem) (λ _ _, is_submonoid.mul_mem),
+suffices closure (set.range ⇑(algebra_map R A) ∪ s) ⊆ adjoin R s, from @this x,
+closure_subset subsemiring.subset_closure⟩
+
+
+theorem adjoin_eq_ring_closure (s : set A) :
+  (adjoin R s : set A) = closure (set.range (algebra_map R A) ∪ s) :=
+set.ext $ λ x, mem_adjoin_iff
+
+end ring
+
+section comm_ring
+variables [comm_ring R] [comm_ring A]
+variables [algebra R A] {s t : set A}
+variables {R s t}
+open ring
 
 theorem fg_trans (h1 : (adjoin R s : submodule R A).fg)
   (h2 : (adjoin (adjoin R s) t : submodule (adjoin R s) A).fg) :
@@ -141,6 +175,8 @@ begin
     intros t ht, change _ * _ ∈ _, rw smul_mul_assoc, refine smul_mem _ _ _,
     exact subset_span ⟨t, z, hlp ht, hlq hz, rfl⟩ }
 end
+
+end comm_ring
 
 end algebra
 

--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -6,7 +6,7 @@ Authors: Kenny Lau, Yury Kudryashov
 import tactic.simps
 import data.matrix.basic
 import linear_algebra.tensor_product
-import data.equiv.ring
+import ring_theory.subsemiring
 
 /-!
 # Algebra over Commutative Semiring (under category)
@@ -125,17 +125,30 @@ by rw [smul_def, smul_def, left_comm]
   (r • x) * y = r • (x * y) :=
 by rw [smul_def, smul_def, mul_assoc]
 
-end semiring
+instance id : algebra R R := (ring_hom.id R).to_algebra
 
--- TODO (semimodule linear maps): once we have them, port next section to semirings
+namespace id
 
-section ring
+@[simp] lemma map_eq_self (x : R) : algebra_map R R x = x := rfl
 
-variables [comm_ring R] [ring A] [algebra R A]
+@[simp] lemma smul_eq_mul (x y : R) : x • y = x * y := rfl
 
-/-- Creating an algebra from a subring. This is the dual of ring extension. -/
-instance of_subring (S : set R) [is_subring S] : algebra S R :=
-ring_hom.to_algebra ⟨coe, rfl, λ _ _, rfl, rfl, λ _ _, rfl⟩
+end id
+
+/-- Algebra over a subsemiring. -/
+instance of_subsemiring (S : subsemiring R) : algebra S A :=
+{ smul := λ s x, (s : R) • x,
+  commutes' := λ r x, algebra.commutes r x,
+  smul_def' := λ r x, algebra.smul_def r x,
+  .. (algebra_map R A).comp (subsemiring.subtype S) }
+
+/-- Algebra over a subring. -/
+instance of_subring {R A : Type*} [comm_ring R] [ring A] [algebra R A]
+  (S : set R) [is_subring S] : algebra S A :=
+{ smul := λ s x, (s : R) • x,
+  commutes' := λ r x, algebra.commutes r x,
+  smul_def' := λ r x, algebra.smul_def r x,
+  .. (algebra_map R A).comp (⟨coe, rfl, λ _ _, rfl, rfl, λ _ _, rfl⟩ : S →+* R) }
 
 variables (R A)
 /-- The multiplication in an algebra is a bilinear map. -/
@@ -160,7 +173,7 @@ variables {R A}
 @[simp] lemma lmul_left_apply (p q : A) : lmul_left R A p q = p * q := rfl
 @[simp] lemma lmul_right_apply (p q : A) : lmul_right R A p q = q * p := rfl
 
-end ring
+end semiring
 
 end algebra
 
@@ -303,6 +316,20 @@ theorem comp_assoc (φ₁ : C →ₐ[R] D) (φ₂ : B →ₐ[R] C) (φ₃ : A �
   (φ₁.comp φ₂).comp φ₃ = φ₁.comp (φ₂.comp φ₃) :=
 ext $ λ x, rfl
 
+/-- R-Alg ⥤ R-Mod -/
+def to_linear_map : A →ₗ B :=
+{ to_fun := φ,
+  map_add' := φ.map_add,
+  map_smul' := φ.map_smul }
+
+@[simp] lemma to_linear_map_apply (p : A) : φ.to_linear_map p = φ p := rfl
+
+theorem to_linear_map_inj {φ₁ φ₂ : A →ₐ[R] B} (H : φ₁.to_linear_map = φ₂.to_linear_map) : φ₁ = φ₂ :=
+ext $ λ x, show φ₁.to_linear_map x = φ₂.to_linear_map x, by rw H
+
+@[simp] lemma comp_to_linear_map (f : A →ₐ[R] B) (g : B →ₐ[R] C) :
+  (g.comp f).to_linear_map = g.to_linear_map.comp f.to_linear_map := rfl
+
 end semiring
 
 section comm_semiring
@@ -318,6 +345,8 @@ lemma map_prod {ι : Type*} (f : ι → A) (s : finset ι) :
 
 end comm_semiring
 
+section ring
+
 variables [comm_ring R] [ring A] [ring B] [ring C]
 variables [algebra R A] [algebra R B] [algebra R C] (φ : A →ₐ[R] B)
 
@@ -327,19 +356,7 @@ variables [algebra R A] [algebra R B] [algebra R C] (φ : A →ₐ[R] B)
 @[simp] lemma map_sub (x y) : φ (x - y) = φ x - φ y :=
 φ.to_ring_hom.map_sub x y
 
-/-- R-Alg ⥤ R-Mod -/
-def to_linear_map : A →ₗ B :=
-{ to_fun := φ,
-  map_add' := φ.map_add,
-  map_smul' := φ.map_smul }
-
-@[simp] lemma to_linear_map_apply (p : A) : φ.to_linear_map p = φ p := rfl
-
-theorem to_linear_map_inj {φ₁ φ₂ : A →ₐ[R] B} (H : φ₁.to_linear_map = φ₂.to_linear_map) : φ₁ = φ₂ :=
-ext $ λ x, show φ₁.to_linear_map x = φ₂.to_linear_map x, by rw H
-
-@[simp] lemma comp_to_linear_map (f : A →ₐ[R] B) (g : B →ₐ[R] C) :
-  (g.comp f).to_linear_map = g.to_linear_map.comp f.to_linear_map := rfl
+end ring
 
 end alg_hom
 
@@ -561,20 +578,18 @@ end rat
 
 /-- A subalgebra is a subring that includes the range of `algebra_map`. -/
 structure subalgebra (R : Type u) (A : Type v)
-  [comm_ring R] [ring A] [algebra R A] : Type v :=
-(carrier : set A) [subring : is_subring carrier]
-(range_le' : set.range (algebra_map R A) ≤ carrier)
+  [comm_semiring R] [semiring A] [algebra R A] : Type v :=
+(carrier : subsemiring A)
+(algebra_map_mem' : ∀ r, algebra_map R A r ∈ carrier)
 
 namespace subalgebra
 
 variables {R : Type u} {A : Type v} {B : Type w}
-variables [comm_ring R] [ring A] [algebra R A] [ring B] [algebra R B]
+variables [comm_semiring R] [semiring A] [algebra R A] [semiring B] [algebra R B]
 include R
 
-instance : has_coe (subalgebra R A) (set A) :=
+instance : has_coe (subalgebra R A) (subsemiring A) :=
 ⟨λ S, S.carrier⟩
-
-lemma range_le (S : subalgebra R A) : set.range (algebra_map R A) ≤ S := S.range_le'
 
 instance : has_mem A (subalgebra R A) :=
 ⟨λ x S, x ∈ (S : set A)⟩
@@ -592,22 +607,113 @@ theorem ext_iff {S T : subalgebra R A} : S = T ↔ ∀ x : A, x ∈ S ↔ x ∈ 
 
 variables (S : subalgebra R A)
 
-instance : is_subring (S : set A) := S.subring
-instance : ring S := @@subtype.ring _ S.is_subring
+theorem algebra_map_mem (r : R) : algebra_map R A r ∈ S :=
+S.algebra_map_mem' r
+
+theorem srange_le : (algebra_map R A).srange ≤ S :=
+λ x ⟨r, _, hr⟩, hr ▸ S.algebra_map_mem r
+
+theorem range_subset : set.range (algebra_map R A) ⊆ S :=
+λ x ⟨r, hr⟩, hr ▸ S.algebra_map_mem r
+
+theorem range_le : set.range (algebra_map R A) ≤ S :=
+S.range_subset
+
+theorem one_mem : (1 : A) ∈ S :=
+subsemiring.one_mem S
+
+theorem mul_mem {x y : A} (hx : x ∈ S) (hy : y ∈ S) : x * y ∈ S :=
+subsemiring.mul_mem S hx hy
+
+theorem smul_mem {x : A} (hx : x ∈ S) (r : R) : r • x ∈ S :=
+(algebra.smul_def r x).symm ▸ S.mul_mem (S.algebra_map_mem r) hx
+
+theorem pow_mem {x : A} (hx : x ∈ S) (n : ℕ) : x ^ n ∈ S :=
+subsemiring.pow_mem S hx n
+
+theorem zero_mem : (0 : A) ∈ S :=
+subsemiring.zero_mem S
+
+theorem add_mem {x y : A} (hx : x ∈ S) (hy : y ∈ S) : x + y ∈ S :=
+subsemiring.add_mem S hx hy
+
+theorem neg_mem {R : Type u} {A : Type v} [comm_ring R] [ring A]
+  [algebra R A] (S : subalgebra R A) {x : A} (hx : x ∈ S) : -x ∈ S :=
+neg_one_smul R x ▸ S.smul_mem hx _
+
+theorem sub_mem {R : Type u} {A : Type v} [comm_ring R] [ring A]
+  [algebra R A] (S : subalgebra R A) {x y : A} (hx : x ∈ S) (hy : y ∈ S) : x - y ∈ S :=
+S.add_mem hx $ S.neg_mem hy
+
+theorem nsmul_mem {x : A} (hx : x ∈ S) (n : ℕ) : n •ℕ x ∈ S :=
+subsemiring.nsmul_mem S hx n
+
+theorem gsmul_mem {R : Type u} {A : Type v} [comm_ring R] [ring A]
+  [algebra R A] (S : subalgebra R A) {x : A} (hx : x ∈ S) (n : ℤ) : n •ℤ x ∈ S :=
+int.cases_on n (λ i, S.nsmul_mem hx i) (λ i, S.neg_mem $ S.nsmul_mem hx _)
+
+theorem coe_nat_mem (n : ℕ) : (n : A) ∈ S :=
+subsemiring.coe_nat_mem S n
+
+theorem coe_int_mem {R : Type u} {A : Type v} [comm_ring R] [ring A]
+  [algebra R A] (S : subalgebra R A) (n : ℤ) : (n : A) ∈ S :=
+int.cases_on n (λ i, S.coe_nat_mem i) (λ i, S.neg_mem $ S.coe_nat_mem $ i + 1)
+
+theorem list_prod_mem {L : list A} (h : ∀ x ∈ L, x ∈ S) : L.prod ∈ S :=
+subsemiring.list_prod_mem S h
+
+theorem list_sum_mem {L : list A} (h : ∀ x ∈ L, x ∈ S) : L.sum ∈ S :=
+subsemiring.list_sum_mem S h
+
+theorem multiset_prod_mem {R : Type u} {A : Type v} [comm_semiring R] [comm_semiring A]
+  [algebra R A] (S : subalgebra R A) {m : multiset A} (h : ∀ x ∈ m, x ∈ S) : m.prod ∈ S :=
+subsemiring.multiset_prod_mem S m h
+
+theorem multiset_sum_mem {m : multiset A} (h : ∀ x ∈ m, x ∈ S) : m.sum ∈ S :=
+subsemiring.multiset_sum_mem S m h
+
+theorem prod_mem {R : Type u} {A : Type v} [comm_semiring R] [comm_semiring A]
+  [algebra R A] (S : subalgebra R A) {ι : Type w} {t : finset ι} {f : ι → A}
+  (h : ∀ x ∈ t, f x ∈ S) : ∏ x in t, f x ∈ S :=
+subsemiring.prod_mem S h
+
+theorem sum_mem {ι : Type w} {t : finset ι} {f : ι → A}
+  (h : ∀ x ∈ t, f x ∈ S) : ∑ x in t, f x ∈ S :=
+subsemiring.sum_mem S h
+
+instance {R : Type u} {A : Type v} [comm_semiring R] [semiring A] [algebra R A]
+  (S : subalgebra R A) : is_add_submonoid (S : set A) :=
+{ zero_mem := S.zero_mem,
+  add_mem := λ _ _, S.add_mem }
+
+instance {R : Type u} {A : Type v} [comm_semiring R] [semiring A] [algebra R A]
+  (S : subalgebra R A) : is_submonoid (S : set A) :=
+{ one_mem := S.one_mem,
+  mul_mem := λ _ _, S.mul_mem }
+
+instance {R : Type u} {A : Type v} [comm_ring R] [ring A] [algebra R A] (S : subalgebra R A) :
+  is_subring (S : set A) :=
+{ neg_mem := λ _, S.neg_mem }
+
 instance : inhabited S := ⟨0⟩
+instance (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
+  [algebra R A] (S : subalgebra R A) : semiring S := subsemiring.to_semiring S
+instance (R : Type u) (A : Type v) [comm_semiring R] [comm_semiring A]
+  [algebra R A] (S : subalgebra R A) : comm_semiring S := subsemiring.to_comm_semiring S
+instance (R : Type u) (A : Type v) [comm_ring R] [ring A]
+  [algebra R A] (S : subalgebra R A) : ring S := @@subtype.ring _ S.is_subring
 instance (R : Type u) (A : Type v) [comm_ring R] [comm_ring A]
   [algebra R A] (S : subalgebra R A) : comm_ring S := @@subtype.comm_ring _ S.is_subring
 
 instance algebra : algebra R S :=
-{ smul := λ (c:R) x, ⟨c • x.1,
-    by rw algebra.smul_def; exact @@is_submonoid.mul_mem _ S.2.2 (S.3 ⟨c, rfl⟩) x.2⟩,
+{ smul := λ (c:R) x, ⟨c • x.1, S.smul_mem x.2 c⟩,
   commutes' := λ c x, subtype.eq $ algebra.commutes _ _,
   smul_def' := λ c x, subtype.eq $ algebra.smul_def _ _,
-  .. (algebra_map R A).cod_restrict S $ λ x, S.range_le ⟨x, rfl⟩ }
+  .. (algebra_map R A).cod_srestrict S $ λ x, S.range_le ⟨x, rfl⟩ }
 
-instance to_algebra (R : Type u) (A : Type v) [comm_ring R] [comm_ring A]
+instance to_algebra {R : Type u} {A : Type v} [comm_semiring R] [comm_semiring A]
   [algebra R A] (S : subalgebra R A) : algebra S A :=
-algebra.of_subring _
+algebra.of_subsemiring _
 
 /-- Embedding of a subalgebra into the algebra. -/
 def val : S →ₐ[R] A :=
@@ -624,7 +730,16 @@ def to_submodule : submodule R A :=
 instance coe_to_submodule : has_coe (subalgebra R A) (submodule R A) :=
 ⟨to_submodule⟩
 
-instance to_submodule.is_subring : is_subring ((S : submodule R A) : set A) := S.2
+instance to_submodule.is_subring {R : Type u} {A : Type v} [comm_ring R] [ring A] [algebra R A]
+  (S : subalgebra R A) : is_subring ((S : submodule R A) : set A) := S.is_subring
+
+@[simp] lemma mem_to_submodule {x} : x ∈ (S : submodule R A) ↔ x ∈ S := iff.rfl
+
+theorem to_submodule_injective {S U : subalgebra R A} (h : (S : submodule R A) = U) : S = U :=
+ext $ λ x, by rw [← mem_to_submodule, ← mem_to_submodule, h]
+
+theorem to_submodule_inj {S U : subalgebra R A} : (S : submodule R A) = U ↔ S = U :=
+⟨to_submodule_injective, congr_arg _⟩
 
 instance : partial_order (subalgebra R A) :=
 { le := λ S T, (S : set A) ≤ (T : set A),
@@ -634,34 +749,29 @@ instance : partial_order (subalgebra R A) :=
 
 /-- Reinterpret an `S`-subalgebra as an `R`-subalgebra in `comap R S A`. -/
 def comap {R : Type u} {S : Type v} {A : Type w}
-  [comm_ring R] [comm_ring S] [ring A] [algebra R S] [algebra S A]
+  [comm_semiring R] [comm_semiring S] [semiring A] [algebra R S] [algebra S A]
   (iSB : subalgebra S A) : subalgebra R (algebra.comap R S A) :=
-{ carrier := (iSB : set A),
-  subring := iSB.is_subring,
-  range_le' := λ a ⟨r, hr⟩, hr ▸ iSB.range_le ⟨_, rfl⟩ }
+{ carrier := (iSB : subsemiring A),
+  algebra_map_mem' := λ r, iSB.algebra_map_mem (algebra_map R S r) }
 
 /-- If `S` is an `R`-subalgebra of `A` and `T` is an `S`-subalgebra of `A`,
 then `T` is an `R`-subalgebra of `A`. -/
-def under {R : Type u} {A : Type v} [comm_ring R] [comm_ring A]
+def under {R : Type u} {A : Type v} [comm_semiring R] [comm_semiring A]
   {i : algebra R A} (S : subalgebra R A)
   (T : subalgebra S A) : subalgebra R A :=
 { carrier := T,
-  range_le' := (λ a ⟨r, hr⟩, hr ▸ T.range_le ⟨⟨algebra_map R A r, S.range_le ⟨r, rfl⟩⟩, rfl⟩) }
-
-lemma mul_mem (A' : subalgebra R A) (x y : A) :
-  x ∈ A' → y ∈ A' → x * y ∈ A' := @is_submonoid.mul_mem A _ A' _ x y
+  algebra_map_mem' := λ r, T.algebra_map_mem ⟨algebra_map R A r, S.algebra_map_mem r⟩ }
 
 /-- Transport a subalgebra via an algebra homomorphism. -/
 def map (S : subalgebra R A) (f : A →ₐ[R] B) : subalgebra R B :=
-{ carrier := f '' (S : set A),
-  subring := ring_hom.is_subring_image (f : A →+* B) _,
-  range_le' := λ x ⟨r, hr⟩, ⟨algebra_map R A r, S.range_le ⟨r, rfl⟩, by rw [f.commutes, hr]⟩ }
+{ carrier := subsemiring.map (f : A →+* B) S,
+  algebra_map_mem' := λ r, f.commutes r ▸ set.mem_image_of_mem _ (S.algebra_map_mem r) }
 
 /-- Preimage of a subalgebra under an algebra homomorphism. -/
 def comap' (S : subalgebra R B) (f : A →ₐ[R] B) : subalgebra R A :=
-{ carrier := f ⁻¹' (S : set B),
-  subring := ring_hom.is_subring_preimage (f : A →+* B) _,
-  range_le' := λ x ⟨r, hr⟩, show f x ∈ S, by { rw [← hr, f.commutes], exact S.range_le ⟨r, rfl⟩ } }
+{ carrier := subsemiring.comap (f : A →+* B) S,
+  algebra_map_mem' := λ r, show f (algebra_map R A r) ∈ S,
+    from (f.commutes r).symm ▸ S.algebra_map_mem r }
 
 theorem map_le {S : subalgebra R A} {f : A →ₐ[R] B} {U : subalgebra R B} :
   map S f ≤ U ↔ S ≤ comap' U f :=
@@ -672,15 +782,18 @@ end subalgebra
 namespace alg_hom
 
 variables {R : Type u} {A : Type v} {B : Type w}
-variables [comm_ring R] [ring A] [ring B] [algebra R A] [algebra R B]
+variables [comm_semiring R] [semiring A] [semiring B] [algebra R A] [algebra R B]
 variables (φ : A →ₐ[R] B)
 
 /-- Range of an `alg_hom` as a subalgebra. -/
 protected def range (φ : A →ₐ[R] B) : subalgebra R B :=
-begin
-  haveI : is_subring (set.range φ) := show is_subring (set.range φ.to_ring_hom), by apply_instance,
-  exact ⟨set.range φ, λ y ⟨r, hr⟩, ⟨algebra_map R A r, hr ▸ φ.commutes r⟩⟩
-end
+{ carrier :=
+  { carrier := set.range φ,
+    one_mem' := ⟨1, φ.map_one⟩,
+    mul_mem' := λ _ _ ⟨x, hx⟩ ⟨y, hy⟩, ⟨x * y, by rw [φ.map_mul, hx, hy]⟩,
+    zero_mem' := ⟨0, φ.map_zero⟩,
+    add_mem' := λ _ _ ⟨x, hx⟩ ⟨y, hy⟩, ⟨x + y, by rw [φ.map_add, hx, hy]⟩ },
+  algebra_map_mem' := λ r, ⟨algebra_map R A r, φ.commutes r⟩ }
 
 end alg_hom
 
@@ -689,16 +802,6 @@ namespace algebra
 variables (R : Type u) (A : Type v)
 
 variables [comm_semiring R] [semiring A] [algebra R A]
-
-instance id : algebra R R := (ring_hom.id R).to_algebra
-
-namespace id
-
-@[simp] lemma map_eq_self (x : R) : algebra_map R R x = x := rfl
-
-@[simp] lemma smul_eq_mul (x y : R) : x • y = x * y := rfl
-
-end id
 
 /-- `algebra_map` as an `alg_hom`. -/
 def of_id : R →ₐ[R] A :=
@@ -712,17 +815,17 @@ end algebra
 namespace algebra
 
 variables (R : Type u) {A : Type v} {B : Type w}
-variables [comm_ring R] [ring A] [algebra R A] [ring B] [algebra R B]
+variables [comm_semiring R] [semiring A] [algebra R A] [semiring B] [algebra R B]
 
 /-- The minimal subalgebra that includes `s`. -/
 def adjoin (s : set A) : subalgebra R A :=
-{ carrier := ring.closure (set.range (algebra_map R A) ∪ s),
-  range_le' := le_trans (set.subset_union_left _ _) ring.subset_closure }
+{ carrier := subsemiring.closure (set.range (algebra_map R A) ∪ s),
+  algebra_map_mem' := λ r, subsemiring.subset_closure $ or.inl ⟨r, rfl⟩ }
 variables {R}
 
 protected lemma gc : galois_connection (adjoin R : set A → subalgebra R A) coe :=
-λ s S, ⟨λ H, le_trans (le_trans (set.subset_union_right _ _) ring.subset_closure) H,
-λ H, ring.closure_subset $ set.union_subset S.range_le H⟩
+λ s S, ⟨λ H, le_trans (le_trans (set.subset_union_right _ _) subsemiring.subset_closure) H,
+λ H, subsemiring.closure_le.2 $ set.union_subset S.range_subset H⟩
 
 /-- Galois insertion between `adjoin` and `coe`. -/
 protected def gi : galois_insertion (adjoin R : set A → subalgebra R A) coe :=
@@ -741,7 +844,7 @@ suffices (⊥ : subalgebra R A) = (of_id R A).range, by rw this; refl,
 le_antisymm bot_le $ subalgebra.range_le _
 
 theorem mem_top {x : A} : x ∈ (⊤ : subalgebra R A) :=
-ring.mem_closure $ or.inr trivial
+subsemiring.subset_closure $ or.inr trivial
 
 theorem eq_top_iff {S : subalgebra R A} :
   S = ⊤ ↔ ∀ x : A, x ∈ S :=
@@ -763,6 +866,49 @@ by refine_struct { to_fun := λ x, (⟨x, mem_top⟩ : (⊤ : subalgebra R A)) }
 
 end algebra
 
+section nat
+
+variables (R : Type*) [semiring R]
+
+/-- Reinterpret a `ring_hom` as an `ℕ`-algebra homomorphism. -/
+def alg_hom_nat
+  {R : Type u} [semiring R] [algebra ℕ R]
+  {S : Type v} [semiring S] [algebra ℕ S]
+  (f : R →+* S) : R →ₐ[ℕ] S :=
+{ commutes' := λ i, show f _ = _, by simp, .. f }
+
+/-- Semiring ⥤ ℕ-Alg -/
+instance algebra_nat : algebra ℕ R :=
+{ commutes' := nat.cast_commute,
+  smul_def' := λ _ _, nsmul_eq_mul _ _,
+  .. nat.cast_ring_hom R }
+
+variables {R}
+/-- A subsemiring is a `ℕ`-subalgebra. -/
+def subalgebra_of_subsemiring (S : subsemiring R) : subalgebra ℕ R :=
+{ carrier := S,
+  algebra_map_mem' := λ i, S.coe_nat_mem i }
+
+@[simp] lemma mem_subalgebra_of_subsemiring {x : R} {S : subsemiring R} :
+  x ∈ subalgebra_of_subsemiring S ↔ x ∈ S :=
+iff.rfl
+
+section span_nat
+open submodule
+
+lemma span_nat_eq_add_group_closure (s : set R) :
+  (span ℕ s).to_add_submonoid = add_submonoid.closure s :=
+eq.symm $ add_submonoid.closure_eq_of_le subset_span $ λ x hx, span_induction hx
+  (λ x hx, add_submonoid.subset_closure hx) (add_submonoid.zero_mem _)
+  (λ _ _, add_submonoid.add_mem _) (λ _ _ _, add_submonoid.nsmul_mem _ ‹_› _)
+
+@[simp] lemma span_nat_eq (s : add_submonoid R) : (span ℕ (s : set R)).to_add_submonoid = s :=
+by rw [span_nat_eq_add_group_closure, s.closure_eq]
+
+end span_nat
+
+end nat
+
 section int
 
 variables (R : Type*) [ring R]
@@ -774,7 +920,7 @@ def alg_hom_int
   (f : R →+* S) : R →ₐ[ℤ] S :=
 { commutes' := λ i, show f _ = _, by simp, .. f }
 
-/-- CRing ⥤ ℤ-Alg -/
+/-- Ring ⥤ ℤ-Alg -/
 instance algebra_int : algebra ℤ R :=
 { commutes' := int.cast_commute,
   smul_def' := λ _ _, gsmul_eq_mul _ _,
@@ -783,9 +929,16 @@ instance algebra_int : algebra ℤ R :=
 variables {R}
 /-- A subring is a `ℤ`-subalgebra. -/
 def subalgebra_of_subring (S : set R) [is_subring S] : subalgebra ℤ R :=
-{ carrier := S,
-  range_le' := by { rintros _ ⟨i, rfl⟩, rw [ring_hom.eq_int_cast, ← gsmul_one],
-    exact is_add_subgroup.gsmul_mem is_submonoid.one_mem } }
+{ carrier :=
+  { carrier := S,
+    one_mem' := is_submonoid.one_mem,
+    mul_mem' := λ _ _, is_submonoid.mul_mem,
+    zero_mem' := is_add_submonoid.zero_mem,
+    add_mem' := λ _ _, is_add_submonoid.add_mem, },
+  algebra_map_mem' := λ i, int.induction_on i (show (0 : R) ∈ S, from is_add_submonoid.zero_mem)
+    (λ i ih, show (i + 1 : R) ∈ S, from is_add_submonoid.add_mem ih is_submonoid.one_mem)
+    (λ i ih, show ((-i - 1 : ℤ) : R) ∈ S, by { rw [int.cast_sub, int.cast_one],
+      exact is_add_subgroup.sub_mem S _ _ ih is_submonoid.one_mem }) }
 
 @[simp] lemma mem_subalgebra_of_subring {x : R} {S : set R} [is_subring S] :
   x ∈ subalgebra_of_subring S ↔ x ∈ S :=

--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -125,7 +125,9 @@ by rw [smul_def, smul_def, left_comm]
   (r • x) * y = r • (x * y) :=
 by rw [smul_def, smul_def, mul_assoc]
 
+variables (R)
 instance id : algebra R R := (ring_hom.id R).to_algebra
+variables {R}
 
 namespace id
 

--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -15,6 +15,10 @@ In this file we define algebra over commutative (semi)rings, algebra homomorphis
 algebra equivalences `alg_equiv`, and `subalgebra`s. We also define usual operations on `alg_hom`s
 (`id`, `comp`) and subalgebras (`map`, `comap`).
 
+If `S` is an `R`-algebra and `A` is an `S`-algebra then `algebra.comap.algebra R S A` can be used
+to provide `A` with a structure of an `R`-algebra. Other than that, `algebra.comap` is now
+deprecated and replcaed with `is_algebra_tower`.
+
 ## Notations
 
 * `A →ₐ[R] B` : `R`-algebra homomorphism from `A` to `B`.
@@ -515,7 +519,9 @@ variables (R : Type u) (S : Type v) (A : Type w)
 include R S A
 
 /-- `comap R S A` is a type alias for `A`, and has an R-algebra structure defined on it
-  when `algebra R S` and `algebra S A`. -/
+  when `algebra R S` and `algebra S A`. If `S` is an `R`-algebra and `A` is an `S`-algebra then
+  `algebra.comap.algebra R S A` can be used to provide `A` with a structure of an `R`-algebra.
+  Other than that, `algebra.comap` is now deprecated and replcaed with `is_algebra_tower`. -/
 /- This is done to avoid a type class search with meta-variables `algebra R ?m_1` and
     `algebra ?m_1 A -/
 /- The `nolint` attribute is added because it has unused arguments `R` and `S`, but these are necessary for synthesizing the

--- a/src/ring_theory/algebra_operations.lean
+++ b/src/ring_theory/algebra_operations.lean
@@ -16,18 +16,18 @@ open algebra set
 
 namespace submodule
 
-variables {R : Type u} [comm_ring R]
+variables {R : Type u} [comm_semiring R]
 
 section ring
 
-variables {A : Type v} [ring A] [algebra R A]
+variables {A : Type v} [semiring A] [algebra R A]
 variables (S T : set A) {M N P Q : submodule R A} {m n : A}
 
 instance : has_one (submodule R A) :=
-⟨submodule.map (of_id R A).to_linear_map (⊤ : ideal R)⟩
+⟨submodule.map (of_id R A).to_linear_map (⊤ : submodule R R)⟩
 
 theorem one_eq_map_top :
-  (1 : submodule R A) = submodule.map (of_id R A).to_linear_map (⊤ : ideal R) := rfl
+  (1 : submodule R A) = submodule.map (of_id R A).to_linear_map (⊤ : submodule R R) := rfl
 
 theorem one_eq_span : (1 : submodule R A) = span R {1} :=
 begin
@@ -121,7 +121,7 @@ le_antisymm (mul_le.2 $ λ mn hmn p hp, let ⟨m, hm, n, hn, hmn⟩ := mem_sup.1
 lemma mul_subset_mul : (↑M : set A) * (↑N : set A) ⊆ (↑(M * N) : set A) :=
 by { rintros _ ⟨i, j, hi, hj, rfl⟩, exact mul_mem_mul hi hj }
 
-lemma map_mul {A'} [ring A'] [algebra R A'] (f : A →ₐ[R] A') :
+lemma map_mul {A'} [semiring A'] [algebra R A'] (f : A →ₐ[R] A') :
   map f.to_linear_map (M * N) = map f.to_linear_map M * map f.to_linear_map N :=
 calc map f.to_linear_map (M * N)
     = ⨆ (i : M), (N.map (lmul R A i)).map f.to_linear_map : map_supr _ _
@@ -171,8 +171,8 @@ end
 def span.ring_hom : set_semiring A →+* submodule R A :=
 { to_fun := submodule.span R,
   map_zero' := span_empty,
-  map_one' := show _ = map _ ⊤, by { erw [← ideal.span_singleton_one, ← span_image,
-      set.image_singleton, alg_hom.map_one], refl },
+  map_one' := le_antisymm (span_le.2 $ singleton_subset_iff.2 ⟨1, ⟨⟩, (algebra_map R A).map_one⟩)
+    (map_le_iff_le_comap.2 $ λ r _, mem_span_singleton.2 ⟨r, (algebra_map_eq_smul_one r).symm⟩),
   map_add' := span_union,
   map_mul' := λ s t, by erw [span_mul_span, ← image_mul_prod] }
 
@@ -180,7 +180,7 @@ end ring
 
 section comm_ring
 
-variables {A : Type v} [comm_ring A] [algebra R A]
+variables {A : Type v} [comm_semiring A] [algebra R A]
 variables {M N : submodule R A} {m n : A}
 
 theorem mul_mem_mul_rev (hm : m ∈ M) (hn : n ∈ N) : n * m ∈ M * N :=

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -10,15 +10,16 @@ universes u v w u₁
 
 variables (R : Type u) (S : Type v) (A : Type w) (B : Type u₁)
 
-section comm_semiring
-variables [comm_semiring R] [comm_semiring S] [semiring A] [semiring B]
-variables [algebra R S] [algebra S A] [algebra R A] [algebra S B] [algebra R B]
-
 /-- Typeclass for a tower of three algebras. -/
-class is_algebra_tower : Prop :=
+class is_algebra_tower [comm_semiring R] [comm_semiring S] [semiring A]
+  [algebra R S] [algebra S A] [algebra R A] : Prop :=
 (smul_assoc : ∀ (x : R) (y : S) (z : A), (x • y) • z = x • (y • z))
 
 namespace is_algebra_tower
+
+section semiring
+variables [comm_semiring R] [comm_semiring S] [semiring A] [semiring B]
+variables [algebra R S] [algebra S A] [algebra R A] [algebra S B] [algebra R B]
 
 theorem algebra_map_eq [is_algebra_tower R S A] :
   algebra_map R A = (algebra_map S A).comp (algebra_map R S) :=
@@ -29,6 +30,7 @@ theorem algebra_map_apply [is_algebra_tower R S A] (x : R) :
   algebra_map R A x = algebra_map S A (algebra_map R S x) :=
 by rw [algebra_map_eq R S A, ring_hom.comp_apply]
 
+variables {R S A}
 theorem of_algebra_map_eq (h : ∀ x, algebra_map R A x = algebra_map S A (algebra_map R S x)) :
   is_algebra_tower R S A :=
 ⟨λ x y z, by simp_rw [algebra.smul_def, ring_hom.map_mul, mul_assoc, h]⟩
@@ -41,8 +43,9 @@ begin
   ext r, erw [← mul_one (g1 r), ← h12, ← mul_one (g2 r), ← h22, h], refl }
 end
 
-variables [is_algebra_tower R S A]
+variables [is_algebra_tower R S A] [is_algebra_tower R S B]
 
+variables (R S A)
 theorem comap_eq : algebra.comap.algebra R S A = ‹_› :=
 algebra.ext _ _ $ λ x (z : A),
 calc  algebra_map R S x • z
@@ -56,33 +59,95 @@ def to_alg_hom : S →ₐ[R] A :=
 { commutes' := λ _, (algebra_map_apply _ _ _ _).symm,
   .. algebra_map S A }
 
-end is_algebra_tower
+@[simp] lemma to_alg_hom_apply (y : S) : to_alg_hom R S A y = algebra_map S A y := rfl
+
+variables (R) {S A B}
+/-- R ⟶ S induces S-Alg ⥤ R-Alg -/
+def restrict_base (f : A →ₐ[S] B) : A →ₐ[R] B :=
+{ commutes' := λ r, by { rw [algebra_map_apply R S A, algebra_map_apply R S B],
+    exact f.commutes (algebra_map R S r) },
+  .. (f : A →+* B) }
+
+@[simp] lemma restrict_base_apply (f : A →ₐ[S] B) (x : A) : restrict_base R f x = f x := rfl
+
+instance left : is_algebra_tower S S A :=
+of_algebra_map_eq $ λ x, rfl
+
+instance right : is_algebra_tower R S S :=
+of_algebra_map_eq $ λ x, rfl
+
+instance nat : is_algebra_tower ℕ S A :=
+of_algebra_map_eq $ λ x, ((algebra_map S A).map_nat_cast x).symm
+
+instance comap {R S A : Type*} [comm_semiring R] [comm_semiring S] [semiring A]
+  [algebra R S] [algebra S A] : is_algebra_tower R S (algebra.comap R S A) :=
+of_algebra_map_eq $ λ x, rfl
+
+instance subsemiring (U : subsemiring S) : is_algebra_tower U S A :=
+of_algebra_map_eq $ λ x, rfl
+
+instance subring {S A : Type*} [comm_ring S] [ring A] [algebra S A]
+  (U : set S) [is_subring U] : is_algebra_tower U S A :=
+of_algebra_map_eq $ λ x, rfl
+
+end semiring
+
+section comm_semiring
+variables [comm_semiring R] [comm_semiring A] [algebra R A]
+variables [comm_semiring B] [algebra A B] [algebra R B] [is_algebra_tower R A B]
+
+instance subalgebra (S : subalgebra R A) : is_algebra_tower R S A :=
+of_algebra_map_eq $ λ x, rfl
+
+instance polynomial : is_algebra_tower R A (polynomial B) :=
+of_algebra_map_eq $ λ x, congr_arg polynomial.C $ algebra_map_apply R A B x
+
+theorem aeval_apply (x : B) (p) : polynomial.aeval R B x p =
+  polynomial.aeval A B x (polynomial.map (algebra_map R A) p) :=
+by rw [polynomial.aeval_def, polynomial.aeval_def, polynomial.eval₂_map, algebra_map_eq R A B]
 
 end comm_semiring
 
-section comm_ring
-
-variables [comm_ring R] [comm_ring S] [comm_ring A] [algebra R S] [algebra S A] [algebra R A]
+section ring
+variables [comm_ring R] [comm_ring S] [ring A] [algebra R S] [algebra S A] [algebra R A]
 variables [is_algebra_tower R S A]
-
-namespace is_algebra_tower
 
 /-- If A/S/R is a tower of algebras then any S-subalgebra of A gives an R-subalgebra of A. -/
 def subalgebra_comap (U : subalgebra S A) : subalgebra R A :=
 { carrier := U,
-  range_le' := λ z ⟨x, hx⟩, U.range_le ⟨algebra_map R S x, by rwa ← algebra_map_apply⟩ }
+  algebra_map_mem' := λ x, by { rw algebra_map_apply R S A, exact U.algebra_map_mem _ } }
 
 theorem subalgebra_comap_top : subalgebra_comap R S A ⊤ = ⊤ :=
-algebra.eq_top_iff.2 $ λ _, algebra.mem_top
+algebra.eq_top_iff.2 $ λ _, show _ ∈ (⊤ : subalgebra S A), from algebra.mem_top
+
+end ring
+
+section comm_ring
+variables [comm_ring R] [comm_ring S] [comm_ring A] [algebra R S] [algebra S A] [algebra R A]
+variables [is_algebra_tower R S A]
 
 theorem range_under_adjoin (t : set A) :
   (to_alg_hom R S A).range.under (algebra.adjoin _ t) =
     subalgebra_comap R S A (algebra.adjoin S t) :=
-subalgebra.ext $ λ z, show z ∈ ring.closure _ ↔ z ∈ ring.closure _,
-by { congr' 4, ext z, exact ⟨λ ⟨⟨x, y, h1⟩, h2⟩, ⟨y, h2 ▸ h1⟩, λ ⟨y, hy⟩, ⟨⟨z, y, hy⟩, rfl⟩⟩ }
+subalgebra.ext $ λ z,
+show z ∈ subsemiring.closure (set.range (algebra_map (to_alg_hom R S A).range A) ∪ t : set A) ↔
+  z ∈ subsemiring.closure (set.range (algebra_map S A) ∪ t : set A),
+from suffices set.range (algebra_map (to_alg_hom R S A).range A) = set.range (algebra_map S A),
+  by rw this,
+by { ext z, exact ⟨λ ⟨⟨x, y, h1⟩, h2⟩, ⟨y, h2 ▸ h1⟩, λ ⟨y, hy⟩, ⟨⟨z, y, hy⟩, rfl⟩⟩ }
 
-instance : is_algebra_tower ℤ S A :=
-of_algebra_map_eq _ _ _ $ λ x, ((algebra_map S A).map_int_cast x).symm
+instance int : is_algebra_tower ℤ S A :=
+of_algebra_map_eq $ λ x, ((algebra_map S A).map_int_cast x).symm
+
+end comm_ring
+
+section division_ring
+variables [field R] [division_ring S] [algebra R S] [char_zero R] [char_zero S]
+
+instance rat : is_algebra_tower ℚ R S :=
+of_algebra_map_eq $ λ x, ((algebra_map R S).map_rat_cast x).symm
+
+end division_ring
 
 end is_algebra_tower
 
@@ -102,5 +167,3 @@ le_antisymm (adjoin_le $ set.image_subset_iff.2 $ λ y hy, ⟨y, subset_adjoin h
   (subalgebra.map_le.2 $ adjoin_le $ λ y hy, subset_adjoin ⟨y, hy, rfl⟩)
 
 end algebra
-
-end comm_ring

--- a/src/ring_theory/algebraic.lean
+++ b/src/ring_theory/algebraic.lean
@@ -95,12 +95,12 @@ end field
 namespace algebra
 variables {K : Type*} {L : Type*} {A : Type*}
 variables [field K] [field L] [comm_ring A]
-variables [algebra K L] [algebra L A]
+variables [algebra K L] [algebra L A] [algebra K A] [is_algebra_tower K L A]
 
 /-- If L is an algebraic field extension of K and A is an algebraic algebra over L,
 then A is algebraic over K. -/
 lemma is_algebraic_trans (L_alg : is_algebraic K L) (A_alg : is_algebraic L A) :
-  is_algebraic K (comap K L A) :=
+  is_algebraic K A :=
 begin
   simp only [is_algebraic, is_algebraic_iff_is_integral] at L_alg A_alg ⊢,
   exact is_integral_trans L_alg A_alg,

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -273,7 +273,7 @@ section algebra
 open algebra
 variables {R : Type*} {A : Type*} {B : Type*}
 variables [comm_ring R] [comm_ring A] [comm_ring B]
-variables [algebra R A] [algebra A B] [algebra R B] [is_algebra_tower R A B]
+variables [algebra R A] [algebra A B] [algebra R B]
 
 lemma is_integral_trans_aux (x : B) {p : polynomial A} (pmonic : monic p) (hp : aeval A B x p = 0) :
   is_integral (adjoin R (↑(p.map $ algebra_map A B).frange : set B)) x :=
@@ -296,6 +296,8 @@ begin
     replace hq := congr_arg (eval x) hq,
     convert hq using 1; symmetry; apply eval_map },
 end
+
+variables [is_algebra_tower R A B]
 
 /-- If A is an R-algebra all of whose elements are integral over R,
 and x is an element of an A-algebra that is integral over A, then x is integral over R.-/

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -273,7 +273,7 @@ section algebra
 open algebra
 variables {R : Type*} {A : Type*} {B : Type*}
 variables [comm_ring R] [comm_ring A] [comm_ring B]
-variables [algebra R A] [algebra A B] [algebra R B]
+variables [algebra A B] [algebra R B]
 
 lemma is_integral_trans_aux (x : B) {p : polynomial A} (pmonic : monic p) (hp : aeval A B x p = 0) :
   is_integral (adjoin R (↑(p.map $ algebra_map A B).frange : set B)) x :=
@@ -297,7 +297,7 @@ begin
     convert hq using 1; symmetry; apply eval_map },
 end
 
-variables [is_algebra_tower R A B]
+variables [algebra R A] [is_algebra_tower R A B]
 
 /-- If A is an R-algebra all of whose elements are integral over R,
 and x is an element of an A-algebra that is integral over A, then x is integral over R.-/

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -3,20 +3,20 @@ Copyright (c) 2019 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
-import ring_theory.adjoin
+import ring_theory.algebra_tower
 
 /-!
 # Integral closure of a subring.
 -/
-universes u v
+universes u v w
 
 open_locale classical
 open polynomial submodule
 
 section
-variables (R : Type u) {A : Type v}
-variables [comm_ring R] [comm_ring A]
-variables [algebra R A]
+variables (R : Type u) {A : Type v} {B : Type w}
+variables [comm_ring R] [comm_ring A] [comm_ring B]
+variables [algebra R A] [algebra R B]
 
 /-- An element `x` of an algebra `A` over a commutative ring `R` is said to be *integral*,
 if it is a root of some monic polynomial `p : polynomial R`. -/
@@ -28,8 +28,11 @@ theorem is_integral_algebra_map {x : R} : is_integral R (algebra_map R A x) :=
 ⟨X - C x, monic_X_sub_C _,
 by rw [alg_hom.map_sub, aeval_def, aeval_def, eval₂_X, eval₂_C, sub_self]⟩
 
+theorem is_integral_alg_hom (f : A →ₐ[R] B) {x : A} (hx : is_integral R x) : is_integral R (f x) :=
+let ⟨p, hp, hpx⟩ := hx in ⟨p, hp, by rw [aeval_alg_hom_apply, hpx, f.map_zero]⟩
+
 theorem is_integral_of_subring {x : A} (T : set R) [is_subring T]
-  (hx : is_integral T (algebra.comap.to_comap T R A x)) : is_integral R (x : A) :=
+  (hx : is_integral T x) : is_integral R x :=
 let ⟨p, hpm, hpx⟩ := hx in
 ⟨⟨p.support, λ n, (p.to_fun n).1,
   λ n, finsupp.mem_support_iff.trans (not_iff_not_of_iff
@@ -38,8 +41,7 @@ let ⟨p, hpm, hpx⟩ := hx in
 have _ := congr_arg subtype.val hpm, this, hpx⟩
 
 theorem is_integral_iff_is_integral_closure_finite {r : A} :
-  is_integral R r ↔ ∃ s : set R, s.finite ∧
-    is_integral (ring.closure s) (algebra.comap.to_comap (ring.closure s) R A r) :=
+  is_integral R r ↔ ∃ s : set R, s.finite ∧ is_integral (ring.closure s) r :=
 begin
   split; intro hr,
   { rcases hr with ⟨p, hmp, hpr⟩,
@@ -77,15 +79,9 @@ end
 
 theorem fg_adjoin_of_finite {s : set A} (hfs : s.finite)
   (his : ∀ x ∈ s, is_integral R x) : (algebra.adjoin R s : submodule R A).fg :=
-set.finite.induction_on hfs (λ _, ⟨{1}, le_antisymm
-  (span_le.2 $ finset.singleton_subset_set_iff.2 $ is_submonoid.one_mem)
-  begin
-    rw submodule.le_def,
-    change ring.closure _ ⊆ _,
-    simp only [set.union_empty, finset.coe_singleton, span_singleton_eq_range,
-      algebra.smul_def, mul_one],
-    exact ring.closure_subset (set.subset.refl _)
-  end⟩)
+set.finite.induction_on hfs (λ _, ⟨{1}, submodule.ext $ λ x,
+  by { erw [algebra.adjoin_empty, finset.coe_singleton, ← one_eq_span, one_eq_map_top,
+      map_top, linear_map.mem_range, algebra.mem_bot], refl }⟩)
 (λ a s has hs ih his, by rw [← set.union_singleton, algebra.adjoin_union_coe_submodule]; exact
   fg_mul _ _ (ih $ λ i hi, his i $ set.mem_insert_of_mem a hi)
     (fg_adjoin_singleton_of_integral _ $ his a $ set.mem_insert a s)) his
@@ -140,66 +136,50 @@ begin
   obtain ⟨lx, hlx1, hlx2⟩ :
     ∃ (l : A →₀ R) (H : l ∈ finsupp.supported R R ↑y), (finsupp.total A A R id) l = x,
   { rwa [←(@finsupp.mem_span_iff_total A A R _ _ _ id ↑y x), set.image_id ↑y, hy] },
-  have : ∀ (jk : (↑(y.product y) : set (A × A))), jk.1.1 * jk.1.2 ∈ (span R ↑y : submodule R A),
-  { intros jk,
-    let j : ↥(↑y : set A) := ⟨jk.1.1, (finset.mem_product.1 jk.2).1⟩,
-    let k : ↥(↑y : set A) := ⟨jk.1.2, (finset.mem_product.1 jk.2).2⟩,
-    have hj : j.1 ∈ (span R ↑y : submodule R A) := subset_span j.2,
-    have hk : k.1 ∈ (span R ↑y : submodule R A) := subset_span k.2,
-    revert hj hk, rw hy, exact @is_submonoid.mul_mem A _ S _ j.1 k.1 },
-  rw ← set.image_id ↑y at this,
-  simp only [finsupp.mem_span_iff_total] at this,
+  have hyS : ∀ {p}, p ∈ y → p ∈ S := λ p hp, show p ∈ (S : submodule R A),
+    by { rw ← hy, exact subset_span hp },
+  have : ∀ (jk : (↑(y.product y) : set (A × A))), jk.1.1 * jk.1.2 ∈ (S : submodule R A) :=
+    λ jk, S.mul_mem (hyS (finset.mem_product.1 jk.2).1) (hyS (finset.mem_product.1 jk.2).2),
+  rw [← hy, ← set.image_id ↑y] at this, simp only [finsupp.mem_span_iff_total] at this,
   choose ly hly1 hly2,
-  let S₀' : finset R := lx.frange ∪ finset.bind finset.univ (finsupp.frange ∘ ly),
-  let S₀ : set R := ring.closure ↑S₀',
-  refine is_integral_of_subring (ring.closure ↑S₀') _,
-  letI : algebra S₀ (algebra.comap S₀ R A) := algebra.comap.algebra _ _ _,
-  letI hmod : module S₀ (algebra.comap S₀ R A) := by apply_instance,
-  have : (span S₀ (insert 1 (↑y:set A) : set (algebra.comap S₀ R A)) : submodule S₀ (algebra.comap S₀ R A)) =
-      (algebra.adjoin S₀ ((↑y : set A) : set (algebra.comap S₀ R A)) : subalgebra S₀ (algebra.comap S₀ R A)),
-  { apply le_antisymm,
-    { rw [span_le, set.insert_subset, mem_coe], split,
-      change _ ∈ ring.closure _, exact is_submonoid.one_mem, exact algebra.subset_adjoin },
-    rw [algebra.adjoin_eq_span, span_le], intros r hr, refine monoid.in_closure.rec_on hr _ _ _,
-    { intros r hr, exact subset_span (set.mem_insert_of_mem _ hr) },
-    { exact subset_span (set.mem_insert _ _) },
-    intros r1 r2 hr1 hr2 ih1 ih2,
-    rw ← set.image_id (insert _ ↑y) at ih1 ih2,
-    simp only [mem_coe, finsupp.mem_span_iff_total] at ih1 ih2,
-    have ih1' := ih1, have ih2' := ih2,
-    rcases ih1' with ⟨l1, hl1, rfl⟩, rcases ih2' with ⟨l2, hl2, rfl⟩,
-    simp only [finsupp.total_apply, finsupp.sum_mul, finsupp.mul_sum, mem_coe],
-    rw [finsupp.sum], refine sum_mem _ _, intros r2 hr2,
-    rw [finsupp.sum], refine sum_mem _ _, intros r1 hr1,
-    rw [algebra.mul_smul_comm, algebra.smul_mul_assoc],
-    letI : module ↥S₀ A := hmod, refine smul_mem _ _ (smul_mem _ _ _),
-    rcases hl1 hr1 with rfl | hr1,
-    { change 1 * r2 ∈ _, rw one_mul r2, exact subset_span (hl2 hr2) },
-    rcases hl2 hr2 with rfl | hr2,
-    { change r1 * 1 ∈ _, rw mul_one, exact subset_span (set.mem_insert_of_mem _ hr1) },
-    let jk : ↥(↑(finset.product y y) : set (A × A)) := ⟨(r1, r2), finset.mem_product.2 ⟨hr1, hr2⟩⟩,
-    specialize hly2 jk, change _ = r1 * r2 at hly2, rw [id, id, ← hly2, finsupp.total_apply],
-    rw [finsupp.sum], refine sum_mem _ _, intros z hz,
-    have : ly jk z ∈ S₀,
-    { apply ring.subset_closure,
-      apply finset.mem_union_right, apply finset.mem_bind.2,
-      exact ⟨jk, finset.mem_univ _, by convert finset.mem_image_of_mem _ hz⟩ },
-    change @has_scalar.smul S₀ (algebra.comap S₀ R A) hmod.to_has_scalar ⟨ly jk z, this⟩ z ∈ _,
-    exact smul_mem _ _ (subset_span (set.mem_insert_of_mem _ (hly1 _ hz))) },
-  haveI : is_noetherian_ring ↥S₀ :=
-    is_noetherian_ring_closure _ (finset.finite_to_set _),
-  apply is_integral_of_noetherian
-    (algebra.adjoin S₀ ((↑y : set A) : set (algebra.comap S₀ R A)) : subalgebra S₀ (algebra.comap S₀ R A))
-    (is_noetherian_of_fg_of_noetherian _ ⟨insert 1 y, by rw finset.coe_insert; convert this⟩),
-  show x ∈ ((algebra.adjoin S₀ ((↑y : set A) : set (algebra.comap S₀ R A)) :
-      subalgebra S₀ (algebra.comap S₀ R A)) : submodule S₀ (algebra.comap S₀ R A)),
-  rw [← hlx2, finsupp.total_apply, finsupp.sum], refine sum_mem _ _, intros r hr,
-  rw ← this,
-  have : lx r ∈ ring.closure ↑S₀' :=
-    ring.subset_closure (finset.mem_union_left _ (by convert finset.mem_image_of_mem _ hr)),
-  change @has_scalar.smul S₀ (algebra.comap S₀ R A) hmod.to_has_scalar ⟨lx r, this⟩ r ∈ _,
+  let S₀ : set R := ring.closure ↑(lx.frange ∪ finset.bind finset.univ (finsupp.frange ∘ ly)),
+  refine is_integral_of_subring S₀ _,
+  have : span S₀ (insert 1 ↑y : set A) * span S₀ (insert 1 ↑y : set A) ≤ span S₀ (insert 1 ↑y : set A),
+  { rw span_mul_span, refine span_le.2 (λ z hz, _),
+    rcases set.mem_mul.1 hz with ⟨p, q, rfl | hp, hq, rfl⟩,
+    { rw one_mul, exact subset_span hq },
+    rcases hq with rfl | hq,
+    { rw mul_one, exact subset_span (or.inr hp) },
+    erw ← hly2 ⟨(p, q), finset.mem_product.2 ⟨hp, hq⟩⟩,
+    rw [finsupp.total_apply, finsupp.sum],
+    refine (span S₀ (insert 1 ↑y : set A)).sum_mem (λ t ht, _),
+    have : ly ⟨(p, q), finset.mem_product.2 ⟨hp, hq⟩⟩ t ∈ S₀ :=
+    ring.subset_closure (finset.mem_union_right _ $ finset.mem_bind.2
+      ⟨⟨(p, q), finset.mem_product.2 ⟨hp, hq⟩⟩, finset.mem_univ _,
+        finsupp.mem_frange.2 ⟨finsupp.mem_support_iff.1 ht, _, rfl⟩⟩),
+    change (⟨_, this⟩ : S₀) • t ∈ _, exact smul_mem _ _ (subset_span $ or.inr $ hly1 _ ht) },
+  haveI : is_subring (span S₀ (insert 1 ↑y : set A) : set A) :=
+  { one_mem := subset_span $ or.inl rfl,
+    mul_mem := λ p q hp hq, this $ mul_mem_mul hp hq,
+    zero_mem := (span S₀ (insert 1 ↑y : set A)).zero_mem,
+    add_mem := λ _ _, (span S₀ (insert 1 ↑y : set A)).add_mem,
+    neg_mem := λ _, (span S₀ (insert 1 ↑y : set A)).neg_mem },
+  have : span S₀ (insert 1 ↑y : set A) = algebra.adjoin S₀ (↑y : set A),
+  { refine le_antisymm (span_le.2 $ set.insert_subset.2
+        ⟨(algebra.adjoin S₀ ↑y).one_mem, algebra.subset_adjoin⟩) (λ z hz, _),
+    rw [subalgebra.mem_to_submodule, algebra.mem_adjoin_iff] at hz, rw ← submodule.mem_coe,
+    refine ring.closure_subset (set.union_subset (set.range_subset_iff.2 $ λ t, _)
+      (λ t ht, subset_span $ or.inr ht)) hz,
+    rw algebra.algebra_map_eq_smul_one,
+    exact smul_mem (span S₀ (insert 1 ↑y : set A)) _ (subset_span $ or.inl rfl) },
+  haveI : is_noetherian_ring ↥S₀ := is_noetherian_ring_closure _ (finset.finite_to_set _),
+  refine is_integral_of_noetherian (algebra.adjoin S₀ ↑y)
+    (is_noetherian_of_fg_of_noetherian _ ⟨insert 1 y, by rw [finset.coe_insert, this]⟩) _ _,
+  rw [← hlx2, finsupp.total_apply, finsupp.sum], refine subalgebra.sum_mem _ (λ r hr, _),
+  have : lx r ∈ S₀ := ring.subset_closure (finset.mem_union_left _ (finset.mem_image_of_mem _ hr)),
+  change (⟨_, this⟩ : S₀) • r ∈ _,
   rw finsupp.mem_supported at hlx1,
-  exact smul_mem _ _ (subset_span (set.mem_insert_of_mem _ (hlx1 hr))),
+  exact subalgebra.smul_mem _ (algebra.subset_adjoin $ hlx1 hr) _
 end
 
 theorem is_integral_of_mem_closure {x y z : A}
@@ -210,7 +190,7 @@ begin
   have := fg_mul _ _ (fg_adjoin_singleton_of_integral x hx) (fg_adjoin_singleton_of_integral y hy),
   rw [← algebra.adjoin_union_coe_submodule, set.singleton_union] at this,
   exact is_integral_of_mem_of_fg (algebra.adjoin R {x, y}) this z
-    (ring.closure_mono (set.subset_union_right _ _) hz)
+    (algebra.mem_adjoin_iff.2  $ ring.closure_mono (set.subset_union_right _ _) hz)
 end
 
 theorem is_integral_zero : is_integral R (0:A) :=
@@ -242,14 +222,13 @@ is_integral_of_mem_closure hx hy (is_submonoid.mul_mem
 
 variables (R A)
 def integral_closure : subalgebra R A :=
-{ carrier := { r | is_integral R r },
-  subring :=
-  { zero_mem := is_integral_zero,
-    one_mem := is_integral_one,
-    add_mem := λ _ _, is_integral_add,
-    neg_mem := λ _, is_integral_neg,
-    mul_mem := λ _ _, is_integral_mul },
-  range_le' := λ y ⟨x, hx⟩, hx ▸ is_integral_algebra_map }
+{ carrier :=
+  { carrier := { r | is_integral R r },
+    zero_mem' := is_integral_zero,
+    one_mem' := is_integral_one,
+    add_mem' := λ _ _, is_integral_add,
+    mul_mem' := λ _ _, is_integral_mul },
+  algebra_map_mem' := λ x, is_integral_algebra_map }
 
 theorem mem_integral_closure_iff_mem_fg {r : A} :
   r ∈ integral_closure R A ↔ ∃ M : subalgebra R A, (M : submodule R A).fg ∧ r ∈ M :=
@@ -268,21 +247,21 @@ begin
   rcases hr with ⟨p, hmp, hpx⟩,
   refine ⟨to_subring (of_subring _ (of_subring _ p)) _ _, _, hpx⟩,
   { intros x hx, rcases finsupp.mem_frange.1 hx with ⟨h1, n, rfl⟩,
-    change (coeff p n).1.1 ∈ ring.closure _,
+    change (coeff p n).1.1 ∈ algebra.adjoin R (_ : set A),
     rcases ring.exists_list_of_mem_closure (coeff p n).2 with ⟨L, HL1, HL2⟩, rw ← HL2,
     clear HL2 hfs h1 hx n hmp hpx hr r p,
-    induction L with hd tl ih, { exact is_add_submonoid.zero_mem },
+    induction L with hd tl ih, { exact subalgebra.zero_mem _ },
     rw list.forall_mem_cons at HL1,
     rw [list.map_cons, list.sum_cons],
-    refine is_add_submonoid.add_mem _ (ih HL1.2),
+    refine subalgebra.add_mem _ _ (ih HL1.2),
     cases HL1 with HL HL', clear HL' ih tl,
-    induction hd with hd tl ih, { exact is_submonoid.one_mem },
+    induction hd with hd tl ih, { exact subalgebra.one_mem _ },
     rw list.forall_mem_cons at HL,
     rw list.prod_cons,
-    refine is_submonoid.mul_mem _ (ih HL.2),
+    refine subalgebra.mul_mem _ _ (ih HL.2),
     rcases HL.1 with hs | rfl,
     { exact algebra.subset_adjoin (set.mem_image_of_mem _ hs) },
-    exact is_add_subgroup.neg_mem (is_submonoid.one_mem) },
+    exact subalgebra.neg_mem _ (subalgebra.one_mem _) },
   replace hmp := congr_arg subtype.val hmp,
   replace hmp := congr_arg subtype.val hmp,
   exact subtype.eq hmp
@@ -294,72 +273,51 @@ section algebra
 open algebra
 variables {R : Type*} {A : Type*} {B : Type*}
 variables [comm_ring R] [comm_ring A] [comm_ring B]
-variables [algebra R A] [algebra A B]
+variables [algebra R A] [algebra A B] [algebra R B] [is_algebra_tower R A B]
 
-
-lemma is_integral_trans_aux (x : B) {p : polynomial A} (pmonic : monic p) (hp : aeval A B x p = 0)
-  (S : set (comap R A B))
-  (hS : S = (↑((finset.range (p.nat_degree + 1)).image
-    (λ i, to_comap R A B (p.coeff i))) : set (comap R A B))) :
-  is_integral (adjoin R S) (comap.to_comap R A B x) :=
+lemma is_integral_trans_aux (x : B) {p : polynomial A} (pmonic : monic p) (hp : aeval A B x p = 0) :
+  is_integral (adjoin R (↑(p.map $ algebra_map A B).frange : set B)) x :=
 begin
-  have coeffs_mem : ∀ i, coeff (map ↑(to_comap R A B) p) i ∈ adjoin R S,
-  { intro i,
-    by_cases hi : i ∈ finset.range (p.nat_degree + 1),
-    { apply algebra.subset_adjoin, subst S,
-      rw [finset.mem_coe, finset.mem_image, coeff_map],
-      exact ⟨i, hi, rfl⟩ },
-    { rw [finset.mem_range, not_lt] at hi,
-      rw [coeff_map, coeff_eq_zero_of_nat_degree_lt hi, ring_hom.map_zero],
-      exact submodule.zero_mem (adjoin R S : submodule R (comap R A B)) } },
-  obtain ⟨q, hq⟩ : ∃ q : polynomial (adjoin R S), q.map (algebra_map (adjoin R S) (comap R A B)) =
-      (p.map $ to_comap R A B),
-  { rw [← set.mem_range], dsimp only,
-    apply (polynomial.mem_map_range _).2,
-    { intros i, specialize coeffs_mem i, rw ← subalgebra.mem_coe at coeffs_mem,
-      convert coeffs_mem, exact subtype.range_coe } },
+  generalize hS : (↑(p.map $ algebra_map A B).frange : set B) = S,
+  have coeffs_mem : ∀ i, (p.map $ algebra_map A B).coeff i ∈ adjoin R S,
+  { intro i, by_cases hi : (p.map $ algebra_map A B).coeff i = 0,
+    { rw hi, exact subalgebra.zero_mem _ },
+    rw ← hS, exact subset_adjoin (finsupp.mem_frange.2 ⟨hi, i, rfl⟩) },
+  obtain ⟨q, hq⟩ : ∃ q : polynomial (adjoin R S), q.map (algebra_map (adjoin R S) B) =
+      (p.map $ algebra_map A B),
+  { rw ← set.mem_range, exact (polynomial.mem_map_range _).2 (λ i, ⟨⟨_, coeffs_mem i⟩, rfl⟩) },
   use q,
   split,
-  { suffices h : (q.map (algebra_map (adjoin R S) (comap R A B))).monic,
+  { suffices h : (q.map (algebra_map (adjoin R S) B)).monic,
     { refine monic_of_injective _ h,
       exact subtype.val_injective },
     { rw hq, exact monic_map _ pmonic } },
   { convert hp using 1,
-    replace hq := congr_arg (eval (comap.to_comap R A B x)) hq,
+    replace hq := congr_arg (eval x) hq,
     convert hq using 1; symmetry; apply eval_map },
 end
 
 /-- If A is an R-algebra all of whose elements are integral over R,
 and x is an element of an A-algebra that is integral over A, then x is integral over R.-/
 lemma is_integral_trans (A_int : ∀ x : A, is_integral R x) (x : B) (hx : is_integral A x) :
-  is_integral R (comap.to_comap R A B x) :=
+  is_integral R x :=
 begin
   rcases hx with ⟨p, pmonic, hp⟩,
-  let S : set (comap R A B) :=
-    (↑((finset.range (p.nat_degree + 1)).image
-      (λ i, to_comap R A B (p.coeff i))) : set (comap R A B)),
-  refine is_integral_of_mem_of_fg (adjoin R (S ∪ {comap.to_comap R A B x})) _ _ _,
-  swap, { apply subset_adjoin, simp },
-  apply fg_trans,
-  { apply fg_adjoin_of_finite, { apply finset.finite_to_set },
-    intros x hx,
-    rw [finset.mem_coe, finset.mem_image] at hx,
-    rcases hx with ⟨i, hi, rfl⟩,
-    rcases A_int (p.coeff i) with ⟨q, hq, hqx⟩,
-    use [q, hq],
-    replace hqx := congr_arg (to_comap R A B : A → (comap R A B)) hqx,
-    rw alg_hom.map_zero at hqx,
-    convert hqx using 1,
-    symmetry, exact polynomial.hom_eval₂ _ _ _ _ },
+  let S : set B := ↑(p.map $ algebra_map A B).frange,
+  refine is_integral_of_mem_of_fg (adjoin R (S ∪ {x})) _ _ (subset_adjoin $ or.inr rfl),
+  refine fg_trans (fg_adjoin_of_finite (finset.finite_to_set _) (λ x hx, _)) _,
+  { rw [finset.mem_coe, finsupp.mem_frange] at hx, rcases hx with ⟨_, i, rfl⟩,
+    show is_integral R ((p.map $ algebra_map A B).coeff i), rw coeff_map,
+    convert is_integral_alg_hom (is_algebra_tower.to_alg_hom R A B) (A_int _) },
   { apply fg_adjoin_singleton_of_integral,
-    exact is_integral_trans_aux _ pmonic hp _ rfl }
+    exact is_integral_trans_aux _ pmonic hp }
 end
 
 /-- If A is an R-algebra all of whose elements are integral over R,
 and B is an A-algebra all of whose elements are integral over A,
 then all elements of B are integral over R.-/
 lemma algebra.is_integral_trans (A_int : ∀ x : A, is_integral R x)(B_int : ∀ x:B, is_integral A x) :
-  ∀ x:(comap R A B), is_integral R x :=
+  ∀ x:B, is_integral R x :=
 λ x, is_integral_trans A_int x (B_int x)
 
 end algebra

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -623,6 +623,8 @@ instance : algebra R f.codomain := f.to_map.to_algebra
   (algebra.of_id R f.codomain) a = f.to_map a :=
 rfl
 
+@[simp] lemma algebra_map_eq : algebra_map R f.codomain = f.to_map := rfl
+
 variables (f)
 /-- Localization map `f` from `R` to `S` as an `R`-linear map. -/
 def lin_coe : R →ₗ[R] f.codomain :=
@@ -709,10 +711,11 @@ lemma integer_normalization_eval₂_eq_zero (g : f.codomain →+* R') (p : polyn
 let ⟨b, hb⟩ := integer_normalization_map_to_map p in
 trans (eval₂_map f.to_map g x).symm (by rw [hb, eval₂_smul, hx, smul_zero])
 
-lemma integer_normalization_aeval_eq_zero [algebra f.codomain R'] (p : polynomial f.codomain)
-  {x : R'} (hx : aeval _ _ x p = 0) :
-  aeval _ (algebra.comap R f.codomain R') x (integer_normalization p) = 0 :=
-integer_normalization_eval₂_eq_zero (algebra_map f.codomain R') p hx
+lemma integer_normalization_aeval_eq_zero [algebra R R'] [algebra f.codomain R']
+  [is_algebra_tower R f.codomain R'] (p : polynomial f.codomain)
+  {x : R'} (hx : aeval _ _ x p = 0) : aeval _ R' x (integer_normalization p) = 0 :=
+by rw [aeval_def, is_algebra_tower.algebra_map_eq R f.codomain R', algebra_map_eq,
+    integer_normalization_eval₂_eq_zero _ _ hx]
 
 end integer_normalization
 
@@ -931,14 +934,14 @@ begin
 end
 
 /-- A field is algebraic over the ring `A` iff it is algebraic over the field of fractions of `A`. -/
-lemma comap_is_algebraic_iff [algebra f.codomain L] :
-  algebra.is_algebraic A (algebra.comap A f.codomain L) ↔ algebra.is_algebraic f.codomain L :=
+lemma comap_is_algebraic_iff [algebra A L] [algebra f.codomain L] [is_algebra_tower A f.codomain L] :
+  algebra.is_algebraic A L ↔ algebra.is_algebraic f.codomain L :=
 begin
   split; intros h x; obtain ⟨p, hp, px⟩ := h x,
   { refine ⟨p.map f.to_map, λ h, hp (polynomial.ext (λ i, _)), _⟩,
   { have : f.to_map (p.coeff i) = 0 := trans (polynomial.coeff_map _ _).symm (by simp [h]),
     exact f.to_map_eq_zero_iff.mpr this },
-  { exact trans (polynomial.eval₂_map _ _ _) px } },
+  { rwa [is_algebra_tower.aeval_apply _ f.codomain, algebra_map_eq] at px } },
   { exact ⟨integer_normalization p,
            mt f.integer_normalization_eq_zero_iff.mp hp,
            integer_normalization_aeval_eq_zero p px⟩ },
@@ -1037,11 +1040,13 @@ def fraction_map_of_algebraic [algebra A L] (alg : is_algebraic A L)
 
 /-- If the field `L` is a finite extension of the fraction field of the integral domain `A`,
 the integral closure of `A` in `L` has fraction field `L`. -/
-def fraction_map_of_finite_extension [algebra f.codomain L] [finite_dimensional f.codomain L] :
-  fraction_map (integral_closure A (algebra.comap A f.codomain L)) (algebra.comap A f.codomain L) :=
+def fraction_map_of_finite_extension [algebra A L] [algebra f.codomain L]
+  [is_algebra_tower A f.codomain L] [finite_dimensional f.codomain L] :
+  fraction_map (integral_closure A L) L :=
 fraction_map_of_algebraic
   (f.comap_is_algebraic_iff.mpr is_algebraic_of_finite)
-  (λ x hx, f.to_map_eq_zero_iff.mpr ((algebra_map f.codomain L).map_eq_zero.mp hx))
+  (λ x hx, f.to_map_eq_zero_iff.mpr ((algebra_map f.codomain L).map_eq_zero.mp $
+    (is_algebra_tower.algebra_map_apply _ _ _ _).symm.trans hx))
 
 end integral_closure
 

--- a/src/ring_theory/subsemiring.lean
+++ b/src/ring_theory/subsemiring.lean
@@ -94,7 +94,7 @@ protected theorem ext'_iff {s t : subsemiring R}  : s = t ↔ (s : set R) = t :=
 ⟨λ h, h ▸ rfl, λ h, ext' h⟩
 
 /-- Two subsemirings are equal if they have the same elements. -/
-theorem ext {S T : subsemiring R} (h : ∀ x, x ∈ S ↔ x ∈ T) : S = T := ext' $ set.ext h
+@[ext] theorem ext {S T : subsemiring R} (h : ∀ x, x ∈ S ↔ x ∈ T) : S = T := ext' $ set.ext h
 
 /-- A subsemiring contains the semiring's 1. -/
 theorem one_mem : (1 : R) ∈ s := s.one_mem'
@@ -337,6 +337,41 @@ lemma closure_induction {s : set R} {p : R → Prop} {x} (h : x ∈ closure s)
   (Hs : ∀ x ∈ s, p x) (H0 : p 0) (H1 : p 1)
   (Hadd : ∀ x y, p x → p y → p (x + y)) (Hmul : ∀ x y, p x → p y → p (x * y)) : p x :=
 (@closure_le _ _ _ ⟨p, H1, Hmul, H0, Hadd⟩).2 Hs h
+
+lemma mem_closure_iff {s : set R} {x} :
+  x ∈ closure s ↔ x ∈ add_submonoid.closure (submonoid.closure s : set R) :=
+⟨λ h, closure_induction h (λ x hx, add_submonoid.subset_closure $ submonoid.subset_closure hx)
+  (add_submonoid.zero_mem _)
+  (add_submonoid.subset_closure $ submonoid.one_mem $ submonoid.closure s)
+  (λ _ _, add_submonoid.add_mem _)
+  (λ x y ihx ihy, add_submonoid.closure_induction ihy
+    (λ q hq, add_submonoid.closure_induction ihx
+      (λ p hp, add_submonoid.subset_closure $ (submonoid.closure s).mul_mem hp hq)
+      ((zero_mul q).symm ▸ add_submonoid.zero_mem _)
+      (λ p₁ p₂ ihp₁ ihp₂, (add_mul p₁ p₂ q).symm ▸ add_submonoid.add_mem _ ihp₁ ihp₂))
+    ((mul_zero x).symm ▸ add_submonoid.zero_mem _)
+    (λ q₁ q₂ ihq₁ ihq₂, (mul_add x q₁ q₂).symm ▸ add_submonoid.add_mem _ ihq₁ ihq₂)),
+λ h, add_submonoid.closure_induction h
+  (λ x hx, submonoid.closure_induction hx subset_closure (one_mem _) (λ _ _, mul_mem _))
+  (zero_mem _)
+  (λ _ _, add_mem _)⟩
+
+lemma mem_closure_iff_exists_list {s : set R} {x} : x ∈ closure s ↔
+  ∃ L : list (list R), (∀ t ∈ L, ∀ y ∈ t, y ∈ s) ∧ (L.map list.prod).sum = x :=
+⟨λ hx, add_submonoid.closure_induction (mem_closure_iff.1 hx)
+  (λ x hx, suffices ∃ t : list R, (∀ y ∈ t, y ∈ s) ∧ t.prod = x,
+    from let ⟨t, ht1, ht2⟩ := this in ⟨[t], list.forall_mem_singleton.2 ht1,
+      by rw [list.map_singleton, list.sum_singleton, ht2]⟩,
+    submonoid.closure_induction hx
+      (λ x hx, ⟨[x], list.forall_mem_singleton.2 hx, one_mul x⟩)
+      ⟨[], list.forall_mem_nil _, rfl⟩
+      (λ x y ⟨t, ht1, ht2⟩ ⟨u, hu1, hu2⟩, ⟨t ++ u, list.forall_mem_append.2 ⟨ht1, hu1⟩,
+        by rw [list.prod_append, ht2, hu2]⟩))
+  ⟨[], list.forall_mem_nil _, rfl⟩
+  (λ x y ⟨L, HL1, HL2⟩ ⟨M, HM1, HM2⟩, ⟨L ++ M, list.forall_mem_append.2 ⟨HL1, HM1⟩,
+    by rw [list.map_append, list.sum_append, HL2, HM2]⟩),
+λ ⟨L, HL1, HL2⟩, HL2 ▸ list_sum_mem _ (λ r hr, let ⟨t, ht1, ht2⟩ := list.mem_map.1 hr in
+  ht2 ▸ list_prod_mem _ (λ y hy, subset_closure $ HL1 t ht1 y hy))⟩
 
 variable (R)
 


### PR DESCRIPTION
`algebra.comap` is now reserved to the **creation** of new algebra instances. For assumptions of theorems / constructions, `is_algebra_tower` is the new way to do it. For example:
```lean
variables [algebra K L] [algebra L A]
lemma is_algebraic_trans (L_alg : is_algebraic K L) (A_alg : is_algebraic L A) :
  is_algebraic K (comap K L A) :=
```
is now written as:
```lean
variables [algebra K L] [algebra L A] [algebra K A] [is_algebra_tower K L A]
lemma is_algebraic_trans (L_alg : is_algebraic K L) (A_alg : is_algebraic L A) :
  is_algebraic K A :=
```


---
<!-- put comments you want to keep out of the PR commit here -->
