### PR TITLE
feat(data/polynomial/eval): eval_sum

### DIFF
--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -459,6 +459,21 @@ lemma root_mul_right_of_is_root {p : polynomial R} (q : polynomial R) :
 λ H, by rw [is_root, eval_mul, is_root.def.1 H, zero_mul]
 
 /--
+Polynomial evaluation commutes with finset.sum
+-/
+lemma eval_finset.sum {ι : Type*} (s : finset ι) (p : ι → polynomial R) (x : R) :
+  eval x (∑ j in s, p j) = ∑ j in s, eval x (p j) :=
+begin
+  classical,
+  apply finset.induction_on s,
+    { simp only [finset.sum_empty, eval_zero] },
+    { intros j s hj hpj,
+      have h0 : ∑ i in insert j s, eval x (p i) = (eval x (p j)) + ∑ i in s, eval x (p i),
+      { apply finset.sum_insert hj },
+      rw [h0, ← hpj, finset.sum_insert hj, eval_add] },
+end
+
+/--
 Polynomial evaluation commutes with finset.prod
 -/
 lemma eval_prod {ι : Type*} (s : finset ι) (p : ι → polynomial R) (x : R) :


### PR DESCRIPTION

---
<!-- put comments you want to keep out of the PR commit here -->
This is the counterpart to `eval_prod` just below. One difference, though, is the fact that it can't be called `eval_sum`, since such a lemma appears above. Nevertheless, I think `eval_sum` and `eval_finset.sum` are different enough to both be present in mathlib. We could, of course, rename `eval_prod` to `eval_finset.prod` to keep both in sync, or just leave the names as they are. Other suggestions?