### PR TITLE
chore(ci): generalize deploy_docs.sh

### DIFF
--- a/scripts/deploy_docs.sh
+++ b/scripts/deploy_docs.sh
@@ -34,7 +34,7 @@ elan override set "$lean_version"
 
 ./gen_docs -w -r "$3/" -t "mathlib_docs/docs/"
 
-if { [ "$github_repo" = "leanprover-community/mathlib" ] || [ "$github_repo" = "leanprover-community/doc-gen" ]; } && [ "$github_event" = "push" ] && [ "$github_ref" = "refs/heads/master" ]; then
+if { [ "$github_repo" = "leanprover-community/mathlib" ] || [ "$github_repo" = "leanprover-community/doc-gen" ]; } && [ "$github_ref" = "refs/heads/master" ]; then
   cd mathlib_docs/docs
   git config user.email "leanprover.community@gmail.com"
   git config user.name "leanprover-community-bot"


### PR DESCRIPTION
By removing this line, the CI script in the `doc-gen` repo can be used as a scheduled job as well, and we can remove pushing the build docs from mathlib CI.


---
<!-- put comments you want to keep out of the PR commit here -->

I'm not completely sure what this line is guarding against -- pull requests from master?