### PR TITLE
[Merged by Bors] - feat(linear_algebra/matrix): define equivalences for reindexing matrices with equivalent types

### DIFF
--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -817,7 +817,8 @@ by simp [linear_equiv.symm_conj_apply, matrix.lie_conj, matrix.comp_to_matrix_mu
 types is an equivalence of Lie algebras. -/
 def matrix.reindex_lie_equiv {m : Type w₁} [fintype m] [decidable_eq m]
   (e : n ≃ m) : matrix n n R ≃ₗ⁅R⁆ matrix m m R :=
-{ map_lie := λ M N, by simp [lie_ring.of_associative_ring_bracket, matrix.reindex_mul],
+{ map_lie := λ M N, by simp only [lie_ring.of_associative_ring_bracket, matrix.reindex_mul,
+    matrix.mul_eq_mul, linear_equiv.map_sub, linear_equiv.to_fun_apply],
 ..(matrix.reindex_linear_equiv e e) }
 
 @[simp] lemma matrix.reindex_lie_equiv_apply {m : Type w₁} [fintype m] [decidable_eq m]

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -813,6 +813,13 @@ by simp [linear_equiv.conj_apply, matrix.lie_conj, matrix.comp_to_matrix_mul, to
   (P.lie_conj h).symm A = P⁻¹ ⬝ A ⬝ P :=
 by simp [linear_equiv.symm_conj_apply, matrix.lie_conj, matrix.comp_to_matrix_mul, to_lin_to_matrix]
 
+/-- For square matrices, the natural map that reindexes a matrix's rows and columns with equivalent
+types is an equivalence of Lie algebras. -/
+def matrix.reindex_lie_equiv {m : Type w₁} [fintype m] [decidable_eq m]
+  (eₘ : n ≃ m) : matrix n n R ≃ₗ⁅R⁆ matrix m m R :=
+{ map_lie := λ M N, by simp [lie_ring.of_associative_ring_bracket, matrix.reindex_mul],
+..(matrix.reindex_linear_equiv eₘ eₘ) }
+
 end matrices
 
 section skew_adjoint_endomorphisms

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -816,9 +816,19 @@ by simp [linear_equiv.symm_conj_apply, matrix.lie_conj, matrix.comp_to_matrix_mu
 /-- For square matrices, the natural map that reindexes a matrix's rows and columns with equivalent
 types is an equivalence of Lie algebras. -/
 def matrix.reindex_lie_equiv {m : Type w₁} [fintype m] [decidable_eq m]
-  (eₘ : n ≃ m) : matrix n n R ≃ₗ⁅R⁆ matrix m m R :=
+  (e : n ≃ m) : matrix n n R ≃ₗ⁅R⁆ matrix m m R :=
 { map_lie := λ M N, by simp [lie_ring.of_associative_ring_bracket, matrix.reindex_mul],
-..(matrix.reindex_linear_equiv eₘ eₘ) }
+..(matrix.reindex_linear_equiv e e) }
+
+@[simp] lemma matrix.reindex_lie_equiv_apply {m : Type w₁} [fintype m] [decidable_eq m]
+  (e : n ≃ m) (M : matrix n n R) :
+  matrix.reindex_lie_equiv e M = λ i j, M (e.symm i) (e.symm j) :=
+rfl
+
+@[simp] lemma matrix.reindex_lie_equiv_symm_apply {m : Type w₁} [fintype m] [decidable_eq m]
+  (e : n ≃ m) (M : matrix m m R) :
+  (matrix.reindex_lie_equiv e).symm M = λ i j, M (e i) (e j) :=
+rfl
 
 end matrices
 

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -442,6 +442,16 @@ def reindex_linear_equiv [semiring R] (eₘ : m ≃ m') (eₙ : n ≃ n') :
   map_smul' := λ M N, rfl,
 ..(reindex eₘ eₙ)}
 
+@[simp] lemma reindex_linear_equiv_apply [semiring R]
+  (eₘ : m ≃ m') (eₙ : n ≃ n') (M : matrix m n R) :
+  reindex_linear_equiv eₘ eₙ M = λ i j, M (eₘ.symm i) (eₙ.symm j) :=
+rfl
+
+@[simp] lemma reindex_linear_equiv_symm_apply [semiring R]
+  (eₘ : m ≃ m') (eₙ : n ≃ n') (M : matrix m' n' R) :
+  (reindex_linear_equiv eₘ eₙ).symm M = λ i j, M (eₘ i) (eₙ j) :=
+rfl
+
 lemma reindex_mul [semiring R]
   (eₘ : m ≃ m') (eₙ : n ≃ n') (eₗ : l ≃ l') (M : matrix m n R) (N : matrix n l R) :
   (reindex_linear_equiv eₘ eₙ M) ⬝ (reindex_linear_equiv eₙ eₗ N) = reindex_linear_equiv eₘ eₗ (M ⬝ N) :=
@@ -449,17 +459,26 @@ begin
   ext i j,
   dsimp only [matrix.mul, matrix.dot_product],
   rw [←finset.univ_map_equiv_to_embedding eₙ, finset.sum_map finset.univ eₙ.to_embedding],
-  simp [reindex_linear_equiv],
+  simp,
 end
 
 /-- For square matrices, the natural map that reindexes a matrix's rows and columns with equivalent
 types is an equivalence of algebras. -/
 def reindex_alg_equiv [comm_semiring R] [decidable_eq m] [decidable_eq n]
   (e : m ≃ n) : matrix m m R ≃ₐ[R] matrix n n R :=
-{ map_mul'  := λ M N, by simp [reindex_mul],
-  commutes' := λ r, by { ext, simp [reindex_linear_equiv, algebra_map, algebra.to_ring_hom],
-                         by_cases h : i = j; simp [h], },
+{ map_mul'  := λ M N, by simp only [reindex_mul, linear_equiv.to_fun_apply, mul_eq_mul],
+  commutes' := λ r, by { ext, simp [algebra_map, algebra.to_ring_hom], by_cases h : i = j; simp [h], },
 ..(reindex_linear_equiv e e) }
+
+@[simp] lemma reindex_alg_equiv_apply [comm_semiring R] [decidable_eq m] [decidable_eq n]
+  (e : m ≃ n) (M : matrix m m R) :
+  reindex_alg_equiv e M = λ i j, M (e.symm i) (e.symm j) :=
+rfl
+
+@[simp] lemma reindex_alg_equiv_symm_apply [comm_semiring R] [decidable_eq m] [decidable_eq n]
+  (e : m ≃ n) (M : matrix n n R) :
+  (reindex_alg_equiv e).symm M = λ i j, M (e i) (e j) :=
+rfl
 
 end reindexing
 

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -413,6 +413,56 @@ by rw [@linear_equiv.findim_eq R (matrix m n R) _ _ _ _ _ _ (linear_equiv.uncurr
 
 end finite_dimensional
 
+section reindexing
+
+variables {l' m' n' : Type w} [fintype l'] [fintype m'] [fintype n']
+variables {R : Type v}
+
+/-- The natural map that reindexes a matrix's rows and columns with equivalent types is an
+equivalence. -/
+def reindex (eₘ : m ≃ m') (eₙ : n ≃ n') : matrix m n R ≃ matrix m' n' R :=
+{ to_fun    := λ M i j, M (eₘ.symm i) (eₙ.symm j),
+  inv_fun   := λ M i j, M (eₘ i) (eₙ j),
+  left_inv  := λ M, by simp,
+  right_inv := λ M, by simp, }
+
+@[simp] lemma reindex_apply (eₘ : m ≃ m') (eₙ : n ≃ n') (M : matrix m n R) :
+  reindex eₘ eₙ M = λ i j, M (eₘ.symm i) (eₙ.symm j) :=
+rfl
+
+@[simp] lemma reindex_symm_apply (eₘ : m ≃ m') (eₙ : n ≃ n') (M : matrix m' n' R) :
+  (reindex eₘ eₙ).symm M = λ i j, M (eₘ i) (eₙ j) :=
+rfl
+
+/-- The natural map that reindexes a matrix's rows and columns with equivalent types is a linear
+equivalence. -/
+def reindex_linear_equiv [semiring R] (eₘ : m ≃ m') (eₙ : n ≃ n') :
+  matrix m n R ≃ₗ[R] matrix m' n' R :=
+{ map_add'  := λ M N, rfl,
+  map_smul' := λ M N, rfl,
+..(reindex eₘ eₙ)}
+
+lemma reindex_mul [semiring R]
+  (eₘ : m ≃ m') (eₙ : n ≃ n') (eₗ : l ≃ l') (M : matrix m n R) (N : matrix n l R) :
+  (reindex_linear_equiv eₘ eₙ M) ⬝ (reindex_linear_equiv eₙ eₗ N) = reindex_linear_equiv eₘ eₗ (M ⬝ N) :=
+begin
+  ext i j,
+  dsimp only [matrix.mul, matrix.dot_product],
+  rw [←finset.univ_map_equiv_to_embedding eₙ, finset.sum_map finset.univ eₙ.to_embedding],
+  simp [reindex_linear_equiv],
+end
+
+/-- For square matrices, the natural map that reindexes a matrix's rows and columns with equivalent
+types is an equivalence of algebras. -/
+def reindex_alg_equiv [comm_semiring R] [decidable_eq m] [decidable_eq n]
+  (e : m ≃ n) : matrix m m R ≃ₐ[R] matrix n n R :=
+{ map_mul'  := λ M N, by simp [reindex_mul],
+  commutes' := λ r, by { ext, simp [reindex_linear_equiv, algebra_map, algebra.to_ring_hom],
+                         by_cases h : i = j; simp [h], },
+..(reindex_linear_equiv e e) }
+
+end reindexing
+
 end matrix
 
 namespace linear_map


### PR DESCRIPTION
---
I have started some work to define and prove basic facts about the classical Lie algebras and I need `matrix.reindex_lie_equiv`.
