### PR TITLE
[Merged by Bors] - chore(*): add copyright header, cleanup imports

### DIFF
--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -3,8 +3,6 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Simon Hudon, Mario Carneiro
 -/
-import tactic.basic
-import algebra.group.to_additive
 import algebra.group.defs
 import logic.function.basic
 

--- a/src/category_theory/category/default.lean
+++ b/src/category_theory/category/default.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stephen Morgan, Scott Morrison, Johannes Hölzl, Reid Barton
 -/
 import tactic.basic
-import tactic.obviously
 
 /-!
 # Categories

--- a/src/category_theory/fully_faithful.lean
+++ b/src/category_theory/fully_faithful.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import logic.function.basic
 import category_theory.natural_isomorphism
 
 universes v₁ v₂ v₃ u₁ u₂ u₃ -- declare the `v`'s first; see `category_theory.category` for an explanation

--- a/src/category_theory/functor.lean
+++ b/src/category_theory/functor.lean
@@ -12,7 +12,6 @@ Introduces notations
   `C ⥤ D` for the type of all functors from `C` to `D`.
     (I would like a better arrow here, unfortunately ⇒ (`\functor`) is taken by core.)
 -/
-import category_theory.category
 import tactic.reassoc_axiom
 
 namespace category_theory

--- a/src/category_theory/limits/limits.lean
+++ b/src/category_theory/limits/limits.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Reid Barton, Mario Carneiro, Scott Morrison, Floris van Doorn
 -/
-import category_theory.limits.cones
 import category_theory.adjunction.basic
 import category_theory.reflect_isomorphisms
 

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -9,7 +9,6 @@ We say two types are equivalent if they are isomorphic.
 Two equivalent types have the same cardinality.
 -/
 import data.set.function
-import data.option.basic
 import algebra.group.basic
 
 open function

--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -6,7 +6,7 @@ Authors: Johannes Hölzl
 Type class hierarchy for Boolean algebras.
 -/
 import order.bounded_lattice
-import logic.function.basic
+
 set_option old_structure_cmd true
 
 universes u v

--- a/src/tactic/basic.lean
+++ b/src/tactic/basic.lean
@@ -13,6 +13,7 @@ import tactic.lint
 import tactic.localized
 import tactic.mk_iff_of_inductive_prop
 import tactic.norm_cast
+import tactic.obviously
 import tactic.protected
 import tactic.push_neg
 import tactic.replacer

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -865,6 +865,16 @@ the list of goals, since the goals can be manually edited. -/
 meta def metavariables : tactic (list expr) :=
 expr.list_meta_vars <$> result
 
+/--
+`sorry_if_contains_sorry` will solve any goal already containing `sorry` in its type with `sorry`,
+and fail otherwise.
+-/
+meta def sorry_if_contains_sorry : tactic unit :=
+do
+  g ← target,
+  guard g.contains_sorry <|> fail "goal does not contain `sorrry`",
+  tactic.admit
+
 /-- Fail if the target contains a metavariable. -/
 meta def no_mvars_in_target : tactic unit :=
 expr.has_meta_var <$> target >>= guardb ∘ bnot

--- a/src/tactic/ext.lean
+++ b/src/tactic/ext.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon
 -/
 import tactic.rcases
-import data.sum logic.function.basic
+import data.sum
+import logic.function.basic
+
 universes u₁ u₂
 
 open interactive interactive.types

--- a/src/tactic/obviously.lean
+++ b/src/tactic/obviously.lean
@@ -6,19 +6,22 @@ Authors: Scott Morrison
 import tactic.tidy
 import tactic.replacer
 
-namespace tactic
+/-!
+# The `obviously` tactic
 
-/--
-`sorry_if_contains_sorry` will solve any goal already containing `sorry` in its type with `sorry`,
-and fail otherwise.
+This file sets up a tactic called `obviously`,
+which is subsequently used throughout the category theory library
+as an `auto_param` to discharge easy proof obligations when building structures.
+
+In this file, we set up `obviously` as a "replacer" tactic,
+whose implementation can be modified after the fact.
+Then we set the default implementation to be `tidy`.
+
+## Implementation note
+At present we don't actually take advantage of the replacer mechanism in mathlib.
+In the past it had been used by an external category theory library which wanted to incorporate
+`rewrite_search` as part of `obviously`.
 -/
-meta def sorry_if_contains_sorry : tactic unit :=
-do
-  g ← target,
-  guard g.contains_sorry <|> fail "goal does not contain `sorrry`",
-  tactic.admit
-
-end tactic
 
 /-
 The propositional fields of `category` are annotated with the auto_param `obviously`,

--- a/src/tactic/obviously.lean
+++ b/src/tactic/obviously.lean
@@ -1,5 +1,10 @@
+/-
+Copyright (c) 2017 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
 import tactic.tidy
-import tactic.basic
+import tactic.replacer
 
 namespace tactic
 

--- a/src/tactic/pi_instances.lean
+++ b/src/tactic/pi_instances.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Simon Hudon All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Simon Hudon
 -/
-import tactic.solve_by_elim
 import order.basic
 
 /-!


### PR DESCRIPTION
Fixes

1. a missing copyright header
2. moves `tactic.obviously` into the imports of `tactic.basic`, so everyone has `tidy` and `obviously` available.
3. removes a few redundant imports

---
<!-- put comments you want to keep out of the PR commit here -->
