### PR TITLE
[Merged by Bors] - doc(tactic/lean_core_docs): by_cases is classical

### DIFF
--- a/src/tactic/lean_core_docs.lean
+++ b/src/tactic/lean_core_docs.lean
@@ -109,11 +109,6 @@ add_tactic_doc
 `by_cases p` splits the main goal into two cases, assuming `h : p` in the first branch, and
 `h : ¬ p` in the second branch. You can specify the name of the new hypothesis using the syntax
 `by_cases h : p`.
-
-This tactic requires that `p` is decidable. To ensure that all propositions are decidable via
-classical reasoning, use `open_locale classical`
-(or `local attribute [instance, priority 10] classical.prop_decidable` if you are not using
-mathlib).
 -/
 add_tactic_doc
 { name       := "by_cases",

--- a/src/tactic/lean_core_docs.lean
+++ b/src/tactic/lean_core_docs.lean
@@ -109,6 +109,8 @@ add_tactic_doc
 `by_cases p` splits the main goal into two cases, assuming `h : p` in the first branch, and
 `h : ¬ p` in the second branch. You can specify the name of the new hypothesis using the syntax
 `by_cases h : p`.
+
+If `p` is not already decidable, `by_cases` will use the instance `classical.prop_decidable p`.
 -/
 add_tactic_doc
 { name       := "by_cases",


### PR DESCRIPTION
`by_cases` was changed to use classical reasoning (leanprover-community/mathlib#3354, leanprover-community/lean#409), but the documentation hasn't been updated yet.

I leave `by_contra` alone as it still uses `decidable`.


---

As discussed in https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/if-then-else.20needs.20.5Bdecidable.5D.20but.20by_cases.20doesn't!.3F
