### PR TITLE
[Merged by Bors] - feat(tactic/unfold_cases): add unfold_cases tactic

### DIFF
--- a/src/tactic/default.lean
+++ b/src/tactic/default.lean
@@ -33,3 +33,4 @@ import tactic.group
 import tactic.cancel_denoms
 import tactic.zify
 import tactic.transport
+import tactic.unfold_cases

--- a/src/tactic/unfold_cases.lean
+++ b/src/tactic/unfold_cases.lean
@@ -5,11 +5,6 @@ Authors: Dany Fabian
 -/
 
 import tactic.split_ifs
-namespace tactic
-
-
-
-open expr
 /-!
   # Unfold cases tactic
 

--- a/src/tactic/unfold_cases.lean
+++ b/src/tactic/unfold_cases.lean
@@ -124,7 +124,7 @@ do
   Given a target of the form `⊢ f x₁ ... xₙ = y`, unfolds `f` using a delta reduction.
 -/
 meta def unfold_tgt : expr → tactic unit
-| e@`(%%l@(app _ _) = %%r) :=
+| `(%%l@(app _ _) = %%r) :=
   match l.get_app_fn with
   | const n ls := delta_target [n]
   | e := fail!"couldn't unfold:\n{e}"

--- a/src/tactic/unfold_cases.lean
+++ b/src/tactic/unfold_cases.lean
@@ -150,8 +150,8 @@ open unfold_cases
 
   The tactic expects a goal in the form of an equation, possibly universally quantified.
 
-  We can prove a theorem, even if the various case do not directly to function definition.
-  Here is an example application of the tactic:
+  We can prove a theorem, even if the various case do not directly correspond to the
+  function definition. Here is an example application of the tactic:
 
   ```lean
   def foo : ℕ → ℕ → ℕ
@@ -174,7 +174,7 @@ open unfold_cases
   that whenever the function is applied to `17` in the second argument, it returns `17`.
 
   Proving this property consists of merely considering all the cases, eliminating invalid ones
-  and applying `refl` of the ones which remain.
+  and applying `refl` on the ones which remain.
 
   Further examples can be found in `test/unfold_cases.lean`.
 -/

--- a/src/tactic/unfold_cases.lean
+++ b/src/tactic/unfold_cases.lean
@@ -163,7 +163,7 @@ add_tactic_doc
 { name       := "unfold_cases",
   category   := doc_category.tactic,
   decl_names := [`tactic.interactive.unfold_cases],
-  tags       := ["induction"] }
+  tags       := ["induction", "case bashing"] }
 
 end interactive
 end tactic

--- a/src/tactic/unfold_cases.lean
+++ b/src/tactic/unfold_cases.lean
@@ -150,6 +150,32 @@ open unfold_cases
 
   The tactic expects a goal in the form of an equation, possibly universally quantified.
 
+  We can prove a theorem, even if the various case do not directly to function definition.
+  Here is an example application of the tactic:
+
+  ```lean
+  def foo : ℕ → ℕ → ℕ
+  | 0     0 := 17
+  | (n+2) 17 := 17
+  | 1     0 := 23
+  | 0     (n+18) := 15
+  | 0     17 := 17
+  | 1     17 := 17
+  | _     (n+18) := 27
+  | _     _ := 15
+
+  example : ∀ x, foo x 17 = 17 :=
+  begin
+    unfold_cases { refl },
+  end
+  ```
+
+  The compiler generates 57 cases for `foo`. However, when we look at the definition, we see
+  that whenever the function is applied to `17` in the second argument, it returns `17`.
+
+  Proving this property consists of merely considering all the cases, eliminating invalid ones
+  and applying `refl` of the ones which remain.
+
   Further examples can be found in `test/unfold_cases.lean`.
 -/
 meta def unfold_cases (inner : itactic) : tactic unit := focus1 $ do

--- a/src/tactic/unfold_cases.lean
+++ b/src/tactic/unfold_cases.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2020 Dany Fabian. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dany Fabian
+-/
+
+import tactic.split_ifs
+namespace tactic
+
+open expr
+
+namespace unfold_cases
+meta def find_splitting_expr : expr → tactic expr
+| `(@ite %%cond %%dec_inst _ _ _ = _) := pure `(@decidable.em %%cond %%dec_inst)
+| `(%%l@(app x y) = _) := pure y
+| e := fail!"expected an expression of the form: f x = y. Got:\n{e}"
+
+meta def unfold_cases_core (inner : interactive.itactic) : tactic unit :=
+inner <|>
+(do split_ifs [], all_goals unfold_cases_core, skip) <|>
+do
+  tgt ← target,
+  e ← find_splitting_expr tgt,
+  focus1 $ do
+    cases e,
+    all_goals $ (dsimp_target >> unfold_cases_core) <|> skip,
+    skip
+
+meta def unfold_tgt : expr → tactic unit
+| e@`(%%l@(app _ _) = %%r) :=
+  match l.get_app_fn with
+  | const n ls := delta_target [n]
+  | e := fail!"couldn't unfold:\n{e}"
+  end
+| e := fail!"expected an expression of the form: f x = y. Got:\n{e}"
+end unfold_cases
+
+namespace interactive
+open unfold_cases
+
+/--
+  This tactic unfolds the definition of a function or pattern match expression.
+  Then it introduces recursively introduces a distinction by cases. The decision what express
+  to do the distinction on is driven by the pattern match expression.
+
+  A typical use case is using `unfold_cases { refl }` to collapse cases that need to be
+  considered in a pattern matching.
+
+  ```lean
+  have h : foo x = y, by unfold_cases { refl },
+  rw h,
+  ```
+
+  The tactic expects a goal in the form of an equation, possibly universally quantified.
+
+  Further examples can be found in `test/unfold_cases.lean`.
+-/
+meta def unfold_cases (inner : itactic) : tactic unit := focus1 $ do
+  tactic.intros,
+  tgt ← target,
+  unfold_tgt tgt,
+  try dsimp_target,
+  unfold_cases_core inner
+
+add_tactic_doc
+{ name       := "unfold_cases",
+  category   := doc_category.tactic,
+  decl_names := [`tactic.interactive.unfold_cases],
+  tags       := ["induction"] }
+
+end interactive
+end tactic

--- a/src/tactic/unfold_cases.lean
+++ b/src/tactic/unfold_cases.lean
@@ -96,7 +96,7 @@ namespace unfold_cases
 -/
 meta def find_splitting_expr : expr → tactic expr
 | `(@ite %%cond %%dec_inst _ _ _ = _) := pure `(@decidable.em %%cond %%dec_inst)
-| `(%%l@(app x y) = _) := pure y
+| `(%%(app x y) = _) := pure y
 | e := fail!"expected an expression of the form: f x = y. Got:\n{e}"
 
 /--

--- a/src/tactic/unfold_cases.lean
+++ b/src/tactic/unfold_cases.lean
@@ -8,13 +8,44 @@ import tactic.split_ifs
 namespace tactic
 
 open expr
+/-!
+  # Unfold cases tactic
 
+  In Lean, pattern matching expressions are not atomic parts of the syntax, but
+  rather they are compiled down into simpler terms that are later checked by the kernel.
+
+  This allows Lean to have a minimalistic kernel but can occasionally lead an explosion
+  of cases that need to be considered. What looks like one case in the `match` expression
+  can in fact be compiled into many different cases that all need to proved by case analysis.
+
+  This tactic automates the process by allowing us to write down an equation `f x = y`
+  where we know that `f x = y` is provably true, but does not hold definitionally. In that
+  case the `unfold_cases` tactic will continue unfolding `f` and introducing `cases` where
+  necessary until the left hand side becomes definitionally equal to the right hand side.
+-/
 namespace unfold_cases
+/--
+  Given an equation `f x = y`, this tactic tries to infer an expression that can be
+  used to do distinction by cases on to make progress.
+
+  Pre-condition: assumes that the outer-most application cannot be beta-reduced
+  (e.g. `whnf` or `dsimp`).
+-/
 meta def find_splitting_expr : expr → tactic expr
 | `(@ite %%cond %%dec_inst _ _ _ = _) := pure `(@decidable.em %%cond %%dec_inst)
 | `(%%l@(app x y) = _) := pure y
 | e := fail!"expected an expression of the form: f x = y. Got:\n{e}"
 
+/--
+  Tries to finish the current goal using the `inner` tactic. If the tactic
+  fails, it tries to find an expression on which to do a distinction by
+  cases and calls itself recursively.
+
+  The order of operations is significant. Because the unfolding can potentially
+  be infinite, it is important to apply the `inner` tactic at every step.
+
+  Notice, that if the `inner` tactic succeeds, the recursive unfolding is stopped.
+-/
 meta def unfold_cases_core (inner : interactive.itactic) : tactic unit :=
 inner <|>
 (do split_ifs [], all_goals unfold_cases_core, skip) <|>
@@ -26,6 +57,9 @@ do
     all_goals $ (dsimp_target >> unfold_cases_core) <|> skip,
     skip
 
+/--
+  Given a target of the form `⊢ f x₁ ... xₙ = y`, unfolds `f` using a delta reduction.
+-/
 meta def unfold_tgt : expr → tactic unit
 | e@`(%%l@(app _ _) = %%r) :=
   match l.get_app_fn with
@@ -39,9 +73,9 @@ namespace interactive
 open unfold_cases
 
 /--
-  This tactic unfolds the definition of a function or pattern match expression.
-  Then it introduces recursively introduces a distinction by cases. The decision what express
-  to do the distinction on is driven by the pattern match expression.
+  This tactic unfolds the definition of a function or `match` expression.
+  Then it recursively introduces a distinction by cases. The decision what expression
+  to do the distinction on is driven by the pattern matching expression.
 
   A typical use case is using `unfold_cases { refl }` to collapse cases that need to be
   considered in a pattern matching.

--- a/src/tactic/unfold_cases.lean
+++ b/src/tactic/unfold_cases.lean
@@ -84,6 +84,8 @@ import tactic.split_ifs
 
   Now, however, both goals can be discharged using `refl`.
 -/
+namespace tactic
+open expr
 namespace unfold_cases
 /--
   Given an equation `f x = y`, this tactic tries to infer an expression that can be

--- a/test/unfold_cases.lean
+++ b/test/unfold_cases.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2020 Dany Fabian. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dany Fabian
+-/
+
+import tactic
+open tactic
+
+variable {α : Type*}
+
+inductive color
+| red
+| black
+
+inductive node (α)
+| leaf {} : node
+| tree {} (color : color) (left : node) (val : α) (right : node) : node
+
+/-- this function creates 122 cases as opposed to the 5 we see here. -/
+def balance_eqn_compiler {α} : color → node α → α → node α → node α
+| color.black (node.tree color.red (node.tree color.red a x b) y c) z d :=
+    node.tree color.red (node.tree color.black a x b) y (node.tree color.black c z d)
+| color.black (node.tree color.red a x (node.tree color.red b y c)) z d :=
+    node.tree color.red (node.tree color.black a x b) y (node.tree color.black c z d)
+| color.black a x (node.tree color.red (node.tree color.red b y c) z d) :=
+    node.tree color.red (node.tree color.black a x b) y (node.tree color.black c z d)
+| color.black a x (node.tree color.red b y (node.tree color.red c z d)) :=
+    node.tree color.red (node.tree color.black a x b) y (node.tree color.black c z d)
+| color a x b := node.tree color a x b
+
+example : ∀ a (x:α) b y c z d, balance_eqn_compiler color.black (node.tree color.red (node.tree color.red a x b) y c) z d =
+    node.tree color.red (node.tree color.black a x b) y (node.tree color.black c z d) :=
+begin
+  unfold_cases { refl },
+end
+
+/-- this function creates 122 cases as opposed to the 5 we see here. -/
+def balance_match {α}  (c:color) (l:node α) (v:α) (r:node α) : node α :=
+match c, l, v, r with
+| color.black, node.tree color.red (node.tree color.red a x b) y c, z, d :=
+    node.tree color.red (node.tree color.black a x b) y (node.tree color.black c z d)
+| color.black, node.tree color.red a x (node.tree color.red b y c), z, d :=
+    node.tree color.red (node.tree color.black a x b) y (node.tree color.black c z d)
+| color.black, a, x, node.tree color.red (node.tree color.red b y c) z d :=
+    node.tree color.red (node.tree color.black a x b) y (node.tree color.black c z d)
+| color.black, a, x, node.tree color.red b y (node.tree color.red c z d) :=
+     node.tree color.red (node.tree color.black a x b) y (node.tree color.black c z d)
+| color, a, x, b := node.tree color a x b
+end
+
+example : ∀ a (x:α) b y c z d, balance_match color.black (node.tree color.red (node.tree color.red a x b) y c) z d =
+    node.tree color.red (node.tree color.black a x b) y (node.tree color.black c z d) :=
+begin
+  unfold_cases { refl },
+end
+
+def foo : ℕ → ℕ → ℕ
+| 0 0 := 17
+| (n+2) 17 := 17
+| 1 0 := 23
+| 0 (n+18) := 15
+| 0 17 := 17
+| 1 17 := 17
+| _ (n+18) := 27
+| _ _ := 15
+
+example : ∀ x, foo x 17 = 17 :=
+begin
+  unfold_cases { refl },
+end
+
+def bar : ℕ → ℕ
+| 17 := 17
+| 9 := 17
+| n := 17
+
+example : ∀ x, bar x = 17 :=
+begin
+  unfold_cases { refl }
+end
+
+def baz : ℕ → ℕ → Prop
+| 0 0 := false
+| 0 n := true
+| n 0 := false
+| n m := n < m
+
+example : ∀ x, baz x 0 = false :=
+begin
+  unfold_cases { refl },
+end


### PR DESCRIPTION
---
This is a tactic that proves a goal by recursively unfolding cases until a finisher tactic like `refl` or `assumption` can get the job done. 

The motivating example is the one with the red-black tree balancing which creates a whopping 122 cases out of a 5-case pattern match. This makes proving things about the algorithm a huge pain and this tactic helps.

We considered various alternative approaches like defining an inductively defined proposition with only the few cases that can be seen in a pattern match. Whilst this is potentially a nice and viable approach, it does need to be in line with the equation compiler.

That is something I am happy to look into once Lean 4 is around, but for now it's too much work as it would require modifying the C++ code base and would end up being wasted effort w.r.t. Lean 4.
<!-- put comments you want to keep out of the PR commit here -->
