### PR TITLE
[Merged by Bors] - feat(order/conditionally_complete_lattice, topology/algebra/ordered): inherited order properties for `ord_connected` subset

### DIFF
--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -296,8 +296,8 @@ lemma Ici_inter_Iio : Ici a ∩ Iio b = Ico a b := rfl
 lemma Ioi_inter_Iic : Ioi a ∩ Iic b = Ioc a b := rfl
 lemma Ioi_inter_Iio : Ioi a ∩ Iio b = Ioo a b := rfl
 
-/-- In a dense order `α`, open intervals `Ioo a b` are also densely ordered, for any `a < b`. -/
-instance Ioo_densely_ordered [densely_ordered α] {a b : α} (hab : a < b) :
+/-- In a dense order `α`, open intervals `Ioo a b` are also densely ordered. -/
+instance Ioo_densely_ordered [densely_ordered α] {a b : α} :
   densely_ordered (set.Ioo a b) :=
 ⟨ begin
     intros a₁ a₂ ha,

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -296,6 +296,17 @@ lemma Ici_inter_Iio : Ici a ∩ Iio b = Ico a b := rfl
 lemma Ioi_inter_Iic : Ioi a ∩ Iic b = Ioc a b := rfl
 lemma Ioi_inter_Iio : Ioi a ∩ Iio b = Ioo a b := rfl
 
+/-- In a dense order `α`, open intervals `Ioo a b` are also densely ordered, for any `a < b`. -/
+instance Ioo_densely_ordered [densely_ordered α] {a b : α} (hab : a < b) :
+  densely_ordered (set.Ioo a b) :=
+⟨ begin
+    intros a₁ a₂ ha,
+    have ha' : ↑a₁ < ↑a₂ := ha,
+    obtain ⟨x, ha₁x, hxa₂⟩ := dense ha',
+    refine ⟨⟨x, _⟩, ⟨ha₁x, hxa₂⟩⟩,
+    exact ⟨lt_trans a₁.2.1 ha₁x, lt_trans hxa₂ a₂.2.2⟩,
+  end ⟩
+
 end intervals
 
 section partial_order

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -296,17 +296,6 @@ lemma Ici_inter_Iio : Ici a ∩ Iio b = Ico a b := rfl
 lemma Ioi_inter_Iic : Ioi a ∩ Iic b = Ioc a b := rfl
 lemma Ioi_inter_Iio : Ioi a ∩ Iio b = Ioo a b := rfl
 
-/-- In a dense order `α`, open intervals `Ioo a b` are also densely ordered. -/
-instance Ioo_densely_ordered [densely_ordered α] {a b : α} :
-  densely_ordered (set.Ioo a b) :=
-⟨ begin
-    intros a₁ a₂ ha,
-    have ha' : ↑a₁ < ↑a₂ := ha,
-    obtain ⟨x, ha₁x, hxa₂⟩ := dense ha',
-    refine ⟨⟨x, _⟩, ⟨ha₁x, hxa₂⟩⟩,
-    exact ⟨lt_trans a₁.2.1 ha₁x, lt_trans hxa₂ a₂.2.2⟩,
-  end ⟩
-
 end intervals
 
 section partial_order

--- a/src/data/set/intervals/ord_connected.lean
+++ b/src/data/set/intervals/ord_connected.lean
@@ -99,7 +99,7 @@ lemma ord_connected_empty : ord_connected (∅ : set α) := λ x, false.elim
 lemma ord_connected_univ : ord_connected (univ : set α) := λ _ _ _ _, subset_univ _
 
 /-- In a dense order `α`, the subtype from an `ord_connected` set is also densely ordered. -/
-lemma subtype_densely_ordered [densely_ordered α] {s : set α} [hs : ord_connected s] :
+instance [densely_ordered α] {s : set α} [hs : ord_connected s] :
   densely_ordered s :=
 ⟨ begin
     intros a₁ a₂ ha,

--- a/src/data/set/intervals/ord_connected.lean
+++ b/src/data/set/intervals/ord_connected.lean
@@ -95,7 +95,7 @@ lemma ord_connected_empty : ord_connected (∅ : set α) := λ x, false.elim
 lemma ord_connected_univ : ord_connected (univ : set α) := λ _ _ _ _, subset_univ _
 
 /-- In a dense order `α`, the subtype from an `ord_connected` set is also densely ordered. -/
-instance Ioo_densely_ordered [densely_ordered α] {s : set α} (hs : ord_connected s) :
+def subtype_densely_ordered [densely_ordered α] {s : set α} (hs : ord_connected s) :
   densely_ordered s :=
 ⟨ begin
     intros a₁ a₂ ha,
@@ -104,6 +104,10 @@ instance Ioo_densely_ordered [densely_ordered α] {s : set α} (hs : ord_connect
     refine ⟨⟨x, _⟩, ⟨ha₁x, hxa₂⟩⟩,
     exact (hs a₁.2 a₂.2) (Ioo_subset_Icc_self ⟨ha₁x, hxa₂⟩),
   end ⟩
+
+/-- In a dense order `α`, open intervals `Ioo a b` are also densely ordered. -/
+instance [densely_ordered α] {a b : α} : densely_ordered (Ioo a b) :=
+subtype_densely_ordered ord_connected_Ioo
 
 variables {β : Type*} [decidable_linear_order β]
 

--- a/src/data/set/intervals/ord_connected.lean
+++ b/src/data/set/intervals/ord_connected.lean
@@ -95,7 +95,7 @@ lemma ord_connected_empty : ord_connected (∅ : set α) := λ x, false.elim
 lemma ord_connected_univ : ord_connected (univ : set α) := λ _ _ _ _, subset_univ _
 
 /-- In a dense order `α`, the subtype from an `ord_connected` set is also densely ordered. -/
-def subtype_densely_ordered [densely_ordered α] {s : set α} (hs : ord_connected s) :
+lemma subtype_densely_ordered [densely_ordered α] {s : set α} (hs : ord_connected s) :
   densely_ordered s :=
 ⟨ begin
     intros a₁ a₂ ha,

--- a/src/data/set/intervals/ord_connected.lean
+++ b/src/data/set/intervals/ord_connected.lean
@@ -29,6 +29,7 @@ the `order_topology`, then this condition is equivalent to `is_preconnected s`. 
 this condition is also equivalent to `convex s`.
 -/
 def ord_connected (s : set α) : Prop := ∀ ⦃x⦄ (hx : x ∈ s) ⦃y⦄ (hy : y ∈ s), Icc x y ⊆ s
+attribute [class] ord_connected
 
 /-- It suffices to prove `[x, y] ⊆ s` for `x y ∈ s`, `x ≤ y`. -/
 lemma ord_connected_iff : ord_connected s ↔ ∀ (x ∈ s) (y ∈ s), x ≤ y → Icc x y ⊆ s :=
@@ -86,6 +87,9 @@ ord_connected_Ioi.inter ord_connected_Iic
 lemma ord_connected_Ioo {a b : α} : ord_connected (Ioo a b) :=
 ord_connected_Ioi.inter ord_connected_Iio
 
+attribute [instance] ord_connected_Ici ord_connected_Iic ord_connected_Ioi ord_connected_Iio
+ord_connected_Icc ord_connected_Ico ord_connected_Ioc ord_connected_Ioo
+
 lemma ord_connected_singleton {α : Type*} [partial_order α] {a : α} :
   ord_connected ({a} : set α) :=
 by { rw ← Icc_self, exact ord_connected_Icc }
@@ -95,7 +99,7 @@ lemma ord_connected_empty : ord_connected (∅ : set α) := λ x, false.elim
 lemma ord_connected_univ : ord_connected (univ : set α) := λ _ _ _ _, subset_univ _
 
 /-- In a dense order `α`, the subtype from an `ord_connected` set is also densely ordered. -/
-lemma subtype_densely_ordered [densely_ordered α] {s : set α} (hs : ord_connected s) :
+lemma subtype_densely_ordered [densely_ordered α] {s : set α} [hs : ord_connected s] :
   densely_ordered s :=
 ⟨ begin
     intros a₁ a₂ ha,
@@ -104,10 +108,6 @@ lemma subtype_densely_ordered [densely_ordered α] {s : set α} (hs : ord_connec
     refine ⟨⟨x, _⟩, ⟨ha₁x, hxa₂⟩⟩,
     exact (hs a₁.2 a₂.2) (Ioo_subset_Icc_self ⟨ha₁x, hxa₂⟩),
   end ⟩
-
-/-- In a dense order `α`, open intervals `Ioo a b` are also densely ordered. -/
-instance [densely_ordered α] {a b : α} : densely_ordered (Ioo a b) :=
-subtype_densely_ordered ord_connected_Ioo
 
 variables {β : Type*} [decidable_linear_order β]
 

--- a/src/data/set/intervals/ord_connected.lean
+++ b/src/data/set/intervals/ord_connected.lean
@@ -94,6 +94,17 @@ lemma ord_connected_empty : ord_connected (∅ : set α) := λ x, false.elim
 
 lemma ord_connected_univ : ord_connected (univ : set α) := λ _ _ _ _, subset_univ _
 
+/-- In a dense order `α`, the subtype from an `ord_connected` set is also densely ordered. -/
+instance Ioo_densely_ordered [densely_ordered α] {s : set α} (hs : ord_connected s) :
+  densely_ordered s :=
+⟨ begin
+    intros a₁ a₂ ha,
+    have ha' : ↑a₁ < ↑a₂ := ha,
+    obtain ⟨x, ha₁x, hxa₂⟩ := dense ha',
+    refine ⟨⟨x, _⟩, ⟨ha₁x, hxa₂⟩⟩,
+    exact (hs a₁.2 a₂.2) (Ioo_subset_Icc_self ⟨ha₁x, hxa₂⟩),
+  end ⟩
+
 variables {β : Type*} [decidable_linear_order β]
 
 lemma ord_connected_interval {a b : β} : ord_connected (interval a b) :=

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -341,6 +341,8 @@ instance subtype.decidable_linear_order {α} [decidable_linear_order α] (p : α
   decidable_linear_order (subtype p) :=
 decidable_linear_order.lift subtype.val subtype.val_injective
 
+lemma strict_mono_coe [preorder α] (t : set α) : strict_mono (coe : (subtype t) → α) := λ x y, id
+
 instance prod.has_le (α : Type u) (β : Type v) [has_le α] [has_le β] : has_le (α × β) :=
 ⟨λp q, p.1 ≤ q.1 ∧ p.2 ≤ q.2⟩
 

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
 import data.nat.enat
+import data.set.intervals.ord_connected
 
 /-!
 # Theory of conditionally complete lattices.
@@ -718,7 +719,7 @@ noncomputable instance with_top.with_bot.complete_lattice {α : Type*}
 end with_top_bot
 
 section subtype
-variables [conditionally_complete_linear_order α] (s : set α)
+variables (s : set α)
 
 /-! ### Subtypes of conditionally complete linear orders
 
@@ -735,6 +736,7 @@ TODO There are innumerable possible variants -- the interval `Ioo` could be chan
 open_locale classical
 
 section has_Sup
+variables [has_Sup α]
 
 /-- `has_Sup` structure on a nonempty open subset `s` of a conditionally complete linear
 order. This definition is non-canonical (it uses `default s`); it should be used only as
@@ -757,6 +759,7 @@ by simp [dif_pos h]
 end has_Sup
 
 section has_Inf
+variables [has_Inf α]
 
 /-- `has_Inf` structure on a nonempty open subset `s` of a conditionally complete linear
 order. This definition is non-canonical (it uses `default s`); it should be used only as
@@ -777,6 +780,8 @@ lemma subset_Inf_of_within [inhabited s] {t : set s} (h : Inf (coe '' t : set α
 by simp [dif_pos h]
 
 end has_Inf
+
+variables [conditionally_complete_linear_order α]
 
 local attribute [instance] subset_has_Sup
 local attribute [instance] subset_has_Inf
@@ -815,38 +820,40 @@ noncomputable def subset_conditionally_complete_linear_order [inhabited s]
   ..distrib_lattice.to_lattice s,
   ..classical.DLO s }
 
-section Ioo
-variables {a b : α}
+section ord_connected
 
-/-- The `Sup` function on a nonempty open subinterval `Ioo a b` of a conditionally complete linear
-order takes values within `Ioo a b`, for all nonempty bounded-above sets. -/
-lemma Ioo_Sup_within {a b : α} ⦃t : set (Ioo a b)⦄ (ht : t.nonempty) (h_bdd : bdd_above t) :
-  Sup (coe '' t : set α) ∈ Ioo a b :=
+/-- The `Sup` function on a nonempty `ord_connected` set `s` in a conditionally complete linear
+order takes values within `s`, for all nonempty bounded-above subsets of `s`. -/
+lemma Sup_within_of_ord_connected
+  {s : set α} [hs : ord_connected s] ⦃t : set s⦄ (ht : t.nonempty) (h_bdd : bdd_above t) :
+  Sup (coe '' t : set α) ∈ s :=
 begin
   obtain ⟨c, hct⟩ : ∃ c, c ∈ t := ht,
   obtain ⟨B, hB⟩ : ∃ B, B ∈ upper_bounds t := h_bdd,
-  have ha := lt_of_lt_of_le c.2.1 ((strict_mono_coe (Ioo a b)).monotone.le_cSup_image hct ⟨B, hB⟩),
-  have hb := lt_of_le_of_lt ((strict_mono_coe (Ioo a b)).monotone.cSup_image_le ⟨c, hct⟩ hB) B.2.2,
-  exact ⟨ha, hb⟩,
+  refine hs c.2 B.2 ⟨_, _⟩,
+  { exact (strict_mono_coe s).monotone.le_cSup_image hct ⟨B, hB⟩ },
+  { exact (strict_mono_coe s).monotone.cSup_image_le ⟨c, hct⟩ hB },
 end
 
-/-- The `Inf` function on a nonempty open subinterval `Ioo a b` of a conditionally complete linear
-order takes values within `Ioo a b`, for all nonempty bounded-above sets. -/
-lemma Ioo_Inf_within {a b : α} ⦃t : set (Ioo a b)⦄ (ht : t.nonempty) (h_bdd : bdd_below t) :
-  Inf (coe '' t : set α) ∈ Ioo a b :=
+/-- The `Inf` function on a nonempty `ord_connected` set `s` in a conditionally complete linear
+order takes values within `s`, for all nonempty bounded-below subsets of `s`. -/
+lemma Inf_within_of_ord_connected
+  {s : set α} [hs : ord_connected s] ⦃t : set s⦄ (ht : t.nonempty) (h_bdd : bdd_below t) :
+  Inf (coe '' t : set α) ∈ s :=
 begin
   obtain ⟨c, hct⟩ : ∃ c, c ∈ t := ht,
   obtain ⟨B, hB⟩ : ∃ B, B ∈ lower_bounds t := h_bdd,
-  have ha := lt_of_lt_of_le B.2.1 ((strict_mono_coe (Ioo a b)).monotone.le_cInf_image ⟨c, hct⟩ hB),
-  have hb := lt_of_le_of_lt ((strict_mono_coe (Ioo a b)).monotone.cInf_image_le hct ⟨B, hB⟩) c.2.2,
-  exact ⟨ha, hb⟩,
+  refine hs B.2 c.2 ⟨_, _⟩,
+  { exact (strict_mono_coe s).monotone.le_cInf_image ⟨c, hct⟩ hB },
+  { exact (strict_mono_coe s).monotone.cInf_image_le hct ⟨B, hB⟩ },
 end
 
-/-- A nonempty open interval of a conditionally complete linear order is naturally a conditionally
-complete linear order. -/
-noncomputable instance Ioo_conditionally_complete_linear_order [inhabited (Ioo a b)] :=
-subset_conditionally_complete_linear_order (Ioo a b) Ioo_Sup_within Ioo_Inf_within
+/-- A nonempty `ord_connected` set in a conditionally complete linear order is naturally a
+conditionally complete linear order. -/
+noncomputable instance ord_connected_subset_conditionally_complete_linear_order
+  [inhabited s] [ord_connected s] :=
+subset_conditionally_complete_linear_order s Sup_within_of_ord_connected Inf_within_of_ord_connected
 
-end Ioo
+end ord_connected
 
 end subtype

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -723,7 +723,7 @@ variables [conditionally_complete_linear_order α] (s : set α)
 /-! ### Subtypes of conditionally complete linear orders
 
 In this section we give conditions on a subset of a conditionally complete linear order, to ensure
-that the subsypeshow is itself conditionally complete.
+that the subtype is itself conditionally complete.
 
 We check that `Ioo` satisfies these conditions.
 

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -726,11 +726,10 @@ variables (s : set α)
 In this section we give conditions on a subset of a conditionally complete linear order, to ensure
 that the subtype is itself conditionally complete.
 
-We check that `Ioo` satisfies these conditions.
+We check that an `ord_connected` set satisfies these conditions.
 
-TODO There are innumerable possible variants -- the interval `Ioo` could be changed to `Ico`, `Icc`,
-`Ioi`, etc.; the `conditionally_complete_linear_order` could be changed to
-`conditionally_complete_linear_order_bot` or `complete_linear_order`.
+TODO There are several possible variants; the `conditionally_complete_linear_order` could be changed
+to `conditionally_complete_linear_order_bot` or `complete_linear_order`.
 -/
 
 open_locale classical
@@ -851,7 +850,8 @@ end
 /-- A nonempty `ord_connected` set in a conditionally complete linear order is naturally a
 conditionally complete linear order. -/
 noncomputable instance ord_connected_subset_conditionally_complete_linear_order
-  [inhabited s] [ord_connected s] :=
+  [inhabited s] [ord_connected s] :
+  conditionally_complete_linear_order s :=
 subset_conditionally_complete_linear_order s Sup_within_of_ord_connected Inf_within_of_ord_connected
 
 end ord_connected

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -737,10 +737,9 @@ open_locale classical
 section has_Sup
 variables [has_Sup α]
 
-/-- `has_Sup` structure on a nonempty open subset `s` of a conditionally complete linear
-order. This definition is non-canonical (it uses `default s`); it should be used only as
-here, as an auxiliary instance in the construction of the `conditionally_complete_linear_order`
-structure. -/
+/-- `has_Sup` structure on a nonempty subset `s` of an object with `has_Sup`. This definition is
+non-canonical (it uses `default s`); it should be used only as here, as an auxiliary instance in the
+construction of the `conditionally_complete_linear_order` structure. -/
 noncomputable def subset_has_Sup [inhabited s] : has_Sup s := {Sup := λ t,
 if ht : Sup (coe '' t : set α) ∈ s then ⟨Sup (coe '' t : set α), ht⟩ else default s}
 
@@ -760,10 +759,9 @@ end has_Sup
 section has_Inf
 variables [has_Inf α]
 
-/-- `has_Inf` structure on a nonempty open subset `s` of a conditionally complete linear
-order. This definition is non-canonical (it uses `default s`); it should be used only as
-here, as an auxiliary instance in the construction of the `conditionally_complete_linear_order`
-structure. -/
+/-- `has_Inf` structure on a nonempty subset `s` of an object with `has_Inf`. This definition is
+non-canonical (it uses `default s`); it should be used only as here, as an auxiliary instance in the
+construction of the `conditionally_complete_linear_order` structure. -/
 noncomputable def subset_has_Inf [inhabited s] : has_Inf s := {Inf := λ t,
 if ht : Inf (coe '' t : set α) ∈ s then ⟨Inf (coe '' t : set α), ht⟩ else default s}
 

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -820,8 +820,7 @@ variables {a b : α}
 
 /-- The `Sup` function on a nonempty open subinterval `Ioo a b` of a conditionally complete linear
 order takes values within `Ioo a b`, for all nonempty bounded-above sets. -/
-lemma Ioo_Sup_within {a b : α} [inhabited (Ioo a b)] ⦃t : set (Ioo a b)⦄ (ht : t.nonempty)
-  (h_bdd : bdd_above t) :
+lemma Ioo_Sup_within {a b : α} ⦃t : set (Ioo a b)⦄ (ht : t.nonempty) (h_bdd : bdd_above t) :
   Sup (coe '' t : set α) ∈ Ioo a b :=
 begin
   obtain ⟨c, hct⟩ : ∃ c, c ∈ t := ht,
@@ -833,8 +832,7 @@ end
 
 /-- The `Inf` function on a nonempty open subinterval `Ioo a b` of a conditionally complete linear
 order takes values within `Ioo a b`, for all nonempty bounded-above sets. -/
-lemma Ioo_Inf_within {a b : α} [inhabited (Ioo a b)] ⦃t : set (Ioo a b)⦄ (ht : t.nonempty)
-  (h_bdd : bdd_below t) :
+lemma Ioo_Inf_within {a b : α} ⦃t : set (Ioo a b)⦄ (ht : t.nonempty) (h_bdd : bdd_below t) :
   Inf (coe '' t : set α) ∈ Ioo a b :=
 begin
   obtain ⟨c, hct⟩ : ∃ c, c ∈ t := ht,

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -721,6 +721,31 @@ induced_order_topology' f @hf
   (λ a x xa, let ⟨b, xb, ba⟩ := H xa in ⟨b, hf.1 ba, le_of_lt xb⟩)
   (λ a x ax, let ⟨b, ab, bx⟩ := H ax in ⟨b, hf.1 ab, le_of_lt bx⟩)
 
+/-- On an open subinterval of a dense linear order, the order topology for the restriction of the
+order is the same as the restriction to the interval of the order topology. -/
+instance {α : Type*}
+  [topological_space α] [decidable_linear_order α] [densely_ordered α] [order_topology α]
+  {a b : α} :
+  order_topology (Ioo a b) :=
+induced_order_topology' (coe : (Ioo a b) → α)
+( λ x y, by refl ) -- `by refl` works, `rfl` doesn't
+( begin
+    intros x y hxy,
+    have hayx : max a y < x := max_lt x.2.1 hxy,
+    obtain ⟨c, hc⟩ := dense hayx,
+    use c,
+    exact ⟨lt_of_le_of_lt (le_max_left a y) hc.1, lt_trans hc.2 x.2.2⟩,
+    exact ⟨hc.2, le_trans (le_max_right a y) (le_of_lt hc.1)⟩,
+  end )
+( begin
+    intros x y hxy,
+    have hxyb : (x : α) < min y b := lt_min hxy x.2.2,
+    obtain ⟨c, hc⟩ := dense hxyb,
+    use c,
+    exact ⟨lt_trans x.2.1 hc.1, lt_of_lt_of_le hc.2 (min_le_right y b)⟩,
+    exact ⟨hc.1, le_trans (le_of_lt hc.2) (min_le_left y b)⟩
+  end)
+
 lemma nhds_top_order [topological_space α] [order_top α] [order_topology α] :
   𝓝 (⊤:α) = (⨅l (h₂ : l < ⊤), 𝓟 (Ioi l)) :=
 by simp [nhds_eq_order (⊤:α)]

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -721,30 +721,54 @@ induced_order_topology' f @hf
   (λ a x xa, let ⟨b, xb, ba⟩ := H xa in ⟨b, hf.1 ba, le_of_lt xb⟩)
   (λ a x ax, let ⟨b, ab, bx⟩ := H ax in ⟨b, hf.1 ab, le_of_lt bx⟩)
 
-/-- On an open subinterval of a dense linear order, the order topology for the restriction of the
-order is the same as the restriction to the interval of the order topology. -/
-instance {α : Type*}
-  [topological_space α] [decidable_linear_order α] [densely_ordered α] [order_topology α]
-  {a b : α} :
-  order_topology (Ioo a b) :=
-induced_order_topology' (coe : (Ioo a b) → α)
-( λ x y, by refl ) -- `by refl` works, `rfl` doesn't
-( begin
-    intros x y hxy,
-    have hayx : max a y < x := max_lt x.2.1 hxy,
-    obtain ⟨c, hc⟩ := dense hayx,
-    use c,
-    exact ⟨lt_of_le_of_lt (le_max_left a y) hc.1, lt_trans hc.2 x.2.2⟩,
-    exact ⟨hc.2, le_trans (le_max_right a y) (le_of_lt hc.1)⟩,
-  end )
-( begin
-    intros x y hxy,
-    have hxyb : (x : α) < min y b := lt_min hxy x.2.2,
-    obtain ⟨c, hc⟩ := dense hxyb,
-    use c,
-    exact ⟨lt_trans x.2.1 hc.1, lt_of_lt_of_le hc.2 (min_le_right y b)⟩,
-    exact ⟨hc.1, le_trans (le_of_lt hc.2) (min_le_left y b)⟩
-  end)
+/-- On an `ord_connected` subset of a linear order, the order topology for the restriction of the
+order is the same as the restriction to the subset of the order topology. -/
+instance order_topology_of_ord_connected {α : Type u}
+  [ta : topological_space α] [decidable_linear_order α] [order_topology α]
+  {t : set α} [ht : ord_connected t] :
+  order_topology t :=
+begin
+  letI := induced (coe : t → α) ta,
+  refine ⟨eq_of_nhds_eq_nhds (λ a, _)⟩,
+  rw [nhds_induced, nhds_generate_from, nhds_eq_order (a : α)],
+  apply le_antisymm,
+  { refine le_infi (λ s, le_infi $ λ hs, le_principal_iff.2 _),
+    rcases hs with ⟨ab, b, rfl|rfl⟩,
+    { refine ⟨Ioi b, _, λ _, id⟩,
+      refine mem_inf_sets_of_left (mem_infi_sets b _),
+      exact mem_infi_sets ab (mem_principal_self (Ioi ↑b)) },
+    { refine ⟨Iio b, _, λ _, id⟩,
+      refine mem_inf_sets_of_right (mem_infi_sets b _),
+      exact mem_infi_sets ab (mem_principal_self (Iio b)) } },
+  { rw [← map_le_iff_le_comap],
+    refine le_inf _ _,
+    { refine le_infi (λ x, le_infi $ λ h, le_principal_iff.2 _),
+      by_cases hx : x ∈ t,
+      { refine mem_infi_sets (Ioi ⟨x, hx⟩) (mem_infi_sets ⟨h, ⟨⟨x, hx⟩, or.inl rfl⟩⟩ _),
+        exact λ _, id },
+      simp only [set_coe.exists, mem_set_of_eq, mem_map],
+      convert univ_sets _,
+      suffices hx' : ∀ (y : t), ↑y ∈ Ioi x,
+      { simp [hx'] },
+      intros y,
+      revert hx,
+      contrapose!,
+      -- here we use the `ord_connected` hypothesis
+      exact λ hx, ht y.2 a.2 ⟨le_of_not_gt hx, le_of_lt h⟩ },
+    { refine le_infi (λ x, le_infi $ λ h, le_principal_iff.2 _),
+      by_cases hx : x ∈ t,
+      { refine mem_infi_sets (Iio ⟨x, hx⟩) (mem_infi_sets ⟨h, ⟨⟨x, hx⟩, or.inr rfl⟩⟩ _),
+        exact λ _, id },
+      simp only [set_coe.exists, mem_set_of_eq, mem_map],
+      convert univ_sets _,
+      suffices hx' : ∀ (y : t), ↑y ∈ Iio x,
+      { simp [hx'] },
+      intros y,
+      revert hx,
+      contrapose!,
+      -- here we use the `ord_connected` hypothesis
+      exact λ hx, ht a.2 y.2 ⟨le_of_lt h, le_of_not_gt hx⟩ } }
+end
 
 lemma nhds_top_order [topological_space α] [order_top α] [order_topology α] :
   𝓝 (⊤:α) = (⨅l (h₂ : l < ⊤), 𝓟 (Ioi l)) :=


### PR DESCRIPTION
If `α` is `densely_ordered`, then so is the subtype `s`, for any `ord_connected` subset `s` of `α`.

Same result for `order_topology`.

Same result for `conditionally_complete_linear_order`, under the hypothesis `inhabited s`.

---
<!-- put comments you want to keep out of the PR commit here -->

Zulip [(1)](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Errors.20with.20order.20hierarchy) [(2)](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.233991)

With these facts, it should be possible to make relative versions of the results from #3843.