### PR TITLE
[Merged by Bors] - feat(computability/encoding): define encoding of basic data types

### DIFF
--- a/src/computability/encode_alphabet.lean
+++ b/src/computability/encode_alphabet.lean
@@ -1,0 +1,174 @@
+import data.fintype.basic
+import data.num.lemmas
+import tactic
+import tactic.derive_fintype
+
+namespace encoding
+structure encoding (α : Type) :=
+(Γ : Type)
+(encode : α → list Γ)
+(decode : list Γ → option α)
+(encodek : decode ∘ encode = option.some)
+
+structure fin_encoding (α : Type) extends encoding α :=
+(Γ_fin : fintype Γ)
+
+#check fin_encoding
+
+@[derive [inhabited,decidable_eq]]
+inductive Γ₀₁
+| bit0 | bit1
+
+--TODO: check if lean can do this automatically
+def Γ₀₁_fin : fintype Γ₀₁ :=
+{ elems := {Γ₀₁.bit0, Γ₀₁.bit1},
+  complete := λ x, begin cases x; finish, end }
+
+@[derive [decidable_eq]]
+inductive Γ'
+| blank | bit0 | bit1 | bra | ket | comma
+
+--TODO: check if lean can do this automatically
+def Γ'_fin : fintype Γ' :=
+{ elems := {Γ'.blank, Γ'.bit0, Γ'.bit1, Γ'.bra, Γ'.ket, Γ'.comma},
+  complete := λ x, begin cases x; finish, end }
+
+def inclusion_Γ₀₁_Γ' : Γ₀₁ → Γ'
+| Γ₀₁.bit0 := Γ'.bit0
+| Γ₀₁.bit1 := Γ'.bit1
+
+def section_Γ'_Γ₀₁ : Γ' → Γ₀₁
+| Γ'.bit0 := Γ₀₁.bit0
+| Γ'.bit1 := Γ₀₁.bit1
+| _ := arbitrary Γ₀₁
+
+lemma left_inverse_section_inclusion : function.left_inverse section_Γ'_Γ₀₁ inclusion_Γ₀₁_Γ' := begin intros x, cases x; trivial, end
+
+--TODO: prove directly from having a left inverse
+def inclusion_Γ₀₁_Γ'_injective : function.injective inclusion_Γ₀₁_Γ' :=
+begin tidy, cases a₁; cases a₂; simp; finish end
+
+instance inhabited_Γ' : inhabited Γ' := ⟨Γ'.blank⟩
+
+def encode_pos_num : pos_num → list Γ₀₁
+| pos_num.one := [Γ₀₁.bit1]
+| (pos_num.bit0 n) := Γ₀₁.bit0 :: encode_pos_num n
+| (pos_num.bit1 n) := Γ₀₁.bit1 :: encode_pos_num n
+
+def encode_num : num → list Γ₀₁
+| num.zero := []
+| (num.pos n) := encode_pos_num n
+
+def encode_nat (n : ℕ) : list Γ₀₁ := encode_num n
+
+def decode_pos_num : list Γ₀₁ → pos_num
+| [Γ₀₁.bit1] := pos_num.one
+| (Γ₀₁.bit0 :: l) := (pos_num.bit0 (decode_pos_num l))
+| (Γ₀₁.bit1 :: l) := (pos_num.bit1 (decode_pos_num l))
+| _ := pos_num.one
+
+def decode_num : list Γ₀₁ → num
+| [] := num.zero
+| l := decode_pos_num l
+
+def decode_nat : list Γ₀₁ → nat := λ l, decode_num l
+
+def encode_pos_num_nonempty (n : pos_num) : (encode_pos_num n) ≠ [] :=
+begin
+  cases n with m,
+  exact list.cons_ne_nil Γ₀₁.bit1 list.nil,
+  exact list.cons_ne_nil Γ₀₁.bit1 (encode_pos_num m),
+  exact list.cons_ne_nil Γ₀₁.bit0 (encode_pos_num n),
+end
+
+def encodek_pos_num : ∀ n, (decode_pos_num(encode_pos_num n) ) = n := begin
+  intros n,
+  induction n with m hm m hm,
+  trivial,
+  change decode_pos_num ((Γ₀₁.bit1) :: encode_pos_num m) = m.bit1,
+  have h := encode_pos_num_nonempty m,
+  calc decode_pos_num (Γ₀₁.bit1 :: encode_pos_num m)
+    = pos_num.bit1 (decode_pos_num (encode_pos_num m)) : begin cases (encode_pos_num m), exfalso, trivial,trivial, end
+    ... = m.bit1 : by rw hm,
+  calc decode_pos_num (Γ₀₁.bit0 :: encode_pos_num m)
+    = pos_num.bit0 (decode_pos_num (encode_pos_num m)) :  by trivial
+    ... = m.bit0 : by rw hm,
+end
+
+def encodek_num : ∀ n, (decode_num(encode_num n) ) = n := begin
+  intros n,
+  cases n,
+  trivial,
+  change decode_num (encode_pos_num n) = num.pos n,
+  have h : encode_pos_num n ≠ [] := encode_pos_num_nonempty n,
+  have h' : decode_num (encode_pos_num n) = decode_pos_num (encode_pos_num n) := begin
+    cases encode_pos_num n; trivial,
+  end,
+  rw h',
+  rw (encodek_pos_num n),
+  simp only [pos_num.cast_to_num],
+end
+
+def encodek_nat : ∀ n, (decode_nat(encode_nat n) ) = n := begin
+  intros n,
+  change decode_nat (encode_num n) = n,
+  have h :decode_num (encode_num n) = n :=
+  begin
+    change decode_num (encode_num n) = n,
+    exact encodek_num ↑n,
+  end,
+  unfold decode_nat,
+  --simp,
+  exact_mod_cast h,--TODO: fix
+end
+
+def encoding_nat_Γ₀₁ : encoding ℕ :=
+{ Γ := Γ₀₁,
+  encode := encode_nat,
+  decode := λ n, option.some (decode_nat n),
+  encodek := begin funext, simp, exact encodek_nat x end }
+
+def fin_encoding_nat_Γ₀₁ : fin_encoding ℕ :=
+{ Γ_fin := Γ₀₁_fin,
+  ..encoding_nat_Γ₀₁ }
+
+def encoding_nat_Γ' : encoding ℕ :=
+{ Γ := Γ',
+  encode := (list.map inclusion_Γ₀₁_Γ') ∘ encode_nat,
+  decode :=  option.some ∘ decode_nat ∘ (list.map section_Γ'_Γ₀₁),
+  encodek := begin --TODO: golf
+    funext,
+    simp,
+     have h : section_Γ'_Γ₀₁ ∘ inclusion_Γ₀₁_Γ' = id := begin funext, simp, exact left_inverse_section_inclusion x end,
+    simp [h],
+    exact encodek_nat x,
+  end }
+
+def fin_encoding_nat_Γ' : fin_encoding ℕ :=
+{ Γ_fin := Γ'_fin,
+..encoding_nat_Γ' }
+
+--TODO: unary encodings
+
+def encode_bool : bool → list Γ₀₁
+| ff := [Γ₀₁.bit0]
+| tt := [Γ₀₁.bit1]
+
+def decode_bool : list Γ₀₁ → bool
+| [Γ₀₁.bit0] := ff
+| [Γ₀₁.bit1] := tt
+| _ := arbitrary bool
+
+def encodek_bool : ∀ b, (decode_bool(encode_bool b) ) = b := λ b,
+begin
+  cases b; refl
+end
+
+def encoding_bool_Γ₀₁ : fin_encoding bool :=
+{ Γ := Γ₀₁,
+  encode := encode_bool,
+  decode := option.some ∘ decode_bool,
+  encodek := begin funext, simp [encodek_bool x], end,
+  Γ_fin := Γ₀₁_fin }
+
+end encoding

--- a/src/computability/encode_alphabet.lean
+++ b/src/computability/encode_alphabet.lean
@@ -122,7 +122,7 @@ def encoding_nat_Γ' : encoding ℕ :=
 
 def fin_encoding_nat_Γ' : fin_encoding ℕ := ⟨ encoding_nat_Γ', Γ'.fintype ⟩
 
-def unary_encode_nat : nat → list Γ₀₁ :=
+def unary_encode_nat : nat → list Γ₀₁
 | 0 := []
 | (n+1) := Γ₀₁.bit1 :: (unary_encode_nat n)
 

--- a/src/computability/encode_alphabet.lean
+++ b/src/computability/encode_alphabet.lean
@@ -122,7 +122,20 @@ def encoding_nat_Γ' : encoding ℕ :=
 
 def fin_encoding_nat_Γ' : fin_encoding ℕ := ⟨ encoding_nat_Γ', Γ'.fintype ⟩
 
---TODO: unary encodings
+def unary_encode_nat : nat → list Γ₀₁ :=
+| 0 := []
+| (n+1) := Γ₀₁.bit1 :: (unary_encode_nat n)
+
+def unary_decode_nat : list Γ₀₁ → nat := list.length
+
+def unary_encodek_nat : ∀ n, unary_decode_nat (unary_encode_nat n) = n :=
+λ n, nat.rec rfl (λ (m : ℕ) (hm : unary_decode_nat (unary_encode_nat m) = m), (congr_arg nat.succ hm.symm).symm) n
+
+def unary_encoding_nat : encoding ℕ :=
+{ Γ := Γ₀₁,
+  encode := unary_encode_nat,
+  decode := λ n, some (unary_decode_nat n),
+  encodek := λ n, congr_arg _ (unary_encodek_nat n)}
 
 def encode_bool : bool → list Γ₀₁
 | ff := [Γ₀₁.bit0]

--- a/src/computability/encode_alphabet.lean
+++ b/src/computability/encode_alphabet.lean
@@ -13,8 +13,6 @@ structure encoding (α : Type) :=
 structure fin_encoding (α : Type) extends encoding α :=
 (Γ_fin : fintype Γ)
 
-#check fin_encoding
-
 @[derive [inhabited,decidable_eq]]
 inductive Γ₀₁
 | bit0 | bit1
@@ -111,18 +109,8 @@ end
 
 def encodek_nat : ∀ n, (decode_nat(encode_nat n) ) = n := begin
   intros n,
-  change decode_nat (encode_num n) = n,
-  have h :decode_num (encode_num n) = n :=
-  begin
-    change decode_num (encode_num n) = n,
-    exact encodek_num ↑n,
-  end,
-  unfold decode_nat,
-  have k : ∀ m : nat, m = ((m : num) : nat) := λ m, begin
-    exact (num.to_of_nat m).symm,
-  end,
-  conv_rhs {rw k n},
-  exact congr_arg coe h,
+  conv_rhs {rw ← num.to_of_nat n},
+  exact congr_arg coe (encodek_num ↑n),
 end
 
 def encoding_nat_Γ₀₁ : encoding ℕ :=

--- a/src/computability/encode_alphabet.lean
+++ b/src/computability/encode_alphabet.lean
@@ -1,6 +1,25 @@
+/-
+Copyright (c) 2020 Pim Spelier, Daan van Gent. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Pim Spelier, Daan van Gent.
+-/
+
 import data.fintype.basic
 import data.num.lemmas
 import tactic
+
+/-!
+# Encodings
+
+This file contains the definition of a (finite) encoding, a map from a type to strings in an alphabet, used in defining computability by Turing machines. It also contains several examples
+
+## Examples
+
+- `fin_encoding_nat_Γ₀₁`   : a binary encoding of ℕ in a simple alphabet.
+- `fin_encoding_nat_Γ'`    : a binary encoding of ℕ in the alphabet used for TM's.
+- `unary_fin_encoding_nat` : a unary encoding of ℕ
+- `fin_encoding_bool_Γ₀₁`  : an encoding of bool.
+-/
 
 namespace encoding
 structure encoding (α : Type) :=
@@ -131,11 +150,12 @@ def unary_decode_nat : list Γ₀₁ → nat := list.length
 def unary_encodek_nat : ∀ n, unary_decode_nat (unary_encode_nat n) = n :=
 λ n, nat.rec rfl (λ (m : ℕ) (hm : unary_decode_nat (unary_encode_nat m) = m), (congr_arg nat.succ hm.symm).symm) n
 
-def unary_encoding_nat : encoding ℕ :=
+def unary_fin_encoding_nat : fin_encoding ℕ :=
 { Γ := Γ₀₁,
   encode := unary_encode_nat,
   decode := λ n, some (unary_decode_nat n),
-  encodek := λ n, congr_arg _ (unary_encodek_nat n)}
+  encodek := λ n, congr_arg _ (unary_encodek_nat n),
+  Γ_fin := Γ₀₁.fintype}
 
 def encode_bool : bool → list Γ₀₁
 | ff := [Γ₀₁.bit0]
@@ -148,7 +168,7 @@ def decode_bool : list Γ₀₁ → bool
 
 def encodek_bool : ∀ b, (decode_bool(encode_bool b)) = b := λ b, bool.cases_on b rfl rfl
 
-def encoding_bool_Γ₀₁ : fin_encoding bool :=
+def fin_encoding_bool_Γ₀₁ : fin_encoding bool :=
 { Γ := Γ₀₁,
   encode := encode_bool,
   decode := λ x, some(decode_bool x),

--- a/src/computability/encode_alphabet.lean
+++ b/src/computability/encode_alphabet.lean
@@ -118,8 +118,11 @@ def encodek_nat : ∀ n, (decode_nat(encode_nat n) ) = n := begin
     exact encodek_num ↑n,
   end,
   unfold decode_nat,
-  --simp,
-  exact_mod_cast h,--TODO: fix
+  have k : ∀ m : nat, m = ((m : num) : nat) := λ m, begin
+    exact (num.to_of_nat m).symm,
+  end,
+  conv_rhs {rw k n},
+  exact congr_arg coe h,
 end
 
 def encoding_nat_Γ₀₁ : encoding ℕ :=

--- a/src/computability/encode_alphabet.lean
+++ b/src/computability/encode_alphabet.lean
@@ -21,30 +21,35 @@ This file contains the definition of a (finite) encoding, a map from a type to s
 - `fin_encoding_bool_Γ₀₁`  : an encoding of bool.
 -/
 
-namespace encoding
+/-- An encoding of a type in a certain alphabet, together with a decoding. -/
 structure encoding (α : Type) :=
 (Γ : Type)
 (encode : α → list Γ)
 (decode : list Γ → option α)
-(encodek : ∀ x, decode(encode x) = some x )
+(encodek : ∀ x, decode(encode x) = some x)
 
+/-- An encoding plus a guarantue of finiteness of the alphabet. -/
 structure fin_encoding (α : Type) extends encoding α :=
 (Γ_fin : fintype Γ)
 
+/-- An alphabet consisting of bit0 and bit1 -/
 @[derive [inhabited,decidable_eq,fintype]]
 inductive Γ₀₁
 | bit0 | bit1
 
+/-- A standard Turing machine alphabet, consisting of blank,bit0,bit1,bra,ket,comma. -/
 @[derive [decidable_eq,fintype]]
 inductive Γ'
 | blank | bit0 | bit1 | bra | ket | comma
 
 instance inhabited_Γ' : inhabited Γ' := ⟨Γ'.blank⟩
 
+/-- The natural inclusion of Γ₀₁ in Γ'. -/
 def inclusion_Γ₀₁_Γ' : Γ₀₁ → Γ'
 | Γ₀₁.bit0 := Γ'.bit0
 | Γ₀₁.bit1 := Γ'.bit1
 
+/-- An arbitrary section of the natural inclusion of Γ₀₁ in Γ'. -/
 def section_Γ'_Γ₀₁ : Γ' → Γ₀₁
 | Γ'.bit0 := Γ₀₁.bit0
 | Γ'.bit1 := Γ₀₁.bit1
@@ -56,36 +61,38 @@ lemma left_inverse_section_inclusion : function.left_inverse section_Γ'_Γ₀�
 lemma inclusion_Γ₀₁_Γ'_injective : function.injective inclusion_Γ₀₁_Γ' :=
 function.has_left_inverse.injective (Exists.intro section_Γ'_Γ₀₁ left_inverse_section_inclusion)
 
+/-- An encoding function of the positive binary numbers in Γ₀₁. -/
 def encode_pos_num : pos_num → list Γ₀₁
 | pos_num.one := [Γ₀₁.bit1]
 | (pos_num.bit0 n) := Γ₀₁.bit0 :: encode_pos_num n
 | (pos_num.bit1 n) := Γ₀₁.bit1 :: encode_pos_num n
 
+/-- An encoding function of the binary numbers in Γ₀₁. -/
 def encode_num : num → list Γ₀₁
 | num.zero := []
 | (num.pos n) := encode_pos_num n
 
+/-- An encoding function of ℕ in Γ₀₁. -/
 def encode_nat (n : ℕ) : list Γ₀₁ := encode_num n
 
+/-- A decoding function from `list Γ₀₁` to the positive binary numbers. -/
 def decode_pos_num : list Γ₀₁ → pos_num
--- | [Γ₀₁.bit1] := pos_num.one
--- | (Γ₀₁.bit0 :: l) := (pos_num.bit0 (decode_pos_num l))
--- | (Γ₀₁.bit1 :: l) := (pos_num.bit1 (decode_pos_num l))
--- | _ := pos_num.one
 | (Γ₀₁.bit0 :: l) := (pos_num.bit0 (decode_pos_num l))
 | (Γ₀₁.bit1 :: l) := ite (l = []) pos_num.one (pos_num.bit1 (decode_pos_num l))
 | _ := pos_num.one
 
+/-- A decoding function from `list Γ₀₁` to the binary numbers. -/
 def decode_num : list Γ₀₁ → num
 | [] := num.zero
 | l := decode_pos_num l
 
+/-- A decoding function from `list Γ₀₁` to ℕ. -/
 def decode_nat : list Γ₀₁ → nat := λ l, decode_num l
 
-def encode_pos_num_nonempty (n : pos_num) : (encode_pos_num n) ≠ [] :=
+lemma encode_pos_num_nonempty (n : pos_num) : (encode_pos_num n) ≠ [] :=
 pos_num.cases_on n (list.cons_ne_nil _ _) (λ m, list.cons_ne_nil _ _) (λ m, list.cons_ne_nil _ _)
 
-def encodek_pos_num : ∀ n, (decode_pos_num(encode_pos_num n) ) = n := begin
+lemma encodek_pos_num : ∀ n, (decode_pos_num(encode_pos_num n) ) = n := begin
   intros n,
   induction n with m hm m hm; unfold encode_pos_num decode_pos_num,
   { refl },
@@ -94,7 +101,7 @@ def encodek_pos_num : ∀ n, (decode_pos_num(encode_pos_num n) ) = n := begin
   { exact congr_arg pos_num.bit0 hm }
 end
 
-def encodek_num : ∀ n, (decode_num(encode_num n) ) = n := begin
+lemma encodek_num : ∀ n, (decode_num(encode_num n) ) = n := begin
   intros n,
   cases n, {
     trivial,
@@ -109,20 +116,23 @@ def encodek_num : ∀ n, (decode_num(encode_num n) ) = n := begin
   simp only [pos_num.cast_to_num],
 end
 
-def encodek_nat : ∀ n, (decode_nat(encode_nat n) ) = n := begin
+lemma encodek_nat : ∀ n, (decode_nat(encode_nat n) ) = n := begin
   intro n,
   conv_rhs {rw ← num.to_of_nat n},
   exact congr_arg coe (encodek_num ↑n),
 end
 
+/-- A binary encoding of ℕ in Γ₀₁. -/
 def encoding_nat_Γ₀₁ : encoding ℕ :=
 { Γ := Γ₀₁,
   encode := encode_nat,
   decode := λ n, some (decode_nat n),
   encodek := λ n, congr_arg _ (encodek_nat n) }
 
+/-- A binary fin_encoding of ℕ in Γ₀₁. -/
 def fin_encoding_nat_Γ₀₁ : fin_encoding ℕ := ⟨ encoding_nat_Γ₀₁, Γ₀₁.fintype ⟩
 
+/-- A binary encoding of ℕ in Γ'. -/
 def encoding_nat_Γ' : encoding ℕ :=
 { Γ := Γ',
   encode := λ x, list.map inclusion_Γ₀₁_Γ' (encode_nat x),
@@ -133,17 +143,21 @@ def encoding_nat_Γ' : encoding ℕ :=
     exact encodek_nat x,
   end }
 
+/-- A binary fin_encoding of ℕ in Γ'. -/
 def fin_encoding_nat_Γ' : fin_encoding ℕ := ⟨ encoding_nat_Γ', Γ'.fintype ⟩
 
+/-- A unary encoding function of ℕ in Γ₀₁. -/
 def unary_encode_nat : nat → list Γ₀₁
 | 0 := []
 | (n+1) := Γ₀₁.bit1 :: (unary_encode_nat n)
 
+/-- A unary decoding function from `list Γ₀₁` to ℕ. -/
 def unary_decode_nat : list Γ₀₁ → nat := list.length
 
-def unary_encodek_nat : ∀ n, unary_decode_nat (unary_encode_nat n) = n :=
+lemma unary_encodek_nat : ∀ n, unary_decode_nat (unary_encode_nat n) = n :=
 λ n, nat.rec rfl (λ (m : ℕ) (hm : unary_decode_nat (unary_encode_nat m) = m), (congr_arg nat.succ hm.symm).symm) n
 
+/-- A unary fin_encoding of ℕ. -/
 def unary_fin_encoding_nat : fin_encoding ℕ :=
 { Γ := Γ₀₁,
   encode := unary_encode_nat,
@@ -151,17 +165,20 @@ def unary_fin_encoding_nat : fin_encoding ℕ :=
   encodek := λ n, congr_arg _ (unary_encodek_nat n),
   Γ_fin := Γ₀₁.fintype}
 
+/-- An encoding function of bool in Γ₀₁. -/
 def encode_bool : bool → list Γ₀₁
 | ff := [Γ₀₁.bit0]
 | tt := [Γ₀₁.bit1]
 
+/-- A decoding function from `list Γ₀₁` to bool. -/
 def decode_bool : list Γ₀₁ → bool
 | [Γ₀₁.bit0] := ff
 | [Γ₀₁.bit1] := tt
 | _ := arbitrary bool
 
-def encodek_bool : ∀ b, (decode_bool(encode_bool b)) = b := λ b, bool.cases_on b rfl rfl
+lemma encodek_bool : ∀ b, (decode_bool(encode_bool b)) = b := λ b, bool.cases_on b rfl rfl
 
+/-- A fin_encoding of bool in Γ₀₁. -/
 def fin_encoding_bool_Γ₀₁ : fin_encoding bool :=
 { Γ := Γ₀₁,
   encode := encode_bool,
@@ -169,4 +186,6 @@ def fin_encoding_bool_Γ₀₁ : fin_encoding bool :=
   encodek := λ x, congr_arg _ (encodek_bool x),
   Γ_fin := Γ₀₁.fintype }
 
-end encoding
+instance inhabited_fin_encoding : inhabited (fin_encoding bool) := ⟨fin_encoding_bool_Γ₀₁⟩
+
+instance inhabited_encoding : inhabited (encoding bool) := ⟨fin_encoding_bool_Γ₀₁.to_encoding⟩

--- a/src/computability/encode_alphabet.lean
+++ b/src/computability/encode_alphabet.lean
@@ -31,9 +31,11 @@ def section_Γ'_Γ₀₁ : Γ' → Γ₀₁
 | Γ'.bit1 := Γ₀₁.bit1
 | _ := arbitrary Γ₀₁
 
-lemma left_inverse_section_inclusion : function.left_inverse section_Γ'_Γ₀₁ inclusion_Γ₀₁_Γ' := begin intros x, cases x; trivial, end
+lemma left_inverse_section_inclusion : function.left_inverse section_Γ'_Γ₀₁ inclusion_Γ₀₁_Γ' :=
+λ x, Γ₀₁.cases_on x rfl rfl
 
-lemma inclusion_Γ₀₁_Γ'_injective : function.injective inclusion_Γ₀₁_Γ' := by tidy
+lemma inclusion_Γ₀₁_Γ'_injective : function.injective inclusion_Γ₀₁_Γ' :=
+function.has_left_inverse.injective (Exists.intro section_Γ'_Γ₀₁ left_inverse_section_inclusion)
 
 def encode_pos_num : pos_num → list Γ₀₁
 | pos_num.one := [Γ₀₁.bit1]
@@ -103,20 +105,18 @@ end
 def encoding_nat_Γ₀₁ : encoding ℕ :=
 { Γ := Γ₀₁,
   encode := encode_nat,
-  decode := λ n, option.some (decode_nat n),
-  encodek := begin funext, simp, exact encodek_nat x end }
+  decode := λ n, some (decode_nat n),
+  encodek := λ n, congr_arg _ (encodek_nat n) }
 
 def fin_encoding_nat_Γ₀₁ : fin_encoding ℕ := ⟨ encoding_nat_Γ₀₁, Γ₀₁.fintype ⟩
 
 def encoding_nat_Γ' : encoding ℕ :=
 { Γ := Γ',
-  encode := (list.map inclusion_Γ₀₁_Γ') ∘ encode_nat,
-  decode :=  option.some ∘ decode_nat ∘ (list.map section_Γ'_Γ₀₁),
-  encodek := begin --TODO: golf
-    funext,
-    simp,
-     have h : section_Γ'_Γ₀₁ ∘ inclusion_Γ₀₁_Γ' = id := begin funext, simp, exact left_inverse_section_inclusion x end,
-    simp [h],
+  encode := λ x, list.map inclusion_Γ₀₁_Γ' (encode_nat x),
+  decode := λ x, option.some (decode_nat (list.map section_Γ'_Γ₀₁ x)),
+  encodek := λ x, congr_arg _ begin
+    rw list.map_map,
+    rw list.map_id' left_inverse_section_inclusion,
     exact encodek_nat x,
   end }
 
@@ -139,7 +139,7 @@ def encoding_bool_Γ₀₁ : fin_encoding bool :=
 { Γ := Γ₀₁,
   encode := encode_bool,
   decode := λ x, some(decode_bool x),
-  encodek := λ x, congr_arg _ ( encodek_bool x ),
+  encodek := λ x, congr_arg _ (encodek_bool x),
   Γ_fin := Γ₀₁.fintype }
 
 end encoding

--- a/src/computability/encode_alphabet.lean
+++ b/src/computability/encode_alphabet.lean
@@ -11,7 +11,7 @@ import tactic
 /-!
 # Encodings
 
-This file contains the definition of a (finite) encoding, a map from a type to strings in an alphabet, used in defining computability by Turing machines. It also contains several examples
+This file contains the definition of a (finite) encoding, a map from a type to strings in an alphabet, used in defining computability by Turing machines. It also contains several examples:
 
 ## Examples
 
@@ -68,14 +68,13 @@ def encode_num : num → list Γ₀₁
 def encode_nat (n : ℕ) : list Γ₀₁ := encode_num n
 
 def decode_pos_num : list Γ₀₁ → pos_num
-| [Γ₀₁.bit1] := pos_num.one
+-- | [Γ₀₁.bit1] := pos_num.one
+-- | (Γ₀₁.bit0 :: l) := (pos_num.bit0 (decode_pos_num l))
+-- | (Γ₀₁.bit1 :: l) := (pos_num.bit1 (decode_pos_num l))
+-- | _ := pos_num.one
 | (Γ₀₁.bit0 :: l) := (pos_num.bit0 (decode_pos_num l))
-| (Γ₀₁.bit1 :: l) := (pos_num.bit1 (decode_pos_num l))
+| (Γ₀₁.bit1 :: l) := ite (l = []) pos_num.one (pos_num.bit1 (decode_pos_num l))
 | _ := pos_num.one
-
---| (Γ₀₁.bit0 :: l) := (pos_num.bit0 (decode_pos_num l))
---| (Γ₀₁.bit1 :: l) := ite (l = []) pos_num.one (pos_num.bit1 (decode_pos_num l))
---| _ := pos_num.one
 
 def decode_num : list Γ₀₁ → num
 | [] := num.zero
@@ -88,15 +87,11 @@ pos_num.cases_on n (list.cons_ne_nil _ _) (λ m, list.cons_ne_nil _ _) (λ m, li
 
 def encodek_pos_num : ∀ n, (decode_pos_num(encode_pos_num n) ) = n := begin
   intros n,
-  induction n with m hm m hm; unfold encode_pos_num decode_pos_num, {
-    have h := encode_pos_num_nonempty m,
-    cases (encode_pos_num m) with p ph, {
-      trivial,
-    },
-    unfold decode_pos_num,
-    rw hm,
-  },
-  rw hm,
+  induction n with m hm m hm; unfold encode_pos_num decode_pos_num,
+  { refl },
+  { rw hm,
+    exact if_neg (encode_pos_num_nonempty m) },
+  { exact congr_arg pos_num.bit0 hm }
 end
 
 def encodek_num : ∀ n, (decode_num(encode_num n) ) = n := begin

--- a/src/computability/encode_alphabet.lean
+++ b/src/computability/encode_alphabet.lean
@@ -54,6 +54,10 @@ def decode_pos_num : list Γ₀₁ → pos_num
 | (Γ₀₁.bit1 :: l) := (pos_num.bit1 (decode_pos_num l))
 | _ := pos_num.one
 
+--| (Γ₀₁.bit0 :: l) := (pos_num.bit0 (decode_pos_num l))
+--| (Γ₀₁.bit1 :: l) := ite (l = []) pos_num.one (pos_num.bit1 (decode_pos_num l))
+--| _ := pos_num.one
+
 def decode_num : list Γ₀₁ → num
 | [] := num.zero
 | l := decode_pos_num l
@@ -61,32 +65,27 @@ def decode_num : list Γ₀₁ → num
 def decode_nat : list Γ₀₁ → nat := λ l, decode_num l
 
 def encode_pos_num_nonempty (n : pos_num) : (encode_pos_num n) ≠ [] :=
-begin
-  cases n with m,
-  exact list.cons_ne_nil Γ₀₁.bit1 list.nil,
-  exact list.cons_ne_nil Γ₀₁.bit1 (encode_pos_num m),
-  exact list.cons_ne_nil Γ₀₁.bit0 (encode_pos_num n),
-end
+pos_num.cases_on n (list.cons_ne_nil _ _) (λ m, list.cons_ne_nil _ _) (λ m, list.cons_ne_nil _ _)
 
 def encodek_pos_num : ∀ n, (decode_pos_num(encode_pos_num n) ) = n := begin
   intros n,
-  induction n with m hm m hm,
-  trivial,
-  change decode_pos_num ((Γ₀₁.bit1) :: encode_pos_num m) = m.bit1,
-  have h := encode_pos_num_nonempty m,
-  calc decode_pos_num (Γ₀₁.bit1 :: encode_pos_num m)
-    = pos_num.bit1 (decode_pos_num (encode_pos_num m)) : begin cases (encode_pos_num m), exfalso, trivial,trivial, end
-    ... = m.bit1 : by rw hm,
-  calc decode_pos_num (Γ₀₁.bit0 :: encode_pos_num m)
-    = pos_num.bit0 (decode_pos_num (encode_pos_num m)) :  by trivial
-    ... = m.bit0 : by rw hm,
+  induction n with m hm m hm; unfold encode_pos_num decode_pos_num, {
+    have h := encode_pos_num_nonempty m,
+    cases (encode_pos_num m) with p ph, {
+      trivial,
+    },
+    unfold decode_pos_num,
+    rw hm,
+  },
+  rw hm,
 end
 
 def encodek_num : ∀ n, (decode_num(encode_num n) ) = n := begin
   intros n,
-  cases n,
-  trivial,
-  change decode_num (encode_pos_num n) = num.pos n,
+  cases n, {
+    trivial,
+  },
+  unfold encode_num,
   have h : encode_pos_num n ≠ [] := encode_pos_num_nonempty n,
   have h' : decode_num (encode_pos_num n) = decode_pos_num (encode_pos_num n) := begin
     cases encode_pos_num n; trivial,
@@ -97,7 +96,7 @@ def encodek_num : ∀ n, (decode_num(encode_num n) ) = n := begin
 end
 
 def encodek_nat : ∀ n, (decode_nat(encode_nat n) ) = n := begin
-  intros n,
+  intro n,
   conv_rhs {rw ← num.to_of_nat n},
   exact congr_arg coe (encodek_num ↑n),
 end

--- a/src/computability/encoding.lean
+++ b/src/computability/encoding.lean
@@ -68,17 +68,11 @@ def encode_num : num → list Γ₀₁
 def encode_nat (n : ℕ) : list Γ₀₁ := encode_num n
 
 def decode_pos_num : list Γ₀₁ → pos_num
--- | [Γ₀₁.bit1] := pos_num.one
--- | (Γ₀₁.bit0 :: l) := (pos_num.bit0 (decode_pos_num l))
--- | (Γ₀₁.bit1 :: l) := (pos_num.bit1 (decode_pos_num l))
--- | _ := pos_num.one
 | (Γ₀₁.bit0 :: l) := (pos_num.bit0 (decode_pos_num l))
 | (Γ₀₁.bit1 :: l) := ite (l = []) pos_num.one (pos_num.bit1 (decode_pos_num l))
 | _ := pos_num.one
 
-def decode_num : list Γ₀₁ → num
-| [] := num.zero
-| l := decode_pos_num l
+def decode_num : list Γ₀₁ → num := λ l, ite (l = []) num.zero $ decode_pos_num l
 
 def decode_nat : list Γ₀₁ → nat := λ l, decode_num l
 
@@ -96,17 +90,11 @@ end
 
 def encodek_num : ∀ n, (decode_num(encode_num n) ) = n := begin
   intros n,
-  cases n, {
-    trivial,
-  },
-  unfold encode_num,
-  have h : encode_pos_num n ≠ [] := encode_pos_num_nonempty n,
-  have h' : decode_num (encode_pos_num n) = decode_pos_num (encode_pos_num n) := begin
-    cases encode_pos_num n; trivial,
-  end,
-  rw h',
-  rw (encodek_pos_num n),
-  simp only [pos_num.cast_to_num],
+  cases n; unfold encode_num decode_num,
+  { refl },
+  rw encodek_pos_num n,
+  rw pos_num.cast_to_num,
+  exact if_neg (encode_pos_num_nonempty n),
 end
 
 def encodek_nat : ∀ n, (decode_nat(encode_nat n) ) = n := begin

--- a/src/computability/encoding.lean
+++ b/src/computability/encoding.lean
@@ -30,7 +30,7 @@ structure encoding (α : Type) :=
 (Γ : Type)
 (encode : α → list Γ)
 (decode : list Γ → option α)
-(encodek : ∀ x, decode (encode x) = some x)
+(decode_encode : ∀ x, decode (encode x) = some x)
 
 /-- An encoding plus a guarantee of finiteness of the alphabet. -/
 structure fin_encoding (α : Type) extends encoding α :=
@@ -94,7 +94,7 @@ def decode_nat : list Γ₀₁ → nat := λ l, decode_num l
 lemma encode_pos_num_nonempty (n : pos_num) : (encode_pos_num n) ≠ [] :=
 pos_num.cases_on n (list.cons_ne_nil _ _) (λ m, list.cons_ne_nil _ _) (λ m, list.cons_ne_nil _ _)
 
-lemma encodek_pos_num : ∀ n, (decode_pos_num(encode_pos_num n) ) = n :=
+lemma decode_encode_pos_num : ∀ n, decode_pos_num(encode_pos_num n) = n :=
 begin
   intros n,
   induction n with m hm m hm; unfold encode_pos_num decode_pos_num,
@@ -104,21 +104,21 @@ begin
   { exact congr_arg pos_num.bit0 hm }
 end
 
-lemma encodek_num : ∀ n, (decode_num(encode_num n) ) = n :=
+lemma decode_encode_num : ∀ n, decode_num(encode_num n) = n :=
 begin
   intros n,
   cases n; unfold encode_num decode_num,
   { refl },
-  rw encodek_pos_num n,
+  rw decode_encode_pos_num n,
   rw pos_num.cast_to_num,
   exact if_neg (encode_pos_num_nonempty n),
 end
 
-lemma encodek_nat : ∀ n, (decode_nat(encode_nat n) ) = n :=
+lemma decode_encode_nat : ∀ n, decode_nat(encode_nat n) = n :=
 begin
   intro n,
   conv_rhs {rw ← num.to_of_nat n},
-  exact congr_arg coe (encodek_num ↑n),
+  exact congr_arg coe (decode_encode_num ↑n),
 end
 
 /-- A binary encoding of ℕ in Γ₀₁. -/
@@ -126,7 +126,7 @@ def encoding_nat_Γ₀₁ : encoding ℕ :=
 { Γ := Γ₀₁,
   encode := encode_nat,
   decode := λ n, some (decode_nat n),
-  encodek := λ n, congr_arg _ (encodek_nat n) }
+  decode_encode := λ n, congr_arg _ (decode_encode_nat n) }
 
 /-- A binary fin_encoding of ℕ in Γ₀₁. -/
 def fin_encoding_nat_Γ₀₁ : fin_encoding ℕ := ⟨encoding_nat_Γ₀₁, Γ₀₁.fintype⟩
@@ -135,9 +135,9 @@ def fin_encoding_nat_Γ₀₁ : fin_encoding ℕ := ⟨encoding_nat_Γ₀₁, Γ
 def encoding_nat_Γ' : encoding ℕ :=
 { Γ := Γ',
   encode := λ x, list.map inclusion_Γ₀₁_Γ' (encode_nat x),
-  decode := λ x, option.some (decode_nat (list.map section_Γ'_Γ₀₁ x)),
-  encodek := λ x, congr_arg _ $
-    by rw [list.map_map, list.map_id' left_inverse_section_inclusion, encodek_nat] }
+  decode := λ x, some (decode_nat (list.map section_Γ'_Γ₀₁ x)),
+  decode_encode := λ x, congr_arg _ $
+    by rw [list.map_map, list.map_id' left_inverse_section_inclusion, decode_encode_nat] }
 
 /-- A binary fin_encoding of ℕ in Γ'. -/
 def fin_encoding_nat_Γ' : fin_encoding ℕ := ⟨encoding_nat_Γ', Γ'.fintype⟩
@@ -150,15 +150,15 @@ def unary_encode_nat : nat → list Γ₀₁
 /-- A unary decoding function from `list Γ₀₁` to ℕ. -/
 def unary_decode_nat : list Γ₀₁ → nat := list.length
 
-lemma unary_encodek_nat : ∀ n, unary_decode_nat (unary_encode_nat n) = n :=
-λ n, nat.rec rfl (λ (m : ℕ) (hm : unary_decode_nat (unary_encode_nat m) = m), (congr_arg nat.succ hm.symm).symm) n
+lemma unary_decode_encode_nat : ∀ n, unary_decode_nat (unary_encode_nat n) = n :=
+λ n, nat.rec rfl (λ (m : ℕ) hm, (congr_arg nat.succ hm.symm).symm) n
 
 /-- A unary fin_encoding of ℕ. -/
 def unary_fin_encoding_nat : fin_encoding ℕ :=
 { Γ := Γ₀₁,
   encode := unary_encode_nat,
   decode := λ n, some (unary_decode_nat n),
-  encodek := λ n, congr_arg _ (unary_encodek_nat n),
+  decode_encode := λ n, congr_arg _ (unary_decode_encode_nat n),
   Γ_fin := Γ₀₁.fintype}
 
 /-- An encoding function of bool in Γ₀₁. -/
@@ -172,14 +172,14 @@ def decode_bool : list Γ₀₁ → bool
 | [Γ₀₁.bit1] := tt
 | _ := arbitrary bool
 
-lemma encodek_bool : ∀ b, (decode_bool(encode_bool b)) = b := λ b, bool.cases_on b rfl rfl
+lemma decode_encode_bool : ∀ b, decode_bool(encode_bool b) = b := λ b, bool.cases_on b rfl rfl
 
 /-- A fin_encoding of bool in Γ₀₁. -/
 def fin_encoding_bool_Γ₀₁ : fin_encoding bool :=
 { Γ := Γ₀₁,
   encode := encode_bool,
-  decode := λ x, some(decode_bool x),
-  encodek := λ x, congr_arg _ (encodek_bool x),
+  decode := λ x, some (decode_bool x),
+  decode_encode := λ x, congr_arg _ (decode_encode_bool x),
   Γ_fin := Γ₀₁.fintype }
 
 instance inhabited_fin_encoding : inhabited (fin_encoding bool) := ⟨fin_encoding_bool_Γ₀₁⟩

--- a/src/computability/encoding.lean
+++ b/src/computability/encoding.lean
@@ -11,7 +11,9 @@ import tactic
 /-!
 # Encodings
 
-This file contains the definition of a (finite) encoding, a map from a type to strings in an alphabet, used in defining computability by Turing machines. It also contains several examples:
+This file contains the definition of a (finite) encoding, a map from a type to
+strings in an alphabet, used in defining computability by Turing machines.
+It also contains several examples:
 
 ## Examples
 
@@ -26,7 +28,7 @@ structure encoding (α : Type) :=
 (Γ : Type)
 (encode : α → list Γ)
 (decode : list Γ → option α)
-(encodek : ∀ x, decode(encode x) = some x)
+(encodek : ∀ x, decode (encode x) = some x)
 
 /-- An encoding plus a guarantue of finiteness of the alphabet. -/
 structure fin_encoding (α : Type) extends encoding α :=
@@ -90,7 +92,8 @@ def decode_nat : list Γ₀₁ → nat := λ l, decode_num l
 lemma encode_pos_num_nonempty (n : pos_num) : (encode_pos_num n) ≠ [] :=
 pos_num.cases_on n (list.cons_ne_nil _ _) (λ m, list.cons_ne_nil _ _) (λ m, list.cons_ne_nil _ _)
 
-lemma encodek_pos_num : ∀ n, (decode_pos_num(encode_pos_num n) ) = n := begin
+lemma encodek_pos_num : ∀ n, (decode_pos_num(encode_pos_num n) ) = n :=
+begin
   intros n,
   induction n with m hm m hm; unfold encode_pos_num decode_pos_num,
   { refl },
@@ -99,7 +102,8 @@ lemma encodek_pos_num : ∀ n, (decode_pos_num(encode_pos_num n) ) = n := begin
   { exact congr_arg pos_num.bit0 hm }
 end
 
-lemma encodek_num : ∀ n, (decode_num(encode_num n) ) = n := begin
+lemma encodek_num : ∀ n, (decode_num(encode_num n) ) = n :=
+begin
   intros n,
   cases n; unfold encode_num decode_num,
   { refl },
@@ -108,7 +112,8 @@ lemma encodek_num : ∀ n, (decode_num(encode_num n) ) = n := begin
   exact if_neg (encode_pos_num_nonempty n),
 end
 
-lemma encodek_nat : ∀ n, (decode_nat(encode_nat n) ) = n := begin
+lemma encodek_nat : ∀ n, (decode_nat(encode_nat n) ) = n :=
+begin
   intro n,
   conv_rhs {rw ← num.to_of_nat n},
   exact congr_arg coe (encodek_num ↑n),
@@ -122,21 +127,18 @@ def encoding_nat_Γ₀₁ : encoding ℕ :=
   encodek := λ n, congr_arg _ (encodek_nat n) }
 
 /-- A binary fin_encoding of ℕ in Γ₀₁. -/
-def fin_encoding_nat_Γ₀₁ : fin_encoding ℕ := ⟨ encoding_nat_Γ₀₁, Γ₀₁.fintype ⟩
+def fin_encoding_nat_Γ₀₁ : fin_encoding ℕ := ⟨encoding_nat_Γ₀₁, Γ₀₁.fintype⟩
 
 /-- A binary encoding of ℕ in Γ'. -/
 def encoding_nat_Γ' : encoding ℕ :=
 { Γ := Γ',
   encode := λ x, list.map inclusion_Γ₀₁_Γ' (encode_nat x),
   decode := λ x, option.some (decode_nat (list.map section_Γ'_Γ₀₁ x)),
-  encodek := λ x, congr_arg _ begin
-    rw list.map_map,
-    rw list.map_id' left_inverse_section_inclusion,
-    exact encodek_nat x,
-  end }
+  encodek := λ x, congr_arg _ $
+    by rw [list.map_map, list.map_id' left_inverse_section_inclusion, encodek_nat] }
 
 /-- A binary fin_encoding of ℕ in Γ'. -/
-def fin_encoding_nat_Γ' : fin_encoding ℕ := ⟨ encoding_nat_Γ', Γ'.fintype ⟩
+def fin_encoding_nat_Γ' : fin_encoding ℕ := ⟨encoding_nat_Γ', Γ'.fintype⟩
 
 /-- A unary encoding function of ℕ in Γ₀₁. -/
 def unary_encode_nat : nat → list Γ₀₁
@@ -181,5 +183,3 @@ def fin_encoding_bool_Γ₀₁ : fin_encoding bool :=
 instance inhabited_fin_encoding : inhabited (fin_encoding bool) := ⟨fin_encoding_bool_Γ₀₁⟩
 
 instance inhabited_encoding : inhabited (encoding bool) := ⟨fin_encoding_bool_Γ₀₁.to_encoding⟩
-
-#lint

--- a/src/computability/encoding.lean
+++ b/src/computability/encoding.lean
@@ -32,7 +32,7 @@ structure encoding (α : Type) :=
 (decode : list Γ → option α)
 (encodek : ∀ x, decode (encode x) = some x)
 
-/-- An encoding plus a guarantue of finiteness of the alphabet. -/
+/-- An encoding plus a guarantee of finiteness of the alphabet. -/
 structure fin_encoding (α : Type) extends encoding α :=
 (Γ_fin : fintype Γ)
 

--- a/src/computability/encoding.lean
+++ b/src/computability/encoding.lean
@@ -6,7 +6,7 @@ Authors: Pim Spelier, Daan van Gent.
 
 import data.fintype.basic
 import data.num.lemmas
-import tactic
+import tactic.derive_fintype
 
 /-!
 # Encodings
@@ -17,10 +17,10 @@ It also contains several examples:
 
 ## Examples
 
-- `fin_encoding_nat_Γ₀₁`   : a binary encoding of ℕ in a simple alphabet.
+- `fin_encoding_nat_bool`   : a binary encoding of ℕ in a simple alphabet.
 - `fin_encoding_nat_Γ'`    : a binary encoding of ℕ in the alphabet used for TM's.
 - `unary_fin_encoding_nat` : a unary encoding of ℕ
-- `fin_encoding_bool_Γ₀₁`  : an encoding of bool.
+- `fin_encoding_bool_bool`  : an encoding of bool.
 -/
 
 namespace computability
@@ -36,60 +36,52 @@ structure encoding (α : Type) :=
 structure fin_encoding (α : Type) extends encoding α :=
 (Γ_fin : fintype Γ)
 
-/-- An alphabet consisting of bit0 and bit1 -/
-@[derive [inhabited,decidable_eq,fintype]]
-inductive Γ₀₁
-| bit0 | bit1
-
 /-- A standard Turing machine alphabet, consisting of blank,bit0,bit1,bra,ket,comma. -/
 @[derive [decidable_eq,fintype]]
 inductive Γ'
-| blank | bit0 | bit1 | bra | ket | comma
+| blank | bit (b : bool) | bra | ket | comma
 
 instance inhabited_Γ' : inhabited Γ' := ⟨Γ'.blank⟩
 
-/-- The natural inclusion of Γ₀₁ in Γ'. -/
-def inclusion_Γ₀₁_Γ' : Γ₀₁ → Γ'
-| Γ₀₁.bit0 := Γ'.bit0
-| Γ₀₁.bit1 := Γ'.bit1
+/-- The natural inclusion of bool in Γ'. -/
+def inclusion_bool_Γ' : bool → Γ' := Γ'.bit
 
-/-- An arbitrary section of the natural inclusion of Γ₀₁ in Γ'. -/
-def section_Γ'_Γ₀₁ : Γ' → Γ₀₁
-| Γ'.bit0 := Γ₀₁.bit0
-| Γ'.bit1 := Γ₀₁.bit1
-| _ := arbitrary Γ₀₁
+/-- An arbitrary section of the natural inclusion of bool in Γ'. -/
+def section_Γ'_bool : Γ' → bool
+| (Γ'.bit b) := b
+| _ := arbitrary bool
 
-lemma left_inverse_section_inclusion : function.left_inverse section_Γ'_Γ₀₁ inclusion_Γ₀₁_Γ' :=
-λ x, Γ₀₁.cases_on x rfl rfl
+lemma left_inverse_section_inclusion : function.left_inverse section_Γ'_bool inclusion_bool_Γ' :=
+λ x, bool.cases_on x rfl rfl
 
-lemma inclusion_Γ₀₁_Γ'_injective : function.injective inclusion_Γ₀₁_Γ' :=
-function.has_left_inverse.injective (Exists.intro section_Γ'_Γ₀₁ left_inverse_section_inclusion)
+lemma inclusion_bool_Γ'_injective : function.injective inclusion_bool_Γ' :=
+function.has_left_inverse.injective (Exists.intro section_Γ'_bool left_inverse_section_inclusion)
 
-/-- An encoding function of the positive binary numbers in Γ₀₁. -/
-def encode_pos_num : pos_num → list Γ₀₁
-| pos_num.one := [Γ₀₁.bit1]
-| (pos_num.bit0 n) := Γ₀₁.bit0 :: encode_pos_num n
-| (pos_num.bit1 n) := Γ₀₁.bit1 :: encode_pos_num n
+/-- An encoding function of the positive binary numbers in bool. -/
+def encode_pos_num : pos_num → list bool
+| pos_num.one := [tt]
+| (pos_num.bit0 n) := ff :: encode_pos_num n
+| (pos_num.bit1 n) := tt :: encode_pos_num n
 
-/-- An encoding function of the binary numbers in Γ₀₁. -/
-def encode_num : num → list Γ₀₁
+/-- An encoding function of the binary numbers in bool. -/
+def encode_num : num → list bool
 | num.zero := []
 | (num.pos n) := encode_pos_num n
 
-/-- An encoding function of ℕ in Γ₀₁. -/
-def encode_nat (n : ℕ) : list Γ₀₁ := encode_num n
+/-- An encoding function of ℕ in bool. -/
+def encode_nat (n : ℕ) : list bool := encode_num n
 
-/-- A decoding function from `list Γ₀₁` to the positive binary numbers. -/
-def decode_pos_num : list Γ₀₁ → pos_num
-| (Γ₀₁.bit0 :: l) := (pos_num.bit0 (decode_pos_num l))
-| (Γ₀₁.bit1 :: l) := ite (l = []) pos_num.one (pos_num.bit1 (decode_pos_num l))
+/-- A decoding function from `list bool` to the positive binary numbers. -/
+def decode_pos_num : list bool → pos_num
+| (ff :: l) := (pos_num.bit0 (decode_pos_num l))
+| (tt :: l) := ite (l = []) pos_num.one (pos_num.bit1 (decode_pos_num l))
 | _ := pos_num.one
 
-/-- A decoding function from `list Γ₀₁` to the binary numbers. -/
-def decode_num : list Γ₀₁ → num := λ l, ite (l = []) num.zero $ decode_pos_num l
+/-- A decoding function from `list bool` to the binary numbers. -/
+def decode_num : list bool → num := λ l, ite (l = []) num.zero $ decode_pos_num l
 
-/-- A decoding function from `list Γ₀₁` to ℕ. -/
-def decode_nat : list Γ₀₁ → nat := λ l, decode_num l
+/-- A decoding function from `list bool` to ℕ. -/
+def decode_nat : list bool → nat := λ l, decode_num l
 
 lemma encode_pos_num_nonempty (n : pos_num) : (encode_pos_num n) ≠ [] :=
 pos_num.cases_on n (list.cons_ne_nil _ _) (λ m, list.cons_ne_nil _ _) (λ m, list.cons_ne_nil _ _)
@@ -121,69 +113,66 @@ begin
   exact congr_arg coe (decode_encode_num ↑n),
 end
 
-/-- A binary encoding of ℕ in Γ₀₁. -/
-def encoding_nat_Γ₀₁ : encoding ℕ :=
-{ Γ := Γ₀₁,
+/-- A binary encoding of ℕ in bool. -/
+def encoding_nat_bool : encoding ℕ :=
+{ Γ := bool,
   encode := encode_nat,
   decode := λ n, some (decode_nat n),
   decode_encode := λ n, congr_arg _ (decode_encode_nat n) }
 
-/-- A binary fin_encoding of ℕ in Γ₀₁. -/
-def fin_encoding_nat_Γ₀₁ : fin_encoding ℕ := ⟨encoding_nat_Γ₀₁, Γ₀₁.fintype⟩
+/-- A binary fin_encoding of ℕ in bool. -/
+def fin_encoding_nat_bool : fin_encoding ℕ := ⟨encoding_nat_bool, bool.fintype⟩
 
 /-- A binary encoding of ℕ in Γ'. -/
 def encoding_nat_Γ' : encoding ℕ :=
 { Γ := Γ',
-  encode := λ x, list.map inclusion_Γ₀₁_Γ' (encode_nat x),
-  decode := λ x, some (decode_nat (list.map section_Γ'_Γ₀₁ x)),
+  encode := λ x, list.map inclusion_bool_Γ' (encode_nat x),
+  decode := λ x, some (decode_nat (list.map section_Γ'_bool x)),
   decode_encode := λ x, congr_arg _ $
     by rw [list.map_map, list.map_id' left_inverse_section_inclusion, decode_encode_nat] }
 
 /-- A binary fin_encoding of ℕ in Γ'. -/
 def fin_encoding_nat_Γ' : fin_encoding ℕ := ⟨encoding_nat_Γ', Γ'.fintype⟩
 
-/-- A unary encoding function of ℕ in Γ₀₁. -/
-def unary_encode_nat : nat → list Γ₀₁
+/-- A unary encoding function of ℕ in bool. -/
+def unary_encode_nat : nat → list bool
 | 0 := []
-| (n+1) := Γ₀₁.bit1 :: (unary_encode_nat n)
+| (n+1) := tt :: (unary_encode_nat n)
 
-/-- A unary decoding function from `list Γ₀₁` to ℕ. -/
-def unary_decode_nat : list Γ₀₁ → nat := list.length
+/-- A unary decoding function from `list bool` to ℕ. -/
+def unary_decode_nat : list bool → nat := list.length
 
 lemma unary_decode_encode_nat : ∀ n, unary_decode_nat (unary_encode_nat n) = n :=
 λ n, nat.rec rfl (λ (m : ℕ) hm, (congr_arg nat.succ hm.symm).symm) n
 
 /-- A unary fin_encoding of ℕ. -/
 def unary_fin_encoding_nat : fin_encoding ℕ :=
-{ Γ := Γ₀₁,
+{ Γ := bool,
   encode := unary_encode_nat,
   decode := λ n, some (unary_decode_nat n),
   decode_encode := λ n, congr_arg _ (unary_decode_encode_nat n),
-  Γ_fin := Γ₀₁.fintype}
+  Γ_fin := bool.fintype}
 
-/-- An encoding function of bool in Γ₀₁. -/
-def encode_bool : bool → list Γ₀₁
-| ff := [Γ₀₁.bit0]
-| tt := [Γ₀₁.bit1]
+/-- An encoding function of bool in bool. -/
+def encode_bool : bool → list bool := list.ret
 
-/-- A decoding function from `list Γ₀₁` to bool. -/
-def decode_bool : list Γ₀₁ → bool
-| [Γ₀₁.bit0] := ff
-| [Γ₀₁.bit1] := tt
+/-- A decoding function from `list bool` to bool. -/
+def decode_bool : list bool → bool
+| (b :: _) := b
 | _ := arbitrary bool
 
 lemma decode_encode_bool : ∀ b, decode_bool(encode_bool b) = b := λ b, bool.cases_on b rfl rfl
 
-/-- A fin_encoding of bool in Γ₀₁. -/
-def fin_encoding_bool_Γ₀₁ : fin_encoding bool :=
-{ Γ := Γ₀₁,
+/-- A fin_encoding of bool in bool. -/
+def fin_encoding_bool_bool : fin_encoding bool :=
+{ Γ := bool,
   encode := encode_bool,
   decode := λ x, some (decode_bool x),
   decode_encode := λ x, congr_arg _ (decode_encode_bool x),
-  Γ_fin := Γ₀₁.fintype }
+  Γ_fin := bool.fintype }
 
-instance inhabited_fin_encoding : inhabited (fin_encoding bool) := ⟨fin_encoding_bool_Γ₀₁⟩
+instance inhabited_fin_encoding : inhabited (fin_encoding bool) := ⟨fin_encoding_bool_bool⟩
 
-instance inhabited_encoding : inhabited (encoding bool) := ⟨fin_encoding_bool_Γ₀₁.to_encoding⟩
+instance inhabited_encoding : inhabited (encoding bool) := ⟨fin_encoding_bool_bool.to_encoding⟩
 
 end computability

--- a/src/computability/encoding.lean
+++ b/src/computability/encoding.lean
@@ -23,6 +23,8 @@ It also contains several examples:
 - `fin_encoding_bool_Γ₀₁`  : an encoding of bool.
 -/
 
+namespace computability
+
 /-- An encoding of a type in a certain alphabet, together with a decoding. -/
 structure encoding (α : Type) :=
 (Γ : Type)
@@ -183,3 +185,5 @@ def fin_encoding_bool_Γ₀₁ : fin_encoding bool :=
 instance inhabited_fin_encoding : inhabited (fin_encoding bool) := ⟨fin_encoding_bool_Γ₀₁⟩
 
 instance inhabited_encoding : inhabited (encoding bool) := ⟨fin_encoding_bool_Γ₀₁.to_encoding⟩
+
+end computability


### PR DESCRIPTION
We define the encoding of natural numbers and booleans to strings for Turing machines to be used in our future PR on polynomial time computation on Turing machines.

---
<!-- put comments you want to keep out of the PR commit here -->
