### PR TITLE
[Merged by Bors] - feat(linear_algebra): add `restrict` for endomorphisms

### DIFF
--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -169,10 +169,10 @@ instance linear_map_apply_is_add_monoid_hom (a : M) :
 { map_add := λ f g, linear_map.add_apply f g a,
   map_zero := rfl }
 
-@[simp] lemma add_comp (g : M₂ →ₗ[R] M₃) (h : M₂ →ₗ[R] M₃) :
+lemma add_comp (g : M₂ →ₗ[R] M₃) (h : M₂ →ₗ[R] M₃) :
   (h + g).comp f = h.comp f + g.comp f := rfl
 
-@[simp] lemma comp_add (g : M →ₗ[R] M₂) (h : M₂ →ₗ[R] M₃) :
+lemma comp_add (g : M →ₗ[R] M₂) (h : M₂ →ₗ[R] M₃) :
   h.comp (f + g) = h.comp f + h.comp g := by { ext, simp }
 
 lemma sum_apply (t : finset ι) (f : ι → M →ₗ[R] M₂) (b : M) :
@@ -335,10 +335,10 @@ instance linear_map_apply_is_add_group_hom (a : M) :
 
 @[simp] lemma sub_apply (x : M) : (f - g) x = f x - g x := rfl
 
-@[simp] lemma sub_comp (g : M₂ →ₗ[R] M₃) (h : M₂ →ₗ[R] M₃) :
+lemma sub_comp (g : M₂ →ₗ[R] M₃) (h : M₂ →ₗ[R] M₃) :
   (g - h).comp f = g.comp f - h.comp f := rfl
 
-@[simp] lemma comp_sub (g : M →ₗ[R] M₂) (h : M₂ →ₗ[R] M₃) :
+lemma comp_sub (g : M →ₗ[R] M₂) (h : M₂ →ₗ[R] M₃) :
   h.comp (g - f) = h.comp g - h.comp f := by { ext, simp }
 
 end add_comm_group

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -128,25 +128,25 @@ ext $ assume b, rfl
 ext $ assume b, rfl
 
 /-- Restrict domain and codomain of an endomorphism. -/
-def restrict (f : M →ₗ[R] M) (p : submodule R M) (hf : ∀ x ∈ p, f x ∈ p) : p →ₗ[R] p :=
+def restrict (f : M →ₗ[R] M) {p : submodule R M} (hf : ∀ x ∈ p, f x ∈ p) : p →ₗ[R] p :=
 { to_fun := λ x, ⟨f x, hf x.1 x.2⟩,
   map_add' := begin intros, apply set_coe.ext, simp end,
   map_smul' := begin intros, apply set_coe.ext, simp end }
 
 lemma restrict_apply
   {f : M →ₗ[R] M} {p : submodule R M} (hf : ∀ x ∈ p, f x ∈ p) (x : p) :
-  f.restrict p hf x = ⟨f x, hf x.1 x.2⟩ := rfl
+  f.restrict hf x = ⟨f x, hf x.1 x.2⟩ := rfl
 
 lemma subtype_comp_restrict {f : M →ₗ[R] M} {p : submodule R M} (hf : ∀ x ∈ p, f x ∈ p) :
-  p.subtype.comp (f.restrict p hf) = f.dom_restrict p := rfl
+  p.subtype.comp (f.restrict hf) = f.dom_restrict p := rfl
 
 lemma restrict_eq_cod_restrict_dom_restrict
   {f : M →ₗ[R] M} {p : submodule R M} (hf : ∀ x ∈ p, f x ∈ p) :
-  f.restrict p hf = (f.dom_restrict p).cod_restrict p (λ x, hf x.1 x.2) := rfl
+  f.restrict hf = (f.dom_restrict p).cod_restrict p (λ x, hf x.1 x.2) := rfl
 
 lemma restrict_eq_dom_restrict_cod_restrict
   {f : M →ₗ[R] M} {p : submodule R M} (hf : ∀ x, f x ∈ p) :
-  f.restrict p (λ x _, hf x) = (f.cod_restrict p hf).dom_restrict p := rfl
+  f.restrict (λ x _, hf x) = (f.cod_restrict p hf).dom_restrict p := rfl
 
 /-- If a function `g` is a left and right inverse of a linear map `f`, then `g` is linear itself. -/
 def inverse (g : M₂ → M) (h₁ : left_inverse g f) (h₂ : right_inverse g f) : M₂ →ₗ[R] M :=

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -127,6 +127,19 @@ ext $ assume b, rfl
   p.subtype.comp (cod_restrict p f h) = f :=
 ext $ assume b, rfl
 
+/-- Restrict domain and codomain of an endomorphism. -/
+def restrict (f : M →ₗ[R] M) (p : submodule R M) (hf : ∀ x ∈ p, f x ∈ p) : p →ₗ[R] p :=
+{ to_fun := λ x, ⟨f x, hf x.1 x.2⟩,
+  map_add' := begin intros, apply set_coe.ext, simp end,
+  map_smul' := begin intros, apply set_coe.ext, simp end }
+
+lemma restrict_apply
+  {f : M →ₗ[R] M} {p : submodule R M} (hf : ∀ x ∈ p, f x ∈ p) (x : p) :
+  f.restrict p hf x = ⟨f x, hf x.1 x.2⟩ := rfl
+
+lemma subtype_comp_restrict {f : M →ₗ[R] M} {p : submodule R M} (hf : ∀ x ∈ p, f x ∈ p) :
+  p.subtype.comp (f.restrict p hf) = f.comp p.subtype := rfl
+
 /-- If a function `g` is a left and right inverse of a linear map `f`, then `g` is linear itself. -/
 def inverse (g : M₂ → M) (h₁ : left_inverse g f) (h₂ : right_inverse g f) : M₂ →ₗ[R] M :=
 by dsimp [left_inverse, function.right_inverse] at h₁ h₂; exact
@@ -155,6 +168,12 @@ instance linear_map_apply_is_add_monoid_hom (a : M) :
   is_add_monoid_hom (λ f : M →ₗ[R] M₂, f a) :=
 { map_add := λ f g, linear_map.add_apply f g a,
   map_zero := rfl }
+
+@[simp] lemma add_comp (g : M₂ →ₗ[R] M₃) (h : M₂ →ₗ[R] M₃) :
+  (h + g).comp f = h.comp f + g.comp f := rfl
+
+@[simp] lemma comp_add (g : M →ₗ[R] M₂) (h : M₂ →ₗ[R] M₃) :
+  h.comp (f + g) = h.comp f + h.comp g := by { ext, simp }
 
 lemma sum_apply (t : finset ι) (f : ι → M →ₗ[R] M₂) (b : M) :
   (∑ d in t, f d) b = ∑ d in t, f d b :=
@@ -303,6 +322,8 @@ instance : has_neg (M →ₗ[R] M₂) :=
 
 @[simp] lemma neg_apply (x : M) : (- f) x = - f x := rfl
 
+@[simp] lemma comp_neg (g : M₂ →ₗ[R] M₃) : g.comp (- f) = - g.comp f := by { ext, simp }
+
 /-- The type of linear maps is an additive group. -/
 instance : add_comm_group (M →ₗ[R] M₂) :=
 by refine {zero := 0, add := (+), neg := has_neg.neg, ..};
@@ -313,6 +334,12 @@ instance linear_map_apply_is_add_group_hom (a : M) :
 { map_add := λ f g, linear_map.add_apply f g a }
 
 @[simp] lemma sub_apply (x : M) : (f - g) x = f x - g x := rfl
+
+@[simp] lemma sub_comp (g : M₂ →ₗ[R] M₃) (h : M₂ →ₗ[R] M₃) :
+  (g - h).comp f = g.comp f - h.comp f := rfl
+
+@[simp] lemma comp_sub (g : M →ₗ[R] M₂) (h : M₂ →ₗ[R] M₃) :
+  h.comp (g - f) = h.comp g - h.comp f := by { ext, simp }
 
 end add_comm_group
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -138,7 +138,15 @@ lemma restrict_apply
   f.restrict p hf x = ⟨f x, hf x.1 x.2⟩ := rfl
 
 lemma subtype_comp_restrict {f : M →ₗ[R] M} {p : submodule R M} (hf : ∀ x ∈ p, f x ∈ p) :
-  p.subtype.comp (f.restrict p hf) = f.comp p.subtype := rfl
+  p.subtype.comp (f.restrict p hf) = f.dom_restrict p := rfl
+
+lemma restrict_eq_cod_restrict_dom_restrict
+  {f : M →ₗ[R] M} {p : submodule R M} (hf : ∀ x ∈ p, f x ∈ p) :
+  f.restrict p hf = (f.dom_restrict p).cod_restrict p (λ x, hf x.1 x.2) := rfl
+
+lemma restrict_eq_dom_restrict_cod_restrict
+  {f : M →ₗ[R] M} {p : submodule R M} (hf : ∀ x, f x ∈ p) :
+  f.restrict p (λ x _, hf x) = (f.cod_restrict p hf).dom_restrict p := rfl
 
 /-- If a function `g` is a left and right inverse of a linear map `f`, then `g` is linear itself. -/
 def inverse (g : M₂ → M) (h₁ : left_inverse g f) (h₂ : right_inverse g f) : M₂ →ₗ[R] M :=

--- a/src/linear_algebra/eigenspace.lean
+++ b/src/linear_algebra/eigenspace.lean
@@ -330,7 +330,7 @@ ker_pow_eq_ker_pow_findim_of_le hk
 lemma generalized_eigenspace_restrict [field K] [vector_space K V]
   (f : End K V) (p : submodule K V) (k : ℕ) (μ : K) (x : p) (hfp : ∀ (x : V), x ∈ p → f x ∈ p) :
   generalized_eigenspace (linear_map.restrict f p hfp) μ k
-    = (f.generalized_eigenspace μ k).comap p.subtype :=
+    = submodule.comap p.subtype (f.generalized_eigenspace μ k) :=
 begin
   rw [generalized_eigenspace, generalized_eigenspace, ←linear_map.ker_comp],
   induction k with k ih,

--- a/src/linear_algebra/eigenspace.lean
+++ b/src/linear_algebra/eigenspace.lean
@@ -329,7 +329,7 @@ ker_pow_eq_ker_pow_findim_of_le hk
     of `f` to `p` is the part of the generalized eigenspace of `f` that lies in `p`. -/
 lemma generalized_eigenspace_restrict [field K] [vector_space K V]
   (f : End K V) (p : submodule K V) (k : ℕ) (μ : K) (hfp : ∀ (x : V), x ∈ p → f x ∈ p) :
-  generalized_eigenspace (linear_map.restrict f p hfp) μ k =
+  generalized_eigenspace (linear_map.restrict f hfp) μ k =
     submodule.comap p.subtype (f.generalized_eigenspace μ k) :=
 begin
   rw [generalized_eigenspace, generalized_eigenspace, ←linear_map.ker_comp],

--- a/src/linear_algebra/eigenspace.lean
+++ b/src/linear_algebra/eigenspace.lean
@@ -329,8 +329,8 @@ ker_pow_eq_ker_pow_findim_of_le hk
     of `f` to `p` is the part of the generalized eigenspace of `f` that lies in `p`. -/
 lemma generalized_eigenspace_restrict [field K] [vector_space K V]
   (f : End K V) (p : submodule K V) (k : ℕ) (μ : K) (hfp : ∀ (x : V), x ∈ p → f x ∈ p) :
-  generalized_eigenspace (linear_map.restrict f p hfp) μ k
-    = submodule.comap p.subtype (f.generalized_eigenspace μ k) :=
+  generalized_eigenspace (linear_map.restrict f p hfp) μ k =
+    submodule.comap p.subtype (f.generalized_eigenspace μ k) :=
 begin
   rw [generalized_eigenspace, generalized_eigenspace, ←linear_map.ker_comp],
   induction k with k ih,

--- a/src/linear_algebra/eigenspace.lean
+++ b/src/linear_algebra/eigenspace.lean
@@ -328,7 +328,7 @@ ker_pow_eq_ker_pow_findim_of_le hk
 /-- If `f` maps a subspace `p` into itself, then the generalized eigenspace of the restriction
     of `f` to `p` is the part of the generalized eigenspace of `f` that lies in `p`. -/
 lemma generalized_eigenspace_restrict [field K] [vector_space K V]
-  (f : End K V) (p : submodule K V) (k : ℕ) (μ : K) (x : p) (hfp : ∀ (x : V), x ∈ p → f x ∈ p) :
+  (f : End K V) (p : submodule K V) (k : ℕ) (μ : K) (hfp : ∀ (x : V), x ∈ p → f x ∈ p) :
   generalized_eigenspace (linear_map.restrict f p hfp) μ k
     = submodule.comap p.subtype (f.generalized_eigenspace μ k) :=
 begin

--- a/src/linear_algebra/eigenspace.lean
+++ b/src/linear_algebra/eigenspace.lean
@@ -325,5 +325,21 @@ lemma generalized_eigenspace_eq_generalized_eigenspace_findim_of_le
   f.generalized_eigenspace μ k = f.generalized_eigenspace μ (findim K V) :=
 ker_pow_eq_ker_pow_findim_of_le hk
 
+/-- If `f` maps a subspace `p` into itself, then the generalized eigenspace of the restriction
+    of `f` to `p` is the part of the generalized eigenspace of `f` that lies in `p`. -/
+lemma generalized_eigenspace_restrict [field K] [vector_space K V]
+  (f : End K V) (p : submodule K V) (k : ℕ) (μ : K) (x : p) (hfp : ∀ (x : V), x ∈ p → f x ∈ p) :
+  generalized_eigenspace (linear_map.restrict f p hfp) μ k
+    = (f.generalized_eigenspace μ k).comap p.subtype :=
+begin
+  rw [generalized_eigenspace, generalized_eigenspace, ←linear_map.ker_comp],
+  induction k with k ih,
+  { rw [pow_zero,pow_zero],
+    convert linear_map.ker_id,
+    apply submodule.ker_subtype },
+  { erw [pow_succ', pow_succ', linear_map.ker_comp,
+      ih, ←linear_map.ker_comp, linear_map.comp_assoc], }
+end
+
 end End
 end module


### PR DESCRIPTION
Add a `restrict` function for endomorphisms. Add some lemmas about the new function, including one about generalized eigenspaces. Add some additional lemmas about `linear_map.comp` that I do not use in the final proof, but still consider useful.


---
<!-- put comments you want to keep out of the PR commit here -->
