### PR TITLE
[Merged by Bors] - feat(algebra/ring): the codomain of a ring hom is trivial iff ...

### DIFF
--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -257,6 +257,15 @@ theorem coe_monoid_hom_injective : function.injective (coe : (α →+* β) → (
 /-- Ring homomorphisms preserve multiplication. -/
 @[simp] lemma map_mul (f : α →+* β) (a b : α) : f (a * b) = f a * f b := f.map_mul' a b
 
+/-- `f : R →+* S` has a trivial codomain iff `f 1 = 0`. -/
+lemma codomain_trivial_iff_map_one_eq_zero : (0 : β) = 1 ↔ f 1 = 0 :=
+by rw [map_one, eq_comm]
+
+/-- `f : R →+* S` has a trivial codomain iff it has a trivial image. -/
+lemma codomain_trivial_iff_image_trivial : (0 : β) = 1 ↔ (∀ x, f x = 0) :=
+f.codomain_trivial_iff_map_one_eq_zero.trans
+  ⟨λ h x, by rw [←mul_one x, map_mul, h, mul_zero], λ h, h 1⟩
+
 end
 
 /-- The identity ring homomorphism from a semiring to itself. -/

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -274,12 +274,12 @@ f.codomain_trivial_iff_range_trivial.trans
     λ h x, set.mem_singleton_iff.mp (h ▸ set.mem_range_self x)⟩
 
 /-- `f : R →+* S` doesn't map `1` to `0` if `S` is nontrivial -/
-lemma map_one_ne_zero_of_nontrivial [nontrivial β] : f 1 ≠ 0 :=
+lemma map_one_ne_zero [nontrivial β] : f 1 ≠ 0 :=
 mt f.codomain_trivial_iff_map_one_eq_zero.mpr zero_ne_one
 
 /-- If there is a homomorphism `f : R →+* S` and `S` is nontrivial, then `R` is nontrivial. -/
 lemma domain_nontrivial [nontrivial β] : nontrivial α :=
-⟨⟨1, 0, mt (λ h, show f 1 = 0, by rw [h, map_zero]) f.map_one_ne_zero_of_nontrivial⟩⟩
+⟨⟨1, 0, mt (λ h, show f 1 = 0, by rw [h, map_zero]) f.map_one_ne_zero⟩⟩
 
 end
 

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -266,6 +266,14 @@ lemma codomain_trivial_iff_image_trivial : (0 : β) = 1 ↔ (∀ x, f x = 0) :=
 f.codomain_trivial_iff_map_one_eq_zero.trans
   ⟨λ h x, by rw [←mul_one x, map_mul, h, mul_zero], λ h, h 1⟩
 
+/-- `f : R →+* S` doesn't map `1` to `0` if `S` is nontrivial -/
+lemma map_one_ne_zero_of_nontrivial [nontrivial β] : f 1 ≠ 0 :=
+mt f.codomain_trivial_iff_map_one_eq_zero.mpr zero_ne_one
+
+/-- `f : R →+* S` doesn't map `1` to `0` if `S` is nontrivial -/
+lemma codomain_nontrivial [nontrivial β] : nontrivial α :=
+⟨⟨1, 0, mt (λ h, show f 1 = 0, by rw [h, map_zero]) f.map_one_ne_zero_of_nontrivial⟩⟩
+
 end
 
 /-- The identity ring homomorphism from a semiring to itself. -/

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -5,6 +5,7 @@ Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Amelia Livingston, 
 Neil Strickland
 -/
 import algebra.group_with_zero
+import data.set.basic
 
 /-!
 # Properties and homomorphisms of semirings and rings
@@ -261,17 +262,23 @@ theorem coe_monoid_hom_injective : function.injective (coe : (α →+* β) → (
 lemma codomain_trivial_iff_map_one_eq_zero : (0 : β) = 1 ↔ f 1 = 0 :=
 by rw [map_one, eq_comm]
 
-/-- `f : R →+* S` has a trivial codomain iff it has a trivial image. -/
-lemma codomain_trivial_iff_image_trivial : (0 : β) = 1 ↔ (∀ x, f x = 0) :=
+/-- `f : R →+* S` has a trivial codomain iff it has a trivial range. -/
+lemma codomain_trivial_iff_range_trivial : (0 : β) = 1 ↔ (∀ x, f x = 0) :=
 f.codomain_trivial_iff_map_one_eq_zero.trans
   ⟨λ h x, by rw [←mul_one x, map_mul, h, mul_zero], λ h, h 1⟩
+
+/-- `f : R →+* S` has a trivial codomain iff its range is `{0}`. -/
+lemma codomain_trivial_iff_range_eq_singleton_zero : (0 : β) = 1 ↔ set.range f = {0} :=
+f.codomain_trivial_iff_range_trivial.trans
+  ⟨ λ h, set.ext (λ y, ⟨λ ⟨x, hx⟩, by simp [←hx, h x], λ hy, ⟨0, by simpa using hy.symm⟩⟩),
+    λ h x, set.mem_singleton_iff.mp (h ▸ set.mem_range_self x)⟩
 
 /-- `f : R →+* S` doesn't map `1` to `0` if `S` is nontrivial -/
 lemma map_one_ne_zero_of_nontrivial [nontrivial β] : f 1 ≠ 0 :=
 mt f.codomain_trivial_iff_map_one_eq_zero.mpr zero_ne_one
 
-/-- `f : R →+* S` doesn't map `1` to `0` if `S` is nontrivial -/
-lemma codomain_nontrivial [nontrivial β] : nontrivial α :=
+/-- If there is a homomorphism `f : R →+* S` and `S` is nontrivial, then `R` is nontrivial. -/
+lemma domain_nontrivial [nontrivial β] : nontrivial α :=
 ⟨⟨1, 0, mt (λ h, show f 1 = 0, by rw [h, map_zero]) f.map_one_ne_zero_of_nontrivial⟩⟩
 
 end

--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -311,7 +311,7 @@ lemma map_monic_eq_zero_iff (hp : p.monic) : p.map f = 0 ↔ ∀ x, f x = 0 :=
   λ h, ext (λ n, trans (coeff_map f n) (h _)) ⟩
 
 lemma map_monic_ne_zero_of_nontrivial (hp : p.monic) [nontrivial S] : p.map f ≠ 0 :=
-mt f.map_one_ne_zero_of_nontrivial zero_ne_one
+λ h, f.map_one_ne_zero_of_nontrivial ((map_monic_eq_zero_iff hp).mp h _)
 
 variables (f)
 

--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -310,6 +310,9 @@ lemma map_monic_eq_zero_iff (hp : p.monic) : p.map f = 0 ↔ ∀ x, f x = 0 :=
                 ... = 0 : by simp [hfp],
   λ h, ext (λ n, trans (coeff_map f n) (h _)) ⟩
 
+lemma map_monic_ne_zero_of_nontrivial (hp : p.monic) [nontrivial S] : p.map f ≠ 0 :=
+mt (f.codomain_trivial_iff_image_trivial.mpr ∘ (map_monic_eq_zero_iff hp).mp) zero_ne_one
+
 variables (f)
 
 open is_semiring_hom

--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -311,7 +311,7 @@ lemma map_monic_eq_zero_iff (hp : p.monic) : p.map f = 0 ↔ ∀ x, f x = 0 :=
   λ h, ext (λ n, trans (coeff_map f n) (h _)) ⟩
 
 lemma map_monic_ne_zero_of_nontrivial (hp : p.monic) [nontrivial S] : p.map f ≠ 0 :=
-mt (f.codomain_trivial_iff_image_trivial.mpr ∘ (map_monic_eq_zero_iff hp).mp) zero_ne_one
+mt f.map_one_ne_zero_of_nontrivial zero_ne_one
 
 variables (f)
 

--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -310,8 +310,8 @@ lemma map_monic_eq_zero_iff (hp : p.monic) : p.map f = 0 ↔ ∀ x, f x = 0 :=
                 ... = 0 : by simp [hfp],
   λ h, ext (λ n, trans (coeff_map f n) (h _)) ⟩
 
-lemma map_monic_ne_zero_of_nontrivial (hp : p.monic) [nontrivial S] : p.map f ≠ 0 :=
-λ h, f.map_one_ne_zero_of_nontrivial ((map_monic_eq_zero_iff hp).mp h _)
+lemma map_monic_ne_zero (hp : p.monic) [nontrivial S] : p.map f ≠ 0 :=
+λ h, f.map_one_ne_zero ((map_monic_eq_zero_iff hp).mp h _)
 
 variables (f)
 

--- a/src/ring_theory/ideal_over.lean
+++ b/src/ring_theory/ideal_over.lean
@@ -129,7 +129,7 @@ begin
   obtain ⟨p, p_monic, hpx⟩ := integral,
   refine comap_lt_comap_of_root_mem_sdiff hIJ mem _ _,
   swap,
-  { apply map_monic_ne_zero_of_nontrivial p_monic,
+  { apply map_monic_ne_zero p_monic,
     apply quotient.nontrivial,
     apply mt comap_eq_top_iff.mp,
     apply hI.1 },

--- a/src/ring_theory/ideal_over.lean
+++ b/src/ring_theory/ideal_over.lean
@@ -122,7 +122,7 @@ comap_ne_bot_of_algebraic_mem x_ne_zero x_mem (hx.is_algebraic R)
 lemma mem_of_one_mem (h : (1 : S) ∈ I) (x) : x ∈ I :=
 (I.eq_top_iff_one.mpr h).symm ▸ mem_top
 
-lemma comap_lt_comap_of_integral_mem_sdiff [I.is_prime] (hIJ : I ≤ J)
+lemma comap_lt_comap_of_integral_mem_sdiff [hI : I.is_prime] (hIJ : I ≤ J)
   {x : S} (mem : x ∈ (J : set S) \ I) (integral : is_integral R x) :
   I.comap (algebra_map R S) < J.comap (algebra_map _ _) :=
 begin
@@ -131,7 +131,8 @@ begin
   swap,
   { apply map_monic_ne_zero_of_nontrivial p_monic,
     apply quotient.nontrivial,
-    rw [ne.def, comap_eq_top_iff], },
+    apply mt comap_eq_top_iff.mp,
+    apply hI.1 },
   convert I.zero_mem
 end
 

--- a/src/ring_theory/ideal_over.lean
+++ b/src/ring_theory/ideal_over.lean
@@ -129,10 +129,9 @@ begin
   obtain ⟨p, p_monic, hpx⟩ := integral,
   refine comap_lt_comap_of_root_mem_sdiff hIJ mem _ _,
   swap,
-  { intro h,
-    refine mem.2 (mem_of_one_mem _ _),
-    rw [←(algebra_map R S).map_one, ←mem_comap, ←quotient.eq_zero_iff_mem],
-    apply (map_monic_eq_zero_iff p_monic).mp h 1 },
+  { apply map_monic_ne_zero_of_nontrivial p_monic,
+    apply quotient.nontrivial,
+    rw [ne.def, comap_eq_top_iff], },
   convert I.zero_mem
 end
 


### PR DESCRIPTION
In the discussion of #3488, Johan (currently on vacation, so I'm not pinging him) noted that we were missing the lemma "if `f` is a ring homomorphism, `∀ x, f x = 0` implies that the codomain is trivial". This PR adds a couple of ways to derive from homomorphisms that rings are trivial.

I used `0 = 1` to express that the ring is trivial because that seems to be the one that is used in practice.

---
<!-- put comments you want to keep out of the PR commit here -->
