### PR TITLE
[Merged by Bors] - feat(data/list/basic): add a proof that `(a :: l) ≠ l`

### DIFF
--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -39,6 +39,10 @@ theorem tail_eq_of_cons_eq {h₁ h₂ : α} {t₁ t₂ : list α} :
       (h₁::t₁) = (h₂::t₂) → t₁ = t₂ :=
 assume Peq, list.no_confusion Peq (assume Pheq Pteq, Pteq)
 
+theorem cons_ne_self {α : Type u} : ∀ (a : α) (l : list α), a::l ≠ l
+| a nil := cons_ne_nil a nil
+| a (h :: t) := cons_ne_self h t ∘ tail_eq_of_cons_eq
+
 theorem cons_injective {a : α} : injective (cons a) :=
 assume l₁ l₂, assume Pe, tail_eq_of_cons_eq Pe
 

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -31,6 +31,9 @@ instance : is_associative (list α) has_append.append :=
 
 theorem cons_ne_nil (a : α) (l : list α) : a::l ≠ [].
 
+theorem cons_ne_self (a : α) (l : list α) : a::l ≠ l :=
+mt (congr_arg length) (nat.succ_ne_self _)
+
 theorem head_eq_of_cons_eq {h₁ h₂ : α} {t₁ t₂ : list α} :
       (h₁::t₁) = (h₂::t₂) → h₁ = h₂ :=
 assume Peq, list.no_confusion Peq (assume Pheq Pteq, Pheq)
@@ -38,10 +41,6 @@ assume Peq, list.no_confusion Peq (assume Pheq Pteq, Pheq)
 theorem tail_eq_of_cons_eq {h₁ h₂ : α} {t₁ t₂ : list α} :
       (h₁::t₁) = (h₂::t₂) → t₁ = t₂ :=
 assume Peq, list.no_confusion Peq (assume Pheq Pteq, Pteq)
-
-theorem cons_ne_self {α : Type u} : ∀ (a : α) (l : list α), a::l ≠ l
-| a nil := cons_ne_nil a nil
-| a (h :: t) := cons_ne_self h t ∘ tail_eq_of_cons_eq
 
 theorem cons_injective {a : α} : injective (cons a) :=
 assume l₁ l₂, assume Pe, tail_eq_of_cons_eq Pe


### PR DESCRIPTION
`list.cons_ne_self` is motivated by the existence of `nat.succ_ne_self`.

---
<!-- put comments you want to keep out of the PR commit here -->
Discussed in https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/(list.2Econs.20a.20l).20.E2.89.A0.20l
