### PR TITLE
[Merged by Bors] - feat(widget): add go to definition button.

### DIFF
--- a/src/tactic/interactive_expr.lean
+++ b/src/tactic/interactive_expr.lean
@@ -133,7 +133,10 @@ meta def goto_def_button {γ} : expr → tactic (list (html (action γ)))
     env ← tactic.get_env,
     let file := environment.decl_olean env n,
     pos ← environment.decl_pos env n,
-    pure $ h "button" [cn "pointer ba br3 mr1", on_click (λ _, action.effect $ widget.effect.reveal_position file pos), attr.val "title" "go to definition"] ["↪"]
+    pure $ [h "button" [
+      cn "pointer ba br3 mr1",
+      on_click (λ _, action.effect $ widget.effect.reveal_position file pos),
+      attr.val "title" "go to definition"] ["↪"]]
   ) <|> pure []
 
 /--

--- a/src/tactic/interactive_expr.lean
+++ b/src/tactic/interactive_expr.lean
@@ -122,6 +122,16 @@ meta inductive action (γ : Type)
 | on_tooltip_action : γ → action
 | on_close_tooltip : action
 | copy : string → action
+| go_to_def : (string × pos) → action
+
+meta def goto_def_button {γ} : expr → tactic (list (html (action γ)))
+| e := (do
+  (expr.const n _) ← pure $ expr.get_app_fn e,
+  env ← tactic.get_env,
+  file ← environment.decl_olean env n,
+  pos ← environment.decl_pos env n,
+  htm ←  pure $ h "button" [cn "pointer ba br3 mr1", on_click (λ _, action.go_to_def (file, pos)), attr.val "title" "go to definition"] ["↪"],
+  pure [htm]) <|> pure []
 
 /--
 Renders a subexpression as a list of html elements.
@@ -135,11 +145,12 @@ meta def view {γ} (tooltip_component : tc subexpr (action γ)) (click_address :
     if some new_address = click_address then do
       content ← tc.to_html tooltip_component (e, new_address),
       efmt : string ← format.to_string <$> tactic.pp e,
+      gd_btn ← goto_def_button e,
       pure [tooltip $ h "div" [] [
-          h "div" [cn "fr"] [
+          h "div" [cn "fr"] (gd_btn ++ [
             h "button" [cn "pointer ba br3 mr1", on_click (λ _, action.copy efmt), attr.val "title" "copy expression to clipboard"] ["📋"],
             h "button" [cn "pointer ba br3", on_click (λ _, action.on_close_tooltip), attr.val "title" "close"] ["×"]
-          ],
+          ]),
           content
       ]]
     else pure [],
@@ -161,11 +172,11 @@ let tooltip_comp :=
    component.with_should_update (λ (x y : tactic_state × expr × expr.address), x.2.2 ≠ y.2.2)
    $ component.map_action (action.on_tooltip_action) tooltip in
 component.filter_map_action
-  (λ _ (a : γ ⊕ string), sum.cases_on a some (λ _, none))
-$ component.with_effects (λ _ (a : γ ⊕ string),
+  (λ _ (a : γ ⊕ widget.effect), sum.cases_on a some (λ _, none))
+$ component.with_effects (λ _ (a : γ ⊕ widget.effect),
   match a with
   | (sum.inl g) := []
-  | (sum.inr s) := [effect.copy_text s]
+  | (sum.inr s) := [s]
   end
 )
 $ tc.mk_simple
@@ -179,7 +190,8 @@ $ tc.mk_simple
     | (action.on_click ⟨e, ea⟩)       := if some (e,ea) = ca then ((none, sa), none) else ((some (e, ea), sa), none)
     | (action.on_tooltip_action g)    := ((none, sa), some $ sum.inl g)
     | (action.on_close_tooltip)       := ((none, sa), none)
-    | (action.copy s)                 := ((ca,sa), some $ sum.inr s)
+    | (action.copy s)                 := ((ca,sa), some $ sum.inr $ widget.effect.copy_text s)
+    | (action.go_to_def (f,p))    := ((ca,sa), some $ sum.inr $ widget.effect.reveal_position (some f) p)
     end
   )
   (λ e ⟨ca, sa⟩, do

--- a/src/tactic/interactive_expr.lean
+++ b/src/tactic/interactive_expr.lean
@@ -127,7 +127,7 @@ meta def goto_def_button {γ} : expr → tactic (list (html (action γ)))
 | e := (do
     (expr.const n _) ← pure $ expr.get_app_fn e,
     env ← tactic.get_env,
-    file ← pure $ environment.decl_olean env n,
+    let file := environment.decl_olean env n,
     pos ← environment.decl_pos env n,
     htm ←  pure $ h "button" [cn "pointer ba br3 mr1", on_click (λ _, action.effect $ widget.effect.reveal_position file pos), attr.val "title" "go to definition"] ["↪"],
     pure [htm]

--- a/src/tactic/interactive_expr.lean
+++ b/src/tactic/interactive_expr.lean
@@ -123,6 +123,10 @@ meta inductive action (γ : Type)
 | on_close_tooltip : action
 | effect : widget.effect → action
 
+/--
+Render a 'go to definition' button for a given expression.
+If there is no definition available, then returns an empty list.
+-/
 meta def goto_def_button {γ} : expr → tactic (list (html (action γ)))
 | e := (do
     (expr.const n _) ← pure $ expr.get_app_fn e,

--- a/src/tactic/interactive_expr.lean
+++ b/src/tactic/interactive_expr.lean
@@ -121,17 +121,17 @@ meta inductive action (γ : Type)
 | on_click : subexpr → action
 | on_tooltip_action : γ → action
 | on_close_tooltip : action
-| copy : string → action
-| go_to_def : (string × pos) → action
+| effect : widget.effect → action
 
 meta def goto_def_button {γ} : expr → tactic (list (html (action γ)))
 | e := (do
-  (expr.const n _) ← pure $ expr.get_app_fn e,
-  env ← tactic.get_env,
-  file ← environment.decl_olean env n,
-  pos ← environment.decl_pos env n,
-  htm ←  pure $ h "button" [cn "pointer ba br3 mr1", on_click (λ _, action.go_to_def (file, pos)), attr.val "title" "go to definition"] ["↪"],
-  pure [htm]) <|> pure []
+    (expr.const n _) ← pure $ expr.get_app_fn e,
+    env ← tactic.get_env,
+    file ← pure $ environment.decl_olean env n,
+    pos ← environment.decl_pos env n,
+    htm ←  pure $ h "button" [cn "pointer ba br3 mr1", on_click (λ _, action.effect $ widget.effect.reveal_position file pos), attr.val "title" "go to definition"] ["↪"],
+    pure [htm]
+  ) <|> pure []
 
 /--
 Renders a subexpression as a list of html elements.
@@ -148,7 +148,7 @@ meta def view {γ} (tooltip_component : tc subexpr (action γ)) (click_address :
       gd_btn ← goto_def_button e,
       pure [tooltip $ h "div" [] [
           h "div" [cn "fr"] (gd_btn ++ [
-            h "button" [cn "pointer ba br3 mr1", on_click (λ _, action.copy efmt), attr.val "title" "copy expression to clipboard"] ["📋"],
+            h "button" [cn "pointer ba br3 mr1", on_click (λ _, action.effect $ widget.effect.copy_text efmt), attr.val "title" "copy expression to clipboard"] ["📋"],
             h "button" [cn "pointer ba br3", on_click (λ _, action.on_close_tooltip), attr.val "title" "close"] ["×"]
           ]),
           content
@@ -190,8 +190,7 @@ $ tc.mk_simple
     | (action.on_click ⟨e, ea⟩)       := if some (e,ea) = ca then ((none, sa), none) else ((some (e, ea), sa), none)
     | (action.on_tooltip_action g)    := ((none, sa), some $ sum.inl g)
     | (action.on_close_tooltip)       := ((none, sa), none)
-    | (action.copy s)                 := ((ca,sa), some $ sum.inr $ widget.effect.copy_text s)
-    | (action.go_to_def (f,p))    := ((ca,sa), some $ sum.inr $ widget.effect.reveal_position (some f) p)
+    | (action.effect e)               := ((ca,sa), some $ sum.inr $ e)
     end
   )
   (λ e ⟨ca, sa⟩, do

--- a/src/tactic/interactive_expr.lean
+++ b/src/tactic/interactive_expr.lean
@@ -129,8 +129,7 @@ meta def goto_def_button {γ} : expr → tactic (list (html (action γ)))
     env ← tactic.get_env,
     let file := environment.decl_olean env n,
     pos ← environment.decl_pos env n,
-    htm ←  pure $ h "button" [cn "pointer ba br3 mr1", on_click (λ _, action.effect $ widget.effect.reveal_position file pos), attr.val "title" "go to definition"] ["↪"],
-    pure [htm]
+    pure $ h "button" [cn "pointer ba br3 mr1", on_click (λ _, action.effect $ widget.effect.reveal_position file pos), attr.val "title" "go to definition"] ["↪"]
   ) <|> pure []
 
 /--


### PR DESCRIPTION
Now you can hit a new button in the tooltip and it will reveal the definition location in the editor!