### PR TITLE
[Merged by Bors] - chore(data/polynomial): reduce imports

### DIFF
--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -8,7 +8,7 @@ Group action on rings.
 
 import group_theory.group_action
 import data.equiv.ring
-import data.polynomial
+import data.polynomial.eval
 
 universes u v
 

--- a/src/algebra/polynomial/basic.lean
+++ b/src/algebra/polynomial/basic.lean
@@ -3,7 +3,8 @@ Copyright (c) 2020 Aaron Anderson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Aaron Anderson, Jalex Stark.
 -/
-import data.polynomial
+import data.polynomial.ring_division
+
 open polynomial finset
 
 /-!

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Gabriel Ebner, Sébastien Gouëzel
 -/
 import analysis.calculus.fderiv
-import data.polynomial
+import data.polynomial.derivative
 
 /-!
 

--- a/src/data/mv_polynomial.lean
+++ b/src/data/mv_polynomial.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Johan Commelin, Mario Carneiro, Shing Tak Lam
 -/
-import data.polynomial
+import data.polynomial.eval
 import data.equiv.ring
 import data.equiv.fin
 import tactic.omega

--- a/src/data/padics/hensel.lean
+++ b/src/data/padics/hensel.lean
@@ -6,6 +6,7 @@ Authors: Robert Y. Lewis
 import data.padics.padic_integers
 import topology.metric_space.cau_seq_filter
 import analysis.specific_limits
+import data.polynomial.identities
 import topology.algebra.polynomial
 
 /-!

--- a/src/data/polynomial/identities.lean
+++ b/src/data/polynomial/identities.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Scott Morrison, Jens Wagemaker
 -/
-import data.polynomial.algebra_map
 import data.polynomial.derivative
 
 /-!

--- a/src/field_theory/minimal_polynomial.lean
+++ b/src/field_theory/minimal_polynomial.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johan Commelin
 -/
 import ring_theory.integral_closure
+import data.polynomial.field_division
 
 /-!
 # Minimal polynomials

--- a/src/field_theory/separable.lean
+++ b/src/field_theory/separable.lean
@@ -5,6 +5,7 @@ Authors: Kenny Lau.
 -/
 
 import ring_theory.polynomial
+import data.polynomial.derivative
 
 /-!
 

--- a/src/ring_theory/adjoin_root.lean
+++ b/src/ring_theory/adjoin_root.lean
@@ -5,7 +5,7 @@ Authors: Mario Carneiro, Chris Hughes
 
 Adjoining roots of polynomials
 -/
-import data.polynomial
+import data.polynomial.field_division
 import ring_theory.adjoin
 import ring_theory.principal_ideal_domain
 

--- a/src/ring_theory/algebraic.lean
+++ b/src/ring_theory/algebraic.lean
@@ -6,6 +6,7 @@ Authors: Johan Commelin
 
 import linear_algebra.finite_dimensional
 import ring_theory.integral_closure
+import data.polynomial.field_division
 
 /-!
 # Algebraic elements and algebraic extensions

--- a/src/ring_theory/eisenstein_criterion.lean
+++ b/src/ring_theory/eisenstein_criterion.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
 import ring_theory.ideal_operations
-import data.polynomial
+import data.polynomial.ring_division
 import tactic.apply_fun
 import ring_theory.prime
 /-!

--- a/src/ring_theory/free_ring.lean
+++ b/src/ring_theory/free_ring.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Johan Commelin
 -/
-import data.polynomial
+import group_theory.free_abelian_group
 
 universes u v
 

--- a/src/ring_theory/integral_domain.lean
+++ b/src/ring_theory/integral_domain.lean
@@ -5,7 +5,7 @@ Authors: Johan Commelin, Chris Hughes
 -/
 
 import data.fintype.card
-import data.polynomial
+import data.polynomial.ring_division
 import group_theory.order_of_element
 import algebra.geom_sum
 

--- a/src/ring_theory/polynomial/basic.lean
+++ b/src/ring_theory/polynomial/basic.lean
@@ -9,6 +9,7 @@ Main result: Hilbert basis theorem, that if a ring is noetherian then so is its 
 -/
 import algebra.char_p
 import data.mv_polynomial
+import data.polynomial.ring_division
 import ring_theory.noetherian
 
 noncomputable theory

--- a/src/ring_theory/polynomial_algebra.lean
+++ b/src/ring_theory/polynomial_algebra.lean
@@ -5,7 +5,7 @@ Authors: Scott Morrison
 -/
 import ring_theory.tensor_product
 import ring_theory.matrix_algebra
-import data.polynomial
+import data.polynomial.algebra_map
 
 /-!
 # Algebra isomorphism between matrices of polynomials and polynomials of matrices

--- a/src/ring_theory/power_series.lean
+++ b/src/ring_theory/power_series.lean
@@ -5,6 +5,7 @@ Authors: Johan Commelin, Kenny Lau
 -/
 import data.mv_polynomial
 import ring_theory.ideal_operations
+import ring_theory.multiplicity
 import tactic.linarith
 
 /-!

--- a/src/topology/algebra/polynomial.lean
+++ b/src/topology/algebra/polynomial.lean
@@ -6,7 +6,7 @@ Author: Robert Y. Lewis
 Analytic facts about polynomials.
 -/
 import topology.algebra.ring
-import data.polynomial
+import data.polynomial.div
 import data.real.cau_seq
 
 open polynomial is_absolute_value


### PR DESCRIPTION
Now that @jalex-stark has split up `data.polynomial` into submodules, this PR minimises imports.

---
<!-- put comments you want to keep out of the PR commit here -->
