### PR TITLE
[Merged by Bors] - chore(geometry/manifold/real_instance): remove global fact instance

### DIFF
--- a/src/geometry/manifold/real_instances.lean
+++ b/src/geometry/manifold/real_instances.lean
@@ -368,7 +368,7 @@ begin
   constructor
 end
 
-/- Register the manifold structure on `Icc 0 1`, and also its zero and one. -/
+/-! Register the manifold structure on `Icc 0 1`, and also its zero and one. -/
 section
 
 lemma fact_zero_lt_one : fact ((0 : ℝ) < 1) := zero_lt_one

--- a/src/geometry/manifold/real_instances.lean
+++ b/src/geometry/manifold/real_instances.lean
@@ -368,8 +368,17 @@ begin
   constructor
 end
 
-/- Register an instance of `0 < 1` to be able to use freely the manifold structure on `Icc 0 1`,
-and also its zero and one. -/
-instance : fact ((0 : ℝ) < 1) := zero_lt_one
+/- Register the manifold structure on `Icc 0 1`, and also its zero and one. -/
+section
+
+lemma fact_zero_lt_one : fact ((0 : ℝ) < 1) := zero_lt_one
+
+local attribute [instance] fact_zero_lt_one
+
+instance : charted_space (euclidean_half_space 1) (Icc (0 : ℝ) 1) := by apply_instance
+instance : smooth_manifold_with_corners (𝓡∂ 1) (Icc (0 : ℝ) 1) := by apply_instance
+
 instance : has_zero (Icc (0 : ℝ) 1) := ⟨⟨(0 : ℝ), ⟨le_refl _, zero_le_one⟩⟩⟩
 instance : has_one (Icc (0 : ℝ) 1) := ⟨⟨(1 : ℝ), ⟨zero_le_one, le_refl _⟩⟩⟩
+
+end


### PR DESCRIPTION
Remove global `fact` instance that was used to get a manifold structure on `[0, 1]`, and register only the manifold structure.
