### PR TITLE
[Merged by Bors] - feat(tactic/explode): correctly indent long statements

### DIFF
--- a/src/tactic/explode.lean
+++ b/src/tactic/explode.lean
@@ -56,7 +56,7 @@ meta def format_aux : list string → list string → list string → list entry
       end,
     p ← infer_type en.expr >>= pp,
     let lhs :=  line ++ "│" ++ dep ++ "│ " ++ thm ++ margin ++ " ",
-    return $ format.of_string lhs ++ to_string p ++ format.line },
+    return $ format.of_string lhs ++ (p.nest lhs.length).group ++ format.line },
   (++ fmt) <$> format_aux lines deps thms es
 | _ _ _ _ := return format.nil
 


### PR DESCRIPTION
`#explode` didn't indent long statements in the proof, such as in this lemma:
```lean
import tactic.explode

variables (p q r : ℕ → Prop)

lemma ex (h : ∃ x, ∀ y, ∃ z, p x ∧ q y ∧ r z) :
              ∃ z, ∀ y, ∃ x, p x ∧ q y ∧ r z :=
Exists.rec_on h $ λ x h',
Exists.rec_on (h' 0) $ λ z h'',
⟨z, λ y,
  Exists.rec_on (h' y) $ λ w h''',
  ⟨x, h''.1, h'''.2.1, h''.2.2⟩⟩

#explode ex
```
---

Now it prints the following (scroll down to see the effect):
```
ex : ∀ (p q r : ℕ → Prop),
  (∃ (x : ℕ), ∀ (y : ℕ), ∃ (z : ℕ), p x ∧ q y ∧ r z) →
  (∃ (z : ℕ), ∀ (y : ℕ), ∃ (x : ℕ), p x ∧ q y ∧ r z)
0 │     │ p             ├ ℕ → Prop
1 │     │ q             ├ ℕ → Prop
2 │     │ r             ├ ℕ → Prop
3 │     │ h             ├ ∃ (x : ℕ), ∀ (y : ℕ), ∃ (z : ℕ), p x ∧ q y ∧ r z
4 │     │ x             │ ┌ ℕ
5 │     │ h'            │ │ ┌ ∀ (y : ℕ), ∃ (z : ℕ), p x ∧ q y ∧ r z
6 │5    │ ∀E            │ │ │ ∃ (z : ℕ), p x ∧ q 0 ∧ r z
7 │     │ z             │ │ │ ┌ ℕ
8 │     │ h''           │ │ │ │ ┌ p x ∧ q 0 ∧ r z
9 │     │ y             │ │ │ │ │ ┌ ℕ
10│5    │ ∀E            │ │ │ │ │ │ ∃ (z : ℕ), p x ∧ q y ∧ r z
11│     │ w             │ │ │ │ │ │ ┌ ℕ
12│     │ h'''          │ │ │ │ │ │ │ ┌ p x ∧ q y ∧ r w
13│8    │ and.left      │ │ │ │ │ │ │ │ p x
14│12   │ and.right     │ │ │ │ │ │ │ │ q y ∧ r w
15│14   │ and.left      │ │ │ │ │ │ │ │ q y
16│8    │ and.right     │ │ │ │ │ │ │ │ q 0 ∧ r z
17│16   │ and.right     │ │ │ │ │ │ │ │ r z
18│15,17│ and.intro     │ │ │ │ │ │ │ │ q y ∧ r z
19│13,18│ and.intro     │ │ │ │ │ │ │ │ p x ∧ q y ∧ r z
20│19   │ Exists.intro  │ │ │ │ │ │ │ │ ∃ (x : ℕ), p x ∧ q y ∧ r z
21│12,20│ ∀I            │ │ │ │ │ │ │ p x ∧ q y ∧ r w → (∃ (x : ℕ), p x ∧ q y ∧ r z)
22│21   │ ∀I            │ │ │ │ │ │ ∀ (w : ℕ),
                                      p x ∧ q y ∧ r w → (∃ (x : ℕ), p x ∧ q y ∧ r z)
23│10,22│ Exists.rec_on │ │ │ │ │ │ ∃ (x : ℕ), p x ∧ q y ∧ r z
24│23   │ ∀I            │ │ │ │ │ ∀ (y : ℕ), ∃ (x : ℕ), p x ∧ q y ∧ r z
25│24   │ Exists.intro  │ │ │ │ │ ∃ (z : ℕ), ∀ (y : ℕ), ∃ (x : ℕ), p x ∧ q y ∧ r z
26│8,25 │ ∀I            │ │ │ │ p x ∧ q 0 ∧ r z →
                                (∃ (z : ℕ), ∀ (y : ℕ), ∃ (x : ℕ), p x ∧ q y ∧ r z)
27│26   │ ∀I            │ │ │ ∀ (z : ℕ),
                                p x ∧ q 0 ∧ r z →
                                (∃ (z : ℕ), ∀ (y : ℕ), ∃ (x : ℕ), p x ∧ q y ∧ r z)
28│6,27 │ Exists.rec_on │ │ │ ∃ (z : ℕ), ∀ (y : ℕ), ∃ (x : ℕ), p x ∧ q y ∧ r z
29│5,28 │ ∀I            │ │ (∀ (y : ℕ), ∃ (z : ℕ), p x ∧ q y ∧ r z) →
                            (∃ (z : ℕ), ∀ (y : ℕ), ∃ (x : ℕ), p x ∧ q y ∧ r z)
30│29   │ ∀I            │ ∀ (x : ℕ),
                            (∀ (y : ℕ), ∃ (z : ℕ), p x ∧ q y ∧ r z) →
                            (∃ (z : ℕ), ∀ (y : ℕ), ∃ (x : ℕ), p x ∧ q y ∧ r z)
31│3,30 │ Exists.rec_on │ ∃ (z : ℕ), ∀ (y : ℕ), ∃ (x : ℕ), p x ∧ q y ∧ r z
32│3,31 │ ∀I            │ (∃ (x : ℕ), ∀ (y : ℕ), ∃ (z : ℕ), p x ∧ q y ∧ r z) →
                          (∃ (z : ℕ), ∀ (y : ℕ), ∃ (x : ℕ), p x ∧ q y ∧ r z)
33│2,32 │ ∀I            │ ∀ (r : ℕ → Prop),
                            (∃ (x : ℕ), ∀ (y : ℕ), ∃ (z : ℕ), p x ∧ q y ∧ r z) →
                            (∃ (z : ℕ), ∀ (y : ℕ), ∃ (x : ℕ), p x ∧ q y ∧ r z)
34│1,33 │ ∀I            │ ∀ (q r : ℕ → Prop),
                            (∃ (x : ℕ), ∀ (y : ℕ), ∃ (z : ℕ), p x ∧ q y ∧ r z) →
                            (∃ (z : ℕ), ∀ (y : ℕ), ∃ (x : ℕ), p x ∧ q y ∧ r z)
35│0,34 │ ∀I            │ ∀ (p q r : ℕ → Prop),
                            (∃ (x : ℕ), ∀ (y : ℕ), ∃ (z : ℕ), p x ∧ q y ∧ r z) →
                            (∃ (z : ℕ), ∀ (y : ℕ), ∃ (x : ℕ), p x ∧ q y ∧ r z)
```