### PR TITLE
[Merged by Bors] - feat(algebra/classical_lie_algebras): add lie_algebra.orthogonal.mem_so

### DIFF
--- a/src/algebra/classical_lie_algebras.lean
+++ b/src/algebra/classical_lie_algebras.lean
@@ -149,9 +149,9 @@ bilinear form defined by the identity matrix. -/
 def so : lie_subalgebra R (matrix n n R) :=
   skew_adjoint_matrices_lie_subalgebra (1 : matrix n n R)
 
-lemma mem_so (A : matrix l l R) : A ∈ so l R ↔ Aᵀ = -A :=
+@[simp] lemma mem_so (A : matrix n n R) : A ∈ so n R ↔ Aᵀ = -A :=
 begin
-  erw mem_skew_adjoint_matrices_submodule 1 A,
+  erw mem_skew_adjoint_matrices_submodule,
   simp only [matrix.is_skew_adjoint, matrix.is_adjoint_pair, matrix.mul_one, matrix.one_mul],
 end
 

--- a/src/algebra/classical_lie_algebras.lean
+++ b/src/algebra/classical_lie_algebras.lean
@@ -149,6 +149,12 @@ bilinear form defined by the identity matrix. -/
 def so : lie_subalgebra R (matrix n n R) :=
   skew_adjoint_matrices_lie_subalgebra (1 : matrix n n R)
 
+lemma mem_so (A : matrix l l R) : A ∈ so l R ↔ Aᵀ = -A :=
+begin
+  erw mem_skew_adjoint_matrices_submodule 1 A,
+  simp only [matrix.is_skew_adjoint, matrix.is_adjoint_pair, matrix.mul_one, matrix.one_mul],
+end
+
 /-- The indefinite diagonal matrix with `p` 1s and `q` -1s. -/
 def indefinite_diagonal : matrix (p ⊕ q) (p ⊕ q) R :=
   matrix.diagonal $ sum.elim (λ _, 1) (λ _, -1)

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -315,13 +315,14 @@ end equiv
 
 namespace direct_sum
 open dfinsupp
+open_locale direct_sum
 
 variables {R : Type u} [comm_ring R]
 variables {ι : Type v} [decidable_eq ι] {L : ι → Type w}
 variables [Π i, lie_ring (L i)] [Π i, lie_algebra R (L i)]
 
 /-- The direct sum of Lie rings carries a natural Lie ring structure. -/
-instance : lie_ring (direct_sum ι L) := {
+instance : lie_ring (⨁ i, L i) := {
   bracket  := zip_with (λ i, λ x y, ⁅x, y⁆) (λ i, lie_zero 0),
   add_lie  := λ x y z, by { ext, simp only [zip_with_apply, add_apply, add_lie], },
   lie_add  := λ x y z, by { ext, simp only [zip_with_apply, add_apply, lie_add], },
@@ -329,11 +330,11 @@ instance : lie_ring (direct_sum ι L) := {
   jacobi   := λ x y z, by { ext, simp only [zip_with_apply, add_apply, lie_ring.jacobi, zero_apply], },
   ..(infer_instance : add_comm_group _) }
 
-@[simp] lemma bracket_apply {x y : direct_sum ι L} {i : ι} :
+@[simp] lemma bracket_apply {x y : (⨁ i, L i)} {i : ι} :
   ⁅x, y⁆ i = ⁅x i, y i⁆ := zip_with_apply
 
 /-- The direct sum of Lie algebras carries a natural Lie algebra structure. -/
-instance : lie_algebra R (direct_sum ι L) :=
+instance : lie_algebra R (⨁ i, L i) :=
 { lie_smul := λ c x y, by { ext, simp only [zip_with_apply, smul_apply, bracket_apply, lie_smul], },
   ..(infer_instance : module R _) }
 


### PR DESCRIPTION
Also unrelated change to use new notation for direct_sum
