### PR TITLE
[Merged by Bors] - feat(category_theory/limits/fubini): another formulation for limits commuting

### DIFF
--- a/src/category_theory/limits/fubini.lean
+++ b/src/category_theory/limits/fubini.lean
@@ -210,6 +210,8 @@ end
 
 section
 variables (G : J × K ⥤ C)
+
+section
 variables [has_limits_of_shape K C]
 variables [has_limit G]
 variables [has_limit ((curry.obj G) ⋙ lim)]
@@ -229,7 +231,7 @@ begin
   exact limit_uncurry_iso_limit_comp_lim ((@curry J _ K _ C _).obj G),
 end
 
-@[simp]
+@[simp,reassoc]
 lemma limit_iso_limit_curry_comp_lim_hom_π_π {j} {k} :
   (limit_iso_limit_curry_comp_lim G).hom ≫ limit.π _ j ≫ limit.π _ k = limit.π _ (j, k) :=
 begin
@@ -238,12 +240,57 @@ begin
   simp, dsimp, simp, -- See note [dsimp, simp].
 end
 
-@[simp]
+@[simp,reassoc]
 lemma limit_iso_limit_curry_comp_lim_inv_π {j} {k} :
   (limit_iso_limit_curry_comp_lim G).inv ≫ limit.π _ (j, k) = limit.π _ j ≫ limit.π _ k :=
 begin
   rw [←cancel_epi (limit_iso_limit_curry_comp_lim G).hom],
   simp,
+end
+end
+
+
+section
+variables [has_limits C] -- Certainly one could weaken the hypotheses here.
+
+open category_theory.prod
+
+/--
+A variant of the Fubini theorem for a functor `G : J × K ⥤ C`,
+showing that $\lim_k \lim_j G(j,k) ≅ \lim_j \lim_k G(j,k)$.
+-/
+def limit_curry_swap_comp_lim_iso_limit_curry_comp_lim :
+  limit ((curry.obj (swap K J ⋙ G)) ⋙ lim) ≅ limit ((curry.obj G) ⋙ lim) :=
+calc
+  limit ((curry.obj (swap K J ⋙ G)) ⋙ lim)
+      ≅ limit (swap K J ⋙ G) : (limit_iso_limit_curry_comp_lim _).symm
+  ... ≅ limit G : has_limit.iso_of_equivalence (braiding K J) (iso.refl _)
+  ... ≅ limit ((curry.obj G) ⋙ lim) : limit_iso_limit_curry_comp_lim _
+
+@[simp]
+lemma limit_curry_swap_comp_lim_iso_limit_curry_comp_lim_hom_π_π {j} {k} :
+  (limit_curry_swap_comp_lim_iso_limit_curry_comp_lim G).hom ≫ limit.π _ j ≫ limit.π _ k =
+   limit.π _ k ≫ limit.π _ j :=
+begin
+  dsimp [limit_curry_swap_comp_lim_iso_limit_curry_comp_lim],
+  simp only [iso.refl_hom, braiding_counit_iso_hom_app, limits.has_limit.iso_of_equivalence_hom_π,
+    iso.refl_inv, limit_iso_limit_curry_comp_lim_hom_π_π, eq_to_iso_refl, category.assoc],
+  erw [nat_trans.id_app], -- Why can't `simp` do this`?
+  dsimp, simp,
+end
+
+@[simp]
+lemma limit_curry_swap_comp_lim_iso_limit_curry_comp_lim_inv_π_π {j} {k} :
+  (limit_curry_swap_comp_lim_iso_limit_curry_comp_lim G).inv ≫ limit.π _ k ≫ limit.π _ j =
+   limit.π _ j ≫ limit.π _ k :=
+begin
+  dsimp [limit_curry_swap_comp_lim_iso_limit_curry_comp_lim],
+  simp only [iso.refl_hom, braiding_counit_iso_hom_app, limits.has_limit.iso_of_equivalence_inv_π,
+    iso.refl_inv, limit_iso_limit_curry_comp_lim_hom_π_π, eq_to_iso_refl, category.assoc],
+  erw [nat_trans.id_app], -- Why can't `simp` do this`?
+  dsimp, simp,
+end
+
 end
 
 end

--- a/src/category_theory/limits/limits.lean
+++ b/src/category_theory/limits/limits.lean
@@ -862,10 +862,21 @@ def has_limit.iso_of_equivalence {F : J ⥤ C} [has_limit F] {G : K ⥤ C} [has_
 is_limit.cone_points_iso_of_equivalence (limit.is_limit F) (limit.is_limit G) e w
 
 @[simp]
-lemma has_limit.iso_of_equivalence_π {F : J ⥤ C} [has_limit F] {G : K ⥤ C} [has_limit G]
+lemma has_limit.iso_of_equivalence_hom_π {F : J ⥤ C} [has_limit F] {G : K ⥤ C} [has_limit G]
    (e : J ≌ K) (w : e.functor ⋙ G ≅ F) (k : K) :
   (has_limit.iso_of_equivalence e w).hom ≫ limit.π G k =
     limit.π F (e.inverse.obj k) ≫ w.inv.app (e.inverse.obj k) ≫ G.map (e.counit.app k) :=
+begin
+  simp [has_limit.iso_of_equivalence, is_limit.cone_points_iso_of_equivalence_hom],
+  dsimp,
+  simp,
+end
+
+@[simp]
+lemma has_limit.iso_of_equivalence_inv_π {F : J ⥤ C} [has_limit F] {G : K ⥤ C} [has_limit G]
+   (e : J ≌ K) (w : e.functor ⋙ G ≅ F) (j : J) :
+  (has_limit.iso_of_equivalence e w).inv ≫ limit.π F j =
+    limit.π G (e.functor.obj j) ≫ w.hom.app j :=
 begin
   simp [has_limit.iso_of_equivalence, is_limit.cone_points_iso_of_equivalence_hom],
   dsimp,
@@ -1226,10 +1237,21 @@ def has_colimit.iso_of_equivalence {F : J ⥤ C} [has_colimit F] {G : K ⥤ C} [
 is_colimit.cocone_points_iso_of_equivalence (colimit.is_colimit F) (colimit.is_colimit G) e w
 
 @[simp]
-lemma has_colimit.iso_of_equivalence_π {F : J ⥤ C} [has_colimit F] {G : K ⥤ C} [has_colimit G]
+lemma has_colimit.iso_of_equivalence_hom_π {F : J ⥤ C} [has_colimit F] {G : K ⥤ C} [has_colimit G]
    (e : J ≌ K) (w : e.functor ⋙ G ≅ F) (j : J) :
   colimit.ι F j ≫ (has_colimit.iso_of_equivalence e w).hom =
      F.map (e.unit.app j) ≫ w.inv.app _ ≫ colimit.ι G _ :=
+begin
+  simp [has_colimit.iso_of_equivalence, is_colimit.cocone_points_iso_of_equivalence_inv],
+  dsimp,
+  simp,
+end
+
+@[simp]
+lemma has_colimit.iso_of_equivalence_inv_π {F : J ⥤ C} [has_colimit F] {G : K ⥤ C} [has_colimit G]
+   (e : J ≌ K) (w : e.functor ⋙ G ≅ F) (k : K) :
+  colimit.ι G k ≫ (has_colimit.iso_of_equivalence e w).inv =
+     G.map (e.counit_inv.app k) ≫ w.hom.app (e.inverse.obj k) ≫ colimit.ι F (e.inverse.obj k) :=
 begin
   simp [has_colimit.iso_of_equivalence, is_colimit.cocone_points_iso_of_equivalence_inv],
   dsimp,

--- a/src/category_theory/limits/limits.lean
+++ b/src/category_theory/limits/limits.lean
@@ -867,7 +867,7 @@ lemma has_limit.iso_of_equivalence_hom_π {F : J ⥤ C} [has_limit F] {G : K ⥤
   (has_limit.iso_of_equivalence e w).hom ≫ limit.π G k =
     limit.π F (e.inverse.obj k) ≫ w.inv.app (e.inverse.obj k) ≫ G.map (e.counit.app k) :=
 begin
-  simp [has_limit.iso_of_equivalence, is_limit.cone_points_iso_of_equivalence_hom],
+  simp only [has_limit.iso_of_equivalence, is_limit.cone_points_iso_of_equivalence_hom],
   dsimp,
   simp,
 end
@@ -878,7 +878,7 @@ lemma has_limit.iso_of_equivalence_inv_π {F : J ⥤ C} [has_limit F] {G : K ⥤
   (has_limit.iso_of_equivalence e w).inv ≫ limit.π F j =
     limit.π G (e.functor.obj j) ≫ w.hom.app j :=
 begin
-  simp [has_limit.iso_of_equivalence, is_limit.cone_points_iso_of_equivalence_hom],
+  simp only [has_limit.iso_of_equivalence, is_limit.cone_points_iso_of_equivalence_hom],
   dsimp,
   simp,
 end

--- a/src/category_theory/products/basic.lean
+++ b/src/category_theory/products/basic.lean
@@ -69,14 +69,23 @@ variables (C : Type u₁) [category.{v₁} C] (D : Type u₂) [category.{v₂} D
 { obj := λ X, X.2,
   map := λ X Y f, f.2 }
 
+/-- The functor swapping the factors of a cartesian product of categories, `C × D ⥤ D × C`. -/
 @[simps] def swap : C × D ⥤ D × C :=
 { obj := λ X, (X.2, X.1),
   map := λ _ _ f, (f.2, f.1) }
 
+/--
+Swapping the factors of a cartesion product of categories twice is naturally isomorphic
+to the identity functor.
+-/
 @[simps] def symmetry : swap C D ⋙ swap D C ≅ 𝟭 (C × D) :=
 { hom := { app := λ X, 𝟙 X },
   inv := { app := λ X, 𝟙 X } }
 
+/--
+The equivalence, given by swapping factors, between `C × D` and `D × C`.
+-/
+@[simps {rhs_md:=semireducible}]
 def braiding : C × D ≌ D × C :=
 equivalence.mk (swap C D) (swap D C)
   (nat_iso.of_components (λ X, eq_to_iso (by simp)) (by tidy))


### PR DESCRIPTION
The statement that you can swap limits, rather than just combine into a single limit as we had before.

(This just uses two copies of the previous isomorphism.)

---
<!-- put comments you want to keep out of the PR commit here -->
