### PR TITLE
[Merged by Bors] - fix(tactic/norm_cast): remove bad norm_cast lemma

### DIFF
--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1210,7 +1210,7 @@ end
 @[simp, norm_cast] theorem cast_one [add_monoid α] [has_one α] [has_neg α] :
   ((1 : ℤ) : α) = 1 := nat.cast_one
 
-@[simp, norm_cast] theorem cast_sub_nat_nat [add_group α] [has_one α] (m n) :
+@[simp] theorem cast_sub_nat_nat [add_group α] [has_one α] (m n) :
   ((int.sub_nat_nat m n : ℤ) : α) = m - n :=
 begin
   unfold sub_nat_nat, cases e : n - m,

--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -75,9 +75,7 @@ begin
   congr' 1,
   rw [← mul_div_assoc, eq_div_iff],
   { rw [mul_comm ((n+1 : ℕ) : ℚ)],
-    rw_mod_cast nat.choose_mul_succ_eq n k,
-    rw [int.coe_nat_mul],
     have hk' : k ≤ n + 1, by linarith,
-    rw [int.coe_nat_sub hk', int.sub_nat_nat_eq_coe] },
+    rw_mod_cast nat.choose_mul_succ_eq n k },
   { contrapose! hk with H, rw sub_eq_zero at H, norm_cast at H, linarith }
 end


### PR DESCRIPTION
This was identified as a move_cast lemma, which meant it was rewriting to the LHS which it couldn't reduce. It's better to let the conditional rewriting handle nat subtraction -- if the right inequality is in the context there's no need to go to `int.sub_nat_nat`.