### PR TITLE
[Merged by Bors] - feat(tactic/rcases): clear pattern `-` in rcases

### DIFF
--- a/src/tactic/rcases.lean
+++ b/src/tactic/rcases.lean
@@ -356,6 +356,8 @@ with rcases.continue : listΠ (rcases_patt × expr) → tactic (list uncleared_g
     ugs ← rcases.continue pes,
     pure $ ugs.map $ λ ⟨cs', gs⟩, (cs ++ cs', gs))
 
+/-- Given a list of `uncleared_goal`s, each of which is a goal metavariable and
+a list of variables to clear, actually perform the clear and set the goals with the result. -/
 meta def clear_goals (ugs : list uncleared_goal) : tactic unit := do
   gs ← ugs.mmap (λ ⟨cs, g⟩, do
     set_goals [g],

--- a/src/tactic/rcases.lean
+++ b/src/tactic/rcases.lean
@@ -304,9 +304,8 @@ with rcases_core : rcases_patt → expr → tactic goals
 -- If the pattern is any other name, we already bound the name in the
 -- top-level `cases` tactic, so there is no more work to do for it.
 | (rcases_patt.one _) _ := get_goals
-| rcases_patt.clear e := do
-  (t, e) ← get_local_and_type e,
-  tactic.clear' tt [e],
+| rcases_patt.clear e :=
+  try (do (t, e) ← get_local_and_type e, tactic.clear' tt [e]) >>
   get_goals
 | (rcases_patt.typed p ty) e := do
   (t, e) ← get_local_and_type e,

--- a/test/rcases.lean
+++ b/test/rcases.lean
@@ -20,9 +20,8 @@ end
 
 example (x : α × β × γ) : true :=
 begin
-  rcases x with ⟨a, ⟨b, c⟩⟩,
+  rcases x with ⟨a, ⟨-, c⟩⟩,
   { guard_hyp a := α,
-    guard_hyp b := β,
     guard_hyp c := γ,
     trivial }
 end
@@ -62,11 +61,10 @@ end
 
 example : true :=
 begin
-  obtain ⟨n : ℕ, h : n = n, f : true⟩ : ∃ n : ℕ, n = n ∧ true,
+  obtain ⟨n : ℕ, h : n = n, -⟩ : ∃ n : ℕ, n = n ∧ true,
   { existsi 0, simp },
   guard_hyp n := ℕ,
   guard_hyp h := n = n,
-  guard_hyp f := true,
   trivial
 end
 

--- a/test/rcases.lean
+++ b/test/rcases.lean
@@ -22,6 +22,7 @@ example (x : α × β × γ) : true :=
 begin
   rcases x with ⟨a, ⟨-, c⟩⟩,
   { guard_hyp a := α,
+    success_if_fail { guard_hyp x_snd_fst := β },
     guard_hyp c := γ,
     trivial }
 end
@@ -65,6 +66,7 @@ begin
   { existsi 0, simp },
   guard_hyp n := ℕ,
   guard_hyp h := n = n,
+  success_if_fail {assumption},
   trivial
 end
 
@@ -130,4 +132,27 @@ example (n : ℕ) : true :=
 begin
   obtain one_lt_n | (n_le_one : n + 1 ≤ 1) := nat.lt_or_ge 1 (n + 1),
   trivial, trivial,
+end
+
+example (h : ∃ x : ℕ, x = x ∧ 1 = 1) : true :=
+begin
+  rcases h with ⟨-, _⟩,
+  (do lc ← tactic.local_context, guard lc.empty),
+  trivial
+end
+
+example (h : ∃ x : ℕ, x = x ∧ 1 = 1) : true :=
+begin
+  rcases h with ⟨-, _, h⟩,
+  (do lc ← tactic.local_context, guard (lc.length = 1)),
+  guard_hyp h := 1 = 1,
+  trivial
+end
+
+example (h : true ∨ true ∨ true) : true :=
+begin
+  rcases h with -|-|-,
+  iterate 3 {
+    (do lc ← tactic.local_context, guard lc.empty),
+    trivial },
 end


### PR DESCRIPTION
This allows you to write:
```lean
example (h : ∃ x : ℕ, true) : true :=
begin
  rcases h with ⟨x, -⟩,
  -- x : ℕ |- true
end
```
to clear unwanted hypotheses. Note that dependents are also cleared,
meaning that you can get into trouble if you try to keep matching when a
variable later in the pattern is deleted. The `_` pattern will match
a hypothesis even if it has been deleted, so this is the recommended way
to match on variables dependent on a deleted hypothesis.
You can use `-` if you prefer, but watch out for unintended variables
getting deleted if there are duplicate names!
