### PR TITLE
[Merged by Bors] - feat(tactic/obviously): improve error reporting

### DIFF
--- a/src/category_theory/category/default.lean
+++ b/src/category_theory/category/default.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stephen Morgan, Scott Morrison, Johannes Hölzl, Reid Barton
 -/
 import tactic.basic
-import tactic.tidy
+import tactic.obviously
 
 /-!
 # Categories
@@ -29,15 +29,6 @@ universes v u
 
 namespace category_theory
 
-/-
-The propositional fields of `category` are annotated with the auto_param `obviously`,
-which is defined here as a
-[`replacer` tactic](https://leanprover-community.github.io/mathlib_docs/commands.html#def_replacer).
-We then immediately set up `obviously` to call `tidy`. Later, this can be replaced with more
-powerful tactics.
--/
-def_replacer obviously
-@[obviously] meta def obviously' := tactic.tidy
 
 class has_hom (obj : Type u) : Type (max u (v+1)) :=
 (hom : obj → obj → Type v)

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -305,6 +305,13 @@ meta def is_sort : expr → bool
 | (sort _) := tt
 | e         := ff
 
+/--
+Replace any metavariables in the expression with underscores, in preparation for printing
+`refine ...` statements.
+-/
+meta def replace_mvars (e : expr) : expr :=
+e.replace (λ e' _, if e'.is_mvar then some (unchecked_cast pexpr.mk_placeholder) else none)
+
 /-- If `e` is a local constant, `to_implicit_local_const e` changes the binder info of `e` to
  `implicit`. See also `to_implicit_binder`, which also changes lambdas and pis. -/
 meta def to_implicit_local_const : expr → expr

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -370,6 +370,9 @@ e.fold mk_name_set $ λ e' _ l,
 meta def contains_constant (e : expr) (p : name → Prop) [decidable_pred p] : bool :=
 e.fold ff (λ e' _ b, if p (e'.const_name) then tt else b)
 
+/--
+Returns true if `e` contains a `sorry`.
+-/
 meta def contains_sorry (e : expr) : bool :=
 e.fold ff (λ e' _ b, if (is_sorry e').is_some then tt else b)
 

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -370,6 +370,9 @@ e.fold mk_name_set $ λ e' _ l,
 meta def contains_constant (e : expr) (p : name → Prop) [decidable_pred p] : bool :=
 e.fold ff (λ e' _ b, if p (e'.const_name) then tt else b)
 
+meta def contains_sorry (e : expr) : bool :=
+e.fold ff (λ e' _ b, if (is_sorry e').is_some then tt else b)
+
 /--
 `app_symbol_in e l` returns true iff `e` is an application of a constant whose name is in `l`.
 -/

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -1741,14 +1741,6 @@ meta def success_if_fail_with_msg {α : Type u} (t : tactic α) (msg : string) :
    mk_exception "success_if_fail_with_msg combinator failed, given tactic succeeded" none s
 end
 
-
-/--
-Replace any metavariables in the expression with underscores, in preparation for printing
-`refine ...` statements.
--/
-meta def replace_mvars (e : expr) : expr :=
-e.replace (λ e' _, if e'.is_mvar then some (unchecked_cast pexpr.mk_placeholder) else none)
-
 /--
 Construct a `refine ...` or `exact ...` string which would construct `g`.
 -/

--- a/src/tactic/obviously.lean
+++ b/src/tactic/obviously.lean
@@ -10,10 +10,7 @@ and fail otherwise.
 meta def sorry_if_contains_sorry : tactic unit :=
 do
   g ← target,
-  lock_tactic_state -- so the metavariable type in `sorry : _` doesn't become a goal
-    -- we use `.replace_mvars` here to avoid unifying `sorry` with a goal whose type is a metavariable.
-    (to_expr ``(sorry : _) >>= kdepends_on g.replace_mvars >>= guardb) <|>
-    fail "goal does not contain `sorrry`",
+  guard g.contains_sorry <|> fail "goal does not contain `sorrry`",
   tactic.admit
 
 end tactic

--- a/src/tactic/obviously.lean
+++ b/src/tactic/obviously.lean
@@ -3,6 +3,10 @@ import tactic.basic
 
 namespace tactic
 
+/--
+`sorry_if_contains_sorry` will solve any goal already containing `sorry` in its type with `sorry`,
+and fail otherwise.
+-/
 meta def sorry_if_contains_sorry : tactic unit :=
 do
   g ← target,
@@ -18,8 +22,17 @@ which is defined here as a
 [`replacer` tactic](https://leanprover-community.github.io/mathlib_docs/commands.html#def_replacer).
 We then immediately set up `obviously` to call `tidy`. Later, this can be replaced with more
 powerful tactics.
+
+(In fact, at present this mechanism is not actually used, and the implementation of
+`obviously` below stays in place throughout mathlib.)
 -/
 def_replacer obviously
+
+/--
+The default implementation of `obviously`
+discharges any goals which contain `sorry` in their type using `sorry`,
+and then calls `tidy`.
+-/
 @[obviously] meta def obviously' :=
 tactic.sorry_if_contains_sorry <|>
 tactic.tidy <|>

--- a/src/tactic/obviously.lean
+++ b/src/tactic/obviously.lean
@@ -11,7 +11,9 @@ meta def sorry_if_contains_sorry : tactic unit :=
 do
   g ← target,
   lock_tactic_state -- so the metavariable type in `sorry : _` doesn't become a goal
-    (to_expr ``(sorry : _) >>= kdepends_on g >>= guardb) <|> fail "goal does not contain `sorrry`",
+    -- we use `.replace_mvars` here to avoid unifying `sorry` with a goal whose type is a metavariable.
+    (to_expr ``(sorry : _) >>= kdepends_on g.replace_mvars >>= guardb) <|>
+    fail "goal does not contain `sorrry`",
   tactic.admit
 
 end tactic

--- a/src/tactic/obviously.lean
+++ b/src/tactic/obviously.lean
@@ -1,0 +1,28 @@
+import tactic.tidy
+import tactic.basic
+
+namespace tactic
+
+meta def sorry_if_contains_sorry : tactic unit :=
+do
+  g ← target,
+  lock_tactic_state -- so the metavariable type in `sorry : _` doesn't become a goal
+    (to_expr ``(sorry : _) >>= kdepends_on g >>= guardb) <|> fail "goal does not contain `sorrry`",
+  tactic.admit
+
+end tactic
+
+/-
+The propositional fields of `category` are annotated with the auto_param `obviously`,
+which is defined here as a
+[`replacer` tactic](https://leanprover-community.github.io/mathlib_docs/commands.html#def_replacer).
+We then immediately set up `obviously` to call `tidy`. Later, this can be replaced with more
+powerful tactics.
+-/
+def_replacer obviously
+@[obviously] meta def obviously' :=
+tactic.sorry_if_contains_sorry <|>
+tactic.tidy <|>
+tactic.fail (
+"`obviously` failed to solve a subgoal.\n" ++
+"You may need to explicitly provide a proof of the corresponding structure field.")


### PR DESCRIPTION
If `obviously` (used for auto_params) fails, it now prints a more useful message than "chain tactic made no progress"

If the goal presented to obviously contains `sorry`, it just uses `sorry` to discard it.

---
<!-- put comments you want to keep out of the PR commit here -->
