### PR TITLE
[Merged by Bors] - refactor(topology/algebra/monoid): changed topological_monoid into has_continuous_mul

### DIFF
--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -418,7 +418,7 @@ begin
 end
 
 @[priority 100] -- see Note [lower instance priority]
-instance normed_top_monoid : topological_add_monoid α := by apply_instance -- short-circuit type class inference
+instance normed_top_monoid : has_continuous_add α := by apply_instance -- short-circuit type class inference
 @[priority 100] -- see Note [lower instance priority]
 instance normed_top_group : topological_add_group α := by apply_instance -- short-circuit type class inference
 
@@ -484,7 +484,7 @@ instance prod.normed_ring [normed_ring α] [normed_ring β] : normed_ring (α ×
 end normed_ring
 
 @[priority 100] -- see Note [lower instance priority]
-instance normed_ring_top_monoid [normed_ring α] : topological_monoid α :=
+instance normed_ring_top_monoid [normed_ring α] : has_continuous_mul α :=
 ⟨ continuous_iff_continuous_at.2 $ λ x, tendsto_iff_norm_tendsto_zero.2 $
     have ∀ e : α × α, e.fst * e.snd - x.fst * x.snd =
       e.fst * e.snd - e.fst * x.snd + (e.fst * x.snd - x.fst * x.snd), by intro; rw sub_add_sub_cancel,

--- a/src/measure_theory/ae_eq_fun.lean
+++ b/src/measure_theory/ae_eq_fun.lean
@@ -301,7 +301,7 @@ instance [inhabited β] : inhabited (α →ₘ[μ] β) := ⟨const α (default �
 section monoid
 variables
   [topological_space γ] [second_countable_topology γ] [borel_space γ]
-  [monoid γ] [topological_monoid γ]
+  [monoid γ] [has_continuous_mul γ]
 
 @[to_additive]
 instance : has_mul (α →ₘ[μ] γ) := ⟨comp₂ (*) measurable_mul⟩
@@ -324,7 +324,7 @@ end monoid
 
 @[to_additive add_comm_monoid]
 instance comm_monoid [topological_space γ] [second_countable_topology γ] [borel_space γ]
-  [comm_monoid γ] [topological_monoid γ] : comm_monoid (α →ₘ[μ] γ) :=
+  [comm_monoid γ] [has_continuous_mul γ] : comm_monoid (α →ₘ[μ] γ) :=
 to_germ_injective.comm_monoid to_germ one_to_germ mul_to_germ
 
 section group
@@ -382,7 +382,7 @@ lemma coe_fn_smul (c : 𝕜) (f : α →ₘ[μ] γ) : ⇑(c • f) =ᵐ[μ] c �
 lemma smul_to_germ (c : 𝕜) (f : α →ₘ[μ] γ) : (c • f).to_germ = c • f.to_germ :=
 comp_to_germ _ _ _
 
-variables [second_countable_topology γ] [topological_add_monoid γ]
+variables [second_countable_topology γ] [has_continuous_add γ]
 
 instance : semimodule 𝕜 (α →ₘ[μ] γ) :=
 to_germ_injective.semimodule 𝕜 ⟨@to_germ α γ _ _ μ, zero_to_germ, add_to_germ⟩ smul_to_germ

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -339,17 +339,17 @@ instance prod.borel_space [second_countable_topology α] [second_countable_topol
 ⟨le_antisymm prod_le_borel_prod opens_measurable_space.borel_le⟩
 
 @[to_additive]
-lemma measurable_mul [monoid α] [topological_monoid α] [second_countable_topology α] :
+lemma measurable_mul [monoid α] [has_continuous_mul α] [second_countable_topology α] :
   measurable (λ p : α × α, p.1 * p.2) :=
 continuous_mul.measurable
 
 @[to_additive]
-lemma measurable.mul [monoid α] [topological_monoid α] [second_countable_topology α]
+lemma measurable.mul [monoid α] [has_continuous_mul α] [second_countable_topology α]
   {f : δ → α} {g : δ → α} : measurable f → measurable g → measurable (λa, f a * g a) :=
 continuous_mul.measurable2
 
 @[to_additive]
-lemma finset.measurable_prod {ι : Type*} [comm_monoid α] [topological_monoid α]
+lemma finset.measurable_prod {ι : Type*} [comm_monoid α] [has_continuous_mul α]
   [second_countable_topology α] {f : ι → δ → α} (s : finset ι) (hf : ∀i, measurable (f i)) :
   measurable (λa, ∏ i in s, f i a) :=
 finset.induction_on s

--- a/src/topology/algebra/continuous_functions.lean
+++ b/src/topology/algebra/continuous_functions.lean
@@ -31,10 +31,10 @@ a structure of group.
 
 @[to_additive continuous_add_submonoid]
 instance continuous_submonoid (α : Type u) (β : Type v) [topological_space α] [topological_space β]
-  [monoid β] [topological_monoid β] : is_submonoid { f : α → β | continuous f } :=
+  [monoid β] [has_continuous_mul β] : is_submonoid { f : α → β | continuous f } :=
 { one_mem := @continuous_const _ _ _ _ 1,
   mul_mem :=
-  λ f g fc gc, continuous.comp topological_monoid.continuous_mul (continuous.prod_mk fc gc) }.
+  λ f g fc gc, continuous.comp has_continuous_mul.continuous_mul (continuous.prod_mk fc gc) }.
 
 @[to_additive continuous_add_subgroup]
 instance continuous_subgroup (α : Type u) (β : Type v) [topological_space α] [topological_space β]
@@ -44,7 +44,7 @@ instance continuous_subgroup (α : Type u) (β : Type v) [topological_space α] 
 
 @[to_additive continuous_add_monoid]
 instance continuous_monoid {α : Type u} {β : Type v} [topological_space α] [topological_space β]
-  [monoid β] [topological_monoid β] : monoid { f : α → β | continuous f } :=
+  [monoid β] [has_continuous_mul β] : monoid { f : α → β | continuous f } :=
 subtype.monoid
 
 @[to_additive continuous_add_group]

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -24,14 +24,14 @@ set_option default_priority 100 -- see Note [default priority]
 /-- A topological (additive) group is a group in which the addition and negation operations are
 continuous. -/
 class topological_add_group (α : Type u) [topological_space α] [add_group α]
-  extends topological_add_monoid α : Prop :=
+  extends has_continuous_add α : Prop :=
 (continuous_neg : continuous (λa:α, -a))
 
 /-- A topological group is a group in which the multiplication and inversion operations are
 continuous. -/
 @[to_additive topological_add_group]
 class topological_group (α : Type*) [topological_space α] [group α]
-  extends topological_monoid α : Prop :=
+  extends has_continuous_mul α : Prop :=
 (continuous_inv : continuous (λa:α, a⁻¹))
 end prio
 
@@ -323,7 +323,7 @@ topological_space.nhds_mk_of_nhds _ _
 lemma nhds_zero_eq_Z : 𝓝 0 = Z α := by simp [nhds_eq]; exact filter.map_id
 
 @[priority 100] -- see Note [lower instance priority]
-instance : topological_add_monoid α :=
+instance : has_continuous_add α :=
 ⟨ continuous_iff_continuous_at.2 $ assume ⟨a, b⟩,
   begin
     rw [continuous_at, nhds_prod_eq, nhds_eq, nhds_eq, nhds_eq, filter.prod_map_map_eq,

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -200,7 +200,7 @@ lemma equiv.summable_iff_of_has_sum_iff {α' : Type*} [add_comm_monoid α']
   summable f ↔ summable g :=
 ⟨λ ⟨a, ha⟩, ⟨e.symm a, he.1 $ by rwa [e.apply_symm_apply]⟩, λ ⟨a, ha⟩, ⟨e a, he.2 ha⟩⟩
 
-variable [topological_add_monoid α]
+variable [has_continuous_add α]
 
 lemma has_sum.add (hf : has_sum f a) (hg : has_sum g b) : has_sum (λb, f b + g b) (a + b) :=
 by simp only [has_sum, sum_add_distrib]; exact hf.add hg
@@ -363,8 +363,8 @@ lemma tsum_subtype (s : set β) (f : β → α) :
   (∑' x : s, f x) = ∑' x, s.indicator f x :=
 tsum_eq_tsum_of_has_sum_iff_has_sum $ λ _, has_sum_subtype_iff_indicator
 
-section topological_add_monoid
-variable [topological_add_monoid α]
+section has_continuous_add
+variable [has_continuous_add α]
 
 lemma tsum_add (hf : summable f) (hg : summable g) : (∑'b, f b + g b) = (∑'b, f b) + (∑'b, g b) :=
 (hf.has_sum.add hg.has_sum).tsum_eq
@@ -391,7 +391,7 @@ begin
   assumption
 end
 
-end topological_add_monoid
+end has_continuous_add
 
 section encodable
 open encodable

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -116,7 +116,7 @@ lemma is_closed_map_smul_of_unit (a : units R) : is_closed_map (λ (x : M), (a :
 /-- If `M` is a topological module over `R` and `0` is a limit of invertible elements of `R`, then
 `⊤` is the only submodule of `M` with a nonempty interior. See also
 `submodule.eq_top_of_nonempty_interior` for a `normed_space` version. -/
-lemma submodule.eq_top_of_nonempty_interior' [topological_add_monoid M]
+lemma submodule.eq_top_of_nonempty_interior' [has_continuous_add M]
   (h : nhds_within (0:R) {x | is_unit x} ≠ ⊥)
   (s : submodule R M) (hs : (interior (s:set M)).nonempty) :
   s = ⊤ :=
@@ -261,7 +261,7 @@ lemma id_apply : id R M x = x := rfl
 @[simp] lemma one_apply : (1 : M →L[R] M) x = x := rfl
 
 section add
-variables [topological_add_monoid M₂]
+variables [has_continuous_add M₂]
 
 instance : has_add (M →L[R] M₂) :=
 ⟨λ f g, ⟨f + g, f.2.add g.2⟩⟩
@@ -303,12 +303,12 @@ by { ext, simp }
 @[simp] theorem zero_comp : (0 : M₂ →L[R] M₃).comp f = 0 :=
 by { ext, simp }
 
-@[simp] lemma comp_add [topological_add_monoid M₂] [topological_add_monoid M₃]
+@[simp] lemma comp_add [has_continuous_add M₂] [has_continuous_add M₃]
   (g : M₂ →L[R] M₃) (f₁ f₂ : M →L[R] M₂) :
   g.comp (f₁ + f₂) = g.comp f₁ + g.comp f₂ :=
 by { ext, simp }
 
-@[simp] lemma add_comp [topological_add_monoid M₃]
+@[simp] lemma add_comp [has_continuous_add M₃]
   (g₁ g₂ : M₂ →L[R] M₃) (f : M →L[R] M₂) :
   (g₁ + g₂).comp f = g₁.comp f + g₂.comp f :=
 by { ext, simp }
@@ -440,16 +440,16 @@ rfl
 rfl
 
 /-- The continuous linear map given by `(x, y) ↦ f₁ x + f₂ y`. -/
-def coprod [topological_add_monoid M₃] (f₁ : M →L[R] M₃) (f₂ : M₂ →L[R] M₃) :
+def coprod [has_continuous_add M₃] (f₁ : M →L[R] M₃) (f₂ : M₂ →L[R] M₃) :
   (M × M₂) →L[R] M₃ :=
 ⟨linear_map.coprod f₁ f₂, (f₁.cont.comp continuous_fst).add (f₂.cont.comp continuous_snd)⟩
 
-@[norm_cast, simp] lemma coe_coprod [topological_add_monoid M₃]
+@[norm_cast, simp] lemma coe_coprod [has_continuous_add M₃]
   (f₁ : M →L[R] M₃) (f₂ : M₂ →L[R] M₃) :
   (f₁.coprod f₂ : (M × M₂) →ₗ[R] M₃) = linear_map.coprod f₁ f₂ :=
 rfl
 
-@[simp] lemma coprod_apply [topological_add_monoid M₃] (f₁ : M →L[R] M₃) (f₂ : M₂ →L[R] M₃) (x) :
+@[simp] lemma coprod_apply [has_continuous_add M₃] (f₁ : M →L[R] M₃) (f₂ : M₂ →L[R] M₃) (x) :
   f₁.coprod f₂ x = f₁ x.1 + f₂ x.2 := rfl
 
 variables [topological_space R] [topological_semimodule R M₂]

--- a/src/topology/algebra/monoid.lean
+++ b/src/topology/algebra/monoid.lean
@@ -4,39 +4,36 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 
 Theory of topological monoids.
-
-TODO: generalize `topological_monoid` and `topological_add_monoid` to semigroups, or add a type class
-`topological_operator α (*)`.
 -/
+
 import topology.continuous_on
 import algebra.pi_instances
 
 open classical set filter topological_space
 open_locale classical topological_space big_operators
 
-universes u v w
-variables {α : Type u} {β : Type v} {γ : Type w}
+variables {α : Type*} {β : Type*} {γ : Type*}
 
-section topological_monoid
-
-/-- A topological monoid is a monoid in which the multiplication is continuous as a function
-`α × α → α`. -/
-class topological_monoid (α : Type u) [topological_space α] [monoid α] : Prop :=
-(continuous_mul : continuous (λp:α×α, p.1 * p.2))
-
-/-- A topological (additive) monoid is a monoid in which the addition is
-  continuous as a function `α × α → α`. -/
-class topological_add_monoid (α : Type u) [topological_space α] [add_monoid α] : Prop :=
+/-- Basic hypothesis to talk about a topological additive monoid or a topological additive
+semigroup. A topological additive monoid over α, for example, is obtained by requiring both the
+instances `add_monoid α` and `has_continuous_add α`. -/
+class has_continuous_add (α : Type*) [topological_space α] [has_add α] : Prop :=
 (continuous_add : continuous (λp:α×α, p.1 + p.2))
 
-attribute [to_additive topological_add_monoid] topological_monoid
+/-- Basic hypothesis to talk about a topological monoid or a topological semigroup.
+A topological monoid over α, for example, is obtained by requiring both the instances `monoid α` and
+`has_continuous_mul α`. -/
+@[to_additive]
+class has_continuous_mul (α : Type*) [topological_space α] [has_mul α] : Prop :=
+(continuous_mul : continuous (λp:α×α, p.1 * p.2))
 
-section
-variables [topological_space α] [monoid α] [topological_monoid α]
+section has_continuous_mul
+
+variables [topological_space α] [has_mul α] [has_continuous_mul α]
 
 @[to_additive]
 lemma continuous_mul : continuous (λp:α×α, p.1 * p.2) :=
-topological_monoid.continuous_mul
+has_continuous_mul.continuous_mul
 
 @[to_additive]
 lemma continuous.mul [topological_space β] {f : β → α} {g : β → α}
@@ -58,14 +55,9 @@ lemma continuous_on.mul [topological_space β] {f : β → α} {g : β → α} {
   continuous_on (λx, f x * g x) s :=
 (continuous_mul.comp_continuous_on (hf.prod hg) : _)
 
--- @[to_additive continuous_smul]
-lemma continuous_pow : ∀ n : ℕ, continuous (λ a : α, a ^ n)
-| 0 := by simpa using continuous_const
-| (k+1) := show continuous (λ (a : α), a * a ^ k), from continuous_id.mul (continuous_pow _)
-
 @[to_additive]
 lemma tendsto_mul {a b : α} : tendsto (λp:α×α, p.fst * p.snd) (𝓝 (a, b)) (𝓝 (a * b)) :=
-continuous_iff_continuous_at.mp topological_monoid.continuous_mul (a, b)
+continuous_iff_continuous_at.mp has_continuous_mul.continuous_mul (a, b)
 
 @[to_additive]
 lemma filter.tendsto.mul {f : β → α} {g : β → α} {x : filter β} {a b : α}
@@ -86,6 +78,19 @@ lemma continuous_within_at.mul [topological_space β] {f : β → α} {g : β �
 hf.mul hg
 
 @[to_additive]
+instance [topological_space β] [has_mul β] [has_continuous_mul β] : has_continuous_mul (α × β) :=
+⟨((continuous_fst.comp continuous_fst).mul (continuous_fst.comp continuous_snd)).prod_mk
+ ((continuous_snd.comp continuous_fst).mul (continuous_snd.comp continuous_snd))⟩
+
+attribute [instance] prod.has_continuous_mul
+
+end has_continuous_mul
+
+section has_continuous_mul
+
+variables [topological_space α] [monoid α] [has_continuous_mul α]
+
+@[to_additive]
 lemma tendsto_list_prod {f : γ → β → α} {x : filter β} {a : γ → α} :
   ∀l:list γ, (∀c∈l, tendsto (f c) x (𝓝 (a c))) →
     tendsto (λb, (l.map (λc, f c b)).prod) x (𝓝 ((l.map a).prod))
@@ -104,16 +109,15 @@ lemma continuous_list_prod [topological_space β] {f : γ → β → α} (l : li
 continuous_iff_continuous_at.2 $ assume x, tendsto_list_prod l $ assume c hc,
   continuous_iff_continuous_at.1 (h c hc) x
 
-@[to_additive topological_add_monoid]
-instance [topological_space β] [monoid β] [topological_monoid β] : topological_monoid (α × β) :=
-⟨((continuous_fst.comp continuous_fst).mul (continuous_fst.comp continuous_snd)).prod_mk
- ((continuous_snd.comp continuous_fst).mul (continuous_snd.comp continuous_snd))⟩
+-- @[to_additive continuous_smul]
+lemma continuous_pow : ∀ n : ℕ, continuous (λ a : α, a ^ n)
+| 0 := by simpa using continuous_const
+| (k+1) := show continuous (λ (a : α), a * a ^ k), from continuous_id.mul (continuous_pow _)
 
-attribute [instance] prod.topological_add_monoid
-
-end
+end has_continuous_mul
 
 section
+
 variables [topological_space α] [comm_monoid α]
 
 @[to_additive]
@@ -121,7 +125,7 @@ lemma is_submonoid.mem_nhds_one (β : set α) [is_submonoid β] (oβ : is_open �
   β ∈ 𝓝 (1 : α) :=
 mem_nhds_sets_iff.2 ⟨β, (by refl), oβ, is_submonoid.one_mem⟩
 
-variable [topological_monoid α]
+variable [has_continuous_mul α]
 
 @[to_additive]
 lemma tendsto_multiset_prod {f : γ → β → α} {x : filter β} {a : γ → α} (s : multiset γ) :
@@ -145,5 +149,3 @@ lemma continuous_finset_prod [topological_space β] {f : γ → β → α} (s : 
 continuous_multiset_prod _
 
 end
-
-end topological_monoid

--- a/src/topology/algebra/monoid.lean
+++ b/src/topology/algebra/monoid.lean
@@ -15,13 +15,13 @@ open_locale classical topological_space big_operators
 variables {α : Type*} {β : Type*} {γ : Type*}
 
 /-- Basic hypothesis to talk about a topological additive monoid or a topological additive
-semigroup. A topological additive monoid over α, for example, is obtained by requiring both the
+semigroup. A topological additive monoid over `α`, for example, is obtained by requiring both the
 instances `add_monoid α` and `has_continuous_add α`. -/
 class has_continuous_add (α : Type*) [topological_space α] [has_add α] : Prop :=
 (continuous_add : continuous (λp:α×α, p.1 + p.2))
 
 /-- Basic hypothesis to talk about a topological monoid or a topological semigroup.
-A topological monoid over α, for example, is obtained by requiring both the instances `monoid α` and
+A topological monoid over `α`, for example, is obtained by requiring both the instances `monoid α` and
 `has_continuous_mul α`. -/
 @[to_additive]
 class has_continuous_mul (α : Type*) [topological_space α] [has_mul α] : Prop :=
@@ -81,8 +81,6 @@ hf.mul hg
 instance [topological_space β] [has_mul β] [has_continuous_mul β] : has_continuous_mul (α × β) :=
 ⟨((continuous_fst.comp continuous_fst).mul (continuous_fst.comp continuous_snd)).prod_mk
  ((continuous_snd.comp continuous_fst).mul (continuous_snd.comp continuous_snd))⟩
-
-attribute [instance] prod.has_continuous_mul
 
 end has_continuous_mul
 

--- a/src/topology/algebra/multilinear.lean
+++ b/src/topology/algebra/multilinear.lean
@@ -93,8 +93,8 @@ instance : inhabited (continuous_multilinear_map R M₁ M₂) := ⟨0⟩
 
 @[simp] lemma zero_apply (m : Πi, M₁ i) : (0 : continuous_multilinear_map R M₁ M₂) m = 0 := rfl
 
-section topological_add_monoid
-variable [topological_add_monoid M₂]
+section has_continuous_add
+variable [has_continuous_add M₂]
 
 instance : has_add (continuous_multilinear_map R M₁ M₂) :=
 ⟨λ f f', {cont := f.cont.add f'.cont, ..(f.to_multilinear_map + f'.to_multilinear_map)}⟩
@@ -113,7 +113,7 @@ begin
   { assume a s has H, rw finset.sum_insert has, simp [H, has] }
 end
 
-end topological_add_monoid
+end has_continuous_add
 
 /-- If `f` is a continuous multilinear map, then `f.to_continuous_linear_map m i` is the continuous
 linear map obtained by fixing all coordinates but `i` equal to those of `m`, and varying the

--- a/src/topology/algebra/open_subgroup.lean
+++ b/src/topology/algebra/open_subgroup.lean
@@ -92,7 +92,7 @@ instance : has_top (open_subgroup G) := ⟨{ is_open' := is_open_univ, .. (⊤ :
 instance : inhabited (open_subgroup G) := ⟨⊤⟩
 
 @[to_additive]
-lemma is_closed [topological_monoid G] (U : open_subgroup G) : is_closed (U : set G) :=
+lemma is_closed [has_continuous_mul G] (U : open_subgroup G) : is_closed (U : set G) :=
 begin
   refine is_open_iff_forall_mem_open.2 (λ x hx, ⟨(λ y, y * x⁻¹) ⁻¹' U, _, _, _⟩),
   { intros u hux,
@@ -143,7 +143,7 @@ end open_subgroup
 
 namespace subgroup
 
-variables {G : Type*} [group G] [topological_space G] [topological_monoid G] (H : subgroup G)
+variables {G : Type*} [group G] [topological_space G] [has_continuous_mul G] (H : subgroup G)
 
 @[to_additive]
 lemma is_open_of_mem_nhds {g : G} (hg : (H : set G) ∈ 𝓝 g) :
@@ -174,7 +174,7 @@ end subgroup
 
 namespace open_subgroup
 
-variables {G : Type*} [group G] [topological_space G] [topological_monoid G]
+variables {G : Type*} [group G] [topological_space G] [has_continuous_mul G]
 
 @[to_additive]
 instance : semilattice_sup_top (open_subgroup G) :=

--- a/src/topology/algebra/ring.lean
+++ b/src/topology/algebra/ring.lean
@@ -19,7 +19,7 @@ section prio
 set_option default_priority 100 -- see Note [default priority]
 /-- A topological semiring is a semiring where addition and multiplication are continuous. -/
 class topological_semiring [semiring α]
-  extends topological_add_monoid α, topological_monoid α : Prop
+  extends has_continuous_add α, has_continuous_mul α : Prop
 end prio
 
 variables [ring α]
@@ -27,7 +27,7 @@ variables [ring α]
 section prio
 set_option default_priority 100 -- see Note [default priority]
 /-- A topological ring is a ring where the ring operations are continuous. -/
-class topological_ring extends topological_add_monoid α, topological_monoid α : Prop :=
+class topological_ring extends has_continuous_add α, has_continuous_mul α : Prop :=
 (continuous_neg : continuous (λa:α, -a))
 end prio
 

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -218,7 +218,7 @@ begin
   exact coe_lt_coe.2 (lt_of_lt_of_le (nat.cast_lt.2 (nat.lt_succ_self _)) ha)
 end
 
-instance : topological_add_monoid ennreal :=
+instance : has_continuous_add ennreal :=
 ⟨ continuous_iff_continuous_at.2 $
   have hl : ∀a:ennreal, tendsto (λ (p : ennreal × ennreal), p.fst + p.snd) (𝓝 (⊤, a)) (𝓝 ⊤), from
     assume a, tendsto_nhds_top $ assume n,

--- a/test/apply.lean
+++ b/test/apply.lean
@@ -38,5 +38,5 @@ begin
   apply' continuous.add,
   guard_target' continuous (λ (x : ℝ), x), apply @continuous_id ℝ _,
   guard_target' continuous (λ (x : ℝ), x), apply @continuous_id ℝ _,
-  -- guard_target' topological_add_monoid ℝ, admit,
+  -- guard_target' has_continuous_add ℝ, admit,
 end


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->
We generalized `topological_monoid` to `has_continuous_mul`. See https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/has_continuous_mul