### PR TITLE
[Merged by Bors] - fix(test/norm_cast): fix(?) test

### DIFF
--- a/test/norm_cast.lean
+++ b/test/norm_cast.lean
@@ -71,7 +71,7 @@ instance [has_mul α] : mul_zero_class (with_zero α) :=
 { mul       := λ o₁ o₂, o₁.bind (λ a, o₂.map (λ b, a * b)),
   zero_mul  := λ a, rfl,
   mul_zero  := λ a, by cases a; refl,
-  ..with_zero.has_zero }
+  ..hidden.has_zero }
 
 @[norm_cast] lemma coe_one [has_one α] : ((1 : α) : with_zero α) = 1 := rfl
 


### PR DESCRIPTION
---

This test currently uses mathlib's `with_zero.has_zero` when creating an API for a new "hidden" `with_zero`. Is this intentional? I have no idea what this test is testing. If it's supposed to be testing how `hidden.with_zero` is defeq to `with_zero` and hence the system can abuse this, then a proposed future PR of mine is going to break this test as it stands; I don't believe that this is what the test is testing however, so this PR is a pre-emptive fix. Just to be clear -- Lean's slightly silly instance naming conventions ensure that the instance defined on line 66 is called `hidden.has_zero`. The file currently compiles even if line 66 is deleted. This PR makes it break if line 66 is deleted. I don't know what I'm doing because I don't know what the tests are -- I have never even looked at any file in this dir before today AFAIR.

<!-- put comments you want to keep out of the PR commit here -->
