### PR TITLE
[Merged by Bors] - feat(tactic/to_additive): automate substructure naming

### DIFF
--- a/scripts/nolints.txt
+++ b/scripts/nolints.txt
@@ -1206,8 +1206,8 @@ apply_nolint add_con.to_setoid doc_blame
 apply_nolint con.to_setoid doc_blame
 
 -- group_theory/coset.lean
-apply_nolint is_add_subgroup.group_equiv_quotient_times_subgroup doc_blame
-apply_nolint is_add_subgroup.left_coset_equiv_subgroup doc_blame
+apply_nolint is_add_subgroup.add_group_equiv_quotient_times_add_subgroup doc_blame
+apply_nolint is_add_subgroup.left_coset_equiv_add_subgroup doc_blame
 apply_nolint is_subgroup.group_equiv_quotient_times_subgroup doc_blame
 apply_nolint is_subgroup.left_coset_equiv_subgroup doc_blame
 apply_nolint left_add_coset doc_blame

--- a/src/algebra/category/Group/basic.lean
+++ b/src/algebra/category/Group/basic.lean
@@ -41,7 +41,7 @@ attribute [derive [has_coe_to_sort, large_category, concrete_category]] Group Ad
 /-- Construct a bundled `AddGroup` from the underlying type and typeclass. -/
 add_decl_doc AddGroup.of
 
-@[to_additive add_group]
+@[to_additive]
 instance (G : Group) : group G := G.str
 
 @[to_additive]
@@ -92,7 +92,7 @@ attribute [derive [has_coe_to_sort, large_category, concrete_category]] CommGrou
 /-- Construct a bundled `AddCommGroup` from the underlying type and typeclass. -/
 add_decl_doc AddCommGroup.of
 
-@[to_additive add_comm_group_instance]
+@[to_additive]
 instance comm_group_instance (G : CommGroup) : comm_group G := G.str
 
 @[to_additive] instance : has_one CommGroup := ⟨CommGroup.of punit⟩

--- a/src/algebra/category/Mon/basic.lean
+++ b/src/algebra/category/Mon/basic.lean
@@ -49,7 +49,7 @@ instance : inhabited Mon :=
 -- which breaks to_additive.
 ⟨@of punit $ @group.to_monoid _ $ @comm_group.to_group _ punit.comm_group⟩
 
-@[to_additive add_monoid]
+@[to_additive]
 instance (M : Mon) : monoid M := M.str
 
 end Mon
@@ -81,7 +81,7 @@ instance : inhabited CommMon :=
 -- which breaks to_additive.
 ⟨@of punit $ @comm_group.to_comm_monoid _ punit.comm_group⟩
 
-@[to_additive add_comm_monoid]
+@[to_additive]
 instance (M : CommMon) : comm_monoid M := M.str
 
 @[to_additive has_forget_to_AddMon]
@@ -154,7 +154,7 @@ def Mon_iso_to_mul_equiv {X Y : Mon} (i : X ≅ Y) : X ≃* Y :=
   map_mul'  := by tidy }.
 
 /-- Build a `mul_equiv` from an isomorphism in the category `CommMon`. -/
-@[to_additive AddCommMon_iso_to_add_equiv "Build an `add_equiv` from an isomorphism in the category
+@[to_additive "Build an `add_equiv` from an isomorphism in the category
 `AddCommMon`."]
 def CommMon_iso_to_mul_equiv {X Y : CommMon} (i : X ≅ Y) : X ≃* Y :=
 { to_fun    := i.hom,

--- a/src/algebra/free.lean
+++ b/src/algebra/free.lean
@@ -35,7 +35,7 @@ inductive free_add_magma (α : Type u) : Type u
 | of : α → free_add_magma
 | add : free_add_magma → free_add_magma → free_add_magma
 
-attribute [to_additive free_add_magma] free_magma
+attribute [to_additive] free_magma
 
 namespace free_magma
 
@@ -370,7 +370,7 @@ end magma
 
 /-- Free semigroup over a given alphabet.
 (Note: In this definition, the free semigroup does not contain the empty word.) -/
-@[to_additive free_add_semigroup "Free additive semigroup over a given alphabet."]
+@[to_additive "Free additive semigroup over a given alphabet."]
 def free_semigroup (α : Type u) : Type u :=
 α × list α
 
@@ -565,7 +565,7 @@ instance [decidable_eq α] : decidable_eq (free_semigroup α) := prod.decidable_
 end free_semigroup
 
 /-- Isomorphism between `magma.free_semigroup (free_magma α)` and `free_semigroup α`. -/
-@[to_additive free_add_semigroup_free_add_magma "Isomorphism between
+@[to_additive "Isomorphism between
 `add_magma.free_add_semigroup (free_add_magma α)` and `free_add_semigroup α`."]
 def free_semigroup_free_magma (α : Type u) :
   magma.free_semigroup (free_magma α) ≃ free_semigroup α :=

--- a/src/algebra/free_monoid.lean
+++ b/src/algebra/free_monoid.lean
@@ -21,7 +21,7 @@ import data.list.basic
 variables {α : Type*} {β : Type*} {γ : Type*} {M : Type*} [monoid M] {N : Type*} [monoid N]
 
 /-- Free monoid over a given alphabet. -/
-@[to_additive free_add_monoid "Free nonabelian additive monoid over a given alphabet"]
+@[to_additive "Free nonabelian additive monoid over a given alphabet"]
 def free_monoid (α) := list α
 
 namespace free_monoid

--- a/src/algebra/group/defs.lean
+++ b/src/algebra/group/defs.lean
@@ -54,7 +54,7 @@ universe u
 /-- An additive semigroup is a type with an associative `(+)`. -/
 @[protect_proj, ancestor has_add] class add_semigroup (G : Type u) extends has_add G :=
 (add_assoc : ∀ a b c : G, a + b + c = a + (b + c))
-attribute [to_additive add_semigroup] semigroup
+attribute [to_additive] semigroup
 
 section semigroup
 variables {G : Type u} [semigroup G]
@@ -80,7 +80,7 @@ class comm_semigroup (G : Type u) extends semigroup G :=
 @[protect_proj, ancestor add_semigroup]
 class add_comm_semigroup (G : Type u) extends add_semigroup G :=
 (add_comm : ∀ a b : G, a + b = b + a)
-attribute [to_additive add_comm_semigroup] comm_semigroup
+attribute [to_additive] comm_semigroup
 
 section comm_semigroup
 variables {G : Type u} [comm_semigroup G]
@@ -169,7 +169,7 @@ class monoid (M : Type u) extends semigroup M, has_one M :=
 @[ancestor add_semigroup has_zero]
 class add_monoid (M : Type u) extends add_semigroup M, has_zero M :=
 (zero_add : ∀ a : M, 0 + a = a) (add_zero : ∀ a : M, a + 0 = a)
-attribute [to_additive add_monoid] monoid
+attribute [to_additive] monoid
 
 section monoid
 variables {M : Type u} [monoid M]
@@ -184,11 +184,11 @@ monoid.mul_one
 
 attribute [ematch] add_zero zero_add -- TODO(Mario): Make to_additive transfer this
 
-@[to_additive add_monoid_to_is_left_id]
+@[to_additive]
 instance monoid_to_is_left_id : is_left_id M (*) 1 :=
 ⟨ monoid.one_mul ⟩
 
-@[to_additive add_monoid_to_is_right_id]
+@[to_additive]
 instance monoid_to_is_right_id : is_right_id M (*) 1 :=
 ⟨ monoid.mul_one ⟩
 
@@ -205,7 +205,7 @@ class comm_monoid (M : Type u) extends monoid M, comm_semigroup M
 /-- An additive commutative monoid is an additive monoid with commutative `(+)`. -/
 @[protect_proj, ancestor add_monoid add_comm_semigroup]
 class add_comm_monoid (M : Type u) extends add_monoid M, add_comm_semigroup M
-attribute [to_additive add_comm_monoid] comm_monoid
+attribute [to_additive] comm_monoid
 
 /-- A monoid in which multiplication is left-cancellative. -/
 @[protect_proj, ancestor left_cancel_semigroup monoid]
@@ -229,7 +229,7 @@ class group (α : Type u) extends monoid α, has_inv α :=
 @[protect_proj, ancestor add_monoid has_neg]
 class add_group (α : Type u) extends add_monoid α, has_neg α :=
 (add_left_neg : ∀ a : α, -a + a = 0)
-attribute [to_additive add_group] group
+attribute [to_additive] group
 
 section group
 variables {G : Type u} [group G] {a b c : G}
@@ -263,12 +263,12 @@ by rwa [inv_inv] at this
 lemma mul_inv_cancel_right (a b : G) : a * b * b⁻¹ = a :=
 by rw [mul_assoc, mul_right_inv, mul_one]
 
-@[to_additive to_left_cancel_add_semigroup]
+@[to_additive]
 instance group.to_left_cancel_semigroup : left_cancel_semigroup G :=
 { mul_left_cancel := λ a b c h, by rw [← inv_mul_cancel_left a b, h, inv_mul_cancel_left],
   ..‹group G› }
 
-@[to_additive to_right_cancel_add_semigroup]
+@[to_additive]
 instance group.to_right_cancel_semigroup : right_cancel_semigroup G :=
 { mul_right_cancel := λ a b c h, by rw [← mul_inv_cancel_right a b, h, mul_inv_cancel_right],
   ..‹group G› }
@@ -299,5 +299,5 @@ class comm_group (G : Type u) extends group G, comm_monoid G
 /-- An additive commutative group is an additive group with commutative `(+)`. -/
 @[protect_proj, ancestor add_group add_comm_monoid]
 class add_comm_group (G : Type u) extends add_group G, add_comm_monoid G
-attribute [to_additive add_comm_group] comm_group
+attribute [to_additive] comm_group
 attribute [instance, priority 300] add_comm_group.to_add_comm_monoid

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -57,7 +57,7 @@ structure add_monoid_hom (M : Type*) (N : Type*) [add_monoid M] [add_monoid N] :
 infixr ` →+ `:25 := add_monoid_hom
 
 /-- Bundled monoid homomorphisms; use this for bundled group homomorphisms too. -/
-@[to_additive add_monoid_hom]
+@[to_additive]
 structure monoid_hom (M : Type*) (N : Type*) [monoid M] [monoid N] :=
 (to_fun : M → N)
 (map_one' : to_fun 1 = 1)
@@ -214,7 +214,7 @@ add_decl_doc add_monoid_hom.has_add
   (f * g) x = f x * g x := rfl
 
 /-- (M →* N) is a comm_monoid if N is commutative. -/
-@[to_additive add_comm_monoid]
+@[to_additive]
 instance {M N} [monoid M] [comm_monoid N] : comm_monoid (M →* N) :=
 { mul := (*),
   mul_assoc := by intros; ext; apply mul_assoc,
@@ -295,7 +295,7 @@ add_decl_doc add_monoid_hom.has_neg
   f⁻¹ x = (f x)⁻¹ := rfl
 
 /-- If `G` is a commutative group, then `M →* G` a commutative group too. -/
-@[to_additive add_comm_group]
+@[to_additive]
 instance {M G} [monoid M] [comm_group G] : comm_group (M →* G) :=
 { inv := has_inv.inv,
   mul_left_inv := by intros; ext; apply mul_left_inv,

--- a/src/algebra/group/inj_surj.lean
+++ b/src/algebra/group/inj_surj.lean
@@ -35,7 +35,7 @@ variables {M₁ : Type*} {M₂ : Type*} [has_mul M₁]
 
 /-- A type endowed with `*` is a semigroup,
 if it admits an injective map that preserves `*` to a semigroup. -/
-@[to_additive add_semigroup
+@[to_additive
 "A type endowed with `+` is an additive semigroup,
 if it admits an injective map that preserves `+` to an additive semigroup."]
 protected def semigroup [semigroup M₂] (f : M₁ → M₂) (hf : injective f)
@@ -46,7 +46,7 @@ protected def semigroup [semigroup M₂] (f : M₁ → M₂) (hf : injective f)
 
 /-- A type endowed with `*` is a commutative semigroup,
 if it admits an injective map that preserves `*` to a commutative semigroup. -/
-@[to_additive add_comm_semigroup
+@[to_additive
 "A type endowed with `+` is an additive commutative semigroup,
 if it admits an injective map that preserves `+` to an additive commutative semigroup."]
 protected def comm_semigroup [comm_semigroup M₂] (f : M₁ → M₂) (hf : injective f)
@@ -83,7 +83,7 @@ variables [has_one M₁]
 
 /-- A type endowed with `1` and `*` is a monoid,
 if it admits an injective map that preserves `1` and `*` to a monoid. -/
-@[to_additive add_monoid
+@[to_additive
 "A type endowed with `0` and `+` is an additive monoid,
 if it admits an injective map that preserves `0` and `+` to an additive monoid."]
 protected def monoid [monoid M₂] (f : M₁ → M₂) (hf : injective f)
@@ -105,7 +105,7 @@ protected def left_cancel_monoid [left_cancel_monoid M₂] (f : M₁ → M₂) (
 
 /-- A type endowed with `1` and `*` is a commutative monoid,
 if it admits an injective map that preserves `1` and `*` to a commutative monoid. -/
-@[to_additive add_comm_monoid
+@[to_additive
 "A type endowed with `0` and `+` is an additive commutative monoid,
 if it admits an injective map that preserves `0` and `+` to an additive commutative monoid."]
 protected def comm_monoid [comm_monoid M₂] (f : M₁ → M₂) (hf : injective f)
@@ -117,7 +117,7 @@ variables [has_inv M₁]
 
 /-- A type endowed with `1`, `*` and `⁻¹` is a group,
 if it admits an injective map that preserves `1`, `*` and `⁻¹` to a group. -/
-@[to_additive add_group
+@[to_additive
 "A type endowed with `0` and `+` is an additive group,
 if it admits an injective map that preserves `0` and `+` to an additive group."]
 protected def group [group M₂] (f : M₁ → M₂) (hf : injective f)
@@ -128,7 +128,7 @@ protected def group [group M₂] (f : M₁ → M₂) (hf : injective f)
 
 /-- A type endowed with `1`, `*` and `⁻¹` is a commutative group,
 if it admits an injective map that preserves `1`, `*` and `⁻¹` to a commutative group. -/
-@[to_additive add_comm_group
+@[to_additive
 "A type endowed with `0` and `+` is an additive commutative group,
 if it admits an injective map that preserves `0` and `+` to an additive commutative group."]
 protected def comm_group [comm_group M₂] (f : M₁ → M₂) (hf : injective f)
@@ -147,7 +147,7 @@ variables {M₁ : Type*} {M₂ : Type*} [has_mul M₂]
 
 /-- A type endowed with `*` is a semigroup,
 if it admits a surjective map that preserves `*` from a semigroup. -/
-@[to_additive add_semigroup
+@[to_additive
 "A type endowed with `+` is an additive semigroup,
 if it admits a surjective map that preserves `+` from an additive semigroup."]
 protected def semigroup [semigroup M₁] (f : M₁ → M₂) (hf : surjective f)
@@ -158,7 +158,7 @@ protected def semigroup [semigroup M₁] (f : M₁ → M₂) (hf : surjective f)
 
 /-- A type endowed with `*` is a commutative semigroup,
 if it admits a surjective map that preserves `*` from a commutative semigroup. -/
-@[to_additive add_comm_semigroup
+@[to_additive
 "A type endowed with `+` is an additive commutative semigroup,
 if it admits a surjective map that preserves `+` from an additive commutative semigroup."]
 protected def comm_semigroup [comm_semigroup M₁] (f : M₁ → M₂) (hf : surjective f)
@@ -171,7 +171,7 @@ variables [has_one M₂]
 
 /-- A type endowed with `1` and `*` is a monoid,
 if it admits a surjective map that preserves `1` and `*` from a monoid. -/
-@[to_additive add_monoid
+@[to_additive
 "A type endowed with `0` and `+` is an additive monoid,
 if it admits a surjective map that preserves `0` and `+` to an additive monoid."]
 protected def monoid [monoid M₁] (f : M₁ → M₂) (hf : surjective f)
@@ -183,7 +183,7 @@ protected def monoid [monoid M₁] (f : M₁ → M₂) (hf : surjective f)
 
 /-- A type endowed with `1` and `*` is a commutative monoid,
 if it admits a surjective map that preserves `1` and `*` from a commutative monoid. -/
-@[to_additive add_comm_monoid
+@[to_additive
 "A type endowed with `0` and `+` is an additive commutative monoid,
 if it admits a surjective map that preserves `0` and `+` to an additive commutative monoid."]
 protected def comm_monoid [comm_monoid M₁] (f : M₁ → M₂) (hf : surjective f)
@@ -195,7 +195,7 @@ variables [has_inv M₂]
 
 /-- A type endowed with `1`, `*` and `⁻¹` is a group,
 if it admits a surjective map that preserves `1`, `*` and `⁻¹` from a group. -/
-@[to_additive add_group
+@[to_additive
 "A type endowed with `0` and `+` is an additive group,
 if it admits a surjective map that preserves `0` and `+` to an additive group."]
 protected def group [group M₁] (f : M₁ → M₂) (hf : surjective f)
@@ -206,7 +206,7 @@ protected def group [group M₁] (f : M₁ → M₂) (hf : surjective f)
 
 /-- A type endowed with `1`, `*` and `⁻¹` is a commutative group,
 if it admits a surjective map that preserves `1`, `*` and `⁻¹` from a commutative group. -/
-@[to_additive add_comm_group
+@[to_additive
 "A type endowed with `0` and `+` is an additive commutative group,
 if it admits a surjective map that preserves `0` and `+` to an additive commutative group."]
 protected def comm_group [comm_group M₁] (f : M₁ → M₂) (hf : surjective f)

--- a/src/algebra/group/pi.lean
+++ b/src/algebra/group/pi.lean
@@ -28,30 +28,30 @@ instance has_mul [∀ i, has_mul $ f i] : has_mul (Π i : I, f i) := ⟨λ f g i
 @[to_additive] instance has_inv [∀ i, has_inv $ f i] : has_inv (Π i : I, f i) := ⟨λ f i, (f i)⁻¹⟩
 @[simp, to_additive] lemma inv_apply [∀ i, has_inv $ f i] : x⁻¹ i = (x i)⁻¹ := rfl
 
-@[to_additive add_semigroup]
+@[to_additive]
 instance semigroup [∀ i, semigroup $ f i] : semigroup (Π i : I, f i) :=
 by refine_struct { mul := (*), .. }; tactic.pi_instance_derive_field
 
-@[to_additive add_comm_semigroup]
+@[to_additive]
 instance comm_semigroup [∀ i, comm_semigroup $ f i] : comm_semigroup (Π i : I, f i) :=
 by refine_struct { mul := (*), .. }; tactic.pi_instance_derive_field
 
-@[to_additive add_monoid]
+@[to_additive]
 instance monoid [∀ i, monoid $ f i] : monoid (Π i : I, f i) :=
 by refine_struct { one := (1 : Π i, f i), mul := (*), .. }; tactic.pi_instance_derive_field
 
-@[to_additive add_comm_monoid]
+@[to_additive]
 instance comm_monoid [∀ i, comm_monoid $ f i] : comm_monoid (Π i : I, f i) :=
 by refine_struct { one := (1 : Π i, f i), mul := (*), .. }; tactic.pi_instance_derive_field
 
-@[to_additive add_group]
+@[to_additive]
 instance group [∀ i, group $ f i] : group (Π i : I, f i) :=
 by refine_struct { one := (1 : Π i, f i), mul := (*), inv := has_inv.inv, .. };
   tactic.pi_instance_derive_field
 
 @[simp] lemma sub_apply [∀ i, add_group $ f i] : (x - y) i = x i - y i := rfl
 
-@[to_additive add_comm_group]
+@[to_additive]
 instance comm_group [∀ i, comm_group $ f i] : comm_group (Π i : I, f i) :=
 by refine_struct { one := (1 : Π i, f i), mul := (*), inv := has_inv.inv, .. };
   tactic.pi_instance_derive_field
@@ -66,13 +66,13 @@ instance right_cancel_semigroup [∀ i, right_cancel_semigroup $ f i] :
   right_cancel_semigroup (Π i : I, f i) :=
 by refine_struct { mul := (*) }; tactic.pi_instance_derive_field
 
-@[to_additive ordered_cancel_add_comm_monoid]
+@[to_additive]
 instance ordered_cancel_comm_monoid [∀ i, ordered_cancel_comm_monoid $ f i] :
   ordered_cancel_comm_monoid (Π i : I, f i) :=
 by refine_struct { mul := (*), one := (1 : Π i, f i), le := (≤), lt := (<), .. pi.partial_order };
   tactic.pi_instance_derive_field
 
-@[to_additive ordered_add_comm_group]
+@[to_additive]
 instance ordered_comm_group [∀ i, ordered_comm_group $ f i] :
   ordered_comm_group (Π i : I, f i) :=
 { mul_le_mul_left := λ x y hxy c i, mul_le_mul_left' (hxy i) _,

--- a/src/algebra/group/prod.lean
+++ b/src/algebra/group/prod.lean
@@ -65,18 +65,18 @@ lemma snd_inv [has_inv G] [has_inv H] (p : G × H) : (p⁻¹).2 = (p.2)⁻¹ := 
 @[simp, to_additive]
 lemma inv_mk [has_inv G] [has_inv H] (a : G) (b : H) : (a, b)⁻¹ = (a⁻¹, b⁻¹) := rfl
 
-@[to_additive add_semigroup]
+@[to_additive]
 instance [semigroup M] [semigroup N] : semigroup (M × N) :=
 { mul_assoc := assume a b c, mk.inj_iff.mpr ⟨mul_assoc _ _ _, mul_assoc _ _ _⟩,
   .. prod.has_mul }
 
-@[to_additive add_monoid]
+@[to_additive]
 instance [monoid M] [monoid N] : monoid (M × N) :=
 { one_mul := assume a, prod.rec_on a $ λa b, mk.inj_iff.mpr ⟨one_mul _, one_mul _⟩,
   mul_one := assume a, prod.rec_on a $ λa b, mk.inj_iff.mpr ⟨mul_one _, mul_one _⟩,
   .. prod.semigroup, .. prod.has_one }
 
-@[to_additive add_group]
+@[to_additive]
 instance [group G] [group H] : group (G × H) :=
 { mul_left_inv := assume a, mk.inj_iff.mpr ⟨mul_left_inv _, mul_left_inv _⟩,
   .. prod.monoid, .. prod.has_inv }
@@ -86,16 +86,16 @@ instance [group G] [group H] : group (G × H) :=
 @[simp] lemma mk_sub_mk [add_group A] [add_group B] (x₁ x₂ : A) (y₁ y₂ : B) :
   (x₁, y₁) - (x₂, y₂) = (x₁ - x₂, y₁ - y₂) := rfl
 
-@[to_additive add_comm_semigroup]
+@[to_additive]
 instance [comm_semigroup G] [comm_semigroup H] : comm_semigroup (G × H) :=
 { mul_comm := assume a b, mk.inj_iff.mpr ⟨mul_comm _ _, mul_comm _ _⟩,
   .. prod.semigroup }
 
-@[to_additive add_comm_monoid]
+@[to_additive]
 instance [comm_monoid M] [comm_monoid N] : comm_monoid (M × N) :=
 { .. prod.comm_semigroup, .. prod.monoid }
 
-@[to_additive add_comm_group]
+@[to_additive]
 instance [comm_group G] [comm_group H] : comm_group (G × H) :=
 { .. prod.comm_semigroup, .. prod.group }
 

--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -80,25 +80,37 @@ optional doc string. -/
 @[derive has_reflect, derive inhabited]
 structure value_type : Type := (tgt : name) (doc : option string)
 
+meta def add_comm_prefix : bool → string → string
+| tt s := ("comm_" ++ s)
+| ff s := s
+
 /-- Dictionary used by `to_additive.guess_name` to autogenerate names. -/
-meta def tr : list string → list string
-| ("one" :: "le" :: s) := "nonneg" :: tr s
-| ("one" :: "lt" :: s) := "pos"    :: tr s
-| ("le" :: "one" :: s) := "nonpos" :: tr s
-| ("lt" :: "one" :: s) := "neg"    :: tr s
-| ("mul" :: s)         := "add"    :: tr s
-| ("inv" :: s)         := "neg"    :: tr s
-| ("div" :: s)         := "sub"    :: tr s
-| ("one" :: s)         := "zero"   :: tr s
-| ("prod" :: s)        := "sum"    :: tr s
-| (x :: s)             := (x :: tr s)
-| []                   := []
+meta def tr : bool → list string → list string
+| is_comm ("one" :: "le" :: s) := add_comm_prefix is_comm "nonneg" :: tr ff s
+| is_comm ("one" :: "lt" :: s) := add_comm_prefix is_comm "pos"    :: tr ff s
+| is_comm ("le" :: "one" :: s) := add_comm_prefix is_comm "nonpos" :: tr ff s
+| is_comm ("lt" :: "one" :: s) := add_comm_prefix is_comm "neg"    :: tr ff s
+| is_comm ("mul" :: s)         := add_comm_prefix is_comm "add"    :: tr ff s
+| is_comm ("inv" :: s)         := add_comm_prefix is_comm "neg"    :: tr ff s
+| is_comm ("div" :: s)         := add_comm_prefix is_comm "sub"    :: tr ff s
+| is_comm ("one" :: s)         := add_comm_prefix is_comm "zero"   :: tr ff s
+| is_comm ("prod" :: s)        := add_comm_prefix is_comm "sum"    :: tr ff s
+| is_comm ("monoid" :: s)      := ("add_" ++ add_comm_prefix is_comm "monoid")    :: tr ff s
+| is_comm ("submonoid" :: s)   := ("add_" ++ add_comm_prefix is_comm "submonoid") :: tr ff s
+| is_comm ("group" :: s)       := ("add_" ++ add_comm_prefix is_comm "group")     :: tr ff s
+| is_comm ("subgroup" :: s)    := ("add_" ++ add_comm_prefix is_comm "subgroup")  :: tr ff s
+| is_comm ("semigroup" :: s)   := ("add_" ++ add_comm_prefix is_comm "semigroup") :: tr ff s
+| is_comm ("magma" :: s)       := ("add_" ++ add_comm_prefix is_comm "magma") :: tr ff s
+| is_comm ("comm" :: s)        := tr tt s
+| is_comm (x :: s)             := (add_comm_prefix is_comm x :: tr ff s)
+| tt []                   := ["comm"]
+| ff []                   := []
 
 /-- Autogenerate target name for `to_additive`. -/
 meta def guess_name : string → string :=
 string.map_tokens ''' $
 λ s, string.intercalate (string.singleton '_') $
-tr (s.split_on '_')
+tr ff (s.split_on '_')
 
 /-- Return the provided target name or autogenerate one if one was not provided. -/
 meta def target_name (src tgt : name) (dict : name_map name) : tactic name :=

--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -80,6 +80,7 @@ optional doc string. -/
 @[derive has_reflect, derive inhabited]
 structure value_type : Type := (tgt : name) (doc : option string)
 
+/-- `add_comm_prefix x s` returns `"comm_" ++ s` if `x = tt` and `s` otherwise. -/
 meta def add_comm_prefix : bool → string → string
 | tt s := ("comm_" ++ s)
 | ff s := s

--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -57,7 +57,7 @@ instance [has_mul α] : has_mul (with_one α) :=
 @[simp, to_additive]
 lemma mul_coe [has_mul α] (a b : α) : (a : with_one α) * b = (a * b : α) := rfl
 
-@[to_additive add_monoid]
+@[to_additive]
 instance [semigroup α] : monoid (with_one α) :=
 { mul_assoc := (option.lift_or_get_assoc _).1,
   one_mul   := (option.lift_or_get_is_left_id _).1,
@@ -65,7 +65,7 @@ instance [semigroup α] : monoid (with_one α) :=
   ..with_one.has_one,
   ..with_one.has_mul }
 
-@[to_additive add_comm_monoid]
+@[to_additive]
 instance [comm_semigroup α] : comm_monoid (with_one α) :=
 { mul_comm := (option.lift_or_get_comm _).1,
   ..with_one.monoid }

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -46,7 +46,7 @@ class ordered_add_comm_monoid (α : Type*) extends add_comm_monoid α, partial_o
 (add_le_add_left       : ∀ a b : α, a ≤ b → ∀ c : α, c + a ≤ c + b)
 (lt_of_add_lt_add_left : ∀ a b c : α, a + b < a + c → b < c)
 
-attribute [to_additive ordered_add_comm_monoid] ordered_comm_monoid
+attribute [to_additive] ordered_comm_monoid
 
 section ordered_comm_monoid
 variables [ordered_comm_monoid α] {a b c d : α}
@@ -566,7 +566,7 @@ class ordered_cancel_comm_monoid (α : Type u)
 (mul_le_mul_left       : ∀ a b : α, a ≤ b → ∀ c : α, c * a ≤ c * b)
 (le_of_mul_le_mul_left : ∀ a b c : α, a * b ≤ a * c → b ≤ c)
 
-attribute [to_additive ordered_cancel_add_comm_monoid] ordered_cancel_comm_monoid
+attribute [to_additive] ordered_cancel_comm_monoid
 
 section ordered_cancel_comm_monoid
 variables [ordered_cancel_comm_monoid α] {a b c d : α}
@@ -812,7 +812,7 @@ with a partial order in which multiplication is strictly monotone. -/
 class ordered_comm_group (α : Type u) extends comm_group α, partial_order α :=
 (mul_le_mul_left : ∀ a b : α, a ≤ b → ∀ c : α, c * a ≤ c * b)
 
-attribute [to_additive ordered_add_comm_group] ordered_comm_group
+attribute [to_additive] ordered_comm_group
 
 /--The units of an ordered commutative monoid form an ordered commutative group. -/
 @[to_additive]

--- a/src/algebra/punit_instances.lean
+++ b/src/algebra/punit_instances.lean
@@ -12,7 +12,7 @@ universes u
 namespace punit
 variables (x y : punit.{u+1}) (s : set punit.{u+1})
 
-@[to_additive add_comm_group]
+@[to_additive]
 instance : comm_group punit :=
 by refine
 { mul := λ _ _, star,

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -139,7 +139,7 @@ lemma map_ne_one_iff {M N} [monoid M] [monoid N] (h : M ≃* N) {x : M} :
 Extract the forward direction of a multiplicative equivalence
 as a multiplication preserving function.
 -/
-@[to_additive to_add_monoid_hom]
+@[to_additive]
 def to_monoid_hom {M N} [monoid M] [monoid N] (h : M ≃* N) : (M →* N) :=
 { map_one' := h.map_one, .. h }
 
@@ -155,13 +155,13 @@ h.to_monoid_hom.map_inv x
 
 /-- A multiplicative bijection between two monoids is a monoid hom
   (deprecated -- use to_monoid_hom). -/
-@[to_additive is_add_monoid_hom]
+@[to_additive]
 instance is_monoid_hom {M N} [monoid M] [monoid N] (h : M ≃* N) : is_monoid_hom h :=
 ⟨h.map_one⟩
 
 /-- A multiplicative bijection between two groups is a group hom
   (deprecated -- use to_monoid_hom). -/
-@[to_additive is_add_group_hom]
+@[to_additive]
 instance is_group_hom {G H} [group G] [group H] (h : G ≃* H) :
   is_group_hom h := { map_mul := h.map_mul }
 

--- a/src/deprecated/group.lean
+++ b/src/deprecated/group.lean
@@ -98,7 +98,7 @@ class is_add_monoid_hom [add_monoid α] [add_monoid β] (f : α → β) extends 
 (map_zero [] : f 0 = 0)
 
 /-- Predicate for monoid homomorphisms (deprecated -- use the bundled `monoid_hom` version). -/
-@[to_additive is_add_monoid_hom]
+@[to_additive]
 class is_monoid_hom [monoid α] [monoid β] (f : α → β) extends is_mul_hom f : Prop :=
 (map_one [] : f 1 = 1)
 end prio
@@ -120,7 +120,7 @@ variables {mM mN mP}
 lemma coe_of (f : M → N) [is_monoid_hom f] : ⇑ (monoid_hom.of f) = f :=
 rfl
 
-@[to_additive is_add_monoid_hom]
+@[to_additive]
 instance (f : M →* N) : is_monoid_hom (f : M → N) :=
 { map_mul := f.map_mul,
   map_one := f.map_one }
@@ -178,11 +178,11 @@ set_option default_priority 100 -- see Note [default priority]
 class is_add_group_hom [add_group α] [add_group β] (f : α → β) extends is_add_hom f : Prop
 
 /-- Predicate for group homomorphisms (deprecated -- use bundled `monoid_hom`). -/
-@[to_additive is_add_group_hom]
+@[to_additive]
 class is_group_hom [group α] [group β] (f : α → β) extends is_mul_hom f : Prop
 end prio
 
-@[to_additive is_add_group_hom]
+@[to_additive]
 instance monoid_hom.is_group_hom {G H : Type*} {_ : group G} {_ : group H} (f : G →* H) :
   is_group_hom (f : G → H) :=
 { map_mul := f.map_mul }
@@ -199,7 +199,7 @@ variables [group α] [group β] (f : α → β) [is_group_hom f]
 open is_mul_hom (map_mul)
 
 /-- A group homomorphism is a monoid homomorphism. -/
-@[priority 100, to_additive to_is_add_monoid_hom] -- see Note [lower instance priority]
+@[priority 100, to_additive] -- see Note [lower instance priority]
 instance to_is_monoid_hom : is_monoid_hom f :=
 is_monoid_hom.of_mul f
 
@@ -246,7 +246,7 @@ lemma inv {α β} [group α] [comm_group β] (f : α → β) [is_group_hom f] :
 end is_group_hom
 
 /-- Inversion is a group homomorphism if the group is commutative. -/
-@[instance, to_additive is_add_group_hom]
+@[instance, to_additive]
 lemma inv.is_group_hom [comm_group α] : is_group_hom (has_inv.inv : α → α) :=
 { map_mul := mul_inv }
 

--- a/src/deprecated/subgroup.lean
+++ b/src/deprecated/subgroup.lean
@@ -20,7 +20,7 @@ class is_add_subgroup (s : set A) extends is_add_submonoid s : Prop :=
 (neg_mem {a} : a ∈ s → -a ∈ s)
 
 /-- `s` is a subgroup: a set containing 1 and closed under multiplication and inverse. -/
-@[to_additive is_add_subgroup]
+@[to_additive]
 class is_subgroup (s : set G) extends is_submonoid s : Prop :=
 (inv_mem {a} : a ∈ s → a⁻¹ ∈ s)
 end prio
@@ -45,13 +45,13 @@ theorem multiplicative.is_subgroup_iff
 ⟨by rintro ⟨⟨h₁, h₂⟩, h₃⟩; exact @is_add_subgroup.mk A _ _ ⟨h₁, @h₂⟩ @h₃,
   λ h, by exactI multiplicative.is_subgroup _⟩
 
-@[to_additive add_group]
+@[to_additive]
 instance subtype.group {s : set G} [is_subgroup s] : group s :=
 { inv := λ x, ⟨(x:G)⁻¹, is_subgroup.inv_mem x.2⟩,
   mul_left_inv := λ x, subtype.eq $ mul_left_inv x.1,
   .. subtype.monoid }
 
-@[to_additive add_comm_group]
+@[to_additive]
 instance subtype.comm_group {G : Type*} [comm_group G] {s : set G} [is_subgroup s] : comm_group s :=
 { .. subtype.group, .. subtype.comm_monoid }
 
@@ -96,7 +96,7 @@ instance is_subgroup.Inter {ι : Sort*} (s : ι → set G) [h : ∀ y : ι, is_s
   is_subgroup (set.Inter s) :=
 { inv_mem := λ x h, set.mem_Inter.2 $ λ y, is_subgroup.inv_mem (set.mem_Inter.1 h y) }
 
-@[to_additive is_add_subgroup_Union_of_directed]
+@[to_additive]
 lemma is_subgroup_Union_of_directed {ι : Type*} [hι : nonempty ι]
   (s : ι → set G) [∀ i, is_subgroup (s i)]
   (directed : ∀ i j, ∃ k, s i ⊆ s k ∧ s j ⊆ s k) :
@@ -117,7 +117,7 @@ instance gpowers.is_subgroup (x : G) : is_subgroup (gpowers x) :=
 
 instance gmultiples.is_add_subgroup (x : A) : is_add_subgroup (gmultiples x) :=
 multiplicative.is_subgroup_iff.1 $ gpowers.is_subgroup _
-attribute [to_additive is_add_subgroup] gpowers.is_subgroup
+attribute [to_additive] gpowers.is_subgroup
 
 lemma is_subgroup.gpow_mem {a : G} {s : set G} [is_subgroup s] (h : a ∈ s) : ∀{i:ℤ}, a ^ i ∈ s
 | (n : ℕ) := is_submonoid.pow_mem h
@@ -167,12 +167,12 @@ set_option default_priority 100 -- see Note [default priority]
 class normal_add_subgroup [add_group A] (s : set A) extends is_add_subgroup s : Prop :=
 (normal : ∀ n ∈ s, ∀ g : A, g + n - g ∈ s)
 
-@[to_additive normal_add_subgroup]
+@[to_additive]
 class normal_subgroup [group G] (s : set G) extends is_subgroup s : Prop :=
 (normal : ∀ n ∈ s, ∀ g : G, g * n * g⁻¹ ∈ s)
 end prio
 
-@[to_additive normal_add_subgroup_of_add_comm_group]
+@[to_additive]
 lemma normal_subgroup_of_comm_group [comm_group G] (s : set G) [hs : is_subgroup s] :
   normal_subgroup s :=
 { normal := λ n hn g, by rwa [mul_right_comm, mul_right_inv, one_mul],
@@ -262,7 +262,7 @@ instance center_normal : normal_subgroup (center G) :=
 def normalizer (s : set G) : set G :=
 {g : G | ∀ n, n ∈ s ↔ g * n * g⁻¹ ∈ s}
 
-@[to_additive normalizer_is_add_subgroup]
+@[to_additive]
 instance normalizer_is_subgroup (s : set G) : is_subgroup (normalizer s) :=
 { one_mem := by simp [normalizer],
   mul_mem := λ a b (ha : ∀ n, n ∈ s ↔ a * n * a⁻¹ ∈ s)
@@ -343,7 +343,7 @@ by rw [mem_ker]; exact one_iff_ker_inv _ _ _
 lemma inv_iff_ker' (f : G → H) [w : is_group_hom f] (a b : G) : f a = f b ↔ a⁻¹ * b ∈ ker f :=
 by rw [mem_ker]; exact one_iff_ker_inv' _ _ _
 
-@[to_additive image_add_subgroup]
+@[to_additive]
 instance image_subgroup (f : G → H) [is_group_hom f] (s : set G) [is_subgroup s] :
   is_subgroup (f '' s) :=
 { mul_mem := assume a₁ a₂ ⟨b₁, hb₁, eq₁⟩ ⟨b₂, hb₂, eq₂⟩,
@@ -351,7 +351,7 @@ instance image_subgroup (f : G → H) [is_group_hom f] (s : set G) [is_subgroup 
   one_mem := ⟨1, one_mem, map_one f⟩,
   inv_mem := assume a ⟨b, hb, eq⟩, ⟨b⁻¹, inv_mem hb, by rw map_inv f; simp *⟩ }
 
-@[to_additive range_add_subgroup]
+@[to_additive]
 instance range_subgroup (f : G → H) [is_group_hom f] : is_subgroup (set.range f) :=
 @set.image_univ _ _ f ▸ is_group_hom.image_subgroup f set.univ
 
@@ -403,20 +403,20 @@ by rw set.ext_iff; simp [ker]; exact
 
 end is_group_hom
 
-@[to_additive is_add_group_hom]
+@[to_additive]
 instance subtype_val.is_group_hom [group G] {s : set G} [is_subgroup s] :
   is_group_hom (subtype.val : s → G) := { ..subtype_val.is_monoid_hom }
 
-@[to_additive is_add_group_hom]
+@[to_additive]
 instance coe.is_group_hom [group G] {s : set G} [is_subgroup s] :
   is_group_hom (coe : s → G) := { ..subtype_val.is_monoid_hom }
 
-@[to_additive is_add_group_hom]
+@[to_additive]
 instance subtype_mk.is_group_hom [group G] [group H] {s : set G}
   [is_subgroup s] (f : H → G) [is_group_hom f] (h : ∀ x, f x ∈ s) :
   is_group_hom (λ x, (⟨f x, h x⟩ : s)) := { ..subtype_mk.is_monoid_hom f h }
 
-@[to_additive is_add_group_hom]
+@[to_additive]
 instance set_inclusion.is_group_hom [group G] {s t : set G}
   [is_subgroup s] [is_subgroup t] (h : s ⊆ t) : is_group_hom (set.inclusion h) :=
 subtype_mk.is_group_hom _ _
@@ -467,7 +467,7 @@ def closure (s : set G) : set G := {a | in_closure s a }
 @[to_additive]
 lemma mem_closure {a : G} : a ∈ s → a ∈ closure s := in_closure.basic
 
-@[to_additive is_add_subgroup]
+@[to_additive]
 instance closure.is_subgroup (s : set G) : is_subgroup (closure s) :=
 { one_mem := in_closure.one,
   mul_mem := assume a b, in_closure.mul,
@@ -488,7 +488,7 @@ lemma closure_subset_iff (s t : set G) [is_subgroup t] : closure s ⊆ t ↔ s �
 theorem closure_mono {s t : set G} (h : s ⊆ t) : closure s ⊆ closure t :=
 closure_subset $ set.subset.trans h subset_closure
 
-@[simp, to_additive closure_add_subgroup]
+@[simp, to_additive]
 lemma closure_subgroup (s : set G) [is_subgroup s] : closure s = s :=
 set.subset.antisymm (closure_subset $ set.subset.refl s) subset_closure
 
@@ -645,7 +645,7 @@ class simple_group (G : Type*) [group G] : Prop :=
 class simple_add_group (A : Type*) [add_group A] : Prop :=
 (simple : ∀ (N : set A) [normal_add_subgroup N], N = is_add_subgroup.trivial A ∨ N = set.univ)
 
-attribute [to_additive simple_add_group] simple_group
+attribute [to_additive] simple_group
 
 theorem additive.simple_add_group_iff [group G] :
   simple_add_group (additive G) ↔ simple_group G :=
@@ -663,7 +663,7 @@ theorem multiplicative.simple_group_iff [add_group A] :
 instance multiplicative.simple_group [add_group A] [simple_add_group A] :
 simple_group (multiplicative A) := multiplicative.simple_group_iff.2 (by apply_instance)
 
-@[to_additive simple_add_group_of_surjective]
+@[to_additive]
 lemma simple_group_of_surjective [group G] [group H] [simple_group G] (f : G → H)
   [is_group_hom f] (hf : function.surjective f) : simple_group H :=
 ⟨λ H iH, have normal_subgroup (f ⁻¹' H), by resetI; apply_instance,

--- a/src/deprecated/submonoid.lean
+++ b/src/deprecated/submonoid.lean
@@ -36,7 +36,7 @@ class is_add_submonoid (s : set A) : Prop :=
 (add_mem {a b} : a ∈ s → b ∈ s → a + b ∈ s)
 
 /-- `s` is a submonoid: a set containing 1 and closed under multiplication. -/
-@[to_additive is_add_submonoid]
+@[to_additive]
 class is_submonoid (s : set M) : Prop :=
 (one_mem : (1:M) ∈ s)
 (mul_mem {a b} : a ∈ s → b ∈ s → a * b ∈ s)
@@ -77,7 +77,7 @@ instance is_submonoid.Inter {ι : Sort*} (s : ι → set M) [h : ∀ y : ι, is_
 
 /-- The union of an indexed, directed, nonempty set of submonoids of a monoid `M` is a submonoid
     of `M`. -/
-@[to_additive is_add_submonoid_Union_of_directed "The union of an indexed, directed, nonempty set
+@[to_additive "The union of an indexed, directed, nonempty set
 of `add_submonoid`s of an `add_monoid` `M` is an `add_submonoid` of `M`. "]
 lemma is_submonoid_Union_of_directed {ι : Type*} [hι : nonempty ι]
   (s : ι → set M) [∀ i, is_submonoid (s i)]
@@ -124,18 +124,18 @@ lemma multiples.add_mem {x y z : A} :
 attribute [to_additive] powers.mul_mem
 
 /-- The set of natural number powers of an element of a monoid `M` is a submonoid of `M`. -/
-@[to_additive is_add_submonoid "The set of natural number multiples of an element of
+@[to_additive "The set of natural number multiples of an element of
 an `add_monoid` `M` is an `add_submonoid` of `M`."]
 instance powers.is_submonoid (x : M) : is_submonoid (powers x) :=
 { one_mem := powers.one_mem,
   mul_mem := λ y z, powers.mul_mem }
 
 /-- A monoid is a submonoid of itself. -/
-@[to_additive is_add_submonoid "An `add_monoid` is an `add_submonoid` of itself."]
+@[to_additive "An `add_monoid` is an `add_submonoid` of itself."]
 instance univ.is_submonoid : is_submonoid (@set.univ M) := by split; simp
 
 /-- The preimage of a submonoid under a monoid hom is a submonoid of the domain. -/
-@[to_additive is_add_submonoid "The preimage of an `add_submonoid` under an `add_monoid` hom is
+@[to_additive "The preimage of an `add_submonoid` under an `add_monoid` hom is
 an `add_submonoid` of the domain."]
 instance preimage.is_submonoid {N : Type*} [monoid N] (f : M → N) [is_monoid_hom f]
   (s : set N) [is_submonoid s] : is_submonoid (f ⁻¹' s) :=
@@ -144,7 +144,7 @@ instance preimage.is_submonoid {N : Type*} [monoid N] (f : M → N) [is_monoid_h
     show f (a * b) ∈ s, by rw is_monoid_hom.map_mul f; exact is_submonoid.mul_mem ha hb }
 
 /-- The image of a submonoid under a monoid hom is a submonoid of the codomain. -/
-@[instance, to_additive is_add_submonoid "The image of an `add_submonoid` under an `add_monoid`
+@[instance, to_additive "The image of an `add_submonoid` under an `add_monoid`
 hom is an `add_submonoid` of the codomain."]
 lemma image.is_submonoid {γ : Type*} [monoid γ] (f : M → γ) [is_monoid_hom f]
   (s : set M) [is_submonoid s] : is_submonoid (f '' s) :=
@@ -153,7 +153,7 @@ lemma image.is_submonoid {γ : Type*} [monoid γ] (f : M → γ) [is_monoid_hom 
     by rw [is_monoid_hom.map_mul f, hx.2, hy.2]⟩ }
 
 /-- The image of a monoid hom is a submonoid of the codomain. -/
-@[to_additive is_add_submonoid "The image of an `add_monoid` hom is an `add_submonoid`
+@[to_additive "The image of an `add_monoid` hom is an `add_submonoid`
 of the codomain."]
 instance range.is_submonoid {γ : Type*} [monoid γ] (f : M → γ) [is_monoid_hom f] :
   is_submonoid (set.range f) :=
@@ -227,7 +227,7 @@ end is_submonoid
 --  and for `subtype.group`
 
 /-- Submonoids are themselves monoids. -/
-@[to_additive add_monoid "An `add_submonoid` is itself an `add_monoid`."]
+@[to_additive "An `add_submonoid` is itself an `add_monoid`."]
 instance subtype.monoid {s : set M} [is_submonoid s] : monoid s :=
 { one := ⟨1, is_submonoid.one_mem⟩,
   mul := λ x y, ⟨x * y, is_submonoid.mul_mem x.2 y.2⟩,
@@ -236,7 +236,7 @@ instance subtype.monoid {s : set M} [is_submonoid s] : monoid s :=
   mul_assoc := λ x y z, subtype.eq $ mul_assoc x.1 y.1 z.1 }
 
 /-- Submonoids of commutative monoids are themselves commutative monoids. -/
-@[to_additive add_comm_monoid "An `add_submonoid` of a commutative `add_monoid` is itself
+@[to_additive "An `add_submonoid` of a commutative `add_monoid` is itself
 a commutative `add_monoid`. "]
 instance subtype.comm_monoid {M} [comm_monoid M] {s : set M} [is_submonoid s] : comm_monoid s :=
 { mul_comm := λ x y, subtype.eq $ mul_comm x.1 y.1,
@@ -265,20 +265,20 @@ by {induction n, refl, simp [*, succ_nsmul]}
 attribute [to_additive smul_coe] is_submonoid.coe_pow
 
 /-- The natural injection from a submonoid into the monoid is a monoid hom. -/
-@[to_additive is_add_monoid_hom "The natural injection from an `add_submonoid` into
+@[to_additive "The natural injection from an `add_submonoid` into
 the `add_monoid` is an `add_monoid` hom. "]
 instance subtype_val.is_monoid_hom [is_submonoid s] : is_monoid_hom (subtype.val : s → M) :=
 { map_one := rfl, map_mul := λ _ _, rfl }
 
 /-- The natural injection from a submonoid into the monoid is a monoid hom. -/
-@[to_additive is_add_monoid_hom "The natural injection from an `add_submonoid` into
+@[to_additive "The natural injection from an `add_submonoid` into
 the `add_monoid` is an `add_monoid` hom. "]
 instance coe.is_monoid_hom [is_submonoid s] : is_monoid_hom (coe : s → M) :=
 subtype_val.is_monoid_hom
 
 /-- Given a monoid hom `f : γ → M` whose image is contained in a submonoid `s`, the induced map
     from `γ` to `s` is a monoid hom. -/
-@[to_additive is_add_monoid_hom "Given an `add_monoid` hom `f : γ → M` whose image is contained in
+@[to_additive "Given an `add_monoid` hom `f : γ → M` whose image is contained in
 an `add_submonoid` s, the induced map from `γ` to `s` is an `add_monoid` hom."]
 instance subtype_mk.is_monoid_hom {γ : Type*} [monoid γ] [is_submonoid s] (f : γ → M)
   [is_monoid_hom f] (h : ∀ x, f x ∈ s) : is_monoid_hom (λ x, (⟨f x, h x⟩ : s)) :=
@@ -287,7 +287,7 @@ instance subtype_mk.is_monoid_hom {γ : Type*} [monoid γ] [is_submonoid s] (f :
 
 /-- Given two submonoids `s` and `t` such that `s ⊆ t`, the natural injection from `s` into `t` is
     a monoid hom. -/
-@[to_additive is_add_monoid_hom "Given two `add_submonoid`s `s` and `t` such that `s ⊆ t`, the
+@[to_additive "Given two `add_submonoid`s `s` and `t` such that `s ⊆ t`, the
 natural injection from `s` into `t` is an `add_monoid` hom."]
 instance set_inclusion.is_monoid_hom (t : set M) [is_submonoid s] [is_submonoid t] (h : s ⊆ t) :
   is_monoid_hom (set.inclusion h) :=
@@ -321,7 +321,7 @@ attribute [to_additive] monoid.in_closure.mul
 @[to_additive "The inductively defined `add_submonoid` genrated by a subset of an `add_monoid`."]
 def closure (s : set M) : set M := {a | in_closure s a }
 
-@[to_additive is_add_submonoid]
+@[to_additive]
 instance closure.is_submonoid (s : set M) : is_submonoid (closure s) :=
 { one_mem := in_closure.one, mul_mem := assume a b, in_closure.mul }
 

--- a/src/group_theory/congruence.lean
+++ b/src/group_theory/congruence.lean
@@ -544,7 +544,7 @@ end
 variables {M} [monoid M] [monoid N] [monoid P] (c : con M)
 
 /-- The quotient of a monoid by a congruence relation is a monoid. -/
-@[to_additive add_monoid "The quotient of an `add_monoid` by an additive congruence relation is
+@[to_additive "The quotient of an `add_monoid` by an additive congruence relation is
 an `add_monoid`."]
 instance monoid : monoid c.quotient :=
 { one := ((1 : M) : c.quotient),
@@ -556,7 +556,7 @@ instance monoid : monoid c.quotient :=
 
 
 /-- The quotient of a `comm_monoid` by a congruence relation is a `comm_monoid`. -/
-@[to_additive add_comm_monoid "The quotient of an `add_comm_monoid` by an additive congruence
+@[to_additive "The quotient of an `add_comm_monoid` by an additive congruence
 relation is an `add_comm_monoid`."]
 instance comm_monoid {α : Type*} [comm_monoid α] (c : con α) :
   comm_monoid c.quotient :=
@@ -574,7 +574,7 @@ lemma coe_one : ((1 : M) : c.quotient) = 1 := rfl
 variables (M c)
 
 /-- The submonoid of `M × M` defined by a congruence relation on a monoid `M`. -/
-@[to_additive add_submonoid "The `add_submonoid` of `M × M` defined by an additive congruence
+@[to_additive "The `add_submonoid` of `M × M` defined by an additive congruence
 relation on an `add_monoid` `M`."]
 protected def submonoid : submonoid (M × M) :=
 { carrier := { x | c x.1 x.2 },
@@ -585,7 +585,7 @@ variables {M c}
 
 /-- The congruence relation on a monoid `M` from a submonoid of `M × M` for which membership
     is an equivalence relation. -/
-@[to_additive of_add_submonoid "The additive congruence relation on an `add_monoid` `M` from
+@[to_additive "The additive congruence relation on an `add_monoid` `M` from
 an `add_submonoid` of `M × M` for which membership is an equivalence relation."]
 def of_submonoid (N : submonoid (M × M)) (H : equivalence (λ x y, (x, y) ∈ N)) : con M :=
 { r := λ x y, (x, y) ∈ N,
@@ -594,7 +594,7 @@ def of_submonoid (N : submonoid (M × M)) (H : equivalence (λ x y, (x, y) ∈ N
 
 /-- Coercion from a congruence relation `c` on a monoid `M` to the submonoid of `M × M` whose
     elements are `(x, y)` such that `x` is related to `y` by `c`. -/
-@[to_additive to_add_submonoid "Coercion from a congruence relation `c` on an `add_monoid` `M`
+@[to_additive "Coercion from a congruence relation `c` on an `add_monoid` `M`
 to the `add_submonoid` of `M × M` whose elements are `(x, y)` such that `x`
 is related to `y` by `c`."]
 instance to_submonoid : has_coe (con M) (submonoid (M × M)) := ⟨λ c, c.submonoid M⟩
@@ -602,7 +602,7 @@ instance to_submonoid : has_coe (con M) (submonoid (M × M)) := ⟨λ c, c.submo
 @[to_additive] lemma mem_coe {c : con M} {x y} :
   (x, y) ∈ (↑c : submonoid (M × M)) ↔ (x, y) ∈ c := iff.rfl
 
-@[to_additive to_add_submonoid_inj]
+@[to_additive]
 theorem to_submonoid_inj (c d : con M) (H : (c : submonoid (M × M)) = d) : c = d :=
 ext $ λ x y, show (x, y) ∈ (c : submonoid (M × M)) ↔ (x, y) ∈ ↑d, by rw H
 

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -92,7 +92,7 @@ under addition and additive inverse. -/
 structure add_subgroup (G : Type*) [add_group G] extends add_submonoid G:=
 (neg_mem' {x} : x ∈ carrier → -x ∈ carrier)
 
-attribute [to_additive add_subgroup] subgroup
+attribute [to_additive] subgroup
 attribute [to_additive add_subgroup.to_add_submonoid] subgroup.to_submonoid
 
 /-- Reinterpret a `subgroup` as a `submonoid`. -/
@@ -279,14 +279,14 @@ attribute [norm_cast] add_subgroup.coe_add add_subgroup.coe_zero
   add_subgroup.coe_neg add_subgroup.coe_mk
 
 /-- A subgroup of a group inherits a group structure. -/
-@[to_additive to_add_group "An `add_subgroup` of an `add_group` inherits an `add_group` structure."]
+@[to_additive "An `add_subgroup` of an `add_group` inherits an `add_group` structure."]
 instance to_group {G : Type*} [group G] (H : subgroup G) : group H :=
 { inv := has_inv.inv,
   mul_left_inv := λ x, subtype.eq $ mul_left_inv x,
   .. H.to_submonoid.to_monoid }
 
 /-- A subgroup of a `comm_group` is a `comm_group`. -/
-@[to_additive to_add_comm_group "An `add_subgroup` of an `add_comm_group` is an `add_comm_group`."]
+@[to_additive "An `add_subgroup` of an `add_comm_group` is an `add_comm_group`."]
 instance to_comm_group {G : Type*} [comm_group G] (H : subgroup G) : comm_group H :=
 { mul_comm := λ _ _, subtype.eq $ mul_comm _ _, .. H.to_group}
 
@@ -989,7 +989,7 @@ variables {H K : subgroup G}
 
 /-- Makes the identity isomorphism from a proof two subgroups of a multiplicative
     group are equal. -/
-@[to_additive add_subgroup_congr "Makes the identity additive isomorphism from a proof
+@[to_additive "Makes the identity additive isomorphism from a proof
 two subgroups of an additive group are equal."]
 def subgroup_congr (h : H = K) : H ≃* K :=
 { map_mul' :=  λ _ _, rfl, ..equiv.set_congr $ subgroup.ext'_iff.1 h }

--- a/src/group_theory/submonoid/basic.lean
+++ b/src/group_theory/submonoid/basic.lean
@@ -63,7 +63,7 @@ structure add_submonoid (M : Type*) [add_monoid M] :=
 (zero_mem' : (0 : M) ∈ carrier)
 (add_mem' {a b} : a ∈ carrier → b ∈ carrier → a + b ∈ carrier)
 
-attribute [to_additive add_submonoid] submonoid
+attribute [to_additive] submonoid
 
 namespace submonoid
 

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -194,13 +194,13 @@ attribute [norm_cast] coe_mul coe_one
 attribute [norm_cast] add_submonoid.coe_add add_submonoid.coe_zero
 
 /-- A submonoid of a monoid inherits a monoid structure. -/
-@[to_additive to_add_monoid "An `add_submonoid` of an `add_monoid` inherits an `add_monoid`
+@[to_additive "An `add_submonoid` of an `add_monoid` inherits an `add_monoid`
 structure."]
 instance to_monoid {M : Type*} [monoid M] (S : submonoid M) : monoid S :=
 S.coe_injective.monoid coe rfl (λ _ _, rfl)
 
 /-- A submonoid of a `comm_monoid` is a `comm_monoid`. -/
-@[to_additive to_add_comm_monoid "An `add_submonoid` of an `add_comm_monoid` is
+@[to_additive "An `add_submonoid` of an `add_comm_monoid` is
 an `add_comm_monoid`."]
 instance to_comm_monoid {M} [comm_monoid M] (S : submonoid M) : comm_monoid S :=
 S.coe_injective.comm_monoid coe rfl (λ _ _, rfl)
@@ -396,7 +396,7 @@ variables {S} {T : submonoid M}
 
 /-- Makes the identity isomorphism from a proof that two submonoids of a multiplicative
     monoid are equal. -/
-@[to_additive add_submonoid_congr "Makes the identity additive isomorphism from a proof two
+@[to_additive "Makes the identity additive isomorphism from a proof two
 submonoids of an additive monoid are equal."]
 def submonoid_congr (h : S = T) : S ≃* T :=
 { map_mul' :=  λ _ _, rfl, ..equiv.set_congr $ submonoid.ext'_iff.1 h }

--- a/src/measure_theory/ae_eq_fun.lean
+++ b/src/measure_theory/ae_eq_fun.lean
@@ -316,13 +316,13 @@ rfl
   (f * g).to_germ = f.to_germ * g.to_germ :=
 comp₂_to_germ _ _ _ _
 
-@[to_additive add_monoid]
+@[to_additive]
 instance : monoid (α →ₘ[μ] γ) :=
 to_germ_injective.monoid to_germ one_to_germ mul_to_germ
 
 end monoid
 
-@[to_additive add_comm_monoid]
+@[to_additive]
 instance comm_monoid [topological_space γ] [second_countable_topology γ] [borel_space γ]
   [comm_monoid γ] [has_continuous_mul γ] : comm_monoid (α →ₘ[μ] γ) :=
 to_germ_injective.comm_monoid to_germ one_to_germ mul_to_germ
@@ -340,7 +340,7 @@ variables [topological_space γ] [borel_space γ] [group γ] [topological_group 
 @[to_additive] lemma inv_to_germ (f : α →ₘ[μ] γ) : (f⁻¹).to_germ = f.to_germ⁻¹ := comp_to_germ _ _ _
 
 variables [second_countable_topology γ]
-@[to_additive add_group]
+@[to_additive]
 instance : group (α →ₘ[μ] γ) := to_germ_injective.group _ one_to_germ mul_to_germ inv_to_germ
 
 end group
@@ -359,7 +359,7 @@ lemma coe_fn_sub (f g : α →ₘ[μ] γ) : ⇑(f - g) =ᵐ[μ] f - g :=
 
 end add_group
 
-@[to_additive add_comm_group]
+@[to_additive]
 instance [topological_space γ] [borel_space γ] [comm_group γ] [topological_group γ]
   [second_countable_topology γ] : comm_group (α →ₘ[μ] γ) :=
 { .. ae_eq_fun.group, .. ae_eq_fun.comm_monoid }

--- a/src/order/filter/germ.lean
+++ b/src/order/filter/germ.lean
@@ -253,12 +253,12 @@ lemma coe_one [has_one M] : ↑(1 : α → M) = (1 : germ l M) := rfl
 
 attribute [norm_cast] coe_one coe_zero
 
-@[to_additive add_semigroup]
+@[to_additive]
 instance [semigroup M] : semigroup (germ l M) :=
 { mul := (*), mul_assoc := by { rintros ⟨f⟩ ⟨g⟩ ⟨h⟩,
     simp only [mul_assoc, quot_mk_eq_coe, ← coe_mul] } }
 
-@[to_additive add_comm_semigroup]
+@[to_additive]
 instance [comm_semigroup M] : comm_semigroup (germ l M) :=
 { mul := (*),
   mul_comm := by { rintros ⟨f⟩ ⟨g⟩, simp only [mul_comm, quot_mk_eq_coe, ← coe_mul] },
@@ -278,7 +278,7 @@ instance [right_cancel_semigroup M] : right_cancel_semigroup (germ l M) :=
     coe_eq.2 $ (coe_eq.1 H).mono $ λ x, mul_right_cancel,
   .. germ.semigroup }
 
-@[to_additive add_monoid]
+@[to_additive]
 instance [monoid M] : monoid (germ l M) :=
 { mul := (*),
   one := 1,
@@ -296,7 +296,7 @@ add_decl_doc coe_add_hom
 @[simp, to_additive]
 lemma coe_coe_mul_hom [monoid M] : (coe_mul_hom l : (α → M) → germ l M) = coe := rfl
 
-@[to_additive add_comm_monoid]
+@[to_additive]
 instance [comm_monoid M] : comm_monoid (germ l M) :=
 { mul := (*),
   one := 1,
@@ -310,7 +310,7 @@ lemma coe_inv [has_inv G] (f : α → G) : ↑f⁻¹ = (f⁻¹ : germ l G) := rf
 
 attribute [norm_cast] coe_inv coe_neg
 
-@[to_additive add_group]
+@[to_additive]
 instance [group G] : group (germ l G) :=
 { mul := (*),
   one := 1,
@@ -321,7 +321,7 @@ instance [group G] : group (germ l G) :=
 @[simp, norm_cast]
 lemma coe_sub [add_group G] (f  g : α → G) : ↑(f - g) = (f - g : germ l G) := rfl
 
-@[to_additive add_comm_group]
+@[to_additive]
 instance [comm_group G] : comm_group (germ l G) :=
 { mul := (*),
   one := 1,
@@ -506,7 +506,7 @@ instance [lattice β] : lattice (germ l β) :=
 instance [bounded_lattice β] : bounded_lattice (germ l β) :=
 { .. germ.lattice, .. germ.order_bot, .. germ.order_top }
 
-@[to_additive ordered_cancel_add_comm_monoid]
+@[to_additive]
 instance [ordered_cancel_comm_monoid β] : ordered_cancel_comm_monoid (germ l β) :=
 { mul_le_mul_left := λ f g, induction_on₂ f g $ λ f g H h, induction_on h $ λ h,
     H.mono $ λ x H, mul_le_mul_left' H _,
@@ -515,7 +515,7 @@ instance [ordered_cancel_comm_monoid β] : ordered_cancel_comm_monoid (germ l β
   .. germ.partial_order, .. germ.comm_monoid, .. germ.left_cancel_semigroup,
   .. germ.right_cancel_semigroup }
 
-@[to_additive ordered_add_comm_group]
+@[to_additive]
 instance ordered_comm_group [ordered_comm_group β] : ordered_comm_group (germ l β) :=
 { mul_le_mul_left := λ f g, induction_on₂ f g $ λ f g H h, induction_on h $ λ h,
     H.mono $ λ x H, mul_le_mul_left' H _,

--- a/src/topology/algebra/continuous_functions.lean
+++ b/src/topology/algebra/continuous_functions.lean
@@ -51,30 +51,30 @@ the structure of a group.
 
 section subtype
 
-@[to_additive continuous_add_submonoid]
+@[to_additive]
 instance continuous_submonoid (α : Type*) (β : Type*) [topological_space α] [topological_space β]
   [monoid β] [has_continuous_mul β] : is_submonoid { f : α → β | continuous f } :=
 { one_mem := @continuous_const _ _ _ _ 1,
   mul_mem := λ f g fc gc, continuous.comp
   has_continuous_mul.continuous_mul (continuous.prod_mk fc gc) }.
 
-@[to_additive continuous_add_subgroup]
+@[to_additive]
 instance continuous_subgroup (α : Type*) (β : Type*) [topological_space α] [topological_space β]
   [group β] [topological_group β] : is_subgroup { f : α → β | continuous f } :=
 { inv_mem := λ f fc, continuous.comp topological_group.continuous_inv fc,
   ..continuous_submonoid α β, }.
 
-@[to_additive continuous_add_monoid]
+@[to_additive]
 instance continuous_monoid {α : Type*} {β : Type*} [topological_space α] [topological_space β]
   [monoid β] [has_continuous_mul β] : monoid { f : α → β | continuous f } :=
 subtype.monoid
 
-@[to_additive continuous_add_group]
+@[to_additive]
 instance continuous_group {α : Type*} {β : Type*} [topological_space α] [topological_space β]
   [group β] [topological_group β] : group { f : α → β | continuous f } :=
 subtype.group
 
-@[to_additive continuous_add_comm_group]
+@[to_additive]
 instance continuous_comm_group {α : Type*} {β : Type*} [topological_space α] [topological_space β]
   [comm_group β] [topological_group β] : comm_group { f : α → β | continuous f } :=
 @subtype.comm_group _ _ _ (continuous_subgroup α β) -- infer_instance doesn't work?!
@@ -83,13 +83,13 @@ end subtype
 
 section continuous_map
 
-@[to_additive continuous_map_add_semigroup]
+@[to_additive]
 instance continuous_map_semigroup {α : Type*} {β : Type*} [topological_space α] [topological_space β]
   [semigroup β] [has_continuous_mul β] : semigroup C(α, β) :=
 { mul_assoc := λ a b c, by ext; exact mul_assoc _ _ _,
   ..continuous_map.has_mul}
 
-@[to_additive continuous_map_add_monoid]
+@[to_additive]
 instance continuous_map_monoid {α : Type*} {β : Type*} [topological_space α] [topological_space β]
   [monoid β] [has_continuous_mul β] : monoid C(α, β) :=
 { one_mul := λ a, by ext; exact one_mul _,
@@ -97,7 +97,7 @@ instance continuous_map_monoid {α : Type*} {β : Type*} [topological_space α] 
   ..continuous_map_semigroup,
   ..continuous_map.has_one }
 
-@[to_additive continuous_map_add_comm_monoid]
+@[to_additive]
 instance continuous_map_comm_monoid {α : Type*} {β : Type*} [topological_space α]
 [topological_space β] [comm_monoid β] [has_continuous_mul β] : comm_monoid C(α, β) :=
 { one_mul := λ a, by ext; exact one_mul _,
@@ -106,14 +106,14 @@ instance continuous_map_comm_monoid {α : Type*} {β : Type*} [topological_space
   ..continuous_map_semigroup,
   ..continuous_map.has_one }
 
-@[to_additive continuous_map_add_group]
+@[to_additive]
 instance continuous_map_group {α : Type*} {β : Type*} [topological_space α] [topological_space β]
   [group β] [topological_group β] : group C(α, β) :=
 { inv := λ f, ⟨λ x, (f x)⁻¹, continuous_inv.comp f.continuous⟩,
   mul_left_inv := λ a, by ext; exact mul_left_inv _,
   ..continuous_map_monoid }
 
-@[to_additive continuous_map_add_comm_group]
+@[to_additive]
 instance continuous_map_comm_group {α : Type*} {β : Type*} [topological_space α] [topological_space β]
   [comm_group β] [topological_group β] : comm_group C(α, β) :=
 { ..continuous_map_group,

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -29,7 +29,7 @@ class topological_add_group (α : Type u) [topological_space α] [add_group α]
 
 /-- A topological group is a group in which the multiplication and inversion operations are
 continuous. -/
-@[to_additive topological_add_group]
+@[to_additive]
 class topological_group (α : Type*) [topological_space α] [group α]
   extends has_continuous_mul α : Prop :=
 (continuous_inv : continuous (λa:α, a⁻¹))
@@ -82,7 +82,7 @@ lemma continuous_within_at.inv [topological_group α] [topological_space β] {f 
   continuous_within_at (λx, (f x)⁻¹) s x :=
 hf.inv
 
-@[to_additive topological_add_group]
+@[to_additive]
 instance [topological_group α] [topological_space β] [group β] [topological_group β] :
   topological_group (α × β) :=
 { continuous_inv := continuous_fst.inv.prod_mk continuous_snd.inv }
@@ -201,7 +201,7 @@ instance {α : Type u} [group α] [topological_space α] (N : set α) [normal_su
 by dunfold quotient_group.quotient; apply_instance
 
 open quotient_group
-@[to_additive quotient_add_group_saturate]
+@[to_additive]
 lemma quotient_group_saturate {α : Type u} [group α] (N : set α) [normal_subgroup N] (s : set α) :
   (coe : α → quotient N) ⁻¹' ((coe : α → quotient N) '' s) = (⋃ x : N, (λ y, y*x.1) '' s) :=
 begin
@@ -224,7 +224,7 @@ begin
   exact is_open_map_mul_right n s s_op
 end
 
-@[to_additive topological_add_group_quotient]
+@[to_additive]
 instance topological_group_quotient : topological_group (quotient N) :=
 { continuous_mul := begin
     have cont : continuous ((coe : α → quotient N) ∘ (λ (p : α × α), p.fst * p.snd)) :=

--- a/src/topology/algebra/open_subgroup.lean
+++ b/src/topology/algebra/open_subgroup.lean
@@ -19,7 +19,7 @@ structure open_add_subgroup  (G : Type*) [add_group G] [topological_space G]
 (is_open' : is_open carrier)
 
 /-- The type of open subgroups of a topological group. -/
-@[ancestor subgroup, to_additive open_add_subgroup]
+@[ancestor subgroup, to_additive]
 structure open_subgroup (G : Type*) [group G] [topological_space G] extends subgroup G :=
 (is_open' : is_open carrier)
 
@@ -52,7 +52,7 @@ instance has_coe_opens : has_coe_t (open_subgroup G) (opens G) := ⟨λ U, ⟨U,
 
 @[simp, to_additive] lemma mem_coe : g ∈ (U : set G) ↔ g ∈ U := iff.rfl
 @[simp, to_additive] lemma mem_coe_opens : g ∈ (U : opens G) ↔ g ∈ U := iff.rfl
-@[simp, to_additive mem_coe_add_subgroup]
+@[simp, to_additive]
 lemma mem_coe_subgroup : g ∈ (U : subgroup G) ↔ g ∈ U := iff.rfl
 
 attribute [norm_cast] mem_coe mem_coe_opens mem_coe_subgroup open_add_subgroup.mem_coe
@@ -137,7 +137,7 @@ instance : semilattice_inf_top (open_subgroup G) :=
 @[simp, to_additive] lemma coe_subgroup_le : (U : subgroup G) ≤ (V : subgroup G) ↔ U ≤ V := iff.rfl
 
 attribute [norm_cast] coe_inf coe_subset coe_subgroup_le open_add_subgroup.coe_inf
-  open_add_subgroup.coe_subset open_add_subgroup.coe_subgroup_le
+  open_add_subgroup.coe_subset open_add_subgroup.coe_add_subgroup_le
 
 end open_subgroup
 
@@ -160,7 +160,7 @@ begin
   exact this
 end
 
-@[to_additive is_open_of_open_add_subgroup]
+@[to_additive]
 lemma is_open_of_open_subgroup {U : open_subgroup G} (h : U.1 ≤ H) :
   is_open (H : set G) :=
 H.is_open_of_mem_nhds (filter.mem_sets_of_superset U.mem_nhds_one h)


### PR DESCRIPTION
This is all @cipher1024's work, improving `to_additive` to correctly generate names when we're talking about structures (rather than just operations).

Co-authored-by: Simon Hudon <simon.hudon@gmail.com>

---
<!-- put comments you want to keep out of the PR commit here -->
