### PR TITLE
[Merged by Bors] - fix(tactic/library_search): 1 ≤ n goals in nat

### DIFF
--- a/src/tactic/suggest.lean
+++ b/src/tactic/suggest.lean
@@ -34,6 +34,8 @@ to solve a goal with head symbol `n`.
 For example, `>` is mapped to `<` because `a > b` is definitionally equal to `b < a`,
 and `not` is mapped to `false` because `¬ a` is definitionally equal to `p → false`
 The default is that the original argument is returned, so `<` is just mapped to `<`.
+
+`normalize_synonym` is called for every lemma in the library, so it needs to be fast.
 -/
 -- TODO this is a hack; if you suspect more cases here would help, please report them
 meta def normalize_synonym : name → name
@@ -42,13 +44,28 @@ meta def normalize_synonym : name → name
 | `not := `false
 | n   := n
 
-/-- compute the head symbol of an expression, but normalise synonyms -/
+/--
+Compute the head symbol of an expression, then normalise synonyms.
+
+This is only used when analysing the goal, so it is okay to do more expensive analysis here.
+-/
 -- We may want to tweak this further?
-meta def head_symbol : expr → name
-| (expr.pi _ _ _ t) := head_symbol t
-| (expr.app f _) := head_symbol f
-| (expr.const n _) := normalize_synonym n
-| _ := `_
+meta def allowed_head_symbols : expr → list name
+-- We first have a various "customisations":
+--   Because in `ℕ` `a.succ ≤ b` is definitionally `a < b`,
+--   we add some special cases to allow looking for `<` lemmas even when the goal has a `≤`.
+--   Note we only do this in the `ℕ` case, for performance.
+| `(@has_le.le ℕ _ (nat.succ _) _) := [`has_le.le, `has_lt.lt]
+| `(@ge ℕ _ _ (nat.succ _)) := [`has_le.le, `has_lt.lt]
+| `(@has_le.le ℕ _ 1 _) := [`has_le.le, `has_lt.lt]
+| `(@ge ℕ _ _ 1) := [`has_le.le, `has_lt.lt]
+
+-- And then the generic cases:
+| (expr.pi _ _ _ t) := allowed_head_symbols t
+| (expr.app f _) := allowed_head_symbols f
+| (expr.const n _) := [normalize_synonym n]
+| _ := [`_]
+.
 
 /--
 A declaration can match the head symbol of the current goal in four possible ways:
@@ -71,9 +88,9 @@ def head_symbol_match.to_string : head_symbol_match → string
 | both := "iff.mp and iff.mpr"
 
 /-- Determine if, and in which way, a given expression matches the specified head symbol. -/
-meta def match_head_symbol (hs : name) : expr → option head_symbol_match
+meta def match_head_symbol (hs : list name) : expr → option head_symbol_match
 | (expr.pi _ _ _ t) := match_head_symbol t
-| `(%%a ↔ %%b)      := if `iff = hs then some ex else
+| `(%%a ↔ %%b)      := if `iff ∈ hs then some ex else
                        match (match_head_symbol a, match_head_symbol b) with
                        | (some ex, some ex) :=
                            some both
@@ -82,8 +99,8 @@ meta def match_head_symbol (hs : name) : expr → option head_symbol_match
                        | _ := none
                        end
 | (expr.app f _)    := match_head_symbol f
-| (expr.const n _)  := if hs = normalize_synonym n then some ex else none
-| _ := if hs = `_ then some ex else none
+| (expr.const n _)  := if normalize_synonym n ∈ hs then some ex else none
+| _ := if `_ ∈ hs then some ex else none
 
 /-- A package of `declaration` metadata, including the way in which its type matches the head symbol
 which we are searching for. -/
@@ -99,7 +116,7 @@ it matches the head symbol `hs` for the current goal.
 -/
 -- We used to check here for private declarations, or declarations with certain suffixes.
 -- It turns out `apply` is so fast, it's better to just try them all.
-meta def process_declaration (hs : name) (d : declaration) : option decl_data :=
+meta def process_declaration (hs : list name) (d : declaration) : option decl_data :=
 let n := d.to_name in
 if !d.is_trusted || n.is_internal then
   none
@@ -107,8 +124,9 @@ else
   (λ m, ⟨d, n, m, n.length⟩) <$> match_head_symbol hs d.type
 
 /-- Retrieve all library definitions with a given head symbol. -/
-meta def library_defs (hs : name) : tactic (list decl_data) :=
-do env ← get_env,
+meta def library_defs (hs : list name) : tactic (list decl_data) :=
+do trace_if_enabled `suggest format!"Looking for lemmas with head symbols {hs}.",
+   env ← get_env,
    let defs := env.decl_filter_map (process_declaration hs),
    -- Sort by length; people like short proofs
    let defs := defs.qsort(λ d₁ d₂, d₁.l ≤ d₂.l),
@@ -242,7 +260,7 @@ do g :: _ ← get_goals,
    (do
    -- Collect all definitions with the correct head symbol
    t ← infer_type g,
-   defs ← unpack_iff_both <$> library_defs (head_symbol t),
+   defs ← unpack_iff_both <$> library_defs (allowed_head_symbols t),
 
    let defs : mllist tactic _ := mllist.of_list defs,
 

--- a/test/library_search/basic.lean
+++ b/test/library_search/basic.lean
@@ -3,8 +3,7 @@ Copyright (c) 2018 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import tactic.suggest
-import data.nat.basic
+import tactic.suggest -- No other imports, for fast testing
 
 /- Turn off trace messages so they don't pollute the test build: -/
 set_option trace.silence_library_search true
@@ -29,12 +28,6 @@ by library_search
 example (X : Type) (P : Prop) (x : X) (h : Π x : X, x = x → P) : P :=
 by library_search
 
-def lt_one (n : ℕ) := n < 1
-lemma zero_lt_one (n : ℕ) (h : n = 0) : lt_one n := by subst h; dsimp [lt_one]; simp
--- Verify that calls to solve_by_elim to discharge subgoals use `rfl`
-example : lt_one 0 :=
-by library_search
-
 example (α : Prop) : α → α :=
 by library_search -- says: `exact id`
 
@@ -50,17 +43,11 @@ by library_search -- says: `exact not_imp_not.mp`
 example (a b : ℕ) : a + b = b + a :=
 by library_search -- says: `exact add_comm a b`
 
-example {a b : ℕ} : a ≤ a + b :=
-by library_search -- says: `exact nat.le.intro rfl`
-
 example (n m k : ℕ) : n * (m - k) = n * m - n * k :=
 by library_search -- says: `exact nat.mul_sub_left_distrib n m k`
 
 example (n m k : ℕ) : n * m - n * k = n * (m - k) :=
 by library_search -- says: `exact eq.symm (nat.mul_sub_left_distrib n m k)`
-
-example {n m : ℕ} (h : m < n) : m ≤ n - 1 :=
-by library_search -- says: `exact nat.le_pred_of_lt h`
 
 example {α : Type} (x y : α) : x = y ↔ y = x :=
 by library_search -- says: `exact eq_comm`
@@ -68,18 +55,7 @@ by library_search -- says: `exact eq_comm`
 example (a b : ℕ) (ha : 0 < a) (hb : 0 < b) : 0 < a + b :=
 by library_search -- says: `exact add_pos ha hb`
 
-example (a b : ℕ) : 0 < a → 0 < b → 0 < a + b :=
-by library_search -- says: `exact add_pos`
-
 section synonym
-
--- Synonym `>` for `<` in the goal
-example (a b : ℕ) : 0 < a → 0 < b → a + b > 0 :=
-by library_search -- says: `exact add_pos`
-
--- Synonym `>` for `<` in another part of the goal
-example (a b : ℕ) : a > 0 → 0 < b → 0 < a + b :=
-by library_search -- says: `exact add_pos`
 
 -- Synonym `>` for `<` in another part of the goal
 example (a b : ℕ) (ha : a > 0) (hb : 0 < b) : 0 < a + b :=
@@ -125,45 +101,8 @@ end synonym
 example : ∀ P : Prop, ¬(P ↔ ¬P) :=
 by library_search! -- says: `λ (a : Prop), (iff_not_self a).mp`
 
-example {a b c : ℕ} (ha : a > 0) (w : b ∣ c) : a * b ∣ a * c :=
-by library_search -- exact mul_dvd_mul_left a w
-
 example {a b c : ℕ} (h₁ : a ∣ c) (h₂ : a ∣ b + c) : a ∣ b :=
 by library_search -- says `exact (nat.dvd_add_left h₁).mp h₂`
-
--- We have control of how `library_search` uses `solve_by_elim`.
-
--- In particular, we can add extra lemmas to the `solve_by_elim` step
--- (i.e. for `library_search` to use to attempt to discharge subgoals
--- after successfully applying a lemma from the library.)
-example {a b c d: nat} (h₁ : a < c) (h₂ : b < d) : max (c + d) (a + b) = (c + d) :=
-begin
-  library_search [add_lt_add], -- Says: `exact max_eq_left_of_lt (add_lt_add h₁ h₂)`
-end
-
--- We can also use attributes:
-meta def ex_attr : user_attribute := {
-  name := `ex,
-  descr := "A lemma that should be applied by `library_search` when discharging subgoals."
-}
-
-run_cmd attribute.register ``ex_attr
-
-attribute [ex] add_lt_add
-
-example {a b c d: nat} (h₁ : a < c) (h₂ : b < d) : max (c + d) (a + b) = (c + d) :=
-begin
-  library_search with ex, -- Says: `exact max_eq_left_of_lt (add_lt_add h₁ h₂)`
-end
-
-example (a b : ℕ) (h : 0 < b) : (a * b) / b = a :=
-by library_search -- Says: `exact nat.mul_div_left a h`
-
-example (a b : ℕ) (h : b ≠ 0) : (a * b) / b = a :=
-begin
-  success_if_fail { library_search },
-  library_search [nat.pos_iff_ne_zero.mpr],
-end
 
 -- Checking examples from issue #2220
 example {α : Sort*} (h : empty) : α :=
@@ -188,5 +127,9 @@ constant f : ℕ → ℕ
 axiom F (a b : ℕ) : f a ≤ f b ↔ a ≤ b
 
 example (a b : ℕ) (h : a ≤ b) : f a ≤ f b := by library_search
+
+-- Test #3432
+theorem nonzero_gt_one (n : ℕ ): ¬ n = 0 → n ≥ 1 :=
+by library_search!   -- `exact nat.pos_of_ne_zero`
 
 end test.library_search

--- a/test/library_search/basic.lean
+++ b/test/library_search/basic.lean
@@ -129,7 +129,7 @@ axiom F (a b : ℕ) : f a ≤ f b ↔ a ≤ b
 example (a b : ℕ) (h : a ≤ b) : f a ≤ f b := by library_search
 
 -- Test #3432
-theorem nonzero_gt_one (n : ℕ ): ¬ n = 0 → n ≥ 1 :=
+theorem nonzero_gt_one (n : ℕ) : ¬ n = 0 → n ≥ 1 :=
 by library_search!   -- `exact nat.pos_of_ne_zero`
 
 end test.library_search

--- a/test/library_search/nat.lean
+++ b/test/library_search/nat.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2018 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import tactic.suggest
+import data.nat.basic
+
+namespace test.library_search
+
+
+/- Turn off trace messages so they don't pollute the test build: -/
+set_option trace.silence_library_search true
+/- For debugging purposes, we can display the list of lemmas: -/
+-- set_option trace.suggest true
+
+def lt_one (n : ℕ) := n < 1
+lemma zero_lt_one (n : ℕ) (h : n = 0) : lt_one n := by subst h; dsimp [lt_one]; simp
+
+-- Verify that calls to solve_by_elim to discharge subgoals use `rfl`
+example : lt_one 0 :=
+by library_search
+
+
+example {n m : ℕ} (h : m < n) : m ≤ n - 1 :=
+by library_search -- says: `exact nat.le_pred_of_lt h`
+
+example (a b : ℕ) : 0 < a → 0 < b → 0 < a + b :=
+by library_search -- says: `exact add_pos`
+
+section synonym
+
+-- Synonym `>` for `<` in the goal
+example (a b : ℕ) : 0 < a → 0 < b → a + b > 0 :=
+by library_search -- says: `exact add_pos`
+
+-- Synonym `>` for `<` in another part of the goal
+example (a b : ℕ) : a > 0 → 0 < b → 0 < a + b :=
+by library_search -- says: `exact add_pos`
+
+end synonym
+
+
+example {a b c : ℕ} (ha : a > 0) (w : b ∣ c) : a * b ∣ a * c :=
+by library_search -- exact mul_dvd_mul_left a w
+
+-- We have control of how `library_search` uses `solve_by_elim`.
+
+-- In particular, we can add extra lemmas to the `solve_by_elim` step
+-- (i.e. for `library_search` to use to attempt to discharge subgoals
+-- after successfully applying a lemma from the library.)
+example {a b c d: nat} (h₁ : a < c) (h₂ : b < d) : max (c + d) (a + b) = (c + d) :=
+begin
+  library_search [add_lt_add], -- Says: `exact max_eq_left_of_lt (add_lt_add h₁ h₂)`
+end
+
+-- We can also use attributes:
+meta def ex_attr : user_attribute := {
+  name := `ex,
+  descr := "A lemma that should be applied by `library_search` when discharging subgoals."
+}
+
+run_cmd attribute.register ``ex_attr
+
+attribute [ex] add_lt_add
+
+example {a b c d: nat} (h₁ : a < c) (h₂ : b < d) : max (c + d) (a + b) = (c + d) :=
+begin
+  library_search with ex, -- Says: `exact max_eq_left_of_lt (add_lt_add h₁ h₂)`
+end
+
+example (a b : ℕ) (h : 0 < b) : (a * b) / b = a :=
+by library_search -- Says: `exact nat.mul_div_left a h`
+
+example (a b : ℕ) (h : b ≠ 0) : (a * b) / b = a :=
+begin
+  success_if_fail { library_search },
+  library_search [nat.pos_iff_ne_zero.mpr],
+end
+
+end test.library_search


### PR DESCRIPTION
Fixes #3432.

This PR changes `library_search` and `suggest`:
1. instead of just selecting lemma with a single `name` as their head symbol, allows selecting from a `name_set`.
2. when the goal is `≤` on certain `ℕ` goals, set that `name_set` to `[has_lt.lt, has_le.le]`, for more flexible matching of inequality lemmas about `ℕ`
3. now successfully solves `theorem nonzero_gt_one (n : ℕ) : ¬ n = 0 → n ≥ 1 := by library_search!`
4. splits the `test/library_search/basic.lean` file into two parts, one which doesn't import `data.nat.basic`, for faster testing

---
<!-- put comments you want to keep out of the PR commit here -->
