### PR TITLE
[Merged by Bors] - fix(tactic/linarith): find correct zero_lt_one

### DIFF
--- a/src/tactic/linarith/verification.lean
+++ b/src/tactic/linarith/verification.lean
@@ -97,7 +97,8 @@ term_of_ineq_prf prf >>= infer_type
 where the numerals are natively of type `tp`.
 -/
 meta def mk_neg_one_lt_zero_pf (tp : expr) : tactic expr :=
-to_expr ``((neg_neg_of_pos zero_lt_one : -1 < (0 : %%tp)))
+do zero_lt_one ← mk_mapp `zero_lt_one [tp, none],
+   mk_app `neg_neg_of_pos [zero_lt_one]
 
 /--
 If `e` is a proof that `t = 0`, `mk_neg_eq_zero_pf e` returns a proof that `-t = 0`.

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -362,3 +362,19 @@ by linarith [abs_nonneg' abs (t^2)]
 
 example (t : R) (a b : ℚ) (h : a ≤ b) : abs t * a ≤ abs t * b :=
 by nlinarith [abs_nonneg' abs t]
+
+constant T : Type
+
+attribute [instance]
+constant T_zero : ordered_ring T
+
+namespace T
+
+lemma zero_lt_one : (0 : T) < 1 := sorry
+
+lemma works {a b : ℕ} (hab : a ≤ b) (h : b < a) : false :=
+begin
+  linarith,
+end
+
+end T


### PR DESCRIPTION
Zulip: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/linarith.20and.20ordinal.20file

---
<!-- put comments you want to keep out of the PR commit here -->
