### PR TITLE
[Merged by Bors] - feat(data/*): Add sizeof lemmas.

### DIFF
--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -49,8 +49,6 @@ erase_dup_eq_self.2 s.2
 instance has_decidable_eq [decidable_eq α] : decidable_eq (finset α)
 | s₁ s₂ := decidable_of_iff _ val_inj
 
-instance has_sizeof [has_sizeof α] : has_sizeof (finset α) := ⟨λ s, sizeof s.val⟩
-
 /- membership -/
 
 instance : has_mem α (finset α) := ⟨λ a s, a ∈ s.1⟩
@@ -780,7 +778,9 @@ end decidable_eq
 def attach (s : finset α) : finset {x // x ∈ s} := ⟨attach s.1, nodup_attach.2 s.2⟩
 
 theorem sizeof_lt_sizeof_of_mem [has_sizeof α] {x : α} {s : finset α} (hx : x ∈ s) :
-  sizeof x < sizeof s := multiset.sizeof_lt_sizeof_of_mem hx
+  sizeof x < sizeof s := by
+{ cases s, dsimp [sizeof, has_sizeof.sizeof, finset.sizeof],
+  exact lt_add_left _ _ _ (multiset.sizeof_lt_sizeof_of_mem hx) }
 
 @[simp] theorem attach_val (s : finset α) : s.attach.1 = s.1.attach := rfl
 

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -780,7 +780,7 @@ def attach (s : finset α) : finset {x // x ∈ s} := ⟨attach s.1, nodup_attac
 theorem sizeof_lt_sizeof_of_mem [has_sizeof α] {x : α} {s : finset α} (hx : x ∈ s) :
   sizeof x < sizeof s := by
 { cases s, dsimp [sizeof, has_sizeof.sizeof, finset.sizeof],
-  exact lt_add_left _ _ _ (multiset.sizeof_lt_sizeof_of_mem hx) }
+  apply lt_add_left, exact multiset.sizeof_lt_sizeof_of_mem hx }
 
 @[simp] theorem attach_val (s : finset α) : s.attach.1 = s.1.attach := rfl
 

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -49,6 +49,8 @@ erase_dup_eq_self.2 s.2
 instance has_decidable_eq [decidable_eq α] : decidable_eq (finset α)
 | s₁ s₂ := decidable_of_iff _ val_inj
 
+instance has_sizeof [has_sizeof α] : has_sizeof (finset α) := ⟨λ s, sizeof s.val⟩
+
 /- membership -/
 
 instance : has_mem α (finset α) := ⟨λ a s, a ∈ s.1⟩
@@ -776,6 +778,9 @@ end decidable_eq
 /-- `attach s` takes the elements of `s` and forms a new set of elements of the
   subtype `{x // x ∈ s}`. -/
 def attach (s : finset α) : finset {x // x ∈ s} := ⟨attach s.1, nodup_attach.2 s.2⟩
+
+theorem sizeof_lt_sizeof_of_mem [has_sizeof α] {x : α} {s : finset α} (hx : x ∈ s) :
+  sizeof x < sizeof s := multiset.sizeof_lt_sizeof_of_mem hx
 
 @[simp] theorem attach_val (s : finset α) : s.attach.1 = s.1.attach := rfl
 

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -2314,6 +2314,12 @@ decidable_of_iff _ any_iff_exists_prop
   with the same elements but in the type `{x // x ∈ l}`. -/
 def attach (l : list α) : list {x // x ∈ l} := pmap subtype.mk l (λ a, id)
 
+theorem sizeof_lt_sizeof_of_mem [has_sizeof α] {x : α} {l : list α} (hx : x ∈ l) :
+  sizeof x < sizeof l :=
+by { induction l with h t ih, { cases hx }, cases hx,
+  { rw hx, exact lt_add_of_lt_of_nonneg (lt_one_add _) (nat.zero_le _) },
+  exact lt_add_of_pos_of_le (zero_lt_one_add _) (le_of_lt (ih hx)) }
+
 theorem pmap_eq_map (p : α → Prop) (f : α → β) (l : list α) (H) :
   @pmap _ _ p (λ a _, f a) l H = map f l :=
 by induction l; [refl, simp only [*, pmap, map]]; split; refl

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -2316,9 +2316,11 @@ def attach (l : list α) : list {x // x ∈ l} := pmap subtype.mk l (λ a, id)
 
 theorem sizeof_lt_sizeof_of_mem [has_sizeof α] {x : α} {l : list α} (hx : x ∈ l) :
   sizeof x < sizeof l :=
-by { induction l with h t ih, { cases hx }, cases hx,
+begin
+  induction l with h t ih; cases hx,
   { rw hx, exact lt_add_of_lt_of_nonneg (lt_one_add _) (nat.zero_le _) },
-  exact lt_add_of_pos_of_le (zero_lt_one_add _) (le_of_lt (ih hx)) }
+  { exact lt_add_of_pos_of_le (zero_lt_one_add _) (le_of_lt (ih hx)) }
+end
 
 theorem pmap_eq_map (p : α → Prop) (f : α → β) (l : list α) (H) :
   @pmap _ _ p (λ a _, f a) l H = map f l :=

--- a/src/data/list/perm.lean
+++ b/src/data/list/perm.lean
@@ -216,6 +216,17 @@ begin
           ⟨r₁, pr.trans pm, sr⟩ }
 end
 
+theorem perm.sizeof_eq_sizeof [has_sizeof α] {l₁ l₂ : list α} (h : l₁ ~ l₂) :
+  l₁.sizeof = l₂.sizeof :=
+begin
+  induction h with hd l₁ l₂ h₁₂ h_sz₁₂ a b l l₁ l₂ l₃ h₁₂ h₂₃ h_sz₁₂ h_sz₂₃,
+  { refl },
+  { simp only [list.sizeof, h_sz₁₂] },
+  { simp only [list.sizeof, add_left_comm] },
+  { simp only [h_sz₁₂, h_sz₂₃] }
+end
+
+
 section rel
 open relator
 variables {γ : Type*} {δ : Type*} {r : α → β → Prop} {p : γ → δ → Prop}

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -39,13 +39,7 @@ instance has_decidable_eq [decidable_eq α] : decidable_eq (multiset α)
 
 /-- defines a size for a multiset by referring to the size of the underlying list -/
 protected def sizeof [has_sizeof α] (s : multiset α) : ℕ :=
-begin
-  induction s with l x y ih, { exact l.sizeof },
-  simp only [eq_rec_constant],
-  induction ih with hd l₁ l₂ h₁₂ h_sz₁₂ a b l l₁ l₂ l₃ h₁₂ h₂₃ h_sz₁₂ h_sz₂₃,
-  { refl }, { simp [list.sizeof, h_sz₁₂] },
-  { dsimp [list.sizeof], apply add_left_comm }, { simp [h_sz₁₂, h_sz₂₃] }
-end
+quot.lift_on s sizeof $ λ l₁ l₂, perm.sizeof_eq_sizeof
 
 instance has_sizeof [has_sizeof α] : has_sizeof (multiset α) := ⟨multiset.sizeof⟩
 

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -37,6 +37,7 @@ instance has_decidable_eq [decidable_eq α] : decidable_eq (multiset α)
 | s₁ s₂ := quotient.rec_on_subsingleton₂ s₁ s₂ $ λ l₁ l₂,
   decidable_of_iff' _ quotient.eq
 
+/-- defines a size for a multiset by referring to the size of the underlying list -/
 protected def sizeof [has_sizeof α] (s : multiset α) : ℕ :=
 begin
   induction s with l x y ih, { exact l.sizeof },

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -37,6 +37,17 @@ instance has_decidable_eq [decidable_eq α] : decidable_eq (multiset α)
 | s₁ s₂ := quotient.rec_on_subsingleton₂ s₁ s₂ $ λ l₁ l₂,
   decidable_of_iff' _ quotient.eq
 
+private def sizeof_core [has_sizeof α] (s : multiset α) : ℕ :=
+begin
+  induction s with l x y ih, { exact l.sizeof },
+  simp only [eq_rec_constant],
+  induction ih with hd l₁ l₂ h₁₂ h_sz₁₂ a b l l₁ l₂ l₃ h₁₂ h₂₃ h_sz₁₂ h_sz₂₃,
+  { refl }, { simp [list.sizeof, h_sz₁₂] },
+  { dsimp [list.sizeof], apply add_left_comm }, { simp [h_sz₁₂, h_sz₂₃] }
+end
+
+instance has_sizeof [has_sizeof α] : has_sizeof (multiset α) := ⟨sizeof_core⟩
+
 /- empty multiset -/
 
 /-- `0 : multiset α` is the empty set -/
@@ -1024,6 +1035,10 @@ def attach (s : multiset α) : multiset {x // x ∈ s} := pmap subtype.mk s (λ 
 
 @[simp] theorem coe_attach (l : list α) :
  @eq (multiset {x // x ∈ l}) (@attach α l) l.attach := rfl
+
+theorem sizeof_lt_sizeof_of_mem [has_sizeof α] {x : α} {s : multiset α} (hx : x ∈ s) :
+  sizeof x < sizeof s := by
+{ induction s with l a b, exact list.sizeof_lt_sizeof_of_mem hx, refl }
 
 theorem pmap_eq_map (p : α → Prop) (f : α → β) (s : multiset α) :
   ∀ H, @pmap _ _ p (λ a _, f a) s H = map f s :=

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -37,7 +37,7 @@ instance has_decidable_eq [decidable_eq α] : decidable_eq (multiset α)
 | s₁ s₂ := quotient.rec_on_subsingleton₂ s₁ s₂ $ λ l₁ l₂,
   decidable_of_iff' _ quotient.eq
 
-private def sizeof_core [has_sizeof α] (s : multiset α) : ℕ :=
+protected def sizeof [has_sizeof α] (s : multiset α) : ℕ :=
 begin
   induction s with l x y ih, { exact l.sizeof },
   simp only [eq_rec_constant],
@@ -46,7 +46,7 @@ begin
   { dsimp [list.sizeof], apply add_left_comm }, { simp [h_sz₁₂, h_sz₂₃] }
 end
 
-instance has_sizeof [has_sizeof α] : has_sizeof (multiset α) := ⟨sizeof_core⟩
+instance has_sizeof [has_sizeof α] : has_sizeof (multiset α) := ⟨multiset.sizeof⟩
 
 /- empty multiset -/
 


### PR DESCRIPTION
---
Adding 3 small lemmas about `sizeof`. The idea being, that for `list`, `multiset` and `finset`, we have an `attach`, which then makes it possible to `map` over them, in a restricted recursion context. Unfortunately you have to prove that `x in t -> sizeof x < sizeof t`. Those are the lemmas helping with that.

<!-- put comments you want to keep out of the PR commit here -->
