### PR TITLE
[Merged by Bors] - feat(data/mv_polynomial): a few facts about `constant_coeff` and `aeval`

### DIFF
--- a/src/data/mv_polynomial/basic.lean
+++ b/src/data/mv_polynomial/basic.lean
@@ -757,6 +757,14 @@ by { rw [← eval_map, ← eval_map, map_map], }
   eval₂_hom φ g (map f p) = eval₂_hom (φ.comp f) g p :=
 eval₂_map f g φ p
 
+lemma constant_coeff_map (f : α →+* β) (φ : mv_polynomial σ α) :
+  constant_coeff (mv_polynomial.map f φ) = f (constant_coeff φ) :=
+coeff_map f φ 0
+
+lemma constant_coeff_comp_map (f : α →+* β) :
+  (constant_coeff : mv_polynomial σ β →+* β).comp (mv_polynomial.map f) = f.comp (constant_coeff) :=
+by { ext, apply constant_coeff_map }
+
 lemma support_map_subset (p : mv_polynomial σ α) : (map f p).support ⊆ p.support :=
 begin
   intro x,
@@ -852,6 +860,23 @@ aeval_zero p
 lemma aeval_monomial (g : σ → A) (d : σ →₀ ℕ) (r : R) :
   aeval g (monomial d r) = algebra_map _ _ r * d.prod (λ i k, g i ^ k) :=
 eval₂_hom_monomial _ _ _ _
+
+lemma eval₂_hom_eq_zero (f : R →+* S) (g : σ → S) (φ : mv_polynomial σ R)
+  (h : ∀ d, φ.coeff d ≠ 0 → ∃ i ∈ d.support, g i = 0) :
+  eval₂_hom f g φ = 0 :=
+begin
+  rw [φ.as_sum, ring_hom.map_sum, finset.sum_eq_zero],
+  intros d hd,
+  obtain ⟨i, hi, hgi⟩ : ∃ i ∈ d.support, g i = 0 := h d (finsupp.mem_support_iff.mp hd),
+  rw [eval₂_hom_monomial, finsupp.prod, finset.prod_eq_zero hi, mul_zero],
+  rw [hgi, zero_pow],
+  rwa [nat.pos_iff_ne_zero, ← finsupp.mem_support_iff]
+end
+
+lemma aeval_eq_zero [algebra R S] (f : σ → S) (φ : mv_polynomial σ R)
+  (h : ∀ d, φ.coeff d ≠ 0 → ∃ i ∈ d.support, f i = 0) :
+  aeval f φ = 0 :=
+eval₂_hom_eq_zero _ _ _ h
 
 end aeval
 

--- a/src/data/mv_polynomial/basic.lean
+++ b/src/data/mv_polynomial/basic.lean
@@ -757,7 +757,7 @@ by { rw [← eval_map, ← eval_map, map_map], }
   eval₂_hom φ g (map f p) = eval₂_hom (φ.comp f) g p :=
 eval₂_map f g φ p
 
-lemma constant_coeff_map (f : α →+* β) (φ : mv_polynomial σ α) :
+@[simp] lemma constant_coeff_map (f : α →+* β) (φ : mv_polynomial σ α) :
   constant_coeff (mv_polynomial.map f φ) = f (constant_coeff φ) :=
 coeff_map f φ 0
 


### PR DESCRIPTION
A few additional facts about `constant_coeff_map` and `aeval` from the witt vector branch.

Co-authored by: Johan Commelin <johan@commelin.net>

---
<!-- put comments you want to keep out of the PR commit here -->
