### PR TITLE
[Merged by Bors] - feat(*): reorder implicit arguments in tsum, supr, infi

### DIFF
--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -47,9 +47,9 @@ add_decl_doc has_Sup.Sup
 add_decl_doc has_Inf.Inf
 
 /-- Indexed supremum -/
-def supr [has_Sup α] (s : ι → α) : α := Sup (range s)
+def supr [has_Sup α] {ι} (s : ι → α) : α := Sup (range s)
 /-- Indexed infimum -/
-def infi [has_Inf α] (s : ι → α) : α := Inf (range s)
+def infi [has_Inf α] {ι} (s : ι → α) : α := Inf (range s)
 
 @[priority 50] instance has_Inf_to_nonempty (α) [has_Inf α] : nonempty α := ⟨Inf ∅⟩
 @[priority 50] instance has_Sup_to_nonempty (α) [has_Sup α] : nonempty α := ⟨Sup ∅⟩
@@ -268,7 +268,7 @@ Inf_lt_iff.trans exists_range_iff
 
 end complete_linear_order
 
-/- 
+/-
 ### supr & infi
 -/
 

--- a/src/tactic/converter/binders.lean
+++ b/src/tactic/converter/binders.lean
@@ -172,14 +172,14 @@ meta def forall_eq_elim : binder_eq_elim :=
   apply_elim_eq := apply' ``forall_elim_eq_left <|> apply' ``forall_elim_eq_right }
 
 meta def supr_eq_elim : binder_eq_elim :=
-{ match_binder  := λe, (do `(@supr %%α %%β %%cl %%f) ← return e, return (β, f)),
+{ match_binder  := λe, (do `(@supr %%α %%cl %%β %%f) ← return e, return (β, f)),
   adapt_rel     := λc, (do r ← current_relation, guard (r = `eq), c),
   apply_comm    := applyc ``supr_comm,
   apply_congr   := congr_arg ∘ funext',
   apply_elim_eq := applyc ``supr_supr_eq_left <|> applyc ``supr_supr_eq_right }
 
 meta def infi_eq_elim : binder_eq_elim :=
-{ match_binder  := λe, (do `(@infi %%α %%β %%cl %%f) ← return e, return (β, f)),
+{ match_binder  := λe, (do `(@infi %%α %%cl %%β %%f) ← return e, return (β, f)),
   adapt_rel     := λc, (do r ← current_relation, guard (r = `eq), c),
   apply_comm    := applyc ``infi_comm,
   apply_congr   := congr_arg ∘ funext',

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -50,7 +50,7 @@ def has_sum (f : β → α) (a : α) : Prop := tendsto (λs:finset β, ∑ b in 
 def summable (f : β → α) : Prop := ∃a, has_sum f a
 
 /-- `∑' i, f i` is the sum of `f` it exists, or 0 otherwise -/
-def tsum (f : β → α) := if h : summable f then classical.some h else 0
+def tsum {β} (f : β → α) := if h : summable f then classical.some h else 0
 
 notation `∑'` binders `, ` r:(scoped f, tsum f) := r
 


### PR DESCRIPTION
This is helpful for a future version of the `ge_or_gt` linter to recognize binders: the binding type is the (implicit) argument directly before the binding body.

---
<!-- put comments you want to keep out of the PR commit here -->

I expect this will not break anything. If it breaks a lot, we probably shouldn't merge this.