### PR TITLE
[Merged by Bors] - feat(ring_theory/dedekind_domain): definitions

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -369,3 +369,18 @@ howpublished = {\url{https://leanprover.github.io/theorem_proving_in_lean/}},
       series        = "Penguin books",
       year          = "1979",
 }
+
+@book{marcus1977number,
+  title={Number fields},
+  author={Marcus, Daniel A and Sacco, Emanuele},
+  volume={2},
+  year={1977},
+  publisher={Springer}
+}
+
+@book{cassels1967algebraic,
+  title={Algebraic number theory: proceedings of an instructional conference},
+  author={Cassels, John William Scott and Fr{\"o}lich, Albrecht},
+  year={1967},
+  publisher={Academic Pr}
+}

--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -656,7 +656,7 @@ theorem to_linear_map_inj {e₁ e₂ : A₁ ≃ₐ[R] A₂} (H : e₁.to_linear_
 ext $ λ x, show e₁.to_linear_map x = e₂.to_linear_map x, by rw H
 
 @[simp] lemma trans_to_linear_map (f : A₁ ≃ₐ[R] A₂) (g : A₂ ≃ₐ[R] A₃) :
-(f.trans g).to_linear_map = g.to_linear_map.comp f.to_linear_map := rfl
+  (f.trans g).to_linear_map = g.to_linear_map.comp f.to_linear_map := rfl
 
 end alg_equiv
 

--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -908,6 +908,10 @@ theorem map_le {S : subalgebra R A} {f : A →ₐ[R] B} {U : subalgebra R B} :
   map S f ≤ U ↔ S ≤ comap' U f :=
 set.image_subset_iff
 
+lemma mem_map {S : subalgebra R A} {f : A →ₐ[R] B} {y : B} :
+  y ∈ map S f ↔ ∃ x ∈ S, f x = y :=
+subsemiring.mem_map
+
 instance integral_domain {R A : Type*} [comm_ring R] [integral_domain A] [algebra R A]
   (S : subalgebra R A) : integral_domain S :=
 @subring.domain A _ S _

--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -484,6 +484,7 @@ namespace alg_equiv
 variables {R : Type u} {A₁ : Type v} {A₂ : Type w} {A₃ : Type u₁}
 variables [comm_semiring R] [semiring A₁] [semiring A₂] [semiring A₃]
 variables [algebra R A₁] [algebra R A₂] [algebra R A₃]
+variables (e : A₁ ≃ₐ[R] A₂)
 
 instance : has_coe_to_fun (A₁ ≃ₐ[R] A₂) := ⟨_, alg_equiv.to_fun⟩
 
@@ -511,7 +512,7 @@ rfl
 
 @[simp] lemma to_fun_apply {e : A₁ ≃ₐ[R] A₂} {a : A₁} : e.to_fun a = e a := rfl
 
-@[simp, norm_cast] lemma coe_ring_equiv (e : A₁ ≃ₐ[R] A₂) : ((e : A₁ ≃+* A₂) : A₁ → A₂) = e := rfl
+@[simp, norm_cast] lemma coe_ring_equiv : ((e : A₁ ≃+* A₂) : A₁ → A₂) = e := rfl
 
 lemma coe_ring_equiv_injective : function.injective (λ e : A₁ ≃ₐ[R] A₂, (e : A₁ ≃+* A₂)) :=
 begin
@@ -522,15 +523,15 @@ begin
   exact congr_fun w a,
 end
 
-@[simp] lemma map_add (e : A₁ ≃ₐ[R] A₂) : ∀ x y, e (x + y) = e x + e y := e.to_add_equiv.map_add
+@[simp] lemma map_add : ∀ x y, e (x + y) = e x + e y := e.to_add_equiv.map_add
 
-@[simp] lemma map_zero (e : A₁ ≃ₐ[R] A₂) : e 0 = 0 := e.to_add_equiv.map_zero
+@[simp] lemma map_zero : e 0 = 0 := e.to_add_equiv.map_zero
 
-@[simp] lemma map_mul (e : A₁ ≃ₐ[R] A₂) : ∀ x y, e (x * y) = (e x) * (e y) := e.to_mul_equiv.map_mul
+@[simp] lemma map_mul : ∀ x y, e (x * y) = (e x) * (e y) := e.to_mul_equiv.map_mul
 
-@[simp] lemma map_one (e : A₁ ≃ₐ[R] A₂) : e 1 = 1 := e.to_mul_equiv.map_one
+@[simp] lemma map_one : e 1 = 1 := e.to_mul_equiv.map_one
 
-@[simp] lemma commutes (e : A₁ ≃ₐ[R] A₂) : ∀ (r : R), e (algebra_map R A₁ r) = algebra_map R A₂ r :=
+@[simp] lemma commutes : ∀ (r : R), e (algebra_map R A₁ r) = algebra_map R A₂ r :=
   e.commutes'
 
 @[simp] lemma map_neg {A₁ : Type v} {A₂ : Type w}
@@ -541,21 +542,30 @@ end
   [ring A₁] [ring A₂] [algebra R A₁] [algebra R A₂] (e : A₁ ≃ₐ[R] A₂) :
   ∀ x y, e (x - y) = e x - e y := e.to_add_equiv.map_sub
 
-lemma map_sum (e : A₁ ≃ₐ[R] A₂) {ι : Type*} (f : ι → A₁) (s : finset ι) :
+lemma map_sum {ι : Type*} (f : ι → A₁) (s : finset ι) :
   e (∑ x in s, f x) = ∑ x in s, e (f x) :=
 e.to_add_equiv.map_sum f s
 
+/-- Interpret an algebra equivalence as an algebra homomorphism.
+
+This definition is included for symmetry with the other `to_*_hom` projections.
+The `simp` normal form is to use the coercion of the `has_coe_to_alg_hom` instance. -/
+def to_alg_hom : A₁ →ₐ[R] A₂ :=
+{ map_one' := e.map_one, map_zero' := e.map_zero, ..e }
+
 instance has_coe_to_alg_hom : has_coe (A₁ ≃ₐ[R] A₂) (A₁ →ₐ[R] A₂) :=
-  ⟨λ e, { map_one' := e.map_one, map_zero' := e.map_zero, ..e }⟩
+⟨to_alg_hom⟩
 
-@[simp, norm_cast] lemma coe_alg_hom (e : A₁ ≃ₐ[R] A₂) : ((e : A₁ →ₐ[R] A₂) : A₁ → A₂) = e :=
-  rfl
+@[simp] lemma to_alg_hom_eq_coe : e.to_alg_hom = e := rfl
 
-lemma injective (e : A₁ ≃ₐ[R] A₂) : function.injective e := e.to_equiv.injective
+@[simp, norm_cast] lemma coe_alg_hom : ((e : A₁ →ₐ[R] A₂) : A₁ → A₂) = e :=
+rfl
 
-lemma surjective (e : A₁ ≃ₐ[R] A₂) : function.surjective e := e.to_equiv.surjective
+lemma injective : function.injective e := e.to_equiv.injective
 
-lemma bijective (e : A₁ ≃ₐ[R] A₂) : function.bijective e := e.to_equiv.bijective
+lemma surjective : function.surjective e := e.to_equiv.surjective
+
+lemma bijective : function.bijective e := e.to_equiv.bijective
 
 instance : has_one (A₁ ≃ₐ[R] A₁) := ⟨{commutes' := λ r, rfl, ..(1 : A₁ ≃+* A₁)}⟩
 
@@ -624,6 +634,29 @@ def to_linear_equiv (e : A₁ ≃ₐ[R] A₂) : A₁ ≃ₗ[R] A₂ :=
   right_inv := e.right_inv, }
 
 @[simp] lemma to_linear_equiv_apply (e : A₁ ≃ₐ[R] A₂) (x : A₁) : e.to_linear_equiv x = e x := rfl
+
+theorem to_linear_equiv_inj {e₁ e₂ : A₁ ≃ₐ[R] A₂} (H : e₁.to_linear_equiv = e₂.to_linear_equiv) :
+  e₁ = e₂ :=
+ext $ λ x, show e₁.to_linear_equiv x = e₂.to_linear_equiv x, by rw H
+
+/-- Interpret an algebra equivalence as a linear map. -/
+def to_linear_map : A₁ →ₗ[R] A₂ :=
+e.to_alg_hom.to_linear_map
+
+@[simp] lemma to_alg_hom_to_linear_map :
+  (e : A₁ →ₐ[R] A₂).to_linear_map = e.to_linear_map := rfl
+
+@[simp] lemma to_linear_equiv_to_linear_map :
+  e.to_linear_equiv.to_linear_map = e.to_linear_map := rfl
+
+@[simp] lemma to_linear_map_apply (x : A₁) : e.to_linear_map x = e x := rfl
+
+theorem to_linear_map_inj {e₁ e₂ : A₁ ≃ₐ[R] A₂} (H : e₁.to_linear_map = e₂.to_linear_map) :
+  e₁ = e₂ :=
+ext $ λ x, show e₁.to_linear_map x = e₂.to_linear_map x, by rw H
+
+@[simp] lemma trans_to_linear_map (f : A₁ ≃ₐ[R] A₂) (g : A₂ ≃ₐ[R] A₃) :
+(f.trans g).to_linear_map = g.to_linear_map.comp f.to_linear_map := rfl
 
 end alg_equiv
 

--- a/src/ring_theory/algebra_operations.lean
+++ b/src/ring_theory/algebra_operations.lean
@@ -279,6 +279,19 @@ lemma mem_div_iff_smul_subset {x : A} {I J : submodule R A} : x ∈ I / J ↔ x 
   λ h y hy, h (set.smul_mem_smul_set hy) ⟩
 
 lemma le_div_iff {I J K : submodule R A} : I ≤ J / K ↔ ∀ (x ∈ I) (z ∈ K), x * z ∈ J := iff.refl _
+
+@[simp] lemma map_div {B : Type*} [comm_ring B] [algebra R B] (I J : submodule R A) (h : A →ₐ[R] B) :
+  (I / J).map h.to_linear_map = I.map h.to_linear_map / J.map h.to_linear_map :=
+begin
+  ext x,
+  simp only [mem_map, mem_div_iff_forall_mul_mem],
+  split,
+  { rintro ⟨x, hx, rfl⟩ _ ⟨y, hy, rfl⟩,
+    exact ⟨x * y, hx _ hy, h.map_mul x y⟩ },
+  { rintro hx,
+    sorry }
+end
+
 end quotient
 
 end comm_ring

--- a/src/ring_theory/algebra_operations.lean
+++ b/src/ring_theory/algebra_operations.lean
@@ -280,7 +280,8 @@ lemma mem_div_iff_smul_subset {x : A} {I J : submodule R A} : x ∈ I / J ↔ x 
 
 lemma le_div_iff {I J K : submodule R A} : I ≤ J / K ↔ ∀ (x ∈ I) (z ∈ K), x * z ∈ J := iff.refl _
 
-@[simp] lemma map_div {B : Type*} [comm_ring B] [algebra R B] (I J : submodule R A) (h : A →ₐ[R] B) :
+@[simp] lemma map_div {B : Type*} [comm_ring B] [algebra R B]
+  (I J : submodule R A) (h : A ≃ₐ[R] B) :
   (I / J).map h.to_linear_map = I.map h.to_linear_map / J.map h.to_linear_map :=
 begin
   ext x,
@@ -289,7 +290,11 @@ begin
   { rintro ⟨x, hx, rfl⟩ _ ⟨y, hy, rfl⟩,
     exact ⟨x * y, hx _ hy, h.map_mul x y⟩ },
   { rintro hx,
-    sorry }
+    refine ⟨h.symm x, λ z hz, _, h.apply_symm_apply x⟩,
+    obtain ⟨xz, xz_mem, hxz⟩ := hx (h z) ⟨z, hz, rfl⟩,
+    convert xz_mem,
+    apply h.injective,
+    erw [h.map_mul, h.apply_symm_apply, hxz] }
 end
 
 end quotient

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -11,45 +11,6 @@ def dimension_le_one (R : Type*) [comm_ring R] : Prop :=
 
 variables {R : Type*} [comm_ring R]
 
-lemma not_is_field_of_subsingleton {R : Type*} [ring R] [subsingleton R] : ¬ is_field R :=
-λ ⟨⟨x, y, hxy⟩, _, _⟩, hxy (subsingleton.elim x y)
-
-lemma exists_not_is_unit_of_not_is_field [nontrivial R] (hf : ¬ is_field R) :
-  ∃ x ≠ (0 : R), ¬ is_unit x :=
-begin
-  have : ¬ _ := λ h, hf ⟨exists_pair_ne R, mul_comm, h⟩,
-  simp_rw is_unit_iff_exists_inv,
-  push_neg at ⊢ this,
-  obtain ⟨x, hx, not_unit⟩ := this,
-  exact ⟨x, hx, not_unit⟩
-end
-
-lemma not_is_field_iff_exists_ideal_bot_lt_and_lt_top [nontrivial R] :
-  ¬ is_field R ↔ ∃ I : ideal R, ⊥ < I ∧ I < ⊤ :=
-begin
-  split,
-  { intro h,
-    obtain ⟨x, nz, nu⟩ := exists_not_is_unit_of_not_is_field h,
-    use ideal.span {x},
-    rw [bot_lt_iff_ne_bot, lt_top_iff_ne_top],
-    exact ⟨mt ideal.span_singleton_eq_bot.mp nz, mt ideal.span_singleton_eq_top.mp nu⟩ },
-  { rintros ⟨I, bot_lt, lt_top⟩ hf,
-    obtain ⟨x, mem, ne_zero⟩ := submodule.exists_of_lt bot_lt,
-    rw submodule.mem_bot at ne_zero,
-    obtain ⟨y, hy⟩ := hf.mul_inv_cancel ne_zero,
-    rw [lt_top_iff_ne_top, ne.def, ideal.eq_top_iff_one, ← hy] at lt_top,
-    exact lt_top (ideal.mul_mem_right _ mem), }
-end
-
-lemma not_is_field_iff_exists_ideal_ne_bot_and_is_prime [nontrivial R] :
-  ¬ is_field R ↔ ∃ p : ideal R, p ≠ ⊥ ∧ p.is_prime :=
-not_is_field_iff_exists_ideal_bot_lt_and_lt_top.trans
-  ⟨λ ⟨I, bot_lt, lt_top⟩, let ⟨p, hp, le_p⟩ := I.exists_le_maximal (lt_top_iff_ne_top.mp lt_top) in
-    ⟨p, bot_lt_iff_ne_bot.mp (lt_of_lt_of_le bot_lt le_p), hp.is_prime⟩,
-   λ ⟨p, ne_bot, prime⟩, ⟨p, bot_lt_iff_ne_bot.mpr ne_bot, lt_top_iff_ne_top.mpr prime.1⟩⟩
-
-end ring
-
 open ideal ring
 
 lemma is_principal_ideal_ring.dimension_le_one (R : Type*) [integral_domain R]
@@ -69,19 +30,29 @@ begin
   apply is_prime.comap
 end
 
-/--Noetherian, integrally closed, Krull dimension 1-/
+/-- A Dedekind domain is a nonfield is Noetherian, integrally closed, and has Krull dimension exactly one.
+This is the default implementation, but there are equivalent definitions, which are
+`is_dedekind_domain_dvr` and `is_dedekind_domain_inv`.
+TODO: Prove that these are actually equivalent definitions.
+-/
 class is_dedekind_domain [comm_ring R] [comm_ring K] (f : fraction_map R K) :=
   (not_is_field : ¬ is_field R)
   (is_noetherian_ring : is_noetherian_ring R)
   (dimension_le_one : dimension_le_one R)
   (is_integrally_closed : integral_closure R f.codomain = ⊥)
-/--Noetherian, localization at every maximal prime is a discrete valuation ring-/
-class is_dedekind_domain_dvr [integral_domain R]: Prop :=
+
+/-- A Dedekind domain is a nonfield that is Noetherian, and the localization at every nonzero prime is a discrete valuation ring.
+This is equivalent to `is_dedekind_domain`.
+-/
+structure is_dedekind_domain_dvr [integral_domain R]: Prop :=
   (not_is_field : ¬ is_field R)
   (is_noetherian_ring : is_noetherian_ring R)
   (is_dvr_at_nonzero_prime : ∀ P ≠ (⊥ : ideal R), P.is_prime →
     @discrete_valuation_ring (localization.at_prime P) (by {exact localization_map.integral_domain_of_local_at_prime a}))
-/--Every fractional ideal has an inverse-/
-class is_dedekind_domain_inv [integral_domain R] [comm_ring K] (f : fraction_map R K) : Prop :=
+
+/-- A dedekind domain is a nonfield such that every fractional ideal has an inverse.
+This is equivalent to `is_dedekind_domain`
+-/
+structure is_dedekind_domain_inv [integral_domain R] [comm_ring K] (f : fraction_map R K) : Prop :=
   (not_is_field : ¬ is_field R)
   (is_invertible_ideal : ∀ I : ring.fractional_ideal f, ⊥ < I → (∃ J : ring.fractional_ideal f, I * J = 1))

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -46,42 +46,6 @@ class is_dedekind_domain (R : Type*) [integral_domain R] : Prop :=
 (dimension_le_one : dimension_le_one R)
 (is_integrally_closed : integral_closure R (fraction_ring R) = ⊥)
 
-namespace subalgebra
-
-lemma mem_map
-  {R A A' : Type*} [comm_ring R] [comm_ring A] [comm_ring A'] [algebra R A] [algebra R A']
-  {f : A →ₐ[R] A'} {S : subalgebra R A} {y : A'} : y ∈ map S f ↔ ∃ x ∈ S, f x = y :=
-subsemiring.mem_map
-
-lemma bot_map_equiv
-  {R A A' : Type*} [comm_ring R] [comm_ring A] [comm_ring A'] [algebra R A] [algebra R A']
-  (f : A ≃ₐ[R] A') : map ⊥ (f : A →ₐ[R] A') = ⊥ :=
-begin
-  rw ← le_bot_iff,
-  intros y hy,
-  obtain ⟨x, hx, rfl⟩ := mem_map.mp hy,
-  obtain ⟨x', rfl⟩ := algebra.mem_bot.mp hx,
-  erw [f.commutes, algebra.mem_bot],
-  exact ⟨x', rfl⟩
-end
-
-end subalgebra
-
-/-- Mapping an integral closure along an `alg_equiv` gives the integral closure. -/
-lemma integral_closure_map_alg_equiv
-  {R A A' : Type*} [comm_ring R] [comm_ring A] [comm_ring A'] [algebra R A] [algebra R A']
-  (f : A ≃ₐ[R] A') : (integral_closure R A).map (f : A →ₐ[R] A') = integral_closure R A' :=
-begin
-  ext y,
-  rw subalgebra.mem_map,
-  split,
-  { rintros ⟨x, hx, rfl⟩,
-    exact is_integral_alg_hom f hx },
-  { intro hy,
-    use [f.symm y, is_integral_alg_hom (f.symm : A' →ₐ[R] A) hy],
-    simp }
-end
-
 /-- The non-field, noetherian ring, dimension ≤ 1, integrally closed definition of Dedekind domain
 doesn't depend on the choice of fraction field. -/
 lemma is_dedekind_domain_iff [integral_domain R] [field K] (f : fraction_map R K) :
@@ -90,10 +54,10 @@ lemma is_dedekind_domain_iff [integral_domain R] [field K] (f : fraction_map R K
     integral_closure R f.codomain = ⊥ :=
 ⟨λ ⟨hf, hr, hd, hi⟩, ⟨hf, hr, hd,
   by rw [←integral_closure_map_alg_equiv (fraction_ring.alg_equiv_of_quotient f),
-         hi, subalgebra.bot_map_equiv]⟩,
+         hi, algebra.map_bot]⟩,
  λ ⟨hf, hr, hd, hi⟩, ⟨hf, hr, hd,
   by rw [←integral_closure_map_alg_equiv (fraction_ring.alg_equiv_of_quotient f).symm,
-         hi, subalgebra.bot_map_equiv]⟩⟩
+         hi, algebra.map_bot]⟩⟩
 
 /-- A Dedekind domain is a nonfield that is Noetherian, and the localization at every nonzero prime is a discrete valuation ring.
 This is equivalent to `is_dedekind_domain`.

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -40,16 +40,65 @@ This is the default implementation, but there are equivalent definitions,
 `is_dedekind_domain_dvr` and `is_dedekind_domain_inv`.
 TODO: Prove that these are actually equivalent definitions.
 -/
-class is_dedekind_domain [comm_ring R] [comm_ring K] (f : fraction_map R K) :=
+class is_dedekind_domain (R : Type*) [integral_domain R] : Prop :=
 (not_is_field : ¬ is_field R)
 (is_noetherian_ring : is_noetherian_ring R)
 (dimension_le_one : dimension_le_one R)
-(is_integrally_closed : integral_closure R f.codomain = ⊥)
+(is_integrally_closed : integral_closure R (fraction_ring R) = ⊥)
+
+namespace subalgebra
+
+lemma mem_map
+  {R A A' : Type*} [comm_ring R] [comm_ring A] [comm_ring A'] [algebra R A] [algebra R A']
+  {f : A →ₐ[R] A'} {S : subalgebra R A} {y : A'} : y ∈ map S f ↔ ∃ x ∈ S, f x = y :=
+subsemiring.mem_map
+
+lemma bot_map_equiv
+  {R A A' : Type*} [comm_ring R] [comm_ring A] [comm_ring A'] [algebra R A] [algebra R A']
+  (f : A ≃ₐ[R] A') : map ⊥ (f : A →ₐ[R] A') = ⊥ :=
+begin
+  rw ← le_bot_iff,
+  intros y hy,
+  obtain ⟨x, hx, rfl⟩ := mem_map.mp hy,
+  obtain ⟨x', rfl⟩ := algebra.mem_bot.mp hx,
+  erw [f.commutes, algebra.mem_bot],
+  exact ⟨x', rfl⟩
+end
+
+end subalgebra
+
+/-- Mapping an integral closure along an `alg_equiv` gives the integral closure. -/
+lemma integral_closure_map_alg_equiv
+  {R A A' : Type*} [comm_ring R] [comm_ring A] [comm_ring A'] [algebra R A] [algebra R A']
+  (f : A ≃ₐ[R] A') : (integral_closure R A).map (f : A →ₐ[R] A') = integral_closure R A' :=
+begin
+  ext y,
+  rw subalgebra.mem_map,
+  split,
+  { rintros ⟨x, hx, rfl⟩,
+    exact is_integral_alg_hom f hx },
+  { intro hy,
+    use [f.symm y, is_integral_alg_hom (f.symm : A' →ₐ[R] A) hy],
+    simp }
+end
+
+/-- The non-field, noetherian ring, dimension ≤ 1, integrally closed definition of Dedekind domain
+doesn't depend on the choice of fraction field. -/
+lemma is_dedekind_domain_iff [integral_domain R] [field K] (f : fraction_map R K) :
+  is_dedekind_domain R ↔
+    (¬ is_field R) ∧ is_noetherian_ring R ∧ dimension_le_one R ∧
+    integral_closure R f.codomain = ⊥ :=
+⟨λ ⟨hf, hr, hd, hi⟩, ⟨hf, hr, hd,
+  by rw [←integral_closure_map_alg_equiv (fraction_ring.alg_equiv_of_quotient f),
+         hi, subalgebra.bot_map_equiv]⟩,
+ λ ⟨hf, hr, hd, hi⟩, ⟨hf, hr, hd,
+  by rw [←integral_closure_map_alg_equiv (fraction_ring.alg_equiv_of_quotient f).symm,
+         hi, subalgebra.bot_map_equiv]⟩⟩
 
 /-- A Dedekind domain is a nonfield that is Noetherian, and the localization at every nonzero prime is a discrete valuation ring.
 This is equivalent to `is_dedekind_domain`.
 -/
-structure is_dedekind_domain_dvr [integral_domain R]: Prop :=
+structure is_dedekind_domain_dvr [integral_domain R] : Prop :=
 (not_is_field : ¬ is_field R)
 (is_noetherian_ring : is_noetherian_ring R)
 (is_dvr_at_nonzero_prime : ∀ P ≠ (⊥ : ideal R), P.is_prime →

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -6,7 +6,6 @@ Authors: Kenji Nakagawa, Anne Baanen, Filippo A. E. Nuccio
 import ring_theory.fractional_ideal
 import ring_theory.ideal.over
 import ring_theory.discrete_valuation_ring
-import order.zorn
 
 namespace ring
 

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -103,7 +103,24 @@ use `is_dedekind_domain_inv_iff` to prove `is_dedekind_domain_inv` for a given `
 This is equivalent to `is_dedekind_domain`.
 TODO: prove the equivalence.
 -/
--- TODO: choose that `f` is the fraction_map from `A` to `fraction_ring A` and show the independence of `f`
-structure is_dedekind_domain_inv (f : fraction_map A K) : Prop :=
-(not_is_field : ¬ is_field R)
-(mul_inv_cancel : ∀ I ≠ (⊥ : fractional_ideal f), I * I⁻¹ = 1)
+structure is_dedekind_domain_inv : Prop :=
+(not_is_field : ¬ is_field A)
+(mul_inv_cancel : ∀ I ≠ (⊥ : fractional_ideal (fraction_ring.of A)), I * I⁻¹ = 1)
+
+section
+
+open ring.fractional_ideal
+
+#check map_equiv
+
+lemma is_dedekind_domain_inv_iff (f : fraction_map A K) :
+  is_dedekind_domain_inv A ↔
+    (¬ is_field A) ∧ (∀ I ≠ (⊥ : fractional_ideal f), I * I⁻¹ = 1) :=
+begin
+  split; rintros ⟨hf, hi⟩; use hf; intros I hI,
+  { convert congr_arg (map_equiv (fraction_ring.alg_equiv_of_quotient f))
+      (hi (map_equiv (fraction_ring.alg_equiv_of_quotient f).symm I) _);
+      simp },
+end
+
+end

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -3,42 +3,64 @@ Copyright (c) 2020 Kenji Nakagawa. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenji Nakagawa, Anne Baanen, Filippo A. E. Nuccio
 -/
+import ring_theory.discrete_valuation_ring
 import ring_theory.fractional_ideal
 import ring_theory.ideal.over
-import ring_theory.discrete_valuation_ring
 
-namespace ring
+/-!
+# Dedekind domains
+
+This file defines the notion of a Dedekind domain (or Dedekind ring),
+giving three equivalent definitions (TODO: and shows that they are equivalent).
+
+## Main definitions
+
+ - `is_dedekind_domain` defines a Dedekind domain as a commutative ring that is not a field,
+   Noetherian, integrally closed in its field of fractions and has Krull dimension exactly one.
+   `is_dedekind_domain_iff` shows that this does not depend on the choice of field of fractions.
+
+TODO
+
+## Implementation notes
+
+The definitions that involve a field of fractions choose a canonical field of fractions,
+but are independent of that choice. The `..._iff` lemmas express this independence.
+-/
+
+variables (R A K : Type*) [comm_ring R] [integral_domain A] [field K]
 
 /-- A ring `R` has Krull dimension at most one if all nonzero prime ideals are maximal. -/
-def dimension_le_one (R : Type*) [comm_ring R] : Prop :=
+def ring.dimension_le_one : Prop :=
 ∀ p ≠ (⊥ : ideal R), p.is_prime → p.is_maximal
-
-end ring
 
 open ideal ring
 
-lemma is_principal_ideal_ring.dimension_le_one (R : Type*) [integral_domain R]
-  [is_principal_ideal_ring R] :
-  ring.dimension_le_one R :=
+lemma is_principal_ideal_ring.dimension_le_one
+  [is_principal_ideal_ring A] : ring.dimension_le_one A :=
 λ p nonzero prime, by { haveI := prime, exact is_prime.to_maximal_ideal nonzero }
 
-variables {R K : Type*}
-
-lemma integral_closure.dimension_le_one [comm_ring R] [nontrivial R] [integral_domain K] [algebra R K]
-  (h : dimension_le_one R) :
-  dimension_le_one (integral_closure R K) :=
+lemma integral_closure.dimension_le_one [nontrivial R] [algebra R A]
+  (h : dimension_le_one R) : dimension_le_one (integral_closure R A) :=
 begin
   intros p ne_bot prime,
   haveI := prime,
-  refine integral_closure.is_maximal_of_is_maximal_comap p (h _ (integral_closure.comap_ne_bot ne_bot) _),
+  refine integral_closure.is_maximal_of_is_maximal_comap p
+    (h _ (integral_closure.comap_ne_bot ne_bot) _),
   apply is_prime.comap
 end
 
-/-- A Dedekind domain is a nonfield that is Noetherian, integrally closed, and has Krull dimension exactly one (`not_is_field` and `dimension_le_one`).
+/--
+A Dedekind domain is a nonfield that is Noetherian, integrally closed, and
+has Krull dimension exactly one (`not_is_field` and `dimension_le_one`).
+
+The integral closure condition is independent of the choice of field of fractions:
+use `is_dedekind_domain_iff` to prove `is_dedekind_domain` for a given `fraction_map`.
+
 This is the default implementation, but there are equivalent definitions,
 `is_dedekind_domain_dvr` and `is_dedekind_domain_inv`.
 TODO: Prove that these are actually equivalent definitions.
 -/
+-- TODO: R should be a `comm_ring`
 class is_dedekind_domain (R : Type*) [integral_domain R] : Prop :=
 (not_is_field : ¬ is_field R)
 (is_noetherian_ring : is_noetherian_ring R)
@@ -47,10 +69,10 @@ class is_dedekind_domain (R : Type*) [integral_domain R] : Prop :=
 
 /-- The non-field, noetherian ring, dimension ≤ 1, integrally closed definition of Dedekind domain
 doesn't depend on the choice of fraction field. -/
-lemma is_dedekind_domain_iff [integral_domain R] [field K] (f : fraction_map R K) :
-  is_dedekind_domain R ↔
-    (¬ is_field R) ∧ is_noetherian_ring R ∧ dimension_le_one R ∧
-    integral_closure R f.codomain = ⊥ :=
+lemma is_dedekind_domain_iff (f : fraction_map A K) :
+  is_dedekind_domain A ↔
+    (¬ is_field A) ∧ is_noetherian_ring A ∧ dimension_le_one A ∧
+    integral_closure A f.codomain = ⊥ :=
 ⟨λ ⟨hf, hr, hd, hi⟩, ⟨hf, hr, hd,
   by rw [←integral_closure_map_alg_equiv (fraction_ring.alg_equiv_of_quotient f),
          hi, algebra.map_bot]⟩,
@@ -58,18 +80,30 @@ lemma is_dedekind_domain_iff [integral_domain R] [field K] (f : fraction_map R K
   by rw [←integral_closure_map_alg_equiv (fraction_ring.alg_equiv_of_quotient f).symm,
          hi, algebra.map_bot]⟩⟩
 
-/-- A Dedekind domain is a nonfield that is Noetherian, and the localization at every nonzero prime is a discrete valuation ring.
-This is equivalent to `is_dedekind_domain`.
--/
-structure is_dedekind_domain_dvr [integral_domain R] : Prop :=
-(not_is_field : ¬ is_field R)
-(is_noetherian_ring : is_noetherian_ring R)
-(is_dvr_at_nonzero_prime : ∀ P ≠ (⊥ : ideal R), P.is_prime →
-  @discrete_valuation_ring (localization.at_prime P) (by {exact localization_map.integral_domain_of_local_at_prime a}))
+/--
+A Dedekind domain is a nonfield that is Noetherian, and the localization at
+every nonzero prime is a discrete valuation ring.
 
-/-- A dedekind domain is a nonfield such that every fractional ideal has an inverse.
-This is equivalent to `is_dedekind_domain`
+This is equivalent to `is_dedekind_domain`.
+TODO: prove the equivalence.
 -/
-structure is_dedekind_domain_inv [integral_domain R] [comm_ring K] (f : fraction_map R K) : Prop :=
+structure is_dedekind_domain_dvr : Prop :=
+(not_is_field : ¬ is_field A)
+(is_noetherian_ring : is_noetherian_ring A)
+(is_dvr_at_nonzero_prime : ∀ P ≠ (⊥ : ideal A), P.is_prime →
+  discrete_valuation_ring (localization.at_prime P))
+
+/--
+A Dedekind domain is a nonfield such that every fractional ideal has an inverse.
+
+TODO:
+The fractional ideals are independent of the choice of field of fractions:
+use `is_dedekind_domain_inv_iff` to prove `is_dedekind_domain_inv` for a given `fraction_map`.
+
+This is equivalent to `is_dedekind_domain`.
+TODO: prove the equivalence.
+-/
+-- TODO: choose that `f` is the fraction_map from `A` to `fraction_ring A` and show the independence of `f`
+structure is_dedekind_domain_inv (f : fraction_map A K) : Prop :=
 (not_is_field : ¬ is_field R)
-(is_invertible_ideal : ∀ I : ring.fractional_ideal f, ⊥ < I → (∃ J : ring.fractional_ideal f, I * J = 1))
+(mul_inv_cancel : ∀ I ≠ (⊥ : fractional_ideal f), I * I⁻¹ = 1)

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -1,0 +1,44 @@
+import ring_theory.fractional_ideal
+import ring_theory.ideal.over
+import ring_theory.discrete_valuation_ring
+import tactic
+
+/-- A ring `R` is (at most) one-dimensional if all nonzero prime ideals are maximal. -/
+def ring.is_one_dimensional (R : Type*) [comm_ring R] :=
+∀ p ≠ (⊥ : ideal R), p.is_prime → p.is_maximal
+
+open ideal ring
+
+lemma principal_ideal_ring.is_one_dimensional (R : Type*) [integral_domain R]
+  [is_principal_ideal_ring R] :
+  ring.is_one_dimensional R :=
+λ p nonzero prime, by { haveI := prime, exact is_prime.to_maximal_ideal nonzero }
+
+variables {R K : Type*}
+
+lemma integral_closure.is_one_dimensional [comm_ring R] [nontrivial R] [integral_domain K] [algebra R K]
+  (h : is_one_dimensional R) :
+  is_one_dimensional (integral_closure R K) :=
+begin
+  intros p ne_bot prime,
+  haveI := prime,
+  refine integral_closure.is_maximal_of_is_maximal_comap p (h _ (integral_closure.comap_ne_bot ne_bot) _),
+  apply is_prime.comap
+end
+
+/--Noetherian, integrally closed, Krull dimension 1-/
+class is_dedekind_domain [comm_ring R] [comm_ring K] (f : fraction_map R K) :=
+  (is_non_field : ∃(I : ideal R), ⊥ < I ∧ I < ⊤)
+  (is_noetherian_ring : is_noetherian_ring R)
+  (is_one_dimensional : is_one_dimensional R)
+  (is_integrally_closed : integral_closure R f.codomain = ⊥)
+/--Noetherian, localization at every maximal prime is a discrete valuation ring-/
+class is_dedekind_domain_dvr [integral_domain R]: Prop :=
+  (is_non_field : ∃(I : ideal R), ⊥ < I ∧ I < ⊤)
+  (is_noetherian_ring : is_noetherian_ring R)
+  (is_dvr_at_nonzero_prime : ∀ P ≠ (⊥ : ideal R), P.is_prime →
+    @discrete_valuation_ring (localization.at_prime P) (by {exact localization_map.integral_domain_of_local_at_prime a}))
+/--Every fractional ideal has an inverse-/
+class is_dedekind_domain_inv [integral_domain R] [comm_ring K] (f : fraction_map R K) : Prop :=
+  (is_non_field : ∃(I : ideal R), ⊥ < I ∧ I < ⊤)
+  (is_invertible_ideal : ∀ I : ring.fractional_ideal f, ⊥ < I → (∃ J : ring.fractional_ideal f, I * J = 1))

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -1,7 +1,6 @@
 import ring_theory.fractional_ideal
 import ring_theory.ideal.over
 import ring_theory.discrete_valuation_ring
-import tactic
 
 /-- A ring `R` is (at most) one-dimensional if all nonzero prime ideals are maximal. -/
 def ring.is_one_dimensional (R : Type*) [comm_ring R] :=

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -9,7 +9,7 @@ namespace ring
 def dimension_le_one (R : Type*) [comm_ring R] : Prop :=
 ∀ p ≠ (⊥ : ideal R), p.is_prime → p.is_maximal
 
-variables {R : Type*} [comm_ring R]
+end ring
 
 open ideal ring
 

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2020 Kenji Nakagawa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenji Nakagawa, Anne Baanen, Filippo A. E. Nuccio
+-/
 import ring_theory.fractional_ideal
 import ring_theory.ideal.over
 import ring_theory.discrete_valuation_ring
@@ -5,7 +10,7 @@ import order.zorn
 
 namespace ring
 
-/-- A ring `R` is at most one-dimensional if all nonzero prime ideals are maximal. -/
+/-- A ring `R` has Krull dimension at most one if all nonzero prime ideals are maximal. -/
 def dimension_le_one (R : Type*) [comm_ring R] : Prop :=
 ∀ p ≠ (⊥ : ideal R), p.is_prime → p.is_maximal
 
@@ -30,8 +35,8 @@ begin
   apply is_prime.comap
 end
 
-/-- A Dedekind domain is a nonfield is Noetherian, integrally closed, and has Krull dimension exactly one.
-This is the default implementation, but there are equivalent definitions, which are
+/-- A Dedekind domain is a nonfield that is Noetherian, integrally closed, and has Krull dimension exactly one (`not_is_field` and `dimension_le_one`).
+This is the default implementation, but there are equivalent definitions,
 `is_dedekind_domain_dvr` and `is_dedekind_domain_inv`.
 TODO: Prove that these are actually equivalent definitions.
 -/

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -41,23 +41,23 @@ This is the default implementation, but there are equivalent definitions,
 TODO: Prove that these are actually equivalent definitions.
 -/
 class is_dedekind_domain [comm_ring R] [comm_ring K] (f : fraction_map R K) :=
-  (not_is_field : ¬ is_field R)
-  (is_noetherian_ring : is_noetherian_ring R)
-  (dimension_le_one : dimension_le_one R)
-  (is_integrally_closed : integral_closure R f.codomain = ⊥)
+(not_is_field : ¬ is_field R)
+(is_noetherian_ring : is_noetherian_ring R)
+(dimension_le_one : dimension_le_one R)
+(is_integrally_closed : integral_closure R f.codomain = ⊥)
 
 /-- A Dedekind domain is a nonfield that is Noetherian, and the localization at every nonzero prime is a discrete valuation ring.
 This is equivalent to `is_dedekind_domain`.
 -/
 structure is_dedekind_domain_dvr [integral_domain R]: Prop :=
-  (not_is_field : ¬ is_field R)
-  (is_noetherian_ring : is_noetherian_ring R)
-  (is_dvr_at_nonzero_prime : ∀ P ≠ (⊥ : ideal R), P.is_prime →
-    @discrete_valuation_ring (localization.at_prime P) (by {exact localization_map.integral_domain_of_local_at_prime a}))
+(not_is_field : ¬ is_field R)
+(is_noetherian_ring : is_noetherian_ring R)
+(is_dvr_at_nonzero_prime : ∀ P ≠ (⊥ : ideal R), P.is_prime →
+  @discrete_valuation_ring (localization.at_prime P) (by {exact localization_map.integral_domain_of_local_at_prime a}))
 
 /-- A dedekind domain is a nonfield such that every fractional ideal has an inverse.
 This is equivalent to `is_dedekind_domain`
 -/
 structure is_dedekind_domain_inv [integral_domain R] [comm_ring K] (f : fraction_map R K) : Prop :=
-  (not_is_field : ¬ is_field R)
-  (is_invertible_ideal : ∀ I : ring.fractional_ideal f, ⊥ < I → (∃ J : ring.fractional_ideal f, I * J = 1))
+(not_is_field : ¬ is_field R)
+(is_invertible_ideal : ∀ I : ring.fractional_ideal f, ⊥ < I → (∃ J : ring.fractional_ideal f, I * J = 1))

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -1,23 +1,67 @@
 import ring_theory.fractional_ideal
 import ring_theory.ideal.over
 import ring_theory.discrete_valuation_ring
+import order.zorn
 
-/-- A ring `R` is (at most) one-dimensional if all nonzero prime ideals are maximal. -/
-def ring.is_one_dimensional (R : Type*) [comm_ring R] :=
+namespace ring
+
+/-- A ring `R` is at most one-dimensional if all nonzero prime ideals are maximal. -/
+def dimension_le_one (R : Type*) [comm_ring R] : Prop :=
 ∀ p ≠ (⊥ : ideal R), p.is_prime → p.is_maximal
+
+variables {R : Type*} [comm_ring R]
+
+lemma not_is_field_of_subsingleton {R : Type*} [ring R] [subsingleton R] : ¬ is_field R :=
+λ ⟨⟨x, y, hxy⟩, _, _⟩, hxy (subsingleton.elim x y)
+
+lemma exists_not_is_unit_of_not_is_field [nontrivial R] (hf : ¬ is_field R) :
+  ∃ x ≠ (0 : R), ¬ is_unit x :=
+begin
+  have : ¬ _ := λ h, hf ⟨exists_pair_ne R, mul_comm, h⟩,
+  simp_rw is_unit_iff_exists_inv,
+  push_neg at ⊢ this,
+  obtain ⟨x, hx, not_unit⟩ := this,
+  exact ⟨x, hx, not_unit⟩
+end
+
+lemma not_is_field_iff_exists_ideal_bot_lt_and_lt_top [nontrivial R] :
+  ¬ is_field R ↔ ∃ I : ideal R, ⊥ < I ∧ I < ⊤ :=
+begin
+  split,
+  { intro h,
+    obtain ⟨x, nz, nu⟩ := exists_not_is_unit_of_not_is_field h,
+    use ideal.span {x},
+    rw [bot_lt_iff_ne_bot, lt_top_iff_ne_top],
+    exact ⟨mt ideal.span_singleton_eq_bot.mp nz, mt ideal.span_singleton_eq_top.mp nu⟩ },
+  { rintros ⟨I, bot_lt, lt_top⟩ hf,
+    obtain ⟨x, mem, ne_zero⟩ := submodule.exists_of_lt bot_lt,
+    rw submodule.mem_bot at ne_zero,
+    obtain ⟨y, hy⟩ := hf.mul_inv_cancel ne_zero,
+    rw [lt_top_iff_ne_top, ne.def, ideal.eq_top_iff_one, ← hy] at lt_top,
+    exact lt_top (ideal.mul_mem_right _ mem), }
+end
+
+lemma not_is_field_iff_exists_ideal_ne_bot_and_is_prime [nontrivial R] :
+  ¬ is_field R ↔ ∃ p : ideal R, p ≠ ⊥ ∧ p.is_prime :=
+not_is_field_iff_exists_ideal_bot_lt_and_lt_top.trans
+  ⟨λ ⟨I, bot_lt, lt_top⟩, let ⟨p, hp, le_p⟩ := I.exists_le_maximal (lt_top_iff_ne_top.mp lt_top) in
+    ⟨p, bot_lt_iff_ne_bot.mp (lt_of_lt_of_le bot_lt le_p), hp.is_prime⟩,
+   λ ⟨p, ne_bot, prime⟩, ⟨p, bot_lt_iff_ne_bot.mpr ne_bot, lt_top_iff_ne_top.mpr prime.1⟩⟩
+
+end ring
 
 open ideal ring
 
-lemma principal_ideal_ring.is_one_dimensional (R : Type*) [integral_domain R]
+lemma is_principal_ideal_ring.dimension_le_one (R : Type*) [integral_domain R]
   [is_principal_ideal_ring R] :
-  ring.is_one_dimensional R :=
+  ring.dimension_le_one R :=
 λ p nonzero prime, by { haveI := prime, exact is_prime.to_maximal_ideal nonzero }
 
 variables {R K : Type*}
 
-lemma integral_closure.is_one_dimensional [comm_ring R] [nontrivial R] [integral_domain K] [algebra R K]
-  (h : is_one_dimensional R) :
-  is_one_dimensional (integral_closure R K) :=
+lemma integral_closure.dimension_le_one [comm_ring R] [nontrivial R] [integral_domain K] [algebra R K]
+  (h : dimension_le_one R) :
+  dimension_le_one (integral_closure R K) :=
 begin
   intros p ne_bot prime,
   haveI := prime,
@@ -27,17 +71,17 @@ end
 
 /--Noetherian, integrally closed, Krull dimension 1-/
 class is_dedekind_domain [comm_ring R] [comm_ring K] (f : fraction_map R K) :=
-  (is_non_field : ∃(I : ideal R), ⊥ < I ∧ I < ⊤)
+  (not_is_field : ¬ is_field R)
   (is_noetherian_ring : is_noetherian_ring R)
-  (is_one_dimensional : is_one_dimensional R)
+  (dimension_le_one : dimension_le_one R)
   (is_integrally_closed : integral_closure R f.codomain = ⊥)
 /--Noetherian, localization at every maximal prime is a discrete valuation ring-/
 class is_dedekind_domain_dvr [integral_domain R]: Prop :=
-  (is_non_field : ∃(I : ideal R), ⊥ < I ∧ I < ⊤)
+  (not_is_field : ¬ is_field R)
   (is_noetherian_ring : is_noetherian_ring R)
   (is_dvr_at_nonzero_prime : ∀ P ≠ (⊥ : ideal R), P.is_prime →
     @discrete_valuation_ring (localization.at_prime P) (by {exact localization_map.integral_domain_of_local_at_prime a}))
 /--Every fractional ideal has an inverse-/
 class is_dedekind_domain_inv [integral_domain R] [comm_ring K] (f : fraction_map R K) : Prop :=
-  (is_non_field : ∃(I : ideal R), ⊥ < I ∧ I < ⊤)
+  (not_is_field : ¬ is_field R)
   (is_invertible_ideal : ∀ I : ring.fractional_ideal f, ⊥ < I → (∃ J : ring.fractional_ideal f, I * J = 1))

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -28,6 +28,15 @@ giving three equivalent definitions (TODO: and shows that they are equivalent).
 
 The definitions that involve a field of fractions choose a canonical field of fractions,
 but are independent of that choice. The `..._iff` lemmas express this independence.
+
+## References
+
+* [D. Marcus, *Number Fields*][marcus1977number]
+* [J.W.S. Cassels, A. Frölich, *Algebraic Number Theory*][cassels1967algebraic]
+
+## Tags
+
+dedekind domain, dedekind ring
 -/
 
 variables (R A K : Type*) [comm_ring R] [integral_domain A] [field K]
@@ -64,11 +73,11 @@ This is the default implementation, but there are equivalent definitions,
 TODO: Prove that these are actually equivalent definitions.
 -/
 -- TODO: R should be a `comm_ring`
-class is_dedekind_domain (R : Type*) [integral_domain R] : Prop :=
-(not_is_field : ¬ is_field R)
-(is_noetherian_ring : is_noetherian_ring R)
-(dimension_le_one : dimension_le_one R)
-(is_integrally_closed : integral_closure R (fraction_ring R) = ⊥)
+class is_dedekind_domain : Prop :=
+(not_is_field : ¬ is_field A)
+(is_noetherian_ring : is_noetherian_ring A)
+(dimension_le_one : dimension_le_one A)
+(is_integrally_closed : integral_closure A (fraction_ring A) = ⊥)
 
 /-- The non-field, noetherian ring, dimension ≤ 1, integrally closed definition of Dedekind domain
 doesn't depend on the choice of fraction field. -/

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -96,10 +96,6 @@ structure is_dedekind_domain_dvr : Prop :=
 /--
 A Dedekind domain is a nonfield such that every fractional ideal has an inverse.
 
-TODO:
-The fractional ideals are independent of the choice of field of fractions:
-use `is_dedekind_domain_inv_iff` to prove `is_dedekind_domain_inv` for a given `fraction_map`.
-
 This is equivalent to `is_dedekind_domain`.
 TODO: prove the equivalence.
 -/
@@ -111,16 +107,19 @@ section
 
 open ring.fractional_ideal
 
-#check map_equiv
-
 lemma is_dedekind_domain_inv_iff (f : fraction_map A K) :
   is_dedekind_domain_inv A ↔
     (¬ is_field A) ∧ (∀ I ≠ (⊥ : fractional_ideal f), I * I⁻¹ = 1) :=
 begin
   split; rintros ⟨hf, hi⟩; use hf; intros I hI,
-  { convert congr_arg (map_equiv (fraction_ring.alg_equiv_of_quotient f))
-      (hi (map_equiv (fraction_ring.alg_equiv_of_quotient f).symm I) _);
-      simp },
+  { have := hi (map (fraction_ring.alg_equiv_of_quotient f).symm.to_alg_hom I) (map_ne_zero _ hI),
+    erw [← map_inv, ← fractional_ideal.map_mul] at this,
+    convert congr_arg (map (fraction_ring.alg_equiv_of_quotient f).to_alg_hom) this;
+      simp only [alg_equiv.to_alg_hom_eq_coe, map_symm_map, map_one] },
+  { have := hi (map (fraction_ring.alg_equiv_of_quotient f).to_alg_hom I) (map_ne_zero _ hI),
+    erw [← map_inv, ← fractional_ideal.map_mul] at this,
+    convert congr_arg (map (fraction_ring.alg_equiv_of_quotient f).symm.to_alg_hom) this;
+      simp only [alg_equiv.to_alg_hom_eq_coe, map_map_symm, map_one] }
 end
 
 end

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -18,8 +18,11 @@ giving three equivalent definitions (TODO: and shows that they are equivalent).
  - `is_dedekind_domain` defines a Dedekind domain as a commutative ring that is not a field,
    Noetherian, integrally closed in its field of fractions and has Krull dimension exactly one.
    `is_dedekind_domain_iff` shows that this does not depend on the choice of field of fractions.
-
-TODO
+ - `is_dedekind_domain_dvr` alternatively defines a Dedekind domain as an integral domain that is not a field,
+   Noetherian, and the localization at every nonzero prime ideal is a discrete valuation ring.
+ - `is_dedekind_domain_inv` alternatively defines a Dedekind domain as an integral domain that is not a field,
+   and every nonzero fractional ideal is invertible.
+ - `is_dedekind_domain_inv_iff` shows that this does note depend on the choice of field of fractions.
 
 ## Implementation notes
 

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -75,7 +75,6 @@ This is the default implementation, but there are equivalent definitions,
 `is_dedekind_domain_dvr` and `is_dedekind_domain_inv`.
 TODO: Prove that these are actually equivalent definitions.
 -/
--- TODO: R should be a `comm_ring`
 class is_dedekind_domain : Prop :=
 (not_is_field : ¬ is_field A)
 (is_noetherian_ring : is_noetherian_ring A)

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -47,11 +47,13 @@ def ring.dimension_le_one : Prop :=
 
 open ideal ring
 
-lemma is_principal_ideal_ring.dimension_le_one
-  [is_principal_ideal_ring A] : ring.dimension_le_one A :=
+namespace ring
+
+lemma dimension_le_one.principal_ideal_ring
+  [is_principal_ideal_ring A] : dimension_le_one A :=
 λ p nonzero prime, by { haveI := prime, exact is_prime.to_maximal_ideal nonzero }
 
-lemma integral_closure.dimension_le_one [nontrivial R] [algebra R A]
+lemma dimension_le_one.integral_closure [nontrivial R] [algebra R A]
   (h : dimension_le_one R) : dimension_le_one (integral_closure R A) :=
 begin
   intros p ne_bot prime,
@@ -60,6 +62,7 @@ begin
     (h _ (integral_closure.comap_ne_bot ne_bot) _),
   apply is_prime.comap
 end
+end ring
 
 /--
 A Dedekind domain is an integral domain that is Noetherian, integrally closed, and

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -62,7 +62,7 @@ begin
 end
 
 /--
-A Dedekind domain is a nonfield that is Noetherian, integrally closed, and
+A Dedekind domain is an integral domain that is Noetherian, integrally closed, and
 has Krull dimension exactly one (`not_is_field` and `dimension_le_one`).
 
 The integral closure condition is independent of the choice of field of fractions:
@@ -79,8 +79,9 @@ class is_dedekind_domain : Prop :=
 (dimension_le_one : dimension_le_one A)
 (is_integrally_closed : integral_closure A (fraction_ring A) = ⊥)
 
-/-- The non-field, noetherian ring, dimension ≤ 1, integrally closed definition of Dedekind domain
-doesn't depend on the choice of fraction field. -/
+/-- An integral domain is a Dedekind domain iff and only if it is not a field, is Noetherian, has dimension ≤ 1,
+and is integrally closed in a given fraction field.
+In particular, this definition does not depend on the choice of this fraction field. -/
 lemma is_dedekind_domain_iff (f : fraction_map A K) :
   is_dedekind_domain A ↔
     (¬ is_field A) ∧ is_noetherian_ring A ∧ dimension_le_one A ∧
@@ -93,7 +94,7 @@ lemma is_dedekind_domain_iff (f : fraction_map A K) :
          hi, algebra.map_bot]⟩⟩
 
 /--
-A Dedekind domain is a nonfield that is Noetherian, and the localization at
+A Dedekind domain is an integral domain that is not a field, is Noetherian, and the localization at
 every nonzero prime is a discrete valuation ring.
 
 This is equivalent to `is_dedekind_domain`.
@@ -106,7 +107,7 @@ structure is_dedekind_domain_dvr : Prop :=
   discrete_valuation_ring (localization.at_prime P))
 
 /--
-A Dedekind domain is a nonfield such that every fractional ideal has an inverse.
+A Dedekind domain is an integral domain that is not a field such that every fractional ideal has an inverse.
 
 This is equivalent to `is_dedekind_domain`.
 TODO: prove the equivalence.

--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -372,6 +372,22 @@ ext (submodule.map_id I.1)
   (I : fractional_ideal f) : I.map (g'.comp g) = (I.map g).map g' :=
 ext (submodule.map_comp g.to_linear_map g'.to_linear_map I.1)
 
+@[simp] lemma map_coe_ideal (I : ideal R) (g : f.codomain →ₐ[R] f'.codomain) :
+  (I : fractional_ideal f).map g = I :=
+begin
+  ext x,
+  simp only [coe_coe_ideal, mem_coe_submodule],
+  split,
+  { rintro ⟨_, ⟨y, hy, rfl⟩, rfl⟩,
+    exact ⟨y, hy, (g.commutes y).symm⟩ },
+  { rintro ⟨y, hy, rfl⟩,
+    exact ⟨_, ⟨y, hy, rfl⟩, g.commutes y⟩ },
+end
+
+@[simp] lemma map_one (g : f.codomain →ₐ[R] f'.codomain) :
+  (1 : fractional_ideal f).map g = 1 :=
+map_coe_ideal 1 g
+
 @[simp] lemma map_add (I J : fractional_ideal f) (g : f.codomain →ₐ[R] f'.codomain) :
   (I + J).map g = I.map g + J.map g :=
 ext (submodule.map_sup _ _ _)
@@ -379,6 +395,14 @@ ext (submodule.map_sup _ _ _)
 @[simp] lemma map_mul (I J : fractional_ideal f) (g : f.codomain →ₐ[R] f'.codomain) :
   (I * J).map g = I.map g * J.map g :=
 ext (submodule.map_mul _ _ _)
+
+@[simp] lemma map_map_symm (I : fractional_ideal f) (g : f.codomain ≃ₐ[R] f'.codomain) :
+  (I.map (g : f.codomain →ₐ[R] f'.codomain)).map (g.symm : f'.codomain →ₐ[R] f.codomain) = I :=
+by rw [←map_comp, g.symm_comp, map_id]
+
+@[simp] lemma map_symm_map (I : fractional_ideal f') (g : f.codomain ≃ₐ[R] f'.codomain) :
+  (I.map (g.symm : f'.codomain →ₐ[R] f.codomain)).map (g : f.codomain →ₐ[R] f'.codomain) = I :=
+by rw [←map_comp, g.comp_symm, map_id]
 
 /-- If `g` is an equivalence, `map g` is an isomorphism -/
 def map_equiv (g : f.codomain ≃ₐ[R] f'.codomain) :
@@ -459,6 +483,8 @@ noncomputable instance fractional_ideal_has_div :
 
 noncomputable instance : has_inv (fractional_ideal g) := ⟨λ I, 1 / I⟩
 
+lemma inv_eq {I : fractional_ideal g} : I⁻¹ = 1 / I := rfl
+
 lemma div_nonzero {I J : fractional_ideal g} (h : J ≠ 0) :
   (I / J) = ⟨I.1 / J.1, fractional_div_of_nonzero h⟩ :=
 dif_neg h
@@ -514,6 +540,18 @@ end
 theorem mul_inv_cancel_iff {I : fractional_ideal g} :
   I * I⁻¹ = 1 ↔ ∃ J, I * J = 1 :=
 ⟨λ h, ⟨I⁻¹, h⟩, λ ⟨J, hJ⟩, by rwa [←right_inverse_eq I J hJ]⟩
+
+variables {K' : Type*} [field K'] {g' : fraction_map R K'}
+
+#check submodule.has_div
+
+@[simp] lemma map_div (I J : fractional_ideal g) (h : g.codomain →ₐ[R] g'.codomain) :
+  (I / J).map h = I.map h / J.map h :=
+ext submodule.map_div
+
+@[simp] lemma map_inv (I : fractional_ideal g) (h : g.codomain →ₐ[R] g'.codomain) :
+  (I⁻¹).map h = (I.map h)⁻¹ :=
+by rw [inv_eq, map_div, map_one, inv_eq]
 
 end quotient
 

--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -467,7 +467,6 @@ lemma inv_nonzero {I : fractional_ideal g} (h : I ≠ 0) :
   I⁻¹ = ⟨(1 : fractional_ideal g) / I, fractional_div_of_nonzero h⟩ :=
 div_nonzero h
 
--- set_option pp.all true
 lemma coe_inv_of_nonzero {I : fractional_ideal g} (h : I ≠ 0) :
   (↑(I⁻¹) : submodule R g.codomain) = g.coe_submodule 1 / I :=
 by { rw inv_nonzero h, refl }

--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -97,6 +97,9 @@ instance : has_coe (fractional_ideal f) (submodule R f.codomain) := ⟨λ I, I.v
 
 @[simp] lemma val_eq_coe (I : fractional_ideal f) : I.val = I := rfl
 
+@[simp] lemma coe_mk (I : submodule R f.codomain) (hI : is_fractional f I) :
+  (subtype.mk I hI : submodule R f.codomain) = I := rfl
+
 instance : has_mem P (fractional_ideal f) := ⟨λ x I, x ∈ (I : submodule R f.codomain)⟩
 
 /-- Fractional ideals are equal if their submodules are equal.
@@ -364,15 +367,20 @@ def map (g : f.codomain →ₐ[R] f'.codomain) :
 @[simp] lemma coe_map (g : f.codomain →ₐ[R] f'.codomain) (I : fractional_ideal f) :
   ↑(map g I) = submodule.map g.to_linear_map I := rfl
 
-@[simp] lemma map_id (I : fractional_ideal f) : I.map (alg_hom.id _ _) = I :=
+@[simp] lemma mem_map {I : fractional_ideal f} {g : f.codomain →ₐ[R] f'.codomain}
+  {y : f'.codomain} : y ∈ I.map g ↔ ∃ x, x ∈ I ∧ g x = y :=
+submodule.mem_map
+
+variables (I J : fractional_ideal f) (g : f.codomain →ₐ[R] f'.codomain)
+
+@[simp] lemma map_id : I.map (alg_hom.id _ _) = I :=
 ext (submodule.map_id I.1)
 
-@[simp] lemma map_comp
-  (g : f.codomain →ₐ[R] f'.codomain) (g' : f'.codomain →ₐ[R] f''.codomain)
-  (I : fractional_ideal f) : I.map (g'.comp g) = (I.map g).map g' :=
+@[simp] lemma map_comp (g' : f'.codomain →ₐ[R] f''.codomain) :
+  I.map (g'.comp g) = (I.map g).map g' :=
 ext (submodule.map_comp g.to_linear_map g'.to_linear_map I.1)
 
-@[simp] lemma map_coe_ideal (I : ideal R) (g : f.codomain →ₐ[R] f'.codomain) :
+@[simp] lemma map_coe_ideal (I : ideal R) :
   (I : fractional_ideal f).map g = I :=
 begin
   ext x,
@@ -384,19 +392,21 @@ begin
     exact ⟨_, ⟨y, hy, rfl⟩, g.commutes y⟩ },
 end
 
-@[simp] lemma map_one (g : f.codomain →ₐ[R] f'.codomain) :
-  (1 : fractional_ideal f).map g = 1 :=
-map_coe_ideal 1 g
+@[simp] lemma map_one :
+(1 : fractional_ideal f).map g = 1 :=
+map_coe_ideal g 1
 
-@[simp] lemma map_add (I J : fractional_ideal f) (g : f.codomain →ₐ[R] f'.codomain) :
-  (I + J).map g = I.map g + J.map g :=
+@[simp] lemma map_zero :
+  (0 : fractional_ideal f).map g = 0 :=
+map_coe_ideal g 0
+
+@[simp] lemma map_add : (I + J).map g = I.map g + J.map g :=
 ext (submodule.map_sup _ _ _)
 
-@[simp] lemma map_mul (I J : fractional_ideal f) (g : f.codomain →ₐ[R] f'.codomain) :
-  (I * J).map g = I.map g * J.map g :=
+@[simp] lemma map_mul : (I * J).map g = I.map g * J.map g :=
 ext (submodule.map_mul _ _ _)
 
-@[simp] lemma map_map_symm (I : fractional_ideal f) (g : f.codomain ≃ₐ[R] f'.codomain) :
+@[simp] lemma map_map_symm (g : f.codomain ≃ₐ[R] f'.codomain) :
   (I.map (g : f.codomain →ₐ[R] f'.codomain)).map (g.symm : f'.codomain →ₐ[R] f.codomain) = I :=
 by rw [←map_comp, g.symm_comp, map_id]
 
@@ -414,7 +424,7 @@ def map_equiv (g : f.codomain ≃ₐ[R] f'.codomain) :
   left_inv := λ I, by { rw [←map_comp, alg_equiv.symm_comp, map_id] },
   right_inv := λ I, by { rw [←map_comp, alg_equiv.comp_symm, map_id] } }
 
-@[simp] lemma map_equiv_apply (g : f.codomain ≃ₐ[R] f'.codomain) (I : fractional_ideal f) :
+@[simp] lemma map_equiv_apply (g : f.codomain ≃ₐ[R] f'.codomain) :
   map_equiv g I = map ↑g I := rfl
 
 @[simp] lemma map_equiv_refl :
@@ -431,6 +441,46 @@ map_equiv
       (by rw [ring_equiv.to_monoid_hom_refl, submonoid.map_id]) }
 
 end semiring
+
+section fraction_map
+
+/-!
+### `fraction_map` section
+
+This section concerns fractional ideals in the field of fractions,
+i.e. the type `fractional_ideal g` when `g` is a `fraction_map R K`.
+-/
+
+variables {K K' : Type*} [field K] [field K'] {g : fraction_map R K} {g' : fraction_map R K'}
+variables {I J : fractional_ideal g} (h : g.codomain →ₐ[R] g'.codomain)
+
+/-- Nonzero fractional ideals contain a nonzero integer. -/
+lemma exists_ne_zero_mem_is_integer (hI : I ≠ 0) :
+  ∃ x ≠ (0 : R), g.to_map x ∈ I :=
+begin
+  obtain ⟨y, y_mem, y_not_mem⟩ := submodule.exists_of_lt (bot_lt_iff_ne_bot.mpr hI),
+  have y_ne_zero : y ≠ 0 := by simpa using y_not_mem,
+  obtain ⟨z, ⟨x, hx⟩⟩ := g.exists_integer_multiple y,
+  refine ⟨x, _, _⟩,
+  { rw [ne.def, ← g.to_map_eq_zero_iff, hx],
+    exact mul_ne_zero (g.to_map_ne_zero_of_mem_non_zero_divisors _) y_ne_zero },
+  { rw hx,
+    exact smul_mem _ _ y_mem }
+end
+
+@[simp] lemma map_ne_zero (hI : I ≠ 0) : I.map h ≠ 0 :=
+begin
+  obtain ⟨x, x_ne_zero, hx⟩ := exists_ne_zero_mem_is_integer hI,
+  contrapose! x_ne_zero with map_eq_zero,
+  refine g'.to_map_eq_zero_iff.mp (eq_zero_iff.mp map_eq_zero _ (mem_map.mpr _)),
+  exact ⟨g.to_map x, hx, h.commutes x⟩,
+end
+
+@[simp] lemma map_eq_zero_iff : I.map h = 0 ↔ I = 0 :=
+⟨imp_of_not_imp_not _ _ (map_ne_zero _),
+ λ hI, hI.symm ▸ map_zero h⟩
+
+end fraction_map
 
 section quotient
 
@@ -485,9 +535,16 @@ noncomputable instance : has_inv (fractional_ideal g) := ⟨λ I, 1 / I⟩
 
 lemma inv_eq {I : fractional_ideal g} : I⁻¹ = 1 / I := rfl
 
+@[simp] lemma div_zero {I : fractional_ideal g} :
+  I / 0 = 0 :=
+dif_pos rfl
+
 lemma div_nonzero {I J : fractional_ideal g} (h : J ≠ 0) :
   (I / J) = ⟨I.1 / J.1, fractional_div_of_nonzero h⟩ :=
 dif_neg h
+
+lemma inv_zero : (0 : fractional_ideal g)⁻¹ = 0 :=
+div_zero
 
 lemma inv_nonzero {I : fractional_ideal g} (h : I ≠ 0) :
   I⁻¹ = ⟨(1 : fractional_ideal g) / I, fractional_div_of_nonzero h⟩ :=
@@ -543,14 +600,17 @@ theorem mul_inv_cancel_iff {I : fractional_ideal g} :
 
 variables {K' : Type*} [field K'] {g' : fraction_map R K'}
 
-#check submodule.has_div
+@[simp] lemma map_div (I J : fractional_ideal g) (h : g.codomain ≃ₐ[R] g'.codomain) :
+  (I / J).map (h : g.codomain →ₐ[R] g'.codomain) = I.map h / J.map h :=
+begin
+  by_cases H : J = 0,
+  { rw [H, div_zero, map_zero, div_zero] },
+  { ext x,
+    simp [div_nonzero H, div_nonzero (map_ne_zero _ H), submodule.map_div] }
+end
 
-@[simp] lemma map_div (I J : fractional_ideal g) (h : g.codomain →ₐ[R] g'.codomain) :
-  (I / J).map h = I.map h / J.map h :=
-ext submodule.map_div
-
-@[simp] lemma map_inv (I : fractional_ideal g) (h : g.codomain →ₐ[R] g'.codomain) :
-  (I⁻¹).map h = (I.map h)⁻¹ :=
+@[simp] lemma map_inv (I : fractional_ideal g) (h : g.codomain ≃ₐ[R] g'.codomain) :
+  (I⁻¹).map (h : g.codomain →ₐ[R] g'.codomain) = (I.map h)⁻¹ :=
 by rw [inv_eq, map_div, map_one, inv_eq]
 
 end quotient

--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -468,7 +468,7 @@ begin
     exact smul_mem _ _ y_mem }
 end
 
-@[simp] lemma map_ne_zero (hI : I ≠ 0) : I.map h ≠ 0 :=
+lemma map_ne_zero (hI : I ≠ 0) : I.map h ≠ 0 :=
 begin
   obtain ⟨x, x_ne_zero, hx⟩ := exists_ne_zero_mem_is_integer hI,
   contrapose! x_ne_zero with map_eq_zero,

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -446,6 +446,42 @@ lemma bot_is_maximal {K : Type u} [field K] : is_maximal (⊥ : ideal K) :=
 ⟨λ h, absurd ((eq_top_iff_one (⊤ : ideal K)).mp rfl) (by rw ← h; simp),
 λ I hI, or_iff_not_imp_left.mp (eq_bot_or_top I) (ne_of_gt hI)⟩
 
+/-- Maximal ideals in a non-field are nontrivial. -/
+variables {R : Type u} [comm_ring R]
+lemma maximal_gt_bot {M : ideal R} (hm : M.is_maximal) (non_field : ∃(I : ideal R), ⊥ < I ∧ I < ⊤) : ⊥ < M :=
+begin
+  split,
+  simp only [le_eq_subset, submodule.mem_coe, zero_subset, singleton_zero, submodule.bot_coe, submodule.zero_mem],
+  intro mle,
+  have : M = ⊥,
+  { have h1 : M ≤ ⊥ := by assumption,
+    have h2 : ⊥ ≤ M := by simp only [bot_le],
+    exact le_antisymm h1 h2, },
+  unfold ideal.is_maximal at hm,
+  rcases hm with ⟨ne_top, h1⟩,
+  contrapose! h1,
+  rcases non_field with ⟨I, ibot, itop⟩,
+  use I, rw this at *,
+  split, assumption,
+  rcases itop with ⟨-, itop⟩,
+  contrapose! itop,
+  rw itop,
+  exact le_refl ⊤,
+end
+
+lemma exists_prime_ne_bot [nontrivial R] (non_field : ∃(I : ideal R), ⊥ < I ∧ I < ⊤) : ∃(P : ideal R), P.is_prime ∧ ⊥ < P ∧ P < ⊤ :=
+begin
+  cases @exists_maximal R _ _ with P hp,
+  use P,
+  split,
+  exact is_maximal.is_prime hp,
+  split,
+  refine maximal_gt_bot hp non_field,
+  unfold is_maximal at hp,
+  rcases hp with ⟨ne_top, pkey⟩,
+  exact lt_top_iff_ne_top.mpr ne_top,
+end
+
 section pi
 variables (ι : Type v)
 

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -469,17 +469,13 @@ begin
   exact le_refl ⊤,
 end
 
-lemma exists_prime_ne_bot [nontrivial R] (non_field : ∃(I : ideal R), ⊥ < I ∧ I < ⊤) : ∃(P : ideal R), P.is_prime ∧ ⊥ < P ∧ P < ⊤ :=
+lemma exists_prime_gt_bot [nontrivial R] (non_field : ∃(I : ideal R), ⊥ < I ∧ I < ⊤) : ∃(P : ideal R), P.is_prime ∧ ⊥ < P :=
 begin
   cases @exists_maximal R _ _ with P hp,
   use P,
   split,
-  exact is_maximal.is_prime hp,
-  split,
-  refine maximal_gt_bot hp non_field,
-  unfold is_maximal at hp,
-  rcases hp with ⟨ne_top, pkey⟩,
-  exact lt_top_iff_ne_top.mpr ne_top,
+  { exact is_maximal.is_prime hp, },
+  { refine maximal_gt_bot hp non_field, }
 end
 
 section pi

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -566,17 +566,14 @@ namespace ideal
 variables {R : Type u} [comm_ring R] [nontrivial R]
 lemma bot_lt_of_maximal (M : ideal R) [hm : M.is_maximal] (non_field : ¬ is_field R) : ⊥ < M :=
 begin
-  rw ring.not_is_field_iff_exists_ideal_bot_lt_and_lt_top at non_field,
+  rcases (ring.not_is_field_iff_exists_ideal_bot_lt_and_lt_top.1 non_field)
+    with ⟨I, Ibot, Itop⟩,
   split, finish,
   intro mle,
-  have : M = ⊥ := by exact eq_bot_iff.mpr mle,
+  apply @irrefl _ (<) _ (⊤ : ideal R),
+  have : M = ⊥ := eq_bot_iff.mpr mle,
   rw this at *,
-  unfold ideal.is_maximal at hm,
-  rcases hm with ⟨ne_top, h1⟩,
-  rcases non_field with ⟨I, ibot, itop⟩,
-  have h2 := h1 I ibot,
-  rw h2 at itop,
-  exact irrefl ⊤ itop,
+  rwa hm.2 I Ibot at Itop,
 end
 
 end ideal

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -551,7 +551,7 @@ begin
     exact lt_top (ideal.mul_mem_right _ mem), }
 end
 
-lemma not_is_field_iff_exists_ideal_ne_bot_and_is_prime [nontrivial R] :
+lemma not_is_field_iff_exists_prime [nontrivial R] :
   ¬ is_field R ↔ ∃ p : ideal R, p ≠ ⊥ ∧ p.is_prime :=
 not_is_field_iff_exists_ideal_bot_lt_and_lt_top.trans
   ⟨λ ⟨I, bot_lt, lt_top⟩, let ⟨p, hp, le_p⟩ := I.exists_le_maximal (lt_top_iff_ne_top.mp lt_top) in

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -292,11 +292,11 @@ theorem span_mul_span (S T : set R) : span S * span T =
 submodule.span_smul_span S T
 variables {I J K}
 
-lemma span_mul_span' (T S : set R) : span T * span S = span (T*S) :=
+lemma span_mul_span' (S T : set R) : span S * span T = span (S*T) :=
 by { unfold span, rw submodule.span_mul_span,}
 
-lemma mul_span_singleton (r s : R) : span{r} * span{s} = (span{r * s} : ideal R) :=
-by { rw [span_mul_span', set.singleton_mul_singleton],}
+lemma span_singleton_mul_span_singleton (r s : R) : span {r} * span {s} = (span {r * s} : ideal R) :=
+by { unfold span, rw [submodule.span_mul_span, set.singleton_mul_singleton],}
 
 theorem mul_le_inf : I * J ≤ I ⊓ J :=
 mul_le.2 $ λ r hri s hsj, ⟨I.mul_mem_right hri, J.mul_mem_left hsj⟩

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -292,6 +292,12 @@ theorem span_mul_span (S T : set R) : span S * span T =
 submodule.span_smul_span S T
 variables {I J K}
 
+lemma span_mul_span' (T S : set R) : span T * span S = span (T*S) :=
+by { unfold span, rw submodule.span_mul_span,}
+
+lemma mul_span_singleton (r s : R) : ideal.span{r} * ideal.span{s} = (ideal.span{r * s} : ideal R) :=
+by { rw [span_mul_span', set.singleton_mul_singleton],}
+
 theorem mul_le_inf : I * J ≤ I ⊓ J :=
 mul_le.2 $ λ r hri s hsj, ⟨I.mul_mem_right hri, J.mul_mem_left hsj⟩
 

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -295,7 +295,7 @@ variables {I J K}
 lemma span_mul_span' (T S : set R) : span T * span S = span (T*S) :=
 by { unfold span, rw submodule.span_mul_span,}
 
-lemma mul_span_singleton (r s : R) : ideal.span{r} * ideal.span{s} = (ideal.span{r * s} : ideal R) :=
+lemma mul_span_singleton (r s : R) : span{r} * span{s} = (span{r * s} : ideal R) :=
 by { rw [span_mul_span', set.singleton_mul_singleton],}
 
 theorem mul_le_inf : I * J ≤ I ⊓ J :=

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -254,6 +254,20 @@ theorem mem_integral_closure_iff_mem_fg {r : A} :
 
 variables {R} {A}
 
+/-- Mapping an integral closure along an `alg_equiv` gives the integral closure. -/
+lemma integral_closure_map_alg_equiv (f : A ≃ₐ[R] B) :
+  (integral_closure R A).map (f : A →ₐ[R] B) = integral_closure R B :=
+begin
+  ext y,
+  rw subalgebra.mem_map,
+  split,
+  { rintros ⟨x, hx, rfl⟩,
+    exact is_integral_alg_hom f hx },
+  { intro hy,
+    use [f.symm y, is_integral_alg_hom (f.symm : B →ₐ[R] A) hy],
+    simp }
+end
+
 lemma integral_closure.is_integral (x : integral_closure R A) : is_integral R x :=
 let ⟨p, hpm, hpx⟩ := x.2 in ⟨p, hpm, subtype.eq $
 by rwa [subtype.val_eq_coe, ← subalgebra.val_apply, aeval_alg_hom_apply] at hpx⟩

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -959,7 +959,31 @@ lemma map_smul (x : f.codomain) (z : R) :
 show f.map hy k (f.to_map z * x) = k.to_map (g z) * f.map hy k x,
 by rw [ring_hom.map_mul, map_eq]
 
+end localization_map
+
+namespace localization
+
+variables (f : localization_map M S)
+
+/-- Given a localization map `f : R →+* S` for a submonoid `M`, we get an `R`-preserving
+isomorphism between the localization of `R` at `M` as a quotient type and `S`. -/
+noncomputable def alg_equiv_of_quotient : localization M ≃ₐ[R] f.codomain :=
+{ commutes' := ring_equiv_of_quotient_of,
+  ..ring_equiv_of_quotient f }
+
+lemma alg_equiv_of_quotient_apply (x : localization M) :
+alg_equiv_of_quotient f x = ring_equiv_of_quotient f x := rfl
+
+lemma alg_equiv_of_quotient_symm_apply (x : f.codomain) :
+  (alg_equiv_of_quotient f).symm x = (ring_equiv_of_quotient f).symm x := rfl
+
+end localization
+
+namespace localization_map
+
 section integer_normalization
+
+variables {f : localization_map M S}
 
 open finsupp polynomial
 open_locale classical
@@ -1441,10 +1465,10 @@ noncomputable instance : field (fraction_ring A) :=
 by erw [localization.mk_eq_mk', (of A).mk'_eq_div]
 
 /-- Given an integral domain `A` and a localization map to a field of fractions
-`f : A →+* K`, we get an isomorphism between the field of fractions of `A` as a quotient
+`f : A →+* K`, we get an `A`-isomorphism between the field of fractions of `A` as a quotient
 type and `K`. -/
-noncomputable def field_equiv_of_quotient {K : Type*} [field K] (f : fraction_map A K) :
-  fraction_ring A ≃+* K :=
-localization.ring_equiv_of_quotient f
+noncomputable def alg_equiv_of_quotient {K : Type*} [field K] (f : fraction_map A K) :
+  fraction_ring A ≃ₐ[A] f.codomain :=
+localization.alg_equiv_of_quotient f
 
 end fraction_ring

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -1448,12 +1448,12 @@ variables (A)
 /-- The fraction field of an integral domain as a quotient type. -/
 @[reducible] def fraction_ring := localization (non_zero_divisors A)
 
+namespace fraction_ring
+
 /-- Natural hom sending `x : A`, `A` an integral domain, to the equivalence class of
 `(x, 1)` in the field of fractions of `A`. -/
 def of : fraction_map A (localization (non_zero_divisors A)) :=
 localization.of (non_zero_divisors A)
-
-namespace fraction_ring
 
 variables {A}
 


### PR DESCRIPTION
Defines `is_dedekind_domain` in three variants:

1.  `is_dedekind_domain`: Noetherian, Integrally closed, Krull dimension 1, thanks to @Vierkantor 
2. `is_dedekind_domain_dvr`: Noetherian, localization at every nonzero prime is a DVR
3. `is_dedekind_domain_inv`: Every nonzero ideal is invertible.

TODO: prove that these definitions are equivalent.

This PR also includes some misc. lemmas required to show the definitions are independent of choice of fraction field.

Co-Authored-By: mushokunosora <knaka3435@gmail.com>
Co-Authored-By: faenuccio <filippo.nuccio@univ-st-etienne.fr>
Co-Authored-By: Vierkantor <vierkantor@vierkantor.com>

---
