### PR TITLE
[Merged by Bors] - feat(algebra/category/Group): the category of abelian groups is abelian

### DIFF
--- a/src/algebra/category/Group/abelian.lean
+++ b/src/algebra/category/Group/abelian.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2020 Markus Himmel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus Himmel
+-/
+import algebra.category.Group.Z_Module_equivalence
+import algebra.category.Group.limits
+import algebra.category.Group.colimits
+import algebra.category.Module.abelian
+import category_theory.abelian.basic
+
+/-!
+# The category of abelian groups is abelian
+-/
+
+open category_theory
+open category_theory.limits
+
+noncomputable theory
+
+namespace AddCommGroup
+
+section
+variables {X Y : AddCommGroup.{0}} (f : X ⟶ Y)
+
+/-- In the category of abelian groups, every monomorphism is normal. -/
+def normal_mono (hf : mono f) : normal_mono f :=
+equivalence_reflects_normal_mono (forget₂ (Module ℤ) AddCommGroup).inv $
+  Module.normal_mono _ $ right_adjoint_preserves_mono (functor.adjunction _) hf
+
+/-- In the category of abelian groups, every epimorphism is normal. -/
+def normal_epi (hf : epi f) : normal_epi f :=
+equivalence_reflects_normal_epi (forget₂ (Module ℤ) AddCommGroup).inv $
+  Module.normal_epi _ $ left_adjoint_preserves_epi (functor.adjunction _) hf
+
+end
+
+/-- The category of abelian groups is abelian. -/
+instance : abelian AddCommGroup :=
+{ has_finite_products := by apply_instance,
+  has_kernels := by apply_instance,
+  has_cokernels := by apply_instance,
+  normal_mono := λ X Y, normal_mono,
+  normal_epi := λ X Y, normal_epi }
+
+end AddCommGroup

--- a/src/algebra/category/Group/abelian.lean
+++ b/src/algebra/category/Group/abelian.lean
@@ -35,6 +35,9 @@ equivalence_reflects_normal_epi (forget₂ (Module ℤ) AddCommGroup).inv $
 
 end
 
+local attribute [instance] has_equalizers_of_has_finite_limits
+local attribute [instance] has_coequalizers_of_has_finite_colimits
+
 /-- The category of abelian groups is abelian. -/
 instance : abelian AddCommGroup :=
 { has_finite_products := by apply_instance,

--- a/src/algebra/category/Module/abelian.lean
+++ b/src/algebra/category/Module/abelian.lean
@@ -22,7 +22,7 @@ namespace Module
 variables {R : Type u} [ring R] {M N : Module R} (f : M ⟶ N)
 
 /-- In the category of modules, every monomorphism is normal. -/
-def normal_mono [mono f] : normal_mono f :=
+def normal_mono (hf : mono f) : normal_mono f :=
 { Z := of R f.range.quotient,
   g := f.range.mkq,
   w := linear_map.range_mkq_comp _,
@@ -44,7 +44,7 @@ def normal_mono [mono f] : normal_mono f :=
       by { ext, refl } }
 
 /-- In the category of modules, every epimorphism is normal. -/
-def normal_epi [epi f] : normal_epi f :=
+def normal_epi (hf : epi f) : normal_epi f :=
 { W := of R f.ker,
   g := f.ker.subtype,
   w := linear_map.comp_ker_subtype _,
@@ -71,7 +71,7 @@ instance : abelian (Module R) :=
 { has_finite_products := by apply_instance,
   has_kernels := by apply_instance,
   has_cokernels := has_cokernels_Module,
-  normal_mono := λ X Y f m, by exactI normal_mono f,
-  normal_epi := λ X Y f e, by exactI normal_epi f }
+  normal_mono := λ X Y, normal_mono,
+  normal_epi := λ X Y, normal_epi }
 
 end Module

--- a/src/category_theory/limits/shapes/equalizers.lean
+++ b/src/category_theory/limits/shapes/equalizers.lean
@@ -95,7 +95,7 @@ variables {X Y : C}
 
 /-- `parallel_pair f g` is the diagram in `C` consisting of the two morphisms `f` and `g` with
     common domain and codomain. -/
-def parallel_pair (f g : X ⟶ Y) : walking_parallel_pair ⥤ C :=
+def parallel_pair (f g : X ⟶ Y) : walking_parallel_pair.{v} ⥤ C :=
 { obj := λ x, match x with
   | zero := X
   | one := Y

--- a/src/category_theory/limits/shapes/finite_limits.lean
+++ b/src/category_theory/limits/shapes/finite_limits.lean
@@ -80,14 +80,12 @@ end
 instance : fin_category walking_parallel_pair := { }
 
 /-- Equalizers are finite limits, so if `C` has all finite limits, it also has all equalizers -/
-@[priority 100]
-instance has_equalizers_of_has_finite_limits [has_finite_limits C] : has_equalizers C :=
+def has_equalizers_of_has_finite_limits [has_finite_limits C] : has_equalizers C :=
 { has_limits_of_shape := infer_instance }
 
 /-- Coequalizers are finite colimits, of if `C` has all finite colimits, it also has all
     coequalizers -/
-@[priority 100]
-instance has_coequalizers_of_has_finite_colimits [has_finite_colimits C] : has_coequalizers C :=
+def has_coequalizers_of_has_finite_colimits [has_finite_colimits C] : has_coequalizers C :=
 { has_colimits_of_shape := infer_instance }
 
 variables {J : Type v}

--- a/src/category_theory/limits/shapes/finite_limits.lean
+++ b/src/category_theory/limits/shapes/finite_limits.lean
@@ -80,12 +80,14 @@ end
 instance : fin_category walking_parallel_pair := { }
 
 /-- Equalizers are finite limits, so if `C` has all finite limits, it also has all equalizers -/
-def has_equalizers_of_has_finite_limits [has_finite_limits C] : has_equalizers C :=
+@[priority 100]
+instance has_equalizers_of_has_finite_limits [has_finite_limits C] : has_equalizers C :=
 { has_limits_of_shape := infer_instance }
 
 /-- Coequalizers are finite colimits, of if `C` has all finite colimits, it also has all
     coequalizers -/
-def has_coequalizers_of_has_finite_colimits [has_finite_colimits C] : has_coequalizers C :=
+@[priority 100]
+instance has_coequalizers_of_has_finite_colimits [has_finite_colimits C] : has_coequalizers C :=
 { has_colimits_of_shape := infer_instance }
 
 variables {J : Type v}

--- a/src/category_theory/limits/shapes/kernels.lean
+++ b/src/category_theory/limits/shapes/kernels.lean
@@ -44,7 +44,7 @@ general limits can be used.
 * [F. Borceux, *Handbook of Categorical Algebra 2*][borceux-vol2]
 -/
 
-universes v u
+universes v u u'
 
 open category_theory
 open category_theory.limits.walking_parallel_pair
@@ -80,6 +80,29 @@ fork.of_ι ι $ by rw [w, has_zero_morphisms.comp_zero]
 
 @[simp] lemma kernel_fork.ι_of_ι {X Y P : C} (f : X ⟶ Y) (ι : P ⟶ X) (w : ι ≫ f = 0) :
   fork.ι (kernel_fork.of_ι ι w) = ι := rfl
+
+section
+local attribute [tidy] tactic.case_bash
+
+/-- Every kernel fork `s` is isomorphic (actually, equal) to `fork.of_ι (fork.ι s) _`. -/
+def iso_of_ι (s : fork f 0) : s ≅ fork.of_ι (fork.ι s) (fork.condition s) :=
+cones.ext (iso.refl _) $ by tidy
+
+/-- If `ι = ι'`, then `fork.of_ι ι _` and `fork.of_ι ι' _` are isomorphic. -/
+def of_ι_congr {P : C} {ι ι' : P ⟶ X} {w : ι ≫ f = 0} (h : ι = ι') :
+  kernel_fork.of_ι ι w ≅ kernel_fork.of_ι ι' (by rw [←h, w]) :=
+cones.ext (iso.refl _) $ by tidy
+
+/-- If `F` is an equivalence, then applying `F` to a diagram indexing a (co)kernel of `f` yields
+    the diagram indexing the (co)kernel of `F.map f`. -/
+def comp_nat_iso {D : Type u'} [category.{v} D] [has_zero_morphisms D] (F : C ⥤ D)
+  [is_equivalence F] : parallel_pair f 0 ⋙ F ≅ parallel_pair (F.map f) 0 :=
+nat_iso.of_components (λ j, match j with
+  | zero := iso.refl _
+  | one := iso.refl _
+  end) $ by tidy
+
+end
 
 /-- If `s` is a limit kernel fork and `k : W ⟶ X` satisfies ``k ≫ f = 0`, then there is some
     `l : W ⟶ s.X` such that `l ≫ fork.ι s = k`. -/
@@ -323,6 +346,15 @@ cofork.of_π π $ by rw [w, has_zero_morphisms.zero_comp]
 
 @[simp] lemma cokernel_cofork.π_of_π {X Y P : C} (f : X ⟶ Y) (π : Y ⟶ P) (w : f ≫ π = 0) :
   cofork.π (cokernel_cofork.of_π π w) = π := rfl
+
+/-- Every cokernel cofork `s` is isomorphic (actually, equal) to `cofork.of_π (cofork.π s) _`. -/
+def iso_of_π (s : cofork f 0) : s ≅ cofork.of_π (cofork.π s) (cofork.condition s) :=
+cocones.ext (iso.refl _) $ λ j, by cases j; tidy
+
+/-- If `π = π'`, then `cokernel_cofork.of_π π _` and `cokernel_cofork.of_π π' _` are isomorphic. -/
+def of_π_congr {P : C} {π π' : Y ⟶ P} {w : f ≫ π = 0} (h : π = π') :
+  cokernel_cofork.of_π π w ≅ cokernel_cofork.of_π π' (by rw [←h, w]) :=
+cocones.ext (iso.refl _) $ λ j, by cases j; tidy
 
 /-- If `s` is a colimit cokernel cofork, then every `k : Y ⟶ W` satisfying `f ≫ k = 0` induces
     `l : s.X ⟶ W` such that `cofork.π s ≫ l = k`. -/

--- a/src/category_theory/limits/shapes/regular_mono.lean
+++ b/src/category_theory/limits/shapes/regular_mono.lean
@@ -3,6 +3,7 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Bhavik Mehta
 -/
+import category_theory.limits.preserves
 import category_theory.limits.shapes.kernels
 import category_theory.limits.shapes.strong_epi
 import category_theory.limits.shapes.pullbacks
@@ -26,7 +27,7 @@ construction
 namespace category_theory
 open category_theory.limits
 
-universes v₁ u₁
+universes v₁ u₁ u₂
 
 variables {C : Type u₁} [category.{v₁} C]
 
@@ -123,6 +124,26 @@ class normal_mono (f : X ⟶ Y) :=
 (g : Y ⟶ Z)
 (w : f ≫ g = 0)
 (is_limit : is_limit (kernel_fork.of_ι f w))
+
+section
+local attribute [instance] fully_faithful_reflects_limits
+local attribute [instance] equivalence.ess_surj_of_equivalence
+
+/-- If `F` is an equivalence and `F.map f` is a normal mono, then `f` is a normal mono. -/
+def equivalence_reflects_normal_mono {D : Type u₂} [category.{v₁} D] [has_zero_morphisms D]
+  (F : C ⥤ D) [is_equivalence F] {X Y : C} {f : X ⟶ Y} (hf : normal_mono (F.map f)) :
+  normal_mono f :=
+{ Z := F.obj_preimage hf.Z,
+  g := full.preimage (hf.g ≫ (F.fun_obj_preimage_iso hf.Z).inv),
+  w := faithful.map_injective F $ by simp [reassoc_of hf.w],
+  is_limit := reflects_limit.reflects $
+    is_limit.of_cone_equiv (cones.postcompose_equivalence (comp_nat_iso F)) $
+      is_limit.of_iso_limit
+        (by exact is_limit.of_iso_limit
+          (is_kernel.of_comp_iso _ _ (F.fun_obj_preimage_iso hf.Z) (by simp) hf.is_limit)
+          (of_ι_congr (category.comp_id _).symm)) (iso_of_ι _).symm }
+
+end
 
 /-- Every normal monomorphism is a regular monomorphism. -/
 @[priority 100]
@@ -276,6 +297,27 @@ class normal_epi (f : X ⟶ Y) :=
 (g : W ⟶ X)
 (w : g ≫ f = 0)
 (is_colimit : is_colimit (cokernel_cofork.of_π f w))
+
+section
+local attribute [instance] fully_faithful_reflects_colimits
+local attribute [instance] equivalence.ess_surj_of_equivalence
+
+/-- If `F` is an equivalence and `F.map f` is a normal epi, then `f` is a normal epi. -/
+def equivalence_reflects_normal_epi {D : Type u₂} [category.{v₁} D] [has_zero_morphisms D]
+  (F : C ⥤ D) [is_equivalence F] {X Y : C} {f : X ⟶ Y} (hf : normal_epi (F.map f)) :
+  normal_epi f :=
+{ W := F.obj_preimage hf.W,
+  g := full.preimage ((F.fun_obj_preimage_iso hf.W).hom ≫ hf.g),
+  w := faithful.map_injective F $ by simp [hf.w],
+  is_colimit := reflects_colimit.reflects $
+    is_colimit.of_cocone_equiv (cocones.precompose_equivalence (comp_nat_iso F).symm) $
+      is_colimit.of_iso_colimit
+        (by exact is_colimit.of_iso_colimit
+          (is_cokernel.of_iso_comp _ _ (F.fun_obj_preimage_iso hf.W).symm (by simp) hf.is_colimit)
+            (of_π_congr (category.id_comp _).symm))
+        (iso_of_π _).symm }
+
+end
 
 /-- Every normal epimorphism is a regular epimorphism. -/
 @[priority 100]

--- a/src/category_theory/limits/shapes/zero.lean
+++ b/src/category_theory/limits/shapes/zero.lean
@@ -111,7 +111,7 @@ variables (D : Type u') [category.{v'} D]
 
 variables [has_zero_morphisms C] [has_zero_morphisms D]
 
-@[simp] lemma equivalence_preserves_zero_morphisms (F : C ≌ D) (X Y : C) :
+lemma equivalence_preserves_zero_morphisms (F : C ≌ D) (X Y : C) :
   F.functor.map (0 : X ⟶ Y) = (0 : F.functor.obj X ⟶ F.functor.obj Y) :=
 begin
   have t : F.functor.map (0 : X ⟶ Y) = F.functor.map (0 : X ⟶ Y) ≫ (0 : F.functor.obj Y ⟶ F.functor.obj Y),
@@ -121,6 +121,10 @@ begin
     rw [zero_comp, comp_zero, zero_comp], },
   exact t.trans (by simp)
 end
+
+@[simp] lemma is_equivalence_preserves_zero_morphisms (F : C ⥤ D) [is_equivalence F] (X Y : C) :
+  F.map (0 : X ⟶ Y) = 0 :=
+by rw [←functor.as_equivalence_functor F, equivalence_preserves_zero_morphisms]
 
 end
 


### PR DESCRIPTION
---

We pull back the `normal_mono` and `normal_epi` instances via the equivalence between `Module ℤ` and `AddCommGroup`.

There are some universe issues here: Since the equivalence is between `Module ℤ` and `AddCommGroup.{0}`, we don't get the abelian instance for abelian groups in higher universes. Can the equivalence somehow be generalized?

The four-character change in `equalizers.lean` is very significant: without it, the proof that equivalences reflect `normal_*` does not compile. This suggests that maybe removing all the universe annotations was slightly too ambitious?