### PR TITLE
[Merged by Bors] - feat(ring_theory/ideal/basic): R/I is an ID iff I is prime

### DIFF
--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -329,6 +329,11 @@ instance (I : ideal α) [hI : I.is_prime] : integral_domain I.quotient :=
   .. quotient.comm_ring I,
   .. quotient.nontrivial hI.1 }
 
+lemma is_integral_domain_iff_prime (I : ideal α) : is_integral_domain I.quotient ↔ I.is_prime :=
+⟨ λ ⟨h1, h2, h3⟩, ⟨zero_ne_one_iff.1 $ @zero_ne_one _ _ ⟨h1⟩, λ x y h,
+    by { simp only [←eq_zero_iff_mem, (mk I).map_mul] at ⊢ h, exact h3 _ _ h}⟩,
+  λ h, by exactI integral_domain.to_is_integral_domain I.quotient⟩
+
 lemma exists_inv {I : ideal α} [hI : I.is_maximal] :
  ∀ {a : I.quotient}, a ≠ 0 → ∃ b : I.quotient, a * b = 1 :=
 begin


### PR DESCRIPTION
`is_integral_domain_iff_prime (I : ideal α) : is_integral_domain I.quotient ↔ I.is_prime`

---
<!-- put comments you want to keep out of the PR commit here -->

I would also add the lemma that R/I is a field iff I is maximal, but we don't have an `is_field` predicate. The uncontroversial way is in mathlib -- if I is maximal then I.quotient is a field. But how to say "this ring is a field"? The way things are set up in mathlib, this is more data (`inv`) but this data is uniquely determined if the ring is a field. We could have an `is_field` predicate on rings and a little API like this: https://github.com/leanprover-community/mathlib/blob/187bfa5255c51db9602d1a032b0c36799c0bd47b/src/algebra/ring/basic.lean#L779-L801 . I propose that this be another PR if people are interested.
