### PR TITLE
[Merged by Bors] - feat(geometry/manifold/local_invariant_properties):  local structomorphism is `local_invariant_prop`

### DIFF
--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -364,6 +364,10 @@ class closed_under_restriction (G : structure_groupoid H) : Prop :=
 (closed_under_restriction : ∀ {e : local_homeomorph H H}, e ∈ G → ∀ (s : set H), is_open s →
   (e : local_homeomorph H H).restr s ∈ G)
 
+lemma closed_under_restriction' (G : structure_groupoid H) [h : closed_under_restriction G] :
+  ∀ {e : local_homeomorph H H}, e ∈ G → ∀ (s : set H), is_open s →
+  (e : local_homeomorph H H).restr s ∈ G := h.closed_under_restriction
+
 /-- The trivial restriction-closed groupoid, containing only local homeomorphisms equivalent to the
 restriction of the identity to the various open subsets. -/
 def id_restr_groupoid : structure_groupoid H :=
@@ -398,7 +402,7 @@ def id_restr_groupoid : structure_groupoid H :=
 }
 
 lemma id_restr_groupoid_mem {s : set H} (hs : is_open s) :
-  of_set s hs ∈ (@id_restr_groupoid H _).members := ⟨s, hs, by refl⟩
+  of_set s hs ∈ @id_restr_groupoid H _ := ⟨s, hs, by refl⟩
 
 /-- The trivial restriction-closed groupoid is indeed `closed_under_restriction`. -/
 instance closed_under_restriction_id_restr_groupoid :
@@ -416,12 +420,11 @@ lemma closed_under_restriction_iff_id_le (G : structure_groupoid H) :
   closed_under_restriction G ↔ id_restr_groupoid ≤ G :=
 begin
   split,
-  { intros _i,
+  { intros _i, resetI,
     apply structure_groupoid.le_iff.mpr,
     rintros e ⟨s, hs, hes⟩,
     refine G.eq_on_source _ hes,
-    have h := _i.closed_under_restriction,
-    convert h G.id_mem s hs,
+    convert closed_under_restriction' G G.id_mem s hs,
     rw interior_eq_of_open hs,
     simp only with mfld_simps },
   { intros h,

--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -364,9 +364,10 @@ class closed_under_restriction (G : structure_groupoid H) : Prop :=
 (closed_under_restriction : ∀ {e : local_homeomorph H H}, e ∈ G → ∀ (s : set H), is_open s →
   (e : local_homeomorph H H).restr s ∈ G)
 
-lemma closed_under_restriction' (G : structure_groupoid H) [h : closed_under_restriction G] :
-  ∀ {e : local_homeomorph H H}, e ∈ G → ∀ (s : set H), is_open s →
-  (e : local_homeomorph H H).restr s ∈ G := h.closed_under_restriction
+lemma closed_under_restriction' {G : structure_groupoid H} [closed_under_restriction G]
+  {e : local_homeomorph H H} (he : e ∈ G) {s : set H} (hs : is_open s) :
+  (e : local_homeomorph H H).restr s ∈ G :=
+closed_under_restriction.closed_under_restriction he s hs
 
 /-- The trivial restriction-closed groupoid, containing only local homeomorphisms equivalent to the
 restriction of the identity to the various open subsets. -/
@@ -424,7 +425,7 @@ begin
     apply structure_groupoid.le_iff.mpr,
     rintros e ⟨s, hs, hes⟩,
     refine G.eq_on_source _ hes,
-    convert closed_under_restriction' G G.id_mem s hs,
+    convert closed_under_restriction' G.id_mem hs,
     rw interior_eq_of_open hs,
     simp only with mfld_simps },
   { intros h,

--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -362,11 +362,11 @@ instance : order_top (structure_groupoid H) :=
 homeomorphisms to open subsets of the source. -/
 class closed_under_restriction (G : structure_groupoid H) : Prop :=
 (closed_under_restriction : ∀ {e : local_homeomorph H H}, e ∈ G → ∀ (s : set H), is_open s →
-  (e : local_homeomorph H H).restr s ∈ G)
+  e.restr s ∈ G)
 
 lemma closed_under_restriction' {G : structure_groupoid H} [closed_under_restriction G]
   {e : local_homeomorph H H} (he : e ∈ G) {s : set H} (hs : is_open s) :
-  (e : local_homeomorph H H).restr s ∈ G :=
+  e.restr s ∈ G :=
 closed_under_restriction.closed_under_restriction he s hs
 
 /-- The trivial restriction-closed groupoid, containing only local homeomorphisms equivalent to the
@@ -421,7 +421,7 @@ lemma closed_under_restriction_iff_id_le (G : structure_groupoid H) :
   closed_under_restriction G ↔ id_restr_groupoid ≤ G :=
 begin
   split,
-  { introsI _i, 
+  { introsI _i,
     apply structure_groupoid.le_iff.mpr,
     rintros e ⟨s, hs, hes⟩,
     refine G.eq_on_source _ hes,

--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -420,7 +420,7 @@ lemma closed_under_restriction_iff_id_le (G : structure_groupoid H) :
   closed_under_restriction G ↔ id_restr_groupoid ≤ G :=
 begin
   split,
-  { intros _i, resetI,
+  { introsI _i, 
     apply structure_groupoid.le_iff.mpr,
     rintros e ⟨s, hs, hes⟩,
     refine G.eq_on_source _ hes,

--- a/src/geometry/manifold/local_invariant_properties.lean
+++ b/src/geometry/manifold/local_invariant_properties.lean
@@ -490,18 +490,18 @@ end local_invariant_prop
 
 section local_structomorph
 
-variables (G) [closed_under_restriction G]
+variables (G)
 open local_homeomorph
 
-/- A function from a model space `H` to itself is a local structomorphism, with respect to a
+/-- A function from a model space `H` to itself is a local structomorphism, with respect to a
 structure groupoid `G` for `H`, relative to a set `s` in `H`, if for all points `x` in the set, the
 function agrees with a `G`-structomorphism on `s` in a neighbourhood of `x`. -/
 def is_local_structomorph_within_at (f : H → H) (s : set H) (x : H) : Prop :=
 (x ∈ s) → ∃ (e : local_homeomorph H H), e ∈ G ∧ eq_on f e.to_fun (s ∩ e.source) ∧ x ∈ e.source
 
-/- For a groupoid `G` which is `closed_under_restriction`, being a local structomorphism is a local
+/-- For a groupoid `G` which is `closed_under_restriction`, being a local structomorphism is a local
 invariant property. -/
-lemma is_local_structomorph_within_at_local_invariant_prop :
+lemma is_local_structomorph_within_at_local_invariant_prop [closed_under_restriction G] :
   local_invariant_prop G G (is_local_structomorph_within_at G) :=
 { is_local := begin
     intros s x u f hu hux,

--- a/src/geometry/manifold/local_invariant_properties.lean
+++ b/src/geometry/manifold/local_invariant_properties.lean
@@ -488,4 +488,63 @@ end
 
 end local_invariant_prop
 
+section local_structomorph
+
+variables (G) [closed_under_restriction G]
+open local_homeomorph
+
+/- A function from a model space `H` to itself is a local structomorphism, with respect to a
+structure groupoid `G` for `H`, relative to a set `s` in `H`, if for all points `x` in the set, the
+function agrees with a `G`-structomorphism on `s` in a neighbourhood of `x`. -/
+def is_local_structomorph_within_at (f : H → H) (s : set H) (x : H) : Prop :=
+(x ∈ s) → ∃ (e : local_homeomorph H H), e ∈ G ∧ eq_on f e.to_fun (s ∩ e.source) ∧ x ∈ e.source
+
+/- For a groupoid `G` which is `closed_under_restriction`, being a local structomorphism is a local
+invariant property. -/
+lemma is_local_structomorph_within_at_local_invariant_prop :
+  local_invariant_prop G G (is_local_structomorph_within_at G) :=
+{ is_local := begin
+    intros s x u f hu hux,
+    split,
+    { rintros h hx,
+      rcases h hx.1 with ⟨e, heG, hef, hex⟩,
+      have : s ∩ u ∩ e.source ⊆ s ∩ e.source := by mfld_set_tac,
+      exact ⟨e, heG, hef.mono this, hex⟩ },
+    { rintros h hx,
+      rcases h ⟨hx, hux⟩ with ⟨e, heG, hef, hex⟩,
+      refine ⟨e.restr (interior u), _, _, _⟩,
+      { exact closed_under_restriction' G heG (interior u) (is_open_interior) },
+      { have : s ∩ u ∩ e.source = s ∩ (e.source ∩ u) := by mfld_set_tac,
+        simpa only [this, interior_interior, interior_eq_of_open hu] with mfld_simps using hef },
+      { simp only [*, interior_interior, interior_eq_of_open hu] with mfld_simps }}
+  end,
+  right_invariance := begin
+    intros s x f e' he'G he'x h hx,
+    have hxs : x ∈ s := by simpa only [e'.left_inv he'x] with mfld_simps using hx.2,
+    rcases h hxs with ⟨e, heG, hef, hex⟩,
+    refine ⟨e'.symm.trans e, G.trans (G.symm he'G) heG, _, _⟩,
+    { intros y hy,
+      simp only with mfld_simps at hy,
+      simp only [hef ⟨hy.1.2, hy.2.2⟩] with mfld_simps },
+    { simp only [hex, he'x] with mfld_simps }
+  end,
+  congr := begin
+    intros s x f g hfgs hfg' h hx,
+    rcases h hx with ⟨e, heG, hef, hex⟩,
+    refine ⟨e, heG, _, hex⟩,
+    intros y hy,
+    rw [← hef hy, hfgs y hy.1]
+  end,
+  left_invariance := begin
+    intros s x f e' he'G he' hfx h hx,
+    rcases h hx with ⟨e, heG, hef, hex⟩,
+    refine ⟨e.trans e', G.trans heG he'G, _, _⟩,
+    { intros y hy,
+      simp only with mfld_simps at hy,
+      simp only [hef ⟨hy.1, hy.2.1⟩] with mfld_simps },
+    { simpa only [hex, hef ⟨hx, hex⟩] with mfld_simps using hfx }
+  end }
+
+end local_structomorph
+
 end structure_groupoid

--- a/src/geometry/manifold/local_invariant_properties.lean
+++ b/src/geometry/manifold/local_invariant_properties.lean
@@ -513,7 +513,7 @@ lemma is_local_structomorph_within_at_local_invariant_prop [closed_under_restric
     { rintros h hx,
       rcases h ⟨hx, hux⟩ with ⟨e, heG, hef, hex⟩,
       refine ⟨e.restr (interior u), _, _, _⟩,
-      { exact closed_under_restriction' G heG (interior u) (is_open_interior) },
+      { exact closed_under_restriction' heG (is_open_interior) },
       { have : s ∩ u ∩ e.source = s ∩ (e.source ∩ u) := by mfld_set_tac,
         simpa only [this, interior_interior, interior_eq_of_open hu] with mfld_simps using hef },
       { simp only [*, interior_interior, interior_eq_of_open hu] with mfld_simps }}

--- a/src/geometry/manifold/local_invariant_properties.lean
+++ b/src/geometry/manifold/local_invariant_properties.lean
@@ -516,7 +516,7 @@ lemma is_local_structomorph_within_at_local_invariant_prop [closed_under_restric
       { exact closed_under_restriction' G heG (interior u) (is_open_interior) },
       { have : s ∩ u ∩ e.source = s ∩ (e.source ∩ u) := by mfld_set_tac,
         simpa only [this, interior_interior, interior_eq_of_open hu] with mfld_simps using hef },
-      { simp only [*, interior_interior, interior_eq_of_open hu] with mfld_simps }}
+      { simp only [*, interior_interior, interior_eq_of_open hu] with mfld_simps } }
   end,
   right_invariance := begin
     intros s x f e' he'G he'x h hx,


### PR DESCRIPTION
For a groupoid `G`, define the property of being a local structomorphism; prove that if `G` is closed under restriction then this property satisfies `local_invariant_prop` (i.e., is local and `G`-invariant).

---
<!-- put comments you want to keep out of the PR commit here -->
I wrote this as an exercise to understand the `local_invariant_prop` definition.  Feel free to close this PR if it doesn't fit well in the library (for example, if it should follow later from more general theory).

See [Zulip](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.233387.3A.20smooth.20functions.20on.20manifolds/near/204014463) for discussion of the choice of definition.