### PR TITLE
[Merged by Bors] - feat(topology): more lemmas about Ici and Iic neighborhoods

### DIFF
--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -169,6 +169,14 @@ Icc_subset_Icc h (le_refl _)
 lemma Icc_subset_Icc_right (h : b₁ ≤ b₂) : Icc a b₁ ⊆ Icc a b₂ :=
 Icc_subset_Icc (le_refl _) h
 
+lemma Icc_subset_Ioo (ha : a₂ < a₁) (hb : b₁ < b₂) :
+  Icc a₁ b₁ ⊆ Ioo a₂ b₂ :=
+λ x hx, ⟨ (lt_of_lt_of_le ha hx.1), (lt_of_le_of_lt hx.2 hb) ⟩
+
+lemma Icc_subset_Ici_self : Icc a b ⊆ Ici a := λ x, and.left
+
+lemma Icc_subset_Iic_self : Icc a b ⊆ Iic b := λ x, and.right
+
 lemma Ioc_subset_Ioc (h₁ : a₂ ≤ a₁) (h₂ : b₁ ≤ b₂) :
   Ioc a₁ b₁ ⊆ Ioc a₂ b₂ :=
 λ x ⟨hx₁, hx₂⟩, ⟨lt_of_le_of_lt h₁ hx₁, le_trans hx₂ h₂⟩
@@ -181,6 +189,9 @@ Ioc_subset_Ioc (le_refl _) h
 
 lemma Ico_subset_Ioo_left (h₁ : a₁ < a₂) : Ico a₂ b ⊆ Ioo a₁ b :=
 λ x, and.imp_left $ lt_of_lt_of_le h₁
+
+lemma Ioc_subset_Ioo_right (h : b₁ < b₂) : Ioc a b₁ ⊆ Ioo a b₂ :=
+λ x, and.imp_right $ λ h', lt_of_le_of_lt h' h
 
 lemma Icc_subset_Ico_right (h₁ : b₁ < b₂) : Icc a b₁ ⊆ Ico a b₂ :=
 λ x, and.imp_right $ λ h₂, lt_of_le_of_lt h₂ h₁

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -171,7 +171,7 @@ Icc_subset_Icc (le_refl _) h
 
 lemma Icc_subset_Ioo (ha : a₂ < a₁) (hb : b₁ < b₂) :
   Icc a₁ b₁ ⊆ Ioo a₂ b₂ :=
-λ x hx, ⟨ (lt_of_lt_of_le ha hx.1), (lt_of_le_of_lt hx.2 hb) ⟩
+λ x hx, ⟨lt_of_lt_of_le ha hx.1, lt_of_le_of_lt hx.2 hb⟩
 
 lemma Icc_subset_Ici_self : Icc a b ⊆ Ici a := λ x, and.left
 

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -188,6 +188,24 @@ lemma is_closed.is_closed_le [topological_space β] {f g : β → α} {s : set �
   is_closed {x ∈ s | f x ≤ g x} :=
 (hf.prod hg).preimage_closed_of_closed hs order_closed_topology.is_closed_le'
 
+omit t
+
+lemma nhds_within_Ici_ne_bot {a b : α} (H₂ : a ≤ b) :
+  nhds_within b (Ici a) ≠ ⊥ :=
+nhds_within_ne_bot_of_mem H₂
+
+lemma nhds_within_Ici_self_ne_bot (a : α) :
+  nhds_within a (Ici a) ≠ ⊥ :=
+nhds_within_Ici_ne_bot (le_refl a)
+
+lemma nhds_within_Iic_ne_bot {a b : α} (H : a ≤ b) :
+  nhds_within a (Iic b) ≠ ⊥ :=
+nhds_within_ne_bot_of_mem H
+
+lemma nhds_within_Iic_self_ne_bot (a : α) :
+  nhds_within a (Iic a) ≠ ⊥ :=
+nhds_within_Iic_ne_bot (le_refl a)
+
 end preorder
 
 section partial_order


### PR DESCRIPTION
Main feature :  add `tfae_mem_nhds_within_Ici` and `tfae_mem_nhds_within_Iic`, analogous to the existing `tfae_mem_nhds_within_Ioi` and `tfae_mem_nhds_within_Iio`, as well as related lemmas (again imitating the open case)

I also added a few lemmas in `data/set/intervals/basic.lean` that were useful for this and a few upcoming PRs

---
This does also contains preliminaries for L'Hopital's rule, although this only apply to a small part of the PR
