### PR TITLE
WIP: new datatype compiler

### DIFF
--- a/src/control/functor/multivariate.lean
+++ b/src/control/functor/multivariate.lean
@@ -70,8 +70,8 @@ namespace mvfunctor
 export is_lawful_mvfunctor (comp_map)
 open is_lawful_mvfunctor
 
-variables {α β γ : typevec.{u} n}
 variables {F : typevec.{u} n → Type v} [mvfunctor F]
+variables {α β γ : typevec.{u} n}
 
 variables (p : α ⟹ repeat n Prop) (r : α ⊗ α ⟹ repeat n Prop)
 

--- a/src/control/functor/multivariate.lean
+++ b/src/control/functor/multivariate.lean
@@ -115,6 +115,11 @@ begin
 end
 variables {F}
 
+#check @liftp
+#check @liftp'
+
+#print of_subtype
+
 lemma liftp_def (x : F α) : liftp' p x ↔ ∃ u : F (subtype_ p), subtype_val p <$$> u = x :=
 begin
   dsimp only [liftp', mvfunctor.liftp],

--- a/src/data/list/defs.lean
+++ b/src/data/list/defs.lean
@@ -271,6 +271,25 @@ as.foldr_with_index (λ i a mb, do b ← mb, f i a b) (pure b)
 
 end mfold_with_index
 
+section zip_with
+
+def zip_with₃ {α β γ φ} (f : α → β → γ → φ) : list α → list β → list γ → list φ
+| (x::xs) (y::ys) (z::zs) := f x y z :: zip_with₃ xs ys zs
+| _ _ _ := []
+
+variables {m : Type v → Type w} [applicative m]
+
+def mzip_with₃ {α β γ φ} (f : α → β → γ → m φ) : list α → list β → list γ → m (list φ)
+| (x::xs) (y::ys) (z::zs) := (::) <$> f x y z <*> mzip_with₃ xs ys zs
+| _ _ _ := pure []
+
+def mzip_with₄ {α β γ φ ψ} (f : α → β → γ → φ → m ψ) :
+  list α → list β → list γ → list φ → m (list ψ)
+| (w :: ws) (x::xs) (y::ys) (z::zs) := (::) <$> f w x y z <*> mzip_with₄ ws xs ys zs
+| _ _ _ _ := pure []
+
+end zip_with
+
 section mmap_with_index
 
 variables {m : Type v → Type w} [applicative m]

--- a/src/data/qpf/compiler/basic.lean
+++ b/src/data/qpf/compiler/basic.lean
@@ -1,0 +1,1655 @@
+
+import control.bitraversable.instances
+-- import data.qpf.compiler.equations
+import data.qpf.compiler.fn_var
+import data.qpf.compiler.inductive_decl
+import data.qpf.multivariate
+import .for_mathlib
+
+universes u v
+
+namespace level
+
+meta def pred : level → level
+| level.zero := level.zero
+| (level.succ a) := a
+| (level.max a b) := max (pred a) (pred b)
+| (level.imax a b) := max (pred a) (pred b)
+| l@(level.param a) := l
+| l@(level.mvar a) := l
+
+end level
+
+def reversed (m : Type u → Type v) := m
+def reversed.mk {m : Type u → Type v} {α} (x : m α) : reversed m α := x
+def reversed.run {m : Type u → Type v} {α} (x : reversed m α) : m α := x
+
+instance {m : Type u → Type v} [F : functor m] : functor (reversed m) := F
+instance {m : Type u → Type v} [functor m] [L : is_lawful_functor m] : is_lawful_functor (reversed m) := L
+
+instance {m : Type u → Type v} [applicative m] : applicative (reversed m) :=
+{ pure := λ α x, @pure m _ _ x,
+  map := λ α β f (x : m α), show m β, from f <$> x,
+  map_const := λ α β f (x : m _), show m α, from f <$ x,
+  seq := λ α β f x, show m β, from flip id <$> x <*> f }
+
+instance {m : Type u → Type v} [applicative m] [F : is_lawful_applicative m] : is_lawful_applicative (reversed m) :=
+{ map_const_eq := λ α β, @map_const_eq m _ _ α β,
+  pure_seq_eq_map := by intros; simp [(<*>),(<$>),pure,flip] with functor_norm,
+  map_pure := λ α β g x, @map_pure m _ _ _ _ g x,
+  seq_pure := by intros; simp [(<*>),(<$>),pure,flip] with functor_norm,
+  seq_assoc := by intros; simp [(<*>),(<$>),pure,flip] with functor_norm,
+  .. F.to_is_lawful_functor }
+
+attribute [irreducible] reversed
+
+namespace list
+
+def mmap_reversed {t : Type u → Type u} [traversable t] {m : Type u → Type u} [applicative m] {α β} (f : α → m β) : t α → m (t β) :=
+reversed.run ∘ traverse (reversed.mk ∘ f)
+
+open bitraversable
+variables {α β γ : Type u} {m : Type u → Type u} [monad m]
+
+meta def mmap_dead (f : α → m γ) (xs : α ⊕ β) : m (γ ⊕ β) :=
+tfst f xs
+
+meta def mmap_live (f : β → m γ) (xs : α ⊕ β) : m (α ⊕ γ) :=
+tsnd f xs
+
+meta def map_dead (f : α → γ) (xs : α ⊕ β) : (γ ⊕ β) :=
+sum.map f id xs
+
+meta def map_live (f : β → γ) (xs : α ⊕ β) : (α ⊕ γ) :=
+sum.map id f xs
+
+meta def mmap_dead' (f : α → m γ) (xs : list $ α ⊕ β) : m (list $ γ ⊕ β) :=
+xs.mmap (mmap_dead f)
+
+meta def mmap_live' (f : β → m γ) (xs : list $ α ⊕ β) : m (list $ α ⊕ γ) :=
+xs.mmap (mmap_live f)
+
+meta def mmap_reversed_live' (f : β → m γ) (xs : list $ α ⊕ β) : m (list $ α ⊕ γ) :=
+mmap_reversed (mmap_live f) xs
+
+meta def par_join (xs : list (task unit)) : tactic unit :=
+pure $ xs.foldl (function.const _ task.get) ()
+
+meta def par_mmap' {α} (f : α → tactic unit) (xs : list α) : tactic unit :=
+do ys ← xs.mmap $ tactic.run_async ∘ f,
+   par_join ys
+
+meta def par_mmap {α β} (f : α → tactic β) (xs : list α) : tactic (list β) :=
+do ys ← xs.mmap $ tactic.run_async ∘ f,
+   pure $ ys.map task.get
+
+end list
+
+namespace expr
+
+meta def instantiate_pi : expr → list expr → expr
+| (expr.pi n bi d b) (e::es) := instantiate_pi (b.instantiate_var e) es
+| e _ := e
+
+meta def sort_univ : expr → level
+| (sort ls) := ls
+| _ := level.zero
+
+end expr
+
+namespace tactic
+-- setup_tactic_parser
+-- meta def synth_pos (p : parse cur_pos) : tactic unit :=
+-- refine ``(%%(p))
+
+-- meta def bind {α β} (x : tactic α) (f : α → tactic β) (x : pos . synth_pos) : tactic β := fail "foo"
+
+-- run_cmd do
+--   x ← get_env,
+--   trace "bar"
+
+meta def simp_only (ls : list pexpr) (attrs : list name := []) (loc : option name := none) : tactic unit :=
+do let ls := ls.map (simp_arg_type.expr), -- >>= simp_lemmas.append_pexprs simp_lemmas.mk [],
+   -- interactive.dsimp tt ls [] (interactive.loc.ns [none])
+   interactive.simp none tt ls attrs (interactive.loc.ns [loc])
+
+meta def mk_substitution (vs : list expr) : tactic (list expr × list (name × expr)) :=
+do vs' ← intron' vs.length,
+   let σ := (vs.map expr.local_uniq_name).zip vs',
+   pure (vs', σ)
+
+meta def lambdas' (xs : list $ list expr) (e : expr) : tactic expr :=
+xs.mfoldr lambdas e
+
+meta def pis' (xs : list $ list expr) (e : expr) : tactic expr :=
+xs.mfoldr pis e
+
+meta def add_eqn_lemmas (n : name) : tactic unit :=
+updateex_env $ λ e, pure $ e.add_eqn_lemma n
+
+-- replace with `mk_local_pis`
+meta def binders : expr → tactic (list expr)
+| (expr.pi n bi d b) :=
+  do v ← mk_local' n bi d,
+     (::) v <$> binders (b.instantiate_var v)
+| _ := pure []
+
+meta def match_induct_hyp (n : name) : list expr → list expr → tactic (list $ expr × option expr)
+| [] [] := pure []
+| [] _ := fail "wrong number of inductive hypotheses"
+| (x :: xs) [] := (::) (x,none) <$> match_induct_hyp xs []
+| (x :: xs) (h :: hs) :=
+do t ← infer_type x,
+   if t.is_app_of n
+     then (::) (x,h) <$> match_induct_hyp xs hs
+     else (::) (x,none) <$> match_induct_hyp xs (h :: hs)
+
+meta def rec_args_count (t c : name) : tactic ℕ :=
+do ct ← mk_const c >>= infer_type,
+   (list.length ∘ list.filter (λ v : expr, v.local_type.is_app_of t)) <$> binders ct
+
+meta def better_induction (e : expr) : tactic $ list (name × list (expr × option expr) × list (name × expr)) :=
+do t ← infer_type e,
+   let tn := t.get_app_fn.const_name,
+   env ← get_env,
+   focus1 $
+   do vs ← induction e,
+      gs ← get_goals,
+      vs' ← list.mzip_with₃ (λ n g (pat : name × list expr × list (name × expr)),
+        do let ⟨_,args,σ⟩ := pat,
+           set_goals [g],
+           nrec ← rec_args_count tn n,
+           let ⟨args,rec⟩ := args.split_at (args.length - nrec),
+           args ← match_induct_hyp tn args rec,
+           pure ((n,args,σ))) (env.constructors_of tn) gs vs,
+      set_goals gs,
+      pure vs'
+
+meta def prove_goal_async' (xs : list expr) (tac : tactic unit) : tactic unit := do
+tgt ← target, tgt' ← instantiate_mvars tgt >>= pis xs,
+env ← get_env, tgt' ← return $ env.unfold_untrusted_macros tgt',
+when tgt.has_meta_var (fail "goal contains metavariables"),
+params ← return tgt.collect_univ_params,
+lemma_name ← new_aux_decl_name,
+proof ← run_async (do
+  goal_meta ← mk_meta_var tgt,
+  set_goals [goal_meta],
+  tac,
+  proof ← instantiate_mvars goal_meta,
+  proof ← return $ env.unfold_untrusted_macros proof,
+  proof ← lambdas xs proof,
+  when proof.has_meta_var $ fail "async proof failed: contains metavariables",
+  return proof),
+add_decl $ declaration.thm lemma_name params tgt' proof,
+exact $ (expr.const lemma_name (params.map level.param)).mk_app xs
+
+meta def renew : expr → tactic expr
+| (expr.local_const uniq pp bi t) := mk_local' pp bi t
+| e := fail format!"{e} is not a local constant"
+
+end tactic
+
+
+def cache {α} (x : α) := { y : α // y = x }
+
+def cache.init {α} {x : α} : cache x := ⟨x,rfl⟩
+
+noncomputable def classical.indefinite_description' {α : Sort*} (p : α → Prop) (h : ∃ (x : α), p x) : psigma p :=
+let ⟨x,h'⟩ := classical.indefinite_description p h in ⟨x,h'⟩
+
+namespace tactic
+
+meta def init_cache : tactic unit :=
+refine ``(subtype.mk _ rfl)
+
+end tactic
+
+meta instance {α : Type*} [has_to_format α] {x : α} : has_to_format (cache x) :=
+subtype.has_to_format
+
+namespace tactic
+
+open native
+
+meta def solve_async (vs : list $ list expr) (p : expr) (tac : tactic unit) : tactic (task expr) :=
+run_async $ do
+  pr ← prod.snd <$> solve_aux p tac >>= instantiate_mvars,
+  vs.reverse.mfoldl (flip lambdas) pr
+
+def elim {α β γ} (f : α → γ) (g : β → γ) : α ⊕ β → γ :=
+λ x, sum.rec_on x f g
+
+meta def map_arg' (m : rb_map expr expr) : expr → expr → tactic expr
+| e (expr.pi n bi d b) :=
+do v ← mk_local' n bi d,
+   e' ← head_beta (e v) >>= whnf,
+   map_arg' e' (b.instantiate_var v) >>= lambdas [v]
+| e v@(expr.local_const _ _ _ _) :=
+do some f ← pure $ m.find v | pure e,
+   pure $ f e
+| e _ := pure e
+
+meta def map_arg (m : rb_map expr expr) (e : expr) : tactic expr :=
+infer_type e >>= whnf >>= map_arg' m e
+
+meta def find_dead_occ (n : name) : rb_map expr ℕ → expr → rb_map expr ℕ
+| m `(%%a → %%b) := find_dead_occ (a.list_local_consts.foldl rb_map.erase m) b
+| m (expr.local_const _ _ _ _) := m
+| m e :=
+if e.get_app_fn.const_name = n
+  then m
+  else e.list_local_consts.foldl rb_map.erase m
+
+meta def live_vars (induct : inductive_type) : tactic $ list $ expr × bool :=
+do let n := induct.name,
+   let params : list expr := induct.params,
+   let e := (@expr.const tt n induct.u_params).mk_app induct.params,
+   let vs := rb_map.of_list $ params.enum.map prod.swap,
+   let ls := induct.ctors,
+   ls ← ls.mmap $ λ c,
+     do { ts ← c.args.mmap infer_type,
+          pure $ ts.foldl (find_dead_occ n) vs },
+   let m := ls.foldl rb_map.intersect vs,
+   let m' := params.map $ λ x, (x,m.contains x),
+   pure m'
+
+meta instance : has_repr expr := ⟨ to_string ⟩
+meta instance task.has_repr {α} [has_repr α] : has_repr (task α) := ⟨ repr ∘ task.get ⟩
+
+open level
+meta def level.repr : level → ℕ → string
+| zero n := repr n
+| (succ a) n := level.repr a n.succ
+| (max x y) n := sformat!"(max {level.repr x n} {level.repr y n})"
+| (imax x y) n := sformat!"(imax {level.repr x n} {level.repr y n})"
+| (param a) n := if n = 0 then repr a
+                          else sformat!"({n} + {repr a})"
+| (mvar a) n := if n = 0 then repr a
+                         else sformat!"({n} + {repr a})"
+
+meta instance level.has_repr : has_repr level := ⟨ λ l, level.repr l 0 ⟩
+
+def no_print {α} (x : string) (y : α) := y
+
+meta instance no_print.has_to_format {msg : string} (x : Sort*) : has_to_format (no_print msg x) :=
+⟨ λ _, format!"⟨ {msg} ⟩" ⟩
+
+attribute [derive has_to_format] reducibility_hints
+
+meta def both {α} : α ⊕ α → α
+| (sum.inl x) := x
+| (sum.inr x) := x
+
+def get_left {α β} : α ⊕ β → option α
+| (sum.inl x) := some x
+| (sum.inr x) := none
+
+def get_right {α β γ} (f : β → γ) : α ⊕ β → option γ
+| (sum.inl x) := none
+| (sum.inr x) := some (f x)
+
+@[derive has_to_format]
+meta structure internal_mvfunctor :=
+(decl : no_print "declaration" declaration)
+(induct : inductive_type)
+(def_name eqn_name map_name abs_name repr_name pfunctor_name : name)
+(univ_params : list level)
+(vec_lvl : level)
+-- (live_params : list $ expr × ℕ)
+-- (dead_params : list $ expr × ℕ)
+-- (params : list expr)
+(params' : list $ expr ⊕ expr) -- dead on the left, live on the right
+(live_params' : cache $ params'.filter_map (get_right id) . init_cache)
+(dead_params' : cache $ params'.filter_map get_left . init_cache)
+(type : expr)
+
+-- meta def internal_mvfunctor.map_live (fn : internal_mvfunctor) (f : expr → expr) : list expr :=
+-- fn.live_params.map $ f ∘ prod.fst
+
+-- meta def internal_mvfunctor.mmap_live {m} [monad m] (fn : internal_mvfunctor) (f : expr → m expr) : m (list expr) :=
+-- fn.live_params.mmap $ f ∘ prod.fst
+
+-- meta def inductive_type.to_format (decl : inductive_type) : tactic format :=
+-- do let n₀ := name.anonymous,
+--    t ← pis decl.idx decl.type,
+--    cn ← mk_local_def (decl.name.replace_prefix decl.pre n₀) t,
+--    brs ← decl.ctors.mmap $ λ c,
+--        do { let rt := cn.mk_app c.result,
+--             t ← pis c.args rt >>= pp,
+--             pure format!"| {(c.name.update_prefix n₀).to_string} : {t}" },
+--    args ← decl.params.mmap $ λ p,
+--      do { t ← infer_type p >>= pp,
+--           pure $ expr.fmt_binder p.local_pp_name p.binding_info t },
+--    t ← pp t,
+--    let xs := format!"
+-- inductive {cn} {format.intercalate \" \" args} : {t}
+-- {format.intercalate \"\n\" brs}",
+--    return xs
+
+meta def internalize_mvfunctor (ind : inductive_type) : tactic internal_mvfunctor :=
+do let decl := declaration.cnst ind.name ind.u_names ind.type tt,
+   let n := decl.to_name,
+   let df_name := n <.> "internal",
+   let lm_name := n <.> "internal_eq",
+   (params,t) ← mk_local_pis decl.type,
+   let params := ind.params ++ params,
+   ps ← live_vars ind,
+   let ps := ps.map $ λ ⟨e,b⟩, if b then sum.inr e else sum.inl e,
+   -- let m := rb_map.sort prod.snd m.to_list,
+   -- let m' := rb_map.sort prod.snd m'.to_list,
+   u ← mk_meta_univ,
+   let vars := string.intercalate "," (ps.map to_string),
+   (params.mmap' (λ e, infer_type e >>= unify (expr.sort u))
+     <|> fail format!"live type parameters ({params}) are not in the same universe" : tactic _),
+   (level.succ u) ← get_univ_assignment u <|> pure level.zero.succ,
+   ts ← (params.mmap infer_type : tactic _),
+   pure { decl := decl,
+          induct := ind,
+          def_name := df_name,
+          eqn_name := lm_name,
+          map_name := (df_name <.> "map"),
+          abs_name := (df_name <.> "abs"),
+          repr_name := (df_name <.> "repr"),
+          pfunctor_name := n <.> "pfunctor",
+          vec_lvl := u,
+          univ_params := decl.univ_params.map level.param,
+          -- live_params := m,
+          -- dead_params := m',
+          params' := ps,
+          type := t }
+
+meta def internal_mvfunctor.live_params (p : internal_mvfunctor) : list expr :=
+p.live_params'.val
+-- p.params'.filter_map $ λ v, sum.cases_on v some $ λ _, none -- λ ⟨x,l⟩, x <$ guard l
+
+meta def internal_mvfunctor.dead_params (p : internal_mvfunctor) : list expr :=
+p.dead_params'.val
+-- filter_map $ λ v, sum.cases_on v (λ _, none) some
+
+meta def internal_mvfunctor.params (p : internal_mvfunctor) : list expr :=
+p.params'.map both
+
+open bitraversable
+
+notation `⦃ ` r:( foldr `, ` (h t, typevec.append1 t h) fin2.elim0 ) ` ⦄` := r
+notation `⦃`  `⦄` := typevec.nil
+
+local prefix `♯`:0 := cast (by try { simp only with typevec }; congr' 1; try { simp only with typevec })
+
+meta def mk_internal_functor_def (func : internal_mvfunctor) : tactic unit :=
+do let trusted := func.decl.is_trusted,
+   let arity := func.live_params.length,
+   let vec := @expr.const tt ``_root_.typevec [func.vec_lvl] `(arity),
+   v_arg ← mk_local_def `v_arg vec,
+   t ← pis (func.dead_params ++ [v_arg]) func.type,
+   (_,df) ← @solve_aux unit t $ do
+     { vs ← func.params'.mmap_dead' $ λ v, intro v.local_pp_name,
+       vs ← vs.mmap_reversed_live' $ λ x : expr, do
+         { refine ``(typevec.cases_cons _ _),
+           x' ← intro x.local_pp_name,
+           pure x' },
+       refine ``(typevec.cases_nil _),
+       let e := (@expr.const tt func.decl.to_name (func.decl.univ_params.map level.param)).mk_app $ vs.map both,
+       exact e },
+   df ← instantiate_mvars df,
+   add_decl $ declaration.defn func.def_name func.decl.univ_params t df (reducibility_hints.regular 1 tt) trusted
+
+meta def mk_live_vec (u : level) (vs : list expr) : tactic expr :=
+trace_scope $
+do let nil : expr := expr.const ``typevec.nil [u],
+   vs.reverse.mfoldr (λ e s, mk_mapp ``typevec.append1 [none,s,e]) nil
+
+meta def mk_map_vec (u u' : level) (vs : list expr) : tactic expr :=
+do let nil : expr := expr.const ``typevec.nil [u],
+   let nil' : expr := expr.const ``typevec.nil [u'], --  [u.succ.succ] (expr.sort u.succ),
+   nil_fun ← mk_mapp ``typevec.nil_fun [nil,nil'],
+   vs.reverse.mfoldr (λ e s, do
+     app ← mk_const ``typevec.append_fun,
+     mk_mapp ``typevec.append_fun [none,none,none,none,none,s,e]) nil_fun
+
+meta def mk_internal_functor_app (func : internal_mvfunctor) : tactic expr :=
+trace_scope $
+do let decl := func.decl,
+   vec ← mk_live_vec func.vec_lvl $ func.live_params,
+   pure $ (@expr.const tt func.def_name decl.univ_levels).mk_app (func.dead_params ++ [vec])
+
+meta def mk_internal_functor_eqn (func : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do let decl := func.decl,
+   lhs ← mk_internal_functor_app func,
+   let rhs := (@expr.const tt decl.to_name decl.univ_levels).mk_app func.params,
+   trace_expr lhs,
+   trace_expr rhs,
+   p ← mk_app `eq [lhs,rhs] >>= pis func.params,
+   pr ← solve_async [] p $ intros >> reflexivity,
+   add_decl $ declaration.thm func.eqn_name decl.univ_params p pr
+
+meta def mk_internal_functor (n : name) : tactic internal_mvfunctor :=
+do d ← inductive_type.of_name n,
+   func ← internalize_mvfunctor d,
+   mk_internal_functor_def func,
+   mk_internal_functor_eqn func,
+   pure func
+
+meta def mk_internal_functor' (d : interactive.inductive_decl) : tactic internal_mvfunctor :=
+do d ← inductive_type.of_decl d,
+   mk_inductive d,
+   func ← internalize_mvfunctor d,
+   mk_internal_functor_def func,
+   mk_internal_functor_eqn func,
+   pure func
+
+open typevec
+
+meta def destruct_typevec₃ {α} (params : list (α ⊕ expr)) (v : name) : tactic (list $ α ⊕ fn_var) :=
+do vs ← params.mmap_reversed_live' $ λ x : expr, do
+     { refine ``(typevec.typevec_cases_cons₃ _ _),
+       α ← get_unused_name `α >>= intro,
+       β ← get_unused_name `β >>= intro,
+       f ← get_unused_name `f >>= intro,
+       pure $ fn_var.mk α β f },
+   refine ``(typevec.typevec_cases_nil₃ _),
+   pure vs
+
+meta def destruct_typevec' {α} (params : list (α ⊕ expr)) (v : name) : tactic (list $ α ⊕ expr) :=
+do vs ← params.mmap_reversed_live' $ λ x : expr, do
+     { refine ``(typevec.cases_cons _ _),
+       α ← get_unused_name `α >>= intro,
+       pure α },
+   refine ``(typevec.cases_nil _),
+   pure vs
+
+-- def mk_arg_list {α} (xs : list (α × ℕ)) : list α :=
+-- (rb_map.sort prod.snd xs).map prod.fst
+
+meta def internal_expr (func : internal_mvfunctor) :=
+(@expr.const tt func.def_name func.decl.univ_levels).mk_app func.dead_params
+
+meta def functor_expr (func : internal_mvfunctor) :=
+(@expr.const tt func.pfunctor_name func.decl.univ_levels).mk_app func.dead_params
+
+meta def mk_mvfunctor_map (func : internal_mvfunctor) : tactic expr :=
+trace_scope $
+do let decl := func.decl,
+   let intl := internal_expr func,
+   let arity := func.live_params.length,
+   α ← mk_local_def `α $ @expr.const tt ``typevec [func.vec_lvl] `(arity),
+   β ← mk_local_def `β $ @expr.const tt ``typevec [func.vec_lvl] `(arity),
+   f ← mk_app ``typevec.arrow [α,β] >>= mk_local_def `f,
+   let r := expr.imp (intl α) (intl β),
+
+   map_t ← pis (func.dead_params ++ [α,β,f]) r,
+   (_,df) ← @solve_aux unit map_t $ do
+     { vs ← func.params'.mmap_dead' $ λ _, intro1,
+       -- let vs := vs.zip $ func.dead_params.map prod.snd,
+       mαβf ← destruct_typevec₃ vs `α,
+       let m : rb_map expr expr := rb_map.of_list $ mαβf.filter_map $ get_right (λ ⟨α,β,f⟩, (α,f)),
+       let mαβ : list expr := mαβf.map $ elim id fn_var.codom, -- λ ⟨α,β,f,i⟩, (β,i),
+       target >>= instantiate_mvars >>= unsafe_change,
+       let e := (@expr.const tt func.eqn_name func.decl.univ_levels),
+       g ← target,
+       (g',_) ← solve_aux g $
+         repeat (rewrite_target e) >> target,
+       unsafe_change g',
+       x ← intro1,
+       xs ← cases_core x,
+       xs.mmap' $ λ ⟨c, args, _⟩, do
+         { let e := (@expr.const tt c decl.univ_levels).mk_app mαβ,
+           args' ← args.mmap (map_arg m),
+           exact $ e.mk_app args' } },
+   df ← instantiate_mvars df,
+   add_decl' $ declaration.defn func.map_name decl.univ_params map_t df (reducibility_hints.regular 1 tt) decl.is_trusted
+open expr
+
+meta def mk_vecs {α} (l : level) (xs : list (α ⊕ fn_var)) : tactic (expr × expr × expr) :=
+do let live := xs.filter_map $ get_right id,
+   v  ← mk_live_vec l $ live.map fn_var.dom,
+   v' ← mk_live_vec l $ live.map fn_var.codom,
+   f ← mk_map_vec l l $ live.map fn_var.fn,
+   pure (v,v',f)
+
+meta def mk_functor_map (func : internal_mvfunctor) : tactic expr :=
+do params ← func.params'.mmap $ bitraverse (pure ∘ to_implicit_local_const) mk_fn_var,
+   let F := (@const tt func.induct.name func.induct.u_params).mk_app $ params.map $ elim id fn_var.dom,
+   let F' := (@const tt func.induct.name func.induct.u_params).mk_app $ params.map $ elim id fn_var.codom,
+   x ← mk_local_def `x F,
+   (v,v',f) ← mk_vecs func.vec_lvl params,
+   let map := (@const tt func.map_name func.univ_params).mk_app func.dead_params v v' f x,
+   t ← pis' [params.bind decls, [x]] F',
+   df ← lambdas' [params.bind decls, [x]] map,
+   add_decl' $ mk_definition (func.induct.name <.> "map") func.induct.u_names t df
+
+meta def mk_mvfunctor_map_eqn (func : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do env ← get_env,
+   let decl := func.decl,
+   let cs := env.constructors_of func.decl.to_name,
+   params' ← func.params'.mmap_live' mk_fn_var,
+
+   let arity := func.live_params.length,
+   -- fs ← mzip_with (λ v v' : expr × ℕ, prod.mk v.1 <$> mk_local_def ("f" ++ to_string v.2 : string) (v.1.imp v'.1)) func.live_params live_params',
+   -- let get_arg : expr × expr × expr → expr := prod.fst,
+   -- let get_arg' : expr × expr × expr → expr := prod.fst ∘ prod.snd,
+   -- let get_fn : expr × expr × expr → expr := prod.snd ∘ prod.snd,
+   let m : rb_map expr expr := rb_map.of_list $ params'.filter_map $ get_right (λ x, (fn_var.dom x, fn_var.fn x)),
+   let fs := params'.filter_map get_fn,
+   let flat := params'.bind decls,
+   cs.enum.mmap' $ λ ⟨i,c⟩, do
+     { let c := @expr.const tt c func.decl.univ_levels,
+       let e := c.mk_app func.params,
+       -- trace live_params',
+       let e' := c.mk_app $ params'.map $ elim id fn_var.codom,
+       t  ← infer_type e,
+       (vs,_) ← mk_local_pis t,
+       t' ← infer_type e',
+       vs' ← vs.mmap (map_arg m),
+       α ← mk_live_vec func.vec_lvl func.live_params,
+       β ← mk_live_vec func.vec_lvl $ params'.filter_map get_codom,
+       f ← mk_map_vec func.vec_lvl func.vec_lvl fs,
+       let x := e.mk_app vs,
+       -- trace_expr x,
+       let map_e := (@expr.const tt func.map_name func.decl.univ_levels).mk_app' [func.dead_params, [α,β,f,x]],
+       let map_e' := (@expr.const tt (func.induct.name <.> "map") func.decl.univ_levels).mk_app' [flat, [x]],
+       -- trace_expr map_e,
+       -- trace_expr e',
+       -- trace! "{vs'} : {vs'.mmap infer_type}",
+       -- trace_expr (e'.mk_app vs'),
+       eqn ← mk_app `eq [map_e,(e'.mk_app vs')] >>= pis (params'.bind  decls++ vs) >>= instantiate_mvars,
+       eqn' ← mk_app `eq [map_e',(e'.mk_app vs')] >>= pis (params'.bind  decls++ vs) >>= instantiate_mvars,
+       pr ← solve_async [] eqn $ do
+         { intros >> reflexivity },
+       let n := func.map_name <.> ("_equation_" ++ to_string i),
+       d ← add_decl' $ declaration.thm n decl.univ_params eqn pr,
+       add_eqn_lemmas n,
+       simp_attr.typevec.set n () tt,
+       let n := func.induct.name <.> "map" <.> ("_equation_" ++ to_string i),
+       d ← add_decl' $ declaration.thm n decl.univ_params eqn' pr,
+       add_eqn_lemmas n,
+       simp_attr.typevec.set n () tt,
+       pure () }
+
+meta def mk_mvfunctor_instance (func : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do map_d ← mk_mvfunctor_map func,
+   mk_functor_map func,
+   mk_mvfunctor_map_eqn func,
+   vec ← mk_live_vec func.vec_lvl $ func.live_params,
+   let decl := func.decl,
+   let vs := func.dead_params,
+   let intl := (@expr.const tt func.def_name decl.univ_levels).mk_app vs,
+   -- trace intl,
+   t ← mk_app ``mvfunctor [intl] >>= pis vs,
+   (_,df) ← @solve_aux unit t $ do
+     { vs ← intro_lst $ vs.map expr.local_pp_name,
+       to_expr ``( { mvfunctor . map := %%(map_d.mk_app vs) } ) >>= exact },
+   df ← instantiate_mvars df,
+   let inst_n := func.def_name <.> "mvfunctor",
+   add_decl $ declaration.defn inst_n func.decl.univ_params t df (reducibility_hints.regular 1 tt) func.decl.is_trusted,
+   set_basic_attribute `instance inst_n,
+   pure ()
+
+open expr (const)
+
+meta def mk_head_t (decl : inductive_type) (func : internal_mvfunctor) : tactic inductive_type :=
+do let n := decl.name,
+   let head_n := (n <.> "head_t"),
+   let sig_c  : expr := const n decl.u_params,
+   cs ← decl.ctors.mmap $ λ d : type_cnstr,
+   do { vs' ← d.args.mfilter $ λ v,
+          do { t ← infer_type v,
+               pure $ ¬ ∃ v ∈ func.live_params, expr.occurs v t },
+        pure { name := d.name.update_prefix head_n, args := vs', .. d } },
+   let decl' := { name := head_n, ctors := cs, params := func.dead_params, .. decl },
+   decl' <$ mk_inductive decl'
+
+meta def mk_child_t (decl : inductive_type) (func : internal_mvfunctor) : tactic (list inductive_type) :=
+do let n := decl.name,
+   let dead := func.dead_params,
+   let live := func.live_params,
+   let mk_constr : name → expr := λ n', (const (n'.update_prefix $ n <.> "head_t") decl.u_params).mk_app dead,
+   let head_t : expr := const (n <.> "head_t") decl.u_params,
+   live.mmap $ λ l : expr,
+     do let child_n := (n <.> "child_t" ++ l.local_pp_name),
+        let sig_c  : expr := const n decl.u_params,
+        cs ← (decl.ctors.mmap $ λ d : type_cnstr,
+          do { (rec,vs') ← d.args.mpartition $ λ v,
+                 do { t ← infer_type v,
+                      pure $ expr.occurs l t },
+               vs' ← vs'.mfilter $ λ v,
+                 do { t ← infer_type v,
+                      pure $ ¬ ∃ v ∈ live, expr.occurs v t },
+               rec.enum.mmap $ λ ⟨i,r⟩, do
+                 (args',r') ← infer_type r >>= mk_local_pis,
+                 pure { name := (d.name.append_after i).update_prefix $ n <.> "child_t"  ++ l.local_pp_name,
+                        args := vs' ++ args', result := [(mk_constr d.name).mk_app vs'], .. d } } : tactic _),
+        idx ← (mk_local_def `i $ head_t.mk_app $ dead : tactic _),
+        let decl' := { name := child_n,
+                       params := dead,
+                       idx := decl.idx ++ [idx],
+                       ctors := cs.join, .. decl },
+        decl' <$ mk_inductive decl'
+
+meta def inductive_type.of_pfunctor (func : internal_mvfunctor) : tactic inductive_type :=
+do let d := func.decl,
+   let params := func.params,
+   (idx,t) ← mk_local_pis (d.type.instantiate_pi params),
+   env ← get_env,
+   cs ← (env.constructors_of d.to_name).mmap $ λ c : name,
+   do { let e := @const tt c d.univ_levels,
+        t ← infer_type $ e.mk_app params,
+        (vs,t) ← mk_local_pis t,
+        let infer := implicit_infer_kind_of $ vs.take params.length,
+        pure (t.get_app_fn.const_name,{ type_cnstr .
+               name := c,
+               args := vs,
+               result := t.get_app_args.drop $ env.inductive_num_params d.to_name,
+               infer  := infer }) },
+   pure { pre     := func.induct.pre,
+          name    := d.to_name,
+          u_names := d.univ_params,
+          params  := params,
+          idx     := idx, type := t,
+          ctors   := cs.map prod.snd }
+
+meta def mk_child_t_vec (decl : inductive_type) (func : internal_mvfunctor) (vs : list inductive_type) : tactic expr :=
+do let n := decl.name,
+   let dead := func.dead_params,
+   let live := func.live_params,
+   let head_t := (@const tt (n <.> "head_t") func.decl.univ_levels).mk_app dead,
+   let child_n := (n <.> "child_t"),
+   let arity := live.length,
+   hd_v ← mk_local_def `hd head_t,
+   (expr.sort u') ← pure decl.type,
+   let u := u'.pred,
+   let vec_t := @const tt ``typevec [u] (reflect arity),
+   t ← pis (dead ++ [hd_v]) vec_t,
+   let nil : expr := expr.const ``typevec.nil [u],
+   vec ← live.reverse.mfoldr (λ e v,
+     do c ← mk_const $ child_n ++ e.local_pp_name,
+        let c := (@const tt (n <.> "child_t" ++ e.local_pp_name) func.decl.univ_levels).mk_app dead hd_v,
+        mv ← mk_mvar,
+        unify_app (const ``append1 [u]) [mv,v,c]) nil,
+   df ← (instantiate_mvars vec >>= lambdas (dead ++ [hd_v]) : tactic _),
+   let r := reducibility_hints.regular 1 tt,
+   add_decl' $ declaration.defn child_n func.decl.univ_params t df r tt,
+   pure $ expr.const child_n $ func.induct.u_params
+
+meta def mk_pfunctor (func : internal_mvfunctor) : tactic unit :=
+do d ← inductive_type.of_pfunctor func,
+   hd ← mk_head_t d func,
+   ch ← mk_child_t d func,
+   mk_child_t_vec d func ch,
+   let arity := func.live_params.length,
+   (expr.sort u') ← pure d.type,
+   let u := u'.pred,
+   let dead := func.dead_params,
+   let vec_t := @const tt ``mvpfunctor [u] $ reflect arity,
+   t ← pis dead vec_t,
+   let n := d.name,
+   let head_t := (@const tt (n <.> "head_t") func.decl.univ_levels).mk_app dead,
+   let child_t := (@const tt (n <.> "child_t") func.decl.univ_levels).mk_app dead,
+   df ← (mk_mapp ``mvpfunctor.mk [some $ reflect arity, head_t,child_t] >>= lambdas dead : tactic _),
+   add_decl $ mk_definition func.pfunctor_name func.decl.univ_params t df,
+   pure ()
+
+meta def mk_pfunc_constr (func : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do env ← get_env,
+   let cs := env.constructors_of func.decl.to_name,
+   let u := func.type.sort_univ.pred,
+   let u' := func.univ_params.foldl level.max u,
+   let dead := func.dead_params,
+   let live := func.live_params,
+   let out_t :=  (@const tt func.pfunctor_name func.univ_params).mk_app dead,
+   vec_t ← mk_live_vec func.vec_lvl live,
+   let arity := func.live_params.length,
+   let fn := @const tt ``mvpfunctor.obj [u],
+   r ← unify_app fn [reflect arity,out_t,vec_t],
+   cs.mmap $ λ c,
+     do { let p := c.update_prefix (c.get_prefix <.> "pfunctor"),
+          let hd_c := c.update_prefix (func.decl.to_name <.> "head_t"),
+          let e := (@const tt c func.univ_params).mk_app func.params,
+          (args,_) ← infer_type e >>= mk_local_pis,
+          sig ← pis (func.params ++ args) r,
+          (rec,vs') ← args.mpartition $ λ v,
+                 do { t ← infer_type v,
+                      pure $ ¬ ∃ v ∈ live, expr.occurs v t },
+
+          let e := ((@const tt hd_c func.univ_params).mk_app dead).mk_app rec,
+          ms ← live.mmap $ λ l,
+                do { let l_name := l.local_pp_name,
+                     vs' ← vs'.mfilter $ λ v,
+                       do { t ← infer_type v,
+                            pure $ expr.occurs l t },
+                     y ← infer_type e >>= mk_local_def `y,
+                     hy ← mk_app `eq [y,e] >>= mk_local_def `hy,
+                     let ch_t := (@const tt (func.decl.to_name <.> "child_t" ++ l_name) func.univ_params).mk_app func.dead_params y,
+                     let ch_c := c.update_prefix (func.decl.to_name <.> "child_t" ++ l_name),
+                     t ← pis (vs' ++ rec ++ [y,hy]) $ ch_t.imp l,
+                     (_,f) ← @solve_aux unit t $ do
+                       { (vs',σ₀) ← mk_substitution vs' ,
+                         (rec,σ₁) ← mk_substitution rec ,
+                         y ← intro1, hy ← intro1,
+                         x ← intro `x,
+                         interactive.generalize `hx () (to_pexpr x,`x'),
+                         solve1 $ do
+                         { a ← better_induction x,
+                           gs ← get_goals,
+                           rs ← mzip_with (λ (x : name × list (expr × option expr) × list (name × expr)) g,
+                             do let ⟨ctor,a,b⟩ := x,
+                                set_goals [g],
+                                cases $ hy.instantiate_locals b,
+                                gs ← get_goals,
+                                pure $ gs.map $ λ g, (a,b,g)) a gs,
+                           mzip_with' (λ (v : expr) (r : list (expr × option expr) × list (name × expr) × expr),
+                             do let (a,b,g) := r,
+                                set_goals [g],
+                                x' ← get_local `x',
+                                expr.app _ t ← infer_type x',
+                                let ts := t.get_app_args.length - func.dead_params.length,
+                                let a' := (a.drop ts).map prod.fst, exact $ v.mk_app a' ) vs' rs.join,
+                           skip } },
+                     pr ← mk_eq_refl e,
+                     pure $ f.mk_app $ vs' ++ rec ++ [e,pr] },
+          (_,df) ← solve_aux r $ do
+            { m ← mk_map_vec func.vec_lvl func.vec_lvl ms,
+              refine ``( ⟨ %%e, _ ⟩ ),
+              exact m,
+              pure () },
+          let c' := c.update_prefix $ c.get_prefix <.> "pfunctor",
+          let vs := func.params ++ args,
+          r  ← pis vs r >>= instantiate_mvars,
+          df ← instantiate_mvars df >>= lambdas vs,
+          add_decl $ mk_definition c' func.decl.univ_params r df,
+          pure () },
+   pure ()
+
+-- meta def saturate' : expr → expr → tactic expr
+-- | (expr.pi n bi t b) e :=
+-- do v ← mk_meta_var t,
+--    t ← whnf $ b.instantiate_var v,
+--    saturate' t (e v)
+-- | t e := pure e
+
+-- meta def saturate (e : expr) : tactic expr :=
+-- do t ← infer_type e >>= whnf,
+--    saturate' t e
+
+open nat (hiding to_pexpr) expr
+
+meta def mk_motive : tactic expr :=
+do (pi en bi d b) ← target,
+   pure $ lam en bi d b
+
+meta def destruct_multimap' : ℕ → expr → expr → list expr → tactic (list expr)
+| 0 v₀ v₁ xs :=
+do C ← mk_motive,
+   refine ``(@typevec_cases_nil₂ %%C _),
+   pure xs
+| (succ n) v₀ v₁ xs :=
+do C ← mk_motive,
+   a ← mk_mvar, b ← mk_mvar,
+   to_expr ``(append1 %%a %%b) tt ff >>= unify v₀,
+   `(append1 %%a' %%b') ← pure v₁,
+   refine ``(@typevec_cases_cons₂ _ %%b %%b' %%a %%a' %%C _),
+   f ← intro `f,
+   destruct_multimap' n a a' (f :: xs)
+
+open_locale mvfunctor
+
+meta def destruct_multimap (e : expr) : tactic (list expr) :=
+do `(%%v₀ ⟹ %%v₁) ← infer_type e,
+   `(typevec %%n) ← infer_type v₀,
+   n ← eval_expr ℕ n,
+   n_h ← revert e,
+   destruct_multimap' n v₀ v₁ [] <*
+     intron (n_h-1)
+
+def santas_helper {n} {P : mvpfunctor n} {α} (C : P.obj α → Sort*) {a : P.A} {b} (b')
+  (x : C ⟨a,b⟩) (h : b = b') : C ⟨a,b'⟩ :=
+by cases h; exact x
+
+open list
+
+section zip_vars
+variables (n : name) (univs : list level)
+  (args : list expr) (shape_args : list expr)
+
+meta def mk_child_arg (e : expr × list expr) : list (expr × expr × ℕ) → list (expr × expr × ℕ) × list expr × expr
+| [] := ([],shape_args.tail,shape_args.head)
+| (⟨v,e',i⟩::vs) :=
+if v.occurs e.1
+  then let c : expr := const ( (n.update_prefix $ n.get_prefix ++ v.local_pp_name).append_after i ) univs
+       in ( ⟨v,e',i+1⟩::vs, shape_args, expr.lambdas e.2 $ e' $ c.mk_app $ args ++ e.2)
+  else prod.map (cons ⟨v,e',i⟩) id $ mk_child_arg vs
+
+meta def zip_vars' : list expr → list (expr × expr × ℕ) → list (expr × list expr) → list expr
+| _ xs [] := []
+| shape_args xs (v :: vs) :=
+let (xs',shape_args',v') := mk_child_arg n univs args shape_args v xs in
+v' :: zip_vars' shape_args' xs' vs
+
+meta def zip_vars (ls : list (expr × expr)) (vs : list expr) : tactic $ list expr :=
+do vs' ← vs.mmap $ λ v, do { (vs,_) ← infer_type v >>= mk_local_pis, pure (v,vs) },
+   pure $ zip_vars' n univs args shape_args (ls.map $ λ x, (x.1,x.2,0)) vs'
+
+end zip_vars
+
+meta def mk_pfunc_recursor (func : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do let u := fresh_univ func.induct.u_names,
+   v ← mk_live_vec func.vec_lvl $ func.live_params,
+   fn ← mk_app `mvpfunctor.obj [functor_expr func,v],
+   C ← mk_local' `C binder_info.implicit (expr.imp fn $ expr.sort $ level.param u),
+   let dead_params := func.dead_params,
+   cases_t ← func.induct.ctors.par_mmap $ λ c,
+   do { let n := c.name.update_prefix (func.decl.to_name <.> "pfunctor"),
+        let e := (@expr.const tt n func.induct.u_params).mk_app' [func.params,c.args],
+        prod.mk c <$> (pis c.args (C e) >>= mk_local_def `v) },
+   n ← mk_local_def `n fn,
+   (_,df) ← solve_aux (expr.pis [n] $ C n) $ do
+     { n ← intro1, [(_, [n_fst,n_snd], _)] ← cases_core n,
+       hs ← cases_core n_fst,
+       gs ← get_goals,
+       gs ← list.mzip_with₃ (λ h g v,
+         do { let ⟨c,h⟩ := (h : type_cnstr × expr),
+              set_goals [g],
+              ⟨n,xs,[(_,n_snd)]⟩ ← pure (v : name × list expr × list (name × expr)),
+              fs ← destruct_multimap n_snd,
+              n_snd ← mk_map_vec func.vec_lvl func.vec_lvl fs,
+              let child_n := c.name.update_prefix $ func.induct.name <.> "child_t",
+              let subst := func.live_params.zip fs,
+              h_args ← zip_vars child_n func.induct.u_params (dead_params ++ xs) xs subst c.args,
+              let h := h.mk_app h_args,
+              let n_fst := (@const tt n func.induct.u_params).mk_app $ func.dead_params ++ xs,
+              vec ← mk_live_vec func.vec_lvl $ func.live_params,
+              fn ← mk_const ``santas_helper,
+              unify_mapp fn [none,none,vec,C,none,none,n_snd,h,none] >>= refine ∘ to_pexpr,
+              reflexivity <|> (congr; ext [rcases_patt.many [[rcases_patt.one `_]]] none; reflexivity),
+              done }) cases_t gs hs,
+       pure () },
+   let vs := [func.params.map expr.to_implicit_local_const, C :: cases_t.map prod.snd],
+   df ← instantiate_mvars df >>= lambdas' vs,
+   t ← pis' (vs ++ [[n]]) (C n),
+   add_decl $ mk_definition (func.pfunctor_name <.> "rec") (u :: func.induct.u_names) t df,
+   pure ()
+
+meta def mk_pfunc_rec_eqns (func : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do let u := fresh_univ func.induct.u_names,
+   let rec := (@const tt (func.pfunctor_name <.> "rec") (level.param u :: func.induct.u_params)).mk_app func.params,
+   let eqn := (@const tt func.eqn_name func.induct.u_params).mk_app func.params,
+   (C::fs,_) ← infer_type rec >>= mk_local_pis,
+   let rec := rec C,
+   let fs := fs.init,
+   mzip_with' (λ (c : type_cnstr) (f : expr), do
+   { let cn := c.name.update_prefix $ c.name.get_prefix <.> "pfunctor",
+     let c := (@const tt cn func.induct.u_params).mk_app func.params,
+     (args,_) ← infer_type c >>= mk_local_pis,
+     let x := c.mk_app args,
+     t ← mk_app `eq [rec.mk_app' [fs,[x]],f.mk_app args] >>= pis' [func.params,C :: fs,args],
+     df ← solve_async [] t $ do
+     { intros, reflexivity },
+     let n := cn.append_suffix "_rec",
+     add_decl $ declaration.thm n (u :: func.induct.u_names) t df,
+     add_eqn_lemmas n,
+     simp_attr.typevec.set n () tt }) func.induct.ctors fs,
+   skip
+
+meta def mk_qpf_abs (func : internal_mvfunctor) : tactic unit :=
+do let n := func.live_params.length,
+   let dead_params := func.dead_params,
+   let e := (@const tt func.def_name func.induct.u_params).mk_app dead_params,
+   let e' := (@const tt func.pfunctor_name func.induct.u_params).mk_app dead_params,
+   t ← to_expr ``(∀ v, mvpfunctor.obj %%e' v → %%e v),
+   (_,df) ← @solve_aux unit t $ do
+   { params ← map both <$> destruct_typevec' func.params' `v,
+     C ← mk_motive,
+     -- let params := (rb_map.sort prod.snd $ func.dead_params ++ vs).map prod.fst,
+     let rec := @const tt (func.pfunctor_name <.> "rec") $ level.succ func.vec_lvl :: func.induct.u_params,
+     let branches := list.repeat (@none expr) func.induct.ctors.length,
+     rec ← unify_mapp rec (params.map some ++ C :: branches),
+     refine ∘ to_pexpr $ rec,
+     let cs := func.induct.ctors,
+     let c' := cs.map $ λ c : type_cnstr, c.name.update_prefix $ c.name.get_prefix <.> "pfunctor",
+     let eqn := (@const tt func.eqn_name func.induct.u_params).mk_app params,
+     cs.mmap $ λ c, solve1 $ do
+       { xs ← intros,
+         let n := c.name.update_prefix func.induct.name,
+         let e := (@const tt n func.induct.u_params).mk_app' [params,xs],
+         mk_eq_mpr eqn e >>= exact },
+     done },
+   t ← pis dead_params t,
+   df ← instantiate_mvars df >>= lambdas dead_params,
+   add_decl $ mk_definition func.abs_name func.induct.u_names t df
+
+meta def mk_qpf_repr (func : internal_mvfunctor) : tactic unit :=
+do let n := func.live_params.length,
+   let dead_params := func.dead_params,
+   let e := (@const tt func.def_name func.induct.u_params).mk_app dead_params,
+   let e' := (@const tt func.pfunctor_name func.induct.u_params).mk_app dead_params,
+   t ← to_expr ``(∀ v, %%e v → mvpfunctor.obj %%e' v),
+   (_,df) ← @solve_aux unit t $ do
+   { params ← map both <$> destruct_typevec' func.params' `v,
+     C ← mk_motive,
+     -- let params := (rb_map.sort prod.snd $ func.dead_params ++ vs),
+     let rec := @const tt (func.induct.name <.> "rec") $ level.succ func.vec_lvl :: func.induct.u_params,
+     let branches := list.repeat (@none expr) func.induct.ctors.length,
+     rec ← unify_mapp rec (params.map some ++ C :: branches),
+     refine ∘ to_pexpr $ rec,
+     let cs := func.induct.ctors,
+     let c' := cs.map $ λ c : type_cnstr, c.name.update_prefix $ c.name.get_prefix <.> "pfunctor",
+     let eqn := (@const tt func.eqn_name func.induct.u_params).mk_app params,
+     cs.mmap $ λ c, solve1 $ do
+       { xs ← intros,
+         let n := c.name.update_prefix func.pfunctor_name,
+         let e := (@const tt n func.induct.u_params).mk_app' [params,xs],
+         exact e },
+     done },
+   t ← pis dead_params t,
+   df ← instantiate_mvars df >>= lambdas dead_params,
+   add_decl $ mk_definition func.repr_name func.induct.u_names t df
+
+open bitraversable
+
+meta def mk_pfunctor_map_eqn (func : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do params ← mmap_live' mk_fn_var func.params',
+   -- fs ← mzip_with (λ x y : expr, mk_local_def `f $ x.imp y) func.live_params β,
+   let fs := params.filter_map $ elim (λ _, none) (some ∘ fn_var.fn),
+   vf ← mk_map_vec func.vec_lvl func.vec_lvl fs,
+   let cs := func.induct.ctors.map $ λ c : type_cnstr, c.name.update_prefix func.pfunctor_name,
+   let params' := params.map $ elim id fn_var.codom,
+   cs.mmap' $ λ cn,
+     do { let c := (@const tt cn func.induct.u_params).mk_app func.params,
+          let c' := (@const tt cn func.induct.u_params).mk_app params',
+          (vs,_) ← infer_type c >>= mk_local_pis,
+          lhs ← mk_app ``mvfunctor.map [vf,c.mk_app vs],
+          vs' ← vs.mmap $ λ v,
+            do { some ⟨_,_,f⟩ ← pure $ (params.filter_map $ get_right id).find $ λ x, x.dom.occurs v | pure v,
+                 (ws,_) ← infer_type v >>= mk_local_pis,
+                 lambdas ws (f $ v.mk_app ws) },
+          let rhs := c'.mk_app vs',
+          let params := params.bind decls,
+          t ← mk_app `eq [lhs,rhs] >>= pis' [params, vs],
+          df ← solve_async [] t $ do
+          { intros,
+            dunfold_target cs,
+            map_eq ← mk_const ``mvpfunctor.map_eq, rewrite_target map_eq { md := semireducible },
+            simp_only [``(append_fun_comp'),``(nil_fun_comp)],
+            done <|> reflexivity <|> (congr; ext [rcases_patt.many [[rcases_patt.one `_]]] none; reflexivity),
+            done },
+          let n := cn.append_suffix "_map",
+          add_decl $ declaration.thm n func.induct.u_names t df,
+          simp_attr.typevec.set n () tt },
+   skip
+
+meta def prove_abs_repr (func : internal_mvfunctor) : tactic unit :=
+do vs ← destruct_typevec' func.params' `α,
+   let cs := func.induct.ctors.map $ λ c : type_cnstr, c.name.update_prefix func.pfunctor_name,
+   x ← intro1, cases x,
+   repeat $ do
+   { dunfold_target [func.repr_name,func.abs_name],
+     simp_only [``(typevec.cases_nil_append1),``(typevec.cases_cons_append1)],
+     dunfold_target $ [func.pfunctor_name <.> "rec"] ++ cs,
+     `[dsimp],
+     reflexivity }
+
+meta def prove_abs_map (func : internal_mvfunctor) : tactic unit :=
+do vs ← destruct_typevec₃ func.params' `α,
+   C ← mk_motive,
+   -- let vs := vs.map $ λ ⟨α,β,f,i⟩, (α,i),
+   -- let params := (rb_map.sort prod.snd $ func.dead_params ++ vs).map prod.fst,
+   let params := vs.map $ elim id fn_var.dom,
+   let rec_n := func.pfunctor_name <.> "rec",
+   let rec := (@const tt rec_n $ level.zero :: func.induct.u_params).mk_app params C,
+   let cs := func.induct.ctors.map $ λ c : type_cnstr, c.name.update_prefix func.pfunctor_name,
+   apply rec,
+   all_goals $ do
+   { intros,
+     dunfold_target [func.repr_name,func.abs_name],
+     simp_only [``(typevec.cases_nil_append1),``(typevec.cases_cons_append1)] [`typevec],
+     reflexivity },
+   pure ()
+
+meta def mk_mvqpf_instance (func : internal_mvfunctor) : tactic unit :=
+do let n := func.live_params.length,
+   let dead_params := func.dead_params,
+   let e := (@const tt func.def_name func.induct.u_params).mk_app dead_params,
+   let abs_fn := (@const tt func.abs_name func.induct.u_params).mk_app dead_params,
+   let repr_fn := (@const tt func.repr_name func.induct.u_params).mk_app dead_params,
+   mk_qpf_abs func,
+   mk_qpf_repr func,
+   mk_pfunctor_map_eqn func,
+   pfunctor_i ← mk_mapp ``mvfunctor [some (reflect n),e] >>= mk_instance,
+   mvqpf_t ← mk_mapp ``mvqpf [some (reflect n),e,pfunctor_i] >>= instantiate_mvars,
+   (_,df) ← solve_aux mvqpf_t $ do
+     { let p := (@const tt func.pfunctor_name func.induct.u_params).mk_app dead_params,
+       refine ``( { P := %%p, abs := %%abs_fn, repr := %%repr_fn, .. } ),
+       prove_goal_async' dead_params $ prove_abs_repr func,
+       prove_goal_async' dead_params $ prove_abs_map func },
+   df ← instantiate_mvars df >>= lambdas dead_params,
+   mvqpf_t ← pis dead_params mvqpf_t,
+   let inst_n := func.def_name <.> "mvqpf",
+   add_decl $ mk_definition inst_n func.induct.u_names mvqpf_t df,
+   set_basic_attribute `instance inst_n
+
+meta def mk_conj : list expr → expr
+| [] := `(true)
+| [x] := x
+| (x :: xs) := @const tt ``and [] x (mk_conj xs)
+
+def list.lookup {α β} [decidable_eq α] (a : α) : list (α × β) → option β
+| []             := none
+| (⟨a', b⟩ :: l) := if h : a' = a then some b else list.lookup l
+
+meta def replace_all (e : expr) (σ : list (expr × expr)) : expr :=
+expr.replace e $ λ x _, list.lookup x σ
+
+meta def mk_liftp_eqns (func : internal_mvfunctor) : tactic unit :=
+do let my_t := (@const tt func.induct.name func.induct.u_params).mk_app func.params,
+   let F := (@const tt func.def_name func.induct.u_params).mk_app $ func.dead_params,
+   let internal_eq := (@const tt func.eqn_name func.induct.u_params).mk_app func.params,
+   x ← mk_local_def `x my_t,
+   x' ← mk_eq_mpr internal_eq x,
+   let live_params := func.live_params,
+   v ← mk_live_vec func.vec_lvl live_params,
+   fs ← live_params.mmap $ λ v, mk_local_def `f $ v.imp `(Prop),
+   let m := rb_map.of_list $ list.zip live_params fs,
+   fv ← mk_map_vec func.vec_lvl level.zero fs,
+   fv_map ← fs.mmap (λ f, mk_mapp ``subtype.val [none,f]) >>= mk_map_vec func.vec_lvl func.vec_lvl,
+   fv_t ← fs.mmap (λ f, mk_mapp ``subtype [none,f]) >>= mk_live_vec func.vec_lvl,
+   let n := func.live_params.length,
+   df ← mk_mapp ``mvfunctor.liftp' [`(n),F,none,v,fv],
+   func.induct.ctors.mmap $ λ c, do
+   { let e := (@const tt c.name func.induct.u_params).mk_app' [func.params, c.args],
+     x' ← mk_eq_mpr internal_eq e,
+     args ← c.args.mmap $ λ arg, do
+       { (args,rhs_t) ← infer_type arg >>= mk_local_pis,
+         (some f) ← pure $ m.find rhs_t | pure [],
+         list.ret <$> pis args (f $ arg.mk_app args) },
+     let rhs := mk_conj args.join,
+     t ← pis (c.args.map to_implicit_local_const) $ (df x').imp rhs,
+     df ← solve_async [func.params,fs] t $ do
+     { solve1 $ do
+       { args ← intron' c.args.length,
+         mk_const ``mvfunctor.liftp_def >>= rewrite_target,
+         dunfold_target [``mvfunctor.map],
+         h ← intro `h,
+         t ← infer_type h,
+         let n := func.live_params.length,
+         x ← mk_mapp ``subtype_ [`(n),none,fv],
+         y ← mk_mapp ``typevec.subtype_val [`(n),none,fv],
+         h' ← assertv `h' (replace_all t [(x,fv_t),(y,fv_map)]) h, clear h,
+         [(_,[x,y],_)] ← cases_core h',
+         hs ← cases_core x,
+         gs ← get_goals,
+         gs ← (gs.zip hs.enum).mmap $ λ ⟨g,i,n,x,b⟩,
+         do { set_goals [g],
+              eqn ← mk_const $ (func.induct.name ++ `internal.map._equation).append_after i,
+              h' ← rewrite_hyp eqn (y.instantiate_locals b) { md := semireducible },
+              t ← target,
+              cases h',
+              get_goals },
+         set_goals gs.join,
+         repeat $ do { split, intros, applyc ``subtype.property },
+         intros, applyc ``subtype.property <|> interactive.trivial,
+         done },
+       done },
+     t ← pis ((func.params ++ fs).map to_implicit_local_const) t,
+     let n := c.name.append_suffix "_liftp",
+     add_decl $ declaration.thm n func.induct.u_names t df },
+   skip
+
+-- #check @typevec.liftr_def
+-- #check @typevec.liftr'
+-- #exit
+meta def mk_exists : list expr → expr → tactic expr
+| [] e := pure e
+| (x :: xs) e :=
+trace_scope $
+  do e ← mk_exists xs e >>= lambdas [x],
+     mk_app ``Exists [e]
+
+meta def mk_liftp_defn' (func : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do let F := (@const tt func.induct.name func.induct.u_params).mk_app func.params,
+   x ← mk_local_def `x F,
+   params ← func.params'.mmap $ bitraverse (pure ∘ to_implicit_local_const) mk_pred_var,
+   let fs := params.filter_map $ get_right prod.snd,
+   let m := rb_map.of_list $ list.zip func.live_params fs,
+   let n := func.induct.name <.> "liftp",
+   cs ← func.induct.ctors.mmap $ λ c, do
+   { let constr := @const tt c.name func.induct.u_params,
+     args' ← c.args.mmap (λ arg₀ : expr, do
+       { (args,rhs_t) ← infer_type arg₀ >>= mk_local_pis,
+         (some f) ← pure $ m.find rhs_t | pure (sum.inl arg₀),
+         v ← pis args (f (arg₀.mk_app args) ) >>= mk_local_def `h,
+         pure (sum.inr (arg₀, v)) } ),
+     let x := constr.mk_app $ func.params ++ args'.map (elim id prod.fst),
+     pure { type_cnstr .
+           name := n ++ c.name,
+           args := args'.bind decls',
+           result := [x],
+           infer := environment.implicit_infer_kind.implicit  } },
+   let decl : inductive_type :=
+       { name := n,
+         params := params.bind decls',
+         idx := [x],
+         type := `(Prop),
+         ctors := cs,
+         .. func.induct },
+   mk_inductive decl,
+   skip
+
+meta def mk_liftr_defn' (func : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do let F := (@const tt func.induct.name func.induct.u_params).mk_app func.params,
+   x ← mk_local_def `x F, y ← mk_local_def `y F,
+   params ← func.params'.mmap $ bitraverse (pure ∘ to_implicit_local_const) mk_rel_var,
+   let fs := params.filter_map $ get_right prod.snd,
+   let m := rb_map.of_list $ list.zip func.live_params fs,
+   let n := func.induct.name <.> "liftr",
+   cs ← func.induct.ctors.mmap $ λ c, do
+   { args ← c.args.mmap renew,
+     let constr := @const tt c.name func.induct.u_params,
+     args' ← mzip_with (λ arg₀ arg₁ : expr, do
+       { (args,rhs_t) ← infer_type arg₀ >>= mk_local_pis,
+         (some f) ← pure $ m.find rhs_t | pure (sum.inl arg₀),
+         v ← pis args (f (arg₀.mk_app args) (arg₁.mk_app args) ) >>= mk_local_def `h,
+         pure (sum.inr $ fn_var.mk arg₀ arg₁ v) } ) c.args args,
+     let x := constr.mk_app $ func.params ++ args'.map (elim id fn_var.dom),
+     let y := constr.mk_app $ func.params ++ args'.map (elim id fn_var.codom),
+     pure { type_cnstr .
+           name := n ++ c.name,
+           args := args'.bind decls,
+           result := [x,y],
+           infer := environment.implicit_infer_kind.implicit  } },
+   let decl : inductive_type :=
+       { name := n,
+         params := params.bind decls',
+         idx := [x,y],
+         type := `(Prop),
+         ctors := cs,
+         .. func.induct },
+   mk_inductive decl,
+   skip
+
+meta def resolve : expr → tactic expr
+| e@(local_const uniq pp bi t) :=
+  do t ← infer_type e,
+     pure (local_const uniq pp bi t)
+| e := pure e
+
+open function (uncurry)
+
+lemma apply_uncurried {α β} {f : α → β → Sort*} : Π {x : α × β}, uncurry f x → f x.1 x.2
+| (x,y) := id
+
+lemma apply_curried {α β} {f : α → β → Sort*} : Π {x : α} {y : β}, f x y → uncurry f (x,y)
+| x y := id
+
+meta def intro_local_def (n : name) (t : expr) : tactic expr :=
+do `(true) ← (↑`(true) <$ done) <|> target | fail "expecting trivial goal",
+   v ← mk_meta_var $ pi n binder_info.default t `(true),
+   set_goals [v],
+   intro1
+
+meta def zip_goals_with {α β} (xs : list α) (f : α → tactic β) : tactic (list β) :=
+do gs ← get_goals,
+   gs' ← mzip_with (λ x g,
+       do set_goals [g],
+          prod.mk <$> f x <*> get_goals ) xs gs,
+   let ⟨xs',gs'⟩ := gs'.unzip,
+   set_goals gs'.join,
+   return xs'
+
+
+meta def extract_pattern_p (σ : list (name × expr)) : tactic (list expr) :=
+do [x] ← pure $ (σ.map prod.snd).filter $ λ x, is_app x,
+   pure (x.get_app_args)
+
+meta def extract_pattern_r (σ : list (name × expr)) : tactic (list expr × list expr) :=
+do [x,y] ← pure $ (σ.map prod.snd).filter $ λ x, is_app x,
+   pure (x.get_app_args, y.get_app_args)
+
+meta def mk_pred_args (m : list (expr × expr)) : list expr → tactic (list expr)
+| (x :: xs) :=
+ do some p ← pure $ m.find (λ p : expr × expr, x.occurs p.2)
+         | (::) x <$> mk_pred_args xs,
+    (vs,t) ← mk_local_pis p.2,
+    let f := t.get_app_fn,
+    let p' := p.1.mk_app vs,
+    x' ← mk_mapp ``subtype.mk [none,f,t.app_arg,p'] >>= lambdas vs,
+    xs' ← mk_pred_args xs,
+    return (x' :: xs')
+| _ := pure []
+
+meta def mk_rel_args (m : list (expr × expr)) : list expr → list expr → tactic (list expr)
+| (x :: xs) (y :: ys) :=
+trace_scope $
+  if x = y then (::) x <$> mk_rel_args xs ys
+           else do
+             p ← m.find (λ p : expr × expr, x.occurs p.2),
+             (vs,t) ← mk_local_pis p.2,
+             unc ← mk_mapp ``uncurry [none,none,none,t.get_app_fn],
+             x' ← mk_app ``prod.mk t.get_app_args,
+             p' ← mk_app ``apply_curried [p.1.mk_app vs],
+             x' ← mk_mapp ``subtype.mk [none,unc,x',p'] >>= lambdas vs,
+             xs' ← mk_rel_args xs ys,
+             return (x' :: xs')
+| _ _ := pure []
+
+meta def mk_rel_proof_map (s : expr_set) : list expr → tactic (list expr)
+| [] := pure []
+| (x :: xs) :=
+  do ps ← mk_rel_proof_map xs,
+     t ← infer_type x,
+     let b : bool := t.fold ff $ λ e _ b, b ∨ (e.is_local_constant ∧ s.contains e),
+     if b then pure $ x :: ps
+          else pure ps
+
+meta def mk_liftp_eqns₀ (func : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do params ← func.params'.mmap_live' mk_pred_var,
+   let F := (@const tt func.induct.name func.induct.u_params).mk_app $ params.map $ elim id prod.fst,
+   let F_intl := (@const tt func.def_name func.induct.u_params).mk_app func.dead_params,
+   let n := func.live_params.length,
+   vec ← mk_live_vec func.vec_lvl func.live_params,
+   let fs := params.filter_map $ get_right prod.snd,
+   map_f ← mk_map_vec func.vec_lvl func.vec_lvl fs,
+   x ← mk_local_def `x F,
+   let vs := [params.bind $ decls' ∘ bimap to_implicit_local_const (bimap to_implicit_local_const id),[x]],
+   liftp ← mk_mapp ``mvfunctor.liftp' [`(n),F_intl,none,vec],
+   let df := liftp map_f x,
+   mk_const ``mvfunctor.liftp_def,
+   fn ← mk_mapp ``is_lawful_mvfunctor [`(n),F_intl,none] >>= mk_instance,
+   defn ← mk_mapp ``mvfunctor.liftp_def [`(n),F_intl,none,vec], -- ,map_f,none,x,y
+   let defn := defn map_f fn x,
+   param_sub ← params.mmap_live' $ λ ⟨α,f⟩,
+   do { σ ← mk_mapp ``subtype [none,f],
+        pure (α,f,σ) },
+   let F_sub := (@const tt func.induct.name func.induct.u_params).mk_app $ param_sub.map $ elim id $ prod.snd ∘ prod.snd,
+   u ← mk_local_def `u F_sub,
+   args ← list.join <$> param_sub.mmap (elim (pure ∘ list.ret) $ λ ⟨α,unc,σ⟩,
+           do { val ← mk_mapp ``subtype.val [none,unc],
+                -- f ← to_expr ``(%%val),
+                pure [σ,α,val] }),
+   let map  := (@const tt (func.induct.name <.> "map") func.induct.u_params).mk_app args u,
+   l ← mk_app ``eq [map,x],
+   -- trace_expr df,
+   `(@Exists %%t₀ _) ← whnf df,
+   let lhs := df,
+   rhs ← mk_exists [u] l,
+   t ← mk_app `iff [lhs,rhs],
+   is_def_eq F_sub t₀ <|> fail "not def eq",
+   trace!"F_sub : {F_sub}",
+   trace!"t₀    : {t₀}",
+   -- trace!"t₀    : {whnf t₀}",
+   trace!"defn  : {infer_type defn}",
+   trace!"t     : {t}",
+   (_,pr) ← solve_aux t $ refine ``(iff.trans %%defn (iff.refl _)),
+   t ← pis' vs t,
+   pr ← instantiate_mvars pr >>= lambdas' vs,
+   let vars := pr.list_local_consts,
+   add_decl $ mk_definition (func.induct.name <.> "liftp_def") func.induct.u_names t pr,
+   skip
+
+meta def mk_liftp_eqns₁ (func : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do let F := (@const tt func.induct.name func.univ_params).mk_app func.params,
+   let F_intl := (@const tt func.def_name func.univ_params).mk_app func.dead_params,
+   let n := func.live_params.length,
+   α ← mk_live_vec func.vec_lvl func.live_params,
+   -- let v_liftr :=
+   params ← func.params'.mmap_live' mk_pred_var,
+   let fs₀ := params.filter_map $ get_right id,
+   fs' ← params.mmap_live' $ λ ⟨v,f⟩,
+     do { t ← mk_mapp ``subtype [none,f],
+          pure (f,t) },
+   let fs := fs'.filter_map $ get_right prod.fst,
+   let fsₛ := fs'.map $ elim id prod.snd,
+   map_f ← mk_map_vec func.vec_lvl func.vec_lvl fs,
+   lhs ← mk_mapp ``mvfunctor.liftp' [`(n),F_intl,none,α],
+   x ← intro_local_def `x F,
+   let lhs := lhs map_f x,
+   let vs := [params.bind decls',[x]],
+   let rhs := (@const tt (func.induct.name <.> "liftp") func.univ_params).mk_app' vs,
+   t ← mk_app `iff [lhs,rhs],
+   let fs' := (fs₀.map prod.snd).to_rb_set,
+   pr ← solve_async vs t $
+   do { mk_const (func.induct.name <.> "liftp_def") >>= rewrite_target,
+        split,
+        solve1 $
+        do { x ← intro1,
+             [(c,[x,h],_)] ← cases_core x [`a,`h],
+             (s,u) ← mk_simp_set tt [`typevec] [],
+             σ ← cases_core x,
+             σ.mmap $ λ ⟨a,b,c⟩, solve1 $
+             do { h ← simp_hyp s u (h.instantiate_locals c),
+                  mk_eq_symm h >>= rewrite_target,
+                  constructor,
+                  all_goals $ solve1 $
+                  do { intros,
+                       (expr.app f (expr.app _ x)) ← target,
+                       h ← mk_mapp ``subtype.property [none,none,x],
+                       apply h,
+                       skip } },
+             skip },
+        solve1 $
+        do { x ← intro1,
+             vs ← resolve x >>= cases_core,
+             param_sub ← params.mmap_live' $ λ ⟨α,f⟩,
+             do { σ ← mk_mapp ``subtype [none,f],
+                  pure (α,f,σ) },
+             let F_sub := (@const tt func.induct.name func.induct.u_params).mk_app $ param_sub.map $ elim id $ prod.snd ∘ prod.snd,
+             zip_goals_with (func.induct.ctors.zip vs) $ λ ⟨c,c',vs,σ⟩,
+               do { x ← extract_pattern_p σ,
+                    m ← mk_rel_proof_map fs' vs,
+                    m' ← m.mmap infer_type,
+                    args ← mk_pred_args (m.zip m') x,
+                    let u := (@const tt c.name func.univ_params).mk_app' [fsₛ, args.drop params.length],
+                    existsi u,
+                    `[simp only [(∘)] with typevec],
+                    repeat $ () <$ split,
+                    done },
+             skip },
+        done },
+   t ← pis' vs t,
+   add_decl $ declaration.thm (func.induct.name <.> "liftp_iff") func.induct.u_names t pr,
+   skip
+
+meta def mk_liftr_eqns₀ (func : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do params ← func.params'.mmap_live' mk_rel_var,
+   let F := (@const tt func.induct.name func.induct.u_params).mk_app $ params.map $ elim id prod.fst,
+   let F_intl := (@const tt func.def_name func.induct.u_params).mk_app func.dead_params,
+   let n := func.live_params.length,
+   vec ← mk_live_vec func.vec_lvl func.live_params,
+   fs ← (params.filter_map $ get_right id).mmap $ λ ⟨v,f⟩,
+     mk_mapp ``function.uncurry [none,none,none,f],
+   map_f ← mk_map_vec func.vec_lvl func.vec_lvl fs,
+   x ← mk_local_def `x F, y ← mk_local_def `y F,
+   let vs := [params.bind $ decls' ∘ bimap to_implicit_local_const (bimap to_implicit_local_const id),[x,y]],
+   liftr ← mk_mapp ``mvfunctor.liftr' [`(n),F_intl,none,vec],
+   let df := liftr map_f x y,
+   mk_const ``mvfunctor.liftr_def,
+   fn ← mk_mapp ``is_lawful_mvfunctor [`(n),F_intl,none] >>= mk_instance,
+   defn ← mk_mapp ``mvfunctor.liftr_def [`(n),F_intl,none,vec], -- ,map_f,none,x,y
+   let defn := defn map_f fn x y,
+   param_sub ← params.mmap_live' $ λ ⟨α,f⟩,
+   do { unc ← mk_mapp ``function.uncurry [none,none,none,f],
+        σ ← mk_mapp ``subtype [none,unc],
+        pure (α,unc,σ) },
+   let F_sub := (@const tt func.induct.name func.induct.u_params).mk_app $ param_sub.map $ elim id $ prod.snd ∘ prod.snd,
+   u ← mk_local_def `u F_sub,
+   let mk_args := λ prj : pexpr,
+       list.join <$> param_sub.mmap (elim (pure ∘ list.ret) $ λ ⟨α,unc,σ⟩,
+           do { val ← mk_mapp ``subtype.val [none,unc],
+                f ← to_expr ``(%%prj ∘ %%val),
+                pure [σ,α,f] }),
+   args  ← mk_args ``(prod.fst),
+   args' ← mk_args ``(prod.snd),
+   let map  := (@const tt (func.induct.name <.> "map") func.induct.u_params).mk_app args u,
+   let map' := (@const tt (func.induct.name <.> "map") func.induct.u_params).mk_app args' u,
+   l ← mk_app ``eq [map,x],
+   r ← mk_app ``eq [map',y],
+   let lhs := df,
+   rhs ← mk_app ``and [l,r] >>= mk_exists [u],
+   t ← mk_app `iff [lhs,rhs],
+   (_,pr) ← solve_aux t $ refine ``(iff.trans %%defn (iff.refl _)),
+   t ← pis' vs t,
+   pr ← instantiate_mvars pr >>= lambdas' vs,
+   let vars := pr.list_local_consts,
+   add_decl $ mk_definition (func.induct.name <.> "liftr_def") func.induct.u_names t pr,
+   skip
+
+meta def mk_liftr_eqns₁ (func : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do let F := (@const tt func.induct.name func.univ_params).mk_app func.params,
+   let F_intl := (@const tt func.def_name func.univ_params).mk_app func.dead_params,
+   let n := func.live_params.length,
+   α ← mk_live_vec func.vec_lvl func.live_params,
+   -- let v_liftr :=
+   params ← func.params'.mmap_live' mk_rel_var,
+   let fs₀ := params.filter_map $ get_right id,
+   fs' ← params.mmap_live' $ λ ⟨v,f⟩,
+     do { f' ← mk_mapp ``function.uncurry [v,v,none,f],
+          t ← mk_mapp ``subtype [none,f'],
+          pure (f',t) },
+   let fs := fs'.filter_map $ get_right prod.fst,
+   let fsₛ := fs'.map $ elim id prod.snd,
+   map_f ← mk_map_vec func.vec_lvl func.vec_lvl fs,
+   lhs ← mk_mapp ``mvfunctor.liftr' [`(n),F_intl,none,α],
+   x ← intro_local_def `x F,
+   y ← intro_local_def `y F,
+   let lhs := lhs map_f x y,
+   let vs := [params.bind decls',[x,y]],
+   let rhs := (@const tt (func.induct.name <.> "liftr") func.univ_params).mk_app' vs,
+   t ← mk_app `iff [lhs,rhs],
+   let fs' := (fs₀.map prod.snd).to_rb_set,
+   pr ← solve_async vs t $
+   do { mk_const (func.induct.name <.> "liftr_def") >>= rewrite_target,
+        split,
+        solve1 $
+        do { x ← intro1,
+             [(c,[x,h],_)] ← cases_core x [`a,`h],
+             (s,u) ← mk_simp_set tt [`typevec] [],
+             σ ← cases_core x,
+             σ.mmap $ λ ⟨a,b,c⟩, solve1 $
+             do { h ← simp_hyp s u (h.instantiate_locals c),
+                  [(c,[h₀,h₁],_)] ← cases_core h [`h₀,`h₁],
+                  mk_eq_symm h₀ >>= rewrite_target,
+                  mk_eq_symm h₁ >>= rewrite_target,
+                  constructor,
+                  all_goals $ solve1 $
+                  do { intros,
+                       (expr.app (expr.app f (expr.app _ x)) y) ← target,
+                       h ← mk_mapp ``subtype.property [none,none,x],
+                       mk_app ``apply_uncurried [h] >>= apply,
+                       skip } },
+             skip },
+        solve1 $
+        do { x ← intro1,
+             vs ← resolve x >>= cases_core,
+             param_sub ← params.mmap_live' $ λ ⟨α,f⟩,
+             do { unc ← mk_mapp ``function.uncurry [none,none,none,f],
+                  σ ← mk_mapp ``subtype [none,unc],
+                  pure (α,unc,σ) },
+             let F_sub := (@const tt func.induct.name func.induct.u_params).mk_app $ param_sub.map $ elim id $ prod.snd ∘ prod.snd,
+             zip_goals_with (func.induct.ctors.zip vs) $ λ ⟨c,c',vs,σ⟩,
+               do { (x,y) ← extract_pattern_r σ,
+                    m ← mk_rel_proof_map fs' vs,
+                    m' ← m.mmap infer_type,
+                    args ← mk_rel_args (m.zip m') x y,
+                    let u := (@const tt c.name func.univ_params).mk_app' [fsₛ, args.drop params.length],
+                    existsi u,
+                    `[simp only [(∘)] with typevec],
+                    repeat $ () <$ split,
+                    done },
+             skip },
+        done },
+   t ← pis' vs t,
+   add_decl $ declaration.thm (func.induct.name <.> "liftr_iff") func.induct.u_names t pr,
+   skip
+
+-- meta def mk_liftr_defn (func : internal_mvfunctor) : tactic unit :=
+-- do params ← func.params'.mmap_live' mk_rel_var,
+--    let F := (@const tt func.induct.name func.induct.u_params).mk_app $ params.map $ elim id prod.fst,
+--    let F_intl := (@const tt func.def_name func.induct.u_params).mk_app func.dead_params,
+--    let n := func.live_params.length,
+--    let internal_eq := (@const tt func.eqn_name func.induct.u_params).mk_app func.params,
+--    vec ← mk_live_vec func.vec_lvl func.live_params,
+--    fs ← (params.filter_map get_right).mmap $ λ ⟨v,f⟩,
+--      mk_mapp ``function.uncurry [none,none,none,f],
+--    map_f ← mk_map_vec func.vec_lvl func.vec_lvl fs,
+--    x ← mk_local_def `x F, y ← mk_local_def `y F,
+--    let vs := [params.bind $ decls' ∘ bimap to_implicit_local_const (bimap to_implicit_local_const id),[x,y]],
+--    x' ← mk_eq_mpr internal_eq x, y' ← mk_eq_mpr internal_eq y,
+--    liftr ← mk_mapp ``typevec.liftr' [`(n),F_intl,none,vec],
+--    t ← pis' vs `(Prop),
+--    df ← lambdas' vs $ liftr map_f x' y',
+--    df ← add_decl' $ mk_definition (func.induct.name <.> "liftr") func.induct.u_names t df,
+
+--    /- now generate equation -/
+--    defn ← mk_mapp ``typevec.liftr_def [`(n),F_intl,none,vec,map_f,none,x',y'],
+--    param_sub ← params.mmap_live' $ λ ⟨α,f⟩,
+--    do { unc ← mk_mapp ``function.uncurry [none,none,none,f],
+--         σ ← mk_mapp ``subtype [none,unc],
+--         pure (α,unc,σ) },
+--    let F_sub := (@const tt func.induct.name func.induct.u_params).mk_app $ param_sub.map $ elim id $ prod.snd ∘ prod.snd,
+--    u ← mk_local_def `u F_sub,
+--    let mk_args := λ prj : pexpr,
+--        list.join <$> param_sub.mmap (elim (pure ∘ list.ret) $ λ ⟨α,unc,σ⟩,
+--            do { val ← mk_mapp ``subtype.val [none,unc],
+--                 f ← to_expr ``(%%prj ∘ %%val),
+--                 pure [σ,α,f] }),
+--    args  ← mk_args ``(prod.fst),
+--    args' ← mk_args ``(prod.snd),
+--    let map  := (@const tt (func.induct.name <.> "map") func.induct.u_params).mk_app args u,
+--    let map' := (@const tt (func.induct.name <.> "map") func.induct.u_params).mk_app args' u,
+--    l ← mk_app ``eq [map,x],
+--    r ← mk_app ``eq [map',y],
+--    let lhs := df.mk_app' vs,
+--    rhs ← mk_app ``and [l,r] >>= mk_exists [u],
+--    t ← mk_app `iff [lhs,rhs],
+--    (_,pr) ← solve_aux t $ refine ``(iff.trans %%defn (iff.refl _)),
+--    t ← pis' vs t,
+--    pr ← instantiate_mvars pr >>= lambdas' vs,
+--    let vars := pr.list_local_consts,
+--    add_decl $ mk_definition (func.induct.name <.> "liftr_def") func.induct.u_names t pr,
+--    skip
+
+-- meta def mk_liftr_eqns (func : internal_mvfunctor) : tactic unit :=
+-- do let my_t := (@const tt func.induct.name func.induct.u_params).mk_app func.params,
+--    let F := (@const tt func.def_name func.induct.u_params).mk_app $ func.dead_params,
+--    let internal_eq := (@const tt func.eqn_name func.induct.u_params).mk_app func.params,
+--    x ← mk_local_def `x my_t,
+--    x' ← mk_eq_mpr internal_eq x,
+--    params ← func.params'.mmap_live' mk_rel_var,
+--    let live_params := func.live_params,
+--    v ← mk_live_vec func.vec_lvl live_params,
+--    let fs := params.filter_map $ (<$>) prod.snd ∘ get_right,
+--    -- fs ← live_params.mmap $ λ v,
+--    --   do { -- prod ← mk_app ``prod.mk [v,v],
+--    --        v ← mk_local_def `f $ v.imp $ v.imp `(Prop),
+--    --        v' ← mk_mapp ``function.uncurry [none,none,none,v],
+--    --        pure (v,v') },
+--    prod_params ← func.params'.mmap $ elim pure $ λ v, mk_app ``_root_.prod [v,v],
+--    let internal_eq' := (@const tt func.eqn_name func.induct.u_params).mk_app prod_params,
+--    let m := rb_map.of_list $ list.zip live_params fs,
+--    -- fv ← mk_map_vec func.vec_lvl level.zero $ fs.map prod.snd,
+--    -- fv_map ← fs.mmap (λ f, mk_mapp ``subtype.val [none,f.2]) >>= mk_map_vec func.vec_lvl func.vec_lvl,
+--    -- fv_t ← fs.mmap (λ f, mk_mapp ``subtype [none,f.2]) >>= mk_live_vec func.vec_lvl,
+--    let n := func.live_params.length,
+--    -- df ← mk_mapp ``typevec.liftr' [`(n),F,none,v],
+--    let df := (@const tt (func.induct.name <.> "liftr") func.induct.u_params).mk_app (params.bind decls'),
+--    -- let df := df fv,
+--    -- df ← mk_mapp ``typevec.liftr' [`(n),F,none,v,fv],
+--    param_sub ← params.mmap_live' $ λ ⟨α,f⟩,
+--    do { unc ← mk_mapp ``function.uncurry [none,none,none,f],
+--         σ ← mk_mapp ``subtype [none,unc],
+--         pure (α,unc,σ) },
+--    let F_sub := (@const tt func.induct.name func.induct.u_params).mk_app $ param_sub.map $ elim id $ prod.snd ∘ prod.snd,
+--    func.induct.ctors.mmap $ λ c, do
+--    { args ← c.args.mmap renew,
+--      let constr := @const tt c.name func.induct.u_params,
+--      let e₀ := constr.mk_app $ func.params ++ c.args,
+--      let e₁ := constr.mk_app $ func.params ++ args,
+--      args' ← mzip_with (λ a b, mk_app ``prod.mk [a,b]) c.args args,
+--      let e₂ := constr.mk_app $ prod_params ++ args',
+--      -- x₀ ← mk_eq_mpr internal_eq e₀,
+--      -- x₁ ← mk_eq_mpr internal_eq e₁,
+--      x₂ ← mk_eq_mpr internal_eq' e₂,
+--      args' ← mzip_with (λ arg₀ arg₁ : expr, do
+--        { (args,rhs_t) ← infer_type arg₀ >>= mk_local_pis,
+--          (some f) ← pure $ m.find rhs_t | pure [],
+--          list.ret <$> pis args (f (arg₀.mk_app args) (arg₁.mk_app args) ) } ) c.args args,
+--      trace "• 2",
+--      -- let rhs := mk_conj args'.join,
+--      let args' := args'.join,
+--      t ← pis ((c.args ++ args).map to_implicit_local_const) $ args'.foldr (λ l r, l.imp r) (df e₀ e₁),
+--      trace t,
+--      (_,df) ← solve_aux t $ do
+--      { solve1 $ do
+--        { args₀ ← intron' c.args.length,
+--          args₁ ← intron' c.args.length,
+--          -- mk_const (func.induct.name <.> "liftr") >>= trace_expr,
+--          mk_const (func.induct.name <.> "liftr_def") >>= rewrite_target,
+--          -- dunfold_target [``mvfunctor.map],
+--          hs ← intron' $ args'.length,
+
+--          -- h ← intro `h,
+--          -- t ← infer_type h,
+--          let n := func.live_params.length,
+--          u ← mk_meta_var F_sub,
+--          gs ← get_goals, set_goals $ u :: gs,
+--          constructor,
+--          trace_state,
+
+--          trace "\n• • •",
+--          -- x ← mk_mapp ``subtype_ [`(n),none,fv],
+--          trace_expr df,
+--          trace_expr x,
+--          trace "• • •\n",
+
+--          trace_state,
+--          -- existsi x₂,
+--          done,
+--          trace "•",
+--          trace_state, done,
+--    -- y ← mk_mapp ``typevec.subtype_val [`(n),none,fv],
+--          -- h' ← assertv `h' (replace_all t [(x,fv_t),(y,fv_map)]) h, clear h,
+--          -- [(_,[x,y],_)] ← cases_core h',
+--          -- hs ← cases_core x,
+--          -- gs ← get_goals,
+--          -- gs ← (gs.zip hs.enum).mmap $ λ ⟨g,i,n,x,b⟩,
+--          -- do { set_goals [g],
+--          --      eqn ← mk_const $ (func.induct.name ++ `internal.map._equation).append_after i,
+--          --      h' ← rewrite_hyp eqn (y.instantiate_locals b) { md := semireducible },
+--          --      t ← target,
+--          --      cases h',
+--          --      get_goals },
+--          -- set_goals gs.join,
+--          -- repeat $ do { split, intros, applyc ``subtype.property },
+--          -- intros, applyc ``subtype.property <|> interactive.trivial,
+--          done },
+--        done },
+--      t ← pis ((params.bind decls').map to_implicit_local_const) t,
+--      df ← instantiate_mvars df >>= lambdas (params.bind decls'),
+--      -- trace_state,
+--      -- add_decl $ declaration.thm (c.name.append_suffix "_liftr") func.induct.u_names t (pure df),
+--      skip },
+
+--    skip
+
+open interactive lean.parser lean
+
+@[user_attribute]
+meta def qpf_attribute : user_attribute :=
+{ name := `qpf,
+  descr := "derive qpf machinery for inductive type",
+  after_set := some $ λ n p t,
+-- trace_error
+trace_scope $
+(do func ← mk_internal_functor n,
+    mk_mvfunctor_instance func,
+    mk_pfunctor func,
+    mk_pfunc_constr func,
+    mk_pfunc_recursor func,
+    -- trace_error $ mk_pfunc_rec_eqns func,
+    -- mk_pfunc_map func,
+    -- mk_pfunc_mvfunctor_instance func,
+    mk_mvqpf_instance func,
+    -- mk_liftp_eqns func,
+    mk_liftp_defn' func,
+    mk_liftp_eqns₀ func,
+    mk_liftp_eqns₁ func,
+    mk_liftr_defn' func,
+    mk_liftr_eqns₀ func,
+    mk_liftr_eqns₁ func,
+    pure ())
+ }
+
+end tactic
+open function typevec typevec.prod

--- a/src/data/qpf/compiler/datatype.lean
+++ b/src/data/qpf/compiler/datatype.lean
@@ -1,0 +1,568 @@
+import data.qpf.compiler.shape
+import .for_mathlib
+
+namespace tactic
+
+open interactive lean lean.parser
+open expr
+
+meta def trace' {α} (x : α) [has_to_tactic_format α] : tactic α :=
+x <$ trace x
+
+-- #check eq.mpr
+
+meta def mk_constr (mk_fn : name) (d : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do let my_t := (@const tt d.induct.name d.induct.u_params).mk_app d.params,
+   let intl_eq := (@const tt (d.induct.name <.> "shape" <.> "internal_eq") d.induct.u_params).mk_app d.params my_t,
+   let params' := d.params.map to_implicit_local_const,
+   d.induct.ctors.mmap' $ λ c : type_cnstr,
+     do { t ← type_cnstr.type d.induct c,
+          let t := instantiate_pi t d.params,
+          let c' := c.name.update_prefix (d.decl.to_name <.> "shape"),
+          (vs,t') ← mk_local_pis t,
+          let mk_shape := ((@const tt c' d.induct.u_params).mk_app d.params my_t).mk_app vs,
+          e ← mk_eq_mpr intl_eq mk_shape,
+          df ← mk_app mk_fn [e] >>= lambdas' [d.params,vs],
+          t ← pis params' t,
+          add_decl $ mk_definition c.name d.induct.u_names t df }
+
+meta def mk_destr (dest_fn mk_fn mk_dest_eqn : name) (func : datatype_shape) (d : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do let params := d.params.map to_implicit_local_const,
+   let my_t := (@const tt d.induct.name d.induct.u_params).mk_app params,
+   vec ← mk_live_vec d.vec_lvl (d.live_params ++ [my_t]),
+   vec' ← mk_live_vec d.vec_lvl d.live_params,
+   let my_shape_t := (@const tt (d.induct.name <.> "shape" <.> "internal") d.induct.u_params).mk_app func.dead_params,
+   let u_params := d.induct.u_params,
+   let u := fresh_univ d.induct.u_names,
+   let intl_eq := (@const tt (d.induct.name <.> "shape" <.> "internal_eq") u_params).mk_app params my_t,
+   v_t ← mk_local_def `x (my_shape_t vec),
+   C ← mk_local' `C binder_info.implicit (my_t.imp (sort $ level.param u)),
+   let n := d.live_params.length,
+   C' ← mk_mapp mk_fn [reflect n,my_shape_t,none,none,vec',v_t] >>= lambdas [v_t] ∘ C,
+   cs ← d.induct.ctors.mmap $ λ c : type_cnstr,
+     do { let t := (@const tt c.name u_params).mk_app params ,
+          (vs,_) ← infer_type t >>= mk_local_pis,
+          x ← pis vs (C $ t.mk_app vs),
+          v ← mk_local_def `v x,
+          pure (v) },
+   n ← mk_local_def `n my_t,
+   n' ← mk_app dest_fn [n],
+   let vs := [params,[C,n],cs],
+   rec_t ← pis' vs (C n),
+   let shape_cases := (@const tt (d.induct.name <.> "shape" <.> "cases_on") $ level.param u :: u_params).mk_app (params ++ [my_t,C',n'] ++ cs),
+   shape_cases ← mk_app mk_dest_eqn [n] >>= mk_congr_arg C >>= flip mk_eq_mp shape_cases,
+   df ← lambdas' vs shape_cases,
+   add_decl $ mk_definition (d.induct.name <.> "cases_on") (u :: d.induct.u_names) rec_t df,
+   set_basic_attribute `elab_as_eliminator (d.induct.name <.> "cases_on"),
+   pure ()
+
+meta def mk_destr_constr_eqn (dest_mk : name) (func : datatype_shape) (d : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do let params := d.params.map to_implicit_local_const,
+   let my_t := (@const tt d.induct.name d.induct.u_params).mk_app params,
+   let u := fresh_univ d.induct.u_names,
+   C ← mk_local' `C binder_info.implicit (my_t.imp (sort $ level.param u)),
+   let my_shape_intl_t := (@const tt (d.induct.name <.> "shape" <.> "internal") d.induct.u_params).mk_app $ d.dead_params,
+   let my_shape_t := (@const tt (d.induct.name <.> "shape") d.induct.u_params).mk_app params my_t,
+   C' ← mk_local' `C binder_info.implicit (my_shape_t.imp (sort $ level.param u)),
+   let cases_on := @const tt (d.induct.name <.> "cases_on") (level.param u :: d.induct.u_params),
+   let cases_on := cases_on.mk_app params C,
+   let shape_cases_on := (@const tt (d.induct.name <.> "shape" <.> "cases_on") (level.param u :: d.induct.u_params)).mk_app params my_t C',
+   (_ :: vs,_) ← infer_type cases_on >>= mk_local_pis,
+   (c :: vs',_) ← infer_type shape_cases_on >>= mk_local_pis,
+   c' ← renew c,
+   h ← mk_app `eq [c,c'] >>= mk_local_def `h,
+   t ← mk_mapp `heq [none,shape_cases_on.mk_app $ c :: vs',none,shape_cases_on.mk_app $ c' :: vs']
+     >>= pis [c,c',h] >>= pis (C' :: vs') >>= pis params,
+   (_,cases_congr) ← solve_aux t (intros >> cc),
+   (d.induct.ctors.zip vs).mmap' $ λ ⟨ctor,v⟩,
+   do { let c := ((@const tt ctor.name d.induct.u_params).mk_app params).mk_app ctor.args,
+        eqn ← mk_app `eq [cases_on.mk_app $ c::vs,v.mk_app ctor.args],
+        df ← solve_async [params,C::vs,ctor.args] eqn $ do
+        { dunfold_target [d.induct.name <.> "cases_on",ctor.name],
+          applyc ``mp_eq_of_heq,
+          transitivity,
+          apply cases_congr,
+          applyc dest_mk, reflexivity,
+          done },
+        t ← pis ctor.args eqn >>= pis (C :: vs) >>= pis (params),
+        let n := ((d.induct.name <.> "cases_on").bundle ctor.name),
+        add_decl $ declaration.thm n (u :: d.induct.u_names) t df,
+        add_eqn_lemmas n,
+        simp_attr.pseudo_eqn.set n () tt,
+        skip }
+
+open tactic.interactive (rw_rules_t rw_rule)
+open tactic.interactive.rw_rules_t
+open interactive.rw_rule
+open_locale mvfunctor
+
+meta def mk_dep_recursor (func : datatype_shape) (d : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do let params := d.params.map to_implicit_local_const,
+   let my_shape_intl_t := (@const tt (d.induct.name <.> "shape" <.> "internal") d.induct.u_params).mk_app func.dead_params,
+   let u_params := d.induct.u_params,
+   vec' ← mk_live_vec d.vec_lvl d.live_params,
+   arg ← mk_local_def `y ((@const tt d.induct.name d.induct.u_params).mk_app params),
+   C ← pis [arg] d.type >>= mk_local' `C binder_info.implicit,
+   X ← mk_app ``sigma [C],
+   vec ← mk_live_vec d.vec_lvl (d.live_params ++ [X]),
+   let my_shape_t := (@const tt (d.induct.name <.> "shape") d.induct.u_params).mk_app params X,
+   v_t ← mk_local_def `x my_shape_t,
+   x ← mk_local_def `x' (my_shape_intl_t vec),
+   let intl_eq := (@const tt (d.induct.name <.> "shape" <.> "internal_eq") u_params).mk_app params X,
+   x' ← mk_eq_mpr intl_eq x,
+   C' ← to_expr ``(%%C $ mvqpf.fix.mk (typevec.append_fun typevec.id sigma.fst <$$> %%x')) >>= lambdas [x],
+   let cases_on := d.induct.name <.> "shape" <.> "cases_on",
+   let cases_u : list level := level.succ d.vec_lvl :: d.induct.u_params,
+   let fs := (@const tt cases_on cases_u).mk_app params X C' x',
+   (vs,_) ← infer_type fs >>= mk_local_pis,
+   vs ← mzip_with (λ l (c : type_cnstr),
+     do { (args,t) ← infer_type l >>= mk_local_pis,
+          head_beta t >>= pis args >>= mk_local_def l.local_pp_name }) vs d.induct.ctors,
+   let fn := fs.mk_app vs,
+   rule ← mk_const ``mpr_mpr,
+   (t',pr,_) ← infer_type fn >>= head_beta >>= rewrite rule,
+   fn ← mk_eq_mp pr fn >>= lambdas [x],
+   df ← mk_mapp ``mvqpf.fix.drec [none,my_shape_intl_t,none,none,vec',C,fn,arg]
+     >>= lambdas' [params, C :: vs, [arg]],
+   t ← infer_type df,
+   add_decl $ mk_definition (d.induct.name <.> "drec") d.induct.u_names t df,
+   pure ()
+
+meta def mk_recursor (func : datatype_shape) (d : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do let my_shape_intl_t := (@const tt (d.induct.name <.> "shape" <.> "internal") d.induct.u_params).mk_app func.dead_params,
+   let my_shape_t := (@const tt (d.induct.name <.> "shape") d.induct.u_params).mk_app func.params,
+   let u_params := d.induct.u_params,
+   let X := to_implicit_local_const func.hole,
+   let intl_eq := (@const tt (d.induct.name <.> "shape" <.> "internal_eq") u_params).mk_app d.params X,
+   vec' ← mk_live_vec d.vec_lvl d.live_params,
+   vec ← mk_live_vec d.vec_lvl (d.live_params ++ [X]),
+   x ← mk_local_def `x (my_shape_intl_t vec),
+   v_t ← mk_local_def `x my_shape_t,
+   C ← lambdas [v_t] X,
+   v_t ← mk_eq_mp intl_eq x,
+   let cases_on := d.induct.name <.> "shape" <.> "cases_on",
+   let cases_u : list level := level.succ d.vec_lvl :: d.induct.u_params,
+   let fs := (@const tt cases_on $ cases_u).mk_app func.params C v_t,
+   (vs,_) ← infer_type fs >>= mk_local_pis,
+   vs ← mzip_with (λ l (c : type_cnstr),
+     do { (args,t) ← infer_type l >>= mk_local_pis,
+          head_beta t >>= pis args >>= mk_local_def l.local_pp_name }) vs d.induct.ctors,
+   fn ← lambdas [x] (fs.mk_app vs),
+   arg ← mk_local_def `y $ (@const tt d.induct.name d.induct.u_params).mk_app d.params,
+   let params := d.params.map to_implicit_local_const,
+   df ← mk_mapp ``mvqpf.fix.rec [none,my_shape_intl_t,none,none,vec',X,fn,arg] >>= lambdas' [params, X :: vs, [arg]],
+   t ← infer_type df,
+   add_decl $ mk_definition (d.induct.name <.> "rec") d.induct.u_names t df,
+   pure ()
+
+meta def mk_corecursor (func : datatype_shape) (d : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do -- let u := fresh_univ d.induct.u_names,
+   let t := (@const tt d.decl.to_name d.induct.u_params).mk_app d.params,
+   let x := func.hole,
+   v ← mk_live_vec d.vec_lvl $ d.live_params,
+   v' ← mk_live_vec d.vec_lvl $ x :: d.live_params,
+   let u_params := d.induct.u_params,
+   let n := d.decl.to_name,
+   let shape_n := n <.> "shape",
+   let internal_eq_n := shape_n <.> "internal_eq",
+   let t' := (@const tt (shape_n <.> "internal") d.induct.u_params).mk_app func.dead_params,
+   let intl_eq := (@const tt internal_eq_n u_params).mk_app $ d.params,
+   let my_fun (rec_n rec_n' : name) (a : expr) := do
+   { let ft := imp x $ (@const tt shape_n u_params).mk_app d.params a,
+     fn ← mk_local_def `f ft,
+     i  ← mk_local_def `i x,
+     fn' ← mk_eq_mpr (intl_eq a) (fn i) >>= lambdas [i],
+     df ← mk_mapp rec_n [none,t',none,none,v,x,fn'],
+     let t := imp x $ (@const tt n u_params).mk_app d.params,
+     t ← pis' [d.params, [x,fn]] t,
+     df ← lambdas' [d.params, [x,fn]] df,
+     add_decl $ mk_definition rec_n' (d.induct.u_names) t df },
+   x' ← mk_mapp ``sum [t,x],
+   -- my_fun ``mvqpf.cofix.corec₁ (n <.> "corec₁") x',
+   my_fun ``mvqpf.cofix.corec' (n <.> "corec'") x',
+   my_fun ``mvqpf.cofix.corec (n <.> "corec") x,
+   do
+   { let rec_n := ``mvqpf.cofix.corec₁,
+     let rec_n' := n <.> "corec₁",
+     let shape_t := (@const tt shape_n u_params).mk_app d.params,
+     `(%%t₂ → _) ← infer_type shape_t,
+     X ← mk_local_def `X t₂,
+     let ft := shape_t X,
+     exit_fn ← mk_local_def `exit_fn (t.imp X),
+     rec_fn ← mk_local_def `rec_fn (func.hole.imp X),
+     x₀ ← mk_local_def `x₀ x,
+     shape_fn ← pis [X,exit_fn,rec_fn,x₀] (shape_t X) >>= mk_local_def `shape_fn,
+     df ← mk_mapp rec_n [none,t',none,none,v,x,shape_fn,x₀],
+     t ← pis' [d.params, [x,shape_fn,x₀]] t,
+     df ← lambdas' [d.params, [x,shape_fn,x₀]] df,
+     add_decl $ mk_definition rec_n' (d.induct.u_names) t df,
+     pure () },
+   pure ()
+
+meta def parse_conjunction_aux : (expr → expr) → expr → expr → dlist expr
+| ρ `(true) e := dlist.empty
+| ρ `(%%p ∧ %%q) e := parse_conjunction_aux (λ e, @const tt ``and.elim_left [] p q (ρ e)) p e ++ parse_conjunction_aux (λ e, @const tt ``and.elim_right [] p q (ρ e)) q e
+| ρ _ e := dlist.singleton $ ρ e
+
+meta def parse_conjunction (e : expr) : tactic $ list expr :=
+trace_scope $
+do t ← infer_type e >>= instantiate_mvars,
+   return (parse_conjunction_aux id t e).to_list
+
+meta def mk_ind (func : datatype_shape) (d : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do let my_shape_intl_t := (@const tt (d.induct.name <.> "shape" <.> "internal") d.induct.u_params).mk_app func.dead_params,
+   let my_t := (@const tt (d.induct.name) d.induct.u_params).mk_app d.params,
+   let my_shape_t := (@const tt (d.induct.name <.> "shape") d.induct.u_params).mk_app $ d.params,
+   v' ← mk_live_vec d.vec_lvl d.live_params,
+   v ← mk_live_vec d.vec_lvl $ d.live_params ++ [my_t],
+   yy ← mk_local_def `y (my_shape_intl_t v),
+   x ← mk_local_def `x my_t,
+   p ← mk_local_def `p (my_t.imp `(Prop)),
+   let eqn := (@const tt (func.eqn_name) d.induct.u_params).mk_app d.params my_t,
+   a ← mk_mapp ``typevec.pred_last [none,v',none,p],
+   liftp ← mk_const ``mvfunctor.liftp,
+   unify_mapp liftp [none,my_shape_intl_t,none],
+   b ← unify_mapp liftp [none,my_shape_intl_t,none,none,a,yy] >>= mk_local_def `a,
+   mk_y ← mk_app ``mvqpf.fix.mk [yy],
+   branches ← d.induct.ctors.mmap $ λ c,
+     do { let c_t := (@const tt c.name d.induct.u_params).mk_app d.params,
+          (args,_) ← infer_type c_t >>= mk_local_pis,
+          ih ← args.mmap $ λ x,
+            do { t ← infer_type x,
+                 if my_t.occurs t then do
+                   (xs,_) ← mk_local_pis t,
+                   v ← pis xs (p $ x.mk_app xs) >>= mk_local_def `v,
+                   pure [v]
+                 else pure [] },
+          b ← pis' [args, ih.join] (p $ c_t.mk_app args) >>= mk_local_def `a,
+          pure (c,ih,b) },
+   ht ← pis [yy,b] (p mk_y),
+   (_,h) ← solve_aux ht $ do
+   { y ← intro1,
+     y' ← mk_eq_mp eqn y,
+     generalize_with `h `y' y',
+     C ← mk_motive, y' ← intro `y',
+     cases_fn ← mk_const (d.induct.name <.> "shape" <.> "cases_on"),
+     gs ← list.mrepeat d.induct.ctors.length mk_mvar,
+     unify_app cases_fn (d.params ++ [my_t,C,y'] ++ gs) >>= exact,
+     set_goals gs,
+     branches.mmap $ λ ⟨c,ih,b⟩,
+       solve1 $ do
+       { let _a : type_cnstr := c,
+         args ← intron' c.args.length,
+         h ← intro1,
+         h' ← mk_app ``eq_mpr_of_mp_eq [h] >>= rewrite_target,
+         ih ← intro1,
+         v ← mk_mvar, v' ← mk_mvar,
+         thm ← mk_const ``mvfunctor.liftp_last_pred_iff,
+         thm ← unify_app' thm [v',v],
+         mpr ← mk_const ``iff.mpr,
+         ih ← (unify_app' mpr [thm,ih] >>= instantiate_mvars >>= note ih.local_pp_name none) <* clear ih,
+         simp_only [``(typevec.pred_last'),``(typevec.const_append1),``(typevec.const_nil),``(typevec.subtype_val_append1),``(typevec.subtype_val_nil)] [] (some ih.local_pp_name),
+         let n := (c.name.update_prefix $ c.name.get_prefix <.> "shape").append_suffix "_liftp",
+         n' ← mk_const n,
+         ih ← get_local ih.local_pp_name,
+         ih ← (unify_app' n' [ih] >>= note ih.local_pp_name none) <* clear ih,
+         p_args ← parse_conjunction ih,
+         exact $ b.mk_app' [args,p_args],
+         done },
+     done },
+   ind ← mk_const ``mvqpf.fix.ind,
+   df ← unify_mapp ind [none,my_shape_intl_t,none,none,v',p,h,x] >>= instantiate_mvars,
+   df ← lambdas' [d.params.map to_implicit_local_const, to_implicit_local_const p :: branches.map (prod.snd ∘ prod.snd),[x]] df,
+   t ← infer_type df,
+   add_decl $ declaration.thm (d.induct.name <.> "ind") d.induct.u_names t (pure df),
+   skip
+
+meta def mk_last_rel' : list (expr ⊕ expr) → tactic (bool × list (expr ⊕ expr × expr))
+| [] := pure (ff,[])
+| (sum.inl x :: xs) :=
+  prod.map id (list.cons $ sum.inl x) <$> mk_last_rel' xs
+| (sum.inr x :: xs) :=
+  do (b,ys) ← mk_last_rel' xs,
+     if b then do
+       R ← mk_mapp ``eq [x],
+       pure (tt,sum.inr (x, R) :: ys)
+     else do
+       R ← mk_rel_var x,
+       pure (tt,sum.inr R :: ys)
+
+meta def mk_last_rel : list (expr ⊕ expr) → tactic (list (expr ⊕ expr × expr)) :=
+(<$>) prod.snd ∘ mk_last_rel'
+
+-- #check mvqpf.cofix.bisim
+
+-- #exit
+meta def mk_bisim (func : datatype_shape) (d : internal_mvfunctor) : tactic unit :=
+trace_scope $ do
+do let my_shape_intl_t := (@const tt (d.induct.name <.> "shape" <.> "internal") d.induct.u_params).mk_app func.dead_params,
+   let my_t := (@const tt (d.induct.name) d.induct.u_params).mk_app d.params,
+   v' ← mk_live_vec d.vec_lvl d.live_params,
+   x ← mk_local_def `x my_t,
+   y ← mk_local_def `y my_t,
+   -- r  ← mk_local_def `r (my_t.imp $ my_t.imp `(Prop)) >>= trace_expr,
+   let rel := (@const tt (d.induct.name <.> "bisim_rel") d.induct.u_params).mk_app d.params,
+   -- trace $ ls,
+
+   -- let R := (@const tt (func.induct.name ++ "liftr") func.univ_params).mk_app (params.bind decls') x y,
+   -- R ← mk_app (func.induct.name ++ "liftr") [r',x',y'],
+   -- R' ← mk_app ``mvfunctor.liftr [r',x',y'],
+   -- trace_expr my_shape_intl_t,
+   e ← mk_mapp ``mvqpf.cofix.bisim [none,my_shape_intl_t,none,none,v',rel] >>= trace_expr,
+   t ← infer_type e,
+   let t := t.binding_domain,
+   solve_aux t $ do {
+     xs ← introv [],
+     hr ← intro `hr,
+     trace_state,
+     h ← mk_const ``mvfunctor.liftr_last_rel_iff,
+     -- trace_expr h,
+     rewrite_target h { symm := tt },
+     `[simp only [typevec.rel_last'] with typevec],
+     trace_state },
+
+   -- mk_const ``mvqpf.cofix.bisim >>= trace_expr,
+   skip
+
+/-
+
+-/
+meta def mk_bisim' (func : datatype_shape) (d : internal_mvfunctor) : tactic unit :=
+trace_scope $ do
+do let my_shape_intl_t := (@const tt (d.induct.name <.> "shape" <.> "internal") d.induct.u_params).mk_app func.dead_params,
+   let my_t := (@const tt (d.induct.name) d.induct.u_params).mk_app d.params,
+
+   v' ← mk_live_vec d.vec_lvl d.live_params,
+   x ← mk_local_def `x my_t,
+   y ← mk_local_def `y my_t,
+   x' ← mk_app ``mvqpf.cofix.dest [x],
+   y' ← mk_app ``mvqpf.cofix.dest [y],
+   r  ← mk_local_def `r (my_t.imp $ my_t.imp `(Prop)),
+   r' ← mk_mapp ``typevec.rel_last [none,v',none,none,r],
+   hr ← mk_local_def `a (r x y),
+   R ← mk_app ``mvfunctor.liftr [r',x',y'],
+   f ← pis [x,y,hr] R >>= mk_local_def `f,
+   trace_expr f,
+   df ← mk_mapp ``mvqpf.cofix.bisim [none,my_shape_intl_t,none,none,v',r,f,x,y,hr]
+      >>= lambdas (d.params ++ [r,f,x,y,hr]),
+   t  ← mk_app `eq [x,y] >>= pis (d.params ++ [r,f,x,y,hr]),
+   f ← add_decl' $ declaration.thm (d.induct.name <.> "bisim") d.induct.u_names t (pure df),
+   -- let r := (@const tt (d.induct.name <.> "bisim_rel") d.induct.u_params).mk_app d.params,
+   -- let e := f.mk_app d.params r,
+   -- t ← expr.binding_domain <$> infer_type e,
+   -- @solve_aux unit t $ do
+   -- { x ← intro1, y ← intro1, h ← intro1,
+   --   C ← target >>= lambdas [x,y],
+   --   let cases_on := (@const tt (d.induct.name <.> "bisim_rel" <.> "cases_on") d.induct.u_params).mk_app d.params C x y h,
+   --   args ← infer_type cases_on >>= mk_mvar_pis,
+   --   exact $ cases_on.mk_app args,
+   --   mzip_with (λ g (c : type_cnstr),
+   --   do { set_goals [g], trace c.name,
+   --        dunfold_target [c.name,``mvfunctor.liftr],
+   --        simp_only [``(mvqpf.cofix.dest_mk)],
+   --        `(∃ _ : %%t, _) ← target,
+   --        v ← mk_meta_var t, trace t,
+   --        let cn := c.name.update_prefix $ c.name.get_prefix <.> "shape",
+   --        let n  := (cn.update_prefix $ cn.get_prefix <.> "pfunctor").append_suffix "_map",
+   --        mk_const n >>= trace_expr,
+   --        let w := (@const tt cn d.induct.u_params).mk_app [], -- d.params v,
+   --        args ← infer_type w >>= mk_mvar_pis,
+   --        let w := w.mk_app args,
+   --        trace "",
+   --        trace_expr w,
+   --        trace "",
+   --        existsi w,
+   --        -- simp_only [] [`typevec],
+   --        trace_state, done })
+   --    args d.induct.ctors,
+   --   trace "",
+   --   trace_state },
+   -- trace_expr $ e,
+   skip
+
+open environment.implicit_infer_kind
+-- meta def mk_bisim_rel (func : datatype_shape) (d : internal_mvfunctor) : tactic unit :=
+-- -- trace_scope $
+-- do let params := d.params.map to_implicit_local_const,
+--    let t := (@const tt d.induct.name d.induct.u_params).mk_app params,
+--    let n := d.induct.name <.> "bisim_rel",
+--    let decl := d.induct,
+--    let type_ctor := (@const tt n decl.u_params).mk_app params,
+--    cs ← d.induct.ctors.mmap $ λ c,
+--    do { args ← c.args.mmap $ λ e,
+--              if t.occurs e then renew e
+--                            else pure e,
+--         let (xs,ys) := c.args.partition $ λ e, t.occurs e,
+--         let xs' := args.filter $ λ e, t.occurs e,
+--         co_ind ← mzip_with (λ x x' : expr,
+--         do (args,t) ← infer_type x >>= mk_local_pis,
+--            pis args (type_ctor (x.mk_app args) (x'.mk_app args)) >>= mk_local_def `h ) xs xs',
+--         let x  := (@const tt c.name d.induct.u_params).mk_app' [d.params,c.args],
+--         let x' := (@const tt c.name d.induct.u_params).mk_app' [d.params,args],
+--         return ({ name := c.name.update_prefix n,
+--                   args := ys ++ xs ++ xs' ++ co_ind,
+--                   result := [x,x'],
+--                   infer := relaxed_implicit } : type_cnstr) },
+--    x ← mk_local_def `x t,
+--    y ← mk_local_def `y t,
+--    let decl : inductive_type :=
+--             { pre := d.induct.pre,
+--               name := n,
+--               u_names := d.induct.u_names,
+--               params := params,
+--               idx := [x,y],
+--               type := `(Prop),
+--               ctors := cs },
+--    sig ← decl.sig,
+--    intros ← decl.intros,
+--    add_coinductive_predicate decl.u_names decl.params [(sig,intros)]
+
+meta def mk_fix_functor_instance (func : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do let params := func.dead_params,
+   let c := (@const tt func.def_name func.induct.u_params).mk_app params,
+   let shape_c := (@const tt (func.induct.name <.> "shape" <.> "internal") func.induct.u_params).mk_app params,
+   t ← mk_app ``mvfunctor [c] >>= pis params,
+   df ← mk_mapp ``mvqpf.fix.mvfunctor [none,shape_c,none,none] >>= lambdas params,
+   -- updateex_env $ λ env, pure $ env.add_namespace func.induct.name,
+   add_decl $ mk_definition (func.induct.name <.> "mvfunctor") func.induct.u_names t df,
+   set_basic_attribute `instance (func.induct.name <.> "mvfunctor"),
+   t ← mk_mapp ``mvqpf [none,c,none] >>= pis params,
+   df ← mk_mapp ``mvqpf.mvqpf_fix [none,shape_c,none,none] >>= lambdas params,
+   add_decl $ mk_definition (func.induct.name <.> "mvqpf") func.induct.u_names t df,
+   set_basic_attribute `instance (func.induct.name <.> "mvqpf")
+
+meta def mk_cofix_functor_instance (func : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do let params := func.dead_params,
+   let c := (@const tt func.def_name func.induct.u_params).mk_app params,
+   let shape_c := (@const tt (func.induct.name <.> "shape" <.> "internal") func.induct.u_params).mk_app params,
+   t ← mk_app ``mvfunctor [c] >>= pis params,
+   df ← mk_mapp ``mvqpf.cofix.mvfunctor [none,shape_c,none,none] >>= lambdas params,
+   -- updateex_env $ λ env, pure $ env.add_namespace func.induct.name,
+   add_decl $ mk_definition (func.induct.name <.> "mvfunctor") func.induct.u_names t df,
+   set_basic_attribute `instance (func.induct.name <.> "mvfunctor"),
+   t ← mk_mapp ``mvqpf [none,c,none] >>= pis params,
+    df ← mk_mapp ``mvqpf.mvqpf_cofix [none,shape_c,none,none] >>= lambdas params,
+   add_decl $ mk_definition (func.induct.name <.> "mvqpf") func.induct.u_names t df,
+   set_basic_attribute `instance (func.induct.name <.> "mvqpf")
+
+@[user_command]
+meta def data_decl (meta_info : decl_meta_info) (_ : parse (tk "data")) : lean.parser unit :=
+do d ← inductive_decl.parse meta_info,
+   trace_scope $
+   trace_error "bad" (do
+     (func,d) ← mk_datatype ``mvqpf.fix d,
+     mk_liftp_eqns func.to_internal_mvfunctor,
+     mk_constr ``mvqpf.fix.mk d,
+     mk_destr ``mvqpf.fix.dest ``mvqpf.fix.mk ``mvqpf.fix.mk_dest func d,
+     mk_destr_constr_eqn ``mvqpf.fix.dest_mk func d,
+     mk_recursor func d,
+     mk_dep_recursor func d,
+     mk_fix_functor_instance d,
+     mk_ind func d,
+     mk_no_confusion_type d.induct,
+     mk_no_confusion d.induct,
+     pure ())
+
+@[user_command]
+meta def codata_decl (meta_info : decl_meta_info) (_ : parse (tk "codata")) : lean.parser unit :=
+do d ← inductive_decl.parse meta_info,
+   -- let d := { name :=  .. d },
+   trace_scope $
+   trace_error "bad" (do
+     (func,d) ← mk_datatype ``mvqpf.cofix d,
+     mk_liftp_eqns func.to_internal_mvfunctor,
+     mk_constr ``mvqpf.cofix.mk d,
+     mk_destr ``mvqpf.cofix.dest ``mvqpf.cofix.mk ``mvqpf.cofix.mk_dest func d,
+     mk_destr_constr_eqn ``mvqpf.cofix.dest_mk func d,
+     mk_corecursor func d,
+     mk_cofix_functor_instance d,
+     mk_liftr_defn' d,
+     -- mk_liftr_eqns₀ d,
+     -- mk_liftr_eqns₁ d,
+     -- mk_bisim_rel func d,
+     -- mk_bisim func d,
+     mk_no_confusion_type d.induct,
+     mk_no_confusion d.induct,
+     pure ())
+
+meta def mk_liftp_eqns₀_debug (func : internal_mvfunctor) : tactic unit :=
+trace_scope $
+do params ← func.params'.mmap_live' mk_pred_var,
+   let F := (@const tt func.induct.name func.induct.u_params).mk_app $ params.map $ elim id prod.fst,
+   let F_intl := (@const tt func.def_name func.induct.u_params).mk_app func.dead_params,
+   let n := func.live_params.length,
+   vec ← mk_live_vec func.vec_lvl func.live_params,
+   let fs := params.filter_map $ get_right prod.snd,
+   map_f ← mk_map_vec func.vec_lvl func.vec_lvl fs,
+   x ← mk_local_def `x F,
+   let vs := [params.bind $ decls' ∘ bimap to_implicit_local_const (bimap to_implicit_local_const id),[x]],
+   liftp ← mk_mapp ``mvfunctor.liftp' [`(n),F_intl,none,vec],
+   let df := liftp map_f x,
+   mk_const ``mvfunctor.liftp_def,
+   fn ← mk_mapp ``is_lawful_mvfunctor [`(n),F_intl,none] >>= mk_instance,
+   defn ← mk_mapp ``mvfunctor.liftp_def [`(n),F_intl,none,vec], -- ,map_f,none,x,y
+   let defn := defn map_f fn x,
+   param_sub ← params.mmap_live' $ λ ⟨α,f⟩,
+   do { σ ← mk_mapp ``subtype [none,f],
+        pure (α,f,σ) },
+   let F_sub := (@const tt func.induct.name func.induct.u_params).mk_app $ param_sub.map $ elim id $ prod.snd ∘ prod.snd,
+   u ← mk_local_def `u F_sub,
+   args ← list.join <$> param_sub.mmap (elim (pure ∘ list.ret) $ λ ⟨α,unc,σ⟩,
+           do { val ← mk_mapp ``subtype.val [none,unc],
+                -- f ← to_expr ``(%%val),
+                pure [σ,α,val] }),
+   let map  := (@const tt (func.induct.name <.> "map") func.induct.u_params).mk_app args u,
+   l ← mk_app ``eq [map,x],
+   -- trace_expr df,
+   `(@Exists %%t₀ _) ← whnf df,
+   let lhs := df,
+   rhs ← mk_exists [u] l,
+   t ← mk_app `iff [lhs,rhs],
+   is_def_eq F_sub t₀ <|> fail "not def eq",
+   -- trace!"F_sub : {F_sub}",
+   -- trace!"t₀    : {t₀}",
+   -- trace!"t₀    : {whnf t₀}",
+   -- trace!"defn  : {infer_type defn}",
+   -- trace!"t     : {t}",
+   v ← mk_mvar,
+   (_,pr) ← solve_aux t $ refine ``(iff.trans %%defn %%v), -- (iff.refl _)
+   trace_expr v,
+   retrieve $ do {
+     set_goals [v],
+     applyc ``exists_congr, intro1,
+     applyc ``eq.congr,
+     (l,r) ← target >>= match_eq,
+     trace!"l: {l}",
+     trace!"r: {whnf r}",
+     applyc ``congr_arg,
+     trace_state},
+
+   t ← pis' vs t,
+   pr ← instantiate_mvars pr >>= lambdas' vs,
+   let vars := pr.list_local_consts,
+   add_decl $ mk_definition (func.induct.name <.> "liftp_def") func.induct.u_names t pr,
+   skip
+
+attribute [vm_override mk_liftp_eqns₀_debug] mk_liftp_eqns₀
+
+-- meta def mk_meta_sort : tactic expr :=
+-- expr.sort <$> mk_meta_univ >>= mk_meta_var
+
+end tactic
+
+set_option trace.app_builder true
+set_option trace.trace_scope.error true
+set_option trace.compiler.input true
+
+codata tree' (α β : Type)
+| nil : tree'
+| cons : α → (β → tree') → tree'

--- a/src/data/qpf/compiler/fn_var.lean
+++ b/src/data/qpf/compiler/fn_var.lean
@@ -1,0 +1,47 @@
+
+-- import for_mathlib
+import tactic.mk_has_to_format
+
+namespace tactic
+
+@[derive has_to_format]
+meta structure fn_var :=
+(dom codom fn : expr)
+
+meta def mk_fn_var (v : expr) : tactic fn_var :=
+do { let v := expr.to_implicit_local_const v,
+     v' ← (infer_type v >>= mk_local' (name.add_prime v.local_pp_name) binder_info.implicit),
+     f ← mk_local_def `f (v.imp v'),
+     pure ⟨v,v',f⟩ }
+
+meta def mk_pred_var (v : expr) : tactic (expr × expr) :=
+do { let v := expr.to_implicit_local_const v,
+     f ← mk_local_def `f $ v.imp `(Prop),
+     pure ⟨v,f⟩ }
+
+meta def mk_rel_var (v : expr) : tactic (expr × expr) :=
+do { let v := expr.to_implicit_local_const v,
+     f ← mk_local_def `f $ v.imp $ v.imp `(Prop),
+     pure ⟨v,f⟩ }
+
+meta def get_dom {α} : α ⊕ fn_var → option expr
+| (sum.inr x) := some x.dom
+| _ := none
+
+meta def get_codom {α} : α ⊕ fn_var → option expr
+| (sum.inr x) := some x.codom
+| _ := none
+
+meta def get_fn {α} : α ⊕ fn_var → option expr
+| (sum.inr x) := some x.fn
+| _ := none
+
+meta def decls : expr ⊕ fn_var → list expr
+| (sum.inl x) := [x]
+| (sum.inr x) := [x.dom,x.codom,x.fn]
+
+meta def decls' : expr ⊕ (expr × expr) → list expr
+| (sum.inl x) := [x]
+| (sum.inr (x,y)) := [x,y]
+
+end tactic

--- a/src/data/qpf/compiler/for_mathlib.lean
+++ b/src/data/qpf/compiler/for_mathlib.lean
@@ -1,0 +1,819 @@
+
+/-
+Copyright (c) 2018 Simon Hudon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Simon Hudon
+-/
+import data.pfun
+import data.list.sort
+import data.lazy_list2
+
+universes u v w
+
+lemma eq_mp_heq :
+  ∀ {α β : Sort*} {a : α} {a' : β} (h₂ : a == a'), (eq.mp (type_eq_of_heq h₂) a) = a'
+| α ._ a a' heq.rfl := rfl
+
+namespace sigma
+variables {α₁ α₂ α₃ : Type u}
+variables {β₁ : α₁ → Type v} {β₂ : α₂ → Type v} {β₃ : α₃ → Type v}
+variables {g : sigma β₂ → sigma β₃} {f : sigma β₁ → sigma β₂}
+
+theorem eq_fst {s₁ s₂ : sigma β₁} : s₁ = s₂ → s₁.1 = s₂.1 :=
+by cases s₁; cases s₂; cc
+
+theorem eq_snd {s₁ s₂ : sigma β₁} : s₁ = s₂ → s₁.2 == s₂.2 :=
+by cases s₁; cases s₂; cc
+
+@[ext]
+lemma ext {x₀ x₁ : sigma β₁}
+  (h₀ : x₀.1 = x₁.1)
+  (h₁ : x₀.1 = x₁.1 → x₀.2 == x₁.2) :
+  x₀ = x₁ :=
+by casesm* sigma _; cases h₀; cases h₁ h₀; refl
+
+end sigma
+
+namespace list
+
+variables {m : Type u → Type v} [applicative m]
+
+-- def mmap_enum_if' {α} (p : α → Prop) [decidable_pred p] (f : ℕ → α → m α) : ℕ → list α → m (list α)
+-- | n [] := pure []
+-- | n (x :: xs) :=
+--   if p x then (::) <$> f n x <*> mmap_enum_if' (n+1) xs
+--          else cons x <$> mmap_enum_if' n xs
+
+-- def mmap_enum_if {α} (p : α → Prop) [decidable_pred p] (f : ℕ → α → m α) : list α → m (list α) :=
+-- mmap_enum_if' p f 0
+open nat
+def mrepeat {α} : ℕ → m α → m (list α)
+| 0        cmd := pure []
+| (succ n) cmd := (::) <$> cmd <*> mrepeat n cmd
+
+open function
+
+end list
+namespace roption
+variables {α : Type*} {β : Type*} {γ : Type*}
+
+open function
+lemma assert_if_neg {p : Prop}
+  (x : p → roption α)
+  (h : ¬ p)
+: assert p x = roption.none :=
+by { dsimp [assert,roption.none],
+     have : (∃ (h : p), (x h).dom) ↔ false,
+     { split ; intros h' ; repeat { cases h' with h' },
+       exact h h' },
+     congr,
+     repeat { rw this <|> apply hfunext },
+     intros h h', cases h', }
+
+lemma assert_if_pos {p : Prop}
+  (x : p → roption α)
+  (h : p)
+: assert p x = x h :=
+by { dsimp [assert],
+     have : (∃ (h : p), (x h).dom) ↔ (x h).dom,
+     { split ; intros h'
+       ; cases h' <|> split
+       ; assumption, },
+     cases hx : x h, congr, rw [this,hx],
+     apply hfunext, rw [this,hx],
+     intros, simp [hx] }
+
+@[simp]
+lemma roption.none_bind {α β : Type*} (f : α → roption β)
+: roption.none >>= f = roption.none :=
+by simp [roption.none,has_bind.bind,roption.bind,assert_if_neg]
+
+end roption
+
+namespace monad
+
+@[simp]
+lemma bind_pure_star {m} [monad m] [is_lawful_monad m] (x : m punit) :
+  x >>= (λ (_x : punit), pure punit.star : punit → m punit) = x :=
+by { transitivity,
+     { apply congr_arg, ext z, cases z, refl },
+     { simp } }
+
+variables {α β γ : Type u}
+variables {m : Type u → Type v} [monad m]
+
+@[reducible]
+def pipe (a : α → m β) (b : β → m γ) : α → m γ :=
+λ x, a x >>= b
+
+infixr ` >=> `:55 := pipe
+
+@[functor_norm]
+lemma map_bind_eq_bind_comp {α β γ} {m} [monad m] [is_lawful_monad m]
+  (f : α → β) (cmd : m α) (g : β → m γ) :
+  (f <$> cmd) >>= g = cmd >>= g ∘ f :=
+by rw [← bind_pure_comp_eq_map,bind_assoc,(∘)]; simp
+
+@[functor_norm]
+lemma bind_map {α β γ} {m} [monad m] [is_lawful_monad m]
+  (f : α → γ → β) (cmd : m α) (g : α → m γ) :
+  cmd >>= (λ x, f x <$> g x) = do { x ← cmd, y ← g x, pure $ f x y }  :=
+by congr; ext; rw [← bind_pure (g x),map_bind]; simp
+
+@[functor_norm]
+lemma bind_seq {α β γ : Type u} {m} [monad m] [is_lawful_monad m]
+  (f : α → m (γ → β)) (cmd : m α) (g : α → m γ) :
+  cmd >>= (λ x, f x <*> g x) = do { x ← cmd, h ← f x, y ← g x, pure $ h y }  :=
+by congr; ext; simp [seq_eq_bind_map] with functor_norm
+
+end monad
+
+attribute [functor_norm] bind_assoc has_bind.and_then map_bind seq_left_eq seq_right_eq
+
+namespace sum
+
+variables {e : Type v} {α β : Type u}
+
+protected def seq : Π (x : sum e (α → β)) (f : sum e α), sum e β
+| (sum.inl e) _ := sum.inl e
+| (sum.inr f) x := f <$> x
+
+instance : applicative (sum e) :=
+{ seq := @sum.seq e,
+  pure := @sum.inr e }
+
+instance : is_lawful_applicative (sum e) :=
+by constructor; intros;
+   casesm* _ ⊕ _; simp [(<*>),sum.seq,pure,(<$>)];
+   refl
+
+end sum
+
+namespace functor
+def foldl (α : Type u) (β : Type v) := α → α
+def foldr (α : Type u) (β : Type v) := α → α
+
+instance foldr.applicative {α} : applicative (foldr α) :=
+{ pure := λ _ _, id,
+  seq := λ _ _ f x, f ∘ x }
+
+instance foldl.applicative {α} : applicative (foldl α) :=
+{ pure := λ _ _, id,
+  seq := λ _ _ f x, x ∘ f }
+
+instance foldr.is_lawful_applicative {α} : is_lawful_applicative (foldr α) :=
+by refine { .. }; intros; refl
+
+instance foldl.is_lawful_applicative {α} : is_lawful_applicative (foldl α) :=
+by refine { .. }; intros; refl
+
+def foldr.eval {α β} (x : foldr α β) : α → α := x
+
+def foldl.eval {α β} (x : foldl α β) : α → α := x
+
+def foldr.mk {α β} (x : α → α) : foldr α β := x
+
+def foldl.mk {α β} (x : α → α) : foldl α β := x
+
+def foldl.cons {α β} (x : α) : foldl (list α) β :=
+list.cons x
+
+def foldr.cons {α β} (x : α) : foldr (list α) β :=
+list.cons x
+
+def foldl.cons' {α} (x : α) : foldl (list α) punit :=
+list.cons x
+
+def foldl.lift {α} (x : α → α) : foldl α punit := x
+def foldr.lift {α} (x : α → α) : foldr α punit := x
+
+end functor
+
+instance {α : Type u} : traversable (prod.{u u} α) :=
+{ map := λ β γ f (x : α × β), prod.mk x.1 $ f x.2,
+  traverse := λ m _ β γ f (x : α × β), by exactI prod.mk x.1 <$> f x.2 }
+
+-- namespace traversable
+
+-- variables {t : Type u → Type u} [traversable t]
+
+-- -- def to_list {α} (x : t α) : list α :=
+-- -- @functor.foldr.eval _ (t punit) (traverse functor.foldr.cons x) []
+
+-- end traversable
+
+
+namespace name
+
+-- def append_suffix : name → string → name
+-- | (mk_string s n) s' := mk_string (s ++ s') n
+-- | n _ := n
+
+def bundle : name → name → name
+| (mk_string s n) (mk_string s' _) := mk_string (s ++ "_" ++ s') n
+| n _ := n
+
+end name
+
+namespace native
+namespace rb_map
+
+-- #check rb_map
+
+variables {key : Type} {val val' : Type}
+
+-- section
+
+variables [has_lt key] [decidable_rel ((<) : key → key → Prop)]
+variables (f : val → val → val)
+
+-- def intersect' : list (key × val) → list (key × val) → list (key × val)
+-- | [] m := []
+-- | ((k,x)::xs) [] := []
+-- | ((k,x)::xs) ((k',x')::xs') :=
+-- if h : k < k' then intersect' xs ((k',x')::xs')
+-- else if k' < k then intersect' ((k,x)::xs) xs'
+-- else (k,f x x') :: intersect' xs xs'
+
+open function (on_fun)
+def sort {α : Type} (f : α → key) : list α → list α := list.merge_sort (on_fun (<) f)
+
+-- end
+
+-- meta def filter_map (f : key → val → option val') (x : rb_map key val) : rb_map key val' :=
+-- fold x (mk _ _) $ λa b m', (insert m' a <$> f a b).get_or_else m'
+
+-- meta def intersect_with (m m' : rb_map key val) : rb_map key val :=
+-- m.filter_map $ λ k x, f x <$> m'.find k
+
+-- meta def intersect (x y : rb_map key val) : rb_map key val :=
+-- intersect_with (function.const val) x y
+
+-- meta def difference (m m' : rb_map key val) : rb_map key val :=
+-- m.filter_map (λ k x, guard (¬ m'.contains k) >> pure x)
+
+end rb_map
+end native
+
+namespace string
+
+open nat
+
+def pop (s : string) : string :=
+(s.mk_iterator.next).next_to_string
+
+lemma nextn_next (it : iterator) (n : ℕ) : iterator.nextn it.next n = iterator.next (iterator.nextn it n) :=
+by induction n generalizing it; simp [iterator.nextn,*]
+
+lemma nextn_succ (it : iterator) (n : ℕ) : iterator.nextn it (succ n) = iterator.next (iterator.nextn it n) :=
+by simp [iterator.nextn, nextn_next]
+
+lemma popn_zero (s : string) : popn s 0 = s :=
+by simp [popn, iterator.nextn]
+
+lemma length_pop (s : string) : length (pop s) = length s - 1 :=
+by simp [pop]
+
+lemma to_string_next (it : iterator) : (iterator.next it).next_to_string = it.next_to_string.pop :=
+by { cases it; cases it_snd; refl, }
+
+lemma popn_succ' (n : ℕ) (s : string) : popn s (succ n) = pop (popn s n) :=
+by simp [popn, nextn_succ, to_string_next]
+
+@[simp]
+lemma next_to_string_nextn (it : iterator) (n : ℕ) : (iterator.nextn it n).next_to_string = it.next_to_string.popn n :=
+begin
+  induction n generalizing it, simp [iterator.nextn, popn],
+  rw [popn_succ', nextn_succ, to_string_next, n_ih, popn]
+end
+
+@[simp]
+lemma length_popn (s : string) (n : ℕ) : (s.popn n).length = s.length - n :=
+begin
+  induction n generalizing s, rw [popn_zero,nat.sub_zero],
+  rw [popn_succ',length_pop,n_ih,sub_succ _ n_n,sub_one],
+end
+
+private def split_with_core (sep : string) (h' : 0 < sep.length) : iterator → iterator → list string
+| start stop :=
+if h : stop.has_next then
+  -- wf hint
+  have stop.next_to_string.length - 1 < stop.next_to_string.length,
+    from nat.sub_lt (iterator.zero_lt_length_next_to_string_of_has_next h) dec_trivial,
+  have stop.next_to_string.length - sep.length < stop.next_to_string.length,
+    from nat.sub_lt (iterator.zero_lt_length_next_to_string_of_has_next h) h',
+  if sep.is_prefix_of stop.next_to_string then
+    let rest := stop.next.next_to_string,
+        stop' := stop.nextn sep.length in
+    (start.extract stop).get_or_else "" :: split_with_core stop' stop'
+  else
+    split_with_core start stop.next
+else
+  [start.next_to_string]
+using_well_founded { rel_tac := λ _ _, `[exact ⟨_, measure_wf (λ e, e.2.next_to_string.length)⟩] }
+
+def split_with (sep s : string) : list string :=
+if h : 0 < sep.length
+  then split_with_core sep h (mk_iterator s) (mk_iterator s)
+  else s.to_list.map string.singleton
+
+private def replace_core (sep t : string) (h' : 0 < sep.length) : iterator → iterator → string → string
+| start stop s :=
+if h : stop.has_next then
+  have stop.next_to_string.length - 1 < stop.next_to_string.length,
+    from nat.sub_lt (iterator.zero_lt_length_next_to_string_of_has_next h) dec_trivial,
+  have stop.next_to_string.length - sep.length < stop.next_to_string.length,
+    from nat.sub_lt (iterator.zero_lt_length_next_to_string_of_has_next h) h',
+  if sep.is_prefix_of stop.next_to_string then
+    let rest := stop.next.next_to_string,
+        stop' := stop.nextn sep.length,
+        pre := (start.extract stop).get_or_else "" in
+    replace_core stop' stop' (s ++ pre ++ t)
+  else
+    replace_core start stop.next s
+else
+  s ++ start.next_to_string
+using_well_founded { rel_tac := λ _ _, `[exact ⟨_, measure_wf (λ e, e.2.1.next_to_string.length)⟩] }
+
+def replace (s sep t : string) : string :=
+if h : 0 < sep.length
+  then replace_core sep t h (mk_iterator s) (mk_iterator s) ""
+  else string.intercalate t (s.to_list.map string.singleton)
+
+end string
+
+namespace expr
+
+meta def is_local_constant' {elab} : expr elab → bool
+| (expr.local_const _ _ _ _) := tt
+| _ := ff
+
+meta def replace_all (e : expr) (p : expr → Prop) [decidable_pred p] (r : expr) : expr :=
+e.replace $ λ e i, guard (p e) >> pure (r.lift_vars 0 i)
+
+meta def const_params : expr → list level
+| (const _ ls) := ls
+| _ := []
+
+meta def collect_meta_univ (e : expr) : list name :=
+native.rb_set.to_list $ e.fold native.mk_rb_set $ λ e' i s,
+match e' with
+| (sort u) := u.fold_mvar (flip native.rb_set.insert) s
+| (const _ ls) := ls.foldl (λ s' l, l.fold_mvar (flip native.rb_set.insert) s') s
+| _ := s
+end
+
+meta def list_univ (e : expr) : list level :=
+e.fold [] $ λ e' i s,
+match e' with
+| (sort u) := s.insert u
+| (const _ ls) := s ∪ ls
+| _ := s
+end
+
+-- meta def replace_aux {elab} (f : expr elab → ℕ → option (expr elab)) : expr elab → ℕ → option (expr elab)
+-- | e@(var a) i := f e i
+-- | e@(sort a) i := f e i
+-- | e@(const a a_1) i := f e i
+-- | e@(mvar unique pretty type) i := f e i
+-- | e@(local_const unique pretty bi type) i x := fold_aux type i (f e i x)
+-- | e@(app fn arg) i x := fold_aux arg i $ fold_aux fn i (f e i x)
+-- | e@(lam var_name bi var_type body) i x := fold_aux body (i+1) $ fold_aux var_type i (f e i x)
+-- | e@(pi var_name bi var_type body) i x := fold_aux body (i+1) $ fold_aux var_type i (f e i x)
+-- | e@(elet var_name type assignment body) i x := fold_aux body (i+1) $ fold_aux assignment i $ fold_aux type i (f e i x)
+-- | e@(macro a xs) i x := xs.foldl (λ acc x, fold_aux x i acc) (f e i x)
+
+-- meta def fold_aux {α elab} (f : expr elab → ℕ → α → α) : expr elab → ℕ → α → α
+-- | e@(var a) i x := f e i x
+-- | e@(sort a) i x := f e i x
+-- | e@(const a a_1) i x := f e i x
+-- | e@(mvar unique pretty type) i x := fold_aux type i $ f e i x
+-- | e@(local_const unique pretty bi type) i x := fold_aux type i (f e i x)
+-- | e@(app fn arg) i x := fold_aux arg i $ fold_aux fn i (f e i x)
+-- | e@(lam var_name bi var_type body) i x := fold_aux body (i+1) $ fold_aux var_type i (f e i x)
+-- | e@(pi var_name bi var_type body) i x := fold_aux body (i+1) $ fold_aux var_type i (f e i x)
+-- | e@(elet var_name type assignment body) i x := fold_aux body (i+1) $ fold_aux assignment i $ fold_aux type i (f e i x)
+-- | e@(macro a xs) i x := xs.foldl (λ acc x, fold_aux x i acc) (f e i x)
+
+-- meta def fold' {α elab} (f : expr elab → ℕ → α → α) (e : expr elab) : α → α :=
+-- fold_aux f e 0
+
+end expr
+
+namespace tactic
+
+meta def instantiate_unify_pi : expr → list expr → tactic expr
+| (expr.pi n bi d b) (e::es) :=
+  do infer_type e >>= unify d,
+     instantiate_unify_pi (b.instantiate_var e) es
+| e _ := pure e
+
+meta def unify_univ (u u' : level) : tactic unit :=
+unify (expr.sort u) (expr.sort u')
+
+meta def trace_expr (e : expr) : tactic expr :=
+do t ← infer_type e >>= pp,
+   e' ← pp e,
+   trace format!"{e'} : {t}",
+   pure e
+
+open declaration (defn)
+meta def trace_def (n : name) : tactic unit :=
+do (defn n _ t df _ _) ← get_decl n,
+   t ← pp t, df ← pp df,
+   trace format!"\ndef {n} : {t} :=\n{df}\n"
+
+meta def is_type (e : expr) : tactic bool :=
+do (expr.sort _) ← infer_type e | pure ff,
+   pure tt
+
+meta def list_macros : expr → list (name × list expr) | e :=
+e.fold [] (λ m i s,
+  match m with
+  | (expr.macro m args) := (expr.macro_def_name m, args) :: s
+  | _ := s end)
+
+meta def expand_untrusted (tac : tactic unit) : tactic unit :=
+do tgt ← target,
+   mv  ← mk_meta_var tgt,
+   gs ← get_goals,
+   set_goals [mv],
+   tac,
+   env ← get_env,
+   pr ← env.unfold_untrusted_macros <$> instantiate_mvars mv,
+   set_goals gs,
+   exact pr
+
+-- meta def is_recursive_type (n : name) : tactic bool :=
+-- do e ← get_env,
+--    let cs := e.constructors_of n,
+--    rs ← cs.mmap (rec_args_count n),
+--    pure $ rs.any (λ r, r > 0)
+
+meta def extract_def' {α} (n : name) (trusted : bool) (elab_def : tactic α) : tactic α :=
+do cxt ← list.map expr.to_implicit_binder <$> local_context,
+   t ← target,
+   (r,d) ← solve_aux t elab_def,
+   d ← instantiate_mvars d,
+   t' ← pis cxt t,
+   d' ← lambdas cxt d,
+   let univ := t'.collect_univ_params,
+   add_decl $ declaration.defn n univ t' d' (reducibility_hints.regular 1 tt) trusted,
+   r <$ (applyc n; assumption)
+
+open expr list nat
+
+meta def remove_intl_const : expr → tactic expr
+| v@(local_const uniq pp bi _) :=
+  do t ← infer_type v,
+     pure $ local_const uniq pp bi t
+| e := pure e
+
+instance name.has_repr : has_repr name :=
+{ repr := λ x, "`" ++ x.to_string }
+
+private meta def report_invalid_simp_lemma {α : Type} (n : name): tactic α :=
+fail format!"invalid simplification lemma '{n}' (use command 'set_option trace.simp_lemmas true' for more details)"
+
+private meta def check_no_overload (p : pexpr) : tactic unit :=
+when p.is_choice_macro $
+  match p with
+  | macro _ ps :=
+    fail $ to_fmt "ambiguous overload, possible interpretations" ++
+           format.join (ps.map (λ p, (to_fmt p).indent 4))
+  | _ := failed
+  end
+
+private meta def add_simps : simp_lemmas → list name → tactic simp_lemmas
+| s []      := return s
+| s (n::ns) := do s' ← s.add_simp n, add_simps s' ns
+
+-- private meta def simp_lemmas.resolve_and_add (s : simp_lemmas) (u : list name) (n : name) (ref : pexpr) : tactic (simp_lemmas × list name) :=
+-- do
+--   p ← resolve_name n,
+--   check_no_overload p,
+--   -- unpack local refs
+--   let e := p.erase_annotations.get_app_fn.erase_annotations,
+--   match e with
+--   | const n _           :=
+--     (do b ← is_valid_simp_lemma_cnst n, guard b, save_const_type_info n ref, s ← s.add_simp n, return (s, u))
+--     <|>
+--     (do eqns ← get_eqn_lemmas_for tt tt n, guard (eqns.length > 0), save_const_type_info n ref, s ← add_simps s eqns, return (s, u))
+--     <|>
+--     (do env ← get_env, guard (env.is_projection n).is_some, return (s, n::u))
+--     <|>
+--     report_invalid_simp_lemma n
+--   | _ :=
+--     (do e ← i_to_expr_no_subgoals p, b ← is_valid_simp_lemma e, guard b, try (save_type_info e ref), s ← s.add e, return (s, u))
+--     <|>
+--     report_invalid_simp_lemma n
+--   end
+
+-- meta def simp_lemmas.add_pexpr (s : simp_lemmas) (u : list name) (p : pexpr) : tactic (simp_lemmas × list name) :=
+-- match p with
+-- | (const c [])          := simp_lemmas.resolve_and_add s u c p
+-- | (local_const c _ _ _) := simp_lemmas.resolve_and_add s u c p
+-- | _                     := do new_e ← i_to_expr_no_subgoals p, s ← s.add new_e, return (s, u)
+-- end
+
+-- meta def simp_lemmas.append_pexprs : simp_lemmas → list name → list pexpr → tactic (simp_lemmas × list name)
+-- | s u []      := return (s, u)
+-- | s u (l::ls) := do (s, u) ← simp_lemmas.add_pexpr s u l, simp_lemmas.append_pexprs s u ls
+
+
+meta def generalize_with (h x : name) (e : expr) : tactic unit :=
+do t ← infer_type e,
+   v ← mk_local_def x t,
+   h ← mk_app `eq [e,v] >>= mk_local_def h,
+   tgt ← target,
+   (tgt',_) ← solve_aux tgt $ do
+   { generalize e,
+     pi _ _ _ e' ← target,
+     pure $ e'.instantiate_var v } <|> pure tgt,
+   tgt' ← pis [v,h] tgt',
+   new_goal ← mk_meta_var tgt',
+   heq ← mk_eq_refl e,
+   exact $ new_goal e heq,
+   gs ← get_goals, set_goals $ new_goal :: gs
+
+meta def solve_sync (vs : list $ list expr) (p : expr) (tac : tactic unit) : tactic (task expr) :=
+do pr ← prod.snd <$> solve_aux p tac >>= instantiate_mvars,
+   return <$> vs.reverse.mfoldl (flip lambdas) pr
+
+meta def mk_mvar_pis : expr → tactic (list expr)
+| (pi n bi d b) :=
+do v ← mk_meta_var d,
+   cons v <$> mk_mvar_pis (b.instantiate_var v)
+| _ := pure []
+
+open interactive.types interactive lean.parser
+
+@[user_command]
+meta def test_signature_cmd (_ : parse $ tk "#test") : lean.parser unit :=
+do e ← ident,
+show tactic unit, from
+do d ← get_decl e,
+   let e := @const tt d.to_name d.univ_levels,
+   t ← infer_type e >>= pp,
+   e.collect_meta_univ.enum.mmap' $ λ ⟨i,v⟩, unify_univ (level.mvar v) (level.param ("u_" ++ to_string i : string)),
+   e ← instantiate_mvars e,
+   e ← pp e,
+   trace format!"\nexample : {t} :=\n{e}\n",
+   pure ()
+
+end tactic
+
+namespace tactic.interactive
+
+open lean lean.parser interactive interactive.types tactic
+
+local postfix `*`:9000 := many
+
+meta def splita := split; [skip, assumption]
+
+@[hole_command]
+meta def whnf_type_hole : hole_command :=
+{ name := "Reduce expected type",
+  descr := "Reduce expected type",
+  action := λ es,
+    do t ← match es with
+           | [h] := to_expr h >>= infer_type >>= whnf
+           | [] := target >>= whnf
+           | _ := fail "too many expressions"
+           end,
+       trace t,
+       pure [] }
+
+@[hole_command]
+meta def dsimp_hole : hole_command :=
+{ name := "dsimp expected type",
+  descr := "dsimp expected type",
+  action := λ es,
+    do -- s ← simp_lemmas.mk_default,
+       -- s ← es.mmap to_expr >>= s.append,
+       (s, u) ← mk_simp_set ff [] $ es.map simp_arg_type.expr,
+       dsimp_target s u,
+       tgt ← target,
+       s ← pformat!"(_ : {tgt})",
+       pure [(to_string s, "")] }
+
+@[hole_command]
+meta def constructor_hole : hole_command :=
+{ name := "constructor",
+  descr := "apply constructor",
+  action := λ es,
+    do g ← main_goal,
+       constructor,
+       g ← instantiate_mvars g,
+       let g := g.replace $ λ e _,
+         match e with
+         | expr.mvar _ _ t := some $ expr.const `_ []
+         | _ := none end,
+       s ← pp g,
+       let s := if es.empty
+         then (to_string s).replace "«_»" "_"
+         else (to_string s).replace "«_»" "{!!}",
+       pure [(to_string s, "")] }
+
+meta def trace_error {α} (tac : tactic α) : tactic α
+| s :=
+match tac s with
+| r@(interaction_monad.result.success a a_1) := r
+| r@(interaction_monad.result.exception none a_1 a_2) := (trace "(no error message)" >> interaction_monad.result.exception none a_1) s
+| r@(interaction_monad.result.exception (some msg) a_1 a_2) := (trace (msg ()) >> interaction_monad.result.exception none a_1) s
+end
+
+
+end tactic.interactive
+
+instance subsingleton.fin0 {α} : subsingleton (fin 0 → α) :=
+subsingleton.intro $ λ a b, funext $ λ i, fin.elim0 i
+
+attribute [ext] function.hfunext
+
+meta def options.list_names (o : options) : list name := o.fold [] (::)
+
+namespace expr
+
+meta def bracket (p : ℕ) (fmt : format) (p' : ℕ) : format :=
+if p' < p then format.paren fmt else fmt
+
+meta def fmt_binder (n : name) : binder_info → format → format
+| binder_info.default t := format!"({n} : {t})"
+| binder_info.implicit t := format!"{{{n} : {t}}"
+| binder_info.strict_implicit t := format!"⦃{n} : {t}⦄"
+| binder_info.inst_implicit t := format!"[{n} : {t}]"
+| binder_info.aux_decl t := "_"
+
+meta def parsable_printer' : expr → list name → ℕ → format
+| (expr.var a) l := λ _, format!"@{(l.nth a).get_or_else name.anonymous}"
+| (expr.sort level.zero) l := λ _, to_fmt "Prop"
+| (expr.sort (level.succ u)) l := λ _, format!"Type.{{{u}}"
+| (expr.sort u) l := λ _, format!"Sort.{{{u}}"
+| (expr.const a []) l := λ _, format!"@{a}"
+| (expr.const a ls) l := λ _, format!"@{a}.{{{format.intercalate  \" \" $ list.map to_fmt ls}}"
+| (expr.mvar a a_1 a_2) l := λ _, to_fmt a
+| (expr.local_const a a_1 a_2 a_3) l := λ _, to_fmt a_1
+| (expr.app a a_1) l := bracket 10 $ format!"{parsable_printer' a l 10} {parsable_printer' a_1 l 9}"
+| (expr.lam a a_1 a_2 a_3) l := bracket 8 $ format!"λ {fmt_binder a a_1 $ parsable_printer' a_2 l 10}, {parsable_printer' a_3 (a :: l) 10}"
+| (expr.pi a a_1 a_2 a_3) l :=
+       if a_3.has_var_idx 0
+          then bracket 8 $ format!"Π {fmt_binder a a_1 $ parsable_printer' a_2 l 10}, {parsable_printer' a_3 (a :: l) 10}"
+          else bracket 8 $ format!"{parsable_printer' a_2 l 7} → {parsable_printer' a_3 (a :: l) 7}"
+| (expr.elet a a_1 a_2 a_3) l := bracket 8 $ format!"let {a} : {parsable_printer' a_1 l 10} := {parsable_printer' a_2 l 10} in {parsable_printer' a_3 (a :: l) 10}"
+| (expr.macro a a_1) l := λ _, to_fmt "unsupported"
+
+meta def parsable_printer (e : expr) : format := parsable_printer' e [] 10
+
+meta def as_binder (e : expr) := fmt_binder e.local_pp_name e.binding_info (parsable_printer e.local_type)
+
+end expr
+
+meta def enclosing_name : tactic unit :=
+do n ← tactic.decl_name,
+   tactic.exact `(n)
+
+meta def on_error {α β} (tac : tactic α) (hdl : tactic β) : tactic α
+| s := match tac s with
+       | (result.success a a_1) := result.success a a_1
+       | (result.exception a a_1 s) := (hdl >> result.exception a a_1) s
+       end
+
+meta def finally {α β} (tac : tactic α) (hdl : tactic β) : tactic α :=
+on_error tac hdl <* hdl
+
+-- meta def brackets {α β} (tac : tactic α) (hdl : tactic β) : tactic α :=
+-- on_error tac hdl <* hdl
+
+meta def with_options {α} (xs : list name) (tac : tactic α) : tactic α :=
+do opt ← tactic.get_options,
+   tactic.set_options $ xs.foldl (λ o n, o.set_bool n tt) opt,
+   finally tac (tactic.set_options opt)
+
+declare_trace trace_scope.begin_end
+declare_trace trace_scope.error
+
+meta def trace_scope {α} (tac : tactic α) (n : name . enclosing_name) : tactic α :=
+do tactic.when_tracing `trace_scope.begin_end $ trace!"• begin {n}",
+   r ← on_error tac (tactic.when_tracing `trace_scope.error $ trace!"• error in {n}"),
+   tactic.when_tracing `trace_scope.begin_end $ trace!"• end {n}",
+   pure r
+
+meta def stack_trace : vm_monitor ℕ :=
+{ init := 0,
+  step := λ i,
+  do j ← vm.stack_size,
+     if i = j then pure i else do
+       fn ← vm.curr_fn,
+       vm.put_str $ (list.repeat ' ' j).as_string ++ fn.to_string,
+       pure j }
+
+lemma mpr_mpr : Π {α β} (h : α = β) (h' : β = α) (x : α), h.mpr (h'.mpr x) = x
+| _ _ rfl rfl x := rfl
+
+lemma eq_mpr_of_mp_eq : Π {α β} {h : α = β} {x : α} {y : β} (h' : h.mp x = y), x = h.mpr y
+| _ _ rfl _ _ := id
+
+lemma mp_eq_of_eq_mpr : Π {α β} {h : α = β} {x : α} {y : β} (h' : x = h.mpr y), h.mp x = y
+| _ _ rfl _ _ := id
+
+lemma mp_eq_of_heq : Π {α β} {h : α = β} {x : α} {y : β} (h' : x == y), h.mp x = y
+| _ _ rfl _ _ heq.rfl := rfl
+
+namespace lazy_list
+
+protected def pure {α} (x : α) : lazy_list α :=
+lazy_list.cons x lazy_list.nil
+
+protected def bind {α β} : lazy_list α → (α → lazy_list β) → lazy_list β
+| lazy_list.nil _ := lazy_list.nil
+| (lazy_list.cons x xs) f := (f x).append (bind (xs ()) f)
+
+instance : monad lazy_list :=
+{ pure := @lazy_list.pure,
+  bind := @lazy_list.bind }
+
+variables
+{α β γ : Type u}
+(x : α) (x' : lazy_list α)
+(f : α → lazy_list β)
+(g : β → lazy_list γ)
+
+lemma append_nil (xs : lazy_list α) : xs.append nil = xs :=
+begin
+  induction xs; simp only [*, true_and, eq_self_iff_true, append],
+  ext ⟨ ⟩; refl
+end
+
+lemma append_assoc (xs ys zs : lazy_list α) : (xs.append ys).append zs = xs.append (ys.append zs) :=
+by induction xs; simp only [*, true_and, eq_self_iff_true, append]
+
+lemma pure_bind : lazy_list.bind (lazy_list.pure x) f = f x :=
+by simp only [lazy_list.pure,lazy_list.bind,append_nil]
+
+lemma bind_pure : lazy_list.bind x' pure = x' :=
+begin
+  induction x'; simp [lazy_list.bind,has_pure.pure,lazy_list.pure,append],
+  ext ⟨ ⟩, apply x'_ih
+end
+
+lemma bind_append {xs ys : lazy_list α} :
+  lazy_list.bind (xs.append ys) f = (xs.bind f).append (ys.bind f) :=
+by induction xs; simp only [*,append,lazy_list.bind,append_assoc]
+
+lemma bind_assoc : lazy_list.bind (lazy_list.bind x' f) g = lazy_list.bind x' (λ a, lazy_list.bind (f a) g) :=
+begin
+  induction x', refl,
+  dsimp at x'_ih,
+  simp only [lazy_list.bind,*],
+  rw [← x'_ih,bind_append],
+end
+
+instance : is_lawful_monad lazy_list :=
+{ pure_bind := λ α β, pure_bind,
+  bind_assoc := @bind_assoc,
+  id_map := by intros; apply bind_pure
+   }
+
+end lazy_list
+
+namespace lean.parser
+
+meta def returnex {α : Type} (e : exceptional α) : lean.parser α :=
+λ s, match e with
+| exceptional.success a      := result.success a s
+| exceptional.exception f := result.exception (some (λ u, f s.options)) none s
+end
+
+end lean.parser
+
+namespace tactic
+
+setup_tactic_parser
+
+meta def apply_symm (n : name) : tactic expr :=
+do e ← mk_const n,
+   (vs,t) ← infer_type e >>= mk_local_pis,
+   e' ← mk_eq_symm $ e.mk_app vs,
+   lambdas vs e'
+
+@[interactive]
+meta def fold (ns : parse ident*) (ls : parse location) : tactic unit :=
+do hs ← ns.mmap $ get_eqn_lemmas_for tt,
+   hs ← hs.join.mmap apply_symm,
+   (s,u) ← mk_simp_set tt [] (hs.map $ simp_arg_type.expr ∘ to_pexpr),
+   ls.try_apply (λ h, () <$ simp_hyp s u h) (simp_target s u)
+
+end tactic
+
+namespace psigma
+
+variables {α : Sort u} {β : α → Sort v} {γ : Sort w}
+
+def curry (f : psigma β → γ) : Π a (b : β a), γ :=
+λ x y, f ⟨x,y⟩
+
+def uncurry (f : Π a (b : β a), γ) : psigma β → γ
+| ⟨a,b⟩ := f a b
+
+end psigma

--- a/src/data/qpf/compiler/for_mathlib.lean
+++ b/src/data/qpf/compiler/for_mathlib.lean
@@ -811,7 +811,9 @@ meta def decl_kind : declaration → string
 | (declaration.ax a a_1 a_2) := "axiom"
 
 declare_trace generated_decl
+declare_trace generated_decl.tests
 
+@[user_attribute]
 meta def generated_attr : user_attribute (native.rb_lmap name name) name :=
 { name := `generated,
   parser := ident,
@@ -823,6 +825,8 @@ meta def generated_attr : user_attribute (native.rb_lmap name name) name :=
 
 meta def emit_decl' (n : name) (d : declaration) : tactic expr :=
 do when_tracing `generated_decl $ trace!"[generated for {n}]\n  {decl_kind d} {d.to_name} : {d.type}",
+   when_tracing `generated_decl.tests $ trace!"#check (@{d.to_name} : {d.type})",
+   generated_attr.set d.to_name n tt,
    add_decl' d
 
 meta def emit_decl (n : name) (d : declaration) : tactic unit :=

--- a/src/data/qpf/compiler/inductive_decl.lean
+++ b/src/data/qpf/compiler/inductive_decl.lean
@@ -1,0 +1,263 @@
+/-
+Copyright (c) 2018 Simon Hudon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Simon Hudon
+-/
+import meta.expr
+import tactic.core
+import tactic.mk_has_to_format
+
+namespace tactic
+open expr
+open environment ( implicit_infer_kind intro_rule ) environment.implicit_infer_kind
+
+attribute [derive has_to_format] binder_info implicit_infer_kind
+attribute [derive has_reflect] implicit_infer_kind
+
+@[derive [has_reflect,has_to_format]]
+meta structure type_cnstr :=
+(name : name)
+(args : list expr)
+(result : list expr)
+(infer : implicit_infer_kind)
+
+meta def local_ctor (n : name) : expr → expr :=
+local_const n n binder_info.default
+
+meta instance : has_to_format type_cnstr :=
+{ to_format := λ ⟨n,a,r,_⟩, format!"{n} : {expr.pis a $ (@const tt `type []).mk_app r}" }
+
+
+@[derive [has_reflect,has_to_format]]
+meta structure inductive_type :=
+(pre : name)
+(name : name)
+(u_names : list _root_.name)
+(params : list expr)
+(idx : list expr)
+(type : expr)
+(ctors : list type_cnstr)
+
+-- meta instance inductive_type.has_to_tactic_format : has_to_tactic_format inductive_type :=
+-- { to_tactic_format := λ a, pure $ to_fmt a }
+
+meta def inductive_type.u_params (decl : inductive_type) :=
+decl.u_names.map level.param
+
+meta def inductive_type.type_ctor (decl : inductive_type) : expr :=
+(@const tt decl.name decl.u_params).mk_app decl.params
+
+meta def inductive_type.sig (decl : inductive_type) : tactic expr :=
+local_ctor decl.name <$> pis decl.idx decl.type
+
+meta def inductive_type.intros (decl : inductive_type) : tactic (list expr) :=
+do let t := inductive_type.type_ctor decl,
+   decl.ctors.mmap $ λ c, local_ctor c.name <$> pis c.args (t.mk_app c.result)
+
+meta def type_cnstr.to_intro_rule (decl : inductive_type) (c : type_cnstr) : intro_rule :=
+let t := inductive_type.type_ctor decl in
+⟨ c.name, (t.mk_app c.result).pis c.args, c.infer ⟩
+
+meta def inductive_type.mk_const (decl : inductive_type) (n : string) : expr :=
+const (decl.name <.> n) $ decl.u_params
+
+meta def inductive_type.mk_name (decl : inductive_type) (n : string) : name :=
+decl.name <.> n
+
+meta def inductive_type.is_constructor (decl : inductive_type) (n : name) : bool :=
+n ∈ decl.ctors.map type_cnstr.name
+
+meta def fresh_univ (xs : list name) (n : name := `u) : name :=
+(((list.iota (xs.length + 1)).reverse.map n.append_after).diff xs).head
+open expr (to_implicit_local_const)
+meta def mk_cases_on (decl : inductive_type) : tactic unit :=
+do let u := fresh_univ decl.u_names,
+   let idx := decl.idx,
+   let c := @const tt decl.name decl.u_params,
+   n ← unify_app c ( decl.params ++ idx ) >>= mk_local_def `n,
+   C ← pis (idx ++ [n]) (sort $ level.param u) >>= mk_local_def `C,
+   cases ← decl.ctors.mmap $ λ c,
+     do { cn ← get_unused_name "c",
+          n ← unify_app (const c.name decl.u_params) $ decl.params ++ c.args,
+          pis c.args (C.mk_app $ c.result ++ [n]) >>= mk_local_def cn },
+   t ← pis ((decl.params ++ [C] ++ idx).map to_implicit_local_const ++ [n] ++ cases) (C.mk_app (idx ++ [n])),
+   p ← mk_mapp (decl.name <.> "rec") $ (decl.params ++ [C] ++ cases ++ idx ++ [n]).map some,
+   p ← lambdas (decl.params ++ [C] ++ idx ++ [n] ++ cases) p,
+   d ← instantiate_mvars p,
+   add_decl $ mk_definition (decl.name <.> "cases_on") (u :: decl.u_names) t d,
+   updateex_env $ λ e, pure $ e.add_namespace decl.name,
+   return ()
+
+meta def inductive_type.mk_cases_on (decl : inductive_type) (C e : expr) (f : name → list expr → tactic expr) : tactic expr :=
+do let cases_on_n := decl.mk_name "cases_on",
+   cases_on ← mk_const cases_on_n,
+   cs ← decl.ctors.mmap $ λ c,
+     do { (args',_) ← pis c.args `(true) >>= mk_local_pis,
+          f c.name args' >>= lambdas args' },
+   unify_app cases_on (decl.params ++ [C] ++ decl.idx ++ [e] ++ cs)
+
+meta def inductive_type.mk_cases_on' (decl : inductive_type) (C e' : expr) (f : name → list expr → tactic unit) : tactic (list expr) :=
+do let cases_on_n := decl.mk_name "cases_on",
+   cases_on ← mk_const cases_on_n,
+   cs ← decl.ctors.mmap $ λ c,
+     do { n ← unify_app (const c.name decl.u_params) $ decl.params ++ c.args,
+          t ← pis (c.args) (C.mk_app $ c.result ++ [n]),
+          mk_meta_var t  },
+   gs ← get_goals,
+   e ← unify_app cases_on (decl.params ++ [C] ++ decl.idx ++ [e'] ++ cs),
+   mzip_with' (λ g (c : type_cnstr),
+       do set_goals [g],
+          intro_lst ( c.args.map expr.local_pp_name )
+            >>= f c.name )
+       cs decl.ctors,
+   set_goals gs,
+   apply e,
+   (>>= list_meta_vars) <$> cs.mmap instantiate_mvars.
+
+meta def mk_no_confusion_type (decl : inductive_type) : tactic unit :=
+do let params := decl.params.map to_implicit_local_const,
+   let t := (const decl.name $ decl.u_params).mk_app $ params ++ decl.idx,
+   let u := fresh_univ decl.u_names,
+   let cases_on_n := decl.mk_name "cases_on",
+   cases_on ← mk_const cases_on_n,
+   v1 ← mk_local_def `v1 t,
+   v2 ← mk_local_def `v2 t,
+   P  ← mk_local_def `P (expr.sort $ level.param u),
+   C ← lambdas (decl.idx ++ [v1]) (sort $ level.param u),
+   e ← decl.mk_cases_on C v1 $ λ c args,
+     do { decl.mk_cases_on C v2 $ λ c' args',
+          if c = c' then do
+            hs ← mzip_with (λ x y,
+              mk_app `eq [x,y] >>= mk_local_def `h)
+              args args',
+            h ← pis hs P,
+            pure $ h.imp P
+          else pure P },
+   let vs := (params ++ decl.idx ++ [P,v1,v2]),
+   e ← lambdas vs e,
+   p ← pis vs (sort $ level.param u),
+   infer_type e >>= unify p,
+   e ← instantiate_mvars e,
+   add_decl $ mk_definition (decl.mk_name "no_confusion_type") (u :: decl.u_names) p e
+
+run_cmd mk_simp_attr `pseudo_eqn
+
+meta def mk_no_confusion (decl : inductive_type) : tactic unit :=
+do let params := decl.params.map to_implicit_local_const,
+   let t := (const decl.name $ decl.u_params).mk_app $ params ++ decl.idx,
+   let u := fresh_univ decl.u_names,
+   v1 ← mk_local_def `v1 t,
+   v2 ← mk_local_def `v2 t,
+   P  ← mk_local_def `P (expr.sort $ level.param u),
+   type ← mk_const (decl.mk_name "no_confusion_type"),
+   Heq ← mk_app `eq [v1,v2] >>= mk_local_def `Heq,
+   let vs := (params ++ decl.idx ++ [P,v1,v2]).map to_implicit_local_const,
+   p ← unify_app type vs,
+   let vs := vs ++ [Heq],
+   (_,pr) ← solve_aux p $
+     do { intros,
+          dunfold_target [decl.mk_name "no_confusion_type"],
+          tgt ← target,
+          cases_on ← mk_const ``eq.rec,
+          C ← pis [Heq] tgt >>= lambdas ([v2]),
+          t ← infer_type v1,
+          g ← mk_mvar,
+          unify_app cases_on ([t,v1,C,g,v2,Heq,Heq]) >>= exact,
+          set_goals [g],
+          intro1,
+          tgt ← target,
+          C ← lambdas (decl.idx ++ [v1]) tgt,
+          cases_on ← mk_const (decl.mk_name "cases_on"),
+          decl.mk_cases_on' C v1 $ λ _ _,
+            do { try $ `[simp only with pseudo_eqn],
+                 h ← intro `h, () <$ apply h; reflexivity },
+          done },
+   p ← pis vs p,
+   p ← instantiate_mvars p,
+   pr ← instantiate_mvars pr,
+   pr ← lambdas vs pr,
+   add_decl $ mk_definition (decl.mk_name "no_confusion") (u :: decl.u_names) p pr,
+   pure ()
+
+meta def inductive_type.get_constructor (c_name : name) : inductive_type → option type_cnstr
+| { ctors := ctors, .. } := ctors.find (λ c, c.name = c_name)
+
+meta def type_cnstr.type (decl : inductive_type) : type_cnstr → tactic expr
+| ⟨cn,vs,r,i⟩ :=
+do let sig_c  : expr := const decl.name decl.u_params,
+   ts ← vs.mmap infer_type,
+   let params : list expr := match i with
+                             | implicit := decl.params
+                             | relaxed_implicit := decl.params.map to_implicit_local_const
+                             | none := decl.params.map $ λ v, if v ∈ ts then to_implicit_local_const v
+                                                                        else v
+                             end,
+   tactic.pis vs (sig_c.mk_app' [decl.params,r]) >>= pis params
+
+meta def mk_inductive : inductive_type → tactic unit
+| decl :=
+do opt ← get_options,
+   updateex_env $ λ env, pure $ env.add_namespace decl.name,
+   updateex_env $ λ e : environment,
+     e.add_ginductive opt decl.u_names decl.params
+     [((decl.name,decl.type.pis decl.idx),decl.ctors.map $ type_cnstr.to_intro_rule decl)] ff,
+   pure ()
+
+open interactive
+
+meta def implicit_infer_kind_of (us : list expr) : implicit_infer_kind :=
+let b₀ := us.all $ λ v, v.local_binding_info = binder_info.default,
+    b₁ := us.all $ λ v, v.local_binding_info ≠ binder_info.default in
+if b₀ then if b₁ then implicit
+                 else none
+else if b₁ then relaxed_implicit
+           else implicit
+
+meta def inductive_type.of_name (decl : name) : tactic inductive_type :=
+do d ← get_decl decl,
+   (idx,t) ← mk_local_pis d.type,
+   env ← get_env,
+   let (params,idx) := idx.split_at $ env.inductive_num_params decl,
+   cs ← (env.constructors_of decl).mmap $ λ c : name,
+   do { let e := @const tt c d.univ_levels,
+        t ← infer_type $ e.mk_app params,
+        (vs,t) ← mk_local_pis t,
+        (us,_) ← infer_type e >>= mk_local_pis,
+        let infer := implicit_infer_kind_of $ us.take params.length,
+        pure (t.get_app_fn.const_name,{ type_cnstr .
+               name := c,
+               args := vs,
+               result := t.get_app_args.drop $ env.inductive_num_params decl,
+               infer  := infer }) },
+   pure { pre := decl.get_prefix,
+          name := decl,
+          u_names := d.univ_params,
+          params := params,
+          idx := idx, type := t,
+          ctors := cs.map prod.snd }
+
+-- meta def with_namespace (decl : inductive_decl) : tactic inductive_type :=
+-- do
+--    env ← get_env,
+
+meta def inductive_type.of_decl (decl : inductive_decl) : tactic inductive_type :=
+do [d] ← pure decl.decls | fail "mutually (co)inductive types are not supported",
+   (idx,t) ← infer_type  d.sig >>= mk_local_pis,
+   -- env ← get_env,
+   cs ← d.intros.mmap $ λ c : expr,
+   do { t ← infer_type c,
+        (vs,t) ← mk_local_pis t,
+        pure (t.get_app_fn.const_name,{ type_cnstr .
+               name := c.local_pp_name,
+               args := vs,
+               result := t.get_app_args.drop $ decl.params.length,
+               infer  := relaxed_implicit }) },
+   let n := (prod.fst <$> cs.nth 0).get_or_else d.sig.local_pp_name,
+   pure { pre := n.get_prefix,
+          name := n,
+          u_names := decl.u_names,
+          params := decl.params,
+          idx := idx, type := t,
+          ctors := cs.map prod.snd }
+
+end tactic

--- a/src/data/qpf/compiler/shape.lean
+++ b/src/data/qpf/compiler/shape.lean
@@ -1,0 +1,97 @@
+
+import data.qpf.compiler.basic
+import data.qpf.multivariate
+
+namespace tactic
+
+open interactive lean lean.parser
+
+meta def replace_rec_occ (tn tn' : name) (nested : expr) (var : expr) : type_cnstr → type_cnstr
+| (tactic.type_cnstr.mk name args result infer) :=
+{ name := name.replace_prefix tn tn',
+  args := args.map $ λ e, expr.replace e $ λ e' _, if e' = nested then pure var else none,
+  result := result.map $ λ e, expr.replace e $ λ e' _, if e' = nested then pure var else none,
+  infer := infer }
+
+open expr interactive
+
+meta structure datatype_shape extends internal_mvfunctor :=
+(hole : expr)
+
+meta def datatype_shape.params (d : datatype_shape) := internal_mvfunctor.params d.to_internal_mvfunctor
+meta def datatype_shape.dead_params (d : datatype_shape) := internal_mvfunctor.dead_params d.to_internal_mvfunctor
+meta def datatype_shape.live_params (d : datatype_shape) := internal_mvfunctor.live_params d.to_internal_mvfunctor
+
+meta def mk_shape_decl (d : inductive_type) : tactic (expr × inductive_type) :=
+do v ← mk_local_def (fresh_univ (d.params.map expr.local_pp_name) `α) d.type,
+   let c := @const tt d.name d.u_params,
+   let c' := c.mk_app d.params,
+   pure (v, { pre := d.name.get_prefix,
+              name := d.name <.> "shape",
+              u_names := d.u_names,
+              params := d.params ++ [v],
+              idx := d.idx,
+              type := d.type,
+              ctors := d.ctors.map (replace_rec_occ d.name (d.name <.> "shape") c' v) })
+
+meta def mk_shape_functor' (d : inductive_type) : tactic (datatype_shape × internal_mvfunctor) :=
+do func' ← internalize_mvfunctor d,
+   (v,func) ← mk_shape_decl d,
+   mk_inductive func,
+   func ← internalize_mvfunctor func,
+   mk_internal_functor_def func,
+   mk_internal_functor_eqn func,
+   pure ({ hole := v .. func }, func')
+
+meta def decl_kind : declaration → string
+| (declaration.defn a a_1 a_2 a_3 a_4 a_5) := "defn"
+| (declaration.thm a a_1 a_2 a_3) := "thm"
+| (declaration.cnst a a_1 a_2 a_3) := "cnst"
+| (declaration.ax a a_1 a_2) := "ax"
+
+-- meta def mk_struct (n : name) (ls : list name)
+
+meta def mk_fixpoint (fix : name) (func d : internal_mvfunctor) : tactic unit :=
+do let dead := func.dead_params,
+   let shape := (@const tt (func.decl.to_name <.> "internal") func.induct.u_params).mk_app dead,
+   df ← (mk_mapp fix [none,shape,none,none] >>= lambdas dead : tactic _),
+   t ← infer_type df,
+   let intl_n := func.decl.to_name.get_prefix <.> "internal",
+   updateex_env $ λ env, pure $ env.add_namespace intl_n,
+   add_decl $ mk_definition intl_n func.induct.u_names t df,
+   v ← mk_live_vec func.vec_lvl $ func.live_params.init,
+   df ← lambdas d.params $ (@const tt intl_n func.induct.u_params).mk_app func.dead_params v,
+   t  ← infer_type df,
+   add_decl $ mk_definition func.decl.to_name.get_prefix func.induct.u_names t df,
+   pure ()
+
+meta def timetac' {α : Type*} (_ : string) (tac : thunk (tactic α)) : tactic α :=
+tac ()
+
+meta def get_type_spec (n : name) : tactic inductive_type :=
+mk_const (n <.> "_spec") >>= eval_expr _
+
+meta def mk_datatype (iter : name) (d : inductive_decl) : tactic (datatype_shape × internal_mvfunctor) :=
+do dt ← inductive_type.of_decl d,
+   (func', d) ← mk_shape_functor' dt,
+   let func : internal_mvfunctor := { .. func' },
+   timetac' "mk_mvfunctor_instance" $ mk_mvfunctor_instance func,
+   mk_pfunctor func,
+   timetac' "mk_pfunc_constr" $ mk_pfunc_constr func,
+   timetac' "mk_pfunc_recursor" $ mk_pfunc_recursor func,
+   timetac' "mk_mvqpf_instance" $ mk_mvqpf_instance func,
+   timetac' "mk_fixpoint" $ mk_fixpoint iter func d,
+   updateex_env $ λ env, pure $ env.add_namespace d.induct.name,
+   updateex_env $ λ env, pure $ env.add_namespace func'.induct.name,
+   let spec : inductive_type := func.induct,
+   add_meta_definition (d.induct.name <.> "_spec") [] `(inductive_type) `(dt),
+
+   mk_liftp_defn' func,
+   mk_liftp_eqns₀ func,
+   mk_liftp_eqns₁ func,
+   mk_liftr_defn' func,
+   mk_liftr_eqns₀ func,
+   mk_liftr_eqns₁ func,
+   pure (func',d)
+
+end tactic

--- a/src/data/qpf/compiler/shape.lean
+++ b/src/data/qpf/compiler/shape.lean
@@ -23,6 +23,7 @@ meta def datatype_shape.dead_params (d : datatype_shape) := internal_mvfunctor.d
 meta def datatype_shape.live_params (d : datatype_shape) := internal_mvfunctor.live_params d.to_internal_mvfunctor
 
 meta def mk_shape_decl (d : inductive_type) : tactic (expr × inductive_type) :=
+trace_scope $
 do v ← mk_local_def (fresh_univ (d.params.map expr.local_pp_name) `α) d.type,
    let c := @const tt d.name d.u_params,
    let c' := c.mk_app d.params,
@@ -35,9 +36,10 @@ do v ← mk_local_def (fresh_univ (d.params.map expr.local_pp_name) `α) d.type,
               ctors := d.ctors.map (replace_rec_occ d.name (d.name <.> "shape") c' v) })
 
 meta def mk_shape_functor' (d : inductive_type) : tactic (datatype_shape × internal_mvfunctor) :=
+trace_scope $
 do func' ← internalize_mvfunctor d,
    (v,func) ← mk_shape_decl d,
-   mk_inductive func,
+   mk_inductive d.name func,
    func ← internalize_mvfunctor func,
    mk_internal_functor_def func,
    mk_internal_functor_eqn func,
@@ -46,6 +48,7 @@ do func' ← internalize_mvfunctor d,
 -- meta def mk_struct (n : name) (ls : list name)
 
 meta def mk_fixpoint (fix : name) (func d : internal_mvfunctor) : tactic unit :=
+trace_scope $
 do let dead := func.dead_params,
    let shape := (@const tt (func.decl.to_name <.> "internal") func.induct.u_params).mk_app dead,
    df ← (mk_mapp fix [none,shape,none,none] >>= lambdas dead : tactic _),
@@ -66,6 +69,7 @@ meta def get_type_spec (n : name) : tactic inductive_type :=
 mk_const (n <.> "_spec") >>= eval_expr _
 
 meta def mk_datatype (iter : name) (d : inductive_decl) : tactic (datatype_shape × internal_mvfunctor) :=
+trace_scope $
 do dt ← inductive_type.of_decl d,
    (func', d) ← mk_shape_functor' dt,
    let func : internal_mvfunctor := { .. func' },
@@ -81,11 +85,11 @@ do dt ← inductive_type.of_decl d,
    add_meta_definition (d.induct.name <.> "_spec") [] `(inductive_type) `(dt),
 
    mk_liftp_defn' func,
-   mk_liftp_eqns₀ func,
-   mk_liftp_eqns₁ func,
+   -- mk_liftp_eqns₀ func,
+   -- mk_liftp_eqns₁ func,
    mk_liftr_defn' func,
-   mk_liftr_eqns₀ func,
-   mk_liftr_eqns₁ func,
+   -- mk_liftr_eqns₀ func,
+   -- mk_liftr_eqns₁ func,
    pure (func',d)
 
 end tactic

--- a/src/data/qpf/compiler/shape.lean
+++ b/src/data/qpf/compiler/shape.lean
@@ -43,12 +43,6 @@ do func' ← internalize_mvfunctor d,
    mk_internal_functor_eqn func,
    pure ({ hole := v .. func }, func')
 
-meta def decl_kind : declaration → string
-| (declaration.defn a a_1 a_2 a_3 a_4 a_5) := "defn"
-| (declaration.thm a a_1 a_2 a_3) := "thm"
-| (declaration.cnst a a_1 a_2 a_3) := "cnst"
-| (declaration.ax a a_1 a_2) := "ax"
-
 -- meta def mk_struct (n : name) (ls : list name)
 
 meta def mk_fixpoint (fix : name) (func d : internal_mvfunctor) : tactic unit :=
@@ -58,11 +52,11 @@ do let dead := func.dead_params,
    t ← infer_type df,
    let intl_n := func.decl.to_name.get_prefix <.> "internal",
    updateex_env $ λ env, pure $ env.add_namespace intl_n,
-   add_decl $ mk_definition intl_n func.induct.u_names t df,
+   emit_decl fix $ mk_definition intl_n func.induct.u_names t df,
    v ← mk_live_vec func.vec_lvl $ func.live_params.init,
    df ← lambdas d.params $ (@const tt intl_n func.induct.u_params).mk_app func.dead_params v,
    t  ← infer_type df,
-   add_decl $ mk_definition func.decl.to_name.get_prefix func.induct.u_names t df,
+   emit_decl fix $ mk_definition func.decl.to_name.get_prefix func.induct.u_names t df,
    pure ()
 
 meta def timetac' {α : Type*} (_ : string) (tac : thunk (tactic α)) : tactic α :=

--- a/src/data/typevec.lean
+++ b/src/data/typevec.lean
@@ -85,6 +85,9 @@ def drop (α : typevec.{u} (n+1)) : typevec n := λ i, α i.fs
 /-- take the last value of a `(n+1)-length` vector -/
 def last (α : typevec.{u} (n+1)) : Type* := α fin2.fz
 
+/-- typevec of length 0 -/
+def nil : typevec.{u} 0 := fin2.elim0
+
 instance last.inhabited (α : typevec (n+1)) [inhabited (α fin2.fz)] : inhabited (last α) :=
 ⟨ (default (α fin2.fz) : α fin2.fz) ⟩
 
@@ -205,7 +208,7 @@ lemma append_fun_comp' {α₀ α₁ α₂ : typevec n} {β₀ β₁ β₂ : Type
   (f₁ ::: g₁) ⊚ (f₀ ::: g₀) = f₁ ⊚ f₀ ::: g₁ ∘ g₀ :=
 eq_of_drop_last_eq rfl rfl
 
-lemma nil_fun_comp {α₀ : typevec 0} (f₀ : α₀ ⟹ fin2.elim0) : nil_fun ⊚ f₀ = f₀ :=
+lemma nil_fun_comp {α₀ : typevec 0} (f₀ : α₀ ⟹ nil) : nil_fun ⊚ f₀ = f₀ :=
 funext $ λ x, fin2.elim0 x
 
 theorem append_fun_comp_id {α : typevec n} {β₀ β₁ β₂ : Type*}
@@ -240,7 +243,7 @@ run_cmd do
 local prefix `♯`:0 := cast (by try { simp }; congr' 1; try { simp })
 
 /-- cases distinction for 0-length type vector -/
-protected def cases_nil {β : typevec 0 → Sort*} (f : β fin2.elim0) :
+protected def cases_nil {β : typevec 0 → Sort*} (f : β nil) :
   Π v, β v :=
 λ v, ♯ f
 
@@ -249,8 +252,8 @@ protected def cases_cons (n : ℕ) {β : typevec (n+1) → Sort*} (f : Π t (v :
   Π v, β v :=
 λ v : typevec (n+1), ♯ f v.last v.drop
 
-protected lemma cases_nil_append1 {β : typevec 0 → Sort*} (f : β fin2.elim0) :
-  typevec.cases_nil f fin2.elim0 = f := rfl
+protected lemma cases_nil_append1 {β : typevec 0 → Sort*} (f : β nil) :
+  typevec.cases_nil f nil = f := rfl
 
 protected lemma cases_cons_append1 (n : ℕ) {β : typevec (n+1) → Sort*}
       (f : Π t (v : typevec n), β (v ::: t))
@@ -258,7 +261,7 @@ protected lemma cases_cons_append1 (n : ℕ) {β : typevec (n+1) → Sort*}
   typevec.cases_cons n f (v ::: α) = f α v := rfl
 
 /-- cases distinction for an arrow in the category of 0-length type vectors -/
-def typevec_cases_nil₃ {β : Π v v' : typevec 0, v ⟹ v' → Sort*} (f : β fin2.elim0 fin2.elim0 nil_fun) :
+def typevec_cases_nil₃ {β : Π v v' : typevec 0, v ⟹ v' → Sort*} (f : β nil nil nil_fun) :
   Π v v' fs, β v v' fs :=
 λ v v' fs,
 begin
@@ -278,7 +281,7 @@ begin
 end
 
 /-- specialized cases distinction for an arrow in the category of 0-length type vectors -/
-def typevec_cases_nil₂ {β : fin2.elim0 ⟹ fin2.elim0 → Sort*}
+def typevec_cases_nil₂ {β : nil ⟹ nil → Sort*}
   (f : β nil_fun) :
   Π f, β f :=
 begin
@@ -296,7 +299,7 @@ begin
   apply F
 end
 
-lemma typevec_cases_nil₂_append_fun {β : fin2.elim0 ⟹ fin2.elim0 → Sort*}
+lemma typevec_cases_nil₂_append_fun {β : nil ⟹ nil → Sort*}
   (f : β nil_fun) :
   typevec_cases_nil₂ f nil_fun = f := rfl
 
@@ -322,12 +325,12 @@ open nat
 
 /-- `repeat n t` is a `n-length` type vector that contains `n` occurences of `t` -/
 def repeat : Π (n : ℕ) (t : Sort*), typevec n
-| 0 t := fin2.elim0
+| 0 t := nil
 | (nat.succ i) t := append1 (repeat i t) t
 
 /-- `prod α β` is the pointwise product of the components of `α` and `β` -/
 def prod : Π {n} (α β : typevec.{u} n), typevec n
-| 0 α β := fin2.elim0
+| 0 α β := nil
 | (n+1) α β := prod (drop α) (drop β) ::: (last α × last β)
 
 localized "infix ` ⊗ `:45 := typevec.prod" in mvfunctor

--- a/src/tactic/mk_has_to_format.lean
+++ b/src/tactic/mk_has_to_format.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2018 Simon Hudon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Simon Hudon
+-/
+import tactic.core
+
+namespace format
+
+open tactic expr
+
+meta def mk_to_string (t : expr) (fn of_string : name) (ls : list expr) (out : expr) (trusted : bool) : tactic expr :=
+do let n := t.get_app_fn.const_name,
+   d ← get_decl n,
+   let r : reducibility_hints := reducibility_hints.regular 1 tt,
+   env ← get_env,
+   ls ← local_context,
+   sig ← to_expr ``(%%t → %%out),
+   of_string ← mk_const of_string,
+   (_,df) ← solve_aux sig $ do
+     { match env.structure_fields n with
+       | (some fs) :=
+       do a ← intro1,
+          [(_,xs,_)] ← cases_core a,
+          let l := xs.length,
+          fn' ← mk_const fn,
+          out ← list.mzip_with₄ (λ x (fn : name) (y : expr) z,
+            do let fn := (fn.update_prefix name.anonymous).to_string,
+               to_expr ``(%%of_string (%%(reflect x) ++ %%(reflect fn) ++ " := ") ++ %%fn' %%y ++ %%of_string %%(reflect z)))
+            ("{ " :: list.repeat "  " (l-1)) fs xs (list.repeat ",\n" (l-1) ++ [" }"]),
+          to_expr (out.foldr (λ e acc, ``(%%e ++ %%acc)) ``(%%of_string %%(reflect "" : expr))) >>= exact,
+          pure ()
+       | none :=
+       do g ← main_goal,
+          a ← intro1,
+          xs ← cases_core a,
+          fn ← mk_const fn,
+          out ← xs.mmap $ λ ⟨c,xs,_⟩,
+            do { out ← xs.mmap $ λ x, to_expr ``(%%of_string " (" ++ %%fn %%x ++ %%of_string ")"),
+                 let c := (c.update_prefix name.anonymous).to_string,
+                 to_expr (out.foldr (λ e acc, ``(%%e ++ %%acc)) ``(%%of_string %%(reflect c : expr))) >>= exact },
+          pure () end },
+   df ← instantiate_mvars df >>= lambdas ls,
+   t ← infer_type df,
+   add_decl' $ declaration.defn (n ++ fn) d.univ_params t df r (trusted ∧ d.is_trusted)
+
+meta def mk_has_to_format : tactic unit :=
+do `(has_to_format %%t) ← target,
+   ls ← local_context,
+   e ← mk_to_string t `to_fmt `format.of_string ls `(format) ff,
+   refine ``( { to_format := %%(e.mk_app ls) } ),
+   pure ()
+
+meta def mk_has_repr : tactic unit :=
+do `(has_repr %%t) ← target,
+   ls ← local_context,
+   e ← mk_to_string t `repr `id ls `(string) tt,
+   refine ``( { repr := %%(e.mk_app ls) } ),
+   pure ()
+
+@[derive_handler]
+meta def has_repr_derive_handler : derive_handler :=
+instance_derive_handler ``has_repr mk_has_repr
+
+@[derive_handler]
+meta def has_to_format_derive_handler : derive_handler :=
+instance_derive_handler ``has_to_format mk_has_to_format
+
+end format


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->

The goal of this PR is to enable the specification of `inductive` and `coinductive` data types using syntax such as

```lean
data tree (a : Type) 
| tip : tree
| node : a -> tree -> tree -> tree

codata inf_tree (a b : Type)
| node : a -> (b -> inf_tree) -> inf_tree
```

and have the relevant recursors and corecursors generated appropriately. The current infrastructure does not support nesting but it is a planned extension.