### PR TITLE
[Merged by Bors] - feat(geometry/euclidean): circumradius simp lemmas

### DIFF
--- a/src/geometry/euclidean.lean
+++ b/src/geometry/euclidean.lean
@@ -1185,9 +1185,19 @@ s.circumcenter_circumradius_unique_dist_eq.1.1
 
 /-- All points have distance from the circumcenter equal to the
 circumradius. -/
-lemma dist_circumcenter_eq_circumradius {n : ℕ} (s : simplex ℝ P n) :
+@[simp] lemma dist_circumcenter_eq_circumradius {n : ℕ} (s : simplex ℝ P n) :
   ∀ i, dist (s.points i) s.circumcenter = s.circumradius :=
 s.circumcenter_circumradius_unique_dist_eq.1.2
+
+/-- All points have distance to the circumcenter equal to the
+circumradius. -/
+@[simp] lemma dist_circumcenter_eq_circumradius' {n : ℕ} (s : simplex ℝ P n) :
+  ∀ i, dist s.circumcenter (s.points i) = s.circumradius :=
+begin
+  intro i,
+  rw dist_comm,
+  exact dist_circumcenter_eq_circumradius _ _
+end
 
 /-- Given a point in the affine span from which all the points are
 equidistant, that point is the circumcenter. -/


### PR DESCRIPTION
Mark `dist_circumcenter_eq_circumradius` as a `simp` lemma.  Also add
a variant of that lemma where the distance is the other way round so
`simp` can work with both forms.


---
<!-- put comments you want to keep out of the PR commit here -->
