### PR TITLE
[Merged by Bors] - feat(measurable_space): more properties of measurable sets in a product

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1747,15 +1747,14 @@ by { ext, simp }
 @[simp] theorem univ_prod_univ : (@univ α).prod (@univ β) = univ :=
 by { ext ⟨x, y⟩, simp }
 
-@[simp] theorem singleton_prod_singleton {a : α} {b : β} :
-  set.prod {a} {b} = ({(a, b)} : set (α × β)) :=
-by { ext ⟨x, y⟩, simp }
-
 @[simp] theorem singleton_prod {a : α} : set.prod {a} t = prod.mk a '' t :=
 by { ext ⟨x, y⟩, simp [and.left_comm, eq_comm] }
 
 @[simp] theorem prod_singleton {b : β} : s.prod {b} = (λ a, (a, b)) '' s :=
 by { ext ⟨x, y⟩, simp [and.left_comm, eq_comm] }
+
+theorem singleton_prod_singleton {a : α} {b : β} : set.prod {a} {b} = ({(a, b)} : set (α × β)) :=
+by simp
 
 @[simp] theorem union_prod : (s₁ ∪ s₂).prod t = s₁.prod t ∪ s₂.prod t :=
 by { ext ⟨x, y⟩, simp [or_and_distrib_right] }

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -621,19 +621,19 @@ theorem ssubset_insert {s : set α} {a : α} (h : a ∉ s) : s ⊂ insert a s :=
 ssubset_iff_insert.2 ⟨a, h, subset.refl _⟩
 
 theorem insert_comm (a b : α) (s : set α) : insert a (insert b s) = insert b (insert a s) :=
-ext $ by simp [or.left_comm]
+by { ext, simp [or.left_comm] }
 
 theorem insert_union : insert a s ∪ t = insert a (s ∪ t) :=
-ext $ assume a, by simp [or.comm, or.left_comm]
+by { ext, simp [or.comm, or.left_comm] }
 
 @[simp] theorem union_insert : s ∪ insert a t = insert a (s ∪ t) :=
-ext $ assume a, by simp [or.comm, or.left_comm]
+by { ext, simp [or.comm, or.left_comm] }
 
 theorem insert_nonempty (a : α) (s : set α) : (insert a s).nonempty :=
 ⟨a, mem_insert a s⟩
 
 lemma insert_inter (x : α) (s t : set α) : insert x (s ∩ t) = insert x s ∩ insert x t :=
-by { ext y, simp, tauto! }
+by { ext y, simp [←or_and_distrib_left] }
 
 -- useful in proofs by induction
 theorem forall_of_forall_insert {P : α → Prop} {a : α} {s : set α} (h : ∀ x, x ∈ insert a s → P x) :
@@ -661,7 +661,8 @@ theorem singleton_def (a : α) : ({a} : set α) = insert a ∅ :=
 iff.rfl
 
 @[simp]
-lemma set_of_eq_eq_singleton {a : α} : {n | n = a} = {a} := set.ext $ λ n, (set.mem_singleton_iff).symm
+lemma set_of_eq_eq_singleton {a : α} : {n | n = a} = {a} :=
+set.ext $ λ n, (set.mem_singleton_iff).symm
 
 -- TODO: again, annotation needed
 @[simp] theorem mem_singleton (a : α) : a ∈ ({a} : set α) := by finish
@@ -685,10 +686,10 @@ by finish
 ⟨a, rfl⟩
 
 @[simp] theorem singleton_subset_iff {a : α} {s : set α} : {a} ⊆ s ↔ a ∈ s :=
-⟨λh, h (by simp), λh b e, by simp at e; simp [*]⟩
+⟨λh, h (by simp), λh b e, by { rw [mem_singleton_iff] at e, simp [*] }⟩
 
 theorem set_compr_eq_eq_singleton {a : α} : {b | b = a} = {a} :=
-ext $ by simp
+by { ext, simp }
 
 @[simp] theorem singleton_union : {a} ∪ s = insert a s :=
 rfl
@@ -737,7 +738,7 @@ theorem forall_not_of_sep_empty {s : set α} {p : α → Prop} (h : {x ∈ s | p
 by finish [ext_iff]
 
 @[simp] lemma sep_univ {α} {p : α → Prop} : {a ∈ (univ : set α) | p a} = {a | p a} :=
-set.ext $ by simp
+by { ext, simp }
 
 /-! ### Lemmas about complement -/
 
@@ -944,8 +945,8 @@ lemma diff_inter {s t u : set α} : s \ (t ∩ u) = (s \ t) ∪ (s \ u) :=
 ext $ λ x, by simp [classical.not_and_distrib, and_or_distrib_left]
 
 lemma diff_inter_diff {s t u : set α} : s \ t ∩ (s \ u) = s \ (t ∪ u) :=
-by { ext x, simp only [mem_inter_eq, mem_union_eq, mem_diff, not_or_distrib],
-     exact ⟨λ ⟨⟨h1, h2⟩, _, h3⟩, ⟨h1, h2, h3⟩, λ ⟨h1, h2, h3⟩, ⟨⟨h1, h2⟩, h1, h3⟩⟩ }
+by { ext x, simp only [mem_inter_eq, mem_union_eq, mem_diff, not_or_distrib, and.left_comm,
+  and.assoc, and_self_left] }
 
 lemma diff_compl : s \ tᶜ = s ∩ t := by rw [diff_eq, compl_compl]
 
@@ -953,7 +954,7 @@ lemma diff_diff_right {s t u : set α} : s \ (t \ u) = (s \ t) ∪ (s ∩ u) :=
 by rw [diff_eq t u, diff_inter, diff_compl]
 
 @[simp] theorem insert_diff_of_mem (s) (h : a ∈ t) : insert a s \ t = s \ t :=
-ext $ by intro; constructor; simp [or_imp_distrib, h] {contextual := tt}
+by { ext, split; simp [or_imp_distrib, h] {contextual := tt} }
 
 theorem insert_diff_of_not_mem (s) (h : a ∉ t) : insert a s \ t = insert a (s \ t) :=
 begin
@@ -970,7 +971,7 @@ end
 
 lemma insert_diff_self_of_not_mem {a : α} {s : set α} (h : a ∉ s) :
   insert a s \ {a} = s :=
-ext $ λ x, by simp [and_iff_left_of_imp (λ hx : x ∈ s, show x ≠ a, from λ hxa, h $ hxa ▸ hx)]
+by { ext, simp [and_iff_left_of_imp (λ hx : x ∈ s, show x ≠ a, from λ hxa, h $ hxa ▸ hx)] }
 
 theorem union_diff_self {s t : set α} : s ∪ (t \ s) = s ∪ t :=
 by finish [ext_iff, iff_def]
@@ -979,7 +980,7 @@ theorem diff_union_self {s t : set α} : (s \ t) ∪ t = s ∪ t :=
 by rw [union_comm, union_diff_self, union_comm]
 
 theorem diff_inter_self {a b : set α} : (b \ a) ∩ a = ∅ :=
-ext $ by simp [iff_def] {contextual:=tt}
+by { ext, by simp [iff_def] {contextual:=tt} }
 
 theorem diff_eq_self {s t : set α} : s \ t = s ↔ t ∩ s ⊆ ∅ :=
 by finish [ext_iff, iff_def, subset_def]
@@ -991,7 +992,7 @@ diff_eq_self.2 $ by simp [singleton_inter_eq_empty.2 h]
   insert a (s \ {a}) = insert a s :=
 by simp [insert_eq, union_diff_self, -union_singleton, -singleton_union]
 
-@[simp] lemma diff_self {s : set α} : s \ s = ∅ := ext $ by simp
+@[simp] lemma diff_self {s : set α} : s \ s = ∅ := by { ext, simp }
 
 lemma diff_diff_cancel_left {s t : set α} (h : s ⊆ t) : t \ (t \ s) = s :=
 by simp only [diff_diff_right, diff_self, inter_eq_self_of_subset_right h, empty_union]
@@ -1078,8 +1079,8 @@ preimage_comp.symm
 
 theorem eq_preimage_subtype_val_iff {p : α → Prop} {s : set (subtype p)} {t : set α} :
   s = subtype.val ⁻¹' t ↔ (∀x (h : p x), (⟨x, h⟩ : subtype p) ∈ s ↔ x ∈ t) :=
-⟨assume s_eq x h, by rw [s_eq]; simp,
- assume h, ext $ assume ⟨x, hx⟩, by simp [h]⟩
+⟨assume s_eq x h, by { rw [s_eq], simp },
+ assume h, ext $ λ ⟨x, hx⟩, by simp [h]⟩
 
 lemma preimage_coe_coe_diagonal {α : Type*} (s : set α) :
   (prod.map coe coe) ⁻¹' (diagonal α) = diagonal s :=
@@ -1163,7 +1164,7 @@ theorem image_union (f : α → β) (s t : set α) :
   f '' (s ∪ t) = f '' s ∪ f '' t :=
 by finish [ext_iff, iff_def, mem_image_eq]
 
-@[simp] theorem image_empty (f : α → β) : f '' ∅ = ∅ := ext $ by simp
+@[simp] theorem image_empty (f : α → β) : f '' ∅ = ∅ := by { ext, simp }
 
 lemma image_inter_subset (f : α → β) (s t : set α) :
   f '' (s ∩ t) ⊆ f '' s ∩ f '' t :=
@@ -1182,18 +1183,18 @@ theorem image_inter {f : α → β} {s t : set α} (H : injective f) :
 image_inter_on (assume x _ y _ h, H h)
 
 theorem image_univ_of_surjective {ι : Type*} {f : ι → β} (H : surjective f) : f '' univ = univ :=
-eq_univ_of_forall $ by simp [image]; exact H
+eq_univ_of_forall $ by { simpa [image] }
 
 @[simp] theorem image_singleton {f : α → β} {a : α} : f '' {a} = {f a} :=
-ext $ λ x, by simp [image]; rw eq_comm
+by { ext, simp [image, eq_comm] }
 
 theorem nonempty.image_const {s : set α} (hs : s.nonempty) (a : β) : (λ _, a) '' s = {a} :=
 ext $ λ x, ⟨λ ⟨y, _, h⟩, h ▸ mem_singleton _,
   λ h, (eq_of_mem_singleton h).symm ▸ hs.imp (λ y hy, ⟨hy, rfl⟩)⟩
 
 @[simp] lemma image_eq_empty {α β} {f : α → β} {s : set α} : f '' s = ∅ ↔ s = ∅ :=
-by simp only [eq_empty_iff_forall_not_mem]; exact
-⟨λ H a ha, H _ ⟨_, ha, rfl⟩, λ H b ⟨_, ha, _⟩, H _ ha⟩
+by { simp only [eq_empty_iff_forall_not_mem],
+     exact ⟨λ H a ha, H _ ⟨_, ha, rfl⟩, λ H b ⟨_, ha, _⟩, H _ ha⟩ }
 
 lemma inter_singleton_nonempty {s : set α} {a : α} : (s ∩ {a}).nonempty ↔ a ∈ s :=
 by finish [set.nonempty]
@@ -1202,12 +1203,12 @@ by finish [set.nonempty]
 theorem mem_compl_image (t : set α) (S : set (set α)) :
   t ∈ compl '' S ↔ tᶜ ∈ S :=
 begin
-  suffices : ∀ x, xᶜ = t ↔ tᶜ = x, {simp [this]},
+  suffices : ∀ x, xᶜ = t ↔ tᶜ = x, { simp [this] },
   intro x, split; { intro e, subst e, simp }
 end
 
 /-- A variant of `image_id` -/
-@[simp] lemma image_id' (s : set α) : (λx, x) '' s = s := ext $ by simp
+@[simp] lemma image_id' (s : set α) : (λx, x) '' s = s := by { ext, simp }
 
 theorem image_id (s : set α) : id '' s = s := by simp
 
@@ -1217,7 +1218,7 @@ by rw [← image_comp, compl_comp_compl, image_id]
 
 theorem image_insert_eq {f : α → β} {a : α} {s : set α} :
   f '' (insert a s) = insert (f a) (f '' s) :=
-ext $ by simp [and_or_distrib_left, exists_or_distrib, eq_comm, or_comm, and_comm]
+by { ext, simp [and_or_distrib_left, exists_or_distrib, eq_comm, or_comm, and_comm] }
 
 theorem image_pair (f : α → β) (a b : α) : f '' {a, b} = {f a, f b} :=
 by simp only [image_insert_eq, image_singleton]
@@ -1247,7 +1248,7 @@ subset_compl_iff_disjoint.2 $ by simp [image_inter H]
 
 theorem subset_image_compl {f : α → β} {s : set α} (H : surjective f) : (f '' s)ᶜ ⊆ f '' sᶜ :=
 compl_subset_iff_union.2 $
-by rw ← image_union; simp [image_univ_of_surjective H]
+by { rw ← image_union, simp [image_univ_of_surjective H] }
 
 theorem image_compl_eq {f : α → β} {s : set α} (H : bijective f) : f '' sᶜ = (f '' s)ᶜ :=
 subset.antisymm (image_compl_subset H.1) (subset_image_compl H.2)
@@ -1436,13 +1437,13 @@ eq_univ_iff_forall
 @[simp] theorem range_id : range (@id α) = univ := range_iff_surjective.2 surjective_id
 
 theorem range_inl_union_range_inr : range (@sum.inl α β) ∪ range sum.inr = univ :=
-ext $ λ x, by cases x; simp
+by { ext x, cases x; simp }
 
 @[simp] theorem range_quot_mk (r : α → α → Prop) : range (quot.mk r) = univ :=
 range_iff_surjective.2 quot.exists_rep
 
 @[simp] theorem image_univ {ι : Type*} {f : ι → β} : f '' univ = range f :=
-ext $ by simp [image, range]
+by { ext, simp [image, range] }
 
 theorem image_subset_range {ι : Type*} (f : ι → β) (s : set ι) : f '' s ⊆ range f :=
 by rw ← image_univ; exact image_subset _ (subset_univ _)
@@ -1716,47 +1717,65 @@ variables {s s₁ s₂ : set α} {t t₁ t₂ : set β}
 protected def prod (s : set α) (t : set β) : set (α × β) :=
 {p | p.1 ∈ s ∧ p.2 ∈ t}
 
-lemma prod_eq (s : set α) (t : set β) : set.prod s t = prod.fst ⁻¹' s ∩ prod.snd ⁻¹' t := rfl
+lemma prod_eq (s : set α) (t : set β) : s.prod t = prod.fst ⁻¹' s ∩ prod.snd ⁻¹' t := rfl
 
-theorem mem_prod_eq {p : α × β} : p ∈ set.prod s t = (p.1 ∈ s ∧ p.2 ∈ t) := rfl
+theorem mem_prod_eq {p : α × β} : p ∈ s.prod t = (p.1 ∈ s ∧ p.2 ∈ t) := rfl
 
-@[simp] theorem mem_prod {p : α × β} : p ∈ set.prod s t ↔ p.1 ∈ s ∧ p.2 ∈ t := iff.rfl
+@[simp] theorem mem_prod {p : α × β} : p ∈ s.prod t ↔ p.1 ∈ s ∧ p.2 ∈ t := iff.rfl
 
-lemma mk_mem_prod {a : α} {b : β} (a_in : a ∈ s) (b_in : b ∈ t) : (a, b) ∈ set.prod s t :=
+@[simp] theorem prod_mk_mem_set_prod_eq {a : α} {b : β} :
+  (a, b) ∈ s.prod t = (a ∈ s ∧ b ∈ t) := rfl
+
+lemma mk_mem_prod {a : α} {b : β} (a_in : a ∈ s) (b_in : b ∈ t) : (a, b) ∈ s.prod t :=
 ⟨a_in, b_in⟩
 
 theorem prod_mono {s₁ s₂ : set α} {t₁ t₂ : set β} (hs : s₁ ⊆ s₂) (ht : t₁ ⊆ t₂) :
-  set.prod s₁ t₁ ⊆ set.prod s₂ t₂ :=
+  s₁.prod t₁ ⊆ s₂.prod t₂ :=
 assume x ⟨h₁, h₂⟩, ⟨hs h₁, ht h₂⟩
 
 lemma prod_subset_iff {P : set (α × β)} :
-  (set.prod s t ⊆ P) ↔ ∀ (x ∈ s) (y ∈ t), (x, y) ∈ P :=
+  (s.prod t ⊆ P) ↔ ∀ (x ∈ s) (y ∈ t), (x, y) ∈ P :=
 ⟨λ h _ xin _ yin, h (mk_mem_prod xin yin),
  λ h _ pin, by { cases mem_prod.1 pin with hs ht, simpa using h _ hs _ ht }⟩
 
-@[simp] theorem prod_empty : set.prod s ∅ = (∅ : set (α × β)) :=
-ext $ by simp [set.prod]
+@[simp] theorem prod_empty : s.prod ∅ = (∅ : set (α × β)) :=
+by { ext, simp }
 
 @[simp] theorem empty_prod : set.prod ∅ t = (∅ : set (α × β)) :=
-ext $ by simp [set.prod]
+by { ext, simp }
 
-theorem prod_inter_prod : set.prod s₁ t₁ ∩ set.prod s₂ t₂ = set.prod (s₁ ∩ s₂) (t₁ ∩ t₂) :=
-subset.antisymm
-  (assume ⟨a, b⟩ ⟨⟨ha₁, hb₁⟩, ⟨ha₂, hb₂⟩⟩, ⟨⟨ha₁, ha₂⟩, ⟨hb₁, hb₂⟩⟩)
-  (subset_inter
-    (prod_mono (inter_subset_left _ _) (inter_subset_left _ _))
-    (prod_mono (inter_subset_right _ _) (inter_subset_right _ _)))
+@[simp] theorem univ_prod_univ : (@univ α).prod (@univ β) = univ :=
+by { ext ⟨x, y⟩, simp }
+
+@[simp] theorem singleton_prod_singleton {a : α} {b : β} :
+  set.prod {a} {b} = ({(a, b)} : set (α × β)) :=
+by { ext ⟨x, y⟩, simp }
+
+@[simp] theorem singleton_prod {a : α} : set.prod {a} t = prod.mk a '' t :=
+by { ext ⟨x, y⟩, simp [and.left_comm, eq_comm] }
+
+@[simp] theorem prod_singleton {b : β} : s.prod {b} = (λ a, (a, b)) '' s :=
+by { ext ⟨x, y⟩, simp [and.left_comm, eq_comm] }
+
+@[simp] theorem union_prod : (s₁ ∪ s₂).prod t = s₁.prod t ∪ s₂.prod t :=
+by { ext ⟨x, y⟩, simp [or_and_distrib_right] }
+
+@[simp] theorem prod_union : s.prod (t₁ ∪ t₂) = s.prod t₁ ∪ s.prod t₂ :=
+by { ext ⟨x, y⟩, simp [and_or_distrib_left] }
+
+theorem prod_inter_prod : s₁.prod t₁ ∩ s₂.prod t₂ = (s₁ ∩ s₂).prod (t₁ ∩ t₂) :=
+by { ext ⟨x, y⟩, simp [and_assoc, and.left_comm] }
 
 theorem insert_prod {a : α} {s : set α} {t : set β} :
-  set.prod (insert a s) t = (prod.mk a '' t) ∪ set.prod s t :=
-begin ext ⟨x, y⟩, simp [set.prod, image, iff_def, or_imp_distrib, imp.swap] {contextual := tt} end
+  (insert a s).prod t = (prod.mk a '' t) ∪ s.prod t :=
+by { ext ⟨x, y⟩, simp [image, iff_def, or_imp_distrib, imp.swap] {contextual := tt} }
 
 theorem prod_insert {b : β} {s : set α} {t : set β} :
-  set.prod s (insert b t) = ((λa, (a, b)) '' s) ∪ set.prod s t :=
-begin ext ⟨x, y⟩, simp [set.prod, image, iff_def, or_imp_distrib, imp.swap] {contextual := tt} end
+  s.prod (insert b t) = ((λa, (a, b)) '' s) ∪ s.prod t :=
+by { ext ⟨x, y⟩, simp [image, iff_def, or_imp_distrib, imp.swap] {contextual := tt} }
 
 theorem prod_preimage_eq {f : γ → α} {g : δ → β} :
-  set.prod (preimage f s) (preimage g t) = preimage (λp, (f p.1, g p.2)) (set.prod s t) := rfl
+  (preimage f s).prod (preimage g t) = preimage (λp, (f p.1, g p.2)) (s.prod t) := rfl
 
 @[simp] lemma mk_preimage_prod_left {y : β} (h : y ∈ t) : (λ x, (x, y)) ⁻¹' s.prod t = s :=
 by { ext x, simp [h] }
@@ -1764,34 +1783,28 @@ by { ext x, simp [h] }
 @[simp] lemma mk_preimage_prod_right {x : α} (h : x ∈ s) : prod.mk x ⁻¹' s.prod t = t :=
 by { ext y, simp [h] }
 
-theorem image_swap_prod : (λp:β×α, (p.2, p.1)) '' set.prod t s = set.prod s t :=
-ext $ λ ⟨a, b⟩, by simp [mem_image_eq, set.prod, and_comm]; exact
-⟨ λ ⟨b', a', ⟨h_a, h_b⟩, h⟩, by subst a'; subst b'; assumption,
-  λ h, ⟨b, a, ⟨rfl, rfl⟩, h⟩⟩
-
 theorem image_swap_eq_preimage_swap : image (@prod.swap α β) = preimage prod.swap :=
 image_eq_preimage_of_inverse prod.swap_left_inverse prod.swap_right_inverse
 
+theorem image_swap_prod : prod.swap '' t.prod s = s.prod t :=
+by { ext ⟨x, y⟩, simp [image_swap_eq_preimage_swap, and_comm] }
+
 theorem prod_image_image_eq {m₁ : α → γ} {m₂ : β → δ} :
-  set.prod (image m₁ s) (image m₂ t) = image (λp:α×β, (m₁ p.1, m₂ p.2)) (set.prod s t) :=
+  (image m₁ s).prod (image m₂ t) = image (λp:α×β, (m₁ p.1, m₂ p.2)) (s.prod t) :=
 ext $ by simp [-exists_and_distrib_right, exists_and_distrib_right.symm, and.left_comm,
   and.assoc, and.comm]
 
 theorem prod_range_range_eq {α β γ δ} {m₁ : α → γ} {m₂ : β → δ} :
-  set.prod (range m₁) (range m₂) = range (λp:α×β, (m₁ p.1, m₂ p.2)) :=
+  (range m₁).prod (range m₂) = range (λp:α×β, (m₁ p.1, m₂ p.2)) :=
 ext $ by simp [range]
 
 theorem prod_range_univ_eq {α β γ} {m₁ : α → γ} :
-  set.prod (range m₁) (univ : set β) = range (λp:α×β, (m₁ p.1, p.2)) :=
+  (range m₁).prod (univ : set β) = range (λp:α×β, (m₁ p.1, p.2)) :=
 ext $ by simp [range]
 
 theorem prod_univ_range_eq {α β δ} {m₂ : β → δ} :
-  set.prod (univ : set α) (range m₂) = range (λp:α×β, (p.1, m₂ p.2)) :=
+  (univ : set α).prod (range m₂) = range (λp:α×β, (p.1, m₂ p.2)) :=
 ext $ by simp [range]
-
-@[simp] theorem prod_singleton_singleton {a : α} {b : β} :
-  set.prod {a} {b} = ({(a, b)} : set (α×β)) :=
-ext $ by simp [set.prod]
 
 theorem nonempty.prod : s.nonempty → t.nonempty → (s.prod t).nonempty
 | ⟨x, hx⟩ ⟨y, hy⟩ := ⟨(x, y), ⟨hx, hy⟩⟩
@@ -1806,43 +1819,37 @@ theorem prod_nonempty_iff : (s.prod t).nonempty ↔ s.nonempty ∧ t.nonempty :=
 ⟨λ h, ⟨h.fst, h.snd⟩, λ h, nonempty.prod h.1 h.2⟩
 
 theorem prod_eq_empty_iff {s : set α} {t : set β} :
-  set.prod s t = ∅ ↔ (s = ∅ ∨ t = ∅) :=
+  s.prod t = ∅ ↔ (s = ∅ ∨ t = ∅) :=
 by simp only [not_nonempty_iff_eq_empty.symm, prod_nonempty_iff, classical.not_and_distrib]
 
-@[simp] theorem prod_mk_mem_set_prod_eq {a : α} {b : β} {s : set α} {t : set β} :
-  (a, b) ∈ set.prod s t = (a ∈ s ∧ b ∈ t) := rfl
-
-@[simp] theorem univ_prod_univ : set.prod (@univ α) (@univ β) = univ :=
-ext $ λ ⟨a, b⟩, by simp
-
 lemma prod_sub_preimage_iff {W : set γ} {f : α × β → γ} :
-  set.prod s t ⊆ f ⁻¹' W ↔ ∀ a b, a ∈ s → b ∈ t → f (a, b) ∈ W :=
+  s.prod t ⊆ f ⁻¹' W ↔ ∀ a b, a ∈ s → b ∈ t → f (a, b) ∈ W :=
 by simp [subset_def]
 
 lemma fst_image_prod_subset (s : set α) (t : set β) :
-  prod.fst '' (set.prod s t) ⊆ s :=
+  prod.fst '' (s.prod t) ⊆ s :=
 λ _ h, let ⟨_, ⟨h₂, _⟩, h₁⟩ := (set.mem_image _ _ _).1 h in h₁ ▸ h₂
 
 lemma prod_subset_preimage_fst (s : set α) (t : set β) :
-  set.prod s t ⊆ prod.fst ⁻¹' s :=
+  s.prod t ⊆ prod.fst ⁻¹' s :=
 image_subset_iff.1 (fst_image_prod_subset s t)
 
 lemma fst_image_prod (s : set β) {t : set α} (ht : t.nonempty) :
-  prod.fst '' (set.prod s t) = s :=
+  prod.fst '' (s.prod t) = s :=
 set.subset.antisymm (fst_image_prod_subset _ _)
   $ λ y y_in, let ⟨x, x_in⟩ := ht in
     ⟨(y, x), ⟨y_in, x_in⟩, rfl⟩
 
 lemma snd_image_prod_subset (s : set α) (t : set β) :
-  prod.snd '' (set.prod s t) ⊆ t :=
+  prod.snd '' (s.prod t) ⊆ t :=
 λ _ h, let ⟨_, ⟨_, h₂⟩, h₁⟩ := (set.mem_image _ _ _).1 h in h₁ ▸ h₂
 
 lemma prod_subset_preimage_snd (s : set α) (t : set β) :
-  set.prod s t ⊆ prod.snd ⁻¹' t :=
+  s.prod t ⊆ prod.snd ⁻¹' t :=
 image_subset_iff.1 (snd_image_prod_subset s t)
 
 lemma snd_image_prod {s : set α} (hs : s.nonempty) (t : set β) :
-  prod.snd '' (set.prod s t) = t :=
+  prod.snd '' (s.prod t) = t :=
 set.subset.antisymm (snd_image_prod_subset _ _)
   $ λ y y_in, let ⟨x, x_in⟩ := hs in
     ⟨(x, y), ⟨x_in, y_in⟩, rfl⟩
@@ -1850,14 +1857,14 @@ set.subset.antisymm (snd_image_prod_subset _ _)
 /-- A product set is included in a product set if and only factors are included, or a factor of the
 first set is empty. -/
 lemma prod_subset_prod_iff :
-  (set.prod s t ⊆ set.prod s₁ t₁) ↔ (s ⊆ s₁ ∧ t ⊆ t₁) ∨ (s = ∅) ∨ (t = ∅) :=
+  (s.prod t ⊆ s₁.prod t₁) ↔ (s ⊆ s₁ ∧ t ⊆ t₁) ∨ (s = ∅) ∨ (t = ∅) :=
 begin
   classical,
-  cases (set.prod s t).eq_empty_or_nonempty with h h,
+  cases (s.prod t).eq_empty_or_nonempty with h h,
   { simp [h, prod_eq_empty_iff.1 h] },
   { have st : s.nonempty ∧ t.nonempty, by rwa [prod_nonempty_iff] at h,
     split,
-    { assume H : set.prod s t ⊆ set.prod s₁ t₁,
+    { assume H : s.prod t ⊆ s₁.prod t₁,
       have h' : s₁.nonempty ∧ t₁.nonempty := prod_nonempty_iff.1 (h.mono H),
       refine or.inl ⟨_, _⟩,
       show s ⊆ s₁,
@@ -1887,11 +1894,11 @@ def pi (i : set α) (s : Πa, set (π a)) : set (Πa, π a) := { f | ∀a∈i, f
 
 @[simp] lemma pi_insert_index (a : α) (i : set α) (s : Πa, set (π a)) :
   pi (insert a i) s = ((λf, f a) ⁻¹' s a) ∩ pi i s :=
-by ext; simp [pi, or_imp_distrib, forall_and_distrib]
+by { ext, simp [pi, or_imp_distrib, forall_and_distrib] }
 
 @[simp] lemma pi_singleton_index (a : α) (s : Πa, set (π a)) :
   pi {a} s = ((λf:(Πa, π a), f a) ⁻¹' s a) :=
-by ext; simp [pi]
+by { ext, simp [pi] }
 
 lemma pi_if {p : α → Prop} [h : decidable_pred p] (i : set α) (s t : Πa, set (π a)) :
   pi i (λa, if p a then s a else t a) = pi {a ∈ i | p a} s ∩ pi {a ∈ i | ¬ p a} t :=
@@ -1929,7 +1936,7 @@ lemma inclusion_injective {s t : set α} (h : s ⊆ t) :
 | ⟨_, _⟩ ⟨_, _⟩ := subtype.ext_iff_val.2 ∘ subtype.ext_iff_val.1
 
 lemma range_inclusion {s t : set α} (h : s ⊆ t) : range (inclusion h) = {x : t | (x:α) ∈ s} :=
-ext $ λ ⟨x, hx⟩ , by simp [inclusion]
+by { ext ⟨x, hx⟩, simp [inclusion] }
 
 end inclusion
 

--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -551,11 +551,11 @@ instance : complete_boolean_algebra (set α) :=
   .. set.boolean_algebra, .. set.lattice_set }
 
 lemma sInter_union_sInter {S T : set (set α)} :
-  (⋂₀S) ∪ (⋂₀T) = (⋂p ∈ set.prod S T, (p : (set α) × (set α)).1 ∪ p.2) :=
+  (⋂₀S) ∪ (⋂₀T) = (⋂p ∈ S.prod T, (p : (set α) × (set α)).1 ∪ p.2) :=
 Inf_sup_Inf
 
 lemma sUnion_inter_sUnion {s t : set (set α)} :
-  (⋃₀s) ∩ (⋃₀t) = (⋃p ∈ set.prod s t, (p : (set α) × (set α )).1 ∩ p.2) :=
+  (⋃₀s) ∩ (⋃₀t) = (⋃p ∈ s.prod t, (p : (set α) × (set α )).1 ∩ p.2) :=
 Sup_inf_Sup
 
 /-- If `S` is a set of sets, and each `s ∈ S` can be represented as an intersection
@@ -940,7 +940,7 @@ lemma image_seq {f : β → γ} {s : set (α → β)} {t : set α} :
   f '' seq s t = seq ((∘) f '' s) t :=
 by rw [← singleton_seq, ← singleton_seq, seq_seq, image_singleton]
 
-lemma prod_eq_seq {s : set α} {t : set β} : set.prod s t = (prod.mk '' s).seq t :=
+lemma prod_eq_seq {s : set α} {t : set β} : s.prod t = (prod.mk '' s).seq t :=
 begin
   ext ⟨a, b⟩,
   split,
@@ -950,12 +950,12 @@ end
 
 lemma prod_image_seq_comm (s : set α) (t : set β) :
   (prod.mk '' s).seq t = seq ((λb a, (a, b)) '' t) s :=
-by rw [← prod_eq_seq, ← image_swap_prod, prod_eq_seq, image_seq, ← image_comp]
+by rw [← prod_eq_seq, ← image_swap_prod, prod_eq_seq, image_seq, ← image_comp, prod.swap]
 
 end seq
 
 theorem monotone_prod [preorder α] {f : α → set β} {g : α → set γ}
-  (hf : monotone f) (hg : monotone g) : monotone (λx, set.prod (f x) (g x)) :=
+  (hf : monotone f) (hg : monotone g) : monotone (λx, (f x).prod (g x)) :=
 assume a b h, prod_mono (hf h) (hg h)
 
 instance : monad set :=

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -216,7 +216,7 @@ lemma pair_preimage (f : α →ₛ β) (g : α →ₛ γ) (s : set β) (t : set 
 /- A special form of `pair_preimage` -/
 lemma pair_preimage_singleton (f : α →ₛ β) (g : α →ₛ γ) (b : β) (c : γ) :
   (pair f g) ⁻¹' {(b, c)} = (f ⁻¹' {b}) ∩ (g ⁻¹' {c}) :=
-by { rw ← prod_singleton_singleton, exact pair_preimage _ _ _ _ }
+by { rw ← singleton_prod_singleton, exact pair_preimage _ _ _ _ }
 
 theorem bind_const (f : α →ₛ β) : f.bind (const α) = f := by ext; simp
 

--- a/src/measure_theory/lebesgue_measure.lean
+++ b/src/measure_theory/lebesgue_measure.lean
@@ -222,7 +222,7 @@ end
 
 The outer Lebesgue measure is the completion of this measure. (TODO: proof this)
 -/
-instance : measure_space ℝ :=
+instance real.measure_space : measure_space ℝ :=
 ⟨{to_outer_measure := lebesgue_outer,
   m_Union :=
     have borel ℝ ≤ lebesgue_outer.caratheodory,

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -580,36 +580,59 @@ section prod
 instance [m₁ : measurable_space α] [m₂ : measurable_space β] : measurable_space (α × β) :=
 m₁.comap prod.fst ⊔ m₂.comap prod.snd
 
-lemma measurable_fst [measurable_space α] [measurable_space β] :
-  measurable (prod.fst : α × β → α) :=
+variables [measurable_space α] [measurable_space β] [measurable_space γ]
+
+lemma measurable_fst : measurable (prod.fst : α × β → α) :=
 measurable.of_comap_le le_sup_left
 
-lemma measurable.fst [measurable_space α] [measurable_space β] [measurable_space γ]
-  {f : α → β × γ} (hf : measurable f) : measurable (λa:α, (f a).1) :=
+lemma measurable.fst {f : α → β × γ} (hf : measurable f) : measurable (λa:α, (f a).1) :=
 measurable_fst.comp hf
 
-lemma measurable_snd [measurable_space α] [measurable_space β] :
-  measurable (prod.snd : α × β → β) :=
+lemma measurable_snd : measurable (prod.snd : α × β → β) :=
 measurable.of_comap_le le_sup_right
 
-lemma measurable.snd [measurable_space α] [measurable_space β] [measurable_space γ]
-  {f : α → β × γ} (hf : measurable f) : measurable (λa:α, (f a).2) :=
+lemma measurable.snd {f : α → β × γ} (hf : measurable f) : measurable (λa:α, (f a).2) :=
 measurable_snd.comp hf
 
-lemma measurable.prod [measurable_space α] [measurable_space β] [measurable_space γ]
-  {f : α → β × γ} (hf₁ : measurable (λa, (f a).1)) (hf₂ : measurable (λa, (f a).2)) :
-  measurable f :=
+lemma measurable.prod {f : α → β × γ}
+  (hf₁ : measurable (λa, (f a).1)) (hf₂ : measurable (λa, (f a).2)) : measurable f :=
 measurable.of_le_map $ sup_le
   (by { rw [measurable_space.comap_le_iff_le_map, measurable_space.map_comp], exact hf₁ })
   (by { rw [measurable_space.comap_le_iff_le_map, measurable_space.map_comp], exact hf₂ })
 
-lemma measurable.prod_mk [measurable_space α] [measurable_space β] [measurable_space γ]
-  {f : α → β} {g : α → γ} (hf : measurable f) (hg : measurable g) : measurable (λa:α, (f a, g a)) :=
+lemma measurable.prod_mk {f : α → β} {g : α → γ} (hf : measurable f) (hg : measurable g) :
+  measurable (λa:α, (f a, g a)) :=
 measurable.prod hf hg
 
-lemma is_measurable.prod [measurable_space α] [measurable_space β] {s : set α} {t : set β}
-  (hs : is_measurable s) (ht : is_measurable t) : is_measurable (set.prod s t) :=
+lemma is_measurable.prod {s : set α} {t : set β} (hs : is_measurable s) (ht : is_measurable t) :
+  is_measurable (s.prod t) :=
 is_measurable.inter (measurable_fst hs) (measurable_snd ht)
+
+lemma is_measurable.prod_mk_preimage_left {s : set (α × β)} (hs : is_measurable s) (y : β) :
+  is_measurable ((λ x, (x, y)) ⁻¹' s) :=
+measurable_id.prod_mk measurable_const hs
+
+lemma is_measurable.prod_mk_preimage_right {s : set (α × β)} (hs : is_measurable s) (x : α) :
+  is_measurable (prod.mk x ⁻¹' s) :=
+measurable_const.prod_mk measurable_id hs
+
+lemma is_measurable_prod_of_nonempty {s : set α} {t : set β} (h : (s.prod t).nonempty) :
+  is_measurable (s.prod t) ↔ is_measurable s ∧ is_measurable t :=
+begin
+  rcases h with ⟨⟨x, y⟩, hx, hy⟩,
+  refine ⟨λ hst, _, λ h, h.1.prod h.2⟩,
+  have := is_measurable.prod_mk_preimage_left hst y,
+  have := is_measurable.prod_mk_preimage_right hst x,
+  simp * at *
+end
+
+lemma is_measurable_prod {s : set α} {t : set β} :
+  is_measurable (s.prod t) ↔ (is_measurable s ∧ is_measurable t) ∨ s = ∅ ∨ t = ∅ :=
+begin
+  cases (s.prod t).eq_empty_or_nonempty with h h,
+  { simp [h, prod_eq_empty_iff.mp h] },
+  { simp [←not_nonempty_iff_eq_empty, prod_nonempty_iff.mp h, is_measurable_prod_of_nonempty h] }
+end
 
 end prod
 

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -608,21 +608,13 @@ lemma is_measurable.prod {s : set α} {t : set β} (hs : is_measurable s) (ht : 
   is_measurable (s.prod t) :=
 is_measurable.inter (measurable_fst hs) (measurable_snd ht)
 
-lemma is_measurable.prod_mk_preimage_left {s : set (α × β)} (hs : is_measurable s) (y : β) :
-  is_measurable ((λ x, (x, y)) ⁻¹' s) :=
-measurable_id.prod_mk measurable_const hs
-
-lemma is_measurable.prod_mk_preimage_right {s : set (α × β)} (hs : is_measurable s) (x : α) :
-  is_measurable (prod.mk x ⁻¹' s) :=
-measurable_const.prod_mk measurable_id hs
-
 lemma is_measurable_prod_of_nonempty {s : set α} {t : set β} (h : (s.prod t).nonempty) :
   is_measurable (s.prod t) ↔ is_measurable s ∧ is_measurable t :=
 begin
   rcases h with ⟨⟨x, y⟩, hx, hy⟩,
   refine ⟨λ hst, _, λ h, h.1.prod h.2⟩,
-  have := is_measurable.prod_mk_preimage_left hst y,
-  have := is_measurable.prod_mk_preimage_right hst x,
+  have : is_measurable ((λ x, (x, y)) ⁻¹' s.prod t) := measurable_id.prod_mk measurable_const hst,
+  have : is_measurable (prod.mk x ⁻¹' s.prod t) := measurable_const.prod_mk measurable_id hst,
   simp * at *
 end
 

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -385,7 +385,7 @@ instance GH_space_metric_space : metric_space GH_space :=
            = ((λ (p : nonempty_compacts ℓ_infty_ℝ × nonempty_compacts ℓ_infty_ℝ),
                  Hausdorff_dist ((p.fst).val) ((p.snd).val)) ∘ prod.swap) '' (set.prod {a | ⟦a⟧ = x} {b | ⟦b⟧ = y}) :=
       by { congr, funext, simp, rw Hausdorff_dist_comm },
-    simp only [dist, A, image_comp, prod.swap, image_swap_prod],
+    simp only [dist, A, image_comp, image_swap_prod],
   end,
   eq_of_dist_eq_zero := λx y hxy, begin
     /- To show that two spaces at zero distance are isometric, we argue that the distance

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -66,7 +66,7 @@ begin
   exact h₂ (h₁ hs)
 end
 
-/-- If `p : set α → Prop` is stable under restriction and union, and each point `x of a compact set `s` 
+/-- If `p : set α → Prop` is stable under restriction and union, and each point `x of a compact set `s`
   has a neighborhood `t` within `s` such that `p t`, then `p s` holds. -/
 @[elab_as_eliminator]
 lemma is_compact.induction_on {s : set α} (hs : is_compact s) {p : set α → Prop} (he : p ∅)
@@ -337,9 +337,9 @@ assume H n hn hp,
   let ⟨u, v, uo, vo, su, tv, p⟩ :=
     H (prod.swap ⁻¹' n)
       (continuous_swap n hn)
-      (by rwa [←image_subset_iff, prod.swap, image_swap_prod]) in
+      (by rwa [←image_subset_iff, image_swap_prod]) in
   ⟨v, u, vo, uo, tv, su,
-    by rwa [←image_subset_iff, prod.swap, image_swap_prod] at p⟩
+    by rwa [←image_subset_iff, image_swap_prod] at p⟩
 
 lemma nhds_contain_boxes.comm {s : set α} {t : set β} :
   nhds_contain_boxes s t ↔ nhds_contain_boxes t s :=


### PR DESCRIPTION
Add multiple lemmas about `prod` to `set.basic`
Some cleanup in `set.basic`
Fix the name of the instance `measure_space ℝ`
Cleanup and a couple of additions to the `prod` section of `measurable_space`.
Rename: `prod_singleton_singleton` -> `singleton_prod_singleton`
Use `prod.swap` in the statement of `image_swap_prod`.

---
<!-- put comments you want to keep out of the PR commit here -->
