### PR TITLE
fix(tactic/resolve_constant): add a version that handles `parameters`

### DIFF
--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -456,6 +456,19 @@ do cxt ← list.map expr.to_implicit_local_const <$> local_context,
    add_decl $ declaration.defn n univ t' d' (reducibility_hints.regular 1 tt) trusted,
    applyc n
 
+/-- Replacement for `resolve_constant`. `resolve_constant` crashes
+when called on a name defined within a section that also uses `parameters`.
+This version handles can be used in all the same definitions as `resolve_constant`
+plus those declared within the scope of `parameters`. -/
+meta def resolve_constant' (n : name) : tactic name :=
+do e ← resolve_name n,
+   match e with
+   | expr.const n _ := pure n
+   | _ := do
+     e ← to_expr e,
+     pure $ e.get_app_fn.const_name
+   end
+
 /-- Attempts to close the goal with `dec_trivial`. -/
 meta def exact_dec_trivial : tactic unit := `[exact dec_trivial]
 

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -465,7 +465,7 @@ do e ← resolve_name n,
    match e with
    | expr.const n _ := pure n
    | _ := do
-     e ← to_expr e,
+     e ← to_expr e tt ff,
      pure $ e.get_app_fn.const_name
    end
 

--- a/src/tactic/ext.lean
+++ b/src/tactic/ext.lean
@@ -41,7 +41,7 @@ meta def derive_struct_ext_lemma (n : name) : tactic name :=
 do e ← get_env,
    fs ← e.structure_fields n,
    d ← get_decl n,
-   n ← resolve_constant n,
+   n ← resolve_constant' n,
    let r := @expr.const tt n $ d.univ_params.map level.param,
    (args,_) ← infer_type r >>= open_pis,
    let args := args.map expr.to_implicit_local_const,
@@ -143,7 +143,7 @@ do v₀ ← mk_mvar,
 do u ← mk_meta_univ,
    pure $ expr.sort u
 | n :=
-do e ← resolve_constant n >>= mk_const,
+do e ← resolve_constant' n >>= mk_const,
    a ← get_arity e,
    e.mk_app <$> (list.iota a).mmap (λ _, mk_mvar)
 

--- a/test/ext.lean
+++ b/test/ext.lean
@@ -123,3 +123,15 @@ begin
 end
 
 @[ext] structure dumb (V : Type) := (val : V)
+
+section param
+
+parameters x y : ℤ
+
+@[ext]
+lemma my_ext (s s' : set ℤ) (h : x ∈ s ↔ y ∈ s') : s = s' := sorry
+
+-- this is what used to cause it to fail
+-- run_cmd tactic.resolve_constant `my_ext
+
+end param

--- a/test/ext.lean
+++ b/test/ext.lean
@@ -127,9 +127,10 @@ end
 section param
 
 parameters x y : ℤ
+variable [fact false] -- we work in an inconsistent context below
 
 @[ext]
-lemma my_ext (s s' : set ℤ) (h : x ∈ s ↔ y ∈ s') : s = s' := sorry
+lemma my_ext (s s' : set ℤ) (h : x ∈ s ↔ y ∈ s') : s = s' := false.elim _inst_1
 
 -- this is what used to cause it to fail
 -- run_cmd tactic.resolve_constant `my_ext


### PR DESCRIPTION
This PR fixes the following issue:

```lean

import tactic.ext
section

parameters (A : Type)

def tuple (a : A) : Type := sorry

@[ext] theorem tuple.ext {a} {t₁ t₂ : tuple a} : t₁ = t₂ := sorry
-- match failed

end
```

Because `tuple` is defined in the scope of a `parameters` clause, `resolve_constant` crashes. `resolve_constant'` was defined to remedy the situation.

For reference: https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Function.20on.20equal.20types/near/208905177

---
<!-- put comments you want to keep out of the PR commit here -->