### PR TITLE
[Merged by Bors] - chore(data/set/finite): explicit `f` in `finset.preimage s f hf`

### DIFF
--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -951,7 +951,7 @@ the preimage of `l.support`, `comap_domain f l hf` is the finitely supported fun
 from `α₁` to `γ` given by composing `l` with `f`. -/
 def comap_domain {α₁ α₂ γ : Type*} [has_zero γ]
   (f : α₁ → α₂) (l : α₂ →₀ γ) (hf : set.inj_on f (f ⁻¹' ↑l.support)) : α₁ →₀ γ :=
-{ support := l.support.preimage hf,
+{ support := l.support.preimage f hf,
   to_fun := (λ a, l (f a)),
   mem_support_to_fun :=
     begin

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -566,36 +566,40 @@ namespace finset
 section preimage
 
 /-- Preimage of `s : finset β` under a map `f` injective of `f ⁻¹' s` as a `finset`.  -/
-noncomputable def preimage {f : α → β} (s : finset β)
+noncomputable def preimage (s : finset β) (f : α → β)
   (hf : set.inj_on f (f ⁻¹' ↑s)) : finset α :=
 (s.finite_to_set.preimage hf).to_finset
 
 @[simp] lemma mem_preimage {f : α → β} {s : finset β} {hf : set.inj_on f (f ⁻¹' ↑s)} {x : α} :
-  x ∈ preimage s hf ↔ f x ∈ s :=
+  x ∈ preimage s f hf ↔ f x ∈ s :=
 set.finite.mem_to_finset
 
 @[simp, norm_cast] lemma coe_preimage {f : α → β} (s : finset β)
-  (hf : set.inj_on f (f ⁻¹' ↑s)) : (↑(preimage s hf) : set α) = f ⁻¹' ↑s :=
+  (hf : set.inj_on f (f ⁻¹' ↑s)) : (↑(preimage s f hf) : set α) = f ⁻¹' ↑s :=
 set.finite.coe_to_finset _
+
+lemma monotone_preimage {f : α → β} (h : injective f) :
+  monotone (λ s, preimage s f (h.inj_on _)) :=
+λ s t hst x hx, mem_preimage.2 (hst $ mem_preimage.1 hx)
 
 lemma image_subset_iff_subset_preimage [decidable_eq β] {f : α → β} {s : finset α} {t : finset β}
   (hf : set.inj_on f (f ⁻¹' ↑t)) :
-  s.image f ⊆ t ↔ s ⊆ t.preimage hf :=
+  s.image f ⊆ t ↔ s ⊆ t.preimage f hf :=
 image_subset_iff.trans $ by simp only [subset_iff, mem_preimage]
 
 lemma map_subset_iff_subset_preimage {f : α ↪ β} {s : finset α} {t : finset β} :
-  s.map f ⊆ t ↔ s ⊆ t.preimage (f.injective.inj_on _) :=
+  s.map f ⊆ t ↔ s ⊆ t.preimage f (f.injective.inj_on _) :=
 by classical; rw [map_eq_image, image_subset_iff_subset_preimage]
 
 lemma image_preimage [decidable_eq β] (f : α → β) (s : finset β) [Π x, decidable (x ∈ set.range f)]
   (hf : set.inj_on f (f ⁻¹' ↑s)) :
-  image f (preimage s hf) = s.filter (λ x, x ∈ set.range f) :=
+  image f (preimage s f hf) = s.filter (λ x, x ∈ set.range f) :=
 finset.coe_inj.1 $ by simp only [coe_image, coe_preimage, coe_filter,
   set.image_preimage_eq_inter_range, set.sep_mem_eq]
 
 lemma image_preimage_of_bij [decidable_eq β] (f : α → β) (s : finset β)
   (hf : set.bij_on f (f ⁻¹' ↑s) ↑s) :
-  image f (preimage s hf.inj_on) = s :=
+  image f (preimage s f hf.inj_on) = s :=
 finset.coe_inj.1 $ by simpa using hf.image_eq
 
 end preimage
@@ -603,9 +607,9 @@ end preimage
 @[to_additive]
 lemma prod_preimage [comm_monoid β] (f : α → γ) (s : finset γ)
   (hf : set.inj_on f (f ⁻¹' ↑s)) (g : γ → β) (hg : ∀ x ∈ s, x ∉ set.range f → g x = 1) :
-  ∏ x in s.preimage hf, g (f x) = ∏ x in s, g x :=
+  ∏ x in s.preimage f hf, g (f x) = ∏ x in s, g x :=
 by classical;
-calc ∏ x in preimage s hf, g (f x) = ∏ x in image f (preimage s hf), g x :
+calc ∏ x in preimage s f hf, g (f x) = ∏ x in image f (preimage s f hf), g x :
   eq.symm $ prod_image $ by simpa only [mem_preimage, inj_on] using hf
   ... = ∏ x in s.filter (λ x, x ∈ set.range f), g x : by rw [image_preimage]
   ... = ∏ x in s, g x : prod_filter_of_ne $ λ x hxs hxg, not.imp_symm (hg x hxs) hxg
@@ -613,7 +617,7 @@ calc ∏ x in preimage s hf, g (f x) = ∏ x in image f (preimage s hf), g x :
 @[to_additive]
 lemma prod_preimage_of_bij [comm_monoid β] (f : α → γ) (s : finset γ)
   (hf : set.bij_on f (f ⁻¹' ↑s) ↑s) (g : γ → β) :
-  ∏ x in s.preimage hf.inj_on, g (f x) = ∏ x in s, g x :=
+  ∏ x in s.preimage f hf.inj_on, g (f x) = ∏ x in s, g x :=
 prod_preimage _ _ hf.inj_on g $ λ x hxs hxf, (hxf $ hf.subset_range hxs).elim
 
 /-- A finset is bounded above. -/

--- a/src/field_theory/separable.lean
+++ b/src/field_theory/separable.lean
@@ -266,7 +266,7 @@ include hp
 
 /-- The opposite of `expand`: sends `∑ aₙ xⁿᵖ` to `∑ aₙ xⁿ`. -/
 noncomputable def contract (f : polynomial F) : polynomial F :=
-⟨@finset.preimage ℕ ℕ (*p) f.support $ λ _ _ _ _, (nat.mul_left_inj hp.pos).1,
+⟨f.support.preimage (*p) $ λ _ _ _ _, (nat.mul_left_inj hp.pos).1,
 λ n, f.coeff (n * p),
 λ n, by { rw [finset.mem_preimage, finsupp.mem_support_iff], refl }⟩
 

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -391,7 +391,8 @@ end
 
 lemma total_comap_domain
  (f : α → α') (l : α' →₀ R) (hf : set.inj_on f (f ⁻¹' ↑l.support)) :
- finsupp.total α M R v (finsupp.comap_domain f l hf) = (l.support.preimage hf).sum (λ i, (l (f i)) • (v i)) :=
+ finsupp.total α M R v (finsupp.comap_domain f l hf) =
+   (l.support.preimage f hf).sum (λ i, (l (f i)) • (v i)) :=
 by rw finsupp.total_apply; refl
 
 end total

--- a/src/order/filter/at_top_bot.lean
+++ b/src/order/filter/at_top_bot.lean
@@ -632,7 +632,7 @@ lemma function.injective.map_at_top_finset_prod_eq [comm_monoid α] {g : γ → 
   map (λ s, ∏ i in s, f (g i)) at_top = map (λ s, ∏ i in s, f i) at_top :=
 begin
   apply le_antisymm; refine map_at_top_finset_prod_le_of_prod_eq (λ s, _),
-  { refine ⟨s.preimage (hg.inj_on _), λ t ht, _⟩,
+  { refine ⟨s.preimage g (hg.inj_on _), λ t ht, _⟩,
     refine ⟨t.image g ∪ s, finset.subset_union_right _ _, _⟩,
     rw [← finset.prod_image (hg.inj_on _)],
     refine (prod_subset (subset_union_left _ _) _).symm,


### PR DESCRIPTION
Otherwise pretty printer shows just `finset.preimage s _`.

---
<!-- put comments you want to keep out of the PR commit here -->
