### PR TITLE
[Merged by Bors] - feat(slim_check/errors): improve error messages and add useful instances

### DIFF
--- a/src/tactic/slim_check.lean
+++ b/src/tactic/slim_check.lean
@@ -192,7 +192,9 @@ What to do:
 3. make sure that instances of `testable` exist that, when combined, apply to your decorated proposition:
 ```
 {tgt'}
-```",
+```
+
+Use `set_option trace.class_instances true` to understand what instances are missing.",
   e ← mk_mapp ``testable.check [tgt, `(cfg), tgt', inst],
   when_tracing `slim_check.decoration trace!"[testable decoration]\n  {tgt'}",
   when_tracing `slim_check.instance   $ do

--- a/src/tactic/slim_check.lean
+++ b/src/tactic/slim_check.lean
@@ -52,18 +52,18 @@ h : ∃ (x : ℕ) (H : x ∈ xs), x < 3
 The local constants are reverted and an instance is found for
 `testable (∀ (xs : list ℕ), (∃ x ∈ xs, x < 3) → (∀ y ∈ xs, y < 5))`.
 The `testable` instance is supported by instances of `sampleable (list ℕ)`,
-`decidable (x < 3)` and `decidable (y < 5)`. `slim_check` builds a 
+`decidable (x < 3)` and `decidable (y < 5)`. `slim_check` builds a
 `testable` instance step by step with:
 
 ```
-- testable (∀ (xs : list ℕ), (∃ x ∈ xs, x < 3) → (∀ y ∈ xs, y < 5)) 
+- testable (∀ (xs : list ℕ), (∃ x ∈ xs, x < 3) → (∀ y ∈ xs, y < 5))
                                      -: sampleable (list xs)
 - testable ((∃ x ∈ xs, x < 3) → (∀ y ∈ xs, y < 5))
 - testable (∀ x ∈ xs, x < 3 → (∀ y ∈ xs, y < 5))
 - testable (x < 3 → (∀ y ∈ xs, y < 5))
-                                     -: decidable (x < 3) 
+                                     -: decidable (x < 3)
 - testable (∀ y ∈ xs, y < 5)
-                                     -: decidable (y < 5) 
+                                     -: decidable (y < 5)
 ```
 
 `sampleable (list ℕ)` lets us create random data of type `list ℕ` in a way that
@@ -71,7 +71,7 @@ helps find small counter-examples.  Next, the test of the proposition
 hinges on `x < 3` and `y < 5` to both be decidable. The
 implication between the two could be tested as a whole but it would be
 less informative. Indeed, if we generate lists that only contain numbers
-greater than `3`, the implication will always trivially hold but we should 
+greater than `3`, the implication will always trivially hold but we should
 conclude that we haven't found meaningful examples. Instead, when `x < 3`
 does not hold, we reject the example (i.e.  we do not count it toward
 the 100 required positive examples) and we start over. Therefore, when
@@ -184,8 +184,16 @@ meta def slim_check (cfg : slim_check_cfg := {}) : tactic unit := do
 { tgt ← retrieve $ tactic.revert_all >> target,
   let tgt' := tactic.add_decorations tgt,
   let cfg := { cfg with enable_tracing := cfg.enable_tracing || is_trace_enabled_for `slim_check.discared },
-  e ← mk_mapp ``testable.check [tgt, `(cfg), tgt', none],
-  `(@testable.check _ _ _ %%inst) ← pure e,
+  inst ← mk_app ``testable [tgt'] >>= mk_instance <|>
+    fail!"Failed to create a `testable` instance for `{tgt}`.
+What to do:
+1. make sure that the types you are using have `sampleable` instances (you can use `#sample my_type` if you are unsure);
+2. make sure that the relations and predicates that your proposition use are decidable;
+3. make sure that instances of `testable` exist that, when combined, apply to your decorated proposition:
+```
+{tgt'}
+```",
+  e ← mk_mapp ``testable.check [tgt, `(cfg), tgt', inst],
   when_tracing `slim_check.decoration trace!"[testable decoration]\n  {tgt'}",
   when_tracing `slim_check.instance   $ do
   { inst ← summarize_instance inst >>= pp,

--- a/src/testing/slim_check/testable.lean
+++ b/src/testing/slim_check/testable.lean
@@ -317,6 +317,12 @@ instance or_testable (p q : Prop) [testable p] [testable q] :
      pure $ or_counter_example xp xq
    end ⟩
 
+instance iff_testable (p q : Prop) [testable ((p ∧ q) ∨ (¬ p ∧ ¬ q))] :
+  testable (p ↔ q) :=
+⟨ λ tracing min, do
+   xp ← testable.run ((p ∧ q) ∨ (¬ p ∧ ¬ q)) tracing min,
+   return $ convert_counter_example' (by tauto!) xp ⟩
+
 @[priority 1000]
 instance imp_dec_testable (p : Prop) [decidable p] (β : p → Prop)
   [∀ h, testable (β h)] : testable (named_binder var $ Π h, β h) :=


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->

A fix for #4021. This improves `slim_check`'s error messages to help understand failures. It also adds useful instances.

Examples from #4021:

```lean

example (l : list (fin 3)): l.sum < 10 :=
begin
  slim_check
-- ===================
-- Found problems!

-- l := [1]
-- -------------------
end

example (l : list (fin 3)): l.sum > 10 :=
begin
  slim_check
-- ===================
-- Found problems!

-- l := [0]
-- -------------------
end

example (l : list (fin 3)): ↑l.sum < 10 :=
begin
  slim_check
-- ===================
-- Found problems!

-- l := [0]
-- -------------------
end

example (l : list (fin 3)): ↑l.sum > 10 :=
begin
  slim_check
-- ===================
-- Found problems!

-- l := []
-- -------------------
end

example (l : list (fin 3)): (l.map coe).sum < 10 :=
begin
  slim_check
-- ===================
-- Found problems!

-- l := [1, 2, 1, 2, 1, 1, 2]
-- -------------------
end

example (l : list (fin 3)): (l.map coe).sum > 10 :=
begin
  slim_check
-- ===================
-- Found problems!

-- l := [0]
-- -------------------
end

local attribute [-instance] slim_check.sampleable_fin slim_check.sampleable_fin'

#sample (fin 3)
-- tactic.mk_instance failed to generate instance for
--   slim_check.sampleable (fin 3)

example (l : list (fin 3)): ↑l.sum < 10 :=
begin
  slim_check
-- Failed to create a `testable` instance for `∀ (l : list (fin 3)), ↑(l.sum) < 10`.
-- What to do:
-- 1. make sure that the types you are using have `sampleable` instances (you can use `#sample my_type` if you are unsure);
-- 2. make sure that the relations and predicates that your proposition use are decidable;
-- 3. make sure that instances of `testable` exist that, when combined, apply to your decorated proposition:
-- ```
-- slim_check.named_binder "l" (∀ (l : list (fin 3)), ↑(l.sum) < 10)
-- ```
end

example (l : list bool) : l = [] :=
begin
  slim_check
-- ===================
-- Found problems!

-- l := [tt]
-- -------------------
end
```

The last one didn't produce an unreachable code error. @robertylewis can you check if it happens with this patch as well?
