### PR TITLE
[Merged by Bors] - feat(data/fintype/basic): set.to_finset_empty

### DIFF
--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -644,6 +644,10 @@ set_fintype _
   (set.univ : set α).to_finset = finset.univ :=
 by { ext, simp only [set.mem_univ, mem_univ, set.mem_to_finset] }
 
+@[simp] lemma set.to_finset_empty [fintype α]:
+  (∅ : set α).to_finset = ∅ :=
+by {ext, simp only [set.mem_empty_eq, set.mem_to_finset, not_mem_empty] }
+
 theorem fintype.card_subtype_le [fintype α] (p : α → Prop) [decidable_pred p] :
   fintype.card {x // p x} ≤ fintype.card α :=
 by rw fintype.subtype_card; exact card_le_of_subset (subset_univ _)

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -644,9 +644,9 @@ set_fintype _
   (set.univ : set α).to_finset = finset.univ :=
 by { ext, simp only [set.mem_univ, mem_univ, set.mem_to_finset] }
 
-@[simp] lemma set.to_finset_empty [fintype α]:
+@[simp] lemma set.to_finset_empty [fintype α] :
   (∅ : set α).to_finset = ∅ :=
-by {ext, simp only [set.mem_empty_eq, set.mem_to_finset, not_mem_empty] }
+by { ext, simp only [set.mem_empty_eq, set.mem_to_finset, not_mem_empty] }
 
 theorem fintype.card_subtype_le [fintype α] (p : α → Prop) [decidable_pred p] :
   fintype.card {x // p x} ≤ fintype.card α :=


### PR DESCRIPTION
Add set.to_finset_empty, analogously to set.to_finset_univ.

---
<!-- put comments you want to keep out of the PR commit here -->
This is my first mathlib pull request, Kevin and Reid told me to open it: https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/motive.20is.20not.20type-correct.20when.20proving.20simple.20fintype.20lemma