### PR TITLE
[Merged by Bors] - fix(algebra/group/units): add missing coe lemmas to units

### DIFF
--- a/src/algebra/group/units.lean
+++ b/src/algebra/group/units.lean
@@ -46,9 +46,11 @@ variables [monoid α]
   by change v = v' at e; subst v'; congr;
       simpa only [iv₂, vi₁, one_mul, mul_one] using mul_assoc i₂ v i₁
 
+@[norm_cast, to_additive] theorem eq_iff {a b : units α} :
+  (a : α) = b ↔ a = b := ext.eq_iff
+
 @[to_additive] theorem ext_iff {a b : units α} :
-  a = b ↔ (a : α) = b :=
-ext.eq_iff.symm
+  a = b ↔ (a : α) = b := eq_iff.symm
 
 @[to_additive] instance [decidable_eq α] : decidable_eq (units α) :=
 λ a b, decidable_of_iff' _ ext_iff
@@ -71,6 +73,9 @@ attribute [norm_cast] add_units.coe_add
 
 @[simp, norm_cast, to_additive] lemma coe_one : ((1 : units α) : α) = 1 := rfl
 attribute [norm_cast] add_units.coe_zero
+
+@[simp, norm_cast, to_additive] lemma coe_eq_one {a : units α} : (a : α) = 1 ↔ a = 1 :=
+by rw [←units.coe_one, eq_iff]
 
 @[to_additive] lemma val_coe : (↑a : α) = a.val := rfl
 

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -938,7 +938,7 @@ units.ext_iff.1 $ nat.units_eq_one ⟨nat_abs u, nat_abs ↑u⁻¹,
   by rw [← nat_abs_mul, units.inv_mul]; refl⟩
 
 theorem units_eq_one_or (u : units ℤ) : u = 1 ∨ u = -1 :=
-by simpa [units.ext_iff, units_nat_abs] using nat_abs_eq u
+by simpa only [units.ext_iff, units_nat_abs] using nat_abs_eq u
 
 lemma units_inv_eq_self (u : units ℤ) : u⁻¹ = u :=
 (units_eq_one_or u).elim (λ h, h.symm ▸ rfl) (λ h, h.symm ▸ rfl)


### PR DESCRIPTION
Per @kbuzzard's suggestions [here](https://leanprover-community.github.io/archive/stream/113489-new-members/topic/Shortening.20proof.20on.20product.20of.20units.20in.20Z.html#204406319):

- Add a new lemma `coe_eq_one` to `units` API
- Tag `eq_iff` with `norm_cast`
---