### PR TITLE
[Merged by Bors] - refactor(data/mv_polynomial/pderivative): make pderivative a linear map

### DIFF
--- a/src/data/mv_polynomial/pderivative.lean
+++ b/src/data/mv_polynomial/pderivative.lean
@@ -70,11 +70,6 @@ def pderivative (i : σ) : mv_polynomial σ R →ₗ[R] mv_polynomial σ R :=
     (by simp only [add_mul, forall_const, eq_self_iff_true, monomial_add]), }
 
 @[simp]
-lemma pderivative_add {i : σ} {f g : mv_polynomial σ R} :
-  pderivative i (f + g) = pderivative i f + pderivative i g :=
-(pderivative i).map_add _ _
-
-@[simp]
 lemma pderivative_monomial {i : σ} :
   pderivative i (monomial s a) = monomial (s - single i 1) (a * (s i)) :=
 begin
@@ -88,17 +83,13 @@ lemma pderivative_C {i : σ} : pderivative i (C a) = 0 :=
 suffices pderivative i (monomial 0 a) = 0, by simpa,
 by simp
 
-@[simp]
-lemma pderivative_zero {i : σ} : pderivative i (0 : mv_polynomial σ R) = 0 :=
-(pderivative i).map_zero
-
 lemma pderivative_eq_zero_of_not_mem_vars {i : σ} {f : mv_polynomial σ R} (h : i ∉ f.vars) :
   pderivative i f = 0 :=
 begin
   change (pderivative i) f = 0,
   rw [f.as_sum, linear_map.map_sum],
   apply finset.sum_eq_zero,
-  intros,
+  intros x H,
   simp [mem_support_not_mem_vars_zero H h],
 end
 
@@ -133,7 +124,7 @@ begin
   { apply induction_on' g,
     { intros u r u' r', exact pderivative_monomial_mul },
     { intros p q hp hq u r,
-      rw [mul_add, pderivative_add, hp, hq, mul_add, pderivative_add],
+      rw [mul_add, linear_map.map_add, hp, hq, mul_add, linear_map.map_add],
       ring } },
   { intros p q hp hq,
     simp [add_mul, hp, hq],

--- a/src/data/mv_polynomial/pderivative.lean
+++ b/src/data/mv_polynomial/pderivative.lean
@@ -72,16 +72,12 @@ def pderivative (i : σ) : mv_polynomial σ R →ₗ[R] mv_polynomial σ R :=
 @[simp]
 lemma pderivative_monomial {i : σ} :
   pderivative i (monomial s a) = monomial (s - single i 1) (a * (s i)) :=
-begin
-  change (_ : _ →ₗ[R] _).to_fun _ = _,
-  change (⟨_, _, _⟩ : _ →ₗ[R] _).to_fun _ = _,
-  simp,
-end
+by simp only [pderivative, monomial_zero, sum_monomial, zero_mul, linear_map.coe_mk]
 
 @[simp]
 lemma pderivative_C {i : σ} : pderivative i (C a) = 0 :=
 suffices pderivative i (monomial 0 a) = 0, by simpa,
-by simp
+by simp only [monomial_zero, pderivative_monomial, nat.cast_zero, mul_zero, zero_apply]
 
 lemma pderivative_eq_zero_of_not_mem_vars {i : σ} {f : mv_polynomial σ R} (h : i ∉ f.vars) :
   pderivative i f = 0 :=

--- a/src/data/mv_polynomial/pderivative.lean
+++ b/src/data/mv_polynomial/pderivative.lean
@@ -134,7 +134,7 @@ end
 @[simp]
 lemma pderivative_C_mul {f : mv_polynomial σ R} {i : σ} :
   pderivative i (C a * f) = C a * pderivative i f :=
-by rw [pderivative_mul, pderivative_C, zero_mul, zero_add]
+by convert linear_map.map_smul (pderivative i) a f; rw C_mul'
 
 end pderivative
 


### PR DESCRIPTION
Make `pderivative i` a linear map as suggested at https://github.com/leanprover-community/mathlib/pull/4083#issuecomment-689712833

---
<!-- put comments you want to keep out of the PR commit here -->

Should I do the same to `polynomial.derivative`?