### PR TITLE
[Merged by Bors] - fix(tactic/lint/type_classes): add missing unfreeze_local_instances

### DIFF
--- a/src/tactic/cache.lean
+++ b/src/tactic/cache.lean
@@ -24,8 +24,8 @@ unfreeze_local_instances,
 freeze_local_instances
 
 /-- Unfreeze the local instances while executing `tac` on the main goal. -/
-meta def unfreezing (tac : tactic unit) : tactic unit :=
-unfreeze_local_instances *> (tac; freeze_local_instances)
+meta def unfreezing {α} (tac : tactic α) : tactic α :=
+focus1 $ unfreeze_local_instances *> tac <* all_goals freeze_local_instances
 
 /--
 Unfreeze local instances while executing `tac`,

--- a/src/tactic/lint/simp.lean
+++ b/src/tactic/lint/simp.lean
@@ -84,7 +84,7 @@ try_for timeout $
 retrieve $ do
 g ← mk_meta_var d.type,
 set_goals [g],
-unfreezing (intros *> skip),
+unfreezing intros,
 (lhs, rhs) ← target >>= simp_lhs_rhs,
 sls ← simp_lemmas.mk_default,
 let sls' := sls.erase [d.to_name],

--- a/src/tactic/lint/type_classes.lean
+++ b/src/tactic/lint/type_classes.lean
@@ -305,9 +305,8 @@ forall_or_distrib_right not_ball
 
 private meta def has_coe_to_fun_linter (d : declaration) : tactic (option string) :=
 retrieve $ do
-reset_instance_cache,
 mk_meta_var d.type >>= set_goals ∘ pure,
-args ← intros,
+args ← unfreezing intros,
 expr.sort _ ← target | pure none,
 let ty : expr := (expr.const d.to_name d.univ_levels).mk_app args,
 some coe_fn_inst ←

--- a/test/lint_coe_to_fun.lean
+++ b/test/lint_coe_to_fun.lean
@@ -31,3 +31,31 @@ decl ← get_decl ``sparkling_equiv,
 res ← linter.has_coe_to_fun.test decl,
 -- linter doesn't complain
 guard res.is_none
+
+
+
+
+-- Test support for type-class parameters in the `has_coe_to_fun` instance.
+namespace with_tc_param
+
+structure equiv (α β : Sort*) :=
+(to_fun : α → β)
+(inv_fun : β → α)
+
+instance {α β} [nonempty α] : has_coe_to_fun (equiv α β) :=
+⟨λ _, α → β, equiv.to_fun⟩
+
+structure sparkling_equiv (α β) [nonempty α] extends equiv α β
+
+instance {α β} [nonempty α] : has_coe (sparkling_equiv α β) (equiv α β) :=
+⟨sparkling_equiv.to_equiv⟩
+
+-- should complain
+open tactic
+#eval do
+decl ← get_decl ``sparkling_equiv,
+res ← linter.has_coe_to_fun.test decl,
+-- linter complains
+guard res.is_some
+
+end with_tc_param


### PR DESCRIPTION
---
This might fail during linting.