### PR TITLE
[Merged by Bors] - feat(order/category): various categories of ordered types

### DIFF
--- a/src/order/category/LinearOrder.lean
+++ b/src/order/category/LinearOrder.lean
@@ -1,5 +1,6 @@
 /-
-Copyleft 2020 Johan Commelin. No rights reserved.
+Copyright (c) 2020 Johan Commelin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
 

--- a/src/order/category/LinearOrder.lean
+++ b/src/order/category/LinearOrder.lean
@@ -1,0 +1,25 @@
+/-
+Copyleft 2020 Johan Commelin. No rights reserved.
+Authors: Johan Commelin
+-/
+
+import order.category.PartialOrder
+
+/-! # Category of linearly ordered types -/
+
+open category_theory
+
+def LinearOrder := bundled linear_order
+
+namespace LinearOrder
+
+instance : bundled_hom.parent_projection @linear_order.to_partial_order := ⟨⟩
+
+attribute [derive [has_coe_to_sort, large_category, concrete_category]] LinearOrder
+
+/-- Construct a bundled Ring from the underlying type and typeclass. -/
+def of (α : Type*) [linear_order α] : LinearOrder := bundled.of α
+
+instance : inhabited LinearOrder := ⟨of punit⟩
+
+end LinearOrder

--- a/src/order/category/LinearOrder.lean
+++ b/src/order/category/LinearOrder.lean
@@ -9,6 +9,7 @@ import order.category.PartialOrder
 
 open category_theory
 
+/-- The category of linearly ordered types. -/
 def LinearOrder := bundled linear_order
 
 namespace LinearOrder
@@ -17,7 +18,7 @@ instance : bundled_hom.parent_projection @linear_order.to_partial_order := ⟨�
 
 attribute [derive [has_coe_to_sort, large_category, concrete_category]] LinearOrder
 
-/-- Construct a bundled Ring from the underlying type and typeclass. -/
+/-- Construct a bundled LinearOrder from the underlying type and typeclass. -/
 def of (α : Type*) [linear_order α] : LinearOrder := bundled.of α
 
 instance : inhabited LinearOrder := ⟨of punit⟩

--- a/src/order/category/LinearOrder.lean
+++ b/src/order/category/LinearOrder.lean
@@ -24,4 +24,6 @@ def of (α : Type*) [linear_order α] : LinearOrder := bundled.of α
 
 instance : inhabited LinearOrder := ⟨of punit⟩
 
+instance (α : LinearOrder) : linear_order α := α.str
+
 end LinearOrder

--- a/src/order/category/NonemptyFinLinOrd.lean
+++ b/src/order/category/NonemptyFinLinOrd.lean
@@ -1,5 +1,6 @@
 /-
-Copyleft 2020 Johan Commelin. No rights reserved.
+Copyright (c) 2020 Johan Commelin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
 

--- a/src/order/category/NonemptyFinLinOrd.lean
+++ b/src/order/category/NonemptyFinLinOrd.lean
@@ -30,10 +30,12 @@ class nonempty_fin_lin_ord (α : Type*) extends fintype α, decidable_linear_ord
 end prio
 
 instance punit.nonempty_fin_lin_ord : nonempty_fin_lin_ord punit :=
-by { refine_struct
-{ .. punit.decidable_linear_ordered_cancel_add_comm_monoid,
-  .. punit.fintype };
-{ intros, exact punit.star <|> exact dec_trivial }, }
+begin
+  refine_struct
+  { .. punit.decidable_linear_ordered_cancel_add_comm_monoid,
+    .. punit.fintype };
+  { intros, exact punit.star <|> exact dec_trivial }
+end
 
 section
 open_locale classical

--- a/src/order/category/NonemptyFinLinOrd.lean
+++ b/src/order/category/NonemptyFinLinOrd.lean
@@ -1,0 +1,70 @@
+/-
+Copyleft 2020 Johan Commelin. No rights reserved.
+Authors: Johan Commelin
+-/
+
+import data.fintype.sort
+import data.fin
+import order.category.LinearOrder
+
+/-! # Nonempty finite linear orders
+
+Nonempty finite linear orders form the index category for simplicial objects.
+-/
+
+universe variables u v
+
+open category_theory
+
+set_option old_structure_cmd true
+
+class nonempty_fin_lin_ord (α : Type*) extends fintype α, decidable_linear_order α, order_bot α, order_top α.
+
+instance punit.nonempty_fin_lin_ord : nonempty_fin_lin_ord punit :=
+by { refine_struct
+{ .. punit.decidable_linear_ordered_cancel_add_comm_monoid,
+  .. punit.fintype };
+{ intros, exact punit.star <|> exact dec_trivial }, }
+
+section
+open_locale classical
+
+instance fin.nonempty_fin_lin_ord (n : ℕ) :
+  nonempty_fin_lin_ord (fin (n+1)) :=
+{ top := fin.last n,
+  le_top := fin.le_last,
+  bot := 0,
+  bot_le := fin.zero_le,
+  .. fin.fintype _,
+  .. fin.decidable_linear_order }
+
+end
+
+instance ulift.nonempty_fin_lin_ord (α : Type u) [nonempty_fin_lin_ord α] :
+  nonempty_fin_lin_ord (ulift.{v} α) :=
+{ top := ulift.up ⊤,
+  bot := ulift.up ⊥,
+  le_top := λ ⟨a⟩, show a ≤ ⊤, from le_top,
+  bot_le := λ ⟨a⟩, show ⊥ ≤ a, from bot_le,
+  decidable_le := λ ⟨a⟩ ⟨b⟩, decidable_linear_order.decidable_le _ _,
+  .. linear_order.lift equiv.ulift (equiv.injective _),
+  .. ulift.fintype _ }
+
+def NonemptyFinLinOrd := bundled nonempty_fin_lin_ord
+
+namespace NonemptyFinLinOrd
+
+instance : bundled_hom.parent_projection
+  (λ α i, @decidable_linear_order.to_linear_order _
+  (@nonempty_fin_lin_ord.to_decidable_linear_order α i)) := ⟨⟩
+
+attribute [derive [has_coe_to_sort, large_category, concrete_category]] NonemptyFinLinOrd
+
+/-- Construct a bundled Ring from the underlying type and typeclass. -/
+def of (α : Type*) [nonempty_fin_lin_ord α] : NonemptyFinLinOrd := bundled.of α
+
+instance : inhabited NonemptyFinLinOrd := ⟨of punit⟩
+
+instance (α : NonemptyFinLinOrd) : nonempty_fin_lin_ord α := α.str
+
+end NonemptyFinLinOrd

--- a/src/order/category/NonemptyFinLinOrd.lean
+++ b/src/order/category/NonemptyFinLinOrd.lean
@@ -18,6 +18,7 @@ open category_theory
 
 set_option old_structure_cmd true
 
+/-- A typeclass for nonempty finite linear orders. -/
 class nonempty_fin_lin_ord (α : Type*) extends fintype α, decidable_linear_order α, order_bot α, order_top α.
 
 instance punit.nonempty_fin_lin_ord : nonempty_fin_lin_ord punit :=
@@ -50,6 +51,7 @@ instance ulift.nonempty_fin_lin_ord (α : Type u) [nonempty_fin_lin_ord α] :
   .. linear_order.lift equiv.ulift (equiv.injective _),
   .. ulift.fintype _ }
 
+/-- The category of nonempty finite linear orders. -/
 def NonemptyFinLinOrd := bundled nonempty_fin_lin_ord
 
 namespace NonemptyFinLinOrd
@@ -60,7 +62,7 @@ instance : bundled_hom.parent_projection
 
 attribute [derive [has_coe_to_sort, large_category, concrete_category]] NonemptyFinLinOrd
 
-/-- Construct a bundled Ring from the underlying type and typeclass. -/
+/-- Construct a bundled NonemptyFinLinOrd from the underlying type and typeclass. -/
 def of (α : Type*) [nonempty_fin_lin_ord α] : NonemptyFinLinOrd := bundled.of α
 
 instance : inhabited NonemptyFinLinOrd := ⟨of punit⟩

--- a/src/order/category/NonemptyFinLinOrd.lean
+++ b/src/order/category/NonemptyFinLinOrd.lean
@@ -19,8 +19,15 @@ open category_theory
 
 set_option old_structure_cmd true
 
+section prio
+
+-- see note [default priority]
+set_option default_priority 100
+
 /-- A typeclass for nonempty finite linear orders. -/
 class nonempty_fin_lin_ord (α : Type*) extends fintype α, decidable_linear_order α, order_bot α, order_top α.
+
+end prio
 
 instance punit.nonempty_fin_lin_ord : nonempty_fin_lin_ord punit :=
 by { refine_struct

--- a/src/order/category/PartialOrder.lean
+++ b/src/order/category/PartialOrder.lean
@@ -1,0 +1,25 @@
+/-
+Copyleft 2020 Johan Commelin. No rights reserved.
+Authors: Johan Commelin
+-/
+
+import order.category.Preorder
+
+/-! # Category of partially ordered types -/
+
+open category_theory
+
+def PartialOrder := bundled partial_order
+
+namespace PartialOrder
+
+instance : bundled_hom.parent_projection @partial_order.to_preorder := ⟨⟩
+
+attribute [derive [has_coe_to_sort, large_category, concrete_category]] PartialOrder
+
+/-- Construct a bundled Ring from the underlying type and typeclass. -/
+def of (α : Type*) [partial_order α] : PartialOrder := bundled.of α
+
+instance : inhabited PartialOrder := ⟨of punit⟩
+
+end PartialOrder

--- a/src/order/category/PartialOrder.lean
+++ b/src/order/category/PartialOrder.lean
@@ -1,5 +1,6 @@
 /-
-Copyleft 2020 Johan Commelin. No rights reserved.
+Copyright (c) 2020 Johan Commelin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
 

--- a/src/order/category/PartialOrder.lean
+++ b/src/order/category/PartialOrder.lean
@@ -24,4 +24,6 @@ def of (α : Type*) [partial_order α] : PartialOrder := bundled.of α
 
 instance : inhabited PartialOrder := ⟨of punit⟩
 
+instance (α : PartialOrder) : partial_order α := α.str
+
 end PartialOrder

--- a/src/order/category/PartialOrder.lean
+++ b/src/order/category/PartialOrder.lean
@@ -9,6 +9,7 @@ import order.category.Preorder
 
 open category_theory
 
+/-- The category of partially ordered types. -/
 def PartialOrder := bundled partial_order
 
 namespace PartialOrder
@@ -17,7 +18,7 @@ instance : bundled_hom.parent_projection @partial_order.to_preorder := ⟨⟩
 
 attribute [derive [has_coe_to_sort, large_category, concrete_category]] PartialOrder
 
-/-- Construct a bundled Ring from the underlying type and typeclass. -/
+/-- Construct a bundled PartialOrder from the underlying type and typeclass. -/
 def of (α : Type*) [partial_order α] : PartialOrder := bundled.of α
 
 instance : inhabited PartialOrder := ⟨of punit⟩

--- a/src/order/category/Preorder.lean
+++ b/src/order/category/Preorder.lean
@@ -1,0 +1,75 @@
+/-
+Copyleft 2020 Johan Commelin. No rights reserved.
+Authors: Johan Commelin
+-/
+
+import category_theory.concrete_category
+import algebra.punit_instances
+
+/-! # Category of preorders -/
+
+open category_theory
+
+/-- The category of preorders. -/
+def Preorder := bundled preorder
+
+/-- Bundled monotone (aka, increasing) function -/
+structure preorder_hom (α β : Type*) [preorder α] [preorder β] :=
+(to_fun   : α → β)
+(monotone : monotone to_fun)
+
+namespace preorder_hom
+variables {α β γ : Type*} [preorder α] [preorder β] [preorder γ]
+
+instance : has_coe_to_fun (preorder_hom α β) :=
+{ F := λ f, α → β,
+  coe := λ f, f.to_fun }
+
+@[ext] lemma ext (f g : preorder_hom α β) (h : ∀ a, f a = g a) : f = g :=
+by { cases f, cases g, congr, funext, exact h _ }
+
+lemma coe_inj (f g : preorder_hom α β) (h : (f : α → β) = g) : f = g :=
+by { ext, rw h }
+
+/-- The identity function as bundled monotone function. -/
+def id : preorder_hom α α :=
+⟨id, monotone_id⟩
+
+@[simp] lemma coe_id : (@id α _ : α → α) = id := rfl
+
+@[simp] lemma id_apply (a : α) : (id a) = a := rfl
+
+/-- The composition of two bundled monotone functions. -/
+def comp (g : preorder_hom β γ) (f : preorder_hom α β) : preorder_hom α γ :=
+⟨g ∘ f, g.monotone.comp f.monotone⟩
+
+@[simp] lemma coe_comp (g : preorder_hom β γ) (f : preorder_hom α β) :
+  (g.comp f : α → γ) = g ∘ f := rfl
+
+@[simp] lemma comp_apply (g : preorder_hom β γ) (f : preorder_hom α β) (a : α) :
+  g.comp f a = g (f a) := rfl
+
+@[simp] lemma comp_id (f : preorder_hom α β) : f.comp id = f :=
+by { ext, refl }
+
+@[simp] lemma id_comp (f : preorder_hom α β) : id.comp f = f :=
+by { ext, refl }
+
+end preorder_hom
+
+namespace Preorder
+
+instance : bundled_hom @preorder_hom :=
+{ to_fun := @preorder_hom.to_fun,
+  id := @preorder_hom.id,
+  comp := @preorder_hom.comp,
+  hom_ext := @preorder_hom.coe_inj }
+
+attribute [derive [has_coe_to_sort, large_category, concrete_category]] Preorder
+
+/-- Construct a bundled Preorder from the underlying type and typeclass. -/
+def of (α : Type*) [preorder α] : Preorder := bundled.of α
+
+instance : inhabited Preorder := ⟨of punit⟩
+
+end Preorder

--- a/src/order/category/Preorder.lean
+++ b/src/order/category/Preorder.lean
@@ -1,5 +1,6 @@
 /-
-Copyleft 2020 Johan Commelin. No rights reserved.
+Copyright (c) 2020 Johan Commelin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
 

--- a/src/order/category/Preorder.lean
+++ b/src/order/category/Preorder.lean
@@ -22,7 +22,6 @@ structure preorder_hom (α β : Type*) [preorder α] [preorder β] :=
 namespace preorder_hom
 variables {α β γ : Type*} [preorder α] [preorder β] [preorder γ]
 
-@[simps]
 instance : has_coe_to_fun (preorder_hom α β) :=
 { F := λ f, α → β,
   coe := preorder_hom.to_fun }
@@ -34,6 +33,7 @@ lemma coe_inj (f g : preorder_hom α β) (h : (f : α → β) = g) : f = g :=
 by { ext, rw h }
 
 /-- The identity function as bundled monotone function. -/
+@[simps]
 def id : preorder_hom α α :=
 ⟨id, monotone_id⟩
 

--- a/src/order/category/Preorder.lean
+++ b/src/order/category/Preorder.lean
@@ -42,14 +42,12 @@ instance : inhabited (preorder_hom α α) := ⟨id⟩
 @[simp] lemma coe_id : (@id α _ : α → α) = id := rfl
 
 /-- The composition of two bundled monotone functions. -/
+@[simps]
 def comp (g : preorder_hom β γ) (f : preorder_hom α β) : preorder_hom α γ :=
 ⟨g ∘ f, g.monotone.comp f.monotone⟩
 
 @[simp] lemma coe_comp (g : preorder_hom β γ) (f : preorder_hom α β) :
   (g.comp f : α → γ) = g ∘ f := rfl
-
-@[simp] lemma comp_apply (g : preorder_hom β γ) (f : preorder_hom α β) (a : α) :
-  g.comp f a = g (f a) := rfl
 
 @[simp] lemma comp_id (f : preorder_hom α β) : f.comp id = f :=
 by { ext, refl }

--- a/src/order/category/Preorder.lean
+++ b/src/order/category/Preorder.lean
@@ -22,9 +22,10 @@ structure preorder_hom (α β : Type*) [preorder α] [preorder β] :=
 namespace preorder_hom
 variables {α β γ : Type*} [preorder α] [preorder β] [preorder γ]
 
+@[simps]
 instance : has_coe_to_fun (preorder_hom α β) :=
 { F := λ f, α → β,
-  coe := λ f, f.to_fun }
+  coe := preorder_hom.to_fun }
 
 @[ext] lemma ext (f g : preorder_hom α β) (h : ∀ a, f a = g a) : f = g :=
 by { cases f, cases g, congr, funext, exact h _ }
@@ -39,8 +40,6 @@ def id : preorder_hom α α :=
 instance : inhabited (preorder_hom α α) := ⟨id⟩
 
 @[simp] lemma coe_id : (@id α _ : α → α) = id := rfl
-
-@[simp] lemma id_apply (a : α) : (id a) = a := rfl
 
 /-- The composition of two bundled monotone functions. -/
 def comp (g : preorder_hom β γ) (f : preorder_hom α β) : preorder_hom α γ :=

--- a/src/order/category/Preorder.lean
+++ b/src/order/category/Preorder.lean
@@ -69,4 +69,6 @@ def of (α : Type*) [preorder α] : Preorder := bundled.of α
 
 instance : inhabited Preorder := ⟨of punit⟩
 
+instance (α : Preorder) : preorder α := α.str
+
 end Preorder

--- a/src/order/category/Preorder.lean
+++ b/src/order/category/Preorder.lean
@@ -35,6 +35,8 @@ by { ext, rw h }
 def id : preorder_hom α α :=
 ⟨id, monotone_id⟩
 
+instance : inhabited (preorder_hom α α) := ⟨id⟩
+
 @[simp] lemma coe_id : (@id α _ : α → α) = id := rfl
 
 @[simp] lemma id_apply (a : α) : (id a) = a := rfl

--- a/src/order/category/Preorder.lean
+++ b/src/order/category/Preorder.lean
@@ -46,9 +46,6 @@ instance : inhabited (preorder_hom α α) := ⟨id⟩
 def comp (g : preorder_hom β γ) (f : preorder_hom α β) : preorder_hom α γ :=
 ⟨g ∘ f, g.monotone.comp f.monotone⟩
 
-@[simp] lemma coe_comp (g : preorder_hom β γ) (f : preorder_hom α β) :
-  (g.comp f : α → γ) = g ∘ f := rfl
-
 @[simp] lemma comp_id (f : preorder_hom α β) : f.comp id = f :=
 by { ext, refl }
 


### PR DESCRIPTION
This is a first step towards the category of simplicial sets (which are presheaves on the category of nonempty finite linear orders).

---
<!-- put comments you want to keep out of the PR commit here -->

@cipher1024 also wanted the category of posets.