### PR TITLE
[Merged by Bors] - chore(algebra/classical_lie_algebras): fix some doc strings

### DIFF
--- a/src/algebra/classical_lie_algebras.lean
+++ b/src/algebra/classical_lie_algebras.lean
@@ -43,10 +43,10 @@ which approach should be preferred so the choice should be assumed to be somewha
 For the algebras of type `B` and `D`, there are two natural definitions. For example since the
 the `2l × 2l` matrix:
 $$
-  J = \left[\begin{align}{cc}
-              0_l & 1_l\\
+  J = \left[\begin{array}{cc}
+              0_l & 1_l\\\\
               1_l & 0_l
-            \end{align}\right]
+            \end{array}\right]
 $$
 defines a symmetric bilinear form equivalent to that defined by the identity matrix `I`, we can
 define the algebras of type `D` to be the Lie subalgebra of skew-adjoint matrices either for `J` or
@@ -221,7 +221,8 @@ by erw [lie_algebra.equiv.trans_apply, lie_algebra.equiv.of_eq_apply,
 /-- A matrix defining a canonical even-rank symmetric bilinear form.
 
 It looks like this as a `2l x 2l` matrix of `l x l` blocks:
-   [ 0 1 ]
+
+   [ 0 1 ]  
    [ 1 0 ]
 -/
 def JD : matrix (l ⊕ l) (l ⊕ l) R := matrix.from_blocks 0 1 1 0
@@ -234,7 +235,8 @@ def type_D := skew_adjoint_matrices_lie_subalgebra (JD l R)
 diagonal matrix.
 
 It looks like this as a `2l x 2l` matrix of `l x l` blocks:
-   [ 1 -1 ]
+
+   [ 1 -1 ]  
    [ 1  1 ]
 -/
 def PD : matrix (l ⊕ l) (l ⊕ l) R := matrix.from_blocks 1 (-1) 1 1
@@ -287,12 +289,15 @@ end
 /-- A matrix defining a canonical odd-rank symmetric bilinear form.
 
 It looks like this as a `(2l+1) x (2l+1)` matrix of blocks:
-   [ 2 0 0 ]
-   [ 0 0 1 ]
+
+   [ 2 0 0 ]  
+   [ 0 0 1 ]  
    [ 0 1 0 ]
+
 where sizes of the blocks are:
-   [`1 x 1` `1 x l` `1 x l`]
-   [`l x 1` `l x l` `l x l`]
+
+   [`1 x 1` `1 x l` `1 x l`]  
+   [`l x 1` `l x l` `l x l`]  
    [`l x 1` `l x l` `l x l`]
 -/
 def JB := matrix.from_blocks ((2 : R) • 1 : matrix punit punit R) 0 0 (JD l R)
@@ -305,12 +310,15 @@ def type_B := skew_adjoint_matrices_lie_subalgebra (JB l R)
 almost-split-signature diagonal matrix.
 
 It looks like this as a `(2l+1) x (2l+1)` matrix of blocks:
-   [ 1 0  0 ]
-   [ 0 1 -1 ]
+
+   [ 1 0  0 ]  
+   [ 0 1 -1 ]  
    [ 0 1  1 ]
+
 where sizes of the blocks are:
-   [`1 x 1` `1 x l` `1 x l`]
-   [`l x 1` `l x l` `l x l`]
+
+   [`1 x 1` `1 x l` `1 x l`]  
+   [`l x 1` `l x l` `l x l`]  
    [`l x 1` `l x l` `l x l`]
 -/
 def PB := matrix.from_blocks (1 : matrix punit punit R) 0 0 (PD l R)

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -2099,7 +2099,7 @@ begin
 end
 
 /-- Given modules `M`, `M₂` over a commutative ring, together with submodules `p ⊆ M`, `q ⊆ M₂`, the
-set of maps $\{f ∈ Hom(M, M₂) | f(p) ⊆ q \}$ is a submodule of `Hom(M, M₂)`. -/
+set of maps $\\{f ∈ Hom(M, M₂) | f(p) ⊆ q \\}$ is a submodule of `Hom(M, M₂)`. -/
 def compatible_maps : submodule R (M →ₗ[R] M₂) :=
 { carrier   := {f | p ≤ comap f q},
   zero_mem' := by { change p ≤ comap 0 q, rw comap_zero, refine le_top, },
@@ -2108,7 +2108,7 @@ def compatible_maps : submodule R (M →ₗ[R] M₂) :=
   smul_mem' := λ c f h, le_trans h (comap_le_comap_smul q f c), }
 
 /-- Given modules `M`, `M₂` over a commutative ring, together with submodules `p ⊆ M`, `q ⊆ M₂`, the
-natural map $\{f ∈ Hom(M, M₂) | f(p) ⊆ q \} \to Hom(M/p, M₂/q)$ is linear. -/
+natural map $\\{f ∈ Hom(M, M₂) | f(p) ⊆ q \\} \to Hom(M/p, M₂/q)$ is linear. -/
 def mapq_linear : compatible_maps p q →ₗ[R] p.quotient →ₗ[R] q.quotient :=
 { to_fun    := λ f, mapq _ _ f.val f.property,
   map_add'  := λ x y, by { ext m', apply quotient.induction_on' m', intros m, refl, },


### PR DESCRIPTION
---
While admiring my own work by reading the [docs on the classical Lie algebras](https://leanprover-community.github.io/mathlib_docs/algebra/classical_lie_algebras.html) I noticed the horrible `align` instead of `array` bug which I fix here. The other fixes are very minor, and I'm only about 90% confident they are correct.

I did test with https://observablehq.com/@bryangingechen/github-lean-file-viewer and it disagrees about the double `\`s but I _think_ it's wrong about this.
