### PR TITLE
[Merged by Bors] - refactor(linear_algebra/affine_space/combination): bundled affine_combination

### DIFF
--- a/src/geometry/euclidean.lean
+++ b/src/geometry/euclidean.lean
@@ -672,12 +672,12 @@ in terms of the pairwise distances between the points in that
 combination. -/
 lemma dist_affine_combination {ι : Type*} {s : finset ι} {w₁ w₂ : ι → ℝ} (p : ι → P)
     (h₁ : ∑ i in s, w₁ i = 1) (h₂ : ∑ i in s, w₂ i = 1) :
-  dist (s.affine_combination w₁ p) (s.affine_combination w₂ p) *
-    dist (s.affine_combination w₁ p) (s.affine_combination w₂ p) =
+  dist (s.affine_combination p w₁) (s.affine_combination p w₂) *
+    dist (s.affine_combination p w₁) (s.affine_combination p w₂) =
     (-∑ i₁ in s, ∑ i₂ in s,
       (w₁ - w₂) i₁ * (w₁ - w₂) i₂ * (dist (p i₁) (p i₂) * dist (p i₁) (p i₂))) / 2 :=
 begin
-  rw [dist_eq_norm_vsub V (s.affine_combination w₁ p) (s.affine_combination w₂ p),
+  rw [dist_eq_norm_vsub V (s.affine_combination p w₁) (s.affine_combination p w₂),
       ←inner_self_eq_norm_square, finset.affine_combination_vsub],
   have h : ∑ i in s, (w₁ - w₂) i = 0,
   { simp_rw [pi.sub_apply, finset.sum_sub_distrib, h₁, h₂, sub_self] },

--- a/src/linear_algebra/affine_space/independent.lean
+++ b/src/linear_algebra/affine_space/independent.lean
@@ -107,7 +107,7 @@ combinations (with sum of weights 1) that evaluate to the same point
 have equal `set.indicator`. -/
 lemma affine_independent_iff_indicator_eq_of_affine_combination_eq (p : ι → P) :
   affine_independent k p ↔ ∀ (s1 s2 : finset ι) (w1 w2 : ι → k), ∑ i in s1, w1 i = 1 →
-    ∑ i in s2, w2 i = 1 → s1.affine_combination w1 p = s2.affine_combination w2 p →
+    ∑ i in s2, w2 i = 1 → s1.affine_combination p w1 = s2.affine_combination p w2 →
       set.indicator ↑s1 w1 = set.indicator ↑s2 w2 :=
 begin
   split,
@@ -129,13 +129,13 @@ begin
     let w1 : ι → k := function.update (function.const ι 0) i0 1,
     have hw1 : ∑ i in s, w1 i = 1,
     { rw [finset.sum_update_of_mem hi0, finset.sum_const_zero, add_zero] },
-    have hw1s : s.affine_combination w1 p = p i0 :=
+    have hw1s : s.affine_combination p w1 = p i0 :=
       s.affine_combination_of_eq_one_of_eq_zero w1 p hi0 (function.update_same _ _ _)
                                                 (λ _ _ hne, function.update_noteq hne _ _),
     let w2 := w + w1,
     have hw2 : ∑ i in s, w2 i = 1,
     { simp [w2, finset.sum_add_distrib, hw, hw1] },
-    have hw2s : s.affine_combination w2 p = p i0,
+    have hw2s : s.affine_combination p w2 = p i0,
     { simp [w2, ←finset.weighted_vsub_vadd_affine_combination, hs, hw1s] },
     replace ha := ha s s w2 w1 hw2 hw1 (hw1s.symm ▸ hw2s),
     have hws : w2 i0 - w1 i0 = 0,


### PR DESCRIPTION
When `weighted_vsub_of_point` and `weighted_vsub` became bundled
`linear_map`s on the weights, `affine_combination` was left as an
unbundled function with different argument order from the other two
related operations.  Make it into a bundled `affine_map` on the
weights, so making it more consistent with the other two operations
and allowing general results on `affine_map`s to be used on
`affine_combination` (as illustrated by the changed proofs of
`weighted_vsub_vadd_affine_combination` and
`affine_combination_vsub`).


---
<!-- put comments you want to keep out of the PR commit here -->
