### PR TITLE
[Merged by Bors] - refactor(set_theory/game): make impartial a class

### DIFF
--- a/src/set_theory/game/impartial.lean
+++ b/src/set_theory/game/impartial.lean
@@ -22,7 +22,7 @@ namespace pgame
 
 local infix ` ≈ ` := equiv
 
-/-- The definiton for a impartial game, defined using Conway induction -/
+/-- The definition for a impartial game, defined using Conway induction -/
 @[class] def impartial : pgame → Prop
 | G := G ≈ -G ∧ (∀ i, impartial (G.move_left i)) ∧ (∀ j, impartial (G.move_right j))
 using_well_founded { dec_tac := pgame_wf_tac }
@@ -62,12 +62,12 @@ begin
   { apply equiv_trans _ (equiv_of_relabelling (neg_add_relabelling G H)).symm,
     exact add_congr (neg_equiv_self _) (neg_equiv_self _) },
   split,
-  all_goals {
-    intro i,
+  all_goals
+  { intro i,
     equiv_rw pgame.left_moves_add G H at i <|> equiv_rw pgame.right_moves_add G H at i,
     cases i },
-  all_goals {
-    simp only [add_move_left_inl, add_move_right_inl, add_move_left_inr, add_move_right_inr],
+  all_goals
+  { simp only [add_move_left_inl, add_move_right_inl, add_move_left_inr, add_move_right_inr],
     exact impartial_add _ _ }
 end
 using_well_founded { dec_tac := pgame_wf_tac }
@@ -82,8 +82,8 @@ begin
     symmetry,
     exact neg_equiv_self G },
   split,
-  all_goals {
-    intro i,
+  all_goals
+  { intro i,
     equiv_rw G.left_moves_neg at i <|> equiv_rw G.right_moves_neg at i,
     simp only [move_left_left_moves_neg_symm, move_right_right_moves_neg_symm],
     exact impartial_neg _ }

--- a/src/set_theory/game/impartial.lean
+++ b/src/set_theory/game/impartial.lean
@@ -10,7 +10,7 @@ import tactic.equiv_rw
 universe u
 
 /-!
-# Basic deinitions about impartial (pre-)games
+# Basic definitions about impartial (pre-)games
 
 We will define an impartial game, one in which left and right can make exactly the same moves.
 Our definition differs slightly by saying that the game is always equivalent to its negative,
@@ -23,11 +23,9 @@ namespace pgame
 local infix ` ≈ ` := equiv
 
 /-- The definiton for a impartial game, defined using Conway induction -/
-def impartial : pgame → Prop
+@[class] def impartial : pgame → Prop
 | G := G ≈ -G ∧ (∀ i, impartial (G.move_left i)) ∧ (∀ j, impartial (G.move_right j))
-using_well_founded {dec_tac := pgame_wf_tac}
-
-lemma zero_impartial : impartial 0 := by tidy
+using_well_founded { dec_tac := pgame_wf_tac }
 
 lemma impartial_def {G : pgame} :
   G.impartial ↔ G ≈ -G ∧ (∀ i, impartial (G.move_left i)) ∧ (∀ j, impartial (G.move_right j)) :=
@@ -41,152 +39,125 @@ begin
     exact hi }
 end
 
-lemma impartial_neg_equiv_self {G : pgame} (h : G.impartial) : G ≈ -G := (impartial_def.1 h).1
+namespace impartial
 
-lemma impartial_move_left_impartial {G : pgame} (h : G.impartial) (i : G.left_moves) :
-  impartial (G.move_left i) :=
+instance impartial_zero : impartial 0 := by tidy
+
+lemma neg_equiv_self (G : pgame) [h : G.impartial] : G ≈ -G := (impartial_def.1 h).1
+
+instance move_left_impartial {G : pgame} [h : G.impartial] (i : G.left_moves) :
+  (G.move_left i).impartial :=
 (impartial_def.1 h).2.1 i
 
-lemma impartial_move_right_impartial {G : pgame} (h : G.impartial) (j : G.right_moves) :
-  impartial (G.move_right j) :=
+instance move_right_impartial {G : pgame} [h : G.impartial] (j : G.right_moves) :
+  (G.move_right j).impartial :=
 (impartial_def.1 h).2.2 j
 
-lemma impartial_add : ∀ {G H : pgame}, G.impartial → H.impartial → (G + H).impartial
+instance impartial_add : ∀ (G H : pgame) [G.impartial] [H.impartial], (G + H).impartial
 | G H :=
 begin
-  intros hG hH,
+  introsI hG hH,
   rw impartial_def,
   split,
   { apply equiv_trans _ (equiv_of_relabelling (neg_add_relabelling G H)).symm,
-    apply add_congr,
-    exact impartial_neg_equiv_self hG,
-    exact impartial_neg_equiv_self hH },
+    exact add_congr (neg_equiv_self _) (neg_equiv_self _) },
   split,
-  { intro i,
-    equiv_rw pgame.left_moves_add G H at i,
-    cases i with iG iH,
-    { rw add_move_left_inl,
-      exact impartial_add (impartial_move_left_impartial hG _) hH },
-    { rw add_move_left_inr,
-      exact impartial_add hG (impartial_move_left_impartial hH _) } },
-  { intro j,
-    equiv_rw pgame.right_moves_add G H at j,
-    cases j with jG jH,
-    { rw add_move_right_inl,
-      exact impartial_add (impartial_move_right_impartial hG _) hH },
-    { rw add_move_right_inr,
-      exact impartial_add hG (impartial_move_right_impartial hH _) } }
+  all_goals {
+    intro i,
+    equiv_rw pgame.left_moves_add G H at i <|> equiv_rw pgame.right_moves_add G H at i,
+    cases i },
+  all_goals {
+    simp only [add_move_left_inl, add_move_right_inl, add_move_left_inr, add_move_right_inr],
+    exact impartial_add _ _ }
 end
-using_well_founded {dec_tac := pgame_wf_tac}
+using_well_founded { dec_tac := pgame_wf_tac }
 
-lemma impartial_neg : ∀ {G : pgame}, G.impartial → (-G).impartial
+instance impartial_neg : ∀ (G : pgame) [G.impartial], (-G).impartial
 | G :=
 begin
-  intro hG,
+  introI hG,
   rw impartial_def,
   split,
   { rw neg_neg,
     symmetry,
-    exact impartial_neg_equiv_self hG },
+    exact neg_equiv_self G },
   split,
-  { intro i,
-    equiv_rw G.left_moves_neg at i,
-    rw move_left_left_moves_neg_symm,
-    exact impartial_neg (impartial_move_right_impartial hG _) },
-  { intro j,
-    equiv_rw G.right_moves_neg at j,
-    rw move_right_right_moves_neg_symm,
-    exact impartial_neg (impartial_move_left_impartial hG _) }
+  all_goals {
+    intro i,
+    equiv_rw G.left_moves_neg at i <|> equiv_rw G.right_moves_neg at i,
+    simp only [move_left_left_moves_neg_symm, move_right_right_moves_neg_symm],
+    exact impartial_neg _ }
 end
-using_well_founded {dec_tac := pgame_wf_tac}
+using_well_founded { dec_tac := pgame_wf_tac }
 
-lemma impartial_winner_cases {G : pgame} (hG : G.impartial) : G.first_loses ∨ G.first_wins :=
+lemma winner_cases (G : pgame) [G.impartial] : G.first_loses ∨ G.first_wins :=
 begin
   rcases G.winner_cases with hl | hr | hp | hn,
   { cases hl with hpos hnonneg,
     rw ←not_lt at hnonneg,
-    have hneg := lt_of_lt_of_equiv hpos (impartial_neg_equiv_self hG),
+    have hneg := lt_of_lt_of_equiv hpos (neg_equiv_self G),
     rw [lt_iff_neg_gt, neg_neg, neg_zero] at hneg,
     contradiction },
   { cases hr with hnonpos hneg,
     rw ←not_lt at hnonpos,
-    have hpos := lt_of_equiv_of_lt (impartial_neg_equiv_self hG).symm hneg,
+    have hpos := lt_of_equiv_of_lt (neg_equiv_self G).symm hneg,
     rw [lt_iff_neg_gt, neg_neg, neg_zero] at hpos,
     contradiction },
   { left, assumption },
   { right, assumption }
 end
 
-lemma impartial_not_first_wins {G : pgame} (hG : G.impartial) : ¬G.first_wins ↔ G.first_loses :=
-by cases impartial_winner_cases hG; finish using [not_first_loses_of_first_wins]
+lemma not_first_wins (G : pgame) [G.impartial] : ¬G.first_wins ↔ G.first_loses :=
+by cases winner_cases G; finish using [not_first_loses_of_first_wins]
 
-lemma impartial_not_first_loses {G : pgame} (hG : G.impartial) : ¬G.first_loses ↔ G.first_wins :=
-iff.symm $ iff_not_comm.1 $ iff.symm $ impartial_not_first_wins hG
+lemma not_first_loses (G : pgame) [G.impartial] : ¬G.first_loses ↔ G.first_wins :=
+iff.symm $ iff_not_comm.1 $ iff.symm $ not_first_wins G
 
-lemma impartial_add_self {G : pgame} (hG : G.impartial) : (G + G).first_loses :=
-  first_loses_is_zero.2 $ equiv_trans (add_congr (impartial_neg_equiv_self hG) G.equiv_refl)
+lemma add_self (G : pgame) [G.impartial] : (G + G).first_loses :=
+  first_loses_is_zero.2 $ equiv_trans (add_congr (neg_equiv_self G) G.equiv_refl)
   add_left_neg_equiv
 
-lemma equiv_iff_sum_first_loses {G H : pgame} (hG : G.impartial) (hH : H.impartial) :
+lemma equiv_iff_sum_first_loses (G H : pgame) [G.impartial] [H.impartial] :
   G ≈ H ↔ (G + H).first_loses :=
 begin
   split,
   { intro heq,
-    exact first_loses_of_equiv (add_congr (equiv_refl _) heq) (impartial_add_self hG) },
+    exact first_loses_of_equiv (add_congr (equiv_refl _) heq) (add_self G) },
   { intro hGHp,
     split,
     { rw le_iff_sub_nonneg,
       exact le_trans hGHp.2
         (le_trans add_comm_le $ le_of_le_of_equiv (le_refl _) $ add_congr (equiv_refl _)
-        (impartial_neg_equiv_self hG)) },
+        (neg_equiv_self G)) },
     { rw le_iff_sub_nonneg,
       exact le_trans hGHp.2
-        (le_of_le_of_equiv (le_refl _) $ add_congr (equiv_refl _) (impartial_neg_equiv_self hH)) } }
+        (le_of_le_of_equiv (le_refl _) $ add_congr (equiv_refl _) (neg_equiv_self H)) } }
 end
 
-lemma impartial_first_loses_symm {G : pgame} (hG : G.impartial) : G.first_loses ↔ G ≤ 0 :=
-begin
-  use and.left,
-  { intro hneg,
-    use hneg,
-    exact zero_le_iff_neg_le_zero.2 (le_of_equiv_of_le (impartial_neg_equiv_self hG).symm hneg) }
-end
+lemma le_zero_iff {G : pgame} [G.impartial] : G ≤ 0 ↔ 0 ≤ G :=
+by rw [le_zero_iff_zero_le_neg, le_congr (equiv_refl 0) (neg_equiv_self G)]
 
-lemma impartial_first_wins_symm {G : pgame} (hG : G.impartial) : G.first_wins ↔ G < 0 :=
-begin
-  use and.right,
-  { intro hneg,
-    split,
-    rw lt_iff_neg_gt,
-    rw neg_zero,
-    exact lt_of_equiv_of_lt (impartial_neg_equiv_self hG).symm hneg,
-    exact hneg }
-end
+lemma lt_zero_iff {G : pgame} [G.impartial] : G < 0 ↔ 0 < G :=
+by rw [lt_iff_neg_gt, neg_zero, lt_congr (equiv_refl 0) (neg_equiv_self G)]
 
-lemma impartial_first_loses_symm' {G : pgame} (hG : G.impartial) : G.first_loses ↔ 0 ≤ G :=
-begin
-  use and.right,
-  { intro hpos,
-    use le_zero_iff_zero_le_neg.2 (le_of_le_of_equiv hpos $ impartial_neg_equiv_self hG),
-    exact hpos }
-end
+lemma first_loses_symm (G : pgame) [G.impartial] : G.first_loses ↔ G ≤ 0 :=
+⟨and.left, λ h, ⟨h, le_zero_iff.1 h⟩⟩
 
-lemma impartial_first_wins_symm' {G : pgame} (hG : G.impartial) : G.first_wins ↔ 0 < G :=
-begin
-  use and.left,
-  { intro hpos,
-    use hpos,
-    rw lt_iff_neg_gt,
-    rw neg_zero,
-    exact lt_of_lt_of_equiv hpos (impartial_neg_equiv_self hG) }
-end
+lemma first_wins_symm (G : pgame) [G.impartial] : G.first_wins ↔ G < 0 :=
+⟨and.right, λ h, ⟨lt_zero_iff.1 h, h⟩⟩
 
-lemma no_good_left_moves_iff_first_loses {G : pgame} (hG : G.impartial) :
+lemma first_loses_symm' (G : pgame) [G.impartial] : G.first_loses ↔ 0 ≤ G :=
+⟨and.right, λ h, ⟨le_zero_iff.2 h, h⟩⟩
+
+lemma first_wins_symm' (G : pgame) [G.impartial] : G.first_wins ↔ 0 < G :=
+⟨and.left, λ h, ⟨h, lt_zero_iff.2 h⟩⟩
+
+lemma no_good_left_moves_iff_first_loses (G : pgame) [G.impartial] :
   (∀ (i : G.left_moves), (G.move_left i).first_wins) ↔ G.first_loses :=
 begin
   split,
   { intro hbad,
-    rw [impartial_first_loses_symm hG, le_def_lt],
+    rw [first_loses_symm G, le_def_lt],
     split,
     { intro i,
       specialize hbad i,
@@ -194,51 +165,40 @@ begin
     { intro j,
       exact pempty.elim j } },
   { intros hp i,
-    rw impartial_first_wins_symm (impartial_move_left_impartial hG _),
-    exact (le_def_lt.1 $ (impartial_first_loses_symm hG).1 hp).1 i }
+    rw first_wins_symm,
+    exact (le_def_lt.1 $ (first_loses_symm G).1 hp).1 i }
 end
 
-lemma no_good_right_moves_iff_first_loses {G : pgame} (hG : G.impartial) :
+lemma no_good_right_moves_iff_first_loses (G : pgame) [G.impartial] :
   (∀ (j : G.right_moves), (G.move_right j).first_wins) ↔ G.first_loses :=
 begin
-  split,
-  { intro hbad,
-    rw [impartial_first_loses_symm' hG, le_def_lt],
-    split,
-    { intro i,
-      exact pempty.elim i },
-    { intro j,
-      specialize hbad j,
-      exact hbad.1 } },
-  { intros hp j,
-    rw impartial_first_wins_symm' (impartial_move_right_impartial hG _),
-    exact ((le_def_lt.1 $ (impartial_first_loses_symm' hG).1 hp).2 j) }
+  rw [first_loses_of_equiv_iff (neg_equiv_self G), ←no_good_left_moves_iff_first_loses],
+  refine ⟨λ h i, _, λ h i, _⟩,
+  { simpa [first_wins_of_equiv_iff (neg_equiv_self ((-G).move_left i))]
+    using h (left_moves_neg _ i) },
+  { simpa [first_wins_of_equiv_iff (neg_equiv_self (G.move_right i))]
+      using h ((left_moves_neg _).symm i) }
 end
 
-lemma good_left_move_iff_first_wins {G : pgame} (hG : G.impartial) :
+lemma good_left_move_iff_first_wins (G : pgame) [G.impartial] :
   (∃ (i : G.left_moves), (G.move_left i).first_loses) ↔ G.first_wins :=
 begin
-  split,
-  { rintro ⟨ i, hi ⟩,
-    exact (impartial_first_wins_symm' hG).2 (lt_def_le.2 $ or.inl ⟨ i, hi.2 ⟩) },
-  { intro hn,
-    rw [impartial_first_wins_symm' hG, lt_def_le] at hn,
-    rcases hn with ⟨ i, hi ⟩ | ⟨ j, _ ⟩,
-    { exact ⟨ i, (impartial_first_loses_symm' $ impartial_move_left_impartial hG _).2 hi ⟩ },
-    { exact pempty.elim j } }
+  refine ⟨λ ⟨i, hi⟩, (first_wins_symm' G).2 (lt_def_le.2 $ or.inl ⟨i, hi.2⟩), λ hn, _⟩,
+  rw [first_wins_symm' G, lt_def_le] at hn,
+  rcases hn with ⟨i, hi⟩ | ⟨j, _⟩,
+  { exact ⟨i, (first_loses_symm' _).2 hi⟩ },
+  { exact pempty.elim j }
 end
 
-lemma good_right_move_iff_first_wins {G : pgame} (hG : G.impartial) :
+lemma good_right_move_iff_first_wins (G : pgame) [G.impartial] :
   (∃ j : G.right_moves, (G.move_right j).first_loses) ↔ G.first_wins :=
 begin
-  split,
-  { rintro ⟨ j, hj ⟩,
-    exact (impartial_first_wins_symm hG).2 (lt_def_le.2 $ or.inr ⟨ j, hj.1 ⟩) },
-  { intro hn,
-    rw [impartial_first_wins_symm hG, lt_def_le] at hn,
-    rcases hn with ⟨ i, _ ⟩ | ⟨ j, hj ⟩,
-    { exact pempty.elim i },
-    { exact ⟨ j, (impartial_first_loses_symm $ impartial_move_right_impartial hG _).2 hj ⟩ } }
+  refine ⟨λ ⟨j, hj⟩, (first_wins_symm G).2 (lt_def_le.2 $ or.inr ⟨j, hj.1⟩), λ hn, _⟩,
+  rw [first_wins_symm G, lt_def_le] at hn,
+  rcases hn with ⟨i, _⟩ | ⟨j, hj⟩,
+  { exact pempty.elim i },
+  { exact ⟨j, (first_loses_symm _).2 hj⟩ }
 end
 
+end impartial
 end pgame

--- a/src/set_theory/game/nim.lean
+++ b/src/set_theory/game/nim.lean
@@ -55,8 +55,6 @@ local infix ` ≈ ` := equiv
 
 namespace nim
 
-open pgame
-
 lemma nim_def (O : ordinal) : nim O = pgame.mk O.out.α O.out.α
   (λ O₂, nim (ordinal.typein O.out.r O₂))
   (λ O₂, nim (ordinal.typein O.out.r O₂)) :=

--- a/src/set_theory/game/nim.lean
+++ b/src/set_theory/game/nim.lean
@@ -29,14 +29,10 @@ tedious, but avoids the universe bump.
 
 -/
 
-open pgame
-
-local infix ` ≈ ` := equiv
-
 /-- `ordinal.out` and `ordinal.type_out'` are required to make the definition of nim computable.
  `ordinal.out` performs the same job as `quotient.out` but is specific to ordinals. -/
 def ordinal.out (o : ordinal) : Well_order :=
-⟨ o.out.α, λ x y, o.out.r x y, o.out.wo ⟩
+⟨o.out.α, λ x y, o.out.r x y, o.out.wo⟩
 
 /-- This is the same as `ordinal.type_out` but defined to use `ordinal.out`. -/
 theorem ordinal.type_out' : ∀ (o : ordinal), ordinal.type (ordinal.out o).r = o := ordinal.type_out
@@ -53,7 +49,13 @@ def nim : ordinal → pgame
     nim (ordinal.typein O₁.out.r O₂)⟩
 using_well_founded { dec_tac := tactic.assumption }
 
+namespace pgame
+
+local infix ` ≈ ` := equiv
+
 namespace nim
+
+open pgame
 
 lemma nim_def (O : ordinal) : nim O = pgame.mk O.out.α O.out.α
   (λ O₂, nim (ordinal.typein O.out.r O₂))
@@ -66,7 +68,7 @@ begin
   exact ordinal.typein_lt_type _ _
 end
 
-lemma nim_impartial : ∀ (O : ordinal), impartial (nim O)
+instance nim_impartial : ∀ (O : ordinal), impartial (nim O)
 | O :=
 begin
   rw [impartial_def, nim_def, neg_def],
@@ -76,18 +78,18 @@ begin
     split,
     { intro i,
       let hwf : (ordinal.typein O.out.r i) < O := nim_wf_lemma i,
-      exact or.inl ⟨i, (impartial_neg_equiv_self $ nim_impartial $ ordinal.typein O.out.r i).1⟩ },
+      exact or.inl ⟨i, (@impartial.neg_equiv_self _ $ nim_impartial $ ordinal.typein O.out.r i).1⟩ },
     { intro j,
       let hwf : (ordinal.typein O.out.r j) < O := nim_wf_lemma j,
-      exact or.inr ⟨j, (impartial_neg_equiv_self $ nim_impartial $ ordinal.typein O.out.r j).1⟩ } },
+      exact or.inr ⟨j, (@impartial.neg_equiv_self _ $ nim_impartial $ ordinal.typein O.out.r j).1⟩ } },
   { rw pgame.le_def,
     split,
     { intro i,
       let hwf : (ordinal.typein O.out.r i) < O := nim_wf_lemma i,
-      exact or.inl ⟨i, (impartial_neg_equiv_self $ nim_impartial $ ordinal.typein O.out.r i).2⟩ },
+      exact or.inl ⟨i, (@impartial.neg_equiv_self _ $ nim_impartial $ ordinal.typein O.out.r i).2⟩ },
     { intro j,
       let hwf : (ordinal.typein O.out.r j) < O := nim_wf_lemma j,
-      exact or.inr ⟨j, (impartial_neg_equiv_self $ nim_impartial $ ordinal.typein O.out.r j).2⟩ } },
+      exact or.inr ⟨j, (@impartial.neg_equiv_self _ $ nim_impartial $ ordinal.typein O.out.r j).2⟩ } },
   split,
   { intro i,
     let hwf : (ordinal.typein O.out.r i) < O := nim_wf_lemma i,
@@ -98,9 +100,9 @@ begin
 end
 using_well_founded { dec_tac := tactic.assumption }
 
-lemma nim_zero_first_loses : (nim (0 : ordinal)).first_loses :=
+lemma zero_first_loses : (nim (0 : ordinal)).first_loses :=
 begin
-  rw [impartial_first_loses_symm (nim_impartial _), nim_def, le_def_lt],
+  rw [impartial.first_loses_symm, nim_def, le_def_lt],
   split,
   { rintro (i : (0 : ordinal).out.α),
     have h := ordinal.typein_lt_type _ i,
@@ -109,40 +111,40 @@ begin
   { tidy }
 end
 
-lemma nim_non_zero_first_wins (O : ordinal) (hO : O ≠ 0) : (nim O).first_wins :=
+lemma non_zero_first_wins (O : ordinal) (hO : O ≠ 0) : (nim O).first_wins :=
 begin
-  rw [impartial_first_wins_symm (nim_impartial _), nim_def, lt_def_le],
+  rw [impartial.first_wins_symm, nim_def, lt_def_le],
   rw ←ordinal.pos_iff_ne_zero at hO,
-  exact or.inr ⟨(ordinal.principal_seg_out hO).top, by simpa using nim_zero_first_loses.1⟩
+  exact or.inr ⟨(ordinal.principal_seg_out hO).top, by simpa using zero_first_loses.1⟩
 end
 
-lemma nim_sum_first_loses_iff_eq (O₁ O₂ : ordinal) : (nim O₁ + nim O₂).first_loses ↔ O₁ = O₂ :=
+lemma sum_first_loses_iff_eq (O₁ O₂ : ordinal) : (nim O₁ + nim O₂).first_loses ↔ O₁ = O₂ :=
 begin
   split,
   { contrapose,
     intro h,
-    rw [impartial_not_first_loses (impartial_add (nim_impartial _) (nim_impartial _))],
+    rw [impartial.not_first_loses],
     wlog h' : O₁ ≤ O₂ using [O₁ O₂, O₂ O₁],
     { exact ordinal.le_total O₁ O₂ },
     { have h : O₁ < O₂ := lt_of_le_of_ne h' h,
-      rw [impartial_first_wins_symm' (impartial_add (nim_impartial _) (nim_impartial _)),
-        lt_def_le, nim_def O₂],
+      rw [impartial.first_wins_symm', lt_def_le, nim_def O₂],
       refine or.inl ⟨(left_moves_add (nim O₁) _).symm (sum.inr _), _⟩,
       { exact (ordinal.principal_seg_out h).top },
-      { simpa using (impartial_add_self (nim_impartial _)).2 } },
+      { simpa using (impartial.add_self (nim O₁)).2 } },
     { exact first_wins_of_equiv add_comm_equiv (this (ne.symm h)) } },
   { rintro rfl,
-    exact impartial_add_self (nim_impartial O₁) }
+    exact impartial.add_self (nim O₁) }
 end
 
-lemma nim_sum_first_wins_iff_neq (O₁ O₂ : ordinal) : (nim O₁ + nim O₂).first_wins ↔ O₁ ≠ O₂ :=
-by rw [iff_not_comm, impartial_not_first_wins (impartial_add (nim_impartial _) (nim_impartial _)),
-  nim_sum_first_loses_iff_eq]
+lemma sum_first_wins_iff_neq (O₁ O₂ : ordinal) : (nim O₁ + nim O₂).first_wins ↔ O₁ ≠ O₂ :=
+by rw [iff_not_comm, impartial.not_first_wins, sum_first_loses_iff_eq]
 
-lemma nim_equiv_iff_eq (O₁ O₂ : ordinal) : nim O₁ ≈ nim O₂ ↔ O₁ = O₂ :=
-⟨λ h, (nim_sum_first_loses_iff_eq _ _).1 $
-  by rw [first_loses_of_equiv_iff (add_congr h (equiv_refl _)), nim_sum_first_loses_iff_eq],
+lemma equiv_iff_eq (O₁ O₂ : ordinal) : nim O₁ ≈ nim O₂ ↔ O₁ = O₂ :=
+⟨λ h, (sum_first_loses_iff_eq _ _).1 $
+  by rw [first_loses_of_equiv_iff (add_congr h (equiv_refl _)), sum_first_loses_iff_eq],
  by { rintro rfl, refl }⟩
+
+end nim
 
 /-- This definition will be used in the proof of the Sprague-Grundy theorem. It takes a function
   from some type to ordinals and returns a nonempty set of ordinals with empty intersection with
@@ -175,63 +177,56 @@ end
 
 /-- The Grundy value of an impartial game, the ordinal which corresponds to the game of nim that the
  game is equivalent to -/
-noncomputable def Grundy_value : Π {G : pgame.{u}}, G.impartial → ordinal.{u}
-| G :=
-  λ hG, ordinal.omin (nonmoves (λ i, Grundy_value $ impartial_move_left_impartial hG i))
-    (nonmoves_nonempty (λ i, Grundy_value (impartial_move_left_impartial hG i)))
+noncomputable def grundy_value : Π (G : pgame.{u}) [G.impartial], ordinal.{u}
+| G := λ hG, by exactI
+    ordinal.omin (nonmoves (λ i, grundy_value (G.move_left i))) (nonmoves_nonempty _)
 using_well_founded { dec_tac := pgame_wf_tac }
 
-lemma Grundy_value_def {G : pgame} (hG : G.impartial) :
-Grundy_value hG = ordinal.omin (nonmoves (λ i, (Grundy_value $ impartial_move_left_impartial hG i)))
-  (nonmoves_nonempty (λ i, Grundy_value (impartial_move_left_impartial hG i))) :=
-begin
-  rw Grundy_value,
-  refl
-end
+lemma grundy_value_def (G : pgame) [G.impartial] :
+grundy_value G = ordinal.omin (nonmoves (λ i, (grundy_value (G.move_left i))))
+  (nonmoves_nonempty _) :=
+by { rw grundy_value, refl }
 
 /-- The Sprague-Grundy theorem which states that every impartial game is equivalent to a game of
  nim, namely the game of nim corresponding to the games Grundy value -/
-theorem Sprague_Grundy : ∀ {G : pgame.{u}} (hG : G.impartial), G ≈ nim (Grundy_value hG)
+theorem equiv_nim_grundy_value : ∀ (G : pgame.{u}) [G.impartial], by exactI G ≈ nim (grundy_value G)
 | G :=
 begin
   classical,
-  intro hG,
-  rw [equiv_iff_sum_first_loses hG (nim_impartial _),
-    ←no_good_left_moves_iff_first_loses (impartial_add hG (nim_impartial _))],
+  introI hG,
+  rw [impartial.equiv_iff_sum_first_loses, ←impartial.no_good_left_moves_iff_first_loses],
   intro i,
-  equiv_rw left_moves_add G (nim $ Grundy_value hG) at i,
+  equiv_rw left_moves_add G (nim (grundy_value G)) at i,
   cases i with i₁ i₂,
   { rw add_move_left_inl,
     apply first_wins_of_equiv
-     (add_congr (Sprague_Grundy $ impartial_move_left_impartial hG i₁).symm (equiv_refl _)),
-    rw nim_sum_first_wins_iff_neq,
+     (add_congr (equiv_nim_grundy_value (G.move_left i₁)).symm (equiv_refl _)),
+    rw nim.sum_first_wins_iff_neq,
     intro heq,
-    rw [eq_comm, Grundy_value_def hG] at heq,
+    rw [eq_comm, grundy_value_def G] at heq,
     have h := ordinal.omin_mem
-      (nonmoves (λ (i : G.left_moves), Grundy_value (impartial_move_left_impartial hG i)))
-      (nonmoves_nonempty _),
+      (nonmoves (λ (i : G.left_moves), grundy_value (G.move_left i))) (nonmoves_nonempty _),
     rw heq at h,
     have hcontra : ∃ (i' : G.left_moves),
-      (λ (i'' : G.left_moves), Grundy_value $ impartial_move_left_impartial hG i'') i' =
-        Grundy_value (impartial_move_left_impartial hG i₁) := ⟨i₁, rfl⟩,
+      (λ (i'' : G.left_moves), grundy_value (G.move_left i'')) i' = grundy_value (G.move_left i₁) :=
+      ⟨i₁, rfl⟩,
     contradiction },
-  { rw [add_move_left_inr, ←good_left_move_iff_first_wins
-      (impartial_add hG $ impartial_move_left_impartial (nim_impartial _) _)],
+  { rw [add_move_left_inr, ←impartial.good_left_move_iff_first_wins],
     revert i₂,
-    rw nim_def,
+    rw nim.nim_def,
     intro i₂,
 
-    have h' : ∃ i : G.left_moves, (Grundy_value $ impartial_move_left_impartial hG i) =
-      ordinal.typein (quotient.out $ Grundy_value hG).r i₂,
-    { have hlt : ordinal.typein (quotient.out $ Grundy_value hG).r i₂ <
-        ordinal.type (quotient.out $ Grundy_value hG).r := ordinal.typein_lt_type _ _,
+    have h' : ∃ i : G.left_moves, (grundy_value (G.move_left i)) =
+      ordinal.typein (quotient.out (grundy_value G)).r i₂,
+    { have hlt : ordinal.typein (quotient.out (grundy_value G)).r i₂ <
+        ordinal.type (quotient.out (grundy_value G)).r := ordinal.typein_lt_type _ _,
       rw ordinal.type_out at hlt,
       revert i₂ hlt,
-      rw Grundy_value_def,
+      rw grundy_value_def,
       intros i₂ hlt,
       have hnotin : ordinal.typein (quotient.out (ordinal.omin
-          (nonmoves (λ i, Grundy_value (impartial_move_left_impartial hG i))) _)).r i₂ ∉
-        (nonmoves (λ (i : G.left_moves), Grundy_value (impartial_move_left_impartial hG i))),
+          (nonmoves (λ i, grundy_value (G.move_left i))) _)).r i₂ ∉
+        (nonmoves (λ (i : G.left_moves), grundy_value (G.move_left i))),
       { intro hin,
         have hge := ordinal.omin_le hin,
         have hcontra := (le_not_le_of_lt hlt).2,
@@ -242,17 +237,17 @@ begin
     use (left_moves_add _ _).symm (sum.inl i),
     rw [add_move_left_inl, move_left_mk],
     apply first_loses_of_equiv
-      (add_congr (equiv_symm (Sprague_Grundy (impartial_move_left_impartial hG i))) (equiv_refl _)),
-    simpa only [hi] using impartial_add_self (nim_impartial _) }
+      (add_congr (equiv_symm (equiv_nim_grundy_value (G.move_left i))) (equiv_refl _)),
+    simpa only [hi] using impartial.add_self (nim (grundy_value (G.move_left i))) }
 end
 using_well_founded { dec_tac := pgame_wf_tac }
 
-lemma equiv_nim_iff_Grundy_value_eq {G : pgame.{u}} (hG : impartial G) (O : ordinal) :
-  G ≈ nim O ↔ Grundy_value hG = O :=
-⟨by { intro h, rw ←nim_equiv_iff_eq, exact equiv_trans (equiv_symm (Sprague_Grundy hG)) h },
- by { rintro rfl, exact Sprague_Grundy hG }⟩
+lemma equiv_nim_iff_grundy_value_eq {G : pgame.{u}} (hG : impartial G) (O : ordinal) :
+  G ≈ nim O ↔ grundy_value G = O :=
+⟨by { intro h, rw ←nim.equiv_iff_eq, exact equiv_trans (equiv_symm (equiv_nim_grundy_value G)) h },
+ by { rintro rfl, exact equiv_nim_grundy_value G }⟩
 
-lemma Grundy_value_nim (O : ordinal.{u}) : Grundy_value (nim_impartial O) = O :=
-by rw ←equiv_nim_iff_Grundy_value_eq
+lemma nim.grundy_value (O : ordinal.{u}) : grundy_value (nim O) = O :=
+by rw ←equiv_nim_iff_grundy_value_eq
 
-end nim
+end pgame

--- a/src/set_theory/game/winner.lean
+++ b/src/set_theory/game/winner.lean
@@ -31,20 +31,11 @@ def right_wins (G : pgame) : Prop := G ≤ 0 ∧ G < 0
 
 theorem zero_first_loses : first_loses 0 := by tidy
 theorem one_left_wins : left_wins 1 :=
-begin
-    split,
-    rw lt_def_le,
-    tidy
-end
-theorem star_first_wins : first_wins star := ⟨ zero_lt_star, star_lt_zero ⟩
+⟨by { rw lt_def_le, tidy }, by tidy⟩
+
+theorem star_first_wins : first_wins star := ⟨zero_lt_star, star_lt_zero⟩
 theorem omega_left_wins : left_wins omega :=
-begin
-  split,
-    rw lt_def_le,
-    left,
-    use 0,
-  tidy
-end
+⟨by { rw lt_def_le, exact or.inl ⟨ulift.up 0, by tidy⟩ }, by tidy⟩
 
 lemma winner_cases (G : pgame) : G.left_wins ∨ G.right_wins ∨ G.first_loses ∨ G.first_wins :=
 begin
@@ -53,31 +44,31 @@ begin
   by_cases hneg : G < 0;
   { try { rw not_lt at hpos },
     try { rw not_lt at hneg },
-    try { left, exact ⟨ hpos, hneg ⟩ },
-    try { right, left, exact ⟨ hpos, hneg ⟩ },
-    try { right, right, left, exact ⟨ hpos, hneg ⟩ },
-    try { right, right, right, exact ⟨ hpos, hneg ⟩ } }
+    try { left, exact ⟨hpos, hneg⟩ },
+    try { right, left, exact ⟨hpos, hneg⟩ },
+    try { right, right, left, exact ⟨hpos, hneg⟩ },
+    try { right, right, right, exact ⟨hpos, hneg⟩ } }
 end
 
 lemma first_loses_is_zero {G : pgame} : G.first_loses ↔ G ≈ 0 := by refl
 
 lemma first_loses_of_equiv {G H : pgame} (h : G ≈ H) : G.first_loses → H.first_loses :=
-λ hGp, ⟨ le_of_equiv_of_le h.symm hGp.1, le_of_le_of_equiv hGp.2 h ⟩
+λ hGp, ⟨le_of_equiv_of_le h.symm hGp.1, le_of_le_of_equiv hGp.2 h⟩
 lemma first_wins_of_equiv {G H : pgame} (h : G ≈ H) : G.first_wins → H.first_wins :=
-λ hGn, ⟨ lt_of_lt_of_equiv hGn.1 h, lt_of_equiv_of_lt h.symm hGn.2 ⟩
+λ hGn, ⟨lt_of_lt_of_equiv hGn.1 h, lt_of_equiv_of_lt h.symm hGn.2⟩
 lemma left_wins_of_equiv {G H : pgame} (h : G ≈ H) : G.left_wins → H.left_wins :=
-λ hGl, ⟨ lt_of_lt_of_equiv hGl.1 h, le_of_le_of_equiv hGl.2 h ⟩
+λ hGl, ⟨lt_of_lt_of_equiv hGl.1 h, le_of_le_of_equiv hGl.2 h⟩
 lemma right_wins_of_equiv {G H : pgame} (h : G ≈ H) : G.right_wins → H.right_wins :=
-λ hGr, ⟨ le_of_equiv_of_le h.symm hGr.1, lt_of_equiv_of_lt h.symm hGr.2 ⟩
+λ hGr, ⟨le_of_equiv_of_le h.symm hGr.1, lt_of_equiv_of_lt h.symm hGr.2⟩
 
 lemma first_loses_of_equiv_iff {G H : pgame} (h : G ≈ H) : G.first_loses ↔ H.first_loses :=
-⟨ first_loses_of_equiv h, first_loses_of_equiv h.symm ⟩
+⟨first_loses_of_equiv h, first_loses_of_equiv h.symm⟩
 lemma first_wins_of_equiv_iff {G H : pgame} (h : G ≈ H) : G.first_wins ↔ H.first_wins :=
-⟨ first_wins_of_equiv h, first_wins_of_equiv h.symm ⟩
+⟨first_wins_of_equiv h, first_wins_of_equiv h.symm⟩
 lemma left_wins_of_equiv_iff {G H : pgame} (h : G ≈ H) : G.left_wins ↔ H.left_wins :=
-⟨ left_wins_of_equiv h, left_wins_of_equiv h.symm ⟩
+⟨left_wins_of_equiv h, left_wins_of_equiv h.symm⟩
 lemma right_wins_of_equiv_iff {G H : pgame} (h : G ≈ H) : G.right_wins ↔ H.right_wins :=
-⟨ right_wins_of_equiv h, right_wins_of_equiv h.symm ⟩
+⟨right_wins_of_equiv h, right_wins_of_equiv h.symm⟩
 
 lemma not_first_wins_of_first_loses {G : pgame} : G.first_loses → ¬G.first_wins :=
 begin


### PR DESCRIPTION
* Misc. style cleanups and code golf
* Changed naming and namespace to adhere more closely to the naming convention
* Changed `impartial` to be a `class`. I am aware that @semorrison explicitly requested not to make `impartial` a class in the #3855, but after working with the definition a bit I concluded that making it a class is worth it, simply because writing `impartial_add (nim_impartial _) (nim_impartial _)` gets annoying quite quickly, but also because you tend to get goal states of the form `Grundy_value _ = Grundy_value _`. By making `impartial` a class and making the game argument explicit, these goal states look like `grundy_value G = grundy_value H`, which is much nicer to work with.

---
<!-- put comments you want to keep out of the PR commit here -->
