### PR TITLE
[Merged by Bors] - feat(tactic/simps): improvements

### DIFF
--- a/src/algebra/category/CommRing/colimits.lean
+++ b/src/algebra/category/CommRing/colimits.lean
@@ -395,7 +395,6 @@ begin
 end
 
 /-- The ring homomorphism from the colimit commutative ring to the cone point of any other cocone. -/
-@[simps]
 def desc_morphism (s : cocone F) : colimit F ⟶ s.X :=
 { to_fun := desc_fun F s,
   map_one' := rfl,

--- a/src/algebra/category/Group/colimits.lean
+++ b/src/algebra/category/Group/colimits.lean
@@ -260,7 +260,6 @@ begin
 end
 
 /-- The group homomorphism from the colimit abelian group to the cone point of any other cocone. -/
-@[simps]
 def desc_morphism (s : cocone F) : colimit F ⟶ s.X :=
 { to_fun := desc_fun F s,
   map_zero' := rfl,

--- a/src/algebra/category/Mon/colimits.lean
+++ b/src/algebra/category/Mon/colimits.lean
@@ -218,7 +218,6 @@ begin
 end
 
 /-- The monoid homomorphism from the colimit monoid to the cone point of any other cocone. -/
-@[simps]
 def desc_morphism (s : cocone F) : colimit F ⟶ s.X :=
 { to_fun := desc_fun F s,
   map_one' := rfl,

--- a/src/category_theory/products/associator.lean
+++ b/src/category_theory/products/associator.lean
@@ -24,14 +24,14 @@ The associator functor `(C × D) × E ⥤ C × (D × E)`.
 -/
 -- Here and below we specify explicitly the projections to generate `@[simp]` lemmas for,
 -- as the default behaviour of `@[simps]` will generate projections all the way down to components of pairs.
-@[simps obj map] def associator : (C × D) × E ⥤ C × (D × E) :=
+@[simps] def associator : (C × D) × E ⥤ C × (D × E) :=
 { obj := λ X, (X.1.1, (X.1.2, X.2)),
   map := λ _ _ f, (f.1.1, (f.1.2, f.2)) }
 
 /--
 The inverse associator functor `C × (D × E) ⥤ (C × D) × E `.
 -/
-@[simps obj map] def inverse_associator : C × (D × E) ⥤ (C × D) × E :=
+@[simps] def inverse_associator : C × (D × E) ⥤ (C × D) × E :=
 { obj := λ X, ((X.1, X.2.1), X.2.2),
   map := λ _ _ f, ((f.1, f.2.1), f.2.2) }
 

--- a/src/category_theory/products/basic.lean
+++ b/src/category_theory/products/basic.lean
@@ -49,13 +49,13 @@ namespace prod
 -- Here and below we specify explicitly the projections to generate `@[simp]` lemmas for,
 -- as the default behaviour of `@[simps]` will generate projections all the way down to components
 -- of pairs.
-@[simps obj map] def sectl
+@[simps] def sectl
   (C : Type u₁) [category.{v₁} C] {D : Type u₂} [category.{v₂} D] (Z : D) : C ⥤ C × D :=
 { obj := λ X, (X, Z),
   map := λ X Y f, (f, 𝟙 Z) }
 
 /-- `sectr Z D` is the functor `D ⥤ C × D` given by `Y ↦ (Z, Y)` . -/
-@[simps obj map] def sectr
+@[simps] def sectr
   {C : Type u₁} [category.{v₁} C] (Z : C) (D : Type u₂) [category.{v₂} D] : D ⥤ C × D :=
 { obj := λ X, (Z, X),
   map := λ X Y f, (𝟙 Z, f) }
@@ -63,20 +63,20 @@ namespace prod
 variables (C : Type u₁) [category.{v₁} C] (D : Type u₂) [category.{v₂} D]
 
 /-- `fst` is the functor `(X, Y) ↦ X`. -/
-@[simps obj map] def fst : C × D ⥤ C :=
+@[simps] def fst : C × D ⥤ C :=
 { obj := λ X, X.1,
   map := λ X Y f, f.1 }
 
 /-- `snd` is the functor `(X, Y) ↦ Y`. -/
-@[simps obj map] def snd : C × D ⥤ D :=
+@[simps] def snd : C × D ⥤ D :=
 { obj := λ X, X.2,
   map := λ X Y f, f.2 }
 
-@[simps obj map] def swap : C × D ⥤ D × C :=
+@[simps] def swap : C × D ⥤ D × C :=
 { obj := λ X, (X.2, X.1),
   map := λ _ _ f, (f.2, f.1) }
 
-@[simps hom_app inv_app] def symmetry : swap C D ⋙ swap D C ≅ 𝟭 (C × D) :=
+@[simps] def symmetry : swap C D ⋙ swap D C ≅ 𝟭 (C × D) :=
 { hom := { app := λ X, 𝟙 X },
   inv := { app := λ X, 𝟙 X } }
 
@@ -101,7 +101,7 @@ variables (C : Type u₁) [category.{v₁} C] (D : Type u₂) [category.{v₂} D
   { app := λ F, F.map f,
     naturality' := λ F G α, eq.symm (α.naturality f) } }
 
-@[simps obj map] def evaluation_uncurried : C × (C ⥤ D) ⥤ D :=
+@[simps] def evaluation_uncurried : C × (C ⥤ D) ⥤ D :=
 { obj := λ p, p.2.obj p.1,
   map := λ x y f, (x.2.map f.1) ≫ (f.2.app y.1),
   map_comp' := λ X Y Z f g,
@@ -121,7 +121,7 @@ variables {A : Type u₁} [category.{v₁} A]
 
 namespace functor
 /-- The cartesian product of two functors. -/
-@[simps obj map] def prod (F : A ⥤ B) (G : C ⥤ D) : A × C ⥤ B × D :=
+@[simps] def prod (F : A ⥤ B) (G : C ⥤ D) : A × C ⥤ B × D :=
 { obj := λ X, (F.obj X.1, G.obj X.2),
   map := λ _ _ f, (F.map f.1, G.map f.2) }
 
@@ -133,7 +133,7 @@ end functor
 namespace nat_trans
 
 /-- The cartesian product of two natural transformations. -/
-@[simps app] def prod {F G : A ⥤ B} {H I : C ⥤ D} (α : F ⟶ G) (β : H ⟶ I) :
+@[simps] def prod {F G : A ⥤ B} {H I : C ⥤ D} (α : F ⟶ G) (β : H ⟶ I) :
   F.prod H ⟶ G.prod I :=
 { app         := λ X, (α.app X.1, β.app X.2),
   naturality' := λ X Y f,

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -276,6 +276,11 @@ meta def is_num_eq : expr → expr → bool
 | `(%%a/%%a') `(%%b/%%b') :=  a.is_num_eq b
 | _ _ := ff
 
+/-- Get the universe levels of a `const` expression -/
+meta def univ_levels : expr → list level
+| (const n ls) := ls
+| _            := []
+
 end expr
 
 /-! ### Declarations about `expr` -/

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -276,14 +276,6 @@ meta def is_num_eq : expr → expr → bool
 | `(%%a/%%a') `(%%b/%%b') :=  a.is_num_eq b
 | _ _ := ff
 
-/-- Get the universe levels of a `const` expression -/
-meta def univ_levels : expr → list level
-| (const n ls) := ls
-| _            := []
-
-/-- Get the universe levels of a `const` expression -/
-meta def substs : expr → list expr → expr | e es := es.foldl expr.subst e
-
 end expr
 
 /-! ### Declarations about `expr` -/
@@ -312,6 +304,11 @@ meta def is_mvar : expr → bool
 meta def is_sort : expr → bool
 | (sort _) := tt
 | e         := ff
+
+/-- Get the universe levels of a `const` expression -/
+meta def univ_levels : expr → list level
+| (const n ls) := ls
+| _            := []
 
 /--
 Replace any metavariables in the expression with underscores, in preparation for printing
@@ -453,10 +450,15 @@ meta def instantiate_lambdas : list expr → expr → expr
 | (e'::es) (lam n bi t e) := instantiate_lambdas es (e.instantiate_var e')
 | _        e              := e
 
+/-- Repeatedly apply `expr.subst`. -/
+meta def substs : expr → list expr → expr | e es := es.foldl expr.subst e
+
 /-- `instantiate_lambdas_or_apps es e` instantiates lambdas in `e` by expressions from `es`.
 If the length of `es` is larger than the number of lambdas in `e`,
 then the term is applied to the remaining terms.
-Also reduces head let-expressions in `e`, including those after instantiating all lambdas. -/
+Also reduces head let-expressions in `e`, including those after instantiating all lambdas.
+
+This is very similar to `expr.substs`, but also reduces head let-expressions. -/
 meta def instantiate_lambdas_or_apps : list expr → expr → expr
 | (v::es) (lam n bi t b) := instantiate_lambdas_or_apps es $ b.instantiate_var v
 | es      (elet _ _ v b) := instantiate_lambdas_or_apps es $ b.instantiate_var v

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -281,6 +281,9 @@ meta def univ_levels : expr → list level
 | (const n ls) := ls
 | _            := []
 
+/-- Get the universe levels of a `const` expression -/
+meta def substs : expr → list expr → expr | e es := es.foldl expr.subst e
+
 end expr
 
 /-! ### Declarations about `expr` -/

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -725,7 +725,7 @@ meta def is_eta_expansion_test : list (name × expr) → option expr
 /-- `is_eta_expansion_aux val l` checks whether `val` can be eta-reduced to an expression `e`.
   Here `l` is intended to consists of the projections and the fields of `val`.
   This tactic calls `is_eta_expansion_test l`, but first removes all proofs from the list `l` and
-  afterward checks whether the retulting expression `e` unifies with `val`.
+  afterward checks whether the resulting expression `e` unifies with `val`.
   This last check is necessary, because `val` and `e` might have different types. -/
 meta def is_eta_expansion_aux (val : expr) (l : list (name × expr)) : tactic (option expr) :=
 do l' ← l.mfilter (λ⟨proj, val⟩, bnot <$> is_proof val),

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -19,6 +19,9 @@ expr, name, declaration, level, environment, meta, metaprogramming, tactic
 
 attribute [derive has_reflect, derive decidable_eq] binder_info congr_arg_kind
 
+@[priority 100] meta instance has_reflect.has_to_pexpr {α} [has_reflect α] : has_to_pexpr α :=
+⟨λ b, pexpr.of_expr (reflect b)⟩
+
 namespace binder_info
 
 /-! ### Declarations about `binder_info` -/

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -458,7 +458,7 @@ If the length of `es` is larger than the number of lambdas in `e`,
 then the term is applied to the remaining terms.
 Also reduces head let-expressions in `e`, including those after instantiating all lambdas.
 
-This is very similar to `expr.substs`, but also reduces head let-expressions. -/
+This is very similar to `expr.substs`, but this also reduces head let-expressions. -/
 meta def instantiate_lambdas_or_apps : list expr → expr → expr
 | (v::es) (lam n bi t b) := instantiate_lambdas_or_apps es $ b.instantiate_var v
 | es      (elet _ _ v b) := instantiate_lambdas_or_apps es $ b.instantiate_var v

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -1045,8 +1045,8 @@ meta def dependent_pose_core (l : list (expr × expr)) : tactic unit := do
 
 /-- Like `mk_local_pis` but translating into weak head normal form before checking if it is a `Π`.
 -/
-meta def mk_local_pis_whnf : expr → tactic (list expr × expr) | e := do
-(expr.pi n bi d b) ← whnf e | return ([], e),
+meta def mk_local_pis_whnf (e : expr) (md := semireducible) : tactic (list expr × expr) := do
+(expr.pi n bi d b) ← whnf e md | return ([], e),
 p ← mk_local' n bi d,
 (ps, r) ← mk_local_pis (expr.instantiate_var b p),
 return ((p :: ps), r)

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -14,13 +14,13 @@ import tactic.fix_by_cases
 
 universe variable u
 
+attribute [derive [has_reflect, decidable_eq]] tactic.transparency
+
 instance : has_lt pos :=
 { lt := λ x y, (x.line, x.column) < (y.line, y.column) }
 
 namespace expr
 open tactic
-
-attribute [derive [has_reflect, decidable_eq]] tactic.transparency
 
 /-- Given an expr `α` representing a type with numeral structure,
 `of_nat α n` creates the `α`-valued numeral expression corresponding to `n`. -/

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -63,6 +63,8 @@ inst ← mk_instance tgt,
 return (e, inst)
 
 /-- Get the projections used by `simps` associated to a given structure. -/
+-- if performance becomes a problem: possible heuristic: use the names of the projections to
+-- skip all classes that don't have the corresponding field.
 meta def simps_get_raw_projections (e : environment) (str : name) :
   tactic (list name × list expr) := do
   has_attr ← has_attribute' `simps_str str,
@@ -158,7 +160,8 @@ meta def simps_add_projections : ∀(e : environment) (nm : name) (suffix : stri
   (type lhs rhs : expr) (args : list expr) (univs : list name) (must_be_str : bool)
   (cfg : simps_cfg) (todo : list string), tactic unit
 | e nm suffix type lhs rhs args univs must_be_str cfg todo := do
-  (type_args, tgt) ← mk_local_pis_whnf type,
+  -- we don't want to unfold non-reducible definitions (like `set`) to apply more arguments
+  (type_args, tgt) ← mk_local_pis_whnf type transparency.reducible,
   tgt ← whnf tgt,
   let new_args := args ++ type_args,
   let lhs_ap := lhs.mk_app type_args,

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -18,7 +18,8 @@ structures, projections, simp, simplifier, generates declarations
 open tactic expr
 
 setup_tactic_parser
-@[derive has_reflect] structure simps_cfg :=
+/-- configuration for the `@[simps]` attribute -/
+@[derive [has_reflect, inhabited]] structure simps_cfg :=
 -- give the generated lemmas the `@[simp]` attribute
 (simp_attr    := tt)
 -- give the generated lemmas a shorter name
@@ -112,16 +113,17 @@ meta def simps_get_raw_projections (e : environment) (str : name) :
         -- trace e_inst.to_string,
         raw_expr ← mk_mapp proj_nm [e_str, e_inst],
         return (raw_expr, raw_expr.lambdas args)),
-      trace raw_expr.to_string,
-      infer_type raw_expr >>= trace,
+      -- trace raw_expr.to_string,
+      -- infer_type raw_expr >>= trace,
       raw_expr_whnf ← whnf raw_expr.binding_body,
-      trace raw_expr_whnf.to_string,
+      -- trace raw_expr_whnf.to_string,
       let relevant_proj := raw_expr_whnf.get_app_fn.const_name,
       guard (projs.any (= relevant_proj)),
       let pos := projs.find_index (= relevant_proj),
+      when_tracing `simps.verbose trace!"        > using function {proj_nm} instead of the default projection {relevant_proj.last}.",
       return $ raw_exprs.update_nth pos lambda_raw_expr) <|> return raw_exprs) raw_exprs,
-    when_tracing `simps.verbose trace!"[simps] > {raw_exprs}",
-    when_tracing `simps.verbose trace!"[simps] > {raw_exprs.map expr.to_string}",
+    when_tracing `simps.verbose trace!"[simps] > resulting projections:\n        > {raw_exprs}",
+    -- when_tracing `simps.verbose trace!"[simps] > {raw_exprs.map expr.to_string}",
     simps_str_attr.set str (raw_univs, raw_exprs) tt,
     return (raw_univs, raw_exprs)
 

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -99,7 +99,7 @@ meta def simps_add_projections : ∀(e : environment) (nm : name) (suffix : stri
     when must_be_str $
       fail "Invalid `simps` attribute. Target is not a structure",
     when (todo ≠ [] ∧ todo ≠ [""] ∧ str ∉ [`prod, `pprod]) $
-        fail format!"Invalid simp-lemma {nm.append_suffix $ suffix ++ todo.head}. Projection {todo.head} doesn't exist, because target is not a structure.",
+        fail format!"Invalid simp-lemma {nm.append_suffix $ suffix ++ todo.head}. Projection {(todo.head.split_on '_').tail.head} doesn't exist, because target is not a structure.",
     simps_add_projection (nm.append_suffix suffix) tgt lhs_ap rhs_ap new_args univs add_simp
 
 /-- `simps_tac` derives simp-lemmas for all (nested) non-Prop projections of the declaration.

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -451,34 +451,6 @@ derives two simp-lemmas:
   after_set := some $
     λ n _ _, do (todo, cfg) ← simps_attr.get_param n, simps_tac n cfg todo }
 
-open function
-structure equiv (α : Sort*) (β : Sort*) :=
-(to_fun    : α → β)
-(inv_fun   : β → α)
-(left_inv  : left_inverse inv_fun to_fun)
-(right_inv : right_inverse inv_fun to_fun)
-
-local infix ` ≃ `:25 := equiv
-
-@[simps] protected def equiv.refl (α) : α ≃ α :=
-⟨id, λ x, x, λ x, rfl, λ x, rfl⟩
-
-set_option trace.simps.verbose true
-structure equiv_plus_data (α β) extends α ≃ β := (data : bool)
-/-
-[simps] > generating projection information for structure equiv_plus_data:
-[simps] > generated projections for equiv_plus_data:
-        > [equiv_plus_data.to_equiv, equiv_plus_data.data]
-[simps] > found projection information for structure equiv
-[simps] > adding projection
-        > bar_to_equiv : ∀ {α : Sort u_1}, bar.to_equiv = equiv.refl α
-[simps] > adding projection
-        > bar_data : ∀ {α : Sort u_1}, bar.data = tt
-
--/
-
-@[simps] def bar {α} : equiv_plus_data α α := { data := tt, ..equiv.refl α }
-
 add_tactic_doc
 { name                     := "simps",
   category                 := doc_category.attr,

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -18,7 +18,7 @@ structures, projections, simp, simplifier, generates declarations
 open tactic expr
 
 setup_tactic_parser
-reserve notation `specify_simps_projections`
+reserve notation `initialize_simps_projections`
 declare_trace simps.verbose
 
 /--

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -93,8 +93,8 @@ meta def simps_get_raw_projections (e : environment) (str : name) :
     /- check for other coercions and type-class arguments to use as projections instead. -/
     let e_str := (expr.const str raw_levels).mk_app args,
     raw_exprs ← simps_decls.mfoldl (λ (raw_exprs : list expr) ⟨is_class, class_nm, proj_nm⟩, (do
-      (raw_expr, lambda_raw_expr) ← if is_class then (do
-        let e_inst_type := (expr.const class_nm raw_levels).mk_app args,
+      (raw_expr, lambda_raw_expr) ← if is_class then (do failed -- todo
+        /-let e_inst_type := (expr.const class_nm raw_levels).mk_app args,
         -- trace e_inst_type.to_string,
         (hyp, e_inst) ← try_for 1000 (mk_conditional_instance e_str e_inst_type),
         -- trace e_inst.to_string,
@@ -104,7 +104,7 @@ meta def simps_get_raw_projections (e : environment) (str : name) :
         -- trace e_str.to_string,
         -- trace e_inst.to_string,
         raw_expr ← mk_mapp proj_nm [args.head, e_inst],
-        return (raw_expr, (raw_expr.bind_lambda hyp).lambdas args))
+        return (raw_expr, (raw_expr.bind_lambda hyp).lambdas args)-/)
       else (do
         e_inst_type ← to_expr ((expr.const class_nm []).app (pexpr.of_expr e_str)),
         -- trace e_inst_type.to_string,

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -228,7 +228,7 @@ meta def simps_add_projection (nm : name) (type lhs rhs : expr) (args : list exp
     add_decl decl,
   b ← succeeds $ is_def_eq lhs rhs,
   when (b ∧ `simp ∈ cfg.attrs) (set_basic_attribute `_refl_lemma decl_name tt),
-  cfg.attrs.mmap' $ λ nm, set_basic_attribute nm decl_name tt
+  cfg.attrs.mmap' $ λ nm, set_attribute nm decl_name tt
 
 /-- Derive lemmas specifying the projections of the declaration.
   If `todo` is non-empty, it will generate exactly the names in `todo`. -/

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -183,7 +183,8 @@ meta def simps_add_projection (nm : name) (type lhs rhs : expr) (args : list exp
   let decl_value := prf.lambdas args,
   let decl := declaration.thm decl_name univs decl_type (pure decl_value),
   when_tracing `simps.verbose trace!"[simps] > adding projection\n        > {decl_name} : {decl_type}",
-  add_decl decl <|> fail format!"failed to add projection lemma {decl_name}.",
+  decorate_error ("failed to add projection lemma " ++ decl_name.to_string ++ ". Nested error:") $
+    add_decl decl,
   b ← succeeds $ is_def_eq lhs rhs,
   when (b ∧ `simp ∈ cfg.attrs) (set_basic_attribute `_refl_lemma decl_name tt),
   cfg.attrs.mmap' $ λ nm, set_basic_attribute nm decl_name tt

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -53,7 +53,7 @@ attribute [notation_class* coe_sort] has_coe_to_sort
 attribute [notation_class* coe_fn] has_coe_to_fun
 
 
-/- finds an instance of an implication `cond → tgt`.
+/-- finds an instance of an implication `cond → tgt`.
   Returns a pair of a local constant `e` of type `cond`, and an instance of `tgt` that can mention `e`. -/
 meta def mk_conditional_instance (cond tgt : expr) : tactic (expr × expr) := do
 f ← mk_meta_var cond,

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -470,3 +470,11 @@ set_option trace.app_builder true
 
 
 end manual_coercion
+
+-- transparency setting
+structure set_plus (α : Type) :=
+(s : set α)
+(x : α)
+(h : x ∈ s)
+
+@[simps] def nat_set_plus : set_plus ℕ := ⟨set.univ, 1, trivial⟩

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -360,11 +360,14 @@ example {α} (x : α) : coercing.rfl2 x = x := by rw [coercing.rfl2_to_fun]
 example {α} (x : α) : coercing.rfl2 x = x := by simp
 example {α} (x : α) : coercing.rfl2.inv_fun x = x := by simp
 
-@[simps] protected def equiv2.symm2 {α β} (f : equiv2 α β) : equiv2 β α :=
+@[simps] protected def equiv2.symm {α β} (f : equiv2 α β) : equiv2 β α :=
 ⟨f.inv_fun, f, f.right_inv, f.left_inv⟩
 
-example {α β} (f : equiv2 α β) (y : β) : f.symm2 y = f.inv_fun y := by simp
-example {α β} (f : equiv2 α β) (x : α) : f.symm2.inv_fun x = f x := by simp
+@[simps] protected def equiv2.symm2 {α β} (f : equiv2 α β) : equiv2 β α :=
+⟨f.inv_fun, f.to_fun, f.right_inv, f.left_inv⟩
+
+example {α β} (f : equiv2 α β) (y : β) : f.symm y = f.inv_fun y := by simp
+example {α β} (f : equiv2 α β) (x : α) : f.symm.inv_fun x = f x := by simp
 
 section
 set_option old_structure_cmd true
@@ -502,3 +505,14 @@ begin
   guard_target @set.univ ℕ = set.univ,
   refl
 end
+
+/-
+todo:
+set_basic_attribute tactic failed, 'mfld_simps' is not a basic attribute
+make reducibility an option, default instance?
+bug? equiv2.symm and equiv2.symm2 have different number of arguments
+Invalid `simps` attribute. Body is not a constructor application
+test def-eq in custom projections.
+failed to add projection lemma local_equiv.prod_inv_fun.
+
+-/

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -20,6 +20,7 @@ def myprod.map {α α' β β'} (f : α → α') (g : β → β') (x : my_prod α
 
 namespace foo
 
+set_option trace.app_builder true
 @[simps] protected def rfl {α} : α ≃ α :=
 ⟨id, λ x, x, λ x, rfl, λ x, rfl⟩
 
@@ -172,13 +173,16 @@ structure very_partially_applied_str :=
 (data : ∀β, ℕ → β → my_prod ℕ β)
 
 /- if we have a partially applied constructor, we treat it as if it were eta-expanded -/
-@[simps]
-def very_partially_applied_term : very_partially_applied_str := ⟨@my_prod.mk ℕ⟩
+/- This is no longer supported, (it is useless) -/
 
-run_cmd do
-  e ← get_env,
-  e.get `very_partially_applied_term_data_fst,
-  e.get `very_partially_applied_term_data_snd
+-- @[simps]
+-- -- def very_partially_applied_term : very_partially_applied_str := ⟨@my_prod.mk ℕ⟩
+-- def very_partially_applied_term : very_partially_applied_str := ⟨λ x y z, my_prod.mk y z⟩
+
+-- run_cmd do
+--   e ← get_env,
+--   e.get `very_partially_applied_term_data_fst,
+--   e.get `very_partially_applied_term_data_snd
 
 @[simps] def let1 : ℕ × ℤ :=
 let n := 3 in ⟨n + 4, 5⟩

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -1,6 +1,6 @@
 import tactic.simps
 
--- set_option trace.simps.verbose true
+set_option trace.simps.verbose true
 
 open function tactic expr
 
@@ -15,9 +15,7 @@ local infix ` ≃ `:25 := equiv
 
 /- Since `prod` and `pprod` are a special case for `@[simps]`, we define a new structure to test
   the basic functionality.-/
-structure my_prod (α β : Type*) :=
-  (fst : α)
-  (snd : β)
+structure my_prod (α β : Type*) := (fst : α) (snd : β)
 
 def myprod.map {α α' β β'} (f : α → α') (g : β → β') (x : my_prod α β) : my_prod α' β' :=
 ⟨f x.1, g x.2⟩
@@ -479,6 +477,8 @@ def equiv.symm (e : α ≃ β) : β ≃ α := ⟨e.inv_fun, e.to_fun⟩
 
 /-- See Note [custom simps projection] -/
 def equiv.simps.inv_fun (e : α ≃ β) : β → α := e.symm
+@[simps] def equiv.trans (e₁ : α ≃ β) (e₂ : β ≃ γ) : α ≃ γ :=
+⟨e₂ ∘ e₁, e₁.symm ∘ e₂.symm⟩
 
 /-- Composition of equivalences `e₁ : α ≃ β` and `e₂ : β ≃ γ`. -/
 @[simps {simp_rhs := tt}] protected def equiv.trans (e₁ : α ≃ β) (e₂ : β ≃ γ) : α ≃ γ :=

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -340,34 +340,35 @@ set_option pp.all true
 @[simps] protected def symm2 {α β} (f : equiv2 α β) : equiv2 β α :=
 ⟨f.inv_fun, f.to_fun, f.right_inv, f.left_inv⟩
 
-set_option old_structure_cmd true
-class semigroup (G : Type u) extends has_mul G :=
-(mul_assoc : ∀ a b c : G, a * b * c = a * (b * c))
+-- todo
+-- set_option old_structure_cmd true
+-- class semigroup (G : Type u) extends has_mul G :=
+-- (mul_assoc : ∀ a b c : G, a * b * c = a * (b * c))
 
-def bazz {G : Type*} [semigroup G] (x y : G) : x * y = semigroup.mul x y := rfl
-#print bazz
+-- def bazz {G : Type*} [semigroup G] (x y : G) : x * y = semigroup.mul x y := rfl
+-- #print bazz
 
-example {α : Type u} : unit :=
-begin
-  do e ← get_local `α,
-  f ← mk_conditional_instance 
-    ((expr.const `coercing.semigroup [level.param `u]).app e)
-    ((expr.const `has_mul [level.param `u]).app e),
-  -- infer_type f.2 >>= trace,
-  trace f
-end
+-- example {α : Type u} : unit :=
+-- begin
+--   do e ← get_local `α,
+--   f ← mk_conditional_instance
+--     ((expr.const `coercing.semigroup [level.param `u]).app e)
+--     ((expr.const `has_mul [level.param `u]).app e),
+--   -- infer_type f.2 >>= trace,
+--   trace f
+-- end
 
-set_option pp.all true
-@[simps] instance : semigroup ℕ :=
-{ mul := (*),
-  mul_assoc := nat.mul_assoc }
+-- set_option pp.all true
+-- @[simps] instance : semigroup ℕ :=
+-- { mul := (*),
+--   mul_assoc := nat.mul_assoc }
 
-def bazzz (x y : ℕ) : x * y = nat.mul x y :=
-_
-#print has_mul
+-- def bazzz (x y : ℕ) : x * y = nat.mul x y :=
+-- _
+-- #print has_mul
 
-def baz (α : Type*) : semigroup α → has_mul α := by introI; apply_instance
+-- def baz (α : Type*) : semigroup α → has_mul α := by introI; apply_instance
 
-#print baz
+-- #print baz
 
 end coercing

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -246,6 +246,30 @@ run_cmd do
   e.get `short_name1_fst, e.get `short_name1_fst_2,
   e.get `short_name1_snd, e.get `short_name1_snd_2
 
+/- check simp_rhs option -/
+@[simps {simp_rhs := tt}] def equiv.trans {α β γ} (f : α ≃ β) (g : β ≃ γ) : α ≃ γ :=
+⟨g.to_fun ∘ f.to_fun, f.inv_fun ∘ g.inv_fun,
+  by { intro x, simp [equiv.left_inv _ _] }, by { intro x, simp [equiv.right_inv _ _] }⟩
+
+example {α β γ : Type} (f : α ≃ β) (g : β ≃ γ) (x : α) :
+  (f.trans g).to_fun x = (f.trans g).to_fun x :=
+begin
+  dsimp only [equiv.trans_to_fun],
+  guard_target g.to_fun (f.to_fun x) = g.to_fun (f.to_fun x),
+  refl,
+end
+
+local attribute [simp] nat.zero_add nat.one_mul nat.mul_one
+@[simps {simp_rhs := tt}] def my_nat_equiv : ℕ ≃ ℕ :=
+⟨λ n, 0 + n, λ n, 1 * n * 1, by { intro n, simp }, by { intro n, simp }⟩
+
+example (n : ℕ) : my_nat_equiv.to_fun (my_nat_equiv.to_fun $ my_nat_equiv.inv_fun n) = n :=
+by { success_if_fail { refl }, simp only [my_nat_equiv_to_fun, my_nat_equiv_inv_fun] }
+
+@[simps {simp_rhs := tt}] def succeed_without_simplification_possible : ℕ ≃ ℕ :=
+⟨λ n, n, λ n, n, by { intro n, refl }, by { intro n, refl }⟩
+
+
 /- test that we don't recursively take projections of `prod` and `pprod` -/
 @[simps] def pprod_equiv_prod : pprod ℕ ℕ ≃ ℕ × ℕ :=
 { to_fun := λ x, ⟨x.1, x.2⟩,

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -1,6 +1,6 @@
 import tactic.simps
 
-set_option trace.simps.verbose true
+-- set_option trace.simps.verbose true
 
 open function tactic expr
 

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -1,5 +1,7 @@
 import tactic.simps
 
+set_option trace.simps.verbose true
+
 open function tactic expr
 structure equiv (α : Sort*) (β : Sort*) :=
 (to_fun    : α → β)
@@ -20,7 +22,6 @@ def myprod.map {α α' β β'} (f : α → α') (g : β → β') (x : my_prod α
 
 namespace foo
 
-set_option trace.app_builder true
 @[simps] protected def rfl {α} : α ≃ α :=
 ⟨id, λ x, x, λ x, rfl, λ x, rfl⟩
 

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -214,13 +214,13 @@ run_cmd do
   guard $ 12 = e.fold 0 -- there are no other lemmas generated
     (λ d n, n + if d.to_name.components.init.ilast = `specify then 1 else 0),
   success_if_fail_with_msg (simps_tac `specify.specify1 tt ff ["fst_fst"])
-    "Invalid simp-lemma specify.specify1_fst_fst. Too many projections given.",
+    "Invalid simp-lemma specify.specify1_fst_fst. Projection fst doesn't exist, because target is not a structure.",
   success_if_fail_with_msg (simps_tac `specify.specify1 tt ff ["foo_fst"])
     "Invalid simp-lemma specify.specify1_foo_fst. Projection foo doesn't exist.",
   success_if_fail_with_msg (simps_tac `specify.specify1 tt ff ["snd_bar"])
     "Invalid simp-lemma specify.specify1_snd_bar. Projection bar doesn't exist.",
   success_if_fail_with_msg (simps_tac `specify.specify5 tt ff ["snd_snd"])
-    "Invalid simp-lemma specify.specify5_snd_snd. Too many projections given."
+    "Invalid simp-lemma specify.specify5_snd_snd. The given definition is not a constructor application."
 
 
 /- We also eta-reduce if we explicitly specify the projection. -/

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -1,6 +1,6 @@
 import tactic.simps
 
-set_option trace.simps.verbose true
+-- set_option trace.simps.verbose true
 
 open function tactic expr
 structure equiv (α : Sort*) (β : Sort*) :=
@@ -54,17 +54,17 @@ noncomputable def bar3 {α} : α ≃ α :=
 classical.choice ⟨foo.rfl⟩
 
 run_cmd do
-  success_if_fail_with_msg (simps_tac `foo.bar1 tt)
+  success_if_fail_with_msg (simps_tac `foo.bar1)
     "Invalid `simps` attribute. Target is not a structure",
-  success_if_fail_with_msg (simps_tac `foo.bar2 tt)
+  success_if_fail_with_msg (simps_tac `foo.bar2)
     "Invalid `simps` attribute. Body is not a constructor application",
-  success_if_fail_with_msg (simps_tac `foo.bar3 tt)
+  success_if_fail_with_msg (simps_tac `foo.bar3)
     "Invalid `simps` attribute. Body is not a constructor application",
   e ← get_env,
   let nm := `foo.bar1,
   d ← e.get nm,
   let lhs : expr := const d.to_name (d.univ_params.map level.param),
-  simps_add_projections e nm "" d.type lhs d.value [] d.univ_params tt ff ff []
+  simps_add_projections e nm "" d.type lhs d.value [] d.univ_params ff {} []
 
 end foo
 
@@ -89,7 +89,7 @@ namespace count_nested
 @[simps] def nested1 : my_prod ℕ $ my_prod ℤ ℕ :=
 ⟨2, -1, 1⟩
 
-@[simps lemmas_only] def nested2 : ℕ × my_prod ℕ ℕ :=
+@[simps {simp_attr := ff}] def nested2 : ℕ × my_prod ℕ ℕ :=
 ⟨2, myprod.map nat.succ nat.pred ⟨1, 2⟩⟩
 
 end count_nested
@@ -218,13 +218,13 @@ run_cmd do
   e.get `specify.specify5_fst, e.get `specify.specify5_snd,
   guard $ 12 = e.fold 0 -- there are no other lemmas generated
     (λ d n, n + if d.to_name.components.init.ilast = `specify then 1 else 0),
-  success_if_fail_with_msg (simps_tac `specify.specify1 tt ff ["fst_fst"])
+  success_if_fail_with_msg (simps_tac `specify.specify1 {} ["fst_fst"])
     "Invalid simp-lemma specify.specify1_fst_fst. Projection fst doesn't exist, because target is not a structure.",
-  success_if_fail_with_msg (simps_tac `specify.specify1 tt ff ["foo_fst"])
+  success_if_fail_with_msg (simps_tac `specify.specify1 {} ["foo_fst"])
     "Invalid simp-lemma specify.specify1_foo_fst. Projection foo doesn't exist.",
-  success_if_fail_with_msg (simps_tac `specify.specify1 tt ff ["snd_bar"])
+  success_if_fail_with_msg (simps_tac `specify.specify1 {} ["snd_bar"])
     "Invalid simp-lemma specify.specify1_snd_bar. Projection bar doesn't exist.",
-  success_if_fail_with_msg (simps_tac `specify.specify5 tt ff ["snd_snd"])
+  success_if_fail_with_msg (simps_tac `specify.specify5 {} ["snd_snd"])
     "Invalid simp-lemma specify.specify5_snd_snd. The given definition is not a constructor application."
 
 
@@ -238,7 +238,7 @@ run_cmd do
   skip
 
 /- check short_name option -/
-@[simps short_name] def short_name1 : my_prod ℕ ℕ × my_prod ℕ ℕ := ⟨⟨1, 2⟩, 3, 4⟩
+@[simps {short_name := tt}] def short_name1 : my_prod ℕ ℕ × my_prod ℕ ℕ := ⟨⟨1, 2⟩, 3, 4⟩
 run_cmd do
   e ← get_env,
   e.get `short_name1_fst, e.get `short_name1_fst_2,

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -261,3 +261,24 @@ run_cmd do
   e ← get_env,
   e.get `pprod_equiv_prod_to_fun_fst,
   e.get `pprod_equiv_prod_inv_fun_snd
+
+/- Tests with universe levels -/
+universe variables v u
+class has_hom (obj : Type u) : Type (max u (v+1)) :=
+(hom : obj → obj → Type v)
+
+infixr ` ⟶ `:10 := has_hom.hom -- type as \h
+
+section prio
+set_option default_priority 100
+class category_struct (obj : Type u) extends has_hom.{v} obj : Type (max u (v+1)) :=
+(id       : Π X : obj, hom X X)
+(comp     : Π {X Y Z : obj}, (X ⟶ Y) → (Y ⟶ Z) → (X ⟶ Z))
+
+end prio
+
+-- test the universe levels in the category theory library
+@[simps] def types : category_struct (Type u) :=
+{ hom     := λ a b, (a → b),
+  id      := λ a, id,
+  comp    := λ _ _ _ f g, g ∘ f }

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -282,7 +282,7 @@ class category_struct (obj : Type u) extends has_hom.{v} obj : Type (max u (v+1)
 
 end prio
 
-set_option trace.app_builder true
+-- set_option trace.app_builder true
 -- test the universe levels in the category theory library
 @[simps] def types : category_struct (Type u) :=
 { hom     := λ a b, (a → b),

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -476,8 +476,6 @@ def equiv.symm (e : α ≃ β) : β ≃ α := ⟨e.inv_fun, e.to_fun⟩
 
 /-- See Note [custom simps projection] -/
 def equiv.simps.inv_fun (e : α ≃ β) : β → α := e.symm
-@[simps] def equiv.trans (e₁ : α ≃ β) (e₂ : β ≃ γ) : α ≃ γ :=
-⟨e₂ ∘ e₁, e₁.symm ∘ e₂.symm⟩
 
 /-- Composition of equivalences `e₁ : α ≃ β` and `e₂ : β ≃ γ`. -/
 @[simps {simp_rhs := tt}] protected def equiv.trans (e₁ : α ≃ β) (e₂ : β ≃ γ) : α ≃ γ :=

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -597,3 +597,6 @@ begin
 end
 
 end nested_non_fully_applied
+
+/- fail if you add an attribute with a parameter. -/
+run_cmd success_if_fail $ simps_tac `foo.rfl { attrs := [`higher_order] }

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -1,6 +1,7 @@
 import tactic.simps
 
-set_option trace.simps.verbose true
+-- set_option trace.simps.verbose true
+-- set_option trace.app_builder true
 
 open function tactic expr
 
@@ -21,8 +22,6 @@ def myprod.map {α α' β β'} (f : α → α') (g : β → β') (x : my_prod α
 ⟨f x.1, g x.2⟩
 
 namespace foo
-
--- set_option trace.app_builder true
 
 @[simps] protected def rfl {α} : α ≃ α :=
 ⟨id, λ x, x, λ x, rfl, λ x, rfl⟩

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -178,16 +178,14 @@ structure very_partially_applied_str :=
 (data : ∀β, ℕ → β → my_prod ℕ β)
 
 /- if we have a partially applied constructor, we treat it as if it were eta-expanded -/
-/- This is no longer supported, (it is useless) -/
+@[simps]
+-- def very_partially_applied_term : very_partially_applied_str := ⟨@my_prod.mk ℕ⟩
+def very_partially_applied_term : very_partially_applied_str := ⟨λ x y z, my_prod.mk y z⟩
 
--- @[simps]
--- -- def very_partially_applied_term : very_partially_applied_str := ⟨@my_prod.mk ℕ⟩
--- def very_partially_applied_term : very_partially_applied_str := ⟨λ x y z, my_prod.mk y z⟩
-
--- run_cmd do
---   e ← get_env,
---   e.get `very_partially_applied_term_data_fst,
---   e.get `very_partially_applied_term_data_snd
+run_cmd do
+  e ← get_env,
+  e.get `very_partially_applied_term_data_fst,
+  e.get `very_partially_applied_term_data_snd
 
 @[simps] def let1 : ℕ × ℤ :=
 let n := 3 in ⟨n + 4, 5⟩

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -101,7 +101,7 @@ run_cmd do
 /- check projections for nested structures -/
 
 namespace count_nested
-@[simps] def nested1 : my_prod ℕ $ my_prod ℤ ℕ :=
+@[simps {attrs := [`simp, `norm]}] def nested1 : my_prod ℕ $ my_prod ℤ ℕ :=
 ⟨2, -1, 1⟩
 
 @[simps {attrs := []}] def nested2 : ℕ × my_prod ℕ ℕ :=

--- a/test/tactics.lean
+++ b/test/tactics.lean
@@ -566,3 +566,22 @@ begin
 end
 
 end local_definitions
+
+section set_attribute
+
+@[user_attribute] meta def my_user_attribute : user_attribute unit bool :=
+{ name := `my_attr,
+  descr := "",
+  parser := return ff }
+
+run_cmd do nm ← get_user_attribute_name `library_note, guard $ nm = `library_note_attr
+run_cmd do nm ← get_user_attribute_name `higher_order, guard $ nm = `tactic.higher_order_attr
+run_cmd do success_if_fail $ get_user_attribute_name `zxy.xzy
+
+run_cmd set_attribute `norm `prod.map tt
+run_cmd success_if_fail $ set_attribute `higher_order `prod.map tt
+run_cmd success_if_fail $ set_attribute `my_attr `prod.map
+run_cmd success_if_fail $ set_attribute `norm `xyz.zxy
+run_cmd success_if_fail $ set_attribute `zxy.xyz `prod.map
+
+end attribute

--- a/test/tactics.lean
+++ b/test/tactics.lean
@@ -586,4 +586,4 @@ run_cmd success_if_fail $ set_attribute `my_attr `prod.map
 run_cmd success_if_fail $ set_attribute `norm `xyz.zxy
 run_cmd success_if_fail $ set_attribute `zxy.xyz `prod.map
 
-end attribute
+end set_attribute

--- a/test/tactics.lean
+++ b/test/tactics.lean
@@ -569,6 +569,8 @@ end local_definitions
 
 section set_attribute
 
+open tactic
+
 @[user_attribute] meta def my_user_attribute : user_attribute unit bool :=
 { name := `my_attr,
   descr := "",


### PR DESCRIPTION
Features:
* `@[simps]` will look for `has_coe_to_sort` and `has_coe_to_fun` instances, and use those instead of direct projections. This should make it way more applicable for `equiv`, `local_equiv` and all other structures that coerce to a function (and for the few structures that coerce to a type). This works out-of-the-box without special configuration.
* Use `has_mul.mul`, `has_zero.zero` and all the other "notation projections" instead of the projections directly. This should make it more useful in category theory and the algebraic hierarchy (note: the `[notation_class]` attribute still needs to be added to all notation classes not defined in `init.core`)
* Add an easy way to specify custom projections of structures (like using `⇑e.symm` instead of `e.inv_fun`). They have to be definitionally equal to the projection.

Minor changes:
* Change the syntax to specify options.
* `prod` (and `pprod`) are treated as a special case: we do not recursively apply projections of these structure. This was the most common reason that we had to write the desired projections manually. You can still override this behavior by writing out the projections manually.
* A flag to apply `simp` to the rhs of the generated lemma, so that they are in simp-normal-form.
* Added an options to add more attributes to the generated lemmas
* Added an option which definitions to unfold to determine whether a type is a function type. By default it will unfold reducible definitions and instances (but e.g. not `set α`)
* Added an option to unfold definitions in the declaration to determine whether it is a constructor. (default: none)
* Added an option to not fully-apply the terms in the generated lemmas.

Design decisions:
* For every field in a structure there is a specified "projection expression" that acts as the projection for that field. For most fields this is just the projection of the structure, but this will be automatically overridden under certain conditions, like a coercion to functions/sorts existing, or a notation typeclass existing for a certain field.
* The first time you call `simps` for a specific structure, these projection expressions are cached using an attribute for that structure, and it is assumed you want to use the same projection expressions every time.
* You can also manually specify the projection. See Note [custom simps projection].
---
<!-- put comments you want to keep out of the PR commit here -->



Comments, concerns, additional feature requests and trying out this branch are all very welcome!
@sgouezel @semorrison 

Similar to the old PR #1693 by @cipher1024. I started from scratch, because I wanted to make some design decisions differently.
