### PR TITLE
[Merged by Bors] - feat(data/list/basic): induction from both ends

### DIFF
--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -632,6 +632,15 @@ by simp only [concat_eq_append, last_append]
 @[simp] theorem last_cons_cons (a₁ a₂ : α) (l : list α) (h : a₁::a₂::l ≠ []) :
   last (a₁::a₂::l) h = last (a₂::l) (cons_ne_nil a₂ l) := rfl
 
+theorem init_append_last : ∀ {l : list α} (h : l ≠ []), init l ++ [last l h] = l
+| [] h := absurd rfl h
+| [a] h := rfl
+| (a::b::l) h := begin
+  rw [init, cons_append, last_cons (cons_ne_nil _ _) (cons_ne_nil _ _)],
+  congr,
+  exact init_append_last (cons_ne_nil b l),
+end
+
 theorem last_congr {l₁ l₂ : list α} (h₁ : l₁ ≠ []) (h₂ : l₂ ≠ []) (h₃ : l₁ = l₂) :
   last l₁ h₁ = last l₂ h₂ :=
 by subst l₁

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -702,9 +702,11 @@ private def init_last_of_cons : ∀ (a : α) (l : list α), Σ' l' a', a :: l = 
 | a [] := ⟨[], a, rfl⟩
 | a (b :: l) := let ⟨l', b', h'⟩ := init_last_of_cons b l in ⟨a :: l', b', by { congr, from h' }⟩
 
-/-- Implementation of `bidirectional_rec_on`. The `l` parameter is moved to the end to make the
-recursion easier to write. -/
-private def bidirectional_rec_on_aux {C : list α → Sort*}
+/-- Bidirectional induction principle for lists: if a property holds for the empty list, the
+singleton list, and `a :: (l ++ [b])` from `l`, then it holds for all lists. This can be used to
+prove statements about palindromes. The principle is given for a `Sort`-valued predicate, i.e., it
+can also be used to construct data. -/
+def bidirectional_rec {C : list α → Sort*}
     (H0 : C []) (H1 : ∀ (a : α), C [a])
     (Hn : ∀ (a : α) (l : list α) (b : α), C l → C (a :: (l ++ [b]))) : ∀ l, C l
 | [] := H0
@@ -718,19 +720,16 @@ have length l' < length (a :: b :: l), from
     ... = length (a :: b :: l) : by rw ←Hreassoc,
 begin
   rw Hreassoc,
-  have : C l', from bidirectional_rec_on_aux l',
+  have : C l', from bidirectional_rec l',
   exact Hn a l' b' ‹C l'›
 end
 using_well_founded { rel_tac := λ _ _, `[exact ⟨_, measure_wf list.length⟩] }
 
-/-- Bidirectional induction principle for lists: if a property holds for the empty list, the
-singleton list, and `a :: (l ++ [b])` from `l`, then it holds for all lists. This can be used to
-prove statements about palindromes. The principle is given for a `Sort`-valued predicate, i.e., it
-can also be used to construct data. -/
+/-- Like `bidirectional_rec`, but with the list parameter placed first for dot-notation. -/
 @[elab_as_eliminator] def bidirectional_rec_on {C : list α → Sort*}
     (l : list α) (H0 : C []) (H1 : ∀ (a : α), C [a])
     (Hn : ∀ (a : α) (l : list α) (b : α), C l → C (a :: (l ++ [b]))) : C l :=
-bidirectional_rec_on_aux H0 H1 Hn l
+bidirectional_rec H0 H1 Hn l
 
 /-! ### sublists -/
 

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -569,7 +569,8 @@ list.cases_on l (by simp [is_nil]) (by simp [is_nil])
 @[simp] theorem length_init : ∀ (l : list α), length (init l) = length l - 1
 | [] := rfl
 | [a] := rfl
-| (a :: b :: l) := begin
+| (a :: b :: l) :=
+begin
   rw init,
   simp only [add_left_inj, length, succ_add_sub_one],
   exact length_init (b :: l)
@@ -596,7 +597,8 @@ by simp only [concat_eq_append, last_append]
 theorem init_append_last : ∀ {l : list α} (h : l ≠ []), init l ++ [last l h] = l
 | [] h := absurd rfl h
 | [a] h := rfl
-| (a::b::l) h := begin
+| (a::b::l) h :=
+begin
   rw [init, cons_append, last_cons (cons_ne_nil _ _) (cons_ne_nil _ _)],
   congr,
   exact init_append_last (cons_ne_nil b l),

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -729,7 +729,7 @@ begin
 end
 using_well_founded { rel_tac := λ _ _, `[exact ⟨_, measure_wf list.length⟩] }
 
-/-- Like `bidirectional_rec`, but with the list parameter placed first for dot-notation. -/
+/-- Like `bidirectional_rec`, but with the list parameter placed first. -/
 @[elab_as_eliminator] def bidirectional_rec_on {C : list α → Sort*}
     (l : list α) (H0 : C []) (H1 : ∀ (a : α), C [a])
     (Hn : ∀ (a : α) (l : list α) (b : α), C l → C (a :: (l ++ [b]))) : C l :=

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -579,9 +579,9 @@ private def init_last_of_cons : ∀ (a : α) (l : list α), Σ' l' a', a :: l = 
 | a [] := ⟨[], a, rfl⟩
 | a (b :: l) := let ⟨l', b', h'⟩ := init_last_of_cons b l in ⟨a :: l', b', by { congr, from h' }⟩
 
-/-- Implementation of `bidi_rec_on`. The `l` parameter is moved to the end to make the recursion
-easier to write. -/
-private def bidi_rec_on_aux {C : list α → Sort*}
+/-- Implementation of `bidirectional_rec_on`. The `l` parameter is moved to the end to make the
+recursion easier to write. -/
+private def bidirectional_rec_on_aux {C : list α → Sort*}
     (H0 : C []) (H1 : ∀ (a : α), C [a])
     (Hn : ∀ (a : α) (l : list α) (b : α), C l → C (a :: (l ++ [b]))) : ∀ l, C l
 | [] := H0
@@ -595,7 +595,7 @@ have length l' < length (a :: b :: l), from
     ... = length (a :: b :: l) : by rw ←Hreassoc,
 begin
   rw Hreassoc,
-  have : C l', from bidi_rec_on_aux l',
+  have : C l', from bidirectional_rec_on_aux l',
   exact Hn a l' b' ‹C l'›
 end
 using_well_founded { rel_tac := λ _ _, `[exact ⟨_, measure_wf list.length⟩] }
@@ -604,10 +604,10 @@ using_well_founded { rel_tac := λ _ _, `[exact ⟨_, measure_wf list.length⟩]
 singleton list, and `a :: (l ++ [b])` from `l`, then it holds for all lists. This can be used to
 prove statements about palindromes. The principle is given for a `Sort`-valued predicate, i.e., it
 can also be used to construct data. -/
-@[elab_as_eliminator] def bidi_rec_on {C : list α → Sort*}
+@[elab_as_eliminator] def bidirectional_rec_on {C : list α → Sort*}
     (l : list α) (H0 : C []) (H1 : ∀ (a : α), C [a])
     (Hn : ∀ (a : α) (l : list α) (b : α), C l → C (a :: (l ++ [b]))) : C l :=
-bidi_rec_on_aux H0 H1 Hn l
+bidirectional_rec_on_aux H0 H1 Hn l
 
 /-! ### is_nil -/
 

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -559,6 +559,8 @@ by induction l; [refl, simp only [*, reverse_cons, mem_append, mem_singleton, me
 eq_repeat.2 ⟨by simp only [length_reverse, length_repeat],
   λ b h, eq_of_mem_repeat (mem_reverse.1 h)⟩
 
+/-! ### Induction from the right -/
+
 /-- Induction principle from the right for lists: if a property holds for the empty list, and
 for `l ++ [a]` if it holds for `l`, then it holds for all lists. The principle is given for
 a `Sort`-valued predicate, i.e., it can also be used to construct data. -/
@@ -571,6 +573,41 @@ begin
   { exact H0 },
   { rw reverse_cons, exact H1 _ _ ih }
 end
+
+/-- Reassociates a list, revealing its last element. -/
+private def init_last_of_cons : ∀ (a : α) (l : list α), Σ' l' a', a :: l = l' ++ [a']
+| a [] := ⟨[], a, rfl⟩
+| a (b :: l) := let ⟨l', b', h'⟩ := init_last_of_cons b l in ⟨a :: l', b', by { congr, from h' }⟩
+
+/-- Implementation of `bidi_rec_on`. The `l` parameter is moved to the end to make the recursion
+easier to write. -/
+private def bidi_rec_on_aux {C : list α → Sort*}
+    (H0 : C []) (H1 : ∀ (a : α), C [a])
+    (Hn : ∀ (a : α) (l : list α) (b : α), C l → C (a :: (l ++ [b]))) : ∀ l, C l
+| [] := H0
+| [a] := H1 a
+| (a :: b :: l) :=
+let ⟨l', b', Hreassoc⟩ := init_last_of_cons b l in
+have length l' < length (a :: b :: l), from
+  calc length l'
+        < length l' + 2 : by simp
+    ... = length (a :: (l' ++ [b'])) : by simp
+    ... = length (a :: b :: l) : by rw ←Hreassoc,
+begin
+  rw Hreassoc,
+  have : C l', from bidi_rec_on_aux l',
+  exact Hn a l' b' ‹C l'›
+end
+using_well_founded { rel_tac := λ _ _, `[exact ⟨_, measure_wf list.length⟩] }
+
+/-- Bidirectional induction principle for lists: if a property holds for the empty list, the
+singleton list, and `a :: (l ++ [b])` from `l`, then it holds for all lists. This can be used to
+prove statements about palindromes. The principle is given for a `Sort`-valued predicate, i.e., it
+can also be used to construct data. -/
+@[elab_as_eliminator] def bidi_rec_on {C : list α → Sort*}
+    (l : list α) (H0 : C []) (H1 : ∀ (a : α), C [a])
+    (Hn : ∀ (a : α) (l : list α) (b : α), C l → C (a :: (l ++ [b]))) : C l :=
+bidi_rec_on_aux H0 H1 Hn l
 
 /-! ### is_nil -/
 

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -601,7 +601,7 @@ theorem init_append_last : ∀ {l : list α} (h : l ≠ []), init l ++ [last l h
 begin
   rw [init, cons_append, last_cons (cons_ne_nil _ _) (cons_ne_nil _ _)],
   congr,
-  exact init_append_last (cons_ne_nil b l),
+  exact init_append_last (cons_ne_nil b l)
 end
 
 theorem last_congr {l₁ l₂ : list α} (h₁ : l₁ ≠ []) (h₂ : l₂ ≠ []) (h₃ : l₁ = l₂) :


### PR DESCRIPTION
This was originally an induction principle on palindromes, but researching Coq solutions made me realize that weakening the statement made it simpler and much easier to prove.

- ["The way we proceeded was to prove first an induction principle for lists, considering insertions at both ends..."][1]
- ["... generalizing a single variable in that definition would create another inductive definition of a list."][2]

[1]: https://www.labri.fr/perso/casteran/CoqArt/inductive-prop-chap/palindrome.html
[2]: https://danilafe.com/blog/coq_palindrome/

This also adds the lemmas `length_init` and `init_append_last`.

---
<!-- put comments you want to keep out of the PR commit here -->
