### PR TITLE
[Merged by Bors] - chore(data/subtype,order/complete_lattice): use `coe` instead of `subtype.val`

### DIFF
--- a/src/data/subtype.lean
+++ b/src/data/subtype.lean
@@ -24,15 +24,12 @@ lemma prop (x : subtype p) : p x := x.2
 /-- An alternative version of `subtype.forall`. This one is useful if Lean cannot figure out `q`
   when using `subtype.forall` from right to left. -/
 protected theorem forall' {q : ∀x, p x → Prop} :
-  (∀ x h, q x h) ↔ (∀ x : {a // p a}, q x.1 x.2) :=
+  (∀ x h, q x h) ↔ (∀ x : {a // p a}, q x x.2) :=
 (@subtype.forall _ _ (λ x, q x.1 x.2)).symm
 
 @[simp] protected theorem «exists» {q : {a // p a} → Prop} :
   (∃ x, q x) ↔ (∃ a b, q ⟨a, b⟩) :=
 ⟨assume ⟨⟨a, b⟩, h⟩, ⟨a, b, h⟩, assume ⟨a, b, h⟩, ⟨⟨a, b⟩, h⟩⟩
-
--- lemma ext {f g : equiv α β} (H : ∀ x, f x = g x) : f = g :=
--- coe_fn_injective (funext H)
 
 @[ext] protected lemma ext : ∀ {a1 a2 : {x // p x}}, (a1 : α) = (a2 : α) → a1 = a2
 | ⟨x, h1⟩ ⟨.(x), h2⟩ rfl := rfl

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -947,6 +947,7 @@ begin
   rw [measure_eq_infi, infi_subtype', infi_subtype'],
   convert infi_const,
   { ext1 ⟨⟨t, hst⟩, ht⟩,
+    dsimp only [subtype.coe_mk] at *,
     simp only [dirac_apply _ ht, indicator_of_mem (hst h), pi.one_apply] },
   { exact ⟨⟨⟨set.univ, subset_univ _⟩, is_measurable.univ⟩⟩ }
 end

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -802,7 +802,7 @@ le_antisymm
   (le_infi $ assume ⟨i, h⟩, infi_le_of_le i $ infi_le _ _)
 
 lemma infi_subtype' {p : ι → Prop} {f : ∀ i, p i → α} :
-  (⨅ i (h : p i), f i h) = (⨅ x : subtype p, f x.val x.property) :=
+  (⨅ i (h : p i), f i h) = (⨅ x : subtype p, f x x.property) :=
 (@infi_subtype _ _ _ p (λ x, f x.val x.property)).symm
 
 lemma infi_subtype'' {ι} (s : set ι) (f : ι → α) :

--- a/src/order/filter/bases.lean
+++ b/src/order/filter/bases.lean
@@ -513,15 +513,16 @@ begin
   { apply infi_le_of_le i _, rw principal_mono, intro a, simp, intro h, apply h, refl },
 end
 
-lemma countable_binfi_eq_infi_seq [complete_lattice α] {B : set ι} (Bcbl : countable B) (Bne : B.nonempty) (f : ι → α)
- : ∃ (x : ℕ → ι), (⨅ t ∈ B, f t) = ⨅ i, f (x i) :=
+lemma countable_binfi_eq_infi_seq [complete_lattice α] {B : set ι} (Bcbl : countable B)
+  (Bne : B.nonempty) (f : ι → α) :
+  ∃ (x : ℕ → ι), (⨅ t ∈ B, f t) = ⨅ i, f (x i) :=
 begin
   rw countable_iff_exists_surjective_to_subtype Bne at Bcbl,
   rcases Bcbl with ⟨g, gsurj⟩,
   rw infi_subtype',
   use (λ n, g n), apply le_antisymm; rw le_infi_iff,
   { intro i, apply infi_le_of_le (g i) _, apply le_refl _ },
-  { intros a, rcases gsurj a with i, apply infi_le_of_le i _, subst h, apply le_refl _ }
+  { intros a, rcases gsurj a with ⟨i, rfl⟩, apply infi_le }
 end
 
 lemma countable_binfi_eq_infi_seq' [complete_lattice α] {B : set ι} (Bcbl : countable B) (f : ι → α)

--- a/src/ring_theory/algebraic.lean
+++ b/src/ring_theory/algebraic.lean
@@ -52,7 +52,7 @@ begin
   apply and_congr iff.rfl,
   have h : function.injective (S.val) := subtype.val_injective,
   conv_rhs { rw [← h.eq_iff, alg_hom.map_zero], },
-  rw [← aeval_alg_hom_apply, S.val_apply, subtype.val_eq_coe],
+  rw [← aeval_alg_hom_apply, S.val_apply]
 end
 
 /-- An algebra is algebraic if and only if it is algebraic as a subalgebra. -/


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->