### PR TITLE
[Merged by Bors] - refactor(tactic/push_neg): simp ¬ (p ∧ q) better

### DIFF
--- a/src/data/pequiv.lean
+++ b/src/data/pequiv.lean
@@ -85,7 +85,10 @@ lemma trans_eq_some (f : α ≃. β) (g : β ≃. γ) (a : α) (c : γ) :
 
 lemma trans_eq_none (f : α ≃. β) (g : β ≃. γ) (a : α) :
   f.trans g a = none ↔ (∀ b c, b ∉ f a ∨ c ∉ g b) :=
-by simp only [eq_none_iff_forall_not_mem, mem_trans]; push_neg; tauto
+begin
+  simp only [eq_none_iff_forall_not_mem, mem_trans, classical.imp_iff_not_or.symm],
+  push_neg, tauto
+end
 
 @[simp] lemma refl_trans (f : α ≃. β) : (pequiv.refl α).trans f = f :=
 by ext; dsimp [pequiv.trans]; refl

--- a/src/order/filter/at_top_bot.lean
+++ b/src/order/filter/at_top_bot.lean
@@ -262,12 +262,12 @@ variables [ordered_cancel_add_comm_monoid β] {l : filter α} {f g : α → β}
 lemma tendsto_at_top_of_add_const_left (C : β) (hf : tendsto (λ x, C + f x) l at_top) :
   tendsto f l at_top :=
 (tendsto_at_top _ l).2 $ assume b,
-  ((tendsto_at_top _ _).1 hf (C + b)).mono (λ x, le_of_add_le_add_left) 
+  ((tendsto_at_top _ _).1 hf (C + b)).mono (λ x, le_of_add_le_add_left)
 
 lemma tendsto_at_top_of_add_const_right (C : β) (hf : tendsto (λ x, f x + C) l at_top) :
   tendsto f l at_top :=
 (tendsto_at_top _ l).2 $ assume b,
-  ((tendsto_at_top _ _).1 hf (b + C)).mono (λ x, le_of_add_le_add_right) 
+  ((tendsto_at_top _ _).1 hf (b + C)).mono (λ x, le_of_add_le_add_right)
 
 lemma tendsto_at_top_of_add_bdd_above_left' (C) (hC : ∀ᶠ x in l, f x ≤ C)
   (h : tendsto (λ x, f x + g x) l at_top) :
@@ -410,7 +410,7 @@ begin
     inhabit β₂,
     simp [at_top, prod_infi_left (default β₁), prod_infi_right (default β₂), infi_prod],
     exact infi_comm },
-  { push_neg at ne,
+  { rw not_and_distrib at ne,
     cases ne;
     { have : ¬ (nonempty (β₁ × β₂)), by simp [ne],
       rw [at_top.filter_eq_bot_of_not_nonempty ne, at_top.filter_eq_bot_of_not_nonempty this],

--- a/src/tactic/push_neg.lean
+++ b/src/tactic/push_neg.lean
@@ -21,7 +21,7 @@ variable  (s : α → Prop)
 
 local attribute [instance, priority 10] classical.prop_decidable
 theorem not_not_eq : (¬ ¬ p) = p := propext not_not
-theorem not_and_eq : (¬ (p ∧ q)) = (¬ p ∨ ¬ q) := propext not_and_distrib
+theorem not_and_eq : (¬ (p ∧ q)) = (p → ¬ q) := propext not_and
 theorem not_or_eq : (¬ (p ∨ q)) = (¬ p ∧ ¬ q) := propext not_or_distrib
 theorem not_forall_eq : (¬ ∀ x, s x) = (∃ x, ¬ s x) := propext not_forall
 theorem not_exists_eq : (¬ ∃ x, s x) = (∀ x, ¬ s x) := propext not_exists
@@ -50,7 +50,7 @@ do e ← whnf_reducible e,
       | `(¬ %%a)      := do pr ← mk_app ``not_not_eq [a],
                             return (some (a, pr))
       | `(%%a ∧ %%b)  := do pr ← mk_app ``not_and_eq [a, b],
-                            return (some (`(¬ %%a ∨ ¬ %%b), pr))
+                            return (some (`((%%a : Prop) → ¬ %%b), pr))
       | `(%%a ∨ %%b)  := do pr ← mk_app ``not_or_eq [a, b],
                             return (some (`(¬ %%a ∧ ¬ %%b), pr))
       | `(%%a ≤ %%b)  := do e ← to_expr ``(%%b < %%a),

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -305,7 +305,7 @@ begin
   { rcases h H.1 H.2 with ⟨i, hi⟩,
     rw [H.2, mul_zero, ← bot_eq_zero, infi_eq_bot],
     exact λ b hb, ⟨i, by rwa [hi, mul_zero, ← bot_eq_zero]⟩ },
-  { push_neg at H,
+  { rw not_and_distrib at H,
     exact (map_infi_of_continuous_at_of_monotone' (ennreal.continuous_at_const_mul H)
       ennreal.mul_left_mono).symm }
 end

--- a/src/topology/sequences.lean
+++ b/src/topology/sequences.lean
@@ -302,7 +302,6 @@ begin
   cases hu with u_in hu,
   use [u, u_in], clear u_in,
   intros x x_in φ,
-  rw ← imp_iff_not_or,
   intros hφ huφ,
   obtain ⟨N, hN⟩ : ∃ N, ∀ p q, p ≥ N → q ≥ N → (u (φ p), u (φ q)) ∈ V,
     from (cauchy_seq_of_tendsto_nhds _ huφ).mem_entourage V_in,


### PR DESCRIPTION
This simplifies `¬ (p ∧ q)` to `(p → ¬ q)` instead of `¬ p ∨ ¬ q`. This has better behavior when going between `\forall x, P -> Q` and `\exists x, P /\ Q'` where `Q` and `Q'` are opposite.