### PR TITLE
[Merged by Bors] - feat(algebra/big_operators): more general prod_insert_one

### DIFF
--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -150,12 +150,11 @@ lemma prod_empty {α : Type u} {f : α → β} : (∏ x in (∅:finset α), f x)
 lemma prod_insert [decidable_eq α] :
   a ∉ s → (∏ x in (insert a s), f x) = f a * ∏ x in s, f x := fold_insert
 
-/-- If a function applied at a point is 1 if that point is not in a
-`finset`, a product is unchanged by adding that point, whether or not
-present, to that `finset`. -/
-@[simp, to_additive "If a function applied at a point is 0 if that point is not in a
-`finset`, a sum is unchanged by adding that point, whether or not
-present, to that `finset`."]
+/--
+The product of `f` over `insert a s` is the same as the product over `s`, as long as `a` is in `s` or `f a = 1`.
+-/
+@[simp, to_additive "The sum of `f` over `insert a s` is the same as the sum over `s`, as long as `a` is in `s` or `f a = 0`.
+"]
 lemma prod_insert_of_eq_one_if_not_mem [decidable_eq α] (h : a ∉ s → f a = 1) :
   ∏ x in insert a s, f x = ∏ x in s, f x :=
 begin
@@ -164,10 +163,10 @@ begin
   { rw [prod_insert hm, h hm, one_mul] },
 end
 
-/-- If a function applied at a point is 1, a product is unchanged by
-adding that point, whether or not present, to a `finset`. -/
-@[simp, to_additive "If a function applied at a point is 0, a sum is unchanged by
-adding that point, whether or not present, to a `finset`."]
+/--
+The product of `f` over `insert a s` is the same as the product over `s`, as long as `f a = 1`.
+-/
+@[simp, to_additive "The sum of `f` over `insert a s` is the same as the sum over `s`, as long as `f a = 0`."]
 lemma prod_insert_one [decidable_eq α] (h : f a = 1) :
   ∏ x in insert a s, f x = ∏ x in s, f x :=
 prod_insert_of_eq_one_if_not_mem (λ _, h)

--- a/src/algebra/big_operators.lean
+++ b/src/algebra/big_operators.lean
@@ -150,17 +150,27 @@ lemma prod_empty {α : Type u} {f : α → β} : (∏ x in (∅:finset α), f x)
 lemma prod_insert [decidable_eq α] :
   a ∉ s → (∏ x in (insert a s), f x) = f a * ∏ x in s, f x := fold_insert
 
+/-- If a function applied at a point is 1 if that point is not in a
+`finset`, a product is unchanged by adding that point, whether or not
+present, to that `finset`. -/
+@[simp, to_additive "If a function applied at a point is 0 if that point is not in a
+`finset`, a sum is unchanged by adding that point, whether or not
+present, to that `finset`."]
+lemma prod_insert_of_eq_one_if_not_mem [decidable_eq α] (h : a ∉ s → f a = 1) :
+  ∏ x in insert a s, f x = ∏ x in s, f x :=
+begin
+  by_cases hm : a ∈ s,
+  { simp_rw insert_eq_of_mem hm },
+  { rw [prod_insert hm, h hm, one_mul] },
+end
+
 /-- If a function applied at a point is 1, a product is unchanged by
 adding that point, whether or not present, to a `finset`. -/
 @[simp, to_additive "If a function applied at a point is 0, a sum is unchanged by
 adding that point, whether or not present, to a `finset`."]
 lemma prod_insert_one [decidable_eq α] (h : f a = 1) :
   ∏ x in insert a s, f x = ∏ x in s, f x :=
-begin
-  by_cases hm : a ∈ s,
-  { simp_rw insert_eq_of_mem hm },
-  { rw [prod_insert hm, h, one_mul] },
-end
+prod_insert_of_eq_one_if_not_mem (λ _, h)
 
 @[simp, to_additive]
 lemma prod_singleton : (∏ x in (singleton a), f x) = f a :=


### PR DESCRIPTION
I found I had a use for a slightly more general version of
`prod_insert_one` / `sum_insert_zero`.  Add that version and use it in
the proof of `prod_insert_one`.


---
<!-- put comments you want to keep out of the PR commit here -->
