### PR TITLE
[Merged by Bors] - feat(ring_theory/polynomial/basic): Isomorphism between polynomials over a quotient and quotient over polynomials

### DIFF
--- a/src/ring_theory/polynomial/basic.lean
+++ b/src/ring_theory/polynomial/basic.lean
@@ -178,6 +178,36 @@ variables {R : Type u} {σ : Type v} [comm_ring R]
 namespace ideal
 open polynomial
 
+/-- The push-forward of an ideal `I` of `R` to `polynomial R` via inclusion
+ is exactly the set of polynomials whose coefficients are in `I` -/
+theorem mem_map_C_iff {I : ideal R} {f : polynomial R} :
+  f ∈ (ideal.map C I : ideal (polynomial R)) ↔ ∀ n : ℕ, f.coeff n ∈ I :=
+begin
+  split,
+  { intros hf,
+    apply submodule.span_induction hf,
+    { intros f hf,
+      rw set.mem_image at hf,
+      cases hf with x hx,
+      rw ← hx.right,
+      intro n,
+      rw coeff_C,
+      by_cases (n = 0),
+      { simpa [h] using hx.left },
+      { simp [h] } },
+    { simp },
+    { exact λ f g hf hg n, by simp [I.add_mem (hf n) (hg n)] },
+    { refine λ f g hg n, _,
+      rw [smul_eq_mul, coeff_mul],
+      refine I.sum_mem (λ c hc, I.smul_mem (f.coeff c.fst) (hg c.snd)) } },
+  { intros hf,
+    rw ← sum_monomial_eq f,
+    refine (map C I : ideal (polynomial R)).sum_mem (λ n hn, _),
+    simp [single_eq_C_mul_X],
+    rw mul_comm,
+    exact (map C I : ideal (polynomial R)).smul_mem _ (mem_map_of_mem (hf n)) }
+end
+
 /-- Transport an ideal of `R[X]` to an `R`-submodule of `R[X]`. -/
 def of_polynomial (I : ideal (polynomial R)) : submodule R (polynomial R) :=
 { carrier := I.carrier,

--- a/src/ring_theory/polynomial/basic.lean
+++ b/src/ring_theory/polynomial/basic.lean
@@ -242,22 +242,22 @@ def polynomial_quotient_equiv_quotient_polynomial {I : ideal R} :
     (eval₂_ring_hom (C.comp (quotient.mk I)) X) eval₂_C_mk_eq_zero,
   map_mul' := λ f g, by simp,
   map_add' := λ f g, by simp,
-  left_inv := by {
+  left_inv := begin
     intro f,
     apply polynomial.induction_on' f,
     { simp_intros p q hp hq,
       rw [hp, hq] },
     { rintros n ⟨x⟩,
       simp [monomial_eq_smul_X, C_mul'] }
-  },
-  right_inv := by {
+  end,
+  right_inv := begin
     rintro ⟨f⟩,
     apply polynomial.induction_on' f,
     { simp_intros p q hp hq,
       rw [hp, hq] },
     { intros n a,
       simp [monomial_eq_smul_X, ← C_mul' a (X ^ n)] },
-  },
+  end,
 }
 
 /-- Transport an ideal of `R[X]` to an `R`-submodule of `R[X]`. -/

--- a/src/ring_theory/polynomial/basic.lean
+++ b/src/ring_theory/polynomial/basic.lean
@@ -196,7 +196,7 @@ begin
     { exact λ f g hf hg n, by simp [I.add_mem (hf n) (hg n)] },
     { refine λ f g hg n, _,
       rw [smul_eq_mul, coeff_mul],
-      refine I.sum_mem (λ c hc, I.smul_mem (f.coeff c.fst) (hg c.snd)) } },
+      exact I.sum_mem (λ c hc, I.smul_mem (f.coeff c.fst) (hg c.snd)) } },
   { intros hf,
     rw ← sum_monomial_eq f,
     refine (map C I : ideal (polynomial R)).sum_mem (λ n hn, _),
@@ -219,10 +219,10 @@ begin
   intros a ha,
   rw ← sum_monomial_eq a,
   dsimp,
-  erw eval₂_sum,
+  rw eval₂_sum (C.comp (quotient.mk I)) a monomial X,
   refine finset.sum_eq_zero (λ n hn, _),
   dsimp,
-  rw eval₂_monomial,
+  rw eval₂_monomial (C.comp (quotient.mk I)) X,
   refine mul_eq_zero_of_left (polynomial.ext (λ m, _)) (X ^ n),
   erw coeff_C,
   by_cases h : m = 0,
@@ -230,7 +230,10 @@ begin
   { simp [h] }
 end
 
-noncomputable def polynomial_quotient_equiv_quotient_polynomial {I : ideal R} :
+/-- If `I` is an ideal of `R`, then the ring polynomials over the quotient ring `I.quotient` is
+isomorphic to the quotient of `polynomial R` by the ideal `map C I`,
+where `map C I` contains exactly the polynomials whose coefficients all lie in `I` -/
+def polynomial_quotient_equiv_quotient_polynomial {I : ideal R} :
   polynomial (I.quotient) ≃+* (map C I : ideal (polynomial R)).quotient :=
 { to_fun := eval₂_ring_hom
     (quotient.lift I ((quotient.mk (map C I : ideal (polynomial R))).comp C) quotient_map_C_eq_zero)


### PR DESCRIPTION
The main statement is `polynomial_quotient_equiv_quotient_polynomial`, which gives that If `I` is an ideal of `R`, then the ring polynomials over the quotient ring `I.quotient` is isomorphic to the quotient of `polynomial R` by the ideal `map C I`.

Also, `mem_map_C_iff` shows that `map C I` contains exactly the polynomials whose coefficients all lie in `I`

---
I couldn't find this equivalence anywhere in mathlib already. I created `quotient_map_C_eq_zero ` and `eval₂_C_mk_eq_zero ` just so they could be passed to `quotient.lift` as proofs that functions being defined are well defined. If they don't seem generally useful, I can inline them into the definition of the isomorphism, but the definition got very messy when I originally did that.
