### PR TITLE
[Merged by Bors] - chore(*): use new `extends_priority` default of 100

### DIFF
--- a/src/algebra/add_torsor.lean
+++ b/src/algebra/add_torsor.lean
@@ -49,8 +49,7 @@ class has_vsub (G : out_param Type*) (P : Type*) :=
 infix ` +ᵥ `:65 := has_vadd.vadd
 infix ` -ᵥ `:65 := has_vsub.vsub
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
+section old_structure_cmd
 set_option old_structure_cmd true
 /-- Type class for additive monoid actions. -/
 class add_action (G : Type*) (P : Type*) [add_monoid G] extends has_vadd G P :=
@@ -70,7 +69,7 @@ class add_torsor (G : out_param Type*) (P : Type*) [out_param $ add_group G]
 
 attribute [instance, priority 100, nolint dangerous_instance] add_torsor.nonempty
 
-end prio
+end old_structure_cmd
 
 /-- An `add_group G` is a torsor for itself. -/
 @[nolint instance_priority]

--- a/src/algebra/char_p.lean
+++ b/src/algebra/char_p.lean
@@ -293,9 +293,7 @@ section char_one
 
 variables {R : Type*}
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
-
+@[priority 100]  -- see Note [lower instance priority]
 instance [semiring R] [char_p R 1] : subsingleton R :=
 subsingleton.intro $
 suffices ∀ (r : R), r = 0,
@@ -305,8 +303,6 @@ calc r = 1 * r       : by rw one_mul
    ... = (1 : ℕ) * r : by rw nat.cast_one
    ... = 0 * r       : by rw char_p.cast_eq_zero
    ... = 0           : by rw zero_mul
-
-end prio
 
 lemma false_of_nonzero_of_char_one [semiring R] [nontrivial R] [char_p R 1] : false :=
 zero_ne_one $ show (0:R) = 1, from subsingleton.elim 0 1

--- a/src/algebra/euclidean_domain.lean
+++ b/src/algebra/euclidean_domain.lean
@@ -11,8 +11,7 @@ import algebra.field
 
 universe u
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
+section old_structure_cmd
 set_option old_structure_cmd true
 
 /-- A `euclidean_domain` is an `integral_domain` with a division and a remainder, satisfying
@@ -31,7 +30,7 @@ class euclidean_domain (R : Type u) extends comm_ring R, nontrivial R :=
 (r_well_founded : well_founded r)
 (remainder_lt : ∀ a {b}, b ≠ 0 → r (remainder a b) b)
 (mul_left_not_lt : ∀ a {b}, b ≠ 0 → ¬r (a * b) a)
-end prio
+end old_structure_cmd
 
 namespace euclidean_domain
 variable {R : Type u}

--- a/src/algebra/field.lean
+++ b/src/algebra/field.lean
@@ -7,7 +7,6 @@ import algebra.ring.basic
 import algebra.group_with_zero
 open set
 
-set_option default_priority 100 -- see Note [default priority]
 set_option old_structure_cmd true
 
 universe u
@@ -23,6 +22,7 @@ class division_ring (α : Type u) extends ring α, has_inv α, nontrivial α :=
 section division_ring
 variables [division_ring α] {a b : α}
 
+@[priority 100] -- see Note [lower instance priority]
 instance division_ring_has_div : has_div α :=
 ⟨λ a b, a * b⁻¹⟩
 
@@ -103,6 +103,7 @@ by rw [(mul_sub_left_distrib (1 / a)), (one_div_mul_cancel ha), mul_sub_right_di
 lemma add_div_eq_mul_add_div (a b : α) {c : α} (hc : c ≠ 0) : a + b / c = (a * c + b) / c :=
 (eq_div_iff_mul_eq hc).2 $ by rw [right_distrib, (div_mul_cancel _ hc)]
 
+@[priority 100] -- see Note [lower instance priority]
 instance division_ring.to_domain : domain α :=
 { ..‹division_ring α›, ..(by apply_instance : semiring α),
   ..(by apply_instance : no_zero_divisors α) }
@@ -119,11 +120,13 @@ section field
 
 variable [field α]
 
+@[priority 100] -- see Note [lower instance priority]
 instance field.to_division_ring : division_ring α :=
 { inv_mul_cancel := λ _ h, by rw [mul_comm, field.mul_inv_cancel h]
   ..show field α, by apply_instance }
 
 /-- Every field is a `comm_group_with_zero`. -/
+@[priority 100] -- see Note [lower instance priority]
 instance field.to_comm_group_with_zero :
   comm_group_with_zero α :=
 { .. (_ : group_with_zero α), .. ‹field α› }

--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -718,6 +718,7 @@ lemma units_eq_one (u : units α) : u = 1 := subsingleton.elim u 1
 
 variable [nontrivial α]
 
+@[priority 100] -- see Note [lower instance priority]
 instance normalization_monoid_of_unique_units : normalization_monoid α :=
 { norm_unit := λ x, 1,
   norm_unit_zero := rfl,

--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -51,8 +51,6 @@ set_option old_structure_cmd true
 
 
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /-- Normalization monoid: multiplying with `norm_unit` gives a normal form for associated elements. -/
 @[protect_proj] class normalization_monoid (α : Type*) [nontrivial α]
   [comm_cancel_monoid_with_zero α] :=
@@ -60,7 +58,6 @@ set_option default_priority 100 -- see Note [default priority]
 (norm_unit_zero      : norm_unit 0 = 1)
 (norm_unit_mul       : ∀{a b}, a ≠ 0 → b ≠ 0 → norm_unit (a * b) = norm_unit a * norm_unit b)
 (norm_unit_coe_units : ∀(u : units α), norm_unit u = u⁻¹)
-end prio
 
 export normalization_monoid (norm_unit norm_unit_zero norm_unit_mul norm_unit_coe_units)
 
@@ -171,8 +168,6 @@ quotient.induction_on a normalize_idem
 
 end associates
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /-- GCD monoid: a `comm_cancel_monoid_with_zero` with normalization and `gcd`
 (greatest common divisor) and `lcm` (least common multiple) operations. In this setting `gcd` and
 `lcm` form a bounded lattice on the associated elements where `gcd` is the infimum, `lcm` is the
@@ -190,7 +185,6 @@ corresponding `lcm` facts from `gcd`.
 (gcd_mul_lcm    : ∀a b, gcd a b * lcm a b = normalize (a * b))
 (lcm_zero_left  : ∀a, lcm 0 a = 0)
 (lcm_zero_right : ∀a, lcm a 0 = 0)
-end prio
 
 export gcd_monoid (gcd lcm gcd_dvd_left gcd_dvd_right dvd_gcd  lcm_zero_left lcm_zero_right)
 
@@ -724,14 +718,11 @@ lemma units_eq_one (u : units α) : u = 1 := subsingleton.elim u 1
 
 variable [nontrivial α]
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 instance normalization_monoid_of_unique_units : normalization_monoid α :=
 { norm_unit := λ x, 1,
   norm_unit_zero := rfl,
   norm_unit_mul := λ x y hx hy, (mul_one 1).symm,
   norm_unit_coe_units := λ u, subsingleton.elim _ _ }
-end prio
 
 @[simp] lemma norm_unit_eq_one (x : α) : norm_unit x = 1 := rfl
 

--- a/src/algebra/group/defs.lean
+++ b/src/algebra/group/defs.lean
@@ -332,17 +332,17 @@ by rwa [inv_inv] at this
 lemma mul_inv_cancel_right (a b : G) : a * b * b⁻¹ = a :=
 by rw [mul_assoc, mul_right_inv, mul_one]
 
-@[to_additive]
+@[priority 100, to_additive]    -- see Note [lower instance priority]
 instance group.to_left_cancel_semigroup : left_cancel_semigroup G :=
 { mul_left_cancel := λ a b c h, by rw [← inv_mul_cancel_left a b, h, inv_mul_cancel_left],
   ..‹group G› }
 
-@[to_additive]
+@[priority 100, to_additive]    -- see Note [lower instance priority]
 instance group.to_right_cancel_semigroup : right_cancel_semigroup G :=
 { mul_right_cancel := λ a b c h, by rw [← mul_inv_cancel_right a b, h, mul_inv_cancel_right],
   ..‹group G› }
 
-@[to_additive]
+@[priority 100, to_additive]    -- see Note [lower instance priority]
 instance group.to_cancel_monoid : cancel_monoid G :=
 { ..‹group G›, .. group.to_left_cancel_semigroup,
   ..group.to_right_cancel_semigroup }
@@ -357,6 +357,7 @@ variables {G : Type u} [add_group G]
 @[reducible] protected def algebra.sub (a b : G) : G :=
 a + -b
 
+@[priority 100]    -- see Note [lower instance priority]
 instance add_group_has_sub : has_sub G :=
 ⟨algebra.sub⟩
 
@@ -378,7 +379,7 @@ section comm_group
 
 variables {G : Type u} [comm_group G]
 
-@[to_additive]
+@[priority 100, to_additive]    -- see Note [lower instance priority]
 instance comm_group.to_cancel_comm_monoid : cancel_comm_monoid G :=
 { ..‹comm_group G›,
   ..group.to_left_cancel_semigroup,

--- a/src/algebra/group/defs.lean
+++ b/src/algebra/group/defs.lean
@@ -22,7 +22,6 @@ The file does not contain any lemmas except for
 For basic lemmas about these classes see `algebra.group.basic`.
 -/
 
-set_option default_priority 100
 set_option old_structure_cmd true
 
 universe u

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -30,16 +30,11 @@ group action, invariant subring
 universes u v
 open_locale big_operators
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
-
 /-- Typeclass for multiplicative actions by monoids on semirings. -/
 class mul_semiring_action (M : Type u) [monoid M] (R : Type v) [semiring R]
   extends distrib_mul_action M R :=
 (smul_one : ∀ (g : M), (g • 1 : R) = 1)
 (smul_mul : ∀ (g : M) (x y : R), g • (x * y) = (g • x) * (g • y))
-
-end prio
 
 export mul_semiring_action (smul_one)
 

--- a/src/algebra/group_with_zero.lean
+++ b/src/algebra/group_with_zero.lean
@@ -44,17 +44,12 @@ division-free."
 
 section
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
-
 /-- Typeclass for expressing that a type `M₀` with multiplication and a zero satisfies
 `0 * a = 0` and `a * 0 = 0` for all `a : M₀`. -/
 @[protect_proj, ancestor has_mul has_zero]
 class mul_zero_class (M₀ : Type*) extends has_mul M₀, has_zero M₀ :=
 (zero_mul : ∀ a : M₀, 0 * a = 0)
 (mul_zero : ∀ a : M₀, a * 0 = 0)
-
-end prio
 
 section mul_zero_class
 
@@ -156,10 +151,7 @@ lemma zero_eq_mul_self : 0 = a * a ↔ a = 0 := by simp
 
 end
 
-end -- default_priority 100
-
-section prio
-set_option default_priority 100 -- see Note [default priority]
+end
 
 /-- A type `M` is a “monoid with zero” if it is a monoid with zero element, and `0` is left
 and right absorbing. -/
@@ -235,10 +227,9 @@ The type is required to come with an “inverse” function, and the inverse of 
 class comm_group_with_zero (G₀ : Type*) extends comm_monoid_with_zero G₀, group_with_zero G₀.
 
 /-- The division operation on a group with zero element. -/
+@[priority 100] -- see Note [lower instance priority]
 instance group_with_zero.has_div {G₀ : Type*} [group_with_zero G₀] :
   has_div G₀ := ⟨λ g h, g * h⁻¹⟩
-
-end prio
 
 section monoid_with_zero
 
@@ -344,14 +335,10 @@ section cancel_monoid_with_zero
 
 variables [cancel_monoid_with_zero M₀] {a b c : M₀}
 
-section prio
-set_option default_priority 10 -- see Note [default priority]
-
+@[priority 10] -- see Note [lower instance priority]
 instance comm_cancel_monoid_with_zero.no_zero_divisors : no_zero_divisors M₀ :=
 ⟨λ a b ab0, by { by_cases a = 0, { left, exact h }, right,
   apply cancel_monoid_with_zero.mul_left_cancel_of_ne_zero h, rw [ab0, mul_zero], }⟩
-
-end prio
 
 lemma mul_left_cancel' (ha : a ≠ 0) (h : a * b = a * c) : b = c :=
 cancel_monoid_with_zero.mul_left_cancel_of_ne_zero ha h
@@ -565,9 +552,7 @@ lemma is_unit.mk0 (x : G₀) (hx : x ≠ 0) : is_unit x := is_unit_unit (units.m
 lemma is_unit_iff_ne_zero {x : G₀} : is_unit x ↔ x ≠ 0 :=
 units.exists_iff_ne_zero
 
-section prio
-set_option default_priority 10 -- see Note [default priority]
-
+@[priority 10] -- see Note [lower instance priority]
 instance group_with_zero.no_zero_divisors : no_zero_divisors G₀ :=
 { eq_zero_or_eq_zero_of_mul_eq_zero := λ a b h,
     begin
@@ -576,14 +561,13 @@ instance group_with_zero.no_zero_divisors : no_zero_divisors G₀ :=
     end,
   .. (‹_› : group_with_zero G₀) }
 
+@[priority 10] -- see Note [lower instance priority]
 instance group_with_zero.cancel_monoid_with_zero : cancel_monoid_with_zero G₀ :=
 { mul_left_cancel_of_ne_zero := λ x y z hx h,
     by rw [← inv_mul_cancel_left' hx y, h, inv_mul_cancel_left' hx z],
   mul_right_cancel_of_ne_zero := λ x y z hy h,
     by rw [← mul_inv_cancel_right' hy x, h, mul_inv_cancel_right' hy z],
   .. (‹_› : group_with_zero G₀) }
-
-end prio
 
 lemma mul_inv_rev' (x y : G₀) : (x * y)⁻¹ = y⁻¹ * x⁻¹ :=
 begin
@@ -729,13 +713,9 @@ end group_with_zero
 section comm_group_with_zero -- comm
 variables [comm_group_with_zero G₀] {a b c : G₀}
 
-section prio
-set_option default_priority 10 -- see Note [default priority]
-
+@[priority 10] -- see Note [lower instance priority]
 instance comm_group_with_zero.comm_cancel_monoid_with_zero : comm_cancel_monoid_with_zero G₀ :=
 { ..group_with_zero.cancel_monoid_with_zero, ..comm_group_with_zero.to_comm_monoid_with_zero G₀ }
-
-end prio
 
 /-- Pullback a `comm_group_with_zero` class along an injective function. -/
 protected def function.injective.comm_group_with_zero [has_zero G₀'] [has_mul G₀'] [has_one G₀']

--- a/src/algebra/lie_algebra.lean
+++ b/src/algebra/lie_algebra.lean
@@ -71,8 +71,6 @@ lemma commutator (x y : A) : ⁅x, y⁆ = x*y - y*x := rfl
 
 end ring_commutator
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /--
 A Lie ring is an additive group with compatible product, known as the bracket, satisfying the
 Jacobi identity. The bracket is not associative unless it is identically zero.
@@ -82,7 +80,6 @@ Jacobi identity. The bracket is not associative unless it is identically zero.
 (lie_add : ∀ (x y z : L), ⁅z, x + y⁆ = ⁅z, x⁆ + ⁅z, y⁆)
 (lie_self : ∀ (x : L), ⁅x, x⁆ = 0)
 (jacobi : ∀ (x y z : L), ⁅x, ⁅y, z⁆⁆ + ⁅y, ⁅z, x⁆⁆ + ⁅z, ⁅x, y⁆⁆ = 0)
-end prio
 
 section lie_ring
 
@@ -154,15 +151,12 @@ end
 
 end lie_ring
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /--
 A Lie algebra is a module with compatible product, known as the bracket, satisfying the Jacobi
 identity. Forgetting the scalar multiplication, every Lie algebra is a Lie ring.
 -/
 class lie_algebra (R : Type u) (L : Type v) [comm_ring R] [lie_ring L] extends semimodule R L :=
 (lie_smul : ∀ (t : R) (x y : L), ⁅x, t • y⁆ = t • ⁅x, y⁆)
-end prio
 
 @[simp] lemma lie_smul  (R : Type u) (L : Type v) [comm_ring R] [lie_ring L] [lie_algebra R L]
   (t : R) (x y : L) : ⁅x, t • y⁆ = t • ⁅x, y⁆ :=
@@ -545,15 +539,12 @@ section lie_module
 variables (R : Type u) (L : Type v) [comm_ring R] [lie_ring L] [lie_algebra R L]
 variables (M  : Type v) [add_comm_group M] [module R M]
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /--
 A Lie module is a module over a commutative ring, together with a linear action of a Lie algebra
 on this module, such that the Lie bracket acts as the commutator of endomorphisms.
 -/
 class lie_module extends linear_action R L M :=
 (lie_act : ∀ (l l' : L) (m : M), act ⁅l, l'⁆ m = act l (act l' m) - act l' (act l m))
-end prio
 
 @[simp] lemma lie_act [lie_module R L M]
   (l l' : L) (m : M) : linear_action.act R ⁅l, l'⁆ m =

--- a/src/algebra/linear_ordered_comm_group_with_zero.lean
+++ b/src/algebra/linear_ordered_comm_group_with_zero.lean
@@ -23,7 +23,6 @@ The solutions is to use a typeclass, and that is exactly what we do in this file
 -/
 
 set_option old_structure_cmd true
-set_option default_priority 100 -- see Note [default priority]
 
 /-- A linearly ordered commutative group with a zero element. -/
 class linear_ordered_comm_group_with_zero (α : Type*)
@@ -37,6 +36,7 @@ variables {a b c d x y z : α}
 local attribute [instance] classical.prop_decidable
 
 /-- Every linearly ordered commutative group with zero is an ordered commutative monoid.-/
+@[priority 100] -- see Note [lower instance priority]
 instance linear_ordered_comm_group_with_zero.to_ordered_comm_monoid : ordered_comm_monoid α :=
 { lt_of_mul_lt_mul_left := λ a b c h, by { contrapose! h,
     exact linear_ordered_comm_group_with_zero.mul_le_mul_left h a }

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -41,8 +41,6 @@ universes u u' v w x y z
 variables {R : Type u} {k : Type u'} {S : Type v} {M : Type w} {M₂ : Type x} {M₃ : Type y}
   {ι : Type z}
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /-- A semimodule is a generalization of vector spaces to a scalar semiring.
   It consists of a scalar semiring `R` and an additive monoid of "vectors" `M`,
   connected by a "scalar multiplication" operation `r • x : M`
@@ -52,7 +50,6 @@ set_option default_priority 100 -- see Note [default priority]
   [add_comm_monoid M] extends distrib_mul_action R M :=
 (add_smul : ∀(r s : R) (x : M), (r + s) • x = r • x + s • x)
 (zero_smul : ∀x : M, (0 : R) • x = 0)
-end prio
 
 section add_comm_monoid
 variables [semiring R] [add_comm_monoid M] [semimodule R M] (r s : R) (x y : M)
@@ -197,8 +194,7 @@ theorem smul_eq_zero {R E : Type*} [division_ring R] [add_comm_group E] [module 
 
 end module
 
-section
-set_option default_priority 910
+@[priority 910] -- see Note [lower instance priority]
 instance semiring.to_semimodule [semiring R] : semimodule R R :=
 { smul := (*),
   smul_add := mul_add,
@@ -207,7 +203,6 @@ instance semiring.to_semimodule [semiring R] : semimodule R R :=
   one_smul := one_mul,
   zero_smul := zero_mul,
   smul_zero := mul_zero }
-end
 
 @[simp] lemma smul_eq_mul [semiring R] {a a' : R} : a • a' = a * a' := rfl
 

--- a/src/algebra/module/ordered.lean
+++ b/src/algebra/module/ordered.lean
@@ -34,8 +34,6 @@ ordered semimodule, ordered module, ordered vector space
 -/
 
 
-set_option default_priority 100 -- see Note [default priority]
-
 /--
 An ordered semimodule is an ordered additive commutative monoid
 with a partial order in which the scalar multiplication is compatible with the order.

--- a/src/algebra/ordered_field.lean
+++ b/src/algebra/ordered_field.lean
@@ -18,7 +18,6 @@ import algebra.field
     decidable.
 -/
 
-set_option default_priority 100 -- see Note [default priority]
 set_option old_structure_cmd true
 
 variable {α : Type*}
@@ -485,6 +484,7 @@ lemma strict_mono.div_const {β : Type*} [preorder β] {f : β → α} (hf : str
   strict_mono (λ x, (f x) / c) :=
 hf.mul_const (inv_pos.2 hc)
 
+@[priority 100] -- see Note [lower instance priority]
 instance linear_ordered_field.to_densely_ordered : densely_ordered α :=
 { dense := λ a₁ a₂ h, ⟨(a₁ + a₂) / 2,
   calc a₁ = (a₁ + a₁) / 2 : (add_self_div_two a₁).symm

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -602,6 +602,7 @@ class canonically_linear_ordered_add_monoid (α : Type*)
 section canonically_linear_ordered_add_monoid
 variables [canonically_linear_ordered_add_monoid α]
 
+@[priority 100]  -- see Note [lower instance priority]
 instance canonically_linear_ordered_add_monoid.semilattice_sup_bot : semilattice_sup_bot α :=
 { ..lattice_of_decidable_linear_order, ..canonically_ordered_add_monoid.to_order_bot α }
 

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -8,7 +8,6 @@ import algebra.group.type_tags
 import order.bounded_lattice
 
 set_option old_structure_cmd true
-set_option default_priority 100 -- see Note [default priority]
 
 /-!
 # Ordered monoids and groups
@@ -633,7 +632,7 @@ attribute [to_additive] ordered_cancel_comm_monoid
 section ordered_cancel_comm_monoid
 variables [ordered_cancel_comm_monoid α] {a b c d : α}
 
-@[to_additive]
+@[priority 100, to_additive]    -- see Note [lower instance priority]
 instance ordered_cancel_comm_monoid.to_left_cancel_monoid :
   left_cancel_monoid α := { ..‹ordered_cancel_comm_monoid α› }
 
@@ -641,7 +640,7 @@ instance ordered_cancel_comm_monoid.to_left_cancel_monoid :
 lemma le_of_mul_le_mul_left' : ∀ {a b c : α}, a * b ≤ a * c → b ≤ c :=
 ordered_cancel_comm_monoid.le_of_mul_le_mul_left
 
-@[to_additive]
+@[priority 100, to_additive]    -- see Note [lower instance priority]
 instance ordered_cancel_comm_monoid.to_ordered_comm_monoid : ordered_comm_monoid α :=
 { lt_of_mul_lt_mul_left := λ a b c h, lt_of_le_not_le (le_of_mul_le_mul_left' h.le) $
       mt (λ h, ordered_cancel_comm_monoid.mul_le_mul_left _ _ h _) (not_le_of_gt h),
@@ -910,7 +909,7 @@ lemma ordered_comm_group.lt_of_mul_lt_mul_left (h : a * b < a * c) : b < c :=
 have a⁻¹ * (a * b) < a⁻¹ * (a * c), from ordered_comm_group.mul_lt_mul_left' _ _ h _,
 begin simp [inv_mul_cancel_left] at this, assumption end
 
-@[to_additive]
+@[priority 100, to_additive]    -- see Note [lower instance priority]
 instance ordered_comm_group.to_ordered_cancel_comm_monoid (α : Type u)
   [s : ordered_comm_group α] : ordered_cancel_comm_monoid α :=
 { mul_left_cancel       := @mul_left_cancel α _,
@@ -1585,6 +1584,7 @@ addition is strictly monotone. -/
   extends add_comm_group α, decidable_linear_order α :=
 (add_le_add_left : ∀ a b : α, a ≤ b → ∀ c : α, c + a ≤ c + b)
 
+@[priority 100] -- see Note [lower instance priority]
 instance decidable_linear_ordered_comm_group.to_ordered_add_comm_group (α : Type u)
   [s : decidable_linear_ordered_add_comm_group α] : ordered_add_comm_group α :=
 { add := s.add, ..s }
@@ -1806,9 +1806,6 @@ eq_of_abs_sub_eq_zero (le_antisymm h (abs_nonneg (a - b)))
 
 end decidable_linear_ordered_add_comm_group
 
-set_option old_structure_cmd true
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /-- This is not so much a new structure as a construction mechanism
   for ordered groups, by specifying only the "positive cone" of the group. -/
 class nonneg_add_comm_group (α : Type*) extends add_comm_group α :=
@@ -1818,7 +1815,6 @@ class nonneg_add_comm_group (α : Type*) extends add_comm_group α :=
 (zero_nonneg : nonneg 0)
 (add_nonneg : ∀ {a b}, nonneg a → nonneg b → nonneg (a + b))
 (nonneg_antisymm : ∀ {a}, nonneg a → nonneg (-a) → a = 0)
-end prio
 
 namespace nonneg_add_comm_group
 variable [s : nonneg_add_comm_group α]

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -5,7 +5,6 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro
 -/
 import algebra.ordered_group
 
-set_option default_priority 100 -- see Note [default priority]
 set_option old_structure_cmd true
 
 universe u
@@ -332,6 +331,7 @@ lt_of_not_ge (λ ha, absurd h (mul_nonpos_of_nonneg_of_nonpos ha hb).not_lt)
 lemma neg_of_mul_pos_right (h : 0 < a * b) (ha : a ≤ 0) : b < 0 :=
 lt_of_not_ge (λ hb, absurd h (mul_nonpos_of_nonpos_of_nonneg ha hb).not_lt)
 
+@[priority 100] -- see Note [lower instance priority]
 instance linear_ordered_semiring.to_nontrivial {α : Type*} [linear_ordered_semiring α] :
   nontrivial α :=
 { exists_pair_ne := ⟨0, 1, ne_of_lt zero_lt_one⟩ }
@@ -339,6 +339,7 @@ instance linear_ordered_semiring.to_nontrivial {α : Type*} [linear_ordered_semi
 /- TODO This theorem ought to be written in the context of `nontrivial` linearly ordered (additive)
 commutative monoids rather than linearly ordered rings; however, the former concept does not
 currently exist in mathlib. -/
+@[priority 100] -- see Note [lower instance priority]
 instance linear_ordered_semiring.to_no_top_order {α : Type*} [linear_ordered_semiring α] :
   no_top_order α :=
 ⟨assume a, ⟨a + 1, lt_add_of_pos_right _ zero_lt_one⟩⟩
@@ -461,6 +462,7 @@ begin
   apply lt_of_sub_pos this
 end
 
+@[priority 100] -- see Note [lower instance priority]
 instance ordered_ring.to_ordered_semiring : ordered_semiring α :=
 { mul_zero                   := mul_zero,
   zero_mul                   := zero_mul,
@@ -513,6 +515,7 @@ multiplication with a positive number and addition are monotone. -/
 section linear_ordered_ring
 variables [linear_ordered_ring α] {a b c : α}
 
+@[priority 100] -- see Note [lower instance priority]
 instance linear_ordered_ring.to_linear_ordered_semiring : linear_ordered_semiring α :=
 { mul_zero                   := mul_zero,
   zero_mul                   := zero_mul,
@@ -609,6 +612,7 @@ end
 /- TODO This theorem ought to be written in the context of `nontrivial` linearly ordered (additive)
 commutative groups rather than linearly ordered rings; however, the former concept does not
 currently exist in mathlib. -/
+@[priority 100] -- see Note [lower instance priority]
 instance linear_ordered_ring.to_no_bot_order : no_bot_order α :=
 ⟨assume a, ⟨a - 1, sub_lt_iff_lt_add.mpr $ lt_add_of_pos_right _ zero_lt_one⟩⟩
 
@@ -674,6 +678,7 @@ such that multiplication with a positive number and addition are monotone. -/
 @[protect_proj]
 class linear_ordered_comm_ring (α : Type u) extends linear_ordered_ring α, comm_monoid α
 
+@[priority 100] -- see Note [lower instance priority]
 instance linear_ordered_comm_ring.to_integral_domain [s: linear_ordered_comm_ring α] : integral_domain α :=
 { eq_zero_or_eq_zero_of_mul_eq_zero := @linear_ordered_ring.eq_zero_or_eq_zero_of_mul_eq_zero α _,
   ..s }
@@ -684,6 +689,7 @@ addition are monotone. -/
 @[protect_proj] class decidable_linear_ordered_comm_ring (α : Type u) extends linear_ordered_comm_ring α,
     decidable_linear_ordered_add_comm_group α
 
+@[priority 100] -- see Note [lower instance priority]
 instance decidable_linear_ordered_comm_ring.to_decidable_linear_ordered_semiring [d : decidable_linear_ordered_comm_ring α] :
    decidable_linear_ordered_semiring α :=
 let s : linear_ordered_semiring α := @linear_ordered_ring.to_linear_ordered_semiring α _ in
@@ -814,6 +820,7 @@ namespace nonneg_ring
 open nonneg_add_comm_group
 variable [nonneg_ring α]
 
+@[priority 100] -- see Note [lower instance priority]
 instance to_ordered_ring : ordered_ring α :=
 { mul_pos := λ a b, by simp [pos_def.symm]; exact mul_pos,
   ..‹nonneg_ring α›, ..(infer_instance : ordered_add_comm_group α) }
@@ -900,6 +907,7 @@ variables [canonically_ordered_comm_semiring α] {a b : α}
 
 open canonically_ordered_add_monoid (le_iff_exists_add)
 
+@[priority 100] -- see Note [lower instance priority]
 instance canonically_ordered_comm_semiring.to_no_zero_divisors :
   no_zero_divisors α :=
 ⟨canonically_ordered_comm_semiring.eq_zero_or_eq_zero_of_mul_eq_zero⟩

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -48,7 +48,6 @@ to use this method than to use type class inference.
 universes u v w x
 variables {α : Type u} {β : Type v} {γ : Type w} {R : Type x}
 
-set_option default_priority 100 -- see Note [default priority]
 set_option old_structure_cmd true
 open function
 
@@ -197,15 +196,12 @@ structure ring_hom (α : Type*) (β : Type*) [semiring α] [semiring β]
 
 infixr ` →+* `:25 := ring_hom
 
-@[priority 1000]
 instance {α : Type*} {β : Type*} {rα : semiring α} {rβ : semiring β} : has_coe_to_fun (α →+* β) :=
 ⟨_, ring_hom.to_fun⟩
 
-@[priority 1000]
 instance {α : Type*} {β : Type*} {rα : semiring α} {rβ : semiring β} : has_coe (α →+* β) (α →* β) :=
 ⟨ring_hom.to_monoid_hom⟩
 
-@[priority 1000]
 instance {α : Type*} {β : Type*} {rα : semiring α} {rβ : semiring β} : has_coe (α →+* β) (α →+ β) :=
 ⟨ring_hom.to_add_monoid_hom⟩
 
@@ -354,12 +350,14 @@ end ring_hom
 @[protect_proj, ancestor semiring comm_monoid]
 class comm_semiring (α : Type u) extends semiring α, comm_monoid α
 
+@[priority 100] -- see Note [lower instance priority]
 instance comm_semiring.to_comm_monoid_with_zero [comm_semiring α] : comm_monoid_with_zero α :=
 { .. comm_semiring.to_comm_monoid α, .. comm_semiring.to_semiring α }
 
 section comm_semiring
 variables [comm_semiring α] [comm_semiring β] {a b c : α}
 
+@[priority 100] -- see Note [lower instance priority]
 instance comm_semiring.comm_monoid_with_zero : comm_monoid_with_zero α :=
 { .. (‹_› : comm_semiring α) }
 
@@ -401,18 +399,17 @@ class ring (α : Type u) extends add_comm_group α, monoid α, distrib α
 section ring
 variables [ring α] {a b c d e : α}
 
+/- The instance from `ring` to `semiring` happens often in linear algebra, for which all the basic
+definitions are given in terms of semirings, but many applications use rings or fields. We increase
+a little bit its priority above 100 to try it quickly, but remaining below the default 1000 so that
+more specific instances are tried first. -/
+@[priority 200]
 instance ring.to_semiring : semiring α :=
 { zero_mul := λ a, add_left_cancel $ show 0 * a + 0 * a = 0 * a + 0,
     by rw [← add_mul, zero_add, add_zero],
   mul_zero := λ a, add_left_cancel $ show a * 0 + a * 0 = a * 0 + 0,
     by rw [← mul_add, add_zero, add_zero],
   ..‹ring α› }
-
-/- The instance from `ring` to `semiring` happens often in linear algebra, for which all the basic
-definitions are given in terms of semirings, but many applications use rings or fields. We increase
-a little bit its priority above 100 to try it quickly, but remaining below the default 1000 so that
-more specific instances are tried first. -/
-attribute [instance, priority 200] ring.to_semiring
 
 /-- Pullback a `ring` instance along an injective function. -/
 protected def function.injective.ring [has_zero β] [has_one β] [has_add β] [has_mul β] [has_neg β]
@@ -560,6 +557,7 @@ end ring_hom
 @[protect_proj, ancestor ring comm_semigroup]
 class comm_ring (α : Type u) extends ring α, comm_semigroup α
 
+@[priority 100] -- see Note [lower instance priority]
 instance comm_ring.to_comm_semiring [s : comm_ring α] : comm_semiring α :=
 { mul_zero := mul_zero, zero_mul := zero_mul, ..s }
 
@@ -704,9 +702,11 @@ lemma pred_ne_self [ring α] [nontrivial α] (a : α) : a - 1 ≠ a :=
 section domain
 variable [domain α]
 
+@[priority 100] -- see Note [lower instance priority]
 instance domain.to_no_zero_divisors : no_zero_divisors α :=
 ⟨domain.eq_zero_or_eq_zero_of_mul_eq_zero⟩
 
+@[priority 100] -- see Note [lower instance priority]
 instance domain.to_cancel_monoid_with_zero : cancel_monoid_with_zero α :=
 { mul_left_cancel_of_ne_zero := λ a b c ha,
     by { rw [← sub_eq_zero, ← mul_sub], simp [ha, sub_eq_zero] },
@@ -735,6 +735,7 @@ class integral_domain (α : Type u) extends comm_ring α, domain α
 section integral_domain
 variables [integral_domain α] {a b c d e : α}
 
+@[priority 100] -- see Note [lower instance priority]
 instance integral_domain.to_comm_cancel_monoid_with_zero : comm_cancel_monoid_with_zero α :=
 { ..comm_semiring.to_comm_monoid_with_zero, ..domain.to_cancel_monoid_with_zero }
 

--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -19,8 +19,6 @@ spaces.
 
 universes u v
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /-- A `normed_add_torsor V P` is a torsor of an additive normed group
 action by a `normed_group V` on points `P`. We bundle the metric space
 structure and require the distance to be the same as results from the
@@ -31,7 +29,6 @@ class normed_add_torsor (V : out_param $ Type u) (P : Type v)
   [out_param $ normed_group V] [metric_space P]
   extends add_torsor V P :=
 (dist_eq_norm' : ∀ (x y : P), dist x y = ∥(x -ᵥ y : V)∥)
-end prio
 
 variables (V : Type u) {P : Type v} [normed_group V] [metric_space P] [normed_add_torsor V P]
 include V

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -27,13 +27,10 @@ export has_norm (norm)
 
 notation `∥`:1024 e:1 `∥`:1 := norm e
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /-- A normed group is an additive group endowed with a norm for which `dist x y = ∥x - y∥` defines
 a metric space structure. -/
 class normed_group (α : Type*) extends has_norm α, add_comm_group α, metric_space α :=
 (dist_eq : ∀ x y, dist x y = norm (x - y))
-end prio
 
 /-- Construct a normed group from a translation invariant distance -/
 def normed_group.of_add_dist [has_norm α] [add_comm_group α] [metric_space α]
@@ -425,13 +422,10 @@ end normed_group
 
 section normed_ring
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /-- A normed ring is a ring endowed with a norm which satisfies the inequality `∥x y∥ ≤ ∥x∥ ∥y∥`. -/
 class normed_ring (α : Type*) extends has_norm α, ring α, metric_space α :=
 (dist_eq : ∀ x y, dist x y = norm (x - y))
 (norm_mul : ∀ a b, norm (a * b) ≤ norm a * norm b)
-end prio
 
 @[priority 100] -- see Note [lower instance priority]
 instance normed_ring.to_normed_group [β : normed_ring α] : normed_group α := { ..β }
@@ -520,8 +514,6 @@ instance normed_top_ring [normed_ring α] : topological_ring α :=
     have ∀ e : α, -e - -x = -(e - x), by intro; simp,
     by simp only [this, norm_neg]; apply lim_norm ⟩
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /-- A normed field is a field with a norm satisfying ∥x y∥ = ∥x∥ ∥y∥. -/
 class normed_field (α : Type*) extends has_norm α, field α, metric_space α :=
 (dist_eq : ∀ x y, dist x y = norm (x - y))
@@ -532,7 +524,6 @@ class normed_field (α : Type*) extends has_norm α, field α, metric_space α :
 by the powers of any element, and thus to relate algebra and topology. -/
 class nondiscrete_normed_field (α : Type*) extends normed_field α :=
 (non_trivial : ∃x:α, 1<∥x∥)
-end prio
 
 @[priority 100] -- see Note [lower instance priority]
 instance normed_field.to_normed_ring [i : normed_field α] : normed_ring α :=
@@ -746,7 +737,8 @@ by rw [← rat.norm_cast_real, ← int.norm_cast_real]; congr' 1; norm_cast
 section normed_space
 
 section prio
-set_option default_priority 920 -- see Note [default priority]. Here, we set a rather high priority,
+set_option extends_priority 920
+-- Here, we set a rather high priority for the instance `[normed_space α β] : semimodule α β`
 -- to take precedence over `semiring.to_semimodule` as this leads to instance paths with better
 -- unification properties.
 -- see Note[vector space definition] for why we extend `semimodule`.
@@ -935,14 +927,11 @@ end normed_space
 
 section normed_algebra
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /-- A normed algebra `𝕜'` over `𝕜` is an algebra endowed with a norm for which the embedding of
 `𝕜` in `𝕜'` is an isometry. -/
 class normed_algebra (𝕜 : Type*) (𝕜' : Type*) [normed_field 𝕜] [normed_ring 𝕜']
   extends algebra 𝕜 𝕜' :=
 (norm_algebra_map_eq : ∀x:𝕜, ∥algebra_map 𝕜 𝕜' x∥ = ∥x∥)
-end prio
 
 @[simp] lemma norm_algebra_map_eq {𝕜 : Type*} (𝕜' : Type*) [normed_field 𝕜] [normed_ring 𝕜']
   [h : normed_algebra 𝕜 𝕜'] (x : 𝕜) : ∥algebra_map 𝕜 𝕜' x∥ = ∥x∥ :=

--- a/src/analysis/normed_space/real_inner_product.lean
+++ b/src/analysis/normed_space/real_inner_product.lean
@@ -57,10 +57,6 @@ class has_inner (α : Type*) := (inner : α → α → ℝ)
 
 export has_inner (inner)
 
-section prio
-
-set_option default_priority 100 -- see Note [default priority]
-
 -- the norm is embedded in the inner product space structure
 -- to avoid definitional equality issues. See Note [forgetful inheritance].
 
@@ -78,7 +74,6 @@ class inner_product_space (α : Type*) extends normed_group α, normed_space ℝ
 (comm      : ∀ x y, inner x y = inner y x)
 (add_left  : ∀ x y z, inner (x + y) z = inner x z + inner y z)
 (smul_left : ∀ x y r, inner (r • x) y = r * inner x y)
-end prio
 
 /-!
 ### Constructing a normed space structure from a scalar product

--- a/src/category_theory/abelian/basic.lean
+++ b/src/category_theory/abelian/basic.lean
@@ -90,9 +90,6 @@ variables {C : Type u} [category.{v} C]
 
 variables (C)
 
-section prio
-set_option default_priority 100
-
 /--
 A (preadditive) category `C` is called abelian if it has all finite products,
 all kernels and cokernels, and if every monomorphism is the kernel of some morphism
@@ -109,10 +106,9 @@ class abelian extends preadditive C :=
 (normal_mono : Π {X Y : C} (f : X ⟶ Y) [mono f], normal_mono f)
 (normal_epi : Π {X Y : C} (f : X ⟶ Y) [epi f], normal_epi f)
 
-attribute [instance] abelian.has_finite_products
-attribute [instance] abelian.has_kernels abelian.has_cokernels
+attribute [instance, priority 100] abelian.has_finite_products
+attribute [instance, priority 100] abelian.has_kernels abelian.has_cokernels
 
-end prio
 end category_theory
 
 open category_theory

--- a/src/category_theory/category/default.lean
+++ b/src/category_theory/category/default.lean
@@ -34,9 +34,6 @@ class has_hom (obj : Type u) : Type (max u (v+1)) :=
 
 infixr ` ⟶ `:10 := has_hom.hom -- type as \h
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
-
 /-- A preliminary structure on the way to defining a category,
 containing the data, but none of the axioms. -/
 class category_struct (obj : Type u)
@@ -58,7 +55,6 @@ extends category_struct.{v} obj : Type (max u (v+1)) :=
 (comp_id' : ∀ {X Y : obj} (f : hom X Y), f ≫ 𝟙 Y = f . obviously)
 (assoc'   : ∀ {W X Y Z : obj} (f : hom W X) (g : hom X Y) (h : hom Y Z),
   (f ≫ g) ≫ h = f ≫ (g ≫ h) . obviously)
-end prio
 
 -- `restate_axiom` is a command that creates a lemma from a structure field,
 -- discarding any auto_param wrappers from the type.

--- a/src/category_theory/concrete_category/basic.lean
+++ b/src/category_theory/concrete_category/basic.lean
@@ -38,8 +38,6 @@ universes w v v' u
 
 namespace category_theory
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /--
 A concrete category is a category `C` with a fixed faithful functor `forget : C ⥤ Type`.
 
@@ -52,7 +50,6 @@ They are specified that order, to avoid unnecessary universe annotations.
 class concrete_category (C : Type u) [category.{v} C] :=
 (forget [] : C ⥤ Type w)
 [forget_faithful : faithful forget]
-end prio
 
 attribute [instance] concrete_category.forget_faithful
 

--- a/src/category_theory/connected.lean
+++ b/src/category_theory/connected.lean
@@ -44,9 +44,6 @@ universes v₁ v₂ u₁ u₂
 open category_theory.category
 namespace category_theory
 
-section connected
--- See note [default priority]
-set_option default_priority 100
 /--
 We define a connected category as a _nonempty_ category for which every
 functor to a discrete category is constant.
@@ -59,7 +56,6 @@ This allows us to show that the functor X ⨯ - preserves connected limits.
 -/
 class connected (J : Type v₂) [category.{v₁} J] extends inhabited J :=
 (iso_constant : Π {α : Type v₂} (F : J ⥤ discrete α), F ≅ (functor.const J).obj (F.obj default))
-end connected
 
 variables {J : Type v₂} [category.{v₁} J]
 

--- a/src/category_theory/filtered.lean
+++ b/src/category_theory/filtered.lean
@@ -56,9 +56,6 @@ class is_filtered_or_empty : Prop :=
 (cocone_objs : ∀ (X Y : C), ∃ Z (f : X ⟶ Z) (g : Y ⟶ Z), true)
 (cocone_maps : ∀ ⦃X Y : C⦄ (f g : X ⟶ Y), ∃ Z (h : Y ⟶ Z), f ≫ h = g ≫ h)
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
-
 /--
 A category `is_filtered` if
 1. for every pair of objects there exists another object "to the right",
@@ -68,8 +65,6 @@ A category `is_filtered` if
 -/
 class is_filtered extends is_filtered_or_empty C : Prop :=
 [nonempty : nonempty C]
-
-end prio
 
 @[priority 100]
 instance is_filtered_or_empty_of_semilattice_sup

--- a/src/category_theory/groupoid.lean
+++ b/src/category_theory/groupoid.lean
@@ -9,14 +9,11 @@ namespace category_theory
 
 universes v v₂ u u₂ -- declare the `v`'s first; see `category_theory.category` for an explanation
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /-- A `groupoid` is a category such that all morphisms are isomorphisms. -/
 class groupoid (obj : Type u) extends category.{v} obj : Type (max u (v+1)) :=
 (inv       : Π {X Y : obj}, (X ⟶ Y) → (Y ⟶ X))
 (inv_comp' : ∀ {X Y : obj} (f : X ⟶ Y), comp (inv f) f = id Y . obviously)
 (comp_inv' : ∀ {X Y : obj} (f : X ⟶ Y), comp f (inv f) = id X . obviously)
-end prio
 
 restate_axiom groupoid.inv_comp'
 restate_axiom groupoid.comp_inv'

--- a/src/category_theory/limits/creates.lean
+++ b/src/category_theory/limits/creates.lean
@@ -224,9 +224,10 @@ creates_limit_of_fully_faithful_of_lift
 (by { fapply cones.ext, exact i, tidy, })
 
 /-- `F` preserves the limit of `K` if it creates the limit and `K ⋙ F` has the limit. -/
+@[priority 100] -- see Note [lower instance priority]
 instance preserves_limit_of_creates_limit_and_has_limit (K : J ⥤ C) (F : C ⥤ D)
   [creates_limit K F] [has_limit (K ⋙ F)] :
-preserves_limit K F :=
+  preserves_limit K F :=
 { preserves := λ c t, is_limit.of_iso_limit (limit.is_limit _)
     ((lifted_limit_maps_to_original (limit.is_limit _)).symm ≪≫
       ((cones.functoriality K F).map_iso ((lifted_limit_is_limit (limit.is_limit _)).unique_up_to_iso t))) }
@@ -235,7 +236,7 @@ preserves_limit K F :=
 @[priority 100] -- see Note [lower instance priority]
 instance preserves_limit_of_shape_of_creates_limits_of_shape_and_has_limits_of_shape (F : C ⥤ D)
   [creates_limits_of_shape J F] [has_limits_of_shape J D] :
-preserves_limits_of_shape J F :=
+  preserves_limits_of_shape J F :=
 { preserves_limit := λ K, category_theory.preserves_limit_of_creates_limit_and_has_limit K F }
 
 /-- `F` preserves limits if it creates limits and `D` has limits. -/
@@ -271,7 +272,7 @@ def creates_colimit_of_reflects_iso {K : J ⥤ C} {F : C ⥤ D} [reflects_isomor
 @[priority 100] -- see Note [lower instance priority]
 instance preserves_colimit_of_creates_colimit_and_has_colimit (K : J ⥤ C) (F : C ⥤ D)
   [creates_colimit K F] [has_colimit (K ⋙ F)] :
-preserves_colimit K F :=
+  preserves_colimit K F :=
 { preserves := λ c t, is_colimit.of_iso_colimit (colimit.is_colimit _)
     ((lifted_colimit_maps_to_original (colimit.is_colimit _)).symm ≪≫
       ((cocones.functoriality K F).map_iso ((lifted_colimit_is_colimit (colimit.is_colimit _)).unique_up_to_iso t))) }
@@ -280,7 +281,7 @@ preserves_colimit K F :=
 @[priority 100] -- see Note [lower instance priority]
 instance preserves_colimit_of_shape_of_creates_colimits_of_shape_and_has_colimits_of_shape (F : C ⥤ D)
   [creates_colimits_of_shape J F] [has_colimits_of_shape J D] :
-preserves_colimits_of_shape J F :=
+  preserves_colimits_of_shape J F :=
 { preserves_colimit := λ K, category_theory.preserves_colimit_of_creates_colimit_and_has_colimit K F }
 
 /-- `F` preserves limits if it creates limits and `D` has limits. -/

--- a/src/category_theory/limits/creates.lean
+++ b/src/category_theory/limits/creates.lean
@@ -44,8 +44,6 @@ structure liftable_cocone (K : J ⥤ C) (F : C ⥤ D) (c : cocone (K ⋙ F)) :=
 (lifted_cocone : cocone K)
 (valid_lift : F.map_cocone lifted_cocone ≅ c)
 
-set_option default_priority 100
-
 /--
 Definition 3.3.1 of [Riehl].
 We say that `F` creates limits of `K` if, given any limit cone `c` for `K ⋙ F`
@@ -234,12 +232,14 @@ preserves_limit K F :=
       ((cones.functoriality K F).map_iso ((lifted_limit_is_limit (limit.is_limit _)).unique_up_to_iso t))) }
 
 /-- `F` preserves the limit of shape `J` if it creates these limits and `D` has them. -/
+@[priority 100] -- see Note [lower instance priority]
 instance preserves_limit_of_shape_of_creates_limits_of_shape_and_has_limits_of_shape (F : C ⥤ D)
   [creates_limits_of_shape J F] [has_limits_of_shape J D] :
 preserves_limits_of_shape J F :=
 { preserves_limit := λ K, category_theory.preserves_limit_of_creates_limit_and_has_limit K F }
 
 /-- `F` preserves limits if it creates limits and `D` has limits. -/
+@[priority 100] -- see Note [lower instance priority]
 instance preserves_limits_of_creates_limits_and_has_limits (F : C ⥤ D) [creates_limits F] [has_limits D] :
   preserves_limits F :=
 { preserves_limits_of_shape := λ J 𝒥,
@@ -268,6 +268,7 @@ def creates_colimit_of_reflects_iso {K : J ⥤ C} {F : C ⥤ D} [reflects_isomor
     end } }
 
 /-- `F` preserves the colimit of `K` if it creates the colimit and `K ⋙ F` has the colimit. -/
+@[priority 100] -- see Note [lower instance priority]
 instance preserves_colimit_of_creates_colimit_and_has_colimit (K : J ⥤ C) (F : C ⥤ D)
   [creates_colimit K F] [has_colimit (K ⋙ F)] :
 preserves_colimit K F :=
@@ -276,12 +277,14 @@ preserves_colimit K F :=
       ((cocones.functoriality K F).map_iso ((lifted_colimit_is_colimit (colimit.is_colimit _)).unique_up_to_iso t))) }
 
 /-- `F` preserves the colimit of shape `J` if it creates these colimits and `D` has them. -/
+@[priority 100] -- see Note [lower instance priority]
 instance preserves_colimit_of_shape_of_creates_colimits_of_shape_and_has_colimits_of_shape (F : C ⥤ D)
   [creates_colimits_of_shape J F] [has_colimits_of_shape J D] :
 preserves_colimits_of_shape J F :=
 { preserves_colimit := λ K, category_theory.preserves_colimit_of_creates_colimit_and_has_colimit K F }
 
 /-- `F` preserves limits if it creates limits and `D` has limits. -/
+@[priority 100] -- see Note [lower instance priority]
 instance preserves_colimits_of_creates_colimits_and_has_colimits (F : C ⥤ D) [creates_colimits F] [has_colimits D] :
   preserves_colimits F :=
 { preserves_colimits_of_shape := λ J 𝒥,

--- a/src/category_theory/monad/adjunction.lean
+++ b/src/category_theory/monad/adjunction.lean
@@ -55,8 +55,6 @@ def comparison_forget [is_right_adjoint R] : comparison R ⋙ forget ((left_adjo
 
 end monad
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /-- A functor is *reflective*, or *a reflective inclusion*, if it is fully faithful and right adjoint. -/
 class reflective (R : D ⥤ C) extends is_right_adjoint R, full R, faithful R.
 
@@ -64,7 +62,6 @@ class reflective (R : D ⥤ C) extends is_right_adjoint R, full R, faithful R.
 category of Eilenberg-Moore algebras for the adjunction is an equivalence. -/
 class monadic_right_adjoint (R : D ⥤ C) extends is_right_adjoint R :=
 (eqv : is_equivalence (monad.comparison R))
-end prio
 
 instance μ_iso_of_reflective [reflective R] : is_iso (μ_ ((left_adjoint R) ⋙ R)) :=
 by { dsimp [adjunction.monad], apply_instance }

--- a/src/category_theory/monoidal/braided.lean
+++ b/src/category_theory/monoidal/braided.lean
@@ -60,9 +60,6 @@ open braided_category
 
 notation `β_` := braiding
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
-
 /--
 A symmetric monoidal category is a braided monoidal category for which the braiding is symmetric.
 -/
@@ -70,8 +67,6 @@ class symmetric_category (C : Type u) [category.{v} C] [monoidal_category.{v} C]
    extends braided_category.{v} C :=
 -- braiding symmetric:
 (symmetry' : ∀ X Y : C, (β_ X Y).hom ≫ (β_ Y X).hom = 𝟙 (X ⊗ Y) . obviously)
-
-end prio
 
 restate_axiom symmetric_category.symmetry'
 attribute [simp,reassoc] symmetric_category.symmetry

--- a/src/computability/primrec.lean
+++ b/src/computability/primrec.lean
@@ -109,13 +109,10 @@ end primrec
 
 end nat
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /-- A `primcodable` type is an `encodable` type for which
   the encode/decode functions are primitive recursive. -/
 class primcodable (α : Type*) extends encodable α :=
 (prim [] : nat.primrec (λ n, encodable.encode (decode n)))
-end prio
 
 namespace primcodable
 open nat.primrec

--- a/src/control/basic.lean
+++ b/src/control/basic.lean
@@ -190,11 +190,8 @@ instance : is_lawful_monad (sum.{v u} e) :=
 
 end sum
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 class is_comm_applicative (m : Type* → Type*) [applicative m] extends is_lawful_applicative m : Prop :=
 (commutative_prod : ∀{α β} (a : m α) (b : m β), prod.mk <$> a <*> b = (λb a, (a, b)) <$> b <*> a)
-end prio
 
 open functor
 

--- a/src/control/bitraversable/basic.lean
+++ b/src/control/bitraversable/basic.lean
@@ -34,13 +34,10 @@ traversable bitraversable iterator functor bifunctor applicative
 
 universes u
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 class bitraversable (t : Type u → Type u → Type u)
   extends bifunctor t :=
 (bitraverse : Π {m : Type u → Type u} [applicative m] {α α' β β'},
   (α → m α') → (β → m β') → t α β → m (t α' β'))
-end prio
 export bitraversable ( bitraverse )
 
 def bisequence {t m} [bitraversable t] [applicative m] {α β} : t (m α) (m β) → m (t α β) :=
@@ -48,8 +45,6 @@ bitraverse id id
 
 open functor
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 class is_lawful_bitraversable (t : Type u → Type u → Type u) [bitraversable t]
   extends is_lawful_bifunctor t :=
 (id_bitraverse : ∀ {α β} (x : t α β), bitraverse id.mk id.mk x = id.mk x )
@@ -66,7 +61,6 @@ class is_lawful_bitraversable (t : Type u → Type u → Type u) [bitraversable 
     (η : applicative_transformation F G) {α α' β β'}
     (f : α → F β) (f' : α' → F β') (x : t α α'),
   η (bitraverse f f' x) = bitraverse (@η _ ∘ f) (@η _ ∘ f') x)
-end prio
 
 export is_lawful_bitraversable ( id_bitraverse comp_bitraverse
                                  bitraverse_eq_bimap_id  )

--- a/src/control/lawful_fix.lean
+++ b/src/control/lawful_fix.lean
@@ -27,10 +27,6 @@ variables {α : Type*} {β : α → Type*}
 
 open omega_complete_partial_order
 
-section prio
-
-set_option default_priority 100  -- see Note [default priority]
-
 /-- Intuitively, a fixed point operator `fix` is lawful if it satisfies `fix f = f (fix f)` for all
 `f`, but this is inconsistent / uninteresting in most cases due to the existence of "exotic"
 functions `f`, such as the function that is defined iff its argument is not, familiar from the
@@ -44,8 +40,6 @@ lemma lawful_fix.fix_eq' {α} [omega_complete_partial_order α] [lawful_fix α]
   {f : α → α} (hf : continuous' f) :
   has_fix.fix f = f (has_fix.fix f) :=
 lawful_fix.fix_eq (continuous.to_bundled _ hf)
-
-end prio
 
 namespace roption
 

--- a/src/control/monad/cont.lean
+++ b/src/control/monad/cont.lean
@@ -21,8 +21,6 @@ class monad_cont (m : Type u → Type v) :=
 
 open monad_cont
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 class is_lawful_monad_cont (m : Type u → Type v) [monad m] [monad_cont m]
 extends is_lawful_monad m :=
 (call_cc_bind_right {α ω γ} (cmd : m α) (next : (label ω m γ) → α → m ω) :
@@ -31,7 +29,6 @@ extends is_lawful_monad m :=
   call_cc (λ f : label α m β, goto f x >>= dead f) = pure x)
 (call_cc_dummy {α β} (dummy : m α) :
   call_cc (λ f : label α m β, dummy) = dummy)
-end prio
 
 export is_lawful_monad_cont
 

--- a/src/control/traversable/basic.lean
+++ b/src/control/traversable/basic.lean
@@ -94,12 +94,9 @@ end applicative_transformation
 
 open applicative_transformation
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 class traversable (t : Type u → Type u) extends functor t :=
 (traverse : Π {m : Type u → Type u} [applicative m] {α β},
    (α → m β) → t α → m (t β))
-end prio
 
 open functor
 
@@ -118,8 +115,6 @@ def sequence [traversable t] : t (f α) → f (t α) := traverse id
 
 end functions
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 class is_lawful_traversable (t : Type u → Type u) [traversable t]
   extends is_lawful_functor t : Type (u+1) :=
 (id_traverse : ∀ {α} (x : t α), traverse id.mk x = x )
@@ -134,7 +129,6 @@ class is_lawful_traversable (t : Type u → Type u) [traversable t]
     [is_lawful_applicative F] [is_lawful_applicative G]
     (η : applicative_transformation F G) {α β} (f : α → F β) (x : t α),
   η (traverse f x) = traverse (@η _ ∘ f) x)
-end prio
 
 instance : traversable id := ⟨λ _ _ _ _, id⟩
 instance : is_lawful_traversable id := by refine {..}; intros; refl

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -21,8 +21,6 @@ typeclass, which basically amounts to doing the complex case, and the two cases 
 immediately from the two instances of the class.
 -/
 
-set_option default_priority 100 -- see Note [default priority]
-
 /--
 This typeclass captures properties shared by ℝ and ℂ, with an API that closely matches that of ℂ.
 -/

--- a/src/data/equiv/denumerable.lean
+++ b/src/data/equiv/denumerable.lean
@@ -13,14 +13,11 @@ import data.fintype.basic
 import data.list.min_max
 open nat
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /-- A denumerable type is one which is (constructively) bijective with ℕ.
   Although we already have a name for this property, namely `α ≃ ℕ`,
   we are here interested in using it as a typeclass. -/
 class denumerable (α : Type*) extends encodable α :=
 (decode_inv : ∀ n, ∃ a ∈ decode n, encode a = n)
-end prio
 
 namespace denumerable
 

--- a/src/deprecated/group.lean
+++ b/src/deprecated/group.lean
@@ -91,8 +91,6 @@ lemma inv {α β} [has_mul α] [comm_group β] (f : α → β) [is_mul_hom f] :
 
 end is_mul_hom
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /-- Predicate for add_monoid homomorphisms (deprecated -- use the bundled `monoid_hom` version). -/
 class is_add_monoid_hom [add_monoid α] [add_monoid β] (f : α → β) extends is_add_hom f : Prop :=
 (map_zero [] : f 0 = 0)
@@ -101,7 +99,6 @@ class is_add_monoid_hom [add_monoid α] [add_monoid β] (f : α → β) extends 
 @[to_additive]
 class is_monoid_hom [monoid α] [monoid β] (f : α → β) extends is_mul_hom f : Prop :=
 (map_one [] : f 1 = 1)
-end prio
 
 namespace monoid_hom
 variables {M : Type*} {N : Type*} {P : Type*} [mM : monoid M] [mN : monoid N] {mP : monoid P}
@@ -172,15 +169,12 @@ instance is_add_monoid_hom_mul_right {γ : Type*} [semiring γ] (x : γ) :
 
 end is_add_monoid_hom
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /-- Predicate for additive group homomorphism (deprecated -- use bundled `monoid_hom`). -/
 class is_add_group_hom [add_group α] [add_group β] (f : α → β) extends is_add_hom f : Prop
 
 /-- Predicate for group homomorphisms (deprecated -- use bundled `monoid_hom`). -/
 @[to_additive]
 class is_group_hom [group α] [group β] (f : α → β) extends is_mul_hom f : Prop
-end prio
 
 @[to_additive]
 instance monoid_hom.is_group_hom {G H : Type*} {_ : group G} {_ : group H} (f : G →* H) :

--- a/src/deprecated/subgroup.lean
+++ b/src/deprecated/subgroup.lean
@@ -14,8 +14,6 @@ variables {G : Type*} {H : Type*} {A : Type*} {a a₁ a₂ b c: G}
 section group
 variables [group G] [add_group A]
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /-- `s` is an additive subgroup: a set containing 0 and closed under addition and negation. -/
 class is_add_subgroup (s : set A) extends is_add_submonoid s : Prop :=
 (neg_mem {a} : a ∈ s → -a ∈ s)
@@ -24,7 +22,6 @@ class is_add_subgroup (s : set A) extends is_add_submonoid s : Prop :=
 @[to_additive]
 class is_subgroup (s : set G) extends is_submonoid s : Prop :=
 (inv_mem {a} : a ∈ s → a⁻¹ ∈ s)
-end prio
 
 lemma additive.is_add_subgroup
   (s : set G) [is_subgroup s] : @is_add_subgroup (additive G) _ s :=
@@ -163,15 +160,12 @@ theorem is_add_subgroup.sub_mem {A} [add_group A] (s : set A) [is_add_subgroup s
   (ha : a ∈ s) (hb : b ∈ s) : a - b ∈ s :=
 is_add_submonoid.add_mem ha (is_add_subgroup.neg_mem hb)
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 class normal_add_subgroup [add_group A] (s : set A) extends is_add_subgroup s : Prop :=
 (normal : ∀ n ∈ s, ∀ g : A, g + n - g ∈ s)
 
 @[to_additive]
 class normal_subgroup [group G] (s : set G) extends is_subgroup s : Prop :=
 (normal : ∀ n ∈ s, ∀ g : G, g * n * g⁻¹ ∈ s)
-end prio
 
 @[to_additive]
 lemma normal_subgroup_of_comm_group [comm_group G] (s : set G) [hs : is_subgroup s] :

--- a/src/deprecated/subring.lean
+++ b/src/deprecated/subring.lean
@@ -12,11 +12,8 @@ open group
 
 variables {R : Type u} [ring R]
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /-- `S` is a subring: a set containing 1 and closed under multiplication, addition and and additive inverse. -/
 class is_subring (S : set R) extends is_add_subgroup S, is_submonoid S : Prop.
-end prio
 
 instance subset.ring {S : set R} [is_subring S] : ring S :=
 { left_distrib := λ x y z, subtype.eq $ left_distrib x.1 y.1 z.1,

--- a/src/field_theory/subfield.lean
+++ b/src/field_theory/subfield.lean
@@ -7,11 +7,8 @@ import deprecated.subring
 
 variables {F : Type*} [field F] (S : set F)
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 class is_subfield extends is_subring S : Prop :=
 (inv_mem : ∀ {x : F}, x ∈ S → x⁻¹ ∈ S)
-end prio
 
 instance is_subfield.field [is_subfield S] : field S :=
 { inv := λ x, ⟨x⁻¹, is_subfield.inv_mem x.2⟩,

--- a/src/geometry/algebra/lie_group.lean
+++ b/src/geometry/algebra/lie_group.lean
@@ -46,8 +46,6 @@ noncomputable theory
 
 section lie_group
 
-set_option default_priority 100
-
 /-- A Lie (additive) group is a group and a smooth manifold at the same time in which
 the addition and negation operations are smooth. -/
 class lie_add_group {𝕜 : Type*} [nondiscrete_normed_field 𝕜]

--- a/src/geometry/euclidean/monge_point.lean
+++ b/src/geometry/euclidean/monge_point.lean
@@ -133,8 +133,7 @@ begin
   { rw [if_pos (mem_univ _), sub_zero, add_zero, card_fin],
     have hn3 : (n + 2 + 1 : ℝ) ≠ 0,
     { exact_mod_cast nat.succ_ne_zero _ },
-    field_simp [hn1, hn3],
-    ring },
+    field_simp [hn1, hn3] },
   { field_simp [hn1],
     ring }
 end

--- a/src/group_theory/group_action.lean
+++ b/src/group_theory/group_action.lean
@@ -16,13 +16,10 @@ class has_scalar (α : Type u) (γ : Type v) := (smul : α → γ → γ)
 
 infixr ` • `:73 := has_scalar.smul
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /-- Typeclass for multiplicative actions by monoids. This generalizes group actions. -/
 @[protect_proj] class mul_action (α : Type u) (β : Type v) [monoid α] extends has_scalar α β :=
 (one_smul : ∀ b : β, (1 : α) • b = b)
 (mul_smul : ∀ (x y : α) (b : β), (x * y) • b = x • y • b)
-end prio
 
 section
 variables [monoid α] [mul_action α β]
@@ -347,13 +344,10 @@ end
 
 end mul_action
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /-- Typeclass for multiplicative actions on additive structures. This generalizes group modules. -/
 class distrib_mul_action (α : Type u) (β : Type v) [monoid α] [add_monoid β] extends mul_action α β :=
 (smul_add : ∀(r : α) (x y : β), r • (x + y) = r • x + r • y)
 (smul_zero : ∀(r : α), r • (0 : β) = 0)
-end prio
 
 section
 variables [monoid α] [add_monoid β] [distrib_mul_action α β]

--- a/src/linear_algebra/linear_action.lean
+++ b/src/linear_algebra/linear_action.lean
@@ -23,8 +23,6 @@ section linear_action
 variables (R : Type u) (M N : Type v)
 variables [comm_ring R] [add_comm_group M] [add_comm_group N] [module R M] [module R N]
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
 /--
 A binary operation representing one module acting linearly on another.
 -/
@@ -34,7 +32,6 @@ class linear_action :=
 (act_add  : ∀ (m : M) (n n' : N), act m (n + n') = act m n + act m n')
 (act_smul : ∀ (r : R) (m : M) (n : N), act (r • m) n = r • (act m n))
 (smul_act : ∀ (r : R) (m : M) (n : N), act m (r • n) = act (r • m) n)
-end prio
 
 @[simp] lemma zero_linear_action [linear_action R M N] (n : N) :
   linear_action.act R (0 : M) n = 0 :=

--- a/src/logic/nontrivial.lean
+++ b/src/logic/nontrivial.lean
@@ -43,13 +43,9 @@ end
 lemma nontrivial_of_ne (x y : α) (h : x ≠ y) : nontrivial α :=
 ⟨⟨x, y, h⟩⟩
 
-section prio
-set_option default_priority 100 -- see Note [default priority]
-
+@[priority 100] -- see Note [lower instance priority]
 instance nontrivial.to_nonempty [nontrivial α] : nonempty α :=
 let ⟨x, _⟩ := exists_pair_ne α in ⟨x⟩
-
-end prio
 
 /-- An inhabited type is either nontrivial, or has a unique element. -/
 noncomputable def nontrivial_psum_unique (α : Type*) [inhabited α] :


### PR DESCRIPTION
This is the first of (most likely) two PRs which remove the use of
`set_option default_priority 100` in favor of per-instance priority
attributes, taking advantage of Lean 3.19c's new default priority
of 100 on instances produced by `extends`.


---
<!-- put comments you want to keep out of the PR commit here -->
