### PR TITLE
[Merged by Bors] - feat (linear_algebra/matrix): make diag and trace compatible with semirings

### DIFF
--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -267,6 +267,7 @@ def diag : (matrix n n M) →ₗ[R] n → M :=
 { to_fun    := λ A i, A i i,
   map_add'  := by { intros, ext, refl, },
   map_smul' := by { intros, ext, refl, } }
+
 variables {n} {R} {M}
 
 @[simp] lemma diag_apply (A : matrix n n M) (i : n) : diag n R M A i = A i i := rfl
@@ -277,6 +278,7 @@ variables {n} {R} {M}
 @[simp] lemma diag_transpose (A : matrix n n M) : diag n R M Aᵀ = diag n R M A := rfl
 
 variables (n) (R) (M)
+
 /--
 The trace of a square matrix.
 -/
@@ -284,6 +286,7 @@ def trace : (matrix n n M) →ₗ[R] M :=
 { to_fun    := λ A, ∑ i, diag n R M A i,
   map_add'  := by { intros, apply finset.sum_add_distrib, },
   map_smul' := by { intros, simp [finset.smul_sum], } }
+
 variables {n} {R} {M}
 
 @[simp] lemma trace_diag (A : matrix n n M) : trace n R M A = ∑ i, diag n R M A i := rfl

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -262,11 +262,12 @@ variables {R : Type v} {M : Type w} [semiring R] [add_comm_monoid M] [semimodule
 /--
 The diagonal of a square matrix.
 -/
-def diag (n : Type u) (R : Type v) (M : Type w)
-  [semiring R] [add_comm_monoid M] [semimodule R M] [fintype n] : (matrix n n M) →ₗ[R] n → M :=
+variables (n) (R) (M)
+def diag : (matrix n n M) →ₗ[R] n → M :=
 { to_fun    := λ A i, A i i,
   map_add'  := by { intros, ext, refl, },
   map_smul' := by { intros, ext, refl, } }
+variables {n} {R} {M}
 
 @[simp] lemma diag_apply (A : matrix n n M) (i : n) : diag n R M A i = A i i := rfl
 
@@ -278,11 +279,12 @@ def diag (n : Type u) (R : Type v) (M : Type w)
 /--
 The trace of a square matrix.
 -/
-def trace (n : Type u) (R : Type v) (M : Type w)
-  [semiring R] [add_comm_monoid M] [semimodule R M] [fintype n] : (matrix n n M) →ₗ[R] M :=
+variables (n) (R) (M)
+def trace : (matrix n n M) →ₗ[R] M :=
 { to_fun    := λ A, ∑ i, diag n R M A i,
   map_add'  := by { intros, apply finset.sum_add_distrib, },
   map_smul' := by { intros, simp [finset.smul_sum], } }
+variables {n} {R} {M}
 
 @[simp] lemma trace_diag (A : matrix n n M) : trace n R M A = ∑ i, diag n R M A i := rfl
 

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -259,10 +259,10 @@ section trace
 
 variables {R : Type v} {M : Type w} [semiring R] [add_comm_monoid M] [semimodule R M]
 
+variables (n) (R) (M)
 /--
 The diagonal of a square matrix.
 -/
-variables (n) (R) (M)
 def diag : (matrix n n M) →ₗ[R] n → M :=
 { to_fun    := λ A i, A i i,
   map_add'  := by { intros, ext, refl, },
@@ -276,10 +276,10 @@ variables {n} {R} {M}
 
 @[simp] lemma diag_transpose (A : matrix n n M) : diag n R M Aᵀ = diag n R M A := rfl
 
+variables (n) (R) (M)
 /--
 The trace of a square matrix.
 -/
-variables (n) (R) (M)
 def trace : (matrix n n M) →ₗ[R] M :=
 { to_fun    := λ A, ∑ i, diag n R M A i,
   map_add'  := by { intros, apply finset.sum_add_distrib, },

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -257,9 +257,8 @@ linear_equiv_matrix_comp hb hb hb f g
 
 section trace
 
-variables {R : Type v} {M : Type w} [semiring R] [add_comm_monoid M] [semimodule R M]
+variables (n) (R : Type v) (M : Type w) [semiring R] [add_comm_monoid M] [semimodule R M]
 
-variables (n) (R) (M)
 /--
 The diagonal of a square matrix.
 -/

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -257,13 +257,13 @@ linear_equiv_matrix_comp hb hb hb f g
 
 section trace
 
-variables {R : Type v} {M : Type w} [ring R] [add_comm_group M] [module R M]
+variables {R : Type v} {M : Type w} [semiring R] [add_comm_monoid M] [semimodule R M]
 
 /--
 The diagonal of a square matrix.
 -/
 def diag (n : Type u) (R : Type v) (M : Type w)
-  [ring R] [add_comm_group M] [module R M] [fintype n] : (matrix n n M) →ₗ[R] n → M :=
+  [semiring R] [add_comm_monoid M] [semimodule R M] [fintype n] : (matrix n n M) →ₗ[R] n → M :=
 { to_fun    := λ A i, A i i,
   map_add'  := by { intros, ext, refl, },
   map_smul' := by { intros, ext, refl, } }
@@ -279,7 +279,7 @@ def diag (n : Type u) (R : Type v) (M : Type w)
 The trace of a square matrix.
 -/
 def trace (n : Type u) (R : Type v) (M : Type w)
-  [ring R] [add_comm_group M] [module R M] [fintype n] : (matrix n n M) →ₗ[R] M :=
+  [semiring R] [add_comm_monoid M] [semimodule R M] [fintype n] : (matrix n n M) →ₗ[R] M :=
 { to_fun    := λ A, ∑ i, diag n R M A i,
   map_add'  := by { intros, apply finset.sum_add_distrib, },
   map_smul' := by { intros, simp [finset.smul_sum], } }


### PR DESCRIPTION
changes ring and related instances to semiring etc. in requirements for matrix.diag and matrix.trace

---
<!-- put comments you want to keep out of the PR commit here -->
