### PR TITLE
[Merged by Bors] - feat(data/fin): flesh out API for fin

### DIFF
--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -323,7 +323,7 @@ begin
     by exact H.congr A (A x hx),
   rw continuous_linear_equiv.comp_has_fderiv_within_at_iff',
   have : ((0 : ℕ) : with_top ℕ) < n :=
-    lt_of_lt_of_le (with_top.coe_lt_coe.2 zero_lt_one) hn,
+    lt_of_lt_of_le (with_top.coe_lt_coe.2 nat.zero_lt_one) hn,
   convert h.fderiv_within _ this x hx,
   ext y v,
   change (p x 1) (snoc 0 y) = (p x 1) (cons y v),

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -343,7 +343,7 @@ by simp [lt_iff_val_lt_val]
 
 /-- Coercing a `nat` into a term of the smallest `fin` that can hold it
 results in the greatest term for that type -/
-@[norm_cast, simp] lemma coe_nat_eq_last (n) : (n : fin (n + 1)) = fin.last n :=
+lemma coe_nat_eq_last (n) : (n : fin (n + 1)) = fin.last n :=
 by { rw [←fin.of_nat_eq_coe, fin.of_nat, fin.last], simp only [nat.mod_eq_of_lt n.lt_succ_self] }
 
 /-- Every term is less than or equal to the greatest term of the type,

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -390,7 +390,7 @@ cast_le_injective (le_add_right n 1)
   p.succ_above i = i.cast_succ :=
 by { rw [fin.succ_above], split_ifs, refl }
 
-@[simp] lemma succ_above_zero (i : fin n) : succ_above 0 i = i.succ := rfl
+lemma succ_above_zero (i : fin n) : succ_above 0 i = i.succ := rfl
 
 @[simp] lemma succ_above_above (p : fin (n + 1)) (i : fin n) (h : p.val ≤ i.val) :
   p.succ_above i = i.succ :=

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -76,11 +76,9 @@ iff.intro (congr_arg _) fin.eq_of_veq
 
 lemma val_injective {n : ℕ} : injective (val : fin n → ℕ) := λ _ _, fin.eq_of_veq
 
-/-- Terms are equal if their values are equal -/
 lemma eq_iff_veq (a b : fin n) : a = b ↔ a.1 = b.1 :=
 ⟨veq_of_eq, eq_of_veq⟩
 
-/-- Terms are not equal if their values are not equal -/
 lemma ne_iff_vne (a b : fin n) : a ≠ b ↔ a.1 ≠ b.1 :=
 ⟨vne_of_ne, ne_of_vne⟩
 
@@ -92,7 +90,6 @@ instance fin_to_nat (n : ℕ) : has_coe (fin n) nat := ⟨fin.val⟩
 
 lemma mk_val {m n : ℕ} (h : m < n) : (⟨m, h⟩ : fin n).val = m := rfl
 
-/-- Equality between terms of type `fin n` where one is constructed from the value and proof -/
 lemma eq_mk_iff_val_eq {k : ℕ} {hk : k < n} : a = ⟨k, hk⟩ ↔ a.val = k :=
 fin.eq_iff_veq a ⟨k, hk⟩
 
@@ -123,15 +120,10 @@ lemma val_mul {n : ℕ} :  ∀ a b : fin n, (a * b).val = (a.val * b.val) % n
 
 lemma one_val {n : ℕ} : (1 : fin (n+1)).val = 1 % (n+1) := rfl
 
-/-- The `val_zero` lemma uses `n.succ` instead `n+1` -/
 @[simp] lemma val_zero' (n) : (0 : fin (n+1)).val = 0 := rfl
 
-/-- All types of `fin (n + 1)` have a zero term,
-so constructing with a zero `nat` gives zero -/
 @[simp] lemma mk_zero_eq_zero : (⟨0, nat.succ_pos'⟩ : fin (n + 1)) = 0 := rfl
 
-/-- All types of `fin (n + 2)` have a 1 term that is different than 0,
-so constructing with 1 gives 1 -/
 @[simp] lemma mk_one_eq_one : (⟨1, nat.succ_lt_succ (nat.succ_pos n)⟩ : fin (n + 2)) = 1 := rfl
 
 @[simp]
@@ -195,13 +187,11 @@ lemma lt_iff_val_lt_val : a < b ↔ a.val < b.val := iff.rfl
 
 lemma le_iff_val_le_val : a ≤ b ↔ a.val ≤ b.val := iff.rfl
 
-/-- Zero is always the lowest term in the order -/
 lemma zero_le (a : fin (n + 1)) : 0 ≤ a := zero_le a.1
 
 @[simp] lemma succ_val (j : fin n) : j.succ.val = j.val.succ :=
 by cases j; simp [fin.succ]
 
-/-- Zero is less than any term that is the result of `succ` -/
 lemma zero_lt (a : fin (n + 1)) : (0 : fin (n + 2)) < a.succ := by simp [lt_iff_val_lt_val]
 
 protected theorem succ.inj (p : fin.succ a = fin.succ b) : a = b :=
@@ -210,15 +200,12 @@ by cases a; cases b; exact eq_of_veq (nat.succ.inj (veq_of_eq p))
 @[simp] lemma succ_inj {a b : fin n} : a.succ = b.succ ↔ a = b :=
 ⟨λh, succ.inj h, λh, by rw h⟩
 
-/-- `succ` is injective across an order -/
 lemma succ_le_succ_iff : a.succ ≤ b.succ ↔ a ≤ b :=
 by { simp only [le_iff_val_le_val, succ_val], exact ⟨le_of_succ_le_succ, succ_le_succ⟩ }
 
-/-- `succ` is injective across an inequality -/
 lemma succ_lt_succ_iff : a.succ < b.succ ↔ a < b :=
 by { simp only [lt_iff_val_lt_val, succ_val], exact ⟨lt_of_succ_lt_succ, succ_lt_succ⟩ }
 
-/-- `succ` is injective across a strict inequality -/
 lemma succ_ne_succ_iff : a.succ ≠ b.succ ↔ a ≠ b :=
 ⟨λ h H, h (congr_arg fin.succ H), λ h H, h (succ.inj H)⟩
 
@@ -228,14 +215,11 @@ lemma succ_injective (n : ℕ) : injective (@fin.succ n) :=
 lemma succ_ne_zero {n} : ∀ k : fin n, fin.succ k ≠ 0
 | ⟨k, hk⟩ heq := nat.succ_ne_zero k $ (fin.ext_iff _ _).1 heq
 
-/-- All terms of zero can be `succ` into a 1 -/
 @[simp] lemma succ_zero_eq_one : fin.succ (0 : fin (n + 1)) = 1 := rfl
 
-/-- All terms that `succ` twice are not 1 -/
 lemma succ_succ_ne_one : fin.succ (fin.succ a) ≠ 1 :=
 by { intro h, rw [←succ_zero_eq_one, succ_inj] at h, exact (fin.succ_ne_zero a) h }
 
-/-- All `fin n` inhabited by more than two terms have a term greater than 1 -/
 lemma one_lt_succ_succ (a : fin (n + 1)) : (1 : fin (n + 3)) < a.succ.succ :=
 by { rw [←succ_zero_eq_one, succ_lt_succ_iff], exact zero_lt a }
 
@@ -334,28 +318,20 @@ by simp [eq_iff_veq]
 lemma cast_succ_ne_last (a : fin n) : cast_succ a ≠ last n :=
 by simp [eq_iff_veq, ne_of_lt a.2]
 
-/-- Zero embedded into the `fin` directly above is zero -/
 @[simp] lemma cast_succ_zero : cast_succ (0 : fin (n + 1)) = 0 := rfl
 
-/-- Zero is less than the greatest term -/
 @[simp] lemma zero_lt_last : (0 : fin (n + 2)) < last (n + 1) :=
 by simp [lt_iff_val_lt_val]
 
-/-- Coercing a `nat` into a term of the smallest `fin` that can hold it
-results in the greatest term for that type -/
 lemma coe_nat_eq_last (n) : (n : fin (n + 1)) = fin.last n :=
 by { rw [←fin.of_nat_eq_coe, fin.of_nat, fin.last], simp only [nat.mod_eq_of_lt n.lt_succ_self] }
 
-/-- Every term is less than or equal to the greatest term of the type,
-even if the greatest term is coerced from `nat` -/
 lemma le_coe_last (i : fin (n + 1)) : i ≤ n :=
 by { rw fin.coe_nat_eq_last, exact fin.le_last i }
 
 lemma eq_last_of_not_lt {i : fin (n+1)} (h : ¬ i.val < n) : i = last n :=
 le_antisymm (le_last i) (not_lt.1 h)
 
-/-- Adding 1 to a term strictly less than the greatest term will not overflow,
-that is, zero is not equal to a term + 1, as long as the term is not the greatest term -/
 lemma zero_ne_not_last_add_one (i : fin (n + 1)) (hl : i < fin.last n) : (0 : fin (n + 1)) ≠ i + 1 :=
 begin
   intro h,
@@ -367,15 +343,12 @@ begin
     exact nat.succ_ne_zero _ h.symm }
 end
 
-/-- In any `fin` inhabited by more than two terms, 0 is not equal to 1 -/
 lemma zero_ne_one : (0 : fin (n + 2)) ≠ 1 := zero_ne_not_last_add_one 0 zero_lt_last
 
 lemma cast_succ_fin_succ (n : ℕ) (j : fin n) :
   cast_succ (fin.succ j) = fin.succ (cast_succ j) :=
 by simp [fin.ext_iff]
 
-/-- Casting an existing term into the `fin` directly larger
-is never equal to `succ` of the term -/
 lemma cast_succ_ne_succ (i : fin (n + 1)) : i.cast_succ ≠ i.succ :=
 begin
   intro h,
@@ -383,17 +356,12 @@ begin
   exact (nat.succ_ne_self _) h.symm
 end
 
-/-- Coercing a term into the `fin` directly larger
-is equal to `cast_succ` of the term -/
 @[norm_cast, simp] lemma coe_eq_cast_succ : (a : fin (n + 1)) = a.cast_succ :=
 begin
   rw [cast_succ, cast_add, cast_le, cast_lt, eq_iff_veq],
   exact coe_val_of_lt (nat.lt.step a.is_lt),
 end
 
-/-- Coercing a term by adding 1 from the `fin` directly larger
-is equal to `succ` of the term. Relies on simplifying the coercion
-via `coe_eq_cast_succ`. -/
 @[simp] lemma coe_succ_eq_succ (a : fin n) : (a.cast_succ + 1) = a.succ :=
 begin
   cases n,
@@ -401,8 +369,6 @@ begin
   { simp [a.is_lt, eq_iff_veq, add_def, nat.mod_eq_of_lt] }
 end
 
-/-- Casting a term into the `fin` directly larger is always less
-than `succ` of the term. Useful for statements like `↑a < ↑a + 1` -/
 @[simp] lemma lt_succ : a.cast_succ < a.succ :=
 by { rw [cast_succ, lt_iff_val_lt_val, cast_add_val, succ_val], exact lt_add_one a.val }
 
@@ -418,12 +384,10 @@ lemma cast_le_injective {n₁ n₂ : ℕ} (h : n₁ ≤ n₂) : injective (fin.c
 lemma cast_succ_injective (n : ℕ) : injective (@fin.cast_succ n) :=
 cast_le_injective (le_add_right n 1)
 
-/-- `succ_above` of a term below the pivot is equal to `cast_succ` of the term -/
 @[simp] lemma succ_above_below (p : fin (n + 1)) (i : fin n) (h : i.val < p.val) :
   p.succ_above i = i.cast_succ :=
 by { rw [fin.succ_above], split_ifs, refl }
 
-/-- `succ_above` of a term above the pivot is equal to `succ` of the term -/
 @[simp] lemma succ_above_above (p : fin (n + 1)) (i : fin n) (h : p.val ≤ i.val) :
   p.succ_above i = i.succ :=
 by { rw [fin.succ_above], split_ifs with H, { exfalso, exact nat.lt_le_antisymm H h }, refl }

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -348,7 +348,7 @@ by { rw [←fin.of_nat_eq_coe, fin.of_nat, fin.last], simp only [nat.mod_eq_of_l
 
 /-- Every term is less than or equal to the greatest term of the type,
 even if the greatest term is coerced from `nat` -/
-lemma le_coe_last {n : ℕ} (i : fin (n + 1)) : i ≤ n :=
+lemma le_coe_last (i : fin (n + 1)) : i ≤ n :=
 by { rw fin.coe_nat_eq_last, exact fin.le_last i }
 
 lemma eq_last_of_not_lt {i : fin (n+1)} (h : ¬ i.val < n) : i = last n :=
@@ -356,7 +356,7 @@ le_antisymm (le_last i) (not_lt.1 h)
 
 /-- Adding 1 to a term strictly less than the greatest term will not overflow,
 that is, zero is not equal to a term + 1, as long as the term is not the greatest term -/
-lemma zero_ne_not_last_add_one {n : ℕ} (i : fin (n + 1)) (hl : i < fin.last n) : (0 : fin (n + 1)) ≠ i + 1 :=
+lemma zero_ne_not_last_add_one (i : fin (n + 1)) (hl : i < fin.last n) : (0 : fin (n + 1)) ≠ i + 1 :=
 begin
   intro h,
   rw [lt_iff_val_lt_val, last_val] at hl,

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -372,6 +372,8 @@ end
 @[simp] lemma lt_succ : a.cast_succ < a.succ :=
 by { rw [cast_succ, lt_iff_val_lt_val, cast_add_val, succ_val], exact lt_add_one a.val }
 
+@[simp] lemma pred_one {n : ℕ} : fin.pred (1 : fin (n + 2)) (zero_ne_one.symm) = 0 := rfl
+
 /-- `min n m` as an element of `fin (m + 1)` -/
 def clamp (n m : ℕ) : fin (m + 1) := fin.of_nat $ min n m
 
@@ -387,6 +389,8 @@ cast_le_injective (le_add_right n 1)
 @[simp] lemma succ_above_below (p : fin (n + 1)) (i : fin n) (h : i.val < p.val) :
   p.succ_above i = i.cast_succ :=
 by { rw [fin.succ_above], split_ifs, refl }
+
+@[simp] lemma succ_above_zero (i : fin n) : succ_above 0 i = i.succ := rfl
 
 @[simp] lemma succ_above_above (p : fin (n + 1)) (i : fin n) (h : p.val ≤ i.val) :
   p.succ_above i = i.succ :=

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -409,7 +409,7 @@ end
 
 lemma succ_above_pos (p : fin (n + 2)) (i : fin (n + 1)) (h : 0 < i) : 0 < p.succ_above i :=
 begin
-  by_cases H : i.val < p.val,
+  by_cases H : (i : ℕ) < p,
   { simpa [succ_above_below, H, lt_iff_val_lt_val] using h },
   { push_neg at H,
     simp [succ_above_above, H, lt_iff_val_lt_val], },

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -235,7 +235,7 @@ by cases i; refl
 
 @[simp] lemma pred_mk_succ (i : ℕ) {h : i < n + 1} :
   (⟨i.succ, add_lt_add_right h 1⟩ : fin (n + 2)).pred (ne_of_vne (ne_of_gt (zero_lt_mk_succ i h))) = ⟨i, h⟩ :=
-by squeeze_simp [eq_iff_veq, succ_pred_eq_of_pos, h, mod_eq_of_lt]
+by simp only [eq_iff_veq, pred_val, nat.pred_succ]
 
 @[simp] lemma pred_inj :
   ∀ {a b : fin (n + 1)} {ha : a ≠ 0} {hb : b ≠ 0}, a.pred ha = b.pred hb ↔ a = b

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -126,6 +126,23 @@ lemma one_val {n : ℕ} : (1 : fin (n+1)).val = 1 % (n+1) := rfl
 
 @[simp] lemma mk_one : (⟨1, nat.succ_lt_succ (nat.succ_pos n)⟩ : fin (n + 2)) = 1 := rfl
 
+section bit
+
+@[simp] lemma mk_bit0 {m n : ℕ} (h : bit0 m < n) :
+  (⟨bit0 m, h⟩ : fin n) = bit0 ⟨m, (nat.le_add_right m m).trans_lt h⟩ :=
+eq_of_veq (nat.mod_eq_of_lt h).symm
+
+@[simp] lemma mk_bit1 {m n : ℕ} (h : bit1 m < n + 1) :
+  (⟨bit1 m, h⟩ : fin (n + 1)) = bit1 ⟨m, (nat.le_add_right m m).trans_lt
+    ((m + m).lt_succ_self.trans h)⟩ :=
+begin
+  ext,
+  simp only [bit1, bit0] at h,
+  simp only [bit1, bit0, val_add, one_val, ←nat.add_mod, nat.mod_eq_of_lt h]
+end
+
+end bit
+
 @[simp]
 lemma of_nat_eq_coe (n : ℕ) (a : ℕ) : (of_nat a : fin (n+1)) = a :=
 begin

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -90,7 +90,7 @@ instance fin_to_nat (n : ℕ) : has_coe (fin n) nat := ⟨fin.val⟩
 
 lemma mk_val {m n : ℕ} (h : m < n) : (⟨m, h⟩ : fin n).val = m := rfl
 
-lemma eq_mk_iff_val_eq {k : ℕ} {hk : k < n} : a = ⟨k, hk⟩ ↔ a.val = k :=
+lemma eq_mk_iff_coe_eq {k : ℕ} {hk : k < n} : a = ⟨k, hk⟩ ↔ (a : ℕ) = k :=
 fin.eq_iff_veq a ⟨k, hk⟩
 
 @[simp, norm_cast] lemma coe_mk {m n : ℕ} (h : m < n) : ((⟨m, h⟩ : fin n) : ℕ) = m := rfl
@@ -200,10 +200,10 @@ by cases a; cases b; exact eq_of_veq (nat.succ.inj (veq_of_eq p))
 @[simp] lemma succ_inj {a b : fin n} : a.succ = b.succ ↔ a = b :=
 ⟨λh, succ.inj h, λh, by rw h⟩
 
-lemma succ_le_succ_iff : a.succ ≤ b.succ ↔ a ≤ b :=
+@[simp] lemma succ_le_succ_iff : a.succ ≤ b.succ ↔ a ≤ b :=
 by { simp only [le_iff_val_le_val, succ_val], exact ⟨le_of_succ_le_succ, succ_le_succ⟩ }
 
-lemma succ_lt_succ_iff : a.succ < b.succ ↔ a < b :=
+@[simp] lemma succ_lt_succ_iff : a.succ < b.succ ↔ a < b :=
 by { simp only [lt_iff_val_lt_val, succ_val], exact ⟨lt_of_succ_lt_succ, succ_lt_succ⟩ }
 
 lemma succ_injective (n : ℕ) : injective (@fin.succ n) :=
@@ -370,9 +370,9 @@ by { rw [cast_succ, lt_iff_val_lt_val, cast_add_val, succ_val], exact lt_add_one
 
 @[simp] lemma pred_one {n : ℕ} : fin.pred (1 : fin (n + 2)) (ne.symm (ne_of_lt one_pos)) = 0 := rfl
 
-lemma pred_add_one (i : fin (n + 2)) (h : i.val < n + 1) :
+lemma pred_add_one (i : fin (n + 2)) (h : (i : ℕ) < n + 1) :
   pred (i + 1) (ne_of_gt (add_one_pos _ (lt_iff_val_lt_val.mpr h))) = cast_lt i h :=
-by simp [eq_iff_veq, succ_pred_eq_of_pos, h, add_def, mod_eq_of_lt]
+by { rw coe_eq_val at h, simp [eq_iff_veq, succ_pred_eq_of_pos, h, add_def, mod_eq_of_lt] }
 
 /-- `min n m` as an element of `fin (m + 1)` -/
 def clamp (n m : ℕ) : fin (m + 1) := fin.of_nat $ min n m
@@ -386,18 +386,18 @@ lemma cast_le_injective {n₁ n₂ : ℕ} (h : n₁ ≤ n₂) : injective (fin.c
 lemma cast_succ_injective (n : ℕ) : injective (@fin.cast_succ n) :=
 cast_le_injective (le_add_right n 1)
 
-lemma succ_above_below (p : fin (n + 1)) (i : fin n) (h : i.val < p.val) :
+lemma succ_above_below (p : fin (n + 1)) (i : fin n) (h : (i : ℕ) < p) :
   p.succ_above i = i.cast_succ :=
-by { rw [fin.succ_above], split_ifs, refl }
+by { rw [coe_eq_val, coe_eq_val] at h, rw [succ_above], exact if_pos h }
 
 @[simp] lemma succ_above_zero : succ_above (0 : fin (n + 1)) = fin.succ := rfl
 
 @[simp] lemma succ_above_last : succ_above (fin.last n) = cast_succ :=
 by { ext i, simp only [succ_above, i.is_lt, if_true, last_val] }
 
-lemma succ_above_above (p : fin (n + 1)) (i : fin n) (h : p.val ≤ i.val) :
+lemma succ_above_above (p : fin (n + 1)) (i : fin n) (h : (p : ℕ) ≤ i) :
   p.succ_above i = i.succ :=
-by { rw [fin.succ_above], split_ifs with H, { exfalso, exact nat.lt_le_antisymm H h }, refl }
+by { rw [coe_eq_val, coe_eq_val] at h, rw [succ_above], exact if_neg (not_lt_of_le h) }
 
 theorem succ_above_ne (p : fin (n+1)) (i : fin n) : p.succ_above i ≠ p :=
 begin

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -233,7 +233,7 @@ by cases j; simp [fin.pred]
 @[simp] lemma pred_succ (i : fin n) {h : i.succ ≠ 0} : i.succ.pred h = i :=
 by cases i; refl
 
-@[simp] lemma pred_mk_succ (i : ℕ) {h : i < n + 1} :
+@[simp] lemma pred_mk_succ (i : ℕ) (h : i < n + 1) :
   (⟨i.succ, add_lt_add_right h 1⟩ : fin (n + 2)).pred (ne_of_vne (ne_of_gt (zero_lt_mk_succ i h))) = ⟨i, h⟩ :=
 by simp only [eq_iff_veq, pred_val, nat.pred_succ]
 

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -217,6 +217,9 @@ lemma succ_ne_zero {n} : ∀ k : fin n, fin.succ k ≠ 0
 lemma succ_succ_ne_one : fin.succ (fin.succ a) ≠ 1 :=
 by { intro h, rw [←succ_zero_eq_one, succ_inj] at h, exact (fin.succ_ne_zero a) h }
 
+lemma zero_lt_mk_succ (i : ℕ) (h : i < n) : (0 : fin (n + 1)) < ⟨i.succ, add_lt_add_right h 1⟩ :=
+by { rw [lt_iff_val_lt_val, val_zero], exact nat.succ_pos i }
+
 lemma one_lt_succ_succ (a : fin n) : (1 : fin (n + 2)) < a.succ.succ :=
 by { cases n, { exact fin.elim0 a }, { rw [←succ_zero_eq_one, succ_lt_succ_iff], exact zero_lt_succ a } }
 
@@ -229,6 +232,10 @@ by cases j; simp [fin.pred]
 
 @[simp] lemma pred_succ (i : fin n) {h : i.succ ≠ 0} : i.succ.pred h = i :=
 by cases i; refl
+
+@[simp] lemma pred_mk_succ (i : ℕ) {h : i < n + 1} :
+  (⟨i.succ, add_lt_add_right h 1⟩ : fin (n + 2)).pred (ne_of_vne (ne_of_gt (zero_lt_mk_succ i h))) = ⟨i, h⟩ :=
+by squeeze_simp [eq_iff_veq, succ_pred_eq_of_pos, h, mod_eq_of_lt]
 
 @[simp] lemma pred_inj :
   ∀ {a b : fin (n + 1)} {ha : a ≠ 0} {hb : b ≠ 0}, a.pred ha = b.pred hb ↔ a = b

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -360,7 +360,7 @@ begin
   { simp [a.is_lt, eq_iff_veq, add_def, nat.mod_eq_of_lt] }
 end
 
-@[simp] lemma lt_succ : a.cast_succ < a.succ :=
+lemma lt_succ : a.cast_succ < a.succ :=
 by { rw [cast_succ, lt_iff_val_lt_val, cast_add_val, succ_val], exact lt_add_one a.val }
 
 @[simp] lemma pred_one {n : ℕ} : fin.pred (1 : fin (n + 2)) (ne.symm (ne_of_lt zero_lt_one)) = 0 := rfl

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -312,13 +312,14 @@ rfl
 @[simp] lemma cast_succ_inj {a b : fin n} : a.cast_succ = b.cast_succ ↔ a = b :=
 by simp [eq_iff_veq]
 
-lemma cast_succ_ne_last (a : fin n) : cast_succ a ≠ last n :=
-by simp [eq_iff_veq, ne_of_lt a.2]
+lemma cast_succ_lt_last (a : fin n) : cast_succ a < last n := lt_iff_val_lt_val.mpr a.is_lt
 
 @[simp] lemma cast_succ_zero : cast_succ (0 : fin (n + 1)) = 0 := rfl
 
 lemma zero_lt_last : (0 : fin (n + 2)) < last (n + 1) :=
 by simp [lt_iff_val_lt_val]
+
+lemma pred_one_add (i : fin (n + 1)) (h : i.val < n + 1) : pred (i + 1) _ = cast_lt i := sorry
 
 lemma coe_nat_eq_last (n) : (n : fin (n + 1)) = fin.last n :=
 by { rw [←fin.of_nat_eq_coe, fin.of_nat, fin.last], simp only [nat.mod_eq_of_lt n.lt_succ_self] }

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -405,6 +405,14 @@ begin
     simpa [lt_irrefl, nat.lt_succ_self, eq.symm] using h
 end
 
+lemma succ_above_pos (p : fin (n + 2)) (i : fin (n + 1)) (h : 0 < i) : 0 < p.succ_above i :=
+begin
+  by_cases H : i.val < p.val,
+  { simpa [succ_above_below, H, lt_iff_val_lt_val] using h },
+  { push_neg at H,
+    simp [succ_above_above, H, lt_iff_val_lt_val], },
+end
+
 @[simp] lemma succ_above_descend :
   ∀(p i : fin (n+1)) (h : i ≠ p), p.succ_above (p.pred_above i h) = i
 | ⟨p, hp⟩ ⟨0,   hi⟩ h := fin.eq_of_veq $ by simp [succ_above, pred_above]; split_ifs; simp * at *

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -485,7 +485,7 @@ A version of `fin.succ_rec` taking `i : fin n` as the first argument. -/
   (Hs : Π n i, C n i → C (succ n) i.succ) : C n i :=
 i.succ_rec H0 Hs
 
-@[simp] theorem succ_rec_on_zeoo {C : ∀ n, fin n → Sort*} {H0 Hs} (n) :
+@[simp] theorem succ_rec_on_zero {C : ∀ n, fin n → Sort*} {H0 Hs} (n) :
   @fin.succ_rec_on (succ n) 0 C H0 Hs = H0 n :=
 rfl
 

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -192,7 +192,7 @@ lemma zero_le (a : fin (n + 1)) : 0 ≤ a := zero_le a.1
 @[simp] lemma succ_val (j : fin n) : j.succ.val = j.val.succ :=
 by cases j; simp [fin.succ]
 
-lemma zero_lt_succ (a : fin n) : (0 : fin (n + 1)) < a.succ := by simp [lt_iff_val_lt_val]
+lemma succ_pos (a : fin n) : (0 : fin (n + 1)) < a.succ := by simp [lt_iff_val_lt_val]
 
 protected theorem succ.inj (p : fin.succ a = fin.succ b) : a = b :=
 by cases a; cases b; exact eq_of_veq (nat.succ.inj (veq_of_eq p))
@@ -214,14 +214,13 @@ lemma succ_ne_zero {n} : ∀ k : fin n, fin.succ k ≠ 0
 
 @[simp] lemma succ_zero_eq_one : fin.succ (0 : fin (n + 1)) = 1 := rfl
 
-lemma succ_succ_ne_one : fin.succ (fin.succ a) ≠ 1 :=
-by { intro h, rw [←succ_zero_eq_one, succ_inj] at h, exact (fin.succ_ne_zero a) h }
-
-lemma zero_lt_mk_succ (i : ℕ) (h : i < n) : (0 : fin (n + 1)) < ⟨i.succ, add_lt_add_right h 1⟩ :=
+lemma mk_succ_pos (i : ℕ) (h : i < n) : (0 : fin (n + 1)) < ⟨i.succ, add_lt_add_right h 1⟩ :=
 by { rw [lt_iff_val_lt_val, val_zero], exact nat.succ_pos i }
 
 lemma one_lt_succ_succ (a : fin n) : (1 : fin (n + 2)) < a.succ.succ :=
-by { cases n, { exact fin.elim0 a }, { rw [←succ_zero_eq_one, succ_lt_succ_iff], exact zero_lt_succ a } }
+by { cases n, { exact fin.elim0 a }, { rw [←succ_zero_eq_one, succ_lt_succ_iff], exact succ_pos a } }
+
+lemma succ_succ_ne_one : fin.succ (fin.succ a) ≠ 1 := ne_of_gt (one_lt_succ_succ a)
 
 @[simp] lemma pred_val (j : fin (n+1)) (h : j ≠ 0) : (j.pred h).val = j.val.pred :=
 by cases j; simp [fin.pred]
@@ -234,7 +233,7 @@ by cases j; simp [fin.pred]
 by cases i; refl
 
 @[simp] lemma pred_mk_succ (i : ℕ) (h : i < n + 1) :
-  (⟨i.succ, add_lt_add_right h 1⟩ : fin (n + 2)).pred (ne_of_vne (ne_of_gt (zero_lt_mk_succ i h))) = ⟨i, h⟩ :=
+  (⟨i.succ, add_lt_add_right h 1⟩ : fin (n + 2)).pred (ne_of_vne (ne_of_gt (mk_succ_pos i h))) = ⟨i, h⟩ :=
 by simp only [eq_iff_veq, pred_val, nat.pred_succ]
 
 @[simp] lemma pred_inj :
@@ -323,7 +322,7 @@ lemma cast_succ_lt_last (a : fin n) : cast_succ a < last n := lt_iff_val_lt_val.
 
 @[simp] lemma cast_succ_zero : cast_succ (0 : fin (n + 1)) = 0 := rfl
 
-lemma zero_lt_last : (0 : fin (n + 2)) < last (n + 1) :=
+lemma last_pos : (0 : fin (n + 2)) < last (n + 1) :=
 by simp [lt_iff_val_lt_val]
 
 lemma coe_nat_eq_last (n) : (n : fin (n + 1)) = fin.last n :=
@@ -335,7 +334,7 @@ by { rw fin.coe_nat_eq_last, exact fin.le_last i }
 lemma eq_last_of_not_lt {i : fin (n+1)} (h : ¬ i.val < n) : i = last n :=
 le_antisymm (le_last i) (not_lt.1 h)
 
-lemma zero_lt_not_last_add_one (i : fin (n + 1)) (h : i < fin.last n) : (0 : fin (n + 1)) < i + 1 :=
+lemma add_one_pos (i : fin (n + 1)) (h : i < fin.last n) : (0 : fin (n + 1)) < i + 1 :=
 begin
   cases n,
   { exact absurd h (nat.not_lt_zero _) },
@@ -344,7 +343,7 @@ begin
     exact nat.zero_lt_succ _ }
 end
 
-lemma zero_lt_one : (0 : fin (n + 2)) < 1 := zero_lt_succ 0
+lemma one_pos : (0 : fin (n + 2)) < 1 := succ_pos 0
 
 lemma cast_succ_fin_succ (n : ℕ) (j : fin n) :
   cast_succ (fin.succ j) = fin.succ (cast_succ j) :=
@@ -369,10 +368,10 @@ end
 lemma lt_succ : a.cast_succ < a.succ :=
 by { rw [cast_succ, lt_iff_val_lt_val, cast_add_val, succ_val], exact lt_add_one a.val }
 
-@[simp] lemma pred_one {n : ℕ} : fin.pred (1 : fin (n + 2)) (ne.symm (ne_of_lt zero_lt_one)) = 0 := rfl
+@[simp] lemma pred_one {n : ℕ} : fin.pred (1 : fin (n + 2)) (ne.symm (ne_of_lt one_pos)) = 0 := rfl
 
 lemma pred_add_one (i : fin (n + 2)) (h : i.val < n + 1) :
-  pred (i + 1) (ne_of_gt (zero_lt_not_last_add_one _ (lt_iff_val_lt_val.mpr h))) = cast_lt i h :=
+  pred (i + 1) (ne_of_gt (add_one_pos _ (lt_iff_val_lt_val.mpr h))) = cast_lt i h :=
 by simp [eq_iff_veq, succ_pred_eq_of_pos, h, add_def, mod_eq_of_lt]
 
 /-- `min n m` as an element of `fin (m + 1)` -/

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -319,8 +319,6 @@ lemma cast_succ_lt_last (a : fin n) : cast_succ a < last n := lt_iff_val_lt_val.
 lemma zero_lt_last : (0 : fin (n + 2)) < last (n + 1) :=
 by simp [lt_iff_val_lt_val]
 
-lemma pred_one_add (i : fin (n + 1)) (h : i.val < n + 1) : pred (i + 1) _ = cast_lt i := sorry
-
 lemma coe_nat_eq_last (n) : (n : fin (n + 1)) = fin.last n :=
 by { rw [←fin.of_nat_eq_coe, fin.of_nat, fin.last], simp only [nat.mod_eq_of_lt n.lt_succ_self] }
 
@@ -365,6 +363,10 @@ lemma lt_succ : a.cast_succ < a.succ :=
 by { rw [cast_succ, lt_iff_val_lt_val, cast_add_val, succ_val], exact lt_add_one a.val }
 
 @[simp] lemma pred_one {n : ℕ} : fin.pred (1 : fin (n + 2)) (ne.symm (ne_of_lt zero_lt_one)) = 0 := rfl
+
+lemma pred_one_add (i : fin (n + 2)) (h : i.val < n + 1) :
+  pred (i + 1) (ne_of_gt (zero_lt_not_last_add_one _ (lt_iff_val_lt_val.mpr h))) = cast_lt i h :=
+by simp [eq_iff_veq, succ_pred_eq_of_pos, h, add_def, mod_eq_of_lt]
 
 /-- `min n m` as an element of `fin (m + 1)` -/
 def clamp (n m : ℕ) : fin (m + 1) := fin.of_nat $ min n m

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -122,9 +122,9 @@ lemma one_val {n : ℕ} : (1 : fin (n+1)).val = 1 % (n+1) := rfl
 
 @[simp] lemma val_zero' (n) : (0 : fin (n+1)).val = 0 := rfl
 
-@[simp] lemma mk_zero_eq_zero : (⟨0, nat.succ_pos'⟩ : fin (n + 1)) = 0 := rfl
+@[simp] lemma mk_zero : (⟨0, nat.succ_pos'⟩ : fin (n + 1)) = 0 := rfl
 
-@[simp] lemma mk_one_eq_one : (⟨1, nat.succ_lt_succ (nat.succ_pos n)⟩ : fin (n + 2)) = 1 := rfl
+@[simp] lemma mk_one : (⟨1, nat.succ_lt_succ (nat.succ_pos n)⟩ : fin (n + 2)) = 1 := rfl
 
 @[simp]
 lemma of_nat_eq_coe (n : ℕ) (a : ℕ) : (of_nat a : fin (n+1)) = a :=

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -366,7 +366,7 @@ lemma cast_succ_fin_succ (n : ℕ) (j : fin n) :
   cast_succ (fin.succ j) = fin.succ (cast_succ j) :=
 by simp [fin.ext_iff]
 
-lemma cast_succ_lt_succ (i : fin (n + 1)) : i.cast_succ < i.succ :=
+lemma cast_succ_lt_succ (i : fin n) : i.cast_succ < i.succ :=
 by { rw [lt_iff_val_lt_val, cast_succ, cast_add_val, succ_val], exact lt_add_one _ }
 
 @[norm_cast, simp] lemma coe_eq_cast_succ : (a : fin (n + 1)) = a.cast_succ :=

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -390,10 +390,10 @@ lemma succ_above_below (p : fin (n + 1)) (i : fin n) (h : i.val < p.val) :
   p.succ_above i = i.cast_succ :=
 by { rw [fin.succ_above], split_ifs, refl }
 
-@[simp] lemma succ_above_zero (i : fin n) : succ_above 0 i = i.succ := rfl
+@[simp] lemma succ_above_zero : succ_above (0 : fin (n + 1)) = fin.succ := rfl
 
-@[simp] lemma succ_above_last (i : fin n) : succ_above (fin.last n) i = i.cast_succ :=
-by simp only [succ_above, i.is_lt, if_true, last_val]
+@[simp] lemma succ_above_last : succ_above (fin.last n) = cast_succ :=
+by { ext i, simp only [succ_above, i.is_lt, if_true, last_val] }
 
 lemma succ_above_above (p : fin (n + 1)) (i : fin n) (h : p.val ≤ i.val) :
   p.succ_above i = i.succ :=

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -674,7 +674,7 @@ begin
         by { assume E, apply h', rw [← E, cast_succ_cast_lt] },
       simp [h', this, snoc, h] } },
   { rw eq_last_of_not_lt h,
-    simp [ne.symm (cast_succ_ne_last i)] }
+    simp [ne.symm (ne_of_lt (cast_succ_lt_last i))] }
 end
 
 /-- Adding an element at the beginning of a tuple and then updating it amounts to adding it
@@ -705,7 +705,7 @@ end
 
 /-- Updating the last element of a tuple does not change the beginning. -/
 @[simp] lemma init_update_last : init (update q (last n) z) = init q :=
-by { ext j, simp [init, cast_succ_ne_last] }
+by { ext j, simp [init, ne_of_lt, cast_succ_lt_last] }
 
 /-- Updating an element and taking the beginning commute. -/
 @[simp] lemma init_update_cast_succ :

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -392,6 +392,9 @@ by { rw [fin.succ_above], split_ifs, refl }
 
 @[simp] lemma succ_above_zero (i : fin n) : succ_above 0 i = i.succ := rfl
 
+@[simp] lemma succ_above_last (i : fin n) : succ_above (fin.last n) i = i.cast_succ :=
+by simp only [succ_above, i.is_lt, if_true, last_val]
+
 lemma succ_above_above (p : fin (n + 1)) (i : fin n) (h : p.val ≤ i.val) :
   p.succ_above i = i.succ :=
 by { rw [fin.succ_above], split_ifs with H, { exfalso, exact nat.lt_le_antisymm H h }, refl }

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -362,6 +362,8 @@ end
 
 lemma one_pos : (0 : fin (n + 2)) < 1 := succ_pos 0
 
+lemma zero_ne_one : (0 : fin (n + 2)) ≠ 1 := ne_of_lt one_pos
+
 lemma cast_succ_fin_succ (n : ℕ) (j : fin n) :
   cast_succ (fin.succ j) = fin.succ (cast_succ j) :=
 by simp [fin.ext_iff]

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -371,7 +371,7 @@ by { rw [cast_succ, lt_iff_val_lt_val, cast_add_val, succ_val], exact lt_add_one
 
 @[simp] lemma pred_one {n : ℕ} : fin.pred (1 : fin (n + 2)) (ne.symm (ne_of_lt zero_lt_one)) = 0 := rfl
 
-lemma pred_one_add (i : fin (n + 2)) (h : i.val < n + 1) :
+lemma pred_add_one (i : fin (n + 2)) (h : i.val < n + 1) :
   pred (i + 1) (ne_of_gt (zero_lt_not_last_add_one _ (lt_iff_val_lt_val.mpr h))) = cast_lt i h :=
 by simp [eq_iff_veq, succ_pred_eq_of_pos, h, add_def, mod_eq_of_lt]
 

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -237,7 +237,7 @@ by { rw [lt_iff_val_lt_val, val_zero], exact nat.succ_pos i }
 lemma one_lt_succ_succ (a : fin n) : (1 : fin (n + 2)) < a.succ.succ :=
 by { cases n, { exact fin_zero_elim a }, { rw [←succ_zero_eq_one, succ_lt_succ_iff], exact succ_pos a } }
 
-lemma succ_succ_ne_one : fin.succ (fin.succ a) ≠ 1 := ne_of_gt (one_lt_succ_succ a)
+lemma succ_succ_ne_one (a : fin n) : fin.succ (fin.succ a) ≠ 1 := ne_of_gt (one_lt_succ_succ a)
 
 @[simp] lemma pred_val (j : fin (n+1)) (h : j ≠ 0) : (j.pred h).val = j.val.pred :=
 by cases j; simp [fin.pred]

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -14,7 +14,7 @@ This file expands on the development in the core library.
 
 ### Induction principles
 
-* `fin_zero.elim` : Elimination principle for the empty set `fin 0`, generalizes `fin.elim0`.
+* `fin_zero_elim` : Elimination principle for the empty set `fin 0`, generalizes `fin.elim0`.
 * `fin.succ_rec` : Define `C n i` by induction on  `i : fin n` interpreted
   as `(0 : fin (n - i)).succ.succ…`. This function has two arguments: `H0 n` defines
   `0`-th element `C (n+1) 0` of an `(n+1)`-tuple, and `Hs n i` defines `(i+1)`-st element
@@ -218,7 +218,7 @@ lemma mk_succ_pos (i : ℕ) (h : i < n) : (0 : fin (n + 1)) < ⟨i.succ, add_lt_
 by { rw [lt_iff_val_lt_val, val_zero], exact nat.succ_pos i }
 
 lemma one_lt_succ_succ (a : fin n) : (1 : fin (n + 2)) < a.succ.succ :=
-by { cases n, { exact fin.elim0 a }, { rw [←succ_zero_eq_one, succ_lt_succ_iff], exact succ_pos a } }
+by { cases n, { exact fin_zero_elim a }, { rw [←succ_zero_eq_one, succ_lt_succ_iff], exact succ_pos a } }
 
 lemma succ_succ_ne_one : fin.succ (fin.succ a) ≠ 1 := ne_of_gt (one_lt_succ_succ a)
 
@@ -361,7 +361,7 @@ end
 @[simp] lemma coe_succ_eq_succ : a.cast_succ + 1 = a.succ :=
 begin
   cases n,
-  { exact fin.elim0 a },
+  { exact fin_zero_elim a },
   { simp [a.is_lt, eq_iff_veq, add_def, nat.mod_eq_of_lt] }
 end
 
@@ -807,7 +807,7 @@ end
 /-- `find p` does not return `none` if and only if `p i` holds at some index `i`. -/
 lemma is_some_find_iff : Π {n : ℕ} {p : fin n → Prop} [decidable_pred p],
   by exactI (find p).is_some ↔ ∃ i, p i
-| 0     p _ := iff_of_false (λ h, bool.no_confusion h) (λ ⟨i, _⟩, fin.elim0 i)
+| 0     p _ := iff_of_false (λ h, bool.no_confusion h) (λ ⟨i, _⟩, fin_zero_elim i)
 | (n+1) p _ := ⟨λ h, begin
   rw [option.is_some_iff_exists] at h,
   cases h with i hi,

--- a/src/data/fintype/card.lean
+++ b/src/data/fintype/card.lean
@@ -95,7 +95,7 @@ theorem fin.prod_univ_cast_succ [comm_monoid β] {n:ℕ} (f : fin n.succ → β)
 begin
   rw [fin.univ_cast_succ, prod_insert, prod_image, mul_comm],
   { intros x _ y _ hxy, exact fin.cast_succ_inj.mp hxy },
-  { simpa using fin.cast_succ_ne_last }
+  { simp [ne_of_lt, fin.cast_succ_lt_last] }
 end
 
 theorem fin.sum_univ_cast_succ [add_comm_monoid β] {n:ℕ} (f : fin n.succ → β) :

--- a/src/data/matrix/notation.lean
+++ b/src/data/matrix/notation.lean
@@ -78,7 +78,7 @@ section val
 
 @[simp] lemma cons_val_zero (x : α) (u : fin m → α) : vec_cons x u 0 = x := rfl
 
-@[simp] lemma cons_val_zero' (h : 0 < m.succ) (x : α) (u : fin m → α) :
+lemma cons_val_zero' (h : 0 < m.succ) (x : α) (u : fin m → α) :
   vec_cons x u ⟨0, h⟩ = x :=
 rfl
 

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -263,6 +263,11 @@ end
 @[simp] lemma pred_one_add (n : ℕ) : pred (1 + n) = n :=
 by rw [add_comm, add_one, pred_succ]
 
+/-- Decreasing then increasing via `pred` then `succ` is idempotent
+only if the term is not 0 -/
+@[simp] lemma pred_succ_ne_zero (n : ℕ) (h : n ≠ 0) : n.pred.succ = n :=
+by { cases n, exact absurd rfl h, rw nat.pred_succ }
+
 theorem pos_iff_ne_zero : 0 < n ↔ n ≠ 0 :=
 ⟨ne_of_gt, nat.pos_of_ne_zero⟩
 

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -263,8 +263,6 @@ end
 @[simp] lemma pred_one_add (n : ℕ) : pred (1 + n) = n :=
 by rw [add_comm, add_one, pred_succ]
 
-/-- Decreasing then increasing via `pred` then `succ` is idempotent
-only if the term is not 0 -/
 @[simp] lemma succ_pred_eq_of_ne_zero (n : ℕ) (h : n ≠ 0) : n.pred.succ = n :=
 by { cases n, exact absurd rfl h, rw nat.pred_succ }
 

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -265,7 +265,7 @@ by rw [add_comm, add_one, pred_succ]
 
 /-- Decreasing then increasing via `pred` then `succ` is idempotent
 only if the term is not 0 -/
-@[simp] lemma pred_succ_ne_zero (n : ℕ) (h : n ≠ 0) : n.pred.succ = n :=
+@[simp] lemma succ_pred_eq_of_ne_zero (n : ℕ) (h : n ≠ 0) : n.pred.succ = n :=
 by { cases n, exact absurd rfl h, rw nat.pred_succ }
 
 theorem pos_iff_ne_zero : 0 < n ↔ n ≠ 0 :=

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -263,9 +263,6 @@ end
 @[simp] lemma pred_one_add (n : ℕ) : pred (1 + n) = n :=
 by rw [add_comm, add_one, pred_succ]
 
-lemma succ_pred_eq_of_ne_zero (n : ℕ) (h : n ≠ 0) : n.pred.succ = n :=
-succ_pred_eq_of_pos (nat.pos_of_ne_zero h)
-
 theorem pos_iff_ne_zero : 0 < n ↔ n ≠ 0 :=
 ⟨ne_of_gt, nat.pos_of_ne_zero⟩
 

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -263,8 +263,8 @@ end
 @[simp] lemma pred_one_add (n : ℕ) : pred (1 + n) = n :=
 by rw [add_comm, add_one, pred_succ]
 
-@[simp] lemma succ_pred_eq_of_ne_zero (n : ℕ) (h : n ≠ 0) : n.pred.succ = n :=
-by { cases n, exact absurd rfl h, rw nat.pred_succ }
+lemma succ_pred_eq_of_ne_zero (n : ℕ) (h : n ≠ 0) : n.pred.succ = n :=
+succ_pred_eq_of_pos (nat.pos_of_ne_zero h)
 
 theorem pos_iff_ne_zero : 0 < n ↔ n ≠ 0 :=
 ⟨ne_of_gt, nat.pos_of_ne_zero⟩

--- a/src/linear_algebra/multilinear.lean
+++ b/src/linear_algebra/multilinear.lean
@@ -346,7 +346,7 @@ begin
         ⟨i₀, finset.mem_univ _, _⟩,
       have : {j₂} ⊆ A i₀, by simp [hj₂],
       simp only [B, finset.card_sdiff this, function.update_same, finset.card_singleton],
-      exact nat.pred_lt (ne_of_gt (lt_trans zero_lt_one hi₀)) },
+      exact nat.pred_lt (ne_of_gt (lt_trans nat.zero_lt_one hi₀)) },
     rw h at this,
     exact IH _ this B rfl },
   -- Express the inductive assumption for `C`


### PR DESCRIPTION
Provide more API for `fin n`. Lemma names chosen to match equivalent lemmas in `nat`. Does not develop docstrings for the lemmas.

New lemmas:
iff lemmas for comparison
`ne_iff_vne`
`eq_mk_iff_coe_eq`
`succ_le_succ_iff`
`succ_lt_succ_iff`

lemmas about explicit numerals
`val_zero'`
`mk_zero`
`mk_one`
`mk_bit0`
`mk_bit1`
`cast_succ_zero`
`succ_zero_eq_one`
`zero_ne_one`
`pred_one`

lemmas about order
`zero_le`
`succ_pos`
`mk_succ_pos`
`one_pos`
`one_lt_succ_succ`
`succ_succ_ne_one`
`pred_mk_succ`
`cast_succ_lt_last`
`cast_succ_lt_succ`
`lt_succ`
`last_pos`
`le_coe_last`

coe lemmas:
`coe_eq_cast_succ`
`coe_succ_eq_succ`
`coe_nat_eq_last`

succ_above API:
`succ_above_below`
`succ_above_zero`
`succ_above_last`
`succ_above_above`
`succ_above_pos`

addition API:
`add_one_pos`
`pred_add_one`

Co-authored by: Yury Kudryashov urkud@ya.ru

---
<!-- put comments you want to keep out of the PR commit here -->
