### PR TITLE
feat(tactic/tidy): limit the amount of time spent on refl

### DIFF
--- a/src/category_theory/types.lean
+++ b/src/category_theory/types.lean
@@ -106,7 +106,9 @@ end functor_to_types
 The isomorphism between a `Type` which has been `ulift`ed to the same universe,
 and the original type.
 -/
-def ulift_trivial (V : Type u) : ulift.{u} V ≅ V := by tidy
+def ulift_trivial (V : Type u) : ulift.{u} V ≅ V :=
+{ hom := ulift.down,
+  inv := ulift.up, }
 
 /--
 The functor embedding `Type u` into `Type (max u v)`.

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -25,9 +25,26 @@ add_tactic_doc
   decl_names := [`tactic.interactive.fconstructor],
   tags       := ["logic", "goal management"] }
 
-/-- `try_for n { tac }` executes `tac` for `n` ticks, otherwise uses `sorry` to close the goal.
-Never fails. Useful for debugging. -/
+/--
+`try_for n { tac }` executes `tac` for `n` ticks, and otherwise fails.
+Useful for limiting the run-time of potentially expensive tactics.
+
+See also `try_for_sorry`.
+-/
 meta def try_for (max : parse parser.pexpr) (tac : itactic) : tactic unit :=
+do max ← i_to_expr_strict max >>= tactic.eval_expr nat,
+  λ s, match _root_.try_for max (tac s) with
+  | some r := r
+  | none   := (tactic.fail "try_for timeout") s
+  end
+
+/--
+`try_for_sorry n { tac }` executes `tac` for `n` ticks, otherwise uses `sorry` to close the goal.
+Never fails. Useful for debugging.
+
+See also `try_for`.
+-/
+meta def try_for_sorry (max : parse parser.pexpr) (tac : itactic) : tactic unit :=
 do max ← i_to_expr_strict max >>= tactic.eval_expr nat,
   λ s, match _root_.try_for max (tac s) with
   | some r := r

--- a/src/topology/sheaves/presheaf_of_functions.lean
+++ b/src/topology/sheaves/presheaf_of_functions.lean
@@ -68,7 +68,7 @@ def CommRing_yoneda : TopCommRing.{u} ⥤ (Top.{u}ᵒᵖ ⥤ CommRing.{u}) :=
     map := λ X Y f, continuous_functions.pullback f R },
   map := λ R S φ,
   { app := λ X, continuous_functions.map X φ, },
-  map_comp' := by { intros X Y Z f g, ext1 V f, refl }, }
+  map_comp' := by { intros X Y Z f g, ext V h, dsimp, refl, }, }
 
 /-- The presheaf (of commutative rings), consisting of functions on an open set `U ⊆ X` with
 values in some topological commutative ring `T`. -/

--- a/src/topology/sheaves/presheaf_of_functions.lean
+++ b/src/topology/sheaves/presheaf_of_functions.lean
@@ -67,7 +67,8 @@ def CommRing_yoneda : TopCommRing.{u} ⥤ (Top.{u}ᵒᵖ ⥤ CommRing.{u}) :=
   { obj := λ X, continuous_functions X R,
     map := λ X Y f, continuous_functions.pullback f R },
   map := λ R S φ,
-  { app := λ X, continuous_functions.map X φ } }
+  { app := λ X, continuous_functions.map X φ, },
+  map_comp' := by { intros X Y Z f g, ext1 V f, refl }, }
 
 /-- The presheaf (of commutative rings), consisting of functions on an open set `U ⊆ X` with
 values in some topological commutative ring `T`. -/


### PR DESCRIPTION
I have mixed feelings about `refl` in `tidy`.

On the one hand, including it near the top of `default_tactics` list (as it is now) saves about 60s in compiling mathlib.

On the other hand, it potentially makes `tidy` very slow, as it is willing to tackle "heavy `rfl`" problems, even when other tactics would be more advisable.

As a compromise, in this PR we run `refl` inside a `try_for` wrapper.
The time limit was chosen as a smallest value for which we get the full compilation time benefits
(in fact a slight overall improvement).

This PR also
1. replaces the unique proof `by tidy` that fails if `refl` is removed entirely
2. satisfies the linter on `tactic/tidy.lean`

---
<!-- put comments you want to keep out of the PR commit here -->
