### PR TITLE
[Merged by Bors] - feat(data/fin): iffs about succ_above ordering

### DIFF
--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -488,6 +488,36 @@ lemma succ_above_lt_gt (p : fin (n + 1)) (i : fin n) : i.cast_succ < p ∨ p < i
 or.cases_on (succ_above_lt_ge p i)
   (λ h, or.inl h) (λ h, or.inr (lt_of_le_of_lt h (cast_succ_lt_succ i)))
 
+/-- Embedding `i : fin n` into `fin (n + 1)` using a pivot `p` that is greater
+results in a value that is less than `p`. -/
+lemma succ_above_lt_iff (p : fin (n + 1)) (i : fin n) : i.cast_succ < p ↔ p.succ_above i < p :=
+begin
+  refine iff.intro _ _,
+  { intro h,
+    rw succ_above_below _ _ h,
+    exact h },
+  { intro h,
+    cases succ_above_lt_ge p i with H H,
+    { exact H },
+    { rw succ_above_above _ _ H at h,
+      exact lt_trans (cast_succ_lt_succ i) h } }
+end
+
+/-- Embedding `i : fin n` into `fin (n + 1)` using a pivot `p` that is lesser
+results in a value that is greater than `p`. -/
+lemma succ_above_gt_iff (p : fin (n + 1)) (i : fin n) : p ≤ i.cast_succ ↔ p < p.succ_above i :=
+begin
+  refine iff.intro _ _,
+  { intro h,
+    rw succ_above_above _ _ h,
+    exact lt_of_le_of_lt h (cast_succ_lt_succ i) },
+  { intro h,
+    cases succ_above_lt_ge p i with H H,
+    { rw succ_above_below _ _ H at h,
+      exact le_of_lt h },
+    { exact H } }
+end
+
 /-- Embedding `i : fin n` into `fin (n + 1)` with a hole around `p : fin (n + 1)`
 never results in `p` itself -/
 theorem succ_above_ne (p : fin (n + 1)) (i : fin n) : p.succ_above i ≠ p :=

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -490,32 +490,32 @@ or.cases_on (succ_above_lt_ge p i)
 
 /-- Embedding `i : fin n` into `fin (n + 1)` using a pivot `p` that is greater
 results in a value that is less than `p`. -/
-lemma succ_above_lt_iff (p : fin (n + 1)) (i : fin n) : i.cast_succ < p ↔ p.succ_above i < p :=
+@[simp] lemma succ_above_lt_iff (p : fin (n + 1)) (i : fin n) : p.succ_above i < p ↔ i.cast_succ < p :=
 begin
   refine iff.intro _ _,
-  { intro h,
-    rw succ_above_below _ _ h,
-    exact h },
   { intro h,
     cases succ_above_lt_ge p i with H H,
     { exact H },
     { rw succ_above_above _ _ H at h,
-      exact lt_trans (cast_succ_lt_succ i) h } }
+      exact lt_trans (cast_succ_lt_succ i) h } },
+  { intro h,
+    rw succ_above_below _ _ h,
+    exact h }
 end
 
 /-- Embedding `i : fin n` into `fin (n + 1)` using a pivot `p` that is lesser
 results in a value that is greater than `p`. -/
-lemma succ_above_gt_iff (p : fin (n + 1)) (i : fin n) : p ≤ i.cast_succ ↔ p < p.succ_above i :=
+@[simp] lemma lt_succ_above_iff (p : fin (n + 1)) (i : fin n) : p < p.succ_above i ↔ p ≤ i.cast_succ :=
 begin
   refine iff.intro _ _,
-  { intro h,
-    rw succ_above_above _ _ h,
-    exact lt_of_le_of_lt h (cast_succ_lt_succ i) },
   { intro h,
     cases succ_above_lt_ge p i with H H,
     { rw succ_above_below _ _ H at h,
       exact le_of_lt h },
-    { exact H } }
+    { exact H } },
+  { intro h,
+    rw succ_above_above _ _ h,
+    exact lt_of_le_of_lt h (cast_succ_lt_succ i) }
 end
 
 /-- Embedding `i : fin n` into `fin (n + 1)` with a hole around `p : fin (n + 1)`

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -505,7 +505,7 @@ end
 
 /-- Embedding `i : fin n` into `fin (n + 1)` using a pivot `p` that is lesser
 results in a value that is greater than `p`. -/
-@[simp] lemma lt_succ_above_iff (p : fin (n + 1)) (i : fin n) : p < p.succ_above i ↔ p ≤ i.cast_succ :=
+lemma lt_succ_above_iff (p : fin (n + 1)) (i : fin n) : p < p.succ_above i ↔ p ≤ i.cast_succ :=
 begin
   refine iff.intro _ _,
   { intro h,
@@ -515,7 +515,7 @@ begin
     { exact H } },
   { intro h,
     rw succ_above_above _ _ h,
-    exact lt_of_le_of_lt h (cast_succ_lt_succ i) }
+    exact lt_of_le_of_lt h (cast_succ_lt_succ i) },
 end
 
 /-- Embedding `i : fin n` into `fin (n + 1)` with a hole around `p : fin (n + 1)`
@@ -583,7 +583,7 @@ begin
   { simp [succ_above_below _ _ H, H] },
   { cases succ_above_lt_gt p i with h h,
     { exact absurd h H },
-    { simp [succ_above_above _ _ (le_of_not_lt H), pred_succ, dif_neg (asymm h)] } }
+    { simp [succ_above_above _ _ (le_of_not_lt H), dif_neg H] } }
 end
 
 /-- `succ_above` is injective at the pivot -/


### PR DESCRIPTION
New lemmas:
`succ_above_lt_iff`
`lt_succ_above_iff`

These help avoid needing to do case analysis when faced with
inequalities about `succ_above`.

---
<!-- put comments you want to keep out of the PR commit here -->
