### PR TITLE
[Merged by Bors] - feat(logic/basic): nonempty.some

### DIFF
--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -970,8 +970,8 @@ noncomputable def classical.inhabited_of_nonempty' {α : Sort u} [h : nonempty �
 ⟨classical.choice h⟩
 
 /-- Using `classical.choice`, extracts a term from a `nonempty` type. -/
-protected noncomputable def nonempty.some {α : Sort u} (p : nonempty α) : α :=
-classical.choice p
+protected noncomputable def nonempty.some {α : Sort u} (h : nonempty α) : α :=
+classical.choice h
 
 /-- Given `f : α → β`, if `α` is nonempty then `β` is also nonempty.
   `nonempty` cannot be a `functor`, because `functor` is restricted to `Type`. -/

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -519,8 +519,15 @@ theorem exists_swap {p : α → β → Prop} : (∃ x y, p x y) ↔ ∃ y x, p x
 @[simp] theorem exists_imp_distrib : ((∃ x, p x) → b) ↔ ∀ x, p x → b :=
 ⟨λ h x hpx, h ⟨x, hpx⟩, λ h ⟨x, hpx⟩, h x hpx⟩
 
+/--
+Extract an element from a existential statement, using `classical.some`.
+-/
+-- This enables projection notation.
 noncomputable abbreviation Exists.some {p : α → Prop} (P : ∃ a, p a) : α := classical.some P
 
+/--
+Show that an element extracted from `P : ∃ a, p a` using `P.some` satisfies `p`.
+-/
 abbreviation Exists.some_spec {p : α → Prop} (P : ∃ a, p a) : p (P.some) := classical.some_spec P
 
 --theorem forall_not_of_not_exists (h : ¬ ∃ x, p x) : ∀ x, ¬ p x :=

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -523,12 +523,12 @@ theorem exists_swap {p : α → β → Prop} : (∃ x y, p x y) ↔ ∃ y x, p x
 Extract an element from a existential statement, using `classical.some`.
 -/
 -- This enables projection notation.
-noncomputable abbreviation Exists.some {p : α → Prop} (P : ∃ a, p a) : α := classical.some P
+@[reducible] noncomputable def Exists.some {p : α → Prop} (P : ∃ a, p a) : α := classical.some P
 
 /--
 Show that an element extracted from `P : ∃ a, p a` using `P.some` satisfies `p`.
 -/
-abbreviation Exists.some_spec {p : α → Prop} (P : ∃ a, p a) : p (P.some) := classical.some_spec P
+lemma Exists.some_spec {p : α → Prop} (P : ∃ a, p a) : p (P.some) := classical.some_spec P
 
 --theorem forall_not_of_not_exists (h : ¬ ∃ x, p x) : ∀ x, ¬ p x :=
 --forall_imp_of_exists_imp h
@@ -970,7 +970,7 @@ noncomputable def classical.inhabited_of_nonempty' {α : Sort u} [h : nonempty �
 ⟨classical.choice h⟩
 
 /-- Using `classical.choice`, extracts a term from a `nonempty` type. -/
-protected noncomputable def nonempty.some {α : Sort u} (p : nonempty α) : α :=
+@[reducible] protected noncomputable def nonempty.some {α : Sort u} (p : nonempty α) : α :=
 classical.choice p
 
 /-- Given `f : α → β`, if `α` is nonempty then `β` is also nonempty.

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -958,8 +958,9 @@ iff.intro (assume ⟨f⟩ a, ⟨f a⟩) (assume f, ⟨assume a, classical.choice
 noncomputable def classical.inhabited_of_nonempty' {α : Sort u} [h : nonempty α] : inhabited α :=
 ⟨classical.choice h⟩
 
+/-- Using `classical.choice`, extracts a term from a `nonempty` type. -/
 protected noncomputable def nonempty.some {α : Sort u} (p : nonempty α) : α :=
-(classical.inhabited_of_nonempty p).default
+classical.choice p
 
 /-- Given `f : α → β`, if `α` is nonempty then `β` is also nonempty.
   `nonempty` cannot be a `functor`, because `functor` is restricted to `Type`. -/

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -958,6 +958,9 @@ iff.intro (assume ⟨f⟩ a, ⟨f a⟩) (assume f, ⟨assume a, classical.choice
 noncomputable def classical.inhabited_of_nonempty' {α : Sort u} [h : nonempty α] : inhabited α :=
 ⟨classical.choice h⟩
 
+protected noncomputable def nonempty.some {α : Sort u} (p : nonempty α) : α :=
+(classical.inhabited_of_nonempty p).default
+
 /-- Given `f : α → β`, if `α` is nonempty then `β` is also nonempty.
   `nonempty` cannot be a `functor`, because `functor` is restricted to `Type`. -/
 lemma nonempty.map {α : Sort u} {β : Sort v} (f : α → β) : nonempty α → nonempty β

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -519,6 +519,10 @@ theorem exists_swap {p : α → β → Prop} : (∃ x y, p x y) ↔ ∃ y x, p x
 @[simp] theorem exists_imp_distrib : ((∃ x, p x) → b) ↔ ∀ x, p x → b :=
 ⟨λ h x hpx, h ⟨x, hpx⟩, λ h ⟨x, hpx⟩, h x hpx⟩
 
+noncomputable abbreviation Exists.some {p : α → Prop} (P : ∃ a, p a) : α := classical.some P
+
+abbreviation Exists.some_spec {p : α → Prop} (P : ∃ a, p a) : p (P.some) := classical.some_spec P
+
 --theorem forall_not_of_not_exists (h : ¬ ∃ x, p x) : ∀ x, ¬ p x :=
 --forall_imp_of_exists_imp h
 

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -973,6 +973,10 @@ noncomputable def classical.inhabited_of_nonempty' {α : Sort u} [h : nonempty �
 @[reducible] protected noncomputable def nonempty.some {α : Sort u} (h : nonempty α) : α :=
 classical.choice h
 
+/-- Using `classical.choice`, extracts a term from a `nonempty` type. -/
+@[reducible] protected noncomputable def classical.arbitrary (α : Sort u) [h : nonempty α] : α :=
+classical.choice h
+
 /-- Given `f : α → β`, if `α` is nonempty then `β` is also nonempty.
   `nonempty` cannot be a `functor`, because `functor` is restricted to `Type`. -/
 lemma nonempty.map {α : Sort u} {β : Sort v} (f : α → β) : nonempty α → nonempty β


### PR DESCRIPTION
Could we please have this? I've a number of times been annoyed by the difficulty of extracting an element from a `nonempty`.

(Criterion for alternative solutions: `library_search` solves `nonempty X -> X`.)

---
<!-- put comments you want to keep out of the PR commit here -->
