### PR TITLE
[Merged by Bors] - refactor(data/list/tfae): tfae.out

### DIFF
--- a/src/data/list/tfae.lean
+++ b/src/data/list/tfae.lean
@@ -42,9 +42,15 @@ begin
 end
 
 theorem tfae.out {l} (h : tfae l) (n₁ n₂)
- (h₁ : n₁ < list.length l . tactic.exact_dec_trivial)
- (h₂ : n₂ < list.length l . tactic.exact_dec_trivial) :
+  (h₁ : n₁ < list.length l . tactic.exact_dec_trivial)
+  (h₂ : n₂ < list.length l . tactic.exact_dec_trivial) :
   list.nth_le l n₁ h₁ ↔ list.nth_le l n₂ h₂ :=
 h _ (list.nth_le_mem _ _ _) _ (list.nth_le_mem _ _ _)
+
+theorem tfae.out' {l} (h : tfae l) (n₁ n₂) {a b}
+  (h₁ : list.nth l n₁ = some a . tactic.interactive.refl)
+  (h₂ : list.nth l n₂ = some b . tactic.interactive.refl) :
+  a ↔ b :=
+h _ (list.nth_mem h₁) _ (list.nth_mem h₂)
 
 end list

--- a/src/data/list/tfae.lean
+++ b/src/data/list/tfae.lean
@@ -41,13 +41,7 @@ begin
   exact ⟨⟨ab, la ∘ (this.2 c (or.inl rfl) _ (ilast'_mem _ _)).1 ∘ bc⟩, this⟩
 end
 
-theorem tfae.out {l} (h : tfae l) (n₁ n₂)
-  (h₁ : n₁ < list.length l . tactic.exact_dec_trivial)
-  (h₂ : n₂ < list.length l . tactic.exact_dec_trivial) :
-  list.nth_le l n₁ h₁ ↔ list.nth_le l n₂ h₂ :=
-h _ (list.nth_le_mem _ _ _) _ (list.nth_le_mem _ _ _)
-
-theorem tfae.out' {l} (h : tfae l) (n₁ n₂) {a b}
+theorem tfae.out {l} (h : tfae l) (n₁ n₂) {a b}
   (h₁ : list.nth l n₁ = some a . tactic.interactive.refl)
   (h₂ : list.nth l n₂ = some b . tactic.interactive.refl) :
   a ↔ b :=


### PR DESCRIPTION
This version of `tfae.out` has slightly better automatic reduction behavior: if `h : [a, b, c].tfae` then the original of `h.out 1 2` proves `[a, b, c].nth_le 1 _ <-> [a, b, c].nth_le 2 _` while the new version of `h.out 1 2` proves `b <-> c`. These are the same, of course, and you can mostly use them interchangeably, but the second one is a bit nicer to look at (and possibly works better with e.g. subsequent rewrites).