### PR TITLE
[Merged by Bors] - feat(category_theory): monoidal_category (C ⥤ D) when D is monoidal

### DIFF
--- a/src/category_theory/monoidal/functor_category.lean
+++ b/src/category_theory/monoidal/functor_category.lean
@@ -27,6 +27,10 @@ namespace category_theory.monoidal_category_functor_category
 
 variables (F G F' G' : C ⥤ D)
 
+/--
+(An auxiliary definition for `functor_category_monoidal`.)
+Tensor product of functors `C ⥤ D`, when `D` is monoidal.
+ -/
 @[simps]
 def tensor_obj : C ⥤ D :=
 { obj := λ X, F.obj X ⊗ G.obj X,
@@ -37,6 +41,10 @@ def tensor_obj : C ⥤ D :=
 variables {F G F' G'}
 variables (α : F ⟶ G) (β : F' ⟶ G')
 
+/--
+(An auxiliary definition for `functor_category_monoidal`.)
+Tensor product of natural transformations into `D`, when `D` is monoidal.
+-/
 @[simps]
 def tensor_hom : tensor_obj F F' ⟶ tensor_obj G G' :=
 { app := λ X, α.app X ⊗ β.app X,
@@ -47,7 +55,12 @@ end category_theory.monoidal_category_functor_category
 
 open category_theory.monoidal_category_functor_category
 
-instance : monoidal_category (C ⥤ D) :=
+/--
+When `C` is any category, and `D` is a monoidal category,
+the functor category `C ⥤ D` has a natural pointwise monoidal structure,
+where `(F ⊗ G).obj X = F.obj X ⊗ G.obj X`.
+-/
+instance functor_category_monoidal : monoidal_category (C ⥤ D) :=
 { tensor_obj := λ F G, tensor_obj F G,
   tensor_hom := λ F G F' G' α β, tensor_hom α β,
   tensor_id' := λ F G, by { ext, dsimp, rw [tensor_id], },

--- a/src/category_theory/monoidal/functor_category.lean
+++ b/src/category_theory/monoidal/functor_category.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import category_theory.monoidal.category
+import category_theory.functor_category
 import category_theory.const
 
 /-!
@@ -20,10 +21,12 @@ universes v₁ v₂ u₁ u₂
 open category_theory
 open category_theory.monoidal_category
 
+namespace category_theory.monoidal
+
 variables {C : Type u₁} [category.{v₁} C]
 variables {D : Type u₂} [category.{v₂} D] [monoidal_category.{v₂} D]
 
-namespace category_theory.monoidal_category_functor_category
+namespace functor_category
 
 variables (F G F' G' : C ⥤ D)
 
@@ -51,9 +54,9 @@ def tensor_hom : tensor_obj F F' ⟶ tensor_obj G G' :=
   naturality' :=
   λ X Y f, by { dsimp, rw [←tensor_comp, α.naturality, β.naturality, tensor_comp], } }
 
-end category_theory.monoidal_category_functor_category
+end functor_category
 
-open category_theory.monoidal_category_functor_category
+open category_theory.monoidal.functor_category
 
 /--
 When `C` is any category, and `D` is a monoidal category,
@@ -78,3 +81,46 @@ instance functor_category_monoidal : monoidal_category (C ⥤ D) :=
   associator_naturality' := λ F G H F' G' H' α β γ, by { ext X, dsimp, rw associator_naturality, },
   triangle' := λ F G, begin ext X, dsimp, rw triangle, end,
   pentagon' := λ F G H K, begin ext X, dsimp, rw pentagon, end, }
+
+@[simp]
+lemma tensor_unit_obj {X} : (𝟙_ (C ⥤ D)).obj X = 𝟙_ D := rfl
+
+@[simp]
+lemma tensor_unit_map {X Y} {f : X ⟶ Y} : (𝟙_ (C ⥤ D)).map f = 𝟙 (𝟙_ D) := rfl
+
+@[simp]
+lemma tensor_obj_obj {F G : C ⥤ D} {X} : (F ⊗ G).obj X = F.obj X ⊗ G.obj X := rfl
+
+@[simp]
+lemma tensor_obj_map {F G : C ⥤ D} {X Y} {f : X ⟶ Y} : (F ⊗ G).map f = F.map f ⊗ G.map f := rfl
+
+@[simp]
+lemma tensor_hom_app {F G F' G' : C ⥤ D} {α : F ⟶ G} {β : F' ⟶ G'} {X} :
+  (α ⊗ β).app X = α.app X ⊗ β.app X := rfl
+
+@[simp]
+lemma left_unitor_hom_app {F : C ⥤ D} {X} :
+  ((λ_ F).hom : (𝟙_ _) ⊗ F ⟶ F).app X = (λ_ (F.obj X)).hom := rfl
+
+@[simp]
+lemma left_unitor_inv_app {F : C ⥤ D} {X} :
+  ((λ_ F).inv : F ⟶ (𝟙_ _) ⊗ F).app X = (λ_ (F.obj X)).inv := rfl
+
+@[simp]
+lemma right_unitor_hom_app {F : C ⥤ D} {X} :
+  ((ρ_ F).hom : F ⊗ (𝟙_ _) ⟶ F).app X = (ρ_ (F.obj X)).hom := rfl
+
+@[simp]
+lemma right_unitor_inv_app {F : C ⥤ D} {X} :
+  ((ρ_ F).inv : F ⟶ F ⊗ (𝟙_ _)).app X = (ρ_ (F.obj X)).inv := rfl
+
+@[simp]
+lemma associator_hom_app {F G H : C ⥤ D} {X} :
+  ((α_ F G H).hom : (F ⊗ G) ⊗ H ⟶ F ⊗ (G ⊗ H)).app X = (α_ (F.obj X) (G.obj X) (H.obj X)).hom := rfl
+
+@[simp]
+lemma associator_inv_app {F G H : C ⥤ D} {X} :
+  ((α_ F G H).inv : F ⊗ (G ⊗ H) ⟶ (F ⊗ G) ⊗ H).app X = (α_ (F.obj X) (G.obj X) (H.obj X)).inv := rfl
+
+
+end category_theory.monoidal

--- a/src/category_theory/monoidal/functor_category.lean
+++ b/src/category_theory/monoidal/functor_category.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2020 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import category_theory.monoidal.category
+import category_theory.const
+
+/-!
+# Monoidal structure on `C ⥤ D` when `D` is monoidal.
+
+When `C` is any category, and `D` is a monoidal category,
+there is a natural "pointwise" monoidal structure on `C ⥤ D`.
+
+The initial intended application is tensor product of presheaves.
+-/
+
+universes v₁ v₂ u₁ u₂
+
+open category_theory
+open category_theory.monoidal_category
+
+variables {C : Type u₁} [category.{v₁} C]
+variables {D : Type u₂} [category.{v₂} D] [monoidal_category.{v₂} D]
+
+namespace category_theory.monoidal_category_functor_category
+
+variables (F G F' G' : C ⥤ D)
+
+@[simps]
+def tensor_obj : C ⥤ D :=
+{ obj := λ X, F.obj X ⊗ G.obj X,
+  map := λ X Y f, F.map f ⊗ G.map f,
+  map_id' := λ X, by rw [F.map_id, G.map_id, tensor_id],
+  map_comp' := λ X Y Z f g, by rw [F.map_comp, G.map_comp, tensor_comp], }
+
+variables {F G F' G'}
+variables (α : F ⟶ G) (β : F' ⟶ G')
+
+@[simps]
+def tensor_hom : tensor_obj F F' ⟶ tensor_obj G G' :=
+{ app := λ X, α.app X ⊗ β.app X,
+  naturality' :=
+  λ X Y f, by { dsimp, rw [←tensor_comp, α.naturality, β.naturality, tensor_comp], } }
+
+end category_theory.monoidal_category_functor_category
+
+open category_theory.monoidal_category_functor_category
+
+instance : monoidal_category (C ⥤ D) :=
+{ tensor_obj := λ F G, tensor_obj F G,
+  tensor_hom := λ F G F' G' α β, tensor_hom α β,
+  tensor_id' := λ F G, by { ext, dsimp, rw [tensor_id], },
+  tensor_comp' := λ F G H F' G' H' α β γ δ, by { ext, dsimp, rw [tensor_comp], },
+  tensor_unit := (category_theory.functor.const C).obj (𝟙_ D),
+  left_unitor :=  λ F,
+    nat_iso.of_components (λ X, λ_ (F.obj X)) (λ X Y f, by { dsimp, rw left_unitor_naturality, }),
+  right_unitor := λ F,
+    nat_iso.of_components (λ X, ρ_ (F.obj X)) (λ X Y f, by { dsimp, rw right_unitor_naturality, }),
+  associator := λ F G H,
+    nat_iso.of_components
+      (λ X, α_ (F.obj X) (G.obj X) (H.obj X)) (λ X Y f, by { dsimp, rw associator_naturality, }),
+  left_unitor_naturality' := λ F G α, by { ext X, dsimp, rw left_unitor_naturality, },
+  right_unitor_naturality' := λ F G α, by { ext X, dsimp, rw right_unitor_naturality, },
+  associator_naturality' := λ F G H F' G' H' α β γ, by { ext X, dsimp, rw associator_naturality, },
+  triangle' := λ F G, begin ext X, dsimp, rw triangle, end,
+  pentagon' := λ F G H K, begin ext X, dsimp, rw pentagon, end, }


### PR DESCRIPTION
When `C` is any category, and `D` is a monoidal category,
there is a natural "pointwise" monoidal structure on `C ⥤ D`.

The initial intended application is tensor product of presheaves.

---
<!-- put comments you want to keep out of the PR commit here -->
