### PR TITLE
[Merged by Bors] - feat(linear_algebra/char_poly): rephrase Cayley-Hamilton with `aeval`, define `matrix.min_poly`

### DIFF
--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -149,7 +149,7 @@
   title  : Dirichlet’s Theorem
 49:
   title  : The Cayley-Hamilton Theorem
-  decl   : aeval_char_poly
+  decl   : aeval_self_char_poly
   author : Scott Morrison
 50:
   title  : The Number of Platonic Solids

--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -149,7 +149,7 @@
   title  : Dirichlet’s Theorem
 49:
   title  : The Cayley-Hamilton Theorem
-  decl   : char_poly_map_eval_self
+  decl   : aeval_char_poly
   author : Scott Morrison
 50:
   title  : The Number of Platonic Solids

--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -140,7 +140,6 @@ Linear algebra:
     determinant: 'matrix.det'
     invertibility: 'matrix.nonsing_inv'
   Endomorphism polynomials:
-    minimal polynomial: 'matrix.min_poly'
     characteristic polynomial: 'char_poly'
     Cayley-Hamilton theorem: 'aeval_self_char_poly'
   Structure theory of endomorphisms:

--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -140,8 +140,9 @@ Linear algebra:
     determinant: 'matrix.det'
     invertibility: 'matrix.nonsing_inv'
   Endomorphism polynomials:
+    minimal polynomial: 'matrix.min_poly'
     characteristic polynomial: 'char_poly'
-    Cayley-Hamilton theorem: 'char_poly_map_eval_self'
+    Cayley-Hamilton theorem: 'aeval_self_char_poly'
   Structure theory of endomorphisms:
     eigenvalue: 'module.End.has_eigenvalue'
     eigenvector: 'module.End.has_eigenvector'

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -52,7 +52,7 @@ Linear algebra:
     row-reduced matrices: ''
   Endomorphism polynomials:
     annihilating polynomials: ''
-    minimal polynomial: 'matrix.min_poly'
+    minimal polynomial: ''
     characteristic polynomial: 'char_poly'
     Cayley-Hamilton theorem: 'aeval_self_char_poly'
   Structure theory of endomorphisms:

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -52,9 +52,9 @@ Linear algebra:
     row-reduced matrices: ''
   Endomorphism polynomials:
     annihilating polynomials: ''
-    minimal polynomial: ''
+    minimal polynomial: 'matrix.min_poly'
     characteristic polynomial: 'char_poly'
-    Cayley-Hamilton theorem: 'char_poly_map_eval_self'
+    Cayley-Hamilton theorem: 'aeval_self_char_poly'
   Structure theory of endomorphisms:
     eigenvalue: 'module.End.has_eigenvalue'
     eigenvector: 'module.End.has_eigenvector'

--- a/src/linear_algebra/char_poly.lean
+++ b/src/linear_algebra/char_poly.lean
@@ -79,8 +79,8 @@ applied to the matrix itself, is zero.
 This holds over any commutative ring.
 -/
 -- This proof follows http://drorbn.net/AcademicPensieve/2015-12/CayleyHamilton.pdf
-theorem aeval_char_poly (M : matrix n n R) :
-  polynomial.aeval M (char_poly M) = 0 :=
+theorem aeval_self_char_poly (M : matrix n n R) :
+  aeval M (char_poly M) = 0 :=
 begin
   -- We begin with the fact $χ_M(t) I = adjugate (t I - M) * (t I - M)$,
   -- as an identity in `matrix n n (polynomial R)`.

--- a/src/linear_algebra/char_poly.lean
+++ b/src/linear_algebra/char_poly.lean
@@ -79,8 +79,8 @@ applied to the matrix itself, is zero.
 This holds over any commutative ring.
 -/
 -- This proof follows http://drorbn.net/AcademicPensieve/2015-12/CayleyHamilton.pdf
-theorem char_poly_map_eval_self (M : matrix n n R) :
-  ((char_poly M).map (algebra_map R (matrix n n R))).eval M = 0 :=
+theorem aeval_char_poly (M : matrix n n R) :
+  polynomial.aeval M (char_poly M) = 0 :=
 begin
   -- We begin with the fact $χ_M(t) I = adjugate (t I - M) * (t I - M)$,
   -- as an identity in `matrix n n (polynomial R)`.
@@ -103,5 +103,6 @@ begin
   -- and evaluated at some `N` is exactly $χ_M (N)$.
   rw mat_poly_equiv_smul_one at h,
   -- Thus we have $χ_M(M) = 0$, which is the desired result.
+  rw eval_map at h,
   exact h,
 end

--- a/src/linear_algebra/char_poly.lean
+++ b/src/linear_algebra/char_poly.lean
@@ -101,8 +101,7 @@ begin
   rw eval_mul_X_sub_C at h,
   -- Now $χ_M (t) I$, when thought of as a polynomial of matrices
   -- and evaluated at some `N` is exactly $χ_M (N)$.
-  rw mat_poly_equiv_smul_one at h,
+  rw [mat_poly_equiv_smul_one, eval_map] at h,
   -- Thus we have $χ_M(M) = 0$, which is the desired result.
-  rw eval_map at h,
   exact h,
 end

--- a/src/linear_algebra/char_poly/coeff.lean
+++ b/src/linear_algebra/char_poly/coeff.lean
@@ -208,11 +208,8 @@ namespace matrix
 
 theorem is_integral : is_integral R M := ⟨char_poly M, ⟨char_poly_monic M, aeval_self_char_poly M⟩⟩
 
-/-- The minimal polynomial of a matrix -/
-def min_poly : polynomial R := minimal_polynomial (M.is_integral)
-
 theorem min_poly_dvd_char_poly {K : Type*} [field K] (M : matrix n n K) :
-  M.min_poly ∣ char_poly M :=
+  (minimal_polynomial M.is_integral) ∣ char_poly M :=
 minimal_polynomial.dvd M.is_integral (aeval_self_char_poly M)
 
 end matrix

--- a/src/linear_algebra/char_poly/coeff.lean
+++ b/src/linear_algebra/char_poly/coeff.lean
@@ -203,3 +203,16 @@ by rw [trace_eq_neg_char_poly_coeff, trace_eq_neg_char_poly_coeff,
 lemma zmod.trace_pow_card {p:ℕ} [fact p.prime] [nonempty n] (M : matrix n n (zmod p)) :
   trace n (zmod p) (zmod p) (M ^ p) = (trace n (zmod p) (zmod p) M)^p :=
 by { have h := finite_field.trace_pow_card M, rwa zmod.card at h, }
+
+namespace matrix
+
+theorem is_integral : is_integral R M := ⟨char_poly M, ⟨char_poly_monic M, aeval_char_poly M⟩⟩
+
+/-- The minimal polynomial of a matrix -/
+def min_poly : polynomial R := minimal_polynomial (M.is_integral)
+
+theorem min_poly_dvd_char_poly {K : Type*} [field K] (M : matrix n n K) :
+  M.min_poly ∣ char_poly M :=
+minimal_polynomial.dvd M.is_integral (aeval_char_poly M)
+
+end matrix

--- a/src/linear_algebra/char_poly/coeff.lean
+++ b/src/linear_algebra/char_poly/coeff.lean
@@ -206,13 +206,13 @@ by { have h := finite_field.trace_pow_card M, rwa zmod.card at h, }
 
 namespace matrix
 
-theorem is_integral : is_integral R M := ⟨char_poly M, ⟨char_poly_monic M, aeval_char_poly M⟩⟩
+theorem is_integral : is_integral R M := ⟨char_poly M, ⟨char_poly_monic M, aeval_self_char_poly M⟩⟩
 
 /-- The minimal polynomial of a matrix -/
 def min_poly : polynomial R := minimal_polynomial (M.is_integral)
 
 theorem min_poly_dvd_char_poly {K : Type*} [field K] (M : matrix n n K) :
   M.min_poly ∣ char_poly M :=
-minimal_polynomial.dvd M.is_integral (aeval_char_poly M)
+minimal_polynomial.dvd M.is_integral (aeval_self_char_poly M)
 
 end matrix


### PR DESCRIPTION
Rephrases the Cayley-Hamilton theorem to use `aeval`, renames it `aeval_self_char_poly`
Defines `matrix.min_poly`, the minimal polynomial of a matrix, which divides `char_poly`

---
<!-- put comments you want to keep out of the PR commit here -->
