### PR TITLE
[Merged by Bors] - feat(logic/basic, logic/function/basic): involute ite 

### DIFF
--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -1142,13 +1142,13 @@ lemma ite_apply {α : Sort*} {β : α → Sort*} (P : Prop) [decidable P]
 dite_apply P (λ _, f) (λ _, g) x
 
 /-- Negation of the condition `P : Prop` in a `dite` is the same as swapping the branches. -/
-@[simp] lemma dite_not {α : Sort*} (P : Prop) [decidable P] (x : ¬¬ P → α) (y : ¬ P → α) :
-  dite (¬ P) y x = dite P (λ h, x (not_not_intro h)) y :=
+@[simp] lemma dite_not {α : Sort*} (P : Prop) [decidable P] (x : ¬ P → α) (y : ¬¬ P → α) :
+  dite (¬ P) x y = dite P (λ h, y (not_not_intro h)) x :=
 by { by_cases h : P; simp [h] }
 
 /-- Negation of the condition `P : Prop` in a `ite` is the same as swapping the branches. -/
 @[simp] lemma ite_not {α : Sort*} (P : Prop) [decidable P] (x y : α) :
   ite (¬ P) x y = ite P y x :=
-dite_not P (λ _, y) (λ _, x)
+dite_not P (λ _, x) (λ _, y)
 
 end ite

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -1104,31 +1104,35 @@ end nonempty
 
 section ite
 
-lemma apply_dite {α β : Type*} (f : α → β) (P : Prop) [decidable P] (x : P → α) (y : ¬P → α) :
+lemma apply_dite {α β : Sort*} (f : α → β) (P : Prop) [decidable P] (x : P → α) (y : ¬P → α) :
   f (dite P x y) = dite P (λ h, f (x h)) (λ h, f (y h)) :=
-by { by_cases h : P; simp [h], }
+by { by_cases h : P; simp [h] }
 
-lemma apply_ite {α β : Type*} (f : α → β) (P : Prop) [decidable P] (x y : α) :
+lemma apply_ite {α β : Sort*} (f : α → β) (P : Prop) [decidable P] (x y : α) :
   f (ite P x y) = ite P (f x) (f y) :=
 apply_dite f P (λ _, x) (λ _, y)
 
-lemma apply_dite2 {α β γ : Type*} (f : α → β → γ) (P : Prop) [decidable P] (a : P → α)
+lemma apply_dite2 {α β γ : Sort*} (f : α → β → γ) (P : Prop) [decidable P] (a : P → α)
   (b : ¬P → α) (c : P → β) (d : ¬P → β) :
   f (dite P a b) (dite P c d) = dite P (λ h, f (a h) (c h)) (λ h, f (b h) (d h)) :=
 by { by_cases h : P; simp [h] }
 
-lemma apply_ite2 {α β γ : Type*} (f : α → β → γ) (P : Prop) [decidable P] (a b : α) (c d : β) :
+lemma apply_ite2 {α β γ : Sort*} (f : α → β → γ) (P : Prop) [decidable P] (a b : α) (c d : β) :
   f (ite P a b) (ite P c d) = ite P (f a c) (f b d) :=
 apply_dite2 f P (λ _, a) (λ _, b) (λ _, c) (λ _, d)
 
-lemma dite_apply {α : Type*} {β : α → Type*} (P : Prop) [decidable P]
+lemma dite_apply {α : Sort*} {β : α → Sort*} (P : Prop) [decidable P]
   (f : P → Π a, β a) (g : ¬ P → Π a, β a) (x : α) :
   (dite P f g) x = dite P (λ h, f h x) (λ h, g h x) :=
-by { by_cases h : P; simp [h], }
+by { by_cases h : P; simp [h] }
 
-lemma ite_apply {α : Type*} {β : α → Type*} (P : Prop) [decidable P]
+lemma ite_apply {α : Sort*} {β : α → Sort*} (P : Prop) [decidable P]
   (f g : Π a, β a) (x : α) :
   (ite P f g) x = ite P (f x) (g x) :=
 dite_apply P (λ _, f) (λ _, g) x
+
+lemma ite_not (P : Prop) [decidable P] {α : Sort*}  (x y : α) :
+  ite (¬ P) x y = ite P y x :=
+by { by_cases h : P; simp [h] }
 
 end ite

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -1141,9 +1141,14 @@ lemma ite_apply {α : Sort*} {β : α → Sort*} (P : Prop) [decidable P]
   (ite P f g) x = ite P (f x) (g x) :=
 dite_apply P (λ _, f) (λ _, g) x
 
-/-- Negation of the condition `P : Prop` in a `ite` is the same as swapping the branches. -/
-lemma ite_not (P : Prop) [decidable P] {α : Sort*} (x y : α) :
-  ite (¬ P) x y = ite P y x :=
+/-- Negation of the condition `P : Prop` in a `dite` is the same as swapping the branches. -/
+lemma dite_not {α : Sort*} (P : Prop) [decidable P] (x : P → α) (y : ¬P → α) :
+  dite (¬ P) y (λ h, x (of_not_not h)) = dite P x y :=
 by { by_cases h : P; simp [h] }
+
+/-- Negation of the condition `P : Prop` in a `ite` is the same as swapping the branches. -/
+lemma ite_not {α : Sort*} (P : Prop) [decidable P] (x y : α) :
+  ite (¬ P) x y = ite P y x :=
+dite_not P (λ _, y) (λ _, x)
 
 end ite

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -1104,33 +1104,44 @@ end nonempty
 
 section ite
 
+/-- A function applied to a `dite` is a `dite` of that function applied to each of the branches. -/
 lemma apply_dite {α β : Sort*} (f : α → β) (P : Prop) [decidable P] (x : P → α) (y : ¬P → α) :
   f (dite P x y) = dite P (λ h, f (x h)) (λ h, f (y h)) :=
 by { by_cases h : P; simp [h] }
 
+/-- A function applied to a `ite` is a `ite` of that function applied to each of the branches. -/
 lemma apply_ite {α β : Sort*} (f : α → β) (P : Prop) [decidable P] (x y : α) :
   f (ite P x y) = ite P (f x) (f y) :=
 apply_dite f P (λ _, x) (λ _, y)
 
+/-- A two-argument function applied to two `dite`s is a `dite` of that two-argument function
+applied to each of the branches. -/
 lemma apply_dite2 {α β γ : Sort*} (f : α → β → γ) (P : Prop) [decidable P] (a : P → α)
   (b : ¬P → α) (c : P → β) (d : ¬P → β) :
   f (dite P a b) (dite P c d) = dite P (λ h, f (a h) (c h)) (λ h, f (b h) (d h)) :=
 by { by_cases h : P; simp [h] }
 
+/-- A two-argument function applied to two `ite`s is a `ite` of that two-argument function
+applied to each of the branches. -/
 lemma apply_ite2 {α β γ : Sort*} (f : α → β → γ) (P : Prop) [decidable P] (a b : α) (c d : β) :
   f (ite P a b) (ite P c d) = ite P (f a c) (f b d) :=
 apply_dite2 f P (λ _, a) (λ _, b) (λ _, c) (λ _, d)
 
+/-- A 'dite' producing a `Pi` type `Π a, β a`, applied to a value `x : α`
+is a `dite` that applies either branch to `x`. -/
 lemma dite_apply {α : Sort*} {β : α → Sort*} (P : Prop) [decidable P]
   (f : P → Π a, β a) (g : ¬ P → Π a, β a) (x : α) :
   (dite P f g) x = dite P (λ h, f h x) (λ h, g h x) :=
 by { by_cases h : P; simp [h] }
 
+/-- A 'ite' producing a `Pi` type `Π a, β a`, applied to a value `x : α`
+is a `ite` that applies either branch to `x` -/
 lemma ite_apply {α : Sort*} {β : α → Sort*} (P : Prop) [decidable P]
   (f g : Π a, β a) (x : α) :
   (ite P f g) x = ite P (f x) (g x) :=
 dite_apply P (λ _, f) (λ _, g) x
 
+/-- Negation of the condition `P : Prop` in a `ite` is the same as swapping the branches. -/
 lemma ite_not (P : Prop) [decidable P] {α : Sort*}  (x y : α) :
   ite (¬ P) x y = ite P y x :=
 by { by_cases h : P; simp [h] }

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -1142,7 +1142,7 @@ lemma ite_apply {α : Sort*} {β : α → Sort*} (P : Prop) [decidable P]
 dite_apply P (λ _, f) (λ _, g) x
 
 /-- Negation of the condition `P : Prop` in a `ite` is the same as swapping the branches. -/
-lemma ite_not (P : Prop) [decidable P] {α : Sort*}  (x y : α) :
+lemma ite_not (P : Prop) [decidable P] {α : Sort*} (x y : α) :
   ite (¬ P) x y = ite P y x :=
 by { by_cases h : P; simp [h] }
 

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -1142,12 +1142,12 @@ lemma ite_apply {α : Sort*} {β : α → Sort*} (P : Prop) [decidable P]
 dite_apply P (λ _, f) (λ _, g) x
 
 /-- Negation of the condition `P : Prop` in a `dite` is the same as swapping the branches. -/
-lemma dite_not {α : Sort*} (P : Prop) [decidable P] (x : ¬¬ P → α) (y : ¬ P → α) :
+@[simp] lemma dite_not {α : Sort*} (P : Prop) [decidable P] (x : ¬¬ P → α) (y : ¬ P → α) :
   dite (¬ P) y x = dite P (λ h, x (not_not_intro h)) y :=
 by { by_cases h : P; simp [h] }
 
 /-- Negation of the condition `P : Prop` in a `ite` is the same as swapping the branches. -/
-lemma ite_not {α : Sort*} (P : Prop) [decidable P] (x y : α) :
+@[simp] lemma ite_not {α : Sort*} (P : Prop) [decidable P] (x y : α) :
   ite (¬ P) x y = ite P y x :=
 dite_not P (λ _, y) (λ _, x)
 

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -1142,8 +1142,8 @@ lemma ite_apply {α : Sort*} {β : α → Sort*} (P : Prop) [decidable P]
 dite_apply P (λ _, f) (λ _, g) x
 
 /-- Negation of the condition `P : Prop` in a `dite` is the same as swapping the branches. -/
-lemma dite_not {α : Sort*} (P : Prop) [decidable P] (x : P → α) (y : ¬P → α) :
-  dite (¬ P) y (λ h, x (of_not_not h)) = dite P x y :=
+lemma dite_not {α : Sort*} (P : Prop) [decidable P] (x : ¬¬ P → α) (y : ¬ P → α) :
+  dite (¬ P) y x = dite P (λ h, x (not_not_intro h)) y :=
 by { by_cases h : P; simp [h] }
 
 /-- Negation of the condition `P : Prop` in a `ite` is the same as swapping the branches. -/

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -404,6 +404,7 @@ def involutive {α} (f : α → α) : Prop := ∀ x, f (f x) = x
 lemma involutive_iff_iter_2_eq_id {α} {f : α → α} : involutive f ↔ (f^[2] = id) :=
 funext_iff.symm
 
+/-- Involuting an `ite` of an involuted value `x : α` negates the `Prop` condition in the `ite`. -/
 lemma inv_ite {α} (P : Prop) [decidable P] {f : α → α} (h : involutive f) (x : α) :
   f (ite P x (f x)) = ite (¬ P) x (f x) :=
 by rw [apply_ite f, h, ite_not]

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -404,13 +404,9 @@ def involutive {α} (f : α → α) : Prop := ∀ x, f (f x) = x
 lemma involutive_iff_iter_2_eq_id {α} {f : α → α} : involutive f ↔ (f^[2] = id) :=
 funext_iff.symm
 
-/-- Involuting an `ite` of an involuted value `x : α` negates the `Prop` condition in the `ite`. -/
-lemma involutive_ite {α} (P : Prop) [decidable P] {f : α → α} (h : involutive f) (x : α) :
-  f (ite P x (f x)) = ite (¬ P) x (f x) :=
-by rw [apply_ite f, h, ite_not]
-
 namespace involutive
 variables {α : Sort u} {f : α → α} (h : involutive f)
+include h
 
 protected lemma left_inverse : left_inverse f f := h
 protected lemma right_inverse : right_inverse f f := h
@@ -418,6 +414,11 @@ protected lemma right_inverse : right_inverse f f := h
 protected lemma injective : injective f := h.left_inverse.injective
 protected lemma surjective : surjective f := λ x, ⟨f x, h x⟩
 protected lemma bijective : bijective f := ⟨h.injective, h.surjective⟩
+
+/-- Involuting an `ite` of an involuted value `x : α` negates the `Prop` condition in the `ite`. -/
+protected lemma ite_not (P : Prop) [decidable P] (x : α) :
+  f (ite P x (f x)) = ite (¬ P) x (f x) :=
+by rw [apply_ite f, h, ite_not]
 
 end involutive
 

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -405,7 +405,7 @@ lemma involutive_iff_iter_2_eq_id {α} {f : α → α} : involutive f ↔ (f^[2]
 funext_iff.symm
 
 /-- Involuting an `ite` of an involuted value `x : α` negates the `Prop` condition in the `ite`. -/
-lemma inv_ite {α} (P : Prop) [decidable P] {f : α → α} (h : involutive f) (x : α) :
+lemma involutive_ite {α} (P : Prop) [decidable P] {f : α → α} (h : involutive f) (x : α) :
   f (ite P x (f x)) = ite (¬ P) x (f x) :=
 by rw [apply_ite f, h, ite_not]
 

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -404,6 +404,10 @@ def involutive {α} (f : α → α) : Prop := ∀ x, f (f x) = x
 lemma involutive_iff_iter_2_eq_id {α} {f : α → α} : involutive f ↔ (f^[2] = id) :=
 funext_iff.symm
 
+lemma inv_ite {α} (P : Prop) [decidable P] {f : α → α} (h : involutive f) (x : α) :
+  f (ite P x (f x)) = ite (¬ P) x (f x) :=
+by rw [apply_ite f, h, ite_not]
+
 namespace involutive
 variables {α : Sort u} {f : α → α} (h : involutive f)
 


### PR DESCRIPTION
Some lemmas about `ite`:
- `(d)ite_not`: exchanges the branches of an `(d)ite`
  when negating the given prop.
- `involutive.ite_not`: applying an involutive function to an `ite`
  negates the prop

Other changes:
Generalize the arguments for `(d)ite_apply` and `apply_(d)ite(2)`
to `Sort*` over `Type*`.

Co-authored-by: Alex J Best <alex.j.best@gmail.com>
Co-authored-by: Bryan Gin-ge Chen <bryangingechen@gmail.com>

---
<!-- put comments you want to keep out of the PR commit here -->
After Zulip discussion at https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/involution.20and.20ite