### PR TITLE
[Merged by Bors] - feat(ci): auto label merge conflicts

### DIFF
--- a/.github/workflows/merge_conflicts.yml
+++ b/.github/workflows/merge_conflicts.yml
@@ -1,0 +1,12 @@
+on:
+  push:
+    branches:
+      - master
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@master
+        with:
+          CONFLICT_LABEL_NAME: "merge-conflict"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->

After tagging a couple merge conflicts by hand this morning, I figured it should be doable automatically, and turns out there's already an action for it. The [description](https://github.com/marketplace/actions/auto-label-merge-conflicts) says it adds and removes the label as needed.