### PR TITLE
[Merged by Bors] - docs(algebra/module): Remove completed TODO

### DIFF
--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -34,10 +34,6 @@ In this file we define
 
 * `vector_space` and `module` are abbreviations for `semimodule R M`.
 
-## TODO
-
-* `submodule R M` was written before bundled `submonoid`s, so it does not extend it.
-
 ## Tags
 
 semimodule, module, vector space, submodule, subspace, linear map


### PR DESCRIPTION
Today, submodule _does_ extend `add_submonoid`, which is I assume what this TODO was about


---
<!-- put comments you want to keep out of the PR commit here -->

This was done in #3032, cc @urkud