### PR TITLE
[Merged by Bors] - chore(*): import tactic.basic as early as possible, and reduce imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
-  "search.usePCRE2": true
+  "search.usePCRE2": true,
+  "git.ignoreLimitWarning": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,5 @@
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
-  "search.usePCRE2": true,
+  "search.usePCRE2": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,4 @@
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
   "search.usePCRE2": true,
-  "git.ignoreLimitWarning": true
 }

--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -11,7 +11,6 @@ import data.finset.powerset
 import data.finset.pi
 import data.equiv.mul_add
 import tactic.abel
-import tactic.simp_rw
 import data.nat.enat
 
 /-!

--- a/src/algebra/category/Group/biproducts.lean
+++ b/src/algebra/category/Group/biproducts.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import tactic.converter.apply_congr
 import algebra.category.Group.basic
 import algebra.category.Group.preadditive
 import category_theory.limits.shapes.biproducts

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -3,11 +3,10 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Simon Hudon, Mario Carneiro
 -/
+import tactic.basic
 import algebra.group.to_additive
 import algebra.group.defs
-import tactic.simpa
 import logic.function.basic
-import tactic.protected
 
 universe u
 

--- a/src/algebra/group/conj.lean
+++ b/src/algebra/group/conj.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Chris Hughes, Michael Howes
 -/
 import algebra.group.hom
-import tactic.rewrite
+
 /-!
 # Conjugacy of group elements
 -/

--- a/src/algebra/group/defs.lean
+++ b/src/algebra/group/defs.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Simon Hudon, Mario Carneiro
 -/
 import algebra.group.to_additive
-import tactic.protected
+import tactic.basic
 
 /-!
 # Typeclasses for (semi)groups and monoid

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -5,7 +5,6 @@ Authors: Patrick Massot, Kevin Buzzard, Scott Morrison, Johan Commelin, Chris Hu
   Johannes Hölzl, Yury Kudryashov
 -/
 import algebra.group.commute
-import tactic.ext
 
 /-!
 # monoid and group homomorphisms

--- a/src/algebra/group/semiconj.lean
+++ b/src/algebra/group/semiconj.lean
@@ -6,7 +6,6 @@ Authors: Yury Kudryashov
 Some proofs and docs came from `algebra/commute` (c) Neil Strickland
 -/
 import algebra.group.units
-import tactic.rewrite
 
 /-!
 # Semiconjugate elements of a semigroup

--- a/src/algebra/group/units.lean
+++ b/src/algebra/group/units.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Mario Carneiro, Johannes Hölzl, Chris Hughes, Jens Wagemaker
 -/
 import algebra.group.basic
-import tactic.ext
-import tactic.norm_cast
 
 /-!
 # Units (i.e., invertible elements) of a multiplicative monoid

--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Johan Commelin
 -/
-import algebra.group.hom
 import algebra.ring
 
 universes u v

--- a/src/algebra/group_with_zero.lean
+++ b/src/algebra/group_with_zero.lean
@@ -3,13 +3,9 @@ Copyright (c) 2020 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import tactic.alias
-import tactic.push_neg
-import tactic.localized
-import logic.unique
+import logic.nontrivial
 import algebra.group.commute
 import algebra.group.units_hom
-import logic.nontrivial
 import algebra.group.inj_surj
 
 /-!

--- a/src/algebra/homology/homology.lean
+++ b/src/algebra/homology/homology.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Markus Himmel
 -/
 import algebra.homology.chain_complex
-import category_theory.limits.shapes.images
 import category_theory.limits.shapes.kernels
 
 /-!

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -3,7 +3,6 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
-import algebra.group.units
 import algebra.group.with_one
 import algebra.group.type_tags
 import order.bounded_lattice

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -3,7 +3,6 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro
 -/
-import algebra.ring
 import algebra.ordered_group
 
 set_option default_priority 100 -- see Note [default priority]

--- a/src/algebra/ring.lean
+++ b/src/algebra/ring.lean
@@ -7,9 +7,6 @@ Neil Strickland
 import algebra.group.hom
 import algebra.group.units
 import algebra.group_with_zero
-import tactic.alias
-import tactic.norm_cast
-import tactic.split_ifs
 
 /-!
 # Properties and homomorphisms of semirings and rings

--- a/src/category_theory/category/default.lean
+++ b/src/category_theory/category/default.lean
@@ -3,10 +3,7 @@ Copyright (c) 2017 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stephen Morgan, Scott Morrison, Johannes Hölzl, Reid Barton
 -/
-import tactic.replacer
-import tactic.restate_axiom
-import tactic.split_ifs
-import tactic.simpa
+import tactic.basic
 import tactic.tidy
 
 /-!

--- a/src/category_theory/concrete_category/bundled.lean
+++ b/src/category_theory/concrete_category/bundled.lean
@@ -2,18 +2,17 @@
 Copyright (c) 2018 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Johannes Hölzl, Reid Barton, Sean Leather
-
-Bundled types.
 -/
-import tactic.doc_commands
-import tactic.lint
+import category_theory.category
 
 /-!
+# Bundled types
+
 `bundled c` provides a uniform structure for bundling a type equipped with a type class.
 
-We provide `category` instances for these in `unbundled_hom.lean` (for categories with unbundled
-homs, e.g. topological spaces) and in `bundled_hom.lean` (for categories with bundled homs, e.g.
-monoids).
+We provide `category` instances for these in `category_theory/unbundled_hom.lean`
+(for categories with unbundled homs, e.g. topological spaces)
+and in `category_theory/bundled_hom.lean` (for categories with bundled homs, e.g. monoids).
 -/
 
 universes u v

--- a/src/category_theory/fully_faithful.lean
+++ b/src/category_theory/fully_faithful.lean
@@ -5,7 +5,6 @@ Authors: Scott Morrison
 -/
 import logic.function.basic
 import category_theory.natural_isomorphism
-import tactic.alias
 
 universes v₁ v₂ v₃ u₁ u₂ u₃ -- declare the `v`'s first; see `category_theory.category` for an explanation
 

--- a/src/category_theory/groupoid.lean
+++ b/src/category_theory/groupoid.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Reid Barton All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Reid Barton, Scott Morrison, David Wärn
 -/
-import tactic.trunc_cases
 import category_theory.category
 import category_theory.epi_mono
 

--- a/src/category_theory/isomorphism.lean
+++ b/src/category_theory/isomorphism.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tim Baumann, Stephen Morgan, Scott Morrison, Floris van Doorn
 -/
 import category_theory.functor
-import tactic.simps
 
 /-!
 # Isomorphisms

--- a/src/category_theory/limits/shapes/kernels.lean
+++ b/src/category_theory/limits/shapes/kernels.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Markus Himmel
 -/
 import category_theory.limits.shapes.zero
-import category_theory.limits.shapes.equalizers
 
 /-!
 # Kernels and cokernels

--- a/src/category_theory/natural_isomorphism.lean
+++ b/src/category_theory/natural_isomorphism.lean
@@ -5,7 +5,6 @@ Authors: Tim Baumann, Stephen Morgan, Scott Morrison, Floris van Doorn
 -/
 import category_theory.functor_category
 import category_theory.isomorphism
-import tactic.localized
 
 open category_theory
 

--- a/src/category_theory/preadditive/biproducts.lean
+++ b/src/category_theory/preadditive/biproducts.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import tactic.abel
-import tactic.converter.apply_congr
 import category_theory.limits.shapes.biproducts
 import category_theory.preadditive
 

--- a/src/category_theory/types.lean
+++ b/src/category_theory/types.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stephen Morgan, Scott Morrison, Johannes Hölzl
 -/
-import control.functor
 import category_theory.fully_faithful
 import data.equiv.basic
 

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -8,8 +8,6 @@ We say two types are equivalent if they are isomorphic.
 
 Two equivalent types have the same cardinality.
 -/
-import tactic.converter.interactive
-import data.quot
 import data.set.function
 import data.option.basic
 import algebra.group.basic

--- a/src/data/equiv/local_equiv.lean
+++ b/src/data/equiv/local_equiv.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
 import data.equiv.basic
-import tactic.tauto
-import tactic.simps
 
 /-!
 # Local equivalences

--- a/src/data/finset/sort.lean
+++ b/src/data/finset/sort.lean
@@ -5,7 +5,6 @@ Author: Mario Carneiro
 -/
 import data.finset.lattice
 import data.multiset.sort
-import tactic.suggest
 
 /-!
 # Construct a sorted list from a finset.

--- a/src/data/fintype/card.lean
+++ b/src/data/fintype/card.lean
@@ -5,7 +5,6 @@ Author: Mario Carneiro
 -/
 import data.fintype.basic
 import data.nat.choose
-import tactic.ring
 
 /-!
 Results about "big operations" over a `fintype`, and consequent

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -5,9 +5,7 @@ Authors: Jeremy Avigad
 
 The integers, with addition, multiplication, and subtraction.
 -/
-import tactic.lift
 import algebra.char_zero
-import algebra.ring
 import data.list.range
 
 open nat

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2014 Parikshit Khanna. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Mario Carneiro
 -/
-import algebra.group
 import deprecated.group
 import data.nat.basic
 import order.rel_classes

--- a/src/data/list/forall2.lean
+++ b/src/data/list/forall2.lean
@@ -3,8 +3,6 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Johannes Hölzl
 -/
-import tactic.mk_iff_of_inductive_prop
-import logic.relator
 import data.list.basic
 
 universes u v w z

--- a/src/data/list/func.lean
+++ b/src/data/list/func.lean
@@ -3,7 +3,6 @@ Copyright (c) 2019 Seul Baek. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Seul Baek
 -/
-import tactic.localized
 import data.nat.basic
 
 open list

--- a/src/data/list/pairwise.lean
+++ b/src/data/list/pairwise.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import tactic.mk_iff_of_inductive_prop
 import data.list.basic
 
 open nat function

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -3,8 +3,6 @@ Copyright (c) 2014 Floris van Doorn (c) 2016 Microsoft Corporation. All rights r
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
-import tactic.finish
-import algebra.ordered_ring
 import algebra.order_functions
 import data.set.basic
 

--- a/src/data/opposite.lean
+++ b/src/data/opposite.lean
@@ -5,7 +5,6 @@ Authors: Scott Morrison, Reid Barton, Simon Hudon, Kenny Lau
 
 Opposites.
 -/
-import data.list.defs
 import data.equiv.basic
 
 universes v u -- declare the `v` first; see `category_theory.category` for an explanation

--- a/src/data/option/basic.lean
+++ b/src/data/option/basic.lean
@@ -3,9 +3,7 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import tactic.simpa
-import tactic.ext
-import data.option.defs
+import tactic.basic
 
 namespace option
 variables {α : Type*} {β : Type*} {γ : Type*}

--- a/src/data/polynomial.lean
+++ b/src/data/polynomial.lean
@@ -5,7 +5,6 @@ Authors: Chris Hughes, Johannes Hölzl, Scott Morrison, Jens Wagemaker
 -/
 import tactic.ring_exp
 import tactic.chain
-import tactic.converter.apply_congr
 import data.monoid_algebra
 import algebra.gcd_domain
 import ring_theory.euclidean_domain

--- a/src/data/prod.lean
+++ b/src/data/prod.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
-import tactic.ext
+import tactic.basic
 
 /-!
 # Extra facts about `prod`

--- a/src/data/seq/computation.lean
+++ b/src/data/seq/computation.lean
@@ -7,6 +7,7 @@ Coinductive formalization of unbounded computations.
 -/
 import data.stream
 import tactic.basic
+
 universes u v w
 
 /-

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -3,9 +3,6 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura
 -/
-import tactic.split_ifs
-import tactic.finish
-import tactic.tauto
 import logic.unique
 import order.boolean_algebra
 

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot, Yury Kudryashov
 -/
-import tactic.localized
 import algebra.order_functions
 import data.set.basic
 

--- a/src/data/sym.lean
+++ b/src/data/sym.lean
@@ -6,8 +6,7 @@ Author: Kyle Miller.
 
 import data.multiset.basic
 import data.vector
-import data.quot
-import tactic
+import tactic.tidy
 
 /-!
 # Symmetric powers

--- a/src/data/sym2.lean
+++ b/src/data/sym2.lean
@@ -3,12 +3,9 @@ Copyright (c) 2020 Kyle Miller All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Kyle Miller.
 -/
-
-import data.quot
-import data.equiv.basic
+import tactic.linarith
 import data.sym
-import data.vector
-import tactic
+
 open function
 open sym
 

--- a/src/data/vector2.lean
+++ b/src/data/vector2.lean
@@ -5,12 +5,10 @@ Authors: Mario Carneiro
 
 Additional theorems about the `vector` type.
 -/
-import tactic.tauto
 import data.vector
 import data.list.nodup
 import data.list.of_fn
 import control.applicative
-import control.traversable.basic
 
 universes u
 variables {n : ℕ}

--- a/src/group_theory/eckmann_hilton.lean
+++ b/src/group_theory/eckmann_hilton.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Kenny Lau, Robert Y. Lewis
 -/
-import tactic.basic
 import algebra.group.basic
 
 universe u

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -3,7 +3,6 @@ Copyright (c) 2019 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
-import tactic.converter.apply_congr
 import linear_algebra.dimension
 import ring_theory.principal_ideal_domain
 

--- a/src/logic/nontrivial.lean
+++ b/src/logic/nontrivial.lean
@@ -3,11 +3,8 @@ Copyright (c) 2020 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
-
 import logic.unique
 import logic.function.basic
-import tactic.localized
-import tactic.push_neg
 
 /-!
 # Nontrivial types

--- a/src/logic/relation.lean
+++ b/src/logic/relation.lean
@@ -5,10 +5,7 @@ Authors: Johannes Hölzl
 
 Transitive reflexive as well as reflexive closure of relations.
 -/
-import tactic.mk_iff_of_inductive_prop
-import tactic.rcases
-import tactic.simpa
-import logic.relator
+import tactic.basic
 
 variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*}
 

--- a/src/logic/unique.lean
+++ b/src/logic/unique.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import tactic.ext
+import tactic.basic
 
 universes u v w
 

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -3,8 +3,6 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Mario Carneiro
 -/
-import tactic.interactive
-import tactic.push_neg
 import data.subtype
 import data.prod
 

--- a/src/order/bounded_lattice.lean
+++ b/src/order/bounded_lattice.lean
@@ -10,7 +10,6 @@ Includes the Prop and fun instances.
 import order.lattice
 import data.option.basic
 import tactic.pi_instances
-import tactic.norm_cast
 
 set_option old_structure_cmd true
 

--- a/src/order/rel_classes.lean
+++ b/src/order/rel_classes.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Mario Carneiro, Yury G. Kudryashov
 -/
-import tactic.localized
 import data.set.basic
 
 /-!

--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Yury Kudryashov
 -/
-import tactic.simps
 import data.matrix.basic
 import linear_algebra.tensor_product
 import ring_theory.subsemiring

--- a/src/ring_theory/algebra_operations.lean
+++ b/src/ring_theory/algebra_operations.lean
@@ -5,7 +5,6 @@ Authors: Kenny Lau
 
 Multiplication and division of submodules of an algebra.
 -/
-import tactic.chain
 import ring_theory.algebra
 import ring_theory.ideals
 import algebra.pointwise

--- a/src/tactic/basic.lean
+++ b/src/tactic/basic.lean
@@ -4,12 +4,15 @@ import tactic.converter.apply_congr
 import tactic.elide
 import tactic.explode
 import tactic.find
+import tactic.finish
 import tactic.generalizes
 import tactic.generalize_proofs
 import tactic.lift
 import tactic.lint
 import tactic.localized
 import tactic.mk_iff_of_inductive_prop
+import tactic.norm_cast
+import tactic.protected
 import tactic.push_neg
 import tactic.replacer
 import tactic.rename_var
@@ -23,5 +26,6 @@ import tactic.simps
 import tactic.split_ifs
 import tactic.squeeze
 import tactic.suggest
+import tactic.tauto
 import tactic.trunc_cases
 import tactic.where

--- a/src/tactic/chain.lean
+++ b/src/tactic/chain.lean
@@ -23,34 +23,6 @@ This tactic is used by the `tidy` tactic.
 -- describing what that tactic did as an interactive tactic.
 variable {α : Type}
 
-/-
-Because chain sometimes pauses work on the first goal and works on later goals, we need a method
-for combining a list of results generated while working on a later goal into a single result.
-This enables `tidy {trace_result := tt}` to output faithfully reproduces its operation, e.g.
-````
-intros,
-simp,
-apply lemma_1,
-work_on_goal 2 {
-  dsimp,
-  simp
-},
-refl
-````
--/
-
-namespace interactive
-open lean.parser
-meta def work_on_goal : parse small_nat → itactic → tactic unit
-| n t := do goals ← get_goals,
-            let earlier_goals := goals.take n,
-            let later_goals := goals.drop (n+1),
-            set_goals (goals.nth n).to_list,
-            t,
-            new_goals ← get_goals,
-            set_goals (earlier_goals ++ new_goals ++ later_goals)
-end interactive
-
 inductive tactic_script (α : Type) : Type
 | base : α → tactic_script
 | work (index : ℕ) (first : α) (later : list tactic_script) (closed : bool) : tactic_script

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -85,6 +85,35 @@ non-interactive tactic for patterns like `tac1; id {tac2}` where `tac2` is non-i
 @[inline] protected meta def id (tac : itactic) : tactic unit := tac
 
 /--
+`work_on_goal n { tac }` creates a block scope for the `n`-goal (indexed from zero),
+and does not require that the goal be solved at the end
+(any remaining subgoals are inserted back into the list of goals).
+
+Typically usage might look like:
+````
+intros,
+simp,
+apply lemma_1,
+work_on_goal 2 {
+  dsimp,
+  simp
+},
+refl
+````
+
+See also `id { tac }`, which is equivalent to `work_on_goal 0 { tac }`.
+-/
+meta def work_on_goal : parse small_nat → itactic → tactic unit
+| n t := do
+  goals ← get_goals,
+  let earlier_goals := goals.take n,
+  let later_goals := goals.drop (n+1),
+  set_goals (goals.nth n).to_list,
+  t,
+  new_goals ← get_goals,
+  set_goals (earlier_goals ++ new_goals ++ later_goals)
+
+/--
 `swap n` will move the `n`th goal to the front.
 `swap` defaults to `swap 2`, and so interchanges the first and second goals.
 -/

--- a/src/tactic/noncomm_ring.lean
+++ b/src/tactic/noncomm_ring.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Oliver Nash. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Oliver Nash
 -/
-import tactic.doc_commands
 import tactic.abel
 
 namespace tactic

--- a/src/tactic/push_neg.lean
+++ b/src/tactic/push_neg.lean
@@ -6,9 +6,7 @@ Author: Patrick Massot, Simon Hudon
 A tactic pushing negations into an expression
 -/
 
-
-
-import tactic.interactive
+import logic.basic
 import algebra.order
 
 open tactic expr

--- a/src/tactic/wlog.lean
+++ b/src/tactic/wlog.lean
@@ -5,7 +5,6 @@ Authors: Johannes Hölzl
 
 Without loss of generality tactic.
 -/
-import tactic.tauto
 import data.list.perm
 
 open expr tactic lean lean.parser

--- a/test/mk_iff_of_inductive.lean
+++ b/test/mk_iff_of_inductive.lean
@@ -1,5 +1,3 @@
-import tactic.mk_iff_of_inductive_prop
-
 import data.list
 import data.list.perm
 import data.multiset.basic


### PR DESCRIPTION
As discussed on [zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/import.20refactor.20and.20library_search), #3235 had the unfortunate effect of making `library_search` and `#where` and various other things unavailable in many places in mathlib.

This PR makes an effort to import `tactic.basic` as early as possible, while otherwise reducing unnecessary imports. 

1. import `tactic.basic` "as early as possible" (i.e. in any file that `tactic.basic` doesn't depend on, and which imports any tactic strictly between `tactic.core` and `tactic.basic`, just `import tactic.basic` itself
2. add `tactic.finish`, `tactic.tauto` and `tactic.norm_cast` to tactic.basic (doesn't requires adding any dependencies)
3. delete various unnecessary imports


---
<!-- put comments you want to keep out of the PR commit here -->
