### PR TITLE
[Merged by Bors] - feat(data/finset/basic): insert_singleton_comm

### DIFF
--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -319,6 +319,12 @@ insert_eq_of_mem $ mem_singleton_self _
 theorem insert.comm (a b : α) (s : finset α) : insert a (insert b s) = insert b (insert a s) :=
 ext $ λ x, by simp only [mem_insert, or.left_comm]
 
+theorem insert_singleton_comm (a b : α) : ({a, b} : finset α) = {b, a} :=
+begin
+  ext,
+  simp [or.comm]
+end
+
 @[simp] theorem insert_idem (a : α) (s : finset α) : insert a (insert a s) = insert a s :=
 ext $ λ x, by simp only [mem_insert, or.assoc.symm, or_self]
 


### PR DESCRIPTION
Add the result that `({a, b} : finset α) = {b, a}`.  This came up in
#3872, and `library_search` does not show it as already present.

---
<!-- put comments you want to keep out of the PR commit here -->
