### PR TITLE
[Merged by Bors] - feat(logic/basic): mark cast_eq as a `simp` lemma

### DIFF
--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -563,7 +563,7 @@ begin
 end
 
 @[simp] lemma snoc_last : snoc p x (last n) = x :=
-by { simp [snoc], refl }
+by { simp [snoc] }
 
 /-- Updating a tuple and adding an element at the end commute. -/
 @[simp] lemma snoc_update : snoc (update p i y) x = update (snoc p x) i.cast_succ y :=
@@ -668,8 +668,7 @@ begin
   ext j,
   by_cases h : j.val < n,
   { have : j ≠ last n := ne_of_lt h,
-    simp [h, this, snoc, cast_succ_cast_lt],
-    refl },
+    simp [h, this, snoc, cast_succ_cast_lt] },
   { rw eq_last_of_not_lt h,
     simp }
 end

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -26,6 +26,8 @@ section miscellany
 attribute [inline] and.decidable or.decidable decidable.false xor.decidable iff.decidable
   decidable.true implies.decidable not.decidable ne.decidable
   bool.decidable_eq decidable.to_bool
+  
+attribute [simp] cast_eq
 
 variables {α : Type*} {β : Type*}
 


### PR DESCRIPTION
The theorem `cast_eq` is in core and says `theorem cast_eq : ∀ {α : Sort u} (h : α = α) (a : α), cast h a = a`


---
<!-- put comments you want to keep out of the PR commit here -->
