### PR TITLE
[Merged by Bors] - feat(ci): auto label merge conflicts, try 2

### DIFF
--- a/.github/workflows/merge_conflicts.yml
+++ b/.github/workflows/merge_conflicts.yml
@@ -1,12 +1,20 @@
 on:
+  # So that PRs touching the same files as the push are updated
   push:
     branches:
       - master
+  # So that the `dirtyLabel` is removed if conflicts are resolve
+  # We recommend `pull_request_target` so that github secrets are available.
+  # In `pull_request` we wouldn't be able to change labels of fork PRs
+  pull_request_target:
+    types: [synchronize]
+
 jobs:
-  triage:
+  main:
     runs-on: ubuntu-latest
     steps:
-      - uses: mschilde/auto-label-merge-conflicts@master
+      - name: check if prs are dirty
+        uses: eps1lon/actions-label-merge-conflict@releases/2.x
         with:
-          CONFLICT_LABEL_NAME: "merge-conflict"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          dirtyLabel: "merge-conflict"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->

The action I added earlier today doesn't seem to be reliable. This one sounds more robust. Let's see if it's better.