### PR TITLE
Run CI against pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
       - 'nolints'
       # do not build lean-x.y.z branch used by leanpkg
       - 'lean-3.*'
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
Currently, CI only runs against PRs made from an internal branch.


---
<!-- put comments you want to keep out of the PR commit here -->

edit: hmm, looks like this was deliberate: https://github.com/leanprover-community/mathlib/pull/2237