### PR TITLE
[Merged by Bors] - chore(topology/category/): switch to bundled morphisms in Top

### DIFF
--- a/docs/tutorial/category_theory/calculating_colimits_in_Top.lean
+++ b/docs/tutorial/category_theory/calculating_colimits_in_Top.lean
@@ -16,13 +16,13 @@ def pt : Top := Top.of unit
 section MappingCylinder
 -- Let's construct the mapping cylinder.
 def to_pt (X : Top) : X ⟶ pt :=
-{ val := λ _, unit.star, property := continuous_const }
+{ to_fun := λ _, unit.star, continuous_to_fun := continuous_const }
 def I₀ : pt ⟶ I :=
-{ val := λ _, ⟨(0 : ℝ), by norm_num [set.left_mem_Icc]⟩,
-  property := continuous_const }
+{ to_fun := λ _, ⟨(0 : ℝ), by norm_num [set.left_mem_Icc]⟩,
+  continuous_to_fun := continuous_const }
 def I₁ : pt ⟶ I :=
-{ val := λ _, ⟨(1 : ℝ), by norm_num [set.right_mem_Icc]⟩,
-  property := continuous_const }
+{ to_fun := λ _, ⟨(1 : ℝ), by norm_num [set.right_mem_Icc]⟩,
+  continuous_to_fun := continuous_const }
 
 def cylinder (X : Top) : Top := prod X I
 -- To define a map to the cylinder, we give a map to each factor.
@@ -71,7 +71,7 @@ end MappingCylinder
 section Gluing
 
 -- Here's two copies of the real line glued together at a point.
-def f : pt ⟶ R := { val := λ _, (0 : ℝ), property := continuous_const }
+def f : pt ⟶ R := { to_fun := λ _, (0 : ℝ), continuous_to_fun := continuous_const }
 
 /-- Two copies of the real line glued together at 0. -/
 def X : Top := pushout f f
@@ -102,6 +102,6 @@ pi.lift (λ (n : ℕ), ⟨λ (_ : pt), (n + 1 : ℝ), continuous_const⟩)
 -- `q.property` is the fact this function is continuous (i.e. no content, since `pt` is a singleton)
 
 -- We can check that this function is definitionally just the function we specified.
-example : (q.val ()).val (9 : ℕ) = ((10 : ℕ) : ℝ) := rfl
+example : (q ()).val (9 : ℕ) = ((10 : ℕ) : ℝ) := rfl
 
 end Products

--- a/src/algebraic_geometry/presheafed_space.lean
+++ b/src/algebraic_geometry/presheafed_space.lean
@@ -126,7 +126,7 @@ instance {X Y : PresheafedSpace C} : has_coe (X ⟶ Y) ((X : Top.{v}) ⟶ (Y : T
 
 -- see Note [function coercion]
 instance {X Y : PresheafedSpace C} : has_coe_to_fun (X ⟶ Y) :=
-⟨λ _, (X : Top.{v}) → Y.to_Top, λ h, h⟩
+⟨λ _, (X : Top.{v}) → (Y : Top.{v}), λ h, h⟩
 
 @[simp] lemma hom_mk_coe {X Y : PresheafedSpace C} (f) (c) :
   (({ f := f, c := c } : X ⟶ Y) : (X : Top.{v}) ⟶ (Y : Top.{v})) = f := rfl
@@ -209,7 +209,8 @@ def map_presheaf (F : C ⥤ D) : PresheafedSpace C ⥤ PresheafedSpace D :=
 @[simp] lemma map_presheaf_obj_𝒪 (F : C ⥤ D) (X : PresheafedSpace C) :
   (F.map_presheaf.obj X).𝒪 = X.𝒪 ⋙ F := rfl
 @[simp] lemma map_presheaf_map_f (F : C ⥤ D) {X Y : PresheafedSpace C} (f : X ⟶ Y) :
-  ((F.map_presheaf.map f) : (X : Top.{v}) ⟶ (Y : Top.{v})) = f := rfl
+  ((F.map_presheaf.map f) : (F.map_presheaf.obj X : Top.{v}) ⟶ (F.map_presheaf.obj Y : Top.{v})) =
+    (f : (X : Top.{v}) ⟶ (Y : Top.{v})) := rfl
 @[simp] lemma map_presheaf_map_c (F : C ⥤ D) {X Y : PresheafedSpace C} (f : X ⟶ Y) :
   (F.map_presheaf.map f).c = whisker_right f.c F := rfl
 

--- a/src/algebraic_geometry/stalks.lean
+++ b/src/algebraic_geometry/stalks.lean
@@ -39,7 +39,7 @@ namespace stalk_map
 begin
   dsimp [stalk_map],
   simp only [stalk_pushforward.id],
-  erw [←map_comp],
+  rw [←map_comp],
   convert (stalk_functor C x).map_id X.𝒪,
   tidy,
 end

--- a/src/algebraic_geometry/stalks.lean
+++ b/src/algebraic_geometry/stalks.lean
@@ -31,7 +31,7 @@ namespace algebraic_geometry.PresheafedSpace
 def stalk (X : PresheafedSpace C) (x : X) : C := X.𝒪.stalk x
 
 def stalk_map {X Y : PresheafedSpace C} (α : X ⟶ Y) (x : X) : Y.stalk (α x) ⟶ X.stalk x :=
-(stalk_functor C (α x)).map (α.c) ≫ X.𝒪.stalk_pushforward C α x
+(stalk_functor C (α x)).map (α.c) ≫ X.𝒪.stalk_pushforward C (α : (X : Top.{v}) ⟶ (Y : Top.{v})) x
 
 namespace stalk_map
 
@@ -39,7 +39,7 @@ namespace stalk_map
 begin
   dsimp [stalk_map],
   simp only [stalk_pushforward.id],
-  rw [←map_comp],
+  erw [←map_comp],
   convert (stalk_functor C x).map_id X.𝒪,
   tidy,
 end

--- a/src/topology/category/Top/adjunctions.lean
+++ b/src/topology/category/Top/adjunctions.lean
@@ -13,9 +13,8 @@ open Top
 
 namespace Top
 
--- FIXME deterministic timeout with `-T50000`
 /-- Equipping a type with the discrete topology is left adjoint to the forgetful functor `Top ⥤ Type`. -/
-def adj₁ : discrete ⊣ forget Top :=
+def adj₁ : discrete ⊣ forget Top.{u} :=
 { hom_equiv := λ X Y,
   { to_fun := λ f, f,
     inv_fun := λ f, ⟨f, continuous_bot⟩,
@@ -25,12 +24,12 @@ def adj₁ : discrete ⊣ forget Top :=
   counit := { app := λ X, ⟨id, continuous_bot⟩ } }
 
 /-- Equipping a type with the trivial topology is right adjoint to the forgetful functor `Top ⥤ Type`. -/
-def adj₂ : forget Top ⊣ trivial :=
+def adj₂ : forget Top.{u} ⊣ trivial :=
 { hom_equiv := λ X Y,
   { to_fun := λ f, ⟨f, continuous_top⟩,
     inv_fun := λ f, f,
     left_inv := λ X, rfl,
-    right_inv := λ Y, subtype.eq rfl, },
+    right_inv := λ Y, continuous_map.coe_inj rfl, },
   unit := { app := λ X, ⟨id, continuous_top⟩ },
   counit := { app := λ X, id }, }
 

--- a/src/topology/category/Top/basic.lean
+++ b/src/topology/category/Top/basic.lean
@@ -24,13 +24,11 @@ attribute [derive [has_coe_to_sort, large_category, concrete_category]] Top
 
 instance topological_space_unbundled (x : Top) : topological_space x := x.str
 
--- FIXME confirm safe to remove:
+@[simp] lemma id_app (X : Top.{u}) (x : X) :
+  (𝟙 X : X → X) x = x := rfl
 
--- instance hom_has_coe_to_fun (X Y : Top.{u}) : has_coe_to_fun (X ⟶ Y) :=
--- { F := _, coe := subtype.val }
-
--- @[simp] lemma id_app (X : Top.{u}) (x : X) :
---   @coe_fn (X ⟶ X) (Top.hom_has_coe_to_fun X X) (𝟙 X) x = x := rfl
+@[simp] lemma comp_app {X Y Z : Top.{u}} (f : X ⟶ Y) (g : Y ⟶ Z) (x : X) :
+  (f ≫ g : X → Z) x = g (f x) := rfl
 
 /-- Construct a bundled `Top` from the underlying type and the typeclass. -/
 def of (X : Type u) [topological_space X] : Top := ⟨X⟩

--- a/src/topology/category/Top/basic.lean
+++ b/src/topology/category/Top/basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Scott Morrison, Mario Carneiro
 -/
 import category_theory.concrete_category.unbundled_hom
+import topology.continuous_map
 import topology.opens
 
 open category_theory
@@ -16,32 +17,36 @@ def Top : Type (u+1) := bundled topological_space
 
 namespace Top
 
-instance : unbundled_hom @continuous :=
-⟨@continuous_id, @continuous.comp⟩
+instance bundled_hom : bundled_hom @continuous_map :=
+⟨@continuous_map.to_fun, @continuous_map.id, @continuous_map.comp, @continuous_map.coe_inj⟩
 
 attribute [derive [has_coe_to_sort, large_category, concrete_category]] Top
 
 instance topological_space_unbundled (x : Top) : topological_space x := x.str
 
-instance hom_has_coe_to_fun (X Y : Top.{u}) : has_coe_to_fun (X ⟶ Y) :=
-{ F := _, coe := subtype.val }
+-- FIXME confirm safe to remove:
 
-@[simp] lemma id_app (X : Top.{u}) (x : X) :
-  @coe_fn (X ⟶ X) (Top.hom_has_coe_to_fun X X) (𝟙 X) x = x := rfl
+-- instance hom_has_coe_to_fun (X Y : Top.{u}) : has_coe_to_fun (X ⟶ Y) :=
+-- { F := _, coe := subtype.val }
+
+-- @[simp] lemma id_app (X : Top.{u}) (x : X) :
+--   @coe_fn (X ⟶ X) (Top.hom_has_coe_to_fun X X) (𝟙 X) x = x := rfl
 
 /-- Construct a bundled `Top` from the underlying type and the typeclass. -/
 def of (X : Type u) [topological_space X] : Top := ⟨X⟩
+
+instance (X : Top) : topological_space X := X.str
 
 instance : inhabited Top := ⟨Top.of empty⟩
 
 /-- The discrete topology on any type. -/
 def discrete : Type u ⥤ Top.{u} :=
 { obj := λ X, ⟨X, ⊥⟩,
-  map := λ X Y f, ⟨f, continuous_bot⟩ }
+  map := λ X Y f, { to_fun := f, continuous_to_fun := continuous_bot } }
 
 /-- The trivial topology on any type. -/
 def trivial : Type u ⥤ Top.{u} :=
 { obj := λ X, ⟨X, ⊤⟩,
-  map := λ X Y f, ⟨f, continuous_top⟩ }
+  map := λ X Y f, { to_fun := f, continuous_to_fun := continuous_top } }
 
 end Top

--- a/src/topology/category/Top/limits.lean
+++ b/src/topology/category/Top/limits.lean
@@ -23,12 +23,12 @@ def limit (F : J ⥤ Top.{u}) : cone F :=
 { X := ⟨limit (F ⋙ forget), ⨅j, (F.obj j).str.induced (limit.π (F ⋙ forget) j)⟩,
   π :=
   { app := λ j, ⟨limit.π (F ⋙ forget) j, continuous_iff_le_induced.mpr (infi_le _ _)⟩,
-    naturality' := λ j j' f, subtype.eq ((limit.cone (F ⋙ forget)).π.naturality f) } }
+    naturality' := λ j j' f, continuous_map.coe_inj ((limit.cone (F ⋙ forget)).π.naturality f) } }
 
 def limit_is_limit (F : J ⥤ Top.{u}) : is_limit (limit F) :=
 by { refine is_limit.of_faithful forget (limit.is_limit _) (λ s, ⟨_, _⟩) (λ s, rfl),
      exact continuous_iff_coinduced_le.mpr (le_infi $ λ j,
-       coinduced_le_iff_le_induced.mp $ continuous_iff_coinduced_le.mp (s.π.app j).property) }
+       coinduced_le_iff_le_induced.mp $ continuous_iff_coinduced_le.mp (s.π.app j).continuous) }
 
 instance Top_has_limits : has_limits.{u} Top.{u} :=
 { has_limits_of_shape := λ J 𝒥,
@@ -44,12 +44,12 @@ def colimit (F : J ⥤ Top.{u}) : cocone F :=
 { X := ⟨colimit (F ⋙ forget), ⨆ j, (F.obj j).str.coinduced (colimit.ι (F ⋙ forget) j)⟩,
   ι :=
   { app := λ j, ⟨colimit.ι (F ⋙ forget) j, continuous_iff_coinduced_le.mpr (le_supr _ j)⟩,
-    naturality' := λ j j' f, subtype.eq ((colimit.cocone (F ⋙ forget)).ι.naturality f) } }
+    naturality' := λ j j' f, continuous_map.coe_inj ((colimit.cocone (F ⋙ forget)).ι.naturality f) } }
 
 def colimit_is_colimit (F : J ⥤ Top.{u}) : is_colimit (colimit F) :=
 by { refine is_colimit.of_faithful forget (colimit.is_colimit _) (λ s, ⟨_, _⟩) (λ s, rfl),
      exact continuous_iff_le_induced.mpr (supr_le $ λ j,
-       coinduced_le_iff_le_induced.mp $ continuous_iff_coinduced_le.mp (s.ι.app j).property) }
+       coinduced_le_iff_le_induced.mp $ continuous_iff_coinduced_le.mp (s.ι.app j).continuous) }
 
 instance Top_has_colimits : has_colimits.{u} Top.{u} :=
 { has_colimits_of_shape := λ J 𝒥,

--- a/src/topology/category/Top/opens.lean
+++ b/src/topology/category/Top/opens.lean
@@ -29,10 +29,10 @@ def to_Top (X : Top.{u}) : opens X ⥤ Top :=
 /-- `opens.map f` gives the functor from open sets in Y to open set in X,
     given by taking preimages under f. -/
 def map (f : X ⟶ Y) : opens Y ⥤ opens X :=
-{ obj := λ U, ⟨ f.val ⁻¹' U.val, f.property _ U.property ⟩,
+{ obj := λ U, ⟨ f ⁻¹' U.val, f.continuous _ U.property ⟩,
   map := λ U V i, ⟨ ⟨ λ a b, i.down.down b ⟩ ⟩ }.
 
-@[simp] lemma map_obj (f : X ⟶ Y) (U) (p) : (map f).obj ⟨U, p⟩ = ⟨ f.val ⁻¹' U, f.property _ p ⟩ :=
+@[simp] lemma map_obj (f : X ⟶ Y) (U) (p) : (map f).obj ⟨U, p⟩ = ⟨ f ⁻¹' U, f.continuous _ p ⟩ :=
 rfl
 
 @[simp] lemma map_id_obj (U : opens X) : (map (𝟙 X)).obj U = U :=

--- a/src/topology/category/UniformSpace.lean
+++ b/src/topology/category/UniformSpace.lean
@@ -51,9 +51,9 @@ lemma hom_ext {X Y : UniformSpace} {f g : X ⟶ Y} : (f : X → Y) = g → f = g
 
 /-- The forgetful functor from uniform spaces to topological spaces. -/
 instance has_forget_to_Top : has_forget₂ UniformSpace.{u} Top.{u} :=
-unbundled_hom.mk_has_forget₂
-  @uniform_space.to_topological_space
-  @uniform_continuous.continuous
+{ forget₂ :=
+  { obj := λ X, Top.of X,
+    map := λ X Y f, { to_fun := f, continuous_to_fun := uniform_continuous.continuous f.property }, }, }
 
 end UniformSpace
 

--- a/src/topology/continuous_map.lean
+++ b/src/topology/continuous_map.lean
@@ -23,7 +23,8 @@ notation `C(` α `, ` β `)` := continuous_map α β
 
 namespace continuous_map
 
-variables {α : Type*} {β : Type*} [topological_space α] [topological_space β]
+variables {α : Type*} {β : Type*} {γ : Type*}
+variables [topological_space α] [topological_space β] [topological_space γ]
 
 instance : has_coe_to_fun (C(α, β)) := ⟨_, continuous_map.to_fun⟩
 
@@ -34,6 +35,21 @@ by cases f; cases g; congr'; exact funext H
 
 instance [inhabited β] : inhabited C(α, β) :=
 ⟨⟨λ _, default _, continuous_const⟩⟩
+
+lemma coe_inj ⦃f g : C(α, β)⦄ (h : (f : α → β) = g) : f = g :=
+by cases f; cases g; cases h; refl
+
+/--
+The identity as a continuous map.
+-/
+def id : C(α, α) := ⟨id, continuous_id⟩
+
+/--
+The composition of continuous maps, as a continuous map.
+-/
+def comp (f : C(β, γ)) (g : C(α, β)) : C(α, γ) :=
+{ to_fun := λ a, f (g a),
+  continuous_to_fun := continuous.comp f.continuous_to_fun g.continuous_to_fun, }
 
 protected lemma continuous (f : C(α, β)) : continuous f := f.continuous_to_fun
 

--- a/src/topology/sheaves/presheaf_of_functions.lean
+++ b/src/topology/sheaves/presheaf_of_functions.lean
@@ -15,7 +15,7 @@ open opposite
 
 namespace Top
 
-variables (X : Top.{v})
+variables (X Y : Top.{v})
 
 /-- The presheaf of continuous functions on `X` with values in fixed target topological space `T`. -/
 def presheaf_to_Top (T : Top.{v}) : X.presheaf (Type v) :=
@@ -28,16 +28,6 @@ def continuous_functions (X : Top.{v}ᵒᵖ) (R : TopCommRing.{v}) : CommRing.{v
 CommRing.of (unop X ⟶ (forget₂ TopCommRing Top).obj R)
 
 namespace continuous_functions
--- FIXME get rid of all these `.to_fun`s
-
-@[simp] lemma one (X : Top.{v}ᵒᵖ) (R : TopCommRing.{v}) (x : unop X) :
-  (1 : continuous_functions X R).to_fun x = 1 := rfl
-@[simp] lemma zero (X : Top.{v}ᵒᵖ) (R : TopCommRing.{v}) (x : unop X) :
-  (0 : continuous_functions X R).to_fun x = 0 := rfl
-@[simp] lemma add (X : Top.{v}ᵒᵖ) (R : TopCommRing.{v}) (f g : continuous_functions X R) (x : unop X) :
-  (f + g).to_fun x = f.1 x + g.1 x := rfl
-@[simp] lemma mul (X : Top.{v}ᵒᵖ) (R : TopCommRing.{v}) (f g : continuous_functions X R) (x : unop X) :
-  (f * g).to_fun x = f.1 x * g.1 x := rfl
 
 /-- Pulling back functions into a topological ring along a continuous map is a ring homomorphism. -/
 def pullback {X Y : Topᵒᵖ} (f : X ⟶ Y) (R : TopCommRing) :

--- a/src/topology/sheaves/presheaf_of_functions.lean
+++ b/src/topology/sheaves/presheaf_of_functions.lean
@@ -25,18 +25,19 @@ def presheaf_to_Top (T : Top.{v}) : X.presheaf (Type v) :=
 to a topological commutative ring, with pointwise multiplication. -/
 -- TODO upgrade the result to TopCommRing?
 def continuous_functions (X : Top.{v}ᵒᵖ) (R : TopCommRing.{v}) : CommRing.{v} :=
-{ α := unop X ⟶ (forget₂ TopCommRing Top).obj R,
-  str := _root_.continuous_comm_ring }
+CommRing.of (unop X ⟶ (forget₂ TopCommRing Top).obj R)
 
 namespace continuous_functions
-@[simp] lemma one (X : Top.{v}ᵒᵖ) (R : TopCommRing.{v}) (x) :
-  (monoid.one : continuous_functions X R).val x = 1 := rfl
-@[simp] lemma zero (X : Top.{v}ᵒᵖ) (R : TopCommRing.{v}) (x) :
-  (comm_ring.zero : continuous_functions X R).val x = 0 := rfl
-@[simp] lemma add (X : Top.{v}ᵒᵖ) (R : TopCommRing.{v}) (f g : continuous_functions X R) (x) :
-  (comm_ring.add f g).val x = f.1 x + g.1 x := rfl
-@[simp] lemma mul (X : Top.{v}ᵒᵖ) (R : TopCommRing.{v}) (f g : continuous_functions X R) (x) :
-  (ring.mul f g).val x = f.1 x * g.1 x := rfl
+-- FIXME get rid of all these `.to_fun`s
+
+@[simp] lemma one (X : Top.{v}ᵒᵖ) (R : TopCommRing.{v}) (x : unop X) :
+  (1 : continuous_functions X R).to_fun x = 1 := rfl
+@[simp] lemma zero (X : Top.{v}ᵒᵖ) (R : TopCommRing.{v}) (x : unop X) :
+  (0 : continuous_functions X R).to_fun x = 0 := rfl
+@[simp] lemma add (X : Top.{v}ᵒᵖ) (R : TopCommRing.{v}) (f g : continuous_functions X R) (x : unop X) :
+  (f + g).to_fun x = f.1 x + g.1 x := rfl
+@[simp] lemma mul (X : Top.{v}ᵒᵖ) (R : TopCommRing.{v}) (f g : continuous_functions X R) (x : unop X) :
+  (f * g).to_fun x = f.1 x * g.1 x := rfl
 
 /-- Pulling back functions into a topological ring along a continuous map is a ring homomorphism. -/
 def pullback {X Y : Topᵒᵖ} (f : X ⟶ Y) (R : TopCommRing) :
@@ -47,11 +48,9 @@ def pullback {X Y : Topᵒᵖ} (f : X ⟶ Y) (R : TopCommRing) :
   map_add' := by tidy,
   map_mul' := by tidy }
 
-local attribute [ext] subtype.eq
-
 /-- A homomorphism of topological rings can be postcomposed with functions from a source space `X`;
 this is a ring homomorphism (with respect to the pointwise ring operations on functions). -/
-def map (X : Topᵒᵖ) {R S : TopCommRing} (φ : R ⟶ S) :
+def map (X : Top.{u}ᵒᵖ) {R S : TopCommRing.{u}} (φ : R ⟶ S) :
   continuous_functions X R ⟶ continuous_functions X S :=
 { to_fun := λ g, g ≫ ((forget₂ TopCommRing Top).map φ),
   map_one' := by ext; exact φ.1.map_one,


### PR DESCRIPTION
This is a natural follow-up to @Nicknamen's recent PRs splitting bundled continuous maps out of `compact_open`.

There is a slight regression in `algebraic_geometry.presheafed_space` and `algebraic_geometry.stalks`, requiring a more explicit coercion. I'd encourage reviewers to ignore this, as I'll make a separate PR simplifying this (basically: having a coercion from morphisms of `PresheafedSpace`s to morphisms of `Top`s is unrealistically ambitious, and moreover harder to read, than just using the projection notation, and removing it makes everything easier).

---
<!-- put comments you want to keep out of the PR commit here -->
