### PR TITLE
[Merged by Bors] - chore(order/liminf_limsup): use dot notation and `order_dual`

### DIFF
--- a/src/order/liminf_limsup.lean
+++ b/src/order/liminf_limsup.lean
@@ -79,10 +79,10 @@ lemma is_bounded_sup [is_trans α r] (hr : ∀b₁ b₂, ∃b, r b₁ b ∧ r b�
 | ⟨b₁, h₁⟩ ⟨b₂, h₂⟩ := let ⟨b, rb₁b, rb₂b⟩ := hr b₁ b₂ in
   ⟨b, eventually_sup.mpr ⟨h₁.mono (λ x h, trans h rb₁b), h₂.mono (λ x h, trans h rb₂b)⟩⟩
 
-lemma is_bounded_of_le (h : f ≤ g) : is_bounded r g → is_bounded r f
+lemma is_bounded.mono (h : f ≤ g) : is_bounded r g → is_bounded r f
 | ⟨b, hb⟩ := ⟨b, h hb⟩
 
-lemma is_bounded_under_of_is_bounded {q : β → β → Prop} {u : α → β}
+lemma is_bounded.is_bounded_under {q : β → β → Prop} {u : α → β}
   (hf : ∀a₀ a₁, r a₀ a₁ → q (u a₀) (u a₁)) : f.is_bounded r → f.is_bounded_under q u
 | ⟨b, h⟩ := ⟨u b, show ∀ᶠ x in f, q (u x) (u b), from h.mono (λ x, hf x b)⟩
 
@@ -112,7 +112,7 @@ lemma is_cobounded.mk [is_trans α r] (a : α) (h : ∀s∈f, ∃x∈s, r a x) :
 
 /-- A filter which is eventually bounded is in particular frequently bounded (in the opposite
 direction). At least if the filter is not trivial. -/
-lemma is_cobounded_of_is_bounded [is_trans α r] [ne_bot f] :
+lemma is_bounded.is_cobounded_flip [is_trans α r] [ne_bot f] :
   f.is_bounded r → f.is_cobounded (flip r)
 | ⟨a, ha⟩ := ⟨a, assume b hb,
   let ⟨x, rxa, rbx⟩ := (ha.and hb).exists in
@@ -125,18 +125,13 @@ lemma is_cobounded_top : is_cobounded r ⊤ ↔ nonempty α :=
 by simp [is_cobounded, eq_univ_iff_forall, exists_true_iff_nonempty] {contextual := tt}
 
 lemma is_cobounded_principal (s : set α) :
-  (𝓟 s).is_cobounded r↔ (∃b, ∀a, (∀x∈s, r x a) → r b a) :=
+  (𝓟 s).is_cobounded r ↔ (∃b, ∀a, (∀x∈s, r x a) → r b a) :=
 by simp [is_cobounded, subset_def]
 
-lemma is_cobounded_of_le (h : f ≤ g) : f.is_cobounded r → g.is_cobounded r
+lemma is_cobounded.mono (h : f ≤ g) : f.is_cobounded r → g.is_cobounded r
 | ⟨b, hb⟩ := ⟨b, assume a ha, hb a (h ha)⟩
 
 end relation
-
-instance is_trans_le [preorder α] : is_trans α (≤) := ⟨assume a b c, le_trans⟩
-
-@[nolint ge_or_gt] -- see Note [nolint_ge]
-instance is_trans_ge [preorder α] : is_trans α (≥) := ⟨assume a b c h₁ h₂, le_trans h₂ h₁⟩
 
 lemma is_cobounded_le_of_bot [order_bot α] {f : filter α} : f.is_cobounded (≤) :=
 ⟨⊥, assume a h, bot_le⟩
@@ -246,20 +241,18 @@ lemma Liminf_le_Liminf_of_le {f g : filter α} (h : g ≤ f)
 Liminf_le_Liminf hf hg (assume a ha, h ha)
 
 lemma limsup_le_limsup {α : Type*} [conditionally_complete_lattice β] {f : filter α} {u v : α → β}
-  (h : ∀ᶠ a in f, u a ≤ v a)
+  (h : u ≤ᶠ[f] v)
   (hu : f.is_cobounded_under (≤) u . is_bounded_default)
   (hv : f.is_bounded_under (≤) v . is_bounded_default) :
   f.limsup u ≤ f.limsup v :=
-Limsup_le_Limsup hu hv $ assume b (hb : ∀ᶠ a in f, v a ≤ b), show ∀ᶠ a in f, u a ≤ b,
-  by filter_upwards [h, hb] assume a, le_trans
+Limsup_le_Limsup hu hv $ assume b, h.trans
 
 lemma liminf_le_liminf {α : Type*} [conditionally_complete_lattice β] {f : filter α} {u v : α → β}
   (h : ∀ᶠ a in f, u a ≤ v a)
   (hu : f.is_bounded_under (≥) u . is_bounded_default)
   (hv : f.is_cobounded_under (≥) v . is_bounded_default) :
   f.liminf u ≤ f.liminf v :=
-Liminf_le_Liminf hu hv $ assume b (hb : ∀ᶠ a in f, b ≤ u a), show ∀ᶠ a in f, b ≤ v a,
-  by filter_upwards [hb, h] assume a, le_trans
+@limsup_le_limsup (order_dual β) α _ _ _ _ h hv hu
 
 theorem Limsup_principal {s : set α} (h : bdd_above s) (hs : s.nonempty) :
   (𝓟 s).Limsup = Sup s :=
@@ -267,7 +260,7 @@ by simp [Limsup]; exact cInf_upper_bounds_eq_cSup h hs
 
 theorem Liminf_principal {s : set α} (h : bdd_below s) (hs : s.nonempty) :
   (𝓟 s).Liminf = Inf s :=
-by simp [Liminf]; exact cSup_lower_bounds_eq_cInf h hs
+@Limsup_principal (order_dual α) _ s h hs
 
 lemma limsup_congr {α : Type*} [conditionally_complete_lattice β] {f : filter α} {u v : α → β}
   (h : ∀ᶠ a in f, u a = v a) : limsup f u = limsup f v :=
@@ -280,12 +273,7 @@ end
 
 lemma liminf_congr {α : Type*} [conditionally_complete_lattice β] {f : filter α} {u v : α → β}
   (h : ∀ᶠ a in f, u a = v a) : liminf f u = liminf f v :=
-begin
-  rw liminf_eq,
-  congr,
-  ext b,
-  exact eventually_congr (h.mono $ λ x hx, by simp [hx])
-end
+@limsup_congr (order_dual β) _ _ _ _ _ h
 
 lemma limsup_const {α : Type*} [conditionally_complete_lattice β] {f : filter α} [ne_bot f]
   (b : β) : limsup f (λ x, b) = b :=
@@ -322,68 +310,38 @@ bot_unique $ Sup_le $
 lemma liminf_le_limsup {f : filter β} [ne_bot f] {u : β → α}  : liminf f u ≤ limsup f u :=
 Liminf_le_Limsup is_bounded_le_of_top is_bounded_ge_of_bot
 
-theorem Limsup_eq_infi_Sup {f : filter α} : f.Limsup = ⨅ s ∈ f, Sup s :=
+theorem has_basis.Limsup_eq_infi_Sup {ι} {p : ι → Prop} {s} {f : filter α} (h : f.has_basis p s) :
+  f.Limsup = ⨅ i (hi : p i), Sup (s i) :=
 le_antisymm
-  (le_infi $ assume s, le_infi $ assume hs, Inf_le $ show ∀ᶠ n in f, n ≤ Sup s,
-    by filter_upwards [hs] assume a, le_Sup)
-  (le_Inf $ assume a (ha : ∀ᶠ n in f, n ≤ a),
-    infi_le_of_le _ $ infi_le_of_le ha $ Sup_le $ assume b, id)
+  (le_binfi $ λ i hi, Inf_le $ h.eventually_iff.2 ⟨i, hi, λ x, le_Sup⟩)
+  (le_Inf $ assume a ha, let ⟨i, hi, ha⟩ := h.eventually_iff.1 ha in
+    infi_le_of_le _ $ infi_le_of_le hi $ Sup_le ha)
+
+theorem Limsup_eq_infi_Sup {f : filter α} : f.Limsup = ⨅ s ∈ f, Sup s :=
+f.basis_sets.Limsup_eq_infi_Sup
 
 /-- In a complete lattice, the limsup of a function is the infimum over sets `s` in the filter
 of the supremum of the function over `s` -/
 theorem limsup_eq_infi_supr {f : filter β} {u : β → α} : f.limsup u = ⨅ s ∈ f, ⨆ a ∈ s, u a :=
-calc f.limsup u = ⨅ s ∈ (f.map u), Sup s : Limsup_eq_infi_Sup
-  ... = ⨅ s ∈ f, ⨆ a ∈ s, u a :
-    le_antisymm
-      (le_infi $ assume s, le_infi $ assume hs,
-        infi_le_of_le (u '' s) $ infi_le_of_le (image_mem_map hs) $ le_of_eq Sup_image)
-      (le_infi $ assume s, le_infi $ assume (hs : u ⁻¹' s ∈ f),
-        infi_le_of_le _ $ infi_le_of_le hs $ supr_le $ assume a, supr_le $ assume ha, le_Sup ha)
+(f.basis_sets.map u).Limsup_eq_infi_Sup.trans $
+  by simp only [Sup_image, id]
 
 @[nolint ge_or_gt] -- see Note [nolint_ge]
 lemma limsup_eq_infi_supr_of_nat {u : ℕ → α} : limsup at_top u = ⨅n:ℕ, ⨆i≥n, u i :=
-calc
-  limsup at_top u = ⨅ s ∈ at_top, ⨆n∈s, u n : limsup_eq_infi_supr
-  ... = ⨅ n, ⨆i≥n, u i :
-    le_antisymm
-      (le_infi $ assume n, infi_le_of_le {i | i ≥ n} $ infi_le_of_le
-        (mem_at_top _)
-        (supr_le_supr $ assume i, supr_le_supr_const (by simp)))
-      (le_infi $ assume s, le_infi $ assume hs,
-        let ⟨n, hn⟩ := mem_at_top_sets.1 hs in
-        infi_le_of_le n $ supr_le_supr $ assume i, supr_le_supr_const (hn i))
+(at_top_basis.map u).Limsup_eq_infi_Sup.trans $
+  by simp only [Sup_image, infi_const]; refl
 
 theorem Liminf_eq_supr_Inf {f : filter α} : f.Liminf = ⨆ s ∈ f, Inf s :=
-le_antisymm
-  (Sup_le $ assume a (ha : ∀ᶠ n in f, a ≤ n),
-    le_supr_of_le _ $ le_supr_of_le ha $ le_Inf $ assume b, id)
-  (supr_le $ assume s, supr_le $ assume hs, le_Sup $ show ∀ᶠ n in f, Inf s ≤ n,
-    by filter_upwards [hs] assume a, Inf_le)
+@Limsup_eq_infi_Sup (order_dual α) _ _
 
 /-- In a complete lattice, the liminf of a function is the infimum over sets `s` in the filter
 of the supremum of the function over `s` -/
 theorem liminf_eq_supr_infi {f : filter β} {u : β → α} : f.liminf u = ⨆ s ∈ f, ⨅ a ∈ s, u a :=
-calc f.liminf u = ⨆ s ∈ f.map u, Inf s : Liminf_eq_supr_Inf
-  ... = ⨆ s ∈ f, ⨅a∈s, u a :
-    le_antisymm
-      (supr_le $ assume s, supr_le $ assume (hs : u ⁻¹' s ∈ f),
-        le_supr_of_le _ $ le_supr_of_le hs $ le_infi $ assume a, le_infi $ assume ha, Inf_le ha)
-      (supr_le $ assume s, supr_le $ assume hs,
-        le_supr_of_le (u '' s) $ le_supr_of_le (image_mem_map hs) $ ge_of_eq Inf_image)
+@limsup_eq_infi_supr (order_dual α) β _ _ _
 
 @[nolint ge_or_gt] -- see Note [nolint_ge]
 lemma liminf_eq_supr_infi_of_nat {u : ℕ → α} : liminf at_top u = ⨆n:ℕ, ⨅i≥n, u i :=
-calc
-  liminf at_top u = ⨆ s ∈ at_top, ⨅ n ∈ s, u n : liminf_eq_supr_infi
-  ... = ⨆n:ℕ, ⨅i≥n, u i :
-    le_antisymm
-      (supr_le $ assume s, supr_le $ assume hs,
-        let ⟨n, hn⟩ := mem_at_top_sets.1 hs in
-        le_supr_of_le n $ infi_le_infi $ assume i, infi_le_infi_const (hn _) )
-      (supr_le $ assume n, le_supr_of_le {i | n ≤ i} $
-        le_supr_of_le
-          (mem_at_top _)
-          (infi_le_infi $ assume i, infi_le_infi_const (by simp)))
+@limsup_eq_infi_supr_of_nat (order_dual α) _ u
 
 end complete_lattice
 
@@ -401,11 +359,7 @@ end
 lemma eventually_lt_of_limsup_lt {f : filter α} [conditionally_complete_linear_order β]
   {u : α → β} {b : β} (h : limsup f u < b) (hu : f.is_bounded_under (≤) u . is_bounded_default) :
   ∀ᶠ a in f, u a < b :=
-begin
-  obtain ⟨c, hc, hbc⟩ : ∃ (c : β) (hc : c ∈ {c : β | ∀ᶠ (n : α) in f, u n ≤ c}), c < b :=
-    exists_lt_of_cInf_lt hu h,
-  exact hc.mono (λ x hx, lt_of_le_of_lt hx hbc)
-end
+@eventually_lt_of_lt_liminf _ (order_dual β) _ _ _ _ h hu
 
 end conditionally_complete_linear_order
 

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -1852,7 +1852,7 @@ lemma filter.tendsto.is_bounded_under_ge {f : filter β} {u : β → α} {a : α
 lemma is_cobounded_le_nhds (a : α) : (𝓝 a).is_cobounded (≤) :=
 (is_bounded_ge_nhds a).is_cobounded_flip
 
-lemma is_cobounded_under_le_of_tendsto {f : filter β} {u : β → α} {a : α}
+lemma filter.tendsto.is_cobounded_under_le {f : filter β} {u : β → α} {a : α}
   [ne_bot f] (h : tendsto u f (𝓝 a)) : f.is_cobounded_under (≤) u :=
 h.is_bounded_under_ge.is_cobounded_flip
 

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -135,7 +135,7 @@ lemma is_closed_Icc {a b : α} : is_closed (Icc a b) :=
 is_closed_inter is_closed_Ici is_closed_Iic
 
 lemma le_of_tendsto_of_tendsto {f g : β → α} {b : filter β} {a₁ a₂ : α} [ne_bot b]
-  (hf : tendsto f b (𝓝 a₁)) (hg : tendsto g b (𝓝 a₂)) (h : ∀ᶠ x in b, f x ≤ g x) :
+  (hf : tendsto f b (𝓝 a₁)) (hg : tendsto g b (𝓝 a₂)) (h : f ≤ᶠ[b] g) :
   a₁ ≤ a₂ :=
 have tendsto (λb, (f b, g b)) b (𝓝 (a₁, a₂)),
   by rw [nhds_prod_eq]; exact hf.prod_mk hg,
@@ -1822,18 +1822,18 @@ match forall_le_or_exists_lt_sup a with
 | or.inr ⟨b, hb⟩ := ⟨b, ge_mem_nhds hb⟩
 end
 
-lemma is_bounded_under_le_of_tendsto {f : filter β} {u : β → α} {a : α}
+lemma filter.tendsto.is_bounded_under_le {f : filter β} {u : β → α} {a : α}
   (h : tendsto u f (𝓝 a)) : f.is_bounded_under (≤) u :=
-is_bounded_of_le h (is_bounded_le_nhds a)
+(is_bounded_le_nhds a).mono h
 
 @[nolint ge_or_gt] -- see Note [nolint_ge]
 lemma is_cobounded_ge_nhds (a : α) : (𝓝 a).is_cobounded (≥) :=
-is_cobounded_of_is_bounded (is_bounded_le_nhds a)
+(is_bounded_le_nhds a).is_cobounded_flip
 
 @[nolint ge_or_gt] -- see Note [nolint_ge]
-lemma is_cobounded_under_ge_of_tendsto {f : filter β} {u : β → α} {a : α}
+lemma filter.tendsto.is_cobounded_under_ge {f : filter β} {u : β → α} {a : α}
   [ne_bot f] (h : tendsto u f (𝓝 a)) : f.is_cobounded_under (≥) u :=
-is_cobounded_of_is_bounded (is_bounded_under_le_of_tendsto h)
+h.is_bounded_under_le.is_cobounded_flip
 
 end order_closed_topology
 
@@ -1842,22 +1842,19 @@ variables [semilattice_inf α] [topological_space α] [order_topology α]
 
 @[nolint ge_or_gt] -- see Note [nolint_ge]
 lemma is_bounded_ge_nhds (a : α) : (𝓝 a).is_bounded (≥) :=
-match forall_le_or_exists_lt_inf a with
-| or.inl h := ⟨a, eventually_of_forall h⟩
-| or.inr ⟨b, hb⟩ := ⟨b, le_mem_nhds hb⟩
-end
+@is_bounded_le_nhds (order_dual α) _ _ _ a
 
 @[nolint ge_or_gt] -- see Note [nolint_ge]
-lemma is_bounded_under_ge_of_tendsto {f : filter β} {u : β → α} {a : α}
+lemma filter.tendsto.is_bounded_under_ge {f : filter β} {u : β → α} {a : α}
   (h : tendsto u f (𝓝 a)) : f.is_bounded_under (≥) u :=
-is_bounded_of_le h (is_bounded_ge_nhds a)
+(is_bounded_ge_nhds a).mono h
 
 lemma is_cobounded_le_nhds (a : α) : (𝓝 a).is_cobounded (≤) :=
-is_cobounded_of_is_bounded (is_bounded_ge_nhds a)
+(is_bounded_ge_nhds a).is_cobounded_flip
 
 lemma is_cobounded_under_le_of_tendsto {f : filter β} {u : β → α} {a : α}
   [ne_bot f] (h : tendsto u f (𝓝 a)) : f.is_cobounded_under (≤) u :=
-is_cobounded_of_is_bounded (is_bounded_under_ge_of_tendsto h)
+h.is_bounded_under_ge.is_cobounded_flip
 
 end order_closed_topology
 
@@ -1900,16 +1897,16 @@ theorem Liminf_nhds : ∀ (a : α), Liminf (𝓝 a) = a :=
 
 /-- If a filter is converging, its limsup coincides with its limit. -/
 theorem Liminf_eq_of_le_nhds {f : filter α} {a : α} [ne_bot f] (h : f ≤ 𝓝 a) : f.Liminf = a :=
-have hb_ge : is_bounded (≥) f, from is_bounded_of_le h (is_bounded_ge_nhds a),
-have hb_le : is_bounded (≤) f, from is_bounded_of_le h (is_bounded_le_nhds a),
+have hb_ge : is_bounded (≥) f, from (is_bounded_ge_nhds a).mono h,
+have hb_le : is_bounded (≤) f, from (is_bounded_le_nhds a).mono h,
 le_antisymm
   (calc f.Liminf ≤ f.Limsup : Liminf_le_Limsup hb_le hb_ge
     ... ≤ (𝓝 a).Limsup :
-      Limsup_le_Limsup_of_le h (is_cobounded_of_is_bounded hb_ge) (is_bounded_le_nhds a)
+      Limsup_le_Limsup_of_le h hb_ge.is_cobounded_flip (is_bounded_le_nhds a)
     ... = a : Limsup_nhds a)
   (calc a = (𝓝 a).Liminf : (Liminf_nhds a).symm
     ... ≤ f.Liminf :
-      Liminf_le_Liminf_of_le h (is_bounded_ge_nhds a) (is_cobounded_of_is_bounded hb_le))
+      Liminf_le_Liminf_of_le h (is_bounded_ge_nhds a) hb_le.is_cobounded_flip)
 
 /-- If a filter is converging, its liminf coincides with its limit. -/
 theorem Limsup_eq_of_le_nhds : ∀ {f : filter α} {a : α} [ne_bot f], f ≤ 𝓝 a → f.Limsup = a :=


### PR DESCRIPTION
## New

* `filter.has_basis.Limsup_eq_infi_Sup`

## Rename

### Namespace `filter`

* `is_bounded_of_le` → `is_bounded_mono`;
* `is_bounded_under_of_is_bounded` → `is_bounded.is_bounded_under`;
* `is_cobounded_of_is_bounded` → `is_bounded.is_cobounded_flip`;
* `is_cobounded_of_le` → `is_cobounded.mono`;

### Top namespace

* `is_bounded_under_le_of_tendsto` → `filter.tendsto.is_bounded_under_le`;
* `is_cobounded_under_ge_of_tendsto` → `filter.tendsto.is_cobounded_under_ge`;
* `is_bounded_under_ge_of_tendsto` → `filter.tendsto.is_bounded_under_ge`;
* `is_cobounded_under_le_of_tendsto` → `filter.tendsto.is_cobounded_under_le`.

## Remove

* `filter.is_trans_le`, `filter.is_trans_ge`: we have both
  in `order/rel_classes`.

---
<!-- put comments you want to keep out of the PR commit here -->