### PR TITLE
[Merged by Bors] - fix(ring_theory/jacobson): Clean up documentation in Jacobson Ring definitions

### DIFF
--- a/src/ring_theory/ideal_operations.lean
+++ b/src/ring_theory/ideal_operations.lean
@@ -811,8 +811,7 @@ begin
     cases (set.mem_image _ _ _).mp hj with J hJ,
     rw [← hJ.right, ← hx.right],
     exact mem_map_of_mem (Inf_le_of_le hJ.left (le_of_eq rfl) hx.left) },
-  {
-    intros y hy,
+  { intros y hy,
     cases hf y with x hx,
     rw ← hx,
     refine mem_map_of_mem _,
@@ -821,14 +820,12 @@ begin
     intros J hJ,
     have : y ∈ map f J := hy (map f J) J hJ rfl,
     cases (mem_map_iff_of_surjective f hf).1 this with x' hx',
-    have : x - x' ∈ J, {
-      apply h J hJ,
+    have : x - x' ∈ J,
+    { apply h J hJ,
       rw [ring_hom.mem_ker, ring_hom.map_sub, hx, hx'.right],
-      exact sub_self y
-    },
+      exact sub_self y },
     have := J.add_mem this hx'.left,
-    rwa [sub_add, sub_self, sub_zero] at this,
-  }
+    rwa [sub_add, sub_self, sub_zero] at this }
 end
 
 end ideal

--- a/src/ring_theory/jacobson.lean
+++ b/src/ring_theory/jacobson.lean
@@ -9,7 +9,7 @@ import ring_theory.ideal_operations
 import ring_theory.jacobson_ideal
 
 /-!
-# Jacobson rings
+# Jacobson Rings
 
 The following conditions are equivalent for a ring `R`:
 1. Every radical ideal `I` is equal to its jacobson radical
@@ -44,11 +44,12 @@ section is_jacobson
 variables {R : Type u} [comm_ring R] {I : ideal R}
 variables {S : Type v} [comm_ring S]
 
-/-- Definition of jacobson rings in terms of radical ideals -/
+/-- A ring is a Jacobson ring if for every radical ideal `I`, the Jacobson radical of `I` is equal to `I`.
+See `is_jacobson_iff_prime_eq` and `is_jacobson_iff_Inf_maximal` for equivalent characterisations. -/
 @[class] def is_jacobson (R : Type u) [comm_ring R] :=
     ∀ (I : ideal R), I.radical = I → I.jacobson = I
 
-/-- Defining jacobson rings in terms of prime ideals is completely equivalent -/
+/--  A ring is a Jacobson ring if and only if for all prime ideals `P` the Jacobson radical of `P` is equal to `P`. -/
 lemma is_jacobson_iff_prime_eq : is_jacobson R ↔ ∀ P : ideal R, is_prime P → P.jacobson = P :=
 begin
   split,
@@ -62,7 +63,7 @@ begin
     exact λ J hJ, hx ⟨le_trans hP.left hJ.left, hJ.right⟩ }
 end
 
-/-- I equals its jacobson iff it can be written as an Inf of maximal ideals -/
+/-- A ring `R` is Jacobson if and only if every radical ideal is the infimum of a collection of maximal ideals. -/
 lemma is_jacobson_iff_Inf_maximal : is_jacobson R ↔
     ∀ {I : ideal R}, I.radical = I → ∃ M ⊆ {J : ideal R | J.is_maximal ∨ J = ⊤}, I = Inf M :=
 begin

--- a/src/ring_theory/jacobson_ideal.lean
+++ b/src/ring_theory/jacobson_ideal.lean
@@ -29,11 +29,11 @@ Let `R` be a commutative ring, and `I` be an ideal of `R`
 
 * `mem_jacobson_iff` gives a characterization of members of the jacobson of I
 
-* `is_local_of_is_maximal_radical` says that if the regular radical of I is maximal then so is the jacobson radical
+* `is_local_of_is_maximal_radical`: if the radical of I is maximal then so is the jacobson radical
 
 ## Tags
 
-Jacobson, Jacobson Radical, Local Ideal
+Jacobson, Jacobson radical, Local Ideal
 
 -/
 

--- a/src/ring_theory/jacobson_ideal.lean
+++ b/src/ring_theory/jacobson_ideal.lean
@@ -5,6 +5,36 @@ Authors: Kenny Lau, Devon Tuma
 -/
 import ring_theory.ideal_operations
 
+/-!
+# Jacobson Radical
+
+The Jacobson Radical of a ring `R` is defined to be the intersection of all maximal ideals of `R`.
+This is similar to how the nilradical of `R` is equal to the intersection of all prime ideals of `R`.
+
+We can extend the idea of the nilradical to ideals of `R`, by letting the radical of an ideal `I` be the intersection of prime ideals containing `I`.
+Under this extension, the original nilradical is the radical of the zero ideal `⊥`.
+Here we define the Jacobson Radical of an ideal `I` in a similar way, as the intersection of maximal ideals containing `I`.
+
+## Main definitions
+
+Let `R` be a commutative ring, and `I` be an ideal of `R`
+
+* `jacobson I` is the jacobson radical, i.e. the infimum of all maximal ideals containing I.
+
+* `is_local I` is the proposition that the jacobson radical of `I` is itself a maximal ideal
+
+## Main statements
+
+* `mem_jacobson_iff` gives a characterization of members of the jacobson of I
+
+* `is_local_of_is_maximal_radical` says that if the regular radical of I is maximal then so is the jacobson radical
+
+## Tags
+
+Jacobson, Jacobson Radical, Local Ideal
+
+-/
+
 universes u v
 
 namespace ideal

--- a/src/ring_theory/jacobson_ideal.lean
+++ b/src/ring_theory/jacobson_ideal.lean
@@ -6,14 +6,16 @@ Authors: Kenny Lau, Devon Tuma
 import ring_theory.ideal_operations
 
 /-!
-# Jacobson Radical
+# Jacobson radical
 
-The Jacobson Radical of a ring `R` is defined to be the intersection of all maximal ideals of `R`.
-This is similar to how the nilradical of `R` is equal to the intersection of all prime ideals of `R`.
+The Jacobson radical of a ring `R` is defined to be the intersection of all maximal ideals of `R`.
+This is similar to how the nilradical is equal to the intersection of all prime ideals of `R`.
 
-We can extend the idea of the nilradical to ideals of `R`, by letting the radical of an ideal `I` be the intersection of prime ideals containing `I`.
+We can extend the idea of the nilradical to ideals of `R`,
+by letting the radical of an ideal `I` be the intersection of prime ideals containing `I`.
 Under this extension, the original nilradical is the radical of the zero ideal `⊥`.
-Here we define the Jacobson Radical of an ideal `I` in a similar way, as the intersection of maximal ideals containing `I`.
+Here we define the Jacobson radical of an ideal `I` in a similar way,
+as the intersection of maximal ideals containing `I`.
 
 ## Main definitions
 


### PR DESCRIPTION
Fixes to formatting and documentation found after merging the definition of Jacobson Rings in https://github.com/leanprover-community/mathlib/pull/3404 
