### PR TITLE
[Merged by Bors] - feat(linear_algebra/affine_space): more lemmas

### DIFF
--- a/src/geometry/euclidean/circumcenter.lean
+++ b/src/geometry/euclidean/circumcenter.lean
@@ -244,10 +244,7 @@ begin
       rw hr,
       change ∃! (cccr : P × ℝ), (_ ∧ ∀ (i2 : ι2), (λ q, dist q cccr.fst = cccr.snd) (p i2)) at hm,
       conv at hm { congr, funext, conv { congr, skip, rw ←set.forall_range_iff } },
-      have hs : affine_span ℝ (insert (p i) (set.range (λ (i2 : ι2), p i2))) =
-        affine_span ℝ (insert (p i) (affine_span ℝ (set.range (λ (i2 : ι2), p i2)) : set P)),
-      { rw [set.insert_eq, set.insert_eq, span_union, span_union, affine_span_coe] },
-      rw hs,
+      rw ←affine_span_insert_affine_span,
       refine exists_unique_dist_eq_of_insert
         (submodule.complete_of_finite_dimensional _)
         (set.range_nonempty _)

--- a/src/linear_algebra/affine_space/basic.lean
+++ b/src/linear_algebra/affine_space/basic.lean
@@ -484,6 +484,10 @@ def affine_span (s : set P) : affine_subspace k P :=
   (affine_span k s : set P) = span_points k s :=
 rfl
 
+/-- A set is contained in its affine span. -/
+lemma subset_affine_span (s : set P) : s ⊆ affine_span k s :=
+subset_span_points k s
+
 /-- The direction of the affine span is the `vector_span`. -/
 lemma direction_affine_span (s : set P) : (affine_span k s).direction = vector_span k s :=
 begin
@@ -828,6 +832,8 @@ variables (k : Type*) {V : Type*} {P : Type*} [ring k] [add_comm_group V] [modul
 variables {ι : Type*}
 include V
 
+open affine_subspace
+
 /-- The `vector_span` is the span of the pairwise subtractions with a
 given point on the left. -/
 lemma vector_span_eq_span_vsub_set_left {s : set P} {p : P} (hp : p ∈ s) :
@@ -932,17 +938,39 @@ lemma affine_span_singleton_union_vadd_eq_top_of_span_eq_top {s : set V} (p : P)
     (h : submodule.span k (set.range (coe : s → V)) = ⊤) :
   affine_span k ({p} ∪ (λ v, v +ᵥ p) '' s) = ⊤ :=
 begin
-  convert affine_subspace.ext_of_direction_eq _
+  convert ext_of_direction_eq _
     ⟨p,
      mem_affine_span k (set.mem_union_left _ (set.mem_singleton _)),
-     affine_subspace.mem_top k V p⟩,
-  rw [direction_affine_span, affine_subspace.direction_top,
+     mem_top k V p⟩,
+  rw [direction_affine_span, direction_top,
       vector_span_eq_span_vsub_set_right k
         ((set.mem_union_left _ (set.mem_singleton _)) : p ∈ _), eq_top_iff, ←h],
   apply submodule.span_mono,
   rintros v ⟨v', rfl⟩,
   use (v' : V) +ᵥ p,
   simp
+end
+
+variables (k)
+
+/-- `affine_span` is monotone. -/
+lemma affine_span_mono {s₁ s₂ : set P} (h : s₁ ⊆ s₂) : affine_span k s₁ ≤ affine_span k s₂ :=
+span_points_subset_coe_of_subset_coe (set.subset.trans h (subset_affine_span k _))
+
+/-- Taking the affine span of a set, adding a point and taking the
+span again produces the same results as adding the point to the set
+and taking the span. -/
+lemma affine_span_insert_affine_span (p : P) (ps : set P) :
+  affine_span k (insert p (affine_span k ps : set P)) = affine_span k (insert p ps) :=
+by rw [set.insert_eq, set.insert_eq, span_union, span_union, affine_span_coe]
+
+/-- If a point is in the affine span of a set, adding it to that set
+does not change the affine span. -/
+lemma affine_span_insert_eq_affine_span {p : P} {ps : set P} (h : p ∈ affine_span k ps) :
+  affine_span k (insert p ps) = affine_span k ps :=
+begin
+  rw ←mem_coe at h,
+  rw [←affine_span_insert_affine_span, set.insert_eq_of_mem h, affine_span_coe]
 end
 
 end affine_space'

--- a/src/linear_algebra/affine_space/independent.lean
+++ b/src/linear_algebra/affine_space/independent.lean
@@ -269,7 +269,7 @@ begin
 end
 
 /-- If a set of points is affinely independent, so is any subset. -/
-lemma affine_independent_subset_of_affine_independent {s t : set P}
+lemma affine_independent_of_subset_affine_independent {s t : set P}
   (ha : affine_independent k (λ x, x : t → P)) (hs : s ⊆ t) :
   affine_independent k (λ x, x : s → P) :=
 begin

--- a/src/linear_algebra/affine_space/independent.lean
+++ b/src/linear_algebra/affine_space/independent.lean
@@ -47,10 +47,33 @@ nontrivial weighted subtractions (where the sum of weights is 0) are
 def affine_independent (p : ι → P) : Prop :=
 ∀ (s : finset ι) (w : ι → k), ∑ i in s, w i = 0 → s.weighted_vsub p w = (0:V) → ∀ i ∈ s, w i = 0
 
+/-- The definition of `affine_independent`. -/
+lemma affine_independent_def (p : ι → P) :
+  affine_independent k p ↔
+    ∀ (s : finset ι) (w : ι → k),
+      ∑ i in s, w i = 0 → s.weighted_vsub p w = (0 : V) → ∀ i ∈ s, w i = 0 :=
+iff.rfl
+
 /-- A family with at most one point is affinely independent. -/
 lemma affine_independent_of_subsingleton [subsingleton ι] (p : ι → P) :
   affine_independent k p :=
 λ s w h hs i hi, fintype.eq_of_subsingleton_of_sum_eq h i hi
+
+/-- A family indexed by a `fintype` is affinely independent if and
+only if no nontrivial weighted subtractions over `finset.univ` (where
+the sum of the weights is 0) are 0. -/
+lemma affine_independent_iff_of_fintype [fintype ι] (p : ι → P) :
+  affine_independent k p ↔
+    ∀ w : ι → k, ∑ i, w i = 0 → finset.univ.weighted_vsub p w = (0 : V) → ∀ i, w i = 0 :=
+begin
+  split,
+  { exact λ h w hw hs i, h finset.univ w hw hs i (finset.mem_univ _) },
+  { intros h s w hw hs i hi,
+    rw finset.weighted_vsub_indicator_subset _ _ (finset.subset_univ s) at hs,
+    rw set.sum_indicator_subset _ (finset.subset_univ s) at hw,
+    replace h := h ((↑s : set ι).indicator w) hw hs i,
+    simpa [hi] using h }
+end
 
 /-- A family is affinely independent if and only if the differences
 from a base point in that family are linearly independent. -/
@@ -244,6 +267,28 @@ begin
   ext,
   simp [hf]
 end
+
+/-- If a set of points is affinely independent, so is any subset. -/
+lemma affine_independent_subset_of_affine_independent {s t : set P}
+  (ha : affine_independent k (λ x, x : t → P)) (hs : s ⊆ t) :
+  affine_independent k (λ x, x : s → P) :=
+begin
+  let f : s → t := λ x, ⟨x, hs x.property⟩,
+  let fe : s ↪ t := ⟨f, λ x y h, begin
+    rw subtype.ext_iff,
+    rw subtype.mk_eq_mk at h,
+    exact h
+  end⟩,
+  exact affine_independent_embedding_of_affine_independent fe ha
+end
+
+/-- If the range of an injective indexed family of points is affinely
+independent, so is that family. -/
+lemma affine_independent_of_affine_independent_set_of_injective {p : ι → P}
+  (ha : affine_independent k (λ x, x : set.range p → P)) (hi : function.injective p) :
+  affine_independent k p :=
+affine_independent_embedding_of_affine_independent
+  (⟨λ i, ⟨p i, set.mem_range_self _⟩, λ x y h, hi (subtype.mk_eq_mk.1 h)⟩ : ι ↪ set.range p) ha
 
 /-- If a family is affinely independent, and the spans of points
 indexed by two subsets of the index type have a point in common, those

--- a/src/linear_algebra/affine_space/independent.lean
+++ b/src/linear_algebra/affine_space/independent.lean
@@ -272,15 +272,7 @@ end
 lemma affine_independent_of_subset_affine_independent {s t : set P}
   (ha : affine_independent k (λ x, x : t → P)) (hs : s ⊆ t) :
   affine_independent k (λ x, x : s → P) :=
-begin
-  let f : s → t := λ x, ⟨x, hs x.property⟩,
-  let fe : s ↪ t := ⟨f, λ x y h, begin
-    rw subtype.ext_iff,
-    rw subtype.mk_eq_mk at h,
-    exact h
-  end⟩,
-  exact affine_independent_embedding_of_affine_independent fe ha
-end
+affine_independent_embedding_of_affine_independent (set.embedding_of_subset s t hs) ha
 
 /-- If the range of an injective indexed family of points is affinely
 independent, so is that family. -/


### PR DESCRIPTION
Add some more lemmas about affine spaces.  One,
`affine_span_insert_affine_span`, is extracted from the proof of
`exists_unique_dist_eq_of_affine_independent` as it turned out to be
useful elsewhere.


---
<!-- put comments you want to keep out of the PR commit here -->
