### PR TITLE
[Merged by Bors] - feat(tactic/linarith): put certificate generation in tactic monad

### DIFF
--- a/src/tactic/linarith/datatypes.lean
+++ b/src/tactic/linarith/datatypes.lean
@@ -266,7 +266,7 @@ This map represents that we can find a contradiction by taking the sum  `∑ (co
 The default `certificate_oracle` used by `linarith` is `linarith.fourier_motzkin.produce_certificate`
 -/
 meta def certificate_oracle : Type :=
-list comp → ℕ → option (rb_map ℕ ℕ)
+list comp → ℕ → tactic (rb_map ℕ ℕ)
 
 /-- A configuration object for `linarith`. -/
 meta structure linarith_config : Type :=

--- a/src/tactic/linarith/datatypes.lean
+++ b/src/tactic/linarith/datatypes.lean
@@ -257,7 +257,7 @@ meta instance : has_coe preprocessor global_preprocessor :=
 ⟨preprocessor.globalize⟩
 
 /--
-A `certificate_oracle` is a function `produce_certificate : list comp → ℕ → option (rb_map ℕ ℕ)`.
+A `certificate_oracle` is a function `produce_certificate : list comp → ℕ → tactic (rb_map ℕ ℕ)`.
 `produce_certificate hyps max_var` tries to derive a contradiction from the comparisons in `hyps`
 by eliminating all variables ≤ `max_var`.
 If successful, it returns a map `coeff : ℕ → ℕ` as a certificate.

--- a/src/tactic/linarith/elimination.lean
+++ b/src/tactic/linarith/elimination.lean
@@ -323,7 +323,7 @@ meta def fourier_motzkin.produce_certificate : certificate_oracle :=
 λ hyps max_var,
 let state := mk_linarith_structure hyps max_var in
 match except_t.run (state_t.run (validate >> elim_all_vars) state) with
-| (except.ok (a, _)) := none
+| (except.ok (a, _)) := tactic.failed
 | (except.error contr) := return contr.src.flatten
 end
 

--- a/src/tactic/linarith/elimination.lean
+++ b/src/tactic/linarith/elimination.lean
@@ -324,7 +324,7 @@ meta def fourier_motzkin.produce_certificate : certificate_oracle :=
 let state := mk_linarith_structure hyps max_var in
 match except_t.run (state_t.run (validate >> elim_all_vars) state) with
 | (except.ok (a, _)) := none
-| (except.error contr) := contr.src.flatten
+| (except.error contr) := return contr.src.flatten
 end
 
 end linarith

--- a/src/tactic/linarith/frontend.lean
+++ b/src/tactic/linarith/frontend.lean
@@ -75,7 +75,7 @@ disequality hypotheses, since this would lead to a number of runs exponential in
 disequalities in the context.
 
 The Fourier-Motzkin oracle is very modular. It can easily be replaced with another function of type
-`certificate_oracle := list comp → ℕ → option (rb_map ℕ ℕ)`,
+`certificate_oracle := list comp → ℕ → tactic (rb_map ℕ ℕ)`,
 which takes a list of comparisons and the largest variable
 index appearing in those comparisons, and returns a map from comparison indices to coefficients.
 An alternate oracle can be specified in the `linarith_config` object.

--- a/src/tactic/linarith/verification.lean
+++ b/src/tactic/linarith/verification.lean
@@ -163,7 +163,7 @@ meta def prove_false_by_linarith (cfg : linarith_config) : list expr → tactic 
     -- perform the elimination and fail if no contradiction is found.
     (comps, max_var) ← linear_forms_and_max_var cfg.transparency inputs,
     certificate ← cfg.oracle.get_or_else fourier_motzkin.produce_certificate comps max_var
-      | fail "linarith failed to find a contradiction",
+      <|> fail "linarith failed to find a contradiction",
     linarith_trace "linarith has found a contradiction",
     let enum_inputs := inputs.enum,
     -- construct a list pairing nonzero coeffs with the proof of their corresponding comparison


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->

Sorry, this should have gone into #3502 but I realized too late. I was pleasantly surprised at how small this change was! When I realized I needed it, I got worried it would be a pain.

I now (locally) have Mathematica plugged into `linarith` to compute certificates. Clearly I'm using the wrong Mathematica linear solver because it chokes on the `nlinarith` examples, but hey, proof of concept.