### PR TITLE
[Merged by Bors] - fix(*): remove usages of ge/gt

### DIFF
--- a/scripts/nolints.txt
+++ b/scripts/nolints.txt
@@ -1791,7 +1791,7 @@ apply_nolint tactic.interactive.solve_mvar doc_blame
 apply_nolint tactic.interactive.unify_with_instance doc_blame
 
 -- tactic/monotonicity/lemmas.lean
-apply_nolint gt_of_mul_lt_mul_neg_right ge_or_gt
+apply_nolint lt_of_mul_lt_mul_neg_right ge_or_gt
 
 -- tactic/norm_num.lean
 apply_nolint norm_num.derive doc_blame

--- a/src/algebra/char_p.lean
+++ b/src/algebra/char_p.lean
@@ -214,7 +214,7 @@ assume hp : p = 1,
 have ( 1 : α) = 0, by simpa using (cast_eq_zero_iff α p 1).mpr (hp ▸ dvd_refl p),
 absurd this one_ne_zero
 
-theorem char_is_prime_of_ge_two (p : ℕ) [hc : char_p α p] (hp : p ≥ 2) : nat.prime p :=
+theorem char_is_prime_of_two_le (p : ℕ) [hc : char_p α p] (hp : 2 ≤ p) : nat.prime p :=
 suffices ∀d ∣ p, d = 1 ∨ d = p, from ⟨hp, this⟩,
 assume (d : ℕ) (hdvd : ∃ e, p = d * e),
 let ⟨e, hmul⟩ := hdvd in
@@ -236,7 +236,7 @@ theorem char_is_prime_or_zero (p : ℕ) [hc : char_p α p] : nat.prime p ∨ p =
 match p, hc with
 | 0,     _  := or.inr rfl
 | 1,     hc := absurd (eq.refl (1 : ℕ)) (@char_ne_one α _ (1 : ℕ) hc)
-| (m+2), hc := or.inl (@char_is_prime_of_ge_two α _ (m+2) hc (nat.le_add_left 2 m))
+| (m+2), hc := or.inl (@char_is_prime_of_two_le α _ (m+2) hc (nat.le_add_left 2 m))
 end
 
 lemma char_is_prime_of_pos (p : ℕ) [h : fact (0 < p)] [char_p α p] : fact p.prime :=

--- a/src/algebra/order_functions.lean
+++ b/src/algebra/order_functions.lean
@@ -181,17 +181,17 @@ calc  abs a
     ≤ b : by { apply abs_le_of_le_of_neg_le; assumption }
 ... ≤ abs b : le_abs_self _
 
-lemma min_le_add_of_nonneg_right {a b : α} (hb : b ≥ 0) : min a b ≤ a + b :=
+lemma min_le_add_of_nonneg_right {a b : α} (hb : 0 ≤ b) : min a b ≤ a + b :=
 calc
   min a b ≤ a     : by apply min_le_left
       ... ≤ a + b : le_add_of_nonneg_right hb
 
-lemma min_le_add_of_nonneg_left {a b : α} (ha : a ≥ 0) : min a b ≤ a + b :=
+lemma min_le_add_of_nonneg_left {a b : α} (ha : 0 ≤ a) : min a b ≤ a + b :=
 calc
   min a b ≤ b     : by apply min_le_right
       ... ≤ a + b : le_add_of_nonneg_left ha
 
-lemma max_le_add_of_nonneg {a b : α} (ha : a ≥ 0) (hb : b ≥ 0) : max a b ≤ a + b :=
+lemma max_le_add_of_nonneg {a b : α} (ha : 0 ≤ a) (hb : 0 ≤ b) : max a b ≤ a + b :=
 max_le_iff.2 (by split; simpa)
 
 lemma max_zero_sub_eq_self (a : α) : max a 0 - max (-a) 0 = a :=

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -113,7 +113,7 @@ theorem le_mul_self : Π (n : ℕ), n ≤ n * n
 | 0     := le_refl _
 | (n+1) := let t := mul_le_mul_left (n+1) (succ_pos n) in by simp at t; exact t
 
-theorem eq_of_mul_eq_mul_right {n m k : ℕ} (Hm : m > 0) (H : n * m = k * m) : n = k :=
+theorem eq_of_mul_eq_mul_right {n m k : ℕ} (Hm : 0 < m) (H : n * m = k * m) : n = k :=
 by rw [mul_comm n m, mul_comm k m] at H; exact eq_of_mul_eq_mul_left Hm H
 
 theorem one_add (n : ℕ) : 1 + n = succ n := by simp [add_comm]

--- a/src/data/nat/dist.lean
+++ b/src/data/nat/dist.lean
@@ -35,11 +35,11 @@ begin rw [h, dist_self] end
 theorem dist_eq_sub_of_le {n m : ℕ} (h : n ≤ m) : dist n m = m - n :=
 begin rw [dist.def, sub_eq_zero_of_le h, zero_add] end
 
-theorem dist_eq_sub_of_ge {n m : ℕ} (h : n ≥ m) : dist n m = n - m :=
+theorem dist_eq_sub_of_le_right {n m : ℕ} (h : m ≤ n) : dist n m = n - m :=
 begin rw [dist_comm], apply dist_eq_sub_of_le h end
 
 theorem dist_zero_right (n : ℕ) : dist n 0 = n :=
-eq.trans (dist_eq_sub_of_ge (zero_le n)) (nat.sub_zero n)
+eq.trans (dist_eq_sub_of_le_right (zero_le n)) (nat.sub_zero n)
 
 theorem dist_zero_left (n : ℕ) : dist 0 n = n :=
 eq.trans (dist_eq_sub_of_le (zero_le n)) (nat.sub_zero n)
@@ -87,7 +87,7 @@ or.elim (lt_or_ge i j)
   (assume : i < j,
     by rw [max_eq_right_of_lt this, min_eq_left_of_lt this, dist_eq_sub_of_lt this])
   (assume : i ≥ j,
-    by rw [max_eq_left this , min_eq_right this, dist_eq_sub_of_ge this])
+    by rw [max_eq_left this , min_eq_right this, dist_eq_sub_of_le_right this])
 -/
 
 theorem dist_succ_succ {i j : nat} : dist (succ i) (succ j) = dist i j :=
@@ -99,6 +99,6 @@ assume hne, nat.lt_by_cases
      begin rw [dist_eq_sub_of_le (le_of_lt this)], apply nat.sub_pos_of_lt this end)
   (assume : i = j, by contradiction)
   (assume : i > j,
-     begin rw [dist_eq_sub_of_ge (le_of_lt this)], apply nat.sub_pos_of_lt this end)
+     begin rw [dist_eq_sub_of_le_right (le_of_lt this)], apply nat.sub_pos_of_lt this end)
 
 end nat

--- a/src/data/num/lemmas.lean
+++ b/src/data/num/lemmas.lean
@@ -97,7 +97,7 @@ theorem cmp_swap (m) : ∀n, (cmp m n).swap = cmp n m :=
 by induction m with m IH m IH; intro n;
    cases n with n n; try {unfold cmp}; try {refl}; rw ←IH; cases cmp m n; refl
 
-theorem cmp_to_nat : ∀ (m n), (ordering.cases_on (cmp m n) ((m:ℕ) < n) (m = n) ((m:ℕ) > n) : Prop)
+theorem cmp_to_nat : ∀ (m n), (ordering.cases_on (cmp m n) ((m:ℕ) < n) (m = n) ((n:ℕ) < m) : Prop)
 | 1        1        := rfl
 | (bit0 a) 1        := let h : (1:ℕ) ≤ a := to_nat_pos a in add_le_add h h
 | (bit1 a) 1        := nat.succ_lt_succ $ to_nat_pos $ bit0 a
@@ -227,7 +227,7 @@ theorem mul_to_nat : ∀ m n, ((m * n : num) : ℕ) = m * n
 | (pos p) 0       := rfl
 | (pos p) (pos q) := pos_num.mul_to_nat _ _
 
-theorem cmp_to_nat : ∀ (m n), (ordering.cases_on (cmp m n) ((m:ℕ) < n) (m = n) ((m:ℕ) > n) : Prop)
+theorem cmp_to_nat : ∀ (m n), (ordering.cases_on (cmp m n) ((m:ℕ) < n) (m = n) ((n:ℕ) < m) : Prop)
 | 0       0       := rfl
 | 0       (pos b) := to_nat_pos _
 | (pos a) 0       := to_nat_pos _
@@ -517,7 +517,7 @@ end num
 namespace pos_num
 open num
 
-theorem pred_to_nat {n : pos_num} (h : n > 1) : (pred n : ℕ) = nat.pred n :=
+theorem pred_to_nat {n : pos_num} (h : 1 < n) : (pred n : ℕ) = nat.pred n :=
 begin
   unfold pred,
   have := pred'_to_nat n,
@@ -950,7 +950,7 @@ of_int_cast n
 | (n : ℕ) := to_int_inj.1 $ by simp [znum.of_int']
 | -[1+ n] := to_int_inj.1 $ by simp [znum.of_int']
 
-theorem cmp_to_int : ∀ (m n), (ordering.cases_on (cmp m n) ((m:ℤ) < n) (m = n) ((m:ℤ) > n) : Prop)
+theorem cmp_to_int : ∀ (m n), (ordering.cases_on (cmp m n) ((m:ℤ) < n) (m = n) ((n:ℤ) < m) : Prop)
 | 0       0       := rfl
 | (pos a) (pos b) := begin
     have := pos_num.cmp_to_nat a b; revert this; dsimp [cmp];

--- a/src/data/padics/padic_numbers.lean
+++ b/src/data/padics/padic_numbers.lean
@@ -95,7 +95,7 @@ def stationary_point {f : padic_seq p} (hf : ¬ f ≈ 0) : ℕ :=
 classical.some $ stationary hf
 
 lemma stationary_point_spec {f : padic_seq p} (hf : ¬ f ≈ 0) :
-  ∀ {m n}, m ≥ stationary_point hf → n ≥ stationary_point hf →
+  ∀ {m n}, stationary_point hf ≤ m → stationary_point hf ≤ n →
     padic_norm p (f n) = padic_norm p (f m) :=
 classical.some_spec $ stationary hf
 
@@ -147,7 +147,7 @@ lemma not_lim_zero_const_of_nonzero {q : ℚ} (hq : q ≠ 0) : ¬ lim_zero (cons
 lemma not_equiv_zero_const_of_nonzero {q : ℚ} (hq : q ≠ 0) : ¬ (const (padic_norm p) q) ≈ 0 :=
 λ h : lim_zero (const (padic_norm p) q - 0), not_lim_zero_const_of_nonzero hq $ by simpa using h
 
-lemma norm_nonneg (f : padic_seq p) : f.norm ≥ 0 :=
+lemma norm_nonneg (f : padic_seq p) : 0 ≤ f.norm :=
 if hf : f ≈ 0 then by simp [hf, norm]
 else by simp [norm, hf, padic_norm.nonneg]
 
@@ -265,22 +265,22 @@ by simp [h1, norm, hp.one_lt]
 
 private lemma norm_eq_of_equiv_aux {f g : padic_seq p} (hf : ¬ f ≈ 0) (hg : ¬ g ≈ 0) (hfg : f ≈ g)
   (h : padic_norm p (f (stationary_point hf)) ≠ padic_norm p (g (stationary_point hg)))
-  (hgt : padic_norm p (f (stationary_point hf)) > padic_norm p (g (stationary_point hg))) :
+  (hlt : padic_norm p (g (stationary_point hg)) < padic_norm p (f (stationary_point hf))) :
   false :=
 begin
-  have hpn : padic_norm p (f (stationary_point hf)) - padic_norm p (g (stationary_point hg)) > 0,
-    from sub_pos_of_lt hgt,
+  have hpn : 0 < padic_norm p (f (stationary_point hf)) - padic_norm p (g (stationary_point hg)),
+    from sub_pos_of_lt hlt,
   cases hfg _ hpn with N hN,
   let i := max N (max (stationary_point hf) (stationary_point hg)),
-  have hi : i ≥ N, from le_max_left _ _,
+  have hi : N ≤ i, from le_max_left _ _,
   have hN' := hN _ hi,
-  padic_index_simp [N, hf, hg] at hN' h hgt,
+  padic_index_simp [N, hf, hg] at hN' h hlt,
   have hpne : padic_norm p (f i) ≠ padic_norm p (-(g i)),
     by rwa [ ←padic_norm.neg p (g i)] at h,
   let hpnem := add_eq_max_of_ne p hpne,
   have hpeq : padic_norm p ((f - g) i) = max (padic_norm p (f i)) (padic_norm p (g i)),
   { rwa padic_norm.neg at hpnem },
-  rw [hpeq, max_eq_left_of_lt hgt] at hN',
+  rw [hpeq, max_eq_left_of_lt hlt] at hN',
   have : padic_norm p (f i) < padic_norm p (f i),
   { apply lt_of_lt_of_le hN', apply sub_le_self, apply padic_norm.nonneg },
   exact lt_irrefl _ this
@@ -290,13 +290,13 @@ private lemma norm_eq_of_equiv {f g : padic_seq p} (hf : ¬ f ≈ 0) (hg : ¬ g 
   padic_norm p (f (stationary_point hf)) = padic_norm p (g (stationary_point hg)) :=
 begin
   by_contradiction h,
-  cases (decidable.em (padic_norm p (f (stationary_point hf)) >
-          padic_norm p (g (stationary_point hg))))
-      with hgt hngt,
-  { exact norm_eq_of_equiv_aux hf hg hfg h hgt },
+  cases (decidable.em (padic_norm p (g (stationary_point hg)) <
+          padic_norm p (f (stationary_point hf))))
+      with hlt hnlt,
+  { exact norm_eq_of_equiv_aux hf hg hfg h hlt },
   { apply norm_eq_of_equiv_aux hg hf (setoid.symm hfg) (ne.symm h),
     apply lt_of_le_of_ne,
-    apply le_of_not_gt hngt,
+    apply le_of_not_gt hnlt,
     apply h }
 end
 
@@ -501,20 +501,20 @@ section embedding
 open padic_seq
 variables {p : ℕ} [fact p.prime]
 
-lemma defn (f : padic_seq p) {ε : ℚ} (hε : ε > 0) : ∃ N, ∀ i ≥ N, padic_norm_e (⟦f⟧ - f i) < ε :=
+lemma defn (f : padic_seq p) {ε : ℚ} (hε : 0 < ε) : ∃ N, ∀ i ≥ N, padic_norm_e (⟦f⟧ - f i) < ε :=
 begin
   simp only [padic.cast_eq_of_rat],
   change ∃ N, ∀ i ≥ N, (f - const _ (f i)).norm < ε,
   by_contradiction h,
   cases cauchy₂ f hε with N hN,
-  have : ∀ N, ∃ i ≥ N, (f - const _ (f i)).norm ≥ ε,
+  have : ∀ N, ∃ i ≥ N, ε ≤ (f - const _ (f i)).norm,
     by simpa [not_forall] using h,
   rcases this N with ⟨i, hi, hge⟩,
   have hne : ¬ (f - const (padic_norm p) (f i)) ≈ 0,
   { intro h, unfold padic_seq.norm at hge; split_ifs at hge, exact not_lt_of_ge hge hε },
   unfold padic_seq.norm at hge; split_ifs at hge,
   apply not_le_of_gt _ hge,
-  cases decidable.em ((stationary_point hne) ≥ N) with hgen hngen,
+  cases decidable.em (N ≤ stationary_point hne) with hgen hngen,
   { apply hN; assumption },
   { have := stationary_point_spec hne (le_refl _) (le_of_not_le hngen),
     rw ←this,
@@ -522,7 +522,7 @@ begin
     apply le_refl, assumption }
 end
 
-protected lemma nonneg (q : ℚ_[p]) : padic_norm_e q ≥ 0 :=
+protected lemma nonneg (q : ℚ_[p]) : 0 ≤ padic_norm_e q :=
 quotient.induction_on q $ norm_nonneg
 
 lemma zero_def : (0 : ℚ_[p]) = ⟦0⟧ := rfl
@@ -595,7 +595,7 @@ namespace padic
 section complete
 open padic_seq padic
 
-theorem rat_dense' {p : ℕ} [fact p.prime] (q : ℚ_[p]) {ε : ℚ} (hε : ε > 0) :
+theorem rat_dense' {p : ℕ} [fact p.prime] (q : ℚ_[p]) {ε : ℚ} (hε : 0 < ε) :
   ∃ r : ℚ, padic_norm_e (q - r) < ε :=
 quotient.induction_on q $ λ q',
   have ∃ N, ∀ m n ≥ N, padic_norm p (q' m - q' n) < ε, from cauchy₂ _ hε,
@@ -609,7 +609,7 @@ quotient.induction_on q $ λ q',
       { simp only [padic_seq.norm, dif_neg hne'],
         change padic_norm p (q' _ - q' _) < ε,
         have := stationary_point_spec hne',
-        cases decidable.em (N ≥ stationary_point hne') with hle hle,
+        cases decidable.em (stationary_point hne' ≤ N) with hle hle,
         { have := eq.symm (this (le_refl _) hle),
           simp at this, simpa [this] },
         { apply hN,
@@ -619,7 +619,7 @@ quotient.induction_on q $ λ q',
 variables {p : ℕ} [fact p.prime] (f : cau_seq _ (@padic_norm_e p _))
 open classical
 
-private lemma div_nat_pos (n : ℕ) : (1 / ((n + 1): ℚ)) > 0 :=
+private lemma div_nat_pos (n : ℕ) : 0 < (1 / ((n + 1): ℚ)) :=
 div_pos zero_lt_one (by exact_mod_cast succ_pos _)
 
 def lim_seq : ℕ → ℚ := λ n, classical.some (rat_dense' (f n) (div_nat_pos n))
@@ -638,7 +638,7 @@ end
 
 lemma exi_rat_seq_conv_cauchy : is_cau_seq (padic_norm p) (lim_seq f) :=
 assume ε hε,
-have hε3 : ε / 3 > 0, from div_pos hε (by norm_num),
+have hε3 : 0 < ε / 3, from div_pos hε (by norm_num),
 let ⟨N, hN⟩ := exi_rat_seq_conv f hε3,
     ⟨N2, hN2⟩ := f.cauchy₂ hε3 in
 begin
@@ -677,8 +677,8 @@ private def lim : ℚ_[p] := ⟦lim' f⟧
 theorem complete' : ∃ q : ℚ_[p], ∀ ε > 0, ∃ N, ∀ i ≥ N, padic_norm_e (q - f i) < ε :=
 ⟨ lim f,
   λ ε hε,
-  let ⟨N, hN⟩ := exi_rat_seq_conv f (show ε / 2 > 0, from div_pos hε (by norm_num)),
-      ⟨N2, hN2⟩ := padic_norm_e.defn (lim' f) (show ε / 2 > 0, from div_pos hε (by norm_num)) in
+  let ⟨N, hN⟩ := exi_rat_seq_conv f (show 0 < ε / 2, from div_pos hε (by norm_num)),
+      ⟨N2, hN2⟩ := padic_norm_e.defn (lim' f) (show 0 < ε / 2, from div_pos hε (by norm_num)) in
   begin
     existsi max N N2,
     intros i hi,
@@ -730,7 +730,7 @@ instance : is_absolute_value (λ a : ℚ_[p], ∥a∥) :=
   abv_add := norm_add_le,
   abv_mul := by simp [has_norm.norm, padic_norm_e.mul'] }
 
-theorem rat_dense {p : ℕ} {hp : fact p.prime} (q : ℚ_[p]) {ε : ℝ} (hε : ε > 0) :
+theorem rat_dense {p : ℕ} {hp : fact p.prime} (q : ℚ_[p]) {ε : ℝ} (hε : 0 < ε) :
         ∃ r : ℚ, ∥q - r∥ < ε :=
 let ⟨ε', hε'l, hε'r⟩ := exists_rat_btwn hε,
     ⟨r, hr⟩ := rat_dense' q (by simpa using hε'l)  in
@@ -858,7 +858,7 @@ begin
   exact_mod_cast hN i hi
 end
 
-lemma padic_norm_e_lim_le {f : cau_seq ℚ_[p] norm} {a : ℝ} (ha : a > 0)
+lemma padic_norm_e_lim_le {f : cau_seq ℚ_[p] norm} {a : ℝ} (ha : 0 < a)
       (hf : ∀ i, ∥f i∥ ≤ a) : ∥f.lim∥ ≤ a :=
 let ⟨N, hN⟩ := setoid.symm (cau_seq.equiv_lim f) _ ha in
 calc ∥f.lim∥ = ∥f.lim - f N + f N∥ : by simp

--- a/src/data/polynomial/degree/basic.lean
+++ b/src/data/polynomial/degree/basic.lean
@@ -76,7 +76,7 @@ lemma degree_eq_iff_nat_degree_eq {p : polynomial R} {n : ℕ} (hp : p ≠ 0) :
   p.degree = n ↔ p.nat_degree = n :=
 by rw [degree_eq_nat_degree hp, with_bot.coe_eq_coe]
 
-lemma degree_eq_iff_nat_degree_eq_of_pos {p : polynomial R} {n : ℕ} (hn : n > 0) :
+lemma degree_eq_iff_nat_degree_eq_of_pos {p : polynomial R} {n : ℕ} (hn : 0 < n) :
   p.degree = n ↔ p.nat_degree = n :=
 begin
   split,

--- a/src/data/real/basic.lean
+++ b/src/data/real/basic.lean
@@ -153,7 +153,7 @@ noncomputable instance decidable_lt (a b : ℝ) : decidable (a < b) := by apply_
 noncomputable instance decidable_le (a b : ℝ) : decidable (a ≤ b) := by apply_instance
 noncomputable instance decidable_eq (a b : ℝ) : decidable (a = b) := by apply_instance
 
-lemma le_of_forall_epsilon_le {a b : real} (h : ∀ε, ε > 0 → a ≤ b + ε) : a ≤ b :=
+lemma le_of_forall_epsilon_le {a b : real} (h : ∀ε, 0 < ε → a ≤ b + ε) : a ≤ b :=
 le_of_forall_le_of_dense $ assume x hxb,
 calc  a ≤ b + (x - b) : h (x-b) $ sub_pos.2 hxb
     ... = x : by rw [add_comm]; simp

--- a/src/data/real/cau_seq.lean
+++ b/src/data/real/cau_seq.lean
@@ -169,7 +169,7 @@ variables {α : Type*} [discrete_linear_ordered_field α]
   {β : Type*} [ring β] {abv : β → α} [is_absolute_value abv] {f : ℕ → β}
 
 @[nolint ge_or_gt] -- see Note [nolint_ge]
-theorem cauchy₂ (hf : is_cau_seq abv f) {ε : α} (ε0 : ε > 0) :
+theorem cauchy₂ (hf : is_cau_seq abv f) {ε : α} (ε0 : 0 < ε) :
   ∃ i, ∀ j k ≥ i, abv (f j - f k) < ε :=
 begin
   refine (hf _ (half_pos ε0)).imp (λ i hi j k ij ik, _),
@@ -179,7 +179,7 @@ begin
 end
 
 @[nolint ge_or_gt] -- see Note [nolint_ge]
-theorem cauchy₃ (hf : is_cau_seq abv f) {ε : α} (ε0 : ε > 0) :
+theorem cauchy₃ (hf : is_cau_seq abv f) {ε : α} (ε0 : 0 < ε) :
   ∃ i, ∀ j ≥ i, ∀ k ≥ j, abv (f k - f j) < ε :=
 let ⟨i, H⟩ := hf.cauchy₂ ε0 in ⟨i, λ j ij k jk, H _ _ (le_trans ij jk) ij⟩
 
@@ -209,7 +209,7 @@ theorem is_cau (f : cau_seq β abv) : is_cau_seq abv f := f.2
 
 @[nolint ge_or_gt] -- see Note [nolint_ge]
 theorem cauchy (f : cau_seq β abv) :
-  ∀ {ε}, ε > 0 → ∃ i, ∀ j ≥ i, abv (f j - f i) < ε := f.2
+  ∀ {ε}, 0 < ε → ∃ i, ∀ j ≥ i, abv (f j - f i) < ε := f.2
 
 /-- Given a Cauchy sequence `f`, create a Cauchy sequence from a sequence `g` with
 the same values as `f`. -/
@@ -219,11 +219,11 @@ def of_eq (f : cau_seq β abv) (g : ℕ → β) (e : ∀ i, f i = g i) : cau_seq
 variable [is_absolute_value abv]
 
 @[nolint ge_or_gt] -- see Note [nolint_ge]
-theorem cauchy₂ (f : cau_seq β abv) {ε} : ε > 0 →
+theorem cauchy₂ (f : cau_seq β abv) {ε} : 0 < ε →
   ∃ i, ∀ j k ≥ i, abv (f j - f k) < ε := f.2.cauchy₂
 
 @[nolint ge_or_gt] -- see Note [nolint_ge]
-theorem cauchy₃ (f : cau_seq β abv) {ε} : ε > 0 →
+theorem cauchy₃ (f : cau_seq β abv) {ε} : 0 < ε →
   ∃ i, ∀ j ≥ i, ∀ k ≥ j, abv (f k - f j) < ε := f.2.cauchy₃
 
 theorem bounded (f : cau_seq β abv) : ∃ r, ∀ i, abv (f i) < r :=
@@ -424,7 +424,7 @@ have hg' : ¬ lim_zero g, by simpa using (show ¬ lim_zero (g - 0), from hg),
 begin
   rcases abv_pos_of_not_lim_zero hf' with ⟨a1, ha1, N1, hN1⟩,
   rcases abv_pos_of_not_lim_zero hg' with ⟨a2, ha2, N2, hN2⟩,
-  have : a1 * a2 > 0, from mul_pos ha1 ha2,
+  have : 0 < a1 * a2, from mul_pos ha1 ha2,
   cases hlz _ this with N hN,
   let i := max N (max N1 N2),
   have hN' := hN i (le_max_left _ _),
@@ -456,12 +456,12 @@ variables {β : Type*} [integral_domain β] (abv : β → α) [is_absolute_value
 
 lemma one_not_equiv_zero : ¬ (const abv 1) ≈ (const abv 0) :=
 assume h,
-have ∀ ε > 0, ∃ i, ∀ k, k ≥ i → abv (1 - 0) < ε, from h,
+have ∀ ε > 0, ∃ i, ∀ k, i ≤ k → abv (1 - 0) < ε, from h,
 have h1 : abv 1 ≤ 0, from le_of_not_gt $
-  assume h2 : abv 1 > 0,
+  assume h2 : 0 < abv 1,
   exists.elim (this _ h2) $ λ i hi,
     lt_irrefl (abv 1) $ by simpa using hi _ (le_refl _),
-have h2 : abv 1 ≥ 0, from is_absolute_value.abv_nonneg _ _,
+have h2 : 0 ≤ abv 1, from is_absolute_value.abv_nonneg _ _,
 have abv 1 = 0, from le_antisymm h1 h2,
 have (1 : β) = 0, from (is_absolute_value.abv_eq_zero abv).1 this,
 absurd this one_ne_zero

--- a/src/data/real/hyperreal.lean
+++ b/src/data/real/hyperreal.lean
@@ -73,7 +73,7 @@ lemma inv_epsilon_eq_omega : ε⁻¹ = ω := @inv_inv' _ _ ω
 
 lemma epsilon_pos : 0 < ε :=
 suffices ∀ᶠ i in hyperfilter, (0 : ℝ) < (i : ℕ)⁻¹, by rwa lt_def U,
-have h0' : {n : ℕ | ¬ n > 0} = {0} :=
+have h0' : {n : ℕ | ¬ 0 < n} = {0} :=
 by simp only [not_lt, (set.set_of_eq_eq_singleton).symm]; ext; exact nat.le_zero_iff,
 begin
   simp only [inv_pos, nat.cast_pos],
@@ -101,7 +101,7 @@ begin
 end
 
 lemma neg_lt_of_tendsto_zero_of_pos {f : ℕ → ℝ} (hf : tendsto f at_top (𝓝 0)) :
-  ∀ {r : ℝ}, r > 0 → (-r : ℝ*) < of_seq f :=
+  ∀ {r : ℝ}, 0 < r → (-r : ℝ*) < of_seq f :=
 λ r hr, have hg : _ := hf.neg,
 neg_lt_of_neg_lt (by rw [neg_zero] at hg; exact lt_of_tendsto_zero_of_pos hg hr)
 
@@ -124,7 +124,7 @@ noncomputable def st : ℝ* → ℝ :=
 def infinitesimal (x : ℝ*) := is_st x 0
 
 /-- A hyperreal number is positive infinite if it is larger than all real numbers -/
-def infinite_pos (x : ℝ*) := ∀ r : ℝ, x > r
+def infinite_pos (x : ℝ*) := ∀ r : ℝ, ↑r < x
 
 /-- A hyperreal number is negative infinite if it is smaller than all real numbers -/
 def infinite_neg (x : ℝ*) := ∀ r : ℝ, x < r
@@ -251,7 +251,7 @@ lemma is_st_inj_real {r₁ r₂ s : ℝ} (h1 : is_st r₁ s) (h2 : is_st r₂ s)
 eq.trans (eq_of_is_st_real h1) (eq_of_is_st_real h2).symm
 
 lemma is_st_iff_abs_sub_lt_delta {x : ℝ*} {r : ℝ} :
-  is_st x r ↔ ∀ (δ : ℝ), δ > 0 → abs (x - r) < δ :=
+  is_st x r ↔ ∀ (δ : ℝ), 0 < δ → abs (x - r) < δ :=
 by simp only [abs_sub_lt_iff, @sub_lt _ _ (r : ℝ*) x _,
     @sub_lt_iff_lt_add' _ _ x (r : ℝ*) _, and_comm]; refl
 
@@ -300,7 +300,7 @@ lt_of_is_st_lt hx' hy'
 ### Basic lemmas about infinite
 -/
 
-lemma infinite_pos_def {x : ℝ*} : infinite_pos x ↔ ∀ r : ℝ, x > r := by rw iff_eq_eq; refl
+lemma infinite_pos_def {x : ℝ*} : infinite_pos x ↔ ∀ r : ℝ, ↑r < x := by rw iff_eq_eq; refl
 
 lemma infinite_neg_def {x : ℝ*} : infinite_neg x ↔ ∀ r : ℝ, x < r := by rw iff_eq_eq; refl
 
@@ -311,7 +311,7 @@ lemma ne_zero_of_infinite {x : ℝ*} : infinite x → x ≠ 0 :=
 
 lemma not_infinite_zero : ¬ infinite 0 := λ hI, ne_zero_of_infinite hI rfl
 
-lemma pos_of_infinite_pos {x : ℝ*} : infinite_pos x → x > 0 := λ hip, hip 0
+lemma pos_of_infinite_pos {x : ℝ*} : infinite_pos x → 0 < x := λ hip, hip 0
 
 lemma neg_of_infinite_neg {x : ℝ*} : infinite_neg x → x < 0 := λ hin, hin 0
 
@@ -355,7 +355,7 @@ lemma not_infinitesimal_of_infinite_pos {x : ℝ*} : infinite_pos x → ¬ infin
 lemma not_infinitesimal_of_infinite_neg {x : ℝ*} : infinite_neg x → ¬ infinitesimal x :=
 λ hn, not_infinitesimal_of_infinite (or.inr hn)
 
-lemma infinite_pos_iff_infinite_and_pos {x : ℝ*} : infinite_pos x ↔ (infinite x ∧ x > 0) :=
+lemma infinite_pos_iff_infinite_and_pos {x : ℝ*} : infinite_pos x ↔ (infinite x ∧ 0 < x) :=
 ⟨ λ hip, ⟨or.inl hip, hip 0⟩,
   λ ⟨hi, hp⟩, hi.cases_on (λ hip, hip) (λ hin, false.elim (not_lt_of_lt hp (hin 0))) ⟩
 
@@ -363,10 +363,10 @@ lemma infinite_neg_iff_infinite_and_neg {x : ℝ*} : infinite_neg x ↔ (infinit
 ⟨ λ hip, ⟨or.inr hip, hip 0⟩,
   λ ⟨hi, hp⟩, hi.cases_on (λ hin, false.elim (not_lt_of_lt hp (hin 0))) (λ hip, hip) ⟩
 
-lemma infinite_pos_iff_infinite_of_pos {x : ℝ*} (hp : x > 0) : infinite_pos x ↔ infinite x :=
+lemma infinite_pos_iff_infinite_of_pos {x : ℝ*} (hp : 0 < x) : infinite_pos x ↔ infinite x :=
 by rw [infinite_pos_iff_infinite_and_pos]; exact ⟨λ hI, hI.1, λ hI, ⟨hI, hp⟩⟩
 
-lemma infinite_pos_iff_infinite_of_nonneg {x : ℝ*} (hp : x ≥ 0) : infinite_pos x ↔ infinite x :=
+lemma infinite_pos_iff_infinite_of_nonneg {x : ℝ*} (hp : 0 ≤ x) : infinite_pos x ↔ infinite x :=
 or.cases_on (lt_or_eq_of_le hp) (infinite_pos_iff_infinite_of_pos)
   (λ h, by rw h.symm; exact
   ⟨λ hIP, false.elim (not_infinite_zero (or.inl hIP)), λ hI, false.elim (not_infinite_zero hI)⟩)
@@ -569,13 +569,13 @@ theorem infinitesimal_def {x : ℝ*} :
 ⟨ λ hi r hr, by { convert (hi r hr); simp },
   λ hi d hd, by { convert (hi d hd); simp } ⟩
 
-theorem lt_of_pos_of_infinitesimal {x : ℝ*} : infinitesimal x → ∀ r : ℝ, r > 0 → x < r :=
+theorem lt_of_pos_of_infinitesimal {x : ℝ*} : infinitesimal x → ∀ r : ℝ, 0 < r → x < r :=
 λ hi r hr, ((infinitesimal_def.mp hi) r hr).2
 
-theorem lt_neg_of_pos_of_infinitesimal {x : ℝ*} : infinitesimal x → ∀ r : ℝ, r > 0 → x > -r :=
+theorem lt_neg_of_pos_of_infinitesimal {x : ℝ*} : infinitesimal x → ∀ r : ℝ, 0 < r → -↑r < x :=
 λ hi r hr, ((infinitesimal_def.mp hi) r hr).1
 
-theorem gt_of_neg_of_infinitesimal {x : ℝ*} : infinitesimal x → ∀ r : ℝ, r < 0 → x > r :=
+theorem gt_of_neg_of_infinitesimal {x : ℝ*} : infinitesimal x → ∀ r : ℝ, r < 0 → ↑r < x :=
 λ hi r hr, by convert ((infinitesimal_def.mp hi) (-r) (neg_pos.mpr hr)).1;
 exact (neg_neg ↑r).symm
 
@@ -627,12 +627,12 @@ theorem infinitesimal_sub_st {x : ℝ*} (hx : ¬infinite x) : infinitesimal (x -
 infinitesimal_sub_is_st $ is_st_st' hx
 
 lemma infinite_pos_iff_infinitesimal_inv_pos {x : ℝ*} :
-  infinite_pos x ↔ (infinitesimal x⁻¹ ∧ x⁻¹ > 0) :=
+  infinite_pos x ↔ (infinitesimal x⁻¹ ∧ 0 < x⁻¹) :=
 ⟨ λ hip, ⟨ infinitesimal_def.mpr $ λ r hr,
   ⟨ lt_trans (coe_lt_coe.2 (neg_neg_of_pos hr)) (inv_pos.2 (hip 0)),
     (inv_lt (coe_lt_coe.2 hr) (hip 0)).mp (by convert hip r⁻¹) ⟩,
   inv_pos.2 $ hip 0 ⟩,
-  λ ⟨hi, hp⟩ r, @classical.by_cases (r = 0) (x > (r : ℝ*)) (λ h, eq.substr h (inv_pos.mp hp)) $
+  λ ⟨hi, hp⟩ r, @classical.by_cases (r = 0) (↑r < x) (λ h, eq.substr h (inv_pos.mp hp)) $
   λ h, lt_of_le_of_lt (coe_le_coe.2 (le_abs_self r))
   ((inv_lt_inv (inv_pos.mp hp) (coe_lt_coe.2 (abs_pos_of_ne_zero h))).mp
   ((infinitesimal_def.mp hi) ((abs r)⁻¹) (inv_pos.2 (abs_pos_of_ne_zero h))).2) ⟩
@@ -663,7 +663,7 @@ theorem infinite_iff_infinitesimal_inv {x : ℝ*} (h0 : x ≠ 0) : infinite x �
 ⟨ infinitesimal_inv_of_infinite, infinite_of_infinitesimal_inv h0 ⟩
 
 lemma infinitesimal_pos_iff_infinite_pos_inv {x : ℝ*} :
-  infinite_pos x⁻¹ ↔ (infinitesimal x ∧ x > 0) :=
+  infinite_pos x⁻¹ ↔ (infinitesimal x ∧ 0 < x) :=
 by convert infinite_pos_iff_infinitesimal_inv_pos; simp only [inv_inv']
 
 lemma infinitesimal_neg_iff_infinite_neg_inv {x : ℝ*} :
@@ -714,7 +714,7 @@ lemma infinite_omega : infinite ω :=
 (infinite_iff_infinitesimal_inv omega_ne_zero).mpr infinitesimal_epsilon
 
 lemma infinite_pos_mul_of_infinite_pos_not_infinitesimal_pos {x y : ℝ*} :
-  infinite_pos x → ¬ infinitesimal y → y > 0 → infinite_pos (x * y) :=
+  infinite_pos x → ¬ infinitesimal y → 0 < y → infinite_pos (x * y) :=
 λ hx hy₁ hy₂ r, have hy₁' : _ := not_forall.mp (by rw infinitesimal_def at hy₁; exact hy₁),
 Exists.dcases_on hy₁' $ λ r₁ hy₁'',
 have hyr : _ := by rw [not_imp, ←abs_lt, not_lt, abs_of_pos hy₂] at hy₁''; exact hy₁'',
@@ -749,7 +749,7 @@ by rw [infinite_neg_iff_infinite_pos_neg, infinite_neg_iff_infinite_pos_neg, neg
 exact infinite_pos_mul_of_infinite_pos_not_infinitesimal_pos
 
 lemma infinite_neg_mul_of_not_infinitesimal_pos_infinite_neg {x y : ℝ*} :
-  ¬ infinitesimal x → x > 0 → infinite_neg y → infinite_neg (x * y) :=
+  ¬ infinitesimal x → 0 < x → infinite_neg y → infinite_neg (x * y) :=
 λ hx hp hy, by rw mul_comm; exact infinite_neg_mul_of_infinite_neg_not_infinitesimal_pos hy hx hp
 
 lemma infinite_pos_mul_infinite_pos {x y : ℝ*} :
@@ -774,7 +774,7 @@ hx (not_infinitesimal_of_infinite_pos hy) (hy 0)
 
 lemma infinite_mul_of_infinite_not_infinitesimal {x y : ℝ*} :
   infinite x → ¬ infinitesimal y → infinite (x * y) :=
-λ hx hy, have h0 : y < 0 ∨ y > 0 := lt_or_gt_of_ne (λ H0, hy (eq.substr H0 (is_st_refl_real 0))),
+λ hx hy, have h0 : y < 0 ∨ 0 < y := lt_or_gt_of_ne (λ H0, hy (eq.substr H0 (is_st_refl_real 0))),
 or.dcases_on hx
   (or.dcases_on h0
     (λ H0 Hx, or.inr (infinite_neg_mul_of_infinite_pos_not_infinitesimal_neg Hx hy H0))

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -27,7 +27,7 @@ instance : has_coe ℝ≥0 ℝ := ⟨subtype.val⟩
 
 instance : can_lift ℝ nnreal :=
 { coe := coe,
-  cond := λ r, r ≥ 0,
+  cond := λ r, 0 ≤ r,
   prf := λ x hx, ⟨⟨x, hx⟩, rfl⟩ }
 
 protected lemma eq {n m : ℝ≥0} : (n : ℝ) = (m : ℝ) → n = m := subtype.eq
@@ -265,7 +265,7 @@ instance : archimedean nnreal :=
   let ⟨n, hr⟩ := archimedean.arch (x:ℝ) (pos_y : (0 : ℝ) < y) in
   ⟨n, show (x:ℝ) ≤ (n •ℕ y : nnreal), by simp [*, -nsmul_eq_mul, nsmul_coe]⟩ ⟩
 
-lemma le_of_forall_epsilon_le {a b : nnreal} (h : ∀ε, ε > 0 → a ≤ b + ε) : a ≤ b :=
+lemma le_of_forall_epsilon_le {a b : nnreal} (h : ∀ε, 0 < ε → a ≤ b + ε) : a ≤ b :=
 le_of_forall_le_of_dense $ assume x hxb,
 begin
   rcases le_iff_exists_add.1 (le_of_lt hxb) with ⟨ε, rfl⟩,
@@ -358,10 +358,10 @@ nnreal.coe_le_coe.1 $ max_le (add_le_add (le_max_left _ _) (le_max_left _ _)) nn
 lemma of_real_le_iff_le_coe {r : ℝ} {p : nnreal} : nnreal.of_real r ≤ p ↔ r ≤ ↑p :=
 nnreal.gi.gc r p
 
-lemma le_of_real_iff_coe_le {r : nnreal} {p : ℝ} (hp : p ≥ 0) : r ≤ nnreal.of_real p ↔ ↑r ≤ p :=
+lemma le_of_real_iff_coe_le {r : nnreal} {p : ℝ} (hp : 0 ≤ p) : r ≤ nnreal.of_real p ↔ ↑r ≤ p :=
 by rw [← nnreal.coe_le_coe, nnreal.coe_of_real p hp]
 
-lemma of_real_lt_iff_lt_coe {r : ℝ} {p : nnreal} (ha : r ≥ 0) : nnreal.of_real r < p ↔ r < ↑p :=
+lemma of_real_lt_iff_lt_coe {r : ℝ} {p : nnreal} (ha : 0 ≤ r) : nnreal.of_real r < p ↔ r < ↑p :=
 by rw [← nnreal.coe_lt_coe, nnreal.coe_of_real r ha]
 
 lemma lt_of_real_iff_coe_lt {r : nnreal} {p : ℝ} : r < nnreal.of_real p ↔ ↑r < p :=

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -409,19 +409,19 @@ lemma eq_of_le_of_forall_le_of_dense [linear_order α] [densely_ordered α] {a�
 le_antisymm (le_of_forall_le_of_dense h₂) h₁
 
 lemma le_of_forall_ge_of_dense [linear_order α] [densely_ordered α] {a₁ a₂ : α}
-  (h : ∀a₃<a₁, a₂ ≥ a₃) :
+  (h : ∀a₃<a₁, a₃ ≤ a₂) :
   a₁ ≤ a₂ :=
 le_of_not_gt $ assume ha,
   let ⟨a, ha₁, ha₂⟩ := dense ha in
   lt_irrefl a $ lt_of_le_of_lt (h _ ‹a < a₁›) ‹a₂ < a›
 
 lemma eq_of_le_of_forall_ge_of_dense [linear_order α] [densely_ordered α] {a₁ a₂ : α}
-  (h₁ : a₂ ≤ a₁) (h₂ : ∀a₃<a₁, a₂ ≥ a₃) : a₁ = a₂ :=
+  (h₁ : a₂ ≤ a₁) (h₂ : ∀a₃<a₁, a₃ ≤ a₂) : a₁ = a₂ :=
 le_antisymm (le_of_forall_ge_of_dense h₂) h₁
 
 @[nolint ge_or_gt] -- see Note [nolint_ge]
 lemma dense_or_discrete [linear_order α] (a₁ a₂ : α) :
-  (∃a, a₁ < a ∧ a < a₂) ∨ ((∀a>a₁, a ≥ a₂) ∧ (∀a<a₂, a ≤ a₁)) :=
+  (∃a, a₁ < a ∧ a < a₂) ∨ ((∀a>a₁, a₂ ≤ a) ∧ (∀a<a₂, a ≤ a₁)) :=
 classical.or_iff_not_imp_left.2 $ assume h,
   ⟨assume a ha₁, le_of_not_gt $ assume ha₂, h ⟨a, ha₁, ha₂⟩,
     assume a ha₂, le_of_not_gt $ assume ha₁, h ⟨a, ha₁, ha₂⟩⟩

--- a/src/order/filter/at_top_bot.lean
+++ b/src/order/filter/at_top_bot.lean
@@ -491,7 +491,7 @@ lemma tendsto_add_at_top_iff_nat {f : ℕ → α} {l : filter α} (k : ℕ) :
 show tendsto (f ∘ (λn, n + k)) at_top l ↔ tendsto f at_top l,
   by rw [← tendsto_map'_iff, map_add_at_top_eq_nat]
 
-lemma map_div_at_top_eq_nat (k : ℕ) (hk : k > 0) : map (λa, a / k) at_top = at_top :=
+lemma map_div_at_top_eq_nat (k : ℕ) (hk : 0 < k) : map (λa, a / k) at_top = at_top :=
 map_at_top_eq_of_gc (λb, b * k + (k - 1)) 1
   (assume a b h, nat.div_le_div_right h)
   (assume a b _,

--- a/src/order/galois_connection.lean
+++ b/src/order/galois_connection.lean
@@ -216,7 +216,7 @@ end galois_connection
 
 namespace nat
 
-lemma galois_connection_mul_div {k : ℕ} (h : k > 0) : galois_connection (λn, n * k) (λn, n / k) :=
+lemma galois_connection_mul_div {k : ℕ} (h : 0 < k) : galois_connection (λn, n * k) (λn, n / k) :=
 assume x y, (le_div_iff_mul_le x y h).symm
 
 end nat

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -867,7 +867,7 @@ lemma sup_succ {ι} (f : ι → ordinal) : sup (λ i, succ (f i)) ≤ succ (sup 
 by { rw [ordinal.sup_le], intro i, rw ordinal.succ_le_succ, apply ordinal.le_sup }
 
 lemma unbounded_range_of_sup_ge {α β : Type u} (r : α → α → Prop) [is_well_order α r] (f : β → α)
-  (h : sup.{u u} (typein r ∘ f) ≥ type r) : unbounded r (range f) :=
+  (h : type r ≤ sup.{u u} (typein r ∘ f)) : unbounded r (range f) :=
 begin
   apply (not_bounded_iff _).mp, rintro ⟨x, hx⟩, apply not_lt_of_ge h,
   refine lt_of_le_of_lt _ (typein_lt_type r x), rw [sup_le], intro y,
@@ -1498,7 +1498,7 @@ by rwa [← add_omega_power h₁, add_lt_add_iff_left]
 theorem add_absorp {a b c : ordinal} (h₁ : a < omega ^ b) (h₂ : omega ^ b ≤ c) : a + c = c :=
 by rw [← add_sub_cancel_of_le h₂, ← add_assoc, add_omega_power h₁]
 
-theorem add_absorp_iff {o : ordinal} (o0 : o > 0) : (∀ a < o, a + o = o) ↔ ∃ a, o = omega ^ a :=
+theorem add_absorp_iff {o : ordinal} (o0 : 0 < o) : (∀ a < o, a + o = o) ↔ ∃ a, o = omega ^ a :=
 ⟨λ H, ⟨log omega o, begin
   refine ((lt_or_eq_of_le (power_log_le _ o0))
     .resolve_left $ λ h, _).symm,

--- a/src/tactic/linarith/lemmas.lean
+++ b/src/tactic/linarith/lemmas.lean
@@ -52,17 +52,17 @@ by simp *
 lemma lt_of_lt_of_eq {α} [ordered_semiring α] {a b : α} (ha : a < 0) (hb : b = 0) : a + b < 0 :=
 by simp *
 
-lemma mul_neg {α} [ordered_ring α] {a b : α} (ha : a < 0) (hb : b > 0) : b * a < 0 :=
+lemma mul_neg {α} [ordered_ring α] {a b : α} (ha : a < 0) (hb : 0 < b) : b * a < 0 :=
 have (-b)*a > 0, from mul_pos_of_neg_of_neg (neg_neg_of_pos hb) ha,
 neg_of_neg_pos (by simpa)
 
-lemma mul_nonpos {α} [ordered_ring α] {a b : α} (ha : a ≤ 0) (hb : b > 0) : b * a ≤ 0 :=
+lemma mul_nonpos {α} [ordered_ring α] {a b : α} (ha : a ≤ 0) (hb : 0 < b) : b * a ≤ 0 :=
 have (-b)*a ≥ 0, from mul_nonneg_of_nonpos_of_nonpos (le_of_lt (neg_neg_of_pos hb)) ha,
 by simpa
 
 -- used alongside `mul_neg` and `mul_nonpos`, so has the same argument pattern for uniformity
 @[nolint unused_arguments]
-lemma mul_eq {α} [ordered_semiring α] {a b : α} (ha : a = 0) (hb : b > 0) : b * a = 0 :=
+lemma mul_eq {α} [ordered_semiring α] {a b : α} (ha : a = 0) (hb : 0 < b) : b * a = 0 :=
 by simp *
 
 lemma eq_of_not_lt_of_not_gt {α} [linear_order α] (a b : α) (h1 : ¬ a < b) (h2 : ¬ b < a) : a = b :=

--- a/src/tactic/monotonicity/lemmas.lean
+++ b/src/tactic/monotonicity/lemmas.lean
@@ -16,8 +16,8 @@ lemma mul_mono_nonneg {x y z : α} [ordered_semiring α]
 : x * z ≤ y * z :=
 by apply mul_le_mul_of_nonneg_right; assumption
 
-lemma gt_of_mul_lt_mul_neg_right {a b c : α}  [linear_ordered_ring α]
-  (h : a * c < b * c) (hc : c ≤ 0) : a > b :=
+lemma lt_of_mul_lt_mul_neg_right {a b c : α}  [linear_ordered_ring α]
+  (h : a * c < b * c) (hc : c ≤ 0) : b < a :=
 have nhc : -c ≥ 0, from neg_nonneg_of_nonpos hc,
 have h2 : -(b * c) < -(a * c), from neg_lt_neg h,
 have h3 : b * (-c) < a * (-c), from calc
@@ -36,7 +36,7 @@ begin
   by_contradiction h'',
   revert h,
   apply not_le_of_lt,
-  apply gt_of_mul_lt_mul_neg_right _ h',
+  apply lt_of_mul_lt_mul_neg_right _ h',
   apply lt_of_not_ge h''
 end
 

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -1999,8 +1999,8 @@ let ⟨c, (h : ∀ᶠ a in f, a ≤ c), hcb⟩ := exists_lt_of_cInf_lt h l in
 mem_sets_of_superset h $ assume a hac, lt_of_le_of_lt hac hcb
 
 @[nolint ge_or_gt] -- see Note [nolint_ge]
-theorem gt_mem_sets_of_Liminf_gt : ∀ {f : filter α} {b}, f.is_bounded (≥) → f.Liminf > b →
-  ∀ᶠ a in f, a > b :=
+theorem gt_mem_sets_of_Liminf_gt : ∀ {f : filter α} {b}, f.is_bounded (≥) → b < f.Liminf →
+  ∀ᶠ a in f, b < a :=
 @lt_mem_sets_of_Limsup_lt (order_dual α) _
 
 variables [topological_space α] [order_topology α]

--- a/src/topology/bounded_continuous_function.lean
+++ b/src/topology/bounded_continuous_function.lean
@@ -335,7 +335,7 @@ lemma equicontinuous_of_continuity_modulus {α : Type u} [metric_space α]
   (b : ℝ → ℝ) (b_lim : tendsto b (𝓝 0) (𝓝 0))
   (A : set (α →ᵇ β))
   (H : ∀(x y:α) (f : α →ᵇ β), f ∈ A → dist (f x) (f y) ≤ b (dist x y))
-  (x:α) (ε : ℝ) (ε0 : ε > 0) : ∃U ∈ 𝓝 x, ∀ (y z ∈ U) (f : α →ᵇ β),
+  (x:α) (ε : ℝ) (ε0 : 0 < ε) : ∃U ∈ 𝓝 x, ∀ (y z ∈ U) (f : α →ᵇ β),
     f ∈ A → dist (f y) (f z) < ε :=
 begin
   rcases tendsto_nhds_nhds.1 b_lim ε ε0 with ⟨δ, δ0, hδ⟩,

--- a/src/topology/metric_space/hausdorff_distance.lean
+++ b/src/topology/metric_space/hausdorff_distance.lean
@@ -548,7 +548,7 @@ by simp [Hausdorff_dist_comm]
 
 /-- Bounding the Hausdorff distance by bounding the distance of any point
 in each set to the other set -/
-lemma Hausdorff_dist_le_of_inf_dist {r : ℝ} (hr : r ≥ 0)
+lemma Hausdorff_dist_le_of_inf_dist {r : ℝ} (hr : 0 ≤ r)
   (H1 : ∀x ∈ s, inf_dist x t ≤ r) (H2 : ∀x ∈ t, inf_dist x s ≤ r) :
   Hausdorff_dist s t ≤ r :=
 begin


### PR DESCRIPTION
These were not caught by the old `ge_or_gt` linter, but they will be caught by the new (upcoming) `ge_or_gt` linter.
The `nolint` flags are not yet removed, this will happen in a later PR.
Renamings:
```
char_is_prime_of_ge_two -> char_is_prime_of_two_le
dist_eq_sub_of_ge -> dist_eq_sub_of_le_right
gt_of_mul_lt_mul_neg_right -> lt_of_mul_lt_mul_neg_right
```
---
<!-- put comments you want to keep out of the PR commit here -->
