### PR TITLE
[Merged by Bors] - fix(tactic/library_search): group monotone lemmas with le lemmas

### DIFF
--- a/src/tactic/suggest.lean
+++ b/src/tactic/suggest.lean
@@ -41,6 +41,7 @@ The default is that the original argument is returned, so `<` is just mapped to 
 meta def normalize_synonym : name → name
 | `gt := `has_lt.lt
 | `ge := `has_le.le
+| `monotone := `has_le.le
 | `not := `false
 | n   := n
 

--- a/test/library_search/filter.lean
+++ b/test/library_search/filter.lean
@@ -1,0 +1,10 @@
+import order.filter.basic
+
+open filter
+
+example {α β γ : Type*} {A : filter α} {B : filter β} {C : filter γ} {f : α → β} {g : β → γ}
+  (hf : tendsto f A B) (hg : tendsto g B C) : tendsto (g ∘ f) A C :=
+calc
+map (g ∘ f) A = map g (map f A) : by library_search
+          ... ≤ map g B         : by library_search!
+          ... ≤ C               : by library_search!


### PR DESCRIPTION
This lets `library_search` use `monotone` lemmas to prove `\le` goals, and vice versa, resolving a problem people were experiencing in Patrick's exercises at LftCM2020:

```
import order.filter.basic

open filter

example {α β γ : Type*} {A : filter α} {B : filter β} {C : filter γ} {f : α → β} {g : β → γ}
  (hf : tendsto f A B) (hg : tendsto g B C) : tendsto (g ∘ f) A C :=
calc
map (g ∘ f) A = map g (map f A) : by library_search
          ... ≤ map g B         : by library_search!
          ... ≤ C               : by library_search!
```

---
<!-- put comments you want to keep out of the PR commit here -->
