### PR TITLE
refactor(algebra/category/*/limits): refactor concrete limits

### DIFF
--- a/src/algebra/category/CommRing/limits.lean
+++ b/src/algebra/category/CommRing/limits.lean
@@ -5,6 +5,7 @@ Authors: Scott Morrison
 -/
 import algebra.category.CommRing.basic
 import algebra.category.Group.limits
+import deprecated.subgroup
 
 /-!
 # The category of commutative rings has all limits
@@ -30,20 +31,30 @@ instance comm_ring_obj (F : J ⥤ CommRing) (j) :
   comm_ring ((F ⋙ forget CommRing).obj j) :=
 by { change comm_ring (F.obj j), apply_instance }
 
-instance sections_submonoid (F : J ⥤ CommRing) :
-  is_submonoid (F ⋙ forget CommRing).sections :=
-{ one_mem := λ j j' f, by simp,
-  mul_mem := λ a b ah bh j j' f,
+def sections_submonoid (F : J ⥤ CommRing) :
+  submonoid (Π j, F.obj j) :=
+{ carrier := (F ⋙ forget CommRing).sections,
+  one_mem' := λ j j' f, by simp,
+  mul_mem' := λ a b ah bh j j' f,
   begin
     simp only [forget_map_eq_coe, functor.comp_map, ring_hom.map_mul, pi.mul_apply],
     dsimp [functor.sections] at ah bh,
     rw [ah f, bh f],
   end }
 
+-- We still don't have bundled subrings,
+-- so we need to convert the bundled sub-objects back to unbundled
+
+instance sections_submonoid' (F : J ⥤ CommRing) :
+  is_submonoid (F ⋙ forget CommRing).sections :=
+(sections_submonoid F).is_submonoid
+
+instance sections_add_subgroup' (F : J ⥤ CommRing) :
+  is_add_subgroup (F ⋙ forget CommRing).sections :=
+(AddCommGroup.sections_add_subgroup (F ⋙ forget₂ CommRing Ring ⋙ forget₂ Ring AddCommGroup)).is_subgroup
+
 instance sections_subring (F : J ⥤ CommRing) :
-  is_subring (F ⋙ forget CommRing).sections :=
-{ ..(CommRing.sections_submonoid F),
-  ..(AddCommGroup.sections_add_subgroup (F ⋙ forget₂ CommRing Ring ⋙ forget₂ Ring AddCommGroup)) }
+  is_subring (F ⋙ forget CommRing).sections := {}
 
 instance limit_comm_ring (F : J ⥤ CommRing) :
   comm_ring (limit (F ⋙ forget CommRing)) :=

--- a/src/algebra/category/CommRing/limits.lean
+++ b/src/algebra/category/CommRing/limits.lean
@@ -31,6 +31,9 @@ instance comm_ring_obj (F : J ⥤ CommRing) (j) :
   comm_ring ((F ⋙ forget CommRing).obj j) :=
 by { change comm_ring (F.obj j), apply_instance }
 
+/--
+The flat sections of a functor into `CommRing` form a multiplicative submonoid of all sections.
+-/
 def sections_submonoid (F : J ⥤ CommRing) :
   submonoid (Π j, F.obj j) :=
 { carrier := (F ⋙ forget CommRing).sections,

--- a/src/algebra/category/CommRing/limits.lean
+++ b/src/algebra/category/CommRing/limits.lean
@@ -69,7 +69,7 @@ Construction of a limit cone in `CommRing`.
 (Internal use only; use the limits API.)
 -/
 def limit (F : J ⥤ CommRing) : cone F :=
-{ X := ⟨limit (F ⋙ forget _), by apply_instance⟩,
+{ X := CommRing.of (limit (F ⋙ forget _)),
   π :=
   { app := limit_π_ring_hom F,
     naturality' := λ j j' f,

--- a/src/algebra/category/CommRing/limits.lean
+++ b/src/algebra/category/CommRing/limits.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import algebra.category.CommRing.basic
+import algebra.category.Group.limits
 
 /-!
 # The category of commutative rings has all limits
@@ -31,53 +32,18 @@ by { change comm_ring (F.obj j), apply_instance }
 
 instance sections_submonoid (F : J ⥤ CommRing) :
   is_submonoid (F ⋙ forget CommRing).sections :=
-{ one_mem := λ j j' f,
-  begin
-    erw [functor.comp_map, forget_map_eq_coe, (F.map f).map_one],
-    refl
-  end,
+{ one_mem := λ j j' f, by simp,
   mul_mem := λ a b ah bh j j' f,
   begin
-    erw [functor.comp_map, forget_map_eq_coe, (F.map f).map_mul],
-    dsimp [functor.sections] at ah,
-    rw ah f,
-    dsimp [functor.sections] at bh,
-    rw bh f,
-    refl,
+    simp only [forget_map_eq_coe, functor.comp_map, ring_hom.map_mul, pi.mul_apply],
+    dsimp [functor.sections] at ah bh,
+    rw [ah f, bh f],
   end }
-
-instance sections_add_submonoid (F : J ⥤ CommRing) :
-  is_add_submonoid (F ⋙ forget CommRing).sections :=
-{ zero_mem := λ j j' f,
-  begin
-    erw [functor.comp_map, forget_map_eq_coe, (F.map f).map_zero],
-    refl,
-  end,
-  add_mem := λ a b ah bh j j' f,
-  begin
-    erw [functor.comp_map, forget_map_eq_coe, (F.map f).map_add],
-    dsimp [functor.sections] at ah,
-    rw ah f,
-    dsimp [functor.sections] at bh,
-    rw bh f,
-    refl,
-  end }
-
-instance sections_add_subgroup (F : J ⥤ CommRing) :
-  is_add_subgroup (F ⋙ forget CommRing).sections :=
-{ neg_mem := λ a ah j j' f,
-  begin
-    erw [functor.comp_map, forget_map_eq_coe, (F.map f).map_neg],
-    dsimp [functor.sections] at ah,
-    rw ah f,
-    refl,
-  end,
-  ..(CommRing.sections_add_submonoid F) }
 
 instance sections_subring (F : J ⥤ CommRing) :
   is_subring (F ⋙ forget CommRing).sections :=
 { ..(CommRing.sections_submonoid F),
-  ..(CommRing.sections_add_subgroup F) }
+  ..(AddCommGroup.sections_add_subgroup (F ⋙ forget₂ CommRing Ring ⋙ forget₂ Ring AddCommGroup)) }
 
 instance limit_comm_ring (F : J ⥤ CommRing) :
   comm_ring (limit (F ⋙ forget CommRing)) :=
@@ -117,11 +83,7 @@ def limit_is_limit (F : J ⥤ CommRing) : is_limit (limit F) :=
 begin
   refine is_limit.of_faithful
     (forget CommRing) (limit.is_limit _)
-    (λ s, ⟨_, _, _, _, _⟩) (λ s, rfl); dsimp,
-  { ext j, dsimp, rw (s.π.app j).map_one },
-  { intros x y, ext j, dsimp, rw (s.π.app j).map_mul },
-  { ext j, dsimp, rw (s.π.app j).map_zero, refl },
-  { intros x y, ext j, dsimp, rw (s.π.app j).map_add, refl }
+    (λ s, ⟨_, _, _, _, _⟩) (λ s, rfl); tidy
 end
 
 end CommRing_has_limits

--- a/src/algebra/category/Group/limits.lean
+++ b/src/algebra/category/Group/limits.lean
@@ -34,29 +34,21 @@ by { change add_comm_group (F.obj j), apply_instance }
 
 instance sections_add_submonoid (F : J ⥤ AddCommGroup) :
   is_add_submonoid (F ⋙ forget AddCommGroup).sections :=
-{ zero_mem := λ j j' f,
-  begin
-    erw [functor.comp_map, forget_map_eq_coe, (F.map f).map_zero],
-    refl,
-  end,
+{ zero_mem := λ j j' f, by simp,
   add_mem := λ a b ah bh j j' f,
   begin
-    erw [functor.comp_map, forget_map_eq_coe, (F.map f).map_add],
-    dsimp [functor.sections] at ah,
-    rw ah f,
-    dsimp [functor.sections] at bh,
-    rw bh f,
-    refl,
+    simp only [forget_map_eq_coe, functor.comp_map, add_monoid_hom.map_add, pi.add_apply],
+    dsimp [functor.sections] at ah bh,
+    rw [ah f, bh f],
   end }
 
 instance sections_add_subgroup (F : J ⥤ AddCommGroup) :
   is_add_subgroup (F ⋙ forget AddCommGroup).sections :=
 { neg_mem := λ a ah j j' f,
   begin
-    erw [functor.comp_map, forget_map_eq_coe, (F.map f).map_neg],
+    simp only [forget_map_eq_coe, functor.comp_map, pi.neg_apply, add_monoid_hom.map_neg, neg_inj],
     dsimp [functor.sections] at ah,
     rw ah f,
-    refl,
   end,
   ..(AddCommGroup.sections_add_submonoid F) }
 
@@ -96,11 +88,7 @@ def limit_is_limit (F : J ⥤ AddCommGroup) : is_limit (limit F) :=
 begin
   refine is_limit.of_faithful
     (forget AddCommGroup) (limit.is_limit _)
-    (λ s, ⟨_, _, _⟩) (λ s, rfl); dsimp,
-  { apply subtype.eq, funext, dsimp,
-    erw (s.π.app j).map_zero, refl },
-  { intros x y, apply subtype.eq, funext, dsimp,
-    erw (s.π.app j).map_add, refl }
+    (λ s, ⟨_, _, _⟩) (λ s, rfl); tidy,
 end
 
 end AddCommGroup_has_limits

--- a/src/algebra/category/Group/limits.lean
+++ b/src/algebra/category/Group/limits.lean
@@ -74,7 +74,7 @@ Construction of a limit cone in `AddCommGroup`.
 (Internal use only; use the limits API.)
 -/
 def limit (F : J ⥤ AddCommGroup) : cone F :=
-{ X := ⟨limit (F ⋙ forget _), by apply_instance⟩,
+{ X := AddCommGroup.of (limit (F ⋙ forget _)),
   π :=
   { app := limit_π_add_monoid_hom F,
     naturality' := λ j j' f,

--- a/src/algebra/category/Group/limits.lean
+++ b/src/algebra/category/Group/limits.lean
@@ -32,6 +32,9 @@ instance add_comm_group_obj (F : J ⥤ AddCommGroup) (j) :
   add_comm_group ((F ⋙ forget AddCommGroup).obj j) :=
 by { change add_comm_group (F.obj j), apply_instance }
 
+/--
+The flat sections of a functor into `AddCommGroup` form a additive submonoid of all sections.
+-/
 def sections_add_submonoid (F : J ⥤ AddCommGroup) :
   add_submonoid (Π j, F.obj j) :=
 { carrier := (F ⋙ forget AddCommGroup).sections,
@@ -43,6 +46,9 @@ def sections_add_submonoid (F : J ⥤ AddCommGroup) :
     rw [ah f, bh f],
   end }
 
+/--
+The flat sections of a functor into `AddCommGroup` form a additive subgroup of all sections.
+-/
 def sections_add_subgroup (F : J ⥤ AddCommGroup) :
   add_subgroup (Π j, F.obj j) :=
 { carrier := (F ⋙ forget AddCommGroup).sections,

--- a/src/algebra/category/Group/limits.lean
+++ b/src/algebra/category/Group/limits.lean
@@ -32,19 +32,21 @@ instance add_comm_group_obj (F : J ⥤ AddCommGroup) (j) :
   add_comm_group ((F ⋙ forget AddCommGroup).obj j) :=
 by { change add_comm_group (F.obj j), apply_instance }
 
-instance sections_add_submonoid (F : J ⥤ AddCommGroup) :
-  is_add_submonoid (F ⋙ forget AddCommGroup).sections :=
-{ zero_mem := λ j j' f, by simp,
-  add_mem := λ a b ah bh j j' f,
+def sections_add_submonoid (F : J ⥤ AddCommGroup) :
+  add_submonoid (Π j, F.obj j) :=
+{ carrier := (F ⋙ forget AddCommGroup).sections,
+  zero_mem' := λ j j' f, by simp,
+  add_mem' := λ a b ah bh j j' f,
   begin
     simp only [forget_map_eq_coe, functor.comp_map, add_monoid_hom.map_add, pi.add_apply],
     dsimp [functor.sections] at ah bh,
     rw [ah f, bh f],
   end }
 
-instance sections_add_subgroup (F : J ⥤ AddCommGroup) :
-  is_add_subgroup (F ⋙ forget AddCommGroup).sections :=
-{ neg_mem := λ a ah j j' f,
+def sections_add_subgroup (F : J ⥤ AddCommGroup) :
+  add_subgroup (Π j, F.obj j) :=
+{ carrier := (F ⋙ forget AddCommGroup).sections,
+  neg_mem' := λ a ah j j' f,
   begin
     simp only [forget_map_eq_coe, functor.comp_map, pi.neg_apply, add_monoid_hom.map_neg, neg_inj],
     dsimp [functor.sections] at ah,
@@ -54,8 +56,10 @@ instance sections_add_subgroup (F : J ⥤ AddCommGroup) :
 
 instance limit_add_comm_group (F : J ⥤ AddCommGroup) :
   add_comm_group (limit (F ⋙ forget AddCommGroup)) :=
-@subtype.add_comm_group ((Π (j : J), (F ⋙ forget _).obj j)) (by apply_instance) _
-  (by convert (AddCommGroup.sections_add_subgroup F))
+begin
+  change add_comm_group (sections_add_subgroup F),
+  apply_instance,
+end
 
 /-- `limit.π (F ⋙ forget AddCommGroup) j` as a `add_monoid_hom`. -/
 def limit_π_add_monoid_hom (F : J ⥤ AddCommGroup) (j) :


### PR DESCRIPTION
I think it's time to provide limits for all the concrete categories. Before doing that, this PR is just refactoring the existing constructions. The two changes are:

1. use bundled substructures where possible (we don't have `subring` yet, so this isn't completely possible)
2. reuse the work from limits for `AddCommGroup` in limits for `CommRing` (this will be very helpful for providing everything)

There are also a bunch of `erw` that now just work by `simp`.

---
<!-- put comments you want to keep out of the PR commit here -->
