### PR TITLE
[Merged by Bors] - feat(ring_theory/integral_closure): Rings lying within an integral extension are integral extensions

### DIFF
--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -320,7 +320,7 @@ lemma is_integral_tower_top_of_is_integral {x : B} (h : is_integral R x) : is_in
 begin
   rcases h with ⟨p, ⟨hp, hp'⟩⟩,
   refine ⟨p.map (algebra_map R A), ⟨monic_map (algebra_map R A) hp, _⟩⟩,
-  rw [aeval_def, is_algebra_tower.algebra_map_eq R A B, ← eval₂_map] at hp',
+  rw [aeval_def, is_scalar_tower.algebra_map_eq R A B, ← eval₂_map] at hp',
   rw [aeval_def],
   exact hp',
 end

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -297,6 +297,37 @@ lemma algebra.is_integral_trans (A_int : ∀ x : A, is_integral R x)(B_int : ∀
   ∀ x:B, is_integral R x :=
 λ x, is_integral_trans A_int x (B_int x)
 
+lemma is_integral_of_surjective (h : function.surjective (algebra_map R A))
+  : ∀ x : A, is_integral R x :=
+λ x, (h x).rec_on (λ y hy, (hy ▸ is_integral_algebra_map : is_integral R x))
+
+/-- If `R → A → B` is an algebra tower with `A → B` injective,
+then if the entire tower is an integral extension so is `R → A` -/
+lemma is_integral_of_is_integral_tower_back (H : function.injective (algebra_map A B))
+  : (∀ x : B, is_integral R x) → (∀ x : A, is_integral R x) :=
+begin
+  intros h x,
+  rcases h (algebra_map A B x) with ⟨p, ⟨hp, hp'⟩⟩,
+  refine ⟨p, ⟨hp, _⟩⟩,
+  rw [aeval_def, is_algebra_tower.algebra_map_eq R A B, ← eval₂_map,
+      eval₂_hom, ← ring_hom.map_zero (algebra_map A B)] at hp',
+  rw [aeval_def, eval₂_eq_eval_map],
+  exact H hp',
+end
+
+/-- If `R → A → B` is an algebra tower,
+then if the entire tower is an integral extension so is `A → B` -/
+lemma is_integral_of_is_integral_tower_front
+  : (∀ x : B, is_integral R x) → (∀ x : B, is_integral A x) :=
+begin
+  intros h x,
+  rcases h x with ⟨p, ⟨hp, hp'⟩⟩,
+  refine ⟨p.map (algebra_map R A), ⟨monic_map (algebra_map R A) hp, _⟩⟩,
+  rw [aeval_def, is_algebra_tower.algebra_map_eq R A B, ← eval₂_map] at hp',
+  rw [aeval_def],
+  exact hp',
+end
+
 end algebra
 
 theorem integral_closure_idem {R : Type*} {A : Type*} [comm_ring R] [comm_ring A] [algebra R A] :

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -297,14 +297,14 @@ lemma algebra.is_integral_trans (A_int : ∀ x : A, is_integral R x)(B_int : ∀
   ∀ x:B, is_integral R x :=
 λ x, is_integral_trans A_int x (B_int x)
 
-lemma is_integral_of_surjective (h : function.surjective (algebra_map R A))
-  : ∀ x : A, is_integral R x :=
+lemma is_integral_of_surjective (h : function.surjective (algebra_map R A)) :
+  ∀ x : A, is_integral R x :=
 λ x, (h x).rec_on (λ y hy, (hy ▸ is_integral_algebra_map : is_integral R x))
 
 /-- If `R → A → B` is an algebra tower with `A → B` injective,
 then if the entire tower is an integral extension so is `R → A` -/
-lemma is_integral_of_is_integral_tower_back (H : function.injective (algebra_map A B))
-  : (∀ x : B, is_integral R x) → (∀ x : A, is_integral R x) :=
+lemma is_integral_of_is_integral_tower_bot (H : function.injective (algebra_map A B)) :
+  (∀ x : B, is_integral R x) → (∀ x : A, is_integral R x) :=
 begin
   intros h x,
   rcases h (algebra_map A B x) with ⟨p, ⟨hp, hp'⟩⟩,
@@ -317,8 +317,8 @@ end
 
 /-- If `R → A → B` is an algebra tower,
 then if the entire tower is an integral extension so is `A → B` -/
-lemma is_integral_of_is_integral_tower_front
-  : (∀ x : B, is_integral R x) → (∀ x : B, is_integral A x) :=
+lemma is_integral_of_is_integral_tower_top :
+  (∀ x : B, is_integral R x) → (∀ x : B, is_integral A x) :=
 begin
   intros h x,
   rcases h x with ⟨p, ⟨hp, hp'⟩⟩,

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -308,7 +308,7 @@ lemma is_integral_tower_bot_of_is_integral (H : function.injective (algebra_map 
 begin
   rcases h with ⟨p, ⟨hp, hp'⟩⟩,
   refine ⟨p, ⟨hp, _⟩⟩,
-  rw [aeval_def, is_algebra_tower.algebra_map_eq R A B, ← eval₂_map,
+  rw [aeval_def, is_scalar_tower.algebra_map_eq R A B, ← eval₂_map,
       eval₂_hom, ← ring_hom.map_zero (algebra_map A B)] at hp',
   rw [aeval_def, eval₂_eq_eval_map],
   exact H hp',

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -303,11 +303,10 @@ lemma is_integral_of_surjective (h : function.surjective (algebra_map R A)) :
 
 /-- If `R → A → B` is an algebra tower with `A → B` injective,
 then if the entire tower is an integral extension so is `R → A` -/
-lemma is_integral_of_is_integral_tower_bot (H : function.injective (algebra_map A B)) :
-  (∀ x : B, is_integral R x) → (∀ x : A, is_integral R x) :=
+lemma is_integral_tower_bot_of_is_integral (H : function.injective (algebra_map A B))
+  {x : A} (h : is_integral R (algebra_map A B x)) : is_integral R x :=
 begin
-  intros h x,
-  rcases h (algebra_map A B x) with ⟨p, ⟨hp, hp'⟩⟩,
+  rcases h with ⟨p, ⟨hp, hp'⟩⟩,
   refine ⟨p, ⟨hp, _⟩⟩,
   rw [aeval_def, is_algebra_tower.algebra_map_eq R A B, ← eval₂_map,
       eval₂_hom, ← ring_hom.map_zero (algebra_map A B)] at hp',
@@ -317,11 +316,9 @@ end
 
 /-- If `R → A → B` is an algebra tower,
 then if the entire tower is an integral extension so is `A → B` -/
-lemma is_integral_of_is_integral_tower_top :
-  (∀ x : B, is_integral R x) → (∀ x : B, is_integral A x) :=
+lemma is_integral_tower_top_of_is_integral {x : B} (h : is_integral R x) : is_integral A x :=
 begin
-  intros h x,
-  rcases h x with ⟨p, ⟨hp, hp'⟩⟩,
+  rcases h with ⟨p, ⟨hp, hp'⟩⟩,
   refine ⟨p.map (algebra_map R A), ⟨monic_map (algebra_map R A) hp, _⟩⟩,
   rw [aeval_def, is_algebra_tower.algebra_map_eq R A B, ← eval₂_map] at hp',
   rw [aeval_def],


### PR DESCRIPTION
Proofs that if an algebra tower is integral then so are the two extensions making up the tower. I needed these for another proof I'm working on, but it seemed reasonable to create a smaller PR now since they are basically self contained.