### PR TITLE
[Merged by Bors] - feat(data/fin): bundled embedding

### DIFF
--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -806,3 +806,8 @@ end fin
 /-- Embedding of `fin n` into `ℕ`. -/
 def function.embedding.fin (n : ℕ) : fin n ↪ ℕ :=
 ⟨coe, fin.val_injective⟩
+
+-- Once lean#359 is fixed (making `fin n` a subtype), this can go away
+-- as a duplicate of `function.embedding.coe_subtype`.
+/-- `function.embedding.fin` coerced to a function. -/
+@[simp] lemma function.embedding.coe_fin (n : ℕ) : ⇑(function.embedding.fin n) = coe := rfl

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis, Keeley Hoek
 -/
 import data.nat.cast
+import logic.embedding
 /-!
 # The finite type with `n` elements
 
@@ -799,3 +800,9 @@ mem_find_iff.2 ⟨hi, λ j hj, le_of_eq $ h i j hi hj⟩
 end find
 
 end fin
+
+-- Once lean#359 is fixed (making `fin n` a subtype), this can go away
+-- as a duplicate of `function.embedding.subtype`.
+/-- Embedding of `fin n` into `ℕ`. -/
+def function.embedding.fin (n : ℕ) : fin n ↪ ℕ :=
+⟨coe, fin.val_injective⟩


### PR DESCRIPTION
Add the coercion from `fin n` to `ℕ` as a bundled embedding, an
equivalent of `function.embedding.subtype`.  Once leanprover-community/lean#359 is fixed
(making `fin n` a subtype), this can go away as a duplicate, but until
then it is useful.


---
<!-- put comments you want to keep out of the PR commit here -->
