### PR TITLE
[Merged by Bors] - feat(tactic/linarith): support case splits in preprocessing (including `ne` hypotheses)

### DIFF
--- a/src/tactic/linarith/datatypes.lean
+++ b/src/tactic/linarith/datatypes.lean
@@ -228,7 +228,6 @@ meta structure preprocessor : Type :=
 (name : string)
 (transform : expr → tactic (list expr))
 
-
 /--
 Some preprocessors need to examine the full list of hypotheses instead of working item by item.
 As with `preprocessor`, the input to a `global_preprocessor` is replaced by, not added to, its output.

--- a/src/tactic/linarith/datatypes.lean
+++ b/src/tactic/linarith/datatypes.lean
@@ -228,33 +228,51 @@ meta structure preprocessor : Type :=
 (name : string)
 (transform : expr → tactic (list expr))
 
-/--
-Some preprocessors need to examine the full list of hypotheses instead of working item by item.
-As with `preprocessor`, the input to a `global_preprocessor` is replaced by, not added to, its output.
--/
 meta structure global_preprocessor : Type :=
 (name : string)
 (transform : list expr → tactic (list expr))
 
+meta def branch : Type := expr × list expr
+
 /--
-A `preprocessor` lifts to a `global_preprocessor` by folding it over the input list.
+Some preprocessors need to examine the full list of hypotheses instead of working item by item.
+As with `preprocessor`, the input to a `global_branching_preprocessor` is replaced by, not added to, its output.
+-/
+meta structure global_branching_preprocessor : Type :=
+(name : string)
+(transform : list expr → tactic (list branch))
+
+/--
+A `preprocessor` lifts to a `global_branching_preprocessor` by folding it over the input list.
 -/
 meta def preprocessor.globalize (pp : preprocessor) : global_preprocessor :=
 { name := pp.name,
   transform := list.mfoldl (λ ret e, do l' ← pp.transform e, return (l' ++ ret)) [] }
 
+meta def global_preprocessor.branching (pp : global_preprocessor) : global_branching_preprocessor :=
+{ name := pp.name,
+  transform := λ l, do g ← tactic.get_goal, singleton <$> prod.mk g <$> pp.transform l }
+
 /--
 `process pp l` runs `pp.transform` on `l` and returns the result,
 tracing the result if `trace.linarith` is on.
 -/
-meta def global_preprocessor.process (pp : global_preprocessor) (l : list expr) :
-  tactic (list expr) :=
+meta def global_branching_preprocessor.process (pp : global_branching_preprocessor) (l : list expr) :
+  tactic (list branch) :=
 do l ← pp.transform l,
-   linarith_trace_proofs (to_string format!"Preprocessing: {pp.name}") l,
+   when (l.length > 1) $
+     linarith_trace format!"Preprocessing: {pp.name} has branched, with branches:",
+   l.mmap' $ λ l, tactic.set_goals [l.1] >> linarith_trace_proofs (to_string format!"Preprocessing: {pp.name}") l.2,
    return l
 
-meta instance : has_coe preprocessor global_preprocessor :=
-⟨preprocessor.globalize⟩
+meta instance preprocessor_to_gb_preprocessor :
+  has_coe preprocessor global_branching_preprocessor :=
+⟨global_preprocessor.branching ∘ preprocessor.globalize⟩
+
+meta instance global_preprocessor_to_gb_preprocessor :
+  has_coe global_preprocessor global_branching_preprocessor :=
+⟨global_preprocessor.branching⟩
+
 
 /--
 A `certificate_oracle` is a function `produce_certificate : list comp → ℕ → tactic (rb_map ℕ ℕ)`.
@@ -276,7 +294,7 @@ meta structure linarith_config : Type :=
 (exfalso : bool := tt)
 (transparency : tactic.transparency := reducible)
 (split_hypotheses : bool := tt)
-(preprocessors : option (list global_preprocessor) := none)
+(preprocessors : option (list global_branching_preprocessor) := none)
 (oracle : option certificate_oracle := none)
 
 /--

--- a/src/tactic/linarith/frontend.lean
+++ b/src/tactic/linarith/frontend.lean
@@ -371,4 +371,4 @@ add_tactic_doc
 { name       := "nlinarith",
   category   := doc_category.tactic,
   decl_names := [`tactic.interactive.nlinarith],
-  tags       := ["arithmetic", "finishing"] }
+  tags       := ["arithmetic", "decision procedure", "finishing"] }

--- a/src/tactic/linarith/frontend.lean
+++ b/src/tactic/linarith/frontend.lean
@@ -228,6 +228,7 @@ expressions.
 -/
 meta def tactic.linarith (reduce_semi : bool) (only_on : bool) (hyps : list pexpr)
   (cfg : linarith_config := {}) : tactic unit :=
+focus1 $
 do t ← target,
 -- if the target is an equality, we run `linarith` twice, to prove ≤ and ≥.
 if t.is_eq.is_some then

--- a/src/tactic/linarith/preprocessing.lean
+++ b/src/tactic/linarith/preprocessing.lean
@@ -261,7 +261,7 @@ do s ← ls.mfoldr (λ h s', infer_type h >>= find_squares s') mk_rb_set,
 /--
 The default list of preprocessors, in the order they should typically run.
 -/
-meta def default_preprocessors : list global_preprocessor :=
+meta def default_preprocessors : list global_branching_preprocessor :=
 [filter_comparisons, remove_negations, nat_to_int, strengthen_strict_int,
   make_comp_with_zero, cancel_denoms]
 
@@ -272,8 +272,10 @@ The preprocessors are run sequentially: each recieves the output of the previous
 Note that a preprocessor produces a `list expr` for each input `expr`,
 so the size of the list may change.
 -/
-meta def preprocess (pps : list global_preprocessor) (l : list expr) : tactic (list expr) :=
-pps.mfoldl (λ l' pp, pp.process l') l
-
+meta def preprocess (pps : list global_branching_preprocessor) (l : list expr) : tactic (list branch) :=
+do g ← get_goal,
+pps.mfoldl (λ ls pp,
+  list.join <$> (ls.mmap $ λ b, set_goals [b.1] >> pp.process b.2))
+  [(g, l)]
 
 end linarith

--- a/src/tactic/linarith/preprocessing.lean
+++ b/src/tactic/linarith/preprocessing.lean
@@ -259,6 +259,31 @@ do s ← ls.mfoldr (λ h s', infer_type h >>= find_squares s') mk_rb_set,
    return $ new_es ++ ls ++ products }
 
 /--
+`remove_ne_aux` case splits on any proof `h : a ≠ b` in the input, turning it into `a < b ∨ a > b`.
+This produces `2^n` branches when there are `n` such hypotheses in the input.
+-/
+meta def remove_ne_aux : list expr → tactic (list branch) :=
+λ hs,
+(do e ← hs.mfind (λ e : expr, do e ← infer_type e, guard $ e.is_ne.is_some),
+    [(_, ng1), (_, ng2)] ← to_expr ``(or.elim (lt_or_gt_of_ne %%e)) >>= apply,
+     let do_goal : expr → tactic (list branch) := λ g,
+       do set_goals [g],
+          h ← intro1,
+          ls ← remove_ne_aux $ hs.remove_all [e],
+          return $ ls.map (λ b : branch, (b.1, h::b.2)) in
+      (++) <$> do_goal ng1 <*> do_goal ng2)
+<|> do g ← get_goal, return [(g, hs)]
+
+/--
+`remove_ne` case splits on any proof `h : a ≠ b` in the input, turning it into `a < b ∨ a > b`,
+by calling `linarith.remove_ne_aux`.
+This produces `2^n` branches when there are `n` such hypotheses in the input.
+-/
+meta def remove_ne : global_branching_preprocessor :=
+{ name := "remove_ne",
+  transform := remove_ne_aux }
+
+/--
 The default list of preprocessors, in the order they should typically run.
 -/
 meta def default_preprocessors : list global_branching_preprocessor :=
@@ -269,7 +294,7 @@ meta def default_preprocessors : list global_branching_preprocessor :=
 `preprocess pps l` takes a list `l` of proofs of propositions.
 It maps each preprocessor `pp ∈ pps` over this list.
 The preprocessors are run sequentially: each recieves the output of the previous one.
-Note that a preprocessor produces a `list expr` for each input `expr`,
+Note that a preprocessor may produce multiple or no expressions from each input expression,
 so the size of the list may change.
 -/
 meta def preprocess (pps : list global_branching_preprocessor) (l : list expr) : tactic (list branch) :=

--- a/src/tactic/linarith/preprocessing.lean
+++ b/src/tactic/linarith/preprocessing.lean
@@ -266,12 +266,12 @@ meta def remove_ne_aux : list expr → tactic (list branch) :=
 λ hs,
 (do e ← hs.mfind (λ e : expr, do e ← infer_type e, guard $ e.is_ne.is_some),
     [(_, ng1), (_, ng2)] ← to_expr ``(or.elim (lt_or_gt_of_ne %%e)) >>= apply,
-     let do_goal : expr → tactic (list branch) := λ g,
-       do set_goals [g],
-          h ← intro1,
-          ls ← remove_ne_aux $ hs.remove_all [e],
-          return $ ls.map (λ b : branch, (b.1, h::b.2)) in
-      (++) <$> do_goal ng1 <*> do_goal ng2)
+    let do_goal : expr → tactic (list branch) := λ g,
+      do set_goals [g],
+         h ← intro1,
+         ls ← remove_ne_aux $ hs.remove_all [e],
+         return $ ls.map (λ b : branch, (b.1, h::b.2)) in
+    (++) <$> do_goal ng1 <*> do_goal ng2)
 <|> do g ← get_goal, return [(g, hs)]
 
 /--

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -379,27 +379,8 @@ end
 
 end T
 
-#check expr.is_ne
-
-
-open linarith tactic
-
-meta def remove_ne : list expr → tactic (list branch) :=
-λ hs,
-(do e ← hs.mfind (λ e : expr, do e ← infer_type e, guard $ e.is_ne.is_some),
-    [(_, ng1), (_, ng2)] ← to_expr ``(or.elim (lt_or_gt_of_ne %%e)) >>= apply,
-     let do_goal : expr → tactic (list branch) := λ g,
-       do set_goals [g],
-          h ← intro1,
-          ls ← remove_ne $ hs.remove_all [e],
-          return $ ls.map (λ b : branch, (b.1, h::b.2)) in
-      (++) <$> do_goal ng1 <*> do_goal ng2)
-<|> do g ← get_goal, return [(g, hs)]
-
-meta def ne_preprocessor : global_branching_preprocessor :=
-{ name := "ne_preprocessor",
-  transform := remove_ne }
-
-
 example (a b c : ℚ) (h : a ≠ b) (h3 : b ≠ c) (h2 : a ≥ b) : b ≠ c :=
-by linarith {preprocessors := ne_preprocessor::default_preprocessors}
+by linarith {split_ne := tt}
+
+example (a b c : ℚ) (h : a ≠ b) (h2 : a ≥ b) (h3 : b ≠ c) : a > b :=
+by linarith {split_ne := tt}

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -378,3 +378,28 @@ begin
 end
 
 end T
+
+#check expr.is_ne
+
+
+open linarith tactic
+
+meta def remove_ne : list expr → tactic (list branch) :=
+λ hs,
+(do e ← hs.mfind (λ e : expr, do e ← infer_type e, guard $ e.is_ne.is_some),
+    [(_, ng1), (_, ng2)] ← to_expr ``(or.elim (lt_or_gt_of_ne %%e)) >>= apply,
+     let do_goal : expr → tactic (list branch) := λ g,
+       do set_goals [g],
+          h ← intro1,
+          ls ← remove_ne $ hs.remove_all [e],
+          return $ ls.map (λ b : branch, (b.1, h::b.2)) in
+      (++) <$> do_goal ng1 <*> do_goal ng2)
+<|> do g ← get_goal, return [(g, hs)]
+
+meta def ne_preprocessor : global_branching_preprocessor :=
+{ name := "ne_preprocessor",
+  transform := remove_ne }
+
+
+example (a b c : ℚ) (h : a ≠ b) (h3 : b ≠ c) (h2 : a ≥ b) : b ≠ c :=
+by linarith {preprocessors := ne_preprocessor::default_preprocessors}


### PR DESCRIPTION
This adds an API for `linarith` preprocessors to branch. Each branch results in a separate call to `linarith`, so this can be exponentially bad. Use responsibly.

Given that the functionality is there, and I needed a way to test it, I've added a feature that people have been begging for that I've resisted: you can now call `linarith {split_ne := tt}` to handle `a ≠ b` hypotheses. Again: 2^n `linarith` calls for `n` disequalities in your context.

---
<!-- put comments you want to keep out of the PR commit here -->

@digama0 requested this feature for a possible `linarith` extension.