### PR TITLE
[Merged by Bors] - refactor(data/mv_polynomial): move `smul` lemmas into basic.lean

### DIFF
--- a/src/data/mv_polynomial/basic.lean
+++ b/src/data/mv_polynomial/basic.lean
@@ -151,6 +151,23 @@ finsupp.single_injective _
 lemma C_eq_coe_nat (n : ℕ) : (C ↑n : mv_polynomial σ α) = n :=
 by induction n; simp [nat.succ_eq_add_one, *]
 
+theorem C_mul' : mv_polynomial.C a * p = a • p :=
+begin
+  apply finsupp.induction p,
+  { exact (mul_zero $ mv_polynomial.C a).trans (@smul_zero α (mv_polynomial σ α) _ _ _ a).symm },
+  intros p b f haf hb0 ih,
+  rw [mul_add, ih, @smul_add α (mv_polynomial σ α) _ _ _ a], congr' 1,
+  rw [add_monoid_algebra.mul_def, finsupp.smul_single],
+  simp only [mv_polynomial.C],
+  dsimp [mv_polynomial.monomial],
+  rw [finsupp.sum_single_index, finsupp.sum_single_index, zero_add],
+  { rw [mul_zero, finsupp.single_zero] },
+  { rw finsupp.sum_single_index,
+    all_goals { rw [zero_mul, finsupp.single_zero] }, }
+end
+
+lemma smul_eq_C_mul (p : mv_polynomial σ α) (a : α) : a • p = C a * p := C_mul'.symm
+
 lemma X_pow_eq_single : X n ^ e = monomial (single n e) (1 : α) :=
 begin
   induction e,
@@ -641,6 +658,9 @@ eval₂_monomial _ _
 @[simp] lemma eval_C : ∀ a, eval f (C a) = a := eval₂_C _ _
 
 @[simp] lemma eval_X : ∀ n, eval f (X n) = f n := eval₂_X _ _
+
+@[simp] lemma smul_eval (x) (p : mv_polynomial σ α) (s) : eval x (s • p) = s * eval x p :=
+by rw [smul_eq_C_mul, (eval x).map_mul, eval_C]
 
 lemma eval_sum {ι : Type*} (s : finset ι) (f : ι → mv_polynomial σ α) (g : σ → α) :
   eval g (∑ i in s, f i) = ∑ i in s, eval g (f i) :=

--- a/src/data/mv_polynomial/comm_ring.lean
+++ b/src/data/mv_polynomial/comm_ring.lean
@@ -71,31 +71,6 @@ instance coeff.is_add_group_hom (m : σ →₀ ℕ) :
 { map_add := coeff_add m }
 
 variables {σ} (p)
-theorem C_mul' : mv_polynomial.C a * p = a • p :=
-begin
-  apply finsupp.induction p,
-  { exact (mul_zero $ mv_polynomial.C a).trans (@smul_zero α (mv_polynomial σ α) _ _ _ a).symm },
-  intros p b f haf hb0 ih,
-  rw [mul_add, ih, @smul_add α (mv_polynomial σ α) _ _ _ a], congr' 1,
-  rw [add_monoid_algebra.mul_def, finsupp.smul_single],
-  simp only [mv_polynomial.C],
-  dsimp [mv_polynomial.monomial],
-  rw [finsupp.sum_single_index, finsupp.sum_single_index, zero_add],
-  { rw [mul_zero, finsupp.single_zero] },
-  { rw finsupp.sum_single_index,
-    all_goals { rw [zero_mul, finsupp.single_zero] }, }
-end
-
-lemma smul_eq_C_mul (p : mv_polynomial σ α) (a : α) : a • p = C a * p :=
-begin
-  rw [← finsupp.sum_single p, @finsupp.smul_sum (σ →₀ ℕ) α α, finsupp.mul_sum],
-  refine finset.sum_congr rfl (assume n _, _),
-  simp only [finsupp.smul_single],
-  exact C_mul_monomial.symm
-end
-
-@[simp] lemma smul_eval (x) (p : mv_polynomial σ α) (s) : eval x (s • p) = s * eval x p :=
-by rw [smul_eq_C_mul, (eval x).map_mul, eval_C]
 
 section degrees
 


### PR DESCRIPTION
`C_mul'`, `smul_eq_C_mul` and `smul_eval` seemed a bit out of place in `comm_ring.lean`, since they only need `comm_semiring α`. So I moved them to `basic.lean` where they probably fit in a bit better?

I've also golfed the proof of `smul_eq_C_mul`.

---
<!-- put comments you want to keep out of the PR commit here -->
