### PR TITLE
[Merged by Bors] - chore(algebraic_geometry/Spec): reduce imports

### DIFF
--- a/src/algebra/category/Group/limits.lean
+++ b/src/algebra/category/Group/limits.lean
@@ -6,10 +6,7 @@ Authors: Scott Morrison
 import algebra.category.Mon.limits
 import algebra.category.Group.preadditive
 import category_theory.over
-import category_theory.limits.types
-import category_theory.limits.preserves.basic
 import category_theory.limits.shapes.concrete_category
-import algebra.group.pi
 
 /-!
 # The category of (commutative) (additive) groups has all limits

--- a/src/algebraic_geometry/Scheme.lean
+++ b/src/algebraic_geometry/Scheme.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import algebraic_geometry.locally_ringed_space
 import algebraic_geometry.Spec
 
 /-!

--- a/src/algebraic_geometry/locally_ringed_space.lean
+++ b/src/algebraic_geometry/locally_ringed_space.lean
@@ -5,7 +5,8 @@ Authors: Johan Commelin
 -/
 
 import algebraic_geometry.sheafed_space
-import algebra.category.CommRing
+import algebra.category.CommRing.limits
+import algebra.category.CommRing.colimits
 import algebraic_geometry.stalks
 import ring_theory.ideal.basic
 

--- a/src/algebraic_geometry/sheafed_space.lean
+++ b/src/algebraic_geometry/sheafed_space.lean
@@ -5,7 +5,6 @@ Authors: Scott Morrison
 -/
 import algebraic_geometry.presheafed_space
 import topology.sheaves.sheaf
-import category_theory.full_subcategory
 
 /-!
 # Sheafed spaces

--- a/src/algebraic_geometry/structure_sheaf.lean
+++ b/src/algebraic_geometry/structure_sheaf.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Scott Morrison
 -/
 import algebraic_geometry.prime_spectrum
-import algebra.category.CommRing
+import algebra.category.CommRing.limits
 import topology.sheaves.local_predicate
 import topology.sheaves.forget
 import ring_theory.localization

--- a/src/category_theory/full_subcategory.lean
+++ b/src/category_theory/full_subcategory.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Reid Barton
 -/
-import category_theory.fully_faithful
 import category_theory.groupoid
 
 namespace category_theory

--- a/src/category_theory/limits/types.lean
+++ b/src/category_theory/limits/types.lean
@@ -5,7 +5,6 @@ Authors: Scott Morrison, Reid Barton
 -/
 import category_theory.limits.shapes.images
 import category_theory.filtered
-import data.quot
 import tactic.equiv_rw
 
 universes u

--- a/src/ring_theory/adjoin.lean
+++ b/src/ring_theory/adjoin.lean
@@ -3,8 +3,7 @@ Copyright (c) 2019 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
-import ring_theory.polynomial
-import ring_theory.principal_ideal_domain
+import ring_theory.polynomial.basic
 
 /-!
 # Adjoining elements to form subalgebras

--- a/src/ring_theory/algebraic.lean
+++ b/src/ring_theory/algebraic.lean
@@ -6,7 +6,6 @@ Authors: Johan Commelin
 
 import linear_algebra.finite_dimensional
 import ring_theory.integral_closure
-import data.polynomial.field_division
 import data.polynomial.integral_normalization
 
 /-!

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -5,11 +5,8 @@ Authors: Kenny Lau, Mario Carneiro, Johan Commelin, Amelia Livingston
 -/
 
 import data.equiv.ring
-import tactic.ring_exp
-import ring_theory.ideal.operations
 import group_theory.monoid_localization
 import ring_theory.algebraic
-import ring_theory.integral_closure
 
 /-!
 # Localizations of commutative rings

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -5,7 +5,6 @@ Authors: Johannes Hölzl, Mario Carneiro, Jeremy Avigad
 -/
 import order.filter.ultrafilter
 import order.filter.partial
-import order.filter.bases
 
 /-!
 # Basic theory of topological spaces.
@@ -578,7 +577,7 @@ assume a s hs, mem_pure_sets.2 $ mem_of_nhds hs
 
 lemma tendsto_pure_nhds {α : Type*} [topological_space β] (f : α → β) (a : α) :
   tendsto f (pure a) (𝓝 (f a)) :=
-(tendsto_pure_pure f a).mono_right (pure_le_nhds _) 
+(tendsto_pure_pure f a).mono_right (pure_le_nhds _)
 
 lemma order_top.tendsto_at_top_nhds {α : Type*} [order_top α] [topological_space β] (f : α → β) :
   tendsto f at_top (𝓝 $ f ⊤) :=

--- a/src/topology/category/TopCommRing.lean
+++ b/src/topology/category/TopCommRing.lean
@@ -5,7 +5,7 @@ Authors: Scott Morrison
 -/
 import algebra.category.CommRing.basic
 import topology.category.Top.basic
-import topology.instances.complex
+import topology.algebra.ring
 
 universes u
 
@@ -40,10 +40,6 @@ instance : concrete_category TopCommRing.{u} :=
 
 /-- Construct a bundled `TopCommRing` from the underlying type and the appropriate typeclasses. -/
 def of (X : Type u) [comm_ring X] [topological_space X] [topological_ring X] : TopCommRing := ⟨X⟩
-
-noncomputable example : TopCommRing := TopCommRing.of ℚ
-noncomputable example : TopCommRing := TopCommRing.of ℝ
-noncomputable example : TopCommRing := TopCommRing.of ℂ
 
 @[simp] lemma coe_of (X : Type u) [comm_ring X] [topological_space X] [topological_ring X] :
   (of X : Type u) = X := rfl

--- a/src/topology/local_homeomorph.lean
+++ b/src/topology/local_homeomorph.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
 import data.equiv.local_equiv
-import topology.homeomorph
 import topology.opens
 
 /-!

--- a/src/topology/sheaves/presheaf_of_functions.lean
+++ b/src/topology/sheaves/presheaf_of_functions.lean
@@ -21,7 +21,8 @@ We construct some simple examples of presheaves of functions on a topological sp
 * `presheaf_To_TopCommRing X R`, where `R : TopCommRing`
   is the presheaf valued in `CommRing` of functions functions into a topological ring `R`
 * as an example of the previous construction,
-  `presheaf_ℂ X` is the presheaf of rings of continuous complex-valued functions on `X`.
+  `presheaf_to_TopCommRing X (TopCommRing.of ℂ)`
+  is the presheaf of rings of continuous complex-valued functions on `X`.
 -/
 
 universes v u
@@ -121,18 +122,18 @@ def CommRing_yoneda : TopCommRing.{u} ⥤ (Top.{u}ᵒᵖ ⥤ CommRing.{u}) :=
   map := λ R S φ,
   { app := λ X, continuous_functions.map X φ } }
 
-/-- The presheaf (of commutative rings), consisting of functions on an open set `U ⊆ X` with
-values in some topological commutative ring `T`. -/
+/--
+The presheaf (of commutative rings), consisting of functions on an open set `U ⊆ X` with
+values in some topological commutative ring `T`.
+
+For example, we could construct the presheaf of continuous complex valued functions of `X` as
+```
+presheaf_to_TopCommRing X (TopCommRing.of ℂ)
+```
+(this requires `import topology.instances.complex`).
+-/
 def presheaf_to_TopCommRing (T : TopCommRing.{v}) :
   X.presheaf CommRing.{v} :=
 (opens.to_Top X).op ⋙ (CommRing_yoneda.obj T)
-
-/-- The presheaf (of commutative rings) of real valued functions. -/
-noncomputable def presheaf_ℝ (Y : Top) : Y.presheaf CommRing :=
-presheaf_to_TopCommRing Y (TopCommRing.of ℝ)
-
-/-- The presheaf (of commutative rings) of complex valued functions. -/
-noncomputable def presheaf_ℂ (Y : Top) : Y.presheaf CommRing :=
-presheaf_to_TopCommRing Y (TopCommRing.of ℂ)
 
 end Top

--- a/src/topology/sheaves/sheaf.lean
+++ b/src/topology/sheaves/sheaf.lean
@@ -7,7 +7,6 @@ import topology.sheaves.presheaf
 import category_theory.limits.punit
 import category_theory.limits.shapes.products
 import category_theory.limits.shapes.equalizers
-import category_theory.full_subcategory
 
 /-!
 # Sheaves


### PR DESCRIPTION
The main change is to remove some `example`s from `topology.category.TopCommRing`, so that we don't need to know about the real and complex numbers on the way to defining a `Scheme`.

While I was staring at `leanproject import-graph --to algebraic_geometry.Scheme`, I also removed a bunch of redundant or unused imports elsewhere.

---
<!-- put comments you want to keep out of the PR commit here -->
