### PR TITLE
[Merged by Bors] - feat(tactic/choose): derive local nonempty instances

### DIFF
--- a/src/tactic/choose.lean
+++ b/src/tactic/choose.lean
@@ -65,11 +65,8 @@ meta def choose1 (nondep : bool) (h : expr) (data : name) (spec : name) :
         set_goals [m],
         ctxt.mmap' (λ e, do
           b ← is_proof e,
-          monad.unlessb b $ do
-            h ← get_unused_name,
-            v ← mk_app ``nonempty.intro [e],
-            t ← infer_type v,
-            tactic.assertv h t v $> ()),
+          monad.unlessb b $ 
+            (mk_app ``nonempty.intro [e] >>= note_anon none) $> ()),
         unfreeze_local_instances >> apply_instance,
         instantiate_mvars m)),
       pure (some (option.guard (λ _, nonemp.is_none) ne), nonemp)

--- a/test/choose.lean
+++ b/test/choose.lean
@@ -46,3 +46,13 @@ begin
   guard_hyp h' := ∀ (i : ℕ), f i < i + i,
   trivial,
 end
+
+-- test choose with nonempty instances
+universe u
+example {α : Type u} (p : α → Prop) (h : ∀ i : α, p i → ∃ j : α × α, p j.1) : true :=
+begin
+  choose! f h using h,
+  guard_hyp f := α → α × α,
+  guard_hyp h := ∀ (i : α), p i → p (f i).1,
+  trivial,
+end


### PR DESCRIPTION
This allows `choose!` to work even in cases like `{A : Type} (p : A -> Prop) (h : ∀ x : A, p x → ∃ y : A, p y)`, where we don't know that `A` is nonempty because it is generic, but it can be derived from the inhabitance of other variables in the context of the `∃ y : A` statement. As requested on zulip: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/non.20dependent.20chooser/near/207126587