### PR TITLE
[Merged by Bors] - chore(*): cleanup imports

### DIFF
--- a/src/algebra/char_zero.lean
+++ b/src/algebra/char_zero.lean
@@ -5,7 +5,6 @@ Authors: Mario Carneiro
 
 Natural homomorphism from the natural numbers into a monoid with one.
 -/
-import algebra.field
 import data.nat.cast
 import tactic.wlog
 

--- a/src/algebra/group/prod.lean
+++ b/src/algebra/group/prod.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot, Yury Kudryashov
 -/
 import algebra.group.hom
-import algebra.group_with_zero
 import data.prod
 
 /-!

--- a/src/algebra/group/units_hom.lean
+++ b/src/algebra/group/units_hom.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Johan Commelin All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Chris Hughes, Kevin Buzzard
 -/
-import algebra.group.units
 import algebra.group.hom
 /-!
 # Lift monoid homomorphisms to group homomorphisms of their units subgroups.

--- a/src/algebra/group_power.lean
+++ b/src/algebra/group_power.lean
@@ -162,7 +162,11 @@ theorem nsmul_add_comm : ∀ (a : A) (m n : ℕ), m •ℕ a + n •ℕ a = n �
 
 @[simp, priority 500]
 theorem list.prod_repeat (a : M) (n : ℕ) : (list.repeat a n).prod = a ^ n :=
-by induction n with n ih; [refl, rw [list.repeat_succ, list.prod_cons, ih]]; refl
+begin
+  induction n with n ih,
+  { refl },
+  { rw [list.repeat_succ, list.prod_cons, ih], refl, }
+end
 @[simp, priority 500]
 theorem list.sum_repeat : ∀ (a : A) (n : ℕ), (list.repeat a n).sum = n •ℕ a :=
 @list.prod_repeat (multiplicative A) _

--- a/src/algebra/pi_instances.lean
+++ b/src/algebra/pi_instances.lean
@@ -6,6 +6,7 @@ Authors: Simon Hudon, Patrick Massot
 import algebra.module
 import ring_theory.subring
 import ring_theory.prod
+import data.fintype.basic
 
 open_locale big_operators
 

--- a/src/algebra/pointwise.lean
+++ b/src/algebra/pointwise.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Floris van Doorn
 -/
 import algebra.module
+import data.set.finite
 
 /-!
 # Pointwise addition, multiplication, and scalar multiplication of sets.

--- a/src/algebra/ring.lean
+++ b/src/algebra/ring.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Amelia Livingston, Yury Kudryashov,
 Neil Strickland
 -/
-import algebra.group.hom
-import algebra.group.units
 import algebra.group_with_zero
 
 /-!

--- a/src/analysis/convex/basic.lean
+++ b/src/analysis/convex/basic.lean
@@ -6,7 +6,6 @@ Authors: Alexander Bentkamp, Yury Kudriashov
 import data.set.intervals.unordered_interval
 import data.set.intervals.image_preimage
 import data.complex.module
-import algebra.pointwise
 
 /-!
 # Convex sets and functions on real vector spaces

--- a/src/computability/primrec.lean
+++ b/src/computability/primrec.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Mario Carneiro
 -/
 import data.equiv.list
+import logic.function.iterate
 
 /-!
 # The primitive recursive functions

--- a/src/computability/turing_machine.lean
+++ b/src/computability/turing_machine.lean
@@ -7,6 +7,7 @@ import algebra.order
 import data.fintype.basic
 import data.pfun
 import tactic.apply_fun
+import logic.function.iterate
 
 /-!
 # Turing machines

--- a/src/data/dfinsupp.lean
+++ b/src/data/dfinsupp.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Kenny Lau
 -/
 import algebra.pi_instances
+import data.set.finite
 
 /-!
 # Dependent functions with finite support

--- a/src/data/finsupp.lean
+++ b/src/data/finsupp.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl, Scott Morrison
 -/
 import algebra.module
 import data.fintype.card
+import data.set.finite
 import data.multiset.antidiagonal
 
 /-!

--- a/src/data/monoid_algebra.lean
+++ b/src/data/monoid_algebra.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Yury G. Kudryashov, Scott Morrison
 -/
-import data.finsupp
 import ring_theory.algebra
 
 /-!

--- a/src/data/polynomial/algebra_map.lean
+++ b/src/data/polynomial/algebra_map.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Scott Morrison, Jens Wagemaker
 -/
-import data.polynomial.induction
 import data.polynomial.degree
 
 /-!

--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Scott Morrison, Jens Wagemaker
 -/
-import data.polynomial.degree.basic
 import data.polynomial.induction
 
 /-!

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Scott Morrison, Jens Wagemaker
 -/
 import data.polynomial.div
-import tactic.omega
 
 /-!
 # Theory of univariate polynomials

--- a/src/data/sigma/basic.lean
+++ b/src/data/sigma/basic.lean
@@ -3,7 +3,8 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Johannes Hölzl
 -/
-import tactic.lint tactic.ext
+import tactic.lint
+import tactic.ext
 
 section sigma
 variables {α : Type*} {β : α → Type*}

--- a/src/deprecated/group.lean
+++ b/src/deprecated/group.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Yury Kudryashov
 -/
 import algebra.group.type_tags
-import algebra.group.units_hom
 import algebra.ring
 
 /-!

--- a/src/deprecated/ring.lean
+++ b/src/deprecated/ring.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Mario Carneiro
 -/
 import deprecated.group
-import algebra.ring
 
 /-!
 # Unbundled semiring and ring homomorphisms (deprecated)

--- a/src/group_theory/group_action.lean
+++ b/src/group_theory/group_action.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
-import data.set.finite
 import group_theory.coset
 
 universes u v w
@@ -117,9 +116,6 @@ iff.rfl
 
 @[simp] lemma mem_orbit_self (b : β) : b ∈ orbit α b :=
 ⟨1, by simp [mul_action.one_smul]⟩
-
-instance orbit_fintype (b : β) [fintype α] [decidable_eq β] :
-  fintype (orbit α b) := set.fintype_range _
 
 variable (α)
 

--- a/src/group_theory/submonoid/basic.lean
+++ b/src/group_theory/submonoid/basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Kenny Lau, Johan Commelin, Mario Carneiro, Kevin Buzzard,
 Amelia Livingston, Yury Kudryashov
 -/
-import algebra.group.basic
 import data.set.lattice
 
 /-!

--- a/src/logic/embedding.lean
+++ b/src/logic/embedding.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
 import data.equiv.basic
-import data.sigma
+import data.sigma.basic
 
 /-!
 # Injective functions

--- a/src/order/complete_boolean_algebra.lean
+++ b/src/order/complete_boolean_algebra.lean
@@ -6,7 +6,6 @@ Authors: Johannes Hölzl
 Theory of complete Boolean algebras.
 -/
 import order.complete_lattice
-import order.boolean_algebra
 
 set_option old_structure_cmd true
 

--- a/src/order/order_iso.lean
+++ b/src/order/order_iso.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import logic.embedding
-import logic.function.iterate
 import order.rel_classes
 
 open function

--- a/src/order/order_iso_nat.lean
+++ b/src/order/order_iso_nat.lean
@@ -5,6 +5,7 @@ Author: Mario Carneiro
 -/
 import data.nat.basic
 import order.order_iso
+import logic.function.iterate
 
 namespace order_embedding
 

--- a/src/ring_theory/algebra_operations.lean
+++ b/src/ring_theory/algebra_operations.lean
@@ -6,8 +6,6 @@ Authors: Kenny Lau
 Multiplication and division of submodules of an algebra.
 -/
 import ring_theory.algebra
-import ring_theory.ideals
-import algebra.pointwise
 
 universes u v
 

--- a/src/ring_theory/ideal_operations.lean
+++ b/src/ring_theory/ideal_operations.lean
@@ -8,6 +8,7 @@ More operations on modules and ideals.
 import data.nat.choose
 import data.equiv.ring
 import ring_theory.algebra_operations
+import ring_theory.ideals
 
 universes u v w x
 

--- a/src/ring_theory/ideals.lean
+++ b/src/ring_theory/ideals.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Chris Hughes, Mario Carneiro
 -/
 import algebra.associated
-import algebra.pointwise
 import linear_algebra.basic
 import order.zorn
 

--- a/src/ring_theory/matrix_algebra.lean
+++ b/src/ring_theory/matrix_algebra.lean
@@ -3,9 +3,7 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import tactic.tidy
 import ring_theory.tensor_product
-import data.matrix.basic
 
 /-!
 We provide the `R`-algebra structure on `matrix n n A` when `A` is an `R`-algebra,

--- a/src/ring_theory/polynomial_algebra.lean
+++ b/src/ring_theory/polynomial_algebra.lean
@@ -3,9 +3,8 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import ring_theory.tensor_product
 import ring_theory.matrix_algebra
-import data.polynomial
+import data.polynomial.basic
 
 /-!
 # Algebra isomorphism between matrices of polynomials and polynomials of matrices

--- a/src/ring_theory/polynomial_algebra.lean
+++ b/src/ring_theory/polynomial_algebra.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import ring_theory.matrix_algebra
-import data.polynomial.basic
+import data.polynomial.algebra_map
 
 /-!
 # Algebra isomorphism between matrices of polynomials and polynomials of matrices

--- a/src/topology/metric_space/lipschitz.lean
+++ b/src/topology/metric_space/lipschitz.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Rohan Mitta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rohan Mitta, Kevin Buzzard, Alistair Tucker, Johannes Hölzl, Yury Kudryashov
 -/
+import logic.function.iterate
 import topology.metric_space.basic
 import category_theory.endomorphism
 import category_theory.types


### PR DESCRIPTION
A not-very-interesting cleanup of imports.

I deleted 
```
instance orbit_fintype (b : β) [fintype α] [decidable_eq β] :	
  fintype (orbit α b) := set.fintype_range _
```
which wasn't being used, for the sake of not having to import everything about finiteness into `algebra.group_action`.

---
<!-- put comments you want to keep out of the PR commit here -->
