### PR TITLE
[Merged by Bors] - feat(linear_algebra/affine_space): faces of simplices

### DIFF
--- a/src/linear_algebra/affine_space.lean
+++ b/src/linear_algebra/affine_space.lean
@@ -598,8 +598,7 @@ def face {n : ℕ} (s : simplex k V P n) {fs : finset (fin (n + 1))} {m : ℕ} (
 
 /-- The points of a face of a simplex are given by `mono_of_fin`. -/
 lemma face_points {n : ℕ} (s : simplex k V P n) {fs : finset (fin (n + 1))} {m : ℕ}
-    (h : fs.card = m + 1) (i : fin (m + 1)) :
-  (s.face h).points i = s.points (fs.mono_of_fin h i) :=
+  (h : fs.card = m + 1) (i : fin (m + 1)) : (s.face h).points i = s.points (fs.mono_of_fin h i) :=
 rfl
 
 /-- A single-point face equals the 0-simplex constructed with

--- a/src/linear_algebra/affine_space.lean
+++ b/src/linear_algebra/affine_space.lean
@@ -606,10 +606,7 @@ rfl
 `mk_of_point`. -/
 @[simp] lemma face_eq_mk_of_point {n : ℕ} (s : simplex k V P n) (i : fin (n + 1)) :
   s.face (finset.card_singleton i) = mk_of_point k V (s.points i) :=
-begin
-  ext i0,
-  simp [face_points]
-end
+by { ext, simp [face_points] }
 
 end simplex
 

--- a/src/linear_algebra/affine_space.lean
+++ b/src/linear_algebra/affine_space.lean
@@ -588,6 +588,29 @@ end
 lemma ext_iff {n : ℕ} (s1 s2 : simplex k V P n): s1 = s2 ↔ ∀ i, s1.points i = s2.points i :=
 ⟨λ h _, h ▸ rfl, ext⟩
 
+/-- A face of a simplex is a simplex with the given subset of
+points. -/
+def face {n : ℕ} (s : simplex k V P n) {fs : finset (fin (n + 1))} {m : ℕ} (h : fs.card = m + 1) :
+  simplex k V P m :=
+⟨s.points ∘ fs.mono_of_fin h,
+ affine_independent_embedding_of_affine_independent
+   ⟨fs.mono_of_fin h, fs.mono_of_fin_injective h⟩ s.independent⟩
+
+/-- The points of a face of a simplex are given by `mono_of_fin`. -/
+lemma face_points {n : ℕ} (s : simplex k V P n) {fs : finset (fin (n + 1))} {m : ℕ}
+    (h : fs.card = m + 1) (i : fin (m + 1)) :
+  (s.face h).points i = s.points (fs.mono_of_fin h i) :=
+rfl
+
+/-- A single-point face equals the 0-simplex constructed with
+`mk_of_point`. -/
+@[simp] lemma face_eq_mk_of_point {n : ℕ} (s : simplex k V P n) (i : fin (n + 1)) :
+  s.face (finset.card_singleton i) = mk_of_point k V (s.points i) :=
+begin
+  ext i0,
+  simp [face_points]
+end
+
 end simplex
 
 end affine_space


### PR DESCRIPTION
Define a `face` of an `affine_space.simplex` with any given nonempty
subset of the vertices, using `finset.mono_of_fin`.


---
<!-- put comments you want to keep out of the PR commit here -->
