### PR TITLE
[Merged by Bors] - feat(category_theory/kernels): kernel_iso_of_eq

### DIFF
--- a/src/category_theory/limits/limits.lean
+++ b/src/category_theory/limits/limits.lean
@@ -754,7 +754,7 @@ def has_limit.iso_of_nat_iso {F G : J ⥤ C} [has_limit F] [has_limit G] (w : F 
   limit F ≅ limit G :=
 is_limit.cone_points_iso_of_nat_iso (limit.is_limit F) (limit.is_limit G) w
 
-@[simp]
+@[simp, reassoc]
 lemma has_limit.iso_of_nat_iso_hom_π {F G : J ⥤ C} [has_limit F] [has_limit G]
   (w : F ≅ G) (j : J) :
   (has_limit.iso_of_nat_iso w).hom ≫ limit.π G j = limit.π F j ≫ w.hom.app j :=
@@ -1108,8 +1108,8 @@ def has_colimit.iso_of_nat_iso {F G : J ⥤ C} [has_colimit F] [has_colimit G] (
   colimit F ≅ colimit G :=
 is_colimit.cocone_points_iso_of_nat_iso (colimit.is_colimit F) (colimit.is_colimit G) w
 
-@[simp]
-lemma has_colimit.iso_of_nat_iso_hom_π {F G : J ⥤ C} [has_colimit F] [has_colimit G]
+@[simp, reassoc]
+lemma has_colimit.iso_of_nat_iso_ι_hom {F G : J ⥤ C} [has_colimit F] [has_colimit G]
   (w : F ≅ G) (j : J) :
   colimit.ι F j ≫ (has_colimit.iso_of_nat_iso w).hom = w.hom.app j ≫ colimit.ι G j :=
 by simp [has_colimit.iso_of_nat_iso, is_colimit.cocone_points_iso_of_nat_iso_inv]

--- a/src/category_theory/limits/shapes/equalizers.lean
+++ b/src/category_theory/limits/shapes/equalizers.lean
@@ -454,11 +454,11 @@ is_iso_limit_cone_parallel_pair_of_eq ((cancel_epi _).1 (fork.condition c)) h
 
 end
 
-/-- The equalizer of `(f, f)` is an isomorphism. -/
+/-- The equalizer inclusion for `(f, f)` is an isomorphism. -/
 instance equalizer.ι_of_self [has_limit (parallel_pair f f)] : is_iso (equalizer.ι f f) :=
 equalizer.ι_of_eq rfl
 
-/-- The equalizer of a morphism with itself is isomorphic to the target. -/
+/-- The equalizer of a morphism with itself is isomorphic to the source. -/
 def equalizer.iso_source_of_self [has_limit (parallel_pair f f)] : equalizer f f ≅ X :=
 as_iso (equalizer.ι f f)
 
@@ -567,7 +567,7 @@ is_iso_colimit_cocone_parallel_pair_of_eq ((cancel_mono _).1 (cofork.condition c
 
 end
 
-/-- The coequalizer of `(f, f)` is an isomorphism. -/
+/-- The coequalizer projection for `(f, f)` is an isomorphism. -/
 instance coequalizer.π_of_self [has_colimit (parallel_pair f f)] : is_iso (coequalizer.π f f) :=
 coequalizer.π_of_eq rfl
 

--- a/src/category_theory/limits/shapes/equalizers.lean
+++ b/src/category_theory/limits/shapes/equalizers.lean
@@ -466,6 +466,10 @@ as_iso (equalizer.ι f f)
   (equalizer.iso_source_of_self f).hom = equalizer.ι f f :=
 rfl
 
+@[simp] lemma equalizer.iso_source_of_self_inv [has_limit (parallel_pair f f)] :
+  (equalizer.iso_source_of_self f).inv = equalizer.lift (𝟙 X) (by simp) :=
+rfl
+
 section
 variables [has_colimit (parallel_pair f g)]
 
@@ -570,6 +574,10 @@ coequalizer.π_of_eq rfl
 /-- The coequalizer of a morphism with itself is isomorphic to the target. -/
 def coequalizer.iso_target_of_self [has_colimit (parallel_pair f f)] : coequalizer f f ≅ Y :=
 (as_iso (coequalizer.π f f)).symm
+
+@[simp] lemma coequalizer.iso_target_of_self_hom [has_colimit (parallel_pair f f)] :
+  (coequalizer.iso_target_of_self f).hom = coequalizer.desc (𝟙 Y) (by simp) :=
+rfl
 
 @[simp] lemma coequalizer.iso_target_of_self_inv [has_colimit (parallel_pair f f)] :
   (coequalizer.iso_target_of_self f).inv = coequalizer.π f f :=

--- a/src/category_theory/limits/shapes/equalizers.lean
+++ b/src/category_theory/limits/shapes/equalizers.lean
@@ -30,7 +30,7 @@ Each of these has a dual.
 ## Main statements
 
 * `equalizer.ι_mono` states that every equalizer map is a monomorphism
-* `is_limit_cone_parallel_pair_self` states that the identity on the domain of `f` is an equalizer
+* `is_iso_limit_cone_parallel_pair_of_self` states that the identity on the domain of `f` is an equalizer
   of `f` and `f`.
 
 ## Implementation notes
@@ -455,8 +455,12 @@ is_iso_limit_cone_parallel_pair_of_eq ((cancel_epi _).1 (fork.condition c)) h
 end
 
 /-- The equalizer of `(f, f)` is an isomorphism. -/
-def equalizer.ι_of_self [has_limit (parallel_pair f f)] : is_iso (equalizer.ι f f) :=
+instance equalizer.ι_of_self [has_limit (parallel_pair f f)] : is_iso (equalizer.ι f f) :=
 equalizer.ι_of_eq rfl
+
+/-- The equalizer of a morphism with itself is isomorphic to the target. -/
+def equalizer.iso_source_of_self [has_limit (parallel_pair f f)] : equalizer f f ≅ X :=
+as_iso (equalizer.ι f f)
 
 section
 variables [has_colimit (parallel_pair f g)]
@@ -556,8 +560,12 @@ is_iso_colimit_cocone_parallel_pair_of_eq ((cancel_mono _).1 (cofork.condition c
 end
 
 /-- The coequalizer of `(f, f)` is an isomorphism. -/
-def coequalizer.π_of_self [has_colimit (parallel_pair f f)] : is_iso (coequalizer.π f f) :=
+instance coequalizer.π_of_self [has_colimit (parallel_pair f f)] : is_iso (coequalizer.π f f) :=
 coequalizer.π_of_eq rfl
+
+/-- The coequalizer of a morphism with itself is isomorphic to the target. -/
+def coequalizer.iso_target_of_self [has_colimit (parallel_pair f f)] : coequalizer f f ≅ Y :=
+(as_iso (coequalizer.π f f)).symm
 
 variables (C)
 

--- a/src/category_theory/limits/shapes/equalizers.lean
+++ b/src/category_theory/limits/shapes/equalizers.lean
@@ -462,6 +462,10 @@ equalizer.ι_of_eq rfl
 def equalizer.iso_source_of_self [has_limit (parallel_pair f f)] : equalizer f f ≅ X :=
 as_iso (equalizer.ι f f)
 
+@[simp] lemma equalizer.iso_source_of_self_hom [has_limit (parallel_pair f f)] :
+  (equalizer.iso_source_of_self f).hom = equalizer.ι f f :=
+rfl
+
 section
 variables [has_colimit (parallel_pair f g)]
 
@@ -566,6 +570,10 @@ coequalizer.π_of_eq rfl
 /-- The coequalizer of a morphism with itself is isomorphic to the target. -/
 def coequalizer.iso_target_of_self [has_colimit (parallel_pair f f)] : coequalizer f f ≅ Y :=
 (as_iso (coequalizer.π f f)).symm
+
+@[simp] lemma coequalizer.iso_target_of_self_inv [has_colimit (parallel_pair f f)] :
+  (coequalizer.iso_target_of_self f).inv = coequalizer.π f f :=
+rfl
 
 variables (C)
 

--- a/src/category_theory/limits/shapes/kernels.lean
+++ b/src/category_theory/limits/shapes/kernels.lean
@@ -139,6 +139,9 @@ lemma eq_zero_of_epi_kernel [epi (kernel.ι f)] : f = 0 :=
 def kernel_zero_iso_source [has_kernel (0 : X ⟶ Y)] : kernel (0 : X ⟶ Y) ≅ X :=
 equalizer.iso_source_of_self 0
 
+@[simp] lemma kernel_zero_iso_source_hom [has_kernel (0 : X ⟶ Y)] :
+  kernel_zero_iso_source.hom = kernel.ι (0 : X ⟶ Y) := rfl
+
 /-- If two morphisms are known to be equal, then their kernels are isomorphic. -/
 def kernel_iso_of_eq {f g : X ⟶ Y} [has_kernel f] [has_kernel g] (h : f = g) :
   kernel f ≅ kernel g :=
@@ -315,6 +318,9 @@ lemma eq_zero_of_mono_cokernel [mono (cokernel.π f)] : f = 0 :=
 /-- The cokernel of a zero morphism is isomorphic to the target. -/
 def cokernel_zero_iso_target [has_cokernel (0 : X ⟶ Y)] : cokernel (0 : X ⟶ Y) ≅ Y :=
 coequalizer.iso_target_of_self 0
+
+@[simp] lemma cokernel_zero_iso_target_inv [has_cokernel (0 : X ⟶ Y)] :
+  cokernel_zero_iso_target.inv = cokernel.π (0 : X ⟶ Y) := rfl
 
 /-- If two morphisms are known to be equal, then their cokernels are isomorphic. -/
 def cokernel_iso_of_eq {f g : X ⟶ Y} [has_cokernel f] [has_cokernel g] (h : f = g) :

--- a/src/category_theory/limits/shapes/kernels.lean
+++ b/src/category_theory/limits/shapes/kernels.lean
@@ -135,6 +135,25 @@ equalizer.ι_of_self _
 lemma eq_zero_of_epi_kernel [epi (kernel.ι f)] : f = 0 :=
 (cancel_epi (kernel.ι f)).1 (by simp)
 
+/-- The kernel of a zero morphism is isomorphic to the source. -/
+def kernel_zero_iso_source [has_kernel (0 : X ⟶ Y)] : kernel (0 : X ⟶ Y) ≅ X :=
+equalizer.iso_source_of_self 0
+
+/-- If two morphisms are known to be equal, then their kernels are isomorphic. -/
+def kernel_iso_of_eq {f g : X ⟶ Y} [has_kernel f] [has_kernel g] (h : f = g) :
+  kernel f ≅ kernel g :=
+has_limit.iso_of_nat_iso (by simp[h])
+
+@[simp]
+lemma kernel_iso_of_eq_refl {h : f = f} : kernel_iso_of_eq h = iso.refl (kernel f) :=
+by { ext, simp [kernel_iso_of_eq], }
+
+@[simp]
+lemma kernel_iso_of_eq_trans {f g h : X ⟶ Y} [has_kernel f] [has_kernel g] [has_kernel h]
+  (w₁ : f = g) (w₂ : g = h) :
+  kernel_iso_of_eq w₁ ≪≫ kernel_iso_of_eq w₂ = kernel_iso_of_eq (w₁.trans w₂) :=
+by { unfreezingI { induction w₁, induction w₂, }, ext, simp [kernel_iso_of_eq], }
+
 variables {f}
 
 lemma kernel_not_epi_of_nonzero (w : f ≠ 0) : ¬epi (kernel.ι f) :=
@@ -292,6 +311,25 @@ coequalizer.π_of_self _
 
 lemma eq_zero_of_mono_cokernel [mono (cokernel.π f)] : f = 0 :=
 (cancel_mono (cokernel.π f)).1 (by simp)
+
+/-- The cokernel of a zero morphism is isomorphic to the target. -/
+def cokernel_zero_iso_target [has_cokernel (0 : X ⟶ Y)] : cokernel (0 : X ⟶ Y) ≅ Y :=
+coequalizer.iso_target_of_self 0
+
+/-- If two morphisms are known to be equal, then their cokernels are isomorphic. -/
+def cokernel_iso_of_eq {f g : X ⟶ Y} [has_cokernel f] [has_cokernel g] (h : f = g) :
+  cokernel f ≅ cokernel g :=
+has_colimit.iso_of_nat_iso (by simp[h])
+
+@[simp]
+lemma cokernel_iso_of_eq_refl {h : f = f} : cokernel_iso_of_eq h = iso.refl (cokernel f) :=
+by { ext, simp [cokernel_iso_of_eq], }
+
+@[simp]
+lemma cokernel_iso_of_eq_trans {f g h : X ⟶ Y} [has_cokernel f] [has_cokernel g] [has_cokernel h]
+  (w₁ : f = g) (w₂ : g = h) :
+  cokernel_iso_of_eq w₁ ≪≫ cokernel_iso_of_eq w₂ = cokernel_iso_of_eq (w₁.trans w₂) :=
+by { unfreezingI { induction w₁, induction w₂, }, ext, simp [cokernel_iso_of_eq], }
 
 variables {f}
 

--- a/src/category_theory/limits/shapes/kernels.lean
+++ b/src/category_theory/limits/shapes/kernels.lean
@@ -142,6 +142,9 @@ equalizer.iso_source_of_self 0
 @[simp] lemma kernel_zero_iso_source_hom [has_kernel (0 : X ⟶ Y)] :
   kernel_zero_iso_source.hom = kernel.ι (0 : X ⟶ Y) := rfl
 
+@[simp] lemma kernel_zero_iso_source_inv [has_kernel (0 : X ⟶ Y)] :
+  kernel_zero_iso_source.inv = kernel.lift (0 : X ⟶ Y) (𝟙 X) (by simp) := rfl
+
 /-- If two morphisms are known to be equal, then their kernels are isomorphic. -/
 def kernel_iso_of_eq {f g : X ⟶ Y} [has_kernel f] [has_kernel g] (h : f = g) :
   kernel f ≅ kernel g :=
@@ -318,6 +321,9 @@ lemma eq_zero_of_mono_cokernel [mono (cokernel.π f)] : f = 0 :=
 /-- The cokernel of a zero morphism is isomorphic to the target. -/
 def cokernel_zero_iso_target [has_cokernel (0 : X ⟶ Y)] : cokernel (0 : X ⟶ Y) ≅ Y :=
 coequalizer.iso_target_of_self 0
+
+@[simp] lemma cokernel_zero_iso_target_hom [has_cokernel (0 : X ⟶ Y)] :
+  cokernel_zero_iso_target.hom = cokernel.desc (0 : X ⟶ Y) (𝟙 Y) (by simp) := rfl
 
 @[simp] lemma cokernel_zero_iso_target_inv [has_cokernel (0 : X ⟶ Y)] :
   cokernel_zero_iso_target.inv = cokernel.π (0 : X ⟶ Y) := rfl


### PR DESCRIPTION
This provides two useful isomorphisms when working with abstract (co)kernels:

```
def kernel_zero_iso_source [has_kernel (0 : X ⟶ Y)] : kernel (0 : X ⟶ Y) ≅ X :=

def kernel_iso_of_eq {f g : X ⟶ Y} [has_kernel f] [has_kernel g] (h : f = g) : kernel f ≅ kernel g :=
```
and some associated simp lemmas.

---
<!-- put comments you want to keep out of the PR commit here -->
