### PR TITLE
[Merged by Bors] - feat(data/finset/basic): more lemmas on finsets of subtypes

### DIFF
--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1458,7 +1458,7 @@ lemma map_subtype_subset {t : set α} (s : finset t) :
 begin
   intros a ha,
   rw mem_coe at ha,
-  exact property_of_mem_map_subtype s ha
+  convert property_of_mem_map_subtype s ha
 end
 
 lemma subset_image_iff {f : α → β}

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1439,6 +1439,29 @@ begin
   exact λ x, λ hxs hx, h (hx ▸ x.property)
 end
 
+/-- If a `finset` of a subtype is converted to the main type with
+`embedding.subtype`, all elements of the result have the property of
+the subtype. -/
+lemma property_of_mem_map_subtype {p : α → Prop} (s : finset {x // p x}) {a : α}
+    (h : a ∈ s.map (function.embedding.subtype _)) : p a :=
+begin
+  revert h,
+  contrapose,
+  exact not_mem_map_subtype_of_not_property s
+end
+
+/-- If a `finset` of a subtype is converted to the main type with
+`embedding.subtype`, the result is a subset of the set giving the
+subtype. -/
+lemma map_subtype_subset {p : set α} (s : finset {x // p x}) :
+    ↑(s.map (function.embedding.subtype _)) ⊆ p :=
+begin
+  intros a ha,
+  rw mem_coe at ha,
+  change p a,
+  exact property_of_mem_map_subtype s ha
+end
+
 lemma subset_image_iff {f : α → β}
   {s : finset β} {t : set α} : ↑s ⊆ f '' t ↔ ∃s' : finset α, ↑s' ⊆ t ∧ s'.image f = s :=
 begin

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1429,26 +1429,21 @@ lemma subtype_map_of_mem {p : α → Prop} [decidable_pred p] (h : ∀ x ∈ s, 
 by rw [subtype_map, filter_true_of_mem h]
 
 /-- If a `finset` of a subtype is converted to the main type with
-`embedding.subtype`, the result does not contain any value that does
-not satisfy the property of the subtype. -/
-lemma not_mem_map_subtype_of_not_property {p : α → Prop} (s : finset {x // p x})
-    {a : α} (h : ¬ p a) : a ∉ (s.map (function.embedding.subtype _)) :=
-begin
-  rw mem_map,
-  push_neg,
-  exact λ x, λ hxs hx, h (hx ▸ x.property)
-end
-
-/-- If a `finset` of a subtype is converted to the main type with
 `embedding.subtype`, all elements of the result have the property of
 the subtype. -/
 lemma property_of_mem_map_subtype {p : α → Prop} (s : finset {x // p x}) {a : α}
     (h : a ∈ s.map (function.embedding.subtype _)) : p a :=
 begin
-  revert h,
-  contrapose,
-  exact not_mem_map_subtype_of_not_property s
+  rcases mem_map.1 h with ⟨x, hx, rfl⟩,
+  exact x.2
 end
+
+/-- If a `finset` of a subtype is converted to the main type with
+`embedding.subtype`, the result does not contain any value that does
+not satisfy the property of the subtype. -/
+lemma not_mem_map_subtype_of_not_property {p : α → Prop} (s : finset {x // p x})
+    {a : α} (h : ¬ p a) : a ∉ (s.map (function.embedding.subtype _)) :=
+mt s.property_of_mem_map_subtype h
 
 /-- If a `finset` of a subtype is converted to the main type with
 `embedding.subtype`, the result is a subset of the set giving the

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1453,12 +1453,11 @@ end
 /-- If a `finset` of a subtype is converted to the main type with
 `embedding.subtype`, the result is a subset of the set giving the
 subtype. -/
-lemma map_subtype_subset {p : set α} (s : finset {x // p x}) :
-    ↑(s.map (function.embedding.subtype _)) ⊆ p :=
+lemma map_subtype_subset {t : set α} (s : finset t) :
+    ↑(s.map (function.embedding.subtype _)) ⊆ t :=
 begin
   intros a ha,
   rw mem_coe at ha,
-  change p a,
   exact property_of_mem_map_subtype s ha
 end
 


### PR DESCRIPTION
Add two more lemmas related to `not_mem_map_subtype_of_not_property`.


---
<!-- put comments you want to keep out of the PR commit here -->
