### PR TITLE
[Merged by Bors] - feat(measure_theory/measure_space): add 3 typeclasses

### DIFF
--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -1159,8 +1159,7 @@ end
 lemma one_lt_rpow {x : ennreal} {z : ℝ} (hx : 1 < x) (hz : 0 < z) : 1 < x^z :=
 begin
   cases x,
-  { simp [top_rpow_of_pos hz],
-    exact coe_lt_top },
+  { simp [top_rpow_of_pos hz] },
   { simp at hx,
     simp [coe_rpow_of_nonneg _ (le_of_lt hz), nnreal.one_lt_rpow hx hz] }
 end

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -237,6 +237,7 @@ lemma zero_lt_coe_iff : 0 < (↑p : ennreal) ↔ 0 < p := coe_lt_coe
 @[simp, norm_cast] lemma coe_nat (n : nat) : ((n : nnreal) : ennreal) = n := with_top.coe_nat n
 @[simp] lemma nat_ne_top (n : nat) : (n : ennreal) ≠ ⊤ := with_top.nat_ne_top n
 @[simp] lemma top_ne_nat (n : nat) : (⊤ : ennreal) ≠ n := with_top.top_ne_nat n
+@[simp] lemma one_lt_top : 1 < ∞ := coe_lt_top
 
 lemma le_coe_iff : a ≤ ↑r ↔ (∃p:nnreal, a = p ∧ p ≤ r) := with_top.le_coe_iff r a
 lemma coe_le_iff : ↑r ≤ a ↔ (∀p:nnreal, a = p → r ≤ p) := with_top.coe_le_iff r a

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -640,9 +640,10 @@ begin
 end
 
 /-- If two simple functions are equal a.e., then their `lintegral`s are equal. -/
-lemma lintegral_congr {f g : α →ₛ ennreal} (h : ∀ᵐ a ∂ μ, f a = g a) :
+lemma lintegral_congr {f g : α →ₛ ennreal} (h : f =ᵐ[μ] g) :
   f.lintegral μ = g.lintegral μ :=
-lintegral_eq_of_measure_preimage $ λ y, measure_congr $ h.mono $ λ x hx, by simp [hx]
+lintegral_eq_of_measure_preimage $ λ y, measure_congr $
+  eventually.set_eq $ h.mono $ λ x hx, by simp [hx]
 
 lemma lintegral_map {β} [measurable_space β] {μ' : measure β} (f : α →ₛ ennreal) (g : β →ₛ ennreal)
   (m : α → β) (eq : ∀a:α, f a = g (m a)) (h : ∀s:set β, is_measurable s → μ' s = μ (m ⁻¹' s)) :

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -24,6 +24,12 @@ extension of the restricted measure.
 
 Measures on `α` form a complete lattice, and are closed under scalar multiplication with `ennreal`.
 
+We introduce the following typeclasses for measures:
+
+* `probability_measure μ`: `μ univ = 1`;
+* `finite_measure μ`: `μ univ < ⊤`;
+* `locally_finite_measure μ` : `∀ x, ∃ s ∈ 𝓝 x, μ s < ⊤`.
+
 Given a measure, the null sets are the sets where `μ s = 0`, where `μ` denotes the corresponding
 outer measure (so `s` might not be measurable). We can then define the completion of `μ` as the
 measure on the least `σ`-algebra that also contains all null sets, by defining the measure to be `0`
@@ -779,6 +785,9 @@ le_trans
   sum f s = ∑' i, f i s :=
 to_measure_apply _ _ hs
 
+lemma le_sum {ι : Type*} (μ : ι → measure α) (i : ι) : μ i ≤ sum μ :=
+λ s hs, by simp only [sum_apply μ hs, ennreal.le_tsum i]
+
 lemma restrict_Union {ι} [encodable ι] {s : ι → set α} (hd : pairwise (disjoint on s))
   (hm : ∀ i, is_measurable (s i)) :
   μ.restrict (⋃ i, s i) = sum (λ i, μ.restrict (s i)) :=
@@ -849,7 +858,7 @@ calc count s < ⊤ ↔ count s ≠ ⊤ : lt_top_iff_ne_top
 @[class] def is_complete {α} {_:measurable_space α} (μ : measure α) : Prop :=
 ∀ s, μ s = 0 → is_measurable s
 
-/-- The "almost everywhere" filter of co-null sets. -/
+/-- The “almost everywhere” filter of co-null sets. -/
 def ae (μ : measure α) : filter α :=
 { sets := {s | μ sᶜ = 0},
   univ_sets := by simp,
@@ -896,6 +905,9 @@ by rw [← empty_in_sets_eq_bot, mem_ae_iff, compl_empty, measure.measure_univ_e
 lemma ae_of_all {p : α → Prop} (μ : measure α) : (∀a, p a) → ∀ᵐ a ∂ μ, p a :=
 eventually_of_forall
 
+@[mono] lemma ae_mono {μ ν : measure α} (h : μ ≤ ν) : μ.ae ≤ ν.ae :=
+λ s hs, bot_unique $ trans_rel_left (≤) (measure.le_iff'.1 h _) hs
+
 instance : countable_Inter_filter μ.ae :=
 ⟨begin
   intros S hSc hS,
@@ -934,6 +946,14 @@ lemma ae_map_iff [measurable_space β] {f : α → β} (hf : measurable f)
   {p : β → Prop} (hp : is_measurable {x | p x}) :
   (∀ᵐ y ∂ (measure.map f μ), p y) ↔ ∀ᵐ x ∂ μ, p (f x) :=
 mem_ae_map_iff hf hp
+
+lemma ae_restrict_iff {s : set α} {p : α → Prop} (hp : is_measurable {x | p x}) :
+  (∀ᵐ x ∂(μ.restrict s), p x) ↔ ∀ᵐ x ∂μ, x ∈ s → p x :=
+begin
+  simp only [ae_iff, ← compl_set_of, measure.restrict_apply hp.compl],
+  congr',
+  ext x, simp [and_comm]
+end
 
 @[simp] lemma ae_restrict_eq {s : set α} (hs : is_measurable s):
   (μ.restrict s).ae = μ.ae ⊓ 𝓟 s :=
@@ -980,22 +1000,123 @@ lemma eventually_eq_dirac' [measurable_singleton_class α] {a : α} (f : α → 
   f =ᵐ[measure.dirac a] const α (f a) :=
 by { rw [dirac_ae_eq], show f a = f a, refl }
 
-lemma measure_diff_of_ae_imp {s t : set α} (H : ∀ᵐ x ∂μ, x ∈ s → x ∈ t) :
+lemma measure_diff_of_ae_le {s t : set α} (H : s ≤ᵐ[μ] t) :
   μ (s \ t) = 0 :=
 flip measure_mono_null H $ λ x hx H, hx.2 (H hx.1)
 
 /-- If `s ⊆ t` modulo a set of measure `0`, then `μ s ≤ μ t`. -/
-lemma measure_le_of_ae_imp {s t : set α} (H : ∀ᵐ x ∂μ, x ∈ s → x ∈ t) :
+lemma measure_mono_ae {s t : set α} (H : s ≤ᵐ[μ] t) :
   μ s ≤ μ t :=
 calc μ s ≤ μ (s ∪ t)       : measure_mono $ subset_union_left s t
      ... = μ (t ∪ s \ t)   : by rw [union_diff_self, set.union_comm]
      ... ≤ μ t + μ (s \ t) : measure_union_le _ _
-     ... = μ t             : by rw [measure_diff_of_ae_imp H, add_zero]
+     ... = μ t             : by rw [measure_diff_of_ae_le H, add_zero]
+
+alias measure_mono_ae ← filter.eventually_le.measure_le
 
 /-- If two sets are equal modulo a set of measure zero, then `μ s = μ t`. -/
-lemma measure_congr {s t : set α} (H : ∀ᵐ x ∂μ, x ∈ s ↔ x ∈ t) : μ s = μ t :=
-le_antisymm (measure_le_of_ae_imp $ H.mono $ λ x, iff.mp)
-  (measure_le_of_ae_imp $ H.mono $ λ x, iff.mpr)
+lemma measure_congr {s t : set α} (H : s =ᵐ[μ] t) : μ s = μ t :=
+le_antisymm H.le.measure_le H.symm.le.measure_le
+
+lemma restrict_mono_ae {s t : set α} (h : s ≤ᵐ[μ] t) : μ.restrict s ≤ μ.restrict t :=
+begin
+  intros u hu,
+  simp only [measure.restrict_apply hu],
+  exact measure_mono_ae (h.mono $ λ x hx, and.imp id hx)
+end
+
+lemma restrict_congr {s t : set α} (H : s =ᵐ[μ] t) : μ.restrict s = μ.restrict t :=
+le_antisymm (restrict_mono_ae H.le) (restrict_mono_ae H.symm.le)
+
+/-- A measure `μ` is called a probability measure if `μ univ = 1`. -/
+class probability_measure (μ : measure α) : Prop := (meas_univ : μ univ = 1)
+
+/-- A measure `μ` is called finite if `μ univ < ⊤`. -/
+class finite_measure (μ : measure α) : Prop := (meas_univ_lt_top : μ univ < ⊤)
+
+export finite_measure (meas_univ_lt_top) probability_measure (meas_univ)
+
+@[priority 100]
+instance probability_measure.to_finite_measure (μ : measure α) [probability_measure μ] :
+  finite_measure μ :=
+⟨by simp only [meas_univ, ennreal.one_lt_top]⟩
+
+/-- A measure is called finite at filter `f` if it is finite at some set `s ∈ f`.
+Equivalently, it is eventually finite at `s` in `f.lift' powerset`. -/
+def measure.finite_at_filter (μ : measure α) (f : filter α) : Prop := ∃ s ∈ f, μ s < ⊤
+
+lemma finite_at_filter_of_finite (μ : measure α) [finite_measure μ] (f : filter α) :
+  μ.finite_at_filter f :=
+⟨univ, univ_mem_sets, meas_univ_lt_top⟩
+
+/-- A measure is called locally finite if it is finite in some neighborhood of each point. -/
+class locally_finite_measure [topological_space α] (μ : measure α) : Prop :=
+(finite_at_nhds : ∀ x, μ.finite_at_filter (𝓝 x))
+
+@[priority 100]
+instance finite_measure.to_locally_finite_measure [topological_space α] (μ : measure α)
+  [finite_measure μ] :
+  locally_finite_measure μ :=
+⟨λ x, finite_at_filter_of_finite _ _⟩
+
+lemma measure.finite_at_nhds [topological_space α] (μ : measure α)
+  [locally_finite_measure μ] (x : α) :
+  μ.finite_at_filter (𝓝 x) :=
+locally_finite_measure.finite_at_nhds x
+
+namespace measure
+
+namespace finite_at_filter
+
+variables {ν : measure α} {f g : filter α}
+
+lemma filter_mono (h : f ≤ g) : μ.finite_at_filter g → μ.finite_at_filter f :=
+λ ⟨s, hs, hμ⟩, ⟨s, h hs, hμ⟩
+
+lemma inf_of_left (h : μ.finite_at_filter f) : μ.finite_at_filter (f ⊓ g) :=
+h.filter_mono inf_le_left
+
+lemma inf_of_right (h : μ.finite_at_filter g) : μ.finite_at_filter (f ⊓ g) :=
+h.filter_mono inf_le_right
+
+@[simp] lemma inf_ae_iff : μ.finite_at_filter (f ⊓ μ.ae) ↔ μ.finite_at_filter f :=
+begin
+  refine ⟨_, λ h, h.filter_mono inf_le_left⟩,
+  rintros ⟨s, ⟨t, ht, u, hu, hs⟩, hμ⟩,
+  suffices : μ t ≤ μ s, from ⟨t, ht, this.trans_lt hμ⟩,
+  exact measure_mono_ae (mem_sets_of_superset hu (λ x hu ht, hs ⟨ht, hu⟩))
+end
+
+alias inf_ae_iff ↔ measure_theory.measure.finite_at_filter.of_inf_ae _
+
+lemma filter_mono_ae (h : f ⊓ μ.ae ≤ g) (hg : μ.finite_at_filter g) : μ.finite_at_filter f :=
+inf_ae_iff.1 (hg.filter_mono h)
+
+protected lemma measure_mono (h : μ ≤ ν) : ν.finite_at_filter f → μ.finite_at_filter f :=
+λ ⟨s, hs, hν⟩, ⟨s, hs, (measure.le_iff'.1 h s).trans_lt hν⟩
+
+@[mono] protected lemma mono (hf : f ≤ g) (hμ : μ ≤ ν) :
+  ν.finite_at_filter g → μ.finite_at_filter f :=
+λ h, (h.filter_mono hf).measure_mono hμ
+
+protected lemma eventually (h : μ.finite_at_filter f) : ∀ᶠ s in f.lift' powerset, μ s < ⊤ :=
+(eventually_lift'_powerset' $ λ s t hst ht, (measure_mono hst).trans_lt ht).2 h
+
+lemma filter_sup : μ.finite_at_filter f → μ.finite_at_filter g → μ.finite_at_filter (f ⊔ g) :=
+λ ⟨s, hsf, hsμ⟩ ⟨t, htg, htμ⟩,
+ ⟨s ∪ t, union_mem_sup hsf htg, (measure_union_le s t).trans_lt (ennreal.add_lt_top.2 ⟨hsμ, htμ⟩)⟩
+
+end finite_at_filter
+
+lemma finite_at_nhds_within [topological_space α] (μ : measure α) [locally_finite_measure μ]
+  (x : α) (s : set α) :
+  μ.finite_at_filter (nhds_within x s) :=
+(finite_at_nhds μ x).inf_of_left
+
+@[simp] lemma finite_at_principal {s : set α} : μ.finite_at_filter (𝓟 s) ↔ μ s < ⊤ :=
+⟨λ ⟨t, ht, hμ⟩, (measure_mono ht).trans_lt hμ, λ h, ⟨s, mem_principal_self s, h⟩⟩
+
+end measure
 
 end measure_theory
 
@@ -1177,18 +1298,29 @@ end measure_space
 
 end measure_theory
 
-namespace is_compact
-
 open measure_theory
+
+namespace is_compact
 
 variables {α : Type*} [topological_space α] [measurable_space α] {μ : measure α} {s : set α}
 
 lemma finite_measure_of_nhds_within (hs : is_compact s) :
-  (∀ a ∈ s, ∃ t ∈ nhds_within a s, μ t < ⊤) → μ s < ⊤ :=
-by simpa only [← measure.compl_mem_cofinite] using hs.compl_mem_sets_of_nhds_within
+  (∀ a ∈ s, μ.finite_at_filter (nhds_within a s)) → μ s < ⊤ :=
+by simpa only [← measure.compl_mem_cofinite, measure.finite_at_filter]
+  using hs.compl_mem_sets_of_nhds_within
+
+lemma finite_measure [locally_finite_measure μ] (hs : is_compact s) : μ s < ⊤ :=
+hs.finite_measure_of_nhds_within $ λ a ha, μ.finite_at_nhds_within _ _
 
 lemma measure_zero_of_nhds_within (hs : is_compact s) :
   (∀ a ∈ s, ∃ t ∈ nhds_within a s, μ t = 0) → μ s = 0 :=
 by simpa only [← compl_mem_ae_iff] using hs.compl_mem_sets_of_nhds_within
 
 end is_compact
+
+lemma metric.bounded.finite_measure {α : Type*} [metric_space α] [proper_space α]
+  [measurable_space α] {μ : measure α} [locally_finite_measure μ] {s : set α}
+  (hs : metric.bounded s) :
+  μ s < ⊤ :=
+(measure_mono subset_closure).trans_lt (metric.compact_iff_closed_bounded.2
+  ⟨is_closed_closure, metric.bounded_closure_of_bounded hs⟩).finite_measure

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -1140,13 +1140,11 @@ lemma eventually_eq.rw {l : filter α} {f g : α → β} (h : f =ᶠ[l] g) (p : 
   ∀ᶠ x in l, p x (g x) :=
 hf.congr $ h.mono $ λ x hx, hx ▸ iff.rfl
 
-lemma eventually_set_ext {s t : set α} {l : filter α} :
+lemma eventually_eq_set {s t : set α} {l : filter α} :
    s =ᶠ[l] t ↔ ∀ᶠ x in l, x ∈ s ↔ x ∈ t :=
 eventually_congr $ eventually_of_forall $ λ x, ⟨eq.to_iff, iff.to_eq⟩
 
-lemma eventually_eq.mem_iff {s t : set α} {l : filter α} (h : s =ᶠ[l] t) :
-  ∀ᶠ x in l, x ∈ s ↔ x ∈ t :=
-eventually_set_ext.1 h
+alias eventually_eq_set ↔ filter.eventually_eq.mem_iff filter.eventually.set_eq
 
 lemma eventually_eq.exists_mem {l : filter α} {f g : α → β} (h : f =ᶠ[l] g) :
   ∃ s ∈ l, eq_on f g s :=
@@ -1159,6 +1157,10 @@ eventually_of_mem hs h
 lemma eventually_eq_iff_exists_mem {l : filter α} {f g : α → β} :
   (f =ᶠ[l] g) ↔ ∃ s ∈ l, eq_on f g s :=
 eventually_iff_exists_mem
+
+lemma eventually_eq.filter_mono {l l' : filter α} {f g : α → β} (h₁ : f =ᶠ[l] g) (h₂ : l' ≤ l) :
+  f =ᶠ[l'] g :=
+h₂ h₁
 
 @[refl] lemma eventually_eq.refl (l : filter α) (f : α → β) :
   f =ᶠ[l] f :=


### PR DESCRIPTION
Define `probability_measure`, `finite_measure`, and `locally_finite_measure`.

---
<!-- put comments you want to keep out of the PR commit here -->
Another chunk from #3640