### PR TITLE
[Merged by Bors] - chore(measure_theory/l1_space): make `measure` argument of `integrable` optional

### DIFF
--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -1243,7 +1243,7 @@ end
 
 variable {ν : measure α}
 
-lemma integral_add_meas {f : α → E} (hfm : measurable f) (hfi : integrable f (μ + ν)) :
+@[simp] lemma integral_add_meas {f : α → E} (hfm : measurable f) (hfi : integrable f (μ + ν)) :
   ∫ x, f x ∂(μ + ν) = ∫ x, f x ∂μ + ∫ x, f x ∂ν :=
 begin
   rcases simple_func_sequence_tendsto' hfm hfi with ⟨F, hFi, hFt⟩,
@@ -1266,6 +1266,9 @@ begin
   apply tendsto_nhds_unique hμν,
   simpa only [← simple_func.integral_eq_integral, *, simple_func.integral_add_meas] using hμ.add hν
 end
+
+@[simp] lemma integral_zero_meas (f : α → E) : ∫ x, f x ∂0 = 0 :=
+norm_le_zero_iff.1 $ le_trans (norm_integral_le_lintegral_norm f) $ by simp
 
 end properties
 

--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -1243,7 +1243,7 @@ end
 
 variable {ν : measure α}
 
-@[simp] lemma integral_add_meas {f : α → E} (hfm : measurable f) (hfi : integrable f (μ + ν)) :
+lemma integral_add_meas {f : α → E} (hfm : measurable f) (hfi : integrable f (μ + ν)) :
   ∫ x, f x ∂(μ + ν) = ∫ x, f x ∂μ + ∫ x, f x ∂ν :=
 begin
   rcases simple_func_sequence_tendsto' hfm hfi with ⟨F, hFi, hFt⟩,

--- a/src/measure_theory/l1_space.lean
+++ b/src/measure_theory/l1_space.lean
@@ -61,7 +61,8 @@ universes u v w
 variables {α : Type u} [measurable_space α] {μ ν : measure α}
 variables {β : Type v} [normed_group β] {γ : Type w} [normed_group γ]
 
-/-- A function is `integrable` if the integral of its pointwise norm is less than infinity. -/
+/-- `integrable f μ` means that the integral `∫⁻ a, ∥f a∥ ∂μ` is finite; `integrable f` means
+`integrable f volume`. -/
 def integrable (f : α → β) (μ : measure α . volume_tac) : Prop := ∫⁻ a, nnnorm (f a) ∂μ < ⊤
 
 lemma integrable_iff_norm (f : α → β) : integrable f μ ↔ ∫⁻ a, (ennreal.of_real ∥f a∥) ∂μ < ⊤ :=

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -1027,9 +1027,9 @@ end measure
 
 variables {α : Type*} {β : Type*} [measurable_space α] {μ : measure α}
 
-notation `∀ᵐ` binders `∂` μ `, ` r:(scoped P, μ.ae.eventually P) := r
-notation f ` =ᵐ[`:50 μ:50 `] `:0 g:50 := f =ᶠ[μ.ae] g
-notation f ` ≤ᵐ[`:50 μ:50 `] `:0 g:50 := f ≤ᶠ[μ.ae] g
+notation `∀ᵐ` binders `∂` μ `, ` r:(scoped P, filter.eventually P (measure.ae μ)) := r
+notation f ` =ᵐ[`:50 μ:50 `] `:0 g:50 := f =ᶠ[measure.ae μ] g
+notation f ` ≤ᵐ[`:50 μ:50 `] `:0 g:50 := f ≤ᶠ[measure.ae μ] g
 
 lemma mem_ae_iff {s : set α} : s ∈ μ.ae ↔ μ sᶜ = 0 := iff.rfl
 
@@ -1303,7 +1303,10 @@ add_decl_doc volume
 section measure_space
 variables {α : Type*} {ι : Type*} [measure_space α] {s₁ s₂ : set α}
 
-notation `∀ᵐ` binders `, ` r:(scoped P, volume.ae.eventually P) := r
+notation `∀ᵐ` binders `, ` r:(scoped P, filter.eventually P (measure.ae volume)) := r
+
+/-- The tactic `exact volume`, to be used in optional arguments. -/
+meta def volume_tac : tactic unit := `[exact volume]
 
 end measure_space
 

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -1306,7 +1306,7 @@ variables {α : Type*} {ι : Type*} [measure_space α] {s₁ s₂ : set α}
 notation `∀ᵐ` binders `, ` r:(scoped P, filter.eventually P (measure.ae volume)) := r
 
 /-- The tactic `exact volume`, to be used in optional arguments. -/
-meta def volume_tac : tactic unit := `[exact volume]
+meta def volume_tac : tactic unit := `[exact measure_theory.measure_space.volume]
 
 end measure_space
 

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -1305,7 +1305,7 @@ variables {α : Type*} {ι : Type*} [measure_space α] {s₁ s₂ : set α}
 
 notation `∀ᵐ` binders `, ` r:(scoped P, filter.eventually P (measure.ae volume)) := r
 
-/-- The tactic `exact volume`, to be used in optional arguments. -/
+/-- The tactic `exact volume`, to be used in optional (`auto_param`) arguments. -/
 meta def volume_tac : tactic unit := `[exact measure_theory.measure_space.volume]
 
 end measure_space


### PR DESCRIPTION
Other changes:

* a few trivial lemmas;
* fix notation for `∀ᵐ`: now Lean can use it for printing, not only
  for parsing.

---
<!-- put comments you want to keep out of the PR commit here -->