### PR TITLE
[Merged by Bors] - chore(*): remove `plift` from some lemmas about `infi`/`supr`

### DIFF
--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -261,12 +261,18 @@ def prop_equiv_punit {p : Prop} (h : p) : p ≃ punit :=
 def true_equiv_punit : true ≃ punit := prop_equiv_punit trivial
 
 /-- `ulift α` is equivalent to `α`. -/
-protected def ulift {α : Type u} : ulift α ≃ α :=
+protected def ulift {α : Type v} : ulift.{u} α ≃ α :=
 ⟨ulift.down, ulift.up, ulift.up_down, λ a, rfl⟩
+
+@[simp] lemma coe_ulift {α : Type v} : ⇑(@equiv.ulift.{u} α) = ulift.down := rfl
+@[simp] lemma coe_ulift_symm {α : Type v} : ⇑(@equiv.ulift.{u} α).symm = ulift.up := rfl
 
 /-- `plift α` is equivalent to `α`. -/
 protected def plift : plift α ≃ α :=
 ⟨plift.down, plift.up, plift.up_down, plift.down_up⟩
+
+@[simp] lemma coe_plift : ⇑(@equiv.plift α) = plift.down := rfl
+@[simp] lemma coe_plift_symm : ⇑(@equiv.plift α).symm = plift.up := rfl
 
 /-- equivalence of propositions is the same as iff -/
 def of_iff {P Q : Prop} (h : P ↔ Q) : P ≃ Q :=

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -352,33 +352,33 @@ end multiset
 
 
 section lattice
-variables {ι : Sort*} [complete_lattice α]
+variables {ι : Type*} [complete_lattice α]
 
 lemma supr_eq_supr_finset (s : ι → α) :
-  (⨆i, s i) = (⨆t:finset (plift ι), ⨆i∈t, s (plift.down i)) :=
+  (⨆i, s i) = (⨆t:finset ι, ⨆i∈t, s i) :=
 begin
   classical,
   exact le_antisymm
-    (supr_le $ assume b, le_supr_of_le {plift.up b} $ le_supr_of_le (plift.up b) $ le_supr_of_le
+    (supr_le $ assume b, le_supr_of_le {b} $ le_supr_of_le b $ le_supr_of_le
       (by simp) $ le_refl _)
     (supr_le $ assume t, supr_le $ assume b, supr_le $ assume hb, le_supr _ _)
 end
 
 lemma infi_eq_infi_finset (s : ι → α) :
-  (⨅i, s i) = (⨅t:finset (plift ι), ⨅i∈t, s (plift.down i)) :=
+  (⨅i, s i) = (⨅t:finset ι, ⨅i∈t, s i) :=
 @supr_eq_supr_finset (order_dual α) _ _ _
 
 end lattice
 
 namespace set
-variables {ι : Sort*}
+variables {ι : Type*}
 
 lemma Union_eq_Union_finset (s : ι → set α) :
-  (⋃i, s i) = (⋃t:finset (plift ι), ⋃i∈t, s (plift.down i)) :=
+  (⋃i, s i) = (⋃t:finset ι, ⋃i∈t, s i) :=
 supr_eq_supr_finset s
 
 lemma Inter_eq_Inter_finset (s : ι → set α) :
-  (⋂i, s i) = (⋂t:finset (plift ι), ⋂i∈t, s (plift.down i)) :=
+  (⋂i, s i) = (⋂t:finset ι, ⋂i∈t, s i) :=
 infi_eq_infi_finset s
 
 end set

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -352,8 +352,11 @@ end multiset
 
 
 section lattice
-variables {ι : Type*} [complete_lattice α]
+variables {ι : Type*} {ι' : Sort*} [complete_lattice α]
 
+/-- Supremum of `s i`, `i : ι`, is equal to the supremum over `t : finset ι` of suprema
+`⨆ i ∈ t, s i`. This version assumes `ι` is a `Type*`. See `supr_eq_supr_finset'` for a version
+that works for `ι : Sort*`. -/
 lemma supr_eq_supr_finset (s : ι → α) :
   (⨆i, s i) = (⨆t:finset ι, ⨆i∈t, s i) :=
 begin
@@ -364,22 +367,60 @@ begin
     (supr_le $ assume t, supr_le $ assume b, supr_le $ assume hb, le_supr _ _)
 end
 
+/-- Supremum of `s i`, `i : ι`, is equal to the supremum over `t : finset ι` of suprema
+`⨆ i ∈ t, s i`. This version works for `ι : Sort*`. See `supr_eq_supr_finset` for a version
+that assumes `ι : Type*` but has no `plift`s. -/
+lemma supr_eq_supr_finset' (s : ι' → α) :
+  (⨆i, s i) = (⨆t:finset (plift ι'), ⨆i∈t, s (plift.down i)) :=
+by rw [← supr_eq_supr_finset, ← equiv.plift.surjective.supr_comp]; refl
+
+/-- Infimum of `s i`, `i : ι`, is equal to the infimum over `t : finset ι` of infima
+`⨆ i ∈ t, s i`. This version assumes `ι` is a `Type*`. See `infi_eq_infi_finset'` for a version
+that works for `ι : Sort*`. -/
 lemma infi_eq_infi_finset (s : ι → α) :
   (⨅i, s i) = (⨅t:finset ι, ⨅i∈t, s i) :=
 @supr_eq_supr_finset (order_dual α) _ _ _
 
+/-- Infimum of `s i`, `i : ι`, is equal to the infimum over `t : finset ι` of infima
+`⨆ i ∈ t, s i`. This version works for `ι : Sort*`. See `infi_eq_infi_finset` for a version
+that assumes `ι : Type*` but has no `plift`s. -/
+lemma infi_eq_infi_finset' (s : ι' → α) :
+  (⨅i, s i) = (⨅t:finset (plift ι'), ⨅i∈t, s (plift.down i)) :=
+@supr_eq_supr_finset' (order_dual α) _ _ _
+
 end lattice
 
 namespace set
-variables {ι : Type*}
+variables {ι : Type*} {ι' : Sort*}
 
+/-- Union of an indexed family of sets `s : ι → set α` is equal to the union of the unions
+of finite subfamilies. This version assumes `ι : Type*`. See also `Union_eq_Union_finset'` for
+a version that works for `ι : Sort*`. -/
 lemma Union_eq_Union_finset (s : ι → set α) :
   (⋃i, s i) = (⋃t:finset ι, ⋃i∈t, s i) :=
 supr_eq_supr_finset s
 
+/-- Union of an indexed family of sets `s : ι → set α` is equal to the union of the unions
+of finite subfamilies. This version works for `ι : Sort*`. See also `Union_eq_Union_finset` for
+a version that assumes `ι : Type*` but avoids `plift`s in the right hand side. -/
+lemma Union_eq_Union_finset' (s : ι' → set α) :
+  (⋃i, s i) = (⋃t:finset (plift ι'), ⋃i∈t, s (plift.down i)) :=
+supr_eq_supr_finset' s
+
+/-- Intersection of an indexed family of sets `s : ι → set α` is equal to the intersection of the
+intersections of finite subfamilies. This version assumes `ι : Type*`. See also
+`Inter_eq_Inter_finset'` for a version that works for `ι : Sort*`. -/
 lemma Inter_eq_Inter_finset (s : ι → set α) :
   (⋂i, s i) = (⋂t:finset ι, ⋂i∈t, s i) :=
 infi_eq_infi_finset s
+
+/-- Intersection of an indexed family of sets `s : ι → set α` is equal to the intersection of the
+intersections of finite subfamilies. This version works for `ι : Sort*`. See also
+`Inter_eq_Inter_finset` for a version that assumes `ι : Type*` but avoids `plift`s in the right
+hand side. -/
+lemma Inter_eq_Inter_finset' (s : ι' → set α) :
+  (⋂i, s i) = (⋂t:finset (plift ι'), ⋂i∈t, s (plift.down i)) :=
+infi_eq_infi_finset' s
 
 end set
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1584,9 +1584,9 @@ by { intros s t h, rw [←preimage_image_eq s hf, ←preimage_image_eq t hf, h] 
 lemma surjective.range_eq {f : ι → α} (hf : surjective f) : range f = univ :=
 range_iff_surjective.2 hf
 
-lemma surjective.range_comp (g : α → β) {f : ι → α} (hf : surjective f) :
+lemma surjective.range_comp {ι' : Sort*} {f : ι → ι'} (hf : surjective f) (g : ι' → α) :
   range (g ∘ f) = range g :=
-by rw [range_comp, hf.range_eq, image_univ]
+ext $ λ y, (@surjective.exists _ _ _ hf (λ x, g x = y)).symm
 
 lemma injective.nonempty_apply_iff {f : set α → set β} (hf : injective f)
   (h2 : f ∅ = ∅) {s : set α} : (f s).nonempty ↔ s.nonempty :=

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -404,16 +404,15 @@ begin
   { rw finset.sup_empty,
     apply linear_independent_empty_type (not_nonempty_iff_imp_false.2 _),
     exact λ x, set.not_mem_empty x (subtype.mem x) },
-  { rintros ⟨i⟩ s his ih,
+  { rintros i s his ih,
     rw [finset.sup_insert],
     refine (hl _).union ih _,
     rw [finset.sup_eq_supr],
     refine (hd i _ _ his).mono_right _,
     { simp only [(span_Union _).symm],
       refine span_mono (@supr_le_supr2 (set M) _ _ _ _ _ _),
-      rintros ⟨i⟩, exact ⟨i, le_refl _⟩ },
-    { change finite (plift.up ⁻¹' ↑s),
-      exact s.finite_to_set.preimage (assume i j _ _, plift.up.inj) } }
+      rintros i, exact ⟨i, le_refl _⟩ },
+    { exact s.finite_to_set } }
 end
 
 lemma linear_independent_Union_finite {η : Type*} {ιs : η → Type*}

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -351,21 +351,19 @@ lemma monotone.supr_comp_eq [preorder β] {f : β → α} (hf : monotone f)
   (⨆ x, f (s x)) = ⨆ y, f y :=
 le_antisymm (supr_comp_le _ _) (supr_le_supr2 $ λ x, (hs x).imp $ λ i hi, hf hi)
 
-lemma supr_congr {f : β → α} {g : β₂ → α} (h : β → β₂)
-  (h1 : function.surjective h) (h2 : ∀ x, g (h x) = f x) : (⨆ x, f x) = ⨆ y, g y :=
-by { unfold supr, congr' 1, convert h1.range_comp g, ext, rw ←h2 }
+lemma function.surjective.supr_comp {α : Type*} [has_Sup α] {f : ι → ι₂}
+  (hf : function.surjective f) (g : ι₂ → α) :
+  (⨆ x, g (f x)) = ⨆ y, g y :=
+by simp only [supr, hf.range_comp]
 
 -- TODO: finish doesn't do well here.
 @[congr] theorem supr_congr_Prop {α : Type*} [has_Sup α] {p q : Prop} {f₁ : p → α} {f₂ : q → α}
   (pq : p ↔ q) (f : ∀x, f₁ (pq.mpr x) = f₂ x) : supr f₁ = supr f₂ :=
 begin
-  unfold supr,
-  apply congr_arg,
-  ext,
-  simp,
-  split,
-  exact λ⟨h, W⟩, ⟨pq.1 h, eq.trans (f (pq.1 h)).symm W⟩,
-  exact λ⟨h, W⟩, ⟨pq.2 h, eq.trans (f h) W⟩
+  have : f₁ ∘ pq.mpr = f₂ := funext f,
+  rw [← this],
+  refine (function.surjective.supr_comp (λ h, ⟨pq.1 h, _⟩) f₁).symm,
+  refl
 end
 
 theorem infi_le (s : ι → α) (i : ι) : infi s ≤ s i :=
@@ -441,21 +439,14 @@ lemma monotone.infi_comp_eq [preorder β] {f : β → α} (hf : monotone f)
   (⨅ x, f (s x)) = ⨅ y, f y :=
 le_antisymm (infi_le_infi2 $ λ x, (hs x).imp $ λ i hi, hf hi) (le_infi_comp _ _)
 
-lemma infi_congr {f : β → α} {g : β₂ → α} (h : β → β₂)
-  (h1 : function.surjective h) (h2 : ∀ x, g (h x) = f x) : (⨅ x, f x) = ⨅ y, g y :=
-by { unfold infi, congr' 1, convert h1.range_comp g, ext, rw ←h2 }
+lemma function.surjective.infi_comp {α : Type*} [has_Inf α] {f : ι → ι₂}
+  (hf : function.surjective f) (g : ι₂ → α) :
+  (⨅ x, g (f x)) = ⨅ y, g y :=
+@function.surjective.supr_comp _ _ (order_dual α) _ f hf g
 
 @[congr] theorem infi_congr_Prop {α : Type*} [has_Inf α] {p q : Prop} {f₁ : p → α} {f₂ : q → α}
   (pq : p ↔ q) (f : ∀x, f₁ (pq.mpr x) = f₂ x) : infi f₁ = infi f₂ :=
-begin
-  unfold infi,
-  apply congr_arg,
-  ext,
-  simp,
-  split,
-  exact λ⟨h, W⟩, ⟨pq.1 h, eq.trans (f (pq.1 h)).symm W⟩,
-  exact λ⟨h, W⟩, ⟨pq.2 h, eq.trans (f h) W⟩
-end
+@supr_congr_Prop (order_dual α) _ p q f₁ f₂ pq f
 
 -- We will generalize this to conditionally complete lattices in `cinfi_const`.
 theorem infi_const [nonempty ι] {a : α} : (⨅ b:ι, a) = a :=

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -598,17 +598,16 @@ lemma mem_binfi {f : β → filter α} {s : set β}
   t ∈ (⨅ i∈s, f i) ↔ ∃ i ∈ s, t ∈ f i :=
 by simp only [binfi_sets_eq h ne, mem_bUnion_iff]
 
-lemma infi_sets_eq_finite (f : ι → filter α) :
-  (⨅i, f i).sets = (⋃t:finset (plift ι), (⨅i∈t, f (plift.down i)).sets) :=
+lemma infi_sets_eq_finite {ι : Type*} (f : ι → filter α) :
+  (⨅i, f i).sets = (⋃t:finset ι, (⨅i∈t, f i).sets) :=
 begin
   rw [infi_eq_infi_finset, infi_sets_eq],
   exact (directed_of_sup $ λs₁ s₂ hs, infi_le_infi $ λi, infi_le_infi_const $ λh, hs h),
 end
 
-lemma mem_infi_finite {f : ι → filter α} (s) :
-  s ∈ infi f ↔ s ∈ ⋃t:finset (plift ι), (⨅i∈t, f (plift.down i)).sets :=
-show  s ∈ (infi f).sets ↔ s ∈ ⋃t:finset (plift ι), (⨅i∈t, f (plift.down i)).sets,
-by rw infi_sets_eq_finite
+lemma mem_infi_finite {ι : Type*} {f : ι → filter α} (s) :
+  s ∈ infi f ↔ s ∈ ⋃t:finset ι, (⨅i∈t, f i).sets :=
+set.ext_iff.1 (infi_sets_eq_finite f) s
 
 @[simp] lemma sup_join {f₁ f₂ : filter (filter α)} : (join f₁ ⊔ join f₂) = join (f₁ ⊔ f₂) :=
 filter_eq $ set.ext $ assume x,
@@ -640,7 +639,7 @@ lemma infi_sup_eq {f : filter α} {g : ι → filter α} : (⨅ x, f ⊔ g x) = 
 begin
   refine le_antisymm _ (le_infi $ assume i, sup_le_sup_left (infi_le _ _) _),
   rintros t ⟨h₁, h₂⟩,
-  rw [infi_sets_eq_finite] at h₂,
+  rw [← equiv.plift.surjective.infi_comp, infi_sets_eq_finite] at h₂,
   simp only [mem_Union, (finset.inf_eq_infi _ _).symm] at h₂,
   rcases h₂ with ⟨s, hs⟩,
   suffices : (⨅i, f ⊔ g i) ≤ f ⊔ s.inf (λi, g i.down), { exact this ⟨h₁, hs⟩ },
@@ -720,7 +719,7 @@ lemma infi_sets_induct {f : ι → filter α} {s : set α} (hs : s ∈ infi f) {
   (ins : ∀{i s₁ s₂}, s₁ ∈ f i → p s₂ → p (s₁ ∩ s₂))
   (upw : ∀{s₁ s₂}, s₁ ⊆ s₂ → p s₁ → p s₂) : p s :=
 begin
-  rw [mem_infi_finite] at hs,
+  rw [← equiv.plift.surjective.infi_comp, mem_infi_finite] at hs,
   simp only [mem_Union, (finset.inf_eq_infi _ _).symm] at hs,
   rcases hs with ⟨is, his⟩,
   revert s,

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -605,9 +605,17 @@ begin
   exact (directed_of_sup $ λs₁ s₂ hs, infi_le_infi $ λi, infi_le_infi_const $ λh, hs h),
 end
 
+lemma infi_sets_eq_finite' (f : ι → filter α) :
+  (⨅i, f i).sets = (⋃t:finset (plift ι), (⨅i∈t, f (plift.down i)).sets) :=
+by rw [← infi_sets_eq_finite, ← equiv.plift.surjective.infi_comp]; refl
+
 lemma mem_infi_finite {ι : Type*} {f : ι → filter α} (s) :
   s ∈ infi f ↔ s ∈ ⋃t:finset ι, (⨅i∈t, f i).sets :=
 set.ext_iff.1 (infi_sets_eq_finite f) s
+
+lemma mem_infi_finite' {f : ι → filter α} (s) :
+  s ∈ infi f ↔ s ∈ ⋃t:finset (plift ι), (⨅i∈t, f (plift.down i)).sets :=
+set.ext_iff.1 (infi_sets_eq_finite' f) s
 
 @[simp] lemma sup_join {f₁ f₂ : filter (filter α)} : (join f₁ ⊔ join f₂) = join (f₁ ⊔ f₂) :=
 filter_eq $ set.ext $ assume x,
@@ -639,7 +647,7 @@ lemma infi_sup_eq {f : filter α} {g : ι → filter α} : (⨅ x, f ⊔ g x) = 
 begin
   refine le_antisymm _ (le_infi $ assume i, sup_le_sup_left (infi_le _ _) _),
   rintros t ⟨h₁, h₂⟩,
-  rw [← equiv.plift.surjective.infi_comp, infi_sets_eq_finite] at h₂,
+  rw [infi_sets_eq_finite'] at h₂,
   simp only [mem_Union, (finset.inf_eq_infi _ _).symm] at h₂,
   rcases h₂ with ⟨s, hs⟩,
   suffices : (⨅i, f ⊔ g i) ≤ f ⊔ s.inf (λi, g i.down), { exact this ⟨h₁, hs⟩ },
@@ -719,7 +727,7 @@ lemma infi_sets_induct {f : ι → filter α} {s : set α} (hs : s ∈ infi f) {
   (ins : ∀{i s₁ s₂}, s₁ ∈ f i → p s₂ → p (s₁ ∩ s₂))
   (upw : ∀{s₁ s₂}, s₁ ⊆ s₂ → p s₁ → p s₂) : p s :=
 begin
-  rw [← equiv.plift.surjective.infi_comp, mem_infi_finite] at hs,
+  rw [mem_infi_finite'] at hs,
   simp only [mem_Union, (finset.inf_eq_infi _ _).symm] at hs,
   rcases hs with ⟨is, his⟩,
   revert s,

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -760,14 +760,14 @@ quotient.sound ⟨⟨punit_equiv_punit, λ _ _, iff.rfl⟩⟩
   see `lift.initial_seg`. -/
 def lift (o : ordinal.{u}) : ordinal.{max u v} :=
 quotient.lift_on o (λ ⟨α, r, wo⟩,
-  @type _ _ (@order_embedding.is_well_order _ _ (@equiv.ulift.{u v} α ⁻¹'o r) r
-    (order_iso.preimage equiv.ulift.{u v} r) wo)) $
+  @type _ _ (@order_embedding.is_well_order _ _ (@equiv.ulift.{v} α ⁻¹'o r) r
+    (order_iso.preimage equiv.ulift.{v} r) wo)) $
 λ ⟨α, r, _⟩ ⟨β, s, _⟩ ⟨f⟩,
 quot.sound ⟨(order_iso.preimage equiv.ulift r).trans $
   f.trans (order_iso.preimage equiv.ulift s).symm⟩
 
 theorem lift_type {α} (r : α → α → Prop) [is_well_order α r] :
-  ∃ wo', lift (type r) = @type _ (@equiv.ulift.{u v} α ⁻¹'o r) wo' :=
+  ∃ wo', lift (type r) = @type _ (@equiv.ulift.{v} α ⁻¹'o r) wo' :=
 ⟨_, rfl⟩
 
 theorem lift_umax : lift.{u (max u v)} = lift.{u v} :=
@@ -803,10 +803,10 @@ quotient.eq.trans
 
 theorem lift_type_lt {α : Type u} {β : Type v} {r s} [is_well_order α r] [is_well_order β s] :
   lift.{u (max v w)} (type r) < lift.{v (max u w)} (type s) ↔ nonempty (r ≺i s) :=
-by haveI := @order_embedding.is_well_order _ _ (@equiv.ulift.{u (max v w)} α ⁻¹'o r)
-     r (order_iso.preimage equiv.ulift.{u (max v w)} r) _;
-   haveI := @order_embedding.is_well_order _ _ (@equiv.ulift.{v (max u w)} β ⁻¹'o s)
-     s (order_iso.preimage equiv.ulift.{v (max u w)} s) _; exact
+by haveI := @order_embedding.is_well_order _ _ (@equiv.ulift.{(max v w)} α ⁻¹'o r)
+     r (order_iso.preimage equiv.ulift.{(max v w)} r) _;
+   haveI := @order_embedding.is_well_order _ _ (@equiv.ulift.{(max u w)} β ⁻¹'o s)
+     s (order_iso.preimage equiv.ulift.{(max u w)} s) _; exact
 ⟨λ ⟨f⟩, ⟨(f.equiv_lt (order_iso.preimage equiv.ulift r).symm).lt_le
     (initial_seg.of_iso (order_iso.preimage equiv.ulift s))⟩,
  λ ⟨f⟩, ⟨(f.equiv_lt (order_iso.preimage equiv.ulift r)).lt_le


### PR DESCRIPTION
Now `supr_eq_supr_finset` etc assume `ι` is a `Type*` and don't use `plift`. If you want
to apply it to a `Sort*`, rewrite on `equiv.plift.surjective.supr_comp` first.

## Full list of API changes:

### `data/equiv/basic`

* `equiv.ulift`: change the order of universe arguments to match `ulift`;
* add `coe_ulift`, `coe_plift`, `coe_ulift_symm`, `coe_plift_symm`;

### `data/finset/lattice`

* `supr_eq_supr_finset`, `infi_eq_infi_finset`: assume `ι` is a `Type*`, avoid `plift`;
* `Union_eq_Union_finset`, `Inter_eq_Inter_finset`: same as above;

### `data/set/basic`

* `function.surjective.range_comp`: generalize to `Sort*` for 2 of 3 arguments;

### `order/complete_lattice`

* remove `supr_congr` and `infi_congr`;
* add `function.surjective.supr_comp` and `function.surjective.infi_comp`.

---
<!-- put comments you want to keep out of the PR commit here -->
