### PR TITLE
[Merged by Bors] - chore(data/finset/order): use `[nonempty]` in `directed.finset_le`

### DIFF
--- a/src/data/finset/order.lean
+++ b/src/data/finset/order.lean
@@ -4,7 +4,7 @@ universes u v w
 variables {α : Type u}
 
 theorem directed.finset_le {r : α → α → Prop} [is_trans α r]
-  {ι} (hι : nonempty ι) {f : ι → α} (D : directed r f) (s : finset ι) :
+  {ι} [hι : nonempty ι] {f : ι → α} (D : directed r f) (s : finset ι) :
   ∃ z, ∀ i ∈ s, r (f i) (f z) :=
 show ∃ z, ∀ i ∈ s.1, r (f i) (f z), from
 multiset.induction_on s.1 (let ⟨z⟩ := hι in ⟨z, λ _, false.elim⟩) $
@@ -15,4 +15,4 @@ multiset.induction_on s.1 (let ⟨z⟩ := hι in ⟨z, λ _, false.elim⟩) $
 
 theorem finset.exists_le {α : Type u} [nonempty α] [directed_order α] (s : finset α) :
   ∃ M, ∀ i ∈ s, i ≤ M :=
-directed.finset_le (by apply_instance) directed_order.directed s
+directed.finset_le directed_order.directed s

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -369,9 +369,10 @@ lemma linear_independent_Union_of_directed {η : Type*}
   linear_independent R (λ x, x : (⋃ i, s i) → M) :=
 begin
   by_cases hη : nonempty η,
-  { refine linear_independent_of_finite (⋃ i, s i) (λ t ht ft, _),
+  { resetI,
+    refine linear_independent_of_finite (⋃ i, s i) (λ t ht ft, _),
     rcases finite_subset_Union ft ht with ⟨I, fi, hI⟩,
-    rcases hs.finset_le hη fi.to_finset with ⟨i, hi⟩,
+    rcases hs.finset_le fi.to_finset with ⟨i, hi⟩,
     exact (h i).mono (subset.trans hI $ bUnion_subset $
       λ j hj, hi j (finite.mem_to_finset.2 hj)) },
   { refine (linear_independent_empty _ _).mono _,

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -187,7 +187,7 @@ begin
     from (hZc i₀).elim_finite_subfamily_closed Z'
       (assume i, is_closed_inter (hZcl i) (hZcl i₀)) (by rw [H, inter_empty]),
   obtain ⟨i₁, hi₁⟩ : ∃ i₁ : ι, Z i₁ ⊆ Z i₀ ∧ ∀ i ∈ t, Z i₁ ⊆ Z' i,
-  { rcases directed.finset_le hι hZd t with ⟨i, hi⟩,
+  { rcases directed.finset_le hZd t with ⟨i, hi⟩,
     rcases hZd i i₀ with ⟨i₁, hi₁, hi₁₀⟩,
     use [i₁, hi₁₀],
     intros j hj,


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->