### PR TITLE
[Merged by Bors] - feat(algebra/invertible): lemmas

### DIFF
--- a/src/algebra/invertible.lean
+++ b/src/algebra/invertible.lean
@@ -181,6 +181,10 @@ def invertible_of_char_p_not_dvd {K : Type*} [field K] {p : ℕ} [char_p K p]
   {t : ℕ} (not_dvd : ¬(p ∣ t)) : invertible (t : K) :=
 invertible_of_nonzero (λ h, not_dvd ((char_p.cast_eq_zero_iff K p t).mp h))
 
+instance invertible_of_pos {K : Type*} [field K] [char_zero K] (n : ℕ) [h : fact (0 < n)] :
+  invertible (n : K) :=
+invertible_of_nonzero $ by simpa [nat.pos_iff_ne_zero] using h
+
 end char_p
 
 section division_ring

--- a/src/algebra/invertible.lean
+++ b/src/algebra/invertible.lean
@@ -165,6 +165,15 @@ def invertible_inv {a : α} [invertible a] : invertible (a⁻¹) :=
 
 end group_with_zero
 
+/--
+Monoid homs preserve invertibility.
+-/
+def invertible.map {R : Type*} {S : Type*} [monoid R] [monoid S] (f : R →* S) (r : R) [invertible r] :
+  invertible (f r) :=
+{ inv_of := f (⅟r),
+  inv_of_mul_self := by rw [← f.map_mul, inv_of_mul_self, f.map_one],
+  mul_inv_of_self := by rw [← f.map_mul, mul_inv_of_self, f.map_one] }
+
 section ring_char
 
 /-- A natural number `t` is invertible in a field `K` if the charactistic of `K` does not divide `t`. -/


### PR DESCRIPTION
Coauthored by: Johan Commelin <johan@commelin.net>
---
<!-- put comments you want to keep out of the PR commit here -->

More from @jcommelin 's Witt vector project.

I notice that nothing in `invertible.lean` is namespaced. Intentional or an oversight?