### PR TITLE
[Merged by Bors] - chore(data/opposite): pp_nodot on op and unop

### DIFF
--- a/src/data/opposite.lean
+++ b/src/data/opposite.lean
@@ -41,7 +41,9 @@ notation α `ᵒᵖ`:std.prec.max_plus := opposite α
 namespace opposite
 
 variables {α}
+@[pp_nodot]
 def op : α → αᵒᵖ := id
+@[pp_nodot]
 def unop : αᵒᵖ → α := id
 
 lemma op_injective : function.injective (op : α → αᵒᵖ) := λ _ _, id


### PR DESCRIPTION
Since it's not possible to write `X.op`, its extremely unhelpful for the pretty printer to output this.

---
<!-- put comments you want to keep out of the PR commit here -->
