### PR TITLE
[Merged by Bors] - fix(tactic/refine_struct): accept synonyms for `structure` types

### DIFF
--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -360,7 +360,7 @@ prod.map id list.reverse <$> (collect_struct' e).run []
 
 meta def refine_one (str : structure_instance_info) :
   tactic $ list (expr×structure_instance_info) :=
-do    tgt ← target,
+do    tgt ← target >>= whnf,
       let struct_n : name := tgt.get_app_fn.const_name,
       exp_fields ← expanded_field_list struct_n,
       let missing_f := exp_fields.filter (λ f, (f.2 : name) ∉ str.field_names),

--- a/test/refine_struct.lean
+++ b/test/refine_struct.lean
@@ -136,3 +136,13 @@ begin
     guard_tags _field mul_one monoid, admit, },
   trivial
 end
+
+def my_semigroup := semigroup
+
+example {α} (mul : α → α → α) : my_semigroup α :=
+begin
+  refine_struct { mul := mul, .. },
+  field mul_assoc {
+    guard_target ∀ a b c : α, mul (mul a b) c = mul a (mul b c),
+    admit }
+end


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->

The following used to break `refine_struct` because `module` is not a `structure` but it is a synonym for one.

```lean
import algebra.module.basic

example {α β : Type} [ring α] [add_comm_group β] : module α β :=
begin
  refine_struct { .. },
end
```