### PR TITLE
[Merged by Bors] - feat(tactic/interval_cases): add `with h` option

### DIFF
--- a/src/tactic/interval_cases.lean
+++ b/src/tactic/interval_cases.lean
@@ -189,8 +189,12 @@ an `Ico` interval corresponding to a lower and an upper bound.
 Here `hl` should be an expression of the form `a ≤ n`, for some explicit `a`, and
 `hu` should be of the form `n < b`, for some explicit `b`.
 -/
-meta def interval_cases_using (hl hu : expr) : tactic unit :=
-to_expr ``(mem_set_elems (Ico _ _) ⟨%%hl, %%hu⟩) >>= note_anon none >>= fin_cases_at none
+meta def interval_cases_using (hl hu : expr) (n : option name) : tactic unit :=
+to_expr ``(mem_set_elems (Ico _ _) ⟨%%hl, %%hu⟩) >>=
+(if hn : n.is_some then (do
+  note (option.get hn))
+else
+  note_anon none) >>= fin_cases_at none
 
 setup_tactic_parser
 
@@ -218,16 +222,16 @@ as `interval_cases using hl hu`.
 The hypotheses should be in the form `hl : a ≤ n` and `hu : n < b`,
 in which case `interval_cases` calls `fin_cases` on the resulting fact `n ∈ set.Ico a b`.
 -/
-meta def interval_cases (n : parse texpr?) (bounds : parse (tk "using" *> (prod.mk <$> ident <*> ident))?) : tactic unit :=
+meta def interval_cases (n : parse texpr?) (bounds : parse (tk "using" *> (prod.mk <$> ident <*> ident))?) (lname : parse (tk "with" *> ident)?) : tactic unit :=
 do
   if h : n.is_some then (do
     guard bounds.is_none <|> fail "Do not use the `using` keyword if specifying the variable explicitly.",
     n ← to_expr (option.get h),
     (hl, hu) ← get_bounds n,
-    tactic.interval_cases_using hl hu)
+    tactic.interval_cases_using hl hu lname)
   else if h' : bounds.is_some then (do
     [hl, hu] ← [(option.get h').1, (option.get h').2].mmap get_local,
-    tactic.interval_cases_using hl hu)
+    tactic.interval_cases_using hl hu lname)
   else
     fail "Call `interval_cases n` (specifying a variable), or `interval_cases lb ub` (specifying a lower bound and upper bound on the same variable)."
 

--- a/src/tactic/interval_cases.lean
+++ b/src/tactic/interval_cases.lean
@@ -221,7 +221,7 @@ end
 after `interval_cases n`, the goals are `3 = 3 ∨ 3 = 4` and `4 = 3 ∨ 4 = 4`.
 
 You can also explicitly specify a lower and upper bound to use,
-as `interval_cases n using hl hu`.
+as `interval_cases using hl hu`.
 The hypotheses should be in the form `hl : a ≤ n` and `hu : n < b`,
 in which case `interval_cases` calls `fin_cases` on the resulting fact `n ∈ set.Ico a b`.
 
@@ -257,7 +257,7 @@ end
 after `interval_cases n`, the goals are `3 = 3 ∨ 3 = 4` and `4 = 3 ∨ 4 = 4`.
 
 You can also explicitly specify a lower and upper bound to use,
-as `interval_cases n using hl hu`.
+as `interval_cases using hl hu`.
 The hypotheses should be in the form `hl : a ≤ n` and `hu : n < b`,
 in which case `interval_cases` calls `fin_cases` on the resulting fact `n ∈ set.Ico a b`.
 

--- a/src/tactic/interval_cases.lean
+++ b/src/tactic/interval_cases.lean
@@ -188,11 +188,14 @@ an `Ico` interval corresponding to a lower and an upper bound.
 
 Here `hl` should be an expression of the form `a ≤ n`, for some explicit `a`, and
 `hu` should be of the form `n < b`, for some explicit `b`.
+
+`n` if provided is the name of the hypothesis added. If an automatically generated name is wanted,
+pass in `none` as `n`.
 -/
 meta def interval_cases_using (hl hu : expr) (n : option name) : tactic unit :=
 to_expr ``(mem_set_elems (Ico _ _) ⟨%%hl, %%hu⟩) >>=
-(if hn : n.is_some then (do
-  note (option.get hn))
+(if hn : n.is_some then
+  note (option.get hn)
 else
   note_anon none) >>= fin_cases_at none
 
@@ -218,9 +221,12 @@ end
 after `interval_cases n`, the goals are `3 = 3 ∨ 3 = 4` and `4 = 3 ∨ 4 = 4`.
 
 You can also explicitly specify a lower and upper bound to use,
-as `interval_cases using hl hu`.
+as `interval_cases n using hl hu`.
 The hypotheses should be in the form `hl : a ≤ n` and `hu : n < b`,
 in which case `interval_cases` calls `fin_cases` on the resulting fact `n ∈ set.Ico a b`.
+
+You can also explicitly specify a name to use for the hypothesis added,
+as `interval_cases n with hn` or `interval_cases n using hl hu with hn`.
 -/
 meta def interval_cases (n : parse texpr?) (bounds : parse (tk "using" *> (prod.mk <$> ident <*> ident))?) (lname : parse (tk "with" *> ident)?) : tactic unit :=
 do
@@ -251,9 +257,12 @@ end
 after `interval_cases n`, the goals are `3 = 3 ∨ 3 = 4` and `4 = 3 ∨ 4 = 4`.
 
 You can also explicitly specify a lower and upper bound to use,
-as `interval_cases using hl hu`.
+as `interval_cases n using hl hu`.
 The hypotheses should be in the form `hl : a ≤ n` and `hu : n < b`,
 in which case `interval_cases` calls `fin_cases` on the resulting fact `n ∈ set.Ico a b`.
+
+You can also explicitly specify a name to use for the hypothesis added,
+as `interval_cases n with hn` or `interval_cases n using hl hu with hn`.
 
 In particular, `interval_cases n`
 1) inspects hypotheses looking for lower and upper bounds of the form `a ≤ n` and `n < b`

--- a/src/tactic/interval_cases.lean
+++ b/src/tactic/interval_cases.lean
@@ -189,8 +189,7 @@ an `Ico` interval corresponding to a lower and an upper bound.
 Here `hl` should be an expression of the form `a ≤ n`, for some explicit `a`, and
 `hu` should be of the form `n < b`, for some explicit `b`.
 
-`n` if provided is the name of the hypothesis added. If an automatically generated name is wanted,
-pass in `none` as `n`.
+By default `interval_cases_using` automatically generates a name for the new hypothesis. The name can be specified via the optional argument `n`.
 -/
 meta def interval_cases_using (hl hu : expr) (n : option name) : tactic unit :=
 to_expr ``(mem_set_elems (Ico _ _) ⟨%%hl, %%hu⟩) >>=
@@ -225,8 +224,8 @@ as `interval_cases using hl hu`.
 The hypotheses should be in the form `hl : a ≤ n` and `hu : n < b`,
 in which case `interval_cases` calls `fin_cases` on the resulting fact `n ∈ set.Ico a b`.
 
-You can also explicitly specify a name to use for the hypothesis added,
-as `interval_cases n with hn` or `interval_cases n using hl hu with hn`.
+You can specify a name `h` for the new hypothesis,
+as `interval_cases n with h` or `interval_cases n using hl hu with h`.
 -/
 meta def interval_cases (n : parse texpr?) (bounds : parse (tk "using" *> (prod.mk <$> ident <*> ident))?) (lname : parse (tk "with" *> ident)?) : tactic unit :=
 do

--- a/test/interval_cases.lean
+++ b/test/interval_cases.lean
@@ -118,6 +118,15 @@ begin
   guard_target (1 : ℤ) < 20, norm_num,
 end
 
+example (n : ℕ) : n % 2 = 0 ∨ n % 2 = 1 :=
+begin
+  set r := n % 2 with hr,
+  have h2 : r < 2 := nat.mod_lt _ (dec_trivial),
+  interval_cases r with hrv,
+  { left, assumption },
+  { right, assumption }
+end
+
 /-
 Sadly, this one doesn't work, reporting:
   `deep recursion was detected at 'expression equality test'`

--- a/test/interval_cases.lean
+++ b/test/interval_cases.lean
@@ -123,8 +123,8 @@ begin
   set r := n % 2 with hr,
   have h2 : r < 2 := nat.mod_lt _ (dec_trivial),
   interval_cases r with hrv,
-  { left, assumption },
-  { right, assumption }
+  { left, exact hrv },
+  { right, exact hrv }
 end
 
 /-


### PR DESCRIPTION
closes #2881

---
<!-- put comments you want to keep out of the PR commit here -->

Notes:

* I put the `with h` part after the `using`, so it's `interval_cases n using hl hh with hn`, Should it be switched around?
* I'm not 100% sure this is correct. I tested it on one file, and it seemed to work. It also seems to have not broken anything when the `with h` is not provided.