### PR TITLE
[Merged by Bors] - feat(data/enat): some API and a module docstring

### DIFF
--- a/src/data/nat/enat.lean
+++ b/src/data/nat/enat.lean
@@ -25,14 +25,20 @@ followed by `@[simp] lemma to_with_top_zero'` whose proof uses `convert`.
 
 ## Main definitions
 
-* `canonically_ordered_add_monoid enat` : an instance is defined
-* `canonically_ordered_add_monoid enat` : an instance is defined.
+The following instances are defined:
+
+* `ordered_add_comm_monoid enat`
+* `canonically_ordered_add_monoid enat`
 
 There is no additive analogue of `monoid_with_zero`; if there were then `enat` could
 be an `add_monoid_with_top`.
 
 * `to_with_top` : the map from `enat` to `with_top ℕ`, with theorems that it plays well
 with `+` and `≤`.
+
+* `with_top_add_equiv : enat ≃+ with_top ℕ`
+* `with_top_order_iso : enat ≃o with_top ℕ`
+
 
 ## Tags
 
@@ -342,6 +348,7 @@ to_with_top_le
 @[simp] lemma with_top_equiv_lt {x y : enat} : with_top_equiv x < with_top_equiv y ↔ x < y :=
 to_with_top_lt
 
+/-- `to_with_top` induces an order isomorphism between `enat` and `with_top ℕ`.-/
 noncomputable def with_top_order_iso : enat ≃o with_top ℕ :=
 { map_rel_iff' := λ _ _, with_top_equiv_le.symm,
   ..with_top_equiv}
@@ -363,6 +370,7 @@ by rw ← with_top_equiv_le; simp
   with_top_equiv.symm x < with_top_equiv.symm y ↔ x < y :=
 by rw ← with_top_equiv_lt; simp
 
+/-- `to_with_top` induces an additive monoid isomorphism between `enat` and `with_top ℕ`.-/
 noncomputable def with_top_add_equiv : enat ≃+ with_top ℕ :=
 { map_add' := λ x y, by simp only [with_top_equiv]; convert to_with_top_add,
   ..with_top_equiv}

--- a/src/data/nat/enat.lean
+++ b/src/data/nat/enat.lean
@@ -348,7 +348,7 @@ to_with_top_le
 @[simp] lemma with_top_equiv_lt {x y : enat} : with_top_equiv x < with_top_equiv y ↔ x < y :=
 to_with_top_lt
 
-/-- `to_with_top` induces an order isomorphism between `enat` and `with_top ℕ`.-/
+/-- `to_with_top` induces an order isomorphism between `enat` and `with_top ℕ`. -/
 noncomputable def with_top_order_iso : enat ≃o with_top ℕ :=
 { map_rel_iff' := λ _ _, with_top_equiv_le.symm,
   ..with_top_equiv}

--- a/src/data/nat/enat.lean
+++ b/src/data/nat/enat.lean
@@ -33,7 +33,8 @@ with `+` and `≤`.
 `enat` is defined to be `roption ℕ`.
 
 `+` and `≤` are defined on `enat`, but there is an issue with `*` because it's not
-clear what `0 * ⊤` should be. `mul` is hence left undefined.
+clear what `0 * ⊤` should be. `mul` is hence left undefined. Similarly `⊤ - ⊤` is ambiguous
+so there is no `-` defined on `enat`.
 
 Before the `open_locale classical` line, various proofs are made with decidability assumptions.
 This can cause issues -- see for example the non-simp lemma `to_with_top_zero` proved by `rfl`,

--- a/src/data/nat/enat.lean
+++ b/src/data/nat/enat.lean
@@ -12,17 +12,6 @@ import data.equiv.mul_add
 
 The natural numbers and an extra `top` element `⊤`.
 
-## Implementation details
-
-`enat` represented as `roption ℕ`.
-
-`+` and `≤` are defined on `enat`, but there is an issue with `*` because it's not
-clear what `0 * ⊤` should be. `mul` is hence left undefined.
-
-Before the `open_locale classical` line various proofs are made with decidability assumptions.
-This can cause issues -- see for example the non-simp lemma `to_with_top_zero` proved by `rfl`,
-followed by `@[simp] lemma to_with_top_zero'` whose proof uses `convert`.
-
 ## Main definitions
 
 The following instances are defined:
@@ -38,6 +27,17 @@ with `+` and `≤`.
 
 * `with_top_add_equiv : enat ≃+ with_top ℕ`
 * `with_top_order_iso : enat ≃o with_top ℕ`
+
+## Implementation details
+
+`enat` is defined to be `roption ℕ`.
+
+`+` and `≤` are defined on `enat`, but there is an issue with `*` because it's not
+clear what `0 * ⊤` should be. `mul` is hence left undefined.
+
+Before the `open_locale classical` line, various proofs are made with decidability assumptions.
+This can cause issues -- see for example the non-simp lemma `to_with_top_zero` proved by `rfl`,
+followed by `@[simp] lemma to_with_top_zero'` whose proof uses `convert`.
 
 
 ## Tags

--- a/src/data/nat/enat.lean
+++ b/src/data/nat/enat.lean
@@ -326,7 +326,7 @@ begin
   { intros, rw [to_with_top_coe', to_with_top_coe'], norm_cast, exact to_with_top_coe' _ }
 end
 
-/-- equiv between `enat` and `with_top ℕ` (for the order isomorphism see with_top_order_iso). -/
+/-- `equiv` between `enat` and `with_top ℕ` (for the order isomorphism see `with_top_order_iso`). -/
 noncomputable def with_top_equiv : enat ≃ with_top ℕ :=
 { to_fun := λ x, to_with_top x,
   inv_fun := λ x, match x with (some n) := coe n | none := ⊤ end,

--- a/src/data/nat/enat.lean
+++ b/src/data/nat/enat.lean
@@ -370,7 +370,7 @@ by rw ← with_top_equiv_le; simp
   with_top_equiv.symm x < with_top_equiv.symm y ↔ x < y :=
 by rw ← with_top_equiv_lt; simp
 
-/-- `to_with_top` induces an additive monoid isomorphism between `enat` and `with_top ℕ`.-/
+/-- `to_with_top` induces an additive monoid isomorphism between `enat` and `with_top ℕ`. -/
 noncomputable def with_top_add_equiv : enat ≃+ with_top ℕ :=
 { map_add' := λ x y, by simp only [with_top_equiv]; convert to_with_top_add,
   ..with_top_equiv}

--- a/src/data/nat/enat.lean
+++ b/src/data/nat/enat.lean
@@ -2,12 +2,42 @@
 Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
-
-Natural numbers with infinity, represented as roption ℕ.
 -/
 import data.pfun
 import tactic.norm_num
+import data.equiv.mul_add
 
+/-!
+# Natural numbers with infinity
+
+The natural numbers and an extra `top` element `⊤`.
+
+## Implementation details
+
+`enat` represented as `roption ℕ`.
+
+`+` and `≤` are defined on `enat`, but there is an issue with `*` because it's not
+clear what `0 * ⊤` should be. `mul` is hence left undefined.
+
+Before the `open_locale classical` line various proofs are made with decidability assumptions.
+This can cause issues -- see for example the non-simp lemma `to_with_top_zero` proved by `rfl`,
+followed by `@[simp] lemma to_with_top_zero'` whose proof uses `convert`.
+
+## Main definitions
+
+* `canonically_ordered_add_monoid enat` : an instance is defined
+* `canonically_ordered_add_monoid enat` : an instance is defined.
+
+There is no additive analogue of `monoid_with_zero`; if there were then `enat` could
+be an `add_monoid_with_top`.
+
+* `to_with_top` : the map from `enat` to `with_top ℕ`, with theorems that it plays well
+with `+` and `≤`.
+
+## Tags
+
+enat, with_top ℕ
+-/
 open roption
 
 /-- Type of natural numbers with infinity -/
@@ -252,14 +282,17 @@ section with_top
 def to_with_top (x : enat) [decidable x.dom]: with_top ℕ := x.to_option
 
 lemma to_with_top_top : to_with_top ⊤ = ⊤ := rfl
+
 @[simp] lemma to_with_top_top' {h : decidable (⊤ : enat).dom} : to_with_top ⊤ = ⊤ :=
 by convert to_with_top_top
 
 lemma to_with_top_zero : to_with_top 0 = 0 := rfl
+
 @[simp] lemma to_with_top_zero' {h : decidable (0 : enat).dom}: to_with_top 0 = 0 :=
 by convert to_with_top_zero
 
 lemma to_with_top_coe (n : ℕ) : to_with_top n = n := rfl
+
 @[simp] lemma to_with_top_coe' (n : ℕ) {h : decidable (n : enat).dom} : to_with_top (n : enat) = n :=
 by convert to_with_top_coe n
 
@@ -274,9 +307,20 @@ by simp only [lt_iff_le_not_le, to_with_top_le]
 end with_top
 
 section with_top_equiv
+
 open_locale classical
 
-/-- Order isomorphism between `enat` and `with_top ℕ`. -/
+@[simp] lemma to_with_top_add {x y : enat} : to_with_top (x + y) = to_with_top x + to_with_top y :=
+begin
+  apply enat.cases_on y; apply enat.cases_on x,
+  { simp },
+  { simp },
+  { simp },
+  -- not sure why `simp` can't do this
+  { intros, rw [to_with_top_coe', to_with_top_coe'], norm_cast, exact to_with_top_coe' _ }
+end
+
+/-- equiv between `enat` and `with_top ℕ` (for the order isomorphism see with_top_order_iso). -/
 noncomputable def with_top_equiv : enat ≃ with_top ℕ :=
 { to_fun := λ x, to_with_top x,
   inv_fun := λ x, match x with (some n) := coe n | none := ⊤ end,
@@ -298,6 +342,10 @@ to_with_top_le
 @[simp] lemma with_top_equiv_lt {x y : enat} : with_top_equiv x < with_top_equiv y ↔ x < y :=
 to_with_top_lt
 
+noncomputable def with_top_order_iso : enat ≃o with_top ℕ :=
+{ map_rel_iff' := λ _ _, with_top_equiv_le.symm,
+  ..with_top_equiv}
+
 @[simp] lemma with_top_equiv_symm_top : with_top_equiv.symm ⊤ = ⊤ :=
 rfl
 
@@ -314,6 +362,10 @@ by rw ← with_top_equiv_le; simp
 @[simp] lemma with_top_equiv_symm_lt {x y : with_top ℕ} :
   with_top_equiv.symm x < with_top_equiv.symm y ↔ x < y :=
 by rw ← with_top_equiv_lt; simp
+
+noncomputable def with_top_add_equiv : enat ≃+ with_top ℕ :=
+{ map_add' := λ x y, by simp only [with_top_equiv]; convert to_with_top_add,
+  ..with_top_equiv}
 
 end with_top_equiv
 


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->

We need a route from the additive `enat` to the multiplicative `with_zero (multiplicative int)` to put a valuation on a discrete valuation ring. This is a beginning. 