### PR TITLE
[Merged by Bors] - chore(data/polynomial): make eval2 irreducible

### DIFF
--- a/src/data/polynomial/algebra_map.lean
+++ b/src/data/polynomial/algebra_map.lean
@@ -148,10 +148,10 @@ variables [comm_ring S] {f : R →+* S}
 
 lemma is_root_of_eval₂_map_eq_zero
   (hf : function.injective f) {r : R} : eval₂ f (f r) p = 0 → p.is_root r :=
-show eval₂ (f.comp (ring_hom.id R)) (f r) p = 0 → eval₂ (ring_hom.id R) r p = 0, begin
+begin
   intro h,
   apply hf,
-  rw [hom_eval₂, h, f.map_zero]
+  rw [←eval₂_hom, h, f.map_zero],
 end
 
 lemma is_root_of_aeval_algebra_map_eq_zero [algebra R S] {p : polynomial R}

--- a/src/data/polynomial/degree.lean
+++ b/src/data/polynomial/degree.lean
@@ -31,6 +31,7 @@ lemma nat_degree_comp_le : nat_degree (p.comp q) ≤ nat_degree p * nat_degree q
 if h0 : p.comp q = 0 then by rw [h0, nat_degree_zero]; exact nat.zero_le _
 else with_bot.coe_le_coe.1 $
   calc ↑(nat_degree (p.comp q)) = degree (p.comp q) : (degree_eq_nat_degree h0).symm
+  ... = _ : congr_arg degree comp_eq_sum_left
   ... ≤ _ : degree_sum_le _ _
   ... ≤ _ : sup_le (λ n hn,
     calc degree (C (coeff p n) * q ^ n)

--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -34,6 +34,8 @@ variables (f : R →+* S) (x : S)
 def eval₂ (p : polynomial R) : S :=
 p.sum (λ e a, f a * x ^ e)
 
+lemma eval₂_eq_sum {f : R →+* S} {x : S} : p.eval₂ f x = p.sum (λ e a, f a * x ^ e) := rfl
+
 @[simp] lemma eval₂_zero : (0 : polynomial R).eval₂ f x = 0 :=
 finsupp.sum_zero_index
 
@@ -145,6 +147,9 @@ variables {x : R}
 /-- `eval x p` is the evaluation of the polynomial `p` at `x` -/
 def eval : R → polynomial R → R := eval₂ (ring_hom.id _)
 
+lemma eval_eq_sum : p.eval x = sum p (λ e a, a * x ^ e) :=
+rfl
+
 @[simp] lemma eval_C : (C a).eval x = a := eval₂_C _ _
 
 @[simp] lemma eval_nat_cast {n : ℕ} : (n : polynomial R).eval x = n :=
@@ -198,6 +203,9 @@ section comp
 
 /-- The composition of polynomials as a polynomial. -/
 def comp (p q : polynomial R) : polynomial R := p.eval₂ C q
+
+lemma comp_eq_sum_left : p.comp q = p.sum (λ e a, C a * q ^ e) :=
+rfl
 
 @[simp] lemma comp_X : p.comp X = p :=
 begin
@@ -361,6 +369,13 @@ eval₂_map f (ring_hom.id _) x
 
 end map
 
+/-!
+After having set up the basic theory of `eval₂`, `eval`, `comp`, and `map`,
+we make `eval₂` irreducible.
+
+Perhaps we can make the others irreducible too?
+-/
+attribute [irreducible] polynomial.eval₂
 
 section hom_eval₂
 -- TODO: Here we need commutativity in both `S` and `T`?

--- a/src/data/polynomial/identities.lean
+++ b/src/data/polynomial/identities.lean
@@ -73,6 +73,7 @@ begin
   existsi f.sum (λ e a, a *((poly_binom_aux1 x y e a).val)),
   rw poly_binom_aux3,
   congr,
+  { rw [←eval_eq_sum], },
   { rw derivative_eval, symmetry,
     apply finsupp.sum_mul },
   { symmetry, apply finsupp.sum_mul }

--- a/src/field_theory/fixed.lean
+++ b/src/field_theory/fixed.lean
@@ -76,9 +76,14 @@ hn ▸ prod_X_sub_smul.coeff G F x g n
 theorem fixed_points.minpoly.monic : (fixed_points.minpoly G F x).monic :=
 subtype.eq $ prod_X_sub_smul.monic G F x
 
+section
+local attribute [semireducible] polynomial.eval₂
+
 theorem fixed_points.minpoly.eval₂ :
   polynomial.eval₂ (is_subring.subtype $ fixed_points G F) x (fixed_points.minpoly G F x) = 0 :=
 prod_X_sub_smul.eval G F x
+
+end
 
 theorem fixed_points.is_integral : is_integral (fixed_points G F) x :=
 ⟨fixed_points.minpoly G F x,

--- a/src/field_theory/fixed.lean
+++ b/src/field_theory/fixed.lean
@@ -77,11 +77,17 @@ theorem fixed_points.minpoly.monic : (fixed_points.minpoly G F x).monic :=
 subtype.eq $ prod_X_sub_smul.monic G F x
 
 section
-local attribute [semireducible] polynomial.eval₂
+-- local attribute [semireducible] polynomial.eval₂
 
 theorem fixed_points.minpoly.eval₂ :
   polynomial.eval₂ (is_subring.subtype $ fixed_points G F) x (fixed_points.minpoly G F x) = 0 :=
-prod_X_sub_smul.eval G F x
+begin
+  rw [← prod_X_sub_smul.eval G F x, polynomial.eval₂_eq_eval_map],
+  simp [fixed_points.minpoly],
+end
+
+-- prod_X_sub_smul.eval G F x
+
 
 end
 

--- a/src/field_theory/fixed.lean
+++ b/src/field_theory/fixed.lean
@@ -76,19 +76,11 @@ hn ▸ prod_X_sub_smul.coeff G F x g n
 theorem fixed_points.minpoly.monic : (fixed_points.minpoly G F x).monic :=
 subtype.eq $ prod_X_sub_smul.monic G F x
 
-section
--- local attribute [semireducible] polynomial.eval₂
-
 theorem fixed_points.minpoly.eval₂ :
   polynomial.eval₂ (is_subring.subtype $ fixed_points G F) x (fixed_points.minpoly G F x) = 0 :=
 begin
   rw [← prod_X_sub_smul.eval G F x, polynomial.eval₂_eq_eval_map],
   simp [fixed_points.minpoly],
-end
-
--- prod_X_sub_smul.eval G F x
-
-
 end
 
 theorem fixed_points.is_integral : is_integral (fixed_points G F) x :=

--- a/src/field_theory/minimal_polynomial.lean
+++ b/src/field_theory/minimal_polynomial.lean
@@ -164,7 +164,8 @@ begin
   show is_root q a,
   apply (algebra_map α β).injective,
   rw [(algebra_map α β).map_zero, ← H],
-  exact q.hom_eval₂ (ring_hom.id _) (algebra_map α β) _,
+  convert q.hom_eval₂ (ring_hom.id _) (algebra_map α β) _,
+  rw [aeval_def, ring_hom.comp_id],
 end
 
 variable (β)

--- a/src/field_theory/separable.lean
+++ b/src/field_theory/separable.lean
@@ -97,6 +97,10 @@ lemma coe_expand : (expand R p : polynomial R → polynomial R) = eval₂ C (X ^
 
 variables {R}
 
+lemma expand_eq_sum {f : polynomial R} :
+  expand R p f = f.sum (λ e a, C a * (X ^ p) ^ e) :=
+by { dsimp [expand, eval₂], refl, }
+
 @[simp] lemma expand_C (r : R) : expand R p (C r) = C r := eval₂_C _ _
 @[simp] lemma expand_X : expand R p X = X ^ p := eval₂_X _ _
 @[simp] lemma expand_monomial (r : R) : expand R p (monomial q r) = monomial (q * p) r :=
@@ -128,6 +132,7 @@ by rw [coe_expand, derivative_eval₂_C, derivative_pow, derivative_X, mul_one]
 theorem coeff_expand {p : ℕ} (hp : 0 < p) (f : polynomial R) (n : ℕ) :
   (expand R p f).coeff n = if p ∣ n then f.coeff (n / p) else 0 :=
 begin
+  simp only [expand_eq_sum],
   change (show ℕ →₀ R, from (f.sum (λ e a, C a * (X ^ p) ^ e) : polynomial R)) n = _,
   simp_rw [finsupp.sum_apply, finsupp.sum, ← pow_mul, C_mul', ← monomial_eq_smul_X,
     monomial, finsupp.single_apply],
@@ -148,7 +153,7 @@ by rw [mul_comm, coeff_expand_mul hp]
 
 theorem expand_eq_map_domain (p : ℕ) (f : polynomial R) :
   expand R p f = f.map_domain (*p) :=
-finsupp.induction f rfl $ λ n r f hf hr ih,
+finsupp.induction f (by { simp only [expand_eq_sum], refl }) $ λ n r f hf hr ih,
 by rw [finsupp.map_domain_add, finsupp.map_domain_single, alg_hom.map_add, ← monomial,
   expand_monomial, ← monomial, ih]
 

--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -736,29 +736,18 @@ instance {R : Type u} {A : Type v} [comm_ring R] [ring A] [algebra R A] (S : sub
 instance : inhabited S := ⟨0⟩
 instance (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
   [algebra R A] (S : subalgebra R A) : semiring S := subsemiring.to_semiring S
-instance semiring' (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
-  [algebra R A] (S : subalgebra R A) : semiring (S : set A) := subsemiring.to_semiring S
 instance (R : Type u) (A : Type v) [comm_semiring R] [comm_semiring A]
   [algebra R A] (S : subalgebra R A) : comm_semiring S := subsemiring.to_comm_semiring S
-instance comm_semiring' (R : Type u) (A : Type v) [comm_semiring R] [comm_semiring A]
-  [algebra R A] (S : subalgebra R A) : comm_semiring (S : set A) := subsemiring.to_comm_semiring S
 instance (R : Type u) (A : Type v) [comm_ring R] [ring A]
   [algebra R A] (S : subalgebra R A) : ring S := @@subtype.ring _ S.is_subring
-instance ring' (R : Type u) (A : Type v) [comm_ring R] [ring A]
-  [algebra R A] (S : subalgebra R A) : ring (S : set A) := @@subtype.ring _ S.is_subring
 instance (R : Type u) (A : Type v) [comm_ring R] [comm_ring A]
   [algebra R A] (S : subalgebra R A) : comm_ring S := @@subtype.comm_ring _ S.is_subring
-instance comm_ring' (R : Type u) (A : Type v) [comm_ring R] [comm_ring A]
-  [algebra R A] (S : subalgebra R A) : comm_ring (S : set A) := @@subtype.comm_ring _ S.is_subring
 
 instance algebra : algebra R S :=
 { smul := λ (c:R) x, ⟨c • x.1, S.smul_mem x.2 c⟩,
   commutes' := λ c x, subtype.eq $ algebra.commutes _ _,
   smul_def' := λ c x, subtype.eq $ algebra.smul_def _ _,
   .. (algebra_map R A).cod_srestrict S $ λ x, S.range_le ⟨x, rfl⟩ }
-
-instance algebra' : algebra R (S : set A) :=
-subalgebra.algebra S
 
 instance to_algebra {R : Type u} {A : Type v} [comm_semiring R] [comm_semiring A]
   [algebra R A] (S : subalgebra R A) : algebra S A :=

--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -177,14 +177,14 @@ instance of_subring {R A : Type*} [comm_ring R] [ring A] [algebra R A]
   smul_def' := λ r x, algebra.smul_def r x,
   .. (algebra_map R A).comp (⟨coe, rfl, λ _ _, rfl, rfl, λ _ _, rfl⟩ : S →+* R) }
 
-lemma subring_coe_algebra_map_hom {R A : Type*} [comm_ring R] [ring A] [algebra R A]
-  (S : set R) [is_subring S] : (algebra_map S R : S →+* R) = is_subring.subtype S := rfl
+lemma subring_coe_algebra_map_hom {R : Type*} [comm_ring R] (S : set R) [is_subring S] :
+  (algebra_map S R : S →+* R) = is_subring.subtype S := rfl
 
-lemma subring_coe_algebra_map {R A : Type*} [comm_ring R] [ring A] [algebra R A]
-  (S : set R) [is_subring S] : (algebra_map S R : S → R) = subtype.val := rfl
+lemma subring_coe_algebra_map {R : Type*} [comm_ring R] (S : set R) [is_subring S] :
+  (algebra_map S R : S → R) = subtype.val := rfl
 
-lemma subring_algebra_map_apply {R A : Type*} [comm_ring R] [ring A] [algebra R A]
-  (S : set R) [is_subring S] (x : S) : algebra_map S R x = x := rfl
+lemma subring_algebra_map_apply {R : Type*} [comm_ring R] (S : set R) [is_subring S] (x : S) :
+  algebra_map S R x = x := rfl
 
 variables (R A)
 /-- The multiplication in an algebra is a bilinear map. -/

--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -177,6 +177,15 @@ instance of_subring {R A : Type*} [comm_ring R] [ring A] [algebra R A]
   smul_def' := λ r x, algebra.smul_def r x,
   .. (algebra_map R A).comp (⟨coe, rfl, λ _ _, rfl, rfl, λ _ _, rfl⟩ : S →+* R) }
 
+lemma subring_coe_algebra_map_hom {R A : Type*} [comm_ring R] [ring A] [algebra R A]
+  (S : set R) [is_subring S] : (algebra_map S R : S →+* R) = is_subring.subtype S := rfl
+
+lemma subring_coe_algebra_map {R A : Type*} [comm_ring R] [ring A] [algebra R A]
+  (S : set R) [is_subring S] : (algebra_map S R : S → R) = subtype.val := rfl
+
+lemma subring_algebra_map_apply {R A : Type*} [comm_ring R] [ring A] [algebra R A]
+  (S : set R) [is_subring S] (x : S) : algebra_map S R x = x := rfl
+
 variables (R A)
 /-- The multiplication in an algebra is a bilinear map. -/
 def lmul : A →ₗ A →ₗ A :=
@@ -727,18 +736,29 @@ instance {R : Type u} {A : Type v} [comm_ring R] [ring A] [algebra R A] (S : sub
 instance : inhabited S := ⟨0⟩
 instance (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
   [algebra R A] (S : subalgebra R A) : semiring S := subsemiring.to_semiring S
+instance semiring' (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
+  [algebra R A] (S : subalgebra R A) : semiring (S : set A) := subsemiring.to_semiring S
 instance (R : Type u) (A : Type v) [comm_semiring R] [comm_semiring A]
   [algebra R A] (S : subalgebra R A) : comm_semiring S := subsemiring.to_comm_semiring S
+instance comm_semiring' (R : Type u) (A : Type v) [comm_semiring R] [comm_semiring A]
+  [algebra R A] (S : subalgebra R A) : comm_semiring (S : set A) := subsemiring.to_comm_semiring S
 instance (R : Type u) (A : Type v) [comm_ring R] [ring A]
   [algebra R A] (S : subalgebra R A) : ring S := @@subtype.ring _ S.is_subring
+instance ring' (R : Type u) (A : Type v) [comm_ring R] [ring A]
+  [algebra R A] (S : subalgebra R A) : ring (S : set A) := @@subtype.ring _ S.is_subring
 instance (R : Type u) (A : Type v) [comm_ring R] [comm_ring A]
   [algebra R A] (S : subalgebra R A) : comm_ring S := @@subtype.comm_ring _ S.is_subring
+instance comm_ring' (R : Type u) (A : Type v) [comm_ring R] [comm_ring A]
+  [algebra R A] (S : subalgebra R A) : comm_ring (S : set A) := @@subtype.comm_ring _ S.is_subring
 
 instance algebra : algebra R S :=
 { smul := λ (c:R) x, ⟨c • x.1, S.smul_mem x.2 c⟩,
   commutes' := λ c x, subtype.eq $ algebra.commutes _ _,
   smul_def' := λ c x, subtype.eq $ algebra.smul_def _ _,
   .. (algebra_map R A).cod_srestrict S $ λ x, S.range_le ⟨x, rfl⟩ }
+
+instance algebra' : algebra R (S : set A) :=
+subalgebra.algebra S
 
 instance to_algebra {R : Type u} {A : Type v} [comm_semiring R] [comm_semiring A]
   [algebra R A] (S : subalgebra R A) : algebra S A :=

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -125,6 +125,9 @@ variables [comm_semiring B] [algebra A B] [algebra R B] [is_algebra_tower R A B]
 instance subalgebra (S : subalgebra R A) : is_algebra_tower R S A :=
 of_algebra_map_eq $ λ x, rfl
 
+instance subalgebra' (S : subalgebra R A) : is_algebra_tower R (S : set A) A :=
+is_algebra_tower.subalgebra R A S
+
 instance polynomial : is_algebra_tower R A (polynomial B) :=
 of_algebra_map_eq $ λ x, congr_arg polynomial.C $ algebra_map_apply R A B x
 

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -125,9 +125,6 @@ variables [comm_semiring B] [algebra A B] [algebra R B] [is_algebra_tower R A B]
 instance subalgebra (S : subalgebra R A) : is_algebra_tower R S A :=
 of_algebra_map_eq $ λ x, rfl
 
-instance subalgebra' (S : subalgebra R A) : is_algebra_tower R (S : set A) A :=
-is_algebra_tower.subalgebra R A S
-
 instance polynomial : is_algebra_tower R A (polynomial B) :=
 of_algebra_map_eq $ λ x, congr_arg polynomial.C $ algebra_map_apply R A B x
 

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -299,7 +299,6 @@ lemma algebra.is_integral_trans (A_int : ∀ x : A, is_integral R x)(B_int : ∀
 
 end algebra
 
--- Why is this so slow?
 theorem integral_closure_idem {R : Type*} {A : Type*} [comm_ring R] [comm_ring A] [algebra R A] :
   integral_closure (integral_closure R A : set A) A = ⊥ :=
 eq_bot_iff.2 $ λ x hx, algebra.mem_bot.2

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -31,6 +31,9 @@ by rw [alg_hom.map_sub, aeval_def, aeval_def, eval₂_X, eval₂_C, sub_self]⟩
 theorem is_integral_alg_hom (f : A →ₐ[R] B) {x : A} (hx : is_integral R x) : is_integral R (f x) :=
 let ⟨p, hp, hpx⟩ := hx in ⟨p, hp, by rw [aeval_alg_hom_apply, hpx, f.map_zero]⟩
 
+section
+local attribute [semireducible] eval₂
+
 theorem is_integral_of_subring {x : A} (T : set R) [is_subring T]
   (hx : is_integral T x) : is_integral R x :=
 let ⟨p, hpm, hpx⟩ := hx in
@@ -49,6 +52,9 @@ begin
   rcases hr with ⟨s, hs, hsr⟩,
   exact is_integral_of_subring _ hsr
 end
+
+end
+
 
 theorem fg_adjoin_singleton_of_integral (x : A) (hx : is_integral R x) :
   (algebra.adjoin R ({x} : set A) : submodule R A).fg :=
@@ -237,6 +243,9 @@ theorem mem_integral_closure_iff_mem_fg {r : A} :
 
 variables {R} {A}
 
+section
+local attribute [semireducible] eval₂
+
 lemma integral_closure.is_integral (x : integral_closure R A) : is_integral R x :=
 exists_imp_exists
   (λ p, and.imp_right (λ hp, show aeval x p = 0,
@@ -273,6 +282,8 @@ begin
   replace hmp := congr_arg subtype.val hmp,
   replace hmp := congr_arg subtype.val hmp,
   exact subtype.eq hmp
+end
+
 end
 
 end

--- a/src/ring_theory/polynomial/basic.lean
+++ b/src/ring_theory/polynomial/basic.lean
@@ -98,6 +98,9 @@ def restriction (p : polynomial R) : polynomial (ring.closure (↑p.frange : set
 
 @[simp] theorem coeff_restriction' {p : polynomial R} {n : ℕ} : (coeff (restriction p) n).1 = coeff p n := rfl
 
+@[simp] theorem map_restriction (p : polynomial R) : p.restriction.map (algebra_map _ _) = p :=
+ext $ λ n, by rw [coeff_map, algebra.subring_algebra_map_apply, coeff_restriction]
+
 @[simp] theorem degree_restriction {p : polynomial R} : (restriction p).degree = p.degree := rfl
 
 @[simp] theorem nat_degree_restriction {p : polynomial R} : (restriction p).nat_degree = p.nat_degree := rfl

--- a/src/ring_theory/polynomial/basic.lean
+++ b/src/ring_theory/polynomial/basic.lean
@@ -114,7 +114,7 @@ variables {S : Type v} [ring S] {f : R →+* S} {x : S}
 
 theorem eval₂_restriction {p : polynomial R} :
   eval₂ f x p = eval₂ (f.comp (is_subring.subtype _)) x p.restriction :=
-rfl
+by { dsimp only [eval₂_eq_sum], refl, }
 
 section to_subring
 variables (p : polynomial R) (T : set R) [is_subring T]

--- a/src/ring_theory/polynomial/rational_root.lean
+++ b/src/ring_theory/polynomial/rational_root.lean
@@ -102,15 +102,17 @@ by simp [monic, leading_coeff]
 lemma scale_roots_eval₂_eq_zero {p : polynomial S} (f : S →+* R)
   {r : R} {s : S} (hr : eval₂ f r p = 0) (hs : s ∈ non_zero_divisors S) :
   eval₂ f (f s * r) (scale_roots p s) = 0 :=
-calc (scale_roots p s).support.sum (λ i, f (coeff p i * s ^ (p.nat_degree - i)) * (f s * r) ^ i)
-    = p.support.sum (λ (i : ℕ), f (p.coeff i) * f s ^ (p.nat_degree - i + i) * r ^ i) :
+calc eval₂ f (f s * r) (scale_roots p s) =
+  (scale_roots p s).support.sum (λ i, f (coeff p i * s ^ (p.nat_degree - i)) * (f s * r) ^ i) : eval₂_eq_sum
+... = p.support.sum (λ (i : ℕ), f (p.coeff i) * f s ^ (p.nat_degree - i + i) * r ^ i) :
   finset.sum_congr (support_scale_roots_eq p hs)
     (λ i hi, by simp_rw [f.map_mul, f.map_pow, pow_add, mul_pow, mul_assoc])
 ... = p.support.sum (λ (i : ℕ), f s ^ p.nat_degree * (f (p.coeff i) * r ^ i)) :
   finset.sum_congr rfl
   (λ i hi, by { rw [mul_assoc, mul_left_comm, nat.sub_add_cancel],
                 exact le_nat_degree_of_ne_zero (mem_support_iff.mp hi) })
-... = f s ^ p.nat_degree * eval₂ f r p : finset.mul_sum.symm
+... = f s ^ p.nat_degree * p.support.sum (λ (i : ℕ), (f (p.coeff i) * r ^ i)) : finset.mul_sum.symm
+... = f s ^ p.nat_degree * eval₂ f r p : by { rw [eval₂_eq_sum], refl }
 ... = 0 : by rw [hr, _root_.mul_zero]
 
 lemma scale_roots_aeval_eq_zero [algebra S R] {p : polynomial S}

--- a/src/topology/algebra/polynomial.lean
+++ b/src/topology/algebra/polynomial.lean
@@ -34,14 +34,14 @@ lemma polynomial.continuous_eval {α} [comm_semiring α] [topological_space α]
 begin
   apply p.induction,
   { convert continuous_const,
-    ext, show polynomial.eval x 0 = 0, from rfl },
+    ext, exact eval_zero, },
   { intros a b f haf hb hcts,
     simp only [polynomial.eval_add],
     refine continuous.add _ hcts,
     have : ∀ x, finsupp.sum (finsupp.single a b) (λ (e : ℕ) (a : α), a * x ^ e) = b * x ^a,
       from λ x, finsupp.sum_single_index (by simp),
     convert continuous.mul _ _,
-    { ext, apply this },
+    { ext, dsimp only [eval_eq_sum], apply this },
     { apply_instance },
     { apply continuous_const },
     { apply continuous_pow }}


### PR DESCRIPTION
A while back @gebner identified that [an unfortunate timeout could be avoided](https://github.com/leanprover-community/mathlib/pull/3380#issuecomment-657449148) by making `polynomial.eval2` irreducible.

This PR does that.

It's not perfect: on a few occasions I have to temporarily set it back to semireducible, because it looks like the proofs really do some heavy refling.

I'd like to make more things irreducible in the polynomial API, but not yet.

---
<!-- put comments you want to keep out of the PR commit here -->
