### PR TITLE
[Merged by Bors] - refactor(data/list/palindrome): use decidable_of_iff'

### DIFF
--- a/src/data/list/palindrome.lean
+++ b/src/data/list/palindrome.lean
@@ -62,6 +62,6 @@ lemma append_reverse (l : list α) : palindrome (l ++ reverse l) :=
 by { apply of_reverse_eq, rw [reverse_append, reverse_reverse] }
 
 instance [decidable_eq α] (l : list α) : decidable (palindrome l) :=
-decidable_of_iff _ iff_reverse_eq.symm
+decidable_of_iff' _ iff_reverse_eq
 
 end palindrome


### PR DESCRIPTION
Follow-up to #3729.

`decidable_of_iff'` allows for omitting the `eq.symm`.

---
<!-- put comments you want to keep out of the PR commit here -->
