### PR TITLE
[Merged by Bors] - feat(tactic/rcases): type ascriptions in rcases

### DIFF
--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -31,7 +31,7 @@ lemma tendsto_at_top_mul_left [decidable_linear_ordered_semiring α] [archimedea
   tendsto (λx, r * f x) l at_top :=
 begin
   apply (tendsto_at_top _ _).2 (λb, _),
-  obtain ⟨n, hn⟩ : ∃ (n : ℕ), (1 : α) ≤ n • r := archimedean.arch 1 hr,
+  obtain ⟨n : ℕ, hn : 1 ≤ n •ℕ r⟩ := archimedean.arch 1 hr,
   have hn' : 1 ≤ r * n, by rwa nsmul_eq_mul' at hn,
   filter_upwards [(tendsto_at_top _ _).1 hf (n * max b 0)],
   assume x hx,
@@ -50,7 +50,7 @@ lemma tendsto_at_top_mul_right [decidable_linear_ordered_semiring α] [archimede
   tendsto (λx, f x * r) l at_top :=
 begin
   apply (tendsto_at_top _ _).2 (λb, _),
-  obtain ⟨n, hn⟩ : ∃ (n : ℕ), (1 : α) ≤ n • r := archimedean.arch 1 hr,
+  obtain ⟨n : ℕ, hn : 1 ≤ n •ℕ r⟩ := archimedean.arch 1 hr,
   have hn' : 1 ≤ (n : α) * r, by rwa nsmul_eq_mul at hn,
   filter_upwards [(tendsto_at_top _ _).1 hf (max b 0 * n)],
   assume x hx,

--- a/src/data/nat/digits.lean
+++ b/src/data/nat/digits.lean
@@ -172,7 +172,7 @@ begin
     cases m, },
   { intros l m,
     dsimp [of_digits] at w,
-    rcases m with rfl,
+    rcases m with ⟨rfl⟩,
     { convert nat.eq_zero_of_add_eq_zero_right w, simp, },
     { exact ih ((nat.mul_right_inj h).mp (nat.eq_zero_of_add_eq_zero_left w)) _ m, }, }
 end

--- a/src/data/pnat/factors.lean
+++ b/src/data/pnat/factors.lean
@@ -210,7 +210,7 @@ theorem factor_multiset_prod (v : prime_multiset) :
 begin
   apply prime_multiset.coe_nat_injective,
   rw [v.prod.coe_nat_factor_multiset, prime_multiset.coe_prod],
-  rcases v with l,
+  rcases v with ⟨l⟩,
   unfold_coes,
   dsimp [prime_multiset.to_nat_multiset],
   rw [multiset.coe_prod],

--- a/src/tactic/ext.lean
+++ b/src/tactic/ext.lean
@@ -365,7 +365,7 @@ attribute [ext] has_zero
 
 namespace tactic
 
-meta def try_intros : ext_patt → tactic ext_patt
+meta def try_intros : list rcases_patt → tactic (list rcases_patt)
 | [] := try intros $> []
 | (x::xs) :=
 do tgt ← target >>= whnf,
@@ -373,7 +373,7 @@ do tgt ← target >>= whnf,
      then rintro [x] >> try_intros xs
      else pure (x :: xs)
 
-meta def ext1 (xs : ext_patt) (cfg : apply_cfg := {}) : tactic ext_patt :=
+meta def ext1 (xs : list rcases_patt) (cfg : apply_cfg := {}) : tactic (list rcases_patt) :=
 do subject ← target >>= get_ext_subject,
    m ← get_ext_lemmas,
    do { rule ← m.find subject,
@@ -383,7 +383,7 @@ do subject ← target >>= get_ext_subject,
      fail format!"no applicable extensionality rule found for {subject}",
    try_intros xs
 
-meta def ext : ext_patt → option ℕ → tactic unit
+meta def ext : list rcases_patt → option ℕ → tactic unit
 | _  (some 0) := skip
 | xs n        := focus1 $ do
   ys ← ext1 xs, try (ext ys (nat.pred <$> n))
@@ -398,7 +398,7 @@ local postfix *:9001 := many
 introduced by the lemma. If `id` is omitted, the local constant is
 named automatically, as per `intro`.
 -/
-meta def interactive.ext1 (xs : parse ext_parse) : tactic unit :=
+meta def interactive.ext1 (xs : parse (rcases_patt_parse tt)*) : tactic unit :=
 ext1 xs $> ()
 
 /--
@@ -450,7 +450,8 @@ by applying functional extensionality and destructing the introduced pair.
 
 A maximum depth can be provided with `ext x y z : 3`.
 -/
-meta def interactive.ext : parse ext_parse → parse (tk ":" *> small_nat)? → tactic unit
+meta def interactive.ext :
+  parse (rcases_patt_parse tt)* → parse (tk ":" *> small_nat)? → tactic unit
  | [] (some n) := iterate_range 1 n (ext1 [] $> ())
  | [] none     := repeat1 (ext1 [] $> ())
  | xs n        := tactic.ext xs n

--- a/src/tactic/lift.lean
+++ b/src/tactic/lift.lean
@@ -112,7 +112,7 @@ do
   temp_e ← note temp_nm none prf_ex,
   dsimp_hyp temp_e s to_unfold {},
   /- We case on the existential. We use `rcases` because `eq_nm` could be `rfl`. -/
-  rcases none (pexpr.of_expr temp_e) [[rcases_patt.one new_nm, rcases_patt.one eq_nm]],
+  rcases none (pexpr.of_expr temp_e) $ rcases_patt.tuple ([new_nm, eq_nm].map rcases_patt.one),
   /- If the lifted variable is not a local constant, try to rewrite it away using the new equality-/
   when (¬ e.is_local_constant) (get_local eq_nm >>=
     λ e, interactive.rw ⟨[⟨⟨0, 0⟩, tt, (pexpr.of_expr e)⟩], none⟩ interactive.loc.wildcard),

--- a/src/tactic/rcases.lean
+++ b/src/tactic/rcases.lean
@@ -5,7 +5,6 @@ Authors: Mario Carneiro
 -/
 import data.dlist
 import tactic.core
-import tactic.lint
 
 /-!
 

--- a/src/tactic/rcases.lean
+++ b/src/tactic/rcases.lean
@@ -201,7 +201,8 @@ with rcases_core : rcases_patt → expr → tactic goals
   unify t ty,
   t ← instantiate_mvars t,
   ty ← instantiate_mvars ty,
-  monad.unlessb (t =ₐ ty) (change_core ty (some e)),
+  e ← if t =ₐ ty then pure e else
+    change_core ty (some e) >> get_local e.local_pp_name,
   rcases_core p e
 | (rcases_patt.alts [p]) e := rcases_core p e
 | pat e := do

--- a/src/tactic/rcases.lean
+++ b/src/tactic/rcases.lean
@@ -175,9 +175,10 @@ with rcases_core : rcases_patt → expr → tactic goals
 | (rcases_patt.one _) _ := get_goals
 | (rcases_patt.typed p ty) e := do
   (t, e) ← get_local_and_type e,
-  ty2 ← infer_type e,
   ty ← i_to_expr_no_subgoals ``(%%ty : Sort*),
   unify t ty,
+  t ← instantiate_mvars t,
+  ty ← instantiate_mvars ty,
   monad.unlessb (t =ₐ ty) (change_core ty (some e)),
   rcases_core p e
 | (rcases_patt.alts [p]) e := rcases_core p e

--- a/src/tactic/rcases.lean
+++ b/src/tactic/rcases.lean
@@ -5,12 +5,61 @@ Authors: Mario Carneiro
 -/
 import data.dlist
 import tactic.core
+import tactic.lint
+
+/-!
+
+# Recursive cases (`rcases`) tactic and related tactics
+
+`rcases` is a tactic that will perform `cases` recursively, according to a pattern. It is used to
+destructure hypotheses or expressions composed of inductive types like `h1 : a ∧ b ∧ c ∨ d` or
+`h2 : ∃ x y, trans_rel R x y`. Usual usage might be `rcases h1 with ⟨ha, hb, hc⟩ | hd` or
+`rcases h2 with ⟨x, y, _ | ⟨z, hxz, hzy⟩⟩` for these examples.
+
+Each element of an `rcases` pattern is matched against a particular local hypothesis (most of which
+are generated during the execution of `rcases` and represent individual elements destructured from
+the input expression). An `rcases` pattern has the following grammar:
+
+* A name like `x`, which names the active hypothesis as `x`.
+* A blank `_`, which does nothing (letting the automatic naming system used by `cases` name the
+  hypothesis).
+* The keyword `rfl`, which expects the hypothesis to be `h : a = b`, and calls `subst` on the
+  hypothesis (which has the effect of replacing `b` with `a` everywhere or vice versa).
+* A type ascription `p : ty`, which sets the type of the hypothesis to `ty` and then matches it
+  against `p`. (Of course, `ty` must unify with the actual type of `h` for this to work.)
+* A tuple pattern `⟨p1, p2, p3⟩`, which matches a constructor with many arguments, or a series
+  of nested conjunctions or existentials. For example if the active hypothesis is `a ∧ b ∧ c`,
+  then the conjunction will be destructured, and `p1` will be matched against `a`, `p2` against `b`
+  and so on.
+* An alteration pattern `p1 | p2 | p3`, which matches an inductive type with multiple constructors,
+  or a nested disjunction like `a ∨ b ∨ c`.
+
+The patterns are fairly liberal about the exact shape of the constructors, and will insert
+additional alternation branches and tuple arguments if there are not enough arguments provided, and
+reuse the tail for further matches if there are too many arguments provided to alternation and
+tuple patterns.
+
+This file also contains the `obtain` and `rintro` tactics, which use the same syntax of `rcases`
+patterns but with a slightly different use case:
+
+* `rintro` (or `rintros`) is used like `rintro x ⟨y, z⟩` and is the same as `intros` followed by
+  `rcases` on the newly introduced arguments.
+* `obtain` is the same as `rcases` but with a syntax styled after `have` rather than `cases`.
+  `obtain ⟨hx, hy⟩ | hz := foo` is equivalent to `rcases foo with ⟨hx, hy⟩ | hz`. Unlike `rcases`,
+  `obtain` also allows one to omit `:= foo`, although a type must be provided in this case,
+  as in `obtain ⟨hx, hy⟩ | hz : a ∧ b ∨ c`, in which case it produces a subgoal for proving
+  `a ∧ b ∨ c` in addition to the subgoals `hx : a, hy : b |- goal` and `hz : c |- goal`.
+
+## Tags
+
+rcases, rintro, obtain, destructuring, cases, pattern matching, match
+-/
 
 open lean lean.parser
 
 namespace tactic
 
-/-
+/-!
 These synonyms for `list` are used to clarify the meanings of the many
 usages of lists in this module.
 
@@ -26,11 +75,17 @@ by the compiler.
 The `def`/`local notation` combination makes Lean retain these
 annotations in reported types.
 -/
+
+/-- A list, with a disjunctive meaning (like a list of inductive constructors, or subgoals) -/
 @[reducible] def list_Sigma := list
+
+/-- A list, with a conjunctive meaning (like a list of constructor arguments, or hypotheses) -/
 @[reducible] def list_Pi := list
+
 local notation `listΣ` := list_Sigma
 local notation `listΠ` := list_Pi
 
+/-- A list of metavariables representing subgoals. -/
 @[reducible] meta def goals := list expr
 
 /--
@@ -58,134 +113,182 @@ meta inductive rcases_patt : Type
 | tuple : listΠ rcases_patt → rcases_patt
 | alts : listΣ rcases_patt → rcases_patt
 
-meta instance rcases_patt.inhabited : inhabited rcases_patt :=
-⟨rcases_patt.one `_⟩
+namespace rcases_patt
+meta instance inhabited : inhabited rcases_patt :=
+⟨one `_⟩
 
-meta def rcases_patt.name : rcases_patt → option name
-| (rcases_patt.one n) := some n
-| (rcases_patt.typed p _) := p.name
-| (rcases_patt.alts [p]) := p.name
+/-- Get the name from a pattern, if provided -/
+meta def name : rcases_patt → option name
+| (one `_) := none
+| (one `rfl) := none
+| (one n) := some n
+| (typed p _) := p.name
+| (alts [p]) := p.name
 | _ := none
 
-meta def rcases_patt.as_tuple : rcases_patt → listΠ rcases_patt
-| (rcases_patt.tuple ps) := ps
+/-- Interpret an rcases pattern as a tuple, where `p` becomes `⟨p⟩`
+if `p` is not already a tuple. -/
+meta def as_tuple : rcases_patt → listΠ rcases_patt
+| (tuple ps) := ps
 | p := [p]
 
-meta def rcases_patt.as_alts : rcases_patt → listΣ rcases_patt
-| (rcases_patt.alts ps) := ps
+/-- Interpret an rcases pattern as an alternation, where non-alternations are treated as one
+alternative. -/
+meta def as_alts : rcases_patt → listΣ rcases_patt
+| (alts ps) := ps
 | p := [p]
 
-meta def rcases_patt.tuple' : listΠ rcases_patt → rcases_patt
+/-- Convert a list of patterns to a tuple pattern, but mapping `[p]` to `p` instead of `⟨p⟩`. -/
+meta def tuple' : listΠ rcases_patt → rcases_patt
 | [p] := p
-| ps := rcases_patt.tuple ps
+| ps := tuple ps
 
-meta def rcases_patt.alts' : listΣ rcases_patt → rcases_patt
+/-- Convert a list of patterns to an alternation pattern, but mapping `[p]` to `p` instead of
+a unary alternation `|p`. -/
+meta def alts' : listΣ rcases_patt → rcases_patt
 | [p] := p
-| ps := rcases_patt.alts ps
+| ps := alts ps
 
-meta def rcases_patt.tuple₁_core : listΠ rcases_patt → listΠ rcases_patt
+/-- This function is used for producing rcases patterns based on a case tree. Suppose that we have
+a list of patterns `ps` that will match correctly against the branches of the case tree for one
+constructor. This function will merge tuples at the end of the list, so that `[a, b, ⟨c, d⟩]`
+becomes `⟨a, b, c, d⟩` instead of `⟨a, b, ⟨c, d⟩⟩`.
+
+We must be careful to turn `[a, ⟨⟩]` into `⟨a, ⟨⟩⟩` instead of `⟨a⟩` (which will not perform the
+nested match). -/
+meta def tuple₁_core : listΠ rcases_patt → listΠ rcases_patt
 | [] := []
-| [rcases_patt.tuple []] := [rcases_patt.tuple []]
-| [rcases_patt.tuple ps] := ps
-| (p :: ps) := p :: rcases_patt.tuple₁_core ps
+| [tuple []] := [tuple []]
+| [tuple ps] := ps
+| (p :: ps) := p :: tuple₁_core ps
 
-meta def rcases_patt.tuple₁ : listΠ rcases_patt → rcases_patt
+/-- This function is used for producing rcases patterns based on a case tree. This is like
+`tuple₁_core` but it produces a pattern instead of a tuple pattern list, converting `[n]` to `n`
+instead of `⟨n⟩` and `[]` to `_`, and otherwise just converting `[a, b, c]` to `⟨a, b, c⟩`. -/
+meta def tuple₁ : listΠ rcases_patt → rcases_patt
 | [] := default _
-| [rcases_patt.one n] := rcases_patt.one n
-| ps := rcases_patt.tuple (rcases_patt.tuple₁_core ps)
+| [one n] := one n
+| ps := tuple (tuple₁_core ps)
 
-meta def rcases_patt.alts₁_core : listΣ (listΠ rcases_patt) → listΣ rcases_patt
+/-- This function is used for producing rcases patterns based on a case tree. Here we are given
+the list of patterns to apply to each argument of each constructor after the main case, and must
+produce a list of alternatives with the same effect. This function calls `tuple₁` to make the
+individual alternatives, and handles merging `[a, b, c | d]` to `a | b | c | d` instead of
+`a | b | (c | d)`. -/
+meta def alts₁_core : listΣ (listΠ rcases_patt) → listΣ rcases_patt
 | [] := []
-| [[rcases_patt.alts ps]] := ps
-| (p :: ps) := rcases_patt.tuple₁ p :: rcases_patt.alts₁_core ps
+| [[alts ps]] := ps
+| (p :: ps) := tuple₁ p :: alts₁_core ps
 
-meta def rcases_patt.alts₁ : listΣ (listΠ rcases_patt) → rcases_patt
-| [[]] := rcases_patt.tuple []
-| [[rcases_patt.alts ps]] := rcases_patt.tuple [rcases_patt.alts ps]
-| ps := rcases_patt.alts' (rcases_patt.alts₁_core ps)
+/-- This function is used for producing rcases patterns based on a case tree. This is like
+`alts₁_core`, but it produces a cases pattern directly instead of a list of alternatives. We
+specially translate the empty alternation to `⟨⟩`, and translate `|(a | b)` to `⟨a | b⟩` (because we
+don't have any syntax for unary alternation). Otherwise we can use the regular merging of
+alternations at the last argument so that `a | b | (c | d)` becomes `a | b | c | d`. -/
+meta def alts₁ : listΣ (listΠ rcases_patt) → rcases_patt
+| [[]] := tuple []
+| [[alts ps]] := tuple [alts ps]
+| ps := alts' (alts₁_core ps)
 
-meta instance rcases_patt.has_reflect : has_reflect rcases_patt
-| (rcases_patt.one n) := `(_)
-| (rcases_patt.typed l e) :=
-  (`(rcases_patt.typed).subst (rcases_patt.has_reflect l)).subst (reflect e)
-| (rcases_patt.tuple l) := `(λ l, rcases_patt.tuple l).subst $
-  by haveI := rcases_patt.has_reflect; exact list.reflect l
-| (rcases_patt.alts l) := `(λ l, rcases_patt.alts l).subst $
-  by haveI := rcases_patt.has_reflect; exact list.reflect l
+meta instance has_reflect : has_reflect rcases_patt
+| (one n) := `(_)
+| (typed l e) :=
+  (`(typed).subst (has_reflect l)).subst (reflect e)
+| (tuple l) := `(λ l, tuple l).subst $
+  by haveI := has_reflect; exact list.reflect l
+| (alts l) := `(λ l, alts l).subst $
+  by haveI := has_reflect; exact list.reflect l
 
-meta def rcases_patt.format : bool → rcases_patt → tactic format
-| _ (rcases_patt.one n) := pure $ to_fmt n
-| _ (rcases_patt.tuple []) := pure "⟨⟩"
-| _ (rcases_patt.tuple ls) := do
-  fs ← ls.mmap $ rcases_patt.format ff,
-  pure $ "⟨" ++ format.group (format.nest 1 $
-    format.join $ list.intersperse ("," ++ format.line) fs) ++ "⟩"
-| br (rcases_patt.alts ls) := do
-  fs ← ls.mmap $ rcases_patt.format tt,
-  let fmt := format.join $ list.intersperse (↑" |" ++ format.space) fs,
-  pure $ if br then format.bracket "(" ")" fmt else fmt
-| br (rcases_patt.typed p e) := do
-  fp ← rcases_patt.format ff p,
+/-- Formats an `rcases` pattern. -/
+protected meta def format : bool → rcases_patt → tactic _root_.format
+| _ (one n) := pure $ to_fmt n
+| _ (tuple []) := pure "⟨⟩"
+| _ (tuple ls) := do
+  fs ← ls.mmap $ format ff,
+  pure $ "⟨" ++ _root_.format.group (_root_.format.nest 1 $
+    _root_.format.join $ list.intersperse ("," ++ _root_.format.line) fs) ++ "⟩"
+| br (alts ls) := do
+  fs ← ls.mmap $ format tt,
+  let fmt := _root_.format.join $ list.intersperse (↑" |" ++ _root_.format.space) fs,
+  pure $ if br then _root_.format.bracket "(" ")" fmt else fmt
+| br (typed p e) := do
+  fp ← format ff p,
   fe ← pp e,
   let fmt := fp ++ " : " ++ fe,
-  pure $ if br then format.bracket "(" ")" fmt else fmt
+  pure $ if br then _root_.format.bracket "(" ")" fmt else fmt
 
-meta instance rcases_patt.has_to_tactic_format : has_to_tactic_format rcases_patt :=
-⟨λ e, rcases_patt.format ff e⟩
+meta instance has_to_tactic_format : has_to_tactic_format rcases_patt := ⟨rcases_patt.format ff⟩
 
-/--
-Takes the number of fields of a single constructor and patterns to
-match its fields against (not necessarily the same number). The
-returned lists each contain one element per field of the
-constructor. The `name` is the name which will be used in the
-top-level `cases` tactic, and the `rcases_patt` is the pattern which
-the field will be matched against by subsequent `cases` tactics.
--/
+end rcases_patt
 
+/-- Takes the number of fields of a single constructor and patterns to match its fields against
+(not necessarily the same number). The returned lists each contain one element per field of the
+constructor. The `name` is the name which will be used in the top-level `cases` tactic, and the
+`rcases_patt` is the pattern which the field will be matched against by subsequent `cases`
+tactics. -/
 meta def rcases.process_constructor :
   nat → listΠ rcases_patt → listΠ name × listΠ rcases_patt
-| 0     ids  := ([], [])
-| 1     []   := ([`_], [default _])
-| 1     [id] := ([id.name.get_or_else `_], [id])
+| 0     ps  := ([], [])
+| 1     []  := ([`_], [default _])
+| 1     [p] := ([p.name.get_or_else `_], [p])
 
 -- The interesting case: we matched the last field against multiple
 -- patterns, so split off the remaining patterns into a subsequent
 -- match. This handles matching `α × β × γ` against `⟨a, b, c⟩`.
-| 1     ids  := ([`_], [rcases_patt.tuple ids])
+| 1     ps  := ([`_], [rcases_patt.tuple ps])
 
-| (n+1) ids  :=
-  let (ns, ps) := rcases.process_constructor n ids.tail,
-      p := ids.head in
+| (n+1) ps  :=
+  let (ns, ps) := rcases.process_constructor n ps.tail,
+      p := ps.head in
   (p.name.get_or_else `_ :: ns, p :: ps)
 
+/-- Takes a list of constructor names, and an (alternation) list of patterns, and matches each
+pattern against its constructor. It returns the list of names that will be passed to `cases`,
+and the list of `(constructor name, patterns)` for each constructor, where `patterns` is the
+(conjunctive) list of patterns to apply to each constructor argument. -/
 meta def rcases.process_constructors (params : nat) :
   listΣ name → listΣ rcases_patt →
   tactic (dlist name × listΣ (name × listΠ rcases_patt))
-| []      ids := pure (dlist.empty, [])
-| (c::cs) ids := do
+| []      ps := pure (dlist.empty, [])
+| (c::cs) ps := do
   n ← mk_const c >>= get_arity,
-  let (h, t) := (match cs, ids.tail with
+  let (h, t) := (match cs, ps.tail with
   -- We matched the last constructor against multiple patterns,
   -- so split off the remaining constructors. This handles matching
   -- `α ⊕ β ⊕ γ` against `a|b|c`.
-  | [], _::_ := ([rcases_patt.alts ids], [])
-  | _, _ := (ids.head.as_tuple, ids.tail)
+  | [], _::_ := ([rcases_patt.alts ps], [])
+  | _, _ := (ps.head.as_tuple, ps.tail)
   end : _),
   let (ns, ps) := rcases.process_constructor (n - params) h,
   (l, r) ← rcases.process_constructors cs t,
   pure (dlist.of_list ns ++ l, (c, ps) :: r)
 
+/-- Like `zip`, but only elements satisfying a matching predicate `p` will go in the list,
+and elements of the first list that fail to match the second list will be skipped. -/
 private def align {α β} (p : α → β → Prop) [∀ a b, decidable (p a b)] :
   list α → list β → list (α × β)
 | (a::as) (b::bs) :=
   if p a b then (a, b) :: align as bs else align as (b::bs)
 | _ _ := []
 
+/-- Given a local constant `e`, get its type. *But* if `e` does not exist, go find a hypothesis
+with the same pretty name as `e` and get it instead. This is needed because we can sometimes lose
+track of the unique names of hypotheses when they are revert/intro'd by `change` and `cases`. (A
+better solution would be for these tactics to return a map of renamed hypotheses so that we don't
+lose track of them.) -/
 private meta def get_local_and_type (e : expr) : tactic (expr × expr) :=
 (do t ← infer_type e, pure (t, e)) <|> (do
     e ← get_local e.local_pp_name,
     t ← infer_type e, pure (t, e))
 
+/--
+* `rcases_core p e` will match a pattern `p` against a local hypothesis `e`.
+  It returns the list of subgoals that were produced.
+* `rcases.continue pes` will match a (conjunctive) list of `(p, e)` pairs which refer to
+  patterns and local hypotheses to match against, and applies all of them. Note that this can
+  involve matching later arguments multiple times given earlier arguments, for example
+  `⟨a | b, ⟨c, d⟩⟩` performs the `⟨c, d⟩` match twice, once on the `a` branch and once on `b`.
+-/
 meta mutual def rcases_core, rcases.continue
 with rcases_core : rcases_patt → expr → tactic goals
 | (rcases_patt.one `rfl) e := do
@@ -238,14 +341,14 @@ with rcases_core : rcases_patt → expr → tactic goals
 
 with rcases.continue : listΠ (rcases_patt × expr) → tactic goals
 | [] := get_goals
-| ((pat, e) :: l) := do
+| ((pat, e) :: pes) := do
   gs ← rcases_core pat e,
-  list.join <$> gs.mmap (λ g, set_goals [g] >> rcases.continue l)
+  list.join <$> gs.mmap (λ g, set_goals [g] >> rcases.continue pes)
 
 /-- `rcases h e pat` performs case distinction on `e` using `pat` to
 name the arising new variables and assumptions. If `h` is `some` name,
 a new assumption `h : e = pat` will relate the expression `e` with the
-current pattern. -/
+current pattern. See the module comment for the syntax of `pat`. -/
 meta def rcases (h : option name) (p : pexpr) (pat : rcases_patt) : tactic unit := do
   let p := match pat with
   | rcases_patt.typed _ ty := ``(%%p : %%ty)
@@ -271,17 +374,26 @@ meta def rcases (h : option name) (p : pexpr) (pat : rcases_patt) : tactic unit 
     h ← tactic.intro1,
     focus1 (rcases_core pat h >>= set_goals)
 
+/-- `rintro pat₁ pat₂ ... patₙ` introduces `n` arguments, then pattern matches on the `patᵢ` using
+the same syntax as `rcases`. -/
 meta def rintro (ids : listΠ rcases_patt) : tactic unit :=
 do l ← ids.mmap (λ id, do
     e ← intro $ id.name.get_or_else `_,
     pure (id, e)),
   focus1 (rcases.continue l >>= set_goals)
 
+/-- Like `zip_with`, but if the lists don't match in length, the excess elements will be put at the
+end of the result. -/
 def merge_list {α} (m : α → α → α) : list α → list α → list α
 | [] l₂ := l₂
 | l₁ [] := l₁
 | (a :: l₁) (b :: l₂) := m a b :: merge_list l₁ l₂
 
+/-- Merge two `rcases` patterns. This is used to underapproximate a case tree by an `rcases`
+pattern. The two patterns come from cases in two branches, that due to the syntax of `rcases`
+patterns are forced to overlap. The rule here is that we take only the case splits that are in
+common between both branches. For example if one branch does `⟨a, b⟩` and the other does `c`,
+then we return `c` because we don't know that a case on `c` would be safe to do. -/
 meta def rcases_patt.merge : rcases_patt → rcases_patt → rcases_patt
 | (rcases_patt.alts p₁) p₂ := rcases_patt.alts (merge_list rcases_patt.merge p₁ p₂.as_alts)
 | p₁ (rcases_patt.alts p₂) := rcases_patt.alts (merge_list rcases_patt.merge p₁.as_alts p₂)
@@ -294,6 +406,21 @@ meta def rcases_patt.merge : rcases_patt → rcases_patt → rcases_patt
 | p (rcases_patt.one `_) := p
 | (rcases_patt.one n) _ := rcases_patt.one n
 
+/--
+* `rcases_hint_core depth e` does the same as `rcases p e`, except the pattern `p` is an output
+  instead of an input, controlled only by the case depth argument `depth`. We use `cases` to depth
+  `depth` and then reconstruct an `rcases` pattern `p` that would, if passed to `rcases`, perform
+  the same thing as the case tree we just constructed (or at least, the nearest expressible
+  approximation to this.)
+* `rcases_hint.process_constructors depth cs l` takes a list of constructor names `cs` and a
+  matching list `l` of elements `(g, c', hs, _)` where  `c'` is a constructor name (used for
+  alignment with `cs`), `g` is the subgoal, and `hs` is the list of local hypotheses created by
+  `cases` in that subgoal. It matches on all of them, and then produces a `ΣΠ`-list of `rcases`
+  patterns describing the result, and the list of generated subgoals.
+* `rcases_hint.continue depth es` does the same as `rcases.continue (ps.zip es)`, except the
+  patterns `ps` are an output instead of an input, created by matching on everything to depth
+  `depth` and recording the successful cases. It returns `ps`, and the list of generated subgoals.
+-/
 meta mutual def rcases_hint_core, rcases_hint.process_constructors, rcases_hint.continue
 with rcases_hint_core : ℕ → expr → tactic (rcases_patt × goals)
 | depth e := do
@@ -328,13 +455,18 @@ with rcases_hint.process_constructors : ℕ → listΣ name →
 
 with rcases_hint.continue : ℕ → listΠ expr → tactic (listΠ rcases_patt × goals)
 | depth [] := prod.mk [] <$> get_goals
-| depth (e :: l) := do
+| depth (e :: es) := do
   (p, gs) ← rcases_hint_core depth e,
   (ps, gs') ← gs.mfoldl (λ (r : listΠ rcases_patt × goals) g,
-    do (ps, gs') ← set_goals [g] >> rcases_hint.continue depth l,
+    do (ps, gs') ← set_goals [g] >> rcases_hint.continue depth es,
       pure (merge_list rcases_patt.merge r.1 ps, r.2 ++ gs')) ([], []),
   pure (p :: ps, gs')
 
+/--
+* `rcases? e` is like `rcases e with ...`, except it generates `...` by matching on everything it
+can, and it outputs an `rcases` invocation that should have the same effect.
+* `rcases? e : n` can be used to control the depth of case splits (especially important for
+recursive types like `nat`, which can be cased as many times as you like). -/
 meta def rcases_hint (p : pexpr) (depth : nat) : tactic rcases_patt :=
 do e ← i_to_expr p,
   if e.is_local_constant then
@@ -350,6 +482,11 @@ do e ← i_to_expr p,
     h ← tactic.intro1,
     focus1 $ do (p, gs) ← rcases_hint_core depth h, set_goals gs, pure p
 
+/--
+* `rintro?` is like `rintro ...`, except it generates `...` by introducing and matching on
+everything it can, and it outputs an `rintro` invocation that should have the same effect.
+* `rintro? : n` can be used to control the depth of case splits (especially important for
+recursive types like `nat`, which can be cased as many times as you like). -/
 meta def rintro_hint (depth : nat) : tactic (listΠ rcases_patt) :=
 do l ← intros,
   focus1 $ do
@@ -359,12 +496,27 @@ do l ← intros,
 
 setup_tactic_parser
 
-local notation `listΣ` := list_Sigma
-local notation `listΠ` := list_Pi
+/--
+* `rcases_patt_parse tt` will parse a high precedence `rcases` pattern, `patt_hi`.
+  This means only tuples and identifiers are allowed; alternations and type ascriptions
+  require `(...)` instead, which switches to `patt`.
+* `rcases_patt_parse ff` will parse a low precedence `rcases` pattern, `patt`. This consists of a
+  `patt_med` (which deals with alternations), optionally followed by a `: ty` type ascription. The
+  expression `ty` is at `texpr` precedence because it can appear at the end of a tactic, for
+  example in `rcases e with x : ty <|> skip`.
+* `rcases_patt_parse_list` will parse an alternation list, `patt_med`, one or more `patt`
+  patterns separated by `|`. It does not parse a `:` at the end, so that `a | b : ty` parses as
+  `(a | b) : ty` where `a | b` is the `patt_med` part.
 
+```lean
+patt ::= patt_med (":" expr)?
+patt_med ::= (patt_hi "|")* patt_hi
+patt_hi ::= id | "rfl" | "_" | "⟨" (patt ",")* patt "⟩" | "(" patt ")"
+```
+-/
 meta mutual def rcases_patt_parse, rcases_patt_parse_list
 with rcases_patt_parse : bool → parser rcases_patt
-| tt := with_desc "patt" $
+| tt := with_desc "patt_hi" $
   (brackets "(" ")" (rcases_patt_parse ff)) <|>
   (rcases_patt.tuple <$> brackets "⟨" "⟩" (sep_by (tk ",") (rcases_patt_parse ff))) <|>
   (rcases_patt.one <$> ident_)
@@ -373,19 +525,22 @@ with rcases_patt_parse : bool → parser rcases_patt
   (tk ":" *> pat.typed <$> texpr) <|> pure pat
 
 with rcases_patt_parse_list : parser (listΣ rcases_patt)
-| x := (with_desc "patt_list" $ do
+| x := (with_desc "patt_med" $ do
   pat ← rcases_patt_parse tt,
   (tk "|" *> list.cons pat <$> rcases_patt_parse_list) <|>
   pure [pat]) x
 
+/-- Parse the optional depth argument `(: n)?` of `rcases?` and `rintro?`, with default depth 5. -/
 meta def rcases_parse_depth : parser nat :=
 do o ← (tk ":" *> small_nat)?, pure $ o.get_or_else 5
 
 precedence `?`:max
 
-/-- syntax for a `rcases` pattern: `('?' expr (: n)?) | ((h :)? expr (with patt_list)?)`  -/
+/-- Syntax for a `rcases` pattern:
+* `rcases? expr (: n)?`
+* `rcases (h :)? expr (with patt_list (: expr)?)?`. -/
 meta def rcases_parse : parser (pexpr × ((option name × rcases_patt) ⊕ nat)) :=
-with_desc "('?' expr (: n)?) | ((h :)? expr (with patt_list)?)" $ do
+with_desc "('?' expr (: n)?) | ((h :)? expr (with patt)?)" $ do
   hint ← (tk "?")?,
   p ← texpr,
   match hint with
@@ -398,14 +553,11 @@ with_desc "('?' expr (: n)?) | ((h :)? expr (with patt_list)?)" $ do
   | some _ := do depth ← rcases_parse_depth, pure (p, sum.inr depth)
   end
 
+/-- Syntax for a `rintro` pattern: `('?' (: n)?) | patt*`. -/
 meta def rintro_parse : parser (listΠ rcases_patt ⊕ nat) :=
-with_desc "('?' (: n)?) | patt_list" $
+with_desc "('?' (: n)?) | patt*" $
 (tk "?" >> sum.inr <$> rcases_parse_depth) <|>
 sum.inl <$> (rcases_patt_parse tt)*
-
-meta def ext_patt := listΠ rcases_patt
-
-meta def ext_parse : parser ext_patt := (rcases_patt_parse tt)*
 
 namespace interactive
 open interactive interactive.types expr
@@ -416,8 +568,9 @@ The `rcases` tactic is the same as `cases`, but with more flexibility in the
 uses the following recursive grammar:
 
 ```lean
-patt ::= (patt_list "|")* patt_list
-patt_list ::= id | "rfl" | "_" | "⟨" (patt ",")* patt "⟩"
+patt ::= patt_med (":" expr)?
+patt_med ::= (patt_hi "|")* patt_hi
+patt_hi ::= id | "rfl" | "_" | "⟨" (patt ",")* patt "⟩" | "(" patt ")"
 ```
 
 A pattern like `⟨a, b, c⟩ | ⟨d, e⟩` will do a split over the inductive datatype,
@@ -433,6 +586,10 @@ parameter as necessary.
 If `rcases` results in an expression of the form `x = a`, then using `rfl`
 in the pattern will have the same effect as writing `h` and then
 following the `rcases` with a `subst h`.
+
+Type ascriptions like `⟨x : ℕ, h : x < 1⟩` can be inserted into the pattern,
+and they will `change` the target hypothesis to the stated type if it is defeq
+to the actual type of the hypothesis.
 
 `rcases` also has special support for quotient types: quotient induction into Prop works like
 matching on the constructor `quot.mk`.
@@ -495,8 +652,9 @@ add_tactic_doc
 
 setup_tactic_parser
 
+/-- Parses `patt? (: expr)?`. (This is almost the same as `-/
 meta def obtain_parse : parser (option rcases_patt × option pexpr) :=
-with_desc "patt_list? (: expr)?" $
+with_desc "patt? (: expr)?" $
   (do pat ← rcases_patt_parse ff,
     pure $ match pat with
     | rcases_patt.typed pat tp := (some pat, some tp)

--- a/src/tactic/rcases.lean
+++ b/src/tactic/rcases.lean
@@ -37,6 +37,7 @@ local notation `listΠ` := list_Pi
 An `rcases` pattern can be one of the following, in a nested combination:
 
 * A name like `foo`
+* The special keyword `rfl` (for pattern matching on equality using `subst`)
 * A type ascription like `pat : ty` (parentheses are optional)
 * A tuple constructor like `⟨p1, p2, p3⟩`
 * An alternation / variant pattern `p1 | p2 | p3`

--- a/src/tactic/rcases.lean
+++ b/src/tactic/rcases.lean
@@ -238,9 +238,8 @@ meta def rcases.process_constructor :
 | 1     ps  := ([`_], [rcases_patt.tuple ps])
 
 | (n+1) ps  :=
-  let (ns, ps) := rcases.process_constructor n ps.tail,
-      p := ps.head in
-  (p.name.get_or_else `_ :: ns, p :: ps)
+  let hd := ps.head, (ns, tl) := rcases.process_constructor n ps.tail in
+  (hd.name.get_or_else `_ :: ns, hd :: tl)
 
 /-- Takes a list of constructor names, and an (alternation) list of patterns, and matches each
 pattern against its constructor. It returns the list of names that will be passed to `cases`,

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -135,7 +135,7 @@ lemma to_GH_space_eq_to_GH_space_iff_isometric {α : Type u} [metric_space α] [
 ⟨begin
   simp only [to_GH_space, quotient.eq],
   assume h,
-  rcases h with e,
+  rcases h with ⟨e⟩,
   have I : ((nonempty_compacts.Kuratowski_embedding α).val ≃ᵢ (nonempty_compacts.Kuratowski_embedding β).val)
           = ((range (Kuratowski_embedding α)) ≃ᵢ (range (Kuratowski_embedding β))),
     by { dunfold nonempty_compacts.Kuratowski_embedding, refl },
@@ -601,7 +601,7 @@ begin
   { assume p t ht,
     letI : fintype t := finite.fintype ht,
     rcases fintype.exists_equiv_fin t with ⟨n, hn⟩,
-    rcases hn with e,
+    rcases hn with ⟨e⟩,
     exact ⟨n, e, trivial⟩ },
   choose N e hne using this,
   -- cardinality of the nice finite subset `s p` of `p.rep`, called `N p`

--- a/src/topology/metric_space/isometry.lean
+++ b/src/topology/metric_space/isometry.lean
@@ -363,7 +363,7 @@ begin
   cases (univ : set α).eq_empty_or_nonempty with h h,
   { use (λ_, 0), assume x, exact absurd h (nonempty.ne_empty ⟨x, mem_univ x⟩) },
   { /- We construct a map x : ℕ → α with dense image -/
-    rcases h with basepoint,
+    rcases h with ⟨basepoint⟩,
     haveI : inhabited α := ⟨basepoint⟩,
     have : ∃s:set α, countable s ∧ closure s = univ := separable_space.exists_countable_closure_eq_univ,
     rcases this with ⟨S, ⟨S_countable, S_dense⟩⟩,

--- a/test/rcases.lean
+++ b/test/rcases.lean
@@ -121,3 +121,15 @@ begin
   obtain ⟨a, h⟩ : ∃ p, p ∈ (V.foo V) ∩ (V.foo V) := w trivial,
   trivial,
 end
+
+example (n : ℕ) : true :=
+begin
+  obtain one_lt_n | n_le_one : 1 < n + 1 ∨ n + 1 ≤ 1 := nat.lt_or_ge 1 (n + 1),
+  trivial, trivial,
+end
+
+example (n : ℕ) : true :=
+begin
+  obtain one_lt_n | (n_le_one : n + 1 ≤ 1) := nat.lt_or_ge 1 (n + 1),
+  trivial, trivial,
+end

--- a/test/rcases.lean
+++ b/test/rcases.lean
@@ -113,3 +113,11 @@ begin
   guard_hyp h' := h = ⟨x,h₀,h₁⟩,
   apply le_trans h₀ h₁,
 end
+
+protected def set.foo {α β} (s : set α) (t : set β) : set (α × β) := ∅
+
+example {α} (V : set α) (w : true → ∃ p, p ∈ (V.foo V) ∩ (V.foo V)) : true :=
+begin
+  obtain ⟨a, h⟩ : ∃ p, p ∈ (V.foo V) ∩ (V.foo V) := w trivial,
+  trivial,
+end

--- a/test/rcases.lean
+++ b/test/rcases.lean
@@ -29,7 +29,7 @@ end
 
 example (x : (α × β) × γ) : true :=
 begin
-  rcases x with ⟨⟨a, b⟩, c⟩,
+  rcases x with ⟨⟨a:α, b⟩, c⟩,
   { guard_hyp a := α,
     guard_hyp b := β,
     guard_hyp c := γ,
@@ -62,7 +62,7 @@ end
 
 example : true :=
 begin
-  obtain ⟨n, h, f⟩ : ∃ n : ℕ, n = n ∧ true,
+  obtain ⟨n : ℕ, h : n = n, f : true⟩ : ∃ n : ℕ, n = n ∧ true,
   { existsi 0, simp },
   guard_hyp n := ℕ,
   guard_hyp h := n = n,
@@ -79,7 +79,7 @@ end
 
 example : true :=
 begin
-  obtain h | ⟨⟨⟩⟩ : true ∨ false,
+  obtain (h : true) | ⟨⟨⟩⟩ : true ∨ false,
   { left, trivial },
   guard_hyp h := true,
   trivial


### PR DESCRIPTION
This is a general rewrite of the `rcases` tactic, with the primary intent of adding support for type ascriptions in `rcases` patterns but it also includes a bunch more documentation, as well as making the grammar simpler, avoiding the strict tuple/alts alternations required by the previous `many` constructor (and the need for `rcases_patt_inverted` for whether the constructor means `tuple` of `alts` or `alts` of `tuple`).

From a user perspective, it should not be noticeably different, except:

* You can now use parentheses freely in patterns, so things like `a | (b | c)` work
* You can use type ascriptions

The new `rcases` is backward compatible with the old one, except that `rcases e with a` (where `a` is a name) no longer does any cases and is basically just another way to write `have a := e`; to get the same effect as `cases e with a` you have to write `rcases e with ⟨a⟩` instead.
