### PR TITLE
[Merged by Bors] - feat(measure_theory/measurable_space): introduce `filter.is_measurably_generated`

### DIFF
--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -215,7 +215,7 @@ end
 /-- If `s` is a measurable set, then `nhds_within a s` is a measurably generated filter for
 each `a`. This cannot be an `instance` because it depends on a non-instance `hs : is_measurable s`.
 -/
-def is_measurable.nhds_within_is_measurably_generated {s : set α} (hs : is_measurable s) (a : α) :
+lemma is_measurable.nhds_within_is_measurably_generated {s : set α} (hs : is_measurable s) (a : α) :
   (nhds_within a s).is_measurably_generated :=
 by haveI := hs.principal_is_measurably_generated; exact filter.inf_is_measurably_generated _ _
 

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -34,7 +34,7 @@ import analysis.normed_space.basic
 noncomputable theory
 
 open classical set
-open_locale classical big_operators
+open_locale classical big_operators topological_space
 
 universes u v w x y
 variables {α : Type u} {β : Type v} {γ : Type w} {δ : Type x} {ι : Sort y} {s t u : set α}
@@ -205,6 +205,20 @@ h.is_closed.is_measurable
 lemma is_measurable_closure : is_measurable (closure s) :=
 is_closed_closure.is_measurable
 
+instance nhds_is_measurably_generated (a : α) : (𝓝 a).is_measurably_generated :=
+begin
+  rw [nhds, infi_subtype'],
+  refine @filter.infi_is_measurably_generated _ _ _ _ (λ i, _),
+  exact i.2.2.is_measurable.principal_is_measurably_generated
+end
+
+/-- If `s` is a measurable set, then `nhds_within a s` is a measurably generated filter for
+each `a`. This cannot be an `instance` because it depends on a non-instance `hs : is_measurable s`.
+-/
+def is_measurable.nhds_within_is_measurably_generated {s : set α} (hs : is_measurable s) (a : α) :
+  (nhds_within a s).is_measurably_generated :=
+by haveI := hs.principal_is_measurably_generated; exact filter.inf_is_measurably_generated _ _
+
 @[priority 100] -- see Note [lower instance priority]
 instance opens_measurable_space.to_measurable_singleton_class [t1_space α] :
   measurable_singleton_class α :=
@@ -216,6 +230,14 @@ variables [preorder α] [order_closed_topology α] {a b : α}
 lemma is_measurable_Ici : is_measurable (Ici a) := is_closed_Ici.is_measurable
 lemma is_measurable_Iic : is_measurable (Iic a) := is_closed_Iic.is_measurable
 lemma is_measurable_Icc : is_measurable (Icc a b) := is_closed_Icc.is_measurable
+
+instance at_top_is_measurably_generated : (filter.at_top : filter α).is_measurably_generated :=
+@filter.infi_is_measurably_generated _ _ _ _ $
+  λ a, (is_measurable_Ici : is_measurable (Ici a)).principal_is_measurably_generated
+
+instance at_bot_is_measurably_generated : (filter.at_bot : filter α).is_measurably_generated :=
+@filter.infi_is_measurably_generated _ _ _ _ $
+  λ a, (is_measurable_Iic : is_measurable (Iic a)).principal_is_measurably_generated
 
 end order_closed_topology
 

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -32,7 +32,7 @@ which respects the σ-algebras, that is, for which both directions of
 the equivalence are measurable functions.
 
 We say that a filter `f` is measurably generated if every set `s ∈ f` includes a measurable
-set `t ∈ f`. This property is useful, e.g., to extract a measurably witness of `filter.eventually`.
+set `t ∈ f`. This property is useful, e.g., to extract a measurable witness of `filter.eventually`.
 
 ## Main statements
 

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -31,6 +31,9 @@ A measurable equivalence between measurable spaces is an equivalence
 which respects the σ-algebras, that is, for which both directions of
 the equivalence are measurable functions.
 
+We say that a filter `f` is measurably generated if every set `s ∈ f` includes a measurable
+set `t ∈ f`. This property is useful, e.g., to extract a measurably witness of `filter.eventually`.
+
 ## Main statements
 
 The main theorem of this file is Dynkin's π-λ theorem, which appears

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -1079,6 +1079,10 @@ instance : countable_Inter_filter μ.ae :=
   exact measure_Union_null (subtype.forall.2 hS)
 end⟩
 
+instance ae_is_measurably_generated : is_measurably_generated μ.ae :=
+⟨λ s hs, let ⟨t, hst, htm, htμ⟩ := exists_is_measurable_superset_of_measure_eq_zero hs in
+  ⟨tᶜ, compl_mem_ae_iff.2 htμ, htm.compl, compl_subset_comm.1 hst⟩⟩
+
 lemma ae_all_iff {ι : Type*} [encodable ι] {p : α → ι → Prop} :
   (∀ᵐ a ∂ μ, ∀i, p a i) ↔ (∀i, ∀ᵐ a ∂ μ, p a i) :=
 eventually_countable_forall


### PR DESCRIPTION
Sometimes I want to extract an `is_measurable` witness of a `filter.eventually` statement.

---
<!-- put comments you want to keep out of the PR commit here -->
