### PR TITLE
[Merged by Bors] - feat(data/list/palindrome): define palindromes

### DIFF
--- a/src/data/list/palindrome.lean
+++ b/src/data/list/palindrome.lean
@@ -42,10 +42,10 @@ inductive palindrome : list α → Prop
 
 namespace palindrome
 
-lemma to_reverse_eq {l : list α} (p : palindrome l) : reverse l = l :=
+lemma reverse_eq {l : list α} (p : palindrome l) : reverse l = l :=
 palindrome.rec_on p rfl (λ _, rfl) (λ x l p h, by simp [h])
 
-lemma reverse_eq {l : list α} : reverse l = l → palindrome l :=
+lemma of_reverse_eq {l : list α} : reverse l = l → palindrome l :=
 begin
   refine bidirectional_rec_on l (λ _, palindrome.nil) (λ a _, palindrome.singleton a) _,
   intros x l y hp hr,
@@ -56,9 +56,9 @@ begin
 end
 
 lemma iff_reverse_eq {l : list α} : palindrome l ↔ reverse l = l :=
-iff.intro to_reverse_eq reverse_eq
+iff.intro reverse_eq of_reverse_eq
 
 lemma append_reverse (l : list α) : palindrome (l ++ reverse l) :=
-by { apply reverse_eq, rw [reverse_append, reverse_reverse] }
+by { apply of_reverse_eq, rw [reverse_append, reverse_reverse] }
 
 end palindrome

--- a/src/data/list/palindrome.lean
+++ b/src/data/list/palindrome.lean
@@ -45,7 +45,7 @@ namespace palindrome
 lemma to_reverse_eq {l : list α} (p : palindrome l) : reverse l = l :=
 palindrome.rec_on p rfl (λ _, rfl) (λ x l p h, by simp [h])
 
-lemma of_reverse_eq {l : list α} : reverse l = l → palindrome l :=
+lemma reverse_eq {l : list α} : reverse l = l → palindrome l :=
 begin
   refine bidirectional_rec_on l (λ _, palindrome.nil) (λ a _, palindrome.singleton a) _,
   intros x l y hp hr,
@@ -56,9 +56,9 @@ begin
 end
 
 lemma iff_reverse_eq {l : list α} : palindrome l ↔ reverse l = l :=
-iff.intro to_reverse_eq of_reverse_eq
+iff.intro to_reverse_eq reverse_eq
 
-lemma of_append_reverse (l : list α) : palindrome (l ++ reverse l) :=
-by { apply of_reverse_eq, rw [reverse_append, reverse_reverse] }
+lemma append_reverse (l : list α) : palindrome (l ++ reverse l) :=
+by { apply reverse_eq, rw [reverse_append, reverse_reverse] }
 
 end palindrome

--- a/src/data/list/palindrome.lean
+++ b/src/data/list/palindrome.lean
@@ -61,7 +61,7 @@ iff.intro reverse_eq of_reverse_eq
 lemma append_reverse (l : list α) : palindrome (l ++ reverse l) :=
 by { apply of_reverse_eq, rw [reverse_append, reverse_reverse] }
 
-instance (l : list α) : decidable (palindrome l) :=
+instance [decidable_eq α] (l : list α) : decidable (palindrome l) :=
 decidable_of_iff _ iff_reverse_eq.symm
 
 end palindrome

--- a/src/data/list/palindrome.lean
+++ b/src/data/list/palindrome.lean
@@ -45,9 +45,8 @@ namespace palindrome
 lemma to_reverse_eq {l : list α} (p : palindrome l) : reverse l = l :=
 palindrome.rec_on p rfl (λ _, rfl) (λ x l p h, by simp [h])
 
-lemma of_reverse_eq {l : list α} (h : reverse l = l) : palindrome l :=
+lemma of_reverse_eq {l : list α} : reverse l = l → palindrome l :=
 begin
-  suffices : reverse l = l → palindrome l, from this h,
   refine bidirectional_rec_on l (λ _, palindrome.nil) (λ a _, palindrome.singleton a) _,
   intros x l y hp hr,
   rw [reverse_cons, reverse_append] at hr,

--- a/src/data/list/palindrome.lean
+++ b/src/data/list/palindrome.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2020 Google LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Wong
+-/
+
+import data.list.basic
+open list
+
+/-!
+# Palindromes
+
+This module defines *palindromes*, lists which are equal to their reverse.
+
+The main result is the `palindrome` inductive type, and its associated `palindrome.rec_on` induction
+principle. Also provided are conversions to and from other equivalent definitions.
+
+## References
+
+* [Pierre Castéran, *On palindromes*][casteran]
+
+[casteran]: https://www.labri.fr/perso/casteran/CoqArt/inductive-prop-chap/palindrome.html
+
+## Tags
+
+palindrome, reverse, induction
+-/
+
+variables {α : Type*}
+
+/--
+`palindrome l` asserts that `l` is a palindrome. This is defined inductively:
+
+* The empty list is a palindrome;
+* A list with one element is a palindrome;
+* Adding the same element to both ends of a palindrome results in a bigger palindrome.
+-/
+inductive palindrome : list α → Prop
+| nil : palindrome []
+| singleton : ∀ x, palindrome [x]
+| cons_concat : ∀ x {l}, palindrome l → palindrome (x :: (l ++ [x]))
+
+namespace palindrome
+
+lemma to_reverse_eq {l : list α} (p : palindrome l) : reverse l = l :=
+palindrome.rec_on p rfl (λ _, rfl) (λ x l p h, by simp [h])
+
+lemma of_reverse_eq {l : list α} (h : reverse l = l) : palindrome l :=
+begin
+  suffices : reverse l = l → palindrome l, from this h,
+  refine bidirectional_rec_on l (λ _, palindrome.nil) (λ a _, palindrome.singleton a) _,
+  intros x l y hp hr,
+  rw [reverse_cons, reverse_append] at hr,
+  rw head_eq_of_cons_eq hr,
+  have : palindrome l, from hp (append_inj_left' (tail_eq_of_cons_eq hr) rfl),
+  exact palindrome.cons_concat x this
+end
+
+lemma iff_reverse_eq {l : list α} : palindrome l ↔ reverse l = l :=
+iff.intro to_reverse_eq of_reverse_eq
+
+lemma of_append_reverse (l : list α) : palindrome (l ++ reverse l) :=
+by { apply of_reverse_eq, rw [reverse_append, reverse_reverse] }
+
+end palindrome

--- a/src/data/list/palindrome.lean
+++ b/src/data/list/palindrome.lean
@@ -61,4 +61,7 @@ iff.intro reverse_eq of_reverse_eq
 lemma append_reverse (l : list α) : palindrome (l ++ reverse l) :=
 by { apply of_reverse_eq, rw [reverse_append, reverse_reverse] }
 
+instance (l : list α) : decidable (palindrome l) :=
+decidable_of_iff _ iff_reverse_eq.symm
+
 end palindrome


### PR DESCRIPTION
This introduces an inductive type `palindrome`, with conversions to and from the proposition `reverse l = l`.

Review of this PR indicates two things: (1) maybe the name `is_palindrome` is better, especially if we define the subtype of palindromic lists; (2) maybe defining palindrome by `reverse l = l` is simpler. We note these for future development.

---

I'm using this to prove that every Fibonacci word contains a palindrome – see [`palindrome_tail_fibword_morph`](https://github.com/leanprover-community/mathlib/blob/15055f2bffdd81590aad1626f260f6b81db10427/src/data/list/fibword.lean#L55-L75) and [`palindrome_fibword`](https://github.com/leanprover-community/mathlib/blob/15055f2bffdd81590aad1626f260f6b81db10427/src/data/list/fibword.lean#L111-L128).