### PR TITLE
[Merged by Bors] - feat(normed_space): second countability for linear maps

### DIFF
--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -793,7 +793,7 @@ lemma nndist_smul [normed_space α β] (s : α) (x y : β) :
   nndist (s • x) (s • y) = nnnorm s * nndist x y :=
 nnreal.eq $ dist_smul s x y
 
-lemma mul_norm_of_nonneg [normed_space ℝ α] {t : ℝ} (ht : 0 ≤ t) (x : α) : t*∥x∥ = ∥t • x∥ :=
+lemma norm_smul_of_nonneg [normed_space ℝ α] {t : ℝ} (ht : 0 ≤ t) (x : α) : ∥t • x∥ = t * ∥x∥ :=
 by rw [norm_smul, real.norm_eq_abs, abs_of_nonneg ht]
 
 variables {E : Type*} {F : Type*}

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -175,6 +175,16 @@ le_trans (le_abs_self _) (abs_norm_sub_norm_le g h)
 lemma dist_norm_norm_le (g h : α) : dist ∥g∥ ∥h∥ ≤ ∥g - h∥ :=
 abs_norm_sub_norm_le g h
 
+lemma eq_of_norm_sub_eq_zero {u v : α} (h : ∥u - v∥ = 0) : u = v :=
+begin
+  apply eq_of_dist_eq_zero,
+  rwa dist_eq_norm
+end
+
+lemma norm_le_insert (u v : α) : ∥v∥ ≤ ∥u∥ + ∥u - v∥ :=
+calc ∥v∥ = ∥u - (u - v)∥ : by abel
+... ≤ ∥u∥ + ∥u - v∥ : norm_sub_le u _
+
 lemma ball_0_eq (ε : ℝ) : ball (0:α) ε = {x | ∥x∥ < ε} :=
 set.ext $ assume a, by simp
 
@@ -195,6 +205,10 @@ calc
 theorem normed_group.tendsto_nhds_zero {f : γ → α} {l : filter γ} :
   tendsto f l (𝓝 0) ↔ ∀ ε > 0, ∀ᶠ x in l, ∥ f x ∥ < ε :=
 metric.tendsto_nhds.trans $ by simp only [dist_zero_right]
+
+lemma normed_group.tendsto_nhds_nhds {f : α → β} {x : α} {y : β} :
+  tendsto f (𝓝 x) (𝓝 y) ↔ ∀ ε > 0, ∃ δ > 0, ∀ x', ∥x' - x∥ < δ → ∥f x' - y∥ < ε :=
+by simp_rw [metric.tendsto_nhds_nhds, dist_eq_norm]
 
 /-- A homomorphism `f` of normed groups is Lipschitz, if there exists a constant `C` such that for
 all `x`, one has `∥f x∥ ≤ C * ∥x∥`.
@@ -778,6 +792,9 @@ nnreal.eq $ norm_smul s x
 lemma nndist_smul [normed_space α β] (s : α) (x y : β) :
   nndist (s • x) (s • y) = nnnorm s * nndist x y :=
 nnreal.eq $ dist_smul s x y
+
+lemma mul_norm_of_nonneg [normed_space ℝ α] {t : ℝ} (ht : 0 ≤ t) (x : α) : t*∥x∥ = ∥t • x∥ :=
+by rw [norm_smul, real.norm_eq_abs, abs_of_nonneg ht]
 
 variables {E : Type*} {F : Type*}
 [normed_group E] [normed_space α E] [normed_group F] [normed_space α F]

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -187,7 +187,7 @@ def is_basis.constrL {v : ι → E} (hv : is_basis 𝕜 v) (f : ι → F) :
   exact (hv.constr f).continuous_of_finite_dimensional,
 end⟩
 
-@[norm_cast] lemma is_basis.coe_constrL {v : ι → E} (hv : is_basis 𝕜 v) (f : ι → F) :
+@[simp, norm_cast] lemma is_basis.coe_constrL {v : ι → E} (hv : is_basis 𝕜 v) (f : ι → F) :
   (hv.constrL f : E →ₗ[𝕜] F) = hv.constr f := rfl
 
 /-- The continuous linear equivalence between a vector space over `𝕜` with a finite basis and
@@ -206,19 +206,13 @@ def is_basis.equiv_funL {v : ι → E} (hv : is_basis 𝕜 v) : E ≃L[𝕜] (ι
 
 @[simp] lemma is_basis.constrL_apply {v : ι → E} (hv : is_basis 𝕜 v) (f : ι → F) (e : E) :
   (hv.constrL f) e = ∑ i, (hv.equiv_fun e i) • f i :=
-by simp [is_basis.constrL, hv.equiv_fun_apply, hv.constr_apply, finsupp.sum_fintype]
+hv.constr_apply_fintype _ _
 
-@[simp] lemma is_basis.constrL_apply_self {v : ι → E} (hv : is_basis 𝕜 v) (f : ι → F) (i : ι) :
+@[simp] lemma is_basis.constrL_basis {v : ι → E} (hv : is_basis 𝕜 v) (f : ι → F) (i : ι) :
   (hv.constrL f) (v i) = f i :=
-begin
- simp only [is_basis.constrL_apply, hv.equiv_fun_self],
- have : ∀ j ∈ (finset.univ : finset ι), ite (i = j) (1 :𝕜) 0 • f j = ite (i = j) (f i) 0,
- { intros x hx,
-   split_ifs ; simp [h] },
- simpa using finset.sum_congr rfl this
-end
+constr_basis _
 
-lemma is_basis.sup_norm_le_norm  {v : ι → E} (hv : is_basis 𝕜 v) :
+lemma is_basis.sup_norm_le_norm {v : ι → E} (hv : is_basis 𝕜 v) :
   ∃ C > (0 : ℝ), ∀ e : E, ∑ i, ∥hv.equiv_fun e i∥ ≤ C * ∥e∥ :=
 begin
   set φ := hv.equiv_funL.to_continuous_linear_map,

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -177,17 +177,22 @@ def linear_equiv.to_continuous_linear_equiv [finite_dimensional 𝕜 E] (e : E �
   end,
   ..e }
 
+variables {ι : Type*} [fintype ι]
+
 /-- Construct a continuous linear map given the value at a finite basis. -/
-def is_basis.constrL {ι : Type*} [fintype ι] {v : ι → E} (hv : is_basis 𝕜 v) (f : ι → F) :
+def is_basis.constrL {v : ι → E} (hv : is_basis 𝕜 v) (f : ι → F) :
   E →L[𝕜] F :=
 ⟨hv.constr f, begin
   haveI : finite_dimensional 𝕜 E := finite_dimensional.of_finite_basis hv,
   exact (hv.constr f).continuous_of_finite_dimensional,
 end⟩
 
+@[norm_cast] lemma is_basis.coe_constrL {v : ι → E} (hv : is_basis 𝕜 v) (f : ι → F) :
+  (hv.constrL f : E →ₗ[𝕜] F) = hv.constr f := rfl
+
 /-- The continuous linear equivalence between a vector space over `𝕜` with a finite basis and
 functions from its basis indexing type to `𝕜`. -/
-def is_basis.equiv_funL {ι : Type*} [fintype ι] {v : ι → E} (hv : is_basis 𝕜 v) : E ≃L[𝕜] (ι → 𝕜) :=
+def is_basis.equiv_funL {v : ι → E} (hv : is_basis 𝕜 v) : E ≃L[𝕜] (ι → 𝕜) :=
 { continuous_to_fun := begin
     haveI : finite_dimensional 𝕜 E := finite_dimensional.of_finite_basis hv,
     apply linear_map.continuous_of_finite_dimensional,
@@ -198,34 +203,56 @@ def is_basis.equiv_funL {ι : Type*} [fintype ι] {v : ι → E} (hv : is_basis 
   end,
   ..hv.equiv_fun }
 
-@[simp] lemma is_basis.constrL_apply {ι : Type*} [fintype ι] {v : ι → E} (hv : is_basis 𝕜 v)(f : ι → F) (e : E) :
-  (hv.constrL f) e = ∑ i, (hv.equiv_fun e i) • f i :=
-by { simp [is_basis.constrL, hv.equiv_fun_apply, hv.constr_apply, finsupp.sum_fintype] }
 
-lemma is_basis.sup_norm_le_norm  {ι : Type*} [fintype ι] {v : ι → E} (hv : is_basis 𝕜 v) :
+@[simp] lemma is_basis.constrL_apply {v : ι → E} (hv : is_basis 𝕜 v) (f : ι → F) (e : E) :
+  (hv.constrL f) e = ∑ i, (hv.equiv_fun e i) • f i :=
+by simp [is_basis.constrL, hv.equiv_fun_apply, hv.constr_apply, finsupp.sum_fintype]
+
+@[simp] lemma is_basis.constrL_apply_self {v : ι → E} (hv : is_basis 𝕜 v) (f : ι → F) (i : ι) :
+  (hv.constrL f) (v i) = f i :=
+begin
+ simp only [is_basis.constrL_apply, hv.equiv_fun_self],
+ have : ∀ j ∈ (finset.univ : finset ι), ite (i = j) (1 :𝕜) 0 • f j = ite (i = j) (f i) 0,
+ { intros x hx,
+   split_ifs ; simp [h] },
+ simpa using finset.sum_congr rfl this
+end
+
+lemma is_basis.sup_norm_le_norm  {v : ι → E} (hv : is_basis 𝕜 v) :
   ∃ C > (0 : ℝ), ∀ e : E, ∑ i, ∥hv.equiv_fun e i∥ ≤ C * ∥e∥ :=
 begin
   set φ := hv.equiv_funL.to_continuous_linear_map,
   set C := ∥φ∥ * (fintype.card ι),
-  use if 0 < C then C else 1,
-  split,
-  { split_ifs,
-    exacts [h, zero_lt_one] },
-  { intros e,
-    have key :=
-      calc ∑ i, ∥φ e i∥ ≤ ∑ i : ι, ∥φ e∥ : by { apply finset.sum_le_sum,
-                                               exact λ i hi, norm_le_pi_norm (φ e) i }
-      ... = ∥φ e∥*(fintype.card ι) : by simpa only [mul_comm, finset.sum_const, nsmul_eq_mul]
-      ... ≤ ∥φ∥ * ∥e∥ * (fintype.card ι) : mul_le_mul_of_nonneg_right (φ.le_op_norm e)
-                                                                     (fintype.card ι).cast_nonneg
-      ... = (∥φ∥ * (fintype.card ι)) * ∥e∥ : by ring,
-    split_ifs,
-    { exact key },
-    { apply le_trans key,
-      simp [C] at h,
-      rw one_mul,
-      calc ∥φ∥ * (fintype.card ι) * ∥e∥ ≤ 0 : mul_nonpos_of_nonpos_of_nonneg h (norm_nonneg e)
-      ... ≤ ∥e∥ : norm_nonneg e } }
+  use [max C 1, lt_of_lt_of_le (zero_lt_one) (le_max_right C 1)],
+  intros e,
+  calc ∑ i, ∥φ e i∥ ≤ ∑ i : ι, ∥φ e∥ : by { apply finset.sum_le_sum,
+                                           exact λ i hi, norm_le_pi_norm (φ e) i }
+  ... = ∥φ e∥*(fintype.card ι) : by simpa only [mul_comm, finset.sum_const, nsmul_eq_mul]
+  ... ≤ ∥φ∥ * ∥e∥ * (fintype.card ι) : mul_le_mul_of_nonneg_right (φ.le_op_norm e)
+                                                                 (fintype.card ι).cast_nonneg
+  ... = ∥φ∥ * (fintype.card ι) * ∥e∥ : by ring
+  ... ≤ max C 1 * ∥e∥ :  mul_le_mul_of_nonneg_right (le_max_left _ _) (norm_nonneg _)
+end
+
+lemma is_basis.op_norm_le  {ι : Type*} [fintype ι] {v : ι → E} (hv : is_basis 𝕜 v) :
+  ∃ C > (0 : ℝ), ∀ {u : E →L[𝕜] F} {M : ℝ}, 0 ≤ M → (∀ i, ∥u (v i)∥ ≤ M) → ∥u∥ ≤ C*M :=
+begin
+  obtain ⟨C, C_pos, hC⟩ : ∃ C > (0 : ℝ), ∀ (e : E), ∑ i, ∥hv.equiv_fun e i∥ ≤ C * ∥e∥,
+    from hv.sup_norm_le_norm,
+  use [C, C_pos],
+  intros u M hM hu,
+  apply u.op_norm_le_bound (mul_nonneg (le_of_lt C_pos) hM),
+  intros e,
+  calc
+  ∥u e∥ = ∥u (∑ i, hv.equiv_fun e i • v i)∥ :  by conv_lhs { rw ← hv.equiv_fun_total e }
+  ... = ∥∑ i, (hv.equiv_fun e i) • (u $ v i)∥ :  by simp [u.map_sum, linear_map.map_smul]
+  ... ≤ ∑ i, ∥(hv.equiv_fun e i) • (u $ v i)∥ : norm_sum_le _ _
+  ... = ∑ i, ∥hv.equiv_fun e i∥ * ∥u (v i)∥ : by simp only [norm_smul]
+  ... ≤ ∑ i, ∥hv.equiv_fun e i∥ * M : finset.sum_le_sum (λ i hi,
+                                                  mul_le_mul_of_nonneg_left (hu i) (norm_nonneg _))
+  ... = (∑ i, ∥hv.equiv_fun e i∥) * M : finset.sum_mul.symm
+  ... ≤ C * ∥e∥ * M : mul_le_mul_of_nonneg_right (hC e) hM
+  ... = C * M * ∥e∥ : by ring
 end
 
 instance [finite_dimensional 𝕜 E] [second_countable_topology F] :
@@ -237,10 +264,10 @@ begin
   from metric.second_countable_of_countable_discretization
     (λ ε ε_pos, ⟨fin d → ℕ, by apply_instance, this ε ε_pos⟩),
   intros ε ε_pos,
-  obtain ⟨u, hu⟩ := exists_dense_seq F,
-  obtain ⟨v, hv⟩ : ∃ v : fin d → E, is_basis 𝕜 v := finite_dimensional.fin_basis 𝕜 E,
-  obtain ⟨C, C_pos, hC⟩ : ∃ C > (0 : ℝ), ∀ (e : E), ∑ i, ∥hv.equiv_fun e i∥ ≤ C * ∥e∥,
-    from hv.sup_norm_le_norm,
+  obtain ⟨u : ℕ → F, hu : closure (range u) = univ⟩ := exists_dense_seq F,
+  obtain ⟨v : fin d → E, hv : is_basis 𝕜 v⟩ := finite_dimensional.fin_basis 𝕜 E,
+  obtain ⟨C : ℝ, C_pos : 0 < C,
+          hC : ∀ {φ : E →L[𝕜] F} {M : ℝ}, 0 ≤ M → (∀ i, ∥φ (v i)∥ ≤ M) → ∥φ∥ ≤ C * M⟩ := hv.op_norm_le,
   have h_2C : 0 < 2*C := mul_pos two_pos C_pos,
   have hε2C : 0 < ε/(2*C) := div_pos ε_pos h_2C,
   have : ∀ φ : E →L[𝕜] F, ∃ n : fin d → ℕ, ∥φ - (hv.constrL $ u ∘ n)∥ ≤ ε/2,
@@ -256,22 +283,12 @@ begin
       exact ⟨n, le_of_lt hn⟩ },
     choose n hn using this,
     use n,
-    apply continuous_linear_map.op_norm_le_bound _ (le_of_lt $ half_pos ε_pos),
-    intros e,
-    simp only [is_basis.constrL_apply, continuous_linear_map.coe_sub', function.comp_app, pi.sub_apply],
-    conv_lhs { congr, congr, rw ← hv.equiv_fun_total e },
-    rw [φ.map_sum, ← finset.sum_sub_distrib],
-    conv_lhs { congr, congr, skip, simp [linear_map.map_smul, ← smul_sub] },
-    calc ∥∑ i, (hv.equiv_fun) e i • (φ (v i) - u (n i))∥
-        ≤ ∑ i, ∥(hv.equiv_fun) e i • (φ (v i) - u (n i))∥ : by { apply norm_sum_le }
-    ... = ∑ i, ∥(hv.equiv_fun) e i∥ * ∥(φ (v i) - u (n i))∥ : by simp [norm_smul]
-    ... ≤  ∑ i, ∥(hv.equiv_fun) e i∥ * (ε/(2*C)) : finset.sum_le_sum (λ i hi,
-                                                   mul_le_mul_of_nonneg_left (hn i) (norm_nonneg _))
-    ... = (∑ i, ∥(hv.equiv_fun) e i∥) * (ε/(2*C)) : by rw finset.sum_mul
-    ... ≤ C*∥e∥ * (ε/(2*C)) : mul_le_mul_of_nonneg_right (hC e) (le_of_lt hε2C)
-    ... = ε / 2 * ∥e∥ : by { field_simp [C_pos, h_2C],
-                             rw [show C * ∥e∥ * ε * 2= ∥e∥ * ε * (2*C), by ring,
-                                 mul_div_cancel _ (ne_of_gt h_2C), mul_comm] } },
+    replace hn : ∀ i : fin d, ∥(φ - (hv.constrL $ u ∘ n)) (v i)∥ ≤ ε / (2 * C), by simp [hn],
+    have : C * (ε / (2 * C)) = ε/2,
+    { rw [eq_div_iff (two_ne_zero : (2 : ℝ) ≠ 0), mul_comm, ← mul_assoc,
+          mul_div_cancel' _ (ne_of_gt h_2C)] },
+    specialize hC (le_of_lt hε2C) hn,
+    rwa this at hC },
   choose n hn using this,
   set Φ := λ φ : E →L[𝕜] F, (hv.constrL $ u ∘ (n φ)),
   change ∀ z, dist z (Φ z) ≤ ε/2 at hn,

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -73,6 +73,11 @@ follow automatically in `linear_map.mk_continuous_norm_le`. -/
 def linear_map.mk_continuous_of_exists_bound (h : ∃C, ∀x, ∥f x∥ ≤ C * ∥x∥) : E →L[𝕜] F :=
 ⟨f, let ⟨C, hC⟩ := h in linear_map.continuous_of_bound f C hC⟩
 
+lemma continuous_of_linear_of_bound {f : E → F} (h_add : ∀ x y, f (x + y) = f x + f y)
+  (h_smul : ∀ (c : 𝕜) x, f (c • x) = c • f x) {C : ℝ} (h_bound : ∀ x, ∥f x∥ ≤ C*∥x∥) :
+  continuous f :=
+let φ : E →ₗ[𝕜] F := ⟨f, h_add, h_smul⟩ in φ.continuous_of_bound C h_bound
+
 @[simp, norm_cast] lemma linear_map.mk_continuous_coe (C : ℝ) (h : ∀x, ∥f x∥ ≤ C * ∥x∥) :
   ((f.mk_continuous C h) : E →ₗ[𝕜] F) = f := rfl
 
@@ -278,6 +283,31 @@ Inf_le _ bounds_bdd_below ⟨hMp, hM⟩
 theorem op_norm_le_of_lipschitz {f : E →L[𝕜] F} {K : nnreal} (hf : lipschitz_with K f) :
   ∥f∥ ≤ K :=
 f.op_norm_le_bound K.2 $ λ x, by simpa only [dist_zero_right, f.map_zero] using hf.dist_le_mul x 0
+
+lemma op_norm_le_of_ball {f : E →L[𝕜] F} {ε : ℝ} {C : ℝ} (ε_pos : 0 < ε) (hC : 0 ≤ C)
+  (hf : ∀ x ∈ ball (0 : E) ε, ∥f x∥ ≤ C * ∥x∥ ) : ∥f∥ ≤ C :=
+begin
+  apply f.op_norm_le_bound hC,
+  intros x,
+  rcases normed_field.exists_one_lt_norm 𝕜 with ⟨c, hc⟩,
+  by_cases hx : x = 0, { simp [hx] },
+  rcases rescale_to_shell hc (half_pos ε_pos) hx with ⟨δ, hδ, δxle, leδx, δinv⟩,
+  have δx_in : δ • x ∈ ball (0 : E) ε,
+  { rw [mem_ball, dist_eq_norm, sub_zero],
+    linarith },
+  calc ∥f x∥ = ∥f ((1/δ) • δ • x)∥ : by simp [hδ, smul_smul]
+  ... = ∥1/δ∥ * ∥f (δ • x)∥ : by simp [norm_smul]
+  ... ≤ ∥1/δ∥ * (C*∥δ • x∥) : mul_le_mul_of_nonneg_left _ (norm_nonneg _)
+  ... = C * ∥x∥ : by { rw norm_smul, field_simp [hδ], ring },
+  exact hf _ δx_in
+end
+
+lemma op_norm_eq_of_bounds {φ : E →L[𝕜] F} {M : ℝ} (M_nonneg : 0 ≤ M)
+  (h_above : ∀ x, ∥φ x∥ ≤ M*∥x∥) (h_below : ∀ N ≥ 0, (∀ x, ∥φ x∥ ≤ N*∥x∥) → M ≤ N) :
+  ∥φ∥ = M :=
+le_antisymm (φ.op_norm_le_bound M_nonneg h_above)
+  ((le_cInf_iff continuous_linear_map.bounds_bdd_below ⟨M, M_nonneg, h_above⟩).mpr $
+   λ N ⟨N_nonneg, hN⟩, h_below N N_nonneg hN)
 
 /-- The operator norm satisfies the triangle inequality. -/
 theorem op_norm_add_le : ∥f + g∥ ≤ ∥f∥ + ∥g∥ :=

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -285,7 +285,7 @@ theorem op_norm_le_of_lipschitz {f : E →L[𝕜] F} {K : nnreal} (hf : lipschit
 f.op_norm_le_bound K.2 $ λ x, by simpa only [dist_zero_right, f.map_zero] using hf.dist_le_mul x 0
 
 lemma op_norm_le_of_ball {f : E →L[𝕜] F} {ε : ℝ} {C : ℝ} (ε_pos : 0 < ε) (hC : 0 ≤ C)
-  (hf : ∀ x ∈ ball (0 : E) ε, ∥f x∥ ≤ C * ∥x∥ ) : ∥f∥ ≤ C :=
+  (hf : ∀ x ∈ ball (0 : E) ε, ∥f x∥ ≤ C * ∥x∥) : ∥f∥ ≤ C :=
 begin
   apply f.op_norm_le_bound hC,
   intros x,

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -787,7 +787,7 @@ def is_basis.constr (f : ι → M') : M →ₗ[R] M' :=
 
 theorem is_basis.constr_apply (f : ι → M') (x : M) :
   (hv.constr f : M → M') x = (hv.repr x).sum (λb a, a • f b) :=
-by dsimp [is_basis.constr];
+by dsimp [is_basis.constr] ;
    rw [finsupp.total_apply, finsupp.sum_map_domain_index]; simp [add_smul]
 
 lemma is_basis.ext {f g : M →ₗ[R] M'} (hv : is_basis R v) (h : ∀i, f (v i) = g (v i)) : f = g :=
@@ -1023,6 +1023,10 @@ end
 @[simp]
 lemma is_basis.equiv_fun_self (i j : ι) : h.equiv_fun (v i) j = if i = j then 1 else 0 :=
 by { rw [h.equiv_fun_apply, h.repr_self_apply] }
+
+@[simp] theorem is_basis.constr_apply_fintype [fintype ι] (f : ι → M') (x : M) :
+  (h.constr f : M → M') x = ∑ i, (h.equiv_fun x i) • f i :=
+by simp [h.constr_apply, h.equiv_fun_apply, finsupp.sum_fintype]
 
 end module
 

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -1024,7 +1024,7 @@ end
 lemma is_basis.equiv_fun_self (i j : ι) : h.equiv_fun (v i) j = if i = j then 1 else 0 :=
 by { rw [h.equiv_fun_apply, h.repr_self_apply] }
 
-@[simp] theorem is_basis.constr_apply_fintype [fintype ι] (f : ι → M') (x : M) :
+@[simp] theorem is_basis.constr_apply_fintype (f : ι → M') (x : M) :
   (h.constr f : M → M') x = ∑ i, (h.equiv_fun x i) • f i :=
 by simp [h.constr_apply, h.equiv_fun_apply, finsupp.sum_fintype]
 

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -231,6 +231,9 @@ variables (c : R) (f g : M →L[R] M₂) (h : M₂ →L[R] M₃) (x y z : M)
 @[simp] lemma map_add  : f (x + y) = f x + f y := (to_linear_map _).map_add _ _
 @[simp] lemma map_smul : f (c • x) = c • f x := (to_linear_map _).map_smul _ _
 
+lemma map_sum {ι : Type*} (s : finset ι) (g : ι → M) :
+  f (∑ i in s, g i) = ∑ i in s, f (g i) := f.to_linear_map.map_sum
+
 @[simp, norm_cast] lemma coe_coe : ((f : M →ₗ[R] M₂) : (M → M₂)) = (f : M → M₂) := rfl
 
 /-- The continuous map that is constantly zero. -/


### PR DESCRIPTION
From the sphere eversion project, various lemmas about continuous linear maps and a theorem: if E is finite dimensional and F is second countable then the space of continuous linear maps from E to F is second countable.

---
<!-- put comments you want to keep out of the PR commit here -->
