### PR TITLE
[Merged by Bors] - fix(algebraic_geometry/Spec): inline TeX in heading

### DIFF
--- a/src/algebraic_geometry/Spec.lean
+++ b/src/algebraic_geometry/Spec.lean
@@ -7,7 +7,7 @@ import algebraic_geometry.locally_ringed_space
 import algebraic_geometry.structure_sheaf
 
 /-!
-# $Spec R$ as a `SheafedSpace`.
+# $Spec R$ as a `SheafedSpace`
 
 We bundle the `structure_sheaf R` construction for `R : CommRing` as a `SheafedSpace`.
 

--- a/src/algebraic_geometry/Spec.lean
+++ b/src/algebraic_geometry/Spec.lean
@@ -7,7 +7,7 @@ import algebraic_geometry.locally_ringed_space
 import algebraic_geometry.structure_sheaf
 
 /-!
-# $$Spec R$$ as a `SheafedSpace`.
+# $Spec R$ as a `SheafedSpace`.
 
 We bundle the `structure_sheaf R` construction for `R : CommRing` as a `SheafedSpace`.
 


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->

In https://leanprover-community.github.io/mathlib_docs/algebraic_geometry/Spec.html "Spec R" is on its own line.