### PR TITLE
[Merged by Bors] - feat(algebra/ordered_field): rewrite and cleanup

### DIFF
--- a/src/algebra/continued_fractions/computation/approximations.lean
+++ b/src/algebra/continued_fractions/computation/approximations.lean
@@ -77,12 +77,11 @@ begin
     ∧ int_fract_pair.of ifp_n.fr⁻¹ = ifp_succ_n, from
       succ_nth_stream_eq_some_iff.elim_left succ_nth_stream_eq,
   change 1 ≤ ⌊ifp_n.fr⁻¹⌋,
-  suffices : 1 ≤ ifp_n.fr⁻¹, by { rw_mod_cast [le_floor], assumption },
-  suffices : 1 * ifp_n.fr ≤ 1, by
-  { rw inv_eq_one_div,
-    have : 0 < ifp_n.fr, from
+  suffices : 1 ≤ ifp_n.fr⁻¹, { rw_mod_cast [le_floor], assumption },
+  suffices : ifp_n.fr ≤ 1,
+  { have h : 0 < ifp_n.fr :=
       lt_of_le_of_ne (nth_stream_fr_nonneg nth_stream_eq) stream_nth_fr_ne_zero.symm,
-    solve_by_elim [le_div_of_mul_le], },
+    apply one_le_inv h this },
   simp [(le_of_lt (nth_stream_fr_lt_one nth_stream_eq))]
 end
 

--- a/src/algebra/ordered_field.lean
+++ b/src/algebra/ordered_field.lean
@@ -1,20 +1,37 @@
 /-
 Copyright (c) 2014 Robert Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Robert Lewis, Leonardo de Moura, Mario Carneiro
+Authors: Robert Lewis, Leonardo de Moura, Mario Carneiro, Floris van Doorn
 -/
 import algebra.ordered_ring
 import algebra.field
+/-!
+  ### Linear ordered fields
+  A linear ordered field is a field equipped with a linear order such that
+  * addition respects the order: `a ≤ b → c + a ≤ c + b`;
+  * multiplication of positives is positive: `0 < a → 0 < b → 0 < a * b`;
+  * `0 < 1`.
+
+  ### Main Definitions
+  * `linear_ordered_field`: the class of linear ordered fields.
+  * `discrete_linear_ordered_field`: the class of linear ordered fields where the inequality is
+    decidable.
+-/
 
 set_option default_priority 100 -- see Note [default priority]
 set_option old_structure_cmd true
 
 variable {α : Type*}
 
+/-- A linear ordered field is a field with a linear order respecting the operations. -/
 @[protect_proj] class linear_ordered_field (α : Type*) extends linear_ordered_comm_ring α, field α
 
 section linear_ordered_field
 variables [linear_ordered_field α] {a b c d e : α}
+
+/-!
+### Lemmas about pos, nonneg, nonpos, neg
+-/
 
 @[simp] lemma inv_pos : 0 < a⁻¹ ↔ 0 < a :=
 suffices ∀ a : α, 0 < a → 0 < a⁻¹,
@@ -66,116 +83,163 @@ mul_nonpos_of_nonpos_of_nonneg ha (inv_nonneg.2 hb)
 lemma div_nonpos_of_nonneg_of_nonpos (ha : 0 ≤ a) (hb : b ≤ 0) : a / b ≤ 0 :=
 mul_nonpos_of_nonneg_of_nonpos ha (inv_nonpos.2 hb)
 
-lemma one_le_div_of_le (a : α) {b : α} (hb : 0 < b) (h : b ≤ a) : 1 ≤ a / b :=
-have hb'   : b ≠ 0,     from ne_of_gt hb,
-have hbinv : 0 < 1 / b, from one_div_pos.2 hb,
-calc
-   1  = b * (1 / b)  : eq.symm (mul_one_div_cancel hb')
-   ... ≤ a * (1 / b) : mul_le_mul_of_nonneg_right h (le_of_lt hbinv)
-   ... = a / b       : eq.symm $ div_eq_mul_one_div a b
+/-!
+### Relating one division with another term.
+-/
 
-lemma le_of_one_le_div (a : α) {b : α} (hb : 0 < b) (h : 1 ≤ a / b) : b ≤ a :=
-have hb'   : b ≠ 0,     from (ne_of_lt hb).symm,
-calc
-   b   ≤ b * (a / b) : le_mul_of_one_le_right (le_of_lt hb) h
-   ... = a           : by rw [mul_div_cancel' _ hb']
-
-lemma one_lt_div_of_lt (a : α) {b : α} (hb : 0 < b) (h : b < a) : 1 < a / b :=
-have hb' : b ≠ 0, from (ne_of_lt hb).symm,
-have hbinv : 0 < 1 / b, from  one_div_pos.2 hb, calc
-     1 = b * (1 / b) : eq.symm (mul_one_div_cancel hb')
-   ... < a * (1 / b) : mul_lt_mul_of_pos_right h hbinv
-   ... = a / b       : eq.symm $ div_eq_mul_one_div a b
-
-lemma lt_of_one_lt_div (a : α) {b : α} (hb : 0 < b) (h : 1 < a / b) : b < a :=
-have hb' : b ≠ 0, from (ne_of_lt hb).symm,
-calc
-   b   < b * (a / b) : lt_mul_of_one_lt_right hb h
-   ... = a           : by rw [mul_div_cancel' _ hb']
-
--- the following lemmas amount to four iffs, for <, ≤, ≥, >.
-
-lemma mul_le_of_le_div (hc : 0 < c) (h : a ≤ b / c) : a * c ≤ b :=
-div_mul_cancel b (ne.symm (ne_of_lt hc)) ▸ mul_le_mul_of_nonneg_right h (le_of_lt hc)
-
-lemma le_div_of_mul_le (hc : 0 < c) (h : a * c ≤ b) : a ≤ b / c :=
-calc
-    a   = a * c * (1 / c) : mul_mul_div a (ne.symm (ne_of_lt hc))
+lemma le_div_iff (hc : 0 < c) : a ≤ b / c ↔ a * c ≤ b :=
+⟨λ h, div_mul_cancel b (ne_of_lt hc).symm ▸ mul_le_mul_of_nonneg_right h (le_of_lt hc),
+  λ h, calc
+    a   = a * c * (1 / c) : mul_mul_div a (ne_of_lt hc).symm
     ... ≤ b * (1 / c)     : mul_le_mul_of_nonneg_right h (le_of_lt (one_div_pos.2 hc))
-    ... = b / c           : eq.symm $ div_eq_mul_one_div b c
+    ... = b / c           : (div_eq_mul_one_div b c).symm⟩
 
-lemma mul_lt_of_lt_div (hc : 0 < c) (h : a < b / c) : a * c < b :=
-div_mul_cancel b (ne.symm (ne_of_lt hc)) ▸ mul_lt_mul_of_pos_right h hc
+lemma le_div_iff' (hc : 0 < c) : a ≤ b / c ↔ c * a ≤ b :=
+by rw [mul_comm, le_div_iff hc]
 
-lemma lt_div_of_mul_lt (hc : 0 < c) (h : a * c < b) : a < b / c :=
-calc
-   a   = a * c * (1 / c) : mul_mul_div a (ne.symm (ne_of_lt hc))
-   ... < b * (1 / c)     : mul_lt_mul_of_pos_right h (one_div_pos.2 hc)
-   ... = b / c           : eq.symm $ div_eq_mul_one_div b c
+lemma div_le_iff (hb : 0 < b) : a / b ≤ c ↔ a ≤ c * b :=
+⟨λ h, calc
+  a = a / b * b : by rw (div_mul_cancel _ (ne_of_lt hb).symm)
+  ... ≤ c * b     : mul_le_mul_of_nonneg_right h (le_of_lt hb),
+  λ h, calc
+  a / b = a * (1 / b)     : div_eq_mul_one_div a b
+  ... ≤ (c * b) * (1 / b) : mul_le_mul_of_nonneg_right h $ le_of_lt $ one_div_pos.2 hb
+  ... = (c * b) / b       : (div_eq_mul_one_div (c * b) b).symm
+  ... = c                 : by refine (div_eq_iff (ne_of_gt hb)).mpr rfl⟩
 
-lemma mul_le_of_neg_of_div_le (hc : c < 0) (h : b / c ≤ a) : a * c ≤ b :=
-div_mul_cancel b (ne_of_lt hc) ▸ mul_le_mul_of_nonpos_right h (le_of_lt hc)
+lemma div_le_iff' (hb : 0 < b) : a / b ≤ c ↔ a ≤ b * c :=
+by rw [mul_comm, div_le_iff hb]
 
-lemma div_le_of_neg_of_mul_le (hc : c < 0) (h : a * c ≤ b) : b / c ≤ a :=
-calc
-   a   = a * c * (1 / c) : mul_mul_div a (ne_of_lt hc)
-    ... ≥ b * (1 / c)     : mul_le_mul_of_nonpos_right h (le_of_lt (one_div_neg.2 hc))
-    ... = b / c           : eq.symm $ div_eq_mul_one_div b c
+lemma lt_div_iff (hc : 0 < c) : a < b / c ↔ a * c < b :=
+lt_iff_lt_of_le_iff_le $ div_le_iff hc
 
-lemma mul_lt_of_neg_of_div_lt (hc : c < 0) (h : b / c < a) : a * c < b :=
-div_mul_cancel b (ne_of_lt hc) ▸ mul_lt_mul_of_neg_right h hc
+lemma lt_div_iff' (hc : 0 < c) : a < b / c ↔ c * a < b :=
+by rw [mul_comm, lt_div_iff hc]
 
-lemma div_lt_of_pos_of_lt_mul (hc : 0 < c) (h : b < a * c) : b / c < a :=
-calc
-   a   = a * c * (1 / c) : mul_mul_div a (ne_of_gt hc)
-   ... > b * (1 / c)     : mul_lt_mul_of_pos_right h (one_div_pos.2 hc)
-   ... = b / c           : eq.symm $ div_eq_mul_one_div b c
+lemma div_lt_iff (hc : 0 < c) : b / c < a ↔ b < a * c :=
+lt_iff_lt_of_le_iff_le (le_div_iff hc)
 
-lemma div_lt_of_neg_of_mul_lt (hc : c < 0) (h : a * c < b) : b / c < a :=
-calc
-   a   = a * c * (1 / c) : mul_mul_div a (ne_of_lt hc)
-   ... > b * (1 / c)     : mul_lt_mul_of_neg_right h (one_div_neg.2 hc)
-   ... = b / c           : eq.symm $ div_eq_mul_one_div b c
+lemma div_lt_iff' (hc : 0 < c) : b / c < a ↔ b < c * a :=
+by rw [mul_comm, div_lt_iff hc]
 
-lemma div_le_of_le_mul (hb : 0 < b) (h : a ≤ b * c) : a / b ≤ c :=
-calc
-   a / b = a * (1 / b)       : div_eq_mul_one_div a b
-     ... ≤ (b * c) * (1 / b) : mul_le_mul_of_nonneg_right h (le_of_lt (one_div_pos.2 hb))
-     ... = (b * c) / b       : eq.symm $ div_eq_mul_one_div (b * c) b
-     ... = c                 : by rw [mul_div_cancel_left _ (ne.symm (ne_of_lt hb))]
+lemma div_le_iff_of_neg (hc : c < 0) : b / c ≤ a ↔ a * c ≤ b :=
+⟨λ h, div_mul_cancel b (ne_of_lt hc) ▸ mul_le_mul_of_nonpos_right h (le_of_lt hc),
+  λ h, calc
+    a = a * c * (1 / c) : mul_mul_div a (ne_of_lt hc)
+  ... ≥ b * (1 / c)     : mul_le_mul_of_nonpos_right h (le_of_lt (one_div_neg.2 hc))
+  ... = b / c           : (div_eq_mul_one_div b c).symm⟩
 
-lemma le_mul_of_div_le (hc : 0 < c) (h : a / c ≤ b) : a ≤ b * c :=
-calc
-   a = a / c * c : by rw (div_mul_cancel _ (ne.symm (ne_of_lt hc)))
- ... ≤ b * c     : mul_le_mul_of_nonneg_right h (le_of_lt hc)
+lemma div_le_iff_of_neg' (hc : c < 0) : b / c ≤ a ↔ c * a ≤ b :=
+by rw [mul_comm, div_le_iff_of_neg hc]
 
-  -- following these in the isabelle file, there are 8 biconditionals for the above with - signs
-  -- skipping for now
+lemma le_div_iff_of_neg (hc : c < 0) : a ≤ b / c ↔ b ≤ a * c :=
+by rw [← neg_neg c, mul_neg_eq_neg_mul_symm, div_neg, le_neg,
+    div_le_iff (neg_pos.2 hc), neg_mul_eq_neg_mul_symm]
 
-lemma mul_sub_mul_div_mul_neg_iff (hc : c ≠ 0) (hd : d ≠ 0) :
-  (a * d - b * c) / (c * d) < 0 ↔ a / c < b / d :=
-by rw [mul_comm b c, ← div_sub_div _ _ hc hd, sub_lt_zero]
+lemma le_div_iff_of_neg' (hc : c < 0) : a ≤ b / c ↔ b ≤ c * a :=
+by rw [mul_comm, le_div_iff_of_neg hc]
 
-alias mul_sub_mul_div_mul_neg_iff ↔ div_lt_div_of_mul_sub_mul_div_neg  mul_sub_mul_div_mul_neg
+lemma div_lt_iff_of_neg (hc : c < 0) : b / c < a ↔ a * c < b :=
+lt_iff_lt_of_le_iff_le $ le_div_iff_of_neg hc
 
-lemma mul_sub_mul_div_mul_nonpos_iff (hc : c ≠ 0) (hd : d ≠ 0) :
-      (a * d - b * c) / (c * d) ≤ 0 ↔ a / c ≤ b / d :=
-by rw [mul_comm b c, ← div_sub_div _ _ hc hd, sub_nonpos]
+lemma div_lt_iff_of_neg' (hc : c < 0) : b / c < a ↔ c * a < b :=
+by rw [mul_comm, div_lt_iff_of_neg hc]
 
-alias mul_sub_mul_div_mul_nonpos_iff ↔
-  div_le_div_of_mul_sub_mul_div_nonpos mul_sub_mul_div_mul_nonpos
+lemma lt_div_iff_of_neg (hc : c < 0) : a < b / c ↔ b < a * c :=
+lt_iff_lt_of_le_iff_le $ div_le_iff_of_neg hc
 
-lemma div_lt_div_of_pos_of_lt (hc : 0 < c) (h : a < b) : a / c < b / c :=
+lemma lt_div_iff_of_neg' (hc : c < 0) : a < b / c ↔ b < c * a :=
+by rw [mul_comm, lt_div_iff_of_neg hc]
+
+/-- One direction of `div_le_iff` where `b` is allowed to be `0` (but `c` must be nonnegative) -/
+lemma div_le_iff_of_nonneg_of_le (hb : 0 ≤ b) (hc : 0 ≤ c) (h : a ≤ c * b) : a / b ≤ c :=
+by { rcases eq_or_lt_of_le hb with rfl|hb', simp [hc], rwa [div_le_iff hb'] }
+
+/-!
+### Bi-implications of inequalities using inversions
+-/
+
+lemma inv_le_inv_of_le (ha : 0 < a) (h : a ≤ b) : b⁻¹ ≤ a⁻¹ :=
+by rwa [← one_div a, le_div_iff' ha, ← div_eq_mul_inv, div_le_iff (lt_of_lt_of_le ha h), one_mul]
+
+/-- See `inv_le_inv_of_le` for the implication from right-to-left with one fewer assumption. -/
+lemma inv_le_inv (ha : 0 < a) (hb : 0 < b) : a⁻¹ ≤ b⁻¹ ↔ b ≤ a :=
+by rw [← one_div, div_le_iff ha, ← div_eq_inv_mul, le_div_iff hb, one_mul]
+
+lemma inv_le (ha : 0 < a) (hb : 0 < b) : a⁻¹ ≤ b ↔ b⁻¹ ≤ a :=
+by rw [← inv_le_inv hb (inv_pos.2 ha), inv_inv']
+
+lemma le_inv (ha : 0 < a) (hb : 0 < b) : a ≤ b⁻¹ ↔ b ≤ a⁻¹ :=
+by rw [← inv_le_inv (inv_pos.2 hb) ha, inv_inv']
+
+lemma inv_lt_inv (ha : 0 < a) (hb : 0 < b) : a⁻¹ < b⁻¹ ↔ b < a :=
+lt_iff_lt_of_le_iff_le (inv_le_inv hb ha)
+
+lemma inv_lt (ha : 0 < a) (hb : 0 < b) : a⁻¹ < b ↔ b⁻¹ < a :=
+lt_iff_lt_of_le_iff_le (le_inv hb ha)
+
+lemma lt_inv (ha : 0 < a) (hb : 0 < b) : a < b⁻¹ ↔ b < a⁻¹ :=
+lt_iff_lt_of_le_iff_le (inv_le hb ha)
+
+lemma inv_le_inv_of_neg (ha : a < 0) (hb : b < 0) : a⁻¹ ≤ b⁻¹ ↔ b ≤ a :=
+by rw [← one_div, div_le_iff_of_neg ha, ← div_eq_inv_mul, div_le_iff_of_neg hb, one_mul]
+
+lemma inv_le_of_neg (ha : a < 0) (hb : b < 0) : a⁻¹ ≤ b ↔ b⁻¹ ≤ a :=
+by rw [← inv_le_inv_of_neg hb (inv_lt_zero.2 ha), inv_inv']
+
+lemma le_inv_of_neg (ha : a < 0) (hb : b < 0) : a ≤ b⁻¹ ↔ b ≤ a⁻¹ :=
+by rw [← inv_le_inv_of_neg (inv_lt_zero.2 hb) ha, inv_inv']
+
+lemma inv_lt_inv_of_neg (ha : a < 0) (hb : b < 0) : a⁻¹ < b⁻¹ ↔ b < a :=
+lt_iff_lt_of_le_iff_le (inv_le_inv_of_neg hb ha)
+
+lemma inv_lt_of_neg (ha : a < 0) (hb : b < 0) : a⁻¹ < b ↔ b⁻¹ < a :=
+lt_iff_lt_of_le_iff_le (le_inv_of_neg hb ha)
+
+lemma lt_inv_of_neg (ha : a < 0) (hb : b < 0) : a < b⁻¹ ↔ b < a⁻¹ :=
+lt_iff_lt_of_le_iff_le (inv_le_of_neg hb ha)
+
+lemma inv_lt_one (ha : 1 < a) : a⁻¹ < 1 :=
+by rwa [inv_lt (lt_trans (@zero_lt_one α _) ha) zero_lt_one, inv_one]
+
+lemma one_lt_inv (h₁ : 0 < a) (h₂ : a < 1) : 1 < a⁻¹ :=
+by rwa [lt_inv (@zero_lt_one α _) h₁, inv_one]
+
+lemma inv_le_one (ha : 1 ≤ a) : a⁻¹ ≤ 1 :=
+by rwa [inv_le (lt_of_lt_of_le (@zero_lt_one α _) ha) zero_lt_one, inv_one]
+
+lemma one_le_inv (h₁ : 0 < a) (h₂ : a ≤ 1) : 1 ≤ a⁻¹ :=
+by rwa [le_inv (@zero_lt_one α _) h₁, inv_one]
+
+/-!
+### Relating two divisions.
+-/
+
+lemma div_le_div_of_le (hc : 0 ≤ c) (h : a ≤ b) : a / c ≤ b / c :=
 begin
-  intros,
   rw [div_eq_mul_one_div a c, div_eq_mul_one_div b c],
-  exact mul_lt_mul_of_pos_right h (one_div_pos.2 hc)
+  exact mul_le_mul_of_nonneg_right h (one_div_nonneg.2 hc)
 end
 
-lemma div_le_div_of_pos_of_le (hc : 0 < c) (h : a ≤ b) : a / c ≤ b / c :=
+lemma div_le_div_of_le_left (ha : 0 ≤ a) (hc : 0 < c) (h : c ≤ b) : a / b ≤ a / c :=
+begin
+  rw [div_eq_mul_inv, div_eq_mul_inv],
+  exact mul_le_mul_of_nonneg_left ((inv_le_inv (lt_of_lt_of_le hc h) hc).mpr h) ha
+end
+
+lemma div_le_div_of_le_of_nonneg (hab : a ≤ b) (hc : 0 ≤ c) : a / c ≤ b / c :=
+mul_le_mul_of_nonneg_right hab (inv_nonneg.2 hc)
+
+lemma div_le_div_of_nonpos_of_le (hc : c ≤ 0) (h : b ≤ a) : a / c ≤ b / c :=
 begin
   rw [div_eq_mul_one_div a c, div_eq_mul_one_div b c],
-  exact mul_le_mul_of_nonneg_right h (le_of_lt (one_div_pos.2 hc))
+  exact mul_le_mul_of_nonpos_right h (one_div_nonpos.2 hc)
+end
+
+lemma div_lt_div_of_lt (hc : 0 < c) (h : a < b) : a / c < b / c :=
+begin
+  rw [div_eq_mul_one_div a c, div_eq_mul_one_div b c],
+  exact mul_lt_mul_of_pos_right h (one_div_pos.2 hc)
 end
 
 lemma div_lt_div_of_neg_of_lt (hc : c < 0) (h : b < a) : a / c < b / c :=
@@ -184,252 +248,17 @@ begin
   exact mul_lt_mul_of_neg_right h (one_div_neg.2 hc)
 end
 
-lemma div_le_div_of_neg_of_le (hc : c < 0) (h : b ≤ a) : a / c ≤ b / c :=
-begin
-  rw [div_eq_mul_one_div a c, div_eq_mul_one_div b c],
-  exact mul_le_mul_of_nonpos_right h (le_of_lt (one_div_neg.2 hc))
-end
-
-lemma add_halves (a : α) : a / 2 + a / 2 = a :=
-by { rw [div_add_div_same, ← two_mul, mul_div_cancel_left], exact two_ne_zero }
-
-lemma sub_self_div_two (a : α) : a - a / 2 = a / 2 :=
-suffices a / 2 + a / 2 - a / 2 = a / 2, by rwa add_halves at this,
-by rw [add_sub_cancel]
-
-lemma add_midpoint {a b : α} (h : a < b) : a + (b - a) / 2 < b :=
-begin
-  rw [← div_sub_div_same, sub_eq_add_neg, add_comm (b/2), ← add_assoc, ← sub_eq_add_neg],
-  apply add_lt_of_lt_sub_right,
-  rw [sub_self_div_two, sub_self_div_two],
-  apply div_lt_div_of_pos_of_lt (@two_pos α _) h
-end
-
-lemma div_two_sub_self (a : α) : a / 2 - a = - (a / 2) :=
-suffices a / 2 - (a / 2 + a / 2) = - (a / 2), by rwa add_halves at this,
-by rw [sub_add_eq_sub_sub, sub_self, zero_sub]
-
-lemma add_self_div_two (a : α) : (a + a) / 2 = a :=
-eq.symm
-  (iff.mpr (eq_div_iff_mul_eq (ne_of_gt (add_pos (@zero_lt_one α _) zero_lt_one)))
-           (begin unfold bit0, rw [left_distrib, mul_one] end))
-
-lemma mul_le_mul_of_mul_div_le {a b c d : α} (h : a * (b / c) ≤ d) (hc : 0 < c) : b * a ≤ d * c :=
-begin
-  rw [← mul_div_assoc] at h, rw [mul_comm b],
-  apply le_mul_of_div_le hc h
-end
-
-lemma div_two_lt_of_pos {a : α} (h : 0 < a) : a / 2 < a :=
-have ha : a / 2 > 0, from div_pos h two_pos,
-calc
-      a / 2 < a / 2 + a / 2 : lt_add_of_pos_left _ ha
-        ... = a             : add_halves a
-
-lemma div_mul_le_div_mul_of_div_le_div_nonneg {a b c d e : α} (h : a / b ≤ c / d) (he : 0 ≤ e) :
-  a / (b * e) ≤ c / (d * e) :=
-begin
-  rw [div_mul_eq_div_mul_one_div, div_mul_eq_div_mul_one_div],
-  exact mul_le_mul_of_nonneg_right h (one_div_nonneg.2 he)
-end
-
-lemma exists_add_lt_and_pos_of_lt {a b : α} (h : b < a) : ∃ c : α, b + c < a ∧ 0 < c :=
-begin
-  apply exists.intro ((a - b) / (1 + 1)),
-  split,
-  {have h2 : a + a > (b + b) + (a - b),
-    calc
-      a + a > b + a             : add_lt_add_right h _
-        ... = b + a + b - b     : by rw add_sub_cancel
-        ... = b + b + a - b     : by simp [add_comm, add_left_comm]
-        ... = (b + b) + (a - b) : by rw add_sub,
-   have h3 : (a + a) / 2 > ((b + b) + (a - b)) / 2,
-     exact div_lt_div_of_pos_of_lt two_pos h2,
-   rw [one_add_one_eq_two, sub_eq_add_neg],
-   rw [add_self_div_two, ← div_add_div_same, add_self_div_two, sub_eq_add_neg] at h3,
-   exact h3},
-  exact div_pos (sub_pos_of_lt h) two_pos
-end
-
-lemma le_of_forall_sub_le {a b : α} (h : ∀ ε > 0, b - ε ≤ a) : b ≤ a :=
-begin
-  contrapose! h,
-  simpa only [and_comm ((0:α) < _), lt_sub_iff_add_lt, gt_iff_lt]
-    using exists_add_lt_and_pos_of_lt h,
-end
-
-lemma one_div_lt_one_div_of_lt {a b : α} (ha : 0 < a) (h : a < b) : 1 / b < 1 / a :=
-begin
-  apply lt_div_of_mul_lt ha,
-  rw [mul_comm, ← div_eq_mul_one_div],
-  apply div_lt_of_pos_of_lt_mul (lt_trans ha h),
-  rwa [one_mul]
-end
-
-lemma one_div_le_one_div_of_le {a b : α} (ha : 0 < a) (h : a ≤ b) : 1 / b ≤ 1 / a :=
-(lt_or_eq_of_le h).elim
-  (λ h, le_of_lt $ one_div_lt_one_div_of_lt ha h)
-  (λ h, by rw [h])
-
-lemma one_div_lt_one_div_of_neg_of_lt {a b : α} (hb : b < 0) (h : a < b) : 1 / b < 1 / a :=
-begin
-  apply div_lt_of_neg_of_mul_lt hb,
-  rw [mul_comm, ← div_eq_mul_one_div],
-  apply div_lt_of_neg_of_mul_lt (lt_trans h hb),
-  rwa [one_mul]
-end
-
-lemma one_div_le_one_div_of_neg_of_le {a b : α} (hb : b < 0) (h : a ≤ b) : 1 / b ≤ 1 / a :=
-(lt_or_eq_of_le h).elim
-  (λ h, le_of_lt $ one_div_lt_one_div_of_neg_of_lt hb h)
-  (λ h, by rw [h])
-
-lemma le_of_one_div_le_one_div {a b : α} (h : 0 < a) (hl : 1 / a ≤ 1 / b) : b ≤ a :=
-le_of_not_gt $ λ hn, not_lt_of_ge hl $ one_div_lt_one_div_of_lt h hn
-
-lemma le_of_neg_of_one_div_le_one_div {a b : α} (h : b < 0) (hl : 1 / a ≤ 1 / b) : b ≤ a :=
-le_of_not_gt $ λ hn, not_lt_of_ge hl $ one_div_lt_one_div_of_neg_of_lt h hn
-
-lemma lt_of_one_div_lt_one_div {a b : α} (h : 0 < a) (hl : 1 / a < 1 / b) : b < a :=
-lt_of_not_ge $ λ hn, not_le_of_gt hl $ one_div_le_one_div_of_le h hn
-
-lemma lt_of_neg_of_one_div_lt_one_div {a b : α} (h : b < 0) (hl : 1 / a < 1 / b) : b < a :=
-lt_of_not_ge $ λ hn, not_le_of_gt hl $ one_div_le_one_div_of_neg_of_le h hn
-
-lemma one_div_le_of_pos_of_one_div_le {a b : α} (ha : 0 < a) (h : 1 / a ≤ b) : 1 / b ≤ a :=
-begin
-  rw [← one_div_one_div a],
-  apply one_div_le_one_div_of_le _ h,
-  apply one_div_pos.2 ha
-end
-
-lemma one_div_le_of_neg_of_one_div_le {a b : α} (hb : b < 0) (h : 1 / a ≤ b) : 1 / b ≤ a :=
-le_of_not_gt $ λ hl, begin
-  have : a < 0, from lt_trans hl (one_div_neg.2 hb),
-  rw ← one_div_one_div a at hl,
-  exact not_lt_of_ge h (lt_of_neg_of_one_div_lt_one_div hb hl)
-end
-
-lemma one_lt_one_div {a : α} (h1 : 0 < a) (h2 : a < 1) : 1 < 1 / a :=
-suffices 1 / 1 < 1 / a, by rwa one_div_one at this,
-one_div_lt_one_div_of_lt h1 h2
-
-lemma one_le_one_div {a : α} (h1 : 0 < a) (h2 : a ≤ 1) : 1 ≤ 1 / a :=
-suffices 1 / 1 ≤ 1 / a, by rwa one_div_one at this,
-one_div_le_one_div_of_le h1 h2
-
-lemma one_div_lt_neg_one {a : α} (h1 : a < 0) (h2 : -1 < a) : 1 / a < -1 :=
-suffices 1 / a < 1 / -1, by rwa one_div_neg_one_eq_neg_one at this,
-one_div_lt_one_div_of_neg_of_lt h1 h2
-
-lemma one_div_le_neg_one {a : α} (h1 : a < 0) (h2 : -1 ≤ a) : 1 / a ≤ -1 :=
-suffices 1 / a ≤ 1 / -1, by rwa one_div_neg_one_eq_neg_one at this,
-one_div_le_one_div_of_neg_of_le h1 h2
-
-lemma div_lt_div_of_pos_of_lt_of_pos (hb : 0 < b) (h : b < a) (hc : 0 < c) : c / a < c / b :=
-begin
-  apply lt_of_sub_neg,
-  rw [div_eq_mul_one_div, div_eq_mul_one_div c b, ← mul_sub_left_distrib],
-  apply mul_neg_of_pos_of_neg,
-  exact hc,
-  apply sub_neg_of_lt,
-  apply one_div_lt_one_div_of_lt; assumption,
-end
-
-lemma one_le_div_iff_le (hb : 0 < b) : 1 ≤ a / b ↔ b ≤ a :=
-⟨le_of_one_le_div a hb, one_le_div_of_le a hb⟩
-
-lemma one_lt_div_iff_lt (hb : 0 < b) : 1 < a / b ↔ b < a :=
-⟨lt_of_one_lt_div a hb, one_lt_div_of_lt a hb⟩
-
-lemma div_le_one_iff_le (hb : 0 < b) : a / b ≤ 1 ↔ a ≤ b :=
-le_iff_le_iff_lt_iff_lt.2 (one_lt_div_iff_lt hb)
-
-lemma div_lt_one_iff_lt (hb : 0 < b) : a / b < 1 ↔ a < b :=
-lt_iff_lt_of_le_iff_le (one_le_div_iff_le hb)
-
-lemma le_div_iff (hc : 0 < c) : a ≤ b / c ↔ a * c ≤ b :=
-⟨mul_le_of_le_div hc, le_div_of_mul_le hc⟩
-
-lemma le_div_iff' (hc : 0 < c) : a ≤ b / c ↔ c * a ≤ b :=
-by rw [mul_comm, le_div_iff hc]
-
-lemma div_le_iff (hb : 0 < b) : a / b ≤ c ↔ a ≤ c * b :=
-⟨le_mul_of_div_le hb, by rw [mul_comm]; exact div_le_of_le_mul hb⟩
-
-lemma div_le_iff' (hb : 0 < b) : a / b ≤ c ↔ a ≤ b * c :=
-by rw [mul_comm, div_le_iff hb]
-
-lemma lt_div_iff (hc : 0 < c) : a < b / c ↔ a * c < b :=
-⟨mul_lt_of_lt_div hc, lt_div_of_mul_lt hc⟩
-
-lemma lt_div_iff' (hc : 0 < c) : a < b / c ↔ c * a < b :=
-by rw [mul_comm, lt_div_iff hc]
-
-lemma div_le_iff_of_neg (hc : c < 0) : b / c ≤ a ↔ a * c ≤ b :=
-⟨mul_le_of_neg_of_div_le hc, div_le_of_neg_of_mul_le hc⟩
-
-lemma le_div_iff_of_neg (hc : c < 0) : a ≤ b / c ↔ b ≤ a * c :=
-by rw [← neg_neg c, mul_neg_eq_neg_mul_symm, div_neg, le_neg,
-    div_le_iff (neg_pos.2 hc), neg_mul_eq_neg_mul_symm]
-
-lemma div_lt_iff (hc : 0 < c) : b / c < a ↔ b < a * c :=
-lt_iff_lt_of_le_iff_le (le_div_iff hc)
-
-lemma div_lt_iff' (hc : 0 < c) : b / c < a ↔ b < c * a :=
-by rw [mul_comm, div_lt_iff hc]
-
-lemma div_lt_iff_of_neg (hc : c < 0) : b / c < a ↔ a * c < b :=
-⟨mul_lt_of_neg_of_div_lt hc, div_lt_of_neg_of_mul_lt hc⟩
-
-lemma lt_div_iff_of_neg (hc : c < 0) : a < b / c ↔ b < a * c :=
-by rw [← neg_neg c, div_neg, lt_neg, div_lt_iff (neg_pos.2 hc), ← neg_mul_eq_neg_mul,
-  ← neg_mul_eq_mul_neg _ (-c)]
-
-lemma inv_le_inv (ha : 0 < a) (hb : 0 < b) : a⁻¹ ≤ b⁻¹ ↔ b ≤ a :=
-by rw [inv_eq_one_div, div_le_iff ha,
-       ← div_eq_inv_mul, one_le_div_iff_le hb]
-
-lemma inv_le (ha : 0 < a) (hb : 0 < b) : a⁻¹ ≤ b ↔ b⁻¹ ≤ a :=
-by rw [← inv_le_inv hb (inv_pos.2 ha), inv_inv']
-
-lemma le_inv (ha : 0 < a) (hb : 0 < b) : a ≤ b⁻¹ ↔ b ≤ a⁻¹ :=
-by rw [← inv_le_inv (inv_pos.2 hb) ha, inv_inv']
-
-lemma one_div_le_one_div (ha : 0 < a) (hb : 0 < b) : 1 / a ≤ 1 / b ↔ b ≤ a :=
-by simpa [one_div] using inv_le_inv ha hb
-
-lemma inv_lt_inv (ha : 0 < a) (hb : 0 < b) : a⁻¹ < b⁻¹ ↔ b < a :=
-lt_iff_lt_of_le_iff_le (inv_le_inv hb ha)
-
-lemma inv_lt (ha : 0 < a) (hb : 0 < b) : a⁻¹ < b ↔ b⁻¹ < a :=
-lt_iff_lt_of_le_iff_le (le_inv hb ha)
-
-lemma one_div_lt (ha : 0 < a) (hb : 0 < b) : 1 / a < b ↔ 1 / b < a :=
-(one_div a).symm ▸ (one_div b).symm ▸ inv_lt ha hb
-
-lemma one_div_le (ha : 0 < a) (hb : 0 < b) : 1 / a ≤ b ↔ 1 / b ≤ a :=
-by simpa using inv_le ha hb
-
-lemma lt_inv (ha : 0 < a) (hb : 0 < b) : a < b⁻¹ ↔ b < a⁻¹ :=
-lt_iff_lt_of_le_iff_le (inv_le hb ha)
-
-lemma one_div_lt_one_div (ha : 0 < a) (hb : 0 < b) : 1 / a < 1 / b ↔ b < a :=
-lt_iff_lt_of_le_iff_le (one_div_le_one_div hb ha)
-
-lemma div_lt_div_right (hc : 0 < c) : a / c < b / c ↔ a < b :=
-⟨lt_imp_lt_of_le_imp_le (λ h, div_le_div_of_pos_of_le hc h),
- λ h, div_lt_div_of_pos_of_lt hc h⟩
-
 lemma div_le_div_right (hc : 0 < c) : a / c ≤ b / c ↔ a ≤ b :=
-le_iff_le_iff_lt_iff_lt.2 (div_lt_div_right hc)
-
-lemma div_lt_div_right_of_neg (hc : c < 0) : a / c < b / c ↔ b < a :=
-⟨lt_imp_lt_of_le_imp_le (λ h, div_le_div_of_neg_of_le hc h),
- λ h, div_lt_div_of_neg_of_lt hc h⟩
+⟨le_imp_le_of_lt_imp_lt $ div_lt_div_of_lt hc, div_le_div_of_le $ le_of_lt hc⟩
 
 lemma div_le_div_right_of_neg (hc : c < 0) : a / c ≤ b / c ↔ b ≤ a :=
-le_iff_le_iff_lt_iff_lt.2 (div_lt_div_right_of_neg hc)
+⟨le_imp_le_of_lt_imp_lt $ div_lt_div_of_neg_of_lt hc, div_le_div_of_nonpos_of_le $ le_of_lt hc⟩
+
+lemma div_lt_div_right (hc : 0 < c) : a / c < b / c ↔ a < b :=
+lt_iff_lt_of_le_iff_le $ div_le_div_right hc
+
+lemma div_lt_div_right_of_neg (hc : c < 0) : a / c < b / c ↔ b < a :=
+lt_iff_lt_of_le_iff_le $ div_le_div_right_of_neg hc
 
 lemma div_lt_div_left (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) : a / b < a / c ↔ c < b :=
 (mul_lt_mul_left ha).trans (inv_lt_inv hb hc)
@@ -445,10 +274,7 @@ lemma div_le_div_iff (b0 : 0 < b) (d0 : 0 < d) : a / b ≤ c / d ↔ a * d ≤ c
 by rw [le_div_iff d0, div_mul_eq_mul_div, div_le_iff b0]
 
 lemma div_le_div (hc : 0 ≤ c) (hac : a ≤ c) (hd : 0 < d) (hbd : d ≤ b) : a / b ≤ c / d :=
-begin
-  rw div_le_div_iff (lt_of_lt_of_le hd hbd) hd,
-  exact mul_le_mul hac hbd (le_of_lt hd) hc
-end
+by { rw div_le_div_iff (lt_of_lt_of_le hd hbd) hd, exact mul_le_mul hac hbd (le_of_lt hd) hc }
 
 lemma div_lt_div (hac : a < c) (hbd : d ≤ b) (c0 : 0 ≤ c) (d0 : 0 < d) :
   a / b < c / d :=
@@ -458,9 +284,200 @@ lemma div_lt_div' (hac : a ≤ c) (hbd : d < b) (c0 : 0 < c) (d0 : 0 < d) :
   a / b < c / d :=
 (div_lt_div_iff (lt_trans d0 hbd) d0).2 (mul_lt_mul' hac hbd (le_of_lt d0) c0)
 
+lemma div_lt_div_of_lt_left (hb : 0 < b) (h : b < a) (hc : 0 < c) : c / a < c / b :=
+(div_lt_div_left hc (lt_trans hb h) hb).mpr h
+
+/-!
+### Relating one division and involving `1`
+-/
+
+lemma one_le_div (hb : 0 < b) : 1 ≤ a / b ↔ b ≤ a :=
+by rw [le_div_iff hb, one_mul]
+
+lemma div_le_one (hb : 0 < b) : a / b ≤ 1 ↔ a ≤ b :=
+by rw [div_le_iff hb, one_mul]
+
+lemma one_lt_div (hb : 0 < b) : 1 < a / b ↔ b < a :=
+by rw [lt_div_iff hb, one_mul]
+
+lemma div_lt_one (hb : 0 < b) : a / b < 1 ↔ a < b :=
+by rw [div_lt_iff hb, one_mul]
+
+lemma one_le_div_of_neg (hb : b < 0) : 1 ≤ a / b ↔ a ≤ b :=
+by rw [le_div_iff_of_neg hb, one_mul]
+
+lemma div_le_one_of_neg (hb : b < 0) : a / b ≤ 1 ↔ b ≤ a :=
+by rw [div_le_iff_of_neg hb, one_mul]
+
+lemma one_lt_div_of_neg (hb : b < 0) : 1 < a / b ↔ a < b :=
+by rw [lt_div_iff_of_neg hb, one_mul]
+
+lemma div_lt_one_of_neg (hb : b < 0) : a / b < 1 ↔ b < a :=
+by rw [div_lt_iff_of_neg hb, one_mul]
+
+lemma one_div_le (ha : 0 < a) (hb : 0 < b) : 1 / a ≤ b ↔ 1 / b ≤ a :=
+by simpa using inv_le ha hb
+
+lemma one_div_lt (ha : 0 < a) (hb : 0 < b) : 1 / a < b ↔ 1 / b < a :=
+by simpa using inv_lt ha hb
+
+lemma le_one_div (ha : 0 < a) (hb : 0 < b) : a ≤ 1 / b ↔ b ≤ 1 / a :=
+by simpa using le_inv ha hb
+
+lemma lt_one_div (ha : 0 < a) (hb : 0 < b) : a < 1 / b ↔ b < 1 / a :=
+by simpa using lt_inv ha hb
+
+lemma one_div_le_of_neg (ha : a < 0) (hb : b < 0) : 1 / a ≤ b ↔ 1 / b ≤ a :=
+by simpa using inv_le_of_neg ha hb
+
+lemma one_div_lt_of_neg (ha : a < 0) (hb : b < 0) : 1 / a < b ↔ 1 / b < a :=
+by simpa using inv_lt_of_neg ha hb
+
+lemma le_one_div_of_neg (ha : a < 0) (hb : b < 0) : a ≤ 1 / b ↔ b ≤ 1 / a :=
+by simpa using le_inv_of_neg ha hb
+
+lemma lt_one_div_of_neg (ha : a < 0) (hb : b < 0) : a < 1 / b ↔ b < 1 / a :=
+by simpa using lt_inv_of_neg ha hb
+
+/-!
+### Relating two divisions, involving `1`
+-/
+lemma one_div_le_one_div_of_le (ha : 0 < a) (h : a ≤ b) : 1 / b ≤ 1 / a :=
+by simpa using inv_le_inv_of_le ha h
+
+lemma one_div_lt_one_div_of_lt (ha : 0 < a) (h : a < b) : 1 / b < 1 / a :=
+by rwa [lt_div_iff' ha, ← div_eq_mul_one_div, div_lt_one (lt_trans ha h)]
+
+lemma one_div_le_one_div_of_neg_of_le (hb : b < 0) (h : a ≤ b) : 1 / b ≤ 1 / a :=
+by rwa [div_le_iff_of_neg' hb, ← div_eq_mul_one_div, div_le_one_of_neg (lt_of_le_of_lt h hb)]
+
+lemma one_div_lt_one_div_of_neg_of_lt (hb : b < 0) (h : a < b) : 1 / b < 1 / a :=
+by rwa [div_lt_iff_of_neg' hb, ← div_eq_mul_one_div, div_lt_one_of_neg (lt_trans h hb)]
+
+lemma le_of_one_div_le_one_div (ha : 0 < a) (h : 1 / a ≤ 1 / b) : b ≤ a :=
+le_imp_le_of_lt_imp_lt (one_div_lt_one_div_of_lt ha) h
+
+lemma lt_of_one_div_lt_one_div (ha : 0 < a) (h : 1 / a < 1 / b) : b < a :=
+lt_imp_lt_of_le_imp_le (one_div_le_one_div_of_le ha) h
+
+lemma le_of_neg_of_one_div_le_one_div (hb : b < 0) (h : 1 / a ≤ 1 / b) : b ≤ a :=
+le_imp_le_of_lt_imp_lt (one_div_lt_one_div_of_neg_of_lt hb) h
+
+lemma lt_of_neg_of_one_div_lt_one_div (hb : b < 0) (h : 1 / a < 1 / b) : b < a :=
+lt_imp_lt_of_le_imp_le (one_div_le_one_div_of_neg_of_le hb) h
+
+/-- For the single implications with fewer assumptions, see `one_div_le_one_div_of_le` and
+  `le_of_one_div_le_one_div` -/
+lemma one_div_le_one_div (ha : 0 < a) (hb : 0 < b) : 1 / a ≤ 1 / b ↔ b ≤ a :=
+div_le_div_left zero_lt_one ha hb
+
+/-- For the single implications with fewer assumptions, see `one_div_lt_one_div_of_lt` and
+  `lt_of_one_div_lt_one_div` -/
+lemma one_div_lt_one_div (ha : 0 < a) (hb : 0 < b) : 1 / a < 1 / b ↔ b < a :=
+div_lt_div_left zero_lt_one ha hb
+
+/-- For the single implications with fewer assumptions, see `one_div_lt_one_div_of_neg_of_lt` and
+  `lt_of_one_div_lt_one_div` -/
+lemma one_div_le_one_div_of_neg (ha : a < 0) (hb : b < 0) : 1 / a ≤ 1 / b ↔ b ≤ a :=
+by simpa [one_div] using inv_le_inv_of_neg ha hb
+
+/-- For the single implications with fewer assumptions, see `one_div_lt_one_div_of_lt` and
+  `lt_of_one_div_lt_one_div` -/
+lemma one_div_lt_one_div_of_neg (ha : a < 0) (hb : b < 0) : 1 / a < 1 / b ↔ b < a :=
+lt_iff_lt_of_le_iff_le (one_div_le_one_div_of_neg hb ha)
+
+lemma one_lt_one_div (h1 : 0 < a) (h2 : a < 1) : 1 < 1 / a :=
+by rwa [lt_one_div (@zero_lt_one α _) h1, one_div_one]
+
+lemma one_le_one_div (h1 : 0 < a) (h2 : a ≤ 1) : 1 ≤ 1 / a :=
+by rwa [le_one_div (@zero_lt_one α _) h1, one_div_one]
+
+lemma one_div_lt_neg_one (h1 : a < 0) (h2 : -1 < a) : 1 / a < -1 :=
+suffices 1 / a < 1 / -1, by rwa one_div_neg_one_eq_neg_one at this,
+one_div_lt_one_div_of_neg_of_lt h1 h2
+
+lemma one_div_le_neg_one (h1 : a < 0) (h2 : -1 ≤ a) : 1 / a ≤ -1 :=
+suffices 1 / a ≤ 1 / -1, by rwa one_div_neg_one_eq_neg_one at this,
+one_div_le_one_div_of_neg_of_le h1 h2
+
+/-!
+### Results about halving.
+
+The equalities also hold in fields of characteristic `0`. -/
+lemma add_halves (a : α) : a / 2 + a / 2 = a :=
+by rw [div_add_div_same, ← two_mul, mul_div_cancel_left a two_ne_zero]
+
+lemma sub_self_div_two (a : α) : a - a / 2 = a / 2 :=
+suffices a / 2 + a / 2 - a / 2 = a / 2, by rwa add_halves at this,
+by rw [add_sub_cancel]
+
+lemma div_two_sub_self (a : α) : a / 2 - a = - (a / 2) :=
+suffices a / 2 - (a / 2 + a / 2) = - (a / 2), by rwa add_halves at this,
+by rw [sub_add_eq_sub_sub, sub_self, zero_sub]
+
+lemma add_self_div_two (a : α) : (a + a) / 2 = a :=
+by rw [← mul_two, mul_div_cancel a two_ne_zero]
+
+lemma half_pos (h : 0 < a) : 0 < a / 2 := div_pos h two_pos
+
+lemma one_half_pos : (0:α) < 1 / 2 := half_pos zero_lt_one
+
+lemma div_two_lt_of_pos (h : 0 < a) : a / 2 < a :=
+by { rw [div_lt_iff (@two_pos α _)], exact lt_mul_of_one_lt_right h one_lt_two }
+
+lemma half_lt_self : 0 < a → a / 2 < a := div_two_lt_of_pos
+
+lemma one_half_lt_one : (1 / 2 : α) < 1 := half_lt_self zero_lt_one
+
+lemma add_sub_div_two_lt (h : a < b) : a + (b - a) / 2 < b :=
+begin
+  rwa [← div_sub_div_same, sub_eq_add_neg, add_comm (b/2), ← add_assoc, ← sub_eq_add_neg,
+    ← lt_sub_iff_add_lt, sub_self_div_two, sub_self_div_two, div_lt_div_right (@two_pos α _)]
+end
+
+
+/-!
+### Miscellaneous lemmas
+-/
+
+lemma mul_sub_mul_div_mul_neg_iff (hc : c ≠ 0) (hd : d ≠ 0) :
+  (a * d - b * c) / (c * d) < 0 ↔ a / c < b / d :=
+by rw [mul_comm b c, ← div_sub_div _ _ hc hd, sub_lt_zero]
+
+alias mul_sub_mul_div_mul_neg_iff ↔ div_lt_div_of_mul_sub_mul_div_neg mul_sub_mul_div_mul_neg
+
+lemma mul_sub_mul_div_mul_nonpos_iff (hc : c ≠ 0) (hd : d ≠ 0) :
+      (a * d - b * c) / (c * d) ≤ 0 ↔ a / c ≤ b / d :=
+by rw [mul_comm b c, ← div_sub_div _ _ hc hd, sub_nonpos]
+
+alias mul_sub_mul_div_mul_nonpos_iff ↔
+  div_le_div_of_mul_sub_mul_div_nonpos mul_sub_mul_div_mul_nonpos
+
+lemma mul_le_mul_of_mul_div_le (h : a * (b / c) ≤ d) (hc : 0 < c) : b * a ≤ d * c :=
+begin
+  rw [← mul_div_assoc] at h,
+  rwa [mul_comm b, ← div_le_iff hc],
+end
+
+lemma div_mul_le_div_mul_of_div_le_div (h : a / b ≤ c / d) (he : 0 ≤ e) :
+  a / (b * e) ≤ c / (d * e) :=
+begin
+  rw [div_mul_eq_div_mul_one_div, div_mul_eq_div_mul_one_div],
+  exact mul_le_mul_of_nonneg_right h (one_div_nonneg.2 he)
+end
+
+lemma exists_add_lt_and_pos_of_lt (h : b < a) : ∃ c : α, b + c < a ∧ 0 < c :=
+⟨(a - b) / 2, add_sub_div_two_lt h, div_pos (sub_pos_of_lt h) two_pos⟩
+
+lemma le_of_forall_sub_le (h : ∀ ε > 0, b - ε ≤ a) : b ≤ a :=
+begin
+  contrapose! h,
+  simpa only [and_comm ((0 : α) < _), lt_sub_iff_add_lt, gt_iff_lt]
+    using exists_add_lt_and_pos_of_lt h,
+end
+
 lemma monotone.div_const {β : Type*} [preorder β] {f : β → α} (hf : monotone f)
-  {c : α} (hc : 0 ≤ c) :
-  monotone (λ x, (f x) / c) :=
+  {c : α} (hc : 0 ≤ c) : monotone (λ x, (f x) / c) :=
 hf.mul_const (inv_nonneg.2 hc)
 
 lemma strict_mono.div_const {β : Type*} [preorder β] {f : β → α} (hf : strict_mono f)
@@ -468,62 +485,27 @@ lemma strict_mono.div_const {β : Type*} [preorder β] {f : β → α} (hf : str
   strict_mono (λ x, (f x) / c) :=
 hf.mul_const (inv_pos.2 hc)
 
-lemma half_pos {a : α} (h : 0 < a) : 0 < a / 2 := div_pos h two_pos
-
-lemma one_half_pos : (0:α) < 1 / 2 := half_pos zero_lt_one
-
-lemma half_lt_self : 0 < a → a / 2 < a := div_two_lt_of_pos
-
-lemma one_half_lt_one : (1 / 2 : α) < 1 := half_lt_self zero_lt_one
-
 instance linear_ordered_field.to_densely_ordered : densely_ordered α :=
-{ dense := assume a₁ a₂ h, ⟨(a₁ + a₂) / 2,
+{ dense := λ a₁ a₂ h, ⟨(a₁ + a₂) / 2,
   calc a₁ = (a₁ + a₁) / 2 : (add_self_div_two a₁).symm
-    ... < (a₁ + a₂) / 2 : div_lt_div_of_pos_of_lt two_pos (add_lt_add_left h _),
-  calc (a₁ + a₂) / 2 < (a₂ + a₂) / 2 : div_lt_div_of_pos_of_lt two_pos (add_lt_add_right h _)
-    ... = a₂ : add_self_div_two a₂⟩ }
+      ... < (a₁ + a₂) / 2 : div_lt_div_of_lt two_pos (add_lt_add_left h _),
+  calc (a₁ + a₂) / 2 < (a₂ + a₂) / 2 : div_lt_div_of_lt two_pos (add_lt_add_right h _)
+                 ... = a₂            : add_self_div_two a₂⟩ }
 
 instance linear_ordered_field.to_no_top_order : no_top_order α :=
-{ no_top := assume a, ⟨a + 1, lt_add_of_le_of_pos (le_refl a) zero_lt_one ⟩ }
+{ no_top := λ a, ⟨a + 1, lt_add_of_le_of_pos (le_refl a) zero_lt_one ⟩ }
 
 instance linear_ordered_field.to_no_bot_order : no_bot_order α :=
-{ no_bot := assume a, ⟨a + -1,
-    add_lt_of_le_of_neg (le_refl _) (neg_lt_of_neg_lt $ by simp [zero_lt_one]) ⟩ }
-
-lemma inv_lt_one (ha : 1 < a) : a⁻¹ < 1 :=
-by rw [inv_eq_one_div]; exact div_lt_of_pos_of_lt_mul (lt_trans zero_lt_one ha) (by simp *)
-
-lemma one_lt_inv (h₁ : 0 < a) (h₂ : a < 1) : 1 < a⁻¹ :=
-by rw [inv_eq_one_div, lt_div_iff h₁]; simp [h₂]
-
-lemma inv_le_one (ha : 1 ≤ a) : a⁻¹ ≤ 1 :=
-by rw [inv_eq_one_div]; exact div_le_of_le_mul (lt_of_lt_of_le zero_lt_one ha) (by simp *)
-
-lemma one_le_inv (ha0 : 0 < a) (ha : a ≤ 1) : 1 ≤ a⁻¹ :=
-le_of_mul_le_mul_left (by simpa [mul_inv_cancel (ne.symm (ne_of_lt ha0))]) ha0
+{ no_bot := λ a, ⟨a + -1, add_lt_of_le_of_neg (le_refl _) neg_one_lt_zero ⟩ }
 
 lemma mul_self_inj_of_nonneg (a0 : 0 ≤ a) (b0 : 0 ≤ b) : a * a = b * b ↔ a = b :=
 mul_self_eq_mul_self_iff.trans $ or_iff_left_of_imp $
-λ h, by subst a; rw [le_antisymm (neg_nonneg.1 a0) b0, neg_zero]
-
-lemma div_le_div_of_le_left (ha : 0 ≤ a) (hc : 0 < c) (h : c ≤ b) :
-  a / b ≤ a / c :=
-by haveI := classical.dec_eq α; exact
-if ha0 : a = 0 then by simp [ha0]
-else (div_le_div_left (lt_of_le_of_ne ha (ne.symm ha0)) (lt_of_lt_of_le hc h) hc).2 h
-
-lemma inv_le_inv_of_le (hb : 0 < b) (h : b ≤ a) : a⁻¹ ≤ b⁻¹ :=
-begin
-  rw [inv_eq_one_div, inv_eq_one_div],
-  exact one_div_le_one_div_of_le hb h
-end
-
-lemma div_le_div_of_le_of_nonneg (hab : a ≤ b) (hc : 0 ≤ c) :
-  a / c ≤ b / c :=
-mul_le_mul_of_nonneg_right hab (inv_nonneg.2 hc)
+  λ h, by { subst a, have : b = 0 := le_antisymm (neg_nonneg.1 a0) b0, rw [this, neg_zero] }
 
 end linear_ordered_field
 
+/-- A discrete linear ordered field is a field with a decidable linear order respecting the
+  operations. -/
 @[protect_proj] class discrete_linear_ordered_field (α : Type*)
   extends linear_ordered_field α, decidable_linear_ordered_comm_ring α
 
@@ -534,17 +516,15 @@ lemma abs_div (a b : α) : abs (a / b) = abs a / abs b :=
 decidable.by_cases
   (assume h : b = 0, by rw [h, abs_zero, div_zero, div_zero, abs_zero])
   (assume h : b ≠ 0,
-   have h₁ : abs b ≠ 0, from
-     assume h₂, h (eq_zero_of_abs_eq_zero h₂),
-   eq_div_of_mul_eq h₁
-   (show abs (a / b) * abs b = abs a, by rw [← abs_mul, div_mul_cancel _ h]))
+   have h₁ : abs b ≠ 0, from mt eq_zero_of_abs_eq_zero h,
+   eq_div_of_mul_eq h₁ (show abs (a / b) * abs b = abs a, by rw [← abs_mul, div_mul_cancel _ h]))
 
 lemma abs_one_div (a : α) : abs (1 / a) = 1 / abs a :=
 by rw [abs_div, abs_of_nonneg (zero_le_one : 1 ≥ (0 : α))]
 
 lemma abs_inv (a : α) : abs a⁻¹ = (abs a)⁻¹ :=
 have h : abs (1 / a) = 1 / abs a,
-  begin rw [abs_div, abs_of_nonneg], exact zero_le_one end,
-by simp [*] at *
+  by { rw [abs_div, abs_of_nonneg], exact zero_le_one },
+by simp * at *
 
 end discrete_linear_ordered_field

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -287,7 +287,7 @@ lemma antilipschitz_with.add_lipschitz_with {α : Type*} [metric_space α] {Kf :
 begin
   refine antilipschitz_with.of_le_mul_dist (λ x y, _),
   rw [nnreal.coe_inv, ← div_eq_inv_mul],
-  apply le_div_of_mul_le (nnreal.coe_pos.2 $ nnreal.sub_pos.2 hK),
+  rw le_div_iff (nnreal.coe_pos.2 $ nnreal.sub_pos.2 hK),
   rw [mul_comm, nnreal.coe_sub (le_of_lt hK), sub_mul],
   calc ↑Kf⁻¹ * dist x y - Kg * dist x y ≤ dist (f x) (f y) - dist (g x) (g y) :
     sub_le_sub (hf.mul_le_dist x y) (hg.dist_le_mul x y)

--- a/src/analysis/normed_space/multilinear.lean
+++ b/src/analysis/normed_space/multilinear.lean
@@ -328,8 +328,9 @@ begin
     rw [this, norm_zero],
     exact mul_nonneg (op_norm_nonneg f) A },
   { have hlt : 0 < ∏ i, ∥m i∥ := lt_of_le_of_ne A (ne.symm h),
-    exact le_mul_of_div_le hlt ((le_Inf _ bounds_nonempty bounds_bdd_below).2
-      (λ c ⟨_, hc⟩, div_le_of_le_mul hlt (begin rw mul_comm, apply hc, end))) }
+    rw [← div_le_iff hlt],
+    apply (le_Inf _ bounds_nonempty bounds_bdd_below).2,
+    rintro c ⟨_, hc⟩, rw [div_le_iff hlt], apply hc }
 end
 
 lemma ratio_le_op_norm : ∥f m∥ / ∏ i, ∥m i∥ ≤ ∥f∥ :=

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -252,8 +252,8 @@ theorem le_op_norm : ∥f x∥ ≤ ∥f∥ * ∥x∥ :=
 classical.by_cases
   (λ heq : x = 0, by { rw heq, simp })
   (λ hne, have hlt : 0 < ∥x∥, from norm_pos_iff.2 hne,
-    le_mul_of_div_le hlt ((le_Inf _ bounds_nonempty bounds_bdd_below).2
-    (λ c ⟨_, hc⟩, div_le_of_le_mul hlt (by { rw mul_comm, apply hc }))))
+    (div_le_iff hlt).mp ((le_Inf _ bounds_nonempty bounds_bdd_below).2
+    (λ c ⟨_, hc⟩, (div_le_iff hlt).mpr $ by { apply hc })))
 
 theorem le_op_norm_of_le {c : ℝ} {x} (h : ∥x∥ ≤ c) : ∥f x∥ ≤ ∥f∥ * c :=
 le_trans (f.le_op_norm x) (mul_le_mul_of_nonneg_left h f.op_norm_nonneg)
@@ -264,9 +264,7 @@ lipschitz_with.of_dist_le_mul $ λ x y,
   by { rw [dist_eq_norm, dist_eq_norm, ←map_sub], apply le_op_norm }
 
 lemma ratio_le_op_norm : ∥f x∥ / ∥x∥ ≤ ∥f∥ :=
-(or.elim (lt_or_eq_of_le (norm_nonneg _))
-  (λ hlt, div_le_of_le_mul hlt (by { rw mul_comm, apply le_op_norm }))
-  (λ heq, by { rw [←heq, div_zero], apply op_norm_nonneg }))
+div_le_iff_of_nonneg_of_le (norm_nonneg _) f.op_norm_nonneg (le_op_norm _ _)
 
 /-- The image of the unit ball under a continuous linear map is bounded. -/
 lemma unit_le_op_norm : ∥x∥ ≤ 1 → ∥f x∥ ≤ ∥f∥ :=

--- a/src/analysis/normed_space/real_inner_product.lean
+++ b/src/analysis/normed_space/real_inner_product.lean
@@ -449,7 +449,7 @@ begin
   by_cases h : 0 = abs (∥x∥ * ∥y∥),
   { rw [←h, div_zero],
     norm_num },
-  { apply div_le_of_le_mul (lt_of_le_of_ne (ge_iff_le.mp (abs_nonneg (∥x∥ * ∥y∥))) h),
+  { rw div_le_iff' (lt_of_le_of_ne (ge_iff_le.mp (abs_nonneg (∥x∥ * ∥y∥))) h),
     convert abs_inner_le_norm x y using 1,
     rw [abs_mul, abs_of_nonneg (norm_nonneg x), abs_of_nonneg (norm_nonneg y), mul_one] }
 end

--- a/src/analysis/normed_space/riesz_lemma.lean
+++ b/src/analysis/normed_space/riesz_lemma.lean
@@ -35,7 +35,7 @@ begin
   let r' := max r 2⁻¹,
   have hr' : r' < 1, by { simp [r', hr], norm_num },
   have hlt : 0 < r' := lt_of_lt_of_le (by norm_num) (le_max_right r 2⁻¹),
-  have hdlt : d < d / r', from lt_div_of_mul_lt hlt ((mul_lt_iff_lt_one_right hdp).2 hr'),
+  have hdlt : d < d / r', from (lt_div_iff hlt).mpr ((mul_lt_iff_lt_one_right hdp).2 hr'),
   obtain ⟨y₀, hy₀F, hxy₀⟩ : ∃ y ∈ F, dist x y < d / r' :=
     metric.exists_dist_lt_of_inf_dist_lt hdlt hFn,
   have x_ne_y₀ : x - y₀ ∉ F,

--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -434,7 +434,7 @@ begin
       exp y = exp y * 1 : by simp
       ... ≤ exp y * (exp y / y)^n : begin
           apply mul_le_mul_of_nonneg_left (one_le_pow_of_one_le _ n) (le_of_lt (exp_pos _)),
-          apply one_le_div_of_le _ y_pos,
+          rw one_le_div y_pos,
           apply le_trans _ (add_one_le_exp_of_nonneg (le_of_lt y_pos)),
           exact le_add_of_le_of_nonneg (le_refl _) (zero_le_one)
         end

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -91,7 +91,7 @@ have (log x * (↑n)⁻¹).im = (log x).im / n,
 have h : -π < (log x * (↑n)⁻¹).im ∧ (log x * (↑n)⁻¹).im ≤ π,
   from (le_total (log x).im 0).elim
     (λ h, ⟨calc -π < (log x).im : by simp [log, neg_pi_lt_arg]
-            ... ≤ ((log x).im * 1) / n : le_div_of_mul_le (nat.cast_pos.2 hn)
+            ... ≤ ((log x).im * 1) / n : (le_div_iff (nat.cast_pos.2 hn : (0 : ℝ) < _)).mpr
               (mul_le_mul_of_nonpos_left (by rw ← nat.cast_one; exact nat.cast_le.2 hn) h)
             ... = (log x * (↑n)⁻¹).im : by simp [this],
           this.symm ▸ le_trans (div_nonpos_of_nonpos_of_nonneg h n.cast_nonneg)
@@ -99,8 +99,8 @@ have h : -π < (log x * (↑n)⁻¹).im ∧ (log x * (↑n)⁻¹).im ≤ π,
     (λ h, ⟨this.symm ▸ lt_of_lt_of_le (neg_neg_of_pos real.pi_pos)
             (div_nonneg h n.cast_nonneg),
           calc (log x * (↑n)⁻¹).im = (1 * (log x).im) / n : by simp [this]
-            ... ≤ (log x).im : (div_le_of_le_mul (nat.cast_pos.2 hn)
-              (mul_le_mul_of_nonneg_right (by rw ← nat.cast_one; exact nat.cast_le.2 hn) h))
+            ... ≤ (log x).im : (div_le_iff' (nat.cast_pos.2 hn : (0 : ℝ) < _)).mpr
+              (mul_le_mul_of_nonneg_right (by rw ← nat.cast_one; exact nat.cast_le.2 hn) h)
             ... ≤ _ : by simp [log, arg_le_pi]⟩),
 by rw [← cpow_nat_cast, ← cpow_mul _ h.1 h.2,
     inv_mul_cancel (show (n : ℂ) ≠ 0, from nat.cast_ne_zero.2 (nat.pos_iff_ne_zero.1 hn)),

--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -434,13 +434,11 @@ by simpa [re_add_im] using abs_add z.re (z.im * I)
 
 lemma abs_re_div_abs_le_one (z : ℂ) : abs' (z.re / z.abs) ≤ 1 :=
 if hz : z = 0 then by simp [hz, zero_le_one]
-else by rw [_root_.abs_div, abs_abs]; exact
-  div_le_of_le_mul (abs_pos.2 hz) (by rw mul_one; exact abs_re_le_abs _)
+else by { simp_rw [_root_.abs_div, abs_abs, div_le_iff (abs_pos.2 hz), one_mul, abs_re_le_abs] }
 
 lemma abs_im_div_abs_le_one (z : ℂ) : abs' (z.im / z.abs) ≤ 1 :=
 if hz : z = 0 then by simp [hz, zero_le_one]
-else by rw [_root_.abs_div, abs_abs]; exact
-  div_le_of_le_mul (abs_pos.2 hz) (by rw mul_one; exact abs_im_le_abs _)
+else by { simp_rw [_root_.abs_div, abs_abs, div_le_iff (abs_pos.2 hz), one_mul, abs_im_le_abs] }
 
 @[simp, norm_cast] lemma abs_cast_nat (n : ℕ) : abs (n : ℂ) = n :=
 by rw [← of_real_nat_cast, abs_of_nonneg (nat.cast_nonneg n)]

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -137,7 +137,7 @@ begin
   refine @is_cau_of_mono_bounded _ _ _ _ ((1 : α) / (1 - abv x)) 0 _ _,
   { assume n hn,
     rw abs_of_nonneg,
-    refine div_le_div_of_pos_of_le (sub_pos.2 hx1)
+    refine div_le_div_of_le (le_of_lt $ sub_pos.2 hx1)
       (sub_le_self _ (abv_pow abv x n ▸ abv_nonneg _ _)),
     refine div_nonneg (sub_nonneg.2 _) (sub_nonneg.2 $ le_of_lt hx1),
     clear hn,
@@ -146,7 +146,7 @@ begin
     { rw [pow_succ, ← one_mul (1 : α)],
       refine mul_le_mul (le_of_lt hx1) ih (abv_pow abv x n ▸ abv_nonneg _ _) (by norm_num) } },
   { assume n hn,
-    refine div_le_div_of_pos_of_le (sub_pos.2 hx1) (sub_le_sub_left _ _),
+    refine div_le_div_of_le (le_of_lt $ sub_pos.2 hx1) (sub_le_sub_left _ _),
     rw [← one_mul (_ ^ n), pow_succ],
     exact mul_le_mul_of_nonneg_right (le_of_lt hx1) (pow_nonneg (abv_nonneg _ _) _) }
 end
@@ -1129,7 +1129,7 @@ calc 0 < x - x ^ 3 / 6 - abs' x ^ 4 * (5 / 96) :
     (by rwa [_root_.abs_of_nonneg (le_of_lt hx0)]))).2
 
 lemma sin_pos_of_pos_of_le_two {x : ℝ} (hx0 : 0 < x) (hx : x ≤ 2) : 0 < sin x :=
-have x / 2 ≤ 1, from div_le_of_le_mul (by norm_num) (by simpa),
+have x / 2 ≤ 1, from (div_le_iff (by norm_num)).mpr (by simpa),
 calc 0 < 2 * sin (x / 2) * cos (x / 2) :
   mul_pos (mul_pos (by norm_num) (sin_pos_of_pos_of_le_one (half_pos hx0) this))
     (cos_pos_of_le_one (by rwa [_root_.abs_of_nonneg (le_of_lt (half_pos hx0))]))

--- a/src/data/padics/hensel.lean
+++ b/src/data/padics/hensel.lean
@@ -111,7 +111,7 @@ calc T = ∥F.eval a∥ / ∥((F.derivative.eval a)^2 : ℚ_[p])∥ : normed_fie
    ... = ∥F.eval a∥ / ∥(F.derivative.eval a)∥^2 : by simp [pow, monoid.pow]
 
 private lemma T_lt_one : T < 1 :=
-let h := (div_lt_one_iff_lt deriv_sq_norm_pos).2 hnorm in
+let h := (div_lt_one deriv_sq_norm_pos).2 hnorm in
 by rw T_def; apply h
 
 private lemma T_pow {n : ℕ} (hn : n > 0) : T ^ n < 1 :=
@@ -367,10 +367,9 @@ tendsto_nhds_unique newton_seq_dist_tendsto' newton_seq_dist_tendsto
 
 private lemma soln_dist_to_a_lt_deriv : ∥soln - a∥ < ∥F.derivative.eval a∥ :=
 begin
-  rw soln_dist_to_a,
-  apply div_lt_of_pos_of_lt_mul,
-  { apply deriv_norm_pos; assumption },
-  { rwa _root_.pow_two at hnorm }
+  rw [soln_dist_to_a, div_lt_iff],
+  { rwa _root_.pow_two at hnorm },
+  { apply deriv_norm_pos, assumption }
 end
 
 private lemma eval_soln : F.eval soln = 0 :=

--- a/src/data/padics/padic_numbers.lean
+++ b/src/data/padics/padic_numbers.lean
@@ -629,10 +629,10 @@ lemma exi_rat_seq_conv {ε : ℚ} (hε : 0 < ε) :
 begin
   refine (exists_nat_gt (1/ε)).imp (λ N hN i hi, _),
   have h := classical.some_spec (rat_dense' (f i) (div_nat_pos i)),
-  refine lt_of_lt_of_le h (div_le_of_le_mul (by exact_mod_cast succ_pos _) _),
+  refine lt_of_lt_of_le h ((div_le_iff' $ by exact_mod_cast succ_pos _).mpr _),
   rw right_distrib,
   apply le_add_of_le_of_nonneg,
-  { exact le_mul_of_div_le hε (le_trans (le_of_lt hN) (by exact_mod_cast hi)) },
+  { exact (div_le_iff hε).mp (le_trans (le_of_lt hN) (by exact_mod_cast hi)) },
   { apply le_of_lt, simpa }
 end
 

--- a/src/data/real/basic.lean
+++ b/src/data/real/basic.lean
@@ -447,7 +447,7 @@ end,
       ← le_div_iff (div_pos h _30), div_div_cancel' (ne_of_gt h)],
     apply add_le_add,
     { simpa using (mul_le_mul_left (@two_pos ℝ _)).2 (Sup_le_ub _ ⟨_, lb⟩ ub) },
-    { rw [div_le_one_iff_le _30],
+    { rw [div_le_one _30],
       refine le_trans (sub_le_self _ (mul_self_nonneg _)) (le_trans x1 _),
       exact (le_add_iff_nonneg_left _).2 (le_of_lt two_pos) } }
 end

--- a/src/data/real/cardinality.lean
+++ b/src/data/real/cardinality.lean
@@ -74,7 +74,7 @@ begin
     apply lt_of_le_of_lt (cantor_function_le (le_of_lt h1) h3 hf_max),
     apply lt_of_lt_of_le _ (cantor_function_le (le_of_lt h1) h3 hg_min),
     have : c / (1 - c) < 1,
-    { rw [div_lt_one_iff_lt, lt_sub_iff_add_lt],
+    { rw [div_lt_one, lt_sub_iff_add_lt],
       { convert add_lt_add h2 h2, norm_num },
       rwa sub_pos },
     convert this,

--- a/src/data/real/conjugate_exponents.lean
+++ b/src/data/real/conjugate_exponents.lean
@@ -78,7 +78,7 @@ lemma mul_eq_add : p * q = p + q :=
 by simpa only [sub_mul, sub_eq_iff_eq_add, one_mul] using h.sub_one_mul_conj
 
 @[symm] protected lemma symm : q.is_conjugate_exponent p :=
-{ one_lt := by { rw [h.conj_eq], exact one_lt_div_of_lt _ h.sub_one_pos (sub_one_lt p) },
+{ one_lt := by { rw [h.conj_eq], exact (one_lt_div h.sub_one_pos).mpr (sub_one_lt p) },
   inv_add_inv_conj := by simpa [add_comm] using h.inv_add_inv_conj }
 
 end is_conjugate_exponent

--- a/src/data/real/hyperreal.lean
+++ b/src/data/real/hyperreal.lean
@@ -511,7 +511,7 @@ is_st_iff_abs_sub_lt_delta.mpr $ λ d hd,
         field_simp [this, @two_ne_zero ℝ* _, add_mul, mul_add, mul_assoc, mul_comm, mul_left_comm] }
   ... < (d / 2 * 1 + d / 2 : ℝ*) :
         add_lt_add_right (mul_lt_mul_of_pos_left
-        ((div_lt_one_iff_lt $ lt_of_le_of_lt (abs_nonneg x) ht).mpr ht) $
+        ((div_lt_one $ lt_of_le_of_lt (abs_nonneg x) ht).mpr ht) $
         half_pos $ coe_pos.2 hd) _
   ... = (d : ℝ*) : by rw [mul_one, add_halves]
 

--- a/src/data/real/pi.lean
+++ b/src/data/real/pi.lean
@@ -10,8 +10,8 @@ namespace real
 lemma pi_gt_sqrt_two_add_series (n : ℕ) : 2 ^ (n+1) * sqrt (2 - sqrt_two_add_series 0 n) < pi :=
 begin
   have : sqrt (2 - sqrt_two_add_series 0 n) / 2 * 2 ^ (n+2) < pi,
-  { apply mul_lt_of_lt_div, apply pow_pos, norm_num,
-    rw [←sin_pi_over_two_pow_succ], apply sin_lt, apply div_pos pi_pos, apply pow_pos, norm_num },
+  { rw [← lt_div_iff, ←sin_pi_over_two_pow_succ], apply sin_lt, apply div_pos pi_pos,
+    all_goals { apply pow_pos, norm_num } },
   apply lt_of_le_of_lt (le_of_eq _) this,
   rw [pow_succ _ (n+1), ←mul_assoc, div_mul_cancel, mul_comm], norm_num
 end
@@ -20,23 +20,24 @@ lemma pi_lt_sqrt_two_add_series (n : ℕ) :
   pi < 2 ^ (n+1) * sqrt (2 - sqrt_two_add_series 0 n) + 1 / 4 ^ n :=
 begin
   have : pi < (sqrt (2 - sqrt_two_add_series 0 n) / 2 + 1 / (2 ^ n) ^ 3 / 4) * 2 ^ (n+2),
-  { rw [←div_lt_iff, ←sin_pi_over_two_pow_succ],
+  { rw [← div_lt_iff, ← sin_pi_over_two_pow_succ],
     refine lt_of_lt_of_le (lt_add_of_sub_right_lt (sin_gt_sub_cube _ _)) _,
     { apply div_pos pi_pos, apply pow_pos, norm_num },
-    { apply div_le_of_le_mul, apply pow_pos, norm_num, refine le_trans pi_le_four _,
-      simp only [show ((4 : ℝ) = 2 ^ 2), by norm_num, mul_one],
-      apply pow_le_pow, norm_num, apply le_add_of_nonneg_left, apply nat.zero_le },
+    { rw div_le_iff',
+      { refine le_trans pi_le_four _,
+        simp only [show ((4 : ℝ) = 2 ^ 2), by norm_num, mul_one],
+        apply pow_le_pow, norm_num, apply le_add_of_nonneg_left, apply nat.zero_le },
+        { apply pow_pos, norm_num }},
     apply add_le_add_left, rw div_le_div_right,
-    apply le_div_of_mul_le, apply pow_pos, apply pow_pos, norm_num,
-    rw [←mul_pow],
+    rw [le_div_iff, ←mul_pow],
     refine le_trans _ (le_of_eq (one_pow 3)), apply pow_le_pow_of_le_left,
     { apply le_of_lt, apply mul_pos, apply div_pos pi_pos, apply pow_pos, norm_num, apply pow_pos,
       norm_num },
-    apply mul_le_of_le_div, apply pow_pos, norm_num,
+    rw ← le_div_iff,
     refine le_trans ((div_le_div_right _).mpr pi_le_four) _, apply pow_pos, norm_num,
     rw [pow_succ, pow_succ, ←mul_assoc, ←div_div_eq_div_mul],
-    convert le_refl _, norm_num, norm_num,
-    apply pow_pos, norm_num },
+    convert le_refl _,
+    all_goals { repeat {apply pow_pos}, norm_num }},
   apply lt_of_lt_of_le this (le_of_eq _), rw [add_mul], congr' 1,
   { rw [pow_succ _ (n+1), ←mul_assoc, div_mul_cancel, mul_comm], norm_num },
   rw [pow_succ, ←pow_mul, mul_comm n 2, pow_mul, show (2 : ℝ) ^ 2 = 4, by norm_num, pow_succ,
@@ -52,7 +53,7 @@ theorem pi_lower_bound_start (n : ℕ) {a}
   (h : sqrt_two_add_series ((0:ℕ) / (1:ℕ)) n ≤ 2 - (a / 2 ^ (n + 1)) ^ 2) : a < pi :=
 begin
   refine lt_of_le_of_lt _ (pi_gt_sqrt_two_add_series n), rw [mul_comm],
-  refine le_mul_of_div_le (pow_pos (by norm_num) _) (le_sqrt_of_sqr_le _),
+  refine (div_le_iff (pow_pos (by norm_num) _ : (0 : ℝ) < _)).mp (le_sqrt_of_sqr_le _),
   rwa [le_sub, show (0:ℝ) = (0:ℕ)/(1:ℕ), by rw [nat.cast_zero, zero_div]],
 end
 

--- a/src/dynamics/circle/rotation_number/translation_number.lean
+++ b/src/dynamics/circle/rotation_number/translation_number.lean
@@ -535,7 +535,7 @@ translation_number_translate z ▸ translation_number_mono
 
 lemma translation_number_le_of_le_add_int {x : ℝ} {m : ℤ} (h : f x ≤ x + m) : τ f ≤ m :=
 le_of_tendsto' (f.tendsto_translation_number' x) $ λ n,
-div_le_of_le_mul n.cast_add_one_pos $ sub_le_iff_le_add'.2 $
+(div_le_iff' (n.cast_add_one_pos : (0 : ℝ) < _)).mpr $ sub_le_iff_le_add'.2 $
 (coe_pow f (n + 1)).symm ▸ f.iterate_le_of_map_le_add_int h (n + 1)
 
 lemma translation_number_le_of_le_add_nat {x : ℝ} {m : ℕ} (h : f x ≤ x + m) : τ f ≤ m :=
@@ -543,7 +543,7 @@ lemma translation_number_le_of_le_add_nat {x : ℝ} {m : ℕ} (h : f x ≤ x + m
 
 lemma le_translation_number_of_add_int_le {x : ℝ} {m : ℤ} (h : x + m ≤ f x) : ↑m ≤ τ f :=
 ge_of_tendsto' (f.tendsto_translation_number' x) $ λ n,
-le_div_of_mul_le n.cast_add_one_pos $ le_sub_iff_add_le'.2 $
+(le_div_iff (n.cast_add_one_pos : (0 : ℝ) < _)).mpr $ le_sub_iff_add_le'.2 $
 by simp only [coe_pow, mul_comm (m:ℝ), ← nat.cast_add_one, f.le_iterate_of_add_int_le_map h]
 
 lemma le_translation_number_of_add_nat_le {x : ℝ} {m : ℕ} (h : x + m ≤ f x) : ↑m ≤ τ f :=

--- a/src/topology/metric_space/antilipschitz.lean
+++ b/src/topology/metric_space/antilipschitz.lean
@@ -42,7 +42,7 @@ lemma antilipschitz_with.mul_le_dist [metric_space α] [metric_space β] {K : �
 begin
   by_cases hK : K = 0, by simp [hK, dist_nonneg],
   rw [nnreal.coe_inv, ← div_eq_inv_mul],
-  apply div_le_of_le_mul (nnreal.coe_pos.2 $ zero_lt_iff_ne_zero.2 hK),
+  rw div_le_iff' (nnreal.coe_pos.2 $ zero_lt_iff_ne_zero.2 hK),
   exact hf.le_mul_dist x y
 end
 


### PR DESCRIPTION
Group similar lemmas in a more intuitive way
Add docstrings, module doc and section headers
Simplify some proofs
Remove some implications if they had a corresponding `iff` lemma.
Add some more variants of some lemmas
Rename some lemmas for consistency
List of name changes (the lemma on the right might be a bi-implication, if the original version was an implication):
`add_midpoint` -> `add_sub_div_two_lt`
`le_div_of_mul_le`, `mul_le_of_le_div` -> `le_div_iff`
`lt_div_of_mul_lt`, `mul_lt_of_lt_div` -> `lt_div_iff`
`div_le_of_le_mul` -> `div_le_iff'`
`le_mul_of_div_le` -> `div_le_iff`
`div_lt_of_pos_of_lt_mul` -> `div_lt_iff'`
`mul_le_of_neg_of_div_le`, `div_le_of_neg_of_mul_le` -> `div_le_iff_of_neg`
`mul_lt_of_neg_of_div_lt`, `div_lt_of_neg_of_mul_lt` -> `div_lt_iff_of_neg`
`div_le_div_of_pos_of_le` -> `div_le_div_of_le`
`div_le_div_of_neg_of_le` -> `div_le_div_of_nonpos_of_le`
`div_lt_div_of_pos_of_lt` -> `div_lt_div_of_lt`
`div_mul_le_div_mul_of_div_le_div_nonneg` -> `div_mul_le_div_mul_of_div_le_div`
`one_le_div_of_le`, `le_of_one_le_div`, `one_le_div_iff_le` -> `one_le_div`
`one_lt_div_of_lt`, `lt_of_one_lt_div`, `one_lt_div_iff_lt` -> `one_lt_div`
`div_le_one_iff_le` -> `div_le_one`
`div_lt_one_iff_lt` -> `div_lt_one`
`one_div_le_of_pos_of_one_div_le` -> `one_div_le`
`one_div_le_of_neg_of_one_div_le` -> `one_div_le_of_neg`
`div_lt_div_of_pos_of_lt_of_pos` -> `div_lt_div_of_lt_left`

One regression I noticed in some other files: when using `div_le_iff`, and the argument is proven by some lemma about `linear_ordered_semiring` then Lean gives a type mismatch. Presumably this happens because the instance chain `ordered_field -> has_le` doesn't go via `ordered_semiring`. The fix is to give the type explicitly, for example using `div_le_iff (t : (0 : ℝ) < _)`

---
<!-- put comments you want to keep out of the PR commit here -->

I wanted to do a couple more changes after #3723, and then I rewrote the whole file.
