### PR TITLE
[Merged by Bors] - fix(tactic/simps): do not reach unreachable code

### DIFF
--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -199,7 +199,8 @@ library_note "custom simps projection"
 meta def simps_get_projection_exprs (e : environment) (tgt : expr)
   (rhs : expr) : tactic $ list $ expr × name × expr := do
   let params := get_app_args tgt, -- the parameters of the structure
-  guard ((get_app_args rhs).take params.length = params) <|> fail "unreachable code (1)",
+  (params.zip $ (get_app_args rhs).take params.length).mmap' (λ ⟨a, b⟩, is_def_eq a b)
+    <|> fail "unreachable code (1)",
   let str := tgt.get_app_fn.const_name,
   projs ← e.structure_fields_full str,
   let rhs_args := (get_app_args rhs).drop params.length, -- the fields of the object

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -597,3 +597,15 @@ end nested_non_fully_applied
 
 /- fail if you add an attribute with a parameter. -/
 run_cmd success_if_fail $ simps_tac `foo.rfl { attrs := [`higher_order] }
+
+-- test that type classes which are props work
+class prop_class (n : ℕ) : Prop :=
+(has_true : true)
+
+instance has_prop_class (n : ℕ) : prop_class n := ⟨trivial⟩
+
+structure needs_prop_class (n : ℕ) [prop_class n] :=
+(t : true)
+
+@[simps] def test_prop_class : needs_prop_class 1 :=
+{ t := trivial }


### PR DESCRIPTION
Fixes #3636 

---
This weakens the guard by not requiring equality of expressions, but rather definitional equality for the parameters. Perhaps this is a little too heavy and/or permissive and there is a better way to do it?
<!-- put comments you want to keep out of the PR commit here -->
