### PR TITLE
[Merged by Bors] - doc(tactic/lean_core_docs): remove "hypothesis management" tag

### DIFF
--- a/src/tactic/lean_core_docs.lean
+++ b/src/tactic/lean_core_docs.lean
@@ -590,7 +590,7 @@ add_tactic_doc
 { name       := "specialize",
   category   := doc_category.tactic,
   decl_names := [`tactic.interactive.specialize],
-  tags       := ["core", "hypothesis management", "lemma application"] }
+  tags       := ["core", "context management", "lemma application"] }
 
 add_tactic_doc
 { name       := "split",


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->
I feel like I've tried to kill this tag before but it came back. "Hypothesis management" and "context management" are redundant and this is the only of the former right now.