### PR TITLE
[Merged by Bors] - feat(solve_by_elim): add tracing

### DIFF
--- a/src/tactic/solve_by_elim.lean
+++ b/src/tactic/solve_by_elim.lean
@@ -111,18 +111,27 @@ meta structure basic_opt extends apply_any_opt :=
 
 declare_trace solve_by_elim         -- trace attempted lemmas
 
+/--
+A helper function for trace messages, prepending '....' depending on the current search depth.
+-/
 meta def solve_by_elim_trace (n : ℕ) (f : format) : tactic unit :=
 trace_if_enabled `solve_by_elim
   (format!"[solve_by_elim {(list.repeat '.' (n+1)).as_string} " ++ f ++ "]")
 
+/-- A helper function to generate trace messages on successful applications. -/
 meta def on_success (g : format) (n : ℕ) (e : expr) : tactic unit :=
 do
   pp ← pp e,
   solve_by_elim_trace n (format!"✅ `{pp}` solves `⊢ {g}`")
 
+/-- A helper function to generate trace messages on unsuccessful applications. -/
 meta def on_failure (g : format) (n : ℕ) : tactic unit :=
 solve_by_elim_trace n (format!"❌ failed to solve `⊢ {g}`")
 
+/--
+A helper function to generate the tactic that print trace messages.
+This function exists to ensure the target is pretty printed only as necessary.
+-/
 meta def trace_hooks (n : ℕ) : tactic ((expr → tactic unit) × tactic unit) :=
 if is_trace_enabled_for `solve_by_elim then
   do

--- a/src/tactic/solve_by_elim.lean
+++ b/src/tactic/solve_by_elim.lean
@@ -218,8 +218,9 @@ do
   (if opt.backtrack_all_goals then id else focus1) $ (do
     gs ← get_goals,
     solve_by_elim_aux opt.to_basic_opt gs lemmas opt.max_depth <|>
-    fail ("`solve_by_elim` failed.\nTry `solve_by_elim { max_depth := N }` for a larger `N`,\n" ++
-         "or use `set_option trace.solve_by_elim true` to view the search."))
+    fail ("`solve_by_elim` failed.\n" ++
+      "Try `solve_by_elim { max_depth := N }` for `N > " ++ (to_string opt.max_depth) ++ "`\n" ++
+      "or use `set_option trace.solve_by_elim true` to view the search."))
 
 open interactive lean.parser interactive.types
 local postfix `?`:9001 := optional

--- a/test/solve_by_elim.lean
+++ b/test/solve_by_elim.lean
@@ -99,7 +99,7 @@ end
 -- Verifying that `solve_by_elim*` backtracks when given multiple goals.
 example (n m : ℕ) (f : ℕ → ℕ → Prop) (h : f n m) : ∃ p : ℕ × ℕ, f p.1 p.2 :=
 begin
-  repeat { split },
+  repeat { fsplit },
   solve_by_elim*,
 end
 


### PR DESCRIPTION
When `solve_by_elim` fails, it now prints:

```
`solve_by_elim` failed.
Try `solve_by_elim { max_depth := N }` for a larger `N`,
or use `set_option trace.solve_by_elim true` to view the search.
```

and with `set_option trace.solve_by_elim true` we get messages like:

```
example (n m : ℕ) (f : ℕ → ℕ → Prop) (h : f n m) : ∃ p : ℕ × ℕ, f p.1 p.2 :=
begin
  repeat { fsplit },
  solve_by_elim*,
end
```
producing:
```
[solve_by_elim . ✅ `n` solves `⊢ ℕ`]
[solve_by_elim .. ✅ `n` solves `⊢ ℕ`]
[solve_by_elim ... ❌ failed to solve `⊢ f (n, n).fst (n, n).snd`]
[solve_by_elim .. ✅ `m` solves `⊢ ℕ`]
[solve_by_elim ... ✅ `h` solves `⊢ f (n, m).fst (n, m).snd`]
[solve_by_elim .... success!]
```

Fixed #3063 

---
<!-- put comments you want to keep out of the PR commit here -->
