### PR TITLE
[Merged by Bors] - chore(order/complete_lattice): use `Prop` args in `infi_inf` etc

### DIFF
--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -593,9 +593,7 @@ end
 -/
 
 lemma infi_inf [h : nonempty ι] {f : ι → α} {a : α} : (⨅x, f x) ⊓ a = (⨅ x, f x ⊓ a) :=
-le_antisymm
-  (le_infi $ assume i, le_inf (inf_le_left_of_le $ infi_le _ _) inf_le_right)
-  (le_inf (infi_le_infi $ assume i, inf_le_left) (infi_le_of_le (classical.choice h) inf_le_right))
+by rw [infi_inf_eq, infi_const]
 
 lemma inf_infi [nonempty ι] {f : ι → α} {a : α} : a ⊓ (⨅x, f x) = (⨅ x, a ⊓ f x) :=
 by rw [inf_comm, infi_inf]; simp [inf_comm]

--- a/src/order/filter/at_top_bot.lean
+++ b/src/order/filter/at_top_bot.lean
@@ -427,9 +427,7 @@ begin
   by_cases ne : nonempty β₁ ∧ nonempty β₂,
   { cases ne,
     resetI,
-    inhabit β₁,
-    inhabit β₂,
-    simp [at_top, prod_infi_left (default β₁), prod_infi_right (default β₂), infi_prod],
+    simp [at_top, prod_infi_left, prod_infi_right, infi_prod],
     exact infi_comm },
   { rw not_and_distrib at ne,
     cases ne;

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -2202,13 +2202,13 @@ begin
   exact ha.mono (λ a ha, hb.mono $ λ b hb, h ha hb)
 end
 
-lemma prod_infi_left {f : ι → filter α} {g : filter β} (i : ι) :
+lemma prod_infi_left [nonempty ι] {f : ι → filter α} {g : filter β}:
   (⨅i, f i) ×ᶠ g = (⨅i, (f i) ×ᶠ g) :=
-by rw [filter.prod, comap_infi, infi_inf i]; simp only [filter.prod, eq_self_iff_true]
+by rw [filter.prod, comap_infi, infi_inf]; simp only [filter.prod, eq_self_iff_true]
 
-lemma prod_infi_right {f : filter α} {g : ι → filter β} (i : ι) :
+lemma prod_infi_right [nonempty ι] {f : filter α} {g : ι → filter β} :
   f ×ᶠ (⨅i, g i) = (⨅i, f ×ᶠ (g i)) :=
-by rw [filter.prod, comap_infi, inf_infi i]; simp only [filter.prod, eq_self_iff_true]
+by rw [filter.prod, comap_infi, inf_infi]; simp only [filter.prod, eq_self_iff_true]
 
 @[mono] lemma prod_mono {f₁ f₂ : filter α} {g₁ g₂ : filter β} (hf : f₁ ≤ f₂) (hg : g₁ ≤ g₂) :
   f₁ ×ᶠ g₁ ≤ f₂ ×ᶠ g₂ :=

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -616,10 +616,8 @@ tendsto_of_tendsto_of_tendsto_of_le_of_le' hg hh
 
 lemma nhds_order_unbounded {a : α} (hu : ∃u, a < u) (hl : ∃l, l < a) :
   𝓝 a = (⨅l (h₂ : l < a) u (h₂ : a < u), 𝓟 (Ioo l u)) :=
-let ⟨u, hu⟩ := hu, ⟨l, hl⟩ := hl in
 calc 𝓝 a = (⨅b<a, 𝓟 {c | b < c}) ⊓ (⨅b>a, 𝓟 {c | c < b}) : nhds_eq_order a
-  ... = (⨅b<a, 𝓟 {c | b < c} ⊓ (⨅b>a, 𝓟 {c | c < b})) :
-    binfi_inf hl
+  ... = (⨅b<a, 𝓟 {c | b < c} ⊓ (⨅b>a, 𝓟 {c | c < b})) : binfi_inf hl
   ... = (⨅l<a, (⨅u>a, 𝓟 {c | c < u} ⊓ 𝓟 {c | l < c})) :
     begin
       congr, funext x,

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -191,35 +191,37 @@ end
 @[priority 100] -- see Note [lower instance priority]
 instance second_countable_topology.to_separable_space
   [second_countable_topology α] : separable_space α :=
-let ⟨b, hb₁, hb₂, hb₃, hb₄, eq⟩ := is_open_generated_countable_inter α in
-have nhds_eq : ∀a, 𝓝 a = (⨅ s : {s : set α // a ∈ s ∧ s ∈ b}, 𝓟 s.val),
-  by intro a; rw [eq, nhds_generate_from, infi_subtype]; refl,
-have ∀s∈b, set.nonempty s,
-  from assume s hs, ne_empty_iff_nonempty.1 $ λ eq, absurd hs (eq.symm ▸ hb₂),
-have ∃f:∀s∈b, α, ∀s h, f s h ∈ s, by simpa only [skolem, set.nonempty] using this,
-let ⟨f, hf⟩ := this in
-⟨⟨(⋃s∈b, ⋃h:s∈b, {f s h}),
-  hb₁.bUnion (λ _ _, countable_Union_Prop $ λ _, countable_singleton _),
-  set.ext $ assume a,
-  have a ∈ (⋃₀ b), by rw [hb₄]; exact trivial,
-  let ⟨t, ht₁, ht₂⟩ := this in
-  have w : {s : set α // a ∈ s ∧ s ∈ b}, from ⟨t, ht₂, ht₁⟩,
-  suffices (⨅ (x : {s // a ∈ s ∧ s ∈ b}), 𝓟 (x.val ∩ ⋃s (h₁ h₂ : s ∈ b), {f s h₂})) ≠ ⊥,
-    by simpa only [closure_eq_cluster_pts, cluster_pt, nhds_eq, infi_inf w, inf_principal,
-                   mem_set_of_eq, mem_univ, iff_true],
-  by haveI : nonempty α := ⟨a⟩; exact infi_ne_bot_of_directed
-    (assume ⟨s₁, has₁, hs₁⟩ ⟨s₂, has₂, hs₂⟩,
-      have a ∈ s₁ ∩ s₂, from ⟨has₁, has₂⟩,
-      let ⟨s₃, hs₃, has₃, hs⟩ := hb₃ _ hs₁ _ hs₂ _ this in
-      ⟨⟨s₃, has₃, hs₃⟩, begin
-        simp only [le_principal_iff, mem_principal_sets, (≥)],
-        simp only [subset_inter_iff] at hs, split;
-          apply inter_subset_inter_left; simp only [hs]
-      end⟩)
-    (assume ⟨s, has, hs⟩,
-      have (s ∩ (⋃ (s : set α) (H h : s ∈ b), {f s h})).nonempty,
-        from ⟨_, hf _ hs, mem_bUnion hs $ mem_Union.mpr ⟨hs, mem_singleton _⟩⟩,
-      principal_ne_bot_iff.2 this) ⟩⟩
+begin
+  rcases is_open_generated_countable_inter α with  ⟨b, hbc, hbne, hb, hbU, eq⟩,
+  set S : α → set (set α) := λ a, {s : set α | a ∈ s ∧ s ∈ b},
+  have nhds_eq : ∀a, 𝓝 a = (⨅ s ∈ S a, 𝓟 s),
+  { intro a, rw [eq, nhds_generate_from] },
+  have : ∀ s ∈ b, set.nonempty s :=
+    assume s hs, ne_empty_iff_nonempty.1 $ λ eq, absurd hs (eq.symm ▸ hbne),
+  choose f hf,
+  refine ⟨⟨⋃ s ∈ b, {f s ‹_›}, hbc.bUnion (λ _ _, countable_singleton _), _⟩⟩,
+  refine eq_univ_of_forall (λ a, _),
+  suffices : (⨅ s ∈ S a, 𝓟 (s ∩ ⋃ t ∈ b, {f t ‹_›})).ne_bot,
+  { obtain ⟨t, htb, hta⟩ : a ∈ ⋃₀ b, { simp only [hbU] },
+    have A : ∃ s, s ∈ S a := ⟨t, hta, htb⟩,
+    simpa only [← inf_principal, mem_closure_iff_cluster_pt,
+      cluster_pt, nhds_eq, binfi_inf A] using this },
+  rw [infi_subtype'],
+  haveI : nonempty α := ⟨a⟩,
+  refine infi_ne_bot_of_directed _ _,
+  { rintros ⟨s₁, has₁, hs₁⟩ ⟨s₂, has₂, hs₂⟩,
+    obtain ⟨t, htb, hta, ht⟩ : ∃ t ∈ b, a ∈ t ∧ t ⊆ s₁ ∩ s₂,
+      from hb _ hs₁ _ hs₂ a ⟨has₁, has₂⟩,
+    refine ⟨⟨t, hta, htb⟩, _⟩,
+    simp only [subset_inter_iff] at ht,
+    simp only [principal_mono, subtype.coe_mk, (≥)],
+    exact ⟨inter_subset_inter_left _ ht.1, inter_subset_inter_left _ ht.2⟩ },
+  rintros ⟨s, hsa, hsb⟩,
+  suffices : (s ∩ ⋃ t ∈ b, {f t ‹_›}).nonempty, { simpa [principal_ne_bot_iff] },
+  refine ⟨_, hf _ hsb, _⟩,
+  simp only [mem_Union],
+  exact ⟨s, hsb, rfl⟩
+end
 
 variables {α}
 

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -52,10 +52,10 @@ end
 
 theorem nhds_within_eq (a : α) (s : set α) :
   nhds_within a s = ⨅ t ∈ {t : set α | a ∈ t ∧ is_open t}, 𝓟 (t ∩ s) :=
-have set.univ ∈ {s : set α | a ∈ s ∧ is_open s}, from ⟨set.mem_univ _, is_open_univ⟩,
 begin
-  rw [nhds_within, nhds, binfi_inf]; try { exact this },
-  simp only [inf_principal]
+  rw [nhds_within, nhds, binfi_inf],
+  simp only [inf_principal],
+  exact ⟨univ, mem_univ _, is_open_univ⟩
 end
 
 theorem nhds_within_univ (a : α) : nhds_within a set.univ = 𝓝 a :=


### PR DESCRIPTION
This way one can `rw binfi_inf` first, then prove `∃ i, p i`.

Also move some code up to make it available near `infi_inf`.

---
<!-- put comments you want to keep out of the PR commit here -->
