### PR TITLE
[Merged by Bors] - chore(data/matrix, linear_algebra): generalize universe parameters

### DIFF
--- a/src/algebra/classical_lie_algebras.lean
+++ b/src/algebra/classical_lie_algebras.lean
@@ -65,15 +65,16 @@ universes u₁ u₂
 namespace lie_algebra
 open_locale matrix
 
-variables (n p q l : Type u₁) (R : Type u₂)
+variables (n p q l : Type*) (R : Type u₂)
 variables [fintype n] [fintype l] [fintype p] [fintype q]
 variables [decidable_eq n] [decidable_eq p] [decidable_eq q] [decidable_eq l]
 variables [comm_ring R]
 
 @[simp] lemma matrix_trace_commutator_zero (X Y : matrix n n R) : matrix.trace n R R ⁅X, Y⁆ = 0 :=
 begin
-  change matrix.trace n R R (X ⬝ Y - Y ⬝ X) = 0,
-  simp only [matrix.trace_mul_comm, linear_map.map_sub, sub_self],
+  -- TODO: if we use matrix.mul here, we get a timeout
+  change matrix.trace n R R (X * Y - Y * X) = 0,
+  erw [linear_map.map_sub, matrix.trace_mul_comm, sub_self]
 end
 
 namespace special_linear
@@ -297,7 +298,7 @@ where sizes of the blocks are:
    [`l x 1` `l x l` `l x l`]  
    [`l x 1` `l x l` `l x l`]
 -/
-def JB := matrix.from_blocks ((2 : R) • 1 : matrix punit punit R) 0 0 (JD l R)
+def JB := matrix.from_blocks ((2 : R) • 1 : matrix unit unit R) 0 0 (JD l R)
 
 /-- The classical Lie algebra of type B as a Lie subalgebra of matrices associated to the matrix
 `JB`. -/
@@ -318,7 +319,7 @@ where sizes of the blocks are:
    [`l x 1` `l x l` `l x l`]  
    [`l x 1` `l x l` `l x l`]
 -/
-def PB := matrix.from_blocks (1 : matrix punit punit R) 0 0 (PD l R)
+def PB := matrix.from_blocks (1 : matrix unit unit R) 0 0 (PD l R)
 
 lemma PB_inv [invertible (2 : R)] : (PB l R) * (matrix.from_blocks 1 0 0 (PD l R)⁻¹) = 1 :=
 begin
@@ -338,8 +339,8 @@ by simp [PB, JB, JD_transform, matrix.from_blocks_transpose, matrix.from_blocks_
          matrix.from_blocks_smul]
 
 lemma indefinite_diagonal_assoc :
-  indefinite_diagonal ((punit : Type u₁) ⊕ l) l R =
-  matrix.reindex_lie_equiv (equiv.sum_assoc punit l l).symm
+  indefinite_diagonal (unit ⊕ l) l R =
+  matrix.reindex_lie_equiv (equiv.sum_assoc unit l l).symm
     (matrix.from_blocks 1 0 0 (indefinite_diagonal l l R)) :=
 begin
   ext i j,
@@ -350,12 +351,12 @@ end
 
 /-- An equivalence between two possible definitions of the classical Lie algebra of type B. -/
 noncomputable def type_B_equiv_so' [invertible (2 : R)] :
-  type_B l R ≃ₗ⁅R⁆ so' ((punit : Type u₁) ⊕ l) l R :=
+  type_B l R ≃ₗ⁅R⁆ so' (unit ⊕ l) l R :=
 begin
   apply (skew_adjoint_matrices_lie_subalgebra_equiv (JB l R) (PB l R) (is_unit_PB l R)).trans,
   symmetry,
   apply (skew_adjoint_matrices_lie_subalgebra_equiv_transpose
-    (indefinite_diagonal ((punit : Type u₁) ⊕ l) l R)
+    (indefinite_diagonal (unit ⊕ l) l R)
     (matrix.reindex_alg_equiv (equiv.sum_assoc punit l l)) (matrix.reindex_transpose _ _)).trans,
   apply lie_algebra.equiv.of_eq,
   ext A,

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -11,15 +11,15 @@ import data.fintype.card
 /-!
 # Matrices
 -/
-universes u v w
+universes u u' v w
 
 open_locale big_operators
 
 @[nolint unused_arguments]
-def matrix (m n : Type u) [fintype m] [fintype n] (α : Type v) : Type (max u v) :=
+def matrix (m : Type u) (n : Type u') [fintype m] [fintype n] (α : Type v) : Type (max u u' v) :=
 m → n → α
 
-variables {l m n o : Type u} [fintype l] [fintype m] [fintype n] [fintype o]
+variables {l m n o : Type*} [fintype l] [fintype m] [fintype n] [fintype o]
 variables {α : Type v}
 
 namespace matrix
@@ -47,10 +47,10 @@ def transpose (M : matrix m n α) : matrix n m α
 
 localized "postfix `ᵀ`:1500 := matrix.transpose" in matrix
 
-def col (w : m → α) : matrix m punit α
+def col (w : m → α) : matrix m unit α
 | x y := w x
 
-def row (v : n → α) : matrix punit n α
+def row (v : n → α) : matrix unit n α
 | x y := v y
 
 instance [inhabited α] : inhabited (matrix m n α) := pi.inhabited _
@@ -901,7 +901,7 @@ begin
   ext i j, rcases i; rcases j; refl,
 end
 
-lemma from_blocks_multiply {p q : Type u} [fintype p] [fintype q]
+lemma from_blocks_multiply {p q : Type*} [fintype p] [fintype q]
   (A  : matrix n l α) (B  : matrix n m α) (C  : matrix o l α) (D  : matrix o m α)
   (A' : matrix l p α) (B' : matrix l q α) (C' : matrix m p α) (D' : matrix m q α) :
   (from_blocks A B C D) ⬝ (from_blocks A' B' C' D') =

--- a/src/data/matrix/notation.lean
+++ b/src/data/matrix/notation.lean
@@ -69,7 +69,7 @@ v ∘ fin.succ
 
 end matrix_notation
 
-variables {m n o : ℕ} {m' n' o' : Type} [fintype m'] [fintype n'] [fintype o']
+variables {m n o : ℕ} {m' n' o' : Type*} [fintype m'] [fintype n'] [fintype o']
 
 lemma empty_eq (v : fin 0 → α) : v = ![] :=
 by { ext i, fin_cases i }
@@ -98,7 +98,7 @@ rfl
   vec_tail (vec_cons x u) = u :=
 by { ext, simp [vec_tail] }
 
-@[simp] lemma empty_val' {n' : Type} (j : n') :
+@[simp] lemma empty_val' {n' : Type*} (j : n') :
   (λ i, (![] : fin 0 → n' → α) i j) = ![] :=
 empty_eq _
 
@@ -283,7 +283,7 @@ variables [semiring α]
 
 @[simp] lemma smul_empty (x : α) (v : fin 0 → α) : x • v = ![] := empty_eq _
 
-@[simp] lemma smul_mat_empty {m' : Type} (x : α) (A : fin 0 → m' → α) : x • A = ![] := empty_eq _
+@[simp] lemma smul_mat_empty {m' : Type*} (x : α) (A : fin 0 → m' → α) : x • A = ![] := empty_eq _
 
 @[simp] lemma smul_cons (x y : α) (v : fin n → α) :
   x • vec_cons y v = vec_cons (x * y) (x • v) :=

--- a/src/data/matrix/pequiv.lean
+++ b/src/data/matrix/pequiv.lean
@@ -36,7 +36,7 @@ open matrix
 
 universes u v
 
-variables {k l m n : Type u}
+variables {k l m n : Type*}
 variables [fintype k] [fintype l] [fintype m] [fintype n]
 variables {α : Type v}
 

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -298,7 +298,7 @@ end bilin_form
 
 section matrix
 variables {R : Type u} [comm_ring R]
-variables {n o : Type w} [fintype n] [fintype o]
+variables {n o : Type*} [fintype n] [fintype o]
 
 open bilin_form finset matrix
 open_locale matrix

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -22,7 +22,7 @@ import set_theory.cardinal_ordinal
 
 ## Implementation notes
 
-Many theorems in this file are not universe-generic wheen they relate dimensions
+Many theorems in this file are not universe-generic when they relate dimensions
 in different universes. They should be as general as they can be without
 inserting `lift`s. The types `V`, `V'`, ... all live in different universes,
 and `V₁`, `V₂`, ... all live in the same universe.

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -17,23 +17,28 @@ import set_theory.cardinal_ordinal
 
 * `mk_eq_mk_of_basis`: the dimension theorem, any two bases of the same vector space have the same
   cardinality.
-* `dim_quotient_add_dim`: if V' is a submodule of V, then dim (V/V') + dim V' = dim V.
+* `dim_quotient_add_dim`: if V₁ is a submodule of V, then dim (V/V₁) + dim V₁ = dim V.
 * `dim_range_add_dim_ker`: the rank-nullity theorem.
 
+## Implementation notes
+
+Many theorems in this file are not universe-generic wheen they relate dimensions
+in different universes. They should be as general as they can be without
+inserting `lift`s. The types `V`, `V'`, ... all live in different universes,
+and `V₁`, `V₂`, ... all live in the same universe.
 -/
 
 noncomputable theory
 
-universes u u' u'' v' w w'
+universes u v v' v'' u₁' w w'
 
-variables {K : Type u} {V V₂ V₃ V₄ : Type u'}
-variables {ι : Type w} {ι' : Type w'} {η : Type u''} {φ : η → Type*}
--- TODO: relax these universe constraints
+variables {K : Type u} {V V₁ V₂ V₃ : Type v} {V' V'₁ : Type v'} {V'' : Type v''}
+variables {ι : Type w} {ι' : Type w'} {η : Type u₁'} {φ : η → Type*}
 
 open_locale classical big_operators
 
 section vector_space
-variables [field K] [add_comm_group V] [vector_space K V]
+variables [field K] [add_comm_group V] [vector_space K V] [add_comm_group V₁] [vector_space K V₁]
 include K
 open submodule function set
 
@@ -89,18 +94,18 @@ theorem mk_eq_mk_of_basis {v : ι → V} {v' : ι' → V}
   (hv : is_basis K v) (hv' : is_basis K v') :
   cardinal.lift.{w w'} (cardinal.mk ι) = cardinal.lift.{w' w} (cardinal.mk ι') :=
 begin
-  rw ←cardinal.lift_inj.{(max w w') u'},
+  rw ←cardinal.lift_inj.{(max w w') v},
   rw [cardinal.lift_lift, cardinal.lift_lift],
   apply le_antisymm,
-  { convert cardinal.lift_le.{u' (max w w')}.2 (hv.le_span hv'.2),
-    { rw cardinal.lift_max.{w u' w'},
+  { convert cardinal.lift_le.{v (max w w')}.2 (hv.le_span hv'.2),
+    { rw cardinal.lift_max.{w v w'},
       apply (cardinal.mk_range_eq_of_injective hv.injective).symm, },
-    { rw cardinal.lift_max.{w' u' w},
+    { rw cardinal.lift_max.{w' v w},
       apply (cardinal.mk_range_eq_of_injective hv'.injective).symm, }, },
-  { convert cardinal.lift_le.{u' (max w w')}.2 (hv'.le_span hv.2),
-    { rw cardinal.lift_max.{w' u' w},
+  { convert cardinal.lift_le.{v (max w w')}.2 (hv'.le_span hv.2),
+    { rw cardinal.lift_max.{w' v w},
       apply (cardinal.mk_range_eq_of_injective hv'.injective).symm, },
-    { rw cardinal.lift_max.{w u' w'},
+    { rw cardinal.lift_max.{w v w'},
       apply (cardinal.mk_range_eq_of_injective hv.injective).symm, }, }
 end
 
@@ -116,20 +121,20 @@ begin
 end
 
 theorem is_basis.mk_eq_dim {v : ι → V} (h : is_basis K v) :
-  cardinal.lift.{w u'} (cardinal.mk ι) = cardinal.lift.{u' w} (dim K V) :=
+  cardinal.lift.{w v} (cardinal.mk ι) = cardinal.lift.{v w} (dim K V) :=
 by rw [←h.mk_range_eq_dim, cardinal.mk_range_eq_of_injective h.injective]
 
 theorem {m} is_basis.mk_eq_dim' {v : ι → V} (h : is_basis K v) :
-  cardinal.lift.{w (max u' m)} (cardinal.mk ι) = cardinal.lift.{u' (max w m)} (dim K V) :=
+  cardinal.lift.{w (max v m)} (cardinal.mk ι) = cardinal.lift.{v (max w m)} (dim K V) :=
 by simpa using h.mk_eq_dim
 
-variables [add_comm_group V₂] [vector_space K V₂]
+variables [add_comm_group V'] [vector_space K V']
 
 /-- Two linearly equivalent vector spaces have the same dimension. -/
-theorem linear_equiv.dim_eq (f : V ≃ₗ[K] V₂) :
-  dim K V = dim K V₂ :=
+theorem linear_equiv.dim_eq (f : V ≃ₗ[K] V₁) :
+  dim K V = dim K V₁ :=
 by letI := classical.dec_eq V;
-letI := classical.dec_eq V₂; exact
+letI := classical.dec_eq V₁; exact
 let ⟨b, hb⟩ := exists_is_basis K V in
 cardinal.lift_inj.1 $ hb.mk_eq_dim.symm.trans (f.is_basis hb).mk_eq_dim
 
@@ -155,18 +160,18 @@ by { rw [← @set_of_mem_eq _ s, ← subtype.range_coe_subtype], exact dim_span 
 
 lemma {m} cardinal_lift_le_dim_of_linear_independent
   {ι : Type w} {v : ι → V} (hv : linear_independent K v) :
-  cardinal.lift.{w (max u' m)} (cardinal.mk ι) ≤ cardinal.lift.{u' (max w m)} (dim K V) :=
+  cardinal.lift.{w (max v m)} (cardinal.mk ι) ≤ cardinal.lift.{v (max w m)} (dim K V) :=
 begin
   obtain ⟨ι', v', is⟩ := exists_sum_is_basis hv,
-  rw [← cardinal.lift_umax, ← cardinal.lift_umax.{u'}],
+  rw [← cardinal.lift_umax, ← cardinal.lift_umax.{v}],
   simpa using le_trans
-    (cardinal.lift_mk_le.{w _ (max u' m)}.2 ⟨@function.embedding.inl ι ι'⟩)
+    (cardinal.lift_mk_le.{w _ (max v m)}.2 ⟨@function.embedding.inl ι ι'⟩)
     (le_of_eq $ is_basis.mk_eq_dim'.{_ _ _ (max w m)} is),
 end
 
 lemma cardinal_le_dim_of_linear_independent
-  {ι : Type u'} {v : ι → V} (hv : linear_independent K v) :
-  (cardinal.mk ι) ≤ (dim.{u u'} K V) :=
+  {ι : Type v} {v : ι → V} (hv : linear_independent K v) :
+  (cardinal.mk ι) ≤ (dim.{u v} K V) :=
 by simpa using cardinal_lift_le_dim_of_linear_independent hv
 
 lemma cardinal_le_dim_of_linear_independent'
@@ -197,14 +202,14 @@ calc dim K (span K (↑s : set V)) ≤ cardinal.mk (↑s : set V) : dim_span_le 
                              ... = s.card : by rw ←cardinal.finset_card
                              ... < cardinal.omega : cardinal.nat_lt_omega _
 
-theorem dim_prod : dim K (V × V₂) = dim K V + dim K V₂ :=
+theorem dim_prod : dim K (V × V₁) = dim K V + dim K V₁ :=
 begin
   letI := classical.dec_eq V,
-  letI := classical.dec_eq V₂,
+  letI := classical.dec_eq V₁,
   rcases exists_is_basis K V with ⟨b, hb⟩,
-  rcases exists_is_basis K V₂ with ⟨c, hc⟩,
+  rcases exists_is_basis K V₁ with ⟨c, hc⟩,
   rw [← cardinal.lift_inj,
-      ← @is_basis.mk_eq_dim K (V × V₂) _ _ _ _ _ (is_basis_inl_union_inr hb hc),
+      ← @is_basis.mk_eq_dim K (V × V₁) _ _ _ _ _ (is_basis_inl_union_inr hb hc),
       cardinal.lift_add, cardinal.lift_mk,
       ← hb.mk_eq_dim, ← hc.mk_eq_dim,
       cardinal.lift_mk, cardinal.lift_mk,
@@ -222,42 +227,42 @@ theorem dim_quotient_le (p : submodule K V) :
 by { rw ← dim_quotient_add_dim p, exact cardinal.le_add_right _ _ }
 
 /-- rank-nullity theorem -/
-theorem dim_range_add_dim_ker (f : V →ₗ[K] V₂) : dim K f.range + dim K f.ker = dim K V :=
+theorem dim_range_add_dim_ker (f : V →ₗ[K] V₁) : dim K f.range + dim K f.ker = dim K V :=
 begin
   haveI := λ (p : submodule K V), classical.dec_eq p.quotient,
   rw [← f.quot_ker_equiv_range.dim_eq, dim_quotient_add_dim]
 end
 
-lemma dim_range_le (f : V →ₗ[K] V₂) : dim K f.range ≤ dim K V :=
+lemma dim_range_le (f : V →ₗ[K] V₁) : dim K f.range ≤ dim K V :=
 by rw ← dim_range_add_dim_ker f; exact le_add_right (le_refl _)
 
-lemma dim_map_le (f : V →ₗ V₂) (p : submodule K V) : dim K (p.map f) ≤ dim K p :=
+lemma dim_map_le (f : V →ₗ V₁) (p : submodule K V) : dim K (p.map f) ≤ dim K p :=
 begin
   have h := dim_range_le (f.comp (submodule.subtype p)),
   rwa [linear_map.range_comp, range_subtype] at h,
 end
 
-lemma dim_range_of_surjective (f : V →ₗ[K] V₂) (h : surjective f) : dim K f.range = dim K V₂ :=
+lemma dim_range_of_surjective (f : V →ₗ[K] V') (h : surjective f) : dim K f.range = dim K V' :=
 begin
   refine linear_equiv.dim_eq (linear_equiv.of_bijective (submodule.subtype _) _ _),
   exact linear_map.ker_eq_bot.2 subtype.val_injective,
   rwa [range_subtype, linear_map.range_eq_top]
 end
 
-lemma dim_eq_of_surjective (f : V →ₗ[K] V₂) (h : surjective f) : dim K V = dim K V₂ + dim K f.ker :=
+lemma dim_eq_of_surjective (f : V →ₗ[K] V₁) (h : surjective f) : dim K V = dim K V₁ + dim K f.ker :=
 by rw [← dim_range_add_dim_ker f, ← dim_range_of_surjective f h]
 
-lemma dim_le_of_surjective (f : V →ₗ[K] V₂) (h : surjective f) : dim K V₂ ≤ dim K V :=
+lemma dim_le_of_surjective (f : V →ₗ[K] V₁) (h : surjective f) : dim K V₁ ≤ dim K V :=
 by rw [dim_eq_of_surjective f h]; refine le_add_right (le_refl _)
 
-lemma dim_eq_of_injective (f : V →ₗ[K] V₂) (h : injective f) : dim K V = dim K f.range :=
+lemma dim_eq_of_injective (f : V →ₗ[K] V₁) (h : injective f) : dim K V = dim K f.range :=
 by rw [← dim_range_add_dim_ker f, linear_map.ker_eq_bot.2 h]; simp [dim_bot]
 
 lemma dim_submodule_le (s : submodule K V) : dim K s ≤ dim K V :=
 by { rw ← dim_quotient_add_dim s, exact cardinal.le_add_left _ _ }
 
-lemma dim_le_of_injective (f : V →ₗ[K] V₂) (h : injective f) :
-  dim K V ≤ dim K V₂ :=
+lemma dim_le_of_injective (f : V →ₗ[K] V₁) (h : injective f) :
+  dim K V ≤ dim K V₁ :=
 by { rw [dim_eq_of_injective f h], exact dim_submodule_le _ }
 
 lemma dim_le_of_submodule (s t : submodule K V) (h : s ≤ t) : dim K s ≤ dim K t :=
@@ -265,18 +270,18 @@ dim_le_of_injective (of_le h) $ assume ⟨x, hx⟩ ⟨y, hy⟩ eq,
   subtype.eq $ show x = y, from subtype.ext_iff_val.1 eq
 
 section
+variables [add_comm_group V₂] [vector_space K V₂]
 variables [add_comm_group V₃] [vector_space K V₃]
-variables [add_comm_group V₄] [vector_space K V₄]
 open linear_map
 
 /-- This is mostly an auxiliary lemma for `dim_sup_add_dim_inf_eq`. -/
 lemma dim_add_dim_split
-  (db : V₃ →ₗ[K] V) (eb : V₄ →ₗ[K] V) (cd : V₂ →ₗ[K] V₃) (ce : V₂ →ₗ[K] V₄)
+  (db : V₂ →ₗ[K] V) (eb : V₃ →ₗ[K] V) (cd : V₁ →ₗ[K] V₂) (ce : V₁ →ₗ[K] V₃)
   (hde : ⊤ ≤ db.range ⊔ eb.range)
   (hgd : ker cd = ⊥)
   (eq : db.comp cd = eb.comp ce)
   (eq₂ : ∀d e, db d = eb e → (∃c, cd c = d ∧ ce c = e)) :
-  dim K V + dim K V₂ = dim K V₃ + dim K V₄ :=
+  dim K V + dim K V₁ = dim K V₂ + dim K V₃ :=
 have hf : surjective (coprod db eb),
 begin
   refine (range_eq_top.1 $ top_unique $ _),
@@ -348,8 +353,8 @@ lemma dim_fun {V η : Type u} [fintype η] [add_comm_group V] [vector_space K V]
 by rw [dim_pi, cardinal.sum_const, cardinal.fintype_card]
 
 lemma dim_fun_eq_lift_mul :
-  vector_space.dim K (η → V) = (fintype.card η : cardinal.{max u'' u'}) *
-    cardinal.lift.{u' u''} (vector_space.dim K V) :=
+  vector_space.dim K (η → V) = (fintype.card η : cardinal.{max u₁' v}) *
+    cardinal.lift.{v u₁'} (vector_space.dim K V) :=
 by rw [dim_pi, cardinal.sum_const_eq_lift_mul, cardinal.fintype_card, cardinal.lift_nat_cast]
 
 lemma dim_fun' : vector_space.dim K (η → K) = fintype.card η :=
@@ -384,42 +389,44 @@ end
 section rank
 
 /-- `rank f` is the rank of a `linear_map f`, defined as the dimension of `f.range`. -/
-def rank (f : V →ₗ[K] V₂) : cardinal := dim K f.range
+def rank (f : V →ₗ[K] V') : cardinal := dim K f.range
 
-lemma rank_le_domain (f : V →ₗ[K] V₂) : rank f ≤ dim K V :=
+lemma rank_le_domain (f : V →ₗ[K] V₁) : rank f ≤ dim K V :=
 by rw [← dim_range_add_dim_ker f]; exact le_add_right (le_refl _)
 
-lemma rank_le_range (f : V →ₗ[K] V₂) : rank f ≤ dim K V₂ :=
+lemma rank_le_range (f : V →ₗ[K] V₁) : rank f ≤ dim K V₁ :=
 dim_submodule_le _
 
-lemma rank_add_le (f g : V →ₗ[K] V₂) : rank (f + g) ≤ rank f + rank g :=
-calc rank (f + g) ≤ dim K (f.range ⊔ g.range : submodule K V₂) :
+lemma rank_add_le (f g : V →ₗ[K] V') : rank (f + g) ≤ rank f + rank g :=
+calc rank (f + g) ≤ dim K (f.range ⊔ g.range : submodule K V') :
   begin
     refine dim_le_of_submodule _ _ _,
     exact (linear_map.range_le_iff_comap.2 $ eq_top_iff'.2 $
-      assume x, show f x + g x ∈ (f.range ⊔ g.range : submodule K V₂), from
+      assume x, show f x + g x ∈ (f.range ⊔ g.range : submodule K V'), from
         mem_sup.2 ⟨_, mem_image_of_mem _ (mem_univ _), _, mem_image_of_mem _ (mem_univ _), rfl⟩)
   end
   ... ≤ rank f + rank g : dim_add_le_dim_add_dim _ _
 
-@[simp] lemma rank_zero : rank (0 : V →ₗ[K] V₂) = 0 :=
+@[simp] lemma rank_zero : rank (0 : V →ₗ[K] V') = 0 :=
 by rw [rank, linear_map.range_zero, dim_bot]
 
-lemma rank_finset_sum_le {η} (s : finset η) (f : η → V →ₗ[K] V₂) :
+lemma rank_finset_sum_le {η} (s : finset η) (f : η → V →ₗ[K] V') :
   rank (∑ d in s, f d) ≤ ∑ d in s, rank (f d) :=
 @finset.sum_hom_rel _ _ _ _ _ (λa b, rank a ≤ b) f (λ d, rank (f d)) s (le_of_eq rank_zero)
       (λ i g c h, le_trans (rank_add_le _ _) (add_le_add_left h _))
 
-variables [add_comm_group V₃] [vector_space K V₃]
+variables [add_comm_group V''] [vector_space K V'']
 
-lemma rank_comp_le1 (g : V →ₗ[K] V₂) (f : V₂ →ₗ[K] V₃) : rank (f.comp g) ≤ rank f :=
+lemma rank_comp_le1 (g : V →ₗ[K] V') (f : V' →ₗ[K] V'') : rank (f.comp g) ≤ rank f :=
 begin
   refine dim_le_of_submodule _ _ _,
   rw [linear_map.range_comp],
   exact image_subset _ (subset_univ _)
 end
 
-lemma rank_comp_le2 (g : V →ₗ[K] V₂) (f : V₂ →ₗ V₃) : rank (f.comp g) ≤ rank g :=
+variables [add_comm_group V'₁] [vector_space K V'₁]
+
+lemma rank_comp_le2 (g : V →ₗ[K] V') (f : V' →ₗ V'₁) : rank (f.comp g) ≤ rank g :=
 by rw [rank, rank, linear_map.range_comp]; exact dim_map_le _ _
 
 end rank
@@ -466,7 +473,7 @@ open vector_space
 
 /-- Version of linear_equiv.dim_eq without universe constraints. -/
 theorem linear_equiv.dim_eq_lift (f : V ≃ₗ[K] E) :
-  cardinal.lift.{u' v'} (dim K V) = cardinal.lift.{v' u'} (dim K E) :=
+  cardinal.lift.{v v'} (dim K V) = cardinal.lift.{v' v} (dim K E) :=
 begin
   cases exists_is_basis K V with b hb,
   rw [← cardinal.lift_inj.1 hb.mk_eq_dim, ← (f.is_basis hb).mk_eq_dim, cardinal.lift_mk],

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -34,7 +34,7 @@ open set submodule
 open_locale big_operators
 
 universes u v w
-variables {l m n : Type u} [fintype l] [fintype m] [fintype n]
+variables {l m n : Type*} [fintype l] [fintype m] [fintype n]
 
 namespace matrix
 
@@ -357,14 +357,17 @@ variables {K : Type u} [field K] -- maybe try to relax the universe constraint
 
 open linear_map matrix
 
-lemma rank_vec_mul_vec (w : m → K) (v : n → K) :
+set_option pp.all true
+
+lemma rank_vec_mul_vec {m n : Type u} [fintype m] [fintype n]
+  (w : m → K) (v : n → K) :
   rank (vec_mul_vec w v).to_lin ≤ 1 :=
 begin
   rw [vec_mul_vec_eq, mul_to_lin],
   refine le_trans (rank_comp_le1 _ _) _,
   refine le_trans (rank_le_domain _) _,
-  rw [dim_fun', ← cardinal.fintype_card],
-  exact le_refl _
+  rw [dim_fun', ← cardinal.lift_eq_nat_iff.mpr (cardinal.fintype_card unit), cardinal.mk_unit],
+  exact le_of_eq (cardinal.lift_one)
 end
 
 lemma ker_diagonal_to_lin [decidable_eq m] (w : m → K) :
@@ -420,7 +423,7 @@ end finite_dimensional
 
 section reindexing
 
-variables {l' m' n' : Type w} [fintype l'] [fintype m'] [fintype n']
+variables {l' m' n' : Type*} [fintype l'] [fintype m'] [fintype n']
 variables {R : Type v}
 
 /-- The natural map that reindexes a matrix's rows and columns with equivalent types is an


### PR DESCRIPTION
@PatrickMassot was complaining that `matrix m n R` often doesn't work when the parameters are declared as `m n : Type*` because the universe parameters were equal. This PR makes the universe parameters of `m` and `n` distinct where possible, also generalizing some other linear algebra definitions.

The types of `col` and `row` used to be `matrix n punit` but are now `matrix n unit`, otherwise the elaborator can't figure out the universe. This doesn't seem to break anything except for the cases where `punit.{n}` was explicitly written down.

There were some breakages, but the total amount of changes is not too big.


---
<!-- put comments you want to keep out of the PR commit here -->
