### PR TITLE
[Merged by Bors] - refactor(algebra/gcd_monoid, ring_theory/multiplicity): generalize normalization_domain, gcd_domain, multiplicity

### DIFF
--- a/scripts/nolints.txt
+++ b/scripts/nolints.txt
@@ -33,11 +33,6 @@ apply_nolint euclidean_domain.xgcd_aux doc_blame
 apply_nolint division_ring doc_blame
 apply_nolint field doc_blame
 
--- algebra/gcd_monoid.lean
-apply_nolint associates.out doc_blame
-apply_nolint associates_int_equiv_nat doc_blame
-apply_nolint normalize doc_blame
-
 -- algebra/group/defs.lean
 apply_nolint algebra.sub doc_blame
 

--- a/scripts/nolints.txt
+++ b/scripts/nolints.txt
@@ -33,7 +33,7 @@ apply_nolint euclidean_domain.xgcd_aux doc_blame
 apply_nolint division_ring doc_blame
 apply_nolint field doc_blame
 
--- algebra/gcd_domain.lean
+-- algebra/gcd_monoid.lean
 apply_nolint associates.out doc_blame
 apply_nolint associates_int_equiv_nat doc_blame
 apply_nolint normalize doc_blame

--- a/scripts/nolints.txt
+++ b/scripts/nolints.txt
@@ -33,6 +33,11 @@ apply_nolint euclidean_domain.xgcd_aux doc_blame
 apply_nolint division_ring doc_blame
 apply_nolint field doc_blame
 
+-- algebra/gcd_domain.lean
+apply_nolint associates.out doc_blame
+apply_nolint associates_int_equiv_nat doc_blame
+apply_nolint normalize doc_blame
+
 -- algebra/group/defs.lean
 apply_nolint algebra.sub doc_blame
 
@@ -2105,4 +2110,3 @@ apply_nolint uniform_space.completion.map₂ doc_blame
 
 -- topology/uniform_space/uniform_embedding.lean
 apply_nolint uniform_embedding doc_blame
-apply_nolint uniform_inducing doc_blame

--- a/scripts/nolints.txt
+++ b/scripts/nolints.txt
@@ -2110,3 +2110,4 @@ apply_nolint uniform_space.completion.map₂ doc_blame
 
 -- topology/uniform_space/uniform_embedding.lean
 apply_nolint uniform_embedding doc_blame
+apply_nolint uniform_inducing doc_blame

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -412,10 +412,10 @@ multiset.induction_on p
   (by simp)
   (by simp [mul_eq_one_iff, or_imp_distrib, forall_and_distrib] {contextual := tt})
 
-@[simp] theorem associates.units_eq_one (u : units (associates α)) : u = 1 :=
+@[simp] theorem units_eq_one (u : units (associates α)) : u = 1 :=
 units.ext (mul_eq_one_iff.1 u.val_inv).1
 
-instance associates.unique_units [comm_monoid α] : unique (units (associates α)) :=
+instance unique_units [comm_monoid α] : unique (units (associates α)) :=
 { default := 1, uniq := associates.units_eq_one }
 
 theorem coe_unit_eq_one (u : units (associates α)): (u : associates α) = 1 :=

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -412,10 +412,10 @@ multiset.induction_on p
   (by simp)
   (by simp [mul_eq_one_iff, or_imp_distrib, forall_and_distrib] {contextual := tt})
 
-@[simp] theorem units_eq_one (u : units (associates α)) : u = 1 :=
+theorem units_eq_one (u : units (associates α)) : u = 1 :=
 units.ext (mul_eq_one_iff.1 u.val_inv).1
 
-instance unique_units [comm_monoid α] : unique (units (associates α)) :=
+instance unique_units : unique (units (associates α)) :=
 { default := 1, uniq := associates.units_eq_one }
 
 theorem coe_unit_eq_one (u : units (associates α)): (u : associates α) = 1 :=

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -412,8 +412,14 @@ multiset.induction_on p
   (by simp)
   (by simp [mul_eq_one_iff, or_imp_distrib, forall_and_distrib] {contextual := tt})
 
-theorem coe_unit_eq_one : ∀u:units (associates α), (u : associates α) = 1
-| ⟨u, v, huv, hvu⟩ := by rw [mul_eq_one_iff] at huv; exact huv.1
+@[simp] theorem associates.units_eq_one (u : units (associates α)) : u = 1 :=
+units.ext (mul_eq_one_iff.1 u.val_inv).1
+
+instance associates.unique_units [comm_monoid α] : unique (units (associates α)) :=
+{ default := 1, uniq := associates.units_eq_one }
+
+theorem coe_unit_eq_one (u : units (associates α)): (u : associates α) = 1 :=
+by simp
 
 theorem is_unit_iff_eq_one (a : associates α) : is_unit a ↔ a = 1 :=
 iff.intro

--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -3,9 +3,9 @@ Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Jens Wagemaker
 
-GCD domain and integral domains with normalization functions
+GCD monoid and integral monoids with normalization functions
 
-TODO: abstract the domains to semi domains (i.e. domains on semirings) to include ℕ and ℕ[X] etc.
+TODO: abstract the monoids to semi monoids (i.e. monoids on semirings) to include ℕ and ℕ[X] etc.
 -/
 import algebra.associated
 import data.nat.basic
@@ -19,23 +19,34 @@ set_option old_structure_cmd true
 
 section prio
 set_option default_priority 100 -- see Note [default priority]
-/-- Normalization domain: multiplying with `norm_unit` gives a normal form for associated elements. -/
-@[protect_proj] class normalization_domain (α : Type*) extends integral_domain α :=
+/-- Normalization monoid: multiplying with `norm_unit` gives a normal form for associated elements. -/
+@[protect_proj] class normalization_monoid (α : Type*) [nontrivial α]
+  [comm_cancel_monoid_with_zero α] :=
 (norm_unit : α → units α)
 (norm_unit_zero      : norm_unit 0 = 1)
 (norm_unit_mul       : ∀{a b}, a ≠ 0 → b ≠ 0 → norm_unit (a * b) = norm_unit a * norm_unit b)
 (norm_unit_coe_units : ∀(u : units α), norm_unit u = u⁻¹)
 end prio
 
-export normalization_domain (norm_unit norm_unit_zero norm_unit_mul norm_unit_coe_units)
+export normalization_monoid (norm_unit norm_unit_zero norm_unit_mul norm_unit_coe_units)
 
 attribute [simp] norm_unit_coe_units norm_unit_zero norm_unit_mul
 
-section normalization_domain
-variable [normalization_domain α]
+section normalization_monoid
+variables [comm_cancel_monoid_with_zero α] [nontrivial α] [normalization_monoid α]
 
-def normalize (x : α) : α :=
-x * norm_unit x
+@[simp] theorem norm_unit_one : norm_unit (1:α) = 1 :=
+norm_unit_coe_units 1
+
+def normalize : α →* α :=
+{ to_fun := λ x, x * norm_unit x,
+  map_one' := by rw [norm_unit_one, units.coe_one, mul_one],
+  map_mul' := λ x y,
+  classical.by_cases (λ hx : x = 0, by rw [hx, zero_mul, zero_mul, zero_mul]) $ λ hx,
+  classical.by_cases (λ hy : y = 0, by rw [hy, mul_zero, zero_mul, mul_zero]) $ λ hy,
+  by simp only [norm_unit_mul hx hy, units.coe_mul]; simp only [mul_assoc, mul_left_comm y], }
+
+@[simp] lemma normalize_apply {x : α} : normalize x = x * norm_unit x := rfl
 
 theorem associated_normalize {x : α} : associated x (normalize x) :=
 ⟨_, rfl⟩
@@ -43,22 +54,13 @@ theorem associated_normalize {x : α} : associated x (normalize x) :=
 theorem normalize_associated {x : α} : associated (normalize x) x :=
 associated_normalize.symm
 
-@[simp] theorem norm_unit_one : norm_unit (1:α) = 1 :=
-norm_unit_coe_units 1
-
 @[simp] lemma normalize_zero : normalize (0 : α) = 0 :=
-by rw [normalize, zero_mul]
+by rw [normalize_apply, zero_mul]
 
-@[simp] lemma normalize_one : normalize (1 : α) = 1 :=
-by rw [normalize, norm_unit_one, units.coe_one, mul_one]
+@[simp] lemma normalize_one : normalize (1 : α) = 1 := normalize.map_one
 
 lemma normalize_coe_units (u : units α) : normalize (u : α) = 1 :=
-by rw [normalize, norm_unit_coe_units, ← units.coe_mul, mul_inv_self, units.coe_one]
-
-theorem normalize_mul (x y : α) : normalize (x * y) = normalize x * normalize y :=
-classical.by_cases (λ hx : x = 0, by rw [hx, zero_mul, normalize_zero, zero_mul]) $ λ hx,
-classical.by_cases (λ hy : y = 0, by rw [hy, mul_zero, normalize_zero, mul_zero]) $ λ hy,
-by simp only [normalize, norm_unit_mul hx hy, units.coe_mul]; simp only [mul_assoc, mul_left_comm y]
+by rw [normalize_apply, norm_unit_coe_units, ← units.coe_mul, mul_inv_self, units.coe_one]
 
 lemma normalize_eq_zero {x : α} : normalize x = 0 ↔ x = 0 :=
 ⟨λ hx, (associated_zero_iff_eq_zero x).1 $ hx ▸ associated_normalize, by rintro rfl; exact normalize_zero⟩
@@ -71,7 +73,7 @@ classical.by_cases (assume : a = 0, by simp only [this, norm_unit_zero, zero_mul
   assume h, by rw [norm_unit_mul h (units.ne_zero _), norm_unit_coe_units, mul_inv_eq_one]
 
 theorem normalize_idem (x : α) : normalize (normalize x) = normalize x :=
-by rw [normalize, normalize, norm_unit_mul_norm_unit, units.coe_one, mul_one]
+by rw [normalize_apply, normalize_apply, norm_unit_mul_norm_unit, units.coe_one, mul_one]
 
 theorem normalize_eq_normalize {a b : α}
   (hab : a ∣ b) (hba : b ∣ a) : normalize a = normalize b :=
@@ -79,7 +81,7 @@ begin
   rcases associated_of_dvd_dvd hab hba with ⟨u, rfl⟩,
   refine classical.by_cases (by rintro rfl; simp only [zero_mul]) (assume ha : a ≠ 0, _),
   suffices : a * ↑(norm_unit a) = a * ↑u * ↑(norm_unit a) * ↑u⁻¹,
-    by simpa only [normalize, mul_assoc, norm_unit_mul ha u.ne_zero, norm_unit_coe_units],
+    by simpa only [normalize_apply, mul_assoc, norm_unit_mul ha u.ne_zero, norm_unit_coe_units],
   calc a * ↑(norm_unit a) = a * ↑(norm_unit a) * ↑u * ↑u⁻¹:
       (units.mul_inv_cancel_right _ _).symm
     ... = a * ↑u * ↑(norm_unit a) * ↑u⁻¹ : by rw mul_right_comm a
@@ -100,10 +102,10 @@ units.dvd_mul_right
 @[simp] lemma normalize_dvd_iff {a b : α} : normalize a ∣ b ↔ a ∣ b :=
 units.mul_right_dvd
 
-end normalization_domain
+end normalization_monoid
 
 namespace associates
-variable [normalization_domain α]
+variables [comm_cancel_monoid_with_zero α] [nontrivial α] [normalization_monoid α]
 
 local attribute [instance] associated.setoid
 
@@ -118,7 +120,7 @@ normalize_one
 
 lemma out_mul (a b : associates α) : (a * b).out = a.out * b.out :=
 quotient.induction_on₂ a b $ assume a b,
-by simp only [associates.quotient_mk_eq_mk, out_mk, mk_mul_mk, normalize_mul]
+by simp only [associates.quotient_mk_eq_mk, out_mk, mk_mul_mk, normalize.map_mul]
 
 lemma dvd_out_iff (a : α) (b : associates α) : a ∣ b.out ↔ associates.mk a ≤ b :=
 quotient.induction_on b $ by simp [associates.out_mk, associates.quotient_mk_eq_mk, mk_le_mk_iff_dvd_iff]
@@ -136,12 +138,13 @@ end associates
 
 section prio
 set_option default_priority 100 -- see Note [default priority]
-/-- GCD domain: an integral domain with normalization and `gcd` (greatest common divisor) and
+/-- GCD monoid: an integral monoid with normalization and `gcd` (greatest common divisor) and
 `lcm` (least common multiple) operations. In this setting `gcd` and `lcm` form a bounded lattice on
 the associated elements where `gcd` is the infimum, `lcm` is the supremum, `1` is bottom, and
 `0` is top. The type class focuses on `gcd` and we derive the correpsonding `lcm` facts from `gcd`.
 -/
-@[protect_proj] class gcd_domain (α : Type*) extends normalization_domain α :=
+@[protect_proj] class gcd_monoid (α : Type*) [comm_cancel_monoid_with_zero α] [nontrivial α]
+  extends normalization_monoid α :=
 (gcd : α → α → α)
 (lcm : α → α → α)
 (gcd_dvd_left   : ∀a b, gcd a b ∣ a)
@@ -153,18 +156,18 @@ the associated elements where `gcd` is the infimum, `lcm` is the supremum, `1` i
 (lcm_zero_right : ∀a, lcm a 0 = 0)
 end prio
 
-export gcd_domain (gcd lcm gcd_dvd_left gcd_dvd_right dvd_gcd  lcm_zero_left lcm_zero_right)
+export gcd_monoid (gcd lcm gcd_dvd_left gcd_dvd_right dvd_gcd  lcm_zero_left lcm_zero_right)
 
 attribute [simp] lcm_zero_left lcm_zero_right
 
-section gcd_domain
-variables [gcd_domain α]
+section gcd_monoid
+variables [comm_cancel_monoid_with_zero α] [nontrivial α] [gcd_monoid α]
 
 @[simp] theorem normalize_gcd : ∀a b:α, normalize (gcd a b) = gcd a b :=
-gcd_domain.normalize_gcd
+gcd_monoid.normalize_gcd
 
 @[simp] theorem gcd_mul_lcm : ∀a b:α, gcd a b * lcm a b = normalize (a * b) :=
-gcd_domain.gcd_mul_lcm
+gcd_monoid.gcd_mul_lcm
 
 section gcd
 
@@ -221,7 +224,7 @@ gcd_eq_normalize (gcd_dvd_left _ _) (dvd_gcd (dvd_refl a) (dvd_refl a))
 @[simp] theorem gcd_mul_left (a b c : α) : gcd (a * b) (a * c) = normalize a * gcd b c :=
 classical.by_cases (by rintro rfl; simp only [zero_mul, gcd_zero_left, normalize_zero]) $ assume ha : a ≠ 0,
 suffices gcd (a * b) (a * c) = normalize (a * gcd b c),
-  by simpa only [normalize_mul, normalize_gcd],
+  by simpa only [normalize.map_mul, normalize_gcd],
 let ⟨d, eq⟩ := dvd_gcd (dvd_mul_right a b) (dvd_mul_right a c) in
 gcd_eq_normalize
   (eq.symm ▸ mul_dvd_mul_left a $ show d ∣ gcd b c, from
@@ -267,7 +270,7 @@ classical.by_cases
     let ⟨h1, h2⟩ := not_or_distrib.1 this in
     have h : gcd a b ≠ 0, from λ H, h1 ((gcd_eq_zero_iff _ _).1 H).1,
     by rw [← mul_dvd_mul_iff_left h, gcd_mul_lcm, normalize_dvd_iff, ← dvd_normalize_iff,
-        normalize_mul, normalize_gcd, ← gcd_mul_right, dvd_gcd_iff,
+        normalize.map_mul, normalize_gcd, ← gcd_mul_right, dvd_gcd_iff,
         mul_comm b c, mul_dvd_mul_iff_left h1, mul_dvd_mul_iff_right h2, and_comm])
 
 lemma dvd_lcm_left (a b : α) : a ∣ lcm a b := (lcm_dvd_iff.1 (dvd_refl _)).1
@@ -292,7 +295,7 @@ classical.by_cases (assume : lcm a b = 0, by rw [this, normalize_zero]) $
     rintros ⟨rfl, rfl⟩; left; refl) h_lcm,
   have h2 : normalize (gcd a b * lcm a b) = gcd a b * lcm a b,
     by rw [gcd_mul_lcm, normalize_idem],
-  by simpa only [normalize_mul, normalize_gcd, one_mul, mul_right_inj' h1] using h2
+  by simpa only [normalize.map_mul, normalize_gcd, one_mul, mul_right_inj' h1] using h2
 
 theorem lcm_comm (a b : α) : lcm a b = lcm b a :=
 dvd_antisymm_of_normalize_eq (normalize_lcm _ _) (normalize_lcm _ _)
@@ -343,7 +346,7 @@ iff.intro
 @[simp] theorem lcm_mul_left (a b c : α) : lcm (a * b) (a * c) = normalize a * lcm b c :=
 classical.by_cases (by rintro rfl; simp only [zero_mul, lcm_zero_left, normalize_zero]) $ assume ha : a ≠ 0,
 suffices lcm (a * b) (a * c) = normalize (a * lcm b c),
-  by simpa only [normalize_mul, normalize_lcm],
+  by simpa only [normalize.map_mul, normalize_lcm],
 have a ∣ lcm (a * b) (a * c), from dvd.trans (dvd_mul_right _ _) (dvd_lcm_left _ _),
 let ⟨d, eq⟩ := this in
 lcm_eq_normalize
@@ -376,13 +379,13 @@ lcm_dvd_lcm (dvd_refl _) (dvd_mul_right _ _)
 
 end lcm
 
-end gcd_domain
+end gcd_monoid
 
 namespace int
 
-section normalization_domain
+section normalization_monoid
 
-instance : normalization_domain ℤ :=
+instance : normalization_monoid ℤ :=
 { norm_unit      := λa:ℤ, if 0 ≤ a then 1 else -1,
   norm_unit_zero := if_pos (le_refl _),
   norm_unit_mul  := assume a b hna hnb,
@@ -395,8 +398,7 @@ instance : normalization_domain ℤ :=
   end,
   norm_unit_coe_units := assume u, (units_eq_one_or u).elim
     (assume eq, eq.symm ▸ if_pos zero_le_one)
-    (assume eq, eq.symm ▸ if_neg (not_le_of_gt $ show (-1:ℤ) < 0, by simp [@neg_lt ℤ _ 1 0])),
-  .. (infer_instance : integral_domain ℤ) }
+    (assume eq, eq.symm ▸ if_neg (not_le_of_gt $ show (-1:ℤ) < 0, by simp [@neg_lt ℤ _ 1 0])), }
 
 lemma normalize_of_nonneg {z : ℤ} (h : 0 ≤ z) : normalize z = z :=
 show z * ↑(ite _ _ _) = z, by rw [if_pos h, units.coe_one, mul_one]
@@ -414,14 +416,14 @@ begin
   { simp [of_nat_nat_abs_of_nonpos (le_of_not_ge h), normalize_of_neg (lt_of_not_ge h)] }
 end
 
-end normalization_domain
+end normalization_monoid
 
 /-- ℤ specific version of least common multiple. -/
 def lcm (i j : ℤ) : ℕ := nat.lcm (nat_abs i) (nat_abs j)
 
 theorem lcm_def (i j : ℤ) : lcm i j = nat.lcm (nat_abs i) (nat_abs j) := rfl
 
-section gcd_domain
+section gcd_monoid
 
 theorem gcd_dvd_left (i j : ℤ) : (gcd i j : ℤ) ∣ i :=
 dvd_nat_abs.mp $ coe_nat_dvd.mpr $ nat.gcd_dvd_left _ _
@@ -435,7 +437,7 @@ nat_abs_dvd.1 $ coe_nat_dvd.2 $ nat.dvd_gcd (nat_abs_dvd_abs_iff.2 h1) (nat_abs_
 theorem gcd_mul_lcm (i j : ℤ) : gcd i j * lcm i j = nat_abs (i * j) :=
 by rw [int.gcd, int.lcm, nat.gcd_mul_lcm, nat_abs_mul]
 
-instance : gcd_domain ℤ :=
+instance : gcd_monoid ℤ :=
 { gcd            := λa b, int.gcd a b,
   lcm            := λa b, int.lcm a b,
   gcd_dvd_left   := assume a b, int.gcd_dvd_left _ _,
@@ -445,15 +447,15 @@ instance : gcd_domain ℤ :=
   gcd_mul_lcm    := by intros; rw [← int.coe_nat_mul, gcd_mul_lcm, coe_nat_abs_eq_normalize],
   lcm_zero_left  := assume a, coe_nat_eq_zero.2 $ nat.lcm_zero_left _,
   lcm_zero_right := assume a, coe_nat_eq_zero.2 $ nat.lcm_zero_right _,
-  .. int.normalization_domain }
+  .. int.normalization_monoid }
 
-lemma coe_gcd (i j : ℤ) : ↑(int.gcd i j) = gcd_domain.gcd i j := rfl
-lemma coe_lcm (i j : ℤ) : ↑(int.lcm i j) = gcd_domain.lcm i j := rfl
+lemma coe_gcd (i j : ℤ) : ↑(int.gcd i j) = gcd_monoid.gcd i j := rfl
+lemma coe_lcm (i j : ℤ) : ↑(int.lcm i j) = gcd_monoid.lcm i j := rfl
 
-lemma nat_abs_gcd (i j : ℤ) : nat_abs (gcd_domain.gcd i j) = int.gcd i j := rfl
-lemma nat_abs_lcm (i j : ℤ) : nat_abs (gcd_domain.lcm i j) = int.lcm i j := rfl
+lemma nat_abs_gcd (i j : ℤ) : nat_abs (gcd_monoid.gcd i j) = int.gcd i j := rfl
+lemma nat_abs_lcm (i j : ℤ) : nat_abs (gcd_monoid.lcm i j) = int.lcm i j := rfl
 
-end gcd_domain
+end gcd_monoid
 
 theorem gcd_comm (i j : ℤ) : gcd i j = gcd j i := nat.gcd_comm _ _
 
@@ -626,8 +628,8 @@ begin
       associates.mk_eq_mk_iff_associated.2 $ associated.symm $ ⟨norm_unit a, _⟩),
     show normalize a = int.nat_abs (normalize a),
     rw [int.coe_nat_abs_eq_normalize, normalize_idem] },
-  { assume n, show int.nat_abs (normalize n) = n,
-    rw [← int.coe_nat_abs_eq_normalize, int.nat_abs_of_nat, int.nat_abs_of_nat] }
+  { intro n, dsimp, rw [associates.out_mk ↑n,
+    ← int.coe_nat_abs_eq_normalize, int.nat_abs_of_nat, int.nat_abs_of_nat] }
 end
 
 lemma int.prime.dvd_mul {m n : ℤ} {p : ℕ}

--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -411,6 +411,7 @@ lcm_dvd_lcm (dvd_refl _) (dvd_mul_right _ _)
 
 end lcm
 
+namespace gcd_monoid
 theorem prime_of_irreducible {x : α} (hi: irreducible x) : prime x :=
 begin
   split, apply hi.ne_zero, --unfold irreducible at hi,
@@ -425,9 +426,10 @@ begin
     transitivity, {apply dvd_of_associated, symmetry, use u}, apply gcd_dvd_right, }
 end
 
-theorem gcd_monoid.irreducible_iff_prime {p : α} : irreducible p ↔ prime p :=
+theorem irreducible_iff_prime {p : α} : irreducible p ↔ prime p :=
 ⟨prime_of_irreducible, irreducible_of_prime⟩
 
+end gcd_monoid
 end gcd_monoid
 
 namespace int

--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -13,7 +13,7 @@ import data.int.gcd
 
 /-!
 
-# Monoids with Normalization Functions, GCD, and LCM
+# Monoids with normalization functions, `gcd`, and `lcm`
 
 This file defines extra structures on `comm_cancel_monoid_with_zero`s, including `integral_domain`s.
 
@@ -31,6 +31,13 @@ definition as currently implemented does casework on `0`.
 * `gcd_monoid` extends `normalization_monoid`, so the `gcd` and `lcm` are always normalized.
 This makes `gcd`s of polynomials easier to work with, but excludes Euclidean domains, and monoids
 without zero.
+
+## TODO
+
+* Provide a GCD monoid instance for `ℕ`, port GCD facts about nats, definition of coprime
+* Generalize normalization monoids to commutative (cancellative) monoids with or without zero
+* Generalize GCD monoid to not require normalization in all cases
+
 
 ## Tags
 
@@ -162,10 +169,11 @@ end associates
 
 section prio
 set_option default_priority 100 -- see Note [default priority]
-/-- GCD monoid: an `comm_cancel_monoid_with_zero` with normalization and `gcd` (greatest common divisor) and
-`lcm` (least common multiple) operations. In this setting `gcd` and `lcm` form a bounded lattice on
-the associated elements where `gcd` is the infimum, `lcm` is the supremum, `1` is bottom, and
-`0` is top. The type class focuses on `gcd` and we derive the correpsonding `lcm` facts from `gcd`.
+/-- GCD monoid: a `comm_cancel_monoid_with_zero` with normalization and `gcd`
+(greatest common divisor) and `lcm` (least common multiple) operations. In this setting `gcd` and
+`lcm` form a bounded lattice on the associated elements where `gcd` is the infimum, `lcm` is the
+supremum, `1` is bottom, and `0` is top. The type class focuses on `gcd` and we derive the
+corresponding `lcm` facts from `gcd`.
 -/
 @[protect_proj] class gcd_monoid (α : Type*) [comm_cancel_monoid_with_zero α] [nontrivial α]
   extends normalization_monoid α :=

--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -96,10 +96,10 @@ theorem dvd_antisymm_of_normalize_eq {a b : α}
   a = b :=
 ha ▸ hb ▸ normalize_eq_normalize hab hba
 
-@[simp] lemma dvd_normalize_iff {a b : α} : a ∣ normalize b ↔ a ∣ b :=
+lemma dvd_normalize_iff {a b : α} : a ∣ normalize b ↔ a ∣ b :=
 units.dvd_mul_right
 
-@[simp] lemma normalize_dvd_iff {a b : α} : normalize a ∣ b ↔ a ∣ b :=
+lemma normalize_dvd_iff {a b : α} : normalize a ∣ b ↔ a ∣ b :=
 units.mul_right_dvd
 
 end normalization_monoid

--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -128,9 +128,11 @@ theorem dvd_antisymm_of_normalize_eq {a b : α}
   a = b :=
 ha ▸ hb ▸ normalize_eq_normalize hab hba
 
+--can be proven by simp
 lemma dvd_normalize_iff {a b : α} : a ∣ normalize b ↔ a ∣ b :=
 units.dvd_mul_right
 
+--can be proven by simp
 lemma normalize_dvd_iff {a b : α} : normalize a ∣ b ↔ a ∣ b :=
 units.mul_right_dvd
 
@@ -415,9 +417,8 @@ end lcm
 
 namespace gcd_monoid
 theorem prime_of_irreducible {x : α} (hi: irreducible x) : prime x :=
+⟨hi.ne_zero, ⟨hi.1, λ a b h,
 begin
-  split, apply hi.ne_zero, --unfold irreducible at hi,
-  split, apply hi.1, intros a b h,
   cases gcd_dvd_left x a with y hy,
   cases hi.2 _ _ hy with hu hu; cases hu with u hu,
   { right, transitivity (gcd (x * b) (a * b)), apply dvd_gcd (dvd_mul_right x b) h,
@@ -426,7 +427,7 @@ begin
     apply normalize_associated, },
   { left, rw [hy, ← hu],
     transitivity, {apply dvd_of_associated, symmetry, use u}, apply gcd_dvd_right, }
-end
+end ⟩⟩
 
 theorem irreducible_iff_prime {p : α} : irreducible p ↔ prime p :=
 ⟨prime_of_irreducible, irreducible_of_prime⟩

--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -670,13 +670,16 @@ instance nat.unique_units : unique (units ℕ) :=
 
 variables [comm_cancel_monoid_with_zero α] [nontrivial α] [unique (units α)]
 
-@[simp] lemma units_eq_one (u : units α) : u = 1 := subsingleton.elim u 1
+lemma units_eq_one (u : units α) : u = 1 := subsingleton.elim u 1
 
+section prio
+set_option default_priority 100 -- see Note [default priority]
 instance normalization_monoid_of_unique_units : normalization_monoid α :=
 { norm_unit := λ x, 1,
   norm_unit_zero := rfl,
   norm_unit_mul := λ x y hx hy, (mul_one 1).symm,
-  norm_unit_coe_units := λ u, by simp, }
+  norm_unit_coe_units := λ u, subsingleton.elim _ _ }
+end prio
 
 @[simp] lemma norm_unit_eq_one (x : α) : norm_unit x = 1 := rfl
 

--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -72,6 +72,7 @@ variables [comm_cancel_monoid_with_zero α] [nontrivial α] [normalization_monoi
 @[simp] theorem norm_unit_one : norm_unit (1:α) = 1 :=
 norm_unit_coe_units 1
 
+/-- Chooses an element of each associate class, by multiplying by `norm_unit` -/
 def normalize : α →* α :=
 { to_fun := λ x, x * norm_unit x,
   map_one' := by rw [norm_unit_one, units.coe_one, mul_one],
@@ -140,6 +141,7 @@ variables [comm_cancel_monoid_with_zero α] [nontrivial α] [normalization_monoi
 
 local attribute [instance] associated.setoid
 
+/-- Maps an element of `associates` back to the normalized element of its associate class -/
 protected def out : associates α → α :=
 quotient.lift (normalize : α → α) $ λ a b ⟨u, hu⟩, hu ▸
 normalize_eq_normalize ⟨_, rfl⟩ (units.mul_right_dvd.2 $ dvd_refl a)
@@ -672,6 +674,7 @@ lemma nat.prime_iff_prime_int {p : ℕ} : p.prime ↔ _root_.prime (p : ℤ) :=
       mt nat.is_unit_iff.1 $ λ h, by simpa [h, not_prime_one] using hp,
     λ a b, by simpa only [int.coe_nat_dvd, (int.coe_nat_mul _ _).symm] using hp.2.2 a b⟩⟩
 
+/-- Maps an associate class of integers consisting of `-n, n` to `n : ℕ` -/
 def associates_int_equiv_nat : associates ℤ ≃ ℕ :=
 begin
   refine ⟨λz, z.out.nat_abs, λn, associates.mk n, _, _⟩,

--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -668,9 +668,11 @@ section unique_unit
 instance nat.unique_units : unique (units ℕ) :=
 { default := 1, uniq := nat.units_eq_one }
 
-variables [comm_cancel_monoid_with_zero α] [nontrivial α] [unique (units α)]
+variables [comm_cancel_monoid_with_zero α] [unique (units α)]
 
 lemma units_eq_one (u : units α) : u = 1 := subsingleton.elim u 1
+
+variable [nontrivial α]
 
 section prio
 set_option default_priority 100 -- see Note [default priority]

--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -3,13 +3,39 @@ Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Jens Wagemaker
 
-GCD monoid and integral monoids with normalization functions
-
-TODO: abstract the monoids to semi monoids (i.e. monoids on semirings) to include ℕ and ℕ[X] etc.
+TODO: Provide a GCD monoid instance for `ℕ`, port GCD facts about nats
+TODO: Generalize normalization monoids commutative (cancellative) monoids with or without zero
+TODO: Generalize GCD monoid to not require normalization in all cases
 -/
 import algebra.associated
 import data.nat.basic
 import data.int.gcd
+
+/-!
+
+# Monoids with Normalization Functions, GCD, and LCM
+
+This file defines extra structures on `comm_cancel_monoid_with_zero`s, including `integral_domain`s.
+
+## Main Definitions
+
+* `normalization_monoid`
+* `gcd_monoid`
+
+## Implementation Notes
+
+* `normalization_monoid` is defined by assigning to each element a `norm_unit` such that multiplying
+by that unit normalizes the monoid, and `normalize` is an idempotent monoid homomorphism.
+
+* `gcd_monoid` extends `normalization_monoid`, so the `gcd` and `lcm` are always normalized.
+This makes `gcd`s of polynomials easier to work with, but excludes Euclidean domains, and monoids
+without zero.
+
+## Tags
+
+divisibility, gcd, lcm, normalize
+
+-/
 
 variables {α : Type*}
 
@@ -72,7 +98,7 @@ theorem norm_unit_mul_norm_unit (a : α) : norm_unit (a * norm_unit a) = 1 :=
 classical.by_cases (assume : a = 0, by simp only [this, norm_unit_zero, zero_mul]) $
   assume h, by rw [norm_unit_mul h (units.ne_zero _), norm_unit_coe_units, mul_inv_eq_one]
 
-theorem normalize_idem (x : α) : normalize (normalize x) = normalize x :=
+@[simp] theorem normalize_idem (x : α) : normalize (normalize x) = normalize x :=
 by rw [normalize_apply, normalize_apply, norm_unit_mul_norm_unit, units.coe_one, mul_one]
 
 theorem normalize_eq_normalize {a b : α}
@@ -138,7 +164,7 @@ end associates
 
 section prio
 set_option default_priority 100 -- see Note [default priority]
-/-- GCD monoid: an integral monoid with normalization and `gcd` (greatest common divisor) and
+/-- GCD monoid: an `comm_cancel_monoid_with_zero` with normalization and `gcd` (greatest common divisor) and
 `lcm` (least common multiple) operations. In this setting `gcd` and `lcm` form a bounded lattice on
 the associated elements where `gcd` is the infimum, `lcm` is the supremum, `1` is bottom, and
 `0` is top. The type class focuses on `gcd` and we derive the correpsonding `lcm` facts from `gcd`.

--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -81,13 +81,11 @@ theorem associated_normalize {x : α} : associated x (normalize x) :=
 theorem normalize_associated {x : α} : associated (normalize x) x :=
 associated_normalize.symm
 
-@[simp] lemma normalize_zero : normalize (0 : α) = 0 :=
-by rw [normalize_apply, zero_mul]
+@[simp] lemma normalize_zero : normalize (0 : α) = 0 := by simp
 
 @[simp] lemma normalize_one : normalize (1 : α) = 1 := normalize.map_one
 
-lemma normalize_coe_units (u : units α) : normalize (u : α) = 1 :=
-by rw [normalize_apply, norm_unit_coe_units, ← units.coe_mul, mul_inv_self, units.coe_one]
+lemma normalize_coe_units (u : units α) : normalize (u : α) = 1 := by simp
 
 lemma normalize_eq_zero {x : α} : normalize x = 0 ↔ x = 0 :=
 ⟨λ hx, (associated_zero_iff_eq_zero x).1 $ hx ▸ associated_normalize, by rintro rfl; exact normalize_zero⟩
@@ -95,12 +93,11 @@ lemma normalize_eq_zero {x : α} : normalize x = 0 ↔ x = 0 :=
 lemma normalize_eq_one {x : α} : normalize x = 1 ↔ is_unit x :=
 ⟨λ hx, is_unit_iff_exists_inv.2 ⟨_, hx⟩, λ ⟨u, hu⟩, hu ▸ normalize_coe_units u⟩
 
-theorem norm_unit_mul_norm_unit (a : α) : norm_unit (a * norm_unit a) = 1 :=
+@[simp] theorem norm_unit_mul_norm_unit (a : α) : norm_unit (a * norm_unit a) = 1 :=
 classical.by_cases (assume : a = 0, by simp only [this, norm_unit_zero, zero_mul]) $
   assume h, by rw [norm_unit_mul h (units.ne_zero _), norm_unit_coe_units, mul_inv_eq_one]
 
-@[simp] theorem normalize_idem (x : α) : normalize (normalize x) = normalize x :=
-by rw [normalize_apply, normalize_apply, norm_unit_mul_norm_unit, units.coe_one, mul_one]
+theorem normalize_idem (x : α) : normalize (normalize x) = normalize x := by simp
 
 theorem normalize_eq_normalize {a b : α}
   (hab : a ∣ b) (hba : b ∣ a) : normalize a = normalize b :=

--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -32,23 +32,6 @@ export normalization_monoid (norm_unit norm_unit_zero norm_unit_mul norm_unit_co
 
 attribute [simp] norm_unit_coe_units norm_unit_zero norm_unit_mul
 
-section instances
-
-instance nat.unique_units : unique (units ℕ) :=
-{ default := 1, uniq := nat.units_eq_one }
-
-variables [comm_cancel_monoid_with_zero α] [nontrivial α] [unique (units α)]
-
-@[simp] lemma units_eq_one (u : units α) : u = 1 := subsingleton.elim u 1
-
-instance normalization_monoid_of_unique_units : normalization_monoid α :=
-{ norm_unit := λ x, 1,
-  norm_unit_zero := rfl,
-  norm_unit_mul := λ x y hx hy, (mul_one 1).symm,
-  norm_unit_coe_units := λ u, by simp, }
-
-end instances
-
 section normalization_monoid
 variables [comm_cancel_monoid_with_zero α] [nontrivial α] [normalization_monoid α]
 
@@ -674,3 +657,29 @@ begin
     rw [pow_two, int.nat_abs_mul] at hpp,
     exact (or_self _).mp ((nat.prime.dvd_mul hp).mp hpp)}
 end
+
+instance nat.comm_cancel_monoid_with_zero : comm_cancel_monoid_with_zero ℕ :=
+{ mul_left_cancel_of_ne_zero := λ _ _ _ h1 h2, nat.eq_of_mul_eq_mul_left (nat.pos_of_ne_zero h1) h2,
+  mul_right_cancel_of_ne_zero := λ _ _ _ h1 h2, nat.eq_of_mul_eq_mul_right (nat.pos_of_ne_zero h1) h2,
+  .. (infer_instance : comm_monoid_with_zero ℕ) }
+
+section unique_unit
+
+instance nat.unique_units : unique (units ℕ) :=
+{ default := 1, uniq := nat.units_eq_one }
+
+variables [comm_cancel_monoid_with_zero α] [nontrivial α] [unique (units α)]
+
+@[simp] lemma units_eq_one (u : units α) : u = 1 := subsingleton.elim u 1
+
+instance normalization_monoid_of_unique_units : normalization_monoid α :=
+{ norm_unit := λ x, 1,
+  norm_unit_zero := rfl,
+  norm_unit_mul := λ x y hx hy, (mul_one 1).symm,
+  norm_unit_coe_units := λ u, by simp, }
+
+@[simp] lemma norm_unit_eq_one (x : α) : norm_unit x = 1 := rfl
+
+@[simp] lemma normalize_eq (x : α) : normalize x = x := mul_one x
+
+end unique_unit

--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -425,7 +425,7 @@ begin
     transitivity, {apply dvd_of_associated, symmetry, use u}, apply gcd_dvd_right, }
 end
 
-theorem irreducible_iff_prime {p : α} : irreducible p ↔ prime p :=
+theorem gcd_monoid.irreducible_iff_prime {p : α} : irreducible p ↔ prime p :=
 ⟨prime_of_irreducible, irreducible_of_prime⟩
 
 end gcd_monoid

--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -32,6 +32,23 @@ export normalization_monoid (norm_unit norm_unit_zero norm_unit_mul norm_unit_co
 
 attribute [simp] norm_unit_coe_units norm_unit_zero norm_unit_mul
 
+section instances
+
+instance nat.unique_units : unique (units ℕ) :=
+{ default := 1, uniq := nat.units_eq_one }
+
+variables [comm_cancel_monoid_with_zero α] [nontrivial α] [unique (units α)]
+
+@[simp] lemma units_eq_one (u : units α) : u = 1 := subsingleton.elim u 1
+
+instance normalization_monoid_of_unique_units : normalization_monoid α :=
+{ norm_unit := λ x, 1,
+  norm_unit_zero := rfl,
+  norm_unit_mul := λ x y hx hy, (mul_one 1).symm,
+  norm_unit_coe_units := λ u, by simp, }
+
+end instances
+
 section normalization_monoid
 variables [comm_cancel_monoid_with_zero α] [nontrivial α] [normalization_monoid α]
 

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -116,6 +116,11 @@ theorem le_mul_self : Π (n : ℕ), n ≤ n * n
 theorem eq_of_mul_eq_mul_right {n m k : ℕ} (Hm : m > 0) (H : n * m = k * m) : n = k :=
 by rw [mul_comm n m, mul_comm k m] at H; exact eq_of_mul_eq_mul_left Hm H
 
+instance nat.comm_cancel_monoid_with_zero : comm_cancel_monoid_with_zero ℕ :=
+{ mul_left_cancel_of_ne_zero := λ _ _ _ h1 h2, nat.eq_of_mul_eq_mul_left (nat.pos_of_ne_zero h1) h2,
+  mul_right_cancel_of_ne_zero := λ _ _ _ h1 h2, nat.eq_of_mul_eq_mul_right (nat.pos_of_ne_zero h1) h2,
+  .. (infer_instance : comm_monoid_with_zero ℕ) }
+
 theorem one_add (n : ℕ) : 1 + n = succ n := by simp [add_comm]
 
 -- Sometimes a bare `nat.add` or similar appears as a consequence of unfolding

--- a/src/data/nat/multiplicity.lean
+++ b/src/data/nat/multiplicity.lean
@@ -6,7 +6,7 @@ Authors: Chris Hughes
 import data.nat.choose
 import ring_theory.multiplicity
 import data.nat.modeq
-import algebra.gcd_domain
+import algebra.gcd_monoid
 
 /-!
 

--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
 -/
-import algebra.gcd_domain
+import algebra.gcd_monoid
 import algebra.field_power
 import ring_theory.multiplicity
 import data.real.cau_seq

--- a/src/data/polynomial/field_division.lean
+++ b/src/data/polynomial/field_division.lean
@@ -275,7 +275,7 @@ else by rw [← normalize_dvd_iff, ← @normalize_dvd_iff (polynomial R),
     leading_coeff_map, ← f.map_inv, ← map_C, ← map_mul,
     map_dvd_map _ f.injective (monic_mul_leading_coeff_inv H)]
 
-lemma degree_normalize : degree (normalize p) = degree p :=
+@[simp] lemma degree_normalize : degree (normalize p) = degree p :=
 if hp0 : p = 0 then by simp [hp0]
 else by rw [normalize_apply, degree_mul, degree_eq_zero_of_is_unit (is_unit_unit _), add_zero]
 

--- a/src/data/polynomial/field_division.lean
+++ b/src/data/polynomial/field_division.lean
@@ -275,7 +275,7 @@ else by rw [← normalize_dvd_iff, ← @normalize_dvd_iff (polynomial R),
     leading_coeff_map, ← f.map_inv, ← map_C, ← map_mul,
     map_dvd_map _ f.injective (monic_mul_leading_coeff_inv H)]
 
-@[simp] lemma degree_normalize : degree (normalize p) = degree p :=
+lemma degree_normalize : degree (normalize p) = degree p :=
 if hp0 : p = 0 then by simp [hp0]
 else by rw [normalize_apply, degree_mul, degree_eq_zero_of_is_unit (is_unit_unit _), add_zero]
 

--- a/src/data/polynomial/field_division.lean
+++ b/src/data/polynomial/field_division.lean
@@ -275,9 +275,7 @@ else by rw [← normalize_dvd_iff, ← @normalize_dvd_iff (polynomial R),
     leading_coeff_map, ← f.map_inv, ← map_C, ← map_mul,
     map_dvd_map _ f.injective (monic_mul_leading_coeff_inv H)]
 
-@[simp] lemma degree_normalize : degree (normalize p) = degree p :=
-if hp0 : p = 0 then by simp [hp0]
-else by rw [normalize_apply, degree_mul, degree_eq_zero_of_is_unit (is_unit_unit _), add_zero]
+lemma degree_normalize : degree (normalize p) = degree p := by simp
 
 lemma prime_of_degree_eq_one (hp1 : degree p = 1) : prime p :=
 have prime (normalize p),

--- a/src/data/polynomial/field_division.lean
+++ b/src/data/polynomial/field_division.lean
@@ -6,7 +6,7 @@ Authors: Chris Hughes, Johannes Hölzl, Scott Morrison, Jens Wagemaker
 -/
 import data.polynomial.ring_division
 import data.polynomial.derivative
-import algebra.gcd_domain
+import algebra.gcd_monoid
 
 /-!
 # Theory of univariate polynomials
@@ -234,7 +234,7 @@ begin
   { simp }
 end
 
-instance : normalization_domain (polynomial R) :=
+instance : normalization_monoid (polynomial R) :=
 { norm_unit := λ p, if hp0 : p = 0 then 1
     else ⟨C p.leading_coeff⁻¹, C p.leading_coeff,
       by rw [← C_mul, inv_mul_cancel, C_1];
@@ -258,8 +258,7 @@ instance : normalization_domain (polynomial R) :=
       rw [← nat_degree_eq_of_degree_eq_some hu, leading_coeff,
         coeff_inv_units],
       simp
-    end,
-  ..polynomial.integral_domain }
+    end, }
 
 lemma monic_normalize (hp0 : p ≠ 0) : monic (normalize p) :=
 show leading_coeff (p * ↑(dite _ _ _)) = 1,
@@ -270,14 +269,15 @@ show ↑(dite _ _ _) = C p.leading_coeff⁻¹, by rw dif_neg hp; refl
 
 theorem map_dvd_map' [field k] (f : R →+* k) {x y : polynomial R} : x.map f ∣ y.map f ↔ x ∣ y :=
 if H : x = 0 then by rw [H, map_zero, zero_dvd_iff, zero_dvd_iff, map_eq_zero]
-else by rw [← normalize_dvd_iff, ← @normalize_dvd_iff (polynomial R), normalize, normalize,
+else by rw [← normalize_dvd_iff, ← @normalize_dvd_iff (polynomial R),
+    normalize_apply, normalize_apply,
     coe_norm_unit H, coe_norm_unit (mt (map_eq_zero _).1 H),
     leading_coeff_map, ← f.map_inv, ← map_C, ← map_mul,
     map_dvd_map _ f.injective (monic_mul_leading_coeff_inv H)]
 
 @[simp] lemma degree_normalize : degree (normalize p) = degree p :=
 if hp0 : p = 0 then by simp [hp0]
-else by rw [normalize, degree_mul, degree_eq_zero_of_is_unit (is_unit_unit _), add_zero]
+else by rw [normalize_apply, degree_mul, degree_eq_zero_of_is_unit (is_unit_unit _), add_zero]
 
 lemma prime_of_degree_eq_one (hp1 : degree p = 1) : prime p :=
 have prime (normalize p),

--- a/src/data/real/irrational.lean
+++ b/src/data/real/irrational.lean
@@ -5,7 +5,7 @@ Authors: Mario Carneiro, Abhimanyu Pallavi Sudhir, Jean Lo, Calle Sönne, Yury K
 -/
 import data.real.basic
 import data.rat.sqrt
-import algebra.gcd_domain
+import algebra.gcd_monoid
 import ring_theory.multiplicity
 /-!
 # Irrational real numbers

--- a/src/number_theory/pythagorean_triples.lean
+++ b/src/number_theory/pythagorean_triples.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Paul van Wamelen.
 -/
 import algebra.field
-import algebra.gcd_domain
+import algebra.gcd_monoid
 import algebra.group_with_zero_power
 import tactic
 

--- a/src/ring_theory/multiplicity.lean
+++ b/src/ring_theory/multiplicity.lean
@@ -22,13 +22,13 @@ nat.find_min' _ ((h _) (nat.find_spec hq))
 /-- `multiplicity a b` returns the largest natural number `n` such that
   `a ^ n ∣ b`, as an `enat` or natural with infinity. If `∀ n, a ^ n ∣ b`,
   then it returns `⊤`-/
-def multiplicity [comm_semiring α] [decidable_rel ((∣) : α → α → Prop)] (a b : α) : enat :=
+def multiplicity [comm_monoid α] [decidable_rel ((∣) : α → α → Prop)] (a b : α) : enat :=
 ⟨∃ n : ℕ, ¬a ^ (n + 1) ∣ b, λ h, nat.find h⟩
 
 namespace multiplicity
 
-section comm_semiring
-variables [comm_semiring α]
+section comm_monoid
+variables [comm_monoid α]
 
 @[reducible] def finite (a b : α) : Prop := ∃ n : ℕ, ¬a ^ (n + 1) ∣ b
 
@@ -55,9 +55,6 @@ lemma not_finite_iff_forall {a b : α} : (¬ finite a b) ↔ ∀ n : ℕ, a ^ n 
 lemma not_unit_of_finite {a b : α} (h : finite a b) : ¬is_unit a :=
 let ⟨n, hn⟩ := h in mt (is_unit_iff_forall_dvd.1 ∘ is_unit_pow (n + 1)) $
 λ h, hn (h b)
-
-lemma ne_zero_of_finite {a b : α} (h : finite a b) : b ≠ 0 :=
-let ⟨n, hn⟩ := h in λ hb, by simpa [hb] using hn
 
 lemma finite_of_finite_mul_left {a b c : α} : finite a (b * c) → finite a c :=
 λ ⟨n, hn⟩, ⟨n, λ h, hn (dvd.trans h (by simp [_root_.mul_pow]))⟩
@@ -119,9 +116,6 @@ lemma eq_top_iff {a b : α} :
   (λ n, by_contradiction (not_exists.1 (eq_none_iff'.1 h) n : _)),
    λ h, eq_none_iff.2 (λ n ⟨⟨_, h₁⟩, _⟩, h₁ (h _))⟩
 
-@[simp] protected lemma zero (a : α) : multiplicity a 0 = ⊤ :=
-roption.eq_none_iff.2 (λ n ⟨⟨k, hk⟩, _⟩, hk (dvd_zero _))
-
 lemma one_right {a : α} (ha : ¬is_unit a) : multiplicity a 1 = 0 :=
 eq_some_iff.2 ⟨dvd_refl _, mt is_unit_iff_dvd_one.2 $ by simpa⟩
 
@@ -151,14 +145,6 @@ lemma multiplicity_le_multiplicity_iff {a b c d : α} : multiplicity a b ≤ mul
     have ∀ n : ℕ, c ^ n ∣ d, from λ n, h n (not_finite_iff_forall.1 hab _),
     by rw [eq_top_iff_not_finite.2 hab, eq_top_iff_not_finite.2
       (not_finite_iff_forall.2 this)]⟩
-
-lemma min_le_multiplicity_add {p a b : α} :
-  min (multiplicity p a) (multiplicity p b) ≤ multiplicity p (a + b) :=
-(le_total (multiplicity p a) (multiplicity p b)).elim
-  (λ h, by rw [min_eq_left h, multiplicity_le_multiplicity_iff];
-    exact λ n hn, dvd_add hn (multiplicity_le_multiplicity_iff.1 h n hn))
-  (λ h, by rw [min_eq_right h, multiplicity_le_multiplicity_iff];
-    exact λ n hn, dvd_add (multiplicity_le_multiplicity_iff.1 h n hn) hn)
 
 lemma dvd_of_multiplicity_pos {a b : α} (h : (0 : enat) < multiplicity a b) : a ∣ b :=
 by rw [← _root_.pow_one a]; exact pow_dvd_of_le_multiplicity (enat.pos_iff_one_le.1 h)
@@ -198,6 +184,34 @@ instance decidable_nat : decidable_rel (λ a b : ℕ, (multiplicity a b).dom) :=
 
 instance decidable_int : decidable_rel (λ a b : ℤ, (multiplicity a b).dom) :=
 λ a b, decidable_of_iff _ finite_int_iff.symm
+
+end comm_monoid
+
+section comm_monoid_with_zero
+
+variable [comm_monoid_with_zero α]
+
+lemma ne_zero_of_finite {a b : α} (h : finite a b) : b ≠ 0 :=
+let ⟨n, hn⟩ := h in λ hb, by simpa [hb] using hn
+
+variable [decidable_rel ((∣) : α → α → Prop)]
+
+@[simp] protected lemma zero (a : α) : multiplicity a 0 = ⊤ :=
+roption.eq_none_iff.2 (λ n ⟨⟨k, hk⟩, _⟩, hk (dvd_zero _))
+
+end comm_monoid_with_zero
+
+section comm_semiring
+
+variables [comm_semiring α] [decidable_rel ((∣) : α → α → Prop)]
+
+lemma min_le_multiplicity_add {p a b : α} :
+  min (multiplicity p a) (multiplicity p b) ≤ multiplicity p (a + b) :=
+(le_total (multiplicity p a) (multiplicity p b)).elim
+  (λ h, by rw [min_eq_left h, multiplicity_le_multiplicity_iff];
+    exact λ n hn, dvd_add hn (multiplicity_le_multiplicity_iff.1 h n hn))
+  (λ h, by rw [min_eq_right h, multiplicity_le_multiplicity_iff];
+    exact λ n hn, dvd_add (multiplicity_le_multiplicity_iff.1 h n hn) hn)
 
 end comm_semiring
 
@@ -241,9 +255,9 @@ end
 
 end comm_ring
 
-section integral_domain
+section comm_cancel_monoid_with_zero
 
-variables [integral_domain α]
+variables [comm_cancel_monoid_with_zero α]
 
 lemma finite_mul_aux {p : α} (hp : prime p) : ∀ {n m : ℕ} {a b : α},
   ¬p ^ (n + 1) ∣ a → ¬p ^ (m + 1) ∣ b → ¬p ^ (n + m + 1) ∣ a * b
@@ -372,7 +386,7 @@ lemma multiplicity_pow_self_of_prime {p : α} (hp : prime p) (n : ℕ) :
 multiplicity_pow_self hp.ne_zero hp.not_unit n
 
 
-end integral_domain
+end comm_cancel_monoid_with_zero
 
 end multiplicity
 

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -7,7 +7,7 @@ Theory of unique factorization domains.
 
 @TODO: setup the complete lattice structure on `factor_set`.
 -/
-import algebra.gcd_domain
+import algebra.gcd_monoid
 import ring_theory.integral_domain
 
 variables {α : Type*}
@@ -435,11 +435,11 @@ end associates
 section
 open associates unique_factorization_domain
 
-/-- `to_gcd_domain` constructs a GCD domain out of a unique factorization domain over a normalization
+/-- `to_gcd_monoid` constructs a GCD domain out of a unique factorization domain over a normalization
 domain. -/
-def unique_factorization_domain.to_gcd_domain
-  (α : Type*) [normalization_domain α] [unique_factorization_domain α] [decidable_eq (associates α)] :
-  gcd_domain α :=
+def unique_factorization_domain.to_gcd_monoid
+  (α : Type*) [normalization_monoid α] [unique_factorization_domain α] [decidable_eq (associates α)] :
+  gcd_monoid α :=
 { gcd := λa b, (associates.mk a ⊓ associates.mk b).out,
   lcm := λa b, (associates.mk a ⊔ associates.mk b).out,
   gcd_dvd_left := assume a b, (out_dvd_iff a (associates.mk a ⊓ associates.mk b)).2 $ inf_le_left,
@@ -453,7 +453,7 @@ def unique_factorization_domain.to_gcd_domain
       normalize (a * b),
     by rw [← out_mk, ← out_mul, mul_comm, sup_mul_inf]; refl,
   normalize_gcd := assume a b, by convert normalize_out _,
-  .. ‹normalization_domain α› }
+  .. ‹normalization_monoid α› }
 
 end
 

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -435,11 +435,11 @@ end associates
 section
 open associates unique_factorization_domain
 
-/-- `to_gcd_monoid` constructs a GCD domain out of a unique factorization domain over a normalization
-domain. -/
+/-- `to_gcd_monoid` constructs a GCD monoid out of a normalization on a
+  unique factorization domain. -/
 def unique_factorization_domain.to_gcd_monoid
-  (α : Type*) [normalization_monoid α] [unique_factorization_domain α] [decidable_eq (associates α)] :
-  gcd_monoid α :=
+  (α : Type*) [integral_domain α] [unique_factorization_domain α] [normalization_monoid α]
+  [decidable_eq (associates α)] : gcd_monoid α :=
 { gcd := λa b, (associates.mk a ⊓ associates.mk b).out,
   lcm := λa b, (associates.mk a ⊔ associates.mk b).out,
   gcd_dvd_left := assume a b, (out_dvd_iff a (associates.mk a ⊓ associates.mk b)).2 $ inf_le_left,


### PR DESCRIPTION
* generalize `normalization_domain`, `gcd_domain`, `multiplicity` to not reference addition and subtraction
* make `gcd_monoid` and `normalization_monoid` into mixins
* add instances of `normalization_monoid` for `nat`, `associates`

---
<!-- put comments you want to keep out of the PR commit here -->
