### PR TITLE
[Merged by Bors] - feat(geometry/manifold/charted_space):  typeclass `closed_under_restriction` for structure groupoids

### DIFF
--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -388,7 +388,7 @@ def id_restr_groupoid : structure_groupoid H :=
     rw [← of_set_symm],
     exact local_homeomorph.eq_on_source.symm' hse,
   end,
-  id_mem' := ⟨univ, is_open_univ, by rw refl_eq_of_set⟩,
+  id_mem' := ⟨univ, is_open_univ, by simp⟩,
   locality' := begin
     intros e h,
     refine ⟨e.source, e.open_source, by simp, _⟩,

--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -749,7 +749,7 @@ end maximal_atlas
 
 section singleton
 variables {α : Type*} [topological_space α]
-variables {e : local_homeomorph α H}
+variables (e : local_homeomorph α H)
 
 /-- If a single local homeomorphism `e` from a space `α` into `H` has source covering the whole
 space `α`, then that local homeomorphism induces an `H`-charted space structure on `α`.
@@ -761,17 +761,17 @@ def singleton_charted_space (h : e.source = set.univ) : charted_space H α :=
   chart_mem_atlas := λ _, by tauto }
 
 lemma singleton_charted_space_one_chart (h : e.source = set.univ) (e' : local_homeomorph α H)
-  (h' : e' ∈ (singleton_charted_space h).atlas) : e' = e := h'
+  (h' : e' ∈ (singleton_charted_space e h).atlas) : e' = e := h'
 
 /-- Given a local homeomorphism `e` from a space `α` into `H`, if its source covers the whole
 space `α`, then the induced charted space structure on `α` is `has_groupoid G` for any structure
 groupoid `G` which is closed under restrictions. -/
 lemma singleton_has_groupoid (h : e.source = set.univ) (G : structure_groupoid H)
-  [closed_under_restriction G] : @has_groupoid _ _ _ _ (singleton_charted_space h) G :=
+  [closed_under_restriction G] : @has_groupoid _ _ _ _ (singleton_charted_space e h) G :=
 { compatible := begin
     intros e' e'' he' he'',
-    rw singleton_charted_space_one_chart h e' he',
-    rw singleton_charted_space_one_chart h e'' he'',
+    rw singleton_charted_space_one_chart e h e' he',
+    rw singleton_charted_space_one_chart e h e'' he'',
     refine G.eq_on_source _ e.trans_symm_self,
     have hle : id_restr_groupoid ≤ G := (closed_under_restriction_iff_id_le G).mp (by assumption),
     exact structure_groupoid.le_iff.mp hle _ (id_restr_groupoid_mem _),

--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -375,7 +375,7 @@ class closed_under_restriction (G : structure_groupoid H) : Prop :=
 /-- The trivial restriction-closed groupoid, containing only local homeomorphisms equivalent to the
 restriction of the identity to the various open subsets. -/
 def id_restr_groupoid : structure_groupoid H :=
-{ members := λ e, ∃ {s : set H} (h : is_open s), e ≈ local_homeomorph.of_set s h,
+{ members := {e | ∃ {s : set H} (h : is_open s), e ≈ local_homeomorph.of_set s h},
   trans' := begin
     rintros e e' ⟨s, hs, hse⟩ ⟨s', hs', hse'⟩,
     refine ⟨s ∩ s', is_open_inter hs hs', _⟩,
@@ -755,7 +755,7 @@ variables {e : local_homeomorph α H}
 space `α`, then that local homeomorphism induces an `H`-charted space structure on `α`.
 (This condition is equivalent to `e` being an open embedding of `α` into `H`.) -/
 def singleton_charted_space (h : e.source = set.univ) : charted_space H α :=
-{ atlas := λ e', e' = e,
+{ atlas := {e},
   chart_at := λ _, e,
   mem_chart_source := λ _, by {rw h, simp},
   chart_mem_atlas := λ _, by tauto }

--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -369,8 +369,8 @@ instance : order_top (structure_groupoid H) :=
 /-- A groupoid is closed under restriction if it contains all restrictions of its element local
 homeomorphisms to open subsets of the source. -/
 class closed_under_restriction (G : structure_groupoid H) : Prop :=
-(closed_under_restriction : ∀ {e : local_homeomorph H H}, e ∈ G.members → ∀ (s : set H), is_open s →
-  (e : local_homeomorph H H).restr s ∈ G.members)
+(closed_under_restriction : ∀ {e : local_homeomorph H H}, e ∈ G → ∀ (s : set H), is_open s →
+  (e : local_homeomorph H H).restr s ∈ G)
 
 /-- The trivial restriction-closed groupoid, containing only local homeomorphisms equivalent to the
 restriction of the identity to the various open subsets. -/
@@ -397,7 +397,7 @@ def id_restr_groupoid : structure_groupoid H :=
     have hes : x ∈ (e.restr s).source,
     { rw e.restr_source, refine ⟨hx, _⟩,
       rw interior_eq_of_open hs, exact hxs },
-    simpa using local_homeomorph.eq_on_source.eq_on hes' hes,
+    simpa only with mfld_simps using local_homeomorph.eq_on_source.eq_on hes' hes,
   end,
   eq_on_source' := begin
     rintros e e' ⟨s, hs, hse⟩ hee',
@@ -413,9 +413,9 @@ instance closed_under_restriction_id_restr_groupoid :
   closed_under_restriction (@id_restr_groupoid H _) :=
 ⟨ begin
     rintros e ⟨s', hs', he⟩ s hs,
-    use s' ∩ s, use is_open_inter hs' hs,
+    use [s' ∩ s, is_open_inter hs' hs],
     refine setoid.trans (local_homeomorph.eq_on_source.restr he s) _,
-    exact ⟨by simp [interior_eq_of_open hs], by simp⟩,
+    exact ⟨by simp only [interior_eq_of_open hs] with mfld_simps, by simp only with mfld_simps⟩,
   end ⟩
 
 /-- A groupoid is closed under restriction if and only if it contains the trivial restriction-closed

--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -369,7 +369,7 @@ instance : order_top (structure_groupoid H) :=
 /-- A groupoid is closed under restriction if it contains all restrictions of its element local
 homeomorphisms to open subsets of the source. -/
 class closed_under_restriction (G : structure_groupoid H) : Prop :=
-(closed_under_restriction : ∀ (e : G.members), ∀ (s : set H), is_open s →
+(closed_under_restriction : ∀ {e : local_homeomorph H H}, e ∈ G.members → ∀ (s : set H), is_open s →
   (e : local_homeomorph H H).restr s ∈ G.members)
 
 /-- The trivial restriction-closed groupoid, containing only local homeomorphisms equivalent to the
@@ -412,8 +412,8 @@ lemma id_restr_groupoid_mem {s : set H} (hs : is_open s) :
 instance closed_under_restriction_id_restr_groupoid :
   closed_under_restriction (@id_restr_groupoid H _) :=
 ⟨ begin
-    rintros ⟨e, s', hs', he⟩ s hs,
-    use s' ∩ s, use is_open_inter hs' hs, simp only [subtype.coe_mk],
+    rintros e ⟨s', hs', he⟩ s hs,
+    use s' ∩ s, use is_open_inter hs' hs,
     refine setoid.trans (local_homeomorph.eq_on_source.restr he s) _,
     exact ⟨by simp [interior_eq_of_open hs], by simp⟩,
   end ⟩
@@ -429,14 +429,14 @@ begin
     rintros e ⟨s, hs, hes⟩,
     refine G.eq_on_source' _ _ _ hes,
     have h := _i.closed_under_restriction,
-    convert h ⟨local_homeomorph.refl H, G.id_mem'⟩ s hs,
+    convert h G.id_mem' s hs,
     rw interior_eq_of_open hs,
     simp },
   { intros h,
     split,
-    intros e s hs,
+    intros e he s hs,
     rw ← of_set_trans (e : local_homeomorph H H) hs,
-    refine G.trans' _ _ _ (by simp),
+    refine G.trans' _ _ _ he,
     apply structure_groupoid.le_iff.mp h,
     exact id_restr_groupoid_mem hs },
 end

--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
 import topology.local_homeomorph
-import tactic
 
 /-!
 # Charted spaces

--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -752,7 +752,7 @@ variables {α : Type*} [topological_space α]
 variables {e : local_homeomorph α H}
 
 /-- If a single local homeomorphism `e` from a space `α` into `H` has source covering the whole
-space `α`, then that local homeomorphism induces an `H`-charted space structure on `alpha`.
+space `α`, then that local homeomorphism induces an `H`-charted space structure on `α`.
 (This condition is equivalent to `e` being an open embedding of `α` into `H`.) -/
 def singleton_charted_space (h : e.source = set.univ) : charted_space H α :=
 { atlas := λ e', e' = e,
@@ -763,9 +763,9 @@ def singleton_charted_space (h : e.source = set.univ) : charted_space H α :=
 lemma singleton_charted_space_one_chart (h : e.source = set.univ) (e' : local_homeomorph α H)
   (h' : e' ∈ (singleton_charted_space h).atlas) : e' = e := h'
 
-/-- Given a local homeomorphism `e` from a space `α` into `H`, if its sources covers the whole
-space `α`, then the induced charted space structure on `α` is `has_groupoid G` for any structure `G`
-which is closed under restrictions. -/
+/-- Given a local homeomorphism `e` from a space `α` into `H`, if its source covers the whole
+space `α`, then the induced charted space structure on `α` is `has_groupoid G` for any structure
+groupoid `G` which is closed under restrictions. -/
 lemma singleton_has_groupoid (h : e.source = set.univ) (G : structure_groupoid H)
   [closed_under_restriction G] : @has_groupoid _ _ _ _ (singleton_charted_space h) G :=
 { compatible := begin

--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
 import topology.local_homeomorph
+import tactic
 
 /-!
 # Charted spaces
@@ -388,10 +389,10 @@ def id_restr_groupoid : structure_groupoid H :=
     rw [← of_set_symm],
     exact local_homeomorph.eq_on_source.symm' hse,
   end,
-  id_mem' := ⟨univ, is_open_univ, by simp⟩,
+  id_mem' := ⟨univ, is_open_univ, by simp only with mfld_simps⟩,
   locality' := begin
     intros e h,
-    refine ⟨e.source, e.open_source, by simp, _⟩,
+    refine ⟨e.source, e.open_source, by simp only with mfld_simps, _⟩,
     intros x hx,
     rcases h x hx with ⟨s, hs, hxs, s', hs', hes'⟩,
     have hes : x ∈ (e.restr s).source,
@@ -427,16 +428,16 @@ begin
   { intros _i,
     apply structure_groupoid.le_iff.mpr,
     rintros e ⟨s, hs, hes⟩,
-    refine G.eq_on_source' _ _ _ hes,
+    refine G.eq_on_source _ hes,
     have h := _i.closed_under_restriction,
-    convert h G.id_mem' s hs,
+    convert h G.id_mem s hs,
     rw interior_eq_of_open hs,
-    simp },
+    simp only with mfld_simps },
   { intros h,
     split,
     intros e he s hs,
     rw ← of_set_trans (e : local_homeomorph H H) hs,
-    refine G.trans' _ _ _ he,
+    refine G.trans _ he,
     apply structure_groupoid.le_iff.mp h,
     exact id_restr_groupoid_mem hs },
 end
@@ -757,7 +758,7 @@ space `α`, then that local homeomorphism induces an `H`-charted space structure
 def singleton_charted_space (h : e.source = set.univ) : charted_space H α :=
 { atlas := {e},
   chart_at := λ _, e,
-  mem_chart_source := λ _, by {rw h, simp},
+  mem_chart_source := λ _, by simp only [h] with mfld_simps,
   chart_mem_atlas := λ _, by tauto }
 
 lemma singleton_charted_space_one_chart (h : e.source = set.univ) (e' : local_homeomorph α H)

--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -766,7 +766,7 @@ lemma singleton_charted_space_one_chart (h : e.source = set.univ) (e' : local_ho
 /-- Given a local homeomorphism `e` from a space `α` into `H`, if its sources covers the whole
 space `α`, then the induced charted space structure on `α` is `has_groupoid G` for any structure `G`
 which is closed under restrictions. -/
-def singleton_has_groupoid (h : e.source = set.univ) (G : structure_groupoid H)
+lemma singleton_has_groupoid (h : e.source = set.univ) (G : structure_groupoid H)
   [closed_under_restriction G] : @has_groupoid _ _ _ _ (singleton_charted_space h) G :=
 { compatible := begin
     intros e' e'' he' he'',

--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -134,13 +134,14 @@ open set local_homeomorph
 
 section groupoid
 
-/- One could add to the definition of a structure groupoid the fact that the restriction of an
+/-! One could add to the definition of a structure groupoid the fact that the restriction of an
 element of the groupoid to any open set still belongs to the groupoid.
 (This is in Kobayashi-Nomizu.)
 I am not sure I want this, for instance on `H × E` where `E` is a vector space, and the groupoid is
 made of functions respecting the fibers and linear in the fibers (so that a charted space over this
 groupoid is naturally a vector bundle) I prefer that the members of the groupoid are always
-defined on sets of the form `s × E`.
+defined on sets of the form `s × E`.  There is a typeclass `closed_under_restriction` for groupoids
+which have the restriction property.
 
 The only nontrivial requirement is locality: if a local homeomorphism belongs to the groupoid
 around each point in its domain of definition, then it belongs to the groupoid. Without this
@@ -364,6 +365,86 @@ instance : order_top (structure_groupoid H) :=
 { top    := continuous_groupoid H,
   le_top := λ u f hf, by { split; exact dec_trivial },
   ..structure_groupoid.partial_order }
+
+/-- A groupoid is closed under restriction if it contains all restrictions of its element local
+homeomorphisms to open subsets of the source. -/
+class closed_under_restriction (G : structure_groupoid H) : Prop :=
+(closed_under_restriction : ∀ (e : G.members), ∀ (s : set H), is_open s →
+  (e : local_homeomorph H H).restr s ∈ G.members)
+
+/-- The trivial restriction-closed groupoid, containing only local homeomorphisms equivalent to the
+restriction of the identity to the various open subsets. -/
+def id_restr_groupoid : structure_groupoid H :=
+{ members := λ e, ∃ {s : set H} (h : is_open s), e ≈ local_homeomorph.of_set s h,
+  trans' := begin
+    rintros e e' ⟨s, hs, hse⟩ ⟨s', hs', hse'⟩,
+    refine ⟨s ∩ s', is_open_inter hs hs', _⟩,
+    have := local_homeomorph.eq_on_source.trans' hse hse',
+    rwa local_homeomorph.of_set_trans_of_set at this,
+  end,
+  symm' := begin
+    rintros e ⟨s, hs, hse⟩,
+    refine ⟨s, hs, _⟩,
+    rw [← of_set_symm],
+    exact local_homeomorph.eq_on_source.symm' hse,
+  end,
+  id_mem' := ⟨univ, is_open_univ, by rw refl_eq_of_set⟩,
+  locality' := begin
+    intros e h,
+    refine ⟨e.source, e.open_source, by simp, _⟩,
+    intros x hx,
+    rcases h x hx with ⟨s, hs, hxs, s', hs', hes'⟩,
+    have hes : x ∈ (e.restr s).source,
+    { rw e.restr_source, refine ⟨hx, _⟩,
+      rw interior_eq_of_open hs, exact hxs },
+    simpa using local_homeomorph.eq_on_source.eq_on hes' hes,
+  end,
+  eq_on_source' := begin
+    rintros e e' ⟨s, hs, hse⟩ hee',
+    exact ⟨s, hs, setoid.trans hee' hse⟩,
+  end
+}
+
+lemma id_restr_groupoid_mem {s : set H} (hs : is_open s) :
+  of_set s hs ∈ (@id_restr_groupoid H _).members := ⟨s, hs, by refl⟩
+
+/-- The trivial restriction-closed groupoid is indeed `closed_under_restriction`. -/
+instance closed_under_restriction_id_restr_groupoid :
+  closed_under_restriction (@id_restr_groupoid H _) :=
+⟨ begin
+    rintros ⟨e, s', hs', he⟩ s hs,
+    use s' ∩ s, use is_open_inter hs' hs, simp only [subtype.coe_mk],
+    refine setoid.trans (local_homeomorph.eq_on_source.restr he s) _,
+    exact ⟨by simp [interior_eq_of_open hs], by simp⟩,
+  end ⟩
+
+/-- A groupoid is closed under restriction if and only if it contains the trivial restriction-closed
+groupoid. -/
+lemma closed_under_restriction_iff_id_le (G : structure_groupoid H) :
+  closed_under_restriction G ↔ id_restr_groupoid ≤ G :=
+begin
+  split,
+  { intros _i,
+    apply structure_groupoid.le_iff.mpr,
+    rintros e ⟨s, hs, hes⟩,
+    refine G.eq_on_source' _ _ _ hes,
+    have h := _i.closed_under_restriction,
+    convert h ⟨local_homeomorph.refl H, G.id_mem'⟩ s hs,
+    rw interior_eq_of_open hs,
+    simp },
+  { intros h,
+    split,
+    intros e s hs,
+    rw ← of_set_trans (e : local_homeomorph H H) hs,
+    refine G.trans' _ _ _ (by simp),
+    apply structure_groupoid.le_iff.mp h,
+    exact id_restr_groupoid_mem hs },
+end
+
+/-- The groupoid of all local homeomorphisms on a topological space `H` is closed under restriction.
+-/
+instance : closed_under_restriction (continuous_groupoid H) :=
+(closed_under_restriction_iff_id_le _).mpr (by convert le_top)
 
 end groupoid
 
@@ -665,6 +746,38 @@ begin
 end
 
 end maximal_atlas
+
+section singleton
+variables {α : Type*} [topological_space α]
+variables {e : local_homeomorph α H}
+
+/-- If a single local homeomorphism `e` from a space `α` into `H` has source covering the whole
+space `α`, then that local homeomorphism induces an `H`-charted space structure on `alpha`.
+(This condition is equivalent to `e` being an open embedding of `α` into `H`.) -/
+def singleton_charted_space (h : e.source = set.univ) : charted_space H α :=
+{ atlas := λ e', e' = e,
+  chart_at := λ _, e,
+  mem_chart_source := λ _, by {rw h, simp},
+  chart_mem_atlas := λ _, by tauto }
+
+lemma singleton_charted_space_one_chart (h : e.source = set.univ) (e' : local_homeomorph α H)
+  (h' : e' ∈ (singleton_charted_space h).atlas) : e' = e := h'
+
+/-- Given a local homeomorphism `e` from a space `α` into `H`, if its sources covers the whole
+space `α`, then the induced charted space structure on `α` is `has_groupoid G` for any structure `G`
+which is closed under restrictions. -/
+def singleton_has_groupoid (h : e.source = set.univ) (G : structure_groupoid H)
+  [closed_under_restriction G] : @has_groupoid _ _ _ _ (singleton_charted_space h) G :=
+{ compatible := begin
+    intros e' e'' he' he'',
+    rw singleton_charted_space_one_chart h e' he',
+    rw singleton_charted_space_one_chart h e'' he'',
+    refine G.eq_on_source _ e.trans_symm_self,
+    have hle : id_restr_groupoid ≤ G := (closed_under_restriction_iff_id_le G).mp (by assumption),
+    exact structure_groupoid.le_iff.mp hle _ (id_restr_groupoid_mem _),
+  end }
+
+end singleton
 
 /-! ### Structomorphisms -/
 

--- a/src/geometry/manifold/smooth_manifold_with_corners.lean
+++ b/src/geometry/manifold/smooth_manifold_with_corners.lean
@@ -472,6 +472,16 @@ begin
     exact h3, }
 end
 
+/-- The `C^n` groupoid is closed under restriction. -/
+instance : closed_under_restriction (times_cont_diff_groupoid n I) :=
+(closed_under_restriction_iff_id_le _).mpr
+begin
+  apply structure_groupoid.le_iff.mpr,
+  rintros e ⟨s, hs, hes⟩,
+  apply (times_cont_diff_groupoid n I).eq_on_source' _ _ _ hes,
+  exact of_set_mem_times_cont_diff_groupoid n I hs,
+end
+
 end times_cont_diff_groupoid
 
 end model_with_corners

--- a/src/topology/local_homeomorph.lean
+++ b/src/topology/local_homeomorph.lean
@@ -318,6 +318,9 @@ lemma of_set_target : (of_set s hs).target = s := rfl
 @[simp, mfld_simps] lemma of_set_coe : (of_set s hs : α → α) = id := rfl
 @[simp, mfld_simps] lemma of_set_symm : (of_set s hs).symm = of_set s hs := rfl
 
+lemma refl_eq_of_set : local_homeomorph.refl α = of_set univ is_open_univ :=
+by ext; simp
+
 end
 
 /-- Composition of two local homeomorphisms when the target of the first and the source of
@@ -403,6 +406,13 @@ local_homeomorph.ext _ _ (λx, rfl) (λx, rfl) $
 lemma of_set_trans' {s : set α} (hs : is_open s) :
   (of_set s hs).trans e = e.restr (e.source ∩ s) :=
 by rw [of_set_trans, restr_source_inter]
+
+lemma of_set_trans_of_set {s : set α} (hs : is_open s) {s' : set α} (hs' : is_open s') :
+  (of_set s hs).trans (of_set s' hs') = of_set (s ∩ s') (is_open_inter hs hs')  :=
+begin
+  rw (of_set s hs).trans_of_set hs',
+  ext; simp [interior_eq_of_open hs']
+end
 
 lemma restr_trans (s : set α) :
   (e.restr s).trans e' = (e.trans e').restr s :=

--- a/src/topology/local_homeomorph.lean
+++ b/src/topology/local_homeomorph.lean
@@ -318,7 +318,7 @@ lemma of_set_target : (of_set s hs).target = s := rfl
 @[simp, mfld_simps] lemma of_set_coe : (of_set s hs : α → α) = id := rfl
 @[simp, mfld_simps] lemma of_set_symm : (of_set s hs).symm = of_set s hs := rfl
 
-@[simp] lemma of_set_univ_eq_refl : of_set univ is_open_univ = local_homeomorph.refl α :=
+@[simp, mfld_simps] lemma of_set_univ_eq_refl : of_set univ is_open_univ = local_homeomorph.refl α :=
 by ext; simp
 
 end
@@ -407,7 +407,7 @@ lemma of_set_trans' {s : set α} (hs : is_open s) :
   (of_set s hs).trans e = e.restr (e.source ∩ s) :=
 by rw [of_set_trans, restr_source_inter]
 
-lemma of_set_trans_of_set {s : set α} (hs : is_open s) {s' : set α} (hs' : is_open s') :
+@[simp, mfld_simps] lemma of_set_trans_of_set {s : set α} (hs : is_open s) {s' : set α} (hs' : is_open s') :
   (of_set s hs).trans (of_set s' hs') = of_set (s ∩ s') (is_open_inter hs hs')  :=
 begin
   rw (of_set s hs).trans_of_set hs',

--- a/src/topology/local_homeomorph.lean
+++ b/src/topology/local_homeomorph.lean
@@ -318,7 +318,7 @@ lemma of_set_target : (of_set s hs).target = s := rfl
 @[simp, mfld_simps] lemma of_set_coe : (of_set s hs : α → α) = id := rfl
 @[simp, mfld_simps] lemma of_set_symm : (of_set s hs).symm = of_set s hs := rfl
 
-lemma refl_eq_of_set : local_homeomorph.refl α = of_set univ is_open_univ :=
+@[simp] lemma of_set_univ_eq_refl : of_set univ is_open_univ = local_homeomorph.refl α :=
 by ext; simp
 
 end


### PR DESCRIPTION
* Define a typeclass `closed_under_restriction` for structure groupoids.
* Prove that it is equivalent to requiring that the structure groupoid contain all local homeomorphisms equivalent to the restriction of the identity to an open subset.
* Verify that `continuous_groupoid` and `times_cont_diff_groupoid` satisfy `closed_under_restriction`.  
* Show that a charted space defined by a single chart is `has_groupoid` for any structure groupoid satisfying `closed_under_restriction`.

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Restriction.20in.20structure.20groupoid)

---
<!-- put comments you want to keep out of the PR commit here -->
