### PR TITLE
[Merged by Bors] - feat(tactic): fix two bugs with generalize'

### DIFF
--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -444,7 +444,7 @@ with name `n` of the same type as `e` and replaces all occurrences of `e` by `n`
 goal, in which case it just calls `assert`.
 In contrast to `generalize` it already introduces the generalized variable. -/
 meta def generalize' (e : expr) (n : name) : tactic expr :=
-(generalize e n >> intro1) <|> note n none e
+(generalize e n >> intro n) <|> note n none e
 
 /--
 `intron_no_renames n` calls `intro` `n` times, using the pretty-printing name

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -1237,10 +1237,10 @@ propagate_tags $
 do let (p, x) := p,
    e ← i_to_expr p,
    some h ← pure h | tactic.generalize' e x >> skip,
+   -- `h` is given, the regular implementation of `generalize` works.
    tgt ← target,
-   -- if generalizing fails, fall back to not replacing anything
    tgt' ← do {
-     ⟨tgt', _⟩ ← solve_aux tgt (tactic.generalize' e x >> target),
+     ⟨tgt', _⟩ ← solve_aux tgt (tactic.generalize e x >> target),
      to_expr ``(Π x, %%e = x → %%(tgt'.binding_body.lift_vars 0 1))
    } <|> to_expr ``(Π x, %%e = x → %%tgt),
    t ← assert h tgt',

--- a/test/tactics.lean
+++ b/test/tactics.lean
@@ -528,6 +528,7 @@ begin
   success_if_fail_with_msg {clear_value k}
     "Cannot clear the body of k. The resulting goal is not type correct.",
   clear_value k f,
+  get_local `k, -- test that `k` is not renamed.
   exact unit.star
 end
 

--- a/test/tactics.lean
+++ b/test/tactics.lean
@@ -539,6 +539,23 @@ begin
   exact unit.star
 end
 
+/- Test whether generalize' always uses the exact name stated by the user, even if that name already
+  exists. (note: the two occurrences of `n` in guard_target are different -/
+example (n : ℕ) : n = 5 → unit :=
+begin
+  generalize' : 5 = n,
+  guard_target (n = n → unit)
+  intro, constructor
+end
+
+/- Test that `generalize'` works correctly with argument `h`, when the expression occurs in the
+  target -/
+example (n : ℕ) : n = 5 → unit :=
+begin
+  generalize' h : 5 = n,
+  guard_target (n = n)
+end
+
 end local_definitions
 
 section set_attribute

--- a/test/tactics.lean
+++ b/test/tactics.lean
@@ -541,7 +541,7 @@ begin
 end
 
 /- Test whether generalize' always uses the exact name stated by the user, even if that name already
-  exists. (note: the two occurrences of `n` in guard_target are different -/
+  exists. -/
 example (n : Type) (k : ℕ) : k = 5 → unit :=
 begin
   generalize' : 5 = n,

--- a/test/tactics.lean
+++ b/test/tactics.lean
@@ -541,19 +541,20 @@ end
 
 /- Test whether generalize' always uses the exact name stated by the user, even if that name already
   exists. (note: the two occurrences of `n` in guard_target are different -/
-example (n : ℕ) : n = 5 → unit :=
+example (n : Type) (k : ℕ) : k = 5 → unit :=
 begin
   generalize' : 5 = n,
-  guard_target (n = n → unit)
+  guard_target (k = n → unit),
   intro, constructor
 end
 
 /- Test that `generalize'` works correctly with argument `h`, when the expression occurs in the
   target -/
-example (n : ℕ) : n = 5 → unit :=
+example (n : Type) (k : ℕ) : k = 5 → unit :=
 begin
   generalize' h : 5 = n,
-  guard_target (n = n)
+  guard_target (k = n → unit),
+  intro, constructor
 end
 
 end local_definitions


### PR DESCRIPTION
The name generated by `generalize'` will be exactly the given name, even if the name already occurs in the context.
There was a bug with `generalize' h : e = x` if `e` occurred in the goal.

---
<!-- put comments you want to keep out of the PR commit here -->
