### PR TITLE
[Merged by Bors] - feat(group_theory/group_action): generalize `is_algebra_tower`

### DIFF
--- a/src/algebra/module/pi.lean
+++ b/src/algebra/module/pi.lean
@@ -33,12 +33,17 @@ lemma smul_apply' {g : I → Type*} [∀ i, has_scalar (f i) (g i)] (s : Π i, f
   (s • x) i = s i • x i :=
 rfl
 
-instance is_scalar_tower {g : I → Type*} {α : Type*}
+instance is_scalar_tower {α β : Type*}
+  [has_scalar α β] [Π i, has_scalar β $ f i] [Π i, has_scalar α $ f i]
+  [Π i, is_scalar_tower α β (f i)] : is_scalar_tower α β (Π i : I, f i) :=
+⟨λ x y z, funext $ λ i, smul_assoc x y (z i)⟩
+
+instance is_scalar_tower' {g : I → Type*} {α : Type*}
   [Π i, has_scalar α $ f i] [Π i, has_scalar (f i) (g i)] [Π i, has_scalar α $ g i]
   [Π i, is_scalar_tower α (f i) (g i)] : is_scalar_tower α (Π i : I, f i) (Π i : I, g i) :=
 ⟨λ x y z, funext $ λ i, smul_assoc x (y i) (z i)⟩
 
-instance is_scalar_tower' {g : I → Type*} {h : I → Type*}
+instance is_scalar_tower'' {g : I → Type*} {h : I → Type*}
   [Π i, has_scalar (f i) (g i)] [Π i, has_scalar (g i) (h i)] [Π i, has_scalar (f i) (h i)]
   [Π i, is_scalar_tower (f i) (g i) (h i)] : is_scalar_tower (Π i, f i) (Π i, g i) (Π i, h i) :=
 ⟨λ x y z, funext $ λ i, smul_assoc (x i) (y i) (z i)⟩

--- a/src/algebra/module/pi.lean
+++ b/src/algebra/module/pi.lean
@@ -33,6 +33,16 @@ lemma smul_apply' {g : I → Type*} [∀ i, has_scalar (f i) (g i)] (s : Π i, f
   (s • x) i = s i • x i :=
 rfl
 
+instance is_scalar_tower {g : I → Type*} {α : Type*}
+  [Π i, has_scalar α $ f i] [Π i, has_scalar (f i) (g i)] [Π i, has_scalar α $ g i]
+  [Π i, is_scalar_tower α (f i) (g i)] : is_scalar_tower α (Π i : I, f i) (Π i : I, g i) :=
+⟨λ x y z, funext $ λ i, smul_assoc x (y i) (z i)⟩
+
+instance is_scalar_tower' {g : I → Type*} {h : I → Type*}
+  [Π i, has_scalar (f i) (g i)] [Π i, has_scalar (g i) (h i)] [Π i, has_scalar (f i) (h i)]
+  [Π i, is_scalar_tower (f i) (g i) (h i)] : is_scalar_tower (Π i, f i) (Π i, g i) (Π i, h i) :=
+⟨λ x y z, funext $ λ i, smul_assoc (x i) (y i) (z i)⟩
+
 instance mul_action (α) {m : monoid α} [Π i, mul_action α $ f i] :
   @mul_action α (Π i : I, f i) m :=
 { smul := (•),

--- a/src/algebra/module/ulift.lean
+++ b/src/algebra/module/ulift.lean
@@ -21,6 +21,7 @@ namespace ulift
 universes u v w
 variable {R : Type u}
 variable {M : Type v}
+variable {N : Type w}
 
 instance has_scalar [has_scalar R M] :
   has_scalar (ulift R) M :=
@@ -36,6 +37,18 @@ instance has_scalar' [has_scalar R M] :
 lemma smul_down' [has_scalar R M] (s : R) (x : ulift M) :
   (s • x).down = s • x.down :=
 rfl
+
+instance is_scalar_tower [has_scalar R M] [has_scalar M N] [has_scalar R N]
+  [is_scalar_tower R M N] : is_scalar_tower (ulift R) M N :=
+⟨λ x y z, show (x.down • y) • z = x.down • y • z, from smul_assoc _ _ _⟩
+
+instance is_scalar_tower' [has_scalar R M] [has_scalar M N] [has_scalar R N]
+  [is_scalar_tower R M N] : is_scalar_tower R (ulift M) N :=
+⟨λ x y z, show (x • y.down) • z = x • y.down • z, from smul_assoc _ _ _⟩
+
+instance is_scalar_tower'' [has_scalar R M] [has_scalar M N] [has_scalar R N]
+  [is_scalar_tower R M N] : is_scalar_tower R M (ulift N) :=
+⟨λ x y z, show up ((x • y) • z.down) = ⟨x • y • z.down⟩, by rw smul_assoc⟩
 
 instance mul_action [monoid R] [mul_action R M] :
   mul_action (ulift R) M :=

--- a/src/group_theory/group_action.lean
+++ b/src/group_theory/group_action.lean
@@ -91,6 +91,23 @@ by split_ifs; refl
 
 end
 
+section compatible_scalar
+
+variables (R M N : Type*) [has_scalar R M] [has_scalar M N] [has_scalar R N]
+
+/-- An instance of `is_scalar_tower R M N` states that the multiplicative
+action of `R` on `N` is determined by the multiplicative actions of `R` on `M`
+and `M` on `N`. -/
+class is_scalar_tower : Prop :=
+(smul_assoc : ∀ (x : R) (y : M) (z : N), (x • y) • z = x • (y • z))
+
+variables {R M N}
+
+lemma smul_assoc [is_scalar_tower R M N] (x : R) (y : M) (z : N) :
+  (x • y) • z = x • y • z := is_scalar_tower.smul_assoc x y z
+
+end compatible_scalar
+
 namespace mul_action
 
 variables (α) [monoid α]
@@ -102,6 +119,15 @@ def regular : mul_action α α :=
   mul_smul := λ a₁ a₂ a₃, mul_assoc _ _ _, }
 
 variables [mul_action α β]
+
+section regular
+
+local attribute [instance] regular
+
+instance is_scalar_tower.left : is_scalar_tower α α β :=
+⟨λ x y z, mul_smul x y z⟩
+
+end regular
 
 /-- The orbit of an element under an action. -/
 def orbit (b : β) := set.range (λ x : α, x • b)

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -28,17 +28,16 @@ universes u v w u₁
 variables (R : Type u) (S : Type v) (A : Type w) (B : Type u₁)
 
 /-- Typeclass for a tower of three algebras. -/
-class is_algebra_tower [comm_semiring R] [comm_semiring S] [semiring A]
-  [algebra R S] [algebra S A] [algebra R A] : Prop :=
-(smul_assoc : ∀ (x : R) (y : S) (z : A), (x • y) • z = x • (y • z))
+abbreviation is_algebra_tower [comm_semiring R] [comm_semiring S] [semiring A]
+  [algebra R S] [algebra S A] [algebra R A] := is_scalar_tower R S A
 
 namespace is_algebra_tower
 
 section semiring
 variables [comm_semiring R] [comm_semiring S] [semiring A] [semiring B]
 variables [algebra R S] [algebra S A] [algebra R A] [algebra S B] [algebra R B]
-
 variables {R S A}
+
 theorem of_algebra_map_eq (h : ∀ x, algebra_map R A x = algebra_map S A (algebra_map R S x)) :
   is_algebra_tower R S A :=
 ⟨λ x y z, by simp_rw [algebra.smul_def, ring_hom.map_mul, mul_assoc, h]⟩
@@ -95,9 +94,6 @@ def restrict_base (f : A →ₐ[S] B) : A →ₐ[R] B :=
   .. (f : A →+* B) }
 
 @[simp] lemma restrict_base_apply (f : A →ₐ[S] B) (x : A) : restrict_base R f x = f x := rfl
-
-instance left : is_algebra_tower S S A :=
-of_algebra_map_eq $ λ x, rfl
 
 instance right : is_algebra_tower R S S :=
 of_algebra_map_eq $ λ x, rfl
@@ -272,7 +268,7 @@ theorem smul_mem_span_smul_of_mem {s : set S} {t : set A} {k : S} (hks : k ∈ s
 span_induction hks (λ c hc, subset_span $ set.mem_smul.2 ⟨c, x, hc, hx, rfl⟩)
   (by { rw zero_smul, exact zero_mem _ })
   (λ c₁ c₂ ih₁ ih₂, by { rw add_smul, exact add_mem _ ih₁ ih₂ })
-  (λ b c hc, by { rw is_algebra_tower.smul_assoc, exact smul_mem _ _ hc })
+  (λ b c hc, by { rw is_scalar_tower.smul_assoc, exact smul_mem _ _ hc })
 
 theorem smul_mem_span_smul {s : set S} (hs : span R s = ⊤) {t : set A} {k : S}
   {x : A} (hx : x ∈ span R t) :
@@ -324,7 +320,7 @@ begin
     { rw ← hsg, exact (finset.sum_subset finset.subset_product $ λ p _ hp,
         show g p • b p.1 • c p.2 = 0, by rw [hg p hp, zero_smul]).symm },
     rw [finset.sum_product, finset.sum_comm] at h1,
-    simp_rw [← is_algebra_tower.smul_assoc, ← finset.sum_smul] at h1,
+    simp_rw [← is_scalar_tower.smul_assoc, ← finset.sum_smul] at h1,
     exact hb _ _ (hc _ _ h1 k (finset.mem_image_of_mem _ hik)) i (finset.mem_image_of_mem _ hik) },
   exact hg _ hik
 end

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -268,7 +268,7 @@ theorem smul_mem_span_smul_of_mem {s : set S} {t : set A} {k : S} (hks : k ∈ s
 span_induction hks (λ c hc, subset_span $ set.mem_smul.2 ⟨c, x, hc, hx, rfl⟩)
   (by { rw zero_smul, exact zero_mem _ })
   (λ c₁ c₂ ih₁ ih₂, by { rw add_smul, exact add_mem _ ih₁ ih₂ })
-  (λ b c hc, by { rw is_scalar_tower.smul_assoc, exact smul_mem _ _ hc })
+  (λ b c hc, by { rw smul_assoc, exact smul_mem _ _ hc })
 
 theorem smul_mem_span_smul {s : set S} (hs : span R s = ⊤) {t : set A} {k : S}
   {x : A} (hx : x ∈ span R t) :
@@ -320,7 +320,7 @@ begin
     { rw ← hsg, exact (finset.sum_subset finset.subset_product $ λ p _ hp,
         show g p • b p.1 • c p.2 = 0, by rw [hg p hp, zero_smul]).symm },
     rw [finset.sum_product, finset.sum_comm] at h1,
-    simp_rw [← is_scalar_tower.smul_assoc, ← finset.sum_smul] at h1,
+    simp_rw [← smul_assoc, ← finset.sum_smul] at h1,
     exact hb _ _ (hc _ _ h1 k (finset.mem_image_of_mem _ hik)) i (finset.mem_image_of_mem _ hik) },
   exact hg _ hik
 end

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -130,7 +130,7 @@ le_antisymm (smul_le.2 $ λ r hrij n hn, let ⟨ri, hri, rj, hrj, hrijr⟩ := me
 (sup_le (smul_mono_left le_sup_left)
   (smul_mono_left le_sup_right))
 
-theorem smul_assoc : (I • J) • N = I • (J • N) :=
+protected theorem smul_assoc : (I • J) • N = I • (J • N) :=
 le_antisymm (smul_le.2 $ λ rs hrsij t htn,
   smul_induction_on hrsij
   (λ r hr s hs, (@smul_eq_mul R _ r s).symm ▸ smul_smul r s t ▸ smul_mem_smul hr (smul_mem_smul hs htn))
@@ -869,7 +869,7 @@ variables [comm_ring R] [add_comm_group M] [module R M]
 instance semimodule_submodule : semimodule (ideal R) (submodule R M) :=
 { smul_add := smul_sup,
   add_smul := sup_smul,
-  mul_smul := smul_assoc,
+  mul_smul := submodule.smul_assoc,
   one_smul := by simp,
   zero_smul := bot_smul,
   smul_zero := smul_bot }


### PR DESCRIPTION
This PR introduces a new typeclass `is_scalar_tower R M N` stating that scalar multiplications between the three types are compatible: `smul_assoc : ((x : R) • (y : M)) • (z : N) = x • (y • z)`.
This typeclass is the general form of `is_algebra_tower`. It also generalizes some of the existing instances of `is_algebra_tower`. I didn't try very hard though, so I might have missed some instances.

Related Zulip discussions:
 * https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/Effect.20of.20changing.20the.20base.20field.20on.20span
 * https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/pull.20back.20an.20R.20module.20along.20.60S.20-.3E.2B*.20R.60


---
<!-- put comments you want to keep out of the PR commit here -->
