### PR TITLE
[Merged by Bors] - feat(data/polynomial/ring_division): make `polynomial.roots` a multiset

### DIFF
--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -1,4 +1,3 @@
-
 /-
 Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
@@ -87,10 +86,106 @@ begin
   rw [nat_degree_mul h2.1 h2.2], exact nat.le_add_right _ _
 end
 
+section roots
+
+open multiset
+
 local attribute [reducible] with_zero
 
-lemma exists_finset_roots : ∀ {p : polynomial R} (hp : p ≠ 0),
-  ∃ s : finset R, (s.card : with_bot ℕ) ≤ degree p ∧ ∀ x, x ∈ s ↔ is_root p x
+lemma degree_eq_zero_of_is_unit (h : is_unit p) : degree p = 0 :=
+let ⟨q, hq⟩ := is_unit_iff_dvd_one.1 h in
+have hp0 : p ≠ 0, from λ hp0, by simpa [hp0] using hq,
+have hq0 : q ≠ 0, from λ hp0, by simpa [hp0] using hq,
+have nat_degree (1 : polynomial R) = nat_degree (p * q),
+  from congr_arg _ hq,
+by rw [nat_degree_one, nat_degree_mul hp0 hq0, eq_comm,
+    _root_.add_eq_zero_iff, ← with_bot.coe_eq_coe,
+    ← degree_eq_nat_degree hp0] at this;
+  exact this.1
+
+@[simp] lemma degree_coe_units (u : units (polynomial R)) :
+  degree (u : polynomial R) = 0 :=
+degree_eq_zero_of_is_unit ⟨u, rfl⟩
+
+theorem prime_X_sub_C {r : R} : prime (X - C r) :=
+⟨X_sub_C_ne_zero r, not_is_unit_X_sub_C,
+ λ _ _, by { simp_rw [dvd_iff_is_root, is_root.def, eval_mul, mul_eq_zero], exact id }⟩
+
+theorem prime_X : prime (X : polynomial R) :=
+by { convert (prime_X_sub_C : prime (X - C 0 : polynomial R)), simp }
+
+lemma prime_of_degree_eq_one_of_monic (hp1 : degree p = 1)
+  (hm : monic p) : prime p :=
+have p = X - C (- p.coeff 0),
+  by simpa [hm.leading_coeff] using eq_X_add_C_of_degree_eq_one hp1,
+this.symm ▸ prime_X_sub_C
+
+theorem irreducible_X_sub_C (r : R) : irreducible (X - C r) :=
+irreducible_of_prime prime_X_sub_C
+
+theorem irreducible_X : irreducible (X : polynomial R) :=
+irreducible_of_prime prime_X
+
+lemma irreducible_of_degree_eq_one_of_monic (hp1 : degree p = 1)
+  (hm : monic p) : irreducible p :=
+irreducible_of_prime (prime_of_degree_eq_one_of_monic hp1 hm)
+
+theorem eq_of_monic_of_associated (hp : p.monic) (hq : q.monic) (hpq : associated p q) : p = q :=
+begin
+  obtain ⟨u, hu⟩ := hpq,
+  unfold monic at hp hq,
+  rw eq_C_of_degree_le_zero (le_of_eq $ degree_coe_units _) at hu,
+  rw [← hu, leading_coeff_mul, hp, one_mul, leading_coeff_C] at hq,
+  rwa [hq, C_1, mul_one] at hu
+end
+
+@[simp] lemma root_multiplicity_zero {x : R} : root_multiplicity x 0 = 0 := dif_pos rfl
+
+lemma root_multiplicity_eq_zero {p : polynomial R} {x : R} (h : ¬ is_root p x) :
+  root_multiplicity x p = 0 :=
+begin
+  rw root_multiplicity_eq_multiplicity,
+  split_ifs, { refl },
+  rw [← enat.coe_inj, enat.coe_get, multiplicity.multiplicity_eq_zero_of_not_dvd, enat.coe_zero],
+  intro hdvd,
+  exact h (dvd_iff_is_root.mp hdvd)
+end
+
+lemma root_multiplicity_pos {p : polynomial R} (hp : p ≠ 0) {x : R} :
+  0 < root_multiplicity x p ↔ is_root p x :=
+begin
+  rw [← dvd_iff_is_root, root_multiplicity_eq_multiplicity, dif_neg hp,
+      ← enat.coe_lt_coe, enat.coe_get],
+  exact multiplicity.dvd_iff_multiplicity_pos
+end
+
+lemma root_multiplicity_mul {p q : polynomial R} {x : R} (hpq : p * q ≠ 0) :
+  root_multiplicity x (p * q) = root_multiplicity x p + root_multiplicity x q :=
+begin
+  have hp : p ≠ 0 := left_ne_zero_of_mul hpq,
+  have hq : q ≠ 0 := right_ne_zero_of_mul hpq,
+  rw [root_multiplicity_eq_multiplicity (p * q), dif_neg hpq,
+      root_multiplicity_eq_multiplicity p, dif_neg hp,
+      root_multiplicity_eq_multiplicity q, dif_neg hq,
+      @multiplicity.mul' _ _ _ (X - C x) _ _ prime_X_sub_C],
+end
+
+lemma root_multiplicity_X_sub_C_self {x : R} :
+  root_multiplicity x (X - C x) = 1 :=
+by rw [root_multiplicity_eq_multiplicity, dif_neg (X_sub_C_ne_zero x),
+       multiplicity.get_multiplicity_self]
+
+lemma root_multiplicity_X_sub_C {x y : R} :
+  root_multiplicity x (X - C y) = if x = y then 1 else 0 :=
+begin
+  split_ifs with hxy,
+  { rw hxy,
+    exact root_multiplicity_X_sub_C_self },
+  exact root_multiplicity_eq_zero (mt root_X_sub_C.mp (ne.symm hxy))
+end
+
+lemma exists_multiset_roots : ∀ {p : polynomial R} (hp : p ≠ 0),
+  ∃ s : multiset R, (s.card : with_bot ℕ) ≤ degree p ∧ ∀ a, s.count a = root_multiplicity a p
 | p := λ hp, by haveI := classical.prop_decidable (∃ x, is_root p x); exact
 if h : ∃ x, is_root p x
 then
@@ -101,7 +196,7 @@ then
   have wf : degree (p /ₘ _) < degree p :=
     degree_div_by_monic_lt _ (monic_X_sub_C x) hp
     ((degree_X_sub_C x).symm ▸ dec_trivial),
-  let ⟨t, htd, htr⟩ := @exists_finset_roots (p /ₘ (X - C x)) hd0 in
+  let ⟨t, htd, htr⟩ := @exists_multiset_roots (p /ₘ (X - C x)) hd0 in
   have hdeg : degree (X - C x) ≤ degree p := begin
     rw [degree_X_sub_C, degree_eq_nat_degree hp],
     rw degree_eq_nat_degree hp at hpd,
@@ -109,36 +204,39 @@ then
   end,
   have hdiv0 : p /ₘ (X - C x) ≠ 0 := mt (div_by_monic_eq_zero_iff (monic_X_sub_C x)
     (ne_zero_of_monic (monic_X_sub_C x))).1 $ not_lt.2 hdeg,
-  ⟨insert x t, calc (card (insert x t) : with_bot ℕ) ≤ card t + 1 :
-    with_bot.coe_le_coe.2 $ finset.card_insert_le _ _
+  ⟨x :: t, calc (card (x :: t) : with_bot ℕ) = t.card + 1 :
+      by exact_mod_cast card_cons _ _
     ... ≤ degree p :
       by rw [← degree_add_div_by_monic (monic_X_sub_C x) hdeg,
           degree_X_sub_C, add_comm];
         exact add_le_add (le_refl (1 : with_bot ℕ)) htd,
   begin
-    assume y,
-    rw [mem_insert, htr, eq_comm, ← root_X_sub_C],
-    conv {to_rhs, rw ← mul_div_by_monic_eq_iff_is_root.2 hx},
-    exact ⟨λ h, or.cases_on h (root_mul_right_of_is_root _) (root_mul_left_of_is_root _),
-      root_or_root_of_root_mul⟩
+    assume a,
+    conv_rhs { rw ← mul_div_by_monic_eq_iff_is_root.mpr hx },
+    rw [root_multiplicity_mul (mul_ne_zero (X_sub_C_ne_zero _) hdiv0),
+        root_multiplicity_X_sub_C, ← htr a],
+    split_ifs with ha,
+    { rw [ha, count_cons_self, nat.succ_eq_add_one, add_comm] },
+    { rw [count_cons_of_ne ha, zero_add] },
   end⟩
 else
-  ⟨∅, (degree_eq_nat_degree hp).symm ▸ with_bot.coe_le_coe.2 (nat.zero_le _),
-    by simpa only [not_mem_empty, false_iff, not_exists] using h⟩
+  ⟨0, (degree_eq_nat_degree hp).symm ▸ with_bot.coe_le_coe.2 (nat.zero_le _),
+    by { intro a, rw [count_zero, root_multiplicity_eq_zero (not_exists.mp h a)] }⟩
 using_well_founded {dec_tac := tactic.assumption}
 
-/-- `roots p` noncomputably gives a finset containing all the roots of `p` -/
-noncomputable def roots (p : polynomial R) : finset R :=
-if h : p = 0 then ∅ else classical.some (exists_finset_roots h)
+/-- `roots p` noncomputably gives a multiset containing all the roots of `p`,
+including their multiplicities. -/
+noncomputable def roots (p : polynomial R) : multiset R :=
+if h : p = 0 then ∅ else classical.some (exists_multiset_roots h)
 
-@[simp] lemma roots_zero : (0 : polynomial R).roots = ∅ :=
+@[simp] lemma roots_zero : (0 : polynomial R).roots = 0 :=
 dif_pos rfl
 
 lemma card_roots (hp0 : p ≠ 0) : ((roots p).card : with_bot ℕ) ≤ degree p :=
 begin
   unfold roots,
   rw dif_neg hp0,
-  exact (classical.some_spec (exists_finset_roots hp0)).1
+  exact (classical.some_spec (exists_multiset_roots hp0)).1
 end
 
 lemma card_roots' {p : polynomial R} (hp0 : p ≠ 0) : p.roots.card ≤ nat_degree p :=
@@ -155,12 +253,16 @@ lemma card_roots_sub_C' {p : polynomial R} {a : R} (hp0 : 0 < degree p) :
 with_bot.coe_le_coe.1 (le_trans (card_roots_sub_C hp0) (le_of_eq $ degree_eq_nat_degree
   (λ h, by simp [*, lt_irrefl] at *)))
 
-@[simp] lemma mem_roots (hp : p ≠ 0) : a ∈ p.roots ↔ is_root p a :=
-by unfold roots; rw dif_neg hp; exact (classical.some_spec (exists_finset_roots hp)).2 _
+@[simp] lemma count_roots (hp : p ≠ 0) : p.roots.count a = root_multiplicity a p :=
+by { rw [roots, dif_neg hp], exact (classical.some_spec (exists_multiset_roots hp)).2 a }
 
-lemma roots_mul (hpq : p * q ≠ 0) : (p * q).roots = p.roots ∪ q.roots :=
-finset.ext $ λ r, by rw [mem_union, mem_roots hpq, mem_roots (mul_ne_zero_iff.1 hpq).1,
-    mem_roots (mul_ne_zero_iff.1 hpq).2, root_mul]
+@[simp] lemma mem_roots (hp : p ≠ 0) : a ∈ p.roots ↔ is_root p a :=
+by rw [← count_pos, count_roots hp, root_multiplicity_pos hp]
+
+lemma roots_mul {p q : polynomial R} (hpq : p * q ≠ 0) : (p * q).roots = p.roots + q.roots :=
+multiset.ext.mpr $ λ r,
+  by rw [count_add, count_roots hpq, count_roots (left_ne_zero_of_mul hpq),
+         count_roots (right_ne_zero_of_mul hpq), root_multiplicity_mul hpq]
 
 @[simp] lemma mem_roots_sub_C {p : polynomial R} {a x : R} (hp0 : 0 < degree p) :
   x ∈ (p - C a).roots ↔ p.eval x = a :=
@@ -168,49 +270,57 @@ finset.ext $ λ r, by rw [mem_union, mem_roots hpq, mem_roots (mul_ne_zero_iff.1
     not_le_of_gt hp0 $ h.symm ▸ degree_C_le)).trans
   (by rw [is_root.def, eval_sub, eval_C, sub_eq_zero])
 
-@[simp] lemma roots_X_sub_C (r : R) : roots (X - C r) = {r} :=
-finset.ext $ λ s, by rw [mem_roots (X_sub_C_ne_zero r), root_X_sub_C, mem_singleton, eq_comm]
+@[simp] lemma roots_X_sub_C (r : R) : roots (X - C r) = r :: 0 :=
+begin
+  ext s,
+  rw [count_roots (X_sub_C_ne_zero r), root_multiplicity_X_sub_C],
+  split_ifs with h,
+  { rw [h, count_singleton] },
+  { rw [count_cons_of_ne h, count_zero] }
+end
 
-@[simp] lemma roots_C (x : R) : (C x).roots = ∅ :=
-if H : x = 0 then by rw [H, C_0, roots_zero] else finset.ext $ λ r,
+@[simp] lemma roots_C (x : R) : (C x).roots = 0 :=
+if H : x = 0 then by rw [H, C_0, roots_zero] else multiset.ext.mpr $ λ r,
 have h : C x ≠ 0, from λ h, H $ C_inj.1 $ h.symm ▸ C_0.symm,
-by rw [mem_roots h, is_root.def, eval_C, eq_false_intro H, eq_false_intro (finset.not_mem_empty r)]
+have not_root : ¬ is_root (C x) r := mt (λ (h : eval r (C x) = 0), trans eval_C.symm h) H,
+by rw [count_roots h, count_zero, root_multiplicity_eq_zero not_root]
 
 @[simp] lemma roots_one : (1 : polynomial R).roots = ∅ :=
 roots_C 1
 
 lemma roots_list_prod (L : list (polynomial R)) :
-  (∀ p ∈ L, (p : _) ≠ 0) → L.prod.roots = L.to_finset.bind roots :=
+  (∀ p ∈ L, (p : _) ≠ 0) → L.prod.roots = (L : multiset (polynomial R)).bind roots :=
 list.rec_on L (λ _, roots_one) $ λ hd tl ih H,
 begin
   rw list.forall_mem_cons at H,
   rw [list.prod_cons, roots_mul (mul_ne_zero H.1 $ list.prod_ne_zero H.2),
-      list.to_finset_cons, finset.bind_insert, ih H.2]
+      ← multiset.cons_coe, multiset.cons_bind, ih H.2]
 end
 
 lemma roots_multiset_prod (m : multiset (polynomial R)) :
-  (∀ p ∈ m, (p : _) ≠ 0) → m.prod.roots = m.to_finset.bind roots :=
+  (∀ p ∈ m, (p : _) ≠ 0) → m.prod.roots = m.bind roots :=
 multiset.induction_on m (λ _, roots_one) $ λ hd tl ih H,
 begin
   rw multiset.forall_mem_cons at H,
   rw [multiset.prod_cons, roots_mul (mul_ne_zero H.1 $ multiset.prod_ne_zero H.2),
-      multiset.to_finset_cons, finset.bind_insert, ih H.2]
+      multiset.cons_bind, ih H.2]
 end
 
 lemma roots_prod {ι : Type*} (f : ι → polynomial R) (s : finset ι) :
-  s.prod f ≠ 0 → (s.prod f).roots = s.bind (λ i, roots (f i)) :=
+  s.prod f ≠ 0 → (s.prod f).roots = s.val.bind (λ i, roots (f i)) :=
 begin
   refine s.induction_on _ _,
   { intros, exact roots_one },
   intros i s hi ih ne_zero,
   rw prod_insert hi at ⊢ ne_zero,
-  rw [roots_mul ne_zero, ih (right_ne_zero_of_mul ne_zero), bind_insert]
+  rw [roots_mul ne_zero, ih (right_ne_zero_of_mul ne_zero), insert_val,
+      ndinsert_of_not_mem hi, cons_bind]
 end
 
 lemma roots_prod_X_sub_C (s : finset R) :
-  (s.prod (λ a, X - C a)).roots = s :=
+  (s.prod (λ a, X - C a)).roots = s.val :=
 (roots_prod (λ a, X - C a) s (prod_ne_zero_iff.mpr (λ a _, X_sub_C_ne_zero a))).trans
-  (by simp_rw [roots_X_sub_C, bind_singleton_eq_self])
+  (by simp_rw [roots_X_sub_C, bind_cons, bind_zero, add_zero, multiset.map_id'])
 
 lemma card_roots_X_pow_sub_C {n : ℕ} (hn : 0 < n) (a : R) :
   (roots ((X : polynomial R) ^ n - C a)).card ≤ n :=
@@ -221,7 +331,7 @@ calc ((roots ((X : polynomial R) ^ n - C a)).card : with_bot ℕ)
 
 
 /-- `nth_roots n a` noncomputably returns the solutions to `x ^ n = a`-/
-def nth_roots {R : Type*} [integral_domain R] (n : ℕ) (a : R) : finset R :=
+def nth_roots {R : Type*} [integral_domain R] (n : ℕ) (a : R) : multiset R :=
 roots ((X : polynomial R) ^ n - C a)
 
 @[simp] lemma mem_nth_roots {R : Type*} [integral_domain R] {n : ℕ} (hn : 0 < n) {a x : R} :
@@ -233,7 +343,7 @@ lemma card_nth_roots {R : Type*} [integral_domain R] (n : ℕ) (a : R) :
   (nth_roots n a).card ≤ n :=
 if hn : n = 0
 then if h : (X : polynomial R) ^ n - C a = 0
-  then by simp only [nat.zero_le, nth_roots, roots, h, dif_pos rfl, card_empty]
+  then by simp only [nat.zero_le, nth_roots, roots, h, dif_pos rfl, empty_eq_zero, card_zero]
   else with_bot.coe_le_coe.1 (le_trans (card_roots h)
    (by rw [hn, pow_zero, ← C_1, ← @is_ring_hom.map_sub _ _ _ _ (@C R _)];
       exact degree_C_le))
@@ -288,21 +398,6 @@ lemma leading_coeff_comp (hq : nat_degree q ≠ 0) : leading_coeff (p.comp q) =
   leading_coeff p * leading_coeff q ^ nat_degree p :=
 by rw [← coeff_comp_degree_mul_degree hq, ← nat_degree_comp]; refl
 
-lemma degree_eq_zero_of_is_unit (h : is_unit p) : degree p = 0 :=
-let ⟨q, hq⟩ := is_unit_iff_dvd_one.1 h in
-have hp0 : p ≠ 0, from λ hp0, by simpa [hp0] using hq,
-have hq0 : q ≠ 0, from λ hp0, by simpa [hp0] using hq,
-have nat_degree (1 : polynomial R) = nat_degree (p * q),
-  from congr_arg _ hq,
-by rw [nat_degree_one, nat_degree_mul hp0 hq0, eq_comm,
-    _root_.add_eq_zero_iff, ← with_bot.coe_eq_coe,
-    ← degree_eq_nat_degree hp0] at this;
-  exact this.1
-
-@[simp] lemma degree_coe_units (u : units (polynomial R)) :
-  degree (u : polynomial R) = 0 :=
-degree_eq_zero_of_is_unit ⟨u, rfl⟩
-
 lemma units_coeff_zero_smul (c : units (polynomial R)) (p : polynomial R) :
   (c : polynomial R).coeff 0 • p = c * p :=
 by rw [←polynomial.C_mul', ←polynomial.eq_C_of_degree_eq_zero (degree_coe_units c)]
@@ -310,6 +405,8 @@ by rw [←polynomial.C_mul', ←polynomial.eq_C_of_degree_eq_zero (degree_coe_un
 @[simp] lemma nat_degree_coe_units (u : units (polynomial R)) :
   nat_degree (u : polynomial R) = 0 :=
 nat_degree_eq_of_degree_eq_some (degree_coe_units u)
+
+end roots
 
 theorem is_unit_iff {f : polynomial R} : is_unit f ↔ ∃ r : R, is_unit r ∧ C r = f :=
 ⟨λ hf, ⟨f.coeff 0,
@@ -337,38 +434,6 @@ this.elim
     have h₂ : degree (X - C x) = 0, from degree_eq_zero_of_is_unit h,
     by rw h₁ at h₂; exact absurd h₂ dec_trivial)
   (λ hgu, by rw [hg, degree_mul, degree_X_sub_C, degree_eq_zero_of_is_unit hgu, add_zero])
-
-theorem prime_X_sub_C {r : R} : prime (X - C r) :=
-⟨X_sub_C_ne_zero r, not_is_unit_X_sub_C,
-λ _ _, by { simp_rw [dvd_iff_is_root, is_root.def, eval_mul, mul_eq_zero], exact id }⟩
-
-theorem prime_X : prime (X : polynomial R) :=
-by simpa only [C_0, sub_zero] using (prime_X_sub_C : prime (X - C 0 : polynomial R))
-
-lemma prime_of_degree_eq_one_of_monic (hp1 : degree p = 1)
-  (hm : monic p) : prime p :=
-have p = X - C (- p.coeff 0),
-  by simpa [hm.leading_coeff] using eq_X_add_C_of_degree_eq_one hp1,
-this.symm ▸ prime_X_sub_C
-
-theorem irreducible_X_sub_C (r : R) : irreducible (X - C r) :=
-irreducible_of_prime prime_X_sub_C
-
-theorem irreducible_X : irreducible (X : polynomial R) :=
-irreducible_of_prime prime_X
-
-lemma irreducible_of_degree_eq_one_of_monic (hp1 : degree p = 1)
-  (hm : monic p) : irreducible p :=
-irreducible_of_prime (prime_of_degree_eq_one_of_monic hp1 hm)
-
-theorem eq_of_monic_of_associated (hp : p.monic) (hq : q.monic) (hpq : associated p q) : p = q :=
-begin
-  obtain ⟨u, hu⟩ := hpq,
-  unfold monic at hp hq,
-  rw eq_C_of_degree_le_zero (le_of_eq $ degree_coe_units _) at hu,
-  rw [← hu, leading_coeff_mul, hp, one_mul, leading_coeff_C] at hq,
-  rwa [hq, C_1, mul_one] at hu
-end
 
 end integral_domain
 

--- a/src/field_theory/finite.lean
+++ b/src/field_theory/finite.lean
@@ -53,8 +53,9 @@ open polynomial
 lemma card_image_polynomial_eval [decidable_eq R] [fintype R] {p : polynomial R} (hp : 0 < p.degree) :
   fintype.card R ≤ nat_degree p * (univ.image (λ x, eval x p)).card :=
 finset.card_le_mul_card_image _ _
-  (λ a _, calc _ = (p - C a).roots.card : congr_arg card
-    (by simp [finset.ext_iff, mem_roots_sub_C hp, -sub_eq_add_neg])
+  (λ a _, calc _ = (p - C a).roots.to_finset.card : congr_arg card
+    (by simp [finset.ext_iff, mem_roots_sub_C hp])
+    ... ≤ (p - C a).roots.card : multiset.to_finset_card_le _
     ... ≤ _ : card_roots_sub_C' hp)
 
 /-- If `f` and `g` are quadratic polynomials, then the `f.eval a + g.eval b = 0` has a solution. -/

--- a/src/field_theory/normal.lean
+++ b/src/field_theory/normal.lean
@@ -45,7 +45,8 @@ begin
     splits_prod _ $ λ x hx, normal.splits F K x,
     subalgebra.to_submodule_injective _⟩,
   rw [algebra.coe_top, eq_top_iff, ← hs.2, submodule.span_le, set.range_subset_iff],
-  refine λ x, algebra.subset_adjoin ((mem_roots $ mt (map_eq_zero $ algebra_map F K).1 $
+  refine λ x, algebra.subset_adjoin (multiset.mem_to_finset.mpr $
+    (mem_roots $ mt (map_eq_zero $ algebra_map F K).1 $
     finset.prod_ne_zero_iff.2 $ λ x hx, _).2 _),
   { exact minimal_polynomial.ne_zero _ },
   rw [is_root.def, eval_map, ← aeval_def, alg_hom.map_prod],

--- a/src/field_theory/separable.lean
+++ b/src/field_theory/separable.lean
@@ -431,9 +431,39 @@ begin
   simpa only [multiset.map_cons, multiset.prod_cons] using mul_dvd_mul_left _ (dvd_mul_right _ _)
 end
 
+lemma multiplicity_le_one_of_seperable {p q : polynomial F} (hq : ¬ is_unit q)
+  (hsep : separable p) : multiplicity q p ≤ 1 :=
+begin
+  contrapose! hq,
+  apply is_unit_of_self_mul_dvd_separable hsep,
+  rw ← pow_two,
+  apply multiplicity.pow_dvd_of_le_multiplicity,
+  exact_mod_cast (enat.add_one_le_of_lt hq)
+end
+
+lemma root_multiplicity_le_one_of_seperable {p : polynomial F} (hp : p ≠ 0)
+  (hsep : separable p) (x : F) : root_multiplicity x p ≤ 1 :=
+begin
+  rw [root_multiplicity_eq_multiplicity, dif_neg hp, ← enat.coe_le_coe, enat.coe_get],
+  exact multiplicity_le_one_of_seperable (not_unit_X_sub_C _) hsep
+end
+
+lemma count_roots_le_one {p : polynomial F} (hsep : separable p) (x : F) :
+  p.roots.count x ≤ 1 :=
+begin
+  by_cases hp : p = 0,
+  { simp [hp] },
+  rw count_roots hp,
+  exact root_multiplicity_le_one_of_seperable hp hsep x
+end
+
+lemma nodup_roots {p : polynomial F} (hsep : separable p) :
+  p.roots.nodup :=
+multiset.nodup_iff_count_le_one.mpr (count_roots_le_one hsep)
+
 lemma eq_prod_roots_of_separable {p : polynomial F} {i : F →+* K}
   (hsep : separable p) (hsplit : splits i p) :
-  p.map i = C (i p.leading_coeff) * ∏ a in roots (p.map i), (X - C a : polynomial K) :=
+  p.map i = C (i p.leading_coeff) * ((p.map i).roots.map (λ (a : K), X - C a)).prod :=
 begin
   by_cases p_eq_zero : p = 0,
   { rw [p_eq_zero, map_zero, leading_coeff_zero, i.map_zero, C.map_zero, zero_mul] },
@@ -453,28 +483,46 @@ begin
   { intros p mem,
     obtain ⟨a, _, rfl⟩ := multiset.mem_map.mp mem,
     apply X_sub_C_ne_zero },
-  have map_bind_roots_eq : (s.map (λ a, X - C a)).bind (λ a, a.roots.val) = s,
+  have map_bind_roots_eq : (s.map (λ a, X - C a)).bind (λ a, a.roots) = s,
   { refine multiset.induction_on s (by rw [multiset.map_zero, multiset.zero_bind]) _,
     intros a s ih,
-    rw [multiset.map_cons, multiset.cons_bind, ih, roots_X_sub_C, singleton_val,
+    rw [multiset.map_cons, multiset.cons_bind, ih, roots_X_sub_C,
         multiset.cons_add, zero_add] },
 
-  rw [hs, finset.prod_eq_multiset_prod, roots_mul prod_ne_zero, roots_C, empty_union,
-      roots_multiset_prod _ ne_zero_of_mem, ← multiset.to_finset_eq nodup_map_s,
-      bind_val, map_bind_roots_eq, multiset.erase_dup_eq_self.mpr nodup_s],
+  rw [hs, roots_mul prod_ne_zero, roots_C, zero_add,
+      roots_multiset_prod _ ne_zero_of_mem,
+      map_bind_roots_eq]
+end
+
+lemma nat_degree_multiset_prod {R : Type*} [integral_domain R] {s : multiset (polynomial R)}
+  (h : ∀ p ∈ s, p ≠ (0 : polynomial R)) :
+  nat_degree s.prod = (s.map nat_degree).sum :=
+begin
+  revert h,
+  refine s.induction_on _ _,
+  { simp },
+  intros p s ih h,
+  have hs : ∀ p ∈ s, p ≠ (0 : polynomial R) := λ p hp, h p (multiset.mem_cons_of_mem hp),
+  have hprod : s.prod ≠ 0 := multiset.prod_ne_zero (λ p hp, hs p hp),
+  rw [multiset.prod_cons, nat_degree_mul (h p (multiset.mem_cons_self _ _)) hprod, ih hs,
+      multiset.map_cons, multiset.sum_cons],
 end
 
 lemma nat_degree_separable_eq_card_roots {p : polynomial F} {i : F →+* K}
   (hsep : separable p) (hsplit : splits i p) : p.nat_degree = (p.map i).roots.card :=
 begin
   by_cases p_eq_zero : p = 0,
-  { rw [p_eq_zero, nat_degree_zero, map_zero, roots_zero, card_empty] },
+  { rw [p_eq_zero, nat_degree_zero, map_zero, roots_zero, multiset.card_zero] },
   have map_ne_zero : p.map i ≠ 0 := map_ne_zero (p_eq_zero),
   rw eq_prod_roots_of_separable hsep hsplit at map_ne_zero,
 
   conv_lhs { rw [← nat_degree_map i, eq_prod_roots_of_separable hsep hsplit] },
+  have : ∀ p' ∈ (map i p).roots.map (λ (a : K), X - C a), p' ≠ (0 : polynomial K),
+  { intros p hp,
+    obtain ⟨a, ha, rfl⟩ := multiset.mem_map.mp hp,
+    exact X_sub_C_ne_zero _ },
   simp [nat_degree_mul (left_ne_zero_of_mul map_ne_zero) (right_ne_zero_of_mul map_ne_zero),
-        nat_degree_prod (roots (p.map i)) (λ a, X - C a) (λ a _, X_sub_C_ne_zero a)]
+        nat_degree_multiset_prod this]
 end
 
 lemma degree_separable_eq_card_roots {p : polynomial F} {i : F →+* K} (p_ne_zero : p ≠ 0)

--- a/src/field_theory/separable.lean
+++ b/src/field_theory/separable.lean
@@ -461,39 +461,6 @@ lemma nodup_roots {p : polynomial F} (hsep : separable p) :
   p.roots.nodup :=
 multiset.nodup_iff_count_le_one.mpr (count_roots_le_one hsep)
 
-lemma eq_prod_roots_of_separable {p : polynomial F} {i : F →+* K}
-  (hsep : separable p) (hsplit : splits i p) :
-  p.map i = C (i p.leading_coeff) * ((p.map i).roots.map (λ (a : K), X - C a)).prod :=
-begin
-  by_cases p_eq_zero : p = 0,
-  { rw [p_eq_zero, map_zero, leading_coeff_zero, i.map_zero, C.map_zero, zero_mul] },
-
-  obtain ⟨s, hs⟩ := exists_multiset_of_splits i hsplit,
-  have map_ne_zero : p.map i ≠ 0 := map_ne_zero (p_eq_zero),
-  have prod_ne_zero : C (i p.leading_coeff) * (multiset.map (λ a, X - C a) s).prod ≠ 0 :=
-    by rwa hs at map_ne_zero,
-
-  have map_sep : separable (map i p) := (separable_map i).mpr hsep,
-  rw hs at map_sep,
-
-  have nodup_s : s.nodup := nodup_of_separable_prod (separable.of_mul_right map_sep),
-  have nodup_map_s : (s.map (λ a, X - C a)).nodup :=
-    multiset.nodup_map (λ a b h, C_inj.mp (sub_right_inj.mp h)) nodup_s,
-  have ne_zero_of_mem : ∀ (p : polynomial K), p ∈ s.map (λ a, X - C a) → p ≠ 0,
-  { intros p mem,
-    obtain ⟨a, _, rfl⟩ := multiset.mem_map.mp mem,
-    apply X_sub_C_ne_zero },
-  have map_bind_roots_eq : (s.map (λ a, X - C a)).bind (λ a, a.roots) = s,
-  { refine multiset.induction_on s (by rw [multiset.map_zero, multiset.zero_bind]) _,
-    intros a s ih,
-    rw [multiset.map_cons, multiset.cons_bind, ih, roots_X_sub_C,
-        multiset.cons_add, zero_add] },
-
-  rw [hs, roots_mul prod_ne_zero, roots_C, zero_add,
-      roots_multiset_prod _ ne_zero_of_mem,
-      map_bind_roots_eq]
-end
-
 lemma nat_degree_multiset_prod {R : Type*} [integral_domain R] {s : multiset (polynomial R)}
   (h : ∀ p ∈ s, p ≠ (0 : polynomial R)) :
   nat_degree s.prod = (s.map nat_degree).sum :=

--- a/src/field_theory/separable.lean
+++ b/src/field_theory/separable.lean
@@ -461,41 +461,6 @@ lemma nodup_roots {p : polynomial F} (hsep : separable p) :
   p.roots.nodup :=
 multiset.nodup_iff_count_le_one.mpr (count_roots_le_one hsep)
 
-lemma nat_degree_multiset_prod {R : Type*} [integral_domain R] {s : multiset (polynomial R)}
-  (h : ∀ p ∈ s, p ≠ (0 : polynomial R)) :
-  nat_degree s.prod = (s.map nat_degree).sum :=
-begin
-  revert h,
-  refine s.induction_on _ _,
-  { simp },
-  intros p s ih h,
-  have hs : ∀ p ∈ s, p ≠ (0 : polynomial R) := λ p hp, h p (multiset.mem_cons_of_mem hp),
-  have hprod : s.prod ≠ 0 := multiset.prod_ne_zero (λ p hp, hs p hp),
-  rw [multiset.prod_cons, nat_degree_mul (h p (multiset.mem_cons_self _ _)) hprod, ih hs,
-      multiset.map_cons, multiset.sum_cons],
-end
-
-lemma nat_degree_separable_eq_card_roots {p : polynomial F} {i : F →+* K}
-  (hsep : separable p) (hsplit : splits i p) : p.nat_degree = (p.map i).roots.card :=
-begin
-  by_cases p_eq_zero : p = 0,
-  { rw [p_eq_zero, nat_degree_zero, map_zero, roots_zero, multiset.card_zero] },
-  have map_ne_zero : p.map i ≠ 0 := map_ne_zero (p_eq_zero),
-  rw eq_prod_roots_of_separable hsep hsplit at map_ne_zero,
-
-  conv_lhs { rw [← nat_degree_map i, eq_prod_roots_of_separable hsep hsplit] },
-  have : ∀ p' ∈ (map i p).roots.map (λ (a : K), X - C a), p' ≠ (0 : polynomial K),
-  { intros p hp,
-    obtain ⟨a, ha, rfl⟩ := multiset.mem_map.mp hp,
-    exact X_sub_C_ne_zero _ },
-  simp [nat_degree_mul (left_ne_zero_of_mul map_ne_zero) (right_ne_zero_of_mul map_ne_zero),
-        nat_degree_multiset_prod this]
-end
-
-lemma degree_separable_eq_card_roots {p : polynomial F} {i : F →+* K} (p_ne_zero : p ≠ 0)
-  (hsep : separable p) (hsplit : splits i p) : p.degree = (p.map i).roots.card :=
-by rw [degree_eq_nat_degree p_ne_zero, nat_degree_separable_eq_card_roots hsep hsplit]
-
 end splits
 
 end field

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -191,6 +191,33 @@ begin
       multiset.bind_cons, multiset.bind_zero, add_zero, multiset.map_id']
 end
 
+lemma eq_prod_roots_of_splits {p : polynomial α} {i : α →+* β}
+  (hsplit : splits i p) :
+  p.map i = C (i p.leading_coeff) * ((p.map i).roots.map (λ a, X - C a)).prod :=
+begin
+  by_cases p_eq_zero : p = 0,
+  { rw [p_eq_zero, map_zero, leading_coeff_zero, i.map_zero, C.map_zero, zero_mul] },
+
+  obtain ⟨s, hs⟩ := exists_multiset_of_splits i hsplit,
+  have map_ne_zero : p.map i ≠ 0 := map_ne_zero (p_eq_zero),
+  have prod_ne_zero : C (i p.leading_coeff) * (multiset.map (λ a, X - C a) s).prod ≠ 0 :=
+    by rwa hs at map_ne_zero,
+
+  have ne_zero_of_mem : ∀ (p : polynomial β), p ∈ s.map (λ a, X - C a) → p ≠ 0,
+  { intros p mem,
+    obtain ⟨a, _, rfl⟩ := multiset.mem_map.mp mem,
+    apply X_sub_C_ne_zero },
+  have map_bind_roots_eq : (s.map (λ a, X - C a)).bind (λ a, a.roots) = s,
+  { refine multiset.induction_on s (by rw [multiset.map_zero, multiset.zero_bind]) _,
+    intros a s ih,
+    rw [multiset.map_cons, multiset.cons_bind, ih, roots_X_sub_C,
+        multiset.cons_add, zero_add] },
+
+  rw [hs, roots_mul prod_ne_zero, roots_C, zero_add,
+      roots_multiset_prod _ ne_zero_of_mem,
+      map_bind_roots_eq]
+end
+
 section UFD
 
 local attribute [instance, priority 10] principal_ideal_ring.to_unique_factorization_domain

--- a/src/linear_algebra/lagrange.lean
+++ b/src/linear_algebra/lagrange.lean
@@ -131,8 +131,9 @@ theorem eq_zero_of_eval_eq_zero {f : polynomial F'} (hf1 : f.degree < s'.card)
   (hf2 : ∀ x ∈ s', f.eval x = 0) : f = 0 :=
 by_contradiction $ λ hf3, not_le_of_lt hf1 $
 calc  (s'.card : with_bot ℕ)
-    ≤ f.roots.card : with_bot.coe_le_coe.2 $ finset.card_le_of_subset $ λ x hx,
-        (mem_roots hf3).2 $ hf2 x hx
+    ≤ f.roots.to_finset.card : with_bot.coe_le_coe.2 $ finset.card_le_of_subset $ λ x hx,
+        (multiset.mem_to_finset).mpr $ (mem_roots hf3).2 $ hf2 x hx
+... ≤ f.roots.card : with_bot.coe_le_coe.2 $ f.roots.to_finset_card_le
 ... ≤ f.degree : card_roots hf3
 
 theorem eq_of_eval_eq {f g : polynomial F'} (hf : f.degree < s'.card) (hg : g.degree < s'.card)

--- a/src/ring_theory/integral_domain.lean
+++ b/src/ring_theory/integral_domain.lean
@@ -35,8 +35,12 @@ variables {R : Type*} {G : Type*} [integral_domain R] [group G] [fintype G]
 lemma card_nth_roots_subgroup_units (f : G →* R) (hf : injective f) {n : ℕ} (hn : 0 < n) (g₀ : G) :
   ({g ∈ univ | g ^ n = g₀} : finset G).card ≤ (nth_roots n (f g₀)).card :=
 begin
+  haveI : decidable_eq R := classical.dec_eq _,
+  refine le_trans _ (nth_roots n (f g₀)).to_finset_card_le,
   apply card_le_card_of_inj_on f,
-  { intros g hg, rw [sep_def, mem_filter] at hg, rw [mem_nth_roots hn, ← f.map_pow, hg.2] },
+  { intros g hg,
+    rw [sep_def, mem_filter] at hg,
+    rw [multiset.mem_to_finset, mem_nth_roots hn, ← f.map_pow, hg.2] },
   { intros, apply hf, assumption }
 end
 

--- a/src/ring_theory/multiplicity.lean
+++ b/src/ring_theory/multiplicity.lean
@@ -7,7 +7,7 @@ import algebra.associated
 import data.int.gcd
 import algebra.big_operators.basic
 import data.nat.enat
-
+import tactic
 
 variables {α : Type*}
 
@@ -148,6 +148,12 @@ lemma multiplicity_le_multiplicity_iff {a b c d : α} : multiplicity a b ≤ mul
 
 lemma dvd_of_multiplicity_pos {a b : α} (h : (0 : enat) < multiplicity a b) : a ∣ b :=
 by rw [← _root_.pow_one a]; exact pow_dvd_of_le_multiplicity (enat.pos_iff_one_le.1 h)
+
+lemma dvd_iff_multiplicity_pos {a b : α} : (0 : enat) < multiplicity a b ↔ a ∣ b :=
+⟨dvd_of_multiplicity_pos,
+  λ hdvd, lt_of_le_of_ne (zero_le _) (λ heq, is_greatest
+    (show multiplicity a b < 1, from heq ▸ enat.coe_lt_coe.mpr zero_lt_one)
+    (by rwa pow_one a))⟩
 
 lemma finite_nat_iff {a b : ℕ} : finite a b ↔ (a ≠ 1 ∧ 0 < b) :=
 begin


### PR DESCRIPTION
The original definition of `polynomial.roots` was basically "while ∃ x, p.is_root x { finset.insert x polynomial.roots }", so it was not
too hard to replace this with `multiset.cons`.

I tried to refactor most usages of `polynomial.roots` to talk about the multiset instead of coercing it to a finset, since that should give a bit more power to the results.


---
<!-- put comments you want to keep out of the PR commit here -->
