### PR TITLE
[Merged by Bors] - feat(data): Mark all `sqrt`s as `@[pp_nodot]`

### DIFF
--- a/src/data/int/sqrt.lean
+++ b/src/data/int/sqrt.lean
@@ -12,7 +12,7 @@ namespace int
   perfect square, and is positive, it returns the largest `k:ℤ` such
   that `k*k ≤ n`. If it is negative, it returns 0. For example,
   `sqrt 2 = 1` and `sqrt 1 = 1` and `sqrt (-1) = 0` -/
-def sqrt (n : ℤ) : ℤ :=
+@[pp_nodot] def sqrt (n : ℤ) : ℤ :=
 nat.sqrt $ int.to_nat n
 
 theorem sqrt_eq (n : ℤ) : sqrt (n*n) = n.nat_abs :=

--- a/src/data/nat/sqrt.lean
+++ b/src/data/nat/sqrt.lean
@@ -31,7 +31,7 @@ def sqrt_aux : ℕ → ℕ → ℕ → ℕ
 
 /-- `sqrt n` is the square root of a natural number `n`. If `n` is not a
   perfect square, it returns the largest `k:ℕ` such that `k*k ≤ n`. -/
-def sqrt (n : ℕ) : ℕ :=
+@[pp_nodot] def sqrt (n : ℕ) : ℕ :=
 match size n with
 | 0      := 0
 | succ s := sqrt_aux (shiftl 1 (bit0 (div2 s))) 0 n

--- a/src/data/rat/order.lean
+++ b/src/data/rat/order.lean
@@ -224,7 +224,7 @@ end
 
 section sqrt
 
-def sqrt (q : ℚ) : ℚ := rat.mk (int.sqrt q.num) (nat.sqrt q.denom)
+@[pp_nodot] def sqrt (q : ℚ) : ℚ := rat.mk (int.sqrt q.num) (nat.sqrt q.denom)
 
 theorem sqrt_eq (q : ℚ) : rat.sqrt (q*q) = abs q :=
 by rw [sqrt, mul_self_num, mul_self_denom, int.sqrt_eq, nat.sqrt_eq, abs_def]

--- a/src/data/real/basic.lean
+++ b/src/data/real/basic.lean
@@ -476,7 +476,7 @@ begin
      }
 end -/
 
-noncomputable def sqrt (x : ℝ) : ℝ :=
+@[pp_nodot] noncomputable def sqrt (x : ℝ) : ℝ :=
 classical.some (sqrt_exists (le_max_left 0 x))
 /-quotient.lift_on x
   (λ f, mk ⟨sqrt_aux f, (sqrt_aux_converges f).fst⟩)


### PR DESCRIPTION
---

`2.sqrt` seems a bit silly to me, but other people might think otherwise?