### PR TITLE
[Merged by Bors] - feat(tactic/squeeze_*): improve suggestions

### DIFF
--- a/src/tactic/squeeze.lean
+++ b/src/tactic/squeeze.lean
@@ -310,7 +310,6 @@ meta def squeeze_dsimp
 do (cfg',c) ← parse_dsimp_config cfg,
    simp_set ← attribute.get_instances `simp,
    simp_set ← simp_set.mfilter $ has_attribute' `_refl_lemma,
-   trace $ simp_set.length,
    simp_set ← simp_set.mmap $ resolve_name' >=> pure ∘ simp_arg_type.expr,
    squeeze_simp_core no_dflt (hs ++ simp_set)
      (λ l_no_dft l_args, dsimp l_no_dft l_args attr_names locat cfg')

--- a/src/tactic/squeeze.lean
+++ b/src/tactic/squeeze.lean
@@ -146,7 +146,7 @@ do e ← resolve_name' n, pure $ simp_arg_type.expr e
 /-- tactic combinator to create a `simp`-like tactic that minimizes its
 argument list.
 
- * `slow`: should we use a slower, more accurate strategy?
+ * `slow`: adds all rfl-lemmas from the environment to the initial list (this is a slower but more accurate strategy)
  * `no_dflt`: did the user use the `only` keyword?
  * `args`:    list of `simp` arguments
  * `tac`:     how to invoke the underlying `simp` tactic


### PR DESCRIPTION
This makes this gives `squeeze_simp`, `squeeze_simpa` and `squeeze_dsimp` the `?` optional argument that indicates that we should consider all `simp` lemmas that are also `_refl_lemma`

---
<!-- put comments you want to keep out of the PR commit here -->
