### PR TITLE
[Merged by Bors] - feat(algebra/order): more lemmas for projection notation

### DIFF
--- a/src/algebra/order.lean
+++ b/src/algebra/order.lean
@@ -87,7 +87,7 @@ alias not_le_of_lt ← has_lt.lt.not_le
 lemma not_lt_of_le [preorder α] {a b : α} (h : a ≤ b) : ¬ b < a
 | hab := not_le_of_gt hab h
 
-alias not_lt_of_le ← has_le.not_lt
+alias not_lt_of_le ← has_le.le.not_lt
 
 lemma le_iff_eq_or_lt [partial_order α] {a b : α} : a ≤ b ↔ a = b ∨ a < b :=
 le_iff_lt_or_eq.trans or.comm

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -46,6 +46,9 @@ open function
 - expand module docs
 - automatic construction of dual definitions / theorems
 
+## See also
+- `algebra.order` for basic lemmas about orders, and projection notation for orders
+
 ## Tags
 
 preorder, order, partial order, linear order, monotone, strictly monotone
@@ -53,10 +56,6 @@ preorder, order, partial order, linear order, monotone, strictly monotone
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w} {r : α → α → Prop}
-
-@[nolint ge_or_gt] -- see Note [nolint_ge]
-theorem ge_of_eq [preorder α] {a b : α} : a = b → a ≥ b :=
-λ h, h ▸ le_refl a
 
 theorem preorder.ext {α} {A B : preorder α}
   (H : ∀ x y : α, (by haveI := A; exact x ≤ y) ↔ x ≤ y) : A = B :=
@@ -180,7 +179,7 @@ lemma le_iff_le (H : strict_mono f) {a b} :
 end
 
 protected lemma nat {β} [preorder β] {f : ℕ → β} (h : ∀n, f n < f (n+1)) : strict_mono f :=
-by { intros n m hnm, induction hnm with m' hnm' ih, apply h, exact lt.trans ih (h _) }
+by { intros n m hnm, induction hnm with m' hnm' ih, apply h, exact ih.trans (h _) }
 
 -- `preorder α` isn't strong enough: if the preorder on α is an equivalence relation,
 -- then `strict_mono f` is vacuously true.
@@ -236,7 +235,7 @@ lemma dual_lt [has_lt α] {a b : α} :
 
 instance (α : Type*) [preorder α] : preorder (order_dual α) :=
 { le_refl  := le_refl,
-  le_trans := assume a b c hab hbc, le_trans hbc hab,
+  le_trans := assume a b c hab hbc, hbc.trans hab,
   lt_iff_le_not_le := λ _ _, lt_iff_le_not_le,
   .. order_dual.has_le α,
   .. order_dual.has_lt α }

--- a/src/order/filter/germ.lean
+++ b/src/order/filter/germ.lean
@@ -437,7 +437,7 @@ instance [preorder β] : preorder (germ l β) :=
 
 instance [partial_order β] : partial_order (germ l β) :=
 { le := (≤),
-  le_antisymm := λ f g, induction_on₂ f g $ λ f g h₁ h₂, (h₁.antisymm h₂).germ_eq,
+  le_antisymm := λ f g, induction_on₂ f g $ λ f g h₁ h₂, (eventually_le.antisymm h₁ h₂).germ_eq,
   .. germ.preorder }
 
 instance [has_bot β] : has_bot (germ l β) := ⟨↑(⊥:β)⟩


### PR DESCRIPTION
Also import `tactic.lint` and ensure that the linter passes
Move `ge_of_eq` to this file

---
<!-- put comments you want to keep out of the PR commit here -->
