### PR TITLE
[Merged by Bors] - feat(analysis/calculus): Rolle's and Cauchy's mean value theorems with weaker assumptions (deps : 3590)

### DIFF
--- a/src/analysis/calculus/local_extr.lean
+++ b/src/analysis/calculus/local_extr.lean
@@ -315,4 +315,36 @@ lemma exists_deriv_eq_zero : ∃ c ∈ Ioo a b, deriv f c = 0 :=
 let ⟨c, cmem, hc⟩ := exists_local_extr_Ioo f hab hfc hfI in
   ⟨c, cmem, hc.deriv_eq_zero⟩
 
+omit hfc hfI
+
+lemma exists_has_deriv_at_eq_zero' {l : ℝ}
+  (hfa : tendsto f (nhds_within a $ Ioi a) (nhds l)) (hfb : tendsto f (nhds_within b $ Iio b) (nhds l))
+  (hff' : ∀ x ∈ Ioo a b, has_deriv_at f (f' x) x) :
+  ∃ c ∈ Ioo a b, f' c = 0 :=
+begin
+  have : continuous_on f (Ioo a b) := λ x hx, (hff' x hx).continuous_at.continuous_within_at,
+  have hcont := continuous_on_Icc_extend_from_Ioo hab this hfa hfb,
+  obtain ⟨c, hc, hcextr⟩ : ∃ c ∈ Ioo a b,
+    is_local_extr (extend_from (Ioo a b) f) c,
+      from exists_local_extr_Ioo _ hab hcont
+      (by { rw eq_lim_at_right_extend_from_Ioo hab hfb,
+            exact eq_lim_at_left_extend_from_Ioo hab hfa }),
+  use [c, hc],
+  apply (hcextr.congr _).has_deriv_at_eq_zero (hff' c hc),
+  apply eventually_eq_iff_exists_mem.mpr,
+  use [Ioo a b, Ioo_mem_nhds hc.1 hc.2],
+  exact extend_from_extends this,
+end
+
+lemma exists_deriv_eq_zero' {l : ℝ}
+  (hfa : tendsto f (nhds_within a $ Ioi a) (nhds l)) (hfb : tendsto f (nhds_within b $ Iio b) (nhds l)) :
+  ∃ c ∈ Ioo a b, deriv f c = 0 :=
+classical.by_cases
+  (assume h : ∀ x ∈ Ioo a b, differentiable_at ℝ f x,
+    show ∃ c ∈ Ioo a b, deriv f c = 0,
+      from exists_has_deriv_at_eq_zero' _ _ hab hfa hfb (λ x hx, (h x hx).has_deriv_at))
+  (assume h : ¬∀ x ∈ Ioo a b, differentiable_at ℝ f x,
+    have h : ∃ x, x ∈ Ioo a b ∧ ¬differentiable_at ℝ f x, by { push_neg at h, exact h },
+      let ⟨c, hc, hcdiff⟩ := h in ⟨c, hc, deriv_zero_of_not_differentiable_at hcdiff ⟩)
+
 end Rolle

--- a/src/analysis/calculus/local_extr.lean
+++ b/src/analysis/calculus/local_extr.lean
@@ -317,34 +317,34 @@ let ⟨c, cmem, hc⟩ := exists_local_extr_Ioo f hab hfc hfI in
 
 omit hfc hfI
 
+variables {f f'}
+
 lemma exists_has_deriv_at_eq_zero' {l : ℝ}
-  (hfa : tendsto f (nhds_within a $ Ioi a) (nhds l)) (hfb : tendsto f (nhds_within b $ Iio b) (nhds l))
+  (hfa : tendsto f (𝓝[Ioi a] a) (𝓝 l)) (hfb : tendsto f (𝓝[Iio b] b) (𝓝 l))
   (hff' : ∀ x ∈ Ioo a b, has_deriv_at f (f' x) x) :
   ∃ c ∈ Ioo a b, f' c = 0 :=
 begin
   have : continuous_on f (Ioo a b) := λ x hx, (hff' x hx).continuous_at.continuous_within_at,
   have hcont := continuous_on_Icc_extend_from_Ioo hab this hfa hfb,
-  obtain ⟨c, hc, hcextr⟩ : ∃ c ∈ Ioo a b,
-    is_local_extr (extend_from (Ioo a b) f) c,
-      from exists_local_extr_Ioo _ hab hcont
-      (by { rw eq_lim_at_right_extend_from_Ioo hab hfb,
-            exact eq_lim_at_left_extend_from_Ioo hab hfa }),
+  obtain ⟨c, hc, hcextr⟩ : ∃ c ∈ Ioo a b, is_local_extr (extend_from (Ioo a b) f) c,
+  { apply exists_local_extr_Ioo _ hab hcont,
+    rw eq_lim_at_right_extend_from_Ioo hab hfb,
+    exact eq_lim_at_left_extend_from_Ioo hab hfa },
   use [c, hc],
   apply (hcextr.congr _).has_deriv_at_eq_zero (hff' c hc),
-  apply eventually_eq_iff_exists_mem.mpr,
-  use [Ioo a b, Ioo_mem_nhds hc.1 hc.2],
-  exact extend_from_extends this,
+  rw eventually_eq_iff_exists_mem,
+  exact ⟨Ioo a b, Ioo_mem_nhds hc.1 hc.2, extend_from_extends this⟩
 end
 
 lemma exists_deriv_eq_zero' {l : ℝ}
-  (hfa : tendsto f (nhds_within a $ Ioi a) (nhds l)) (hfb : tendsto f (nhds_within b $ Iio b) (nhds l)) :
+  (hfa : tendsto f (𝓝[Ioi a] a) (𝓝 l)) (hfb : tendsto f (𝓝[Iio b] b) (𝓝 l)) :
   ∃ c ∈ Ioo a b, deriv f c = 0 :=
 classical.by_cases
   (assume h : ∀ x ∈ Ioo a b, differentiable_at ℝ f x,
     show ∃ c ∈ Ioo a b, deriv f c = 0,
-      from exists_has_deriv_at_eq_zero' _ _ hab hfa hfb (λ x hx, (h x hx).has_deriv_at))
+      from exists_has_deriv_at_eq_zero' hab hfa hfb (λ x hx, (h x hx).has_deriv_at))
   (assume h : ¬∀ x ∈ Ioo a b, differentiable_at ℝ f x,
     have h : ∃ x, x ∈ Ioo a b ∧ ¬differentiable_at ℝ f x, by { push_neg at h, exact h },
-      let ⟨c, hc, hcdiff⟩ := h in ⟨c, hc, deriv_zero_of_not_differentiable_at hcdiff ⟩)
+      let ⟨c, hc, hcdiff⟩ := h in ⟨c, hc, deriv_zero_of_not_differentiable_at hcdiff⟩)
 
 end Rolle

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -573,7 +573,46 @@ begin
   exact ⟨c, cmem, sub_eq_zero.1 hc⟩
 end
 
-omit hgc hgg'
+omit hfc hgc
+
+/-- Cauchy's Mean Value Theorem, extended `has_deriv_at` version. -/
+lemma exists_ratio_has_deriv_at_eq_ratio_slope' {lfa lga lfb lgb : ℝ}
+  (hff' : ∀ x ∈ Ioo a b, has_deriv_at f (f' x) x) (hgg' : ∀ x ∈ Ioo a b, has_deriv_at g (g' x) x)
+  (hfa : tendsto f (nhds_within a $ Ioi a) (nhds lfa)) (hga : tendsto g (nhds_within a $ Ioi a) (nhds lga))
+  (hfb : tendsto f (nhds_within b $ Iio b) (nhds lfb)) (hgb : tendsto g (nhds_within b $ Iio b) (nhds lgb)) :
+  ∃ c ∈ Ioo a b, (lgb - lga) * (f' c) = (lfb - lfa) * (g' c) :=
+begin
+  let h := λ x, (lgb - lga) * f x - (lfb - lfa) * g x,
+  have hha : tendsto h (nhds_within a $ Ioi a) (nhds $ lgb * lfa - lfb * lga),
+  { rw (show h = λ x, lfa * g x - lga * f x + lgb * f x - lfb * g x, by { ext, simp only [h], ring }),
+    rw (show (nhds $ lgb * lfa - lfb * lga) = (nhds $ 0 + lgb * lfa - lfb * lga), by ring),
+    apply tendsto.sub,
+    apply tendsto.add,
+    rw (show 0 = lfa * lga - lga * lfa, by ring),
+    apply tendsto.sub,
+    any_goals { exact tendsto.mul tendsto_const_nhds hfa },
+    any_goals { exact tendsto.mul tendsto_const_nhds hga } },
+  have hhb : tendsto h (nhds_within b $ Iio b) (nhds $ lgb * lfa - lfb * lga),
+  { rw (show h = λ x, lgb * f x - lfb * g x + lfa * g x - lga * f x, by{ ext, simp only [h], ring }),
+    rw (show (nhds $ lgb * lfa - lfb * lga) = (nhds $ 0 + lfa * lgb - lga * lfb), by {rw nhds_eq_nhds_iff, ring, }),
+    apply tendsto.sub,
+    apply tendsto.add,
+    rw (show 0 = lgb * lfb - lfb * lgb, by ring),
+    apply tendsto.sub,
+    any_goals { exact tendsto.mul tendsto_const_nhds hfb },
+    any_goals { exact tendsto.mul tendsto_const_nhds hgb } },
+  let h' := λ x, (lgb - lga) * f' x - (lfb - lfa) * g' x,
+  have hhh' : ∀ x ∈ Ioo a b, has_deriv_at h (h' x) x,
+  { intros x hx,
+    simp only [h', h],
+    exact ((hff' x hx).const_mul _ ).sub (((hgg' x hx)).const_mul _) },
+  rcases exists_has_deriv_at_eq_zero' h h' hab hha hhb hhh' with ⟨c, cmem, hc⟩,
+  exact ⟨ c, cmem, sub_eq_zero.1 hc ⟩
+end
+
+include hfc
+
+omit hgg'
 
 /-- Lagrange's Mean Value Theorem, `has_deriv_at` version -/
 lemma exists_has_deriv_at_eq_slope : ∃ c ∈ Ioo a b, f' c = (f b - f a) / (b - a) :=
@@ -594,6 +633,18 @@ lemma exists_ratio_deriv_eq_ratio_slope :
 exists_ratio_has_deriv_at_eq_ratio_slope f (deriv f) hab hfc
   (λ x hx, ((hfd x hx).differentiable_at $ mem_nhds_sets is_open_Ioo hx).has_deriv_at)
   g (deriv g) hgc (λ x hx, ((hgd x hx).differentiable_at $ mem_nhds_sets is_open_Ioo hx).has_deriv_at)
+
+omit hfc
+
+/-- Cauchy's Mean Value Theorem, extended `deriv` version. -/
+lemma exists_ratio_deriv_eq_ratio_slope' {lfa lga lfb lgb : ℝ} (hdf : differentiable_on ℝ f $ Ioo a b)
+  (hdg : differentiable_on ℝ g $ Ioo a b) (hfa : tendsto f (nhds_within a $ Ioi a) (nhds lfa)) (hga : tendsto g (nhds_within a $ Ioi a) (nhds lga))
+  (hfb : tendsto f (nhds_within b $ Iio b) (nhds lfb)) (hgb : tendsto g (nhds_within b $ Iio b) (nhds lgb)) :
+  ∃ c ∈ Ioo a b, (lgb - lga) * (deriv f c) = (lfb - lfa) * (deriv g c) :=
+exists_ratio_has_deriv_at_eq_ratio_slope' _ _ hab _ _
+  (λ x hx, ((hdf x hx).differentiable_at $ Ioo_mem_nhds hx.1 hx.2).has_deriv_at)
+  (λ x hx, ((hdg x hx).differentiable_at $ Ioo_mem_nhds hx.1 hx.2).has_deriv_at)
+  hfa hga hfb hgb
 
 /-- Lagrange's Mean Value Theorem, `deriv` version. -/
 lemma exists_deriv_eq_slope : ∃ c ∈ Ioo a b, deriv f c = (f b - f a) / (b - a) :=

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -583,31 +583,22 @@ lemma exists_ratio_has_deriv_at_eq_ratio_slope' {lfa lga lfb lgb : ℝ}
   ∃ c ∈ Ioo a b, (lgb - lga) * (f' c) = (lfb - lfa) * (g' c) :=
 begin
   let h := λ x, (lgb - lga) * f x - (lfb - lfa) * g x,
-  have hha : tendsto h (nhds_within a $ Ioi a) (nhds $ lgb * lfa - lfb * lga),
-  { rw (show h = λ x, lfa * g x - lga * f x + lgb * f x - lfb * g x, by { ext, simp only [h], ring }),
-    rw (show (nhds $ lgb * lfa - lfb * lga) = (nhds $ 0 + lgb * lfa - lfb * lga), by ring),
-    apply tendsto.sub,
-    apply tendsto.add,
-    rw (show 0 = lfa * lga - lga * lfa, by ring),
-    apply tendsto.sub,
-    any_goals { exact tendsto.mul tendsto_const_nhds hfa },
-    any_goals { exact tendsto.mul tendsto_const_nhds hga } },
-  have hhb : tendsto h (nhds_within b $ Iio b) (nhds $ lgb * lfa - lfb * lga),
-  { rw (show h = λ x, lgb * f x - lfb * g x + lfa * g x - lga * f x, by{ ext, simp only [h], ring }),
-    rw (show (nhds $ lgb * lfa - lfb * lga) = (nhds $ 0 + lfa * lgb - lga * lfb), by {rw nhds_eq_nhds_iff, ring, }),
-    apply tendsto.sub,
-    apply tendsto.add,
-    rw (show 0 = lgb * lfb - lfb * lgb, by ring),
-    apply tendsto.sub,
-    any_goals { exact tendsto.mul tendsto_const_nhds hfb },
-    any_goals { exact tendsto.mul tendsto_const_nhds hgb } },
+  have hha : tendsto h (𝓝[Ioi a] a) (𝓝 $ lgb * lfa - lfb * lga),
+  { have : tendsto h (𝓝[Ioi a] a)(𝓝 $ (lgb - lga) * lfa - (lfb - lfa) * lga) :=
+      (tendsto_const_nhds.mul hfa).sub (tendsto_const_nhds.mul hga),
+    convert this using 2,
+    ring },
+  have hhb : tendsto h (𝓝[Iio b] b) (𝓝 $ lgb * lfa - lfb * lga),
+  { have : tendsto h (𝓝[Iio b] b)(𝓝 $ (lgb - lga) * lfb - (lfb - lfa) * lgb) :=
+      (tendsto_const_nhds.mul hfb).sub (tendsto_const_nhds.mul hgb),
+    convert this using 2,
+    ring },
   let h' := λ x, (lgb - lga) * f' x - (lfb - lfa) * g' x,
   have hhh' : ∀ x ∈ Ioo a b, has_deriv_at h (h' x) x,
   { intros x hx,
-    simp only [h', h],
     exact ((hff' x hx).const_mul _ ).sub (((hgg' x hx)).const_mul _) },
   rcases exists_has_deriv_at_eq_zero' hab hha hhb hhh' with ⟨c, cmem, hc⟩,
-  exact ⟨ c, cmem, sub_eq_zero.1 hc ⟩
+  exact ⟨c, cmem, sub_eq_zero.1 hc⟩
 end
 
 include hfc

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -578,8 +578,8 @@ omit hfc hgc
 /-- Cauchy's Mean Value Theorem, extended `has_deriv_at` version. -/
 lemma exists_ratio_has_deriv_at_eq_ratio_slope' {lfa lga lfb lgb : ℝ}
   (hff' : ∀ x ∈ Ioo a b, has_deriv_at f (f' x) x) (hgg' : ∀ x ∈ Ioo a b, has_deriv_at g (g' x) x)
-  (hfa : tendsto f (nhds_within a $ Ioi a) (nhds lfa)) (hga : tendsto g (nhds_within a $ Ioi a) (nhds lga))
-  (hfb : tendsto f (nhds_within b $ Iio b) (nhds lfb)) (hgb : tendsto g (nhds_within b $ Iio b) (nhds lgb)) :
+  (hfa : tendsto f (𝓝[Ioi a] a) (𝓝 lfa)) (hga : tendsto g (𝓝[Ioi a] a) (𝓝 lga))
+  (hfb : tendsto f (𝓝[Iio b] b) (𝓝 lfb)) (hgb : tendsto g (𝓝[Iio b] b) (𝓝 lgb)) :
   ∃ c ∈ Ioo a b, (lgb - lga) * (f' c) = (lfb - lfa) * (g' c) :=
 begin
   let h := λ x, (lgb - lga) * f x - (lfb - lfa) * g x,
@@ -606,7 +606,7 @@ begin
   { intros x hx,
     simp only [h', h],
     exact ((hff' x hx).const_mul _ ).sub (((hgg' x hx)).const_mul _) },
-  rcases exists_has_deriv_at_eq_zero' h h' hab hha hhb hhh' with ⟨c, cmem, hc⟩,
+  rcases exists_has_deriv_at_eq_zero' hab hha hhb hhh' with ⟨c, cmem, hc⟩,
   exact ⟨ c, cmem, sub_eq_zero.1 hc ⟩
 end
 
@@ -637,9 +637,10 @@ exists_ratio_has_deriv_at_eq_ratio_slope f (deriv f) hab hfc
 omit hfc
 
 /-- Cauchy's Mean Value Theorem, extended `deriv` version. -/
-lemma exists_ratio_deriv_eq_ratio_slope' {lfa lga lfb lgb : ℝ} (hdf : differentiable_on ℝ f $ Ioo a b)
-  (hdg : differentiable_on ℝ g $ Ioo a b) (hfa : tendsto f (nhds_within a $ Ioi a) (nhds lfa)) (hga : tendsto g (nhds_within a $ Ioi a) (nhds lga))
-  (hfb : tendsto f (nhds_within b $ Iio b) (nhds lfb)) (hgb : tendsto g (nhds_within b $ Iio b) (nhds lgb)) :
+lemma exists_ratio_deriv_eq_ratio_slope' {lfa lga lfb lgb : ℝ}
+  (hdf : differentiable_on ℝ f $ Ioo a b) (hdg : differentiable_on ℝ g $ Ioo a b)
+  (hfa : tendsto f (𝓝[Ioi a] a) (𝓝 lfa)) (hga : tendsto g (𝓝[Ioi a] a) (𝓝 lga))
+  (hfb : tendsto f (𝓝[Iio b] b) (𝓝 lfb)) (hgb : tendsto g (𝓝[Iio b] b) (𝓝 lgb)) :
   ∃ c ∈ Ioo a b, (lgb - lga) * (deriv f c) = (lfb - lfa) * (deriv g c) :=
 exists_ratio_has_deriv_at_eq_ratio_slope' _ _ hab _ _
   (λ x hx, ((hdf x hx).differentiable_at $ Ioo_mem_nhds hx.1 hx.2).has_deriv_at)


### PR DESCRIPTION
This introduces stronger versions of Rolle's theorem and Cauchy's mean value theorem, essentially by encapsulating an extension by continuity using the newly introduced `extend_from` of #3590 
