### PR TITLE
[Merged by Bors] - chore(ci): only store oleans in azure cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,10 +55,10 @@ jobs:
         if: always() && github.repository == 'leanprover-community/mathlib'
         run: |
           archive_name="$(git rev-parse HEAD).tar.gz"
-          tar czf "$archive_name" src
+          find src/ -name "*.olean" | tar czf "$archive_name" -T -
           azcopy copy "$archive_name" "${{ secrets.AZURE_SAS_TOKEN }}" --block-size-mb 99 --overwrite false
           archive_name="$(git rev-parse HEAD).tar.xz"
-          tar cJf "$archive_name" src
+          find src/ -name "*.olean" | tar cJf "$archive_name" -T -
           azcopy copy "$archive_name" "${{ secrets.AZURE_SAS_TOKEN }}" --block-size-mb 99 --overwrite false
 
       - name: setup precompiled zip file

--- a/scripts/fetch_olean_cache.sh
+++ b/scripts/fetch_olean_cache.sh
@@ -17,7 +17,8 @@ done
 
 curl "$archive_url$new_git_sha.tar.xz" | tar xJ src
 
-# Extracting the archive overwrites all .lean files, which is fine if we
+# Archives no longer contain .lean files, but they used to.
+# Extracting such an archive overwrites all .lean files, which is fine if we
 # downloaded an "equivalent" cache. However, since we might be using an older
 # cache, we must revert any changes made to the .lean files.
 #


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->
As far as we can tell, no infrastructure depends on these caches containing more than just the oleans, and the presence of .lean files can create minor complications.