### PR TITLE
[Merged by Bors] - feat(tactic/lint): quieter output by default

### DIFF
--- a/scripts/lint_mathlib.lean
+++ b/scripts/lint_mathlib.lean
@@ -87,6 +87,6 @@ let results := (do
   (linter_name, linter, decls) ← results₀,
   [(linter_name, linter, (nolint_file.find linter_name).foldl rb_map.erase decls)]),
 io.print $ to_string $ format_linter_results env results decls non_auto_decls
-  mathlib_path_len "in mathlib" tt tt,
+  mathlib_path_len "in mathlib" tt lint_verbosity.medium,
 io.write_file "nolints.txt" $ to_string $ mk_nolint_file env mathlib_path_len results₀,
 if results.all (λ r, r.2.2.empty) then pure () else io.fail ""

--- a/src/tactic/lint/default.lean
+++ b/src/tactic/lint/default.lean
@@ -53,8 +53,11 @@ The command `#list_linters` prints a list of the names of all available linters.
 You can append a `*` to any command (e.g. `#lint_mathlib*`) to omit the slow tests (4).
 
 You can append a `-` to any command (e.g. `#lint_mathlib-`) to run a silent lint
-that suppresses the output of passing checks.
+that suppresses the output if all checks pass.
 A silent lint will fail if any test fails.
+
+You can append a `+` to any command (e.g. `#lint_mathlib+`) to run a verbose lint
+that reports the result of each linter, including  the successes.
 
 You can append a sequence of linter names to any command to run extra tests, in addition to the
 default ones. e.g. `#lint doc_blame_thm` will run all default tests and `doc_blame_thm`.

--- a/src/tactic/lint/frontend.lean
+++ b/src/tactic/lint/frontend.lean
@@ -22,8 +22,11 @@ The command `#list_linters` prints a list of the names of all available linters.
 You can append a `*` to any command (e.g. `#lint_mathlib*`) to omit the slow tests (4).
 
 You can append a `-` to any command (e.g. `#lint_mathlib-`) to run a silent lint
-that suppresses the output of passing checks.
+that suppresses the output if all checks pass.
 A silent lint will fail if any test fails.
+
+You can append a `+` to any command (e.g. `#lint_mathlib+`) to run a verbose lint
+that reports the result of each linter, including  the successes.
 
 You can append a sequence of linter names to any command to run extra tests, in addition to the
 default ones. e.g. `#lint doc_blame_thm` will run all default tests and `doc_blame_thm`.
@@ -51,6 +54,14 @@ reserve notation `#list_linters`
 
 open tactic expr native
 setup_tactic_parser
+
+/--
+Verbosity for the linter output.
+* `low`: only print failing checks, print nothing on success.
+* `medium`: only print failing checks, print confirmation on success.
+* `high`: print output of every check.
+-/
+@[derive decidable_eq] inductive lint_verbosity | low | medium | high
 
 /-- `get_checks slow extra use_only` produces a list of linters.
 `extras` is a list of names that should resolve to declarations with type `linter`.
@@ -127,20 +138,21 @@ meta def format_linter_results
   (results : list (name × linter × rb_map name string))
   (decls non_auto_decls : list declaration)
   (group_by_filename : option nat)
-  (where_desc : string) (slow verbose : bool) :
+  (where_desc : string) (slow : bool) (verbose : lint_verbosity) :
   format := do
 let formatted_results := results.map $ λ ⟨linter_name, linter, results⟩,
   let report_str : format := to_fmt "/- The `" ++ to_fmt linter_name ++ "` linter reports: -/\n" in
-  if ¬ results.empty then do
+  if ¬ results.empty then
     let warnings := match group_by_filename with
       | none := print_warnings env results
       | some dropped := grouped_by_filename env results dropped (print_warnings env)
       end in
     report_str ++ "/- " ++ linter.errors_found ++ ": -/\n" ++ warnings ++ "\n"
-  else
-    if verbose then "/- OK: " ++ linter.no_errors_found ++ ". -/" else format.nil,
+  else if verbose = lint_verbosity.high then
+    "/- OK: " ++ linter.no_errors_found ++ ". -/"
+  else format.nil,
 let s := format.intercalate "\n" (formatted_results.filter (λ f, ¬ f.is_nil)),
-let s := if ¬ verbose then s else
+let s := if verbose = lint_verbosity.low then s else
   format!"/- Checking {non_auto_decls.length} declarations (plus {decls.length - non_auto_decls.length} automatically generated ones) {where_desc} -/\n\n" ++ s,
 let s := if slow then s else s ++ "/- (slow tests skipped) -/\n",
 s
@@ -155,7 +167,7 @@ By setting `checks` you can customize which checks are performed.
 Returns a `name_set` containing the names of all declarations that fail any check in `check`,
 and a `format` object describing the failures. -/
 meta def lint_aux (decls : list declaration) (group_by_filename : option nat)
-    (where_desc : string) (slow verbose : bool) (checks : list (name × linter)) :
+    (where_desc : string) (slow : bool) (verbose : lint_verbosity) (checks : list (name × linter)) :
   tactic (name_set × format) := do
 e ← get_env,
 let non_auto_decls := decls.filter (λ d, ¬ d.is_auto_or_internal e),
@@ -166,8 +178,8 @@ let ns := name_set.of_list (do (_,_,rs) ← results, rs.keys),
 pure (ns, s)
 
 /-- Return the message printed by `#lint` and a `name_set` containing all declarations that fail. -/
-meta def lint (slow : bool := tt) (verbose : bool := tt) (extra : list name := [])
-  (use_only : bool := ff) : tactic (name_set × format) := do
+meta def lint (slow : bool := tt) (verbose : lint_verbosity := lint_verbosity.medium)
+  (extra : list name := []) (use_only : bool := ff) : tactic (name_set × format) := do
   checks ← get_checks slow extra use_only,
   e ← get_env,
   let l := e.filter (λ d, e.in_current_file' d.to_name),
@@ -181,8 +193,8 @@ pure $ e.filter $ λ d, e.is_prefix_of_file ml d.to_name
 
 /-- Return the message printed by `#lint_mathlib` and a `name_set` containing all declarations
 that fail. -/
-meta def lint_mathlib (slow : bool := tt) (verbose : bool := tt) (extra : list name := [])
-  (use_only : bool := ff) : tactic (name_set × format) := do
+meta def lint_mathlib (slow : bool := tt) (verbose : lint_verbosity := lint_verbosity.medium)
+  (extra : list name := []) (use_only : bool := ff) : tactic (name_set × format) := do
 checks ← get_checks slow extra use_only,
 decls ← lint_mathlib_decls,
 mathlib_path_len ← string.length <$> get_mathlib_dir,
@@ -190,8 +202,8 @@ lint_aux decls mathlib_path_len "in mathlib (only in imported files)" slow verbo
 
 /-- Return the message printed by `#lint_all` and a `name_set` containing all declarations
 that fail. -/
-meta def lint_all (slow : bool := tt) (verbose : bool := tt) (extra : list name := [])
-  (use_only : bool := ff) : tactic (name_set × format) := do
+meta def lint_all (slow : bool := tt) (verbose : lint_verbosity := lint_verbosity.medium)
+  (extra : list name := []) (use_only : bool := ff) : tactic (name_set × format) := do
   checks ← get_checks slow extra use_only,
   e ← get_env,
   let l := e.get_decls,
@@ -202,35 +214,53 @@ Prepends `linter.` to each of these identifiers. -/
 private meta def parse_lint_additions : parser (bool × list name) :=
 prod.mk <$> only_flag <*> (list.map (name.append `linter) <$> ident_*)
 
+/--
+Parses a "-" or "+", returning `lint_verbosity.low` or `lint_verbosity.high` respectively,
+or returns `none`.
+-/
+private meta def parse_verbosity : parser (option lint_verbosity) :=
+tk "-" >> return lint_verbosity.low <|>
+tk "+" >> return lint_verbosity.high <|>
+return none
+
 /-- The common denominator of `lint_cmd`, `lint_mathlib_cmd`, `lint_all_cmd` -/
-private meta def lint_cmd_aux (scope : bool → bool → list name → bool → tactic (name_set × format)) :
+private meta def lint_cmd_aux (scope : bool → lint_verbosity → list name → bool → tactic (name_set × format)) :
   parser unit :=
-do silent ← optional (tk "-"),
+do verbosity ← parse_verbosity,
    fast_only ← optional (tk "*"),
-   silent ← if silent.is_some then return silent else optional (tk "-"), -- allow either order of *-
+   verbosity ← if verbosity.is_some then return verbosity else parse_verbosity, -- allow either order of *-
+   let verbosity := verbosity.get_or_else lint_verbosity.medium,
    (use_only, extra) ← parse_lint_additions,
-   (failed, s) ← scope fast_only.is_none silent.is_none extra use_only,
+   (failed, s) ← scope fast_only.is_none verbosity extra use_only,
    when (¬ s.is_nil) $ trace s,
-   when (silent.is_some ∧ ¬ failed.empty) $
-    fail "Linting did not succeed"
+   when (verbosity = lint_verbosity.low ∧ ¬ failed.empty) $
+    fail "Linting did not succeed",
+   when (verbosity = lint_verbosity.medium ∧ failed.empty) $
+    trace "All linting checks passed!"
 
 /-- The command `#lint` at the bottom of a file will warn you about some common mistakes
 in that file. Usage: `#lint`, `#lint linter_1 linter_2`, `#lint only linter_1 linter_2`.
-`#lint-` will suppress the output of passing checks.
+`#lint-` will suppress the output if all checks pass.
+`#lint+` will enable verbose output.
+
 Use the command `#list_linters` to see all available linters. -/
 @[user_command] meta def lint_cmd (_ : parse $ tk "#lint") : parser unit :=
 lint_cmd_aux @lint
 
 /-- The command `#lint_mathlib` checks all of mathlib for certain mistakes.
 Usage: `#lint_mathlib`, `#lint_mathlib linter_1 linter_2`, `#lint_mathlib only linter_1 linter_2`.
-`#lint_mathlib-` will suppress the output of passing checks.
+`#lint_mathlib-` will suppress the output if all checks pass.
+`lint_mathlib+` will enable verbose output.
+
 Use the command `#list_linters` to see all available linters. -/
 @[user_command] meta def lint_mathlib_cmd (_ : parse $ tk "#lint_mathlib") : parser unit :=
 lint_cmd_aux @lint_mathlib
 
 /-- The command `#lint_all` checks all imported files for certain mistakes.
 Usage: `#lint_all`, `#lint_all linter_1 linter_2`, `#lint_all only linter_1 linter_2`.
-`#lint_all-` will suppress the output of passing checks.
+`#lint_all-` will suppress the output if all checks pass.
+`lint_all+` will enable verbose output.
+
 Use the command `#list_linters` to see all available linters. -/
 @[user_command] meta def lint_all_cmd (_ : parse $ tk "#lint_all") : parser unit :=
 lint_cmd_aux @lint_all

--- a/src/tactic/lint/frontend.lean
+++ b/src/tactic/lint/frontend.lean
@@ -61,7 +61,8 @@ Verbosity for the linter output.
 * `medium`: only print failing checks, print confirmation on success.
 * `high`: print output of every check.
 -/
-@[derive decidable_eq] inductive lint_verbosity | low | medium | high
+@[derive [decidable_eq, inhabited]]
+inductive lint_verbosity | low | medium | high
 
 /-- `get_checks slow extra use_only` produces a list of linters.
 `extras` is a list of names that should resolve to declarations with type `linter`.

--- a/src/tactic/lint/frontend.lean
+++ b/src/tactic/lint/frontend.lean
@@ -236,7 +236,7 @@ do verbosity ← parse_verbosity,
    when (verbosity = lint_verbosity.low ∧ ¬ failed.empty) $
     fail "Linting did not succeed",
    when (verbosity = lint_verbosity.medium ∧ failed.empty) $
-    trace "All linting checks passed!"
+    trace "/- All linting checks passed! -/"
 
 /-- The command `#lint` at the bottom of a file will warn you about some common mistakes
 in that file. Usage: `#lint`, `#lint linter_1 linter_2`, `#lint only linter_1 linter_2`.

--- a/test/lint.lean
+++ b/test/lint.lean
@@ -62,7 +62,7 @@ meta def linter.dummy_linter : linter :=
 def bar.foo : (if 3 = 3 then 1 else 2) = 1 := if_pos (by refl)
 
 run_cmd do
-  (_, s) ← lint tt tt [`linter.dummy_linter] tt,
+  (_, s) ← lint tt lint_verbosity.medium [`linter.dummy_linter] tt,
   guard $ "/- found something: -/\n#print foo.foo /- gotcha! -/\n".is_suffix_of s.to_string
 
 def incorrect_type_class_argument_test {α : Type} (x : α) [x = x] [decidable_eq α] [group α] :


### PR DESCRIPTION
* The behavior of `lint-` hasn't changed.
* `lint` will now suppress the output of successful checks. If everything succeeds, it will print "All linting checks passed!"
* `lint+` behaves like the old `lint`. It prints a confirmation for each test.

Zulip: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/quiet.20linter

---
<!-- put comments you want to keep out of the PR commit here -->
