### PR TITLE
[Merged by Bors] - feat(topology/tactic): continuity faster and more powerful

### DIFF
--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -767,7 +767,10 @@ meta def build_list_expr_for_apply : list pexpr → tactic (list (tactic expr))
   a ← i_to_expr_for_apply h,
   (do l ← attribute.get_instances (expr.const_name a),
       m ← l.mmap (λ n, _root_.to_pexpr <$> mk_const n),
-      build_list_expr_for_apply (m ++ t))
+      -- We reverse the list of lemmas marked with an attribute,
+      -- on the assumption that lemmas proved earlier are more often applicable
+      -- than lemmas proved later. This is a performance optimization.
+      build_list_expr_for_apply (m.reverse ++ t))
   <|> return ((i_to_expr_for_apply h) :: tail)
 
 /--`apply_rules hs n`: apply the list of rules `hs` (given as pexpr) and `assumption` on the

--- a/src/topology/algebra/multilinear.lean
+++ b/src/topology/algebra/multilinear.lean
@@ -67,7 +67,7 @@ variables [semiring R]
 instance : has_coe_to_fun (continuous_multilinear_map R M₁ M₂) :=
 ⟨_, λ f, f.to_multilinear_map.to_fun⟩
 
-attribute [continuity] cont
+@[continuity] lemma coe_continuous : continuous (f : (Π i, M₁ i) → M₂) := f.cont
 
 @[simp] lemma coe_coe : (f.to_multilinear_map : (Π i, M₁ i) → M₂) = f := rfl
 

--- a/src/topology/continuous_map.lean
+++ b/src/topology/continuous_map.lean
@@ -33,6 +33,8 @@ instance : has_coe_to_fun (C(α, β)) := ⟨_, continuous_map.to_fun⟩
 
 variables {α β} {f g : continuous_map α β}
 
+@[continuity] lemma coe_continuous : continuous (f : α → β) := f.continuous_to_fun
+
 @[ext] theorem ext (H : ∀ x, f x = g x) : f = g :=
 by cases f; cases g; congr'; exact funext H
 

--- a/src/topology/tactic.lean
+++ b/src/topology/tactic.lean
@@ -65,23 +65,28 @@ meta def apply_continuous.comp : tactic unit :=
   fail_if_success { exact continuous_id }]
 
 /-- List of tactics used by `continuity` internally. -/
-meta def continuity_tactics : list (tactic string) :=
+meta def continuity_tactics (md : transparency := reducible) : list (tactic string) :=
 [
   intros1               >>= λ ns, pure ("intros " ++ (" ".intercalate (ns.map (λ e, e.to_string)))),
-  `[apply_rules [continuity] 50 {md:=reducible}]
+  apply_rules [``(continuity)] 50 { md := md }
                         >> pure "apply_rules continuity",
   apply_continuous.comp >> pure "refine continuous.comp _ _"
 ]
 
 namespace interactive
+setup_tactic_parser
 
-/-- Solve goals of the form `continuous f`. -/
-meta def continuity (cfg : tidy.cfg := {}) : tactic unit :=
+/--
+Solve goals of the form `continuous f`.
+-/
+meta def continuity
+  (bang : parse $ optional (tk "!")) (cfg : tidy.cfg := {}) : tactic unit :=
 with_local_reducibility `continuous decl_reducibility.irreducible $
-tactic.tidy { tactics := continuity_tactics, ..cfg }
+let md := if bang.is_some then semireducible else reducible in
+tactic.tidy { tactics := continuity_tactics md, ..cfg }
 
 /-- Version of `continuity` for use with auto_param. -/
-meta def continuity' : tactic unit := continuity
+meta def continuity' : tactic unit := continuity none {}
 
 /--
 `continuity` solves goals of the form `continuous f` by applying lemmas tagged with the
@@ -95,6 +100,10 @@ by continuity
 ```
 will discharge the goal, generating a proof term like
 `((continuous.comp hg hf₁).max (continuous.comp hg hf₂)).add continuous_const`
+
+You can also use `continuity!`, which applies lemmas with `{ md := semireducible }`.
+The default behaviour is more conservative, and only unfolds `reducible` definitions
+when attempting to match lemmas with the goal.
 -/
 add_tactic_doc
 { name := "continuity / continuity'",

--- a/src/topology/tactic.lean
+++ b/src/topology/tactic.lean
@@ -35,6 +35,11 @@ attribute [continuity]
   continuous_id
   continuous_const
 
+-- As we will be using `apply_rules` with `md := semireducible`,
+-- we need another version of `continuous_id`.
+@[continuity] lemma continuous_id' {α : Type*} [topological_space α] : continuous (λ a : α, a) :=
+continuous_id
+
 namespace tactic
 
 /--
@@ -62,11 +67,10 @@ meta def apply_continuous.comp : tactic unit :=
 /-- List of tactics used by `continuity` internally. -/
 meta def continuity_tactics : list (tactic string) :=
 [
-  `[apply_rules continuity]            >> pure "apply_rules continuity",
-  -- auto_cases,
-  intros1                              >>= λ ns, pure ("intros " ++ (" ".intercalate (ns.map (λ e, e.to_string)))),
-  tactic.interactive.apply_assumption  >> pure "apply_assumption",
-  apply_continuous.comp                >> pure "refine continuous.comp _ _"
+  intros1               >>= λ ns, pure ("intros " ++ (" ".intercalate (ns.map (λ e, e.to_string)))),
+  `[apply_rules [continuity] 50 {md:=reducible}]
+                        >> pure "apply_rules continuity",
+  apply_continuous.comp >> pure "refine continuous.comp _ _"
 ]
 
 namespace interactive

--- a/test/continuity.lean
+++ b/test/continuity.lean
@@ -26,7 +26,17 @@ by show_term { continuity }
 -- prints
 --   `exact (continuous_exp.comp ((continuous_id.max continuous_id.neg).add continuous_sin)).pow 2`
 
--- Without `md := semireducible` in the call to `apply_rules` in `continuity`,
--- this example would have run off the rails.
 example : continuous (λ x : ℝ, exp ((max x (-x)) + sin (cos x))^2) :=
 by show_term { continuity }
+
+-- Without `md := semireducible` in the call to `apply_rules` in `continuity`,
+-- this last example would have run off the rails:
+-- ```
+-- example : continuous (λ x : ℝ, exp ((max x (-x)) + sin (cos x))^2) :=
+-- by show_term { continuity! }
+-- ```
+-- produces lots of subgoals, including many copies of
+-- ⊢ continuous complex.re
+-- ⊢ continuous complex.exp
+-- ⊢ continuous coe
+-- ⊢ continuous (λ (x : ℝ), ↑x)

--- a/test/continuity.lean
+++ b/test/continuity.lean
@@ -9,14 +9,13 @@ example {X Y : Type*} [topological_space X] [topological_space Y]
 by show_term { continuity }
 -- prints `refine ((continuous.comp hg hf₁).max (continuous.comp hg hf₂)).add continuous_const`
 
--- This example works but is too slow, and causes a timeout. Perhaps we can get it working later.
--- example {κ ι : Type}
---   (K : κ → Type) [∀ k, topological_space (K k)] (I : ι → Type) [∀ i, topological_space (I i)]
---   (e : κ ≃ ι) (F : Π k, homeomorph (K k) (I (e k))) :
---   continuous (λ (f : Π k, K k) (i : ι), F (e.symm i) (f (e.symm i))) :=
--- by show_term { continuity }
--- -- prints, modulo a little bit of cleaning up the pretty printer:
--- --   `exact continuous_pi (λ i, ((F (e.symm i)).continuous).comp (continuous_apply (e.symm i)))`
+example {κ ι : Type}
+  (K : κ → Type) [∀ k, topological_space (K k)] (I : ι → Type) [∀ i, topological_space (I i)]
+  (e : κ ≃ ι) (F : Π k, homeomorph (K k) (I (e k))) :
+  continuous (λ (f : Π k, K k) (i : ι), F (e.symm i) (f (e.symm i))) :=
+by show_term { continuity }
+-- prints, modulo a little bit of cleaning up the pretty printer:
+--   `exact continuous_pi (λ i, ((F (e.symm i)).continuous).comp (continuous_apply (e.symm i)))`
 
 open real
 
@@ -27,17 +26,7 @@ by show_term { continuity }
 -- prints
 --   `exact (continuous_exp.comp ((continuous_id.max continuous_id.neg).add continuous_sin)).pow 2`
 
-
-
--- On the other hand, it's not that hard to get `continuity` to run off the rails:
--- ```
--- example : continuous (λ x : ℝ, exp ((max x (-x)) + sin (cos x))^2) :=
--- by show_term { continuity }
--- ```
--- produces a giant term, and repeats of these goals:
--- ⊢ continuous complex.re
--- ⊢ continuous complex.exp
--- ⊢ continuous coe
--- ⊢ continuous complex.im
-
--- Perhaps we should make `continuity` use `apply { md := reducible }` under the hood?
+-- Without `md := semireducible` in the call to `apply_rules` in `continuity`,
+-- this example would have run off the rails.
+example : continuous (λ x : ℝ, exp ((max x (-x)) + sin (cos x))^2) :=
+by show_term { continuity }


### PR DESCRIPTION
Following up on the recent introduction of Reid's continuity tactic in #2879, I've made some tweaks that make it both faster and more capable.

1. we use `apply_rules {md:=semireducible}`, taking advantage of #3538. This makes examples like
`example : continuous (λ x : ℝ, exp ((max x (-x)) + sin (cos x))^2) := by continuity` viable.
2. in `apply_rules`, if we pull in lemmas using an attribute, we reverse the list of lemmas (on the heuristic that older lemmas are more frequently applicable than newer lemmas)
3. in `continuity`, I removed the `apply_assumption` step in the `tidy` loop, since `apply_rules` is already calling `assumption`
4. also in the `tidy` loop, I moved `intro1` above `apply_rules`.

The example in the test file
```
example {κ ι : Type}
  (K : κ → Type) [∀ k, topological_space (K k)] (I : ι → Type) [∀ i, topological_space (I i)]
  (e : κ ≃ ι) (F : Π k, homeomorph (K k) (I (e k))) :
  continuous (λ (f : Π k, K k) (i : ι), F (e.symm i) (f (e.symm i))) :=
by show_term { continuity }
```
which previously timed out now runs happily even with `-T50000`.

---
<!-- put comments you want to keep out of the PR commit here -->
