### PR TITLE
[Merged by Bors] - chore(measure_theory/lebesgue_measure): review

### DIFF
--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -55,8 +55,10 @@ protected def of_real (r : real) : ennreal := coe (nnreal.of_real r)
 @[simp] lemma of_real_to_real {a : ennreal} (h : a ≠ ∞) : ennreal.of_real (a.to_real) = a :=
 by simp [ennreal.to_real, ennreal.of_real, h]
 
-@[simp] lemma to_real_of_real {r : real} (h : 0 ≤ r) : ennreal.to_real (ennreal.of_real r) = r :=
+@[simp] lemma to_real_of_real {r : ℝ} (h : 0 ≤ r) : ennreal.to_real (ennreal.of_real r) = r :=
 by simp [ennreal.to_real, ennreal.of_real, nnreal.coe_of_real _ h]
+
+lemma to_real_of_real' {r : ℝ} : ennreal.to_real (ennreal.of_real r) = max r 0 := rfl
 
 lemma coe_to_nnreal_le_self : ∀{a:ennreal}, ↑(a.to_nnreal) ≤ a
 | (some r) := by rw [some_eq_coe, to_nnreal_coe]; exact le_refl _
@@ -65,9 +67,11 @@ lemma coe_to_nnreal_le_self : ∀{a:ennreal}, ↑(a.to_nnreal) ≤ a
 lemma coe_nnreal_eq (r : nnreal) : (r : ennreal) = ennreal.of_real r :=
 by { rw [ennreal.of_real, nnreal.of_real], cases r with r h, congr, dsimp, rw max_eq_left h }
 
-lemma of_real_eq_coe_nnreal {x : real} (h : 0 ≤ x) :
+lemma of_real_eq_coe_nnreal {x : ℝ} (h : 0 ≤ x) :
   ennreal.of_real x = @coe nnreal ennreal _ (⟨x, h⟩ : nnreal) :=
 by { rw [coe_nnreal_eq], refl }
+
+@[simp] lemma of_real_coe_nnreal : ennreal.of_real p = p := (coe_nnreal_eq p).symm
 
 @[simp, norm_cast] lemma coe_zero : ↑(0 : nnreal) = (0 : ennreal) := rfl
 @[simp, norm_cast] lemma coe_one : ↑(1 : nnreal) = (1 : ennreal) := rfl
@@ -994,6 +998,9 @@ lemma of_real_add {p q : ℝ} (hp : 0 ≤ p) (hq : 0 ≤ q) :
   ennreal.of_real (p + q) = ennreal.of_real p + ennreal.of_real q :=
 by rw [ennreal.of_real, ennreal.of_real, ennreal.of_real, ← coe_add,
        coe_eq_coe, nnreal.of_real_add hp hq]
+
+lemma of_real_add_le {p q : ℝ} : ennreal.of_real (p + q) ≤ ennreal.of_real p + ennreal.of_real q :=
+coe_le_coe.2 nnreal.of_real_add_le
 
 @[simp] lemma to_real_le_to_real (ha : a ≠ ⊤) (hb : b ≠ ⊤) : a.to_real ≤ b.to_real ↔ a ≤ b :=
 begin

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -374,6 +374,7 @@ begin
 end
 
 end
+
 /-- Obtain a measure by giving an outer measure where all sets in the σ-algebra are
   Carathéodory measurable. -/
 def outer_measure.to_measure {α} (m : outer_measure α)

--- a/src/measure_theory/outer_measure.lean
+++ b/src/measure_theory/outer_measure.lean
@@ -97,6 +97,15 @@ lemma le_inter_add_diff {m : outer_measure α} {t : set α} (s : set α) :
   m t ≤ m (t ∩ s) + m (t \ s) :=
 by { convert m.union _ _, rw inter_union_diff t s }
 
+lemma diff_null (m : outer_measure α) (s : set α) {t : set α} (ht : m t = 0) :
+  m (s \ t) = m s :=
+begin
+  refine le_antisymm (m.mono $ diff_subset _ _) _,
+  calc m s ≤ m (s ∩ t) + m (s \ t) : le_inter_add_diff _
+       ... ≤ m t + m (s \ t)       : add_le_add_right (m.mono $ inter_subset_right _ _) _
+       ... = m (s \ t)             : by rw [ht, zero_add]
+end
+
 lemma union_null (m : outer_measure α) {s₁ s₂ : set α}
   (h₁ : m s₁ = 0) (h₂ : m s₂ = 0) : m (s₁ ∪ s₂) = 0 :=
 by simpa [h₁, h₂] using m.union s₁ s₂


### PR DESCRIPTION
* use `ennreal.of_real` instead of `coe ∘ nnreal.of_real`;
* avoid some non-finishing `simp`s;
* simplify proofs of `lebesgue_outer_Ico/Ioc/Ioo`;
* add `instance : locally_finite_measure (volume : measure ℝ)`
  instead of `real.volume_lt_top_of_bounded` and
  `real.volume_lt_top_of_compact`.

---
<!-- put comments you want to keep out of the PR commit here -->