### PR TITLE
[Merged by Bors] - chore(ci): get xz archive

### DIFF
--- a/scripts/fetch_olean_cache.sh
+++ b/scripts/fetch_olean_cache.sh
@@ -15,7 +15,7 @@ done
 # exit if there were no successful requests
 [ "$new_git_sha" != "" ] || exit 0
 
-curl "$archive_url$new_git_sha.tar.gz" | tar xz src
+curl "$archive_url$new_git_sha.tar.xz" | tar xJ src
 
 # Extracting the archive overwrites all .lean files, which is fine if we
 # downloaded an "equivalent" cache. However, since we might be using an older


### PR DESCRIPTION
We've been storing both .gz and .xz for a while for backward compatibility but will eventually drop .gz support.


---
<!-- put comments you want to keep out of the PR commit here -->
