### PR TITLE
[Merged by Bors] - feat (order/order_iso): lemmas about order_isos on lattices

### DIFF
--- a/src/order/order_iso.lean
+++ b/src/order/order_iso.lean
@@ -364,8 +364,7 @@ lemma order_iso.map_inf [semilattice_inf α] [semilattice_inf β]
 begin
   apply le_antisymm, { apply f.to_order_embedding.map_inf_le },
   rw [f.symm.ord, order_iso.symm_apply_apply],
-  conv_rhs {rw [← order_iso.symm_apply_apply f a₁, ← order_iso.symm_apply_apply f a₂]},
-  apply f.symm.to_order_embedding.map_inf_le
+  convert f.symm.to_order_embedding.map_inf_le; simp,
 end
 
 lemma order_embedding.le_map_sup [semilattice_sup α] [semilattice_sup β]
@@ -380,8 +379,7 @@ lemma order_iso.map_sup [semilattice_sup α] [semilattice_sup β]
 begin
   apply le_antisymm, swap, { apply f.to_order_embedding.le_map_sup },
   rw [f.symm.ord, order_iso.symm_apply_apply],
-  conv_lhs {rw [← order_iso.symm_apply_apply f a₁, ← order_iso.symm_apply_apply f a₂]},
-  apply f.symm.to_order_embedding.le_map_sup
+  convert f.symm.to_order_embedding.le_map_sup; simp,
 end
 
 end lattice_isos

--- a/src/order/order_iso.lean
+++ b/src/order/order_iso.lean
@@ -341,13 +341,25 @@ def order_embedding.cod_restrict (p : set β) (f : r ≼o s) (H : ∀ a, f a ∈
 
 section lattice_isos
 
+lemma order_iso.map_bot [order_bot α] [order_bot β]
+  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop)) :
+  f ⊥ = ⊥ :=
+by { rw [eq_bot_iff, ← f.apply_symm_apply ⊥, ← f.ord], apply bot_le, }
+
+lemma order_iso.map_top [order_top α] [order_top β]
+  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop)) :
+  f ⊤ = ⊤ :=
+by { rw [eq_top_iff, ← f.apply_symm_apply ⊤, ← f.ord], apply le_top, }
+
+variables {a₁ a₂ : α}
+
 lemma order_embedding.map_inf_le [semilattice_inf α] [semilattice_inf β]
-  (f : (has_le.le : α → α → Prop) ≼o (has_le.le : β → β → Prop)) {a₁ a₂ : α} :
+  (f : (has_le.le : α → α → Prop) ≼o (has_le.le : β → β → Prop)) :
   f (a₁ ⊓ a₂) ≤ f a₁ ⊓ f a₂ :=
 by { apply le_inf; rw ← f.ord; simp }
 
 lemma order_iso.map_inf [semilattice_inf α] [semilattice_inf β]
-  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop)) {a₁ a₂ : α} :
+  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop)) :
   f (a₁ ⊓ a₂) = f a₁ ⊓ f a₂ :=
 begin
   apply le_antisymm, { apply f.to_order_embedding.map_inf_le },
@@ -357,12 +369,12 @@ begin
 end
 
 lemma order_embedding.le_map_sup [semilattice_sup α] [semilattice_sup β]
-  (f : (has_le.le : α → α → Prop) ≼o (has_le.le : β → β → Prop)) {a₁ a₂ : α} :
+  (f : (has_le.le : α → α → Prop) ≼o (has_le.le : β → β → Prop)) :
   f a₁ ⊔ f a₂ ≤ f (a₁ ⊔ a₂) :=
 by { apply sup_le; rw ← f.ord; simp }
 
 lemma order_iso.map_sup [semilattice_sup α] [semilattice_sup β]
-  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop)) {a₁ a₂ : α} :
+  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop)) :
   f (a₁ ⊔ a₂) = f a₁ ⊔ f a₂ :=
 begin
   apply le_antisymm, swap, { apply f.to_order_embedding.le_map_sup },
@@ -370,15 +382,5 @@ begin
   conv_lhs {rw [← order_iso.symm_apply_apply f a₁, ← order_iso.symm_apply_apply f a₂]},
   apply f.symm.to_order_embedding.le_map_sup
 end
-
-lemma order_iso.map_bot [order_bot α] [order_bot β]
-  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop)) {a₁ a₂ : α} :
-  f ⊥ = ⊥ :=
-by { rw [eq_bot_iff, ← f.apply_symm_apply ⊥, ← f.ord], apply bot_le, }
-
-lemma order_iso.map_top [order_top α] [order_top β]
-  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop)) {a₁ a₂ : α} :
-  f ⊤ = ⊤ :=
-by { rw [eq_top_iff, ← f.apply_symm_apply ⊤, ← f.ord], apply le_top, }
 
 end lattice_isos

--- a/src/order/order_iso.lean
+++ b/src/order/order_iso.lean
@@ -149,7 +149,7 @@ end
 
 -- If le is preserved by an order embedding of preorders, then lt is too
 def lt_embedding_of_le_embedding [preorder α] [preorder β]
-  (f : (has_le.le : α → α → Prop) ≼o (has_le.le : β → β → Prop)) :
+  (f : ((≤)  : α → α → Prop) ≼o ((≤) : β → β → Prop)) :
 (has_lt.lt : α → α → Prop) ≼o (has_lt.lt : β → β → Prop) :=
 { ord' := by intros; simp [lt_iff_le_not_le,f.ord], .. f }
 
@@ -342,24 +342,24 @@ def order_embedding.cod_restrict (p : set β) (f : r ≼o s) (H : ∀ a, f a ∈
 section lattice_isos
 
 lemma order_iso.map_bot [order_bot α] [order_bot β]
-  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop)) :
+  (f : ((≤) : α → α → Prop) ≃o ((≤) : β → β → Prop)) :
   f ⊥ = ⊥ :=
 by { rw [eq_bot_iff, ← f.apply_symm_apply ⊥, ← f.ord], apply bot_le, }
 
 lemma order_iso.map_top [order_top α] [order_top β]
-  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop)) :
+  (f : ((≤) : α → α → Prop) ≃o ((≤) : β → β → Prop)) :
   f ⊤ = ⊤ :=
 by { rw [eq_top_iff, ← f.apply_symm_apply ⊤, ← f.ord], apply le_top, }
 
 variables {a₁ a₂ : α}
 
 lemma order_embedding.map_inf_le [semilattice_inf α] [semilattice_inf β]
-  (f : (has_le.le : α → α → Prop) ≼o (has_le.le : β → β → Prop)) :
+  (f : ((≤) : α → α → Prop) ≼o ((≤) : β → β → Prop)) :
   f (a₁ ⊓ a₂) ≤ f a₁ ⊓ f a₂ :=
-by { apply le_inf; rw ← f.ord; simp }
+by simp [← f.ord]
 
 lemma order_iso.map_inf [semilattice_inf α] [semilattice_inf β]
-  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop)) :
+  (f : ((≤) : α → α → Prop) ≃o ((≤) : β → β → Prop)) :
   f (a₁ ⊓ a₂) = f a₁ ⊓ f a₂ :=
 begin
   apply le_antisymm, { apply f.to_order_embedding.map_inf_le },
@@ -369,12 +369,13 @@ begin
 end
 
 lemma order_embedding.le_map_sup [semilattice_sup α] [semilattice_sup β]
-  (f : (has_le.le : α → α → Prop) ≼o (has_le.le : β → β → Prop)) :
+  (f : ((≤) : α → α → Prop) ≼o ((≤) : β → β → Prop)) :
   f a₁ ⊔ f a₂ ≤ f (a₁ ⊔ a₂) :=
-by { apply sup_le; rw ← f.ord; simp }
+by simp [← f.ord]
+
 
 lemma order_iso.map_sup [semilattice_sup α] [semilattice_sup β]
-  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop)) :
+  (f : ((≤) : α → α → Prop) ≃o ((≤) : β → β → Prop)) :
   f (a₁ ⊔ a₂) = f a₁ ⊔ f a₂ :=
 begin
   apply le_antisymm, swap, { apply f.to_order_embedding.le_map_sup },

--- a/src/order/order_iso.lean
+++ b/src/order/order_iso.lean
@@ -342,48 +342,42 @@ def order_embedding.cod_restrict (p : set β) (f : r ≼o s) (H : ∀ a, f a ∈
 section lattice_isos
 
 lemma order_embedding.map_inf_le [semilattice_inf α] [semilattice_inf β]
-  (f : (has_le.le : α → α → Prop) ≼o (has_le.le : β → β → Prop))
-  {a₁ a₂ : α} :
+  (f : (has_le.le : α → α → Prop) ≼o (has_le.le : β → β → Prop)) {a₁ a₂ : α} :
   f (a₁ ⊓ a₂) ≤ f a₁ ⊓ f a₂ :=
 by { apply le_inf; rw ← f.ord; simp }
 
 lemma order_iso.map_inf [semilattice_inf α] [semilattice_inf β]
-  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop))
-  {a₁ a₂ : α} :
+  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop)) {a₁ a₂ : α} :
   f (a₁ ⊓ a₂) = f a₁ ⊓ f a₂ :=
 begin
-  apply le_antisymm, apply f.to_order_embedding.map_inf_le,
-  rw f.symm.ord, rw order_iso.symm_apply_apply,
+  apply le_antisymm, { apply f.to_order_embedding.map_inf_le },
+  rw [f.symm.ord, order_iso.symm_apply_apply],
   conv_rhs {rw [← order_iso.symm_apply_apply f a₁, ← order_iso.symm_apply_apply f a₂]},
   apply f.symm.to_order_embedding.map_inf_le
 end
 
 lemma order_embedding.le_map_sup [semilattice_sup α] [semilattice_sup β]
-  (f : (has_le.le : α → α → Prop) ≼o (has_le.le : β → β → Prop))
-  {a₁ a₂ : α} :
+  (f : (has_le.le : α → α → Prop) ≼o (has_le.le : β → β → Prop)) {a₁ a₂ : α} :
   f a₁ ⊔ f a₂ ≤ f (a₁ ⊔ a₂) :=
 by { apply sup_le; rw ← f.ord; simp }
 
 lemma order_iso.map_sup [semilattice_sup α] [semilattice_sup β]
-  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop))
-  {a₁ a₂ : α} :
+  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop)) {a₁ a₂ : α} :
   f (a₁ ⊔ a₂) = f a₁ ⊔ f a₂ :=
 begin
-  apply le_antisymm, swap, apply f.to_order_embedding.le_map_sup,
-  rw f.symm.ord, rw order_iso.symm_apply_apply,
+  apply le_antisymm, swap, { apply f.to_order_embedding.le_map_sup },
+  rw [f.symm.ord, order_iso.symm_apply_apply],
   conv_lhs {rw [← order_iso.symm_apply_apply f a₁, ← order_iso.symm_apply_apply f a₂]},
   apply f.symm.to_order_embedding.le_map_sup
 end
 
-lemma order_iso.bot_eq [order_bot α] [order_bot β]
-  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop))
-  {a₁ a₂ : α} :
+lemma order_iso.map_bot [order_bot α] [order_bot β]
+  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop)) {a₁ a₂ : α} :
   f ⊥ = ⊥ :=
 by { rw [eq_bot_iff, ← f.apply_symm_apply ⊥, ← f.ord], apply bot_le, }
 
-lemma order_iso.top_eq [order_top α] [order_top β]
-  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop))
-  {a₁ a₂ : α} :
+lemma order_iso.map_top [order_top α] [order_top β]
+  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop)) {a₁ a₂ : α} :
   f ⊤ = ⊤ :=
 by { rw [eq_top_iff, ← f.apply_symm_apply ⊤, ← f.ord], apply le_top, }
 

--- a/src/order/order_iso.lean
+++ b/src/order/order_iso.lean
@@ -377,13 +377,13 @@ end
 
 lemma order_iso.bot_eq [order_bot α] [order_bot β]
   (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop))
-  {a₁ a₂ : α}:
+  {a₁ a₂ : α} :
   f ⊥ = ⊥ :=
 by { rw [eq_bot_iff, ← f.apply_symm_apply ⊥, ← f.ord], apply bot_le, }
 
 lemma order_iso.top_eq [order_top α] [order_top β]
   (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop))
-  {a₁ a₂ : α}:
+  {a₁ a₂ : α} :
   f ⊤ = ⊤ :=
 by { rw [eq_top_iff, ← f.apply_symm_apply ⊤, ← f.ord], apply le_top, }
 

--- a/src/order/order_iso.lean
+++ b/src/order/order_iso.lean
@@ -149,7 +149,7 @@ end
 
 -- If le is preserved by an order embedding of preorders, then lt is too
 def lt_embedding_of_le_embedding [preorder α] [preorder β]
-  (f : ((≤)  : α → α → Prop) ≼o ((≤) : β → β → Prop)) :
+  (f : ((≤) : α → α → Prop) ≼o ((≤) : β → β → Prop)) :
 (has_lt.lt : α → α → Prop) ≼o (has_lt.lt : β → β → Prop) :=
 { ord' := by intros; simp [lt_iff_le_not_le,f.ord], .. f }
 

--- a/src/order/order_iso.lean
+++ b/src/order/order_iso.lean
@@ -338,3 +338,53 @@ def order_embedding.cod_restrict (p : set β) (f : r ≼o s) (H : ∀ a, f a ∈
 
 @[simp] theorem order_embedding.cod_restrict_apply (p) (f : r ≼o s) (H a) :
   order_embedding.cod_restrict p f H a = ⟨f a, H a⟩ := rfl
+
+section lattice_isos
+
+lemma order_embedding.map_inf_le [semilattice_inf α] [semilattice_inf β]
+  (f : (has_le.le : α → α → Prop) ≼o (has_le.le : β → β → Prop))
+  {a₁ a₂ : α} :
+  f (a₁ ⊓ a₂) ≤ f a₁ ⊓ f a₂ :=
+by { apply le_inf; rw ← f.ord; simp }
+
+lemma order_iso.map_inf [semilattice_inf α] [semilattice_inf β]
+  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop))
+  {a₁ a₂ : α} :
+  f (a₁ ⊓ a₂) = f a₁ ⊓ f a₂ :=
+begin
+  apply le_antisymm, apply f.to_order_embedding.map_inf_le,
+  rw f.symm.ord, rw order_iso.symm_apply_apply,
+  conv_rhs {rw [← order_iso.symm_apply_apply f a₁, ← order_iso.symm_apply_apply f a₂]},
+  apply f.symm.to_order_embedding.map_inf_le
+end
+
+lemma order_embedding.le_map_sup [semilattice_sup α] [semilattice_sup β]
+  (f : (has_le.le : α → α → Prop) ≼o (has_le.le : β → β → Prop))
+  {a₁ a₂ : α} :
+  f a₁ ⊔ f a₂ ≤ f (a₁ ⊔ a₂) :=
+by { apply sup_le; rw ← f.ord; simp }
+
+lemma order_iso.map_sup [semilattice_sup α] [semilattice_sup β]
+  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop))
+  {a₁ a₂ : α} :
+  f (a₁ ⊔ a₂) = f a₁ ⊔ f a₂ :=
+begin
+  apply le_antisymm, swap, apply f.to_order_embedding.le_map_sup,
+  rw f.symm.ord, rw order_iso.symm_apply_apply,
+  conv_lhs {rw [← order_iso.symm_apply_apply f a₁, ← order_iso.symm_apply_apply f a₂]},
+  apply f.symm.to_order_embedding.le_map_sup
+end
+
+lemma order_iso.bot_eq [order_bot α] [order_bot β]
+  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop))
+  {a₁ a₂ : α}:
+  f ⊥ = ⊥ :=
+by { rw [eq_bot_iff, ← f.apply_symm_apply ⊥, ← f.ord], apply bot_le, }
+
+lemma order_iso.top_eq [order_top α] [order_top β]
+  (f : (has_le.le : α → α → Prop) ≃o (has_le.le : β → β → Prop))
+  {a₁ a₂ : α}:
+  f ⊤ = ⊤ :=
+by { rw [eq_top_iff, ← f.apply_symm_apply ⊤, ← f.ord], apply le_top, }
+
+end lattice_isos


### PR DESCRIPTION
shows that `order_embedding`s and `order_iso`s respect `lattice` operations

---
<!-- put comments you want to keep out of the PR commit here -->
