### PR TITLE
[Merged by Bors] - feat(order/filter/extr, topology/local_extr): links between extremas of two eventually le/eq functions

### DIFF
--- a/src/order/filter/extr.lean
+++ b/src/order/filter/extr.lean
@@ -482,16 +482,13 @@ section eventually
 
 /-! ### Relation with `eventually` comparisons of two functions -/
 
-lemma filter.eventually_le.is_max_filter {α β : Type*} [preorder β] {f g : α → β} {a : α} {l : filter α}
-  (heq : g ≤ᶠ[l] f) (hfga : f a = g a) (h : is_max_filter f l a) :
+lemma filter.eventually_le.is_max_filter {α β : Type*} [preorder β] {f g : α → β} {a : α}
+  {l : filter α} (hle : g ≤ᶠ[l] f) (hfga : f a = g a) (h : is_max_filter f l a) :
   is_max_filter g l a :=
 begin
-  simp [is_max_filter, hfga, eventually_le, eventually_iff_exists_mem] at *,
-  rcases h with ⟨ s, hsl, hs ⟩,
-  rcases heq with ⟨ t, htl, ht ⟩,
-  use s ∩ t,
-  use inter_mem_sets hsl htl,
-  exact λ y ⟨ hys, hyt ⟩, le_trans (ht y hyt) (hs y hys)
+  refine hle.mp (h.mono $ λ x hf hgf, _),
+  rw ← hfga,
+  exact le_trans hgf hf
 end
 
 lemma is_max_filter.congr {α β : Type*} [preorder β] {f g : α → β} {a : α} {l : filter α}
@@ -499,32 +496,37 @@ lemma is_max_filter.congr {α β : Type*} [preorder β] {f g : α → β} {a : �
   is_max_filter g l a :=
 heq.symm.le.is_max_filter hfga h
 
-lemma filter.eventually_eq.is_max_filter_iff {α β : Type*} [preorder β] {f g : α → β} {a : α} {l : filter α} (heq : f =ᶠ[l] g) (hfga : f a = g a) :
+lemma filter.eventually_eq.is_max_filter_iff {α β : Type*} [preorder β] {f g : α → β} {a : α}
+  {l : filter α} (heq : f =ᶠ[l] g) (hfga : f a = g a) :
   is_max_filter f l a ↔ is_max_filter g l a :=
-⟨ λ h, h.congr heq hfga, λ h, h.congr heq.symm hfga.symm ⟩
+⟨λ h, h.congr heq hfga, λ h, h.congr heq.symm hfga.symm⟩
 
-lemma filter.eventually_le.is_min_filter {α β : Type*} [preorder β] {f g : α → β} {a : α} {l : filter α}
-  (heq : f ≤ᶠ[l] g) (hfga : f a = g a) (h : is_min_filter f l a) :
+lemma filter.eventually_le.is_min_filter {α β : Type*} [preorder β] {f g : α → β} {a : α}
+  {l : filter α} (hle : f ≤ᶠ[l] g) (hfga : f a = g a) (h : is_min_filter f l a) :
   is_min_filter g l a :=
-@filter.eventually_le.is_max_filter _ (order_dual β) _ _ _ _ _ heq hfga h
+@filter.eventually_le.is_max_filter _ (order_dual β) _ _ _ _ _ hle hfga h
 
-lemma is_min_filter.congr {α β : Type*} [preorder β] {f g : α → β} {a : α} {l : filter α} (h : is_min_filter f l a) (heq : f =ᶠ[l] g) (hfga : f a = g a) :
+lemma is_min_filter.congr {α β : Type*} [preorder β] {f g : α → β} {a : α} {l : filter α}
+  (h : is_min_filter f l a) (heq : f =ᶠ[l] g) (hfga : f a = g a) :
   is_min_filter g l a :=
 heq.le.is_min_filter hfga h
 
-lemma filter.eventually_eq.is_min_filter_iff {α β : Type*} [preorder β] {f g : α → β} {a : α} {l : filter α} (heq : f =ᶠ[l] g) (hfga : f a = g a) :
+lemma filter.eventually_eq.is_min_filter_iff {α β : Type*} [preorder β] {f g : α → β} {a : α}
+  {l : filter α} (heq : f =ᶠ[l] g) (hfga : f a = g a) :
   is_min_filter f l a ↔ is_min_filter g l a :=
-⟨ λ h, h.congr heq hfga, λ h, h.congr heq.symm hfga.symm ⟩
+⟨λ h, h.congr heq hfga, λ h, h.congr heq.symm hfga.symm⟩
 
-lemma is_extr_filter.congr {α β : Type*} [preorder β] {f g : α → β} {a : α} {l : filter α} (h : is_extr_filter f l a) (heq : f =ᶠ[l] g) (hfga : f a = g a) :
+lemma is_extr_filter.congr {α β : Type*} [preorder β] {f g : α → β} {a : α} {l : filter α}
+  (h : is_extr_filter f l a) (heq : f =ᶠ[l] g) (hfga : f a = g a) :
   is_extr_filter g l a :=
 begin
   rw is_extr_filter at *,
   rwa [← heq.is_max_filter_iff hfga, ← heq.is_min_filter_iff hfga],
 end
 
-lemma filter.eventually_eq.is_extr_filter_iff {α β : Type*} [preorder β] {f g : α → β} {a : α} {l : filter α} (heq : f =ᶠ[l] g) (hfga : f a = g a) :
+lemma filter.eventually_eq.is_extr_filter_iff {α β : Type*} [preorder β] {f g : α → β} {a : α}
+  {l : filter α} (heq : f =ᶠ[l] g) (hfga : f a = g a) :
   is_extr_filter f l a ↔ is_extr_filter g l a :=
-⟨ λ h, h.congr heq hfga, λ h, h.congr heq.symm hfga.symm ⟩
+⟨λ h, h.congr heq hfga, λ h, h.congr heq.symm hfga.symm⟩
 
 end eventually

--- a/src/order/filter/extr.lean
+++ b/src/order/filter/extr.lean
@@ -477,3 +477,54 @@ lemma is_max_on.max (hf : is_max_on f s a) (hg : is_max_on g s a) :
 hf.max hg
 
 end decidable_linear_order
+
+section eventually
+
+/-! ### Relation with `eventually` comparisons of two functions -/
+
+lemma filter.eventually_le.is_max_filter {α β : Type*} [preorder β] {f g : α → β} {a : α} {l : filter α}
+  (heq : g ≤ᶠ[l] f) (hfga : f a = g a) (h : is_max_filter f l a) :
+  is_max_filter g l a :=
+begin
+  simp [is_max_filter, hfga, eventually_le, eventually_iff_exists_mem] at *,
+  rcases h with ⟨ s, hsl, hs ⟩,
+  rcases heq with ⟨ t, htl, ht ⟩,
+  use s ∩ t,
+  use inter_mem_sets hsl htl,
+  exact λ y ⟨ hys, hyt ⟩, le_trans (ht y hyt) (hs y hys)
+end
+
+lemma is_max_filter.congr {α β : Type*} [preorder β] {f g : α → β} {a : α} {l : filter α}
+  (h : is_max_filter f l a) (heq : f =ᶠ[l] g) (hfga : f a = g a) :
+  is_max_filter g l a :=
+heq.symm.le.is_max_filter hfga h
+
+lemma filter.eventually_eq.is_max_filter_iff {α β : Type*} [preorder β] {f g : α → β} {a : α} {l : filter α} (heq : f =ᶠ[l] g) (hfga : f a = g a) :
+  is_max_filter f l a ↔ is_max_filter g l a :=
+⟨ λ h, h.congr heq hfga, λ h, h.congr heq.symm hfga.symm ⟩
+
+lemma filter.eventually_le.is_min_filter {α β : Type*} [preorder β] {f g : α → β} {a : α} {l : filter α}
+  (heq : f ≤ᶠ[l] g) (hfga : f a = g a) (h : is_min_filter f l a) :
+  is_min_filter g l a :=
+@filter.eventually_le.is_max_filter _ (order_dual β) _ _ _ _ _ heq hfga h
+
+lemma is_min_filter.congr {α β : Type*} [preorder β] {f g : α → β} {a : α} {l : filter α} (h : is_min_filter f l a) (heq : f =ᶠ[l] g) (hfga : f a = g a) :
+  is_min_filter g l a :=
+heq.le.is_min_filter hfga h
+
+lemma filter.eventually_eq.is_min_filter_iff {α β : Type*} [preorder β] {f g : α → β} {a : α} {l : filter α} (heq : f =ᶠ[l] g) (hfga : f a = g a) :
+  is_min_filter f l a ↔ is_min_filter g l a :=
+⟨ λ h, h.congr heq hfga, λ h, h.congr heq.symm hfga.symm ⟩
+
+lemma is_extr_filter.congr {α β : Type*} [preorder β] {f g : α → β} {a : α} {l : filter α} (h : is_extr_filter f l a) (heq : f =ᶠ[l] g) (hfga : f a = g a) :
+  is_extr_filter g l a :=
+begin
+  rw is_extr_filter at *,
+  rwa [← heq.is_max_filter_iff hfga, ← heq.is_min_filter_iff hfga],
+end
+
+lemma filter.eventually_eq.is_extr_filter_iff {α β : Type*} [preorder β] {f g : α → β} {a : α} {l : filter α} (heq : f =ᶠ[l] g) (hfga : f a = g a) :
+  is_extr_filter f l a ↔ is_extr_filter g l a :=
+⟨ λ h, h.congr heq hfga, λ h, h.congr heq.symm hfga.symm ⟩
+
+end eventually

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -241,6 +241,10 @@ lemma tendsto_nhds_within_of_tendsto_nhds_of_eventually_within {β : Type*} {a :
   tendsto f l (nhds_within a s) :=
 tendsto_inf.2 ⟨h1, tendsto_principal.2 h2⟩
 
+lemma filter.eventually_eq.eq_of_nhds_within {s : set α} {f g : α → β} {a : α}
+  (h : f =ᶠ[nhds_within a s] g) (hmem : a ∈ s) : f a = g a :=
+h.self_of_nhds_within hmem
+
 /-
 nhds_within and subtypes
 -/

--- a/src/topology/local_extr.lean
+++ b/src/topology/local_extr.lean
@@ -423,3 +423,75 @@ lemma is_local_max_on.max (hf : is_local_max_on f s a) (hg : is_local_max_on g s
 hf.max hg
 
 end decidable_linear_order
+
+section eventually
+
+/-! ### Relation with `eventually` comparisons of two functions -/
+
+variables [preorder β] {s : set α}
+
+lemma filter.eventually_le.is_local_max_on {f g : α → β} {a : α} (heq : g ≤ᶠ[nhds_within a s] f)
+  (hfga : f a = g a) (h : is_local_max_on f s a) : is_local_max_on g s a :=
+heq.is_max_filter hfga h
+
+lemma is_local_max_on.congr {f g : α → β} {a : α} (h : is_local_max_on f s a)
+  (heq : f =ᶠ[nhds_within a s] g) (hmem : a ∈ s) : is_local_max_on g s a :=
+h.congr heq $ heq.eq_of_nhds_within hmem
+
+lemma filter.eventually_eq.is_local_max_on_iff {f g : α → β} {a : α} (heq : f =ᶠ[nhds_within a s] g)
+  (hmem : a ∈ s) : is_local_max_on f s a ↔ is_local_max_on g s a :=
+heq.is_max_filter_iff $ heq.eq_of_nhds_within hmem
+
+lemma filter.eventually_le.is_local_min_on {f g : α → β} {a : α} (heq : f ≤ᶠ[nhds_within a s] g)
+  (hfga : f a = g a) (h : is_local_min_on f s a) : is_local_min_on g s a :=
+heq.is_min_filter hfga h
+
+lemma is_local_min_on.congr {f g : α → β} {a : α} (h : is_local_min_on f s a)
+  (heq : f =ᶠ[nhds_within a s] g) (hmem : a ∈ s) : is_local_min_on g s a :=
+h.congr heq $ heq.eq_of_nhds_within hmem
+
+lemma filter.eventually_eq.is_local_min_on_iff {f g : α → β} {a : α} (heq : f =ᶠ[nhds_within a s] g)
+  (hmem : a ∈ s) : is_local_min_on f s a ↔ is_local_min_on g s a :=
+heq.is_min_filter_iff $ heq.eq_of_nhds_within hmem
+
+lemma is_local_extr_on.congr {f g : α → β} {a : α} (h : is_local_extr_on f s a)
+  (heq : f =ᶠ[nhds_within a s] g) (hmem : a ∈ s) : is_local_extr_on g s a :=
+h.congr heq $ heq.eq_of_nhds_within hmem
+
+lemma filter.eventually_eq.is_local_extr_on_iff {f g : α → β} {a : α} (heq : f =ᶠ[nhds_within a s] g)
+  (hmem : a ∈ s) : is_local_extr_on f s a ↔ is_local_extr_on g s a :=
+heq.is_extr_filter_iff $ heq.eq_of_nhds_within hmem
+
+lemma filter.eventually_le.is_local_max {f g : α → β} {a : α} (heq : g ≤ᶠ[𝓝 a] f) (hfga : f a = g a)
+  (h : is_local_max f a) : is_local_max g a :=
+heq.is_max_filter hfga h
+
+lemma is_local_max.congr {f g : α → β} {a : α} (h : is_local_max f a) (heq : f =ᶠ[𝓝 a] g) :
+  is_local_max g a :=
+h.congr heq heq.eq_of_nhds
+
+lemma filter.eventually_eq.is_local_max_iff {f g : α → β} {a : α} (heq : f =ᶠ[𝓝 a] g) :
+  is_local_max f a ↔ is_local_max g a :=
+heq.is_max_filter_iff heq.eq_of_nhds
+
+lemma filter.eventually_le.is_local_min {f g : α → β} {a : α} (heq : f ≤ᶠ[𝓝 a] g) (hfga : f a = g a)
+  (h : is_local_min f a) : is_local_min g a :=
+heq.is_min_filter hfga h
+
+lemma is_local_min.congr {f g : α → β} {a : α} (h : is_local_min f a) (heq : f =ᶠ[𝓝 a] g) :
+  is_local_min g a :=
+h.congr heq heq.eq_of_nhds
+
+lemma filter.eventually_eq.is_local_min_iff {f g : α → β} {a : α} (heq : f =ᶠ[𝓝 a] g) :
+  is_local_min f a ↔ is_local_min g a :=
+heq.is_min_filter_iff heq.eq_of_nhds
+
+lemma is_local_extr.congr {f g : α → β} {a : α} (h : is_local_extr f a) (heq : f =ᶠ[𝓝 a] g) :
+  is_local_extr g a :=
+h.congr heq heq.eq_of_nhds
+
+lemma filter.eventually_eq.is_local_extr_iff {f g : α → β} {a : α} (heq : f =ᶠ[𝓝 a] g) :
+  is_local_extr f a ↔ is_local_extr g a :=
+heq.is_extr_filter_iff heq.eq_of_nhds
+
+end eventually

--- a/src/topology/local_extr.lean
+++ b/src/topology/local_extr.lean
@@ -430,9 +430,9 @@ section eventually
 
 variables [preorder β] {s : set α}
 
-lemma filter.eventually_le.is_local_max_on {f g : α → β} {a : α} (heq : g ≤ᶠ[nhds_within a s] f)
+lemma filter.eventually_le.is_local_max_on {f g : α → β} {a : α} (hle : g ≤ᶠ[nhds_within a s] f)
   (hfga : f a = g a) (h : is_local_max_on f s a) : is_local_max_on g s a :=
-heq.is_max_filter hfga h
+hle.is_max_filter hfga h
 
 lemma is_local_max_on.congr {f g : α → β} {a : α} (h : is_local_max_on f s a)
   (heq : f =ᶠ[nhds_within a s] g) (hmem : a ∈ s) : is_local_max_on g s a :=
@@ -442,9 +442,9 @@ lemma filter.eventually_eq.is_local_max_on_iff {f g : α → β} {a : α} (heq :
   (hmem : a ∈ s) : is_local_max_on f s a ↔ is_local_max_on g s a :=
 heq.is_max_filter_iff $ heq.eq_of_nhds_within hmem
 
-lemma filter.eventually_le.is_local_min_on {f g : α → β} {a : α} (heq : f ≤ᶠ[nhds_within a s] g)
+lemma filter.eventually_le.is_local_min_on {f g : α → β} {a : α} (hle : f ≤ᶠ[nhds_within a s] g)
   (hfga : f a = g a) (h : is_local_min_on f s a) : is_local_min_on g s a :=
-heq.is_min_filter hfga h
+hle.is_min_filter hfga h
 
 lemma is_local_min_on.congr {f g : α → β} {a : α} (h : is_local_min_on f s a)
   (heq : f =ᶠ[nhds_within a s] g) (hmem : a ∈ s) : is_local_min_on g s a :=
@@ -462,9 +462,9 @@ lemma filter.eventually_eq.is_local_extr_on_iff {f g : α → β} {a : α} (heq 
   (hmem : a ∈ s) : is_local_extr_on f s a ↔ is_local_extr_on g s a :=
 heq.is_extr_filter_iff $ heq.eq_of_nhds_within hmem
 
-lemma filter.eventually_le.is_local_max {f g : α → β} {a : α} (heq : g ≤ᶠ[𝓝 a] f) (hfga : f a = g a)
+lemma filter.eventually_le.is_local_max {f g : α → β} {a : α} (hle : g ≤ᶠ[𝓝 a] f) (hfga : f a = g a)
   (h : is_local_max f a) : is_local_max g a :=
-heq.is_max_filter hfga h
+hle.is_max_filter hfga h
 
 lemma is_local_max.congr {f g : α → β} {a : α} (h : is_local_max f a) (heq : f =ᶠ[𝓝 a] g) :
   is_local_max g a :=
@@ -474,9 +474,9 @@ lemma filter.eventually_eq.is_local_max_iff {f g : α → β} {a : α} (heq : f 
   is_local_max f a ↔ is_local_max g a :=
 heq.is_max_filter_iff heq.eq_of_nhds
 
-lemma filter.eventually_le.is_local_min {f g : α → β} {a : α} (heq : f ≤ᶠ[𝓝 a] g) (hfga : f a = g a)
+lemma filter.eventually_le.is_local_min {f g : α → β} {a : α} (hle : f ≤ᶠ[𝓝 a] g) (hfga : f a = g a)
   (h : is_local_min f a) : is_local_min g a :=
-heq.is_min_filter hfga h
+hle.is_min_filter hfga h
 
 lemma is_local_min.congr {f g : α → β} {a : α} (h : is_local_min f a) (heq : f =ᶠ[𝓝 a] g) :
   is_local_min g a :=


### PR DESCRIPTION
Add many lemmas that look similar to e.g : if f and g are equal at `a`, and `f ≤ᶠ[l] g` for some filter `l`, then `is_min_filter l f a`implies `is_min_filter l g a`
