### PR TITLE
[Merged by Bors] - feat(order/rel_iso): define `rel_hom` (relation-preserving maps)

### DIFF
--- a/src/combinatorics/simple_graph.lean
+++ b/src/combinatorics/simple_graph.lean
@@ -210,14 +210,18 @@ section maps
 
 variables {W : Type*} (G) (H : simple_graph W)
 
+/-- A graph homomorphism maps adjacent vertices to adjacent vertices -/
 abbreviation hom := rel_hom G.adj H.adj
 
 infix ` →g ` : 50 := hom
 
+/-- A graph embedding is an embedding `f` such that for vertices `v w : V`,
+  `G.adj f(v) f(w) ↔ G.adj v w `-/
 abbreviation embedding := rel_embedding G.adj H.adj
 
 infix ` ↪g ` : 50 := embedding
 
+/-- A graph isomorphism is an equivalence that preserves adjacency-/
 abbreviation iso := rel_iso G.adj H.adj
 
 infix ` ≃g ` : 50 := iso

--- a/src/combinatorics/simple_graph.lean
+++ b/src/combinatorics/simple_graph.lean
@@ -206,4 +206,22 @@ by { intro v, simp }
 
 end finite
 
+section maps
+
+variables {W : Type*} (G) (H : simple_graph W)
+
+abbreviation hom := rel_hom G.adj H.adj
+
+infix ` →g ` : 50 := hom
+
+abbreviation embedding := rel_embedding G.adj H.adj
+
+infix ` ↪g ` : 50 := embedding
+
+abbreviation iso := rel_iso G.adj H.adj
+
+infix ` ≃g ` : 50 := iso
+
+end maps
+
 end simple_graph

--- a/src/combinatorics/simple_graph.lean
+++ b/src/combinatorics/simple_graph.lean
@@ -206,26 +206,4 @@ by { intro v, simp }
 
 end finite
 
-section maps
-
-variables {W : Type*} (G) (H : simple_graph W)
-
-/-- A graph homomorphism maps adjacent vertices to adjacent vertices -/
-abbreviation hom := rel_hom G.adj H.adj
-
-infix ` →g ` : 50 := hom
-
-/-- A graph embedding is an embedding `f` such that for vertices `v w : V`,
-  `G.adj f(v) f(w) ↔ G.adj v w `-/
-abbreviation embedding := rel_embedding G.adj H.adj
-
-infix ` ↪g ` : 50 := embedding
-
-/-- A graph isomorphism is an equivalence that preserves adjacency-/
-abbreviation iso := rel_iso G.adj H.adj
-
-infix ` ≃g ` : 50 := iso
-
-end maps
-
 end simple_graph

--- a/src/order/ord_continuous.lean
+++ b/src/order/ord_continuous.lean
@@ -245,7 +245,7 @@ protected lemma left_ord_continuous : left_ord_continuous e :=
   λ y hy, e.rel_symm_apply.1 $ (is_lub_le_iff hx).2 $ λ x' hx', e.rel_symm_apply.2 $ hy $
     mem_image_of_mem _ hx'⟩
 
-protected lemma right_ord_continuous : right_ord_continuous e := order_iso.left_ord_continuous e.osymm
+protected lemma right_ord_continuous : right_ord_continuous e := order_iso.left_ord_continuous e.dual
 
 end preorder
 

--- a/src/order/order_iso_nat.lean
+++ b/src/order/order_iso_nat.lean
@@ -22,7 +22,7 @@ end
 
 def nat_gt [is_strict_order α r] (f : ℕ → α) (H : ∀ n:ℕ, r (f (n+1)) (f n)) :
   ((>) : ℕ → ℕ → Prop) ↪r r :=
-by haveI := is_strict_order.swap r; exact rsymm (nat_lt f H)
+by haveI := is_strict_order.swap r; exact rel_embedding.swap (nat_lt f H)
 
 theorem well_founded_iff_no_descending_seq [is_strict_order α r] :
   well_founded r ↔ ¬ nonempty (((>) : ℕ → ℕ → Prop) ↪r r) :=

--- a/src/order/rel_iso.lean
+++ b/src/order/rel_iso.lean
@@ -15,6 +15,7 @@ variables {α : Type*} {β : Type*} {γ : Type*}
 
 /-- A relation homomorphism with respect to a given pair of relations `r` and `s`
 is a function `f : α → β` such that `r a b → s (f a) (f b)`. -/
+@[nolint has_inhabited_instance]
 structure rel_hom {α β : Type*} (r : α → α → Prop) (s : β → β → Prop) :=
 (to_fun : α → β)
 (map_rel' : ∀ {a b}, r a b → s (to_fun a) (to_fun b))

--- a/src/order/rel_iso.lean
+++ b/src/order/rel_iso.lean
@@ -33,29 +33,34 @@ theorem map_rel (f : r →r s) : ∀ {a b}, r a b → s (f a) (f b) := f.map_rel
 
 @[simp] theorem coe_fn_to_fun (f : r →r s) : (f.to_fun : α → β) = f := rfl
 
-/-- The map `coe_fn : (r →r s) → (r → s)` is injective. We can't use `function.injective`
+/-- The map `coe_fn : (r →r s) → (α → β)` is injective. We can't use `function.injective`
 here but mimic its signature by using `⦃e₁ e₂⦄`. -/
 theorem coe_fn_inj : ∀ ⦃e₁ e₂ : r →r s⦄, (e₁ : α → β) = e₂ → e₁ = e₂
 | ⟨f₁, o₁⟩ ⟨f₂, o₂⟩ h := by { congr, exact h }
 
+@[ext] theorem ext ⦃f g : r →r s⦄ (h : ∀ x, f x = g x) : f = g :=
+coe_fn_inj (funext h)
+
+theorem ext_iff {f g : r →r s} : f = g ↔ ∀ x, f x = g x :=
+⟨λ h x, h ▸ rfl, λ h, ext h⟩
+
 /-- Identity map is a relation homomorphism. -/
-@[refl] protected def refl (r : α → α → Prop) : r →r r :=
+@[refl] protected def id (r : α → α → Prop) : r →r r :=
 ⟨id, λ a b, id⟩
 
 /-- Composition of two relation homomorphisms is a relation homomorphism. -/
-@[trans] protected def trans (f : r →r s) (g : s →r t) : r →r t :=
+@[trans] protected def comp (g : s →r t) (f : r →r s) : r →r t :=
 ⟨g.1 ∘ f.1, λ a b h, g.2 (f.2 h)⟩
 
-@[simp] theorem refl_apply (x : α) : rel_hom.refl r x = x := rfl
+@[simp] theorem id_apply (x : α) : rel_hom.id r x = x := rfl
 
-@[simp] theorem trans_apply (f : r →r s) (g : s →r t) (a : α) : (f.trans g) a = g (f a) := rfl
+@[simp] theorem comp_apply (g : s →r t) (f : r →r s) (a : α) : (g.comp f) a = g (f a) := rfl
 
-/-- a relation embedding is also a relation embedding between dual relations. -/
-def rsymm (f : r →r s) : swap r →r swap s :=
-⟨f.to_fun, λ a b, f.map_rel⟩
+/-- A relation homomorphism is also a relation homomorphism between dual relations. -/
+protected def swap (f : r →r s) : swap r →r swap s :=
+⟨f, λ a b, f.map_rel⟩
 
-/-- If `f` is injective, then it is a relation embedding from the
-  preimage relation of `s` to `s`. -/
+/-- A function is a relation homomorphism from the preimage relation of `s` to `s`. -/
 def preimage (f : α → β) (s : β → β → Prop) : f ⁻¹'o s →r s := ⟨f, λ a b, id⟩
 
 protected theorem is_irrefl : ∀ (f : r →r s) [is_irrefl β s], is_irrefl α r
@@ -73,15 +78,6 @@ end
 
 protected theorem well_founded : ∀ (f : r →r s) (h : well_founded s), well_founded r
 | f ⟨H⟩ := ⟨λ a, f.acc _ (H _)⟩
-
-/-- It suffices to prove `f` is monotone between strict relations
-  to show it is a relation embedding. -/
-def of_monotone (f : α → β)
-  (H : ∀ a b, r a b → s (f a) (f b)) : r →r s :=
-⟨f, λ a b, H a b⟩
-
-@[simp] theorem of_monotone_coe (f : α → β) (H : ∀ a b, r a b → s (f a) (f b)) :
-  (of_monotone f H : α → β) = f := rfl
 
 end rel_hom
 
@@ -115,7 +111,7 @@ abbreviation order_embedding (α β : Type*) [has_le α] [has_le β] :=
 
 infix ` ↪o `:25 := order_embedding
 
-/-- the induced relation on a subtype is an embedding under the natural inclusion. -/
+/-- The induced relation on a subtype is an embedding under the natural inclusion. -/
 definition subtype.rel_embedding {X : Type*} (r : X → X → Prop) (p : X → Prop) :
 ((subtype.val : subtype p → X) ⁻¹'o r) ↪r r :=
 ⟨⟨subtype.val,subtype.val_injective⟩,by intros;refl⟩
@@ -129,7 +125,7 @@ namespace rel_embedding
 /-- A relation embedding is also a relation homomorphism -/
 def to_rel_hom (f : r ↪r s) : (r →r s) :=
 { to_fun := f.to_embedding.to_fun,
-  map_rel' := λ x y, by { rw f.map_rel_iff', exact id, } }
+  map_rel' := λ x y, (map_rel_iff' f).mp }
 
 instance : has_coe (r ↪r s) (r →r s) := ⟨to_rel_hom⟩
 -- see Note [function coercion]
@@ -148,10 +144,16 @@ theorem map_rel_iff (f : r ↪r s) : ∀ {a b}, r a b ↔ s (f a) (f b) := f.map
 
 @[simp] theorem coe_fn_to_embedding (f : r ↪r s) : (f.to_embedding : α → β) = f := rfl
 
-/-- The map `coe_fn : (r ↪r s) → (r → s)` is injective. We can't use `function.injective`
+/-- The map `coe_fn : (r ↪r s) → (α → β)` is injective. We can't use `function.injective`
 here but mimic its signature by using `⦃e₁ e₂⦄`. -/
 theorem coe_fn_inj : ∀ ⦃e₁ e₂ : r ↪r s⦄, (e₁ : α → β) = e₂ → e₁ = e₂
 | ⟨⟨f₁, h₁⟩, o₁⟩ ⟨⟨f₂, h₂⟩, o₂⟩ h := by { congr, exact h }
+
+@[ext] theorem ext ⦃f g : r ↪r s⦄ (h : ∀ x, f x = g x) : f = g :=
+coe_fn_inj (funext h)
+
+theorem ext_iff {f g : r ↪r s} : f = g ↔ ∀ x, f x = g x :=
+⟨λ h x, h ▸ rfl, λ h, ext h⟩
 
 /-- Identity map is a relation embedding. -/
 @[refl] protected def refl (r : α → α → Prop) : r ↪r r :=
@@ -165,8 +167,8 @@ theorem coe_fn_inj : ∀ ⦃e₁ e₂ : r ↪r s⦄, (e₁ : α → β) = e₂ �
 
 @[simp] theorem trans_apply (f : r ↪r s) (g : s ↪r t) (a : α) : (f.trans g) a = g (f a) := rfl
 
-/-- a relation embedding is also a relation embedding between dual relations. -/
-def rsymm (f : r ↪r s) : swap r ↪r swap s :=
+/-- A relation embedding is also a relation embedding between dual relations. -/
+protected def swap (f : r ↪r s) : swap r ↪r swap s :=
 ⟨f.to_embedding, λ a b, f.map_rel_iff⟩
 
 /-- If `f` is injective, then it is a relation embedding from the
@@ -280,7 +282,7 @@ protected theorem is_well_order [is_well_order β (<)] : is_well_order α (<) :=
 f.lt_embedding.is_well_order
 
 /-- An order embedding is also an order embedding between dual orders. -/
-def osymm : order_dual α ↪o order_dual β :=
+protected def dual : order_dual α ↪o order_dual β :=
 ⟨f.to_embedding, λ a b, f.map_rel_iff⟩
 
 end order_embedding
@@ -327,8 +329,6 @@ instance : has_coe_to_fun (r ≃r s) := ⟨λ _, α → β, λ f, f⟩
 
 @[simp] lemma coe_coe_fn (f : r ≃r s) : ((f : r ↪r s) : α → β) = f := rfl
 
-@[simp] lemma coe_coe_coe_fn (f : r ≃r s) : (((f : r ↪r s) : r →r s) : α → β) = f := rfl
-
 theorem map_rel_iff (f : r ≃r s) : ∀ {a b}, r a b ↔ s (f a) (f b) := f.map_rel_iff'
 
 lemma map_rel_iff'' {r : α → α → Prop} {s : β → β → Prop} (f : r ≃r s) {x y : α} :
@@ -342,13 +342,16 @@ lemma map_rel_iff'' {r : α → α → Prop} {s : β → β → Prop} (f : r ≃
 theorem to_equiv_injective : injective (to_equiv : (r ≃r s) → α ≃ β)
 | ⟨e₁, o₁⟩ ⟨e₂, o₂⟩ h := by { congr, exact h }
 
-/-- The map `coe_fn : (r ≃r s) → (r → s)` is injective. We can't use `function.injective`
+/-- The map `coe_fn : (r ≃r s) → (α → β)` is injective. We can't use `function.injective`
 here but mimic its signature by using `⦃e₁ e₂⦄`. -/
 theorem coe_fn_injective ⦃e₁ e₂ : r ≃r s⦄ (h : (e₁ : α → β) = e₂) : e₁ = e₂ :=
 to_equiv_injective $ equiv.coe_fn_injective h
 
-@[ext] theorem ext {e₁ e₂ : r ≃r s} (h : ∀ x, e₁ x = e₂ x) : e₁ = e₂ :=
-coe_fn_injective $ funext h
+@[ext] theorem ext ⦃f g : r ≃r s⦄ (h : ∀ x, f x = g x) : f = g :=
+coe_fn_injective (funext h)
+
+theorem ext_iff {f g : r ≃r s} : f = g ↔ ∀ x, f x = g x :=
+⟨λ h x, h ▸ rfl, λ h, ext h⟩
 
 /-- Identity map is a relation isomorphism. -/
 @[refl] protected def refl (r : α → α → Prop) : r ≃r r :=
@@ -363,7 +366,7 @@ coe_fn_injective $ funext h
 ⟨f₁.to_equiv.trans f₂.to_equiv, λ a b, f₁.map_rel_iff.trans f₂.map_rel_iff⟩
 
 /-- a relation isomorphism is also a relation isomorphism between dual relations. -/
-def rsymm (f : r ≃r s) : (swap r) ≃r (swap s) :=
+protected def swap (f : r ≃r s) : (swap r) ≃r (swap s) :=
 ⟨f.to_equiv, λ _ _, f.map_rel_iff⟩
 
 @[simp] theorem coe_fn_symm_mk (f o) : ((@rel_iso.mk _ _ r s f o).symm : β → α) = f.symm :=
@@ -479,7 +482,7 @@ def rel_embedding.cod_restrict (p : set β) (f : r ↪r s) (H : ∀ a, f a ∈ p
   rel_embedding.cod_restrict p f H a = ⟨f a, H a⟩ := rfl
 
   /-- An order isomorphism is also an order isomorphism between dual orders. -/
-def order_iso.osymm [preorder α] [preorder β] (f : α ≃o β) :
+protected def order_iso.dual [preorder α] [preorder β] (f : α ≃o β) :
   order_dual α ≃o order_dual β := ⟨f.to_equiv, λ _ _, f.map_rel_iff⟩
 
 section lattice_isos

--- a/src/order/rel_iso.lean
+++ b/src/order/rel_iso.lean
@@ -97,6 +97,16 @@ lemma rel_hom.injective_of_increasing [is_trichotomous α r]
   [is_irrefl β s] (f : r →r s) : injective f :=
 injective_of_increasing r s f (λ x y, f.map_rel)
 
+theorem surjective.well_founded_iff {f : α → β} (hf : surjective f)
+  (o : ∀ {a b}, r a b ↔ s (f a) (f b)) : well_founded r ↔ well_founded s :=
+iff.intro (begin
+  apply rel_hom.well_founded,
+  refine rel_hom.mk _ _,
+  {exact classical.some hf.has_right_inverse},
+  intros a b h, apply o.2, convert h,
+  iterate 2 { apply classical.some_spec hf.has_right_inverse },
+end) (rel_hom.well_founded ⟨f, λ _ _, o.1⟩)
+
 /-- A relation embedding with respect to a given pair of relations `r` and `s`
 is an embedding `f : α ↪ β` such that `r a b ↔ s (f a) (f b)`. -/
 structure rel_embedding {α β : Type*} (r : α → α → Prop) (s : β → β → Prop) extends α ↪ β :=
@@ -334,8 +344,8 @@ theorem map_rel_iff (f : r ≃r s) : ∀ {a b}, r a b ↔ s (f a) (f b) := f.map
 lemma map_rel_iff'' {r : α → α → Prop} {s : β → β → Prop} (f : r ≃r s) {x y : α} :
     r x y ↔ s ((↑f : r ↪r s) x) ((↑f : r ↪r s) y) := f.map_rel_iff
 
-@[simp] theorem coe_fn_mk (f : α ≃ β) (o) :
-  (@rel_iso.mk _ _ r s f o : α → β) = f := rfl
+@[simp] theorem coe_fn_mk (f : α ≃ β) (o : ∀ ⦃a b⦄, r a b ↔ s (f a) (f b)) :
+  (rel_iso.mk f o : α → β) = f := rfl
 
 @[simp] theorem coe_fn_to_equiv (f : r ≃r s) : (f.to_equiv : α → β) = f := rfl
 

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -382,14 +382,14 @@ theorem is_noetherian_of_submodule_of_noetherian (R M) [ring R] [add_comm_group 
   (N : submodule R M) (h : is_noetherian R M) : is_noetherian R N :=
 begin
   rw is_noetherian_iff_well_founded at h ⊢,
-  exact order_embedding.well_founded (submodule.map_subtype.order_embedding N).osymm h,
+  exact order_embedding.well_founded (submodule.map_subtype.order_embedding N).dual h,
 end
 
 theorem is_noetherian_of_quotient_of_noetherian (R) [ring R] (M) [add_comm_group M] [module R M]
   (N : submodule R M) (h : is_noetherian R M) : is_noetherian R N.quotient :=
 begin
   rw is_noetherian_iff_well_founded at h ⊢,
-  exact order_embedding.well_founded (submodule.comap_mkq.order_embedding N).osymm h,
+  exact order_embedding.well_founded (submodule.comap_mkq.order_embedding N).dual h,
 end
 
 theorem is_noetherian_of_fg_of_noetherian {R M} [ring R] [add_comm_group M] [module R M]
@@ -434,7 +434,7 @@ theorem is_noetherian_ring_of_surjective (R) [comm_ring R] (S) [comm_ring S]
   [H : is_noetherian_ring R] : is_noetherian_ring S :=
 begin
   rw [is_noetherian_ring, is_noetherian_iff_well_founded] at H ⊢,
-  exact order_embedding.well_founded (ideal.order_embedding_of_surjective f hf).osymm H,
+  exact order_embedding.well_founded (ideal.order_embedding_of_surjective f hf).dual H,
 end
 
 instance is_noetherian_ring_range {R} [comm_ring R] {S} [comm_ring S] (f : R →+* S)


### PR DESCRIPTION
Creates a typeclass for (unidirectionally) relation-preserving maps that are not necessarily injective
(In the case of <= relations, this is essentially a bundled monotone map)
Proves that these transfer well-foundedness between relations

---
<!--  -->
