### PR TITLE
[Merged by Bors] - feat(category_theory): cancel fully faithful functor

### DIFF
--- a/src/category_theory/fully_faithful.lean
+++ b/src/category_theory/fully_faithful.lean
@@ -184,10 +184,21 @@ instance full.comp [full F] [full G] : full (F ⋙ G) :=
 Given a natural isomorphism between `F ⋙ H` and `G ⋙ H` for a fully faithful functor `H`, we
 can 'cancel' it to give a natural iso between `F` and `G`.
 -/
-def faithful_functor_right_cancel {F G : C ⥤ D} (H : D ⥤ E)
+def fully_faithful_cancel_right {F G : C ⥤ D} (H : D ⥤ E)
   [full H] [faithful H] (comp_iso: F ⋙ H ≅ G ⋙ H) : F ≅ G :=
 nat_iso.of_components
   (λ X, preimage_iso (comp_iso.app X))
   (λ X Y f, H.map_injective (by simpa using comp_iso.hom.naturality f))
+
+@[simp]
+lemma fully_faithful_cancel_right_hom_app {F G : C ⥤ D} {H : D ⥤ E}
+  [full H] [faithful H] (comp_iso: F ⋙ H ≅ G ⋙ H) (X : C) :
+  (fully_faithful_cancel_right H comp_iso).hom.app X = H.preimage (comp_iso.hom.app X) :=
+rfl
+@[simp]
+lemma fully_faithful_cancel_right_inv_app {F G : C ⥤ D} {H : D ⥤ E}
+  [full H] [faithful H] (comp_iso: F ⋙ H ≅ G ⋙ H) (X : C) :
+  (fully_faithful_cancel_right H comp_iso).inv.app X = H.preimage (comp_iso.inv.app X) :=
+rfl
 
 end category_theory

--- a/src/category_theory/fully_faithful.lean
+++ b/src/category_theory/fully_faithful.lean
@@ -180,4 +180,14 @@ lemma faithful.div_faithful (F : C ⥤ E) [faithful F] (G : D ⥤ E) [faithful G
 instance full.comp [full F] [full G] : full (F ⋙ G) :=
 { preimage := λ _ _ f, F.preimage (G.preimage f) }
 
+/--
+Given a natural isomorphism between `F ⋙ H` and `G ⋙ H` for a fully faithful functor `H`, we
+can 'cancel' it to give a natural iso between `F` and `G`.
+-/
+def faithful_functor_right_cancel {F G : C ⥤ D} (H : D ⥤ E)
+  [full H] [faithful H] (comp_iso: F ⋙ H ≅ G ⋙ H) : F ≅ G :=
+nat_iso.of_components
+  (λ X, preimage_iso (comp_iso.app X))
+  (λ X Y f, H.map_injective (by simpa using comp_iso.hom.naturality f))
+
 end category_theory


### PR DESCRIPTION
Construct the natural isomorphism between `F` and `G` given a natural iso between `F ⋙ H` and `G ⋙ H` for a fully faithful `H`. 

Co-authored-by: Thomas Read <thjread@gmail.com>