### PR TITLE
[Merged by Bors] - feat(order/filters, topology): relation between neighborhoods of a in [a, u), [a, u] and [a,+inf) + various nhds_within lemmas

### DIFF
--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -1174,6 +1174,10 @@ lemma eventually_eq.sub [add_group β] {f f' g g' : α → β} {l : filter α} (
   ((λ x, f x - f' x) =ᶠ[l] (λ x, g x - g' x)) :=
 h.add h'.neg
 
+lemma eventually_eq_inf_principal_iff {F : filter α} {s : set α} {f g : α → β} :
+  (f =ᶠ[F ⊓ 𝓟 s] g) ↔ ∀ᶠ x in F, x ∈ s → f x = g x :=
+by simp [eventually_eq, eventually_iff, mem_inf_principal]
+
 section has_le
 
 variables [has_le β] {l : filter α}
@@ -2049,6 +2053,10 @@ by simp only [tendsto, iff_self, le_infi_iff]
 lemma tendsto_infi' {f : α → β} {x : ι → filter α} {y : filter β} (i : ι) :
   tendsto f (x i) y → tendsto f (⨅i, x i) y :=
 tendsto_le_left (infi_le _ _)
+
+lemma tendsto_sup {f : α → β} {x₁ x₂ : filter α} {y : filter β} :
+  tendsto f (x₁ ⊔ x₂) y ↔ tendsto f x₁ y ∧ tendsto f x₂ y :=
+by simp only [tendsto, map_sup, sup_le_iff]
 
 lemma tendsto_principal {f : α → β} {l : filter α} {s : set β} :
   tendsto f l (𝓟 s) ↔ ∀ᶠ a in l, f a ∈ s :=

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -2058,6 +2058,10 @@ lemma tendsto_sup {f : α → β} {x₁ x₂ : filter α} {y : filter β} :
   tendsto f (x₁ ⊔ x₂) y ↔ tendsto f x₁ y ∧ tendsto f x₂ y :=
 by simp only [tendsto, map_sup, sup_le_iff]
 
+lemma tendsto.sup {f : α → β} {x₁ x₂ : filter α} {y : filter β} :
+  tendsto f x₁ y → tendsto f x₂ y → tendsto f (x₁ ⊔ x₂) y :=
+λ h₁ h₂, tendsto_sup.mpr ⟨ h₁, h₂ ⟩
+
 lemma tendsto_principal {f : α → β} {l : filter α} {s : set β} :
   tendsto f l (𝓟 s) ↔ ∀ᶠ a in l, f a ∈ s :=
 by simp only [tendsto, le_principal_iff, mem_map, iff_self, filter.eventually]

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -1176,7 +1176,7 @@ h.add h'.neg
 
 lemma eventually_eq_inf_principal_iff {F : filter α} {s : set α} {f g : α → β} :
   (f =ᶠ[F ⊓ 𝓟 s] g) ↔ ∀ᶠ x in F, x ∈ s → f x = g x :=
-by simp [eventually_eq, eventually_iff, mem_inf_principal]
+eventually_inf_principal
 
 section has_le
 

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -319,12 +319,12 @@ begin
 end
 
 /-!
-### Neighborhoods to the left and to the right on an order_closed_topology
+### Neighborhoods to the left and to the right on an `order_closed_topology`
 
 Limits to the left and to the right of real functions are defined in terms of neighborhoods to
 the left and to the right, either open or closed, i.e., members of `nhds_within a (Ioi a)` and
-`nhds_wihin a (Ici a)` on the right, and similarly on the left. Here we simply prove that all
-right-neighborhood of a point are equal, and we'll prove later other useful characterizations which
+`nhds_within a (Ici a)` on the right, and similarly on the left. Here we simply prove that all
+right-neighborhoods of a point are equal, and we'll prove later other useful characterizations which
 require the stronger hypothesis `order_topology α` -/
 
 -- NB: If you extend the list, append to the end please to avoid breaking the API
@@ -890,10 +890,10 @@ lemma not_tendsto_at_bot_of_tendsto_nhds [no_bot_order α]
 hf.not_tendsto (disjoint_nhds_at_bot x)
 
 /-!
-### Neighborhoods to the left and to the right on an order_topology
+### Neighborhoods to the left and to the right on an `order_topology`
 
-We've seen some properties of left and right neighborhood of a point in an order_closed_topology.
-In an order_topology, such neighborhoods can be characterized as the sets containing suitable
+We've seen some properties of left and right neighborhood of a point in an `order_closed_topology`.
+In an `order_topology`, such neighborhoods can be characterized as the sets containing suitable
 intervals to the right or to the left of `a`. We give now these characterizations. -/
 
 -- NB: If you extend the list, append to the end please to avoid breaking the API

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -318,6 +318,78 @@ begin
   exact hs.Icc_subset ys zs ⟨le_of_lt hy, le_of_lt hz⟩
 end
 
+lemma nhds_within_Icc_eq_nhds_within_Ico {hab : a < b} :
+  nhds_within a (Icc a b) = nhds_within a (Ico a b) :=
+begin
+  by_cases h : ∃ a', a' < a,
+  { cases h with a' ha',
+    apply nhds_within_eq_nhds_within,
+    exact show a ∈ Ioo a' b, from ⟨ ha', hab ⟩,
+    exact is_open_Ioo,
+    rw (show Ico a b ∩ Ioo a' b = Ico a b, from
+         inter_eq_self_of_subset_left
+         (λ x hx, ⟨ lt_of_lt_of_le ha' hx.1, hx.2 ⟩)),
+    exact eq_of_subset_of_subset
+          ( id (λ (x : α) (hx : x ∈ Icc a b ∩ Ioo a' b), ⟨hx.left.left, hx.right.right⟩) )
+          ( λ (x' : α) (hx' : x' ∈ Ico a b),
+            ⟨⟨hx'.left, le_of_lt hx'.right⟩, ⟨lt_of_lt_of_le ha' hx'.left, hx'.right⟩⟩ ) },
+  { push_neg at h,
+    have h1 : Icc a b = Iic b := eq_of_subset_of_subset (λ x hx, hx.2) (λ x hx, ⟨ h x, hx ⟩),
+    have h2 : Ico a b = Iio b := eq_of_subset_of_subset (λ x hx, hx.2) (λ x hx, ⟨ h x, hx ⟩),
+    rw [h1, h2, nhds_within_eq_nhds_within],
+    exact show a ∈ Iio b, from hab,
+    exact is_open_Iio,
+    rw inter_self,
+    apply inter_eq_self_of_subset_right,
+    exact λ x hx, le_of_lt hx }
+end
+
+lemma nhds_within_Icc_eq_nhds_within_Ioc {hab : a < b} :
+  nhds_within b (Icc a b) = nhds_within b (Ioc a b) :=
+begin
+  by_cases h : ∃ b', b < b',
+  { cases h with b' hb',
+    apply nhds_within_eq_nhds_within,
+    exact show b ∈ Ioo a b', from ⟨ hab, hb' ⟩,
+    exact is_open_Ioo,
+    rw (show Ioc a b ∩ Ioo a b' = Ioc a b, from
+          inter_eq_self_of_subset_left
+          (λ x hx, ⟨ hx.1, lt_of_le_of_lt hx.2 hb' ⟩)),
+    exact eq_of_subset_of_subset
+          ( id (λ (x : α) (hx : x ∈ Icc a b ∩ Ioo a b'), ⟨hx.right.left, hx.left.right⟩) )
+          ( λ (x' : α) (hx' : x' ∈ Ioc a b),
+            ⟨⟨le_of_lt hx'.left, hx'.right⟩, ⟨hx'.left, lt_of_le_of_lt hx'.right hb'⟩⟩ ) },
+  { push_neg at h,
+    have h1 : Icc a b = Ici a := eq_of_subset_of_subset (λ x hx, hx.1) (λ x hx, ⟨ hx, h x ⟩),
+    have h2 : Ioc a b = Ioi a := eq_of_subset_of_subset (λ x hx, hx.1) (λ x hx, ⟨ hx, h x ⟩),
+    rw [h1, h2, nhds_within_eq_nhds_within],
+    exact show b ∈ Ioi a, from hab,
+    exact is_open_Ioi,
+    rw inter_self,
+    apply inter_eq_self_of_subset_right,
+    exact λ x hx, le_of_lt hx }
+end
+
+lemma continuous_within_at_Icc_iff_continuous_within_at_Ico
+  {β : Type*} [topological_space β] {hab : a < b} :
+  ∀ f : α → β, continuous_within_at f (Icc a b) a ↔ continuous_within_at f (Ico a b) a :=
+begin
+  unfold continuous_within_at,
+  rw nhds_within_Icc_eq_nhds_within_Ico,
+  intros f, refl,
+  exact hab
+end
+
+lemma continuous_within_at_Icc_iff_continuous_within_at_Ioc
+  {β : Type*} [topological_space β] {hab : a < b} :
+  ∀ f : α → β, continuous_within_at f (Icc a b) b ↔ continuous_within_at f (Ioc a b) b :=
+begin
+  unfold continuous_within_at,
+  rw nhds_within_Icc_eq_nhds_within_Ioc,
+  intros f, refl,
+  exact hab
+end
+
 end linear_order
 
 section decidable_linear_order

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -347,27 +347,8 @@ end
 lemma nhds_within_Icc_eq_nhds_within_Ioc {hab : a < b} :
   nhds_within b (Icc a b) = nhds_within b (Ioc a b) :=
 begin
-  by_cases h : ∃ b', b < b',
-  { cases h with b' hb',
-    apply nhds_within_eq_nhds_within,
-    exact show b ∈ Ioo a b', from ⟨ hab, hb' ⟩,
-    exact is_open_Ioo,
-    rw (show Ioc a b ∩ Ioo a b' = Ioc a b, from
-          inter_eq_self_of_subset_left
-          (λ x hx, ⟨ hx.1, lt_of_le_of_lt hx.2 hb' ⟩)),
-    exact eq_of_subset_of_subset
-          ( id (λ (x : α) (hx : x ∈ Icc a b ∩ Ioo a b'), ⟨hx.right.left, hx.left.right⟩) )
-          ( λ (x' : α) (hx' : x' ∈ Ioc a b),
-            ⟨⟨le_of_lt hx'.left, hx'.right⟩, ⟨hx'.left, lt_of_le_of_lt hx'.right hb'⟩⟩ ) },
-  { push_neg at h,
-    have h1 : Icc a b = Ici a := eq_of_subset_of_subset (λ x hx, hx.1) (λ x hx, ⟨ hx, h x ⟩),
-    have h2 : Ioc a b = Ioi a := eq_of_subset_of_subset (λ x hx, hx.1) (λ x hx, ⟨ hx, h x ⟩),
-    rw [h1, h2, nhds_within_eq_nhds_within],
-    exact show b ∈ Ioi a, from hab,
-    exact is_open_Ioi,
-    rw inter_self,
-    apply inter_eq_self_of_subset_right,
-    exact λ x hx, le_of_lt hx }
+  have := @nhds_within_Icc_eq_nhds_within_Ico (order_dual α) _ _ _ _ _ hab,
+  rwa [dual_Ico, dual_Icc] at this,
 end
 
 lemma continuous_within_at_Icc_iff_continuous_within_at_Ico
@@ -384,10 +365,8 @@ lemma continuous_within_at_Icc_iff_continuous_within_at_Ioc
   {β : Type*} [topological_space β] {hab : a < b} :
   ∀ f : α → β, continuous_within_at f (Icc a b) b ↔ continuous_within_at f (Ioc a b) b :=
 begin
-  unfold continuous_within_at,
-  rw nhds_within_Icc_eq_nhds_within_Ioc,
-  intros f, refl,
-  exact hab
+  have := @continuous_within_at_Icc_iff_continuous_within_at_Ico (order_dual α) _ _ _ _ _ _ _ hab,
+  rwa [dual_Ico, dual_Icc] at this
 end
 
 end linear_order

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -216,6 +216,27 @@ lemma is_closed.mem_of_nhds_within_ne_bot {s : set α} (hs : is_closed s)
   {x : α} (hx : ne_bot $ nhds_within x s) : x ∈ s :=
 by simpa only [hs.closure_eq] using mem_closure_iff_nhds_within_ne_bot.2 hx
 
+lemma eventually_eq_nhds_within_iff {f g : α → β} {s : set α} {a : α} :
+  (f =ᶠ[nhds_within a s] g) ↔ ∀ᶠ x in 𝓝 a, x ∈ s → f x = g x :=
+mem_inf_principal
+
+lemma eventually_eq_nhds_within_of_eq_on {f g : α → β} {s : set α} {a : α} (h : eq_on f g s) :
+  f =ᶠ[nhds_within a s] g :=
+mem_inf_sets_of_right h
+
+lemma tendsto_nhds_within_congr {f g : α → β} {s : set α} {a : α} {l : filter β}
+  (hfg : ∀ x ∈ s, f x = g x) (hf : tendsto f (nhds_within a s) l) : tendsto g (nhds_within a s) l :=
+(tendsto_congr' $ eventually_eq_nhds_within_of_eq_on hfg).1 hf
+
+lemma eventually_nhds_with_of_forall {s : set α} {a : α} {p : α → Prop} (h : ∀ x ∈ s, p x) :
+  ∀ᶠ x in nhds_within a s, p x :=
+mem_inf_sets_of_right h
+
+lemma tendsto_nhds_within_of_tendsto_nhds_of_eventually_within {β : Type*} {a : α} {l : filter β}
+  {s : set α} (f : β → α) (h1 : tendsto f l (nhds a)) (h2 : ∀ᶠ x in l, f x ∈ s) :
+  tendsto f l (nhds_within a s) :=
+tendsto_inf.2 ⟨h1, tendsto_principal.2 h2⟩
+
 /-
 nhds_within and subtypes
 -/

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -224,7 +224,7 @@ lemma eventually_eq_nhds_within_of_eq_on {f g : α → β} {s : set α} {a : α}
   f =ᶠ[nhds_within a s] g :=
 mem_inf_sets_of_right h
 
-lemma set.eq_on.eventually_eq {f g : α → β} {s : set α} {a : α} (h : eq_on f g s) :
+lemma set.eq_on.eventually_eq_nhds_within {f g : α → β} {s : set α} {a : α} (h : eq_on f g s) :
   f =ᶠ[nhds_within a s] g :=
 eventually_eq_nhds_within_of_eq_on h
 

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -224,6 +224,10 @@ lemma eventually_eq_nhds_within_of_eq_on {f g : α → β} {s : set α} {a : α}
   f =ᶠ[nhds_within a s] g :=
 mem_inf_sets_of_right h
 
+lemma set.eq_on.eventually_eq {f g : α → β} {s : set α} {a : α} (h : eq_on f g s) :
+  f =ᶠ[nhds_within a s] g :=
+eventually_eq_nhds_within_of_eq_on h
+
 lemma tendsto_nhds_within_congr {f g : α → β} {s : set α} {a : α} {l : filter β}
   (hfg : ∀ x ∈ s, f x = g x) (hf : tendsto f (nhds_within a s) l) : tendsto g (nhds_within a s) l :=
 (tendsto_congr' $ eventually_eq_nhds_within_of_eq_on hfg).1 hf


### PR DESCRIPTION
Content : 
- two lemmas about filters, namely `tendsto_sup` and `eventually_eq_inf_principal_iff`
- a few lemmas about `nhds_within`
- duplicate and move parts of the lemmas `tfae_mem_nhds_within_[Ioi/Iio/Ici/Iic]` that only require `order_closed_topology α` instead of `order_topology α`. This allows to turn any left/right neighborhood of `a` into its "canonical" form (i.e `Ioi`/`Iio`/`Ici`/`Iic`) with a weaker assumption than before

---

This is another PR preparing L'Hopital's rule. I try (maybe a little bit too much) to break things in small coherent part.

Please tell me if I should change anything about the way I open and manage PRs !
