### PR TITLE
[Merged by Bors] - feat(linear_algebra/finite_dimensional): finite dimensional `is_basis` helpers

### DIFF
--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -2018,7 +2018,7 @@ variables [semiring R] [add_comm_monoid M] [semimodule R M]
 /-- If `s ≤ t`, then we can view `s` as a submodule of `t` by taking the comap
 of `t.subtype`. -/
 def comap_subtype_equiv_of_le {p q : submodule R M} (hpq : p ≤ q) :
-p.comap q.subtype ≃ₗ[R] p :=
+comap q.subtype p ≃ₗ[R] p :=
 { to_fun := λ x, ⟨x, x.2⟩,
   inv_fun := λ x, ⟨⟨x, hpq x.2⟩, x.2⟩,
   left_inv := λ x, by simp only [coe_mk, submodule.eta, coe_coe],

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -955,6 +955,13 @@ semimodule.of_core $ by refine {smul := (•), ..};
   repeat {rintro ⟨⟩ <|> intro}; simp [smul_add, add_smul, smul_smul,
     -mk_add, (mk_add p).symm, -mk_smul, (mk_smul p).symm]
 
+lemma nontrivial_of_lt_top (h : p < ⊤) : nontrivial (p.quotient) :=
+begin
+  obtain ⟨x, _, not_mem_s⟩ := exists_of_lt h,
+  refine ⟨⟨mk x, 0, _⟩⟩,
+  simpa using not_mem_s
+end
+
 end quotient
 
 lemma quot_hom_ext ⦃f g : quotient p →ₗ[R] M₂⦄ (h : ∀ x, f (quotient.mk x) = g (quotient.mk x)) :
@@ -2003,6 +2010,23 @@ end field
 end linear_equiv
 
 namespace submodule
+
+section semimodule
+
+variables [semiring R] [add_comm_monoid M] [semimodule R M]
+
+/-- If `s ≤ t`, then we can view `s` as a submodule of `t` by taking the comap
+of `t.subtype`. -/
+def comap_subtype_equiv_of_le {p q : submodule R M} (hpq : p ≤ q) :
+p.comap q.subtype ≃ₗ[R] p :=
+{ to_fun := λ x, ⟨x, x.2⟩,
+  inv_fun := λ x, ⟨⟨x, hpq x.2⟩, x.2⟩,
+  left_inv := λ x, by simp only [coe_mk, submodule.eta, coe_coe],
+  right_inv := λ x, by simp only [subtype.coe_mk, submodule.eta, coe_coe],
+  map_add' := λ x y, rfl,
+  map_smul' := λ c x, rfl }
+
+end semimodule
 
 variables [ring R] [add_comm_group M] [module R M]
 variables (p : submodule R M)

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -245,6 +245,10 @@ begin
   exact fintype_card_le_findim_of_linear_independent h,
 end
 
+/-- A finite dimensional space has positive `findim` iff it has a nonzero element. -/
+lemma findim_pos_iff_exists_ne_zero [finite_dimensional K V] : 0 < findim K V ↔ ∃ x : V, x ≠ 0 :=
+iff.trans (by { rw ← findim_eq_dim, norm_cast }) (@dim_pos_iff_exists_ne_zero K V _ _ _)
+
 /-- A finite dimensional space has positive `findim` iff it is nontrivial. -/
 lemma findim_pos_iff [finite_dimensional K V] : 0 < findim K V ↔ nontrivial V :=
 iff.trans (by { rw ← findim_eq_dim, norm_cast }) (@dim_pos_iff_nontrivial K V _ _ _)

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -670,7 +670,7 @@ namespace submodule
 lemma findim_mono [finite_dimensional K V] :
   monotone (λ (s : submodule K V), findim K s) :=
 λ s t hst,
-calc findim K s = findim K (s.comap t.subtype)
+calc findim K s = findim K (comap t.subtype s)
   : linear_equiv.findim_eq (comap_subtype_equiv_of_le hst).symm
 ... ≤ findim K t : submodule.findim_le _
 


### PR DESCRIPTION
If we have a family of vectors in `V` with cardinality equal to the (finite) dimension of `V` over a field `K`, they span the whole space iff they are linearly independent.
This PR proves those two facts (in the form that either of the conditions of `is_basis K b` suffices to prove `is_basis K b` if `b` has the right cardinality).

We don't need to assume that `V` is finite dimensional, because the case that `findim K V = 0` will generally lead to a contradiction. We do sometimes need to assume that the family is nonempty, which seems like a much nicer condition.

---
<!-- put comments you want to keep out of the PR commit here -->
