### PR TITLE
[Merged by Bors] - feat(category_theory/comma): constructing isos in the comma,over,under cats

### DIFF
--- a/src/category_theory/comma.lean
+++ b/src/category_theory/comma.lean
@@ -127,6 +127,19 @@ def nat_trans : fst L R ⋙ L ⟶ snd L R ⋙ R :=
 section
 variables {L₁ L₂ L₃ : A ⥤ T} {R₁ R₂ R₃ : B ⥤ T}
 
+/--
+Construct an isomorphism in the comma category given isomorphisms of the objects whose forward
+directions give a commutative square.
+-/
+@[simps]
+def iso_mk {X Y : comma L₁ R₁} (l : X.left ≅ Y.left) (r : X.right ≅ Y.right)
+  (h : L₁.map l.hom ≫ Y.hom = X.hom ≫ R₁.map r.hom) : X ≅ Y :=
+{ hom := { left := l.hom, right := r.hom },
+  inv :=
+  { left := l.inv,
+    right := r.inv,
+    w' := by { erw [L₁.map_inv l.hom, iso.inv_comp_eq, reassoc_of h, ← R₁.map_comp], simp } } }
+
 /-- A natural transformation `L₁ ⟶ L₂` induces a functor `comma L₂ R ⥤ comma L₁ R`. -/
 @[simps]
 def map_left (l : L₁ ⟶ L₂) : comma L₂ R ⥤ comma L₁ R :=

--- a/src/category_theory/over.lean
+++ b/src/category_theory/over.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2019 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johan Commelin
+Authors: Johan Commelin, Bhavik Mehta
 -/
 import category_theory.comma
 import category_theory.punit
@@ -55,11 +55,9 @@ by tidy
 by have := f.w; tidy
 
 /-- To give an object in the over category, it suffices to give a morphism with codomain `X`. -/
+@[simps]
 def mk {X Y : T} (f : Y ⟶ X) : over X :=
 { left := Y, hom := f }
-
-@[simp] lemma mk_left {X Y : T} (f : Y ⟶ X) : (mk f).left = Y := rfl
-@[simp] lemma mk_hom {X Y : T} (f : Y ⟶ X) : (mk f).hom = f := rfl
 
 /-- To give a morphism in the over category, it suffices to give an arrow fitting in a commutative
     triangle. -/
@@ -68,8 +66,23 @@ def hom_mk {U V : over X} (f : U.left ⟶ V.left) (w : f ≫ V.hom = U.hom . obv
   U ⟶ V :=
 { left := f }
 
+/--
+Construct an isomorphism in the over category given isomorphisms of the objects whose forward
+direction gives a commutative triangle.
+-/
+def iso_mk {f g : over X} (hl : f.left ≅ g.left) (hw : hl.hom ≫ g.hom = f.hom) : f ≅ g :=
+comma.iso_mk hl (eq_to_iso (subsingleton.elim _ _)) (by simp [hw])
+
+@[simp]
+lemma iso_mk_hom_left {f g : over X} (hl : f.left ≅ g.left) (hw : hl.hom ≫ g.hom = f.hom) :
+  (iso_mk hl hw).hom.left = hl.hom := rfl
+
+@[simp]
+lemma iso_mk_inv_left {f g : over X} (hl : f.left ≅ g.left) (hw : hl.hom ≫ g.hom = f.hom) :
+  (iso_mk hl hw).inv.left = hl.inv := rfl
+
 /-- The forgetful functor mapping an arrow to its domain. -/
-def forget : (over X) ⥤ T := comma.fst _ _
+def forget : over X ⥤ T := comma.fst _ _
 
 @[simp] lemma forget_obj {U : over X} : forget.obj U = U.left := rfl
 @[simp] lemma forget_map {U V : over X} {f : U ⟶ V} : forget.map f = f.left := rfl
@@ -110,15 +123,11 @@ def iterated_slice_equiv : over f ≌ over f.left :=
   inverse := iterated_slice_backward f,
   unit_iso :=
     nat_iso.of_components
-    (λ g, ⟨hom_mk (hom_mk (𝟙 g.left.left)) (by apply_auto_param),
-           hom_mk (hom_mk (𝟙 g.left.left)) (by apply_auto_param),
-           by { ext, dsimp, simp }, by { ext, dsimp, simp }⟩) -- See note [dsimp, simp].
+    (λ g, over.iso_mk (over.iso_mk (iso.refl _) (by tidy)) (by tidy))
     (λ X Y g, by { ext, dsimp, simp }),
   counit_iso :=
     nat_iso.of_components
-    (λ g, ⟨hom_mk (𝟙 g.left) (by apply_auto_param),
-           hom_mk (𝟙 g.left) (by apply_auto_param),
-           by { ext, dsimp, simp }, by { ext, dsimp, simp }⟩)
+    (λ g, over.iso_mk (iso.refl _) (by tidy))
     (λ X Y g, by { ext, dsimp, simp }) }
 
 lemma iterated_slice_forward_forget :
@@ -135,6 +144,7 @@ section
 variables {D : Type u₂} [category.{v₂} D]
 
 /-- A functor `F : T ⥤ D` induces a functor `over X ⥤ over (F.obj X)` in the obvious way. -/
+@[simps]
 def post (F : T ⥤ D) : over X ⥤ over (F.obj X) :=
 { obj := λ Y, mk $ F.map Y.hom,
   map := λ Y₁ Y₂ f,
@@ -185,8 +195,23 @@ def hom_mk {U V : under X} (f : U.right ⟶ V.right) (w : U.hom ≫ f = V.hom . 
   U ⟶ V :=
 { right := f }
 
+/--
+Construct an isomorphism in the over category given isomorphisms of the objects whose forward
+direction gives a commutative triangle.
+-/
+def iso_mk {f g : under X} (hr : f.right ≅ g.right) (hw : f.hom ≫ hr.hom = g.hom) : f ≅ g :=
+comma.iso_mk (eq_to_iso (subsingleton.elim _ _)) hr (by simp [hw])
+
+@[simp]
+lemma iso_mk_hom_right {f g : under X} (hr : f.right ≅ g.right) (hw : f.hom ≫ hr.hom = g.hom) :
+  (iso_mk hr hw).hom.right = hr.hom := rfl
+
+@[simp]
+lemma iso_mk_inv_right {f g : under X} (hr : f.right ≅ g.right) (hw : f.hom ≫ hr.hom = g.hom) :
+  (iso_mk hr hw).inv.right = hr.inv := rfl
+
 /-- The forgetful functor mapping an arrow to its domain. -/
-def forget : (under X) ⥤ T := comma.snd _ _
+def forget : under X ⥤ T := comma.snd _ _
 
 @[simp] lemma forget_obj {U : under X} : forget.obj U = U.right := rfl
 @[simp] lemma forget_map {U V : under X} {f : U ⟶ V} : forget.map f = f.right := rfl
@@ -205,6 +230,7 @@ section
 variables {D : Type u₂} [category.{v₂} D]
 
 /-- A functor `F : T ⥤ D` induces a functor `under X ⥤ under (F.obj X)` in the obvious way. -/
+@[simps]
 def post {X : T} (F : T ⥤ D) : under X ⥤ under (F.obj X) :=
 { obj := λ Y, mk $ F.map Y.hom,
   map := λ Y₁ Y₂ f,


### PR DESCRIPTION
Constructors to give isomorphisms in comma, over and under categories - essentially these just let you omit checking one of the commuting squares using the fact that the components are iso and the other square works.